### PR TITLE
HIP MLIR Dialect Compiler POC

### DIFF
--- a/tools/hip-opt/CMakeLists.txt
+++ b/tools/hip-opt/CMakeLists.txt
@@ -1,0 +1,42 @@
+cmake_minimum_required(VERSION 3.20)
+project(hip-opt)
+
+# Find LLVM using LLVM_DIR
+find_package(LLVM REQUIRED CONFIG)
+find_package(MLIR REQUIRED CONFIG)
+
+message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
+message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
+
+# Add LLVM and MLIR definitions
+separate_arguments(LLVM_DEFINITIONS_LIST NATIVE_COMMAND ${LLVM_DEFINITIONS})
+add_definitions(${LLVM_DEFINITIONS_LIST})
+
+# Include directories
+include_directories(${LLVM_INCLUDE_DIRS})
+include_directories(${MLIR_INCLUDE_DIRS})
+
+# Add the executable
+add_executable(hip-opt hip-opt.cpp)
+
+# Link LLVM components
+llvm_map_components_to_libnames(llvm_libs Support Core)
+
+# Link against MLIR libraries
+target_link_libraries(hip-opt PRIVATE
+  MLIROptLib
+  MLIRSupport
+  MLIRIR
+  MLIRParser
+  MLIRPass
+  MLIRTransforms
+  MLIRAnalysis
+  ${llvm_libs}
+)
+
+# Set C++ standard
+set_target_properties(hip-opt PROPERTIES
+  CXX_STANDARD 17
+  CXX_STANDARD_REQUIRED ON
+)

--- a/tools/hip-opt/CMakeLists.txt
+++ b/tools/hip-opt/CMakeLists.txt
@@ -1,6 +1,14 @@
 cmake_minimum_required(VERSION 3.20)
 project(hip-opt)
 
+# Optional: use LLVM/MLIR from a build tree at C:/local/llvm-project
+if(NOT LLVM_DIR AND EXISTS "C:/local/llvm-project/build/lib/cmake/llvm/LLVMConfig.cmake")
+  set(LLVM_DIR "C:/local/llvm-project/build/lib/cmake/llvm")
+endif()
+if(NOT MLIR_DIR AND EXISTS "C:/local/llvm-project/build/lib/cmake/mlir/MLIRConfig.cmake")
+  set(MLIR_DIR "C:/local/llvm-project/build/lib/cmake/mlir")
+endif()
+
 # Find LLVM using LLVM_DIR
 find_package(LLVM REQUIRED CONFIG)
 find_package(MLIR REQUIRED CONFIG)

--- a/tools/hip-opt/CMakeLists.txt
+++ b/tools/hip-opt/CMakeLists.txt
@@ -16,9 +16,47 @@ add_definitions(${LLVM_DEFINITIONS_LIST})
 # Include directories
 include_directories(${LLVM_INCLUDE_DIRS})
 include_directories(${MLIR_INCLUDE_DIRS})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
+# Add LLVM TableGen function
+list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
+list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
+include(TableGen)
+include(AddLLVM)
+include(AddMLIR)
+
+# Generate dialect definition
+set(LLVM_TARGET_DEFINITIONS HipDialect.td)
+mlir_tablegen(HipDialect.h.inc -gen-dialect-decls -dialect=hip)
+mlir_tablegen(HipDialect.cpp.inc -gen-dialect-defs -dialect=hip)
+add_public_tablegen_target(HipDialectIncGen)
+
+# Generate type definitions
+set(LLVM_TARGET_DEFINITIONS HipTypes.td)
+mlir_tablegen(HipTypes.h.inc -gen-typedef-decls -typedefs-dialect=hip)
+mlir_tablegen(HipTypes.cpp.inc -gen-typedef-defs -typedefs-dialect=hip)
+add_public_tablegen_target(HipTypesIncGen)
+
+# Generate operation definitions
+set(LLVM_TARGET_DEFINITIONS HipOps.td)
+mlir_tablegen(HipOps.h.inc -gen-op-decls)
+mlir_tablegen(HipOps.cpp.inc -gen-op-defs)
+add_public_tablegen_target(HipOpsIncGen)
 
 # Add the executable
-add_executable(hip-opt hip-opt.cpp)
+add_executable(hip-opt 
+  hip-opt.cpp
+  HipDialect.cpp
+  HipToLLVM.cpp
+)
+
+# Add dependencies on TableGen targets
+add_dependencies(hip-opt 
+  HipDialectIncGen
+  HipTypesIncGen
+  HipOpsIncGen
+)
 
 # Link LLVM components
 llvm_map_components_to_libnames(llvm_libs Support Core)
@@ -32,6 +70,10 @@ target_link_libraries(hip-opt PRIVATE
   MLIRPass
   MLIRTransforms
   MLIRAnalysis
+  MLIRLLVMDialect
+  MLIRLLVMCommonConversion
+  MLIRFuncDialect
+  MLIRTransformUtils
   ${llvm_libs}
 )
 

--- a/tools/hip-opt/CMakeLists.txt
+++ b/tools/hip-opt/CMakeLists.txt
@@ -69,7 +69,7 @@ add_dependencies(hip-opt
 # Link LLVM components
 llvm_map_components_to_libnames(llvm_libs Support Core)
 
-# Link against MLIR libraries
+# Link against MLIR libraries (no RegisterAll*; we register dialects explicitly)
 target_link_libraries(hip-opt PRIVATE
   MLIROptLib
   MLIRSupport
@@ -78,9 +78,11 @@ target_link_libraries(hip-opt PRIVATE
   MLIRPass
   MLIRTransforms
   MLIRAnalysis
+  MLIRArithDialect
+  MLIRFuncDialect
+  MLIRMemRefDialect
   MLIRLLVMDialect
   MLIRLLVMCommonConversion
-  MLIRFuncDialect
   MLIRTransformUtils
   ${llvm_libs}
 )

--- a/tools/hip-opt/HipDialect.cpp
+++ b/tools/hip-opt/HipDialect.cpp
@@ -1,0 +1,26 @@
+//===- HipDialect.cpp - HIP dialect implementation ------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "HipDialect.h"
+#include "mlir/IR/DialectImplementation.h"
+
+using namespace mlir;
+using namespace mlir::hip;
+
+#include "HipDialect.cpp.inc"
+
+void HipDialect::initialize() {
+  addTypes<
+#define GET_TYPEDEF_LIST
+#include "HipTypes.cpp.inc"
+      >();
+  addOperations<
+#define GET_OP_LIST
+#include "HipOps.cpp.inc"
+      >();
+}

--- a/tools/hip-opt/HipDialect.cpp
+++ b/tools/hip-opt/HipDialect.cpp
@@ -7,7 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "HipDialect.h"
+#include "mlir/IR/Builders.h"
 #include "mlir/IR/DialectImplementation.h"
+#include "llvm/ADT/TypeSwitch.h"
 
 using namespace mlir;
 using namespace mlir::hip;
@@ -24,3 +26,10 @@ void HipDialect::initialize() {
 #include "HipOps.cpp.inc"
       >();
 }
+
+// Type and op class implementations (parse/print/verify, TypeIDs)
+#define GET_TYPEDEF_CLASSES
+#include "HipTypes.cpp.inc"
+
+#define GET_OP_CLASSES
+#include "HipOps.cpp.inc"

--- a/tools/hip-opt/HipDialect.h
+++ b/tools/hip-opt/HipDialect.h
@@ -1,0 +1,18 @@
+#ifndef HIP_DIALECT_H
+#define HIP_DIALECT_H
+
+#include "mlir/IR/Dialect.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/IR/Types.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+
+#include "HipDialect.h.inc"
+
+#define GET_TYPEDEF_CLASSES
+#include "HipTypes.h.inc"
+
+#define GET_OP_CLASSES
+#include "HipOps.h.inc"
+
+#endif // HIP_DIALECT_H

--- a/tools/hip-opt/HipDialect.td
+++ b/tools/hip-opt/HipDialect.td
@@ -1,0 +1,18 @@
+#ifndef HIP_DIALECT
+#define HIP_DIALECT
+
+include "mlir/IR/OpBase.td"
+include "mlir/IR/DialectBase.td"
+
+def Hip_Dialect : Dialect {
+  let name = "hip";
+  let summary = "HIP runtime dialect";
+  let description = [{
+    A dialect for HIP (Heterogeneous-compute Interface for Portability) operations.
+    Provides operations for memory management and runtime handle operations.
+  }];
+  let cppNamespace = "::mlir::hip";
+  let useDefaultTypePrinterParser = 1;
+}
+
+#endif // HIP_DIALECT

--- a/tools/hip-opt/HipOps.td
+++ b/tools/hip-opt/HipOps.td
@@ -1,0 +1,85 @@
+#ifndef HIP_OPS
+#define HIP_OPS
+
+include "HipDialect.td"
+include "HipTypes.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/IR/OpBase.td"
+
+class Hip_Op<string mnemonic, list<Trait> traits = []> :
+    Op<Hip_Dialect, mnemonic, traits>;
+
+def Hip_CreateHandleOp : Hip_Op<"create_handle", []> {
+  let summary = "Create a HIP runtime handle";
+  let description = [{
+    Creates and returns a new HIP runtime handle.
+    
+    Example:
+    ```mlir
+    %handle = hip.create_handle() : !hip.handle
+    ```
+  }];
+  
+  let results = (outs Hip_HandleType:$handle);
+  let assemblyFormat = "attr-dict `:` type($handle)";
+}
+
+def Hip_DestroyHandleOp : Hip_Op<"destroy_handle", []> {
+  let summary = "Destroy a HIP runtime handle";
+  let description = [{
+    Destroys a HIP runtime handle.
+    
+    Example:
+    ```mlir
+    hip.destroy_handle(%handle) : !hip.handle
+    ```
+  }];
+  
+  let arguments = (ins Hip_HandleType:$handle);
+  let assemblyFormat = "`(` $handle `)` attr-dict `:` type($handle)";
+}
+
+def Hip_AllocOp : Hip_Op<"alloc", []> {
+  let summary = "Allocate device memory";
+  let description = [{
+    Allocates device memory using HIP and returns a memref.
+    
+    Example:
+    ```mlir
+    %x = hip.alloc(%handle, %N) : memref<?x128xf32, 1>
+    ```
+  }];
+  
+  let arguments = (ins 
+    Hip_HandleType:$handle,
+    Variadic<Index>:$dynamicSizes
+  );
+  let results = (outs AnyMemRef:$memref);
+  
+  let assemblyFormat = [{
+    `(` $handle (`,` $dynamicSizes^ )? `)` attr-dict `:` type($memref)
+  }];
+}
+
+def Hip_FreeOp : Hip_Op<"free", []> {
+  let summary = "Free device memory";
+  let description = [{
+    Frees device memory allocated with hip.alloc.
+    
+    Example:
+    ```mlir
+    hip.free(%handle, %x) : memref<?x128xf32, 1>
+    ```
+  }];
+  
+  let arguments = (ins 
+    Hip_HandleType:$handle,
+    AnyMemRef:$memref
+  );
+  
+  let assemblyFormat = [{
+    `(` $handle `,` $memref `)` attr-dict `:` type($memref)
+  }];
+}
+
+#endif // HIP_OPS

--- a/tools/hip-opt/HipOps.td
+++ b/tools/hip-opt/HipOps.td
@@ -21,7 +21,7 @@ def Hip_CreateHandleOp : Hip_Op<"create_handle", []> {
   }];
   
   let results = (outs Hip_HandleType:$handle);
-  let assemblyFormat = "attr-dict `:` type($handle)";
+  let assemblyFormat = "`(` `)` attr-dict `:` type($handle)";
 }
 
 def Hip_DestroyHandleOp : Hip_Op<"destroy_handle", []> {

--- a/tools/hip-opt/HipPasses.h
+++ b/tools/hip-opt/HipPasses.h
@@ -1,0 +1,19 @@
+#ifndef HIP_PASSES_H
+#define HIP_PASSES_H
+
+#include "mlir/Pass/Pass.h"
+#include <memory>
+
+namespace mlir {
+namespace hip {
+
+/// Create a pass to convert HIP operations to LLVM dialect.
+std::unique_ptr<Pass> createConvertHipToLLVMPass();
+
+/// Register all HIP passes.
+void registerHipPasses();
+
+} // namespace hip
+} // namespace mlir
+
+#endif // HIP_PASSES_H

--- a/tools/hip-opt/HipToLLVM.cpp
+++ b/tools/hip-opt/HipToLLVM.cpp
@@ -17,6 +17,7 @@
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/DialectRegistry.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
@@ -167,6 +168,11 @@ struct ConvertHipToLLVMPass
   StringRef getArgument() const final { return "convert-hip-to-llvm"; }
   StringRef getDescription() const final {
     return "Convert HIP dialect to LLVM dialect";
+  }
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<LLVM::LLVMDialect>();
+    registry.insert<memref::MemRefDialect>();
   }
 
   void runOnOperation() override {

--- a/tools/hip-opt/HipToLLVM.cpp
+++ b/tools/hip-opt/HipToLLVM.cpp
@@ -1,0 +1,43 @@
+//===- HipToLLVM.cpp - HIP to LLVM dialect conversion ---------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "HipPasses.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace hip {
+
+namespace {
+
+struct ConvertHipToLLVMPass
+    : public PassWrapper<ConvertHipToLLVMPass, OperationPass<ModuleOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ConvertHipToLLVMPass)
+
+  StringRef getArgument() const final { return "convert-hip-to-llvm"; }
+  StringRef getDescription() const final {
+    return "Convert HIP dialect to LLVM dialect";
+  }
+
+  void runOnOperation() override {
+    // Stub: conversion patterns can be added here.
+    // For now the pass runs without modifying the module.
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> createConvertHipToLLVMPass() {
+  return std::make_unique<ConvertHipToLLVMPass>();
+}
+
+void registerHipPasses() {
+  PassRegistration<ConvertHipToLLVMPass>();
+}
+
+} // namespace hip
+} // namespace mlir

--- a/tools/hip-opt/HipToLLVM.cpp
+++ b/tools/hip-opt/HipToLLVM.cpp
@@ -6,15 +6,160 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "HipDialect.h"
 #include "HipPasses.h"
+#include "mlir/Conversion/LLVMCommon/ConversionTarget.h"
+#include "mlir/Conversion/LLVMCommon/MemRefBuilder.h"
+#include "mlir/Conversion/LLVMCommon/Pattern.h"
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#include "mlir/Dialect/LLVMIR/FunctionCallUtils.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
 
 namespace mlir {
 namespace hip {
 
 namespace {
 
+static constexpr const char *kHipCreateHandle = "hipCreateHandle";
+static constexpr const char *kHipDestroyHandle = "hipDestroyHandle";
+static constexpr const char *kHipMalloc = "hipMalloc";
+static constexpr const char *kHipFree = "hipFree";
+
+// --- CreateHandleOp: hip.create_handle() -> llvm.call @hipCreateHandle()
+struct CreateHandleOpLowering : public ConvertOpToLLVMPattern<CreateHandleOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(CreateHandleOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    ModuleOp module = op->getParentOfType<ModuleOp>();
+    Type ptrType = getPtrType();
+
+    FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
+        rewriter, module, kHipCreateHandle, /*paramTypes=*/{}, ptrType);
+    if (failed(funcOp))
+      return failure();
+
+    auto callOp = LLVM::CallOp::create(rewriter, loc, *funcOp, ValueRange());
+    rewriter.replaceOp(op, callOp.getResult());
+    return success();
+  }
+};
+
+// --- DestroyHandleOp: hip.destroy_handle(%h) -> llvm.call @hipDestroyHandle(%h)
+struct DestroyHandleOpLowering
+    : public ConvertOpToLLVMPattern<DestroyHandleOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(DestroyHandleOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    ModuleOp module = op->getParentOfType<ModuleOp>();
+    Type voidType = getVoidType();
+    Type ptrType = getPtrType();
+
+    FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
+        rewriter, module, kHipDestroyHandle, ptrType, voidType);
+    if (failed(funcOp))
+      return failure();
+
+    LLVM::CallOp::create(rewriter, loc, *funcOp, adaptor.getHandle());
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+// --- AllocOp: hip.alloc(%handle, %dyn...) -> hipMalloc(bytes) + memref descriptor
+struct AllocOpLowering : public ConvertOpToLLVMPattern<AllocOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(AllocOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    ModuleOp module = op->getParentOfType<ModuleOp>();
+    MemRefType memRefType = op.getMemref().getType();
+
+    if (!isConvertibleAndHasIdentityMaps(memRefType))
+      return rewriter.notifyMatchFailure(op, "incompatible memref type");
+
+    // Declare hipMalloc(size: i64) -> ptr
+    Type indexType = getIndexType();
+    Type ptrType = getPtrType();
+    FailureOr<LLVM::LLVMFuncOp> mallocFn = LLVM::lookupOrCreateFn(
+        rewriter, module, kHipMalloc, indexType, ptrType);
+    if (failed(mallocFn))
+      return failure();
+
+    // Compute sizes and sizeBytes (dynamic sizes are after the handle).
+    SmallVector<Value, 4> sizes;
+    SmallVector<Value, 4> strides;
+    Value sizeBytes;
+    getMemRefDescriptorSizes(loc, memRefType, adaptor.getDynamicSizes(),
+                             rewriter, sizes, strides, sizeBytes, true);
+
+    Value allocatedPtr =
+        LLVM::CallOp::create(rewriter, loc, *mallocFn, sizeBytes).getResult();
+
+    // Cast to memref address space if needed
+    Type elementPtrType = getElementPtrType(memRefType);
+    if (!elementPtrType)
+      return rewriter.notifyMatchFailure(op, "could not compute element ptr type");
+    FailureOr<unsigned> addrSpace = getTypeConverter()->getMemRefAddressSpace(memRefType);
+    if (failed(addrSpace))
+      return failure();
+    if (cast<LLVM::LLVMPointerType>(allocatedPtr.getType()).getAddressSpace() != *addrSpace)
+      allocatedPtr = rewriter.create<LLVM::AddrSpaceCastOp>(
+          loc, LLVM::LLVMPointerType::get(rewriter.getContext(), *addrSpace),
+          allocatedPtr);
+
+    MemRefDescriptor desc = createMemRefDescriptor(
+        loc, memRefType, allocatedPtr, allocatedPtr, sizes, strides, rewriter);
+    rewriter.replaceOp(op, {desc});
+    return success();
+  }
+};
+
+// --- FreeOp: hip.free(%handle, %memref) -> llvm.call @hipFree(allocated_ptr)
+struct FreeOpLowering : public ConvertOpToLLVMPattern<FreeOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(FreeOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    ModuleOp module = op->getParentOfType<ModuleOp>();
+    Type voidType = getVoidType();
+    Type ptrType = getPtrType();
+
+    FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
+        rewriter, module, kHipFree, ptrType, voidType);
+    if (failed(funcOp))
+      return failure();
+
+    Value memrefDesc = adaptor.getMemref();
+    Value allocatedPtr =
+        MemRefDescriptor(memrefDesc).allocatedPtr(rewriter, loc);
+    // hipFree expects void*; if memref is in non-default address space, cast
+    auto ptrTy = allocatedPtr.getType();
+    if (cast<LLVM::LLVMPointerType>(ptrTy).getAddressSpace() != 0)
+      allocatedPtr = rewriter.create<LLVM::AddrSpaceCastOp>(loc, ptrType, allocatedPtr);
+
+    LLVM::CallOp::create(rewriter, loc, *funcOp, allocatedPtr);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+// --- Pass
 struct ConvertHipToLLVMPass
     : public PassWrapper<ConvertHipToLLVMPass, OperationPass<ModuleOp>> {
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ConvertHipToLLVMPass)
@@ -25,8 +170,29 @@ struct ConvertHipToLLVMPass
   }
 
   void runOnOperation() override {
-    // Stub: conversion patterns can be added here.
-    // For now the pass runs without modifying the module.
+    ModuleOp module = getOperation();
+    MLIRContext *ctx = module.getContext();
+
+    LowerToLLVMOptions options(ctx);
+    LLVMTypeConverter typeConverter(ctx, options);
+
+    // Convert !hip.handle to !llvm.ptr
+    typeConverter.addConversion(
+        [ctx](HandleType type) -> Type {
+          return LLVM::LLVMPointerType::get(ctx, 0);
+        });
+
+    RewritePatternSet patterns(ctx);
+    patterns.add<CreateHandleOpLowering, DestroyHandleOpLowering,
+                 AllocOpLowering, FreeOpLowering>(typeConverter);
+
+    LLVMConversionTarget target(*ctx);
+    target.addLegalDialect<LLVM::LLVMDialect>();
+    target.addIllegalDialect<HipDialect>();
+    target.addLegalOp<ModuleOp>();
+
+    if (failed(applyPartialConversion(module, target, std::move(patterns))))
+      signalPassFailure();
   }
 };
 

--- a/tools/hip-opt/HipToLLVM.cpp
+++ b/tools/hip-opt/HipToLLVM.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "HipPasses.h"
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
 
 namespace mlir {

--- a/tools/hip-opt/HipTypes.td
+++ b/tools/hip-opt/HipTypes.td
@@ -1,0 +1,19 @@
+#ifndef HIP_TYPES
+#define HIP_TYPES
+
+include "HipDialect.td"
+include "mlir/IR/AttrTypeBase.td"
+
+class Hip_Type<string name, string typeMnemonic>
+    : TypeDef<Hip_Dialect, name> {
+  let mnemonic = typeMnemonic;
+}
+
+def Hip_HandleType : Hip_Type<"Handle", "handle"> {
+  let summary = "HIP runtime handle type";
+  let description = [{
+    Represents an opaque HIP runtime handle used for managing HIP operations.
+  }];
+}
+
+#endif // HIP_TYPES

--- a/tools/hip-opt/README.md
+++ b/tools/hip-opt/README.md
@@ -108,13 +108,13 @@ Frees device memory previously allocated with `hip.alloc`.
 ## Type System
 
 ### `!hip.handle`
-An opaque type representing a HIP runtime handle. Lowered to `i8*` (pointer to i8) in LLVM.
+An opaque type representing a HIP runtime handle. Lowered to `!llvm.ptr` (opaque pointer type in address space 0) in LLVM.
 
 ## Pass Pipeline
 
 The `--convert-hip-to-llvm` pass performs the following conversions:
 
-1. **Type Conversion**: `!hip.handle` → `!llvm.ptr` (i8*)
+1. **Type Conversion**: `!hip.handle` → `!llvm.ptr` (opaque pointer type in address space 0)
 2. **Operation Lowering**: Each HIP operation is converted to LLVM function calls
 3. **Function Declaration**: Required HIP runtime functions are declared in the module
 

--- a/tools/hip-opt/README.md
+++ b/tools/hip-opt/README.md
@@ -1,0 +1,115 @@
+# HIP MLIR Dialect Compiler
+
+This directory contains a custom MLIR dialect for HIP (Heterogeneous-compute Interface for Portability) operations and a compiler tool `hip-opt` to lower them to LLVM IR.
+
+## Overview
+
+The HIP dialect provides high-level operations for:
+- Creating and destroying HIP runtime handles
+- Allocating and freeing device memory
+
+These operations are lowered to LLVM IR function calls that interface with the HIP runtime library.
+
+## Files
+
+- `HipDialect.td` - Dialect definition
+- `HipTypes.td` - Type definitions (e.g., `!hip.handle`)
+- `HipOps.td` - Operation definitions
+- `HipDialect.h/cpp` - Dialect C++ implementation
+- `HipPasses.h` - Pass registration
+- `HipToLLVM.cpp` - Conversion pass from HIP dialect to LLVM dialect
+- `hip-opt.cpp` - Main compiler driver
+- `test.mlir` - Example MLIR file using HIP dialect
+
+## Building
+
+```bash
+mkdir build
+cd build
+cmake .. -DLLVM_DIR=/path/to/llvm/lib/cmake/llvm -DMLIR_DIR=/path/to/llvm/lib/cmake/mlir
+cmake --build .
+```
+
+## Usage
+
+### Input MLIR with HIP Dialect
+
+```mlir
+module {
+  func.func @example(%N: index) {
+    %handle = hip.create_handle() : !hip.handle
+    %x = hip.alloc(%handle, %N) : memref<?x128xf32, 1>
+    hip.free(%handle, %x) : memref<?x128xf32, 1>
+    hip.destroy_handle(%handle) : !hip.handle
+    return
+  }
+}
+```
+
+### Convert to LLVM Dialect
+
+```bash
+./hip-opt test.mlir --convert-hip-to-llvm
+```
+
+### Output LLVM Dialect
+
+The conversion will generate LLVM dialect code with function declarations and calls:
+
+```llvm
+llvm.func @hipCreateHandle() -> !llvm.ptr
+llvm.func @hipDestroyHandle(!llvm.ptr)
+llvm.func @hipMalloc(i64) -> !llvm.ptr
+llvm.func @hipFree(!llvm.ptr)
+
+// In the function body:
+%handle = llvm.call @hipCreateHandle() : () -> !llvm.ptr
+%void_x = llvm.call @hipMalloc(%bytes) : (i64) -> !llvm.ptr
+%x = llvm.bitcast %void_x : !llvm.ptr to !llvm.ptr<f32>
+%free_x = llvm.bitcast %x : !llvm.ptr<f32> to !llvm.ptr
+llvm.call @hipFree(%free_x) : (!llvm.ptr) -> ()
+llvm.call @hipDestroyHandle(%handle) : (!llvm.ptr) -> ()
+```
+
+### Convert to LLVM IR
+
+To get actual LLVM IR, you can further translate the LLVM dialect:
+
+```bash
+./hip-opt test.mlir --convert-hip-to-llvm | mlir-translate --mlir-to-llvmir
+```
+
+## HIP Dialect Operations
+
+### `hip.create_handle() : !hip.handle`
+Creates and returns a HIP runtime handle.
+
+### `hip.destroy_handle(%handle) : !hip.handle`
+Destroys a HIP runtime handle.
+
+### `hip.alloc(%handle, %dynamicSizes...) : memref<...>`
+Allocates device memory and returns a memref. Supports dynamic dimensions.
+
+### `hip.free(%handle, %memref) : memref<...>`
+Frees device memory previously allocated with `hip.alloc`.
+
+## Type System
+
+### `!hip.handle`
+An opaque type representing a HIP runtime handle. Lowered to `i8*` (pointer to i8) in LLVM.
+
+## Pass Pipeline
+
+The `--convert-hip-to-llvm` pass performs the following conversions:
+
+1. **Type Conversion**: `!hip.handle` → `!llvm.ptr` (i8*)
+2. **Operation Lowering**: Each HIP operation is converted to LLVM function calls
+3. **Function Declaration**: Required HIP runtime functions are declared in the module
+
+## Extending the Dialect
+
+To add new operations:
+
+1. Add the operation definition in `HipOps.td`
+2. Add a conversion pattern in `HipToLLVM.cpp`
+3. Rebuild the project (TableGen will regenerate the necessary files)

--- a/tools/hip-opt/README.md
+++ b/tools/hip-opt/README.md
@@ -23,10 +23,22 @@ These operations are lowered to LLVM IR function calls that interface with the H
 
 ## Building
 
+Build LLVM and MLIR first (e.g. from `C:\local\llvm-project`):
+
+```bash
+cd C:\local\llvm-project
+cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_TARGETS_TO_BUILD=host
+cmake --build build
+```
+
+Then build hip-opt. If LLVM is at `C:\local\llvm-project`, CMake will auto-detect the build under `C:\local\llvm-project\build`:
+
 ```bash
 mkdir build
 cd build
 cmake .. -DLLVM_DIR=/path/to/llvm/lib/cmake/llvm -DMLIR_DIR=/path/to/llvm/lib/cmake/mlir
+# On Windows with LLVM at C:\local\llvm-project (built in build/):
+# cmake .. -DLLVM_DIR=C:/local/llvm-project/build/lib/cmake/llvm -DMLIR_DIR=C:/local/llvm-project/build/lib/cmake/mlir
 cmake --build .
 ```
 

--- a/tools/hip-opt/hip-opt.cpp
+++ b/tools/hip-opt/hip-opt.cpp
@@ -2,26 +2,26 @@
 #include "mlir/InitAllDialects.h"
 #include "mlir/InitAllPasses.h"
 
-// // 1. Include YOUR custom headers
-// #include "HipDnnDialect.h"      // Defines the "hipdnn" dialect
-// #include "HipDnnPasses.h"       // Defines the "convert-hipdnn-to-llvm" pass
+// Include custom HIP dialect headers
+#include "HipDialect.h"      // Defines the "hip" dialect
+#include "HipPasses.h"       // Defines the "convert-hip-to-llvm" pass
 
 int main(int argc, char **argv) {
   // A. Create a Dialect Registry
   mlir::DialectRegistry registry;
   
   // B. Register Standard Dialects (so you can use func, scf, etc.)
-  //registerAllDialects(registry);
+  mlir::registerAllDialects(registry);
 
-  // C. Register YOUR Custom Dialect
-  //registry.insert<hipdnn::HipDnnDialect>();
+  // C. Register HIP Custom Dialect
+  registry.insert<mlir::hip::HipDialect>();
 
   // D. Register Standard Passes
-  //registerAllPasses();
+  mlir::registerAllPasses();
 
-  // E. Register YOUR Custom Pass (The "script" we discussed)
-  // This allows you to run: --convert-hipdnn-to-llvm
-  //hipdnn::registerHipDnnPasses();
+  // E. Register HIP Custom Passes
+  // This allows you to run: --convert-hip-to-llvm
+  mlir::hip::registerHipPasses();
 
   // F. Run the tool (Just like mlir-opt)
   return mlir::asMainReturnCode(

--- a/tools/hip-opt/hip-opt.cpp
+++ b/tools/hip-opt/hip-opt.cpp
@@ -1,29 +1,22 @@
 #include "mlir/Tools/mlir-opt/MlirOptMain.h"
-#include "mlir/InitAllDialects.h"
-#include "mlir/InitAllPasses.h"
+#include "mlir/IR/BuiltinDialect.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 
-// Include custom HIP dialect headers
-#include "HipDialect.h"      // Defines the "hip" dialect
-#include "HipPasses.h"       // Defines the "convert-hip-to-llvm" pass
+#include "HipDialect.h"
+#include "HipPasses.h"
 
 int main(int argc, char **argv) {
-  // A. Create a Dialect Registry
   mlir::DialectRegistry registry;
-  
-  // B. Register Standard Dialects (so you can use func, scf, etc.)
-  mlir::registerAllDialects(registry);
-
-  // C. Register HIP Custom Dialect
+  registry.insert<mlir::BuiltinDialect>();
+  registry.insert<mlir::arith::ArithDialect>();
+  registry.insert<mlir::func::FuncDialect>();
+  registry.insert<mlir::memref::MemRefDialect>();
   registry.insert<mlir::hip::HipDialect>();
 
-  // D. Register Standard Passes
-  mlir::registerAllPasses();
-
-  // E. Register HIP Custom Passes
-  // This allows you to run: --convert-hip-to-llvm
   mlir::hip::registerHipPasses();
 
-  // F. Run the tool (Just like mlir-opt)
   return mlir::asMainReturnCode(
       mlir::MlirOptMain(argc, argv, "hip-opt: custom compiler driver\n", registry));
 }

--- a/tools/hip-opt/hip-opt.cpp
+++ b/tools/hip-opt/hip-opt.cpp
@@ -1,0 +1,29 @@
+#include "mlir/Tools/mlir-opt/MlirOptMain.h"
+#include "mlir/InitAllDialects.h"
+#include "mlir/InitAllPasses.h"
+
+// // 1. Include YOUR custom headers
+// #include "HipDnnDialect.h"      // Defines the "hipdnn" dialect
+// #include "HipDnnPasses.h"       // Defines the "convert-hipdnn-to-llvm" pass
+
+int main(int argc, char **argv) {
+  // A. Create a Dialect Registry
+  mlir::DialectRegistry registry;
+  
+  // B. Register Standard Dialects (so you can use func, scf, etc.)
+  //registerAllDialects(registry);
+
+  // C. Register YOUR Custom Dialect
+  //registry.insert<hipdnn::HipDnnDialect>();
+
+  // D. Register Standard Passes
+  //registerAllPasses();
+
+  // E. Register YOUR Custom Pass (The "script" we discussed)
+  // This allows you to run: --convert-hipdnn-to-llvm
+  //hipdnn::registerHipDnnPasses();
+
+  // F. Run the tool (Just like mlir-opt)
+  return mlir::asMainReturnCode(
+      mlir::MlirOptMain(argc, argv, "hip-opt: custom compiler driver\n", registry));
+}

--- a/tools/hip-opt/test.mlir
+++ b/tools/hip-opt/test.mlir
@@ -1,0 +1,25 @@
+// RUN: hip-opt %s --convert-hip-to-llvm | FileCheck %s
+
+module {
+  func.func @test_hip_ops(%N: index) {
+    // Create a HIP handle
+    // CHECK: %[[HANDLE:.*]] = llvm.call @hipCreateHandle() : () -> !llvm.ptr
+    %handle = hip.create_handle() : !hip.handle
+    
+    // Allocate device memory for a dynamic ?x128 f32 tensor
+    // CHECK: %[[MALLOC_RES:.*]] = llvm.call @hipMalloc(%{{.*}}) : (i64) -> !llvm.ptr
+    // CHECK: %[[TYPED_PTR:.*]] = llvm.bitcast %[[MALLOC_RES]] : !llvm.ptr to !llvm.ptr<f32>
+    %x = hip.alloc(%handle, %N) : memref<?x128xf32, 1>
+    
+    // Free the device memory
+    // CHECK: %[[VOID_PTR:.*]] = llvm.bitcast %[[TYPED_PTR]] : !llvm.ptr<f32> to !llvm.ptr
+    // CHECK: llvm.call @hipFree(%[[VOID_PTR]]) : (!llvm.ptr) -> ()
+    hip.free(%handle, %x) : memref<?x128xf32, 1>
+    
+    // Destroy the HIP handle
+    // CHECK: llvm.call @hipDestroyHandle(%[[HANDLE]]) : (!llvm.ptr) -> ()
+    hip.destroy_handle(%handle) : !hip.handle
+    
+    return
+  }
+}


### PR DESCRIPTION
Compiles very basic HIP dialect to LLVM IR.

Sample input:

module {
  func.func @test_hip_ops(%N: index) {
    // Create a HIP handle
    // CHECK: %[[HANDLE:.*]] = llvm.call @hipCreateHandle() : () -> !llvm.ptr
    %handle = hip.create_handle() : !hip.handle

    // Allocate device memory for a dynamic ?x128 f32 tensor
    // CHECK: %[[MALLOC_RES:.*]] = llvm.call @hipMalloc(%{{.*}}) : (i64) -> !llvm.ptr
    // CHECK: %[[TYPED_PTR:.*]] = llvm.bitcast %[[MALLOC_RES]] : !llvm.ptr to !llvm.ptr<f32>
    %x = hip.alloc(%handle, %N) : memref<?x128xf32, 1>

    // Free the device memory
    // CHECK: %[[VOID_PTR:.*]] = llvm.bitcast %[[TYPED_PTR]] : !llvm.ptr<f32> to !llvm.ptr
    // CHECK: llvm.call @hipFree(%[[VOID_PTR]]) : (!llvm.ptr) -> ()
    hip.free(%handle, %x) : memref<?x128xf32, 1>

    // Destroy the HIP handle
    // CHECK: llvm.call @hipDestroyHandle(%[[HANDLE]]) : (!llvm.ptr) -> ()
    hip.destroy_handle(%handle) : !hip.handle

    return
  }
}
Sample output:

C:\local\onnx-hipdnn-ep\tools\hip-opt\build>C:\local\onnx-hipdnn-ep\tools\hip-opt\build\Debug\hip-opt.exe C:/local/onnx-hipdnn-ep/tools/hip-opt/test.mlir --convert-hip-to-llvm
module {
  llvm.func @hipDestroyHandle(!llvm.ptr)
  llvm.func @hipFree(!llvm.ptr)
  llvm.func @hipMalloc(i64) -> !llvm.ptr
  llvm.func @hipCreateHandle() -> !llvm.ptr
  func.func @test_hip_ops(%arg0: index) {
    %0 = builtin.unrealized_conversion_cast %arg0 : index to i64
    %1 = llvm.call @hipCreateHandle() : () -> !llvm.ptr
    %2 = llvm.mlir.constant(128 : index) : i64
    %3 = llvm.mlir.constant(1 : index) : i64
    %4 = llvm.mul %2, %0 : i64
    %5 = llvm.mlir.zero : !llvm.ptr
    %6 = llvm.getelementptr %5[%4] : (!llvm.ptr, i64) -> !llvm.ptr, f32
    %7 = llvm.ptrtoint %6 : !llvm.ptr to i64
    %8 = llvm.call @hipMalloc(%7) : (i64) -> !llvm.ptr
    %9 = llvm.addrspacecast %8 : !llvm.ptr to !llvm.ptr<1>
    %10 = llvm.mlir.poison : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
    %11 = llvm.insertvalue %9, %10[0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
    %12 = llvm.insertvalue %9, %11[1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
    %13 = llvm.mlir.constant(0 : index) : i64
    %14 = llvm.insertvalue %13, %12[2] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
    %15 = llvm.insertvalue %0, %14[3, 0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
    %16 = llvm.insertvalue %2, %15[3, 1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
    %17 = llvm.insertvalue %2, %16[4, 0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
    %18 = llvm.insertvalue %3, %17[4, 1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
    %19 = llvm.extractvalue %18[0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
    %20 = llvm.addrspacecast %19 : !llvm.ptr<1> to !llvm.ptr
    llvm.call @hipFree(%20) : (!llvm.ptr) -> ()
    llvm.call @hipDestroyHandle(%1) : (!llvm.ptr) -> ()
    return
  }
}
The tool is fully AI-generated. Many improvements to be done.