### PR TITLE
feat(GQA): add GroupQueryAttention support with custom FMHA kernel for RDNA3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,34 @@ if(THEROCK_DIST)
   list(APPEND CMAKE_PREFIX_PATH "${THEROCK_DIST}/lib/cmake")
 endif()
 
+# ==============================================================================
+# Composable Kernel (CK) Configuration
+# ==============================================================================
+# CK_ROOT points to the root of the Composable Kernel source tree
+# (i.e., the projects/composablekernel directory inside rocm-libraries).
+# It can be set via:
+#   1. CMake cache variable: -DCK_ROOT=/path/to/composablekernel
+#   2. Environment variable: CK_ROOT=/path/to/composablekernel
+#
+# See README.md for instructions on how to clone rocm-libraries with
+# sparse checkout so that only Composable Kernel is downloaded.
+# ==============================================================================
+set(CK_ROOT "" CACHE PATH "Path to Composable Kernel source root (projects/composablekernel)")
+if(NOT CK_ROOT AND DEFINED ENV{CK_ROOT})
+  set(CK_ROOT "$ENV{CK_ROOT}")
+endif()
+
+if(CK_ROOT)
+  string(STRIP "${CK_ROOT}" CK_ROOT)
+  if(NOT EXISTS "${CK_ROOT}/CMakeLists.txt")
+    message(FATAL_ERROR
+      "[onnx-hipdnn-ep] CK_ROOT is set to '${CK_ROOT}' but no CMakeLists.txt "
+      "was found there. Please verify the path points to the Composable Kernel "
+      "source root (e.g., rocm-libraries/projects/composablekernel).")
+  endif()
+  message(STATUS "[onnx-hipdnn-ep] CK_ROOT: ${CK_ROOT}")
+endif()
+
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/deps.cmake)
 
 # HIP kernels library (compiled with hipcc on Windows, CMake HIP on Linux)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,35 +49,36 @@ if(THEROCK_DIST)
   list(APPEND CMAKE_PREFIX_PATH "${THEROCK_DIST}/lib/cmake")
 endif()
 
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/deps.cmake)
+
 # ==============================================================================
-# Composable Kernel (CK) Configuration
+# Composable Kernel (CK) Configuration (Optional)
 # ==============================================================================
-# CK_ROOT points to the root of the Composable Kernel source tree
-# (i.e., the projects/composablekernel directory inside rocm-libraries).
-# It can be set via:
-#   1. CMake cache variable: -DCK_ROOT=/path/to/composablekernel
-#   2. Environment variable: CK_ROOT=/path/to/composablekernel
+# CK_ROOT points to the CK source tree (header-only library).
+# When available, CK Tile's naive_attention_fwd can be used as an alternative
+# FMHA implementation (selectable at runtime via FMHA_USE_CK_NAIVE=1).
+# Without CK, only the custom portable kernel is available (recommended for RDNA3).
 #
-# See README.md for instructions on how to clone rocm-libraries with
-# sparse checkout so that only Composable Kernel is downloaded.
+# To obtain CK:
+#   git clone https://github.com/ROCm/composable_kernel.git
+# Then pass: -DCK_ROOT=/path/to/composable_kernel
 # ==============================================================================
-set(CK_ROOT "" CACHE PATH "Path to Composable Kernel source root (projects/composablekernel)")
+set(CK_ROOT "" CACHE PATH "Path to Composable Kernel source tree (optional, for CK Tile naive_attention_fwd)")
 if(NOT CK_ROOT AND DEFINED ENV{CK_ROOT})
   set(CK_ROOT "$ENV{CK_ROOT}")
 endif()
-
+set(HAS_CK_TILE OFF)
 if(CK_ROOT)
-  string(STRIP "${CK_ROOT}" CK_ROOT)
-  if(NOT EXISTS "${CK_ROOT}/CMakeLists.txt")
-    message(FATAL_ERROR
-      "[onnx-hipdnn-ep] CK_ROOT is set to '${CK_ROOT}' but no CMakeLists.txt "
-      "was found there. Please verify the path points to the Composable Kernel "
-      "source root (e.g., rocm-libraries/projects/composablekernel).")
+  if(EXISTS "${CK_ROOT}/include/ck_tile/core.hpp")
+    set(HAS_CK_TILE ON)
+    message(STATUS "[onnx-hipdnn-ep] CK_ROOT: ${CK_ROOT} (CK Tile available)")
+  else()
+    message(WARNING "[onnx-hipdnn-ep] CK_ROOT set but ck_tile headers not found at: ${CK_ROOT}/include/ck_tile/core.hpp\n"
+      "CK Tile naive_attention_fwd will NOT be available. Using portable kernel only.")
   endif()
-  message(STATUS "[onnx-hipdnn-ep] CK_ROOT: ${CK_ROOT}")
+else()
+  message(STATUS "[onnx-hipdnn-ep] CK_ROOT not set. Using portable FMHA kernel only (recommended for RDNA3).")
 endif()
-
-include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/deps.cmake)
 
 # HIP kernels library (compiled with hipcc on Windows, CMake HIP on Linux)
 add_subdirectory(kernels)
@@ -95,6 +96,7 @@ add_subdirectory(level-2-pass-rocm-softmax)
 add_subdirectory(level-2-pass-rocm-reshape)
 add_subdirectory(level-2-pass-rocm-transpose)
 add_subdirectory(level-2-pass-rocm-tile)
+add_subdirectory(level-2-pass-rocm-gqa)
 
 add_subdirectory(custom-op-rocm)
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ workspace/
 │   ├── bin/                  # Runtime DLLs (MIOpen.dll, hiprtc.dll, etc.)
 │   └── lib/llvm/bin/         # LLVM tools (amdgpu-arch.exe)
 ├── onnxruntime/              # ONNX Runtime source code (git clone)
+├── rocm-libraries/           # ROCm Libraries (sparse checkout, see below)
+│   └── projects/
+│       └── composablekernel/ # Composable Kernel source (CK_ROOT)
 ├── build/
 │   ├── onnxruntime/          # ONNX Runtime build artifacts
 │   └── onnx-hipdnn-ep/       # onnx-hipdnn-ep build artifacts
@@ -116,7 +119,7 @@ workspace/
 │   └── lib/cmake/            # CMake configuration files
 └── onnx-hipdnn-ep/           # This project (git clone)
     ├── 3rd-party/morphizen/  # MorphiZen framework (git submodule)
-    ├── test/models/     # Test models (gqa_layer_00.onnx)
+    ├── test/models/          # Test models (gqa_layer_00.onnx)
     └── etc/                  # Configuration files (morphizen_config.json)
 ```
 
@@ -186,7 +189,50 @@ cd onnxruntime
 cmake --build ../build/onnxruntime/Release/ --target install
 ```
 
-### Step 3: Build onnx-hipdnn-ep
+### Step 3: Clone Composable Kernel (CK)
+
+This project depends on [Composable Kernel](https://github.com/ROCm/rocm-libraries/tree/develop/projects/composablekernel) from the ROCm Libraries monorepo. Since the full monorepo is very large, we use **git sparse checkout** to download only the `projects/composablekernel` directory.
+
+**Using Bash (Git Bash on Windows):**
+
+```bash
+cd workspace
+
+git clone --no-checkout --depth 1 --filter=blob:none \
+  -b develop https://github.com/ROCm/rocm-libraries.git
+
+cd rocm-libraries
+git sparse-checkout init --cone
+git sparse-checkout set projects/composablekernel
+git checkout develop
+cd ..
+```
+
+**Using PowerShell:**
+
+```powershell
+cd workspace
+
+git clone --no-checkout --depth 1 --filter=blob:none `
+  -b develop https://github.com/ROCm/rocm-libraries.git
+
+cd rocm-libraries
+git sparse-checkout init --cone
+git sparse-checkout set projects/composablekernel
+git checkout develop
+cd ..
+```
+
+After this, only `projects/composablekernel` (and top-level files) will be present in the `rocm-libraries` directory. You can verify with:
+
+```bash
+git -C rocm-libraries sparse-checkout list
+# Expected output: projects/composablekernel
+```
+
+> **Note:** The `--depth 1 --filter=blob:none` flags create a shallow partial clone, keeping the download size minimal. If you need full history for development, omit these flags.
+
+### Step 4: Build onnx-hipdnn-ep
 
 #### Download onnx-hipdnn-ep
 
@@ -258,6 +304,7 @@ $THEROCK_DIST/bin/hipInfo | grep gcnArchName
 ```bash
 cd onnx-hipdnn-ep
 export THEROCK_DIST=$PWD/../therock
+export CK_ROOT=$PWD/../rocm-libraries/projects/composablekernel
 
 # CRITICAL: Detect and set HIP architecture
 export HIP_ARCH=$($THEROCK_DIST/lib/llvm/bin/amdgpu-arch)
@@ -266,6 +313,7 @@ echo "Detected HIP architecture: $HIP_ARCH"
 cmake \
   -B ../build/onnx-hipdnn-ep -S . \
   -DTHEROCK_DIST=$THEROCK_DIST \
+  -DCK_ROOT=$CK_ROOT \
   -DCMAKE_PREFIX_PATH=$PWD/../local \
   -DCMAKE_INSTALL_PREFIX=$PWD/../local \
   -DHIP_PLATFORM=amd \
@@ -281,6 +329,7 @@ cmake --build ../build/onnx-hipdnn-ep --config Release --target install --parall
 cd onnx-hipdnn-ep
 $env:THEROCK_DIST = "$PWD\..\therock"
 $env:HIP_PLATFORM = "amd"
+$CK_ROOT = "$PWD\..\rocm-libraries\projects\composablekernel"
 
 # CRITICAL: Detect and set HIP architecture
 $HIP_ARCH = & "$env:THEROCK_DIST\lib\llvm\bin\amdgpu-arch.exe"
@@ -288,6 +337,7 @@ Write-Host "Detected HIP architecture: $HIP_ARCH"
 
 cmake -B ..\build\onnx-hipdnn-ep -S . `
   -DTHEROCK_DIST="$env:THEROCK_DIST" `
+  -DCK_ROOT="$CK_ROOT" `
   -DCMAKE_PREFIX_PATH="$PWD\..\local" `
   -DCMAKE_INSTALL_PREFIX="$PWD\..\local" `
   -DHIP_PLATFORM=amd `
@@ -302,6 +352,7 @@ cmake --build ..\build\onnx-hipdnn-ep --config Release --target install --parall
 | Option | Default | Description |
 |--------|---------|-------------|
 | `THEROCK_DIST` | (required) | Path to TheRock ROCm SDK installation |
+| `CK_ROOT` | - | Path to Composable Kernel source root (e.g., `rocm-libraries/projects/composablekernel`). Can also be set via `CK_ROOT` environment variable. |
 | `CMAKE_PREFIX_PATH` | - | Path to ONNX Runtime installation (for find_package) |
 | `CMAKE_INSTALL_PREFIX` | - | Installation directory for built artifacts |
 | `HIP_PLATFORM` | `amd` | HIP platform (use `amd` for AMD GPUs) |
@@ -314,6 +365,7 @@ cmake --build ..\build\onnx-hipdnn-ep --config Release --target install --parall
 | Variable | Description |
 |----------|-------------|
 | `THEROCK_DIST` | Path to TheRock SDK installation |
+| `CK_ROOT` | Path to Composable Kernel source root (alternative to CMake `-DCK_ROOT=`) |
 | `HIP_PLATFORM` | Set to `amd` for AMD GPU support |
 | `MORPHIZEN_DEBUG_ROCM` | Debug level (1=basic, 2=verbose) |
 | `MORPHIZEN_ROCM_EN_LVL1_MERGE` | Enable Level-1 subgraph merging (1=enabled) |

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This project demonstrates the integration of HIP (Heterogeneous-compute Interfac
 | Gemm | hipBLASLt | Implemented |
 | Gemm + Bias | hipBLASLt | Implemented |
 | MatMul | rocBLAS | Implemented |
+| GQA (GroupQueryAttention) | Custom HIP Kernel | Implemented |
 | Mul | HIPRTC | Implemented |
 | Softmax | HIPRTC | Implemented |
 | Reshape | HIP Memory | Implemented |
@@ -52,8 +53,9 @@ This project demonstrates the integration of HIP (Heterogeneous-compute Interfac
 - **level-2-pass-rocm-reshape**: Level-2 Reshape pass
 - **level-2-pass-rocm-transpose**: Level-2 Transpose pass (HIPRTC)
 - **level-2-pass-rocm-tile**: Level-2 Tile pass (HIPRTC)
+- **level-2-pass-rocm-gqa**: Level-2 GQA pass (GroupQueryAttention)
 - **custom-op-rocm**: Custom operator implementations using HIP
-- **kernels**: GPU kernel implementations (HIPRTC)
+- **kernels**: GPU kernel implementations (HIPRTC + FMHA). See [doc/04_FMHA_GQA_IMPLEMENTATION.md](doc/04_FMHA_GQA_IMPLEMENTATION.md) for GQA/FMHA details.
 - **proto**: Protocol buffer definitions
 - **test**: Test suite for validation
 
@@ -352,7 +354,7 @@ cmake --build ..\build\onnx-hipdnn-ep --config Release --target install --parall
 | Option | Default | Description |
 |--------|---------|-------------|
 | `THEROCK_DIST` | (required) | Path to TheRock ROCm SDK installation |
-| `CK_ROOT` | - | Path to Composable Kernel source root (e.g., `rocm-libraries/projects/composablekernel`). Can also be set via `CK_ROOT` environment variable. |
+| `CK_ROOT` | (optional) | Path to Composable Kernel source root (e.g., `rocm-libraries/projects/composablekernel`). Enables CK Tile naive\_attention\_fwd as an alternative FMHA backend. When not set, only the custom portable FMHA kernel is available (recommended for RDNA3). Can also be set via `CK_ROOT` environment variable. |
 | `CMAKE_PREFIX_PATH` | - | Path to ONNX Runtime installation (for find_package) |
 | `CMAKE_INSTALL_PREFIX` | - | Installation directory for built artifacts |
 | `HIP_PLATFORM` | `amd` | HIP platform (use `amd` for AMD GPUs) |
@@ -367,6 +369,7 @@ cmake --build ..\build\onnx-hipdnn-ep --config Release --target install --parall
 | `THEROCK_DIST` | Path to TheRock SDK installation |
 | `CK_ROOT` | Path to Composable Kernel source root (alternative to CMake `-DCK_ROOT=`) |
 | `HIP_PLATFORM` | Set to `amd` for AMD GPU support |
+| `FMHA_USE_CK_NAIVE` | Set to `1` to use CK Tile's `naive_attention_fwd` instead of the custom portable kernel for FMHA/GQA. Only effective when built with `CK_ROOT`. See [doc/04_FMHA_GQA_IMPLEMENTATION.md](doc/04_FMHA_GQA_IMPLEMENTATION.md) for details. |
 | `MORPHIZEN_DEBUG_ROCM` | Debug level (1=basic, 2=verbose) |
 | `MORPHIZEN_ROCM_EN_LVL1_MERGE` | Enable Level-1 subgraph merging (1=enabled) |
 | `MORPHIZEN_DRY_RUN` | Dry run mode without GPU execution (1=enabled) |
@@ -453,6 +456,84 @@ cd ..\local\bin
   P99: 53.50 ms
   Throughput: 18.69 infer/sec
 ```
+
+### Test case 3: Run GQA Model Verifier
+
+The model verifier compares CPU and GPU inference results for GQA models. It is
+the primary tool for validating FMHA accuracy.
+
+```bash
+# Set environment
+export PATH="$THEROCK_DIST/bin:$PATH"
+
+# Run with prefill model (seqlen_q=255)
+cd ../build/onnx-hipdnn-ep/bin
+./model_verifier /path/to/gqa_prefill.onnx
+
+# Run with decode model (seqlen_q=1)
+./model_verifier /path/to/gqa_decode.onnx
+```
+
+```powershell
+# Set environment
+$env:PATH = "$env:THEROCK_DIST\bin;$env:PATH"
+
+# Run with prefill model
+cd ..\build\onnx-hipdnn-ep\bin
+.\model_verifier.exe C:\path\to\gqa_prefill.onnx
+
+# Run with decode model
+.\model_verifier.exe C:\path\to\gqa_decode.onnx
+```
+
+**Expected Output (default portable kernel):**
+```
+[FMHA] Using custom portable kernel (default). Set FMHA_USE_CK_NAIVE=1 to use CK Tile.
+[Portable Prefill] batch=1, nhead_q=32, nhead_k=8, seqlen_q=255, seqlen_k=255, hdim=128, ...
+  Max difference: 0.000977
+  [PASS] All elements within tolerance
+```
+
+#### Reproducing RDNA3 CK Tile Accuracy Issues
+
+If the project was built with `CK_ROOT`, you can reproduce the known CK Tile
+accuracy issues on RDNA3 (wave32) hardware by setting `FMHA_USE_CK_NAIVE=1`:
+
+```bash
+# Test CK Tile decode (shows ~0.048 max diff due to cross_wave_reduce bug)
+FMHA_USE_CK_NAIVE=1 ./model_verifier /path/to/gqa_decode.onnx
+
+# Test CK Tile prefill (FAILS — no causal masking support, ~1.67 max diff)
+FMHA_USE_CK_NAIVE=1 ./model_verifier /path/to/gqa_prefill.onnx
+```
+
+```powershell
+# Test CK Tile decode
+$env:FMHA_USE_CK_NAIVE = "1"
+.\model_verifier.exe C:\path\to\gqa_decode.onnx
+
+# Test CK Tile prefill (FAILS)
+.\model_verifier.exe C:\path\to\gqa_prefill.onnx
+
+# Reset to default portable kernel
+Remove-Item Env:\FMHA_USE_CK_NAIVE
+```
+
+**Expected results on RDNA3 with `FMHA_USE_CK_NAIVE=1`:**
+
+| Model | Max Diff | Result | Root Cause |
+|-------|----------|--------|------------|
+| Prefill | ~1.67 | **FAIL** | No causal masking in CK naive |
+| Decode | ~0.048 | PASS (reduced accuracy) | `cross_wave_reduce` hardcodes wave64 |
+
+Compare with default portable kernel (both PASS with max diff < 0.001).
+
+> **Note:** These accuracy issues are specific to RDNA3's native wave32 architecture.
+> On CDNA GPUs (MI-series, wave64), CK Tile's naive_attention_fwd should produce
+> correct results for the decode path.
+
+For detailed technical analysis of the root cause, see
+[doc/04_FMHA_GQA_IMPLEMENTATION.md](doc/04_FMHA_GQA_IMPLEMENTATION.md).
 
 ---
 

--- a/custom-op-rocm/src/custom_op.cpp
+++ b/custom-op-rocm/src/custom_op.cpp
@@ -429,22 +429,30 @@ void RocmCustomOp::AllocateIntermediateBuffers() {
     auto &data = *node_data_[i];
 
     // Calculate output size based on operation parameters
-    size_t output_size = GetOutputSize(i, 0);
+    // GQA has 3 outputs; all other ops have 1 output
+    int num_outputs = 1;
+    if (node.params().op_type() == "gqa") {
+      num_outputs = node.params().gqa_params().num_outputs();
+    }
 
-    if (output_size > 0) {
-      float *output_buf = nullptr;
-      hipError_t err = hipMalloc(&output_buf, output_size);
-      if (err != hipSuccess) {
-        LOG(ERROR)
-            << "[ROCm CustomOp] Failed to allocate output buffer for node " << i
-            << ": " << hipGetErrorString(err);
-        throw std::runtime_error(
-            "Failed to allocate GPU memory for node output");
+    for (int out_idx = 0; out_idx < num_outputs; ++out_idx) {
+      size_t output_size = GetOutputSize(i, out_idx);
+
+      if (output_size > 0) {
+        float *output_buf = nullptr;
+        hipError_t err = hipMalloc(&output_buf, output_size);
+        if (err != hipSuccess) {
+          LOG(ERROR)
+              << "[ROCm CustomOp] Failed to allocate output buffer for node "
+              << i << " output " << out_idx << ": " << hipGetErrorString(err);
+          throw std::runtime_error(
+              "Failed to allocate GPU memory for node output");
+        }
+        data.output_buffers.push_back(output_buf);
+        data.output_sizes.push_back(output_size);
+        MY_LOG(2) << "[ROCm CustomOp] Node " << i << ": Allocated output["
+                  << out_idx << "] buffer " << output_size << " bytes";
       }
-      data.output_buffers.push_back(output_buf);
-      data.output_sizes.push_back(output_size);
-      MY_LOG(2) << "[ROCm CustomOp] Node " << i << ": Allocated output buffer "
-                << output_size << " bytes";
     }
 
     // Upload weights to GPU if not already done
@@ -542,6 +550,22 @@ size_t RocmCustomOp::GetOutputSize(int32_t node_id,
     const auto &tile_params = params.tile_params();
     // Tile expands size
     return tile_params.out_size() * sizeof(float);
+  } else if (params.op_type() == "gqa") {
+    const auto &gqa = params.gqa_params();
+    // GQA has 3 outputs: output, present_key, present_value (all fp16)
+    auto shape_bytes = [](const auto &shape) -> size_t {
+      size_t elems = 1;
+      for (int i = 0; i < shape.size(); ++i)
+        elems *= shape.Get(i);
+      return elems * 2; // fp16 = 2 bytes
+    };
+    if (output_index == 0)
+      return shape_bytes(gqa.output_shape());
+    if (output_index == 1)
+      return shape_bytes(gqa.present_key_shape());
+    if (output_index == 2)
+      return shape_bytes(gqa.present_value_shape());
+    return 0;
   }
 
   return 0;
@@ -645,9 +669,44 @@ void RocmCustomOp::UploadExternalInputs(const OrtApi *api,
 
     size_t elem_count = 0;
     api->GetTensorShapeElementCount(type_info, &elem_count);
+
+    // Detect element type to compute correct byte size
+    ONNXTensorElementDataType elem_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT;
+    api->GetTensorElementType(type_info, &elem_type);
     api->ReleaseTensorTypeAndShapeInfo(type_info);
 
-    size_t bytes = elem_count * sizeof(float);
+    size_t elem_size = sizeof(float); // default
+    switch (elem_type) {
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:
+      elem_size = 2;
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32:
+      elem_size = sizeof(int32_t);
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64:
+      elem_size = sizeof(int64_t);
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT:
+    default:
+      elem_size = sizeof(float);
+      break;
+    }
+    size_t bytes = elem_count * elem_size;
+
+    // Handle zero-sized tensors (e.g., past_key with shape [1, 8, 0, 128])
+    // Allocate a minimal 1-byte placeholder so the buffer exists in the map
+    if (bytes == 0) {
+      auto it = external_input_buffers_.find(name);
+      if (it == external_input_buffers_.end()) {
+        float *d_placeholder = nullptr;
+        hipMalloc(&d_placeholder, 1); // minimal allocation
+        external_input_buffers_[name] = d_placeholder;
+        external_input_sizes_[name] = 0;
+      }
+      MY_LOG(2) << "[ROCm CustomOp] Zero-sized external input: " << name
+                << " (placeholder allocated)";
+      continue;
+    }
 
     // Get host pointer
     float *h_data = nullptr;
@@ -692,7 +751,8 @@ void RocmCustomOp::UploadExternalInputs(const OrtApi *api,
 void RocmCustomOp::ExecuteSubgraph(const OrtApi *api,
                                    OrtKernelContext *context) const {
   MY_LOG(2) << "[ROCm CustomOp] Phase 2: Executing " << subgraph_.nodes_size()
-            << " nodes";
+            << " nodes, external_input_buffers_="
+            << external_input_buffers_.size();
 
   for (const auto &node : subgraph_.nodes()) {
     ExecuteNode(node);
@@ -710,12 +770,22 @@ void RocmCustomOp::ExecuteNode(const rocm::RocmNodeProto &node) const {
 
   // Gather input pointers and log input references
   std::vector<float *> inputs;
+  MY_LOG(2) << "[ROCm CustomOp] Node " << node_id << " has "
+            << node.inputs_size() << " input refs";
   for (int i = 0; i < node.inputs_size(); ++i) {
     const auto &input_ref = node.inputs(i);
+    MY_LOG(2) << "[ROCm CustomOp] Node " << node_id << " input[" << i
+              << "]: has_external=" << input_ref.has_external_name()
+              << " has_internal=" << input_ref.has_internal()
+              << (input_ref.has_external_name()
+                      ? " name=" + input_ref.external_name()
+                      : "");
     float *ptr = ResolveTensorRef(input_ref);
     if (ptr == nullptr) {
-      LOG(ERROR) << "[ROCm CustomOp] Failed to resolve input for node "
-                 << node_id;
+      LOG(ERROR) << "[ROCm CustomOp] Failed to resolve input " << i
+                 << " for node " << node_id
+                 << " (has_ext=" << input_ref.has_external_name()
+                 << " has_int=" << input_ref.has_internal() << ")";
       throw std::runtime_error("Failed to resolve tensor reference");
     }
     inputs.push_back(ptr);
@@ -785,6 +855,8 @@ void RocmCustomOp::ExecuteNode(const rocm::RocmNodeProto &node) const {
     ExecuteTransposeNode(node_id, params.transpose_params(), inputs, output);
   } else if (params.op_type() == "tile") {
     ExecuteTileNode(node_id, params.tile_params(), inputs, output);
+  } else if (params.op_type() == "gqa") {
+    ExecuteGQANode(node_id, params.gqa_params(), inputs);
   } else {
     LOG(ERROR) << "[ROCm CustomOp] Unknown op_type: " << params.op_type();
     throw std::runtime_error("Unknown operation type: " + params.op_type());
@@ -1505,6 +1577,207 @@ void RocmCustomOp::ExecuteTileNode(int32_t node_id,
             << ": Tile executed successfully";
 }
 
+void RocmCustomOp::ExecuteGQANode(int32_t node_id,
+                                  const rocm::GqaParamProto &params,
+                                  const std::vector<float *> &inputs) const {
+  MY_LOG(2) << "[ROCm CustomOp] ExecuteGQANode[" << node_id
+            << "]: num_heads=" << params.num_heads()
+            << ", kv_num_heads=" << params.kv_num_heads()
+            << ", head_size=" << params.head_size()
+            << ", scale=" << params.scale();
+
+  auto stream = hip_context_->stream();
+  auto &data = *node_data_[node_id];
+
+  // GQA params
+  int32_t num_heads = params.num_heads();
+  int32_t kv_num_heads = params.kv_num_heads();
+  int32_t head_size = params.head_size();
+  float scale = params.scale();
+
+  // Input pointers (all on GPU, uploaded as raw bytes)
+  // Inputs: 0=query, 1=key, 2=value, 3=past_key, 4=past_value, 5=seqlens_k,
+  // 6=total_seq_len
+  const void *d_query = inputs[0]; // [B, S_q, num_heads * head_size] fp16
+  const void *d_key = inputs[1];   // [B, S_q, kv_num_heads * head_size] fp16
+  const void *d_value = inputs[2]; // [B, S_q, kv_num_heads * head_size] fp16
+  const void *d_past_key =
+      inputs[3]; // [B, kv_num_heads, past_S, head_size] fp16 (BNSH)
+  const void *d_past_value =
+      inputs[4]; // [B, kv_num_heads, past_S, head_size] fp16 (BNSH)
+  // inputs[5] = seqlens_k (int32), inputs[6] = total_seq_len (int32)
+  // These are used by ORT but our kernel derives lengths from shapes
+
+  // Output buffers (3 outputs for GQA)
+  void *d_output =
+      data.output_buffers[0]; // [B, S_q, num_heads * head_size] fp16
+  void *d_present_key =
+      data.output_buffers[1]; // [B, kv_num_heads, total_S, head_size] fp16
+  void *d_present_value =
+      data.output_buffers[2]; // [B, kv_num_heads, total_S, head_size] fp16
+
+  // Derive dimensions from proto shapes
+  // query_shape: [B, S_q, hidden_size]
+  int32_t batch = (params.query_shape_size() > 0) ? params.query_shape(0) : 1;
+  int32_t seqlen_q =
+      (params.query_shape_size() > 1) ? params.query_shape(1) : 1;
+  // key_shape: [B, S_new, kv_hidden_size]
+  int32_t seqlen_new = (params.key_shape_size() > 1) ? params.key_shape(1) : 1;
+  // past_key_shape: [B, kv_num_heads, past_S, head_size]
+  int32_t past_seqlen =
+      (params.past_key_shape_size() > 2) ? params.past_key_shape(2) : 0;
+  // total sequence length for attention
+  int32_t total_seqlen = past_seqlen + seqlen_new;
+
+  MY_LOG(2) << "[ROCm CustomOp] GQA dims: batch=" << batch
+            << " seqlen_q=" << seqlen_q << " seqlen_new=" << seqlen_new
+            << " past_seqlen=" << past_seqlen
+            << " total_seqlen=" << total_seqlen;
+
+  // TODO: Support batch_size > 1
+  // TODO: Support packed QKV (query contains Q+K+V when key/value are absent)
+  // TODO: Support cos_cache/sin_cache for in-kernel RoPE (do_rotary=1)
+  // TODO: Support position_ids input
+  // TODO: Support attention_bias input
+  // TODO: Support head_sink (smooth softmax) input
+  // TODO: Support local_window_size for sliding window attention
+  // TODO: Support softcap for attention weight capping
+  // TODO: Support output_qk (4th output)
+
+  // ==========================================
+  // Step 1: Build present_key/value = concat(past, new) along seq dim
+  // Layout: [B, kv_num_heads, total_seqlen, head_size] (BNSH, fp16)
+  // New key/value is [B, S_new, kv_hidden] (BSH) -> scatter into BNSH
+  // ==========================================
+
+  size_t fp16_size = 2; // sizeof(half)
+
+  // Helper: build present KV = concat(past BNSH, new BSH->BNSH) for one tensor
+  auto build_present_kv = [&](const void *d_past, const void *d_new,
+                              void *d_present) {
+    // Copy past (BNSH -> BNSH, different seq stride)
+    if (past_seqlen > 0) {
+      for (int b = 0; b < batch; ++b) {
+        for (int h = 0; h < kv_num_heads; ++h) {
+          size_t past_off =
+              ((size_t)b * kv_num_heads * past_seqlen * head_size +
+               (size_t)h * past_seqlen * head_size) *
+              fp16_size;
+          size_t pres_off =
+              ((size_t)b * kv_num_heads * total_seqlen * head_size +
+               (size_t)h * total_seqlen * head_size) *
+              fp16_size;
+          hipMemcpyAsync((char *)d_present + pres_off,
+                         (const char *)d_past + past_off,
+                         (size_t)past_seqlen * head_size * fp16_size,
+                         hipMemcpyDeviceToDevice, stream);
+        }
+      }
+    }
+    // Scatter new (BSH -> BNSH at offset past_seqlen)
+    for (int b = 0; b < batch; ++b) {
+      for (int h = 0; h < kv_num_heads; ++h) {
+        for (int s = 0; s < seqlen_new; ++s) {
+          size_t src_off =
+              ((size_t)b * seqlen_new * kv_num_heads * head_size +
+               (size_t)s * kv_num_heads * head_size + (size_t)h * head_size) *
+              fp16_size;
+          size_t dst_off =
+              ((size_t)b * kv_num_heads * total_seqlen * head_size +
+               (size_t)h * total_seqlen * head_size +
+               (size_t)(past_seqlen + s) * head_size) *
+              fp16_size;
+          hipMemcpyAsync(
+              (char *)d_present + dst_off, (const char *)d_new + src_off,
+              (size_t)head_size * fp16_size, hipMemcpyDeviceToDevice, stream);
+        }
+      }
+    }
+  };
+
+  build_present_kv(d_past_key, d_key, d_present_key);
+  build_present_kv(d_past_value, d_value, d_present_value);
+
+  // ==========================================
+  // Step 2: Transpose Q from BSH to BNSH, run FMHA, transpose O back
+  // ==========================================
+
+  // Helper: transpose fp16 tensor between BSH [B, S, N*D] and BNSH [B, N, S, D]
+  auto transpose_bsh_bnsh = [&](const void *src, void *dst, int nheads,
+                                int seqlen, bool bsh_to_bnsh) {
+    for (int b = 0; b < batch; ++b) {
+      for (int n = 0; n < nheads; ++n) {
+        for (int s = 0; s < seqlen; ++s) {
+          size_t bsh_off =
+              ((size_t)b * seqlen * nheads * head_size +
+               (size_t)s * nheads * head_size + (size_t)n * head_size) *
+              fp16_size;
+          size_t bnsh_off =
+              ((size_t)b * nheads * seqlen * head_size +
+               (size_t)n * seqlen * head_size + (size_t)s * head_size) *
+              fp16_size;
+          auto src_off = bsh_to_bnsh ? bsh_off : bnsh_off;
+          auto dst_off = bsh_to_bnsh ? bnsh_off : bsh_off;
+          hipMemcpyAsync((char *)dst + dst_off, (const char *)src + src_off,
+                         (size_t)head_size * fp16_size, hipMemcpyDeviceToDevice,
+                         stream);
+        }
+      }
+    }
+  };
+
+  size_t q_bnsh_bytes =
+      (size_t)batch * num_heads * seqlen_q * head_size * fp16_size;
+  void *d_q_bnsh = nullptr;
+  hipError_t err = hipMalloc(&d_q_bnsh, q_bnsh_bytes);
+  if (err != hipSuccess) {
+    LOG(ERROR) << "[ROCm CustomOp] Failed to allocate Q BNSH buffer";
+    throw std::runtime_error("Failed to allocate Q BNSH buffer for GQA");
+  }
+
+  transpose_bsh_bnsh(d_query, d_q_bnsh, num_heads, seqlen_q,
+                     /*bsh_to_bnsh=*/true);
+
+  // Allocate FMHA output in BNSH layout
+  void *d_o_bnsh = nullptr;
+  err = hipMalloc(&d_o_bnsh, q_bnsh_bytes);
+  if (err != hipSuccess) {
+    hipFree(d_q_bnsh);
+    LOG(ERROR) << "[ROCm CustomOp] Failed to allocate O BNSH buffer";
+    throw std::runtime_error("Failed to allocate O BNSH buffer for GQA");
+  }
+
+  // Run FMHA forward kernel with causal masking
+  err = launch_fmha_fwd_fp16_causal(
+      stream,
+      d_q_bnsh,        // Q: [B, nhead_q, seqlen_q, hdim]
+      d_present_key,   // K: [B, nhead_k, total_seqlen, hdim]
+      d_present_value, // V: [B, nhead_k, total_seqlen, hdim]
+      d_o_bnsh,        // O: [B, nhead_q, seqlen_q, hdim]
+      batch, num_heads, kv_num_heads, seqlen_q, total_seqlen, head_size, scale);
+
+  if (err != hipSuccess) {
+    hipFree(d_q_bnsh);
+    hipFree(d_o_bnsh);
+    LOG(ERROR) << "[ROCm CustomOp] FMHA kernel failed: "
+               << hipGetErrorString(err);
+    throw std::runtime_error("FMHA kernel failed");
+  }
+
+  // Transpose output from BNSH back to BSH
+  transpose_bsh_bnsh(d_o_bnsh, d_output, num_heads, seqlen_q,
+                     /*bsh_to_bnsh=*/false);
+
+  hipFree(d_q_bnsh);
+  hipFree(d_o_bnsh);
+
+  MY_LOG(2) << "[ROCm CustomOp] Node " << node_id
+            << ": GQA executed successfully"
+            << " (output=" << data.output_sizes[0]
+            << ", present_key=" << data.output_sizes[1]
+            << ", present_value=" << data.output_sizes[2] << " bytes)";
+}
+
 void RocmCustomOp::DownloadExternalOutputs(const OrtApi *api,
                                            OrtKernelContext *context) const {
   // Use per-session stream
@@ -1582,6 +1855,18 @@ void RocmCustomOp::DownloadExternalOutputs(const OrtApi *api,
       for (int j = 0; j < tile_params.shape_out_size(); ++j) {
         output_shape.push_back(tile_params.shape_out(j));
       }
+    } else if (params.op_type() == "gqa") {
+      const auto &gqa = params.gqa_params();
+      auto append_shape = [&output_shape](const auto &shape) {
+        for (int j = 0; j < shape.size(); ++j)
+          output_shape.push_back(shape.Get(j));
+      };
+      if (output_idx == 0)
+        append_shape(gqa.output_shape());
+      else if (output_idx == 1)
+        append_shape(gqa.present_key_shape());
+      else if (output_idx == 2)
+        append_shape(gqa.present_value_shape());
     }
 
     // Get ORT output tensor

--- a/custom-op-rocm/src/custom_op.hpp
+++ b/custom-op-rocm/src/custom_op.hpp
@@ -333,6 +333,10 @@ private:
   void ExecuteTileNode(int32_t node_id, const rocm::TileParamProto &params,
                        const std::vector<float *> &inputs, float *output) const;
 
+  // GQA (Grouped Query Attention) using CK Tile FMHA kernels
+  void ExecuteGQANode(int32_t node_id, const rocm::GqaParamProto &params,
+                      const std::vector<float *> &inputs) const;
+
   // Tensor resolution
   float *ResolveTensorRef(const rocm::TensorRefProto &ref) const;
   size_t GetOutputSize(int32_t node_id, int32_t output_index) const;

--- a/doc/04_FMHA_GQA_IMPLEMENTATION.md
+++ b/doc/04_FMHA_GQA_IMPLEMENTATION.md
@@ -1,0 +1,355 @@
+<!--
+Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+Licensed under the MIT License.
+-->
+# FMHA / GQA Implementation Details
+
+This document describes the Flash Multi-Head Attention (FMHA) kernel implementation
+for Grouped Query Attention (GQA) in onnx-hipdnn-ep, the design decisions made,
+and the accuracy issues encountered on RDNA3 (GFX11) hardware.
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Architecture](#architecture)
+- [Implementation Details](#implementation-details)
+  - [Custom Portable Kernel (Default)](#custom-portable-kernel-default)
+  - [CK Tile naive\_attention\_fwd (Optional)](#ck-tile-naive_attention_fwd-optional)
+- [Build Configuration](#build-configuration)
+- [Runtime Configuration](#runtime-configuration)
+- [RDNA3 Wave32 Accuracy Issues](#rdna3-wave32-accuracy-issues)
+  - [Root Cause: cross\_wave\_reduce Bug](#root-cause-cross_wave_reduce-bug)
+  - [Why wave64 Workarounds Failed](#why-wave64-workarounds-failed)
+  - [CK Tile Prefill Failure: No Causal Masking](#ck-tile-prefill-failure-no-causal-masking)
+- [Accuracy Test Results](#accuracy-test-results)
+- [Approaches Tried and Discarded](#approaches-tried-and-discarded)
+- [File Reference](#file-reference)
+
+---
+
+## Overview
+
+The ONNX `com.microsoft.GroupQueryAttention` (GQA) operator implements multi-head
+attention with grouped key/value heads, as used in models like Llama 3.1. The operation
+has two phases:
+
+- **Prefill** (`seqlen_q > 1`): Processes a full prompt sequence. Requires **causal
+  masking** so that each query token only attends to current and previous key tokens.
+- **Decode** (`seqlen_q == 1`): Generates one token at a time. The single query token
+  attends to all past key/value tokens — no causal masking needed.
+
+The kernel operates in **BHSD layout** `[Batch, Head, Seqlen, Hdim]` with FP16
+data types and supports GQA head ratios (e.g., 32 query heads / 8 KV heads = 4:1).
+
+---
+
+## Architecture
+
+```
+                  launch_fmha_fwd_fp16_causal()    (Public C API)
+                              │
+                    ┌─────────┴──────────┐
+                    │  use_ck_naive_impl()│
+                    │  (env var check)    │
+                    └─────────┬──────────┘
+                              │
+              FMHA_USE_CK_NAIVE=1?
+                   /                \
+                 YES                 NO (default)
+                  │                   │
+    ┌─────────────▼───────────┐  ┌───▼──────────────────────┐
+    │  launch_fmha_ck_naive() │  │  launch_fmha_portable()  │
+    │  (requires HAS_CK_TILE) │  │  (always available)      │
+    │                         │  │                           │
+    │  Uses CK Tile's         │  │  Custom HIP kernel with  │
+    │  naive_attention_fwd    │  │  portable shared-memory   │
+    │  host API               │  │  tree reductions          │
+    │                         │  │  + causal masking          │
+    │  ⚠ No causal masking    │  │                           │
+    │  ⚠ wave64-hardcoded     │  │  ✓ wave32 + wave64 safe  │
+    └─────────────────────────┘  └───────────────────────────┘
+```
+
+---
+
+## Implementation Details
+
+### Custom Portable Kernel (Default)
+
+**Source**: `kernels/src/fmha_ck_tile_kernels.hip` — function `fmha_naive_causal_kernel`
+
+This kernel implements online softmax attention with bottom-right causal masking.
+It is the **default and recommended** implementation for all GPU architectures,
+especially RDNA3.
+
+**Key design decisions:**
+
+1. **Portable shared-memory tree reductions**: Instead of using warp-level
+   intrinsics (which differ between wave32 and wave64), the kernel uses
+   `__syncthreads()`-based tree reductions in shared memory. This works correctly
+   regardless of wavefront size.
+
+   ```cpp
+   // Portable block reduction — works on wave32 AND wave64
+   __device__ AccType block_reduce_max(AccType val, AccType* smem) {
+       smem[threadIdx.x] = val;
+       __syncthreads();
+       for (int s = kBlockSize / 2; s > 0; s >>= 1) {
+           if (threadIdx.x < s)
+               smem[threadIdx.x] = fmaxf(smem[threadIdx.x], smem[threadIdx.x + s]);
+           __syncthreads();
+       }
+       return smem[0];
+   }
+   ```
+
+2. **Online softmax with rescaling**: The kernel processes K/V in chunks of
+   `kBlockSize=256` tokens, maintaining running max and sum statistics. When
+   a new chunk produces a larger max, previous accumulations are rescaled using
+   `expf(old_max - new_max)` to maintain numerical stability.
+
+3. **Bottom-right causal masking**: For prefill, each query row `i` can only
+   attend to key positions `0..causal_limit` where
+   `causal_limit = i + (seqlen_k - seqlen_q)`. For decode (`seqlen_q=1`),
+   `causal_limit = seqlen_k - 1`, which allows attending to all keys.
+
+4. **Grid layout**: `(ceil(hdim/256), seqlen_q, batch*nhead_q)` — each thread
+   block computes one output element dimension for one query row.
+
+**Accuracy**: Excellent on all architectures. Typical max diff vs CPU: ~0.001 for
+prefill, ~0.00006 for decode (FP16 precision limited).
+
+### CK Tile naive_attention_fwd (Optional)
+
+**Source**: `kernels/src/fmha_ck_tile_kernels.hip` — function `launch_fmha_ck_naive`
+(guarded by `#ifdef HAS_CK_TILE`)
+
+This path uses CK Tile's reference `naive_attention_fwd` host API from
+`ck_tile/ref/naive_attention.hpp`. It is available as an alternative for
+testing and comparison when built with `CK_ROOT`.
+
+**Limitations:**
+
+- **No causal masking**: The `naive_attention_fwd` API does not support causal
+  masks, making it incorrect for prefill.
+- **wave64-hardcoded reductions**: The internal kernel uses `ds_bpermute`-based
+  wave reductions and a `cross_wave_reduce` function that hardcodes `wave_size=64`
+  and `waves=4`. On RDNA3 (native wave32), this causes incomplete reductions.
+
+---
+
+## Build Configuration
+
+CK_ROOT is **optional**. The build system behavior:
+
+| CK_ROOT | HAS_CK_TILE | Available Implementations |
+|---------|-------------|--------------------------|
+| Not set | OFF | Portable kernel only |
+| Set (valid) | ON | Portable kernel + CK naive |
+
+CMake automatically detects CK_ROOT and sets `HAS_CK_TILE`:
+
+```cmake
+# In root CMakeLists.txt:
+set(CK_ROOT "" CACHE PATH "Path to Composable Kernel source tree (optional)")
+# ...
+if(CK_ROOT AND EXISTS "${CK_ROOT}/include/ck_tile/core.hpp")
+    set(HAS_CK_TILE ON)
+endif()
+
+# In kernels/CMakeLists.txt: passes -DHAS_CK_TILE=1 to hipcc when ON
+```
+
+---
+
+## Runtime Configuration
+
+| Environment Variable | Values | Description |
+|---------------------|--------|-------------|
+| `FMHA_USE_CK_NAIVE` | `1` = CK naive, unset/other = portable | Selects FMHA implementation at runtime. Only effective when built with `HAS_CK_TILE`. |
+
+The selection is logged to stderr on first invocation:
+```
+[FMHA] Using custom portable kernel (default). Set FMHA_USE_CK_NAIVE=1 to use CK Tile.
+```
+or
+```
+[FMHA] FMHA_USE_CK_NAIVE=1: using CK Tile naive_attention_fwd
+```
+or (when CK was not available at build time):
+```
+[FMHA] Using custom portable kernel (CK Tile not available at build time)
+```
+
+---
+
+## RDNA3 Wave32 Accuracy Issues
+
+### Root Cause: cross_wave_reduce Bug
+
+The core issue is in CK Tile's `naive_attention_fwd_kernel`, specifically the
+`cross_wave_reduce` function in
+`ck_tile/ref/naive_attention.hpp`:
+
+```cpp
+template <typename T, typename F>
+__device__ constexpr T cross_wave_reduce(T local, F reduce_f, T* smem)
+{
+    constexpr int waves     = 4;       // ← HARDCODED: assumes 4 waves
+    constexpr int wave_size = 64;      // ← HARDCODED: assumes wave64
+    int lane_id = threadIdx.x % wave_size;
+
+    __syncthreads();
+    smem[threadIdx.x] = local;
+    __syncthreads();
+
+    T v_local = smem[lane_id];
+    for (int i_stage = 1; i_stage < waves; i_stage++) {
+        T v_remote = smem[i_stage * wave_size + lane_id];
+        v_local = reduce_f(v_local, v_remote);
+    }
+    return v_local;
+}
+```
+
+**What goes wrong on RDNA3 (wave32):**
+
+With a block size of 256 threads:
+- **On wave64 (CDNA)**: 256 threads = 4 waves × 64 threads. The function
+  correctly reduces across all 4 waves. ✓
+- **On wave32 (RDNA3)**: 256 threads = 8 waves × 32 threads. But the function
+  hardcodes `waves=4` and `wave_size=64`, so it only reads shared memory at
+  offsets `0, 64, 128, 192` with stride 64. This means it only samples data
+  from threads `0..31`, `64..95`, `128..159`, `192..223` — **skipping threads
+  `32..63`, `96..127`, `160..191`, `224..255`** (4 out of 8 physical waves).
+
+The result: the global max and sum for softmax normalization are computed from
+only half the data, leading to incorrect attention weights.
+
+Similarly, the `wave_reduce` function uses `__builtin_amdgcn_ds_bpermute` with
+6 stages (for wave64: 2^6 = 64), which on wave32 hardware performs extra
+unnecessary permutations but the result is still constrained to the first 32 lanes.
+
+### Why wave64 Workarounds Failed
+
+We attempted several workarounds to force wave64 mode on RDNA3:
+
+| Approach | Result | Explanation |
+|----------|--------|-------------|
+| `GPU_ENABLE_WAVE32_MODE=0` (runtime env) | No effect on accuracy | This is a runtime hint that the driver may ignore. The ISA is already compiled for wave32. |
+| `GPU_ENABLE_WAVE32_MODE=0` (build-time env) | No effect on accuracy | hipcc doesn't use this env var to select wavefront size at compile time. |
+| `-mwavefrontsize64` (hipcc flag) | No effect on accuracy | The flag appeared to be silently ignored for gfx1151 targets, or the CK kernel's hardcoded constants override any ISA-level wavefront change. |
+| `exp2f` vs `expf` test | No effect on accuracy | Confirmed that the exponential function choice is not the cause; both give identical accuracy in the custom kernel. |
+
+**Conclusion**: The bug is in the **algorithm** (hardcoded constants), not in the
+ISA instruction encoding. Even if wave64 mode could be forced, the hardcoded
+`waves=4` and `wave_size=64` constants in C++ source code would still produce
+incorrect indexing on any system where the actual wavefront size differs.
+
+### CK Tile Prefill Failure: No Causal Masking
+
+CK Tile's `naive_attention_fwd` API does not support causal masking. For prefill,
+where causal masking is mandatory, this results in catastrophic errors:
+
+- Each query token incorrectly attends to **all** key tokens (including future ones)
+- Max diff: **1.67** (vs CPU), with **7.87%** of elements exceeding tolerance
+- The output is essentially random compared to the correct causal result
+
+---
+
+## Accuracy Test Results
+
+Tested with Llama 3.1 8B GQA models (batch=1, nhead_q=32, nhead_k=8, hdim=128)
+on RDNA3 (gfx1151, Radeon 880M, native wave32):
+
+### Prefill (seqlen_q=255, seqlen_k=255)
+
+| Implementation | Max Diff | Mean Diff | Mismatches | Result |
+|---------------|----------|-----------|------------|--------|
+| Custom portable kernel | 0.000977 | 0.000009 | 0 (0%) | **PASS** |
+| CK Tile naive_attention_fwd | 1.672913 | 0.037814 | 82,151 (7.87%) | **FAIL** |
+
+### Decode (seqlen_q=1, seqlen_k=256)
+
+| Implementation | Max Diff | Mean Diff | Mismatches | Result |
+|---------------|----------|-----------|------------|--------|
+| Custom portable kernel | 0.000061 | 0.000005 | 0 (0%) | **PASS** |
+| CK Tile naive_attention_fwd | 0.048279 | 0.002695 | 0 (0%) | PASS* |
+
+\* CK naive decode passes tolerance (0.1) but with ~800x larger max diff than the
+portable kernel, due to the `cross_wave_reduce` bug.
+
+### Error Scaling with Sequence Length
+
+The decode error **scales with sequence length** because longer sequences have more
+waves carrying valid data that get skipped:
+
+| seqlen_k | Max Diff (CK naive) | Explanation |
+|----------|---------------------|-------------|
+| 129 | 0.021881 | ~half of wave groups have valid data |
+| 256 | 0.048279 | All 8 wave groups have valid data; 4 are skipped |
+
+This scaling behavior directly confirms the `cross_wave_reduce` root cause.
+
+---
+
+## Approaches Tried and Discarded
+
+### 1. CK Tile FmhaFwdKernel (Flash Attention production kernel)
+
+The first approach was to use CK Tile's production `FmhaFwdKernel` for Flash
+Attention, which supports causal masking and is highly optimized for CDNA (MI-series)
+GPUs.
+
+**Result**: The kernel failed to compile for GFX11 (RDNA3) targets. The tile-based
+pipeline and matrix instruction dispatching are designed for CDNA's MFMA
+instructions which are not available on RDNA3.
+
+### 2. Custom HIP kernel without CK Tile
+
+A standalone FMHA kernel was implemented without any CK dependency, using hipRTC-style
+kernels with manual FP16 handling.
+
+**Result**: Worked correctly but was eventually replaced by the current approach
+which leverages CK Tile's `half_t` type when available and provides cleaner code.
+
+### 3. CK Tile naive_attention_fwd for decode only
+
+Since CK naive doesn't support causal masking, we tried using it only for decode
+(where masking isn't needed) while keeping the custom kernel for prefill.
+
+**Result**: Worked but showed reduced accuracy on RDNA3 due to the
+`cross_wave_reduce` bug. The custom portable kernel was found to be superior
+for both paths.
+
+### 4. Hybrid: Custom causal prefill + CK naive decode
+
+This was the intermediate solution before the current unified approach.
+
+**Result**: Functionally correct but unnecessarily complex. Since the custom kernel
+handles both cases with excellent accuracy, having two different implementations
+added complexity without benefit.
+
+---
+
+## File Reference
+
+| File | Description |
+|------|-------------|
+| `kernels/src/fmha_ck_tile_kernels.hip` | FMHA kernel implementations (portable + CK naive) |
+| `kernels/include/rocm_kernels.h` | C API declaration for `launch_fmha_fwd_fp16_causal` |
+| `kernels/CMakeLists.txt` | Build configuration (conditional CK Tile support) |
+| `CMakeLists.txt` | Root CMake (CK_ROOT detection, HAS_CK_TILE) |
+| `custom-op-rocm/src/custom_op.cpp` | GQA custom op that calls the FMHA kernel |
+| `level-2-pass-rocm-gqa/src/pass_main.cpp` | GQA pattern matching pass |
+| `patterns/gqa.json` | ONNX subgraph pattern for GQA detection |
+| `test/model_verifier.cpp` | CPU vs GPU comparison test tool |
+
+### CK Tile Source References (for debugging)
+
+| File (relative to CK_ROOT) | Key Functions |
+|----------------------------|---------------|
+| `include/ck_tile/ref/naive_attention.hpp` | `naive_attention_fwd_kernel`, `wave_reduce`, `cross_wave_reduce` |
+| `include/ck_tile/core.hpp` | CK Tile core types and utilities |

--- a/etc/morphizen_config.json
+++ b/etc/morphizen_config.json
@@ -16,7 +16,8 @@
           "morphizen-level2-pass-rocm-transpose",
           "morphizen-level2-pass-rocm-tile",
           "morphizen-level2-pass-rocm-mul",
-          "morphizen-level2-pass-rocm-softmax"
+          "morphizen-level2-pass-rocm-softmax",
+          "morphizen-level2-pass-rocm-gqa"
         ]
       }
     }

--- a/kernels/CMakeLists.txt
+++ b/kernels/CMakeLists.txt
@@ -22,16 +22,42 @@ endif()
 
 # Create HIP kernel library using hipcc (precompiled at build time)
 # Each kernel type is in its own file for better organization and maintainability
-hip_add_library(rocm-hip-kernels STATIC
+
+# Base HIP kernels (always built)
+set(HIP_KERNEL_SOURCES
     src/softmax_kernels.hip      # Softmax operations (2D/3D)
     src/mul_kernels.hip          # Element-wise multiplication with broadcasting
     src/transpose_kernels.hip    # Tensor transpose (0213 optimized + general 4D)
     src/tile_kernels.hip         # N-dimensional tile/repeat operations
     src/utility_kernels.hip      # Memory copy utilities (reshape)
     src/add_bias_kernels.hip     # Bias addition for Conv (NCHW format)
+)
+
+hip_add_library(rocm-hip-kernels STATIC
+    ${HIP_KERNEL_SOURCES}
     INCLUDE_DIRECTORIES
         ${CMAKE_CURRENT_SOURCE_DIR}/include
         ${THEROCK_DIST}/include
+)
+
+# FMHA kernel library
+# When CK_ROOT is available: builds with CK Tile headers and defines HAS_CK_TILE,
+#   enabling the CK naive_attention_fwd path (selectable via FMHA_USE_CK_NAIVE=1).
+# When CK_ROOT is not available: builds with portable kernel only (no CK dependency).
+set(FMHA_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include ${THEROCK_DIST}/include)
+set(FMHA_COMPILE_OPTIONS -std=c++17)
+if(HAS_CK_TILE)
+    list(APPEND FMHA_INCLUDE_DIRS ${CK_ROOT}/include)
+    list(APPEND FMHA_COMPILE_OPTIONS -DHAS_CK_TILE=1)
+    message(STATUS "[rocm-kernels] CK Tile available: FMHA built with CK naive_attention_fwd support")
+else()
+    message(STATUS "[rocm-kernels] CK Tile not available: FMHA built with portable kernel only")
+endif()
+
+hip_add_library(rocm-ck-tile-kernels STATIC
+    src/fmha_ck_tile_kernels.hip
+    INCLUDE_DIRECTORIES ${FMHA_INCLUDE_DIRS}
+    COMPILE_OPTIONS ${FMHA_COMPILE_OPTIONS}
 )
 
 # Create C++ wrapper library (host-side code that calls HIP kernels)
@@ -60,7 +86,7 @@ else()
 endif()
 
 # Link the precompiled HIP kernels
-target_link_libraries(rocm-kernels PRIVATE rocm-hip-kernels)
+target_link_libraries(rocm-kernels PRIVATE rocm-hip-kernels rocm-ck-tile-kernels)
 
 set_target_properties(rocm-kernels PROPERTIES
     FOLDER "rocm"

--- a/kernels/include/rocm_kernels.h
+++ b/kernels/include/rocm_kernels.h
@@ -80,6 +80,36 @@ void launch_tile_nd_f32(const float *input, float *output,
 void launch_reshape_copy_f32(const float *input, float *output, int64_t size,
                              hipStream_t stream);
 
+//--- FMHA (Flash Multi-Head Attention) kernels ---
+
+/**
+ * Forward FMHA with causal masking for GQA (Grouped Query Attention).
+ * Handles both prefill (multi-token) and decode (single-token) cases.
+ *
+ * Causal mask (bottom-right): Q[i] attends to K[j] where
+ *   j <= i + (seqlen_k - seqlen_q)
+ *
+ * @param stream      HIP stream
+ * @param q_ptr       Q tensor [B, nhead_q, seqlen_q, hdim] (fp16)
+ * @param k_ptr       K tensor [B, nhead_k, seqlen_k, hdim] (fp16)
+ * @param v_ptr       V tensor [B, nhead_k, seqlen_k, hdim] (fp16)
+ * @param o_ptr       O tensor [B, nhead_q, seqlen_q, hdim] (fp16, output)
+ * @param batch       Batch size
+ * @param nhead_q     Number of query heads
+ * @param nhead_k     Number of KV heads (nhead_q must be divisible by nhead_k)
+ * @param seqlen_q    Query sequence length
+ * @param seqlen_k    Key sequence length (total including past)
+ * @param hdim        Head dimension (e.g., 64, 96, 128)
+ * @param scale       Attention scale factor (typically 1/sqrt(hdim))
+ * @return            hipSuccess on success, error code on failure
+ */
+hipError_t launch_fmha_fwd_fp16_causal(hipStream_t stream, const void *q_ptr,
+                                       const void *k_ptr, const void *v_ptr,
+                                       void *o_ptr, int32_t batch,
+                                       int32_t nhead_q, int32_t nhead_k,
+                                       int32_t seqlen_q, int32_t seqlen_k,
+                                       int32_t hdim, float scale);
+
 } // extern "C"
 
 //============================================================================

--- a/kernels/src/fmha_ck_tile_kernels.hip
+++ b/kernels/src/fmha_ck_tile_kernels.hip
@@ -1,0 +1,412 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ *
+ * FMHA Forward for GQA.
+ *
+ * Two implementations with the same interface:
+ *
+ *   1. Custom portable kernel (default, always available):
+ *      Uses shared-memory tree reductions that work correctly on both wave32
+ *      (RDNA3/GFX11) and wave64 (CDNA/GFX9). Supports causal masking for
+ *      prefill and no-mask decode. Highest accuracy on RDNA3.
+ *
+ *   2. CK Tile naive_attention_fwd (optional, requires CK_ROOT at build time):
+ *      Uses CK Tile's reference naive_attention_fwd host API. Its internal
+ *      kernel uses wave64-hardcoded reductions (ds_bpermute with 6 stages,
+ *      cross_wave_reduce with wave_size=64). On RDNA3 (wave32), the
+ *      cross_wave_reduce only combines 4 of 8 wave32 groups, causing
+ *      incomplete max/sum reductions and reduced accuracy.
+ *
+ * Build configuration:
+ *   -DHAS_CK_TILE=1   Enables CK Tile naive_attention_fwd (set by CMake when CK_ROOT is found)
+ *   (default)          Only portable kernel is available
+ *
+ * Runtime environment variable (only effective when built with HAS_CK_TILE):
+ *   FMHA_USE_CK_NAIVE=1   Use CK Tile naive_attention_fwd
+ *   (default)              Use custom portable kernel
+ *
+ * BHSD layout [Batch, Head, Seqlen, Hdim], FP16, GQA support.
+ */
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <cstdint>
+#include <cstdio>
+#include <cfloat>
+#include <cstdlib>
+
+#ifdef HAS_CK_TILE
+// CK Tile headers (only included when CK_ROOT is available)
+#include "ck_tile/core.hpp"
+#include "ck_tile/ref/naive_attention.hpp"
+using DataType = ck_tile::half_t;
+#else
+// Without CK Tile, use HIP's native __half
+using DataType = __half;
+#endif
+
+using AccType = float;
+
+// Flag reflecting whether CK Tile is available at build time
+#ifdef HAS_CK_TILE
+static const bool kHasCkTile = true;
+#else
+static const bool kHasCkTile = false;
+#endif
+
+// =============================================================================
+// Custom portable kernel (wave32 + wave64 safe) — always available
+// =============================================================================
+static constexpr int kBlockSize = 256;
+
+struct FmhaCausalArgs
+{
+    const DataType* q_ptr;
+    const DataType* k_ptr;
+    const DataType* v_ptr;
+    DataType*       o_ptr;
+    int seqlen_q;
+    int seqlen_k;
+    int hdim;
+    int nhead_q;
+    int nhead_k;
+    float scale;
+};
+
+// Portable shared-memory tree reductions (wave32 + wave64 safe)
+__device__ __forceinline__
+AccType block_reduce_max(AccType val, AccType* smem)
+{
+    smem[threadIdx.x] = val;
+    __syncthreads();
+    for (int s = kBlockSize / 2; s > 0; s >>= 1) {
+        if (static_cast<int>(threadIdx.x) < s)
+            smem[threadIdx.x] = fmaxf(smem[threadIdx.x], smem[threadIdx.x + s]);
+        __syncthreads();
+    }
+    AccType result = smem[0];
+    __syncthreads();
+    return result;
+}
+
+__device__ __forceinline__
+AccType block_reduce_sum(AccType val, AccType* smem)
+{
+    smem[threadIdx.x] = val;
+    __syncthreads();
+    for (int s = kBlockSize / 2; s > 0; s >>= 1) {
+        if (static_cast<int>(threadIdx.x) < s)
+            smem[threadIdx.x] += smem[threadIdx.x + s];
+        __syncthreads();
+    }
+    AccType result = smem[0];
+    __syncthreads();
+    return result;
+}
+
+// =============================================================================
+// FMHA kernel with bottom-right causal masking
+//
+// Grid:  (ceil(hdim / kBlockSize), seqlen_q, batch * nhead_q)
+// Block: (kBlockSize)
+//
+// Causal mask (bottom-right):
+//   For prefill (seqlen_q == seqlen_k): standard causal, Q[i] attends K[0..i]
+//   For decode  (seqlen_q == 1):        causal_limit = seqlen_k - 1, all keys
+// =============================================================================
+__global__ void __launch_bounds__(kBlockSize)
+fmha_naive_causal_kernel(FmhaCausalArgs args)
+{
+    __shared__ union {
+        AccType  reduce[kBlockSize];
+        DataType p_vals[kBlockSize];
+    } smem;
+
+    const int i_dv         = blockIdx.x * kBlockSize + threadIdx.x;
+    const int i_sq         = blockIdx.y;
+    const int i_batch_head = blockIdx.z;
+    const int i_bq         = i_batch_head / args.nhead_q;
+    const int i_hq         = i_batch_head % args.nhead_q;
+    const int i_hk         = i_hq / (args.nhead_q / args.nhead_k);
+
+    const DataType* q_base = args.q_ptr
+        + static_cast<int64_t>(i_bq) * args.nhead_q * args.seqlen_q * args.hdim
+        + static_cast<int64_t>(i_hq) * args.seqlen_q * args.hdim;
+    const DataType* k_base = args.k_ptr
+        + static_cast<int64_t>(i_bq) * args.nhead_k * args.seqlen_k * args.hdim
+        + static_cast<int64_t>(i_hk) * args.seqlen_k * args.hdim;
+    const DataType* v_base = args.v_ptr
+        + static_cast<int64_t>(i_bq) * args.nhead_k * args.seqlen_k * args.hdim
+        + static_cast<int64_t>(i_hk) * args.seqlen_k * args.hdim;
+    DataType* o_base = args.o_ptr
+        + static_cast<int64_t>(i_bq) * args.nhead_q * args.seqlen_q * args.hdim
+        + static_cast<int64_t>(i_hq) * args.seqlen_q * args.hdim;
+
+    const DataType* q_row = q_base + static_cast<int64_t>(i_sq) * args.hdim;
+    const int causal_limit = i_sq + (args.seqlen_k - args.seqlen_q);
+
+    AccType row_max = -FLT_MAX;
+    AccType l       = 0.0f;
+    AccType o_acc   = 0.0f;
+
+    const int sk_loops = (args.seqlen_k + kBlockSize - 1) / kBlockSize;
+
+    for (int i_loop = 0; i_loop < sk_loops; i_loop++)
+    {
+        const int i_sk = i_loop * kBlockSize + threadIdx.x;
+
+        AccType s_val = -FLT_MAX;
+        if (i_sk < args.seqlen_k && i_sk <= causal_limit)
+        {
+            const DataType* k_row = k_base + static_cast<int64_t>(i_sk) * args.hdim;
+            AccType dot = 0.0f;
+            for (int d = 0; d < args.hdim; d++)
+                dot += static_cast<AccType>(q_row[d]) * static_cast<AccType>(k_row[d]);
+            s_val = dot * args.scale;
+        }
+
+        const AccType old_max = row_max;
+        const AccType cur_max = block_reduce_max(s_val, smem.reduce);
+        row_max = fmaxf(old_max, cur_max);
+
+        const AccType p_val = expf(s_val - row_max);
+        const AccType row_sum = block_reduce_sum(p_val, smem.reduce);
+
+        const AccType rescale = expf(old_max - row_max);
+        l     = rescale * l + row_sum;
+        o_acc = o_acc * rescale;
+
+        smem.p_vals[threadIdx.x] = static_cast<DataType>(p_val);
+        __syncthreads();
+
+        if (i_dv < args.hdim)
+        {
+            const int sk_start = i_loop * kBlockSize;
+            for (int j = 0; j < kBlockSize; j++)
+            {
+                const int i_sv = sk_start + j;
+                if (i_sv < args.seqlen_k)
+                {
+                    AccType p = static_cast<AccType>(smem.p_vals[j]);
+                    AccType v = static_cast<AccType>(v_base[static_cast<int64_t>(i_sv) * args.hdim + i_dv]);
+                    o_acc += p * v;
+                }
+            }
+        }
+        __syncthreads();
+    }
+
+    if (l > 0.0f)
+        o_acc = o_acc / l;
+    else
+        o_acc = 0.0f;
+
+    if (i_dv < args.hdim)
+        o_base[static_cast<int64_t>(i_sq) * args.hdim + i_dv] = static_cast<DataType>(o_acc);
+}
+
+// =============================================================================
+// Implementation 1: Custom portable kernel (default, always available)
+// =============================================================================
+static hipError_t launch_fmha_portable(
+    hipStream_t stream,
+    const void* q_ptr,
+    const void* k_ptr,
+    const void* v_ptr,
+    void* o_ptr,
+    int32_t batch,
+    int32_t nhead_q,
+    int32_t nhead_k,
+    int32_t seqlen_q,
+    int32_t seqlen_k,
+    int32_t hdim,
+    float scale)
+{
+    FmhaCausalArgs args;
+    args.q_ptr    = reinterpret_cast<const DataType*>(q_ptr);
+    args.k_ptr    = reinterpret_cast<const DataType*>(k_ptr);
+    args.v_ptr    = reinterpret_cast<const DataType*>(v_ptr);
+    args.o_ptr    = reinterpret_cast<DataType*>(o_ptr);
+    args.seqlen_q = seqlen_q;
+    args.seqlen_k = seqlen_k;
+    args.hdim     = hdim;
+    args.nhead_q  = nhead_q;
+    args.nhead_k  = nhead_k;
+    args.scale    = scale;
+
+    dim3 grid(
+        (hdim + kBlockSize - 1) / kBlockSize,
+        seqlen_q,
+        batch * nhead_q
+    );
+    dim3 block(kBlockSize);
+
+    const char* mode = (seqlen_q == 1) ? "Decode" : "Prefill";
+    fprintf(stderr, "[Portable %s] batch=%d, nhead_q=%d, nhead_k=%d, "
+            "seqlen_q=%d, seqlen_k=%d, hdim=%d, scale=%f, grid=(%d,%d,%d)\n",
+            mode, batch, nhead_q, nhead_k, seqlen_q, seqlen_k, hdim, scale,
+            grid.x, grid.y, grid.z);
+
+    hipLaunchKernelGGL(
+        fmha_naive_causal_kernel,
+        grid, block, 0, stream, args);
+
+    hipError_t err = hipGetLastError();
+    if (err != hipSuccess) {
+        fprintf(stderr, "[Portable FMHA] Launch error: %s\n",
+                hipGetErrorString(err));
+        return err;
+    }
+    return hipSuccess;
+}
+
+// =============================================================================
+// Implementation 2: CK Tile naive_attention_fwd (only when built with CK_ROOT)
+// NOTE: Uses wave64-hardcoded reductions. On RDNA3 (wave32), the
+// cross_wave_reduce only combines 4 of 8 wave groups, causing reduced accuracy.
+// =============================================================================
+#ifdef HAS_CK_TILE
+
+static hipError_t launch_fmha_ck_naive(
+    hipStream_t stream,
+    const void* q_ptr,
+    const void* k_ptr,
+    const void* v_ptr,
+    void* o_ptr,
+    int32_t batch,
+    int32_t nhead_q,
+    int32_t nhead_k,
+    int32_t seqlen_q,
+    int32_t seqlen_k,
+    int32_t hdim,
+    float scale)
+{
+    ck_tile::naive_attention_fwd_traits traits;
+    traits.q_type      = "fp16";
+    traits.k_type      = "fp16";
+    traits.v_type      = "fp16";
+    traits.o_type      = "fp16";
+    traits.q_layout    = "bhsd";
+    traits.k_layout    = "bhsd";
+    traits.v_layout    = "bhsd";
+    traits.o_layout    = "bhsd";
+    traits.variation    = static_cast<int>(ck_tile::naive_attention_variation_enum::FLASH_BATCHED);
+    traits.quant_algo   = static_cast<int>(ck_tile::naive_attention_quant_algo::NO);
+
+    ck_tile::naive_attention_fwd_args ck_args;
+    ck_args.q_ptr             = const_cast<void*>(q_ptr);
+    ck_args.k_ptr             = const_cast<void*>(k_ptr);
+    ck_args.v_ptr             = const_cast<void*>(v_ptr);
+    ck_args.o_ptr             = o_ptr;
+    ck_args.context_len_ptr   = nullptr;
+    ck_args.page_table_ptr    = nullptr;
+    ck_args.kscale_ptr        = nullptr;
+    ck_args.vscale_ptr        = nullptr;
+    ck_args.scale_s           = scale;
+    ck_args.hdim              = hdim;
+    ck_args.hdim_v            = hdim;
+    ck_args.batch_q           = batch;
+    ck_args.batch_kv          = batch;
+    ck_args.batch_ratio_kv    = 1;
+    ck_args.seqlen_q          = seqlen_q;
+    ck_args.seqlen_kv         = seqlen_k;
+    ck_args.nhead_q           = nhead_q;
+    ck_args.nhead_kv          = nhead_k;
+    ck_args.nhead_ratio_kv    = nhead_q / nhead_k;
+    ck_args.page_size         = 0;
+    ck_args.max_pages_per_seq = 0;
+    ck_args.max_kv_tokens     = 0;
+
+    ck_tile::stream_config sc;
+    sc.stream_id_ = stream;
+
+    const char* mode = (seqlen_q == 1) ? "Decode" : "Prefill";
+    fprintf(stderr, "[CK Naive %s] batch=%d, nhead_q=%d, nhead_k=%d, "
+            "seqlen_q=%d, seqlen_k=%d, hdim=%d, scale=%f\n",
+            mode, batch, nhead_q, nhead_k, seqlen_q, seqlen_k, hdim, scale);
+
+    float result = ck_tile::naive_attention_fwd(traits, ck_args, sc);
+    if (result < 0) {
+        fprintf(stderr, "[CK Naive FMHA] naive_attention_fwd failed (result=%f)\n", result);
+        return hipErrorUnknown;
+    }
+
+    hipError_t err = hipGetLastError();
+    if (err != hipSuccess) {
+        fprintf(stderr, "[CK Naive FMHA] error: %s\n",
+                hipGetErrorString(err));
+        return err;
+    }
+    return hipSuccess;
+}
+
+#else // !HAS_CK_TILE
+
+// Stub: satisfies the compiler when CK Tile is not available.
+// Never called at runtime (use_ck_naive_impl() returns false when kHasCkTile is false).
+// If reached, it indicates a logic error in the dispatch code.
+static hipError_t launch_fmha_ck_naive(
+    hipStream_t, const void*, const void*, const void*, void*,
+    int32_t, int32_t, int32_t, int32_t, int32_t, int32_t, float)
+{
+    fprintf(stderr, "[FMHA ERROR] launch_fmha_ck_naive called but CK Tile was not available at build time.\n"
+                    "  This is a logic error: FMHA_USE_CK_NAIVE=1 should have no effect without CK_ROOT.\n"
+                    "  Rebuild with -DCK_ROOT=/path/to/composable_kernel to enable CK Tile support.\n");
+    return hipErrorNotSupported;
+}
+
+#endif // HAS_CK_TILE
+
+// =============================================================================
+// Check env var once (thread-safe lazy init)
+// =============================================================================
+static bool use_ck_naive_impl()
+{
+    static int cached = -1;
+    if (cached < 0) {
+        if (kHasCkTile) {
+            const char* env = std::getenv("FMHA_USE_CK_NAIVE");
+            cached = (env && env[0] == '1') ? 1 : 0;
+            if (cached) {
+                fprintf(stderr, "[FMHA] FMHA_USE_CK_NAIVE=1: using CK Tile naive_attention_fwd\n");
+            } else {
+                fprintf(stderr, "[FMHA] Using custom portable kernel (default). "
+                        "Set FMHA_USE_CK_NAIVE=1 to use CK Tile.\n");
+            }
+        } else {
+            cached = 0;
+            fprintf(stderr, "[FMHA] Using custom portable kernel (CK Tile not available at build time)\n");
+        }
+    }
+    return cached == 1;
+}
+
+// =============================================================================
+// Public C API — dispatches based on FMHA_USE_CK_NAIVE env var
+// =============================================================================
+extern "C"
+hipError_t launch_fmha_fwd_fp16_causal(
+    hipStream_t stream,
+    const void* q_ptr,
+    const void* k_ptr,
+    const void* v_ptr,
+    void* o_ptr,
+    int32_t batch,
+    int32_t nhead_q,
+    int32_t nhead_k,
+    int32_t seqlen_q,
+    int32_t seqlen_k,
+    int32_t hdim,
+    float scale)
+{
+    if (use_ck_naive_impl()) {
+        return launch_fmha_ck_naive(
+            stream, q_ptr, k_ptr, v_ptr, o_ptr,
+            batch, nhead_q, nhead_k, seqlen_q, seqlen_k, hdim, scale);
+    }
+
+    return launch_fmha_portable(
+        stream, q_ptr, k_ptr, v_ptr, o_ptr,
+        batch, nhead_q, nhead_k, seqlen_q, seqlen_k, hdim, scale);
+}

--- a/level-2-pass-rocm-conv/cmake/generate_pattern_inc.cmake
+++ b/level-2-pass-rocm-conv/cmake/generate_pattern_inc.cmake
@@ -6,7 +6,7 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 add_custom_command (
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/conv_pattern_json.hpp
   COMMAND ${CMAKE_COMMAND} -E env
-    $<TARGET_FILE:Python3::Interpreter> ${morphizen_SOURCE_DIR}/tools/xxd.py
+    $<TARGET_FILE:Python3::Interpreter> ${morphizen_SOURCE_DIR}/cmake/scripts/xxd.py
     "--column" 16
     "--var" conv_json
     --output ${CMAKE_CURRENT_BINARY_DIR}/conv_pattern_json.hpp

--- a/level-2-pass-rocm-gemm/cmake/generate_pattern_inc.cmake
+++ b/level-2-pass-rocm-gemm/cmake/generate_pattern_inc.cmake
@@ -6,7 +6,7 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 add_custom_command (
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/gemm_pattern_json.hpp
   COMMAND ${CMAKE_COMMAND} -E env
-    $<TARGET_FILE:Python3::Interpreter> ${morphizen_SOURCE_DIR}/tools/xxd.py
+    $<TARGET_FILE:Python3::Interpreter> ${morphizen_SOURCE_DIR}/cmake/scripts/xxd.py
     "--column" 16
     "--var" gemm_json
     --output ${CMAKE_CURRENT_BINARY_DIR}/gemm_pattern_json.hpp

--- a/level-2-pass-rocm-gqa/CMakeLists.txt
+++ b/level-2-pass-rocm-gqa/CMakeLists.txt
@@ -1,0 +1,25 @@
+##
+# ** Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# ** Licensed under the MIT License.
+##
+find_package(glog CONFIG REQUIRED)
+include(cmake/generate_pattern_inc.cmake)
+
+set(LIB_NAME morphizen-level2-pass-rocm-gqa)
+add_library(${LIB_NAME} STATIC src/pass_main.cpp ${CMAKE_CURRENT_BINARY_DIR}/gqa_pattern_json.hpp)
+target_link_libraries(${LIB_NAME} PUBLIC
+	morphizen::rocm-pass-common
+)
+target_include_directories(${LIB_NAME} PRIVATE
+	include
+	${CMAKE_CURRENT_BINARY_DIR}
+)
+
+if(WIN32)
+  target_include_directories(${LIB_NAME} SYSTEM PRIVATE "${THEROCK_DIST}/include")
+  target_compile_definitions(${LIB_NAME} PRIVATE "__HIP_PLATFORM_AMD__=1")
+endif()
+
+target_compile_definitions(${LIB_NAME} PRIVATE -DOUTPUT_NAME="morphizen-level2-pass-rocm-gqa")
+target_link_libraries(${morphizen_ONNXRUNTIME_MORPHIZEN_EP_TARGET} PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,${LIB_NAME}>")
+set_target_properties(${LIB_NAME} PROPERTIES FOLDER "rocm-gqa")

--- a/level-2-pass-rocm-gqa/cmake/generate_pattern_inc.cmake
+++ b/level-2-pass-rocm-gqa/cmake/generate_pattern_inc.cmake
@@ -1,0 +1,11 @@
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
+add_custom_command (
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/gqa_pattern_json.hpp
+  COMMAND ${CMAKE_COMMAND} -E env
+    $<TARGET_FILE:Python3::Interpreter> ${morphizen_SOURCE_DIR}/tools/xxd.py
+    "--column" 16
+    "--var" gqa_json
+    --output ${CMAKE_CURRENT_BINARY_DIR}/gqa_pattern_json.hpp
+    "${CMAKE_CURRENT_SOURCE_DIR}/../patterns/gqa.json"
+    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/../patterns/gqa.json" "${CMAKE_CURRENT_LIST_FILE}"
+)

--- a/level-2-pass-rocm-gqa/cmake/generate_pattern_inc.cmake
+++ b/level-2-pass-rocm-gqa/cmake/generate_pattern_inc.cmake
@@ -6,7 +6,7 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 add_custom_command (
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/gqa_pattern_json.hpp
   COMMAND ${CMAKE_COMMAND} -E env
-    $<TARGET_FILE:Python3::Interpreter> ${morphizen_SOURCE_DIR}/tools/xxd.py
+    $<TARGET_FILE:Python3::Interpreter> ${morphizen_SOURCE_DIR}/cmake/scripts/xxd.py
     "--column" 16
     "--var" gqa_json
     --output ${CMAKE_CURRENT_BINARY_DIR}/gqa_pattern_json.hpp

--- a/level-2-pass-rocm-gqa/cmake/generate_pattern_inc.cmake
+++ b/level-2-pass-rocm-gqa/cmake/generate_pattern_inc.cmake
@@ -1,3 +1,7 @@
+##
+# ** Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# ** Licensed under the MIT License.
+##
 find_package(Python3 COMPONENTS Interpreter REQUIRED)
 add_custom_command (
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/gqa_pattern_json.hpp

--- a/level-2-pass-rocm-gqa/src/pass_main.cpp
+++ b/level-2-pass-rocm-gqa/src/pass_main.cpp
@@ -23,7 +23,8 @@ using namespace morphizen_cxx;
  *   4: past_value [B, kv_num_heads, past_S, head_size] fp16, optional (BNSH)
  *   5: seqlens_k  [B]                                  int32, required
  *   6: total_sequence_length  scalar                    int32, required
- *   7-11: cos_cache, sin_cache, position_ids, attention_bias, head_sink (unused)
+ *   7-11: cos_cache, sin_cache, position_ids, attention_bias, head_sink
+ * (unused)
  *
  * GQA outputs (3):
  *   0: output         [B, S_q, num_heads * head_size]       fp16
@@ -65,13 +66,15 @@ struct Level2RocmGqa {
           if (node_has_attr(*gqa_node, "num_heads")) {
             num_heads = node_get_attr_int(*gqa_node, "num_heads");
           } else {
-            ROCM_LOG(1) << LOG_PREFIX << " Missing required attribute: num_heads";
+            ROCM_LOG(1) << LOG_PREFIX
+                        << " Missing required attribute: num_heads";
             return false;
           }
           if (node_has_attr(*gqa_node, "kv_num_heads")) {
             kv_num_heads = node_get_attr_int(*gqa_node, "kv_num_heads");
           } else {
-            ROCM_LOG(1) << LOG_PREFIX << " Missing required attribute: kv_num_heads";
+            ROCM_LOG(1) << LOG_PREFIX
+                        << " Missing required attribute: kv_num_heads";
             return false;
           }
 
@@ -101,8 +104,7 @@ struct Level2RocmGqa {
 
           ROCM_LOG(1) << LOG_PREFIX << " num_heads=" << num_heads
                       << " kv_num_heads=" << kv_num_heads
-                      << " head_size=" << head_size
-                      << " scale=" << scale;
+                      << " head_size=" << head_size << " scale=" << scale;
 
           // Check for unsupported features
           // TODO: Forward cos_cache/sin_cache inputs when do_rotary=1
@@ -113,7 +115,8 @@ struct Level2RocmGqa {
 
           if (node_has_attr(*gqa_node, "do_rotary") &&
               node_get_attr_int(*gqa_node, "do_rotary") != 0) {
-            ROCM_LOG(1) << LOG_PREFIX << " do_rotary=1 not yet supported, skipping";
+            ROCM_LOG(1) << LOG_PREFIX
+                        << " do_rotary=1 not yet supported, skipping";
             return false;
           }
 
@@ -126,8 +129,9 @@ struct Level2RocmGqa {
           gqa_params->set_kv_num_heads(static_cast<int32_t>(kv_num_heads));
           gqa_params->set_head_size(static_cast<int32_t>(head_size));
           gqa_params->set_scale(scale);
-          gqa_params->set_num_inputs(7);   // query, key, value, past_key, past_value, seqlens_k, total_seq_len
-          gqa_params->set_num_outputs(3);  // output, present_key, present_value
+          gqa_params->set_num_inputs(7); // query, key, value, past_key,
+                                         // past_value, seqlens_k, total_seq_len
+          gqa_params->set_num_outputs(3); // output, present_key, present_value
 
           // Store query shape
           if (query_shape) {
@@ -159,9 +163,9 @@ struct Level2RocmGqa {
           }
 
           // Compute present_key/value shapes
-          // The present_key shape depends on runtime total_seq_len, which is dynamic.
-          // We use the output shape from the graph which has this information.
-          // present_key: output 1 of the GQA node
+          // The present_key shape depends on runtime total_seq_len, which is
+          // dynamic. We use the output shape from the graph which has this
+          // information. present_key: output 1 of the GQA node
           auto present_key_out_shape = node_get_output_shape(*gqa_node, 1);
           auto present_value_out_shape = node_get_output_shape(*gqa_node, 2);
 
@@ -179,23 +183,25 @@ struct Level2RocmGqa {
           std::string past_key_name = node_arg_get_name(*past_key.node_arg);
           std::string past_value_name = node_arg_get_name(*past_value.node_arg);
           std::string seqlens_k_name = node_arg_get_name(*seqlens_k.node_arg);
-          std::string total_seq_len_name = node_arg_get_name(*total_seq_len.node_arg);
+          std::string total_seq_len_name =
+              node_arg_get_name(*total_seq_len.node_arg);
           std::string output_name = node_arg_get_name(*output.node_arg);
 
-          // GQA node has 3 outputs - get names for present_key and present_value
-          // The output binder refers to output 0, but we need outputs 1 and 2 as well
+          // GQA node has 3 outputs - get names for present_key and
+          // present_value The output binder refers to output 0, but we need
+          // outputs 1 and 2 as well
           auto gqa_output_node_args = node_get_output_node_args(*gqa_node);
 
           std::vector<std::string> input_names{
-              query_name, key_name, value_name,
-              past_key_name, past_value_name,
-              seqlens_k_name, total_seq_len_name};
+              query_name,      key_name,       value_name,        past_key_name,
+              past_value_name, seqlens_k_name, total_seq_len_name};
 
           // Output names: output(0), present_key(1), present_value(2)
           std::vector<std::string> output_names;
           if (gqa_output_node_args.size() >= 3) {
             for (size_t i = 0; i < 3; ++i) {
-              output_names.push_back(node_arg_get_name(*gqa_output_node_args[i]));
+              output_names.push_back(
+                  node_arg_get_name(*gqa_output_node_args[i]));
             }
           } else {
             output_names.push_back(output_name);
@@ -212,8 +218,9 @@ struct Level2RocmGqa {
                              constant_initializers, "ROCm_EP");
 
           if (meta_def) {
-            return rocm_pass::finalize_level2_fuse(
-                self, *graph, *meta_def, rocm_param, output_names[0], LOG_PREFIX);
+            return rocm_pass::finalize_level2_fuse(self, *graph, *meta_def,
+                                                   rocm_param, output_names[0],
+                                                   LOG_PREFIX);
           }
 
           ROCM_LOG(1) << LOG_PREFIX << " Failed to fuse: " << error.comments;

--- a/level-2-pass-rocm-gqa/src/pass_main.cpp
+++ b/level-2-pass-rocm-gqa/src/pass_main.cpp
@@ -1,0 +1,232 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "gqa_pattern_json.hpp"
+#include "rocm_pass_utils.hpp"
+
+using namespace morphizen;
+using namespace morphizen_cxx;
+
+/**
+ * Level-2 Pass: GroupQueryAttention (GQA) Pattern Matching
+ *
+ * Matches com.microsoft.GroupQueryAttention patterns and replaces them with
+ * ROCm custom ops backed by HIP FMHA kernels with causal masking.
+ *
+ * GQA inputs (7 of 12 used in Llama-3.1-8B):
+ *   0: query      [B, S_q, num_heads * head_size]     fp16, required
+ *   1: key        [B, S_q, kv_num_heads * head_size]   fp16, optional
+ *   2: value      [B, S_q, kv_num_heads * head_size]   fp16, optional
+ *   3: past_key   [B, kv_num_heads, past_S, head_size] fp16, optional (BNSH)
+ *   4: past_value [B, kv_num_heads, past_S, head_size] fp16, optional (BNSH)
+ *   5: seqlens_k  [B]                                  int32, required
+ *   6: total_sequence_length  scalar                    int32, required
+ *   7-11: cos_cache, sin_cache, position_ids, attention_bias, head_sink (unused)
+ *
+ * GQA outputs (3):
+ *   0: output         [B, S_q, num_heads * head_size]       fp16
+ *   1: present_key    [B, kv_num_heads, total_S, head_size] fp16 (BNSH)
+ *   2: present_value  [B, kv_num_heads, total_S, head_size] fp16 (BNSH)
+ */
+struct Level2RocmGqa {
+  static constexpr const char *LOG_PREFIX = "[ROCm GQA L2]";
+
+  Level2RocmGqa(IPass &self) : self_{self} {}
+
+  std::unique_ptr<Rule> create_rule(IPass *self) {
+    auto pattern =
+        PatternBuilder().create_by_json(std::string((const char *)gqa_json));
+
+    return Rule::create_rule(
+        pattern, [=](Graph *graph, binder_t &binder) -> bool {
+          auto query = binder["query"];
+          auto key = binder["key"];
+          auto value = binder["value"];
+          auto past_key = binder["past_key"];
+          auto past_value = binder["past_value"];
+          auto seqlens_k = binder["seqlens_k"];
+          auto total_seq_len = binder["total_sequence_length"];
+          auto output = binder["output"];
+
+          ROCM_LOG(1) << LOG_PREFIX << " Found GroupQueryAttention pattern";
+
+          // Get the GQA node to extract attributes
+          auto *gqa_node = output.node;
+          if (!gqa_node) {
+            ROCM_LOG(1) << LOG_PREFIX << " output node is null";
+            return false;
+          }
+
+          // Extract required attributes
+          int64_t num_heads = 0;
+          int64_t kv_num_heads = 0;
+          if (node_has_attr(*gqa_node, "num_heads")) {
+            num_heads = node_get_attr_int(*gqa_node, "num_heads");
+          } else {
+            ROCM_LOG(1) << LOG_PREFIX << " Missing required attribute: num_heads";
+            return false;
+          }
+          if (node_has_attr(*gqa_node, "kv_num_heads")) {
+            kv_num_heads = node_get_attr_int(*gqa_node, "kv_num_heads");
+          } else {
+            ROCM_LOG(1) << LOG_PREFIX << " Missing required attribute: kv_num_heads";
+            return false;
+          }
+
+          // Extract optional scale attribute via NodeConstRef
+          // scale = 0.0f means "auto-compute as 1/sqrt(head_size)" in custom op
+          auto gqa_ref = NodeConstRef::from_node(*graph, *gqa_node);
+          float scale = gqa_ref.get_attr_float("scale", 0.0f);
+
+          // Get shapes for dimension computation
+          auto query_shape = node_arg_get_shape_i64(*query.node_arg);
+          auto key_shape = node_arg_get_shape_i64(*key.node_arg);
+          auto output_shape = node_arg_get_shape_i64(*output.node_arg);
+
+          if (!query_shape || query_shape->size() < 3) {
+            ROCM_LOG(1) << LOG_PREFIX << " Cannot get query shape";
+            return false;
+          }
+
+          // Compute head_size from query shape: hidden_size / num_heads
+          int64_t hidden_size = (*query_shape)[2];
+          int64_t head_size = hidden_size / num_heads;
+
+          // Compute default scale if not provided
+          if (scale == 0.0f) {
+            scale = 1.0f / std::sqrt(static_cast<float>(head_size));
+          }
+
+          ROCM_LOG(1) << LOG_PREFIX << " num_heads=" << num_heads
+                      << " kv_num_heads=" << kv_num_heads
+                      << " head_size=" << head_size
+                      << " scale=" << scale;
+
+          // Check for unsupported features
+          // TODO: Forward cos_cache/sin_cache inputs when do_rotary=1
+          // TODO: Forward position_ids input
+          // TODO: Forward attention_bias input
+          // TODO: Forward head_sink input
+          // TODO: Handle output_qk (4th output)
+
+          if (node_has_attr(*gqa_node, "do_rotary") &&
+              node_get_attr_int(*gqa_node, "do_rotary") != 0) {
+            ROCM_LOG(1) << LOG_PREFIX << " do_rotary=1 not yet supported, skipping";
+            return false;
+          }
+
+          // Build RocmParamProto
+          rocm::RocmParamProto rocm_param;
+          rocm_param.set_op_type("gqa");
+
+          auto *gqa_params = rocm_param.mutable_gqa_params();
+          gqa_params->set_num_heads(static_cast<int32_t>(num_heads));
+          gqa_params->set_kv_num_heads(static_cast<int32_t>(kv_num_heads));
+          gqa_params->set_head_size(static_cast<int32_t>(head_size));
+          gqa_params->set_scale(scale);
+          gqa_params->set_num_inputs(7);   // query, key, value, past_key, past_value, seqlens_k, total_seq_len
+          gqa_params->set_num_outputs(3);  // output, present_key, present_value
+
+          // Store query shape
+          if (query_shape) {
+            for (auto dim : *query_shape) {
+              gqa_params->add_query_shape(dim);
+            }
+          }
+
+          // Store key shape
+          if (key_shape) {
+            for (auto dim : *key_shape) {
+              gqa_params->add_key_shape(dim);
+            }
+          }
+
+          // Store past_key shape (for past sequence length)
+          auto past_key_shape = node_arg_get_shape_i64(*past_key.node_arg);
+          if (past_key_shape) {
+            for (auto dim : *past_key_shape) {
+              gqa_params->add_past_key_shape(dim);
+            }
+          }
+
+          // Store output shape
+          if (output_shape) {
+            for (auto dim : *output_shape) {
+              gqa_params->add_output_shape(dim);
+            }
+          }
+
+          // Compute present_key/value shapes
+          // The present_key shape depends on runtime total_seq_len, which is dynamic.
+          // We use the output shape from the graph which has this information.
+          // present_key: output 1 of the GQA node
+          auto present_key_out_shape = node_get_output_shape(*gqa_node, 1);
+          auto present_value_out_shape = node_get_output_shape(*gqa_node, 2);
+
+          for (auto dim : present_key_out_shape) {
+            gqa_params->add_present_key_shape(dim);
+          }
+          for (auto dim : present_value_out_shape) {
+            gqa_params->add_present_value_shape(dim);
+          }
+
+          // Build input/output name lists
+          std::string query_name = node_arg_get_name(*query.node_arg);
+          std::string key_name = node_arg_get_name(*key.node_arg);
+          std::string value_name = node_arg_get_name(*value.node_arg);
+          std::string past_key_name = node_arg_get_name(*past_key.node_arg);
+          std::string past_value_name = node_arg_get_name(*past_value.node_arg);
+          std::string seqlens_k_name = node_arg_get_name(*seqlens_k.node_arg);
+          std::string total_seq_len_name = node_arg_get_name(*total_seq_len.node_arg);
+          std::string output_name = node_arg_get_name(*output.node_arg);
+
+          // GQA node has 3 outputs - get names for present_key and present_value
+          // The output binder refers to output 0, but we need outputs 1 and 2 as well
+          auto gqa_output_node_args = node_get_output_node_args(*gqa_node);
+
+          std::vector<std::string> input_names{
+              query_name, key_name, value_name,
+              past_key_name, past_value_name,
+              seqlens_k_name, total_seq_len_name};
+
+          // Output names: output(0), present_key(1), present_value(2)
+          std::vector<std::string> output_names;
+          if (gqa_output_node_args.size() >= 3) {
+            for (size_t i = 0; i < 3; ++i) {
+              output_names.push_back(node_arg_get_name(*gqa_output_node_args[i]));
+            }
+          } else {
+            output_names.push_back(output_name);
+            // Fallback: construct names
+            output_names.push_back(output_name + "_present_key");
+            output_names.push_back(output_name + "_present_value");
+          }
+
+          // No constant initializers for GQA
+          std::vector<std::string> constant_initializers;
+
+          auto [meta_def, error] =
+              self->try_fuse(*graph, "rocm_gqa", input_names, output_names,
+                             constant_initializers, "ROCm_EP");
+
+          if (meta_def) {
+            return rocm_pass::finalize_level2_fuse(
+                self, *graph, *meta_def, rocm_param, output_names[0], LOG_PREFIX);
+          }
+
+          ROCM_LOG(1) << LOG_PREFIX << " Failed to fuse: " << error.comments;
+          return false;
+        });
+  }
+
+  void process(IPass &self, Graph &graph) {
+    ROCM_LOG(1) << LOG_PREFIX << " Processing graph for GQA patterns...";
+    create_rule(&self)->apply(&graph);
+  }
+
+  IPass &self_;
+};
+
+DEFINE_MORPHIZEN_PASS(Level2RocmGqa, morphizen_pass_level2_rocm_gqa)

--- a/level-2-pass-rocm-matmul/cmake/generate_pattern_inc.cmake
+++ b/level-2-pass-rocm-matmul/cmake/generate_pattern_inc.cmake
@@ -6,7 +6,7 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 add_custom_command (
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/matmul_pattern_json.hpp
   COMMAND ${CMAKE_COMMAND} -E env
-    $<TARGET_FILE:Python3::Interpreter> ${morphizen_SOURCE_DIR}/tools/xxd.py
+    $<TARGET_FILE:Python3::Interpreter> ${morphizen_SOURCE_DIR}/cmake/scripts/xxd.py
     "--column" 16
     "--var" matmul_json
     --output ${CMAKE_CURRENT_BINARY_DIR}/matmul_pattern_json.hpp

--- a/level-2-pass-rocm-mul/cmake/generate_pattern_inc.cmake
+++ b/level-2-pass-rocm-mul/cmake/generate_pattern_inc.cmake
@@ -6,7 +6,7 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 add_custom_command (
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/mul_pattern_json.hpp
   COMMAND ${CMAKE_COMMAND} -E env
-    $<TARGET_FILE:Python3::Interpreter> ${morphizen_SOURCE_DIR}/tools/xxd.py
+    $<TARGET_FILE:Python3::Interpreter> ${morphizen_SOURCE_DIR}/cmake/scripts/xxd.py
     "--column" 16
     "--var" mul_json
     --output ${CMAKE_CURRENT_BINARY_DIR}/mul_pattern_json.hpp

--- a/level-2-pass-rocm-reshape/cmake/generate_pattern_inc.cmake
+++ b/level-2-pass-rocm-reshape/cmake/generate_pattern_inc.cmake
@@ -6,7 +6,7 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 add_custom_command (
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/reshape_pattern_json.hpp
   COMMAND ${CMAKE_COMMAND} -E env
-    $<TARGET_FILE:Python3::Interpreter> ${morphizen_SOURCE_DIR}/tools/xxd.py
+    $<TARGET_FILE:Python3::Interpreter> ${morphizen_SOURCE_DIR}/cmake/scripts/xxd.py
     "--column" 16
     "--var" reshape_json
     --output ${CMAKE_CURRENT_BINARY_DIR}/reshape_pattern_json.hpp

--- a/level-2-pass-rocm-softmax/cmake/generate_pattern_inc.cmake
+++ b/level-2-pass-rocm-softmax/cmake/generate_pattern_inc.cmake
@@ -6,7 +6,7 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 add_custom_command (
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/softmax_pattern_json.hpp
   COMMAND ${CMAKE_COMMAND} -E env
-    $<TARGET_FILE:Python3::Interpreter> ${morphizen_SOURCE_DIR}/tools/xxd.py
+    $<TARGET_FILE:Python3::Interpreter> ${morphizen_SOURCE_DIR}/cmake/scripts/xxd.py
     "--column" 16
     "--var" softmax_json
     --output ${CMAKE_CURRENT_BINARY_DIR}/softmax_pattern_json.hpp

--- a/level-2-pass-rocm-tile/cmake/generate_pattern_inc.cmake
+++ b/level-2-pass-rocm-tile/cmake/generate_pattern_inc.cmake
@@ -6,7 +6,7 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 add_custom_command (
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/tile_pattern_json.hpp
   COMMAND ${CMAKE_COMMAND} -E env
-    $<TARGET_FILE:Python3::Interpreter> ${morphizen_SOURCE_DIR}/tools/xxd.py
+    $<TARGET_FILE:Python3::Interpreter> ${morphizen_SOURCE_DIR}/cmake/scripts/xxd.py
     "--column" 16
     "--var" tile_json
     --output ${CMAKE_CURRENT_BINARY_DIR}/tile_pattern_json.hpp

--- a/level-2-pass-rocm-transpose/cmake/generate_pattern_inc.cmake
+++ b/level-2-pass-rocm-transpose/cmake/generate_pattern_inc.cmake
@@ -6,7 +6,7 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 add_custom_command (
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/transpose_pattern_json.hpp
   COMMAND ${CMAKE_COMMAND} -E env
-    $<TARGET_FILE:Python3::Interpreter> ${morphizen_SOURCE_DIR}/tools/xxd.py
+    $<TARGET_FILE:Python3::Interpreter> ${morphizen_SOURCE_DIR}/cmake/scripts/xxd.py
     "--column" 16
     "--var" transpose_json
     --output ${CMAKE_CURRENT_BINARY_DIR}/transpose_pattern_json.hpp

--- a/patterns/gqa.json
+++ b/patterns/gqa.json
@@ -1,0 +1,78 @@
+{
+  "patterns": [
+    {
+      "id": "query",
+      "wildcard": {}
+    },
+    {
+      "id": "key",
+      "wildcard": {}
+    },
+    {
+      "id": "value",
+      "wildcard": {}
+    },
+    {
+      "id": "past_key",
+      "wildcard": {}
+    },
+    {
+      "id": "past_value",
+      "wildcard": {}
+    },
+    {
+      "id": "seqlens_k",
+      "wildcard": {}
+    },
+    {
+      "id": "total_sequence_length",
+      "wildcard": {}
+    },
+    {
+      "id": "cos_cache",
+      "wildcard": {}
+    },
+    {
+      "id": "sin_cache",
+      "wildcard": {}
+    },
+    {
+      "id": "position_ids",
+      "wildcard": {}
+    },
+    {
+      "id": "attention_bias",
+      "wildcard": {}
+    },
+    {
+      "id": "head_sink",
+      "wildcard": {}
+    },
+    {
+      "id": "output",
+      "isRoot": true,
+      "callNode": {
+        "opType": "GroupQueryAttention",
+        "opDomain": "com.microsoft",
+        "args": [
+          { "name": "query" },
+          { "name": "key" },
+          { "name": "value" },
+          { "name": "past_key" },
+          { "name": "past_value" },
+          { "name": "seqlens_k" },
+          { "name": "total_sequence_length" },
+          { "name": "cos_cache" },
+          { "name": "sin_cache" },
+          { "name": "position_ids" },
+          { "name": "attention_bias" },
+          { "name": "head_sink" }
+        ],
+        "optionalArgs": [
+          false, true, true, true, true, false, false,
+          true, true, true, true, true
+        ]
+      }
+    }
+  ]
+}

--- a/proto/rocm.proto
+++ b/proto/rocm.proto
@@ -305,10 +305,34 @@ message TileParamProto {
   repeated string output_names = 8;
 }
 
+// GQA (Grouped Query Attention) parameters
+// Implements com.microsoft.GroupQueryAttention using CK Tile FMHA kernels
+message GqaParamProto {
+  // Attention configuration
+  int32 num_heads = 1;        // Number of query heads (e.g., 32 for Llama-3.1-8B)
+  int32 kv_num_heads = 2;     // Number of key/value heads (e.g., 8 for Llama-3.1-8B)
+  int32 head_size = 3;        // Head dimension (e.g., 128)
+  float scale = 4;            // Attention scale factor (typically 1/sqrt(head_size))
+
+  // Input shapes (from graph analysis)
+  repeated int64 query_shape = 5;        // [B, S, num_heads * head_size]
+  repeated int64 key_shape = 6;          // [B, S, kv_num_heads * head_size]
+  repeated int64 past_key_shape = 7;     // [B, kv_num_heads, past_seqlen, head_size] (BNSH)
+
+  // Output shapes
+  repeated int64 output_shape = 8;       // [B, S, num_heads * head_size]
+  repeated int64 present_key_shape = 9;  // [B, kv_num_heads, total_seqlen, head_size] (BNSH)
+  repeated int64 present_value_shape = 10; // [B, kv_num_heads, total_seqlen, head_size] (BNSH)
+
+  // Number of inputs/outputs actually used
+  int32 num_inputs = 11;      // Number of inputs (7 for our test models)
+  int32 num_outputs = 12;     // Number of outputs (3: output, present_key, present_value)
+}
+
 // Single operation parameters (used by Level-2 passes)
 // When a single operation is fused, this is attached to MetaDef
 message RocmParamProto {
-  // Operation type: "conv", "gemm", "matmul", "mul", "softmax", "reshape", "transpose", "tile"
+  // Operation type: "conv", "gemm", "matmul", "mul", "softmax", "reshape", "transpose", "tile", "gqa"
   string op_type = 1;
 
   // Operation-specific parameters (one of these will be populated)
@@ -320,6 +344,7 @@ message RocmParamProto {
   ReshapeParamProto reshape_params = 9;
   TransposeParamProto transpose_params = 10;
   TileParamProto tile_params = 11;
+  GqaParamProto gqa_params = 12;
 
   // General metadata
   string ep_context_file_name = 4;

--- a/test/model_verifier.cpp
+++ b/test/model_verifier.cpp
@@ -22,7 +22,9 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
@@ -65,6 +67,14 @@ struct Config {
   bool verbose = false;
 };
 
+// Per-element diff entry for top-N tracking
+struct DiffEntry {
+  size_t idx;
+  float cpu_val;
+  float gpu_val;
+  float diff;
+};
+
 // Statistics
 struct ComparisonStats {
   float max_diff = 0.0f;
@@ -77,6 +87,7 @@ struct ComparisonStats {
   size_t total_elements = 0;
   size_t nan_count = 0;
   size_t inf_count = 0;
+  std::vector<DiffEntry> top_diffs; // Top N largest differences
 };
 
 void print_usage(const char *prog_name) {
@@ -145,6 +156,7 @@ ComparisonStats compare_outputs(const std::vector<float> &cpu,
     return stats;
   }
 
+  constexpr size_t TOP_N = 20;
   std::vector<float> diffs(cpu.size());
   float sum_diff = 0.0f;
 
@@ -175,6 +187,22 @@ ComparisonStats compare_outputs(const std::vector<float> &cpu,
                   << ", GPU=" << gpu[i] << ", diff=" << diff << std::endl;
       }
     }
+
+    // Maintain top-N largest diffs (insertion sort into small vector)
+    if (stats.top_diffs.size() < TOP_N || diff > stats.top_diffs.back().diff) {
+      DiffEntry entry{i, cpu[i], gpu[i], diff};
+      if (stats.top_diffs.size() >= TOP_N)
+        stats.top_diffs.back() = entry;
+      else
+        stats.top_diffs.push_back(entry);
+      // Bubble up to maintain descending order
+      for (size_t j = stats.top_diffs.size() - 1; j > 0; --j) {
+        if (stats.top_diffs[j].diff > stats.top_diffs[j - 1].diff)
+          std::swap(stats.top_diffs[j], stats.top_diffs[j - 1]);
+        else
+          break;
+      }
+    }
   }
 
   stats.mean_diff = sum_diff / cpu.size();
@@ -190,7 +218,8 @@ ComparisonStats compare_outputs(const std::vector<float> &cpu,
   return stats;
 }
 
-void print_stats(const ComparisonStats &stats, float tolerance) {
+void print_stats(const ComparisonStats &stats, float tolerance,
+                 const std::vector<float> &cpu, const std::vector<float> &gpu) {
   std::cout << "\n=== Comparison Statistics ===" << std::endl;
   std::cout << std::fixed << std::setprecision(6);
   std::cout << "  Total elements:     " << stats.total_elements << std::endl;
@@ -211,6 +240,44 @@ void print_stats(const ComparisonStats &stats, float tolerance) {
     std::cout << "  WARNING: Inf values: " << stats.inf_count << std::endl;
   }
 
+  // Print top-20 largest differences
+  if (!stats.top_diffs.empty()) {
+    std::cout << "\n=== Top " << stats.top_diffs.size()
+              << " Largest Differences ===" << std::endl;
+    std::cout << "  " << std::setw(8) << "Index"
+              << "  " << std::setw(12) << "CPU"
+              << "  " << std::setw(12) << "GPU"
+              << "  " << std::setw(12) << "Diff" << std::endl;
+    std::cout << "  " << std::string(50, '-') << std::endl;
+    for (const auto &d : stats.top_diffs) {
+      std::cout << "  " << std::setw(8) << d.idx << "  " << std::setw(12)
+                << d.cpu_val << "  " << std::setw(12) << d.gpu_val << "  "
+                << std::setw(12) << d.diff << std::endl;
+    }
+  }
+
+  // Print a window of values around the max diff index
+  if (stats.total_elements > 0 && !cpu.empty() && !gpu.empty()) {
+    std::cout << "\n=== Values Around Max Diff (index " << stats.max_diff_idx
+              << ") ===" << std::endl;
+    std::cout << "  " << std::setw(8) << "Index"
+              << "  " << std::setw(12) << "CPU"
+              << "  " << std::setw(12) << "GPU"
+              << "  " << std::setw(12) << "Diff" << std::endl;
+    std::cout << "  " << std::string(50, '-') << std::endl;
+    int64_t center = static_cast<int64_t>(stats.max_diff_idx);
+    int64_t start = std::max(int64_t(0), center - 5);
+    int64_t end =
+        std::min(static_cast<int64_t>(stats.total_elements), center + 6);
+    for (int64_t i = start; i < end; ++i) {
+      float diff = std::abs(cpu[i] - gpu[i]);
+      std::cout << (static_cast<size_t>(i) == stats.max_diff_idx ? "  >" : "  ")
+                << std::setw(7) << i << "  " << std::setw(12) << cpu[i] << "  "
+                << std::setw(12) << gpu[i] << "  " << std::setw(12) << diff
+                << std::endl;
+    }
+  }
+
   std::cout << "\n=== Result ===" << std::endl;
   if (stats.mismatch_count == 0 && stats.nan_count == 0 &&
       stats.inf_count == 0) {
@@ -220,6 +287,113 @@ void print_stats(const ComparisonStats &stats, float tolerance) {
     std::cout << "  [FAIL] " << stats.mismatch_count
               << " elements exceed tolerance" << std::endl;
   }
+}
+
+// Helper: convert fp16 (uint16_t) to float32
+inline float fp16_to_float(uint16_t h) {
+  uint32_t sign = (h >> 15) & 0x1;
+  uint32_t exponent = (h >> 10) & 0x1f;
+  uint32_t mantissa = h & 0x3ff;
+
+  uint32_t f;
+  if (exponent == 0) {
+    if (mantissa == 0) {
+      f = sign << 31; // +/- zero
+    } else {
+      // Subnormal fp16 -> normal fp32
+      exponent = 1;
+      while (!(mantissa & 0x400)) {
+        mantissa <<= 1;
+        exponent--;
+      }
+      mantissa &= 0x3ff;
+      f = (sign << 31) | ((exponent + 127 - 15) << 23) | (mantissa << 13);
+    }
+  } else if (exponent == 31) {
+    // Inf or NaN
+    f = (sign << 31) | 0x7f800000 | (mantissa << 13);
+  } else {
+    f = (sign << 31) | ((exponent + 127 - 15) << 23) | (mantissa << 13);
+  }
+
+  float result;
+  std::memcpy(&result, &f, sizeof(float));
+  return result;
+}
+
+// Helper: convert float32 to fp16 (uint16_t) with rounding
+inline uint16_t float_to_fp16(float value) {
+  uint32_t f;
+  std::memcpy(&f, &value, sizeof(float));
+
+  uint32_t sign = (f >> 31) & 0x1;
+  int32_t exponent = ((f >> 23) & 0xff) - 127;
+  uint32_t mantissa = f & 0x7fffff;
+
+  uint16_t h;
+  if (exponent > 15) {
+    h = (sign << 15) | 0x7c00; // Inf
+  } else if (exponent > -15) {
+    h = (sign << 15) | ((exponent + 15) << 10) | (mantissa >> 13);
+  } else {
+    h = (sign << 15); // Zero (flush subnormals)
+  }
+  return h;
+}
+
+// Helper: get element type name string
+std::string elem_type_name(ONNXTensorElementDataType type) {
+  switch (type) {
+  case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT:
+    return "float32";
+  case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:
+    return "float16";
+  case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32:
+    return "int32";
+  case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64:
+    return "int64";
+  case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:
+    return "uint8";
+  default:
+    return "type_" + std::to_string(static_cast<int>(type));
+  }
+}
+
+// Helper: extract output tensor data as float vector (handles fp16 conversion)
+std::vector<float> extract_output_as_float(const Ort::Value &tensor) {
+  auto type_info = tensor.GetTensorTypeAndShapeInfo();
+  auto elem_type = type_info.GetElementType();
+  size_t count = type_info.GetElementCount();
+
+  std::vector<float> result(count);
+
+  if (elem_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
+    const float *data = tensor.GetTensorData<float>();
+    std::copy(data, data + count, result.begin());
+  } else if (elem_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16) {
+    const uint16_t *data = tensor.GetTensorData<uint16_t>();
+    for (size_t i = 0; i < count; ++i) {
+      result[i] = fp16_to_float(data[i]);
+    }
+  } else if (elem_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32) {
+    const int32_t *data = tensor.GetTensorData<int32_t>();
+    for (size_t i = 0; i < count; ++i) {
+      result[i] = static_cast<float>(data[i]);
+    }
+  } else if (elem_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64) {
+    const int64_t *data = tensor.GetTensorData<int64_t>();
+    for (size_t i = 0; i < count; ++i) {
+      result[i] = static_cast<float>(data[i]);
+    }
+  } else {
+    std::cerr << "WARNING: Unsupported output type "
+              << static_cast<int>(elem_type) << ", treating as float"
+              << std::endl;
+    const float *data = tensor.GetTensorData<float>();
+    std::copy(data, data + count, result.begin());
+  }
+
+  return result;
 }
 
 int main(int argc, char **argv) {
@@ -306,14 +480,22 @@ int main(int argc, char **argv) {
   std::cout << "Model inputs:  " << num_inputs << std::endl;
   std::cout << "Model outputs: " << num_outputs << std::endl;
 
-  // Prepare inputs
+  // Prepare inputs (supports mixed data types: float32, float16, int32)
   std::vector<std::string> input_names;
   std::vector<std::vector<int64_t>> input_shapes;
-  std::vector<std::vector<float>> input_data;
+  std::vector<ONNXTensorElementDataType> input_types;
+
+  // Raw byte storage for each input (supports any data type)
+  std::vector<std::vector<uint8_t>> input_raw_data;
+  // Element counts for each input
+  std::vector<size_t> input_elem_counts;
 
   std::mt19937 rng(config.seed);
-  std::normal_distribution<float> dist(0.0f, 1.0f);
+  std::normal_distribution<float> dist(0.0f,
+                                       0.5f); // Smaller range for fp16 safety
+  std::uniform_int_distribution<int32_t> int_dist(0, 255);
 
+  // First pass: collect all input metadata to determine GQA-specific values
   std::cout << "\n--- Input Information ---" << std::endl;
   for (size_t i = 0; i < num_inputs; ++i) {
     auto name = cpu_session.GetInputNameAllocated(i, allocator);
@@ -322,32 +504,135 @@ int main(int argc, char **argv) {
     auto type_info = cpu_session.GetInputTypeInfo(i);
     auto tensor_info = type_info.GetTensorTypeAndShapeInfo();
     auto shape = tensor_info.GetShape();
+    auto elem_type = tensor_info.GetElementType();
+    input_types.push_back(elem_type);
 
-    // Handle dynamic dimensions
+    // Handle dynamic dimensions:
+    // - Negative dims (symbolic) -> default to 1
+    // - Zero dims are VALID and preserved (e.g., [1, 8, 0, 128] for empty KV
+    // cache)
     for (auto &dim : shape) {
       if (dim < 0)
-        dim = 1; // Default dynamic dims to 1
+        dim = 1; // Default symbolic dims to 1
+      // NOTE: dim == 0 is intentionally preserved (zero-sized tensor)
     }
     input_shapes.push_back(shape);
 
-    // Calculate size and generate random data
+    // Calculate element count (may be 0 for zero-sized dims)
     size_t size = 1;
     for (auto d : shape)
       size *= static_cast<size_t>(d);
-
-    std::vector<float> data(size);
-    for (size_t j = 0; j < size; ++j) {
-      data[j] = dist(rng);
-    }
-    input_data.push_back(data);
+    input_elem_counts.push_back(size);
 
     std::cout << "  Input " << i << ": " << input_names[i] << " "
-              << shape_to_string(shape) << " (" << size << " elements)"
-              << std::endl;
+              << shape_to_string(shape) << " " << elem_type_name(elem_type)
+              << " (" << size << " elements)" << std::endl;
   }
 
-  // Get output names
+  // Detect GQA-specific inputs and derive proper values:
+  // - past_key shape [B, nhead_k, past_seqlen, hdim] -> past_seq_len
+  // - query shape [B, seqlen_q, hidden] -> current query seq_len
+  int64_t past_seq_len = 0;
+  int64_t query_seq_len = 1; // default
+  for (size_t i = 0; i < num_inputs; ++i) {
+    const auto &name = input_names[i];
+    const auto &shape = input_shapes[i];
+    if (name.find("past_key") != std::string::npos && shape.size() >= 3) {
+      past_seq_len = shape[2]; // [B, nhead, past_seqlen, hdim]
+    }
+    if (name == "query" && shape.size() >= 2) {
+      query_seq_len = shape[1]; // [B, seqlen_q, hidden]
+    }
+  }
+  int64_t total_seq_len_val = past_seq_len + query_seq_len;
+
+  if (config.verbose) {
+    std::cout << "\n  GQA detected: past_seq_len=" << past_seq_len
+              << ", query_seq_len=" << query_seq_len
+              << ", total_seq_len=" << total_seq_len_val << std::endl;
+  }
+
+  // Second pass: generate input data
+  for (size_t i = 0; i < num_inputs; ++i) {
+    auto elem_type = input_types[i];
+    size_t size = input_elem_counts[i];
+    const auto &name = input_names[i];
+
+    // Determine element byte size
+    size_t elem_bytes = 4; // default float32
+    switch (elem_type) {
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:
+      elem_bytes = 2;
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32:
+      elem_bytes = 4;
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64:
+      elem_bytes = 8;
+      break;
+    default:
+      elem_bytes = 4;
+      break;
+    }
+
+    std::vector<uint8_t> raw(size * elem_bytes, 0);
+
+    if (size > 0) {
+      // Check for GQA-specific semantic inputs
+      bool is_seqlens = (name.find("seqlens") != std::string::npos);
+      bool is_total_seq = (name.find("total_seq") != std::string::npos ||
+                           name.find("total_sequence") != std::string::npos);
+
+      if (is_seqlens || is_total_seq) {
+        // GQA semantic values:
+        //   seqlens_k = total_sequence_length - 1  (ORT CPU uses: total_seqlen
+        //   = seqlens_k + 1) total_seq_len = past + query
+        // Ref: onnxruntime/contrib_ops/cpu/bert/gqa_attention_base.h
+        int64_t fill_val =
+            is_seqlens ? (total_seq_len_val - 1) : total_seq_len_val;
+
+        if (config.verbose) {
+          std::cout << "  Setting " << name << " = " << fill_val << std::endl;
+        }
+
+        if (elem_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32) {
+          int32_t *data = reinterpret_cast<int32_t *>(raw.data());
+          for (size_t j = 0; j < size; ++j)
+            data[j] = static_cast<int32_t>(fill_val);
+        } else if (elem_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64) {
+          int64_t *data = reinterpret_cast<int64_t *>(raw.data());
+          for (size_t j = 0; j < size; ++j)
+            data[j] = fill_val;
+        }
+      } else if (elem_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
+        float *data = reinterpret_cast<float *>(raw.data());
+        for (size_t j = 0; j < size; ++j)
+          data[j] = dist(rng);
+      } else if (elem_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16) {
+        uint16_t *data = reinterpret_cast<uint16_t *>(raw.data());
+        for (size_t j = 0; j < size; ++j)
+          data[j] = float_to_fp16(dist(rng));
+      } else if (elem_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32) {
+        int32_t *data = reinterpret_cast<int32_t *>(raw.data());
+        for (size_t j = 0; j < size; ++j)
+          data[j] = int_dist(rng);
+      } else if (elem_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64) {
+        int64_t *data = reinterpret_cast<int64_t *>(raw.data());
+        for (size_t j = 0; j < size; ++j)
+          data[j] = static_cast<int64_t>(int_dist(rng));
+      } else {
+        // Fallback: treat as float32
+        float *data = reinterpret_cast<float *>(raw.data());
+        for (size_t j = 0; j < size; ++j)
+          data[j] = dist(rng);
+      }
+    }
+    input_raw_data.push_back(std::move(raw));
+  }
+
+  // Get output names and types
   std::vector<std::string> output_names;
+  std::vector<ONNXTensorElementDataType> output_types;
   std::cout << "\n--- Output Information ---" << std::endl;
   for (size_t i = 0; i < num_outputs; ++i) {
     auto name = cpu_session.GetOutputNameAllocated(i, allocator);
@@ -356,9 +641,12 @@ int main(int argc, char **argv) {
     auto type_info = cpu_session.GetOutputTypeInfo(i);
     auto tensor_info = type_info.GetTensorTypeAndShapeInfo();
     auto shape = tensor_info.GetShape();
+    auto elem_type = tensor_info.GetElementType();
+    output_types.push_back(elem_type);
 
     std::cout << "  Output " << i << ": " << output_names[i] << " "
-              << shape_to_string(shape) << std::endl;
+              << shape_to_string(shape) << " " << elem_type_name(elem_type)
+              << std::endl;
   }
 
   // Convert names to char pointers
@@ -380,22 +668,68 @@ int main(int argc, char **argv) {
 
     // Regenerate input data for each iteration (except first)
     if (iter > 0) {
-      for (size_t i = 0; i < input_data.size(); ++i) {
-        for (size_t j = 0; j < input_data[i].size(); ++j) {
-          input_data[i][j] = dist(rng);
+      for (size_t i = 0; i < input_raw_data.size(); ++i) {
+        auto elem_type = input_types[i];
+        size_t size = input_elem_counts[i];
+        if (size == 0)
+          continue; // Skip zero-sized tensors
+
+        if (elem_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
+          float *data = reinterpret_cast<float *>(input_raw_data[i].data());
+          for (size_t j = 0; j < size; ++j)
+            data[j] = dist(rng);
+        } else if (elem_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16) {
+          uint16_t *data =
+              reinterpret_cast<uint16_t *>(input_raw_data[i].data());
+          for (size_t j = 0; j < size; ++j)
+            data[j] = float_to_fp16(dist(rng));
+        } else if (elem_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32) {
+          int32_t *data = reinterpret_cast<int32_t *>(input_raw_data[i].data());
+          for (size_t j = 0; j < size; ++j)
+            data[j] = int_dist(rng);
         }
       }
     }
 
-    // Create input tensors
+    // Helper: create ORT input tensors from raw data (reused for CPU and GPU)
     auto memory_info =
         Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
-    std::vector<Ort::Value> input_tensors;
-    for (size_t i = 0; i < num_inputs; ++i) {
-      input_tensors.push_back(Ort::Value::CreateTensor<float>(
-          memory_info, input_data[i].data(), input_data[i].size(),
-          input_shapes[i].data(), input_shapes[i].size()));
-    }
+    auto create_input_tensors = [&]() -> std::vector<Ort::Value> {
+      std::vector<Ort::Value> tensors;
+      for (size_t i = 0; i < num_inputs; ++i) {
+        auto elem_type = input_types[i];
+        size_t elem_count = input_elem_counts[i];
+
+        if (elem_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
+          tensors.push_back(Ort::Value::CreateTensor<float>(
+              memory_info, reinterpret_cast<float *>(input_raw_data[i].data()),
+              elem_count, input_shapes[i].data(), input_shapes[i].size()));
+        } else if (elem_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16) {
+          tensors.push_back(Ort::Value::CreateTensor(
+              memory_info, input_raw_data[i].data(), input_raw_data[i].size(),
+              input_shapes[i].data(), input_shapes[i].size(),
+              ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16));
+        } else if (elem_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32) {
+          tensors.push_back(Ort::Value::CreateTensor<int32_t>(
+              memory_info,
+              reinterpret_cast<int32_t *>(input_raw_data[i].data()), elem_count,
+              input_shapes[i].data(), input_shapes[i].size()));
+        } else if (elem_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64) {
+          tensors.push_back(Ort::Value::CreateTensor<int64_t>(
+              memory_info,
+              reinterpret_cast<int64_t *>(input_raw_data[i].data()), elem_count,
+              input_shapes[i].data(), input_shapes[i].size()));
+        } else {
+          // Fallback: treat as float32
+          tensors.push_back(Ort::Value::CreateTensor<float>(
+              memory_info, reinterpret_cast<float *>(input_raw_data[i].data()),
+              elem_count, input_shapes[i].data(), input_shapes[i].size()));
+        }
+      }
+      return tensors;
+    };
+
+    std::vector<Ort::Value> input_tensors = create_input_tensors();
 
     // Run CPU inference
     std::cout << "\n--- CPU Inference ---" << std::endl;
@@ -411,22 +745,24 @@ int main(int argc, char **argv) {
                         .count();
     std::cout << "  Time: " << (cpu_time / 1000.0f) << " ms" << std::endl;
 
-    // Store CPU outputs
+    // Store CPU outputs (convert to float for comparison)
     std::vector<std::vector<float>> cpu_output_data;
     std::vector<std::vector<int64_t>> output_shapes;
     for (size_t i = 0; i < cpu_outputs.size(); ++i) {
-      const float *data = cpu_outputs[i].GetTensorData<float>();
-      size_t size =
-          cpu_outputs[i].GetTensorTypeAndShapeInfo().GetElementCount();
       auto shape = cpu_outputs[i].GetTensorTypeAndShapeInfo().GetShape();
+      auto out_elem_type =
+          cpu_outputs[i].GetTensorTypeAndShapeInfo().GetElementType();
 
-      cpu_output_data.push_back(std::vector<float>(data, data + size));
+      // Extract as float regardless of actual type
+      auto float_data = extract_output_as_float(cpu_outputs[i]);
+      cpu_output_data.push_back(float_data);
       output_shapes.push_back(shape);
 
-      if (config.verbose) {
-        std::cout << "  Output " << i << " " << shape_to_string(shape)
-                  << ": first=" << data[0] << ", last=" << data[size - 1]
-                  << std::endl;
+      if (config.verbose && !float_data.empty()) {
+        std::cout << "  Output " << i << " " << shape_to_string(shape) << " "
+                  << elem_type_name(out_elem_type)
+                  << ": first=" << float_data[0]
+                  << ", last=" << float_data.back() << std::endl;
       }
     }
 
@@ -490,13 +826,9 @@ int main(int argc, char **argv) {
             << std::endl;
       }
 
-      // Recreate input tensors for GPU session
-      std::vector<Ort::Value> gpu_input_tensors;
-      for (size_t i = 0; i < num_inputs; ++i) {
-        gpu_input_tensors.push_back(Ort::Value::CreateTensor<float>(
-            memory_info, input_data[i].data(), input_data[i].size(),
-            input_shapes[i].data(), input_shapes[i].size()));
-      }
+      // Recreate input tensors for GPU session (same data, separate ORT
+      // objects)
+      std::vector<Ort::Value> gpu_input_tensors = create_input_tensors();
 
       auto gpu_start = std::chrono::high_resolution_clock::now();
 
@@ -515,25 +847,33 @@ int main(int argc, char **argv) {
       // Compare outputs
       std::cout << "\n--- Output Comparison ---" << std::endl;
       for (size_t i = 0; i < gpu_outputs.size(); ++i) {
-        const float *data = gpu_outputs[i].GetTensorData<float>();
-        size_t size =
-            gpu_outputs[i].GetTensorTypeAndShapeInfo().GetElementCount();
+        auto gpu_elem_type =
+            gpu_outputs[i].GetTensorTypeAndShapeInfo().GetElementType();
 
-        std::vector<float> gpu_output(data, data + size);
+        // Extract GPU output as float (handles fp16 conversion)
+        auto gpu_output = extract_output_as_float(gpu_outputs[i]);
 
         std::cout << "\nOutput " << i << " (" << output_names[i] << ") "
-                  << shape_to_string(output_shapes[i]) << ":" << std::endl;
+                  << shape_to_string(output_shapes[i]) << " "
+                  << elem_type_name(gpu_elem_type) << ":" << std::endl;
 
-        if (config.verbose) {
+        if (config.verbose && !gpu_output.empty() &&
+            !cpu_output_data[i].empty()) {
           std::cout << "  CPU: first=" << cpu_output_data[i][0]
                     << ", last=" << cpu_output_data[i].back() << std::endl;
           std::cout << "  GPU: first=" << gpu_output[0]
                     << ", last=" << gpu_output.back() << std::endl;
         }
 
+        if (cpu_output_data[i].empty() && gpu_output.empty()) {
+          std::cout << "  (zero-sized output, skipping comparison)"
+                    << std::endl;
+          continue;
+        }
+
         auto stats = compare_outputs(cpu_output_data[i], gpu_output,
                                      config.tolerance, config.verbose);
-        print_stats(stats, config.tolerance);
+        print_stats(stats, config.tolerance, cpu_output_data[i], gpu_output);
 
         if (stats.mismatch_count > 0 || stats.nan_count > 0) {
           all_passed = false;

--- a/test/models/gqa_decode.onnx
+++ b/test/models/gqa_decode.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f41ebcb837b3dd8294e82ca8bd30b5886ce537b3be1250d2426b3fc75399fb44
+size 691

--- a/test/models/gqa_prefill.onnx
+++ b/test/models/gqa_prefill.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1894a58df66e5943333ec0f674089804cc03c85b4a5899a58d5d1556a2a8b251
+size 694


### PR DESCRIPTION
## Summary

Add **GroupQueryAttention (GQA)** operator support for RDNA3 (gfx1151) using a custom portable FMHA kernel with shared-memory tree reductions that produce correct results on both wave32 and wave64 architectures.

### Key changes

- **Custom FMHA kernel** (`fmha_ck_tile_kernels.hip`): Implements Flash Multi-Head Attention with bottom-right causal masking, supporting both prefill (multi-token) and decode (single-token) paths. Uses `__shared__` memory tree reductions instead of wave intrinsics, ensuring correctness on RDNA3's native wave32.
- **CK Tile optional backend**: When built with `-DCK_ROOT=...`, CK Tile's `naive_attention_fwd` is available as an alternative FMHA implementation (selectable at runtime via `FMHA_USE_CK_NAIVE=1`). Without `CK_ROOT`, only the portable kernel is built — no CK dependency required.
- **Level-2 GQA pass** (`level-2-pass-rocm-gqa/`): Pattern-matching pass that recognizes `com.microsoft.GroupQueryAttention` nodes, extracts attention parameters (num_heads, kv_num_heads, head_size, scale), and serializes them into `GqaParamProto`.
- **GQA execution** in `custom-op-rocm`: Handles BSH↔BNSH layout conversion (query transpose, KV cache concatenation) and calls the FMHA kernel. Supports 3 outputs: attention output, present_key, present_value.
- **Model verifier** (`test/model_verifier.cpp`): Enhanced CPU vs GPU comparison tool with fp16 support, GQA-specific input generation (seqlens_k, total_seq_len), top-20 diff tracking, and optional ORT profiling.
- **Morphizen submodule update**: Updated to include the SSA dominance fix for MLIR graph construction (ensures `none_` operation placement respects use-before-define).
- **Documentation**: Added `doc/04_FMHA_GQA_IMPLEMENTATION.md` with detailed technical analysis of the FMHA implementation, CK Tile accuracy issues on RDNA3, and the wave32 vs wave64 root cause.

### Architecture

```
ONNX Model (GQA op)
  → Level-2 GQA Pass (pattern match + param extraction)
    → custom-op-rocm (BSH↔BNSH layout, KV cache concat)
      → launch_fmha_fwd_fp16_causal()
        ├─ Portable kernel (default) — shared-mem reductions, wave32-safe
        └─ CK Tile naive_attention_fwd (optional) — wave64-hardcoded
```

### RDNA3 (wave32) accuracy results

| Model | Portable Kernel | CK Tile (`FMHA_USE_CK_NAIVE=1`) |
|-------|----------------|----------------------------------|
| Prefill (seqlen=255) | PASS (max diff: 0.000977) | FAIL (max diff: ~1.67, no causal mask) |
| Decode (past_seqlen=255) | PASS (max diff: 0.000061) | PASS (max diff: ~0.048, reduced accuracy) |

The CK Tile accuracy issues stem from `cross_wave_reduce` hardcoding wave64 (6-stage `ds_bpermute`), which only combines 4 of 8 wave32 groups on RDNA3. See `doc/04_FMHA_GQA_IMPLEMENTATION.md` for full analysis.

### Files changed

| Area | Files | Description |
|------|-------|-------------|
| Build | `CMakeLists.txt`, `kernels/CMakeLists.txt` | Optional CK_ROOT, FMHA kernel library |
| Kernel | `kernels/src/fmha_ck_tile_kernels.hip`, `kernels/include/rocm_kernels.h` | FMHA kernel + C API |
| Pass | `level-2-pass-rocm-gqa/` (new), `patterns/gqa.json` (new) | GQA pattern matching |
| Runtime | `custom-op-rocm/src/custom_op.cpp`, `custom_op.hpp` | GQA execution logic |
| Proto | `proto/rocm.proto` | `GqaParamProto` message |
| Config | `etc/morphizen_config.json` | Register GQA pass |
| Test | `test/model_verifier.cpp`, `test/models/gqa_*.onnx` | Verifier + test models |
| Docs | `doc/04_FMHA_GQA_IMPLEMENTATION.md`, `README.md` | Technical docs + usage |
| Submodule | `3rd-party/morphizen` | SSA dominance fix |

## Test plan

- [x] Build succeeds with CK_ROOT (CK Tile enabled)
- [x] Build succeeds without CK_ROOT (portable kernel only)
- [x] Morphizen SSA dominance unit tests pass (3/3)
- [x] `model_verifier` prefill (seqlen=255): all outputs PASS
- [x] `model_verifier` decode (past_seqlen=255): all outputs PASS
- [x] `model_verifier` with `FMHA_USE_CK_NAIVE=1`: confirms known CK Tile accuracy issues
- [x] `lintrunner` and `pre-commit` pass on all changed files
