### PR TITLE
feat: pass FileSystem interface through compilation pipeline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,10 +53,8 @@ if(THEROCK_DIST)
 endif()
 
 option(BUILD_EP "Build the ONNX HIP DNN Execution Provider" OFF)
-
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/deps.cmake)
 if(BUILD_EP)
-  include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/deps.cmake)
-
   # HIP kernels library (compiled with hipcc on Windows, CMake HIP on Linux)
   add_subdirectory(kernels)
 
@@ -143,5 +141,5 @@ if(BUILD_HIP_TOOLS)
   add_subdirectory(tools)
 endif()
 
-# MLIR backend (experimental, built alongside ROCm backend)
+# MLIR backend (experimental, requires morphizen)
 add_subdirectory(backend-mlir-compiler)

--- a/backend-mlir-compiler/custom-op-mlir/src/InferenceState.cpp
+++ b/backend-mlir-compiler/custom-op-mlir/src/InferenceState.cpp
@@ -42,7 +42,8 @@ InferenceState::InferenceState(PrivateTag, void *state,
 }
 
 std::unique_ptr<InferenceState>
-InferenceState::create(const std::vector<uint8_t> &dll_bytes) {
+InferenceState::create(const std::vector<uint8_t> &dll_bytes,
+                       morphizen::FileSystem *fs) {
   MY_LOG(1) << "Loading inference plugin from memory...";
 
   // Write DLL to temp file (morphizen::Plugin loads from file path)
@@ -75,16 +76,16 @@ InferenceState::create(const std::vector<uint8_t> &dll_bytes) {
         << " - check that the file exists and all dependencies are available";
   }
 
-  // Get init function and call it
-  // NOTE: Keep temp DLL file until plugin is destroyed
-  auto init_fn = plugin->get_method<int, void **>("inference_init");
+  // inference_init(void** out_state, void* fs) — the DLL needs a FileSystem
+  // to resolve and load model constants from the EPContext archive.
+  auto init_fn = plugin->get_method<int, void **, void *>("inference_init");
   if (!init_fn) {
     LOG(FATAL) << "inference_init function not found in plugin: " << dll_path
                << " - DLL loaded successfully but symbol is missing";
   }
 
   void *state = nullptr;
-  int ret = init_fn(&state);
+  int ret = init_fn(&state, static_cast<void *>(fs));
   if (ret != 0) {
     LOG(FATAL) << "inference_init() failed with code: " << ret;
   }

--- a/backend-mlir-compiler/custom-op-mlir/src/InferenceState.h
+++ b/backend-mlir-compiler/custom-op-mlir/src/InferenceState.h
@@ -15,6 +15,7 @@
 namespace morphizen {
 struct Plugin; // Must match definition in morphizen_plugin.hpp (struct, not
                // class)
+class FileSystem;
 }
 
 namespace mlir_compilation::customop {
@@ -23,10 +24,11 @@ namespace mlir_compilation::customop {
 // functions. Uses morphizen::Plugin infrastructure for dynamic library loading.
 class InferenceState {
 public:
-  // Create inference state from DLL bytes
-  // Logs FATAL and terminates on failure
+  // Create inference state from DLL bytes.
+  // fs: FileSystem for resolving model constants (passed to inference_init).
+  // Logs FATAL and terminates on failure.
   static std::unique_ptr<InferenceState>
-  create(const std::vector<uint8_t> &dll_bytes);
+  create(const std::vector<uint8_t> &dll_bytes, morphizen::FileSystem *fs);
 
   ~InferenceState();
 

--- a/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
+++ b/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
@@ -237,9 +237,14 @@ MlirCustomOp::MlirCustomOp(
   MY_LOG(1) << "MlirCustomOp constructor";
   // Parse metadata from JSON
   metadata_ = parse_metadata_from_metadef(context, meta_def);
+  // Get FileSystem from PassContext for constants file resolution.
+  // const_cast follows the established morphizen pattern (custom_op_imp.hpp).
+  auto fs = const_cast<morphizen::PassContext *>(context.get())
+                ->get_file_system();
   // Create inference state from DLL bytes (uses morphizen::Plugin)
   inference_state_ = customop::InferenceState::create(
-      load_artifact_from_epcontext(context, metadata_.artifact_filename()));
+      load_artifact_from_epcontext(context, metadata_.artifact_filename()),
+      fs.get());
 }
 
 void MlirCustomOp::Compute(const OrtApi *api, OrtKernelContext *context) const {

--- a/backend-mlir-compiler/level-1-pass/src/MlirCompiler.cpp
+++ b/backend-mlir-compiler/level-1-pass/src/MlirCompiler.cpp
@@ -55,15 +55,16 @@ std::string build_compiler_options_json(const CompilationConfig &config) {
 
 std::optional<CompilationArtifact>
 MlirCompiler::compileFromBytecode(const std::string &mlir_bytecode,
-                                  const CompilationConfig &config) {
+                                  const CompilationConfig &config,
+                                  morphizen::FileSystem *fs) {
 
-  LOG(INFO) << "Compiling MLIR bytecode using UDNA-compiler plugin";
+  LOG(INFO) << "Compiling MLIR bytecode using udna-compiler plugin";
   LOG(INFO) << "Bytecode size: " << mlir_bytecode.size() << " bytes";
 
   // Load plugin via MorphiZen Plugin API
-  auto plugin = morphizen::Plugin::get("UDNA-compiler");
+  auto plugin = morphizen::Plugin::get("udna-compiler");
   if (!plugin) {
-    LOG(ERROR) << "Failed to load UDNA-compiler plugin";
+    LOG(ERROR) << "Failed to load udna-compiler plugin";
     return std::nullopt;
   }
 
@@ -82,26 +83,28 @@ MlirCompiler::compileFromBytecode(const std::string &mlir_bytecode,
   LOG(INFO) << "Compilation options (JSON): " << options_json;
 
   // Check if symbol exists
-  if (!plugin->has_method("udna_compile")) {
-    LOG(ERROR) << "Symbol 'udna_compile' NOT found in DLL";
+  if (!plugin->has_method("udna_compile_with_fs")) {
+    LOG(ERROR) << "Symbol 'udna_compile_with_fs' NOT found in DLL";
     return std::nullopt;
   }
 
-  LOG(INFO) << "Calling udna_compile with JSON options: " << options_json;
+  LOG(INFO) << "Calling udna_compile_with_fs with JSON options: "
+            << options_json;
 
   // Get method with explicit types (avoids template forwarding ref issues)
   // Signature: CompilerErrorCode (*)(const void*, size_t, const char*, const
-  // char*, CompilerError*)
+  // char*, CompilerError*, void* fs)
   auto func =
       plugin->get_method<CompilerErrorCode, const void *, size_t, const char *,
-                         const char *, CompilerError *>("udna_compile");
+                         const char *, CompilerError *, void *>(
+          "udna_compile_with_fs");
 
   MY_LOG(2) << "get_method returned func = " << (void *)func;
   MY_LOG(2) << "Bytecode data() = " << (void *)mlir_bytecode.data();
   MY_LOG(2) << "Bytecode size() = " << mlir_bytecode.size();
 
   if (func == nullptr) {
-    LOG(ERROR) << "get_method returned nullptr for udna_compile";
+    LOG(ERROR) << "get_method returned nullptr for udna_compile_with_fs";
     return std::nullopt;
   }
 
@@ -109,8 +112,9 @@ MlirCompiler::compileFromBytecode(const std::string &mlir_bytecode,
   MY_LOG(2) << "About to call func with size = " << mlir_bytecode.size();
 
   CompilerError error = {};
-  auto result = func(mlir_bytecode.data(), mlir_bytecode.size(),
-                     temp_output_path.c_str(), options_json.c_str(), &error);
+  auto result =
+      func(mlir_bytecode.data(), mlir_bytecode.size(), temp_output_path.c_str(),
+           options_json.c_str(), &error, fs);
 
   if (result != COMPILER_SUCCESS) {
     LOG(ERROR) << "Compilation failed: " << error.message;

--- a/backend-mlir-compiler/level-1-pass/src/MlirCompiler.h
+++ b/backend-mlir-compiler/level-1-pass/src/MlirCompiler.h
@@ -11,6 +11,8 @@
 #include <string>
 #include <vector>
 
+#include <morphizen-foundation/file_io.hpp>
+
 namespace hipdnn::level1pass {
 
 // Artifact format (native DLL or LLVM IR)
@@ -30,12 +32,12 @@ struct CompilationArtifact {
 };
 
 /**
- * Simplified MLIR compiler that uses UDNA-compiler plugin C API.
+ * Simplified MLIR compiler that uses morphizen-mlir-compiler plugin C API.
  *
  * Replaces the old direct LLVM/MLIR integration (MlirParser, MlirTransformer,
  * LlvmCompiler).
  *
- * NOTE: Mock runtime is not supported. The UDNA-compiler plugin
+ * NOTE: Mock runtime is not supported. The morphizen-mlir-compiler plugin
  * always generates native code that targets the actual HIP/ROCm runtime.
  * Mock runtime functionality was removed as it is not compatible with the
  * plugin-based compilation architecture.
@@ -52,7 +54,8 @@ public:
    */
   static std::optional<CompilationArtifact>
   compileFromBytecode(const std::string &mlir_bytecode,
-                      const CompilationConfig &config);
+                      const CompilationConfig &config,
+                      morphizen::FileSystem *fs);
 };
 
 } // namespace hipdnn::level1pass

--- a/backend-mlir-compiler/level-1-pass/src/pass_main.cpp
+++ b/backend-mlir-compiler/level-1-pass/src/pass_main.cpp
@@ -93,9 +93,9 @@ static std::string get_mlir_bytecode(PassContext *ctx, Graph &graph) {
 
 // Step 3: Compile MLIR bytecode to artifact
 static std::optional<CompilationArtifact>
-compile_mlir(const std::string &mlir_bytecode,
-             const CompilationConfig &config) {
-  return MlirCompiler::compileFromBytecode(mlir_bytecode, config);
+compile_mlir(const std::string &mlir_bytecode, const CompilationConfig &config,
+             morphizen::FileSystem *fs) {
+  return MlirCompiler::compileFromBytecode(mlir_bytecode, config, fs);
 }
 
 // Step 4: Write artifact to EPContext
@@ -224,7 +224,8 @@ struct Level1MlirPass {
     }
 
     // Step 3: Compile bytecode to artifact
-    auto artifactOpt = compile_mlir(mlir_bytecode, config);
+    auto fs = self.get_context()->get_file_system();
+    auto artifactOpt = compile_mlir(mlir_bytecode, config, fs.get());
     if (!artifactOpt) {
       LOG(WARNING) << "MLIR compilation failed, skipping";
       return;


### PR DESCRIPTION
## Summary

Cherry-pick of wcy123/onnx-hipdnn-ep commit 4ed4d02d8a3f55c774920b0970d02fe9fece2803.

- Add `morphizen::FileSystem*` parameter to `MlirCompiler::compileFromBytecode` and pass it through the plugin C API call to `morphizen_mlir_compile`.
- Use `PassContext::get_file_system()` in `pass_main.cpp` instead of a manual adapter.
- Update morphizen submodule to include the new `get_file_system()` API.

## Related PR

- Original PR: https://github.com/wcy123/onnx-hipdnn-ep/pull/2
- Depends on the morphizen `FileSystem` interface added in: https://github.com/ROCm/MorphiZen/pull/189

## Test plan

- [ ] Full build of `morphizen-level1-pass-mlir-compiler` target succeeds without errors
- [ ] End-to-end test with a model that exercises the file I/O path through the plugin
