### PR TITLE
Add MLIR-to-GPU tests for element-wise Mul

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,10 @@ if(THEROCK_DIST)
 endif()
 
 option(BUILD_EP "Build the ONNX HIP DNN Execution Provider" OFF)
+option(BUILD_TESTS "Build tests" ON)
+if(BUILD_TESTS)
+  enable_testing()
+endif()
 
 if(BUILD_EP)
   include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/deps.cmake)
@@ -93,6 +97,10 @@ endif()
 option(BUILD_HIP_TOOLS "Build HIP MLIR compiler tools (hip-mlir-opt, hip-compiler)" OFF)
 
 if(BUILD_HIP_TOOLS)
+  if(NOT THEROCK_DIST)
+    message(FATAL_ERROR "BUILD_HIP_TOOLS requires THEROCK_DIST to be set")
+  endif()
+
   find_package(LLVM REQUIRED CONFIG)
   find_package(MLIR REQUIRED CONFIG)
 
@@ -128,6 +136,11 @@ if(BUILD_HIP_TOOLS)
 
   # Executable targets
   add_subdirectory(tools)
+
+  # MLIR-to-GPU tests (compile MLIR to DLL, run on GPU, verify numerics)
+  if(BUILD_TESTS)
+    add_subdirectory(test/MLIRToGPU)
+  endif()
 endif()
 
 if(BUILD_EP)

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -9,6 +9,6 @@ set_target_properties(hip_runtime_static PROPERTIES
   ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}"
 )
 target_compile_definitions(hip_runtime_static PRIVATE __HIP_PLATFORM_AMD__ MIOPEN_BETA_API)
-if(DEFINED ENV{THEROCK_DIST})
-  target_include_directories(hip_runtime_static PRIVATE $ENV{THEROCK_DIST}/include)
+if(THEROCK_DIST)
+  target_include_directories(hip_runtime_static PRIVATE ${THEROCK_DIST}/include)
 endif()

--- a/test/MLIRToGPU/CMakeLists.txt
+++ b/test/MLIRToGPU/CMakeLists.txt
@@ -1,0 +1,32 @@
+##
+# ** Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# ** Licensed under the MIT License.
+##
+
+add_executable(test_mul_f32 test_mul_f32.cpp)
+target_compile_definitions(test_mul_f32 PRIVATE __HIP_PLATFORM_AMD__)
+target_include_directories(test_mul_f32 PRIVATE ${THEROCK_DIST}/include)
+target_link_directories(test_mul_f32 PRIVATE ${THEROCK_DIST}/lib)
+target_link_libraries(test_mul_f32 PRIVATE amdhip64)
+
+# add_mlir_to_gpu_test(<name> <mlir_file> <symbol> [extra_run_args...])
+#   Adds a compile + run test pair with fixture dependency.
+function(add_mlir_to_gpu_test name mlir_file symbol)
+  set(dll "${CMAKE_CURRENT_BINARY_DIR}/${name}.dll")
+
+  add_test(NAME mlir_to_gpu_compile_${name}
+    COMMAND $<TARGET_FILE:hip-compiler>
+      "${CMAKE_CURRENT_SOURCE_DIR}/${mlir_file}" -o "${dll}")
+  set_tests_properties(mlir_to_gpu_compile_${name} PROPERTIES
+    FIXTURES_SETUP ${name}_dll
+    ENVIRONMENT "THEROCK_DIST=${THEROCK_DIST}")
+
+  add_test(NAME mlir_to_gpu_run_${name}
+    COMMAND $<TARGET_FILE:test_mul_f32> "${dll}" "${symbol}" ${ARGN})
+  set_tests_properties(mlir_to_gpu_run_${name} PROPERTIES
+    FIXTURES_REQUIRED ${name}_dll
+    ENVIRONMENT "PATH=${THEROCK_DIST}/bin\;$ENV{PATH}")
+endfunction()
+
+add_mlir_to_gpu_test(mul_f32       mul_f32.mlir       mul)
+add_mlir_to_gpu_test(mul_f32_const mul_f32_const.mlir mul_const --const)

--- a/test/MLIRToGPU/mul_f32.mlir
+++ b/test/MLIRToGPU/mul_f32.mlir
@@ -1,0 +1,24 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+// Pre-bufferized memref IR for hip-compiler.
+// This is the output of `hip-mlir-opt --onnx-to-hip-pipeline` on a simple
+// onnx.Mul with two runtime tensor<8xf32> inputs.
+//
+// hip-compiler runs hip-to-llvm-pipeline internally, then compiles to DLL.
+// The exported function `mul` uses the unpacked memref calling convention:
+//   5 scalar args per rank-1 memref (alloc_ptr, align_ptr, offset, size0, stride0)
+//   3 memrefs (A, B, C) => 15 total args.
+
+module {
+  func.func @mul(%arg0: memref<8xf32, strided<[?], offset: ?>>,
+                 %arg1: memref<8xf32, strided<[?], offset: ?>>,
+                 %arg2: memref<8xf32> {bufferize.result}) {
+    %0 = hip.create_handle() : !hip.handle
+    hip.miopen.mul(%0) ins(%arg0, %arg1 : memref<8xf32, strided<[?], offset: ?>>,
+                                          memref<8xf32, strided<[?], offset: ?>>)
+                       outs(%arg2 : memref<8xf32>)
+    hip.destroy_handle(%0) : !hip.handle
+    return
+  }
+}

--- a/test/MLIRToGPU/mul_f32_const.mlir
+++ b/test/MLIRToGPU/mul_f32_const.mlir
@@ -1,0 +1,28 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+// Pre-bufferized memref IR for hip-compiler.
+// This is the output of:
+//   hip-mlir-opt --onnx-to-hip-pipeline='externalize-min-num-elements=4'
+// on an onnx.Mul where B is an onnx.Constant (8 non-splat f32 elements).
+//
+// The constant blob is passed as memref<?xi8> and viewed as memref<8xf32>.
+// Exported function signature (unpacked): 15 args total
+//   arg0-4:  A  (memref<8xf32>)        -- runtime input
+//   arg5-9:  C  (memref<8xf32>)        -- output
+//   arg10-14: constants blob (memref<?xi8>) -- contains B data
+
+module {
+  func.func @mul_const(%arg0: memref<8xf32, strided<[?], offset: ?>>,
+                       %arg1: memref<8xf32> {bufferize.result},
+                       %arg2: memref<?xi8>) {
+    %0 = hip.create_handle() : !hip.handle
+    %c0 = arith.constant 0 : index
+    %view = memref.view %arg2[%c0][] : memref<?xi8> to memref<8xf32>
+    hip.miopen.mul(%0) ins(%arg0, %view : memref<8xf32, strided<[?], offset: ?>>,
+                                          memref<8xf32>)
+                       outs(%arg1 : memref<8xf32>)
+    hip.destroy_handle(%0) : !hip.handle
+    return
+  }
+}

--- a/test/MLIRToGPU/test_mul_f32.cpp
+++ b/test/MLIRToGPU/test_mul_f32.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <hip/hip_runtime_api.h>
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#endif
+
+#define HIP_CHECK(call)                                                        \
+  do {                                                                         \
+    if (hipError_t e = (call))                                                 \
+      return fprintf(stderr, "HIP error %d at %s:%d\n", e, __FILE__,           \
+                     __LINE__),                                                \
+             1;                                                                \
+  } while (0)
+
+// Unpacked memref ABI: 3 x (ptr, ptr, i64, i64, i64) = 15 args.
+typedef void (*MulFn)(void *, void *, int64_t, int64_t, int64_t, void *, void *,
+                      int64_t, int64_t, int64_t, void *, void *, int64_t,
+                      int64_t, int64_t);
+
+static void *gpuAlloc(const void *src, size_t bytes) {
+  void *d = nullptr;
+  hipMalloc(&d, bytes);
+  if (src)
+    hipMemcpy(d, src, bytes, hipMemcpyHostToDevice);
+  else
+    hipMemset(d, 0, bytes);
+  return d;
+}
+
+static constexpr int N = 8;
+
+int main(int argc, char **argv) {
+  if (argc < 3)
+    return fprintf(stderr, "Usage: %s <dll> <sym> [--const]\n", argv[0]), 1;
+
+  const char *dllPath = argv[1], *sym = argv[2];
+  bool isConst = argc > 3 && strcmp(argv[3], "--const") == 0;
+
+  // Load DLL
+#ifdef _WIN32
+  HMODULE lib = LoadLibraryA(dllPath);
+  auto fn = lib ? (MulFn)GetProcAddress(lib, sym) : nullptr;
+#else
+  void *lib = dlopen(dllPath, RTLD_NOW);
+  auto fn = lib ? (MulFn)dlsym(lib, sym) : nullptr;
+#endif
+  if (!fn)
+    return fprintf(stderr, "Cannot load %s::%s\n", dllPath, sym), 1;
+
+  // Host data: A = {1..8}, B = {2,2,...} (runtime) or {1..8} (const)
+  float hA[N], hB[N], expected[N];
+  for (int i = 0; i < N; i++) {
+    hA[i] = (float)(i + 1);
+    hB[i] = isConst ? (float)(i + 1) : 2.0f;
+    expected[i] = hA[i] * hB[i];
+  }
+
+  // GPU buffers
+  void *dA = gpuAlloc(hA, sizeof(hA));
+  void *dC = gpuAlloc(nullptr, sizeof(hA));
+
+  if (isConst) {
+    int64_t blob = N * (int64_t)sizeof(float);
+    void *dBlob = gpuAlloc(hB, blob);
+    fn(dA, dA, 0, N, 1, dC, dC, 0, N, 1, dBlob, dBlob, 0, blob, 1);
+    hipFree(dBlob);
+  } else {
+    void *dB = gpuAlloc(hB, sizeof(hB));
+    fn(dA, dA, 0, N, 1, dB, dB, 0, N, 1, dC, dC, 0, N, 1);
+    hipFree(dB);
+  }
+
+  float hC[N];
+  HIP_CHECK(hipMemcpy(hC, dC, sizeof(hC), hipMemcpyDeviceToHost));
+  hipFree(dA);
+  hipFree(dC);
+#ifdef _WIN32
+  FreeLibrary(lib);
+#endif
+
+  int fail = 0;
+  for (int i = 0; i < N; i++)
+    if (std::fabs(hC[i] - expected[i]) > 1e-5f)
+      fprintf(stderr, "MISMATCH [%d]: %f != %f\n", i, hC[i], expected[i]),
+          fail++;
+
+  printf("%s: %d elements (%s)\n", fail ? "FAIL" : "PASS", N,
+         isConst ? "const" : "runtime");
+  return fail ? 1 : 0;
+}

--- a/test/Pipeline/mul-runtime-e2e.mlir
+++ b/test/Pipeline/mul-runtime-e2e.mlir
@@ -1,0 +1,37 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+//===----------------------------------------------------------------------===//
+// Pipeline test: onnx.Mul with two runtime f32 inputs through onnx-to-hip.
+//
+// Verifies that a simple element-wise Mul is converted end-to-end:
+//   onnx.Mul -> hip.miopen.mul, bufferized, allocs pooled + lowered.
+//===----------------------------------------------------------------------===//
+
+// RUN: %hip-mlir-opt --onnx-to-hip-pipeline %s | %FileCheck %s
+
+// CHECK-LABEL: func.func @mul
+
+// onnx ops must be gone.
+// CHECK-NOT: onnx.Mul
+// CHECK-NOT: onnx.Return
+
+// Handle lifecycle inserted.
+// CHECK: hip.create_handle
+
+// Mul lowered to HIP dialect.
+// CHECK: hip.miopen.mul
+
+// Allocs lowered to hip.alloc (no memref.alloc left).
+// CHECK-NOT: memref.alloc
+
+// Handle destroyed before return.
+// CHECK: hip.destroy_handle
+// CHECK: return
+
+module {
+  func.func @mul(%A: tensor<8xf32>, %B: tensor<8xf32>) -> tensor<8xf32> {
+    %C = "onnx.Mul"(%A, %B) : (tensor<8xf32>, tensor<8xf32>) -> tensor<8xf32>
+    "onnx.Return"(%C) : (tensor<8xf32>) -> ()
+  }
+}


### PR DESCRIPTION
Add CTest-integrated tests that compile MLIR to DLL via hip-compiler and verify numerical correctness on GPU. Covers runtime inputs and externalized constants.

Made with [Cursor](https://cursor.com)