### PR TITLE
Add module metadata generation to convert-onnx-to-hip pass

### DIFF
--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -621,6 +621,76 @@ static mlir::LogicalResult convertComputeOps(mlir::func::FuncOp funcOp,
 }
 
 //===----------------------------------------------------------------------===//
+// Module metadata generation
+//===----------------------------------------------------------------------===//
+
+/// Generate module metadata attributes required by GenerateInterfacePass.
+/// Must be called BEFORE patterns transform function signatures.
+static mlir::LogicalResult generateModuleMetadata(mlir::ModuleOp module) {
+  auto mainFunc = module.lookupSymbol<mlir::func::FuncOp>("main_graph");
+  if (!mainFunc)
+    return mlir::success();
+
+  auto originalFuncType = mainFunc.getFunctionType();
+  mlir::OpBuilder builder(module.getContext());
+
+  int64_t inputCount = originalFuncType.getNumInputs();
+  llvm::SmallVector<mlir::Attribute> inputShapes;
+  llvm::SmallVector<int64_t> inputElementSizes;
+
+  for (mlir::Type inputType : originalFuncType.getInputs()) {
+    if (mlir::isa<mlir::hip::ContextType>(inputType)) {
+      --inputCount;
+      continue;
+    }
+    if (auto tensorType = mlir::dyn_cast<mlir::RankedTensorType>(inputType)) {
+      llvm::SmallVector<int64_t> shape(tensorType.getShape().begin(),
+                                       tensorType.getShape().end());
+      inputShapes.push_back(builder.getDenseI64ArrayAttr(shape));
+      inputElementSizes.push_back(
+          tensorType.getElementType().getIntOrFloatBitWidth() / 8);
+    } else {
+      llvm::errs() << "[ONNX→HIP] Warning: non-tensor input in @main_graph, "
+                      "skipping metadata\n";
+      return mlir::success();
+    }
+  }
+
+  int64_t outputCount = originalFuncType.getNumResults();
+  llvm::SmallVector<mlir::Attribute> outputShapes;
+  llvm::SmallVector<int64_t> outputElementSizes;
+
+  for (mlir::Type resultType : originalFuncType.getResults()) {
+    if (auto tensorType = mlir::dyn_cast<mlir::RankedTensorType>(resultType)) {
+      llvm::SmallVector<int64_t> shape(tensorType.getShape().begin(),
+                                       tensorType.getShape().end());
+      outputShapes.push_back(builder.getDenseI64ArrayAttr(shape));
+      outputElementSizes.push_back(
+          tensorType.getElementType().getIntOrFloatBitWidth() / 8);
+    } else {
+      llvm::errs() << "[ONNX→HIP] Warning: non-tensor output in @main_graph, "
+                      "skipping metadata\n";
+      return mlir::success();
+    }
+  }
+
+  module->setAttr("hipdnn.input_count", builder.getI64IntegerAttr(inputCount));
+  module->setAttr("hipdnn.input_shapes", builder.getArrayAttr(inputShapes));
+  module->setAttr("hipdnn.input_element_sizes",
+                  builder.getDenseI64ArrayAttr(inputElementSizes));
+  module->setAttr("hipdnn.output_count",
+                  builder.getI64IntegerAttr(outputCount));
+  module->setAttr("hipdnn.output_shapes", builder.getArrayAttr(outputShapes));
+  module->setAttr("hipdnn.output_element_sizes",
+                  builder.getDenseI64ArrayAttr(outputElementSizes));
+
+  llvm::errs() << "[ONNX→HIP] Generated module metadata: input_count="
+               << inputCount << " output_count=" << outputCount << "\n";
+
+  return mlir::success();
+}
+
+//===----------------------------------------------------------------------===//
 // ConvertOnnxToHip Pass
 //===----------------------------------------------------------------------===//
 
@@ -658,6 +728,10 @@ void ConvertOnnxToHipPass::runOnOperation() {
       return signalPassFailure();
     }
   }
+
+  // Capture original function signatures as module metadata before lowering.
+  if (mlir::failed(generateModuleMetadata(module)))
+    return signalPassFailure();
 
   for (auto funcOp :
        llvm::make_early_inc_range(module.getOps<mlir::func::FuncOp>())) {

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -26,10 +26,13 @@
 
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/Sequence.h"
+#include "llvm/Support/Debug.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/JSON.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/raw_ostream.h"
+
+#define DEBUG_TYPE "convert-onnx-to-hip"
 
 namespace mlir {
 namespace hip {
@@ -628,8 +631,10 @@ static mlir::LogicalResult convertComputeOps(mlir::func::FuncOp funcOp,
 /// Must be called BEFORE patterns transform function signatures.
 static mlir::LogicalResult generateModuleMetadata(mlir::ModuleOp module) {
   auto mainFunc = module.lookupSymbol<mlir::func::FuncOp>("main_graph");
-  if (!mainFunc)
-    return mlir::success();
+  if (!mainFunc) {
+    module.emitError("expected @main_graph function for metadata generation");
+    return mlir::failure();
+  }
 
   auto originalFuncType = mainFunc.getFunctionType();
   mlir::OpBuilder builder(module.getContext());
@@ -644,11 +649,16 @@ static mlir::LogicalResult generateModuleMetadata(mlir::ModuleOp module) {
       continue;
     }
     if (auto tensorType = mlir::dyn_cast<mlir::RankedTensorType>(inputType)) {
+      auto elemType = tensorType.getElementType();
+      if (!elemType.isIntOrFloat()) {
+        mainFunc.emitError("unsupported element type in @main_graph input: ")
+            << elemType;
+        return mlir::failure();
+      }
       llvm::SmallVector<int64_t> shape(tensorType.getShape().begin(),
                                        tensorType.getShape().end());
       inputShapes.push_back(builder.getDenseI64ArrayAttr(shape));
-      inputElementSizes.push_back(
-          tensorType.getElementType().getIntOrFloatBitWidth() / 8);
+      inputElementSizes.push_back(elemType.getIntOrFloatBitWidth() / 8);
     } else {
       mainFunc.emitError("non-tensor input type in @main_graph: ") << inputType;
       return mlir::failure();
@@ -661,11 +671,16 @@ static mlir::LogicalResult generateModuleMetadata(mlir::ModuleOp module) {
 
   for (mlir::Type resultType : originalFuncType.getResults()) {
     if (auto tensorType = mlir::dyn_cast<mlir::RankedTensorType>(resultType)) {
+      auto elemType = tensorType.getElementType();
+      if (!elemType.isIntOrFloat()) {
+        mainFunc.emitError("unsupported element type in @main_graph output: ")
+            << elemType;
+        return mlir::failure();
+      }
       llvm::SmallVector<int64_t> shape(tensorType.getShape().begin(),
                                        tensorType.getShape().end());
       outputShapes.push_back(builder.getDenseI64ArrayAttr(shape));
-      outputElementSizes.push_back(
-          tensorType.getElementType().getIntOrFloatBitWidth() / 8);
+      outputElementSizes.push_back(elemType.getIntOrFloatBitWidth() / 8);
     } else {
       mainFunc.emitError("non-tensor output type in @main_graph: ")
           << resultType;
@@ -683,15 +698,17 @@ static mlir::LogicalResult generateModuleMetadata(mlir::ModuleOp module) {
   module->setAttr("hipdnn.output_element_sizes",
                   builder.getDenseI64ArrayAttr(outputElementSizes));
 
-  auto remark = module.emitRemark("module metadata: ");
-  remark << "input_count=" << inputCount
-         << ", input_shapes=" << builder.getArrayAttr(inputShapes)
-         << ", input_element_sizes="
-         << builder.getDenseI64ArrayAttr(inputElementSizes)
-         << ", output_count=" << outputCount
-         << ", output_shapes=" << builder.getArrayAttr(outputShapes)
-         << ", output_element_sizes="
-         << builder.getDenseI64ArrayAttr(outputElementSizes);
+  LLVM_DEBUG({
+    llvm::dbgs() << "[convert-onnx-to-hip] module metadata:"
+                 << " input_count=" << inputCount
+                 << " input_shapes=" << builder.getArrayAttr(inputShapes)
+                 << " input_element_sizes="
+                 << builder.getDenseI64ArrayAttr(inputElementSizes)
+                 << " output_count=" << outputCount
+                 << " output_shapes=" << builder.getArrayAttr(outputShapes)
+                 << " output_element_sizes="
+                 << builder.getDenseI64ArrayAttr(outputElementSizes) << "\n";
+  });
 
   return mlir::success();
 }

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -650,9 +650,8 @@ static mlir::LogicalResult generateModuleMetadata(mlir::ModuleOp module) {
       inputElementSizes.push_back(
           tensorType.getElementType().getIntOrFloatBitWidth() / 8);
     } else {
-      llvm::errs() << "[ONNX→HIP] Warning: non-tensor input in @main_graph, "
-                      "skipping metadata\n";
-      return mlir::success();
+      mainFunc.emitError("non-tensor input type in @main_graph: ") << inputType;
+      return mlir::failure();
     }
   }
 
@@ -668,9 +667,9 @@ static mlir::LogicalResult generateModuleMetadata(mlir::ModuleOp module) {
       outputElementSizes.push_back(
           tensorType.getElementType().getIntOrFloatBitWidth() / 8);
     } else {
-      llvm::errs() << "[ONNX→HIP] Warning: non-tensor output in @main_graph, "
-                      "skipping metadata\n";
-      return mlir::success();
+      mainFunc.emitError("non-tensor output type in @main_graph: ")
+          << resultType;
+      return mlir::failure();
     }
   }
 
@@ -684,8 +683,15 @@ static mlir::LogicalResult generateModuleMetadata(mlir::ModuleOp module) {
   module->setAttr("hipdnn.output_element_sizes",
                   builder.getDenseI64ArrayAttr(outputElementSizes));
 
-  llvm::errs() << "[ONNX→HIP] Generated module metadata: input_count="
-               << inputCount << " output_count=" << outputCount << "\n";
+  auto remark = module.emitRemark("module metadata: ");
+  remark << "input_count=" << inputCount
+         << ", input_shapes=" << builder.getArrayAttr(inputShapes)
+         << ", input_element_sizes="
+         << builder.getDenseI64ArrayAttr(inputElementSizes)
+         << ", output_count=" << outputCount
+         << ", output_shapes=" << builder.getArrayAttr(outputShapes)
+         << ", output_element_sizes="
+         << builder.getDenseI64ArrayAttr(outputElementSizes);
 
   return mlir::success();
 }

--- a/test/lit/Conversion/onnx-to-hip/test_conv.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_conv.mlir
@@ -24,6 +24,11 @@
 // RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip | FileCheck %s
 
 module {
+  // Dummy entry point required by generateModuleMetadata.
+  func.func @main_graph(%arg0: tensor<1x3x224x224xf32>) -> tensor<1x3x224x224xf32> {
+    return %arg0 : tensor<1x3x224x224xf32>
+  }
+
   // --------------------------------------------------------------------------
   // 1. Basic conv with bias
   // --------------------------------------------------------------------------

--- a/test/lit/Pipeline/externalize-constants.mlir
+++ b/test/lit/Pipeline/externalize-constants.mlir
@@ -21,7 +21,7 @@
 // CHECK: memref.global "private" @hip_ext_constant_0 : memref<2x4xf32>
 // CHECK-SAME: hip.external_data = {offset = 0 : i64, size = 32 : i64}
 
-// CHECK-LABEL: func.func @test_externalize
+// CHECK-LABEL: func.func @main_graph
 //   Small constant stays inline (2 elements < threshold 4).
 // CHECK-DAG:   arith.constant dense<[1.000000e+00, 2.000000e+00]> : tensor<2xf32>
 //   Splat constant stays inline despite 16 elements >= threshold.
@@ -32,7 +32,7 @@
 // CHECK:       return
 
 module {
-  func.func @test_externalize() -> (tensor<2xf32>, tensor<4x4xf32>, tensor<2x4xf32>) {
+  func.func @main_graph() -> (tensor<2xf32>, tensor<4x4xf32>, tensor<2x4xf32>) {
     // Small: 2 elements (below threshold of 4).
     %small = "onnx.Constant"() {value = dense<[1.0, 2.0]> : tensor<2xf32>} : () -> tensor<2xf32>
     // Splat: 16 elements (above threshold) but splat -- stays inline.

--- a/test/lit/Pipeline/externalize-symbol-sanitize.mlir
+++ b/test/lit/Pipeline/externalize-symbol-sanitize.mlir
@@ -21,7 +21,7 @@
 // CHECK-DAG: memref.global "private" @hip_ext_constant_2{{.*}}hip.external_data
 
 module {
-  func.func @test_sanitize() -> (tensor<2x4xf32>, tensor<2x4xf32>, tensor<2x4xf32>) {
+  func.func @main_graph() -> (tensor<2x4xf32>, tensor<2x4xf32>, tensor<2x4xf32>) {
     %a = "onnx.Constant"() {
       onnx_node_name = "/model/layers.0/Constant",
       value = dense<[[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]]> : tensor<2x4xf32>

--- a/test/lit/Pipeline/module-metadata-dynamic-shapes.mlir
+++ b/test/lit/Pipeline/module-metadata-dynamic-shapes.mlir
@@ -1,0 +1,25 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+//===----------------------------------------------------------------------===//
+// Pipeline test: module metadata with dynamic shapes.
+//
+// Verifies that dynamic dimensions (?) are preserved as -1 in the metadata
+// shape arrays, matching ShapedType::kDynamic.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
+
+// CHECK: module attributes {
+// CHECK-SAME: hipdnn.input_count = 1 : i64
+// CHECK-SAME: hipdnn.input_element_sizes = array<i64: 4>
+// CHECK-SAME: hipdnn.input_shapes = [array<i64: -9223372036854775808, 3, -9223372036854775808>]
+// CHECK-SAME: hipdnn.output_count = 1 : i64
+// CHECK-SAME: hipdnn.output_element_sizes = array<i64: 4>
+// CHECK-SAME: hipdnn.output_shapes = [array<i64: -9223372036854775808, 3, -9223372036854775808>]
+
+module {
+  func.func @main_graph(%arg0: tensor<?x3x?xf32>) -> tensor<?x3x?xf32> {
+    "onnx.Return"(%arg0) {onnx_node_name = "/Return"} : (tensor<?x3x?xf32>) -> ()
+  }
+}

--- a/test/lit/Pipeline/module-metadata-multi-output.mlir
+++ b/test/lit/Pipeline/module-metadata-multi-output.mlir
@@ -1,0 +1,26 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+//===----------------------------------------------------------------------===//
+// Pipeline test: module metadata with multiple outputs.
+//
+// Verifies metadata generation for a @main_graph with two outputs of
+// different shapes and element types.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
+
+// CHECK: module attributes {
+// CHECK-SAME: hipdnn.input_count = 1 : i64
+// CHECK-SAME: hipdnn.input_element_sizes = array<i64: 4>
+// CHECK-SAME: hipdnn.input_shapes = [array<i64: 2, 4>]
+// CHECK-SAME: hipdnn.output_count = 2 : i64
+// CHECK-SAME: hipdnn.output_element_sizes = array<i64: 4, 2>
+// CHECK-SAME: hipdnn.output_shapes = [array<i64: 2, 4>, array<i64: 4>]
+
+module {
+  func.func @main_graph(%arg0: tensor<2x4xf32>) -> (tensor<2x4xf32>, tensor<4xf16>) {
+    %cst = "onnx.Constant"() {value = dense<1.0> : tensor<4xf16>} : () -> tensor<4xf16>
+    "onnx.Return"(%arg0, %cst) {onnx_node_name = "/Return"} : (tensor<2x4xf32>, tensor<4xf16>) -> ()
+  }
+}

--- a/test/lit/Pipeline/module-metadata-no-main-graph.mlir
+++ b/test/lit/Pipeline/module-metadata-no-main-graph.mlir
@@ -1,0 +1,19 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+//===----------------------------------------------------------------------===//
+// Pipeline test: module metadata without @main_graph.
+//
+// Verifies that the pass emits an error when @main_graph is absent, since
+// our pipeline always expects it.
+//===----------------------------------------------------------------------===//
+
+// RUN: not hip-mlir-opt --convert-onnx-to-hip %s 2>&1 | FileCheck %s
+
+// CHECK: error: expected @main_graph function for metadata generation
+
+module {
+  func.func @other_func(%arg0: tensor<2x4xf32>) -> tensor<2x4xf32> {
+    "onnx.Return"(%arg0) {onnx_node_name = "/Return"} : (tensor<2x4xf32>) -> ()
+  }
+}

--- a/test/lit/Pipeline/module-metadata.mlir
+++ b/test/lit/Pipeline/module-metadata.mlir
@@ -1,0 +1,25 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+//===----------------------------------------------------------------------===//
+// Pipeline test: module metadata generation in convert-onnx-to-hip.
+//
+// Verifies that generateModuleMetadata() sets the six hipdnn.* module
+// attributes from @main_graph's original tensor signature before lowering.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
+
+// CHECK: module attributes {
+// CHECK-SAME: hipdnn.input_count = 2 : i64
+// CHECK-SAME: hipdnn.input_element_sizes = array<i64: 2, 4>
+// CHECK-SAME: hipdnn.input_shapes = [array<i64: 1, 3, 16>, array<i64: 1, 3, 16>]
+// CHECK-SAME: hipdnn.output_count = 1 : i64
+// CHECK-SAME: hipdnn.output_element_sizes = array<i64: 2>
+// CHECK-SAME: hipdnn.output_shapes = [array<i64: 1, 3, 16>]
+
+module {
+  func.func @main_graph(%arg0: tensor<1x3x16xf16>, %arg1: tensor<1x3x16xf32>) -> tensor<1x3x16xf16> {
+    "onnx.Return"(%arg0) {onnx_node_name = "/Return"} : (tensor<1x3x16xf16>) -> ()
+  }
+}


### PR DESCRIPTION
## Summary

- Emit `hipdnn.{input,output}_{count,shapes,element_sizes}` module attributes from `@main_graph`'s original function signature before lowering.
- Metadata is captured before the function-processing loop since pattern rewrites change the signature.
- Required by two downstream consumers to be ported next:
  - `HipToLLVM::transformMainFunction()` -- rewrites `@main_graph` into an array-based C ABI wrapper using input/output counts and shapes.
  - `GenerateInterface` pass -- reads all six attributes to generate `inference_init/compute/cleanup/metadata` entry points.

## Test plan

- [x] Build succeeds with no new warnings
- [x] All existing lit tests pass (no regressions)
- Dedicated metadata lit tests deferred; coverage will come with e2e tests when downstream consumers (GenerateInterface, HipToLLVM metadata usage) are ported

Made with [Cursor](https://cursor.com)
