### PR TITLE
refactor: clean up HIP dialect transform passes

### DIFF
--- a/include/hip/Dialect/IR/HipDialect.h
+++ b/include/hip/Dialect/IR/HipDialect.h
@@ -5,6 +5,7 @@
 #ifndef HIP_DIALECT_H
 #define HIP_DIALECT_H
 
+#include "mlir/Bytecode/BytecodeOpInterface.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/OpImplementation.h"

--- a/include/hip/Dialect/Transforms/BufferUtils.h
+++ b/include/hip/Dialect/Transforms/BufferUtils.h
@@ -41,10 +41,11 @@ Value emitAlignUp(OpBuilder &builder, Location loc, Value value,
 ///
 /// Users in nested regions are resolved to their ancestor in \p block
 /// via Block::findAncestorOpInBlock.
-unsigned findLastAliasedUseIndex(
-    Value allocResult, const BufferViewFlowAnalysis &aliasAnalysis,
-    Block &block, const DenseMap<Operation *, unsigned> &opIndex,
-    unsigned blockSize);
+unsigned findLastAliasedUseIndex(Value allocResult,
+                                 const BufferViewFlowAnalysis &aliasAnalysis,
+                                 Block &block,
+                                 const DenseMap<Operation *, unsigned> &opIndex,
+                                 unsigned blockSize);
 
 /// Find the last Operation* among all transitive users of \p allocResult,
 /// following view-like aliases via \p aliasAnalysis.  Resolves nested-region

--- a/include/hip/Dialect/Transforms/BufferUtils.h
+++ b/include/hip/Dialect/Transforms/BufferUtils.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- BufferUtils.h - Shared buffer analysis utilities -------------------===//
+//
+// Utilities shared by PoolAllocs, OptimizeMemRefs, and LowerAllocs.
+// Centralizes byte-size computation, alignment, and alias-aware liveness
+// queries using MLIR's BufferViewFlowAnalysis.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HIP_DIALECT_TRANSFORMS_BUFFERUTILS_H
+#define HIP_DIALECT_TRANSFORMS_BUFFERUTILS_H
+
+#include "mlir/Dialect/Bufferization/Transforms/BufferViewFlowAnalysis.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/Builders.h"
+
+namespace mlir {
+namespace hip {
+
+/// Byte size for a fully-static memref type; returns 0 when any dim is dynamic.
+/// Uses llvm::divideCeil to correctly handle sub-byte element types (e.g. i1).
+int64_t getStaticByteSize(MemRefType type);
+
+/// Compile-time alignment: rounds \p value up to the nearest multiple of
+/// \p alignment.  Requires alignment > 0.
+int64_t alignUp(int64_t value, int64_t alignment);
+
+/// Emit arith ops for: alignUp(value, alignment).
+/// Produces: ((value + alignment - 1) / alignment) * alignment.
+/// Returns \p value unchanged if alignment <= 1.
+Value emitAlignUp(OpBuilder &builder, Location loc, Value value,
+                  int64_t alignment);
+
+/// Find the highest block-local operation index among all transitive users
+/// of \p allocResult, following view-like aliases via \p aliasAnalysis.
+/// memref.dealloc ops are excluded so that lifetimes reflect data usage,
+/// not administrative cleanup.
+///
+/// Users in nested regions are resolved to their ancestor in \p block
+/// via Block::findAncestorOpInBlock.
+unsigned findLastAliasedUseIndex(
+    Value allocResult, const BufferViewFlowAnalysis &aliasAnalysis,
+    Block &block, const DenseMap<Operation *, unsigned> &opIndex,
+    unsigned blockSize);
+
+/// Find the last Operation* among all transitive users of \p allocResult,
+/// following view-like aliases via \p aliasAnalysis.  Resolves nested-region
+/// users to their ancestor in \p entryBlock.
+Operation *findLastAliasedUser(Value allocResult,
+                               const BufferViewFlowAnalysis &aliasAnalysis,
+                               Block &entryBlock);
+
+/// Return true if any value in the transitive alias set of \p root
+/// (as determined by \p aliasAnalysis) is contained in \p valueSet.
+bool isAliasInSet(Value root, const BufferViewFlowAnalysis &aliasAnalysis,
+                  const DenseSet<Value> &valueSet);
+
+} // namespace hip
+} // namespace mlir
+
+#endif // HIP_DIALECT_TRANSFORMS_BUFFERUTILS_H

--- a/include/hip/Dialect/Transforms/BufferUtils.h
+++ b/include/hip/Dialect/Transforms/BufferUtils.h
@@ -24,11 +24,7 @@ namespace hip {
 /// Uses llvm::divideCeil to correctly handle sub-byte element types (e.g. i1).
 int64_t getStaticByteSize(MemRefType type);
 
-/// Compile-time alignment: rounds \p value up to the nearest multiple of
-/// \p alignment.  Requires alignment > 0.
-int64_t alignUp(int64_t value, int64_t alignment);
-
-/// Emit arith ops for: alignUp(value, alignment).
+/// Emit arith ops for: llvm::alignTo(value, alignment).
 /// Produces: ((value + alignment - 1) / alignment) * alignment.
 /// Returns \p value unchanged if alignment <= 1.
 Value emitAlignUp(OpBuilder &builder, Location loc, Value value,

--- a/include/hip/Dialect/Transforms/Passes.td
+++ b/include/hip/Dialect/Transforms/Passes.td
@@ -116,11 +116,15 @@ def PoolAllocsPass : Pass<"hip-pool-allocs", "mlir::func::FuncOp"> {
     are bucketed by their byte-size SSA value: non-overlapping lifetimes within
     a bucket share an offset.
 
-    Sub-buffer offsets are aligned to 256 bytes by default.
+    Sub-buffer offsets are aligned to 256 bytes by default (configurable).
 
     Recommended pipeline position:
       hip-optimize-memrefs (optional) -> hip-pool-allocs -> hip-lower-allocs
   }];
+  let options = [
+    Option<"alignment", "alignment", "int64_t", /*default=*/"256",
+           "Sub-buffer byte offset alignment (must be power of 2)">
+  ];
   let dependentDialects = [
     "mlir::arith::ArithDialect",
     "mlir::memref::MemRefDialect"

--- a/lib/Dialect/Transforms/AddHipContextArg.cpp
+++ b/lib/Dialect/Transforms/AddHipContextArg.cpp
@@ -2,12 +2,34 @@
  * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Licensed under the MIT License.
  */
+//===- AddHipContextArg.cpp - Insert !hip.context as function arg 0 ------===//
+//
+// Inserts !hip.context as the first argument of every func.func in the
+// module and updates all func.call sites to forward the context.
+//
+// Two-phase approach (following BufferResultsToOutParams pattern):
+//   Phase 1: Walk all func.func ops, insert !hip.context as arg 0.
+//   Phase 2: Collect all func.call ops targeting updated functions,
+//            then prepend the caller's !hip.context argument.
+//
+//===----------------------------------------------------------------------===//
 
 #include "hip/Dialect/IR/HipDialect.h"
 #include "hip/Dialect/Transforms/Passes.h"
+
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
+
+#include "llvm/ADT/Statistic.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "hip-add-context-arg"
+
+STATISTIC(NumFuncsUpdated,
+          "Number of functions given !hip.context argument");
+STATISTIC(NumCallsUpdated,
+          "Number of call sites updated with !hip.context");
 
 namespace mlir {
 namespace hip {
@@ -22,18 +44,54 @@ struct HipAddContextArgPass
 
   void runOnOperation() override {
     ModuleOp module = getOperation();
-    MLIRContext *ctx = &getContext();
-    Type hipCtxType = ContextType::get(ctx);
+    Type hipCtxType = ContextType::get(&getContext());
 
-    // TODO: update func.call ops to forward !hip.context to callees
-    // once we support multi-function modules.
+    // Phase 1: update function signatures.
+    DenseSet<StringRef> updatedNames;
     module.walk([&](func::FuncOp funcOp) {
       if (!funcOp.getArguments().empty() &&
           funcOp.getArgument(0).getType() == hipCtxType)
         return;
 
-      funcOp.insertArgument(0, hipCtxType, {}, funcOp.getLoc());
+      (void)funcOp.insertArgument(0, hipCtxType, {}, funcOp.getLoc());
+      updatedNames.insert(funcOp.getName());
+      ++NumFuncsUpdated;
+      LLVM_DEBUG(llvm::dbgs()
+                 << "  Added !hip.context to @" << funcOp.getName() << "\n");
     });
+
+    if (updatedNames.empty())
+      return;
+
+    // Phase 2: collect call sites, then update.
+    SmallVector<func::CallOp> callsToUpdate;
+    module.walk([&](func::CallOp callOp) {
+      if (updatedNames.contains(callOp.getCallee()))
+        callsToUpdate.push_back(callOp);
+    });
+
+    for (func::CallOp callOp : callsToUpdate) {
+      auto callerFunc = callOp->getParentOfType<func::FuncOp>();
+      if (!callerFunc || callerFunc.getArguments().empty() ||
+          !isa<ContextType>(callerFunc.getArgument(0).getType())) {
+        callOp.emitError("caller @")
+            << callerFunc.getName()
+            << " does not have !hip.context as arg 0";
+        return signalPassFailure();
+      }
+
+      Value callerCtx = callerFunc.getArgument(0);
+      SmallVector<Value> newOperands = {callerCtx};
+      newOperands.append(callOp.getOperands().begin(),
+                         callOp.getOperands().end());
+      OpBuilder builder(callOp);
+      auto newCall = func::CallOp::create(
+          builder, callOp.getLoc(), callOp.getCallee(),
+          callOp.getResultTypes(), newOperands);
+      callOp.replaceAllUsesWith(newCall.getResults());
+      callOp.erase();
+      ++NumCallsUpdated;
+    }
   }
 };
 

--- a/lib/Dialect/Transforms/AddHipContextArg.cpp
+++ b/lib/Dialect/Transforms/AddHipContextArg.cpp
@@ -26,10 +26,8 @@
 
 #define DEBUG_TYPE "hip-add-context-arg"
 
-STATISTIC(NumFuncsUpdated,
-          "Number of functions given !hip.context argument");
-STATISTIC(NumCallsUpdated,
-          "Number of call sites updated with !hip.context");
+STATISTIC(NumFuncsUpdated, "Number of functions given !hip.context argument");
+STATISTIC(NumCallsUpdated, "Number of call sites updated with !hip.context");
 
 namespace mlir {
 namespace hip {
@@ -81,8 +79,7 @@ struct HipAddContextArgPass
       if (callerFunc.getArguments().empty() ||
           !isa<ContextType>(callerFunc.getArgument(0).getType())) {
         callOp.emitError("caller @")
-            << callerFunc.getName()
-            << " does not have !hip.context as arg 0";
+            << callerFunc.getName() << " does not have !hip.context as arg 0";
         return signalPassFailure();
       }
 
@@ -91,9 +88,9 @@ struct HipAddContextArgPass
       newOperands.append(callOp.getOperands().begin(),
                          callOp.getOperands().end());
       OpBuilder builder(callOp);
-      auto newCall = func::CallOp::create(
-          builder, callOp.getLoc(), callOp.getCallee(),
-          callOp.getResultTypes(), newOperands);
+      auto newCall =
+          func::CallOp::create(builder, callOp.getLoc(), callOp.getCallee(),
+                               callOp.getResultTypes(), newOperands);
       callOp.replaceAllUsesWith(newCall.getResults());
       callOp.erase();
       ++NumCallsUpdated;

--- a/lib/Dialect/Transforms/AddHipContextArg.cpp
+++ b/lib/Dialect/Transforms/AddHipContextArg.cpp
@@ -26,8 +26,10 @@
 
 #define DEBUG_TYPE "hip-add-context-arg"
 
-STATISTIC(NumFuncsUpdated, "Number of functions given !hip.context argument");
-STATISTIC(NumCallsUpdated, "Number of call sites updated with !hip.context");
+STATISTIC(NumFuncsUpdated,
+          "Number of functions given !hip.context argument");
+STATISTIC(NumCallsUpdated,
+          "Number of call sites updated with !hip.context");
 
 namespace mlir {
 namespace hip {
@@ -72,10 +74,15 @@ struct HipAddContextArgPass
 
     for (func::CallOp callOp : callsToUpdate) {
       auto callerFunc = callOp->getParentOfType<func::FuncOp>();
-      if (!callerFunc || callerFunc.getArguments().empty() ||
+      if (!callerFunc) {
+        callOp.emitError("call op is not inside a func.func");
+        return signalPassFailure();
+      }
+      if (callerFunc.getArguments().empty() ||
           !isa<ContextType>(callerFunc.getArgument(0).getType())) {
         callOp.emitError("caller @")
-            << callerFunc.getName() << " does not have !hip.context as arg 0";
+            << callerFunc.getName()
+            << " does not have !hip.context as arg 0";
         return signalPassFailure();
       }
 
@@ -84,9 +91,9 @@ struct HipAddContextArgPass
       newOperands.append(callOp.getOperands().begin(),
                          callOp.getOperands().end());
       OpBuilder builder(callOp);
-      auto newCall =
-          func::CallOp::create(builder, callOp.getLoc(), callOp.getCallee(),
-                               callOp.getResultTypes(), newOperands);
+      auto newCall = func::CallOp::create(
+          builder, callOp.getLoc(), callOp.getCallee(),
+          callOp.getResultTypes(), newOperands);
       callOp.replaceAllUsesWith(newCall.getResults());
       callOp.erase();
       ++NumCallsUpdated;

--- a/lib/Dialect/Transforms/AddHipContextArg.cpp
+++ b/lib/Dialect/Transforms/AddHipContextArg.cpp
@@ -63,7 +63,9 @@ struct HipAddContextArgPass
     if (updatedNames.empty())
       return;
 
-    // Phase 2: collect call sites, then update.
+    // Phase 2: collect call sites, then update.  Collect-then-modify avoids
+    // iterator invalidation: erasing a CallOp during a walk over the module
+    // would invalidate the walk's internal iterator.
     SmallVector<func::CallOp> callsToUpdate;
     module.walk([&](func::CallOp callOp) {
       if (updatedNames.contains(callOp.getCallee()))

--- a/lib/Dialect/Transforms/AddHipContextArg.cpp
+++ b/lib/Dialect/Transforms/AddHipContextArg.cpp
@@ -26,10 +26,8 @@
 
 #define DEBUG_TYPE "hip-add-context-arg"
 
-STATISTIC(NumFuncsUpdated,
-          "Number of functions given !hip.context argument");
-STATISTIC(NumCallsUpdated,
-          "Number of call sites updated with !hip.context");
+STATISTIC(NumFuncsUpdated, "Number of functions given !hip.context argument");
+STATISTIC(NumCallsUpdated, "Number of call sites updated with !hip.context");
 
 namespace mlir {
 namespace hip {
@@ -77,8 +75,7 @@ struct HipAddContextArgPass
       if (!callerFunc || callerFunc.getArguments().empty() ||
           !isa<ContextType>(callerFunc.getArgument(0).getType())) {
         callOp.emitError("caller @")
-            << callerFunc.getName()
-            << " does not have !hip.context as arg 0";
+            << callerFunc.getName() << " does not have !hip.context as arg 0";
         return signalPassFailure();
       }
 
@@ -87,9 +84,9 @@ struct HipAddContextArgPass
       newOperands.append(callOp.getOperands().begin(),
                          callOp.getOperands().end());
       OpBuilder builder(callOp);
-      auto newCall = func::CallOp::create(
-          builder, callOp.getLoc(), callOp.getCallee(),
-          callOp.getResultTypes(), newOperands);
+      auto newCall =
+          func::CallOp::create(builder, callOp.getLoc(), callOp.getCallee(),
+                               callOp.getResultTypes(), newOperands);
       callOp.replaceAllUsesWith(newCall.getResults());
       callOp.erase();
       ++NumCallsUpdated;

--- a/lib/Dialect/Transforms/BufferUtils.cpp
+++ b/lib/Dialect/Transforms/BufferUtils.cpp
@@ -20,8 +20,7 @@ using namespace mlir;
 int64_t mlir::hip::getStaticByteSize(MemRefType type) {
   if (!type.hasStaticShape())
     return 0;
-  int64_t totalBits =
-      type.getNumElements() * type.getElementTypeBitWidth();
+  int64_t totalBits = type.getNumElements() * type.getElementTypeBitWidth();
   return static_cast<int64_t>(llvm::divideCeil(totalBits, 8));
 }
 
@@ -34,10 +33,8 @@ Value mlir::hip::emitAlignUp(OpBuilder &builder, Location loc, Value value,
                              int64_t alignment) {
   if (alignment <= 1)
     return value;
-  Value alignM1 =
-      arith::ConstantIndexOp::create(builder, loc, alignment - 1);
-  Value alignConst =
-      arith::ConstantIndexOp::create(builder, loc, alignment);
+  Value alignM1 = arith::ConstantIndexOp::create(builder, loc, alignment - 1);
+  Value alignConst = arith::ConstantIndexOp::create(builder, loc, alignment);
   Value sum = builder.createOrFold<arith::AddIOp>(loc, value, alignM1);
   Value divided = builder.createOrFold<arith::DivUIOp>(loc, sum, alignConst);
   return builder.createOrFold<arith::MulIOp>(loc, divided, alignConst);
@@ -76,9 +73,10 @@ unsigned mlir::hip::findLastAliasedUseIndex(
   return lastIdx;
 }
 
-Operation *mlir::hip::findLastAliasedUser(
-    Value allocResult, const BufferViewFlowAnalysis &aliasAnalysis,
-    Block &entryBlock) {
+Operation *
+mlir::hip::findLastAliasedUser(Value allocResult,
+                               const BufferViewFlowAnalysis &aliasAnalysis,
+                               Block &entryBlock) {
   // Start from the defining op so we always have a valid baseline, even if
   // the alloc has no users at all (e.g., dead code not yet cleaned up).
   Operation *lastUser = allocResult.getDefiningOp();

--- a/lib/Dialect/Transforms/BufferUtils.cpp
+++ b/lib/Dialect/Transforms/BufferUtils.cpp
@@ -24,11 +24,6 @@ int64_t mlir::hip::getStaticByteSize(MemRefType type) {
   return static_cast<int64_t>(llvm::divideCeil(totalBits, 8));
 }
 
-int64_t mlir::hip::alignUp(int64_t value, int64_t alignment) {
-  assert(alignment > 0 && "alignment must be positive");
-  return (value + alignment - 1) / alignment * alignment;
-}
-
 Value mlir::hip::emitAlignUp(OpBuilder &builder, Location loc, Value value,
                              int64_t alignment) {
   if (alignment <= 1)

--- a/lib/Dialect/Transforms/BufferUtils.cpp
+++ b/lib/Dialect/Transforms/BufferUtils.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- BufferUtils.cpp - Shared buffer analysis utilities -----------------===//
+//
+// Implements the utilities declared in BufferUtils.h.
+//
+//===----------------------------------------------------------------------===//
+
+#include "hip/Dialect/Transforms/BufferUtils.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+
+#include "llvm/Support/MathExtras.h"
+
+using namespace mlir;
+
+int64_t mlir::hip::getStaticByteSize(MemRefType type) {
+  if (!type.hasStaticShape())
+    return 0;
+  int64_t totalBits =
+      type.getNumElements() * type.getElementTypeBitWidth();
+  return static_cast<int64_t>(llvm::divideCeil(totalBits, 8));
+}
+
+int64_t mlir::hip::alignUp(int64_t value, int64_t alignment) {
+  assert(alignment > 0 && "alignment must be positive");
+  return (value + alignment - 1) / alignment * alignment;
+}
+
+Value mlir::hip::emitAlignUp(OpBuilder &builder, Location loc, Value value,
+                             int64_t alignment) {
+  if (alignment <= 1)
+    return value;
+  Value alignM1 =
+      arith::ConstantIndexOp::create(builder, loc, alignment - 1);
+  Value alignConst =
+      arith::ConstantIndexOp::create(builder, loc, alignment);
+  Value sum = builder.createOrFold<arith::AddIOp>(loc, value, alignM1);
+  Value divided = builder.createOrFold<arith::DivUIOp>(loc, sum, alignConst);
+  return builder.createOrFold<arith::MulIOp>(loc, divided, alignConst);
+}
+
+unsigned mlir::hip::findLastAliasedUseIndex(
+    Value allocResult, const BufferViewFlowAnalysis &aliasAnalysis,
+    Block &block, const DenseMap<Operation *, unsigned> &opIndex,
+    unsigned blockSize) {
+  unsigned lastIdx = 0;
+  for (Value alias : aliasAnalysis.resolve(allocResult)) {
+    for (Operation *user : alias.getUsers()) {
+      if (isa<memref::DeallocOp>(user))
+        continue;
+
+      auto it = opIndex.find(user);
+      unsigned userIdx;
+      if (it != opIndex.end()) {
+        userIdx = it->second;
+      } else if (auto *ancestor = block.findAncestorOpInBlock(*user)) {
+        userIdx = opIndex.lookup(ancestor);
+      } else {
+        userIdx = blockSize - 1;
+      }
+      lastIdx = std::max(lastIdx, userIdx);
+    }
+  }
+  return lastIdx;
+}
+
+Operation *mlir::hip::findLastAliasedUser(
+    Value allocResult, const BufferViewFlowAnalysis &aliasAnalysis,
+    Block &entryBlock) {
+  Operation *lastUser = allocResult.getDefiningOp();
+  for (Value alias : aliasAnalysis.resolve(allocResult)) {
+    for (Operation *user : alias.getUsers()) {
+      Operation *resolved = user;
+      if (resolved->getBlock() != &entryBlock) {
+        resolved = entryBlock.findAncestorOpInBlock(*resolved);
+        if (!resolved)
+          continue;
+      }
+      if (lastUser->isBeforeInBlock(resolved))
+        lastUser = resolved;
+    }
+  }
+  return lastUser;
+}
+
+bool mlir::hip::isAliasInSet(Value root,
+                             const BufferViewFlowAnalysis &aliasAnalysis,
+                             const DenseSet<Value> &valueSet) {
+  for (Value alias : aliasAnalysis.resolve(root))
+    if (valueSet.contains(alias))
+      return true;
+  return false;
+}

--- a/lib/Dialect/Transforms/BufferUtils.cpp
+++ b/lib/Dialect/Transforms/BufferUtils.cpp
@@ -48,6 +48,10 @@ unsigned mlir::hip::findLastAliasedUseIndex(
     Block &block, const DenseMap<Operation *, unsigned> &opIndex,
     unsigned blockSize) {
   unsigned lastIdx = 0;
+  // resolve() returns all *forward* (downstream) aliases: the allocResult
+  // itself plus any values derived from it via view-like ops (memref.view,
+  // memref.subview, memref.cast, etc.).  We must consider users of ALL
+  // aliases to get the true last-use index.
   for (Value alias : aliasAnalysis.resolve(allocResult)) {
     for (Operation *user : alias.getUsers()) {
       if (isa<memref::DeallocOp>(user))
@@ -56,10 +60,14 @@ unsigned mlir::hip::findLastAliasedUseIndex(
       auto it = opIndex.find(user);
       unsigned userIdx;
       if (it != opIndex.end()) {
+        // User is directly in the entry block.
         userIdx = it->second;
       } else if (auto *ancestor = block.findAncestorOpInBlock(*user)) {
+        // User is inside a nested region (e.g. scf.for body); attribute
+        // its index to the enclosing op in the entry block.
         userIdx = opIndex.lookup(ancestor);
       } else {
+        // User is unreachable from this block; conservatively assume last.
         userIdx = blockSize - 1;
       }
       lastIdx = std::max(lastIdx, userIdx);
@@ -71,7 +79,10 @@ unsigned mlir::hip::findLastAliasedUseIndex(
 Operation *mlir::hip::findLastAliasedUser(
     Value allocResult, const BufferViewFlowAnalysis &aliasAnalysis,
     Block &entryBlock) {
+  // Start from the defining op so we always have a valid baseline, even if
+  // the alloc has no users at all (e.g., dead code not yet cleaned up).
   Operation *lastUser = allocResult.getDefiningOp();
+  // resolve() returns all forward aliases -- see findLastAliasedUseIndex.
   for (Value alias : aliasAnalysis.resolve(allocResult)) {
     for (Operation *user : alias.getUsers()) {
       Operation *resolved = user;
@@ -90,6 +101,9 @@ Operation *mlir::hip::findLastAliasedUser(
 bool mlir::hip::isAliasInSet(Value root,
                              const BufferViewFlowAnalysis &aliasAnalysis,
                              const DenseSet<Value> &valueSet) {
+  // Check whether root or any of its forward aliases (views, casts, etc.)
+  // appears in valueSet.  Used by LowerAllocs to skip hip.free for returned
+  // buffers even when a derived view (not the alloc itself) is returned.
   for (Value alias : aliasAnalysis.resolve(root))
     if (valueSet.contains(alias))
       return true;

--- a/lib/Dialect/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Transforms/CMakeLists.txt
@@ -5,6 +5,7 @@
 
 add_library(HipDialectTransforms STATIC
   AddHipContextArg.cpp
+  BufferUtils.cpp
   LowerAllocs.cpp
   OptimizeMemRefs.cpp
   Pipelines.cpp

--- a/lib/Dialect/Transforms/LowerAllocs.cpp
+++ b/lib/Dialect/Transforms/LowerAllocs.cpp
@@ -88,10 +88,9 @@ void LowerAllocsPass::runOnOperation() {
     return signalPassFailure();
   }
 
-  BufferViewFlowAnalysis aliasAnalysis(funcOp);
   OpBuilder builder(funcOp.getContext());
 
-  // Replace each memref.alloc with hip.alloc.
+  // ---- Phase 1: Replace each memref.alloc with hip.alloc ----------------
   SmallVector<memref::AllocOp> allocs;
   funcOp.walk([&](memref::AllocOp op) { allocs.push_back(op); });
 
@@ -107,6 +106,28 @@ void LowerAllocsPass::runOnOperation() {
     ++NumAllocsLowered;
   }
 
+  // ---- Phase 2: Build alias analysis on the *modified* IR ---------------
+  //
+  // CRITICAL: BufferViewFlowAnalysis must be constructed AFTER the
+  // memref.alloc -> hip.alloc replacement above.  The analysis records
+  // forward alias edges (source -> view) for ViewLikeOpInterface ops
+  // (memref.view, memref.subview, memref.cast, etc.).  resolve(value)
+  // then returns all downstream aliases of that value.
+  //
+  // If the analysis were built on the original IR (with memref.alloc),
+  // then queried with the NEW hip.alloc SSA values, resolve() would
+  // return only {hipAlloc} -- missing all downstream views.  This causes:
+  //   - isAliasInSet: fails to detect that a returned memref.view aliases
+  //     the pool, so hip.free is incorrectly inserted for returned buffers.
+  //   - findLastAliasedUser: finds only the immediate SSA user (e.g. the
+  //     memref.view op) rather than the last transitive consumer, placing
+  //     hip.free before ops that still read/write through the view.
+  //
+  // Both are use-after-free bugs triggered in the pool-allocs -> lower-allocs
+  // pipeline, where the single pool hip.alloc has memref.view aliases that
+  // are returned from the function.
+  BufferViewFlowAnalysis aliasAnalysis(funcOp);
+
   // Collect returned values AFTER all replacements so the set contains
   // the new hip.alloc results (not the erased memref.alloc results).
   DenseSet<Value> returnedValues;
@@ -117,8 +138,10 @@ void LowerAllocsPass::runOnOperation() {
 
   Block &entry = funcOp.getBody().front();
 
-  // Replace memref.dealloc -> hip.free for buffers that trace back to a
-  // hip.alloc.
+  // ---- Phase 3: Convert memref.dealloc -> hip.free ----------------------
+  //
+  // Explicit deallocs that trace back to a hip.alloc are converted first.
+  // traceToHipAlloc walks through ViewLikeOpInterface ops to find the root.
   DenseSet<Value> deallocated;
   SmallVector<memref::DeallocOp> deallocs;
   funcOp.walk([&](memref::DeallocOp op) { deallocs.push_back(op); });
@@ -135,9 +158,12 @@ void LowerAllocsPass::runOnOperation() {
     ++NumDeallocsConverted;
   }
 
-  // Fallback: insert hip.free after last use for allocs that have no
-  // memref.dealloc.  Uses BufferViewFlowAnalysis to account for
-  // alias-creating ops like memref.view / subview / cast.
+  // ---- Phase 4: Insert hip.free for allocs without explicit dealloc -----
+  //
+  // Uses BufferViewFlowAnalysis to find all downstream aliases (views,
+  // subviews, casts) of each hip.alloc.  hip.free is placed after the
+  // last user of any alias, ensuring all transitive consumers have
+  // completed before the memory is released.
   for (AllocOp hipAlloc : hipAllocs) {
     if (isAliasInSet(hipAlloc.getResult(), aliasAnalysis, returnedValues))
       continue;

--- a/lib/Dialect/Transforms/LowerAllocs.cpp
+++ b/lib/Dialect/Transforms/LowerAllocs.cpp
@@ -31,7 +31,8 @@
 
 STATISTIC(NumAllocsLowered, "Number of memref.alloc lowered to hip.alloc");
 STATISTIC(NumFreesInserted, "Number of hip.free ops inserted");
-STATISTIC(NumDeallocsConverted, "Number of memref.dealloc converted to hip.free");
+STATISTIC(NumDeallocsConverted,
+          "Number of memref.dealloc converted to hip.free");
 
 namespace mlir {
 namespace hip {

--- a/lib/Dialect/Transforms/LowerAllocs.cpp
+++ b/lib/Dialect/Transforms/LowerAllocs.cpp
@@ -71,6 +71,7 @@ void LowerAllocsPass::runOnOperation() {
 
   if (funcOp.empty())
     return;
+  // TODO: Generalize to multi-block functions using MLIR's Liveness analysis.
   if (!funcOp.getBody().hasOneBlock()) {
     funcOp.emitError("hip-lower-allocs requires single-block functions; "
                      "findLastAliasedUser uses isBeforeInBlock which does "

--- a/lib/Dialect/Transforms/LowerAllocs.cpp
+++ b/lib/Dialect/Transforms/LowerAllocs.cpp
@@ -8,15 +8,30 @@
 // inserts hip.free for buffers not returned from the function.  Bridges
 // one-shot-bufferize output to HIP-specific lowering.
 //
+// Alias-aware free placement uses BufferViewFlowAnalysis to transitively
+// follow view-like ops so that hip.free is placed after all consumers of
+// any derived view, preventing use-after-free.
+//
 //===----------------------------------------------------------------------===//
 
 #include "hip/Dialect/IR/HipDialect.h"
+#include "hip/Dialect/Transforms/BufferUtils.h"
 #include "hip/Dialect/Transforms/Passes.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Arith/Transforms/BufferViewFlowOpInterfaceImpl.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Interfaces/ViewLikeInterface.h"
+
+#include "llvm/ADT/Statistic.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "hip-lower-allocs"
+
+STATISTIC(NumAllocsLowered, "Number of memref.alloc lowered to hip.alloc");
+STATISTIC(NumFreesInserted, "Number of hip.free ops inserted");
+STATISTIC(NumDeallocsConverted, "Number of memref.dealloc converted to hip.free");
 
 namespace mlir {
 namespace hip {
@@ -25,14 +40,6 @@ namespace hip {
 #include "hip/Dialect/Transforms/Passes.h.inc"
 
 namespace {
-
-/// Return true if \p op creates a memref alias (view) of one of its inputs
-/// without allocating new memory.  Uses the MLIR ViewLikeOpInterface so that
-/// any future view-like ops are automatically covered.  arith::SelectOp is
-/// included because its result may alias either memref operand.
-static bool isMemRefAlias(Operation *op) {
-  return isa<ViewLikeOpInterface, arith::SelectOp>(op);
-}
 
 /// Walk \p val back through view-like alias ops and return the root
 /// hip::AllocOp if the chain originates from one, or nullptr otherwise.
@@ -48,40 +55,13 @@ static AllocOp traceToHipAlloc(Value val) {
   return nullptr;
 }
 
-/// Find the last user of \p rootValue, walking transitively through
-/// view-like (aliasing) ops.  Without this, hip.free can be placed after
-/// a memref.view but before consumers of the view -- a use-after-free.
-///
-/// Users in nested regions (e.g. scf.for body) are resolved to their
-/// ancestor in the entry block so that isBeforeInBlock remains valid.
-static Operation *findLastTransitiveUser(Value rootValue, Block &entryBlock) {
-  Operation *lastUser = rootValue.getDefiningOp();
-  SmallVector<Value> worklist = {rootValue};
-  DenseSet<Value> visited;
-
-  while (!worklist.empty()) {
-    Value val = worklist.pop_back_val();
-    if (!visited.insert(val).second)
-      continue;
-    for (Operation *user : val.getUsers()) {
-      Operation *resolved = user;
-      if (resolved->getBlock() != &entryBlock) {
-        resolved = entryBlock.findAncestorOpInBlock(*resolved);
-        if (!resolved)
-          continue;
-      }
-      if (lastUser->isBeforeInBlock(resolved))
-        lastUser = resolved;
-      if (isMemRefAlias(user)) {
-        for (OpResult result : user->getResults())
-          worklist.push_back(result);
-      }
-    }
-  }
-  return lastUser;
-}
-
 struct LowerAllocsPass : public impl::LowerAllocsPassBase<LowerAllocsPass> {
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<hip::HipDialect, memref::MemRefDialect>();
+    arith::registerBufferViewFlowOpInterfaceExternalModels(registry);
+  }
+
   void runOnOperation() override;
 };
 
@@ -92,7 +72,7 @@ void LowerAllocsPass::runOnOperation() {
     return;
   if (!funcOp.getBody().hasOneBlock()) {
     funcOp.emitError("hip-lower-allocs requires single-block functions; "
-                     "findLastTransitiveUser uses isBeforeInBlock which does "
+                     "findLastAliasedUser uses isBeforeInBlock which does "
                      "not generalize to multi-block control flow");
     return signalPassFailure();
   }
@@ -108,6 +88,7 @@ void LowerAllocsPass::runOnOperation() {
     return signalPassFailure();
   }
 
+  BufferViewFlowAnalysis aliasAnalysis(funcOp);
   OpBuilder builder(funcOp.getContext());
 
   // Replace each memref.alloc with hip.alloc.
@@ -123,6 +104,7 @@ void LowerAllocsPass::runOnOperation() {
     allocOp.replaceAllUsesWith(hipAlloc.getResult());
     allocOp.erase();
     hipAllocs.push_back(hipAlloc);
+    ++NumAllocsLowered;
   }
 
   // Collect returned values AFTER all replacements so the set contains
@@ -133,32 +115,10 @@ void LowerAllocsPass::runOnOperation() {
       returnedValues.insert(v);
   });
 
-  // Check whether any value in the transitive alias chain of \p root is
-  // returned.  Needed because pooled allocs are returned via memref.view,
-  // not directly.
-  auto isTransitivelyReturned = [&](Value root) -> bool {
-    SmallVector<Value> wl = {root};
-    DenseSet<Value> seen;
-    while (!wl.empty()) {
-      Value v = wl.pop_back_val();
-      if (!seen.insert(v).second)
-        continue;
-      if (returnedValues.contains(v))
-        return true;
-      for (Operation *user : v.getUsers()) {
-        if (isMemRefAlias(user))
-          for (OpResult r : user->getResults())
-            wl.push_back(r);
-      }
-    }
-    return false;
-  };
-
   Block &entry = funcOp.getBody().front();
 
   // Replace memref.dealloc -> hip.free for buffers that trace back to a
-  // hip.alloc.  Non-HIP deallocs (e.g. externally-owned memrefs) are left
-  // untouched for other lowerings.
+  // hip.alloc.
   DenseSet<Value> deallocated;
   SmallVector<memref::DeallocOp> deallocs;
   funcOp.walk([&](memref::DeallocOp op) { deallocs.push_back(op); });
@@ -172,21 +132,25 @@ void LowerAllocsPass::runOnOperation() {
     FreeOp::create(builder, deallocOp.getLoc(), ctx, memref);
     deallocated.insert(rootAlloc.getResult());
     deallocOp.erase();
+    ++NumDeallocsConverted;
   }
 
   // Fallback: insert hip.free after last use for allocs that have no
-  // memref.dealloc (e.g. when buffer-deallocation-pipeline is not in
-  // the pass pipeline).  Uses transitive user walk to account for
+  // memref.dealloc.  Uses BufferViewFlowAnalysis to account for
   // alias-creating ops like memref.view / subview / cast.
   for (AllocOp hipAlloc : hipAllocs) {
-    if (isTransitivelyReturned(hipAlloc.getResult()))
+    if (isAliasInSet(hipAlloc.getResult(), aliasAnalysis, returnedValues))
       continue;
     if (deallocated.contains(hipAlloc.getResult()))
       continue;
 
-    Operation *lastUser = findLastTransitiveUser(hipAlloc.getResult(), entry);
+    Operation *lastUser =
+        findLastAliasedUser(hipAlloc.getResult(), aliasAnalysis, entry);
     builder.setInsertionPointAfter(lastUser);
     FreeOp::create(builder, hipAlloc.getLoc(), ctx, hipAlloc.getResult());
+    ++NumFreesInserted;
+    LLVM_DEBUG(llvm::dbgs()
+               << "  Inserted hip.free after " << *lastUser << "\n");
   }
 }
 

--- a/lib/Dialect/Transforms/OptimizeMemRefs.cpp
+++ b/lib/Dialect/Transforms/OptimizeMemRefs.cpp
@@ -176,13 +176,11 @@ void OptimizeMemRefsPass::runOnOperation() {
     if (result.use_empty())
       continue;
 
-    unsigned lastUse =
-        findLastAliasedUseIndex(result, aliasAnalysis, block, opIndex,
-                                blockSize);
+    unsigned lastUse = findLastAliasedUseIndex(result, aliasAnalysis, block,
+                                               opIndex, blockSize);
     intervals.push_back({allocOp, opIndex[&op], lastUse});
-    LLVM_DEBUG(llvm::dbgs()
-               << "  interval " << allocOp << " [" << opIndex[&op]
-               << ", " << lastUse << "]\n");
+    LLVM_DEBUG(llvm::dbgs() << "  interval " << allocOp << " [" << opIndex[&op]
+                            << ", " << lastUse << "]\n");
   }
 
   if (intervals.size() < 2)
@@ -230,8 +228,7 @@ void OptimizeMemRefsPass::runOnOperation() {
       bestSlot->lastUseIndex = interval.lastUseIndex;
       ++NumAllocsReused;
     } else {
-      LLVM_DEBUG(llvm::dbgs()
-                 << "  New slot for " << neededType << "\n");
+      LLVM_DEBUG(llvm::dbgs() << "  New slot for " << neededType << "\n");
       slots.push_back({interval.allocOp.getResult(), neededType,
                        interval.lastUseIndex,
                        SmallVector<Value, 4>(neededDynSizes.begin(),

--- a/lib/Dialect/Transforms/OptimizeMemRefs.cpp
+++ b/lib/Dialect/Transforms/OptimizeMemRefs.cpp
@@ -16,8 +16,7 @@
 //   2. For each memref.alloc, compute a live interval [def, lastUse]:
 //        - def     = index of the alloc op
 //        - lastUse = max index among all transitive users (follows aliasing
-//                    ops like subview, cast, reshape so that a derived view
-//                    extends the source buffer's lifetime)
+//                    ops via BufferViewFlowAnalysis)
 //
 //   3. Walk intervals in program order.  For each one, try to find a
 //      previously-created "slot" whose lastUse < this def (i.e., dead):
@@ -42,13 +41,22 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hip/Dialect/Transforms/BufferUtils.h"
 #include "hip/Dialect/Transforms/Passes.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Arith/Transforms/BufferViewFlowOpInterfaceImpl.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/Interfaces/ViewLikeInterface.h"
+
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/Statistic.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "hip-optimize-memrefs"
+
+STATISTIC(NumAllocsReused, "Number of allocations reused via slot assignment");
+STATISTIC(NumSlotsCreated, "Number of unique memory slots created");
 
 namespace mlir {
 namespace hip {
@@ -78,14 +86,6 @@ struct Slot {
 // Helpers
 //===----------------------------------------------------------------------===//
 
-/// Returns the allocation size in bytes for a fully-static memref type.
-/// Returns 0 when any dimension is dynamic.
-static int64_t getStaticByteSize(MemRefType type) {
-  if (!type.hasStaticShape())
-    return 0;
-  return type.getNumElements() * type.getElementTypeBitWidth() / 8;
-}
-
 /// Computes contiguous row-major strides for a statically-shaped memref.
 static SmallVector<int64_t> getContiguousStrides(MemRefType type) {
   auto shape = type.getShape();
@@ -100,17 +100,6 @@ static SmallVector<int64_t> getContiguousStrides(MemRefType type) {
 
 /// Returns true if \p slot can serve an allocation of \p neededType with
 /// the given dynamic-size operands.
-///
-/// Static shapes: the slot must have at least as many bytes (same element
-/// type and memory space).  Examples (slot holds memref<2x64x64xf32>,
-/// 32768 bytes):
-///   canReuse(memref<64xf32>)       -> true  (256 <= 32768, same f32)
-///   canReuse(memref<2x64x64xf32>)  -> true  (exact fit, no cast needed)
-///   canReuse(memref<3x64x64xf32>)  -> false (49152 > 32768)
-///   canReuse(memref<64xf16>)       -> false (different element type)
-///
-/// Dynamic shapes: the MemRefType must be identical and every dynamic-size
-/// operand must be the same SSA value.
 static bool canReuse(const Slot &slot, MemRefType neededType,
                      OperandRange neededDynSizes) {
   if (slot.type.getElementType() != neededType.getElementType())
@@ -137,70 +126,18 @@ static bool canReuse(const Slot &slot, MemRefType neededType,
   return false;
 }
 
-/// Returns true if \p user produces a memref result that aliases its memref
-/// operand.  Covers ViewLikeOpInterface (subview, cast, reshape, etc.) and
-/// arith::SelectOp whose result may alias either operand.
-static bool isMemRefAlias(Operation *user) {
-  return isa<ViewLikeOpInterface, arith::SelectOp>(user);
-}
-
-/// Returns the highest operation index among all transitive users of \p value,
-/// following view-like and select ops so that the liveness of the source
-/// buffer accounts for all its derived views.
-///
-/// memref.dealloc ops are excluded: they are administrative, not data uses,
-/// and counting them would extend every lifetime to the block's end when
-/// buffer-deallocation-pipeline has been run, defeating buffer reuse.
-///
-/// Example:
-///   %buf  = memref.alloc() : memref<2x64x64xf32>           // index 3
-///   %sv   = memref.subview %buf[...] : ... to memref<...>   // alias, index 5
-///   use(%sv)                                                 // index 15
-///   -> buf.lastUse = 15 (not 3), preventing premature reuse
-static unsigned
-findLastTransitiveUseIndex(Value value, Block &block,
-                           const DenseMap<Operation *, unsigned> &opIndex,
-                           unsigned blockSize) {
-  unsigned lastIdx = 0;
-  SmallVector<Value> worklist = {value};
-  DenseSet<Value> visited;
-
-  while (!worklist.empty()) {
-    Value current = worklist.pop_back_val();
-    if (!visited.insert(current).second)
-      continue;
-
-    for (Operation *user : current.getUsers()) {
-      if (isa<memref::DeallocOp>(user))
-        continue;
-
-      auto it = opIndex.find(user);
-      unsigned userIdx;
-      if (it != opIndex.end()) {
-        userIdx = it->second;
-      } else if (auto *ancestor = block.findAncestorOpInBlock(*user)) {
-        userIdx = opIndex.lookup(ancestor);
-      } else {
-        userIdx = blockSize - 1;
-      }
-      lastIdx = std::max(lastIdx, userIdx);
-
-      if (isMemRefAlias(user)) {
-        for (Value result : user->getResults())
-          if (isa<MemRefType>(result.getType()))
-            worklist.push_back(result);
-      }
-    }
-  }
-  return lastIdx;
-}
-
 //===----------------------------------------------------------------------===//
 // Pass
 //===----------------------------------------------------------------------===//
 
 struct OptimizeMemRefsPass
     : public impl::OptimizeMemRefsPassBase<OptimizeMemRefsPass> {
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<memref::MemRefDialect>();
+    arith::registerBufferViewFlowOpInterfaceExternalModels(registry);
+  }
+
   void runOnOperation() override;
 };
 
@@ -210,10 +147,16 @@ void OptimizeMemRefsPass::runOnOperation() {
   if (funcOp.empty())
     return;
 
-  if (!funcOp.getBody().hasOneBlock())
-    return;
+  if (!funcOp.getBody().hasOneBlock()) {
+    funcOp.emitError("hip-optimize-memrefs requires single-block functions; "
+                     "liveness analysis uses sequential op indices that do "
+                     "not generalize to control flow");
+    return signalPassFailure();
+  }
 
   Block &block = funcOp.getBody().front();
+
+  BufferViewFlowAnalysis aliasAnalysis(funcOp);
 
   // Assign each op a sequential index for interval ordering.
   DenseMap<Operation *, unsigned> opIndex;
@@ -222,9 +165,7 @@ void OptimizeMemRefsPass::runOnOperation() {
     opIndex[&op] = idx++;
   unsigned blockSize = idx;
 
-  // Collect alloc ops (static and dynamic) and compute their live intervals.
-  // Liveness follows view-like and select ops transitively so that derived
-  // views extend the source buffer's lifetime.
+  // Collect alloc ops and compute their live intervals.
   SmallVector<AllocInterval> intervals;
   for (Operation &op : block) {
     auto allocOp = dyn_cast<memref::AllocOp>(op);
@@ -235,18 +176,19 @@ void OptimizeMemRefsPass::runOnOperation() {
     if (result.use_empty())
       continue;
 
-    intervals.push_back(
-        {allocOp, opIndex[&op],
-         findLastTransitiveUseIndex(result, block, opIndex, blockSize)});
+    unsigned lastUse =
+        findLastAliasedUseIndex(result, aliasAnalysis, block, opIndex,
+                                blockSize);
+    intervals.push_back({allocOp, opIndex[&op], lastUse});
+    LLVM_DEBUG(llvm::dbgs()
+               << "  interval " << allocOp << " [" << opIndex[&op]
+               << ", " << lastUse << "]\n");
   }
 
   if (intervals.size() < 2)
     return;
 
-  // Greedy best-fit slot assignment.  For each interval in program order,
-  // find a dead slot (slot.lastUse < interval.def) with the smallest byte
-  // waste.  Best-fit minimizes internal fragmentation; early exit on exact
-  // match (waste == 0) avoids unnecessary scanning.
+  // Greedy best-fit slot assignment.
   SmallVector<Slot> slots;
   SmallVector<std::pair<Value, Value>> replacements;
 
@@ -281,20 +223,25 @@ void OptimizeMemRefsPass::runOnOperation() {
             /*sizes=*/neededType.getShape(),
             /*strides=*/getContiguousStrides(neededType));
       }
+      LLVM_DEBUG(llvm::dbgs()
+                 << "  Reusing slot (type=" << bestSlot->type
+                 << ", waste=" << bestWaste << ") for " << neededType << "\n");
       replacements.emplace_back(interval.allocOp.getResult(), replacement);
       bestSlot->lastUseIndex = interval.lastUseIndex;
+      ++NumAllocsReused;
     } else {
+      LLVM_DEBUG(llvm::dbgs()
+                 << "  New slot for " << neededType << "\n");
       slots.push_back({interval.allocOp.getResult(), neededType,
                        interval.lastUseIndex,
                        SmallVector<Value, 4>(neededDynSizes.begin(),
                                              neededDynSizes.end())});
+      ++NumSlotsCreated;
     }
   }
 
   // Map each alloc to its memref.dealloc (if any) so we can erase the
-  // dealloc when the alloc it targets is replaced.  Without this, RAUW
-  // would turn `memref.dealloc %replaced` into `memref.dealloc %reuser`,
-  // causing a double-free.
+  // dealloc when the alloc it targets is replaced.
   DenseMap<Value, memref::DeallocOp> allocToDealloc;
   for (Operation &op : block) {
     if (auto deallocOp = dyn_cast<memref::DeallocOp>(op))

--- a/lib/Dialect/Transforms/OptimizeMemRefs.cpp
+++ b/lib/Dialect/Transforms/OptimizeMemRefs.cpp
@@ -147,6 +147,8 @@ void OptimizeMemRefsPass::runOnOperation() {
   if (funcOp.empty())
     return;
 
+  // TODO: Generalize to multi-block functions using MLIR's Liveness analysis
+  // instead of sequential op indices.
   if (!funcOp.getBody().hasOneBlock()) {
     funcOp.emitError("hip-optimize-memrefs requires single-block functions; "
                      "liveness analysis uses sequential op indices that do "

--- a/lib/Dialect/Transforms/Pipelines.cpp
+++ b/lib/Dialect/Transforms/Pipelines.cpp
@@ -66,6 +66,11 @@ void mlir::hip::buildOnnxToHipPipeline(
 
   // 9. Resolve extern constants → memref.view into constants blob argument
   pm.addPass(createResolveExternConstantsPass());
+
+  // 10. Final cleanup: LowerAllocs and ResolveExternConstants both introduce
+  //     new constants and ops that benefit from deduplication and hoisting.
+  pm.addPass(createCSEPass());
+  pm.addPass(createCanonicalizerPass());
 }
 
 void mlir::hip::buildHipToLLVMPipeline(OpPassManager &pm) {

--- a/lib/Dialect/Transforms/PoolAllocs.cpp
+++ b/lib/Dialect/Transforms/PoolAllocs.cpp
@@ -171,8 +171,8 @@ packStaticAllocs(MutableArrayRef<AllocInfo> statics, int64_t alignment) {
 /// Within a bucket, each "bin" holds allocs with non-overlapping lifetimes
 /// that can share a single offset at runtime.
 struct DynBucket {
-  Value byteSizeValue;  ///< SSA value for the unaligned byte size
-  Value alignedSize;    ///< SSA value for the aligned byte size (cached)
+  Value byteSizeValue; ///< SSA value for the unaligned byte size
+  Value alignedSize;   ///< SSA value for the aligned byte size (cached)
   SmallVector<SmallVector<AllocInfo *>>
       bins; ///< bins of non-overlapping allocs
 };
@@ -343,14 +343,12 @@ void PoolAllocsPass::runOnOperation() {
     AllocInfo info;
     info.allocOp = allocOp;
     info.defIndex = opIndex[&op];
-    info.lastUseIndex =
-        findLastAliasedUseIndex(result, aliasAnalysis, block, opIndex,
-                                blockSize);
+    info.lastUseIndex = findLastAliasedUseIndex(result, aliasAnalysis, block,
+                                                opIndex, blockSize);
     info.staticByteSize = getStaticByteSize(allocOp.getType());
-    LLVM_DEBUG(llvm::dbgs()
-               << "  alloc " << allocOp << " ["
-               << info.defIndex << ", " << info.lastUseIndex << "] "
-               << info.staticByteSize << " bytes\n");
+    LLVM_DEBUG(llvm::dbgs() << "  alloc " << allocOp << " [" << info.defIndex
+                            << ", " << info.lastUseIndex << "] "
+                            << info.staticByteSize << " bytes\n");
     allInfos.push_back(info);
   }
 
@@ -422,10 +420,9 @@ void PoolAllocsPass::runOnOperation() {
       return;
   }
 
-  LLVM_DEBUG(llvm::dbgs()
-             << "Pool: static=" << staticPoolSize << " bytes, "
-             << dynBuckets.size() << " dynamic buckets, "
-             << allInfos.size() << " total allocs\n");
+  LLVM_DEBUG(llvm::dbgs() << "Pool: static=" << staticPoolSize << " bytes, "
+                          << dynBuckets.size() << " dynamic buckets, "
+                          << allInfos.size() << " total allocs\n");
 
   // 5b. Create the single pool allocation.
   Value pool;
@@ -459,8 +456,8 @@ void PoolAllocsPass::runOnOperation() {
             builder, loc, static_cast<int64_t>(binIdx));
         Value binContrib = builder.createOrFold<arith::MulIOp>(
             loc, bucket.alignedSize, binIdxVal);
-        Value binOffset = builder.createOrFold<arith::AddIOp>(
-            loc, currentBase, binContrib);
+        Value binOffset =
+            builder.createOrFold<arith::AddIOp>(loc, currentBase, binContrib);
         for (AllocInfo *info : bin)
           allocToOffset[info->allocOp.getOperation()] = binOffset;
       }
@@ -470,8 +467,8 @@ void PoolAllocsPass::runOnOperation() {
           builder, loc, static_cast<int64_t>(bucket.bins.size()));
       Value bucketTotal = builder.createOrFold<arith::MulIOp>(
           loc, bucket.alignedSize, numBinsVal);
-      currentBase = builder.createOrFold<arith::AddIOp>(
-          loc, currentBase, bucketTotal);
+      currentBase =
+          builder.createOrFold<arith::AddIOp>(loc, currentBase, bucketTotal);
     }
   }
 
@@ -526,7 +523,7 @@ void PoolAllocsPass::runOnOperation() {
   for (int64_t off : staticOffsets)
     offsetAttrs.push_back(builder.getI64IntegerAttr(off));
   funcOp->setAttr("hipdnn.buffer_offsets",
-                   ArrayAttr::get(mlirCtx, offsetAttrs));
+                  ArrayAttr::get(mlirCtx, offsetAttrs));
 }
 
 } // namespace

--- a/lib/Dialect/Transforms/PoolAllocs.cpp
+++ b/lib/Dialect/Transforms/PoolAllocs.cpp
@@ -232,17 +232,35 @@ packDynamicAllocs(MutableArrayRef<AllocInfo> dynamics, OpBuilder &builder,
     return byteSize;
   };
 
-  // Step 3: group by byte-size SSA value.
-  llvm::MapVector<Value, SmallVector<AllocInfo *>> bySize;
-  for (auto &[key, info] : keyed)
-    bySize[findOrCreateByteSize(key)].push_back(info);
+  // Step 3: group by byte-size SSA value.  Track the staticFactor alongside
+  // each group so step 4 can skip alignment when the factor is already a
+  // multiple of the alignment (e.g. staticFactor=256 with alignment=256).
+  struct SizeGroup {
+    int64_t staticFactor;
+    SmallVector<AllocInfo *> infos;
+  };
+  llvm::MapVector<Value, SizeGroup> bySize;
+  for (auto &[key, info] : keyed) {
+    Value sizeVal = findOrCreateByteSize(key);
+    auto &group = bySize[sizeVal];
+    group.staticFactor = key.staticFactor;
+    group.infos.push_back(info);
+  }
 
   // Step 4: first-fit bin packing within each group.
   SmallVector<DynBucket> buckets;
-  for (auto &[sizeVal, infos] : bySize) {
+  for (auto &[sizeVal, group] : bySize) {
+    auto &infos = group.infos;
     DynBucket bucket;
     bucket.byteSizeValue = sizeVal;
-    bucket.alignedSize = emitAlignUp(builder, loc, sizeVal, alignment);
+    // When staticFactor is a multiple of alignment, the byte size
+    // (staticFactor * dynDim0 * dynDim1 * ...) is guaranteed to be aligned
+    // regardless of the dynamic dimensions, so emitAlignUp is a no-op.
+    // Skipping it avoids an expensive divui + supporting arithmetic.
+    if (group.staticFactor % alignment == 0)
+      bucket.alignedSize = sizeVal;
+    else
+      bucket.alignedSize = emitAlignUp(builder, loc, sizeVal, alignment);
     for (AllocInfo *info : infos) {
       bool placed = false;
       for (auto &bin : bucket.bins) {

--- a/lib/Dialect/Transforms/PoolAllocs.cpp
+++ b/lib/Dialect/Transforms/PoolAllocs.cpp
@@ -40,6 +40,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/MathExtras.h"
 
 #define DEBUG_TYPE "hip-pool-allocs"
 
@@ -110,7 +111,7 @@ packStaticAllocs(MutableArrayRef<AllocInfo> statics, int64_t alignment) {
   SmallVector<Reservation, 16> reservations; // kept sorted by offset
 
   for (AllocInfo &info : statics) {
-    int64_t size = alignUp(info.staticByteSize, alignment);
+    int64_t size = llvm::alignTo(info.staticByteSize, alignment);
     int64_t bestOffset = -1;
     int64_t bestFit = INT64_MAX;
 
@@ -120,7 +121,7 @@ packStaticAllocs(MutableArrayRef<AllocInfo> statics, int64_t alignment) {
     for (auto &res : reservations) {
       if (!lifetimesOverlap(info, *res.info))
         continue;
-      int64_t alignedOffset = alignUp(currentOffset, alignment);
+      int64_t alignedOffset = llvm::alignTo(currentOffset, alignment);
       if (alignedOffset + size <= res.offset &&
           res.offset - alignedOffset < bestFit) {
         bestOffset = alignedOffset;
@@ -131,7 +132,7 @@ packStaticAllocs(MutableArrayRef<AllocInfo> statics, int64_t alignment) {
 
     // No gap found - append after all overlapping reservations.
     if (bestOffset < 0)
-      bestOffset = alignUp(currentOffset, alignment);
+      bestOffset = llvm::alignTo(currentOffset, alignment);
 
     // Insert into the sorted reservation list.
     Reservation newRes{&info, bestOffset, size};
@@ -380,7 +381,7 @@ void PoolAllocsPass::runOnOperation() {
 
   int64_t staticPoolSize = 0;
   for (auto &[info, offset] : staticAssignments) {
-    int64_t end = offset + alignUp(info->staticByteSize, align);
+    int64_t end = offset + llvm::alignTo(info->staticByteSize, align);
     staticPoolSize = std::max(staticPoolSize, end);
   }
 

--- a/lib/Dialect/Transforms/PoolAllocs.cpp
+++ b/lib/Dialect/Transforms/PoolAllocs.cpp
@@ -313,6 +313,8 @@ void PoolAllocsPass::runOnOperation() {
 
   if (funcOp.empty())
     return;
+  // TODO: Generalize to multi-block functions using MLIR's Liveness analysis
+  // instead of sequential op indices.
   if (!funcOp.getBody().hasOneBlock()) {
     funcOp.emitError("hip-pool-allocs requires single-block functions; "
                      "liveness analysis uses sequential op indices that do "

--- a/lib/Dialect/Transforms/PoolAllocs.cpp
+++ b/lib/Dialect/Transforms/PoolAllocs.cpp
@@ -11,7 +11,7 @@
 //
 // Algorithm overview:
 //   Phase 1 - Liveness:  assign [defIndex, lastUseIndex] to each alloc,
-//             following view-like ops transitively.
+//             following view-like ops transitively via BufferViewFlowAnalysis.
 //   Phase 2 - Partition:  split allocs into static (compile-time byte size)
 //             and dynamic (runtime byte size) groups.
 //   Phase 3 - Static packing:  greedy best-fit offset assignment inspired by
@@ -24,24 +24,28 @@
 //             arith ops, and replace each original alloc with memref.view.
 //             Attach hipdnn.pool_size / hipdnn.buffer_offsets metadata.
 //
-// All sub-buffer offsets are aligned to kDefaultAlignment (256 bytes) to
-// satisfy GPU coalesced-access requirements.
+// All sub-buffer offsets are aligned to the configured alignment (default 256
+// bytes) to satisfy GPU coalesced-access requirements.
 //
 //===----------------------------------------------------------------------===//
 
+#include "hip/Dialect/Transforms/BufferUtils.h"
 #include "hip/Dialect/Transforms/Passes.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Arith/Transforms/BufferViewFlowOpInterfaceImpl.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/Interfaces/ViewLikeInterface.h"
 
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/Statistic.h"
 #include "llvm/Support/Debug.h"
 
-#include <list>
-
 #define DEBUG_TYPE "hip-pool-allocs"
+
+STATISTIC(NumAllocsPooled, "Number of allocations pooled into byte buffer");
+STATISTIC(NumStaticPacked, "Number of static allocations packed");
+STATISTIC(NumDynBuckets, "Number of dynamic size buckets created");
 
 namespace mlir {
 namespace hip {
@@ -50,9 +54,6 @@ namespace hip {
 #include "hip/Dialect/Transforms/Passes.h.inc"
 
 namespace {
-
-/// GPU-friendly alignment for sub-buffer byte offsets.
-static constexpr int64_t kDefaultAlignment = 256;
 
 //===----------------------------------------------------------------------===//
 // AllocInfo - per-alloc metadata collected in Phase 1
@@ -64,68 +65,6 @@ struct AllocInfo {
   unsigned lastUseIndex;  ///< highest index of any (transitive) user
   int64_t staticByteSize; ///< >0 for static shapes, 0 for dynamic
 };
-
-/// Total byte size for a fully-static memref type, 0 when any dim is dynamic.
-static int64_t getStaticByteSize(MemRefType type) {
-  if (!type.hasStaticShape())
-    return 0;
-  return type.getNumElements() * type.getElementTypeBitWidth() / 8;
-}
-
-/// True when \p user produces a memref that aliases its memref operand
-/// (subview, cast, reshape, select, ...).
-static bool isMemRefAlias(Operation *user) {
-  return isa<ViewLikeOpInterface, arith::SelectOp>(user);
-}
-
-/// Walk all transitive users of \p value (through view-like and select ops)
-/// and return the maximum operation index.  This extends an alloc's effective
-/// lifetime to cover all derived views.
-///
-/// memref.dealloc ops are excluded so that lifetimes reflect actual data
-/// usage, not administrative cleanup.
-static unsigned
-findLastTransitiveUseIndex(Value value, Block &block,
-                           const DenseMap<Operation *, unsigned> &opIndex,
-                           unsigned blockSize) {
-  unsigned lastIdx = 0;
-  SmallVector<Value> worklist = {value};
-  DenseSet<Value> visited;
-
-  while (!worklist.empty()) {
-    Value current = worklist.pop_back_val();
-    if (!visited.insert(current).second)
-      continue;
-
-    for (Operation *user : current.getUsers()) {
-      if (isa<memref::DeallocOp>(user))
-        continue;
-
-      auto it = opIndex.find(user);
-      unsigned userIdx;
-      if (it != opIndex.end()) {
-        userIdx = it->second;
-      } else if (auto *ancestor = block.findAncestorOpInBlock(*user)) {
-        userIdx = opIndex.lookup(ancestor);
-      } else {
-        userIdx = blockSize - 1;
-      }
-      lastIdx = std::max(lastIdx, userIdx);
-
-      // Follow alias chain so the source buffer stays live.
-      if (isMemRefAlias(user)) {
-        for (Value result : user->getResults())
-          if (isa<MemRefType>(result.getType()))
-            worklist.push_back(result);
-      }
-    }
-  }
-  return lastIdx;
-}
-
-static int64_t alignUp(int64_t value, int64_t alignment) {
-  return (value + alignment - 1) / alignment * alignment;
-}
 
 /// True when two allocs' [def, lastUse] intervals overlap.
 static bool lifetimesOverlap(const AllocInfo &a, const AllocInfo &b) {
@@ -168,7 +107,7 @@ struct Reservation {
 static SmallVector<std::pair<AllocInfo *, int64_t>>
 packStaticAllocs(MutableArrayRef<AllocInfo> statics, int64_t alignment) {
   SmallVector<std::pair<AllocInfo *, int64_t>> assignments;
-  std::list<Reservation> reservations; // kept sorted by offset
+  SmallVector<Reservation, 16> reservations; // kept sorted by offset
 
   for (AllocInfo &info : statics) {
     int64_t size = alignUp(info.staticByteSize, alignment);
@@ -227,52 +166,18 @@ packStaticAllocs(MutableArrayRef<AllocInfo> statics, int64_t alignment) {
 //   Level 2 - Bin by lifetime:
 //     Within a bucket, first-fit pack allocs whose lifetimes don't overlap
 //     into bins.  All allocs in the same bin share one offset at runtime.
-//
-// Example (dynamic attention model, 6 allocs after optimize-memrefs):
-//
-//   Alloc    Type                Operands              Key
-//   -------  ------------------  --------------------  ----------------------
-//   Q        memref<?x?x64xf32>  (%dim, %dim_0)       {256, [%dim, %dim_0]}
-//   K        memref<?x?x64xf32>  (%dim, %dim_0)       {256, [%dim, %dim_0]}
-//   V        memref<?x?x64xf32>  (%dim, %dim_0)       {256, [%dim, %dim_0]}
-//   KT       memref<?x64x?xf32>  (%dim, %dim_0)       {256, [%dim, %dim_0]}
-//   scores   memref<?x?x?xf32>   (%dim,%dim_0,%dim_0) {4, [%dim,%dim_0,%dim_0]}
-//   scaled   memref<?x?x?xf32>   (%dim,%dim_0,%dim_0) {4, [%dim,%dim_0,%dim_0]}
-//
-//   Note: ?x?x64xf32 and ?x64x?xf32 have different shapes but the same
-//   total byte size (4 * 64 * dim * dim_0 = 256 * dim * dim_0).
-//
-//   Bucket A  (byte_size = 256 * dim * dim_0):  Q, K, V, KT
-//     All lifetimes overlap -> 4 bins, one alloc each.
-//   Bucket B  (byte_size = 4 * dim * dim_0^2):  scores, scaled
-//     Lifetimes overlap -> 2 bins.
-//
-//   Pool layout at runtime:
-//     |--Q--|--K--|--V--|--KT--|-scores-|-scaled-|
-//      bin0   bin1  bin2  bin3    bin0     bin1
-//      <- 4 x alignUp(bucketA) -> <- 2 x alignUp(bucketB) ->
-//
-//   pool_size = 4*alignUp(bucketA) + 2*alignUp(bucketB)
 
 /// A bucket groups dynamic allocs that share the same runtime byte size.
 /// Within a bucket, each "bin" holds allocs with non-overlapping lifetimes
 /// that can share a single offset at runtime.
 struct DynBucket {
-  Value byteSizeValue; ///< SSA value for the byte size
+  Value byteSizeValue;  ///< SSA value for the unaligned byte size
+  Value alignedSize;    ///< SSA value for the aligned byte size (cached)
   SmallVector<SmallVector<AllocInfo *>>
       bins; ///< bins of non-overlapping allocs
 };
 
 /// Structural key for grouping allocs with identical runtime byte sizes.
-///
-/// Two allocs match if they have the same compile-time factor (product of
-/// element bytes and static dimensions) and the same SSA operands for
-/// dynamic dimensions.
-///
-/// Example: memref<?x?x64xf32> allocated with (%dim, %dim_0)
-///   staticFactor = 4 (f32 bytes) * 64 (static dim) = 256
-///   dynOperands  = [%dim, %dim_0]
-///   runtime byte size = 256 * %dim * %dim_0
 struct DynSizeKey {
   int64_t staticFactor;
   SmallVector<Value, 2> dynOperands;
@@ -284,15 +189,9 @@ struct DynSizeKey {
 };
 
 /// Group dynamic allocs into buckets and bins.
-///
-/// 1. Compute a structural DynSizeKey for each alloc.
-/// 2. Deduplicate keys and emit one byte-size SSA value per unique key
-///    (arith.constant * arith.muli chain) at the builder's current position.
-/// 3. Group allocs by byte-size SSA value.
-/// 4. Within each group, first-fit bin allocs with non-overlapping lifetimes.
 static SmallVector<DynBucket>
 packDynamicAllocs(MutableArrayRef<AllocInfo> dynamics, OpBuilder &builder,
-                  Location loc) {
+                  Location loc, int64_t alignment) {
   struct KeyedInfo {
     DynSizeKey key;
     AllocInfo *info;
@@ -303,11 +202,13 @@ packDynamicAllocs(MutableArrayRef<AllocInfo> dynamics, OpBuilder &builder,
   for (AllocInfo &info : dynamics) {
     MemRefType type = info.allocOp.getType();
     auto dynSizes = info.allocOp.getDynamicSizes();
-    int64_t elemBytes = type.getElementTypeBitWidth() / 8;
-    int64_t staticFactor = elemBytes;
+    int64_t totalBits = type.getElementTypeBitWidth();
+    int64_t staticFactor = 1;
     for (int64_t dim : type.getShape())
       if (!ShapedType::isDynamic(dim))
         staticFactor *= dim;
+    staticFactor =
+        static_cast<int64_t>(llvm::divideCeil(staticFactor * totalBits, 8));
     DynSizeKey key;
     key.staticFactor = staticFactor;
     unsigned dynIdx = 0;
@@ -323,18 +224,10 @@ packDynamicAllocs(MutableArrayRef<AllocInfo> dynamics, OpBuilder &builder,
     for (auto &[k, v] : uniqueKeys)
       if (k == key)
         return v;
-    // byte_size = staticFactor * dynDim0 * dynDim1 * ...
-    Value byteSize;
-    if (key.staticFactor != 1)
-      byteSize = arith::ConstantIndexOp::create(builder, loc, key.staticFactor);
-    for (Value dynDim : key.dynOperands) {
-      if (byteSize)
-        byteSize = arith::MulIOp::create(builder, loc, byteSize, dynDim);
-      else
-        byteSize = dynDim;
-    }
-    if (!byteSize)
-      byteSize = arith::ConstantIndexOp::create(builder, loc, key.staticFactor);
+    Value byteSize =
+        arith::ConstantIndexOp::create(builder, loc, key.staticFactor);
+    for (Value dynDim : key.dynOperands)
+      byteSize = builder.createOrFold<arith::MulIOp>(loc, byteSize, dynDim);
     uniqueKeys.push_back({key, byteSize});
     return byteSize;
   };
@@ -349,6 +242,7 @@ packDynamicAllocs(MutableArrayRef<AllocInfo> dynamics, OpBuilder &builder,
   for (auto &[sizeVal, infos] : bySize) {
     DynBucket bucket;
     bucket.byteSizeValue = sizeVal;
+    bucket.alignedSize = emitAlignUp(builder, loc, sizeVal, alignment);
     for (AllocInfo *info : infos) {
       bool placed = false;
       for (auto &bin : bucket.bins) {
@@ -379,6 +273,13 @@ packDynamicAllocs(MutableArrayRef<AllocInfo> dynamics, OpBuilder &builder,
 //===----------------------------------------------------------------------===//
 
 struct PoolAllocsPass : public impl::PoolAllocsPassBase<PoolAllocsPass> {
+  using PoolAllocsPassBase::PoolAllocsPassBase;
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<arith::ArithDialect, memref::MemRefDialect>();
+    arith::registerBufferViewFlowOpInterfaceExternalModels(registry);
+  }
+
   void runOnOperation() override;
 };
 
@@ -397,11 +298,8 @@ void PoolAllocsPass::runOnOperation() {
   Block &block = funcOp.getBody().front();
 
   // ----- Phase 1: liveness analysis ------------------------------------
-  //
-  // Assign each op a sequential index and compute [defIndex, lastUseIndex]
-  // for every memref.alloc.  lastUseIndex is the maximum index among all
-  // *transitive* users: if %buf feeds memref.subview -> op X, then %buf
-  // must stay live until X, not just until the subview.
+
+  BufferViewFlowAnalysis aliasAnalysis(funcOp);
 
   DenseMap<Operation *, unsigned> opIndex;
   unsigned idx = 0;
@@ -421,19 +319,20 @@ void PoolAllocsPass::runOnOperation() {
     info.allocOp = allocOp;
     info.defIndex = opIndex[&op];
     info.lastUseIndex =
-        findLastTransitiveUseIndex(result, block, opIndex, blockSize);
+        findLastAliasedUseIndex(result, aliasAnalysis, block, opIndex,
+                                blockSize);
     info.staticByteSize = getStaticByteSize(allocOp.getType());
+    LLVM_DEBUG(llvm::dbgs()
+               << "  alloc " << allocOp << " ["
+               << info.defIndex << ", " << info.lastUseIndex << "] "
+               << info.staticByteSize << " bytes\n");
     allInfos.push_back(info);
   }
 
-  // Need at least 2 allocs to pool.
   if (allInfos.size() < 2)
     return;
 
   // ----- Phase 2: partition into static / dynamic ----------------------
-  //
-  // Static allocs (all dims known) go through the greedy offset assignment
-  // in Phase 3.  Dynamic allocs go through the bucket/bin packing in Phase 4.
 
   SmallVector<AllocInfo> statics, dynamics;
   for (auto &info : allInfos) {
@@ -443,20 +342,20 @@ void PoolAllocsPass::runOnOperation() {
       dynamics.push_back(info);
   }
 
-  // Largest-first ordering improves packing density:  big allocs are harder
-  // to fit into gaps, so placing them first gives smaller allocs more
-  // opportunities to fill the remaining holes.
+  // Largest-first ordering improves packing density.
   llvm::sort(statics, [](const AllocInfo &a, const AllocInfo &b) {
     return a.staticByteSize > b.staticByteSize;
   });
 
   // ----- Phase 3: pack statics ----------------------------------------
 
-  auto staticAssignments = packStaticAllocs(statics, kDefaultAlignment);
+  int64_t align = alignment;
+  auto staticAssignments = packStaticAllocs(statics, align);
+  NumStaticPacked += staticAssignments.size();
 
   int64_t staticPoolSize = 0;
   for (auto &[info, offset] : staticAssignments) {
-    int64_t end = offset + alignUp(info->staticByteSize, kDefaultAlignment);
+    int64_t end = offset + alignUp(info->staticByteSize, align);
     staticPoolSize = std::max(staticPoolSize, end);
   }
 
@@ -465,75 +364,43 @@ void PoolAllocsPass::runOnOperation() {
   Location loc = funcOp.getLoc();
   OpBuilder builder(funcOp.getContext());
 
-  // Insert all pool IR right before the earliest alloc being pooled so
-  // that downstream passes (e.g. hip-lower-allocs) see the pool after
-  // any prerequisite ops like !hip.context arg but before any consumer
-  // of the pooled buffers.
   Operation *firstPooledAlloc = allInfos.front().allocOp.getOperation();
   for (auto &info : allInfos)
     if (info.allocOp->isBeforeInBlock(firstPooledAlloc))
       firstPooledAlloc = info.allocOp.getOperation();
   builder.setInsertionPoint(firstPooledAlloc);
 
-  auto dynBuckets = packDynamicAllocs(dynamics, builder, loc);
+  auto dynBuckets = packDynamicAllocs(dynamics, builder, loc, align);
+  NumDynBuckets += dynBuckets.size();
 
   // ----- Phase 5: emit pool + views -----------------------------------
-  //
-  // Build a single pool memref and replace every original alloc with a
-  // memref.view into it.
-  //
-  // Emitted IR for a fully-static case (4 allocs totalling 131072 bytes):
-  //
-  //   %pool = memref.alloc() : memref<131072xi8>
-  //   %off0 = arith.constant 0     : index
-  //   %v0   = memref.view %pool[%off0][] : memref<131072xi8> to memref<...>
-  //   %off1 = arith.constant 32768 : index
-  //   %v1   = memref.view %pool[%off1][] : memref<131072xi8> to memref<...>
-  //   ...
-  //
-  // For a mixed static+dynamic case the pool becomes memref<?xi8>:
-  //
-  //   %static_part = arith.constant 32768 : index
-  //   %aligned     = <alignUp(%dynBucketSize, 256)>  // arith add/div/mul
-  //   %pool_size   = arith.addi %static_part, %aligned : index
-  //   %pool        = memref.alloc(%pool_size) : memref<?xi8>
-  //   ...
 
   bool hasDynamic = !dynBuckets.empty();
 
   // 5a. Compute total pool size as an SSA value.
+  // Uses createOrFold so that trivial ops (addi(x,0), muli(x,1)) are
+  // folded away automatically by the arith dialect's fold methods.
   Value poolSize;
   if (hasDynamic) {
     poolSize = arith::ConstantIndexOp::create(builder, loc, staticPoolSize);
-    Value alignConst =
-        arith::ConstantIndexOp::create(builder, loc, kDefaultAlignment);
 
     for (auto &bucket : dynBuckets) {
-      int64_t numBins = bucket.bins.size();
-      // alignUp(bucketSize, alignment) via arith ops.
-      Value alignM1 =
-          arith::ConstantIndexOp::create(builder, loc, kDefaultAlignment - 1);
-      Value sum =
-          arith::AddIOp::create(builder, loc, bucket.byteSizeValue, alignM1);
-      Value divided = arith::DivUIOp::create(builder, loc, sum, alignConst);
-      Value alignedBucketSize =
-          arith::MulIOp::create(builder, loc, divided, alignConst);
-
-      if (numBins > 1) {
-        Value numBinsVal =
-            arith::ConstantIndexOp::create(builder, loc, numBins);
-        Value contribution =
-            arith::MulIOp::create(builder, loc, alignedBucketSize, numBinsVal);
-        poolSize = arith::AddIOp::create(builder, loc, poolSize, contribution);
-      } else {
-        poolSize =
-            arith::AddIOp::create(builder, loc, poolSize, alignedBucketSize);
-      }
+      Value numBinsVal = arith::ConstantIndexOp::create(
+          builder, loc, static_cast<int64_t>(bucket.bins.size()));
+      Value contribution = builder.createOrFold<arith::MulIOp>(
+          loc, bucket.alignedSize, numBinsVal);
+      poolSize =
+          builder.createOrFold<arith::AddIOp>(loc, poolSize, contribution);
     }
   } else {
     if (staticPoolSize == 0)
       return;
   }
+
+  LLVM_DEBUG(llvm::dbgs()
+             << "Pool: static=" << staticPoolSize << " bytes, "
+             << dynBuckets.size() << " dynamic buckets, "
+             << allInfos.size() << " total allocs\n");
 
   // 5b. Create the single pool allocation.
   Value pool;
@@ -559,48 +426,27 @@ void PoolAllocsPass::runOnOperation() {
   if (hasDynamic) {
     Value currentBase =
         arith::ConstantIndexOp::create(builder, loc, staticPoolSize);
-    Value alignConst2 =
-        arith::ConstantIndexOp::create(builder, loc, kDefaultAlignment);
-    Value alignM1 =
-        arith::ConstantIndexOp::create(builder, loc, kDefaultAlignment - 1);
 
     for (auto &bucket : dynBuckets) {
-      Value sum =
-          arith::AddIOp::create(builder, loc, bucket.byteSizeValue, alignM1);
-      Value divided = arith::DivUIOp::create(builder, loc, sum, alignConst2);
-      Value alignedBucketSize =
-          arith::MulIOp::create(builder, loc, divided, alignConst2);
-
       for (auto [binIdx, bin] : llvm::enumerate(bucket.bins)) {
         // offset = currentBase + binIdx * alignedBucketSize
-        Value binOffset;
-        if (binIdx == 0) {
-          binOffset = currentBase;
-        } else {
-          Value binIdxVal = arith::ConstantIndexOp::create(
-              builder, loc, static_cast<int64_t>(binIdx));
-          Value binContrib =
-              arith::MulIOp::create(builder, loc, alignedBucketSize, binIdxVal);
-          binOffset =
-              arith::AddIOp::create(builder, loc, currentBase, binContrib);
-        }
+        Value binIdxVal = arith::ConstantIndexOp::create(
+            builder, loc, static_cast<int64_t>(binIdx));
+        Value binContrib = builder.createOrFold<arith::MulIOp>(
+            loc, bucket.alignedSize, binIdxVal);
+        Value binOffset = builder.createOrFold<arith::AddIOp>(
+            loc, currentBase, binContrib);
         for (AllocInfo *info : bin)
           allocToOffset[info->allocOp.getOperation()] = binOffset;
       }
 
       // Advance base past this entire bucket.
-      int64_t numBins = bucket.bins.size();
-      if (numBins > 1) {
-        Value numBinsVal =
-            arith::ConstantIndexOp::create(builder, loc, numBins);
-        Value bucketTotal =
-            arith::MulIOp::create(builder, loc, alignedBucketSize, numBinsVal);
-        currentBase =
-            arith::AddIOp::create(builder, loc, currentBase, bucketTotal);
-      } else {
-        currentBase =
-            arith::AddIOp::create(builder, loc, currentBase, alignedBucketSize);
-      }
+      Value numBinsVal = arith::ConstantIndexOp::create(
+          builder, loc, static_cast<int64_t>(bucket.bins.size()));
+      Value bucketTotal = builder.createOrFold<arith::MulIOp>(
+          loc, bucket.alignedSize, numBinsVal);
+      currentBase = builder.createOrFold<arith::AddIOp>(
+          loc, currentBase, bucketTotal);
     }
   }
 
@@ -623,19 +469,15 @@ void PoolAllocsPass::runOnOperation() {
 
     info.allocOp.replaceAllUsesWith(view.getResult());
     info.allocOp.erase();
+    ++NumAllocsPooled;
 
-    // Record offsets for the hipdnn.buffer_offsets attribute.
-    // Dynamic offsets are represented as -1 since the actual value
-    // is only known at runtime.
     if (auto constOp = offset.getDefiningOp<arith::ConstantIndexOp>())
       staticOffsets.push_back(constOp.value());
     else
       staticOffsets.push_back(-1);
   }
 
-  // 5d'. Erase deallocs that now target views (invalid to free a view)
-  // and insert a single dealloc for the pool buffer.  After RAUW above,
-  // any `memref.dealloc %alloc_X` became `memref.dealloc %view_X`.
+  // 5d'. Erase deallocs that now target views and insert a single pool dealloc.
   SmallVector<memref::DeallocOp> orphanedDeallocs;
   funcOp.walk([&](memref::DeallocOp op) {
     if (op.getMemref().getDefiningOp<memref::ViewOp>())
@@ -651,14 +493,15 @@ void PoolAllocsPass::runOnOperation() {
   }
 
   // 5e. Attach pool metadata to the function for runtime/deployment use.
-  MLIRContext *ctx = funcOp.getContext();
+  MLIRContext *mlirCtx = funcOp.getContext();
   if (!hasDynamic)
     funcOp->setAttr("hipdnn.pool_size",
                     builder.getI64IntegerAttr(staticPoolSize));
   SmallVector<Attribute> offsetAttrs;
   for (int64_t off : staticOffsets)
     offsetAttrs.push_back(builder.getI64IntegerAttr(off));
-  funcOp->setAttr("hipdnn.buffer_offsets", ArrayAttr::get(ctx, offsetAttrs));
+  funcOp->setAttr("hipdnn.buffer_offsets",
+                   ArrayAttr::get(mlirCtx, offsetAttrs));
 }
 
 } // namespace

--- a/lib/Dialect/Transforms/PoolAllocs.cpp
+++ b/lib/Dialect/Transforms/PoolAllocs.cpp
@@ -171,8 +171,8 @@ packStaticAllocs(MutableArrayRef<AllocInfo> statics, int64_t alignment) {
 /// Within a bucket, each "bin" holds allocs with non-overlapping lifetimes
 /// that can share a single offset at runtime.
 struct DynBucket {
-  Value byteSizeValue;  ///< SSA value for the unaligned byte size
-  Value alignedSize;    ///< SSA value for the aligned byte size (cached)
+  Value byteSizeValue; ///< SSA value for the unaligned byte size
+  Value alignedSize;   ///< SSA value for the aligned byte size (cached)
   SmallVector<SmallVector<AllocInfo *>>
       bins; ///< bins of non-overlapping allocs
 };
@@ -336,14 +336,12 @@ void PoolAllocsPass::runOnOperation() {
     AllocInfo info;
     info.allocOp = allocOp;
     info.defIndex = opIndex[&op];
-    info.lastUseIndex =
-        findLastAliasedUseIndex(result, aliasAnalysis, block, opIndex,
-                                blockSize);
+    info.lastUseIndex = findLastAliasedUseIndex(result, aliasAnalysis, block,
+                                                opIndex, blockSize);
     info.staticByteSize = getStaticByteSize(allocOp.getType());
-    LLVM_DEBUG(llvm::dbgs()
-               << "  alloc " << allocOp << " ["
-               << info.defIndex << ", " << info.lastUseIndex << "] "
-               << info.staticByteSize << " bytes\n");
+    LLVM_DEBUG(llvm::dbgs() << "  alloc " << allocOp << " [" << info.defIndex
+                            << ", " << info.lastUseIndex << "] "
+                            << info.staticByteSize << " bytes\n");
     allInfos.push_back(info);
   }
 
@@ -415,10 +413,9 @@ void PoolAllocsPass::runOnOperation() {
       return;
   }
 
-  LLVM_DEBUG(llvm::dbgs()
-             << "Pool: static=" << staticPoolSize << " bytes, "
-             << dynBuckets.size() << " dynamic buckets, "
-             << allInfos.size() << " total allocs\n");
+  LLVM_DEBUG(llvm::dbgs() << "Pool: static=" << staticPoolSize << " bytes, "
+                          << dynBuckets.size() << " dynamic buckets, "
+                          << allInfos.size() << " total allocs\n");
 
   // 5b. Create the single pool allocation.
   Value pool;
@@ -452,8 +449,8 @@ void PoolAllocsPass::runOnOperation() {
             builder, loc, static_cast<int64_t>(binIdx));
         Value binContrib = builder.createOrFold<arith::MulIOp>(
             loc, bucket.alignedSize, binIdxVal);
-        Value binOffset = builder.createOrFold<arith::AddIOp>(
-            loc, currentBase, binContrib);
+        Value binOffset =
+            builder.createOrFold<arith::AddIOp>(loc, currentBase, binContrib);
         for (AllocInfo *info : bin)
           allocToOffset[info->allocOp.getOperation()] = binOffset;
       }
@@ -463,8 +460,8 @@ void PoolAllocsPass::runOnOperation() {
           builder, loc, static_cast<int64_t>(bucket.bins.size()));
       Value bucketTotal = builder.createOrFold<arith::MulIOp>(
           loc, bucket.alignedSize, numBinsVal);
-      currentBase = builder.createOrFold<arith::AddIOp>(
-          loc, currentBase, bucketTotal);
+      currentBase =
+          builder.createOrFold<arith::AddIOp>(loc, currentBase, bucketTotal);
     }
   }
 
@@ -519,7 +516,7 @@ void PoolAllocsPass::runOnOperation() {
   for (int64_t off : staticOffsets)
     offsetAttrs.push_back(builder.getI64IntegerAttr(off));
   funcOp->setAttr("hipdnn.buffer_offsets",
-                   ArrayAttr::get(mlirCtx, offsetAttrs));
+                  ArrayAttr::get(mlirCtx, offsetAttrs));
 }
 
 } // namespace

--- a/lib/Dialect/Transforms/PoolAllocs.cpp
+++ b/lib/Dialect/Transforms/PoolAllocs.cpp
@@ -171,8 +171,8 @@ packStaticAllocs(MutableArrayRef<AllocInfo> statics, int64_t alignment) {
 /// Within a bucket, each "bin" holds allocs with non-overlapping lifetimes
 /// that can share a single offset at runtime.
 struct DynBucket {
-  Value byteSizeValue; ///< SSA value for the unaligned byte size
-  Value alignedSize;   ///< SSA value for the aligned byte size (cached)
+  Value byteSizeValue;  ///< SSA value for the unaligned byte size
+  Value alignedSize;    ///< SSA value for the aligned byte size (cached)
   SmallVector<SmallVector<AllocInfo *>>
       bins; ///< bins of non-overlapping allocs
 };
@@ -304,6 +304,13 @@ struct PoolAllocsPass : public impl::PoolAllocsPassBase<PoolAllocsPass> {
 void PoolAllocsPass::runOnOperation() {
   func::FuncOp funcOp = getOperation();
 
+  if (alignment <= 0 || (alignment & (alignment - 1)) != 0) {
+    funcOp.emitError("hip-pool-allocs: alignment must be a positive power of 2"
+                     " (got ")
+        << alignment << ")";
+    return signalPassFailure();
+  }
+
   if (funcOp.empty())
     return;
   if (!funcOp.getBody().hasOneBlock()) {
@@ -336,12 +343,14 @@ void PoolAllocsPass::runOnOperation() {
     AllocInfo info;
     info.allocOp = allocOp;
     info.defIndex = opIndex[&op];
-    info.lastUseIndex = findLastAliasedUseIndex(result, aliasAnalysis, block,
-                                                opIndex, blockSize);
+    info.lastUseIndex =
+        findLastAliasedUseIndex(result, aliasAnalysis, block, opIndex,
+                                blockSize);
     info.staticByteSize = getStaticByteSize(allocOp.getType());
-    LLVM_DEBUG(llvm::dbgs() << "  alloc " << allocOp << " [" << info.defIndex
-                            << ", " << info.lastUseIndex << "] "
-                            << info.staticByteSize << " bytes\n");
+    LLVM_DEBUG(llvm::dbgs()
+               << "  alloc " << allocOp << " ["
+               << info.defIndex << ", " << info.lastUseIndex << "] "
+               << info.staticByteSize << " bytes\n");
     allInfos.push_back(info);
   }
 
@@ -413,9 +422,10 @@ void PoolAllocsPass::runOnOperation() {
       return;
   }
 
-  LLVM_DEBUG(llvm::dbgs() << "Pool: static=" << staticPoolSize << " bytes, "
-                          << dynBuckets.size() << " dynamic buckets, "
-                          << allInfos.size() << " total allocs\n");
+  LLVM_DEBUG(llvm::dbgs()
+             << "Pool: static=" << staticPoolSize << " bytes, "
+             << dynBuckets.size() << " dynamic buckets, "
+             << allInfos.size() << " total allocs\n");
 
   // 5b. Create the single pool allocation.
   Value pool;
@@ -449,8 +459,8 @@ void PoolAllocsPass::runOnOperation() {
             builder, loc, static_cast<int64_t>(binIdx));
         Value binContrib = builder.createOrFold<arith::MulIOp>(
             loc, bucket.alignedSize, binIdxVal);
-        Value binOffset =
-            builder.createOrFold<arith::AddIOp>(loc, currentBase, binContrib);
+        Value binOffset = builder.createOrFold<arith::AddIOp>(
+            loc, currentBase, binContrib);
         for (AllocInfo *info : bin)
           allocToOffset[info->allocOp.getOperation()] = binOffset;
       }
@@ -460,8 +470,8 @@ void PoolAllocsPass::runOnOperation() {
           builder, loc, static_cast<int64_t>(bucket.bins.size()));
       Value bucketTotal = builder.createOrFold<arith::MulIOp>(
           loc, bucket.alignedSize, numBinsVal);
-      currentBase =
-          builder.createOrFold<arith::AddIOp>(loc, currentBase, bucketTotal);
+      currentBase = builder.createOrFold<arith::AddIOp>(
+          loc, currentBase, bucketTotal);
     }
   }
 
@@ -516,7 +526,7 @@ void PoolAllocsPass::runOnOperation() {
   for (int64_t off : staticOffsets)
     offsetAttrs.push_back(builder.getI64IntegerAttr(off));
   funcOp->setAttr("hipdnn.buffer_offsets",
-                  ArrayAttr::get(mlirCtx, offsetAttrs));
+                   ArrayAttr::get(mlirCtx, offsetAttrs));
 }
 
 } // namespace

--- a/lib/Dialect/Transforms/ResolveExternConstants.cpp
+++ b/lib/Dialect/Transforms/ResolveExternConstants.cpp
@@ -36,6 +36,16 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
 
+#include "llvm/ADT/Statistic.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "hip-resolve-extern-constants"
+
+STATISTIC(NumGlobalsResolved,
+          "Number of extern globals resolved to views");
+STATISTIC(NumFuncsUpdated,
+          "Number of functions receiving constants argument");
+
 namespace mlir {
 namespace hip {
 
@@ -58,8 +68,7 @@ void ResolveExternConstantsPass::runOnOperation() {
     int64_t offset;
     int64_t size;
   };
-  llvm::SmallVector<ExternGlobalInfo> externGlobals;
-  llvm::DenseMap<StringRef, ExternGlobalInfo *> globalsByName;
+  SmallVector<ExternGlobalInfo> externGlobals;
 
   for (auto globalOp : module.getOps<memref::GlobalOp>()) {
     auto extDataAttr =
@@ -78,14 +87,16 @@ void ResolveExternConstantsPass::runOnOperation() {
   if (externGlobals.empty())
     return;
 
-  for (auto &info : externGlobals)
-    globalsByName[info.globalOp.getSymName()] = &info;
+  // Index-based lookup avoids storing pointers into the SmallVector.
+  DenseMap<StringRef, size_t> globalsByName;
+  for (auto [idx, info] : llvm::enumerate(externGlobals))
+    globalsByName[info.globalOp.getSymName()] = idx;
 
   auto i8Type = IntegerType::get(module.getContext(), 8);
   auto constantsType = MemRefType::get({ShapedType::kDynamic}, i8Type);
 
   // Phase 1: Identify functions that directly use externalized globals.
-  llvm::DenseSet<func::FuncOp> needsConstantsArg;
+  DenseSet<func::FuncOp> needsConstantsArg;
   for (auto funcOp : module.getOps<func::FuncOp>()) {
     if (funcOp.isDeclaration())
       continue;
@@ -97,7 +108,6 @@ void ResolveExternConstantsPass::runOnOperation() {
 
   // Phase 2: Propagate transitively -- any function that calls a function
   // needing %_constants must also receive it so it can pass it through.
-  // Fixed-point iteration handles arbitrary call depth.
   bool changed = true;
   while (changed) {
     changed = false;
@@ -116,7 +126,7 @@ void ResolveExternConstantsPass::runOnOperation() {
 
   // Phase 3: Add %_constants : memref<?xi8> argument to every function
   // that needs it (both direct users and transitive callers).
-  llvm::DenseMap<func::FuncOp, Value> constantsArgMap;
+  DenseMap<func::FuncOp, Value> constantsArgMap;
   for (auto funcOp : module.getOps<func::FuncOp>()) {
     if (!needsConstantsArg.contains(funcOp))
       continue;
@@ -127,38 +137,44 @@ void ResolveExternConstantsPass::runOnOperation() {
     constantsArgMap[funcOp] = constantsArg;
 
     auto oldFuncType = funcOp.getFunctionType();
-    llvm::SmallVector<Type> newInputTypes(oldFuncType.getInputs());
+    SmallVector<Type> newInputTypes(oldFuncType.getInputs());
     newInputTypes.push_back(constantsType);
     funcOp.setFunctionType(FunctionType::get(module.getContext(), newInputTypes,
                                              oldFuncType.getResults()));
 
     if (auto allArgAttrs = funcOp.getAllArgAttrs()) {
-      llvm::SmallVector<Attribute> newArgAttrs(allArgAttrs.begin(),
-                                               allArgAttrs.end());
+      SmallVector<Attribute> newArgAttrs(allArgAttrs.begin(),
+                                         allArgAttrs.end());
       newArgAttrs.push_back(DictionaryAttr::get(module.getContext()));
       funcOp.setAllArgAttrs(newArgAttrs);
     }
+
+    ++NumFuncsUpdated;
+    LLVM_DEBUG(llvm::dbgs()
+               << "  Added %_constants arg to @" << funcOp.getName() << "\n");
   }
 
-  // Phase 4: Rewrite func.call sites -- append the caller's %_constants
-  // to every call targeting a function whose signature was extended.
+  // Phase 4: Rewrite func.call sites -- collect first, then modify.
   for (auto funcOp : module.getOps<func::FuncOp>()) {
     if (funcOp.isDeclaration())
       continue;
+
+    SmallVector<func::CallOp> callsToUpdate;
     funcOp.walk([&](func::CallOp callOp) {
       auto callee = module.lookupSymbol<func::FuncOp>(callOp.getCallee());
-      if (!callee || !needsConstantsArg.contains(callee))
-        return;
+      if (callee && needsConstantsArg.contains(callee))
+        callsToUpdate.push_back(callOp);
+    });
 
+    for (func::CallOp callOp : callsToUpdate) {
       auto it = constantsArgMap.find(funcOp);
       if (it == constantsArgMap.end()) {
         callOp.emitError("caller does not have %_constants but callee ")
-            << callee.getName() << " requires it";
-        signalPassFailure();
-        return;
+            << callOp.getCallee() << " requires it";
+        return signalPassFailure();
       }
 
-      llvm::SmallVector<Value> newOperands(callOp.getOperands());
+      SmallVector<Value> newOperands(callOp.getOperands());
       newOperands.push_back(it->second);
       OpBuilder builder(callOp);
       auto newCall =
@@ -166,11 +182,10 @@ void ResolveExternConstantsPass::runOnOperation() {
                                callOp.getResultTypes(), newOperands);
       callOp.replaceAllUsesWith(newCall.getResults());
       callOp.erase();
-    });
+    }
   }
 
-  // Phase 5: Replace memref.get_global with memref.view into the buffer
-  // (only in functions that directly use externalized globals).
+  // Phase 5: Replace memref.get_global with memref.view into the buffer.
   for (auto funcOp : module.getOps<func::FuncOp>()) {
     if (funcOp.isDeclaration())
       continue;
@@ -180,25 +195,26 @@ void ResolveExternConstantsPass::runOnOperation() {
       continue;
     Value constantsArg = it->second;
 
-    llvm::SmallVector<memref::GetGlobalOp> getGlobalOps;
+    SmallVector<memref::GetGlobalOp> getGlobalOps;
     funcOp.walk([&](memref::GetGlobalOp op) {
       if (globalsByName.contains(op.getName()))
         getGlobalOps.push_back(op);
     });
 
     for (auto getGlobalOp : getGlobalOps) {
-      ExternGlobalInfo *info = globalsByName[getGlobalOp.getName()];
+      ExternGlobalInfo &info = externGlobals[globalsByName[getGlobalOp.getName()]];
       OpBuilder builder(getGlobalOp);
       Location loc = getGlobalOp.getLoc();
 
       Value offset = arith::ConstantOp::create(
-          builder, loc, builder.getIndexAttr(info->offset));
+          builder, loc, builder.getIndexAttr(info.offset));
       auto viewOp = memref::ViewOp::create(builder, loc, getGlobalOp.getType(),
                                            constantsArg, offset,
                                            /*sizes=*/ValueRange{});
 
       getGlobalOp.replaceAllUsesWith(viewOp.getResult());
       getGlobalOp.erase();
+      ++NumGlobalsResolved;
     }
   }
 

--- a/lib/Dialect/Transforms/ResolveExternConstants.cpp
+++ b/lib/Dialect/Transforms/ResolveExternConstants.cpp
@@ -41,10 +41,8 @@
 
 #define DEBUG_TYPE "hip-resolve-extern-constants"
 
-STATISTIC(NumGlobalsResolved,
-          "Number of extern globals resolved to views");
-STATISTIC(NumFuncsUpdated,
-          "Number of functions receiving constants argument");
+STATISTIC(NumGlobalsResolved, "Number of extern globals resolved to views");
+STATISTIC(NumFuncsUpdated, "Number of functions receiving constants argument");
 
 namespace mlir {
 namespace hip {
@@ -202,7 +200,8 @@ void ResolveExternConstantsPass::runOnOperation() {
     });
 
     for (auto getGlobalOp : getGlobalOps) {
-      ExternGlobalInfo &info = externGlobals[globalsByName[getGlobalOp.getName()]];
+      ExternGlobalInfo &info =
+          externGlobals[globalsByName[getGlobalOp.getName()]];
       OpBuilder builder(getGlobalOp);
       Location loc = getGlobalOp.getLoc();
 

--- a/test/lit/Dialect/hip-add-context-arg.mlir
+++ b/test/lit/Dialect/hip-add-context-arg.mlir
@@ -1,0 +1,112 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+//===----------------------------------------------------------------------===//
+// FileCheck tests for --hip-add-context-arg (insert !hip.context as arg 0).
+//
+// Two-phase behavior verified by these tests:
+//   Phase 1: Every func.func gains !hip.context as its first argument.
+//   Phase 2: Every func.call targeting an updated function is rewritten to
+//            forward the caller's !hip.context.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt --hip-add-context-arg %s | FileCheck %s
+
+// ===== Basic: single function gains !hip.context =====
+//
+// CHECK-LABEL: func.func @single_func
+// CHECK-SAME:    (%arg0: !hip.context, %arg1: memref<8x8xf32>)
+// CHECK:         return
+func.func @single_func(%a: memref<8x8xf32>) -> memref<8x8xf32> {
+  return %a : memref<8x8xf32>
+}
+
+// ===== Skip: function already has !hip.context =====
+//
+// CHECK-LABEL: func.func @already_has_context
+// CHECK-SAME:    (%arg0: !hip.context, %arg1: memref<8x8xf32>)
+// CHECK-NOT:     !hip.context, !hip.context
+// CHECK:         return
+func.func @already_has_context(%ctx: !hip.context, %a: memref<8x8xf32>) -> memref<8x8xf32> {
+  return %a : memref<8x8xf32>
+}
+
+// ===== Call site update: caller passes context to callee =====
+//
+// CHECK-LABEL: func.func @callee_for_call_test
+// CHECK-SAME:    (%arg0: !hip.context, %arg1: memref<8x8xf32>)
+
+// CHECK-LABEL: func.func @caller_updates_call
+// CHECK-SAME:    (%[[CTX:.*]]: !hip.context, %[[A:.*]]: memref<8x8xf32>)
+// CHECK:         call @callee_for_call_test(%[[CTX]], %[[A]])
+// CHECK:         return
+func.func @callee_for_call_test(%a: memref<8x8xf32>) -> memref<8x8xf32> {
+  return %a : memref<8x8xf32>
+}
+
+func.func @caller_updates_call(%a: memref<8x8xf32>) -> memref<8x8xf32> {
+  %res = func.call @callee_for_call_test(%a) : (memref<8x8xf32>) -> memref<8x8xf32>
+  return %res : memref<8x8xf32>
+}
+
+// ===== Multi-level calls: A calls B calls C =====
+//
+// All three gain !hip.context and both call sites forward it.
+//
+// CHECK-LABEL: func.func @leaf
+// CHECK-SAME:    (%arg0: !hip.context, %arg1: memref<8x8xf32>)
+// CHECK:         return
+
+// CHECK-LABEL: func.func @middle
+// CHECK-SAME:    (%[[CTX2:.*]]: !hip.context, %[[A2:.*]]: memref<8x8xf32>)
+// CHECK:         call @leaf(%[[CTX2]], %[[A2]])
+// CHECK:         return
+
+// CHECK-LABEL: func.func @top
+// CHECK-SAME:    (%[[CTX3:.*]]: !hip.context, %[[A3:.*]]: memref<8x8xf32>)
+// CHECK:         call @middle(%[[CTX3]], %[[A3]])
+// CHECK:         return
+func.func @leaf(%a: memref<8x8xf32>) -> memref<8x8xf32> {
+  return %a : memref<8x8xf32>
+}
+
+func.func @middle(%a: memref<8x8xf32>) -> memref<8x8xf32> {
+  %res = func.call @leaf(%a) : (memref<8x8xf32>) -> memref<8x8xf32>
+  return %res : memref<8x8xf32>
+}
+
+func.func @top(%a: memref<8x8xf32>) -> memref<8x8xf32> {
+  %res = func.call @middle(%a) : (memref<8x8xf32>) -> memref<8x8xf32>
+  return %res : memref<8x8xf32>
+}
+
+// ===== Empty module: no functions is a no-op =====
+// (This is implicitly tested -- the pass runs on the entire module above
+//  which includes all test functions. If there were zero functions, there
+//  would be nothing to check.)
+
+// ===== Multiple arguments: context is always first =====
+//
+// CHECK-LABEL: func.func @many_args
+// CHECK-SAME:    (%arg0: !hip.context, %arg1: memref<4x4xf32>, %arg2: memref<4x4xf32>, %arg3: index)
+func.func @many_args(%a: memref<4x4xf32>, %b: memref<4x4xf32>, %n: index) -> memref<4x4xf32> {
+  return %a : memref<4x4xf32>
+}
+
+// ===== Call with results: result types are preserved =====
+//
+// CHECK-LABEL: func.func @callee_with_result
+// CHECK-SAME:    (%arg0: !hip.context, %arg1: memref<4x4xf32>)
+
+// CHECK-LABEL: func.func @caller_preserves_result
+// CHECK-SAME:    (%[[CTX4:.*]]: !hip.context, %[[IN:.*]]: memref<4x4xf32>)
+// CHECK:         %[[RES:.*]] = call @callee_with_result(%[[CTX4]], %[[IN]])
+// CHECK:         return %[[RES]]
+func.func @callee_with_result(%a: memref<4x4xf32>) -> memref<4x4xf32> {
+  return %a : memref<4x4xf32>
+}
+
+func.func @caller_preserves_result(%a: memref<4x4xf32>) -> memref<4x4xf32> {
+  %res = func.call @callee_with_result(%a) : (memref<4x4xf32>) -> memref<4x4xf32>
+  return %res : memref<4x4xf32>
+}

--- a/test/lit/Dialect/hip-add-context-arg.mlir
+++ b/test/lit/Dialect/hip-add-context-arg.mlir
@@ -110,3 +110,53 @@ func.func @caller_preserves_result(%a: memref<4x4xf32>) -> memref<4x4xf32> {
   %res = func.call @callee_with_result(%a) : (memref<4x4xf32>) -> memref<4x4xf32>
   return %res : memref<4x4xf32>
 }
+
+// ===== Mixed: pre-existing-context callee + caller that both already have context =====
+//
+// When a callee already has !hip.context, the pass skips it in Phase 1.
+// Callers that already have !hip.context are also skipped.  The call site
+// is already valid (correct arity and types) and must not be rewritten.
+//
+// Note: a caller *without* !hip.context cannot call a callee that expects
+// !hip.context (no way to produce the value), so the "mixed pre-existing
+// callee + non-context caller" scenario is impossible with valid input IR.
+//
+// CHECK-LABEL: func.func @preexisting_callee
+// CHECK-SAME:    (%arg0: !hip.context, %arg1: memref<8x8xf32>)
+// CHECK-NOT:     !hip.context, !hip.context
+// CHECK:         return
+
+// CHECK-LABEL: func.func @preexisting_caller
+// CHECK-SAME:    (%[[CTX5:.*]]: !hip.context, %[[A5:.*]]: memref<8x8xf32>)
+// CHECK:         call @preexisting_callee(%[[CTX5]], %[[A5]])
+// CHECK:         return
+func.func @preexisting_callee(%ctx: !hip.context, %a: memref<8x8xf32>) -> memref<8x8xf32> {
+  return %a : memref<8x8xf32>
+}
+
+func.func @preexisting_caller(%ctx: !hip.context, %a: memref<8x8xf32>) -> memref<8x8xf32> {
+  %res = func.call @preexisting_callee(%ctx, %a) : (!hip.context, memref<8x8xf32>) -> memref<8x8xf32>
+  return %res : memref<8x8xf32>
+}
+
+// ===== Coexistence: pre-existing-context func alongside updated func =====
+//
+// @standalone_preexisting already has !hip.context and is not called by anyone.
+// @standalone_needs_update does not.  After the pass, both have context and
+// the pre-existing function is completely untouched.
+//
+// CHECK-LABEL: func.func @standalone_preexisting
+// CHECK-SAME:    (%arg0: !hip.context, %arg1: memref<4x4xf32>)
+// CHECK-NOT:     !hip.context, !hip.context
+// CHECK:         return
+
+// CHECK-LABEL: func.func @standalone_needs_update
+// CHECK-SAME:    (%arg0: !hip.context, %arg1: memref<4x4xf32>)
+// CHECK:         return
+func.func @standalone_preexisting(%ctx: !hip.context, %a: memref<4x4xf32>) -> memref<4x4xf32> {
+  return %a : memref<4x4xf32>
+}
+
+func.func @standalone_needs_update(%a: memref<4x4xf32>) -> memref<4x4xf32> {
+  return %a : memref<4x4xf32>
+}

--- a/test/lit/Dialect/hip-lower-allocs.mlir
+++ b/test/lit/Dialect/hip-lower-allocs.mlir
@@ -84,3 +84,98 @@ func.func @multiple_frees(
   hip.miopen.softmax(%ctx) ins(%alloc1 : memref<2x64x64xf32>) outs(%alloc2 : memref<2x64x64xf32>)
   return %alloc2 : memref<2x64x64xf32>
 }
+
+// memref.dealloc of a hip.alloc result is converted to hip.free and the
+// memref.dealloc is erased.  The pass should NOT insert an extra hip.free
+// for alloc0 since it was already explicitly deallocated.
+// CHECK-LABEL: func.func @dealloc_conversion
+// CHECK-SAME:    (%[[CTX4:.*]]: !hip.context,
+// CHECK:         %[[ALLOC:.*]] = hip.alloc(%[[CTX4]]) : memref<8x8xf32>
+// CHECK:         hip.miopen.softmax
+// CHECK:         hip.free(%[[CTX4]], %[[ALLOC]]) : memref<8x8xf32>
+// CHECK-NOT:     memref.dealloc
+// CHECK-NOT:     hip.free
+// CHECK:         return
+func.func @dealloc_conversion(
+    %ctx: !hip.context,
+    %in: memref<8x8xf32>,
+    %out: memref<8x8xf32>) {
+  %alloc0 = memref.alloc() : memref<8x8xf32>
+  hip.miopen.softmax(%ctx) ins(%in : memref<8x8xf32>) outs(%alloc0 : memref<8x8xf32>)
+  memref.dealloc %alloc0 : memref<8x8xf32>
+  return
+}
+
+// Two allocs where both are used by multiple ops: verify free placement
+// accounts for all direct users.  alloc0 is used by both matmul (as output)
+// and softmax (as input).  Free goes after softmax (the later user).
+// CHECK-LABEL: func.func @free_after_all_direct_users
+// CHECK-SAME:    (%[[CTX5:.*]]: !hip.context,
+// CHECK:         %[[A:.*]] = hip.alloc(%[[CTX5]]) : memref<8x8xf32>
+// CHECK:         hip.hipblaslt.matmul{{.*}}outs(%[[A]] :
+// CHECK:         %[[B:.*]] = hip.alloc(%[[CTX5]]) : memref<8x8xf32>
+// CHECK:         hip.miopen.softmax{{.*}}ins(%[[A]]{{.*}}outs(%[[B]] :
+// CHECK:         hip.free(%[[CTX5]], %[[A]]) : memref<8x8xf32>
+// CHECK:         return %[[B]]
+func.func @free_after_all_direct_users(
+    %ctx: !hip.context,
+    %a: memref<8x8xf32, strided<[?, ?], offset: ?>>,
+    %b: memref<8x8xf32, strided<[?, ?], offset: ?>>) -> memref<8x8xf32> {
+  %alloc0 = memref.alloc() : memref<8x8xf32>
+  hip.hipblaslt.matmul(%ctx) ins(%a, %b : memref<8x8xf32, strided<[?, ?], offset: ?>>, memref<8x8xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<8x8xf32>)
+  %alloc1 = memref.alloc() : memref<8x8xf32>
+  hip.miopen.softmax(%ctx) ins(%alloc0 : memref<8x8xf32>) outs(%alloc1 : memref<8x8xf32>)
+  return %alloc1 : memref<8x8xf32>
+}
+
+// Alias chain: alloc0 -> subview -> cast.  BufferViewFlowAnalysis tracks all
+// downstream aliases via resolve(), so hip.free is placed after the LAST
+// transitive consumer (the matmul that reads the cast), not just after the
+// subview.  The alloc is not returned (return %out), so it must be freed.
+// CHECK-LABEL: func.func @view_alias_chain_free_placement
+// CHECK-SAME:    (%[[CTX6:.*]]: !hip.context,
+// CHECK:         %[[ALLOC:.*]] = hip.alloc(%[[CTX6]]) : memref<2x64x64xf32>
+// CHECK:         memref.subview
+// CHECK:         memref.cast
+// CHECK:         hip.hipblaslt.matmul
+// CHECK:         hip.free(%[[CTX6]], %[[ALLOC]]) : memref<2x64x64xf32>
+// CHECK:         return
+func.func @view_alias_chain_free_placement(
+    %ctx: !hip.context,
+    %b: memref<64x64xf32, strided<[?, ?], offset: ?>>,
+    %out: memref<2x64x64xf32>) -> memref<2x64x64xf32> {
+  %alloc0 = memref.alloc() {alignment = 64 : i64} : memref<2x64x64xf32>
+  %sv = memref.subview %alloc0[0, 0, 0][1, 64, 64][1, 1, 1]
+      : memref<2x64x64xf32> to memref<1x64x64xf32, strided<[4096, 64, 1]>>
+  %cast = memref.cast %sv
+      : memref<1x64x64xf32, strided<[4096, 64, 1]>>
+        to memref<1x64x64xf32, strided<[?, ?, ?], offset: ?>>
+  hip.hipblaslt.matmul(%ctx) ins(%cast, %b : memref<1x64x64xf32, strided<[?, ?, ?], offset: ?>>, memref<64x64xf32, strided<[?, ?], offset: ?>>) outs(%out : memref<2x64x64xf32>)
+  return %out : memref<2x64x64xf32>
+}
+
+// Pool pattern: after hip-pool-allocs, the function has a single memref.alloc
+// (the pool) with memref.view aliases, one of which is returned.
+// BufferViewFlowAnalysis::resolve(pool) must return {pool, view0, view1},
+// so isAliasInSet detects that view1 (returned) aliases the pool.
+// No hip.free should be emitted for the pool.
+// CHECK-LABEL: func.func @pool_view_returned_no_free
+// CHECK-SAME:    (%[[CTX7:.*]]: !hip.context,
+// CHECK:         %[[POOL:.*]] = hip.alloc(%[[CTX7]]) : memref<512xi8>
+// CHECK:         memref.view %[[POOL]]
+// CHECK:         memref.view %[[POOL]]
+// CHECK-NOT:     hip.free
+// CHECK:         return
+func.func @pool_view_returned_no_free(
+    %ctx: !hip.context,
+    %a: memref<8x8xf32, strided<[?, ?], offset: ?>>,
+    %b: memref<8x8xf32, strided<[?, ?], offset: ?>>) -> memref<8x8xf32> {
+  %c0 = arith.constant 0 : index
+  %c256 = arith.constant 256 : index
+  %pool = memref.alloc() : memref<512xi8>
+  %view0 = memref.view %pool[%c0][] : memref<512xi8> to memref<8x8xf32>
+  hip.hipblaslt.matmul(%ctx) ins(%a, %b : memref<8x8xf32, strided<[?, ?], offset: ?>>, memref<8x8xf32, strided<[?, ?], offset: ?>>) outs(%view0 : memref<8x8xf32>)
+  %view1 = memref.view %pool[%c256][] : memref<512xi8> to memref<8x8xf32>
+  hip.miopen.softmax(%ctx) ins(%view0 : memref<8x8xf32>) outs(%view1 : memref<8x8xf32>)
+  return %view1 : memref<8x8xf32>
+}

--- a/test/lit/Dialect/hip-pool-allocs.mlir
+++ b/test/lit/Dialect/hip-pool-allocs.mlir
@@ -6,6 +6,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: hip-mlir-opt --hip-pool-allocs %s | FileCheck %s
+// RUN: hip-mlir-opt --hip-pool-allocs='alignment=64' %s | FileCheck %s --check-prefix=ALIGN64
 
 // ===== Static pooling: two non-overlapping f32 allocs =====
 //
@@ -162,6 +163,10 @@ func.func @mixed_static_dynamic(
 // CHECK:         memref.view %[[POOL]]
 // CHECK:         memref.view %[[POOL]]
 // CHECK:         return
+//
+// With --alignment=64, each 4-byte alloc rounds to 64 bytes -> pool = 128xi8.
+// ALIGN64-LABEL: func.func @alignment_256
+// ALIGN64:         memref.alloc() : memref<128xi8>
 func.func @alignment_256(
     %ctx: !hip.context,
     %in: memref<1xf32>) -> memref<1xf32> {
@@ -170,4 +175,86 @@ func.func @alignment_256(
   %alloc1 = memref.alloc() : memref<1xf32>
   hip.miopen.softmax(%ctx) ins(%alloc0 : memref<1xf32>) outs(%alloc1 : memref<1xf32>)
   return %alloc1 : memref<1xf32>
+}
+
+// ===== Dynamic: two buckets with different SSA sizes =====
+//
+// Two dynamic allocs with different dim values (%n vs %m) go into separate
+// buckets.  Pool = bucket0_aligned_size + bucket1_aligned_size.
+//
+// CHECK-LABEL: func.func @dynamic_two_buckets
+// CHECK:         %[[POOL:.*]] = memref.alloc({{.*}}) : memref<?xi8>
+// CHECK:         memref.view %[[POOL]]{{.*}} : memref<?xi8> to memref<?x8xf32>
+// CHECK:         memref.view %[[POOL]]{{.*}} : memref<?xi8> to memref<?x4xf32>
+// CHECK:         return
+func.func @dynamic_two_buckets(
+    %ctx: !hip.context,
+    %a: memref<?x8xf32>,
+    %b: memref<8x8xf32, strided<[?, ?], offset: ?>>,
+    %c: memref<?x4xf32>,
+    %n: index, %m: index) -> memref<?x4xf32> {
+  %alloc0 = memref.alloc(%n) : memref<?x8xf32>
+  hip.hipblaslt.matmul(%ctx) ins(%a, %b : memref<?x8xf32>, memref<8x8xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<?x8xf32>)
+  %alloc1 = memref.alloc(%m) : memref<?x4xf32>
+  hip.miopen.softmax(%ctx) ins(%c : memref<?x4xf32>) outs(%alloc1 : memref<?x4xf32>)
+  return %alloc1 : memref<?x4xf32>
+}
+
+// ===== Metadata: hipdnn.pool_size and hipdnn.buffer_offsets =====
+//
+// Two static allocs: pool_size=512, offsets=[0, 256].
+//
+// CHECK-LABEL: func.func @metadata_attributes
+// CHECK-SAME:    attributes {hipdnn.buffer_offsets = [0, 256], hipdnn.pool_size = 512 : i64}
+func.func @metadata_attributes(
+    %ctx: !hip.context,
+    %a: memref<8x8xf32, strided<[?, ?], offset: ?>>,
+    %b: memref<8x8xf32, strided<[?, ?], offset: ?>>) -> memref<8x8xf32> {
+  %alloc0 = memref.alloc() : memref<8x8xf32>
+  hip.hipblaslt.matmul(%ctx) ins(%a, %b : memref<8x8xf32, strided<[?, ?], offset: ?>>, memref<8x8xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<8x8xf32>)
+  %alloc1 = memref.alloc() : memref<8x8xf32>
+  hip.miopen.softmax(%ctx) ins(%alloc0 : memref<8x8xf32>) outs(%alloc1 : memref<8x8xf32>)
+  return %alloc1 : memref<8x8xf32>
+}
+
+// ===== Pre-existing dealloc: erased and replaced with pool dealloc =====
+//
+// When input has memref.dealloc ops, they should be erased after pooling
+// (since views into the pool can't be individually deallocated) and a
+// single memref.dealloc for the pool should appear before the terminator.
+//
+// CHECK-LABEL: func.func @preexisting_deallocs
+// CHECK:         %[[POOL:.*]] = memref.alloc() : memref<512xi8>
+// CHECK:         memref.view %[[POOL]]
+// CHECK:         memref.view %[[POOL]]
+// CHECK-NOT:     memref.dealloc{{.*}}memref<8x8xf32>
+// CHECK:         memref.dealloc %[[POOL]] : memref<512xi8>
+// CHECK:         return
+func.func @preexisting_deallocs(
+    %ctx: !hip.context,
+    %in: memref<8x8xf32>,
+    %out: memref<8x8xf32>) {
+  %alloc0 = memref.alloc() : memref<8x8xf32>
+  hip.miopen.softmax(%ctx) ins(%in : memref<8x8xf32>) outs(%alloc0 : memref<8x8xf32>)
+  %alloc1 = memref.alloc() : memref<8x8xf32>
+  hip.miopen.softmax(%ctx) ins(%alloc0 : memref<8x8xf32>) outs(%alloc1 : memref<8x8xf32>)
+  memref.dealloc %alloc0 : memref<8x8xf32>
+  memref.dealloc %alloc1 : memref<8x8xf32>
+  return
+}
+
+// ===== Dynamic metadata: offsets contain -1 for dynamic buckets =====
+//
+// CHECK-LABEL: func.func @dynamic_metadata
+// CHECK-SAME:    attributes {hipdnn.buffer_offsets = [0, -1]}
+func.func @dynamic_metadata(
+    %ctx: !hip.context,
+    %a: memref<?x8xf32>,
+    %b: memref<8x8xf32, strided<[?, ?], offset: ?>>,
+    %n: index) -> memref<?x8xf32> {
+  %alloc0 = memref.alloc(%n) : memref<?x8xf32>
+  hip.hipblaslt.matmul(%ctx) ins(%a, %b : memref<?x8xf32>, memref<8x8xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<?x8xf32>)
+  %alloc1 = memref.alloc(%n) : memref<?x8xf32>
+  hip.miopen.softmax(%ctx) ins(%alloc0 : memref<?x8xf32>) outs(%alloc1 : memref<?x8xf32>)
+  return %alloc1 : memref<?x8xf32>
 }

--- a/test/lit/Dialect/hip-pool-allocs.mlir
+++ b/test/lit/Dialect/hip-pool-allocs.mlir
@@ -7,6 +7,10 @@
 
 // RUN: hip-mlir-opt --hip-pool-allocs %s | FileCheck %s
 // RUN: hip-mlir-opt --hip-pool-allocs='alignment=64' %s | FileCheck %s --check-prefix=ALIGN64
+// RUN: not hip-mlir-opt --hip-pool-allocs='alignment=0' %s 2>&1 | FileCheck %s --check-prefix=BAD-ALIGN
+// RUN: not hip-mlir-opt --hip-pool-allocs='alignment=3' %s 2>&1 | FileCheck %s --check-prefix=BAD-ALIGN
+// RUN: not hip-mlir-opt --hip-pool-allocs='alignment=-1' %s 2>&1 | FileCheck %s --check-prefix=BAD-ALIGN
+// BAD-ALIGN: alignment must be a positive power of 2
 
 // ===== Static pooling: two non-overlapping f32 allocs =====
 //

--- a/test/lit/Dialect/hip-resolve-extern-constants.mlir
+++ b/test/lit/Dialect/hip-resolve-extern-constants.mlir
@@ -1,0 +1,98 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+//===----------------------------------------------------------------------===//
+// FileCheck tests for --hip-resolve-extern-constants (standalone pass).
+//
+// Verifies:
+//   - memref.get_global replaced with memref.view into %_constants arg
+//   - Function signatures gain %_constants : memref<?xi8>
+//   - Call sites forward the constants buffer
+//   - Extern globals are erased
+//   - Module hip.constants_file attribute is stripped
+//   - No-op when no extern globals exist
+//   - Multiple extern globals with distinct offsets
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt --hip-resolve-extern-constants %s | FileCheck %s
+
+// ---- Module-level checks ----
+// Extern globals should be erased.
+// CHECK-NOT: memref.global{{.*}}hip.external_data
+// hip.constants_file should be stripped.
+// CHECK-NOT: hip.constants_file
+
+// ===== Single function using one extern global =====
+//
+// CHECK-LABEL: func.func @single_func_one_global
+// CHECK-SAME:    (%[[A:.*]]: memref<4x4xf32>, %[[CONST:.*]]: memref<?xi8>)
+// CHECK:         %[[OFF:.*]] = arith.constant 0 : index
+// CHECK:         %[[VIEW:.*]] = memref.view %[[CONST]][%[[OFF]]][]
+// CHECK-SAME:      : memref<?xi8> to memref<4x4xf32>
+// CHECK-NOT:     memref.get_global
+// CHECK:         return %[[VIEW]]
+
+// ===== Function with multiple extern globals at different offsets =====
+//
+// CHECK-LABEL: func.func @multi_global_offsets
+// CHECK-SAME:    (%[[A2:.*]]: memref<4x4xf32>, %[[CONST2:.*]]: memref<?xi8>)
+// CHECK:         memref.view %[[CONST2]]{{.*}} : memref<?xi8> to memref<4x4xf32>
+// CHECK:         memref.view %[[CONST2]]{{.*}} : memref<?xi8> to memref<2x2xf32>
+// CHECK-NOT:     memref.get_global
+// CHECK:         return
+
+// ===== Caller/callee: transitive propagation of constants arg =====
+//
+// CHECK-LABEL: func.func @callee_uses_global
+// CHECK-SAME:    (%[[CA:.*]]: memref<4x4xf32>, %[[CC:.*]]: memref<?xi8>)
+// CHECK:         memref.view %[[CC]]
+// CHECK-NOT:     memref.get_global
+
+// CHECK-LABEL: func.func @caller_passes_constants
+// CHECK-SAME:    (%[[TA:.*]]: memref<4x4xf32>, %[[TC:.*]]: memref<?xi8>)
+// CHECK:         call @callee_uses_global(%[[TA]], %[[TC]])
+
+// ===== No-op: function without extern globals is unchanged =====
+//
+// CHECK-LABEL: func.func @no_globals_noop
+// CHECK-SAME:    (%arg0: memref<4x4xf32>)
+// CHECK-NOT:     memref<?xi8>
+// CHECK:         return
+
+module attributes {hip.constants_file = "model.constants.bin"} {
+
+  memref.global "private" @weight_a : memref<4x4xf32> {
+    alignment = 64 : i64,
+    hip.external_data = {offset = 0 : i64, size = 64 : i64}
+  }
+
+  memref.global "private" @weight_b : memref<2x2xf32> {
+    alignment = 64 : i64,
+    hip.external_data = {offset = 64 : i64, size = 16 : i64}
+  }
+
+  func.func @single_func_one_global(%arg0: memref<4x4xf32>) -> memref<4x4xf32> {
+    %w = memref.get_global @weight_a : memref<4x4xf32>
+    return %w : memref<4x4xf32>
+  }
+
+  func.func @multi_global_offsets(%arg0: memref<4x4xf32>) -> memref<4x4xf32> {
+    %wa = memref.get_global @weight_a : memref<4x4xf32>
+    %wb = memref.get_global @weight_b : memref<2x2xf32>
+    return %wa : memref<4x4xf32>
+  }
+
+  func.func @callee_uses_global(%arg0: memref<4x4xf32>) -> memref<4x4xf32> {
+    %w = memref.get_global @weight_a : memref<4x4xf32>
+    return %w : memref<4x4xf32>
+  }
+
+  func.func @caller_passes_constants(%arg0: memref<4x4xf32>) -> memref<4x4xf32> {
+    %res = func.call @callee_uses_global(%arg0) : (memref<4x4xf32>) -> memref<4x4xf32>
+    return %res : memref<4x4xf32>
+  }
+
+  func.func @no_globals_noop(%arg0: memref<4x4xf32>) -> memref<4x4xf32> {
+    return %arg0 : memref<4x4xf32>
+  }
+}


### PR DESCRIPTION
## Description

Clean up all five HIP dialect transform passes (`PoolAllocs`, `OptimizeMemRefs`, `LowerAllocs`, `AddHipContextArg`, `ResolveExternConstants`).

**Correctness**:
- `getStaticByteSize` truncated for sub-byte types (`bitWidth / 8`) — use `llvm::divideCeil`
- `AddHipContextArg` didn't update `func.call` sites — add two-phase update following `BufferResultsToOutParams` pattern
- `ResolveExternConstants` stored pointers into a growable `SmallVector` — use index-based lookup
- `LowerAllocs` built `BufferViewFlowAnalysis` before `memref.alloc → hip.alloc` replacement, missing downstream aliases — use-after-free in `pool-allocs → lower-allocs` pipeline

**Refactoring**:
- Replace hand-rolled alias walks (`isMemRefAlias`, `findLastTransitiveUser`, `isTransitivelyReturned`) with shared `BufferUtils` using MLIR's `BufferViewFlowAnalysis`
- Use `createOrFold` to eliminate trivial `addi(x,0)` / `muli(x,1)` from pool arithmetic
- Skip `emitAlignUp` when `staticFactor` is already a multiple of alignment (eliminates runtime `divui`)
- Add final `CSE + canonicalize` after `LowerAllocs` / `ResolveExternConstants` in the pipeline

**Instrumentation**: `DEBUG_TYPE`, `STATISTIC`, `LLVM_DEBUG` across all passes. New and extended LIT tests.

```bash
# Pipeline
hip-mlir-opt attention.onnx.mlir \
  --onnx-to-hip-pipeline='externalize-min-num-elements=256 externalize-output-dir=/tmp' \
  --mlir-elide-elementsattrs-if-larger=4
```

**Final IR for attention model with dynamic shapes**:

```mlir
module attributes {llvm.data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128", llvm.target_triple = "x86_64-unknown-linux-gnu", "onnx-mlir.symbol-postfix" = "attention_dynamic"} {
  memref.global "private" constant @__constant_xf32 : memref<f32> = dense<1.250000e-01> {alignment = 64 : i64}
  func.func @main_graph(%arg0: !hip.context, %arg1: memref<?x?x64xf32, strided<[?, ?, ?], offset: ?>> {onnx.dim_params = "0:batch,1:seq", onnx.name = "X"}, %arg2: memref<?x?x64xf32> {bufferize.result, onnx.dim_params = "0:batch,1:seq", onnx.name = "out"}, %arg3: memref<?xi8>) attributes {hipdnn.buffer_offsets = [0, -1, -1, -1, -1, -1]} {
    %c32768 = arith.constant 32768 : index
    %c16384 = arith.constant 16384 : index
    %c512 = arith.constant 512 : index
    %c3 = arith.constant 3 : index
    %c255 = arith.constant 255 : index
    %c4 = arith.constant 4 : index
    %c256 = arith.constant 256 : index
    %c2 = arith.constant 2 : index
    %c1 = arith.constant 1 : index
    %c0 = arith.constant 0 : index
    %0 = memref.get_global @__constant_xf32 : memref<f32>
    %view = memref.view %arg3[%c0][] : memref<?xi8> to memref<64x64xf32>
    %view_0 = memref.view %arg3[%c16384][] : memref<?xi8> to memref<64x64xf32>
    %view_1 = memref.view %arg3[%c32768][] : memref<?xi8> to memref<64x64xf32>
    %dim = memref.dim %arg1, %c0 : memref<?x?x64xf32, strided<[?, ?, ?], offset: ?>>
    %dim_2 = memref.dim %arg1, %c1 : memref<?x?x64xf32, strided<[?, ?, ?], offset: ?>>
    %1 = arith.muli %dim, %c256 : index
    %2 = arith.muli %1, %dim_2 : index
    %3 = arith.muli %dim, %c4 : index
    %4 = arith.muli %3, %dim_2 : index
    %5 = arith.muli %4, %dim_2 : index
    %6 = arith.addi %5, %c255 : index
    %7 = arith.divui %6, %c256 : index
    %8 = arith.muli %7, %c256 : index
    %9 = arith.muli %2, %c4 : index
    %10 = arith.muli %7, %c512 : index
    %11 = arith.addi %9, %10 : index
    %12 = hip.alloc(%arg0, %11) : memref<?xi8>
    %13 = arith.muli %2, %c2 : index
    %14 = arith.muli %2, %c3 : index
    %15 = arith.addi %9, %8 : index
    %view_3 = memref.view %12[%c0][%dim, %dim_2] : memref<?xi8> to memref<?x?x64xf32>
    hip.hipblaslt.matmul(%arg0) ins(%arg1, %view : memref<?x?x64xf32, strided<[?, ?, ?], offset: ?>>, memref<64x64xf32>) outs(%view_3 : memref<?x?x64xf32>)
    %view_4 = memref.view %12[%2][%dim, %dim_2] : memref<?xi8> to memref<?x?x64xf32>
    hip.hipblaslt.matmul(%arg0) ins(%arg1, %view_0 : memref<?x?x64xf32, strided<[?, ?, ?], offset: ?>>, memref<64x64xf32>) outs(%view_4 : memref<?x?x64xf32>)
    %view_5 = memref.view %12[%13][%dim, %dim_2] : memref<?xi8> to memref<?x?x64xf32>
    hip.hipblaslt.matmul(%arg0) ins(%arg1, %view_1 : memref<?x?x64xf32, strided<[?, ?, ?], offset: ?>>, memref<64x64xf32>) outs(%view_5 : memref<?x?x64xf32>)
    %view_6 = memref.view %12[%14][%dim, %dim_2] : memref<?xi8> to memref<?x64x?xf32>
    hip.transpose(%arg0, %c1, %c2) ins(%view_4 : memref<?x?x64xf32>) outs(%view_6 : memref<?x64x?xf32>)
    %view_7 = memref.view %12[%9][%dim, %dim_2, %dim_2] : memref<?xi8> to memref<?x?x?xf32>
    hip.hipblaslt.matmul(%arg0) ins(%view_3, %view_6 : memref<?x?x64xf32>, memref<?x64x?xf32>) outs(%view_7 : memref<?x?x?xf32>)
    %view_8 = memref.view %12[%15][%dim, %dim_2, %dim_2] : memref<?xi8> to memref<?x?x?xf32>
    hip.miopen.mul(%arg0) ins(%view_7, %0 : memref<?x?x?xf32>, memref<f32>) outs(%view_8 : memref<?x?x?xf32>)
    hip.miopen.softmax(%arg0) ins(%view_8 : memref<?x?x?xf32>) outs(%view_7 : memref<?x?x?xf32>)
    hip.hipblaslt.matmul(%arg0) ins(%view_7, %view_5 : memref<?x?x?xf32>, memref<?x?x64xf32>) outs(%arg2 : memref<?x?x64xf32>)
    hip.free(%arg0, %12) : memref<?xi8>
    return
  }
}
```