### PR TITLE
Fix #24 build errors caused by PR #26/#23 refactoring

### DIFF
--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -567,7 +567,7 @@ MutableOperandRange SigmoidOp::getDpsInitsMutable() {
 void SigmoidOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
         &effects) {
-  emitDpsMemoryEffects(*this, {getInput()}, getOutputMutable(), effects);
+  emitDpsMemoryEffects(getDpsInputOperands(), getDpsInitsMutable(), effects);
 }
 
 //===----------------------------------------------------------------------===//
@@ -579,8 +579,7 @@ MutableOperandRange SubOp::getDpsInitsMutable() { return getOutputMutable(); }
 void SubOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
         &effects) {
-  emitDpsMemoryEffects(*this, {getLhs(), getRhs()}, getOutputMutable(),
-                       effects);
+  emitDpsMemoryEffects(getDpsInputOperands(), getDpsInitsMutable(), effects);
 }
 
 //===----------------------------------------------------------------------===//
@@ -592,7 +591,7 @@ MutableOperandRange CastOp::getDpsInitsMutable() { return getOutputMutable(); }
 void CastOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
         &effects) {
-  emitDpsMemoryEffects(*this, {getInput()}, getOutputMutable(), effects);
+  emitDpsMemoryEffects(getDpsInputOperands(), getDpsInitsMutable(), effects);
 }
 
 //===----------------------------------------------------------------------===//
@@ -606,8 +605,7 @@ MutableOperandRange ReduceSumOp::getDpsInitsMutable() {
 void ReduceSumOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
         &effects) {
-  emitDpsMemoryEffects(*this, {getData(), getAxes()}, getOutputMutable(),
-                       effects);
+  emitDpsMemoryEffects(getDpsInputOperands(), getDpsInitsMutable(), effects);
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/lit/Conversion/onnx-to-hip/test_cast.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_cast.mlir
@@ -20,6 +20,11 @@
 // RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
 
 module {
+  // Dummy entry point required by generateModuleMetadata.
+  func.func @main_graph(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+    return %arg0 : tensor<4xf32>
+  }
+
   func.func @cast_i64_to_i32(%input: tensor<4xi64>) -> tensor<4xi32> {
     %output = "onnx.Cast"(%input) {to = i32} : (tensor<4xi64>) -> tensor<4xi32>
     return %output : tensor<4xi32>

--- a/test/lit/Conversion/onnx-to-hip/test_reduce_sum.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_reduce_sum.mlir
@@ -21,6 +21,11 @@
 // RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip | FileCheck %s
 
 module {
+  // Dummy entry point required by generateModuleMetadata.
+  func.func @main_graph(%arg0: tensor<1x128xi64>) -> tensor<1x128xi64> {
+    return %arg0 : tensor<1x128xi64>
+  }
+
   // keepdims = 1: reduced dim is kept as size 1
   func.func @test_reduce_sum_keepdims(%data: tensor<1x128xi64>, %axes: tensor<i64>) -> tensor<1x1xi64> {
     // After conversion: context prepended, tensors remain tensors, tensor return

--- a/test/lit/Conversion/onnx-to-hip/test_sub.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_sub.mlir
@@ -20,6 +20,11 @@
 // RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip | FileCheck %s
 
 module {
+  // Dummy entry point required by generateModuleMetadata.
+  func.func @main_graph(%arg0: tensor<1x1xi64>) -> tensor<1x1xi64> {
+    return %arg0 : tensor<1x1xi64>
+  }
+
   func.func @test_sub(%lhs: tensor<1x1xi64>, %rhs: tensor<1x1xi64>) -> tensor<1x1xi64> {
     // After conversion: context prepended, tensors remain tensors, tensor return
     // CHECK-LABEL: func.func @test_sub


### PR DESCRIPTION
## Summary

Fixes build errors in PR #24 caused by PR #26 refactoring and adds missing `@main_graph` functions required by PR #23.

## Problem

PR #24 (merged) added 4 operations but broke the build:
1. **Build error**: Used old `emitDpsMemoryEffects` signature (PR #26 changed it)
2. **Test failures**: Missing `@main_graph` entry point (required by PR #23)

## Solution

### Fix 1: Update emitDpsMemoryEffects calls

Changed 4 operations (SigmoidOp, SubOp, CastOp, ReduceSumOp) in `lib/Dialect/IR/HipDialect.cpp`:

```cpp
// Before (PR #24 - broken)
emitDpsMemoryEffects(*this, {getInput()}, getOutputMutable(), effects);

// After (matches PR #26)
emitDpsMemoryEffects(getDpsInputOperands(), getDpsInitsMutable(), effects);
```

### Fix 2: Add @main_graph to test files

Added dummy entry point to 3 test files:
- `test/lit/Conversion/onnx-to-hip/test_cast.mlir`
- `test/lit/Conversion/onnx-to-hip/test_reduce_sum.mlir`
- `test/lit/Conversion/onnx-to-hip/test_sub.mlir`


