### PR TITLE
Add hip.get_constant and index-based constant resolution

### DIFF
--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -96,6 +96,39 @@ def Hip_FreeOp : Hip_Op<"free",
   }];
 }
 
+// ===== Constant Management ===================================================
+
+def Hip_GetConstantOp : Hip_Op<"get_constant", [
+  DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
+]> {
+  let summary = "Retrieve constant from GPU memory";
+  let description = [{
+    Retrieves a pre-uploaded constant from state->gpu_constants[index].
+
+    Arguments:
+    - ctx: HIP execution context (contains gpu_constants array)
+    - index: Index in gpu_constants array (0, 1, 2, ...)
+
+    Returns:
+    - memref: GPU memory reference to the constant
+
+    Example:
+    ```mlir
+    %weight = hip.get_constant(%ctx, %index_0) : memref<64x3x3x3xf32, 1>
+    ```
+  }];
+
+  let arguments = (ins
+    Hip_ContextType:$ctx,
+    I64:$index
+  );
+  let results = (outs AnyMemRef:$result);
+
+  let assemblyFormat = [{
+    `(` $ctx `,` $index `)` attr-dict `:` type($result)
+  }];
+}
+
 // ===== Region ops (structural grouping, no runtime) =========================
 
 def Hip_MiopenGraphOp : Hip_Op<"miopen.graph", [SingleBlock, NoTerminator]> {

--- a/include/hip/Dialect/Transforms/Passes.td
+++ b/include/hip/Dialect/Transforms/Passes.td
@@ -153,22 +153,26 @@ def LowerAllocsPass : Pass<"hip-lower-allocs", "mlir::func::FuncOp"> {
 
 def ResolveExternConstantsPass
     : Pass<"hip-resolve-extern-constants", "mlir::ModuleOp"> {
-  let summary = "Replace extern memref.global constants with views into a "
-                "constants buffer argument";
+  let summary = "Replace extern memref.global constants with "
+                "hip.get_constant ops";
   let description = [{
     Resolves externalized constants (memref.global ops with hip.external_data
     attributes produced by --convert-onnx-to-hip) by replacing each
-    memref.get_global with a memref.view into a new %_constants : memref<?xi8>
-    function argument.
+    memref.get_global with a hip.get_constant(%ctx, %index) operation.
 
-    The host is responsible for loading the sidecar .constants.bin file
-    (e.g. via hip_load_constants()) and passing the resulting pointer as
-    the %_constants argument.
+    The index is read from the hip.external_data attribute on each extern
+    memref.global. The !hip.context is taken from function argument 0
+    (inserted by --hip-add-context-arg).
+
+    The runtime is responsible for loading the sidecar constants.bin file
+    via morphizen::FileSystem, uploading constants to GPU memory, and
+    returning GPU pointers via hipdnn_ep_constant_get(state, index).
 
     This pass should run after all buffer optimizations (hip-pool-allocs,
     hip-lower-allocs) and before --convert-hip-to-llvm.
   }];
   let dependentDialects = [
+    "mlir::hip::HipDialect",
     "mlir::arith::ArithDialect",
     "mlir::func::FuncDialect",
     "mlir::memref::MemRefDialect"

--- a/include/hip/Support/DiskFileSystem.h
+++ b/include/hip/Support/DiskFileSystem.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#pragma once
+
+#include "morphizen-foundation/file_io.hpp"
+#include <cstdio>
+#include <filesystem>
+#include <string>
+#ifdef _WIN32
+#include <io.h>
+#endif
+
+namespace mlir::hip {
+
+class DiskFileReader : public morphizen::FileReader {
+public:
+  explicit DiskFileReader(const char *path)
+      : file_(std::fopen(path, "rb")), size_(0) {
+    if (!file_)
+      return;
+#ifdef _WIN32
+    _fseeki64(file_, 0, SEEK_END);
+    size_ = static_cast<std::size_t>(_ftelli64(file_));
+    _fseeki64(file_, 0, SEEK_SET);
+#else
+    fseeko(file_, 0, SEEK_END);
+    size_ = static_cast<std::size_t>(ftello(file_));
+    fseeko(file_, 0, SEEK_SET);
+#endif
+  }
+
+  ~DiskFileReader() override {
+    if (file_)
+      std::fclose(file_);
+  }
+
+  bool ok() const { return file_ != nullptr; }
+  std::size_t size() const override { return size_; }
+
+  void rewind() const override {
+    if (file_) {
+#ifdef _WIN32
+      _fseeki64(file_, 0, SEEK_SET);
+#else
+      fseeko(file_, 0, SEEK_SET);
+#endif
+    }
+  }
+
+  std::size_t fread(void *buffer, std::size_t size) const override {
+    if (!file_)
+      return 0;
+    return std::fread(buffer, 1, size, file_);
+  }
+
+private:
+  std::FILE *file_;
+  std::size_t size_;
+};
+
+class DiskFileWriter : public morphizen::FileWriter {
+public:
+  explicit DiskFileWriter(const char *path) : file_(std::fopen(path, "wb")) {}
+
+  ~DiskFileWriter() override {
+    if (file_)
+      std::fclose(file_);
+  }
+
+  bool ok() const { return file_ != nullptr; }
+
+  std::size_t fwrite(const void *buffer, std::size_t size) const override {
+    if (!file_)
+      return 0;
+    return std::fwrite(buffer, 1, size, file_);
+  }
+
+private:
+  std::FILE *file_;
+};
+
+class DiskFileSystem : public morphizen::FileSystem {
+public:
+  explicit DiskFileSystem(const char *base_dir)
+      : base_dir_(std::filesystem::path(base_dir).lexically_normal()) {}
+
+  morphizen::FileReader *create_reader(const char *path) override {
+    std::string full_path = (base_dir_ / path).string();
+    auto *r = new DiskFileReader(full_path.c_str());
+    if (!r->ok()) {
+      delete r;
+      return nullptr;
+    }
+    return r;
+  }
+
+  morphizen::FileWriter *create_writer(const char *path) override {
+    std::string full_path = (base_dir_ / path).string();
+    auto *w = new DiskFileWriter(full_path.c_str());
+    if (!w->ok()) {
+      delete w;
+      return nullptr;
+    }
+    return w;
+  }
+
+  void destroy_reader(morphizen::FileReader *r) override { delete r; }
+  void destroy_writer(morphizen::FileWriter *w) override { delete w; }
+
+private:
+  std::filesystem::path base_dir_;
+};
+
+} // namespace mlir::hip

--- a/include/hip/Support/DiskFileSystem.h
+++ b/include/hip/Support/DiskFileSystem.h
@@ -7,6 +7,7 @@
 #include "morphizen-foundation/file_io.hpp"
 #include <cstdio>
 #include <filesystem>
+#include <memory>
 #include <string>
 #ifdef _WIN32
 #include <io.h>
@@ -14,71 +15,74 @@
 
 namespace mlir::hip {
 
+using FilePtr = std::unique_ptr<std::FILE, decltype(&std::fclose)>;
+
+inline int fileSeek(std::FILE *f, int64_t offset, int origin) {
+#ifdef _WIN32
+  return _fseeki64(f, offset, origin);
+#else
+  return fseeko(f, offset, origin);
+#endif
+}
+
+inline int64_t fileTell(std::FILE *f) {
+#ifdef _WIN32
+  return _ftelli64(f);
+#else
+  return ftello(f);
+#endif
+}
+
 class DiskFileReader : public morphizen::FileReader {
 public:
   explicit DiskFileReader(const char *path)
-      : file_(std::fopen(path, "rb")), size_(0) {
+      : file_(std::fopen(path, "rb"), &std::fclose), size_(0) {
     if (!file_)
       return;
-#ifdef _WIN32
-    _fseeki64(file_, 0, SEEK_END);
-    size_ = static_cast<std::size_t>(_ftelli64(file_));
-    _fseeki64(file_, 0, SEEK_SET);
-#else
-    fseeko(file_, 0, SEEK_END);
-    size_ = static_cast<std::size_t>(ftello(file_));
-    fseeko(file_, 0, SEEK_SET);
-#endif
-  }
-
-  ~DiskFileReader() override {
-    if (file_)
-      std::fclose(file_);
+    fileSeek(file_.get(), 0, SEEK_END);
+    auto pos = fileTell(file_.get());
+    if (pos < 0) {
+      file_.reset();
+      return;
+    }
+    size_ = static_cast<std::size_t>(pos);
+    fileSeek(file_.get(), 0, SEEK_SET);
   }
 
   bool ok() const { return file_ != nullptr; }
   std::size_t size() const override { return size_; }
 
   void rewind() const override {
-    if (file_) {
-#ifdef _WIN32
-      _fseeki64(file_, 0, SEEK_SET);
-#else
-      fseeko(file_, 0, SEEK_SET);
-#endif
-    }
+    if (file_)
+      fileSeek(file_.get(), 0, SEEK_SET);
   }
 
   std::size_t fread(void *buffer, std::size_t size) const override {
     if (!file_)
       return 0;
-    return std::fread(buffer, 1, size, file_);
+    return std::fread(buffer, 1, size, file_.get());
   }
 
 private:
-  std::FILE *file_;
+  FilePtr file_;
   std::size_t size_;
 };
 
 class DiskFileWriter : public morphizen::FileWriter {
 public:
-  explicit DiskFileWriter(const char *path) : file_(std::fopen(path, "wb")) {}
-
-  ~DiskFileWriter() override {
-    if (file_)
-      std::fclose(file_);
-  }
+  explicit DiskFileWriter(const char *path)
+      : file_(std::fopen(path, "wb"), &std::fclose) {}
 
   bool ok() const { return file_ != nullptr; }
 
   std::size_t fwrite(const void *buffer, std::size_t size) const override {
     if (!file_)
       return 0;
-    return std::fwrite(buffer, 1, size, file_);
+    return std::fwrite(buffer, 1, size, file_.get());
   }
 
 private:
-  std::FILE *file_;
+  FilePtr file_;
 };
 
 class DiskFileSystem : public morphizen::FileSystem {

--- a/include/morphizen-foundation/file_io.hpp
+++ b/include/morphizen-foundation/file_io.hpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <type_traits>
+
+namespace morphizen {
+
+class FileReader {
+public:
+  FileReader() = default;
+  FileReader(const FileReader &) = delete;
+  FileReader &operator=(const FileReader &) = delete;
+  virtual ~FileReader() = default;
+
+  virtual size_t size() const = 0;
+  virtual void rewind() const = 0;
+  virtual std::size_t fread(void *buffer, std::size_t size) const = 0;
+  virtual void *mmap() { return nullptr; }
+};
+
+class FileWriter {
+public:
+  FileWriter() = default;
+  FileWriter(const FileWriter &) = delete;
+  FileWriter &operator=(const FileWriter &) = delete;
+  virtual ~FileWriter() = default;
+
+  virtual std::size_t fwrite(const void *buffer, std::size_t size) const = 0;
+};
+
+class FileSystem {
+public:
+  FileSystem() = default;
+  FileSystem(const FileSystem &) = delete;
+  FileSystem &operator=(const FileSystem &) = delete;
+  virtual ~FileSystem() = default;
+
+  virtual FileReader *create_reader(const char *path) = 0;
+  virtual FileWriter *create_writer(const char *path) = 0;
+  virtual void destroy_reader(FileReader *reader) = 0;
+  virtual void destroy_writer(FileWriter *writer) = 0;
+
+  template <typename T> struct Deleter {
+    FileSystem *fs;
+    void operator()(T *ptr) const {
+      if constexpr (std::is_same_v<T, FileReader>)
+        fs->destroy_reader(ptr);
+      else
+        fs->destroy_writer(ptr);
+    }
+  };
+
+  std::unique_ptr<FileReader, Deleter<FileReader>>
+  create_reader_template(const char *path) {
+    return {create_reader(path), {this}};
+  }
+
+  std::unique_ptr<FileWriter, Deleter<FileWriter>>
+  create_writer_template(const char *path) {
+    return {create_writer(path), {this}};
+  }
+};
+
+} // namespace morphizen

--- a/lib/Conversion/HipToLLVM/HipToLLVM.cpp
+++ b/lib/Conversion/HipToLLVM/HipToLLVM.cpp
@@ -61,6 +61,7 @@ static constexpr const char *kWrapMiopenOpTensor =
 static constexpr const char *kWrapMiopenCast = "wrap_miopenCast";
 static constexpr const char *kWrapReduceSum = "wrap_reduce_sum";
 static constexpr const char *kWrapGQA = "wrap_group_query_attention";
+static constexpr const char *kHipGetConstant = "hipdnn_ep_constant_get";
 
 // Maps MLIR element type to runtime data type enum (HIPDNN_EP_DATATYPE_*).
 // Values must match the #defines in hipdnn_ep_runtime.h.
@@ -1647,6 +1648,71 @@ struct MemRefDeallocOpLowering
 };
 
 //===----------------------------------------------------------------------===//
+// GetConstantOp Lowering
+//===----------------------------------------------------------------------===//
+
+struct GetConstantOpLowering : public ConvertOpToLLVMPattern<GetConstantOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(GetConstantOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    ModuleOp module = op->getParentOfType<ModuleOp>();
+    Type ptrType = LLVM::LLVMPointerType::get(rewriter.getContext(), 0);
+    Type i64Type = IntegerType::get(rewriter.getContext(), 64);
+    MemRefType memRefType = op.getResult().getType();
+
+    SmallVector<Type, 2> paramTypes = {ptrType, i64Type};
+
+    FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
+        rewriter, module, kHipGetConstant, paramTypes, ptrType);
+    if (failed(funcOp))
+      return failure();
+
+    SmallVector<Value, 2> args = {adaptor.getCtx(), adaptor.getIndex()};
+    auto callOp = LLVM::CallOp::create(rewriter, loc, *funcOp, args);
+    Value gpuPtr = callOp.getResult();
+
+    // Cast to GPU address space only when the memref declares one (AS != 0).
+    unsigned targetAS = 0;
+    if (auto memSpace = memRefType.getMemorySpace())
+      if (auto intAttr = dyn_cast<IntegerAttr>(memSpace))
+        targetAS = intAttr.getInt();
+
+    Value dataPtr = gpuPtr;
+    if (targetAS != 0)
+      dataPtr = rewriter.create<LLVM::AddrSpaceCastOp>(
+          loc, LLVM::LLVMPointerType::get(rewriter.getContext(), targetAS),
+          gpuPtr);
+
+    auto shape = memRefType.getShape();
+    SmallVector<Value, 4> sizes;
+    SmallVector<Value, 4> strides;
+
+    for (int64_t dim : shape) {
+      Value size = rewriter.create<LLVM::ConstantOp>(
+          loc, i64Type, rewriter.getI64IntegerAttr(dim));
+      sizes.push_back(size);
+    }
+
+    int64_t stride = 1;
+    for (int i = shape.size() - 1; i >= 0; --i) {
+      Value strideVal = rewriter.create<LLVM::ConstantOp>(
+          loc, i64Type, rewriter.getI64IntegerAttr(stride));
+      strides.insert(strides.begin(), strideVal);
+      stride *= shape[i];
+    }
+
+    MemRefDescriptor desc = createMemRefDescriptor(
+        loc, memRefType, dataPtr, dataPtr, sizes, strides, rewriter);
+
+    rewriter.replaceOp(op, {desc});
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
 // ConvertHipToLLVM Pass
 //===----------------------------------------------------------------------===//
 
@@ -1671,13 +1737,13 @@ void ConvertHipToLLVMPass::runOnOperation() {
 
   // HIP dialect-specific lowerings
   patterns
-      .add<AllocOpLowering, FreeOpLowering, MiopenGraphOpLowering,
-           GetPoolOpLowering, HipblasltGraphOpLowering, ConvOpLowering,
-           MatmulOpLowering, RmsNormOpLowering, SkipRmsNormOpLowering,
-           RopeOpLowering, MiopenSoftmaxOpLowering, TransposeOpLowering,
-           GatherOpLowering, SiluOpLowering, SigmoidOpLowering, MulOpLowering,
-           SubOpLowering, CastOpLowering, ReduceSumOpLowering, GqaOpLowering>(
-          typeConverter);
+      .add<AllocOpLowering, FreeOpLowering, GetConstantOpLowering,
+           MiopenGraphOpLowering, GetPoolOpLowering, HipblasltGraphOpLowering,
+           ConvOpLowering, MatmulOpLowering, RmsNormOpLowering,
+           SkipRmsNormOpLowering, RopeOpLowering, MiopenSoftmaxOpLowering,
+           TransposeOpLowering, GatherOpLowering, SiluOpLowering,
+           SigmoidOpLowering, MulOpLowering, SubOpLowering, CastOpLowering,
+           ReduceSumOpLowering, GqaOpLowering>(typeConverter);
   patterns.insert<MiopenBinaryOpLowering<MiopenAddOp>>(typeConverter,
                                                        kMiopenAdd);
   patterns.add<MemRefAllocOpLowering, MemRefDeallocOpLowering>(typeConverter);

--- a/lib/Conversion/HipToLLVM/HipToLLVM.cpp
+++ b/lib/Conversion/HipToLLVM/HipToLLVM.cpp
@@ -1672,34 +1672,35 @@ struct GetConstantOpLowering : public ConvertOpToLLVMPattern<GetConstantOp> {
 
     SmallVector<Value, 2> args = {adaptor.getCtx(), adaptor.getIndex()};
     auto callOp = LLVM::CallOp::create(rewriter, loc, *funcOp, args);
-    Value gpuPtr = callOp.getResult();
 
-    // Cast to GPU address space only when the memref declares one (AS != 0).
-    unsigned targetAS = 0;
-    if (auto memSpace = memRefType.getMemorySpace())
-      if (auto intAttr = dyn_cast<IntegerAttr>(memSpace))
-        targetAS = intAttr.getInt();
+    // The runtime always returns a generic pointer (AS 0).  Cast to the
+    // memref's address space (e.g. AS 1 = AMDGPU global memory) if needed.
+    FailureOr<unsigned> addrSpace =
+        getTypeConverter()->getMemRefAddressSpace(memRefType);
+    if (failed(addrSpace))
+      return failure();
 
-    Value dataPtr = gpuPtr;
-    if (targetAS != 0)
-      dataPtr = rewriter.create<LLVM::AddrSpaceCastOp>(
-          loc, LLVM::LLVMPointerType::get(rewriter.getContext(), targetAS),
-          gpuPtr);
+    Value dataPtr = callOp.getResult();
+    if (*addrSpace != 0)
+      dataPtr = LLVM::AddrSpaceCastOp::create(
+          rewriter, loc,
+          LLVM::LLVMPointerType::get(rewriter.getContext(), *addrSpace),
+          dataPtr);
 
     auto shape = memRefType.getShape();
     SmallVector<Value, 4> sizes;
     SmallVector<Value, 4> strides;
 
     for (int64_t dim : shape) {
-      Value size = rewriter.create<LLVM::ConstantOp>(
-          loc, i64Type, rewriter.getI64IntegerAttr(dim));
+      Value size = LLVM::ConstantOp::create(rewriter, loc, i64Type,
+                                            rewriter.getI64IntegerAttr(dim));
       sizes.push_back(size);
     }
 
     int64_t stride = 1;
     for (int i = shape.size() - 1; i >= 0; --i) {
-      Value strideVal = rewriter.create<LLVM::ConstantOp>(
-          loc, i64Type, rewriter.getI64IntegerAttr(stride));
+      Value strideVal = LLVM::ConstantOp::create(
+          rewriter, loc, i64Type, rewriter.getI64IntegerAttr(stride));
       strides.insert(strides.begin(), strideVal);
       stride *= shape[i];
     }
@@ -1736,14 +1737,14 @@ void ConvertHipToLLVMPass::runOnOperation() {
   RewritePatternSet patterns(ctx);
 
   // HIP dialect-specific lowerings
-  patterns
-      .add<AllocOpLowering, FreeOpLowering, GetConstantOpLowering,
-           MiopenGraphOpLowering, GetPoolOpLowering, HipblasltGraphOpLowering,
-           ConvOpLowering, MatmulOpLowering, RmsNormOpLowering,
-           SkipRmsNormOpLowering, RopeOpLowering, MiopenSoftmaxOpLowering,
-           TransposeOpLowering, GatherOpLowering, SiluOpLowering,
-           SigmoidOpLowering, MulOpLowering, SubOpLowering, CastOpLowering,
-           ReduceSumOpLowering, GqaOpLowering>(typeConverter);
+  patterns.add<AllocOpLowering, FreeOpLowering, GetConstantOpLowering,
+               MiopenGraphOpLowering, GetPoolOpLowering,
+               HipblasltGraphOpLowering, ConvOpLowering, MatmulOpLowering,
+               RmsNormOpLowering, SkipRmsNormOpLowering, RopeOpLowering,
+               MiopenSoftmaxOpLowering, TransposeOpLowering, GatherOpLowering,
+               SiluOpLowering, SigmoidOpLowering, MulOpLowering, SubOpLowering,
+               CastOpLowering, ReduceSumOpLowering, GqaOpLowering>(
+      typeConverter);
   patterns.insert<MiopenBinaryOpLowering<MiopenAddOp>>(typeConverter,
                                                        kMiopenAdd);
   patterns.add<MemRefAllocOpLowering, MemRefDeallocOpLowering>(typeConverter);

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -668,7 +668,7 @@ ReduceSumToHip::matchAndRewrite(mlir::Operation *op,
     auto axesAttr =
         mlir::DenseIntElementsAttr::get(axesType, llvm::ArrayRef(axesVec));
     axesOperand =
-        rewriter.create<mlir::arith::ConstantOp>(loc, axesType, axesAttr);
+        mlir::arith::ConstantOp::create(rewriter, loc, axesType, axesAttr);
   }
 
   // Extract keepdims attribute (defaults to 1 in ONNX)
@@ -789,8 +789,8 @@ ConvToHip::matchAndRewrite(mlir::Operation *op,
   attrs.push_back(rewriter.getNamedAttr("group", groupAttr));
 
   // Create hip.conv operation using generic builder
-  auto hipOp = rewriter.create<mlir::hip::ConvOp>(
-      loc, mlir::TypeRange{resultType}, operands, attrs);
+  auto hipOp = mlir::hip::ConvOp::create(
+      rewriter, loc, mlir::TypeRange{resultType}, operands, attrs);
 
   rewriter.replaceOp(op, hipOp.getResult(0));
   return mlir::success();
@@ -1446,16 +1446,19 @@ void ConvertOnnxToHipPass::runOnOperation() {
     manifest["constants"] = std::move(extState->manifestEntries);
 
     auto jsonWriter = diskFs.create_writer_template(jsonPath.c_str());
-    if (jsonWriter) {
-      std::string jsonStr;
-      llvm::raw_string_ostream jsonOs(jsonStr);
-      jsonOs << llvm::formatv("{0:2}", llvm::json::Value(std::move(manifest)));
-      jsonWriter->fwrite(jsonStr.data(), jsonStr.size());
+    if (!jsonWriter) {
+      module.emitError("failed to open constants manifest via FileSystem: " +
+                       jsonPath);
+      return signalPassFailure();
     }
+    std::string jsonStr;
+    llvm::raw_string_ostream jsonOs(jsonStr);
+    jsonOs << llvm::formatv("{0:2}", llvm::json::Value(std::move(manifest)));
+    jsonWriter->fwrite(jsonStr.data(), jsonStr.size());
 
-    module.emitRemark("externalized ")
-        << extState->constantIndex << " constants (" << extState->currentOffset
-        << " bytes) to " << extState->binFileName;
+    LLVM_DEBUG(llvm::dbgs() << "externalized " << extState->constantIndex
+                            << " constants (" << extState->currentOffset
+                            << " bytes) to " << extState->binFileName << "\n");
   } else if (extState) {
     extState->writer.reset();
   }

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -24,10 +24,12 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
+#include "hip/Support/DiskFileSystem.h"
+#include "morphizen-foundation/file_io.hpp"
+
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/Sequence.h"
 #include "llvm/Support/Debug.h"
-#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/JSON.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/raw_ostream.h"
@@ -133,11 +135,15 @@ static int64_t alignTo(int64_t value, int64_t alignment) {
 /// Mutable state shared across calls to lowerOnnxConstants when
 /// externalization is enabled.
 struct ExternalizationState {
-  std::unique_ptr<llvm::raw_fd_ostream> binFile;
+  std::unique_ptr<morphizen::FileWriter,
+                  morphizen::FileSystem::Deleter<morphizen::FileWriter>>
+      writer;
   llvm::json::Array manifestEntries;
   int64_t currentOffset = 0;
   int64_t constantIndex = 0;
   std::string binFileName;
+  llvm::SmallVector<int64_t> constantSizes;
+  llvm::SmallVector<int64_t> constantOffsets;
 };
 
 /// Lower onnx.Constant ops.
@@ -197,16 +203,20 @@ static mlir::LogicalResult lowerOnnxConstants(mlir::ModuleOp module,
       int64_t padding = aligned - extState->currentOffset;
       if (padding > 0) {
         llvm::SmallVector<char> zeros(padding, 0);
-        extState->binFile->write(zeros.data(), padding);
+        extState->writer->fwrite(zeros.data(), padding);
         extState->currentOffset += padding;
       }
       int64_t entryOffset = extState->currentOffset;
 
-      // Write raw bytes to the sidecar binary.
+      // Write raw bytes to the sidecar binary via FileSystem.
       auto rawData = valueAttr.getRawData();
       int64_t byteSize = static_cast<int64_t>(rawData.size());
-      extState->binFile->write(rawData.data(), byteSize);
+      extState->writer->fwrite(rawData.data(), byteSize);
       extState->currentOffset += byteSize;
+
+      // Track sizes and offsets for module-level metadata.
+      extState->constantSizes.push_back(byteSize);
+      extState->constantOffsets.push_back(entryOffset);
 
       // Build JSON manifest entry.
       llvm::json::Array shapeArray;
@@ -225,6 +235,8 @@ static mlir::LogicalResult lowerOnnxConstants(mlir::ModuleOp module,
       mlir::OpBuilder moduleBuilder(module.getBody(),
                                     module.getBody()->begin());
       auto externalDataAttr = moduleBuilder.getDictionaryAttr({
+          moduleBuilder.getNamedAttr("index", moduleBuilder.getI64IntegerAttr(
+                                                  extState->constantIndex)),
           moduleBuilder.getNamedAttr(
               "offset", moduleBuilder.getI64IntegerAttr(entryOffset)),
           moduleBuilder.getNamedAttr("size",
@@ -1358,6 +1370,7 @@ void ConvertOnnxToHipPass::runOnOperation() {
   std::unique_ptr<ExternalizationState> extState;
   llvm::StringRef dirRef = externalizeOutputDir.getValue();
   std::string dir = dirRef.empty() ? "." : dirRef.str();
+  mlir::hip::DiskFileSystem diskFs(dir.c_str());
   if (externalizeMinNumElements > 0) {
     extState = std::make_unique<ExternalizationState>();
 
@@ -1368,13 +1381,11 @@ void ConvertOnnxToHipPass::runOnOperation() {
       baseName = sym.getValue().str();
     extState->binFileName = baseName + ".constants.bin";
 
-    std::string binPath = dir + "/" + extState->binFileName;
-    std::error_code binEC;
-    extState->binFile = std::make_unique<llvm::raw_fd_ostream>(
-        binPath, binEC, llvm::sys::fs::OF_None);
-    if (binEC) {
-      module.emitError("failed to open constants binary file: " + binPath +
-                       " (" + binEC.message() + ")");
+    extState->writer =
+        diskFs.create_writer_template(extState->binFileName.c_str());
+    if (!extState->writer) {
+      module.emitError("failed to open constants binary file via FileSystem: " +
+                       extState->binFileName);
       return signalPassFailure();
     }
   }
@@ -1403,22 +1414,29 @@ void ConvertOnnxToHipPass::runOnOperation() {
   for (auto *ep : entryPoints)
     ep->erase();
 
-  // Finalize externalization: close binary, write JSON manifest, set module
-  // attribute.
+  // Finalize externalization: release writer, write JSON manifest, set module
+  // attributes.
   if (extState && extState->constantIndex > 0) {
-    extState->binFile->close();
+    extState->writer.reset();
 
     // Set hip.constants_file on the module so downstream passes/tools know
     // where the sidecar lives.
     module->setAttr("hip.constants_file",
                     mlir::StringAttr::get(ctx, extState->binFileName));
 
+    // Emit hipdnn.constant_sizes and hipdnn.constant_offsets for the runtime.
+    module->setAttr("hipdnn.constant_sizes",
+                    mlir::DenseI64ArrayAttr::get(ctx, extState->constantSizes));
+    module->setAttr(
+        "hipdnn.constant_offsets",
+        mlir::DenseI64ArrayAttr::get(ctx, extState->constantOffsets));
+
     // Derive base name again for JSON path.
     std::string baseName = "model";
     if (auto sym = module->getAttrOfType<mlir::StringAttr>(
             mlir::SymbolTable::getSymbolAttrName()))
       baseName = sym.getValue().str();
-    std::string jsonPath = dir + "/" + baseName + ".constants.json";
+    std::string jsonPath = baseName + ".constants.json";
 
     llvm::json::Object manifest;
     manifest["version"] = 1;
@@ -1427,22 +1445,19 @@ void ConvertOnnxToHipPass::runOnOperation() {
     manifest["total_bytes"] = extState->currentOffset;
     manifest["constants"] = std::move(extState->manifestEntries);
 
-    std::error_code ec;
-    llvm::raw_fd_ostream jsonFile(jsonPath, ec);
-    if (ec) {
-      module.emitError("failed to open constants manifest: " + jsonPath + " (" +
-                       ec.message() + ")");
-      return signalPassFailure();
+    auto jsonWriter = diskFs.create_writer_template(jsonPath.c_str());
+    if (jsonWriter) {
+      std::string jsonStr;
+      llvm::raw_string_ostream jsonOs(jsonStr);
+      jsonOs << llvm::formatv("{0:2}", llvm::json::Value(std::move(manifest)));
+      jsonWriter->fwrite(jsonStr.data(), jsonStr.size());
     }
-    jsonFile << llvm::formatv("{0:2}", llvm::json::Value(std::move(manifest)));
-    jsonFile.close();
 
     module.emitRemark("externalized ")
         << extState->constantIndex << " constants (" << extState->currentOffset
-        << " bytes) to " << dir + "/" + extState->binFileName;
+        << " bytes) to " << extState->binFileName;
   } else if (extState) {
-    // No constants qualified -- clean up empty file.
-    extState->binFile->close();
+    extState->writer.reset();
   }
 }
 

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -59,6 +59,13 @@ void FreeOp::getEffects(
                        SideEffects::DefaultResource::get());
 }
 
+void GetConstantOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Read::get(), getOperation()->getResult(0),
+                       SideEffects::DefaultResource::get());
+}
+
 //===----------------------------------------------------------------------===//
 // Helpers for DPS compute ops (custom parse/print, verify, interfaces)
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/Transforms/ResolveExternConstants.cpp
+++ b/lib/Dialect/Transforms/ResolveExternConstants.cpp
@@ -3,31 +3,30 @@
  * Licensed under the MIT License.
  */
 
-//===- ResolveExternConstants.cpp - Wire extern globals to buffer arg -----===//
+//===- ResolveExternConstants.cpp - Replace extern globals with hip.get_constant
 //
 // The --hip-resolve-extern-constants pass bridges the gap between compile-time
 // constant externalization (which produces memref.global ops with
 // hip.external_data attributes and no initial value) and LLVM lowering (which
-// needs concrete data or a runtime mechanism to provide it).
+// needs a runtime mechanism to provide constant data).
 //
-// Strategy (mirrors the pool allocator pattern from --hip-pool-allocs):
+// Strategy:
 //
 // For each function that uses externalized constants via memref.get_global:
-//   1. Add a new argument: %_constants : memref<?xi8>
-//   2. Replace each memref.get_global @hip_ext_xxx with a memref.view into
-//      %_constants at the byte offset recorded in hip.external_data.
-//   3. Erase the now-unused memref.global ops.
-//   4. Strip hip.constants_file from the module.
+//   1. Get !hip.context from arg 0 (inserted by hip-add-context-arg).
+//   2. Read the constant index from hip.external_data on the memref.global.
+//   3. Replace memref.get_global with hip.get_constant(%ctx, %index).
+//   4. Erase the now-unused memref.global ops.
+//   5. Strip hip.constants_file from the module.
 //
-// The host (ORT EP or test harness) is responsible for:
-//   - Loading the sidecar .constants.bin via hip_load_constants()
-//   - Passing the resulting device pointer as the %_constants argument
-//
-// This keeps the MLIR pass simple (no LLVM dialect mixing) and lets
-// --convert-memref-to-llvm handle everything naturally.
+// The runtime is responsible for:
+//   - Loading constants.bin via the FileSystem abstraction
+//   - Uploading constants to GPU memory during initialization
+//   - Returning GPU pointers via hipdnn_ep_constant_get(state, index)
 //
 //===----------------------------------------------------------------------===//
 
+#include "hip/Dialect/IR/HipDialect.h"
 #include "hip/Dialect/Transforms/Passes.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -63,6 +62,7 @@ void ResolveExternConstantsPass::runOnOperation() {
   // Collect extern globals that have hip.external_data.
   struct ExternGlobalInfo {
     memref::GlobalOp globalOp;
+    int64_t index;
     int64_t offset;
     int64_t size;
   };
@@ -73,13 +73,15 @@ void ResolveExternConstantsPass::runOnOperation() {
         globalOp->getAttrOfType<DictionaryAttr>("hip.external_data");
     if (!extDataAttr)
       continue;
+    auto indexAttr = extDataAttr.getAs<IntegerAttr>("index");
     auto offsetAttr = extDataAttr.getAs<IntegerAttr>("offset");
     auto sizeAttr = extDataAttr.getAs<IntegerAttr>("size");
-    if (!offsetAttr || !sizeAttr) {
-      globalOp.emitError("hip.external_data missing offset or size");
+    if (!indexAttr || !offsetAttr || !sizeAttr) {
+      globalOp.emitError("hip.external_data missing index, offset, or size");
       return signalPassFailure();
     }
-    externGlobals.push_back({globalOp, offsetAttr.getInt(), sizeAttr.getInt()});
+    externGlobals.push_back(
+        {globalOp, indexAttr.getInt(), offsetAttr.getInt(), sizeAttr.getInt()});
   }
 
   if (externGlobals.empty())
@@ -90,108 +92,18 @@ void ResolveExternConstantsPass::runOnOperation() {
   for (auto [idx, info] : llvm::enumerate(externGlobals))
     globalsByName[info.globalOp.getSymName()] = idx;
 
-  auto i8Type = IntegerType::get(module.getContext(), 8);
-  auto constantsType = MemRefType::get({ShapedType::kDynamic}, i8Type);
-
-  // Phase 1: Identify functions that directly use externalized globals.
-  DenseSet<func::FuncOp> needsConstantsArg;
-  for (auto funcOp : module.getOps<func::FuncOp>()) {
-    if (funcOp.isDeclaration())
-      continue;
-    funcOp.walk([&](memref::GetGlobalOp op) {
-      if (globalsByName.contains(op.getName()))
-        needsConstantsArg.insert(funcOp);
-    });
-  }
-
-  // Phase 2: Propagate transitively -- any function that calls a function
-  // needing %_constants must also receive it so it can pass it through.
-  bool changed = true;
-  while (changed) {
-    changed = false;
-    for (auto funcOp : module.getOps<func::FuncOp>()) {
-      if (funcOp.isDeclaration() || needsConstantsArg.contains(funcOp))
-        continue;
-      funcOp.walk([&](func::CallOp callOp) {
-        auto callee = module.lookupSymbol<func::FuncOp>(callOp.getCallee());
-        if (callee && needsConstantsArg.contains(callee)) {
-          needsConstantsArg.insert(funcOp);
-          changed = true;
-        }
-      });
-    }
-  }
-
-  // Phase 3: Add %_constants : memref<?xi8> argument to every function
-  // that needs it (both direct users and transitive callers).
-  DenseMap<func::FuncOp, Value> constantsArgMap;
-  for (auto funcOp : module.getOps<func::FuncOp>()) {
-    if (!needsConstantsArg.contains(funcOp))
-      continue;
-
-    Block &entryBlock = funcOp.getBody().front();
-    entryBlock.addArgument(constantsType, funcOp.getLoc());
-    Value constantsArg = entryBlock.getArguments().back();
-    constantsArgMap[funcOp] = constantsArg;
-
-    auto oldFuncType = funcOp.getFunctionType();
-    SmallVector<Type> newInputTypes(oldFuncType.getInputs());
-    newInputTypes.push_back(constantsType);
-    funcOp.setFunctionType(FunctionType::get(module.getContext(), newInputTypes,
-                                             oldFuncType.getResults()));
-
-    if (auto allArgAttrs = funcOp.getAllArgAttrs()) {
-      SmallVector<Attribute> newArgAttrs(allArgAttrs.begin(),
-                                         allArgAttrs.end());
-      newArgAttrs.push_back(DictionaryAttr::get(module.getContext()));
-      funcOp.setAllArgAttrs(newArgAttrs);
-    }
-
-    ++NumFuncsUpdated;
-    LLVM_DEBUG(llvm::dbgs()
-               << "  Added %_constants arg to @" << funcOp.getName() << "\n");
-  }
-
-  // Phase 4: Rewrite func.call sites -- collect first, then modify.
+  // Replace memref.get_global with hip.get_constant in every function.
   for (auto funcOp : module.getOps<func::FuncOp>()) {
     if (funcOp.isDeclaration())
       continue;
 
-    SmallVector<func::CallOp> callsToUpdate;
-    funcOp.walk([&](func::CallOp callOp) {
-      auto callee = module.lookupSymbol<func::FuncOp>(callOp.getCallee());
-      if (callee && needsConstantsArg.contains(callee))
-        callsToUpdate.push_back(callOp);
-    });
-
-    for (func::CallOp callOp : callsToUpdate) {
-      auto it = constantsArgMap.find(funcOp);
-      if (it == constantsArgMap.end()) {
-        callOp.emitError("caller does not have %_constants but callee ")
-            << callOp.getCallee() << " requires it";
-        return signalPassFailure();
-      }
-
-      SmallVector<Value> newOperands(callOp.getOperands());
-      newOperands.push_back(it->second);
-      OpBuilder builder(callOp);
-      auto newCall =
-          func::CallOp::create(builder, callOp.getLoc(), callOp.getCallee(),
-                               callOp.getResultTypes(), newOperands);
-      callOp.replaceAllUsesWith(newCall.getResults());
-      callOp.erase();
-    }
-  }
-
-  // Phase 5: Replace memref.get_global with memref.view into the buffer.
-  for (auto funcOp : module.getOps<func::FuncOp>()) {
-    if (funcOp.isDeclaration())
+    // Get !hip.context from arg 0.
+    auto &entry = funcOp.getBody().front();
+    if (entry.getNumArguments() == 0)
       continue;
-
-    auto it = constantsArgMap.find(funcOp);
-    if (it == constantsArgMap.end())
+    Value ctxArg = entry.getArgument(0);
+    if (!isa<hip::ContextType>(ctxArg.getType()))
       continue;
-    Value constantsArg = it->second;
 
     SmallVector<memref::GetGlobalOp> getGlobalOps;
     funcOp.walk([&](memref::GetGlobalOp op) {
@@ -199,25 +111,38 @@ void ResolveExternConstantsPass::runOnOperation() {
         getGlobalOps.push_back(op);
     });
 
+    if (!getGlobalOps.empty()) {
+      ++NumFuncsUpdated;
+      LLVM_DEBUG(llvm::dbgs()
+                 << "  Resolving constants in @" << funcOp.getName() << "\n");
+    }
+
     for (auto getGlobalOp : getGlobalOps) {
       ExternGlobalInfo &info =
           externGlobals[globalsByName[getGlobalOp.getName()]];
       OpBuilder builder(getGlobalOp);
       Location loc = getGlobalOp.getLoc();
 
-      Value offset = arith::ConstantOp::create(
-          builder, loc, builder.getIndexAttr(info.offset));
-      auto viewOp = memref::ViewOp::create(builder, loc, getGlobalOp.getType(),
-                                           constantsArg, offset,
-                                           /*sizes=*/ValueRange{});
+      // Create index constant.
+      Value indexVal =
+          arith::ConstantOp::create(builder, loc, builder.getI64Type(),
+                                    builder.getI64IntegerAttr(info.index));
 
-      getGlobalOp.replaceAllUsesWith(viewOp.getResult());
+      // Produce hip.get_constant with the original memref type so that all
+      // downstream users see the same type they expected from the
+      // memref.get_global.  The HipToLLVM lowering will emit the correct
+      // GPU-pointer logic regardless of the declared address space.
+      auto origMemRefType = getGlobalOp.getType();
+      auto getConstOp = hip::GetConstantOp::create(builder, loc, origMemRefType,
+                                                   ctxArg, indexVal);
+
+      getGlobalOp.replaceAllUsesWith(getConstOp.getResult());
       getGlobalOp.erase();
       ++NumGlobalsResolved;
     }
   }
 
-  // Phase 6: Clean up -- erase extern globals and strip module attribute.
+  // Clean up -- erase extern globals and strip module attribute.
   for (auto &info : externGlobals)
     info.globalOp.erase();
 

--- a/test/lit/CMakeLists.txt
+++ b/test/lit/CMakeLists.txt
@@ -62,7 +62,7 @@ set(LIT_ARGS "-sv" CACHE STRING "Extra arguments passed to lit (e.g. -j4 --no-pr
 # Add custom build target for manual invocation: cmake --build . --target check-hip-mlir-lit
 add_custom_target(check-hip-mlir-lit
     COMMAND ${LIT_EXECUTABLE} ${LIT_ARGS} --param=build_mode=$<CONFIG> .
-    DEPENDS hip-mlir-opt hip-compiler-exe
+    DEPENDS hip-mlir-opt hip-compiler
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMENT "Running LIT tests for hip-mlir-compiler"
 )

--- a/test/lit/Conversion/hip-to-llvm/test_get_constant.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_get_constant.mlir
@@ -1,0 +1,42 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+//===----------------------------------------------------------------------===//
+// Test: hip.get_constant lowering to LLVM.
+//
+// Verifies:
+// - hip.get_constant(%ctx, %index) lowers to llvm.call @hipdnn_ep_constant_get
+// - Returned GPU pointer is wrapped in a memref descriptor
+// - Address space cast from AS 0 to AS 1 is inserted
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt %s --convert-hip-to-llvm | FileCheck %s
+
+module {
+  // CHECK-LABEL: llvm.func @test_get_constant
+  // CHECK-SAME:  (%[[CTX:.*]]: !llvm.ptr)
+  func.func @test_get_constant(%ctx: !hip.context) -> memref<3x4xf32, 1> {
+    %idx = arith.constant 0 : i64
+    // CHECK:   %[[IDX:.*]] = llvm.mlir.constant(0 : i64) : i64
+    // CHECK:   %[[PTR:.*]] = llvm.call @hipdnn_ep_constant_get(%[[CTX]], %[[IDX]]) : (!llvm.ptr, i64) -> !llvm.ptr
+    // CHECK:   llvm.addrspacecast %[[PTR]] : !llvm.ptr to !llvm.ptr<1>
+    %c = hip.get_constant(%ctx, %idx) : memref<3x4xf32, 1>
+    return %c : memref<3x4xf32, 1>
+  }
+
+  // CHECK-LABEL: llvm.func @test_get_constant_multi
+  // CHECK-SAME:  (%[[CTX2:.*]]: !llvm.ptr)
+  func.func @test_get_constant_multi(%ctx: !hip.context) -> (memref<64x3x3x3xf32, 1>, memref<64xf32, 1>) {
+    %idx0 = arith.constant 0 : i64
+    %idx1 = arith.constant 1 : i64
+    // CHECK:   %[[I0:.*]] = llvm.mlir.constant(0 : i64) : i64
+    // CHECK:   %[[I1:.*]] = llvm.mlir.constant(1 : i64) : i64
+    // CHECK:   %[[P0:.*]] = llvm.call @hipdnn_ep_constant_get(%[[CTX2]], %[[I0]]) : (!llvm.ptr, i64) -> !llvm.ptr
+    // CHECK:   llvm.addrspacecast %[[P0]] : !llvm.ptr to !llvm.ptr<1>
+    // CHECK:   %[[P1:.*]] = llvm.call @hipdnn_ep_constant_get(%[[CTX2]], %[[I1]]) : (!llvm.ptr, i64) -> !llvm.ptr
+    // CHECK:   llvm.addrspacecast %[[P1]] : !llvm.ptr to !llvm.ptr<1>
+    %w = hip.get_constant(%ctx, %idx0) : memref<64x3x3x3xf32, 1>
+    %b = hip.get_constant(%ctx, %idx1) : memref<64xf32, 1>
+    return %w, %b : memref<64x3x3x3xf32, 1>, memref<64xf32, 1>
+  }
+}

--- a/test/lit/Conversion/onnx-to-hip/test_constant_handling.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_constant_handling.mlir
@@ -2,51 +2,42 @@
 // Licensed under the MIT License.
 //
 //===----------------------------------------------------------------------===//
-// Pipeline test: constant externalization in convert-onnx-to-hip.
+// Test: constant externalization emits hipdnn.constant_sizes/offsets and
+// hip.external_data with index field.
 //
-// Verifies that --externalize-min-num-elements selectively externalizes
-// constants:
-//   - Large non-splat constants -> memref.global with hip.external_data
-//   - Small constants (below threshold) -> arith.constant (inline)
-//   - Splat constants (any size) -> arith.constant (inline)
-//
-// Also verifies module-level metadata:
-//   - hip.constants_file attribute
-//   - hipdnn.constant_sizes and hipdnn.constant_offsets arrays
-//   - hip.external_data includes index field
-//
-// All three constants are returned so they survive DCE in the greedy
-// pattern rewrite driver that runs as part of convertComputeOps.
+// Verifies:
+// - Large non-splat constants are externalized to memref.global with
+//   hip.external_data containing index, offset, and size
+// - hipdnn.constant_sizes and hipdnn.constant_offsets module attributes
+//   are emitted
+// - Small and splat constants remain inline as arith.constant
 //===----------------------------------------------------------------------===//
 
 // RUN: mkdir -p %t && hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip='externalize-min-num-elements=4 externalize-output-dir=%t' %s | FileCheck %s
 
-// Module-level: constants file attribute, sizes, and offsets.
+// Module-level: constants file, sizes, and offsets attributes.
 // CHECK: module attributes {
 // CHECK-SAME: hip.constants_file = "model.constants.bin"
 // CHECK-SAME: hipdnn.constant_offsets = array<i64:
 // CHECK-SAME: hipdnn.constant_sizes = array<i64:
 
+// Extern memref.global with index in hip.external_data.
 // CHECK: memref.global "private" @hip_ext_constant_0 : memref<2x4xf32>
 // CHECK-SAME: hip.external_data = {index = 0 : i64, offset = 0 : i64, size = 32 : i64}
 
 // CHECK-LABEL: func.func @main_graph
-//   Small constant stays inline (2 elements < threshold 4).
+//   Small constant stays inline.
 // CHECK-DAG:   arith.constant dense<[1.000000e+00, 2.000000e+00]> : tensor<2xf32>
-//   Splat constant stays inline despite 16 elements >= threshold.
+//   Splat constant stays inline.
 // CHECK-DAG:   arith.constant dense<5.000000e-01> : tensor<4x4xf32>
-//   Large non-splat constant loaded from extern global.
+//   Large non-splat loaded from extern global.
 // CHECK:       memref.get_global @hip_ext_constant_0 : memref<2x4xf32>
 // CHECK-NEXT:  bufferization.to_tensor {{.*}} restrict
-// CHECK:       return
 
 module {
   func.func @main_graph() -> (tensor<2xf32>, tensor<4x4xf32>, tensor<2x4xf32>) {
-    // Small: 2 elements (below threshold of 4).
     %small = "onnx.Constant"() {value = dense<[1.0, 2.0]> : tensor<2xf32>} : () -> tensor<2xf32>
-    // Splat: 16 elements (above threshold) but splat -- stays inline.
     %splat = "onnx.Constant"() {value = dense<0.5> : tensor<4x4xf32>} : () -> tensor<4x4xf32>
-    // Large non-splat: 8 elements (above threshold of 4).
     %large = "onnx.Constant"() {value = dense<[[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]]> : tensor<2x4xf32>} : () -> tensor<2x4xf32>
     "onnx.Return"(%small, %splat, %large) {onnx_node_name = "/Return"} : (tensor<2xf32>, tensor<4x4xf32>, tensor<2x4xf32>) -> ()
   }

--- a/test/lit/Dialect/hip-resolve-extern-constants.mlir
+++ b/test/lit/Dialect/hip-resolve-extern-constants.mlir
@@ -5,13 +5,12 @@
 // FileCheck tests for --hip-resolve-extern-constants (standalone pass).
 //
 // Verifies:
-//   - memref.get_global replaced with memref.view into %_constants arg
-//   - Function signatures gain %_constants : memref<?xi8>
-//   - Call sites forward the constants buffer
+//   - memref.get_global replaced with hip.get_constant
+//   - Function signatures are NOT modified (no %_constants arg)
 //   - Extern globals are erased
 //   - Module hip.constants_file attribute is stripped
 //   - No-op when no extern globals exist
-//   - Multiple extern globals with distinct offsets
+//   - Multiple extern globals with distinct indices
 //===----------------------------------------------------------------------===//
 
 // RUN: hip-mlir-opt --hip-resolve-extern-constants %s | FileCheck %s
@@ -25,74 +24,75 @@
 // ===== Single function using one extern global =====
 //
 // CHECK-LABEL: func.func @single_func_one_global
-// CHECK-SAME:    (%[[A:.*]]: memref<4x4xf32>, %[[CONST:.*]]: memref<?xi8>)
-// CHECK:         %[[OFF:.*]] = arith.constant 0 : index
-// CHECK:         %[[VIEW:.*]] = memref.view %[[CONST]][%[[OFF]]][]
-// CHECK-SAME:      : memref<?xi8> to memref<4x4xf32>
+// CHECK-SAME:    (%[[CTX1:.*]]: !hip.context, %[[A:.*]]: memref<4x4xf32>)
+// CHECK:         %[[C0:.*]] = arith.constant 0 : i64
+// CHECK:         hip.get_constant(%[[CTX1]], %[[C0]]) : memref<4x4xf32>
 // CHECK-NOT:     memref.get_global
-// CHECK:         return %[[VIEW]]
+// CHECK-NOT:     memref.view
 
-// ===== Function with multiple extern globals at different offsets =====
+// ===== Function with multiple extern globals at different indices =====
 //
 // CHECK-LABEL: func.func @multi_global_offsets
-// CHECK-SAME:    (%[[A2:.*]]: memref<4x4xf32>, %[[CONST2:.*]]: memref<?xi8>)
-// CHECK:         memref.view %[[CONST2]]{{.*}} : memref<?xi8> to memref<4x4xf32>
-// CHECK:         memref.view %[[CONST2]]{{.*}} : memref<?xi8> to memref<2x2xf32>
+// CHECK-SAME:    (%[[CTX2:.*]]: !hip.context, %[[A2:.*]]: memref<4x4xf32>)
+// CHECK:         %[[IDX0:.*]] = arith.constant 0 : i64
+// CHECK:         hip.get_constant(%[[CTX2]], %[[IDX0]]) : memref<4x4xf32>
+// CHECK:         %[[IDX1:.*]] = arith.constant 1 : i64
+// CHECK:         hip.get_constant(%[[CTX2]], %[[IDX1]]) : memref<2x2xf32>
 // CHECK-NOT:     memref.get_global
 // CHECK:         return
 
-// ===== Caller/callee: transitive propagation of constants arg =====
+// ===== Caller/callee: no transitive argument propagation needed =====
 //
 // CHECK-LABEL: func.func @callee_uses_global
-// CHECK-SAME:    (%[[CA:.*]]: memref<4x4xf32>, %[[CC:.*]]: memref<?xi8>)
-// CHECK:         memref.view %[[CC]]
+// CHECK-SAME:    (%[[CC:.*]]: !hip.context, %[[CA:.*]]: memref<4x4xf32>)
+// CHECK:         %[[CI:.*]] = arith.constant 0 : i64
+// CHECK:         hip.get_constant(%[[CC]], %[[CI]]) : memref<4x4xf32>
 // CHECK-NOT:     memref.get_global
 
 // CHECK-LABEL: func.func @caller_passes_constants
-// CHECK-SAME:    (%[[TA:.*]]: memref<4x4xf32>, %[[TC:.*]]: memref<?xi8>)
-// CHECK:         call @callee_uses_global(%[[TA]], %[[TC]])
+// CHECK-SAME:    (%[[TC:.*]]: !hip.context, %[[TA:.*]]: memref<4x4xf32>)
+// CHECK:         call @callee_uses_global(%[[TC]], %[[TA]])
 
 // ===== No-op: function without extern globals is unchanged =====
 //
 // CHECK-LABEL: func.func @no_globals_noop
-// CHECK-SAME:    (%arg0: memref<4x4xf32>)
-// CHECK-NOT:     memref<?xi8>
+// CHECK-SAME:    (%{{.*}}: !hip.context, %arg1: memref<4x4xf32>)
 // CHECK:         return
 
 module attributes {hip.constants_file = "model.constants.bin"} {
 
   memref.global "private" @weight_a : memref<4x4xf32> {
     alignment = 64 : i64,
-    hip.external_data = {offset = 0 : i64, size = 64 : i64}
+    hip.external_data = {index = 0 : i64, offset = 0 : i64, size = 64 : i64}
   }
 
   memref.global "private" @weight_b : memref<2x2xf32> {
     alignment = 64 : i64,
-    hip.external_data = {offset = 64 : i64, size = 16 : i64}
+    hip.external_data = {index = 1 : i64, offset = 64 : i64, size = 16 : i64}
   }
 
-  func.func @single_func_one_global(%arg0: memref<4x4xf32>) -> memref<4x4xf32> {
+  func.func @single_func_one_global(%ctx: !hip.context, %arg0: memref<4x4xf32>) -> memref<4x4xf32> {
     %w = memref.get_global @weight_a : memref<4x4xf32>
     return %w : memref<4x4xf32>
   }
 
-  func.func @multi_global_offsets(%arg0: memref<4x4xf32>) -> memref<4x4xf32> {
+  func.func @multi_global_offsets(%ctx: !hip.context, %arg0: memref<4x4xf32>) -> memref<4x4xf32> {
     %wa = memref.get_global @weight_a : memref<4x4xf32>
     %wb = memref.get_global @weight_b : memref<2x2xf32>
     return %wa : memref<4x4xf32>
   }
 
-  func.func @callee_uses_global(%arg0: memref<4x4xf32>) -> memref<4x4xf32> {
+  func.func @callee_uses_global(%ctx: !hip.context, %arg0: memref<4x4xf32>) -> memref<4x4xf32> {
     %w = memref.get_global @weight_a : memref<4x4xf32>
     return %w : memref<4x4xf32>
   }
 
-  func.func @caller_passes_constants(%arg0: memref<4x4xf32>) -> memref<4x4xf32> {
-    %res = func.call @callee_uses_global(%arg0) : (memref<4x4xf32>) -> memref<4x4xf32>
+  func.func @caller_passes_constants(%ctx: !hip.context, %arg0: memref<4x4xf32>) -> memref<4x4xf32> {
+    %res = func.call @callee_uses_global(%ctx, %arg0) : (!hip.context, memref<4x4xf32>) -> memref<4x4xf32>
     return %res : memref<4x4xf32>
   }
 
-  func.func @no_globals_noop(%arg0: memref<4x4xf32>) -> memref<4x4xf32> {
+  func.func @no_globals_noop(%ctx: !hip.context, %arg0: memref<4x4xf32>) -> memref<4x4xf32> {
     return %arg0 : memref<4x4xf32>
   }
 }

--- a/test/lit/Pipeline/resolve-extern-multi-func.mlir
+++ b/test/lit/Pipeline/resolve-extern-multi-func.mlir
@@ -4,9 +4,9 @@
 //===----------------------------------------------------------------------===//
 // Test: hip-resolve-extern-constants with inter-function calls.
 //
-// Verifies that when a callee's signature gains %_constants, all call
-// sites are rewritten to pass the argument through, and transitive
-// callers also receive the new argument.
+// Verifies that extern memref.global ops with hip.external_data are
+// replaced by hip.get_constant ops using the !hip.context from arg 0.
+// Function signatures should NOT be modified (no %_constants arg).
 //===----------------------------------------------------------------------===//
 
 // RUN: hip-mlir-opt --hip-resolve-extern-constants %s | FileCheck %s
@@ -14,33 +14,32 @@
 // The extern globals should be erased.
 // CHECK-NOT: memref.global{{.*}}hip.external_data
 
-// callee gets %_constants (3rd arg) and uses memref.view instead of get_global.
+// callee uses hip.get_constant instead of memref.get_global.
 // CHECK-LABEL: func.func @callee
-// CHECK-SAME:  %arg0: memref<4x4xf32>
-// CHECK-SAME:  %arg1: memref<4x4xf32>
-// CHECK-SAME:  %arg2: memref<?xi8>
-// CHECK:         memref.view %arg2
-// CHECK-NOT:     memref.get_global
+// CHECK-SAME:  %[[CTX:.*]]: !hip.context, %arg1: memref<4x4xf32>, %arg2: memref<4x4xf32>
+// CHECK-NOT:   memref.get_global
+// CHECK:       %[[IDX:.*]] = arith.constant 0 : i64
+// CHECK:       hip.get_constant(%[[CTX]], %[[IDX]]) : memref<4x4xf32>
+// CHECK-NOT:   memref.view
 
-// caller gets %_constants (2nd arg) and passes it to callee.
+// caller signature is unchanged (no %_constants arg).
 // CHECK-LABEL: func.func @caller
-// CHECK-SAME:  %arg0: memref<4x4xf32>
-// CHECK-SAME:  %arg1: memref<?xi8>
-// CHECK:         call @callee(%arg0, %arg0, %arg1)
+// CHECK-SAME:  %[[CTX2:.*]]: !hip.context, %arg1: memref<4x4xf32>
+// CHECK:       call @callee
 
 module attributes {hip.constants_file = "model.constants.bin"} {
   memref.global "private" @weight0 : memref<4x4xf32> {
     alignment = 64 : i64,
-    hip.external_data = {offset = 0 : i64, size = 64 : i64}
+    hip.external_data = {index = 0 : i64, offset = 0 : i64, size = 64 : i64}
   }
 
-  func.func @callee(%arg0: memref<4x4xf32>, %arg1: memref<4x4xf32>) -> memref<4x4xf32> {
+  func.func @callee(%ctx: !hip.context, %arg0: memref<4x4xf32>, %arg1: memref<4x4xf32>) -> memref<4x4xf32> {
     %w = memref.get_global @weight0 : memref<4x4xf32>
     return %w : memref<4x4xf32>
   }
 
-  func.func @caller(%arg0: memref<4x4xf32>) -> memref<4x4xf32> {
-    %res = func.call @callee(%arg0, %arg0) : (memref<4x4xf32>, memref<4x4xf32>) -> memref<4x4xf32>
+  func.func @caller(%ctx: !hip.context, %arg0: memref<4x4xf32>) -> memref<4x4xf32> {
+    %res = func.call @callee(%ctx, %arg0, %arg0) : (!hip.context, memref<4x4xf32>, memref<4x4xf32>) -> memref<4x4xf32>
     return %res : memref<4x4xf32>
   }
 }


### PR DESCRIPTION
## Summary

- Add `hip.get_constant(%ctx, %index)` op to retrieve pre-uploaded GPU constants by index
- Rewrite `hip-resolve-extern-constants` to emit `hip.get_constant` instead of `memref.view`
- Externalize constants via `morphizen::FileSystem`, emitting `hip.external_data{index, offset, size}` and `hipdnn.constant_sizes`/`hipdnn.constant_offsets` module attributes
- Lower `hip.get_constant` to `hipdnn_ep_constant_get(state, index)` runtime call in HipToLLVM

## Suggested review order

1. **Interfaces** — `file_io.hpp`, `DiskFileSystem.h`
   The abstract `FileSystem` interface (EP runtime provides its own impl in deployment). `DiskFileSystem` is a disk-backed impl for CLI tools/debugging only.

2. **New op** — `HipOps.td`, `HipDialect.cpp`
   Defines `hip.get_constant(ctx, index) → memref`. Understanding this makes the passes below straightforward.

3. **Externalization** — `OnnxToHip.cpp` + tests
   Writes constants to sidecar binary via `FileSystem`, tags globals with `hip.external_data`. Produces the IR that step 4 consumes.

4. **Resolution** — `ResolveExternConstants.cpp` + tests
   Replaces `memref.get_global` → `hip.get_constant` using the index from step 3.

5. **LLVM lowering** — `HipToLLVM.cpp` + test
   Lowers `hip.get_constant` to `hipdnn_ep_constant_get` call + memref descriptor.

## Test plan

- [x] All 29 LIT tests pass
