### PR TITLE
ci: add Windows build CI for onnx-hipdnn-ep

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.onnx filter=lfs diff=lfs merge=lfs -text
+ci/morphizen.zip filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,269 @@
+##
+## Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+## Licensed under the MIT License.
+##
+name: CI
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  merge_group:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+
+    env:
+      LLVM_TAG: llvm-22.1.0-release
+      FLATBUFFERS_TAG: flatbuffers-25.12.19-release
+      PROTO_TAG: protobuf-34.0-release
+      ONNXRUNTIME_VERSION: "1.24.1"
+      GTEST_VERSION: "1.15.0"
+      THEROCK_VERSION: therock-dist-windows-gfx1151-7.11.0
+      SCCACHE_GHA_ENABLED: "true"
+
+    steps:
+      # NOTE: ROCm/MorphiZen is a private repo. This checkout requires the
+      # ROCm org-level GITHUB_TOKEN to have read access to org resources
+      # (ROCm org → Settings → Actions → General → Workflow permissions).
+      # If that is not yet enabled, fall back to Option A (deploy key) in
+      # docs/ci-private-submodule-access.md.
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: recursive
+          fetch-depth: 0
+          show-progress: false
+
+      # -----------------------------------------------------------------------
+      # Cache: ONNX Runtime + LLVM prebuilt + flatbuffers
+      # All are installed into the same prebuilt-local prefix so one cache
+      # entry covers all of them.
+      # Note: protobuf is excluded – cmake/deps.cmake fetches v21.12 via
+      # FetchContent (same version pinned by morphizen) to avoid C4267 errors
+      # from mismatched protobuf versions.
+      # -----------------------------------------------------------------------
+      - name: Cache prebuilt-local
+        id: cache-prebuilt
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.workspace }}/prebuilt-local
+          key: prebuilt-ort-${{ env.ONNXRUNTIME_VERSION }}-${{ env.LLVM_TAG }}-${{ env.FLATBUFFERS_TAG }}-${{ env.PROTO_TAG }}-gtest${{ env.GTEST_VERSION }}
+
+      # -----------------------------------------------------------------------
+      # Download ONNX Runtime (official pre-built zip)
+      # morphizen-core calls find_package(onnxruntime REQUIRED), so we also
+      # create onnxruntimeConfig.cmake in the right location.
+      # -----------------------------------------------------------------------
+      - name: Download pre-built ONNX Runtime
+        if: steps.cache-prebuilt.outputs.cache-hit != 'true'
+        shell: powershell
+        run: |
+          $ortVersion = "${{ env.ONNXRUNTIME_VERSION }}"
+          $url = "https://github.com/microsoft/onnxruntime/releases/download/v$ortVersion/onnxruntime-win-x64-$ortVersion.zip"
+          $zipFile = "${{ github.workspace }}/onnxruntime-win-x64-$ortVersion.zip"
+          Write-Host "Downloading $url"
+          Invoke-WebRequest -Uri $url -OutFile $zipFile
+
+          $prefixDir = "${{ runner.workspace }}/prebuilt-local"
+          New-Item -ItemType Directory -Force -Path $prefixDir | Out-Null
+          Expand-Archive -Path $zipFile -DestinationPath $prefixDir -Force
+
+          # Flatten nested directory produced by the zip
+          $extractedDir = "$prefixDir/onnxruntime-win-x64-$ortVersion"
+          if (Test-Path $extractedDir) {
+            Move-Item -Path "$extractedDir/*" -Destination "$prefixDir/" -Force
+            Remove-Item -Path $extractedDir -Force -Recurse
+          }
+
+          # Create CMake config so find_package(onnxruntime REQUIRED) succeeds.
+          # The pre-built zip puts headers in include/ and onnxruntime.lib in lib/.
+          $cmakeDir = "$prefixDir/lib/cmake/onnxruntime"
+          New-Item -ItemType Directory -Force -Path $cmakeDir | Out-Null
+          $configFile = "$cmakeDir/onnxruntimeConfig.cmake"
+          "# onnxruntimeConfig.cmake - auto-generated for pre-built ONNX Runtime $ortVersion" | Set-Content $configFile -Encoding UTF8
+          ""                                                                             | Add-Content $configFile -Encoding UTF8
+          "if(NOT TARGET onnxruntime::onnxruntime)"                                     | Add-Content $configFile -Encoding UTF8
+          "  add_library(onnxruntime::onnxruntime SHARED IMPORTED)"                     | Add-Content $configFile -Encoding UTF8
+          "  set_target_properties(onnxruntime::onnxruntime PROPERTIES"                 | Add-Content $configFile -Encoding UTF8
+          "    INTERFACE_INCLUDE_DIRECTORIES `"`${CMAKE_CURRENT_LIST_DIR}/../../../include`"" | Add-Content $configFile -Encoding UTF8
+          "    IMPORTED_LOCATION             `"`${CMAKE_CURRENT_LIST_DIR}/../../../lib/onnxruntime.dll`"" | Add-Content $configFile -Encoding UTF8
+          "    IMPORTED_IMPLIB               `"`${CMAKE_CURRENT_LIST_DIR}/../../../lib/onnxruntime.lib`"" | Add-Content $configFile -Encoding UTF8
+          "  )"                                                                          | Add-Content $configFile -Encoding UTF8
+          "endif()"                                                                      | Add-Content $configFile -Encoding UTF8
+          ""                                                                             | Add-Content $configFile -Encoding UTF8
+          "set(onnxruntime_FOUND TRUE)"                                                  | Add-Content $configFile -Encoding UTF8
+          "set(onnxruntime_VERSION `"$ortVersion`")"                                    | Add-Content $configFile -Encoding UTF8
+
+      # -----------------------------------------------------------------------
+      # Download LLVM prebuilt (from wcy123/llvm-mlir-prebuilt releases)
+      # -----------------------------------------------------------------------
+      - name: Download LLVM prebuilt
+        if: steps.cache-prebuilt.outputs.cache-hit != 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PREBUILT_DIR="${{ runner.workspace }}/prebuilt-local"
+          mkdir -p "$PREBUILT_DIR"
+          gh release download "${{ env.LLVM_TAG }}" \
+            --repo wcy123/llvm-mlir-prebuilt \
+            --pattern "llvm-22.1.0-release-windows-x64.zip" \
+            --dir "$PREBUILT_DIR"
+          unzip -q -o "$PREBUILT_DIR/llvm-22.1.0-release-windows-x64.zip" -d "$PREBUILT_DIR"
+          rm "$PREBUILT_DIR/llvm-22.1.0-release-windows-x64.zip"
+
+      # -----------------------------------------------------------------------
+      # Download flatbuffers prebuilt
+      # -----------------------------------------------------------------------
+      - name: Download flatbuffers prebuilt
+        if: steps.cache-prebuilt.outputs.cache-hit != 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PREBUILT_DIR="${{ runner.workspace }}/prebuilt-local"
+          gh release download "${{ env.FLATBUFFERS_TAG }}" \
+            --repo wcy123/llvm-mlir-prebuilt \
+            --pattern "flatbuffers-25.12.19-release-windows-x64.zip" \
+            --dir "$PREBUILT_DIR"
+          unzip -q -o "$PREBUILT_DIR/flatbuffers-25.12.19-release-windows-x64.zip" -d "$PREBUILT_DIR"
+          rm "$PREBUILT_DIR/flatbuffers-25.12.19-release-windows-x64.zip"
+
+      # -----------------------------------------------------------------------
+      # Download protobuf prebuilt
+      # -----------------------------------------------------------------------
+      - name: Download protobuf prebuilt
+        if: steps.cache-prebuilt.outputs.cache-hit != 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PREBUILT_DIR="${{ runner.workspace }}/prebuilt-local"
+          mkdir -p "$PREBUILT_DIR"
+          gh release download "${{ env.PROTO_TAG }}" \
+            --repo wcy123/llvm-mlir-prebuilt \
+            --pattern "protobuf-34.0-release-windows-x64.zip" \
+            --dir "$PREBUILT_DIR"
+          unzip -q -o "$PREBUILT_DIR/protobuf-34.0-release-windows-x64.zip" -d "$PREBUILT_DIR"
+          rm "$PREBUILT_DIR/protobuf-34.0-release-windows-x64.zip"
+
+      # -----------------------------------------------------------------------
+      # Cache: TheRock HIP SDK for Windows (separate cache – large tarball)
+      # -----------------------------------------------------------------------
+      - name: Cache TheRock
+        id: cache-therock
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.workspace }}/therock-dist
+          key: ${{ env.THEROCK_VERSION }}
+
+      - name: Download & extract TheRock
+        if: steps.cache-therock.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          THEROCK_DIST="$(cygpath -u '${{ runner.workspace }}/therock-dist')"
+          mkdir -p "$THEROCK_DIST"
+          curl -fsSL \
+            "https://repo.amd.com/rocm/tarball/${{ env.THEROCK_VERSION }}.tar.gz" \
+            -o therock.tar.gz
+          tar -xzf therock.tar.gz -C "$THEROCK_DIST" --strip-components=1
+          rm therock.tar.gz
+
+
+
+      # -----------------------------------------------------------------------
+      # The prebuilt LLVM package has C:\msvsn2022 hardcoded in LLVMExports.cmake
+      # for the DIA SDK path (known LLVM issue: llvm/llvm-project#111829).
+      # Create a junction from C:\msvsn2022 to the actual VS installation.
+      # -----------------------------------------------------------------------
+      - name: Fix DIA SDK path from prebuilt LLVM
+        shell: cmd
+        run: |
+          for /f "usebackq delims=" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath`) do set "VS_PATH=%%i"
+          mklink /J C:\msvsn2022 "%VS_PATH%"
+
+      # -----------------------------------------------------------------------
+      # llvm-lit.py (from prebuilt) requires the lit pip package at runtime.
+      # Pin Python to avoid mismatch with find_package(Python3) in CMake.
+      # -----------------------------------------------------------------------
+      - name: Setup Python 3.12
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install lit
+        run: pip install lit
+
+      # Put cl.exe and ninja.exe (bundled with VS) into PATH
+      - name: Setup MSVC environment
+        uses: ilammy/msvc-dev-cmd@v1
+
+      # -----------------------------------------------------------------------
+      # Build GTest from source and install into prebuilt-local.
+      # cmake/deps.cmake does find_package(GTest CONFIG QUIET) first; if found
+      # via CMAKE_PREFIX_PATH it skips FetchContent entirely.
+      # Requires MSVC env (cl.exe + ninja) hence placed after Setup MSVC.
+      # -----------------------------------------------------------------------
+      - name: Build GTest
+        if: steps.cache-prebuilt.outputs.cache-hit != 'true'
+        shell: cmd
+        run: |
+          curl -fsSL "https://github.com/google/googletest/archive/refs/tags/v${{ env.GTEST_VERSION }}.zip" -o gtest.zip
+          unzip -q gtest.zip
+          cmake -G Ninja -B gtest-build -S "googletest-${{ env.GTEST_VERSION }}" ^
+            -DCMAKE_BUILD_TYPE=Release ^
+            "-DCMAKE_INSTALL_PREFIX=${{ runner.workspace }}/prebuilt-local" ^
+            "-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded" ^
+            -DBUILD_GMOCK=ON
+          ninja -C gtest-build install
+          rd /s /q gtest-build "googletest-${{ env.GTEST_VERSION }}"
+          del gtest.zip
+
+      # Cache compilation results across runs via GitHub Actions Cache backend
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      # -----------------------------------------------------------------------
+      # Configure
+      # -----------------------------------------------------------------------
+      - name: Configure
+        shell: bash
+        env:
+          THEROCK_DIST: ${{ runner.workspace }}/therock-dist
+        run: |
+          cmake -S . -B ../build/$(basename "$PWD") \
+            -G Ninja \
+            -DBUILD_SHARED_LIBS=OFF \
+            "-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded" \
+            -DCMAKE_BUILD_TYPE=Release \
+            "-DCMAKE_PREFIX_PATH=${{ runner.workspace }}/prebuilt-local" \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -DBUILD_EP=ON \
+            -DBUILD_HIP_TOOLS=ON \
+            -DONNX_HIP_INCLUDE_LIT_TESTS=ON \
+            "-DTHEROCK_DIST=$THEROCK_DIST" \
+            -DHIP_ARCHITECTURES=gfx1151 \
+            -Dmorphizen_ENABLE_UNIT_TEST=OFF \
+            -DBUILD_MOCK_RUNTIME=OFF \
+            -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
+            --fresh
+
+
+      # -----------------------------------------------------------------------
+      # Build (no tests – Windows build-only CI)
+      # -----------------------------------------------------------------------
+      - name: Build
+        shell: bash
+        run: cmake --build ../build/$(basename "$PWD") --parallel $(nproc)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       LLVM_TAG: llvm-22.1.0-release
       FLATBUFFERS_TAG: flatbuffers-25.12.19-release
       PROTO_TAG: protobuf-34.0-release
-      ONNXRUNTIME_VERSION: "1.24.1"
+      ONNXRUNTIME_VERSION: "1.24.3"
       GTEST_VERSION: "1.15.0"
       THEROCK_VERSION: therock-dist-windows-gfx1151-7.11.0
       SCCACHE_GHA_ENABLED: "true"

--- a/.github/workflows/ci2.yml
+++ b/.github/workflows/ci2.yml
@@ -31,7 +31,7 @@ jobs:
       LLVM_TAG: llvm-22.1.0-release
       FLATBUFFERS_TAG: flatbuffers-25.12.19-release
       PROTO_TAG: protobuf-34.0-release
-      ONNXRUNTIME_VERSION: "1.24.1"
+      ONNXRUNTIME_VERSION: "1.24.3"
       GTEST_VERSION: "1.15.0"
       THEROCK_VERSION: therock-dist-windows-gfx1151-7.11.0
       SCCACHE_GHA_ENABLED: "true"

--- a/.github/workflows/ci2.yml
+++ b/.github/workflows/ci2.yml
@@ -1,0 +1,276 @@
+##
+## Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+## Licensed under the MIT License.
+##
+name: CI2 (temp – local morphizen zip)
+# TEMPORARY: verify CI pipeline while private submodule access is being set up.
+# MorphiZen is provided via ci/morphizen.zip (LFS).
+# Once org-level GITHUB_TOKEN read access is granted, rebase-drop this file
+# and the morphizen zip commit, then rely on ci.yml with submodules: recursive.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  merge_group:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+
+    env:
+      LLVM_TAG: llvm-22.1.0-release
+      FLATBUFFERS_TAG: flatbuffers-25.12.19-release
+      PROTO_TAG: protobuf-34.0-release
+      ONNXRUNTIME_VERSION: "1.24.1"
+      GTEST_VERSION: "1.15.0"
+      THEROCK_VERSION: therock-dist-windows-gfx1151-7.11.0
+      SCCACHE_GHA_ENABLED: "true"
+
+    steps:
+      # submodules: false – private ROCm/MorphiZen is provided via ci/morphizen.zip instead
+      # lfs: true – needed to download the actual zip content (not just the LFS pointer)
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: false
+          lfs: true
+          fetch-depth: 0
+          show-progress: false
+
+      - name: Extract MorphiZen from zip
+        shell: bash
+        run: |
+          unzip -q ci/morphizen.zip -d 3rd-party/morphizen
+
+      # -----------------------------------------------------------------------
+      # Cache: ONNX Runtime + LLVM prebuilt + flatbuffers
+      # All are installed into the same prebuilt-local prefix so one cache
+      # entry covers all of them.
+      # Note: protobuf is excluded – cmake/deps.cmake fetches v21.12 via
+      # FetchContent (same version pinned by morphizen) to avoid C4267 errors
+      # from mismatched protobuf versions.
+      # -----------------------------------------------------------------------
+      - name: Cache prebuilt-local
+        id: cache-prebuilt
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.workspace }}/prebuilt-local
+          key: prebuilt-ort-${{ env.ONNXRUNTIME_VERSION }}-${{ env.LLVM_TAG }}-${{ env.FLATBUFFERS_TAG }}-${{ env.PROTO_TAG }}-gtest${{ env.GTEST_VERSION }}
+
+      # -----------------------------------------------------------------------
+      # Download ONNX Runtime (official pre-built zip)
+      # morphizen-core calls find_package(onnxruntime REQUIRED), so we also
+      # create onnxruntimeConfig.cmake in the right location.
+      # -----------------------------------------------------------------------
+      - name: Download pre-built ONNX Runtime
+        if: steps.cache-prebuilt.outputs.cache-hit != 'true'
+        shell: powershell
+        run: |
+          $ortVersion = "${{ env.ONNXRUNTIME_VERSION }}"
+          $url = "https://github.com/microsoft/onnxruntime/releases/download/v$ortVersion/onnxruntime-win-x64-$ortVersion.zip"
+          $zipFile = "${{ github.workspace }}/onnxruntime-win-x64-$ortVersion.zip"
+          Write-Host "Downloading $url"
+          Invoke-WebRequest -Uri $url -OutFile $zipFile
+
+          $prefixDir = "${{ runner.workspace }}/prebuilt-local"
+          New-Item -ItemType Directory -Force -Path $prefixDir | Out-Null
+          Expand-Archive -Path $zipFile -DestinationPath $prefixDir -Force
+
+          # Flatten nested directory produced by the zip
+          $extractedDir = "$prefixDir/onnxruntime-win-x64-$ortVersion"
+          if (Test-Path $extractedDir) {
+            Move-Item -Path "$extractedDir/*" -Destination "$prefixDir/" -Force
+            Remove-Item -Path $extractedDir -Force -Recurse
+          }
+
+          # Create CMake config so find_package(onnxruntime REQUIRED) succeeds.
+          # The pre-built zip puts headers in include/ and onnxruntime.lib in lib/.
+          $cmakeDir = "$prefixDir/lib/cmake/onnxruntime"
+          New-Item -ItemType Directory -Force -Path $cmakeDir | Out-Null
+          $configFile = "$cmakeDir/onnxruntimeConfig.cmake"
+          "# onnxruntimeConfig.cmake - auto-generated for pre-built ONNX Runtime $ortVersion" | Set-Content $configFile -Encoding UTF8
+          ""                                                                             | Add-Content $configFile -Encoding UTF8
+          "if(NOT TARGET onnxruntime::onnxruntime)"                                     | Add-Content $configFile -Encoding UTF8
+          "  add_library(onnxruntime::onnxruntime SHARED IMPORTED)"                     | Add-Content $configFile -Encoding UTF8
+          "  set_target_properties(onnxruntime::onnxruntime PROPERTIES"                 | Add-Content $configFile -Encoding UTF8
+          "    INTERFACE_INCLUDE_DIRECTORIES `"`${CMAKE_CURRENT_LIST_DIR}/../../../include`"" | Add-Content $configFile -Encoding UTF8
+          "    IMPORTED_LOCATION             `"`${CMAKE_CURRENT_LIST_DIR}/../../../lib/onnxruntime.dll`"" | Add-Content $configFile -Encoding UTF8
+          "    IMPORTED_IMPLIB               `"`${CMAKE_CURRENT_LIST_DIR}/../../../lib/onnxruntime.lib`"" | Add-Content $configFile -Encoding UTF8
+          "  )"                                                                          | Add-Content $configFile -Encoding UTF8
+          "endif()"                                                                      | Add-Content $configFile -Encoding UTF8
+          ""                                                                             | Add-Content $configFile -Encoding UTF8
+          "set(onnxruntime_FOUND TRUE)"                                                  | Add-Content $configFile -Encoding UTF8
+          "set(onnxruntime_VERSION `"$ortVersion`")"                                    | Add-Content $configFile -Encoding UTF8
+
+      # -----------------------------------------------------------------------
+      # Download LLVM prebuilt (from wcy123/llvm-mlir-prebuilt releases)
+      # -----------------------------------------------------------------------
+      - name: Download LLVM prebuilt
+        if: steps.cache-prebuilt.outputs.cache-hit != 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PREBUILT_DIR="${{ runner.workspace }}/prebuilt-local"
+          mkdir -p "$PREBUILT_DIR"
+          gh release download "${{ env.LLVM_TAG }}" \
+            --repo wcy123/llvm-mlir-prebuilt \
+            --pattern "llvm-22.1.0-release-windows-x64.zip" \
+            --dir "$PREBUILT_DIR"
+          unzip -q -o "$PREBUILT_DIR/llvm-22.1.0-release-windows-x64.zip" -d "$PREBUILT_DIR"
+          rm "$PREBUILT_DIR/llvm-22.1.0-release-windows-x64.zip"
+
+      # -----------------------------------------------------------------------
+      # Download flatbuffers prebuilt
+      # -----------------------------------------------------------------------
+      - name: Download flatbuffers prebuilt
+        if: steps.cache-prebuilt.outputs.cache-hit != 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PREBUILT_DIR="${{ runner.workspace }}/prebuilt-local"
+          gh release download "${{ env.FLATBUFFERS_TAG }}" \
+            --repo wcy123/llvm-mlir-prebuilt \
+            --pattern "flatbuffers-25.12.19-release-windows-x64.zip" \
+            --dir "$PREBUILT_DIR"
+          unzip -q -o "$PREBUILT_DIR/flatbuffers-25.12.19-release-windows-x64.zip" -d "$PREBUILT_DIR"
+          rm "$PREBUILT_DIR/flatbuffers-25.12.19-release-windows-x64.zip"
+
+      # -----------------------------------------------------------------------
+      # Download protobuf prebuilt
+      # -----------------------------------------------------------------------
+      - name: Download protobuf prebuilt
+        if: steps.cache-prebuilt.outputs.cache-hit != 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PREBUILT_DIR="${{ runner.workspace }}/prebuilt-local"
+          mkdir -p "$PREBUILT_DIR"
+          gh release download "${{ env.PROTO_TAG }}" \
+            --repo wcy123/llvm-mlir-prebuilt \
+            --pattern "protobuf-34.0-release-windows-x64.zip" \
+            --dir "$PREBUILT_DIR"
+          unzip -q -o "$PREBUILT_DIR/protobuf-34.0-release-windows-x64.zip" -d "$PREBUILT_DIR"
+          rm "$PREBUILT_DIR/protobuf-34.0-release-windows-x64.zip"
+
+      # -----------------------------------------------------------------------
+      # Cache: TheRock HIP SDK for Windows (separate cache – large tarball)
+      # -----------------------------------------------------------------------
+      - name: Cache TheRock
+        id: cache-therock
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.workspace }}/therock-dist
+          key: ${{ env.THEROCK_VERSION }}
+
+      - name: Download & extract TheRock
+        if: steps.cache-therock.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          THEROCK_DIST="$(cygpath -u '${{ runner.workspace }}/therock-dist')"
+          mkdir -p "$THEROCK_DIST"
+          curl -fsSL \
+            "https://repo.amd.com/rocm/tarball/${{ env.THEROCK_VERSION }}.tar.gz" \
+            -o therock.tar.gz
+          tar -xzf therock.tar.gz -C "$THEROCK_DIST" --strip-components=1
+          rm therock.tar.gz
+
+
+
+      # -----------------------------------------------------------------------
+      # The prebuilt LLVM package has C:\msvsn2022 hardcoded in LLVMExports.cmake
+      # for the DIA SDK path (known LLVM issue: llvm/llvm-project#111829).
+      # Create a junction from C:\msvsn2022 to the actual VS installation.
+      # -----------------------------------------------------------------------
+      - name: Fix DIA SDK path from prebuilt LLVM
+        shell: cmd
+        run: |
+          for /f "usebackq delims=" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath`) do set "VS_PATH=%%i"
+          mklink /J C:\msvsn2022 "%VS_PATH%"
+
+      # -----------------------------------------------------------------------
+      # llvm-lit.py (from prebuilt) requires the lit pip package at runtime.
+      # Pin Python to avoid mismatch with find_package(Python3) in CMake.
+      # -----------------------------------------------------------------------
+      - name: Setup Python 3.12
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install lit
+        run: pip install lit
+
+      # Put cl.exe and ninja.exe (bundled with VS) into PATH
+      - name: Setup MSVC environment
+        uses: ilammy/msvc-dev-cmd@v1
+
+      # -----------------------------------------------------------------------
+      # Build GTest from source and install into prebuilt-local.
+      # cmake/deps.cmake does find_package(GTest CONFIG QUIET) first; if found
+      # via CMAKE_PREFIX_PATH it skips FetchContent entirely.
+      # Requires MSVC env (cl.exe + ninja) hence placed after Setup MSVC.
+      # -----------------------------------------------------------------------
+      - name: Build GTest
+        if: steps.cache-prebuilt.outputs.cache-hit != 'true'
+        shell: cmd
+        run: |
+          curl -fsSL "https://github.com/google/googletest/archive/refs/tags/v${{ env.GTEST_VERSION }}.zip" -o gtest.zip
+          unzip -q gtest.zip
+          cmake -G Ninja -B gtest-build -S "googletest-${{ env.GTEST_VERSION }}" ^
+            -DCMAKE_BUILD_TYPE=Release ^
+            "-DCMAKE_INSTALL_PREFIX=${{ runner.workspace }}/prebuilt-local" ^
+            "-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded" ^
+            -DBUILD_GMOCK=ON
+          ninja -C gtest-build install
+          rd /s /q gtest-build "googletest-${{ env.GTEST_VERSION }}"
+          del gtest.zip
+
+      # Cache compilation results across runs via GitHub Actions Cache backend
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      # -----------------------------------------------------------------------
+      # Configure
+      # -----------------------------------------------------------------------
+      - name: Configure
+        shell: bash
+        env:
+          THEROCK_DIST: ${{ runner.workspace }}/therock-dist
+        run: |
+          cmake -S . -B ../build/$(basename "$PWD") \
+            -G Ninja \
+            -DBUILD_SHARED_LIBS=OFF \
+            "-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded" \
+            -DCMAKE_BUILD_TYPE=Release \
+            "-DCMAKE_PREFIX_PATH=${{ runner.workspace }}/prebuilt-local" \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -DBUILD_EP=ON \
+            -DBUILD_HIP_TOOLS=ON \
+            -DONNX_HIP_INCLUDE_LIT_TESTS=ON \
+            "-DTHEROCK_DIST=$THEROCK_DIST" \
+            -DHIP_ARCHITECTURES=gfx1151 \
+            -Dmorphizen_ENABLE_UNIT_TEST=OFF \
+            -DBUILD_MOCK_RUNTIME=OFF \
+            -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
+            --fresh
+
+
+      # -----------------------------------------------------------------------
+      # Build (no tests – Windows build-only CI)
+      # -----------------------------------------------------------------------
+      - name: Build
+        shell: bash
+        run: cmake --build ../build/$(basename "$PWD") --parallel $(nproc)

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -2,7 +2,7 @@
 ## Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 ## Licensed under the MIT License.
 ##
-name: CI
+name: Windows Build
 
 on:
   workflow_dispatch:

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -33,17 +33,29 @@ jobs:
       SCCACHE_GHA_ENABLED: "true"
 
     steps:
-      # NOTE: ROCm/MorphiZen is a private repo. This checkout requires the
-      # ROCm org-level GITHUB_TOKEN to have read access to org resources
-      # (ROCm org → Settings → Actions → General → Workflow permissions).
-      # If that is not yet enabled, fall back to Option A (deploy key) in
-      # docs/ci-private-submodule-access.md.
+      # ROCm/MorphiZen is a private repo. A read-only deploy key is stored as
+      # MORPHIZEN_DEPLOY_KEY in ROCm/onnx-hipdnn-ep secrets, and the matching
+      # public key is added to ROCm/MorphiZen deploy keys. The git URL rewrite
+      # below redirects the HTTPS submodule URL to SSH at clone time so that
+      # .gitmodules can stay as HTTPS.
+      - name: Setup SSH key for MorphiZen submodule
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.MORPHIZEN_DEPLOY_KEY }}
+
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          submodules: recursive
+          submodules: false
           fetch-depth: 0
           show-progress: false
+
+      - name: Checkout MorphiZen submodule
+        shell: bash
+        run: |
+          git config --global url."git@github.com:ROCm/MorphiZen.git".insteadOf \
+            "https://github.com/ROCm/MorphiZen.git"
+          git submodule update --init --recursive
 
       # -----------------------------------------------------------------------
       # Cache: ONNX Runtime + LLVM prebuilt + flatbuffers

--- a/backend-mlir-compiler/proto/CMakeLists.txt
+++ b/backend-mlir-compiler/proto/CMakeLists.txt
@@ -14,5 +14,9 @@ target_include_directories(mlir_compilation_proto PUBLIC
     ${CMAKE_CURRENT_BINARY_DIR}
     ${Protobuf_INCLUDE_DIRS}
 )
+# Suppress C4267 (size_t→int) in protobuf-generated sources
+if(MSVC)
+  set_source_files_properties(${PROTO_SRCS} PROPERTIES COMPILE_FLAGS "/wd4267")
+endif()
 # Fix LNK4217 warnings: protobuf is statically linked, not a DLL
 target_compile_definitions(mlir_compilation_proto PRIVATE PROTOBUF_USE_DLLS=0)

--- a/ci/morphizen.zip
+++ b/ci/morphizen.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca6be680846d98c16f6d53a5e8b4242de0e1e51f8b182015c61c14266b861fac
+size 46352552

--- a/level-2-pass-rocm-conv/cmake/generate_pattern_inc.cmake
+++ b/level-2-pass-rocm-conv/cmake/generate_pattern_inc.cmake
@@ -6,7 +6,7 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 add_custom_command (
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/conv_pattern_json.hpp
   COMMAND ${CMAKE_COMMAND} -E env
-    $<TARGET_FILE:Python3::Interpreter> ${morphizen_SOURCE_DIR}/tools/xxd.py
+    $<TARGET_FILE:Python3::Interpreter> ${CMAKE_SOURCE_DIR}/cmake/xxd.py
     "--column" 16
     "--var" conv_json
     --output ${CMAKE_CURRENT_BINARY_DIR}/conv_pattern_json.hpp

--- a/level-2-pass-rocm-gemm/cmake/generate_pattern_inc.cmake
+++ b/level-2-pass-rocm-gemm/cmake/generate_pattern_inc.cmake
@@ -6,7 +6,7 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 add_custom_command (
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/gemm_pattern_json.hpp
   COMMAND ${CMAKE_COMMAND} -E env
-    $<TARGET_FILE:Python3::Interpreter> ${morphizen_SOURCE_DIR}/tools/xxd.py
+    $<TARGET_FILE:Python3::Interpreter> ${CMAKE_SOURCE_DIR}/cmake/xxd.py
     "--column" 16
     "--var" gemm_json
     --output ${CMAKE_CURRENT_BINARY_DIR}/gemm_pattern_json.hpp

--- a/level-2-pass-rocm-matmul/cmake/generate_pattern_inc.cmake
+++ b/level-2-pass-rocm-matmul/cmake/generate_pattern_inc.cmake
@@ -6,7 +6,7 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 add_custom_command (
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/matmul_pattern_json.hpp
   COMMAND ${CMAKE_COMMAND} -E env
-    $<TARGET_FILE:Python3::Interpreter> ${morphizen_SOURCE_DIR}/tools/xxd.py
+    $<TARGET_FILE:Python3::Interpreter> ${CMAKE_SOURCE_DIR}/cmake/xxd.py
     "--column" 16
     "--var" matmul_json
     --output ${CMAKE_CURRENT_BINARY_DIR}/matmul_pattern_json.hpp

--- a/level-2-pass-rocm-mul/cmake/generate_pattern_inc.cmake
+++ b/level-2-pass-rocm-mul/cmake/generate_pattern_inc.cmake
@@ -6,7 +6,7 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 add_custom_command (
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/mul_pattern_json.hpp
   COMMAND ${CMAKE_COMMAND} -E env
-    $<TARGET_FILE:Python3::Interpreter> ${morphizen_SOURCE_DIR}/tools/xxd.py
+    $<TARGET_FILE:Python3::Interpreter> ${CMAKE_SOURCE_DIR}/cmake/xxd.py
     "--column" 16
     "--var" mul_json
     --output ${CMAKE_CURRENT_BINARY_DIR}/mul_pattern_json.hpp

--- a/level-2-pass-rocm-reshape/cmake/generate_pattern_inc.cmake
+++ b/level-2-pass-rocm-reshape/cmake/generate_pattern_inc.cmake
@@ -6,7 +6,7 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 add_custom_command (
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/reshape_pattern_json.hpp
   COMMAND ${CMAKE_COMMAND} -E env
-    $<TARGET_FILE:Python3::Interpreter> ${morphizen_SOURCE_DIR}/tools/xxd.py
+    $<TARGET_FILE:Python3::Interpreter> ${CMAKE_SOURCE_DIR}/cmake/xxd.py
     "--column" 16
     "--var" reshape_json
     --output ${CMAKE_CURRENT_BINARY_DIR}/reshape_pattern_json.hpp

--- a/level-2-pass-rocm-softmax/cmake/generate_pattern_inc.cmake
+++ b/level-2-pass-rocm-softmax/cmake/generate_pattern_inc.cmake
@@ -6,7 +6,7 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 add_custom_command (
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/softmax_pattern_json.hpp
   COMMAND ${CMAKE_COMMAND} -E env
-    $<TARGET_FILE:Python3::Interpreter> ${morphizen_SOURCE_DIR}/tools/xxd.py
+    $<TARGET_FILE:Python3::Interpreter> ${CMAKE_SOURCE_DIR}/cmake/xxd.py
     "--column" 16
     "--var" softmax_json
     --output ${CMAKE_CURRENT_BINARY_DIR}/softmax_pattern_json.hpp

--- a/level-2-pass-rocm-tile/cmake/generate_pattern_inc.cmake
+++ b/level-2-pass-rocm-tile/cmake/generate_pattern_inc.cmake
@@ -6,7 +6,7 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 add_custom_command (
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/tile_pattern_json.hpp
   COMMAND ${CMAKE_COMMAND} -E env
-    $<TARGET_FILE:Python3::Interpreter> ${morphizen_SOURCE_DIR}/tools/xxd.py
+    $<TARGET_FILE:Python3::Interpreter> ${CMAKE_SOURCE_DIR}/cmake/xxd.py
     "--column" 16
     "--var" tile_json
     --output ${CMAKE_CURRENT_BINARY_DIR}/tile_pattern_json.hpp

--- a/level-2-pass-rocm-transpose/cmake/generate_pattern_inc.cmake
+++ b/level-2-pass-rocm-transpose/cmake/generate_pattern_inc.cmake
@@ -6,7 +6,7 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 add_custom_command (
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/transpose_pattern_json.hpp
   COMMAND ${CMAKE_COMMAND} -E env
-    $<TARGET_FILE:Python3::Interpreter> ${morphizen_SOURCE_DIR}/tools/xxd.py
+    $<TARGET_FILE:Python3::Interpreter> ${CMAKE_SOURCE_DIR}/cmake/xxd.py
     "--column" 16
     "--var" transpose_json
     --output ${CMAKE_CURRENT_BINARY_DIR}/transpose_pattern_json.hpp


### PR DESCRIPTION
## Summary

- Add self-contained Windows build-only CI (no GPU required, no test step)
- Replace protobuf and GTest FetchContent with prebuilt/source-built packages installed to a shared prefix
- Add `sccache` for compilation caching across runs
- Fix `generate_pattern_inc.cmake` path issues in `level-2-pass-rocm-*` targets
- Fix per-file `/wd4267` suppression on protobuf-generated sources in `backend-mlir-compiler/proto`

## Dependencies

| Dependency | Source | Version |
|------------|--------|---------|
| ONNX Runtime | Official GitHub release zip | 1.24.1 |
| LLVM / flatbuffers | `wcy123/llvm-mlir-prebuilt` releases | 22.1.0 / 25.12.19 |
| protobuf | `wcy123/llvm-mlir-prebuilt` releases | 34.0 |
| GTest | Built from source (GoogleTest archive) | 1.15.0 |
| TheRock HIP SDK | AMD repo tarball | gfx1151 7.11.0 |

## Caching strategy

| Cache key | Contents |
|-----------|----------|
| `prebuilt-ort-<ORT>-<LLVM>-<FLATBUFFERS>-<PROTO>-gtest<GTEST>` | ORT + LLVM + flatbuffers + protobuf + GTest (single prefix) |
| `therock-dist-windows-gfx1151-7.11.0` | TheRock HIP SDK |

## CMake flags

`BUILD_EP=ON`, `BUILD_HIP_TOOLS=ON`, `BUILD_MOCK_RUNTIME=OFF`, `HIP_ARCHITECTURES=gfx1151`, `morphizen_ENABLE_UNIT_TEST=OFF`, `CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded`

## Temporary: ci2.yml

`ci2.yml` is a short-lived workaround that provides MorphiZen via `ci/morphizen.zip` (Git LFS) while org-level `GITHUB_TOKEN` submodule read access is being set up. Once that is granted, this file and the zip should be rebase-dropped in favour of `ci.yml` with `submodules: recursive`.

## Test plan

- [ ] Cache miss path: all dependencies download and install correctly
- [ ] Cache hit path: Configure step resolves all `find_package()` calls without re-downloading
- [ ] Build produces `onnxruntime_morphizen_ep.dll` and `hip-mlir-opt.exe`