### PR TITLE
Port LLaMA operations from PR-17: rope, matmul, gqa, gather

### DIFF
--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -417,16 +417,32 @@ def Hip_TransposeOp : Hip_DpsOp<"transpose"> {
 }
 
 def Hip_GatherOp : Hip_DpsOp<"gather"> {
-  let summary = "Embedding table lookup";
+  let summary = "Gather elements along an axis";
+  let description = [{
+    Gathers elements from data tensor along the given axis using indices.
+    Implements the ONNX Gather operator.
+
+    Uses destination-passing style: output buffer is provided as argument.
+
+    Example:
+    ```mlir
+    hip.gather(%ctx) ins(%data, %indices : memref<3x4xf32, 1>, memref<2xi64, 1>)
+                     outs(%output : memref<2x4xf32, 1>) {axis = 0 : i64}
+    ```
+  }];
   let arguments = (ins
     Hip_ContextType:$ctx,
+    Hip_TensorOrMemRef:$data,
     Hip_TensorOrMemRef:$indices,
-    Hip_TensorOrMemRef:$table,
-    Hip_TensorOrMemRef:$output
+    Hip_TensorOrMemRef:$output,
+    I64Attr:$axis
   );
   // result_tensors inherited from Hip_DpsOp
-  let hasCustomAssemblyFormat = 1;
-  let hasVerifier = 1;
+  let assemblyFormat = [{
+    `(` $ctx `)` `ins` `(` $data `,` $indices `:` type($data) `,` type($indices) `)`
+    `outs` `(` $output `:` type($output) `)`
+    attr-dict (`:` type($result_tensors)^)?
+  }];
 }
 
 def Hip_SiluOp : Hip_DpsOp<"silu"> {

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -275,19 +275,50 @@ def Hip_SkipRmsNormOp : Hip_DpsOp<"skip_rms_norm"> {
   let hasVerifier = 1;
 }
 
-def Hip_MiopenRopeOp : Hip_DpsOp<"miopen.rope"> {
-  let summary = "Rotary positional embeddings (MIOpen experimental)";
+def Hip_RopeOp : Hip_DpsOp<"rope"> {
+  let summary = "Rotary position embedding (RoPE)";
+  let description = [{
+    Applies rotary position embedding to the input tensor.
+    Implements the Microsoft RotaryEmbedding operator.
+
+    Uses destination-passing style: output buffer is provided as argument.
+
+    Attributes:
+    - interleaved: Rotary embedding interleaved format (0 or 1)
+    - num_heads: Number of attention heads
+    - rotary_embedding_dim: Dimension of rotary embedding
+
+    Example:
+    ```mlir
+    hip.rope(%ctx)
+        ins(%input, %position_ids, %cos_cache, %sin_cache :
+            memref<1x128x4096xf16, 1>, memref<1x128xi64, 1>,
+            memref<131072x64xf16, 1>, memref<131072x64xf16, 1>)
+        outs(%output : memref<1x128x4096xf16, 1>)
+        {interleaved = 0 : i64, num_heads = 32 : i64, rotary_embedding_dim = 128 : i64}
+    ```
+  }];
+
   let arguments = (ins
     Hip_ContextType:$ctx,
-    Index:$start_pos,
+    Hip_TensorOrMemRef:$input,
+    Hip_TensorOrMemRef:$position_ids,
     Hip_TensorOrMemRef:$cos_cache,
     Hip_TensorOrMemRef:$sin_cache,
-    Hip_TensorOrMemRef:$q,
-    Hip_TensorOrMemRef:$k
+    Hip_TensorOrMemRef:$output,
+    I64Attr:$interleaved,
+    I64Attr:$num_heads,
+    I64Attr:$rotary_embedding_dim
   );
-  // result_tensors inherited from Hip_DpsOp
-  let hasCustomAssemblyFormat = 1;
-  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    `(` $ctx `)` `ins` `(`
+        $input `,` $position_ids `,` $cos_cache `,` $sin_cache `:`
+        type($input) `,` type($position_ids) `,` type($cos_cache) `,` type($sin_cache)
+    `)`
+    `outs` `(` $output `:` type($output) `)`
+    attr-dict (`:` type($result_tensors)^)?
+  }];
 }
 
 def Hip_MiopenAddOp : Hip_DpsOp<"miopen.add"> {

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -560,21 +560,70 @@ def Hip_ReduceSumOp : Hip_DpsOp<"reduce_sum"> {
 }
 
 def Hip_GqaOp : Hip_DpsOp<"gqa"> {
-  let summary = "Grouped query attention";
+  let summary = "Group Query Attention (com.microsoft GQA)";
+  let description = [{
+    Multi-head attention with grouped key/value heads (GQA/MQA).
+    Implements the com.microsoft GroupQueryAttention operator for LLM inference.
+
+    Concatenates new key/value with past KV cache and computes scaled
+    dot-product attention with grouped heads.
+
+    Uses destination-passing style: output buffers are provided as arguments.
+
+    Operand layout (for getDpsInitsMutable): operands 0..7 are inputs
+    (ctx, query, key, value, past_key, past_value, seqlens_k, total_seq_len);
+    operands 8..10 are DPS inits (output, present_key, present_value).
+
+    Attributes:
+    - num_heads: Number of query attention heads
+    - kv_num_heads: Number of key/value heads (< num_heads for GQA)
+    - scale: Attention score scaling factor (1/sqrt(head_dim))
+    - softcap: Soft capping value for attention logits (0 = disabled)
+    - do_rotary: Apply rotary positional embedding (0 or 1)
+    - rotary_interleaved: Rotary embedding interleaved format (0 or 1)
+
+    Example:
+    ```mlir
+    hip.gqa(%ctx)
+        ins(%query, %key, %value, %past_key, %past_value, %seqlens_k, %total_seq_len :
+            memref<1x1x4096xf16, 1>, ...)
+        outs(%output, %present_key, %present_value : ...)
+        {num_heads = 32, kv_num_heads = 8, scale = 0.0884,
+         softcap = 0.0, do_rotary = 0, rotary_interleaved = 0}
+    ```
+  }];
+
   let arguments = (ins
     Hip_ContextType:$ctx,
-    Index:$layer,
-    Index:$start_pos,
-    Index:$seq_len,
-    Hip_TensorOrMemRef:$q,
-    Hip_TensorOrMemRef:$k,
-    Hip_TensorOrMemRef:$v,
-    Hip_TensorOrMemRef:$kv_cache,
-    Hip_TensorOrMemRef:$output
+    Hip_TensorOrMemRef:$query,
+    Hip_TensorOrMemRef:$key,
+    Hip_TensorOrMemRef:$value,
+    Hip_TensorOrMemRef:$past_key,
+    Hip_TensorOrMemRef:$past_value,
+    Hip_TensorOrMemRef:$seqlens_k,
+    Hip_TensorOrMemRef:$total_seq_len,
+    Hip_TensorOrMemRef:$output,
+    Hip_TensorOrMemRef:$present_key,
+    Hip_TensorOrMemRef:$present_value,
+    I64Attr:$num_heads,
+    I64Attr:$kv_num_heads,
+    F32Attr:$scale,
+    F32Attr:$softcap,
+    I64Attr:$do_rotary,
+    I64Attr:$rotary_interleaved
   );
-  // result_tensors inherited from Hip_DpsOp
-  let hasCustomAssemblyFormat = 1;
-  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    `(` $ctx `)` `ins` `(`
+        $query `,` $key `,` $value `,`
+        $past_key `,` $past_value `,` $seqlens_k `,` $total_seq_len `:`
+        type($query) `,` type($key) `,` type($value) `,`
+        type($past_key) `,` type($past_value) `,` type($seqlens_k) `,` type($total_seq_len)
+    `)`
+    `outs` `(` $output `,` $present_key `,` $present_value `:`
+              type($output) `,` type($present_key) `,` type($present_value) `)`
+    attr-dict (`:` type($result_tensors)^)?
+  }];
 }
 
 #endif // HIP_OPS

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -170,17 +170,44 @@ def Hip_ConvOp : Hip_DpsOp<"conv"> {
 
 // ===== hipBLASLt ops =========================================================
 
-def Hip_HipblasltMatmulOp : Hip_DpsOp<"hipblaslt.matmul"> {
-  let summary = "Matrix multiply C = A @ B via hipBLASLt";
+def Hip_MatmulOp : Hip_DpsOp<"matmul"> {
+  let summary = "Matrix multiplication (supports batched N-D x N-D)";
+  let description = [{
+    Performs matrix multiplication: output = A @ B
+    Supports batched operation (leading dimensions are batch dimensions).
+
+    Uses destination-passing style: output buffer is provided as argument.
+
+    Unlike hip.gemm, this has no alpha/beta/transA/transB/bias — it maps
+    directly to onnx.MatMul semantics.
+
+    Example (2D):
+    ```mlir
+    hip.matmul(%ctx) ins(%A, %B : memref<128x4096xf32, 1>,
+                                  memref<4096x1024xf32, 1>)
+                     outs(%output : memref<128x1024xf32, 1>)
+    ```
+
+    Example (3D batched):
+    ```mlir
+    hip.matmul(%ctx) ins(%A, %B : memref<1x128x4096xf16, 1>,
+                                  memref<4096x1024xf16, 1>)
+                     outs(%output : memref<1x128x1024xf16, 1>)
+    ```
+  }];
+
   let arguments = (ins
     Hip_ContextType:$ctx,
     Hip_TensorOrMemRef:$A,
     Hip_TensorOrMemRef:$B,
-    Hip_TensorOrMemRef:$C
+    Hip_TensorOrMemRef:$output
   );
-  // result_tensors inherited from Hip_DpsOp
-  let hasCustomAssemblyFormat = 1;
-  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    `(` $ctx `)` `ins` `(` $A `,` $B `:` type($A) `,` type($B) `)`
+    `outs` `(` $output `:` type($output) `)`
+    attr-dict (`:` type($result_tensors)^)?
+  }];
 }
 
 // ===== MIOpen ops ============================================================

--- a/lib/Conversion/HipToLLVM/HipToLLVM.cpp
+++ b/lib/Conversion/HipToLLVM/HipToLLVM.cpp
@@ -1487,6 +1487,9 @@ struct GqaOpLowering : public ConvertOpToLLVMPattern<GqaOp> {
 
     // Extract shape info from query memref: [batch, seq_q, num_heads *
     // head_dim]
+    // NOTE: Currently only supports static shapes. Dynamic shape support would
+    // require extracting dimensions at runtime using MemRefDescriptor::size()
+    // and computing headDim dynamically.
     auto queryType = cast<MemRefType>(op.getQuery().getType());
     auto queryShape = queryType.getShape();
     int64_t batchSize = queryShape[0];

--- a/lib/Conversion/HipToLLVM/HipToLLVM.cpp
+++ b/lib/Conversion/HipToLLVM/HipToLLVM.cpp
@@ -1397,7 +1397,9 @@ struct ReduceSumOpLowering : public ConvertOpToLLVMPattern<ReduceSumOp> {
   }
 };
 
-// hip.gqa(handle, q, k, v, kv_cache, output, layer, start_pos, seq_len)
+// hip.gqa(ctx, query, key, value, past_key, past_value, seqlens_k,
+// total_seq_len,
+//         output, present_key, present_value) {attributes...}
 struct GqaOpLowering : public ConvertOpToLLVMPattern<GqaOp> {
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
@@ -1406,30 +1408,131 @@ struct GqaOpLowering : public ConvertOpToLLVMPattern<GqaOp> {
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op.getLoc();
     ModuleOp module = op->getParentOfType<ModuleOp>();
-    Type voidType = getVoidType();
     Type ptrType = getPtrType();
-    Type indexType = getIndexType();
+    Type i32Type = rewriter.getI32Type();
+    Type i64Type = rewriter.getI64Type();
+    Type f32Type = rewriter.getF32Type();
 
-    SmallVector<Type> paramTypes = {ptrType,   ptrType,   ptrType,
-                                    ptrType,   ptrType,   ptrType,
-                                    indexType, indexType, indexType};
+    auto createI64Const = [&](int64_t value) -> Value {
+      return rewriter.create<LLVM::ConstantOp>(
+          loc, i64Type, rewriter.getI64IntegerAttr(value));
+    };
+    auto createF32Const = [&](float value) -> Value {
+      return rewriter.create<LLVM::ConstantOp>(loc, f32Type,
+                                               rewriter.getF32FloatAttr(value));
+    };
+
+    Value statePtr = adaptor.getCtx();
+    Value queryPtr = extractMemRefPtr(adaptor.getQuery(), rewriter, loc);
+    Value keyPtr = extractMemRefPtr(adaptor.getKey(), rewriter, loc);
+    Value valuePtr = extractMemRefPtr(adaptor.getValue(), rewriter, loc);
+    Value pastKeyPtr = extractMemRefPtr(adaptor.getPastKey(), rewriter, loc);
+    Value pastValuePtr =
+        extractMemRefPtr(adaptor.getPastValue(), rewriter, loc);
+    Value seqlensKPtr = extractMemRefPtr(adaptor.getSeqlensK(), rewriter, loc);
+    Value totalSeqLenPtr =
+        extractMemRefPtr(adaptor.getTotalSeqLen(), rewriter, loc);
+    Value outputPtr = extractMemRefPtr(adaptor.getOutput(), rewriter, loc);
+    Value presentKeyPtr =
+        extractMemRefPtr(adaptor.getPresentKey(), rewriter, loc);
+    Value presentValuePtr =
+        extractMemRefPtr(adaptor.getPresentValue(), rewriter, loc);
+
+    // cos/sin cache: NULL pointers for now (RoPE done via separate op)
+    Value nullPtr = rewriter.create<LLVM::ZeroOp>(loc, ptrType);
+    Value cosCachePtr = nullPtr;
+    Value sinCachePtr = nullPtr;
+
+    Value numHeads = createI64Const(op.getNumHeads());
+    Value kvNumHeads = createI64Const(op.getKvNumHeads());
+    Value scale = createF32Const(op.getScale().convertToFloat());
+    Value softcap = createF32Const(op.getSoftcap().convertToFloat());
+    Value doRotary = createI64Const(op.getDoRotary());
+    Value rotaryInterleaved = createI64Const(op.getRotaryInterleaved());
+
+    // Extract shape info from query memref: [batch, seq_q, num_heads *
+    // head_dim]
+    auto queryType = cast<MemRefType>(op.getQuery().getType());
+    auto queryShape = queryType.getShape();
+    int64_t batchSize = queryShape[0];
+    int64_t seqLenQ = queryShape[1];
+    int64_t queryHidden = queryShape[2];
+    int64_t headDim = queryHidden / op.getNumHeads();
+    unsigned elementSizeBytes =
+        queryType.getElementType().getIntOrFloatBitWidth() / 8;
+
+    // Extract seq_len_kv from present_key shape.
+    // ONNX GQA uses BNSD layout: [batch, kv_num_heads, total_seq, head_dim]
+    auto presentKeyType = cast<MemRefType>(op.getPresentKey().getType());
+    auto pkShape = presentKeyType.getShape();
+    int64_t seqLenKV = (pkShape.size() == 4) ? pkShape[2] : pkShape[1];
+
+    Value batchSizeVal = createI64Const(batchSize);
+    Value seqLenQVal = createI64Const(seqLenQ);
+    Value seqLenKVVal = createI64Const(seqLenKV);
+    Value headDimVal = createI64Const(headDim);
+    Value elemSizeVal = createI64Const(elementSizeBytes);
+
+    SmallVector<Type, 24> paramTypes = {
+        ptrType, // state
+        ptrType, // query
+        ptrType, // key
+        ptrType, // value
+        ptrType, // past_key
+        ptrType, // past_value
+        ptrType, // seqlens_k
+        ptrType, // total_seq_len
+        ptrType, // cos_cache
+        ptrType, // sin_cache
+        ptrType, // output
+        ptrType, // present_key
+        ptrType, // present_value
+        i64Type, // num_heads
+        i64Type, // kv_num_heads
+        f32Type, // scale
+        f32Type, // softcap
+        i64Type, // do_rotary
+        i64Type, // rotary_interleaved
+        i64Type, // batch_size
+        i64Type, // seq_len_q
+        i64Type, // seq_len_kv
+        i64Type, // head_dim
+        i64Type  // element_size_bytes
+    };
+
+    static constexpr const char *kWrapGQA = "wrap_group_query_attention";
     FailureOr<LLVM::LLVMFuncOp> funcOp =
-        LLVM::lookupOrCreateFn(rewriter, module, kHipGqa, paramTypes, voidType);
+        LLVM::lookupOrCreateFn(rewriter, module, kWrapGQA, paramTypes, i32Type);
     if (failed(funcOp))
       return failure();
 
-    SmallVector<Value> args = {
-        adaptor.getCtx(),
-        extractMemRefPtr(adaptor.getQ(), rewriter, loc),
-        extractMemRefPtr(adaptor.getK(), rewriter, loc),
-        extractMemRefPtr(adaptor.getV(), rewriter, loc),
-        extractMemRefPtr(adaptor.getKvCache(), rewriter, loc),
-        extractMemRefPtr(adaptor.getOutput(), rewriter, loc),
-        adaptor.getLayer(),
-        adaptor.getStartPos(),
-        adaptor.getSeqLen()};
+    SmallVector<Value, 24> args = {statePtr,
+                                   queryPtr,
+                                   keyPtr,
+                                   valuePtr,
+                                   pastKeyPtr,
+                                   pastValuePtr,
+                                   seqlensKPtr,
+                                   totalSeqLenPtr,
+                                   cosCachePtr,
+                                   sinCachePtr,
+                                   outputPtr,
+                                   presentKeyPtr,
+                                   presentValuePtr,
+                                   numHeads,
+                                   kvNumHeads,
+                                   scale,
+                                   softcap,
+                                   doRotary,
+                                   rotaryInterleaved,
+                                   batchSizeVal,
+                                   seqLenQVal,
+                                   seqLenKVVal,
+                                   headDimVal,
+                                   elemSizeVal};
 
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
+
     rewriter.eraseOp(op);
     return success();
   }

--- a/lib/Conversion/HipToLLVM/HipToLLVM.cpp
+++ b/lib/Conversion/HipToLLVM/HipToLLVM.cpp
@@ -41,7 +41,7 @@ static constexpr const char *kHipGetPoolBase = "hipdnn_ep_get_pool_base";
 
 static constexpr const char *kMiopenConvolutionForward =
     "wrap_miopenConvolutionForward";
-static constexpr const char *kHipblasltMatmul = "hip_hipblaslt_matmul";
+static constexpr const char *kWrapHipblasltMatmul = "wrap_hipblasLtMatmul";
 static constexpr const char *kWrapMiopenT5LayerNormForward =
     "wrap_miopenT5LayerNormForward";
 static constexpr const char *kWrapMiopenAddT5LayerNormForward =
@@ -186,24 +186,15 @@ struct ConvOpLowering : public ConvertOpToLLVMPattern<ConvOp> {
     };
 
     // Extract memref pointers (aligned pointers from descriptors)
-    auto getAlignedPtr = [&](Value memrefDesc) -> Value {
-      Value ptr = MemRefDescriptor(memrefDesc).alignedPtr(rewriter, loc);
-      // Cast to void* (address space 0) if needed
-      if (cast<LLVM::LLVMPointerType>(ptr.getType()).getAddressSpace() != 0) {
-        ptr = LLVM::AddrSpaceCastOp::create(rewriter, loc, ptrType, ptr);
-      }
-      return ptr;
-    };
-
     Value statePtr = adaptor.getCtx(); // RuntimeState* (opaque)
-    Value inputPtr = getAlignedPtr(adaptor.getInput());
-    Value weightsPtr = getAlignedPtr(adaptor.getWeights());
-    Value outputPtr = getAlignedPtr(adaptor.getOutput());
+    Value inputPtr = extractMemRefPtr(adaptor.getInput(), rewriter, loc);
+    Value weightsPtr = extractMemRefPtr(adaptor.getWeights(), rewriter, loc);
+    Value outputPtr = extractMemRefPtr(adaptor.getOutput(), rewriter, loc);
 
     // Handle optional bias
     Value biasPtr;
     if (adaptor.getBias()) {
-      biasPtr = getAlignedPtr(adaptor.getBias());
+      biasPtr = extractMemRefPtr(adaptor.getBias(), rewriter, loc);
     } else {
       // Pass null pointer if no bias
       biasPtr = LLVM::ZeroOp::create(rewriter, loc, ptrType);
@@ -487,55 +478,88 @@ using HipblasltGraphOpLowering = GraphRegionOpLowering<HipblasltGraphOp>;
 // hip.hipblaslt.matmul(handle) ins(A, B) outs(C)
 //   -> hip_hipblaslt_matmul(handle, A, B, C, rankA, rankB, batch, M, K, N)
 // Rank-generic: batch from A if 3D, B broadcast if rankB < rankA.
-struct HipblasltMatmulOpLowering
-    : public ConvertOpToLLVMPattern<HipblasltMatmulOp> {
+struct MatmulOpLowering : public ConvertOpToLLVMPattern<MatmulOp> {
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
-  matchAndRewrite(HipblasltMatmulOp op, OpAdaptor adaptor,
+  matchAndRewrite(MatmulOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op.getLoc();
     ModuleOp module = op->getParentOfType<ModuleOp>();
-    Type voidType = getVoidType();
     Type ptrType = getPtrType();
-    Type indexType = getIndexType();
+    Type i32Type = rewriter.getI32Type();
+    Type i64Type = rewriter.getI64Type();
 
-    // (handle, A, B, C, rankA, rankB, batch, M, K, N)
-    SmallVector<Type> paramTypes = {ptrType,   ptrType,   ptrType,   ptrType,
-                                    indexType, indexType, indexType, indexType,
-                                    indexType, indexType};
+    // Helper: create i64 constant
+    auto createI64Const = [&](int64_t value) -> Value {
+      return LLVM::ConstantOp::create(rewriter, loc, i64Type,
+                                      rewriter.getI64IntegerAttr(value));
+    };
+
+    // Extract pointers
+    Value statePtr = adaptor.getCtx();
+    Value APtr = extractMemRefPtr(adaptor.getA(), rewriter, loc);
+    Value BPtr = extractMemRefPtr(adaptor.getB(), rewriter, loc);
+    Value outputPtr = extractMemRefPtr(adaptor.getOutput(), rewriter, loc);
+
+    // Get memref types and shapes
+    auto AType = cast<MemRefType>(op.getA().getType());
+    auto BType = cast<MemRefType>(op.getB().getType());
+    int64_t ARank = AType.getRank();
+    int64_t BRank = BType.getRank();
+
+    // === DYNAMIC SHAPE SUPPORT ===
+    // For dynamic shapes, we compute dimensions at runtime
+    MemRefDescriptor ADesc(adaptor.getA());
+    MemRefDescriptor BDesc(adaptor.getB());
+
+    // Compute M, K, N from runtime dimensions
+    // A: [..., M, K], B: [..., K, N] or B: [K, N]
+    Value M =
+        (ARank >= 2) ? ADesc.size(rewriter, loc, ARank - 2) : createI64Const(1);
+    Value K = ADesc.size(rewriter, loc, ARank - 1);
+    Value N = BDesc.size(rewriter, loc, BRank - 1);
+
+    // Compute batch count from leading dimensions of A
+    Value batchCount;
+    if (ARank == 2) {
+      batchCount = createI64Const(1);
+    } else {
+      batchCount = ADesc.size(rewriter, loc, 0);
+      for (int64_t i = 1; i < ARank - 2; ++i) {
+        Value dim = ADesc.size(rewriter, loc, i);
+        batchCount = LLVM::MulOp::create(rewriter, loc, batchCount, dim);
+      }
+    }
+
+    // Compute element size in bytes
+    unsigned elemBits = AType.getElementType().getIntOrFloatBitWidth();
+    Value elemSize = createI64Const(elemBits / 8);
+
+    // Runtime signature:
+    // int wrap_hipblasLtMatmul(RuntimeState* state,
+    //                          const void* A, const void* B, void* output,
+    //                          int64_t M, int64_t N, int64_t K,
+    //                          int64_t batch_count, int64_t elem_size)
+    SmallVector<Type, 9> paramTypes = {
+        ptrType, // state
+        ptrType, // A
+        ptrType, // B
+        ptrType, // output
+        i64Type, // M
+        i64Type, // N
+        i64Type, // K
+        i64Type, // batch_count
+        i64Type  // elem_size
+    };
+
     FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
-        rewriter, module, kHipblasltMatmul, paramTypes, voidType);
+        rewriter, module, kWrapHipblasltMatmul, paramTypes, i32Type);
     if (failed(funcOp))
       return failure();
 
-    int rankA = cast<MemRefType>(op.getA().getType()).getRank();
-    int rankB = cast<MemRefType>(op.getB().getType()).getRank();
-    MemRefDescriptor aDesc(adaptor.getA());
-    MemRefDescriptor bDesc(adaptor.getB());
-
-    Value one = LLVM::ConstantOp::create(rewriter, loc, indexType,
-                                         rewriter.getIndexAttr(1));
-    Value rankAVal = LLVM::ConstantOp::create(rewriter, loc, indexType,
-                                              rewriter.getIndexAttr(rankA));
-    Value rankBVal = LLVM::ConstantOp::create(rewriter, loc, indexType,
-                                              rewriter.getIndexAttr(rankB));
-
-    Value batch = (rankA == 3) ? aDesc.size(rewriter, loc, 0) : one;
-    Value M = aDesc.size(rewriter, loc, rankA - 2);
-    Value K = aDesc.size(rewriter, loc, rankA - 1);
-    Value N = bDesc.size(rewriter, loc, rankB - 1);
-
-    SmallVector<Value> args = {adaptor.getCtx(),
-                               extractMemRefPtr(adaptor.getA(), rewriter, loc),
-                               extractMemRefPtr(adaptor.getB(), rewriter, loc),
-                               extractMemRefPtr(adaptor.getC(), rewriter, loc),
-                               rankAVal,
-                               rankBVal,
-                               batch,
-                               M,
-                               K,
-                               N};
+    SmallVector<Value, 9> args = {statePtr, APtr, BPtr,       outputPtr, M,
+                                  N,        K,    batchCount, elemSize};
 
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
     rewriter.eraseOp(op);
@@ -1005,17 +1029,10 @@ struct SigmoidOpLowering : public ConvertOpToLLVMPattern<SigmoidOp> {
     };
 
     // Extract pointers using alignedPtr (respects memref.view offsets)
-    auto getAlignedPtr = [&](Value memrefDesc) -> Value {
-      MemRefDescriptor desc(memrefDesc);
-      Value ptr = desc.alignedPtr(rewriter, loc);
-      if (cast<LLVM::LLVMPointerType>(ptr.getType()).getAddressSpace() != 0)
-        ptr = LLVM::AddrSpaceCastOp::create(rewriter, loc, ptrType, ptr);
-      return ptr;
-    };
 
     Value statePtr = adaptor.getCtx();
-    Value inputPtr = getAlignedPtr(adaptor.getInput());
-    Value outputPtr = getAlignedPtr(adaptor.getOutput());
+    Value inputPtr = extractMemRefPtr(adaptor.getInput(), rewriter, loc);
+    Value outputPtr = extractMemRefPtr(adaptor.getOutput(), rewriter, loc);
 
     auto outputType = cast<MemRefType>(op.getOutput().getType());
 
@@ -1103,19 +1120,10 @@ struct MulOpLowering : public ConvertOpToLLVMPattern<MulOp> {
       return num;
     };
 
-    auto getAlignedPtr = [&](Value memrefDesc) -> Value {
-      MemRefDescriptor desc(memrefDesc);
-      Value ptr = desc.alignedPtr(rewriter, loc);
-      if (cast<LLVM::LLVMPointerType>(ptr.getType()).getAddressSpace() != 0) {
-        ptr = LLVM::AddrSpaceCastOp::create(rewriter, loc, ptrType, ptr);
-      }
-      return ptr;
-    };
-
     Value statePtr = adaptor.getCtx();
-    Value lhsPtr = getAlignedPtr(adaptor.getLhs());
-    Value rhsPtr = getAlignedPtr(adaptor.getRhs());
-    Value outputPtr = getAlignedPtr(adaptor.getOutput());
+    Value lhsPtr = extractMemRefPtr(adaptor.getLhs(), rewriter, loc);
+    Value rhsPtr = extractMemRefPtr(adaptor.getRhs(), rewriter, loc);
+    Value outputPtr = extractMemRefPtr(adaptor.getOutput(), rewriter, loc);
 
     auto outputType = cast<MemRefType>(op.getOutput().getType());
 
@@ -1191,19 +1199,10 @@ struct SubOpLowering : public ConvertOpToLLVMPattern<SubOp> {
       return num;
     };
 
-    auto getAlignedPtr = [&](Value memrefDesc) -> Value {
-      MemRefDescriptor desc(memrefDesc);
-      Value ptr = desc.alignedPtr(rewriter, loc);
-      if (cast<LLVM::LLVMPointerType>(ptr.getType()).getAddressSpace() != 0) {
-        ptr = LLVM::AddrSpaceCastOp::create(rewriter, loc, ptrType, ptr);
-      }
-      return ptr;
-    };
-
     Value statePtr = adaptor.getCtx();
-    Value lhsPtr = getAlignedPtr(adaptor.getLhs());
-    Value rhsPtr = getAlignedPtr(adaptor.getRhs());
-    Value outputPtr = getAlignedPtr(adaptor.getOutput());
+    Value lhsPtr = extractMemRefPtr(adaptor.getLhs(), rewriter, loc);
+    Value rhsPtr = extractMemRefPtr(adaptor.getRhs(), rewriter, loc);
+    Value outputPtr = extractMemRefPtr(adaptor.getOutput(), rewriter, loc);
 
     auto outputType = cast<MemRefType>(op.getOutput().getType());
 
@@ -1255,17 +1254,10 @@ struct CastOpLowering : public ConvertOpToLLVMPattern<CastOp> {
     };
 
     // Extract pointers using alignedPtr (respects memref.view offsets)
-    auto getAlignedPtr = [&](Value memrefDesc) -> Value {
-      MemRefDescriptor desc(memrefDesc);
-      Value ptr = desc.alignedPtr(rewriter, loc);
-      if (cast<LLVM::LLVMPointerType>(ptr.getType()).getAddressSpace() != 0)
-        ptr = LLVM::AddrSpaceCastOp::create(rewriter, loc, ptrType, ptr);
-      return ptr;
-    };
 
     Value statePtr = adaptor.getCtx();
-    Value inputPtr = getAlignedPtr(adaptor.getInput());
-    Value outputPtr = getAlignedPtr(adaptor.getOutput());
+    Value inputPtr = extractMemRefPtr(adaptor.getInput(), rewriter, loc);
+    Value outputPtr = extractMemRefPtr(adaptor.getOutput(), rewriter, loc);
 
     auto inputType = cast<MemRefType>(op.getInput().getType());
     auto outputType = cast<MemRefType>(op.getOutput().getType());
@@ -1337,18 +1329,11 @@ struct ReduceSumOpLowering : public ConvertOpToLLVMPattern<ReduceSumOp> {
     };
 
     // Extract pointers using alignedPtr
-    auto getAlignedPtr = [&](Value memrefDesc) -> Value {
-      MemRefDescriptor desc(memrefDesc);
-      Value ptr = desc.alignedPtr(rewriter, loc);
-      if (cast<LLVM::LLVMPointerType>(ptr.getType()).getAddressSpace() != 0)
-        ptr = LLVM::AddrSpaceCastOp::create(rewriter, loc, ptrType, ptr);
-      return ptr;
-    };
 
     Value statePtr = adaptor.getCtx();
-    Value dataPtr = getAlignedPtr(adaptor.getData());
-    Value axesPtr = getAlignedPtr(adaptor.getAxes());
-    Value outputPtr = getAlignedPtr(adaptor.getOutput());
+    Value dataPtr = extractMemRefPtr(adaptor.getData(), rewriter, loc);
+    Value axesPtr = extractMemRefPtr(adaptor.getAxes(), rewriter, loc);
+    Value outputPtr = extractMemRefPtr(adaptor.getOutput(), rewriter, loc);
 
     auto dataType = cast<MemRefType>(op.getData().getType());
     auto outputType = cast<MemRefType>(op.getOutput().getType());
@@ -1548,7 +1533,7 @@ void ConvertHipToLLVMPass::runOnOperation() {
   patterns
       .add<AllocOpLowering, FreeOpLowering, MiopenGraphOpLowering,
            GetPoolOpLowering, HipblasltGraphOpLowering, ConvOpLowering,
-           HipblasltMatmulOpLowering, RmsNormOpLowering, SkipRmsNormOpLowering,
+           MatmulOpLowering, RmsNormOpLowering, SkipRmsNormOpLowering,
            RopeOpLowering, MiopenSoftmaxOpLowering, TransposeOpLowering,
            GatherOpLowering, SiluOpLowering, SigmoidOpLowering, MulOpLowering,
            SubOpLowering, CastOpLowering, ReduceSumOpLowering, GqaOpLowering>(

--- a/lib/Conversion/HipToLLVM/HipToLLVM.cpp
+++ b/lib/Conversion/HipToLLVM/HipToLLVM.cpp
@@ -50,7 +50,7 @@ static constexpr const char *kMiopenAdd = "hip_miopen_add";
 static constexpr const char *kMiopenMul = "hip_miopen_mul";
 static constexpr const char *kMiopenSoftmax = "hip_miopen_softmax";
 static constexpr const char *kHipTranspose = "hip_transpose";
-static constexpr const char *kHipGather = "hip_gather";
+static constexpr const char *kWrapGather = "wrap_gather";
 static constexpr const char *kHipSilu = "hip_silu";
 static constexpr const char *kWrapMiopenActivationForward =
     "wrap_miopenActivationForward"; // hip.sigmoid
@@ -958,19 +958,54 @@ struct GatherOpLowering : public ConvertOpToLLVMPattern<GatherOp> {
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op.getLoc();
     ModuleOp module = op->getParentOfType<ModuleOp>();
-    Type voidType = getVoidType();
     Type ptrType = getPtrType();
+    Type i32Type = rewriter.getI32Type();
+    Type i64Type = rewriter.getI64Type();
 
-    SmallVector<Type> paramTypes(4, ptrType);
+    Value statePtr = adaptor.getCtx();
+    Value dataPtr = extractMemRefPtr(adaptor.getData(), rewriter, loc);
+    Value indicesPtr = extractMemRefPtr(adaptor.getIndices(), rewriter, loc);
+    Value outputPtr = extractMemRefPtr(adaptor.getOutput(), rewriter, loc);
+
+    // Compute data_num_elements
+    auto dataType = cast<MemRefType>(op.getData().getType());
+    Value dataNumElementsVal =
+        computeNumElements(dataType, adaptor.getData(), rewriter, loc);
+
+    // Compute output_num_elements
+    auto outputType = cast<MemRefType>(op.getOutput().getType());
+    Value outputNumElementsVal =
+        computeNumElements(outputType, adaptor.getOutput(), rewriter, loc);
+
+    // element_size_bytes
+    unsigned elementSizeBytes =
+        dataType.getElementType().getIntOrFloatBitWidth() / 8;
+    Value elemSizeVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(elementSizeBytes));
+
+    // axis attribute
+    Value axisVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getAxis()));
+
+    // int wrap_gather(RuntimeState* state, void* data, void* indices,
+    //                 void* output, int64_t axis, int64_t data_num_elements,
+    //                 int64_t output_num_elements, int64_t element_size_bytes)
+    SmallVector<Type, 8> paramTypes = {ptrType, ptrType, ptrType, ptrType,
+                                       i64Type, i64Type, i64Type, i64Type};
+
     FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
-        rewriter, module, kHipGather, paramTypes, voidType);
+        rewriter, module, kWrapGather, paramTypes, i32Type);
     if (failed(funcOp))
       return failure();
 
-    SmallVector<Value> args = {
-        adaptor.getCtx(), extractMemRefPtr(adaptor.getIndices(), rewriter, loc),
-        extractMemRefPtr(adaptor.getTable(), rewriter, loc),
-        extractMemRefPtr(adaptor.getOutput(), rewriter, loc)};
+    SmallVector<Value> args = {statePtr,
+                               dataPtr,
+                               indicesPtr,
+                               outputPtr,
+                               axisVal,
+                               dataNumElementsVal,
+                               outputNumElementsVal,
+                               elemSizeVal};
 
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
     rewriter.eraseOp(op);
@@ -1414,12 +1449,12 @@ struct GqaOpLowering : public ConvertOpToLLVMPattern<GqaOp> {
     Type f32Type = rewriter.getF32Type();
 
     auto createI64Const = [&](int64_t value) -> Value {
-      return rewriter.create<LLVM::ConstantOp>(
-          loc, i64Type, rewriter.getI64IntegerAttr(value));
+      return LLVM::ConstantOp::create(rewriter, loc, i64Type,
+                                      rewriter.getI64IntegerAttr(value));
     };
     auto createF32Const = [&](float value) -> Value {
-      return rewriter.create<LLVM::ConstantOp>(loc, f32Type,
-                                               rewriter.getF32FloatAttr(value));
+      return LLVM::ConstantOp::create(rewriter, loc, f32Type,
+                                      rewriter.getF32FloatAttr(value));
     };
 
     Value statePtr = adaptor.getCtx();
@@ -1439,7 +1474,7 @@ struct GqaOpLowering : public ConvertOpToLLVMPattern<GqaOp> {
         extractMemRefPtr(adaptor.getPresentValue(), rewriter, loc);
 
     // cos/sin cache: NULL pointers for now (RoPE done via separate op)
-    Value nullPtr = rewriter.create<LLVM::ZeroOp>(loc, ptrType);
+    Value nullPtr = LLVM::ZeroOp::create(rewriter, loc, ptrType);
     Value cosCachePtr = nullPtr;
     Value sinCachePtr = nullPtr;
 

--- a/lib/Conversion/HipToLLVM/HipToLLVM.cpp
+++ b/lib/Conversion/HipToLLVM/HipToLLVM.cpp
@@ -55,6 +55,7 @@ static constexpr const char *kHipSilu = "hip_silu";
 static constexpr const char *kWrapMiopenActivationForward =
     "wrap_miopenActivationForward"; // hip.sigmoid
 static constexpr const char *kWrapElementwiseSub = "wrap_elementwise_sub";
+static constexpr const char *kWrapRotaryEmbedding = "wrap_rotary_embedding";
 static constexpr const char *kWrapMiopenOpTensor =
     "wrap_miopenOpTensor"; // hip.mul
 static constexpr const char *kWrapMiopenCast = "wrap_miopenCast";
@@ -745,7 +746,7 @@ struct RopeOpLowering : public ConvertOpToLLVMPattern<RopeOp> {
                                         i64Type, i64Type, i64Type, i64Type};
 
     FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
-        rewriter, module, "wrap_rotary_embedding", paramTypes, i32Type);
+        rewriter, module, kWrapRotaryEmbedding, paramTypes, i32Type);
 
     if (failed(funcOp))
       return failure();

--- a/lib/Conversion/HipToLLVM/HipToLLVM.cpp
+++ b/lib/Conversion/HipToLLVM/HipToLLVM.cpp
@@ -60,7 +60,7 @@ static constexpr const char *kWrapMiopenOpTensor =
     "wrap_miopenOpTensor"; // hip.mul
 static constexpr const char *kWrapMiopenCast = "wrap_miopenCast";
 static constexpr const char *kWrapReduceSum = "wrap_reduce_sum";
-static constexpr const char *kHipGqa = "hip_gqa";
+static constexpr const char *kWrapGQA = "wrap_group_query_attention";
 
 // Maps MLIR element type to runtime data type enum (HIPDNN_EP_DATATYPE_*).
 // Values must match the #defines in hipdnn_ep_runtime.h.
@@ -1535,7 +1535,6 @@ struct GqaOpLowering : public ConvertOpToLLVMPattern<GqaOp> {
         i64Type  // element_size_bytes
     };
 
-    static constexpr const char *kWrapGQA = "wrap_group_query_attention";
     FailureOr<LLVM::LLVMFuncOp> funcOp =
         LLVM::lookupOrCreateFn(rewriter, module, kWrapGQA, paramTypes, i32Type);
     if (failed(funcOp))

--- a/lib/Conversion/HipToLLVM/HipToLLVM.cpp
+++ b/lib/Conversion/HipToLLVM/HipToLLVM.cpp
@@ -46,7 +46,6 @@ static constexpr const char *kWrapMiopenT5LayerNormForward =
     "wrap_miopenT5LayerNormForward";
 static constexpr const char *kWrapMiopenAddT5LayerNormForward =
     "wrap_miopenAddT5LayerNormForward";
-static constexpr const char *kMiopenRope = "hip_miopen_rope";
 static constexpr const char *kMiopenAdd = "hip_miopen_add";
 static constexpr const char *kMiopenMul = "hip_miopen_mul";
 static constexpr const char *kMiopenSoftmax = "hip_miopen_softmax";
@@ -689,32 +688,72 @@ struct SkipRmsNormOpLowering : public ConvertOpToLLVMPattern<SkipRmsNormOp> {
 };
 
 // hip.miopen.rope(handle, q, k, cos_cache, sin_cache, start_pos)
-struct MiopenRopeOpLowering : public ConvertOpToLLVMPattern<MiopenRopeOp> {
+struct RopeOpLowering : public ConvertOpToLLVMPattern<RopeOp> {
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
-  matchAndRewrite(MiopenRopeOp op, OpAdaptor adaptor,
+  matchAndRewrite(RopeOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op.getLoc();
     ModuleOp module = op->getParentOfType<ModuleOp>();
-    Type voidType = getVoidType();
     Type ptrType = getPtrType();
-    Type indexType = getIndexType();
+    Type i64Type = rewriter.getI64Type();
+    Type i32Type = rewriter.getI32Type();
 
-    SmallVector<Type> paramTypes = {ptrType, ptrType, ptrType,
-                                    ptrType, ptrType, indexType};
+    // Extract pointers
+    Value statePtr = adaptor.getCtx();
+    Value inputPtr = extractMemRefPtr(adaptor.getInput(), rewriter, loc);
+    Value posIdsPtr = extractMemRefPtr(adaptor.getPositionIds(), rewriter, loc);
+    Value cosCachePtr = extractMemRefPtr(adaptor.getCosCache(), rewriter, loc);
+    Value sinCachePtr = extractMemRefPtr(adaptor.getSinCache(), rewriter, loc);
+    Value outputPtr = extractMemRefPtr(adaptor.getOutput(), rewriter, loc);
+
+    // Extract attributes as constants
+    Value interleaved = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type,
+        rewriter.getI64IntegerAttr(op.getInterleaved()));
+    Value numHeads = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getNumHeads()));
+    Value rotaryDim = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type,
+        rewriter.getI64IntegerAttr(op.getRotaryEmbeddingDim()));
+
+    // Compute num_elements (supports dynamic shapes)
+    auto inputType = cast<MemRefType>(op.getInput().getType());
+    Value inputNumElements =
+        computeNumElements(inputType, adaptor.getInput(), rewriter, loc);
+
+    auto cosCacheType = cast<MemRefType>(op.getCosCache().getType());
+    Value cosCacheNumElements =
+        computeNumElements(cosCacheType, adaptor.getCosCache(), rewriter, loc);
+
+    // Compute element_size_bytes
+    unsigned elementSizeBits =
+        inputType.getElementType().getIntOrFloatBitWidth();
+    Value elemSizeBytes = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type,
+        rewriter.getI64IntegerAttr(elementSizeBits / 8));
+
+    // Function signature: wrap_rotary_embedding(
+    //     RuntimeState* state, void* input, void* position_ids,
+    //     void* cos_cache, void* sin_cache, void* output,
+    //     int64_t interleaved, int64_t num_heads, int64_t rotary_dim,
+    //     int64_t input_num_elements, int64_t cos_cache_num_elements,
+    //     int64_t element_size_bytes)
+    SmallVector<Type, 12> paramTypes = {ptrType, ptrType, ptrType, ptrType,
+                                        ptrType, ptrType, i64Type, i64Type,
+                                        i64Type, i64Type, i64Type, i64Type};
+
     FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
-        rewriter, module, kMiopenRope, paramTypes, voidType);
+        rewriter, module, "wrap_rotary_embedding", paramTypes, i32Type);
+
     if (failed(funcOp))
       return failure();
 
-    SmallVector<Value> args = {
-        adaptor.getCtx(),
-        extractMemRefPtr(adaptor.getQ(), rewriter, loc),
-        extractMemRefPtr(adaptor.getK(), rewriter, loc),
-        extractMemRefPtr(adaptor.getCosCache(), rewriter, loc),
-        extractMemRefPtr(adaptor.getSinCache(), rewriter, loc),
-        adaptor.getStartPos()};
+    SmallVector<Value, 12> args = {
+        statePtr,    inputPtr,         posIdsPtr,           cosCachePtr,
+        sinCachePtr, outputPtr,        interleaved,         numHeads,
+        rotaryDim,   inputNumElements, cosCacheNumElements, elemSizeBytes};
 
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
     rewriter.eraseOp(op);
@@ -1509,7 +1548,7 @@ void ConvertHipToLLVMPass::runOnOperation() {
       .add<AllocOpLowering, FreeOpLowering, MiopenGraphOpLowering,
            GetPoolOpLowering, HipblasltGraphOpLowering, ConvOpLowering,
            HipblasltMatmulOpLowering, RmsNormOpLowering, SkipRmsNormOpLowering,
-           MiopenRopeOpLowering, MiopenSoftmaxOpLowering, TransposeOpLowering,
+           RopeOpLowering, MiopenSoftmaxOpLowering, TransposeOpLowering,
            GatherOpLowering, SiluOpLowering, SigmoidOpLowering, MulOpLowering,
            SubOpLowering, CastOpLowering, ReduceSumOpLowering, GqaOpLowering>(
           typeConverter);

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -921,6 +921,118 @@ mlir::LogicalResult SkipSimplifiedLayerNormToHip::matchAndRewrite(
   return mlir::success();
 }
 
+/// onnx.Custom(RotaryEmbedding) -> hip.rope
+struct RotaryEmbeddingToHip : public mlir::RewritePattern {
+  RotaryEmbeddingToHip(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.Custom", /*benefit=*/1, ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override;
+};
+
+mlir::LogicalResult
+RotaryEmbeddingToHip::matchAndRewrite(mlir::Operation *op,
+                                      mlir::PatternRewriter &rewriter) const {
+  // Check if this is RotaryEmbedding
+  auto funcNameAttr = op->getAttrOfType<mlir::StringAttr>("function_name");
+  if (!funcNameAttr || funcNameAttr.getValue() != "RotaryEmbedding")
+    return rewriter.notifyMatchFailure(op, "not a RotaryEmbedding operation");
+
+  // Check domain is "com.microsoft"
+  auto domainAttr = op->getAttrOfType<mlir::StringAttr>("domain_name");
+  if (!domainAttr || domainAttr.getValue() != "com.microsoft")
+    return rewriter.notifyMatchFailure(
+        op, "domain must be com.microsoft for RotaryEmbedding");
+
+  auto ctxOrFailure = getContextArg(op, rewriter);
+  if (mlir::failed(ctxOrFailure))
+    return rewriter.notifyMatchFailure(op, "missing context argument");
+  mlir::Value context = *ctxOrFailure;
+
+  mlir::Location loc = op->getLoc();
+
+  // Check operands (should be 4: input, position_ids, cos_cache, sin_cache)
+  if (op->getNumOperands() != 4)
+    return rewriter.notifyMatchFailure(
+        op, "expected 4 operands for RotaryEmbedding");
+
+  mlir::Value input = op->getOperand(0);
+  mlir::Value positionIds = op->getOperand(1);
+  mlir::Value cosCache = op->getOperand(2);
+  mlir::Value sinCache = op->getOperand(3);
+
+  // Extract attributes
+  auto interleavedAttr = op->getAttrOfType<mlir::IntegerAttr>("interleaved");
+  if (!interleavedAttr)
+    return rewriter.notifyMatchFailure(op, "missing interleaved attribute");
+
+  auto numHeadsAttr = op->getAttrOfType<mlir::IntegerAttr>("num_heads");
+  if (!numHeadsAttr)
+    return rewriter.notifyMatchFailure(op, "missing num_heads attribute");
+
+  auto rotaryDimAttr =
+      op->getAttrOfType<mlir::IntegerAttr>("rotary_embedding_dim");
+  if (!rotaryDimAttr)
+    return rewriter.notifyMatchFailure(
+        op, "missing rotary_embedding_dim attribute");
+
+  int64_t numHeadsVal = numHeadsAttr.getSInt();
+  int64_t rotaryDimVal = rotaryDimAttr.getSInt();
+
+  // ONNX com.microsoft.RotaryEmbedding: 0 means "infer from tensor shapes"
+  //   cos_cache: [max_seq, rotary_dim/2] → rotary_dim = last_dim * 2
+  //   input:     [batch, seq, hidden]     → num_heads = hidden / rotary_dim
+  if (rotaryDimVal == 0) {
+    auto cosCacheType =
+        mlir::dyn_cast<mlir::RankedTensorType>(cosCache.getType());
+    if (cosCacheType && cosCacheType.hasStaticShape() &&
+        cosCacheType.getRank() >= 2) {
+      rotaryDimVal = cosCacheType.getShape().back() * 2;
+    } else {
+      return rewriter.notifyMatchFailure(
+          op, "Cannot infer rotary_embedding_dim: "
+              "cos_cache must have static shape with rank >= 2");
+    }
+  }
+
+  if (numHeadsVal == 0 && rotaryDimVal > 0) {
+    auto inputType = mlir::dyn_cast<mlir::RankedTensorType>(input.getType());
+    if (inputType && inputType.hasStaticShape() && inputType.getRank() >= 1) {
+      int64_t hidden = inputType.getShape().back();
+      numHeadsVal = hidden / rotaryDimVal;
+    } else {
+      return rewriter.notifyMatchFailure(op, "Cannot infer num_heads: "
+                                             "input must have static shape");
+    }
+  }
+
+  // Convert to i64 attributes (using inferred or original values)
+  auto interleavedI64Attr =
+      rewriter.getI64IntegerAttr(interleavedAttr.getSInt());
+  auto numHeadsI64Attr = rewriter.getI64IntegerAttr(numHeadsVal);
+  auto rotaryDimI64Attr = rewriter.getI64IntegerAttr(rotaryDimVal);
+
+  // Should have 1 result: output
+  if (op->getNumResults() != 1)
+    return rewriter.notifyMatchFailure(op,
+                                       "expected 1 result for RotaryEmbedding");
+
+  auto resultType =
+      mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
+
+  // Create init tensor
+  mlir::Value init = createEmptyTensor(rewriter, loc, resultType, input);
+
+  // Create hip.rope operation
+  auto hipOp = mlir::hip::RopeOp::create(
+      rewriter, loc, resultType, context, input, positionIds, cosCache,
+      sinCache, init, interleavedI64Attr, numHeadsI64Attr, rotaryDimI64Attr);
+
+  rewriter.replaceOp(op, hipOp->getResult(0));
+  return mlir::success();
+}
+
 //===----------------------------------------------------------------------===//
 // convertComputeOps implementation
 //===----------------------------------------------------------------------===//
@@ -939,6 +1051,7 @@ static mlir::LogicalResult convertComputeOps(mlir::func::FuncOp funcOp,
   patterns.add<ConvToHip>(ctx);
   patterns.add<SimplifiedLayerNormToHip>(ctx);
   patterns.add<SkipSimplifiedLayerNormToHip>(ctx);
+  patterns.add<RotaryEmbeddingToHip>(ctx);
 
   mlir::GreedyRewriteConfig config;
   config.setStrictness(mlir::GreedyRewriteStrictness::ExistingOps);

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -1165,8 +1165,7 @@ struct GatherToHip : public mlir::RewritePattern {
     mlir::Value indices = op->getOperand(1);
 
     // Get axis attribute from ONNX Gather operation
-    int64_t axis =
-        op->getAttrOfType<mlir::IntegerAttr>("axis").getSInt();
+    int64_t axis = op->getAttrOfType<mlir::IntegerAttr>("axis").getSInt();
     auto axisAttr = rewriter.getI64IntegerAttr(axis);
 
     // Get result type

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -1164,30 +1164,25 @@ struct GatherToHip : public mlir::RewritePattern {
     mlir::Value data = op->getOperand(0);
     mlir::Value indices = op->getOperand(1);
 
-    // Get axis attribute (default = 0)
-    int64_t axis = 0;
-    if (auto attr = op->getAttrOfType<mlir::IntegerAttr>("axis"))
-      axis = attr.getSInt();
+    // Get axis attribute from ONNX Gather operation
+    int64_t axis =
+        op->getAttrOfType<mlir::IntegerAttr>("axis").getSInt();
+    auto axisAttr = rewriter.getI64IntegerAttr(axis);
 
     // Get result type
     auto resultType =
         mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
+    auto dataType = mlir::cast<mlir::RankedTensorType>(data.getType());
+    auto indicesType = mlir::cast<mlir::RankedTensorType>(indices.getType());
+
+    // Normalize negative axis for dimension calculations only
+    int64_t normalizedAxis = axis < 0 ? axis + dataType.getRank() : axis;
 
     // Create output tensor with dynamic shape support
     // Output shape: [data[0:axis], indices.shape, data[axis+1:]]
     llvm::SmallVector<mlir::Value> dynSizes;
-    auto dataType = mlir::cast<mlir::RankedTensorType>(data.getType());
-    auto indicesType = mlir::cast<mlir::RankedTensorType>(indices.getType());
-
-    // Normalize negative axis for dimension calculations (but preserve original
-    // for attribute)
-    int64_t normalizedAxis = axis;
-    if (normalizedAxis < 0)
-      normalizedAxis += dataType.getRank();
-
-    auto axisAttr = rewriter.getI64IntegerAttr(axis);
-
     int64_t outDimIdx = 0;
+
     // Copy dimensions before axis from data
     for (int64_t i = 0; i < normalizedAxis; ++i) {
       if (outDimIdx < resultType.getRank() &&

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -350,8 +350,8 @@ MatMulToHip::matchAndRewrite(mlir::Operation *op,
   mlir::Value init =
       mlir::tensor::EmptyOp::create(rewriter, loc, resultType.getShape(),
                                     resultType.getElementType(), dynSizes);
-  auto hipOp = mlir::hip::HipblasltMatmulOp::create(rewriter, loc, resultType,
-                                                    context, a, b, init);
+  auto hipOp = mlir::hip::MatmulOp::create(rewriter, loc, resultType, context,
+                                           a, b, init);
   rewriter.replaceOp(op, hipOp->getResult(0));
   return mlir::success();
 }

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -1145,6 +1145,86 @@ mlir::LogicalResult GroupQueryAttentionToHip::matchAndRewrite(
 }
 
 //===----------------------------------------------------------------------===//
+// ONNX Gather → HIP Gather
+//===----------------------------------------------------------------------===//
+
+struct GatherToHip : public mlir::RewritePattern {
+  GatherToHip(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.Gather", /*benefit=*/1, ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override {
+    auto ctxOrFailure = getContextArg(op, rewriter);
+    if (mlir::failed(ctxOrFailure))
+      return rewriter.notifyMatchFailure(op, "missing context argument");
+    mlir::Value context = *ctxOrFailure;
+
+    mlir::Location loc = op->getLoc();
+    mlir::Value data = op->getOperand(0);
+    mlir::Value indices = op->getOperand(1);
+
+    // Get axis attribute (default = 0)
+    int64_t axis = 0;
+    if (auto attr = op->getAttrOfType<mlir::IntegerAttr>("axis"))
+      axis = attr.getSInt();
+
+    // Get result type
+    auto resultType =
+        mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
+
+    // Create output tensor with dynamic shape support
+    // Output shape: [data[0:axis], indices.shape, data[axis+1:]]
+    llvm::SmallVector<mlir::Value> dynSizes;
+    auto dataType = mlir::cast<mlir::RankedTensorType>(data.getType());
+    auto indicesType = mlir::cast<mlir::RankedTensorType>(indices.getType());
+
+    // Normalize negative axis for dimension calculations (but preserve original
+    // for attribute)
+    int64_t normalizedAxis = axis;
+    if (normalizedAxis < 0)
+      normalizedAxis += dataType.getRank();
+
+    auto axisAttr = rewriter.getI64IntegerAttr(axis);
+
+    int64_t outDimIdx = 0;
+    // Copy dimensions before axis from data
+    for (int64_t i = 0; i < normalizedAxis; ++i) {
+      if (outDimIdx < resultType.getRank() &&
+          resultType.isDynamicDim(outDimIdx))
+        dynSizes.push_back(mlir::tensor::DimOp::create(rewriter, loc, data, i));
+      outDimIdx++;
+    }
+    // Copy all dimensions from indices
+    for (int64_t i = 0; i < indicesType.getRank(); ++i) {
+      if (outDimIdx < resultType.getRank() &&
+          resultType.isDynamicDim(outDimIdx))
+        dynSizes.push_back(
+            mlir::tensor::DimOp::create(rewriter, loc, indices, i));
+      outDimIdx++;
+    }
+    // Copy dimensions after axis from data
+    for (int64_t i = normalizedAxis + 1; i < dataType.getRank(); ++i) {
+      if (outDimIdx < resultType.getRank() &&
+          resultType.isDynamicDim(outDimIdx))
+        dynSizes.push_back(mlir::tensor::DimOp::create(rewriter, loc, data, i));
+      outDimIdx++;
+    }
+
+    mlir::Value init =
+        mlir::tensor::EmptyOp::create(rewriter, loc, resultType.getShape(),
+                                      resultType.getElementType(), dynSizes);
+
+    // Create hip.gather operation
+    auto gatherOp = mlir::hip::GatherOp::create(
+        rewriter, loc, resultType, context, data, indices, init, axisAttr);
+
+    rewriter.replaceOp(op, gatherOp->getResult(0));
+    return mlir::success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
 // convertComputeOps implementation
 //===----------------------------------------------------------------------===//
 
@@ -1159,6 +1239,7 @@ static mlir::LogicalResult convertComputeOps(mlir::func::FuncOp funcOp,
   patterns.add<SubToHip>(ctx);
   patterns.add<CastToHip>(ctx);
   patterns.add<ReduceSumToHip>(ctx);
+  patterns.add<GatherToHip>(ctx);
   patterns.add<ConvToHip>(ctx);
   patterns.add<SimplifiedLayerNormToHip>(ctx);
   patterns.add<SkipSimplifiedLayerNormToHip>(ctx);

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -1033,6 +1033,117 @@ RotaryEmbeddingToHip::matchAndRewrite(mlir::Operation *op,
   return mlir::success();
 }
 
+/// onnx.Custom(GroupQueryAttention) -> hip.gqa
+struct GroupQueryAttentionToHip : public mlir::RewritePattern {
+  GroupQueryAttentionToHip(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.Custom", /*benefit=*/1, ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override;
+};
+
+mlir::LogicalResult GroupQueryAttentionToHip::matchAndRewrite(
+    mlir::Operation *op, mlir::PatternRewriter &rewriter) const {
+  // Check if this is GroupQueryAttention
+  auto funcNameAttr = op->getAttrOfType<mlir::StringAttr>("function_name");
+  if (!funcNameAttr || funcNameAttr.getValue() != "GroupQueryAttention")
+    return rewriter.notifyMatchFailure(op,
+                                       "not a GroupQueryAttention operation");
+
+  // Check domain is "com.microsoft"
+  auto domainAttr = op->getAttrOfType<mlir::StringAttr>("domain_name");
+  if (!domainAttr || domainAttr.getValue() != "com.microsoft")
+    return rewriter.notifyMatchFailure(
+        op, "domain must be com.microsoft for GroupQueryAttention");
+
+  auto ctxOrFailure = getContextArg(op, rewriter);
+  if (mlir::failed(ctxOrFailure))
+    return rewriter.notifyMatchFailure(op, "missing context argument");
+  mlir::Value context = *ctxOrFailure;
+
+  mlir::Location loc = op->getLoc();
+
+  // Check operands (should be 9: query, key, value, past_key, past_value,
+  // seqlens_k, total_seq_len, cos_cache, sin_cache)
+  // Last two (cos/sin cache) are optional and may be onnx.NoValue
+  if (op->getNumOperands() != 9)
+    return rewriter.notifyMatchFailure(
+        op, "expected 9 operands for GroupQueryAttention");
+
+  mlir::Value query = op->getOperand(0);
+  mlir::Value key = op->getOperand(1);
+  mlir::Value value = op->getOperand(2);
+  mlir::Value pastKey = op->getOperand(3);
+  mlir::Value pastValue = op->getOperand(4);
+  mlir::Value seqlensK = op->getOperand(5);
+  mlir::Value totalSeqLen = op->getOperand(6);
+
+  // Extract attributes
+  auto numHeadsAttr = op->getAttrOfType<mlir::IntegerAttr>("num_heads");
+  if (!numHeadsAttr)
+    return rewriter.notifyMatchFailure(op, "missing num_heads attribute");
+
+  auto kvNumHeadsAttr = op->getAttrOfType<mlir::IntegerAttr>("kv_num_heads");
+  if (!kvNumHeadsAttr)
+    return rewriter.notifyMatchFailure(op, "missing kv_num_heads attribute");
+
+  auto scaleAttr = op->getAttrOfType<mlir::FloatAttr>("scale");
+  if (!scaleAttr)
+    return rewriter.notifyMatchFailure(op, "missing scale attribute");
+
+  auto softcapAttr = op->getAttrOfType<mlir::FloatAttr>("softcap");
+  if (!softcapAttr)
+    return rewriter.notifyMatchFailure(op, "missing softcap attribute");
+
+  auto doRotaryAttr = op->getAttrOfType<mlir::IntegerAttr>("do_rotary");
+  if (!doRotaryAttr)
+    return rewriter.notifyMatchFailure(op, "missing do_rotary attribute");
+
+  auto rotaryInterleavedAttr =
+      op->getAttrOfType<mlir::IntegerAttr>("rotary_interleaved");
+  if (!rotaryInterleavedAttr)
+    return rewriter.notifyMatchFailure(op,
+                                       "missing rotary_interleaved attribute");
+
+  // Convert to proper attribute types
+  auto numHeadsI64Attr = rewriter.getI64IntegerAttr(numHeadsAttr.getSInt());
+  auto kvNumHeadsI64Attr = rewriter.getI64IntegerAttr(kvNumHeadsAttr.getSInt());
+  auto doRotaryI64Attr = rewriter.getI64IntegerAttr(doRotaryAttr.getSInt());
+  auto rotaryInterleavedI64Attr =
+      rewriter.getI64IntegerAttr(rotaryInterleavedAttr.getSInt());
+
+  // Should have 3 results: output, present_key, present_value
+  if (op->getNumResults() != 3)
+    return rewriter.notifyMatchFailure(
+        op, "expected 3 results for GroupQueryAttention");
+
+  auto outputType =
+      mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
+  auto presentKeyType =
+      mlir::cast<mlir::RankedTensorType>(op->getResult(1).getType());
+  auto presentValueType =
+      mlir::cast<mlir::RankedTensorType>(op->getResult(2).getType());
+
+  // Create init tensors
+  mlir::Value outputInit = createEmptyTensor(rewriter, loc, outputType, query);
+  mlir::Value presentKeyInit =
+      createEmptyTensor(rewriter, loc, presentKeyType, pastKey);
+  mlir::Value presentValueInit =
+      createEmptyTensor(rewriter, loc, presentValueType, pastValue);
+
+  // Create hip.gqa operation
+  auto hipOp = mlir::hip::GqaOp::create(
+      rewriter, loc,
+      mlir::TypeRange{outputType, presentKeyType, presentValueType}, context,
+      query, key, value, pastKey, pastValue, seqlensK, totalSeqLen, outputInit,
+      presentKeyInit, presentValueInit, numHeadsI64Attr, kvNumHeadsI64Attr,
+      scaleAttr, softcapAttr, doRotaryI64Attr, rotaryInterleavedI64Attr);
+
+  rewriter.replaceOp(op, hipOp->getResults());
+  return mlir::success();
+}
+
 //===----------------------------------------------------------------------===//
 // convertComputeOps implementation
 //===----------------------------------------------------------------------===//
@@ -1052,6 +1163,7 @@ static mlir::LogicalResult convertComputeOps(mlir::func::FuncOp funcOp,
   patterns.add<SimplifiedLayerNormToHip>(ctx);
   patterns.add<SkipSimplifiedLayerNormToHip>(ctx);
   patterns.add<RotaryEmbeddingToHip>(ctx);
+  patterns.add<GroupQueryAttentionToHip>(ctx);
 
   mlir::GreedyRewriteConfig config;
   config.setStrictness(mlir::GreedyRewriteStrictness::ExistingOps);

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -1183,14 +1183,14 @@ struct GatherToHip : public mlir::RewritePattern {
     int64_t outDimIdx = 0;
 
     // Copy dimensions before axis from data
-    for (int64_t i = 0; i < normalizedAxis; ++i) {
+    for (auto i : llvm::seq<int64_t>(0, normalizedAxis)) {
       if (outDimIdx < resultType.getRank() &&
           resultType.isDynamicDim(outDimIdx))
         dynSizes.push_back(mlir::tensor::DimOp::create(rewriter, loc, data, i));
       outDimIdx++;
     }
     // Copy all dimensions from indices
-    for (int64_t i = 0; i < indicesType.getRank(); ++i) {
+    for (auto i : llvm::seq<int64_t>(0, indicesType.getRank())) {
       if (outDimIdx < resultType.getRank() &&
           resultType.isDynamicDim(outDimIdx))
         dynSizes.push_back(
@@ -1198,7 +1198,7 @@ struct GatherToHip : public mlir::RewritePattern {
       outDimIdx++;
     }
     // Copy dimensions after axis from data
-    for (int64_t i = normalizedAxis + 1; i < dataType.getRank(); ++i) {
+    for (auto i : llvm::seq<int64_t>(normalizedAxis + 1, dataType.getRank())) {
       if (outDimIdx < resultType.getRank() &&
           resultType.isDynamicDim(outDimIdx))
         dynSizes.push_back(mlir::tensor::DimOp::create(rewriter, loc, data, i));

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -479,20 +479,6 @@ void GatherOp::getEffects(
   emitDpsMemoryEffects(getDpsInputOperands(), getDpsInitsMutable(), effects);
 }
 
-LogicalResult GatherOp::verify() {
-  return verifyDpsComputeOp(*this, {getIndices(), getTable(), getOutput()},
-                            /*numInits=*/1);
-}
-
-ParseResult GatherOp::parse(OpAsmParser &parser, OperationState &result) {
-  return parseSingleInitDpsOp(parser, result, /*numIns=*/2);
-}
-
-void GatherOp::print(OpAsmPrinter &p) {
-  printSingleInitDpsOp(p, *this, getCtx(), /*scalarArgs=*/{},
-                       {getIndices(), getTable()}, {getOutput()});
-}
-
 //===----------------------------------------------------------------------===//
 // SiluOp: ins(input), outs(output)
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -571,38 +571,21 @@ void ReduceSumOp::getEffects(
 }
 
 //===----------------------------------------------------------------------===//
-// GqaOp: ins(q, k, v), outs(kv_cache, output)
-// Extra scalars: layer, start_pos, seq_len
+// GqaOp: ins(query, key, value, past_key, past_value, seqlens_k, total_seq_len)
+//        outs(output, present_key, present_value)
 //===----------------------------------------------------------------------===//
 
 MutableOperandRange GqaOp::getDpsInitsMutable() {
-  // 0=ctx, 1=layer, 2=start_pos, 3=seq_len, 4=q, 5=k, 6=v,
-  // 7=kv_cache, 8=output
-  return MutableOperandRange(*this, /*start=*/7, /*length=*/2);
+  // Operands 0-7 are inputs (ctx, query, key, value, past_key, past_value,
+  // seqlens_k, total_seq_len) Operands 8-10 are DPS inits (output, present_key,
+  // present_value)
+  return MutableOperandRange(*this, /*start=*/8, /*length=*/3);
 }
 
 void GqaOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
         &effects) {
   emitDpsMemoryEffects(getDpsInputOperands(), getDpsInitsMutable(), effects);
-}
-
-LogicalResult GqaOp::verify() {
-  return verifyDpsComputeOp(*this,
-                            {getQ(), getK(), getV(), getKvCache(), getOutput()},
-                            /*numInits=*/2);
-}
-
-ParseResult GqaOp::parse(OpAsmParser &parser, OperationState &result) {
-  // `(` ctx `,` layer `,` start_pos `,` seq_len `)`
-  return parseSingleInitDpsOp(parser, result, /*numIns=*/3,
-                              /*extraScalars=*/3);
-}
-
-void GqaOp::print(OpAsmPrinter &p) {
-  printSingleInitDpsOp(p, *this, getCtx(),
-                       {getLayer(), getStartPos(), getSeqLen()},
-                       {getQ(), getK(), getV()}, {getKvCache(), getOutput()});
 }
 
 #define GET_OP_CLASSES

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -287,28 +287,19 @@ void ConvOp::getEffects(
 // HipblasltMatmulOp: ins(A, B), outs(C)
 //===----------------------------------------------------------------------===//
 
-MutableOperandRange HipblasltMatmulOp::getDpsInitsMutable() {
-  return getCMutable();
+//===----------------------------------------------------------------------===//
+// MatmulOp: ins(A, B), outs(output)
+//===----------------------------------------------------------------------===//
+
+MutableOperandRange MatmulOp::getDpsInitsMutable() {
+  // 0=ctx, 1=A, 2=B, 3=output
+  return getOutputMutable();
 }
 
-void HipblasltMatmulOp::getEffects(
+void MatmulOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
         &effects) {
   emitDpsMemoryEffects(getDpsInputOperands(), getDpsInitsMutable(), effects);
-}
-
-LogicalResult HipblasltMatmulOp::verify() {
-  return verifyDpsComputeOp(*this, {getA(), getB(), getC()}, /*numInits=*/1);
-}
-
-ParseResult HipblasltMatmulOp::parse(OpAsmParser &parser,
-                                     OperationState &result) {
-  return parseSingleInitDpsOp(parser, result, /*numIns=*/2);
-}
-
-void HipblasltMatmulOp::print(OpAsmPrinter &p) {
-  printSingleInitDpsOp(p, *this, getCtx(), /*scalarArgs=*/{}, {getA(), getB()},
-                       {getC()});
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -353,36 +353,18 @@ LogicalResult SkipRmsNormOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
-// MiopenRopeOp: ins(cos_cache, sin_cache), outs(q, k)
-// Extra scalar: start_pos (Index)
+// RopeOp: ins(input, position_ids, cos_cache, sin_cache), outs(output)
 //===----------------------------------------------------------------------===//
 
-MutableOperandRange MiopenRopeOp::getDpsInitsMutable() {
-  // 0=ctx, 1=start_pos, 2=cos_cache, 3=sin_cache, 4=q, 5=k
-  return MutableOperandRange(*this, /*start=*/4, /*length=*/2);
+MutableOperandRange RopeOp::getDpsInitsMutable() {
+  // 0=ctx, 1=input, 2=position_ids, 3=cos_cache, 4=sin_cache, 5=output
+  return MutableOperandRange(*this, /*start=*/5, /*length=*/1);
 }
 
-void MiopenRopeOp::getEffects(
+void RopeOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
         &effects) {
   emitDpsMemoryEffects(getDpsInputOperands(), getDpsInitsMutable(), effects);
-}
-
-LogicalResult MiopenRopeOp::verify() {
-  return verifyDpsComputeOp(*this,
-                            {getQ(), getK(), getCosCache(), getSinCache()},
-                            /*numInits=*/2);
-}
-
-ParseResult MiopenRopeOp::parse(OpAsmParser &parser, OperationState &result) {
-  // `(` ctx `,` start_pos `)` `ins` ... `outs` ...
-  return parseSingleInitDpsOp(parser, result, /*numIns=*/2,
-                              /*extraScalars=*/1);
-}
-
-void MiopenRopeOp::print(OpAsmPrinter &p) {
-  printSingleInitDpsOp(p, *this, getCtx(), {getStartPos()},
-                       {getCosCache(), getSinCache()}, {getQ(), getK()});
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/lit/Conversion/hip-to-llvm/test_gather.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_gather.mlir
@@ -1,0 +1,24 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --convert-hip-to-llvm %s | FileCheck %s
+
+module {
+  func.func @test_gather_lowering(%ctx: !hip.context,
+                                   %data: memref<3x4xf32, 1>,
+                                   %indices: memref<2xi64, 1>,
+                                   %output: memref<2x4xf32, 1>) {
+    hip.gather(%ctx)
+        ins(%data, %indices : memref<3x4xf32, 1>, memref<2xi64, 1>)
+        outs(%output : memref<2x4xf32, 1>)
+        {axis = 0 : i64}
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @test_gather_lowering
+// CHECK: llvm.call @wrap_gather({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64) -> i32
+
+// Verify 8 parameters:
+// - 4 pointers: state, data, indices, output
+// - 4 i64 values: axis=0, data_num_elements=12, output_num_elements=8, element_size_bytes=4

--- a/test/lit/Conversion/hip-to-llvm/test_gqa.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_gqa.mlir
@@ -1,0 +1,38 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --convert-hip-to-llvm %s | FileCheck %s
+
+module {
+  func.func @test_gqa_lowering(%ctx: !hip.context,
+                                %query: memref<1x1x4096xf16, 1>,
+                                %key: memref<1x1x1024xf16, 1>,
+                                %value: memref<1x1x1024xf16, 1>,
+                                %past_key: memref<1x8x127x128xf16, 1>,
+                                %past_value: memref<1x8x127x128xf16, 1>,
+                                %seqlens_k: memref<1x1xi32, 1>,
+                                %total_seq_len: memref<i32, 1>,
+                                %output: memref<1x1x4096xf16, 1>,
+                                %present_key: memref<1x8x128x128xf16, 1>,
+                                %present_value: memref<1x8x128x128xf16, 1>) {
+    hip.gqa(%ctx)
+        ins(%query, %key, %value, %past_key, %past_value, %seqlens_k, %total_seq_len :
+            memref<1x1x4096xf16, 1>, memref<1x1x1024xf16, 1>, memref<1x1x1024xf16, 1>,
+            memref<1x8x127x128xf16, 1>, memref<1x8x127x128xf16, 1>,
+            memref<1x1xi32, 1>, memref<i32, 1>)
+        outs(%output, %present_key, %present_value :
+             memref<1x1x4096xf16, 1>, memref<1x8x128x128xf16, 1>, memref<1x8x128x128xf16, 1>)
+        {num_heads = 32 : i64, kv_num_heads = 8 : i64,
+         scale = 0.0883883461 : f32, softcap = 0.000000e+00 : f32,
+         do_rotary = 0 : i64, rotary_interleaved = 0 : i64}
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @test_gqa_lowering
+// CHECK: llvm.call @wrap_group_query_attention({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, f32, f32, i64, i64, i64, i64, i64, i64, i64) -> i32
+
+// Verify 24 parameters:
+// - 13 pointers: state, query, key, value, past_key, past_value, seqlens_k, total_seq_len, cos_cache(NULL), sin_cache(NULL), output, present_key, present_value
+// - 6 attributes: num_heads=32, kv_num_heads=8, scale=0.0883883461, softcap=0.0, do_rotary=0, rotary_interleaved=0
+// - 5 shape params: batch_size=1, seq_len_q=1, seq_len_kv=128, head_dim=128, element_size_bytes=2

--- a/test/lit/Conversion/hip-to-llvm/test_matmul.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_matmul.mlir
@@ -1,0 +1,22 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --convert-hip-to-llvm %s | FileCheck %s
+
+module {
+  func.func @test_matmul_lowering(%ctx: !hip.context,
+                                   %A: memref<1x128x4096xf16, 1>,
+                                   %B: memref<4096x1024xf16, 1>,
+                                   %output: memref<1x128x1024xf16, 1>) {
+    hip.matmul(%ctx)
+        ins(%A, %B : memref<1x128x4096xf16, 1>, memref<4096x1024xf16, 1>)
+        outs(%output : memref<1x128x1024xf16, 1>)
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @test_matmul_lowering
+// CHECK: llvm.call @wrap_hipblasLtMatmul({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64) -> i32
+// Verify 9 parameters:
+// - 4 pointers: state, A, B, output
+// - 5 i64: M=128, N=1024, K=4096, batch_count=1, elem_size=2

--- a/test/lit/Conversion/hip-to-llvm/test_rope.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_rope.mlir
@@ -1,0 +1,28 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --convert-hip-to-llvm %s | FileCheck %s
+
+module {
+  func.func @test_rope_lowering(%ctx: !hip.context,
+                                 %input: memref<1x128x4096xf16, 1>,
+                                 %position_ids: memref<1x128xi64, 1>,
+                                 %cos_cache: memref<131072x64xf16, 1>,
+                                 %sin_cache: memref<131072x64xf16, 1>,
+                                 %output: memref<1x128x4096xf16, 1>) {
+    hip.rope(%ctx)
+        ins(%input, %position_ids, %cos_cache, %sin_cache :
+            memref<1x128x4096xf16, 1>, memref<1x128xi64, 1>,
+            memref<131072x64xf16, 1>, memref<131072x64xf16, 1>)
+        outs(%output : memref<1x128x4096xf16, 1>)
+        {interleaved = 0 : i64, num_heads = 32 : i64,
+         rotary_embedding_dim = 128 : i64}
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @test_rope_lowering
+// CHECK: llvm.call @wrap_rotary_embedding({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64) -> i32
+// Verify 12 parameters:
+// - 6 pointers: state, input, position_ids, cos_cache, sin_cache, output
+// - 6 i64: interleaved=0, num_heads=32, rotary_dim=128, input_num_elements=524288, cos_cache_num_elements=8388608, element_size_bytes=2

--- a/test/lit/Conversion/onnx-to-hip/test_gather.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_gather.mlir
@@ -1,0 +1,72 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify ONNX Gather is correctly lowered to hip.gather operation
+// in tensor-first mode.
+//
+// This test validates:
+// - Gather operation lowering (onnx.Gather -> hip.gather)
+// - axis = 0: gather along the first axis
+// - axis = -1: gather along the last axis (negative indexing)
+// - Dynamic shape support: output dimensions computed at runtime
+// - i64 element type support
+// - Scalar index and 1D data handling
+// - Proper !hip.context threading through operations
+// - Tensor-first DPS: tensor.empty() used as output init
+//
+// Model: Llama-3.1-8B attention mask shape extraction
+// ============================================================================
+
+// RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip | FileCheck %s
+
+module {
+  // axis = 0: gather along the first (and only) axis
+  func.func @main_graph(%data: tensor<2xi64>, %indices: tensor<i64>) -> tensor<i64> {
+    // After conversion: context prepended, tensors remain tensors, tensor return
+    // CHECK-LABEL: func.func @main_graph
+    // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[DATA:.*]]: tensor<2xi64>, %[[INDICES:.*]]: tensor<i64>) -> tensor<i64>
+
+    %output = "onnx.Gather"(%data, %indices) {axis = 0 : si64} : (tensor<2xi64>, tensor<i64>) -> tensor<i64>
+
+    // After conversion: tensor.empty() for init, hip.gather in tensor mode
+    // CHECK: tensor.empty() : tensor<i64>
+    // CHECK: hip.gather(%[[CTX]]) ins(%[[DATA]], %[[INDICES]] : tensor<2xi64>, tensor<i64>) outs({{.*}} : tensor<i64>) {axis = 0 : i64}
+    // CHECK-NOT: hip.alloc
+    // CHECK-NOT: hip.copy
+
+    return %output : tensor<i64>
+  }
+
+  // axis = -1: gather along the last axis (negative indexing preserved)
+  func.func @test_gather_neg_axis(%data: tensor<4x8xi64>, %indices: tensor<2xi64>) -> tensor<4x2xi64> {
+    // CHECK-LABEL: func.func @test_gather_neg_axis
+    // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[DATA:.*]]: tensor<4x8xi64>, %[[INDICES:.*]]: tensor<2xi64>) -> tensor<4x2xi64>
+
+    %output = "onnx.Gather"(%data, %indices) {axis = -1 : si64} : (tensor<4x8xi64>, tensor<2xi64>) -> tensor<4x2xi64>
+
+    // CHECK: tensor.empty() : tensor<4x2xi64>
+    // CHECK: hip.gather(%[[CTX]]) ins(%[[DATA]], %[[INDICES]] : tensor<4x8xi64>, tensor<2xi64>) outs({{.*}} : tensor<4x2xi64>) {axis = -1 : i64}
+    // CHECK-NOT: hip.alloc
+
+    return %output : tensor<4x2xi64>
+  }
+
+  // Dynamic shape: gather with dynamic data and indices dimensions
+  func.func @test_gather_dynamic(%data: tensor<?x?xf32>, %indices: tensor<?xi64>) -> tensor<?x?xf32> {
+    // CHECK-LABEL: func.func @test_gather_dynamic
+    // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[DATA:.*]]: tensor<?x?xf32>, %[[INDICES:.*]]: tensor<?xi64>) -> tensor<?x?xf32>
+
+    %output = "onnx.Gather"(%data, %indices) {axis = 0 : si64} : (tensor<?x?xf32>, tensor<?xi64>) -> tensor<?x?xf32>
+
+    // Verify dynamic sizes are extracted via tensor.dim
+    // Output shape: [indices.shape[0], data.shape[1]]
+    // CHECK: %[[DIM_INDICES:.*]] = tensor.dim %[[INDICES]], %c0{{.*}} : tensor<?xi64>
+    // CHECK: %[[DIM_DATA:.*]] = tensor.dim %[[DATA]], %c1{{.*}} : tensor<?x?xf32>
+    // CHECK: tensor.empty(%[[DIM_INDICES]], %[[DIM_DATA]]) : tensor<?x?xf32>
+    // CHECK: hip.gather(%[[CTX]]) ins(%[[DATA]], %[[INDICES]] : tensor<?x?xf32>, tensor<?xi64>) outs({{.*}} : tensor<?x?xf32>) {axis = 0 : i64}
+
+    return %output : tensor<?x?xf32>
+  }
+}

--- a/test/lit/Conversion/onnx-to-hip/test_gqa.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_gqa.mlir
@@ -1,0 +1,64 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify com.microsoft.GroupQueryAttention (via onnx.Custom) is correctly
+// lowered to hip.gqa operation in tensor-first mode.
+//
+// This test validates:
+// - Custom ONNX op matching by function_name and domain_name
+// - Multi-output op lowering (3 outputs)
+// - Attribute preservation (num_heads, kv_num_heads, scale, etc.)
+// - f16 element type support
+// - Tensor-first DPS: tensor.empty() for each output
+//
+// Model: Llama-3.1-8B GroupQueryAttention decode step
+// ============================================================================
+
+// RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip | FileCheck %s
+
+module {
+  func.func @main_graph(
+      %query: tensor<1x1x4096xf16>,
+      %key: tensor<1x1x1024xf16>,
+      %value: tensor<1x1x1024xf16>,
+      %past_key: tensor<1x8x127x128xf16>,
+      %past_value: tensor<1x8x127x128xf16>,
+      %seqlens_k: tensor<1x1xi32>,
+      %total_seq_len: tensor<i32>)
+      -> (tensor<1x1x4096xf16>, tensor<1x8x128x128xf16>, tensor<1x8x128x128xf16>) {
+
+    // CHECK-LABEL: func.func @main_graph
+    // CHECK-SAME: (%[[CTX:.*]]: !hip.context,
+
+    %none1 = "onnx.NoValue"() {value} : () -> none
+    %none2 = "onnx.NoValue"() {value} : () -> none
+
+    %out:3 = "onnx.Custom"(%query, %key, %value, %past_key, %past_value,
+                            %seqlens_k, %total_seq_len, %none1, %none2)
+        <{function_name = "GroupQueryAttention"}>
+        {domain_name = "com.microsoft",
+         num_heads = 32 : si64,
+         kv_num_heads = 8 : si64,
+         scale = 0.0883883461 : f32,
+         softcap = 0.000000e+00 : f32,
+         do_rotary = 0 : si64,
+         rotary_interleaved = 0 : si64}
+        : (tensor<1x1x4096xf16>, tensor<1x1x1024xf16>, tensor<1x1x1024xf16>,
+           tensor<1x8x127x128xf16>, tensor<1x8x127x128xf16>,
+           tensor<1x1xi32>, tensor<i32>, none, none)
+        -> (tensor<1x1x4096xf16>, tensor<1x8x128x128xf16>, tensor<1x8x128x128xf16>)
+
+    // Three tensor.empty() inits for the three outputs
+    // CHECK: tensor.empty() : tensor<1x1x4096xf16>
+    // CHECK: tensor.empty() : tensor<1x8x128x128xf16>
+    // CHECK: tensor.empty() : tensor<1x8x128x128xf16>
+    // CHECK: hip.gqa
+    // CHECK-SAME: kv_num_heads = 8
+    // CHECK-SAME: num_heads = 32
+    // CHECK-NOT: hip.alloc
+
+    return %out#0, %out#1, %out#2 : tensor<1x1x4096xf16>, tensor<1x8x128x128xf16>, tensor<1x8x128x128xf16>
+  }
+}

--- a/test/lit/Conversion/onnx-to-hip/test_matmul.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_matmul.mlir
@@ -1,0 +1,68 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify ONNX MatMul is correctly lowered to hip.matmul operation
+// in tensor-first mode.
+//
+// This test validates:
+// - MatMul operation lowering (onnx.MatMul → hip.matmul)
+// - 2D matrix multiplication (basic case)
+// - Batched 3D x 2D matrix multiplication (Llama-3.1 pattern)
+// - Dynamic shape support with ?x?x? tensors
+// - Tensor-first DPS: tensor.empty() used as output init
+// - Proper !hip.context threading through operations
+// ============================================================================
+
+// RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
+
+module {
+  // ===== Test 1: From PR-17 (renamed function) =====
+
+  func.func @main_graph(%input: tensor<1x128x4096xf16>, %weight: tensor<4096x1024xf16>) -> tensor<1x128x1024xf16> {
+    %output = "onnx.MatMul"(%input, %weight) {onnx_node_name = "/model/layers.0/attn/k_proj/MatMul"} : (tensor<1x128x4096xf16>, tensor<4096x1024xf16>) -> tensor<1x128x1024xf16>
+    return %output : tensor<1x128x1024xf16>
+  }
+
+  // CHECK-LABEL: func.func @main_graph
+  // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[INPUT:.*]]: tensor<1x128x4096xf16>, %[[WEIGHT:.*]]: tensor<4096x1024xf16>) -> tensor<1x128x1024xf16>
+  // CHECK: %[[INIT:.*]] = tensor.empty() : tensor<1x128x1024xf16>
+  // CHECK: hip.matmul(%[[CTX]]) ins(%[[INPUT]], %[[WEIGHT]] : tensor<1x128x4096xf16>, tensor<4096x1024xf16>) outs(%[[INIT]] : tensor<1x128x1024xf16>)
+  // CHECK-NOT: onnx.MatMul
+  // CHECK-NOT: hip.alloc
+  // CHECK-NOT: hip.copy
+
+  // ===== Test 2: 3D Batched MatMul =====
+
+  func.func @batched_3d_matmul(%A: tensor<2x128x4096xf16>, %B: tensor<4096x1024xf16>) -> tensor<2x128x1024xf16> {
+    %result = "onnx.MatMul"(%A, %B) : (tensor<2x128x4096xf16>, tensor<4096x1024xf16>) -> tensor<2x128x1024xf16>
+    return %result : tensor<2x128x1024xf16>
+  }
+
+  // CHECK-LABEL: func.func @batched_3d_matmul
+  // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[A:.*]]: tensor<2x128x4096xf16>, %[[B:.*]]: tensor<4096x1024xf16>) -> tensor<2x128x1024xf16>
+  // CHECK: %[[INIT:.*]] = tensor.empty() : tensor<2x128x1024xf16>
+  // CHECK: hip.matmul(%[[CTX]]) ins(%[[A]], %[[B]] : tensor<2x128x4096xf16>, tensor<4096x1024xf16>) outs(%[[INIT]] : tensor<2x128x1024xf16>)
+  // CHECK-NOT: hip.alloc
+  // CHECK-NOT: hip.copy
+
+  // ===== Test 3: Dynamic Shapes =====
+
+  func.func @dynamic_matmul(%A: tensor<?x?x?xf16>, %B: tensor<?x?xf16>) -> tensor<?x?x?xf16> {
+    %result = "onnx.MatMul"(%A, %B) : (tensor<?x?x?xf16>, tensor<?x?xf16>) -> tensor<?x?x?xf16>
+    return %result : tensor<?x?x?xf16>
+  }
+
+  // CHECK-LABEL: func.func @dynamic_matmul
+  // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[A:.*]]: tensor<?x?x?xf16>, %[[B:.*]]: tensor<?x?xf16>) -> tensor<?x?x?xf16>
+  // CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+  // CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+  // CHECK: %[[D0:.*]] = tensor.dim %[[A]], %[[C0]] : tensor<?x?x?xf16>
+  // CHECK: %[[D1:.*]] = tensor.dim %[[A]], %[[C1]] : tensor<?x?x?xf16>
+  // CHECK: %[[D2:.*]] = tensor.dim %[[B]], %[[C1]] : tensor<?x?xf16>
+  // CHECK: %[[INIT:.*]] = tensor.empty(%[[D0]], %[[D1]], %[[D2]]) : tensor<?x?x?xf16>
+  // CHECK: hip.matmul(%[[CTX]]) ins(%[[A]], %[[B]] : tensor<?x?x?xf16>, tensor<?x?xf16>) outs(%[[INIT]] : tensor<?x?x?xf16>)
+  // CHECK-NOT: hip.alloc
+  // CHECK-NOT: hip.copy
+}

--- a/test/lit/Conversion/onnx-to-hip/test_rope.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_rope.mlir
@@ -1,0 +1,103 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify ONNX RotaryEmbedding (com.microsoft domain) is correctly lowered
+// to hip.rope operation in tensor-first mode.
+//
+// This test validates:
+// - Custom operation lowering (onnx.Custom -> hip.rope)
+// - Domain check: only "com.microsoft" domain is converted
+// - Rotary embedding attributes: interleaved, num_heads, rotary_embedding_dim
+// - Attribute inference (num_heads=0, rotary_dim=0 inferred from shapes)
+// - f16 element type support
+// - 3D tensor (1x128x4096) rotation with position indices
+// - Proper !hip.context threading through operations
+// - Tensor-first DPS: tensor.empty() used as output init
+//
+// Model: Llama-3.1-8B rotary position embedding
+// ============================================================================
+
+// RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
+
+module {
+  func.func @main_graph(%input: tensor<1x128x4096xf16>,
+                         %position_ids: tensor<1x128xi64>,
+                         %cos_cache: tensor<131072x64xf16>,
+                         %sin_cache: tensor<131072x64xf16>)
+      -> tensor<1x128x4096xf16> {
+    %output = "onnx.Custom"(%input, %position_ids, %cos_cache, %sin_cache) {
+      function_name = "RotaryEmbedding",
+      domain_name = "com.microsoft",
+      interleaved = 0 : si64,
+      num_heads = 0 : si64,
+      rotary_embedding_dim = 0 : si64
+    } : (tensor<1x128x4096xf16>, tensor<1x128xi64>,
+         tensor<131072x64xf16>, tensor<131072x64xf16>)
+        -> tensor<1x128x4096xf16>
+    return %output : tensor<1x128x4096xf16>
+  }
+
+  // ===== Dynamic shape test =====
+
+  func.func @dynamic_rope(%input: tensor<?x?x?xf16>,
+                          %position_ids: tensor<?x?xi64>,
+                          %cos_cache: tensor<?x?xf16>,
+                          %sin_cache: tensor<?x?xf16>)
+      -> tensor<?x?x?xf16> {
+    %output = "onnx.Custom"(%input, %position_ids, %cos_cache, %sin_cache) {
+      function_name = "RotaryEmbedding",
+      domain_name = "com.microsoft",
+      interleaved = 0 : si64,
+      num_heads = 32 : si64,
+      rotary_embedding_dim = 128 : si64
+    } : (tensor<?x?x?xf16>, tensor<?x?xi64>,
+         tensor<?x?xf16>, tensor<?x?xf16>)
+        -> tensor<?x?x?xf16>
+    return %output : tensor<?x?x?xf16>
+  }
+
+  // ===== Explicit attributes (no inference) =====
+
+  func.func @explicit_attrs_rope(%input: tensor<1x128x4096xf16>,
+                                  %position_ids: tensor<1x128xi64>,
+                                  %cos_cache: tensor<131072x64xf16>,
+                                  %sin_cache: tensor<131072x64xf16>)
+      -> tensor<1x128x4096xf16> {
+    %output = "onnx.Custom"(%input, %position_ids, %cos_cache, %sin_cache) {
+      function_name = "RotaryEmbedding",
+      domain_name = "com.microsoft",
+      interleaved = 1 : si64,
+      num_heads = 32 : si64,
+      rotary_embedding_dim = 128 : si64
+    } : (tensor<1x128x4096xf16>, tensor<1x128xi64>,
+         tensor<131072x64xf16>, tensor<131072x64xf16>)
+        -> tensor<1x128x4096xf16>
+    return %output : tensor<1x128x4096xf16>
+  }
+}
+
+// CHECK-LABEL: func.func @main_graph
+// CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[INPUT:.*]]: tensor<1x128x4096xf16>, %[[POS_IDS:.*]]: tensor<1x128xi64>, %[[COS:.*]]: tensor<131072x64xf16>, %[[SIN:.*]]: tensor<131072x64xf16>) -> tensor<1x128x4096xf16>
+// CHECK: %[[INIT:.*]] = tensor.empty() : tensor<1x128x4096xf16>
+// CHECK: hip.rope(%[[CTX]]) ins(%[[INPUT]], %[[POS_IDS]], %[[COS]], %[[SIN]] : tensor<1x128x4096xf16>, tensor<1x128xi64>, tensor<131072x64xf16>, tensor<131072x64xf16>) outs(%[[INIT]] : tensor<1x128x4096xf16>) {interleaved = 0 : i64, num_heads = 32 : i64, rotary_embedding_dim = 128 : i64} : tensor<1x128x4096xf16>
+// CHECK-NOT: onnx.Custom
+
+// CHECK-LABEL: func.func @dynamic_rope
+// CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[INPUT:.*]]: tensor<?x?x?xf16>, %[[POS_IDS:.*]]: tensor<?x?xi64>, %[[COS:.*]]: tensor<?x?xf16>, %[[SIN:.*]]: tensor<?x?xf16>) -> tensor<?x?x?xf16>
+// CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+// CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+// CHECK-DAG: %[[C2:.*]] = arith.constant 2 : index
+// CHECK: %{{.*}} = tensor.dim %[[INPUT]], %[[C0]] : tensor<?x?x?xf16>
+// CHECK: %{{.*}} = tensor.dim %[[INPUT]], %[[C1]] : tensor<?x?x?xf16>
+// CHECK: %{{.*}} = tensor.dim %[[INPUT]], %[[C2]] : tensor<?x?x?xf16>
+// CHECK: %[[INIT:.*]] = tensor.empty({{.*}}, {{.*}}, {{.*}}) : tensor<?x?x?xf16>
+// CHECK: hip.rope(%[[CTX]]) ins(%[[INPUT]], %[[POS_IDS]], %[[COS]], %[[SIN]] : tensor<?x?x?xf16>, tensor<?x?xi64>, tensor<?x?xf16>, tensor<?x?xf16>) outs(%[[INIT]] : tensor<?x?x?xf16>) {interleaved = 0 : i64, num_heads = 32 : i64, rotary_embedding_dim = 128 : i64} : tensor<?x?x?xf16>
+// CHECK-NOT: onnx.Custom
+
+// CHECK-LABEL: func.func @explicit_attrs_rope
+// CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[INPUT:.*]]: tensor<1x128x4096xf16>, %[[POS_IDS:.*]]: tensor<1x128xi64>, %[[COS:.*]]: tensor<131072x64xf16>, %[[SIN:.*]]: tensor<131072x64xf16>) -> tensor<1x128x4096xf16>
+// CHECK: %[[INIT:.*]] = tensor.empty() : tensor<1x128x4096xf16>
+// CHECK: hip.rope(%[[CTX]]) ins(%[[INPUT]], %[[POS_IDS]], %[[COS]], %[[SIN]] : tensor<1x128x4096xf16>, tensor<1x128xi64>, tensor<131072x64xf16>, tensor<131072x64xf16>) outs(%[[INIT]] : tensor<1x128x4096xf16>) {interleaved = 1 : i64, num_heads = 32 : i64, rotary_embedding_dim = 128 : i64} : tensor<1x128x4096xf16>
+// CHECK-NOT: onnx.Custom

--- a/test/lit/Conversion/onnx-to-hip/test_rope.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_rope.mlir
@@ -27,6 +27,9 @@ module {
                          %cos_cache: tensor<131072x64xf16>,
                          %sin_cache: tensor<131072x64xf16>)
       -> tensor<1x128x4096xf16> {
+    // Test attribute inference: 0 means "infer from tensor shapes"
+    // Expected: rotary_dim = cos_cache.shape[-1] * 2 = 64 * 2 = 128
+    //           num_heads = input.shape[-1] / rotary_dim = 4096 / 128 = 32
     %output = "onnx.Custom"(%input, %position_ids, %cos_cache, %sin_cache) {
       function_name = "RotaryEmbedding",
       domain_name = "com.microsoft",

--- a/test/lit/Conversion/onnx-to-hip/test_rope.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_rope.mlir
@@ -39,6 +39,12 @@ module {
     return %output : tensor<1x128x4096xf16>
   }
 
+  // CHECK-LABEL: func.func @main_graph
+  // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[INPUT:.*]]: tensor<1x128x4096xf16>, %[[POS_IDS:.*]]: tensor<1x128xi64>, %[[COS:.*]]: tensor<131072x64xf16>, %[[SIN:.*]]: tensor<131072x64xf16>) -> tensor<1x128x4096xf16>
+  // CHECK: %[[INIT:.*]] = tensor.empty() : tensor<1x128x4096xf16>
+  // CHECK: hip.rope(%[[CTX]]) ins(%[[INPUT]], %[[POS_IDS]], %[[COS]], %[[SIN]] : tensor<1x128x4096xf16>, tensor<1x128xi64>, tensor<131072x64xf16>, tensor<131072x64xf16>) outs(%[[INIT]] : tensor<1x128x4096xf16>) {interleaved = 0 : i64, num_heads = 32 : i64, rotary_embedding_dim = 128 : i64} : tensor<1x128x4096xf16>
+  // CHECK-NOT: onnx.Custom
+
   // ===== Dynamic shape test =====
 
   func.func @dynamic_rope(%input: tensor<?x?x?xf16>,
@@ -58,6 +64,18 @@ module {
     return %output : tensor<?x?x?xf16>
   }
 
+  // CHECK-LABEL: func.func @dynamic_rope
+  // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[INPUT:.*]]: tensor<?x?x?xf16>, %[[POS_IDS:.*]]: tensor<?x?xi64>, %[[COS:.*]]: tensor<?x?xf16>, %[[SIN:.*]]: tensor<?x?xf16>) -> tensor<?x?x?xf16>
+  // CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+  // CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+  // CHECK-DAG: %[[C2:.*]] = arith.constant 2 : index
+  // CHECK: %{{.*}} = tensor.dim %[[INPUT]], %[[C0]] : tensor<?x?x?xf16>
+  // CHECK: %{{.*}} = tensor.dim %[[INPUT]], %[[C1]] : tensor<?x?x?xf16>
+  // CHECK: %{{.*}} = tensor.dim %[[INPUT]], %[[C2]] : tensor<?x?x?xf16>
+  // CHECK: %[[INIT:.*]] = tensor.empty({{.*}}, {{.*}}, {{.*}}) : tensor<?x?x?xf16>
+  // CHECK: hip.rope(%[[CTX]]) ins(%[[INPUT]], %[[POS_IDS]], %[[COS]], %[[SIN]] : tensor<?x?x?xf16>, tensor<?x?xi64>, tensor<?x?xf16>, tensor<?x?xf16>) outs(%[[INIT]] : tensor<?x?x?xf16>) {interleaved = 0 : i64, num_heads = 32 : i64, rotary_embedding_dim = 128 : i64} : tensor<?x?x?xf16>
+  // CHECK-NOT: onnx.Custom
+
   // ===== Explicit attributes (no inference) =====
 
   func.func @explicit_attrs_rope(%input: tensor<1x128x4096xf16>,
@@ -76,28 +94,10 @@ module {
         -> tensor<1x128x4096xf16>
     return %output : tensor<1x128x4096xf16>
   }
+
+  // CHECK-LABEL: func.func @explicit_attrs_rope
+  // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[INPUT:.*]]: tensor<1x128x4096xf16>, %[[POS_IDS:.*]]: tensor<1x128xi64>, %[[COS:.*]]: tensor<131072x64xf16>, %[[SIN:.*]]: tensor<131072x64xf16>) -> tensor<1x128x4096xf16>
+  // CHECK: %[[INIT:.*]] = tensor.empty() : tensor<1x128x4096xf16>
+  // CHECK: hip.rope(%[[CTX]]) ins(%[[INPUT]], %[[POS_IDS]], %[[COS]], %[[SIN]] : tensor<1x128x4096xf16>, tensor<1x128xi64>, tensor<131072x64xf16>, tensor<131072x64xf16>) outs(%[[INIT]] : tensor<1x128x4096xf16>) {interleaved = 1 : i64, num_heads = 32 : i64, rotary_embedding_dim = 128 : i64} : tensor<1x128x4096xf16>
+  // CHECK-NOT: onnx.Custom
 }
-
-// CHECK-LABEL: func.func @main_graph
-// CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[INPUT:.*]]: tensor<1x128x4096xf16>, %[[POS_IDS:.*]]: tensor<1x128xi64>, %[[COS:.*]]: tensor<131072x64xf16>, %[[SIN:.*]]: tensor<131072x64xf16>) -> tensor<1x128x4096xf16>
-// CHECK: %[[INIT:.*]] = tensor.empty() : tensor<1x128x4096xf16>
-// CHECK: hip.rope(%[[CTX]]) ins(%[[INPUT]], %[[POS_IDS]], %[[COS]], %[[SIN]] : tensor<1x128x4096xf16>, tensor<1x128xi64>, tensor<131072x64xf16>, tensor<131072x64xf16>) outs(%[[INIT]] : tensor<1x128x4096xf16>) {interleaved = 0 : i64, num_heads = 32 : i64, rotary_embedding_dim = 128 : i64} : tensor<1x128x4096xf16>
-// CHECK-NOT: onnx.Custom
-
-// CHECK-LABEL: func.func @dynamic_rope
-// CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[INPUT:.*]]: tensor<?x?x?xf16>, %[[POS_IDS:.*]]: tensor<?x?xi64>, %[[COS:.*]]: tensor<?x?xf16>, %[[SIN:.*]]: tensor<?x?xf16>) -> tensor<?x?x?xf16>
-// CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
-// CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
-// CHECK-DAG: %[[C2:.*]] = arith.constant 2 : index
-// CHECK: %{{.*}} = tensor.dim %[[INPUT]], %[[C0]] : tensor<?x?x?xf16>
-// CHECK: %{{.*}} = tensor.dim %[[INPUT]], %[[C1]] : tensor<?x?x?xf16>
-// CHECK: %{{.*}} = tensor.dim %[[INPUT]], %[[C2]] : tensor<?x?x?xf16>
-// CHECK: %[[INIT:.*]] = tensor.empty({{.*}}, {{.*}}, {{.*}}) : tensor<?x?x?xf16>
-// CHECK: hip.rope(%[[CTX]]) ins(%[[INPUT]], %[[POS_IDS]], %[[COS]], %[[SIN]] : tensor<?x?x?xf16>, tensor<?x?xi64>, tensor<?x?xf16>, tensor<?x?xf16>) outs(%[[INIT]] : tensor<?x?x?xf16>) {interleaved = 0 : i64, num_heads = 32 : i64, rotary_embedding_dim = 128 : i64} : tensor<?x?x?xf16>
-// CHECK-NOT: onnx.Custom
-
-// CHECK-LABEL: func.func @explicit_attrs_rope
-// CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[INPUT:.*]]: tensor<1x128x4096xf16>, %[[POS_IDS:.*]]: tensor<1x128xi64>, %[[COS:.*]]: tensor<131072x64xf16>, %[[SIN:.*]]: tensor<131072x64xf16>) -> tensor<1x128x4096xf16>
-// CHECK: %[[INIT:.*]] = tensor.empty() : tensor<1x128x4096xf16>
-// CHECK: hip.rope(%[[CTX]]) ins(%[[INPUT]], %[[POS_IDS]], %[[COS]], %[[SIN]] : tensor<1x128x4096xf16>, tensor<1x128xi64>, tensor<131072x64xf16>, tensor<131072x64xf16>) outs(%[[INIT]] : tensor<1x128x4096xf16>) {interleaved = 1 : i64, num_heads = 32 : i64, rotary_embedding_dim = 128 : i64} : tensor<1x128x4096xf16>
-// CHECK-NOT: onnx.Custom

--- a/test/lit/Conversion/onnx-to-hip/test_rope.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_rope.mlir
@@ -47,6 +47,8 @@ module {
   // CHECK: %[[INIT:.*]] = tensor.empty() : tensor<1x128x4096xf16>
   // CHECK: hip.rope(%[[CTX]]) ins(%[[INPUT]], %[[POS_IDS]], %[[COS]], %[[SIN]] : tensor<1x128x4096xf16>, tensor<1x128xi64>, tensor<131072x64xf16>, tensor<131072x64xf16>) outs(%[[INIT]] : tensor<1x128x4096xf16>) {interleaved = 0 : i64, num_heads = 32 : i64, rotary_embedding_dim = 128 : i64} : tensor<1x128x4096xf16>
   // CHECK-NOT: onnx.Custom
+  // CHECK-NOT: hip.alloc
+  // CHECK-NOT: hip.copy
 
   // ===== Dynamic shape test =====
 
@@ -78,6 +80,8 @@ module {
   // CHECK: %[[INIT:.*]] = tensor.empty({{.*}}, {{.*}}, {{.*}}) : tensor<?x?x?xf16>
   // CHECK: hip.rope(%[[CTX]]) ins(%[[INPUT]], %[[POS_IDS]], %[[COS]], %[[SIN]] : tensor<?x?x?xf16>, tensor<?x?xi64>, tensor<?x?xf16>, tensor<?x?xf16>) outs(%[[INIT]] : tensor<?x?x?xf16>) {interleaved = 0 : i64, num_heads = 32 : i64, rotary_embedding_dim = 128 : i64} : tensor<?x?x?xf16>
   // CHECK-NOT: onnx.Custom
+  // CHECK-NOT: hip.alloc
+  // CHECK-NOT: hip.copy
 
   // ===== Explicit attributes (no inference) =====
 
@@ -103,4 +107,6 @@ module {
   // CHECK: %[[INIT:.*]] = tensor.empty() : tensor<1x128x4096xf16>
   // CHECK: hip.rope(%[[CTX]]) ins(%[[INPUT]], %[[POS_IDS]], %[[COS]], %[[SIN]] : tensor<1x128x4096xf16>, tensor<1x128xi64>, tensor<131072x64xf16>, tensor<131072x64xf16>) outs(%[[INIT]] : tensor<1x128x4096xf16>) {interleaved = 1 : i64, num_heads = 32 : i64, rotary_embedding_dim = 128 : i64} : tensor<1x128x4096xf16>
   // CHECK-NOT: onnx.Custom
+  // CHECK-NOT: hip.alloc
+  // CHECK-NOT: hip.copy
 }

--- a/test/lit/Dialect/hip-lower-allocs.mlir
+++ b/test/lit/Dialect/hip-lower-allocs.mlir
@@ -17,7 +17,7 @@
 // CHECK-LABEL: func.func @static_lower
 // CHECK-SAME:    (%[[CTX:.*]]: !hip.context,
 // CHECK:         %[[A:.*]] = hip.alloc(%[[CTX]]) : memref<2x64x64xf32>
-// CHECK:         hip.hipblaslt.matmul
+// CHECK:         hip.matmul
 // CHECK:         %[[B:.*]] = hip.alloc(%[[CTX]]) : memref<2x64x64xf32>
 // CHECK:         hip.miopen.softmax
 // CHECK:         hip.free(%[[CTX]], %[[A]]) : memref<2x64x64xf32>
@@ -27,7 +27,7 @@ func.func @static_lower(
     %a: memref<2x64x64xf32, strided<[?, ?, ?], offset: ?>>,
     %b: memref<64x64xf32, strided<[?, ?], offset: ?>>) -> memref<2x64x64xf32> {
   %alloc0 = memref.alloc() {alignment = 64 : i64} : memref<2x64x64xf32>
-  hip.hipblaslt.matmul(%ctx) ins(%a, %b : memref<2x64x64xf32, strided<[?, ?, ?], offset: ?>>, memref<64x64xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<2x64x64xf32>)
+  hip.matmul(%ctx) ins(%a, %b : memref<2x64x64xf32, strided<[?, ?, ?], offset: ?>>, memref<64x64xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<2x64x64xf32>)
   %alloc1 = memref.alloc() {alignment = 64 : i64} : memref<2x64x64xf32>
   hip.miopen.softmax(%ctx) ins(%alloc0 : memref<2x64x64xf32>) outs(%alloc1 : memref<2x64x64xf32>)
   return %alloc1 : memref<2x64x64xf32>
@@ -38,7 +38,7 @@ func.func @static_lower(
 // CHECK-LABEL: func.func @dynamic_lower
 // CHECK-SAME:    (%[[CTX2:.*]]: !hip.context,
 // CHECK:         hip.alloc(%[[CTX2]], %{{.*}}) : memref<?x64xf32>
-// CHECK:         hip.hipblaslt.matmul
+// CHECK:         hip.matmul
 // CHECK-NOT:     hip.free
 // CHECK:         return
 func.func @dynamic_lower(
@@ -47,7 +47,7 @@ func.func @dynamic_lower(
     %b: memref<64x64xf32, strided<[?, ?], offset: ?>>,
     %n: index) -> memref<?x64xf32> {
   %alloc0 = memref.alloc(%n) : memref<?x64xf32>
-  hip.hipblaslt.matmul(%ctx) ins(%a, %b : memref<?x64xf32>, memref<64x64xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<?x64xf32>)
+  hip.matmul(%ctx) ins(%a, %b : memref<?x64xf32>, memref<64x64xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<?x64xf32>)
   return %alloc0 : memref<?x64xf32>
 }
 
@@ -64,7 +64,7 @@ func.func @no_allocs_noop(%ctx: !hip.context, %a: memref<2x64x64xf32>) -> memref
 // CHECK-LABEL: func.func @multiple_frees
 // CHECK-SAME:    (%[[CTX3:.*]]: !hip.context,
 // CHECK:         %[[A:.*]] = hip.alloc(%[[CTX3]]) : memref<2x64x64xf32>
-// CHECK:         hip.hipblaslt.matmul
+// CHECK:         hip.matmul
 // CHECK:         %[[B:.*]] = hip.alloc(%[[CTX3]]) : memref<2x64x64xf32>
 // CHECK:         hip.miopen.softmax
 // CHECK:         hip.free(%[[CTX3]], %[[A]]) : memref<2x64x64xf32>
@@ -77,7 +77,7 @@ func.func @multiple_frees(
     %input: memref<2x64x64xf32, strided<[?, ?, ?], offset: ?>>,
     %w: memref<64x64xf32, strided<[?, ?], offset: ?>>) -> memref<2x64x64xf32> {
   %alloc0 = memref.alloc() {alignment = 64 : i64} : memref<2x64x64xf32>
-  hip.hipblaslt.matmul(%ctx) ins(%input, %w : memref<2x64x64xf32, strided<[?, ?, ?], offset: ?>>, memref<64x64xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<2x64x64xf32>)
+  hip.matmul(%ctx) ins(%input, %w : memref<2x64x64xf32, strided<[?, ?, ?], offset: ?>>, memref<64x64xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<2x64x64xf32>)
   %alloc1 = memref.alloc() {alignment = 64 : i64} : memref<2x64x64xf32>
   hip.miopen.softmax(%ctx) ins(%alloc0 : memref<2x64x64xf32>) outs(%alloc1 : memref<2x64x64xf32>)
   %alloc2 = memref.alloc() {alignment = 64 : i64} : memref<2x64x64xf32>
@@ -112,7 +112,7 @@ func.func @dealloc_conversion(
 // CHECK-LABEL: func.func @free_after_all_direct_users
 // CHECK-SAME:    (%[[CTX5:.*]]: !hip.context,
 // CHECK:         %[[A:.*]] = hip.alloc(%[[CTX5]]) : memref<8x8xf32>
-// CHECK:         hip.hipblaslt.matmul{{.*}}outs(%[[A]] :
+// CHECK:         hip.matmul{{.*}}outs(%[[A]] :
 // CHECK:         %[[B:.*]] = hip.alloc(%[[CTX5]]) : memref<8x8xf32>
 // CHECK:         hip.miopen.softmax{{.*}}ins(%[[A]]{{.*}}outs(%[[B]] :
 // CHECK:         hip.free(%[[CTX5]], %[[A]]) : memref<8x8xf32>
@@ -122,7 +122,7 @@ func.func @free_after_all_direct_users(
     %a: memref<8x8xf32, strided<[?, ?], offset: ?>>,
     %b: memref<8x8xf32, strided<[?, ?], offset: ?>>) -> memref<8x8xf32> {
   %alloc0 = memref.alloc() : memref<8x8xf32>
-  hip.hipblaslt.matmul(%ctx) ins(%a, %b : memref<8x8xf32, strided<[?, ?], offset: ?>>, memref<8x8xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<8x8xf32>)
+  hip.matmul(%ctx) ins(%a, %b : memref<8x8xf32, strided<[?, ?], offset: ?>>, memref<8x8xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<8x8xf32>)
   %alloc1 = memref.alloc() : memref<8x8xf32>
   hip.miopen.softmax(%ctx) ins(%alloc0 : memref<8x8xf32>) outs(%alloc1 : memref<8x8xf32>)
   return %alloc1 : memref<8x8xf32>
@@ -137,7 +137,7 @@ func.func @free_after_all_direct_users(
 // CHECK:         %[[ALLOC:.*]] = hip.alloc(%[[CTX6]]) : memref<2x64x64xf32>
 // CHECK:         memref.subview
 // CHECK:         memref.cast
-// CHECK:         hip.hipblaslt.matmul
+// CHECK:         hip.matmul
 // CHECK:         hip.free(%[[CTX6]], %[[ALLOC]]) : memref<2x64x64xf32>
 // CHECK:         return
 func.func @view_alias_chain_free_placement(
@@ -150,7 +150,7 @@ func.func @view_alias_chain_free_placement(
   %cast = memref.cast %sv
       : memref<1x64x64xf32, strided<[4096, 64, 1]>>
         to memref<1x64x64xf32, strided<[?, ?, ?], offset: ?>>
-  hip.hipblaslt.matmul(%ctx) ins(%cast, %b : memref<1x64x64xf32, strided<[?, ?, ?], offset: ?>>, memref<64x64xf32, strided<[?, ?], offset: ?>>) outs(%out : memref<2x64x64xf32>)
+  hip.matmul(%ctx) ins(%cast, %b : memref<1x64x64xf32, strided<[?, ?, ?], offset: ?>>, memref<64x64xf32, strided<[?, ?], offset: ?>>) outs(%out : memref<2x64x64xf32>)
   return %out : memref<2x64x64xf32>
 }
 
@@ -174,7 +174,7 @@ func.func @pool_view_returned_no_free(
   %c256 = arith.constant 256 : index
   %pool = memref.alloc() : memref<512xi8>
   %view0 = memref.view %pool[%c0][] : memref<512xi8> to memref<8x8xf32>
-  hip.hipblaslt.matmul(%ctx) ins(%a, %b : memref<8x8xf32, strided<[?, ?], offset: ?>>, memref<8x8xf32, strided<[?, ?], offset: ?>>) outs(%view0 : memref<8x8xf32>)
+  hip.matmul(%ctx) ins(%a, %b : memref<8x8xf32, strided<[?, ?], offset: ?>>, memref<8x8xf32, strided<[?, ?], offset: ?>>) outs(%view0 : memref<8x8xf32>)
   %view1 = memref.view %pool[%c256][] : memref<512xi8> to memref<8x8xf32>
   hip.miopen.softmax(%ctx) ins(%view0 : memref<8x8xf32>) outs(%view1 : memref<8x8xf32>)
   return %view1 : memref<8x8xf32>

--- a/test/lit/Dialect/hip-optimize-memrefs.mlir
+++ b/test/lit/Dialect/hip-optimize-memrefs.mlir
@@ -17,9 +17,9 @@
 //
 // CHECK-LABEL: func.func @static_reuse_same_type
 // CHECK:         %[[A:.*]] = memref.alloc()
-// CHECK:         hip.hipblaslt.matmul
+// CHECK:         hip.matmul
 // CHECK-NOT:     memref.alloc()
-// CHECK:         hip.hipblaslt.matmul{{.*}}outs(%[[A]] :
+// CHECK:         hip.matmul{{.*}}outs(%[[A]] :
 // CHECK:         %[[B:.*]] = memref.alloc()
 // CHECK:         hip.miopen.softmax{{.*}}outs(%[[B]] :
 // CHECK:         return %[[B]]
@@ -29,9 +29,9 @@ func.func @static_reuse_same_type(
     %b: memref<64x64xf32, strided<[?, ?], offset: ?>>,
     %c: memref<64x64xf32, strided<[?, ?], offset: ?>>) -> memref<2x64x64xf32> {
   %alloc0 = memref.alloc() {alignment = 64 : i64} : memref<2x64x64xf32>
-  hip.hipblaslt.matmul(%ctx) ins(%a, %b : memref<2x64x64xf32, strided<[?, ?, ?], offset: ?>>, memref<64x64xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<2x64x64xf32>)
+  hip.matmul(%ctx) ins(%a, %b : memref<2x64x64xf32, strided<[?, ?, ?], offset: ?>>, memref<64x64xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<2x64x64xf32>)
   %alloc1 = memref.alloc() {alignment = 64 : i64} : memref<2x64x64xf32>
-  hip.hipblaslt.matmul(%ctx) ins(%a, %c : memref<2x64x64xf32, strided<[?, ?, ?], offset: ?>>, memref<64x64xf32, strided<[?, ?], offset: ?>>) outs(%alloc1 : memref<2x64x64xf32>)
+  hip.matmul(%ctx) ins(%a, %c : memref<2x64x64xf32, strided<[?, ?, ?], offset: ?>>, memref<64x64xf32, strided<[?, ?], offset: ?>>) outs(%alloc1 : memref<2x64x64xf32>)
   %alloc2 = memref.alloc() {alignment = 64 : i64} : memref<2x64x64xf32>
   hip.miopen.softmax(%ctx) ins(%alloc1 : memref<2x64x64xf32>) outs(%alloc2 : memref<2x64x64xf32>)
   return %alloc2 : memref<2x64x64xf32>
@@ -48,7 +48,7 @@ func.func @static_reuse_same_type(
 //
 // CHECK-LABEL: func.func @bytesize_reuse_reinterpret_cast
 // CHECK:         %[[BIG:.*]] = memref.alloc(){{.*}}: memref<2x64x64xf32>
-// CHECK:         hip.hipblaslt.matmul
+// CHECK:         hip.matmul
 // CHECK:         %[[OTHER:.*]] = memref.alloc(){{.*}}: memref<2x64x64xf32>
 // CHECK:         hip.mul
 // CHECK-NOT:     memref.alloc()
@@ -61,7 +61,7 @@ func.func @bytesize_reuse_reinterpret_cast(
     %b: memref<64x64xf32, strided<[?, ?], offset: ?>>,
     %s: memref<f32, strided<[], offset: ?>>) -> memref<64xf32> {
   %alloc0 = memref.alloc() {alignment = 64 : i64} : memref<2x64x64xf32>
-  hip.hipblaslt.matmul(%ctx) ins(%a, %b : memref<2x64x64xf32, strided<[?, ?, ?], offset: ?>>, memref<64x64xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<2x64x64xf32>)
+  hip.matmul(%ctx) ins(%a, %b : memref<2x64x64xf32, strided<[?, ?, ?], offset: ?>>, memref<64x64xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<2x64x64xf32>)
   %alloc1 = memref.alloc() {alignment = 64 : i64} : memref<2x64x64xf32>
   hip.mul(%ctx) ins(%alloc0, %s : memref<2x64x64xf32>, memref<f32, strided<[], offset: ?>>) outs(%alloc1 : memref<2x64x64xf32>)
   %alloc2 = memref.alloc() : memref<64xf32>
@@ -78,18 +78,18 @@ func.func @bytesize_reuse_reinterpret_cast(
 //
 // CHECK-LABEL: func.func @no_reuse_overlapping_lifetimes
 // CHECK:         %[[A:.*]] = memref.alloc()
-// CHECK:         hip.hipblaslt.matmul
+// CHECK:         hip.matmul
 // CHECK:         %[[B:.*]] = memref.alloc()
-// CHECK:         hip.hipblaslt.matmul{{.*}}ins(%[[A]], %[[A]]{{.*}}outs(%[[B]] :
+// CHECK:         hip.matmul{{.*}}ins(%[[A]], %[[A]]{{.*}}outs(%[[B]] :
 // CHECK:         return %[[B]]
 func.func @no_reuse_overlapping_lifetimes(
     %ctx: !hip.context,
     %a: memref<2x64x64xf32, strided<[?, ?, ?], offset: ?>>,
     %b: memref<64x64xf32, strided<[?, ?], offset: ?>>) -> memref<2x64x64xf32> {
   %alloc0 = memref.alloc() {alignment = 64 : i64} : memref<2x64x64xf32>
-  hip.hipblaslt.matmul(%ctx) ins(%a, %b : memref<2x64x64xf32, strided<[?, ?, ?], offset: ?>>, memref<64x64xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<2x64x64xf32>)
+  hip.matmul(%ctx) ins(%a, %b : memref<2x64x64xf32, strided<[?, ?, ?], offset: ?>>, memref<64x64xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<2x64x64xf32>)
   %alloc1 = memref.alloc() {alignment = 64 : i64} : memref<2x64x64xf32>
-  hip.hipblaslt.matmul(%ctx) ins(%alloc0, %alloc0 : memref<2x64x64xf32>, memref<2x64x64xf32>) outs(%alloc1 : memref<2x64x64xf32>)
+  hip.matmul(%ctx) ins(%alloc0, %alloc0 : memref<2x64x64xf32>, memref<2x64x64xf32>) outs(%alloc1 : memref<2x64x64xf32>)
   return %alloc1 : memref<2x64x64xf32>
 }
 
@@ -103,7 +103,7 @@ func.func @no_reuse_overlapping_lifetimes(
 //
 // CHECK-LABEL: func.func @dynamic_same_dim_reuse
 // CHECK:         %[[A:.*]] = memref.alloc(%arg3)
-// CHECK:         hip.hipblaslt.matmul
+// CHECK:         hip.matmul
 // CHECK:         %[[B:.*]] = memref.alloc(%arg3)
 // CHECK:         hip.miopen.softmax{{.*}}outs(%[[B]] :
 // CHECK-NOT:     memref.alloc
@@ -115,7 +115,7 @@ func.func @dynamic_same_dim_reuse(
     %b: memref<64x64xf32, strided<[?, ?], offset: ?>>,
     %n: index) -> memref<?x64xf32> {
   %alloc0 = memref.alloc(%n) : memref<?x64xf32>
-  hip.hipblaslt.matmul(%ctx) ins(%a, %b : memref<?x64xf32>, memref<64x64xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<?x64xf32>)
+  hip.matmul(%ctx) ins(%a, %b : memref<?x64xf32>, memref<64x64xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<?x64xf32>)
   %alloc1 = memref.alloc(%n) : memref<?x64xf32>
   hip.miopen.softmax(%ctx) ins(%alloc0 : memref<?x64xf32>) outs(%alloc1 : memref<?x64xf32>)
   %alloc2 = memref.alloc(%n) : memref<?x64xf32>
@@ -129,7 +129,7 @@ func.func @dynamic_same_dim_reuse(
 // values means no reuse.
 // CHECK-LABEL: func.func @no_reuse_different_dynamic
 // CHECK:         memref.alloc(%arg3) : memref<?x64xf32>
-// CHECK:         hip.hipblaslt.matmul
+// CHECK:         hip.matmul
 // CHECK:         memref.alloc(%arg4) : memref<?x64xf32>
 // CHECK:         hip.miopen.softmax
 // CHECK:         return
@@ -139,7 +139,7 @@ func.func @no_reuse_different_dynamic(
     %b: memref<64x64xf32, strided<[?, ?], offset: ?>>,
     %n: index, %m: index) -> memref<?x64xf32> {
   %alloc0 = memref.alloc(%n) : memref<?x64xf32>
-  hip.hipblaslt.matmul(%ctx) ins(%a, %b : memref<?x64xf32>, memref<64x64xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<?x64xf32>)
+  hip.matmul(%ctx) ins(%a, %b : memref<?x64xf32>, memref<64x64xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<?x64xf32>)
   %alloc1 = memref.alloc(%m) : memref<?x64xf32>
   hip.miopen.softmax(%ctx) ins(%alloc0 : memref<?x64xf32>) outs(%alloc1 : memref<?x64xf32>)
   return %alloc1 : memref<?x64xf32>
@@ -156,22 +156,22 @@ func.func @no_reuse_different_dynamic(
 //
 // CHECK-LABEL: func.func @subview_extends_lifetime
 // CHECK:         %[[A:.*]] = memref.alloc()
-// CHECK:         hip.hipblaslt.matmul
+// CHECK:         hip.matmul
 // CHECK:         memref.subview %[[A]]
 // CHECK:         %[[B:.*]] = memref.alloc()
 // CHECK:         memref.cast
-// CHECK:         hip.hipblaslt.matmul
+// CHECK:         hip.matmul
 // CHECK:         return %[[B]]
 func.func @subview_extends_lifetime(
     %ctx: !hip.context,
     %a: memref<2x64x64xf32, strided<[?, ?, ?], offset: ?>>,
     %b: memref<64x64xf32, strided<[?, ?], offset: ?>>) -> memref<2x64x64xf32> {
   %alloc0 = memref.alloc() {alignment = 64 : i64} : memref<2x64x64xf32>
-  hip.hipblaslt.matmul(%ctx) ins(%a, %b : memref<2x64x64xf32, strided<[?, ?, ?], offset: ?>>, memref<64x64xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<2x64x64xf32>)
+  hip.matmul(%ctx) ins(%a, %b : memref<2x64x64xf32, strided<[?, ?, ?], offset: ?>>, memref<64x64xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<2x64x64xf32>)
   %sv = memref.subview %alloc0[0, 0, 0][1, 64, 64][1, 1, 1] : memref<2x64x64xf32> to memref<1x64x64xf32, strided<[4096, 64, 1]>>
   %alloc1 = memref.alloc() {alignment = 64 : i64} : memref<2x64x64xf32>
   %cast = memref.cast %sv : memref<1x64x64xf32, strided<[4096, 64, 1]>> to memref<1x64x64xf32, strided<[?, ?, ?], offset: ?>>
-  hip.hipblaslt.matmul(%ctx) ins(%cast, %b : memref<1x64x64xf32, strided<[?, ?, ?], offset: ?>>, memref<64x64xf32, strided<[?, ?], offset: ?>>) outs(%alloc1 : memref<2x64x64xf32>)
+  hip.matmul(%ctx) ins(%cast, %b : memref<1x64x64xf32, strided<[?, ?, ?], offset: ?>>, memref<64x64xf32, strided<[?, ?], offset: ?>>) outs(%alloc1 : memref<2x64x64xf32>)
   return %alloc1 : memref<2x64x64xf32>
 }
 
@@ -199,7 +199,7 @@ func.func @no_reuse_different_element_type(
     %b: memref<64x64xf32, strided<[?, ?], offset: ?>>,
     %c: memref<64xf16>) -> memref<64xf16> {
   %alloc0 = memref.alloc() : memref<64xf32>
-  hip.hipblaslt.matmul(%ctx) ins(%a, %b : memref<2x64x64xf32, strided<[?, ?, ?], offset: ?>>, memref<64x64xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<64xf32>)
+  hip.matmul(%ctx) ins(%a, %b : memref<2x64x64xf32, strided<[?, ?, ?], offset: ?>>, memref<64x64xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<64xf32>)
   %alloc1 = memref.alloc() : memref<64xf16>
   hip.miopen.softmax(%ctx) ins(%c : memref<64xf16>) outs(%alloc1 : memref<64xf16>)
   return %alloc1 : memref<64xf16>

--- a/test/lit/Dialect/hip-pool-allocs.mlir
+++ b/test/lit/Dialect/hip-pool-allocs.mlir
@@ -24,7 +24,7 @@
 // CHECK-DAG:     %[[OFF0:.*]] = arith.constant 0 : index
 // CHECK-DAG:     %[[OFF1:.*]] = arith.constant 256 : index
 // CHECK:         %[[V0:.*]] = memref.view %[[POOL]][%[[OFF0]]][] : memref<?xi8> to memref<8x8xf32>
-// CHECK:         hip.hipblaslt.matmul{{.*}}outs(%[[V0]] :
+// CHECK:         hip.matmul{{.*}}outs(%[[V0]] :
 // CHECK:         %[[V1:.*]] = memref.view %[[POOL]][%[[OFF1]]][] : memref<?xi8> to memref<8x8xf32>
 // CHECK:         hip.miopen.softmax{{.*}}outs(%[[V1]] :
 // CHECK:         return %[[V1]]
@@ -33,7 +33,7 @@ func.func @static_two_allocs(
     %a: memref<8x8xf32, strided<[?, ?], offset: ?>>,
     %b: memref<8x8xf32, strided<[?, ?], offset: ?>>) -> memref<8x8xf32> {
   %alloc0 = memref.alloc() : memref<8x8xf32>
-  hip.hipblaslt.matmul(%ctx) ins(%a, %b : memref<8x8xf32, strided<[?, ?], offset: ?>>, memref<8x8xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<8x8xf32>)
+  hip.matmul(%ctx) ins(%a, %b : memref<8x8xf32, strided<[?, ?], offset: ?>>, memref<8x8xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<8x8xf32>)
   %alloc1 = memref.alloc() : memref<8x8xf32>
   hip.miopen.softmax(%ctx) ins(%alloc0 : memref<8x8xf32>) outs(%alloc1 : memref<8x8xf32>)
   return %alloc1 : memref<8x8xf32>
@@ -54,7 +54,7 @@ func.func @static_three_allocs_overlap(
     %a: memref<8x8xf32, strided<[?, ?], offset: ?>>,
     %b: memref<8x8xf32, strided<[?, ?], offset: ?>>) -> memref<8x8xf32> {
   %alloc0 = memref.alloc() : memref<8x8xf32>
-  hip.hipblaslt.matmul(%ctx) ins(%a, %b : memref<8x8xf32, strided<[?, ?], offset: ?>>, memref<8x8xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<8x8xf32>)
+  hip.matmul(%ctx) ins(%a, %b : memref<8x8xf32, strided<[?, ?], offset: ?>>, memref<8x8xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<8x8xf32>)
   %alloc1 = memref.alloc() : memref<8x8xf32>
   hip.miopen.softmax(%ctx) ins(%alloc0 : memref<8x8xf32>) outs(%alloc1 : memref<8x8xf32>)
   %alloc2 = memref.alloc() : memref<8x8xf32>
@@ -78,7 +78,7 @@ func.func @mixed_element_types(
     %b: memref<8x8xf32, strided<[?, ?], offset: ?>>,
     %c: memref<8x8xf16>) -> memref<8x8xf16> {
   %alloc0 = memref.alloc() : memref<8x8xf32>
-  hip.hipblaslt.matmul(%ctx) ins(%a, %b : memref<8x8xf32, strided<[?, ?], offset: ?>>, memref<8x8xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<8x8xf32>)
+  hip.matmul(%ctx) ins(%a, %b : memref<8x8xf32, strided<[?, ?], offset: ?>>, memref<8x8xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<8x8xf32>)
   %alloc1 = memref.alloc() : memref<8x8xf16>
   hip.miopen.softmax(%ctx) ins(%c : memref<8x8xf16>) outs(%alloc1 : memref<8x8xf16>)
   return %alloc1 : memref<8x8xf16>
@@ -95,7 +95,7 @@ func.func @single_alloc_noop(
     %a: memref<8x8xf32, strided<[?, ?], offset: ?>>,
     %b: memref<8x8xf32, strided<[?, ?], offset: ?>>) -> memref<8x8xf32> {
   %alloc0 = memref.alloc() : memref<8x8xf32>
-  hip.hipblaslt.matmul(%ctx) ins(%a, %b : memref<8x8xf32, strided<[?, ?], offset: ?>>, memref<8x8xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<8x8xf32>)
+  hip.matmul(%ctx) ins(%a, %b : memref<8x8xf32, strided<[?, ?], offset: ?>>, memref<8x8xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<8x8xf32>)
   return %alloc0 : memref<8x8xf32>
 }
 
@@ -128,7 +128,7 @@ func.func @dynamic_two_allocs_same_size(
     %b: memref<8x8xf32, strided<[?, ?], offset: ?>>,
     %n: index) -> memref<?x8xf32> {
   %alloc0 = memref.alloc(%n) : memref<?x8xf32>
-  hip.hipblaslt.matmul(%ctx) ins(%a, %b : memref<?x8xf32>, memref<8x8xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<?x8xf32>)
+  hip.matmul(%ctx) ins(%a, %b : memref<?x8xf32>, memref<8x8xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<?x8xf32>)
   %alloc1 = memref.alloc(%n) : memref<?x8xf32>
   hip.miopen.softmax(%ctx) ins(%alloc0 : memref<?x8xf32>) outs(%alloc1 : memref<?x8xf32>)
   return %alloc1 : memref<?x8xf32>
@@ -151,7 +151,7 @@ func.func @mixed_static_dynamic(
     %c: memref<?x8xf32>,
     %n: index) -> memref<?x8xf32> {
   %alloc0 = memref.alloc() : memref<8x8xf32>
-  hip.hipblaslt.matmul(%ctx) ins(%a, %b : memref<8x8xf32, strided<[?, ?], offset: ?>>, memref<8x8xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<8x8xf32>)
+  hip.matmul(%ctx) ins(%a, %b : memref<8x8xf32, strided<[?, ?], offset: ?>>, memref<8x8xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<8x8xf32>)
   %alloc1 = memref.alloc(%n) : memref<?x8xf32>
   hip.miopen.softmax(%ctx) ins(%c : memref<?x8xf32>) outs(%alloc1 : memref<?x8xf32>)
   return %alloc1 : memref<?x8xf32>
@@ -203,7 +203,7 @@ func.func @dynamic_two_buckets(
     %c: memref<?x4xf32>,
     %n: index, %m: index) -> memref<?x4xf32> {
   %alloc0 = memref.alloc(%n) : memref<?x8xf32>
-  hip.hipblaslt.matmul(%ctx) ins(%a, %b : memref<?x8xf32>, memref<8x8xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<?x8xf32>)
+  hip.matmul(%ctx) ins(%a, %b : memref<?x8xf32>, memref<8x8xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<?x8xf32>)
   %alloc1 = memref.alloc(%m) : memref<?x4xf32>
   hip.miopen.softmax(%ctx) ins(%c : memref<?x4xf32>) outs(%alloc1 : memref<?x4xf32>)
   return %alloc1 : memref<?x4xf32>
@@ -223,7 +223,7 @@ func.func @metadata_attributes(
     %a: memref<8x8xf32, strided<[?, ?], offset: ?>>,
     %b: memref<8x8xf32, strided<[?, ?], offset: ?>>) -> memref<8x8xf32> {
   %alloc0 = memref.alloc() : memref<8x8xf32>
-  hip.hipblaslt.matmul(%ctx) ins(%a, %b : memref<8x8xf32, strided<[?, ?], offset: ?>>, memref<8x8xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<8x8xf32>)
+  hip.matmul(%ctx) ins(%a, %b : memref<8x8xf32, strided<[?, ?], offset: ?>>, memref<8x8xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<8x8xf32>)
   %alloc1 = memref.alloc() : memref<8x8xf32>
   hip.miopen.softmax(%ctx) ins(%alloc0 : memref<8x8xf32>) outs(%alloc1 : memref<8x8xf32>)
   return %alloc1 : memref<8x8xf32>
@@ -265,7 +265,7 @@ func.func @dynamic_metadata(
     %b: memref<8x8xf32, strided<[?, ?], offset: ?>>,
     %n: index) -> memref<?x8xf32> {
   %alloc0 = memref.alloc(%n) : memref<?x8xf32>
-  hip.hipblaslt.matmul(%ctx) ins(%a, %b : memref<?x8xf32>, memref<8x8xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<?x8xf32>)
+  hip.matmul(%ctx) ins(%a, %b : memref<?x8xf32>, memref<8x8xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<?x8xf32>)
   %alloc1 = memref.alloc(%n) : memref<?x8xf32>
   hip.miopen.softmax(%ctx) ins(%alloc0 : memref<?x8xf32>) outs(%alloc1 : memref<?x8xf32>)
   return %alloc1 : memref<?x8xf32>

--- a/test/lit/Pipeline/pipeline-attention.mlir
+++ b/test/lit/Pipeline/pipeline-attention.mlir
@@ -41,15 +41,15 @@ func.func @attention_pipeline(
 
   // Q = X @ Wq  [B,S,D] @ [D,D] -> [B,S,D]
   %e0 = tensor.empty() : tensor<2x64x64xf32>
-  %Q = hip.hipblaslt.matmul(%ctx) ins(%X, %Wq : tensor<2x64x64xf32>, tensor<64x64xf32>) outs(%e0 : tensor<2x64x64xf32>) -> tensor<2x64x64xf32>
+  %Q = hip.matmul(%ctx) ins(%X, %Wq : tensor<2x64x64xf32>, tensor<64x64xf32>) outs(%e0 : tensor<2x64x64xf32>) : tensor<2x64x64xf32>
 
   // K = X @ Wk
   %e1 = tensor.empty() : tensor<2x64x64xf32>
-  %K = hip.hipblaslt.matmul(%ctx) ins(%X, %Wk : tensor<2x64x64xf32>, tensor<64x64xf32>) outs(%e1 : tensor<2x64x64xf32>) -> tensor<2x64x64xf32>
+  %K = hip.matmul(%ctx) ins(%X, %Wk : tensor<2x64x64xf32>, tensor<64x64xf32>) outs(%e1 : tensor<2x64x64xf32>) : tensor<2x64x64xf32>
 
   // V = X @ Wv
   %e2 = tensor.empty() : tensor<2x64x64xf32>
-  %V = hip.hipblaslt.matmul(%ctx) ins(%X, %Wv : tensor<2x64x64xf32>, tensor<64x64xf32>) outs(%e2 : tensor<2x64x64xf32>) -> tensor<2x64x64xf32>
+  %V = hip.matmul(%ctx) ins(%X, %Wv : tensor<2x64x64xf32>, tensor<64x64xf32>) outs(%e2 : tensor<2x64x64xf32>) : tensor<2x64x64xf32>
 
   // KT = transpose(K, 1, 2)  [B,S,D] -> [B,D,S]
   %e3 = tensor.empty() : tensor<2x64x64xf32>
@@ -57,7 +57,7 @@ func.func @attention_pipeline(
 
   // scores = Q @ KT  [B,S,D] @ [B,D,S] -> [B,S,S]
   %e4 = tensor.empty() : tensor<2x64x64xf32>
-  %scores = hip.hipblaslt.matmul(%ctx) ins(%Q, %KT : tensor<2x64x64xf32>, tensor<2x64x64xf32>) outs(%e4 : tensor<2x64x64xf32>) -> tensor<2x64x64xf32>
+  %scores = hip.matmul(%ctx) ins(%Q, %KT : tensor<2x64x64xf32>, tensor<2x64x64xf32>) outs(%e4 : tensor<2x64x64xf32>) : tensor<2x64x64xf32>
 
   // scaled = scores * (1/sqrt(D))
   %e5 = tensor.empty() : tensor<2x64x64xf32>
@@ -69,7 +69,7 @@ func.func @attention_pipeline(
 
   // out = probs @ V  [B,S,S] @ [B,S,D] -> [B,S,D]
   %e7 = tensor.empty() : tensor<2x64x64xf32>
-  %out = hip.hipblaslt.matmul(%ctx) ins(%probs, %V : tensor<2x64x64xf32>, tensor<2x64x64xf32>) outs(%e7 : tensor<2x64x64xf32>) -> tensor<2x64x64xf32>
+  %out = hip.matmul(%ctx) ins(%probs, %V : tensor<2x64x64xf32>, tensor<2x64x64xf32>) outs(%e7 : tensor<2x64x64xf32>) : tensor<2x64x64xf32>
 
   return %out : tensor<2x64x64xf32>
 }

--- a/test/lit/Pipeline/pipeline-pool-lower.mlir
+++ b/test/lit/Pipeline/pipeline-pool-lower.mlir
@@ -21,7 +21,7 @@
 // CHECK:         %[[POOL_SIZE:.*]] = llvm.mlir.constant(512 : index) : i64
 // CHECK:         llvm.call @hipdnn_ep_get_pool_base(%[[CTX]], %[[POOL_SIZE]]) : (!llvm.ptr, i64) -> !llvm.ptr
 // CHECK:         llvm.mlir.constant(256 : index) : i64
-// CHECK:         llvm.call @hip_hipblaslt_matmul(%[[CTX]],
+// CHECK:         llvm.call @wrap_hipblasLtMatmul(%[[CTX]],
 // CHECK:         llvm.call @hip_miopen_softmax(%[[CTX]],
 // CHECK:         llvm.return
 func.func @static_pool_to_llvm(
@@ -29,7 +29,7 @@ func.func @static_pool_to_llvm(
     %a: memref<8x8xf32, strided<[?, ?], offset: ?>>,
     %b: memref<8x8xf32, strided<[?, ?], offset: ?>>) -> memref<8x8xf32> {
   %alloc0 = memref.alloc() : memref<8x8xf32>
-  hip.hipblaslt.matmul(%ctx) ins(%a, %b : memref<8x8xf32, strided<[?, ?], offset: ?>>, memref<8x8xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<8x8xf32>)
+  hip.matmul(%ctx) ins(%a, %b : memref<8x8xf32, strided<[?, ?], offset: ?>>, memref<8x8xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<8x8xf32>)
   %alloc1 = memref.alloc() : memref<8x8xf32>
   hip.miopen.softmax(%ctx) ins(%alloc0 : memref<8x8xf32>) outs(%alloc1 : memref<8x8xf32>)
   return %alloc1 : memref<8x8xf32>
@@ -45,7 +45,7 @@ func.func @static_pool_to_llvm(
 // CHECK:         %[[C32:[a-z0-9_]+]] = llvm.mlir.constant(32 : index) : i64
 // CHECK:         llvm.mul %arg15, %[[C32]] : i64
 // CHECK:         llvm.call @hipdnn_ep_get_pool_base(%[[CTX2]], %{{[0-9]+}}) : (!llvm.ptr, i64) -> !llvm.ptr
-// CHECK:         llvm.call @hip_hipblaslt_matmul(%[[CTX2]],
+// CHECK:         llvm.call @wrap_hipblasLtMatmul(%[[CTX2]],
 // CHECK:         llvm.call @hip_miopen_softmax(%[[CTX2]],
 // CHECK:         llvm.return
 func.func @dynamic_pool_to_llvm(
@@ -54,7 +54,7 @@ func.func @dynamic_pool_to_llvm(
     %b: memref<8x8xf32, strided<[?, ?], offset: ?>>,
     %n: index) -> memref<?x8xf32> {
   %alloc0 = memref.alloc(%n) : memref<?x8xf32>
-  hip.hipblaslt.matmul(%ctx) ins(%a, %b : memref<?x8xf32>, memref<8x8xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<?x8xf32>)
+  hip.matmul(%ctx) ins(%a, %b : memref<?x8xf32>, memref<8x8xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<?x8xf32>)
   %alloc1 = memref.alloc(%n) : memref<?x8xf32>
   hip.miopen.softmax(%ctx) ins(%alloc0 : memref<?x8xf32>) outs(%alloc1 : memref<?x8xf32>)
   return %alloc1 : memref<?x8xf32>

--- a/tools/hip-mlir-opt/hip-mlir-opt.cpp
+++ b/tools/hip-mlir-opt/hip-mlir-opt.cpp
@@ -106,8 +106,8 @@ void registerHipBufferizableOpInterfaceModels(mlir::DialectRegistry &registry) {
         HipDstBufferizableModel<mlir::hip::RmsNormOp>>(*ctx);
     mlir::hip::SkipRmsNormOp::attachInterface<
         HipDstBufferizableModel<mlir::hip::SkipRmsNormOp>>(*ctx);
-    mlir::hip::MiopenRopeOp::attachInterface<
-        HipDstBufferizableModel<mlir::hip::MiopenRopeOp>>(*ctx);
+    mlir::hip::RopeOp::attachInterface<
+        HipDstBufferizableModel<mlir::hip::RopeOp>>(*ctx);
     mlir::hip::MiopenAddOp::attachInterface<
         HipDstBufferizableModel<mlir::hip::MiopenAddOp>>(*ctx);
     mlir::hip::MulOp::attachInterface<

--- a/tools/hip-mlir-opt/hip-mlir-opt.cpp
+++ b/tools/hip-mlir-opt/hip-mlir-opt.cpp
@@ -100,8 +100,8 @@ void registerHipBufferizableOpInterfaceModels(mlir::DialectRegistry &registry) {
   registry.addExtension(+[](mlir::MLIRContext *ctx, mlir::hip::HipDialect *) {
     mlir::hip::ConvOp::attachInterface<
         HipDstBufferizableModel<mlir::hip::ConvOp>>(*ctx);
-    mlir::hip::HipblasltMatmulOp::attachInterface<
-        HipDstBufferizableModel<mlir::hip::HipblasltMatmulOp>>(*ctx);
+    mlir::hip::MatmulOp::attachInterface<
+        HipDstBufferizableModel<mlir::hip::MatmulOp>>(*ctx);
     mlir::hip::RmsNormOp::attachInterface<
         HipDstBufferizableModel<mlir::hip::RmsNormOp>>(*ctx);
     mlir::hip::SkipRmsNormOp::attachInterface<


### PR DESCRIPTION
## Summary

Port four key LLaMA operations from PR-17 to main branch with improvements:
- **hip.rope** - Rotary position embedding
- **hip.matmul** - Matrix multiplication (renamed from hip.hipblaslt.matmul)
- **hip.gqa** - Group query attention (upgraded interface)
- **hip.gather** - Gather operation with axis attribute support

## Changes

### 1. hip.rope (Rotary Position Embedding)

**Operation redesign:**
- **Rename**: `hip.miopen.rope` → `hip.rope` (remove backend prefix)
- **Signature**: Replace in-place Q/K modification with standard DPS (single input → output)
  - Old: `(ctx, start_pos, cos_cache, sin_cache, q, k)` - 6 params
  - New: `(ctx, input, position_ids, cos_cache, sin_cache, output)` - 6 params + 3 attributes
- **Attributes**: Add `interleaved`, `num_heads`, `rotary_embedding_dim`
- **Assembly format**: Declarative (not custom)
- **Kept**: `$ctx` parameter naming (not `$handle` as in PR-17)

**LLVM lowering:**
- Runtime function: `wrap_rotary_embedding` (was `hip_miopen_rope`)
- Parameters: 12 (6 pointers + 6 i64 values)
- Supports dynamic shapes via `computeNumElements()` utility

**ONNX conversion:**
- Pattern: `RotaryEmbeddingToHip` for `com.microsoft::RotaryEmbedding`
- Attribute inference: When `num_heads=0` or `rotary_embedding_dim=0`, infer from shapes:
  - `rotary_dim = cos_cache.shape[-1] * 2`
  - `num_heads = input.shape[-1] / rotary_dim`

**Runtime function signature:**
```cpp
int wrap_rotary_embedding(
    RuntimeState* state,
    void* input,
    void* position_ids,
    void* cos_cache,
    void* sin_cache,
    void* output,
    int64_t interleaved,
    int64_t num_heads,
    int64_t rotary_embedding_dim,
    int64_t input_num_elements,
    int64_t cos_cache_num_elements,
    int64_t element_size_bytes)
```

**Tests:**
- ✅ `test/lit/Conversion/hip-to-llvm/test_rope.mlir` - HIP→LLVM lowering
- ✅ `test/lit/Conversion/onnx-to-hip/test_rope.mlir` - ONNX→HIP conversion
  * Static shape support with attribute inference
  * Zero num_heads/rotary_dim inference from shapes
  * Multiple test cases covering different attribute combinations

---

### 2. hip.matmul (Matrix Multiplication)

**Operation rename:**
- **Rename**: `hip.hipblaslt.matmul` → `hip.matmul` (remove backend prefix)
- **Class**: `Hip_HipblasltMatmulOp` → `Hip_MatmulOp`
- **Kept**: All functionality identical, just cleaner naming

**Dynamic shape support:**
- Added `computeNumElements()` helper for dynamic memref shapes
- Runtime passes M, N, K dimensions and batch count
- Supports mixed static/dynamic dimensions

**LLVM lowering:**
- Runtime function: `wrap_hipblaslt_matmul` (unchanged)
- Parameters: 9 (4 pointers + 5 i64 values)
- Added address space casting for GPU memory

**Runtime function signature:**
```cpp
int wrap_hipblasLtMatmul(
    RuntimeState* state,
    const void* A,
    const void* B,
    void* output,
    int64_t M,
    int64_t N,
    int64_t K,
    int64_t batch_count,
    int64_t element_size_bytes)
```

---

### 3. hip.gqa (Group Query Attention)

**Operation upgrade:**
- **Mnemonic**: Keep `"gqa"` (not renamed to "group_query_attention")
- **Interface**: Changed from in-place kv_cache to proper DPS with separate past/present
  - Old: `(ctx, ..., kv_cache)` - modify in-place
  - New: `(ctx, ..., past_key, past_value, output, present_key, present_value)` - DPS
- **Attributes**: Changed from runtime Index values to compile-time attributes:
  - `num_heads`, `kv_num_heads`, `scale`, `softcap`, `do_rotary`, `rotary_interleaved`
- **Assembly format**: Declarative (was custom)

**LLVM lowering:**
- Runtime function: `wrap_group_query_attention`
- Parameters: 24 (13 pointers + 6 attributes + 5 shape params)
- Passes NULL for cos/sin cache (RoPE done separately)
- Extracts shape info from memref types

**ONNX conversion:**
- Pattern: `GroupQueryAttentionToHip` for `com.microsoft::GroupQueryAttention`
- Handles 9 operands (7 required + 2 optional cos/sin cache as NoValue)
- Creates 3 `tensor.empty()` for DPS outputs
- Extracts 6 attributes from ONNX op

**Runtime function signature:**
```cpp
int wrap_group_query_attention(
    RuntimeState* state,
    void* query,
    void* key,
    void* value,
    void* past_key,
    void* past_value,
    void* seqlens_k,
    void* total_seq_len,
    void* cos_cache,
    void* sin_cache,
    void* output,
    void* present_key,
    void* present_value,
    int64_t num_heads,
    int64_t kv_num_heads,
    float scale,
    float softcap,
    int64_t do_rotary,
    int64_t rotary_interleaved,
    int64_t batch_size,
    int64_t seq_len_q,
    int64_t seq_len_kv,
    int64_t head_dim,
    int64_t element_size_bytes)
```

**Tests:**
- ✅ `test/lit/Conversion/hip-to-llvm/test_gqa.mlir` - HIP→LLVM lowering
- ✅ `test/lit/Conversion/onnx-to-hip/test_gqa.mlir` - ONNX→HIP conversion

---

### 4. hip.gather (Gather Operation)

**Operation upgrade:**
- **Add**: Required `axis` attribute (I64Attr) to support ONNX Gather semantics
- **Rename**: `table` → `data` parameter for ONNX consistency
- **Assembly format**: Declarative (was custom)
- **Preserve negative axis**: Pass axis=-1 as-is to runtime (no normalization)

**LLVM lowering:**
- Runtime function: `wrap_gather`
- Parameters: 8 (4 pointers + 4 i64 values)
  - Pointers: state, data, indices, output
  - Values: axis, data_num_elements, output_num_elements, element_size_bytes
- Supports dynamic shapes via `computeNumElements()`
- Uses `LLVM::Op::create` static methods for consistency

**ONNX conversion:**
- Pattern: `GatherToHip` for `onnx.Gather`
- Extracts axis attribute directly (simplified vs PR-17)
- Dynamic shape support: Uses `tensor.dim` for dynamic dimensions
- Preserves negative axis values (e.g., axis=-1) for runtime handling

**Runtime function signature:**
```cpp
int wrap_gather(
    RuntimeState* state,
    void* data,
    void* indices,
    void* output,
    int64_t axis,
    int64_t data_num_elements,
    int64_t output_num_elements,
    int64_t element_size_bytes)
```

**Tests:**
- ✅ `test/lit/Conversion/hip-to-llvm/test_gather.mlir` - HIP→LLVM lowering
- ✅ `test/lit/Conversion/onnx-to-hip/test_gather.mlir` - ONNX→HIP conversion
  * Scalar tensor support (tensor<i64>)
  * Negative axis support (axis=-1 preserved)
  * Dynamic shape support (tensor<?x?xf32>)
