### PR TITLE
Add GenerateInterface pass for C-ABI wrappers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,10 +95,12 @@ option(BUILD_HIP_TOOLS "Build HIP MLIR compiler tools (hip-mlir-opt, hip-compile
 if(BUILD_HIP_TOOLS)
   find_package(LLVM REQUIRED CONFIG)
   find_package(MLIR REQUIRED CONFIG)
+  find_package(flatbuffers REQUIRED CONFIG)
 
   message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
   message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
   message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
+  message(STATUS "Using FlatBuffers version: ${flatbuffers_VERSION}")
 
   separate_arguments(LLVM_DEFINITIONS_LIST NATIVE_COMMAND ${LLVM_DEFINITIONS})
   add_definitions(${LLVM_DEFINITIONS_LIST})
@@ -119,6 +121,9 @@ if(BUILD_HIP_TOOLS)
   include(AddMLIR)
 
   llvm_map_components_to_libnames(llvm_libs Support Core)
+
+  # FlatBuffers schemas (GenerateInterface pass metadata)
+  add_subdirectory(schemas)
 
   # TableGen targets
   add_subdirectory(include/hip)

--- a/include/hip/Dialect/Transforms/Passes.h
+++ b/include/hip/Dialect/Transforms/Passes.h
@@ -6,9 +6,12 @@
 #define HIP_PASSES_H
 
 #include "mlir/Pass/Pass.h"
+#include <memory>
+#include <string>
 
-namespace mlir {
-namespace hip {
+namespace mlir::hip {
+
+struct CompilationOptionsT;
 
 #define GEN_PASS_DECL
 #include "hip/Dialect/Transforms/Passes.h.inc"
@@ -16,7 +19,13 @@ namespace hip {
 #define GEN_PASS_REGISTRATION
 #include "hip/Dialect/Transforms/Passes.h.inc"
 
-} // namespace hip
-} // namespace mlir
+/// Creates a pass that generates the C interface for the compiled module.
+/// Transforms @main_graph to produce four C-ABI wrapper functions:
+/// inference_init, inference_compute, inference_cleanup,
+/// inference_get_metadata_json.
+std::unique_ptr<mlir::Pass>
+createGenerateInterfacePass(const CompilationOptionsT &options);
+
+} // namespace mlir::hip
 
 #endif // HIP_PASSES_H

--- a/include/hip/Dialect/Transforms/Pipelines.h
+++ b/include/hip/Dialect/Transforms/Pipelines.h
@@ -30,6 +30,17 @@ struct OnnxToHipPipelineOptions
       llvm::cl::init(0)};
 };
 
+/// Pipeline options for the HIP-to-LLVM lowering pipeline.
+/// Controls the GenerateInterface pass at the end of the pipeline.
+struct HipToLLVMPipelineOptions
+    : public PassPipelineOptions<HipToLLVMPipelineOptions> {
+  Option<std::string> constantsFile{
+      *this, "constants-file",
+      llvm::cl::desc(
+          "Constants filename embedded in metadata (default: constants.bin)"),
+      llvm::cl::init("constants.bin")};
+};
+
 /// Build the ONNX-to-HIP compilation pipeline. This is the main pipeline
 /// that takes ONNX-level tensor IR and produces fully bufferized HIP memref
 /// IR with pooled allocations and resolved extern constants. The pipeline
@@ -42,7 +53,13 @@ void buildOnnxToHipPipeline(OpPassManager &pm,
 /// (not part of buildOnnxToHipPipeline) because the LLVM lowering is only
 /// needed when producing executables via hip-compiler, not when inspecting
 /// intermediate HIP memref IR via hip-mlir-opt.
-void buildHipToLLVMPipeline(OpPassManager &pm);
+///
+/// The pipeline lowers HIP dialect ops to LLVM IR and appends a
+/// GenerateInterface pass that creates four C-ABI wrapper functions
+/// (inference_init, inference_compute, inference_cleanup,
+/// inference_get_metadata_json).
+void buildHipToLLVMPipeline(OpPassManager &pm,
+                            const HipToLLVMPipelineOptions &options);
 
 /// Register both pipelines with MLIR's global pass registry so they appear
 /// in hip-mlir-opt --help and are usable as single-flag invocations.

--- a/include/hip/debug_log.h
+++ b/include/hip/debug_log.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#pragma once
+
+#include "llvm/Support/raw_ostream.h"
+#include <cstdlib>
+
+inline bool hipdnn_ep_debug_enabled() {
+  static const bool enabled = [] {
+    const char *v = std::getenv("HIPDNN_EP_DEBUG");
+    return v && v[0] >= '1';
+  }();
+  return enabled;
+}
+
+#define COMPILER_DEBUG_LOG(expr)                                                \
+  do {                                                                         \
+    if (hipdnn_ep_debug_enabled())                                             \
+      llvm::errs() << expr;                                                    \
+  } while (0)

--- a/include/hip/debug_log.h
+++ b/include/hip/debug_log.h
@@ -15,7 +15,7 @@ inline bool hipdnn_ep_debug_enabled() {
   return enabled;
 }
 
-#define COMPILER_DEBUG_LOG(expr)                                                \
+#define COMPILER_DEBUG_LOG(expr)                                               \
   do {                                                                         \
     if (hipdnn_ep_debug_enabled())                                             \
       llvm::errs() << expr;                                                    \

--- a/include/hip/flatbuffers_json.h
+++ b/include/hip/flatbuffers_json.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#pragma once
+
+/// Schema-driven JSON <-> FlatBuffers native struct helpers.
+///
+/// Both helpers go through FlatBuffers binary as an intermediate:
+///   toJson:   NativeT -> Pack() -> binary -> GenerateText() -> JSON string
+///   fromJson: JSON string -> ParseJson() -> binary -> UnPackTo() -> NativeT
+///
+/// Template parameter: NativeT (e.g. CompilationOptionsT, HipModelMetaInfoT)
+/// FlatT (the binary accessor class) is derived via NativeT::TableType so
+/// callers never need to mention it.
+
+#include "flatbuffers/idl.h"
+
+#include <string>
+
+namespace mlir {
+namespace hip {
+
+template <typename NativeT>
+std::string toJson(const NativeT &native, const char *schema) {
+  using FlatT = typename NativeT::TableType;
+
+  flatbuffers::FlatBufferBuilder fbb;
+  fbb.Finish(FlatT::Pack(fbb, &native));
+
+  flatbuffers::Parser parser;
+  // strict_json=true outputs quoted field names (standard JSON).
+  // Without this, GenerateText produces FlatBuffers relaxed JSON with
+  // unquoted keys, which standard JSON parsers reject.
+  parser.opts.strict_json = true;
+  parser.Parse(schema);
+
+  std::string json;
+  flatbuffers::GenerateText(parser, fbb.GetBufferPointer(), &json);
+  return json;
+}
+
+template <typename NativeT>
+bool fromJson(const std::string &json, const char *schema, NativeT &result,
+              std::string &error) {
+  flatbuffers::Parser parser;
+  if (!parser.Parse(schema)) {
+    error = "Schema parse error: " + std::string(parser.error_);
+    return false;
+  }
+  if (!parser.ParseJson(json.c_str())) {
+    error = "JSON parse error: " + std::string(parser.error_);
+    return false;
+  }
+  flatbuffers::GetRoot<typename NativeT::TableType>(
+      parser.builder_.GetBufferPointer())
+      ->UnPackTo(&result);
+  return true;
+}
+
+} // namespace hip
+} // namespace mlir

--- a/include/hip/flatbuffers_json.h
+++ b/include/hip/flatbuffers_json.h
@@ -23,7 +23,8 @@ namespace mlir {
 namespace hip {
 
 template <typename NativeT>
-std::string toJson(const NativeT &native, const char *schema) {
+bool toJson(const NativeT &native, const char *schema, std::string &result,
+            std::string &error) {
   using FlatT = typename NativeT::TableType;
 
   flatbuffers::FlatBufferBuilder fbb;
@@ -34,11 +35,13 @@ std::string toJson(const NativeT &native, const char *schema) {
   // Without this, GenerateText produces FlatBuffers relaxed JSON with
   // unquoted keys, which standard JSON parsers reject.
   parser.opts.strict_json = true;
-  parser.Parse(schema);
+  if (!parser.Parse(schema)) {
+    error = "Schema parse error: " + std::string(parser.error_);
+    return false;
+  }
 
-  std::string json;
-  flatbuffers::GenerateText(parser, fbb.GetBufferPointer(), &json);
-  return json;
+  flatbuffers::GenerateText(parser, fbb.GetBufferPointer(), &result);
+  return true;
 }
 
 template <typename NativeT>

--- a/lib/Dialect/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Transforms/CMakeLists.txt
@@ -6,6 +6,7 @@
 add_library(HipDialectTransforms STATIC
   AddHipContextArg.cpp
   BufferUtils.cpp
+  GenerateInterface.cpp
   LowerAllocs.cpp
   OptimizeMemRefs.cpp
   Pipelines.cpp
@@ -18,17 +19,20 @@ add_dependencies(HipDialectTransforms
   HipTypesIncGen
   HipOpsIncGen
   HipPassesIncGen
+  HipSchemas
 )
 
 target_link_libraries(HipDialectTransforms PUBLIC
   HipDialectIR
   HipToLLVM
   OnnxToHip
+  HipSchemasLib
   MLIRPass
   MLIRTransforms
   MLIRFuncDialect
   MLIRMemRefDialect
   MLIRArithDialect
+  MLIRLLVMDialect
   MLIRBufferizationDialect
   MLIRBufferizationTransforms
   MLIRBufferizationPipelines
@@ -37,4 +41,5 @@ target_link_libraries(HipDialectTransforms PUBLIC
   MLIRMemRefToLLVM
   MLIRFuncToLLVM
   MLIRReconcileUnrealizedCasts
+  flatbuffers::flatbuffers
 )

--- a/lib/Dialect/Transforms/GenerateInterface.cpp
+++ b/lib/Dialect/Transforms/GenerateInterface.cpp
@@ -228,8 +228,6 @@ public:
     std::vector<uint8_t> blob = buildMetadataBlob(module, constantsFile);
     generateMetadataBlobGlobal(module, blob);
 
-    declareMallocFree(module);
-
     declareRuntimeFunctions(module);
 
     generateInferenceInit(module, blob.size());
@@ -268,247 +266,61 @@ private:
         ctx, {ptrType, ptrType, i64Type, sizeArrayType, strideArrayType});
   }
 
-  void declareMallocFree(ModuleOp module) {
-    OpBuilder builder(module.getContext());
-    Location loc = module.getLoc();
-    Type ptrType = LLVM::LLVMPointerType::get(builder.getContext(), 0);
+  struct RuntimeFuncSpec {
+    llvm::StringRef name;
+    Type resultType;
+    SmallVector<Type, 4> paramTypes;
+  };
 
-    auto &firstOp = module.getBody()->front();
-    builder.setInsertionPoint(&firstOp);
-
-    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("malloc")) {
-      auto mallocFuncType =
-          LLVM::LLVMFunctionType::get(ptrType, {builder.getI64Type()});
-      auto mallocFunc =
-          LLVM::LLVMFuncOp::create(builder, loc, "malloc", mallocFuncType);
-      mallocFunc.setLinkage(LLVM::Linkage::External);
-    }
-
-    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("free")) {
-      auto freeFuncType = LLVM::LLVMFunctionType::get(
-          LLVM::LLVMVoidType::get(builder.getContext()), {ptrType});
-      auto freeFunc =
-          LLVM::LLVMFuncOp::create(builder, loc, "free", freeFuncType);
-      freeFunc.setLinkage(LLVM::Linkage::External);
-    }
+  SmallVector<RuntimeFuncSpec> getRuntimeFuncSpecs(OpBuilder &builder) {
+    Type ptr = LLVM::LLVMPointerType::get(builder.getContext(), 0);
+    Type i32 = builder.getI32Type();
+    Type i64 = builder.getI64Type();
+    Type vd = LLVM::LLVMVoidType::get(builder.getContext());
+    return {
+        {"malloc", ptr, {i64}},
+        {"free", vd, {ptr}},
+        {"hipStreamCreate", i32, {ptr}},
+        {"hipStreamDestroy", i32, {ptr}},
+        {"hipStreamSynchronize", i32, {ptr}},
+        {"miopenCreate", i32, {ptr}},
+        {"miopenSetStream", i32, {ptr, ptr}},
+        {"miopenDestroy", i32, {ptr}},
+        {"hipblasLtCreate", i32, {ptr}},
+        {"hipblasLtDestroy", i32, {ptr}},
+        {"hipdnn_ep_state_cleanup", i32, {ptr}},
+        {"wrap_hipMalloc", i32, {ptr, i64}},
+        {"wrap_hipFree", i32, {ptr}},
+        {"wrap_hipMemcpyH2D", i32, {ptr, ptr, i64, ptr}},
+        {"wrap_hipMemcpyD2H", i32, {ptr, ptr, i64, ptr}},
+        {"wrap_hipStreamSynchronize", i32, {ptr}},
+        {"hipdnn_ep_state_get_stream", ptr, {ptr}},
+        {"hipdnn_ep_pool_init", i32, {ptr, i64, ptr, i64}},
+        {"hipdnn_ep_get_buffer_from_pool", ptr, {ptr, i64}},
+        {"hipdnn_ep_tensor_prepare_input", i32, {ptr, ptr, i64, i64, ptr}},
+        {"hipdnn_ep_tensor_prepare_output", i32, {ptr, ptr, i64, i64, ptr}},
+        {"hipdnn_ep_tensor_finalize_output", i32, {ptr, ptr}},
+        {"hipdnn_ep_tensor_free_input", vd, {ptr, ptr}},
+        {"hipdnn_ep_tensor_buffer_get_gpu_ptr", ptr, {ptr}},
+        {"hipdnn_ep_tensor_buffer_get_host_ptr", ptr, {ptr}},
+        {"hipdnn_ep_tensor_buffer_get_shape_ptr", ptr, {ptr}},
+        {"hipdnn_ep_tensor_buffer_get_rank", i64, {ptr}},
+        {"hipdnn_ep_tensor_buffer_get_size_bytes", i64, {ptr}},
+        {"hipdnn_ep_state_init_with_fs", i32, {ptr, ptr, ptr, i64}},
+    };
   }
 
   void declareRuntimeFunctions(ModuleOp module) {
     OpBuilder builder(module.getContext());
+    builder.setInsertionPoint(&module.getBody()->front());
     Location loc = module.getLoc();
-    Type ptrType = LLVM::LLVMPointerType::get(builder.getContext(), 0);
-    Type i32Type = builder.getI32Type();
-    Type i64Type = builder.getI64Type();
-    Type voidType = LLVM::LLVMVoidType::get(builder.getContext());
-
-    auto &firstOp = module.getBody()->front();
-    builder.setInsertionPoint(&firstOp);
-
-    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("hipStreamCreate")) {
-      auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType});
-      auto func =
-          LLVM::LLVMFuncOp::create(builder, loc, "hipStreamCreate", funcType);
-      func.setLinkage(LLVM::Linkage::External);
-    }
-
-    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("hipStreamDestroy")) {
-      auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType});
-      auto func =
-          LLVM::LLVMFuncOp::create(builder, loc, "hipStreamDestroy", funcType);
-      func.setLinkage(LLVM::Linkage::External);
-    }
-
-    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("hipStreamSynchronize")) {
-      auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType});
-      auto func = LLVM::LLVMFuncOp::create(builder, loc, "hipStreamSynchronize",
-                                           funcType);
-      func.setLinkage(LLVM::Linkage::External);
-    }
-
-    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("miopenCreate")) {
-      auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType});
-      auto func =
-          LLVM::LLVMFuncOp::create(builder, loc, "miopenCreate", funcType);
-      func.setLinkage(LLVM::Linkage::External);
-    }
-
-    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("miopenSetStream")) {
-      auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType, ptrType});
-      auto func =
-          LLVM::LLVMFuncOp::create(builder, loc, "miopenSetStream", funcType);
-      func.setLinkage(LLVM::Linkage::External);
-    }
-
-    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("miopenDestroy")) {
-      auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType});
-      auto func =
-          LLVM::LLVMFuncOp::create(builder, loc, "miopenDestroy", funcType);
-      func.setLinkage(LLVM::Linkage::External);
-    }
-
-    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("hipblasLtCreate")) {
-      auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType});
-      auto func =
-          LLVM::LLVMFuncOp::create(builder, loc, "hipblasLtCreate", funcType);
-      func.setLinkage(LLVM::Linkage::External);
-    }
-
-    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("hipblasLtDestroy")) {
-      auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType});
-      auto func =
-          LLVM::LLVMFuncOp::create(builder, loc, "hipblasLtDestroy", funcType);
-      func.setLinkage(LLVM::Linkage::External);
-    }
-
-    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("hipdnn_ep_state_cleanup")) {
-      auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType});
-      auto func = LLVM::LLVMFuncOp::create(builder, loc,
-                                           "hipdnn_ep_state_cleanup", funcType);
-      func.setLinkage(LLVM::Linkage::External);
-    }
-
-    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("wrap_hipMalloc")) {
-      auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType, i64Type});
-      auto func =
-          LLVM::LLVMFuncOp::create(builder, loc, "wrap_hipMalloc", funcType);
-      func.setLinkage(LLVM::Linkage::External);
-    }
-
-    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("wrap_hipFree")) {
-      auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType});
-      auto func =
-          LLVM::LLVMFuncOp::create(builder, loc, "wrap_hipFree", funcType);
-      func.setLinkage(LLVM::Linkage::External);
-    }
-
-    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("wrap_hipMemcpyH2D")) {
-      auto funcType = LLVM::LLVMFunctionType::get(
-          i32Type, {ptrType, ptrType, i64Type, ptrType});
-      auto func =
-          LLVM::LLVMFuncOp::create(builder, loc, "wrap_hipMemcpyH2D", funcType);
-      func.setLinkage(LLVM::Linkage::External);
-    }
-
-    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("wrap_hipMemcpyD2H")) {
-      auto funcType = LLVM::LLVMFunctionType::get(
-          i32Type, {ptrType, ptrType, i64Type, ptrType});
-      auto func =
-          LLVM::LLVMFuncOp::create(builder, loc, "wrap_hipMemcpyD2H", funcType);
-      func.setLinkage(LLVM::Linkage::External);
-    }
-
-    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("wrap_hipStreamSynchronize")) {
-      auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType});
-      auto func = LLVM::LLVMFuncOp::create(
-          builder, loc, "wrap_hipStreamSynchronize", funcType);
-      func.setLinkage(LLVM::Linkage::External);
-    }
-
-    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("hipdnn_ep_state_get_stream")) {
-      auto funcType = LLVM::LLVMFunctionType::get(ptrType, {ptrType});
-      auto func = LLVM::LLVMFuncOp::create(
-          builder, loc, "hipdnn_ep_state_get_stream", funcType);
-      func.setLinkage(LLVM::Linkage::External);
-    }
-
-    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("hipdnn_ep_pool_init")) {
-      auto funcType = LLVM::LLVMFunctionType::get(
-          i32Type, {ptrType, i64Type, ptrType, i64Type});
-      auto func = LLVM::LLVMFuncOp::create(builder, loc, "hipdnn_ep_pool_init",
-                                           funcType);
-      func.setLinkage(LLVM::Linkage::External);
-    }
-
-    if (!module.lookupSymbol<LLVM::LLVMFuncOp>(
-            "hipdnn_ep_get_buffer_from_pool")) {
-      auto funcType = LLVM::LLVMFunctionType::get(ptrType, {ptrType, i64Type});
-      auto func = LLVM::LLVMFuncOp::create(
-          builder, loc, "hipdnn_ep_get_buffer_from_pool", funcType);
-      func.setLinkage(LLVM::Linkage::External);
-    }
-
-    if (!module.lookupSymbol<LLVM::LLVMFuncOp>(
-            "hipdnn_ep_tensor_prepare_input")) {
-      Type sizeTType = i64Type;
-      auto funcType = LLVM::LLVMFunctionType::get(
-          i32Type, {ptrType, ptrType, sizeTType, sizeTType, ptrType});
-      auto func = LLVM::LLVMFuncOp::create(
-          builder, loc, "hipdnn_ep_tensor_prepare_input", funcType);
-      func.setLinkage(LLVM::Linkage::External);
-    }
-
-    if (!module.lookupSymbol<LLVM::LLVMFuncOp>(
-            "hipdnn_ep_tensor_prepare_output")) {
-      Type sizeTType = i64Type;
-      auto funcType = LLVM::LLVMFunctionType::get(
-          i32Type, {ptrType, ptrType, sizeTType, sizeTType, ptrType});
-      auto func = LLVM::LLVMFuncOp::create(
-          builder, loc, "hipdnn_ep_tensor_prepare_output", funcType);
-      func.setLinkage(LLVM::Linkage::External);
-    }
-
-    if (!module.lookupSymbol<LLVM::LLVMFuncOp>(
-            "hipdnn_ep_tensor_finalize_output")) {
-      auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType, ptrType});
-      auto func = LLVM::LLVMFuncOp::create(
-          builder, loc, "hipdnn_ep_tensor_finalize_output", funcType);
-      func.setLinkage(LLVM::Linkage::External);
-    }
-
-    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("hipdnn_ep_tensor_free_input")) {
-      auto funcType = LLVM::LLVMFunctionType::get(voidType, {ptrType, ptrType});
-      auto func = LLVM::LLVMFuncOp::create(
-          builder, loc, "hipdnn_ep_tensor_free_input", funcType);
-      func.setLinkage(LLVM::Linkage::External);
-    }
-
-    if (!module.lookupSymbol<LLVM::LLVMFuncOp>(
-            "hipdnn_ep_tensor_buffer_get_gpu_ptr")) {
-      auto funcType = LLVM::LLVMFunctionType::get(ptrType, {ptrType});
-      auto func = LLVM::LLVMFuncOp::create(
-          builder, loc, "hipdnn_ep_tensor_buffer_get_gpu_ptr", funcType);
-      func.setLinkage(LLVM::Linkage::External);
-    }
-
-    if (!module.lookupSymbol<LLVM::LLVMFuncOp>(
-            "hipdnn_ep_tensor_buffer_get_host_ptr")) {
-      auto funcType = LLVM::LLVMFunctionType::get(ptrType, {ptrType});
-      auto func = LLVM::LLVMFuncOp::create(
-          builder, loc, "hipdnn_ep_tensor_buffer_get_host_ptr", funcType);
-      func.setLinkage(LLVM::Linkage::External);
-    }
-
-    if (!module.lookupSymbol<LLVM::LLVMFuncOp>(
-            "hipdnn_ep_tensor_buffer_get_shape_ptr")) {
-      auto funcType = LLVM::LLVMFunctionType::get(ptrType, {ptrType});
-      auto func = LLVM::LLVMFuncOp::create(
-          builder, loc, "hipdnn_ep_tensor_buffer_get_shape_ptr", funcType);
-      func.setLinkage(LLVM::Linkage::External);
-    }
-
-    if (!module.lookupSymbol<LLVM::LLVMFuncOp>(
-            "hipdnn_ep_tensor_buffer_get_rank")) {
-      auto funcType = LLVM::LLVMFunctionType::get(i64Type, {ptrType});
-      auto func = LLVM::LLVMFuncOp::create(
-          builder, loc, "hipdnn_ep_tensor_buffer_get_rank", funcType);
-      func.setLinkage(LLVM::Linkage::External);
-    }
-
-    if (!module.lookupSymbol<LLVM::LLVMFuncOp>(
-            "hipdnn_ep_tensor_buffer_get_size_bytes")) {
-      auto funcType = LLVM::LLVMFunctionType::get(i64Type, {ptrType});
-      auto func = LLVM::LLVMFuncOp::create(
-          builder, loc, "hipdnn_ep_tensor_buffer_get_size_bytes", funcType);
-      func.setLinkage(LLVM::Linkage::External);
-    }
-
-    if (!module.lookupSymbol<LLVM::LLVMFuncOp>(
-            "hipdnn_ep_state_init_with_fs")) {
-      auto funcType = LLVM::LLVMFunctionType::get(
-          i32Type, {ptrType, ptrType, ptrType, i64Type});
-      auto func = LLVM::LLVMFuncOp::create(
-          builder, loc, "hipdnn_ep_state_init_with_fs", funcType);
-      func.setLinkage(LLVM::Linkage::External);
+    for (auto &spec : getRuntimeFuncSpecs(builder)) {
+      if (!module.lookupSymbol<LLVM::LLVMFuncOp>(spec.name)) {
+        auto func = LLVM::LLVMFuncOp::create(
+            builder, loc, spec.name,
+            LLVM::LLVMFunctionType::get(spec.resultType, spec.paramTypes));
+        func.setLinkage(LLVM::Linkage::External);
+      }
     }
   }
 

--- a/lib/Dialect/Transforms/GenerateInterface.cpp
+++ b/lib/Dialect/Transforms/GenerateInterface.cpp
@@ -620,9 +620,15 @@ private:
     SmallVector<Value> inputBuffers;
     SmallVector<Value> outputBuffers;
 
+    // sizeof(TensorBuffer) in the runtime (6 fields, 48 bytes on 64-bit).
+    // TODO: Replace with sizeof(TensorBuffer) or a runtime query once the
+    // runtime is ported into this repo.
+    constexpr int64_t kTensorBufferSizeBytes = 48;
+
     Type i8Type = builder.getI8Type();
     Value tensorBufferSize = LLVM::ConstantOp::create(
-        builder, loc, i64Type, builder.getI64IntegerAttr(48));
+        builder, loc, i64Type,
+        builder.getI64IntegerAttr(kTensorBufferSizeBytes));
 
     for (size_t i = 0; i < numInputs; i++) {
       Value bufferPtr = LLVM::AllocaOp::create(builder, loc, ptrType, i8Type,

--- a/lib/Dialect/Transforms/GenerateInterface.cpp
+++ b/lib/Dialect/Transforms/GenerateInterface.cpp
@@ -184,6 +184,65 @@ void generateInferenceGetMetadataJson(ModuleOp module) {
   LLVM::ReturnOp::create(builder, loc, addr);
 }
 
+/// Build an LLVM memref descriptor struct {ptr, ptr, offset, sizes, strides}
+/// from a TensorBuffer's GPU pointer and shape pointer.
+static Value buildMemrefDescriptor(OpBuilder &builder, Location loc,
+                                   Value gpuPtrRaw, Value shapePtr,
+                                   int64_t rank, Type ptrType, Type i64Type) {
+  Type gpuPtrType = LLVM::LLVMPointerType::get(builder.getContext(), 1);
+  Value gpuPtr =
+      LLVM::AddrSpaceCastOp::create(builder, loc, gpuPtrType, gpuPtrRaw);
+
+  Type sizeArrayType = LLVM::LLVMArrayType::get(i64Type, rank);
+  Type memrefType = LLVM::LLVMStructType::getLiteral(
+      builder.getContext(),
+      {gpuPtrType, gpuPtrType, i64Type, sizeArrayType, sizeArrayType});
+
+  Value desc = LLVM::UndefOp::create(builder, loc, memrefType);
+  desc = LLVM::InsertValueOp::create(builder, loc, desc, gpuPtr,
+                                     ArrayRef<int64_t>{0});
+  desc = LLVM::InsertValueOp::create(builder, loc, desc, gpuPtr,
+                                     ArrayRef<int64_t>{1});
+  Value zero = LLVM::ConstantOp::create(builder, loc, i64Type,
+                                        builder.getI64IntegerAttr(0));
+  desc = LLVM::InsertValueOp::create(builder, loc, desc, zero,
+                                     ArrayRef<int64_t>{2});
+
+  Value sizes = LLVM::UndefOp::create(builder, loc, sizeArrayType);
+  for (int64_t d = 0; d < rank; d++) {
+    Value idx = LLVM::ConstantOp::create(builder, loc, i64Type,
+                                         builder.getI64IntegerAttr(d));
+    Value dimPtr = LLVM::GEPOp::create(builder, loc, ptrType, ptrType,
+                                       shapePtr, ArrayRef<LLVM::GEPArg>{idx});
+    Value dimVal = LLVM::LoadOp::create(builder, loc, i64Type, dimPtr);
+    sizes = LLVM::InsertValueOp::create(builder, loc, sizes, dimVal,
+                                        ArrayRef<int64_t>{d});
+  }
+  desc = LLVM::InsertValueOp::create(builder, loc, desc, sizes,
+                                     ArrayRef<int64_t>{3});
+
+  Value strides = LLVM::UndefOp::create(builder, loc, sizeArrayType);
+  Value acc = LLVM::ConstantOp::create(builder, loc, i64Type,
+                                       builder.getI64IntegerAttr(1));
+  for (int64_t d = rank - 1; d >= 0; d--) {
+    strides = LLVM::InsertValueOp::create(builder, loc, strides, acc,
+                                          ArrayRef<int64_t>{d});
+    if (d > 0) {
+      Value idx = LLVM::ConstantOp::create(builder, loc, i64Type,
+                                           builder.getI64IntegerAttr(d));
+      Value dimPtr =
+          LLVM::GEPOp::create(builder, loc, ptrType, ptrType, shapePtr,
+                              ArrayRef<LLVM::GEPArg>{idx});
+      Value dimSize = LLVM::LoadOp::create(builder, loc, i64Type, dimPtr);
+      acc = LLVM::MulOp::create(builder, loc, acc, dimSize);
+    }
+  }
+  desc = LLVM::InsertValueOp::create(builder, loc, desc, strides,
+                                     ArrayRef<int64_t>{4});
+
+  return desc;
+}
+
 class GenerateInterfacePass
     : public PassWrapper<GenerateInterfacePass, OperationPass<ModuleOp>> {
 public:
@@ -251,20 +310,6 @@ public:
 
 private:
   mlir::hip::CompilationOptionsT compilationOptions_;
-
-  /// Returns LLVM struct type for memref: (ptr, ptr, i64, array<rank x i64>,
-  /// array<rank x i64>)
-  Type getMemRefStructType(OpBuilder &builder, int64_t rank,
-                           unsigned addrSpace) {
-    MLIRContext *ctx = builder.getContext();
-    Type ptrType = LLVM::LLVMPointerType::get(ctx, addrSpace);
-    Type i64Type = builder.getI64Type();
-    Type sizeArrayType = LLVM::LLVMArrayType::get(i64Type, rank);
-    Type strideArrayType = LLVM::LLVMArrayType::get(i64Type, rank);
-
-    return LLVM::LLVMStructType::getLiteral(
-        ctx, {ptrType, ptrType, i64Type, sizeArrayType, strideArrayType});
-  }
 
   struct RuntimeFuncSpec {
     llvm::StringRef name;
@@ -648,71 +693,20 @@ private:
 
     for (size_t i = 0; i < numInputs; i++) {
       int64_t rank = cast<DenseI64ArrayAttr>(inputShapes.getValue()[i]).size();
-      Type memrefType = getMemRefStructType(builder, rank, 1);
 
       Value bufferPtr = inputBuffers[i];
-
       Value gpuPtrRaw = LLVM::CallOp::create(builder, loc, getGpuPtrFunc,
                                              ValueRange{bufferPtr})
                             .getResult();
-
-      Type gpuPtrType = LLVM::LLVMPointerType::get(builder.getContext(), 1);
-      Value gpuPtr =
-          LLVM::AddrSpaceCastOp::create(builder, loc, gpuPtrType, gpuPtrRaw);
-
       Value shapePtr = LLVM::CallOp::create(builder, loc, getShapePtrFunc,
                                             ValueRange{bufferPtr})
                            .getResult();
 
-      Value memref = LLVM::UndefOp::create(builder, loc, memrefType);
+      Value memref = buildMemrefDescriptor(builder, loc, gpuPtrRaw, shapePtr,
+                                           rank, ptrType, i64Type);
 
-      memref = LLVM::InsertValueOp::create(builder, loc, memref, gpuPtr,
-                                           ArrayRef<int64_t>{0});
-
-      memref = LLVM::InsertValueOp::create(builder, loc, memref, gpuPtr,
-                                           ArrayRef<int64_t>{1});
-
-      Value c0_i64 = LLVM::ConstantOp::create(builder, loc, i64Type,
-                                              builder.getI64IntegerAttr(0));
-      memref = LLVM::InsertValueOp::create(builder, loc, memref, c0_i64,
-                                           ArrayRef<int64_t>{2});
-
-      Value sizesArray = LLVM::UndefOp::create(
-          builder, loc, LLVM::LLVMArrayType::get(i64Type, rank));
-      for (int64_t dim = 0; dim < rank; dim++) {
-        Value dimIndexVal = LLVM::ConstantOp::create(
-            builder, loc, i64Type, builder.getI64IntegerAttr(dim));
-        Value dimPtr =
-            LLVM::GEPOp::create(builder, loc, ptrType, ptrType, shapePtr,
-                                ArrayRef<LLVM::GEPArg>{dimIndexVal});
-        Value dimValue = LLVM::LoadOp::create(builder, loc, i64Type, dimPtr);
-        sizesArray = LLVM::InsertValueOp::create(
-            builder, loc, sizesArray, dimValue, ArrayRef<int64_t>{dim});
-      }
-      memref = LLVM::InsertValueOp::create(builder, loc, memref, sizesArray,
-                                           ArrayRef<int64_t>{3});
-
-      Value stridesArray = LLVM::UndefOp::create(
-          builder, loc, LLVM::LLVMArrayType::get(i64Type, rank));
-      Value strideAccum = c1_i64;
-      for (int64_t dim = rank - 1; dim >= 0; dim--) {
-        stridesArray = LLVM::InsertValueOp::create(
-            builder, loc, stridesArray, strideAccum, ArrayRef<int64_t>{dim});
-        if (dim > 0) {
-          Value dimIndexVal = LLVM::ConstantOp::create(
-              builder, loc, i64Type, builder.getI64IntegerAttr(dim));
-          Value dimPtr =
-              LLVM::GEPOp::create(builder, loc, ptrType, ptrType, shapePtr,
-                                  ArrayRef<LLVM::GEPArg>{dimIndexVal});
-          Value dimSize = LLVM::LoadOp::create(builder, loc, i64Type, dimPtr);
-          strideAccum = LLVM::MulOp::create(builder, loc, strideAccum, dimSize);
-        }
-      }
-      memref = LLVM::InsertValueOp::create(builder, loc, memref, stridesArray,
-                                           ArrayRef<int64_t>{4});
-
-      Value memrefPtr =
-          LLVM::AllocaOp::create(builder, loc, ptrType, memrefType, c1_i64, 0);
+      Value memrefPtr = LLVM::AllocaOp::create(builder, loc, ptrType,
+                                               memref.getType(), c1_i64, 0);
       LLVM::StoreOp::create(builder, loc, memref, memrefPtr);
 
       Value indexVal = LLVM::ConstantOp::create(builder, loc, i64Type,
@@ -721,9 +715,6 @@ private:
           LLVM::GEPOp::create(builder, loc, ptrType, ptrType, inputMemrefArray,
                               ArrayRef<LLVM::GEPArg>{indexVal});
       LLVM::StoreOp::create(builder, loc, memrefPtr, arraySlot);
-
-      llvm::errs() << "[GenerateInterface] Built input memref " << i
-                   << " using opaque TensorBuffer accessors\n";
     }
 
     Value numOutputsVal = LLVM::ConstantOp::create(
@@ -733,68 +724,20 @@ private:
 
     for (size_t i = 0; i < numOutputs; i++) {
       int64_t rank = cast<DenseI64ArrayAttr>(outputShapes.getValue()[i]).size();
-      Type memrefType = getMemRefStructType(builder, rank, 1);
 
       Value bufferPtr = outputBuffers[i];
-
       Value gpuPtrRaw = LLVM::CallOp::create(builder, loc, getGpuPtrFunc,
                                              ValueRange{bufferPtr})
                             .getResult();
-
-      Type gpuPtrType = LLVM::LLVMPointerType::get(builder.getContext(), 1);
-      Value gpuPtr =
-          LLVM::AddrSpaceCastOp::create(builder, loc, gpuPtrType, gpuPtrRaw);
-
       Value shapePtr = LLVM::CallOp::create(builder, loc, getShapePtrFunc,
                                             ValueRange{bufferPtr})
                            .getResult();
 
-      Value memref = LLVM::UndefOp::create(builder, loc, memrefType);
-      memref = LLVM::InsertValueOp::create(builder, loc, memref, gpuPtr,
-                                           ArrayRef<int64_t>{0});
-      memref = LLVM::InsertValueOp::create(builder, loc, memref, gpuPtr,
-                                           ArrayRef<int64_t>{1});
-      Value c0_i64 = LLVM::ConstantOp::create(builder, loc, i64Type,
-                                              builder.getI64IntegerAttr(0));
-      memref = LLVM::InsertValueOp::create(builder, loc, memref, c0_i64,
-                                           ArrayRef<int64_t>{2});
+      Value memref = buildMemrefDescriptor(builder, loc, gpuPtrRaw, shapePtr,
+                                           rank, ptrType, i64Type);
 
-      Value sizesArray = LLVM::UndefOp::create(
-          builder, loc, LLVM::LLVMArrayType::get(i64Type, rank));
-      for (int64_t dim = 0; dim < rank; dim++) {
-        Value dimIndexVal = LLVM::ConstantOp::create(
-            builder, loc, i64Type, builder.getI64IntegerAttr(dim));
-        Value dimPtr =
-            LLVM::GEPOp::create(builder, loc, ptrType, ptrType, shapePtr,
-                                ArrayRef<LLVM::GEPArg>{dimIndexVal});
-        Value dimValue = LLVM::LoadOp::create(builder, loc, i64Type, dimPtr);
-        sizesArray = LLVM::InsertValueOp::create(
-            builder, loc, sizesArray, dimValue, ArrayRef<int64_t>{dim});
-      }
-      memref = LLVM::InsertValueOp::create(builder, loc, memref, sizesArray,
-                                           ArrayRef<int64_t>{3});
-
-      Value stridesArray = LLVM::UndefOp::create(
-          builder, loc, LLVM::LLVMArrayType::get(i64Type, rank));
-      Value strideAccum = c1_i64;
-      for (int64_t dim = rank - 1; dim >= 0; dim--) {
-        stridesArray = LLVM::InsertValueOp::create(
-            builder, loc, stridesArray, strideAccum, ArrayRef<int64_t>{dim});
-        if (dim > 0) {
-          Value dimIndexVal = LLVM::ConstantOp::create(
-              builder, loc, i64Type, builder.getI64IntegerAttr(dim));
-          Value dimPtr =
-              LLVM::GEPOp::create(builder, loc, ptrType, ptrType, shapePtr,
-                                  ArrayRef<LLVM::GEPArg>{dimIndexVal});
-          Value dimSize = LLVM::LoadOp::create(builder, loc, i64Type, dimPtr);
-          strideAccum = LLVM::MulOp::create(builder, loc, strideAccum, dimSize);
-        }
-      }
-      memref = LLVM::InsertValueOp::create(builder, loc, memref, stridesArray,
-                                           ArrayRef<int64_t>{4});
-
-      Value memrefPtr =
-          LLVM::AllocaOp::create(builder, loc, ptrType, memrefType, c1_i64, 0);
+      Value memrefPtr = LLVM::AllocaOp::create(builder, loc, ptrType,
+                                               memref.getType(), c1_i64, 0);
       LLVM::StoreOp::create(builder, loc, memref, memrefPtr);
 
       Value indexVal = LLVM::ConstantOp::create(builder, loc, i64Type,

--- a/lib/Dialect/Transforms/GenerateInterface.cpp
+++ b/lib/Dialect/Transforms/GenerateInterface.cpp
@@ -134,9 +134,10 @@ void generateMetadataGlobal(ModuleOp module, const std::string &jsonStr) {
   auto arrayType = LLVM::LLVMArrayType::get(i8Type, jsonStr.size() + 1);
 
   builder.setInsertionPoint(&module.getBody()->front());
-  builder.create<LLVM::GlobalOp>(
-      module.getLoc(), arrayType, /*isConstant=*/true, LLVM::Linkage::Internal,
-      "__metadata_json", builder.getStringAttr(jsonStr + '\0'));
+  LLVM::GlobalOp::create(builder, module.getLoc(), arrayType,
+                         /*isConstant=*/true, LLVM::Linkage::Internal,
+                         "__metadata_json",
+                         builder.getStringAttr(jsonStr + '\0'));
 }
 
 /// Generate global constant for metadata FlatBuffers blob
@@ -149,10 +150,9 @@ void generateMetadataBlobGlobal(ModuleOp module,
   builder.setInsertionPoint(&module.getBody()->front());
   llvm::StringRef blobRef(reinterpret_cast<const char *>(blob.data()),
                           blob.size());
-  builder.create<LLVM::GlobalOp>(module.getLoc(), arrayType,
-                                 /*isConstant=*/true, LLVM::Linkage::Internal,
-                                 "__metadata_blob",
-                                 builder.getStringAttr(blobRef));
+  LLVM::GlobalOp::create(builder, module.getLoc(), arrayType,
+                         /*isConstant=*/true, LLVM::Linkage::Internal,
+                         "__metadata_blob", builder.getStringAttr(blobRef));
 }
 
 /// Generate inference_get_metadata_json() function
@@ -165,8 +165,8 @@ void generateInferenceGetMetadataJson(ModuleOp module) {
   auto ptrType = LLVM::LLVMPointerType::get(builder.getContext(), 0);
   auto funcType = LLVM::LLVMFunctionType::get(ptrType, {});
 
-  auto funcOp = builder.create<LLVM::LLVMFuncOp>(
-      loc, "inference_get_metadata_json", funcType);
+  auto funcOp = LLVM::LLVMFuncOp::create(
+      builder, loc, "inference_get_metadata_json", funcType);
   funcOp->setAttr("llvm.emit_c_interface", builder.getUnitAttr());
   funcOp->setAttr("sym_visibility", builder.getStringAttr("public"));
 
@@ -174,8 +174,8 @@ void generateInferenceGetMetadataJson(ModuleOp module) {
   builder.setInsertionPointToStart(entry);
 
   Value addr =
-      builder.create<LLVM::AddressOfOp>(loc, ptrType, "__metadata_json");
-  builder.create<LLVM::ReturnOp>(loc, addr);
+      LLVM::AddressOfOp::create(builder, loc, ptrType, "__metadata_json");
+  LLVM::ReturnOp::create(builder, loc, addr);
 }
 
 class GenerateInterfacePass
@@ -274,7 +274,7 @@ private:
       auto mallocFuncType =
           LLVM::LLVMFunctionType::get(ptrType, {builder.getI64Type()});
       auto mallocFunc =
-          builder.create<LLVM::LLVMFuncOp>(loc, "malloc", mallocFuncType);
+          LLVM::LLVMFuncOp::create(builder, loc, "malloc", mallocFuncType);
       mallocFunc.setLinkage(LLVM::Linkage::External);
     }
 
@@ -282,7 +282,7 @@ private:
       auto freeFuncType = LLVM::LLVMFunctionType::get(
           LLVM::LLVMVoidType::get(builder.getContext()), {ptrType});
       auto freeFunc =
-          builder.create<LLVM::LLVMFuncOp>(loc, "free", freeFuncType);
+          LLVM::LLVMFuncOp::create(builder, loc, "free", freeFuncType);
       freeFunc.setLinkage(LLVM::Linkage::External);
     }
   }
@@ -301,77 +301,77 @@ private:
     if (!module.lookupSymbol<LLVM::LLVMFuncOp>("hipStreamCreate")) {
       auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType});
       auto func =
-          builder.create<LLVM::LLVMFuncOp>(loc, "hipStreamCreate", funcType);
+          LLVM::LLVMFuncOp::create(builder, loc, "hipStreamCreate", funcType);
       func.setLinkage(LLVM::Linkage::External);
     }
 
     if (!module.lookupSymbol<LLVM::LLVMFuncOp>("hipStreamDestroy")) {
       auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType});
       auto func =
-          builder.create<LLVM::LLVMFuncOp>(loc, "hipStreamDestroy", funcType);
+          LLVM::LLVMFuncOp::create(builder, loc, "hipStreamDestroy", funcType);
       func.setLinkage(LLVM::Linkage::External);
     }
 
     if (!module.lookupSymbol<LLVM::LLVMFuncOp>("hipStreamSynchronize")) {
       auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType});
-      auto func = builder.create<LLVM::LLVMFuncOp>(loc, "hipStreamSynchronize",
-                                                   funcType);
+      auto func = LLVM::LLVMFuncOp::create(builder, loc, "hipStreamSynchronize",
+                                           funcType);
       func.setLinkage(LLVM::Linkage::External);
     }
 
     if (!module.lookupSymbol<LLVM::LLVMFuncOp>("miopenCreate")) {
       auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType});
       auto func =
-          builder.create<LLVM::LLVMFuncOp>(loc, "miopenCreate", funcType);
+          LLVM::LLVMFuncOp::create(builder, loc, "miopenCreate", funcType);
       func.setLinkage(LLVM::Linkage::External);
     }
 
     if (!module.lookupSymbol<LLVM::LLVMFuncOp>("miopenSetStream")) {
       auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType, ptrType});
       auto func =
-          builder.create<LLVM::LLVMFuncOp>(loc, "miopenSetStream", funcType);
+          LLVM::LLVMFuncOp::create(builder, loc, "miopenSetStream", funcType);
       func.setLinkage(LLVM::Linkage::External);
     }
 
     if (!module.lookupSymbol<LLVM::LLVMFuncOp>("miopenDestroy")) {
       auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType});
       auto func =
-          builder.create<LLVM::LLVMFuncOp>(loc, "miopenDestroy", funcType);
+          LLVM::LLVMFuncOp::create(builder, loc, "miopenDestroy", funcType);
       func.setLinkage(LLVM::Linkage::External);
     }
 
     if (!module.lookupSymbol<LLVM::LLVMFuncOp>("hipblasLtCreate")) {
       auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType});
       auto func =
-          builder.create<LLVM::LLVMFuncOp>(loc, "hipblasLtCreate", funcType);
+          LLVM::LLVMFuncOp::create(builder, loc, "hipblasLtCreate", funcType);
       func.setLinkage(LLVM::Linkage::External);
     }
 
     if (!module.lookupSymbol<LLVM::LLVMFuncOp>("hipblasLtDestroy")) {
       auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType});
       auto func =
-          builder.create<LLVM::LLVMFuncOp>(loc, "hipblasLtDestroy", funcType);
+          LLVM::LLVMFuncOp::create(builder, loc, "hipblasLtDestroy", funcType);
       func.setLinkage(LLVM::Linkage::External);
     }
 
     if (!module.lookupSymbol<LLVM::LLVMFuncOp>("hipdnn_ep_state_cleanup")) {
       auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType});
-      auto func = builder.create<LLVM::LLVMFuncOp>(
-          loc, "hipdnn_ep_state_cleanup", funcType);
+      auto func = LLVM::LLVMFuncOp::create(builder, loc,
+                                           "hipdnn_ep_state_cleanup", funcType);
       func.setLinkage(LLVM::Linkage::External);
     }
 
     if (!module.lookupSymbol<LLVM::LLVMFuncOp>("wrap_hipMalloc")) {
       auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType, i64Type});
       auto func =
-          builder.create<LLVM::LLVMFuncOp>(loc, "wrap_hipMalloc", funcType);
+          LLVM::LLVMFuncOp::create(builder, loc, "wrap_hipMalloc", funcType);
       func.setLinkage(LLVM::Linkage::External);
     }
 
     if (!module.lookupSymbol<LLVM::LLVMFuncOp>("wrap_hipFree")) {
       auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType});
       auto func =
-          builder.create<LLVM::LLVMFuncOp>(loc, "wrap_hipFree", funcType);
+          LLVM::LLVMFuncOp::create(builder, loc, "wrap_hipFree", funcType);
       func.setLinkage(LLVM::Linkage::External);
     }
 
@@ -379,7 +379,7 @@ private:
       auto funcType = LLVM::LLVMFunctionType::get(
           i32Type, {ptrType, ptrType, i64Type, ptrType});
       auto func =
-          builder.create<LLVM::LLVMFuncOp>(loc, "wrap_hipMemcpyH2D", funcType);
+          LLVM::LLVMFuncOp::create(builder, loc, "wrap_hipMemcpyH2D", funcType);
       func.setLinkage(LLVM::Linkage::External);
     }
 
@@ -387,37 +387,37 @@ private:
       auto funcType = LLVM::LLVMFunctionType::get(
           i32Type, {ptrType, ptrType, i64Type, ptrType});
       auto func =
-          builder.create<LLVM::LLVMFuncOp>(loc, "wrap_hipMemcpyD2H", funcType);
+          LLVM::LLVMFuncOp::create(builder, loc, "wrap_hipMemcpyD2H", funcType);
       func.setLinkage(LLVM::Linkage::External);
     }
 
     if (!module.lookupSymbol<LLVM::LLVMFuncOp>("wrap_hipStreamSynchronize")) {
       auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType});
-      auto func = builder.create<LLVM::LLVMFuncOp>(
-          loc, "wrap_hipStreamSynchronize", funcType);
+      auto func = LLVM::LLVMFuncOp::create(
+          builder, loc, "wrap_hipStreamSynchronize", funcType);
       func.setLinkage(LLVM::Linkage::External);
     }
 
     if (!module.lookupSymbol<LLVM::LLVMFuncOp>("hipdnn_ep_state_get_stream")) {
       auto funcType = LLVM::LLVMFunctionType::get(ptrType, {ptrType});
-      auto func = builder.create<LLVM::LLVMFuncOp>(
-          loc, "hipdnn_ep_state_get_stream", funcType);
+      auto func = LLVM::LLVMFuncOp::create(
+          builder, loc, "hipdnn_ep_state_get_stream", funcType);
       func.setLinkage(LLVM::Linkage::External);
     }
 
     if (!module.lookupSymbol<LLVM::LLVMFuncOp>("hipdnn_ep_pool_init")) {
       auto funcType = LLVM::LLVMFunctionType::get(
           i32Type, {ptrType, i64Type, ptrType, i64Type});
-      auto func = builder.create<LLVM::LLVMFuncOp>(loc, "hipdnn_ep_pool_init",
-                                                   funcType);
+      auto func = LLVM::LLVMFuncOp::create(builder, loc, "hipdnn_ep_pool_init",
+                                           funcType);
       func.setLinkage(LLVM::Linkage::External);
     }
 
     if (!module.lookupSymbol<LLVM::LLVMFuncOp>(
             "hipdnn_ep_get_buffer_from_pool")) {
       auto funcType = LLVM::LLVMFunctionType::get(ptrType, {ptrType, i64Type});
-      auto func = builder.create<LLVM::LLVMFuncOp>(
-          loc, "hipdnn_ep_get_buffer_from_pool", funcType);
+      auto func = LLVM::LLVMFuncOp::create(
+          builder, loc, "hipdnn_ep_get_buffer_from_pool", funcType);
       func.setLinkage(LLVM::Linkage::External);
     }
 
@@ -426,8 +426,8 @@ private:
       Type sizeTType = i64Type;
       auto funcType = LLVM::LLVMFunctionType::get(
           i32Type, {ptrType, ptrType, sizeTType, sizeTType, ptrType});
-      auto func = builder.create<LLVM::LLVMFuncOp>(
-          loc, "hipdnn_ep_tensor_prepare_input", funcType);
+      auto func = LLVM::LLVMFuncOp::create(
+          builder, loc, "hipdnn_ep_tensor_prepare_input", funcType);
       func.setLinkage(LLVM::Linkage::External);
     }
 
@@ -436,63 +436,63 @@ private:
       Type sizeTType = i64Type;
       auto funcType = LLVM::LLVMFunctionType::get(
           i32Type, {ptrType, ptrType, sizeTType, sizeTType, ptrType});
-      auto func = builder.create<LLVM::LLVMFuncOp>(
-          loc, "hipdnn_ep_tensor_prepare_output", funcType);
+      auto func = LLVM::LLVMFuncOp::create(
+          builder, loc, "hipdnn_ep_tensor_prepare_output", funcType);
       func.setLinkage(LLVM::Linkage::External);
     }
 
     if (!module.lookupSymbol<LLVM::LLVMFuncOp>(
             "hipdnn_ep_tensor_finalize_output")) {
       auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType, ptrType});
-      auto func = builder.create<LLVM::LLVMFuncOp>(
-          loc, "hipdnn_ep_tensor_finalize_output", funcType);
+      auto func = LLVM::LLVMFuncOp::create(
+          builder, loc, "hipdnn_ep_tensor_finalize_output", funcType);
       func.setLinkage(LLVM::Linkage::External);
     }
 
     if (!module.lookupSymbol<LLVM::LLVMFuncOp>("hipdnn_ep_tensor_free_input")) {
       auto funcType = LLVM::LLVMFunctionType::get(voidType, {ptrType, ptrType});
-      auto func = builder.create<LLVM::LLVMFuncOp>(
-          loc, "hipdnn_ep_tensor_free_input", funcType);
+      auto func = LLVM::LLVMFuncOp::create(
+          builder, loc, "hipdnn_ep_tensor_free_input", funcType);
       func.setLinkage(LLVM::Linkage::External);
     }
 
     if (!module.lookupSymbol<LLVM::LLVMFuncOp>(
             "hipdnn_ep_tensor_buffer_get_gpu_ptr")) {
       auto funcType = LLVM::LLVMFunctionType::get(ptrType, {ptrType});
-      auto func = builder.create<LLVM::LLVMFuncOp>(
-          loc, "hipdnn_ep_tensor_buffer_get_gpu_ptr", funcType);
+      auto func = LLVM::LLVMFuncOp::create(
+          builder, loc, "hipdnn_ep_tensor_buffer_get_gpu_ptr", funcType);
       func.setLinkage(LLVM::Linkage::External);
     }
 
     if (!module.lookupSymbol<LLVM::LLVMFuncOp>(
             "hipdnn_ep_tensor_buffer_get_host_ptr")) {
       auto funcType = LLVM::LLVMFunctionType::get(ptrType, {ptrType});
-      auto func = builder.create<LLVM::LLVMFuncOp>(
-          loc, "hipdnn_ep_tensor_buffer_get_host_ptr", funcType);
+      auto func = LLVM::LLVMFuncOp::create(
+          builder, loc, "hipdnn_ep_tensor_buffer_get_host_ptr", funcType);
       func.setLinkage(LLVM::Linkage::External);
     }
 
     if (!module.lookupSymbol<LLVM::LLVMFuncOp>(
             "hipdnn_ep_tensor_buffer_get_shape_ptr")) {
       auto funcType = LLVM::LLVMFunctionType::get(ptrType, {ptrType});
-      auto func = builder.create<LLVM::LLVMFuncOp>(
-          loc, "hipdnn_ep_tensor_buffer_get_shape_ptr", funcType);
+      auto func = LLVM::LLVMFuncOp::create(
+          builder, loc, "hipdnn_ep_tensor_buffer_get_shape_ptr", funcType);
       func.setLinkage(LLVM::Linkage::External);
     }
 
     if (!module.lookupSymbol<LLVM::LLVMFuncOp>(
             "hipdnn_ep_tensor_buffer_get_rank")) {
       auto funcType = LLVM::LLVMFunctionType::get(i64Type, {ptrType});
-      auto func = builder.create<LLVM::LLVMFuncOp>(
-          loc, "hipdnn_ep_tensor_buffer_get_rank", funcType);
+      auto func = LLVM::LLVMFuncOp::create(
+          builder, loc, "hipdnn_ep_tensor_buffer_get_rank", funcType);
       func.setLinkage(LLVM::Linkage::External);
     }
 
     if (!module.lookupSymbol<LLVM::LLVMFuncOp>(
             "hipdnn_ep_tensor_buffer_get_size_bytes")) {
       auto funcType = LLVM::LLVMFunctionType::get(i64Type, {ptrType});
-      auto func = builder.create<LLVM::LLVMFuncOp>(
-          loc, "hipdnn_ep_tensor_buffer_get_size_bytes", funcType);
+      auto func = LLVM::LLVMFuncOp::create(
+          builder, loc, "hipdnn_ep_tensor_buffer_get_size_bytes", funcType);
       func.setLinkage(LLVM::Linkage::External);
     }
 
@@ -500,8 +500,8 @@ private:
             "hipdnn_ep_state_init_with_fs")) {
       auto funcType = LLVM::LLVMFunctionType::get(
           i32Type, {ptrType, ptrType, ptrType, i64Type});
-      auto func = builder.create<LLVM::LLVMFuncOp>(
-          loc, "hipdnn_ep_state_init_with_fs", funcType);
+      auto func = LLVM::LLVMFuncOp::create(
+          builder, loc, "hipdnn_ep_state_init_with_fs", funcType);
       func.setLinkage(LLVM::Linkage::External);
     }
   }
@@ -581,7 +581,7 @@ private:
     auto funcType = LLVM::LLVMFunctionType::get(i32Type, paramTypes);
 
     auto funcOp =
-        builder.create<LLVM::LLVMFuncOp>(loc, "inference_init", funcType);
+        LLVM::LLVMFuncOp::create(builder, loc, "inference_init", funcType);
     funcOp->setAttr("llvm.emit_c_interface", builder.getUnitAttr());
     funcOp->setAttr("sym_visibility", builder.getStringAttr("public"));
 
@@ -592,14 +592,15 @@ private:
     Value fsPtr = entryBlock->getArgument(1);
 
     Value blobPtr =
-        builder.create<LLVM::AddressOfOp>(loc, ptrType, "__metadata_blob");
-    Value blobSizeVal = builder.create<LLVM::ConstantOp>(
-        loc, i64Type, builder.getI64IntegerAttr((int64_t)blobSize));
+        LLVM::AddressOfOp::create(builder, loc, ptrType, "__metadata_blob");
+    Value blobSizeVal = LLVM::ConstantOp::create(
+        builder, loc, i64Type, builder.getI64IntegerAttr((int64_t)blobSize));
 
     auto initFunc =
         module.lookupSymbol<LLVM::LLVMFuncOp>("hipdnn_ep_state_init_with_fs");
-    LLVM::CallOp initCall = builder.create<LLVM::CallOp>(
-        loc, initFunc, ValueRange{outStatePtr, fsPtr, blobPtr, blobSizeVal});
+    LLVM::CallOp initCall = LLVM::CallOp::create(
+        builder, loc, initFunc,
+        ValueRange{outStatePtr, fsPtr, blobPtr, blobSizeVal});
 
     auto poolSizeAttr = module->getAttrOfType<IntegerAttr>("hipdnn.pool_size");
     auto bufferOffsetsAttr =
@@ -626,52 +627,54 @@ private:
       size_t numBuffers = bufferCountAttr.getInt();
       auto offsetsAttrArray = bufferOffsetsAttr.getValue();
 
-      Value zero_i32 = builder.create<LLVM::ConstantOp>(
-          loc, i32Type, builder.getI32IntegerAttr(0));
-      Value initFailed = builder.create<LLVM::ICmpOp>(
-          loc, LLVM::ICmpPredicate::ne, initCall.getResult(), zero_i32);
+      Value zero_i32 = LLVM::ConstantOp::create(builder, loc, i32Type,
+                                                builder.getI32IntegerAttr(0));
+      Value initFailed =
+          LLVM::ICmpOp::create(builder, loc, LLVM::ICmpPredicate::ne,
+                               initCall.getResult(), zero_i32);
 
       Block *poolInitBlock = funcOp.addBlock();
       Block *returnErrorBlock = funcOp.addBlock();
 
-      builder.create<LLVM::CondBrOp>(loc, initFailed, returnErrorBlock,
-                                     poolInitBlock);
+      LLVM::CondBrOp::create(builder, loc, initFailed, returnErrorBlock,
+                             poolInitBlock);
 
       builder.setInsertionPointToStart(returnErrorBlock);
-      builder.create<LLVM::ReturnOp>(loc, initCall.getResult());
+      LLVM::ReturnOp::create(builder, loc, initCall.getResult());
 
       builder.setInsertionPointToStart(poolInitBlock);
 
-      Value statePtr = builder.create<LLVM::LoadOp>(loc, ptrType, outStatePtr);
+      Value statePtr = LLVM::LoadOp::create(builder, loc, ptrType, outStatePtr);
 
-      Value numBuffersVal = builder.create<LLVM::ConstantOp>(
-          loc, i64Type, builder.getI64IntegerAttr(numBuffers));
+      Value numBuffersVal = LLVM::ConstantOp::create(
+          builder, loc, i64Type, builder.getI64IntegerAttr(numBuffers));
 
-      Value offsetsArrayPtr = builder.create<LLVM::AllocaOp>(
-          loc, ptrType, i64Type, numBuffersVal, 0);
+      Value offsetsArrayPtr = LLVM::AllocaOp::create(builder, loc, ptrType,
+                                                     i64Type, numBuffersVal, 0);
 
       for (size_t i = 0; i < numBuffers; i++) {
         auto offsetAttr = dyn_cast<IntegerAttr>(offsetsAttrArray[i]);
-        Value offset = builder.create<LLVM::ConstantOp>(
-            loc, i64Type, builder.getI64IntegerAttr(offsetAttr.getInt()));
-        Value idx = builder.create<LLVM::ConstantOp>(
-            loc, i64Type, builder.getI64IntegerAttr(i));
-        Value elemPtr = builder.create<LLVM::GEPOp>(
-            loc, ptrType, i64Type, offsetsArrayPtr, ValueRange{idx});
-        builder.create<LLVM::StoreOp>(loc, offset, elemPtr);
+        Value offset = LLVM::ConstantOp::create(
+            builder, loc, i64Type,
+            builder.getI64IntegerAttr(offsetAttr.getInt()));
+        Value idx = LLVM::ConstantOp::create(builder, loc, i64Type,
+                                             builder.getI64IntegerAttr(i));
+        Value elemPtr = LLVM::GEPOp::create(builder, loc, ptrType, i64Type,
+                                            offsetsArrayPtr, ValueRange{idx});
+        LLVM::StoreOp::create(builder, loc, offset, elemPtr);
       }
 
       auto poolInitFunc =
           module.lookupSymbol<LLVM::LLVMFuncOp>("hipdnn_ep_pool_init");
-      Value poolSizeVal = builder.create<LLVM::ConstantOp>(
-          loc, i64Type, builder.getI64IntegerAttr(poolSize));
-      auto poolInitCall = builder.create<LLVM::CallOp>(
-          loc, poolInitFunc,
+      Value poolSizeVal = LLVM::ConstantOp::create(
+          builder, loc, i64Type, builder.getI64IntegerAttr(poolSize));
+      auto poolInitCall = LLVM::CallOp::create(
+          builder, loc, poolInitFunc,
           ValueRange{statePtr, poolSizeVal, offsetsArrayPtr, numBuffersVal});
 
-      builder.create<LLVM::ReturnOp>(loc, poolInitCall.getResult());
+      LLVM::ReturnOp::create(builder, loc, poolInitCall.getResult());
     } else {
-      builder.create<LLVM::ReturnOp>(loc, initCall.getResult());
+      LLVM::ReturnOp::create(builder, loc, initCall.getResult());
     }
   }
 
@@ -691,7 +694,7 @@ private:
     auto funcType = LLVM::LLVMFunctionType::get(i32Type, paramTypes);
 
     auto funcOp =
-        builder.create<LLVM::LLVMFuncOp>(loc, "inference_compute", funcType);
+        LLVM::LLVMFuncOp::create(builder, loc, "inference_compute", funcType);
     funcOp->setAttr("llvm.emit_c_interface", builder.getUnitAttr());
     funcOp->setAttr("sym_visibility", builder.getStringAttr("public"));
 
@@ -705,10 +708,10 @@ private:
     size_t numInputs = inputShapes ? inputShapes.size() : 0;
     size_t numOutputs = outputShapes ? outputShapes.size() : 0;
 
-    Value c0_i32 = builder.create<LLVM::ConstantOp>(
-        loc, i32Type, builder.getI32IntegerAttr(0));
-    Value c1_i64 = builder.create<LLVM::ConstantOp>(
-        loc, i64Type, builder.getI64IntegerAttr(1));
+    Value c0_i32 = LLVM::ConstantOp::create(builder, loc, i32Type,
+                                            builder.getI32IntegerAttr(0));
+    Value c1_i64 = LLVM::ConstantOp::create(builder, loc, i64Type,
+                                            builder.getI64IntegerAttr(1));
 
     auto prepareInputFunc =
         module.lookupSymbol<LLVM::LLVMFuncOp>("hipdnn_ep_tensor_prepare_input");
@@ -725,23 +728,23 @@ private:
         "hipdnn_ep_tensor_buffer_get_shape_ptr");
 
     Value errorCodePtr =
-        builder.create<LLVM::AllocaOp>(loc, ptrType, i32Type, c1_i64, 0);
+        LLVM::AllocaOp::create(builder, loc, ptrType, i32Type, c1_i64, 0);
 
     SmallVector<Value> inputBuffers;
     SmallVector<Value> outputBuffers;
 
     Type i8Type = builder.getI8Type();
-    Value tensorBufferSize = builder.create<LLVM::ConstantOp>(
-        loc, i64Type, builder.getI64IntegerAttr(48));
+    Value tensorBufferSize = LLVM::ConstantOp::create(
+        builder, loc, i64Type, builder.getI64IntegerAttr(48));
 
     for (size_t i = 0; i < numInputs; i++) {
-      Value bufferPtr = builder.create<LLVM::AllocaOp>(loc, ptrType, i8Type,
-                                                       tensorBufferSize, 0);
+      Value bufferPtr = LLVM::AllocaOp::create(builder, loc, ptrType, i8Type,
+                                               tensorBufferSize, 0);
       inputBuffers.push_back(bufferPtr);
     }
     for (size_t i = 0; i < numOutputs; i++) {
-      Value bufferPtr = builder.create<LLVM::AllocaOp>(loc, ptrType, i8Type,
-                                                       tensorBufferSize, 0);
+      Value bufferPtr = LLVM::AllocaOp::create(builder, loc, ptrType, i8Type,
+                                               tensorBufferSize, 0);
       outputBuffers.push_back(bufferPtr);
     }
 
@@ -753,33 +756,32 @@ private:
     for (size_t i = 0; i < numInputs; i++) {
       Value bufferPtr = inputBuffers[i];
 
-      Value indexVal = builder.create<LLVM::ConstantOp>(
-          loc, i64Type, builder.getI64IntegerAttr(i));
+      Value indexVal = LLVM::ConstantOp::create(builder, loc, i64Type,
+                                                builder.getI64IntegerAttr(i));
 
-      Value rankVal = builder.create<LLVM::ConstantOp>(
-          loc, i64Type,
+      Value rankVal = LLVM::ConstantOp::create(
+          builder, loc, i64Type,
           builder.getI64IntegerAttr(
               cast<DenseI64ArrayAttr>(inputShapes.getValue()[i]).size()));
 
       Value retVal =
-          builder
-              .create<LLVM::CallOp>(loc, prepareInputFunc,
-                                    ValueRange{state, inputsSpanPtr, indexVal,
-                                               rankVal, bufferPtr})
+          LLVM::CallOp::create(
+              builder, loc, prepareInputFunc,
+              ValueRange{state, inputsSpanPtr, indexVal, rankVal, bufferPtr})
               .getResult();
 
-      Value failed = builder.create<LLVM::ICmpOp>(loc, LLVM::ICmpPredicate::ne,
-                                                  retVal, c0_i32);
+      Value failed = LLVM::ICmpOp::create(builder, loc, LLVM::ICmpPredicate::ne,
+                                          retVal, c0_i32);
 
       Block *continueBlock = funcOp.addBlock();
 
       Block *storeErrorBlock = funcOp.addBlock();
-      builder.create<LLVM::CondBrOp>(loc, failed, storeErrorBlock,
-                                     continueBlock);
+      LLVM::CondBrOp::create(builder, loc, failed, storeErrorBlock,
+                             continueBlock);
 
       builder.setInsertionPointToStart(storeErrorBlock);
-      builder.create<LLVM::StoreOp>(loc, retVal, errorCodePtr);
-      builder.create<LLVM::BrOp>(loc, errorCleanupBlock);
+      LLVM::StoreOp::create(builder, loc, retVal, errorCodePtr);
+      LLVM::BrOp::create(builder, loc, errorCleanupBlock);
 
       builder.setInsertionPointToStart(continueBlock);
     }
@@ -790,42 +792,41 @@ private:
     for (size_t i = 0; i < numOutputs; i++) {
       Value bufferPtr = outputBuffers[i];
 
-      Value indexVal = builder.create<LLVM::ConstantOp>(
-          loc, i64Type, builder.getI64IntegerAttr(i));
+      Value indexVal = LLVM::ConstantOp::create(builder, loc, i64Type,
+                                                builder.getI64IntegerAttr(i));
 
-      Value rankVal = builder.create<LLVM::ConstantOp>(
-          loc, i64Type,
+      Value rankVal = LLVM::ConstantOp::create(
+          builder, loc, i64Type,
           builder.getI64IntegerAttr(
               cast<DenseI64ArrayAttr>(outputShapes.getValue()[i]).size()));
 
       Value retVal =
-          builder
-              .create<LLVM::CallOp>(loc, prepareOutputFunc,
-                                    ValueRange{state, outputsSpanPtr, indexVal,
-                                               rankVal, bufferPtr})
+          LLVM::CallOp::create(
+              builder, loc, prepareOutputFunc,
+              ValueRange{state, outputsSpanPtr, indexVal, rankVal, bufferPtr})
               .getResult();
 
-      Value failed = builder.create<LLVM::ICmpOp>(loc, LLVM::ICmpPredicate::ne,
-                                                  retVal, c0_i32);
+      Value failed = LLVM::ICmpOp::create(builder, loc, LLVM::ICmpPredicate::ne,
+                                          retVal, c0_i32);
 
       Block *continueBlock = funcOp.addBlock();
 
       Block *storeErrorBlock = funcOp.addBlock();
-      builder.create<LLVM::CondBrOp>(loc, failed, storeErrorBlock,
-                                     continueBlock);
+      LLVM::CondBrOp::create(builder, loc, failed, storeErrorBlock,
+                             continueBlock);
 
       builder.setInsertionPointToStart(storeErrorBlock);
-      builder.create<LLVM::StoreOp>(loc, retVal, errorCodePtr);
-      builder.create<LLVM::BrOp>(loc, errorCleanupBlock);
+      LLVM::StoreOp::create(builder, loc, retVal, errorCodePtr);
+      LLVM::BrOp::create(builder, loc, errorCleanupBlock);
 
       builder.setInsertionPointToStart(continueBlock);
     }
 
     // Build memref structs for @main call
-    Value numInputsVal = builder.create<LLVM::ConstantOp>(
-        loc, i64Type, builder.getI64IntegerAttr(numInputs));
+    Value numInputsVal = LLVM::ConstantOp::create(
+        builder, loc, i64Type, builder.getI64IntegerAttr(numInputs));
     Value inputMemrefArray =
-        builder.create<LLVM::AllocaOp>(loc, ptrType, ptrType, numInputsVal, 0);
+        LLVM::AllocaOp::create(builder, loc, ptrType, ptrType, numInputsVal, 0);
 
     for (size_t i = 0; i < numInputs; i++) {
       int64_t rank = cast<DenseI64ArrayAttr>(inputShapes.getValue()[i]).size();
@@ -833,86 +834,84 @@ private:
 
       Value bufferPtr = inputBuffers[i];
 
-      Value gpuPtrRaw =
-          builder
-              .create<LLVM::CallOp>(loc, getGpuPtrFunc, ValueRange{bufferPtr})
-              .getResult();
+      Value gpuPtrRaw = LLVM::CallOp::create(builder, loc, getGpuPtrFunc,
+                                             ValueRange{bufferPtr})
+                            .getResult();
 
       Type gpuPtrType = LLVM::LLVMPointerType::get(builder.getContext(), 1);
       Value gpuPtr =
-          builder.create<LLVM::AddrSpaceCastOp>(loc, gpuPtrType, gpuPtrRaw);
+          LLVM::AddrSpaceCastOp::create(builder, loc, gpuPtrType, gpuPtrRaw);
 
-      Value shapePtr =
-          builder
-              .create<LLVM::CallOp>(loc, getShapePtrFunc, ValueRange{bufferPtr})
-              .getResult();
+      Value shapePtr = LLVM::CallOp::create(builder, loc, getShapePtrFunc,
+                                            ValueRange{bufferPtr})
+                           .getResult();
 
-      Value memref = builder.create<LLVM::UndefOp>(loc, memrefType);
+      Value memref = LLVM::UndefOp::create(builder, loc, memrefType);
 
-      memref = builder.create<LLVM::InsertValueOp>(loc, memref, gpuPtr,
-                                                   ArrayRef<int64_t>{0});
+      memref = LLVM::InsertValueOp::create(builder, loc, memref, gpuPtr,
+                                           ArrayRef<int64_t>{0});
 
-      memref = builder.create<LLVM::InsertValueOp>(loc, memref, gpuPtr,
-                                                   ArrayRef<int64_t>{1});
+      memref = LLVM::InsertValueOp::create(builder, loc, memref, gpuPtr,
+                                           ArrayRef<int64_t>{1});
 
-      Value c0_i64 = builder.create<LLVM::ConstantOp>(
-          loc, i64Type, builder.getI64IntegerAttr(0));
-      memref = builder.create<LLVM::InsertValueOp>(loc, memref, c0_i64,
-                                                   ArrayRef<int64_t>{2});
+      Value c0_i64 = LLVM::ConstantOp::create(builder, loc, i64Type,
+                                              builder.getI64IntegerAttr(0));
+      memref = LLVM::InsertValueOp::create(builder, loc, memref, c0_i64,
+                                           ArrayRef<int64_t>{2});
 
-      Value sizesArray = builder.create<LLVM::UndefOp>(
-          loc, LLVM::LLVMArrayType::get(i64Type, rank));
+      Value sizesArray = LLVM::UndefOp::create(
+          builder, loc, LLVM::LLVMArrayType::get(i64Type, rank));
       for (int64_t dim = 0; dim < rank; dim++) {
-        Value dimIndexVal = builder.create<LLVM::ConstantOp>(
-            loc, i64Type, builder.getI64IntegerAttr(dim));
+        Value dimIndexVal = LLVM::ConstantOp::create(
+            builder, loc, i64Type, builder.getI64IntegerAttr(dim));
         Value dimPtr =
-            builder.create<LLVM::GEPOp>(loc, ptrType, ptrType, shapePtr,
-                                        ArrayRef<LLVM::GEPArg>{dimIndexVal});
-        Value dimValue = builder.create<LLVM::LoadOp>(loc, i64Type, dimPtr);
-        sizesArray = builder.create<LLVM::InsertValueOp>(
-            loc, sizesArray, dimValue, ArrayRef<int64_t>{dim});
+            LLVM::GEPOp::create(builder, loc, ptrType, ptrType, shapePtr,
+                                ArrayRef<LLVM::GEPArg>{dimIndexVal});
+        Value dimValue = LLVM::LoadOp::create(builder, loc, i64Type, dimPtr);
+        sizesArray = LLVM::InsertValueOp::create(
+            builder, loc, sizesArray, dimValue, ArrayRef<int64_t>{dim});
       }
-      memref = builder.create<LLVM::InsertValueOp>(loc, memref, sizesArray,
-                                                   ArrayRef<int64_t>{3});
+      memref = LLVM::InsertValueOp::create(builder, loc, memref, sizesArray,
+                                           ArrayRef<int64_t>{3});
 
-      Value stridesArray = builder.create<LLVM::UndefOp>(
-          loc, LLVM::LLVMArrayType::get(i64Type, rank));
+      Value stridesArray = LLVM::UndefOp::create(
+          builder, loc, LLVM::LLVMArrayType::get(i64Type, rank));
       Value strideAccum = c1_i64;
       for (int64_t dim = rank - 1; dim >= 0; dim--) {
-        stridesArray = builder.create<LLVM::InsertValueOp>(
-            loc, stridesArray, strideAccum, ArrayRef<int64_t>{dim});
+        stridesArray = LLVM::InsertValueOp::create(
+            builder, loc, stridesArray, strideAccum, ArrayRef<int64_t>{dim});
         if (dim > 0) {
-          Value dimIndexVal = builder.create<LLVM::ConstantOp>(
-              loc, i64Type, builder.getI64IntegerAttr(dim));
+          Value dimIndexVal = LLVM::ConstantOp::create(
+              builder, loc, i64Type, builder.getI64IntegerAttr(dim));
           Value dimPtr =
-              builder.create<LLVM::GEPOp>(loc, ptrType, ptrType, shapePtr,
-                                          ArrayRef<LLVM::GEPArg>{dimIndexVal});
-          Value dimSize = builder.create<LLVM::LoadOp>(loc, i64Type, dimPtr);
-          strideAccum = builder.create<LLVM::MulOp>(loc, strideAccum, dimSize);
+              LLVM::GEPOp::create(builder, loc, ptrType, ptrType, shapePtr,
+                                  ArrayRef<LLVM::GEPArg>{dimIndexVal});
+          Value dimSize = LLVM::LoadOp::create(builder, loc, i64Type, dimPtr);
+          strideAccum = LLVM::MulOp::create(builder, loc, strideAccum, dimSize);
         }
       }
-      memref = builder.create<LLVM::InsertValueOp>(loc, memref, stridesArray,
-                                                   ArrayRef<int64_t>{4});
+      memref = LLVM::InsertValueOp::create(builder, loc, memref, stridesArray,
+                                           ArrayRef<int64_t>{4});
 
       Value memrefPtr =
-          builder.create<LLVM::AllocaOp>(loc, ptrType, memrefType, c1_i64, 0);
-      builder.create<LLVM::StoreOp>(loc, memref, memrefPtr);
+          LLVM::AllocaOp::create(builder, loc, ptrType, memrefType, c1_i64, 0);
+      LLVM::StoreOp::create(builder, loc, memref, memrefPtr);
 
-      Value indexVal = builder.create<LLVM::ConstantOp>(
-          loc, i64Type, builder.getI64IntegerAttr(i));
+      Value indexVal = LLVM::ConstantOp::create(builder, loc, i64Type,
+                                                builder.getI64IntegerAttr(i));
       Value arraySlot =
-          builder.create<LLVM::GEPOp>(loc, ptrType, ptrType, inputMemrefArray,
-                                      ArrayRef<LLVM::GEPArg>{indexVal});
-      builder.create<LLVM::StoreOp>(loc, memrefPtr, arraySlot);
+          LLVM::GEPOp::create(builder, loc, ptrType, ptrType, inputMemrefArray,
+                              ArrayRef<LLVM::GEPArg>{indexVal});
+      LLVM::StoreOp::create(builder, loc, memrefPtr, arraySlot);
 
       llvm::errs() << "[GenerateInterface] Built input memref " << i
                    << " using opaque TensorBuffer accessors\n";
     }
 
-    Value numOutputsVal = builder.create<LLVM::ConstantOp>(
-        loc, i64Type, builder.getI64IntegerAttr(numOutputs));
-    Value outputMemrefArray =
-        builder.create<LLVM::AllocaOp>(loc, ptrType, ptrType, numOutputsVal, 0);
+    Value numOutputsVal = LLVM::ConstantOp::create(
+        builder, loc, i64Type, builder.getI64IntegerAttr(numOutputs));
+    Value outputMemrefArray = LLVM::AllocaOp::create(builder, loc, ptrType,
+                                                     ptrType, numOutputsVal, 0);
 
     for (size_t i = 0; i < numOutputs; i++) {
       int64_t rank = cast<DenseI64ArrayAttr>(outputShapes.getValue()[i]).size();
@@ -920,74 +919,72 @@ private:
 
       Value bufferPtr = outputBuffers[i];
 
-      Value gpuPtrRaw =
-          builder
-              .create<LLVM::CallOp>(loc, getGpuPtrFunc, ValueRange{bufferPtr})
-              .getResult();
+      Value gpuPtrRaw = LLVM::CallOp::create(builder, loc, getGpuPtrFunc,
+                                             ValueRange{bufferPtr})
+                            .getResult();
 
       Type gpuPtrType = LLVM::LLVMPointerType::get(builder.getContext(), 1);
       Value gpuPtr =
-          builder.create<LLVM::AddrSpaceCastOp>(loc, gpuPtrType, gpuPtrRaw);
+          LLVM::AddrSpaceCastOp::create(builder, loc, gpuPtrType, gpuPtrRaw);
 
-      Value shapePtr =
-          builder
-              .create<LLVM::CallOp>(loc, getShapePtrFunc, ValueRange{bufferPtr})
-              .getResult();
+      Value shapePtr = LLVM::CallOp::create(builder, loc, getShapePtrFunc,
+                                            ValueRange{bufferPtr})
+                           .getResult();
 
-      Value memref = builder.create<LLVM::UndefOp>(loc, memrefType);
-      memref = builder.create<LLVM::InsertValueOp>(loc, memref, gpuPtr,
-                                                   ArrayRef<int64_t>{0});
-      memref = builder.create<LLVM::InsertValueOp>(loc, memref, gpuPtr,
-                                                   ArrayRef<int64_t>{1});
-      Value c0_i64 = builder.create<LLVM::ConstantOp>(
-          loc, i64Type, builder.getI64IntegerAttr(0));
-      memref = builder.create<LLVM::InsertValueOp>(loc, memref, c0_i64,
-                                                   ArrayRef<int64_t>{2});
+      Value memref = LLVM::UndefOp::create(builder, loc, memrefType);
+      memref = LLVM::InsertValueOp::create(builder, loc, memref, gpuPtr,
+                                           ArrayRef<int64_t>{0});
+      memref = LLVM::InsertValueOp::create(builder, loc, memref, gpuPtr,
+                                           ArrayRef<int64_t>{1});
+      Value c0_i64 = LLVM::ConstantOp::create(builder, loc, i64Type,
+                                              builder.getI64IntegerAttr(0));
+      memref = LLVM::InsertValueOp::create(builder, loc, memref, c0_i64,
+                                           ArrayRef<int64_t>{2});
 
-      Value sizesArray = builder.create<LLVM::UndefOp>(
-          loc, LLVM::LLVMArrayType::get(i64Type, rank));
+      Value sizesArray = LLVM::UndefOp::create(
+          builder, loc, LLVM::LLVMArrayType::get(i64Type, rank));
       for (int64_t dim = 0; dim < rank; dim++) {
-        Value dimIndexVal = builder.create<LLVM::ConstantOp>(
-            loc, i64Type, builder.getI64IntegerAttr(dim));
+        Value dimIndexVal = LLVM::ConstantOp::create(
+            builder, loc, i64Type, builder.getI64IntegerAttr(dim));
         Value dimPtr =
-            builder.create<LLVM::GEPOp>(loc, ptrType, ptrType, shapePtr,
-                                        ArrayRef<LLVM::GEPArg>{dimIndexVal});
-        Value dimValue = builder.create<LLVM::LoadOp>(loc, i64Type, dimPtr);
-        sizesArray = builder.create<LLVM::InsertValueOp>(
-            loc, sizesArray, dimValue, ArrayRef<int64_t>{dim});
+            LLVM::GEPOp::create(builder, loc, ptrType, ptrType, shapePtr,
+                                ArrayRef<LLVM::GEPArg>{dimIndexVal});
+        Value dimValue = LLVM::LoadOp::create(builder, loc, i64Type, dimPtr);
+        sizesArray = LLVM::InsertValueOp::create(
+            builder, loc, sizesArray, dimValue, ArrayRef<int64_t>{dim});
       }
-      memref = builder.create<LLVM::InsertValueOp>(loc, memref, sizesArray,
-                                                   ArrayRef<int64_t>{3});
+      memref = LLVM::InsertValueOp::create(builder, loc, memref, sizesArray,
+                                           ArrayRef<int64_t>{3});
 
-      Value stridesArray = builder.create<LLVM::UndefOp>(
-          loc, LLVM::LLVMArrayType::get(i64Type, rank));
+      Value stridesArray = LLVM::UndefOp::create(
+          builder, loc, LLVM::LLVMArrayType::get(i64Type, rank));
       Value strideAccum = c1_i64;
       for (int64_t dim = rank - 1; dim >= 0; dim--) {
-        stridesArray = builder.create<LLVM::InsertValueOp>(
-            loc, stridesArray, strideAccum, ArrayRef<int64_t>{dim});
+        stridesArray = LLVM::InsertValueOp::create(
+            builder, loc, stridesArray, strideAccum, ArrayRef<int64_t>{dim});
         if (dim > 0) {
-          Value dimIndexVal = builder.create<LLVM::ConstantOp>(
-              loc, i64Type, builder.getI64IntegerAttr(dim));
+          Value dimIndexVal = LLVM::ConstantOp::create(
+              builder, loc, i64Type, builder.getI64IntegerAttr(dim));
           Value dimPtr =
-              builder.create<LLVM::GEPOp>(loc, ptrType, ptrType, shapePtr,
-                                          ArrayRef<LLVM::GEPArg>{dimIndexVal});
-          Value dimSize = builder.create<LLVM::LoadOp>(loc, i64Type, dimPtr);
-          strideAccum = builder.create<LLVM::MulOp>(loc, strideAccum, dimSize);
+              LLVM::GEPOp::create(builder, loc, ptrType, ptrType, shapePtr,
+                                  ArrayRef<LLVM::GEPArg>{dimIndexVal});
+          Value dimSize = LLVM::LoadOp::create(builder, loc, i64Type, dimPtr);
+          strideAccum = LLVM::MulOp::create(builder, loc, strideAccum, dimSize);
         }
       }
-      memref = builder.create<LLVM::InsertValueOp>(loc, memref, stridesArray,
-                                                   ArrayRef<int64_t>{4});
+      memref = LLVM::InsertValueOp::create(builder, loc, memref, stridesArray,
+                                           ArrayRef<int64_t>{4});
 
       Value memrefPtr =
-          builder.create<LLVM::AllocaOp>(loc, ptrType, memrefType, c1_i64, 0);
-      builder.create<LLVM::StoreOp>(loc, memref, memrefPtr);
+          LLVM::AllocaOp::create(builder, loc, ptrType, memrefType, c1_i64, 0);
+      LLVM::StoreOp::create(builder, loc, memref, memrefPtr);
 
-      Value indexVal = builder.create<LLVM::ConstantOp>(
-          loc, i64Type, builder.getI64IntegerAttr(i));
+      Value indexVal = LLVM::ConstantOp::create(builder, loc, i64Type,
+                                                builder.getI64IntegerAttr(i));
       Value arraySlot =
-          builder.create<LLVM::GEPOp>(loc, ptrType, ptrType, outputMemrefArray,
-                                      ArrayRef<LLVM::GEPArg>{indexVal});
-      builder.create<LLVM::StoreOp>(loc, memrefPtr, arraySlot);
+          LLVM::GEPOp::create(builder, loc, ptrType, ptrType, outputMemrefArray,
+                              ArrayRef<LLVM::GEPArg>{indexVal});
+      LLVM::StoreOp::create(builder, loc, memrefPtr, arraySlot);
     }
 
     // Call @main with arrays of pointers
@@ -996,25 +993,23 @@ private:
     auto mainFunc = module.lookupSymbol<LLVM::LLVMFuncOp>("main_graph");
     if (!mainFunc) {
       llvm::errs() << "[GenerateInterface] Warning: @main_graph not found\n";
-      builder.create<LLVM::BrOp>(loc, mainSuccessBlock);
+      LLVM::BrOp::create(builder, loc, mainSuccessBlock);
     } else {
-      Value mainRet =
-          builder
-              .create<LLVM::CallOp>(
-                  loc, mainFunc,
-                  ValueRange{state, inputMemrefArray, outputMemrefArray})
-              .getResult();
+      Value mainRet = LLVM::CallOp::create(builder, loc, mainFunc,
+                                           ValueRange{state, inputMemrefArray,
+                                                      outputMemrefArray})
+                          .getResult();
 
-      Value mainFailed = builder.create<LLVM::ICmpOp>(
-          loc, LLVM::ICmpPredicate::ne, mainRet, c0_i32);
+      Value mainFailed = LLVM::ICmpOp::create(
+          builder, loc, LLVM::ICmpPredicate::ne, mainRet, c0_i32);
 
       Block *storeMainErrorBlock = funcOp.addBlock();
-      builder.create<LLVM::CondBrOp>(loc, mainFailed, storeMainErrorBlock,
-                                     mainSuccessBlock);
+      LLVM::CondBrOp::create(builder, loc, mainFailed, storeMainErrorBlock,
+                             mainSuccessBlock);
 
       builder.setInsertionPointToStart(storeMainErrorBlock);
-      builder.create<LLVM::StoreOp>(loc, mainRet, errorCodePtr);
-      builder.create<LLVM::BrOp>(loc, errorCleanupBlock);
+      LLVM::StoreOp::create(builder, loc, mainRet, errorCodePtr);
+      LLVM::BrOp::create(builder, loc, errorCleanupBlock);
     }
 
     // Finalize output tensors (D2H, sync, cleanup)
@@ -1023,23 +1018,22 @@ private:
     for (size_t i = 0; i < numOutputs; i++) {
       Value bufferPtr = outputBuffers[i];
 
-      Value retVal = builder
-                         .create<LLVM::CallOp>(loc, finalizeOutputFunc,
-                                               ValueRange{state, bufferPtr})
+      Value retVal = LLVM::CallOp::create(builder, loc, finalizeOutputFunc,
+                                          ValueRange{state, bufferPtr})
                          .getResult();
 
-      Value failed = builder.create<LLVM::ICmpOp>(loc, LLVM::ICmpPredicate::ne,
-                                                  retVal, c0_i32);
+      Value failed = LLVM::ICmpOp::create(builder, loc, LLVM::ICmpPredicate::ne,
+                                          retVal, c0_i32);
 
       Block *continueBlock = funcOp.addBlock();
 
       Block *storeErrorBlock = funcOp.addBlock();
-      builder.create<LLVM::CondBrOp>(loc, failed, storeErrorBlock,
-                                     continueBlock);
+      LLVM::CondBrOp::create(builder, loc, failed, storeErrorBlock,
+                             continueBlock);
 
       builder.setInsertionPointToStart(storeErrorBlock);
-      builder.create<LLVM::StoreOp>(loc, retVal, errorCodePtr);
-      builder.create<LLVM::BrOp>(loc, errorCleanupBlock);
+      LLVM::StoreOp::create(builder, loc, retVal, errorCodePtr);
+      LLVM::BrOp::create(builder, loc, errorCleanupBlock);
 
       builder.setInsertionPointToStart(continueBlock);
     }
@@ -1047,23 +1041,23 @@ private:
     // Free input tensors
     for (size_t i = 0; i < numInputs; i++) {
       Value bufferPtr = inputBuffers[i];
-      builder.create<LLVM::CallOp>(loc, freeInputFunc,
-                                   ValueRange{state, bufferPtr});
+      LLVM::CallOp::create(builder, loc, freeInputFunc,
+                           ValueRange{state, bufferPtr});
     }
 
-    builder.create<LLVM::ReturnOp>(loc, c0_i32);
+    LLVM::ReturnOp::create(builder, loc, c0_i32);
 
     // Error cleanup block
     builder.setInsertionPointToStart(errorCleanupBlock);
 
-    Value errorCode = builder.create<LLVM::LoadOp>(loc, i32Type, errorCodePtr);
+    Value errorCode = LLVM::LoadOp::create(builder, loc, i32Type, errorCodePtr);
 
     for (size_t i = 0; i < inputBuffers.size(); i++) {
-      builder.create<LLVM::CallOp>(loc, freeInputFunc,
-                                   ValueRange{state, inputBuffers[i]});
+      LLVM::CallOp::create(builder, loc, freeInputFunc,
+                           ValueRange{state, inputBuffers[i]});
     }
 
-    builder.create<LLVM::ReturnOp>(loc, errorCode);
+    LLVM::ReturnOp::create(builder, loc, errorCode);
   }
 
   void generateInferenceCleanup(ModuleOp module) {
@@ -1078,7 +1072,7 @@ private:
     auto funcType = LLVM::LLVMFunctionType::get(i32Type, paramTypes);
 
     auto funcOp =
-        builder.create<LLVM::LLVMFuncOp>(loc, "inference_cleanup", funcType);
+        LLVM::LLVMFuncOp::create(builder, loc, "inference_cleanup", funcType);
     funcOp->setAttr("llvm.emit_c_interface", builder.getUnitAttr());
     funcOp->setAttr("sym_visibility", builder.getStringAttr("public"));
 
@@ -1089,10 +1083,10 @@ private:
 
     auto runtimeCleanupFunc =
         module.lookupSymbol<LLVM::LLVMFuncOp>("hipdnn_ep_state_cleanup");
-    auto call = builder.create<LLVM::CallOp>(loc, runtimeCleanupFunc,
-                                             ValueRange{state});
+    auto call = LLVM::CallOp::create(builder, loc, runtimeCleanupFunc,
+                                     ValueRange{state});
 
-    builder.create<LLVM::ReturnOp>(loc, call.getResult());
+    LLVM::ReturnOp::create(builder, loc, call.getResult());
   }
 };
 

--- a/lib/Dialect/Transforms/GenerateInterface.cpp
+++ b/lib/Dialect/Transforms/GenerateInterface.cpp
@@ -243,6 +243,30 @@ static Value buildMemrefDescriptor(OpBuilder &builder, Location loc,
   return desc;
 }
 
+/// Emit a call to a runtime function and branch to errorBlock if it
+/// returns non-zero.  Leaves the builder at the start of a new
+/// continuation block.
+static void emitErrorCheckedCall(OpBuilder &builder, Location loc,
+                                 LLVM::LLVMFuncOp func, ValueRange args,
+                                 Value errorCodePtr, Block *errorBlock,
+                                 LLVM::LLVMFuncOp &parentFunc) {
+  Value ret = LLVM::CallOp::create(builder, loc, func, args).getResult();
+  Value zero = LLVM::ConstantOp::create(builder, loc, builder.getI32Type(),
+                                        builder.getI32IntegerAttr(0));
+  Value failed =
+      LLVM::ICmpOp::create(builder, loc, LLVM::ICmpPredicate::ne, ret, zero);
+
+  Block *continueBlock = parentFunc.addBlock();
+  Block *storeErrorBlock = parentFunc.addBlock();
+  LLVM::CondBrOp::create(builder, loc, failed, storeErrorBlock, continueBlock);
+
+  builder.setInsertionPointToStart(storeErrorBlock);
+  LLVM::StoreOp::create(builder, loc, ret, errorCodePtr);
+  LLVM::BrOp::create(builder, loc, errorBlock);
+
+  builder.setInsertionPointToStart(continueBlock);
+}
+
 class GenerateInterfacePass
     : public PassWrapper<GenerateInterfacePass, OperationPass<ModuleOp>> {
 public:
@@ -627,26 +651,10 @@ private:
           builder.getI64IntegerAttr(
               cast<DenseI64ArrayAttr>(inputShapes.getValue()[i]).size()));
 
-      Value retVal =
-          LLVM::CallOp::create(
-              builder, loc, prepareInputFunc,
-              ValueRange{state, inputsSpanPtr, indexVal, rankVal, bufferPtr})
-              .getResult();
-
-      Value failed = LLVM::ICmpOp::create(builder, loc, LLVM::ICmpPredicate::ne,
-                                          retVal, c0_i32);
-
-      Block *continueBlock = funcOp.addBlock();
-
-      Block *storeErrorBlock = funcOp.addBlock();
-      LLVM::CondBrOp::create(builder, loc, failed, storeErrorBlock,
-                             continueBlock);
-
-      builder.setInsertionPointToStart(storeErrorBlock);
-      LLVM::StoreOp::create(builder, loc, retVal, errorCodePtr);
-      LLVM::BrOp::create(builder, loc, errorCleanupBlock);
-
-      builder.setInsertionPointToStart(continueBlock);
+      emitErrorCheckedCall(
+          builder, loc, prepareInputFunc,
+          ValueRange{state, inputsSpanPtr, indexVal, rankVal, bufferPtr},
+          errorCodePtr, errorCleanupBlock, funcOp);
     }
 
     // Prepare all output tensors
@@ -663,26 +671,10 @@ private:
           builder.getI64IntegerAttr(
               cast<DenseI64ArrayAttr>(outputShapes.getValue()[i]).size()));
 
-      Value retVal =
-          LLVM::CallOp::create(
-              builder, loc, prepareOutputFunc,
-              ValueRange{state, outputsSpanPtr, indexVal, rankVal, bufferPtr})
-              .getResult();
-
-      Value failed = LLVM::ICmpOp::create(builder, loc, LLVM::ICmpPredicate::ne,
-                                          retVal, c0_i32);
-
-      Block *continueBlock = funcOp.addBlock();
-
-      Block *storeErrorBlock = funcOp.addBlock();
-      LLVM::CondBrOp::create(builder, loc, failed, storeErrorBlock,
-                             continueBlock);
-
-      builder.setInsertionPointToStart(storeErrorBlock);
-      LLVM::StoreOp::create(builder, loc, retVal, errorCodePtr);
-      LLVM::BrOp::create(builder, loc, errorCleanupBlock);
-
-      builder.setInsertionPointToStart(continueBlock);
+      emitErrorCheckedCall(
+          builder, loc, prepareOutputFunc,
+          ValueRange{state, outputsSpanPtr, indexVal, rankVal, bufferPtr},
+          errorCodePtr, errorCleanupBlock, funcOp);
     }
 
     // Build memref structs for @main call
@@ -756,21 +748,11 @@ private:
       COMPILER_DEBUG_LOG("[GenerateInterface] Warning: @main_graph not found\n");
       LLVM::BrOp::create(builder, loc, mainSuccessBlock);
     } else {
-      Value mainRet = LLVM::CallOp::create(builder, loc, mainFunc,
-                                           ValueRange{state, inputMemrefArray,
-                                                      outputMemrefArray})
-                          .getResult();
-
-      Value mainFailed = LLVM::ICmpOp::create(
-          builder, loc, LLVM::ICmpPredicate::ne, mainRet, c0_i32);
-
-      Block *storeMainErrorBlock = funcOp.addBlock();
-      LLVM::CondBrOp::create(builder, loc, mainFailed, storeMainErrorBlock,
-                             mainSuccessBlock);
-
-      builder.setInsertionPointToStart(storeMainErrorBlock);
-      LLVM::StoreOp::create(builder, loc, mainRet, errorCodePtr);
-      LLVM::BrOp::create(builder, loc, errorCleanupBlock);
+      emitErrorCheckedCall(builder, loc, mainFunc,
+                           ValueRange{state, inputMemrefArray,
+                                      outputMemrefArray},
+                           errorCodePtr, errorCleanupBlock, funcOp);
+      LLVM::BrOp::create(builder, loc, mainSuccessBlock);
     }
 
     // Finalize output tensors (D2H, sync, cleanup)
@@ -778,25 +760,9 @@ private:
 
     for (size_t i = 0; i < numOutputs; i++) {
       Value bufferPtr = outputBuffers[i];
-
-      Value retVal = LLVM::CallOp::create(builder, loc, finalizeOutputFunc,
-                                          ValueRange{state, bufferPtr})
-                         .getResult();
-
-      Value failed = LLVM::ICmpOp::create(builder, loc, LLVM::ICmpPredicate::ne,
-                                          retVal, c0_i32);
-
-      Block *continueBlock = funcOp.addBlock();
-
-      Block *storeErrorBlock = funcOp.addBlock();
-      LLVM::CondBrOp::create(builder, loc, failed, storeErrorBlock,
-                             continueBlock);
-
-      builder.setInsertionPointToStart(storeErrorBlock);
-      LLVM::StoreOp::create(builder, loc, retVal, errorCodePtr);
-      LLVM::BrOp::create(builder, loc, errorCleanupBlock);
-
-      builder.setInsertionPointToStart(continueBlock);
+      emitErrorCheckedCall(builder, loc, finalizeOutputFunc,
+                           ValueRange{state, bufferPtr}, errorCodePtr,
+                           errorCleanupBlock, funcOp);
     }
 
     // Free input tensors

--- a/lib/Dialect/Transforms/GenerateInterface.cpp
+++ b/lib/Dialect/Transforms/GenerateInterface.cpp
@@ -136,7 +136,11 @@ std::string buildMetadataJson(ModuleOp module,
   return json;
 }
 
-/// Generate global constant string for metadata JSON
+/// Generate global constant string for metadata JSON.
+///
+/// Generated IR (1 input / 1 output, shape [8], element_size 4):
+///   llvm.mlir.global internal constant @__metadata_json(
+///       "{\0A  \22constants_filename\22: ...}\0A\00") {addr_space = 0 : i32}
 void generateMetadataGlobal(ModuleOp module, const std::string &jsonStr) {
   OpBuilder builder(module.getContext());
   auto i8Type = builder.getI8Type();
@@ -149,7 +153,11 @@ void generateMetadataGlobal(ModuleOp module, const std::string &jsonStr) {
                          builder.getStringAttr(jsonStr + '\0'));
 }
 
-/// Generate global constant for metadata FlatBuffers blob
+/// Generate global constant for metadata FlatBuffers blob.
+///
+/// Generated IR (168-byte blob):
+///   llvm.mlir.global internal constant @__metadata_blob(
+///       "\18\00\00\00...") {addr_space = 0 : i32}
 void generateMetadataBlobGlobal(ModuleOp module,
                                 const std::vector<uint8_t> &blob) {
   OpBuilder builder(module.getContext());
@@ -403,8 +411,9 @@ private:
         module.lookupSymbol<LLVM::LLVMFuncOp>("inference_compute") ||
         module.lookupSymbol<LLVM::LLVMFuncOp>("inference_cleanup") ||
         module.lookupSymbol<LLVM::LLVMFuncOp>("inference_get_metadata_json")) {
-      COMPILER_DEBUG_LOG("[GenerateInterface] Interface functions already exist. "
-                        << "Pass already ran.\n");
+      COMPILER_DEBUG_LOG(
+          "[GenerateInterface] Interface functions already exist. "
+          << "Pass already ran.\n");
       return failure();
     }
 
@@ -442,13 +451,40 @@ private:
     return success();
   }
 
-  /// Generated IR example (no pool):
-  ///   llvm.func @inference_init(%state: !llvm.ptr, %fs: !llvm.ptr) -> i32
+  /// hipdnn_ep_state_init_with_fs: alloc RuntimeState, init HIP/MIOpen/hipBLASLt,
+  /// parse metadata blob, read constants via FileSystem and upload to GPU.
+  ///
+  /// Generated IR (no pool — from test_basic_interface.mlir):
+  ///   llvm.func @inference_init(%arg0: !llvm.ptr, %arg1: !llvm.ptr) -> i32
   ///       attributes {llvm.emit_c_interface, sym_visibility = "public"} {
-  ///     %blob = llvm.mlir.addressof @__metadata_blob : !llvm.ptr
-  ///     %sz  = llvm.mlir.constant(168 : i64) : i64
-  ///     %rc  = llvm.call @hipdnn_ep_state_init_with_fs(%state, %fs, %blob,
-  ///     %sz) llvm.return %rc : i32
+  ///     %0 = llvm.mlir.addressof @__metadata_blob : !llvm.ptr
+  ///     %1 = llvm.mlir.constant(168 : i64) : i64
+  ///     %2 = llvm.call @hipdnn_ep_state_init_with_fs(%arg0, %arg1, %0, %1)
+  ///              : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64) -> i32
+  ///     llvm.return %2 : i32
+  ///   }
+  ///
+  /// Generated IR (with pool, 2 buffers at offsets 0/4096, pool 8192):
+  ///   llvm.func @inference_init(%arg0: !llvm.ptr, %arg1: !llvm.ptr) -> i32
+  ///       attributes {llvm.emit_c_interface, sym_visibility = "public"} {
+  ///     %0 = llvm.mlir.addressof @__metadata_blob : !llvm.ptr
+  ///     %1 = llvm.mlir.constant(168 : i64) : i64
+  ///     %2 = llvm.call @hipdnn_ep_state_init_with_fs(%arg0, %arg1, %0, %1)
+  ///              : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64) -> i32
+  ///     %3 = llvm.mlir.constant(0 : i32) : i32
+  ///     %4 = llvm.icmp "ne" %2, %3 : i32
+  ///     llvm.cond_br %4, ^bb2, ^bb1
+  ///   ^bb1:
+  ///     %5 = llvm.load %arg0 : !llvm.ptr -> !llvm.ptr
+  ///     %6 = llvm.mlir.constant(2 : i64) : i64
+  ///     %7 = llvm.alloca %6 x i64 : (i64) -> !llvm.ptr
+  ///     // ... store offsets [0, 4096] into %7 via GEP+store ...
+  ///     %14 = llvm.mlir.constant(8192 : i64) : i64
+  ///     %15 = llvm.call @hipdnn_ep_pool_init(%5, %14, %7, %6)
+  ///               : (!llvm.ptr, i64, !llvm.ptr, i64) -> i32
+  ///     llvm.return %15 : i32
+  ///   ^bb2:
+  ///     llvm.return %2 : i32
   ///   }
   void generateInferenceInit(ModuleOp module, size_t blobSize) {
     OpBuilder builder(module.getContext());
@@ -756,7 +792,8 @@ private:
 
     auto mainFunc = module.lookupSymbol<LLVM::LLVMFuncOp>("main_graph");
     if (!mainFunc) {
-      COMPILER_DEBUG_LOG("[GenerateInterface] Warning: @main_graph not found\n");
+      COMPILER_DEBUG_LOG(
+          "[GenerateInterface] Warning: @main_graph not found\n");
       LLVM::BrOp::create(builder, loc, mainSuccessBlock);
     } else {
       emitErrorCheckedCall(

--- a/lib/Dialect/Transforms/GenerateInterface.cpp
+++ b/lib/Dialect/Transforms/GenerateInterface.cpp
@@ -1,0 +1,1110 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+//===----------------------------------------------------------------------===//
+// Generate Interface Pass - Create C-compatible interface functions
+//===----------------------------------------------------------------------===//
+// This pass generates four C-ABI compatible functions that wrap the internal
+// @main_graph function:
+// - inference_init: Allocate context, create handles, upload constants
+// - inference_compute: Parse inputs/outputs, call @main_graph
+// - inference_cleanup: Free resources
+// - inference_get_metadata_json: Return JSON metadata (input/output shapes)
+//===----------------------------------------------------------------------===//
+
+#include "compilation_options_generated.h"
+#include "flatbuffers/flatbuffers.h"
+#include "hip/Dialect/IR/HipDialect.h"
+#include "hip/Dialect/Transforms/Passes.h"
+#include "hip/flatbuffers_json.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+#include "model_metadata_generated.h"
+#include "model_metadata_schema.h"
+
+using namespace mlir;
+
+namespace {
+
+/// Build a TensorInfoT native struct from module tensor attributes at index i.
+static std::unique_ptr<mlir::hip::TensorInfoT>
+buildTensorInfo(ArrayAttr shapes, DenseI64ArrayAttr elementSizes, size_t i) {
+  auto ti = std::make_unique<mlir::hip::TensorInfoT>();
+  if (shapes && i < shapes.size()) {
+    if (auto shapeAttr = dyn_cast<DenseI64ArrayAttr>(shapes.getValue()[i]))
+      ti->shape.assign(shapeAttr.asArrayRef().begin(),
+                       shapeAttr.asArrayRef().end());
+  }
+  ti->element_size =
+      (elementSizes && i < elementSizes.size()) ? elementSizes[i] : 4;
+  return ti;
+}
+
+/// Build a HipModelMetaInfoT native struct from module attributes.
+/// Shared by buildMetadataBlob() and buildMetadataJson() so module attributes
+/// are read exactly once.
+/// Each ConstantInfo carries both size and a running byte offset, enabling
+/// future non-sequential or grouped constant layouts.
+mlir::hip::HipModelMetaInfoT
+buildMetadataNative(ModuleOp module, const std::string &constantsFile) {
+  auto inputShapes = module->getAttrOfType<ArrayAttr>("hipdnn.input_shapes");
+  auto outputShapes = module->getAttrOfType<ArrayAttr>("hipdnn.output_shapes");
+  auto inputElementSizes =
+      module->getAttrOfType<DenseI64ArrayAttr>("hipdnn.input_element_sizes");
+  auto outputElementSizes =
+      module->getAttrOfType<DenseI64ArrayAttr>("hipdnn.output_element_sizes");
+  auto inputCountAttr =
+      module->getAttrOfType<IntegerAttr>("hipdnn.input_count");
+  auto outputCountAttr =
+      module->getAttrOfType<IntegerAttr>("hipdnn.output_count");
+  auto constantSizesAttr =
+      module->getAttrOfType<DenseI64ArrayAttr>("hipdnn.constant_sizes");
+  auto constantOffsetsAttr =
+      module->getAttrOfType<DenseI64ArrayAttr>("hipdnn.constant_offsets");
+
+  mlir::hip::HipModelMetaInfoT meta;
+  meta.version = 1;
+  meta.constants_filename = constantsFile;
+
+  if (constantSizesAttr) {
+    auto sizes = constantSizesAttr.asArrayRef();
+    auto offsets = constantOffsetsAttr ? constantOffsetsAttr.asArrayRef()
+                                       : ArrayRef<int64_t>{};
+    for (size_t i = 0; i < sizes.size(); ++i) {
+      auto ci = std::make_unique<mlir::hip::ConstantInfoT>();
+      ci->size = sizes[i];
+      ci->offset = (i < offsets.size()) ? offsets[i] : 0;
+      meta.constants.push_back(std::move(ci));
+    }
+  }
+
+  if (inputShapes) {
+    for (size_t i = 0; i < inputShapes.size(); i++)
+      meta.inputs.push_back(buildTensorInfo(inputShapes, inputElementSizes, i));
+  }
+  if (outputShapes) {
+    for (size_t i = 0; i < outputShapes.size(); i++)
+      meta.outputs.push_back(
+          buildTensorInfo(outputShapes, outputElementSizes, i));
+  }
+
+  meta.input_count = inputCountAttr
+                         ? inputCountAttr.getInt()
+                         : (int64_t)(inputShapes ? inputShapes.size() : 0);
+  meta.output_count = outputCountAttr
+                          ? outputCountAttr.getInt()
+                          : (int64_t)(outputShapes ? outputShapes.size() : 0);
+
+  return meta;
+}
+
+/// Build FlatBuffers binary blob from module attributes.
+/// Uses generated HipModelMetaInfoT native struct (--gen-object-api) so the
+/// code tracks schema changes automatically.
+std::vector<uint8_t> buildMetadataBlob(ModuleOp module,
+                                       const std::string &constantsFile) {
+  mlir::hip::HipModelMetaInfoT meta =
+      buildMetadataNative(module, constantsFile);
+  flatbuffers::FlatBufferBuilder fbb;
+  fbb.Finish(mlir::hip::HipModelMetaInfo::Pack(fbb, &meta));
+  const uint8_t *buf = fbb.GetBufferPointer();
+  return std::vector<uint8_t>(buf, buf + fbb.GetSize());
+}
+
+/// Build JSON metadata string from module attributes.
+/// Uses the embedded model_metadata schema so the output is always consistent
+/// with the binary blob — no manual field mapping needed.
+std::string buildMetadataJson(ModuleOp module,
+                              const std::string &constantsFile) {
+  mlir::hip::HipModelMetaInfoT meta =
+      buildMetadataNative(module, constantsFile);
+  return mlir::hip::toJson<mlir::hip::HipModelMetaInfoT>(
+      meta, mlir::hip::k_model_metadata_schema());
+}
+
+/// Generate global constant string for metadata JSON
+void generateMetadataGlobal(ModuleOp module, const std::string &jsonStr) {
+  OpBuilder builder(module.getContext());
+  auto i8Type = builder.getI8Type();
+  auto arrayType = LLVM::LLVMArrayType::get(i8Type, jsonStr.size() + 1);
+
+  builder.setInsertionPoint(&module.getBody()->front());
+  builder.create<LLVM::GlobalOp>(
+      module.getLoc(), arrayType, /*isConstant=*/true, LLVM::Linkage::Internal,
+      "__metadata_json", builder.getStringAttr(jsonStr + '\0'));
+}
+
+/// Generate global constant for metadata FlatBuffers blob
+void generateMetadataBlobGlobal(ModuleOp module,
+                                const std::vector<uint8_t> &blob) {
+  OpBuilder builder(module.getContext());
+  auto i8Type = builder.getI8Type();
+  auto arrayType = LLVM::LLVMArrayType::get(i8Type, blob.size());
+
+  builder.setInsertionPoint(&module.getBody()->front());
+  llvm::StringRef blobRef(reinterpret_cast<const char *>(blob.data()),
+                          blob.size());
+  builder.create<LLVM::GlobalOp>(module.getLoc(), arrayType,
+                                 /*isConstant=*/true, LLVM::Linkage::Internal,
+                                 "__metadata_blob",
+                                 builder.getStringAttr(blobRef));
+}
+
+/// Generate inference_get_metadata_json() function
+void generateInferenceGetMetadataJson(ModuleOp module) {
+  OpBuilder builder(module.getContext());
+  Location loc = module.getLoc();
+
+  builder.setInsertionPointToEnd(module.getBody());
+
+  auto ptrType = LLVM::LLVMPointerType::get(builder.getContext(), 0);
+  auto funcType = LLVM::LLVMFunctionType::get(ptrType, {});
+
+  auto funcOp = builder.create<LLVM::LLVMFuncOp>(
+      loc, "inference_get_metadata_json", funcType);
+  funcOp->setAttr("llvm.emit_c_interface", builder.getUnitAttr());
+  funcOp->setAttr("sym_visibility", builder.getStringAttr("public"));
+
+  Block *entry = funcOp.addEntryBlock(builder);
+  builder.setInsertionPointToStart(entry);
+
+  Value addr =
+      builder.create<LLVM::AddressOfOp>(loc, ptrType, "__metadata_json");
+  builder.create<LLVM::ReturnOp>(loc, addr);
+}
+
+class GenerateInterfacePass
+    : public PassWrapper<GenerateInterfacePass, OperationPass<ModuleOp>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(GenerateInterfacePass)
+
+  explicit GenerateInterfacePass(
+      const mlir::hip::CompilationOptionsT &compilationOptions)
+      : compilationOptions_(compilationOptions) {}
+  explicit GenerateInterfacePass(
+      mlir::hip::CompilationOptionsT &&compilationOptions)
+      : compilationOptions_(std::move(compilationOptions)) {}
+
+  StringRef getArgument() const final { return "generate-interface"; }
+  StringRef getDescription() const final {
+    return "Generate C interface wrapper functions (inference_init, "
+           "inference_compute, inference_cleanup, inference_get_metadata_json)";
+  }
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<LLVM::LLVMDialect>();
+    registry.insert<func::FuncDialect>();
+    registry.insert<arith::ArithDialect>();
+  }
+
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+
+    if (failed(verifyPrerequisites(module))) {
+      signalPassFailure();
+      return;
+    }
+
+    auto inputCount = module->getAttrOfType<IntegerAttr>("hipdnn.input_count");
+    auto outputCount =
+        module->getAttrOfType<IntegerAttr>("hipdnn.output_count");
+
+    const std::string constantsFile =
+        !compilationOptions_.constants_file.empty()
+            ? compilationOptions_.constants_file
+            : "constants.bin";
+
+    std::vector<uint8_t> blob = buildMetadataBlob(module, constantsFile);
+    generateMetadataBlobGlobal(module, blob);
+
+    declareMallocFree(module);
+
+    declareRuntimeFunctions(module);
+
+    generateInferenceInit(module, blob.size());
+    auto inputShapes = module->getAttrOfType<ArrayAttr>("hipdnn.input_shapes");
+    auto outputShapes =
+        module->getAttrOfType<ArrayAttr>("hipdnn.output_shapes");
+    auto inputElementSizes =
+        module->getAttrOfType<DenseI64ArrayAttr>("hipdnn.input_element_sizes");
+    auto outputElementSizes =
+        module->getAttrOfType<DenseI64ArrayAttr>("hipdnn.output_element_sizes");
+    generateInferenceCompute(module, inputCount, inputShapes, inputElementSizes,
+                             outputCount, outputShapes, outputElementSizes);
+    generateInferenceCleanup(module);
+
+    std::string json = buildMetadataJson(module, constantsFile);
+    generateMetadataGlobal(module, json);
+    generateInferenceGetMetadataJson(module);
+
+    llvm::errs() << "[GenerateInterface] Generated 4 interface functions\n";
+  }
+
+private:
+  mlir::hip::CompilationOptionsT compilationOptions_;
+
+  /// Returns LLVM struct type for memref: (ptr, ptr, i64, array<rank x i64>,
+  /// array<rank x i64>)
+  Type getMemRefStructType(OpBuilder &builder, int64_t rank,
+                           unsigned addrSpace) {
+    MLIRContext *ctx = builder.getContext();
+    Type ptrType = LLVM::LLVMPointerType::get(ctx, addrSpace);
+    Type i64Type = builder.getI64Type();
+    Type sizeArrayType = LLVM::LLVMArrayType::get(i64Type, rank);
+    Type strideArrayType = LLVM::LLVMArrayType::get(i64Type, rank);
+
+    return LLVM::LLVMStructType::getLiteral(
+        ctx, {ptrType, ptrType, i64Type, sizeArrayType, strideArrayType});
+  }
+
+  void declareMallocFree(ModuleOp module) {
+    OpBuilder builder(module.getContext());
+    Location loc = module.getLoc();
+    Type ptrType = LLVM::LLVMPointerType::get(builder.getContext(), 0);
+
+    auto &firstOp = module.getBody()->front();
+    builder.setInsertionPoint(&firstOp);
+
+    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("malloc")) {
+      auto mallocFuncType =
+          LLVM::LLVMFunctionType::get(ptrType, {builder.getI64Type()});
+      auto mallocFunc =
+          builder.create<LLVM::LLVMFuncOp>(loc, "malloc", mallocFuncType);
+      mallocFunc.setLinkage(LLVM::Linkage::External);
+    }
+
+    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("free")) {
+      auto freeFuncType = LLVM::LLVMFunctionType::get(
+          LLVM::LLVMVoidType::get(builder.getContext()), {ptrType});
+      auto freeFunc =
+          builder.create<LLVM::LLVMFuncOp>(loc, "free", freeFuncType);
+      freeFunc.setLinkage(LLVM::Linkage::External);
+    }
+  }
+
+  void declareRuntimeFunctions(ModuleOp module) {
+    OpBuilder builder(module.getContext());
+    Location loc = module.getLoc();
+    Type ptrType = LLVM::LLVMPointerType::get(builder.getContext(), 0);
+    Type i32Type = builder.getI32Type();
+    Type i64Type = builder.getI64Type();
+    Type voidType = LLVM::LLVMVoidType::get(builder.getContext());
+
+    auto &firstOp = module.getBody()->front();
+    builder.setInsertionPoint(&firstOp);
+
+    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("hipStreamCreate")) {
+      auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType});
+      auto func =
+          builder.create<LLVM::LLVMFuncOp>(loc, "hipStreamCreate", funcType);
+      func.setLinkage(LLVM::Linkage::External);
+    }
+
+    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("hipStreamDestroy")) {
+      auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType});
+      auto func =
+          builder.create<LLVM::LLVMFuncOp>(loc, "hipStreamDestroy", funcType);
+      func.setLinkage(LLVM::Linkage::External);
+    }
+
+    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("hipStreamSynchronize")) {
+      auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType});
+      auto func = builder.create<LLVM::LLVMFuncOp>(loc, "hipStreamSynchronize",
+                                                   funcType);
+      func.setLinkage(LLVM::Linkage::External);
+    }
+
+    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("miopenCreate")) {
+      auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType});
+      auto func =
+          builder.create<LLVM::LLVMFuncOp>(loc, "miopenCreate", funcType);
+      func.setLinkage(LLVM::Linkage::External);
+    }
+
+    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("miopenSetStream")) {
+      auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType, ptrType});
+      auto func =
+          builder.create<LLVM::LLVMFuncOp>(loc, "miopenSetStream", funcType);
+      func.setLinkage(LLVM::Linkage::External);
+    }
+
+    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("miopenDestroy")) {
+      auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType});
+      auto func =
+          builder.create<LLVM::LLVMFuncOp>(loc, "miopenDestroy", funcType);
+      func.setLinkage(LLVM::Linkage::External);
+    }
+
+    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("hipblasLtCreate")) {
+      auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType});
+      auto func =
+          builder.create<LLVM::LLVMFuncOp>(loc, "hipblasLtCreate", funcType);
+      func.setLinkage(LLVM::Linkage::External);
+    }
+
+    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("hipblasLtDestroy")) {
+      auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType});
+      auto func =
+          builder.create<LLVM::LLVMFuncOp>(loc, "hipblasLtDestroy", funcType);
+      func.setLinkage(LLVM::Linkage::External);
+    }
+
+    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("hipdnn_ep_state_cleanup")) {
+      auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType});
+      auto func = builder.create<LLVM::LLVMFuncOp>(
+          loc, "hipdnn_ep_state_cleanup", funcType);
+      func.setLinkage(LLVM::Linkage::External);
+    }
+
+    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("wrap_hipMalloc")) {
+      auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType, i64Type});
+      auto func =
+          builder.create<LLVM::LLVMFuncOp>(loc, "wrap_hipMalloc", funcType);
+      func.setLinkage(LLVM::Linkage::External);
+    }
+
+    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("wrap_hipFree")) {
+      auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType});
+      auto func =
+          builder.create<LLVM::LLVMFuncOp>(loc, "wrap_hipFree", funcType);
+      func.setLinkage(LLVM::Linkage::External);
+    }
+
+    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("wrap_hipMemcpyH2D")) {
+      auto funcType = LLVM::LLVMFunctionType::get(
+          i32Type, {ptrType, ptrType, i64Type, ptrType});
+      auto func =
+          builder.create<LLVM::LLVMFuncOp>(loc, "wrap_hipMemcpyH2D", funcType);
+      func.setLinkage(LLVM::Linkage::External);
+    }
+
+    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("wrap_hipMemcpyD2H")) {
+      auto funcType = LLVM::LLVMFunctionType::get(
+          i32Type, {ptrType, ptrType, i64Type, ptrType});
+      auto func =
+          builder.create<LLVM::LLVMFuncOp>(loc, "wrap_hipMemcpyD2H", funcType);
+      func.setLinkage(LLVM::Linkage::External);
+    }
+
+    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("wrap_hipStreamSynchronize")) {
+      auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType});
+      auto func = builder.create<LLVM::LLVMFuncOp>(
+          loc, "wrap_hipStreamSynchronize", funcType);
+      func.setLinkage(LLVM::Linkage::External);
+    }
+
+    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("hipdnn_ep_state_get_stream")) {
+      auto funcType = LLVM::LLVMFunctionType::get(ptrType, {ptrType});
+      auto func = builder.create<LLVM::LLVMFuncOp>(
+          loc, "hipdnn_ep_state_get_stream", funcType);
+      func.setLinkage(LLVM::Linkage::External);
+    }
+
+    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("hipdnn_ep_pool_init")) {
+      auto funcType = LLVM::LLVMFunctionType::get(
+          i32Type, {ptrType, i64Type, ptrType, i64Type});
+      auto func = builder.create<LLVM::LLVMFuncOp>(loc, "hipdnn_ep_pool_init",
+                                                   funcType);
+      func.setLinkage(LLVM::Linkage::External);
+    }
+
+    if (!module.lookupSymbol<LLVM::LLVMFuncOp>(
+            "hipdnn_ep_get_buffer_from_pool")) {
+      auto funcType = LLVM::LLVMFunctionType::get(ptrType, {ptrType, i64Type});
+      auto func = builder.create<LLVM::LLVMFuncOp>(
+          loc, "hipdnn_ep_get_buffer_from_pool", funcType);
+      func.setLinkage(LLVM::Linkage::External);
+    }
+
+    if (!module.lookupSymbol<LLVM::LLVMFuncOp>(
+            "hipdnn_ep_tensor_prepare_input")) {
+      Type sizeTType = i64Type;
+      auto funcType = LLVM::LLVMFunctionType::get(
+          i32Type, {ptrType, ptrType, sizeTType, sizeTType, ptrType});
+      auto func = builder.create<LLVM::LLVMFuncOp>(
+          loc, "hipdnn_ep_tensor_prepare_input", funcType);
+      func.setLinkage(LLVM::Linkage::External);
+    }
+
+    if (!module.lookupSymbol<LLVM::LLVMFuncOp>(
+            "hipdnn_ep_tensor_prepare_output")) {
+      Type sizeTType = i64Type;
+      auto funcType = LLVM::LLVMFunctionType::get(
+          i32Type, {ptrType, ptrType, sizeTType, sizeTType, ptrType});
+      auto func = builder.create<LLVM::LLVMFuncOp>(
+          loc, "hipdnn_ep_tensor_prepare_output", funcType);
+      func.setLinkage(LLVM::Linkage::External);
+    }
+
+    if (!module.lookupSymbol<LLVM::LLVMFuncOp>(
+            "hipdnn_ep_tensor_finalize_output")) {
+      auto funcType = LLVM::LLVMFunctionType::get(i32Type, {ptrType, ptrType});
+      auto func = builder.create<LLVM::LLVMFuncOp>(
+          loc, "hipdnn_ep_tensor_finalize_output", funcType);
+      func.setLinkage(LLVM::Linkage::External);
+    }
+
+    if (!module.lookupSymbol<LLVM::LLVMFuncOp>("hipdnn_ep_tensor_free_input")) {
+      auto funcType = LLVM::LLVMFunctionType::get(voidType, {ptrType, ptrType});
+      auto func = builder.create<LLVM::LLVMFuncOp>(
+          loc, "hipdnn_ep_tensor_free_input", funcType);
+      func.setLinkage(LLVM::Linkage::External);
+    }
+
+    if (!module.lookupSymbol<LLVM::LLVMFuncOp>(
+            "hipdnn_ep_tensor_buffer_get_gpu_ptr")) {
+      auto funcType = LLVM::LLVMFunctionType::get(ptrType, {ptrType});
+      auto func = builder.create<LLVM::LLVMFuncOp>(
+          loc, "hipdnn_ep_tensor_buffer_get_gpu_ptr", funcType);
+      func.setLinkage(LLVM::Linkage::External);
+    }
+
+    if (!module.lookupSymbol<LLVM::LLVMFuncOp>(
+            "hipdnn_ep_tensor_buffer_get_host_ptr")) {
+      auto funcType = LLVM::LLVMFunctionType::get(ptrType, {ptrType});
+      auto func = builder.create<LLVM::LLVMFuncOp>(
+          loc, "hipdnn_ep_tensor_buffer_get_host_ptr", funcType);
+      func.setLinkage(LLVM::Linkage::External);
+    }
+
+    if (!module.lookupSymbol<LLVM::LLVMFuncOp>(
+            "hipdnn_ep_tensor_buffer_get_shape_ptr")) {
+      auto funcType = LLVM::LLVMFunctionType::get(ptrType, {ptrType});
+      auto func = builder.create<LLVM::LLVMFuncOp>(
+          loc, "hipdnn_ep_tensor_buffer_get_shape_ptr", funcType);
+      func.setLinkage(LLVM::Linkage::External);
+    }
+
+    if (!module.lookupSymbol<LLVM::LLVMFuncOp>(
+            "hipdnn_ep_tensor_buffer_get_rank")) {
+      auto funcType = LLVM::LLVMFunctionType::get(i64Type, {ptrType});
+      auto func = builder.create<LLVM::LLVMFuncOp>(
+          loc, "hipdnn_ep_tensor_buffer_get_rank", funcType);
+      func.setLinkage(LLVM::Linkage::External);
+    }
+
+    if (!module.lookupSymbol<LLVM::LLVMFuncOp>(
+            "hipdnn_ep_tensor_buffer_get_size_bytes")) {
+      auto funcType = LLVM::LLVMFunctionType::get(i64Type, {ptrType});
+      auto func = builder.create<LLVM::LLVMFuncOp>(
+          loc, "hipdnn_ep_tensor_buffer_get_size_bytes", funcType);
+      func.setLinkage(LLVM::Linkage::External);
+    }
+
+    if (!module.lookupSymbol<LLVM::LLVMFuncOp>(
+            "hipdnn_ep_state_init_with_fs")) {
+      auto funcType = LLVM::LLVMFunctionType::get(
+          i32Type, {ptrType, ptrType, ptrType, i64Type});
+      auto func = builder.create<LLVM::LLVMFuncOp>(
+          loc, "hipdnn_ep_state_init_with_fs", funcType);
+      func.setLinkage(LLVM::Linkage::External);
+    }
+  }
+
+  LogicalResult verifyPrerequisites(ModuleOp module) {
+    MLIRContext *ctx = module.getContext();
+    Type ptrType = LLVM::LLVMPointerType::get(ctx, 0);
+    Type i32Type = IntegerType::get(ctx, 32);
+    Type i64Type = IntegerType::get(ctx, 64);
+
+    if (module.lookupSymbol<LLVM::LLVMFuncOp>("inference_init") ||
+        module.lookupSymbol<LLVM::LLVMFuncOp>("inference_compute") ||
+        module.lookupSymbol<LLVM::LLVMFuncOp>("inference_cleanup") ||
+        module.lookupSymbol<LLVM::LLVMFuncOp>("inference_get_metadata_json")) {
+      llvm::errs() << "[GenerateInterface] Interface functions already exist. "
+                   << "Pass already ran.\n";
+      return failure();
+    }
+
+    auto mainFunc = module.lookupSymbol<LLVM::LLVMFuncOp>("main_graph");
+    if (!mainFunc) {
+      if (module.lookupSymbol<func::FuncOp>("main_graph")) {
+        llvm::errs() << "[GenerateInterface] @main_graph is func.func, needs "
+                        "llvm.func.\n"
+                     << "Run --convert-hip-to-llvm first.\n";
+        return failure();
+      }
+      llvm::errs() << "[GenerateInterface] @main_graph (llvm.func) not found\n";
+      return failure();
+    }
+
+    auto mainType = mainFunc.getFunctionType();
+    if (mainType.getNumParams() != 3 || mainType.getParamType(0) != ptrType ||
+        mainType.getParamType(1) != ptrType ||
+        mainType.getParamType(2) != ptrType ||
+        mainType.getReturnType() != i32Type) {
+      llvm::errs() << "[GenerateInterface] @main_graph has wrong signature.\n"
+                   << "Expected: (ptr, ptr, ptr) -> i32\n";
+      return failure();
+    }
+
+    if (!module->getAttr("hipdnn.input_count")) {
+      llvm::errs()
+          << "[GenerateInterface] hipdnn.input_count attribute missing\n";
+      return failure();
+    }
+    if (!module->getAttr("hipdnn.input_shapes")) {
+      llvm::errs()
+          << "[GenerateInterface] hipdnn.input_shapes attribute missing\n";
+      return failure();
+    }
+    if (!module->getAttr("hipdnn.output_count")) {
+      llvm::errs()
+          << "[GenerateInterface] hipdnn.output_count attribute missing\n";
+      return failure();
+    }
+    if (!module->getAttr("hipdnn.output_shapes")) {
+      llvm::errs()
+          << "[GenerateInterface] hipdnn.output_shapes attribute missing\n";
+      return failure();
+    }
+
+    return success();
+  }
+
+  void generateInferenceInit(ModuleOp module, size_t blobSize) {
+    OpBuilder builder(module.getContext());
+    Location loc = module.getLoc();
+
+    builder.setInsertionPointToEnd(module.getBody());
+
+    Type ptrType = LLVM::LLVMPointerType::get(builder.getContext(), 0);
+    Type i32Type = builder.getI32Type();
+    Type i64Type = builder.getI64Type();
+
+    SmallVector<Type> paramTypes = {ptrType, ptrType};
+    auto funcType = LLVM::LLVMFunctionType::get(i32Type, paramTypes);
+
+    auto funcOp =
+        builder.create<LLVM::LLVMFuncOp>(loc, "inference_init", funcType);
+    funcOp->setAttr("llvm.emit_c_interface", builder.getUnitAttr());
+    funcOp->setAttr("sym_visibility", builder.getStringAttr("public"));
+
+    Block *entryBlock = funcOp.addEntryBlock(builder);
+    builder.setInsertionPointToStart(entryBlock);
+
+    Value outStatePtr = entryBlock->getArgument(0);
+    Value fsPtr = entryBlock->getArgument(1);
+
+    Value blobPtr =
+        builder.create<LLVM::AddressOfOp>(loc, ptrType, "__metadata_blob");
+    Value blobSizeVal = builder.create<LLVM::ConstantOp>(
+        loc, i64Type, builder.getI64IntegerAttr((int64_t)blobSize));
+
+    auto initFunc =
+        module.lookupSymbol<LLVM::LLVMFuncOp>("hipdnn_ep_state_init_with_fs");
+    LLVM::CallOp initCall = builder.create<LLVM::CallOp>(
+        loc, initFunc, ValueRange{outStatePtr, fsPtr, blobPtr, blobSizeVal});
+
+    auto poolSizeAttr = module->getAttrOfType<IntegerAttr>("hipdnn.pool_size");
+    auto bufferOffsetsAttr =
+        module->getAttrOfType<ArrayAttr>("hipdnn.buffer_offsets");
+    auto bufferCountAttr =
+        module->getAttrOfType<IntegerAttr>("hipdnn.buffer_count");
+
+    if (!poolSizeAttr || !bufferOffsetsAttr || !bufferCountAttr) {
+      llvm::errs()
+          << "[GenerateInterface] FATAL: memory pool attributes missing.\n"
+          << "  hipdnn.pool_size: " << (poolSizeAttr ? "present" : "MISSING")
+          << "\n"
+          << "  hipdnn.buffer_offsets: "
+          << (bufferOffsetsAttr ? "present" : "MISSING") << "\n"
+          << "  hipdnn.buffer_count: "
+          << (bufferCountAttr ? "present" : "MISSING") << "\n"
+          << "  Ensure MemoryPoolingPass runs before GenerateInterface.\n";
+      signalPassFailure();
+      return;
+    }
+
+    if (poolSizeAttr.getInt() > 0) {
+      size_t poolSize = poolSizeAttr.getInt();
+      size_t numBuffers = bufferCountAttr.getInt();
+      auto offsetsAttrArray = bufferOffsetsAttr.getValue();
+
+      Value zero_i32 = builder.create<LLVM::ConstantOp>(
+          loc, i32Type, builder.getI32IntegerAttr(0));
+      Value initFailed = builder.create<LLVM::ICmpOp>(
+          loc, LLVM::ICmpPredicate::ne, initCall.getResult(), zero_i32);
+
+      Block *poolInitBlock = funcOp.addBlock();
+      Block *returnErrorBlock = funcOp.addBlock();
+
+      builder.create<LLVM::CondBrOp>(loc, initFailed, returnErrorBlock,
+                                     poolInitBlock);
+
+      builder.setInsertionPointToStart(returnErrorBlock);
+      builder.create<LLVM::ReturnOp>(loc, initCall.getResult());
+
+      builder.setInsertionPointToStart(poolInitBlock);
+
+      Value statePtr = builder.create<LLVM::LoadOp>(loc, ptrType, outStatePtr);
+
+      Value numBuffersVal = builder.create<LLVM::ConstantOp>(
+          loc, i64Type, builder.getI64IntegerAttr(numBuffers));
+
+      Value offsetsArrayPtr = builder.create<LLVM::AllocaOp>(
+          loc, ptrType, i64Type, numBuffersVal, 0);
+
+      for (size_t i = 0; i < numBuffers; i++) {
+        auto offsetAttr = dyn_cast<IntegerAttr>(offsetsAttrArray[i]);
+        Value offset = builder.create<LLVM::ConstantOp>(
+            loc, i64Type, builder.getI64IntegerAttr(offsetAttr.getInt()));
+        Value idx = builder.create<LLVM::ConstantOp>(
+            loc, i64Type, builder.getI64IntegerAttr(i));
+        Value elemPtr = builder.create<LLVM::GEPOp>(
+            loc, ptrType, i64Type, offsetsArrayPtr, ValueRange{idx});
+        builder.create<LLVM::StoreOp>(loc, offset, elemPtr);
+      }
+
+      auto poolInitFunc =
+          module.lookupSymbol<LLVM::LLVMFuncOp>("hipdnn_ep_pool_init");
+      Value poolSizeVal = builder.create<LLVM::ConstantOp>(
+          loc, i64Type, builder.getI64IntegerAttr(poolSize));
+      auto poolInitCall = builder.create<LLVM::CallOp>(
+          loc, poolInitFunc,
+          ValueRange{statePtr, poolSizeVal, offsetsArrayPtr, numBuffersVal});
+
+      builder.create<LLVM::ReturnOp>(loc, poolInitCall.getResult());
+    } else {
+      builder.create<LLVM::ReturnOp>(loc, initCall.getResult());
+    }
+  }
+
+  void generateInferenceCompute(ModuleOp module, IntegerAttr inputCount,
+                                ArrayAttr inputShapes,
+                                DenseI64ArrayAttr inputElementSizes,
+                                IntegerAttr outputCount, ArrayAttr outputShapes,
+                                DenseI64ArrayAttr outputElementSizes) {
+    OpBuilder builder(module.getContext());
+    Location loc = module.getLoc();
+    builder.setInsertionPointToEnd(module.getBody());
+
+    Type ptrType = LLVM::LLVMPointerType::get(builder.getContext(), 0);
+    Type i32Type = builder.getI32Type();
+    Type i64Type = builder.getI64Type();
+    SmallVector<Type> paramTypes = {ptrType, ptrType, ptrType};
+    auto funcType = LLVM::LLVMFunctionType::get(i32Type, paramTypes);
+
+    auto funcOp =
+        builder.create<LLVM::LLVMFuncOp>(loc, "inference_compute", funcType);
+    funcOp->setAttr("llvm.emit_c_interface", builder.getUnitAttr());
+    funcOp->setAttr("sym_visibility", builder.getStringAttr("public"));
+
+    Block *entryBlock = funcOp.addEntryBlock(builder);
+    builder.setInsertionPointToStart(entryBlock);
+
+    Value state = entryBlock->getArgument(0);
+    Value inputsSpanPtr = entryBlock->getArgument(1);
+    Value outputsSpanPtr = entryBlock->getArgument(2);
+
+    size_t numInputs = inputShapes ? inputShapes.size() : 0;
+    size_t numOutputs = outputShapes ? outputShapes.size() : 0;
+
+    Value c0_i32 = builder.create<LLVM::ConstantOp>(
+        loc, i32Type, builder.getI32IntegerAttr(0));
+    Value c1_i64 = builder.create<LLVM::ConstantOp>(
+        loc, i64Type, builder.getI64IntegerAttr(1));
+
+    auto prepareInputFunc =
+        module.lookupSymbol<LLVM::LLVMFuncOp>("hipdnn_ep_tensor_prepare_input");
+    auto prepareOutputFunc = module.lookupSymbol<LLVM::LLVMFuncOp>(
+        "hipdnn_ep_tensor_prepare_output");
+    auto finalizeOutputFunc = module.lookupSymbol<LLVM::LLVMFuncOp>(
+        "hipdnn_ep_tensor_finalize_output");
+    auto freeInputFunc =
+        module.lookupSymbol<LLVM::LLVMFuncOp>("hipdnn_ep_tensor_free_input");
+
+    auto getGpuPtrFunc = module.lookupSymbol<LLVM::LLVMFuncOp>(
+        "hipdnn_ep_tensor_buffer_get_gpu_ptr");
+    auto getShapePtrFunc = module.lookupSymbol<LLVM::LLVMFuncOp>(
+        "hipdnn_ep_tensor_buffer_get_shape_ptr");
+
+    Value errorCodePtr =
+        builder.create<LLVM::AllocaOp>(loc, ptrType, i32Type, c1_i64, 0);
+
+    SmallVector<Value> inputBuffers;
+    SmallVector<Value> outputBuffers;
+
+    Type i8Type = builder.getI8Type();
+    Value tensorBufferSize = builder.create<LLVM::ConstantOp>(
+        loc, i64Type, builder.getI64IntegerAttr(48));
+
+    for (size_t i = 0; i < numInputs; i++) {
+      Value bufferPtr = builder.create<LLVM::AllocaOp>(loc, ptrType, i8Type,
+                                                       tensorBufferSize, 0);
+      inputBuffers.push_back(bufferPtr);
+    }
+    for (size_t i = 0; i < numOutputs; i++) {
+      Value bufferPtr = builder.create<LLVM::AllocaOp>(loc, ptrType, i8Type,
+                                                       tensorBufferSize, 0);
+      outputBuffers.push_back(bufferPtr);
+    }
+
+    Block *errorCleanupBlock = funcOp.addBlock();
+
+    // Prepare all input tensors
+    SmallVector<Value> inputMemrefs;
+
+    for (size_t i = 0; i < numInputs; i++) {
+      Value bufferPtr = inputBuffers[i];
+
+      Value indexVal = builder.create<LLVM::ConstantOp>(
+          loc, i64Type, builder.getI64IntegerAttr(i));
+
+      Value rankVal = builder.create<LLVM::ConstantOp>(
+          loc, i64Type,
+          builder.getI64IntegerAttr(
+              cast<DenseI64ArrayAttr>(inputShapes.getValue()[i]).size()));
+
+      Value retVal =
+          builder
+              .create<LLVM::CallOp>(loc, prepareInputFunc,
+                                    ValueRange{state, inputsSpanPtr, indexVal,
+                                               rankVal, bufferPtr})
+              .getResult();
+
+      Value failed = builder.create<LLVM::ICmpOp>(loc, LLVM::ICmpPredicate::ne,
+                                                  retVal, c0_i32);
+
+      Block *continueBlock = funcOp.addBlock();
+
+      Block *storeErrorBlock = funcOp.addBlock();
+      builder.create<LLVM::CondBrOp>(loc, failed, storeErrorBlock,
+                                     continueBlock);
+
+      builder.setInsertionPointToStart(storeErrorBlock);
+      builder.create<LLVM::StoreOp>(loc, retVal, errorCodePtr);
+      builder.create<LLVM::BrOp>(loc, errorCleanupBlock);
+
+      builder.setInsertionPointToStart(continueBlock);
+    }
+
+    // Prepare all output tensors
+    SmallVector<Value> outputMemrefs;
+
+    for (size_t i = 0; i < numOutputs; i++) {
+      Value bufferPtr = outputBuffers[i];
+
+      Value indexVal = builder.create<LLVM::ConstantOp>(
+          loc, i64Type, builder.getI64IntegerAttr(i));
+
+      Value rankVal = builder.create<LLVM::ConstantOp>(
+          loc, i64Type,
+          builder.getI64IntegerAttr(
+              cast<DenseI64ArrayAttr>(outputShapes.getValue()[i]).size()));
+
+      Value retVal =
+          builder
+              .create<LLVM::CallOp>(loc, prepareOutputFunc,
+                                    ValueRange{state, outputsSpanPtr, indexVal,
+                                               rankVal, bufferPtr})
+              .getResult();
+
+      Value failed = builder.create<LLVM::ICmpOp>(loc, LLVM::ICmpPredicate::ne,
+                                                  retVal, c0_i32);
+
+      Block *continueBlock = funcOp.addBlock();
+
+      Block *storeErrorBlock = funcOp.addBlock();
+      builder.create<LLVM::CondBrOp>(loc, failed, storeErrorBlock,
+                                     continueBlock);
+
+      builder.setInsertionPointToStart(storeErrorBlock);
+      builder.create<LLVM::StoreOp>(loc, retVal, errorCodePtr);
+      builder.create<LLVM::BrOp>(loc, errorCleanupBlock);
+
+      builder.setInsertionPointToStart(continueBlock);
+    }
+
+    // Build memref structs for @main call
+    Value numInputsVal = builder.create<LLVM::ConstantOp>(
+        loc, i64Type, builder.getI64IntegerAttr(numInputs));
+    Value inputMemrefArray =
+        builder.create<LLVM::AllocaOp>(loc, ptrType, ptrType, numInputsVal, 0);
+
+    for (size_t i = 0; i < numInputs; i++) {
+      int64_t rank = cast<DenseI64ArrayAttr>(inputShapes.getValue()[i]).size();
+      Type memrefType = getMemRefStructType(builder, rank, 1);
+
+      Value bufferPtr = inputBuffers[i];
+
+      Value gpuPtrRaw =
+          builder
+              .create<LLVM::CallOp>(loc, getGpuPtrFunc, ValueRange{bufferPtr})
+              .getResult();
+
+      Type gpuPtrType = LLVM::LLVMPointerType::get(builder.getContext(), 1);
+      Value gpuPtr =
+          builder.create<LLVM::AddrSpaceCastOp>(loc, gpuPtrType, gpuPtrRaw);
+
+      Value shapePtr =
+          builder
+              .create<LLVM::CallOp>(loc, getShapePtrFunc, ValueRange{bufferPtr})
+              .getResult();
+
+      Value memref = builder.create<LLVM::UndefOp>(loc, memrefType);
+
+      memref = builder.create<LLVM::InsertValueOp>(loc, memref, gpuPtr,
+                                                   ArrayRef<int64_t>{0});
+
+      memref = builder.create<LLVM::InsertValueOp>(loc, memref, gpuPtr,
+                                                   ArrayRef<int64_t>{1});
+
+      Value c0_i64 = builder.create<LLVM::ConstantOp>(
+          loc, i64Type, builder.getI64IntegerAttr(0));
+      memref = builder.create<LLVM::InsertValueOp>(loc, memref, c0_i64,
+                                                   ArrayRef<int64_t>{2});
+
+      Value sizesArray = builder.create<LLVM::UndefOp>(
+          loc, LLVM::LLVMArrayType::get(i64Type, rank));
+      for (int64_t dim = 0; dim < rank; dim++) {
+        Value dimIndexVal = builder.create<LLVM::ConstantOp>(
+            loc, i64Type, builder.getI64IntegerAttr(dim));
+        Value dimPtr =
+            builder.create<LLVM::GEPOp>(loc, ptrType, ptrType, shapePtr,
+                                        ArrayRef<LLVM::GEPArg>{dimIndexVal});
+        Value dimValue = builder.create<LLVM::LoadOp>(loc, i64Type, dimPtr);
+        sizesArray = builder.create<LLVM::InsertValueOp>(
+            loc, sizesArray, dimValue, ArrayRef<int64_t>{dim});
+      }
+      memref = builder.create<LLVM::InsertValueOp>(loc, memref, sizesArray,
+                                                   ArrayRef<int64_t>{3});
+
+      Value stridesArray = builder.create<LLVM::UndefOp>(
+          loc, LLVM::LLVMArrayType::get(i64Type, rank));
+      Value strideAccum = c1_i64;
+      for (int64_t dim = rank - 1; dim >= 0; dim--) {
+        stridesArray = builder.create<LLVM::InsertValueOp>(
+            loc, stridesArray, strideAccum, ArrayRef<int64_t>{dim});
+        if (dim > 0) {
+          Value dimIndexVal = builder.create<LLVM::ConstantOp>(
+              loc, i64Type, builder.getI64IntegerAttr(dim));
+          Value dimPtr =
+              builder.create<LLVM::GEPOp>(loc, ptrType, ptrType, shapePtr,
+                                          ArrayRef<LLVM::GEPArg>{dimIndexVal});
+          Value dimSize = builder.create<LLVM::LoadOp>(loc, i64Type, dimPtr);
+          strideAccum = builder.create<LLVM::MulOp>(loc, strideAccum, dimSize);
+        }
+      }
+      memref = builder.create<LLVM::InsertValueOp>(loc, memref, stridesArray,
+                                                   ArrayRef<int64_t>{4});
+
+      Value memrefPtr =
+          builder.create<LLVM::AllocaOp>(loc, ptrType, memrefType, c1_i64, 0);
+      builder.create<LLVM::StoreOp>(loc, memref, memrefPtr);
+
+      Value indexVal = builder.create<LLVM::ConstantOp>(
+          loc, i64Type, builder.getI64IntegerAttr(i));
+      Value arraySlot =
+          builder.create<LLVM::GEPOp>(loc, ptrType, ptrType, inputMemrefArray,
+                                      ArrayRef<LLVM::GEPArg>{indexVal});
+      builder.create<LLVM::StoreOp>(loc, memrefPtr, arraySlot);
+
+      llvm::errs() << "[GenerateInterface] Built input memref " << i
+                   << " using opaque TensorBuffer accessors\n";
+    }
+
+    Value numOutputsVal = builder.create<LLVM::ConstantOp>(
+        loc, i64Type, builder.getI64IntegerAttr(numOutputs));
+    Value outputMemrefArray =
+        builder.create<LLVM::AllocaOp>(loc, ptrType, ptrType, numOutputsVal, 0);
+
+    for (size_t i = 0; i < numOutputs; i++) {
+      int64_t rank = cast<DenseI64ArrayAttr>(outputShapes.getValue()[i]).size();
+      Type memrefType = getMemRefStructType(builder, rank, 1);
+
+      Value bufferPtr = outputBuffers[i];
+
+      Value gpuPtrRaw =
+          builder
+              .create<LLVM::CallOp>(loc, getGpuPtrFunc, ValueRange{bufferPtr})
+              .getResult();
+
+      Type gpuPtrType = LLVM::LLVMPointerType::get(builder.getContext(), 1);
+      Value gpuPtr =
+          builder.create<LLVM::AddrSpaceCastOp>(loc, gpuPtrType, gpuPtrRaw);
+
+      Value shapePtr =
+          builder
+              .create<LLVM::CallOp>(loc, getShapePtrFunc, ValueRange{bufferPtr})
+              .getResult();
+
+      Value memref = builder.create<LLVM::UndefOp>(loc, memrefType);
+      memref = builder.create<LLVM::InsertValueOp>(loc, memref, gpuPtr,
+                                                   ArrayRef<int64_t>{0});
+      memref = builder.create<LLVM::InsertValueOp>(loc, memref, gpuPtr,
+                                                   ArrayRef<int64_t>{1});
+      Value c0_i64 = builder.create<LLVM::ConstantOp>(
+          loc, i64Type, builder.getI64IntegerAttr(0));
+      memref = builder.create<LLVM::InsertValueOp>(loc, memref, c0_i64,
+                                                   ArrayRef<int64_t>{2});
+
+      Value sizesArray = builder.create<LLVM::UndefOp>(
+          loc, LLVM::LLVMArrayType::get(i64Type, rank));
+      for (int64_t dim = 0; dim < rank; dim++) {
+        Value dimIndexVal = builder.create<LLVM::ConstantOp>(
+            loc, i64Type, builder.getI64IntegerAttr(dim));
+        Value dimPtr =
+            builder.create<LLVM::GEPOp>(loc, ptrType, ptrType, shapePtr,
+                                        ArrayRef<LLVM::GEPArg>{dimIndexVal});
+        Value dimValue = builder.create<LLVM::LoadOp>(loc, i64Type, dimPtr);
+        sizesArray = builder.create<LLVM::InsertValueOp>(
+            loc, sizesArray, dimValue, ArrayRef<int64_t>{dim});
+      }
+      memref = builder.create<LLVM::InsertValueOp>(loc, memref, sizesArray,
+                                                   ArrayRef<int64_t>{3});
+
+      Value stridesArray = builder.create<LLVM::UndefOp>(
+          loc, LLVM::LLVMArrayType::get(i64Type, rank));
+      Value strideAccum = c1_i64;
+      for (int64_t dim = rank - 1; dim >= 0; dim--) {
+        stridesArray = builder.create<LLVM::InsertValueOp>(
+            loc, stridesArray, strideAccum, ArrayRef<int64_t>{dim});
+        if (dim > 0) {
+          Value dimIndexVal = builder.create<LLVM::ConstantOp>(
+              loc, i64Type, builder.getI64IntegerAttr(dim));
+          Value dimPtr =
+              builder.create<LLVM::GEPOp>(loc, ptrType, ptrType, shapePtr,
+                                          ArrayRef<LLVM::GEPArg>{dimIndexVal});
+          Value dimSize = builder.create<LLVM::LoadOp>(loc, i64Type, dimPtr);
+          strideAccum = builder.create<LLVM::MulOp>(loc, strideAccum, dimSize);
+        }
+      }
+      memref = builder.create<LLVM::InsertValueOp>(loc, memref, stridesArray,
+                                                   ArrayRef<int64_t>{4});
+
+      Value memrefPtr =
+          builder.create<LLVM::AllocaOp>(loc, ptrType, memrefType, c1_i64, 0);
+      builder.create<LLVM::StoreOp>(loc, memref, memrefPtr);
+
+      Value indexVal = builder.create<LLVM::ConstantOp>(
+          loc, i64Type, builder.getI64IntegerAttr(i));
+      Value arraySlot =
+          builder.create<LLVM::GEPOp>(loc, ptrType, ptrType, outputMemrefArray,
+                                      ArrayRef<LLVM::GEPArg>{indexVal});
+      builder.create<LLVM::StoreOp>(loc, memrefPtr, arraySlot);
+    }
+
+    // Call @main with arrays of pointers
+    Block *mainSuccessBlock = funcOp.addBlock();
+
+    auto mainFunc = module.lookupSymbol<LLVM::LLVMFuncOp>("main_graph");
+    if (!mainFunc) {
+      llvm::errs() << "[GenerateInterface] Warning: @main_graph not found\n";
+      builder.create<LLVM::BrOp>(loc, mainSuccessBlock);
+    } else {
+      Value mainRet =
+          builder
+              .create<LLVM::CallOp>(
+                  loc, mainFunc,
+                  ValueRange{state, inputMemrefArray, outputMemrefArray})
+              .getResult();
+
+      Value mainFailed = builder.create<LLVM::ICmpOp>(
+          loc, LLVM::ICmpPredicate::ne, mainRet, c0_i32);
+
+      Block *storeMainErrorBlock = funcOp.addBlock();
+      builder.create<LLVM::CondBrOp>(loc, mainFailed, storeMainErrorBlock,
+                                     mainSuccessBlock);
+
+      builder.setInsertionPointToStart(storeMainErrorBlock);
+      builder.create<LLVM::StoreOp>(loc, mainRet, errorCodePtr);
+      builder.create<LLVM::BrOp>(loc, errorCleanupBlock);
+    }
+
+    // Finalize output tensors (D2H, sync, cleanup)
+    builder.setInsertionPointToStart(mainSuccessBlock);
+
+    for (size_t i = 0; i < numOutputs; i++) {
+      Value bufferPtr = outputBuffers[i];
+
+      Value retVal = builder
+                         .create<LLVM::CallOp>(loc, finalizeOutputFunc,
+                                               ValueRange{state, bufferPtr})
+                         .getResult();
+
+      Value failed = builder.create<LLVM::ICmpOp>(loc, LLVM::ICmpPredicate::ne,
+                                                  retVal, c0_i32);
+
+      Block *continueBlock = funcOp.addBlock();
+
+      Block *storeErrorBlock = funcOp.addBlock();
+      builder.create<LLVM::CondBrOp>(loc, failed, storeErrorBlock,
+                                     continueBlock);
+
+      builder.setInsertionPointToStart(storeErrorBlock);
+      builder.create<LLVM::StoreOp>(loc, retVal, errorCodePtr);
+      builder.create<LLVM::BrOp>(loc, errorCleanupBlock);
+
+      builder.setInsertionPointToStart(continueBlock);
+    }
+
+    // Free input tensors
+    for (size_t i = 0; i < numInputs; i++) {
+      Value bufferPtr = inputBuffers[i];
+      builder.create<LLVM::CallOp>(loc, freeInputFunc,
+                                   ValueRange{state, bufferPtr});
+    }
+
+    builder.create<LLVM::ReturnOp>(loc, c0_i32);
+
+    // Error cleanup block
+    builder.setInsertionPointToStart(errorCleanupBlock);
+
+    Value errorCode = builder.create<LLVM::LoadOp>(loc, i32Type, errorCodePtr);
+
+    for (size_t i = 0; i < inputBuffers.size(); i++) {
+      builder.create<LLVM::CallOp>(loc, freeInputFunc,
+                                   ValueRange{state, inputBuffers[i]});
+    }
+
+    builder.create<LLVM::ReturnOp>(loc, errorCode);
+  }
+
+  void generateInferenceCleanup(ModuleOp module) {
+    OpBuilder builder(module.getContext());
+    Location loc = module.getLoc();
+
+    builder.setInsertionPointToEnd(module.getBody());
+
+    Type ptrType = LLVM::LLVMPointerType::get(builder.getContext(), 0);
+    Type i32Type = builder.getI32Type();
+    SmallVector<Type> paramTypes = {ptrType};
+    auto funcType = LLVM::LLVMFunctionType::get(i32Type, paramTypes);
+
+    auto funcOp =
+        builder.create<LLVM::LLVMFuncOp>(loc, "inference_cleanup", funcType);
+    funcOp->setAttr("llvm.emit_c_interface", builder.getUnitAttr());
+    funcOp->setAttr("sym_visibility", builder.getStringAttr("public"));
+
+    Block *entryBlock = funcOp.addEntryBlock(builder);
+    builder.setInsertionPointToStart(entryBlock);
+
+    Value state = entryBlock->getArgument(0);
+
+    auto runtimeCleanupFunc =
+        module.lookupSymbol<LLVM::LLVMFuncOp>("hipdnn_ep_state_cleanup");
+    auto call = builder.create<LLVM::CallOp>(loc, runtimeCleanupFunc,
+                                             ValueRange{state});
+
+    builder.create<LLVM::ReturnOp>(loc, call.getResult());
+  }
+};
+
+} // namespace
+
+namespace mlir {
+namespace hip {
+
+std::unique_ptr<mlir::Pass> createGenerateInterfacePass(
+    const mlir::hip::CompilationOptionsT &compilationOptions) {
+  return std::make_unique<GenerateInterfacePass>(compilationOptions);
+}
+
+} // namespace hip
+} // namespace mlir

--- a/lib/Dialect/Transforms/GenerateInterface.cpp
+++ b/lib/Dialect/Transforms/GenerateInterface.cpp
@@ -16,7 +16,6 @@
 
 #include "compilation_options_generated.h"
 #include "flatbuffers/flatbuffers.h"
-#include "llvm/ADT/Sequence.h"
 #include "hip/Dialect/IR/HipDialect.h"
 #include "hip/Dialect/Transforms/Passes.h"
 #include "hip/debug_log.h"
@@ -28,6 +27,7 @@
 #include "mlir/Pass/Pass.h"
 #include "model_metadata_generated.h"
 #include "model_metadata_schema.h"
+#include "llvm/ADT/Sequence.h"
 
 using namespace mlir;
 
@@ -43,7 +43,9 @@ buildTensorInfo(ArrayAttr shapes, DenseI64ArrayAttr elementSizes, size_t i) {
                        shapeAttr.asArrayRef().end());
   }
   ti->element_size =
-      (elementSizes && i < elementSizes.size()) ? elementSizes[i] : 4;
+      (elementSizes && i < static_cast<size_t>(elementSizes.size()))
+          ? elementSizes[i]
+          : 4;
   return ti;
 }
 
@@ -220,8 +222,8 @@ static Value buildMemrefDescriptor(OpBuilder &builder, Location loc,
   for (int64_t d : llvm::seq<int64_t>(0, rank)) {
     Value idx = LLVM::ConstantOp::create(builder, loc, i64Type,
                                          builder.getI64IntegerAttr(d));
-    Value dimPtr = LLVM::GEPOp::create(builder, loc, ptrType, ptrType,
-                                       shapePtr, ArrayRef<LLVM::GEPArg>{idx});
+    Value dimPtr = LLVM::GEPOp::create(builder, loc, ptrType, ptrType, shapePtr,
+                                       ArrayRef<LLVM::GEPArg>{idx});
     Value dimVal = LLVM::LoadOp::create(builder, loc, i64Type, dimPtr);
     sizes = LLVM::InsertValueOp::create(builder, loc, sizes, dimVal,
                                         ArrayRef<int64_t>{d});
@@ -238,9 +240,8 @@ static Value buildMemrefDescriptor(OpBuilder &builder, Location loc,
     if (d > 0) {
       Value idx = LLVM::ConstantOp::create(builder, loc, i64Type,
                                            builder.getI64IntegerAttr(d));
-      Value dimPtr =
-          LLVM::GEPOp::create(builder, loc, ptrType, ptrType, shapePtr,
-                              ArrayRef<LLVM::GEPArg>{idx});
+      Value dimPtr = LLVM::GEPOp::create(builder, loc, ptrType, ptrType,
+                                         shapePtr, ArrayRef<LLVM::GEPArg>{idx});
       Value dimSize = LLVM::LoadOp::create(builder, loc, i64Type, dimPtr);
       acc = LLVM::MulOp::create(builder, loc, acc, dimSize);
     }
@@ -307,10 +308,6 @@ public:
       return;
     }
 
-    auto inputCount = module->getAttrOfType<IntegerAttr>("hipdnn.input_count");
-    auto outputCount =
-        module->getAttrOfType<IntegerAttr>("hipdnn.output_count");
-
     const std::string constantsFile =
         !compilationOptions_.constants_file.empty()
             ? compilationOptions_.constants_file
@@ -325,12 +322,7 @@ public:
     auto inputShapes = module->getAttrOfType<ArrayAttr>("hipdnn.input_shapes");
     auto outputShapes =
         module->getAttrOfType<ArrayAttr>("hipdnn.output_shapes");
-    auto inputElementSizes =
-        module->getAttrOfType<DenseI64ArrayAttr>("hipdnn.input_element_sizes");
-    auto outputElementSizes =
-        module->getAttrOfType<DenseI64ArrayAttr>("hipdnn.output_element_sizes");
-    generateInferenceCompute(module, inputCount, inputShapes, inputElementSizes,
-                             outputCount, outputShapes, outputElementSizes);
+    generateInferenceCompute(module, inputShapes, outputShapes);
     generateInferenceCleanup(module);
 
     std::string json = buildMetadataJson(module, constantsFile);
@@ -438,25 +430,13 @@ private:
       return failure();
     }
 
-    if (!module->getAttr("hipdnn.input_count")) {
-      llvm::errs()
-          << "[GenerateInterface] hipdnn.input_count attribute missing\n";
-      return failure();
-    }
-    if (!module->getAttr("hipdnn.input_shapes")) {
-      llvm::errs()
-          << "[GenerateInterface] hipdnn.input_shapes attribute missing\n";
-      return failure();
-    }
-    if (!module->getAttr("hipdnn.output_count")) {
-      llvm::errs()
-          << "[GenerateInterface] hipdnn.output_count attribute missing\n";
-      return failure();
-    }
-    if (!module->getAttr("hipdnn.output_shapes")) {
-      llvm::errs()
-          << "[GenerateInterface] hipdnn.output_shapes attribute missing\n";
-      return failure();
+    for (StringRef attr : {"hipdnn.input_count", "hipdnn.input_shapes",
+                           "hipdnn.output_count", "hipdnn.output_shapes"}) {
+      if (!module->getAttr(attr)) {
+        llvm::errs() << "[GenerateInterface] " << attr
+                     << " attribute missing\n";
+        return failure();
+      }
     }
 
     return success();
@@ -467,8 +447,8 @@ private:
   ///       attributes {llvm.emit_c_interface, sym_visibility = "public"} {
   ///     %blob = llvm.mlir.addressof @__metadata_blob : !llvm.ptr
   ///     %sz  = llvm.mlir.constant(168 : i64) : i64
-  ///     %rc  = llvm.call @hipdnn_ep_state_init_with_fs(%state, %fs, %blob, %sz)
-  ///     llvm.return %rc : i32
+  ///     %rc  = llvm.call @hipdnn_ep_state_init_with_fs(%state, %fs, %blob,
+  ///     %sz) llvm.return %rc : i32
   ///   }
   void generateInferenceInit(ModuleOp module, size_t blobSize) {
     OpBuilder builder(module.getContext());
@@ -586,19 +566,19 @@ private:
   ///                                %outs: !llvm.ptr) -> i32
   ///       attributes {llvm.emit_c_interface, sym_visibility = "public"} {
   ///     // 1. Alloca TensorBuffer structs on the stack
-  ///     // 2. For each input:  call hipdnn_ep_tensor_prepare_input, error-check
-  ///     // 3. For each output: call hipdnn_ep_tensor_prepare_output, error-check
+  ///     // 2. For each input:  call hipdnn_ep_tensor_prepare_input,
+  ///     error-check
+  ///     // 3. For each output: call hipdnn_ep_tensor_prepare_output,
+  ///     error-check
   ///     // 4. Build LLVM memref descriptors from TensorBuffer GPU/shape ptrs
   ///     // 5. Call @main_graph(%state, %input_memrefs, %output_memrefs)
-  ///     // 6. For each output: call hipdnn_ep_tensor_finalize_output, error-check
+  ///     // 6. For each output: call hipdnn_ep_tensor_finalize_output,
+  ///     error-check
   ///     // 7. Free input TensorBuffers
   ///     // On error: store error code, free inputs, return error
   ///   }
-  void generateInferenceCompute(ModuleOp module, IntegerAttr inputCount,
-                                ArrayAttr inputShapes,
-                                DenseI64ArrayAttr inputElementSizes,
-                                IntegerAttr outputCount, ArrayAttr outputShapes,
-                                DenseI64ArrayAttr outputElementSizes) {
+  void generateInferenceCompute(ModuleOp module, ArrayAttr inputShapes,
+                                ArrayAttr outputShapes) {
     OpBuilder builder(module.getContext());
     Location loc = module.getLoc();
     builder.setInsertionPointToEnd(module.getBody());
@@ -674,9 +654,6 @@ private:
 
     Block *errorCleanupBlock = funcOp.addBlock();
 
-    // Prepare all input tensors
-    SmallVector<Value> inputMemrefs;
-
     for (auto i : llvm::seq<size_t>(0, numInputs)) {
       Value bufferPtr = inputBuffers[i];
 
@@ -693,9 +670,6 @@ private:
           ValueRange{state, inputsSpanPtr, indexVal, rankVal, bufferPtr},
           errorCodePtr, errorCleanupBlock, funcOp);
     }
-
-    // Prepare all output tensors
-    SmallVector<Value> outputMemrefs;
 
     for (auto i : llvm::seq<size_t>(0, numOutputs)) {
       Value bufferPtr = outputBuffers[i];
@@ -785,10 +759,10 @@ private:
       COMPILER_DEBUG_LOG("[GenerateInterface] Warning: @main_graph not found\n");
       LLVM::BrOp::create(builder, loc, mainSuccessBlock);
     } else {
-      emitErrorCheckedCall(builder, loc, mainFunc,
-                           ValueRange{state, inputMemrefArray,
-                                      outputMemrefArray},
-                           errorCodePtr, errorCleanupBlock, funcOp);
+      emitErrorCheckedCall(
+          builder, loc, mainFunc,
+          ValueRange{state, inputMemrefArray, outputMemrefArray}, errorCodePtr,
+          errorCleanupBlock, funcOp);
       LLVM::BrOp::create(builder, loc, mainSuccessBlock);
     }
 

--- a/lib/Dialect/Transforms/GenerateInterface.cpp
+++ b/lib/Dialect/Transforms/GenerateInterface.cpp
@@ -162,7 +162,14 @@ void generateMetadataBlobGlobal(ModuleOp module,
                          "__metadata_blob", builder.getStringAttr(blobRef));
 }
 
-/// Generate inference_get_metadata_json() function
+/// Generate inference_get_metadata_json() function.
+///
+/// Generated IR example:
+///   llvm.func @inference_get_metadata_json() -> !llvm.ptr
+///       attributes {llvm.emit_c_interface, sym_visibility = "public"} {
+///     %0 = llvm.mlir.addressof @__metadata_json : !llvm.ptr
+///     llvm.return %0 : !llvm.ptr
+///   }
 void generateInferenceGetMetadataJson(ModuleOp module) {
   OpBuilder builder(module.getContext());
   Location loc = module.getLoc();
@@ -455,6 +462,14 @@ private:
     return success();
   }
 
+  /// Generated IR example (no pool):
+  ///   llvm.func @inference_init(%state: !llvm.ptr, %fs: !llvm.ptr) -> i32
+  ///       attributes {llvm.emit_c_interface, sym_visibility = "public"} {
+  ///     %blob = llvm.mlir.addressof @__metadata_blob : !llvm.ptr
+  ///     %sz  = llvm.mlir.constant(168 : i64) : i64
+  ///     %rc  = llvm.call @hipdnn_ep_state_init_with_fs(%state, %fs, %blob, %sz)
+  ///     llvm.return %rc : i32
+  ///   }
   void generateInferenceInit(ModuleOp module, size_t blobSize) {
     OpBuilder builder(module.getContext());
     Location loc = module.getLoc();
@@ -566,6 +581,19 @@ private:
     }
   }
 
+  /// Generated IR overview (1 input, 1 output of rank 1):
+  ///   llvm.func @inference_compute(%state: !llvm.ptr, %ins: !llvm.ptr,
+  ///                                %outs: !llvm.ptr) -> i32
+  ///       attributes {llvm.emit_c_interface, sym_visibility = "public"} {
+  ///     // 1. Alloca TensorBuffer structs on the stack
+  ///     // 2. For each input:  call hipdnn_ep_tensor_prepare_input, error-check
+  ///     // 3. For each output: call hipdnn_ep_tensor_prepare_output, error-check
+  ///     // 4. Build LLVM memref descriptors from TensorBuffer GPU/shape ptrs
+  ///     // 5. Call @main_graph(%state, %input_memrefs, %output_memrefs)
+  ///     // 6. For each output: call hipdnn_ep_tensor_finalize_output, error-check
+  ///     // 7. Free input TensorBuffers
+  ///     // On error: store error code, free inputs, return error
+  ///   }
   void generateInferenceCompute(ModuleOp module, IntegerAttr inputCount,
                                 ArrayAttr inputShapes,
                                 DenseI64ArrayAttr inputElementSizes,
@@ -796,6 +824,12 @@ private:
     LLVM::ReturnOp::create(builder, loc, errorCode);
   }
 
+  /// Generated IR example:
+  ///   llvm.func @inference_cleanup(%state: !llvm.ptr) -> i32
+  ///       attributes {llvm.emit_c_interface, sym_visibility = "public"} {
+  ///     %rc = llvm.call @hipdnn_ep_state_cleanup(%state)
+  ///     llvm.return %rc : i32
+  ///   }
   void generateInferenceCleanup(ModuleOp module) {
     OpBuilder builder(module.getContext());
     Location loc = module.getLoc();

--- a/lib/Dialect/Transforms/GenerateInterface.cpp
+++ b/lib/Dialect/Transforms/GenerateInterface.cpp
@@ -16,6 +16,7 @@
 
 #include "compilation_options_generated.h"
 #include "flatbuffers/flatbuffers.h"
+#include "llvm/ADT/Sequence.h"
 #include "hip/Dialect/IR/HipDialect.h"
 #include "hip/Dialect/Transforms/Passes.h"
 #include "hip/debug_log.h"
@@ -76,7 +77,7 @@ buildMetadataNative(ModuleOp module, const std::string &constantsFile) {
     auto sizes = constantSizesAttr.asArrayRef();
     auto offsets = constantOffsetsAttr ? constantOffsetsAttr.asArrayRef()
                                        : ArrayRef<int64_t>{};
-    for (size_t i = 0; i < sizes.size(); ++i) {
+    for (auto i : llvm::seq<size_t>(0, sizes.size())) {
       auto ci = std::make_unique<mlir::hip::ConstantInfoT>();
       ci->size = sizes[i];
       ci->offset = (i < offsets.size()) ? offsets[i] : 0;
@@ -85,11 +86,11 @@ buildMetadataNative(ModuleOp module, const std::string &constantsFile) {
   }
 
   if (inputShapes) {
-    for (size_t i = 0; i < inputShapes.size(); i++)
+    for (auto i : llvm::seq<size_t>(0, inputShapes.size()))
       meta.inputs.push_back(buildTensorInfo(inputShapes, inputElementSizes, i));
   }
   if (outputShapes) {
-    for (size_t i = 0; i < outputShapes.size(); i++)
+    for (auto i : llvm::seq<size_t>(0, outputShapes.size()))
       meta.outputs.push_back(
           buildTensorInfo(outputShapes, outputElementSizes, i));
   }
@@ -209,7 +210,7 @@ static Value buildMemrefDescriptor(OpBuilder &builder, Location loc,
                                      ArrayRef<int64_t>{2});
 
   Value sizes = LLVM::UndefOp::create(builder, loc, sizeArrayType);
-  for (int64_t d = 0; d < rank; d++) {
+  for (int64_t d : llvm::seq<int64_t>(0, rank)) {
     Value idx = LLVM::ConstantOp::create(builder, loc, i64Type,
                                          builder.getI64IntegerAttr(d));
     Value dimPtr = LLVM::GEPOp::create(builder, loc, ptrType, ptrType,
@@ -224,7 +225,7 @@ static Value buildMemrefDescriptor(OpBuilder &builder, Location loc,
   Value strides = LLVM::UndefOp::create(builder, loc, sizeArrayType);
   Value acc = LLVM::ConstantOp::create(builder, loc, i64Type,
                                        builder.getI64IntegerAttr(1));
-  for (int64_t d = rank - 1; d >= 0; d--) {
+  for (int64_t d : llvm::reverse(llvm::seq<int64_t>(0, rank))) {
     strides = LLVM::InsertValueOp::create(builder, loc, strides, acc,
                                           ArrayRef<int64_t>{d});
     if (d > 0) {
@@ -539,7 +540,7 @@ private:
       Value offsetsArrayPtr = LLVM::AllocaOp::create(builder, loc, ptrType,
                                                      i64Type, numBuffersVal, 0);
 
-      for (size_t i = 0; i < numBuffers; i++) {
+      for (auto i : llvm::seq<size_t>(0, numBuffers)) {
         auto offsetAttr = dyn_cast<IntegerAttr>(offsetsAttrArray[i]);
         Value offset = LLVM::ConstantOp::create(
             builder, loc, i64Type,
@@ -630,12 +631,14 @@ private:
         builder, loc, i64Type,
         builder.getI64IntegerAttr(kTensorBufferSizeBytes));
 
-    for (size_t i = 0; i < numInputs; i++) {
+    for (auto i : llvm::seq<size_t>(0, numInputs)) {
+      (void)i;
       Value bufferPtr = LLVM::AllocaOp::create(builder, loc, ptrType, i8Type,
                                                tensorBufferSize, 0);
       inputBuffers.push_back(bufferPtr);
     }
-    for (size_t i = 0; i < numOutputs; i++) {
+    for (auto i : llvm::seq<size_t>(0, numOutputs)) {
+      (void)i;
       Value bufferPtr = LLVM::AllocaOp::create(builder, loc, ptrType, i8Type,
                                                tensorBufferSize, 0);
       outputBuffers.push_back(bufferPtr);
@@ -646,7 +649,7 @@ private:
     // Prepare all input tensors
     SmallVector<Value> inputMemrefs;
 
-    for (size_t i = 0; i < numInputs; i++) {
+    for (auto i : llvm::seq<size_t>(0, numInputs)) {
       Value bufferPtr = inputBuffers[i];
 
       Value indexVal = LLVM::ConstantOp::create(builder, loc, i64Type,
@@ -666,7 +669,7 @@ private:
     // Prepare all output tensors
     SmallVector<Value> outputMemrefs;
 
-    for (size_t i = 0; i < numOutputs; i++) {
+    for (auto i : llvm::seq<size_t>(0, numOutputs)) {
       Value bufferPtr = outputBuffers[i];
 
       Value indexVal = LLVM::ConstantOp::create(builder, loc, i64Type,
@@ -689,7 +692,7 @@ private:
     Value inputMemrefArray =
         LLVM::AllocaOp::create(builder, loc, ptrType, ptrType, numInputsVal, 0);
 
-    for (size_t i = 0; i < numInputs; i++) {
+    for (auto i : llvm::seq<size_t>(0, numInputs)) {
       int64_t rank = cast<DenseI64ArrayAttr>(inputShapes.getValue()[i]).size();
 
       Value bufferPtr = inputBuffers[i];
@@ -720,7 +723,7 @@ private:
     Value outputMemrefArray = LLVM::AllocaOp::create(builder, loc, ptrType,
                                                      ptrType, numOutputsVal, 0);
 
-    for (size_t i = 0; i < numOutputs; i++) {
+    for (auto i : llvm::seq<size_t>(0, numOutputs)) {
       int64_t rank = cast<DenseI64ArrayAttr>(outputShapes.getValue()[i]).size();
 
       Value bufferPtr = outputBuffers[i];
@@ -764,7 +767,7 @@ private:
     // Finalize output tensors (D2H, sync, cleanup)
     builder.setInsertionPointToStart(mainSuccessBlock);
 
-    for (size_t i = 0; i < numOutputs; i++) {
+    for (auto i : llvm::seq<size_t>(0, numOutputs)) {
       Value bufferPtr = outputBuffers[i];
       emitErrorCheckedCall(builder, loc, finalizeOutputFunc,
                            ValueRange{state, bufferPtr}, errorCodePtr,
@@ -772,7 +775,7 @@ private:
     }
 
     // Free input tensors
-    for (size_t i = 0; i < numInputs; i++) {
+    for (auto i : llvm::seq<size_t>(0, numInputs)) {
       Value bufferPtr = inputBuffers[i];
       LLVM::CallOp::create(builder, loc, freeInputFunc,
                            ValueRange{state, bufferPtr});
@@ -785,7 +788,7 @@ private:
 
     Value errorCode = LLVM::LoadOp::create(builder, loc, i32Type, errorCodePtr);
 
-    for (size_t i = 0; i < inputBuffers.size(); i++) {
+    for (auto i : llvm::seq<size_t>(0, inputBuffers.size())) {
       LLVM::CallOp::create(builder, loc, freeInputFunc,
                            ValueRange{state, inputBuffers[i]});
     }

--- a/lib/Dialect/Transforms/GenerateInterface.cpp
+++ b/lib/Dialect/Transforms/GenerateInterface.cpp
@@ -18,6 +18,7 @@
 #include "flatbuffers/flatbuffers.h"
 #include "hip/Dialect/IR/HipDialect.h"
 #include "hip/Dialect/Transforms/Passes.h"
+#include "hip/debug_log.h"
 #include "hip/flatbuffers_json.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -123,8 +124,13 @@ std::string buildMetadataJson(ModuleOp module,
                               const std::string &constantsFile) {
   mlir::hip::HipModelMetaInfoT meta =
       buildMetadataNative(module, constantsFile);
-  return mlir::hip::toJson<mlir::hip::HipModelMetaInfoT>(
-      meta, mlir::hip::k_model_metadata_schema());
+  std::string json, error;
+  if (!mlir::hip::toJson<mlir::hip::HipModelMetaInfoT>(
+          meta, mlir::hip::k_model_metadata_schema(), json, error)) {
+    llvm::errs() << "[GenerateInterface] " << error << "\n";
+    return "";
+  }
+  return json;
 }
 
 /// Generate global constant string for metadata JSON
@@ -242,7 +248,7 @@ public:
     generateMetadataGlobal(module, json);
     generateInferenceGetMetadataJson(module);
 
-    llvm::errs() << "[GenerateInterface] Generated 4 interface functions\n";
+    COMPILER_DEBUG_LOG("[GenerateInterface] Generated 4 interface functions\n");
   }
 
 private:
@@ -516,8 +522,8 @@ private:
         module.lookupSymbol<LLVM::LLVMFuncOp>("inference_compute") ||
         module.lookupSymbol<LLVM::LLVMFuncOp>("inference_cleanup") ||
         module.lookupSymbol<LLVM::LLVMFuncOp>("inference_get_metadata_json")) {
-      llvm::errs() << "[GenerateInterface] Interface functions already exist. "
-                   << "Pass already ran.\n";
+      COMPILER_DEBUG_LOG("[GenerateInterface] Interface functions already exist. "
+                        << "Pass already ran.\n");
       return failure();
     }
 
@@ -992,7 +998,7 @@ private:
 
     auto mainFunc = module.lookupSymbol<LLVM::LLVMFuncOp>("main_graph");
     if (!mainFunc) {
-      llvm::errs() << "[GenerateInterface] Warning: @main_graph not found\n";
+      COMPILER_DEBUG_LOG("[GenerateInterface] Warning: @main_graph not found\n");
       LLVM::BrOp::create(builder, loc, mainSuccessBlock);
     } else {
       Value mainRet = LLVM::CallOp::create(builder, loc, mainFunc,

--- a/lib/Dialect/Transforms/GenerateInterface.cpp
+++ b/lib/Dialect/Transforms/GenerateInterface.cpp
@@ -451,8 +451,9 @@ private:
     return success();
   }
 
-  /// hipdnn_ep_state_init_with_fs: alloc RuntimeState, init HIP/MIOpen/hipBLASLt,
-  /// parse metadata blob, read constants via FileSystem and upload to GPU.
+  /// hipdnn_ep_state_init_with_fs: alloc RuntimeState, init
+  /// HIP/MIOpen/hipBLASLt, parse metadata blob, read constants via FileSystem
+  /// and upload to GPU.
   ///
   /// Generated IR (no pool — from test_basic_interface.mlir):
   ///   llvm.func @inference_init(%arg0: !llvm.ptr, %arg1: !llvm.ptr) -> i32

--- a/lib/Dialect/Transforms/Pipelines.cpp
+++ b/lib/Dialect/Transforms/Pipelines.cpp
@@ -6,11 +6,7 @@
 #include "hip/Dialect/Transforms/Pipelines.h"
 #include "hip/Dialect/Transforms/Passes.h"
 
-#include "mlir/Conversion/ArithToLLVM/ArithToLLVM.h"
 #include "mlir/Conversion/BufferizationToMemRef/BufferizationToMemRef.h"
-#include "mlir/Conversion/FuncToLLVM/ConvertFuncToLLVMPass.h"
-#include "mlir/Conversion/MemRefToLLVM/MemRefToLLVM.h"
-#include "mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h"
 #include "mlir/Dialect/Bufferization/Pipelines/Passes.h"
 #include "mlir/Dialect/Bufferization/Transforms/Passes.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -78,12 +74,7 @@ void mlir::hip::buildOnnxToHipPipeline(
 void mlir::hip::buildHipToLLVMPipeline(
     OpPassManager &pm, const HipToLLVMPipelineOptions &options) {
   pm.addPass(createConvertHipToLLVMPass());
-  pm.addPass(createFinalizeMemRefToLLVMConversionPass());
-  pm.addPass(createArithToLLVMConversionPass());
-  pm.addPass(createConvertFuncToLLVMPass());
-  pm.addPass(createReconcileUnrealizedCastsPass());
 
-  // GenerateInterface: create C-ABI wrapper functions for the compiled module
   mlir::hip::CompilationOptionsT compOpts;
   compOpts.constants_file = options.constantsFile;
   pm.addPass(createGenerateInterfacePass(compOpts));

--- a/lib/Dialect/Transforms/Pipelines.cpp
+++ b/lib/Dialect/Transforms/Pipelines.cpp
@@ -17,6 +17,8 @@
 #include "mlir/Pass/PassRegistry.h"
 #include "mlir/Transforms/Passes.h"
 
+#include "compilation_options_generated.h"
+
 using namespace mlir;
 
 void mlir::hip::buildOnnxToHipPipeline(
@@ -73,12 +75,18 @@ void mlir::hip::buildOnnxToHipPipeline(
   pm.addPass(createCanonicalizerPass());
 }
 
-void mlir::hip::buildHipToLLVMPipeline(OpPassManager &pm) {
+void mlir::hip::buildHipToLLVMPipeline(
+    OpPassManager &pm, const HipToLLVMPipelineOptions &options) {
   pm.addPass(createConvertHipToLLVMPass());
   pm.addPass(createFinalizeMemRefToLLVMConversionPass());
   pm.addPass(createArithToLLVMConversionPass());
   pm.addPass(createConvertFuncToLLVMPass());
   pm.addPass(createReconcileUnrealizedCastsPass());
+
+  // GenerateInterface: create C-ABI wrapper functions for the compiled module
+  mlir::hip::CompilationOptionsT compOpts;
+  compOpts.constants_file = options.constantsFile;
+  pm.addPass(createGenerateInterfacePass(compOpts));
 }
 
 void mlir::hip::registerHipPipelines() {
@@ -88,7 +96,8 @@ void mlir::hip::registerHipPipelines() {
       "externalization",
       buildOnnxToHipPipeline);
 
-  PassPipelineRegistration<>(
-      "hip-to-llvm-pipeline", "Lower HIP memref IR to LLVM dialect",
-      [](OpPassManager &pm) { buildHipToLLVMPipeline(pm); });
+  PassPipelineRegistration<HipToLLVMPipelineOptions>(
+      "hip-to-llvm-pipeline",
+      "Lower HIP memref IR to LLVM dialect and generate C interface",
+      buildHipToLLVMPipeline);
 }

--- a/schemas/CMakeLists.txt
+++ b/schemas/CMakeLists.txt
@@ -1,0 +1,69 @@
+##
+# ** Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# ** Licensed under the MIT License.
+##
+
+# Find flatc executable from the prebuilt package
+find_program(FLATC_EXECUTABLE flatc
+    HINTS "${THEROCK_DIST}/bin"
+    REQUIRED
+)
+message(STATUS "Using flatc: ${FLATC_EXECUTABLE}")
+
+# Generate C++ headers from .fbs schemas
+set(FBS_SCHEMAS
+    ${CMAKE_CURRENT_SOURCE_DIR}/compilation_options.fbs
+    ${CMAKE_CURRENT_SOURCE_DIR}/model_metadata.fbs
+)
+
+set(GENERATED_HEADERS "")
+foreach(schema ${FBS_SCHEMAS})
+    get_filename_component(schema_name ${schema} NAME_WE)
+    set(generated_header ${CMAKE_CURRENT_BINARY_DIR}/${schema_name}_generated.h)
+    add_custom_command(
+        OUTPUT ${generated_header}
+        COMMAND ${FLATC_EXECUTABLE} --cpp --gen-object-api --scoped-enums -o ${CMAKE_CURRENT_BINARY_DIR} ${schema}
+        DEPENDS ${schema}
+        COMMENT "Generating FlatBuffers header: ${schema_name}_generated.h"
+    )
+    list(APPEND GENERATED_HEADERS ${generated_header})
+endforeach()
+
+# Target that drives header generation
+add_custom_target(HipSchemas ALL DEPENDS ${GENERATED_HEADERS})
+
+# Embed each .fbs schema as a C++ string constant so consumers can use
+# flatbuffers::Parser for JSON<->binary conversion without a separate schema file.
+foreach(schema ${FBS_SCHEMAS})
+    get_filename_component(schema_name ${schema} NAME_WE)
+    file(READ ${schema} schema_content)
+    file(CONFIGURE
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${schema_name}_schema.h
+        CONTENT
+"// Auto-generated from ${schema_name}.fbs — do not edit manually.
+#pragma once
+namespace mlir {
+namespace hip {
+inline const char* k_${schema_name}_schema() {
+  static const char kSchema[] = R\"fbs(${schema_content})fbs\";
+  return kSchema;
+}
+} // namespace hip
+} // namespace mlir
+"
+        NEWLINE_STYLE LF
+    )
+endforeach()
+
+# Interface library: consumers depend on this to get generated headers
+# and the flatbuffers include path (for flatbuffers/flatbuffers.h and
+# flatbuffers/idl.h).
+add_library(HipSchemasLib INTERFACE)
+add_dependencies(HipSchemasLib HipSchemas)
+target_include_directories(HipSchemasLib INTERFACE
+    ${CMAKE_CURRENT_BINARY_DIR}
+    ${CMAKE_SOURCE_DIR}/include
+)
+target_link_libraries(HipSchemasLib INTERFACE
+    flatbuffers::flatbuffers
+)

--- a/schemas/compilation_options.fbs
+++ b/schemas/compilation_options.fbs
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+namespace mlir.hip;
+
+enum OutputMode : int {
+  DLL = 0,
+  LLVM_IR = 1
+}
+
+table CompilationOptions {
+  opt_level: int = 2;
+  output_mode: OutputMode = DLL;
+  verbose: bool = false;
+  constants_file: string = "constants.bin";
+}
+
+root_type CompilationOptions;

--- a/schemas/model_metadata.fbs
+++ b/schemas/model_metadata.fbs
@@ -1,0 +1,26 @@
+// Copyright (C) 2023 - 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+namespace mlir.hip;
+
+table TensorInfo {
+  shape: [int64];
+  element_size: int64;
+}
+
+table ConstantInfo {
+  size:   int64;
+  offset: int64;
+}
+
+table HipModelMetaInfo {
+  version: int32 = 1;
+  constants_filename: string;
+  constants: [ConstantInfo];
+  input_count: int64;
+  output_count: int64;
+  inputs: [TensorInfo];
+  outputs: [TensorInfo];
+}
+
+root_type HipModelMetaInfo;

--- a/test/lit/Transforms/GenerateInterface/test_basic_interface.mlir
+++ b/test/lit/Transforms/GenerateInterface/test_basic_interface.mlir
@@ -1,0 +1,63 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+// ============================================================================
+// TEST: GenerateInterface pass creates C-ABI wrapper functions.
+//
+// Input: Pre-lowered LLVM IR with @main_graph(ptr, ptr, ptr) -> i32 and
+// all required hipdnn.* module attributes.  The earlier lowering passes in
+// hip-to-llvm-pipeline are no-ops on already-lowered IR, so GenerateInterface
+// runs directly on the input below.
+//
+// Verifies:
+//   1. Four wrapper functions are generated.
+//   2. inference_init calls hipdnn_ep_state_init_with_fs.
+//   3. inference_compute calls tensor prepare / main_graph / finalize.
+//   4. inference_cleanup calls hipdnn_ep_state_cleanup.
+//   5. Metadata blob is embedded as a global constant.
+// ============================================================================
+
+// RUN: hip-mlir-opt --hip-to-llvm-pipeline %s 2>&1 | FileCheck %s
+
+// --- Metadata blob embedded ---
+// CHECK: llvm.mlir.global internal constant @__metadata_blob
+
+// --- inference_init calls state init ---
+// CHECK-LABEL: llvm.func @inference_init
+// CHECK-SAME:  -> i32
+// CHECK:   llvm.call @hipdnn_ep_state_init_with_fs
+
+// --- inference_compute calls tensor helpers and main_graph ---
+// CHECK-LABEL: llvm.func @inference_compute
+// CHECK-SAME:  -> i32
+// CHECK:   llvm.call @hipdnn_ep_tensor_prepare_input
+// CHECK:   llvm.call @hipdnn_ep_tensor_prepare_output
+// CHECK:   llvm.call @main_graph
+// CHECK:   llvm.call @hipdnn_ep_tensor_finalize_output
+
+// --- inference_cleanup calls state cleanup ---
+// CHECK-LABEL: llvm.func @inference_cleanup
+// CHECK-SAME:  -> i32
+// CHECK:   llvm.call @hipdnn_ep_state_cleanup
+
+// --- inference_get_metadata_json returns metadata pointer ---
+// CHECK-LABEL: llvm.func @inference_get_metadata_json
+// CHECK:   llvm.mlir.addressof @__metadata_json
+
+module attributes {
+  hipdnn.input_count = 1 : i64,
+  hipdnn.input_shapes = [array<i64: 8>],
+  hipdnn.input_element_sizes = array<i64: 4>,
+  hipdnn.output_count = 1 : i64,
+  hipdnn.output_shapes = [array<i64: 8>],
+  hipdnn.output_element_sizes = array<i64: 4>,
+  hipdnn.pool_size = 0 : i64,
+  hipdnn.buffer_offsets = [],
+  hipdnn.buffer_count = 0 : i64
+} {
+  llvm.func @main_graph(%ctx: !llvm.ptr, %inputs: !llvm.ptr,
+                        %outputs: !llvm.ptr) -> i32 {
+    %zero = llvm.mlir.constant(0 : i32) : i32
+    llvm.return %zero : i32
+  }
+}

--- a/tools/hip-compiler/CMakeLists.txt
+++ b/tools/hip-compiler/CMakeLists.txt
@@ -16,6 +16,7 @@ target_link_libraries(hip-compiler PRIVATE
   HipDialectIR
   HipDialectTransforms
   HipToLLVM
+  HipSchemasLib
   MLIROptLib
   MLIRSupport
   MLIRIR

--- a/tools/hip-compiler/hip-compiler.cpp
+++ b/tools/hip-compiler/hip-compiler.cpp
@@ -91,7 +91,8 @@ int main(int argc, char **argv) {
 
   // 2. Run MLIR PassManager (input must be pre-bufferized memref IR)
   mlir::PassManager pm(&context);
-  mlir::hip::buildHipToLLVMPipeline(pm);
+  mlir::hip::HipToLLVMPipelineOptions pipelineOpts;
+  mlir::hip::buildHipToLLVMPipeline(pm, pipelineOpts);
 
   if (mlir::failed(pm.run(*module))) {
     llvm::errs() << "error: MLIR pass pipeline failed\n";


### PR DESCRIPTION
## Summary

Adds `GenerateInterfacePass` to emit C-ABI wrapper functions (`inference_init`, `inference_compute`, `inference_cleanup`, `inference_get_metadata_json`) from a bufferized `@main_graph`. This enables compiled HIP modules to be loaded and called as shared libraries from a C/C++ runtime.

Also adds FlatBuffers schemas (`schemas/`) for model metadata serialization.

## Review focus

1. **`lib/Dialect/Transforms/GenerateInterface.cpp`** -- pass implementation (metadata extraction, LLVM IR emission, runtime call sequences)
2. **`schemas/`** -- FlatBuffers schema design (compiler-runtime contract)
3. **`test/lit/Transforms/GenerateInterface/test_basic_interface.mlir`** -- LIT test

## Test plan
- [x] 33/33 LIT tests pass
- [x] Pre-commit hooks pass
