### PR TITLE
ci: add Windows build CI for onnx-hipdnn-ep

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,6 +7,7 @@ name: pre-commit
 on:
   pull_request:
   push:
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -288,4 +288,4 @@ jobs:
       # -----------------------------------------------------------------------
       - name: Run LIT tests
         shell: bash
-        run: cmake --build ../build/$(basename "$PWD") --target check-hip-lit
+        run: cmake --build ../build/$(basename "$PWD") --target check-hip-mlir-lit

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -31,6 +31,9 @@ jobs:
       GTEST_VERSION: "1.15.0"
       THEROCK_VERSION: therock-dist-windows-gfx1151-7.11.0
       SCCACHE_GHA_ENABLED: "true"
+      # ilammy/msvc-dev-cmd and mozilla-actions/sccache-action have no
+      # Node.js 24 releases yet; allow Node.js 20 until they are updated.
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
 
     steps:
       # ROCm/MorphiZen is a private repo. A read-only deploy key is stored as

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -39,12 +39,12 @@ jobs:
       # below redirects the HTTPS submodule URL to SSH at clone time so that
       # .gitmodules can stay as HTTPS.
       - name: Setup SSH key for MorphiZen submodule
-        uses: webfactory/ssh-agent@v0.9.0
+        uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         with:
           ssh-private-key: ${{ secrets.MORPHIZEN_DEPLOY_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: false
           fetch-depth: 0
@@ -67,7 +67,7 @@ jobs:
       # -----------------------------------------------------------------------
       - name: Cache prebuilt-local
         id: cache-prebuilt
-        uses: actions/cache@v4
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ${{ runner.workspace }}/prebuilt-local
           key: prebuilt-ort-${{ env.ONNXRUNTIME_VERSION }}-${{ env.LLVM_TAG }}-${{ env.FLATBUFFERS_TAG }}-${{ env.PROTO_TAG }}-gtest${{ env.GTEST_VERSION }}
@@ -175,7 +175,7 @@ jobs:
       # -----------------------------------------------------------------------
       - name: Cache TheRock
         id: cache-therock
-        uses: actions/cache@v4
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ${{ runner.workspace }}/therock-dist
           key: ${{ env.THEROCK_VERSION }}
@@ -219,7 +219,7 @@ jobs:
 
       # Put cl.exe and ninja.exe (bundled with VS) into PATH
       - name: Setup MSVC environment
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
       # -----------------------------------------------------------------------
       # Build GTest from source and install into prebuilt-local.

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,0 +1,281 @@
+##
+## Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+## Licensed under the MIT License.
+##
+name: Windows Build
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  merge_group:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+
+    env:
+      LLVM_TAG: llvm-22.1.0-release
+      FLATBUFFERS_TAG: flatbuffers-25.12.19-release
+      PROTO_TAG: protobuf-34.0-release
+      ONNXRUNTIME_VERSION: "1.24.3"
+      GTEST_VERSION: "1.15.0"
+      THEROCK_VERSION: therock-dist-windows-gfx1151-7.11.0
+      SCCACHE_GHA_ENABLED: "true"
+
+    steps:
+      # ROCm/MorphiZen is a private repo. A read-only deploy key is stored as
+      # MORPHIZEN_DEPLOY_KEY in ROCm/onnx-hipdnn-ep secrets, and the matching
+      # public key is added to ROCm/MorphiZen deploy keys. The git URL rewrite
+      # below redirects the HTTPS submodule URL to SSH at clone time so that
+      # .gitmodules can stay as HTTPS.
+      - name: Setup SSH key for MorphiZen submodule
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.MORPHIZEN_DEPLOY_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: false
+          fetch-depth: 0
+          show-progress: false
+
+      - name: Checkout MorphiZen submodule
+        shell: bash
+        run: |
+          git config --global url."git@github.com:ROCm/MorphiZen.git".insteadOf \
+            "https://github.com/ROCm/MorphiZen.git"
+          git submodule update --init --recursive
+
+      # -----------------------------------------------------------------------
+      # Cache: ONNX Runtime + LLVM prebuilt + flatbuffers
+      # All are installed into the same prebuilt-local prefix so one cache
+      # entry covers all of them.
+      # Note: protobuf is excluded – cmake/deps.cmake fetches v21.12 via
+      # FetchContent (same version pinned by morphizen) to avoid C4267 errors
+      # from mismatched protobuf versions.
+      # -----------------------------------------------------------------------
+      - name: Cache prebuilt-local
+        id: cache-prebuilt
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.workspace }}/prebuilt-local
+          key: prebuilt-ort-${{ env.ONNXRUNTIME_VERSION }}-${{ env.LLVM_TAG }}-${{ env.FLATBUFFERS_TAG }}-${{ env.PROTO_TAG }}-gtest${{ env.GTEST_VERSION }}
+
+      # -----------------------------------------------------------------------
+      # Download ONNX Runtime (official pre-built zip)
+      # morphizen-core calls find_package(onnxruntime REQUIRED), so we also
+      # create onnxruntimeConfig.cmake in the right location.
+      # -----------------------------------------------------------------------
+      - name: Download pre-built ONNX Runtime
+        if: steps.cache-prebuilt.outputs.cache-hit != 'true'
+        shell: powershell
+        run: |
+          $ortVersion = "${{ env.ONNXRUNTIME_VERSION }}"
+          $url = "https://github.com/microsoft/onnxruntime/releases/download/v$ortVersion/onnxruntime-win-x64-$ortVersion.zip"
+          $zipFile = "${{ github.workspace }}/onnxruntime-win-x64-$ortVersion.zip"
+          Write-Host "Downloading $url"
+          Invoke-WebRequest -Uri $url -OutFile $zipFile
+
+          $prefixDir = "${{ runner.workspace }}/prebuilt-local"
+          New-Item -ItemType Directory -Force -Path $prefixDir | Out-Null
+          Expand-Archive -Path $zipFile -DestinationPath $prefixDir -Force
+
+          # Flatten nested directory produced by the zip
+          $extractedDir = "$prefixDir/onnxruntime-win-x64-$ortVersion"
+          if (Test-Path $extractedDir) {
+            Move-Item -Path "$extractedDir/*" -Destination "$prefixDir/" -Force
+            Remove-Item -Path $extractedDir -Force -Recurse
+          }
+
+          # Create CMake config so find_package(onnxruntime REQUIRED) succeeds.
+          # The pre-built zip puts headers in include/ and onnxruntime.lib in lib/.
+          $cmakeDir = "$prefixDir/lib/cmake/onnxruntime"
+          New-Item -ItemType Directory -Force -Path $cmakeDir | Out-Null
+          $configFile = "$cmakeDir/onnxruntimeConfig.cmake"
+          "# onnxruntimeConfig.cmake - auto-generated for pre-built ONNX Runtime $ortVersion" | Set-Content $configFile -Encoding UTF8
+          ""                                                                             | Add-Content $configFile -Encoding UTF8
+          "if(NOT TARGET onnxruntime::onnxruntime)"                                     | Add-Content $configFile -Encoding UTF8
+          "  add_library(onnxruntime::onnxruntime SHARED IMPORTED)"                     | Add-Content $configFile -Encoding UTF8
+          "  set_target_properties(onnxruntime::onnxruntime PROPERTIES"                 | Add-Content $configFile -Encoding UTF8
+          "    INTERFACE_INCLUDE_DIRECTORIES `"`${CMAKE_CURRENT_LIST_DIR}/../../../include`"" | Add-Content $configFile -Encoding UTF8
+          "    IMPORTED_LOCATION             `"`${CMAKE_CURRENT_LIST_DIR}/../../../lib/onnxruntime.dll`"" | Add-Content $configFile -Encoding UTF8
+          "    IMPORTED_IMPLIB               `"`${CMAKE_CURRENT_LIST_DIR}/../../../lib/onnxruntime.lib`"" | Add-Content $configFile -Encoding UTF8
+          "  )"                                                                          | Add-Content $configFile -Encoding UTF8
+          "endif()"                                                                      | Add-Content $configFile -Encoding UTF8
+          ""                                                                             | Add-Content $configFile -Encoding UTF8
+          "set(onnxruntime_FOUND TRUE)"                                                  | Add-Content $configFile -Encoding UTF8
+          "set(onnxruntime_VERSION `"$ortVersion`")"                                    | Add-Content $configFile -Encoding UTF8
+
+      # -----------------------------------------------------------------------
+      # Download LLVM prebuilt (from wcy123/llvm-mlir-prebuilt releases)
+      # -----------------------------------------------------------------------
+      - name: Download LLVM prebuilt
+        if: steps.cache-prebuilt.outputs.cache-hit != 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PREBUILT_DIR="${{ runner.workspace }}/prebuilt-local"
+          mkdir -p "$PREBUILT_DIR"
+          gh release download "${{ env.LLVM_TAG }}" \
+            --repo wcy123/llvm-mlir-prebuilt \
+            --pattern "llvm-22.1.0-release-windows-x64.zip" \
+            --dir "$PREBUILT_DIR"
+          unzip -q -o "$PREBUILT_DIR/llvm-22.1.0-release-windows-x64.zip" -d "$PREBUILT_DIR"
+          rm "$PREBUILT_DIR/llvm-22.1.0-release-windows-x64.zip"
+
+      # -----------------------------------------------------------------------
+      # Download flatbuffers prebuilt
+      # -----------------------------------------------------------------------
+      - name: Download flatbuffers prebuilt
+        if: steps.cache-prebuilt.outputs.cache-hit != 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PREBUILT_DIR="${{ runner.workspace }}/prebuilt-local"
+          gh release download "${{ env.FLATBUFFERS_TAG }}" \
+            --repo wcy123/llvm-mlir-prebuilt \
+            --pattern "flatbuffers-25.12.19-release-windows-x64.zip" \
+            --dir "$PREBUILT_DIR"
+          unzip -q -o "$PREBUILT_DIR/flatbuffers-25.12.19-release-windows-x64.zip" -d "$PREBUILT_DIR"
+          rm "$PREBUILT_DIR/flatbuffers-25.12.19-release-windows-x64.zip"
+
+      # -----------------------------------------------------------------------
+      # Download protobuf prebuilt
+      # -----------------------------------------------------------------------
+      - name: Download protobuf prebuilt
+        if: steps.cache-prebuilt.outputs.cache-hit != 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PREBUILT_DIR="${{ runner.workspace }}/prebuilt-local"
+          mkdir -p "$PREBUILT_DIR"
+          gh release download "${{ env.PROTO_TAG }}" \
+            --repo wcy123/llvm-mlir-prebuilt \
+            --pattern "protobuf-34.0-release-windows-x64.zip" \
+            --dir "$PREBUILT_DIR"
+          unzip -q -o "$PREBUILT_DIR/protobuf-34.0-release-windows-x64.zip" -d "$PREBUILT_DIR"
+          rm "$PREBUILT_DIR/protobuf-34.0-release-windows-x64.zip"
+
+      # -----------------------------------------------------------------------
+      # Cache: TheRock HIP SDK for Windows (separate cache – large tarball)
+      # -----------------------------------------------------------------------
+      - name: Cache TheRock
+        id: cache-therock
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.workspace }}/therock-dist
+          key: ${{ env.THEROCK_VERSION }}
+
+      - name: Download & extract TheRock
+        if: steps.cache-therock.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          THEROCK_DIST="$(cygpath -u '${{ runner.workspace }}/therock-dist')"
+          mkdir -p "$THEROCK_DIST"
+          curl -fsSL \
+            "https://repo.amd.com/rocm/tarball/${{ env.THEROCK_VERSION }}.tar.gz" \
+            -o therock.tar.gz
+          tar -xzf therock.tar.gz -C "$THEROCK_DIST" --strip-components=1
+          rm therock.tar.gz
+
+
+
+      # -----------------------------------------------------------------------
+      # The prebuilt LLVM package has C:\msvsn2022 hardcoded in LLVMExports.cmake
+      # for the DIA SDK path (known LLVM issue: llvm/llvm-project#111829).
+      # Create a junction from C:\msvsn2022 to the actual VS installation.
+      # -----------------------------------------------------------------------
+      - name: Fix DIA SDK path from prebuilt LLVM
+        shell: cmd
+        run: |
+          for /f "usebackq delims=" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath`) do set "VS_PATH=%%i"
+          mklink /J C:\msvsn2022 "%VS_PATH%"
+
+      # -----------------------------------------------------------------------
+      # llvm-lit.py (from prebuilt) requires the lit pip package at runtime.
+      # Pin Python to avoid mismatch with find_package(Python3) in CMake.
+      # -----------------------------------------------------------------------
+      - name: Setup Python 3.12
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install lit
+        run: pip install lit
+
+      # Put cl.exe and ninja.exe (bundled with VS) into PATH
+      - name: Setup MSVC environment
+        uses: ilammy/msvc-dev-cmd@v1
+
+      # -----------------------------------------------------------------------
+      # Build GTest from source and install into prebuilt-local.
+      # cmake/deps.cmake does find_package(GTest CONFIG QUIET) first; if found
+      # via CMAKE_PREFIX_PATH it skips FetchContent entirely.
+      # Requires MSVC env (cl.exe + ninja) hence placed after Setup MSVC.
+      # -----------------------------------------------------------------------
+      - name: Build GTest
+        if: steps.cache-prebuilt.outputs.cache-hit != 'true'
+        shell: cmd
+        run: |
+          curl -fsSL "https://github.com/google/googletest/archive/refs/tags/v${{ env.GTEST_VERSION }}.zip" -o gtest.zip
+          unzip -q gtest.zip
+          cmake -G Ninja -B gtest-build -S "googletest-${{ env.GTEST_VERSION }}" ^
+            -DCMAKE_BUILD_TYPE=Release ^
+            "-DCMAKE_INSTALL_PREFIX=${{ runner.workspace }}/prebuilt-local" ^
+            "-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded" ^
+            -DBUILD_GMOCK=ON
+          ninja -C gtest-build install
+          rd /s /q gtest-build "googletest-${{ env.GTEST_VERSION }}"
+          del gtest.zip
+
+      # Cache compilation results across runs via GitHub Actions Cache backend
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      # -----------------------------------------------------------------------
+      # Configure
+      # -----------------------------------------------------------------------
+      - name: Configure
+        shell: bash
+        env:
+          THEROCK_DIST: ${{ runner.workspace }}/therock-dist
+        run: |
+          cmake -S . -B ../build/$(basename "$PWD") \
+            -G Ninja \
+            -DBUILD_SHARED_LIBS=OFF \
+            "-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded" \
+            -DCMAKE_BUILD_TYPE=Release \
+            "-DCMAKE_PREFIX_PATH=${{ runner.workspace }}/prebuilt-local" \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -DBUILD_EP=ON \
+            -DBUILD_HIP_TOOLS=ON \
+            -DONNX_HIP_INCLUDE_LIT_TESTS=ON \
+            "-DTHEROCK_DIST=$THEROCK_DIST" \
+            -DHIP_ARCHITECTURES=gfx1151 \
+            -Dmorphizen_ENABLE_UNIT_TEST=OFF \
+            -DBUILD_MOCK_RUNTIME=OFF \
+            -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
+            --fresh
+
+
+      # -----------------------------------------------------------------------
+      # Build (no tests – Windows build-only CI)
+      # -----------------------------------------------------------------------
+      - name: Build
+        shell: bash
+        run: cmake --build ../build/$(basename "$PWD") --parallel $(nproc)

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -277,8 +277,15 @@ jobs:
 
 
       # -----------------------------------------------------------------------
-      # Build (no tests – Windows build-only CI)
+      # Build
       # -----------------------------------------------------------------------
       - name: Build
         shell: bash
         run: cmake --build ../build/$(basename "$PWD") --parallel $(nproc)
+
+      # -----------------------------------------------------------------------
+      # Run LIT tests (FileCheck-based IR tests; no GPU required)
+      # -----------------------------------------------------------------------
+      - name: Run LIT tests
+        shell: bash
+        run: cmake --build ../build/$(basename "$PWD") --target check-hip-lit

--- a/backend-mlir-compiler/proto/CMakeLists.txt
+++ b/backend-mlir-compiler/proto/CMakeLists.txt
@@ -14,5 +14,9 @@ target_include_directories(mlir_compilation_proto PUBLIC
     ${CMAKE_CURRENT_BINARY_DIR}
     ${Protobuf_INCLUDE_DIRS}
 )
+# Suppress C4267 (size_t→int) in protobuf-generated sources
+if(MSVC)
+  set_source_files_properties(${PROTO_SRCS} PROPERTIES COMPILE_FLAGS "/wd4267")
+endif()
 # Fix LNK4217 warnings: protobuf is statically linked, not a DLL
 target_compile_definitions(mlir_compilation_proto PRIVATE PROTOBUF_USE_DLLS=0)

--- a/include/hip/Dialect/IR/HipBufferize.h
+++ b/include/hip/Dialect/IR/HipBufferize.h
@@ -60,12 +60,11 @@ struct HipDstBufferizableModel
 inline void
 registerHipBufferizableOpInterfaceModels(DialectRegistry &registry) {
   registry.addExtension(+[](MLIRContext *ctx, HipDialect *) {
-    HipblasltMatmulOp::attachInterface<
-        HipDstBufferizableModel<HipblasltMatmulOp>>(*ctx);
+    MatmulOp::attachInterface<HipDstBufferizableModel<MatmulOp>>(*ctx);
     RmsNormOp::attachInterface<HipDstBufferizableModel<RmsNormOp>>(*ctx);
     SkipRmsNormOp::attachInterface<HipDstBufferizableModel<SkipRmsNormOp>>(
         *ctx);
-    MiopenRopeOp::attachInterface<HipDstBufferizableModel<MiopenRopeOp>>(*ctx);
+    RopeOp::attachInterface<HipDstBufferizableModel<RopeOp>>(*ctx);
     MiopenAddOp::attachInterface<HipDstBufferizableModel<MiopenAddOp>>(*ctx);
     MulOp::attachInterface<HipDstBufferizableModel<MulOp>>(*ctx);
     MiopenSoftmaxOp::attachInterface<HipDstBufferizableModel<MiopenSoftmaxOp>>(

--- a/level-2-pass-rocm-conv/cmake/generate_pattern_inc.cmake
+++ b/level-2-pass-rocm-conv/cmake/generate_pattern_inc.cmake
@@ -6,7 +6,7 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 add_custom_command (
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/conv_pattern_json.hpp
   COMMAND ${CMAKE_COMMAND} -E env
-    $<TARGET_FILE:Python3::Interpreter> ${morphizen_SOURCE_DIR}/tools/xxd.py
+    $<TARGET_FILE:Python3::Interpreter> ${CMAKE_SOURCE_DIR}/cmake/xxd.py
     "--column" 16
     "--var" conv_json
     --output ${CMAKE_CURRENT_BINARY_DIR}/conv_pattern_json.hpp

--- a/level-2-pass-rocm-gemm/cmake/generate_pattern_inc.cmake
+++ b/level-2-pass-rocm-gemm/cmake/generate_pattern_inc.cmake
@@ -6,7 +6,7 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 add_custom_command (
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/gemm_pattern_json.hpp
   COMMAND ${CMAKE_COMMAND} -E env
-    $<TARGET_FILE:Python3::Interpreter> ${morphizen_SOURCE_DIR}/tools/xxd.py
+    $<TARGET_FILE:Python3::Interpreter> ${CMAKE_SOURCE_DIR}/cmake/xxd.py
     "--column" 16
     "--var" gemm_json
     --output ${CMAKE_CURRENT_BINARY_DIR}/gemm_pattern_json.hpp

--- a/level-2-pass-rocm-matmul/cmake/generate_pattern_inc.cmake
+++ b/level-2-pass-rocm-matmul/cmake/generate_pattern_inc.cmake
@@ -6,7 +6,7 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 add_custom_command (
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/matmul_pattern_json.hpp
   COMMAND ${CMAKE_COMMAND} -E env
-    $<TARGET_FILE:Python3::Interpreter> ${morphizen_SOURCE_DIR}/tools/xxd.py
+    $<TARGET_FILE:Python3::Interpreter> ${CMAKE_SOURCE_DIR}/cmake/xxd.py
     "--column" 16
     "--var" matmul_json
     --output ${CMAKE_CURRENT_BINARY_DIR}/matmul_pattern_json.hpp

--- a/level-2-pass-rocm-mul/cmake/generate_pattern_inc.cmake
+++ b/level-2-pass-rocm-mul/cmake/generate_pattern_inc.cmake
@@ -6,7 +6,7 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 add_custom_command (
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/mul_pattern_json.hpp
   COMMAND ${CMAKE_COMMAND} -E env
-    $<TARGET_FILE:Python3::Interpreter> ${morphizen_SOURCE_DIR}/tools/xxd.py
+    $<TARGET_FILE:Python3::Interpreter> ${CMAKE_SOURCE_DIR}/cmake/xxd.py
     "--column" 16
     "--var" mul_json
     --output ${CMAKE_CURRENT_BINARY_DIR}/mul_pattern_json.hpp

--- a/level-2-pass-rocm-reshape/cmake/generate_pattern_inc.cmake
+++ b/level-2-pass-rocm-reshape/cmake/generate_pattern_inc.cmake
@@ -6,7 +6,7 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 add_custom_command (
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/reshape_pattern_json.hpp
   COMMAND ${CMAKE_COMMAND} -E env
-    $<TARGET_FILE:Python3::Interpreter> ${morphizen_SOURCE_DIR}/tools/xxd.py
+    $<TARGET_FILE:Python3::Interpreter> ${CMAKE_SOURCE_DIR}/cmake/xxd.py
     "--column" 16
     "--var" reshape_json
     --output ${CMAKE_CURRENT_BINARY_DIR}/reshape_pattern_json.hpp

--- a/level-2-pass-rocm-softmax/cmake/generate_pattern_inc.cmake
+++ b/level-2-pass-rocm-softmax/cmake/generate_pattern_inc.cmake
@@ -6,7 +6,7 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 add_custom_command (
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/softmax_pattern_json.hpp
   COMMAND ${CMAKE_COMMAND} -E env
-    $<TARGET_FILE:Python3::Interpreter> ${morphizen_SOURCE_DIR}/tools/xxd.py
+    $<TARGET_FILE:Python3::Interpreter> ${CMAKE_SOURCE_DIR}/cmake/xxd.py
     "--column" 16
     "--var" softmax_json
     --output ${CMAKE_CURRENT_BINARY_DIR}/softmax_pattern_json.hpp

--- a/level-2-pass-rocm-tile/cmake/generate_pattern_inc.cmake
+++ b/level-2-pass-rocm-tile/cmake/generate_pattern_inc.cmake
@@ -6,7 +6,7 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 add_custom_command (
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/tile_pattern_json.hpp
   COMMAND ${CMAKE_COMMAND} -E env
-    $<TARGET_FILE:Python3::Interpreter> ${morphizen_SOURCE_DIR}/tools/xxd.py
+    $<TARGET_FILE:Python3::Interpreter> ${CMAKE_SOURCE_DIR}/cmake/xxd.py
     "--column" 16
     "--var" tile_json
     --output ${CMAKE_CURRENT_BINARY_DIR}/tile_pattern_json.hpp

--- a/level-2-pass-rocm-transpose/cmake/generate_pattern_inc.cmake
+++ b/level-2-pass-rocm-transpose/cmake/generate_pattern_inc.cmake
@@ -6,7 +6,7 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 add_custom_command (
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/transpose_pattern_json.hpp
   COMMAND ${CMAKE_COMMAND} -E env
-    $<TARGET_FILE:Python3::Interpreter> ${morphizen_SOURCE_DIR}/tools/xxd.py
+    $<TARGET_FILE:Python3::Interpreter> ${CMAKE_SOURCE_DIR}/cmake/xxd.py
     "--column" 16
     "--var" transpose_json
     --output ${CMAKE_CURRENT_BINARY_DIR}/transpose_pattern_json.hpp

--- a/test/lit/CMakeLists.txt
+++ b/test/lit/CMakeLists.txt
@@ -62,7 +62,7 @@ set(LIT_ARGS "-sv" CACHE STRING "Extra arguments passed to lit (e.g. -j4 --no-pr
 # Add custom build target for manual invocation: cmake --build . --target check-hip-mlir-lit
 add_custom_target(check-hip-mlir-lit
     COMMAND ${LIT_EXECUTABLE} ${LIT_ARGS} --param=build_mode=$<CONFIG> .
-    DEPENDS hip-mlir-opt hip-compiler-exe
+    DEPENDS hip-mlir-opt hip-compiler
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMENT "Running LIT tests for hip-mlir-compiler"
 )


### PR DESCRIPTION
## Summary

- Add self-contained Windows build-only CI (`windows-build.yml`) using a deploy key for MorphiZen private submodule access
- Use prebuilt ORT/LLVM/flatbuffers/protobuf and source-built GTest; sccache for compilation caching
- Limit pre-commit push trigger to `main` branch only (eliminates duplicate runs on feature branches)
- Fix `generate_pattern_inc.cmake` path issues in `level-2-pass-rocm-*` targets
- Fix per-file `/wd4267` suppression in `backend-mlir-compiler/proto`
- Fix `HipBufferize.h`: rename `HipblasltMatmulOp` → `MatmulOp`, `MiopenRopeOp` → `RopeOp` to match renames in #34
- Update morphizen submodule to bd6532e (per-target C4267/C4702 suppression on MSVC)
- Update GitHub Actions to Node.js 24 compatible versions where available

## Dependencies

| Dependency | Source | Version |
|------------|--------|---------|
| ONNX Runtime | Official GitHub release zip | 1.24.3 |
| LLVM / flatbuffers | `wcy123/llvm-mlir-prebuilt` releases | 22.1.0 / 25.12.19 |
| protobuf | `wcy123/llvm-mlir-prebuilt` releases | 34.0 |
| GTest | Built from source (GoogleTest archive) | 1.15.0 |
| TheRock HIP SDK | AMD repo tarball | gfx1151 7.11.0 |

## Caching strategy

| Cache key | Contents |
|-----------|----------|
| `prebuilt-ort-<ORT>-<LLVM>-<FLATBUFFERS>-<PROTO>-gtest<GTEST>` | ORT + LLVM + flatbuffers + protobuf + GTest (single prefix) |
| `therock-dist-windows-gfx1151-7.11.0` | TheRock HIP SDK |

## CMake flags

`BUILD_EP=ON`, `BUILD_HIP_TOOLS=ON`, `BUILD_MOCK_RUNTIME=OFF`, `HIP_ARCHITECTURES=gfx1151`, `morphizen_ENABLE_UNIT_TEST=OFF`, `CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded`

## GitHub Actions versions

| Action | Version |
|--------|---------|
| `actions/checkout` | v6.0.2 |
| `actions/cache` | v5.0.3 |
| `actions/setup-python` | v6.0.0 |
| `webfactory/ssh-agent` | v0.10.0 |
| `ilammy/msvc-dev-cmd` | v1.13.0 (latest; no Node.js 24 release yet) |
| `mozilla-actions/sccache-action` | v0.0.9 (latest; no Node.js 24 release yet) |

## Test plan

- [x] pre-commit passes
- [x] Windows build passes (via `workflow_dispatch` and PR CI with deploy key)
- [x] Cache miss path: all dependencies download and install correctly
- [x] Cache hit path: Configure step resolves all `find_package()` calls without re-downloading