### PR TITLE
Port Target/LLVM backend, Compiler pipeline, and CInterface API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,10 +87,12 @@ if(BUILD_HIP_TOOLS)
   separate_arguments(LLVM_DEFINITIONS_LIST NATIVE_COMMAND ${LLVM_DEFINITIONS})
   add_definitions(${LLVM_DEFINITIONS_LIST})
 
+  # Source includes MUST come before LLVM/MLIR includes so that headers in
+  # the source tree take precedence over any stale installed copies.
+  include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+  include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR}/include)
   include_directories(${LLVM_INCLUDE_DIRS})
   include_directories(${MLIR_INCLUDE_DIRS})
-  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
-  include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
 
   # onnx-mlir is no longer required. The convert-onnx-to-hip pass uses
   # MLIR's generic Operation API to match ONNX ops by name, so no onnx-mlir
@@ -101,6 +103,7 @@ if(BUILD_HIP_TOOLS)
   include(TableGen)
   include(AddLLVM)
   include(AddMLIR)
+  include(HandleLLVMOptions)
 
   llvm_map_components_to_libnames(llvm_libs Support Core)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,10 +87,8 @@ if(BUILD_HIP_TOOLS)
   separate_arguments(LLVM_DEFINITIONS_LIST NATIVE_COMMAND ${LLVM_DEFINITIONS})
   add_definitions(${LLVM_DEFINITIONS_LIST})
 
-  # Source includes MUST come before LLVM/MLIR includes so that headers in
-  # the source tree take precedence over any stale installed copies.
-  include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/include)
-  include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR}/include)
+  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
+  include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
   include_directories(${LLVM_INCLUDE_DIRS})
   include_directories(${MLIR_INCLUDE_DIRS})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,10 +87,10 @@ if(BUILD_HIP_TOOLS)
   separate_arguments(LLVM_DEFINITIONS_LIST NATIVE_COMMAND ${LLVM_DEFINITIONS})
   add_definitions(${LLVM_DEFINITIONS_LIST})
 
-  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
-  include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
   include_directories(${LLVM_INCLUDE_DIRS})
   include_directories(${MLIR_INCLUDE_DIRS})
+  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
+  include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
 
   # onnx-mlir is no longer required. The convert-onnx-to-hip pass uses
   # MLIR's generic Operation API to match ONNX ops by name, so no onnx-mlir
@@ -101,7 +101,6 @@ if(BUILD_HIP_TOOLS)
   include(TableGen)
   include(AddLLVM)
   include(AddMLIR)
-  include(HandleLLVMOptions)
 
   llvm_map_components_to_libnames(llvm_libs Support Core)
 

--- a/include/hip/Compiler/CompilerDriver.h
+++ b/include/hip/Compiler/CompilerDriver.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#ifndef HIP_COMPILER_COMPILER_DRIVER_H
+#define HIP_COMPILER_COMPILER_DRIVER_H
+
+#include "compilation_options_generated.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "llvm/ADT/StringRef.h"
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace llvm {
+class LLVMContext;
+class Module;
+} // namespace llvm
+
+namespace mlir {
+class MLIRContext;
+class ModuleOp;
+} // namespace mlir
+
+namespace morphizen {
+class FileSystem;
+} // namespace morphizen
+
+namespace hip::compiler {
+
+/// End-to-end compilation driver for MLIR → DLL/Object/IR.
+///
+/// Orchestrates the complete compilation pipeline:
+/// - MLIR pass pipeline (ONNX→HIP→LLVM→Interface)
+/// - LLVM IR translation and optimization
+/// - Object file generation
+/// - DLL linking
+class CompilerDriver {
+public:
+  CompilerDriver() = default;
+  ~CompilerDriver() = default;
+
+  /// Set FileSystem for external constant storage.
+  /// When set, onnx.Constant data is written to "constants.bin" via fs
+  /// instead of being embedded in the DLL. Must be called before compile().
+  void setFileSystem(morphizen::FileSystem *fs) { fileSystem_ = fs; }
+
+  /// Compile MLIR string to output file.
+  bool compile(llvm::StringRef input_mlir, const std::string &output_path,
+               const mlir::hip::CompilationOptionsT &options,
+               std::string &error_message);
+
+  /// Compile MLIR module to output file.
+  bool compileFromModule(mlir::ModuleOp module, const std::string &output_path,
+                         const mlir::hip::CompilationOptionsT &options,
+                         std::string &error_message);
+
+  /// Validate MLIR input without compiling.
+  bool validate(llvm::StringRef input_mlir, std::string &error_message);
+
+private:
+  bool compileImpl(mlir::ModuleOp module, const std::string &output_path,
+                   const mlir::hip::CompilationOptionsT &options,
+                   std::string &error_message);
+
+  bool runMLIRPasses(mlir::ModuleOp module,
+                     const mlir::hip::CompilationOptionsT &options,
+                     std::string &error_message);
+
+  std::unique_ptr<llvm::Module>
+  translateToLLVMIR(mlir::ModuleOp module, llvm::LLVMContext &llvmContext,
+                    std::string &error_message);
+
+  bool linkRuntime(llvm::Module *llvmModule, std::string &error_message);
+
+  void optimizeLLVMIR(llvm::Module *llvmModule, int optLevel);
+
+  bool emitLLVMIR(llvm::Module *llvmModule, const std::string &outputPath,
+                  std::string &error_message);
+
+  bool compileToObject(llvm::Module *llvmModule, const std::string &outputPath,
+                       std::string &error_message);
+
+  bool linkToDLL(const std::string &objPath, const std::string &dllPath,
+                 const std::vector<std::string> &libraries,
+                 const std::vector<std::string> &library_paths,
+                 const std::vector<std::string> &export_symbols,
+                 std::string &error_message);
+
+  /// Discover GPU runtime libraries from THEROCK_DIST environment variable.
+  void discoverLibraries(std::vector<std::string> &libraries,
+                         std::vector<std::string> &library_paths);
+
+  void cleanupIntermediates(const std::string &basePath);
+
+  morphizen::FileSystem *fileSystem_ = nullptr;
+};
+
+} // namespace hip::compiler
+
+#endif // HIP_COMPILER_COMPILER_DRIVER_H

--- a/include/hip/Compiler/Passes/Passes.h
+++ b/include/hip/Compiler/Passes/Passes.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#ifndef HIP_COMPILER_COMPILER_PASSES_PASSES_H
+#define HIP_COMPILER_COMPILER_PASSES_PASSES_H
+
+#include "hip/Dialect/Transforms/Passes.h"
+
+// Re-export the GenerateInterface pass from the Dialect/Transforms layer.
+// The Compiler pipeline uses the same pass — this header keeps the include
+// path consistent with the Compiler directory layout.
+
+#endif // HIP_COMPILER_COMPILER_PASSES_PASSES_H

--- a/include/hip/Conversion/HipToLLVM/Passes.h
+++ b/include/hip/Conversion/HipToLLVM/Passes.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#ifndef HIP_COMPILER_CONVERSION_HIPTOLLVM_PASSES_H
+#define HIP_COMPILER_CONVERSION_HIPTOLLVM_PASSES_H
+
+#include "mlir/Pass/Pass.h"
+#include <memory>
+
+namespace mlir {
+namespace hip {
+
+/// Creates a pass that converts HIP dialect operations to LLVM dialect.
+/// Lowers HIP GPU operations to LLVM calls to MIOpen/HIP runtime.
+std::unique_ptr<Pass> createConvertHipToLLVMPass();
+
+} // namespace hip
+} // namespace mlir
+
+#endif // HIP_COMPILER_CONVERSION_HIPTOLLVM_PASSES_H

--- a/include/hip/Conversion/OnnxToHip/Passes.h
+++ b/include/hip/Conversion/OnnxToHip/Passes.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#ifndef HIP_CONVERSION_ONNXTOHIP_PASSES_H
+#define HIP_CONVERSION_ONNXTOHIP_PASSES_H
+
+#include "mlir/Pass/Pass.h"
+#include <memory>
+
+namespace mlir {
+namespace hip {
+
+/// Creates a pass that converts ONNX operations to HIP dialect.
+/// Uses default options (constants.bin, no externalization).
+std::unique_ptr<Pass> createConvertOnnxToHipPass();
+
+} // namespace hip
+} // namespace mlir
+
+#endif // HIP_CONVERSION_ONNXTOHIP_PASSES_H

--- a/include/hip/Conversion/Passes.h
+++ b/include/hip/Conversion/Passes.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#ifndef HIP_COMPILER_CONVERSION_PASSES_H
+#define HIP_COMPILER_CONVERSION_PASSES_H
+
+#include "hip/Conversion/HipToLLVM/Passes.h"
+#include "hip/Conversion/OnnxToHip/Passes.h"
+
+namespace hip::compiler {
+
+/// Register all conversion passes (ONNX->HIP, HIP->LLVM).
+void registerConversionPasses();
+
+} // namespace hip::compiler
+
+#endif // HIP_COMPILER_CONVERSION_PASSES_H

--- a/include/hip/InitAllPasses.h
+++ b/include/hip/InitAllPasses.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#ifndef HIP_COMPILER_INITALLPASSES_H
+#define HIP_COMPILER_INITALLPASSES_H
+
+#include "hip/Conversion/Passes.h"
+#include "hip/Dialect/IR/HipBufferize.h"
+#include "hip/Dialect/IR/HipDialect.h"
+#include "hip/Dialect/Transforms/Passes.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Arith/Transforms/BufferizableOpInterfaceImpl.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Bufferization/Transforms/FuncBufferizableOpInterfaceImpl.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/MemRef/Transforms/AllocationOpInterfaceImpl.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Tensor/Transforms/BufferizableOpInterfaceImpl.h"
+#include "mlir/IR/BuiltinDialect.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Transforms/Passes.h"
+
+namespace hip::compiler {
+
+namespace detail {
+/// Minimal ONNX dialect stub that claims the "onnx" namespace and permits
+/// unknown operations.  This avoids depending on the full onnx-mlir library.
+class OnnxStubDialect : public mlir::Dialect {
+public:
+  explicit OnnxStubDialect(mlir::MLIRContext *ctx)
+      : Dialect(getDialectNamespace(), ctx,
+                mlir::TypeID::get<OnnxStubDialect>()) {
+    allowUnknownOperations();
+  }
+  static constexpr llvm::StringLiteral getDialectNamespace() { return "onnx"; }
+};
+} // namespace detail
+
+/// Register all required dialects into a DialectRegistry.
+inline void registerAllDialects(mlir::DialectRegistry &registry) {
+  registry.insert<mlir::BuiltinDialect>();
+  registry.insert<mlir::arith::ArithDialect>();
+  registry.insert<mlir::func::FuncDialect>();
+  registry.insert<mlir::memref::MemRefDialect>();
+  registry.insert<mlir::tensor::TensorDialect>();
+  registry.insert<mlir::bufferization::BufferizationDialect>();
+  registry.insert<mlir::LLVM::LLVMDialect>();
+  registry.insert<mlir::hip::HipDialect>();
+  registry.insert<detail::OnnxStubDialect>();
+  mlir::arith::registerBufferizableOpInterfaceExternalModels(registry);
+  mlir::tensor::registerBufferizableOpInterfaceExternalModels(registry);
+  mlir::bufferization::func_ext::registerBufferizableOpInterfaceExternalModels(
+      registry);
+  mlir::memref::registerAllocationOpInterfaceExternalModels(registry);
+  mlir::hip::registerHipBufferizableOpInterfaceModels(registry);
+}
+
+/// Load all required dialects into an MLIRContext.
+inline void loadAllDialects(mlir::MLIRContext &context) {
+  mlir::DialectRegistry registry;
+  registerAllDialects(registry);
+  context.appendDialectRegistry(registry);
+  context.loadAllAvailableDialects();
+}
+
+/// Register all passes and pipelines.
+inline void registerAllPasses() {
+  mlir::registerCanonicalizerPass();
+  mlir::hip::registerOptimizeMemRefsPass();
+  mlir::hip::registerPoolAllocsPass();
+  registerConversionPasses();
+}
+
+} // namespace hip::compiler
+
+#endif // HIP_COMPILER_INITALLPASSES_H

--- a/include/hip/Target/LLVM/DLLLinker.h
+++ b/include/hip/Target/LLVM/DLLLinker.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#ifndef DLL_LINKER_H
+#define DLL_LINKER_H
+
+#include <string>
+#include <vector>
+
+namespace hipdnn {
+
+// DLL Linker: Links object files with runtime library to produce native DLL
+// Uses LLD (LLVM Linker) library APIs directly - NO external programs
+// Supports Windows (PE/COFF) and Linux (ELF) platforms
+
+class DLLLinker {
+public:
+  DLLLinker();
+  ~DLLLinker();
+
+  // Link object file with libraries to produce DLL/SO
+  // Platform-specific:
+  //   Windows: Produces .dll using LLD-LINK (PE/COFF)
+  //   Linux: Produces .so using LLD-ELF (shared object)
+  //
+  // Parameters:
+  //   objectFile: Input object file path (.obj on Windows, .o on Linux)
+  //   outputDLL: Output DLL path (.dll on Windows, .so on Linux)
+  //   libraries: Library names to link (e.g., "amdhip64", "MIOpen")
+  //   libraryPaths: Directories to search for libraries
+  //   exportSymbols: Symbol names to export from DLL (inference_init, etc.)
+  //
+  // Returns: true on success, false on failure
+  bool linkDLL(const std::string &objectFile, const std::string &outputDLL,
+               const std::vector<std::string> &libraries,
+               const std::vector<std::string> &libraryPaths,
+               const std::vector<std::string> &exportSymbols);
+
+  // In-Memory Mode: Link object bytes to DLL in memory (for EPContext storage)
+  // Parameters:
+  //   objectBytes: Input object file data in memory
+  //   outDLLBytes: Output DLL data in memory
+  //   libraries: Library names to link (e.g., "amdhip64", "MIOpen")
+  //   libraryPaths: Directories to search for libraries
+  //   exportSymbols: Symbol names to export from DLL (inference_init, etc.)
+  //
+  // Returns: true on success, false on failure
+  bool linkDLLInMemory(const std::vector<uint8_t> &objectBytes,
+                       std::vector<uint8_t> &outDLLBytes,
+                       const std::vector<std::string> &libraries,
+                       const std::vector<std::string> &libraryPaths,
+                       const std::vector<std::string> &exportSymbols);
+
+  // Verify DLL has required exports (debugging utility)
+  // Returns: true if all symbols are exported, false otherwise
+  bool verifyDLLExports(const std::string &dllPath,
+                        const std::vector<std::string> &requiredSymbols);
+
+private:
+  // Platform-specific linker implementations
+#ifdef _WIN32
+  bool linkDLL_Windows(const std::string &objectFile,
+                       const std::string &outputDLL,
+                       const std::vector<std::string> &libraries,
+                       const std::vector<std::string> &libraryPaths,
+                       const std::vector<std::string> &exportSymbols);
+
+  // Create module definition file (.def) for Windows exports
+  bool
+  createModuleDefinitionFile(const std::string &defPath,
+                             const std::vector<std::string> &exportSymbols);
+#else
+  bool linkDLL_Linux(const std::string &objectFile,
+                     const std::string &outputDLL,
+                     const std::vector<std::string> &libraries,
+                     const std::vector<std::string> &libraryPaths);
+#endif
+};
+
+} // namespace hipdnn
+
+#endif // DLL_LINKER_H

--- a/include/hip/Target/LLVM/LLVMBackend.h
+++ b/include/hip/Target/LLVM/LLVMBackend.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#ifndef LLVM_BACKEND_H
+#define LLVM_BACKEND_H
+
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Module.h>
+#include <llvm/Target/TargetMachine.h>
+#include <mlir/IR/BuiltinOps.h>
+
+#include <memory>
+#include <string>
+
+namespace hipdnn {
+
+// LLVM Backend: Translates MLIR to LLVM IR and optionally compiles to native
+// object file Supports two compilation modes:
+//   1. IR Mode: MLIR → LLVM IR (.ll text file) - for debugging and
+//   cross-platform
+//   2. Native Mode: MLIR → LLVM IR → Object File (.obj/.o) - for production DLL
+//   generation
+
+class LLVMBackend {
+public:
+  LLVMBackend();
+  ~LLVMBackend();
+
+  // MLIR → LLVM IR translation (used by both modes)
+  // Translates MLIR module in LLVM dialect to LLVM IR using C++ library API
+  // Returns nullptr on failure
+  std::unique_ptr<llvm::Module>
+  translateMLIRtoLLVMIR(mlir::ModuleOp mlirModule,
+                        llvm::LLVMContext &llvmContext);
+
+  // LLVM IR optimization (used by both modes)
+  // Runs standard optimization passes at specified level (0-3)
+  // Level 0: No optimization
+  // Level 1: Basic optimization
+  // Level 2: Default optimization (recommended)
+  // Level 3: Aggressive optimization
+  void optimizeLLVMIR(llvm::Module *module, int optLevel);
+
+  // IR Mode: Emit LLVM IR to text file (.ll)
+  // Returns true on success, false on failure
+  bool emitLLVMIR(llvm::Module *module, const std::string &outputPath);
+
+  // Native Mode: Compile LLVM IR to object file (.obj on Windows, .o on Linux)
+  // Uses LLVM TargetMachine to emit native code
+  // Returns true on success, false on failure
+  bool compileToObjectFile(llvm::Module *module, const std::string &outputPath);
+
+  // In-Memory Mode: Emit LLVM IR to string (for EPContext storage)
+  // Returns true on success, false on failure
+  bool emitLLVMIRToString(llvm::Module *module, std::string &outIR);
+
+  // In-Memory Mode: Compile LLVM IR to object in memory (for EPContext storage)
+  // Returns true on success, false on failure
+  bool compileToObjectInMemory(llvm::Module *module,
+                               std::vector<uint8_t> &outBytes);
+
+  // Link embedded Runtime IR into destination module
+  // Merges Runtime bitcode with generated IR for zero-cost abstraction
+  // Returns true on success, false on failure
+  bool linkRuntimeModule(llvm::Module *destModule);
+
+private:
+  // Helper: Initialize LLVM target for current platform
+  void initializeTarget();
+
+  // Helper: Create TargetMachine for native compilation
+  llvm::TargetMachine *createTargetMachine();
+
+  bool target_initialized_;
+};
+
+} // namespace hipdnn
+
+#endif // LLVM_BACKEND_H

--- a/include/hip/compiler_api.h
+++ b/include/hip/compiler_api.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#ifndef HIP_COMPILER_API_H
+#define HIP_COMPILER_API_H
+
+#include "compiler_types.h"
+
+/* Export macro for DLL visibility */
+#ifdef _WIN32
+#ifdef HIP_COMPILER_EXPORTS
+#define COMPILER_API __declspec(dllexport)
+#else
+#define COMPILER_API __declspec(dllimport)
+#endif
+#else
+#define COMPILER_API __attribute__((visibility("default")))
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Compilation entry point with external constant storage.
+ *
+ * Compiles MLIR input to DLL/object/IR file. onnx.Constant data is written
+ * to "constants.bin" via the provided FileSystem. The DLL contains only code;
+ * all weight data lives in the external file.
+ *
+ * constants.bin format: raw concatenated bytes of each constant in
+ * discovery order. Sizes are hardcoded in the generated inference_init.
+ *
+ * The generated inference_init signature becomes:
+ *   int inference_init(void** out_state, void* fs)
+ * where fs is a morphizen::FileSystem* passed as void* for C ABI.
+ *
+ * @param input_mlir   Input MLIR data (text or bytecode)
+ * @param input_size   Size of input data in bytes
+ * @param output_path  Output DLL/object/IR file path
+ * @param options_json Compilation options as JSON string (can be NULL)
+ * @param error        Error information output (can be NULL)
+ * @param fs           morphizen::FileSystem* (cast to void* for C ABI).
+ *                     Used to create "constants.bin" for writing.
+ * @return             COMPILER_SUCCESS or error code
+ */
+COMPILER_API CompilerErrorCode hip_compile_with_fs(
+    const void *input_mlir, size_t input_size, const char *output_path,
+    const char *options_json, CompilerError *error, void *fs);
+
+/**
+ * Get compiler version string.
+ *
+ * @return Static version string (e.g., "1.0.0")
+ */
+COMPILER_API const char *hip_get_version(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HIP_COMPILER_API_H */

--- a/include/hip/compiler_types.h
+++ b/include/hip/compiler_types.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#ifndef HIP_COMPILER_TYPES_H
+#define HIP_COMPILER_TYPES_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Error codes for compiler operations */
+typedef enum {
+  COMPILER_SUCCESS = 0,
+  COMPILER_ERROR_INVALID_INPUT = 1,
+  COMPILER_ERROR_PARSE_FAILED = 2,
+  COMPILER_ERROR_PASS_FAILED = 3,
+  COMPILER_ERROR_TRANSLATION_FAILED = 4,
+  COMPILER_ERROR_LINKING_FAILED = 5,
+  COMPILER_ERROR_IO_ERROR = 6,
+  COMPILER_ERROR_COMPILATION_FAILED = 7,
+  COMPILER_ERROR_VALIDATION_FAILED = 8,
+  COMPILER_ERROR_INTERNAL = 99
+} CompilerErrorCode;
+
+/* Error information (DLL-safe, fixed-size buffer) */
+#define COMPILER_ERROR_MESSAGE_SIZE 1024
+typedef struct {
+  CompilerErrorCode code;
+  char message[COMPILER_ERROR_MESSAGE_SIZE];
+} CompilerError;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HIP_COMPILER_TYPES_H */

--- a/lib/CInterface/CMakeLists.txt
+++ b/lib/CInterface/CMakeLists.txt
@@ -9,7 +9,6 @@ add_library(HipCInterface STATIC
 
 target_include_directories(HipCInterface PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/include
 )
 
 target_compile_definitions(HipCInterface PRIVATE

--- a/lib/CInterface/CMakeLists.txt
+++ b/lib/CInterface/CMakeLists.txt
@@ -1,0 +1,27 @@
+##
+# ** Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# ** Licensed under the MIT License.
+##
+
+add_library(HipCInterface STATIC
+    CompilerAPI.cpp
+)
+
+target_include_directories(HipCInterface PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+target_compile_definitions(HipCInterface PRIVATE
+    HIP_COMPILER_EXPORTS
+)
+
+target_link_libraries(HipCInterface PUBLIC
+    LibHipCompiler
+    HipSchemasLib
+)
+
+install(TARGETS HipCInterface
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+)

--- a/lib/CInterface/CompilerAPI.cpp
+++ b/lib/CInterface/CompilerAPI.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "hip/Compiler/CompilerDriver.h"
+#include "hip/compiler_api.h"
+#include "hip/compiler_types.h"
+#include "hip/flatbuffers_json.h"
+
+#include "morphizen-foundation/file_io.hpp"
+
+#include "compilation_options_schema.h"
+
+#include "llvm/ADT/StringRef.h"
+
+#include <cstring>
+#include <string>
+
+using namespace hip::compiler;
+
+static const char *COMPILER_VERSION = "1.0.0";
+
+// Parse JSON into CompilationOptionsT (defined in schemas/compilation_options.fbs).
+// Key fields:
+//   opt_level      — LLVM optimization level 0-3 (default 2)
+//   output_mode    — DLL or LLVM_IR (default DLL)
+//   constants_file — externalized weights filename (default "constants.bin")
+static bool parseOptions(const char *options_json,
+                         mlir::hip::CompilationOptionsT &opts,
+                         std::string &error_message) {
+  if (!options_json || strlen(options_json) == 0)
+    return true;
+
+  return mlir::hip::fromJson<mlir::hip::CompilationOptionsT>(
+      options_json, mlir::hip::k_compilation_options_schema(), opts,
+      error_message);
+}
+
+static void setError(CompilerError *error, const std::string &message) {
+  if (error) {
+    size_t len = message.length();
+    if (len >= sizeof(error->message)) {
+      len = sizeof(error->message) - 1;
+    }
+    std::memcpy(error->message, message.c_str(), len);
+    error->message[len] = '\0';
+  }
+}
+
+extern "C" {
+
+COMPILER_API CompilerErrorCode hip_compile_with_fs(
+    const void *input_mlir, size_t input_size, const char *output_path,
+    const char *options_json, CompilerError *error, void *fs) {
+  if (!input_mlir || input_size == 0 || !output_path) {
+    setError(
+        error,
+        "Invalid input: input_mlir, input_size, and output_path must be valid");
+    return COMPILER_ERROR_INVALID_INPUT;
+  }
+  if (!fs) {
+    setError(error, "Invalid input: fs (FileSystem*) must be non-null");
+    return COMPILER_ERROR_INVALID_INPUT;
+  }
+
+  try {
+    mlir::hip::CompilationOptionsT options;
+    std::string parse_error;
+    if (!parseOptions(options_json, options, parse_error)) {
+      setError(error, parse_error);
+      return COMPILER_ERROR_INVALID_INPUT;
+    }
+
+    CompilerDriver driver;
+    driver.setFileSystem(static_cast<morphizen::FileSystem *>(fs));
+
+    std::string error_message;
+    llvm::StringRef input_ref(static_cast<const char *>(input_mlir),
+                              input_size);
+    std::string output_str(output_path);
+
+    bool success =
+        driver.compile(input_ref, output_str, options, error_message);
+
+    if (!success) {
+      setError(error, error_message);
+      return COMPILER_ERROR_COMPILATION_FAILED;
+    }
+
+    return COMPILER_SUCCESS;
+
+  } catch (const std::exception &ex) {
+    setError(error, std::string("Exception: ") + ex.what());
+    return COMPILER_ERROR_INTERNAL;
+  } catch (...) {
+    setError(error, "Unknown exception occurred");
+    return COMPILER_ERROR_INTERNAL;
+  }
+}
+
+COMPILER_API const char *hip_get_version(void) { return COMPILER_VERSION; }
+
+} // extern "C"

--- a/lib/CInterface/CompilerAPI.cpp
+++ b/lib/CInterface/CompilerAPI.cpp
@@ -21,8 +21,8 @@ using namespace hip::compiler;
 
 static const char *COMPILER_VERSION = "1.0.0";
 
-// Parse JSON into CompilationOptionsT (defined in schemas/compilation_options.fbs).
-// Key fields:
+// Parse JSON into CompilationOptionsT (defined in
+// schemas/compilation_options.fbs). Key fields:
 //   opt_level      — LLVM optimization level 0-3 (default 2)
 //   output_mode    — DLL or LLVM_IR (default DLL)
 //   constants_file — externalized weights filename (default "constants.bin")

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -6,3 +6,6 @@
 add_subdirectory(Dialect)
 add_subdirectory(Conversion)
 add_subdirectory(Runtime)
+add_subdirectory(Target/LLVM)
+add_subdirectory(Compiler)
+add_subdirectory(CInterface)

--- a/lib/Compiler/CMakeLists.txt
+++ b/lib/Compiler/CMakeLists.txt
@@ -49,10 +49,7 @@ llvm_map_components_to_libnames(compiler_llvm_libs
 
 target_link_libraries(LibHipCompiler PUBLIC ${compiler_llvm_libs})
 
-# Add include directories
 target_include_directories(LibHipCompiler PUBLIC
-  ${CMAKE_SOURCE_DIR}/include
-  ${CMAKE_BINARY_DIR}/include
   ${CMAKE_BINARY_DIR}/lib
   ${CMAKE_BINARY_DIR}/schemas
   ${CMAKE_SOURCE_DIR}/3rd-party/onnx-mlir

--- a/lib/Compiler/CMakeLists.txt
+++ b/lib/Compiler/CMakeLists.txt
@@ -1,0 +1,63 @@
+##
+# ** Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# ** Licensed under the MIT License.
+##
+
+message(STATUS "Building Compiler Library")
+
+# Create compiler library
+add_library(LibHipCompiler STATIC
+  CompilerDriver.cpp
+)
+
+# Link against required libraries
+target_link_libraries(LibHipCompiler PUBLIC
+  HipConversion
+  HipDialectIR
+  HipDialectTransforms
+  HipTargetLLVM
+  MLIRIR
+  MLIRPass
+  MLIRSupport
+  MLIRTransforms
+  MLIRFuncDialect
+  MLIRArithDialect
+  MLIRMemRefDialect
+  MLIRLLVMDialect
+  MLIRBufferizationDialect
+  MLIRBufferizationTransforms
+  MLIRSCFDialect
+  MLIRSCFToControlFlow
+  MLIRParser
+  MLIRLLVMToLLVMIRTranslation
+  MLIRTargetLLVMIRExport
+  HipSchemasLib
+)
+
+# Link LLVM components
+llvm_map_components_to_libnames(compiler_llvm_libs
+  Support
+  Core
+  IRReader
+  Passes
+  Target
+  X86CodeGen
+  X86AsmParser
+  X86Desc
+  X86Info
+)
+
+target_link_libraries(LibHipCompiler PUBLIC ${compiler_llvm_libs})
+
+# Add include directories
+target_include_directories(LibHipCompiler PUBLIC
+  ${CMAKE_SOURCE_DIR}/include
+  ${CMAKE_BINARY_DIR}/include
+  ${CMAKE_BINARY_DIR}/lib
+  ${CMAKE_BINARY_DIR}/schemas
+  ${CMAKE_SOURCE_DIR}/3rd-party/onnx-mlir
+  ${CMAKE_BINARY_DIR}/3rd-party/onnx-mlir
+)
+
+# Set folder for IDE organization
+set_target_properties(LibHipCompiler PROPERTIES FOLDER "mlir/Compiler")

--- a/lib/Compiler/CompilerDriver.cpp
+++ b/lib/Compiler/CompilerDriver.cpp
@@ -284,8 +284,8 @@ void CompilerDriver::discoverLibraries(
       libraries.push_back(custom_lib);
       COMPILER_DEBUG_LOG("  Custom kernels: " << custom_lib << "\n");
     } else {
-      COMPILER_DEBUG_LOG("  WARNING: custom kernels lib not found at: "
-                         << custom_lib << "\n");
+      COMPILER_DEBUG_LOG(
+          "  WARNING: custom kernels lib not found at: " << custom_lib << "\n");
     }
   }
 #endif

--- a/lib/Compiler/CompilerDriver.cpp
+++ b/lib/Compiler/CompilerDriver.cpp
@@ -1,0 +1,311 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "hip/Compiler/CompilerDriver.h"
+#include "hip/Dialect/IR/HipDialect.h"
+#include "hip/Dialect/Transforms/Pipelines.h"
+#include "hip/InitAllPasses.h"
+
+#include "hip/Target/LLVM/DLLLinker.h"
+#include "hip/Target/LLVM/LLVMBackend.h"
+
+#include "mlir/Dialect/Bufferization/Transforms/Passes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Parser/Parser.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
+#include "mlir/Target/LLVMIR/Export.h"
+#include "mlir/Transforms/Passes.h"
+
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/SourceMgr.h"
+
+#include "hip/debug_log.h"
+
+#include <cstdlib>
+#include <sstream>
+
+namespace hip::compiler {
+
+namespace {
+bool fileExists(const std::string &path) {
+  llvm::sys::fs::file_status status;
+  std::error_code EC = llvm::sys::fs::status(path, status);
+  return !EC && llvm::sys::fs::exists(status);
+}
+} // namespace
+
+bool CompilerDriver::compile(llvm::StringRef input_mlir,
+                             const std::string &output_path,
+                             const mlir::hip::CompilationOptionsT &options,
+                             std::string &error_message) {
+  hip::compiler::registerAllPasses();
+
+  mlir::MLIRContext context;
+  hip::compiler::loadAllDialects(context);
+  mlir::registerLLVMDialectTranslation(context);
+
+  COMPILER_DEBUG_LOG("[CompilerDriver::compile] Input size: "
+                     << input_mlir.size() << " bytes\n");
+
+  // Wrap input in a non-owning buffer (no copy) for MLIR's parser.
+  auto memBuffer = llvm::MemoryBuffer::getMemBuffer(input_mlir, "", false);
+
+  // SourceMgr provides source-location tracking for parser diagnostics.
+  llvm::SourceMgr sourceMgr;
+  sourceMgr.AddNewSourceBuffer(std::move(memBuffer), llvm::SMLoc());
+
+  mlir::OwningOpRef<mlir::ModuleOp> module =
+      mlir::parseSourceFile<mlir::ModuleOp>(sourceMgr, &context);
+
+  if (!module) {
+    error_message = "Failed to parse MLIR input";
+    return false;
+  }
+
+  return compileImpl(*module, output_path, options, error_message);
+}
+
+bool CompilerDriver::compileFromModule(
+    mlir::ModuleOp module, const std::string &output_path,
+    const mlir::hip::CompilationOptionsT &options, std::string &error_message) {
+  hip::compiler::registerAllPasses();
+  return compileImpl(module, output_path, options, error_message);
+}
+
+bool CompilerDriver::validate(llvm::StringRef input_mlir,
+                              std::string &error_message) {
+  mlir::MLIRContext context;
+  hip::compiler::loadAllDialects(context);
+
+  auto memBuffer = llvm::MemoryBuffer::getMemBuffer(input_mlir, "", false);
+  llvm::SourceMgr sourceMgr;
+  sourceMgr.AddNewSourceBuffer(std::move(memBuffer), llvm::SMLoc());
+
+  mlir::OwningOpRef<mlir::ModuleOp> module =
+      mlir::parseSourceFile<mlir::ModuleOp>(sourceMgr, &context);
+
+  if (!module) {
+    error_message = "Failed to parse MLIR input";
+    return false;
+  }
+
+  return true;
+}
+
+bool CompilerDriver::compileImpl(mlir::ModuleOp module,
+                                 const std::string &output_path,
+                                 const mlir::hip::CompilationOptionsT &options,
+                                 std::string &error_message) {
+  if (!runMLIRPasses(module, options, error_message))
+    return false;
+
+  llvm::LLVMContext llvmContext;
+  auto llvmModule = translateToLLVMIR(module, llvmContext, error_message);
+  if (!llvmModule)
+    return false;
+
+  if (!linkRuntime(llvmModule.get(), error_message))
+    return false;
+
+  optimizeLLVMIR(llvmModule.get(), options.opt_level);
+
+  // Strip .dll extension to derive intermediate file paths (.ll, .obj).
+  std::string base_path = output_path;
+  llvm::StringRef dll_ext = ".dll";
+  if (llvm::StringRef(base_path).ends_with(dll_ext))
+    base_path.resize(base_path.size() - dll_ext.size());
+  std::string ll_path = base_path + ".ll";
+  std::string obj_path = base_path + ".obj";
+
+  if (options.output_mode == mlir::hip::OutputMode::LLVM_IR) {
+    if (!emitLLVMIR(llvmModule.get(), ll_path, error_message))
+      return false;
+    return true;
+  }
+
+  if (!compileToObject(llvmModule.get(), obj_path, error_message))
+    return false;
+
+  // Symbols exported from the generated DLL:
+  //   inference_init/compute/cleanup — runtime entry points
+  //   inference_get_metadata_json    — model metadata query
+  //   test_hip_from_dll              — diagnostic hook for test-model-dll
+  std::vector<std::string> export_symbols = {
+      "inference_init", "inference_compute", "inference_cleanup",
+      "inference_get_metadata_json", "test_hip_from_dll"};
+  std::vector<std::string> libraries;
+  std::vector<std::string> library_paths;
+  discoverLibraries(libraries, library_paths);
+
+  if (!linkToDLL(obj_path, output_path, libraries, library_paths,
+                 export_symbols, error_message))
+    return false;
+
+  cleanupIntermediates(base_path);
+
+  return true;
+}
+
+bool CompilerDriver::runMLIRPasses(
+    mlir::ModuleOp module, const mlir::hip::CompilationOptionsT &options,
+    std::string &error_message) {
+  mlir::PassManager pm(module.getContext());
+
+  if (options.verbose) {
+    COMPILER_DEBUG_LOG("Running ONNX->HIP->LLVM->Interface passes\n");
+  }
+
+  mlir::hip::OnnxToHipPipelineOptions onnxToHipOpts;
+  mlir::hip::buildOnnxToHipPipeline(pm, onnxToHipOpts);
+
+  mlir::hip::HipToLLVMPipelineOptions hipToLlvmOpts;
+  hipToLlvmOpts.constantsFile = options.constants_file;
+  mlir::hip::buildHipToLLVMPipeline(pm, hipToLlvmOpts);
+
+  if (mlir::failed(pm.run(module))) {
+    error_message = "MLIR pass pipeline failed";
+    if (options.verbose) {
+      llvm::errs() << "\n=== Failed Module IR ===\n";
+      module.print(llvm::errs());
+      llvm::errs() << "\n========================\n";
+    }
+    return false;
+  }
+
+  if (options.verbose)
+    COMPILER_DEBUG_LOG("MLIR passes completed\n\n");
+
+  return true;
+}
+
+std::unique_ptr<llvm::Module>
+CompilerDriver::translateToLLVMIR(mlir::ModuleOp module,
+                                  llvm::LLVMContext &llvmContext,
+                                  std::string &error_message) {
+  hipdnn::LLVMBackend backend;
+  auto llvmModule = backend.translateMLIRtoLLVMIR(module, llvmContext);
+
+  if (!llvmModule) {
+    error_message = "Failed to translate MLIR to LLVM IR";
+  }
+
+  return llvmModule;
+}
+
+bool CompilerDriver::linkRuntime(llvm::Module *llvmModule,
+                                 std::string &error_message) {
+  hipdnn::LLVMBackend backend;
+  if (!backend.linkRuntimeModule(llvmModule)) {
+    error_message = "Failed to link runtime module";
+    return false;
+  }
+  return true;
+}
+
+void CompilerDriver::optimizeLLVMIR(llvm::Module *llvmModule, int optLevel) {
+  hipdnn::LLVMBackend backend;
+  backend.optimizeLLVMIR(llvmModule, optLevel);
+}
+
+bool CompilerDriver::emitLLVMIR(llvm::Module *llvmModule,
+                                const std::string &outputPath,
+                                std::string &error_message) {
+  hipdnn::LLVMBackend backend;
+  if (!backend.emitLLVMIR(llvmModule, outputPath)) {
+    error_message = "Failed to emit LLVM IR";
+    return false;
+  }
+  return true;
+}
+
+bool CompilerDriver::compileToObject(llvm::Module *llvmModule,
+                                     const std::string &outputPath,
+                                     std::string &error_message) {
+  hipdnn::LLVMBackend backend;
+  if (!backend.compileToObjectFile(llvmModule, outputPath)) {
+    error_message = "Failed to compile to object file";
+    return false;
+  }
+  return true;
+}
+
+bool CompilerDriver::linkToDLL(const std::string &objPath,
+                               const std::string &dllPath,
+                               const std::vector<std::string> &libraries,
+                               const std::vector<std::string> &library_paths,
+                               const std::vector<std::string> &export_symbols,
+                               std::string &error_message) {
+  hipdnn::DLLLinker linker;
+
+  if (!linker.linkDLL(objPath, dllPath, libraries, library_paths,
+                      export_symbols)) {
+    error_message = "Failed to link DLL";
+    return false;
+  }
+
+  return true;
+}
+
+void CompilerDriver::discoverLibraries(
+    std::vector<std::string> &libraries,
+    std::vector<std::string> &library_paths) {
+  const char *therock = std::getenv("THEROCK_DIST");
+  if (!therock)
+    return;
+
+  std::string dist(therock);
+  std::string lib_dir = dist + "/lib";
+  library_paths.push_back(lib_dir);
+  COMPILER_DEBUG_LOG("THEROCK_DIST detected: " << dist << "\n");
+  COMPILER_DEBUG_LOG("  Adding library path: " << lib_dir << "\n");
+
+  libraries.push_back("amdhip64");
+  libraries.push_back("MIOpen");
+
+  // hipblaslt ships as either .lib (Windows) or .dll.a (cross-compiled)
+  std::string hipblaslt_lib = lib_dir + "/hipblaslt.lib";
+  std::string hipblaslt_dll_a = lib_dir + "/libhipblaslt.dll.a";
+  if (llvm::sys::fs::exists(hipblaslt_lib))
+    libraries.push_back("hipblaslt");
+  else if (llvm::sys::fs::exists(hipblaslt_dll_a))
+    libraries.push_back(hipblaslt_dll_a);
+  else
+    COMPILER_DEBUG_LOG("  WARNING: hipblaslt import library not found\n");
+
+#ifdef HIP_CUSTOM_KERNELS_LIB_PATH
+  {
+    std::string custom_lib = HIP_CUSTOM_KERNELS_LIB_PATH;
+    if (llvm::sys::fs::exists(custom_lib)) {
+      libraries.push_back(custom_lib);
+      COMPILER_DEBUG_LOG("  Custom kernels: " << custom_lib << "\n");
+    } else {
+      COMPILER_DEBUG_LOG("  WARNING: custom kernels lib not found at: "
+                         << custom_lib << "\n");
+    }
+  }
+#endif
+
+  for (const auto &lib : libraries) {
+    COMPILER_DEBUG_LOG("  Linking library: " << lib << "\n");
+  }
+}
+
+void CompilerDriver::cleanupIntermediates(const std::string &basePath) {
+  std::string ll_path = basePath + ".ll";
+  std::string obj_path = basePath + ".obj";
+
+  if (fileExists(ll_path)) {
+    llvm::sys::fs::remove(ll_path);
+  }
+
+  if (fileExists(obj_path)) {
+    llvm::sys::fs::remove(obj_path);
+  }
+}
+
+} // namespace hip::compiler

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -20,8 +20,4 @@ target_link_libraries(HipConversion PUBLIC
   MLIRPass
 )
 
-target_include_directories(HipConversion PUBLIC
-  ${CMAKE_SOURCE_DIR}/include
-)
-
 set_target_properties(HipConversion PROPERTIES FOLDER "mlir/Conversion")

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -3,5 +3,25 @@
 # ** Licensed under the MIT License.
 ##
 
-add_subdirectory(HipToLLVM)
+message(STATUS "Building Conversion Libraries")
+
 add_subdirectory(OnnxToHip)
+add_subdirectory(HipToLLVM)
+
+# Umbrella conversion library
+add_library(HipConversion STATIC
+  Passes.cpp
+)
+
+target_link_libraries(HipConversion PUBLIC
+  OnnxToHip
+  HipToLLVM
+  MLIRIR
+  MLIRPass
+)
+
+target_include_directories(HipConversion PUBLIC
+  ${CMAKE_SOURCE_DIR}/include
+)
+
+set_target_properties(HipConversion PROPERTIES FOLDER "mlir/Conversion")

--- a/lib/Conversion/Passes.cpp
+++ b/lib/Conversion/Passes.cpp
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "hip/Conversion/Passes.h"
+#include "mlir/Pass/Pass.h"
+
+namespace hip::compiler {
+
+void registerConversionPasses() {
+  mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
+    return mlir::hip::createConvertOnnxToHipPass();
+  });
+
+  mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
+    return mlir::hip::createConvertHipToLLVMPass();
+  });
+}
+
+} // namespace hip::compiler

--- a/lib/Target/LLVM/CMakeLists.txt
+++ b/lib/Target/LLVM/CMakeLists.txt
@@ -113,10 +113,5 @@ target_link_libraries(HipTargetLLVM PUBLIC
   $<$<BOOL:${LLVM_DTLTO_LIB}>:${LLVM_DTLTO_LIB}>
 )
 
-# Add include directories
-target_include_directories(HipTargetLLVM PUBLIC
-  ${CMAKE_SOURCE_DIR}/include
-)
-
 # Set folder for IDE organization
 set_target_properties(HipTargetLLVM PROPERTIES FOLDER "mlir/Target")

--- a/lib/Target/LLVM/CMakeLists.txt
+++ b/lib/Target/LLVM/CMakeLists.txt
@@ -1,0 +1,122 @@
+##
+# ** Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# ** Licensed under the MIT License.
+##
+
+message(STATUS "Building Target LLVM Library")
+
+# ============================================================================
+# Runtime bitcode stub
+# ============================================================================
+# When RuntimeBitcode is not available (no Clang / no HIP runtime build),
+# generate a stub runtime_ir_data.cpp with empty data.  LLVMBackend handles
+# this gracefully (bcSize == 0 → skip linking).
+if(NOT TARGET RuntimeBitcode)
+    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/runtime_ir_data.cpp
+        "extern \"C\" const unsigned char runtime_bc_data[] = {0};\n"
+        "extern \"C\" const size_t runtime_bc_data_size = 0;\n"
+    )
+    set(RUNTIME_IR_DATA_SRC ${CMAKE_CURRENT_BINARY_DIR}/runtime_ir_data.cpp)
+else()
+    # Python 3 required for xxd.py (converts bitcode to C array)
+    find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
+    if(NOT RUNTIME_BC_PATH)
+        set(RUNTIME_BC_PATH ${CMAKE_CURRENT_BINARY_DIR}/../../Runtime/runtime.bc)
+    endif()
+
+    add_custom_command(
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/runtime_ir_data.cpp
+        COMMAND ${Python3_EXECUTABLE}
+                ${CMAKE_SOURCE_DIR}/cmake/xxd.py
+                --var runtime_bc_data
+                --output ${CMAKE_CURRENT_BINARY_DIR}/runtime_ir_data.cpp.tmp
+                ${RUNTIME_BC_PATH}
+        COMMAND ${Python3_EXECUTABLE} -c
+                "import os; data = open('${CMAKE_CURRENT_BINARY_DIR}/runtime_ir_data.cpp.tmp').read(); data = data.replace('static const unsigned char', 'extern \"C\" const unsigned char'); bc_size = os.path.getsize('${RUNTIME_BC_PATH}'); data += f'\\nextern \"C\" const size_t runtime_bc_data_size = {bc_size};\\n'; open('${CMAKE_CURRENT_BINARY_DIR}/runtime_ir_data.cpp', 'w').write(data)"
+        COMMAND ${CMAKE_COMMAND} -E remove ${CMAKE_CURRENT_BINARY_DIR}/runtime_ir_data.cpp.tmp
+        DEPENDS ${RUNTIME_BC_PATH}
+        COMMENT "Generating runtime_ir_data.cpp from runtime.bc"
+        VERBATIM
+    )
+    set(RUNTIME_IR_DATA_SRC ${CMAKE_CURRENT_BINARY_DIR}/runtime_ir_data.cpp)
+endif()
+
+# Create target LLVM library
+add_library(HipTargetLLVM STATIC
+  LLVMBackend.cpp
+  DLLLinker.cpp
+  ${RUNTIME_IR_DATA_SRC}
+)
+
+if(TARGET RuntimeBitcode)
+    add_dependencies(HipTargetLLVM RuntimeBitcode)
+endif()
+
+# Link LLVM components
+llvm_map_components_to_libnames(llvm_libs
+  # Core infrastructure
+  Support
+  Core
+  IRReader
+  BitWriter
+  Passes
+  Target
+
+  # Code generation (required by lldCOFF)
+  CodeGen
+  SelectionDAG
+  AsmPrinter
+  BinaryFormat
+  MC
+  MCParser
+  TargetParser
+
+  # X86 backend
+  X86CodeGen
+  X86AsmParser
+  X86Desc
+  X86Info
+
+  # Linker support
+  Linker
+
+  # LTO and option parsing (required by lldCOFF)
+  LTO
+  Option
+
+  # Windows-specific (required by lldCOFF on Windows)
+  WindowsDriver
+  WindowsManifest
+  LibDriver
+)
+
+# Find LLD libraries using full paths
+find_library(LLD_COFF_LIB NAMES lldCOFF PATHS ${LLVM_LIBRARY_DIRS} REQUIRED)
+find_library(LLD_ELF_LIB NAMES lldELF PATHS ${LLVM_LIBRARY_DIRS} REQUIRED)
+find_library(LLD_COMMON_LIB NAMES lldCommon PATHS ${LLVM_LIBRARY_DIRS} REQUIRED)
+
+# LLVMDTLTO was split from LLVMLTO in LLVM 22.1; link it when present.
+find_library(LLVM_DTLTO_LIB NAMES LLVMDTLTO PATHS ${LLVM_LIBRARY_DIRS})
+
+# Link against required libraries
+target_link_libraries(HipTargetLLVM PUBLIC
+  MLIRIR
+  MLIRSupport
+  MLIRTargetLLVMIRExport
+  MLIRLLVMToLLVMIRTranslation
+  MLIRBuiltinToLLVMIRTranslation
+  ${llvm_libs}
+  ${LLD_COFF_LIB}
+  ${LLD_ELF_LIB}
+  ${LLD_COMMON_LIB}
+  $<$<BOOL:${LLVM_DTLTO_LIB}>:${LLVM_DTLTO_LIB}>
+)
+
+# Add include directories
+target_include_directories(HipTargetLLVM PUBLIC
+  ${CMAKE_SOURCE_DIR}/include
+)
+
+# Set folder for IDE organization
+set_target_properties(HipTargetLLVM PROPERTIES FOLDER "mlir/Target")

--- a/lib/Target/LLVM/DLLLinker.cpp
+++ b/lib/Target/LLVM/DLLLinker.cpp
@@ -1,0 +1,335 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#include "hip/Target/LLVM/DLLLinker.h"
+
+#include <llvm/Support/CommandLine.h>
+#include <llvm/Support/FileSystem.h>
+#include <llvm/Support/MemoryBuffer.h>
+#include <llvm/Support/Path.h>
+#include <llvm/Support/raw_ostream.h>
+
+#include "hip/debug_log.h"
+
+#include <fstream>
+#include <sstream>
+
+// LLD linker driver - use lldMain for crash recovery
+#include "lld/Common/Driver.h"
+
+// Still need to declare the link functions for driver registration
+LLD_HAS_DRIVER(coff)
+LLD_HAS_DRIVER(elf)
+
+namespace hipdnn {
+
+DLLLinker::DLLLinker() = default;
+DLLLinker::~DLLLinker() = default;
+
+bool DLLLinker::linkDLL(const std::string &objectFile,
+                        const std::string &outputDLL,
+                        const std::vector<std::string> &libraries,
+                        const std::vector<std::string> &libraryPaths,
+                        const std::vector<std::string> &exportSymbols) {
+#ifdef _WIN32
+  return linkDLL_Windows(objectFile, outputDLL, libraries, libraryPaths,
+                         exportSymbols);
+#else
+  return linkDLL_Linux(objectFile, outputDLL, libraries, libraryPaths);
+#endif
+}
+
+bool DLLLinker::linkDLLInMemory(const std::vector<uint8_t> &objectBytes,
+                                std::vector<uint8_t> &outDLLBytes,
+                                const std::vector<std::string> &libraries,
+                                const std::vector<std::string> &libraryPaths,
+                                const std::vector<std::string> &exportSymbols) {
+  // LLD does not provide a pure in-memory linking API
+  // Strategy: Use temporary files for linking, then read result into memory
+  // This approach works for MVP; can be improved with MemoryModule later
+
+  // Create unique temporary files atomically (avoids TOCTOU race of tmpnam)
+  llvm::SmallString<128> objFile, dllFile;
+  if (auto EC =
+          llvm::sys::fs::createTemporaryFile("hip-link", "obj", objFile)) {
+    llvm::errs() << "Failed to create temporary object file: " << EC.message()
+                 << "\n";
+    return false;
+  }
+  if (auto EC =
+          llvm::sys::fs::createTemporaryFile("hip-link", "dll", dllFile)) {
+    llvm::sys::fs::remove(objFile);
+    llvm::errs() << "Failed to create temporary DLL file: " << EC.message()
+                 << "\n";
+    return false;
+  }
+
+  // Write object bytes to temporary file
+  {
+    std::error_code EC;
+    llvm::raw_fd_ostream objOut(objFile, EC, llvm::sys::fs::OF_None);
+    if (EC) {
+      llvm::errs() << "Failed to open temporary object file: " << EC.message()
+                   << "\n";
+      llvm::sys::fs::remove(objFile);
+      llvm::sys::fs::remove(dllFile);
+      return false;
+    }
+    objOut.write(reinterpret_cast<const char *>(objectBytes.data()),
+                 objectBytes.size());
+  }
+
+  // Link using existing file-based API
+  std::string objStr(objFile), dllStr(dllFile);
+  bool linkSuccess =
+      linkDLL(objStr, dllStr, libraries, libraryPaths, exportSymbols);
+
+  if (!linkSuccess) {
+    llvm::sys::fs::remove(objFile);
+    llvm::sys::fs::remove(dllFile);
+    return false;
+  }
+
+  // Read DLL into memory
+  {
+    auto bufOrErr = llvm::MemoryBuffer::getFile(dllFile);
+    if (!bufOrErr) {
+      llvm::errs() << "Failed to read temporary DLL file: "
+                   << bufOrErr.getError().message() << "\n";
+      llvm::sys::fs::remove(objFile);
+      llvm::sys::fs::remove(dllFile);
+      return false;
+    }
+    auto &buf = *bufOrErr;
+    const auto *data = reinterpret_cast<const uint8_t *>(buf->getBufferStart());
+    outDLLBytes.assign(data, data + buf->getBufferSize());
+  }
+
+  // Cleanup temporary files
+  llvm::sys::fs::remove(objFile);
+  llvm::sys::fs::remove(dllFile);
+
+  COMPILER_DEBUG_LOG("Linked DLL in memory: " << outDLLBytes.size()
+                                              << " bytes\n");
+  return true;
+}
+
+#ifdef _WIN32
+
+bool DLLLinker::createModuleDefinitionFile(
+    const std::string &defPath, const std::vector<std::string> &exportSymbols) {
+  std::ofstream defFile(defPath);
+  if (!defFile) {
+    llvm::errs() << "Failed to create .def file: " << defPath << "\n";
+    return false;
+  }
+
+  defFile << "EXPORTS\n";
+  for (const auto &symbol : exportSymbols) {
+    defFile << "    " << symbol << "\n";
+  }
+
+  defFile.close();
+  return true;
+}
+
+bool DLLLinker::linkDLL_Windows(const std::string &objectFile,
+                                const std::string &outputDLL,
+                                const std::vector<std::string> &libraries,
+                                const std::vector<std::string> &libraryPaths,
+                                const std::vector<std::string> &exportSymbols) {
+  // Create temporary .def file for exports
+  std::string defFile = objectFile + ".def";
+  if (!createModuleDefinitionFile(defFile, exportSymbols)) {
+    return false;
+  }
+
+  // Build LLD-LINK command line arguments
+  // Note: lldMain() requires argv[0] to be the program name
+  std::vector<std::string> argStrings;
+  argStrings.push_back("lld-link"); // argv[0] - program name
+  argStrings.push_back("/DLL");     // Create DLL
+  argStrings.push_back("/OUT:" + outputDLL);
+  argStrings.push_back("/DEF:" + defFile);
+  argStrings.push_back(objectFile);
+
+  // Add library paths
+  for (const auto &libPath : libraryPaths) {
+    argStrings.push_back("/LIBPATH:" + libPath);
+  }
+
+  // Add libraries
+  for (const auto &lib : libraries) {
+    if (lib.find('/') != std::string::npos ||
+        lib.find('\\') != std::string::npos) {
+      argStrings.push_back(lib); // full path — pass as-is
+    } else if (lib.size() >= 4 && lib.substr(lib.size() - 4) == ".lib") {
+      argStrings.push_back(lib);
+    } else {
+      argStrings.push_back(lib + ".lib");
+    }
+  }
+
+  // MSVC C Runtime import libraries required for any DLL that uses the
+  // C/C++ standard library (heap, stdio, exceptions). The debug variants
+  // ("d" suffix) match the /MDd flag so the DLL shares CRT state with the
+  // host process. kernel32/user32 provide Win32 API basics.
+  for (const char *sysLib : {"msvcrtd.lib", "ucrtd.lib", "vcruntimed.lib",
+                             "oldnames.lib", "kernel32.lib", "user32.lib"})
+    argStrings.push_back(sysLib);
+
+  // Add default libraries and flags
+  argStrings.push_back("/NOLOGO");
+  argStrings.push_back("/MACHINE:X64");
+
+  // Add debug flags to prevent optimization and get clear backtraces
+  argStrings.push_back("/DEBUG");     // Generate debug info (.pdb)
+  argStrings.push_back("/OPT:NOREF"); // Don't remove unreferenced code
+  argStrings.push_back("/OPT:NOICF"); // Don't fold identical functions
+
+  // Convert to C-style args for LLD
+  std::vector<const char *> args;
+  for (const auto &arg : argStrings) {
+    args.push_back(arg.c_str());
+  }
+
+  COMPILER_DEBUG_LOG("LLD-LINK command (" << args.size() << " args):\n");
+  for (size_t i = 0; i < args.size(); ++i) {
+    COMPILER_DEBUG_LOG("  [" << i << "]='" << args[i] << "'\n");
+  }
+
+  // Call LLD linker library
+  std::string stdoutStr, stderrStr;
+  llvm::raw_string_ostream stdoutOS(stdoutStr);
+  llvm::raw_string_ostream stderrOS(stderrStr);
+
+  llvm::ArrayRef<const char *> argsRef(args);
+
+  // Use lldMain for crash recovery instead of direct link() call
+  // lldMain provides:
+  // - CrashRecoveryContext for handling fatal() calls
+  // - Proper cleanup via CommonLinkerContext::destroy()
+  // - Safe for re-entry
+  lld::Result result =
+      lld::lldMain(argsRef, stdoutOS, stderrOS,
+                   {{lld::WinLink, &lld::coff::link}} // Register COFF driver
+      );
+
+  if (!stdoutStr.empty()) {
+    COMPILER_DEBUG_LOG(stdoutStr);
+  }
+  if (!stderrStr.empty()) {
+    llvm::errs() << stderrStr;
+  }
+
+  if (result.retCode != 0) {
+    llvm::errs() << "LLD-LINK failed with exit code: " << result.retCode
+                 << "\n";
+    if (!result.canRunAgain) {
+      llvm::errs() << "  Warning: Linker crashed, cannot run again\n";
+    }
+    return false;
+  }
+
+  COMPILER_DEBUG_LOG("Successfully linked DLL: " << outputDLL << "\n");
+
+  llvm::sys::fs::remove(defFile);
+
+  return true;
+}
+
+#else // Linux
+
+bool DLLLinker::linkDLL_Linux(const std::string &objectFile,
+                              const std::string &outputDLL,
+                              const std::vector<std::string> &libraries,
+                              const std::vector<std::string> &libraryPaths) {
+  // Build LLD-ELF command line arguments for shared library
+  std::vector<std::string> argStrings;
+  argStrings.push_back("ld.lld");  // Program name (required by LLD)
+  argStrings.push_back("-shared"); // Create shared library
+  argStrings.push_back("-o");
+  argStrings.push_back(outputDLL);
+  argStrings.push_back(objectFile);
+
+  // Add library paths
+  for (const auto &libPath : libraryPaths) {
+    argStrings.push_back("-L" + libPath);
+  }
+
+  // Add libraries
+  for (const auto &lib : libraries) {
+    argStrings.push_back("-l" + lib);
+  }
+
+  // Add RPATH for runtime library search
+  for (const auto &libPath : libraryPaths) {
+    argStrings.push_back("-rpath");
+    argStrings.push_back(libPath);
+  }
+
+  // Add default flags
+  argStrings.push_back("--export-dynamic"); // Export all symbols by default
+  argStrings.push_back("--no-undefined");   // Error on undefined symbols
+
+  // Convert to C-style args for LLD
+  std::vector<const char *> args;
+  for (const auto &arg : argStrings) {
+    args.push_back(arg.c_str());
+  }
+
+  // Call LLD linker library
+  std::string stdoutStr, stderrStr;
+  llvm::raw_string_ostream stdoutOS(stdoutStr);
+  llvm::raw_string_ostream stderrOS(stderrStr);
+
+  // Use lldMain for crash recovery instead of direct link() call
+  lld::Result result =
+      lld::lldMain(args, stdoutOS, stderrOS, {{lld::Gnu, &lld::elf::link}}
+                   // Register ELF driver
+      );
+
+  if (!stdoutStr.empty()) {
+    COMPILER_DEBUG_LOG(stdoutStr);
+  }
+  if (!stderrStr.empty()) {
+    llvm::errs() << stderrStr;
+  }
+
+  if (result.retCode != 0) {
+    llvm::errs() << "LLD-ELF failed with exit code: " << result.retCode << "\n";
+    if (!result.canRunAgain) {
+      llvm::errs() << "  Warning: Linker crashed, cannot run again\n";
+    }
+    return false;
+  }
+
+  COMPILER_DEBUG_LOG("Successfully linked shared library: " << outputDLL
+                                                            << "\n");
+  return true;
+}
+
+#endif
+
+bool DLLLinker::verifyDLLExports(
+    const std::string &dllPath,
+    const std::vector<std::string> &requiredSymbols) {
+  // This is a simplified implementation
+  // A complete implementation would use LLVM's object file libraries
+  // to parse the DLL/SO and verify exported symbols
+
+  COMPILER_DEBUG_LOG("Verifying DLL exports for: " << dllPath << "\n");
+  for (const auto &symbol : requiredSymbols) {
+    COMPILER_DEBUG_LOG("  Required symbol: " << symbol << "\n");
+  }
+
+  if (!llvm::sys::fs::exists(dllPath)) {
+    llvm::errs() << "DLL file does not exist: " << dllPath << "\n";
+    return false;
+  }
+
+  return true;
+}
+
+} // namespace hipdnn

--- a/lib/Target/LLVM/LLVMBackend.cpp
+++ b/lib/Target/LLVM/LLVMBackend.cpp
@@ -1,0 +1,331 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#include "hip/Target/LLVM/LLVMBackend.h"
+
+#include <mlir/Target/LLVMIR/Dialect/Builtin/BuiltinToLLVMIRTranslation.h>
+#include <mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h>
+#include <mlir/Target/LLVMIR/Export.h>
+
+#include <llvm/Bitcode/BitcodeReader.h>
+#include <llvm/IR/LegacyPassManager.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IR/Verifier.h>
+#include <llvm/Linker/Linker.h>
+#include <llvm/MC/TargetRegistry.h>
+#include <llvm/Passes/PassBuilder.h>
+#include <llvm/Support/FileSystem.h>
+#include <llvm/Support/MemoryBuffer.h>
+#include <llvm/Support/TargetSelect.h>
+
+#include <llvm/Support/raw_ostream.h>
+#include <llvm/Target/TargetMachine.h>
+#include <llvm/Target/TargetOptions.h>
+#include <llvm/TargetParser/Host.h>
+
+#include "hip/debug_log.h"
+
+#include <system_error>
+
+namespace hipdnn {
+
+LLVMBackend::LLVMBackend() : target_initialized_(false) {
+  // Target initialization is deferred to first use
+}
+
+LLVMBackend::~LLVMBackend() = default;
+
+void LLVMBackend::initializeTarget() {
+  if (target_initialized_) {
+    return;
+  }
+
+  // Initialize native target for object file emission
+  llvm::InitializeNativeTarget();
+  llvm::InitializeNativeTargetAsmPrinter();
+  llvm::InitializeNativeTargetAsmParser();
+
+  target_initialized_ = true;
+}
+
+std::unique_ptr<llvm::Module>
+LLVMBackend::translateMLIRtoLLVMIR(mlir::ModuleOp mlirModule,
+                                   llvm::LLVMContext &llvmContext) {
+  // Register LLVM IR translation dialects
+  mlir::registerBuiltinDialectTranslation(*mlirModule->getContext());
+  mlir::registerLLVMDialectTranslation(*mlirModule->getContext());
+
+  // Translate MLIR to LLVM IR using C++ library API
+  auto llvmModule = mlir::translateModuleToLLVMIR(mlirModule, llvmContext);
+  if (!llvmModule) {
+    llvm::errs() << "Failed to translate MLIR to LLVM IR\n";
+    return nullptr;
+  }
+
+  // Verify the generated LLVM IR
+  std::string error_msg;
+  llvm::raw_string_ostream error_stream(error_msg);
+  if (llvm::verifyModule(*llvmModule, &error_stream)) {
+    llvm::errs() << "LLVM IR verification failed:\n" << error_msg << "\n";
+    return nullptr;
+  }
+
+  return llvmModule;
+}
+
+void LLVMBackend::optimizeLLVMIR(llvm::Module *module, int optLevel) {
+  if (!module || optLevel < 0 || optLevel > 3) {
+    llvm::errs() << "Invalid arguments to optimizeLLVMIR\n";
+    return;
+  }
+
+  if (optLevel == 0) {
+    // No optimization
+    return;
+  }
+
+  // Create pass builder with optimization level
+  llvm::PassBuilder PB;
+
+  // Create analysis managers
+  llvm::LoopAnalysisManager LAM;
+  llvm::FunctionAnalysisManager FAM;
+  llvm::CGSCCAnalysisManager CGAM;
+  llvm::ModuleAnalysisManager MAM;
+
+  // Register all the basic analyses with the managers
+  PB.registerModuleAnalyses(MAM);
+  PB.registerCGSCCAnalyses(CGAM);
+  PB.registerFunctionAnalyses(FAM);
+  PB.registerLoopAnalyses(LAM);
+  PB.crossRegisterProxies(LAM, FAM, CGAM, MAM);
+
+  // Create optimization pipeline based on level
+  llvm::ModulePassManager MPM;
+  if (optLevel == 1) {
+    MPM = PB.buildPerModuleDefaultPipeline(llvm::OptimizationLevel::O1);
+  } else if (optLevel == 2) {
+    MPM = PB.buildPerModuleDefaultPipeline(llvm::OptimizationLevel::O2);
+  } else if (optLevel == 3) {
+    MPM = PB.buildPerModuleDefaultPipeline(llvm::OptimizationLevel::O3);
+  }
+
+  // Run optimization passes
+  MPM.run(*module, MAM);
+}
+
+bool LLVMBackend::emitLLVMIR(llvm::Module *module,
+                             const std::string &outputPath) {
+  if (!module) {
+    llvm::errs() << "Null module in emitLLVMIR\n";
+    return false;
+  }
+
+  // Open output file
+  std::error_code EC;
+  llvm::raw_fd_ostream out(outputPath, EC, llvm::sys::fs::OF_None);
+  if (EC) {
+    llvm::errs() << "Failed to open output file: " << EC.message() << "\n";
+    return false;
+  }
+
+  // Print LLVM IR in human-readable text format
+  module->print(out, nullptr);
+
+  COMPILER_DEBUG_LOG("Emitted LLVM IR to: " << outputPath << "\n");
+  return true;
+}
+
+bool LLVMBackend::emitLLVMIRToString(llvm::Module *module, std::string &outIR) {
+  if (!module) {
+    llvm::errs() << "Null module in emitLLVMIRToString\n";
+    return false;
+  }
+
+  // Use raw_string_ostream to write LLVM IR to string
+  llvm::raw_string_ostream stringStream(outIR);
+  module->print(stringStream, nullptr);
+  stringStream.flush();
+
+  return true;
+}
+
+llvm::TargetMachine *LLVMBackend::createTargetMachine() {
+  initializeTarget();
+
+  // Get target triple for current platform
+  llvm::Triple target_triple(llvm::sys::getDefaultTargetTriple());
+
+  // Look up target
+  std::string error_msg;
+  const llvm::Target *target =
+      llvm::TargetRegistry::lookupTarget(target_triple.str(), error_msg);
+  if (!target) {
+    llvm::errs() << "Failed to lookup target: " << error_msg << "\n";
+    return nullptr;
+  }
+
+  // Configure target machine
+  std::string cpu = "generic";
+  std::string features = "";
+  llvm::TargetOptions options;
+  llvm::Reloc::Model RM =
+      llvm::Reloc::PIC_; // Position-independent code for DLL
+
+  llvm::TargetMachine *TM =
+      target->createTargetMachine(target_triple, cpu, features, options, RM);
+
+  if (!TM) {
+    llvm::errs() << "Failed to create target machine\n";
+    return nullptr;
+  }
+
+  return TM;
+}
+
+bool LLVMBackend::compileToObjectFile(llvm::Module *module,
+                                      const std::string &outputPath) {
+  if (!module) {
+    llvm::errs() << "Null module in compileToObjectFile\n";
+    return false;
+  }
+
+  // Create target machine
+  std::unique_ptr<llvm::TargetMachine> TM(createTargetMachine());
+  if (!TM) {
+    return false;
+  }
+
+  // Set module data layout and target triple
+  module->setDataLayout(TM->createDataLayout());
+  module->setTargetTriple(TM->getTargetTriple());
+
+  // Open output file
+  std::error_code EC;
+  llvm::raw_fd_ostream out(outputPath, EC, llvm::sys::fs::OF_None);
+  if (EC) {
+    llvm::errs() << "Failed to open output file: " << EC.message() << "\n";
+    return false;
+  }
+
+  // Create legacy pass manager for code generation
+  llvm::legacy::PassManager pass;
+
+  // Add pass to emit object file
+  if (TM->addPassesToEmitFile(pass, out, nullptr,
+                              llvm::CodeGenFileType::ObjectFile)) {
+    llvm::errs() << "TargetMachine can't emit object file\n";
+    return false;
+  }
+
+  // Run code generation passes
+  pass.run(*module);
+  out.flush();
+
+  COMPILER_DEBUG_LOG("Compiled object file to: " << outputPath << "\n");
+  return true;
+}
+
+bool LLVMBackend::compileToObjectInMemory(llvm::Module *module,
+                                          std::vector<uint8_t> &outBytes) {
+  if (!module) {
+    llvm::errs() << "Null module in compileToObjectInMemory\n";
+    return false;
+  }
+
+  // Create target machine
+  std::unique_ptr<llvm::TargetMachine> TM(createTargetMachine());
+  if (!TM) {
+    return false;
+  }
+
+  // Set module data layout and target triple
+  module->setDataLayout(TM->createDataLayout());
+  module->setTargetTriple(TM->getTargetTriple());
+
+  // Use SmallVector with raw_svector_ostream for in-memory compilation
+  llvm::SmallVector<char, 0> objBuffer;
+  llvm::raw_svector_ostream objStream(objBuffer);
+
+  // Create legacy pass manager for code generation
+  llvm::legacy::PassManager pass;
+
+  // Add pass to emit object file to memory stream
+  if (TM->addPassesToEmitFile(pass, objStream, nullptr,
+                              llvm::CodeGenFileType::ObjectFile)) {
+    llvm::errs() << "TargetMachine can't emit object file\n";
+    return false;
+  }
+
+  // Run code generation passes
+  pass.run(*module);
+  // Note: raw_svector_ostream auto-flushes, flush() is deleted in newer LLVM
+
+  // Copy result to output vector
+  outBytes.assign(objBuffer.begin(), objBuffer.end());
+
+  COMPILER_DEBUG_LOG("Compiled object to memory: " << outBytes.size()
+                                                   << " bytes\n");
+  return true;
+}
+
+// Extern declarations for embedded Runtime bitcode
+// Generated by CMake: runtime.bc → xxd.py → runtime_ir_data.cpp
+extern "C" const unsigned char runtime_bc_data[];
+extern "C" const size_t runtime_bc_data_size;
+
+bool LLVMBackend::linkRuntimeModule(llvm::Module *destModule) {
+  if (!destModule) {
+    llvm::errs() << "Error: Null destination module\n";
+    return false;
+  }
+
+  // Use pre-calculated bitcode size
+  size_t bcSize = runtime_bc_data_size;
+
+  if (bcSize == 0) {
+    // Empty bitcode - this means Clang wasn't available during build
+    // Runtime IR merging is disabled, skip linking
+    COMPILER_DEBUG_LOG(
+        "Warning: Runtime bitcode is empty (Clang not available during "
+        "build).\n"
+        "         Runtime IR merging disabled - accessor functions will have "
+        "call overhead.\n"
+        "         To enable zero-cost abstraction, rebuild with Clang "
+        "installed.\n");
+    return true; // Not an error, just a degraded mode
+  }
+
+  // Create memory buffer from embedded bitcode
+  auto MemBuf = llvm::MemoryBuffer::getMemBuffer(
+      llvm::StringRef(reinterpret_cast<const char *>(runtime_bc_data), bcSize),
+      "runtime.bc",
+      /*RequiresNullTerminator=*/false);
+
+  // Parse bitcode into LLVM Module
+  llvm::Expected<std::unique_ptr<llvm::Module>> ModuleOrErr =
+      llvm::parseBitcodeFile(MemBuf->getMemBufferRef(),
+                             destModule->getContext());
+
+  if (!ModuleOrErr) {
+    llvm::errs() << "Error: Failed to parse Runtime bitcode: "
+                 << llvm::toString(ModuleOrErr.takeError()) << "\n";
+    return false;
+  }
+
+  std::unique_ptr<llvm::Module> RuntimeModule = std::move(*ModuleOrErr);
+
+  // Link Runtime module into destination module
+  // Linker::linkInModule() merges RuntimeModule into destModule
+  // After this call, destModule contains both generated + Runtime IR
+  llvm::Linker linker(*destModule);
+  if (linker.linkInModule(std::move(RuntimeModule))) {
+    llvm::errs() << "Error: Failed to link Runtime module into destination\n";
+    return false;
+  }
+
+  return true;
+}
+
+} // namespace hipdnn

--- a/tools/hip-compiler/CMakeLists.txt
+++ b/tools/hip-compiler/CMakeLists.txt
@@ -13,48 +13,6 @@ add_dependencies(hip-compiler
 )
 
 target_link_libraries(hip-compiler PRIVATE
-  HipDialectIR
-  HipDialectTransforms
-  HipToLLVM
-  HipSchemasLib
-  MLIROptLib
-  MLIRSupport
-  MLIRIR
-  MLIRParser
-  MLIRPass
-  MLIRTransforms
-  MLIRAnalysis
-  MLIRArithDialect
-  MLIRControlFlowDialect
-  MLIRFuncDialect
-  MLIRMemRefDialect
-  MLIRSCFDialect
-  MLIRTensorDialect
-  MLIRDestinationStyleOpInterface
-  MLIRBufferizationDialect
-  MLIRBufferizationTransforms
-  MLIRArithTransforms
-  MLIRSCFTransforms
-  MLIRTensorTransforms
-  MLIRFuncTransforms
-  MLIRLLVMDialect
-  MLIRLLVMCommonConversion
-  MLIRArithToLLVM
-  MLIRMemRefToLLVM
-  MLIRFuncToLLVM
-  MLIRSCFToControlFlow
-  MLIRControlFlowToLLVM
-  MLIRReconcileUnrealizedCasts
-  MLIRTransformUtils
-  MLIRTargetLLVMIRExport
-  MLIRExecutionEngine
-  MLIRTranslateLib
-  LLVMX86CodeGen
-  LLVMX86AsmParser
-  LLVMMC
+  LibHipCompiler
   LLVMSupport
-  LLVMTarget
-  LLVMIRReader
-  LLVMLinker
-  ${llvm_libs}
 )

--- a/tools/hip-compiler/hip-compiler.cpp
+++ b/tools/hip-compiler/hip-compiler.cpp
@@ -2,42 +2,9 @@
  * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Licensed under the MIT License.
  */
-#include "mlir/Conversion/Passes.h"
-#include "mlir/Dialect/Arith/IR/Arith.h"
-#include "mlir/Dialect/ControlFlow/IR/ControlFlow.h"
-#include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
-#include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/IR/BuiltinDialect.h"
-#include "mlir/IR/BuiltinOps.h"
-#include "mlir/IR/MLIRContext.h"
-#include "mlir/Parser/Parser.h"
-#include "mlir/Pass/PassManager.h"
-#include "mlir/Support/FileUtilities.h"
-#include "mlir/Target/LLVMIR/Dialect/Builtin/BuiltinToLLVMIRTranslation.h"
-#include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
-#include "mlir/Target/LLVMIR/Export.h"
+#include "hip/Compiler/CompilerDriver.h"
 
-#include "llvm/IR/LegacyPassManager.h"
-#include "llvm/IR/Module.h"
-#include "llvm/MC/TargetRegistry.h"
-#include "llvm/Support/FileSystem.h"
-#include "llvm/Support/Path.h"
-#include "llvm/Support/Program.h"
-#include "llvm/Support/SourceMgr.h"
-#include "llvm/Support/TargetSelect.h"
-#include "llvm/Support/ToolOutputFile.h"
-#include "llvm/Target/TargetMachine.h"
-#include "llvm/Target/TargetOptions.h"
-#include "llvm/TargetParser/Host.h"
-#include "llvm/TargetParser/Triple.h"
-
-#include "hip/Dialect/IR/HipBufferize.h"
-#include "hip/Dialect/IR/HipDialect.h"
-#include "hip/Dialect/Transforms/Passes.h"
-#include "hip/Dialect/Transforms/Pipelines.h"
-
-#include "llvm/Support/Process.h"
+#include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/raw_ostream.h"
 
 int main(int argc, char **argv) {
@@ -52,169 +19,27 @@ int main(int argc, char **argv) {
   }
 
   if (inputFilename.empty() || outputDll.empty()) {
-    llvm::errs() << "Usage: " << argv[0]
-                 << " <input.hip.mlir> -o <output.dll>\n";
+    llvm::errs() << "Usage: " << argv[0] << " <input.mlir> -o <output.dll>\n";
     return 1;
   }
 
-  // 1. Setup MLIR context and parse input
-  mlir::DialectRegistry registry;
-  registry.insert<mlir::BuiltinDialect>();
-  registry.insert<mlir::arith::ArithDialect>();
-  registry.insert<mlir::cf::ControlFlowDialect>();
-  registry.insert<mlir::func::FuncDialect>();
-  registry.insert<mlir::memref::MemRefDialect>();
-  registry.insert<mlir::LLVM::LLVMDialect>();
-  registry.insert<mlir::hip::HipDialect>();
+  auto fileOrErr = llvm::MemoryBuffer::getFile(inputFilename);
+  if (!fileOrErr) {
+    llvm::errs() << "error: could not open " << inputFilename << ": "
+                 << fileOrErr.getError().message() << "\n";
+    return 1;
+  }
 
-  mlir::registerBuiltinDialectTranslation(registry);
-  mlir::registerLLVMDialectTranslation(registry);
-
-  mlir::MLIRContext context(registry);
-
+  mlir::hip::CompilationOptionsT options;
   std::string errorMessage;
-  auto file = mlir::openInputFile(inputFilename, &errorMessage);
-  if (!file) {
-    llvm::errs() << errorMessage << "\n";
+  hip::compiler::CompilerDriver driver;
+
+  if (!driver.compile((*fileOrErr)->getBuffer(), outputDll, options,
+                      errorMessage)) {
+    llvm::errs() << "error: " << errorMessage << "\n";
     return 1;
   }
 
-  llvm::SourceMgr sourceMgr;
-  sourceMgr.AddNewSourceBuffer(std::move(file), llvm::SMLoc());
-
-  mlir::OwningOpRef<mlir::ModuleOp> module =
-      mlir::parseSourceFile<mlir::ModuleOp>(sourceMgr, &context);
-  if (!module) {
-    llvm::errs() << "error: failed to parse MLIR file\n";
-    return 1;
-  }
-
-  // 2. Run MLIR PassManager (input must be pre-bufferized memref IR)
-  mlir::PassManager pm(&context);
-  mlir::hip::HipToLLVMPipelineOptions pipelineOpts;
-  mlir::hip::buildHipToLLVMPipeline(pm, pipelineOpts);
-
-  if (mlir::failed(pm.run(*module))) {
-    llvm::errs() << "error: MLIR pass pipeline failed\n";
-    return 1;
-  }
-
-  // 3. Translate MLIR to LLVM IR
-  llvm::LLVMContext llvmContext;
-  auto llvmModule = mlir::translateModuleToLLVMIR(module.get(), llvmContext);
-  if (!llvmModule) {
-    llvm::errs() << "error: failed to translate to LLVM IR\n";
-    return 1;
-  }
-
-  for (auto &func : *llvmModule) {
-    if (!func.isDeclaration()) {
-      func.setDLLStorageClass(llvm::GlobalValue::DLLExportStorageClass);
-    }
-  }
-
-  // 4. Code Generation to Object File
-  llvm::InitializeNativeTarget();
-  llvm::InitializeNativeTargetAsmPrinter();
-
-  std::string err;
-  auto targetTripleStr = llvm::sys::getDefaultTargetTriple();
-  llvm::Triple targetTriple(targetTripleStr);
-  auto target = llvm::TargetRegistry::lookupTarget(targetTripleStr, err);
-  if (!target) {
-    llvm::errs() << "error: looking up target: " << err << "\n";
-    return 1;
-  }
-
-  llvm::TargetOptions opt;
-  auto rm = std::optional<llvm::Reloc::Model>();
-  auto targetMachine =
-      target->createTargetMachine(targetTriple, "generic", "", opt, rm);
-
-  llvmModule->setDataLayout(targetMachine->createDataLayout());
-  llvmModule->setTargetTriple(targetTriple);
-
-  std::string objFilename = llvm::sys::path::stem(inputFilename).str() + ".obj";
-  std::error_code EC;
-  llvm::raw_fd_ostream dest(objFilename, EC, llvm::sys::fs::OF_None);
-  if (EC) {
-    llvm::errs() << "error: could not open file: " << EC.message() << "\n";
-    return 1;
-  }
-
-  llvm::legacy::PassManager pass;
-  auto fileType = llvm::CodeGenFileType::ObjectFile;
-  if (targetMachine->addPassesToEmitFile(pass, dest, nullptr, fileType)) {
-    llvm::errs() << "error: target machine can't emit a file of this type\n";
-    return 1;
-  }
-  pass.run(*llvmModule);
-  dest.flush();
-  dest.close();
-
-  llvm::outs() << "Generated temporary object: " << objFilename << "\n";
-
-  // 5. Link into DLL
-  auto linkerPath = llvm::sys::findProgramByName("lld-link");
-  if (!linkerPath) {
-    linkerPath = llvm::sys::findProgramByName("link.exe");
-    if (!linkerPath) {
-      llvm::errs() << "error: could not find lld-link or link.exe in PATH\n";
-      return 1;
-    }
-  }
-
-  std::string therockDist;
-  if (auto env = llvm::sys::Process::GetEnv("THEROCK_DIST"))
-    therockDist = *env;
-
-  std::string outArg = "/OUT:" + outputDll;
-  std::string dllArg = "/DLL";
-  std::string noLogoArg = "/NOLOGO";
-
-  llvm::SmallVector<llvm::StringRef, 16> linkArgs;
-  linkArgs.push_back(*linkerPath);
-  linkArgs.push_back(noLogoArg);
-  linkArgs.push_back(dllArg);
-  linkArgs.push_back(outArg);
-  linkArgs.push_back(objFilename);
-
-  std::string exePath =
-      llvm::sys::fs::getMainExecutable(argv[0], (void *)(intptr_t)main);
-  llvm::StringRef exeDir = llvm::sys::path::parent_path(exePath);
-
-  llvm::SmallString<128> runtimeLibPath(exeDir);
-  llvm::sys::path::append(runtimeLibPath, "hip_runtime_static.lib");
-  linkArgs.push_back(runtimeLibPath.str());
-
-  std::string cwdLibPath = "/LIBPATH:.";
-  linkArgs.push_back(cwdLibPath);
-
-  std::string exeDirLibPath = std::string("/LIBPATH:") + exeDir.str();
-  linkArgs.push_back(exeDirLibPath);
-
-  std::string libPathArg;
-  if (!therockDist.empty()) {
-    libPathArg = "/LIBPATH:" + therockDist + "\\lib";
-    linkArgs.push_back(libPathArg);
-  }
-
-  linkArgs.push_back("amdhip64.lib");
-  linkArgs.push_back("hipblaslt.lib");
-  linkArgs.push_back("MIOpen.lib");
-
-  std::string errMsg;
-  int result = llvm::sys::ExecuteAndWait(*linkerPath, linkArgs, std::nullopt,
-                                         {}, 0, 0, &errMsg);
-  if (result != 0) {
-    llvm::errs() << "error: linker failed with code " << result << "\n";
-    if (!errMsg.empty())
-      llvm::errs() << "  " << errMsg << "\n";
-    return 1;
-  }
-
-  llvm::outs() << "Successfully generated " << outputDll
-               << " and its import library\n";
-
+  llvm::outs() << "Successfully generated " << outputDll << "\n";
   return 0;
 }


### PR DESCRIPTION
## Summary

Port the Target/LLVM backend, Compiler driver, and C interface from the reference repository. Refactor `hip-compiler` CLI to use the new `CompilerDriver` instead of 200+ lines of inline logic.

## Files

### New
| File | Purpose |
|------|---------|
| `lib/Target/LLVM/LLVMBackend.h/.cpp` | MLIR → LLVM IR translation, optimization, object emission |
| `lib/Target/LLVM/DLLLinker.h/.cpp` | LLD-based linking (COFF/ELF) to produce DLL/SO |
| `lib/Compiler/CompilerDriver.h/.cpp` | End-to-end orchestration: parse → passes → LLVM IR → link |
| `lib/Compiler/Pipeline.h/.cpp` | MLIR pass pipeline construction |
| `lib/CInterface/CompilerAPI.cpp` | C-ABI wrapper delegating to `CompilerDriver` |
| `include/hip/compiler_api.h` | C entry points (`hip_compile_with_fs`, `hip_get_version`) |
| `include/hip/compiler_types.h` | C-compatible error codes and structs |
| `include/hip/InitAllPasses.h` | Centralized dialect loading and pass registration |
| `include/hip/Conversion/Passes.h` | Conversion pass declarations (HipToLLVM, OnnxToHip) |
| `lib/Conversion/Passes.cpp` | Pass registration |

### Modified
| File | Change |
|------|--------|
| `tools/hip-compiler/hip-compiler.cpp` | ~220 → ~47 lines, delegates to `CompilerDriver` |
