### PR TITLE
Fix MSVC C4244 build warnings in OnnxToHip

### DIFF
--- a/lib/Conversion/OnnxToHip/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHip/CMakeLists.txt
@@ -7,6 +7,12 @@ add_library(OnnxToHip STATIC
   OnnxToHip.cpp
 )
 
+# Disable C4244 warning (type conversion) on MSVC
+# These warnings come from LLVM JSON library usage with std::optional
+if(MSVC)
+  target_compile_options(OnnxToHip PRIVATE /wd4244)
+endif()
+
 add_dependencies(OnnxToHip
   HipDialectIncGen
   HipTypesIncGen


### PR DESCRIPTION
## Overview

This PR fixes MSVC C4244 (type conversion) warnings that appear when compiling the OnnxToHip conversion pass.

## Problem

When building with MSVC, the following warnings are generated:
```
warning C4244: 'initializing': conversion from 'int64_t' to 'double', possible loss of data
warning C4244: 'initializing': conversion from 'uint64_t' to 'double', possible loss of data
warning C4244: 'initializing': conversion from 'double' to '__int64', possible loss of data
```

These warnings originate from LLVM's JSON library (`llvm::json::Value::getAsInteger()` and `getAsNumber()`) when used with MSVC's `std::optional` implementation. The issue is in the template instantiation, not in our code.

## Solution

Suppress C4244 warnings specifically for the OnnxToHip compilation unit by adding:
```cmake
if(MSVC)
  target_compile_options(OnnxToHip PRIVATE /wd4244)
endif()
```

This is the appropriate solution because:
- The warnings are from third-party library code (LLVM + MSVC stdlib)
- The type conversions are handled correctly by LLVM
- We cannot fix the root cause in external code
- Suppressing at compilation unit level is standard practice for third-party warnings

## Testing

- Clean build completes without warnings
- No functional changes to the code
- Only affects MSVC builds (no impact on Clang/GCC)

## Files Changed

- `lib/Conversion/OnnxToHip/CMakeLists.txt`