### PR TITLE
update quick_start.md

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -148,7 +148,10 @@ cmake -S . -B ../build/$(basename $PWD) \
   -DTHEROCK_DIST="$THEROCK_DIST" \
   -DHIP_PLATFORM=amd \
   -DHIP_ARCHITECTURES=gfx1151 \
-  -DBUILD_EP=ON
+  -DBUILD_EP=ON \
+  -DBUILD_MOCK_RUNTIME=OFF \
+  -DBUILD_HIP_TOOLS=ON \
+  -DONNX_HIP_INCLUDE_LIT_TESTS=ON
 ```
 
 **Note**: Replace `gfx1151` with your GPU architecture. Detect using: `$THEROCK_DIST/lib/llvm/bin/amdgpu-arch.exe`

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -89,7 +89,7 @@ cd onnxruntime
 ./build.bat --config Release --build_shared_lib --parallel --compile_no_warning_as_error --skip_submodule_sync --build_dir ../build/onnxruntime --skip_tests --disable_memleak_checker --use_dml
 
 # Install to prebuilt-local (set prefix at install time, not during configuration)
-mkdir -p ../prebuilt-local 
+mkdir -p ../prebuilt-local
 PREBUILT_DIR=$(cd ../prebuilt-local && pwd)
 cmake --install ../build/onnxruntime/Release --prefix "$PREBUILT_DIR"
 ```

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -150,8 +150,7 @@ cmake -S . -B ../build/$(basename $PWD) \
   -DHIP_ARCHITECTURES=gfx1151 \
   -DBUILD_EP=ON \
   -DBUILD_MOCK_RUNTIME=OFF \
-  -DBUILD_HIP_TOOLS=ON \
-  -DONNX_HIP_INCLUDE_LIT_TESTS=ON
+  -DBUILD_HIP_TOOLS=ON
 ```
 
 **Note**: Replace `gfx1151` with your GPU architecture. Detect using: `$THEROCK_DIST/lib/llvm/bin/amdgpu-arch.exe`

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -19,9 +19,9 @@ FlatBuffers, and Protobuf binaries instead of compiling them from source.
 | **`gh` CLI** | Downloading pre-built binaries (`gh auth login` required) |
 | **`unzip`** | Extracting downloaded archives (available in Git Bash / MSYS2) |
 
-**IMPORTANT -- MSVC Environment Setup:**
+**<span style="color:red">IMPORTANT</span> -- MSVC Environment Setup:**
 
-> You **must** launch Git Bash from inside a "Developer Command Prompt for VS
+> You **must** launch Git Bash from inside a "**x64** Native Tools Command Prompt for VS
 > XXXX" (where XXXX is your VS version: 2019, 2022, 2026, etc.).
 > This is required so that `cl.exe`, `link.exe`, and the MSVC headers/libraries
 > are visible to the build system. All commands in this guide assume this
@@ -89,6 +89,7 @@ cd onnxruntime
 ./build.bat --config Release --build_shared_lib --parallel --compile_no_warning_as_error --skip_submodule_sync --build_dir ../build/onnxruntime --skip_tests --disable_memleak_checker --use_dml
 
 # Install to prebuilt-local (set prefix at install time, not during configuration)
+mkdir -p ../prebuilt-local 
 PREBUILT_DIR=$(cd ../prebuilt-local && pwd)
 cmake --install ../build/onnxruntime/Release --prefix "$PREBUILT_DIR"
 ```
@@ -105,6 +106,10 @@ ls $PREBUILT_DIR/lib/cmake/onnxruntime/
 Run from the project root (inside Git Bash / MSYS2):
 
 ```bash
+cd ..
+git clone https://github.com/ROCm/onnx-hipdnn-ep.git
+cd onnx-hipdnn-ep/
+git submodule update --init --recursive
 bash scripts/setup-prebuilt.sh
 ```
 
@@ -129,8 +134,6 @@ Run from the project root:
 ```bash
 PREBUILT_DIR=$(cd ../prebuilt-local && pwd)
 THEROCK_DIST=$(cd ../therock && pwd)
-
-git submodule update --init
 
 cmake -S . -B ../build/$(basename $PWD) \
   -G Ninja \
@@ -179,14 +182,13 @@ compare MorphiZen EP (AMD GPU via HIP) against DML EP.
 
 **Setup:**
 
-`onnxruntime_perf_test.exe` and `morphizen_config.json` are not installed by
-default. Copy them into `../prebuilt-local/bin` before running:
+`onnxruntime_perf_test.exe` are not installed by
+default. Copy it into `../prebuilt-local/bin` before running:
 
 ```bash
 cp ../build/onnxruntime/Release/Release/onnxruntime_perf_test.exe $PREBUILT_DIR/bin/
-cp etc/morphizen_config.json $PREBUILT_DIR/bin/
 
-export THEROCK_DIST=~/workspace/therock
+export THEROCK_DIST=$(cd ../therock && pwd)
 export PATH="$THEROCK_DIST/bin:$PATH"
 cd $PREBUILT_DIR/bin
 ```

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -21,11 +21,11 @@ FlatBuffers, and Protobuf binaries instead of compiling them from source.
 
 **<span style="color:red">IMPORTANT</span> -- MSVC Environment Setup:**
 
-> You **must** launch Git Bash from inside a "**x64** Native Tools Command Prompt for VS
-> XXXX" (where XXXX is your VS version: 2019, 2022, 2026, etc.).
-> This is required so that `cl.exe`, `link.exe`, and the MSVC headers/libraries
-> are visible to the build system. All commands in this guide assume this
-> environment.
+You **must** launch Git Bash from inside a "**x64** Native Tools Command Prompt for VS
+XXXX" (where XXXX is your VS version: 2019, 2022, 2026, etc.).
+This is required so that `cl.exe`, `link.exe`, and the MSVC headers/libraries
+are visible to the build system. All commands in this guide assume this
+environment.
 
 ```bash
 # Verify MSVC environment is inherited

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -286,22 +286,6 @@ set(RUNTIME_BC_PATH ${CMAKE_CURRENT_BINARY_DIR}/runtime.bc PARENT_SCOPE)
 
 add_custom_target(RuntimeBitcode DEPENDS HipRuntime)
 
-# ============================================================================
-# KEEP OLD hip_runtime_static for backward compatibility
-# ============================================================================
-
-if(NOT BUILD_MOCK_RUNTIME)
-  file(GLOB RUNTIME_SRCS "ops_runtime/*.cpp")
-  add_library(hip_runtime_static STATIC ${RUNTIME_SRCS})
-  set_target_properties(hip_runtime_static PROPERTIES
-    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}"
-  )
-  target_compile_definitions(hip_runtime_static PRIVATE __HIP_PLATFORM_AMD__ MIOPEN_BETA_API)
-  if(DEFINED ENV{THEROCK_DIST})
-    target_include_directories(hip_runtime_static PRIVATE $ENV{THEROCK_DIST}/include)
-  endif()
-endif()
-
 message(STATUS "Runtime library configuration:")
 message(STATUS "  Mode: ${BUILD_MOCK_RUNTIME}")
 message(STATUS "  Runtime bitcode will be at: ${CMAKE_CURRENT_BINARY_DIR}/runtime.bc")


### PR DESCRIPTION
## Motivation

The existing quick start guide contained several inaccuracies and missing steps that could cause confusion for new users during the build setup process, such as using the wrong MSVC command prompt, missing directory creation, and lacking explicit clone/submodule instructions.

## Technical Details

* Fix MSVC prompt reference: "Developer Command Prompt" → "x64 Native Tools Command Prompt"
* Add mkdir -p ../prebuilt-local to prevent errors when the directory doesn't exist
* Add explicit git clone and git submodule update --init --recursive steps in the setup section, and remove the misplaced git submodule update from the build section
* Simplify perf test setup by removing the unnecessary morphizen_config.json copy step
* Replace hardcoded THEROCK_DIST path with a dynamic $(cd ../therock && pwd) expression
* Minor formatting: highlight "IMPORTANT" in red for better visibility
