### PR TITLE
ci: add E2E integration tests to GPU test job

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -351,6 +351,10 @@ jobs:
           # MorphiZen EP config
           cp etc/morphizen_config.json staging/
 
+          # E2E integration test files (MLIR → DLL → execute on GPU)
+          mkdir -p staging/e2e
+          cp test/lit/e2e/*.mlir staging/e2e/
+
           # ---------------------------------------------------------------
           # Package MSVC/WinSDK release CRT import libraries for lld-link.
           # The MorphiZen JIT compiler links against the release CRT (/MD),
@@ -468,6 +472,37 @@ jobs:
               "%%M" > "..\results\%%~nxM.txt" 2>&1
             type "..\results\%%~nxM.txt"
             if errorlevel 1 set FAILED=1
+          )
+          exit /b %FAILED%
+
+      # -----------------------------------------------------------------------
+      # E2E integration tests: compile each .mlir → .dll, then execute on GPU.
+      # hip-test-dll --validate returns non-zero if NaN/Inf values are found.
+      # -----------------------------------------------------------------------
+      - name: Run E2E integration tests (GPU)
+        shell: cmd
+        run: |
+          set THEROCK_DIST=${{ runner.workspace }}\therock-dist
+          set PATH=${{ runner.workspace }}\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
+          set LIB=%CD%\gpu-test-package\lib;${{ runner.workspace }}\therock-dist\lib
+          set FAILED=0
+          cd gpu-test-package\bin
+          for %%M in (..\e2e\*.mlir) do (
+            echo === Compile %%~nxM ===
+            hip-compiler.exe "%%M" -o "%%~nM.dll"
+            if errorlevel 1 (
+              echo [FAIL] Compile %%~nxM
+              set FAILED=1
+            ) else (
+              echo === Execute %%~nM ===
+              hip-test-dll.exe "%%~nM.dll" --verbose --validate
+              if errorlevel 1 (
+                echo [FAIL] Execute %%~nM
+                set FAILED=1
+              ) else (
+                echo [PASS] %%~nM
+              )
+            )
           )
           exit /b %FAILED%
 

--- a/lib/Target/LLVM/DLLLinker.cpp
+++ b/lib/Target/LLVM/DLLLinker.cpp
@@ -150,7 +150,8 @@ bool DLLLinker::linkDLL_Windows(const std::string &objectFile,
   std::vector<std::string> argStrings;
   argStrings.push_back("lld-link"); // argv[0] - program name
   argStrings.push_back("/DLL");     // Create DLL
-  argStrings.push_back("/ignore:4099"); // Suppress missing PDB warnings (LNK4099)
+  argStrings.push_back(
+      "/ignore:4099"); // Suppress missing PDB warnings (LNK4099)
   argStrings.push_back("/OUT:" + outputDLL);
   argStrings.push_back("/DEF:" + defFile);
   argStrings.push_back(objectFile);

--- a/lib/Target/LLVM/DLLLinker.cpp
+++ b/lib/Target/LLVM/DLLLinker.cpp
@@ -150,6 +150,7 @@ bool DLLLinker::linkDLL_Windows(const std::string &objectFile,
   std::vector<std::string> argStrings;
   argStrings.push_back("lld-link"); // argv[0] - program name
   argStrings.push_back("/DLL");     // Create DLL
+  argStrings.push_back("/ignore:4099"); // Suppress missing PDB warnings (LNK4099)
   argStrings.push_back("/OUT:" + outputDLL);
   argStrings.push_back("/DEF:" + defFile);
   argStrings.push_back(objectFile);


### PR DESCRIPTION
## Summary
- Stage 16 MLIR E2E test files into the GPU test package artifact
- Add a new CI step that compiles each `.mlir` → `.dll` via `hip-compiler` and executes with `hip-test-dll --validate` on the GPU runner
- Catches regressions in the full MLIR → DLL → GPU execution pipeline that LIT tests (CPU-only FileCheck) cannot detect

## Test plan
- [ ] CI build-windows job stages `.mlir` files into `staging/e2e/`
- [ ] CI gpu-test job compiles and executes all E2E tests
- [ ] Any NaN/Inf in outputs causes step failure