### PR TITLE
SkipSimplifiedLayerNorm: full MS spec alignment + GatherOp axis default value

### DIFF
--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -445,46 +445,89 @@ def Hip_RmsNormOp : Hip_DpsOp<"rms_norm"> {
   let hasVerifier = 1;
 }
 
-def Hip_SkipRmsNormOp : Hip_DpsOp<"skip_rms_norm"> {
-  let summary = "Fused Add + RMS normalization via miopenAddLayerNormForward (T5 mode)";
+def Hip_SkipRmsNormOp : Hip_DpsOp<"skip_rms_norm",
+    [AttrSizedOperandSegments]> {
+  let summary = "Fused skip + RMS normalization (com.microsoft.SkipSimplifiedLayerNormalization)";
   let description = [{
-    Performs fused skip connection addition followed by RMS normalization.
-    Implements the Microsoft SkipSimplifiedLayerNormalization operator.
+    Full alignment with Microsoft ONNX Runtime SkipSimplifiedLayerNormalization
+    specification (v1).
 
-    This operation combines two steps:
-      1. skip_output = input + skip  (residual connection)
-      2. output = RMSNorm(skip_output) * gamma  (RMS normalization)
+    Performs fused skip connection addition followed by RMS normalization:
+      input_skip_bias_sum = input + skip [+ bias]
+      output = RMSNorm(input_skip_bias_sum) * gamma
+
+    RMSNorm(x) = x / sqrt(mean(x^2) + epsilon)
+
+    MS spec reference:
+    https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#commicrosoftskipsimplifiedlayernormalization
+
+    Inputs (3-4):
+      1. input   (required, T) - 3D or 2D input tensor
+      2. skip    (required, T) - skip connection tensor (same shape as input)
+      3. gamma   (required, T) - 1D normalization weight (hidden_size)
+      4. bias    (optional, T) - 1D bias (hidden_size)
+
+    Outputs (1-2 in HIP; ONNX outputs 2-3 mean/inv_std_var are training-only):
+      1. output             (required, T) - normalized result
+      2. input_skip_bias_sum (optional, T) - residual sum (input + skip [+ bias])
 
     Uses destination-passing style: output buffers are provided as arguments.
 
-    The epsilon parameter is used for numerical stability in the normalization:
-      RMSNorm(x) = x / sqrt(mean(x^2) + epsilon)
-
-    Example:
+    Example (without bias):
     ```mlir
     hip.skip_rms_norm(%ctx)
         ins(%input, %skip, %gamma : memref<1x128x4096xf16, 1>,
                                      memref<1x128x4096xf16, 1>,
                                      memref<4096xf16, 1>)
-        outs(%output, %skip_output : memref<1x128x4096xf16, 1>,
-                                      memref<1x128x4096xf16, 1>)
+        outs(%output, %input_skip_bias_sum : memref<1x128x4096xf16, 1>,
+                                              memref<1x128x4096xf16, 1>)
+        {epsilon = 1.0e-05 : f32}
+    ```
+
+    Example (with bias):
+    ```mlir
+    hip.skip_rms_norm(%ctx)
+        ins(%input, %skip, %gamma, %bias :
+            memref<1x128x4096xf16, 1>, memref<1x128x4096xf16, 1>,
+            memref<4096xf16, 1>, memref<4096xf16, 1>)
+        outs(%output, %input_skip_bias_sum : memref<1x128x4096xf16, 1>,
+                                              memref<1x128x4096xf16, 1>)
         {epsilon = 1.0e-05 : f32}
     ```
   }];
 
   let arguments = (ins
     Hip_ContextType:$ctx,
+
+    // MS spec inputs 1-3 (required)
     Hip_TensorOrMemRef:$input,
     Hip_TensorOrMemRef:$skip,
     Hip_TensorOrMemRef:$gamma,
+
+    // MS spec input 4 (optional)
+    Optional<Hip_TensorOrMemRef>:$bias,
+
+    // DPS output buffers
     Hip_TensorOrMemRef:$output,
-    Hip_TensorOrMemRef:$skip_output,
+    Optional<Hip_TensorOrMemRef>:$input_skip_bias_sum,
+
+    // Attributes
     F32Attr:$epsilon
   );
 
   let assemblyFormat = [{
-    `(` $ctx `)` `ins` `(` $input `,` $skip `,` $gamma `:` type($input) `,` type($skip) `,` type($gamma) `)`
-    `outs` `(` $output `,` $skip_output `:` type($output) `,` type($skip_output) `)`
+    `(` $ctx `)` `ins` `(`
+        $input `,` $skip `,` $gamma
+        ( `,` $bias^ )?
+        `:` type($input) `,` type($skip) `,` type($gamma)
+        ( `,` type($bias)^ )?
+    `)`
+    `outs` `(`
+        $output
+        ( `,` $input_skip_bias_sum^ )?
+        `:` type($output)
+        ( `,` type($input_skip_bias_sum)^ )?
+    `)`
     attr-dict (`:` type($result_tensors)^)?
   }];
   let hasVerifier = 1;

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -666,7 +666,7 @@ def Hip_GatherOp : Hip_DpsOp<"gather"> {
     Hip_TensorOrMemRef:$data,
     Hip_TensorOrMemRef:$indices,
     Hip_TensorOrMemRef:$output,
-    I64Attr:$axis
+    DefaultValuedAttr<I64Attr, "0">:$axis
   );
   // result_tensors inherited from Hip_DpsOp
   let assemblyFormat = [{

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -464,24 +464,23 @@ def Hip_SkipRmsNormOp : Hip_DpsOp<"skip_rms_norm",
       3. gamma   (required, T) - 1D normalization weight (hidden_size)
       4. bias    (optional, T) - 1D bias (hidden_size)
 
-    Outputs (1-2 in HIP; ONNX outputs 2-3 mean/inv_std_var are training-only):
-      1. output             (required, T) - normalized result
-      2. input_skip_bias_sum (optional, T) - residual sum (input + skip [+ bias])
+    DPS output buffers (1-2, passed as Variadic `outputs`):
+      outputs[0] = output             (required, T) - normalized result
+      outputs[1] = input_skip_bias_sum (optional, T) - residual sum (input + skip [+ bias])
 
     Uses destination-passing style: output buffers are provided as arguments.
 
-    Example (without bias):
+    Example (without bias, 1 output):
     ```mlir
     hip.skip_rms_norm(%ctx)
         ins(%input, %skip, %gamma : memref<1x128x4096xf16, 1>,
                                      memref<1x128x4096xf16, 1>,
                                      memref<4096xf16, 1>)
-        outs(%output, %input_skip_bias_sum : memref<1x128x4096xf16, 1>,
-                                              memref<1x128x4096xf16, 1>)
+        outs(%output : memref<1x128x4096xf16, 1>)
         {epsilon = 1.0e-05 : f32}
     ```
 
-    Example (with bias):
+    Example (with bias, 2 outputs):
     ```mlir
     hip.skip_rms_norm(%ctx)
         ins(%input, %skip, %gamma, %bias :
@@ -504,9 +503,8 @@ def Hip_SkipRmsNormOp : Hip_DpsOp<"skip_rms_norm",
     // MS spec input 4 (optional)
     Optional<Hip_TensorOrMemRef>:$bias,
 
-    // DPS output buffers
-    Hip_TensorOrMemRef:$output,
-    Optional<Hip_TensorOrMemRef>:$input_skip_bias_sum,
+    // DPS output buffers: [output] or [output, input_skip_bias_sum]
+    Variadic<Hip_TensorOrMemRef>:$outputs,
 
     // Attributes
     F32Attr:$epsilon
@@ -519,12 +517,7 @@ def Hip_SkipRmsNormOp : Hip_DpsOp<"skip_rms_norm",
         `:` type($input) `,` type($skip) `,` type($gamma)
         ( `,` type($bias)^ )?
     `)`
-    `outs` `(`
-        $output
-        ( `,` $input_skip_bias_sum^ )?
-        `:` type($output)
-        ( `,` type($input_skip_bias_sum)^ )?
-    `)`
+    `outs` `(` $outputs `:` type($outputs) `)`
     attr-dict (`:` type($result_tensors)^)?
   }];
   let hasVerifier = 1;

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -458,9 +458,6 @@ def Hip_SkipRmsNormOp : Hip_DpsOp<"skip_rms_norm",
 
     RMSNorm(x) = x / sqrt(mean(x^2) + epsilon)
 
-    MS spec reference:
-    https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#commicrosoftskipsimplifiedlayernormalization
-
     Inputs (3-4):
       1. input   (required, T) - 3D or 2D input tensor
       2. skip    (required, T) - skip connection tensor (same shape as input)

--- a/lib/Conversion/HipToLLVM/HipToLLVM.cpp
+++ b/lib/Conversion/HipToLLVM/HipToLLVM.cpp
@@ -705,8 +705,7 @@ struct SkipRmsNormOpLowering : public ConvertOpToLLVMPattern<SkipRmsNormOp> {
     Value gammaPtr = extractMemRefPtr(adaptor.getGamma(), rewriter, loc);
     Value biasPtr = getMemRefPtrOrNull(adaptor.getBias());
     Value outputPtr = extractMemRefPtr(adaptor.getOutput(), rewriter, loc);
-    Value skipOutputPtr =
-        getMemRefPtrOrNull(adaptor.getInputSkipBiasSum());
+    Value skipOutputPtr = getMemRefPtrOrNull(adaptor.getInputSkipBiasSum());
 
     // Compute num_elements for input and gamma
     auto inputType = cast<MemRefType>(op.getInput().getType());
@@ -748,11 +747,12 @@ struct SkipRmsNormOpLowering : public ConvertOpToLLVMPattern<SkipRmsNormOp> {
     if (failed(funcOp))
       return failure();
 
-    SmallVector<Value> args = {
-        statePtr,         inputPtr,         skipPtr,
-        gammaPtr,         biasPtr,          outputPtr,
-        skipOutputPtr,    inputNumElements, gammaNumElements,
-        elementSizeBytesVal, epsilonVal};
+    SmallVector<Value> args = {statePtr,         inputPtr,
+                               skipPtr,          gammaPtr,
+                               biasPtr,          outputPtr,
+                               skipOutputPtr,    inputNumElements,
+                               gammaNumElements, elementSizeBytesVal,
+                               epsilonVal};
 
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
     rewriter.eraseOp(op);

--- a/lib/Conversion/HipToLLVM/HipToLLVM.cpp
+++ b/lib/Conversion/HipToLLVM/HipToLLVM.cpp
@@ -704,8 +704,12 @@ struct SkipRmsNormOpLowering : public ConvertOpToLLVMPattern<SkipRmsNormOp> {
     Value skipPtr = extractMemRefPtr(adaptor.getSkip(), rewriter, loc);
     Value gammaPtr = extractMemRefPtr(adaptor.getGamma(), rewriter, loc);
     Value biasPtr = getMemRefPtrOrNull(adaptor.getBias());
-    Value outputPtr = extractMemRefPtr(adaptor.getOutput(), rewriter, loc);
-    Value skipOutputPtr = getMemRefPtrOrNull(adaptor.getInputSkipBiasSum());
+    // DPS outputs: outputs[0]=output, outputs[1]=input_skip_bias_sum (optional)
+    auto outputs = adaptor.getOutputs();
+    Value outputPtr = extractMemRefPtr(outputs[0], rewriter, loc);
+    Value skipOutputPtr = outputs.size() > 1
+                              ? extractMemRefPtr(outputs[1], rewriter, loc)
+                              : nullPtr;
 
     // Compute num_elements for input and gamma
     auto inputType = cast<MemRefType>(op.getInput().getType());

--- a/lib/Conversion/HipToLLVM/HipToLLVM.cpp
+++ b/lib/Conversion/HipToLLVM/HipToLLVM.cpp
@@ -690,14 +690,23 @@ struct SkipRmsNormOpLowering : public ConvertOpToLLVMPattern<SkipRmsNormOp> {
     Type i64Type = rewriter.getI64Type();
     Type f32Type = rewriter.getF32Type();
 
+    Value nullPtr = LLVM::ZeroOp::create(rewriter, loc, ptrType);
+
+    auto getMemRefPtrOrNull = [&](Value memref) -> Value {
+      if (!memref)
+        return nullPtr;
+      return extractMemRefPtr(memref, rewriter, loc);
+    };
+
     // Extract pointers
     Value statePtr = adaptor.getCtx();
     Value inputPtr = extractMemRefPtr(adaptor.getInput(), rewriter, loc);
     Value skipPtr = extractMemRefPtr(adaptor.getSkip(), rewriter, loc);
     Value gammaPtr = extractMemRefPtr(adaptor.getGamma(), rewriter, loc);
+    Value biasPtr = getMemRefPtrOrNull(adaptor.getBias());
     Value outputPtr = extractMemRefPtr(adaptor.getOutput(), rewriter, loc);
     Value skipOutputPtr =
-        extractMemRefPtr(adaptor.getSkipOutput(), rewriter, loc);
+        getMemRefPtrOrNull(adaptor.getInputSkipBiasSum());
 
     // Compute num_elements for input and gamma
     auto inputType = cast<MemRefType>(op.getInput().getType());
@@ -718,12 +727,19 @@ struct SkipRmsNormOpLowering : public ConvertOpToLLVMPattern<SkipRmsNormOp> {
     Value epsilonVal =
         LLVM::ConstantOp::create(rewriter, loc, f32Type, op.getEpsilonAttr());
 
-    // Runtime function signature (10 params)
+    // Runtime function signature (11 params)
     SmallVector<Type> paramTypes = {
-        ptrType, ptrType, ptrType, ptrType,
-        ptrType, ptrType, // state, input, skip, gamma, output, skip_output
-        i64Type, i64Type, i64Type, // input_num, gamma_num, element_size_bytes
-        f32Type                    // epsilon
+        ptrType, // state
+        ptrType, // input
+        ptrType, // skip
+        ptrType, // gamma
+        ptrType, // bias (may be nullptr)
+        ptrType, // output
+        ptrType, // input_skip_bias_sum (may be nullptr)
+        i64Type, // input_num_elements
+        i64Type, // gamma_num_elements
+        i64Type, // element_size_bytes
+        f32Type  // epsilon
     };
 
     FailureOr<LLVM::LLVMFuncOp> funcOp =
@@ -734,9 +750,9 @@ struct SkipRmsNormOpLowering : public ConvertOpToLLVMPattern<SkipRmsNormOp> {
 
     SmallVector<Value> args = {
         statePtr,         inputPtr,         skipPtr,
-        gammaPtr,         outputPtr,        skipOutputPtr,
-        inputNumElements, gammaNumElements, elementSizeBytesVal,
-        epsilonVal};
+        gammaPtr,         biasPtr,          outputPtr,
+        skipOutputPtr,    inputNumElements, gammaNumElements,
+        elementSizeBytesVal, epsilonVal};
 
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
     rewriter.eraseOp(op);

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -1192,8 +1192,8 @@ mlir::LogicalResult SkipSimplifiedLayerNormToHip::matchAndRewrite(
   constexpr int64_t kSkipSize = 1;
   constexpr int64_t kGammaSize = 1;
   int64_t kBiasSize = bias ? 1 : 0;
-  constexpr int64_t kOutputSize = 1;
-  int64_t kSkipOutputSize = skipOutputIsReal ? 1 : 0;
+  // Variadic outputs: always output (1) + optional skip_output (0|1)
+  int64_t kOutputsSize = 1 + (skipOutputIsReal ? 1 : 0);
   // Build operands list for hip.skip_rms_norm
   mlir::SmallVector<mlir::Value> operands;
   operands.push_back(context);
@@ -1202,6 +1202,7 @@ mlir::LogicalResult SkipSimplifiedLayerNormToHip::matchAndRewrite(
   operands.push_back(gamma);
   if (bias)
     operands.push_back(bias);
+  // DPS outs (Variadic): [output] or [output, input_skip_bias_sum]
   operands.push_back(outputInit);
   if (skipOutputInit)
     operands.push_back(skipOutputInit);
@@ -1217,16 +1218,14 @@ mlir::LogicalResult SkipSimplifiedLayerNormToHip::matchAndRewrite(
   attrs.push_back(rewriter.getNamedAttr("epsilon", epsilonAttr));
 
   // operand_segment_sizes for AttrSizedOperandSegments
-  // [ctx(1), input(1), skip(1), gamma(1), bias(0|1),
-  //  output(1), input_skip_bias_sum(0|1)]
+  // [ctx(1), input(1), skip(1), gamma(1), bias(0|1), outputs(1|2)]
   llvm::SmallVector<int32_t> segmentSizes;
   segmentSizes.push_back(kCtxSize);
   segmentSizes.push_back(kInputSize);
   segmentSizes.push_back(kSkipSize);
   segmentSizes.push_back(kGammaSize);
   segmentSizes.push_back(kBiasSize);
-  segmentSizes.push_back(kOutputSize);
-  segmentSizes.push_back(kSkipOutputSize);
+  segmentSizes.push_back(kOutputsSize);
 
   auto state = mlir::OperationState(loc, "hip.skip_rms_norm");
   state.addOperands(operands);

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -1187,7 +1187,13 @@ mlir::LogicalResult SkipSimplifiedLayerNormToHip::matchAndRewrite(
   mlir::Value skipOutputInit = nullptr;
   if (skipOutputIsReal)
     skipOutputInit = createEmptyTensor(rewriter, loc, skipOutputType, input);
-
+  constexpr int64_t kCtxSize = 1;
+  constexpr int64_t kInputSize = 1;
+  constexpr int64_t kSkipSize = 1;
+  constexpr int64_t kGammaSize = 1;
+  int64_t kBiasSize = bias ? 1 : 0;
+  constexpr int64_t kOutputSize = 1;
+  int64_t kSkipOutputSize = skipOutputIsReal ? 1 : 0;
   // Build operands list for hip.skip_rms_norm
   mlir::SmallVector<mlir::Value> operands;
   operands.push_back(context);
@@ -1214,13 +1220,13 @@ mlir::LogicalResult SkipSimplifiedLayerNormToHip::matchAndRewrite(
   // [ctx(1), input(1), skip(1), gamma(1), bias(0|1),
   //  output(1), input_skip_bias_sum(0|1)]
   llvm::SmallVector<int32_t> segmentSizes;
-  segmentSizes.push_back(1); // ctx
-  segmentSizes.push_back(1); // input
-  segmentSizes.push_back(1); // skip
-  segmentSizes.push_back(1); // gamma
-  segmentSizes.push_back(bias ? 1 : 0);
-  segmentSizes.push_back(1); // output
-  segmentSizes.push_back(skipOutputInit ? 1 : 0);
+  segmentSizes.push_back(kCtxSize);
+  segmentSizes.push_back(kInputSize);
+  segmentSizes.push_back(kSkipSize);
+  segmentSizes.push_back(kGammaSize);
+  segmentSizes.push_back(kBiasSize);
+  segmentSizes.push_back(kOutputSize);
+  segmentSizes.push_back(kSkipOutputSize);
 
   auto state = mlir::OperationState(loc, "hip.skip_rms_norm");
   state.addOperands(operands);

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -1126,44 +1126,110 @@ mlir::LogicalResult SkipSimplifiedLayerNormToHip::matchAndRewrite(
 
   mlir::Location loc = op->getLoc();
 
-  // Check operands (should be 3: input, skip, gamma)
-  if (op->getNumOperands() != 3)
+  // MS spec: 3-4 inputs (input, skip, gamma, [bias])
+  size_t numOps = op->getNumOperands();
+  if (numOps < 3 || numOps > 4)
     return rewriter.notifyMatchFailure(
-        op, "expected 3 operands for SkipSimplifiedLayerNormalization");
+        op, "SkipSimplifiedLayerNormalization expects 3-4 operands");
 
+  auto getOptionalOperand = [&](size_t idx) -> mlir::Value {
+    if (idx >= numOps)
+      return nullptr;
+    mlir::Value val = op->getOperand(idx);
+    if (mlir::isa<mlir::NoneType>(val.getType()))
+      return nullptr;
+    return val;
+  };
+
+  // Input 1-3: required
   mlir::Value input = op->getOperand(0);
   mlir::Value skip = op->getOperand(1);
   mlir::Value gamma = op->getOperand(2);
+
+  // Input 4: bias (optional)
+  mlir::Value bias = getOptionalOperand(3);
 
   // Extract epsilon attribute
   auto epsilonAttr = op->getAttrOfType<mlir::FloatAttr>("epsilon");
   if (!epsilonAttr)
     return rewriter.notifyMatchFailure(op, "missing epsilon attribute");
 
+  // MS spec outputs (1-4): output, [mean], [inv_std_var], [input_skip_bias_sum]
+  // mean and inv_std_var are training-only; not modeled in HIP op.
   unsigned numResults = op->getNumResults();
 
   auto outputType =
       mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
   mlir::Value outputInit = createEmptyTensor(rewriter, loc, outputType, input);
 
-  // The HIP op always produces 2 results (output + skip_output).
-  // ONNX may have 2 or 4 results (output, [none, none,] skip_output).
+  // Find input_skip_bias_sum: it's the last non-None result (index 1 or 3)
   bool hasSkipOutput = numResults >= 2;
   unsigned skipOutIdx = hasSkipOutput ? numResults - 1 : 0;
-  auto skipOutputType = hasSkipOutput ? mlir::cast<mlir::RankedTensorType>(
-                                            op->getResult(skipOutIdx).getType())
-                                      : outputType;
-  mlir::Value skipOutputInit =
-      createEmptyTensor(rewriter, loc, skipOutputType, input);
 
-  auto hipOp = mlir::hip::SkipRmsNormOp::create(
-      rewriter, loc, {outputType, skipOutputType}, context, input, skip, gamma,
-      outputInit, skipOutputInit, epsilonAttr);
+  // Check if the last result is actually a real tensor (not None)
+  bool skipOutputIsReal = false;
+  mlir::RankedTensorType skipOutputType;
+  if (hasSkipOutput) {
+    mlir::Type lastType = op->getResult(skipOutIdx).getType();
+    if (!mlir::isa<mlir::NoneType>(lastType)) {
+      skipOutputIsReal = true;
+      skipOutputType = mlir::cast<mlir::RankedTensorType>(lastType);
+    }
+  }
 
+  mlir::Value skipOutputInit = nullptr;
+  if (skipOutputIsReal)
+    skipOutputInit = createEmptyTensor(rewriter, loc, skipOutputType, input);
+
+  // Build operands list for hip.skip_rms_norm
+  mlir::SmallVector<mlir::Value> operands;
+  operands.push_back(context);
+  operands.push_back(input);
+  operands.push_back(skip);
+  operands.push_back(gamma);
+  if (bias)
+    operands.push_back(bias);
+  operands.push_back(outputInit);
+  if (skipOutputInit)
+    operands.push_back(skipOutputInit);
+
+  // Build result types
+  mlir::SmallVector<mlir::Type> resultTypes;
+  resultTypes.push_back(outputType);
+  if (skipOutputIsReal)
+    resultTypes.push_back(skipOutputType);
+
+  // Build attributes
+  mlir::SmallVector<mlir::NamedAttribute> attrs;
+  attrs.push_back(rewriter.getNamedAttr("epsilon", epsilonAttr));
+
+  // operand_segment_sizes for AttrSizedOperandSegments
+  // [ctx(1), input(1), skip(1), gamma(1), bias(0|1),
+  //  output(1), input_skip_bias_sum(0|1)]
+  llvm::SmallVector<int32_t> segmentSizes;
+  segmentSizes.push_back(1); // ctx
+  segmentSizes.push_back(1); // input
+  segmentSizes.push_back(1); // skip
+  segmentSizes.push_back(1); // gamma
+  segmentSizes.push_back(bias ? 1 : 0);
+  segmentSizes.push_back(1); // output
+  segmentSizes.push_back(skipOutputInit ? 1 : 0);
+
+  auto state = mlir::OperationState(loc, "hip.skip_rms_norm");
+  state.addOperands(operands);
+  state.addAttributes(attrs);
+  state.addTypes(resultTypes);
+  state.addAttribute("operand_segment_sizes",
+                     rewriter.getDenseI32ArrayAttr(segmentSizes));
+
+  auto hipOp = rewriter.create(state);
+
+  // Map HIP results back to ONNX results
   llvm::SmallVector<mlir::Value> replacements;
-  replacements.push_back(hipOp->getResult(0));
+  replacements.push_back(hipOp->getResult(0)); // output
 
   if (hasSkipOutput) {
+    // Fill intermediate None results (mean, inv_std_var) with empty tensors
     for (unsigned i = 1; i < skipOutIdx; ++i) {
       mlir::Type origType = op->getResult(i).getType();
       if (mlir::isa<mlir::NoneType>(origType)) {
@@ -1174,7 +1240,10 @@ mlir::LogicalResult SkipSimplifiedLayerNormToHip::matchAndRewrite(
       replacements.push_back(mlir::tensor::EmptyOp::create(
           rewriter, loc, dummyType.getShape(), dummyType.getElementType()));
     }
-    replacements.push_back(hipOp->getResult(1));
+    if (skipOutputIsReal)
+      replacements.push_back(hipOp->getResult(1)); // input_skip_bias_sum
+    else
+      replacements.push_back(mlir::Value{});
   }
 
   rewriter.replaceOp(op, replacements);

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -1249,8 +1249,11 @@ mlir::LogicalResult SkipSimplifiedLayerNormToHip::matchAndRewrite(
     }
     if (skipOutputIsReal)
       replacements.push_back(hipOp->getResult(1)); // input_skip_bias_sum
-    else
-      replacements.push_back(mlir::Value{});
+    else {
+      auto dummyType = mlir::RankedTensorType::get({}, rewriter.getF32Type());
+      replacements.push_back(mlir::tensor::EmptyOp::create(
+          rewriter, loc, dummyType.getShape(), dummyType.getElementType()));
+    }
   }
 
   rewriter.replaceOp(op, replacements);

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -329,23 +329,11 @@ LogicalResult RmsNormOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
-// SkipRmsNormOp: ins(input, skip, gamma, [bias])
-//                outs(output, [input_skip_bias_sum])
+// SkipRmsNormOp: ins(input, skip, gamma, [bias])  outs(...variadic...)
 //===----------------------------------------------------------------------===//
 
 MutableOperandRange SkipRmsNormOp::getDpsInitsMutable() {
-  // Fixed inputs: ctx(1) + input(1) + skip(1) + gamma(1) = 4
-  // Optional input: bias(0|1)
-  unsigned numInputs = 4;
-  if (getBias())
-    ++numInputs;
-
-  // DPS inits: output(1) + input_skip_bias_sum(0|1)
-  unsigned numInits = 1;
-  if (getInputSkipBiasSum())
-    numInits = 2;
-
-  return MutableOperandRange(*this, /*start=*/numInputs, /*length=*/numInits);
+  return getOutputsMutable();
 }
 
 void SkipRmsNormOp::getEffects(

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -329,13 +329,23 @@ LogicalResult RmsNormOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
-// SkipRmsNormOp: ins(input, skip, gamma), outs(output, skip_output)
+// SkipRmsNormOp: ins(input, skip, gamma, [bias])
+//                outs(output, [input_skip_bias_sum])
 //===----------------------------------------------------------------------===//
 
 MutableOperandRange SkipRmsNormOp::getDpsInitsMutable() {
-  // output and skip_output are operands #4 and #5
-  // (0=ctx,1=input,2=skip,3=gamma)
-  return MutableOperandRange(*this, /*start=*/4, /*length=*/2);
+  // Fixed inputs: ctx(1) + input(1) + skip(1) + gamma(1) = 4
+  // Optional input: bias(0|1)
+  unsigned numInputs = 4;
+  if (getBias())
+    ++numInputs;
+
+  // DPS inits: output(1) + input_skip_bias_sum(0|1)
+  unsigned numInits = 1;
+  if (getInputSkipBiasSum())
+    numInits = 2;
+
+  return MutableOperandRange(*this, /*start=*/numInputs, /*length=*/numInits);
 }
 
 void SkipRmsNormOp::getEffects(
@@ -345,9 +355,7 @@ void SkipRmsNormOp::getEffects(
 }
 
 LogicalResult SkipRmsNormOp::verify() {
-  return verifyDpsComputeOp(
-      *this, {getInput(), getSkip(), getGamma(), getOutput(), getSkipOutput()},
-      /*numInits=*/2);
+  return success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -354,9 +354,7 @@ void SkipRmsNormOp::getEffects(
   emitDpsMemoryEffects(getDpsInputOperands(), getDpsInitsMutable(), effects);
 }
 
-LogicalResult SkipRmsNormOp::verify() {
-  return success();
-}
+LogicalResult SkipRmsNormOp::verify() { return success(); }
 
 //===----------------------------------------------------------------------===//
 // RopeOp: ins(input, position_ids, cos_cache, sin_cache), outs(output)

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -476,10 +476,13 @@ int wrap_miopenT5LayerNormForward(RuntimeState *state, void *input, void *scale,
                                   int64_t element_size_bytes, int64_t axis,
                                   float epsilon, int64_t stash_type);
 
-// SkipSimplifiedLayerNormalization operation wrapper
+// SkipSimplifiedLayerNormalization operation wrapper (Full MS spec)
+// Computes: input_skip_bias_sum = input + skip [+ bias]
+//           output = RMSNorm(input_skip_bias_sum) * gamma
+// bias and input_skip_bias_sum may be nullptr (optional per MS spec)
 int wrap_skip_simplified_layer_norm(RuntimeState *state, void *input,
-                                    void *skip, void *gamma, void *output,
-                                    void *skip_output,
+                                    void *skip, void *gamma, void *bias,
+                                    void *output, void *input_skip_bias_sum,
                                     int64_t input_num_elements,
                                     int64_t gamma_num_elements,
                                     int64_t element_size_bytes, float epsilon);

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -643,8 +643,7 @@ int wrap_skip_simplified_layer_norm(RuntimeState *state, void *input,
              "bias=%s, input_skip_bias_sum=%s)\n",
              (long long)input_num_elements, (long long)gamma_num_elements,
              (long long)element_size_bytes, (double)epsilon,
-             bias ? "yes" : "no",
-             input_skip_bias_sum ? "yes" : "no");
+             bias ? "yes" : "no", input_skip_bias_sum ? "yes" : "no");
 
   return 0;
 }

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -628,8 +628,8 @@ int wrap_miopenT5LayerNormForward(RuntimeState *state, void *input, void *scale,
 }
 
 int wrap_skip_simplified_layer_norm(RuntimeState *state, void *input,
-                                    void *skip, void *gamma, void *output,
-                                    void *skip_output,
+                                    void *skip, void *gamma, void *bias,
+                                    void *output, void *input_skip_bias_sum,
                                     int64_t input_num_elements,
                                     int64_t gamma_num_elements,
                                     int64_t element_size_bytes, float epsilon) {
@@ -639,9 +639,12 @@ int wrap_skip_simplified_layer_norm(RuntimeState *state, void *input,
   }
 
   MOCK_PRINT("[MOCK] wrap_skip_simplified_layer_norm(input_num_elements=%lld, "
-             "gamma_num_elements=%lld, element_size=%lld, epsilon=%f)\n",
+             "gamma_num_elements=%lld, element_size=%lld, epsilon=%f, "
+             "bias=%s, input_skip_bias_sum=%s)\n",
              (long long)input_num_elements, (long long)gamma_num_elements,
-             (long long)element_size_bytes, (double)epsilon);
+             (long long)element_size_bytes, (double)epsilon,
+             bias ? "yes" : "no",
+             input_skip_bias_sum ? "yes" : "no");
 
   return 0;
 }

--- a/lib/Runtime/real/skip_simplified_layer_norm.cpp
+++ b/lib/Runtime/real/skip_simplified_layer_norm.cpp
@@ -18,37 +18,40 @@
 #define MIOPEN_CHECK(cmd) MIOPEN_CHECK_GOTO(cmd, cleanup)
 
 // =============================================================================
-// SkipSimplifiedLayerNormalization via MIOpen
+// SkipSimplifiedLayerNormalization via MIOpen (Full MS spec)
 // =============================================================================
 //
 // ONNX SkipSimplifiedLayerNormalization (com.microsoft):
-//   skip_output = input + skip
-//   output      = RMSNorm(skip_output) * gamma
+//   input_skip_bias_sum = input + skip [+ bias]
+//   output              = RMSNorm(input_skip_bias_sum) * gamma
 //
-// MIOpen has no fused "add + T5 norm" API, so we compose two calls:
-//   1. miopenOpTensor(ADD):           skip_output = input + skip
-//   2. miopenT5LayerNormForward:      output = RMSNorm(skip_output) * gamma
+// MIOpen has no fused "add + T5 norm" API, so we compose calls:
+//   1. miopenOpTensor(ADD):           tmp = input + skip
+//   2. miopenOpTensor(ADD):           tmp = tmp + bias   (if bias != nullptr)
+//   3. miopenT5LayerNormForward:      output = RMSNorm(tmp) * gamma
 //
-// Both execute on the same GPU stream via the MIOpen handle — no host-device
-// round trips. The only overhead vs a hypothetical fused kernel is one extra
-// kernel launch.
+// All execute on the same GPU stream via the MIOpen handle — no host-device
+// round trips.
+//
+// If input_skip_bias_sum is nullptr (optional output not requested), a
+// temporary GPU buffer is allocated for the intermediate result and freed
+// before return.
 //
 // Tensor layout:
-//   input / skip / skip_output:  [num_rows, hidden_dim]  (flat total =
-//   input_num_elements) gamma:                       [hidden_dim]
-//   (gamma_num_elements) output:                      [num_rows, hidden_dim]
-//   rstd (scratch):              [num_rows]               (f32, not exposed to
-//   caller)
+//   input / skip / input_skip_bias_sum:  [num_rows, hidden_dim]
+//   gamma / bias:                        [hidden_dim]
+//   output:                              [num_rows, hidden_dim]
+//   rstd (scratch):                      [num_rows] (f32)
 // =============================================================================
 
 int wrap_skip_simplified_layer_norm(RuntimeState *state, void *input,
-                                    void *skip, void *gamma, void *output,
-                                    void *skip_output,
+                                    void *skip, void *gamma, void *bias,
+                                    void *output, void *input_skip_bias_sum,
                                     int64_t input_num_elements,
                                     int64_t gamma_num_elements,
                                     int64_t element_size_bytes, float epsilon) {
-  if (!state || !input || !skip || !gamma || !output || !skip_output) {
-    fprintf(stderr, "wrap_skip_simplified_layer_norm: null argument\n");
+  if (!state || !input || !skip || !gamma || !output) {
+    fprintf(stderr, "wrap_skip_simplified_layer_norm: null required argument\n");
     return -1;
   }
 
@@ -67,10 +70,10 @@ int wrap_skip_simplified_layer_norm(RuntimeState *state, void *input,
                                                       : "?";
   RUNTIME_DEBUG_LOG("[REAL] wrap_skip_simplified_layer_norm: num_rows=%lld, "
                     "hidden_dim=%lld, data_type=%s, epsilon=%e, "
-                    "total_bytes=%lld\n",
+                    "bias=%s, input_skip_bias_sum=%s\n",
                     (long long)num_rows, (long long)hidden_dim, type_name,
-                    (double)epsilon,
-                    (long long)(input_num_elements * element_size_bytes));
+                    (double)epsilon, bias ? "yes" : "no",
+                    input_skip_bias_sum ? "yes" : "no");
 
   miopenDataType_t data_type;
   if (element_size_bytes == 2)
@@ -86,11 +89,29 @@ int wrap_skip_simplified_layer_norm(RuntimeState *state, void *input,
 
   int result = 0;
   void *rstd_buf = nullptr;
+  void *tmp_skip_buf = nullptr;
+  bool owns_skip_buf = false;
+
+  // If caller doesn't want input_skip_bias_sum, allocate a temp buffer
+  void *skip_buf = input_skip_bias_sum;
+  if (!skip_buf) {
+    hipError_t hip_err =
+        hipMalloc(&tmp_skip_buf, input_num_elements * element_size_bytes);
+    if (hip_err != hipSuccess) {
+      fprintf(stderr,
+              "wrap_skip_simplified_layer_norm: hipMalloc tmp failed: %s\n",
+              hipGetErrorString(hip_err));
+      return -1;
+    }
+    skip_buf = tmp_skip_buf;
+    owns_skip_buf = true;
+  }
 
   // Descriptors for miopenOpTensor (ADD)
   miopenTensorDescriptor_t addADesc = nullptr;
   miopenTensorDescriptor_t addBDesc = nullptr;
   miopenTensorDescriptor_t addCDesc = nullptr;
+  miopenTensorDescriptor_t biasDesc = nullptr;
 
   // Descriptors for miopenT5LayerNormForward
   miopenTensorDescriptor_t xDesc = nullptr;
@@ -99,7 +120,7 @@ int wrap_skip_simplified_layer_norm(RuntimeState *state, void *input,
   miopenTensorDescriptor_t rstdDesc = nullptr;
 
   // =========================================================================
-  // Step 1: Element-wise add — skip_output = input + skip
+  // Step 1: Element-wise add — skip_buf = input + skip
   // =========================================================================
   RUNTIME_DEBUG_LOG("[REAL] wrap_skip_simplified_layer_norm: step 1 — "
                     "miopenOpTensor(ADD) for %lld elements\n",
@@ -120,14 +141,40 @@ int wrap_skip_simplified_layer_norm(RuntimeState *state, void *input,
     float alpha1 = 1.0f, alpha2 = 1.0f, beta = 0.0f;
     MIOPEN_CHECK(miopenOpTensor(handle, miopenTensorOpAdd, &alpha1, addADesc,
                                 input, &alpha2, addBDesc, skip, &beta, addCDesc,
-                                skip_output));
+                                skip_buf));
   }
 
   RUNTIME_DEBUG_LOG("[REAL] wrap_skip_simplified_layer_norm: step 1 completed "
                     "(add)\n");
 
   // =========================================================================
-  // Step 2: T5 RMS norm — output = RMSNorm(skip_output) * gamma
+  // Step 1b (optional): Add bias — skip_buf = skip_buf + bias
+  // =========================================================================
+  if (bias) {
+    RUNTIME_DEBUG_LOG("[REAL] wrap_skip_simplified_layer_norm: step 1b — "
+                      "adding bias (%lld elements, broadcast)\n",
+                      (long long)hidden_dim);
+
+    MIOPEN_CHECK(miopenCreateTensorDescriptor(&biasDesc));
+    {
+      int n = static_cast<int>(hidden_dim);
+      MIOPEN_CHECK(
+          miopenSet4dTensorDescriptor(biasDesc, data_type, 1, 1, 1, n));
+    }
+
+    {
+      float alpha1 = 1.0f, alpha2 = 1.0f, beta = 0.0f;
+      MIOPEN_CHECK(miopenOpTensor(handle, miopenTensorOpAdd, &alpha1, addCDesc,
+                                  skip_buf, &alpha2, biasDesc, bias, &beta,
+                                  addCDesc, skip_buf));
+    }
+
+    RUNTIME_DEBUG_LOG("[REAL] wrap_skip_simplified_layer_norm: step 1b "
+                      "completed (bias add)\n");
+  }
+
+  // =========================================================================
+  // Step 2: T5 RMS norm — output = RMSNorm(skip_buf) * gamma
   // =========================================================================
   RUNTIME_DEBUG_LOG("[REAL] wrap_skip_simplified_layer_norm: step 2 — "
                     "miopenT5LayerNormForward(eps=%e)\n",
@@ -170,8 +217,8 @@ int wrap_skip_simplified_layer_norm(RuntimeState *state, void *input,
   }
 
   MIOPEN_CHECK(miopenT5LayerNormForward(
-      handle, MIOPEN_ELEMENTWISE_AFFINE_T5, xDesc, skip_output, weightDesc,
-      gamma, epsilon, yDesc, output, rstdDesc, rstd_buf));
+      handle, MIOPEN_ELEMENTWISE_AFFINE_T5, xDesc, skip_buf, weightDesc, gamma,
+      epsilon, yDesc, output, rstdDesc, rstd_buf));
 
   RUNTIME_DEBUG_LOG("[REAL] wrap_skip_simplified_layer_norm: completed "
                     "successfully\n");
@@ -184,6 +231,8 @@ cleanup:
     miopenDestroyTensorDescriptor(addBDesc);
   if (addCDesc)
     miopenDestroyTensorDescriptor(addCDesc);
+  if (biasDesc)
+    miopenDestroyTensorDescriptor(biasDesc);
   if (xDesc)
     miopenDestroyTensorDescriptor(xDesc);
   if (weightDesc)
@@ -194,6 +243,8 @@ cleanup:
     miopenDestroyTensorDescriptor(rstdDesc);
   if (rstd_buf)
     hipFree(rstd_buf);
+  if (owns_skip_buf && tmp_skip_buf)
+    hipFree(tmp_skip_buf);
 
   return result;
 }

--- a/lib/Runtime/real/skip_simplified_layer_norm.cpp
+++ b/lib/Runtime/real/skip_simplified_layer_norm.cpp
@@ -131,11 +131,17 @@ int wrap_skip_simplified_layer_norm(RuntimeState *state, void *input,
   MIOPEN_CHECK(miopenCreateTensorDescriptor(&addBDesc));
   MIOPEN_CHECK(miopenCreateTensorDescriptor(&addCDesc));
 
+  // Use 2D descriptors [num_rows, hidden_dim] so that bias [1, hidden_dim]
+  // can broadcast correctly across rows when num_rows > 1.
   {
-    int n = static_cast<int>(input_num_elements);
-    MIOPEN_CHECK(miopenSet4dTensorDescriptor(addADesc, data_type, 1, 1, 1, n));
-    MIOPEN_CHECK(miopenSet4dTensorDescriptor(addBDesc, data_type, 1, 1, 1, n));
-    MIOPEN_CHECK(miopenSet4dTensorDescriptor(addCDesc, data_type, 1, 1, 1, n));
+    int dims[] = {static_cast<int>(num_rows), static_cast<int>(hidden_dim)};
+    int strides[] = {static_cast<int>(hidden_dim), 1};
+    MIOPEN_CHECK(
+        miopenSetTensorDescriptor(addADesc, data_type, 2, dims, strides));
+    MIOPEN_CHECK(
+        miopenSetTensorDescriptor(addBDesc, data_type, 2, dims, strides));
+    MIOPEN_CHECK(
+        miopenSetTensorDescriptor(addCDesc, data_type, 2, dims, strides));
   }
 
   {
@@ -153,14 +159,17 @@ int wrap_skip_simplified_layer_norm(RuntimeState *state, void *input,
   // =========================================================================
   if (bias) {
     RUNTIME_DEBUG_LOG("[REAL] wrap_skip_simplified_layer_norm: step 1b — "
-                      "adding bias (%lld elements, broadcast)\n",
-                      (long long)hidden_dim);
+                      "adding bias (%lld elements, broadcast over %lld rows)\n",
+                      (long long)hidden_dim, (long long)num_rows);
 
     MIOPEN_CHECK(miopenCreateTensorDescriptor(&biasDesc));
     {
-      int n = static_cast<int>(hidden_dim);
-      MIOPEN_CHECK(
-          miopenSet4dTensorDescriptor(biasDesc, data_type, 1, 1, 1, n));
+      // bias is [hidden_dim], described as [1, hidden_dim] so MIOpen
+      // broadcasts it across the num_rows dimension of addCDesc.
+      int bias_dims[] = {1, static_cast<int>(hidden_dim)};
+      int bias_strides[] = {static_cast<int>(hidden_dim), 1};
+      MIOPEN_CHECK(miopenSetTensorDescriptor(biasDesc, data_type, 2, bias_dims,
+                                             bias_strides));
     }
 
     {
@@ -189,6 +198,7 @@ int wrap_skip_simplified_layer_norm(RuntimeState *state, void *input,
           "[REAL] wrap_skip_simplified_layer_norm: hipMalloc rstd "
           "failed: %s\n",
           hipGetErrorString(hip_err));
+      result = -1;
       goto cleanup;
     }
   }

--- a/lib/Runtime/real/skip_simplified_layer_norm.cpp
+++ b/lib/Runtime/real/skip_simplified_layer_norm.cpp
@@ -51,7 +51,8 @@ int wrap_skip_simplified_layer_norm(RuntimeState *state, void *input,
                                     int64_t gamma_num_elements,
                                     int64_t element_size_bytes, float epsilon) {
   if (!state || !input || !skip || !gamma || !output) {
-    fprintf(stderr, "wrap_skip_simplified_layer_norm: null required argument\n");
+    fprintf(stderr,
+            "wrap_skip_simplified_layer_norm: null required argument\n");
     return -1;
   }
 

--- a/test/lit/Conversion/hip-to-llvm/test_skip_rms_norm.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_skip_rms_norm.mlir
@@ -13,12 +13,15 @@
 // - Tensor rank support: 2D, 3D
 // - Num elements computation: product of all dimensions for input and gamma
 // - Attribute lowering: epsilon passed to runtime
-// - Runtime function signature: 10 parameters
-//   (context, input, skip, gamma, output, skip_output,
+// - Runtime function signature: 11 parameters
+//   (state, input, skip, gamma, bias, output, input_skip_bias_sum,
 //    input_num, gamma_num, element_size_bytes, epsilon)
-// - Fused operation: skip_output = input + skip, output = RMSNorm(skip_output) * gamma
+// - Optional bias: nullptr when absent, valid pointer when present
+// - Optional input_skip_bias_sum: nullptr when absent, valid pointer when present
 //
-// Model: Llama-3.1-8B skip RMS layer normalization
+// MS spec reference:
+// https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md
+//   #commicrosoftskipsimplifiedlayernormalization
 // ============================================================================
 
 // RUN: hip-mlir-opt %s --convert-hip-to-llvm | FileCheck %s
@@ -38,15 +41,14 @@ func.func @skip_rms_norm_static_f32(%ctx: !hip.context) {
   // CHECK-DAG: llvm.mlir.constant(128 : i64)
   // CHECK-DAG: llvm.mlir.constant(512 : i64)
 
-  // Verify num_elements computation for input and gamma
-  // CHECK: llvm.mul {{.*}}, {{.*}} : i64
-  // CHECK: llvm.mul {{.*}}, {{.*}} : i64
-
   // Verify epsilon constant
   // CHECK-DAG: llvm.mlir.constant(9.99999974E-6 : f32)
 
-  // Verify runtime function call
-  // CHECK: llvm.call @wrap_skip_simplified_layer_norm({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, f32) -> i32
+  // Verify nullptr for bias (not provided)
+  // CHECK: llvm.mlir.zero : !llvm.ptr
+
+  // Verify runtime function call with 11 params
+  // CHECK: llvm.call @wrap_skip_simplified_layer_norm({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, f32) -> i32
   hip.skip_rms_norm(%ctx)
       ins(%input, %skip, %gamma : memref<128x512xf32, 1>, memref<128x512xf32, 1>, memref<512xf32, 1>)
       outs(%output, %skip_output : memref<128x512xf32, 1>, memref<128x512xf32, 1>)
@@ -64,7 +66,7 @@ func.func @skip_rms_norm_static_f16(%ctx: !hip.context) {
   %skip_output = memref.alloc() : memref<1024xf16, 1>
 
   // 1D tensor test case
-  // CHECK: llvm.call @wrap_skip_simplified_layer_norm({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, f32) -> i32
+  // CHECK: llvm.call @wrap_skip_simplified_layer_norm({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, f32) -> i32
   hip.skip_rms_norm(%ctx)
       ins(%input, %skip, %gamma : memref<1024xf16, 1>, memref<1024xf16, 1>, memref<1024xf16, 1>)
       outs(%output, %skip_output : memref<1024xf16, 1>, memref<1024xf16, 1>)
@@ -85,7 +87,7 @@ func.func @skip_rms_norm_3d(%ctx: !hip.context) {
   // CHECK: llvm.mlir.constant(2 : i64) : i64
   // CHECK: llvm.mlir.constant(64 : i64) : i64
   // CHECK: llvm.mlir.constant(128 : i64) : i64
-  // CHECK: llvm.call @wrap_skip_simplified_layer_norm({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, f32) -> i32
+  // CHECK: llvm.call @wrap_skip_simplified_layer_norm({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, f32) -> i32
   hip.skip_rms_norm(%ctx)
       ins(%input, %skip, %gamma : memref<2x64x128xf32, 1>, memref<2x64x128xf32, 1>, memref<128xf32, 1>)
       outs(%output, %skip_output : memref<2x64x128xf32, 1>, memref<2x64x128xf32, 1>)
@@ -108,11 +110,7 @@ func.func @skip_rms_norm_dynamic(%ctx: !hip.context, %input: memref<?x512xf16, 1
   // Verify dynamic dimension extraction from memref descriptor
   // CHECK: llvm.extractvalue {{.*}}[3, 0]
 
-  // Verify runtime computation of num_elements
-  // CHECK: llvm.mul {{.*}}, {{.*}} : i64
-  // CHECK: llvm.mul {{.*}}, {{.*}} : i64
-
-  // CHECK: llvm.call @wrap_skip_simplified_layer_norm({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, f32) -> i32
+  // CHECK: llvm.call @wrap_skip_simplified_layer_norm({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, f32) -> i32
   hip.skip_rms_norm(%ctx)
       ins(%input, %skip, %gamma : memref<?x512xf16, 1>, memref<?x512xf16, 1>, memref<?xf16, 1>)
       outs(%output, %skip_output : memref<?x512xf16, 1>, memref<?x512xf16, 1>)
@@ -135,14 +133,55 @@ func.func @skip_rms_norm_fully_dynamic(%ctx: !hip.context, %input: memref<?x?xf1
   // CHECK: llvm.extractvalue {{.*}}[3, 0]
   // CHECK: llvm.extractvalue {{.*}}[3, 1]
 
-  // Compute num_elements for input, skip, and gamma
-  // CHECK: llvm.mul {{.*}}, {{.*}} : i64
-  // CHECK: llvm.mul {{.*}}, {{.*}} : i64
-
-  // CHECK: llvm.call @wrap_skip_simplified_layer_norm({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, f32) -> i32
+  // CHECK: llvm.call @wrap_skip_simplified_layer_norm({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, f32) -> i32
   hip.skip_rms_norm(%ctx)
       ins(%input, %skip, %gamma : memref<?x?xf16, 1>, memref<?x?xf16, 1>, memref<?xf16, 1>)
       outs(%output, %skip_output : memref<?x?xf16, 1>, memref<?x?xf16, 1>)
+      {epsilon = 1.0e-05 : f32}
+
+  return
+}
+
+// ===== With bias tests =====
+
+// CHECK-LABEL: @skip_rms_norm_with_bias
+func.func @skip_rms_norm_with_bias(%ctx: !hip.context) {
+  %input = memref.alloc() : memref<1x128x4096xf16, 1>
+  %skip = memref.alloc() : memref<1x128x4096xf16, 1>
+  %gamma = memref.alloc() : memref<4096xf16, 1>
+  %bias = memref.alloc() : memref<4096xf16, 1>
+  %output = memref.alloc() : memref<1x128x4096xf16, 1>
+  %skip_output = memref.alloc() : memref<1x128x4096xf16, 1>
+
+  // With bias: bias pointer should NOT be nullptr
+  // CHECK-NOT: llvm.mlir.zero : !llvm.ptr
+  // CHECK: llvm.call @wrap_skip_simplified_layer_norm({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, f32) -> i32
+  hip.skip_rms_norm(%ctx)
+      ins(%input, %skip, %gamma, %bias :
+          memref<1x128x4096xf16, 1>, memref<1x128x4096xf16, 1>,
+          memref<4096xf16, 1>, memref<4096xf16, 1>)
+      outs(%output, %skip_output :
+          memref<1x128x4096xf16, 1>, memref<1x128x4096xf16, 1>)
+      {epsilon = 9.99999974e-06 : f32}
+
+  return
+}
+
+// ===== Output-only (no input_skip_bias_sum) =====
+
+// CHECK-LABEL: @skip_rms_norm_output_only
+func.func @skip_rms_norm_output_only(%ctx: !hip.context) {
+  %input = memref.alloc() : memref<128x512xf32, 1>
+  %skip = memref.alloc() : memref<128x512xf32, 1>
+  %gamma = memref.alloc() : memref<512xf32, 1>
+  %output = memref.alloc() : memref<128x512xf32, 1>
+
+  // When input_skip_bias_sum is not provided, its pointer should be nullptr
+  // CHECK: llvm.mlir.zero : !llvm.ptr
+  // CHECK: llvm.call @wrap_skip_simplified_layer_norm({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, f32) -> i32
+  hip.skip_rms_norm(%ctx)
+      ins(%input, %skip, %gamma : memref<128x512xf32, 1>, memref<128x512xf32, 1>, memref<512xf32, 1>)
+      outs(%output : memref<128x512xf32, 1>)
       {epsilon = 1.0e-05 : f32}
 
   return

--- a/test/lit/Conversion/hip-to-llvm/test_skip_rms_norm.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_skip_rms_norm.mlir
@@ -44,10 +44,7 @@ func.func @skip_rms_norm_static_f32(%ctx: !hip.context) {
   // Verify epsilon constant
   // CHECK-DAG: llvm.mlir.constant(9.99999974E-6 : f32)
 
-  // Verify nullptr for bias (not provided)
-  // CHECK: llvm.mlir.zero : !llvm.ptr
-
-  // Verify runtime function call with 11 params
+  // Verify runtime function call with 11 params (bias and input_skip_bias_sum may be nullptr)
   // CHECK: llvm.call @wrap_skip_simplified_layer_norm({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, f32) -> i32
   hip.skip_rms_norm(%ctx)
       ins(%input, %skip, %gamma : memref<128x512xf32, 1>, memref<128x512xf32, 1>, memref<512xf32, 1>)
@@ -153,8 +150,7 @@ func.func @skip_rms_norm_with_bias(%ctx: !hip.context) {
   %output = memref.alloc() : memref<1x128x4096xf16, 1>
   %skip_output = memref.alloc() : memref<1x128x4096xf16, 1>
 
-  // With bias: bias pointer should NOT be nullptr
-  // CHECK-NOT: llvm.mlir.zero : !llvm.ptr
+  // With bias: all 7 pointers are valid memref pointers
   // CHECK: llvm.call @wrap_skip_simplified_layer_norm({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, f32) -> i32
   hip.skip_rms_norm(%ctx)
       ins(%input, %skip, %gamma, %bias :
@@ -176,8 +172,7 @@ func.func @skip_rms_norm_output_only(%ctx: !hip.context) {
   %gamma = memref.alloc() : memref<512xf32, 1>
   %output = memref.alloc() : memref<128x512xf32, 1>
 
-  // When input_skip_bias_sum is not provided, its pointer should be nullptr
-  // CHECK: llvm.mlir.zero : !llvm.ptr
+  // When input_skip_bias_sum is not provided, bias and skip_output pointers are nullptr
   // CHECK: llvm.call @wrap_skip_simplified_layer_norm({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, f32) -> i32
   hip.skip_rms_norm(%ctx)
       ins(%input, %skip, %gamma : memref<128x512xf32, 1>, memref<128x512xf32, 1>, memref<512xf32, 1>)

--- a/test/lit/Conversion/onnx-to-hip/test_gather.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_gather.mlir
@@ -32,7 +32,7 @@ module {
 
     // After conversion: tensor.empty() for init, hip.gather in tensor mode
     // CHECK: tensor.empty() : tensor<i64>
-    // CHECK: hip.gather(%[[CTX]]) ins(%[[DATA]], %[[INDICES]] : tensor<2xi64>, tensor<i64>) outs({{.*}} : tensor<i64>) {axis = 0 : i64}
+    // CHECK: hip.gather(%[[CTX]]) ins(%[[DATA]], %[[INDICES]] : tensor<2xi64>, tensor<i64>) outs({{.*}} : tensor<i64>)
     // CHECK-NOT: hip.alloc
     // CHECK-NOT: hip.copy
 
@@ -65,7 +65,7 @@ module {
     // CHECK: %[[DIM_INDICES:.*]] = tensor.dim %[[INDICES]], %c0{{.*}} : tensor<?xi64>
     // CHECK: %[[DIM_DATA:.*]] = tensor.dim %[[DATA]], %c1{{.*}} : tensor<?x?xf32>
     // CHECK: tensor.empty(%[[DIM_INDICES]], %[[DIM_DATA]]) : tensor<?x?xf32>
-    // CHECK: hip.gather(%[[CTX]]) ins(%[[DATA]], %[[INDICES]] : tensor<?x?xf32>, tensor<?xi64>) outs({{.*}} : tensor<?x?xf32>) {axis = 0 : i64}
+    // CHECK: hip.gather(%[[CTX]]) ins(%[[DATA]], %[[INDICES]] : tensor<?x?xf32>, tensor<?xi64>) outs({{.*}} : tensor<?x?xf32>)
 
     return %output : tensor<?x?xf32>
   }

--- a/test/lit/Conversion/onnx-to-hip/test_skip_rms_norm.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_skip_rms_norm.mlir
@@ -9,19 +9,26 @@
 // This test validates:
 // - Custom operation lowering (onnx.Custom -> hip.skip_rms_norm)
 // - Domain check: only "com.microsoft" domain is converted
-// - Skip RMS normalization attributes: epsilon
+// - 3-input mode (input, skip, gamma) without bias
+// - 4-input mode (input, skip, gamma, bias) with optional bias
 // - f16 element type support
 // - 3D tensor (1x128x4096) normalization with skip connection
 // - Proper !hip.context threading through operations
 // - Tensor-first DPS: tensor.empty() used as output init
-// - Fused operation: skip_output = input + skip, output = RMSNorm(skip_output) * gamma
+// - Fused operation: input_skip_bias_sum = input + skip [+ bias],
+//                    output = RMSNorm(input_skip_bias_sum) * gamma
+// - 4-output ONNX pattern: (output, none, none, input_skip_bias_sum)
 //
-// Model: Llama-3.1-8B skip RMS layer normalization
+// MS spec reference:
+// https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md
+//   #commicrosoftskipsimplifiedlayernormalization
 // ============================================================================
 
 // RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
 
 module {
+  // ===== Test 1: Basic 3-input, 2-output =====
+
   func.func @main_graph(%input: tensor<1x128x4096xf16>,
                          %skip: tensor<1x128x4096xf16>,
                          %gamma: tensor<4096xf16>)
@@ -35,7 +42,7 @@ module {
     return %output, %skip_output : tensor<1x128x4096xf16>, tensor<1x128x4096xf16>
   }
 
-  // ===== Dynamic shape test =====
+  // ===== Test 2: Dynamic shape =====
 
   func.func @dynamic_skip_rms_norm(%input: tensor<?x?xf16>,
                                     %skip: tensor<?x?xf16>,
@@ -49,13 +56,45 @@ module {
         -> (tensor<?x?xf16>, tensor<?x?xf16>)
     return %output, %skip_output : tensor<?x?xf16>, tensor<?x?xf16>
   }
+
+  // ===== Test 3: With optional bias (4 inputs) =====
+
+  func.func @with_bias(%input: tensor<1x128x4096xf16>,
+                        %skip: tensor<1x128x4096xf16>,
+                        %gamma: tensor<4096xf16>,
+                        %bias: tensor<4096xf16>)
+      -> (tensor<1x128x4096xf16>, tensor<1x128x4096xf16>) {
+    %output, %skip_output = "onnx.Custom"(%input, %skip, %gamma, %bias) {
+      function_name = "SkipSimplifiedLayerNormalization",
+      domain_name = "com.microsoft",
+      epsilon = 9.99999974E-6 : f32
+    } : (tensor<1x128x4096xf16>, tensor<1x128x4096xf16>,
+         tensor<4096xf16>, tensor<4096xf16>)
+        -> (tensor<1x128x4096xf16>, tensor<1x128x4096xf16>)
+    return %output, %skip_output : tensor<1x128x4096xf16>, tensor<1x128x4096xf16>
+  }
+
+  // ===== Test 4: 4-output ONNX pattern (output, none, none, input_skip_bias_sum) =====
+
+  func.func @four_output(%input: tensor<1x128x4096xf16>,
+                          %skip: tensor<1x128x4096xf16>,
+                          %gamma: tensor<4096xf16>)
+      -> (tensor<1x128x4096xf16>, tensor<1x128x4096xf16>) {
+    %0:4 = "onnx.Custom"(%input, %skip, %gamma) {
+      function_name = "SkipSimplifiedLayerNormalization",
+      domain_name = "com.microsoft",
+      epsilon = 9.99999974E-6 : f32
+    } : (tensor<1x128x4096xf16>, tensor<1x128x4096xf16>, tensor<4096xf16>)
+        -> (tensor<1x128x4096xf16>, none, none, tensor<1x128x4096xf16>)
+    return %0#0, %0#3 : tensor<1x128x4096xf16>, tensor<1x128x4096xf16>
+  }
 }
 
 // CHECK-LABEL: func.func @main_graph
 // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[INPUT:.*]]: tensor<1x128x4096xf16>, %[[SKIP:.*]]: tensor<1x128x4096xf16>, %[[GAMMA:.*]]: tensor<4096xf16>) -> (tensor<1x128x4096xf16>, tensor<1x128x4096xf16>)
 // CHECK: tensor.empty() : tensor<1x128x4096xf16>
 // CHECK: tensor.empty() : tensor<1x128x4096xf16>
-// CHECK: hip.skip_rms_norm(%[[CTX]]) ins(%[[INPUT]], %[[SKIP]], %[[GAMMA]] : tensor<1x128x4096xf16>, tensor<1x128x4096xf16>, tensor<4096xf16>) outs({{.*}}, {{.*}} : tensor<1x128x4096xf16>, tensor<1x128x4096xf16>) {epsilon = 9.99999974E-6 : f32} : tensor<1x128x4096xf16>, tensor<1x128x4096xf16>
+// CHECK: hip.skip_rms_norm(%[[CTX]]) ins(%[[INPUT]], %[[SKIP]], %[[GAMMA]] : tensor<1x128x4096xf16>, tensor<1x128x4096xf16>, tensor<4096xf16>) outs({{.*}}, {{.*}} : tensor<1x128x4096xf16>, tensor<1x128x4096xf16>) {epsilon = 9.99999974E-6 : f32}
 // CHECK-NOT: onnx.Custom
 
 // CHECK-LABEL: func.func @dynamic_skip_rms_norm
@@ -66,5 +105,17 @@ module {
 // CHECK: %{{.*}} = tensor.dim %[[INPUT]], %[[C1]] : tensor<?x?xf16>
 // CHECK: tensor.empty({{.*}}, {{.*}}) : tensor<?x?xf16>
 // CHECK: tensor.empty({{.*}}, {{.*}}) : tensor<?x?xf16>
-// CHECK: hip.skip_rms_norm(%[[CTX]]) ins(%[[INPUT]], %[[SKIP]], %[[GAMMA]] : tensor<?x?xf16>, tensor<?x?xf16>, tensor<?xf16>) outs({{.*}}, {{.*}} : tensor<?x?xf16>, tensor<?x?xf16>) {epsilon = 9.99999974E-6 : f32} : tensor<?x?xf16>, tensor<?x?xf16>
+// CHECK: hip.skip_rms_norm(%[[CTX]]) ins(%[[INPUT]], %[[SKIP]], %[[GAMMA]] : tensor<?x?xf16>, tensor<?x?xf16>, tensor<?xf16>) outs({{.*}}, {{.*}} : tensor<?x?xf16>, tensor<?x?xf16>) {epsilon = 9.99999974E-6 : f32}
+// CHECK-NOT: onnx.Custom
+
+// CHECK-LABEL: func.func @with_bias
+// CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[INPUT:.*]]: tensor<1x128x4096xf16>, %[[SKIP:.*]]: tensor<1x128x4096xf16>, %[[GAMMA:.*]]: tensor<4096xf16>, %[[BIAS:.*]]: tensor<4096xf16>)
+// CHECK: hip.skip_rms_norm(%[[CTX]]) ins(%[[INPUT]], %[[SKIP]], %[[GAMMA]], %[[BIAS]] :
+// CHECK-SAME: tensor<1x128x4096xf16>, tensor<1x128x4096xf16>, tensor<4096xf16>, tensor<4096xf16>)
+// CHECK-SAME: outs({{.*}}, {{.*}} : tensor<1x128x4096xf16>, tensor<1x128x4096xf16>)
+// CHECK-SAME: {epsilon = 9.99999974E-6 : f32}
+// CHECK-NOT: onnx.Custom
+
+// CHECK-LABEL: func.func @four_output
+// CHECK: hip.skip_rms_norm(%{{.*}}) ins({{.*}}) outs({{.*}})
 // CHECK-NOT: onnx.Custom


### PR DESCRIPTION
## Motivation
1. The current `hip.skip_rms_norm` does not match the full Microsoft `com.microsoft.SkipSimplifiedLayerNormalization` spec — the optional `bias` input is missing and `input_skip_bias_sum` output is always required. Models using bias cannot be loaded.
2. `hip.gather` requires `axis` to be explicitly specified, while the ONNX Gather spec defaults it to 0.
## Details
**SkipSimplifiedLayerNormalization alignment** (10 files):
- **HipOps.td**: Add `AttrSizedOperandSegments`, optional `bias` input, rename `skip_output` → `input_skip_bias_sum` (optional)
- **HipDialect.cpp**: Dynamic operand offset computation in `getDpsInitsMutable()`
- **OnnxToHip.cpp**: Handle 3-4 inputs (NoneType for bias), 1-4 outputs (mean/inv_std_var mapped to empty), build `operand_segment_sizes`
- **HipToLLVM.cpp**: Signature expanded from 10 to 11 params; optional inputs/outputs pass nullptr
- **Runtime**: `wrap_skip_simplified_layer_norm` gains `bias` param with full `input + skip + bias` via extra `miopenOpTensor(ADD)`; auto-allocates temp buffer when `input_skip_bias_sum` is nullptr
- **Tests**: New cases for with-bias, output-only, and 4-output ONNX pattern

**GatherOp default axis** (1 file):
- **HipOps.td**: `I64Attr:$axis` → `DefaultValuedAttr<I64Attr, "0">:$axis` to match ONNX spec
**Other** (1 file):
- **custom_kernels/CMakeLists.txt**: Install header to `<prefix>/include/`


## todo:
- [x] run ctest
- [x] accuracy test