### PR TITLE
ci: add GPU performance & accuracy test workflow

### DIFF
--- a/.github/workflows/gpu-perf-accuracy-test.yml
+++ b/.github/workflows/gpu-perf-accuracy-test.yml
@@ -28,11 +28,6 @@ on:
         required: false
         default: "30"
         type: string
-      enable_full_model_l2:
-        description: "Run L2 accuracy tests on full models (slow)"
-        required: false
-        default: false
-        type: boolean
 
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
@@ -291,11 +286,7 @@ jobs:
       #  Disabled by default — enable via workflow_dispatch input
       # =================================================================
       - name: Run full model L2 accuracy tests
-        if: >-
-          always() &&
-          steps.verify-package.outcome == 'success' &&
-          steps.setup-therock.outcome == 'success' &&
-          github.event.inputs.enable_full_model_l2 == 'true'
+        if: always() && steps.verify-package.outcome == 'success' && steps.setup-therock.outcome == 'success'
         timeout-minutes: 60
         shell: cmd
         run: |

--- a/.github/workflows/gpu-perf-accuracy-test.yml
+++ b/.github/workflows/gpu-perf-accuracy-test.yml
@@ -177,7 +177,8 @@ jobs:
             set "MDIR=%%~dpM"
             set "REL=!MDIR:%OP_MODEL_DIR%\=!"
             mkdir "..\..\perf-results\single-op\!REL!" 2>nul
-            echo === Perf: !REL!%%~nxM ===
+            mkdir "..\..\perf-results\single-op-dml\!REL!" 2>nul
+            echo === Perf [MorphiZen]: !REL!%%~nxM ===
             onnxruntime_perf_test.exe ^
               --plugin_ep_libs "MorphiZenExecutionProvider|onnxruntime_morphizen_ep.dll" ^
               --plugin_eps "MorphiZenExecutionProvider" ^
@@ -185,6 +186,14 @@ jobs:
               -t %PERF_DURATION% -c 1 -s -I ^
               "%%M" > "..\..\perf-results\single-op\!REL!%%~nxM.txt" 2>&1
             type "..\..\perf-results\single-op\!REL!%%~nxM.txt"
+            if errorlevel 1 set FAILED=1
+            echo === Perf [DML]: !REL!%%~nxM ===
+            onnxruntime_perf_test.exe ^
+              -e dml ^
+              -C "ep.dml.disable_graph_fusion|1" ^
+              -t %PERF_DURATION% -c 1 -s -I ^
+              "%%M" > "..\..\perf-results\single-op-dml\!REL!%%~nxM.txt" 2>&1
+            type "..\..\perf-results\single-op-dml\!REL!%%~nxM.txt"
             if errorlevel 1 set FAILED=1
           )
           exit /b !FAILED!
@@ -272,7 +281,8 @@ jobs:
             set "MDIR=%%~dpM"
             set "REL=!MDIR:%MODEL_DIR%\=!"
             mkdir "..\..\perf-results\full-model\!REL!" 2>nul
-            echo === Perf: !REL!%%~nxM ===
+            mkdir "..\..\perf-results\full-model-dml\!REL!" 2>nul
+            echo === Perf [MorphiZen]: !REL!%%~nxM ===
             onnxruntime_perf_test.exe ^
               --plugin_ep_libs "MorphiZenExecutionProvider|onnxruntime_morphizen_ep.dll" ^
               --plugin_eps "MorphiZenExecutionProvider" ^
@@ -280,6 +290,14 @@ jobs:
               -t %PERF_DURATION% -c 1 -s -I ^
               "%%M" > "..\..\perf-results\full-model\!REL!%%~nxM.txt" 2>&1
             type "..\..\perf-results\full-model\!REL!%%~nxM.txt"
+            if errorlevel 1 set FAILED=1
+            echo === Perf [DML]: !REL!%%~nxM ===
+            onnxruntime_perf_test.exe ^
+              -e dml ^
+              -C "ep.dml.disable_graph_fusion|1" ^
+              -t %PERF_DURATION% -c 1 -s -I ^
+              "%%M" > "..\..\perf-results\full-model-dml\!REL!%%~nxM.txt" 2>&1
+            type "..\..\perf-results\full-model-dml\!REL!%%~nxM.txt"
             if errorlevel 1 set FAILED=1
           )
           exit /b !FAILED!
@@ -421,14 +439,18 @@ jobs:
           # --- Build markdown summary ---
           $summary = "## GPU Performance & Accuracy Test Results`n`n"
           $opPerf = Get-PerfTable "perf-results/single-op" "Single-Op Performance (MorphiZen EP)"
+          $opPerfDml = Get-PerfTable "perf-results/single-op-dml" "Single-Op Performance (DirectML EP)"
           $opL2 = Get-L2Table "l2-results/single-op" "Single-Op Accuracy (EP vs CPU)"
           $fullPerf = Get-PerfTable "perf-results/full-model" "Full Model Performance (MorphiZen EP)"
+          $fullPerfDml = Get-PerfTable "perf-results/full-model-dml" "Full Model Performance (DirectML EP)"
           $fullL2 = Get-L2Table "l2-results/full-model" "Full Model Accuracy (EP vs CPU)"
           if ($opPerf) { $summary += $opPerf }
+          if ($opPerfDml) { $summary += $opPerfDml }
           if ($opL2) { $summary += $opL2 }
           if ($fullPerf) { $summary += $fullPerf }
+          if ($fullPerfDml) { $summary += $fullPerfDml }
           if ($fullL2) { $summary += $fullL2 }
-          if (-not $opPerf -and -not $opL2 -and -not $fullPerf -and -not $fullL2) {
+          if (-not $opPerf -and -not $opPerfDml -and -not $opL2 -and -not $fullPerf -and -not $fullPerfDml -and -not $fullL2) {
             $summary += "> No test results collected.`n"
           }
           $summary += "`nL2 threshold: $threshold | Run: [${{ github.run_number }}]($runUrl) | Commit: ``$sha```n"
@@ -436,7 +458,7 @@ jobs:
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $summary
 
           # --- Generate JSON result files ---
-          function Collect-PerfJson($dir, $category) {
+          function Collect-PerfJson($dir, $category, $epName) {
             $entries = @()
             if (-not (Test-Path $dir)) { return $entries }
             $files = Get-ChildItem $dir -Recurse -Filter "*.txt" -ErrorAction SilentlyContinue
@@ -447,6 +469,7 @@ jobs:
               $avgMatch = [regex]::Match($content, 'Average inference time cost:\s+([\d.]+)\s+ms')
               $entry = [ordered]@{
                 category   = $category
+                ep_name    = $epName
                 model_name = $meta.model_name
                 file       = $meta.file
                 qps        = if ($qpsMatch.Success) { [double]$qpsMatch.Groups[1].Value } else { $null }
@@ -488,8 +511,10 @@ jobs:
           }
 
           $perfAll  = @()
-          $perfAll += Collect-PerfJson "perf-results/single-op" "single-op"
-          $perfAll += Collect-PerfJson "perf-results/full-model" "full-model"
+          $perfAll += Collect-PerfJson "perf-results/single-op" "single-op" "MorphiZenExecutionProvider"
+          $perfAll += Collect-PerfJson "perf-results/single-op-dml" "single-op" "DmlExecutionProvider"
+          $perfAll += Collect-PerfJson "perf-results/full-model" "full-model" "MorphiZenExecutionProvider"
+          $perfAll += Collect-PerfJson "perf-results/full-model-dml" "full-model" "DmlExecutionProvider"
 
           $l2All  = @()
           $l2All += Collect-L2Json "l2-results/single-op" "single-op"
@@ -498,7 +523,6 @@ jobs:
           New-Item -ItemType Directory -Force -Path "json-results" | Out-Null
 
           $perfJson = [ordered]@{
-            ep_name   = "MorphiZenExecutionProvider"
             timestamp = $timestamp
             commit    = $sha
             results   = @($perfAll)

--- a/.github/workflows/gpu-perf-accuracy-test.yml
+++ b/.github/workflows/gpu-perf-accuracy-test.yml
@@ -68,13 +68,26 @@ jobs:
       # Clean up leftover processes and directories from previous runs
       # -----------------------------------------------------------------
       - name: Clean workspace
-        shell: cmd
+        shell: pwsh
         run: |
-          taskkill /f /im hip-onnx-runner.exe >nul 2>&1 || ver >nul
-          taskkill /f /im onnxruntime_perf_test.exe >nul 2>&1 || ver >nul
-          if exist gpu-test-package rd /s /q gpu-test-package
-          if exist l2-results rd /s /q l2-results
-          if exist perf-results rd /s /q perf-results
+          foreach ($proc in @("hip-onnx-runner", "onnxruntime_perf_test")) {
+            Get-Process $proc -ErrorAction SilentlyContinue |
+              Stop-Process -Force -ErrorAction SilentlyContinue
+          }
+          Start-Sleep -Seconds 3
+          foreach ($dir in @("gpu-test-package", "l2-results", "perf-results", "json-results")) {
+            if (Test-Path $dir) {
+              for ($i = 0; $i -lt 5; $i++) {
+                Remove-Item $dir -Recurse -Force -ErrorAction SilentlyContinue
+                if (-not (Test-Path $dir)) { break }
+                Write-Host "Retry $($i+1): waiting for $dir to be released..."
+                Start-Sleep -Seconds 2
+              }
+              if (Test-Path $dir) {
+                Write-Warning "$dir could not be fully removed"
+              }
+            }
+          }
 
       # -----------------------------------------------------------------
       # Download the pre-built gpu-test-package artifact from the
@@ -110,6 +123,7 @@ jobs:
           if_no_artifact_found: fail
 
       - name: Verify package contents
+        id: verify-package
         shell: cmd
         run: |
           if not exist gpu-test-package\bin\hip-onnx-runner.exe (
@@ -127,6 +141,7 @@ jobs:
       # TheRock HIP runtime (required by MorphiZen EP at inference time)
       # -----------------------------------------------------------------
       - name: Download & extract TheRock
+        id: setup-therock
         shell: powershell
         run: |
           $dist = "${{ runner.workspace }}\therock-dist"
@@ -142,15 +157,11 @@ jobs:
       #  Models: runner-local test-models\single-op\ directory
       # =================================================================
       - name: Run single-op perf tests
-        if: always()
+        if: always() && steps.verify-package.outcome == 'success' && steps.setup-therock.outcome == 'success'
         timeout-minutes: 30
         shell: cmd
         run: |
           setlocal enabledelayedexpansion
-          if not exist "gpu-test-package\bin" (
-            echo [SKIP] gpu-test-package not found, artifact download may have failed
-            exit /b 0
-          )
           set THEROCK_DIST=${{ runner.workspace }}\therock-dist
           set PATH=${{ runner.workspace }}\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
           set LIB=%CD%\gpu-test-package\lib;${{ runner.workspace }}\therock-dist\lib
@@ -188,15 +199,11 @@ jobs:
       #  EP vs CPU comparison for each op model
       # =================================================================
       - name: Run single-op L2 accuracy tests
-        if: always()
+        if: always() && steps.verify-package.outcome == 'success' && steps.setup-therock.outcome == 'success'
         timeout-minutes: 30
         shell: cmd
         run: |
           setlocal enabledelayedexpansion
-          if not exist "gpu-test-package\bin" (
-            echo [SKIP] gpu-test-package not found, artifact download may have failed
-            exit /b 0
-          )
           set THEROCK_DIST=${{ runner.workspace }}\therock-dist
           set PATH=${{ runner.workspace }}\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
           set LIB=%CD%\gpu-test-package\lib;${{ runner.workspace }}\therock-dist\lib
@@ -242,15 +249,11 @@ jobs:
       #  Models: runner-local test-models\full-model\ directory
       # =================================================================
       - name: Run full model perf tests
-        if: always()
+        if: always() && steps.verify-package.outcome == 'success' && steps.setup-therock.outcome == 'success'
         timeout-minutes: 60
         shell: cmd
         run: |
           setlocal enabledelayedexpansion
-          if not exist "gpu-test-package\bin" (
-            echo [SKIP] gpu-test-package not found, artifact download may have failed
-            exit /b 0
-          )
           set THEROCK_DIST=${{ runner.workspace }}\therock-dist
           set PATH=${{ runner.workspace }}\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
           set LIB=%CD%\gpu-test-package\lib;${{ runner.workspace }}\therock-dist\lib
@@ -288,15 +291,15 @@ jobs:
       #  Disabled by default — enable via workflow_dispatch input
       # =================================================================
       - name: Run full model L2 accuracy tests
-        if: always() && (github.event.inputs.enable_full_model_l2 == 'true')
+        if: >-
+          always() &&
+          steps.verify-package.outcome == 'success' &&
+          steps.setup-therock.outcome == 'success' &&
+          github.event.inputs.enable_full_model_l2 == 'true'
         timeout-minutes: 60
         shell: cmd
         run: |
           setlocal enabledelayedexpansion
-          if not exist "gpu-test-package\bin" (
-            echo [SKIP] gpu-test-package not found, artifact download may have failed
-            exit /b 0
-          )
           set THEROCK_DIST=${{ runner.workspace }}\therock-dist
           set PATH=${{ runner.workspace }}\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
           set LIB=%CD%\gpu-test-package\lib;${{ runner.workspace }}\therock-dist\lib

--- a/.github/workflows/gpu-perf-accuracy-test.yml
+++ b/.github/workflows/gpu-perf-accuracy-test.yml
@@ -8,35 +8,10 @@ on:
   schedule:
     - cron: '0 18 * * *'  # daily at UTC 18:00 (CST 02:00)
 
-  workflow_run:
-    workflows: ["Windows Build"]
-    branches: [main]
-    types: [completed]
-
   workflow_dispatch:
-    inputs:
-      run_id:
-        description: >
-          Build run ID to download gpu-test-package from.
-          Leave empty to use the latest successful build on source_branch.
-        required: false
-        type: string
-      source_branch:
-        description: "Branch to download gpu-test-package from (default: main)"
-        required: false
-        default: "main"
-        type: string
-      perf_duration:
-        description: "Perf test duration per model (seconds)"
-        required: false
-        default: "30"
-        type: string
-
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -44,20 +19,15 @@ permissions:
 
 jobs:
   gpu-perf-accuracy:
-    # Skip if the triggering Windows Build failed
-    if: >-
-      github.event_name != 'workflow_run' ||
-      github.event.workflow_run.conclusion == 'success'
     runs-on: StrixHalo
 
     permissions:
       contents: read
-      pull-requests: write
       actions: read
 
     env:
       THEROCK_VERSION: therock-dist-windows-gfx1151-7.11.0
-      PERF_DURATION: ${{ github.event.inputs.perf_duration || '30' }}
+      PERF_DURATION: "30"
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
 
     steps:
@@ -88,33 +58,15 @@ jobs:
 
       # -----------------------------------------------------------------
       # Download the pre-built gpu-test-package artifact from the
-      # Windows Build workflow. Supports three trigger modes:
-      #   workflow_run  → use the triggering run's ID
-      #   workflow_dispatch with run_id → use the specified ID
-      #   workflow_dispatch without run_id → latest successful main build
+      # latest successful main build of the Windows Build workflow.
       # -----------------------------------------------------------------
-      - name: Resolve source branch
-        id: resolve-branch
-        shell: pwsh
-        run: |
-          $branch = "${{ github.event.inputs.source_branch }}"
-          if (-not $branch) {
-            if ("${{ github.event.workflow_run.head_branch }}") {
-              $branch = "${{ github.event.workflow_run.head_branch }}"
-            } else {
-              $branch = "main"
-            }
-          }
-          "branch=$branch" | Out-File -Append $env:GITHUB_OUTPUT
-          Write-Host "Resolved source branch: $branch"
-
       - name: Download gpu-test-package
         uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
         with:
           workflow: windows-build.yml
           name: gpu-test-package
           path: gpu-test-package
-          run_id: '23830153026'  # DEBUG: hardcoded build with x64 DirectML fix
+          branch: main
           workflow_conclusion: success
           if_no_artifact_found: fail
 
@@ -374,7 +326,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           $runUrl = "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          $rawSha = "${{ github.event.workflow_run.head_sha || github.sha }}"
+          $rawSha = "${{ github.sha }}"
           $sha = $rawSha.Substring(0, [Math]::Min(7, $rawSha.Length))
           $threshold = 0.01
           $timestamp = (Get-Date -Format "o")
@@ -558,35 +510,6 @@ jobs:
           Set-Content -Path "json-results/l2-results.json" -Value $l2Json
           Write-Host "=== l2-results.json ==="
           Write-Host $l2Json
-
-          # --- Post PR comment if triggered by workflow_run on a PR ---
-          $prBranch = "${{ github.event.workflow_run.head_branch }}"
-          if ($prBranch -and $prBranch -ne "main") {
-            $prsJson = gh pr list -R "${{ github.repository }}" --head "$prBranch" --json number --limit 1 2>$null
-            if ($LASTEXITCODE -eq 0 -and $prsJson) {
-              $prs = $prsJson | ConvertFrom-Json
-              if ($prs.Count -gt 0) {
-                $prNumber = $prs[0].number
-                $marker = "<!-- morphizen-gpu-test-results -->"
-                $body = "$marker`n$summary"
-                $commentsJson = gh api "repos/${{ github.repository }}/issues/$prNumber/comments" 2>$null
-                $ghOk = ($LASTEXITCODE -eq 0)
-                $existing = $null
-                if ($ghOk -and $commentsJson) {
-                  $comments = $commentsJson | ConvertFrom-Json
-                  $found = $comments | Where-Object { $_.body -and $_.body.StartsWith($marker) } | Select-Object -First 1
-                  if ($found) { $existing = $found.id }
-                }
-                if ($ghOk -and $existing) {
-                  Write-Host "Updating existing PR comment $existing"
-                  gh api --method PATCH "repos/${{ github.repository }}/issues/comments/$existing" -f body="$body"
-                } elseif ($ghOk) {
-                  Write-Host "Creating new PR comment on #$prNumber"
-                  gh pr comment $prNumber -R "${{ github.repository }}" --body "$body"
-                }
-              }
-            }
-          }
 
       - name: Upload JSON results
         if: always()

--- a/.github/workflows/gpu-perf-accuracy-test.yml
+++ b/.github/workflows/gpu-perf-accuracy-test.yml
@@ -85,19 +85,18 @@ jobs:
       # -----------------------------------------------------------------
       - name: Resolve source branch
         id: resolve-branch
-        shell: bash
+        shell: pwsh
         run: |
-          if [ -n "${{ github.event.inputs.source_branch }}" ]; then
-            BRANCH="${{ github.event.inputs.source_branch }}"
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            BRANCH="feat/improve-test-runner"
-          elif [ -n "${{ github.event.workflow_run.head_branch }}" ]; then
-            BRANCH="${{ github.event.workflow_run.head_branch }}"
-          else
-            BRANCH="main"
-          fi
-          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
-          echo "Resolved source branch: $BRANCH"
+          $branch = "${{ github.event.inputs.source_branch }}"
+          if (-not $branch) {
+            if ("${{ github.event.workflow_run.head_branch }}") {
+              $branch = "${{ github.event.workflow_run.head_branch }}"
+            } else {
+              $branch = "main"
+            }
+          }
+          "branch=$branch" | Out-File -Append $env:GITHUB_OUTPUT
+          Write-Host "Resolved source branch: $branch"
 
       - name: Download gpu-test-package
         uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
@@ -148,6 +147,10 @@ jobs:
         shell: cmd
         run: |
           setlocal enabledelayedexpansion
+          if not exist "gpu-test-package\bin" (
+            echo [SKIP] gpu-test-package not found, artifact download may have failed
+            exit /b 0
+          )
           set THEROCK_DIST=${{ runner.workspace }}\therock-dist
           set PATH=${{ runner.workspace }}\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
           set LIB=%CD%\gpu-test-package\lib;${{ runner.workspace }}\therock-dist\lib
@@ -190,6 +193,10 @@ jobs:
         shell: cmd
         run: |
           setlocal enabledelayedexpansion
+          if not exist "gpu-test-package\bin" (
+            echo [SKIP] gpu-test-package not found, artifact download may have failed
+            exit /b 0
+          )
           set THEROCK_DIST=${{ runner.workspace }}\therock-dist
           set PATH=${{ runner.workspace }}\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
           set LIB=%CD%\gpu-test-package\lib;${{ runner.workspace }}\therock-dist\lib
@@ -240,6 +247,10 @@ jobs:
         shell: cmd
         run: |
           setlocal enabledelayedexpansion
+          if not exist "gpu-test-package\bin" (
+            echo [SKIP] gpu-test-package not found, artifact download may have failed
+            exit /b 0
+          )
           set THEROCK_DIST=${{ runner.workspace }}\therock-dist
           set PATH=${{ runner.workspace }}\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
           set LIB=%CD%\gpu-test-package\lib;${{ runner.workspace }}\therock-dist\lib
@@ -282,6 +293,10 @@ jobs:
         shell: cmd
         run: |
           setlocal enabledelayedexpansion
+          if not exist "gpu-test-package\bin" (
+            echo [SKIP] gpu-test-package not found, artifact download may have failed
+            exit /b 0
+          )
           set THEROCK_DIST=${{ runner.workspace }}\therock-dist
           set PATH=${{ runner.workspace }}\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
           set LIB=%CD%\gpu-test-package\lib;${{ runner.workspace }}\therock-dist\lib

--- a/.github/workflows/gpu-perf-accuracy-test.yml
+++ b/.github/workflows/gpu-perf-accuracy-test.yml
@@ -115,8 +115,8 @@ jobs:
           workflow: windows-build.yml
           name: gpu-test-package
           path: gpu-test-package
-          run_id: ${{ github.event.inputs.run_id || github.event.workflow_run.id || '' }}
-          branch: ${{ steps.resolve-branch.outputs.branch }}
+          run_id: '23830153026'  # DEBUG: hardcoded build with x64 DirectML fix
+          branch: feat/gpu-perf-accuracy-ci
           workflow_conclusion: success
           if_no_artifact_found: fail
 
@@ -152,7 +152,7 @@ jobs:
 
       # =================================================================
       #  SINGLE-OP PERFORMANCE TESTS
-      #  Models: runner-local test-models\single-op\ directory
+      #  Traverse test-models\<family>\* — skip full_model and _dyn
       # =================================================================
       - name: Run single-op perf tests
         if: always() && steps.verify-package.outcome == 'success' && steps.setup-therock.outcome == 'success'
@@ -163,47 +163,50 @@ jobs:
           set THEROCK_DIST=${{ runner.workspace }}\therock-dist
           set PATH=${{ runner.workspace }}\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
           set LIB=%CD%\gpu-test-package\lib;${{ runner.workspace }}\therock-dist\lib
-          set OP_MODEL_DIR=${{ runner.workspace }}\test-models\single-op
-          if not exist "%OP_MODEL_DIR%" (
-            echo [SKIP] Single-op model directory not found: %OP_MODEL_DIR%
-            exit /b 0
-          )
-          set FOUND=0
-          for /r "%OP_MODEL_DIR%" %%M in (*.onnx) do set FOUND=1
-          if "!FOUND!"=="0" (
-            echo [SKIP] No .onnx models found in %OP_MODEL_DIR%
+          set ROOT=${{ runner.workspace }}\test-models
+          if not exist "%ROOT%" (
+            echo [SKIP] test-models directory not found: %ROOT%
             exit /b 0
           )
           set FAILED=0
           cd gpu-test-package\bin
-          for /r "%OP_MODEL_DIR%" %%M in (*.onnx) do (
-            set "MDIR=%%~dpM"
-            set "REL=!MDIR:%OP_MODEL_DIR%\=!"
-            mkdir "..\..\perf-results\single-op\!REL!" 2>nul
-            mkdir "..\..\perf-results\single-op-dml\!REL!" 2>nul
-            echo === Perf [MorphiZen]: !REL!%%~nxM ===
-            onnxruntime_perf_test.exe ^
-              --plugin_ep_libs "MorphiZenExecutionProvider|onnxruntime_morphizen_ep.dll" ^
-              --plugin_eps "MorphiZenExecutionProvider" ^
-              --plugin_ep_options "config_file|..\morphizen_config.json" ^
-              -t %PERF_DURATION% -c 1 -s -I ^
-              "%%M" > "..\..\perf-results\single-op\!REL!%%~nxM.txt" 2>&1
-            type "..\..\perf-results\single-op\!REL!%%~nxM.txt"
-            if errorlevel 1 set FAILED=1
-            echo === Perf [DML]: !REL!%%~nxM ===
-            onnxruntime_perf_test.exe ^
-              -e dml ^
-              -C "ep.dml.disable_graph_fusion|1" ^
-              -t %PERF_DURATION% -c 1 -s -I ^
-              "%%M" > "..\..\perf-results\single-op-dml\!REL!%%~nxM.txt" 2>&1
-            type "..\..\perf-results\single-op-dml\!REL!%%~nxM.txt"
-            if errorlevel 1 set FAILED=1
+          for /r "%ROOT%" %%M in (*.onnx) do (
+            if "%%~xM"==".onnx" (
+              set "FN=%%~nM"
+              set "CHECK=!FN:_dyn=!"
+              if "!CHECK!"=="!FN!" (
+                set "MP=%%~dpM"
+                set "MPCHECK=!MP:\full_model\=!"
+                if "!MPCHECK!"=="!MP!" (
+                  set "REL=!MP:%ROOT%\=!"
+                  mkdir "..\..\perf-results\single-op\!REL!" 2>nul
+                  mkdir "..\..\perf-results\single-op-dml\!REL!" 2>nul
+                  echo === Perf [MorphiZen]: !REL!%%~nxM ===
+                  onnxruntime_perf_test.exe ^
+                    --plugin_ep_libs "MorphiZenExecutionProvider|onnxruntime_morphizen_ep.dll" ^
+                    --plugin_eps "MorphiZenExecutionProvider" ^
+                    --plugin_ep_options "config_file|..\morphizen_config.json" ^
+                    -t %PERF_DURATION% -c 1 -s -I ^
+                    "%%M" > "..\..\perf-results\single-op\!REL!%%~nxM.txt" 2>&1
+                  type "..\..\perf-results\single-op\!REL!%%~nxM.txt"
+                  if errorlevel 1 set FAILED=1
+                  echo === Perf [DML]: !REL!%%~nxM ===
+                  onnxruntime_perf_test.exe ^
+                    -e dml ^
+                    -C "ep.dml.disable_graph_fusion|1" ^
+                    -t %PERF_DURATION% -c 1 -s -I ^
+                    "%%M" > "..\..\perf-results\single-op-dml\!REL!%%~nxM.txt" 2>&1
+                  type "..\..\perf-results\single-op-dml\!REL!%%~nxM.txt"
+                  if errorlevel 1 set FAILED=1
+                )
+              )
+            )
           )
           exit /b 0
 
       # =================================================================
       #  SINGLE-OP ACCURACY TESTS (L2)
-      #  EP vs CPU comparison for each op model
+      #  Traverse test-models\<family>\* — skip full_model and _dyn
       # =================================================================
       - name: Run single-op L2 accuracy tests
         if: always() && steps.verify-package.outcome == 'success' && steps.setup-therock.outcome == 'success'
@@ -214,41 +217,44 @@ jobs:
           set THEROCK_DIST=${{ runner.workspace }}\therock-dist
           set PATH=${{ runner.workspace }}\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
           set LIB=%CD%\gpu-test-package\lib;${{ runner.workspace }}\therock-dist\lib
-          set OP_MODEL_DIR=${{ runner.workspace }}\test-models\single-op
-          if not exist "%OP_MODEL_DIR%" (
-            echo [SKIP] Single-op model directory not found: %OP_MODEL_DIR%
-            exit /b 0
-          )
-          set FOUND=0
-          for /r "%OP_MODEL_DIR%" %%M in (*.onnx) do set FOUND=1
-          if "!FOUND!"=="0" (
-            echo [SKIP] No .onnx models found in %OP_MODEL_DIR%
+          set ROOT=${{ runner.workspace }}\test-models
+          if not exist "%ROOT%" (
+            echo [SKIP] test-models directory not found: %ROOT%
             exit /b 0
           )
           set FAILED=0
           cd gpu-test-package\bin
-          for /r "%OP_MODEL_DIR%" %%M in (*.onnx) do (
-            set "MDIR=%%~dpM"
-            set "REL=!MDIR:%OP_MODEL_DIR%\=!"
-            set "OUT=..\..\l2-results\single-op\!REL!%%~nM.txt"
-            mkdir "..\..\l2-results\single-op\!REL!" 2>nul
-            echo === L2 test: !REL!%%~nxM ===
-            rd /s /q "%%~nM_o_dump" 2>nul
-            rd /s /q "%%~nM_cpu_o_dump" 2>nul
-            hip-onnx-runner.exe -m "%%M" -d 2 -s 42 > "!OUT!" 2>&1
-            if errorlevel 1 (
-              echo [ERROR] EP inference failed>> "!OUT!"
-              type "!OUT!"
-              set FAILED=1
-            ) else (
-              hip-onnx-runner.exe -m "%%M" -d 2 -s 42 -n >> "!OUT!" 2>&1
-              if errorlevel 1 (
-                echo [ERROR] CPU inference failed>> "!OUT!"
-                type "!OUT!"
-                set FAILED=1
-              ) else (
-                hip-onnx-runner.exe -L "%%~nM_o_dump,%%~nM_cpu_o_dump" >> "!OUT!" 2>&1
-                type "!OUT!"
+          for /r "%ROOT%" %%M in (*.onnx) do (
+            if "%%~xM"==".onnx" (
+              set "FN=%%~nM"
+              set "CHECK=!FN:_dyn=!"
+              if "!CHECK!"=="!FN!" (
+                set "MP=%%~dpM"
+                set "MPCHECK=!MP:\full_model\=!"
+                if "!MPCHECK!"=="!MP!" (
+                  set "REL=!MP:%ROOT%\=!"
+                  set "OUT=..\..\l2-results\single-op\!REL!%%~nM.txt"
+                  mkdir "..\..\l2-results\single-op\!REL!" 2>nul
+                  echo === L2 test: !REL!%%~nxM ===
+                  rd /s /q "%%~nM_o_dump" 2>nul
+                  rd /s /q "%%~nM_cpu_o_dump" 2>nul
+                  hip-onnx-runner.exe -m "%%M" -d 2 -s 42 > "!OUT!" 2>&1
+                  if errorlevel 1 (
+                    echo [ERROR] EP inference failed>> "!OUT!"
+                    type "!OUT!"
+                    set FAILED=1
+                  ) else (
+                    hip-onnx-runner.exe -m "%%M" -d 2 -s 42 -n >> "!OUT!" 2>&1
+                    if errorlevel 1 (
+                      echo [ERROR] CPU inference failed>> "!OUT!"
+                      type "!OUT!"
+                      set FAILED=1
+                    ) else (
+                      hip-onnx-runner.exe -L "%%~nM_o_dump,%%~nM_cpu_o_dump" >> "!OUT!" 2>&1
+                      type "!OUT!"
+                    )
+                  )
+                )
               )
             )
           )
@@ -256,7 +262,7 @@ jobs:
 
       # =================================================================
       #  FULL MODEL PERFORMANCE TESTS
-      #  Models: runner-local test-models\full-model\ directory
+      #  Traverse test-models\<family>\full_model\ — skip _dyn
       # =================================================================
       - name: Run full model perf tests
         if: always() && steps.verify-package.outcome == 'success' && steps.setup-therock.outcome == 'success'
@@ -267,47 +273,50 @@ jobs:
           set THEROCK_DIST=${{ runner.workspace }}\therock-dist
           set PATH=${{ runner.workspace }}\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
           set LIB=%CD%\gpu-test-package\lib;${{ runner.workspace }}\therock-dist\lib
-          set MODEL_DIR=${{ runner.workspace }}\test-models\full-model
-          if not exist "%MODEL_DIR%" (
-            echo [SKIP] Full model directory not found: %MODEL_DIR%
-            exit /b 0
-          )
-          set FOUND=0
-          for /r "%MODEL_DIR%" %%M in (*.onnx) do set FOUND=1
-          if "!FOUND!"=="0" (
-            echo [SKIP] No .onnx models found in %MODEL_DIR%
+          set ROOT=${{ runner.workspace }}\test-models
+          if not exist "%ROOT%" (
+            echo [SKIP] test-models directory not found: %ROOT%
             exit /b 0
           )
           set FAILED=0
           cd gpu-test-package\bin
-          for /r "%MODEL_DIR%" %%M in (*.onnx) do (
-            set "MDIR=%%~dpM"
-            set "REL=!MDIR:%MODEL_DIR%\=!"
-            mkdir "..\..\perf-results\full-model\!REL!" 2>nul
-            mkdir "..\..\perf-results\full-model-dml\!REL!" 2>nul
-            echo === Perf [MorphiZen]: !REL!%%~nxM ===
-            onnxruntime_perf_test.exe ^
-              --plugin_ep_libs "MorphiZenExecutionProvider|onnxruntime_morphizen_ep.dll" ^
-              --plugin_eps "MorphiZenExecutionProvider" ^
-              --plugin_ep_options "config_file|..\morphizen_config.json" ^
-              -t %PERF_DURATION% -c 1 -s -I ^
-              "%%M" > "..\..\perf-results\full-model\!REL!%%~nxM.txt" 2>&1
-            type "..\..\perf-results\full-model\!REL!%%~nxM.txt"
-            if errorlevel 1 set FAILED=1
-            echo === Perf [DML]: !REL!%%~nxM ===
-            onnxruntime_perf_test.exe ^
-              -e dml ^
-              -C "ep.dml.disable_graph_fusion|1" ^
-              -t %PERF_DURATION% -c 1 -s -I ^
-              "%%M" > "..\..\perf-results\full-model-dml\!REL!%%~nxM.txt" 2>&1
-            type "..\..\perf-results\full-model-dml\!REL!%%~nxM.txt"
-            if errorlevel 1 set FAILED=1
+          for /r "%ROOT%" %%M in (*.onnx) do (
+            if "%%~xM"==".onnx" (
+              set "FN=%%~nM"
+              set "CHECK=!FN:_dyn=!"
+              if "!CHECK!"=="!FN!" (
+                set "MP=%%~dpM"
+                set "MPCHECK=!MP:\full_model\=!"
+                if not "!MPCHECK!"=="!MP!" (
+                  set "REL=!MP:%ROOT%\=!"
+                  mkdir "..\..\perf-results\full-model\!REL!" 2>nul
+                  mkdir "..\..\perf-results\full-model-dml\!REL!" 2>nul
+                  echo === Perf [MorphiZen]: !REL!%%~nxM ===
+                  onnxruntime_perf_test.exe ^
+                    --plugin_ep_libs "MorphiZenExecutionProvider|onnxruntime_morphizen_ep.dll" ^
+                    --plugin_eps "MorphiZenExecutionProvider" ^
+                    --plugin_ep_options "config_file|..\morphizen_config.json" ^
+                    -t %PERF_DURATION% -c 1 -s -I ^
+                    "%%M" > "..\..\perf-results\full-model\!REL!%%~nxM.txt" 2>&1
+                  type "..\..\perf-results\full-model\!REL!%%~nxM.txt"
+                  if errorlevel 1 set FAILED=1
+                  echo === Perf [DML]: !REL!%%~nxM ===
+                  onnxruntime_perf_test.exe ^
+                    -e dml ^
+                    -C "ep.dml.disable_graph_fusion|1" ^
+                    -t %PERF_DURATION% -c 1 -s -I ^
+                    "%%M" > "..\..\perf-results\full-model-dml\!REL!%%~nxM.txt" 2>&1
+                  type "..\..\perf-results\full-model-dml\!REL!%%~nxM.txt"
+                  if errorlevel 1 set FAILED=1
+                )
+              )
+            )
           )
           exit /b 0
 
       # =================================================================
       #  FULL MODEL ACCURACY TESTS (L2)
-      #  Disabled by default — enable via workflow_dispatch input
+      #  Traverse test-models\<family>\full_model\ — skip _dyn
       # =================================================================
       - name: Run full model L2 accuracy tests
         if: always() && steps.verify-package.outcome == 'success' && steps.setup-therock.outcome == 'success'
@@ -318,41 +327,44 @@ jobs:
           set THEROCK_DIST=${{ runner.workspace }}\therock-dist
           set PATH=${{ runner.workspace }}\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
           set LIB=%CD%\gpu-test-package\lib;${{ runner.workspace }}\therock-dist\lib
-          set MODEL_DIR=${{ runner.workspace }}\test-models\full-model
-          if not exist "%MODEL_DIR%" (
-            echo [SKIP] Full model directory not found: %MODEL_DIR%
-            exit /b 0
-          )
-          set FOUND=0
-          for /r "%MODEL_DIR%" %%M in (*.onnx) do set FOUND=1
-          if "!FOUND!"=="0" (
-            echo [SKIP] No .onnx models found in %MODEL_DIR%
+          set ROOT=${{ runner.workspace }}\test-models
+          if not exist "%ROOT%" (
+            echo [SKIP] test-models directory not found: %ROOT%
             exit /b 0
           )
           set FAILED=0
           cd gpu-test-package\bin
-          for /r "%MODEL_DIR%" %%M in (*.onnx) do (
-            set "MDIR=%%~dpM"
-            set "REL=!MDIR:%MODEL_DIR%\=!"
-            set "OUT=..\..\l2-results\full-model\!REL!%%~nM.txt"
-            mkdir "..\..\l2-results\full-model\!REL!" 2>nul
-            echo === L2 test: !REL!%%~nxM ===
-            rd /s /q "%%~nM_o_dump" 2>nul
-            rd /s /q "%%~nM_cpu_o_dump" 2>nul
-            hip-onnx-runner.exe -m "%%M" -d 2 -s 42 > "!OUT!" 2>&1
-            if errorlevel 1 (
-              echo [ERROR] EP inference failed>> "!OUT!"
-              type "!OUT!"
-              set FAILED=1
-            ) else (
-              hip-onnx-runner.exe -m "%%M" -d 2 -s 42 -n >> "!OUT!" 2>&1
-              if errorlevel 1 (
-                echo [ERROR] CPU inference failed>> "!OUT!"
-                type "!OUT!"
-                set FAILED=1
-              ) else (
-                hip-onnx-runner.exe -L "%%~nM_o_dump,%%~nM_cpu_o_dump" >> "!OUT!" 2>&1
-                type "!OUT!"
+          for /r "%ROOT%" %%M in (*.onnx) do (
+            if "%%~xM"==".onnx" (
+              set "FN=%%~nM"
+              set "CHECK=!FN:_dyn=!"
+              if "!CHECK!"=="!FN!" (
+                set "MP=%%~dpM"
+                set "MPCHECK=!MP:\full_model\=!"
+                if not "!MPCHECK!"=="!MP!" (
+                  set "REL=!MP:%ROOT%\=!"
+                  set "OUT=..\..\l2-results\full-model\!REL!%%~nM.txt"
+                  mkdir "..\..\l2-results\full-model\!REL!" 2>nul
+                  echo === L2 test: !REL!%%~nxM ===
+                  rd /s /q "%%~nM_o_dump" 2>nul
+                  rd /s /q "%%~nM_cpu_o_dump" 2>nul
+                  hip-onnx-runner.exe -m "%%M" -d 2 -s 42 > "!OUT!" 2>&1
+                  if errorlevel 1 (
+                    echo [ERROR] EP inference failed>> "!OUT!"
+                    type "!OUT!"
+                    set FAILED=1
+                  ) else (
+                    hip-onnx-runner.exe -m "%%M" -d 2 -s 42 -n >> "!OUT!" 2>&1
+                    if errorlevel 1 (
+                      echo [ERROR] CPU inference failed>> "!OUT!"
+                      type "!OUT!"
+                      set FAILED=1
+                    ) else (
+                      hip-onnx-runner.exe -L "%%~nM_o_dump,%%~nM_cpu_o_dump" >> "!OUT!" 2>&1
+                      type "!OUT!"
+                    )
+                  )
+                )
               )
             )
           )
@@ -374,8 +386,8 @@ jobs:
           $timestamp = (Get-Date -Format "o")
 
           # --- Helper: extract metadata from a result file's relative path ---
-          # single-op results: <model_name>/<op_name>/<file>.txt
-          # full-model results: <model_name>/<file>.txt
+          # Result paths follow: <family>/<subcategory>/<op>/<file>.txt
+          # subcategory = single_op | single_layer | full_model | ...
           function Get-Meta($file, $categoryRoot) {
             $rel = $file.FullName.Substring($categoryRoot.Length).TrimStart('\', '/')
             $parts = $rel -split '[/\\]'

--- a/.github/workflows/gpu-perf-accuracy-test.yml
+++ b/.github/workflows/gpu-perf-accuracy-test.yml
@@ -199,7 +199,7 @@ jobs:
             type "..\..\perf-results\single-op-dml\!REL!%%~nxM.txt"
             if errorlevel 1 set FAILED=1
           )
-          exit /b !FAILED!
+          exit /b 0
 
       # =================================================================
       #  SINGLE-OP ACCURACY TESTS (L2)
@@ -252,7 +252,7 @@ jobs:
               )
             )
           )
-          exit /b !FAILED!
+          exit /b 0
 
       # =================================================================
       #  FULL MODEL PERFORMANCE TESTS
@@ -303,7 +303,7 @@ jobs:
             type "..\..\perf-results\full-model-dml\!REL!%%~nxM.txt"
             if errorlevel 1 set FAILED=1
           )
-          exit /b !FAILED!
+          exit /b 0
 
       # =================================================================
       #  FULL MODEL ACCURACY TESTS (L2)
@@ -356,7 +356,7 @@ jobs:
               )
             )
           )
-          exit /b !FAILED!
+          exit /b 0
 
       # =================================================================
       #  PUBLISH RESULTS
@@ -399,16 +399,14 @@ jobs:
               if ($meta.seq_length -ne $null) { $label += " (seq$($meta.seq_length))" }
               $content = Get-Content $f.FullName -Raw
               $qpsMatch = [regex]::Match($content, 'Number of inferences per second:\s+([\d.]+)')
-              $avgMatch = [regex]::Match($content, 'Average inference time cost:\s+([\d.]+)\s+ms')
               if ($qpsMatch.Success) {
                 $qps = "{0:F2}" -f [double]$qpsMatch.Groups[1].Value
-                $avg = if ($avgMatch.Success) { "{0:F3} ms" -f [double]$avgMatch.Groups[1].Value } else { "N/A" }
-                $rows += "| $label | $qps | $avg |`n"
+                $rows += "| $label | $qps |`n"
               } else {
-                $rows += "| $label | failed | - |`n"
+                $rows += "| $label | failed |`n"
               }
             }
-            $header = "### $title`n`n| Model | QPS | Avg Latency |`n|-------|----:|------------|`n"
+            $header = "### $title`n`n| Model | QPS |`n|-------|----:|`n"
             return $header + $rows + "`n"
           }
 
@@ -426,16 +424,15 @@ jobs:
               $errMatch = [regex]::Match($content, '\[ERROR\]\s*(.+)')
               if ($l2Match.Success) {
                 $l2val = [double]$l2Match.Groups[1].Value
-                $status = if ($l2val -le $threshold) { [char]0x2705 } else { [char]0x274C }
-                $rows += "| $label | $l2val | $status |`n"
+                $rows += "| $label | $l2val |`n"
               } elseif ($errMatch.Success) {
                 $reason = $errMatch.Groups[1].Value.Trim()
-                $rows += "| $label | $reason | $([char]0x274C) |`n"
+                $rows += "| $label | $reason |`n"
               } else {
-                $rows += "| $label | error | $([char]0x274C) |`n"
+                $rows += "| $label | error |`n"
               }
             }
-            $header = "### $title`n`n| Model | Combined L2 | Status |`n|-------|------------|--------|`n"
+            $header = "### $title`n`n| Model | Combined L2 |`n|-------|------------|`n"
             return $header + $rows + "`n"
           }
 
@@ -469,14 +466,12 @@ jobs:
               $meta = Get-Meta $f (Resolve-Path $dir).Path
               $content = Get-Content $f.FullName -Raw
               $qpsMatch = [regex]::Match($content, 'Number of inferences per second:\s+([\d.]+)')
-              $avgMatch = [regex]::Match($content, 'Average inference time cost:\s+([\d.]+)\s+ms')
               $entry = [ordered]@{
                 category   = $category
                 ep_name    = $epName
                 model_name = $meta.model_name
                 file       = $meta.file
                 qps        = if ($qpsMatch.Success) { [double]$qpsMatch.Groups[1].Value } else { $null }
-                avg_latency_ms = if ($avgMatch.Success) { [double]$avgMatch.Groups[1].Value } else { $null }
               }
               if ($meta.op_name) { $entry["op_name"] = $meta.op_name }
               if ($meta.seq_length -ne $null) { $entry["seq_length"] = $meta.seq_length }
@@ -500,11 +495,9 @@ jobs:
                 model_name = $meta.model_name
                 file       = $meta.file
                 l2         = $l2val
-                pass       = if ($l2val -ne $null) { $l2val -le $threshold } else { $false }
               }
               if ($errMatch.Success) {
                 $entry["error"] = $errMatch.Groups[1].Value.Trim()
-                $entry["pass"] = $false
               }
               if ($meta.op_name) { $entry["op_name"] = $meta.op_name }
               if ($meta.seq_length -ne $null) { $entry["seq_length"] = $meta.seq_length }

--- a/.github/workflows/gpu-perf-accuracy-test.yml
+++ b/.github/workflows/gpu-perf-accuracy-test.yml
@@ -29,9 +29,8 @@ on:
         default: false
         type: boolean
 
-  # Uncomment to enable PR-triggered runs during debugging:
-  # pull_request:
-  #   types: [opened, synchronize, reopened, ready_for_review]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.ref }}

--- a/.github/workflows/gpu-perf-accuracy-test.yml
+++ b/.github/workflows/gpu-perf-accuracy-test.yml
@@ -15,8 +15,13 @@ on:
       run_id:
         description: >
           Build run ID to download gpu-test-package from.
-          Leave empty to use the latest successful main build.
+          Leave empty to use the latest successful build on source_branch.
         required: false
+        type: string
+      source_branch:
+        description: "Branch to download gpu-test-package from (default: main)"
+        required: false
+        default: "main"
         type: string
       perf_duration:
         description: "Perf test duration per model (seconds)"
@@ -78,6 +83,22 @@ jobs:
       #   workflow_dispatch with run_id → use the specified ID
       #   workflow_dispatch without run_id → latest successful main build
       # -----------------------------------------------------------------
+      - name: Resolve source branch
+        id: resolve-branch
+        shell: bash
+        run: |
+          if [ -n "${{ github.event.inputs.source_branch }}" ]; then
+            BRANCH="${{ github.event.inputs.source_branch }}"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            BRANCH="${{ github.event.pull_request.head.ref }}"
+          elif [ -n "${{ github.event.workflow_run.head_branch }}" ]; then
+            BRANCH="${{ github.event.workflow_run.head_branch }}"
+          else
+            BRANCH="main"
+          fi
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "Resolved source branch: $BRANCH"
+
       - name: Download gpu-test-package
         uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
         with:
@@ -85,7 +106,7 @@ jobs:
           name: gpu-test-package
           path: gpu-test-package
           run_id: ${{ github.event.inputs.run_id || github.event.workflow_run.id || '' }}
-          branch: main
+          branch: ${{ steps.resolve-branch.outputs.branch }}
           workflow_conclusion: success
           if_no_artifact_found: fail
 

--- a/.github/workflows/gpu-perf-accuracy-test.yml
+++ b/.github/workflows/gpu-perf-accuracy-test.yml
@@ -147,6 +147,7 @@ jobs:
         timeout-minutes: 30
         shell: cmd
         run: |
+          setlocal enabledelayedexpansion
           set THEROCK_DIST=${{ runner.workspace }}\therock-dist
           set PATH=${{ runner.workspace }}\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
           set LIB=%CD%\gpu-test-package\lib;${{ runner.workspace }}\therock-dist\lib
@@ -157,25 +158,27 @@ jobs:
           )
           set FOUND=0
           for /r "%OP_MODEL_DIR%" %%M in (*.onnx) do set FOUND=1
-          if "%FOUND%"=="0" (
+          if "!FOUND!"=="0" (
             echo [SKIP] No .onnx models found in %OP_MODEL_DIR%
             exit /b 0
           )
-          mkdir perf-results\single-op 2>nul
           set FAILED=0
           cd gpu-test-package\bin
           for /r "%OP_MODEL_DIR%" %%M in (*.onnx) do (
-            echo === Perf: %%~nxM ===
+            set "MDIR=%%~dpM"
+            set "REL=!MDIR:%OP_MODEL_DIR%\=!"
+            mkdir "..\..\perf-results\single-op\!REL!" 2>nul
+            echo === Perf: !REL!%%~nxM ===
             onnxruntime_perf_test.exe ^
               --plugin_ep_libs "MorphiZenExecutionProvider|onnxruntime_morphizen_ep.dll" ^
               --plugin_eps "MorphiZenExecutionProvider" ^
               --plugin_ep_options "config_file|..\morphizen_config.json" ^
               -t %PERF_DURATION% -c 1 -s -I ^
-              "%%M" > "..\..\perf-results\single-op\%%~nxM.txt" 2>&1
-            type "..\..\perf-results\single-op\%%~nxM.txt"
+              "%%M" > "..\..\perf-results\single-op\!REL!%%~nxM.txt" 2>&1
+            type "..\..\perf-results\single-op\!REL!%%~nxM.txt"
             if errorlevel 1 set FAILED=1
           )
-          exit /b %FAILED%
+          exit /b !FAILED!
 
       # =================================================================
       #  SINGLE-OP ACCURACY TESTS (L2)
@@ -186,6 +189,7 @@ jobs:
         timeout-minutes: 30
         shell: cmd
         run: |
+          setlocal enabledelayedexpansion
           set THEROCK_DIST=${{ runner.workspace }}\therock-dist
           set PATH=${{ runner.workspace }}\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
           set LIB=%CD%\gpu-test-package\lib;${{ runner.workspace }}\therock-dist\lib
@@ -196,15 +200,17 @@ jobs:
           )
           set FOUND=0
           for /r "%OP_MODEL_DIR%" %%M in (*.onnx) do set FOUND=1
-          if "%FOUND%"=="0" (
+          if "!FOUND!"=="0" (
             echo [SKIP] No .onnx models found in %OP_MODEL_DIR%
             exit /b 0
           )
-          mkdir l2-results\single-op 2>nul
           set FAILED=0
           cd gpu-test-package\bin
           for /r "%OP_MODEL_DIR%" %%M in (*.onnx) do (
-            echo === L2 test: %%~nxM ===
+            set "MDIR=%%~dpM"
+            set "REL=!MDIR:%OP_MODEL_DIR%\=!"
+            mkdir "..\..\l2-results\single-op\!REL!" 2>nul
+            echo === L2 test: !REL!%%~nxM ===
             rd /s /q "%%~nM_o_dump" 2>nul
             rd /s /q "%%~nM_cpu_o_dump" 2>nul
             hip-onnx-runner.exe -m "%%M" -d 2 -s 42
@@ -217,12 +223,12 @@ jobs:
                 echo [ERROR] CPU inference failed for %%~nxM
                 set FAILED=1
               ) else (
-                hip-onnx-runner.exe -L "%%~nM_o_dump,%%~nM_cpu_o_dump" > "..\..\l2-results\single-op\%%~nM.txt" 2>&1
-                type "..\..\l2-results\single-op\%%~nM.txt"
+                hip-onnx-runner.exe -L "%%~nM_o_dump,%%~nM_cpu_o_dump" > "..\..\l2-results\single-op\!REL!%%~nM.txt" 2>&1
+                type "..\..\l2-results\single-op\!REL!%%~nM.txt"
               )
             )
           )
-          exit /b %FAILED%
+          exit /b !FAILED!
 
       # =================================================================
       #  FULL MODEL PERFORMANCE TESTS
@@ -233,6 +239,7 @@ jobs:
         timeout-minutes: 60
         shell: cmd
         run: |
+          setlocal enabledelayedexpansion
           set THEROCK_DIST=${{ runner.workspace }}\therock-dist
           set PATH=${{ runner.workspace }}\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
           set LIB=%CD%\gpu-test-package\lib;${{ runner.workspace }}\therock-dist\lib
@@ -243,25 +250,27 @@ jobs:
           )
           set FOUND=0
           for /r "%MODEL_DIR%" %%M in (*.onnx) do set FOUND=1
-          if "%FOUND%"=="0" (
+          if "!FOUND!"=="0" (
             echo [SKIP] No .onnx models found in %MODEL_DIR%
             exit /b 0
           )
-          mkdir perf-results\full-model 2>nul
           set FAILED=0
           cd gpu-test-package\bin
           for /r "%MODEL_DIR%" %%M in (*.onnx) do (
-            echo === Perf: %%~nxM ===
+            set "MDIR=%%~dpM"
+            set "REL=!MDIR:%MODEL_DIR%\=!"
+            mkdir "..\..\perf-results\full-model\!REL!" 2>nul
+            echo === Perf: !REL!%%~nxM ===
             onnxruntime_perf_test.exe ^
               --plugin_ep_libs "MorphiZenExecutionProvider|onnxruntime_morphizen_ep.dll" ^
               --plugin_eps "MorphiZenExecutionProvider" ^
               --plugin_ep_options "config_file|..\morphizen_config.json" ^
               -t %PERF_DURATION% -c 1 -s -I ^
-              "%%M" > "..\..\perf-results\full-model\%%~nxM.txt" 2>&1
-            type "..\..\perf-results\full-model\%%~nxM.txt"
+              "%%M" > "..\..\perf-results\full-model\!REL!%%~nxM.txt" 2>&1
+            type "..\..\perf-results\full-model\!REL!%%~nxM.txt"
             if errorlevel 1 set FAILED=1
           )
-          exit /b %FAILED%
+          exit /b !FAILED!
 
       # =================================================================
       #  FULL MODEL ACCURACY TESTS (L2)
@@ -272,6 +281,7 @@ jobs:
         timeout-minutes: 60
         shell: cmd
         run: |
+          setlocal enabledelayedexpansion
           set THEROCK_DIST=${{ runner.workspace }}\therock-dist
           set PATH=${{ runner.workspace }}\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
           set LIB=%CD%\gpu-test-package\lib;${{ runner.workspace }}\therock-dist\lib
@@ -282,15 +292,17 @@ jobs:
           )
           set FOUND=0
           for /r "%MODEL_DIR%" %%M in (*.onnx) do set FOUND=1
-          if "%FOUND%"=="0" (
+          if "!FOUND!"=="0" (
             echo [SKIP] No .onnx models found in %MODEL_DIR%
             exit /b 0
           )
-          mkdir l2-results\full-model 2>nul
           set FAILED=0
           cd gpu-test-package\bin
           for /r "%MODEL_DIR%" %%M in (*.onnx) do (
-            echo === L2 test: %%~nxM ===
+            set "MDIR=%%~dpM"
+            set "REL=!MDIR:%MODEL_DIR%\=!"
+            mkdir "..\..\l2-results\full-model\!REL!" 2>nul
+            echo === L2 test: !REL!%%~nxM ===
             rd /s /q "%%~nM_o_dump" 2>nul
             rd /s /q "%%~nM_cpu_o_dump" 2>nul
             hip-onnx-runner.exe -m "%%M" -d 2 -s 42
@@ -303,12 +315,12 @@ jobs:
                 echo [ERROR] CPU inference failed for %%~nxM
                 set FAILED=1
               ) else (
-                hip-onnx-runner.exe -L "%%~nM_o_dump,%%~nM_cpu_o_dump" > "..\..\l2-results\full-model\%%~nM.txt" 2>&1
-                type "..\..\l2-results\full-model\%%~nM.txt"
+                hip-onnx-runner.exe -L "%%~nM_o_dump,%%~nM_cpu_o_dump" > "..\..\l2-results\full-model\!REL!%%~nM.txt" 2>&1
+                type "..\..\l2-results\full-model\!REL!%%~nM.txt"
               )
             )
           )
-          exit /b %FAILED%
+          exit /b !FAILED!
 
       # =================================================================
       #  PUBLISH RESULTS
@@ -320,75 +332,166 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           $runUrl = "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          $sha = "${{ github.event.workflow_run.head_sha || github.sha }}".Substring(0, 7)
+          $rawSha = "${{ github.event.workflow_run.head_sha || github.sha }}"
+          $sha = $rawSha.Substring(0, [Math]::Min(7, $rawSha.Length))
           $threshold = 0.01
+          $timestamp = (Get-Date -Format "o")
 
-          # --- Helper: parse perf results from a directory ---
+          # --- Helper: extract metadata from a result file's relative path ---
+          # single-op results: <model_name>/<op_name>/<file>.txt
+          # full-model results: <model_name>/<file>.txt
+          function Get-Meta($file, $categoryRoot) {
+            $rel = $file.FullName.Substring($categoryRoot.Length).TrimStart('\', '/')
+            $parts = $rel -split '[/\\]'
+            $modelName = if ($parts.Count -ge 2) { $parts[0] } else { "unknown" }
+            $opName = if ($parts.Count -ge 3) { $parts[$parts.Count - 2] } else { $null }
+            $fileName = $parts[-1] -replace '\.txt$', ''
+            $seqMatch = [regex]::Match($fileName, '[_-]seq(\d+)')
+            $seqLen = if ($seqMatch.Success) { [int]$seqMatch.Groups[1].Value } else { $null }
+            return @{ model_name = $modelName; op_name = $opName; seq_length = $seqLen; file = $fileName }
+          }
+
+          # --- Helper: build markdown table from result files (recursive) ---
           function Get-PerfTable($dir, $title) {
-            $rows = ""
-            $files = Get-ChildItem "$dir/*.txt" -ErrorAction SilentlyContinue
+            if (-not (Test-Path $dir)) { return "" }
+            $files = Get-ChildItem $dir -Recurse -Filter "*.txt" -ErrorAction SilentlyContinue
             if (-not $files) { return "" }
+            $rows = ""
             foreach ($f in $files) {
-              $model = ($f.BaseName -replace '\.onnx$', '')
+              $meta = Get-Meta $f (Resolve-Path $dir).Path
+              $label = if ($meta.op_name) { "$($meta.model_name) / $($meta.op_name)" } else { $meta.model_name }
+              if ($meta.seq_length -ne $null) { $label += " (seq$($meta.seq_length))" }
               $content = Get-Content $f.FullName -Raw
               $qpsMatch = [regex]::Match($content, 'Number of inferences per second:\s+([\d.]+)')
               $avgMatch = [regex]::Match($content, 'Average inference time cost:\s+([\d.]+)\s+ms')
               if ($qpsMatch.Success) {
                 $qps = "{0:F2}" -f [double]$qpsMatch.Groups[1].Value
-                $avg = if ($avgMatch.Success) { "{0:F3}" -f [double]$avgMatch.Groups[1].Value } else { "N/A" }
-                $rows += "| $model | $qps | $avg ms |`n"
+                $avg = if ($avgMatch.Success) { "{0:F3} ms" -f [double]$avgMatch.Groups[1].Value } else { "N/A" }
+                $rows += "| $label | $qps | $avg |`n"
               } else {
-                $rows += "| $model | failed | - |`n"
+                $rows += "| $label | failed | - |`n"
               }
             }
-            if (-not $rows) { return "" }
             $header = "### $title`n`n| Model | QPS | Avg Latency |`n|-------|----:|------------|`n"
             return $header + $rows + "`n"
           }
 
-          # --- Helper: parse L2 results from a directory ---
           function Get-L2Table($dir, $title) {
-            $rows = ""
-            $files = Get-ChildItem "$dir/*.txt" -ErrorAction SilentlyContinue
+            if (-not (Test-Path $dir)) { return "" }
+            $files = Get-ChildItem $dir -Recurse -Filter "*.txt" -ErrorAction SilentlyContinue
             if (-not $files) { return "" }
+            $rows = ""
             foreach ($f in $files) {
-              $model = $f.BaseName
+              $meta = Get-Meta $f (Resolve-Path $dir).Path
+              $label = if ($meta.op_name) { "$($meta.model_name) / $($meta.op_name)" } else { $meta.model_name }
+              if ($meta.seq_length -ne $null) { $label += " (seq$($meta.seq_length))" }
               $content = Get-Content $f.FullName -Raw
               $l2Match = [regex]::Match($content, 'Combined L2 \(stacked diffs\):\s+([\d.eE+-]+)')
               if ($l2Match.Success) {
                 $l2val = [double]$l2Match.Groups[1].Value
                 $status = if ($l2val -le $threshold) { [char]0x2705 } else { [char]0x274C }
-                $rows += "| $model | $l2val | $status |`n"
+                $rows += "| $label | $l2val | $status |`n"
               } else {
-                $rows += "| $model | error | $([char]0x274C) |`n"
+                $rows += "| $label | error | $([char]0x274C) |`n"
               }
             }
-            if (-not $rows) { return "" }
             $header = "### $title`n`n| Model | Combined L2 | Status |`n|-------|------------|--------|`n"
             return $header + $rows + "`n"
           }
 
-          # --- Build full summary ---
+          # --- Build markdown summary ---
           $summary = "## GPU Performance & Accuracy Test Results`n`n"
-
           $opPerf = Get-PerfTable "perf-results/single-op" "Single-Op Performance (MorphiZen EP)"
           $opL2 = Get-L2Table "l2-results/single-op" "Single-Op Accuracy (EP vs CPU)"
           $fullPerf = Get-PerfTable "perf-results/full-model" "Full Model Performance (MorphiZen EP)"
           $fullL2 = Get-L2Table "l2-results/full-model" "Full Model Accuracy (EP vs CPU)"
-
           if ($opPerf) { $summary += $opPerf }
           if ($opL2) { $summary += $opL2 }
           if ($fullPerf) { $summary += $fullPerf }
           if ($fullL2) { $summary += $fullL2 }
-
           if (-not $opPerf -and -not $opL2 -and -not $fullPerf -and -not $fullL2) {
             $summary += "> No test results collected.`n"
           }
-
           $summary += "`nL2 threshold: $threshold | Run: [${{ github.run_number }}]($runUrl) | Commit: ``$sha```n"
-
           Write-Host $summary
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $summary
+
+          # --- Generate JSON result files ---
+          function Collect-PerfJson($dir, $category) {
+            $entries = @()
+            if (-not (Test-Path $dir)) { return $entries }
+            $files = Get-ChildItem $dir -Recurse -Filter "*.txt" -ErrorAction SilentlyContinue
+            foreach ($f in $files) {
+              $meta = Get-Meta $f (Resolve-Path $dir).Path
+              $content = Get-Content $f.FullName -Raw
+              $qpsMatch = [regex]::Match($content, 'Number of inferences per second:\s+([\d.]+)')
+              $avgMatch = [regex]::Match($content, 'Average inference time cost:\s+([\d.]+)\s+ms')
+              $entry = [ordered]@{
+                category   = $category
+                model_name = $meta.model_name
+                file       = $meta.file
+                qps        = if ($qpsMatch.Success) { [double]$qpsMatch.Groups[1].Value } else { $null }
+                avg_latency_ms = if ($avgMatch.Success) { [double]$avgMatch.Groups[1].Value } else { $null }
+              }
+              if ($meta.op_name) { $entry["op_name"] = $meta.op_name }
+              if ($meta.seq_length -ne $null) { $entry["seq_length"] = $meta.seq_length }
+              $entries += [PSCustomObject]$entry
+            }
+            return $entries
+          }
+
+          function Collect-L2Json($dir, $category) {
+            $entries = @()
+            if (-not (Test-Path $dir)) { return $entries }
+            $files = Get-ChildItem $dir -Recurse -Filter "*.txt" -ErrorAction SilentlyContinue
+            foreach ($f in $files) {
+              $meta = Get-Meta $f (Resolve-Path $dir).Path
+              $content = Get-Content $f.FullName -Raw
+              $l2Match = [regex]::Match($content, 'Combined L2 \(stacked diffs\):\s+([\d.eE+-]+)')
+              $l2val = if ($l2Match.Success) { [double]$l2Match.Groups[1].Value } else { $null }
+              $entry = [ordered]@{
+                category   = $category
+                model_name = $meta.model_name
+                file       = $meta.file
+                l2         = $l2val
+                pass       = if ($l2val -ne $null) { $l2val -le $threshold } else { $false }
+              }
+              if ($meta.op_name) { $entry["op_name"] = $meta.op_name }
+              if ($meta.seq_length -ne $null) { $entry["seq_length"] = $meta.seq_length }
+              $entries += [PSCustomObject]$entry
+            }
+            return $entries
+          }
+
+          $perfAll  = @()
+          $perfAll += Collect-PerfJson "perf-results/single-op" "single-op"
+          $perfAll += Collect-PerfJson "perf-results/full-model" "full-model"
+
+          $l2All  = @()
+          $l2All += Collect-L2Json "l2-results/single-op" "single-op"
+          $l2All += Collect-L2Json "l2-results/full-model" "full-model"
+
+          New-Item -ItemType Directory -Force -Path "json-results" | Out-Null
+
+          $perfJson = [ordered]@{
+            ep_name   = "MorphiZenExecutionProvider"
+            timestamp = $timestamp
+            commit    = $sha
+            results   = @($perfAll)
+          } | ConvertTo-Json -Depth 5
+          Set-Content -Path "json-results/perf-results.json" -Value $perfJson
+          Write-Host "=== perf-results.json ==="
+          Write-Host $perfJson
+
+          $l2Json = [ordered]@{
+            timestamp = $timestamp
+            commit    = $sha
+            threshold = $threshold
+            results   = @($l2All)
+          } | ConvertTo-Json -Depth 5
+          Set-Content -Path "json-results/l2-results.json" -Value $l2Json
+          Write-Host "=== l2-results.json ==="
+          Write-Host $l2Json
 
           # --- Post PR comment if triggered by workflow_run on a PR ---
           $prBranch = "${{ github.event.workflow_run.head_branch }}"
@@ -400,7 +503,6 @@ jobs:
                 $prNumber = $prs[0].number
                 $marker = "<!-- morphizen-gpu-test-results -->"
                 $body = "$marker`n$summary"
-
                 $commentsJson = gh api "repos/${{ github.repository }}/issues/$prNumber/comments" 2>$null
                 $ghOk = ($LASTEXITCODE -eq 0)
                 $existing = $null
@@ -409,7 +511,6 @@ jobs:
                   $found = $comments | Where-Object { $_.body -and $_.body.StartsWith($marker) } | Select-Object -First 1
                   if ($found) { $existing = $found.id }
                 }
-
                 if ($ghOk -and $existing) {
                   Write-Host "Updating existing PR comment $existing"
                   gh api --method PATCH "repos/${{ github.repository }}/issues/comments/$existing" -f body="$body"
@@ -420,3 +521,11 @@ jobs:
               }
             }
           }
+
+      - name: Upload JSON results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-json
+          path: json-results/
+          retention-days: 30

--- a/.github/workflows/gpu-perf-accuracy-test.yml
+++ b/.github/workflows/gpu-perf-accuracy-test.yml
@@ -218,22 +218,25 @@ jobs:
           for /r "%OP_MODEL_DIR%" %%M in (*.onnx) do (
             set "MDIR=%%~dpM"
             set "REL=!MDIR:%OP_MODEL_DIR%\=!"
+            set "OUT=..\..\l2-results\single-op\!REL!%%~nM.txt"
             mkdir "..\..\l2-results\single-op\!REL!" 2>nul
             echo === L2 test: !REL!%%~nxM ===
             rd /s /q "%%~nM_o_dump" 2>nul
             rd /s /q "%%~nM_cpu_o_dump" 2>nul
-            hip-onnx-runner.exe -m "%%M" -d 2 -s 42
+            hip-onnx-runner.exe -m "%%M" -d 2 -s 42 > "!OUT!" 2>&1
             if errorlevel 1 (
-              echo [ERROR] EP inference failed for %%~nxM
+              echo [ERROR] EP inference failed>> "!OUT!"
+              type "!OUT!"
               set FAILED=1
             ) else (
-              hip-onnx-runner.exe -m "%%M" -d 2 -s 42 -n
+              hip-onnx-runner.exe -m "%%M" -d 2 -s 42 -n >> "!OUT!" 2>&1
               if errorlevel 1 (
-                echo [ERROR] CPU inference failed for %%~nxM
+                echo [ERROR] CPU inference failed>> "!OUT!"
+                type "!OUT!"
                 set FAILED=1
               ) else (
-                hip-onnx-runner.exe -L "%%~nM_o_dump,%%~nM_cpu_o_dump" > "..\..\l2-results\single-op\!REL!%%~nM.txt" 2>&1
-                type "..\..\l2-results\single-op\!REL!%%~nM.txt"
+                hip-onnx-runner.exe -L "%%~nM_o_dump,%%~nM_cpu_o_dump" >> "!OUT!" 2>&1
+                type "!OUT!"
               )
             )
           )
@@ -310,22 +313,25 @@ jobs:
           for /r "%MODEL_DIR%" %%M in (*.onnx) do (
             set "MDIR=%%~dpM"
             set "REL=!MDIR:%MODEL_DIR%\=!"
+            set "OUT=..\..\l2-results\full-model\!REL!%%~nM.txt"
             mkdir "..\..\l2-results\full-model\!REL!" 2>nul
             echo === L2 test: !REL!%%~nxM ===
             rd /s /q "%%~nM_o_dump" 2>nul
             rd /s /q "%%~nM_cpu_o_dump" 2>nul
-            hip-onnx-runner.exe -m "%%M" -d 2 -s 42
+            hip-onnx-runner.exe -m "%%M" -d 2 -s 42 > "!OUT!" 2>&1
             if errorlevel 1 (
-              echo [ERROR] EP inference failed for %%~nxM
+              echo [ERROR] EP inference failed>> "!OUT!"
+              type "!OUT!"
               set FAILED=1
             ) else (
-              hip-onnx-runner.exe -m "%%M" -d 2 -s 42 -n
+              hip-onnx-runner.exe -m "%%M" -d 2 -s 42 -n >> "!OUT!" 2>&1
               if errorlevel 1 (
-                echo [ERROR] CPU inference failed for %%~nxM
+                echo [ERROR] CPU inference failed>> "!OUT!"
+                type "!OUT!"
                 set FAILED=1
               ) else (
-                hip-onnx-runner.exe -L "%%~nM_o_dump,%%~nM_cpu_o_dump" > "..\..\l2-results\full-model\!REL!%%~nM.txt" 2>&1
-                type "..\..\l2-results\full-model\!REL!%%~nM.txt"
+                hip-onnx-runner.exe -L "%%~nM_o_dump,%%~nM_cpu_o_dump" >> "!OUT!" 2>&1
+                type "!OUT!"
               )
             )
           )
@@ -396,10 +402,14 @@ jobs:
               if ($meta.seq_length -ne $null) { $label += " (seq$($meta.seq_length))" }
               $content = Get-Content $f.FullName -Raw
               $l2Match = [regex]::Match($content, 'Combined L2 \(stacked diffs\):\s+([\d.eE+-]+)')
+              $errMatch = [regex]::Match($content, '\[ERROR\]\s*(.+)')
               if ($l2Match.Success) {
                 $l2val = [double]$l2Match.Groups[1].Value
                 $status = if ($l2val -le $threshold) { [char]0x2705 } else { [char]0x274C }
                 $rows += "| $label | $l2val | $status |`n"
+              } elseif ($errMatch.Success) {
+                $reason = $errMatch.Groups[1].Value.Trim()
+                $rows += "| $label | $reason | $([char]0x274C) |`n"
               } else {
                 $rows += "| $label | error | $([char]0x274C) |`n"
               }
@@ -457,6 +467,7 @@ jobs:
               $meta = Get-Meta $f (Resolve-Path $dir).Path
               $content = Get-Content $f.FullName -Raw
               $l2Match = [regex]::Match($content, 'Combined L2 \(stacked diffs\):\s+([\d.eE+-]+)')
+              $errMatch = [regex]::Match($content, '\[ERROR\]\s*(.+)')
               $l2val = if ($l2Match.Success) { [double]$l2Match.Groups[1].Value } else { $null }
               $entry = [ordered]@{
                 category   = $category
@@ -464,6 +475,10 @@ jobs:
                 file       = $meta.file
                 l2         = $l2val
                 pass       = if ($l2val -ne $null) { $l2val -le $threshold } else { $false }
+              }
+              if ($errMatch.Success) {
+                $entry["error"] = $errMatch.Groups[1].Value.Trim()
+                $entry["pass"] = $false
               }
               if ($meta.op_name) { $entry["op_name"] = $meta.op_name }
               if ($meta.seq_length -ne $null) { $entry["seq_length"] = $meta.seq_length }

--- a/.github/workflows/gpu-perf-accuracy-test.yml
+++ b/.github/workflows/gpu-perf-accuracy-test.yml
@@ -49,7 +49,6 @@ jobs:
       github.event_name != 'workflow_run' ||
       github.event.workflow_run.conclusion == 'success'
     runs-on: StrixHalo
-    timeout-minutes: 120
 
     permissions:
       contents: read
@@ -155,7 +154,6 @@ jobs:
       # =================================================================
       - name: Run single-op perf tests
         if: always() && steps.verify-package.outcome == 'success' && steps.setup-therock.outcome == 'success'
-        timeout-minutes: 30
         shell: cmd
         run: |
           setlocal enabledelayedexpansion
@@ -209,7 +207,6 @@ jobs:
       # =================================================================
       - name: Run single-op L2 accuracy tests
         if: always() && steps.verify-package.outcome == 'success' && steps.setup-therock.outcome == 'success'
-        timeout-minutes: 30
         shell: cmd
         run: |
           setlocal enabledelayedexpansion
@@ -265,7 +262,6 @@ jobs:
       # =================================================================
       - name: Run full model perf tests
         if: always() && steps.verify-package.outcome == 'success' && steps.setup-therock.outcome == 'success'
-        timeout-minutes: 60
         shell: cmd
         run: |
           setlocal enabledelayedexpansion
@@ -319,7 +315,6 @@ jobs:
       # =================================================================
       - name: Run full model L2 accuracy tests
         if: always() && steps.verify-package.outcome == 'success' && steps.setup-therock.outcome == 'success'
-        timeout-minutes: 60
         shell: cmd
         run: |
           setlocal enabledelayedexpansion
@@ -410,14 +405,22 @@ jobs:
               if ($meta.seq_length -ne $null) { $label += " (seq$($meta.seq_length))" }
               $content = Get-Content $f.FullName -Raw
               $qpsMatch = [regex]::Match($content, 'Number of inferences per second:\s+([\d.]+)')
+              $sessMatch = [regex]::Match($content, 'Session creation time cost:\s+([\d.]+)\s+s')
+              $firstMatch = [regex]::Match($content, 'First inference time cost:\s+(\d+)\s+ms')
+              $cpuMatch = [regex]::Match($content, 'Avg CPU usage:\s+(\d+)\s+%')
+              $memMatch = [regex]::Match($content, 'Peak working set size:\s+(\d+)\s+bytes')
+              $sess = if ($sessMatch.Success) { $sessMatch.Groups[1].Value } else { "-" }
+              $first = if ($firstMatch.Success) { $firstMatch.Groups[1].Value } else { "-" }
+              $cpu = if ($cpuMatch.Success) { $cpuMatch.Groups[1].Value } else { "-" }
+              $memMB = if ($memMatch.Success) { "{0:F0}" -f ([double]$memMatch.Groups[1].Value / 1MB) } else { "-" }
               if ($qpsMatch.Success) {
                 $qps = "{0:F2}" -f [double]$qpsMatch.Groups[1].Value
-                $rows += "| $label | $qps |`n"
+                $rows += "| $label | $qps | $sess | $first | $cpu | $memMB |`n"
               } else {
-                $rows += "| $label | failed |`n"
+                $rows += "| $label | failed | $sess | $first | $cpu | $memMB |`n"
               }
             }
-            $header = "### $title`n`n| Model | QPS |`n|-------|----:|`n"
+            $header = "### $title`n`n| Model | QPS | Session (s) | 1st Infer (ms) | CPU% | Mem (MB) |`n|-------|----:|----:|----:|----:|----:|`n"
             return $header + $rows + "`n"
           }
 
@@ -477,12 +480,20 @@ jobs:
               $meta = Get-Meta $f (Resolve-Path $dir).Path
               $content = Get-Content $f.FullName -Raw
               $qpsMatch = [regex]::Match($content, 'Number of inferences per second:\s+([\d.]+)')
+              $sessMatch = [regex]::Match($content, 'Session creation time cost:\s+([\d.]+)\s+s')
+              $firstMatch = [regex]::Match($content, 'First inference time cost:\s+(\d+)\s+ms')
+              $cpuMatch = [regex]::Match($content, 'Avg CPU usage:\s+(\d+)\s+%')
+              $memMatch = [regex]::Match($content, 'Peak working set size:\s+(\d+)\s+bytes')
               $entry = [ordered]@{
-                category   = $category
-                ep_name    = $epName
-                model_name = $meta.model_name
-                file       = $meta.file
-                qps        = if ($qpsMatch.Success) { [double]$qpsMatch.Groups[1].Value } else { $null }
+                category       = $category
+                ep_name        = $epName
+                model_name     = $meta.model_name
+                file           = $meta.file
+                qps            = if ($qpsMatch.Success) { [double]$qpsMatch.Groups[1].Value } else { $null }
+                session_time_s = if ($sessMatch.Success) { [double]$sessMatch.Groups[1].Value } else { $null }
+                first_infer_ms = if ($firstMatch.Success) { [int]$firstMatch.Groups[1].Value } else { $null }
+                avg_cpu_pct    = if ($cpuMatch.Success) { [int]$cpuMatch.Groups[1].Value } else { $null }
+                peak_mem_bytes = if ($memMatch.Success) { [long]$memMatch.Groups[1].Value } else { $null }
               }
               if ($meta.op_name) { $entry["op_name"] = $meta.op_name }
               if ($meta.seq_length -ne $null) { $entry["seq_length"] = $meta.seq_length }

--- a/.github/workflows/gpu-perf-accuracy-test.yml
+++ b/.github/workflows/gpu-perf-accuracy-test.yml
@@ -5,6 +5,9 @@
 name: GPU Performance & Accuracy Test
 
 on:
+  schedule:
+    - cron: '0 18 * * *'  # daily at UTC 18:00 (CST 02:00)
+
   workflow_run:
     workflows: ["Windows Build"]
     branches: [main]

--- a/.github/workflows/gpu-perf-accuracy-test.yml
+++ b/.github/workflows/gpu-perf-accuracy-test.yml
@@ -1,0 +1,402 @@
+##
+## Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+## Licensed under the MIT License.
+##
+name: GPU Performance & Accuracy Test
+
+on:
+  workflow_run:
+    workflows: ["Windows Build"]
+    branches: [main]
+    types: [completed]
+
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: >
+          Build run ID to download gpu-test-package from.
+          Leave empty to use the latest successful main build.
+        required: false
+        type: string
+      perf_duration:
+        description: "Perf test duration per model (seconds)"
+        required: false
+        default: "30"
+        type: string
+      enable_full_model_l2:
+        description: "Run L2 accuracy tests on full models (slow)"
+        required: false
+        default: false
+        type: boolean
+
+  # Uncomment to enable PR-triggered runs during debugging:
+  # pull_request:
+  #   types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  gpu-perf-accuracy:
+    # Skip if the triggering Windows Build failed
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: StrixHalo
+    timeout-minutes: 120
+
+    permissions:
+      contents: read
+      pull-requests: write
+      actions: read
+
+    env:
+      THEROCK_VERSION: therock-dist-windows-gfx1151-7.11.0
+      PERF_DURATION: ${{ github.event.inputs.perf_duration || '30' }}
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
+
+    steps:
+      # -----------------------------------------------------------------
+      # Clean up leftover processes and directories from previous runs
+      # -----------------------------------------------------------------
+      - name: Clean workspace
+        shell: cmd
+        run: |
+          taskkill /f /im hip-onnx-runner.exe >nul 2>&1 || ver >nul
+          taskkill /f /im onnxruntime_perf_test.exe >nul 2>&1 || ver >nul
+          if exist gpu-test-package rd /s /q gpu-test-package
+          if exist l2-results rd /s /q l2-results
+          if exist perf-results rd /s /q perf-results
+
+      # -----------------------------------------------------------------
+      # Download the pre-built gpu-test-package artifact from the
+      # Windows Build workflow. Supports three trigger modes:
+      #   workflow_run  → use the triggering run's ID
+      #   workflow_dispatch with run_id → use the specified ID
+      #   workflow_dispatch without run_id → latest successful main build
+      # -----------------------------------------------------------------
+      - name: Download gpu-test-package
+        uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
+        with:
+          workflow: windows-build.yml
+          name: gpu-test-package
+          path: gpu-test-package
+          run_id: ${{ github.event.inputs.run_id || github.event.workflow_run.id || '' }}
+          branch: main
+          workflow_conclusion: success
+          if_no_artifact_found: fail
+
+      - name: Verify package contents
+        shell: cmd
+        run: |
+          if not exist gpu-test-package\bin\hip-onnx-runner.exe (
+            echo [ERROR] hip-onnx-runner.exe not found in gpu-test-package
+            exit /b 1
+          )
+          if not exist gpu-test-package\bin\onnxruntime_perf_test.exe (
+            echo [ERROR] onnxruntime_perf_test.exe not found in gpu-test-package
+            exit /b 1
+          )
+          echo === Package contents ===
+          dir /s /b gpu-test-package
+
+      # -----------------------------------------------------------------
+      # TheRock HIP runtime (required by MorphiZen EP at inference time)
+      # -----------------------------------------------------------------
+      - name: Download & extract TheRock
+        shell: powershell
+        run: |
+          $dist = "${{ runner.workspace }}\therock-dist"
+          New-Item -ItemType Directory -Force -Path $dist | Out-Null
+          curl.exe -fsSL `
+            "https://repo.amd.com/rocm/tarball/${{ env.THEROCK_VERSION }}.tar.gz" `
+            -o therock.tar.gz
+          tar -xzf therock.tar.gz -C $dist --strip-components=1
+          Remove-Item therock.tar.gz
+
+      # =================================================================
+      #  SINGLE-OP PERFORMANCE TESTS
+      #  Models: runner-local l2-test-models/ directory (individual ops)
+      # =================================================================
+      - name: Run single-op perf tests
+        if: always()
+        timeout-minutes: 30
+        shell: cmd
+        run: |
+          set THEROCK_DIST=${{ runner.workspace }}\therock-dist
+          set PATH=${{ runner.workspace }}\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
+          set LIB=%CD%\gpu-test-package\lib;${{ runner.workspace }}\therock-dist\lib
+          set OP_MODEL_DIR=${{ runner.workspace }}\l2-test-models
+          if not exist "%OP_MODEL_DIR%" (
+            echo [SKIP] Single-op model directory not found: %OP_MODEL_DIR%
+            exit /b 0
+          )
+          set FOUND=0
+          for /r "%OP_MODEL_DIR%" %%M in (*.onnx) do set FOUND=1
+          if "%FOUND%"=="0" (
+            echo [SKIP] No .onnx models found in %OP_MODEL_DIR%
+            exit /b 0
+          )
+          mkdir perf-results\single-op 2>nul
+          set FAILED=0
+          cd gpu-test-package\bin
+          for /r "%OP_MODEL_DIR%" %%M in (*.onnx) do (
+            echo === Perf: %%~nxM ===
+            onnxruntime_perf_test.exe ^
+              --plugin_ep_libs "MorphiZenExecutionProvider|onnxruntime_morphizen_ep.dll" ^
+              --plugin_eps "MorphiZenExecutionProvider" ^
+              --plugin_ep_options "config_file|..\morphizen_config.json" ^
+              -t %PERF_DURATION% -c 1 -s -I ^
+              "%%M" > "..\..\perf-results\single-op\%%~nxM.txt" 2>&1
+            type "..\..\perf-results\single-op\%%~nxM.txt"
+            if errorlevel 1 set FAILED=1
+          )
+          exit /b %FAILED%
+
+      # =================================================================
+      #  SINGLE-OP ACCURACY TESTS (L2)
+      #  EP vs CPU comparison for each op model
+      # =================================================================
+      - name: Run single-op L2 accuracy tests
+        if: always()
+        timeout-minutes: 30
+        shell: cmd
+        run: |
+          set THEROCK_DIST=${{ runner.workspace }}\therock-dist
+          set PATH=${{ runner.workspace }}\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
+          set LIB=%CD%\gpu-test-package\lib;${{ runner.workspace }}\therock-dist\lib
+          set OP_MODEL_DIR=${{ runner.workspace }}\l2-test-models
+          if not exist "%OP_MODEL_DIR%" (
+            echo [SKIP] Single-op model directory not found: %OP_MODEL_DIR%
+            exit /b 0
+          )
+          set FOUND=0
+          for /r "%OP_MODEL_DIR%" %%M in (*.onnx) do set FOUND=1
+          if "%FOUND%"=="0" (
+            echo [SKIP] No .onnx models found in %OP_MODEL_DIR%
+            exit /b 0
+          )
+          mkdir l2-results\single-op 2>nul
+          set FAILED=0
+          cd gpu-test-package\bin
+          for /r "%OP_MODEL_DIR%" %%M in (*.onnx) do (
+            echo === L2 test: %%~nxM ===
+            rd /s /q "%%~nM_o_dump" 2>nul
+            rd /s /q "%%~nM_cpu_o_dump" 2>nul
+            hip-onnx-runner.exe -m "%%M" -d 2 -s 42
+            if errorlevel 1 (
+              echo [ERROR] EP inference failed for %%~nxM
+              set FAILED=1
+            ) else (
+              hip-onnx-runner.exe -m "%%M" -d 2 -s 42 -n
+              if errorlevel 1 (
+                echo [ERROR] CPU inference failed for %%~nxM
+                set FAILED=1
+              ) else (
+                hip-onnx-runner.exe -L "%%~nM_o_dump,%%~nM_cpu_o_dump" > "..\..\l2-results\single-op\%%~nM.txt" 2>&1
+                type "..\..\l2-results\single-op\%%~nM.txt"
+              )
+            )
+          )
+          exit /b %FAILED%
+
+      # =================================================================
+      #  FULL MODEL PERFORMANCE TESTS
+      #  Models: runner-local model/ directory (all seq lengths)
+      # =================================================================
+      - name: Run full model perf tests
+        if: always()
+        timeout-minutes: 60
+        shell: cmd
+        run: |
+          set THEROCK_DIST=${{ runner.workspace }}\therock-dist
+          set PATH=${{ runner.workspace }}\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
+          set LIB=%CD%\gpu-test-package\lib;${{ runner.workspace }}\therock-dist\lib
+          set MODEL_DIR=${{ runner.workspace }}\model
+          if not exist "%MODEL_DIR%" (
+            echo [SKIP] Full model directory not found: %MODEL_DIR%
+            exit /b 0
+          )
+          set FOUND=0
+          for /r "%MODEL_DIR%" %%M in (*.onnx) do set FOUND=1
+          if "%FOUND%"=="0" (
+            echo [SKIP] No .onnx models found in %MODEL_DIR%
+            exit /b 0
+          )
+          mkdir perf-results\full-model 2>nul
+          set FAILED=0
+          cd gpu-test-package\bin
+          for /r "%MODEL_DIR%" %%M in (*.onnx) do (
+            echo === Perf: %%~nxM ===
+            onnxruntime_perf_test.exe ^
+              --plugin_ep_libs "MorphiZenExecutionProvider|onnxruntime_morphizen_ep.dll" ^
+              --plugin_eps "MorphiZenExecutionProvider" ^
+              --plugin_ep_options "config_file|..\morphizen_config.json" ^
+              -t %PERF_DURATION% -c 1 -s -I ^
+              "%%M" > "..\..\perf-results\full-model\%%~nxM.txt" 2>&1
+            type "..\..\perf-results\full-model\%%~nxM.txt"
+            if errorlevel 1 set FAILED=1
+          )
+          exit /b %FAILED%
+
+      # =================================================================
+      #  FULL MODEL ACCURACY TESTS (L2)
+      #  Disabled by default — enable via workflow_dispatch input
+      # =================================================================
+      - name: Run full model L2 accuracy tests
+        if: always() && (github.event.inputs.enable_full_model_l2 == 'true')
+        timeout-minutes: 60
+        shell: cmd
+        run: |
+          set THEROCK_DIST=${{ runner.workspace }}\therock-dist
+          set PATH=${{ runner.workspace }}\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
+          set LIB=%CD%\gpu-test-package\lib;${{ runner.workspace }}\therock-dist\lib
+          set MODEL_DIR=${{ runner.workspace }}\model
+          if not exist "%MODEL_DIR%" (
+            echo [SKIP] Full model directory not found: %MODEL_DIR%
+            exit /b 0
+          )
+          set FOUND=0
+          for /r "%MODEL_DIR%" %%M in (*.onnx) do set FOUND=1
+          if "%FOUND%"=="0" (
+            echo [SKIP] No .onnx models found in %MODEL_DIR%
+            exit /b 0
+          )
+          mkdir l2-results\full-model 2>nul
+          set FAILED=0
+          cd gpu-test-package\bin
+          for /r "%MODEL_DIR%" %%M in (*.onnx) do (
+            echo === L2 test: %%~nxM ===
+            rd /s /q "%%~nM_o_dump" 2>nul
+            rd /s /q "%%~nM_cpu_o_dump" 2>nul
+            hip-onnx-runner.exe -m "%%M" -d 2 -s 42
+            if errorlevel 1 (
+              echo [ERROR] EP inference failed for %%~nxM
+              set FAILED=1
+            ) else (
+              hip-onnx-runner.exe -m "%%M" -d 2 -s 42 -n
+              if errorlevel 1 (
+                echo [ERROR] CPU inference failed for %%~nxM
+                set FAILED=1
+              ) else (
+                hip-onnx-runner.exe -L "%%~nM_o_dump,%%~nM_cpu_o_dump" > "..\..\l2-results\full-model\%%~nM.txt" 2>&1
+                type "..\..\l2-results\full-model\%%~nM.txt"
+              )
+            )
+          )
+          exit /b %FAILED%
+
+      # =================================================================
+      #  PUBLISH RESULTS
+      # =================================================================
+      - name: Publish results
+        if: always()
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $runUrl = "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          $sha = "${{ github.event.workflow_run.head_sha || github.sha }}".Substring(0, 7)
+          $threshold = 0.01
+
+          # --- Helper: parse perf results from a directory ---
+          function Get-PerfTable($dir, $title) {
+            $rows = ""
+            $files = Get-ChildItem "$dir/*.txt" -ErrorAction SilentlyContinue
+            if (-not $files) { return "" }
+            foreach ($f in $files) {
+              $model = ($f.BaseName -replace '\.onnx$', '')
+              $content = Get-Content $f.FullName -Raw
+              $qpsMatch = [regex]::Match($content, 'Number of inferences per second:\s+([\d.]+)')
+              $avgMatch = [regex]::Match($content, 'Average inference time cost:\s+([\d.]+)\s+ms')
+              if ($qpsMatch.Success) {
+                $qps = "{0:F2}" -f [double]$qpsMatch.Groups[1].Value
+                $avg = if ($avgMatch.Success) { "{0:F3}" -f [double]$avgMatch.Groups[1].Value } else { "N/A" }
+                $rows += "| $model | $qps | $avg ms |`n"
+              } else {
+                $rows += "| $model | failed | - |`n"
+              }
+            }
+            if (-not $rows) { return "" }
+            $header = "### $title`n`n| Model | QPS | Avg Latency |`n|-------|----:|------------|`n"
+            return $header + $rows + "`n"
+          }
+
+          # --- Helper: parse L2 results from a directory ---
+          function Get-L2Table($dir, $title) {
+            $rows = ""
+            $files = Get-ChildItem "$dir/*.txt" -ErrorAction SilentlyContinue
+            if (-not $files) { return "" }
+            foreach ($f in $files) {
+              $model = $f.BaseName
+              $content = Get-Content $f.FullName -Raw
+              $l2Match = [regex]::Match($content, 'Combined L2 \(stacked diffs\):\s+([\d.eE+-]+)')
+              if ($l2Match.Success) {
+                $l2val = [double]$l2Match.Groups[1].Value
+                $status = if ($l2val -le $threshold) { [char]0x2705 } else { [char]0x274C }
+                $rows += "| $model | $l2val | $status |`n"
+              } else {
+                $rows += "| $model | error | $([char]0x274C) |`n"
+              }
+            }
+            if (-not $rows) { return "" }
+            $header = "### $title`n`n| Model | Combined L2 | Status |`n|-------|------------|--------|`n"
+            return $header + $rows + "`n"
+          }
+
+          # --- Build full summary ---
+          $summary = "## GPU Performance & Accuracy Test Results`n`n"
+
+          $opPerf = Get-PerfTable "perf-results/single-op" "Single-Op Performance (MorphiZen EP)"
+          $opL2 = Get-L2Table "l2-results/single-op" "Single-Op Accuracy (EP vs CPU)"
+          $fullPerf = Get-PerfTable "perf-results/full-model" "Full Model Performance (MorphiZen EP)"
+          $fullL2 = Get-L2Table "l2-results/full-model" "Full Model Accuracy (EP vs CPU)"
+
+          if ($opPerf) { $summary += $opPerf }
+          if ($opL2) { $summary += $opL2 }
+          if ($fullPerf) { $summary += $fullPerf }
+          if ($fullL2) { $summary += $fullL2 }
+
+          if (-not $opPerf -and -not $opL2 -and -not $fullPerf -and -not $fullL2) {
+            $summary += "> No test results collected.`n"
+          }
+
+          $summary += "`nL2 threshold: $threshold | Run: [${{ github.run_number }}]($runUrl) | Commit: ``$sha```n"
+
+          Write-Host $summary
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $summary
+
+          # --- Post PR comment if triggered by workflow_run on a PR ---
+          $prBranch = "${{ github.event.workflow_run.head_branch }}"
+          if ($prBranch -and $prBranch -ne "main") {
+            $prsJson = gh pr list -R "${{ github.repository }}" --head "$prBranch" --json number --limit 1 2>$null
+            if ($LASTEXITCODE -eq 0 -and $prsJson) {
+              $prs = $prsJson | ConvertFrom-Json
+              if ($prs.Count -gt 0) {
+                $prNumber = $prs[0].number
+                $marker = "<!-- morphizen-gpu-test-results -->"
+                $body = "$marker`n$summary"
+
+                $commentsJson = gh api "repos/${{ github.repository }}/issues/$prNumber/comments" 2>$null
+                $ghOk = ($LASTEXITCODE -eq 0)
+                $existing = $null
+                if ($ghOk -and $commentsJson) {
+                  $comments = $commentsJson | ConvertFrom-Json
+                  $found = $comments | Where-Object { $_.body -and $_.body.StartsWith($marker) } | Select-Object -First 1
+                  if ($found) { $existing = $found.id }
+                }
+
+                if ($ghOk -and $existing) {
+                  Write-Host "Updating existing PR comment $existing"
+                  gh api --method PATCH "repos/${{ github.repository }}/issues/comments/$existing" -f body="$body"
+                } elseif ($ghOk) {
+                  Write-Host "Creating new PR comment on #$prNumber"
+                  gh pr comment $prNumber -R "${{ github.repository }}" --body "$body"
+                }
+              }
+            }
+          }

--- a/.github/workflows/gpu-perf-accuracy-test.yml
+++ b/.github/workflows/gpu-perf-accuracy-test.yml
@@ -119,7 +119,7 @@ jobs:
 
       # =================================================================
       #  SINGLE-OP PERFORMANCE TESTS
-      #  Models: runner-local l2-test-models/ directory (individual ops)
+      #  Models: runner-local test-models\single-op\ directory
       # =================================================================
       - name: Run single-op perf tests
         if: always()
@@ -129,7 +129,7 @@ jobs:
           set THEROCK_DIST=${{ runner.workspace }}\therock-dist
           set PATH=${{ runner.workspace }}\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
           set LIB=%CD%\gpu-test-package\lib;${{ runner.workspace }}\therock-dist\lib
-          set OP_MODEL_DIR=${{ runner.workspace }}\l2-test-models
+          set OP_MODEL_DIR=${{ runner.workspace }}\test-models\single-op
           if not exist "%OP_MODEL_DIR%" (
             echo [SKIP] Single-op model directory not found: %OP_MODEL_DIR%
             exit /b 0
@@ -168,7 +168,7 @@ jobs:
           set THEROCK_DIST=${{ runner.workspace }}\therock-dist
           set PATH=${{ runner.workspace }}\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
           set LIB=%CD%\gpu-test-package\lib;${{ runner.workspace }}\therock-dist\lib
-          set OP_MODEL_DIR=${{ runner.workspace }}\l2-test-models
+          set OP_MODEL_DIR=${{ runner.workspace }}\test-models\single-op
           if not exist "%OP_MODEL_DIR%" (
             echo [SKIP] Single-op model directory not found: %OP_MODEL_DIR%
             exit /b 0
@@ -205,7 +205,7 @@ jobs:
 
       # =================================================================
       #  FULL MODEL PERFORMANCE TESTS
-      #  Models: runner-local model/ directory (all seq lengths)
+      #  Models: runner-local test-models\full-model\ directory
       # =================================================================
       - name: Run full model perf tests
         if: always()
@@ -215,7 +215,7 @@ jobs:
           set THEROCK_DIST=${{ runner.workspace }}\therock-dist
           set PATH=${{ runner.workspace }}\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
           set LIB=%CD%\gpu-test-package\lib;${{ runner.workspace }}\therock-dist\lib
-          set MODEL_DIR=${{ runner.workspace }}\model
+          set MODEL_DIR=${{ runner.workspace }}\test-models\full-model
           if not exist "%MODEL_DIR%" (
             echo [SKIP] Full model directory not found: %MODEL_DIR%
             exit /b 0
@@ -254,7 +254,7 @@ jobs:
           set THEROCK_DIST=${{ runner.workspace }}\therock-dist
           set PATH=${{ runner.workspace }}\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
           set LIB=%CD%\gpu-test-package\lib;${{ runner.workspace }}\therock-dist\lib
-          set MODEL_DIR=${{ runner.workspace }}\model
+          set MODEL_DIR=${{ runner.workspace }}\test-models\full-model
           if not exist "%MODEL_DIR%" (
             echo [SKIP] Full model directory not found: %MODEL_DIR%
             exit /b 0

--- a/.github/workflows/gpu-perf-accuracy-test.yml
+++ b/.github/workflows/gpu-perf-accuracy-test.yml
@@ -90,7 +90,7 @@ jobs:
           if [ -n "${{ github.event.inputs.source_branch }}" ]; then
             BRANCH="${{ github.event.inputs.source_branch }}"
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            BRANCH="${{ github.event.pull_request.head.ref }}"
+            BRANCH="feat/improve-test-runner"
           elif [ -n "${{ github.event.workflow_run.head_branch }}" ]; then
             BRANCH="${{ github.event.workflow_run.head_branch }}"
           else

--- a/.github/workflows/gpu-perf-accuracy-test.yml
+++ b/.github/workflows/gpu-perf-accuracy-test.yml
@@ -116,7 +116,6 @@ jobs:
           name: gpu-test-package
           path: gpu-test-package
           run_id: '23830153026'  # DEBUG: hardcoded build with x64 DirectML fix
-          branch: feat/gpu-perf-accuracy-ci
           workflow_conclusion: success
           if_no_artifact_found: fail
 

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -181,7 +181,7 @@ jobs:
           cp "$PERF_TEST" "${{ runner.workspace }}/prebuilt-local/bin/"
           # DirectML.dll is not installed by cmake --install; copy manually.
           DML_DLL=$(find "${{ runner.workspace }}/build-onnxruntime" \
-            -name "DirectML.dll" -type f | head -1)
+            -path "*/x64-win/DirectML.dll" -type f | head -1)
           if [ -z "$DML_DLL" ]; then
             echo "ERROR: DirectML.dll not found in build tree"
             exit 1

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -483,6 +483,7 @@ jobs:
         timeout-minutes: 10
         shell: cmd
         run: |
+          setlocal enabledelayedexpansion
           set THEROCK_DIST=${{ runner.workspace }}\therock-dist
           set PATH=${{ runner.workspace }}\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
           set LIB=%CD%\gpu-test-package\lib;${{ runner.workspace }}\therock-dist\lib
@@ -493,33 +494,35 @@ jobs:
           )
           set FOUND=0
           for /r "%L2_MODEL_DIR%" %%M in (*.onnx) do set FOUND=1
-          if "%FOUND%"=="0" (
+          if "!FOUND!"=="0" (
             echo [SKIP] No .onnx models found in %L2_MODEL_DIR%
             exit /b 0
           )
           cd gpu-test-package\bin
-          mkdir ..\..\l2-results 2>nul
           set FAILED=0
           for /r "%L2_MODEL_DIR%" %%M in (*.onnx) do (
-            echo === L2 test: %%~nxM ===
+            set "MDIR=%%~dpM"
+            set "REL=!MDIR:%L2_MODEL_DIR%\=!"
+            mkdir "..\..\l2-results\!REL!" 2>nul
+            echo === L2 test: !REL!%%~nxM ===
             rd /s /q "%%~nM_o_dump" 2>nul
             rd /s /q "%%~nM_cpu_o_dump" 2>nul
             hip-onnx-runner.exe -m "%%M" -d 2 -s 42
             if errorlevel 1 (
-              echo [ERROR] EP inference failed for %%~nxM
+              echo [ERROR] EP inference failed for !REL!%%~nxM
               set FAILED=1
             ) else (
               hip-onnx-runner.exe -m "%%M" -d 2 -s 42 -n
               if errorlevel 1 (
-                echo [ERROR] CPU inference failed for %%~nxM
+                echo [ERROR] CPU inference failed for !REL!%%~nxM
                 set FAILED=1
               ) else (
-                hip-onnx-runner.exe -L "%%~nM_o_dump,%%~nM_cpu_o_dump" > "..\..\l2-results\%%~nM.txt" 2>&1
-                type "..\..\l2-results\%%~nM.txt"
+                hip-onnx-runner.exe -L "%%~nM_o_dump,%%~nM_cpu_o_dump" > "..\..\l2-results\!REL!%%~nM.txt" 2>&1
+                type "..\..\l2-results\!REL!%%~nM.txt"
               )
             )
           )
-          exit /b %FAILED%
+          exit /b !FAILED!
 
       - name: Publish L2 results
         if: always()
@@ -532,7 +535,7 @@ jobs:
             Write-Host "No L2 results to publish (directory not found)"
             return
           }
-          $files = Get-ChildItem "$l2Dir/*.txt" -ErrorAction SilentlyContinue
+          $files = Get-ChildItem $l2Dir -Recurse -Filter "*.txt" -ErrorAction SilentlyContinue
           if (-not $files) {
             Write-Host "No L2 result files found"
             return
@@ -543,10 +546,12 @@ jobs:
           $sha = $rawSha.Substring(0, 7)
           $prNumber = "${{ github.event.pull_request.number }}"
           $threshold = 0.01
+          $l2Root = (Resolve-Path $l2Dir).Path
 
           $tableRows = ""
           foreach ($f in $files) {
-            $model = $f.BaseName
+            $rel = $f.FullName.Substring($l2Root.Length).TrimStart('\', '/')
+            $model = $rel -replace '\.txt$', '' -replace '\\', '/'
             $content = Get-Content $f.FullName -Raw
             $l2Match = [regex]::Match($content, 'Combined L2 \(stacked diffs\):\s+([\d.eE+-]+)')
             if ($l2Match.Success) {

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -503,22 +503,25 @@ jobs:
           for /r "%L2_MODEL_DIR%" %%M in (*.onnx) do (
             set "MDIR=%%~dpM"
             set "REL=!MDIR:%L2_MODEL_DIR%\=!"
+            set "OUT=..\..\l2-results\!REL!%%~nM.txt"
             mkdir "..\..\l2-results\!REL!" 2>nul
             echo === L2 test: !REL!%%~nxM ===
             rd /s /q "%%~nM_o_dump" 2>nul
             rd /s /q "%%~nM_cpu_o_dump" 2>nul
-            hip-onnx-runner.exe -m "%%M" -d 2 -s 42
+            hip-onnx-runner.exe -m "%%M" -d 2 -s 42 > "!OUT!" 2>&1
             if errorlevel 1 (
-              echo [ERROR] EP inference failed for !REL!%%~nxM
+              echo [ERROR] EP inference failed>> "!OUT!"
+              type "!OUT!"
               set FAILED=1
             ) else (
-              hip-onnx-runner.exe -m "%%M" -d 2 -s 42 -n
+              hip-onnx-runner.exe -m "%%M" -d 2 -s 42 -n >> "!OUT!" 2>&1
               if errorlevel 1 (
-                echo [ERROR] CPU inference failed for !REL!%%~nxM
+                echo [ERROR] CPU inference failed>> "!OUT!"
+                type "!OUT!"
                 set FAILED=1
               ) else (
-                hip-onnx-runner.exe -L "%%~nM_o_dump,%%~nM_cpu_o_dump" > "..\..\l2-results\!REL!%%~nM.txt" 2>&1
-                type "..\..\l2-results\!REL!%%~nM.txt"
+                hip-onnx-runner.exe -L "%%~nM_o_dump,%%~nM_cpu_o_dump" >> "!OUT!" 2>&1
+                type "!OUT!"
               )
             )
           )
@@ -554,10 +557,14 @@ jobs:
             $model = $rel -replace '\.txt$', '' -replace '\\', '/'
             $content = Get-Content $f.FullName -Raw
             $l2Match = [regex]::Match($content, 'Combined L2 \(stacked diffs\):\s+([\d.eE+-]+)')
+            $errMatch = [regex]::Match($content, '\[ERROR\]\s*(.+)')
             if ($l2Match.Success) {
               $l2val = [double]$l2Match.Groups[1].Value
               $status = if ($l2val -le $threshold) { [char]0x2705 } else { [char]0x274C }
               $tableRows += "| $model | $l2val | $status |`n"
+            } elseif ($errMatch.Success) {
+              $reason = $errMatch.Groups[1].Value.Trim()
+              $tableRows += "| $model | $reason | $([char]0x274C) |`n"
             } else {
               $tableRows += "| $model | error | $([char]0x274C) |`n"
             }

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -384,7 +384,7 @@ jobs:
         with:
           name: gpu-test-package
           path: staging/
-          retention-days: 3
+          retention-days: ${{ github.ref == 'refs/heads/main' && 14 || 3 }}
 
   # ---------------------------------------------------------------------------
   # GPU test job: runs on the self-hosted machine with a real AMD GPU.

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -560,19 +560,18 @@ jobs:
             $errMatch = [regex]::Match($content, '\[ERROR\]\s*(.+)')
             if ($l2Match.Success) {
               $l2val = [double]$l2Match.Groups[1].Value
-              $status = if ($l2val -le $threshold) { [char]0x2705 } else { [char]0x274C }
-              $tableRows += "| $model | $l2val | $status |`n"
+              $tableRows += "| $model | $l2val |`n"
             } elseif ($errMatch.Success) {
               $reason = $errMatch.Groups[1].Value.Trim()
-              $tableRows += "| $model | $reason | $([char]0x274C) |`n"
+              $tableRows += "| $model | $reason |`n"
             } else {
-              $tableRows += "| $model | error | $([char]0x274C) |`n"
+              $tableRows += "| $model | error |`n"
             }
           }
 
           $header = "## L2 Accuracy Results (EP vs CPU)`n`n" +
-                    "| Model | Combined L2 | Status |`n" +
-                    "|-------|------------|--------|`n"
+                    "| Model | Combined L2 |`n" +
+                    "|-------|------------|`n"
           $footer = "`nThreshold: $threshold | Run: [${{ github.run_number }}]($runUrl) - Commit: ``$sha``"
           $summary = $header + $tableRows + $footer
 

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: windows-latest
 
     env:
+      PREBUILT_CACHE_VERSION: "2"  # bump to invalidate prebuilt cache
       LLVM_TAG: llvm-22.1.0-release
       FLATBUFFERS_TAG: flatbuffers-25.12.19-release
       PROTO_TAG: protobuf-34.0-release
@@ -74,7 +75,7 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ${{ runner.workspace }}/prebuilt-local
-          key: prebuilt-ort-src-${{ env.ONNXRUNTIME_VERSION }}-${{ env.LLVM_TAG }}-${{ env.FLATBUFFERS_TAG }}-${{ env.PROTO_TAG }}-gtest${{ env.GTEST_VERSION }}
+          key: prebuilt-v${{ env.PREBUILT_CACHE_VERSION }}-ort${{ env.ONNXRUNTIME_VERSION }}-${{ env.LLVM_TAG }}-${{ env.FLATBUFFERS_TAG }}-${{ env.PROTO_TAG }}-gtest${{ env.GTEST_VERSION }}
 
       # -----------------------------------------------------------------------
       # Cache: TheRock HIP SDK for Windows (separate cache – large tarball)


### PR DESCRIPTION
## Summary
Add a standalone GPU performance & accuracy test workflow that runs on the StrixHalo self-hosted runner.

- **Triggers**: daily schedule (UTC 18:00) + manual dispatch
- **Artifact**: downloads `gpu-test-package` from the latest successful `Windows Build` on main
- **Single-op tests**: traverses `test-models/<family>/*` (skipping `full_model/` and `*_dyn.onnx`)
  - MorphiZen EP perf (onnxruntime_perf_test)
  - DirectML EP perf (for comparison)
  - L2 accuracy (EP vs CPU via hip-onnx-runner)
- **Full model tests**: traverses `test-models/<family>/full_model/` (skipping `*_dyn.onnx`)
  - Same perf + L2 test matrix as single-op
- **Results**: markdown step summary with QPS / Session time / 1st inference / CPU% / Memory + JSON artifacts (30-day retention)
- **Packaging**: stages DirectML.dll (x64), MSVC CRT libs, TheRock runtime for the GPU runner

### Changes to `windows-build.yml`
- Copy x64-win DirectML.dll (not arm-win variant)
- Add `PREBUILT_CACHE_VERSION` env var for cache invalidation control

## Test plan
- [x] Manual dispatch runs successfully on StrixHalo
- [x] Single-op perf results appear in step summary
- [x] L2 accuracy results show Combined L2 values
- [x] JSON artifacts uploaded with correct structure