### PR TITLE
fix: correct input tensor ordering in MlirCustomOp for fused nodes

### DIFF
--- a/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
+++ b/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
@@ -95,10 +95,31 @@ static size_t onnx_elem_type_size(int elem_type) {
   }
 }
 
-// Marshal input tensors from ORT context
-TensorData marshal_input_tensors(OrtKernelContext *context) {
+// Build a mapping from compiler/meta_def input index to ORT kernel context
+// input index. ORT's fused node may reorder inputs relative to the meta_def
+// order; the mapping is recorded in meta_def.input_argument_indice by
+// MorphiZen's Compile phase.
+static std::vector<int>
+build_input_index_map(const morphizen::MetaDefProto &meta_def) {
+  int n = meta_def.inputs_size();
+  std::vector<int> map(n);
+  for (int i = 0; i < n; ++i) {
+    map[i] = (!meta_def.input_argument_indice().empty())
+                 ? meta_def.input_argument_indice(i)
+                 : i;
+    MY_LOG(3) << "Input map: compiler[" << i << "] '" << meta_def.inputs(i)
+              << "' -> ort[" << map[i] << "]";
+  }
+  return map;
+}
+
+// Marshal input tensors from ORT context.
+// input_index_map maps from compiler input index (= DLL input index) to
+// the ORT kernel context input index.
+TensorData marshal_input_tensors(OrtKernelContext *context,
+                                 const std::vector<int> &input_index_map) {
   Ort::KernelContext ctx(context);
-  auto num_inputs = ctx.GetInputCount();
+  size_t num_inputs = input_index_map.size();
 
   MY_LOG(2) << "Marshaling " << num_inputs << " input tensors";
 
@@ -107,7 +128,8 @@ TensorData marshal_input_tensors(OrtKernelContext *context) {
   data.shapes.resize(num_inputs);
 
   for (size_t i = 0; i < num_inputs; ++i) {
-    auto input_tensor = ctx.GetInput(i);
+    int ort_idx = input_index_map[i];
+    auto input_tensor = ctx.GetInput(ort_idx);
     auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
     data.shapes[i] = tensor_info.GetShape();
 
@@ -117,7 +139,8 @@ TensorData marshal_input_tensors(OrtKernelContext *context) {
     data.tensors[i].element_size =
         ort_element_size(tensor_info.GetElementType());
 
-    MY_LOG(3) << "Input[" << i << "]: rank=" << data.tensors[i].rank
+    MY_LOG(3) << "Input[" << i << "] (ort_idx=" << ort_idx
+              << "): rank=" << data.tensors[i].rank
               << " element_size=" << data.tensors[i].element_size;
   }
 
@@ -272,10 +295,11 @@ MlirCustomOp::MlirCustomOp(
     : morphizen::CustomOpImp(context, meta_def, model) {
 
   MY_LOG(1) << "MlirCustomOp constructor";
+
   // Parse metadata from JSON
   metadata_ = parse_metadata_from_metadef(context, meta_def);
-  // Precompute output index mapping (metadata order -> ORT kernel context
-  // order)
+  // Precompute index mappings (compiler order -> ORT kernel context order)
+  input_index_map_ = build_input_index_map(*meta_def);
   output_index_map_ = build_output_index_map(metadata_.outputs(), *meta_def);
   // Get FileSystem from PassContext for constants file resolution.
   // const_cast follows the established morphizen pattern (custom_op_imp.hpp).
@@ -290,7 +314,7 @@ MlirCustomOp::MlirCustomOp(
 void MlirCustomOp::Compute(const OrtApi *api, OrtKernelContext *context) const {
   MY_LOG(2) << "MlirCustomOp::Compute() called";
 
-  auto inputs = marshal_input_tensors(context);
+  auto inputs = marshal_input_tensors(context, input_index_map_);
   auto outputs =
       marshal_output_tensors(context, metadata_.outputs(), output_index_map_);
 

--- a/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.h
+++ b/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.h
@@ -38,6 +38,11 @@ private:
   // Metadata from EPContext (contains output shapes)
   mlir_metadata::Metadata metadata_;
 
+  // Maps compiler input index (= DLL input index) to ORT kernel context
+  // input index. ORT's fused node may reorder inputs relative to the
+  // compiler order; the mapping is derived from input_argument_indice.
+  std::vector<int> input_index_map_;
+
   // Maps metadata output index (= DLL output index) to ORT kernel context
   // output index. Precomputed at construction to handle ordering differences
   // between the metadata (DLL-order) and the fused node (ORT-order).

--- a/lib/Runtime/hipdnn_ep_runtime_tensor.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_tensor.cpp
@@ -187,9 +187,9 @@ int hipdnn_ep_tensor_prepare_input(RuntimeState *state, span_t *inputs,
   // Validate rank
   if (tensor->rank != expected_rank) {
     fprintf(stderr,
-            "hipdnn_ep_tensor_prepare_input: rank mismatch (expected %zu, got "
-            "%zu)\n",
-            expected_rank, tensor->rank);
+            "hipdnn_ep_tensor_prepare_input: rank mismatch at index %zu "
+            "(expected %zu, got %zu)\n",
+            index, expected_rank, tensor->rank);
     return HIPDNN_EP_ERR_RANK_MISMATCH;
   }
 

--- a/tools/hip-onnx-runner/hip-onnx-runner.cpp
+++ b/tools/hip-onnx-runner/hip-onnx-runner.cpp
@@ -774,9 +774,10 @@ int main(int argc, char *argv[]) {
   for (size_t i = 0; i < input_count; ++i) {
     auto name_ptr = session->GetInputNameAllocated(i, allocator);
     input_names_str.push_back(name_ptr.get());
-    auto info = session->GetInputTypeInfo(i).GetTensorTypeAndShapeInfo();
-    input_shapes.push_back(info.GetShape());
-    input_types.push_back(info.GetElementType());
+    auto type_info = session->GetInputTypeInfo(i);
+    auto tensor_info = type_info.GetTensorTypeAndShapeInfo();
+    input_shapes.push_back(tensor_info.GetShape());
+    input_types.push_back(tensor_info.GetElementType());
   }
   for (auto &s : input_names_str)
     input_names.push_back(s.c_str());


### PR DESCRIPTION
## Summary

Fix two bugs that caused Phi-4 single-layer models to fail during inference.

### Bug 1: Input tensor ordering mismatch in MlirCustomOp

**Problem**: When ORT creates a fused node, it may reorder the inputs relative to the compiler/meta_def order. `marshal_input_tensors` retrieved inputs sequentially from `OrtKernelContext` (index 0, 1, 2, ...), assuming the ORT kernel context order matched the compiler's expected order. For models like Phi-4, where ORT reorders inputs during fusion, this resulted in the DLL receiving tensors with unexpected ranks (e.g., a 2D `position_ids` tensor where a 4D `past_key_values` tensor was expected), causing rank mismatch errors.

**Root Cause**: MorphiZen's `try_fuse()` may reorder inputs when creating the fused node. This reordering is recorded in `MetaDefProto.input_argument_indice`, which maps from the meta_def's logical input order to the fused node's physical input port order. The existing code did not use this mapping for inputs (though it already used the analogous `output_argument_indice` for outputs).

**Fix**:
- Add `build_input_index_map()` to derive the compiler-to-ORT index mapping from `MetaDefProto.input_argument_indice`
- Modify `marshal_input_tensors()` to use this mapping when retrieving tensors from `OrtKernelContext`
- Store the precomputed `input_index_map_` in `MlirCustomOp` (symmetric with existing `output_index_map_`)
- Improve rank mismatch error message in the runtime to include the tensor index

### Bug 2: Use-after-free in hip-onnx-runner input type query

**Problem**: Sporadic "Unsupported element type: -425676192" crash when loading certain models. The garbage value and non-deterministic behavior are classic symptoms of reading freed memory.

**Root Cause**: `GetTensorTypeAndShapeInfo()` returns a non-owning view into the `TypeInfo` object. The original code chained it on a temporary:
```cpp
auto info = session->GetInputTypeInfo(i).GetTensorTypeAndShapeInfo();
// TypeInfo temporary is destroyed here — info is now dangling
info.GetShape();       // undefined behavior
info.GetElementType(); // reads garbage
```
The `TypeInfo` temporary was destroyed at the end of the statement, leaving `info` as a dangling reference. Subsequent reads of shape and element type accessed freed memory.

**Fix**: Keep the `TypeInfo` alive in a named local variable:
```cpp
auto type_info = session->GetInputTypeInfo(i);
auto tensor_info = type_info.GetTensorTypeAndShapeInfo();
// type_info stays alive — tensor_info is valid
```

### Files Changed

- `backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp` — Add `build_input_index_map()`, update `marshal_input_tensors()` to use index mapping
- `backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.h` — Add `input_index_map_` member
- `lib/Runtime/hipdnn_ep_runtime_tensor.cpp` — Include tensor index in rank mismatch error message
- `tools/hip-onnx-runner/hip-onnx-runner.cpp` — Fix use-after-free on TypeInfo temporary

## Test Plan

- [x] Verified all 7 Phi-4 single-layer models pass (seq1, seq128, seq256, seq512, seq1024, seq2048, seq3072)
- [x] Pre-commit checks pass on all changed files
