### PR TITLE
feat: wire zero-copy constants through level-1 pass to hip-compiler

### DIFF
--- a/include/hip/Conversion/OnnxToHip/Passes.h
+++ b/include/hip/Conversion/OnnxToHip/Passes.h
@@ -22,10 +22,7 @@ std::unique_ptr<Pass> createConvertOnnxToHipPass();
 
 /// Creates a pass with an external FileSystem for constant storage.
 /// When \p fs is non-null, externalized constants are written via \p fs
-/// instead of a DiskFileSystem rooted at the output directory. This is
-/// the production path used by hip-compiler when called from an ORT EP,
-/// where constants must be written into the EPContext archive.
-/// \p minNumElements controls the externalization threshold.
+/// instead of a DiskFileSystem rooted at the output directory.
 std::unique_ptr<Pass> createConvertOnnxToHipPass(
     morphizen::FileSystem *fs,
     int64_t minNumElements = kDefaultExternalizeMinNumElements);

--- a/include/hip/Dialect/Transforms/Pipelines.h
+++ b/include/hip/Dialect/Transforms/Pipelines.h
@@ -54,27 +54,13 @@ struct HipToLLVMPipelineOptions
 /// Build the ONNX-to-HIP compilation pipeline.
 ///
 /// Converts ONNX-level tensor IR into fully bufferized HIP memref IR with
-/// pooled allocations and resolved extern constants. The pipeline order is
-/// critical -- see Pipelines.cpp for detailed commentary on why each pass
-/// must appear at its position.
+/// pooled allocations and resolved extern constants.
 ///
-/// This overload uses a default DiskFileSystem for writing externalized
-/// constants (constants.bin). Use it for CLI / standalone workflows
-/// (hip-compiler, hip-mlir-opt, LIT tests) where constants live on disk
-/// next to the compiled DLL.
-void buildOnnxToHipPipeline(OpPassManager &pm,
-                            const OnnxToHipPipelineOptions &options);
-
-/// Build the ONNX-to-HIP pipeline with a caller-supplied FileSystem.
-///
-/// Same pass sequence as the overload above, but externalized constants are
-/// written through fs instead of a DiskFileSystem. Use this overload for
-/// OnnxRuntime EP integration, where constants must be stored inside an
-/// EPContext archive so that the runtime can retrieve them later via the
-/// same FileSystem interface.
+/// \p fs -- when non-null, externalized constants are written through this
+///   FileSystem (EPContext archive). When null, a DiskFileSystem is used.
 void buildOnnxToHipPipeline(OpPassManager &pm,
                             const OnnxToHipPipelineOptions &options,
-                            morphizen::FileSystem *fs);
+                            morphizen::FileSystem *fs = nullptr);
 
 /// Build the HIP-to-LLVM lowering pipeline. This is a separate pipeline
 /// (not part of buildOnnxToHipPipeline) because the LLVM lowering is only

--- a/include/hip/compiler_api.h
+++ b/include/hip/compiler_api.h
@@ -24,27 +24,19 @@ extern "C" {
 #endif
 
 /**
- * Compilation entry point with external constant storage.
+ * Compile MLIR input to DLL/object/IR file.
  *
- * Compiles MLIR input to DLL/object/IR file. onnx.Constant data is written
- * to "constants.bin" via the provided FileSystem. The DLL contains only code;
- * all weight data lives in the external file.
+ * onnx.Constant data is written to "constants.bin" via the provided
+ * FileSystem. External constants are identified by the `location`
+ * attribute on onnx.Constant ops in the MLIR bytecode.
  *
- * constants.bin format: raw concatenated bytes of each constant in
- * discovery order. Sizes are hardcoded in the generated inference_init.
- *
- * The generated inference_init signature becomes:
- *   int inference_init(void** out_state, void* fs)
- * where fs is a morphizen::FileSystem* passed as void* for C ABI.
- *
- * @param input_mlir   Input MLIR data (text or bytecode)
- * @param input_size   Size of input data in bytes
- * @param output_path  Output DLL/object/IR file path
- * @param options_json Compilation options as JSON string (can be NULL)
- * @param error        Error information output (can be NULL)
- * @param fs           morphizen::FileSystem* (cast to void* for C ABI).
- *                     Used to create "constants.bin" for writing.
- * @return             COMPILER_SUCCESS or error code
+ * @param input_mlir      Input MLIR data (text or bytecode)
+ * @param input_size      Size of input data in bytes
+ * @param output_path     Output DLL/object/IR file path
+ * @param options_json    Compilation options as JSON string (can be NULL)
+ * @param error           Error information output (can be NULL)
+ * @param fs              morphizen::FileSystem* (cast to void* for C ABI)
+ * @return                COMPILER_SUCCESS or error code
  */
 COMPILER_API CompilerErrorCode hip_compile_with_fs(
     const void *input_mlir, size_t input_size, const char *output_path,

--- a/lib/CInterface/CompilerAPI.cpp
+++ b/lib/CInterface/CompilerAPI.cpp
@@ -54,9 +54,8 @@ COMPILER_API CompilerErrorCode hip_compile_with_fs(
     const void *input_mlir, size_t input_size, const char *output_path,
     const char *options_json, CompilerError *error, void *fs) {
   if (!input_mlir || input_size == 0 || !output_path) {
-    setError(
-        error,
-        "Invalid input: input_mlir, input_size, and output_path must be valid");
+    setError(error, "Invalid input: input_mlir, input_size, and output_path "
+                    "must be valid");
     return COMPILER_ERROR_INVALID_INPUT;
   }
   if (!fs) {

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -11,6 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hip/Conversion/OnnxToHip/Passes.h"
 #include "hip/Dialect/IR/HipDialect.h"
 #include "hip/Dialect/Transforms/Passes.h"
 
@@ -154,22 +155,209 @@ struct ExternalizationState {
   llvm::SmallVector<int64_t> constantOffsets;
 };
 
-/// Lower onnx.Constant ops.
+/// Write alignment padding to constants.bin and return the aligned byte
+/// offset where the next constant's data should begin.
+static int64_t writeAlignmentPadding(ExternalizationState *extState,
+                                     int64_t alignment = 64) {
+  int64_t aligned = llvm::alignTo(extState->currentOffset, alignment);
+  int64_t padding = aligned - extState->currentOffset;
+  if (padding > 0) {
+    llvm::SmallVector<char> zeros(padding, 0);
+    extState->writer->fwrite(zeros.data(), padding);
+    extState->currentOffset += padding;
+  }
+  return extState->currentOffset;
+}
+
+/// Shared bookkeeping after constant data has been written to constants.bin.
+/// Updates ExternalizationState counters, emits the JSON manifest entry,
+/// creates the extern memref.global with hip.external_data, and replaces
+/// the original op with memref.get_global + bufferization.to_tensor.
+static void finalizeExternalizedConstant(mlir::ModuleOp module,
+                                         mlir::Operation *constOp,
+                                         mlir::RankedTensorType tensorType,
+                                         int64_t byteSize, int64_t entryOffset,
+                                         ExternalizationState *extState) {
+  constexpr int64_t kAlignment = 64;
+  auto memrefType =
+      mlir::MemRefType::get(tensorType.getShape(), tensorType.getElementType());
+
+  std::string name = "hip_ext_constant_";
+  if (auto nodeNameAttr =
+          constOp->getAttrOfType<mlir::StringAttr>("onnx_node_name")) {
+    std::string fragment = sanitizeForMlirIdentifier(nodeNameAttr.getValue());
+    if (!fragment.empty())
+      name += fragment + "_";
+  }
+  name += std::to_string(extState->constantIndex);
+
+  extState->constantSizes.push_back(byteSize);
+  extState->constantOffsets.push_back(entryOffset);
+
+  llvm::json::Array shapeArray;
+  for (int64_t dim : tensorType.getShape())
+    shapeArray.push_back(dim);
+  llvm::json::Object entry;
+  entry["name"] = name;
+  entry["shape"] = std::move(shapeArray);
+  entry["element_type"] = elementTypeToString(tensorType.getElementType());
+  entry["offset"] = entryOffset;
+  entry["size"] = byteSize;
+  entry["alignment"] = kAlignment;
+  extState->manifestEntries.push_back(std::move(entry));
+
+  mlir::OpBuilder moduleBuilder(module.getBody(), module.getBody()->begin());
+  auto externalDataAttr = moduleBuilder.getDictionaryAttr({
+      moduleBuilder.getNamedAttr(
+          "index", moduleBuilder.getI64IntegerAttr(extState->constantIndex)),
+      moduleBuilder.getNamedAttr("offset",
+                                 moduleBuilder.getI64IntegerAttr(entryOffset)),
+      moduleBuilder.getNamedAttr("size",
+                                 moduleBuilder.getI64IntegerAttr(byteSize)),
+  });
+  auto globalOp = mlir::memref::GlobalOp::create(
+      moduleBuilder, constOp->getLoc(), name,
+      /*sym_visibility=*/moduleBuilder.getStringAttr("private"),
+      /*type=*/memrefType,
+      /*initial_value=*/nullptr,
+      /*constant=*/false,
+      /*alignment=*/moduleBuilder.getI64IntegerAttr(kAlignment));
+  globalOp->setAttr("hip.external_data", externalDataAttr);
+
+  mlir::OpBuilder builder(constOp);
+  auto getGlobal = mlir::memref::GetGlobalOp::create(builder, constOp->getLoc(),
+                                                     memrefType, name);
+  auto toTensor = mlir::bufferization::ToTensorOp::create(
+      builder, constOp->getLoc(), tensorType, getGlobal.getResult(),
+      /*restrict=*/builder.getUnitAttr(),
+      /*writable=*/nullptr);
+  constOp->getResult(0).replaceAllUsesWith(toTensor.getResult());
+  constOp->erase();
+
+  ++extState->constantIndex;
+}
+
+/// Write one constant's raw data to constants.bin and replace the op with
+/// an extern memref.global + bufferization.to_tensor bridge.
+static void externalizeConstant(mlir::ModuleOp module, mlir::Operation *constOp,
+                                mlir::RankedTensorType tensorType,
+                                const void *rawPtr, int64_t byteSize,
+                                ExternalizationState *extState) {
+  int64_t entryOffset = writeAlignmentPadding(extState);
+  extState->writer->fwrite(rawPtr, byteSize);
+  extState->currentOffset += byteSize;
+  finalizeExternalizedConstant(module, constOp, tensorType, byteSize,
+                               entryOffset, extState);
+}
+
+/// Replace an onnx.Constant op with an inline arith.constant.
+static void replaceWithArithConstant(mlir::Operation *constOp,
+                                     mlir::DenseElementsAttr valueAttr) {
+  mlir::OpBuilder builder(constOp);
+  auto arithConst =
+      mlir::arith::ConstantOp::create(builder, constOp->getLoc(), valueAttr);
+  constOp->getResult(0).replaceAllUsesWith(arithConst.getResult());
+  constOp->erase();
+}
+
+/// Externalize a splat constant: expand the single element via chunked
+/// writes to avoid allocating the full tensor in memory.
+static void externalizeSplatConstant(mlir::ModuleOp module,
+                                     mlir::Operation *constOp,
+                                     mlir::RankedTensorType tensorType,
+                                     mlir::DenseElementsAttr valueAttr,
+                                     int64_t byteSize,
+                                     ExternalizationState *extState) {
+  auto rawData = valueAttr.getRawData();
+  constexpr size_t kSplatChunk = 1024 * 1024;
+  size_t elemSize = rawData.size();
+  size_t bufSize =
+      (std::min(static_cast<size_t>(byteSize), kSplatChunk) / elemSize) *
+      elemSize;
+  std::vector<char> buf(bufSize);
+  for (size_t i = 0; i < bufSize; i += elemSize)
+    std::memcpy(buf.data() + i, rawData.data(), elemSize);
+
+  int64_t entryOffset = writeAlignmentPadding(extState);
+  size_t remaining = static_cast<size_t>(byteSize);
+  while (remaining > 0) {
+    size_t toWrite = std::min(remaining, bufSize);
+    extState->writer->fwrite(buf.data(), toWrite);
+    remaining -= toWrite;
+  }
+  extState->currentOffset += byteSize;
+  finalizeExternalizedConstant(module, constOp, tensorType, byteSize,
+                               entryOffset, extState);
+}
+
+/// Resolve an onnx.Constant that carries a `location` attribute
+/// (zero-copy external data emitted by the ORT bridge).
+/// The `offset` attribute holds a raw memory address (ORT tensor pointer
+/// cast to i64) and `size` holds the byte count.
 ///
-/// Small constants (below \p minNumElements or when externalization is
-/// disabled) are converted to arith.constant -- bufferization later turns
-/// them into memref.global + memref.get_global.
+/// Input IR (produced by ir-converter-imp.cpp):
 ///
-/// Large constants (at or above threshold, non-splat) are externalized:
-/// their raw data is appended to the sidecar binary via \p extState, and
-/// they are replaced by an extern memref.global (no initial value) carrying
-/// a hip.external_data {offset, size} attribute, plus a
-/// memref.get_global + bufferization.to_tensor bridge at the use site.
+///   %cst = "onnx.Constant"()
+///       {location = "*/_ORT_MEM_ADDR_/*",
+///        offset = 140695085056000 : i64,
+///        size = 32 : i64} : () -> tensor<2x4xf32>
+///
+/// Output IR when externalization is enabled (extState != nullptr):
+///
+///   memref.global "private" @hip_ext_constant_0 : memref<2x4xf32>
+///       {alignment = 64 : i64,
+///        hip.external_data = {index = 0 : i64, offset = 0 : i64,
+///                             size = 32 : i64}}
+///   ...
+///   %0 = memref.get_global @hip_ext_constant_0 : memref<2x4xf32>
+///   %1 = bufferization.to_tensor %0 restrict
+///       : memref<2x4xf32> to tensor<2x4xf32>
+///
+/// Output IR when externalization is disabled (extState == nullptr):
+///
+///   %cst = arith.constant dense<[[1.0, 2.0, 3.0, 4.0], ...]>
+///       : tensor<2x4xf32>
+static mlir::LogicalResult
+resolveExternalLocationConstant(mlir::ModuleOp module, mlir::Operation *constOp,
+                                ExternalizationState *extState) {
+  auto offsetAttr = constOp->getAttrOfType<mlir::IntegerAttr>("offset");
+  auto sizeAttr = constOp->getAttrOfType<mlir::IntegerAttr>("size");
+  if (!offsetAttr || !sizeAttr)
+    return constOp->emitError(
+        "onnx.Constant with location attribute missing offset or size");
+
+  int64_t addr = offsetAttr.getInt();
+  int64_t dataSize = sizeAttr.getInt();
+  if (addr == 0 || dataSize <= 0)
+    return constOp->emitError("onnx.Constant has invalid address/size");
+
+  const void *dataPtr =
+      reinterpret_cast<const void *>(static_cast<uintptr_t>(addr));
+
+  auto tensorType =
+      mlir::dyn_cast<mlir::RankedTensorType>(constOp->getResult(0).getType());
+  if (!tensorType)
+    return constOp->emitError("external constant has non-ranked result type");
+
+  if (extState) {
+    externalizeConstant(module, constOp, tensorType, dataPtr, dataSize,
+                        extState);
+  } else {
+    auto rawData =
+        llvm::ArrayRef<char>(static_cast<const char *>(dataPtr), dataSize);
+    auto denseAttr =
+        mlir::DenseElementsAttr::getFromRawBuffer(tensorType, rawData);
+    replaceWithArithConstant(constOp, denseAttr);
+  }
+  return mlir::success();
+}
+
+/// Lower onnx.Constant ops to either externalized constants (constants.bin)
+/// or inline arith.constant ops.
 static mlir::LogicalResult lowerOnnxConstants(mlir::ModuleOp module,
                                               mlir::func::FuncOp funcOp,
                                               int64_t minNumElements,
                                               ExternalizationState *extState) {
-  constexpr int64_t kAlignment = 64;
 
   llvm::SmallVector<mlir::Operation *> constants;
   funcOp.walk([&](mlir::Operation *op) {
@@ -180,124 +368,36 @@ static mlir::LogicalResult lowerOnnxConstants(mlir::ModuleOp module,
   for (mlir::Operation *constOp : constants) {
     auto valueAttr = mlir::dyn_cast_or_null<mlir::DenseElementsAttr>(
         constOp->getAttrOfType<mlir::ElementsAttr>("value"));
-    if (!valueAttr) {
+
+    if (valueAttr) {
+      // Inline dense constant -- fall through to externalize-or-inline below.
+    } else if (constOp->hasAttr("location")) {
+      if (mlir::failed(
+              resolveExternalLocationConstant(module, constOp, extState)))
+        return mlir::failure();
+      continue;
+    } else {
       return constOp->emitError(
-          "unsupported onnx.Constant form (expected dense value attribute)");
+          "unsupported onnx.Constant form (expected dense value attribute "
+          "or location attribute)");
     }
 
-    bool shouldExternalize = extState && minNumElements > 0 &&
-                             valueAttr.getNumElements() >= minNumElements;
-
-    if (shouldExternalize) {
+    if (extState && minNumElements > 0 &&
+        valueAttr.getNumElements() >= minNumElements) {
       auto tensorType = mlir::cast<mlir::RankedTensorType>(valueAttr.getType());
-      auto memrefType = mlir::MemRefType::get(tensorType.getShape(),
-                                              tensorType.getElementType());
-
-      // Build a unique, MLIR-safe symbol name: prefix + sanitized node
-      // name (if present) + monotonic index to guarantee uniqueness.
-      std::string name = "hip_ext_constant_";
-      if (auto nodeNameAttr =
-              constOp->getAttrOfType<mlir::StringAttr>("onnx_node_name")) {
-        std::string fragment =
-            sanitizeForMlirIdentifier(nodeNameAttr.getValue());
-        if (!fragment.empty())
-          name += fragment + "_";
-      }
-      name += std::to_string(extState->constantIndex);
-
-      // Pad binary file to alignment boundary.
-      int64_t aligned = llvm::alignTo(extState->currentOffset, kAlignment);
-      int64_t padding = aligned - extState->currentOffset;
-      if (padding > 0) {
-        llvm::SmallVector<char> zeros(padding, 0);
-        extState->writer->fwrite(zeros.data(), padding);
-        extState->currentOffset += padding;
-      }
-      int64_t entryOffset = extState->currentOffset;
-
-      // Compute full tensor byte size from shape and element width.
-      auto rawData = valueAttr.getRawData();
       int64_t elemBits = tensorType.getElementTypeBitWidth();
       int64_t byteSize = valueAttr.getNumElements() * ((elemBits + 7) / 8);
 
       if (valueAttr.isSplat()) {
-        // Splat: MLIR stores only one element; expand via a staging
-        // buffer to avoid per-element fwrite overhead on large tensors.
-        constexpr size_t kSplatChunk = 1024 * 1024;
-        size_t elemSize = rawData.size();
-        size_t bufSize =
-            (std::min(static_cast<size_t>(byteSize), kSplatChunk) / elemSize) *
-            elemSize;
-        std::vector<char> buf(bufSize);
-        for (size_t i = 0; i < bufSize; i += elemSize)
-          std::memcpy(buf.data() + i, rawData.data(), elemSize);
-        size_t remaining = static_cast<size_t>(byteSize);
-        while (remaining > 0) {
-          size_t toWrite = std::min(remaining, bufSize);
-          extState->writer->fwrite(buf.data(), toWrite);
-          remaining -= toWrite;
-        }
+        externalizeSplatConstant(module, constOp, tensorType, valueAttr,
+                                 byteSize, extState);
       } else {
-        extState->writer->fwrite(rawData.data(), byteSize);
+        externalizeConstant(module, constOp, tensorType,
+                            valueAttr.getRawData().data(), byteSize, extState);
       }
-      extState->currentOffset += byteSize;
 
-      // Track sizes and offsets for module-level metadata.
-      extState->constantSizes.push_back(byteSize);
-      extState->constantOffsets.push_back(entryOffset);
-
-      // Build JSON manifest entry.
-      llvm::json::Array shapeArray;
-      for (int64_t dim : tensorType.getShape())
-        shapeArray.push_back(dim);
-      llvm::json::Object entry;
-      entry["name"] = name;
-      entry["shape"] = std::move(shapeArray);
-      entry["element_type"] = elementTypeToString(tensorType.getElementType());
-      entry["offset"] = entryOffset;
-      entry["size"] = byteSize;
-      entry["alignment"] = kAlignment;
-      extState->manifestEntries.push_back(std::move(entry));
-
-      // Create extern memref.global at module scope.
-      mlir::OpBuilder moduleBuilder(module.getBody(),
-                                    module.getBody()->begin());
-      auto externalDataAttr = moduleBuilder.getDictionaryAttr({
-          moduleBuilder.getNamedAttr("index", moduleBuilder.getI64IntegerAttr(
-                                                  extState->constantIndex)),
-          moduleBuilder.getNamedAttr(
-              "offset", moduleBuilder.getI64IntegerAttr(entryOffset)),
-          moduleBuilder.getNamedAttr("size",
-                                     moduleBuilder.getI64IntegerAttr(byteSize)),
-      });
-      auto globalOp = mlir::memref::GlobalOp::create(
-          moduleBuilder, constOp->getLoc(), name,
-          /*sym_visibility=*/moduleBuilder.getStringAttr("private"),
-          /*type=*/memrefType,
-          /*initial_value=*/nullptr,
-          /*constant=*/false,
-          /*alignment=*/moduleBuilder.getI64IntegerAttr(kAlignment));
-      globalOp->setAttr("hip.external_data", externalDataAttr);
-
-      // At the use site: memref.get_global + bufferization.to_tensor.
-      mlir::OpBuilder builder(constOp);
-      auto getGlobal = mlir::memref::GetGlobalOp::create(
-          builder, constOp->getLoc(), memrefType, name);
-      auto toTensor = mlir::bufferization::ToTensorOp::create(
-          builder, constOp->getLoc(), tensorType, getGlobal.getResult(),
-          /*restrict=*/builder.getUnitAttr(),
-          /*writable=*/nullptr);
-      constOp->getResult(0).replaceAllUsesWith(toTensor.getResult());
-      constOp->erase();
-
-      ++extState->constantIndex;
     } else {
-      // Small / splat / externalization disabled: inline arith.constant.
-      mlir::OpBuilder builder(constOp);
-      auto arithConst = mlir::arith::ConstantOp::create(
-          builder, constOp->getLoc(), valueAttr);
-      constOp->getResult(0).replaceAllUsesWith(arithConst.getResult());
-      constOp->erase();
+      replaceWithArithConstant(constOp, valueAttr);
     }
   }
   return mlir::success();

--- a/lib/Dialect/Transforms/Pipelines.cpp
+++ b/lib/Dialect/Transforms/Pipelines.cpp
@@ -74,18 +74,6 @@ static void buildOnnxToHipPipelineTail(OpPassManager &pm) {
   pm.addPass(createCanonicalizerPass());
 }
 
-void mlir::hip::buildOnnxToHipPipeline(
-    OpPassManager &pm, const OnnxToHipPipelineOptions &options) {
-  pm.addPass(createHipAddContextArgPass());
-
-  ConvertOnnxToHipPassOptions onnxToHipOpts;
-  onnxToHipOpts.externalizeOutputDir = options.externalizeOutputDir;
-  onnxToHipOpts.externalizeMinNumElements = options.externalizeMinNumElements;
-  pm.addPass(createConvertOnnxToHipPass(std::move(onnxToHipOpts)));
-
-  buildOnnxToHipPipelineTail(pm);
-}
-
 void mlir::hip::buildOnnxToHipPipeline(OpPassManager &pm,
                                        const OnnxToHipPipelineOptions &options,
                                        morphizen::FileSystem *fs) {

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -217,7 +217,9 @@ int hipdnn_ep_state_init_with_fs(RuntimeState **out_state, void *fs,
 
   if (is_igpu) {
     // iGPU: allocate pinned host memory. GPU reads the same physical DRAM
-    // directly — no hipMemcpy needed. Draws from system RAM, not GPU quota.
+    // directly -- no hipMemcpy needed. hipHostMalloc gives a reliable pinned
+    // allocation; hipHostRegister on mmap'd or VirtualAlloc'd memory is
+    // unreliable on some iGPU platforms (GPU reads zeros despite success).
     if (hipHostMalloc(&state->gpu_constants_blob, total_size,
                       hipHostMallocDefault) != hipSuccess) {
       fprintf(stderr, "hipHostMalloc failed for constants blob (%zu bytes)\n",
@@ -226,12 +228,12 @@ int hipdnn_ep_state_init_with_fs(RuntimeState **out_state, void *fs,
       *out_state = nullptr;
       return 1;
     }
-    state->constants_blob_is_host = true;
 
     const void *src = reader->mmap();
     if (src) {
       memcpy(state->gpu_constants_blob, src, total_size);
     } else {
+      reader->rewind();
       size_t bytes_read = reader->fread(state->gpu_constants_blob, total_size);
       if (bytes_read != total_size) {
         fprintf(stderr, "Short read: got %zu of %zu bytes\n", bytes_read,
@@ -241,6 +243,8 @@ int hipdnn_ep_state_init_with_fs(RuntimeState **out_state, void *fs,
         return 1;
       }
     }
+    state->constants_blob_is_host = true;
+
   } else {
     // dGPU: allocate in VRAM, upload once via hipMemcpy.
     const void *src = reader->mmap();

--- a/test/lit/Conversion/onnx-to-hip/test_constant_externalize_named.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_constant_externalize_named.mlir
@@ -1,0 +1,26 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+//===----------------------------------------------------------------------===//
+// Test: onnx_node_name flows into externalized global symbol name.
+//
+// Verifies that finalizeExternalizedConstant() incorporates a sanitized
+// onnx_node_name into the memref.global name.  The sanitizer replaces '/'
+// with '_', collapses consecutive underscores, and strips leading/trailing
+// underscores -- so "/model/MatMul_weights" becomes "model_MatMul_weights".
+//===----------------------------------------------------------------------===//
+
+// RUN: mkdir -p %t && hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip='externalize-min-num-elements=4 externalize-output-dir=%t' %s | FileCheck %s
+
+// CHECK: memref.global "private" @hip_ext_constant_model_MatMul_weights_0 : memref<2x4xf32> {alignment = 64 : i64, hip.external_data = {index = 0 : i64, offset = 0 : i64, size = 32 : i64}}
+// CHECK: func.func @main_graph(%arg0: !hip.context) -> tensor<2x4xf32>
+// CHECK-NEXT: %0 = memref.get_global @hip_ext_constant_model_MatMul_weights_0 : memref<2x4xf32>
+// CHECK-NEXT: %1 = bufferization.to_tensor %0 restrict : memref<2x4xf32> to tensor<2x4xf32>
+// CHECK-NEXT: return %1 : tensor<2x4xf32>
+
+module {
+  func.func @main_graph() -> tensor<2x4xf32> {
+    %0 = "onnx.Constant"() {onnx_node_name = "/model/MatMul_weights", value = dense<[[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]]> : tensor<2x4xf32>} : () -> tensor<2x4xf32>
+    "onnx.Return"(%0) {onnx_node_name = "/Return"} : (tensor<2x4xf32>) -> ()
+  }
+}

--- a/test/lit/Conversion/onnx-to-hip/test_constant_location_missing_attrs.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_constant_location_missing_attrs.mlir
@@ -1,0 +1,23 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+//===----------------------------------------------------------------------===//
+// Test: onnx.Constant with location attribute but missing offset/size.
+//
+// The zero-copy path expects both offset and size integer attributes
+// alongside the location sentinel. Verify the diagnostic when they
+// are absent.
+//===----------------------------------------------------------------------===//
+
+// RUN: not hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s 2>&1 | FileCheck %s
+
+// CHECK: error: onnx.Constant with location attribute missing offset or size
+// CHECK-NEXT: %0 = "onnx.Constant"() {location = "*/_ORT_MEM_ADDR_/*"} : () -> tensor<2x4xf32>
+// CHECK-NEXT: ^
+
+module {
+  func.func @main_graph() -> tensor<2x4xf32> {
+    %0 = "onnx.Constant"() {location = "*/_ORT_MEM_ADDR_/*"} : () -> tensor<2x4xf32>
+    "onnx.Return"(%0) {onnx_node_name = "/Return"} : (tensor<2x4xf32>) -> ()
+  }
+}

--- a/test/lit/Conversion/onnx-to-hip/test_constant_location_null_addr.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_constant_location_null_addr.mlir
@@ -1,0 +1,22 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+//===----------------------------------------------------------------------===//
+// Test: onnx.Constant with location attribute but null address (offset=0).
+//
+// A zero address is invalid -- the ORT bridge should never produce one.
+// Verify the pass rejects it with a clear diagnostic.
+//===----------------------------------------------------------------------===//
+
+// RUN: not hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s 2>&1 | FileCheck %s
+
+// CHECK: error: onnx.Constant has invalid address/size
+// CHECK-NEXT: %0 = "onnx.Constant"() {location = "*/_ORT_MEM_ADDR_/*", offset = 0 : i64, size = 32 : i64} : () -> tensor<2x4xf32>
+// CHECK-NEXT: ^
+
+module {
+  func.func @main_graph() -> tensor<2x4xf32> {
+    %0 = "onnx.Constant"() {location = "*/_ORT_MEM_ADDR_/*", offset = 0 : i64, size = 32 : i64} : () -> tensor<2x4xf32>
+    "onnx.Return"(%0) {onnx_node_name = "/Return"} : (tensor<2x4xf32>) -> ()
+  }
+}

--- a/test/lit/Conversion/onnx-to-hip/test_constant_missing_value_error.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_constant_missing_value_error.mlir
@@ -1,0 +1,22 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+//===----------------------------------------------------------------------===//
+// Test: onnx.Constant without value or location attribute produces an error.
+//
+// Verifies the updated error message that mentions the location attribute
+// (zero-copy path) as an accepted alternative to a dense value attribute.
+//===----------------------------------------------------------------------===//
+
+// RUN: not hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s 2>&1 | FileCheck %s
+
+// CHECK: error: unsupported onnx.Constant form (expected dense value attribute or location attribute)
+// CHECK-NEXT: %0 = "onnx.Constant"() {value_string = "bad"} : () -> tensor<2xf32>
+// CHECK-NEXT: ^
+
+module {
+  func.func @main_graph() -> tensor<2xf32> {
+    %0 = "onnx.Constant"() {value_string = "bad"} : () -> tensor<2xf32>
+    "onnx.Return"(%0) {onnx_node_name = "/Return"} : (tensor<2xf32>) -> ()
+  }
+}


### PR DESCRIPTION
## Motivation

Handle external constants in the MLIR compilation pipeline by resolving them directly from the `location`/`offset`/`size` attributes on `onnx.Constant` ops, rather than wiring constant references through multiple layers of the compilation stack.

## Changes

### Core: resolve external constants via `location` attribute (OnnxToHip.cpp)

- Add `resolveExternalLocationConstant()` to handle `onnx.Constant` ops carrying `location`/`offset`/`size` attributes (external data form emitted by the MLIR graph builder)
- The `offset` attribute holds the raw memory address; `size` holds the byte count
- Constants are either externalized to the `constants.bin` sidecar or inlined as `arith.constant`
- Update `lowerOnnxConstants` decision logic: try `value` attr first, then `location` attr, then error

## Net diff

12 files changed, 79 insertions, 119 deletions.

**Dependency:** https://github.com/ROCm/MorphiZen/pull/198