### PR TITLE
fix: Gather multi-index, GQA pre-allocated KV cache, shared constants, custom kernels discovery

### DIFF
--- a/3rd-party/custom_kernels/hip/gather_kernel.hip
+++ b/3rd-party/custom_kernels/hip/gather_kernel.hip
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023 - 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Licensed under the MIT License.
  */
 
@@ -10,26 +10,29 @@
 #include <cstdint>
 #include <cstdio>
 
-// Generic gather kernel for axis=0 with a single scalar index.
-// T is the element type used for copying (uint16_t, uint32_t, int64_t).
-// Indices are always i64.
+// Generic gather kernel for axis=0 with arbitrary number of indices.
+// Each thread copies one element of the output tensor.
+// Thread tid maps to: index_idx = tid / slice_size, offset = tid % slice_size.
+// output[tid] = data[indices[index_idx] * slice_size + offset]
 template <typename T>
 __global__ void gather_axis0_kernel(
     const T* __restrict__ data,
     const int64_t* __restrict__ indices,
     T* __restrict__ output,
     int64_t slice_size,
-    int64_t data_axis_size) {
-  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-  if (idx < slice_size) {
-    int64_t index_val = indices[0];
+    int64_t data_axis_size,
+    int64_t total_elements) {
+  int64_t tid = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (tid < total_elements) {
+    int64_t index_idx = tid / slice_size;
+    int64_t offset = tid % slice_size;
+    int64_t index_val = indices[index_idx];
     if (index_val < 0) index_val += data_axis_size;
     if (index_val < 0 || index_val >= data_axis_size) {
-      output[idx] = T(0);
+      output[tid] = T(0);
       return;
     }
-    int64_t src_offset = index_val * slice_size + idx;
-    output[idx] = data[src_offset];
+    output[tid] = data[index_val * slice_size + offset];
   }
 }
 
@@ -40,6 +43,7 @@ extern "C" int hip_gather(
     void* output,
     int64_t axis,
     int64_t data_num_elements,
+    int64_t indices_num_elements,
     int64_t output_num_elements,
     int element_size_bytes) {
   if (output_num_elements <= 0) return 0;
@@ -56,15 +60,24 @@ extern "C" int hip_gather(
     return -1;
   }
 
-  int64_t slice_size = output_num_elements;
-  int64_t data_axis_size = data_num_elements / slice_size;
+  // For axis=0: output = [indices_shape..., data_shape[1:]]
+  // slice_size = product of data dimensions after axis 0
+  // data_axis_size = data_shape[0]
+  int64_t slice_size = (indices_num_elements > 0)
+      ? output_num_elements / indices_num_elements
+      : output_num_elements;
+  int64_t data_axis_size = (slice_size > 0)
+      ? data_num_elements / slice_size
+      : 0;
 
   CUSTOM_KERNELS_DEBUG_LOG("[custom_kernels] hip_gather: axis=0, elem_size=%d, "
-          "data_num=%lld, output_num=%lld, data_axis_size=%lld, "
-          "grid=%d, block=%d\n",
+          "data_num=%lld, indices_num=%lld, output_num=%lld, "
+          "slice_size=%lld, data_axis_size=%lld, grid=%d, block=%d\n",
           element_size_bytes,
-          (long long)data_num_elements, (long long)output_num_elements,
-          (long long)data_axis_size, grid_size, kBlockSize);
+          (long long)data_num_elements, (long long)indices_num_elements,
+          (long long)output_num_elements,
+          (long long)slice_size, (long long)data_axis_size,
+          grid_size, kBlockSize);
 
   switch (element_size_bytes) {
     case 2:
@@ -73,7 +86,7 @@ extern "C" int hip_gather(
                          static_cast<const uint16_t*>(data),
                          static_cast<const int64_t*>(indices),
                          static_cast<uint16_t*>(output),
-                         slice_size, data_axis_size);
+                         slice_size, data_axis_size, output_num_elements);
       break;
     case 4:
       hipLaunchKernelGGL(gather_axis0_kernel<uint32_t>,
@@ -81,7 +94,7 @@ extern "C" int hip_gather(
                          static_cast<const uint32_t*>(data),
                          static_cast<const int64_t*>(indices),
                          static_cast<uint32_t*>(output),
-                         slice_size, data_axis_size);
+                         slice_size, data_axis_size, output_num_elements);
       break;
     case 8:
       hipLaunchKernelGGL(gather_axis0_kernel<int64_t>,
@@ -89,7 +102,7 @@ extern "C" int hip_gather(
                          static_cast<const int64_t*>(data),
                          static_cast<const int64_t*>(indices),
                          static_cast<int64_t*>(output),
-                         slice_size, data_axis_size);
+                         slice_size, data_axis_size, output_num_elements);
       break;
     default:
       fprintf(stderr,

--- a/3rd-party/custom_kernels/include/hip_custom_kernels.h
+++ b/3rd-party/custom_kernels/include/hip_custom_kernels.h
@@ -232,20 +232,24 @@ int hip_cast(
  * =========================================================================
  *
  * Gathers slices from data along the given axis using indices.
- * For axis=0 with scalar index:
- *   output[i] = data[index * output_num_elements + i]
+ * For axis=0:
+ *   slice_size = data_num_elements / data_shape[0]
+ *   For each index i in [0, indices_num_elements):
+ *     output[i*slice_size : (i+1)*slice_size] =
+ *       data[indices[i]*slice_size : (indices[i]+1)*slice_size]
  *
  * Parameters:
- *   stream              - hipStream_t cast to void*
- *   data                - GPU pointer to source tensor
- *   indices             - GPU pointer to index tensor (i64 values)
- *   output              - GPU pointer to output
- *   axis                - axis along which to gather
- *   data_num_elements   - total elements in data tensor
- *   output_num_elements - total elements in output tensor
- *   element_size_bytes  - byte size per element (used for raw copy)
+ *   stream                - hipStream_t cast to void*
+ *   data                  - GPU pointer to source tensor
+ *   indices               - GPU pointer to index tensor (i64 values)
+ *   output                - GPU pointer to output
+ *   axis                  - axis along which to gather
+ *   data_num_elements     - total elements in data tensor
+ *   indices_num_elements  - total elements in indices tensor
+ *   output_num_elements   - total elements in output tensor
+ *   element_size_bytes    - byte size per element (used for raw copy)
  *
- * Currently supports: axis=0, scalar (single-element) index
+ * Currently supports: axis=0
  * Supported element sizes: 2 (f16/bf16), 4 (f32/i32), 8 (i64/f64)
  * Returns: 0 on success, non-zero on failure
  */
@@ -256,6 +260,7 @@ int hip_gather(
     void* output,
     int64_t axis,
     int64_t data_num_elements,
+    int64_t indices_num_elements,
     int64_t output_num_elements,
     int element_size_bytes);
 

--- a/lib/Compiler/CompilerDriver.cpp
+++ b/lib/Compiler/CompilerDriver.cpp
@@ -306,23 +306,51 @@ void CompilerDriver::discoverLibraries(
   else
     COMPILER_DEBUG_LOG("  WARNING: hipblaslt import library not found\n");
 
-#ifdef HIP_CUSTOM_KERNELS_LIB_PATH
+  // Custom kernels library discovery (priority high → low):
+  //
+  //   1. HIP_CUSTOM_KERNELS_DIR env var  — runtime override for end-users
+  //      who deploy the library in a non-standard location.  The directory
+  //      is added to library_paths so the linker can find it.
+  //
+  //   2. HIP_CUSTOM_KERNELS_LIB_PATH    — compile-time absolute path set
+  //      by CMake (CMAKE_INSTALL_PREFIX/lib/hip_custom_kernels.lib).
+  //      Used by developers whose kernels library is in the install tree.
+  //
+  //   3. Name-only fallback              — "hip_custom_kernels" is passed
+  //      to the linker, which searches library_paths (/LIBPATH:) and the
+  //      system LIB environment variable.
   {
-    std::string custom_lib = HIP_CUSTOM_KERNELS_LIB_PATH;
-    if (llvm::sys::fs::exists(custom_lib)) {
-      libraries.push_back(custom_lib);
-      COMPILER_DEBUG_LOG("  Custom kernels: " << custom_lib << "\n");
-    } else {
-      COMPILER_DEBUG_LOG(
-          "  WARNING: custom kernels lib not found at: " << custom_lib << "\n");
-      // Fall back: add by name so lld-link searches library_paths (/LIBPATH:)
-      // and the LIB environment variable.
+    bool found = false;
+
+    const char *custom_dir_env = std::getenv("HIP_CUSTOM_KERNELS_DIR");
+    if (custom_dir_env && custom_dir_env[0] != '\0') {
+      std::string custom_dir(custom_dir_env);
+      library_paths.push_back(custom_dir);
+      libraries.push_back("hip_custom_kernels");
+      found = true;
+      COMPILER_DEBUG_LOG("  Custom kernels dir (env): " << custom_dir << "\n");
+    }
+
+#ifdef HIP_CUSTOM_KERNELS_LIB_PATH
+    if (!found) {
+      std::string custom_lib = HIP_CUSTOM_KERNELS_LIB_PATH;
+      if (llvm::sys::fs::exists(custom_lib)) {
+        libraries.push_back(custom_lib);
+        found = true;
+        COMPILER_DEBUG_LOG("  Custom kernels: " << custom_lib << "\n");
+      } else {
+        COMPILER_DEBUG_LOG("  WARNING: custom kernels lib not found at: "
+                           << custom_lib << "\n");
+      }
+    }
+#endif
+
+    if (!found) {
       libraries.push_back("hip_custom_kernels");
       COMPILER_DEBUG_LOG(
-          "  Custom kernels (name fallback): hip_custom_kernels.lib\n");
+          "  Custom kernels (name fallback): hip_custom_kernels\n");
     }
   }
-#endif
 
   // hipDNN graph runtime: only needed when hipDNN graphs are compiled
   if (hipdnnHandle_) {

--- a/lib/Conversion/HipToLLVM/HipToLLVM.cpp
+++ b/lib/Conversion/HipToLLVM/HipToLLVM.cpp
@@ -1688,7 +1688,7 @@ struct GqaOpLowering : public ConvertOpToLLVMPattern<GqaOp> {
     Value elemSizeVal = createI64Const(elementSizeBytes);
 
     // Function signature matches Task 4 runtime wrapper
-    SmallVector<Type, 38> paramTypes = {
+    SmallVector<Type, 37> paramTypes = {
         ptrType, // state
         // Inputs (14 pointers - some may be nullptr)
         ptrType, // query
@@ -1710,7 +1710,7 @@ struct GqaOpLowering : public ConvertOpToLLVMPattern<GqaOp> {
         ptrType, // present_key
         ptrType, // present_value
         ptrType, // output_qk
-        // Attributes (13 values)
+        // Attributes (12 values)
         i64Type, // num_heads
         i64Type, // kv_num_heads
         f32Type, // scale
@@ -1737,7 +1737,7 @@ struct GqaOpLowering : public ConvertOpToLLVMPattern<GqaOp> {
     if (failed(funcOp))
       return failure();
 
-    SmallVector<Value, 38> args = {
+    SmallVector<Value, 37> args = {
         statePtr,
         // Inputs (14 pointers)
         queryPtr, keyPtr, valuePtr, pastKeyPtr, pastValuePtr, seqlensKPtr,
@@ -1745,7 +1745,7 @@ struct GqaOpLowering : public ConvertOpToLLVMPattern<GqaOp> {
         attentionBiasPtr, headSinkPtr, kScalePtr, vScalePtr,
         // Outputs (4 pointers)
         outputPtr, presentKeyPtr, presentValuePtr, outputQkPtr,
-        // Attributes (13 values)
+        // Attributes (12 values)
         numHeads, kvNumHeads, scale, doRotary, rotaryInterleaved, softcap,
         localWindowSize, smoothSoftmax, qkOutput, kQuantType, vQuantType,
         kvCacheBitWidth,

--- a/lib/Conversion/HipToLLVM/HipToLLVM.cpp
+++ b/lib/Conversion/HipToLLVM/HipToLLVM.cpp
@@ -1179,7 +1179,7 @@ struct SigmoidOpLowering : public ConvertOpToLLVMPattern<SigmoidOp> {
 };
 
 // Extract the 4D shape (N, C, H, W) of a memref as LLVM i64 values.
-// miopenSet4dTensorDescriptor requires exactly 4 dimensions, so ranks 1-3
+// MIOpen tensor descriptors require exactly 4 dimensions, so ranks 1-3
 // are left-padded with 1:
 //   rank 1: [W]       → [1, 1, 1, W]
 //   rank 2: [H, W]    → [1, 1, H, W]
@@ -1229,9 +1229,9 @@ enum HipdnnTensorOp : int64_t {
 //   lhs=[1,1,128,32], rhs=[1,1,1,32], out=[1,1,128,32]
 // MIOpen broadcasts rhs dims that are 1 against lhs automatically.
 //
-// NOTE: The 4D shape passing is a workaround for MIOpen's
-// miopenSet4dTensorDescriptor API. Will be replaced when hipdnn
-// elementwise support is available.
+// NOTE: The 4D shape passing is a workaround for MIOpen's tensor
+// descriptor API. Will be replaced when hipdnn elementwise support
+// is available.
 template <typename OpTy, HipdnnTensorOp tensorOpEnum>
 struct ElementwiseOpLowering : public ConvertOpToLLVMPattern<OpTy> {
   using ConvertOpToLLVMPattern<OpTy>::ConvertOpToLLVMPattern;

--- a/lib/Conversion/HipToLLVM/HipToLLVM.cpp
+++ b/lib/Conversion/HipToLLVM/HipToLLVM.cpp
@@ -1025,6 +1025,11 @@ struct GatherOpLowering : public ConvertOpToLLVMPattern<GatherOp> {
     Value dataNumElementsVal =
         computeNumElements(dataType, adaptor.getData(), rewriter, loc);
 
+    // Compute indices_num_elements
+    auto indicesType = cast<MemRefType>(op.getIndices().getType());
+    Value indicesNumElementsVal =
+        computeNumElements(indicesType, adaptor.getIndices(), rewriter, loc);
+
     // Compute output_num_elements
     auto outputType = cast<MemRefType>(op.getOutput().getType());
     Value outputNumElementsVal =
@@ -1042,9 +1047,11 @@ struct GatherOpLowering : public ConvertOpToLLVMPattern<GatherOp> {
 
     // int wrap_gather(RuntimeState* state, void* data, void* indices,
     //                 void* output, int64_t axis, int64_t data_num_elements,
-    //                 int64_t output_num_elements, int64_t element_size_bytes)
-    SmallVector<Type, 8> paramTypes = {ptrType, ptrType, ptrType, ptrType,
-                                       i64Type, i64Type, i64Type, i64Type};
+    //                 int64_t indices_num_elements, int64_t output_num_elements,
+    //                 int64_t element_size_bytes)
+    SmallVector<Type, 9> paramTypes = {ptrType, ptrType, ptrType, ptrType,
+                                       i64Type, i64Type, i64Type, i64Type,
+                                       i64Type};
 
     FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
         rewriter, module, kWrapGather, paramTypes, i32Type);
@@ -1057,6 +1064,7 @@ struct GatherOpLowering : public ConvertOpToLLVMPattern<GatherOp> {
                                outputPtr,
                                axisVal,
                                dataNumElementsVal,
+                               indicesNumElementsVal,
                                outputNumElementsVal,
                                elemSizeVal};
 

--- a/lib/Conversion/HipToLLVM/HipToLLVM.cpp
+++ b/lib/Conversion/HipToLLVM/HipToLLVM.cpp
@@ -1047,11 +1047,11 @@ struct GatherOpLowering : public ConvertOpToLLVMPattern<GatherOp> {
 
     // int wrap_gather(RuntimeState* state, void* data, void* indices,
     //                 void* output, int64_t axis, int64_t data_num_elements,
-    //                 int64_t indices_num_elements, int64_t output_num_elements,
-    //                 int64_t element_size_bytes)
-    SmallVector<Type, 9> paramTypes = {ptrType, ptrType, ptrType, ptrType,
-                                       i64Type, i64Type, i64Type, i64Type,
-                                       i64Type};
+    //                 int64_t indices_num_elements, int64_t
+    //                 output_num_elements, int64_t element_size_bytes)
+    SmallVector<Type, 9> paramTypes = {ptrType, ptrType, ptrType,
+                                       ptrType, i64Type, i64Type,
+                                       i64Type, i64Type, i64Type};
 
     FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
         rewriter, module, kWrapGather, paramTypes, i32Type);
@@ -1669,14 +1669,26 @@ struct GqaOpLowering : public ConvertOpToLLVMPattern<GqaOp> {
     auto pkShape = presentKeyType.getShape();
     int64_t seqLenKV = (pkShape.size() == 4) ? pkShape[2] : pkShape[1];
 
+    // Extract past buffer sequence dimension from past_key shape.
+    // When the KV cache is pre-allocated (fixed size), the past buffer
+    // dimension may be larger than the valid past token count.  The concat
+    // kernel needs this as the stride when reading from the past buffer.
+    int64_t pastSeqLen = 0;
+    if (op.getPastKey()) {
+      auto pastKeyType = cast<MemRefType>(op.getPastKey().getType());
+      auto pastKShape = pastKeyType.getShape();
+      pastSeqLen = (pastKShape.size() == 4) ? pastKShape[2] : pastKShape[1];
+    }
+
     Value batchSizeVal = createI64Const(batchSize);
     Value seqLenQVal = createI64Const(seqLenQ);
     Value seqLenKVVal = createI64Const(seqLenKV);
+    Value pastSeqLenVal = createI64Const(pastSeqLen);
     Value headDimVal = createI64Const(headDim);
     Value elemSizeVal = createI64Const(elementSizeBytes);
 
     // Function signature matches Task 4 runtime wrapper
-    SmallVector<Type, 37> paramTypes = {
+    SmallVector<Type, 38> paramTypes = {
         ptrType, // state
         // Inputs (14 pointers - some may be nullptr)
         ptrType, // query
@@ -1711,10 +1723,11 @@ struct GqaOpLowering : public ConvertOpToLLVMPattern<GqaOp> {
         i64Type, // k_quant_type
         i64Type, // v_quant_type
         i64Type, // kv_cache_bit_width
-        // Shape info (5 values)
+        // Shape info (6 values)
         i64Type, // batch_size
         i64Type, // seq_len_q
         i64Type, // seq_len_kv
+        i64Type, // past_seq_len
         i64Type, // head_dim
         i64Type  // element_size_bytes
     };
@@ -1724,7 +1737,7 @@ struct GqaOpLowering : public ConvertOpToLLVMPattern<GqaOp> {
     if (failed(funcOp))
       return failure();
 
-    SmallVector<Value, 37> args = {
+    SmallVector<Value, 38> args = {
         statePtr,
         // Inputs (14 pointers)
         queryPtr, keyPtr, valuePtr, pastKeyPtr, pastValuePtr, seqlensKPtr,
@@ -1736,8 +1749,9 @@ struct GqaOpLowering : public ConvertOpToLLVMPattern<GqaOp> {
         numHeads, kvNumHeads, scale, doRotary, rotaryInterleaved, softcap,
         localWindowSize, smoothSoftmax, qkOutput, kQuantType, vQuantType,
         kvCacheBitWidth,
-        // Shape info (5 values)
-        batchSizeVal, seqLenQVal, seqLenKVVal, headDimVal, elemSizeVal};
+        // Shape info (6 values)
+        batchSizeVal, seqLenQVal, seqLenKVVal, pastSeqLenVal, headDimVal,
+        elemSizeVal};
 
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
 

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -460,7 +460,8 @@ int wrap_elementwise_sub(RuntimeState *state, void *lhs, void *rhs,
 // Gather operation wrapper
 int wrap_gather(RuntimeState *state, void *data, void *indices, void *output,
                 int64_t axis, int64_t data_num_elements,
-                int64_t output_num_elements, int64_t element_size_bytes);
+                int64_t indices_num_elements, int64_t output_num_elements,
+                int64_t element_size_bytes);
 
 // ReduceSum operation wrapper
 int wrap_reduce_sum(RuntimeState *state, void *data, void *axes, void *output,

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -434,9 +434,9 @@ int wrap_group_query_attention(
     int64_t rotary_interleaved, float softcap, int64_t local_window_size,
     int64_t smooth_softmax, int64_t qk_output, int64_t k_quant_type,
     int64_t v_quant_type, int64_t kv_cache_bit_width,
-    // Shape values (5)
-    int64_t batch_size, int64_t seq_len_q, int64_t seq_len_kv, int64_t head_dim,
-    int64_t element_size_bytes);
+    // Shape values (6)
+    int64_t batch_size, int64_t seq_len_q, int64_t seq_len_kv,
+    int64_t past_seq_len, int64_t head_dim, int64_t element_size_bytes);
 
 // Generic MIOpen tensor operation wrapper with per-operand 4D shapes.
 // Computes output = op(lhs, rhs) element-wise via miopenOpTensor.

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -457,7 +457,7 @@ int wrap_elementwise_sub(RuntimeState *state, void *lhs, void *rhs,
                          void *output, int64_t num_elements,
                          int64_t element_size_bytes);
 
-// Gather operation wrapper
+// Gather operation wrapper — supports multi-element indices for axis=0.
 int wrap_gather(RuntimeState *state, void *data, void *indices, void *output,
                 int64_t axis, int64_t data_num_elements,
                 int64_t indices_num_elements, int64_t output_num_elements,

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -218,35 +218,120 @@ int hipdnn_ep_state_init_with_fs(RuntimeState **out_state, void *fs,
   bool is_igpu = (prop.integrated == 1);
 
   if (is_igpu) {
-    // iGPU: allocate pinned host memory. GPU reads the same physical DRAM
-    // directly -- no hipMemcpy needed. hipHostMalloc gives a reliable pinned
-    // allocation; hipHostRegister on mmap'd or VirtualAlloc'd memory is
-    // unreliable on some iGPU platforms (GPU reads zeros despite success).
-    if (hipHostMalloc(&state->gpu_constants_blob, total_size,
-                      hipHostMallocDefault) != hipSuccess) {
-      fprintf(stderr, "hipHostMalloc failed for constants blob (%zu bytes)\n",
-              total_size);
-      hipdnn_ep_state_cleanup(state);
-      *out_state = nullptr;
-      return 1;
-    }
+    // iGPU: try hipMalloc first (1x VRAM pool consumption), then fall
+    // back to hipHostMalloc (2x pool consumption but can spill to GTT).
+    //
+    // On iGPU the VRAM pool is carved from system RAM by the BIOS.
+    // hipHostMalloc consumes ~2x the blob size from this pool (host
+    // allocation + device mapping).  When the pool is large enough to
+    // absorb all constants it gets exhausted and kernel launches fail
+    // with hipErrorLaunchFailure (719).  hipMalloc only consumes 1x,
+    // leaving more pool for kernels.  If hipMalloc fails (pool too
+    // small), hipHostMalloc is used as a fallback — the driver will
+    // partially use the pool and spill the rest to GTT (system RAM),
+    // which the GPU can access directly on iGPU.
+    bool used_hip_malloc = false;
 
-    const void *src = reader->mmap();
-    if (src) {
-      memcpy(state->gpu_constants_blob, src, total_size);
+    RUNTIME_DEBUG_LOG("[constants] blob_size=%.2f GB, is_igpu=1\n",
+                      total_size / (1024.0 * 1024.0 * 1024.0));
+
+    if (hipMalloc(&state->gpu_constants_blob, total_size) == hipSuccess) {
+      used_hip_malloc = true;
+      state->constants_blob_is_host = false;
+
+      // Upload constants via chunked hipMemcpy to limit the peak VRAM
+      // pool overhead from staging buffers.  A single hipMemcpy of the
+      // full blob can allocate a staging buffer as large as the blob
+      // itself (~2x total pool consumption).  Copying in small chunks
+      // keeps the staging overhead bounded.
+      const size_t chunk_size = 64 * 1024 * 1024; // 64 MB chunks
+      const void *src = reader->mmap();
+      void *cpu_buf = nullptr;
+
+      if (!src) {
+        cpu_buf = malloc(chunk_size);
+        if (!cpu_buf) {
+          fprintf(stderr, "Failed to allocate staging buffer (%zu bytes)\n",
+                  chunk_size);
+          hipdnn_ep_state_cleanup(state);
+          *out_state = nullptr;
+          return 1;
+        }
+      }
+
+      size_t offset = 0;
+      bool copy_ok = true;
+      while (offset < total_size) {
+        size_t remaining = total_size - offset;
+        size_t this_chunk = (remaining < chunk_size) ? remaining : chunk_size;
+        char *dst = static_cast<char *>(state->gpu_constants_blob) + offset;
+
+        if (src) {
+          // mmap available — copy directly from mapped file
+          const char *src_ptr = static_cast<const char *>(src) + offset;
+          if (hipMemcpy(dst, src_ptr, this_chunk, hipMemcpyHostToDevice) !=
+              hipSuccess) {
+            fprintf(stderr, "hipMemcpy failed at offset %zu\n", offset);
+            copy_ok = false;
+            break;
+          }
+        } else {
+          // No mmap — read chunk from file into staging buffer, then copy
+          size_t bytes_read = reader->fread(cpu_buf, this_chunk);
+          if (bytes_read != this_chunk) {
+            fprintf(stderr, "Short read at offset %zu: got %zu of %zu\n",
+                    offset, bytes_read, this_chunk);
+            copy_ok = false;
+            break;
+          }
+          if (hipMemcpy(dst, cpu_buf, this_chunk, hipMemcpyHostToDevice) !=
+              hipSuccess) {
+            fprintf(stderr, "hipMemcpy failed at offset %zu\n", offset);
+            copy_ok = false;
+            break;
+          }
+        }
+        offset += this_chunk;
+      }
+
+      free(cpu_buf);
+      if (!copy_ok) {
+        hipdnn_ep_state_cleanup(state);
+        *out_state = nullptr;
+        return 1;
+      }
     } else {
-      reader->rewind();
-      size_t bytes_read = reader->fread(state->gpu_constants_blob, total_size);
-      if (bytes_read != total_size) {
-        fprintf(stderr, "Short read: got %zu of %zu bytes\n", bytes_read,
+      // hipMalloc failed — fall back to hipHostMalloc (spills to GTT)
+      RUNTIME_DEBUG_LOG("[constants] hipMalloc failed, falling back to "
+                        "hipHostMalloc\n");
+      if (hipHostMalloc(&state->gpu_constants_blob, total_size,
+                        hipHostMallocMapped) != hipSuccess) {
+        fprintf(stderr, "hipHostMalloc failed for constants blob (%zu bytes)\n",
                 total_size);
         hipdnn_ep_state_cleanup(state);
         *out_state = nullptr;
         return 1;
       }
-    }
-    state->constants_blob_is_host = true;
+      state->constants_blob_is_host = true;
 
+      const void *src = reader->mmap();
+      if (src) {
+        memcpy(state->gpu_constants_blob, src, total_size);
+      } else {
+        size_t bytes_read =
+            reader->fread(state->gpu_constants_blob, total_size);
+        if (bytes_read != total_size) {
+          fprintf(stderr, "Short read: got %zu of %zu bytes\n", bytes_read,
+                  total_size);
+          hipdnn_ep_state_cleanup(state);
+          *out_state = nullptr;
+          return 1;
+        }
+      }
+    }
+
+    RUNTIME_DEBUG_LOG("[constants] allocated via %s\n",
+                      used_hip_malloc ? "hipMalloc" : "hipHostMalloc(GTT)");
   } else {
     // dGPU: allocate in VRAM, upload once via hipMemcpy.
     const void *src = reader->mmap();

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -22,6 +22,55 @@
     }                                                                          \
   } while (0)
 
+// Win32 API declarations for process-wide environment access and
+// shared constants cache (named shared memory + atomic ref counting).
+// Model DLLs link static CRT (libcmt.lib), so getenv() can't see _putenv()
+// changes from the host. GetEnvironmentVariableA reads the shared process
+// environment block instead.
+#ifdef _WIN32
+extern "C" {
+unsigned long __stdcall GetEnvironmentVariableA(const char *, char *,
+                                                unsigned long);
+void *__stdcall CreateFileMappingA(void *, void *, unsigned long, unsigned long,
+                                   unsigned long, const char *);
+void *__stdcall OpenFileMappingA(unsigned long, int, const char *);
+void *__stdcall MapViewOfFile(void *, unsigned long, unsigned long,
+                              unsigned long, size_t);
+int __stdcall UnmapViewOfFile(const void *);
+int __stdcall CloseHandle(void *);
+unsigned long __stdcall GetCurrentProcessId(void);
+}
+
+// Metadata stored in the named shared memory block.
+// The actual constants data lives in the hipHostMalloc/hipMalloc buffer;
+// this struct just holds the pointer, size, and atomic ref count.
+struct SharedConstantsMeta {
+  void *blob_ptr;
+  size_t blob_size;
+  bool is_host;
+  volatile long ref_count;
+};
+
+// Atomic ref-count helpers. Model DLL bitcode is compiled by Clang/LLVM,
+// where InterlockedIncrement/Decrement are not linkable symbols (they're
+// MSVC intrinsics, not kernel32.lib exports). Use compiler builtins that
+// lower to LLVM IR atomicrmw instructions instead.
+#if defined(__clang__) || defined(__GNUC__)
+static inline long shm_ref_inc(volatile long *p) {
+  return __sync_add_and_fetch(p, 1);
+}
+static inline long shm_ref_dec(volatile long *p) {
+  return __sync_sub_and_fetch(p, 1);
+}
+#else
+static inline long shm_ref_inc(volatile long *p) { return ++(*p); }
+static inline long shm_ref_dec(volatile long *p) { return --(*p); }
+#endif
+
+#define SHM_FILE_MAP_ALL_ACCESS 0x000F001Fu
+#define SHM_PAGE_READWRITE 0x04u
+#endif
+
 // Runtime state management implementation
 
 int hipdnn_ep_state_init_with_fs(RuntimeState **out_state, void *fs,
@@ -46,6 +95,9 @@ int hipdnn_ep_state_init_with_fs(RuntimeState **out_state, void *fs,
   state->constants_blob_is_host = false;
   state->gpu_constants = nullptr;
   state->num_constants = 0;
+  state->constants_is_shared = false;
+  state->shared_constants_mapping = nullptr;
+  state->shared_constants_view = nullptr;
   state->pool_base = nullptr;
   state->pool_size = 0;
   state->buffer_offsets = nullptr;
@@ -134,7 +186,8 @@ int hipdnn_ep_state_init_with_fs(RuntimeState **out_state, void *fs,
   // Create MIOpen handle
   if (miopenCreate(&state->miopen_handle) != miopenStatusSuccess) {
     fprintf(stderr, "Failed to create MIOpen handle\n");
-    HIP_CLEANUP(hipStreamDestroy(state->stream));
+    if (state->stream)
+      HIP_CLEANUP(hipStreamDestroy(state->stream));
     free(state);
     return 7;
   }
@@ -144,31 +197,18 @@ int hipdnn_ep_state_init_with_fs(RuntimeState **out_state, void *fs,
       miopenStatusSuccess) {
     fprintf(stderr, "Failed to set MIOpen stream\n");
     miopenDestroy(state->miopen_handle);
-    HIP_CLEANUP(hipStreamDestroy(state->stream));
+    if (state->stream)
+      HIP_CLEANUP(hipStreamDestroy(state->stream));
     free(state);
     return 8;
-  }
-
-  // DIAGNOSTIC: Check if gcnArchName is still valid AFTER MIOpen initialization
-  hipDeviceProp_t prop_after_miopen;
-  if (hipGetDeviceProperties(&prop_after_miopen, 0) == hipSuccess) {
-    RUNTIME_DEBUG_LOG(
-        "After MIOpen init - gcnArchName='%s' (checking for corruption)\n",
-        prop_after_miopen.gcnArchName);
-    if (prop_after_miopen.gcnArchName[0] == '\0') {
-      fprintf(
-          stderr,
-          "WARNING: gcnArchName became EMPTY after MIOpen initialization!\n");
-      fprintf(stderr,
-              "This will cause rocBLAS to fail with 'No devices found'\n");
-    }
   }
 
   // Create hipBLASLt handle
   if (hipblasLtCreate(&state->hipblas_handle) != HIPBLAS_STATUS_SUCCESS) {
     fprintf(stderr, "Failed to create hipBLASLt handle\n");
     miopenDestroy(state->miopen_handle);
-    HIP_CLEANUP(hipStreamDestroy(state->stream));
+    if (state->stream)
+      HIP_CLEANUP(hipStreamDestroy(state->stream));
     free(state);
     return 9;
   }
@@ -215,86 +255,152 @@ int hipdnn_ep_state_init_with_fs(RuntimeState **out_state, void *fs,
   // gpu_constants[i] into it using the offset stored in ConstantInfo.
   size_t total_size = reader->size();
 
-  bool is_igpu = (prop.integrated == 1);
+  // --- Shared Constants Cache ---
+  // In OGA pipeline mode, prefill and decode models share the same
+  // constants.bin. The second model skips the expensive allocation+load
+  // by reusing the first model's blob via process-wide named shared memory.
+  bool constants_shared = false;
 
-  if (is_igpu) {
-    // iGPU: allocate pinned host memory. GPU reads the same physical DRAM
-    // directly -- no hipMemcpy needed. hipHostMalloc gives a reliable pinned
-    // allocation; hipHostRegister on mmap'd or VirtualAlloc'd memory is
-    // unreliable on some iGPU platforms (GPU reads zeros despite success).
-    if (hipHostMalloc(&state->gpu_constants_blob, total_size,
-                      hipHostMallocDefault) != hipSuccess) {
-      fprintf(stderr, "hipHostMalloc failed for constants blob (%zu bytes)\n",
-              total_size);
-      hipdnn_ep_state_cleanup(state);
-      *out_state = nullptr;
-      return 1;
+#ifdef _WIN32
+  char shm_name[128];
+  snprintf(shm_name, sizeof(shm_name), "Local\\hipdnn_const_%lu_%zu",
+           (unsigned long)GetCurrentProcessId(), total_size);
+
+  {
+    void *existing_map = OpenFileMappingA(SHM_FILE_MAP_ALL_ACCESS, 0, shm_name);
+    if (existing_map) {
+      auto *smeta = (SharedConstantsMeta *)MapViewOfFile(
+          existing_map, SHM_FILE_MAP_ALL_ACCESS, 0, 0,
+          sizeof(SharedConstantsMeta));
+      // TODO: blob_size alone may not be sufficient to identify identical
+      // constants. If collisions become an issue, compute a hash (e.g. MD5)
+      // during the compile stage and pass it through model metadata.
+      if (smeta && smeta->blob_size == total_size && smeta->blob_ptr) {
+        long new_ref = shm_ref_inc(&smeta->ref_count);
+        state->gpu_constants_blob = smeta->blob_ptr;
+        state->constants_blob_is_host = smeta->is_host;
+        state->constants_is_shared = true;
+        state->shared_constants_mapping = existing_map;
+        state->shared_constants_view = smeta;
+        fprintf(stderr,
+                "[SHARED_CONSTANTS] Reusing existing blob "
+                "(%zu bytes, ref_count=%ld)\n",
+                total_size, new_ref);
+        constants_shared = true;
+      } else {
+        if (smeta)
+          UnmapViewOfFile(smeta);
+        CloseHandle(existing_map);
+      }
     }
+  }
+#endif
 
-    const void *src = reader->mmap();
-    if (src) {
-      memcpy(state->gpu_constants_blob, src, total_size);
+  if (!constants_shared) {
+    bool is_igpu = (prop.integrated == 1);
+
+    if (is_igpu) {
+      // iGPU: allocate pinned host memory. GPU reads the same physical DRAM
+      // directly -- no hipMemcpy needed. Draws from system RAM, not GPU quota.
+      if (hipHostMalloc(&state->gpu_constants_blob, total_size,
+                        hipHostMallocDefault) != hipSuccess) {
+        fprintf(stderr, "hipHostMalloc failed for constants blob (%zu bytes)\n",
+                total_size);
+        hipdnn_ep_state_cleanup(state);
+        *out_state = nullptr;
+        return 1;
+      }
+      state->constants_blob_is_host = true;
+
+      const void *src = reader->mmap();
+      if (src) {
+        memcpy(state->gpu_constants_blob, src, total_size);
+      } else {
+        size_t bytes_read =
+            reader->fread(state->gpu_constants_blob, total_size);
+        if (bytes_read != total_size) {
+          fprintf(stderr, "Short read: got %zu of %zu bytes\n", bytes_read,
+                  total_size);
+          hipdnn_ep_state_cleanup(state);
+          *out_state = nullptr;
+          return 1;
+        }
+      }
     } else {
-      reader->rewind();
-      size_t bytes_read = reader->fread(state->gpu_constants_blob, total_size);
-      if (bytes_read != total_size) {
-        fprintf(stderr, "Short read: got %zu of %zu bytes\n", bytes_read,
-                total_size);
-        hipdnn_ep_state_cleanup(state);
-        *out_state = nullptr;
-        return 1;
-      }
-    }
-    state->constants_blob_is_host = true;
+      // dGPU: allocate in VRAM, upload once via hipMemcpy.
+      const void *src = reader->mmap();
+      void *cpu_buf = nullptr;
 
-  } else {
-    // dGPU: allocate in VRAM, upload once via hipMemcpy.
-    const void *src = reader->mmap();
-    void *cpu_buf = nullptr;
-
-    if (!src) {
-      // No mmap — read entire file into a staging buffer
-      cpu_buf = malloc(total_size);
-      if (!cpu_buf) {
-        fprintf(stderr, "Failed to allocate staging buffer (%zu bytes)\n",
-                total_size);
-        hipdnn_ep_state_cleanup(state);
-        *out_state = nullptr;
-        return 1;
+      if (!src) {
+        cpu_buf = malloc(total_size);
+        if (!cpu_buf) {
+          fprintf(stderr, "Failed to allocate staging buffer (%zu bytes)\n",
+                  total_size);
+          hipdnn_ep_state_cleanup(state);
+          *out_state = nullptr;
+          return 1;
+        }
+        size_t bytes_read = reader->fread(cpu_buf, total_size);
+        if (bytes_read != total_size) {
+          fprintf(stderr, "Short read: got %zu of %zu bytes\n", bytes_read,
+                  total_size);
+          free(cpu_buf);
+          hipdnn_ep_state_cleanup(state);
+          *out_state = nullptr;
+          return 1;
+        }
+        src = cpu_buf;
       }
-      size_t bytes_read = reader->fread(cpu_buf, total_size);
-      if (bytes_read != total_size) {
-        fprintf(stderr, "Short read: got %zu of %zu bytes\n", bytes_read,
+
+      if (hipMalloc(&state->gpu_constants_blob, total_size) != hipSuccess) {
+        fprintf(stderr, "hipMalloc failed for constants blob (%zu bytes)\n",
                 total_size);
         free(cpu_buf);
         hipdnn_ep_state_cleanup(state);
         *out_state = nullptr;
         return 1;
       }
-      src = cpu_buf;
+
+      if (hipMemcpy(state->gpu_constants_blob, src, total_size,
+                    hipMemcpyHostToDevice) != hipSuccess) {
+        fprintf(stderr, "hipMemcpy failed for constants blob\n");
+        free(cpu_buf);
+        hipdnn_ep_state_cleanup(state);
+        *out_state = nullptr;
+        return 1;
+      }
+
+      free(cpu_buf); // no-op when mmap was used
+      state->constants_blob_is_host = false;
     }
 
-    if (hipMalloc(&state->gpu_constants_blob, total_size) != hipSuccess) {
-      fprintf(stderr, "hipMalloc failed for constants blob (%zu bytes)\n",
-              total_size);
-      free(cpu_buf);
-      hipdnn_ep_state_cleanup(state);
-      *out_state = nullptr;
-      return 1;
+#ifdef _WIN32
+    // Publish the newly loaded blob to the shared constants cache so that
+    // subsequent models in this process can skip the allocation+load.
+    {
+      void *new_map = CreateFileMappingA(
+          (void *)(intptr_t)-1, nullptr, SHM_PAGE_READWRITE, 0,
+          (unsigned long)sizeof(SharedConstantsMeta), shm_name);
+      if (new_map) {
+        auto *smeta = (SharedConstantsMeta *)MapViewOfFile(
+            new_map, SHM_FILE_MAP_ALL_ACCESS, 0, 0,
+            sizeof(SharedConstantsMeta));
+        if (smeta) {
+          smeta->blob_ptr = state->gpu_constants_blob;
+          smeta->blob_size = total_size;
+          smeta->is_host = state->constants_blob_is_host;
+          smeta->ref_count = 1;
+          state->shared_constants_mapping = new_map;
+          state->shared_constants_view = smeta;
+          fprintf(stderr, "[SHARED_CONSTANTS] Published new blob (%zu bytes)\n",
+                  total_size);
+        } else {
+          CloseHandle(new_map);
+        }
+      }
     }
-
-    if (hipMemcpy(state->gpu_constants_blob, src, total_size,
-                  hipMemcpyHostToDevice) != hipSuccess) {
-      fprintf(stderr, "hipMemcpy failed for constants blob\n");
-      free(cpu_buf);
-      hipdnn_ep_state_cleanup(state);
-      *out_state = nullptr;
-      return 1;
-    }
-
-    free(cpu_buf); // no-op when mmap was used
-    state->constants_blob_is_host = false;
-  }
+#endif
+  } // end if (!constants_shared)
 
   // Point each gpu_constants[i] into the blob using the stored offset
   for (int64_t i = 0; i < count; ++i) {
@@ -333,12 +439,31 @@ int hipdnn_ep_state_cleanup(RuntimeState *state) {
     free(state->buffer_offsets);
   }
 
-  // Free the single constants blob and the pointer array
+  // Free the single constants blob and the pointer array.
+  // With shared constants, only the last reference frees the GPU memory.
   if (state->gpu_constants_blob) {
-    if (state->constants_blob_is_host)
-      HIP_CLEANUP(hipHostFree(state->gpu_constants_blob));
-    else
-      HIP_CLEANUP(hipFree(state->gpu_constants_blob));
+#ifdef _WIN32
+    if (state->shared_constants_view) {
+      auto *smeta = (SharedConstantsMeta *)state->shared_constants_view;
+      long remaining = shm_ref_dec(&smeta->ref_count);
+      fprintf(stderr, "[SHARED_CONSTANTS] Cleanup: ref_count=%ld\n", remaining);
+      if (remaining <= 0) {
+        if (state->constants_blob_is_host)
+          HIP_CLEANUP(hipHostFree(state->gpu_constants_blob));
+        else
+          HIP_CLEANUP(hipFree(state->gpu_constants_blob));
+      }
+      UnmapViewOfFile(state->shared_constants_view);
+      if (state->shared_constants_mapping)
+        CloseHandle(state->shared_constants_mapping);
+    } else
+#endif
+    {
+      if (state->constants_blob_is_host)
+        HIP_CLEANUP(hipHostFree(state->gpu_constants_blob));
+      else
+        HIP_CLEANUP(hipFree(state->gpu_constants_blob));
+    }
   }
   if (state->gpu_constants)
     free(state->gpu_constants);
@@ -478,8 +603,13 @@ int hipdnn_ep_state_ensure_workspace(RuntimeState *state, size_t needed_size) {
   if (state->workspace_size >= needed_size)
     return 0;
 
-  // Grow: free old, allocate new
+  // Grow: free old, allocate new.
+  // Sync the stream first to ensure no in-flight kernel is still using the
+  // old workspace buffer (prevents use-after-free on async GPU execution).
   if (state->workspace) {
+    if (state->stream) {
+      hipStreamSynchronize(state->stream);
+    }
     HIP_CLEANUP(hipFree(state->workspace));
     state->workspace = nullptr;
     state->workspace_size = 0;

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -218,120 +218,35 @@ int hipdnn_ep_state_init_with_fs(RuntimeState **out_state, void *fs,
   bool is_igpu = (prop.integrated == 1);
 
   if (is_igpu) {
-    // iGPU: try hipMalloc first (1x VRAM pool consumption), then fall
-    // back to hipHostMalloc (2x pool consumption but can spill to GTT).
-    //
-    // On iGPU the VRAM pool is carved from system RAM by the BIOS.
-    // hipHostMalloc consumes ~2x the blob size from this pool (host
-    // allocation + device mapping).  When the pool is large enough to
-    // absorb all constants it gets exhausted and kernel launches fail
-    // with hipErrorLaunchFailure (719).  hipMalloc only consumes 1x,
-    // leaving more pool for kernels.  If hipMalloc fails (pool too
-    // small), hipHostMalloc is used as a fallback — the driver will
-    // partially use the pool and spill the rest to GTT (system RAM),
-    // which the GPU can access directly on iGPU.
-    bool used_hip_malloc = false;
+    // iGPU: allocate pinned host memory. GPU reads the same physical DRAM
+    // directly -- no hipMemcpy needed. hipHostMalloc gives a reliable pinned
+    // allocation; hipHostRegister on mmap'd or VirtualAlloc'd memory is
+    // unreliable on some iGPU platforms (GPU reads zeros despite success).
+    if (hipHostMalloc(&state->gpu_constants_blob, total_size,
+                      hipHostMallocDefault) != hipSuccess) {
+      fprintf(stderr, "hipHostMalloc failed for constants blob (%zu bytes)\n",
+              total_size);
+      hipdnn_ep_state_cleanup(state);
+      *out_state = nullptr;
+      return 1;
+    }
 
-    RUNTIME_DEBUG_LOG("[constants] blob_size=%.2f GB, is_igpu=1\n",
-                      total_size / (1024.0 * 1024.0 * 1024.0));
-
-    if (hipMalloc(&state->gpu_constants_blob, total_size) == hipSuccess) {
-      used_hip_malloc = true;
-      state->constants_blob_is_host = false;
-
-      // Upload constants via chunked hipMemcpy to limit the peak VRAM
-      // pool overhead from staging buffers.  A single hipMemcpy of the
-      // full blob can allocate a staging buffer as large as the blob
-      // itself (~2x total pool consumption).  Copying in small chunks
-      // keeps the staging overhead bounded.
-      const size_t chunk_size = 64 * 1024 * 1024; // 64 MB chunks
-      const void *src = reader->mmap();
-      void *cpu_buf = nullptr;
-
-      if (!src) {
-        cpu_buf = malloc(chunk_size);
-        if (!cpu_buf) {
-          fprintf(stderr, "Failed to allocate staging buffer (%zu bytes)\n",
-                  chunk_size);
-          hipdnn_ep_state_cleanup(state);
-          *out_state = nullptr;
-          return 1;
-        }
-      }
-
-      size_t offset = 0;
-      bool copy_ok = true;
-      while (offset < total_size) {
-        size_t remaining = total_size - offset;
-        size_t this_chunk = (remaining < chunk_size) ? remaining : chunk_size;
-        char *dst = static_cast<char *>(state->gpu_constants_blob) + offset;
-
-        if (src) {
-          // mmap available — copy directly from mapped file
-          const char *src_ptr = static_cast<const char *>(src) + offset;
-          if (hipMemcpy(dst, src_ptr, this_chunk, hipMemcpyHostToDevice) !=
-              hipSuccess) {
-            fprintf(stderr, "hipMemcpy failed at offset %zu\n", offset);
-            copy_ok = false;
-            break;
-          }
-        } else {
-          // No mmap — read chunk from file into staging buffer, then copy
-          size_t bytes_read = reader->fread(cpu_buf, this_chunk);
-          if (bytes_read != this_chunk) {
-            fprintf(stderr, "Short read at offset %zu: got %zu of %zu\n",
-                    offset, bytes_read, this_chunk);
-            copy_ok = false;
-            break;
-          }
-          if (hipMemcpy(dst, cpu_buf, this_chunk, hipMemcpyHostToDevice) !=
-              hipSuccess) {
-            fprintf(stderr, "hipMemcpy failed at offset %zu\n", offset);
-            copy_ok = false;
-            break;
-          }
-        }
-        offset += this_chunk;
-      }
-
-      free(cpu_buf);
-      if (!copy_ok) {
-        hipdnn_ep_state_cleanup(state);
-        *out_state = nullptr;
-        return 1;
-      }
+    const void *src = reader->mmap();
+    if (src) {
+      memcpy(state->gpu_constants_blob, src, total_size);
     } else {
-      // hipMalloc failed — fall back to hipHostMalloc (spills to GTT)
-      RUNTIME_DEBUG_LOG("[constants] hipMalloc failed, falling back to "
-                        "hipHostMalloc\n");
-      if (hipHostMalloc(&state->gpu_constants_blob, total_size,
-                        hipHostMallocMapped) != hipSuccess) {
-        fprintf(stderr, "hipHostMalloc failed for constants blob (%zu bytes)\n",
+      reader->rewind();
+      size_t bytes_read = reader->fread(state->gpu_constants_blob, total_size);
+      if (bytes_read != total_size) {
+        fprintf(stderr, "Short read: got %zu of %zu bytes\n", bytes_read,
                 total_size);
         hipdnn_ep_state_cleanup(state);
         *out_state = nullptr;
         return 1;
       }
-      state->constants_blob_is_host = true;
-
-      const void *src = reader->mmap();
-      if (src) {
-        memcpy(state->gpu_constants_blob, src, total_size);
-      } else {
-        size_t bytes_read =
-            reader->fread(state->gpu_constants_blob, total_size);
-        if (bytes_read != total_size) {
-          fprintf(stderr, "Short read: got %zu of %zu bytes\n", bytes_read,
-                  total_size);
-          hipdnn_ep_state_cleanup(state);
-          *out_state = nullptr;
-          return 1;
-        }
-      }
     }
+    state->constants_blob_is_host = true;
 
-    RUNTIME_DEBUG_LOG("[constants] allocated via %s\n",
-                      used_hip_malloc ? "hipMalloc" : "hipHostMalloc(GTT)");
   } else {
     // dGPU: allocate in VRAM, upload once via hipMemcpy.
     const void *src = reader->mmap();

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -556,16 +556,19 @@ int wrap_elementwise_sub(RuntimeState *state, void *lhs, void *rhs,
 
 int wrap_gather(RuntimeState *state, void *data, void *indices, void *output,
                 int64_t axis, int64_t data_num_elements,
-                int64_t output_num_elements, int64_t element_size_bytes) {
+                int64_t indices_num_elements, int64_t output_num_elements,
+                int64_t element_size_bytes) {
   if (!state) {
     fprintf(stderr, "Invalid state in wrap_gather\n");
     return -1;
   }
 
   MOCK_PRINT("[MOCK] wrap_gather(axis=%lld, data_num_elements=%lld, "
-             "output_num_elements=%lld, element_size=%lld)\n",
+             "indices_num_elements=%lld, output_num_elements=%lld, "
+             "element_size=%lld)\n",
              (long long)axis, (long long)data_num_elements,
-             (long long)output_num_elements, (long long)element_size_bytes);
+             (long long)indices_num_elements, (long long)output_num_elements,
+             (long long)element_size_bytes);
 
   return 0;
 }

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -475,9 +475,9 @@ int wrap_group_query_attention(
     int64_t rotary_interleaved, float softcap, int64_t local_window_size,
     int64_t smooth_softmax, int64_t qk_output, int64_t k_quant_type,
     int64_t v_quant_type, int64_t kv_cache_bit_width,
-    // Shape values (5)
-    int64_t batch_size, int64_t seq_len_q, int64_t seq_len_kv, int64_t head_dim,
-    int64_t element_size_bytes) {
+    // Shape values (6)
+    int64_t batch_size, int64_t seq_len_q, int64_t seq_len_kv,
+    int64_t past_seq_len, int64_t head_dim, int64_t element_size_bytes) {
   if (!state) {
     fprintf(stderr, "Invalid state in wrap_group_query_attention\n");
     return -1;
@@ -506,9 +506,10 @@ int wrap_group_query_attention(
   MOCK_PRINT("[MOCK]   do_rotary=%lld, rotary_interleaved=%lld,\n",
              (long long)do_rotary, (long long)rotary_interleaved);
   MOCK_PRINT("[MOCK]   batch=%lld, seq_q=%lld, seq_kv=%lld, "
-             "head_dim=%lld, elem_size=%lld)\n",
+             "past_seq=%lld, head_dim=%lld, elem_size=%lld)\n",
              (long long)batch_size, (long long)seq_len_q, (long long)seq_len_kv,
-             (long long)head_dim, (long long)element_size_bytes);
+             (long long)past_seq_len, (long long)head_dim,
+             (long long)element_size_bytes);
 
   return 0;
 }

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -165,13 +165,18 @@ miopenDestroyTensorDescriptor(miopenTensorDescriptor_t desc) {
   return miopenStatusSuccess;
 }
 
-static miopenStatus_t miopenSet4dTensorDescriptor(miopenTensorDescriptor_t desc,
-                                                  miopenDataType_t dataType,
-                                                  int n, int c, int h, int w) {
+static miopenStatus_t miopenSetNdTensorDescriptorWithLayout(
+    miopenTensorDescriptor_t desc, miopenDataType_t dataType,
+    miopenTensorLayout_t layout, const int *lens, int num_lens) {
   (void)desc;
   (void)dataType;
-  // Print tensor shape for verification
-  MOCK_PRINT("[MOCK]   Tensor descriptor set: [%d, %d, %d, %d]\n", n, c, h, w);
+  (void)layout;
+  if (num_lens == 4) {
+    MOCK_PRINT("[MOCK]   Tensor descriptor set: [%d, %d, %d, %d]\n", lens[0],
+               lens[1], lens[2], lens[3]);
+  } else {
+    MOCK_PRINT("[MOCK]   Tensor descriptor set: %d dims\n", num_lens);
+  }
   return miopenStatusSuccess;
 }
 

--- a/lib/Runtime/mock/mock_types.h
+++ b/lib/Runtime/mock/mock_types.h
@@ -25,7 +25,6 @@ struct hipDeviceProp_t {
 #define hipMemcpyHostToDevice 0
 #define hipMemcpyDeviceToHost 1
 #define hipHostMallocDefault 0
-#define hipHostMallocMapped 2
 
 // MIOpen tensor layout enum (subset used by the runtime)
 typedef int miopenTensorLayout_t;

--- a/lib/Runtime/mock/mock_types.h
+++ b/lib/Runtime/mock/mock_types.h
@@ -25,6 +25,7 @@ struct hipDeviceProp_t {
 #define hipMemcpyHostToDevice 0
 #define hipMemcpyDeviceToHost 1
 #define hipHostMallocDefault 0
+#define hipHostMallocMapped 2
 
 // Forward declarations for mock GPU functions (defined in mock_gpu.cpp)
 extern "C" hipError_t hipGetDeviceCount(int *count);

--- a/lib/Runtime/mock/mock_types.h
+++ b/lib/Runtime/mock/mock_types.h
@@ -27,6 +27,10 @@ struct hipDeviceProp_t {
 #define hipHostMallocDefault 0
 #define hipHostMallocMapped 2
 
+// MIOpen tensor layout enum (subset used by the runtime)
+typedef int miopenTensorLayout_t;
+#define miopenTensorNCHW 0
+
 // Forward declarations for mock GPU functions (defined in mock_gpu.cpp)
 extern "C" hipError_t hipGetDeviceCount(int *count);
 extern "C" hipError_t hipSetDevice(int device);

--- a/lib/Runtime/real/activation.cpp
+++ b/lib/Runtime/real/activation.cpp
@@ -51,7 +51,7 @@ static miopenActivationMode_t hipdnn_ep_to_miopen_activation(int64_t mode) {
 //
 // Applies activation_mode element-wise using miopenActivationForward.
 // Tensor is represented as flat 1D [1, 1, 1, num_elements] to satisfy
-// miopenSet4dTensorDescriptor's 4D requirement.
+// MIOpen's 4D tensor descriptor requirement.
 // =============================================================================
 
 int wrap_miopenActivationForward(RuntimeState *state, void *input, void *output,
@@ -98,8 +98,16 @@ int wrap_miopenActivationForward(RuntimeState *state, void *input, void *output,
 
   MIOPEN_CHECK(miopenCreateTensorDescriptor(&inDesc));
   MIOPEN_CHECK(miopenCreateTensorDescriptor(&outDesc));
-  MIOPEN_CHECK(miopenSet4dTensorDescriptor(inDesc, miopen_type, 1, 1, 1, n));
-  MIOPEN_CHECK(miopenSet4dTensorDescriptor(outDesc, miopen_type, 1, 1, 1, n));
+  // Use miopenSetNdTensorDescriptorWithLayout to set NCHW layout explicitly;
+  // miopenSet4dTensorDescriptor leaves the layout as 'UNKNOWN' which triggers
+  // warnings in MIOpen 7.12+.
+  {
+    int dims[] = {1, 1, 1, n};
+    MIOPEN_CHECK(miopenSetNdTensorDescriptorWithLayout(
+        inDesc, miopen_type, miopenTensorNCHW, dims, 4));
+    MIOPEN_CHECK(miopenSetNdTensorDescriptorWithLayout(
+        outDesc, miopen_type, miopenTensorNCHW, dims, 4));
+  }
   MIOPEN_CHECK(miopenCreateActivationDescriptor(&actDesc));
   MIOPEN_CHECK(
       miopenSetActivationDescriptor(actDesc, miopen_act, 0.0, 0.0, 0.0));

--- a/lib/Runtime/real/elementwise.cpp
+++ b/lib/Runtime/real/elementwise.cpp
@@ -111,12 +111,20 @@ int wrap_miopenOpTensor(RuntimeState *state, void *lhs, void *rhs, void *output,
 
   // Per-operand 4D descriptors enable MIOpen-native broadcasting:
   // dims of 1 are broadcast against the corresponding larger dim.
-  MIOPEN_CHECK(miopenSet4dTensorDescriptor(aDesc, miopen_type, (int)lhs_n,
-                                           (int)lhs_c, (int)lhs_h, (int)lhs_w));
-  MIOPEN_CHECK(miopenSet4dTensorDescriptor(bDesc, miopen_type, (int)rhs_n,
-                                           (int)rhs_c, (int)rhs_h, (int)rhs_w));
-  MIOPEN_CHECK(miopenSet4dTensorDescriptor(cDesc, miopen_type, (int)out_n,
-                                           (int)out_c, (int)out_h, (int)out_w));
+  // Use miopenSetNdTensorDescriptorWithLayout to set NCHW layout explicitly;
+  // miopenSet4dTensorDescriptor leaves the layout as 'UNKNOWN' which triggers
+  // warnings in MIOpen 7.12+.
+  {
+    int a_dims[] = {(int)lhs_n, (int)lhs_c, (int)lhs_h, (int)lhs_w};
+    MIOPEN_CHECK(miopenSetNdTensorDescriptorWithLayout(
+        aDesc, miopen_type, miopenTensorNCHW, a_dims, 4));
+    int b_dims[] = {(int)rhs_n, (int)rhs_c, (int)rhs_h, (int)rhs_w};
+    MIOPEN_CHECK(miopenSetNdTensorDescriptorWithLayout(
+        bDesc, miopen_type, miopenTensorNCHW, b_dims, 4));
+    int c_dims[] = {(int)out_n, (int)out_c, (int)out_h, (int)out_w};
+    MIOPEN_CHECK(miopenSetNdTensorDescriptorWithLayout(
+        cDesc, miopen_type, miopenTensorNCHW, c_dims, 4));
+  }
 
   RUNTIME_DEBUG_LOG("[REAL] wrap_miopenOpTensor: calling miopenOpTensor"
                     "(op=%s, alpha1=%.1f, alpha2=%.1f, beta=%.1f)\n",

--- a/lib/Runtime/real/error_check_macros.h
+++ b/lib/Runtime/real/error_check_macros.h
@@ -88,4 +88,12 @@
     }                                                                          \
   } while (0)
 
+#define HIPBLAS_CLEANUP(expr)                                                  \
+  do {                                                                         \
+    hipblasStatus_t _st = (expr);                                              \
+    if (_st != HIPBLAS_STATUS_SUCCESS) {                                       \
+      fprintf(stderr, "Warning: " #expr " failed with status %d\n", (int)_st); \
+    }                                                                          \
+  } while (0)
+
 #endif // HIPDNN_EP_ERROR_CHECK_MACROS_H

--- a/lib/Runtime/real/error_check_macros.h
+++ b/lib/Runtime/real/error_check_macros.h
@@ -23,7 +23,7 @@
 //   int result = 0;
 //
 //   MIOPEN_CHECK_GOTO(miopenCreateTensorDescriptor(&desc), cleanup);
-//   MIOPEN_CHECK_GOTO(miopenSet4dTensorDescriptor(desc, ...), cleanup);
+//   MIOPEN_CHECK_GOTO(miopenSetNdTensorDescriptorWithLayout(desc, ...), cleanup);
 //
 //   cleanup:
 //     if (desc) miopenDestroyTensorDescriptor(desc);

--- a/lib/Runtime/real/error_check_macros.h
+++ b/lib/Runtime/real/error_check_macros.h
@@ -23,7 +23,8 @@
 //   int result = 0;
 //
 //   MIOPEN_CHECK_GOTO(miopenCreateTensorDescriptor(&desc), cleanup);
-//   MIOPEN_CHECK_GOTO(miopenSetNdTensorDescriptorWithLayout(desc, ...), cleanup);
+//   MIOPEN_CHECK_GOTO(miopenSetNdTensorDescriptorWithLayout(desc, ...),
+//   cleanup);
 //
 //   cleanup:
 //     if (desc) miopenDestroyTensorDescriptor(desc);

--- a/lib/Runtime/real/gather.cpp
+++ b/lib/Runtime/real/gather.cpp
@@ -11,7 +11,8 @@
 
 int wrap_gather(RuntimeState *state, void *data, void *indices, void *output,
                 int64_t axis, int64_t data_num_elements,
-                int64_t output_num_elements, int64_t element_size_bytes) {
+                int64_t indices_num_elements, int64_t output_num_elements,
+                int64_t element_size_bytes) {
   if (!state || !data || !indices || !output) {
     RUNTIME_DEBUG_LOG("[REAL] wrap_gather: null argument\n");
     return -1;
@@ -20,11 +21,13 @@ int wrap_gather(RuntimeState *state, void *data, void *indices, void *output,
   void *stream = hipdnn_ep_state_get_stream(state);
 
   RUNTIME_DEBUG_LOG(
-      "[REAL] wrap_gather: axis=%lld, data_num=%lld, output_num=%lld, "
-      "elem_size=%lld -> calling hip_gather\n",
+      "[REAL] wrap_gather: axis=%lld, data_num=%lld, indices_num=%lld, "
+      "output_num=%lld, elem_size=%lld -> calling hip_gather\n",
       (long long)axis, (long long)data_num_elements,
-      (long long)output_num_elements, (long long)element_size_bytes);
+      (long long)indices_num_elements, (long long)output_num_elements,
+      (long long)element_size_bytes);
 
   return hip_gather(stream, data, indices, output, axis, data_num_elements,
-                    output_num_elements, static_cast<int>(element_size_bytes));
+                    indices_num_elements, output_num_elements,
+                    static_cast<int>(element_size_bytes));
 }

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -138,25 +138,45 @@ static int gqa_forward_hipblaslt(
     const void *query,    // BSHD [B, sq, H, d] or packed [B, sq, (H+2G)*d]
     const void *key,      // BSHD [B, sq, G, d] or null (packed QKV)
     const void *value,    // BSHD [B, sq, G, d] or null (packed QKV)
-    const void *past_key, // BNSD [B, G, past_seq, d] or null
-    const void *past_value, const void *cos_cache, const void *sin_cache,
+    const void *past_key, // BNSD [B, G, past_buf_seq, d] or null
+    const void *past_value,
+    const void *seqlens_k_ptr, // GPU pointer to seqlens_k [B] int32
+    const void *cos_cache, const void *sin_cache,
     void *head_sink,         // [H] smooth softmax factor or null
     bool use_smooth_softmax, // true when smooth softmax is enabled (ORT:
                              // head_sink || smooth_softmax attr)
     void *output,            // BSHD [B, sq, H, d]
-    void *present_key,       // BNSD [B, G, present_seq, d]
-    void *present_value, int64_t B, int64_t sq, int64_t skv, int64_t H,
-    int64_t G, int64_t d, float scale, int64_t do_rotary,
-    int64_t local_window_size) {
+    void *present_key,       // BNSD [B, G, present_buf_seq, d]
+    void *present_value, int64_t B, int64_t sq, int64_t skv,
+    int64_t past_buf_seq, int64_t H, int64_t G, int64_t d, float scale,
+    int64_t do_rotary, int64_t local_window_size) {
 
   int64_t HPG = H / G;
-  int64_t past_len = skv - sq;
+  // present_seq is the buffer dimension of present_key (may be max_length
+  // for pre-allocated caches, larger than the actual valid token count).
+  int64_t present_seq = skv;
+
+  // Determine actual total sequence length from seqlens_k (ORT convention:
+  // seqlens_k[b] = total_valid_tokens - 1).  When seqlens_k is not provided,
+  // fall back to the buffer dimension (non-pre-allocated case).
+  int64_t total_seq = skv;
+  if (seqlens_k_ptr) {
+    int32_t seqlens_k_val = 0;
+    hipError_t memErr =
+        hipMemcpyAsync(&seqlens_k_val, seqlens_k_ptr, sizeof(int32_t),
+                       hipMemcpyDeviceToHost, stream);
+    if (memErr == hipSuccess)
+      memErr = hipStreamSynchronize(stream);
+    if (memErr != hipSuccess) {
+      fprintf(stderr, "GQA: failed to read seqlens_k from GPU\n");
+      return -1;
+    }
+    total_seq = (int64_t)seqlens_k_val + 1;
+  }
+
+  int64_t past_len = total_seq - sq;
   if (past_len < 0)
     past_len = 0;
-  // present_seq is the sequence dimension of the present KV buffer.
-  // In the separate-buffer case this may differ from skv (the total active
-  // token count used for GEMM dimensions) if the buffer is pre-allocated.
-  int64_t present_seq = skv;
 
   bool packed_qkv = (key == nullptr && value == nullptr);
 
@@ -171,8 +191,8 @@ static int gqa_forward_hipblaslt(
 
   size_t elem_sz = 2; // FP16
   size_t Qtrans_bytes = (size_t)B * H * sq * d * elem_sz;
-  size_t Kexp_bytes = (size_t)B * H * skv * d * elem_sz;
-  size_t S_bytes = (size_t)B * H * sq * skv * elem_sz;
+  size_t Kexp_bytes = (size_t)B * H * total_seq * d * elem_sz;
+  size_t S_bytes = (size_t)B * H * sq * total_seq * elem_sz;
   size_t O_bytes = (size_t)B * H * sq * d * elem_sz;
 
   size_t off_Qtrans = 0;
@@ -212,15 +232,16 @@ static int gqa_forward_hipblaslt(
   int32_t batchCount = (int32_t)(B * H);
   hipblasOperation_t opT = HIPBLAS_OP_T, opN = HIPBLAS_OP_N;
 
-  // Score GEMM: S[skv, sq] = K_exp^T[skv,d] * Q_trans[d,sq] * scale
+  // Score GEMM: S[T, sq] = K_exp^T[T,d] * Q_trans[d,sq] * scale
+  // where T = total_seq (actual valid tokens, not buffer dimension)
   hipblasLtMatmulDesc_t scoreDesc = nullptr;
   hipblasLtMatrixLayout_t sLayA = nullptr, sLayB = nullptr, sLayC = nullptr,
                           sLayD = nullptr;
   hipblasLtMatmulDesc_t valueDesc = nullptr;
   hipblasLtMatrixLayout_t vLayA = nullptr, vLayB = nullptr, vLayC = nullptr,
                           vLayD = nullptr;
-  GqaGemmKey scoreKey{skv, sq, d, B * H, true};
-  GqaGemmKey valueKey{d, sq, skv, B * H, false};
+  GqaGemmKey scoreKey{total_seq, sq, d, B * H, true};
+  GqaGemmKey valueKey{d, sq, total_seq, B * H, false};
   hipblasLtMatmulAlgo_t scoreAlgo, valueAlgo;
   size_t scoreWs = 0, valueWs = 0;
   int result = 0;
@@ -232,16 +253,19 @@ static int gqa_forward_hipblaslt(
   HIPBLAS_CHECK(hipblasLtMatmulDescSetAttribute(
       scoreDesc, HIPBLASLT_MATMUL_DESC_TRANSB, &opN, sizeof(opN)));
 
-  HIPBLAS_CHECK(hipblasLtMatrixLayoutCreate(&sLayA, HIP_R_16F, d, skv, d));
+  HIPBLAS_CHECK(
+      hipblasLtMatrixLayoutCreate(&sLayA, HIP_R_16F, d, total_seq, d));
   HIPBLAS_CHECK(hipblasLtMatrixLayoutCreate(&sLayB, HIP_R_16F, d, sq, d));
-  HIPBLAS_CHECK(hipblasLtMatrixLayoutCreate(&sLayC, HIP_R_16F, skv, sq, skv));
-  HIPBLAS_CHECK(hipblasLtMatrixLayoutCreate(&sLayD, HIP_R_16F, skv, sq, skv));
-  HIPBLAS_CHECK(setLayoutBatch(sLayA, batchCount, (int64_t)skv * d));
+  HIPBLAS_CHECK(
+      hipblasLtMatrixLayoutCreate(&sLayC, HIP_R_16F, total_seq, sq, total_seq));
+  HIPBLAS_CHECK(
+      hipblasLtMatrixLayoutCreate(&sLayD, HIP_R_16F, total_seq, sq, total_seq));
+  HIPBLAS_CHECK(setLayoutBatch(sLayA, batchCount, (int64_t)total_seq * d));
   HIPBLAS_CHECK(setLayoutBatch(sLayB, batchCount, (int64_t)sq * d));
-  HIPBLAS_CHECK(setLayoutBatch(sLayC, batchCount, (int64_t)sq * skv));
-  HIPBLAS_CHECK(setLayoutBatch(sLayD, batchCount, (int64_t)sq * skv));
+  HIPBLAS_CHECK(setLayoutBatch(sLayC, batchCount, (int64_t)sq * total_seq));
+  HIPBLAS_CHECK(setLayoutBatch(sLayD, batchCount, (int64_t)sq * total_seq));
 
-  // Value GEMM: O[d, sq] = V_exp[d,skv] * softmax(S)[skv,sq]
+  // Value GEMM: O[d, sq] = V_exp[d,T] * softmax(S)[T,sq]
   HIPBLAS_CHECK(
       hipblasLtMatmulDescCreate(&valueDesc, HIPBLAS_COMPUTE_32F, HIP_R_32F));
   HIPBLAS_CHECK(hipblasLtMatmulDescSetAttribute(
@@ -249,12 +273,14 @@ static int gqa_forward_hipblaslt(
   HIPBLAS_CHECK(hipblasLtMatmulDescSetAttribute(
       valueDesc, HIPBLASLT_MATMUL_DESC_TRANSB, &opN, sizeof(opN)));
 
-  HIPBLAS_CHECK(hipblasLtMatrixLayoutCreate(&vLayA, HIP_R_16F, d, skv, d));
-  HIPBLAS_CHECK(hipblasLtMatrixLayoutCreate(&vLayB, HIP_R_16F, skv, sq, skv));
+  HIPBLAS_CHECK(
+      hipblasLtMatrixLayoutCreate(&vLayA, HIP_R_16F, d, total_seq, d));
+  HIPBLAS_CHECK(
+      hipblasLtMatrixLayoutCreate(&vLayB, HIP_R_16F, total_seq, sq, total_seq));
   HIPBLAS_CHECK(hipblasLtMatrixLayoutCreate(&vLayC, HIP_R_16F, d, sq, d));
   HIPBLAS_CHECK(hipblasLtMatrixLayoutCreate(&vLayD, HIP_R_16F, d, sq, d));
-  HIPBLAS_CHECK(setLayoutBatch(vLayA, batchCount, (int64_t)skv * d));
-  HIPBLAS_CHECK(setLayoutBatch(vLayB, batchCount, (int64_t)sq * skv));
+  HIPBLAS_CHECK(setLayoutBatch(vLayA, batchCount, (int64_t)total_seq * d));
+  HIPBLAS_CHECK(setLayoutBatch(vLayB, batchCount, (int64_t)sq * total_seq));
   HIPBLAS_CHECK(setLayoutBatch(vLayC, batchCount, (int64_t)sq * d));
   HIPBLAS_CHECK(setLayoutBatch(vLayD, batchCount, (int64_t)sq * d));
 
@@ -336,18 +362,29 @@ static int gqa_forward_hipblaslt(
                                          (int)sq, (int)H, (int)d));
 
     // ---- Steps 4-5: KV Cache Update ----
+    // Zero present buffers when past != present (separate buffers) so that
+    // the unused region [total_seq, present_seq) is deterministic, matching
+    // ORT CPU which memsets present to zero before populating valid entries.
+    if (present_key && present_value && past_key != present_key) {
+      size_t present_bytes = (size_t)B * G * present_seq * d * elem_sz;
+      HIP_CHECK(hipMemsetAsync(present_key, 0, present_bytes, stream));
+      HIP_CHECK(hipMemsetAsync(present_value, 0, present_bytes, stream));
+    }
+
     if (present_key && present_value) {
       if (past_key && past_len > 0 && past_key != present_key) {
-        // Separate buffers: past [B,G,past_len,d] and present
-        // [B,G,present_seq,d] have different strides. A single kernel copies
-        // past data at [0,past_len) and transposes new tokens from BSHD into
-        // [past_len,past_len+sq).
+        // Separate buffers: past [B,G,past_buf_seq,d] and present
+        // [B,G,present_seq,d] may have different strides. A single kernel
+        // copies past data at [0,past_len) and transposes new tokens from
+        // BSHD into [past_len,past_len+sq).  past_buf_seq is the actual
+        // buffer dimension of past_key (may be larger than past_len when the
+        // cache is pre-allocated at max_length).
         HIP_CHECK(hip_gqa_kv_cache_concat(
             stream, past_key, kSrc, present_key, (int)B, (int)past_len, (int)sq,
-            (int)G, (int)d, (int)past_len, (int)present_seq));
+            (int)G, (int)d, (int)past_buf_seq, (int)present_seq));
         HIP_CHECK(hip_gqa_kv_cache_concat(
             stream, past_value, vSrc, present_value, (int)B, (int)past_len,
-            (int)sq, (int)G, (int)d, (int)past_len, (int)present_seq));
+            (int)sq, (int)G, (int)d, (int)past_buf_seq, (int)present_seq));
       } else {
         // Same buffer (aliased / in-place): past data already at correct
         // offsets, only append new tokens at [past_len, past_len+sq).
@@ -360,13 +397,15 @@ static int gqa_forward_hipblaslt(
       }
     }
 
-    // ---- Steps 6-7: KV Expand [B*G, present_seq, d] -> [B*H, skv, d] ----
+    // ---- Steps 6-7: KV Expand [B*G, present_seq, d] -> [B*H, total_seq, d]
+    // Source reads from present_key with buffer stride present_seq*d; dest
+    // uses total_seq*d since GEMM only operates on total_seq tokens.
     {
       const void *kCache = present_key ? present_key : key;
       const void *vCache = present_value ? present_value : value;
       int kvSrcStride = (int)(present_seq * d);
-      int kvDstStride = (int)(skv * d);
-      int expandCopy = (int)(skv * d);
+      int kvDstStride = (int)(total_seq * d);
+      int expandCopy = (int)(total_seq * d);
 
       HIP_CHECK(hip_gqa_expand_kv(stream, kCache, d_Kexp, (int)(B * H),
                                   (int)HPG, kvSrcStride, kvDstStride,
@@ -391,15 +430,15 @@ static int gqa_forward_hipblaslt(
     // Smooth softmax: activated when head_sink is non-null (per-head sink
     // factors in the denominator) or when smooth_softmax attr == 1 (uses 0
     // as the sink value, matching ORT default).
-    int scoreBatchStride = (int)(sq * skv);
+    int scoreBatchStride = (int)(sq * total_seq);
     if (sq > 1) {
-      HIP_CHECK(hip_gqa_causal_mask(stream, d_S, (int)(B * H), (int)skv,
+      HIP_CHECK(hip_gqa_causal_mask(stream, d_S, (int)(B * H), (int)total_seq,
                                     (int)sq, scoreBatchStride, (int)past_len,
                                     (int)local_window_size));
     }
-    HIP_CHECK(hip_gqa_softmax_inplace(stream, d_S, (int)(B * H * sq), (int)skv,
-                                      (int)sq, scoreBatchStride, head_sink,
-                                      (int)H, (int)use_smooth_softmax));
+    HIP_CHECK(hip_gqa_softmax_inplace(
+        stream, d_S, (int)(B * H * sq), (int)total_seq, (int)sq,
+        scoreBatchStride, head_sink, (int)H, (int)use_smooth_softmax));
 
     // ---- Step 10: Value GEMM ----
     float valAlpha = 1.0f;
@@ -457,9 +496,9 @@ int wrap_group_query_attention(
     int64_t rotary_interleaved, float softcap, int64_t local_window_size,
     int64_t smooth_softmax, int64_t qk_output, int64_t k_quant_type,
     int64_t v_quant_type, int64_t kv_cache_bit_width,
-    // Shape values (5)
-    int64_t batch_size, int64_t seq_len_q, int64_t seq_len_kv, int64_t head_dim,
-    int64_t element_size_bytes) {
+    // Shape values (6)
+    int64_t batch_size, int64_t seq_len_q, int64_t seq_len_kv,
+    int64_t past_seq_len, int64_t head_dim, int64_t element_size_bytes) {
 
   if (!state) {
     fprintf(stderr, "wrap_group_query_attention: null state\n");
@@ -564,8 +603,8 @@ int wrap_group_query_attention(
 
   RUNTIME_DEBUG_LOG(
       "[REAL] wrap_group_query_attention:\n"
-      "  shapes: batch=%lld, seq_q=%lld, seq_kv=%lld, num_heads=%lld, "
-      "kv_heads=%lld, head_dim=%lld\n"
+      "  shapes: batch=%lld, seq_q=%lld, seq_kv=%lld, past_seq=%lld, "
+      "num_heads=%lld, kv_heads=%lld, head_dim=%lld\n"
       "  attrs:  scale=%f, do_rotary=%lld, rotary_interleaved=%lld, "
       "softcap=%f, local_window_size=%lld, smooth_softmax=%lld\n"
       "  inputs: query=%p, key=%p, value=%p, past_key=%p, past_value=%p\n"
@@ -573,18 +612,20 @@ int wrap_group_query_attention(
       "  outputs: output=%p, present_key=%p, present_value=%p\n"
       "  mode:   packed_qkv=%d, rope=%d, local_window=%d, smooth_softmax=%d\n",
       (long long)batch_size, (long long)seq_len_q, (long long)seq_len_kv,
-      (long long)num_heads, (long long)kv_num_heads, (long long)head_dim,
-      (double)scale, (long long)do_rotary, (long long)rotary_interleaved,
-      (double)softcap, (long long)local_window_size, (long long)smooth_softmax,
-      query, key, value, past_key, past_value, cos_cache, sin_cache, head_sink,
-      output, present_key, present_value, (int)is_packed_qkv, (int)has_rope,
+      (long long)past_seq_len, (long long)num_heads, (long long)kv_num_heads,
+      (long long)head_dim, (double)scale, (long long)do_rotary,
+      (long long)rotary_interleaved, (double)softcap,
+      (long long)local_window_size, (long long)smooth_softmax, query, key,
+      value, past_key, past_value, cos_cache, sin_cache, head_sink, output,
+      present_key, present_value, (int)is_packed_qkv, (int)has_rope,
       (int)has_local_window, (int)has_smooth_softmax);
 
   int rc = gqa_forward_hipblaslt(
       state, stream, ltHandle, query, key, value, past_key, past_value,
-      cos_cache, sin_cache, head_sink, has_smooth_softmax, output, present_key,
-      present_value, batch_size, seq_len_q, seq_len_kv, num_heads, kv_num_heads,
-      head_dim, scale, do_rotary, local_window_size);
+      seqlens_k, cos_cache, sin_cache, head_sink, has_smooth_softmax, output,
+      present_key, present_value, batch_size, seq_len_q, seq_len_kv,
+      past_seq_len, num_heads, kv_num_heads, head_dim, scale, do_rotary,
+      local_window_size);
 
   if (rc != 0) {
     fprintf(stderr, "wrap_group_query_attention: gqa_forward failed (rc=%d)\n",

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -16,6 +16,7 @@
 #include <cstring>
 #include <functional>
 #include <unordered_map>
+#include <vector>
 
 #define HIP_CHECK(cmd) HIP_CHECK_GOTO(cmd, cleanup)
 #define HIPBLAS_CHECK(cmd) HIPBLAS_CHECK_GOTO(cmd, cleanup)
@@ -125,7 +126,7 @@ static int queryGemmAlgo(hipblasLtHandle_t handle, hipblasLtMatmulDesc_t desc,
 
 cleanup_pref:
   if (pref)
-    hipblasLtMatmulPreferenceDestroy(pref);
+    HIPBLAS_CLEANUP(hipblasLtMatmulPreferenceDestroy(pref));
   return result;
 }
 
@@ -151,6 +152,47 @@ static int gqa_forward_hipblaslt(
     int64_t past_buf_seq, int64_t H, int64_t G, int64_t d, float scale,
     int64_t do_rotary, int64_t local_window_size) {
 
+  int result = 0;
+  int32_t seqlens_k_val = 0;
+  int64_t past_len = 0;
+  bool packed_qkv = false;
+  size_t elem_sz = 0;
+  size_t Qtrans_bytes = 0;
+  size_t Kexp_bytes = 0;
+  size_t S_bytes = 0;
+  size_t O_bytes = 0;
+  size_t off_Qtrans = 0;
+  size_t off_Kexp = 0;
+  size_t off_Vexp = 0;
+  size_t off_S = 0;
+  size_t off_O = 0;
+  size_t temp_end = 0;
+  size_t off_Qroped = 0;
+  size_t off_Kroped = 0;
+  bool need_rope = false;
+  size_t off_Qsplit = 0;
+  size_t off_Ksplit = 0;
+  size_t off_Vsplit = 0;
+  int32_t batchCount = 0;
+  hipblasOperation_t opT = HIPBLAS_OP_T;
+  hipblasOperation_t opN = HIPBLAS_OP_N;
+  hipblasLtMatmulDesc_t scoreDesc = nullptr;
+  hipblasLtMatrixLayout_t sLayA = nullptr;
+  hipblasLtMatrixLayout_t sLayB = nullptr;
+  hipblasLtMatrixLayout_t sLayC = nullptr;
+  hipblasLtMatrixLayout_t sLayD = nullptr;
+  hipblasLtMatmulDesc_t valueDesc = nullptr;
+  hipblasLtMatrixLayout_t vLayA = nullptr;
+  hipblasLtMatrixLayout_t vLayB = nullptr;
+  hipblasLtMatrixLayout_t vLayC = nullptr;
+  hipblasLtMatrixLayout_t vLayD = nullptr;
+  GqaGemmKey scoreKey{};
+  GqaGemmKey valueKey{};
+  hipblasLtMatmulAlgo_t scoreAlgo{};
+  hipblasLtMatmulAlgo_t valueAlgo{};
+  size_t scoreWs = 0;
+  size_t valueWs = 0;
+
   int64_t HPG = H / G;
   // present_seq is the buffer dimension of present_key (may be max_length
   // for pre-allocated caches, larger than the actual valid token count).
@@ -161,24 +203,39 @@ static int gqa_forward_hipblaslt(
   // fall back to the buffer dimension (non-pre-allocated case).
   int64_t total_seq = skv;
   if (seqlens_k_ptr) {
-    int32_t seqlens_k_val = 0;
-    hipError_t memErr =
-        hipMemcpyAsync(&seqlens_k_val, seqlens_k_ptr, sizeof(int32_t),
-                       hipMemcpyDeviceToHost, stream);
-    if (memErr == hipSuccess)
-      memErr = hipStreamSynchronize(stream);
-    if (memErr != hipSuccess) {
-      fprintf(stderr, "GQA: failed to read seqlens_k from GPU\n");
-      return -1;
+    if (B > 1) {
+      // Read all B values and verify they are uniform.
+      // The batched GEMM pipeline assumes a single total_seq for all batches;
+      // per-batch variable lengths would require per-batch GEMM calls.
+      std::vector<int32_t> seqlens_k_host(B);
+      HIP_CHECK(hipMemcpyAsync(seqlens_k_host.data(), seqlens_k_ptr,
+                               B * sizeof(int32_t), hipMemcpyDeviceToHost,
+                               stream));
+      HIP_CHECK(hipStreamSynchronize(stream));
+      seqlens_k_val = seqlens_k_host[0];
+      for (int64_t b = 1; b < B; ++b) {
+        if (seqlens_k_host[b] != seqlens_k_val) {
+          fprintf(stderr,
+                  "gqa_forward_hipblaslt: per-batch seqlens_k not yet "
+                  "supported (batch %lld has %d, batch 0 has %d)\n",
+                  (long long)b, seqlens_k_host[b], seqlens_k_val);
+          result = -1;
+          goto cleanup;
+        }
+      }
+    } else {
+      HIP_CHECK(hipMemcpyAsync(&seqlens_k_val, seqlens_k_ptr, sizeof(int32_t),
+                               hipMemcpyDeviceToHost, stream));
+      HIP_CHECK(hipStreamSynchronize(stream));
     }
     total_seq = (int64_t)seqlens_k_val + 1;
   }
 
-  int64_t past_len = total_seq - sq;
+  past_len = total_seq - sq;
   if (past_len < 0)
     past_len = 0;
 
-  bool packed_qkv = (key == nullptr && value == nullptr);
+  packed_qkv = (key == nullptr && value == nullptr);
 
   // ---- Workspace layout ----
   // All temp buffers are packed contiguously into the shared workspace,
@@ -189,22 +246,23 @@ static int gqa_forward_hipblaslt(
   // Layout: [Qtrans | Kexp | Vexp | S | O | Qroped? | Kroped? | Qsplit? |
   // Ksplit? | Vsplit? | GEMM ws]
 
-  size_t elem_sz = 2; // FP16
-  size_t Qtrans_bytes = (size_t)B * H * sq * d * elem_sz;
-  size_t Kexp_bytes = (size_t)B * H * total_seq * d * elem_sz;
-  size_t S_bytes = (size_t)B * H * sq * total_seq * elem_sz;
-  size_t O_bytes = (size_t)B * H * sq * d * elem_sz;
+  elem_sz = 2; // FP16
+  Qtrans_bytes = (size_t)B * H * sq * d * elem_sz;
+  Kexp_bytes = (size_t)B * H * total_seq * d * elem_sz;
+  S_bytes = (size_t)B * H * sq * total_seq * elem_sz;
+  O_bytes = (size_t)B * H * sq * d * elem_sz;
 
-  size_t off_Qtrans = 0;
-  size_t off_Kexp = off_Qtrans + Qtrans_bytes;
-  size_t off_Vexp = off_Kexp + Kexp_bytes;
-  size_t off_S = off_Vexp + Kexp_bytes;
-  size_t off_O = off_S + S_bytes;
-  size_t temp_end = off_O + O_bytes;
+  off_Qtrans = 0;
+  off_Kexp = off_Qtrans + Qtrans_bytes;
+  off_Vexp = off_Kexp + Kexp_bytes;
+  off_S = off_Vexp + Kexp_bytes;
+  off_O = off_S + S_bytes;
+  temp_end = off_O + O_bytes;
 
   // Optional RoPE buffers: allocated only when do_rotary is enabled.
-  size_t off_Qroped = 0, off_Kroped = 0;
-  bool need_rope = (do_rotary == 1) && cos_cache && sin_cache;
+  off_Qroped = 0;
+  off_Kroped = 0;
+  need_rope = (do_rotary == 1) && cos_cache && sin_cache;
   if (need_rope) {
     size_t Q_bytes = (size_t)B * sq * H * d * elem_sz;
     size_t K_bytes = (size_t)B * sq * G * d * elem_sz;
@@ -217,7 +275,9 @@ static int gqa_forward_hipblaslt(
   // null (GPT-OSS style packed input).  These must be placed AFTER the RoPE
   // buffers in the layout so that split outputs remain live while RoPE reads
   // from them and writes to the RoPE region (no overlap).
-  size_t off_Qsplit = 0, off_Ksplit = 0, off_Vsplit = 0;
+  off_Qsplit = 0;
+  off_Ksplit = 0;
+  off_Vsplit = 0;
   if (packed_qkv) {
     size_t Q_bytes = (size_t)B * sq * H * d * elem_sz;
     size_t K_bytes = (size_t)B * sq * G * d * elem_sz;
@@ -229,22 +289,12 @@ static int gqa_forward_hipblaslt(
 
   // Query GEMM algorithms first (cached) to know the GEMM workspace size,
   // then ensure a single workspace allocation covering everything.
-  int32_t batchCount = (int32_t)(B * H);
-  hipblasOperation_t opT = HIPBLAS_OP_T, opN = HIPBLAS_OP_N;
+  batchCount = (int32_t)(B * H);
 
   // Score GEMM: S[T, sq] = K_exp^T[T,d] * Q_trans[d,sq] * scale
   // where T = total_seq (actual valid tokens, not buffer dimension)
-  hipblasLtMatmulDesc_t scoreDesc = nullptr;
-  hipblasLtMatrixLayout_t sLayA = nullptr, sLayB = nullptr, sLayC = nullptr,
-                          sLayD = nullptr;
-  hipblasLtMatmulDesc_t valueDesc = nullptr;
-  hipblasLtMatrixLayout_t vLayA = nullptr, vLayB = nullptr, vLayC = nullptr,
-                          vLayD = nullptr;
-  GqaGemmKey scoreKey{total_seq, sq, d, B * H, true};
-  GqaGemmKey valueKey{d, sq, total_seq, B * H, false};
-  hipblasLtMatmulAlgo_t scoreAlgo, valueAlgo;
-  size_t scoreWs = 0, valueWs = 0;
-  int result = 0;
+  scoreKey = GqaGemmKey{total_seq, sq, d, B * H, true};
+  valueKey = GqaGemmKey{d, sq, total_seq, B * H, false};
 
   HIPBLAS_CHECK(
       hipblasLtMatmulDescCreate(&scoreDesc, HIPBLAS_COMPUTE_32F, HIP_R_32F));
@@ -453,25 +503,25 @@ static int gqa_forward_hipblaslt(
 
 cleanup:
   if (sLayA)
-    hipblasLtMatrixLayoutDestroy(sLayA);
+    HIPBLAS_CLEANUP(hipblasLtMatrixLayoutDestroy(sLayA));
   if (sLayB)
-    hipblasLtMatrixLayoutDestroy(sLayB);
+    HIPBLAS_CLEANUP(hipblasLtMatrixLayoutDestroy(sLayB));
   if (sLayC)
-    hipblasLtMatrixLayoutDestroy(sLayC);
+    HIPBLAS_CLEANUP(hipblasLtMatrixLayoutDestroy(sLayC));
   if (sLayD)
-    hipblasLtMatrixLayoutDestroy(sLayD);
+    HIPBLAS_CLEANUP(hipblasLtMatrixLayoutDestroy(sLayD));
   if (vLayA)
-    hipblasLtMatrixLayoutDestroy(vLayA);
+    HIPBLAS_CLEANUP(hipblasLtMatrixLayoutDestroy(vLayA));
   if (vLayB)
-    hipblasLtMatrixLayoutDestroy(vLayB);
+    HIPBLAS_CLEANUP(hipblasLtMatrixLayoutDestroy(vLayB));
   if (vLayC)
-    hipblasLtMatrixLayoutDestroy(vLayC);
+    HIPBLAS_CLEANUP(hipblasLtMatrixLayoutDestroy(vLayC));
   if (vLayD)
-    hipblasLtMatrixLayoutDestroy(vLayD);
+    HIPBLAS_CLEANUP(hipblasLtMatrixLayoutDestroy(vLayD));
   if (scoreDesc)
-    hipblasLtMatmulDescDestroy(scoreDesc);
+    HIPBLAS_CLEANUP(hipblasLtMatmulDescDestroy(scoreDesc));
   if (valueDesc)
-    hipblasLtMatmulDescDestroy(valueDesc);
+    HIPBLAS_CLEANUP(hipblasLtMatmulDescDestroy(valueDesc));
 
   return result;
 }

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -412,10 +412,13 @@ static int gqa_forward_hipblaslt(
                                          (int)sq, (int)H, (int)d));
 
     // ---- Steps 4-5: KV Cache Update ----
-    // Zero present buffers when past != present (separate buffers) so that
-    // the unused region [total_seq, present_seq) is deterministic, matching
-    // ORT CPU which memsets present to zero before populating valid entries.
-    if (present_key && present_value && past_key != present_key) {
+    // Zero present buffers only when there is an unused region beyond the
+    // valid token range [0, total_seq).  The concat kernel writes [0,
+    // total_seq) completely, so zeroing is redundant when total_seq >=
+    // present_seq.  This avoids 2 × memset per layer in the common case
+    // where the buffer is exactly sized (total_seq == present_seq).
+    if (present_key && present_value && past_key != present_key &&
+        total_seq < present_seq) {
       size_t present_bytes = (size_t)B * G * present_seq * d * elem_sz;
       HIP_CHECK(hipMemsetAsync(present_key, 0, present_bytes, stream));
       HIP_CHECK(hipMemsetAsync(present_value, 0, present_bytes, stream));

--- a/lib/Runtime/real/miopen.cpp
+++ b/lib/Runtime/real/miopen.cpp
@@ -139,19 +139,28 @@ int wrap_miopenConvolutionForward(
   MIOPEN_CHECK(miopenCreateTensorDescriptor(&weights_desc));
   MIOPEN_CHECK(miopenCreateTensorDescriptor(&output_desc));
 
-  // Set tensor descriptors (assuming float32 data type)
-  // Input: [N, C, H, W]
-  MIOPEN_CHECK(miopenSet4dTensorDescriptor(input_desc, miopenFloat, input_n,
-                                           input_c, input_h, input_w));
+  // Set tensor descriptors (assuming float32 data type).
+  // Use miopenSetNdTensorDescriptorWithLayout to set NCHW layout explicitly;
+  // miopenSet4dTensorDescriptor leaves the layout as 'UNKNOWN' which triggers
+  // warnings in MIOpen 7.12+.
+  {
+    // Input: [N, C, H, W]
+    int in_dims[] = {(int)input_n, (int)input_c, (int)input_h, (int)input_w};
+    MIOPEN_CHECK(miopenSetNdTensorDescriptorWithLayout(
+        input_desc, miopenFloat, miopenTensorNCHW, in_dims, 4));
 
-  // Weights: [K, C, R, S] where K=output channels, C=input channels,
-  // R=kernel_h, S=kernel_w
-  MIOPEN_CHECK(miopenSet4dTensorDescriptor(weights_desc, miopenFloat, weights_k,
-                                           input_c, kernel_h, kernel_w));
+    // Weights: [K, C, R, S] where K=output channels, C=input channels,
+    // R=kernel_h, S=kernel_w
+    int w_dims[] = {(int)weights_k, (int)input_c, (int)kernel_h, (int)kernel_w};
+    MIOPEN_CHECK(miopenSetNdTensorDescriptorWithLayout(
+        weights_desc, miopenFloat, miopenTensorNCHW, w_dims, 4));
 
-  // Output: [N, K, H', W']
-  MIOPEN_CHECK(miopenSet4dTensorDescriptor(output_desc, miopenFloat, input_n,
-                                           weights_k, output_h, output_w));
+    // Output: [N, K, H', W']
+    int out_dims[] = {(int)input_n, (int)weights_k, (int)output_h,
+                      (int)output_w};
+    MIOPEN_CHECK(miopenSetNdTensorDescriptorWithLayout(
+        output_desc, miopenFloat, miopenTensorNCHW, out_dims, 4));
+  }
 
   // Create convolution descriptor
   // Note: MIOpen padding is per-side, but if pad_top==pad_bottom and

--- a/lib/Runtime/real/simplified_layer_norm.cpp
+++ b/lib/Runtime/real/simplified_layer_norm.cpp
@@ -88,23 +88,24 @@ int wrap_miopenT5LayerNormForward(RuntimeState *state, void *input, void *scale,
   MIOPEN_CHECK(miopenCreateTensorDescriptor(&yDesc));
   MIOPEN_CHECK(miopenCreateTensorDescriptor(&rstdDesc));
 
+  // Pad all descriptors to 4D NCHW to avoid 'UNKNOWN' layout warnings
+  // in MIOpen 7.12+.  miopenSetTensorDescriptor with 1D/2D strides
+  // leaves the layout string unset, triggering GetLayoutEnum warnings.
   {
-    int x_dims[] = {static_cast<int>(num_rows), static_cast<int>(hidden_dim)};
-    int x_strides[] = {static_cast<int>(hidden_dim), 1};
-    MIOPEN_CHECK(
-        miopenSetTensorDescriptor(xDesc, data_type, 2, x_dims, x_strides));
-    MIOPEN_CHECK(
-        miopenSetTensorDescriptor(yDesc, data_type, 2, x_dims, x_strides));
+    int x_dims[] = {1, 1, static_cast<int>(num_rows),
+                    static_cast<int>(hidden_dim)};
+    MIOPEN_CHECK(miopenSetNdTensorDescriptorWithLayout(
+        xDesc, data_type, miopenTensorNCHW, x_dims, 4));
+    MIOPEN_CHECK(miopenSetNdTensorDescriptorWithLayout(
+        yDesc, data_type, miopenTensorNCHW, x_dims, 4));
 
-    int w_dims[] = {static_cast<int>(hidden_dim)};
-    int w_strides[] = {1};
-    MIOPEN_CHECK(
-        miopenSetTensorDescriptor(weightDesc, data_type, 1, w_dims, w_strides));
+    int w_dims[] = {1, 1, 1, static_cast<int>(hidden_dim)};
+    MIOPEN_CHECK(miopenSetNdTensorDescriptorWithLayout(
+        weightDesc, data_type, miopenTensorNCHW, w_dims, 4));
 
-    int rstd_dims[] = {static_cast<int>(num_rows)};
-    int rstd_strides[] = {1};
-    MIOPEN_CHECK(miopenSetTensorDescriptor(rstdDesc, miopenFloat, 1, rstd_dims,
-                                           rstd_strides));
+    int rstd_dims[] = {1, 1, 1, static_cast<int>(num_rows)};
+    MIOPEN_CHECK(miopenSetNdTensorDescriptorWithLayout(
+        rstdDesc, miopenFloat, miopenTensorNCHW, rstd_dims, 4));
   }
 
   RUNTIME_DEBUG_LOG(

--- a/lib/Runtime/real/skip_simplified_layer_norm.cpp
+++ b/lib/Runtime/real/skip_simplified_layer_norm.cpp
@@ -131,17 +131,18 @@ int wrap_skip_simplified_layer_norm(RuntimeState *state, void *input,
   MIOPEN_CHECK(miopenCreateTensorDescriptor(&addBDesc));
   MIOPEN_CHECK(miopenCreateTensorDescriptor(&addCDesc));
 
-  // Use 2D descriptors [num_rows, hidden_dim] so that bias [1, hidden_dim]
-  // can broadcast correctly across rows when num_rows > 1.
+  // Pad to 4D NCHW so that bias [1,1,1,hidden_dim] broadcasts correctly
+  // across the H (num_rows) dimension, and to avoid 'UNKNOWN' layout
+  // warnings in MIOpen 7.12+.
   {
-    int dims[] = {static_cast<int>(num_rows), static_cast<int>(hidden_dim)};
-    int strides[] = {static_cast<int>(hidden_dim), 1};
-    MIOPEN_CHECK(
-        miopenSetTensorDescriptor(addADesc, data_type, 2, dims, strides));
-    MIOPEN_CHECK(
-        miopenSetTensorDescriptor(addBDesc, data_type, 2, dims, strides));
-    MIOPEN_CHECK(
-        miopenSetTensorDescriptor(addCDesc, data_type, 2, dims, strides));
+    int dims[] = {1, 1, static_cast<int>(num_rows),
+                  static_cast<int>(hidden_dim)};
+    MIOPEN_CHECK(miopenSetNdTensorDescriptorWithLayout(
+        addADesc, data_type, miopenTensorNCHW, dims, 4));
+    MIOPEN_CHECK(miopenSetNdTensorDescriptorWithLayout(
+        addBDesc, data_type, miopenTensorNCHW, dims, 4));
+    MIOPEN_CHECK(miopenSetNdTensorDescriptorWithLayout(
+        addCDesc, data_type, miopenTensorNCHW, dims, 4));
   }
 
   {
@@ -164,12 +165,11 @@ int wrap_skip_simplified_layer_norm(RuntimeState *state, void *input,
 
     MIOPEN_CHECK(miopenCreateTensorDescriptor(&biasDesc));
     {
-      // bias is [hidden_dim], described as [1, hidden_dim] so MIOpen
-      // broadcasts it across the num_rows dimension of addCDesc.
-      int bias_dims[] = {1, static_cast<int>(hidden_dim)};
-      int bias_strides[] = {static_cast<int>(hidden_dim), 1};
-      MIOPEN_CHECK(miopenSetTensorDescriptor(biasDesc, data_type, 2, bias_dims,
-                                             bias_strides));
+      // bias is [hidden_dim], padded to 4D [1,1,1,hidden_dim] so MIOpen
+      // broadcasts it across the H (num_rows) dimension of addCDesc.
+      int bias_dims[] = {1, 1, 1, static_cast<int>(hidden_dim)};
+      MIOPEN_CHECK(miopenSetNdTensorDescriptorWithLayout(
+          biasDesc, data_type, miopenTensorNCHW, bias_dims, 4));
     }
 
     {
@@ -208,23 +208,22 @@ int wrap_skip_simplified_layer_norm(RuntimeState *state, void *input,
   MIOPEN_CHECK(miopenCreateTensorDescriptor(&yDesc));
   MIOPEN_CHECK(miopenCreateTensorDescriptor(&rstdDesc));
 
+  // Pad to 4D NCHW to avoid 'UNKNOWN' layout warnings in MIOpen 7.12+.
   {
-    int x_dims[] = {static_cast<int>(num_rows), static_cast<int>(hidden_dim)};
-    int x_strides[] = {static_cast<int>(hidden_dim), 1};
-    MIOPEN_CHECK(
-        miopenSetTensorDescriptor(xDesc, data_type, 2, x_dims, x_strides));
-    MIOPEN_CHECK(
-        miopenSetTensorDescriptor(yDesc, data_type, 2, x_dims, x_strides));
+    int x_dims[] = {1, 1, static_cast<int>(num_rows),
+                    static_cast<int>(hidden_dim)};
+    MIOPEN_CHECK(miopenSetNdTensorDescriptorWithLayout(
+        xDesc, data_type, miopenTensorNCHW, x_dims, 4));
+    MIOPEN_CHECK(miopenSetNdTensorDescriptorWithLayout(
+        yDesc, data_type, miopenTensorNCHW, x_dims, 4));
 
-    int w_dims[] = {static_cast<int>(hidden_dim)};
-    int w_strides[] = {1};
-    MIOPEN_CHECK(
-        miopenSetTensorDescriptor(weightDesc, data_type, 1, w_dims, w_strides));
+    int w_dims[] = {1, 1, 1, static_cast<int>(hidden_dim)};
+    MIOPEN_CHECK(miopenSetNdTensorDescriptorWithLayout(
+        weightDesc, data_type, miopenTensorNCHW, w_dims, 4));
 
-    int rstd_dims[] = {static_cast<int>(num_rows)};
-    int rstd_strides[] = {1};
-    MIOPEN_CHECK(miopenSetTensorDescriptor(rstdDesc, miopenFloat, 1, rstd_dims,
-                                           rstd_strides));
+    int rstd_dims[] = {1, 1, 1, static_cast<int>(num_rows)};
+    MIOPEN_CHECK(miopenSetNdTensorDescriptorWithLayout(
+        rstdDesc, miopenFloat, miopenTensorNCHW, rstd_dims, 4));
   }
 
   MIOPEN_CHECK(miopenT5LayerNormForward(

--- a/lib/Runtime/runtime_state_internal.h
+++ b/lib/Runtime/runtime_state_internal.h
@@ -29,9 +29,8 @@ struct RuntimeState {
   // Single allocation holding all constants as one blob.
   // gpu_constants[i] points into gpu_constants_blob at the offset stored in
   // ConstantInfo, so only one allocation/copy is needed at init time.
-  // On dGPU: hipMalloc (VRAM).
-  // On iGPU: hipMalloc (1x pool consumption) with hipHostMalloc fallback
-  //          when the VRAM pool is too small (spills to GTT).
+  // On dGPU: hipMalloc (VRAM). On iGPU: hipHostMalloc (pinned system RAM,
+  // GPU reads in-place, no hipMemcpy needed).
   void *gpu_constants_blob;
   bool constants_blob_is_host; // true = hipHostMalloc, false = hipMalloc
   void **gpu_constants;

--- a/lib/Runtime/runtime_state_internal.h
+++ b/lib/Runtime/runtime_state_internal.h
@@ -29,8 +29,9 @@ struct RuntimeState {
   // Single allocation holding all constants as one blob.
   // gpu_constants[i] points into gpu_constants_blob at the offset stored in
   // ConstantInfo, so only one allocation/copy is needed at init time.
-  // On dGPU: hipMalloc (VRAM). On iGPU: hipHostMalloc (pinned system RAM,
-  // GPU reads in-place, no hipMemcpy needed).
+  // On dGPU: hipMalloc (VRAM).
+  // On iGPU: hipMalloc (1x pool consumption) with hipHostMalloc fallback
+  //          when the VRAM pool is too small (spills to GTT).
   void *gpu_constants_blob;
   bool constants_blob_is_host; // true = hipHostMalloc, false = hipMalloc
   void **gpu_constants;

--- a/lib/Runtime/runtime_state_internal.h
+++ b/lib/Runtime/runtime_state_internal.h
@@ -36,6 +36,13 @@ struct RuntimeState {
   void **gpu_constants;
   size_t num_constants;
 
+  // Shared constants support: in OGA pipeline mode, prefill and decode models
+  // share the same constants.bin. The second model reuses the first's blob
+  // via a process-wide named shared memory descriptor with atomic ref count.
+  bool constants_is_shared;       // true = reusing another model's blob
+  void *shared_constants_mapping; // Win32 file mapping HANDLE
+  void *shared_constants_view; // MapViewOfFile pointer (SharedConstantsMeta*)
+
   // Memory pooling support
   void *pool_base;        // Single large memory pool
   size_t pool_size;       // Total pool size in bytes

--- a/test/lit/Conversion/hip-to-llvm/test_gather.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_gather.mlir
@@ -17,8 +17,8 @@ module {
 }
 
 // CHECK-LABEL: llvm.func @test_gather_lowering
-// CHECK: llvm.call @wrap_gather({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64) -> i32
+// CHECK: llvm.call @wrap_gather({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64) -> i32
 
-// Verify 8 parameters:
+// Verify 9 parameters:
 // - 4 pointers: state, data, indices, output
-// - 4 i64 values: axis=0, data_num_elements=12, output_num_elements=8, element_size_bytes=4
+// - 5 i64 values: axis=0, data_num_elements=12, indices_num_elements=2, output_num_elements=8, element_size_bytes=4

--- a/test/lit/Conversion/hip-to-llvm/test_gqa.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_gqa.mlir
@@ -30,9 +30,9 @@ module {
 }
 
 // CHECK-LABEL: llvm.func @test_gqa_lowering
-// CHECK: llvm.call @wrap_group_query_attention({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, f32, i64, i64, f32, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
+// CHECK: llvm.call @wrap_group_query_attention({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, f32, i64, i64, f32, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
 
-// Verify 36 parameters (Phase 1 - full MS GQA spec signature):
+// Verify 37 parameters (Phase 1 - full MS GQA spec signature):
 // - 19 pointers: state, query, key, value, past_key, past_value, seqlens_k, total_seq_len,
 //                cos_cache(NULL), sin_cache(NULL), position_ids(NULL), attention_bias(NULL),
 //                head_sink(NULL), k_scale(NULL), v_scale(NULL),
@@ -40,4 +40,5 @@ module {
 // - 12 attributes: num_heads=32, kv_num_heads=8, scale=0.0883883461, do_rotary=0, rotary_interleaved=0,
 //                  softcap=0.0, local_window_size=-1, smooth_softmax=0, qk_output=0,
 //                  k_quant_type=0(NONE), v_quant_type=0(NONE), kv_cache_bit_width=8
-// - 5 shape params: batch_size=1, seq_len_q=1, seq_len_kv=128, head_dim=128, element_size_bytes=2
+// - 6 shape params: batch_size=1, seq_len_q=1, seq_len_kv=128, past_seq_len=127,
+//                   head_dim=128, element_size_bytes=2


### PR DESCRIPTION
## Summary

- **Gather**: support multi-index embedding lookups (variable-length index tensors)
- **GQA**: use `seqlens_k` to determine actual sequence length for pre-allocated KV caches; add `B > 1` guard for non-uniform batch sequences; introduce `HIPBLAS_CLEANUP` macro for consistent hipBLASLt resource cleanup
- **Shared constants cache**: in OGA pipeline mode (prefill + decode), the second model reuses the first model's constants blob via process-wide named shared memory, avoiding a redundant ~15 GB allocation
- **Custom kernels discovery**: add `HIP_CUSTOM_KERNELS_DIR` environment variable for runtime library path override, with fallback to compile-time path and name-only linker search

## Changes Overview

### Gather multi-index (`gather_kernel.hip`, `gather.cpp`, `HipToLLVM.cpp`, `test_gather.mlir`)
- Extend `gather_axis0_kernel` to support multi-dimensional index tensors (not just scalar/1D)
- Add `indices_num_elements` parameter so `slice_size` and `data_axis_size` are computed correctly for multi-index gathers (e.g. embedding lookups with seq_len > 1)
- Update MLIR lowering to extract and pass the index count
- Update LIT test to match new function signature

### GQA pre-allocated KV cache (`gqa.cpp`, `HipToLLVM.cpp`, `test_gqa.mlir`, `error_check_macros.h`)
- Read `seqlens_k` from device memory (`hipMemcpyAsync` + `hipStreamSynchronize`) to determine actual sequence length, enabling correct attention over pre-allocated (larger-than-used) KV caches
- Use `total_seq` (from `seqlens_k`) for GEMM dimensions and workspace sizing; keep the buffer dimension (`present_seq` / `past_buf_seq`) for memory strides in concat/append/expand kernels
- Zero present KV buffers with `hipMemsetAsync` when `past != present` (separate buffers) so unused slots are deterministic
- Add `B > 1` guard: log error and `goto cleanup` when batch elements have non-uniform `seqlens_k` (batched GEMM pipeline assumes single `total_seq`)
- Add `HIPBLAS_CLEANUP` macro for `hipblasLtMatrixLayoutDestroy` / `hipblasLtMatmulDescDestroy` error checking in cleanup sections
- Extract `past_buf_seq` from MLIR and pass as a separate parameter
- Update LIT test to match new signature

### Shared constants cache (`hipdnn_ep_runtime_state.cpp`, `runtime_state_internal.h`)
- Use Win32 named shared memory (`CreateFileMappingA` / `OpenFileMappingA`) keyed by process ID and blob size to share the GPU constants blob between models in the same OGA pipeline
- Atomic reference counting (`__sync_add_and_fetch` / `__sync_sub_and_fetch`) ensures the last model to clean up frees the GPU memory
- Add `hipStreamSynchronize` before workspace reallocation to prevent use-after-free
- Add null checks on `state->stream` before `hipStreamDestroy` in error paths

### Custom kernels library discovery (`CompilerDriver.cpp`)
- Add 3-tier discovery: (1) `HIP_CUSTOM_KERNELS_DIR` env var, (2) compile-time `HIP_CUSTOM_KERNELS_LIB_PATH`, (3) name-only linker fallback
- When the env var is set, its directory is added to `library_paths` so the JIT linker can find the library at runtime
- Comments document the discovery priority for both end-users and developers

## Test Plan

- [x] Pre-commit checks passed
- [x] Build verified
- [x] LIT conversion tests passed
- [x] E2E runtime tests passed