### PR TITLE
if reduce size >=2048, with shfl kernel

### DIFF
--- a/3rd-party/custom_kernels/hip/reduce_sum_kernel.hip
+++ b/3rd-party/custom_kernels/hip/reduce_sum_kernel.hip
@@ -46,6 +46,89 @@ __global__ void reduce_sum_i64_kernel(
   }
 }
 
+// Parallel sum reduction for i64. Each block reduces one output element
+// by summing reduce_size consecutive input elements using warp shuffles and
+// a small shared-memory staging area for cross-warp reduction.
+__device__ inline int64_t warp_reduce_sum_i64(int64_t value) {
+  const unsigned long long mask = __activemask();
+  for (int offset = warpSize / 2; offset > 0; offset >>= 1) {
+    value += __shfl_down_sync(mask, value, offset);
+  }
+  return value;
+}
+
+__global__ void reduce_sum_i64_shfl_kernel(
+    const int64_t* __restrict__ data,
+    int64_t* __restrict__ output,
+    int64_t reduce_size,
+    int64_t num_output_elements) {
+  extern __shared__ int64_t sdata[];
+
+  int64_t out_idx = blockIdx.x;
+  if (out_idx >= num_output_elements) return;
+
+  const int64_t* slice = data + out_idx * reduce_size;
+  const int tid = static_cast<int>(threadIdx.x);
+  const int lane = tid % warpSize;
+  const int warp_id = tid / warpSize;
+  const int num_warps = (static_cast<int>(blockDim.x) + warpSize - 1) / warpSize;
+  const int64_t stride = static_cast<int64_t>(blockDim.x);
+
+  // Each thread accumulates a partial sum over its strided portion. When the
+  // slice is 16-byte aligned we read two i64 values at a time, otherwise we
+  // fall back to an unrolled scalar loop.
+  int64_t sum = 0;
+  const bool use_vectorized =
+      (reinterpret_cast<std::uintptr_t>(slice) & (alignof(longlong2) - 1)) == 0;
+
+  if (use_vectorized) {
+    const int64_t vec_size = reduce_size / 2;
+    const int64_t vec_stride = stride;
+    const longlong2* slice_vec = reinterpret_cast<const longlong2*>(slice);
+
+    int64_t vec_idx = tid;
+    for (; vec_idx + vec_stride < vec_size; vec_idx += vec_stride * 2) {
+      const longlong2 v0 = slice_vec[vec_idx];
+      const longlong2 v1 = slice_vec[vec_idx + vec_stride];
+      sum += static_cast<int64_t>(v0.x) + static_cast<int64_t>(v0.y);
+      sum += static_cast<int64_t>(v1.x) + static_cast<int64_t>(v1.y);
+    }
+    for (; vec_idx < vec_size; vec_idx += vec_stride) {
+      const longlong2 v = slice_vec[vec_idx];
+      sum += static_cast<int64_t>(v.x) + static_cast<int64_t>(v.y);
+    }
+
+    if (((reduce_size & 1) != 0) && tid == 0) {
+      sum += slice[reduce_size - 1];
+    }
+  } else {
+    int64_t i = tid;
+    for (; i + stride < reduce_size; i += stride * 2) {
+      sum += slice[i];
+      sum += slice[i + stride];
+    }
+    for (; i < reduce_size; i += stride) {
+      sum += slice[i];
+    }
+  }
+
+  sum = warp_reduce_sum_i64(sum);
+
+  if (lane == 0) {
+    sdata[warp_id] = sum;
+  }
+  __syncthreads();
+
+  if (warp_id == 0) {
+    int64_t block_sum = lane < num_warps ? sdata[lane] : 0;
+    block_sum = warp_reduce_sum_i64(block_sum);
+
+    if (tid == 0) {
+      output[out_idx] = block_sum;
+    }
+  }
+}
+
 extern "C" int hip_reduce_sum(
     void* stream,
     const void* data,
@@ -84,13 +167,24 @@ extern "C" int hip_reduce_sum(
               (long long)reduce_size, (long long)num_output_elements,
               block_size, shared_mem);
 
-      hipLaunchKernelGGL(reduce_sum_i64_kernel,
+      if(reduce_size >= 2048){
+        hipLaunchKernelGGL(reduce_sum_i64_shfl_kernel,
                          dim3(static_cast<unsigned>(num_output_elements)),
                          dim3(block_size),
                          shared_mem, hip_stream,
                          static_cast<const int64_t*>(data),
                          static_cast<int64_t*>(output),
                          reduce_size, num_output_elements);
+      }
+      else{
+        hipLaunchKernelGGL(reduce_sum_i64_kernel,
+                         dim3(static_cast<unsigned>(num_output_elements)),
+                         dim3(block_size),
+                         shared_mem, hip_stream,
+                         static_cast<const int64_t*>(data),
+                         static_cast<int64_t*>(output),
+                         reduce_size, num_output_elements);
+      }
       break;
     }
     default:


### PR DESCRIPTION
## Summary

Optimize reduce using __shfl_down_sync in the new kernel.
When the reduce size is ≥ 2048, the new kernel provides performance improvements; for sizes < 2048, the original kernel is still used.



## 8060s results
Number of inferences per second:
old: base kernel
new: First test
new_2: Second test
mixed: if reduce >=2048, with new kernel

| seq | old | dml | new | dml | new_2 | dml | mixed | dml |
|-----|------|------|------|------|------|------|------|------|
| 1    | 16529.7 | 16826.5 | 15842.6 | 16180.9 | 15892.9 | 16478.2 | 16390.9 | 16886.5 |
| 128  | 16256   | 16069.3 | 15968.1 | 15820   | 15893.4 | 16682.8 | 16259.7 | 16628.8 |
| 256  | 16677.3 | 16205.9 | 15922.2 | 15958.4 | 16064.9 | 13138.7 | 16264.9 | 16669.2 |
| 512  | 16158.9 | 15876.3 | 15754.3 | 15983.1 | 15822.8 | 16944.9 | 16005.4 | 16527.8 |
| 1024 | 15976.1 | 16037.6 | 15889.1 | 15909.1 | 15942.1 | 16761.7 | 16107.4 | 17054.8 |
| 2048 | 15573.9 | 15973.5 | 15795.2 | 15890.2 | 15836   | 16861.3 | 15989.2 | 16766.5 |
| 3072 | 15219.2 | 15897.4 | 15591.1 | 15703.9 | 13151.4 | 12446.5 | 15678   | 16746.9 |

