### PR TITLE
ci: upload perf/accuracy results to MongoDB

### DIFF
--- a/.github/workflows/gpu-perf-accuracy-test.yml
+++ b/.github/workflows/gpu-perf-accuracy-test.yml
@@ -5,6 +5,7 @@
 name: GPU Performance & Accuracy Test
 
 on:
+  push:           # TEMPORARY: remove after debugging
   schedule:
     - cron: '0 18 * * *'  # daily at UTC 18:00 (CST 02:00)
 
@@ -131,7 +132,8 @@ jobs:
           Push-Location gpu-test-package\bin
 
           $models = @(Get-ChildItem $root -Recurse -Filter "*.onnx" |
-            Where-Object { $_.Name -notmatch "_dyn" -and $_.FullName -notmatch "\\full_model\\" })
+            Where-Object { $_.Name -notmatch "_dyn" -and $_.FullName -notmatch "\\full_model\\" } |
+            Select-Object -First 1)  # TEMPORARY: remove after debugging
           Write-Host "Eligible single-op models: $($models.Count)"
 
           foreach ($m in $models) {
@@ -210,7 +212,8 @@ jobs:
           Push-Location gpu-test-package\bin
 
           $models = @(Get-ChildItem $root -Recurse -Filter "*.onnx" |
-            Where-Object { $_.Name -notmatch "_dyn" -and $_.FullName -notmatch "\\full_model\\" })
+            Where-Object { $_.Name -notmatch "_dyn" -and $_.FullName -notmatch "\\full_model\\" } |
+            Select-Object -First 1)  # TEMPORARY: remove after debugging
           Write-Host "Eligible single-op models: $($models.Count)"
 
           foreach ($m in $models) {
@@ -288,7 +291,8 @@ jobs:
           Push-Location gpu-test-package\bin
 
           $models = @(Get-ChildItem $root -Recurse -Filter "*.onnx" |
-            Where-Object { $_.Name -notmatch "_dyn" -and $_.FullName -match "\\full_model\\" })
+            Where-Object { $_.Name -notmatch "_dyn" -and $_.FullName -match "\\full_model\\" } |
+            Select-Object -First 1)  # TEMPORARY: remove after debugging
           Write-Host "Eligible full-model models: $($models.Count)"
 
           foreach ($m in $models) {
@@ -367,7 +371,8 @@ jobs:
           Push-Location gpu-test-package\bin
 
           $models = @(Get-ChildItem $root -Recurse -Filter "*.onnx" |
-            Where-Object { $_.Name -notmatch "_dyn" -and $_.FullName -match "\\full_model\\" })
+            Where-Object { $_.Name -notmatch "_dyn" -and $_.FullName -match "\\full_model\\" } |
+            Select-Object -First 1)  # TEMPORARY: remove after debugging
           Write-Host "Eligible full-model models: $($models.Count)"
 
           foreach ($m in $models) {
@@ -617,3 +622,35 @@ jobs:
           name: test-results-json
           path: json-results/
           retention-days: 30
+
+      - name: Upload results to MongoDB
+        if: always()
+        shell: pwsh
+        run: |
+          $apiUrl = "http://xsjnts.xilinx.com/api/database/upload_json/"
+
+          foreach ($file in @("json-results/perf-results.json",
+                              "json-results/l2-results.json")) {
+            if (-not (Test-Path $file)) {
+              Write-Host "[SKIP] $file not found"
+              continue
+            }
+            $jsonData = Get-Content $file -Raw | ConvertFrom-Json
+            $payload = @{
+              database   = "daily-rocm"
+              collection = "HIPDNN-EP"
+              json_data  = $jsonData
+            } | ConvertTo-Json -Depth 10 -Compress
+
+            Write-Host "Uploading $file to $apiUrl ..."
+            try {
+              $resp = Invoke-RestMethod -Uri $apiUrl `
+                -Method POST `
+                -Body $payload `
+                -ContentType "application/json; charset=utf-8" `
+                -TimeoutSec 60
+              Write-Host "OK: $($resp | ConvertTo-Json -Depth 3)"
+            } catch {
+              Write-Warning "Upload failed for $file : $_"
+            }
+          }

--- a/.github/workflows/gpu-perf-accuracy-test.yml
+++ b/.github/workflows/gpu-perf-accuracy-test.yml
@@ -5,7 +5,6 @@
 name: GPU Performance & Accuracy Test
 
 on:
-  push:           # TEMPORARY: remove after debugging
   schedule:
     - cron: '0 18 * * *'  # daily at UTC 18:00 (CST 02:00)
 
@@ -132,8 +131,7 @@ jobs:
           Push-Location gpu-test-package\bin
 
           $models = @(Get-ChildItem $root -Recurse -Filter "*.onnx" |
-            Where-Object { $_.Name -notmatch "_dyn" -and $_.FullName -notmatch "\\full_model\\" } |
-            Select-Object -First 1)  # TEMPORARY: remove after debugging
+            Where-Object { $_.Name -notmatch "_dyn" -and $_.FullName -notmatch "\\full_model\\" })
           Write-Host "Eligible single-op models: $($models.Count)"
 
           foreach ($m in $models) {
@@ -212,8 +210,7 @@ jobs:
           Push-Location gpu-test-package\bin
 
           $models = @(Get-ChildItem $root -Recurse -Filter "*.onnx" |
-            Where-Object { $_.Name -notmatch "_dyn" -and $_.FullName -notmatch "\\full_model\\" } |
-            Select-Object -First 1)  # TEMPORARY: remove after debugging
+            Where-Object { $_.Name -notmatch "_dyn" -and $_.FullName -notmatch "\\full_model\\" })
           Write-Host "Eligible single-op models: $($models.Count)"
 
           foreach ($m in $models) {
@@ -291,8 +288,7 @@ jobs:
           Push-Location gpu-test-package\bin
 
           $models = @(Get-ChildItem $root -Recurse -Filter "*.onnx" |
-            Where-Object { $_.Name -notmatch "_dyn" -and $_.FullName -match "\\full_model\\" } |
-            Select-Object -First 1)  # TEMPORARY: remove after debugging
+            Where-Object { $_.Name -notmatch "_dyn" -and $_.FullName -match "\\full_model\\" })
           Write-Host "Eligible full-model models: $($models.Count)"
 
           foreach ($m in $models) {
@@ -371,8 +367,7 @@ jobs:
           Push-Location gpu-test-package\bin
 
           $models = @(Get-ChildItem $root -Recurse -Filter "*.onnx" |
-            Where-Object { $_.Name -notmatch "_dyn" -and $_.FullName -match "\\full_model\\" } |
-            Select-Object -First 1)  # TEMPORARY: remove after debugging
+            Where-Object { $_.Name -notmatch "_dyn" -and $_.FullName -match "\\full_model\\" })
           Write-Host "Eligible full-model models: $($models.Count)"
 
           foreach ($m in $models) {

--- a/.github/workflows/gpu-perf-accuracy-test.yml
+++ b/.github/workflows/gpu-perf-accuracy-test.yml
@@ -6,7 +6,7 @@ name: GPU Performance & Accuracy Test
 
 on:
   schedule:
-    - cron: '0 18 * * *'  # daily at UTC 18:00 (CST 02:00)
+    - cron: '0 16 * * *'  # daily at UTC 16:00 (CST 00:00)
 
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- Add a new step to the GPU perf/accuracy workflow that uploads `perf-results.json` and `l2-results.json` to the internal MongoDB (`daily-rocm` / `HIPDNN-EP` collection) via REST API

## Test plan
- [x] Workflow runs successfully via schedule or manual dispatch
- [x] MongoDB upload step completes without errors
- [x] Results appear in the `daily-rocm.HIPDNN-EP` collection