### PR TITLE
feat: report total elements and skipped non-finite in L2 output

### DIFF
--- a/.github/workflows/gpu-perf-accuracy-test.yml
+++ b/.github/workflows/gpu-perf-accuracy-test.yml
@@ -5,8 +5,6 @@
 name: GPU Performance & Accuracy Test
 
 on:
-  push:  # TEMPORARY: remove after debugging
-
   schedule:
     - cron: '0 16 * * *'  # daily at UTC 16:00 (CST 00:00)
 
@@ -69,7 +67,8 @@ jobs:
           workflow: windows-build.yml
           name: gpu-test-package
           path: gpu-test-package
-          run_id: 23938832544  # TEMPORARY: hardcoded for debugging
+          branch: main
+          workflow_conclusion: success
           if_no_artifact_found: fail
 
       - name: Verify package contents
@@ -132,8 +131,7 @@ jobs:
           Push-Location gpu-test-package\bin
 
           $models = @(Get-ChildItem $root -Recurse -Filter "*.onnx" |
-            Where-Object { $_.Name -notmatch "_dyn" -and $_.FullName -notmatch "\\full_model\\" -and $_.FullName -notmatch "\\single_layer\\" } |
-            Select-Object -First 1)  # TEMPORARY: remove after debugging
+            Where-Object { $_.Name -notmatch "_dyn" -and $_.FullName -notmatch "\\full_model\\" })
           Write-Host "Eligible single-op models: $($models.Count)"
 
           foreach ($m in $models) {
@@ -212,8 +210,7 @@ jobs:
           Push-Location gpu-test-package\bin
 
           $models = @(Get-ChildItem $root -Recurse -Filter "*.onnx" |
-            Where-Object { $_.Name -notmatch "_dyn" -and $_.FullName -notmatch "\\full_model\\" -and $_.FullName -notmatch "\\single_layer\\" } |
-            Select-Object -First 1)  # TEMPORARY: remove after debugging
+            Where-Object { $_.Name -notmatch "_dyn" -and $_.FullName -notmatch "\\full_model\\" })
           Write-Host "Eligible single-op models: $($models.Count)"
 
           foreach ($m in $models) {
@@ -291,8 +288,7 @@ jobs:
           Push-Location gpu-test-package\bin
 
           $models = @(Get-ChildItem $root -Recurse -Filter "*.onnx" |
-            Where-Object { $_.Name -notmatch "_dyn" -and $_.FullName -match "\\full_model\\" } |
-            Select-Object -First 1)  # TEMPORARY: remove after debugging
+            Where-Object { $_.Name -notmatch "_dyn" -and $_.FullName -match "\\full_model\\" })
           Write-Host "Eligible full-model models: $($models.Count)"
 
           foreach ($m in $models) {
@@ -371,8 +367,7 @@ jobs:
           Push-Location gpu-test-package\bin
 
           $models = @(Get-ChildItem $root -Recurse -Filter "*.onnx" |
-            Where-Object { $_.Name -notmatch "_dyn" -and $_.FullName -match "\\full_model\\" } |
-            Select-Object -First 1)  # TEMPORARY: remove after debugging
+            Where-Object { $_.Name -notmatch "_dyn" -and $_.FullName -match "\\full_model\\" })
           Write-Host "Eligible full-model models: $($models.Count)"
 
           foreach ($m in $models) {

--- a/.github/workflows/gpu-perf-accuracy-test.yml
+++ b/.github/workflows/gpu-perf-accuracy-test.yml
@@ -5,6 +5,8 @@
 name: GPU Performance & Accuracy Test
 
 on:
+  push:  # TEMPORARY: remove after debugging
+
   schedule:
     - cron: '0 16 * * *'  # daily at UTC 16:00 (CST 00:00)
 
@@ -131,7 +133,8 @@ jobs:
           Push-Location gpu-test-package\bin
 
           $models = @(Get-ChildItem $root -Recurse -Filter "*.onnx" |
-            Where-Object { $_.Name -notmatch "_dyn" -and $_.FullName -notmatch "\\full_model\\" })
+            Where-Object { $_.Name -notmatch "_dyn" -and $_.FullName -notmatch "\\full_model\\" } |
+            Select-Object -First 1)  # TEMPORARY: remove after debugging
           Write-Host "Eligible single-op models: $($models.Count)"
 
           foreach ($m in $models) {
@@ -210,7 +213,8 @@ jobs:
           Push-Location gpu-test-package\bin
 
           $models = @(Get-ChildItem $root -Recurse -Filter "*.onnx" |
-            Where-Object { $_.Name -notmatch "_dyn" -and $_.FullName -notmatch "\\full_model\\" })
+            Where-Object { $_.Name -notmatch "_dyn" -and $_.FullName -notmatch "\\full_model\\" } |
+            Select-Object -First 1)  # TEMPORARY: remove after debugging
           Write-Host "Eligible single-op models: $($models.Count)"
 
           foreach ($m in $models) {
@@ -288,7 +292,8 @@ jobs:
           Push-Location gpu-test-package\bin
 
           $models = @(Get-ChildItem $root -Recurse -Filter "*.onnx" |
-            Where-Object { $_.Name -notmatch "_dyn" -and $_.FullName -match "\\full_model\\" })
+            Where-Object { $_.Name -notmatch "_dyn" -and $_.FullName -match "\\full_model\\" } |
+            Select-Object -First 1)  # TEMPORARY: remove after debugging
           Write-Host "Eligible full-model models: $($models.Count)"
 
           foreach ($m in $models) {
@@ -367,7 +372,8 @@ jobs:
           Push-Location gpu-test-package\bin
 
           $models = @(Get-ChildItem $root -Recurse -Filter "*.onnx" |
-            Where-Object { $_.Name -notmatch "_dyn" -and $_.FullName -match "\\full_model\\" })
+            Where-Object { $_.Name -notmatch "_dyn" -and $_.FullName -match "\\full_model\\" } |
+            Select-Object -First 1)  # TEMPORARY: remove after debugging
           Write-Host "Eligible full-model models: $($models.Count)"
 
           foreach ($m in $models) {
@@ -485,19 +491,21 @@ jobs:
               $label = if ($meta.op_name) { "$($meta.model_name) / $($meta.op_name)" } else { $meta.model_name }
               if ($meta.seq_length -ne $null) { $label += " (seq$($meta.seq_length))" }
               $content = Get-Content $f.FullName -Raw
-              $l2Match = [regex]::Match($content, 'Combined L2 \(stacked diffs\):\s+([\d.eE+-]+)')
+              $l2Match = [regex]::Match($content, 'Combined L2 \(stacked diffs\):\s+([\d.eE+-]+)\s+\(total_elems:\s+(\d+),\s+skipped_nonfinite:\s+(\d+)\)')
               $errMatch = [regex]::Match($content, '\[ERROR\]\s*(.+)')
               if ($l2Match.Success) {
                 $l2val = [double]$l2Match.Groups[1].Value
-                $rows += "| $label | $l2val |`n"
+                $elems = $l2Match.Groups[2].Value
+                $skipped = $l2Match.Groups[3].Value
+                $rows += "| $label | $l2val | $elems | $skipped |`n"
               } elseif ($errMatch.Success) {
                 $reason = $errMatch.Groups[1].Value.Trim()
-                $rows += "| $label | $reason |`n"
+                $rows += "| $label | $reason | - | - |`n"
               } else {
-                $rows += "| $label | error |`n"
+                $rows += "| $label | error | - | - |`n"
               }
             }
-            $header = "### $title`n`n| Model | Combined L2 |`n|-------|------------|`n"
+            $header = "### $title`n`n| Model | Combined L2 | Total Elems | Skipped NaN/Inf |`n|-------|------------|------------|----------------|`n"
             return $header + $rows + "`n"
           }
 
@@ -560,14 +568,16 @@ jobs:
             foreach ($f in $files) {
               $meta = Get-Meta $f (Resolve-Path $dir).Path
               $content = Get-Content $f.FullName -Raw
-              $l2Match = [regex]::Match($content, 'Combined L2 \(stacked diffs\):\s+([\d.eE+-]+)')
+              $l2Match = [regex]::Match($content, 'Combined L2 \(stacked diffs\):\s+([\d.eE+-]+)\s+\(total_elems:\s+(\d+),\s+skipped_nonfinite:\s+(\d+)\)')
               $errMatch = [regex]::Match($content, '\[ERROR\]\s*(.+)')
               $l2val = if ($l2Match.Success) { [double]$l2Match.Groups[1].Value } else { $null }
               $entry = [ordered]@{
-                category   = $category
-                model_name = $meta.model_name
-                file       = $meta.file
-                l2         = $l2val
+                category           = $category
+                model_name         = $meta.model_name
+                file               = $meta.file
+                l2                 = $l2val
+                total_elems        = if ($l2Match.Success) { [long]$l2Match.Groups[2].Value } else { $null }
+                skipped_nonfinite  = if ($l2Match.Success) { [long]$l2Match.Groups[3].Value } else { $null }
               }
               if ($errMatch.Success) {
                 $entry["error"] = $errMatch.Groups[1].Value.Trim()

--- a/.github/workflows/gpu-perf-accuracy-test.yml
+++ b/.github/workflows/gpu-perf-accuracy-test.yml
@@ -69,8 +69,7 @@ jobs:
           workflow: windows-build.yml
           name: gpu-test-package
           path: gpu-test-package
-          branch: main
-          workflow_conclusion: success
+          run_id: 23938832544  # TEMPORARY: hardcoded for debugging
           if_no_artifact_found: fail
 
       - name: Verify package contents

--- a/.github/workflows/gpu-perf-accuracy-test.yml
+++ b/.github/workflows/gpu-perf-accuracy-test.yml
@@ -133,7 +133,7 @@ jobs:
           Push-Location gpu-test-package\bin
 
           $models = @(Get-ChildItem $root -Recurse -Filter "*.onnx" |
-            Where-Object { $_.Name -notmatch "_dyn" -and $_.FullName -notmatch "\\full_model\\" } |
+            Where-Object { $_.Name -notmatch "_dyn" -and $_.FullName -notmatch "\\full_model\\" -and $_.FullName -notmatch "\\single_layer\\" } |
             Select-Object -First 1)  # TEMPORARY: remove after debugging
           Write-Host "Eligible single-op models: $($models.Count)"
 
@@ -213,7 +213,7 @@ jobs:
           Push-Location gpu-test-package\bin
 
           $models = @(Get-ChildItem $root -Recurse -Filter "*.onnx" |
-            Where-Object { $_.Name -notmatch "_dyn" -and $_.FullName -notmatch "\\full_model\\" } |
+            Where-Object { $_.Name -notmatch "_dyn" -and $_.FullName -notmatch "\\full_model\\" -and $_.FullName -notmatch "\\single_layer\\" } |
             Select-Object -First 1)  # TEMPORARY: remove after debugging
           Write-Host "Eligible single-op models: $($models.Count)"
 

--- a/tools/hip-onnx-runner/hip-onnx-runner.cpp
+++ b/tools/hip-onnx-runner/hip-onnx-runner.cpp
@@ -509,6 +509,8 @@ static int run_l2norm_output_dumps(const std::string &dir1_str,
   }
 
   long double combined_sq = 0;
+  size_t total_elems = 0;
+  size_t total_skipped_nonfinite = 0;
   for (const std::string &fn : names1) {
     std::vector<char> a, b;
     if (!read_entire_file(d1 / fn, a) || !read_entire_file(d2 / fn, b))
@@ -563,9 +565,13 @@ static int run_l2norm_output_dumps(const std::string &dir1_str,
     }
     std::cout << ")\n";
     combined_sq += static_cast<long double>(sq);
+    total_elems += used_elems;
+    total_skipped_nonfinite += skipped_nonfinite;
   }
   std::cout << "Combined L2 (stacked diffs): "
-            << std::sqrt(static_cast<double>(combined_sq)) << "\n";
+            << std::sqrt(static_cast<double>(combined_sq))
+            << " (total_elems: " << total_elems
+            << ", skipped_nonfinite: " << total_skipped_nonfinite << ")\n";
   return 0;
 }
 


### PR DESCRIPTION
## Summary
- Extend `hip-onnx-runner` L2 combined output to include `total_elems` and `skipped_nonfinite` counts
- Update CI workflow to parse the new format and display `Total Elems` / `Skipped NaN/Inf` columns in step summary tables
- Include `total_elems` and `skipped_nonfinite` fields in JSON result artifacts

## Test plan
- [x] hip-onnx-runner L2 output shows `(total_elems: N, skipped_nonfinite: M)`
- [x] CI step summary table includes Total Elems and Skipped NaN/Inf columns
- [x] JSON results include `total_elems` and `skipped_nonfinite` fields