### PR TITLE
feat: add Unsqueeze and Squeeze operations

### DIFF
--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -2039,9 +2039,11 @@ struct UnsqueezeToStdTensor : public mlir::RewritePattern {
     // Validate operands, types, and constant axes requirement
     mlir::Value data, axes;
     mlir::RankedTensorType inputType, outputType;
-    if (failed(validateSqueezeUnsqueezeOp(op, rewriter, "expand_shape", data,
-                                          axes, inputType, outputType)))
-      return mlir::failure();
+    if (auto result = validateSqueezeUnsqueezeOp(op, rewriter, "expand_shape",
+                                                  data, axes, inputType,
+                                                  outputType);
+        failed(result))
+      return result;
 
     // Unsqueeze is just a special case of Reshape (inserting size-1 dims)
     // Use MLIR's built-in tool to compute reassociation
@@ -2089,9 +2091,11 @@ struct SqueezeToStdTensor : public mlir::RewritePattern {
     // Validate operands, types, and constant axes requirement
     mlir::Value data, axes;
     mlir::RankedTensorType inputType, outputType;
-    if (failed(validateSqueezeUnsqueezeOp(op, rewriter, "collapse_shape", data,
-                                          axes, inputType, outputType)))
-      return mlir::failure();
+    if (auto result = validateSqueezeUnsqueezeOp(op, rewriter, "collapse_shape",
+                                                  data, axes, inputType,
+                                                  outputType);
+        failed(result))
+      return result;
 
     // Squeeze is the inverse of Unsqueeze (removing size-1 dims)
     // Use MLIR's built-in tool to compute reassociation

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -1785,31 +1785,20 @@ struct GatherToHip : public mlir::RewritePattern {
 
 namespace {
 
-/// Helper: Validate common requirements for Unsqueeze/Squeeze operations.
-///
-/// Both operations require:
-/// 1. Exactly 2 operands (data, axes)
-/// 2. Ranked tensor types for input and output
-/// 3. Matching element types
-/// 4. Constant axes (for zero-cost implementation)
-///
-/// Returns failure with informative error message if any validation fails.
-/// On success, populates data and axes output parameters.
+/// Validate common requirements for Unsqueeze/Squeeze operations.
+/// Requires: 2 operands (data, axes), ranked tensors, matching element types,
+/// and constant axes (dynamic axes would require runtime shape computation).
 mlir::LogicalResult
 validateSqueezeUnsqueezeOp(mlir::Operation *op, mlir::PatternRewriter &rewriter,
                            const char *tensorOpName, mlir::Value &data,
-                           mlir::Value &axes,
-                           mlir::RankedTensorType &inputType,
+                           mlir::Value &axes, mlir::RankedTensorType &inputType,
                            mlir::RankedTensorType &outputType) {
-  // Validate operand count
   if (op->getNumOperands() != 2)
-    return rewriter.notifyMatchFailure(op,
-                                       "expected 2 operands (data, axes)");
+    return rewriter.notifyMatchFailure(op, "expected 2 operands (data, axes)");
 
   data = op->getOperand(0);
   axes = op->getOperand(1);
 
-  // Validate tensor types
   inputType = mlir::dyn_cast<mlir::RankedTensorType>(data.getType());
   outputType =
       mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
@@ -1818,21 +1807,18 @@ validateSqueezeUnsqueezeOp(mlir::Operation *op, mlir::PatternRewriter &rewriter,
   if (inputType.getElementType() != outputType.getElementType())
     return rewriter.notifyMatchFailure(op, "element type mismatch");
 
-  // Validate axes is constant (required for zero-cost implementation)
-  // Dynamic axes would require runtime shape computation
   auto axesDefOp = axes.getDefiningOp();
   if (!axesDefOp) {
-    std::string msg = "axes must be defined by a constant operation (block "
-                      "argument not supported). Dynamic axes would require "
-                      "runtime shape computation and cannot use zero-cost tensor.";
+    std::string msg =
+        "axes must be defined by a constant operation (block "
+        "argument not supported). Dynamic axes would require "
+        "runtime shape computation and cannot use zero-cost tensor.";
     msg += tensorOpName;
     return rewriter.notifyMatchFailure(op, msg);
   }
 
-  // Check if it's arith.constant or onnx.Constant
   bool isConstant = mlir::isa<mlir::arith::ConstantOp>(axesDefOp) ||
                     axesDefOp->hasAttr("value");
-
   if (!isConstant) {
     std::string msg =
         "axes must be constant (arith.constant or onnx.Constant). "
@@ -1846,29 +1832,18 @@ validateSqueezeUnsqueezeOp(mlir::Operation *op, mlir::PatternRewriter &rewriter,
   return mlir::success();
 }
 
-/// Helper: Build output shape for expand_shape operations.
+/// Build output shape for expand_shape operations.
 /// Used by both Reshape and Unsqueeze when expanding dimensions.
 ///
-/// Algorithm:
-/// 1. Precompute outDimToInDim mapping: output dim i → source input dim
-/// 2. For each output dimension:
-///    - Static dims: use compile-time size from outputType
-///    - Dynamic dims: extract from input, accounting for static products
-///
-/// Example: input [128, ?], output [1, 128, ?, 1]
-///   reassoc = [[0, 1], [2, 3]]
-///   outDimToInDim = [0, 0, 1, 1]  (output dims 0,1 from input 0; 2,3 from input 1)
-///   - output[0]=1 (static)
-///   - output[1]=128 (static)
-///   - output[2]=input[1] (dynamic, extract via DimOp)
-///   - output[3]=1 (static)
-llvm::SmallVector<mlir::OpFoldResult>
-buildExpandShapeOutputShape(mlir::PatternRewriter &rewriter, mlir::Location loc,
-                            mlir::Value data, mlir::RankedTensorType outputType,
-                            llvm::ArrayRef<mlir::ReassociationIndices> reassoc) {
+/// For static dimensions: use compile-time size from outputType.
+/// For dynamic dimensions: extract from input via DimOp, dividing out any
+/// static dimensions in the same reassociation group.
+llvm::SmallVector<mlir::OpFoldResult> buildExpandShapeOutputShape(
+    mlir::PatternRewriter &rewriter, mlir::Location loc, mlir::Value data,
+    mlir::RankedTensorType outputType,
+    llvm::ArrayRef<mlir::ReassociationIndices> reassoc) {
   int64_t outputRank = outputType.getRank();
 
-  // Precompute mapping: output dim → input dim (O(1) lookup)
   llvm::SmallVector<int64_t> outDimToInDim(outputRank, -1);
   for (auto [g, group] : llvm::enumerate(reassoc))
     for (int64_t idx : group)
@@ -1877,19 +1852,13 @@ buildExpandShapeOutputShape(mlir::PatternRewriter &rewriter, mlir::Location loc,
   llvm::SmallVector<mlir::OpFoldResult> outputShape;
   for (int64_t i : llvm::seq<int64_t>(outputRank)) {
     if (!outputType.isDynamicDim(i)) {
-      // Static dimension: use compile-time size
-      outputShape.push_back(
-          rewriter.getIndexAttr(outputType.getDimSize(i)));
+      outputShape.push_back(rewriter.getIndexAttr(outputType.getDimSize(i)));
       continue;
     }
 
-    // Dynamic dimension: extract from input
     int64_t srcDim = outDimToInDim[i];
     const auto &group = reassoc[srcDim];
 
-    // Compute static product of other dims in this group
-    // For unsqueeze: inserted dims are size 1 (static)
-    // For reshape: may have multiple static dims in group
     int64_t staticProduct = 1;
     for (int64_t idx : group)
       if (!outputType.isDynamicDim(idx))
@@ -1898,11 +1867,8 @@ buildExpandShapeOutputShape(mlir::PatternRewriter &rewriter, mlir::Location loc,
     mlir::Value inputSize =
         mlir::tensor::DimOp::create(rewriter, loc, data, srcDim);
     if (staticProduct == 1) {
-      // Direct mapping: output dim = input dim (no static dims in group)
       outputShape.push_back(inputSize);
     } else {
-      // Has static dims in group, divide them out
-      // Example: input[128*?] → output[128, ?]: output[1] = input[0] / 128
       mlir::Value divisor =
           mlir::arith::ConstantIndexOp::create(rewriter, loc, staticProduct);
       mlir::Value dynSize =
@@ -1963,8 +1929,8 @@ struct ReshapeToStdTensor : public mlir::RewritePattern {
 
       if (outputRank > inputRank) {
         // Expand: use shared helper to build output shape
-        auto outputShape = buildExpandShapeOutputShape(
-            rewriter, loc, data, outputType, *reassocOpt);
+        auto outputShape = buildExpandShapeOutputShape(rewriter, loc, data,
+                                                       outputType, *reassocOpt);
         auto expandOp = mlir::tensor::ExpandShapeOp::create(
             rewriter, loc, outputType, data, *reassocOpt, outputShape);
         rewriter.replaceOp(op, expandOp.getResult());
@@ -2019,16 +1985,7 @@ struct ReshapeToStdTensor : public mlir::RewritePattern {
 // Unsqueeze → standard tensor ops (zero-cost metadata reinterpretation)
 //===----------------------------------------------------------------------===//
 
-/// onnx.Unsqueeze → tensor.expand_shape.
-///
-/// Unsqueeze inserts dimensions of size 1 at specified axes. Like Reshape,
-/// this is a zero-cost metadata operation that only reinterprets shape/strides
-/// without moving data. We lower to tensor.expand_shape which bufferizes to
-/// memref.expand_shape (zero-copy alias).
-///
-/// Strategy: Unsqueeze is a special case of Reshape (inserting size-1 dims).
-/// Use MLIR's built-in getReassociationIndicesForReshape utility to compute
-/// reassociation, then reuse Reshape's output shape building logic.
+/// onnx.Unsqueeze → tensor.expand_shape (zero-cost metadata operation).
 struct UnsqueezeToStdTensor : public mlir::RewritePattern {
   UnsqueezeToStdTensor(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Unsqueeze", /*benefit=*/1, ctx) {}
@@ -2036,32 +1993,25 @@ struct UnsqueezeToStdTensor : public mlir::RewritePattern {
   mlir::LogicalResult
   matchAndRewrite(mlir::Operation *op,
                   mlir::PatternRewriter &rewriter) const override {
-    // Validate operands, types, and constant axes requirement
     mlir::Value data, axes;
     mlir::RankedTensorType inputType, outputType;
-    if (auto result = validateSqueezeUnsqueezeOp(op, rewriter, "expand_shape",
-                                                  data, axes, inputType,
-                                                  outputType);
+    if (auto result = validateSqueezeUnsqueezeOp(
+            op, rewriter, "expand_shape", data, axes, inputType, outputType);
         failed(result))
       return result;
 
-    // Unsqueeze is just a special case of Reshape (inserting size-1 dims)
-    // Use MLIR's built-in tool to compute reassociation
     auto reassocOpt =
         mlir::getReassociationIndicesForReshape(inputType, outputType);
     if (!reassocOpt)
       return rewriter.notifyMatchFailure(
           op, "cannot compute unsqueeze reassociation");
 
-    // Build output shape using shared helper
     mlir::Location loc = op->getLoc();
-    auto outputShape = buildExpandShapeOutputShape(
-        rewriter, loc, data, outputType, *reassocOpt);
-
+    auto outputShape = buildExpandShapeOutputShape(rewriter, loc, data,
+                                                   outputType, *reassocOpt);
     auto expandOp = mlir::tensor::ExpandShapeOp::create(
         rewriter, loc, outputType, data, *reassocOpt, outputShape);
     rewriter.replaceOp(op, expandOp.getResult());
-
     return mlir::success();
   }
 };
@@ -2070,17 +2020,7 @@ struct UnsqueezeToStdTensor : public mlir::RewritePattern {
 // Squeeze → standard tensor ops (zero-cost metadata reinterpretation)
 //===----------------------------------------------------------------------===//
 
-/// onnx.Squeeze → tensor.collapse_shape.
-///
-/// Squeeze removes dimensions of size 1 at specified axes. Like Reshape and
-/// Unsqueeze, this is a zero-cost metadata operation that only reinterprets
-/// shape/strides without moving data. We lower to tensor.collapse_shape which
-/// bufferizes to memref.collapse_shape (zero-copy alias).
-///
-/// Strategy: Squeeze is the inverse of Unsqueeze (removing size-1 dims).
-/// Use MLIR's built-in getReassociationIndicesForReshape utility to compute
-/// reassociation, then use tensor.collapse_shape (no dynamic shape computation
-/// needed for collapse operations).
+/// onnx.Squeeze → tensor.collapse_shape (zero-cost metadata operation).
 struct SqueezeToStdTensor : public mlir::RewritePattern {
   SqueezeToStdTensor(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Squeeze", /*benefit=*/1, ctx) {}
@@ -2088,29 +2028,23 @@ struct SqueezeToStdTensor : public mlir::RewritePattern {
   mlir::LogicalResult
   matchAndRewrite(mlir::Operation *op,
                   mlir::PatternRewriter &rewriter) const override {
-    // Validate operands, types, and constant axes requirement
     mlir::Value data, axes;
     mlir::RankedTensorType inputType, outputType;
-    if (auto result = validateSqueezeUnsqueezeOp(op, rewriter, "collapse_shape",
-                                                  data, axes, inputType,
-                                                  outputType);
+    if (auto result = validateSqueezeUnsqueezeOp(
+            op, rewriter, "collapse_shape", data, axes, inputType, outputType);
         failed(result))
       return result;
 
-    // Squeeze is the inverse of Unsqueeze (removing size-1 dims)
-    // Use MLIR's built-in tool to compute reassociation
     auto reassocOpt =
         mlir::getReassociationIndicesForReshape(inputType, outputType);
     if (!reassocOpt)
       return rewriter.notifyMatchFailure(
           op, "cannot compute squeeze reassociation");
 
-    // Collapse: no dynamic shape computation needed (collapse is always safe)
     mlir::Location loc = op->getLoc();
     auto collapseOp = mlir::tensor::CollapseShapeOp::create(
         rewriter, loc, outputType, data, *reassocOpt);
     rewriter.replaceOp(op, collapseOp.getResult());
-
     return mlir::success();
   }
 };

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -2011,6 +2011,60 @@ struct UnsqueezeToStdTensor : public mlir::RewritePattern {
 };
 
 //===----------------------------------------------------------------------===//
+// Squeeze → standard tensor ops (zero-cost metadata reinterpretation)
+//===----------------------------------------------------------------------===//
+
+/// onnx.Squeeze → tensor.collapse_shape.
+///
+/// Squeeze removes dimensions of size 1 at specified axes. Like Reshape and
+/// Unsqueeze, this is a zero-cost metadata operation that only reinterprets
+/// shape/strides without moving data. We lower to tensor.collapse_shape which
+/// bufferizes to memref.collapse_shape (zero-copy alias).
+///
+/// Strategy: Squeeze is the inverse of Unsqueeze (removing size-1 dims).
+/// Use MLIR's built-in getReassociationIndicesForReshape utility to compute
+/// reassociation, then use tensor.collapse_shape (no dynamic shape computation
+/// needed for collapse operations).
+struct SqueezeToStdTensor : public mlir::RewritePattern {
+  SqueezeToStdTensor(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.Squeeze", /*benefit=*/1, ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override {
+    // Validate operands
+    if (op->getNumOperands() != 2)
+      return rewriter.notifyMatchFailure(op,
+                                         "expected 2 operands (data, axes)");
+
+    mlir::Value data = op->getOperand(0);
+    auto inputType = mlir::dyn_cast<mlir::RankedTensorType>(data.getType());
+    auto outputType =
+        mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
+    if (!inputType || !outputType)
+      return rewriter.notifyMatchFailure(op, "expected ranked tensor types");
+    if (inputType.getElementType() != outputType.getElementType())
+      return rewriter.notifyMatchFailure(op, "element type mismatch");
+
+    // Squeeze is the inverse of Unsqueeze (removing size-1 dims)
+    // Use MLIR's built-in tool to compute reassociation
+    auto reassocOpt =
+        mlir::getReassociationIndicesForReshape(inputType, outputType);
+    if (!reassocOpt)
+      return rewriter.notifyMatchFailure(
+          op, "cannot compute squeeze reassociation");
+
+    // Collapse: no dynamic shape computation needed (collapse is always safe)
+    mlir::Location loc = op->getLoc();
+    auto collapseOp = mlir::tensor::CollapseShapeOp::create(
+        rewriter, loc, outputType, data, *reassocOpt);
+    rewriter.replaceOp(op, collapseOp.getResult());
+
+    return mlir::success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
 // convertComputeOps implementation
 //===----------------------------------------------------------------------===//
 
@@ -2036,6 +2090,7 @@ static mlir::LogicalResult convertComputeOps(mlir::func::FuncOp funcOp,
   patterns.add<QMoEToHip>(ctx);
   patterns.add<ReshapeToStdTensor>(ctx);
   patterns.add<UnsqueezeToStdTensor>(ctx);
+  patterns.add<SqueezeToStdTensor>(ctx);
 
   mlir::GreedyRewriteConfig config;
   config.setStrictness(mlir::GreedyRewriteStrictness::ExistingOps);

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -30,6 +30,7 @@
 
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/Sequence.h"
+#include "llvm/ADT/SmallSet.h"
 #include "llvm/Support/Debug.h"
 #ifdef _MSC_VER
 #pragma warning(push)
@@ -1903,6 +1904,177 @@ struct ReshapeToStdTensor : public mlir::RewritePattern {
 };
 
 //===----------------------------------------------------------------------===//
+// Unsqueeze → standard tensor ops (zero-cost metadata reinterpretation)
+//===----------------------------------------------------------------------===//
+
+/// onnx.Unsqueeze → tensor.expand_shape.
+///
+/// Unsqueeze inserts dimensions of size 1 at specified axes. Like Reshape,
+/// this is a zero-cost metadata operation that only reinterprets shape/strides
+/// without moving data. We lower to tensor.expand_shape which bufferizes to
+/// memref.expand_shape (zero-copy alias).
+///
+/// Strategy: Use getReassociationIndicesForReshape to compute the mapping,
+/// since Unsqueeze is just a special case of Reshape where we insert size-1
+/// dims.
+struct UnsqueezeToStdTensor : public mlir::RewritePattern {
+  UnsqueezeToStdTensor(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.Unsqueeze", /*benefit=*/1, ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override {
+    // ONNX Unsqueeze has two operands: data and axes
+    if (op->getNumOperands() != 2)
+      return rewriter.notifyMatchFailure(op,
+                                         "expected 2 operands (data, axes)");
+
+    mlir::Value data = op->getOperand(0);
+    mlir::Value axesValue = op->getOperand(1);
+
+    auto inputType = mlir::dyn_cast<mlir::RankedTensorType>(data.getType());
+    auto outputType =
+        mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
+
+    if (!inputType || !outputType)
+      return rewriter.notifyMatchFailure(op, "expected ranked tensor types");
+    if (inputType.getElementType() != outputType.getElementType())
+      return rewriter.notifyMatchFailure(op, "element type mismatch");
+
+    mlir::Location loc = op->getLoc();
+    int64_t inputRank = inputType.getRank();
+    int64_t outputRank = outputType.getRank();
+
+    // Unsqueeze always increases rank
+    if (outputRank <= inputRank)
+      return rewriter.notifyMatchFailure(
+          op, "unsqueeze output rank must be greater than input rank");
+
+    // Extract axes values from constant operand
+    llvm::SmallVector<int64_t> axes;
+    if (auto axesDefOp = axesValue.getDefiningOp<mlir::arith::ConstantOp>()) {
+      auto axesAttr =
+          mlir::dyn_cast<mlir::DenseIntElementsAttr>(axesDefOp.getValueAttr());
+      if (!axesAttr)
+        return rewriter.notifyMatchFailure(op,
+                                           "axes must be dense int constant");
+      for (auto val : axesAttr.getValues<int64_t>())
+        axes.push_back(val);
+    } else if (auto axesDefOp = axesValue.getDefiningOp()) {
+      // axes might be from onnx.Constant
+      if (auto axesAttr = mlir::dyn_cast_or_null<mlir::DenseIntElementsAttr>(
+              axesDefOp->getAttrOfType<mlir::ElementsAttr>("value"))) {
+        for (auto val : axesAttr.getValues<int64_t>())
+          axes.push_back(val);
+      } else {
+        return rewriter.notifyMatchFailure(op, "axes must be constant");
+      }
+    } else {
+      return rewriter.notifyMatchFailure(op, "axes must be constant");
+    }
+
+    // Normalize negative axes
+    for (auto &axis : axes) {
+      if (axis < 0)
+        axis += outputRank;
+      if (axis < 0 || axis >= outputRank)
+        return rewriter.notifyMatchFailure(op, "axes value out of range");
+    }
+
+    // Verify the number of inserted axes matches rank difference
+    if (static_cast<int64_t>(axes.size()) != (outputRank - inputRank))
+      return rewriter.notifyMatchFailure(
+          op, "number of axes does not match rank difference");
+
+    // Build reassociation indices based on axes
+    // Reassociation maps each input dimension to a group of output dimensions.
+    // For unsqueeze, each input dim maps to itself plus any inserted dims.
+    //
+    // Example: input [128, 4096], axes=[0, 2] -> output [1, 128, 1, 4096]
+    //   Input dim 0 -> output dims [0, 1]  (inserted 0, original 0)
+    //   Input dim 1 -> output dims [2, 3]  (inserted 2, original 1)
+    llvm::SmallSet<int64_t, 4> axesSet(axes.begin(), axes.end());
+    llvm::SmallVector<mlir::ReassociationIndices> reassociation;
+
+    int64_t inputIdx = 0;
+    int64_t outputIdx = 0;
+
+    while (inputIdx < inputRank) {
+      mlir::ReassociationIndices group;
+
+      // Collect all inserted dimensions before this input dimension
+      while (outputIdx < outputRank && axesSet.contains(outputIdx)) {
+        group.push_back(outputIdx);
+        outputIdx++;
+      }
+
+      // Add the output dimension corresponding to this input dimension
+      if (outputIdx < outputRank) {
+        group.push_back(outputIdx);
+        outputIdx++;
+      }
+
+      reassociation.push_back(group);
+      inputIdx++;
+    }
+
+    // Collect any remaining inserted dimensions at the end
+    if (outputIdx < outputRank) {
+      // These should all be in axesSet
+      if (!reassociation.empty()) {
+        while (outputIdx < outputRank) {
+          reassociation.back().push_back(outputIdx);
+          outputIdx++;
+        }
+      }
+    }
+
+    // Verify we have the correct number of reassociation groups
+    if (static_cast<int64_t>(reassociation.size()) != inputRank)
+      return rewriter.notifyMatchFailure(
+          op, "reassociation size does not match input rank");
+
+    // Build output shape
+    llvm::SmallVector<mlir::OpFoldResult> outputShape;
+    for (int64_t i = 0; i < outputRank; ++i) {
+      if (!outputType.isDynamicDim(i)) {
+        outputShape.push_back(rewriter.getIndexAttr(outputType.getDimSize(i)));
+      } else {
+        // For dynamic dims, need to extract from input
+        // Check if this is an inserted dimension (in axes set)
+        if (axesSet.contains(i)) {
+          // Inserted dim, always size 1
+          outputShape.push_back(rewriter.getIndexAttr(1));
+        } else {
+          // Find which input dim this output dim corresponds to
+          int64_t inputDim = -1;
+          for (auto [inputIdx, group] : llvm::enumerate(reassociation)) {
+            if (std::find(group.begin(), group.end(), i) != group.end()) {
+              inputDim = inputIdx;
+              break;
+            }
+          }
+          if (inputDim >= 0) {
+            mlir::Value inputSize =
+                mlir::tensor::DimOp::create(rewriter, loc, data, inputDim);
+            outputShape.push_back(inputSize);
+          } else {
+            return rewriter.notifyMatchFailure(
+                op, "failed to map dynamic output dim to input");
+          }
+        }
+      }
+    }
+
+    auto expandOp = mlir::tensor::ExpandShapeOp::create(
+        rewriter, loc, outputType, data, reassociation, outputShape);
+    rewriter.replaceOp(op, expandOp.getResult());
+
+    return mlir::success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
 // convertComputeOps implementation
 //===----------------------------------------------------------------------===//
 
@@ -1927,6 +2099,7 @@ static mlir::LogicalResult convertComputeOps(mlir::func::FuncOp funcOp,
   patterns.add<MatMulNBitsToHip>(ctx);
   patterns.add<QMoEToHip>(ctx);
   patterns.add<ReshapeToStdTensor>(ctx);
+  patterns.add<UnsqueezeToStdTensor>(ctx);
 
   mlir::GreedyRewriteConfig config;
   config.setStrictness(mlir::GreedyRewriteStrictness::ExistingOps);

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -1785,6 +1785,67 @@ struct GatherToHip : public mlir::RewritePattern {
 
 namespace {
 
+/// Helper: Validate common requirements for Unsqueeze/Squeeze operations.
+///
+/// Both operations require:
+/// 1. Exactly 2 operands (data, axes)
+/// 2. Ranked tensor types for input and output
+/// 3. Matching element types
+/// 4. Constant axes (for zero-cost implementation)
+///
+/// Returns failure with informative error message if any validation fails.
+/// On success, populates data and axes output parameters.
+mlir::LogicalResult
+validateSqueezeUnsqueezeOp(mlir::Operation *op, mlir::PatternRewriter &rewriter,
+                           const char *tensorOpName, mlir::Value &data,
+                           mlir::Value &axes,
+                           mlir::RankedTensorType &inputType,
+                           mlir::RankedTensorType &outputType) {
+  // Validate operand count
+  if (op->getNumOperands() != 2)
+    return rewriter.notifyMatchFailure(op,
+                                       "expected 2 operands (data, axes)");
+
+  data = op->getOperand(0);
+  axes = op->getOperand(1);
+
+  // Validate tensor types
+  inputType = mlir::dyn_cast<mlir::RankedTensorType>(data.getType());
+  outputType =
+      mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
+  if (!inputType || !outputType)
+    return rewriter.notifyMatchFailure(op, "expected ranked tensor types");
+  if (inputType.getElementType() != outputType.getElementType())
+    return rewriter.notifyMatchFailure(op, "element type mismatch");
+
+  // Validate axes is constant (required for zero-cost implementation)
+  // Dynamic axes would require runtime shape computation
+  auto axesDefOp = axes.getDefiningOp();
+  if (!axesDefOp) {
+    std::string msg = "axes must be defined by a constant operation (block "
+                      "argument not supported). Dynamic axes would require "
+                      "runtime shape computation and cannot use zero-cost tensor.";
+    msg += tensorOpName;
+    return rewriter.notifyMatchFailure(op, msg);
+  }
+
+  // Check if it's arith.constant or onnx.Constant
+  bool isConstant = mlir::isa<mlir::arith::ConstantOp>(axesDefOp) ||
+                    axesDefOp->hasAttr("value");
+
+  if (!isConstant) {
+    std::string msg =
+        "axes must be constant (arith.constant or onnx.Constant). "
+        "Dynamic axes would require runtime shape computation and "
+        "cannot use zero-cost tensor.";
+    msg += tensorOpName;
+    msg += " approach";
+    return rewriter.notifyMatchFailure(op, msg);
+  }
+
+  return mlir::success();
+}
+
 /// Helper: Build output shape for expand_shape operations.
 /// Used by both Reshape and Unsqueeze when expanding dimensions.
 ///
@@ -1975,47 +2036,12 @@ struct UnsqueezeToStdTensor : public mlir::RewritePattern {
   mlir::LogicalResult
   matchAndRewrite(mlir::Operation *op,
                   mlir::PatternRewriter &rewriter) const override {
-    // Validate operands
-    if (op->getNumOperands() != 2)
-      return rewriter.notifyMatchFailure(op,
-                                         "expected 2 operands (data, axes)");
-
-    mlir::Value data = op->getOperand(0);
-    mlir::Value axesValue = op->getOperand(1);
-    auto inputType = mlir::dyn_cast<mlir::RankedTensorType>(data.getType());
-    auto outputType =
-        mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
-    if (!inputType || !outputType)
-      return rewriter.notifyMatchFailure(op, "expected ranked tensor types");
-    if (inputType.getElementType() != outputType.getElementType())
-      return rewriter.notifyMatchFailure(op, "element type mismatch");
-
-    // Check if axes is constant (required for zero-cost implementation)
-    // Dynamic axes would require runtime shape computation and cannot use
-    // the zero-cost tensor.expand_shape approach
-    auto axesDefOp = axesValue.getDefiningOp();
-    if (!axesDefOp) {
-      return rewriter.notifyMatchFailure(
-          op, "axes must be defined by a constant operation (block argument "
-              "not supported). Dynamic axes would require runtime shape "
-              "computation and cannot use zero-cost tensor.expand_shape");
-    }
-
-    // Check if it's arith.constant or onnx.Constant
-    bool isConstant = false;
-    if (mlir::isa<mlir::arith::ConstantOp>(axesDefOp)) {
-      isConstant = true;
-    } else if (axesDefOp->hasAttr("value")) {
-      // onnx.Constant has a "value" attribute
-      isConstant = true;
-    }
-
-    if (!isConstant) {
-      return rewriter.notifyMatchFailure(
-          op, "axes must be constant (arith.constant or onnx.Constant). "
-              "Dynamic axes would require runtime shape computation and "
-              "cannot use zero-cost tensor.expand_shape approach");
-    }
+    // Validate operands, types, and constant axes requirement
+    mlir::Value data, axes;
+    mlir::RankedTensorType inputType, outputType;
+    if (failed(validateSqueezeUnsqueezeOp(op, rewriter, "expand_shape", data,
+                                          axes, inputType, outputType)))
+      return mlir::failure();
 
     // Unsqueeze is just a special case of Reshape (inserting size-1 dims)
     // Use MLIR's built-in tool to compute reassociation
@@ -2060,47 +2086,12 @@ struct SqueezeToStdTensor : public mlir::RewritePattern {
   mlir::LogicalResult
   matchAndRewrite(mlir::Operation *op,
                   mlir::PatternRewriter &rewriter) const override {
-    // Validate operands
-    if (op->getNumOperands() != 2)
-      return rewriter.notifyMatchFailure(op,
-                                         "expected 2 operands (data, axes)");
-
-    mlir::Value data = op->getOperand(0);
-    mlir::Value axesValue = op->getOperand(1);
-    auto inputType = mlir::dyn_cast<mlir::RankedTensorType>(data.getType());
-    auto outputType =
-        mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
-    if (!inputType || !outputType)
-      return rewriter.notifyMatchFailure(op, "expected ranked tensor types");
-    if (inputType.getElementType() != outputType.getElementType())
-      return rewriter.notifyMatchFailure(op, "element type mismatch");
-
-    // Check if axes is constant (required for zero-cost implementation)
-    // Dynamic axes would require runtime shape computation and cannot use
-    // the zero-cost tensor.collapse_shape approach
-    auto axesDefOp = axesValue.getDefiningOp();
-    if (!axesDefOp) {
-      return rewriter.notifyMatchFailure(
-          op, "axes must be defined by a constant operation (block argument "
-              "not supported). Dynamic axes would require runtime shape "
-              "computation and cannot use zero-cost tensor.collapse_shape");
-    }
-
-    // Check if it's arith.constant or onnx.Constant
-    bool isConstant = false;
-    if (mlir::isa<mlir::arith::ConstantOp>(axesDefOp)) {
-      isConstant = true;
-    } else if (axesDefOp->hasAttr("value")) {
-      // onnx.Constant has a "value" attribute
-      isConstant = true;
-    }
-
-    if (!isConstant) {
-      return rewriter.notifyMatchFailure(
-          op, "axes must be constant (arith.constant or onnx.Constant). "
-              "Dynamic axes would require runtime shape computation and "
-              "cannot use zero-cost tensor.collapse_shape approach");
-    }
+    // Validate operands, types, and constant axes requirement
+    mlir::Value data, axes;
+    mlir::RankedTensorType inputType, outputType;
+    if (failed(validateSqueezeUnsqueezeOp(op, rewriter, "collapse_shape", data,
+                                          axes, inputType, outputType)))
+      return mlir::failure();
 
     // Squeeze is the inverse of Unsqueeze (removing size-1 dims)
     // Use MLIR's built-in tool to compute reassociation

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -1981,6 +1981,7 @@ struct UnsqueezeToStdTensor : public mlir::RewritePattern {
                                          "expected 2 operands (data, axes)");
 
     mlir::Value data = op->getOperand(0);
+    mlir::Value axesValue = op->getOperand(1);
     auto inputType = mlir::dyn_cast<mlir::RankedTensorType>(data.getType());
     auto outputType =
         mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
@@ -1988,6 +1989,33 @@ struct UnsqueezeToStdTensor : public mlir::RewritePattern {
       return rewriter.notifyMatchFailure(op, "expected ranked tensor types");
     if (inputType.getElementType() != outputType.getElementType())
       return rewriter.notifyMatchFailure(op, "element type mismatch");
+
+    // Check if axes is constant (required for zero-cost implementation)
+    // Dynamic axes would require runtime shape computation and cannot use
+    // the zero-cost tensor.expand_shape approach
+    auto axesDefOp = axesValue.getDefiningOp();
+    if (!axesDefOp) {
+      return rewriter.notifyMatchFailure(
+          op, "axes must be defined by a constant operation (block argument "
+              "not supported). Dynamic axes would require runtime shape "
+              "computation and cannot use zero-cost tensor.expand_shape");
+    }
+
+    // Check if it's arith.constant or onnx.Constant
+    bool isConstant = false;
+    if (mlir::isa<mlir::arith::ConstantOp>(axesDefOp)) {
+      isConstant = true;
+    } else if (axesDefOp->hasAttr("value")) {
+      // onnx.Constant has a "value" attribute
+      isConstant = true;
+    }
+
+    if (!isConstant) {
+      return rewriter.notifyMatchFailure(
+          op, "axes must be constant (arith.constant or onnx.Constant). "
+              "Dynamic axes would require runtime shape computation and "
+              "cannot use zero-cost tensor.expand_shape approach");
+    }
 
     // Unsqueeze is just a special case of Reshape (inserting size-1 dims)
     // Use MLIR's built-in tool to compute reassociation
@@ -2038,6 +2066,7 @@ struct SqueezeToStdTensor : public mlir::RewritePattern {
                                          "expected 2 operands (data, axes)");
 
     mlir::Value data = op->getOperand(0);
+    mlir::Value axesValue = op->getOperand(1);
     auto inputType = mlir::dyn_cast<mlir::RankedTensorType>(data.getType());
     auto outputType =
         mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
@@ -2045,6 +2074,33 @@ struct SqueezeToStdTensor : public mlir::RewritePattern {
       return rewriter.notifyMatchFailure(op, "expected ranked tensor types");
     if (inputType.getElementType() != outputType.getElementType())
       return rewriter.notifyMatchFailure(op, "element type mismatch");
+
+    // Check if axes is constant (required for zero-cost implementation)
+    // Dynamic axes would require runtime shape computation and cannot use
+    // the zero-cost tensor.collapse_shape approach
+    auto axesDefOp = axesValue.getDefiningOp();
+    if (!axesDefOp) {
+      return rewriter.notifyMatchFailure(
+          op, "axes must be defined by a constant operation (block argument "
+              "not supported). Dynamic axes would require runtime shape "
+              "computation and cannot use zero-cost tensor.collapse_shape");
+    }
+
+    // Check if it's arith.constant or onnx.Constant
+    bool isConstant = false;
+    if (mlir::isa<mlir::arith::ConstantOp>(axesDefOp)) {
+      isConstant = true;
+    } else if (axesDefOp->hasAttr("value")) {
+      // onnx.Constant has a "value" attribute
+      isConstant = true;
+    }
+
+    if (!isConstant) {
+      return rewriter.notifyMatchFailure(
+          op, "axes must be constant (arith.constant or onnx.Constant). "
+              "Dynamic axes would require runtime shape computation and "
+              "cannot use zero-cost tensor.collapse_shape approach");
+    }
 
     // Squeeze is the inverse of Unsqueeze (removing size-1 dims)
     // Use MLIR's built-in tool to compute reassociation

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -1914,9 +1914,9 @@ struct ReshapeToStdTensor : public mlir::RewritePattern {
 /// without moving data. We lower to tensor.expand_shape which bufferizes to
 /// memref.expand_shape (zero-copy alias).
 ///
-/// Strategy: Use getReassociationIndicesForReshape to compute the mapping,
-/// since Unsqueeze is just a special case of Reshape where we insert size-1
-/// dims.
+/// Strategy: Unsqueeze is a special case of Reshape (inserting size-1 dims).
+/// Use MLIR's built-in getReassociationIndicesForReshape utility to compute
+/// reassociation, then reuse Reshape's output shape building logic.
 struct UnsqueezeToStdTensor : public mlir::RewritePattern {
   UnsqueezeToStdTensor(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Unsqueeze", /*benefit=*/1, ctx) {}
@@ -1924,14 +1924,12 @@ struct UnsqueezeToStdTensor : public mlir::RewritePattern {
   mlir::LogicalResult
   matchAndRewrite(mlir::Operation *op,
                   mlir::PatternRewriter &rewriter) const override {
-    // ONNX Unsqueeze has two operands: data and axes
+    // Validate operands
     if (op->getNumOperands() != 2)
       return rewriter.notifyMatchFailure(op,
                                          "expected 2 operands (data, axes)");
 
     mlir::Value data = op->getOperand(0);
-    mlir::Value axesValue = op->getOperand(1);
-
     auto inputType = mlir::dyn_cast<mlir::RankedTensorType>(data.getType());
     auto outputType =
         mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
@@ -1941,133 +1939,60 @@ struct UnsqueezeToStdTensor : public mlir::RewritePattern {
     if (inputType.getElementType() != outputType.getElementType())
       return rewriter.notifyMatchFailure(op, "element type mismatch");
 
+    // Unsqueeze is just a special case of Reshape (inserting size-1 dims)
+    // Use MLIR's built-in tool to compute reassociation
+    auto reassocOpt =
+        mlir::getReassociationIndicesForReshape(inputType, outputType);
+    if (!reassocOpt)
+      return rewriter.notifyMatchFailure(
+          op, "cannot compute unsqueeze reassociation");
+
+    // Build output shape using the same logic as Reshape
+    // Precompute mapping from output dim to input dim for O(1) lookup
     mlir::Location loc = op->getLoc();
-    int64_t inputRank = inputType.getRank();
     int64_t outputRank = outputType.getRank();
+    llvm::SmallVector<int64_t> outDimToInDim(outputRank, -1);
+    for (auto [g, group] : llvm::enumerate(*reassocOpt))
+      for (int64_t idx : group)
+        outDimToInDim[idx] = g;
 
-    // Unsqueeze always increases rank
-    if (outputRank <= inputRank)
-      return rewriter.notifyMatchFailure(
-          op, "unsqueeze output rank must be greater than input rank");
-
-    // Extract axes values from constant operand
-    llvm::SmallVector<int64_t> axes;
-    if (auto axesDefOp = axesValue.getDefiningOp<mlir::arith::ConstantOp>()) {
-      auto axesAttr =
-          mlir::dyn_cast<mlir::DenseIntElementsAttr>(axesDefOp.getValueAttr());
-      if (!axesAttr)
-        return rewriter.notifyMatchFailure(op,
-                                           "axes must be dense int constant");
-      for (auto val : axesAttr.getValues<int64_t>())
-        axes.push_back(val);
-    } else if (auto axesDefOp = axesValue.getDefiningOp()) {
-      // axes might be from onnx.Constant
-      if (auto axesAttr = mlir::dyn_cast_or_null<mlir::DenseIntElementsAttr>(
-              axesDefOp->getAttrOfType<mlir::ElementsAttr>("value"))) {
-        for (auto val : axesAttr.getValues<int64_t>())
-          axes.push_back(val);
-      } else {
-        return rewriter.notifyMatchFailure(op, "axes must be constant");
-      }
-    } else {
-      return rewriter.notifyMatchFailure(op, "axes must be constant");
-    }
-
-    // Normalize negative axes
-    for (auto &axis : axes) {
-      if (axis < 0)
-        axis += outputRank;
-      if (axis < 0 || axis >= outputRank)
-        return rewriter.notifyMatchFailure(op, "axes value out of range");
-    }
-
-    // Verify the number of inserted axes matches rank difference
-    if (static_cast<int64_t>(axes.size()) != (outputRank - inputRank))
-      return rewriter.notifyMatchFailure(
-          op, "number of axes does not match rank difference");
-
-    // Build reassociation indices based on axes
-    // Reassociation maps each input dimension to a group of output dimensions.
-    // For unsqueeze, each input dim maps to itself plus any inserted dims.
-    //
-    // Example: input [128, 4096], axes=[0, 2] -> output [1, 128, 1, 4096]
-    //   Input dim 0 -> output dims [0, 1]  (inserted 0, original 0)
-    //   Input dim 1 -> output dims [2, 3]  (inserted 2, original 1)
-    llvm::SmallSet<int64_t, 4> axesSet(axes.begin(), axes.end());
-    llvm::SmallVector<mlir::ReassociationIndices> reassociation;
-
-    int64_t inputIdx = 0;
-    int64_t outputIdx = 0;
-
-    while (inputIdx < inputRank) {
-      mlir::ReassociationIndices group;
-
-      // Collect all inserted dimensions before this input dimension
-      while (outputIdx < outputRank && axesSet.contains(outputIdx)) {
-        group.push_back(outputIdx);
-        outputIdx++;
-      }
-
-      // Add the output dimension corresponding to this input dimension
-      if (outputIdx < outputRank) {
-        group.push_back(outputIdx);
-        outputIdx++;
-      }
-
-      reassociation.push_back(group);
-      inputIdx++;
-    }
-
-    // Collect any remaining inserted dimensions at the end
-    if (outputIdx < outputRank) {
-      // These should all be in axesSet
-      if (!reassociation.empty()) {
-        while (outputIdx < outputRank) {
-          reassociation.back().push_back(outputIdx);
-          outputIdx++;
-        }
-      }
-    }
-
-    // Verify we have the correct number of reassociation groups
-    if (static_cast<int64_t>(reassociation.size()) != inputRank)
-      return rewriter.notifyMatchFailure(
-          op, "reassociation size does not match input rank");
-
-    // Build output shape
     llvm::SmallVector<mlir::OpFoldResult> outputShape;
-    for (int64_t i = 0; i < outputRank; ++i) {
+    for (int64_t i : llvm::seq<int64_t>(outputRank)) {
       if (!outputType.isDynamicDim(i)) {
-        outputShape.push_back(rewriter.getIndexAttr(outputType.getDimSize(i)));
+        // Static dimension: use compile-time size
+        outputShape.push_back(
+            rewriter.getIndexAttr(outputType.getDimSize(i)));
+        continue;
+      }
+
+      // Dynamic dimension: extract from input
+      int64_t srcDim = outDimToInDim[i];
+      const auto &group = (*reassocOpt)[srcDim];
+
+      // For unsqueeze, inserted dims are always size 1 (static)
+      // Only non-inserted dims can be dynamic, and they map directly to input
+      int64_t staticProduct = 1;
+      for (int64_t idx : group)
+        if (!outputType.isDynamicDim(idx))
+          staticProduct *= outputType.getDimSize(idx);
+
+      mlir::Value inputSize =
+          mlir::tensor::DimOp::create(rewriter, loc, data, srcDim);
+      if (staticProduct == 1) {
+        // Direct mapping: output dim = input dim (no inserted size-1 dims)
+        outputShape.push_back(inputSize);
       } else {
-        // For dynamic dims, need to extract from input
-        // Check if this is an inserted dimension (in axes set)
-        if (axesSet.contains(i)) {
-          // Inserted dim, always size 1
-          outputShape.push_back(rewriter.getIndexAttr(1));
-        } else {
-          // Find which input dim this output dim corresponds to
-          int64_t inputDim = -1;
-          for (auto [inputIdx, group] : llvm::enumerate(reassociation)) {
-            if (std::find(group.begin(), group.end(), i) != group.end()) {
-              inputDim = inputIdx;
-              break;
-            }
-          }
-          if (inputDim >= 0) {
-            mlir::Value inputSize =
-                mlir::tensor::DimOp::create(rewriter, loc, data, inputDim);
-            outputShape.push_back(inputSize);
-          } else {
-            return rewriter.notifyMatchFailure(
-                op, "failed to map dynamic output dim to input");
-          }
-        }
+        // Has static size-1 dims in the group, divide them out
+        mlir::Value divisor =
+            mlir::arith::ConstantIndexOp::create(rewriter, loc, staticProduct);
+        mlir::Value dynSize =
+            mlir::arith::DivUIOp::create(rewriter, loc, inputSize, divisor);
+        outputShape.push_back(dynSize);
       }
     }
 
     auto expandOp = mlir::tensor::ExpandShapeOp::create(
-        rewriter, loc, outputType, data, reassociation, outputShape);
+        rewriter, loc, outputType, data, *reassocOpt, outputShape);
     rewriter.replaceOp(op, expandOp.getResult());
 
     return mlir::success();

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -1780,6 +1780,82 @@ struct GatherToHip : public mlir::RewritePattern {
 };
 
 //===----------------------------------------------------------------------===//
+// Shape Operations Helpers (Reshape, Unsqueeze, Squeeze)
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+/// Helper: Build output shape for expand_shape operations.
+/// Used by both Reshape and Unsqueeze when expanding dimensions.
+///
+/// Algorithm:
+/// 1. Precompute outDimToInDim mapping: output dim i → source input dim
+/// 2. For each output dimension:
+///    - Static dims: use compile-time size from outputType
+///    - Dynamic dims: extract from input, accounting for static products
+///
+/// Example: input [128, ?], output [1, 128, ?, 1]
+///   reassoc = [[0, 1], [2, 3]]
+///   outDimToInDim = [0, 0, 1, 1]  (output dims 0,1 from input 0; 2,3 from input 1)
+///   - output[0]=1 (static)
+///   - output[1]=128 (static)
+///   - output[2]=input[1] (dynamic, extract via DimOp)
+///   - output[3]=1 (static)
+llvm::SmallVector<mlir::OpFoldResult>
+buildExpandShapeOutputShape(mlir::PatternRewriter &rewriter, mlir::Location loc,
+                            mlir::Value data, mlir::RankedTensorType outputType,
+                            llvm::ArrayRef<mlir::ReassociationIndices> reassoc) {
+  int64_t outputRank = outputType.getRank();
+
+  // Precompute mapping: output dim → input dim (O(1) lookup)
+  llvm::SmallVector<int64_t> outDimToInDim(outputRank, -1);
+  for (auto [g, group] : llvm::enumerate(reassoc))
+    for (int64_t idx : group)
+      outDimToInDim[idx] = g;
+
+  llvm::SmallVector<mlir::OpFoldResult> outputShape;
+  for (int64_t i : llvm::seq<int64_t>(outputRank)) {
+    if (!outputType.isDynamicDim(i)) {
+      // Static dimension: use compile-time size
+      outputShape.push_back(
+          rewriter.getIndexAttr(outputType.getDimSize(i)));
+      continue;
+    }
+
+    // Dynamic dimension: extract from input
+    int64_t srcDim = outDimToInDim[i];
+    const auto &group = reassoc[srcDim];
+
+    // Compute static product of other dims in this group
+    // For unsqueeze: inserted dims are size 1 (static)
+    // For reshape: may have multiple static dims in group
+    int64_t staticProduct = 1;
+    for (int64_t idx : group)
+      if (!outputType.isDynamicDim(idx))
+        staticProduct *= outputType.getDimSize(idx);
+
+    mlir::Value inputSize =
+        mlir::tensor::DimOp::create(rewriter, loc, data, srcDim);
+    if (staticProduct == 1) {
+      // Direct mapping: output dim = input dim (no static dims in group)
+      outputShape.push_back(inputSize);
+    } else {
+      // Has static dims in group, divide them out
+      // Example: input[128*?] → output[128, ?]: output[1] = input[0] / 128
+      mlir::Value divisor =
+          mlir::arith::ConstantIndexOp::create(rewriter, loc, staticProduct);
+      mlir::Value dynSize =
+          mlir::arith::DivUIOp::create(rewriter, loc, inputSize, divisor);
+      outputShape.push_back(dynSize);
+    }
+  }
+
+  return outputShape;
+}
+
+} // namespace
+
+//===----------------------------------------------------------------------===//
 // Reshape → standard tensor ops (zero-cost metadata reinterpretation)
 //===----------------------------------------------------------------------===//
 
@@ -1810,11 +1886,13 @@ struct ReshapeToStdTensor : public mlir::RewritePattern {
     int64_t inputRank = inputType.getRank();
     int64_t outputRank = outputType.getRank();
 
+    // No-op: same type
     if (inputType == outputType) {
       rewriter.replaceOp(op, data);
       return mlir::success();
     }
 
+    // Different rank: expand or collapse
     if (outputRank != inputRank) {
       auto reassocOpt =
           mlir::getReassociationIndicesForReshape(inputType, outputType);
@@ -1823,41 +1901,14 @@ struct ReshapeToStdTensor : public mlir::RewritePattern {
             op, "cannot compute reshape reassociation");
 
       if (outputRank > inputRank) {
-        llvm::SmallVector<int64_t> outDimToInDim(outputRank, -1);
-        for (auto [g, group] : llvm::enumerate(*reassocOpt))
-          for (int64_t idx : group)
-            outDimToInDim[idx] = g;
-
-        llvm::SmallVector<mlir::OpFoldResult> outputShape;
-        for (int64_t i : llvm::seq<int64_t>(outputRank)) {
-          if (!outputType.isDynamicDim(i)) {
-            outputShape.push_back(
-                rewriter.getIndexAttr(outputType.getDimSize(i)));
-            continue;
-          }
-          int64_t srcDim = outDimToInDim[i];
-          const auto &group = (*reassocOpt)[srcDim];
-          int64_t staticProduct = 1;
-          for (int64_t idx : group)
-            if (!outputType.isDynamicDim(idx))
-              staticProduct *= outputType.getDimSize(idx);
-          mlir::Value inputSize =
-              mlir::tensor::DimOp::create(rewriter, loc, data, srcDim);
-          if (staticProduct == 1) {
-            outputShape.push_back(inputSize);
-          } else {
-            mlir::Value divisor = mlir::arith::ConstantIndexOp::create(
-                rewriter, loc, staticProduct);
-            mlir::Value dynSize =
-                mlir::arith::DivUIOp::create(rewriter, loc, inputSize, divisor);
-            outputShape.push_back(dynSize);
-          }
-        }
-
+        // Expand: use shared helper to build output shape
+        auto outputShape = buildExpandShapeOutputShape(
+            rewriter, loc, data, outputType, *reassocOpt);
         auto expandOp = mlir::tensor::ExpandShapeOp::create(
             rewriter, loc, outputType, data, *reassocOpt, outputShape);
         rewriter.replaceOp(op, expandOp.getResult());
       } else {
+        // Collapse: no dynamic shape computation needed
         auto collapseOp = mlir::tensor::CollapseShapeOp::create(
             rewriter, loc, outputType, data, *reassocOpt);
         rewriter.replaceOp(op, collapseOp.getResult());
@@ -1933,7 +1984,6 @@ struct UnsqueezeToStdTensor : public mlir::RewritePattern {
     auto inputType = mlir::dyn_cast<mlir::RankedTensorType>(data.getType());
     auto outputType =
         mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
-
     if (!inputType || !outputType)
       return rewriter.notifyMatchFailure(op, "expected ranked tensor types");
     if (inputType.getElementType() != outputType.getElementType())
@@ -1947,49 +1997,10 @@ struct UnsqueezeToStdTensor : public mlir::RewritePattern {
       return rewriter.notifyMatchFailure(
           op, "cannot compute unsqueeze reassociation");
 
-    // Build output shape using the same logic as Reshape
-    // Precompute mapping from output dim to input dim for O(1) lookup
+    // Build output shape using shared helper
     mlir::Location loc = op->getLoc();
-    int64_t outputRank = outputType.getRank();
-    llvm::SmallVector<int64_t> outDimToInDim(outputRank, -1);
-    for (auto [g, group] : llvm::enumerate(*reassocOpt))
-      for (int64_t idx : group)
-        outDimToInDim[idx] = g;
-
-    llvm::SmallVector<mlir::OpFoldResult> outputShape;
-    for (int64_t i : llvm::seq<int64_t>(outputRank)) {
-      if (!outputType.isDynamicDim(i)) {
-        // Static dimension: use compile-time size
-        outputShape.push_back(
-            rewriter.getIndexAttr(outputType.getDimSize(i)));
-        continue;
-      }
-
-      // Dynamic dimension: extract from input
-      int64_t srcDim = outDimToInDim[i];
-      const auto &group = (*reassocOpt)[srcDim];
-
-      // For unsqueeze, inserted dims are always size 1 (static)
-      // Only non-inserted dims can be dynamic, and they map directly to input
-      int64_t staticProduct = 1;
-      for (int64_t idx : group)
-        if (!outputType.isDynamicDim(idx))
-          staticProduct *= outputType.getDimSize(idx);
-
-      mlir::Value inputSize =
-          mlir::tensor::DimOp::create(rewriter, loc, data, srcDim);
-      if (staticProduct == 1) {
-        // Direct mapping: output dim = input dim (no inserted size-1 dims)
-        outputShape.push_back(inputSize);
-      } else {
-        // Has static size-1 dims in the group, divide them out
-        mlir::Value divisor =
-            mlir::arith::ConstantIndexOp::create(rewriter, loc, staticProduct);
-        mlir::Value dynSize =
-            mlir::arith::DivUIOp::create(rewriter, loc, inputSize, divisor);
-        outputShape.push_back(dynSize);
-      }
-    }
+    auto outputShape = buildExpandShapeOutputShape(
+        rewriter, loc, data, outputType, *reassocOpt);
 
     auto expandOp = mlir::tensor::ExpandShapeOp::create(
         rewriter, loc, outputType, data, *reassocOpt, outputShape);

--- a/test/lit/Conversion/onnx-to-hip/test_squeeze.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_squeeze.mlir
@@ -1,0 +1,98 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify ONNX Squeeze is correctly lowered to tensor.collapse_shape
+// (zero-cost standard MLIR metadata op).
+//
+// Squeeze removes dimensions of size 1 at specified axes. Like Reshape and
+// Unsqueeze, it's a zero-cost operation that reinterprets shape/strides
+// without moving data. No custom HIP dialect op or kernel is needed.
+//
+// This test validates:
+// - Remove single dim from front:  3D -> 2D  [1, 128, 4096] -> [128, 4096]
+// - Remove single dim from end:    3D -> 2D  [128, 4096, 1] -> [128, 4096]
+// - Remove single dim from middle: 3D -> 2D  [128, 1, 4096] -> [128, 4096]
+// - Remove multiple dims:          4D -> 2D  [1, 128, 1, 4096] -> [128, 4096]
+// - Negative axis handling:        3D -> 2D  [128, 4096, 1] -> [128, 4096] (axis=-1)
+//
+// Each test checks:
+// - onnx.Squeeze is removed
+// - tensor.collapse_shape is generated with correct reassociation indices
+// - Output shape matches expected dimensions
+//
+// ============================================================================
+
+// RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip | FileCheck %s
+
+module {
+  func.func @main_graph(%arg0: tensor<128x4096xf16>) -> tensor<128x4096xf16> {
+    return %arg0 : tensor<128x4096xf16>
+  }
+
+  // --- Remove dimension from beginning ---
+  func.func @test_squeeze_front(%data: tensor<1x128x4096xf16>) -> tensor<128x4096xf16> {
+    %axes = "onnx.Constant"() {value = dense<[0]> : tensor<1xi64>} : () -> tensor<1xi64>
+    %result = "onnx.Squeeze"(%data, %axes) : (tensor<1x128x4096xf16>, tensor<1xi64>) -> tensor<128x4096xf16>
+    return %result : tensor<128x4096xf16>
+  }
+
+  // --- Remove dimension from end ---
+  func.func @test_squeeze_back(%data: tensor<128x4096x1xf16>) -> tensor<128x4096xf16> {
+    %axes = "onnx.Constant"() {value = dense<[2]> : tensor<1xi64>} : () -> tensor<1xi64>
+    %result = "onnx.Squeeze"(%data, %axes) : (tensor<128x4096x1xf16>, tensor<1xi64>) -> tensor<128x4096xf16>
+    return %result : tensor<128x4096xf16>
+  }
+
+  // --- Remove dimension from middle ---
+  func.func @test_squeeze_middle(%data: tensor<128x1x4096xf16>) -> tensor<128x4096xf16> {
+    %axes = "onnx.Constant"() {value = dense<[1]> : tensor<1xi64>} : () -> tensor<1xi64>
+    %result = "onnx.Squeeze"(%data, %axes) : (tensor<128x1x4096xf16>, tensor<1xi64>) -> tensor<128x4096xf16>
+    return %result : tensor<128x4096xf16>
+  }
+
+  // --- Remove multiple dimensions ---
+  func.func @test_squeeze_multiple(%data: tensor<1x128x1x4096xf16>) -> tensor<128x4096xf16> {
+    %axes = "onnx.Constant"() {value = dense<[0, 2]> : tensor<2xi64>} : () -> tensor<2xi64>
+    %result = "onnx.Squeeze"(%data, %axes) : (tensor<1x128x1x4096xf16>, tensor<2xi64>) -> tensor<128x4096xf16>
+    return %result : tensor<128x4096xf16>
+  }
+
+  // --- Remove dimension with negative axis ---
+  func.func @test_squeeze_negative_axis(%data: tensor<128x4096x1xf16>) -> tensor<128x4096xf16> {
+    %axes = "onnx.Constant"() {value = dense<[-1]> : tensor<1xi64>} : () -> tensor<1xi64>
+    %result = "onnx.Squeeze"(%data, %axes) : (tensor<128x4096x1xf16>, tensor<1xi64>) -> tensor<128x4096xf16>
+    return %result : tensor<128x4096xf16>
+  }
+}
+
+// CHECK-LABEL: func.func @test_squeeze_front
+// CHECK-SAME: %[[CTX:.*]]: !hip.context, %[[DATA:.*]]: tensor<1x128x4096xf16>)
+// CHECK-NOT: onnx.Squeeze
+// CHECK: %[[RESULT:.*]] = tensor.collapse_shape %[[DATA]] {{\[\[}}0, 1], [2]] : tensor<1x128x4096xf16> into tensor<128x4096xf16>
+// CHECK: return %[[RESULT]] : tensor<128x4096xf16>
+
+// CHECK-LABEL: func.func @test_squeeze_back
+// CHECK-SAME: %[[CTX:.*]]: !hip.context, %[[DATA:.*]]: tensor<128x4096x1xf16>)
+// CHECK-NOT: onnx.Squeeze
+// CHECK: %[[RESULT:.*]] = tensor.collapse_shape %[[DATA]] {{\[\[}}0], [1, 2]] : tensor<128x4096x1xf16> into tensor<128x4096xf16>
+// CHECK: return %[[RESULT]] : tensor<128x4096xf16>
+
+// CHECK-LABEL: func.func @test_squeeze_middle
+// CHECK-SAME: %[[CTX:.*]]: !hip.context, %[[DATA:.*]]: tensor<128x1x4096xf16>)
+// CHECK-NOT: onnx.Squeeze
+// CHECK: %[[RESULT:.*]] = tensor.collapse_shape %[[DATA]] {{\[\[}}0], [1, 2]] : tensor<128x1x4096xf16> into tensor<128x4096xf16>
+// CHECK: return %[[RESULT]] : tensor<128x4096xf16>
+
+// CHECK-LABEL: func.func @test_squeeze_multiple
+// CHECK-SAME: %[[CTX:.*]]: !hip.context, %[[DATA:.*]]: tensor<1x128x1x4096xf16>)
+// CHECK-NOT: onnx.Squeeze
+// CHECK: %[[RESULT:.*]] = tensor.collapse_shape %[[DATA]] {{\[\[}}0, 1], [2, 3]] : tensor<1x128x1x4096xf16> into tensor<128x4096xf16>
+// CHECK: return %[[RESULT]] : tensor<128x4096xf16>
+
+// CHECK-LABEL: func.func @test_squeeze_negative_axis
+// CHECK-SAME: %[[CTX:.*]]: !hip.context, %[[DATA:.*]]: tensor<128x4096x1xf16>)
+// CHECK-NOT: onnx.Squeeze
+// CHECK: %[[RESULT:.*]] = tensor.collapse_shape %[[DATA]] {{\[\[}}0], [1, 2]] : tensor<128x4096x1xf16> into tensor<128x4096xf16>
+// CHECK: return %[[RESULT]] : tensor<128x4096xf16>

--- a/test/lit/Conversion/onnx-to-hip/test_unsqueeze.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_unsqueeze.mlir
@@ -1,0 +1,98 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify ONNX Unsqueeze is correctly lowered to tensor.expand_shape
+// (zero-cost standard MLIR metadata op).
+//
+// Unsqueeze inserts dimensions of size 1 at specified axes. Like Reshape,
+// it's a zero-cost operation that reinterprets shape/strides without
+// moving data. No custom HIP dialect op or kernel is needed.
+//
+// This test validates:
+// - Insert single dim at beginning:  2D -> 3D  [128, 4096] -> [1, 128, 4096]
+// - Insert single dim at end:        2D -> 3D  [128, 4096] -> [128, 4096, 1]
+// - Insert single dim in middle:     2D -> 3D  [128, 4096] -> [128, 1, 4096]
+// - Insert multiple dims:            2D -> 4D  [128, 4096] -> [1, 128, 1, 4096]
+// - Negative axis handling:          2D -> 3D  [128, 4096] -> [128, 4096, 1] (axis=-1)
+//
+// Each test checks:
+// - onnx.Unsqueeze is removed
+// - tensor.expand_shape is generated with correct reassociation indices
+// - Output shape matches expected dimensions
+//
+// ============================================================================
+
+// RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip | FileCheck %s
+
+module {
+  func.func @main_graph(%arg0: tensor<128x4096xf16>) -> tensor<128x4096xf16> {
+    return %arg0 : tensor<128x4096xf16>
+  }
+
+  // --- Insert dimension at beginning ---
+  func.func @test_unsqueeze_front(%data: tensor<128x4096xf16>) -> tensor<1x128x4096xf16> {
+    %axes = "onnx.Constant"() {value = dense<[0]> : tensor<1xi64>} : () -> tensor<1xi64>
+    %result = "onnx.Unsqueeze"(%data, %axes) : (tensor<128x4096xf16>, tensor<1xi64>) -> tensor<1x128x4096xf16>
+    return %result : tensor<1x128x4096xf16>
+  }
+
+  // --- Insert dimension at end ---
+  func.func @test_unsqueeze_back(%data: tensor<128x4096xf16>) -> tensor<128x4096x1xf16> {
+    %axes = "onnx.Constant"() {value = dense<[2]> : tensor<1xi64>} : () -> tensor<1xi64>
+    %result = "onnx.Unsqueeze"(%data, %axes) : (tensor<128x4096xf16>, tensor<1xi64>) -> tensor<128x4096x1xf16>
+    return %result : tensor<128x4096x1xf16>
+  }
+
+  // --- Insert dimension in middle ---
+  func.func @test_unsqueeze_middle(%data: tensor<128x4096xf16>) -> tensor<128x1x4096xf16> {
+    %axes = "onnx.Constant"() {value = dense<[1]> : tensor<1xi64>} : () -> tensor<1xi64>
+    %result = "onnx.Unsqueeze"(%data, %axes) : (tensor<128x4096xf16>, tensor<1xi64>) -> tensor<128x1x4096xf16>
+    return %result : tensor<128x1x4096xf16>
+  }
+
+  // --- Insert multiple dimensions ---
+  func.func @test_unsqueeze_multiple(%data: tensor<128x4096xf16>) -> tensor<1x128x1x4096xf16> {
+    %axes = "onnx.Constant"() {value = dense<[0, 2]> : tensor<2xi64>} : () -> tensor<2xi64>
+    %result = "onnx.Unsqueeze"(%data, %axes) : (tensor<128x4096xf16>, tensor<2xi64>) -> tensor<1x128x1x4096xf16>
+    return %result : tensor<1x128x1x4096xf16>
+  }
+
+  // --- Insert dimension with negative axis ---
+  func.func @test_unsqueeze_negative_axis(%data: tensor<128x4096xf16>) -> tensor<128x4096x1xf16> {
+    %axes = "onnx.Constant"() {value = dense<[-1]> : tensor<1xi64>} : () -> tensor<1xi64>
+    %result = "onnx.Unsqueeze"(%data, %axes) : (tensor<128x4096xf16>, tensor<1xi64>) -> tensor<128x4096x1xf16>
+    return %result : tensor<128x4096x1xf16>
+  }
+}
+
+// CHECK-LABEL: func.func @test_unsqueeze_front
+// CHECK-SAME: %[[CTX:.*]]: !hip.context, %[[DATA:.*]]: tensor<128x4096xf16>)
+// CHECK-NOT: onnx.Unsqueeze
+// CHECK: %[[RESULT:.*]] = tensor.expand_shape %[[DATA]] {{\[\[}}0, 1], [2]] output_shape [1, 128, 4096] : tensor<128x4096xf16> into tensor<1x128x4096xf16>
+// CHECK: return %[[RESULT]] : tensor<1x128x4096xf16>
+
+// CHECK-LABEL: func.func @test_unsqueeze_back
+// CHECK-SAME: %[[CTX:.*]]: !hip.context, %[[DATA:.*]]: tensor<128x4096xf16>)
+// CHECK-NOT: onnx.Unsqueeze
+// CHECK: %[[RESULT:.*]] = tensor.expand_shape %[[DATA]] {{\[\[}}0], [1, 2]] output_shape [128, 4096, 1] : tensor<128x4096xf16> into tensor<128x4096x1xf16>
+// CHECK: return %[[RESULT]] : tensor<128x4096x1xf16>
+
+// CHECK-LABEL: func.func @test_unsqueeze_middle
+// CHECK-SAME: %[[CTX:.*]]: !hip.context, %[[DATA:.*]]: tensor<128x4096xf16>)
+// CHECK-NOT: onnx.Unsqueeze
+// CHECK: %[[RESULT:.*]] = tensor.expand_shape %[[DATA]] {{\[\[}}0], [1, 2]] output_shape [128, 1, 4096] : tensor<128x4096xf16> into tensor<128x1x4096xf16>
+// CHECK: return %[[RESULT]] : tensor<128x1x4096xf16>
+
+// CHECK-LABEL: func.func @test_unsqueeze_multiple
+// CHECK-SAME: %[[CTX:.*]]: !hip.context, %[[DATA:.*]]: tensor<128x4096xf16>)
+// CHECK-NOT: onnx.Unsqueeze
+// CHECK: %[[RESULT:.*]] = tensor.expand_shape %[[DATA]] {{\[\[}}0, 1], [2, 3]] output_shape [1, 128, 1, 4096] : tensor<128x4096xf16> into tensor<1x128x1x4096xf16>
+// CHECK: return %[[RESULT]] : tensor<1x128x1x4096xf16>
+
+// CHECK-LABEL: func.func @test_unsqueeze_negative_axis
+// CHECK-SAME: %[[CTX:.*]]: !hip.context, %[[DATA:.*]]: tensor<128x4096xf16>)
+// CHECK-NOT: onnx.Unsqueeze
+// CHECK: %[[RESULT:.*]] = tensor.expand_shape %[[DATA]] {{\[\[}}0], [1, 2]] output_shape [128, 4096, 1] : tensor<128x4096xf16> into tensor<128x4096x1xf16>
+// CHECK: return %[[RESULT]] : tensor<128x4096x1xf16>


### PR DESCRIPTION
Implement onnx.Unsqueeze and onnx.Squeeze as zero-cost metadata operations using tensor.expand_shape and tensor.collapse_shape.

## Summary

- **Unsqueeze**: inserts dimensions of size 1 at specified axes
- **Squeeze**: removes dimensions of size 1 at specified axes  
- Both operations reinterpret shape/strides without moving data

## Implementation

- Use MLIR built-in `getReassociationIndicesForReshape` for reassociation
- Shared validation: `validateSqueezeUnsqueezeOp` helper (eliminates 94 lines of duplicates)
- Shared output shape building: `buildExpandShapeOutputShape` helper
- Zero-cost: `tensor.expand_shape` / `tensor.collapse_shape` → `memref.*_shape` → LLVM
