### PR TITLE
CI:disable cpu fallback

### DIFF
--- a/.github/workflows/gpu-perf-accuracy-test.yml
+++ b/.github/workflows/gpu-perf-accuracy-test.yml
@@ -148,6 +148,7 @@ jobs:
               --plugin_ep_libs "MorphiZenExecutionProvider|onnxruntime_morphizen_ep.dll" `
               --plugin_eps "MorphiZenExecutionProvider" `
               --plugin_ep_options "config_file|..\morphizen_config.json" `
+              -C "session.disable_cpu_ep_fallback|1" `
               -t $env:PERF_DURATION -c 1 -s -I `
               $m.FullName 2>&1 | Tee-Object -FilePath $mzFile
             if ($LASTEXITCODE -ne 0) { $failed = 1 }
@@ -305,6 +306,7 @@ jobs:
               --plugin_ep_libs "MorphiZenExecutionProvider|onnxruntime_morphizen_ep.dll" `
               --plugin_eps "MorphiZenExecutionProvider" `
               --plugin_ep_options "config_file|..\morphizen_config.json" `
+              -C "session.disable_cpu_ep_fallback|1" `
               -t $env:PERF_DURATION -c 1 -s -I `
               $m.FullName 2>&1 | Tee-Object -FilePath $mzFile
             if ($LASTEXITCODE -ne 0) { $failed = 1 }

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -468,6 +468,7 @@ jobs:
               --plugin_ep_libs "MorphiZenExecutionProvider|onnxruntime_morphizen_ep.dll" ^
               --plugin_eps "MorphiZenExecutionProvider" ^
               --plugin_ep_options "config_file|..\morphizen_config.json" ^
+              -C "session.disable_cpu_ep_fallback|1" ^
               -t 30 -c 1 -s -I ^
               "%%M" > "..\results\%%~nxM.txt" 2>&1
             type "..\results\%%~nxM.txt"


### PR DESCRIPTION
Add -C "session.disable_cpu_ep_fallback|1" to all perf test invocations to ensure ops not supported by hipdnn EP are not silently falling back to CPU