### PR TITLE
feat: add PyTorch/torch-mlir frontend (TorchToHip conversion)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,10 +86,13 @@ if(BUILD_HIP_TOOLS)
   separate_arguments(LLVM_DEFINITIONS_LIST NATIVE_COMMAND ${LLVM_DEFINITIONS})
   add_definitions(${LLVM_DEFINITIONS_LIST})
 
-  include_directories(${LLVM_INCLUDE_DIRS})
-  include_directories(${MLIR_INCLUDE_DIRS})
+  # Local source/build includes BEFORE prebuilt LLVM/MLIR includes so that
+  # locally modified headers (e.g. hip/InitAllPasses.h) take precedence over
+  # previously installed copies in CMAKE_PREFIX_PATH.
   include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
   include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
+  include_directories(${LLVM_INCLUDE_DIRS})
+  include_directories(${MLIR_INCLUDE_DIRS})
 
   # onnx-mlir is no longer required. The convert-onnx-to-hip pass uses
   # MLIR's generic Operation API to match ONNX ops by name, so no onnx-mlir

--- a/lib/Conversion/Passes.cpp
+++ b/lib/Conversion/Passes.cpp
@@ -4,6 +4,8 @@
  */
 
 #include "hip/Conversion/Passes.h"
+#include "hip/Conversion/OnnxToHipDNN/Passes.h"
+#include "hip/Conversion/TorchToHip/Passes.h"
 #include "mlir/Pass/Pass.h"
 
 namespace hip::compiler {

--- a/lib/Conversion/TorchToHip/TorchToHip.cpp
+++ b/lib/Conversion/TorchToHip/TorchToHip.cpp
@@ -79,10 +79,10 @@ static mlir::LogicalResult generateModuleMetadata(mlir::ModuleOp module) {
   }
 
   if (!targetFunc) {
-    module.emitError(
-        "expected @forward, @main_graph, or a single public function "
-        "for metadata generation");
-    return mlir::failure();
+    // No single entry function found -- skip metadata generation.
+    // This is expected for unit conversion tests with multiple test functions.
+    // Metadata is only required for E2E compilation (GenerateInterface pass).
+    return mlir::success();
   }
 
   auto originalFuncType = targetFunc.getFunctionType();
@@ -211,10 +211,6 @@ void ConvertTorchToHipPass::runOnOperation() {
 }
 
 } // namespace
-
-std::unique_ptr<mlir::Pass> createConvertTorchToHipPass() {
-  return std::make_unique<ConvertTorchToHipPass>();
-}
 
 } // namespace hip
 } // namespace mlir

--- a/tools/hip-mlir-opt/CMakeLists.txt
+++ b/tools/hip-mlir-opt/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(hip-mlir-opt PRIVATE
   HipDialectTransforms
   HipToLLVM
   OnnxToHip
+  TorchToHip
   MLIROptLib
   MLIRSupport
   MLIRIR

--- a/tools/hip-mlir-opt/hip-mlir-opt.cpp
+++ b/tools/hip-mlir-opt/hip-mlir-opt.cpp
@@ -145,6 +145,7 @@ int main(int argc, char **argv) {
   registry.insert<mlir::LLVM::LLVMDialect>();
   registry.insert<mlir::hip::HipDialect>();
   registry.insert<hip::compiler::detail::OnnxStubDialect>();
+  registry.insert<hip::compiler::detail::TorchStubDialect>();
 
   mlir::arith::registerBufferizableOpInterfaceExternalModels(registry);
   mlir::bufferization::func_ext::registerBufferizableOpInterfaceExternalModels(


### PR DESCRIPTION
## Summary

Add a parallel frontend that converts **torch-mlir backend contract IR** (torch dialect) to the existing HIP dialect, enabling PyTorch model support alongside ONNX. Everything downstream — bufferization, HipToLLVM lowering, runtime — is reused unchanged.

```
                    ┌─ OnnxToHip (existing) ─┐
MLIR input ────────►│                         ├──► HIP dialect ──► HipToLLVM ──► DLL
                    └─ TorchToHip (NEW)  ────┘
```

### What's included (Phase 1 MVP)

**Infrastructure:**
- `TorchStubDialect` — claims `"torch"` namespace, allows unknown ops/types (no torch-mlir library dependency)
- `ConvertTorchToHipPass` — registered as `--convert-torch-to-hip`
- Torch-specific helpers: `getTorchConstantInt()`, `getTorchConstantIntList()`, `isTorchNone()`

**9 operator conversions** (per-operator files mirroring OnnxToHip structure):

| Torch Op | HIP Op |
|----------|--------|
| `torch.aten.mm`, `.bmm`, `.matmul`, `.linear` | `hip.matmul` (+`hip.add` for bias) |
| `torch.aten.conv2d` | `hip.conv` |
| `torch.aten.add/mul/sub.Tensor` | `hip.add/mul/sub` |
| `torch.aten.sigmoid`, `.silu`, `.softmax.int` | `hip.sigmoid`, `hip.silu`, `hip.miopen.softmax` |
| `torch.aten.to.dtype` | `hip.cast` |
| `torch.aten.index_select` | `hip.gather` |
| `torch.aten.sum.dim_IntList` | `hip.reduce_sum` |
| `torch.aten.reshape/unsqueeze/squeeze` | `tensor.expand/collapse_shape` |
| `torch.aten.transpose.int` | `hip.transpose` |

**Pipeline integration:**
- `--torch-to-hip-pipeline` — Torch → bufferized HIP memref
- `--torch-hipdnn-pipeline` — Torch → HIP → LLVM → C Interface (full compilation)

**E2E auto-detection:**
- `CompilerDriver::runMLIRPasses()` auto-detects `torch.*` vs `onnx.*` ops
- `hip-compiler` works with torch `.mlir` files with zero tool changes
- 4 E2E test models (add, matmul, sigmoid, mul) auto-discovered by existing CMake glob

**9 LIT tests** validating each conversion pattern

### Known limitations (Phase 1)
- `torch.aten.add/sub` alpha parameter: only alpha=1 supported
- `torch.aten.permute`: not supported (only `transpose.int` for two-dim swaps)
- Attention ops deferred to Phase 2
- No constant externalization (torch models carry weights as function args)

## Test plan

- [ ] Pre-commit (clang-format) passes
- [ ] Build succeeds (mock + real runtime)
- [ ] LIT tests pass: `hip-mlir-opt --convert-torch-to-hip` on all 9 test files
- [ ] E2E LIT tests pass: `hip-mlir-opt --torch-hipdnn-pipeline` on 4 model files
- [ ] E2E compile+execute tests pass on GPU runner
- [ ] Existing ONNX tests unaffected (auto-detection falls through to ONNX pipeline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)