### PR TITLE
feat: add hipEvent-based GPU profiling infrastructure

### DIFF
--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -1,0 +1,163 @@
+# GPU Profiling Guide
+
+This document describes the built-in GPU profiling infrastructure for the
+hipDNN EP runtime. When enabled, it records per-kernel GPU timestamps using
+`hipEvent` pairs and produces detailed timing reports.
+
+## Quick Start
+
+### 1. Enable at build time
+
+```bash
+cmake -DHIPDNN_EP_ENABLE_PROFILING=ON ...
+```
+
+This defines `HIPDNN_EP_ENABLE_PROFILING` and compiles the profiler into the
+runtime bitcode. When OFF (default), all profiling macros expand to no-ops
+with zero overhead.
+
+### 2. Enable at runtime
+
+```bash
+export HIPDNN_EP_PROFILE=1
+```
+
+The profiler checks this environment variable during `hipdnn_ep_state_init`.
+If unset or `"0"`, no events are recorded even when compiled in.
+
+### 3. Run your model
+
+```bash
+./your_model_runner
+```
+
+### 4. Inspect output files
+
+After cleanup (session teardown), three outputs are produced:
+
+| File | Format | Description |
+|------|--------|-------------|
+| `hipdnn_ep_profile.json` | Chrome Tracing JSON | Open in `chrome://tracing` or [Perfetto](https://ui.perfetto.dev) |
+| `hipdnn_ep_profile.csv` | CSV | `name,category,start_us,duration_us,duration_ms` |
+| `stderr` | Summary table | Sorted by total GPU time descending |
+
+## Output Formats
+
+### Chrome Tracing JSON (`hipdnn_ep_profile.json`)
+
+```json
+{"traceEvents":[
+  {"name":"wrap_hipblasLtMatmul","cat":"compute","ph":"X","ts":1234,"dur":56.7,"pid":1,"tid":1},
+  ...
+]}
+```
+
+- `ph:"X"` = complete event (begin + duration)
+- `ts` = host timestamp in microseconds (relative to profiler start)
+- `dur` = GPU-measured duration in microseconds
+
+### CSV (`hipdnn_ep_profile.csv`)
+
+```csv
+name,category,start_us,duration_us,duration_ms
+wrap_hipblasLtMatmul,compute,1234,56.7,0.0567
+tensor_h2d,h2d,500,12.3,0.0123
+```
+
+### Summary Table (stderr)
+
+```
+[PROFILER] ==================== GPU Profile Summary ====================
+Function                                    Calls    Total (ms)     Avg (ms)       %
+--------------------------------------------------------------------------------
+wrap_hipblasLtMatmul                           24       12.345        0.514    45.2%
+wrap_group_query_attention                     12        8.901        0.742    32.6%
+...
+--------------------------------------------------------------------------------
+TOTAL                                                   27.300
+================================================================================
+```
+
+## Instrumented Functions
+
+| Function | Category | Description |
+|----------|----------|-------------|
+| `wrap_hipblasLtMatmul` | `compute` | Dense matrix multiply (hipBLASLt) |
+| `wrap_group_query_attention` | `compute` | Group query attention (GQA) |
+| `wrap_matmul_nbits` | `compute` | Quantized matrix multiply (N-bit) |
+| `wrap_miopenT5LayerNormForward` | `compute` | Simplified layer norm (RMS) |
+| `wrap_skip_simplified_layer_norm` | `compute` | Skip + simplified layer norm |
+| `wrap_rotary_embedding` | `compute` | Rotary position embedding (RoPE) |
+| `wrap_miopenOpTensor` | `compute` | Element-wise tensor operations |
+| `tensor_h2d` | `h2d` | Host-to-device tensor transfer |
+| `tensor_d2h_sync` | `d2h` | Device-to-host transfer + sync |
+
+## Adding New Instrumentation
+
+To profile a new runtime function:
+
+1. Include the profiler header:
+   ```cpp
+   #include "../hipdnn_ep_profiler.h"   // from real/ subdirectory
+   // or
+   #include "hipdnn_ep_profiler.h"      // from Runtime/ directory
+   ```
+
+2. Add `HIPDNN_EP_PROFILE_BEGIN` / `HIPDNN_EP_PROFILE_END` around the
+   GPU work:
+   ```cpp
+   int wrap_my_kernel(RuntimeState *state, ...) {
+     // ... validation ...
+     HIPDNN_EP_PROFILE_BEGIN(state, "wrap_my_kernel", "compute");
+     // ... GPU kernel launch / library call ...
+     HIPDNN_EP_PROFILE_END(state, "wrap_my_kernel", "compute");
+     // ... error handling ...
+     return 0;
+   }
+   ```
+
+3. The `name` string must match between BEGIN and END (searched backwards).
+4. Use `"compute"` for GPU kernels, `"h2d"` for host-to-device transfers,
+   `"d2h"` for device-to-host transfers, or define a new category.
+
+## Architecture
+
+### hipEvent-Based Timing
+
+The profiler uses `hipEventCreate` / `hipEventRecord` / `hipEventElapsedTime`
+for GPU-accurate timing. Events are recorded on the runtime's HIP stream
+(`state->stream`) so they measure actual GPU execution time, not host-side
+dispatch time.
+
+### Data Flow
+
+```
+PROFILE_BEGIN(state, name, cat)
+  -> hipEventCreate + hipEventRecord(start)
+  -> store in ProfilerState.events[]
+
+PROFILE_END(state, name, cat)
+  -> find matching begin (search backwards by name)
+  -> hipEventCreate + hipEventRecord(end)
+  -> mark has_end = true
+
+profiler_dump(state)
+  -> hipStreamSynchronize
+  -> hipEventElapsedTime for each completed pair
+  -> write JSON, CSV, summary
+```
+
+### Memory Layout
+
+- `ProfilerState` is heap-allocated and stored in `RuntimeState.profiler`
+  (void* field).
+- Events array is pre-allocated to 16,384 entries (sufficient for typical
+  inference sessions).
+- All hipEvents are destroyed in `profiler_cleanup`.
+
+### Compile-Time Gating
+
+When `HIPDNN_EP_ENABLE_PROFILING` is not defined:
+- All functions become inline no-ops
+- `HIPDNN_EP_PROFILE_BEGIN` / `HIPDNN_EP_PROFILE_END` expand to `((void)0)`
+- Zero runtime overhead in production builds

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -94,6 +94,9 @@ message(STATUS "Found morphizen-foundation: ${MORPHIZEN_FOUNDATION_INCLUDE_DIR}"
 # Default to Mock runtime (no GPU required)
 option(BUILD_MOCK_RUNTIME "Build mock runtime (no GPU required)" ON)
 
+# GPU profiling instrumentation (hipEvent-based, default OFF for zero overhead)
+option(HIPDNN_EP_ENABLE_PROFILING "Enable GPU profiling instrumentation" OFF)
+
 if(NOT BUILD_MOCK_RUNTIME)
     # Try to find ROCm components
     # Accept THEROCK_DIST from either CMake variable or environment variable
@@ -191,6 +194,7 @@ macro(compile_to_bitcode SOURCE_FILE OUTPUT_BC)
                 $<$<NOT:$<CONFIG:Debug>>:-DNDEBUG>
                 $<$<NOT:$<CONFIG:Debug>>:-D_ITERATOR_DEBUG_LEVEL=0>
                 $<$<NOT:$<CONFIG:Debug>>:-O2>
+                $<$<BOOL:${HIPDNN_EP_ENABLE_PROFILING}>:-DHIPDNN_EP_ENABLE_PROFILING>
                 ${COMPILE_FLAGS}
                 ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE}
                 -o ${CMAKE_CURRENT_BINARY_DIR}/${OUTPUT_BC}
@@ -206,6 +210,7 @@ endmacro()
 # Compile shared implementation files
 compile_to_bitcode(hipdnn_ep_runtime_state.cpp runtime_state.bc)
 compile_to_bitcode(hipdnn_ep_runtime_tensor.cpp runtime_tensor.bc)
+compile_to_bitcode(hipdnn_ep_profiler.cpp runtime_profiler.bc)
 
 # Compile implementation-specific files
 if(NOT BUILD_MOCK_RUNTIME)
@@ -231,6 +236,7 @@ if(NOT BUILD_MOCK_RUNTIME)
     set(RUNTIME_BC_MODULES
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_state.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_tensor.bc
+        ${CMAKE_CURRENT_BINARY_DIR}/runtime_profiler.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_memory.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_hip.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_miopen.bc
@@ -258,6 +264,7 @@ else()
     set(RUNTIME_BC_MODULES
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_state.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_tensor.bc
+        ${CMAKE_CURRENT_BINARY_DIR}/runtime_profiler.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_memory.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_mock.bc
         ${CMAKE_CURRENT_BINARY_DIR}/test_hip_from_dll.bc

--- a/lib/Runtime/hipdnn_ep_profiler.cpp
+++ b/lib/Runtime/hipdnn_ep_profiler.cpp
@@ -1,0 +1,377 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+//===- hipdnn_ep_profiler.cpp - GPU Profiling Implementation --------------===//
+//
+// hipEvent-based GPU profiling for runtime wrapper functions.
+//
+// When enabled, records hipEvents at PROFILE_BEGIN / PROFILE_END boundaries.
+// On dump, synchronizes the stream, computes elapsed times, and writes:
+//   1. hipdnn_ep_profile.json  (Chrome Tracing format)
+//   2. hipdnn_ep_profile.csv   (name,category,start_us,duration_us,duration_ms)
+//   3. Summary table to stderr (sorted by total time descending)
+//
+//===----------------------------------------------------------------------===//
+
+#ifdef HIPDNN_EP_ENABLE_PROFILING
+
+#include "hipdnn_ep_profiler.h"
+#include "runtime_state_internal.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <hip/hip_runtime.h>
+#include <vector>
+
+//===----------------------------------------------------------------------===//
+// Internal data structures
+//===----------------------------------------------------------------------===//
+
+struct ProfileEvent {
+  const char *name;
+  const char *category;
+  void *event_start; // hipEvent_t
+  void *event_end;   // hipEvent_t
+  int64_t host_ts_us; // host timestamp at begin (microseconds since profiler start)
+  bool has_end;
+};
+
+struct ProfilerState {
+  bool enabled;
+  ProfileEvent *events;
+  size_t event_count;
+  size_t event_capacity;
+  std::chrono::steady_clock::time_point start_time;
+};
+
+static constexpr size_t kDefaultCapacity = 16384;
+
+//===----------------------------------------------------------------------===//
+// Profiler API implementation
+//===----------------------------------------------------------------------===//
+
+void hipdnn_ep_profiler_init(RuntimeState *state) {
+  if (!state)
+    return;
+
+  const char *env = std::getenv("HIPDNN_EP_PROFILE");
+  if (!env || env[0] == '\0' || env[0] == '0') {
+    state->profiler = nullptr;
+    return;
+  }
+
+  ProfilerState *ps =
+      static_cast<ProfilerState *>(std::malloc(sizeof(ProfilerState)));
+  if (!ps) {
+    fprintf(stderr, "[PROFILER] Failed to allocate ProfilerState\n");
+    state->profiler = nullptr;
+    return;
+  }
+
+  ps->enabled = true;
+  ps->event_count = 0;
+  ps->event_capacity = kDefaultCapacity;
+  ps->events = static_cast<ProfileEvent *>(
+      std::calloc(kDefaultCapacity, sizeof(ProfileEvent)));
+  if (!ps->events) {
+    fprintf(stderr, "[PROFILER] Failed to allocate events array\n");
+    std::free(ps);
+    state->profiler = nullptr;
+    return;
+  }
+  ps->start_time = std::chrono::steady_clock::now();
+
+  state->profiler = ps;
+  fprintf(stderr, "[PROFILER] Initialized (capacity=%zu)\n",
+          ps->event_capacity);
+}
+
+void hipdnn_ep_profiler_begin(RuntimeState *state, const char *name,
+                              const char *category) {
+  if (!state || !state->profiler)
+    return;
+
+  ProfilerState *ps = static_cast<ProfilerState *>(state->profiler);
+  if (!ps->enabled)
+    return;
+
+  if (ps->event_count >= ps->event_capacity) {
+    fprintf(stderr,
+            "[PROFILER] WARNING: event capacity (%zu) exceeded, dropping '%s'\n",
+            ps->event_capacity, name);
+    return;
+  }
+
+  hipEvent_t ev_start = nullptr;
+  if (hipEventCreate(&ev_start) != hipSuccess) {
+    fprintf(stderr, "[PROFILER] hipEventCreate failed for '%s'\n", name);
+    return;
+  }
+
+  if (hipEventRecord(ev_start, state->stream) != hipSuccess) {
+    fprintf(stderr, "[PROFILER] hipEventRecord failed for '%s'\n", name);
+    hipEventDestroy(ev_start);
+    return;
+  }
+
+  auto now = std::chrono::steady_clock::now();
+  int64_t host_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                        now - ps->start_time)
+                        .count();
+
+  ProfileEvent &e = ps->events[ps->event_count++];
+  e.name = name;
+  e.category = category;
+  e.event_start = ev_start;
+  e.event_end = nullptr;
+  e.host_ts_us = host_us;
+  e.has_end = false;
+}
+
+void hipdnn_ep_profiler_end(RuntimeState *state, const char *name,
+                            const char *category) {
+  if (!state || !state->profiler)
+    return;
+
+  ProfilerState *ps = static_cast<ProfilerState *>(state->profiler);
+  if (!ps->enabled)
+    return;
+
+  // Search backwards for matching begin event
+  ProfileEvent *match = nullptr;
+  for (size_t i = ps->event_count; i > 0; --i) {
+    ProfileEvent &e = ps->events[i - 1];
+    if (!e.has_end && std::strcmp(e.name, name) == 0) {
+      match = &e;
+      break;
+    }
+  }
+
+  if (!match) {
+    fprintf(stderr,
+            "[PROFILER] WARNING: no matching begin for end '%s', ignoring\n",
+            name);
+    return;
+  }
+
+  hipEvent_t ev_end = nullptr;
+  if (hipEventCreate(&ev_end) != hipSuccess) {
+    fprintf(stderr, "[PROFILER] hipEventCreate (end) failed for '%s'\n", name);
+    return;
+  }
+
+  if (hipEventRecord(ev_end, state->stream) != hipSuccess) {
+    fprintf(stderr, "[PROFILER] hipEventRecord (end) failed for '%s'\n", name);
+    hipEventDestroy(ev_end);
+    return;
+  }
+
+  match->event_end = ev_end;
+  match->has_end = true;
+}
+
+//===----------------------------------------------------------------------===//
+// Dump: synchronize, compute elapsed times, write outputs
+//===----------------------------------------------------------------------===//
+
+/// Summary row for aggregated per-name statistics
+struct SummaryRow {
+  const char *name;
+  const char *category;
+  int calls;
+  double total_ms;
+  double avg_ms;
+};
+
+void hipdnn_ep_profiler_dump(RuntimeState *state) {
+  if (!state || !state->profiler)
+    return;
+
+  ProfilerState *ps = static_cast<ProfilerState *>(state->profiler);
+  if (!ps->enabled || ps->event_count == 0)
+    return;
+
+  // Synchronize stream to ensure all events have completed
+  if (state->stream) {
+    hipStreamSynchronize(state->stream);
+  }
+
+  // Compute elapsed times for all events
+  struct ResolvedEvent {
+    const char *name;
+    const char *category;
+    int64_t host_ts_us;
+    float duration_ms;
+  };
+
+  std::vector<ResolvedEvent> resolved;
+  resolved.reserve(ps->event_count);
+
+  for (size_t i = 0; i < ps->event_count; ++i) {
+    ProfileEvent &e = ps->events[i];
+    if (!e.has_end || !e.event_start || !e.event_end)
+      continue;
+
+    float elapsed_ms = 0.0f;
+    if (hipEventElapsedTime(&elapsed_ms, static_cast<hipEvent_t>(e.event_start),
+                            static_cast<hipEvent_t>(e.event_end)) !=
+        hipSuccess) {
+      continue;
+    }
+
+    resolved.push_back(
+        {e.name, e.category, e.host_ts_us, elapsed_ms});
+  }
+
+  if (resolved.empty()) {
+    fprintf(stderr, "[PROFILER] No completed events to dump\n");
+    return;
+  }
+
+  //===--------------------------------------------------------------------===//
+  // 1. Write Chrome Tracing JSON
+  //===--------------------------------------------------------------------===//
+  {
+    FILE *fp = fopen("hipdnn_ep_profile.json", "w");
+    if (fp) {
+      fprintf(fp, "{\"traceEvents\":[\n");
+      for (size_t i = 0; i < resolved.size(); ++i) {
+        auto &r = resolved[i];
+        double dur_us = static_cast<double>(r.duration_ms) * 1000.0;
+        fprintf(fp,
+                "  {\"name\":\"%s\",\"cat\":\"%s\",\"ph\":\"X\","
+                "\"ts\":%lld,\"dur\":%.1f,\"pid\":1,\"tid\":1}%s\n",
+                r.name, r.category, (long long)r.host_ts_us, dur_us,
+                (i + 1 < resolved.size()) ? "," : "");
+      }
+      fprintf(fp, "]}\n");
+      fclose(fp);
+      fprintf(stderr, "[PROFILER] Wrote hipdnn_ep_profile.json (%zu events)\n",
+              resolved.size());
+    } else {
+      fprintf(stderr, "[PROFILER] WARNING: failed to open "
+                      "hipdnn_ep_profile.json for writing\n");
+    }
+  }
+
+  //===--------------------------------------------------------------------===//
+  // 2. Write CSV
+  //===--------------------------------------------------------------------===//
+  {
+    FILE *fp = fopen("hipdnn_ep_profile.csv", "w");
+    if (fp) {
+      fprintf(fp, "name,category,start_us,duration_us,duration_ms\n");
+      for (auto &r : resolved) {
+        double dur_us = static_cast<double>(r.duration_ms) * 1000.0;
+        fprintf(fp, "%s,%s,%lld,%.1f,%.4f\n", r.name, r.category,
+                (long long)r.host_ts_us, dur_us, r.duration_ms);
+      }
+      fclose(fp);
+      fprintf(stderr, "[PROFILER] Wrote hipdnn_ep_profile.csv (%zu events)\n",
+              resolved.size());
+    } else {
+      fprintf(stderr, "[PROFILER] WARNING: failed to open "
+                      "hipdnn_ep_profile.csv for writing\n");
+    }
+  }
+
+  //===--------------------------------------------------------------------===//
+  // 3. Summary table to stderr
+  //===--------------------------------------------------------------------===//
+  {
+    // Aggregate by name
+    std::vector<SummaryRow> summary;
+    for (auto &r : resolved) {
+      bool found = false;
+      for (auto &s : summary) {
+        if (std::strcmp(s.name, r.name) == 0) {
+          s.calls++;
+          s.total_ms += r.duration_ms;
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        SummaryRow row;
+        row.name = r.name;
+        row.category = r.category;
+        row.calls = 1;
+        row.total_ms = r.duration_ms;
+        row.avg_ms = 0.0;
+        summary.push_back(row);
+      }
+    }
+
+    // Compute total and averages
+    double grand_total_ms = 0.0;
+    for (auto &s : summary) {
+      s.avg_ms = s.total_ms / s.calls;
+      grand_total_ms += s.total_ms;
+    }
+
+    // Sort by total time descending
+    std::sort(summary.begin(), summary.end(),
+              [](const SummaryRow &a, const SummaryRow &b) {
+                return a.total_ms > b.total_ms;
+              });
+
+    fprintf(stderr,
+            "\n[PROFILER] ==================== GPU Profile Summary "
+            "====================\n");
+    fprintf(stderr, "%-40s %8s %12s %12s %8s\n", "Function", "Calls",
+            "Total (ms)", "Avg (ms)", "%%");
+    fprintf(stderr,
+            "----------------------------------------------------------------------"
+            "----------\n");
+
+    for (auto &s : summary) {
+      double pct = (grand_total_ms > 0.0) ? (s.total_ms / grand_total_ms * 100.0)
+                                           : 0.0;
+      fprintf(stderr, "%-40s %8d %12.3f %12.3f %7.1f%%\n", s.name, s.calls,
+              s.total_ms, s.avg_ms, pct);
+    }
+
+    fprintf(stderr,
+            "----------------------------------------------------------------------"
+            "----------\n");
+    fprintf(stderr, "%-40s %8s %12.3f\n", "TOTAL", "",
+            grand_total_ms);
+    fprintf(stderr,
+            "======================================================================"
+            "==========\n\n");
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Cleanup: destroy all hipEvents, free memory
+//===----------------------------------------------------------------------===//
+
+void hipdnn_ep_profiler_cleanup(RuntimeState *state) {
+  if (!state || !state->profiler)
+    return;
+
+  ProfilerState *ps = static_cast<ProfilerState *>(state->profiler);
+
+  for (size_t i = 0; i < ps->event_count; ++i) {
+    ProfileEvent &e = ps->events[i];
+    if (e.event_start) {
+      hipEventDestroy(static_cast<hipEvent_t>(e.event_start));
+    }
+    if (e.event_end) {
+      hipEventDestroy(static_cast<hipEvent_t>(e.event_end));
+    }
+  }
+
+  std::free(ps->events);
+  std::free(ps);
+  state->profiler = nullptr;
+
+  fprintf(stderr, "[PROFILER] Cleanup complete\n");
+}
+
+#endif /* HIPDNN_EP_ENABLE_PROFILING */

--- a/lib/Runtime/hipdnn_ep_profiler.h
+++ b/lib/Runtime/hipdnn_ep_profiler.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+//===- hipdnn_ep_profiler.h - GPU Profiling Instrumentation ---------------===//
+//
+// Provides hipEvent-based GPU profiling for runtime wrapper functions.
+//
+// When HIPDNN_EP_ENABLE_PROFILING is defined at compile time AND the
+// HIPDNN_EP_PROFILE environment variable is set at runtime, each
+// PROFILE_BEGIN / PROFILE_END pair records GPU timestamps via hipEvents.
+// On cleanup, results are dumped to JSON (Chrome Tracing), CSV, and a
+// summary table on stderr.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HIPDNN_EP_PROFILER_H
+#define HIPDNN_EP_PROFILER_H
+
+#include <stddef.h>
+
+struct RuntimeState;
+
+#ifdef HIPDNN_EP_ENABLE_PROFILING
+
+void hipdnn_ep_profiler_init(RuntimeState *state);
+void hipdnn_ep_profiler_begin(RuntimeState *state, const char *name,
+                              const char *category);
+void hipdnn_ep_profiler_end(RuntimeState *state, const char *name,
+                            const char *category);
+void hipdnn_ep_profiler_dump(RuntimeState *state);
+void hipdnn_ep_profiler_cleanup(RuntimeState *state);
+
+#define HIPDNN_EP_PROFILE_BEGIN(state, name, cat)                              \
+  hipdnn_ep_profiler_begin((state), (name), (cat))
+#define HIPDNN_EP_PROFILE_END(state, name, cat)                                \
+  hipdnn_ep_profiler_end((state), (name), (cat))
+
+#else /* HIPDNN_EP_ENABLE_PROFILING not defined */
+
+static inline void hipdnn_ep_profiler_init(RuntimeState *) {}
+static inline void hipdnn_ep_profiler_begin(RuntimeState *, const char *,
+                                            const char *) {}
+static inline void hipdnn_ep_profiler_end(RuntimeState *, const char *,
+                                          const char *) {}
+static inline void hipdnn_ep_profiler_dump(RuntimeState *) {}
+static inline void hipdnn_ep_profiler_cleanup(RuntimeState *) {}
+
+#define HIPDNN_EP_PROFILE_BEGIN(state, name, cat) ((void)0)
+#define HIPDNN_EP_PROFILE_END(state, name, cat) ((void)0)
+
+#endif /* HIPDNN_EP_ENABLE_PROFILING */
+
+#endif /* HIPDNN_EP_PROFILER_H */

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -5,6 +5,7 @@
 #include "debug_log.h"
 #include "hip/timing.h"
 #include "hip_cleanup.h"
+#include "hipdnn_ep_profiler.h"
 #include "hipdnn_ep_runtime.h"
 #include "runtime_state_internal.h"
 
@@ -46,6 +47,7 @@ int hipdnn_ep_state_init_with_fs(RuntimeState **out_state, void *fs,
   state->num_buffers = 0;
   state->workspace = nullptr;
   state->workspace_size = 0;
+  state->profiler = nullptr;
   state->hipdnn_handle = nullptr;
   state->hipdnn_graph_registry = nullptr;
 
@@ -176,6 +178,8 @@ int hipdnn_ep_state_init_with_fs(RuntimeState **out_state, void *fs,
   TIMING_LOG("[Session] hipBLASLt init: %.3fs\n", record_elapsed(t_prev));
 
   *out_state = state;
+
+  hipdnn_ep_profiler_init(state);
 
   // Parse FlatBuffers blob to get constants_filename and constant_sizes
   if (!metadata_blob || blob_size == 0) {
@@ -356,6 +360,10 @@ int hipdnn_ep_state_cleanup(RuntimeState *state) {
 
   // Best-effort cleanup - continue even if operations fail
   // Cleanup in reverse order of initialization (LIFO)
+
+  // Dump and cleanup profiler before stream sync (dump does its own sync)
+  hipdnn_ep_profiler_dump(state);
+  hipdnn_ep_profiler_cleanup(state);
 
   // Synchronize stream to ensure all GPU operations complete
   if (state->stream) {

--- a/lib/Runtime/hipdnn_ep_runtime_tensor.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_tensor.cpp
@@ -4,6 +4,7 @@
  */
 #include "debug_log.h"
 #include "hip_cleanup.h"
+#include "hipdnn_ep_profiler.h"
 #include "hipdnn_ep_runtime.h"
 #include "runtime_state_internal.h"
 
@@ -320,12 +321,14 @@ int hipdnn_ep_tensor_prepare_input(RuntimeState *state, span_t *inputs,
   }
 
   // H2D transfer
+  HIPDNN_EP_PROFILE_BEGIN(state, "tensor_h2d", "h2d");
   if (hipMemcpyAsync(gpu_ptr, tensor->data, size_bytes, hipMemcpyHostToDevice,
                      static_cast<hipStream_t>(state->stream)) != hipSuccess) {
     fprintf(stderr, "hipdnn_ep_tensor_prepare_input: H2D transfer failed\n");
     HIP_CLEANUP(hipFree(gpu_ptr));
     return HIPDNN_EP_ERR_H2D_TRANSFER_FAILED;
   }
+  HIPDNN_EP_PROFILE_END(state, "tensor_h2d", "h2d");
 
   // PERF: accumulate H2D bytes
   if (hipdnn_ep_perf_enabled()) {
@@ -467,6 +470,7 @@ int hipdnn_ep_tensor_finalize_output(RuntimeState *state,
   }
 
   // D2H transfer (async -- sync happens once after all outputs)
+  HIPDNN_EP_PROFILE_BEGIN(state, "tensor_d2h_sync", "d2h");
   if (hipMemcpyAsync(buffer->host_ptr, buffer->gpu_ptr, buffer->size_bytes,
                      hipMemcpyDeviceToHost,
                      static_cast<hipStream_t>(state->stream)) != hipSuccess) {
@@ -474,6 +478,7 @@ int hipdnn_ep_tensor_finalize_output(RuntimeState *state,
     result = HIPDNN_EP_ERR_D2H_TRANSFER_FAILED;
     // Continue to cleanup even on error (best-effort)
   }
+  HIPDNN_EP_PROFILE_END(state, "tensor_d2h_sync", "d2h");
 
   // PERF: accumulate D2H bytes
   if (hipdnn_ep_perf_enabled()) {

--- a/lib/Runtime/real/elementwise.cpp
+++ b/lib/Runtime/real/elementwise.cpp
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 #include "../debug_log.h"
+#include "../hipdnn_ep_profiler.h"
 #include "../hipdnn_ep_runtime.h"
 #include "cache_utils.h"
 #include "error_check_macros.h"
@@ -226,9 +227,11 @@ int wrap_miopenOpTensor(RuntimeState *state, void *lhs, void *rhs, void *output,
                     "(op=%s, alpha1=%.1f, alpha2=%.1f, beta=%.1f)\n",
                     op_name, alpha1, alpha2, beta);
 
+  HIPDNN_EP_PROFILE_BEGIN(state, "wrap_miopenOpTensor", "compute");
   miopenStatus_t st =
       miopenOpTensor(handle, miopen_op, &alpha1, c->aDesc, lhs, &alpha2,
                      c->bDesc, rhs, &beta, c->cDesc, output);
+  HIPDNN_EP_PROFILE_END(state, "wrap_miopenOpTensor", "compute");
   if (st != miopenStatusSuccess) {
     fprintf(stderr, "wrap_miopenOpTensor: miopenOpTensor failed (%d)\n", st);
     return -1;

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "../debug_log.h"
+#include "../hipdnn_ep_profiler.h"
 #include "../hipdnn_ep_runtime.h"
 #include "cache_utils.h"
 #include "error_check_macros.h"
@@ -660,11 +661,13 @@ int wrap_group_query_attention(
       static_cast<int>(has_rope), static_cast<int>(has_local_window),
       static_cast<int>(has_smooth_softmax));
 
+  HIPDNN_EP_PROFILE_BEGIN(state, "wrap_group_query_attention", "compute");
   int rc = gqa_forward_hipblaslt(
       state, stream, ltHandle, query, key, value, past_key, past_value,
       cos_cache, sin_cache, head_sink, has_smooth_softmax, output, present_key,
       present_value, batch_size, seq_len_q, seq_len_kv, num_heads, kv_num_heads,
       head_dim, scale, do_rotary, local_window_size);
+  HIPDNN_EP_PROFILE_END(state, "wrap_group_query_attention", "compute");
 
   if (rc != 0) {
     fprintf(stderr, "wrap_group_query_attention: gqa_forward failed (rc=%d)\n",

--- a/lib/Runtime/real/matmul.cpp
+++ b/lib/Runtime/real/matmul.cpp
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 #include "../debug_log.h"
+#include "../hipdnn_ep_profiler.h"
 #include "../hipdnn_ep_runtime.h"
 #include "cache_utils.h"
 #include "hip_custom_kernels.h"
@@ -373,6 +374,7 @@ int wrap_hipblasLtMatmul(RuntimeState *state, const void *A, const void *B,
   float alpha = 1.0f;
   float beta = 0.0f;
 
+  HIPDNN_EP_PROFILE_BEGIN(state, "wrap_hipblasLtMatmul", "compute");
   hipblasStatus_t st =
       hipblasLtMatmul(handle, cached->desc, &alpha, B,
                       cached->layA,    // "A" = B (row->col trick)
@@ -380,6 +382,7 @@ int wrap_hipblasLtMatmul(RuntimeState *state, const void *A, const void *B,
                       &beta, output, cached->layC, output, cached->layC,
                       const_cast<hipblasLtMatmulAlgo_t *>(&cached->algo),
                       ws_ptr, ws_size, stream);
+  HIPDNN_EP_PROFILE_END(state, "wrap_hipblasLtMatmul", "compute");
 
   if (st != HIPBLAS_STATUS_SUCCESS) {
     fprintf(stderr, "wrap_hipblasLtMatmul: hipblasLtMatmul failed (%d)\n", st);

--- a/lib/Runtime/real/matmul_nbits.cpp
+++ b/lib/Runtime/real/matmul_nbits.cpp
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 #include "../debug_log.h"
+#include "../hipdnn_ep_profiler.h"
 #include "../hipdnn_ep_runtime.h"
 #include "error_check_macros.h"
 #include "hip_custom_kernels.h"
@@ -42,8 +43,10 @@ int wrap_matmul_nbits(RuntimeState *state, const void *A, const void *B,
   }
 
   int result = 0;
+  HIPDNN_EP_PROFILE_BEGIN(state, "wrap_matmul_nbits", "compute");
   HIP_CHECK(hip_matmul_nbits(stream, A, B, scales, zero_points, bias, output, M,
                              N, K, batch_count, bits, block_size, elem_size));
+  HIPDNN_EP_PROFILE_END(state, "wrap_matmul_nbits", "compute");
 
 cleanup:
   return result;

--- a/lib/Runtime/real/rotary_embedding.cpp
+++ b/lib/Runtime/real/rotary_embedding.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "../debug_log.h"
+#include "../hipdnn_ep_profiler.h"
 #include "../hipdnn_ep_runtime.h"
 #include "hip_custom_kernels.h"
 
@@ -70,11 +71,13 @@ int wrap_rotary_embedding(RuntimeState *state, void *input, void *position_ids,
       (long long)rotary_dim, (long long)max_seq_len, (long long)interleaved,
       (long long)element_size_bytes);
 
+  HIPDNN_EP_PROFILE_BEGIN(state, "wrap_rotary_embedding", "compute");
   int rc = hip_rope_forward(
       stream, input, position_ids, cos_cache, sin_cache, output,
       /*batch_size=*/1,
       /*seq_len=*/num_positions, num_heads, head_dim, rotary_dim, max_seq_len,
       interleaved, element_size_bytes);
+  HIPDNN_EP_PROFILE_END(state, "wrap_rotary_embedding", "compute");
 
   if (rc != 0) {
     fprintf(stderr, "wrap_rotary_embedding: hip_rope_forward failed (rc=%d)\n",

--- a/lib/Runtime/real/simplified_layer_norm.cpp
+++ b/lib/Runtime/real/simplified_layer_norm.cpp
@@ -7,6 +7,7 @@
 #define MIOPEN_BETA_API
 
 #include "../debug_log.h"
+#include "../hipdnn_ep_profiler.h"
 #include "../hipdnn_ep_runtime.h"
 #include "cache_utils.h"
 #include "error_check_macros.h"
@@ -201,9 +202,11 @@ int wrap_miopenT5LayerNormForward(RuntimeState *state, void *input, void *scale,
       (double)epsilon);
 
   int result = 0;
+  HIPDNN_EP_PROFILE_BEGIN(state, "wrap_miopenT5LayerNormForward", "compute");
   MIOPEN_CHECK(miopenT5LayerNormForward(
       handle, MIOPEN_ELEMENTWISE_AFFINE_T5, c->xDesc, input, c->weightDesc,
       scale, epsilon, c->yDesc, output, c->rstdDesc, rstd_buf));
+  HIPDNN_EP_PROFILE_END(state, "wrap_miopenT5LayerNormForward", "compute");
 
   RUNTIME_DEBUG_LOG(
       "[REAL] wrap_miopenT5LayerNormForward: completed successfully\n");

--- a/lib/Runtime/real/skip_simplified_layer_norm.cpp
+++ b/lib/Runtime/real/skip_simplified_layer_norm.cpp
@@ -7,6 +7,7 @@
 #define MIOPEN_BETA_API
 
 #include "../debug_log.h"
+#include "../hipdnn_ep_profiler.h"
 #include "../hipdnn_ep_runtime.h"
 #include "cache_utils.h"
 #include "error_check_macros.h"
@@ -238,6 +239,8 @@ int wrap_skip_simplified_layer_norm(RuntimeState *state, void *input,
 
   int result = 0;
 
+  HIPDNN_EP_PROFILE_BEGIN(state, "wrap_skip_simplified_layer_norm", "compute");
+
   //===--------------------------------------------------------------------===//
   // Step 1: Element-wise add -- skip_buf = input + skip
   //===--------------------------------------------------------------------===//
@@ -284,6 +287,8 @@ int wrap_skip_simplified_layer_norm(RuntimeState *state, void *input,
   MIOPEN_CHECK(miopenT5LayerNormForward(
       handle, MIOPEN_ELEMENTWISE_AFFINE_T5, c->xDesc, skip_buf, c->weightDesc,
       gamma, epsilon, c->yDesc, output, c->rstdDesc, rstd_buf));
+
+  HIPDNN_EP_PROFILE_END(state, "wrap_skip_simplified_layer_norm", "compute");
 
   RUNTIME_DEBUG_LOG("[REAL] wrap_skip_simplified_layer_norm: completed "
                     "successfully\n");

--- a/lib/Runtime/runtime_state_internal.h
+++ b/lib/Runtime/runtime_state_internal.h
@@ -47,6 +47,11 @@ struct RuntimeState {
   void *workspace;
   size_t workspace_size;
 
+  // GPU profiler state (see hipdnn_ep_profiler.h).
+  // Allocated by hipdnn_ep_profiler_init() when HIPDNN_EP_ENABLE_PROFILING
+  // is compiled in and HIPDNN_EP_PROFILE env var is set.
+  void *profiler;
+
   // hipDNN graph execution support.
   // Set by EP via hipdnn_graph_runtime_attach() after inference_init().
   // hipdnn_handle: hipdnnHandle_t cast to void* (owned by EP, not cleaned up


### PR DESCRIPTION
## Summary

Adds compile-time gated GPU profiling infrastructure using hipEvent timing. Instruments all runtime wrapper functions and produces Chrome Tracing JSON, CSV, and a summary table for per-kernel GPU timing analysis.

### Controls
- **Compile-time**: `cmake -DHIPDNN_EP_ENABLE_PROFILING=ON` (default OFF, zero overhead when disabled)
- **Runtime**: `set HIPDNN_EP_PROFILE=1` to activate (silent when env var not set)

### Output
- `hipdnn_ep_profile.json` — Chrome Tracing JSON, viewable in [Perfetto UI](https://ui.perfetto.dev) or `chrome://tracing`
- `hipdnn_ep_profile.csv` — raw per-event data for offline analysis
- stderr — aggregated summary table

### Example output
```
=== MorphiZen EP Profile Summary ===
Function                                    Calls   Total (ms)     Avg (ms)       %
wrap_hipblasLtMatmul                         6310     2554.143        0.405    81.5%
wrap_group_query_attention                    898      175.878        0.196     5.6%
tensor_h2d                                   1943      118.130        0.061     3.8%
tensor_d2h_sync                              1820      105.201        0.058     3.4%
...
```

### Instrumented functions
MatMul, GQA, MatMulNBits, LayerNorm, SkipLayerNorm, RoPE, elementwise ops, tensor H2D/D2H transfers.

### Documentation
Added `docs/profiling.md` with usage guide, output format descriptions, and instructions for adding new instrumentation.

## Test plan

- [ ] Build with `HIPDNN_EP_ENABLE_PROFILING=OFF` (default) — verify no overhead
- [ ] Build with `HIPDNN_EP_ENABLE_PROFILING=ON`, env unset — verify no output
- [ ] Build with `HIPDNN_EP_ENABLE_PROFILING=ON`, `HIPDNN_EP_PROFILE=1` — verify JSON/CSV/summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)