### PR TITLE
ci: disable scheduled trigger for GPU perf/accuracy test workflow

### DIFF
--- a/.github/workflows/gpu-perf-accuracy-test.yml
+++ b/.github/workflows/gpu-perf-accuracy-test.yml
@@ -5,9 +5,6 @@
 name: GPU Performance & Accuracy Test
 
 on:
-  schedule:
-    - cron: '0 16 * * *'  # daily at UTC 16:00 (CST 00:00)
-
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
- Remove the daily `schedule` cron trigger (`0 16 * * *`) from `gpu-perf-accuracy-test.yml`
- Workflow is now triggered exclusively via `workflow_dispatch` (manual)

## Motivation
The daily automated run is no longer needed. Manual dispatch gives better control over when tests are executed.

## Test plan
- [x] Workflow file validates (no YAML errors)
- [ ] Confirm workflow no longer appears in scheduled runs