### PR TITLE
feat: extend CI result tables and switch iGPU default to VRAM allocation

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -558,22 +558,24 @@ jobs:
             $rel = $f.FullName.Substring($l2Root.Length).TrimStart('\', '/')
             $model = $rel -replace '\.txt$', '' -replace '\\', '/'
             $content = Get-Content $f.FullName -Raw
-            $l2Match = [regex]::Match($content, 'Combined L2 \(stacked diffs\):\s+([\d.eE+-]+)')
+            $l2Match = [regex]::Match($content, 'Combined L2 \(stacked diffs\):\s+([\d.eE+-]+)\s+\(total_elems:\s+(\d+),\s+skipped_nonfinite:\s+(\d+)\)')
             $errMatch = [regex]::Match($content, '\[ERROR\]\s*(.+)')
             if ($l2Match.Success) {
               $l2val = [double]$l2Match.Groups[1].Value
-              $tableRows += "| $model | $l2val |`n"
+              $elems = $l2Match.Groups[2].Value
+              $skipped = $l2Match.Groups[3].Value
+              $tableRows += "| $model | $l2val | $elems | $skipped |`n"
             } elseif ($errMatch.Success) {
               $reason = $errMatch.Groups[1].Value.Trim()
-              $tableRows += "| $model | $reason |`n"
+              $tableRows += "| $model | $reason | - | - |`n"
             } else {
-              $tableRows += "| $model | error |`n"
+              $tableRows += "| $model | error | - | - |`n"
             }
           }
 
           $header = "## L2 Accuracy Results (EP vs CPU)`n`n" +
-                    "| Model | Combined L2 |`n" +
-                    "|-------|------------|`n"
+                    "| Model | Combined L2 | Total Elems | Skipped NaN/Inf |`n" +
+                    "|-------|------------|------------|----------------|`n"
           $footer = "`nThreshold: $threshold | Run: [${{ github.run_number }}]($runUrl) - Commit: ``$sha``"
           $summary = $header + $tableRows + $footer
 
@@ -628,18 +630,26 @@ jobs:
             $model = $f.BaseName -replace '\.onnx$', ''
             $content = Get-Content $f.FullName -Raw
             $qpsMatch = [regex]::Match($content, 'Number of inferences per second:\s+([\d.]+)')
+            $sessMatch = [regex]::Match($content, 'Session creation time cost:\s+([\d.]+)\s+s')
+            $firstMatch = [regex]::Match($content, 'First inference time cost:\s+(\d+)\s+ms')
+            $cpuMatch = [regex]::Match($content, 'Avg CPU usage:\s+(\d+)\s+%')
+            $memMatch = [regex]::Match($content, 'Peak working set size:\s+(\d+)\s+bytes')
+            $sess = if ($sessMatch.Success) { $sessMatch.Groups[1].Value } else { "-" }
+            $first = if ($firstMatch.Success) { $firstMatch.Groups[1].Value } else { "-" }
+            $cpu = if ($cpuMatch.Success) { $cpuMatch.Groups[1].Value } else { "-" }
+            $memMB = if ($memMatch.Success) { "{0:F0}" -f ([double]$memMatch.Groups[1].Value / 1MB) } else { "-" }
             if ($qpsMatch.Success) {
               $qps = "{0:F2}" -f [double]$qpsMatch.Groups[1].Value
-              $tableRows += "| $model | $qps |`n"
+              $tableRows += "| $model | $qps | $sess | $first | $cpu | $memMB |`n"
             } else {
-              $tableRows += "| $model | failed |`n"
+              $tableRows += "| $model | failed | $sess | $first | $cpu | $memMB |`n"
             }
           }
-          if (-not $tableRows) { $tableRows = "| (no results) | - |`n" }
+          if (-not $tableRows) { $tableRows = "| (no results) | - | - | - | - | - |`n" }
 
           $header = "## MorphiZen EP Performance Results`n`n" +
-                    "| Model | QPS |`n" +
-                    "|-------|----:|`n"
+                    "| Model | QPS | Session (s) | 1st Infer (ms) | CPU% | Mem (MB) |`n" +
+                    "|-------|----:|----:|----:|----:|----:|`n"
           $footer = "`nRun: [${{ github.run_number }}]($runUrl) - Commit: ``$sha``"
           $summary = $header + $tableRows + $footer
 

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -558,7 +558,7 @@ jobs:
             $rel = $f.FullName.Substring($l2Root.Length).TrimStart('\', '/')
             $model = $rel -replace '\.txt$', '' -replace '\\', '/'
             $content = Get-Content $f.FullName -Raw
-            $l2Match = [regex]::Match($content, 'Combined L2 \(stacked diffs\):\s+([\d.eE+-]+)\s+\(total_elems:\s+(\d+),\s+skipped_nonfinite:\s+(\d+)\)')
+            $l2Match = [regex]::Match($content, 'Combined L2 \(stacked diffs\):\s+([\d.eE+-]+)\s+\(total_elems:\s+(\d+),.*?skipped_nonfinite:\s+(\d+)\)')
             $errMatch = [regex]::Match($content, '\[ERROR\]\s*(.+)')
             if ($l2Match.Success) {
               $l2val = [double]$l2Match.Groups[1].Value

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -231,22 +231,17 @@ int hipdnn_ep_state_init_with_fs(RuntimeState **out_state, void *fs,
 
   bool is_igpu = (prop.integrated == 1);
 
-  // Allow forcing VRAM allocation on iGPU for A/B testing.
-  // HIPDNN_EP_IGPU_USE_VRAM=1 → hipMalloc (dedicated VRAM) + hipMemcpy H2D
-  // Default (unset/0)         → hipHostMalloc (pinned host, GPU reads in-place)
-  const char *igpu_vram_env = getenv("HIPDNN_EP_IGPU_USE_VRAM");
-  bool force_vram = igpu_vram_env && igpu_vram_env[0] == '1';
-  if (is_igpu && force_vram) {
-    TIMING_LOG("[Session] iGPU: HIPDNN_EP_IGPU_USE_VRAM=1, using hipMalloc "
-               "(VRAM) path\n");
-    is_igpu = false;
-  }
+  // iGPU defaults to hipMalloc (dedicated VRAM) — +32% QPS over hipHostMalloc.
+  // CPU cannot write hipMalloc'd VRAM directly (0xC0000005), so iGPU uses the
+  // same staging buffer + hipMemcpy path as dGPU.
+  // Set HIPDNN_EP_IGPU_USE_HOST=1 to revert to legacy hipHostMalloc path.
+  const char *igpu_host_env = getenv("HIPDNN_EP_IGPU_USE_HOST");
+  bool force_host = is_igpu && igpu_host_env && igpu_host_env[0] == '1';
 
-  if (is_igpu) {
-    // iGPU: allocate pinned host memory. GPU reads the same physical DRAM
-    // directly -- no hipMemcpy needed. hipHostMalloc gives a reliable pinned
-    // allocation; hipHostRegister on mmap'd or VirtualAlloc'd memory is
-    // unreliable on some iGPU platforms (GPU reads zeros despite success).
+  if (force_host) {
+    // Legacy iGPU path: hipHostMalloc (pinned host memory).
+    TIMING_LOG("[Session] iGPU: HIPDNN_EP_IGPU_USE_HOST=1, using hipHostMalloc "
+               "(pinned host) path\n");
     if (hipHostMalloc(&state->gpu_constants_blob, total_size,
                       hipHostMallocDefault) != hipSuccess) {
       fprintf(stderr, "hipHostMalloc failed for constants blob (%zu bytes)\n",
@@ -280,15 +275,17 @@ int hipdnn_ep_state_init_with_fs(RuntimeState **out_state, void *fs,
     state->constants_blob_is_host = true;
 
   } else {
-    // dGPU: allocate in VRAM, upload once via hipMemcpy.
+    // VRAM path (default for both iGPU and dGPU): staging buffer + hipMemcpy.
+    if (is_igpu)
+      TIMING_LOG("[Session] iGPU: using hipMalloc (VRAM) + hipMemcpy path\n");
+
     const void *src = reader->mmap();
     void *cpu_buf = nullptr;
 
-    TIMING_LOG("[Session] dGPU path: mmap %s\n",
+    TIMING_LOG("[Session] VRAM path: mmap %s\n",
                src ? "succeeded" : "failed, using fread fallback");
 
     if (!src) {
-      // No mmap — read entire file into a staging buffer
       cpu_buf = malloc(total_size);
       if (!cpu_buf) {
         fprintf(stderr, "Failed to allocate staging buffer (%zu bytes)\n",

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -231,9 +231,9 @@ int hipdnn_ep_state_init_with_fs(RuntimeState **out_state, void *fs,
 
   bool is_igpu = (prop.integrated == 1);
 
-  // iGPU defaults to hipMalloc (dedicated VRAM) — +32% QPS over hipHostMalloc.
-  // CPU cannot write hipMalloc'd VRAM directly (0xC0000005), so iGPU uses the
-  // same staging buffer + hipMemcpy path as dGPU.
+  // iGPU defaults to hipMalloc (VRAM) + hipMemcpy H2D, same as dGPU.
+  // The one-time copy cost at session init is negligible for production
+  // workloads; VRAM access is faster than host memory on every inference.
   // Set HIPDNN_EP_IGPU_USE_HOST=1 to revert to legacy hipHostMalloc path.
   const char *igpu_host_env = getenv("HIPDNN_EP_IGPU_USE_HOST");
   bool force_host = is_igpu && igpu_host_env && igpu_host_env[0] == '1';

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -231,6 +231,17 @@ int hipdnn_ep_state_init_with_fs(RuntimeState **out_state, void *fs,
 
   bool is_igpu = (prop.integrated == 1);
 
+  // Allow forcing VRAM allocation on iGPU for A/B testing.
+  // HIPDNN_EP_IGPU_USE_VRAM=1 → hipMalloc (dedicated VRAM) + hipMemcpy H2D
+  // Default (unset/0)         → hipHostMalloc (pinned host, GPU reads in-place)
+  const char *igpu_vram_env = getenv("HIPDNN_EP_IGPU_USE_VRAM");
+  bool force_vram = igpu_vram_env && igpu_vram_env[0] == '1';
+  if (is_igpu && force_vram) {
+    TIMING_LOG("[Session] iGPU: HIPDNN_EP_IGPU_USE_VRAM=1, using hipMalloc "
+               "(VRAM) path\n");
+    is_igpu = false;
+  }
+
   if (is_igpu) {
     // iGPU: allocate pinned host memory. GPU reads the same physical DRAM
     // directly -- no hipMemcpy needed. hipHostMalloc gives a reliable pinned


### PR DESCRIPTION
## Summary

### CI: extended result tables (`windows-build.yml`)
- **L2 accuracy table**: add `Total Elems` and `Skipped NaN/Inf` columns — matches the format already used in `gpu-perf-accuracy-test.yml`
- **Perf table**: add `Session (s)`, `1st Infer (ms)`, `CPU%`, `Mem (MB)` columns for richer at-a-glance diagnostics

### Runtime: iGPU default switched to hipMalloc (VRAM) path (`hipdnn_ep_runtime_state.cpp`)

The original `hipHostMalloc` path was designed to optimize **session creation time** by skipping the H2D copy — the GPU reads weights directly from pinned host memory (shared DRAM on iGPU). However, this means every inference reads weights from the slower host-side memory path, hurting throughput.

For production workloads (session created once, inference run thousands of times), the one-time copy cost at session init is negligible compared to the per-inference benefit of GPU reading from VRAM. Switching to `hipMalloc` (VRAM) + a single `hipMemcpy` at session init gives the GPU fast local access to weights on every inference.

Changes:
- Switch iGPU default from `hipHostMalloc` (pinned host) to `hipMalloc` (VRAM) + `hipMemcpy H2D`
- Add `HIPDNN_EP_IGPU_USE_HOST=1` env var to revert to the legacy path if session creation latency matters

## Performance Comparison (StrixHalo)

Baseline: PR #110 Run 661 (commit `80a921e`, `hipHostMalloc` path)
New: PR #111 Run 666 (commit `ca5312d`, `hipMalloc` VRAM path)

| Model | QPS (base) | QPS (new) | QPS Δ | Session Δ | 1st Infer Δ | Mem Δ |
|-------|----:|----:|----:|----:|----:|----:|
| full_model_seq128 | 5.85 | **7.32** | **+25.1%** | 40.57s → 41.60s | 303ms → 273ms (-9.9%) | 15693MB → 15586MB (-107) |
| GroupQueryAttention_seq128 | 1214.69 | **1216.75** | **+0.2%** | 1.08s → 1.07s | 113ms → 113ms | 330MB → 266MB (-64) |
| matmul_down_seq128 | 630.60 | 609.41 | -3.4% | 1.55s → 1.57s | 58ms → 58ms | 370MB → 341MB (-29) |

> Results are machine- and model-dependent.

## Test plan
- [x] CI step summary shows new table columns correctly
- [x] iGPU VRAM path: improved inference throughput on StrixHalo, no L2 regression
- [ ] `HIPDNN_EP_IGPU_USE_HOST=1` reverts to legacy hipHostMalloc path