### PR TITLE
feat: PyTorch model support with hybrid GPU execution (Qwen3-0.6B & Qwen3.5-35B-A3B)

### DIFF
--- a/scripts/hip_torch/model_adapter.py
+++ b/scripts/hip_torch/model_adapter.py
@@ -233,9 +233,10 @@ class ModelAdapter:
                 layer.mlp = DllBackedModule(original, runners, weights)
             report.replaced_count += 1
 
-        # If max_offload, also offload attention projections
+        # If max_offload, also offload attention projections and LM head
         if self._max_offload and report.replaced_count > 0:
             self._offload_attention_projections(shapes, report)
+            self._offload_lm_head(shapes, report)
 
         report.compile_time = time.perf_counter() - t0
         return report
@@ -290,6 +291,39 @@ class ModelAdapter:
                 runners[list(runners.keys())[0]].input_metas[-1]["shape"]
             )
             log.info(f"Offloaded {proj_strategy.name} in all layers")
+
+    def _offload_lm_head(self, shapes, report):
+        """Offload the LM head (final linear: hidden→vocab) to GPU DLL."""
+        lm_head = getattr(self.model, "lm_head", None)
+        if lm_head is None or not isinstance(lm_head, nn.Linear):
+            return
+
+        strategy = LinearProjectionStrategy("lm_head", "lm_head")
+        hidden = lm_head.in_features
+        runners = {}
+
+        for label, seq_len in shapes.items():
+            runner = self._compile_for_shape(
+                strategy,
+                self.model,
+                hidden,
+                seq_len,
+                3,
+                f"lm_head_{label}",
+            )
+            if runner:
+                runners[label] = runner
+
+        if not runners:
+            report.errors.append("lm_head compilation failed")
+            return
+
+        weights = [lm_head.weight.data.t().contiguous().cpu()]
+        self.model.lm_head = DllBackedModule(lm_head, runners, weights)
+        report.dll_shapes["lm_head"] = list(
+            runners[list(runners.keys())[0]].input_metas[-1]["shape"]
+        )
+        log.info("Offloaded lm_head")
 
     def _compile_for_shape(
         self,


### PR DESCRIPTION
## Summary

This PR adds end-to-end PyTorch model support to the HIP MLIR compiler, enabling hybrid execution where compute-heavy ops run on compiled GPU DLLs while the rest executes on PyTorch.

### Architecture

```
                        PyTorch Model (HuggingFace)
                                  │
                          torch.export()
                                  │
                          FX Graph (ATen ops)
                                  │
                    ┌─────────────┴──────────────┐
                    │                            │
              Supported ops               Unsupported ops
          (linear, silu, mul,         (embedding, attention,
           rms_norm, matmul,           RMSNorm, masks, etc.)
           softmax, etc.)                     │
                    │                    PyTorch eager
              fx_to_mlir.py              execution
                    │                   (CPU or GPU)
            Torch dialect MLIR                │
                    │                         │
              hip-compiler.exe                │
                    │                         │
              GPU DLL (.dll)                  │
                    │                         │
              HipDllRunner                    │
              (ctypes load)                   │
                    │                         │
                    └─────────────┬───────────┘
                                  │
                          Model Output
                       (text generation)
```

### Key Components

| Component | Description |
|-----------|-------------|
| `scripts/fx_to_mlir.py` | Converts torch.export FX graphs to Torch dialect MLIR |
| `scripts/hip_backend.py` | torch.compile custom backend with op support classification |
| `scripts/hip_dll_runner.py` | ctypes-based in-process GPU DLL loader |
| `scripts/run_qwen_hybrid.py` | Top-level hybrid execution script |
| `scripts/run_qwen_pytorch.py` | PyTorch model validation |
| `scripts/test_numerical_accuracy.py` | GPU vs PyTorch numerical comparison |
| `scripts/test_dll_runner.py` | Full pipeline E2E test |
| `lib/Conversion/TorchToHip/*.cpp` | 12 new TorchToHip conversion patterns |
| `lib/Runtime/memref_copy.cpp` | GPU-aware strided memref copy |
| `lib/Runtime/real/silu.cpp` | SiLU activation runtime (MIOpen) |

### TorchToHip Conversion Patterns (30 ops)

**New patterns added in this PR:**
- `NormConversion.cpp`: `torch.aten.rms_norm` → `hip.rms_norm`
- `SliceCatConversion.cpp`: `slice.Tensor` → `tensor.extract_slice`, `cat.default` → `tensor.insert_slice`
- `GqaConversion.cpp`: `scaled_dot_product_attention` → `hip.gqa` (BSD + BHSD)
- `MatMulNBitsConversion.cpp`: `matmul_nbits` → `hip.matmul_nbits` (int4 quantized)
- `QMoEConversion.cpp`: `qmoe` → `hip.qmoe` (256-expert fused MoE)
- `MiscConversion.cpp`: `split.Tensor` → `tensor.extract_slice`

**Infrastructure fixes:**
- GPU-aware `memrefCopy` for strided device-to-device copies via `hipMemcpy2D`
- SiLU runtime via MIOpen (sigmoid + mul, fixes pre-existing unimplemented `hip_silu`)
- Fixed SiLU lowering (3-arg → 5-arg with num_elements/dtype)
- Fixed `torch.aten.linear` weight transpose (PyTorch `[N,K]` → hip.matmul `[K,N]`)
- Allow NULL filesystem in `inference_init` for models without constants
- Iterative dead-op cleanup for chained torch constant ops

### Execution Results

#### Qwen3-0.6B (Dense, 28 layers, GPU)

```
Prompt: "Explain quantum computing to a five year old in simple terms.
         Use examples they can understand."

Phase 1 — PyTorch Eager (cuda, AMD Radeon 8060S):
  Output:  Maybe include some of the key concepts like superposition
           and entanglement. Also, explain what quantum computers are
           different from regular computers. Use a friendly tone and
           avoid technical jargon...
  Tokens: 50 | Time: 1.28s | Tok/s: 39.0

Phase 2 — HIP DLL Compilation:
  Decode DLL:  [1, 1, 1024]  → 2.6s, 366 KB
  Prefill DLL: [1, 19, 1024] → 2.6s, 366 KB

Phase 3 — Hybrid (MLP on GPU DLL, rest on PyTorch GPU):
  Output:  [identical to Phase 1]
  Tokens: 50 | Time: 3.68s | Tok/s: 13.6
  MLP offload: 1400/1400 calls (100%)
  Output match: YES
```

#### Qwen3.5-35B-A3B (MoE, 256 experts, 40 layers, CPU+GPU)

```
Prompt: "Explain quantum computing to a five year old in simple terms.
         Use examples they can understand."

Phase 1 — PyTorch Eager (cpu):
  Output:  <think></think>
           Imagine you have a big box of LEGO bricks.
           ### The Normal Computer (The "One-At-A-Time" Builder)
           A normal computer, like the tablet you use to watch
           cartoons, is like a...
  Tokens: 50 | Time: 23.73s | Tok/s: 2.1

Phase 2 — HIP DLL Compilation:
  Decode DLL:  [1, 2048]  → 2.6s, 366 KB
  Prefill DLL: [19, 2048] → 2.7s, 366 KB
  Replaced shared_expert in 40/40 layers

Phase 3 — Hybrid (shared_expert on GPU DLL, rest on PyTorch CPU):
  Output:  [identical to Phase 1]
  Tokens: 50 | Time: 20.05s | Tok/s: 2.5 (+19% vs baseline)
  MLP offload: 2000/2000 calls (100%)
  Output match: YES
```

### Numerical Accuracy

Validated with SmallTransformerBlock (RMSNorm + SwiGLU MLP + residual):
- Max relative error: **0.40%** (f16 precision)
- GPU DLL output matches PyTorch reference token-for-token

### Test Results

58/59 ctest passing (only pre-existing `test_reshape_model` segfault):
- 91 LIT tests: all pass
- 10 new E2E torch tests: all compile + execute on GPU
  - `test_torch_rms_norm_model`, `test_torch_rope_model`
  - `test_torch_sdpa_model`, `test_torch_qmoe_model`
  - `test_torch_gdn_ops_model`, `test_torch_add/mul/matmul/sigmoid_model`

## Test plan
- [x] `ctest --verbose` — 58/59 passing
- [x] `python scripts/test_dll_runner.py` — full pipeline E2E
- [x] `python scripts/test_numerical_accuracy.py` — GPU vs PyTorch accuracy
- [x] `python scripts/run_qwen_hybrid.py --model Qwen/Qwen3-0.6B` — dense model
- [x] `python scripts/run_qwen_hybrid.py --model Qwen/Qwen3.5-35B-A3B --device cpu` — 35B MoE model

🤖 Generated with [Claude Code](https://claude.com/claude-code)