### PR TITLE
fix: support multi-index Gather kernel for embedding lookups

### DIFF
--- a/3rd-party/custom_kernels/hip/gather_kernel.hip
+++ b/3rd-party/custom_kernels/hip/gather_kernel.hip
@@ -10,26 +10,29 @@
 #include <cstdint>
 #include <cstdio>
 
-// Generic gather kernel for axis=0 with a single scalar index.
-// T is the element type used for copying (uint16_t, uint32_t, int64_t).
-// Indices are always i64.
+// Generic gather kernel for axis=0 with arbitrary number of indices.
+// Each thread copies one element of the output tensor.
+// Thread tid maps to: index_idx = tid / slice_size, offset = tid % slice_size.
+// output[tid] = data[indices[index_idx] * slice_size + offset]
 template <typename T>
 __global__ void gather_axis0_kernel(
     const T* __restrict__ data,
     const int64_t* __restrict__ indices,
     T* __restrict__ output,
     int64_t slice_size,
-    int64_t data_axis_size) {
-  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-  if (idx < slice_size) {
-    int64_t index_val = indices[0];
+    int64_t data_axis_size,
+    int64_t total_elements) {
+  int64_t tid = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (tid < total_elements) {
+    int64_t index_idx = tid / slice_size;
+    int64_t offset = tid % slice_size;
+    int64_t index_val = indices[index_idx];
     if (index_val < 0) index_val += data_axis_size;
     if (index_val < 0 || index_val >= data_axis_size) {
-      output[idx] = T(0);
+      output[tid] = T(0);
       return;
     }
-    int64_t src_offset = index_val * slice_size + idx;
-    output[idx] = data[src_offset];
+    output[tid] = data[index_val * slice_size + offset];
   }
 }
 
@@ -40,6 +43,7 @@ extern "C" int hip_gather(
     void* output,
     int64_t axis,
     int64_t data_num_elements,
+    int64_t indices_num_elements,
     int64_t output_num_elements,
     int element_size_bytes) {
   if (output_num_elements <= 0) return 0;
@@ -56,15 +60,24 @@ extern "C" int hip_gather(
     return -1;
   }
 
-  int64_t slice_size = output_num_elements;
-  int64_t data_axis_size = data_num_elements / slice_size;
+  // For axis=0: output = [indices_shape..., data_shape[1:]]
+  // slice_size = product of data dimensions after axis 0
+  // data_axis_size = data_shape[0]
+  int64_t slice_size = (indices_num_elements > 0)
+      ? output_num_elements / indices_num_elements
+      : output_num_elements;
+  int64_t data_axis_size = (slice_size > 0)
+      ? data_num_elements / slice_size
+      : 0;
 
   CUSTOM_KERNELS_DEBUG_LOG("[custom_kernels] hip_gather: axis=0, elem_size=%d, "
-          "data_num=%lld, output_num=%lld, data_axis_size=%lld, "
-          "grid=%d, block=%d\n",
+          "data_num=%lld, indices_num=%lld, output_num=%lld, "
+          "slice_size=%lld, data_axis_size=%lld, grid=%d, block=%d\n",
           element_size_bytes,
-          (long long)data_num_elements, (long long)output_num_elements,
-          (long long)data_axis_size, grid_size, kBlockSize);
+          (long long)data_num_elements, (long long)indices_num_elements,
+          (long long)output_num_elements,
+          (long long)slice_size, (long long)data_axis_size,
+          grid_size, kBlockSize);
 
   switch (element_size_bytes) {
     case 2:
@@ -73,7 +86,7 @@ extern "C" int hip_gather(
                          static_cast<const uint16_t*>(data),
                          static_cast<const int64_t*>(indices),
                          static_cast<uint16_t*>(output),
-                         slice_size, data_axis_size);
+                         slice_size, data_axis_size, output_num_elements);
       break;
     case 4:
       hipLaunchKernelGGL(gather_axis0_kernel<uint32_t>,
@@ -81,7 +94,7 @@ extern "C" int hip_gather(
                          static_cast<const uint32_t*>(data),
                          static_cast<const int64_t*>(indices),
                          static_cast<uint32_t*>(output),
-                         slice_size, data_axis_size);
+                         slice_size, data_axis_size, output_num_elements);
       break;
     case 8:
       hipLaunchKernelGGL(gather_axis0_kernel<int64_t>,
@@ -89,7 +102,7 @@ extern "C" int hip_gather(
                          static_cast<const int64_t*>(data),
                          static_cast<const int64_t*>(indices),
                          static_cast<int64_t*>(output),
-                         slice_size, data_axis_size);
+                         slice_size, data_axis_size, output_num_elements);
       break;
     default:
       fprintf(stderr,

--- a/3rd-party/custom_kernels/include/hip_custom_kernels.h
+++ b/3rd-party/custom_kernels/include/hip_custom_kernels.h
@@ -259,13 +259,14 @@ int hip_cast(
  *   stream              - hipStream_t cast to void*
  *   data                - GPU pointer to source tensor
  *   indices             - GPU pointer to index tensor (i64 values)
- *   output              - GPU pointer to output
- *   axis                - axis along which to gather
- *   data_num_elements   - total elements in data tensor
- *   output_num_elements - total elements in output tensor
- *   element_size_bytes  - byte size per element (used for raw copy)
+ *   output               - GPU pointer to output
+ *   axis                 - axis along which to gather
+ *   data_num_elements    - total elements in data tensor
+ *   indices_num_elements - total elements in indices tensor
+ *   output_num_elements  - total elements in output tensor
+ *   element_size_bytes   - byte size per element (used for raw copy)
  *
- * Currently supports: axis=0, scalar (single-element) index
+ * Currently supports: axis=0
  * Supported element sizes: 2 (f16/bf16), 4 (f32/i32), 8 (i64/f64)
  * Returns: 0 on success, non-zero on failure
  */
@@ -276,6 +277,7 @@ int hip_gather(
     void* output,
     int64_t axis,
     int64_t data_num_elements,
+    int64_t indices_num_elements,
     int64_t output_num_elements,
     int element_size_bytes);
 

--- a/lib/Conversion/HipToLLVM/GatherLowering.cpp
+++ b/lib/Conversion/HipToLLVM/GatherLowering.cpp
@@ -32,6 +32,11 @@ struct GatherOpLowering : public ConvertOpToLLVMPattern<GatherOp> {
     Value dataNumElementsVal =
         computeNumElements(dataType, adaptor.getData(), rewriter, loc);
 
+    // Compute indices_num_elements
+    auto indicesType = cast<MemRefType>(op.getIndices().getType());
+    Value indicesNumElementsVal =
+        computeNumElements(indicesType, adaptor.getIndices(), rewriter, loc);
+
     // Compute output_num_elements
     auto outputType = cast<MemRefType>(op.getOutput().getType());
     Value outputNumElementsVal =
@@ -49,9 +54,11 @@ struct GatherOpLowering : public ConvertOpToLLVMPattern<GatherOp> {
 
     // int wrap_gather(RuntimeState* state, void* data, void* indices,
     //                 void* output, int64_t axis, int64_t data_num_elements,
+    //                 int64_t indices_num_elements,
     //                 int64_t output_num_elements, int64_t element_size_bytes)
-    SmallVector<Type, 8> paramTypes = {ptrType, ptrType, ptrType, ptrType,
-                                       i64Type, i64Type, i64Type, i64Type};
+    SmallVector<Type, 9> paramTypes = {ptrType, ptrType, ptrType,
+                                       ptrType, i64Type, i64Type,
+                                       i64Type, i64Type, i64Type};
 
     FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
         rewriter, module, kWrapGather, paramTypes, i32Type);
@@ -64,6 +71,7 @@ struct GatherOpLowering : public ConvertOpToLLVMPattern<GatherOp> {
                                outputPtr,
                                axisVal,
                                dataNumElementsVal,
+                               indicesNumElementsVal,
                                outputNumElementsVal,
                                elemSizeVal};
 

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -460,7 +460,8 @@ int wrap_elementwise_sub(RuntimeState *state, void *lhs, void *rhs,
 // Gather operation wrapper
 int wrap_gather(RuntimeState *state, void *data, void *indices, void *output,
                 int64_t axis, int64_t data_num_elements,
-                int64_t output_num_elements, int64_t element_size_bytes);
+                int64_t indices_num_elements, int64_t output_num_elements,
+                int64_t element_size_bytes);
 
 // ReduceSum operation wrapper
 int wrap_reduce_sum(RuntimeState *state, void *data, void *axes, void *output,

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -585,16 +585,19 @@ int wrap_elementwise_sub(RuntimeState *state, void *lhs, void *rhs,
 
 int wrap_gather(RuntimeState *state, void *data, void *indices, void *output,
                 int64_t axis, int64_t data_num_elements,
-                int64_t output_num_elements, int64_t element_size_bytes) {
+                int64_t indices_num_elements, int64_t output_num_elements,
+                int64_t element_size_bytes) {
   if (!state) {
     fprintf(stderr, "Invalid state in wrap_gather\n");
     return -1;
   }
 
   MOCK_PRINT("[MOCK] wrap_gather(axis=%lld, data_num_elements=%lld, "
-             "output_num_elements=%lld, element_size=%lld)\n",
+             "indices_num_elements=%lld, output_num_elements=%lld, "
+             "element_size=%lld)\n",
              (long long)axis, (long long)data_num_elements,
-             (long long)output_num_elements, (long long)element_size_bytes);
+             (long long)indices_num_elements, (long long)output_num_elements,
+             (long long)element_size_bytes);
 
   return 0;
 }

--- a/lib/Runtime/real/gather.cpp
+++ b/lib/Runtime/real/gather.cpp
@@ -11,7 +11,8 @@
 
 int wrap_gather(RuntimeState *state, void *data, void *indices, void *output,
                 int64_t axis, int64_t data_num_elements,
-                int64_t output_num_elements, int64_t element_size_bytes) {
+                int64_t indices_num_elements, int64_t output_num_elements,
+                int64_t element_size_bytes) {
   if (!state || !data || !indices || !output) {
     RUNTIME_DEBUG_LOG("[REAL] wrap_gather: null argument\n");
     return -1;
@@ -20,11 +21,13 @@ int wrap_gather(RuntimeState *state, void *data, void *indices, void *output,
   void *stream = hipdnn_ep_state_get_stream(state);
 
   RUNTIME_DEBUG_LOG(
-      "[REAL] wrap_gather: axis=%lld, data_num=%lld, output_num=%lld, "
-      "elem_size=%lld -> calling hip_gather\n",
+      "[REAL] wrap_gather: axis=%lld, data_num=%lld, indices_num=%lld, "
+      "output_num=%lld, elem_size=%lld -> calling hip_gather\n",
       (long long)axis, (long long)data_num_elements,
-      (long long)output_num_elements, (long long)element_size_bytes);
+      (long long)indices_num_elements, (long long)output_num_elements,
+      (long long)element_size_bytes);
 
   return hip_gather(stream, data, indices, output, axis, data_num_elements,
-                    output_num_elements, static_cast<int>(element_size_bytes));
+                    indices_num_elements, output_num_elements,
+                    static_cast<int>(element_size_bytes));
 }

--- a/test/lit/Conversion/hip-to-llvm/test_gather.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_gather.mlir
@@ -17,8 +17,8 @@ module {
 }
 
 // CHECK-LABEL: llvm.func @test_gather_lowering
-// CHECK: llvm.call @wrap_gather({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64) -> i32
+// CHECK: llvm.call @wrap_gather({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64) -> i32
 
-// Verify 8 parameters:
+// Verify 9 parameters:
 // - 4 pointers: state, data, indices, output
-// - 4 i64 values: axis=0, data_num_elements=12, output_num_elements=8, element_size_bytes=4
+// - 5 i64 values: axis, data_num_elements, indices_num_elements, output_num_elements, element_size_bytes

--- a/test/lit/Conversion/hip-to-llvm/test_gather.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_gather.mlir
@@ -4,21 +4,57 @@
 // RUN: hip-mlir-opt --convert-hip-to-llvm %s | FileCheck %s
 
 module {
-  func.func @test_gather_lowering(%ctx: !hip.context,
-                                   %data: memref<3x4xf32, 1>,
-                                   %indices: memref<2xi64, 1>,
-                                   %output: memref<2x4xf32, 1>) {
+  // Multi-index gather: indices has >1 element (embedding lookup pattern)
+  // data=[3x4xf32], indices=[2xi64] -> output=[2x4xf32]
+  // data_num=12, indices_num=2, output_num=8, elem_size=4
+  func.func @test_gather_multi_index(%ctx: !hip.context,
+                                      %data: memref<3x4xf32, 1>,
+                                      %indices: memref<2xi64, 1>,
+                                      %output: memref<2x4xf32, 1>) {
     hip.gather(%ctx)
         ins(%data, %indices : memref<3x4xf32, 1>, memref<2xi64, 1>)
         outs(%output : memref<2x4xf32, 1>)
         {axis = 0 : i64}
     return
   }
+
+  // Scalar-index gather: indices has exactly 1 element
+  // data=[2xi64], indices=[1xi64] -> output=[1xi64]
+  // data_num=2, indices_num=1, output_num=1, elem_size=8
+  func.func @test_gather_scalar_index(%ctx: !hip.context,
+                                       %data: memref<2xi64, 1>,
+                                       %indices: memref<1xi64, 1>,
+                                       %output: memref<1xi64, 1>) {
+    hip.gather(%ctx)
+        ins(%data, %indices : memref<2xi64, 1>, memref<1xi64, 1>)
+        outs(%output : memref<1xi64, 1>)
+        {axis = 0 : i64}
+    return
+  }
+
+  // Embedding-shaped gather: realistic LLM vocab lookup
+  // data=[32000x128xf16], indices=[128xi64] -> output=[128x128xf16]
+  // data_num=4096000, indices_num=128, output_num=16384, elem_size=2
+  func.func @test_gather_embedding(%ctx: !hip.context,
+                                    %data: memref<32000x128xf16, 1>,
+                                    %indices: memref<128xi64, 1>,
+                                    %output: memref<128x128xf16, 1>) {
+    hip.gather(%ctx)
+        ins(%data, %indices : memref<32000x128xf16, 1>, memref<128xi64, 1>)
+        outs(%output : memref<128x128xf16, 1>)
+        {axis = 0 : i64}
+    return
+  }
 }
 
-// CHECK-LABEL: llvm.func @test_gather_lowering
+// All three variants lower to the same 9-parameter wrap_gather call:
+// 4 pointers (state, data, indices, output) + 5 i64 (axis, data_num, indices_num, output_num, elem_size)
+
+// CHECK-LABEL: llvm.func @test_gather_multi_index
 // CHECK: llvm.call @wrap_gather({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64) -> i32
 
-// Verify 9 parameters:
-// - 4 pointers: state, data, indices, output
-// - 5 i64 values: axis, data_num_elements, indices_num_elements, output_num_elements, element_size_bytes
+// CHECK-LABEL: llvm.func @test_gather_scalar_index
+// CHECK: llvm.call @wrap_gather({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64) -> i32
+
+// CHECK-LABEL: llvm.func @test_gather_embedding
+// CHECK: llvm.call @wrap_gather({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64) -> i32


### PR DESCRIPTION
## Summary

- Fix the Gather HIP kernel to support arbitrary numbers of indices (multi-index), not just scalar (single-element) indices.
- Previously, Gather with more than 1 index produced all-zero outputs because the kernel hardcoded `indices[0]` and only copied one slice. This broke embedding lookups with batch token IDs (e.g., seq_len > 1).

## Changes Overview

### HIP Kernel (`3rd-party/custom_kernels/hip/gather_kernel.hip`)
- Generalize `gather_axis0_kernel` from single-index to multi-index: each thread maps to an output element via `tid / slice_size` (index selector) and `tid % slice_size` (offset within slice).
- Add `indices_num_elements` parameter to `hip_gather` to correctly compute `slice_size` and `data_axis_size` from element counts.
- Add defensive zero-division guards for `slice_size` and `data_axis_size` computation.

### Kernel Header (`3rd-party/custom_kernels/include/hip_custom_kernels.h`)
- Add `indices_num_elements` to `hip_gather` signature and update doc comment (remove "scalar (single-element) index" limitation).

### MLIR Lowering (`lib/Conversion/HipToLLVM/GatherLowering.cpp`)
- Compute `indices_num_elements` via `computeNumElements` and pass it as the new 7th argument to `wrap_gather`.
- Update function signature from 8 to 9 parameters.

### Runtime Wrapper (`lib/Runtime/real/gather.cpp`)
- Add `indices_num_elements` parameter and forward it to `hip_gather`.

### Runtime Header (`lib/Runtime/hipdnn_ep_runtime.h`)
- Update `wrap_gather` declaration to include `indices_num_elements`.

### Mock Runtime (`lib/Runtime/mock/mock_gpu.cpp`)
- Mirror updated `wrap_gather` signature and include `indices_num_elements` in mock print output.

### LIT Test (`test/lit/Conversion/hip-to-llvm/test_gather.mlir`)
- Extend from a single test case to three: multi-index (`memref<2xi64>`), scalar-index (`memref<1xi64>`), and embedding-shaped (`memref<128xi64>` into `memref<32000x128xf16>`).
- Each verifies the 9-parameter `wrap_gather` call signature.

## Test plan

- [x] Build verified (no errors, no check-goto warnings)
- [x] LIT conversion tests passed (3 gather tests: onnx-to-hip, hip-to-llvm, e2e)
- [x] Pre-commit checks passed
