### PR TITLE
fix: use fp32 accumulation for GQA Score GEMM to prevent NaN

### DIFF
--- a/3rd-party/custom_kernels/hip/gqa_kernel.hip
+++ b/3rd-party/custom_kernels/hip/gqa_kernel.hip
@@ -423,6 +423,29 @@ __global__ void causal_mask_kernel(
 }
 
 // -------------------------------------------------------------------------
+// Step 9a (fp32 variant): Causal Mask on fp32 Score matrix
+// -------------------------------------------------------------------------
+
+__global__ void causal_mask_f32_kernel(
+    float* __restrict__ S,
+    int skv, int sq, int batch_stride, int past_len,
+    int local_window_size) {
+  const int head = __builtin_amdgcn_readfirstlane(blockIdx.y);
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int total = skv * sq;
+  if (idx >= total) return;
+
+  int k = idx % skv;
+  int q = idx / skv;
+  int abs_q = past_len + q;
+  if (k > abs_q) {
+    S[(size_t)head * batch_stride + (size_t)q * skv + k] = -INFINITY;
+  } else if (local_window_size > 0 && k < abs_q - local_window_size + 1) {
+    S[(size_t)head * batch_stride + (size_t)q * skv + k] = -INFINITY;
+  }
+}
+
+// -------------------------------------------------------------------------
 // Step 9b: Column-wise Softmax (numerically stable, in-place)
 // -------------------------------------------------------------------------
 // Per column q: softmax(S[:,q]) = exp(S[:,q]-max) / sum(exp(S[:,q]-max))
@@ -629,6 +652,20 @@ extern "C" int hip_gqa_split_qkv(
   return hipSuccess;
 }
 
+// Step 9a (fp32 variant): Causal mask on fp32 Score matrix
+extern "C" int hip_gqa_causal_mask_f32(
+    void* stream_ptr, void* S,
+    int total_heads, int skv, int sq,
+    int batch_stride, int past_len, int local_window_size) {
+  hipStream_t stream = static_cast<hipStream_t>(stream_ptr);
+  int total = skv * sq;
+  int blocksX = (total + GQA_THREADS - 1) / GQA_THREADS;
+  causal_mask_f32_kernel<<<dim3(blocksX, total_heads), GQA_THREADS, 0, stream>>>(
+      static_cast<float*>(S),
+      skv, sq, batch_stride, past_len, local_window_size);
+  return hipSuccess;
+}
+
 // Step 9a: Causal mask
 extern "C" int hip_gqa_causal_mask(
     void* stream_ptr, void* S,
@@ -640,6 +677,96 @@ extern "C" int hip_gqa_causal_mask(
   causal_mask_kernel<<<dim3(blocksX, total_heads), GQA_THREADS, 0, stream>>>(
       static_cast<__half*>(S),
       skv, sq, batch_stride, past_len, local_window_size);
+  return hipSuccess;
+}
+
+// Step 9b (fp32->fp16 variant): Softmax reading fp32 scores, writing fp16 output
+// Avoids inf-inf=NaN by operating entirely in fp32 before the final fp16 store.
+
+__global__ void softmax_f32_to_f16_kernel(
+    const float* input, __half* output,
+    int rows, int cols, int input_batch_stride, int output_batch_stride,
+    const __half* head_sink, int num_heads, int use_smooth_softmax) {
+  const int linear = __builtin_amdgcn_readfirstlane(blockIdx.x);
+  const int head = __builtin_amdgcn_readfirstlane(linear / cols);
+  const int col  = __builtin_amdgcn_readfirstlane(linear % cols);
+  const float* in_col = input + (size_t)head * input_batch_stride + (size_t)col * rows;
+  __half* out_col = output + (size_t)head * output_batch_stride + (size_t)col * rows;
+
+  const int tid = threadIdx.x;
+  const int wave_id = tid / WAVE_SIZE;
+  const int num_waves = blockDim.x / WAVE_SIZE;
+
+  extern __shared__ float smem[];
+
+  // Pass 1: find max (fp32, no overflow risk)
+  float local_max = -INFINITY;
+  for (int i = tid; i < rows; i += blockDim.x)
+    local_max = fmaxf(local_max, in_col[i]);
+
+  local_max = warp_reduce_max(local_max);
+  if (tid % WAVE_SIZE == 0)
+    smem[wave_id] = local_max;
+  __syncthreads();
+
+  if (tid < WAVE_SIZE) {
+    float v = (tid < num_waves) ? smem[tid] : -INFINITY;
+    v = warp_reduce_max(v);
+    smem[0] = v;
+  }
+  __syncthreads();
+  float max_val = smem[0];
+
+  // Pass 2: exp2f + sum (fp32 throughout, values recomputed in Pass 3)
+  float local_sum = 0.0f;
+  for (int i = tid; i < rows; i += blockDim.x)
+    local_sum += exp2f((in_col[i] - max_val) * LOG2E);
+
+  local_sum = warp_reduce_sum(local_sum);
+  if (tid % WAVE_SIZE == 0)
+    smem[wave_id] = local_sum;
+  __syncthreads();
+
+  if (tid < WAVE_SIZE) {
+    float v = (tid < num_waves) ? smem[tid] : 0.0f;
+    v = warp_reduce_sum(v);
+    smem[0] = v;
+  }
+  __syncthreads();
+  float sum_val = smem[0];
+
+  if (head_sink != nullptr) {
+    int actual_head = head % num_heads;
+    float s = __half2float(head_sink[actual_head]);
+    sum_val += expf(s - max_val);
+  } else if (use_smooth_softmax) {
+    sum_val += expf(0.0f - max_val);
+  }
+
+  // Pass 3: normalize and write fp16 output
+  float inv_sum = 1.0f / sum_val;
+  for (int i = tid; i < rows; i += blockDim.x) {
+    float e = exp2f((in_col[i] - max_val) * LOG2E);
+    out_col[i] = __float2half(e * inv_sum);
+  }
+}
+
+extern "C" int hip_gqa_softmax_f32_to_f16(
+    void* stream_ptr, const void* input_f32, void* output_f16,
+    int total_head_queries, int rows, int cols,
+    int input_batch_stride, int output_batch_stride,
+    const void* head_sink, int num_heads, int use_smooth_softmax) {
+  hipStream_t stream = static_cast<hipStream_t>(stream_ptr);
+  int threads = 32;
+  while (threads < std::min(rows, 256)) threads *= 2;
+  if (threads > 256) threads = 256;
+  int num_waves = threads / WAVE_SIZE;
+  softmax_f32_to_f16_kernel<<<total_head_queries, threads,
+                              num_waves * sizeof(float), stream>>>(
+      static_cast<const float*>(input_f32),
+      static_cast<__half*>(output_f16),
+      rows, cols, input_batch_stride, output_batch_stride,
+      static_cast<const __half*>(head_sink), num_heads, use_smooth_softmax);
   return hipSuccess;
 }
 

--- a/3rd-party/custom_kernels/hip/gqa_kernel.hip
+++ b/3rd-party/custom_kernels/hip/gqa_kernel.hip
@@ -393,41 +393,33 @@ __global__ void split_qkv_kernel(
 // -------------------------------------------------------------------------
 // Masks future positions so each query attends only to past + itself.
 //   Score matrix: col-major [skv, sq] per head
-//   S[k, q] = -65504 (FP16 -inf) where k > past_len + q
+//   S[k, q] = -inf where k > past_len + q
 //
 // When local_window_size > 0, also masks distant past positions:
-//   S[k, q] = -65504 where k < past_len + q - local_window_size + 1
+//   S[k, q] = -inf where k < past_len + q - local_window_size + 1
 //
 // blockIdx.y = head (0..B*H-1)
+//
+// Templated on T ∈ {__half, float}. The mask value is -65504 for fp16
+// (largest finite negative) and -INFINITY for fp32.
 // -------------------------------------------------------------------------
 
-__global__ void causal_mask_kernel(
-    __half* __restrict__ S,
-    int skv, int sq, int batch_stride, int past_len,
-    int local_window_size) {
-  const int head = __builtin_amdgcn_readfirstlane(blockIdx.y);
-  int idx = blockIdx.x * blockDim.x + threadIdx.x;
-  int total = skv * sq;
-  if (idx >= total) return;
+template <typename T>
+__device__ __forceinline__ T causal_mask_fill_value();
 
-  int k = idx % skv;
-  int q = idx / skv;
-  int abs_q = past_len + q;
-  if (k > abs_q) {
-    S[(size_t)head * batch_stride + (size_t)q * skv + k] =
-        __float2half(-65504.0f);
-  } else if (local_window_size > 0 && k < abs_q - local_window_size + 1) {
-    S[(size_t)head * batch_stride + (size_t)q * skv + k] =
-        __float2half(-65504.0f);
-  }
+template <>
+__device__ __forceinline__ __half causal_mask_fill_value<__half>() {
+  return __float2half(-65504.0f);
 }
 
-// -------------------------------------------------------------------------
-// Step 9a (fp32 variant): Causal Mask on fp32 Score matrix
-// -------------------------------------------------------------------------
+template <>
+__device__ __forceinline__ float causal_mask_fill_value<float>() {
+  return -INFINITY;
+}
 
-__global__ void causal_mask_f32_kernel(
-    float* __restrict__ S,
+template <typename T>
+__global__ void causal_mask_kernel_impl(
+    T* __restrict__ S,
     int skv, int sq, int batch_stride, int past_len,
     int local_window_size) {
   const int head = __builtin_amdgcn_readfirstlane(blockIdx.y);
@@ -438,10 +430,11 @@ __global__ void causal_mask_f32_kernel(
   int k = idx % skv;
   int q = idx / skv;
   int abs_q = past_len + q;
+  const T fill = causal_mask_fill_value<T>();
   if (k > abs_q) {
-    S[(size_t)head * batch_stride + (size_t)q * skv + k] = -INFINITY;
+    S[(size_t)head * batch_stride + (size_t)q * skv + k] = fill;
   } else if (local_window_size > 0 && k < abs_q - local_window_size + 1) {
-    S[(size_t)head * batch_stride + (size_t)q * skv + k] = -INFINITY;
+    S[(size_t)head * batch_stride + (size_t)q * skv + k] = fill;
   }
 }
 
@@ -652,21 +645,8 @@ extern "C" int hip_gqa_split_qkv(
   return hipSuccess;
 }
 
-// Step 9a (fp32 variant): Causal mask on fp32 Score matrix
-extern "C" int hip_gqa_causal_mask_f32(
-    void* stream_ptr, void* S,
-    int total_heads, int skv, int sq,
-    int batch_stride, int past_len, int local_window_size) {
-  hipStream_t stream = static_cast<hipStream_t>(stream_ptr);
-  int total = skv * sq;
-  int blocksX = (total + GQA_THREADS - 1) / GQA_THREADS;
-  causal_mask_f32_kernel<<<dim3(blocksX, total_heads), GQA_THREADS, 0, stream>>>(
-      static_cast<float*>(S),
-      skv, sq, batch_stride, past_len, local_window_size);
-  return hipSuccess;
-}
+// Step 9a: Causal mask launchers (fp16 and fp32 instantiations)
 
-// Step 9a: Causal mask
 extern "C" int hip_gqa_causal_mask(
     void* stream_ptr, void* S,
     int total_heads, int skv, int sq,
@@ -674,8 +654,21 @@ extern "C" int hip_gqa_causal_mask(
   hipStream_t stream = static_cast<hipStream_t>(stream_ptr);
   int total = skv * sq;
   int blocksX = (total + GQA_THREADS - 1) / GQA_THREADS;
-  causal_mask_kernel<<<dim3(blocksX, total_heads), GQA_THREADS, 0, stream>>>(
+  causal_mask_kernel_impl<__half><<<dim3(blocksX, total_heads), GQA_THREADS, 0, stream>>>(
       static_cast<__half*>(S),
+      skv, sq, batch_stride, past_len, local_window_size);
+  return hipSuccess;
+}
+
+extern "C" int hip_gqa_causal_mask_f32(
+    void* stream_ptr, void* S,
+    int total_heads, int skv, int sq,
+    int batch_stride, int past_len, int local_window_size) {
+  hipStream_t stream = static_cast<hipStream_t>(stream_ptr);
+  int total = skv * sq;
+  int blocksX = (total + GQA_THREADS - 1) / GQA_THREADS;
+  causal_mask_kernel_impl<float><<<dim3(blocksX, total_heads), GQA_THREADS, 0, stream>>>(
+      static_cast<float*>(S),
       skv, sq, batch_stride, past_len, local_window_size);
   return hipSuccess;
 }

--- a/3rd-party/custom_kernels/include/hip_custom_kernels.h
+++ b/3rd-party/custom_kernels/include/hip_custom_kernels.h
@@ -189,6 +189,13 @@ int hip_gqa_causal_mask(
     int total_heads, int skv, int sq,
     int batch_stride, int past_len, int local_window_size);
 
+/* Causal mask on fp32 Score matrix.  Same semantics as hip_gqa_causal_mask
+ * but operates on float* and writes -INFINITY instead of -65504. */
+int hip_gqa_causal_mask_f32(
+    void* stream, void* S,
+    int total_heads, int skv, int sq,
+    int batch_stride, int past_len, int local_window_size);
+
 /* Column-wise softmax in-place. One threadblock per (head, query).
  * Smooth softmax is activated when head_sink is non-null OR use_smooth_softmax
  * is set.  When head_sink is non-null, uses per-head sink factors:
@@ -200,6 +207,15 @@ int hip_gqa_softmax_inplace(
     int total_head_queries, int rows, int cols,
     int batch_stride, const void* head_sink, int num_heads,
     int use_smooth_softmax);
+
+/* Column-wise softmax: fp32 input -> fp16 output.
+ * Reads fp32 Score matrix (no fp16 overflow/inf), writes fp16 probabilities.
+ * input_batch_stride is in float elements, output_batch_stride in half elements. */
+int hip_gqa_softmax_f32_to_f16(
+    void* stream, const void* input_f32, void* output_f16,
+    int total_head_queries, int rows, int cols,
+    int input_batch_stride, int output_batch_stride,
+    const void* head_sink, int num_heads, int use_smooth_softmax);
 
 /* Fused GQA decode (sq == 1, d in {64, 128, 256}): single-token attention
  * via cooperative dot product + online softmax in log2e space, one block

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -51,9 +51,10 @@ static hipblasStatus_t setLayoutBatch(hipblasLtMatrixLayout_t layout,
 struct GqaGemmKey {
   int64_t m, n, k, batch;
   bool transA; // true for Score GEMM (K^T * Q), false for Value GEMM (V * S)
+  bool outputFp32; // true to use HIP_R_32F for C/D layouts (Score GEMM)
   bool operator==(const GqaGemmKey &o) const {
     return m == o.m && n == o.n && k == o.k && batch == o.batch &&
-           transA == o.transA;
+           transA == o.transA && outputFp32 == o.outputFp32;
   }
 };
 
@@ -65,6 +66,7 @@ struct GqaGemmKeyHash {
     hash_combine_val(h, k.k);
     hash_combine_val(h, k.batch);
     hash_combine_val(h, k.transA);
+    hash_combine_val(h, k.outputFp32);
     return h;
   }
 };
@@ -130,11 +132,10 @@ static const GqaGemmCacheEntry *queryOrCreateGemmState(hipblasLtHandle_t handle,
         hipblasLtMatrixLayoutCreate(&entry.layB, HIP_R_16F, k, n, k));
     GQA_CACHE_CHECK(setLayoutBatch(entry.layB, batch, n * k));
 
-    GQA_CACHE_CHECK(
-        hipblasLtMatrixLayoutCreate(&entry.layC, HIP_R_16F, m, n, m));
+    hipDataType outType = key.outputFp32 ? HIP_R_32F : HIP_R_16F;
+    GQA_CACHE_CHECK(hipblasLtMatrixLayoutCreate(&entry.layC, outType, m, n, m));
     GQA_CACHE_CHECK(setLayoutBatch(entry.layC, batch, n * m));
-    GQA_CACHE_CHECK(
-        hipblasLtMatrixLayoutCreate(&entry.layD, HIP_R_16F, m, n, m));
+    GQA_CACHE_CHECK(hipblasLtMatrixLayoutCreate(&entry.layD, outType, m, n, m));
     GQA_CACHE_CHECK(setLayoutBatch(entry.layD, batch, n * m));
   }
 
@@ -327,14 +328,16 @@ static int gqa_forward_hipblaslt(
 
   size_t Qtrans_bytes = static_cast<size_t>(B) * H * sq * d * elem_sz;
   size_t Kexp_bytes = static_cast<size_t>(B) * H * skv * d * elem_sz;
-  size_t S_bytes = static_cast<size_t>(B) * H * sq * skv * elem_sz;
+  size_t S_f32_bytes = static_cast<size_t>(B) * H * sq * skv * sizeof(float);
+  size_t S_fp16_bytes = static_cast<size_t>(B) * H * sq * skv * elem_sz;
   size_t O_bytes = static_cast<size_t>(B) * H * sq * d * elem_sz;
 
   size_t off_Qtrans = 0;
   size_t off_Kexp = off_Qtrans + Qtrans_bytes;
   size_t off_Vexp = off_Kexp + Kexp_bytes;
-  size_t off_S = off_Vexp + Kexp_bytes;
-  size_t off_O = off_S + S_bytes;
+  size_t off_S_f32 = off_Vexp + Kexp_bytes;
+  size_t off_S_fp16 = off_S_f32 + S_f32_bytes;
+  size_t off_O = off_S_fp16 + S_fp16_bytes;
   size_t temp_end = off_O + O_bytes;
 
   // Optional RoPE buffers: allocated only when do_rotary is enabled.
@@ -364,8 +367,8 @@ static int gqa_forward_hipblaslt(
   // Query or create cached GEMM descriptors + algorithms. On first call for
   // a given shape the descriptors and layouts are created and the heuristic
   // is queried; subsequent calls reuse the cached state.
-  GqaGemmKey scoreKey{skv, sq, d, B * H, true};
-  GqaGemmKey valueKey{d, sq, skv, B * H, false};
+  GqaGemmKey scoreKey{skv, sq, d, B * H, true, true};   // outputFp32=true
+  GqaGemmKey valueKey{d, sq, skv, B * H, false, false}; // outputFp32=false
   const GqaGemmCacheEntry *scoreState =
       queryOrCreateGemmState(ltHandle, scoreKey);
   if (!scoreState)
@@ -392,7 +395,8 @@ static int gqa_forward_hipblaslt(
     void *d_Qtrans = ws + off_Qtrans;
     void *d_Kexp = ws + off_Kexp;
     void *d_Vexp = ws + off_Vexp;
-    void *d_S = ws + off_S;
+    void *d_S_f32 = ws + off_S_f32;
+    void *d_S_fp16 = ws + off_S_fp16;
     void *d_O = ws + off_O;
 
     void *gemm_ws_ptr = ws + temp_end;
@@ -474,37 +478,39 @@ static int gqa_forward_hipblaslt(
           static_cast<int>(HPG), kvSrcStride, kvDstStride, expandCopy));
     }
 
-    // ---- Step 8: Score GEMM ----
+    // ---- Step 8: Score GEMM (fp16 in, fp32 out) ----
     float scoreAlpha = scale;
     float beta = 0.0f;
     hipblasLtMatmulAlgo_t sAlgo = scoreState->algo;
 
     HIPBLAS_CHECK(hipblasLtMatmul(
         ltHandle, scoreState->desc, &scoreAlpha, d_Kexp, scoreState->layA,
-        d_Qtrans, scoreState->layB, &beta, d_S, scoreState->layC, d_S,
+        d_Qtrans, scoreState->layB, &beta, d_S_f32, scoreState->layC, d_S_f32,
         scoreState->layD, &sAlgo, gemm_ws_ptr, gemm_ws_bytes, stream));
 
-    // ---- Step 9: Causal Mask + Softmax ----
-    int scoreBatchStride = static_cast<int>(sq * skv);
+    // ---- Step 9: Causal Mask (fp32) + Softmax (fp32 -> fp16) ----
+    int scoreF32BatchStride = static_cast<int>(sq * skv);
+    int scoreFp16BatchStride = static_cast<int>(sq * skv);
     if (sq > 1) {
-      HIP_CHECK(hip_gqa_causal_mask(
-          stream, d_S, static_cast<int>(B * H), static_cast<int>(skv),
-          static_cast<int>(sq), scoreBatchStride, static_cast<int>(past_len),
+      HIP_CHECK(hip_gqa_causal_mask_f32(
+          stream, d_S_f32, static_cast<int>(B * H), static_cast<int>(skv),
+          static_cast<int>(sq), scoreF32BatchStride, static_cast<int>(past_len),
           static_cast<int>(local_window_size)));
     }
-    HIP_CHECK(hip_gqa_softmax_inplace(
-        stream, d_S, static_cast<int>(B * H * sq), static_cast<int>(skv),
-        static_cast<int>(sq), scoreBatchStride, head_sink, static_cast<int>(H),
+    HIP_CHECK(hip_gqa_softmax_f32_to_f16(
+        stream, d_S_f32, d_S_fp16, static_cast<int>(B * H * sq),
+        static_cast<int>(skv), static_cast<int>(sq), scoreF32BatchStride,
+        scoreFp16BatchStride, head_sink, static_cast<int>(H),
         static_cast<int>(use_smooth_softmax)));
 
-    // ---- Step 10: Value GEMM ----
+    // ---- Step 10: Value GEMM (fp16 in, fp16 out) ----
     float valAlpha = 1.0f;
     hipblasLtMatmulAlgo_t vAlgo = valueState->algo;
 
     HIPBLAS_CHECK(hipblasLtMatmul(
-        ltHandle, valueState->desc, &valAlpha, d_Vexp, valueState->layA, d_S,
-        valueState->layB, &beta, d_O, valueState->layC, d_O, valueState->layD,
-        &vAlgo, gemm_ws_ptr, gemm_ws_bytes, stream));
+        ltHandle, valueState->desc, &valAlpha, d_Vexp, valueState->layA,
+        d_S_fp16, valueState->layB, &beta, d_O, valueState->layC, d_O,
+        valueState->layD, &vAlgo, gemm_ws_ptr, gemm_ws_bytes, stream));
 
     // ---- Step 11: O Transpose BNSD [B,H,S,d] -> BSHD [B,S,H,d] ----
     HIP_CHECK(hip_gqa_transpose_mid_dims(


### PR DESCRIPTION
## Summary
- DeepSeek-R1-Distill-Llama-70B `GroupQueryAttention_seq256` prefill produces NaN because fp16 Score GEMM outputs overflow to inf, then softmax computes inf - inf = NaN
- Switch Score GEMM output to fp32 and add `causal_mask_f32_kernel` + `softmax_f32_to_f16_kernel` so the entire score path stays in fp32 until the final fp16 conversion
- Decode path (fused kernel, sq==1) is unaffected

## Test plan
- [ ] CI windows-build passes (LIT + E2E tests)
- [ ] GPU E2E tests 32/32 pass (especially previously failing `test_single_layer_decode`)
- [ ] DeepSeek-R1-Distill-Llama-70B GQA seq256 output is NaN-free
- [ ] Perf comparison shows no significant regression