### PR TITLE
ci: test windows-latest-large runner (8-core)

### DIFF
--- a/.github/workflows/windows-build-mock.yml
+++ b/.github/workflows/windows-build-mock.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   build-windows-mock:
-    runs-on: windows-latest
+    runs-on: windows-latest-large
 
     env:
       LLVM_TAG: llvm-22.1.0-release


### PR DESCRIPTION
Test PR to check if `windows-latest-large` (8-core) runner is available and faster than `windows-latest` (4-core).

Requires GitHub larger runners to be enabled for the org.

**Do not merge** — close after CI result is observed.