### PR TITLE
ci: test windows-2022-arm64 runner

### DIFF
--- a/.github/workflows/windows-build-mock.yml
+++ b/.github/workflows/windows-build-mock.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   build-windows-mock:
-    runs-on: windows-latest
+    runs-on: windows-2022-arm64
 
     env:
       LLVM_TAG: llvm-22.1.0-release


### PR DESCRIPTION
Test PR to check if `windows-2022-arm64` runner is available for the org.

Note: ARM64 runner may not have x64 toolchain — this tests availability only.

**Do not merge** — close after CI result is observed.