### PR TITLE
feat: add  CausalConvWithState operator support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This project demonstrates the integration of HIP (Heterogeneous-compute Interfac
 ## Features
 
 - **MLIR Compiler Pipeline**: ONNX dialect → HIP dialect → LLVM IR → native DLL
-- **MIOpen Integration**: Conv, Softmax, RMS Norm, Mul via MIOpen library
+- **MIOpen Integration**: Conv, Softmax, RMS Norm, Mul, CausalConvWithState via MIOpen library
 - **hipBLASLt MatMul**: High-performance matrix multiplication
 - **Custom HIP Kernels**: GQA, RoPE, Cast, Sub, Gather, ReduceSum
 - **Memory Pool Optimization**: `hip-pool-allocs` pass packs allocations into a single grow-on-demand buffer
@@ -42,6 +42,7 @@ This project demonstrates the integration of HIP (Heterogeneous-compute Interfac
 | GroupQueryAttention (com.microsoft) | Custom HIP Kernel |
 | MatMulNBits (com.microsoft) | Custom HIP Kernel |
 | QMoE (com.microsoft) | Custom HIP Kernel |
+| CausalConvWithState (com.microsoft) | MIOpen |
 
 ### Compiler-Optimized Operations
 

--- a/include/hip/Dialect/IR/HipBufferize.h
+++ b/include/hip/Dialect/IR/HipBufferize.h
@@ -86,6 +86,8 @@ registerHipBufferizableOpInterfaceModels(DialectRegistry &registry) {
     MatMulNBitsOp::attachInterface<HipDstBufferizableModel<MatMulNBitsOp>>(
         *ctx);
     QMoEOp::attachInterface<HipDstBufferizableModel<QMoEOp>>(*ctx);
+    CausalConvWithStateOp::attachInterface<
+        HipDstBufferizableModel<CausalConvWithStateOp>>(*ctx);
     HipDNNGraphOp::attachInterface<HipDstBufferizableModel<HipDNNGraphOp>>(
         *ctx);
   });

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -872,9 +872,8 @@ def Hip_CausalConvWithStateOp : Hip_DpsOp<"causal_conv_with_state",
     Optional<Hip_TensorOrMemRef>:$bias,        // (channels)
     Optional<Hip_TensorOrMemRef>:$past_state,  // (batch, channels, k-1)
 
-    // DPS output buffers
-    Hip_TensorOrMemRef:$output,          // same shape as input
-    Hip_TensorOrMemRef:$present_state,   // (batch, channels, k-1)
+    // DPS output buffers: [output, present_state]
+    Variadic<Hip_TensorOrMemRef>:$outputs,
 
     // Attributes
     DefaultValuedAttr<StrAttr, "\"none\"">:$activation,  // "none", "silu", "swish"
@@ -891,11 +890,7 @@ def Hip_CausalConvWithStateOp : Hip_DpsOp<"causal_conv_with_state",
         (`,` type($bias)^)?
         (`,` type($past_state)^)?
     `)`
-    `outs` `(`
-        $output `,` $present_state
-        `:`
-        type($output) `,` type($present_state)
-    `)`
+    `outs` `(` $outputs `:` type($outputs) `)`
     attr-dict (`:` type($result_tensors)^)?
   }];
 }

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -872,8 +872,9 @@ def Hip_CausalConvWithStateOp : Hip_DpsOp<"causal_conv_with_state",
     Optional<Hip_TensorOrMemRef>:$bias,        // (channels)
     Optional<Hip_TensorOrMemRef>:$past_state,  // (batch, channels, k-1)
 
-    // DPS output buffers: [output, present_state]
-    Variadic<Hip_TensorOrMemRef>:$outputs,
+    // DPS output buffers
+    Hip_TensorOrMemRef:$output,          // same shape as input
+    Hip_TensorOrMemRef:$present_state,   // (batch, channels, k-1)
 
     // Attributes
     DefaultValuedAttr<StrAttr, "\"none\"">:$activation,  // "none", "silu", "swish"
@@ -890,7 +891,11 @@ def Hip_CausalConvWithStateOp : Hip_DpsOp<"causal_conv_with_state",
         (`,` type($bias)^)?
         (`,` type($past_state)^)?
     `)`
-    `outs` `(` $outputs `:` type($outputs) `)`
+    `outs` `(`
+        $output `,` $present_state
+        `:`
+        type($output) `,` type($present_state)
+    `)`
     attr-dict (`:` type($result_tensors)^)?
   }];
 }

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -828,6 +828,80 @@ def Hip_ReduceSumOp : Hip_DpsOp<"reduce_sum"> {
   }];
 }
 
+// ===== Causal Conv with State ================================================
+
+def Hip_CausalConvWithStateOp : Hip_DpsOp<"causal_conv_with_state",
+    [AttrSizedOperandSegments]> {
+  let summary = "Stateful causal depthwise convolution";
+  let description = [{
+    Causal depthwise convolution with carry state for incremental decoding.
+
+    Used by Gated DeltaNet (Qwen3.5) and Mamba (Jamba, FalconMamba) as a
+    preprocessing step. Replaces the 3-op pattern (Concat + Conv + Slice)
+    with a single fused operation.
+
+    The convolution is causal (looks only at current and past positions along
+    the last spatial dimension) and depthwise (each channel is convolved
+    independently with its own kernel).
+
+    Input layout is channels-first: (batch_size, channels, ...).
+    Weight layout: (channels, 1, k_1, ...) for depthwise convolution.
+    The carry state stores the last (k-1) positions along the causal axis
+    for incremental decode.
+
+    Example (1D):
+    ```mlir
+    hip.causal_conv_with_state(%ctx)
+        ins(%input, %weight, %bias, %past_state :
+            tensor<1x64x128xf16>, tensor<64x1x4xf16>,
+            tensor<64xf16>, tensor<1x64x3xf16>)
+        outs(%output, %present_state :
+             tensor<1x64x128xf16>, tensor<1x64x3xf16>)
+        {activation = "silu", ndim = 1 : i64}
+    ```
+  }];
+
+  let arguments = (ins
+    Hip_ContextType:$ctx,
+
+    // Required inputs
+    Hip_TensorOrMemRef:$input,           // (batch, channels, ...)
+    Hip_TensorOrMemRef:$weight,          // (channels, 1, k_1, ...)
+
+    // Optional inputs
+    Optional<Hip_TensorOrMemRef>:$bias,        // (channels)
+    Optional<Hip_TensorOrMemRef>:$past_state,  // (batch, channels, k-1)
+
+    // DPS output buffers
+    Hip_TensorOrMemRef:$output,          // same shape as input
+    Hip_TensorOrMemRef:$present_state,   // (batch, channels, k-1)
+
+    // Attributes
+    DefaultValuedAttr<StrAttr, "\"none\"">:$activation,  // "none", "silu", "swish"
+    DefaultValuedAttr<I64Attr, "1">:$ndim                // 1, 2, or 3
+  );
+
+  let assemblyFormat = [{
+    `(` $ctx `)` `ins` `(`
+        $input `,` $weight
+        (`,` $bias^)?
+        (`,` $past_state^)?
+        `:`
+        type($input) `,` type($weight)
+        (`,` type($bias)^)?
+        (`,` type($past_state)^)?
+    `)`
+    `outs` `(`
+        $output `,` $present_state
+        `:`
+        type($output) `,` type($present_state)
+    `)`
+    attr-dict (`:` type($result_tensors)^)?
+  }];
+}
+
+// ===== Group Query Attention =================================================
+
 def Hip_GqaOp : Hip_DpsOp<"gqa", [AttrSizedOperandSegments]> {
   let summary = "Group Query Attention - Full MS spec implementation";
   let description = [{

--- a/lib/Conversion/HipToLLVM/CMakeLists.txt
+++ b/lib/Conversion/HipToLLVM/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(HipToLLVM STATIC
   MatMulNBitsLowering.cpp
   QMoELowering.cpp
   GraphLowering.cpp
+  CausalConvWithStateLowering.cpp
 )
 
 add_dependencies(HipToLLVM

--- a/lib/Conversion/HipToLLVM/CausalConvWithStateLowering.cpp
+++ b/lib/Conversion/HipToLLVM/CausalConvWithStateLowering.cpp
@@ -81,13 +81,19 @@ struct CausalConvWithStateOpLowering
     }
 
     // Extract kernel size from weight shape: (channels, 1, k_1, ...)
-    // kernel_size = product of spatial kernel dims
+    // kernel_size = product of spatial kernel dims.
+    // Use getMemRefDimSize so we pick up compile-time constants for static dims
+    // and runtime MemRefDescriptor::size for dynamic dims -- otherwise a
+    // dynamic weight shape would multiply ShapedType::kDynamic (a large
+    // negative sentinel) into the runtime argument.
     auto weightType = cast<MemRefType>(op.getWeight().getType());
-    auto weightShape = weightType.getShape();
-    int64_t kernelSize = 1;
-    for (int64_t i = 2; i < static_cast<int64_t>(weightShape.size()); ++i)
-      kernelSize *= weightShape[i];
-    Value kernelSizeVal = createI64Const(kernelSize);
+    int64_t weightRank = weightType.getRank();
+    Value kernelSizeVal = createI64Const(1);
+    for (int64_t i = 2; i < weightRank; ++i) {
+      Value dim =
+          getMemRefDimSize(weightType, i, adaptor.getWeight(), rewriter, loc);
+      kernelSizeVal = LLVM::MulOp::create(rewriter, loc, kernelSizeVal, dim);
+    }
 
     // Attributes
     Value ndimVal = createI64Const(op.getNdim());

--- a/lib/Conversion/HipToLLVM/CausalConvWithStateLowering.cpp
+++ b/lib/Conversion/HipToLLVM/CausalConvWithStateLowering.cpp
@@ -65,18 +65,18 @@ struct CausalConvWithStateOpLowering
     if (rank < 3)
       return op.emitError("input must be at least rank-3");
 
-    Value batchSize = getMemRefDimSize(inputType, 0, adaptor.getInput(),
-                                       rewriter, loc);
-    Value channels = getMemRefDimSize(inputType, 1, adaptor.getInput(),
-                                      rewriter, loc);
+    Value batchSize =
+        getMemRefDimSize(inputType, 0, adaptor.getInput(), rewriter, loc);
+    Value channels =
+        getMemRefDimSize(inputType, 1, adaptor.getInput(), rewriter, loc);
 
     // seq_len = product of spatial dimensions (last ndim dims)
     // For ndim=1: just the last dim
-    Value seqLen = getMemRefDimSize(inputType, 2, adaptor.getInput(),
-                                    rewriter, loc);
+    Value seqLen =
+        getMemRefDimSize(inputType, 2, adaptor.getInput(), rewriter, loc);
     for (int64_t i = 3; i < rank; ++i) {
-      Value dim = getMemRefDimSize(inputType, i, adaptor.getInput(),
-                                   rewriter, loc);
+      Value dim =
+          getMemRefDimSize(inputType, i, adaptor.getInput(), rewriter, loc);
       seqLen = LLVM::MulOp::create(rewriter, loc, seqLen, dim);
     }
 
@@ -127,10 +127,9 @@ struct CausalConvWithStateOpLowering
       return failure();
 
     SmallVector<Value, 14> args = {
-        statePtr,     inputPtr,      weightPtr,    biasPtr,
-        pastStatePtr, outputPtr,     presentStatePtr,
-        batchSize,    channels,      seqLen,       kernelSizeVal,
-        ndimVal,      activationVal, elemSizeVal};
+        statePtr,      inputPtr,        weightPtr,     biasPtr,    pastStatePtr,
+        outputPtr,     presentStatePtr, batchSize,     channels,   seqLen,
+        kernelSizeVal, ndimVal,         activationVal, elemSizeVal};
 
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
 

--- a/lib/Conversion/HipToLLVM/CausalConvWithStateLowering.cpp
+++ b/lib/Conversion/HipToLLVM/CausalConvWithStateLowering.cpp
@@ -49,9 +49,9 @@ struct CausalConvWithStateOpLowering
         adaptor.getPastState()
             ? extractMemRefPtr(adaptor.getPastState(), rewriter, loc)
             : nullPtr;
-    auto outputs = adaptor.getOutputs();
-    Value outputPtr = extractMemRefPtr(outputs[0], rewriter, loc);
-    Value presentStatePtr = extractMemRefPtr(outputs[1], rewriter, loc);
+    Value outputPtr = extractMemRefPtr(adaptor.getOutput(), rewriter, loc);
+    Value presentStatePtr =
+        extractMemRefPtr(adaptor.getPresentState(), rewriter, loc);
 
     // Extract shape info from input memref: (batch, channels, L) for ndim=1
     auto inputType = cast<MemRefType>(op.getInput().getType());

--- a/lib/Conversion/HipToLLVM/CausalConvWithStateLowering.cpp
+++ b/lib/Conversion/HipToLLVM/CausalConvWithStateLowering.cpp
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "HipToLLVMUtils.h"
+
+namespace mlir {
+namespace hip {
+namespace {
+
+// hip.causal_conv_with_state(%ctx)
+//   ins(%input, %weight, %bias, %past_state)
+//   outs(%output, %present_state)
+//   {activation = "silu", ndim = 1}
+// -> wrap_causal_conv_with_state(state, input, weight, bias, past_state,
+//                                 output, present_state,
+//                                 batch_size, channels, seq_len,
+//                                 kernel_size, ndim, activation,
+//                                 element_size_bytes)
+struct CausalConvWithStateOpLowering
+    : public ConvertOpToLLVMPattern<CausalConvWithStateOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(CausalConvWithStateOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    ModuleOp module = op->getParentOfType<ModuleOp>();
+    Type ptrType = getPtrType();
+    Type i32Type = rewriter.getI32Type();
+    Type i64Type = rewriter.getI64Type();
+
+    auto createI64Const = [&](int64_t value) -> Value {
+      return LLVM::ConstantOp::create(rewriter, loc, i64Type,
+                                      rewriter.getI64IntegerAttr(value));
+    };
+
+    Value nullPtr = LLVM::ZeroOp::create(rewriter, loc, ptrType);
+
+    // Extract pointers
+    Value statePtr = adaptor.getCtx();
+    Value inputPtr = extractMemRefPtr(adaptor.getInput(), rewriter, loc);
+    Value weightPtr = extractMemRefPtr(adaptor.getWeight(), rewriter, loc);
+    Value biasPtr = adaptor.getBias()
+                        ? extractMemRefPtr(adaptor.getBias(), rewriter, loc)
+                        : nullPtr;
+    Value pastStatePtr =
+        adaptor.getPastState()
+            ? extractMemRefPtr(adaptor.getPastState(), rewriter, loc)
+            : nullPtr;
+    Value outputPtr = extractMemRefPtr(adaptor.getOutput(), rewriter, loc);
+    Value presentStatePtr =
+        extractMemRefPtr(adaptor.getPresentState(), rewriter, loc);
+
+    // Extract shape info from input memref: (batch, channels, L) for ndim=1
+    auto inputType = cast<MemRefType>(op.getInput().getType());
+    auto inputShape = inputType.getShape();
+    int64_t rank = inputType.getRank();
+
+    // Input layout: (batch, channels, spatial_dims...)
+    // For ndim=1: rank=3, shape = [batch, channels, L]
+    // For ndim=2: rank=4, shape = [batch, channels, H, W]
+    // For ndim=3: rank=5, shape = [batch, channels, D, H, W]
+    if (rank < 3)
+      return op.emitError("input must be at least rank-3");
+
+    Value batchSize = getMemRefDimSize(inputType, 0, adaptor.getInput(),
+                                       rewriter, loc);
+    Value channels = getMemRefDimSize(inputType, 1, adaptor.getInput(),
+                                      rewriter, loc);
+
+    // seq_len = product of spatial dimensions (last ndim dims)
+    // For ndim=1: just the last dim
+    Value seqLen = getMemRefDimSize(inputType, 2, adaptor.getInput(),
+                                    rewriter, loc);
+    for (int64_t i = 3; i < rank; ++i) {
+      Value dim = getMemRefDimSize(inputType, i, adaptor.getInput(),
+                                   rewriter, loc);
+      seqLen = LLVM::MulOp::create(rewriter, loc, seqLen, dim);
+    }
+
+    // Extract kernel size from weight shape: (channels, 1, k_1, ...)
+    // kernel_size = product of spatial kernel dims
+    auto weightType = cast<MemRefType>(op.getWeight().getType());
+    auto weightShape = weightType.getShape();
+    int64_t kernelSize = 1;
+    for (int64_t i = 2; i < static_cast<int64_t>(weightShape.size()); ++i)
+      kernelSize *= weightShape[i];
+    Value kernelSizeVal = createI64Const(kernelSize);
+
+    // Attributes
+    Value ndimVal = createI64Const(op.getNdim());
+
+    // Convert activation string to enum: "none"=0, "silu"/"swish"=1
+    llvm::StringRef activationStr = op.getActivation();
+    int64_t activationEnum = 0;
+    if (activationStr == "silu" || activationStr == "swish")
+      activationEnum = 1;
+    Value activationVal = createI64Const(activationEnum);
+
+    unsigned elemSizeBytes =
+        inputType.getElementType().getIntOrFloatBitWidth() / 8;
+    Value elemSizeVal = createI64Const(elemSizeBytes);
+
+    // Build function signature
+    SmallVector<Type, 14> paramTypes = {
+        ptrType, // state
+        ptrType, // input
+        ptrType, // weight
+        ptrType, // bias (nullable)
+        ptrType, // past_state (nullable)
+        ptrType, // output
+        ptrType, // present_state
+        i64Type, // batch_size
+        i64Type, // channels
+        i64Type, // seq_len
+        i64Type, // kernel_size
+        i64Type, // ndim
+        i64Type, // activation
+        i64Type  // element_size_bytes
+    };
+
+    FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
+        rewriter, module, kWrapCausalConvWithState, paramTypes, i32Type);
+    if (failed(funcOp))
+      return failure();
+
+    SmallVector<Value, 14> args = {
+        statePtr,     inputPtr,      weightPtr,    biasPtr,
+        pastStatePtr, outputPtr,     presentStatePtr,
+        batchSize,    channels,      seqLen,       kernelSizeVal,
+        ndimVal,      activationVal, elemSizeVal};
+
+    LLVM::CallOp::create(rewriter, loc, *funcOp, args);
+
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+} // namespace
+
+void mlir::hip::populateCausalConvWithStateLoweringPatterns(
+    const LLVMTypeConverter &converter, RewritePatternSet &patterns) {
+  patterns.add<CausalConvWithStateOpLowering>(converter);
+}
+
+} // namespace hip
+} // namespace mlir

--- a/lib/Conversion/HipToLLVM/CausalConvWithStateLowering.cpp
+++ b/lib/Conversion/HipToLLVM/CausalConvWithStateLowering.cpp
@@ -49,9 +49,9 @@ struct CausalConvWithStateOpLowering
         adaptor.getPastState()
             ? extractMemRefPtr(adaptor.getPastState(), rewriter, loc)
             : nullPtr;
-    Value outputPtr = extractMemRefPtr(adaptor.getOutput(), rewriter, loc);
-    Value presentStatePtr =
-        extractMemRefPtr(adaptor.getPresentState(), rewriter, loc);
+    auto outputs = adaptor.getOutputs();
+    Value outputPtr = extractMemRefPtr(outputs[0], rewriter, loc);
+    Value presentStatePtr = extractMemRefPtr(outputs[1], rewriter, loc);
 
     // Extract shape info from input memref: (batch, channels, L) for ndim=1
     auto inputType = cast<MemRefType>(op.getInput().getType());

--- a/lib/Conversion/HipToLLVM/HipToLLVM.cpp
+++ b/lib/Conversion/HipToLLVM/HipToLLVM.cpp
@@ -225,6 +225,7 @@ void ConvertHipToLLVMPass::runOnOperation() {
   populateMatMulNBitsLoweringPatterns(typeConverter, patterns);
   populateQMoELoweringPatterns(typeConverter, patterns);
   populateGraphLoweringPatterns(typeConverter, patterns);
+  populateCausalConvWithStateLoweringPatterns(typeConverter, patterns);
 
   // Standard dialect lowerings
   // Bundle func/memref/arith/cf lowering with HIP lowering to minimize

--- a/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
+++ b/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
@@ -64,6 +64,8 @@ inline constexpr const char *kWrapMatMulNBits = "wrap_matmul_nbits";
 inline constexpr const char *kWrapQMoE = "wrap_qmoe";
 inline constexpr const char *kHipGetConstant = "hipdnn_ep_constant_get";
 inline constexpr const char *kHipDNNGraphExecute = "hipdnn_graph_execute";
+inline constexpr const char *kWrapCausalConvWithState =
+    "wrap_causal_conv_with_state";
 
 // LLVM memref descriptor struct field indices.
 // Layout: { allocatedPtr, alignedPtr, offset, sizes[rank], strides[rank] }
@@ -235,6 +237,8 @@ void populateQMoELoweringPatterns(const LLVMTypeConverter &converter,
                                   RewritePatternSet &patterns);
 void populateGraphLoweringPatterns(const LLVMTypeConverter &converter,
                                    RewritePatternSet &patterns);
+void populateCausalConvWithStateLoweringPatterns(
+    const LLVMTypeConverter &converter, RewritePatternSet &patterns);
 
 } // namespace hip
 } // namespace mlir

--- a/lib/Conversion/OnnxToHip/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHip/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(OnnxToHip STATIC
   GqaConversion.cpp
   GatherConversion.cpp
   ReshapeConversion.cpp
+  CausalConvWithStateConversion.cpp
 )
 
 add_dependencies(OnnxToHip

--- a/lib/Conversion/OnnxToHip/CausalConvWithStateConversion.cpp
+++ b/lib/Conversion/OnnxToHip/CausalConvWithStateConversion.cpp
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "OnnxToHipUtils.h"
+
+namespace mlir {
+namespace hip {
+namespace {
+
+/// com.microsoft.CausalConvWithState -> hip.causal_conv_with_state
+struct CausalConvWithStateToHip : public mlir::RewritePattern {
+  CausalConvWithStateToHip(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.Custom", /*benefit=*/1, ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override;
+};
+
+mlir::LogicalResult CausalConvWithStateToHip::matchAndRewrite(
+    mlir::Operation *op, mlir::PatternRewriter &rewriter) const {
+  auto funcNameAttr = op->getAttrOfType<mlir::StringAttr>("function_name");
+  if (!funcNameAttr || funcNameAttr.getValue() != "CausalConvWithState")
+    return rewriter.notifyMatchFailure(
+        op, "not a CausalConvWithState operation");
+
+  auto domainAttr = op->getAttrOfType<mlir::StringAttr>("domain_name");
+  if (!domainAttr || domainAttr.getValue() != "com.microsoft")
+    return rewriter.notifyMatchFailure(
+        op, "domain must be com.microsoft for CausalConvWithState");
+
+  auto ctxOrFailure = getContextArg(op, rewriter);
+  if (mlir::failed(ctxOrFailure))
+    return rewriter.notifyMatchFailure(op, "missing context argument");
+  mlir::Value context = *ctxOrFailure;
+
+  mlir::Location loc = op->getLoc();
+
+  // CausalConvWithState has 2-4 inputs:
+  //   input (required), weight (required), bias (optional), past_state (optional)
+  size_t numOps = op->getNumOperands();
+  if (numOps < 2 || numOps > 4)
+    return rewriter.notifyMatchFailure(
+        op, "CausalConvWithState expects 2-4 operands");
+
+  auto getOptionalOperand = [&](size_t idx) -> mlir::Value {
+    if (idx >= numOps)
+      return nullptr;
+    mlir::Value val = op->getOperand(idx);
+    if (mlir::isa<mlir::NoneType>(val.getType()))
+      return nullptr;
+    return val;
+  };
+
+  mlir::Value input = op->getOperand(0);
+  mlir::Value weight = op->getOperand(1);
+  mlir::Value bias = getOptionalOperand(2);
+  mlir::Value pastState = getOptionalOperand(3);
+
+  // Extract attributes with defaults
+  auto activationAttr = op->getAttrOfType<mlir::StringAttr>("activation");
+  if (!activationAttr)
+    activationAttr = rewriter.getStringAttr("none");
+
+  auto ndimAttrOnnx = op->getAttrOfType<mlir::IntegerAttr>("ndim");
+  auto ndimAttr = ndimAttrOnnx
+                      ? rewriter.getI64IntegerAttr(
+                            ndimAttrOnnx.getValue().getSExtValue())
+                      : rewriter.getI64IntegerAttr(1);
+
+  // Outputs: output (same shape as input), present_state
+  size_t numResults = op->getNumResults();
+  if (numResults != 2)
+    return rewriter.notifyMatchFailure(
+        op, "CausalConvWithState expects exactly 2 results");
+
+  auto outputType =
+      mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
+  auto presentStateType =
+      mlir::cast<mlir::RankedTensorType>(op->getResult(1).getType());
+
+  // Create DPS init tensors
+  mlir::Value outputInit = createEmptyTensor(rewriter, loc, outputType, input);
+  mlir::Value presentStateInit =
+      createEmptyTensor(rewriter, loc, presentStateType,
+                        pastState ? pastState : input);
+
+  // Build operands
+  mlir::SmallVector<mlir::Value> operands;
+  operands.push_back(context);
+  operands.push_back(input);
+  operands.push_back(weight);
+  if (bias)
+    operands.push_back(bias);
+  if (pastState)
+    operands.push_back(pastState);
+  operands.push_back(outputInit);
+  operands.push_back(presentStateInit);
+
+  // Build attributes
+  mlir::SmallVector<mlir::NamedAttribute> attrs;
+  attrs.push_back(rewriter.getNamedAttr("activation", activationAttr));
+  attrs.push_back(rewriter.getNamedAttr("ndim", ndimAttr));
+
+  // Build result types
+  mlir::SmallVector<mlir::Type> resultTypes;
+  resultTypes.push_back(outputType);
+  resultTypes.push_back(presentStateType);
+
+  // Create operation with operand_segment_sizes
+  auto state = mlir::OperationState(loc, "hip.causal_conv_with_state");
+  state.addOperands(operands);
+  state.addAttributes(attrs);
+  state.addTypes(resultTypes);
+
+  // Segments: [ctx(1), input(1), weight(1), bias(0|1), past_state(0|1),
+  //            output(1), present_state(1)]
+  llvm::SmallVector<int32_t> segmentSizes;
+  segmentSizes.push_back(1); // ctx
+  segmentSizes.push_back(1); // input
+  segmentSizes.push_back(1); // weight
+  segmentSizes.push_back(bias ? 1 : 0);
+  segmentSizes.push_back(pastState ? 1 : 0);
+  segmentSizes.push_back(1); // output
+  segmentSizes.push_back(1); // present_state
+
+  state.addAttribute("operand_segment_sizes",
+                     rewriter.getDenseI32ArrayAttr(segmentSizes));
+
+  auto hipOp = rewriter.create(state);
+  rewriter.replaceOp(op, hipOp->getResults());
+  return mlir::success();
+}
+
+} // namespace
+
+void mlir::hip::populateCausalConvWithStateConversionPatterns(
+    RewritePatternSet &patterns, MLIRContext *ctx) {
+  patterns.add<CausalConvWithStateToHip>(ctx);
+}
+
+} // namespace hip
+} // namespace mlir

--- a/lib/Conversion/OnnxToHip/CausalConvWithStateConversion.cpp
+++ b/lib/Conversion/OnnxToHip/CausalConvWithStateConversion.cpp
@@ -23,8 +23,8 @@ mlir::LogicalResult CausalConvWithStateToHip::matchAndRewrite(
     mlir::Operation *op, mlir::PatternRewriter &rewriter) const {
   auto funcNameAttr = op->getAttrOfType<mlir::StringAttr>("function_name");
   if (!funcNameAttr || funcNameAttr.getValue() != "CausalConvWithState")
-    return rewriter.notifyMatchFailure(
-        op, "not a CausalConvWithState operation");
+    return rewriter.notifyMatchFailure(op,
+                                       "not a CausalConvWithState operation");
 
   auto domainAttr = op->getAttrOfType<mlir::StringAttr>("domain_name");
   if (!domainAttr || domainAttr.getValue() != "com.microsoft")
@@ -39,7 +39,8 @@ mlir::LogicalResult CausalConvWithStateToHip::matchAndRewrite(
   mlir::Location loc = op->getLoc();
 
   // CausalConvWithState has 2-4 inputs:
-  //   input (required), weight (required), bias (optional), past_state (optional)
+  //   input (required), weight (required), bias (optional), past_state
+  //   (optional)
   size_t numOps = op->getNumOperands();
   if (numOps < 2 || numOps > 4)
     return rewriter.notifyMatchFailure(
@@ -65,10 +66,10 @@ mlir::LogicalResult CausalConvWithStateToHip::matchAndRewrite(
     activationAttr = rewriter.getStringAttr("none");
 
   auto ndimAttrOnnx = op->getAttrOfType<mlir::IntegerAttr>("ndim");
-  auto ndimAttr = ndimAttrOnnx
-                      ? rewriter.getI64IntegerAttr(
-                            ndimAttrOnnx.getValue().getSExtValue())
-                      : rewriter.getI64IntegerAttr(1);
+  auto ndimAttr =
+      ndimAttrOnnx
+          ? rewriter.getI64IntegerAttr(ndimAttrOnnx.getValue().getSExtValue())
+          : rewriter.getI64IntegerAttr(1);
 
   // Outputs: output (same shape as input), present_state
   size_t numResults = op->getNumResults();
@@ -83,9 +84,8 @@ mlir::LogicalResult CausalConvWithStateToHip::matchAndRewrite(
 
   // Create DPS init tensors
   mlir::Value outputInit = createEmptyTensor(rewriter, loc, outputType, input);
-  mlir::Value presentStateInit =
-      createEmptyTensor(rewriter, loc, presentStateType,
-                        pastState ? pastState : input);
+  mlir::Value presentStateInit = createEmptyTensor(
+      rewriter, loc, presentStateType, pastState ? pastState : input);
 
   // Build operands
   mlir::SmallVector<mlir::Value> operands;

--- a/lib/Conversion/OnnxToHip/CausalConvWithStateConversion.cpp
+++ b/lib/Conversion/OnnxToHip/CausalConvWithStateConversion.cpp
@@ -116,14 +116,15 @@ mlir::LogicalResult CausalConvWithStateToHip::matchAndRewrite(
   state.addTypes(resultTypes);
 
   // Segments: [ctx(1), input(1), weight(1), bias(0|1), past_state(0|1),
-  //            outputs(2)]
+  //            output(1), present_state(1)]
   llvm::SmallVector<int32_t> segmentSizes;
   segmentSizes.push_back(1); // ctx
   segmentSizes.push_back(1); // input
   segmentSizes.push_back(1); // weight
   segmentSizes.push_back(bias ? 1 : 0);
   segmentSizes.push_back(pastState ? 1 : 0);
-  segmentSizes.push_back(2); // outputs: [output, present_state]
+  segmentSizes.push_back(1); // output
+  segmentSizes.push_back(1); // present_state
 
   state.addAttribute("operand_segment_sizes",
                      rewriter.getDenseI32ArrayAttr(segmentSizes));

--- a/lib/Conversion/OnnxToHip/CausalConvWithStateConversion.cpp
+++ b/lib/Conversion/OnnxToHip/CausalConvWithStateConversion.cpp
@@ -116,15 +116,14 @@ mlir::LogicalResult CausalConvWithStateToHip::matchAndRewrite(
   state.addTypes(resultTypes);
 
   // Segments: [ctx(1), input(1), weight(1), bias(0|1), past_state(0|1),
-  //            output(1), present_state(1)]
+  //            outputs(2)]
   llvm::SmallVector<int32_t> segmentSizes;
   segmentSizes.push_back(1); // ctx
   segmentSizes.push_back(1); // input
   segmentSizes.push_back(1); // weight
   segmentSizes.push_back(bias ? 1 : 0);
   segmentSizes.push_back(pastState ? 1 : 0);
-  segmentSizes.push_back(1); // output
-  segmentSizes.push_back(1); // present_state
+  segmentSizes.push_back(2); // outputs: [output, present_state]
 
   state.addAttribute("operand_segment_sizes",
                      rewriter.getDenseI32ArrayAttr(segmentSizes));

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -378,6 +378,7 @@ static mlir::LogicalResult convertComputeOps(mlir::func::FuncOp funcOp,
   populateMatMulNBitsConversionPatterns(patterns, ctx);
   populateQMoEConversionPatterns(patterns, ctx);
   populateReshapeConversionPatterns(patterns, ctx);
+  populateCausalConvWithStateConversionPatterns(patterns, ctx);
 
   mlir::GreedyRewriteConfig config;
   config.setStrictness(mlir::GreedyRewriteStrictness::ExistingOps);

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
@@ -139,6 +139,8 @@ void populateGatherConversionPatterns(RewritePatternSet &patterns,
                                       MLIRContext *ctx);
 void populateReshapeConversionPatterns(RewritePatternSet &patterns,
                                        MLIRContext *ctx);
+void populateCausalConvWithStateConversionPatterns(RewritePatternSet &patterns,
+                                                   MLIRContext *ctx);
 
 } // namespace hip
 } // namespace mlir

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -610,6 +610,31 @@ void QMoEOp::getEffects(
 }
 
 //===----------------------------------------------------------------------===//
+// CausalConvWithStateOp: ins(input, weight, [bias], [past_state])
+//                        outs(output, present_state)
+//===----------------------------------------------------------------------===//
+
+MutableOperandRange CausalConvWithStateOp::getDpsInitsMutable() {
+  // DPS inits: output, present_state (always 2)
+  // Count actual inputs before the inits
+  unsigned numInputs = 1; // ctx
+  numInputs++;            // input
+  numInputs++;            // weight
+  if (getBias())
+    ++numInputs;
+  if (getPastState())
+    ++numInputs;
+
+  return MutableOperandRange(*this, /*start=*/numInputs, /*length=*/2);
+}
+
+void CausalConvWithStateOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  emitDpsMemoryEffects(getDpsInputOperands(), getDpsInitsMutable(), effects);
+}
+
+//===----------------------------------------------------------------------===//
 // GqaOp: Full MS spec implementation
 //        ins(query, [key, value, past_key, past_value], seqlens_k,
 //        total_seq_len,

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -615,17 +615,7 @@ void QMoEOp::getEffects(
 //===----------------------------------------------------------------------===//
 
 MutableOperandRange CausalConvWithStateOp::getDpsInitsMutable() {
-  // DPS inits: output, present_state (always 2)
-  // Count actual inputs before the inits
-  unsigned numInputs = 1; // ctx
-  numInputs++;            // input
-  numInputs++;            // weight
-  if (getBias())
-    ++numInputs;
-  if (getPastState())
-    ++numInputs;
-
-  return MutableOperandRange(*this, /*start=*/numInputs, /*length=*/2);
+  return getOutputsMutable();
 }
 
 void CausalConvWithStateOp::getEffects(

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -615,7 +615,17 @@ void QMoEOp::getEffects(
 //===----------------------------------------------------------------------===//
 
 MutableOperandRange CausalConvWithStateOp::getDpsInitsMutable() {
-  return getOutputsMutable();
+  // DPS inits: output, present_state (always 2)
+  // Count actual inputs before the inits
+  unsigned numInputs = 1; // ctx
+  numInputs++;            // input
+  numInputs++;            // weight
+  if (getBias())
+    ++numInputs;
+  if (getPastState())
+    ++numInputs;
+
+  return MutableOperandRange(*this, /*start=*/numInputs, /*length=*/2);
 }
 
 void CausalConvWithStateOp::getEffects(

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -226,6 +226,7 @@ if(NOT BUILD_MOCK_RUNTIME)
     compile_to_bitcode(real/reduce_sum.cpp runtime_reduce_sum.bc)
     compile_to_bitcode(real/matmul_nbits.cpp runtime_matmul_nbits.bc)
     compile_to_bitcode(real/qmoe.cpp runtime_qmoe.bc)
+    compile_to_bitcode(real/causal_conv_with_state.cpp runtime_causal_conv_with_state.bc)
     compile_to_bitcode(real/test_hip_from_dll.cpp test_hip_from_dll.bc)
 
     set(RUNTIME_BC_MODULES
@@ -247,6 +248,7 @@ if(NOT BUILD_MOCK_RUNTIME)
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_reduce_sum.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_matmul_nbits.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_qmoe.bc
+        ${CMAKE_CURRENT_BINARY_DIR}/runtime_causal_conv_with_state.bc
         ${CMAKE_CURRENT_BINARY_DIR}/test_hip_from_dll.bc
     )
 else()

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -557,6 +557,32 @@ int wrap_qmoe(
     float activation_alpha, float activation_beta, float swiglu_limit,
     int64_t normalize_routing_weights, int64_t elem_size);
 
+// CausalConvWithState operation wrapper (stateful causal depthwise convolution)
+// Used by Gated DeltaNet (Qwen3.5) and Mamba models.
+// Performs causal depthwise convolution with carry state for incremental decode.
+// The convolution is causal (looks only at current and past positions) and
+// depthwise (each channel convolved independently).
+// Input layout: channels-first (batch, channels, seq_len).
+// Weight layout: (channels, 1, kernel_size) for 1D depthwise.
+//   bias:       nullable - per-channel bias (channels)
+//   past_state: nullable - carry state from previous step (batch, channels, k-1)
+//   activation: 0=none, 1=silu/swish
+int wrap_causal_conv_with_state(
+    RuntimeState *state,
+    const void *input,       // (batch, channels, seq_len)
+    const void *weight,      // (channels, 1, kernel_size)
+    const void *bias,        // nullable, (channels)
+    const void *past_state,  // nullable, (batch, channels, kernel_size - 1)
+    void *output,            // (batch, channels, seq_len)
+    void *present_state,     // (batch, channels, kernel_size - 1)
+    int64_t batch_size,
+    int64_t channels,
+    int64_t seq_len,
+    int64_t kernel_size,
+    int64_t ndim,
+    int64_t activation,      // 0=none, 1=silu/swish
+    int64_t element_size_bytes);
+
 //===----------------------------------------------------------------------===//
 // Low-Level HIP Wrappers
 //===----------------------------------------------------------------------===//

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -560,30 +560,27 @@ int wrap_qmoe(
 
 // CausalConvWithState operation wrapper (stateful causal depthwise convolution)
 // Used by Gated DeltaNet (Qwen3.5) and Mamba models.
-// Performs causal depthwise convolution with carry state for incremental decode.
-// The convolution is causal (looks only at current and past positions) and
-// depthwise (each channel convolved independently).
-// Input layout: channels-first (batch, channels, seq_len).
-// Weight layout: (channels, 1, kernel_size) for 1D depthwise.
+// Performs causal depthwise convolution with carry state for incremental
+// decode. The convolution is causal (looks only at current and past positions)
+// and depthwise (each channel convolved independently). Input layout:
+// channels-first (batch, channels, seq_len). Weight layout: (channels, 1,
+// kernel_size) for 1D depthwise.
 //   bias:       nullable - per-channel bias (channels)
-//   past_state: nullable - carry state from previous step (batch, channels, k-1)
-//   activation: 0=none, 1=silu/swish
+//   past_state: nullable - carry state from previous step (batch, channels,
+//   k-1) activation: 0=none, 1=silu/swish
 int wrap_causal_conv_with_state(
     RuntimeState *state,
-    const void *input,       // (batch, channels, seq_len)
-    const void *weight,      // (channels, 1, kernel_size)
-    const void *bias,        // nullable, (channels)
-    const void *past_state,  // nullable, (batch, channels, kernel_size - 1)
-    void *output,            // (batch, channels, seq_len)
-    void *present_state,     // (batch, channels, kernel_size - 1)
-    int64_t batch_size,
-    int64_t channels,
-    int64_t seq_len,
-    int64_t kernel_size,
+    const void *input,      // (batch, channels, seq_len)
+    const void *weight,     // (channels, 1, kernel_size)
+    const void *bias,       // nullable, (channels)
+    const void *past_state, // nullable, (batch, channels, kernel_size - 1)
+    void *output,           // (batch, channels, seq_len)
+    void *present_state,    // (batch, channels, kernel_size - 1)
+    int64_t batch_size, int64_t channels, int64_t seq_len, int64_t kernel_size,
     int64_t ndim,
-    int64_t activation,      // 0=none, 1=silu/swish
+    int64_t activation, // 0=none, 1=silu/swish
     int64_t element_size_bytes);
-  
+
 //==============================================================================
 // ONNX Gemm via hipBLASLt
 //==============================================================================

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -430,6 +430,35 @@ int wrap_miopenConvolutionForward(
   return 0;
 }
 
+int wrap_causal_conv_with_state(
+    RuntimeState *state, const void *input, const void *weight,
+    const void *bias, const void *past_state, void *output, void *present_state,
+    int64_t batch_size, int64_t channels, int64_t seq_len, int64_t kernel_size,
+    int64_t ndim, int64_t activation, int64_t element_size_bytes) {
+  if (!state || !input || !weight || !output || !present_state) {
+    fprintf(stderr,
+            "Invalid required argument in wrap_causal_conv_with_state\n");
+    return -1;
+  }
+
+  // CausalConvWithState fused activation enum: 0=none, 1=silu/swish.
+  // This is independent of hipdnn_ep_activation_name() which maps generic
+  // miopen activations (sigmoid/relu/tanh).
+  const char *act_name = (activation == 1) ? "silu" : "none";
+
+  MOCK_PRINT("[MOCK] wrap_causal_conv_with_state(\n");
+  MOCK_PRINT("[MOCK]   batch=%lld, channels=%lld, seq_len=%lld, kernel=%lld,\n",
+             (long long)batch_size, (long long)channels, (long long)seq_len,
+             (long long)kernel_size);
+  MOCK_PRINT("[MOCK]   ndim=%lld, activation=%s(%lld), elem_size=%lld,\n",
+             (long long)ndim, act_name, (long long)activation,
+             (long long)element_size_bytes);
+  MOCK_PRINT("[MOCK]   bias=%s, past_state=%s)\n", bias ? "yes" : "null",
+             past_state ? "yes" : "null");
+
+  return 0;
+}
+
 int wrap_hipblasLtGemm(void *handle, void *stream, int64_t m, int64_t n,
                        int64_t k, const void *alpha, const void *A,
                        const void *B, const void *beta, void *C) {

--- a/lib/Runtime/real/causal_conv_with_state.cpp
+++ b/lib/Runtime/real/causal_conv_with_state.cpp
@@ -1,0 +1,328 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#include "../debug_log.h"
+#include "../hipdnn_ep_runtime.h"
+#include "runtime_types.h"
+
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+//===----------------------------------------------------------------------===//
+// CausalConvWithState: Stateful Causal Depthwise Convolution
+//
+// Used by Gated DeltaNet (Qwen3.5) and Mamba (Jamba, FalconMamba).
+// Replaces the 3-op pattern (Concat + Conv + Slice) with a single fused op.
+//
+// Algorithm (1D, ndim=1):
+//   1. Build virtual input by prepending past_state to input:
+//      virtual = [past_state | input]  shape: (batch, channels, k-1 + L)
+//   2. Depthwise causal convolution over virtual input:
+//      For each output position t in [0, L):
+//        output[b,c,t] = sum_{j=0}^{k-1} weight[c,0,j] * virtual[b,c,t+j]
+//      Plus optional bias: output[b,c,t] += bias[c]
+//   3. Extract present_state = last (k-1) positions of virtual input:
+//      present_state[b,c,:] = virtual[b,c, L : L+k-1]
+//      (equivalently the last k-1 elements of the concatenation)
+//   4. Optional SiLU activation: output = output * sigmoid(output)
+//===----------------------------------------------------------------------===//
+
+// SiLU(x) = x * sigmoid(x) = x / (1 + exp(-x))
+template <typename T> static inline T silu(T x) {
+  return x / (static_cast<T>(1) + std::exp(-x));
+}
+
+int wrap_causal_conv_with_state(RuntimeState *state, const void *input,
+                                const void *weight, const void *bias,
+                                const void *past_state, void *output,
+                                void *present_state, int64_t batch_size,
+                                int64_t channels, int64_t seq_len,
+                                int64_t kernel_size, int64_t ndim,
+                                int64_t activation,
+                                int64_t element_size_bytes) {
+  if (!state || !input || !weight || !output || !present_state) {
+    fprintf(stderr,
+            "wrap_causal_conv_with_state: null required argument\n");
+    return -1;
+  }
+
+  RUNTIME_DEBUG_LOG("[REAL] wrap_causal_conv_with_state: batch=%lld, "
+                    "channels=%lld, seq_len=%lld, kernel=%lld, ndim=%lld, "
+                    "activation=%lld, elem_size=%lld\n",
+                    (long long)batch_size, (long long)channels,
+                    (long long)seq_len, (long long)kernel_size, (long long)ndim,
+                    (long long)activation, (long long)element_size_bytes);
+
+  hipStream_t stream =
+      static_cast<hipStream_t>(hipdnn_ep_state_get_stream(state));
+  if (!stream) {
+    fprintf(stderr, "wrap_causal_conv_with_state: null stream\n");
+    return -1;
+  }
+
+  // Currently only ndim=1 is implemented
+  if (ndim != 1) {
+    fprintf(stderr,
+            "wrap_causal_conv_with_state: ndim=%lld not yet supported "
+            "(only ndim=1)\n",
+            (long long)ndim);
+    return -1;
+  }
+
+  int64_t state_len = kernel_size - 1; // k-1
+  int64_t virtual_len = state_len + seq_len;
+
+  // Allocate temporary buffer for the virtual input on device:
+  // shape (batch, channels, state_len + seq_len) = (B, C, k-1+L)
+  int64_t virtual_size = batch_size * channels * virtual_len * element_size_bytes;
+  void *virtual_buf = nullptr;
+  hipError_t err = hipMalloc(&virtual_buf, virtual_size);
+  if (err != hipSuccess || !virtual_buf) {
+    fprintf(stderr, "wrap_causal_conv_with_state: hipMalloc failed for "
+                    "virtual buffer (%lld bytes)\n",
+            (long long)virtual_size);
+    return -1;
+  }
+
+  // Fill virtual buffer: [past_state | input] per (batch, channel)
+  // past_state shape: (B, C, k-1) or nullptr (zero-fill)
+  // input shape: (B, C, L)
+  for (int64_t b = 0; b < batch_size; ++b) {
+    for (int64_t c = 0; c < channels; ++c) {
+      int64_t bc = b * channels + c;
+      char *dst_base =
+          static_cast<char *>(virtual_buf) +
+          bc * virtual_len * element_size_bytes;
+
+      // Copy past_state portion (first k-1 elements)
+      if (past_state) {
+        const char *ps_src =
+            static_cast<const char *>(past_state) +
+            bc * state_len * element_size_bytes;
+        hipMemcpyAsync(dst_base, ps_src,
+                       state_len * element_size_bytes,
+                       hipMemcpyDeviceToDevice, stream);
+      } else {
+        hipMemsetAsync(dst_base, 0, state_len * element_size_bytes, stream);
+      }
+
+      // Copy input portion (last L elements)
+      const char *in_src =
+          static_cast<const char *>(input) +
+          bc * seq_len * element_size_bytes;
+      hipMemcpyAsync(dst_base + state_len * element_size_bytes, in_src,
+                     seq_len * element_size_bytes,
+                     hipMemcpyDeviceToDevice, stream);
+    }
+  }
+
+  // Extract present_state: last (k-1) positions from the virtual input
+  // present_state[b,c,:] = virtual[b,c, seq_len : seq_len + k-1]
+  for (int64_t b = 0; b < batch_size; ++b) {
+    for (int64_t c = 0; c < channels; ++c) {
+      int64_t bc = b * channels + c;
+      const char *src =
+          static_cast<const char *>(virtual_buf) +
+          (bc * virtual_len + seq_len) * element_size_bytes;
+      char *dst = static_cast<char *>(present_state) +
+                  bc * state_len * element_size_bytes;
+      hipMemcpyAsync(dst, src, state_len * element_size_bytes,
+                     hipMemcpyDeviceToDevice, stream);
+    }
+  }
+
+  // Perform depthwise causal convolution on the GPU.
+  // We use MIOpen convolution with group=channels for depthwise conv.
+  // Input to MIOpen: virtual_buf as (B, C, 1, virtual_len) [4D for MIOpen]
+  // Weight: (C, 1, 1, k) [depthwise: group=C, each filter sees 1 channel]
+  // Output: (B, C, 1, L)
+  //
+  // We use the existing miopenConvolutionForward for this.
+  miopenHandle_t handle =
+      static_cast<miopenHandle_t>(hipdnn_ep_state_get_miopen_handle(state));
+  if (!handle) {
+    hipFree(virtual_buf);
+    fprintf(stderr, "wrap_causal_conv_with_state: null MIOpen handle\n");
+    return -1;
+  }
+
+  // Determine MIOpen data type
+  miopenDataType_t dt;
+  if (element_size_bytes == 4)
+    dt = miopenFloat;
+  else if (element_size_bytes == 2)
+    dt = miopenHalf;
+  else {
+    hipFree(virtual_buf);
+    fprintf(stderr, "wrap_causal_conv_with_state: unsupported element_size "
+                    "%lld\n",
+            (long long)element_size_bytes);
+    return -1;
+  }
+
+  // Create tensor descriptors (4D: N, C, H, W)
+  miopenTensorDescriptor_t inDesc = nullptr, wDesc = nullptr,
+                           outDesc = nullptr;
+  miopenConvolutionDescriptor_t convDesc = nullptr;
+  miopenStatus_t mst;
+  int ret = 0;
+
+#define CAUSAL_MIOPEN_CHECK(call)                                              \
+  do {                                                                         \
+    mst = (call);                                                              \
+    if (mst != miopenStatusSuccess) {                                          \
+      fprintf(stderr, "wrap_causal_conv_with_state: MIOpen error %d at "       \
+                      "%s:%d\n",                                               \
+              mst, __FILE__, __LINE__);                                         \
+      ret = -1;                                                                \
+      goto cleanup;                                                            \
+    }                                                                          \
+  } while (0)
+
+  CAUSAL_MIOPEN_CHECK(miopenCreateTensorDescriptor(&inDesc));
+  CAUSAL_MIOPEN_CHECK(miopenCreateTensorDescriptor(&wDesc));
+  CAUSAL_MIOPEN_CHECK(miopenCreateTensorDescriptor(&outDesc));
+  CAUSAL_MIOPEN_CHECK(miopenCreateConvolutionDescriptor(&convDesc));
+
+  // Input: (B, C, 1, virtual_len)
+  CAUSAL_MIOPEN_CHECK(miopenSet4dTensorDescriptor(
+      inDesc, dt, static_cast<int>(batch_size), static_cast<int>(channels), 1,
+      static_cast<int>(virtual_len)));
+
+  // Weight: (C, 1, 1, kernel_size) for depthwise (group=C)
+  CAUSAL_MIOPEN_CHECK(miopenSet4dTensorDescriptor(
+      wDesc, dt, static_cast<int>(channels), 1, 1,
+      static_cast<int>(kernel_size)));
+
+  // Output: (B, C, 1, seq_len)
+  CAUSAL_MIOPEN_CHECK(miopenSet4dTensorDescriptor(
+      outDesc, dt, static_cast<int>(batch_size), static_cast<int>(channels), 1,
+      static_cast<int>(seq_len)));
+
+  // Convolution: pad=(0,0), stride=(1,1), dilation=(1,1), group=channels
+  CAUSAL_MIOPEN_CHECK(
+      miopenInitConvolutionDescriptor(convDesc, miopenConvolution,
+                                      /*pad_h=*/0, /*pad_w=*/0,
+                                      /*stride_h=*/1, /*stride_w=*/1,
+                                      /*dilation_h=*/1, /*dilation_w=*/1));
+  CAUSAL_MIOPEN_CHECK(
+      miopenSetConvolutionGroupCount(convDesc, static_cast<int>(channels)));
+
+  {
+    // Find algorithm
+    miopenConvAlgoPerf_t perfResult;
+    int returnedAlgoCount = 0;
+    size_t wsSize = 0;
+    CAUSAL_MIOPEN_CHECK(miopenConvolutionForwardGetWorkSpaceSize(
+        handle, wDesc, inDesc, convDesc, outDesc, &wsSize));
+
+    void *workspace = nullptr;
+    if (wsSize > 0) {
+      if (hipdnn_ep_state_ensure_workspace(state, wsSize) != 0) {
+        ret = -1;
+        goto cleanup;
+      }
+      workspace = hipdnn_ep_state_get_workspace(state);
+    }
+
+    CAUSAL_MIOPEN_CHECK(miopenFindConvolutionForwardAlgorithm(
+        handle, inDesc, virtual_buf, wDesc, weight, convDesc, outDesc, output,
+        /*requestAlgoCount=*/1, &returnedAlgoCount, &perfResult,
+        workspace, wsSize, /*exhaustiveSearch=*/false));
+
+    float alpha = 1.0f, beta = 0.0f;
+    CAUSAL_MIOPEN_CHECK(miopenConvolutionForward(
+        handle, &alpha, inDesc, virtual_buf, wDesc, weight, convDesc,
+        perfResult.fwd_algo, &beta, outDesc, output, workspace, wsSize));
+  }
+
+  // Add bias if present
+  if (bias) {
+    miopenTensorDescriptor_t biasDesc = nullptr;
+    CAUSAL_MIOPEN_CHECK(miopenCreateTensorDescriptor(&biasDesc));
+    CAUSAL_MIOPEN_CHECK(miopenSet4dTensorDescriptor(
+        biasDesc, dt, 1, static_cast<int>(channels), 1, 1));
+    float alpha_bias = 1.0f, beta_bias = 1.0f;
+    mst = miopenOpTensor(handle, miopenTensorOpAdd, &alpha_bias, outDesc,
+                         output, &alpha_bias, biasDesc, bias, &beta_bias,
+                         outDesc, output);
+    miopenDestroyTensorDescriptor(biasDesc);
+    if (mst != miopenStatusSuccess) {
+      fprintf(stderr, "wrap_causal_conv_with_state: bias add failed (%d)\n",
+              mst);
+      ret = -1;
+      goto cleanup;
+    }
+  }
+
+  // Apply activation (SiLU/Swish)
+  if (activation == 1) {
+    // Use MIOpen activation for sigmoid, then elementwise multiply
+    // SiLU(x) = x * sigmoid(x)
+    // We need a temp buffer for sigmoid(x)
+    int64_t output_size = batch_size * channels * seq_len * element_size_bytes;
+    void *sigmoid_buf = nullptr;
+    err = hipMalloc(&sigmoid_buf, output_size);
+    if (err != hipSuccess || !sigmoid_buf) {
+      fprintf(stderr,
+              "wrap_causal_conv_with_state: hipMalloc failed for "
+              "sigmoid buffer\n");
+      ret = -1;
+      goto cleanup;
+    }
+
+    // Compute sigmoid(output) -> sigmoid_buf
+    miopenActivationDescriptor_t actDesc = nullptr;
+    CAUSAL_MIOPEN_CHECK(miopenCreateActivationDescriptor(&actDesc));
+    CAUSAL_MIOPEN_CHECK(miopenSetActivationDescriptor(
+        actDesc, miopenActivationLOGISTIC, 0.0, 0.0, 0.0));
+
+    float alpha_act = 1.0f, beta_act = 0.0f;
+    mst = miopenActivationForward(handle, actDesc, &alpha_act, outDesc, output,
+                                  &beta_act, outDesc, sigmoid_buf);
+    miopenDestroyActivationDescriptor(actDesc);
+    if (mst != miopenStatusSuccess) {
+      hipFree(sigmoid_buf);
+      fprintf(stderr, "wrap_causal_conv_with_state: sigmoid failed (%d)\n",
+              mst);
+      ret = -1;
+      goto cleanup;
+    }
+
+    // Compute output = output * sigmoid_buf
+    float alpha_mul = 1.0f, beta_mul = 0.0f;
+    mst = miopenOpTensor(handle, miopenTensorOpMul, &alpha_mul, outDesc,
+                         output, &alpha_mul, outDesc, sigmoid_buf, &beta_mul,
+                         outDesc, output);
+    hipFree(sigmoid_buf);
+    if (mst != miopenStatusSuccess) {
+      fprintf(stderr, "wrap_causal_conv_with_state: mul failed (%d)\n", mst);
+      ret = -1;
+      goto cleanup;
+    }
+  }
+
+cleanup:
+  if (convDesc)
+    miopenDestroyConvolutionDescriptor(convDesc);
+  if (outDesc)
+    miopenDestroyTensorDescriptor(outDesc);
+  if (wDesc)
+    miopenDestroyTensorDescriptor(wDesc);
+  if (inDesc)
+    miopenDestroyTensorDescriptor(inDesc);
+  if (virtual_buf)
+    hipFree(virtual_buf);
+
+#undef CAUSAL_MIOPEN_CHECK
+
+  if (ret == 0) {
+    RUNTIME_DEBUG_LOG(
+        "[REAL] wrap_causal_conv_with_state: completed successfully\n");
+  }
+  return ret;
+}

--- a/lib/Runtime/real/causal_conv_with_state.cpp
+++ b/lib/Runtime/real/causal_conv_with_state.cpp
@@ -246,7 +246,7 @@ int wrap_causal_conv_with_state(RuntimeState *state, const void *input,
     CAUSAL_MIOPEN_CHECK(miopenCreateTensorDescriptor(&biasDesc));
     CAUSAL_MIOPEN_CHECK(miopenSet4dTensorDescriptor(
         biasDesc, dt, 1, static_cast<int>(channels), 1, 1));
-    float alpha_bias = 1.0f, beta_bias = 1.0f;
+    float alpha_bias = 1.0f, beta_bias = 0.0f;
     mst = miopenOpTensor(handle, miopenTensorOpAdd, &alpha_bias, outDesc,
                          output, &alpha_bias, biasDesc, bias, &beta_bias,
                          outDesc, output);

--- a/lib/Runtime/real/causal_conv_with_state.cpp
+++ b/lib/Runtime/real/causal_conv_with_state.cpp
@@ -160,7 +160,10 @@ int wrap_causal_conv_with_state(
 
   // Create tensor descriptors (4D: N, C, H, W)
   miopenTensorDescriptor_t inDesc = nullptr, wDesc = nullptr, outDesc = nullptr;
+  miopenTensorDescriptor_t biasDesc = nullptr;
   miopenConvolutionDescriptor_t convDesc = nullptr;
+  miopenActivationDescriptor_t actDesc = nullptr;
+  void *sigmoid_buf = nullptr;
   miopenStatus_t mst;
   int ret = 0;
 
@@ -236,30 +239,19 @@ int wrap_causal_conv_with_state(
 
   // Add bias if present
   if (bias) {
-    miopenTensorDescriptor_t biasDesc = nullptr;
     CAUSAL_MIOPEN_CHECK(miopenCreateTensorDescriptor(&biasDesc));
     CAUSAL_MIOPEN_CHECK(miopenSet4dTensorDescriptor(
         biasDesc, dt, 1, static_cast<int>(channels), 1, 1));
     float alpha_bias = 1.0f, beta_bias = 0.0f;
-    mst = miopenOpTensor(handle, miopenTensorOpAdd, &alpha_bias, outDesc,
-                         output, &alpha_bias, biasDesc, bias, &beta_bias,
-                         outDesc, output);
-    miopenDestroyTensorDescriptor(biasDesc);
-    if (mst != miopenStatusSuccess) {
-      fprintf(stderr, "wrap_causal_conv_with_state: bias add failed (%d)\n",
-              mst);
-      ret = -1;
-      goto cleanup;
-    }
+    CAUSAL_MIOPEN_CHECK(miopenOpTensor(handle, miopenTensorOpAdd, &alpha_bias,
+                                       outDesc, output, &alpha_bias, biasDesc,
+                                       bias, &beta_bias, outDesc, output));
   }
 
   // Apply activation (SiLU/Swish)
   if (activation == 1) {
-    // Use MIOpen activation for sigmoid, then elementwise multiply
     // SiLU(x) = x * sigmoid(x)
-    // We need a temp buffer for sigmoid(x)
     int64_t output_size = batch_size * channels * seq_len * element_size_bytes;
-    void *sigmoid_buf = nullptr;
     err = hipMalloc(&sigmoid_buf, output_size);
     if (err != hipSuccess || !sigmoid_buf) {
       fprintf(stderr, "wrap_causal_conv_with_state: hipMalloc failed for "
@@ -268,38 +260,28 @@ int wrap_causal_conv_with_state(
       goto cleanup;
     }
 
-    // Compute sigmoid(output) -> sigmoid_buf
-    miopenActivationDescriptor_t actDesc = nullptr;
     CAUSAL_MIOPEN_CHECK(miopenCreateActivationDescriptor(&actDesc));
     CAUSAL_MIOPEN_CHECK(miopenSetActivationDescriptor(
         actDesc, miopenActivationLOGISTIC, 0.0, 0.0, 0.0));
 
     float alpha_act = 1.0f, beta_act = 0.0f;
-    mst = miopenActivationForward(handle, actDesc, &alpha_act, outDesc, output,
-                                  &beta_act, outDesc, sigmoid_buf);
-    miopenDestroyActivationDescriptor(actDesc);
-    if (mst != miopenStatusSuccess) {
-      hipFree(sigmoid_buf);
-      fprintf(stderr, "wrap_causal_conv_with_state: sigmoid failed (%d)\n",
-              mst);
-      ret = -1;
-      goto cleanup;
-    }
+    CAUSAL_MIOPEN_CHECK(miopenActivationForward(handle, actDesc, &alpha_act,
+                                                outDesc, output, &beta_act,
+                                                outDesc, sigmoid_buf));
 
-    // Compute output = output * sigmoid_buf
     float alpha_mul = 1.0f, beta_mul = 0.0f;
-    mst = miopenOpTensor(handle, miopenTensorOpMul, &alpha_mul, outDesc, output,
-                         &alpha_mul, outDesc, sigmoid_buf, &beta_mul, outDesc,
-                         output);
-    hipFree(sigmoid_buf);
-    if (mst != miopenStatusSuccess) {
-      fprintf(stderr, "wrap_causal_conv_with_state: mul failed (%d)\n", mst);
-      ret = -1;
-      goto cleanup;
-    }
+    CAUSAL_MIOPEN_CHECK(miopenOpTensor(
+        handle, miopenTensorOpMul, &alpha_mul, outDesc, output, &alpha_mul,
+        outDesc, sigmoid_buf, &beta_mul, outDesc, output));
   }
 
 cleanup:
+  if (actDesc)
+    miopenDestroyActivationDescriptor(actDesc);
+  if (sigmoid_buf)
+    hipFree(sigmoid_buf);
+  if (biasDesc)
+    miopenDestroyTensorDescriptor(biasDesc);
   if (convDesc)
     miopenDestroyConvolutionDescriptor(convDesc);
   if (outDesc)

--- a/lib/Runtime/real/causal_conv_with_state.cpp
+++ b/lib/Runtime/real/causal_conv_with_state.cpp
@@ -36,17 +36,13 @@ template <typename T> static inline T silu(T x) {
   return x / (static_cast<T>(1) + std::exp(-x));
 }
 
-int wrap_causal_conv_with_state(RuntimeState *state, const void *input,
-                                const void *weight, const void *bias,
-                                const void *past_state, void *output,
-                                void *present_state, int64_t batch_size,
-                                int64_t channels, int64_t seq_len,
-                                int64_t kernel_size, int64_t ndim,
-                                int64_t activation,
-                                int64_t element_size_bytes) {
+int wrap_causal_conv_with_state(
+    RuntimeState *state, const void *input, const void *weight,
+    const void *bias, const void *past_state, void *output, void *present_state,
+    int64_t batch_size, int64_t channels, int64_t seq_len, int64_t kernel_size,
+    int64_t ndim, int64_t activation, int64_t element_size_bytes) {
   if (!state || !input || !weight || !output || !present_state) {
-    fprintf(stderr,
-            "wrap_causal_conv_with_state: null required argument\n");
+    fprintf(stderr, "wrap_causal_conv_with_state: null required argument\n");
     return -1;
   }
 
@@ -78,12 +74,14 @@ int wrap_causal_conv_with_state(RuntimeState *state, const void *input,
 
   // Allocate temporary buffer for the virtual input on device:
   // shape (batch, channels, state_len + seq_len) = (B, C, k-1+L)
-  int64_t virtual_size = batch_size * channels * virtual_len * element_size_bytes;
+  int64_t virtual_size =
+      batch_size * channels * virtual_len * element_size_bytes;
   void *virtual_buf = nullptr;
   hipError_t err = hipMalloc(&virtual_buf, virtual_size);
   if (err != hipSuccess || !virtual_buf) {
-    fprintf(stderr, "wrap_causal_conv_with_state: hipMalloc failed for "
-                    "virtual buffer (%lld bytes)\n",
+    fprintf(stderr,
+            "wrap_causal_conv_with_state: hipMalloc failed for "
+            "virtual buffer (%lld bytes)\n",
             (long long)virtual_size);
     return -1;
   }
@@ -94,17 +92,14 @@ int wrap_causal_conv_with_state(RuntimeState *state, const void *input,
   for (int64_t b = 0; b < batch_size; ++b) {
     for (int64_t c = 0; c < channels; ++c) {
       int64_t bc = b * channels + c;
-      char *dst_base =
-          static_cast<char *>(virtual_buf) +
-          bc * virtual_len * element_size_bytes;
+      char *dst_base = static_cast<char *>(virtual_buf) +
+                       bc * virtual_len * element_size_bytes;
 
       // Copy past_state portion (first k-1 elements)
       if (past_state) {
-        const char *ps_src =
-            static_cast<const char *>(past_state) +
-            bc * state_len * element_size_bytes;
-        hipMemcpyAsync(dst_base, ps_src,
-                       state_len * element_size_bytes,
+        const char *ps_src = static_cast<const char *>(past_state) +
+                             bc * state_len * element_size_bytes;
+        hipMemcpyAsync(dst_base, ps_src, state_len * element_size_bytes,
                        hipMemcpyDeviceToDevice, stream);
       } else {
         hipMemsetAsync(dst_base, 0, state_len * element_size_bytes, stream);
@@ -112,11 +107,10 @@ int wrap_causal_conv_with_state(RuntimeState *state, const void *input,
 
       // Copy input portion (last L elements)
       const char *in_src =
-          static_cast<const char *>(input) +
-          bc * seq_len * element_size_bytes;
+          static_cast<const char *>(input) + bc * seq_len * element_size_bytes;
       hipMemcpyAsync(dst_base + state_len * element_size_bytes, in_src,
-                     seq_len * element_size_bytes,
-                     hipMemcpyDeviceToDevice, stream);
+                     seq_len * element_size_bytes, hipMemcpyDeviceToDevice,
+                     stream);
     }
   }
 
@@ -125,9 +119,8 @@ int wrap_causal_conv_with_state(RuntimeState *state, const void *input,
   for (int64_t b = 0; b < batch_size; ++b) {
     for (int64_t c = 0; c < channels; ++c) {
       int64_t bc = b * channels + c;
-      const char *src =
-          static_cast<const char *>(virtual_buf) +
-          (bc * virtual_len + seq_len) * element_size_bytes;
+      const char *src = static_cast<const char *>(virtual_buf) +
+                        (bc * virtual_len + seq_len) * element_size_bytes;
       char *dst = static_cast<char *>(present_state) +
                   bc * state_len * element_size_bytes;
       hipMemcpyAsync(dst, src, state_len * element_size_bytes,
@@ -158,15 +151,15 @@ int wrap_causal_conv_with_state(RuntimeState *state, const void *input,
     dt = miopenHalf;
   else {
     hipFree(virtual_buf);
-    fprintf(stderr, "wrap_causal_conv_with_state: unsupported element_size "
-                    "%lld\n",
+    fprintf(stderr,
+            "wrap_causal_conv_with_state: unsupported element_size "
+            "%lld\n",
             (long long)element_size_bytes);
     return -1;
   }
 
   // Create tensor descriptors (4D: N, C, H, W)
-  miopenTensorDescriptor_t inDesc = nullptr, wDesc = nullptr,
-                           outDesc = nullptr;
+  miopenTensorDescriptor_t inDesc = nullptr, wDesc = nullptr, outDesc = nullptr;
   miopenConvolutionDescriptor_t convDesc = nullptr;
   miopenStatus_t mst;
   int ret = 0;
@@ -175,9 +168,10 @@ int wrap_causal_conv_with_state(RuntimeState *state, const void *input,
   do {                                                                         \
     mst = (call);                                                              \
     if (mst != miopenStatusSuccess) {                                          \
-      fprintf(stderr, "wrap_causal_conv_with_state: MIOpen error %d at "       \
-                      "%s:%d\n",                                               \
-              mst, __FILE__, __LINE__);                                         \
+      fprintf(stderr,                                                          \
+              "wrap_causal_conv_with_state: MIOpen error %d at "               \
+              "%s:%d\n",                                                       \
+              mst, __FILE__, __LINE__);                                        \
       ret = -1;                                                                \
       goto cleanup;                                                            \
     }                                                                          \
@@ -194,9 +188,9 @@ int wrap_causal_conv_with_state(RuntimeState *state, const void *input,
       static_cast<int>(virtual_len)));
 
   // Weight: (C, 1, 1, kernel_size) for depthwise (group=C)
-  CAUSAL_MIOPEN_CHECK(miopenSet4dTensorDescriptor(
-      wDesc, dt, static_cast<int>(channels), 1, 1,
-      static_cast<int>(kernel_size)));
+  CAUSAL_MIOPEN_CHECK(
+      miopenSet4dTensorDescriptor(wDesc, dt, static_cast<int>(channels), 1, 1,
+                                  static_cast<int>(kernel_size)));
 
   // Output: (B, C, 1, seq_len)
   CAUSAL_MIOPEN_CHECK(miopenSet4dTensorDescriptor(
@@ -231,8 +225,8 @@ int wrap_causal_conv_with_state(RuntimeState *state, const void *input,
 
     CAUSAL_MIOPEN_CHECK(miopenFindConvolutionForwardAlgorithm(
         handle, inDesc, virtual_buf, wDesc, weight, convDesc, outDesc, output,
-        /*requestAlgoCount=*/1, &returnedAlgoCount, &perfResult,
-        workspace, wsSize, /*exhaustiveSearch=*/false));
+        /*requestAlgoCount=*/1, &returnedAlgoCount, &perfResult, workspace,
+        wsSize, /*exhaustiveSearch=*/false));
 
     float alpha = 1.0f, beta = 0.0f;
     CAUSAL_MIOPEN_CHECK(miopenConvolutionForward(
@@ -268,9 +262,8 @@ int wrap_causal_conv_with_state(RuntimeState *state, const void *input,
     void *sigmoid_buf = nullptr;
     err = hipMalloc(&sigmoid_buf, output_size);
     if (err != hipSuccess || !sigmoid_buf) {
-      fprintf(stderr,
-              "wrap_causal_conv_with_state: hipMalloc failed for "
-              "sigmoid buffer\n");
+      fprintf(stderr, "wrap_causal_conv_with_state: hipMalloc failed for "
+                      "sigmoid buffer\n");
       ret = -1;
       goto cleanup;
     }
@@ -295,9 +288,9 @@ int wrap_causal_conv_with_state(RuntimeState *state, const void *input,
 
     // Compute output = output * sigmoid_buf
     float alpha_mul = 1.0f, beta_mul = 0.0f;
-    mst = miopenOpTensor(handle, miopenTensorOpMul, &alpha_mul, outDesc,
-                         output, &alpha_mul, outDesc, sigmoid_buf, &beta_mul,
-                         outDesc, output);
+    mst = miopenOpTensor(handle, miopenTensorOpMul, &alpha_mul, outDesc, output,
+                         &alpha_mul, outDesc, sigmoid_buf, &beta_mul, outDesc,
+                         output);
     hipFree(sigmoid_buf);
     if (mst != miopenStatusSuccess) {
       fprintf(stderr, "wrap_causal_conv_with_state: mul failed (%d)\n", mst);

--- a/test/lit/Conversion/hip-to-llvm/test_causal_conv_with_state.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_causal_conv_with_state.mlir
@@ -68,23 +68,23 @@ module {
     return
   }
 
-  // Test 3: f32 element type
-  func.func @causal_conv_f32(
+  // Test 3: Different shape, activation=none
+  func.func @causal_conv_no_activation(
       %ctx: !hip.context,
-      %input: memref<2x128x64xf32, 1>,
-      %weight: memref<128x1x3xf32, 1>,
-      %bias: memref<128xf32, 1>,
-      %past_state: memref<2x128x2xf32, 1>,
-      %output: memref<2x128x64xf32, 1>,
-      %present_state: memref<2x128x2xf32, 1>) {
-    // CHECK-LABEL: llvm.func @causal_conv_f32
+      %input: memref<2x128x64xf16, 1>,
+      %weight: memref<128x1x3xf16, 1>,
+      %bias: memref<128xf16, 1>,
+      %past_state: memref<2x128x2xf16, 1>,
+      %output: memref<2x128x64xf16, 1>,
+      %present_state: memref<2x128x2xf16, 1>) {
+    // CHECK-LABEL: llvm.func @causal_conv_no_activation
 
     hip.causal_conv_with_state(%ctx)
         ins(%input, %weight, %bias, %past_state :
-            memref<2x128x64xf32, 1>, memref<128x1x3xf32, 1>,
-            memref<128xf32, 1>, memref<2x128x2xf32, 1>)
+            memref<2x128x64xf16, 1>, memref<128x1x3xf16, 1>,
+            memref<128xf16, 1>, memref<2x128x2xf16, 1>)
         outs(%output, %present_state :
-             memref<2x128x64xf32, 1>, memref<2x128x2xf32, 1>)
+             memref<2x128x64xf16, 1>, memref<2x128x2xf16, 1>)
         {activation = "none", ndim = 1 : i64}
 
     // CHECK: llvm.call @wrap_causal_conv_with_state({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64) -> i32

--- a/test/lit/Conversion/hip-to-llvm/test_causal_conv_with_state.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_causal_conv_with_state.mlir
@@ -12,11 +12,22 @@
 // - Optional inputs (bias, past_state) passed as pointers (null when absent)
 // - Two output buffers (output, present_state) forwarded
 // - Attributes (activation, ndim) converted to integer args
-// - Shape info (batch, channels, seq_len, kernel_size) extracted
+// - Shape info (batch, channels, seq_len, kernel_size) extracted:
+//     * static dims become llvm.mlir.constant
+//     * dynamic dims become llvm.extractvalue %desc[3, N] (+ llvm.mul for
+//       composite sizes like seq_len and kernel_size)
 //
 // Expected: wrap_causal_conv_with_state(state, input, weight, bias,
 //           past_state, output, present_state, batch_size, channels,
 //           seq_len, kernel_size, ndim, activation, element_size_bytes)
+//
+// Test cases:
+// 1. causal_conv_full                  — all static, bias + past_state, silu
+// 2. causal_conv_no_optional           — all static, no bias / past_state
+// 3. causal_conv_no_activation         — all static, activation=none
+// 4. causal_conv_dynamic_activations   — dynamic input/output, static weight
+// 5. causal_conv_fully_dynamic         — dynamic input AND dynamic weight
+//                                         (validates kernel_size extraction)
 // ============================================================================
 
 // RUN: hip-mlir-opt %s --convert-hip-to-llvm | FileCheck %s
@@ -87,6 +98,77 @@ module {
              memref<2x128x64xf16, 1>, memref<2x128x2xf16, 1>)
         {activation = "none", ndim = 1 : i64}
 
+    // CHECK: llvm.call @wrap_causal_conv_with_state({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64) -> i32
+
+    return
+  }
+
+  // --------------------------------------------------------------------------
+  // Test 4: Dynamic input/output (batch + seq_len dynamic, weight static).
+  // Typical LLM incremental-decode scenario.
+  //
+  // Expectations:
+  // - batch_size / channels / seq_len extracted at runtime via
+  //   llvm.extractvalue from the input MemRef descriptor (indices [3, 0..2]).
+  // - kernel_size still a compile-time constant since weight is static.
+  // --------------------------------------------------------------------------
+  func.func @causal_conv_dynamic_activations(
+      %ctx: !hip.context,
+      %input: memref<?x?x?xf16, 1>,
+      %weight: memref<64x1x4xf16, 1>,
+      %bias: memref<64xf16, 1>,
+      %past_state: memref<?x?x3xf16, 1>,
+      %output: memref<?x?x?xf16, 1>,
+      %present_state: memref<?x?x3xf16, 1>) {
+    // CHECK-LABEL: llvm.func @causal_conv_dynamic_activations
+
+    hip.causal_conv_with_state(%ctx)
+        ins(%input, %weight, %bias, %past_state :
+            memref<?x?x?xf16, 1>, memref<64x1x4xf16, 1>,
+            memref<64xf16, 1>, memref<?x?x3xf16, 1>)
+        outs(%output, %present_state :
+             memref<?x?x?xf16, 1>, memref<?x?x3xf16, 1>)
+        {activation = "silu", ndim = 1 : i64}
+
+    // Runtime-extracted dims from input descriptor: batch, channels, seq_len.
+    // CHECK: llvm.extractvalue {{.*}}[3, 0]
+    // CHECK: llvm.extractvalue {{.*}}[3, 1]
+    // CHECK: llvm.extractvalue {{.*}}[3, 2]
+    // kernel_size = 4 remains a compile-time constant from static weight.
+    // CHECK: llvm.mlir.constant(4 : i64)
+    // CHECK: llvm.call @wrap_causal_conv_with_state({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64) -> i32
+
+    return
+  }
+
+  // --------------------------------------------------------------------------
+  // Test 5: Fully dynamic (input, weight, and state all dynamic).
+  // Validates the kernel_size fix: weight's kernel dim must also be extracted
+  // at runtime via llvm.extractvalue, not multiplied as kDynamic sentinel.
+  // --------------------------------------------------------------------------
+  func.func @causal_conv_fully_dynamic(
+      %ctx: !hip.context,
+      %input: memref<?x?x?xf16, 1>,
+      %weight: memref<?x1x?xf16, 1>,
+      %output: memref<?x?x?xf16, 1>,
+      %present_state: memref<?x?x?xf16, 1>) {
+    // CHECK-LABEL: llvm.func @causal_conv_fully_dynamic
+
+    hip.causal_conv_with_state(%ctx)
+        ins(%input, %weight :
+            memref<?x?x?xf16, 1>, memref<?x1x?xf16, 1>)
+        outs(%output, %present_state :
+             memref<?x?x?xf16, 1>, memref<?x?x?xf16, 1>)
+        {ndim = 1 : i64}
+
+    // All 3 input dims extracted at runtime.
+    // CHECK: llvm.extractvalue {{.*}}[3, 0]
+    // CHECK: llvm.extractvalue {{.*}}[3, 1]
+    // CHECK: llvm.extractvalue {{.*}}[3, 2]
+    // kernel_size is now built as: 1 * weight.dim[2] at runtime.
+    // CHECK: llvm.mlir.constant(1 : i64)
+    // CHECK: llvm.extractvalue {{.*}}[3, 2]
+    // CHECK: llvm.mul
     // CHECK: llvm.call @wrap_causal_conv_with_state({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64) -> i32
 
     return

--- a/test/lit/Conversion/hip-to-llvm/test_causal_conv_with_state.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_causal_conv_with_state.mlir
@@ -1,0 +1,94 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify HIP causal_conv_with_state operation is correctly lowered to LLVM
+// call to wrap_causal_conv_with_state runtime function.
+//
+// This test validates:
+// - hip.causal_conv_with_state -> llvm.call @wrap_causal_conv_with_state
+// - Type conversion: !hip.context -> !llvm.ptr
+// - Optional inputs (bias, past_state) passed as pointers (null when absent)
+// - Two output buffers (output, present_state) forwarded
+// - Attributes (activation, ndim) converted to integer args
+// - Shape info (batch, channels, seq_len, kernel_size) extracted
+//
+// Expected: wrap_causal_conv_with_state(state, input, weight, bias,
+//           past_state, output, present_state, batch_size, channels,
+//           seq_len, kernel_size, ndim, activation, element_size_bytes)
+// ============================================================================
+
+// RUN: hip-mlir-opt %s --convert-hip-to-llvm | FileCheck %s
+
+module {
+  // Test 1: Full op with bias and past_state, activation=silu
+  func.func @causal_conv_full(
+      %ctx: !hip.context,
+      %input: memref<1x64x128xf16, 1>,
+      %weight: memref<64x1x4xf16, 1>,
+      %bias: memref<64xf16, 1>,
+      %past_state: memref<1x64x3xf16, 1>,
+      %output: memref<1x64x128xf16, 1>,
+      %present_state: memref<1x64x3xf16, 1>) {
+    // CHECK-LABEL: llvm.func @causal_conv_full
+    // CHECK-SAME: %[[CTX:.*]]: !llvm.ptr
+
+    hip.causal_conv_with_state(%ctx)
+        ins(%input, %weight, %bias, %past_state :
+            memref<1x64x128xf16, 1>, memref<64x1x4xf16, 1>,
+            memref<64xf16, 1>, memref<1x64x3xf16, 1>)
+        outs(%output, %present_state :
+             memref<1x64x128xf16, 1>, memref<1x64x3xf16, 1>)
+        {activation = "silu", ndim = 1 : i64}
+
+    // CHECK: llvm.call @wrap_causal_conv_with_state({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64) -> i32
+
+    return
+  }
+
+  // Test 2: No optional inputs (no bias, no past_state)
+  func.func @causal_conv_no_optional(
+      %ctx: !hip.context,
+      %input: memref<1x64x128xf16, 1>,
+      %weight: memref<64x1x4xf16, 1>,
+      %output: memref<1x64x128xf16, 1>,
+      %present_state: memref<1x64x3xf16, 1>) {
+    // CHECK-LABEL: llvm.func @causal_conv_no_optional
+
+    hip.causal_conv_with_state(%ctx)
+        ins(%input, %weight :
+            memref<1x64x128xf16, 1>, memref<64x1x4xf16, 1>)
+        outs(%output, %present_state :
+             memref<1x64x128xf16, 1>, memref<1x64x3xf16, 1>)
+        {ndim = 1 : i64}
+
+    // CHECK: llvm.call @wrap_causal_conv_with_state({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64) -> i32
+
+    return
+  }
+
+  // Test 3: f32 element type
+  func.func @causal_conv_f32(
+      %ctx: !hip.context,
+      %input: memref<2x128x64xf32, 1>,
+      %weight: memref<128x1x3xf32, 1>,
+      %bias: memref<128xf32, 1>,
+      %past_state: memref<2x128x2xf32, 1>,
+      %output: memref<2x128x64xf32, 1>,
+      %present_state: memref<2x128x2xf32, 1>) {
+    // CHECK-LABEL: llvm.func @causal_conv_f32
+
+    hip.causal_conv_with_state(%ctx)
+        ins(%input, %weight, %bias, %past_state :
+            memref<2x128x64xf32, 1>, memref<128x1x3xf32, 1>,
+            memref<128xf32, 1>, memref<2x128x2xf32, 1>)
+        outs(%output, %present_state :
+             memref<2x128x64xf32, 1>, memref<2x128x2xf32, 1>)
+        {activation = "none", ndim = 1 : i64}
+
+    // CHECK: llvm.call @wrap_causal_conv_with_state({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64) -> i32
+
+    return
+  }
+}

--- a/test/lit/Conversion/onnx-to-hip/test_causal_conv_with_state.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_causal_conv_with_state.mlir
@@ -1,0 +1,122 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify com.microsoft.CausalConvWithState is correctly lowered to
+// hip.causal_conv_with_state in tensor-first mode.
+//
+// Test cases:
+// 1. causal_conv_basic        — 1D with bias and past_state, activation=silu
+// 2. causal_conv_no_optional  — no bias, no past_state
+// 3. causal_conv_bias_only    — with bias, no past_state
+// 4. causal_conv_f32          — f32 element type
+//
+// All cases assert:
+// - context argument prepended
+// - tensor.empty() for output init and present_state init
+// - attributes forwarded (activation, ndim)
+// ============================================================================
+
+// RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip | FileCheck %s
+
+module {
+  func.func @main_graph(%arg0: tensor<1x64x128xf16>) -> tensor<1x64x128xf16> {
+    return %arg0 : tensor<1x64x128xf16>
+  }
+
+  // --------------------------------------------------------------------------
+  // 1. Basic 1D causal conv with bias, past_state, activation=silu
+  // --------------------------------------------------------------------------
+  func.func @causal_conv_basic(
+      %input: tensor<1x64x128xf16>,
+      %weight: tensor<64x1x4xf16>,
+      %bias: tensor<64xf16>,
+      %past_state: tensor<1x64x3xf16>
+  ) -> (tensor<1x64x128xf16>, tensor<1x64x3xf16>) {
+    %output, %present_state = "onnx.Custom"(%input, %weight, %bias, %past_state) {
+      function_name = "CausalConvWithState",
+      domain_name = "com.microsoft",
+      activation = "silu",
+      ndim = 1 : si64
+    } : (tensor<1x64x128xf16>, tensor<64x1x4xf16>, tensor<64xf16>, tensor<1x64x3xf16>)
+      -> (tensor<1x64x128xf16>, tensor<1x64x3xf16>)
+    return %output, %present_state : tensor<1x64x128xf16>, tensor<1x64x3xf16>
+  }
+
+  // CHECK-LABEL: func.func @causal_conv_basic
+  // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[IN:.*]]: tensor<1x64x128xf16>, %[[W:.*]]: tensor<64x1x4xf16>, %[[B:.*]]: tensor<64xf16>, %[[PS:.*]]: tensor<1x64x3xf16>)
+  // CHECK: tensor.empty() : tensor<1x64x128xf16>
+  // CHECK: tensor.empty() : tensor<1x64x3xf16>
+  // CHECK: hip.causal_conv_with_state(%[[CTX]]) ins(%[[IN]], %[[W]], %[[B]], %[[PS]] : tensor<1x64x128xf16>, tensor<64x1x4xf16>, tensor<64xf16>, tensor<1x64x3xf16>) outs({{.*}}, {{.*}} : tensor<1x64x128xf16>, tensor<1x64x3xf16>) {activation = "silu", ndim = 1 : i64}
+  // CHECK-NOT: hip.alloc
+
+  // --------------------------------------------------------------------------
+  // 2. No optional inputs (no bias, no past_state)
+  // --------------------------------------------------------------------------
+  func.func @causal_conv_no_optional(
+      %input: tensor<1x64x128xf16>,
+      %weight: tensor<64x1x4xf16>
+  ) -> (tensor<1x64x128xf16>, tensor<1x64x3xf16>) {
+    %none = "onnx.NoValue"() {value} : () -> none
+    %output, %present_state = "onnx.Custom"(%input, %weight, %none, %none) {
+      function_name = "CausalConvWithState",
+      domain_name = "com.microsoft",
+      ndim = 1 : si64
+    } : (tensor<1x64x128xf16>, tensor<64x1x4xf16>, none, none)
+      -> (tensor<1x64x128xf16>, tensor<1x64x3xf16>)
+    return %output, %present_state : tensor<1x64x128xf16>, tensor<1x64x3xf16>
+  }
+
+  // CHECK-LABEL: func.func @causal_conv_no_optional
+  // CHECK-SAME: (%[[CTX2:.*]]: !hip.context, %[[IN2:.*]]: tensor<1x64x128xf16>, %[[W2:.*]]: tensor<64x1x4xf16>)
+  // CHECK: hip.causal_conv_with_state(%[[CTX2]]) ins(%[[IN2]], %[[W2]] : tensor<1x64x128xf16>, tensor<64x1x4xf16>) outs({{.*}}, {{.*}} : tensor<1x64x128xf16>, tensor<1x64x3xf16>)
+  // CHECK-NOT: hip.alloc
+
+  // --------------------------------------------------------------------------
+  // 3. With bias only (no past_state)
+  // --------------------------------------------------------------------------
+  func.func @causal_conv_bias_only(
+      %input: tensor<1x64x128xf16>,
+      %weight: tensor<64x1x4xf16>,
+      %bias: tensor<64xf16>
+  ) -> (tensor<1x64x128xf16>, tensor<1x64x3xf16>) {
+    %none = "onnx.NoValue"() {value} : () -> none
+    %output, %present_state = "onnx.Custom"(%input, %weight, %bias, %none) {
+      function_name = "CausalConvWithState",
+      domain_name = "com.microsoft",
+      ndim = 1 : si64
+    } : (tensor<1x64x128xf16>, tensor<64x1x4xf16>, tensor<64xf16>, none)
+      -> (tensor<1x64x128xf16>, tensor<1x64x3xf16>)
+    return %output, %present_state : tensor<1x64x128xf16>, tensor<1x64x3xf16>
+  }
+
+  // CHECK-LABEL: func.func @causal_conv_bias_only
+  // CHECK-SAME: (%[[CTX3:.*]]: !hip.context, %[[IN3:.*]]: tensor<1x64x128xf16>, %[[W3:.*]]: tensor<64x1x4xf16>, %[[B3:.*]]: tensor<64xf16>)
+  // CHECK: hip.causal_conv_with_state(%[[CTX3]]) ins(%[[IN3]], %[[W3]], %[[B3]] : tensor<1x64x128xf16>, tensor<64x1x4xf16>, tensor<64xf16>) outs({{.*}}, {{.*}} : tensor<1x64x128xf16>, tensor<1x64x3xf16>)
+  // CHECK-NOT: hip.alloc
+
+  // --------------------------------------------------------------------------
+  // 4. f32 element type
+  // --------------------------------------------------------------------------
+  func.func @causal_conv_f32(
+      %input: tensor<2x128x64xf32>,
+      %weight: tensor<128x1x3xf32>,
+      %bias: tensor<128xf32>,
+      %past_state: tensor<2x128x2xf32>
+  ) -> (tensor<2x128x64xf32>, tensor<2x128x2xf32>) {
+    %output, %present_state = "onnx.Custom"(%input, %weight, %bias, %past_state) {
+      function_name = "CausalConvWithState",
+      domain_name = "com.microsoft",
+      activation = "none",
+      ndim = 1 : si64
+    } : (tensor<2x128x64xf32>, tensor<128x1x3xf32>, tensor<128xf32>, tensor<2x128x2xf32>)
+      -> (tensor<2x128x64xf32>, tensor<2x128x2xf32>)
+    return %output, %present_state : tensor<2x128x64xf32>, tensor<2x128x2xf32>
+  }
+
+  // CHECK-LABEL: func.func @causal_conv_f32
+  // CHECK-SAME: !hip.context
+  // CHECK: hip.causal_conv_with_state({{.*}}) ins({{.*}}) outs({{.*}}) {activation = "none", ndim = 1 : i64}
+  // CHECK-NOT: hip.alloc
+}

--- a/test/lit/Conversion/onnx-to-hip/test_causal_conv_with_state.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_causal_conv_with_state.mlir
@@ -10,7 +10,7 @@
 // 1. causal_conv_basic        — 1D with bias and past_state, activation=silu
 // 2. causal_conv_no_optional  — no bias, no past_state
 // 3. causal_conv_bias_only    — with bias, no past_state
-// 4. causal_conv_f32          — f32 element type
+// 4. causal_conv_no_activation — different shape, activation=none
 //
 // All cases assert:
 // - context argument prepended
@@ -48,7 +48,7 @@ module {
   // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[IN:.*]]: tensor<1x64x128xf16>, %[[W:.*]]: tensor<64x1x4xf16>, %[[B:.*]]: tensor<64xf16>, %[[PS:.*]]: tensor<1x64x3xf16>)
   // CHECK: tensor.empty() : tensor<1x64x128xf16>
   // CHECK: tensor.empty() : tensor<1x64x3xf16>
-  // CHECK: hip.causal_conv_with_state(%[[CTX]]) ins(%[[IN]], %[[W]], %[[B]], %[[PS]] : tensor<1x64x128xf16>, tensor<64x1x4xf16>, tensor<64xf16>, tensor<1x64x3xf16>) outs({{.*}}, {{.*}} : tensor<1x64x128xf16>, tensor<1x64x3xf16>) {activation = "silu", ndim = 1 : i64}
+  // CHECK: hip.causal_conv_with_state(%[[CTX]]) ins(%[[IN]], %[[W]], %[[B]], %[[PS]] : tensor<1x64x128xf16>, tensor<64x1x4xf16>, tensor<64xf16>, tensor<1x64x3xf16>) outs({{.*}}, {{.*}} : tensor<1x64x128xf16>, tensor<1x64x3xf16>) {activation = "silu"}
   // CHECK-NOT: hip.alloc
 
   // --------------------------------------------------------------------------
@@ -97,26 +97,26 @@ module {
   // CHECK-NOT: hip.alloc
 
   // --------------------------------------------------------------------------
-  // 4. f32 element type
+  // 4. Different shape, activation=none
   // --------------------------------------------------------------------------
-  func.func @causal_conv_f32(
-      %input: tensor<2x128x64xf32>,
-      %weight: tensor<128x1x3xf32>,
-      %bias: tensor<128xf32>,
-      %past_state: tensor<2x128x2xf32>
-  ) -> (tensor<2x128x64xf32>, tensor<2x128x2xf32>) {
+  func.func @causal_conv_no_activation(
+      %input: tensor<2x128x64xf16>,
+      %weight: tensor<128x1x3xf16>,
+      %bias: tensor<128xf16>,
+      %past_state: tensor<2x128x2xf16>
+  ) -> (tensor<2x128x64xf16>, tensor<2x128x2xf16>) {
     %output, %present_state = "onnx.Custom"(%input, %weight, %bias, %past_state) {
       function_name = "CausalConvWithState",
       domain_name = "com.microsoft",
       activation = "none",
       ndim = 1 : si64
-    } : (tensor<2x128x64xf32>, tensor<128x1x3xf32>, tensor<128xf32>, tensor<2x128x2xf32>)
-      -> (tensor<2x128x64xf32>, tensor<2x128x2xf32>)
-    return %output, %present_state : tensor<2x128x64xf32>, tensor<2x128x2xf32>
+    } : (tensor<2x128x64xf16>, tensor<128x1x3xf16>, tensor<128xf16>, tensor<2x128x2xf16>)
+      -> (tensor<2x128x64xf16>, tensor<2x128x2xf16>)
+    return %output, %present_state : tensor<2x128x64xf16>, tensor<2x128x2xf16>
   }
 
-  // CHECK-LABEL: func.func @causal_conv_f32
+  // CHECK-LABEL: func.func @causal_conv_no_activation
   // CHECK-SAME: !hip.context
-  // CHECK: hip.causal_conv_with_state({{.*}}) ins({{.*}}) outs({{.*}}) {activation = "none", ndim = 1 : i64}
+  // CHECK: hip.causal_conv_with_state({{.*}}) ins({{.*}}) outs({{.*}})
   // CHECK-NOT: hip.alloc
 }

--- a/test/lit/Conversion/onnx-to-hip/test_causal_conv_with_state.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_causal_conv_with_state.mlir
@@ -7,15 +7,21 @@
 // hip.causal_conv_with_state in tensor-first mode.
 //
 // Test cases:
-// 1. causal_conv_basic        — 1D with bias and past_state, activation=silu
-// 2. causal_conv_no_optional  — no bias, no past_state
-// 3. causal_conv_bias_only    — with bias, no past_state
-// 4. causal_conv_no_activation — different shape, activation=none
+// 1. causal_conv_basic                   — 1D with bias and past_state, activation=silu
+// 2. causal_conv_no_optional             — no bias, no past_state
+// 3. causal_conv_bias_only               — with bias, no past_state
+// 4. causal_conv_no_activation           — different shape, activation=none
+// 5. causal_conv_dynamic                 — dynamic batch + seq_len (LLM decode)
+// 6. causal_conv_dynamic_no_past_state   — dynamic input with no past_state
 //
-// All cases assert:
+// All static cases assert:
 // - context argument prepended
 // - tensor.empty() for output init and present_state init
 // - attributes forwarded (activation, ndim)
+//
+// Dynamic cases additionally assert:
+// - tensor.dim extracts each dynamic dim at runtime
+// - tensor.empty(%dim...) takes those sizes as dynamic operands
 // ============================================================================
 
 // RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip | FileCheck %s
@@ -118,5 +124,73 @@ module {
   // CHECK-LABEL: func.func @causal_conv_no_activation
   // CHECK-SAME: !hip.context
   // CHECK: hip.causal_conv_with_state({{.*}}) ins({{.*}}) outs({{.*}})
+  // CHECK-NOT: hip.alloc
+
+  // --------------------------------------------------------------------------
+  // 5. Dynamic shape: batch + seq_len dynamic (typical LLM inference).
+  //    Weight and kernel dim are static (k-1=3), past_state shares the
+  //    dynamic batch axis.
+  //
+  //    Expectations:
+  //    - output init: tensor.dim for dims 0 and 2 of input + tensor.empty with
+  //      two dynamic sizes.
+  //    - present_state init: tensor.dim for dim 0 of past_state + tensor.empty
+  //      with one dynamic size.
+  // --------------------------------------------------------------------------
+  func.func @causal_conv_dynamic(
+      %input: tensor<?x64x?xf16>,
+      %weight: tensor<64x1x4xf16>,
+      %bias: tensor<64xf16>,
+      %past_state: tensor<?x64x3xf16>
+  ) -> (tensor<?x64x?xf16>, tensor<?x64x3xf16>) {
+    %output, %present_state = "onnx.Custom"(%input, %weight, %bias, %past_state) {
+      function_name = "CausalConvWithState",
+      domain_name = "com.microsoft",
+      activation = "silu",
+      ndim = 1 : si64
+    } : (tensor<?x64x?xf16>, tensor<64x1x4xf16>, tensor<64xf16>, tensor<?x64x3xf16>)
+      -> (tensor<?x64x?xf16>, tensor<?x64x3xf16>)
+    return %output, %present_state : tensor<?x64x?xf16>, tensor<?x64x3xf16>
+  }
+
+  // CHECK-LABEL: func.func @causal_conv_dynamic
+  // CHECK-SAME: (%[[CTX5:.*]]: !hip.context, %[[IN5:.*]]: tensor<?x64x?xf16>, %[[W5:.*]]: tensor<64x1x4xf16>, %[[B5:.*]]: tensor<64xf16>, %[[PS5:.*]]: tensor<?x64x3xf16>)
+  // output init: dims 0 and 2 of input extracted at runtime, fed into empty.
+  // CHECK: tensor.dim %[[IN5]]
+  // CHECK: tensor.dim %[[IN5]]
+  // CHECK: tensor.empty({{.*}}) : tensor<?x64x?xf16>
+  // present_state init: dim 0 of past_state extracted at runtime.
+  // CHECK: tensor.dim %[[PS5]]
+  // CHECK: tensor.empty({{.*}}) : tensor<?x64x3xf16>
+  // CHECK: hip.causal_conv_with_state(%[[CTX5]]) ins(%[[IN5]], %[[W5]], %[[B5]], %[[PS5]] : tensor<?x64x?xf16>, tensor<64x1x4xf16>, tensor<64xf16>, tensor<?x64x3xf16>) outs({{.*}}, {{.*}} : tensor<?x64x?xf16>, tensor<?x64x3xf16>) {activation = "silu"
+  // CHECK-NOT: hip.alloc
+
+  // --------------------------------------------------------------------------
+  // 6. Fully dynamic without past_state: pastState is absent so present_state
+  //    init derives dynamic sizes from input (batch). kernel_size (k-1=3)
+  //    remains static because weight is static.
+  // --------------------------------------------------------------------------
+  func.func @causal_conv_dynamic_no_past_state(
+      %input: tensor<?x64x?xf16>,
+      %weight: tensor<64x1x4xf16>
+  ) -> (tensor<?x64x?xf16>, tensor<?x64x3xf16>) {
+    %none = "onnx.NoValue"() {value} : () -> none
+    %output, %present_state = "onnx.Custom"(%input, %weight, %none, %none) {
+      function_name = "CausalConvWithState",
+      domain_name = "com.microsoft",
+      ndim = 1 : si64
+    } : (tensor<?x64x?xf16>, tensor<64x1x4xf16>, none, none)
+      -> (tensor<?x64x?xf16>, tensor<?x64x3xf16>)
+    return %output, %present_state : tensor<?x64x?xf16>, tensor<?x64x3xf16>
+  }
+
+  // CHECK-LABEL: func.func @causal_conv_dynamic_no_past_state
+  // CHECK-SAME: (%[[CTX6:.*]]: !hip.context, %[[IN6:.*]]: tensor<?x64x?xf16>, %[[W6:.*]]: tensor<64x1x4xf16>)
+  // CHECK: tensor.dim %[[IN6]]
+  // CHECK: tensor.empty({{.*}}) : tensor<?x64x?xf16>
+  // present_state falls back to input for dim extraction (batch only).
+  // CHECK: tensor.dim %[[IN6]]
+  // CHECK: tensor.empty({{.*}}) : tensor<?x64x3xf16>
+  // CHECK: hip.causal_conv_with_state(%[[CTX6]]) ins(%[[IN6]], %[[W6]] : tensor<?x64x?xf16>, tensor<64x1x4xf16>) outs({{.*}}, {{.*}} : tensor<?x64x?xf16>, tensor<?x64x3xf16>)
   // CHECK-NOT: hip.alloc
 }

--- a/test/lit/e2e/test_causal_conv_with_state_model.mlir
+++ b/test/lit/e2e/test_causal_conv_with_state_model.mlir
@@ -1,0 +1,50 @@
+// RUN: hip-mlir-opt %s --hipdnn-pipeline | FileCheck %s
+
+// Test CausalConvWithState E2E full pipeline
+// This IR represents a com.microsoft.CausalConvWithState operation imported
+// via onnx-mlir as an onnx.Custom op. Used by Gated DeltaNet (Qwen3.5) and
+// Mamba (Jamba, FalconMamba) models.
+//
+// The model has one onnx.Custom with f16 tensors:
+//   inputs:  input (B=1, C=64, L=128), weight (64, 1, k=4),
+//            bias (64), past_state (1, 64, k-1=3)
+//   outputs: output (1, 64, 128), present_state (1, 64, 3)
+//   attrs:   activation = "silu", ndim = 1
+//
+// Verifies the complete hipdnn-pipeline:
+// 1. convert-onnx-to-hip: onnx.Custom (CausalConvWithState)
+//                         → hip.causal_conv_with_state
+// 2. canonicalize: Simplify redundant operations
+// 3. memory-pooling: Pool output and present_state buffers into single alloc
+// 4. convert-hip-to-llvm: HIP ops → LLVM runtime calls
+// 5. generate-interface: Create inference_init/compute/cleanup/metadata
+
+// CHECK: module attributes {
+// CHECK-SAME: hipdnn.input_count = 4
+// CHECK-SAME: hipdnn.output_count = 2
+// CHECK: llvm.func @wrap_causal_conv_with_state
+// CHECK: llvm.func @inference_init
+// CHECK: llvm.func @inference_compute
+// CHECK: llvm.func @inference_cleanup
+// CHECK: llvm.func @inference_get_metadata_json
+// CHECK-NOT: onnx.Custom
+module {
+  func.func @main_graph(
+      %arg0: tensor<1x64x128xf16> {onnx.name = "input"},
+      %arg1: tensor<64x1x4xf16> {onnx.name = "weight"},
+      %arg2: tensor<64xf16> {onnx.name = "bias"},
+      %arg3: tensor<1x64x3xf16> {onnx.name = "past_state"})
+      -> (tensor<1x64x128xf16> {onnx.name = "output"},
+          tensor<1x64x3xf16> {onnx.name = "present_state"}) {
+    %0:2 = "onnx.Custom"(%arg0, %arg1, %arg2, %arg3) {
+      function_name = "CausalConvWithState",
+      domain_name = "com.microsoft",
+      onnx_node_name = "causal_conv_node",
+      activation = "silu",
+      ndim = 1 : si64
+    } : (tensor<1x64x128xf16>, tensor<64x1x4xf16>, tensor<64xf16>, tensor<1x64x3xf16>)
+      -> (tensor<1x64x128xf16>, tensor<1x64x3xf16>)
+    "onnx.Return"(%0#0, %0#1) : (tensor<1x64x128xf16>, tensor<1x64x3xf16>) -> ()
+  }
+  "onnx.EntryPoint"() {func = @main_graph} : () -> ()
+}

--- a/tools/hip-mlir-opt/hip-mlir-opt.cpp
+++ b/tools/hip-mlir-opt/hip-mlir-opt.cpp
@@ -125,6 +125,8 @@ void registerHipBufferizableOpInterfaceModels(mlir::DialectRegistry &registry) {
         HipDstBufferizableModel<mlir::hip::MatMulNBitsOp>>(*ctx);
     mlir::hip::QMoEOp::attachInterface<
         HipDstBufferizableModel<mlir::hip::QMoEOp>>(*ctx);
+    mlir::hip::CausalConvWithStateOp::attachInterface<
+        HipDstBufferizableModel<mlir::hip::CausalConvWithStateOp>>(*ctx);
     mlir::hip::HipDNNGraphOp::attachInterface<
         HipDstBufferizableModel<mlir::hip::HipDNNGraphOp>>(*ctx);
   });


### PR DESCRIPTION
## Motivation

Gated DeltaNet (Qwen3.5) and Mamba-based models (Jamba, FalconMamba) use a causal depthwise convolution with carry state for incremental decoding. In ONNX, this is represented as a com.microsoft.CausalConvWithState custom op. Without native support, the runtime falls back to a 3-op pattern (Concat + Conv + Slice), which is suboptimal. This PR adds first-class support for it throughout the entire compilation pipeline.

## Technical Details

Full-stack implementation of hip.causal_conv_with_state:

* Dialect definition (HipOps.td): New DPS op with optional bias/past_state inputs, output/present_state outputs, and activation/ndim attributes.
* ONNX → HIP conversion (CausalConvWithStateConversion.cpp): Matches onnx.Custom with function_name = "CausalConvWithState" and domain_name = "com.microsoft", creates DPS init tensors, and forwards attributes.
* HIP → LLVM lowering (CausalConvWithStateLowering.cpp): Extracts shape info (batch, channels, seq_len, kernel_size) from memref types, converts activation string to enum, and emits an LLVM call to the runtime wrapper.
* GPU runtime (causal_conv_with_state.cpp): Builds a virtual input buffer by prepending past_state to input, runs MIOpen grouped convolution (group=channels for depthwise), adds optional bias via miopenOpTensor, and applies optional SiLU activation via miopenActivationForward + elementwise multiply. Extracts present_state from the tail of the virtual buffer.
* Bufferization & dialect support: Registered bufferizable interface; implemented getDpsInitsMutable() and memory effects.

## Test Plan

onnx-to-hip
- [x] LIT tests: 4 cases (basic with all inputs, no optional inputs, bias-only)

- [x] hip-to-llvm
LIT tests: 3 cases (full op, no optional inputs)

- [x] Verify runtime correctness with end-to-end model inference on a supported AMD GPU

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
