### PR TITLE
feat: add linearattention op

### DIFF
--- a/3rd-party/custom_kernels/CMakeLists.txt
+++ b/3rd-party/custom_kernels/CMakeLists.txt
@@ -37,6 +37,7 @@ hip_add_library(hip_custom_kernels STATIC
     hip/reduce_sum_kernel.hip
     hip/matmul_nbits_kernel.hip
     hip/qmoe_kernel.hip
+    hip/linear_attention_kernel.hip
     INCLUDE_DIRECTORIES
         ${CMAKE_CURRENT_SOURCE_DIR}/include
 )

--- a/3rd-party/custom_kernels/hip/linear_attention_kernel.hip
+++ b/3rd-party/custom_kernels/hip/linear_attention_kernel.hip
@@ -1,0 +1,265 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <cstdint>
+#include <cstdio>
+#include <cmath>
+
+#include "hip_custom_kernels.h"
+#include "debug_log.h"
+
+static constexpr int LA_THREADS = 256;
+
+static constexpr int LA_RULE_LINEAR      = 0;
+static constexpr int LA_RULE_GATED       = 1;
+static constexpr int LA_RULE_DELTA       = 2;
+static constexpr int LA_RULE_GATED_DELTA = 3;
+
+template<typename T> __device__ __forceinline__ float to_float(T val);
+template<> __device__ __forceinline__ float to_float(float val) { return val; }
+template<> __device__ __forceinline__ float to_float(__half val) { return __half2float(val); }
+
+template<typename T> __device__ __forceinline__ T from_float(float val);
+template<> __device__ __forceinline__ float from_float(float val) { return val; }
+template<> __device__ __forceinline__ __half from_float(float val) { return __float2half(val); }
+
+//===----------------------------------------------------------------------===//
+// Fused T=1 linear attention decode kernel
+//===----------------------------------------------------------------------===//
+//
+// One thread-block per (batch, kv_head) pair.
+//
+// Phase 1 (delta/gated_delta only):
+//   Compute sk[j] = sum_i [exp(g[i]) *] S_old[i][j] * k[i]  for j in [0, dv)
+//
+// Phase 2: Update state  S[dk, dv]  in-place.
+//   linear:       S[i][j]  += k[i] * v[j]
+//   gated:        S[i][j]   = exp(g[i]) * S[i][j] + k[i] * v[j]
+//   delta:        S[i][j]  += beta * k[i] * (v[j] - sk[j])
+//   gated_delta:  S[i][j]   = exp(g[i]) * S[i][j] + beta * k[i] * (v[j] - sk[j])
+//
+// Phase 3: For each query head h mapped to this KV group:
+//   o[j] = scale * sum_i q_h[i] * S[i][j]
+//
+// Shared memory layout (all float for accumulation precision):
+//   k_smem[dk] | v_smem[dv] | aux_smem[dk] | sk_smem[dv]
+//   aux_smem holds exp(g) during phases 1-2, then q during phase 3.
+//
+template <typename T>
+__global__ void linear_attention_decode_kernel(
+    const T* __restrict__ query,
+    const T* __restrict__ key,
+    const T* __restrict__ value,
+    const T* __restrict__ decay,
+    const T* __restrict__ beta_in,
+    T* __restrict__ state,
+    T* __restrict__ output,
+    int Hq, int Hkv, int dk, int dv,
+    float scale, int update_rule)
+{
+    const int bg = blockIdx.x;
+    const int b  = bg / Hkv;
+    const int g  = bg % Hkv;
+    const int tid = threadIdx.x;
+    const int nthreads = blockDim.x;
+    const int state_size = dk * dv;
+
+    extern __shared__ float smem[];
+    float* k_smem   = smem;
+    float* v_smem   = smem + dk;
+    float* aux_smem = smem + dk + dv;
+    float* sk_smem  = smem + 2 * dk + dv;
+
+    const T* k_ptr = key   + (int64_t)b * Hkv * dk + (int64_t)g * dk;
+    const T* v_ptr = value + (int64_t)b * Hkv * dv + (int64_t)g * dv;
+    T* S = state + ((int64_t)b * Hkv + g) * dk * dv;
+
+    for (int i = tid; i < dk; i += nthreads)
+        k_smem[i] = to_float(k_ptr[i]);
+    for (int j = tid; j < dv; j += nthreads)
+        v_smem[j] = to_float(v_ptr[j]);
+
+    const bool has_decay =
+        (update_rule == LA_RULE_GATED || update_rule == LA_RULE_GATED_DELTA) &&
+        decay != nullptr;
+
+    if (has_decay) {
+        const T* d_ptr = decay + (int64_t)b * Hkv * dk + (int64_t)g * dk;
+        for (int i = tid; i < dk; i += nthreads)
+            aux_smem[i] = expf(to_float(d_ptr[i]));
+    }
+
+    float beta_val = 0.0f;
+    if (beta_in &&
+        (update_rule == LA_RULE_DELTA || update_rule == LA_RULE_GATED_DELTA))
+        beta_val = to_float(beta_in[(int64_t)b * Hkv + g]);
+
+    __syncthreads();
+
+    // === Phase 1: S^T @ k (with optional decay weighting) ===
+    const bool needs_sk =
+        (update_rule == LA_RULE_DELTA || update_rule == LA_RULE_GATED_DELTA);
+
+    if (needs_sk) {
+        for (int j = tid; j < dv; j += nthreads) {
+            float sum = 0.0f;
+            for (int i = 0; i < dk; i++) {
+                float s_ij = to_float(S[i * dv + j]);
+                float k_i  = k_smem[i];
+                sum += (has_decay ? aux_smem[i] : 1.0f) * s_ij * k_i;
+            }
+            sk_smem[j] = sum;
+        }
+        __syncthreads();
+    }
+
+    // === Phase 2: state update ===
+    for (int idx = tid; idx < state_size; idx += nthreads) {
+        const int i = idx / dv;
+        const int j = idx % dv;
+
+        float s_val = to_float(S[idx]);
+        const float k_i = k_smem[i];
+        const float v_j = v_smem[j];
+
+        switch (update_rule) {
+        case LA_RULE_LINEAR:
+            s_val += k_i * v_j;
+            break;
+        case LA_RULE_GATED:
+            s_val = aux_smem[i] * s_val + k_i * v_j;
+            break;
+        case LA_RULE_DELTA:
+            s_val += beta_val * k_i * (v_j - sk_smem[j]);
+            break;
+        case LA_RULE_GATED_DELTA:
+            s_val = aux_smem[i] * s_val + beta_val * k_i * (v_j - sk_smem[j]);
+            break;
+        }
+
+        S[idx] = from_float<T>(s_val);
+    }
+    __syncthreads();
+
+    // === Phase 3: output = scale * S^T @ q  (per query head) ===
+    const int heads_per_group = Hq / Hkv;
+    float* q_smem = aux_smem;
+
+    for (int hl = 0; hl < heads_per_group; hl++) {
+        const int h = g * heads_per_group + hl;
+        const T* q_ptr = query  + (int64_t)b * Hq * dk + (int64_t)h * dk;
+        T* out_ptr     = output + (int64_t)b * Hq * dv + (int64_t)h * dv;
+
+        for (int i = tid; i < dk; i += nthreads)
+            q_smem[i] = to_float(q_ptr[i]);
+        __syncthreads();
+
+        for (int j = tid; j < dv; j += nthreads) {
+            float sum = 0.0f;
+            for (int i = 0; i < dk; i++)
+                sum += q_smem[i] * to_float(S[i * dv + j]);
+            out_ptr[j] = from_float<T>(scale * sum);
+        }
+        __syncthreads();
+    }
+}
+
+//===----------------------------------------------------------------------===//
+// Host-side launcher
+//===----------------------------------------------------------------------===//
+
+extern "C" int hip_linear_attention_decode(
+    void* stream,
+    const void* query,
+    const void* key,
+    const void* value,
+    const void* decay,
+    const void* beta,
+    void* state,
+    void* output,
+    int64_t batch_size,
+    int64_t q_num_heads,
+    int64_t kv_num_heads,
+    int64_t head_dim_k,
+    int64_t head_dim_v,
+    float scale,
+    int64_t update_rule,
+    int64_t element_size_bytes)
+{
+    if (batch_size <= 0 || kv_num_heads <= 0)
+        return 0;
+
+    if (q_num_heads % kv_num_heads != 0) {
+        fprintf(stderr,
+                "[custom_kernels] hip_linear_attention_decode: "
+                "q_num_heads(%lld) not divisible by kv_num_heads(%lld)\n",
+                (long long)q_num_heads, (long long)kv_num_heads);
+        return -1;
+    }
+
+    hipStream_t hip_stream = static_cast<hipStream_t>(stream);
+    int grid  = static_cast<int>(batch_size * kv_num_heads);
+    int block = LA_THREADS;
+    int dk = static_cast<int>(head_dim_k);
+    int dv = static_cast<int>(head_dim_v);
+
+    size_t smem_bytes = static_cast<size_t>(2 * dk + 2 * dv) * sizeof(float);
+
+    CUSTOM_KERNELS_DEBUG_LOG(
+        "[custom_kernels] hip_linear_attention_decode: B=%lld Hq=%lld "
+        "Hkv=%lld dk=%d dv=%d scale=%.6f rule=%lld elem=%lld "
+        "grid=%d block=%d smem=%zu\n",
+        (long long)batch_size, (long long)q_num_heads,
+        (long long)kv_num_heads, dk, dv, (double)scale,
+        (long long)update_rule, (long long)element_size_bytes,
+        grid, block, smem_bytes);
+
+    if (element_size_bytes == 2) {
+        hipLaunchKernelGGL(
+            linear_attention_decode_kernel<__half>,
+            dim3(grid), dim3(block), smem_bytes, hip_stream,
+            static_cast<const __half*>(query),
+            static_cast<const __half*>(key),
+            static_cast<const __half*>(value),
+            static_cast<const __half*>(decay),
+            static_cast<const __half*>(beta),
+            static_cast<__half*>(state),
+            static_cast<__half*>(output),
+            static_cast<int>(q_num_heads),
+            static_cast<int>(kv_num_heads),
+            dk, dv, scale, static_cast<int>(update_rule));
+    } else if (element_size_bytes == 4) {
+        hipLaunchKernelGGL(
+            linear_attention_decode_kernel<float>,
+            dim3(grid), dim3(block), smem_bytes, hip_stream,
+            static_cast<const float*>(query),
+            static_cast<const float*>(key),
+            static_cast<const float*>(value),
+            static_cast<const float*>(decay),
+            static_cast<const float*>(beta),
+            static_cast<float*>(state),
+            static_cast<float*>(output),
+            static_cast<int>(q_num_heads),
+            static_cast<int>(kv_num_heads),
+            dk, dv, scale, static_cast<int>(update_rule));
+    } else {
+        fprintf(stderr,
+                "[custom_kernels] hip_linear_attention_decode: "
+                "unsupported element_size %lld\n",
+                (long long)element_size_bytes);
+        return -1;
+    }
+
+    hipError_t err = hipGetLastError();
+    if (err != hipSuccess) {
+        fprintf(stderr,
+                "[custom_kernels] hip_linear_attention_decode launch "
+                "failed: %s\n",
+                hipGetErrorString(err));
+    }
+    return static_cast<int>(err);
+}

--- a/3rd-party/custom_kernels/hip/linear_attention_kernel.hip
+++ b/3rd-party/custom_kernels/hip/linear_attention_kernel.hip
@@ -77,8 +77,19 @@ template<> __device__ __forceinline__ __hip_bfloat16 from_float(float val) {
 // H_kv); this KV head reads from key head  h_k = g * n_k / H_kv.
 //
 // Shared memory layout (all float for accumulation precision):
-//   k_smem[dk] | v_smem[dv] | aux_smem[dk] | sk_smem[dv]
-//   aux_smem holds exp(g) during phases 1-2, then q during phase 3.
+//   k_smem[dk] | v_smem[dv] | aux_smem[dk] | sk_smem[dv] | q_smem[Nq * dk]
+//   aux_smem holds exp(g) for phases 1-2-3 (decay).
+//   q_smem holds all Q heads sharing this KV state (loaded once, used in
+//   the fused phase 2+3 readout).  Nq = (Hq >= Hkv) ? Hq/Hkv : 1.
+//
+// Phase 2 and Phase 3 are fused along the j (d_v) axis to avoid the fp16
+// round-trip on S that would otherwise appear between the state write and
+// the readout reload.  Each thread owns a stripe of j columns; for every j
+// it sequentially computes the fp32 column S_new[:, j], writes it back to
+// global S as fp16, and uses the *pre-rounding* fp32 value to accumulate
+// the readout sum for every Q head sharing this KV state.  The readout
+// inner product is therefore performed entirely in fp32, matching the CPU
+// kernel (which keeps S in fp32 between update and readout).
 //
 template <typename T>
 __global__ void linear_attention_decode_kernel(
@@ -94,20 +105,38 @@ __global__ void linear_attention_decode_kernel(
     float scale, int update_rule,
     int decay_per_key_dim, int beta_per_head)
 {
+    // Upper bound on Q heads sharing one KV state.  Used to size a per-thread
+    // register accumulator array.  The host launcher rejects launches that
+    // exceed this bound.
+    constexpr int MAX_Q_HEADS = 16;
+
     const int bg = blockIdx.x;
     const int b  = bg / Hkv;
     const int g  = bg % Hkv;
     const int tid = threadIdx.x;
     const int nthreads = blockDim.x;
-    const int state_size = dk * dv;
 
     // Output head count: max(Hq, Hkv).  Determines stride of output and
-    // controls which branch of Phase 3 runs.
+    // controls the inverse-GQA branch of the fused readout.
     const int Hout = Hq >= Hkv ? Hq : Hkv;
+
+    // GQA direction.  Standard: Hq >= Hkv, this KV state feeds num_q_heads
+    // distinct Q heads.  Inverse: Hq < Hkv, multiple KV heads share a single
+    // Q head, but each KV head still writes its own output slot.
+    const bool inverse_gqa = (Hq < Hkv);
+    const int num_q_heads  = inverse_gqa ? 1 : (Hq / Hkv);
+
+    // Q head indices for the q_smem load:
+    //   inverse GQA: single Q head h_q = g * Hq / Hkv (shared)
+    //   standard   : consecutive heads h_q = g*num_q_heads + hl, hl in [0,Nq)
+    const int h_q_load_base = inverse_gqa ? (g * Hq / Hkv) : (g * num_q_heads);
+    // Output slot base index:
+    //   inverse GQA: write to output[g, j]                 (Hout == Hkv)
+    //   standard   : write to output[g*num_q_heads + hl, j] (Hout == Hq)
+    const int h_out_base    = inverse_gqa ? g : (g * num_q_heads);
 
     // Key-head index for this (b, g): n_k divides Hkv, so multiple KV heads
     // sharing the same K head produce the same index.
-    // this support inverse GQA
     const int h_k = g * n_k / Hkv;
 
     // Per-batch strides for the packed [B, T, H*D] tensors. The kernel reads
@@ -129,11 +158,13 @@ __global__ void linear_attention_decode_kernel(
     extern __shared__ float smem[];
     float* k_smem   = smem;
     float* v_smem   = smem + dk;
-    float* aux_smem = smem + dk + dv;
-    float* sk_smem  = smem + 2 * dk + dv;
-    const T* k_ptr = key   + b * k_batch_stride + (int64_t)h_k * dk;    // k_ptr = &key[b, t, h_k, 0]
-    const T* v_ptr = value + b * v_batch_stride + (int64_t)g   * dv;    // v_ptr = &value[b, t, g, 0]
-    T* S = state + b* state_batch_stride + g * dk * dv;
+    float* aux_smem = smem + dk + dv;          // decay (phases 1-2-3 fused)
+    float* sk_smem  = smem + 2 * dk + dv;      // per-j sk values (phase 1)
+    float* q_smem   = smem + 2 * dk + 2 * dv;  // num_q_heads * dk
+
+    const T* k_ptr = key   + b * k_batch_stride + (int64_t)h_k * dk;    // &key[b, t, h_k, 0]
+    const T* v_ptr = value + b * v_batch_stride + (int64_t)g   * dv;    // &value[b, t, g, 0]
+    T* S = state + b * state_batch_stride + (int64_t)g * dk * dv;
 
     for (int i = tid; i < dk; i += nthreads)
         k_smem[i] = to_float(k_ptr[i]);
@@ -170,12 +201,23 @@ __global__ void linear_attention_decode_kernel(
         beta_val = to_float(beta_in[beta_idx]);
     }
 
+    // Pre-load every Q head sharing this KV state into q_smem.  For inverse
+    // GQA only one head exists; for standard GQA all heads in the group are
+    // loaded so the fused inner loop can update sums for every head against
+    // the fp32 s_new before it is rounded to fp16.
+    for (int hl = 0; hl < num_q_heads; hl++) {
+        const int h_q = h_q_load_base + (inverse_gqa ? 0 : hl);
+        const T* q_ptr_h = query + b * q_batch_stride + (int64_t)h_q * dk;
+        for (int i = tid; i < dk; i += nthreads)
+            q_smem[hl * dk + i] = to_float(q_ptr_h[i]);
+    }
+
     __syncthreads();
 
     // === Phase 1: S^T @ k (with optional decay weighting) ===
     const bool needs_sk =
         (update_rule == LA_RULE_DELTA || update_rule == LA_RULE_GATED_DELTA);
-//todo
+
     if (needs_sk) {
         for (int j = tid; j < dv; j += nthreads) {
             float sum = 0.0f;
@@ -189,72 +231,65 @@ __global__ void linear_attention_decode_kernel(
         __syncthreads();
     }
 
-    // === Phase 2: state update ===
-    for (int idx = tid; idx < state_size; idx += nthreads) {
-        const int i = idx / dv;
-        const int j = idx % dv;
+    // === Phase 2 + Phase 3 fused (per-j stripe) ===
+    //
+    // Each thread owns the j columns { tid, tid+nthreads, ... } < dv.
+    // For each owned j it walks i = 0..dk-1 sequentially, computing
+    //   s_new = update_rule(s_old, decay_i, k_i, v_j, beta, sk_j)   [fp32]
+    // then:
+    //   1. writes fp16 S[i*dv+j]  = from_float(s_new)
+    //   2. accumulates  sums[hl] += q_smem[hl*dk + i] * s_new      [fp32]
+    // After the i loop completes, output[h_out, j] = scale * sums[hl] is
+    // written for every Q head (cast back to T).
+    //
+    // The crucial point is that the readout sum uses the *pre-rounding* fp32
+    // s_new, so the per-step fp16 quantization noise on S no longer enters
+    // the dk-element inner product, matching CPU's fp32-internal kernel.
+    for (int j = tid; j < dv; j += nthreads) {
+        const float v_j  = v_smem[j];
+        const float sk_j = needs_sk ? sk_smem[j] : 0.0f;
 
-        float s_val = to_float(S[idx]);
-        const float k_i = k_smem[i];
-        const float v_j = v_smem[j];
+        float sums[MAX_Q_HEADS];
+        #pragma unroll
+        for (int hl = 0; hl < MAX_Q_HEADS; hl++) sums[hl] = 0.0f;
 
-        switch (update_rule) {
-        case LA_RULE_LINEAR:
-            s_val += k_i * v_j;
-            break;
-        case LA_RULE_GATED:
-            s_val = aux_smem[i] * s_val + k_i * v_j;
-            break;
-        case LA_RULE_DELTA:
-            s_val += beta_val * k_i * (v_j - sk_smem[j]);
-            break;
-        case LA_RULE_GATED_DELTA:
-            s_val = aux_smem[i] * s_val + beta_val * k_i * (v_j - sk_smem[j]);
-            break;
+        for (int i = 0; i < dk; i++) {
+            const float s_old   = to_float(S[i * dv + j]);
+            const float k_i     = k_smem[i];
+            const float decay_i = has_decay ? aux_smem[i] : 1.0f;
+
+            float s_new;
+            switch (update_rule) {
+            case LA_RULE_LINEAR:
+                s_new = s_old + k_i * v_j;
+                break;
+            case LA_RULE_GATED:
+                s_new = decay_i * s_old + k_i * v_j;
+                break;
+            case LA_RULE_DELTA:
+                s_new = s_old + beta_val * k_i * (v_j - sk_j);
+                break;
+            case LA_RULE_GATED_DELTA:
+                s_new = decay_i * s_old + beta_val * k_i * (v_j - sk_j);
+                break;
+            default:
+                s_new = s_old;
+            }
+
+            S[i * dv + j] = from_float<T>(s_new);
+
+            #pragma unroll
+            for (int hl = 0; hl < MAX_Q_HEADS; hl++) {
+                if (hl < num_q_heads)
+                    sums[hl] += q_smem[hl * dk + i] * s_new;
+            }
         }
 
-        S[idx] = from_float<T>(s_val);
-    }
-    __syncthreads();
-
-    // === Phase 3: output = scale * S^T @ q  (per query head) ===
-    // Dispatches on GQA direction:
-    //   Standard (Hq >= Hkv): loop over Hq/Hkv Q heads sharing this KV state,
-    //                          write each to output[h_q * dv] (Hout == Hq).
-    //   Inverse  (Hq <  Hkv): single Q head shared across Hkv/Hq KV heads;
-    //                          write to output[g * dv] (Hout == Hkv).
-    float* q_smem = aux_smem;
-
-    auto readout = [&](const T* q_ptr, T* out_ptr) {
-        for (int i = tid; i < dk; i += nthreads)
-            q_smem[i] = to_float(q_ptr[i]);
-        __syncthreads();
-
-        for (int j = tid; j < dv; j += nthreads) {
-            float sum = 0.0f;
-            for (int i = 0; i < dk; i++)
-                sum += q_smem[i] * to_float(S[i * dv + j]);
-            out_ptr[j] = from_float<T>(scale * sum);
+        for (int hl = 0; hl < num_q_heads; hl++) {
+            const int h_out = h_out_base + (inverse_gqa ? 0 : hl);
+            T* out_ptr = output + b * out_batch_stride + (int64_t)h_out * dv + j;
+            *out_ptr = from_float<T>(scale * sums[hl]);
         }
-        __syncthreads();
-    };
-
-    if (Hq >= Hkv) {
-        const int heads_per_group = Hq / Hkv;
-        for (int hl = 0; hl < heads_per_group; hl++) {
-            const int h = g * heads_per_group + hl;
-            const T* q_ptr = query  + b * q_batch_stride   + (int64_t)h * dk;
-            T* out_ptr     = output + b * out_batch_stride + (int64_t)h * dv;
-            readout(q_ptr, out_ptr);
-        }
-    } else {
-        // Inverse GQA: this KV head maps to a single Q head (shared across
-        // Hkv / Hq consecutive KV heads), but each KV head writes its own
-        // output slot -> Hout = Hkv output heads.
-        const int h_q = g * Hq / Hkv;
-        const T* q_ptr = query  + b * q_batch_stride   + (int64_t)h_q * dk;
-        T* out_ptr     = output + b * out_batch_stride + (int64_t)g   * dv;
-        readout(q_ptr, out_ptr);
     }
 }
 
@@ -342,7 +377,26 @@ extern "C" int hip_linear_attention_decode(
     const int decay_per_key_dim_i = decay_per_key_dim ? 1 : 0;
     const int beta_per_head_i     = beta_per_head     ? 1 : 0;
 
-    size_t smem_bytes = static_cast<size_t>(2 * dk_i + 2 * dv_i) * sizeof(float);
+    // num_q_heads = number of Q heads sharing one KV state (1 in inverse GQA).
+    // Must match the kernel's MAX_Q_HEADS bound for the per-thread register
+    // accumulator array (sums[MAX_Q_HEADS]).  Keep this in sync with the
+    // kernel-side constant.
+    constexpr int MAX_Q_HEADS = 16;
+    const int num_q_heads = (Hq >= Hkv) ? static_cast<int>(Hq / Hkv) : 1;
+    if (num_q_heads > MAX_Q_HEADS) {
+        fprintf(stderr,
+                "[custom_kernels] hip_linear_attention_decode: "
+                "num_q_heads(%d) exceeds MAX_Q_HEADS(%d); "
+                "increase the kernel-side bound to support this GQA ratio\n",
+                num_q_heads, MAX_Q_HEADS);
+        return -1;
+    }
+
+    // smem layout: k_smem[dk] | v_smem[dv] | aux_smem[dk] | sk_smem[dv] |
+    //              q_smem[num_q_heads * dk]
+    size_t smem_bytes =
+        static_cast<size_t>(2 * dk_i + 2 * dv_i + num_q_heads * dk_i) *
+        sizeof(float);
 
     CUSTOM_KERNELS_DEBUG_LOG(
         "[custom_kernels] hip_linear_attention_decode: B=%lld seq_len=%lld "

--- a/3rd-party/custom_kernels/hip/linear_attention_kernel.hip
+++ b/3rd-party/custom_kernels/hip/linear_attention_kernel.hip
@@ -45,6 +45,12 @@ template<> __device__ __forceinline__ __hip_bfloat16 from_float(float val) {
 // launch (e.g. query + t * Hq*dk*elem_size); seq_len is the original T
 // dimension and is used here only to compute the per-batch stride.
 //
+// decay and beta each support two logical layouts (selected at runtime):
+//   decay_per_key_dim = 1 -> [B, T, H_kv * d_k]
+//                       0 -> [B, T, H_kv]   (scalar per head, broadcast on d_k)
+//   beta_per_head     = 1 -> [B, T, H_kv]
+//                       0 -> [B, T, 1]      (scalar per (B,T), broadcast on H_kv)
+//
 // Phase 1 (delta/gated_delta only):
 //   Compute sk[j] = sum_i [exp(g[i]) *] S_old[i][j] * k[i]  for j in [0, dv)
 //
@@ -85,7 +91,8 @@ __global__ void linear_attention_decode_kernel(
     T* __restrict__ output,
     int seq_len,
     int Hq, int Hkv, int n_k, int dk, int dv,
-    float scale, int update_rule)
+    float scale, int update_rule,
+    int decay_per_key_dim, int beta_per_head)
 {
     const int bg = blockIdx.x;
     const int b  = bg / Hkv;
@@ -104,13 +111,18 @@ __global__ void linear_attention_decode_kernel(
 
     // Per-batch strides for the packed [B, T, H*D] tensors. The kernel reads
     // a single time step; the caller has already advanced the pointer to
-    // `t`, so we only need the batch stride here.
-    const int64_t q_batch_stride     = (int64_t)seq_len * Hq   * dk;
-    const int64_t k_batch_stride     = (int64_t)seq_len * n_k  * dk;
-    const int64_t v_batch_stride     = (int64_t)seq_len * Hkv  * dv;
-    const int64_t out_batch_stride   = (int64_t)seq_len * Hout * dv;
-    const int64_t decay_batch_stride = (int64_t)seq_len * Hkv  * dk;
-    const int64_t beta_batch_stride  = (int64_t)seq_len * Hkv;
+    // `t`, so we only need the batch stride here. decay / beta strides depend
+    // on the logical layout flags.
+    const int64_t q_batch_stride   = (int64_t)seq_len * Hq   * dk;
+    const int64_t k_batch_stride   = (int64_t)seq_len * n_k  * dk;
+    const int64_t v_batch_stride   = (int64_t)seq_len * Hkv  * dv;
+    const int64_t out_batch_stride = (int64_t)seq_len * Hout * dv;
+    const int64_t decay_batch_stride = decay_per_key_dim
+        ? (int64_t)seq_len * Hkv * dk
+        : (int64_t)seq_len * Hkv;
+    const int64_t beta_batch_stride = beta_per_head
+        ? (int64_t)seq_len * Hkv
+        : (int64_t)seq_len;
 
     extern __shared__ float smem[];
     float* k_smem   = smem;
@@ -131,15 +143,30 @@ __global__ void linear_attention_decode_kernel(
         decay != nullptr;
 
     if (has_decay) {
-        const T* d_ptr = decay + b * decay_batch_stride + (int64_t)g * dk;
-        for (int i = tid; i < dk; i += nthreads)
-            aux_smem[i] = expf(to_float(d_ptr[i]));
+        if (decay_per_key_dim) {
+            // [B, T, Hkv * dk]: one log-decay per (kv_head, key_dim).
+            const T* d_ptr = decay + b * decay_batch_stride + (int64_t)g * dk;
+            for (int i = tid; i < dk; i += nthreads)
+                aux_smem[i] = expf(to_float(d_ptr[i]));
+        } else {
+            // [B, T, Hkv]: scalar log-decay per kv_head, broadcast on dk.
+            const float g_val =
+                expf(to_float(decay[b * decay_batch_stride + g]));
+            for (int i = tid; i < dk; i += nthreads)
+                aux_smem[i] = g_val;
+        }
     }
 
     float beta_val = 0.0f;
     if (beta_in &&
-        (update_rule == LA_RULE_DELTA || update_rule == LA_RULE_GATED_DELTA))
-        beta_val = to_float(beta_in[b * beta_batch_stride + g]);
+        (update_rule == LA_RULE_DELTA || update_rule == LA_RULE_GATED_DELTA)) {
+        // beta_per_head=1: [B, T, Hkv]  -> one value per kv_head.
+        // beta_per_head=0: [B, T, 1]    -> single value broadcast on heads.
+        const int64_t beta_idx = beta_per_head
+            ? b * beta_batch_stride + g
+            : b * beta_batch_stride;
+        beta_val = to_float(beta_in[beta_idx]);
+    }
 
     __syncthreads();
 
@@ -251,6 +278,8 @@ extern "C" int hip_linear_attention_decode(
     int64_t dv,
     float scale,
     int64_t update_rule,
+    int64_t decay_per_key_dim,
+    int64_t beta_per_head,
     int64_t type)
 {
     if (B <= 0 || Hkv <= 0)
@@ -304,19 +333,24 @@ extern "C" int hip_linear_attention_decode(
     hipStream_t hip_stream = static_cast<hipStream_t>(stream);
     int grid  = static_cast<int>(B * Hkv);
     int block = LA_THREADS;
-    const int dk_i      = static_cast<int>(dk);
-    const int dv_i      = static_cast<int>(dv);
-    const int seq_len_i = static_cast<int>(seq_len);
+    const int dk_i                = static_cast<int>(dk);
+    const int dv_i                = static_cast<int>(dv);
+    const int seq_len_i           = static_cast<int>(seq_len);
+    // Normalise to canonical 0/1 so the kernel can rely on the invariant.
+    const int decay_per_key_dim_i = decay_per_key_dim ? 1 : 0;
+    const int beta_per_head_i     = beta_per_head     ? 1 : 0;
 
     size_t smem_bytes = static_cast<size_t>(2 * dk_i + 2 * dv_i) * sizeof(float);
 
     CUSTOM_KERNELS_DEBUG_LOG(
         "[custom_kernels] hip_linear_attention_decode: B=%lld seq_len=%lld "
         "Hq=%lld Hkv=%lld Nk=%lld dk=%d dv=%d scale=%.6f rule=%lld "
-        "type=%lld grid=%d block=%d smem=%zu\n",
+        "decay_per_key_dim=%d beta_per_head=%d type=%lld grid=%d block=%d "
+        "smem=%zu\n",
         (long long)B, (long long)seq_len, (long long)Hq, (long long)Hkv,
         (long long)Nk, dk_i, dv_i, (double)scale, (long long)update_rule,
-        (long long)type, grid, block, smem_bytes);
+        decay_per_key_dim_i, beta_per_head_i, (long long)type, grid, block,
+        smem_bytes);
 
     // type: HIPDNN_EP_DATATYPE_FLOAT=0, HALF=1, BFLOAT16=2
     if (type == 0) {
@@ -334,7 +368,8 @@ extern "C" int hip_linear_attention_decode(
             static_cast<int>(Hq),
             static_cast<int>(Hkv),
             static_cast<int>(Nk),
-            dk_i, dv_i, scale, static_cast<int>(update_rule));
+            dk_i, dv_i, scale, static_cast<int>(update_rule),
+            decay_per_key_dim_i, beta_per_head_i);
     } else if (type == 1) {
         hipLaunchKernelGGL(
             linear_attention_decode_kernel<__half>,
@@ -350,7 +385,8 @@ extern "C" int hip_linear_attention_decode(
             static_cast<int>(Hq),
             static_cast<int>(Hkv),
             static_cast<int>(Nk),
-            dk_i, dv_i, scale, static_cast<int>(update_rule));
+            dk_i, dv_i, scale, static_cast<int>(update_rule),
+            decay_per_key_dim_i, beta_per_head_i);
     } else if (type == 2) {
         hipLaunchKernelGGL(
             linear_attention_decode_kernel<__hip_bfloat16>,
@@ -366,7 +402,8 @@ extern "C" int hip_linear_attention_decode(
             static_cast<int>(Hq),
             static_cast<int>(Hkv),
             static_cast<int>(Nk),
-            dk_i, dv_i, scale, static_cast<int>(update_rule));
+            dk_i, dv_i, scale, static_cast<int>(update_rule),
+            decay_per_key_dim_i, beta_per_head_i);
     } else {
         fprintf(stderr,
                 "[custom_kernels] hip_linear_attention_decode: unsupported "

--- a/3rd-party/custom_kernels/hip/linear_attention_kernel.hip
+++ b/3rd-party/custom_kernels/hip/linear_attention_kernel.hip
@@ -35,10 +35,15 @@ template<> __device__ __forceinline__ __hip_bfloat16 from_float(float val) {
 }
 
 //===----------------------------------------------------------------------===//
-// Fused T=1 linear attention decode kernel
+// Single-timestep linear attention decode kernel
 //===----------------------------------------------------------------------===//
 //
 // One thread-block per (batch, kv_head) pair.
+//
+// Input tensors are views into packed [B, T, H*D] buffers. The caller is
+// expected to advance the pointers to the current time step before the
+// launch (e.g. query + t * Hq*dk*elem_size); seq_len is the original T
+// dimension and is used here only to compute the per-batch stride.
 //
 // Phase 1 (delta/gated_delta only):
 //   Compute sk[j] = sum_i [exp(g[i]) *] S_old[i][j] * k[i]  for j in [0, dv)
@@ -54,12 +59,12 @@ template<> __device__ __forceinline__ __hip_bfloat16 from_float(float val) {
 //     for hl in [0, heads_per_group):
 //       h = g * heads_per_group + hl
 //       out[h * dv .. h * dv + dv) = scale * q_h @ S
-//     Output is packed in Q-head order: [B, 1, H_q * dv].
+//     Output is packed in Q-head order: [B, T, H_q * dv] at time step t.
 //   Inverse GQA (H_q <  H_kv):
 //     h = g * H_q / H_kv   (one Q head is shared across H_kv/H_q KV heads)
 //     out[g * dv .. g * dv + dv) = scale * q_h @ S
-//     Output is packed in KV-head order: [B, 1, H_kv * dv].
-//   In both cases the caller sees output shape [B, 1, H_out * dv] with
+//     Output is packed in KV-head order: [B, T, H_kv * dv] at time step t.
+//   In both cases the caller sees output shape [B, T, H_out * dv] with
 //   H_out = max(H_q, H_kv).
 //
 // Key-head sharing: the key tensor is packed with n_k heads (n_k must divide
@@ -78,6 +83,7 @@ __global__ void linear_attention_decode_kernel(
     const T* __restrict__ beta_in,
     T* __restrict__ state,
     T* __restrict__ output,
+    int seq_len,
     int Hq, int Hkv, int n_k, int dk, int dv,
     float scale, int update_rule)
 {
@@ -96,13 +102,23 @@ __global__ void linear_attention_decode_kernel(
     // sharing the same K head produce the same index.
     const int h_k = g * n_k / Hkv;
 
+    // Per-batch strides for the packed [B, T, H*D] tensors. The kernel reads
+    // a single time step; the caller has already advanced the pointer to
+    // `t`, so we only need the batch stride here.
+    const int64_t q_batch_stride     = (int64_t)seq_len * Hq   * dk;
+    const int64_t k_batch_stride     = (int64_t)seq_len * n_k  * dk;
+    const int64_t v_batch_stride     = (int64_t)seq_len * Hkv  * dv;
+    const int64_t out_batch_stride   = (int64_t)seq_len * Hout * dv;
+    const int64_t decay_batch_stride = (int64_t)seq_len * Hkv  * dk;
+    const int64_t beta_batch_stride  = (int64_t)seq_len * Hkv;
+
     extern __shared__ float smem[];
     float* k_smem   = smem;
     float* v_smem   = smem + dk;
     float* aux_smem = smem + dk + dv;
     float* sk_smem  = smem + 2 * dk + dv;
-    const T* k_ptr = key   + (int64_t)b * n_k * dk  + (int64_t)h_k * dk;    // k_ptr = &key[b, h_k, 0]
-    const T* v_ptr = value + (int64_t)b * Hkv * dv  + (int64_t)g   * dv;    // v_ptr = &value[b, g, 0]
+    const T* k_ptr = key   + b * k_batch_stride + (int64_t)h_k * dk;    // k_ptr = &key[b, t, h_k, 0]
+    const T* v_ptr = value + b * v_batch_stride + (int64_t)g   * dv;    // v_ptr = &value[b, t, g, 0]
     T* S = state + ((int64_t)b * Hkv + g) * dk * dv;
 
     for (int i = tid; i < dk; i += nthreads)
@@ -115,7 +131,7 @@ __global__ void linear_attention_decode_kernel(
         decay != nullptr;
 
     if (has_decay) {
-        const T* d_ptr = decay + (int64_t)b * Hkv * dk + (int64_t)g * dk;
+        const T* d_ptr = decay + b * decay_batch_stride + (int64_t)g * dk;
         for (int i = tid; i < dk; i += nthreads)
             aux_smem[i] = expf(to_float(d_ptr[i]));
     }
@@ -123,7 +139,7 @@ __global__ void linear_attention_decode_kernel(
     float beta_val = 0.0f;
     if (beta_in &&
         (update_rule == LA_RULE_DELTA || update_rule == LA_RULE_GATED_DELTA))
-        beta_val = to_float(beta_in[(int64_t)b * Hkv + g]);
+        beta_val = to_float(beta_in[b * beta_batch_stride + g]);
 
     __syncthreads();
 
@@ -198,8 +214,8 @@ __global__ void linear_attention_decode_kernel(
         const int heads_per_group = Hq / Hkv;
         for (int hl = 0; hl < heads_per_group; hl++) {
             const int h = g * heads_per_group + hl;
-            const T* q_ptr = query  + (int64_t)b * Hq   * dk + (int64_t)h * dk;
-            T* out_ptr     = output + (int64_t)b * Hout * dv + (int64_t)h * dv;
+            const T* q_ptr = query  + b * q_batch_stride   + (int64_t)h * dk;
+            T* out_ptr     = output + b * out_batch_stride + (int64_t)h * dv;
             readout(q_ptr, out_ptr);
         }
     } else {
@@ -207,8 +223,8 @@ __global__ void linear_attention_decode_kernel(
         // Hkv / Hq consecutive KV heads), but each KV head writes its own
         // output slot -> Hout = Hkv output heads.
         const int h_q = g * Hq / Hkv;
-        const T* q_ptr = query  + (int64_t)b * Hq   * dk + (int64_t)h_q * dk;
-        T* out_ptr     = output + (int64_t)b * Hout * dv + (int64_t)g   * dv;
+        const T* q_ptr = query  + b * q_batch_stride   + (int64_t)h_q * dk;
+        T* out_ptr     = output + b * out_batch_stride + (int64_t)g   * dv;
         readout(q_ptr, out_ptr);
     }
 }
@@ -227,6 +243,7 @@ extern "C" int hip_linear_attention_decode(
     void* state,
     void* output,
     int64_t B,
+    int64_t seq_len,
     int64_t Hq,
     int64_t Hkv,
     int64_t Nk,
@@ -238,6 +255,17 @@ extern "C" int hip_linear_attention_decode(
 {
     if (B <= 0 || Hkv <= 0)
         return 0;
+
+    // seq_len is the T dimension of the packed [B, T, H*D] layout. It
+    // governs the per-batch stride; the kernel itself still processes
+    // exactly one time step per invocation.
+    if (seq_len <= 0) {
+        fprintf(stderr,
+                "[custom_kernels] hip_linear_attention_decode: "
+                "seq_len(%lld) must be positive\n",
+                (long long)seq_len);
+        return -1;
+    }
 
     // GQA direction: support both H_q >= H_kv (standard) and H_q < H_kv
     // (inverse, e.g. Qwen3-style n_k=16, n_kv=32).
@@ -276,18 +304,19 @@ extern "C" int hip_linear_attention_decode(
     hipStream_t hip_stream = static_cast<hipStream_t>(stream);
     int grid  = static_cast<int>(B * Hkv);
     int block = LA_THREADS;
-    const int dk_i = static_cast<int>(dk);
-    const int dv_i = static_cast<int>(dv);
+    const int dk_i      = static_cast<int>(dk);
+    const int dv_i      = static_cast<int>(dv);
+    const int seq_len_i = static_cast<int>(seq_len);
 
     size_t smem_bytes = static_cast<size_t>(2 * dk_i + 2 * dv_i) * sizeof(float);
 
     CUSTOM_KERNELS_DEBUG_LOG(
-        "[custom_kernels] hip_linear_attention_decode: B=%lld Hq=%lld "
-        "Hkv=%lld Nk=%lld dk=%d dv=%d scale=%.6f rule=%lld type=%lld "
-        "grid=%d block=%d smem=%zu\n",
-        (long long)B, (long long)Hq, (long long)Hkv, (long long)Nk, dk_i,
-        dv_i, (double)scale, (long long)update_rule, (long long)type, grid,
-        block, smem_bytes);
+        "[custom_kernels] hip_linear_attention_decode: B=%lld seq_len=%lld "
+        "Hq=%lld Hkv=%lld Nk=%lld dk=%d dv=%d scale=%.6f rule=%lld "
+        "type=%lld grid=%d block=%d smem=%zu\n",
+        (long long)B, (long long)seq_len, (long long)Hq, (long long)Hkv,
+        (long long)Nk, dk_i, dv_i, (double)scale, (long long)update_rule,
+        (long long)type, grid, block, smem_bytes);
 
     // type: HIPDNN_EP_DATATYPE_FLOAT=0, HALF=1, BFLOAT16=2
     if (type == 0) {
@@ -301,6 +330,7 @@ extern "C" int hip_linear_attention_decode(
             static_cast<const float*>(beta),
             static_cast<float*>(state),
             static_cast<float*>(output),
+            seq_len_i,
             static_cast<int>(Hq),
             static_cast<int>(Hkv),
             static_cast<int>(Nk),
@@ -316,6 +346,7 @@ extern "C" int hip_linear_attention_decode(
             static_cast<const __half*>(beta),
             static_cast<__half*>(state),
             static_cast<__half*>(output),
+            seq_len_i,
             static_cast<int>(Hq),
             static_cast<int>(Hkv),
             static_cast<int>(Nk),
@@ -331,6 +362,7 @@ extern "C" int hip_linear_attention_decode(
             static_cast<const __hip_bfloat16*>(beta),
             static_cast<__hip_bfloat16*>(state),
             static_cast<__hip_bfloat16*>(output),
+            seq_len_i,
             static_cast<int>(Hq),
             static_cast<int>(Hkv),
             static_cast<int>(Nk),

--- a/3rd-party/custom_kernels/hip/linear_attention_kernel.hip
+++ b/3rd-party/custom_kernels/hip/linear_attention_kernel.hip
@@ -5,6 +5,7 @@
 
 #include <hip/hip_runtime.h>
 #include <hip/hip_fp16.h>
+#include <hip/hip_bf16.h>
 #include <cstdint>
 #include <cstdio>
 #include <cmath>
@@ -22,10 +23,16 @@ static constexpr int LA_RULE_GATED_DELTA = 3;
 template<typename T> __device__ __forceinline__ float to_float(T val);
 template<> __device__ __forceinline__ float to_float(float val) { return val; }
 template<> __device__ __forceinline__ float to_float(__half val) { return __half2float(val); }
+template<> __device__ __forceinline__ float to_float(__hip_bfloat16 val) {
+  return __bfloat162float(val);
+}
 
 template<typename T> __device__ __forceinline__ T from_float(float val);
 template<> __device__ __forceinline__ float from_float(float val) { return val; }
 template<> __device__ __forceinline__ __half from_float(float val) { return __float2half(val); }
+template<> __device__ __forceinline__ __hip_bfloat16 from_float(float val) {
+  return __float2bfloat16(val);
+}
 
 //===----------------------------------------------------------------------===//
 // Fused T=1 linear attention decode kernel
@@ -94,9 +101,8 @@ __global__ void linear_attention_decode_kernel(
     float* v_smem   = smem + dk;
     float* aux_smem = smem + dk + dv;
     float* sk_smem  = smem + 2 * dk + dv;
-
-    const T* k_ptr = key   + (int64_t)b * n_k * dk  + (int64_t)h_k * dk;
-    const T* v_ptr = value + (int64_t)b * Hkv * dv  + (int64_t)g   * dv;
+    const T* k_ptr = key   + (int64_t)b * n_k * dk  + (int64_t)h_k * dk;    // k_ptr = &key[b, h_k, 0]
+    const T* v_ptr = value + (int64_t)b * Hkv * dv  + (int64_t)g   * dv;    // v_ptr = &value[b, g, 0]
     T* S = state + ((int64_t)b * Hkv + g) * dk * dv;
 
     for (int i = tid; i < dk; i += nthreads)
@@ -220,88 +226,71 @@ extern "C" int hip_linear_attention_decode(
     const void* beta,
     void* state,
     void* output,
-    int64_t batch_size,
-    int64_t q_num_heads,
-    int64_t kv_num_heads,
-    int64_t n_k_heads,
-    int64_t head_dim_k,
-    int64_t head_dim_v,
+    int64_t B,
+    int64_t Hq,
+    int64_t Hkv,
+    int64_t Nk,
+    int64_t dk,
+    int64_t dv,
     float scale,
     int64_t update_rule,
-    int64_t element_size_bytes)
+    int64_t type)
 {
-    if (batch_size <= 0 || kv_num_heads <= 0)
+    if (B <= 0 || Hkv <= 0)
         return 0;
 
     // GQA direction: support both H_q >= H_kv (standard) and H_q < H_kv
     // (inverse, e.g. Qwen3-style n_k=16, n_kv=32).
-    if (q_num_heads <= 0) {
+    if (Hq <= 0) {
         fprintf(stderr,
                 "[custom_kernels] hip_linear_attention_decode: "
-                "q_num_heads(%lld) must be positive\n",
-                (long long)q_num_heads);
+                "Hq(%lld) must be positive\n",
+                (long long)Hq);
         return -1;
     }
-    if (q_num_heads >= kv_num_heads) {
-        if (q_num_heads % kv_num_heads != 0) {
+    if (Hq >= Hkv) {
+        if (Hq % Hkv != 0) {
             fprintf(stderr,
                     "[custom_kernels] hip_linear_attention_decode: "
-                    "q_num_heads(%lld) not divisible by kv_num_heads(%lld)\n",
-                    (long long)q_num_heads, (long long)kv_num_heads);
+                    "Hq(%lld) not divisible by Hkv(%lld)\n",
+                    (long long)Hq, (long long)Hkv);
             return -1;
         }
     } else {
-        if (kv_num_heads % q_num_heads != 0) {
+        if (Hkv % Hq != 0) {
             fprintf(stderr,
                     "[custom_kernels] hip_linear_attention_decode: "
-                    "inverse GQA requires kv_num_heads(%lld) divisible by "
-                    "q_num_heads(%lld)\n",
-                    (long long)kv_num_heads, (long long)q_num_heads);
+                    "inverse GQA requires Hkv(%lld) divisible by Hq(%lld)\n",
+                    (long long)Hkv, (long long)Hq);
             return -1;
         }
     }
-    if (n_k_heads <= 0 || kv_num_heads % n_k_heads != 0) {
+    if (Nk <= 0 || Hkv % Nk != 0) {
         fprintf(stderr,
                 "[custom_kernels] hip_linear_attention_decode: "
-                "n_k_heads(%lld) must be positive and divide "
-                "kv_num_heads(%lld)\n",
-                (long long)n_k_heads, (long long)kv_num_heads);
+                "Nk(%lld) must be positive and divide Hkv(%lld)\n",
+                (long long)Nk, (long long)Hkv);
         return -1;
     }
 
     hipStream_t hip_stream = static_cast<hipStream_t>(stream);
-    int grid  = static_cast<int>(batch_size * kv_num_heads);
+    int grid  = static_cast<int>(B * Hkv);
     int block = LA_THREADS;
-    int dk = static_cast<int>(head_dim_k);
-    int dv = static_cast<int>(head_dim_v);
+    const int dk_i = static_cast<int>(dk);
+    const int dv_i = static_cast<int>(dv);
 
-    size_t smem_bytes = static_cast<size_t>(2 * dk + 2 * dv) * sizeof(float);
+    size_t smem_bytes = static_cast<size_t>(2 * dk_i + 2 * dv_i) * sizeof(float);
 
     CUSTOM_KERNELS_DEBUG_LOG(
         "[custom_kernels] hip_linear_attention_decode: B=%lld Hq=%lld "
-        "Hkv=%lld n_k=%lld dk=%d dv=%d scale=%.6f rule=%lld elem=%lld "
+        "Hkv=%lld Nk=%lld dk=%d dv=%d scale=%.6f rule=%lld type=%lld "
         "grid=%d block=%d smem=%zu\n",
-        (long long)batch_size, (long long)q_num_heads,
-        (long long)kv_num_heads, (long long)n_k_heads, dk, dv, (double)scale,
-        (long long)update_rule, (long long)element_size_bytes,
-        grid, block, smem_bytes);
+        (long long)B, (long long)Hq, (long long)Hkv, (long long)Nk, dk_i,
+        dv_i, (double)scale, (long long)update_rule, (long long)type, grid,
+        block, smem_bytes);
 
-    if (element_size_bytes == 2) {
-        hipLaunchKernelGGL(
-            linear_attention_decode_kernel<__half>,
-            dim3(grid), dim3(block), smem_bytes, hip_stream,
-            static_cast<const __half*>(query),
-            static_cast<const __half*>(key),
-            static_cast<const __half*>(value),
-            static_cast<const __half*>(decay),
-            static_cast<const __half*>(beta),
-            static_cast<__half*>(state),
-            static_cast<__half*>(output),
-            static_cast<int>(q_num_heads),
-            static_cast<int>(kv_num_heads),
-            static_cast<int>(n_k_heads),
-            dk, dv, scale, static_cast<int>(update_rule));
-    } else if (element_size_bytes == 4) {
+    // type: HIPDNN_EP_DATATYPE_FLOAT=0, HALF=1, BFLOAT16=2
+    if (type == 0) {
         hipLaunchKernelGGL(
             linear_attention_decode_kernel<float>,
             dim3(grid), dim3(block), smem_bytes, hip_stream,
@@ -312,15 +301,45 @@ extern "C" int hip_linear_attention_decode(
             static_cast<const float*>(beta),
             static_cast<float*>(state),
             static_cast<float*>(output),
-            static_cast<int>(q_num_heads),
-            static_cast<int>(kv_num_heads),
-            static_cast<int>(n_k_heads),
-            dk, dv, scale, static_cast<int>(update_rule));
+            static_cast<int>(Hq),
+            static_cast<int>(Hkv),
+            static_cast<int>(Nk),
+            dk_i, dv_i, scale, static_cast<int>(update_rule));
+    } else if (type == 1) {
+        hipLaunchKernelGGL(
+            linear_attention_decode_kernel<__half>,
+            dim3(grid), dim3(block), smem_bytes, hip_stream,
+            static_cast<const __half*>(query),
+            static_cast<const __half*>(key),
+            static_cast<const __half*>(value),
+            static_cast<const __half*>(decay),
+            static_cast<const __half*>(beta),
+            static_cast<__half*>(state),
+            static_cast<__half*>(output),
+            static_cast<int>(Hq),
+            static_cast<int>(Hkv),
+            static_cast<int>(Nk),
+            dk_i, dv_i, scale, static_cast<int>(update_rule));
+    } else if (type == 2) {
+        hipLaunchKernelGGL(
+            linear_attention_decode_kernel<__hip_bfloat16>,
+            dim3(grid), dim3(block), smem_bytes, hip_stream,
+            static_cast<const __hip_bfloat16*>(query),
+            static_cast<const __hip_bfloat16*>(key),
+            static_cast<const __hip_bfloat16*>(value),
+            static_cast<const __hip_bfloat16*>(decay),
+            static_cast<const __hip_bfloat16*>(beta),
+            static_cast<__hip_bfloat16*>(state),
+            static_cast<__hip_bfloat16*>(output),
+            static_cast<int>(Hq),
+            static_cast<int>(Hkv),
+            static_cast<int>(Nk),
+            dk_i, dv_i, scale, static_cast<int>(update_rule));
     } else {
         fprintf(stderr,
-                "[custom_kernels] hip_linear_attention_decode: "
-                "unsupported element_size %lld\n",
-                (long long)element_size_bytes);
+                "[custom_kernels] hip_linear_attention_decode: unsupported "
+                "element type %lld (expect 0=float, 1=f16, 2=bf16)\n",
+                (long long)type);
         return -1;
     }
 

--- a/3rd-party/custom_kernels/hip/linear_attention_kernel.hip
+++ b/3rd-party/custom_kernels/hip/linear_attention_kernel.hip
@@ -42,8 +42,21 @@ template<> __device__ __forceinline__ __half from_float(float val) { return __fl
 //   delta:        S[i][j]  += beta * k[i] * (v[j] - sk[j])
 //   gated_delta:  S[i][j]   = exp(g[i]) * S[i][j] + beta * k[i] * (v[j] - sk[j])
 //
-// Phase 3: For each query head h mapped to this KV group:
-//   o[j] = scale * sum_i q_h[i] * S[i][j]
+// Phase 3 (GQA direction dispatched at runtime):
+//   Standard GQA (H_q >= H_kv, heads_per_group = H_q / H_kv):
+//     for hl in [0, heads_per_group):
+//       h = g * heads_per_group + hl
+//       out[h * dv .. h * dv + dv) = scale * q_h @ S
+//     Output is packed in Q-head order: [B, 1, H_q * dv].
+//   Inverse GQA (H_q <  H_kv):
+//     h = g * H_q / H_kv   (one Q head is shared across H_kv/H_q KV heads)
+//     out[g * dv .. g * dv + dv) = scale * q_h @ S
+//     Output is packed in KV-head order: [B, 1, H_kv * dv].
+//   In both cases the caller sees output shape [B, 1, H_out * dv] with
+//   H_out = max(H_q, H_kv).
+//
+// Key-head sharing: the key tensor is packed with n_k heads (n_k must divide
+// H_kv); this KV head reads from key head  h_k = g * n_k / H_kv.
 //
 // Shared memory layout (all float for accumulation precision):
 //   k_smem[dk] | v_smem[dv] | aux_smem[dk] | sk_smem[dv]
@@ -58,7 +71,7 @@ __global__ void linear_attention_decode_kernel(
     const T* __restrict__ beta_in,
     T* __restrict__ state,
     T* __restrict__ output,
-    int Hq, int Hkv, int dk, int dv,
+    int Hq, int Hkv, int n_k, int dk, int dv,
     float scale, int update_rule)
 {
     const int bg = blockIdx.x;
@@ -68,14 +81,22 @@ __global__ void linear_attention_decode_kernel(
     const int nthreads = blockDim.x;
     const int state_size = dk * dv;
 
+    // Output head count: max(Hq, Hkv).  Determines stride of output and
+    // controls which branch of Phase 3 runs.
+    const int Hout = Hq >= Hkv ? Hq : Hkv;
+
+    // Key-head index for this (b, g): n_k divides Hkv, so multiple KV heads
+    // sharing the same K head produce the same index.
+    const int h_k = g * n_k / Hkv;
+
     extern __shared__ float smem[];
     float* k_smem   = smem;
     float* v_smem   = smem + dk;
     float* aux_smem = smem + dk + dv;
     float* sk_smem  = smem + 2 * dk + dv;
 
-    const T* k_ptr = key   + (int64_t)b * Hkv * dk + (int64_t)g * dk;
-    const T* v_ptr = value + (int64_t)b * Hkv * dv + (int64_t)g * dv;
+    const T* k_ptr = key   + (int64_t)b * n_k * dk  + (int64_t)h_k * dk;
+    const T* v_ptr = value + (int64_t)b * Hkv * dv  + (int64_t)g   * dv;
     T* S = state + ((int64_t)b * Hkv + g) * dk * dv;
 
     for (int i = tid; i < dk; i += nthreads)
@@ -146,14 +167,14 @@ __global__ void linear_attention_decode_kernel(
     __syncthreads();
 
     // === Phase 3: output = scale * S^T @ q  (per query head) ===
-    const int heads_per_group = Hq / Hkv;
+    // Dispatches on GQA direction:
+    //   Standard (Hq >= Hkv): loop over Hq/Hkv Q heads sharing this KV state,
+    //                          write each to output[h_q * dv] (Hout == Hq).
+    //   Inverse  (Hq <  Hkv): single Q head shared across Hkv/Hq KV heads;
+    //                          write to output[g * dv] (Hout == Hkv).
     float* q_smem = aux_smem;
 
-    for (int hl = 0; hl < heads_per_group; hl++) {
-        const int h = g * heads_per_group + hl;
-        const T* q_ptr = query  + (int64_t)b * Hq * dk + (int64_t)h * dk;
-        T* out_ptr     = output + (int64_t)b * Hq * dv + (int64_t)h * dv;
-
+    auto readout = [&](const T* q_ptr, T* out_ptr) {
         for (int i = tid; i < dk; i += nthreads)
             q_smem[i] = to_float(q_ptr[i]);
         __syncthreads();
@@ -165,6 +186,24 @@ __global__ void linear_attention_decode_kernel(
             out_ptr[j] = from_float<T>(scale * sum);
         }
         __syncthreads();
+    };
+
+    if (Hq >= Hkv) {
+        const int heads_per_group = Hq / Hkv;
+        for (int hl = 0; hl < heads_per_group; hl++) {
+            const int h = g * heads_per_group + hl;
+            const T* q_ptr = query  + (int64_t)b * Hq   * dk + (int64_t)h * dk;
+            T* out_ptr     = output + (int64_t)b * Hout * dv + (int64_t)h * dv;
+            readout(q_ptr, out_ptr);
+        }
+    } else {
+        // Inverse GQA: this KV head maps to a single Q head (shared across
+        // Hkv / Hq consecutive KV heads), but each KV head writes its own
+        // output slot -> Hout = Hkv output heads.
+        const int h_q = g * Hq / Hkv;
+        const T* q_ptr = query  + (int64_t)b * Hq   * dk + (int64_t)h_q * dk;
+        T* out_ptr     = output + (int64_t)b * Hout * dv + (int64_t)g   * dv;
+        readout(q_ptr, out_ptr);
     }
 }
 
@@ -184,6 +223,7 @@ extern "C" int hip_linear_attention_decode(
     int64_t batch_size,
     int64_t q_num_heads,
     int64_t kv_num_heads,
+    int64_t n_k_heads,
     int64_t head_dim_k,
     int64_t head_dim_v,
     float scale,
@@ -193,11 +233,39 @@ extern "C" int hip_linear_attention_decode(
     if (batch_size <= 0 || kv_num_heads <= 0)
         return 0;
 
-    if (q_num_heads % kv_num_heads != 0) {
+    // GQA direction: support both H_q >= H_kv (standard) and H_q < H_kv
+    // (inverse, e.g. Qwen3-style n_k=16, n_kv=32).
+    if (q_num_heads <= 0) {
         fprintf(stderr,
                 "[custom_kernels] hip_linear_attention_decode: "
-                "q_num_heads(%lld) not divisible by kv_num_heads(%lld)\n",
-                (long long)q_num_heads, (long long)kv_num_heads);
+                "q_num_heads(%lld) must be positive\n",
+                (long long)q_num_heads);
+        return -1;
+    }
+    if (q_num_heads >= kv_num_heads) {
+        if (q_num_heads % kv_num_heads != 0) {
+            fprintf(stderr,
+                    "[custom_kernels] hip_linear_attention_decode: "
+                    "q_num_heads(%lld) not divisible by kv_num_heads(%lld)\n",
+                    (long long)q_num_heads, (long long)kv_num_heads);
+            return -1;
+        }
+    } else {
+        if (kv_num_heads % q_num_heads != 0) {
+            fprintf(stderr,
+                    "[custom_kernels] hip_linear_attention_decode: "
+                    "inverse GQA requires kv_num_heads(%lld) divisible by "
+                    "q_num_heads(%lld)\n",
+                    (long long)kv_num_heads, (long long)q_num_heads);
+            return -1;
+        }
+    }
+    if (n_k_heads <= 0 || kv_num_heads % n_k_heads != 0) {
+        fprintf(stderr,
+                "[custom_kernels] hip_linear_attention_decode: "
+                "n_k_heads(%lld) must be positive and divide "
+                "kv_num_heads(%lld)\n",
+                (long long)n_k_heads, (long long)kv_num_heads);
         return -1;
     }
 
@@ -211,10 +279,10 @@ extern "C" int hip_linear_attention_decode(
 
     CUSTOM_KERNELS_DEBUG_LOG(
         "[custom_kernels] hip_linear_attention_decode: B=%lld Hq=%lld "
-        "Hkv=%lld dk=%d dv=%d scale=%.6f rule=%lld elem=%lld "
+        "Hkv=%lld n_k=%lld dk=%d dv=%d scale=%.6f rule=%lld elem=%lld "
         "grid=%d block=%d smem=%zu\n",
         (long long)batch_size, (long long)q_num_heads,
-        (long long)kv_num_heads, dk, dv, (double)scale,
+        (long long)kv_num_heads, (long long)n_k_heads, dk, dv, (double)scale,
         (long long)update_rule, (long long)element_size_bytes,
         grid, block, smem_bytes);
 
@@ -231,6 +299,7 @@ extern "C" int hip_linear_attention_decode(
             static_cast<__half*>(output),
             static_cast<int>(q_num_heads),
             static_cast<int>(kv_num_heads),
+            static_cast<int>(n_k_heads),
             dk, dv, scale, static_cast<int>(update_rule));
     } else if (element_size_bytes == 4) {
         hipLaunchKernelGGL(
@@ -245,6 +314,7 @@ extern "C" int hip_linear_attention_decode(
             static_cast<float*>(output),
             static_cast<int>(q_num_heads),
             static_cast<int>(kv_num_heads),
+            static_cast<int>(n_k_heads),
             dk, dv, scale, static_cast<int>(update_rule));
     } else {
         fprintf(stderr,

--- a/3rd-party/custom_kernels/hip/linear_attention_kernel.hip
+++ b/3rd-party/custom_kernels/hip/linear_attention_kernel.hip
@@ -107,6 +107,7 @@ __global__ void linear_attention_decode_kernel(
 
     // Key-head index for this (b, g): n_k divides Hkv, so multiple KV heads
     // sharing the same K head produce the same index.
+    // this support inverse GQA
     const int h_k = g * n_k / Hkv;
 
     // Per-batch strides for the packed [B, T, H*D] tensors. The kernel reads
@@ -123,6 +124,7 @@ __global__ void linear_attention_decode_kernel(
     const int64_t beta_batch_stride = beta_per_head
         ? (int64_t)seq_len * Hkv
         : (int64_t)seq_len;
+    const int64_t state_batch_stride = (int64_t)Hkv * dk * dv;
 
     extern __shared__ float smem[];
     float* k_smem   = smem;
@@ -131,7 +133,7 @@ __global__ void linear_attention_decode_kernel(
     float* sk_smem  = smem + 2 * dk + dv;
     const T* k_ptr = key   + b * k_batch_stride + (int64_t)h_k * dk;    // k_ptr = &key[b, t, h_k, 0]
     const T* v_ptr = value + b * v_batch_stride + (int64_t)g   * dv;    // v_ptr = &value[b, t, g, 0]
-    T* S = state + ((int64_t)b * Hkv + g) * dk * dv;
+    T* S = state + b* state_batch_stride + g * dk * dv;
 
     for (int i = tid; i < dk; i += nthreads)
         k_smem[i] = to_float(k_ptr[i]);
@@ -173,7 +175,7 @@ __global__ void linear_attention_decode_kernel(
     // === Phase 1: S^T @ k (with optional decay weighting) ===
     const bool needs_sk =
         (update_rule == LA_RULE_DELTA || update_rule == LA_RULE_GATED_DELTA);
-
+//todo
     if (needs_sk) {
         for (int j = tid; j < dv; j += nthreads) {
             float sum = 0.0f;
@@ -336,7 +338,7 @@ extern "C" int hip_linear_attention_decode(
     const int dk_i                = static_cast<int>(dk);
     const int dv_i                = static_cast<int>(dv);
     const int seq_len_i           = static_cast<int>(seq_len);
-    // Normalise to canonical 0/1 so the kernel can rely on the invariant.
+    // cast from int64 to int32
     const int decay_per_key_dim_i = decay_per_key_dim ? 1 : 0;
     const int beta_per_head_i     = beta_per_head     ? 1 : 0;
 

--- a/3rd-party/custom_kernels/include/hip_custom_kernels.h
+++ b/3rd-party/custom_kernels/include/hip_custom_kernels.h
@@ -461,12 +461,22 @@ int hip_qmoe_scatter_add(
  *   gated:        S = diag(exp(g)) * S + k (x) v
  *   delta:        S = S + beta * k (x) (v - S^T k)
  *   gated_delta:  S = diag(exp(g)) * S + beta * k (x) (v - diag(exp(g)) * S^T k)
- *   output_h = scale * S^T q_h   (for each query head h in the KV group)
+ *   output_h = scale * S^T q_h   (for each query head h mapped to this KV head)
+ *
+ * Head counts are three-way and subject to the following divisibility
+ * constraints:
+ *   - n_k_heads | kv_num_heads
+ *       When n_k_heads < kv_num_heads multiple KV heads share the same key
+ *       head (mapping: h_k = h_kv * n_k_heads / kv_num_heads).
+ *   - Either q_num_heads % kv_num_heads == 0  (standard GQA, H_q >= H_kv)
+ *       or   kv_num_heads % q_num_heads == 0  (inverse GQA, H_q < H_kv)
  *
  * Parameters:
  *   stream             - hipStream_t cast to void*
  *   query              - GPU [batch, 1, q_num_heads * head_dim_k]
- *   key                - GPU [batch, 1, kv_num_heads * head_dim_k]
+ *   key                - GPU [batch, 1, n_k_heads * head_dim_k]
+ *                        n_k_heads may differ from kv_num_heads; it must
+ *                        divide kv_num_heads.
  *   value              - GPU [batch, 1, kv_num_heads * head_dim_v]
  *   decay              - GPU [batch, 1, kv_num_heads * head_dim_k] or nullptr
  *                        Per-key-dimension decay in log-space.
@@ -477,10 +487,15 @@ int hip_qmoe_scatter_add(
  *   state              - GPU [batch, kv_num_heads, head_dim_k, head_dim_v]
  *                        Read/write. Must be pre-initialized (from past_state
  *                        or zeros) before calling this function.
- *   output             - GPU [batch, 1, q_num_heads * head_dim_v]
+ *   output             - GPU [batch, 1, max(q_num_heads, kv_num_heads) *
+ *                             head_dim_v]
+ *                        Standard GQA: heads packed in Q-head order.
+ *                        Inverse GQA: heads packed in KV-head order.
  *   batch_size         - batch dimension
- *   q_num_heads        - number of query heads (must be divisible by kv_num_heads)
- *   kv_num_heads       - number of key/value heads
+ *   q_num_heads        - number of query heads
+ *   kv_num_heads       - number of key/value state heads
+ *   n_k_heads          - number of key heads packed in the key tensor;
+ *                        must divide kv_num_heads
  *   head_dim_k         - key dimension per head
  *   head_dim_v         - value dimension per head
  *   scale              - output scaling factor (typically 1/sqrt(d_k))
@@ -501,6 +516,7 @@ int hip_linear_attention_decode(
     int64_t batch_size,
     int64_t q_num_heads,
     int64_t kv_num_heads,
+    int64_t n_k_heads,
     int64_t head_dim_k,
     int64_t head_dim_v,
     float scale,

--- a/3rd-party/custom_kernels/include/hip_custom_kernels.h
+++ b/3rd-party/custom_kernels/include/hip_custom_kernels.h
@@ -450,11 +450,14 @@ int hip_qmoe_scatter_add(
     int64_t element_size_bytes);
 
 /* =========================================================================
- * Linear Attention Decode (T=1 Single-Token Recurrence)
+ * Linear Attention Decode (Single-Token Recurrence, Prefill-Friendly)
  * =========================================================================
  *
- * Performs one step of the linear attention recurrence for T=1 (decode).
- * Updates state in-place and writes the attention output.
+ * Performs one step of the linear attention recurrence for a single query
+ * token. Updates state in-place and writes the attention output for that
+ * token. The caller is expected to invoke this once per time step for
+ * prefill (seq_len > 1); no batching across the time dimension is
+ * performed inside the kernel.
  *
  * For each (batch, kv_head) pair, the recurrence is:
  *   linear:       S = S + k (x) v
@@ -462,6 +465,14 @@ int hip_qmoe_scatter_add(
  *   delta:        S = S + beta * k (x) (v - S^T k)
  *   gated_delta:  S = diag(exp(g)) * S + beta * k (x) (v - diag(exp(g)) * S^T k)
  *   output_h = scale * S^T q_h   (for each query head h mapped to this KV head)
+ *
+ * Input tensors are views into the packed [B, T, H*D] layout of the full
+ * sequence: query/key/value/output/decay/beta pointers must already point
+ * at the start of the current time step (i.e. the caller has pre-advanced
+ * the pointer by t * token_bytes). seq_len is the original T dimension
+ * of the packed layout and is used by the kernel to compute the per-batch
+ * stride (seq_len * H*D). Pass seq_len = 1 in the pure decode case where
+ * the tensors are already shaped [B, 1, H*D].
  *
  * Head counts are three-way and subject to the following divisibility
  * constraints:
@@ -473,25 +484,32 @@ int hip_qmoe_scatter_add(
  *
  * Parameters:
  *   stream             - hipStream_t cast to void*
- *   query              - GPU [batch, 1, q_num_heads * head_dim_k]
- *   key                - GPU [batch, 1, n_k_heads * head_dim_k]
+ *   query              - GPU [batch, T, q_num_heads * head_dim_k]
+ *                        pointing at time step t
+ *   key                - GPU [batch, T, n_k_heads * head_dim_k]
+ *                        pointing at time step t
  *                        n_k_heads may differ from kv_num_heads; it must
  *                        divide kv_num_heads.
- *   value              - GPU [batch, 1, kv_num_heads * head_dim_v]
- *   decay              - GPU [batch, 1, kv_num_heads * head_dim_k] or nullptr
- *                        Per-key-dimension decay in log-space.
- *                        Required for gated and gated_delta modes.
- *   beta               - GPU [batch, 1, kv_num_heads] or nullptr
- *                        Per-head update rate.
+ *   value              - GPU [batch, T, kv_num_heads * head_dim_v]
+ *                        pointing at time step t
+ *   decay              - GPU [batch, T, kv_num_heads * head_dim_k] or nullptr
+ *                        Per-key-dimension decay in log-space, pointing at
+ *                        time step t. Required for gated and gated_delta
+ *                        modes.
+ *   beta               - GPU [batch, T, kv_num_heads] or nullptr
+ *                        Per-head update rate, pointing at time step t.
  *                        Required for delta and gated_delta modes.
  *   state              - GPU [batch, kv_num_heads, head_dim_k, head_dim_v]
  *                        Read/write. Must be pre-initialized (from past_state
- *                        or zeros) before calling this function.
- *   output             - GPU [batch, 1, max(q_num_heads, kv_num_heads) *
- *                             head_dim_v]
+ *                        or zeros) before the first time step.
+ *   output             - GPU [batch, T, max(q_num_heads, kv_num_heads) *
+ *                             head_dim_v], pointing at time step t.
  *                        Standard GQA: heads packed in Q-head order.
  *                        Inverse GQA: heads packed in KV-head order.
  *   B                  - batch dimension
+ *   seq_len            - length of the T dimension in the packed layout;
+ *                        used to compute per-batch stride. Use 1 when the
+ *                        tensors are already shaped [B, 1, H*D].
  *   Hq                 - number of query heads
  *   Hkv                - number of key/value state heads
  *   Nk                 - number of key heads packed in the key tensor;
@@ -515,6 +533,7 @@ int hip_linear_attention_decode(
     void* state,
     void* output,
     int64_t B,
+    int64_t seq_len,
     int64_t Hq,
     int64_t Hkv,
     int64_t Nk,

--- a/3rd-party/custom_kernels/include/hip_custom_kernels.h
+++ b/3rd-party/custom_kernels/include/hip_custom_kernels.h
@@ -450,6 +450,64 @@ int hip_qmoe_scatter_add(
     int64_t element_size_bytes);
 
 /* =========================================================================
+ * Linear Attention Decode (T=1 Single-Token Recurrence)
+ * =========================================================================
+ *
+ * Performs one step of the linear attention recurrence for T=1 (decode).
+ * Updates state in-place and writes the attention output.
+ *
+ * For each (batch, kv_head) pair, the recurrence is:
+ *   linear:       S = S + k (x) v
+ *   gated:        S = diag(exp(g)) * S + k (x) v
+ *   delta:        S = S + beta * k (x) (v - S^T k)
+ *   gated_delta:  S = diag(exp(g)) * S + beta * k (x) (v - diag(exp(g)) * S^T k)
+ *   output_h = scale * S^T q_h   (for each query head h in the KV group)
+ *
+ * Parameters:
+ *   stream             - hipStream_t cast to void*
+ *   query              - GPU [batch, 1, q_num_heads * head_dim_k]
+ *   key                - GPU [batch, 1, kv_num_heads * head_dim_k]
+ *   value              - GPU [batch, 1, kv_num_heads * head_dim_v]
+ *   decay              - GPU [batch, 1, kv_num_heads * head_dim_k] or nullptr
+ *                        Per-key-dimension decay in log-space.
+ *                        Required for gated and gated_delta modes.
+ *   beta               - GPU [batch, 1, kv_num_heads] or nullptr
+ *                        Per-head update rate.
+ *                        Required for delta and gated_delta modes.
+ *   state              - GPU [batch, kv_num_heads, head_dim_k, head_dim_v]
+ *                        Read/write. Must be pre-initialized (from past_state
+ *                        or zeros) before calling this function.
+ *   output             - GPU [batch, 1, q_num_heads * head_dim_v]
+ *   batch_size         - batch dimension
+ *   q_num_heads        - number of query heads (must be divisible by kv_num_heads)
+ *   kv_num_heads       - number of key/value heads
+ *   head_dim_k         - key dimension per head
+ *   head_dim_v         - value dimension per head
+ *   scale              - output scaling factor (typically 1/sqrt(d_k))
+ *   update_rule        - 0=linear, 1=gated, 2=delta, 3=gated_delta
+ *   element_size_bytes - 2 for fp16, 4 for fp32
+ *
+ * Returns: 0 on success, non-zero on failure
+ */
+int hip_linear_attention_decode(
+    void* stream,
+    const void* query,
+    const void* key,
+    const void* value,
+    const void* decay,
+    const void* beta,
+    void* state,
+    void* output,
+    int64_t batch_size,
+    int64_t q_num_heads,
+    int64_t kv_num_heads,
+    int64_t head_dim_k,
+    int64_t head_dim_v,
+    float scale,
+    int64_t update_rule,
+    int64_t element_size_bytes);
+
+/* =========================================================================
  * WMMA GEMM (Small-M Matrix Multiply via Wave Matrix Multiply-Accumulate)
  * =========================================================================
  *

--- a/3rd-party/custom_kernels/include/hip_custom_kernels.h
+++ b/3rd-party/custom_kernels/include/hip_custom_kernels.h
@@ -492,12 +492,23 @@ int hip_qmoe_scatter_add(
  *                        divide kv_num_heads.
  *   value              - GPU [batch, T, kv_num_heads * head_dim_v]
  *                        pointing at time step t
- *   decay              - GPU [batch, T, kv_num_heads * head_dim_k] or nullptr
- *                        Per-key-dimension decay in log-space, pointing at
- *                        time step t. Required for gated and gated_delta
- *                        modes.
- *   beta               - GPU [batch, T, kv_num_heads] or nullptr
- *                        Per-head update rate, pointing at time step t.
+ *   decay              - GPU decay tensor in log-space, or nullptr.
+ *                        Layout is selected by decay_per_key_dim:
+ *                          1 -> [batch, T, kv_num_heads * head_dim_k]
+ *                               per-key-dimension decay (GLA / RWKV-6)
+ *                          0 -> [batch, T, kv_num_heads]
+ *                               per-head scalar decay (DeltaNet / RetNet),
+ *                               broadcast across the head_dim_k axis.
+ *                        Pointer must already be advanced to time step t.
+ *                        Required for gated and gated_delta modes.
+ *   beta               - GPU update-rate tensor, or nullptr.
+ *                        Layout is selected by beta_per_head:
+ *                          1 -> [batch, T, kv_num_heads]
+ *                               per-head update rate.
+ *                          0 -> [batch, T, 1]
+ *                               single scalar update rate per (batch, T),
+ *                               broadcast across all kv heads.
+ *                        Pointer must already be advanced to time step t.
  *                        Required for delta and gated_delta modes.
  *   state              - GPU [batch, kv_num_heads, head_dim_k, head_dim_v]
  *                        Read/write. Must be pre-initialized (from past_state
@@ -518,6 +529,10 @@ int hip_qmoe_scatter_add(
  *   dv                 - value dimension per head
  *   scale              - output scaling factor (typically 1/sqrt(d_k))
  *   update_rule        - 0=linear, 1=gated, 2=delta, 3=gated_delta
+ *   decay_per_key_dim  - decay layout flag (see `decay` above). Ignored when
+ *                        decay == nullptr. Any non-zero value is treated as 1.
+ *   beta_per_head      - beta  layout flag (see `beta`  above). Ignored when
+ *                        beta  == nullptr. Any non-zero value is treated as 1.
  *   type               - element type enum: 0=float, 1=float16, 2=bfloat16
  *                        (HIPDNN_EP_DATATYPE_* in hipdnn_ep_runtime.h)
  *
@@ -541,6 +556,8 @@ int hip_linear_attention_decode(
     int64_t dv,
     float scale,
     int64_t update_rule,
+    int64_t decay_per_key_dim,
+    int64_t beta_per_head,
     int64_t type);
 
 /* =========================================================================

--- a/3rd-party/custom_kernels/include/hip_custom_kernels.h
+++ b/3rd-party/custom_kernels/include/hip_custom_kernels.h
@@ -491,16 +491,17 @@ int hip_qmoe_scatter_add(
  *                             head_dim_v]
  *                        Standard GQA: heads packed in Q-head order.
  *                        Inverse GQA: heads packed in KV-head order.
- *   batch_size         - batch dimension
- *   q_num_heads        - number of query heads
- *   kv_num_heads       - number of key/value state heads
- *   n_k_heads          - number of key heads packed in the key tensor;
- *                        must divide kv_num_heads
- *   head_dim_k         - key dimension per head
- *   head_dim_v         - value dimension per head
+ *   B                  - batch dimension
+ *   Hq                 - number of query heads
+ *   Hkv                - number of key/value state heads
+ *   Nk                 - number of key heads packed in the key tensor;
+ *                        must divide Hkv
+ *   dk                 - key dimension per head
+ *   dv                 - value dimension per head
  *   scale              - output scaling factor (typically 1/sqrt(d_k))
  *   update_rule        - 0=linear, 1=gated, 2=delta, 3=gated_delta
- *   element_size_bytes - 2 for fp16, 4 for fp32
+ *   type               - element type enum: 0=float, 1=float16, 2=bfloat16
+ *                        (HIPDNN_EP_DATATYPE_* in hipdnn_ep_runtime.h)
  *
  * Returns: 0 on success, non-zero on failure
  */
@@ -513,15 +514,15 @@ int hip_linear_attention_decode(
     const void* beta,
     void* state,
     void* output,
-    int64_t batch_size,
-    int64_t q_num_heads,
-    int64_t kv_num_heads,
-    int64_t n_k_heads,
-    int64_t head_dim_k,
-    int64_t head_dim_v,
+    int64_t B,
+    int64_t Hq,
+    int64_t Hkv,
+    int64_t Nk,
+    int64_t dk,
+    int64_t dv,
     float scale,
     int64_t update_rule,
-    int64_t element_size_bytes);
+    int64_t type);
 
 /* =========================================================================
  * WMMA GEMM (Small-M Matrix Multiply via Wave Matrix Multiply-Accumulate)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This project demonstrates the integration of HIP (Heterogeneous-compute Interfac
 - **MLIR Compiler Pipeline**: ONNX dialect → HIP dialect → LLVM IR → native DLL
 - **MIOpen Integration**: Conv, Softmax, RMS Norm, Mul via MIOpen library
 - **hipBLASLt MatMul**: High-performance matrix multiplication
-- **Custom HIP Kernels**: GQA, RoPE, Cast, Sub, Gather, ReduceSum
+- **Custom HIP Kernels**: GQA, RoPE, Cast, Sub, Gather, ReduceSum, LinearAttention
 - **Memory Pool Optimization**: `hip-pool-allocs` pass packs allocations into a single grow-on-demand buffer
 - **Constant Externalization**: Large model weights stored in sidecar `.constants.bin` files
 - **Mock Runtime**: GPU-free development and testing with `BUILD_MOCK_RUNTIME=ON`
@@ -42,6 +42,7 @@ This project demonstrates the integration of HIP (Heterogeneous-compute Interfac
 | GroupQueryAttention (com.microsoft) | Custom HIP Kernel |
 | MatMulNBits (com.microsoft) | Custom HIP Kernel |
 | QMoE (com.microsoft) | Custom HIP Kernel |
+| LinearAttention (com.microsoft) | Custom HIP Kernel |
 
 ### Compiler-Optimized Operations
 

--- a/include/hip/Dialect/IR/HipBufferize.h
+++ b/include/hip/Dialect/IR/HipBufferize.h
@@ -89,6 +89,8 @@ registerHipBufferizableOpInterfaceModels(DialectRegistry &registry) {
     HipDNNGraphOp::attachInterface<HipDstBufferizableModel<HipDNNGraphOp>>(
         *ctx);
     GemmOp::attachInterface<HipDstBufferizableModel<GemmOp>>(*ctx);
+    LinearAttentionOp::attachInterface<
+        HipDstBufferizableModel<LinearAttentionOp>>(*ctx);
   });
 }
 

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -1074,6 +1074,91 @@ def Hip_HipDNNGraphOp : Hip_DpsOp<"hipdnn_graph", [
   }];
 }
 
+def Hip_LinearAttentionOp : Hip_DpsOp<"linear_attention",
+    [AttrSizedOperandSegments]> {
+  let summary = "Linear attention with recurrent state (com.microsoft.LinearAttention)";
+  let description = [{
+    Unified linear attention operator for autoregressive decoding (T=1) and
+    prefill (T>1).
+
+    All inputs use 3D packed format [B, T, H*D]; q_num_heads and kv_num_heads
+    are always required. The op internally unpacks to 4D for computation.
+
+    The update_rule attribute selects the recurrence type:
+      "linear":       S_t = S_{t-1} + k_t (x) v_t
+      "gated":        S_t = exp(g_t) * S_{t-1} + k_t (x) v_t
+      "delta":        S_t = S_{t-1} + b_t * k_t (x) (v_t - S_{t-1}^T k_t)
+      "gated_delta":  S_t = exp(g_t) * S_{t-1} + b_t * k_t (x) (v_t - exp(g_t) * S_{t-1}^T k_t)
+
+    Inputs (3-6):
+      1. query       (required, T) - [B, T, H_q * d_k]
+      2. key         (required, T) - [B, T, H_kv * d_k]
+      3. value       (required, T) - [B, T, H_kv * d_v]
+      4. past_state  (optional, S) - [B, H_kv, d_k, d_v]
+      5. decay       (optional, T) - [B, T, H_kv * d_k] or [B, T, H_kv]
+      6. beta        (optional, T) - [B, T, H_kv] or [B, T, 1]
+
+    DPS output buffers:
+      output        (required, T) - [B, T, H_q * d_v]
+      present_state (required, S) - [B, H_kv, d_k, d_v]
+
+    Example:
+    ```mlir
+    hip.linear_attention(%ctx)
+        ins(%query, %key, %value :
+            memref<1x1x4096xf16, 1>, memref<1x1x1024xf16, 1>,
+            memref<1x1x1024xf16, 1>)
+        past_state(%past : memref<1x8x128x128xf16, 1>)
+        decay(%g : memref<1x1x1024xf16, 1>)
+        beta(%b : memref<1x1x8xf16, 1>)
+        outs(%output, %state : memref<1x1x4096xf16, 1>,
+                                memref<1x8x128x128xf16, 1>)
+        {q_num_heads = 32 : i64, kv_num_heads = 8 : i64,
+         scale = 0.0 : f32, update_rule = "gated_delta"}
+    ```
+  }];
+
+  let arguments = (ins
+    Hip_ContextType:$ctx,
+
+    // Required inputs (spec order 1-3)
+    Hip_TensorOrMemRef:$query,
+    Hip_TensorOrMemRef:$key,
+    Hip_TensorOrMemRef:$value,
+
+    // Optional inputs (spec order 4-6)
+    Optional<Hip_TensorOrMemRef>:$past_state,
+    Optional<Hip_TensorOrMemRef>:$decay,
+    Optional<Hip_TensorOrMemRef>:$beta,
+
+    // DPS output buffers
+    Hip_TensorOrMemRef:$output,
+    Hip_TensorOrMemRef:$present_state,
+
+    // Required attributes
+    I64Attr:$q_num_heads,
+    I64Attr:$kv_num_heads,
+
+    // Optional attributes (with defaults)
+    DefaultValuedAttr<F32Attr, "0.0">:$scale,
+    DefaultValuedAttr<I64Attr, "0">:$chunk_size,
+    DefaultValuedAttr<StrAttr, "\"gated_delta\"">:$update_rule
+  );
+
+  let assemblyFormat = [{
+    `(` $ctx `)` `ins` `(`
+        $query `,` $key `,` $value `:`
+        type($query) `,` type($key) `,` type($value)
+    `)`
+    (`past_state` `(` $past_state^ `:` type($past_state) `)`)?
+    (`decay` `(` $decay^ `:` type($decay) `)`)?
+    (`beta` `(` $beta^ `:` type($beta) `)`)?
+    `outs` `(` $output `,` $present_state `:`
+              type($output) `,` type($present_state) `)`
+    attr-dict (`:` type($result_tensors)^)?
+  }];
+}
+
 def Hip_GemmOp : Hip_DpsOp<"gemm">{
   let summary = "General matrix multiplication (ONNX Gemm)";
   let description = [{

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -1090,16 +1090,30 @@ def Hip_LinearAttentionOp : Hip_DpsOp<"linear_attention",
       "delta":        S_t = S_{t-1} + b_t * k_t (x) (v_t - S_{t-1}^T k_t)
       "gated_delta":  S_t = exp(g_t) * S_{t-1} + b_t * k_t (x) (v_t - exp(g_t) * S_{t-1}^T k_t)
 
+    Head counts are three-way (subject to divisibility constraints):
+      - H_q   = q_num_heads             (query heads, attribute)
+      - H_kv  = kv_num_heads            (KV state heads, attribute)
+      - n_k   = key.shape[-1] / d_k     (key heads, derived at runtime)
+    Constraints:
+      - n_k divides H_kv  (multiple KV heads may share one K head when n_k<H_kv)
+      - Either H_q % H_kv == 0  (standard GQA, H_q >= H_kv)
+        or     H_kv % H_q == 0  (inverse GQA,   H_q <  H_kv)
+
+    Output head count H_o = max(H_q, H_kv):
+      - Standard GQA (H_q >= H_kv): output packed in Q-head order.
+      - Inverse GQA  (H_q <  H_kv): output packed in KV-head order, i.e. each
+        KV state produces its own output slot.
+
     Inputs (3-6):
       1. query       (required, T) - [B, T, H_q * d_k]
-      2. key         (required, T) - [B, T, H_kv * d_k]
+      2. key         (required, T) - [B, T, n_k * d_k], n_k | H_kv
       3. value       (required, T) - [B, T, H_kv * d_v]
       4. past_state  (optional, S) - [B, H_kv, d_k, d_v]
       5. decay       (optional, T) - [B, T, H_kv * d_k] or [B, T, H_kv]
       6. beta        (optional, T) - [B, T, H_kv] or [B, T, 1]
 
     DPS output buffers:
-      output        (required, T) - [B, T, H_q * d_v]
+      output        (required, T) - [B, T, max(H_q, H_kv) * d_v]
       present_state (required, S) - [B, H_kv, d_k, d_v]
 
     Example:

--- a/lib/Conversion/HipToLLVM/CMakeLists.txt
+++ b/lib/Conversion/HipToLLVM/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(HipToLLVM STATIC
   QMoELowering.cpp
   GraphLowering.cpp
   GemmLowering.cpp
+  LinearAttentionLowering.cpp
 )
 
 add_dependencies(HipToLLVM

--- a/lib/Conversion/HipToLLVM/HipToLLVM.cpp
+++ b/lib/Conversion/HipToLLVM/HipToLLVM.cpp
@@ -225,6 +225,7 @@ void ConvertHipToLLVMPass::runOnOperation() {
   populateMatMulNBitsLoweringPatterns(typeConverter, patterns);
   populateQMoELoweringPatterns(typeConverter, patterns);
   populateGemmLoweringPatterns(typeConverter, patterns);
+  populateLinearAttentionLoweringPatterns(typeConverter, patterns);
   populateGraphLoweringPatterns(typeConverter, patterns);
 
   // Standard dialect lowerings

--- a/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
+++ b/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
@@ -63,6 +63,7 @@ inline constexpr const char *kWrapGQA = "wrap_group_query_attention";
 inline constexpr const char *kWrapMatMulNBits = "wrap_matmul_nbits";
 inline constexpr const char *kWrapQMoE = "wrap_qmoe";
 inline constexpr const char *kWrapGemm = "wrap_gemm";
+inline constexpr const char *kWrapLinearAttention = "wrap_linear_attention";
 inline constexpr const char *kHipGetConstant = "hipdnn_ep_constant_get";
 inline constexpr const char *kHipDNNGraphExecute = "hipdnn_graph_execute";
 
@@ -238,6 +239,8 @@ void populateGraphLoweringPatterns(const LLVMTypeConverter &converter,
                                    RewritePatternSet &patterns);
 void populateGemmLoweringPatterns(const LLVMTypeConverter &converter,
                                   RewritePatternSet &patterns);
+void populateLinearAttentionLoweringPatterns(
+    const LLVMTypeConverter &converter, RewritePatternSet &patterns);
 
 } // namespace hip
 } // namespace mlir

--- a/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
+++ b/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
@@ -239,8 +239,8 @@ void populateGraphLoweringPatterns(const LLVMTypeConverter &converter,
                                    RewritePatternSet &patterns);
 void populateGemmLoweringPatterns(const LLVMTypeConverter &converter,
                                   RewritePatternSet &patterns);
-void populateLinearAttentionLoweringPatterns(
-    const LLVMTypeConverter &converter, RewritePatternSet &patterns);
+void populateLinearAttentionLoweringPatterns(const LLVMTypeConverter &converter,
+                                             RewritePatternSet &patterns);
 
 } // namespace hip
 } // namespace mlir

--- a/lib/Conversion/HipToLLVM/LinearAttentionLowering.cpp
+++ b/lib/Conversion/HipToLLVM/LinearAttentionLowering.cpp
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "HipToLLVMUtils.h"
+
+namespace mlir {
+namespace hip {
+namespace {
+
+struct LinearAttentionOpLowering
+    : public ConvertOpToLLVMPattern<LinearAttentionOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(LinearAttentionOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    ModuleOp module = op->getParentOfType<ModuleOp>();
+    Type ptrType = getPtrType();
+    Type i32Type = rewriter.getI32Type();
+    Type i64Type = rewriter.getI64Type();
+    Type f32Type = rewriter.getF32Type();
+
+    auto createI64Const = [&](int64_t value) -> Value {
+      return LLVM::ConstantOp::create(rewriter, loc, i64Type,
+                                      rewriter.getI64IntegerAttr(value));
+    };
+    auto createF32Const = [&](float value) -> Value {
+      return LLVM::ConstantOp::create(rewriter, loc, f32Type,
+                                      rewriter.getF32FloatAttr(value));
+    };
+
+    Value nullPtr = LLVM::ZeroOp::create(rewriter, loc, ptrType);
+
+    auto getMemRefPtrOrNull = [&](Value memref) -> Value {
+      if (!memref)
+        return nullPtr;
+      return extractMemRefPtr(memref, rewriter, loc);
+    };
+
+    // === Extract all inputs ===
+    Value statePtr = adaptor.getCtx();
+
+    Value queryPtr = extractMemRefPtr(adaptor.getQuery(), rewriter, loc);
+    Value keyPtr = extractMemRefPtr(adaptor.getKey(), rewriter, loc);
+    Value valuePtr = extractMemRefPtr(adaptor.getValue(), rewriter, loc);
+
+    Value pastStatePtr = getMemRefPtrOrNull(adaptor.getPastState());
+    Value decayPtr = getMemRefPtrOrNull(adaptor.getDecay());
+    Value betaPtr = getMemRefPtrOrNull(adaptor.getBeta());
+
+    Value outputPtr = extractMemRefPtr(adaptor.getOutput(), rewriter, loc);
+    Value presentStatePtr =
+        extractMemRefPtr(adaptor.getPresentState(), rewriter, loc);
+
+    // === Extract attributes ===
+    Value qNumHeads = createI64Const(op.getQNumHeads());
+    Value kvNumHeads = createI64Const(op.getKvNumHeads());
+    Value scale = createF32Const(op.getScale().convertToFloat());
+    Value chunkSize = createI64Const(op.getChunkSize());
+
+    // Convert update_rule string to integer enum:
+    // "linear"=0, "gated"=1, "delta"=2, "gated_delta"=3
+    auto updateRuleToEnum = [](llvm::StringRef str) -> int64_t {
+      if (str == "linear")
+        return 0;
+      if (str == "gated")
+        return 1;
+      if (str == "delta")
+        return 2;
+      if (str == "gated_delta")
+        return 3;
+      return 3; // default to gated_delta
+    };
+    Value updateRule = createI64Const(updateRuleToEnum(op.getUpdateRule()));
+
+    // === Extract shape info from query: [B, T, H_q * d_k] ===
+    auto queryType = cast<MemRefType>(op.getQuery().getType());
+    auto queryShape = queryType.getShape();
+    int64_t batchSize = queryShape[0];
+    int64_t seqLen = queryShape[1];
+    int64_t queryHidden = queryShape[2];
+    int64_t headDimK = queryHidden / op.getQNumHeads();
+
+    // Derive d_v from present_state shape: [B, H_kv, d_k, d_v]
+    auto presentStateType = cast<MemRefType>(op.getPresentState().getType());
+    auto psShape = presentStateType.getShape();
+    int64_t headDimV = psShape[3];
+
+    unsigned elementSizeBytes =
+        queryType.getElementType().getIntOrFloatBitWidth() / 8;
+
+    Value batchSizeVal = createI64Const(batchSize);
+    Value seqLenVal = createI64Const(seqLen);
+    Value headDimKVal = createI64Const(headDimK);
+    Value headDimVVal = createI64Const(headDimV);
+    Value elemSizeVal = createI64Const(elementSizeBytes);
+
+    // Function signature: state + 6 inputs + 2 outputs + 5 attrs + 5 shape = 19
+    SmallVector<Type, 19> paramTypes = {
+        ptrType, // state
+        ptrType, // query
+        ptrType, // key
+        ptrType, // value
+        ptrType, // past_state (nullable)
+        ptrType, // decay (nullable)
+        ptrType, // beta (nullable)
+        ptrType, // output
+        ptrType, // present_state
+        i64Type, // q_num_heads
+        i64Type, // kv_num_heads
+        f32Type, // scale
+        i64Type, // chunk_size
+        i64Type, // update_rule
+        i64Type, // batch_size
+        i64Type, // seq_len
+        i64Type, // head_dim_k
+        i64Type, // head_dim_v
+        i64Type  // element_size_bytes
+    };
+
+    FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
+        rewriter, module, kWrapLinearAttention, paramTypes, i32Type);
+    if (failed(funcOp))
+      return failure();
+
+    SmallVector<Value, 19> args = {
+        statePtr,
+        queryPtr, keyPtr, valuePtr,
+        pastStatePtr, decayPtr, betaPtr,
+        outputPtr, presentStatePtr,
+        qNumHeads, kvNumHeads, scale, chunkSize, updateRule,
+        batchSizeVal, seqLenVal, headDimKVal, headDimVVal, elemSizeVal};
+
+    LLVM::CallOp::create(rewriter, loc, *funcOp, args);
+
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+} // namespace
+
+void mlir::hip::populateLinearAttentionLoweringPatterns(
+    const LLVMTypeConverter &converter, RewritePatternSet &patterns) {
+  patterns.add<LinearAttentionOpLowering>(converter);
+}
+
+} // namespace hip
+} // namespace mlir

--- a/lib/Conversion/HipToLLVM/LinearAttentionLowering.cpp
+++ b/lib/Conversion/HipToLLVM/LinearAttentionLowering.cpp
@@ -43,15 +43,18 @@ struct LinearAttentionOpLowering
     // === Extract all inputs ===
     Value statePtr = adaptor.getCtx();
 
-    Value queryPtr = extractContiguousMemRefPtr(adaptor.getQuery(), rewriter, loc);
+    Value queryPtr =
+        extractContiguousMemRefPtr(adaptor.getQuery(), rewriter, loc);
     Value keyPtr = extractContiguousMemRefPtr(adaptor.getKey(), rewriter, loc);
-    Value valuePtr = extractContiguousMemRefPtr(adaptor.getValue(), rewriter, loc);
+    Value valuePtr =
+        extractContiguousMemRefPtr(adaptor.getValue(), rewriter, loc);
 
     Value pastStatePtr = getMemRefPtrOrNull(adaptor.getPastState());
     Value decayPtr = getMemRefPtrOrNull(adaptor.getDecay());
     Value betaPtr = getMemRefPtrOrNull(adaptor.getBeta());
 
-    Value outputPtr = extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
+    Value outputPtr =
+        extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
     Value presentStatePtr =
         extractContiguousMemRefPtr(adaptor.getPresentState(), rewriter, loc);
 

--- a/lib/Conversion/HipToLLVM/LinearAttentionLowering.cpp
+++ b/lib/Conversion/HipToLLVM/LinearAttentionLowering.cpp
@@ -98,6 +98,15 @@ struct LinearAttentionOpLowering
     Value headDimKVal =
         LLVM::UDivOp::create(rewriter, loc, queryHiddenVal, qNumHeadsForDiv);
 
+    // n_k_heads = key.dim[2] / head_dim_k.  The key tensor is [B, T, n_k*d_k]
+    // and n_k may differ from kv_num_heads (it only has to divide it).  Use
+    // getMemRefDimSize so dynamic key shapes fall back to a runtime extract.
+    auto keyType = cast<MemRefType>(op.getKey().getType());
+    Value keyHiddenVal =
+        getMemRefDimSize(keyType, 2, adaptor.getKey(), rewriter, loc);
+    Value nKHeadsVal =
+        LLVM::UDivOp::create(rewriter, loc, keyHiddenVal, headDimKVal);
+
     // Derive d_v from present_state shape: [B, H_kv, d_k, d_v].
     // present_state is always 4D per spec, so index 3 is safe.
     auto presentStateType = cast<MemRefType>(op.getPresentState().getType());
@@ -109,8 +118,14 @@ struct LinearAttentionOpLowering
         queryType.getElementType().getIntOrFloatBitWidth() / 8;
     Value elemSizeVal = createI64Const(elementSizeBytes);
 
-    // Function signature: state + 6 inputs + 2 outputs + 5 attrs + 5 shape = 19
-    SmallVector<Type, 19> paramTypes = {
+    // Function signature:
+    //   state + 6 inputs + 2 outputs (9 ptrs)
+    //   + 3 head-count attrs (q_num_heads, kv_num_heads, n_k_heads)
+    //   + 3 scalar attrs (scale, chunk_size, update_rule)
+    //   + 5 shape params (batch_size, seq_len, head_dim_k, head_dim_v,
+    //                     element_size_bytes)
+    // = 20 parameters total.
+    SmallVector<Type, 20> paramTypes = {
         ptrType, // state
         ptrType, // query
         ptrType, // key
@@ -122,6 +137,7 @@ struct LinearAttentionOpLowering
         ptrType, // present_state
         i64Type, // q_num_heads
         i64Type, // kv_num_heads
+        i64Type, // n_k_heads  (derived from key.dim[2] / head_dim_k)
         f32Type, // scale
         i64Type, // chunk_size
         i64Type, // update_rule
@@ -137,11 +153,11 @@ struct LinearAttentionOpLowering
     if (failed(funcOp))
       return failure();
 
-    SmallVector<Value, 19> args = {
+    SmallVector<Value, 20> args = {
         statePtr,   queryPtr,    keyPtr,      valuePtr,        pastStatePtr,
         decayPtr,   betaPtr,     outputPtr,   presentStatePtr, qNumHeads,
-        kvNumHeads, scale,       chunkSize,   updateRule,      batchSizeVal,
-        seqLenVal,  headDimKVal, headDimVVal, elemSizeVal};
+        kvNumHeads, nKHeadsVal,  scale,       chunkSize,       updateRule,
+        batchSizeVal, seqLenVal, headDimKVal, headDimVVal,     elemSizeVal};
 
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
 

--- a/lib/Conversion/HipToLLVM/LinearAttentionLowering.cpp
+++ b/lib/Conversion/HipToLLVM/LinearAttentionLowering.cpp
@@ -77,25 +77,36 @@ struct LinearAttentionOpLowering
     Value updateRule = createI64Const(updateRuleToEnum(op.getUpdateRule()));
 
     // === Extract shape info from query: [B, T, H_q * d_k] ===
+    // Use getMemRefDimSize so we pick up compile-time constants for static
+    // dims and runtime MemRefDescriptor::size for dynamic dims -- otherwise
+    // a dynamic shape (typical LLM decode/prefill) would feed
+    // ShapedType::kDynamic (a large negative sentinel) into the runtime
+    // argument.
     auto queryType = cast<MemRefType>(op.getQuery().getType());
-    auto queryShape = queryType.getShape();
-    int64_t batchSize = queryShape[0];
-    int64_t seqLen = queryShape[1];
-    int64_t queryHidden = queryShape[2];
-    int64_t headDimK = queryHidden / op.getQNumHeads();
+    Value batchSizeVal =
+        getMemRefDimSize(queryType, 0, adaptor.getQuery(), rewriter, loc);
+    Value seqLenVal =
+        getMemRefDimSize(queryType, 1, adaptor.getQuery(), rewriter, loc);
 
-    // Derive d_v from present_state shape: [B, H_kv, d_k, d_v]
+    // head_dim_k = query.dim[2] / q_num_heads.
+    // q_num_heads is always a compile-time attribute, so when query.dim[2]
+    // is static we fold the division; when it's dynamic we emit a runtime
+    // llvm.udiv so the computed head_dim_k is valid for any shape.
+    Value queryHiddenVal =
+        getMemRefDimSize(queryType, 2, adaptor.getQuery(), rewriter, loc);
+    Value qNumHeadsForDiv = createI64Const(op.getQNumHeads());
+    Value headDimKVal =
+        LLVM::UDivOp::create(rewriter, loc, queryHiddenVal, qNumHeadsForDiv);
+
+    // Derive d_v from present_state shape: [B, H_kv, d_k, d_v].
+    // present_state is always 4D per spec, so index 3 is safe.
     auto presentStateType = cast<MemRefType>(op.getPresentState().getType());
-    auto psShape = presentStateType.getShape();
-    int64_t headDimV = psShape[3];
+    Value headDimVVal = getMemRefDimSize(presentStateType, 3,
+                                         adaptor.getPresentState(), rewriter,
+                                         loc);
 
     unsigned elementSizeBytes =
         queryType.getElementType().getIntOrFloatBitWidth() / 8;
-
-    Value batchSizeVal = createI64Const(batchSize);
-    Value seqLenVal = createI64Const(seqLen);
-    Value headDimKVal = createI64Const(headDimK);
-    Value headDimVVal = createI64Const(headDimV);
     Value elemSizeVal = createI64Const(elementSizeBytes);
 
     // Function signature: state + 6 inputs + 2 outputs + 5 attrs + 5 shape = 19

--- a/lib/Conversion/HipToLLVM/LinearAttentionLowering.cpp
+++ b/lib/Conversion/HipToLLVM/LinearAttentionLowering.cpp
@@ -114,18 +114,63 @@ struct LinearAttentionOpLowering
                                          adaptor.getPresentState(), rewriter,
                                          loc);
 
-    unsigned elementSizeBytes =
-        queryType.getElementType().getIntOrFloatBitWidth() / 8;
-    Value elemSizeVal = createI64Const(elementSizeBytes);
+    // Derive layout flags for the optional decay / beta tensors so the
+    // runtime can pick the correct per-token stride:
+    //   decay_per_key_dim = 1 when decay last dim == H_kv * d_k (GLA/RWKV-6)
+    //                     = 0 when decay last dim == H_kv       (DeltaNet/RetNet)
+    //   beta_per_head     = 1 when beta  last dim == H_kv
+    //                     = 0 when beta  last dim == 1          (broadcast)
+    // Values are meaningless when the corresponding operand is absent, in
+    // which case we pass 0.
+    auto deriveLayoutFlagEqualsOne = [&](Value operand, MemRefType type,
+                                         Value refVal,
+                                         int64_t refConst) -> Value {
+      // Returns 1 when operand's last dim differs from the reference value
+      // (for decay: ref = H_kv -> last == H_kv means per-head layout (0);
+      //  for beta : ref = 1    -> last == 1    means broadcast layout (0)).
+      int dim = type.getRank() - 1;
+      if (!type.isDynamicDim(dim)) {
+        int64_t last = type.getDimSize(dim);
+        return createI64Const(last == refConst ? 0 : 1);
+      }
+      Value lastDim =
+          getMemRefDimSize(type, dim, operand, rewriter, loc);
+      Value cmp = LLVM::ICmpOp::create(
+          rewriter, loc, LLVM::ICmpPredicate::ne, lastDim, refVal);
+      return LLVM::ZExtOp::create(rewriter, loc, i64Type, cmp);
+    };
+
+    Value decayPerKeyDimVal = createI64Const(0);
+    if (adaptor.getDecay()) {
+      auto decayType = cast<MemRefType>(op.getDecay().getType());
+      decayPerKeyDimVal = deriveLayoutFlagEqualsOne(
+          adaptor.getDecay(), decayType, kvNumHeads, op.getKvNumHeads());
+    }
+
+    Value betaPerHeadVal = createI64Const(0);
+    if (adaptor.getBeta()) {
+      auto betaType = cast<MemRefType>(op.getBeta().getType());
+      Value oneConst = createI64Const(1);
+      betaPerHeadVal = deriveLayoutFlagEqualsOne(
+          adaptor.getBeta(), betaType, oneConst, /*refConst=*/1);
+    }
+
+    int64_t elemTypeEnum =
+        getHipdnnDataType(queryType.getElementType());
+    if (elemTypeEnum < 0 || elemTypeEnum > 2) {
+      return rewriter.notifyMatchFailure(
+          op, "hip.linear_attention requires f32, f16, or bf16 element type");
+    }
+    Value typeVal = createI64Const(elemTypeEnum);
 
     // Function signature:
     //   state + 6 inputs + 2 outputs (9 ptrs)
-    //   + 3 head-count attrs (q_num_heads, kv_num_heads, n_k_heads)
+    //   + 3 head-count attrs (Hq, Hkv, Nk)
+    //   + 2 optional-input layout flags (decay_per_key_dim, beta_per_head)
     //   + 3 scalar attrs (scale, chunk_size, update_rule)
-    //   + 5 shape params (batch_size, seq_len, head_dim_k, head_dim_v,
-    //                     element_size_bytes)
-    // = 20 parameters total.
-    SmallVector<Type, 20> paramTypes = {
+    //   + 5 shape params (B, seq_len, dk, dv, type)
+    // = 22 parameters total.
+    SmallVector<Type, 22> paramTypes = {
         ptrType, // state
         ptrType, // query
         ptrType, // key
@@ -135,17 +180,19 @@ struct LinearAttentionOpLowering
         ptrType, // beta (nullable)
         ptrType, // output
         ptrType, // present_state
-        i64Type, // q_num_heads
-        i64Type, // kv_num_heads
-        i64Type, // n_k_heads  (derived from key.dim[2] / head_dim_k)
+        i64Type, // Hq
+        i64Type, // Hkv
+        i64Type, // Nk (derived from key.dim[2] / head_dim_k)
+        i64Type, // decay_per_key_dim (0/1; 0 when decay absent)
+        i64Type, // beta_per_head     (0/1; 0 when beta absent)
         f32Type, // scale
         i64Type, // chunk_size
         i64Type, // update_rule
-        i64Type, // batch_size
+        i64Type, // B
         i64Type, // seq_len
-        i64Type, // head_dim_k
-        i64Type, // head_dim_v
-        i64Type  // element_size_bytes
+        i64Type, // dk
+        i64Type, // dv
+        i64Type  // type (HIPDNN_EP_DATATYPE_FLOAT/HALF/BFLOAT16)
     };
 
     FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
@@ -153,11 +200,13 @@ struct LinearAttentionOpLowering
     if (failed(funcOp))
       return failure();
 
-    SmallVector<Value, 20> args = {
-        statePtr,   queryPtr,    keyPtr,      valuePtr,        pastStatePtr,
-        decayPtr,   betaPtr,     outputPtr,   presentStatePtr, qNumHeads,
-        kvNumHeads, nKHeadsVal,  scale,       chunkSize,       updateRule,
-        batchSizeVal, seqLenVal, headDimKVal, headDimVVal,     elemSizeVal};
+    SmallVector<Value, 22> args = {
+        statePtr,         queryPtr,         keyPtr,         valuePtr,
+        pastStatePtr,     decayPtr,         betaPtr,        outputPtr,
+        presentStatePtr,  qNumHeads,        kvNumHeads,     nKHeadsVal,
+        decayPerKeyDimVal, betaPerHeadVal,  scale,          chunkSize,
+        updateRule,       batchSizeVal,     seqLenVal,      headDimKVal,
+        headDimVVal,      typeVal};
 
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
 

--- a/lib/Conversion/HipToLLVM/LinearAttentionLowering.cpp
+++ b/lib/Conversion/HipToLLVM/LinearAttentionLowering.cpp
@@ -127,12 +127,10 @@ struct LinearAttentionOpLowering
       return failure();
 
     SmallVector<Value, 19> args = {
-        statePtr,
-        queryPtr, keyPtr, valuePtr,
-        pastStatePtr, decayPtr, betaPtr,
-        outputPtr, presentStatePtr,
-        qNumHeads, kvNumHeads, scale, chunkSize, updateRule,
-        batchSizeVal, seqLenVal, headDimKVal, headDimVVal, elemSizeVal};
+        statePtr,   queryPtr,    keyPtr,      valuePtr,        pastStatePtr,
+        decayPtr,   betaPtr,     outputPtr,   presentStatePtr, qNumHeads,
+        kvNumHeads, scale,       chunkSize,   updateRule,      batchSizeVal,
+        seqLenVal,  headDimKVal, headDimVVal, elemSizeVal};
 
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
 

--- a/lib/Conversion/HipToLLVM/LinearAttentionLowering.cpp
+++ b/lib/Conversion/HipToLLVM/LinearAttentionLowering.cpp
@@ -37,23 +37,23 @@ struct LinearAttentionOpLowering
     auto getMemRefPtrOrNull = [&](Value memref) -> Value {
       if (!memref)
         return nullPtr;
-      return extractMemRefPtr(memref, rewriter, loc);
+      return extractContiguousMemRefPtr(memref, rewriter, loc);
     };
 
     // === Extract all inputs ===
     Value statePtr = adaptor.getCtx();
 
-    Value queryPtr = extractMemRefPtr(adaptor.getQuery(), rewriter, loc);
-    Value keyPtr = extractMemRefPtr(adaptor.getKey(), rewriter, loc);
-    Value valuePtr = extractMemRefPtr(adaptor.getValue(), rewriter, loc);
+    Value queryPtr = extractContiguousMemRefPtr(adaptor.getQuery(), rewriter, loc);
+    Value keyPtr = extractContiguousMemRefPtr(adaptor.getKey(), rewriter, loc);
+    Value valuePtr = extractContiguousMemRefPtr(adaptor.getValue(), rewriter, loc);
 
     Value pastStatePtr = getMemRefPtrOrNull(adaptor.getPastState());
     Value decayPtr = getMemRefPtrOrNull(adaptor.getDecay());
     Value betaPtr = getMemRefPtrOrNull(adaptor.getBeta());
 
-    Value outputPtr = extractMemRefPtr(adaptor.getOutput(), rewriter, loc);
+    Value outputPtr = extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
     Value presentStatePtr =
-        extractMemRefPtr(adaptor.getPresentState(), rewriter, loc);
+        extractContiguousMemRefPtr(adaptor.getPresentState(), rewriter, loc);
 
     // === Extract attributes ===
     Value qNumHeads = createI64Const(op.getQNumHeads());

--- a/lib/Conversion/HipToLLVM/LinearAttentionLowering.cpp
+++ b/lib/Conversion/HipToLLVM/LinearAttentionLowering.cpp
@@ -110,14 +110,13 @@ struct LinearAttentionOpLowering
     // Derive d_v from present_state shape: [B, H_kv, d_k, d_v].
     // present_state is always 4D per spec, so index 3 is safe.
     auto presentStateType = cast<MemRefType>(op.getPresentState().getType());
-    Value headDimVVal = getMemRefDimSize(presentStateType, 3,
-                                         adaptor.getPresentState(), rewriter,
-                                         loc);
+    Value headDimVVal = getMemRefDimSize(
+        presentStateType, 3, adaptor.getPresentState(), rewriter, loc);
 
     // Derive layout flags for the optional decay / beta tensors so the
     // runtime can pick the correct per-token stride:
     //   decay_per_key_dim = 1 when decay last dim == H_kv * d_k (GLA/RWKV-6)
-    //                     = 0 when decay last dim == H_kv       (DeltaNet/RetNet)
+    //                     = 0 when decay last dim == H_kv (DeltaNet/RetNet)
     //   beta_per_head     = 1 when beta  last dim == H_kv
     //                     = 0 when beta  last dim == 1          (broadcast)
     // Values are meaningless when the corresponding operand is absent, in
@@ -133,10 +132,9 @@ struct LinearAttentionOpLowering
         int64_t last = type.getDimSize(dim);
         return createI64Const(last == refConst ? 0 : 1);
       }
-      Value lastDim =
-          getMemRefDimSize(type, dim, operand, rewriter, loc);
-      Value cmp = LLVM::ICmpOp::create(
-          rewriter, loc, LLVM::ICmpPredicate::ne, lastDim, refVal);
+      Value lastDim = getMemRefDimSize(type, dim, operand, rewriter, loc);
+      Value cmp = LLVM::ICmpOp::create(rewriter, loc, LLVM::ICmpPredicate::ne,
+                                       lastDim, refVal);
       return LLVM::ZExtOp::create(rewriter, loc, i64Type, cmp);
     };
 
@@ -151,12 +149,11 @@ struct LinearAttentionOpLowering
     if (adaptor.getBeta()) {
       auto betaType = cast<MemRefType>(op.getBeta().getType());
       Value oneConst = createI64Const(1);
-      betaPerHeadVal = deriveLayoutFlagEqualsOne(
-          adaptor.getBeta(), betaType, oneConst, /*refConst=*/1);
+      betaPerHeadVal = deriveLayoutFlagEqualsOne(adaptor.getBeta(), betaType,
+                                                 oneConst, /*refConst=*/1);
     }
 
-    int64_t elemTypeEnum =
-        getHipdnnDataType(queryType.getElementType());
+    int64_t elemTypeEnum = getHipdnnDataType(queryType.getElementType());
     if (elemTypeEnum < 0 || elemTypeEnum > 2) {
       return rewriter.notifyMatchFailure(
           op, "hip.linear_attention requires f32, f16, or bf16 element type");
@@ -201,12 +198,12 @@ struct LinearAttentionOpLowering
       return failure();
 
     SmallVector<Value, 22> args = {
-        statePtr,         queryPtr,         keyPtr,         valuePtr,
-        pastStatePtr,     decayPtr,         betaPtr,        outputPtr,
-        presentStatePtr,  qNumHeads,        kvNumHeads,     nKHeadsVal,
-        decayPerKeyDimVal, betaPerHeadVal,  scale,          chunkSize,
-        updateRule,       batchSizeVal,     seqLenVal,      headDimKVal,
-        headDimVVal,      typeVal};
+        statePtr,          queryPtr,       keyPtr,     valuePtr,
+        pastStatePtr,      decayPtr,       betaPtr,    outputPtr,
+        presentStatePtr,   qNumHeads,      kvNumHeads, nKHeadsVal,
+        decayPerKeyDimVal, betaPerHeadVal, scale,      chunkSize,
+        updateRule,        batchSizeVal,   seqLenVal,  headDimKVal,
+        headDimVVal,       typeVal};
 
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
 

--- a/lib/Conversion/OnnxToHip/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHip/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(OnnxToHip STATIC
   GatherConversion.cpp
   ReshapeConversion.cpp
   GemmConversion.cpp
+  LinearAttentionConversion.cpp
 )
 
 add_dependencies(OnnxToHip

--- a/lib/Conversion/OnnxToHip/LinearAttentionConversion.cpp
+++ b/lib/Conversion/OnnxToHip/LinearAttentionConversion.cpp
@@ -19,12 +19,12 @@ struct LinearAttentionToHip : public mlir::RewritePattern {
                   mlir::PatternRewriter &rewriter) const override;
 };
 
-mlir::LogicalResult LinearAttentionToHip::matchAndRewrite(
-    mlir::Operation *op, mlir::PatternRewriter &rewriter) const {
+mlir::LogicalResult
+LinearAttentionToHip::matchAndRewrite(mlir::Operation *op,
+                                      mlir::PatternRewriter &rewriter) const {
   auto funcNameAttr = op->getAttrOfType<mlir::StringAttr>("function_name");
   if (!funcNameAttr || funcNameAttr.getValue() != "LinearAttention")
-    return rewriter.notifyMatchFailure(op,
-                                       "not a LinearAttention operation");
+    return rewriter.notifyMatchFailure(op, "not a LinearAttention operation");
 
   auto domainAttr = op->getAttrOfType<mlir::StringAttr>("domain_name");
   if (!domainAttr || domainAttr.getValue() != "com.microsoft")
@@ -41,8 +41,8 @@ mlir::LogicalResult LinearAttentionToHip::matchAndRewrite(
   // Support variable operand count (3-6 inputs as per spec)
   size_t numOps = op->getNumOperands();
   if (numOps < 3 || numOps > 6)
-    return rewriter.notifyMatchFailure(
-        op, "LinearAttention expects 3-6 operands");
+    return rewriter.notifyMatchFailure(op,
+                                       "LinearAttention expects 3-6 operands");
 
   auto getOptionalOperand = [&](size_t idx) -> mlir::Value {
     if (idx >= numOps)
@@ -62,8 +62,7 @@ mlir::LogicalResult LinearAttentionToHip::matchAndRewrite(
   mlir::Value beta = getOptionalOperand(5);
 
   // === Extract Attributes ===
-  auto qNumHeadsAttrOnnx =
-      op->getAttrOfType<mlir::IntegerAttr>("q_num_heads");
+  auto qNumHeadsAttrOnnx = op->getAttrOfType<mlir::IntegerAttr>("q_num_heads");
   if (!qNumHeadsAttrOnnx)
     return rewriter.notifyMatchFailure(op, "missing q_num_heads attribute");
   auto qNumHeadsAttr =
@@ -125,8 +124,7 @@ mlir::LogicalResult LinearAttentionToHip::matchAndRewrite(
   // === Create DPS init tensors ===
   mlir::Value outputInit = createEmptyTensor(rewriter, loc, outputType, query);
   mlir::Value presentStateInit = createEmptyTensor(
-      rewriter, loc, presentStateType,
-      pastState ? pastState : key);
+      rewriter, loc, presentStateType, pastState ? pastState : key);
 
   // === Create hip.linear_attention operation ===
   mlir::SmallVector<mlir::Type> resultTypes;

--- a/lib/Conversion/OnnxToHip/LinearAttentionConversion.cpp
+++ b/lib/Conversion/OnnxToHip/LinearAttentionConversion.cpp
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "OnnxToHipUtils.h"
+
+namespace mlir {
+namespace hip {
+namespace {
+
+/// onnx.Custom(LinearAttention) -> hip.linear_attention
+struct LinearAttentionToHip : public mlir::RewritePattern {
+  LinearAttentionToHip(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.Custom", /*benefit=*/1, ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override;
+};
+
+mlir::LogicalResult LinearAttentionToHip::matchAndRewrite(
+    mlir::Operation *op, mlir::PatternRewriter &rewriter) const {
+  auto funcNameAttr = op->getAttrOfType<mlir::StringAttr>("function_name");
+  if (!funcNameAttr || funcNameAttr.getValue() != "LinearAttention")
+    return rewriter.notifyMatchFailure(op,
+                                       "not a LinearAttention operation");
+
+  auto domainAttr = op->getAttrOfType<mlir::StringAttr>("domain_name");
+  if (!domainAttr || domainAttr.getValue() != "com.microsoft")
+    return rewriter.notifyMatchFailure(
+        op, "domain must be com.microsoft for LinearAttention");
+
+  auto ctxOrFailure = getContextArg(op, rewriter);
+  if (mlir::failed(ctxOrFailure))
+    return rewriter.notifyMatchFailure(op, "missing context argument");
+  mlir::Value context = *ctxOrFailure;
+
+  mlir::Location loc = op->getLoc();
+
+  // Support variable operand count (3-6 inputs as per spec)
+  size_t numOps = op->getNumOperands();
+  if (numOps < 3 || numOps > 6)
+    return rewriter.notifyMatchFailure(
+        op, "LinearAttention expects 3-6 operands");
+
+  auto getOptionalOperand = [&](size_t idx) -> mlir::Value {
+    if (idx >= numOps)
+      return nullptr;
+    mlir::Value val = op->getOperand(idx);
+    if (mlir::isa<mlir::NoneType>(val.getType()))
+      return nullptr;
+    return val;
+  };
+
+  // === Extract Inputs (spec order 1-6) ===
+  mlir::Value query = op->getOperand(0);
+  mlir::Value key = op->getOperand(1);
+  mlir::Value value = op->getOperand(2);
+  mlir::Value pastState = getOptionalOperand(3);
+  mlir::Value decay = getOptionalOperand(4);
+  mlir::Value beta = getOptionalOperand(5);
+
+  // === Extract Attributes ===
+  auto qNumHeadsAttrOnnx =
+      op->getAttrOfType<mlir::IntegerAttr>("q_num_heads");
+  if (!qNumHeadsAttrOnnx)
+    return rewriter.notifyMatchFailure(op, "missing q_num_heads attribute");
+  auto qNumHeadsAttr =
+      rewriter.getI64IntegerAttr(qNumHeadsAttrOnnx.getValue().getSExtValue());
+
+  auto kvNumHeadsAttrOnnx =
+      op->getAttrOfType<mlir::IntegerAttr>("kv_num_heads");
+  if (!kvNumHeadsAttrOnnx)
+    return rewriter.notifyMatchFailure(op, "missing kv_num_heads attribute");
+  auto kvNumHeadsAttr =
+      rewriter.getI64IntegerAttr(kvNumHeadsAttrOnnx.getValue().getSExtValue());
+
+  auto getFloatAttr = [&](const char *name,
+                          float defaultVal) -> mlir::FloatAttr {
+    auto attr = op->getAttrOfType<mlir::FloatAttr>(name);
+    return attr ? attr : rewriter.getF32FloatAttr(defaultVal);
+  };
+
+  auto getI64Attr = [&](const char *name,
+                        int64_t defaultVal) -> mlir::IntegerAttr {
+    auto attr = op->getAttrOfType<mlir::IntegerAttr>(name);
+    return attr ? rewriter.getI64IntegerAttr(attr.getValue().getSExtValue())
+                : rewriter.getI64IntegerAttr(defaultVal);
+  };
+
+  auto getStrAttr = [&](const char *name,
+                        const char *defaultVal) -> mlir::StringAttr {
+    auto attr = op->getAttrOfType<mlir::StringAttr>(name);
+    return attr ? attr : rewriter.getStringAttr(defaultVal);
+  };
+
+  // scale = 0.0 means "auto-compute 1/sqrt(d_k) at runtime"
+  auto queryType = mlir::cast<mlir::RankedTensorType>(query.getType());
+  int64_t qNumHeads = qNumHeadsAttrOnnx.getValue().getSExtValue();
+  float defaultScale = 0.0f;
+  if (queryType.hasRank() && queryType.getRank() >= 3) {
+    int64_t hiddenSize = queryType.getDimSize(2);
+    if (hiddenSize != mlir::ShapedType::kDynamic && qNumHeads > 0) {
+      int64_t headSize = hiddenSize / qNumHeads;
+      defaultScale = 1.0f / std::sqrt(static_cast<float>(headSize));
+    }
+  }
+
+  auto scaleAttr = getFloatAttr("scale", defaultScale);
+  auto chunkSizeAttr = getI64Attr("chunk_size", 0);
+  auto updateRuleAttr = getStrAttr("update_rule", "gated_delta");
+
+  // === Check Outputs (always 2: output, present_state) ===
+  size_t numResults = op->getNumResults();
+  if (numResults != 2)
+    return rewriter.notifyMatchFailure(
+        op, "LinearAttention expects exactly 2 results");
+
+  auto outputType =
+      mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
+  auto presentStateType =
+      mlir::cast<mlir::RankedTensorType>(op->getResult(1).getType());
+
+  // === Create DPS init tensors ===
+  mlir::Value outputInit = createEmptyTensor(rewriter, loc, outputType, query);
+  mlir::Value presentStateInit = createEmptyTensor(
+      rewriter, loc, presentStateType,
+      pastState ? pastState : key);
+
+  // === Create hip.linear_attention operation ===
+  mlir::SmallVector<mlir::Type> resultTypes;
+  resultTypes.push_back(outputType);
+  resultTypes.push_back(presentStateType);
+
+  mlir::SmallVector<mlir::Value> operands;
+  operands.push_back(context);
+  operands.push_back(query);
+  operands.push_back(key);
+  operands.push_back(value);
+  if (pastState)
+    operands.push_back(pastState);
+  if (decay)
+    operands.push_back(decay);
+  if (beta)
+    operands.push_back(beta);
+  operands.push_back(outputInit);
+  operands.push_back(presentStateInit);
+
+  mlir::SmallVector<mlir::NamedAttribute> attrs;
+  attrs.push_back(rewriter.getNamedAttr("q_num_heads", qNumHeadsAttr));
+  attrs.push_back(rewriter.getNamedAttr("kv_num_heads", kvNumHeadsAttr));
+  attrs.push_back(rewriter.getNamedAttr("scale", scaleAttr));
+  attrs.push_back(rewriter.getNamedAttr("chunk_size", chunkSizeAttr));
+  attrs.push_back(rewriter.getNamedAttr("update_rule", updateRuleAttr));
+
+  auto state = mlir::OperationState(loc, "hip.linear_attention");
+  state.addOperands(operands);
+  state.addAttributes(attrs);
+  state.addTypes(resultTypes);
+
+  // Segments: [ctx(1), query(1), key(1), value(1), past_state(0|1),
+  //            decay(0|1), beta(0|1), output(1), present_state(1)]
+  llvm::SmallVector<int32_t> segmentSizes;
+  segmentSizes.push_back(1); // ctx
+  segmentSizes.push_back(1); // query
+  segmentSizes.push_back(1); // key
+  segmentSizes.push_back(1); // value
+  segmentSizes.push_back(pastState ? 1 : 0);
+  segmentSizes.push_back(decay ? 1 : 0);
+  segmentSizes.push_back(beta ? 1 : 0);
+  segmentSizes.push_back(1); // output
+  segmentSizes.push_back(1); // present_state
+
+  state.addAttribute("operand_segment_sizes",
+                     rewriter.getDenseI32ArrayAttr(segmentSizes));
+
+  auto hipOp = rewriter.create(state);
+  rewriter.replaceOp(op, hipOp->getResults());
+  return mlir::success();
+}
+
+} // namespace
+
+void mlir::hip::populateLinearAttentionConversionPatterns(
+    RewritePatternSet &patterns, MLIRContext *ctx) {
+  patterns.add<LinearAttentionToHip>(ctx);
+}
+
+} // namespace hip
+} // namespace mlir

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -379,6 +379,7 @@ static mlir::LogicalResult convertComputeOps(mlir::func::FuncOp funcOp,
   populateQMoEConversionPatterns(patterns, ctx);
   populateReshapeConversionPatterns(patterns, ctx);
   populateGemmConversionPatterns(patterns, ctx);
+  populateLinearAttentionConversionPatterns(patterns, ctx);
 
   mlir::GreedyRewriteConfig config;
   config.setStrictness(mlir::GreedyRewriteStrictness::ExistingOps);

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
@@ -141,6 +141,8 @@ void populateReshapeConversionPatterns(RewritePatternSet &patterns,
                                        MLIRContext *ctx);
 void populateGemmConversionPatterns(RewritePatternSet &patterns,
                                     MLIRContext *ctx);
+void populateLinearAttentionConversionPatterns(RewritePatternSet &patterns,
+                                               MLIRContext *ctx);
 
 } // namespace hip
 } // namespace mlir

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -627,6 +627,35 @@ void GemmOp::getEffects(
 //        total_seq_len,
 //            [cos_cache, sin_cache, position_ids, attention_bias, head_sink,
 //             k_scale, v_scale])
+//        outs(output, present_state)
+//===----------------------------------------------------------------------===//
+
+MutableOperandRange LinearAttentionOp::getDpsInitsMutable() {
+  // Operand segments:
+  //   ctx(1), query(1), key(1), value(1),
+  //   past_state(0|1), decay(0|1), beta(0|1),
+  //   output(1), present_state(1)
+  unsigned numInputs = 4; // ctx, query, key, value
+  if (getPastState())
+    ++numInputs;
+  if (getDecay())
+    ++numInputs;
+  if (getBeta())
+    ++numInputs;
+
+  // DPS inits: output, present_state (always 2)
+  return MutableOperandRange(*this, /*start=*/numInputs, /*length=*/2);
+}
+
+void LinearAttentionOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  emitDpsMemoryEffects(getDpsInputOperands(), getDpsInitsMutable(), effects);
+}
+
+//===----------------------------------------------------------------------===//
+// GqaOp: ins(query, [key, value, past_key, past_value,]
+//             seqlens_k, total_seq_len, [cos_cache, ...])
 //        outs(output, present_key, present_value, [output_qk])
 //===----------------------------------------------------------------------===//
 

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -228,6 +228,7 @@ if(NOT BUILD_MOCK_RUNTIME)
     compile_to_bitcode(real/qmoe.cpp runtime_qmoe.bc)
     compile_to_bitcode(real/test_hip_from_dll.cpp test_hip_from_dll.bc)
     compile_to_bitcode(real/gemm.cpp runtime_gemm.bc)
+    compile_to_bitcode(real/linear_attention.cpp runtime_linear_attention.bc)
 
     set(RUNTIME_BC_MODULES
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_state.bc
@@ -250,6 +251,7 @@ if(NOT BUILD_MOCK_RUNTIME)
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_qmoe.bc
         ${CMAKE_CURRENT_BINARY_DIR}/test_hip_from_dll.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_gemm.bc
+        ${CMAKE_CURRENT_BINARY_DIR}/runtime_linear_attention.bc
     )
 else()
     # Mock runtime for testing without GPU

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -572,19 +572,18 @@ int wrap_qmoe(
 // Optional pointer args: pass nullptr if the corresponding input is absent.
 int wrap_linear_attention(
     RuntimeState *state,
-    const void *query,       // [B, T, H_q * d_k]
-    const void *key,         // [B, T, H_kv * d_k]
-    const void *value,       // [B, T, H_kv * d_v]
-    const void *past_state,  // [B, H_kv, d_k, d_v] (nullable)
-    const void *decay,       // [B, T, H_kv * d_k] or [B, T, H_kv] (nullable)
-    const void *beta,        // [B, T, H_kv] or [B, T, 1] (nullable)
-    void *output,            // [B, T, H_q * d_v]
-    void *present_state,     // [B, H_kv, d_k, d_v]
-    int64_t q_num_heads, int64_t kv_num_heads, float scale,
-    int64_t chunk_size,
-    int64_t update_rule,     // 0=linear, 1=gated, 2=delta, 3=gated_delta
-    int64_t batch_size, int64_t seq_len, int64_t head_dim_k,
-    int64_t head_dim_v, int64_t element_size_bytes);
+    const void *query,      // [B, T, H_q * d_k]
+    const void *key,        // [B, T, H_kv * d_k]
+    const void *value,      // [B, T, H_kv * d_v]
+    const void *past_state, // [B, H_kv, d_k, d_v] (nullable)
+    const void *decay,      // [B, T, H_kv * d_k] or [B, T, H_kv] (nullable)
+    const void *beta,       // [B, T, H_kv] or [B, T, 1] (nullable)
+    void *output,           // [B, T, H_q * d_v]
+    void *present_state,    // [B, H_kv, d_k, d_v]
+    int64_t q_num_heads, int64_t kv_num_heads, float scale, int64_t chunk_size,
+    int64_t update_rule, // 0=linear, 1=gated, 2=delta, 3=gated_delta
+    int64_t batch_size, int64_t seq_len, int64_t head_dim_k, int64_t head_dim_v,
+    int64_t element_size_bytes);
 
 //==============================================================================
 // ONNX Gemm via hipBLASLt

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -588,7 +588,8 @@ int wrap_qmoe(
 //   decay_per_key_dim = 1  -> decay is [B, T, H_kv * d_k] (GLA / RWKV-6)
 //                     = 0  -> decay is [B, T, H_kv]       (DeltaNet / RetNet)
 //   beta_per_head     = 1  -> beta  is [B, T, H_kv]
-//                     = 0  -> beta  is [B, T, 1]          (broadcast over heads)
+//                     = 0  -> beta  is [B, T, 1]          (broadcast over
+//                     heads)
 int wrap_linear_attention(
     RuntimeState *state,
     const void *query,      // [B, T, Hq * dk]
@@ -599,9 +600,8 @@ int wrap_linear_attention(
     const void *beta,       // [B, T, H_kv] or [B, T, 1] (nullable)
     void *output,           // [B, T, max(H_q, H_kv) * d_v]
     void *present_state,    // [B, H_kv, d_k, d_v]
-    int64_t Hq, int64_t Hkv, int64_t Nk,
-    int64_t decay_per_key_dim, int64_t beta_per_head,
-    float scale, int64_t chunk_size,
+    int64_t Hq, int64_t Hkv, int64_t Nk, int64_t decay_per_key_dim,
+    int64_t beta_per_head, float scale, int64_t chunk_size,
     int64_t update_rule, // 0=linear, 1=gated, 2=delta, 3=gated_delta
     int64_t B, int64_t seq_len, int64_t dk, int64_t dv, int64_t type);
 

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -569,18 +569,29 @@ int wrap_qmoe(
 // gated_delta(3).
 // All tensor inputs use packed 3D format [B, T, H*D] except past/present
 // state which is 4D [B, H_kv, d_k, d_v].
+// Head counts are three-way:
+//   - q_num_heads  (H_q) : query heads
+//   - kv_num_heads (H_kv): KV state heads
+//   - n_k_heads    (n_k) : number of key heads in the packed key tensor;
+//                          n_k divides H_kv (multiple KV heads may share a K
+//                          head when n_k < H_kv).
+// Supports both standard GQA (H_q >= H_kv, H_q % H_kv == 0) and inverse GQA
+// (H_q <  H_kv, H_kv % H_q == 0).  The output tensor's last dim is
+// max(H_q, H_kv) * d_v, packed in Q-head order for standard GQA and KV-head
+// order for inverse GQA.
 // Optional pointer args: pass nullptr if the corresponding input is absent.
 int wrap_linear_attention(
     RuntimeState *state,
     const void *query,      // [B, T, H_q * d_k]
-    const void *key,        // [B, T, H_kv * d_k]
+    const void *key,        // [B, T, n_k * d_k]
     const void *value,      // [B, T, H_kv * d_v]
     const void *past_state, // [B, H_kv, d_k, d_v] (nullable)
     const void *decay,      // [B, T, H_kv * d_k] or [B, T, H_kv] (nullable)
     const void *beta,       // [B, T, H_kv] or [B, T, 1] (nullable)
-    void *output,           // [B, T, H_q * d_v]
+    void *output,           // [B, T, max(H_q, H_kv) * d_v]
     void *present_state,    // [B, H_kv, d_k, d_v]
-    int64_t q_num_heads, int64_t kv_num_heads, float scale, int64_t chunk_size,
+    int64_t q_num_heads, int64_t kv_num_heads, int64_t n_k_heads, float scale,
+    int64_t chunk_size,
     int64_t update_rule, // 0=linear, 1=gated, 2=delta, 3=gated_delta
     int64_t batch_size, int64_t seq_len, int64_t head_dim_k, int64_t head_dim_v,
     int64_t element_size_bytes);

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -563,6 +563,34 @@ int wrap_qmoe(
 //==============================================================================
 // Y = alpha * op(A) * op(B) + beta * C
 // op(A) shape: [M, K], op(B) shape: [K, N], C optional broadcastable to [M, N]
+// LinearAttention operation wrapper (com.microsoft.LinearAttention)
+// Unified linear attention with recurrent state for autoregressive decoding
+// and prefill. Supports update rules: linear(0), gated(1), delta(2),
+// gated_delta(3).
+// All tensor inputs use packed 3D format [B, T, H*D] except past/present
+// state which is 4D [B, H_kv, d_k, d_v].
+// Optional pointer args: pass nullptr if the corresponding input is absent.
+int wrap_linear_attention(
+    RuntimeState *state,
+    const void *query,       // [B, T, H_q * d_k]
+    const void *key,         // [B, T, H_kv * d_k]
+    const void *value,       // [B, T, H_kv * d_v]
+    const void *past_state,  // [B, H_kv, d_k, d_v] (nullable)
+    const void *decay,       // [B, T, H_kv * d_k] or [B, T, H_kv] (nullable)
+    const void *beta,        // [B, T, H_kv] or [B, T, 1] (nullable)
+    void *output,            // [B, T, H_q * d_v]
+    void *present_state,     // [B, H_kv, d_k, d_v]
+    int64_t q_num_heads, int64_t kv_num_heads, float scale,
+    int64_t chunk_size,
+    int64_t update_rule,     // 0=linear, 1=gated, 2=delta, 3=gated_delta
+    int64_t batch_size, int64_t seq_len, int64_t head_dim_k,
+    int64_t head_dim_v, int64_t element_size_bytes);
+
+//==============================================================================
+// ONNX Gemm via hipBLASLt
+//==============================================================================
+// Y = alpha * op(A) * op(B) + beta * C
+// op(A) shape: [M, K], op(B) shape: [K, N], C optional broadcastable to [M, N]
 int wrap_gemm(RuntimeState *state, const void *A, const void *B, const void *C,
               void *output, int64_t M, int64_t N, int64_t K, float alpha,
               float beta, int64_t transA, int64_t transB, int64_t typeCode,

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -570,31 +570,40 @@ int wrap_qmoe(
 // All tensor inputs use packed 3D format [B, T, H*D] except past/present
 // state which is 4D [B, H_kv, d_k, d_v].
 // Head counts are three-way:
-//   - q_num_heads  (H_q) : query heads
-//   - kv_num_heads (H_kv): KV state heads
-//   - n_k_heads    (n_k) : number of key heads in the packed key tensor;
-//                          n_k divides H_kv (multiple KV heads may share a K
-//                          head when n_k < H_kv).
-// Supports both standard GQA (H_q >= H_kv, H_q % H_kv == 0) and inverse GQA
-// (H_q <  H_kv, H_kv % H_q == 0).  The output tensor's last dim is
-// max(H_q, H_kv) * d_v, packed in Q-head order for standard GQA and KV-head
-// order for inverse GQA.
+//   - Hq : query heads
+//   - Hkv: KV state heads
+//   - Nk : number of key heads in the packed key tensor (Nk divides H_kv when
+//          multiple KV heads share a K head; Nk < Hkv).
+// Supports both standard GQA (Hq >= Hkv, Hq % Hkv == 0) and inverse GQA
+// (Hq < Hkv, Hkv % Hq == 0).  The output tensor's last dim is max(Hq, Hkv)*d_v,
+// packed in Q-head order for standard GQA and KV-head order for inverse GQA.
 // Optional pointer args: pass nullptr if the corresponding input is absent.
+// Last arg `type` is HIPDNN_EP_DATATYPE_FLOAT (0), HIPDNN_EP_DATATYPE_HALF (1),
+// or HIPDNN_EP_DATATYPE_BFLOAT16 (2).
+//
+// decay_per_key_dim / beta_per_head describe the layout of the optional
+// decay / beta tensors so the runtime can pick the correct stride. Values
+// are ignored when the corresponding pointer is nullptr; compilers should
+// pass 0 in that case.
+//   decay_per_key_dim = 1  -> decay is [B, T, H_kv * d_k] (GLA / RWKV-6)
+//                     = 0  -> decay is [B, T, H_kv]       (DeltaNet / RetNet)
+//   beta_per_head     = 1  -> beta  is [B, T, H_kv]
+//                     = 0  -> beta  is [B, T, 1]          (broadcast over heads)
 int wrap_linear_attention(
     RuntimeState *state,
-    const void *query,      // [B, T, H_q * d_k]
-    const void *key,        // [B, T, n_k * d_k]
+    const void *query,      // [B, T, Hq * dk]
+    const void *key,        // [B, T, Nk * dk]
     const void *value,      // [B, T, H_kv * d_v]
     const void *past_state, // [B, H_kv, d_k, d_v] (nullable)
     const void *decay,      // [B, T, H_kv * d_k] or [B, T, H_kv] (nullable)
     const void *beta,       // [B, T, H_kv] or [B, T, 1] (nullable)
     void *output,           // [B, T, max(H_q, H_kv) * d_v]
     void *present_state,    // [B, H_kv, d_k, d_v]
-    int64_t q_num_heads, int64_t kv_num_heads, int64_t n_k_heads, float scale,
-    int64_t chunk_size,
+    int64_t Hq, int64_t Hkv, int64_t Nk,
+    int64_t decay_per_key_dim, int64_t beta_per_head,
+    float scale, int64_t chunk_size,
     int64_t update_rule, // 0=linear, 1=gated, 2=delta, 3=gated_delta
-    int64_t batch_size, int64_t seq_len, int64_t head_dim_k, int64_t head_dim_v,
-    int64_t element_size_bytes);
+    int64_t B, int64_t seq_len, int64_t dk, int64_t dv, int64_t type);
 
 //==============================================================================
 // ONNX Gemm via hipBLASLt

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -542,6 +542,56 @@ int wrap_group_query_attention(
   return 0;
 }
 
+int wrap_linear_attention(RuntimeState *state, const void *query,
+                          const void *key, const void *value,
+                          const void *past_state, const void *decay,
+                          const void *beta, void *output, void *present_state,
+                          int64_t q_num_heads, int64_t kv_num_heads,
+                          float scale, int64_t chunk_size, int64_t update_rule,
+                          int64_t batch_size, int64_t seq_len,
+                          int64_t head_dim_k, int64_t head_dim_v,
+                          int64_t element_size_bytes) {
+  if (!state || !query || !key || !value || !output || !present_state) {
+    fprintf(stderr, "Invalid required argument in wrap_linear_attention\n");
+    return -1;
+  }
+
+  // LinearAttention update_rule enum: 0=linear, 1=gated, 2=delta,
+  // 3=gated_delta. Kept inline here because it is op-specific and does not
+  // belong to the generic hipdnn_ep_* enum helpers.
+  const char *rule_name = "unknown";
+  switch (update_rule) {
+  case 0:
+    rule_name = "linear";
+    break;
+  case 1:
+    rule_name = "gated";
+    break;
+  case 2:
+    rule_name = "delta";
+    break;
+  case 3:
+    rule_name = "gated_delta";
+    break;
+  }
+
+  MOCK_PRINT("[MOCK] wrap_linear_attention(\n");
+  MOCK_PRINT("[MOCK]   batch=%lld, seq_len=%lld, d_k=%lld, d_v=%lld,\n",
+             (long long)batch_size, (long long)seq_len, (long long)head_dim_k,
+             (long long)head_dim_v);
+  MOCK_PRINT("[MOCK]   q_num_heads=%lld, kv_num_heads=%lld,\n",
+             (long long)q_num_heads, (long long)kv_num_heads);
+  MOCK_PRINT("[MOCK]   scale=%f, chunk_size=%lld, update_rule=%s(%lld),\n",
+             (double)scale, (long long)chunk_size, rule_name,
+             (long long)update_rule);
+  MOCK_PRINT("[MOCK]   elem_size=%lld,\n", (long long)element_size_bytes);
+  MOCK_PRINT("[MOCK]   past_state=%s, decay=%s, beta=%s)\n",
+             past_state ? "yes" : "null", decay ? "yes" : "null",
+             beta ? "yes" : "null");
+
+  return 0;
+}
+
 int wrap_miopenOpTensor(RuntimeState *state, void *lhs, void *rhs, void *output,
                         int64_t lhs_n, int64_t lhs_c, int64_t lhs_h,
                         int64_t lhs_w, int64_t rhs_n, int64_t rhs_c,

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -547,10 +547,10 @@ int wrap_linear_attention(RuntimeState *state, const void *query,
                           const void *past_state, const void *decay,
                           const void *beta, void *output, void *present_state,
                           int64_t q_num_heads, int64_t kv_num_heads,
-                          float scale, int64_t chunk_size, int64_t update_rule,
-                          int64_t batch_size, int64_t seq_len,
-                          int64_t head_dim_k, int64_t head_dim_v,
-                          int64_t element_size_bytes) {
+                          int64_t n_k_heads, float scale, int64_t chunk_size,
+                          int64_t update_rule, int64_t batch_size,
+                          int64_t seq_len, int64_t head_dim_k,
+                          int64_t head_dim_v, int64_t element_size_bytes) {
   if (!state || !query || !key || !value || !output || !present_state) {
     fprintf(stderr, "Invalid required argument in wrap_linear_attention\n");
     return -1;
@@ -579,8 +579,9 @@ int wrap_linear_attention(RuntimeState *state, const void *query,
   MOCK_PRINT("[MOCK]   batch=%lld, seq_len=%lld, d_k=%lld, d_v=%lld,\n",
              (long long)batch_size, (long long)seq_len, (long long)head_dim_k,
              (long long)head_dim_v);
-  MOCK_PRINT("[MOCK]   q_num_heads=%lld, kv_num_heads=%lld,\n",
-             (long long)q_num_heads, (long long)kv_num_heads);
+  MOCK_PRINT("[MOCK]   q_num_heads=%lld, kv_num_heads=%lld, n_k_heads=%lld,\n",
+             (long long)q_num_heads, (long long)kv_num_heads,
+             (long long)n_k_heads);
   MOCK_PRINT("[MOCK]   scale=%f, chunk_size=%lld, update_rule=%s(%lld),\n",
              (double)scale, (long long)chunk_size, rule_name,
              (long long)update_rule);

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -546,11 +546,11 @@ int wrap_linear_attention(RuntimeState *state, const void *query,
                           const void *key, const void *value,
                           const void *past_state, const void *decay,
                           const void *beta, void *output, void *present_state,
-                          int64_t q_num_heads, int64_t kv_num_heads,
-                          int64_t n_k_heads, float scale, int64_t chunk_size,
-                          int64_t update_rule, int64_t batch_size,
-                          int64_t seq_len, int64_t head_dim_k,
-                          int64_t head_dim_v, int64_t element_size_bytes) {
+                          int64_t Hq, int64_t Hkv, int64_t Nk,
+                          int64_t decay_per_key_dim, int64_t beta_per_head,
+                          float scale, int64_t chunk_size, int64_t update_rule,
+                          int64_t B, int64_t seq_len, int64_t dk, int64_t dv,
+                          int64_t type) {
   if (!state || !query || !key || !value || !output || !present_state) {
     fprintf(stderr, "Invalid required argument in wrap_linear_attention\n");
     return -1;
@@ -576,16 +576,16 @@ int wrap_linear_attention(RuntimeState *state, const void *query,
   }
 
   MOCK_PRINT("[MOCK] wrap_linear_attention(\n");
-  MOCK_PRINT("[MOCK]   batch=%lld, seq_len=%lld, d_k=%lld, d_v=%lld,\n",
-             (long long)batch_size, (long long)seq_len, (long long)head_dim_k,
-             (long long)head_dim_v);
-  MOCK_PRINT("[MOCK]   q_num_heads=%lld, kv_num_heads=%lld, n_k_heads=%lld,\n",
-             (long long)q_num_heads, (long long)kv_num_heads,
-             (long long)n_k_heads);
+  MOCK_PRINT("[MOCK]   B=%lld, seq_len=%lld, dk=%lld, dv=%lld,\n",
+             (long long)B, (long long)seq_len, (long long)dk, (long long)dv);
+  MOCK_PRINT("[MOCK]   Hq=%lld, Hkv=%lld, Nk=%lld,\n", (long long)Hq,
+             (long long)Hkv, (long long)Nk);
+  MOCK_PRINT("[MOCK]   decay_per_key_dim=%lld, beta_per_head=%lld,\n",
+             (long long)decay_per_key_dim, (long long)beta_per_head);
   MOCK_PRINT("[MOCK]   scale=%f, chunk_size=%lld, update_rule=%s(%lld),\n",
              (double)scale, (long long)chunk_size, rule_name,
              (long long)update_rule);
-  MOCK_PRINT("[MOCK]   elem_size=%lld,\n", (long long)element_size_bytes);
+  MOCK_PRINT("[MOCK]   type=%lld,\n", (long long)type);
   MOCK_PRINT("[MOCK]   past_state=%s, decay=%s, beta=%s)\n",
              past_state ? "yes" : "null", decay ? "yes" : "null",
              beta ? "yes" : "null");

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -576,8 +576,8 @@ int wrap_linear_attention(RuntimeState *state, const void *query,
   }
 
   MOCK_PRINT("[MOCK] wrap_linear_attention(\n");
-  MOCK_PRINT("[MOCK]   B=%lld, seq_len=%lld, dk=%lld, dv=%lld,\n",
-             (long long)B, (long long)seq_len, (long long)dk, (long long)dv);
+  MOCK_PRINT("[MOCK]   B=%lld, seq_len=%lld, dk=%lld, dv=%lld,\n", (long long)B,
+             (long long)seq_len, (long long)dk, (long long)dv);
   MOCK_PRINT("[MOCK]   Hq=%lld, Hkv=%lld, Nk=%lld,\n", (long long)Hq,
              (long long)Hkv, (long long)Nk);
   MOCK_PRINT("[MOCK]   decay_per_key_dim=%lld, beta_per_head=%lld,\n",

--- a/lib/Runtime/real/linear_attention.cpp
+++ b/lib/Runtime/real/linear_attention.cpp
@@ -37,10 +37,10 @@ extern "C" int wrap_linear_attention(
                     "q_heads=%lld kv_heads=%lld n_k=%lld d_k=%lld d_v=%lld "
                     "scale=%.6f chunk=%lld rule=%lld type=%s(%lld)\n",
                     (long long)B, (long long)seq_len, (long long)Hq,
-                    (long long)Hkv,
-                    (long long)Nk, (long long)dk, (long long)dv, (double)scale,
-                    (long long)chunk_size, (long long)update_rule,
-                    hipdnn_ep_datatype_name(type), (long long)type);
+                    (long long)Hkv, (long long)Nk, (long long)dk, (long long)dv,
+                    (double)scale, (long long)chunk_size,
+                    (long long)update_rule, hipdnn_ep_datatype_name(type),
+                    (long long)type);
 
   RUNTIME_DEBUG_LOG("[linear_attention] layout: decay_per_key_dim=%lld "
                     "beta_per_head=%lld\n",
@@ -117,7 +117,8 @@ extern "C" int wrap_linear_attention(
     return -1;
   }
 
-  // Auto-compute scale if sentinel zero
+  // When 0.0 (default), derives d_k = query.shape[-1] / q_num_heads and uses
+  // 1/sqrt(d_k). Set explicitly to override.
   if (scale == 0.0f && dk > 0)
     scale = 1.0f / sqrtf((float)dk);
 
@@ -149,14 +150,13 @@ extern "C" int wrap_linear_attention(
   //   value  : Hkv * dv      output : Hout * dv (Hout = max(Hq, Hkv))
   //   decay_per_key_dim==1 -> Hkv * dk;   ==0 -> Hkv
   //   beta_per_head==1     -> Hkv;        ==0 -> 1
-  const int64_t q_token_bytes = Hq   * dk * elem_size;
-  const int64_t k_token_bytes = Nk   * dk * elem_size;
-  const int64_t v_token_bytes = Hkv  * dv * elem_size;
+  const int64_t q_token_bytes = Hq * dk * elem_size;
+  const int64_t k_token_bytes = Nk * dk * elem_size;
+  const int64_t v_token_bytes = Hkv * dv * elem_size;
   const int64_t o_token_bytes = Hout * dv * elem_size;
   const int64_t decay_token_bytes =
       (decay_per_key_dim ? Hkv * dk : Hkv) * elem_size;
-  const int64_t beta_token_bytes =
-      (beta_per_head ? Hkv : 1) * elem_size;
+  const int64_t beta_token_bytes = (beta_per_head ? Hkv : 1) * elem_size;
 
   RUNTIME_DEBUG_LOG(
       "[linear_attention] dispatching %lld token(s) via per-step decode "
@@ -169,20 +169,20 @@ extern "C" int wrap_linear_attention(
   // through so the kernel can select the appropriate access pattern.
   for (int64_t t = 0; t < seq_len; ++t) {
     const void *q_t = (const char *)query + t * q_token_bytes;
-    const void *k_t = (const char *)key   + t * k_token_bytes;
+    const void *k_t = (const char *)key + t * k_token_bytes;
     const void *v_t = (const char *)value + t * v_token_bytes;
     const void *decay_t =
         decay ? (const void *)((const char *)decay + t * decay_token_bytes)
               : nullptr;
     const void *beta_t =
-        beta  ? (const void *)((const char *)beta  + t * beta_token_bytes)
-              : nullptr;
+        beta ? (const void *)((const char *)beta + t * beta_token_bytes)
+             : nullptr;
     void *o_t = (char *)output + t * o_token_bytes;
 
     int kern_result = hip_linear_attention_decode(
-        hip_stream, q_t, k_t, v_t, decay_t, beta_t, present_state, o_t,
-        B, seq_len, Hq, Hkv, Nk, dk, dv, scale, update_rule,
-        decay_per_key_dim, beta_per_head, type);
+        hip_stream, q_t, k_t, v_t, decay_t, beta_t, present_state, o_t, B,
+        seq_len, Hq, Hkv, Nk, dk, dv, scale, update_rule, decay_per_key_dim,
+        beta_per_head, type);
     if (kern_result != 0) {
       fprintf(stderr,
               "[linear_attention] ERROR: decode kernel failed at t=%lld "
@@ -193,8 +193,8 @@ extern "C" int wrap_linear_attention(
     }
   }
 
-  RUNTIME_DEBUG_LOG(
-      "[linear_attention] completed %lld token(s)\n", (long long)seq_len);
+  RUNTIME_DEBUG_LOG("[linear_attention] completed %lld token(s)\n",
+                    (long long)seq_len);
 
 cleanup:
   RUNTIME_DEBUG_LOG("[linear_attention] exit result=%d\n", result);

--- a/lib/Runtime/real/linear_attention.cpp
+++ b/lib/Runtime/real/linear_attention.cpp
@@ -108,6 +108,7 @@ extern "C" int wrap_linear_attention(
 
   // Dimension aliases
   const int64_t B = batch_size;
+  const int64_t Hq = q_num_heads;
   const int64_t Hkv = kv_num_heads;
   const int64_t dk = head_dim_k;
   const int64_t dv = head_dim_v;
@@ -117,6 +118,10 @@ extern "C" int wrap_linear_attention(
   int64_t total_state_bytes = B * Hkv * state_bytes;
 
   int result = 0;
+
+  // Temp buffers for T>1 token-by-token processing (nullptr when T=1)
+  void *q_t = nullptr, *k_t = nullptr, *v_t = nullptr, *o_t = nullptr;
+  void *decay_t = nullptr, *beta_t = nullptr;
 
   // Initialize present_state from past_state (or zeros)
   if (past_state) {
@@ -139,16 +144,96 @@ extern "C" int wrap_linear_attention(
     }
     RUNTIME_DEBUG_LOG("[linear_attention] T=1 decode kernel dispatched\n");
   } else {
-    // TODO: T>1 prefill via chunk-parallel WY decomposition.
-    fprintf(stderr,
-            "[linear_attention] ERROR: seq_len=%lld not yet supported "
-            "(only T=1 decode is implemented)\n",
-            (long long)seq_len);
-    result = -1;
-    goto cleanup;
+    // T>1 prefill: loop over tokens, reusing the T=1 decode kernel.
+    // Each iteration extracts one token from the packed [B,T,H*D] inputs,
+    // runs one recurrence step (updating present_state in-place), and
+    // writes the output back to the correct position. Correct but O(T)
+    // kernel launches; a chunk-parallel WY kernel would be faster.
+    const int64_t q_token_bytes = Hq * dk * element_size_bytes;
+    const int64_t k_token_bytes = Hkv * dk * element_size_bytes;
+    const int64_t v_token_bytes = Hkv * dv * element_size_bytes;
+    const int64_t o_token_bytes = Hq * dv * element_size_bytes;
+    const int64_t decay_token_bytes = Hkv * dk * element_size_bytes;
+    const int64_t beta_token_bytes = Hkv * element_size_bytes;
+
+    HIP_CHECK(hipMalloc(&q_t, B * q_token_bytes));
+    HIP_CHECK(hipMalloc(&k_t, B * k_token_bytes));
+    HIP_CHECK(hipMalloc(&v_t, B * v_token_bytes));
+    HIP_CHECK(hipMalloc(&o_t, B * o_token_bytes));
+    if (decay)
+      HIP_CHECK(hipMalloc(&decay_t, B * decay_token_bytes));
+    if (beta)
+      HIP_CHECK(hipMalloc(&beta_t, B * beta_token_bytes));
+
+    RUNTIME_DEBUG_LOG(
+        "[linear_attention] T>1 prefill: looping %lld tokens\n",
+        (long long)seq_len);
+
+    for (int64_t t = 0; t < seq_len; ++t) {
+      // Gather token t from packed [B,T,X] into contiguous [B,1,X].
+      // hipMemcpy2DAsync handles the stride between batches.
+      HIP_CHECK(hipMemcpy2DAsync(
+          q_t, q_token_bytes,
+          (const char *)query + t * q_token_bytes, seq_len * q_token_bytes,
+          q_token_bytes, B, hipMemcpyDeviceToDevice,
+          (hipStream_t)hip_stream));
+      HIP_CHECK(hipMemcpy2DAsync(
+          k_t, k_token_bytes,
+          (const char *)key + t * k_token_bytes, seq_len * k_token_bytes,
+          k_token_bytes, B, hipMemcpyDeviceToDevice,
+          (hipStream_t)hip_stream));
+      HIP_CHECK(hipMemcpy2DAsync(
+          v_t, v_token_bytes,
+          (const char *)value + t * v_token_bytes, seq_len * v_token_bytes,
+          v_token_bytes, B, hipMemcpyDeviceToDevice,
+          (hipStream_t)hip_stream));
+      if (decay) {
+        HIP_CHECK(hipMemcpy2DAsync(
+            decay_t, decay_token_bytes,
+            (const char *)decay + t * decay_token_bytes,
+            seq_len * decay_token_bytes, decay_token_bytes, B,
+            hipMemcpyDeviceToDevice, (hipStream_t)hip_stream));
+      }
+      if (beta) {
+        HIP_CHECK(hipMemcpy2DAsync(
+            beta_t, beta_token_bytes,
+            (const char *)beta + t * beta_token_bytes,
+            seq_len * beta_token_bytes, beta_token_bytes, B,
+            hipMemcpyDeviceToDevice, (hipStream_t)hip_stream));
+      }
+
+      int kern_result = hip_linear_attention_decode(
+          hip_stream, q_t, k_t, v_t, decay_t, beta_t, present_state, o_t,
+          B, q_num_heads, Hkv, dk, dv, scale, update_rule,
+          element_size_bytes);
+      if (kern_result != 0) {
+        fprintf(stderr,
+                "[linear_attention] ERROR: decode kernel failed at t=%lld "
+                "(%d)\n",
+                (long long)t, kern_result);
+        result = -1;
+        goto cleanup;
+      }
+
+      // Scatter output token back into packed [B,T,X] output buffer.
+      HIP_CHECK(hipMemcpy2DAsync(
+          (char *)output + t * o_token_bytes, seq_len * o_token_bytes, o_t,
+          o_token_bytes, o_token_bytes, B, hipMemcpyDeviceToDevice,
+          (hipStream_t)hip_stream));
+    }
+
+    RUNTIME_DEBUG_LOG(
+        "[linear_attention] T>1 prefill completed (%lld tokens)\n",
+        (long long)seq_len);
   }
 
 cleanup:
+  hipFree(q_t);
+  hipFree(k_t);
+  hipFree(v_t);
+  hipFree(o_t);
+  hipFree(decay_t);
+  hipFree(beta_t);
   RUNTIME_DEBUG_LOG("[linear_attention] exit result=%d\n", result);
   return result;
 }

--- a/lib/Runtime/real/linear_attention.cpp
+++ b/lib/Runtime/real/linear_attention.cpp
@@ -6,6 +6,7 @@
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
 #include "error_check_macros.h"
+#include "hip_custom_kernels.h"
 #include "runtime_types.h"
 
 #include <algorithm>
@@ -131,24 +132,27 @@ extern "C" int wrap_linear_attention(
                        (hipStream_t)hip_stream));
   }
 
-  // TODO: Implement the full linear attention recurrence kernel.
-  //
-  // The recurrence for each token t (per batch b, per KV head g):
-  //   "linear":       S = S + k_t outer v_t
-  //   "gated":        S = exp(g_t) * S + k_t outer v_t
-  //   "delta":        S = S + beta_t * k_t outer (v_t - S^T k_t)
-  //   "gated_delta":  S = exp(g_t) * S + beta_t * k_t outer (v_t - exp(g_t) * S^T k_t)
-  //   o_t = scale * q_t^T S    (for each query head h mapped to this KV group)
-  //
-  // For T=1 (decode): sequential recurrence is efficient.
-  // For T>1 (prefill): chunk-parallel WY decomposition is preferred.
-  //
-  // Current implementation: initialize state, placeholder for kernel dispatch.
-  // Full GPU kernel integration is pending custom_kernels library extension.
-
-  RUNTIME_DEBUG_LOG("[linear_attention] state initialized (%s), "
-                    "kernel dispatch pending\n",
-                    past_state ? "from past" : "zeros");
+  if (seq_len == 1) {
+    int kern_result = hip_linear_attention_decode(
+        hip_stream, query, key, value, decay, beta, present_state, output, B,
+        q_num_heads, Hkv, dk, dv, scale, update_rule, element_size_bytes);
+    if (kern_result != 0) {
+      fprintf(stderr,
+              "[linear_attention] ERROR: decode kernel failed (%d)\n",
+              kern_result);
+      result = -1;
+      goto cleanup;
+    }
+    RUNTIME_DEBUG_LOG("[linear_attention] T=1 decode kernel dispatched\n");
+  } else {
+    // TODO: T>1 prefill via chunk-parallel WY decomposition.
+    fprintf(stderr,
+            "[linear_attention] ERROR: seq_len=%lld not yet supported "
+            "(only T=1 decode is implemented)\n",
+            (long long)seq_len);
+    result = -1;
+    goto cleanup;
+  }
 
 cleanup:
   RUNTIME_DEBUG_LOG("[linear_attention] exit result=%d\n", result);

--- a/lib/Runtime/real/linear_attention.cpp
+++ b/lib/Runtime/real/linear_attention.cpp
@@ -25,21 +25,6 @@ static constexpr int64_t kUpdateRuleGated = 1;
 static constexpr int64_t kUpdateRuleDelta = 2;
 static constexpr int64_t kUpdateRuleGatedDelta = 3;
 
-static const char *updateRuleName(int64_t rule) {
-  switch (rule) {
-  case kUpdateRuleLinear:
-    return "linear";
-  case kUpdateRuleGated:
-    return "gated";
-  case kUpdateRuleDelta:
-    return "delta";
-  case kUpdateRuleGatedDelta:
-    return "gated_delta";
-  default:
-    return "unknown";
-  }
-}
-
 extern "C" int wrap_linear_attention(
     RuntimeState *state, const void *query, const void *key, const void *value,
     const void *past_state, const void *decay, const void *beta, void *output,
@@ -50,11 +35,11 @@ extern "C" int wrap_linear_attention(
 
   RUNTIME_DEBUG_LOG("[linear_attention] enter: B=%lld seq_len=%lld "
                     "q_heads=%lld kv_heads=%lld n_k=%lld d_k=%lld d_v=%lld "
-                    "scale=%.6f chunk=%lld rule=%s type=%s(%lld)\n",
+                    "scale=%.6f chunk=%lld rule=%lld type=%s(%lld)\n",
                     (long long)B, (long long)seq_len, (long long)Hq,
                     (long long)Hkv,
                     (long long)Nk, (long long)dk, (long long)dv, (double)scale,
-                    (long long)chunk_size, updateRuleName(update_rule),
+                    (long long)chunk_size, (long long)update_rule,
                     hipdnn_ep_datatype_name(type), (long long)type);
 
   RUNTIME_DEBUG_LOG("[linear_attention] layout: decay_per_key_dim=%lld "
@@ -97,15 +82,17 @@ extern "C" int wrap_linear_attention(
   if ((update_rule == kUpdateRuleGated ||
        update_rule == kUpdateRuleGatedDelta) &&
       !decay) {
-    fprintf(stderr, "[linear_attention] ERROR: decay is required for %s mode\n",
-            updateRuleName(update_rule));
+    fprintf(stderr,
+            "[linear_attention] ERROR: decay is required for rule=%lld\n",
+            (long long)update_rule);
     return -1;
   }
   if ((update_rule == kUpdateRuleDelta ||
        update_rule == kUpdateRuleGatedDelta) &&
       !beta) {
-    fprintf(stderr, "[linear_attention] ERROR: beta is required for %s mode\n",
-            updateRuleName(update_rule));
+    fprintf(stderr,
+            "[linear_attention] ERROR: beta is required for rule=%lld\n",
+            (long long)update_rule);
     return -1;
   }
 

--- a/lib/Runtime/real/linear_attention.cpp
+++ b/lib/Runtime/real/linear_attention.cpp
@@ -43,17 +43,18 @@ static const char *updateRuleName(int64_t rule) {
 extern "C" int wrap_linear_attention(
     RuntimeState *state, const void *query, const void *key, const void *value,
     const void *past_state, const void *decay, const void *beta, void *output,
-    void *present_state, int64_t q_num_heads, int64_t kv_num_heads, float scale,
-    int64_t chunk_size, int64_t update_rule, int64_t batch_size,
-    int64_t seq_len, int64_t head_dim_k, int64_t head_dim_v,
+    void *present_state, int64_t q_num_heads, int64_t kv_num_heads,
+    int64_t n_k_heads, float scale, int64_t chunk_size, int64_t update_rule,
+    int64_t batch_size, int64_t seq_len, int64_t head_dim_k, int64_t head_dim_v,
     int64_t element_size_bytes) {
 
   RUNTIME_DEBUG_LOG("[linear_attention] enter: B=%lld T=%lld "
-                    "q_heads=%lld kv_heads=%lld d_k=%lld d_v=%lld "
+                    "q_heads=%lld kv_heads=%lld n_k=%lld d_k=%lld d_v=%lld "
                     "scale=%.6f chunk=%lld rule=%s elem_size=%lld\n",
                     (long long)batch_size, (long long)seq_len,
                     (long long)q_num_heads, (long long)kv_num_heads,
-                    (long long)head_dim_k, (long long)head_dim_v, (double)scale,
+                    (long long)n_k_heads, (long long)head_dim_k,
+                    (long long)head_dim_v, (double)scale,
                     (long long)chunk_size, updateRuleName(update_rule),
                     (long long)element_size_bytes);
 
@@ -110,6 +111,10 @@ extern "C" int wrap_linear_attention(
   const int64_t B = batch_size;
   const int64_t Hq = q_num_heads;
   const int64_t Hkv = kv_num_heads;
+  const int64_t Nk = n_k_heads;
+  // Output head count = max(Hq, Hkv).  In standard GQA (Hq >= Hkv) the output
+  // is packed in Q-head order; in inverse GQA it is packed in KV-head order.
+  const int64_t Hout = Hq >= Hkv ? Hq : Hkv;
   const int64_t dk = head_dim_k;
   const int64_t dv = head_dim_v;
 
@@ -135,7 +140,7 @@ extern "C" int wrap_linear_attention(
   if (seq_len == 1) {
     int kern_result = hip_linear_attention_decode(
         hip_stream, query, key, value, decay, beta, present_state, output, B,
-        q_num_heads, Hkv, dk, dv, scale, update_rule, element_size_bytes);
+        Hq, Hkv, Nk, dk, dv, scale, update_rule, element_size_bytes);
     if (kern_result != 0) {
       fprintf(stderr, "[linear_attention] ERROR: decode kernel failed (%d)\n",
               kern_result);
@@ -149,10 +154,14 @@ extern "C" int wrap_linear_attention(
     // runs one recurrence step (updating present_state in-place), and
     // writes the output back to the correct position. Correct but O(T)
     // kernel launches; a chunk-parallel WY kernel would be faster.
-    const int64_t q_token_bytes = Hq * dk * element_size_bytes;
-    const int64_t k_token_bytes = Hkv * dk * element_size_bytes;
-    const int64_t v_token_bytes = Hkv * dv * element_size_bytes;
-    const int64_t o_token_bytes = Hq * dv * element_size_bytes;
+    //
+    // Per-tensor hidden sizes:
+    //   query  : Hq  * dk      key    : Nk   * dk (may be < Hkv*dk)
+    //   value  : Hkv * dv      output : Hout * dv (Hout = max(Hq, Hkv))
+    const int64_t q_token_bytes = Hq   * dk * element_size_bytes;
+    const int64_t k_token_bytes = Nk   * dk * element_size_bytes;
+    const int64_t v_token_bytes = Hkv  * dv * element_size_bytes;
+    const int64_t o_token_bytes = Hout * dv * element_size_bytes;
     const int64_t decay_token_bytes = Hkv * dk * element_size_bytes;
     const int64_t beta_token_bytes = Hkv * element_size_bytes;
 
@@ -204,7 +213,7 @@ extern "C" int wrap_linear_attention(
 
       int kern_result = hip_linear_attention_decode(
           hip_stream, q_t, k_t, v_t, decay_t, beta_t, present_state, o_t,
-          B, q_num_heads, Hkv, dk, dv, scale, update_rule,
+          B, Hq, Hkv, Nk, dk, dv, scale, update_rule,
           element_size_bytes);
       if (kern_result != 0) {
         fprintf(stderr,

--- a/lib/Runtime/real/linear_attention.cpp
+++ b/lib/Runtime/real/linear_attention.cpp
@@ -156,11 +156,6 @@ extern "C" int wrap_linear_attention(
 
   int result = 0;
 
-  // Temp buffers for seq_len>1 token-by-token processing (nullptr when
-  // seq_len==1)
-  void *q_t = nullptr, *k_t = nullptr, *v_t = nullptr, *o_t = nullptr;
-  void *decay_t = nullptr, *beta_t = nullptr;
-
   // Initialize present_state from past_state (or zeros)
   if (past_state) {
     HIP_CHECK(hipMemcpyAsync(present_state, past_state, total_state_bytes,
@@ -170,120 +165,61 @@ extern "C" int wrap_linear_attention(
                              (hipStream_t)hip_stream));
   }
 
-  if (seq_len == 1) {
-    // TODO: How to do parallel decoding?
+  // Per-token stride (in bytes) for each packed [B, T, H*D] tensor. The
+  // kernel indexes into the packed layout directly using seq_len as the
+  // per-batch stride, so we only need to advance the base pointer by one
+  // token between iterations -- no intermediate gather/scatter buffers.
+  //
+  //   query  : Hq  * dk      key    : Nk   * dk (may be < Hkv*dk)
+  //   value  : Hkv * dv      output : Hout * dv (Hout = max(Hq, Hkv))
+  //   decay_per_key_dim==1 -> Hkv * dk;   ==0 -> Hkv  (rejected above)
+  //   beta_per_head==1     -> Hkv;        ==0 -> 1    (rejected above)
+  const int64_t q_token_bytes = Hq   * dk * elem_size;
+  const int64_t k_token_bytes = Nk   * dk * elem_size;
+  const int64_t v_token_bytes = Hkv  * dv * elem_size;
+  const int64_t o_token_bytes = Hout * dv * elem_size;
+  const int64_t decay_token_bytes =
+      (decay_per_key_dim ? Hkv * dk : Hkv) * elem_size;
+  const int64_t beta_token_bytes =
+      (beta_per_head ? Hkv : 1) * elem_size;
+
+  RUNTIME_DEBUG_LOG(
+      "[linear_attention] dispatching %lld token(s) via per-step decode "
+      "kernel\n",
+      (long long)seq_len);
+
+  // Unified path for decode (seq_len==1) and prefill (seq_len>1):
+  // advance the base pointers by t * token_bytes and let the kernel use
+  // seq_len as the per-batch stride.
+  for (int64_t t = 0; t < seq_len; ++t) {
+    const void *q_t = (const char *)query + t * q_token_bytes;
+    const void *k_t = (const char *)key   + t * k_token_bytes;
+    const void *v_t = (const char *)value + t * v_token_bytes;
+    const void *decay_t =
+        decay ? (const void *)((const char *)decay + t * decay_token_bytes)
+              : nullptr;
+    const void *beta_t =
+        beta  ? (const void *)((const char *)beta  + t * beta_token_bytes)
+              : nullptr;
+    void *o_t = (char *)output + t * o_token_bytes;
+
     int kern_result = hip_linear_attention_decode(
-        hip_stream, query, key, value, decay, beta, present_state, output, B,
-        Hq, Hkv, Nk, dk, dv, scale, update_rule, type);
+        hip_stream, q_t, k_t, v_t, decay_t, beta_t, present_state, o_t,
+        B, seq_len, Hq, Hkv, Nk, dk, dv, scale, update_rule, type);
     if (kern_result != 0) {
-      fprintf(stderr, "[linear_attention] ERROR: decode kernel failed (%d)\n",
-              kern_result);
+      fprintf(stderr,
+              "[linear_attention] ERROR: decode kernel failed at t=%lld "
+              "(%d)\n",
+              (long long)t, kern_result);
       result = -1;
       goto cleanup;
     }
-    RUNTIME_DEBUG_LOG(
-        "[linear_attention] seq_len==1 decode kernel dispatched\n");
-  } else {
-    // seq_len>1 prefill: loop over tokens, reusing the seq_len==1 decode kernel.
-    // Each iteration extracts one token from the packed [B,T,H*D] inputs,
-    // runs one recurrence step (updating present_state in-place), and
-    // writes the output back to the correct position. Correct but O(seq_len)
-    // kernel launches; a chunk-parallel WY kernel would be faster.
-    //
-    // Per-tensor hidden sizes:
-    //   query  : Hq  * dk      key    : Nk   * dk (may be < Hkv*dk)
-    //   value  : Hkv * dv      output : Hout * dv (Hout = max(Hq, Hkv))
-    const int64_t q_token_bytes = Hq   * dk * elem_size;
-    const int64_t k_token_bytes = Nk   * dk * elem_size;
-    const int64_t v_token_bytes = Hkv  * dv * elem_size;
-    const int64_t o_token_bytes = Hout * dv * elem_size;
-    // decay / beta stride per token depends on the logical layout:
-    //   decay_per_key_dim==1 -> [B, T, H_kv * d_k]
-    //   decay_per_key_dim==0 -> [B, T, H_kv]
-    //   beta_per_head==1     -> [B, T, H_kv]
-    //   beta_per_head==0     -> [B, T, 1]
-    const int64_t decay_token_bytes =
-        (decay_per_key_dim ? Hkv * dk : Hkv) * elem_size;
-    const int64_t beta_token_bytes =
-        (beta_per_head ? Hkv : 1) * elem_size;
-
-    HIP_CHECK(hipMalloc(&q_t, B * q_token_bytes));
-    HIP_CHECK(hipMalloc(&k_t, B * k_token_bytes));
-    HIP_CHECK(hipMalloc(&v_t, B * v_token_bytes));
-    HIP_CHECK(hipMalloc(&o_t, B * o_token_bytes));
-    if (decay)
-      HIP_CHECK(hipMalloc(&decay_t, B * decay_token_bytes));
-    if (beta)
-      HIP_CHECK(hipMalloc(&beta_t, B * beta_token_bytes));
-
-    RUNTIME_DEBUG_LOG(
-        "[linear_attention] seq_len>1 prefill: looping %lld tokens\n",
-        (long long)seq_len);
-
-    for (int64_t t = 0; t < seq_len; ++t) {
-      // Gather token t from packed [B,T,X] into contiguous [B,1,X].
-      // hipMemcpy2DAsync handles the stride between batches.
-      HIP_CHECK(hipMemcpy2DAsync(
-          q_t, q_token_bytes,
-          (const char *)query + t * q_token_bytes, seq_len * q_token_bytes,
-          q_token_bytes, B, hipMemcpyDeviceToDevice,
-          (hipStream_t)hip_stream));
-      HIP_CHECK(hipMemcpy2DAsync(
-          k_t, k_token_bytes,
-          (const char *)key + t * k_token_bytes, seq_len * k_token_bytes,
-          k_token_bytes, B, hipMemcpyDeviceToDevice,
-          (hipStream_t)hip_stream));
-      HIP_CHECK(hipMemcpy2DAsync(
-          v_t, v_token_bytes,
-          (const char *)value + t * v_token_bytes, seq_len * v_token_bytes,
-          v_token_bytes, B, hipMemcpyDeviceToDevice,
-          (hipStream_t)hip_stream));
-      if (decay) {
-        HIP_CHECK(hipMemcpy2DAsync(
-            decay_t, decay_token_bytes,
-            (const char *)decay + t * decay_token_bytes,
-            seq_len * decay_token_bytes, decay_token_bytes, B,
-            hipMemcpyDeviceToDevice, (hipStream_t)hip_stream));
-      }
-      if (beta) {
-        HIP_CHECK(hipMemcpy2DAsync(
-            beta_t, beta_token_bytes,
-            (const char *)beta + t * beta_token_bytes,
-            seq_len * beta_token_bytes, beta_token_bytes, B,
-            hipMemcpyDeviceToDevice, (hipStream_t)hip_stream));
-      }
-
-      int kern_result = hip_linear_attention_decode(
-          hip_stream, q_t, k_t, v_t, decay_t, beta_t, present_state, o_t,
-          B, Hq, Hkv, Nk, dk, dv, scale, update_rule, type);
-      if (kern_result != 0) {
-        fprintf(stderr,
-                "[linear_attention] ERROR: decode kernel failed at t=%lld "
-                "(%d)\n",
-                (long long)t, kern_result);
-        result = -1;
-        goto cleanup;
-      }
-
-      // Scatter output token back into packed [B,T,X] output buffer.
-      HIP_CHECK(hipMemcpy2DAsync(
-          (char *)output + t * o_token_bytes, seq_len * o_token_bytes, o_t,
-          o_token_bytes, o_token_bytes, B, hipMemcpyDeviceToDevice,
-          (hipStream_t)hip_stream));
-    }
-
-    RUNTIME_DEBUG_LOG(
-        "[linear_attention] seq_len>1 prefill completed (%lld tokens)\n",
-        (long long)seq_len);
   }
 
+  RUNTIME_DEBUG_LOG(
+      "[linear_attention] completed %lld token(s)\n", (long long)seq_len);
+
 cleanup:
-  hipFree(q_t);
-  hipFree(k_t);
-  hipFree(v_t);
-  hipFree(o_t);
-  hipFree(decay_t);
-  hipFree(beta_t);
   RUNTIME_DEBUG_LOG("[linear_attention] exit result=%d\n", result);
   return result;
 }

--- a/lib/Runtime/real/linear_attention.cpp
+++ b/lib/Runtime/real/linear_attention.cpp
@@ -109,24 +109,12 @@ extern "C" int wrap_linear_attention(
     return -1;
   }
 
-  // The current HIP decode kernel only supports the per-key-dim decay layout
-  // ([B, T, H_kv * d_k]) and the per-head beta layout ([B, T, H_kv]). Flag
-  // other combinations explicitly instead of silently mis-striding.
-  if (decay && !decay_per_key_dim) {
-    fprintf(stderr,
-            "[linear_attention] ERROR: decay layout [B, T, H_kv] is not yet "
-            "supported (kernel expects [B, T, H_kv * d_k]); "
-            "decay_per_key_dim=%lld\n",
-            (long long)decay_per_key_dim);
-    return -1;
-  }
-  if (beta && !beta_per_head) {
-    fprintf(stderr,
-            "[linear_attention] ERROR: beta layout [B, T, 1] is not yet "
-            "supported (kernel expects [B, T, H_kv]); beta_per_head=%lld\n",
-            (long long)beta_per_head);
-    return -1;
-  }
+  // The HIP decode kernel supports all four decay/beta layout combinations:
+  //   decay_per_key_dim=1 -> [B, T, H_kv * d_k]
+  //   decay_per_key_dim=0 -> [B, T, H_kv]        (broadcast across d_k)
+  //   beta_per_head=1     -> [B, T, H_kv]
+  //   beta_per_head=0     -> [B, T, 1]           (broadcast across H_kv)
+  // The flags are forwarded to hip_linear_attention_decode below.
 
   void *hip_stream = hipdnn_ep_state_get_stream(state);
   if (!hip_stream) {
@@ -172,8 +160,8 @@ extern "C" int wrap_linear_attention(
   //
   //   query  : Hq  * dk      key    : Nk   * dk (may be < Hkv*dk)
   //   value  : Hkv * dv      output : Hout * dv (Hout = max(Hq, Hkv))
-  //   decay_per_key_dim==1 -> Hkv * dk;   ==0 -> Hkv  (rejected above)
-  //   beta_per_head==1     -> Hkv;        ==0 -> 1    (rejected above)
+  //   decay_per_key_dim==1 -> Hkv * dk;   ==0 -> Hkv
+  //   beta_per_head==1     -> Hkv;        ==0 -> 1
   const int64_t q_token_bytes = Hq   * dk * elem_size;
   const int64_t k_token_bytes = Nk   * dk * elem_size;
   const int64_t v_token_bytes = Hkv  * dv * elem_size;
@@ -190,7 +178,8 @@ extern "C" int wrap_linear_attention(
 
   // Unified path for decode (seq_len==1) and prefill (seq_len>1):
   // advance the base pointers by t * token_bytes and let the kernel use
-  // seq_len as the per-batch stride.
+  // seq_len as the per-batch stride. decay/beta layout flags are passed
+  // through so the kernel can select the appropriate access pattern.
   for (int64_t t = 0; t < seq_len; ++t) {
     const void *q_t = (const char *)query + t * q_token_bytes;
     const void *k_t = (const char *)key   + t * k_token_bytes;
@@ -205,7 +194,8 @@ extern "C" int wrap_linear_attention(
 
     int kern_result = hip_linear_attention_decode(
         hip_stream, q_t, k_t, v_t, decay_t, beta_t, present_state, o_t,
-        B, seq_len, Hq, Hkv, Nk, dk, dv, scale, update_rule, type);
+        B, seq_len, Hq, Hkv, Nk, dk, dv, scale, update_rule,
+        decay_per_key_dim, beta_per_head, type);
     if (kern_result != 0) {
       fprintf(stderr,
               "[linear_attention] ERROR: decode kernel failed at t=%lld "

--- a/lib/Runtime/real/linear_attention.cpp
+++ b/lib/Runtime/real/linear_attention.cpp
@@ -43,26 +43,46 @@ static const char *updateRuleName(int64_t rule) {
 extern "C" int wrap_linear_attention(
     RuntimeState *state, const void *query, const void *key, const void *value,
     const void *past_state, const void *decay, const void *beta, void *output,
-    void *present_state, int64_t q_num_heads, int64_t kv_num_heads,
-    int64_t n_k_heads, float scale, int64_t chunk_size, int64_t update_rule,
-    int64_t batch_size, int64_t seq_len, int64_t head_dim_k, int64_t head_dim_v,
-    int64_t element_size_bytes) {
+    void *present_state, int64_t Hq, int64_t Hkv, int64_t Nk,
+    int64_t decay_per_key_dim, int64_t beta_per_head, float scale,
+    int64_t chunk_size, int64_t update_rule, int64_t B, int64_t seq_len,
+    int64_t dk, int64_t dv, int64_t type) {
 
-  RUNTIME_DEBUG_LOG("[linear_attention] enter: B=%lld T=%lld "
+  RUNTIME_DEBUG_LOG("[linear_attention] enter: B=%lld seq_len=%lld "
                     "q_heads=%lld kv_heads=%lld n_k=%lld d_k=%lld d_v=%lld "
-                    "scale=%.6f chunk=%lld rule=%s elem_size=%lld\n",
-                    (long long)batch_size, (long long)seq_len,
-                    (long long)q_num_heads, (long long)kv_num_heads,
-                    (long long)n_k_heads, (long long)head_dim_k,
-                    (long long)head_dim_v, (double)scale,
+                    "scale=%.6f chunk=%lld rule=%s type=%s(%lld)\n",
+                    (long long)B, (long long)seq_len, (long long)Hq,
+                    (long long)Hkv,
+                    (long long)Nk, (long long)dk, (long long)dv, (double)scale,
                     (long long)chunk_size, updateRuleName(update_rule),
-                    (long long)element_size_bytes);
+                    hipdnn_ep_datatype_name(type), (long long)type);
+
+  RUNTIME_DEBUG_LOG("[linear_attention] layout: decay_per_key_dim=%lld "
+                    "beta_per_head=%lld\n",
+                    (long long)decay_per_key_dim, (long long)beta_per_head);
 
   RUNTIME_DEBUG_LOG("[linear_attention] ptrs: query=%p key=%p value=%p "
                     "past_state=%p decay=%p beta=%p output=%p "
                     "present_state=%p\n",
                     query, key, value, past_state, decay, beta, output,
                     present_state);
+
+  if (type != HIPDNN_EP_DATATYPE_FLOAT && type != HIPDNN_EP_DATATYPE_HALF &&
+      type != HIPDNN_EP_DATATYPE_BFLOAT16) {
+    fprintf(stderr,
+            "[linear_attention] ERROR: unsupported element type %lld "
+            "(expect HIPDNN_EP_DATATYPE_FLOAT/HALF/BFLOAT16)\n",
+            (long long)type);
+    return -1;
+  }
+
+  const int64_t elem_size = hipdnn_ep_datatype_size(type);
+  if (elem_size <= 0) {
+    fprintf(stderr,
+            "[linear_attention] ERROR: invalid elem_size from type %lld\n",
+            (long long)type);
+    return -1;
+  }
 
   // Validate required inputs
   if (!query || !key || !value || !output || !present_state) {
@@ -89,6 +109,25 @@ extern "C" int wrap_linear_attention(
     return -1;
   }
 
+  // The current HIP decode kernel only supports the per-key-dim decay layout
+  // ([B, T, H_kv * d_k]) and the per-head beta layout ([B, T, H_kv]). Flag
+  // other combinations explicitly instead of silently mis-striding.
+  if (decay && !decay_per_key_dim) {
+    fprintf(stderr,
+            "[linear_attention] ERROR: decay layout [B, T, H_kv] is not yet "
+            "supported (kernel expects [B, T, H_kv * d_k]); "
+            "decay_per_key_dim=%lld\n",
+            (long long)decay_per_key_dim);
+    return -1;
+  }
+  if (beta && !beta_per_head) {
+    fprintf(stderr,
+            "[linear_attention] ERROR: beta layout [B, T, 1] is not yet "
+            "supported (kernel expects [B, T, H_kv]); beta_per_head=%lld\n",
+            (long long)beta_per_head);
+    return -1;
+  }
+
   void *hip_stream = hipdnn_ep_state_get_stream(state);
   if (!hip_stream) {
     fprintf(stderr, "[linear_attention] ERROR: failed to get HIP stream\n");
@@ -104,27 +143,21 @@ extern "C" int wrap_linear_attention(
   }
 
   // Auto-compute scale if sentinel zero
-  if (scale == 0.0f && head_dim_k > 0)
-    scale = 1.0f / sqrtf((float)head_dim_k);
+  if (scale == 0.0f && dk > 0)
+    scale = 1.0f / sqrtf((float)dk);
 
-  // Dimension aliases
-  const int64_t B = batch_size;
-  const int64_t Hq = q_num_heads;
-  const int64_t Hkv = kv_num_heads;
-  const int64_t Nk = n_k_heads;
   // Output head count = max(Hq, Hkv).  In standard GQA (Hq >= Hkv) the output
   // is packed in Q-head order; in inverse GQA it is packed in KV-head order.
   const int64_t Hout = Hq >= Hkv ? Hq : Hkv;
-  const int64_t dk = head_dim_k;
-  const int64_t dv = head_dim_v;
 
   // State size per batch per head: dk * dv elements
-  const int64_t state_bytes = dk * dv * element_size_bytes;
+  const int64_t state_bytes = dk * dv * elem_size;
   int64_t total_state_bytes = B * Hkv * state_bytes;
 
   int result = 0;
 
-  // Temp buffers for T>1 token-by-token processing (nullptr when T=1)
+  // Temp buffers for seq_len>1 token-by-token processing (nullptr when
+  // seq_len==1)
   void *q_t = nullptr, *k_t = nullptr, *v_t = nullptr, *o_t = nullptr;
   void *decay_t = nullptr, *beta_t = nullptr;
 
@@ -138,32 +171,41 @@ extern "C" int wrap_linear_attention(
   }
 
   if (seq_len == 1) {
+    // TODO: How to do parallel decoding?
     int kern_result = hip_linear_attention_decode(
         hip_stream, query, key, value, decay, beta, present_state, output, B,
-        Hq, Hkv, Nk, dk, dv, scale, update_rule, element_size_bytes);
+        Hq, Hkv, Nk, dk, dv, scale, update_rule, type);
     if (kern_result != 0) {
       fprintf(stderr, "[linear_attention] ERROR: decode kernel failed (%d)\n",
               kern_result);
       result = -1;
       goto cleanup;
     }
-    RUNTIME_DEBUG_LOG("[linear_attention] T=1 decode kernel dispatched\n");
+    RUNTIME_DEBUG_LOG(
+        "[linear_attention] seq_len==1 decode kernel dispatched\n");
   } else {
-    // T>1 prefill: loop over tokens, reusing the T=1 decode kernel.
+    // seq_len>1 prefill: loop over tokens, reusing the seq_len==1 decode kernel.
     // Each iteration extracts one token from the packed [B,T,H*D] inputs,
     // runs one recurrence step (updating present_state in-place), and
-    // writes the output back to the correct position. Correct but O(T)
+    // writes the output back to the correct position. Correct but O(seq_len)
     // kernel launches; a chunk-parallel WY kernel would be faster.
     //
     // Per-tensor hidden sizes:
     //   query  : Hq  * dk      key    : Nk   * dk (may be < Hkv*dk)
     //   value  : Hkv * dv      output : Hout * dv (Hout = max(Hq, Hkv))
-    const int64_t q_token_bytes = Hq   * dk * element_size_bytes;
-    const int64_t k_token_bytes = Nk   * dk * element_size_bytes;
-    const int64_t v_token_bytes = Hkv  * dv * element_size_bytes;
-    const int64_t o_token_bytes = Hout * dv * element_size_bytes;
-    const int64_t decay_token_bytes = Hkv * dk * element_size_bytes;
-    const int64_t beta_token_bytes = Hkv * element_size_bytes;
+    const int64_t q_token_bytes = Hq   * dk * elem_size;
+    const int64_t k_token_bytes = Nk   * dk * elem_size;
+    const int64_t v_token_bytes = Hkv  * dv * elem_size;
+    const int64_t o_token_bytes = Hout * dv * elem_size;
+    // decay / beta stride per token depends on the logical layout:
+    //   decay_per_key_dim==1 -> [B, T, H_kv * d_k]
+    //   decay_per_key_dim==0 -> [B, T, H_kv]
+    //   beta_per_head==1     -> [B, T, H_kv]
+    //   beta_per_head==0     -> [B, T, 1]
+    const int64_t decay_token_bytes =
+        (decay_per_key_dim ? Hkv * dk : Hkv) * elem_size;
+    const int64_t beta_token_bytes =
+        (beta_per_head ? Hkv : 1) * elem_size;
 
     HIP_CHECK(hipMalloc(&q_t, B * q_token_bytes));
     HIP_CHECK(hipMalloc(&k_t, B * k_token_bytes));
@@ -175,7 +217,7 @@ extern "C" int wrap_linear_attention(
       HIP_CHECK(hipMalloc(&beta_t, B * beta_token_bytes));
 
     RUNTIME_DEBUG_LOG(
-        "[linear_attention] T>1 prefill: looping %lld tokens\n",
+        "[linear_attention] seq_len>1 prefill: looping %lld tokens\n",
         (long long)seq_len);
 
     for (int64_t t = 0; t < seq_len; ++t) {
@@ -213,8 +255,7 @@ extern "C" int wrap_linear_attention(
 
       int kern_result = hip_linear_attention_decode(
           hip_stream, q_t, k_t, v_t, decay_t, beta_t, present_state, o_t,
-          B, Hq, Hkv, Nk, dk, dv, scale, update_rule,
-          element_size_bytes);
+          B, Hq, Hkv, Nk, dk, dv, scale, update_rule, type);
       if (kern_result != 0) {
         fprintf(stderr,
                 "[linear_attention] ERROR: decode kernel failed at t=%lld "
@@ -232,7 +273,7 @@ extern "C" int wrap_linear_attention(
     }
 
     RUNTIME_DEBUG_LOG(
-        "[linear_attention] T>1 prefill completed (%lld tokens)\n",
+        "[linear_attention] seq_len>1 prefill completed (%lld tokens)\n",
         (long long)seq_len);
   }
 

--- a/lib/Runtime/real/linear_attention.cpp
+++ b/lib/Runtime/real/linear_attention.cpp
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "../debug_log.h"
+#include "../hipdnn_ep_runtime.h"
+#include "error_check_macros.h"
+#include "runtime_types.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+
+#define HIP_CHECK(cmd) HIP_CHECK_GOTO(cmd, cleanup)
+#define HIPBLAS_CHECK(cmd) HIPBLAS_CHECK_GOTO(cmd, cleanup)
+
+// Update rule enum values (must match compiler lowering in
+// LinearAttentionLowering.cpp)
+static constexpr int64_t kUpdateRuleLinear = 0;
+static constexpr int64_t kUpdateRuleGated = 1;
+static constexpr int64_t kUpdateRuleDelta = 2;
+static constexpr int64_t kUpdateRuleGatedDelta = 3;
+
+static const char *updateRuleName(int64_t rule) {
+  switch (rule) {
+  case kUpdateRuleLinear:
+    return "linear";
+  case kUpdateRuleGated:
+    return "gated";
+  case kUpdateRuleDelta:
+    return "delta";
+  case kUpdateRuleGatedDelta:
+    return "gated_delta";
+  default:
+    return "unknown";
+  }
+}
+
+extern "C" int wrap_linear_attention(
+    RuntimeState *state, const void *query, const void *key, const void *value,
+    const void *past_state, const void *decay, const void *beta, void *output,
+    void *present_state, int64_t q_num_heads, int64_t kv_num_heads,
+    float scale, int64_t chunk_size, int64_t update_rule, int64_t batch_size,
+    int64_t seq_len, int64_t head_dim_k, int64_t head_dim_v,
+    int64_t element_size_bytes) {
+
+  RUNTIME_DEBUG_LOG("[linear_attention] enter: B=%lld T=%lld "
+                    "q_heads=%lld kv_heads=%lld d_k=%lld d_v=%lld "
+                    "scale=%.6f chunk=%lld rule=%s elem_size=%lld\n",
+                    (long long)batch_size, (long long)seq_len,
+                    (long long)q_num_heads, (long long)kv_num_heads,
+                    (long long)head_dim_k, (long long)head_dim_v,
+                    (double)scale, (long long)chunk_size,
+                    updateRuleName(update_rule),
+                    (long long)element_size_bytes);
+
+  RUNTIME_DEBUG_LOG("[linear_attention] ptrs: query=%p key=%p value=%p "
+                    "past_state=%p decay=%p beta=%p output=%p "
+                    "present_state=%p\n",
+                    query, key, value, past_state, decay, beta, output,
+                    present_state);
+
+  // Validate required inputs
+  if (!query || !key || !value || !output || !present_state) {
+    fprintf(stderr,
+            "[linear_attention] ERROR: null required pointer "
+            "(query=%p key=%p value=%p output=%p present_state=%p)\n",
+            query, key, value, output, present_state);
+    return -1;
+  }
+
+  // Validate update rule constraints
+  if ((update_rule == kUpdateRuleGated ||
+       update_rule == kUpdateRuleGatedDelta) &&
+      !decay) {
+    fprintf(stderr,
+            "[linear_attention] ERROR: decay is required for %s mode\n",
+            updateRuleName(update_rule));
+    return -1;
+  }
+  if ((update_rule == kUpdateRuleDelta ||
+       update_rule == kUpdateRuleGatedDelta) &&
+      !beta) {
+    fprintf(stderr,
+            "[linear_attention] ERROR: beta is required for %s mode\n",
+            updateRuleName(update_rule));
+    return -1;
+  }
+
+  void *hip_stream = hipdnn_ep_state_get_stream(state);
+  if (!hip_stream) {
+    fprintf(stderr, "[linear_attention] ERROR: failed to get HIP stream\n");
+    return -1;
+  }
+
+  hipblasLtHandle_t blaslt_handle =
+      (hipblasLtHandle_t)hipdnn_ep_state_get_hipblas_handle(state);
+  if (!blaslt_handle) {
+    fprintf(stderr,
+            "[linear_attention] ERROR: failed to get hipBLASLt handle\n");
+    return -1;
+  }
+
+  // Auto-compute scale if sentinel zero
+  if (scale == 0.0f && head_dim_k > 0)
+    scale = 1.0f / sqrtf((float)head_dim_k);
+
+  // Dimension aliases
+  const int64_t B = batch_size;
+  const int64_t Hkv = kv_num_heads;
+  const int64_t dk = head_dim_k;
+  const int64_t dv = head_dim_v;
+
+  // State size per batch per head: dk * dv elements
+  const int64_t state_bytes = dk * dv * element_size_bytes;
+  int64_t total_state_bytes = B * Hkv * state_bytes;
+
+  int result = 0;
+
+  // Initialize present_state from past_state (or zeros)
+  if (past_state) {
+    HIP_CHECK(hipMemcpyAsync(present_state, past_state, total_state_bytes,
+                              hipMemcpyDeviceToDevice,
+                              (hipStream_t)hip_stream));
+  } else {
+    HIP_CHECK(
+        hipMemsetAsync(present_state, 0, total_state_bytes,
+                       (hipStream_t)hip_stream));
+  }
+
+  // TODO: Implement the full linear attention recurrence kernel.
+  //
+  // The recurrence for each token t (per batch b, per KV head g):
+  //   "linear":       S = S + k_t outer v_t
+  //   "gated":        S = exp(g_t) * S + k_t outer v_t
+  //   "delta":        S = S + beta_t * k_t outer (v_t - S^T k_t)
+  //   "gated_delta":  S = exp(g_t) * S + beta_t * k_t outer (v_t - exp(g_t) * S^T k_t)
+  //   o_t = scale * q_t^T S    (for each query head h mapped to this KV group)
+  //
+  // For T=1 (decode): sequential recurrence is efficient.
+  // For T>1 (prefill): chunk-parallel WY decomposition is preferred.
+  //
+  // Current implementation: initialize state, placeholder for kernel dispatch.
+  // Full GPU kernel integration is pending custom_kernels library extension.
+
+  RUNTIME_DEBUG_LOG("[linear_attention] state initialized (%s), "
+                    "kernel dispatch pending\n",
+                    past_state ? "from past" : "zeros");
+
+cleanup:
+  RUNTIME_DEBUG_LOG("[linear_attention] exit result=%d\n", result);
+  return result;
+}

--- a/lib/Runtime/real/linear_attention.cpp
+++ b/lib/Runtime/real/linear_attention.cpp
@@ -43,8 +43,8 @@ static const char *updateRuleName(int64_t rule) {
 extern "C" int wrap_linear_attention(
     RuntimeState *state, const void *query, const void *key, const void *value,
     const void *past_state, const void *decay, const void *beta, void *output,
-    void *present_state, int64_t q_num_heads, int64_t kv_num_heads,
-    float scale, int64_t chunk_size, int64_t update_rule, int64_t batch_size,
+    void *present_state, int64_t q_num_heads, int64_t kv_num_heads, float scale,
+    int64_t chunk_size, int64_t update_rule, int64_t batch_size,
     int64_t seq_len, int64_t head_dim_k, int64_t head_dim_v,
     int64_t element_size_bytes) {
 
@@ -53,9 +53,8 @@ extern "C" int wrap_linear_attention(
                     "scale=%.6f chunk=%lld rule=%s elem_size=%lld\n",
                     (long long)batch_size, (long long)seq_len,
                     (long long)q_num_heads, (long long)kv_num_heads,
-                    (long long)head_dim_k, (long long)head_dim_v,
-                    (double)scale, (long long)chunk_size,
-                    updateRuleName(update_rule),
+                    (long long)head_dim_k, (long long)head_dim_v, (double)scale,
+                    (long long)chunk_size, updateRuleName(update_rule),
                     (long long)element_size_bytes);
 
   RUNTIME_DEBUG_LOG("[linear_attention] ptrs: query=%p key=%p value=%p "
@@ -77,16 +76,14 @@ extern "C" int wrap_linear_attention(
   if ((update_rule == kUpdateRuleGated ||
        update_rule == kUpdateRuleGatedDelta) &&
       !decay) {
-    fprintf(stderr,
-            "[linear_attention] ERROR: decay is required for %s mode\n",
+    fprintf(stderr, "[linear_attention] ERROR: decay is required for %s mode\n",
             updateRuleName(update_rule));
     return -1;
   }
   if ((update_rule == kUpdateRuleDelta ||
        update_rule == kUpdateRuleGatedDelta) &&
       !beta) {
-    fprintf(stderr,
-            "[linear_attention] ERROR: beta is required for %s mode\n",
+    fprintf(stderr, "[linear_attention] ERROR: beta is required for %s mode\n",
             updateRuleName(update_rule));
     return -1;
   }
@@ -124,12 +121,10 @@ extern "C" int wrap_linear_attention(
   // Initialize present_state from past_state (or zeros)
   if (past_state) {
     HIP_CHECK(hipMemcpyAsync(present_state, past_state, total_state_bytes,
-                              hipMemcpyDeviceToDevice,
-                              (hipStream_t)hip_stream));
+                             hipMemcpyDeviceToDevice, (hipStream_t)hip_stream));
   } else {
-    HIP_CHECK(
-        hipMemsetAsync(present_state, 0, total_state_bytes,
-                       (hipStream_t)hip_stream));
+    HIP_CHECK(hipMemsetAsync(present_state, 0, total_state_bytes,
+                             (hipStream_t)hip_stream));
   }
 
   if (seq_len == 1) {
@@ -137,8 +132,7 @@ extern "C" int wrap_linear_attention(
         hip_stream, query, key, value, decay, beta, present_state, output, B,
         q_num_heads, Hkv, dk, dv, scale, update_rule, element_size_bytes);
     if (kern_result != 0) {
-      fprintf(stderr,
-              "[linear_attention] ERROR: decode kernel failed (%d)\n",
+      fprintf(stderr, "[linear_attention] ERROR: decode kernel failed (%d)\n",
               kern_result);
       result = -1;
       goto cleanup;

--- a/test/lit/Conversion/hip-to-llvm/test_linear_attention.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_linear_attention.mlir
@@ -4,14 +4,19 @@
 // ============================================================================
 // TEST PURPOSE:
 // Verify hip.linear_attention lowers to a single call to
-// wrap_linear_attention with 20 parameters:
+// wrap_linear_attention with 22 parameters:
 // - 9 pointers: state, query, key, value, past_state, decay, beta,
 //               output, present_state (absent optionals become null)
 // - 6 attributes: q_num_heads, kv_num_heads, n_k_heads, scale, chunk_size,
 //                 update_rule  (n_k_heads is derived at runtime as
 //                 key.dim[2] / head_dim_k, emitted via a second llvm.udiv)
+// - 2 optional-input layout flags: decay_per_key_dim, beta_per_head
+//                 (i64; 0 when the corresponding operand is absent, otherwise
+//                 derived from the operand's last dim at lowering time:
+//                 decay_per_key_dim = 1 if decay.dim[-1] != H_kv,
+//                 beta_per_head     = 1 if beta.dim[-1]  != 1)
 // - 5 shape params: batch_size, seq_len, head_dim_k, head_dim_v,
-//                   element_size_bytes (static -> llvm.mlir.constant,
+//                   type / HIPDNN_EP_DATATYPE_* (static -> llvm.mlir.constant,
 //                   dynamic -> llvm.extractvalue %desc[3, N], with
 //                   head_dim_k = query.dim[2] / q_num_heads always via
 //                   llvm.udiv)
@@ -51,15 +56,17 @@ module {
         {q_num_heads = 32 : i64, kv_num_heads = 8 : i64,
          scale = 0.0883883461 : f32, update_rule = "gated"}
 
-    // Test 1 verifies 20 parameters:
+    // Test 1 verifies 22 parameters:
     // - 9 pointers: state, query, key, value, past_state, decay(ptr),
     //               beta(NULL), output, present_state
     // - 6 attributes: q_num_heads=32, kv_num_heads=8, n_k_heads=8 (=1024/128),
     //                 scale=0.0883883461, chunk_size=0, update_rule=1(gated)
+    // - 2 layout flags: decay_per_key_dim=1 (decay dim[-1]=1024 != H_kv=8),
+    //                   beta_per_head=0 (beta absent)
     // - 5 shape params: batch_size=1, seq_len=1, head_dim_k=128,
-    //                   head_dim_v=128, element_size_bytes=2
+    //                   head_dim_v=128, type=1 (HIPDNN_EP_DATATYPE_HALF for f16)
     // CHECK-LABEL: llvm.func @test_linear_attention_lowering
-    // CHECK: llvm.call @wrap_linear_attention({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, f32, i64, i64, i64, i64, i64, i64, i64) -> i32
+    // CHECK: llvm.call @wrap_linear_attention({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, f32, i64, i64, i64, i64, i64, i64, i64) -> i32
     return
   }
 
@@ -104,7 +111,7 @@ module {
     // CHECK: llvm.udiv
     // head_dim_v: present_state dim 3 is static.
     // CHECK: llvm.mlir.constant(128 : i64)
-    // CHECK: llvm.call @wrap_linear_attention({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, f32, i64, i64, i64, i64, i64, i64, i64) -> i32
+    // CHECK: llvm.call @wrap_linear_attention({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, f32, i64, i64, i64, i64, i64, i64, i64) -> i32
 
     return
   }
@@ -153,7 +160,7 @@ module {
     // CHECK: llvm.udiv
     // head_dim_v extracted from present_state descriptor (dim 3).
     // CHECK: llvm.extractvalue {{.*}}[3, 3]
-    // CHECK: llvm.call @wrap_linear_attention({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, f32, i64, i64, i64, i64, i64, i64, i64) -> i32
+    // CHECK: llvm.call @wrap_linear_attention({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, f32, i64, i64, i64, i64, i64, i64, i64) -> i32
 
     return
   }

--- a/test/lit/Conversion/hip-to-llvm/test_linear_attention.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_linear_attention.mlir
@@ -1,0 +1,39 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --convert-hip-to-llvm %s | FileCheck %s
+
+module {
+  func.func @test_linear_attention_lowering(
+      %ctx: !hip.context,
+      %query: memref<1x1x4096xf16, 1>,
+      %key: memref<1x1x1024xf16, 1>,
+      %value: memref<1x1x1024xf16, 1>,
+      %past_state: memref<1x8x128x128xf16, 1>,
+      %decay: memref<1x1x1024xf16, 1>,
+      %output: memref<1x1x4096xf16, 1>,
+      %present_state: memref<1x8x128x128xf16, 1>) {
+    hip.linear_attention(%ctx)
+        ins(%query, %key, %value :
+            memref<1x1x4096xf16, 1>, memref<1x1x1024xf16, 1>,
+            memref<1x1x1024xf16, 1>)
+        past_state(%past_state : memref<1x8x128x128xf16, 1>)
+        decay(%decay : memref<1x1x1024xf16, 1>)
+        outs(%output, %present_state :
+             memref<1x1x4096xf16, 1>, memref<1x8x128x128xf16, 1>)
+        {q_num_heads = 32 : i64, kv_num_heads = 8 : i64,
+         scale = 0.0883883461 : f32, update_rule = "gated"}
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @test_linear_attention_lowering
+// CHECK: llvm.call @wrap_linear_attention({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, f32, i64, i64, i64, i64, i64, i64, i64) -> i32
+
+// Verify 19 parameters:
+// - 9 pointers: state, query, key, value, past_state, decay(ptr), beta(NULL),
+//               output, present_state
+// - 5 attributes: q_num_heads=32, kv_num_heads=8, scale=0.0883883461,
+//                 chunk_size=0, update_rule=1(gated)
+// - 5 shape params: batch_size=1, seq_len=1, head_dim_k=128,
+//                   head_dim_v=128, element_size_bytes=2

--- a/test/lit/Conversion/hip-to-llvm/test_linear_attention.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_linear_attention.mlir
@@ -4,10 +4,12 @@
 // ============================================================================
 // TEST PURPOSE:
 // Verify hip.linear_attention lowers to a single call to
-// wrap_linear_attention with 19 parameters:
+// wrap_linear_attention with 20 parameters:
 // - 9 pointers: state, query, key, value, past_state, decay, beta,
 //               output, present_state (absent optionals become null)
-// - 5 attributes: q_num_heads, kv_num_heads, scale, chunk_size, update_rule
+// - 6 attributes: q_num_heads, kv_num_heads, n_k_heads, scale, chunk_size,
+//                 update_rule  (n_k_heads is derived at runtime as
+//                 key.dim[2] / head_dim_k, emitted via a second llvm.udiv)
 // - 5 shape params: batch_size, seq_len, head_dim_k, head_dim_v,
 //                   element_size_bytes (static -> llvm.mlir.constant,
 //                   dynamic -> llvm.extractvalue %desc[3, N], with
@@ -49,15 +51,15 @@ module {
         {q_num_heads = 32 : i64, kv_num_heads = 8 : i64,
          scale = 0.0883883461 : f32, update_rule = "gated"}
 
-    // Test 1 verifies 19 parameters:
+    // Test 1 verifies 20 parameters:
     // - 9 pointers: state, query, key, value, past_state, decay(ptr),
     //               beta(NULL), output, present_state
-    // - 5 attributes: q_num_heads=32, kv_num_heads=8, scale=0.0883883461,
-    //                 chunk_size=0, update_rule=1(gated)
+    // - 6 attributes: q_num_heads=32, kv_num_heads=8, n_k_heads=8 (=1024/128),
+    //                 scale=0.0883883461, chunk_size=0, update_rule=1(gated)
     // - 5 shape params: batch_size=1, seq_len=1, head_dim_k=128,
     //                   head_dim_v=128, element_size_bytes=2
     // CHECK-LABEL: llvm.func @test_linear_attention_lowering
-    // CHECK: llvm.call @wrap_linear_attention({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, f32, i64, i64, i64, i64, i64, i64, i64) -> i32
+    // CHECK: llvm.call @wrap_linear_attention({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, f32, i64, i64, i64, i64, i64, i64, i64) -> i32
     return
   }
 
@@ -97,9 +99,12 @@ module {
     // constants.
     // CHECK: llvm.mlir.constant(4096 : i64)
     // CHECK: llvm.udiv
+    // n_k_heads: key hidden is static (1024), second udiv divides by d_k.
+    // CHECK: llvm.mlir.constant(1024 : i64)
+    // CHECK: llvm.udiv
     // head_dim_v: present_state dim 3 is static.
     // CHECK: llvm.mlir.constant(128 : i64)
-    // CHECK: llvm.call @wrap_linear_attention({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, f32, i64, i64, i64, i64, i64, i64, i64) -> i32
+    // CHECK: llvm.call @wrap_linear_attention({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, f32, i64, i64, i64, i64, i64, i64, i64) -> i32
 
     return
   }
@@ -143,9 +148,12 @@ module {
     // CHECK: llvm.extractvalue {{.*}}[3, 2]
     // head_dim_k = query_hidden / q_num_heads at runtime.
     // CHECK: llvm.udiv
+    // n_k_heads = key_hidden / head_dim_k; key_hidden extracted at runtime.
+    // CHECK: llvm.extractvalue {{.*}}[3, 2]
+    // CHECK: llvm.udiv
     // head_dim_v extracted from present_state descriptor (dim 3).
     // CHECK: llvm.extractvalue {{.*}}[3, 3]
-    // CHECK: llvm.call @wrap_linear_attention({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, f32, i64, i64, i64, i64, i64, i64, i64) -> i32
+    // CHECK: llvm.call @wrap_linear_attention({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, f32, i64, i64, i64, i64, i64, i64, i64) -> i32
 
     return
   }

--- a/test/lit/Conversion/hip-to-llvm/test_linear_attention.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_linear_attention.mlir
@@ -1,6 +1,31 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
 
+// ============================================================================
+// TEST PURPOSE:
+// Verify hip.linear_attention lowers to a single call to
+// wrap_linear_attention with 19 parameters:
+// - 9 pointers: state, query, key, value, past_state, decay, beta,
+//               output, present_state (absent optionals become null)
+// - 5 attributes: q_num_heads, kv_num_heads, scale, chunk_size, update_rule
+// - 5 shape params: batch_size, seq_len, head_dim_k, head_dim_v,
+//                   element_size_bytes (static -> llvm.mlir.constant,
+//                   dynamic -> llvm.extractvalue %desc[3, N], with
+//                   head_dim_k = query.dim[2] / q_num_heads always via
+//                   llvm.udiv)
+//
+// Test cases:
+// 1. test_linear_attention_lowering          - all static, gated + past/decay
+// 2. test_linear_attention_dynamic_prefill   - dynamic batch + seq_len,
+//                                               hidden dims static (typical
+//                                               LLM prefill, no past_state)
+// 3. test_linear_attention_fully_dynamic     - all tensor dims dynamic;
+//                                               validates that head_dim_k and
+//                                               head_dim_v fall back to
+//                                               runtime extraction rather
+//                                               than the kDynamic sentinel.
+// ============================================================================
+
 // RUN: hip-mlir-opt --convert-hip-to-llvm %s | FileCheck %s
 
 module {
@@ -23,17 +48,105 @@ module {
              memref<1x1x4096xf16, 1>, memref<1x8x128x128xf16, 1>)
         {q_num_heads = 32 : i64, kv_num_heads = 8 : i64,
          scale = 0.0883883461 : f32, update_rule = "gated"}
+
+    // Test 1 verifies 19 parameters:
+    // - 9 pointers: state, query, key, value, past_state, decay(ptr),
+    //               beta(NULL), output, present_state
+    // - 5 attributes: q_num_heads=32, kv_num_heads=8, scale=0.0883883461,
+    //                 chunk_size=0, update_rule=1(gated)
+    // - 5 shape params: batch_size=1, seq_len=1, head_dim_k=128,
+    //                   head_dim_v=128, element_size_bytes=2
+    // CHECK-LABEL: llvm.func @test_linear_attention_lowering
+    // CHECK: llvm.call @wrap_linear_attention({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, f32, i64, i64, i64, i64, i64, i64, i64) -> i32
+    return
+  }
+
+  // --------------------------------------------------------------------------
+  // Test 2: Dynamic batch + seq_len, static hidden dims (prefill w/o state).
+  //
+  // Expectations:
+  // - batch_size  = llvm.extractvalue %query_desc[3, 0]
+  // - seq_len     = llvm.extractvalue %query_desc[3, 1]
+  // - head_dim_k  = llvm.udiv(const 4096, const q_num_heads=32)
+  //                 (UDivOp is always emitted; both operands are constants
+  //                  here since the query hidden dim is static)
+  // - head_dim_v  = llvm.mlir.constant(128 : i64) from present_state dim 3
+  // --------------------------------------------------------------------------
+  func.func @test_linear_attention_dynamic_prefill(
+      %ctx: !hip.context,
+      %query: memref<?x?x4096xf16, 1>,
+      %key: memref<?x?x1024xf16, 1>,
+      %value: memref<?x?x1024xf16, 1>,
+      %output: memref<?x?x4096xf16, 1>,
+      %present_state: memref<?x8x128x128xf16, 1>) {
+    // CHECK-LABEL: llvm.func @test_linear_attention_dynamic_prefill
+
+    hip.linear_attention(%ctx)
+        ins(%query, %key, %value :
+            memref<?x?x4096xf16, 1>, memref<?x?x1024xf16, 1>,
+            memref<?x?x1024xf16, 1>)
+        outs(%output, %present_state :
+             memref<?x?x4096xf16, 1>, memref<?x8x128x128xf16, 1>)
+        {q_num_heads = 32 : i64, kv_num_heads = 8 : i64,
+         scale = 0.0883883461 : f32, update_rule = "linear"}
+
+    // Dynamic batch + seq_len extracted from query descriptor.
+    // CHECK: llvm.extractvalue {{.*}}[3, 0]
+    // CHECK: llvm.extractvalue {{.*}}[3, 1]
+    // head_dim_k: query hidden is static (4096), so both udiv operands are
+    // constants.
+    // CHECK: llvm.mlir.constant(4096 : i64)
+    // CHECK: llvm.udiv
+    // head_dim_v: present_state dim 3 is static.
+    // CHECK: llvm.mlir.constant(128 : i64)
+    // CHECK: llvm.call @wrap_linear_attention({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, f32, i64, i64, i64, i64, i64, i64, i64) -> i32
+
+    return
+  }
+
+  // --------------------------------------------------------------------------
+  // Test 3: Fully dynamic (query and present_state all dynamic).
+  //
+  // Regression case for the kDynamic-sentinel bug: without dynamic-shape
+  // support, head_dim_k would fold to kDynamic (a large negative constant)
+  // and head_dim_v would read the static dim (also kDynamic).
+  //
+  // Expectations:
+  // - batch_size, seq_len, query_hidden all extracted from query descriptor
+  //   at indices [3, 0..2].
+  // - head_dim_k emitted via llvm.udiv with the extracted hidden dim.
+  // - head_dim_v extracted from present_state descriptor at index [3, 3].
+  // --------------------------------------------------------------------------
+  func.func @test_linear_attention_fully_dynamic(
+      %ctx: !hip.context,
+      %query: memref<?x?x?xf16, 1>,
+      %key: memref<?x?x?xf16, 1>,
+      %value: memref<?x?x?xf16, 1>,
+      %past_state: memref<?x?x?x?xf16, 1>,
+      %output: memref<?x?x?xf16, 1>,
+      %present_state: memref<?x?x?x?xf16, 1>) {
+    // CHECK-LABEL: llvm.func @test_linear_attention_fully_dynamic
+
+    hip.linear_attention(%ctx)
+        ins(%query, %key, %value :
+            memref<?x?x?xf16, 1>, memref<?x?x?xf16, 1>,
+            memref<?x?x?xf16, 1>)
+        past_state(%past_state : memref<?x?x?x?xf16, 1>)
+        outs(%output, %present_state :
+             memref<?x?x?xf16, 1>, memref<?x?x?x?xf16, 1>)
+        {q_num_heads = 32 : i64, kv_num_heads = 8 : i64,
+         scale = 0.0883883461 : f32, update_rule = "gated_delta"}
+
+    // All 3 query dims extracted at runtime.
+    // CHECK: llvm.extractvalue {{.*}}[3, 0]
+    // CHECK: llvm.extractvalue {{.*}}[3, 1]
+    // CHECK: llvm.extractvalue {{.*}}[3, 2]
+    // head_dim_k = query_hidden / q_num_heads at runtime.
+    // CHECK: llvm.udiv
+    // head_dim_v extracted from present_state descriptor (dim 3).
+    // CHECK: llvm.extractvalue {{.*}}[3, 3]
+    // CHECK: llvm.call @wrap_linear_attention({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, f32, i64, i64, i64, i64, i64, i64, i64) -> i32
+
     return
   }
 }
-
-// CHECK-LABEL: llvm.func @test_linear_attention_lowering
-// CHECK: llvm.call @wrap_linear_attention({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, f32, i64, i64, i64, i64, i64, i64, i64) -> i32
-
-// Verify 19 parameters:
-// - 9 pointers: state, query, key, value, past_state, decay(ptr), beta(NULL),
-//               output, present_state
-// - 5 attributes: q_num_heads=32, kv_num_heads=8, scale=0.0883883461,
-//                 chunk_size=0, update_rule=1(gated)
-// - 5 shape params: batch_size=1, seq_len=1, head_dim_k=128,
-//                   head_dim_v=128, element_size_bytes=2

--- a/test/lit/Conversion/onnx-to-hip/test_linear_attention.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_linear_attention.mlir
@@ -27,13 +27,13 @@
 // Test 1: Minimal linear mode - 3 required inputs only
 // =============================================================================
 module {
-  func.func @test_linear_minimal(
+  func.func @main_graph(
       %query: tensor<1x128x4096xf16>,
       %key: tensor<1x128x1024xf16>,
       %value: tensor<1x128x1024xf16>)
       -> (tensor<1x128x4096xf16>, tensor<1x8x128x128xf16>) {
 
-    // CHECK-LABEL: func.func @test_linear_minimal
+    // CHECK-LABEL: func.func @main_graph
     // CHECK-SAME: (%[[CTX:.*]]: !hip.context,
 
     %out:2 = "onnx.Custom"(%query, %key, %value)

--- a/test/lit/Conversion/onnx-to-hip/test_linear_attention.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_linear_attention.mlir
@@ -162,7 +162,7 @@ module {
     // CHECK-SAME: kv_num_heads = 8
     // CHECK-SAME: q_num_heads = 32
     // CHECK-SAME: scale = {{0.088388[0-9]*|8.838834e-02}}
-    // CHECK-SAME: update_rule = "gated_delta"
+    // "gated_delta" is the default value, so MLIR omits it from output
 
     return %out#0, %out#1 : tensor<1x128x4096xf16>, tensor<1x8x128x128xf16>
   }

--- a/test/lit/Conversion/onnx-to-hip/test_linear_attention.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_linear_attention.mlir
@@ -1,0 +1,169 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify com.microsoft.LinearAttention (via onnx.Custom) is correctly
+// lowered to hip.linear_attention operation in tensor-first mode.
+//
+// This test suite validates:
+// - Custom ONNX op matching by function_name and domain_name
+// - Multi-output op lowering (2 outputs: output, present_state)
+// - Attribute preservation (q_num_heads, kv_num_heads, scale, update_rule, etc.)
+// - Optional inputs handling (past_state, decay, beta)
+// - f16 element type support
+// - Tensor-first DPS: tensor.empty() for each output
+//
+// Test cases:
+// 1. Minimal linear mode (3 required inputs only)
+// 2. Gated mode with decay
+// 3. Delta mode with beta
+// 4. Full gated_delta mode (all 6 inputs + all attributes)
+// ============================================================================
+
+// RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip | FileCheck %s
+
+// =============================================================================
+// Test 1: Minimal linear mode - 3 required inputs only
+// =============================================================================
+module {
+  func.func @test_linear_minimal(
+      %query: tensor<1x128x4096xf16>,
+      %key: tensor<1x128x1024xf16>,
+      %value: tensor<1x128x1024xf16>)
+      -> (tensor<1x128x4096xf16>, tensor<1x8x128x128xf16>) {
+
+    // CHECK-LABEL: func.func @test_linear_minimal
+    // CHECK-SAME: (%[[CTX:.*]]: !hip.context,
+
+    %out:2 = "onnx.Custom"(%query, %key, %value)
+        <{function_name = "LinearAttention"}>
+        {domain_name = "com.microsoft",
+         q_num_heads = 32 : si64,
+         kv_num_heads = 8 : si64,
+         update_rule = "linear"}
+        : (tensor<1x128x4096xf16>, tensor<1x128x1024xf16>,
+           tensor<1x128x1024xf16>)
+        -> (tensor<1x128x4096xf16>, tensor<1x8x128x128xf16>)
+
+    // CHECK: tensor.empty() : tensor<1x128x4096xf16>
+    // CHECK: tensor.empty() : tensor<1x8x128x128xf16>
+    // CHECK: hip.linear_attention(%[[CTX]])
+    // CHECK-SAME: kv_num_heads = 8
+    // CHECK-SAME: q_num_heads = 32
+    // CHECK-SAME: update_rule = "linear"
+
+    return %out#0, %out#1 : tensor<1x128x4096xf16>, tensor<1x8x128x128xf16>
+  }
+
+  // ===========================================================================
+  // Test 2: Gated mode with past_state and decay
+  // ===========================================================================
+  func.func @test_gated_with_decay(
+      %query: tensor<1x1x4096xf16>,
+      %key: tensor<1x1x1024xf16>,
+      %value: tensor<1x1x1024xf16>,
+      %past_state: tensor<1x8x128x128xf16>,
+      %decay: tensor<1x1x1024xf16>)
+      -> (tensor<1x1x4096xf16>, tensor<1x8x128x128xf16>) {
+
+    // CHECK-LABEL: func.func @test_gated_with_decay
+    // CHECK-SAME: (%[[CTX:.*]]: !hip.context,
+
+    %none = "onnx.NoValue"() {value} : () -> none
+
+    %out:2 = "onnx.Custom"(%query, %key, %value, %past_state, %decay, %none)
+        <{function_name = "LinearAttention"}>
+        {domain_name = "com.microsoft",
+         q_num_heads = 32 : si64,
+         kv_num_heads = 8 : si64,
+         update_rule = "gated"}
+        : (tensor<1x1x4096xf16>, tensor<1x1x1024xf16>,
+           tensor<1x1x1024xf16>, tensor<1x8x128x128xf16>,
+           tensor<1x1x1024xf16>, none)
+        -> (tensor<1x1x4096xf16>, tensor<1x8x128x128xf16>)
+
+    // CHECK: hip.linear_attention(%[[CTX]])
+    // CHECK-SAME: kv_num_heads = 8
+    // CHECK-SAME: q_num_heads = 32
+    // CHECK-SAME: update_rule = "gated"
+
+    return %out#0, %out#1 : tensor<1x1x4096xf16>, tensor<1x8x128x128xf16>
+  }
+
+  // ===========================================================================
+  // Test 3: Delta mode with past_state and beta
+  // ===========================================================================
+  func.func @test_delta_with_beta(
+      %query: tensor<1x1x4096xf16>,
+      %key: tensor<1x1x1024xf16>,
+      %value: tensor<1x1x1024xf16>,
+      %past_state: tensor<1x8x128x128xf16>,
+      %beta: tensor<1x1x8xf16>)
+      -> (tensor<1x1x4096xf16>, tensor<1x8x128x128xf16>) {
+
+    // CHECK-LABEL: func.func @test_delta_with_beta
+    // CHECK-SAME: (%[[CTX:.*]]: !hip.context,
+
+    %none = "onnx.NoValue"() {value} : () -> none
+
+    %out:2 = "onnx.Custom"(%query, %key, %value, %past_state, %none, %beta)
+        <{function_name = "LinearAttention"}>
+        {domain_name = "com.microsoft",
+         q_num_heads = 32 : si64,
+         kv_num_heads = 8 : si64,
+         update_rule = "delta"}
+        : (tensor<1x1x4096xf16>, tensor<1x1x1024xf16>,
+           tensor<1x1x1024xf16>, tensor<1x8x128x128xf16>,
+           none, tensor<1x1x8xf16>)
+        -> (tensor<1x1x4096xf16>, tensor<1x8x128x128xf16>)
+
+    // CHECK: hip.linear_attention(%[[CTX]])
+    // CHECK-SAME: kv_num_heads = 8
+    // CHECK-SAME: q_num_heads = 32
+    // CHECK-SAME: update_rule = "delta"
+
+    return %out#0, %out#1 : tensor<1x1x4096xf16>, tensor<1x8x128x128xf16>
+  }
+
+  // ===========================================================================
+  // Test 4: Full gated_delta mode - all 6 inputs + all attributes
+  // ===========================================================================
+  func.func @test_gated_delta_full(
+      %query: tensor<1x128x4096xf16>,
+      %key: tensor<1x128x1024xf16>,
+      %value: tensor<1x128x1024xf16>,
+      %past_state: tensor<1x8x128x128xf16>,
+      %decay: tensor<1x128x1024xf16>,
+      %beta: tensor<1x128x8xf16>)
+      -> (tensor<1x128x4096xf16>, tensor<1x8x128x128xf16>) {
+
+    // CHECK-LABEL: func.func @test_gated_delta_full
+    // CHECK-SAME: (%[[CTX:.*]]: !hip.context,
+
+    %out:2 = "onnx.Custom"(%query, %key, %value, %past_state, %decay, %beta)
+        <{function_name = "LinearAttention"}>
+        {domain_name = "com.microsoft",
+         q_num_heads = 32 : si64,
+         kv_num_heads = 8 : si64,
+         scale = 8.838834e-02 : f32,
+         chunk_size = 64 : si64,
+         update_rule = "gated_delta"}
+        : (tensor<1x128x4096xf16>, tensor<1x128x1024xf16>,
+           tensor<1x128x1024xf16>, tensor<1x8x128x128xf16>,
+           tensor<1x128x1024xf16>, tensor<1x128x8xf16>)
+        -> (tensor<1x128x4096xf16>, tensor<1x8x128x128xf16>)
+
+    // CHECK: tensor.empty() : tensor<1x128x4096xf16>
+    // CHECK: tensor.empty() : tensor<1x8x128x128xf16>
+    // CHECK: hip.linear_attention(%[[CTX]])
+    // CHECK-SAME: ins(
+    // CHECK-SAME: chunk_size = 64
+    // CHECK-SAME: kv_num_heads = 8
+    // CHECK-SAME: q_num_heads = 32
+    // CHECK-SAME: scale = {{0.088388[0-9]*|8.838834e-02}}
+    // CHECK-SAME: update_rule = "gated_delta"
+
+    return %out#0, %out#1 : tensor<1x128x4096xf16>, tensor<1x8x128x128xf16>
+  }
+}

--- a/test/lit/Conversion/onnx-to-hip/test_linear_attention.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_linear_attention.mlir
@@ -19,6 +19,12 @@
 // 2. Gated mode with decay
 // 3. Delta mode with beta
 // 4. Full gated_delta mode (all 6 inputs + all attributes)
+// 5. Dynamic batch + seq_len (prefill case, no past_state)
+// 6. Dynamic batch + seq_len with past_state (typical LLM decode with KV-cache)
+//
+// Dynamic cases additionally assert:
+// - tensor.dim extracts each dynamic dim at runtime
+// - tensor.empty(%dim...) takes those sizes as dynamic operands
 // ============================================================================
 
 // RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip | FileCheck %s
@@ -165,5 +171,104 @@ module {
     // "gated_delta" is the default value, so MLIR omits it from output
 
     return %out#0, %out#1 : tensor<1x128x4096xf16>, tensor<1x8x128x128xf16>
+  }
+
+  // ===========================================================================
+  // Test 5: Dynamic batch + seq_len, linear mode (prefill without past_state).
+  //
+  // Typical LLM prefill scenario: batch and seq_len are runtime values; only
+  // the hidden dims (H_q*d_k, H_kv*d_k, H_kv*d_v, d_k, d_v) are fixed by the
+  // model architecture.
+  //
+  // Expectations:
+  // - output init: tensor.dim for dims 0 and 1 of query + tensor.empty with
+  //   two dynamic sizes (output's last dim H_q*d_v stays static).
+  // - present_state init: no past_state, so source is key -- tensor.dim for
+  //   dim 0 of key + tensor.empty with one dynamic size (B). Remaining dims
+  //   (H_kv=8, d_k=128, d_v=128) are static per spec.
+  // ===========================================================================
+  func.func @test_linear_dynamic_prefill(
+      %query: tensor<?x?x4096xf16>,
+      %key: tensor<?x?x1024xf16>,
+      %value: tensor<?x?x1024xf16>)
+      -> (tensor<?x?x4096xf16>, tensor<?x8x128x128xf16>) {
+
+    // CHECK-LABEL: func.func @test_linear_dynamic_prefill
+    // CHECK-SAME: (%[[CTX5:.*]]: !hip.context, %[[Q5:.*]]: tensor<?x?x4096xf16>, %[[K5:.*]]: tensor<?x?x1024xf16>, %[[V5:.*]]: tensor<?x?x1024xf16>)
+
+    %out:2 = "onnx.Custom"(%query, %key, %value)
+        <{function_name = "LinearAttention"}>
+        {domain_name = "com.microsoft",
+         q_num_heads = 32 : si64,
+         kv_num_heads = 8 : si64,
+         update_rule = "linear"}
+        : (tensor<?x?x4096xf16>, tensor<?x?x1024xf16>,
+           tensor<?x?x1024xf16>)
+        -> (tensor<?x?x4096xf16>, tensor<?x8x128x128xf16>)
+
+    // output init: dims 0 and 1 of query extracted at runtime.
+    // CHECK: tensor.dim %[[Q5]]
+    // CHECK: tensor.dim %[[Q5]]
+    // CHECK: tensor.empty({{.*}}) : tensor<?x?x4096xf16>
+    // present_state init: no past_state -> source is key, only dim 0 dynamic.
+    // CHECK: tensor.dim %[[K5]]
+    // CHECK: tensor.empty({{.*}}) : tensor<?x8x128x128xf16>
+    // CHECK: hip.linear_attention(%[[CTX5]])
+    // CHECK-SAME: ins(%[[Q5]], %[[K5]], %[[V5]]
+    // CHECK-SAME: kv_num_heads = 8
+    // CHECK-SAME: q_num_heads = 32
+    // CHECK-SAME: update_rule = "linear"
+
+    return %out#0, %out#1 : tensor<?x?x4096xf16>, tensor<?x8x128x128xf16>
+  }
+
+  // ===========================================================================
+  // Test 6: Dynamic batch + seq_len with past_state (gated_delta decode).
+  //
+  // When past_state is provided it becomes the preferred source for the
+  // present_state init, which means every present_state dim can be sourced
+  // from the matching past_state dim (shapes are identical per spec).
+  //
+  // Expectations:
+  // - output init: tensor.dim for dims 0 and 1 of query + tensor.empty(...).
+  // - present_state init: tensor.dim for dim 0 of past_state + tensor.empty.
+  // ===========================================================================
+  func.func @test_linear_dynamic_decode_with_state(
+      %query: tensor<?x?x4096xf16>,
+      %key: tensor<?x?x1024xf16>,
+      %value: tensor<?x?x1024xf16>,
+      %past_state: tensor<?x8x128x128xf16>,
+      %decay: tensor<?x?x1024xf16>,
+      %beta: tensor<?x?x8xf16>)
+      -> (tensor<?x?x4096xf16>, tensor<?x8x128x128xf16>) {
+
+    // CHECK-LABEL: func.func @test_linear_dynamic_decode_with_state
+    // CHECK-SAME: (%[[CTX6:.*]]: !hip.context, %[[Q6:.*]]: tensor<?x?x4096xf16>, %[[K6:.*]]: tensor<?x?x1024xf16>, %[[V6:.*]]: tensor<?x?x1024xf16>, %[[PS6:.*]]: tensor<?x8x128x128xf16>
+
+    %out:2 = "onnx.Custom"(%query, %key, %value, %past_state, %decay, %beta)
+        <{function_name = "LinearAttention"}>
+        {domain_name = "com.microsoft",
+         q_num_heads = 32 : si64,
+         kv_num_heads = 8 : si64,
+         update_rule = "gated_delta"}
+        : (tensor<?x?x4096xf16>, tensor<?x?x1024xf16>,
+           tensor<?x?x1024xf16>, tensor<?x8x128x128xf16>,
+           tensor<?x?x1024xf16>, tensor<?x?x8xf16>)
+        -> (tensor<?x?x4096xf16>, tensor<?x8x128x128xf16>)
+
+    // output init: dims 0 and 1 of query extracted at runtime.
+    // CHECK: tensor.dim %[[Q6]]
+    // CHECK: tensor.dim %[[Q6]]
+    // CHECK: tensor.empty({{.*}}) : tensor<?x?x4096xf16>
+    // present_state init: past_state provided -> source is past_state for
+    // the dynamic batch dim.
+    // CHECK: tensor.dim %[[PS6]]
+    // CHECK: tensor.empty({{.*}}) : tensor<?x8x128x128xf16>
+    // CHECK: hip.linear_attention(%[[CTX6]])
+    // CHECK-SAME: ins(%[[Q6]], %[[K6]], %[[V6]]
+    // CHECK-SAME: kv_num_heads = 8
+    // CHECK-SAME: q_num_heads = 32
+
+    return %out#0, %out#1 : tensor<?x?x4096xf16>, tensor<?x8x128x128xf16>
   }
 }

--- a/test/lit/e2e/test_linear_attention_model.mlir
+++ b/test/lit/e2e/test_linear_attention_model.mlir
@@ -1,0 +1,72 @@
+// RUN: hip-mlir-opt %s --hipdnn-pipeline | FileCheck %s
+
+// Test LinearAttention E2E full pipeline
+// This IR represents a com.microsoft.LinearAttention operation imported via
+// onnx-mlir as an onnx.Custom op. Used by Gated DeltaNet (Qwen3.5) and other
+// linear-attention / state-space models that support multiple update rules
+// ("linear", "gated", "delta", "gated_delta").
+//
+// The model has one onnx.Custom with f16 tensors (all 6 inputs + 2 outputs):
+//   inputs:
+//     query       (B=1, T=128, H_q*d_k=4096)   -- H_q=32, d_k=128
+//     key         (1, 128, H_kv*d_k=1024)      -- H_kv=8
+//     value       (1, 128, H_kv*d_v=1024)      -- d_v=128
+//     past_state  (1, H_kv=8, d_k=128, d_v=128)
+//     decay       (1, 128, H_kv*d_v=1024)
+//     beta        (1, 128, H_kv=8)
+//   outputs:
+//     output        (1, 128, 4096)
+//     present_state (1, 8, 128, 128)
+//   attrs:
+//     q_num_heads = 32, kv_num_heads = 8,
+//     scale = 1/sqrt(128) ~= 0.0883883461,
+//     update_rule = "gated_delta"
+//
+// Verifies the complete hipdnn-pipeline:
+// 1. convert-onnx-to-hip: onnx.Custom (LinearAttention)
+//                         -> hip.linear_attention
+// 2. canonicalize: Simplify redundant operations
+// 3. memory-pooling: Pool output and present_state buffers into single alloc
+// 4. convert-hip-to-llvm: HIP ops -> LLVM runtime calls (wrap_linear_attention)
+// 5. generate-interface: Create inference_init/compute/cleanup/metadata
+
+// CHECK: module attributes {
+// CHECK-SAME: hipdnn.input_count = 6
+// CHECK-SAME: hipdnn.output_count = 2
+// CHECK: llvm.func @wrap_linear_attention
+// CHECK: llvm.func private @main_graph(%{{.*}}: !llvm.ptr, %{{.*}}: !llvm.ptr, %{{.*}}: !llvm.ptr) -> i32
+// CHECK: llvm.call @wrap_linear_attention
+// CHECK: llvm.func @inference_init
+// CHECK: llvm.func @inference_compute
+// CHECK: llvm.func @inference_cleanup
+// CHECK: llvm.func @inference_get_metadata_json
+// CHECK-NOT: onnx.Custom
+// CHECK-NOT: onnx.NoValue
+module {
+  func.func @main_graph(
+      %arg0: tensor<1x128x4096xf16> {onnx.name = "query"},
+      %arg1: tensor<1x128x1024xf16> {onnx.name = "key"},
+      %arg2: tensor<1x128x1024xf16> {onnx.name = "value"},
+      %arg3: tensor<1x8x128x128xf16> {onnx.name = "past_state"},
+      %arg4: tensor<1x128x1024xf16> {onnx.name = "decay"},
+      %arg5: tensor<1x128x8xf16> {onnx.name = "beta"})
+      -> (tensor<1x128x4096xf16> {onnx.name = "output"},
+          tensor<1x8x128x128xf16> {onnx.name = "present_state"}) {
+    %0:2 = "onnx.Custom"(%arg0, %arg1, %arg2, %arg3, %arg4, %arg5) {
+      function_name = "LinearAttention",
+      domain_name = "com.microsoft",
+      onnx_node_name = "/model/layers.0/linear_attn/LinearAttention",
+      q_num_heads = 32 : si64,
+      kv_num_heads = 8 : si64,
+      scale = 0.0883883461 : f32,
+      chunk_size = 64 : si64,
+      update_rule = "gated_delta"
+    } : (tensor<1x128x4096xf16>, tensor<1x128x1024xf16>,
+         tensor<1x128x1024xf16>, tensor<1x8x128x128xf16>,
+         tensor<1x128x1024xf16>, tensor<1x128x8xf16>)
+      -> (tensor<1x128x4096xf16>, tensor<1x8x128x128xf16>)
+    "onnx.Return"(%0#0, %0#1)
+        : (tensor<1x128x4096xf16>, tensor<1x8x128x128xf16>) -> ()
+  }
+  "onnx.EntryPoint"() {func = @main_graph} : () -> ()
+}

--- a/tools/hip-mlir-opt/hip-mlir-opt.cpp
+++ b/tools/hip-mlir-opt/hip-mlir-opt.cpp
@@ -125,6 +125,8 @@ void registerHipBufferizableOpInterfaceModels(mlir::DialectRegistry &registry) {
         HipDstBufferizableModel<mlir::hip::MatMulNBitsOp>>(*ctx);
     mlir::hip::QMoEOp::attachInterface<
         HipDstBufferizableModel<mlir::hip::QMoEOp>>(*ctx);
+    mlir::hip::LinearAttentionOp::attachInterface<
+        HipDstBufferizableModel<mlir::hip::LinearAttentionOp>>(*ctx);
     mlir::hip::HipDNNGraphOp::attachInterface<
         HipDstBufferizableModel<mlir::hip::HipDNNGraphOp>>(*ctx);
   });


### PR DESCRIPTION
## Motivation
https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#com.microsoft.LinearAttention
Linear attention models (GLA, DeltaNet, RWKV-6, RetNet) use recurrent state updates instead of softmax attention. This PR adds end-to-end support for `com.microsoft.LinearAttention`, enabling T=1 autoregressive decoding on AMD GPUs via a custom HIP kernel.
## Details
- Define `hip.linear_attention` op in HipOps.td with optional inputs (past_state, decay, beta) and `AttrSizedOperandSegments`
- ONNX→HIP conversion: match `onnx.Custom` by `function_name="LinearAttention"` / `domain_name="com.microsoft"`, handle 3–6 operands
- HIP→LLVM lowering: emit 19-parameter `wrap_linear_attention` runtime call with shape info derived from query and present_state types
- Runtime wrapper: state initialization (memcpy/memset) + dispatch to custom kernel for T=1; explicit error for T>1 (not yet implemented)
- Fused T=1 decode GPU kernel (`linear_attention_kernel.hip`): one block per (batch, kv_head), 3-phase design (S^T@k → state update → output), float accumulation, fp16/fp32 template support, all 4 update rules (linear, gated, delta, gated_delta)
- Cleanup: remove unused `SoftplusOp`, simplify `SigmoidOp` field naming (x/y → input/output)
## Test Plan
- [x] lit: ONNX→HIP conversion (linear / gated / delta / gated_delta modes)
- [x] lit: HIP→LLVM lowering (verify 19-param call signature)
- [x] Build succeeds with correct `HIP_ARCHITECTURES`
- [x] T=1 decode produces correct output against CPU reference for all 4 update rules
- [x] seq_len > 1 run success
- [x] No regression on existing activation / GQA tests
- [x] accuracy test with Qwen3.5 split model