### PR TITLE
feat: unified constants emit path with pre-initialized GPU upload for ORT EP

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -581,7 +581,7 @@ jobs:
               --plugin_eps "MorphiZenExecutionProvider" `
               --plugin_ep_options "config_file|..\morphizen_config.json" `
               -C "session.disable_cpu_ep_fallback|1 ep.context_enable|1 ep.context_embed_mode|0 ep.context_file_path|$ctxPath" `
-              -t 5 -c 1 -s `
+              -t 5 -c 1 -s -I `
               $m.FullName 2>&1 | Tee-Object -FilePath $exportFile
             if ($LASTEXITCODE -ne 0) {
               Add-Content $exportFile "[ERROR] EPContext export failed"
@@ -601,7 +601,7 @@ jobs:
               --plugin_eps "MorphiZenExecutionProvider" `
               --plugin_ep_options "config_file|..\morphizen_config.json" `
               -C "session.disable_cpu_ep_fallback|1" `
-              -t 30 -c 1 -s `
+              -t 30 -c 1 -s -I `
               $ctxPath 2>&1 | Tee-Object -FilePath $importFile
             if ($LASTEXITCODE -ne 0) { $failed = 1 }
 

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -533,6 +533,84 @@ jobs:
           )
           exit /b %FAILED%
 
+      # ----------------------------------------------------------------------
+      # EPContext export + import perf test (PR #132 sidecar-in-tar path).
+      # Limited to full_model_seq128 to bound runtime: each model triggers
+      # one export pass (~60 s + N GB sidecar write) plus one import perf
+      # pass (-t 30). The _ctx.onnx + _MORPHIZEN.bin are deleted right after
+      # import to keep runner disk usage bounded.
+      # ----------------------------------------------------------------------
+      - name: Run EPContext export/import perf test (GPU)
+        if: always()
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Continue'
+          $PSNativeCommandUseErrorActionPreference = $false
+          $env:THEROCK_DIST = "${{ runner.workspace }}\therock-dist"
+          $pkgBin = Join-Path $PWD "gpu-test-package\bin"
+          $env:PATH = "${{ runner.workspace }}\therock-dist\bin;$pkgBin;$env:PATH"
+          $env:LIB = (Join-Path $PWD "gpu-test-package\lib") + ";${{ runner.workspace }}\therock-dist\lib"
+
+          $modelDir = "${{ runner.workspace }}\model"
+          if (-not (Test-Path $modelDir)) {
+            Write-Host "[SKIP] MODEL_DIR not found: $modelDir"
+            exit 0
+          }
+          $models = @(Get-ChildItem $modelDir -Recurse -Filter "full_model_seq128.onnx" -ErrorAction SilentlyContinue)
+          if ($models.Count -eq 0) {
+            Write-Host "[SKIP] No full_model_seq128.onnx in $modelDir"
+            exit 0
+          }
+
+          New-Item -ItemType Directory -Force -Path "gpu-test-package\results-epctx-export" | Out-Null
+          New-Item -ItemType Directory -Force -Path "gpu-test-package\results-epctx-import" | Out-Null
+          $cacheDir = Join-Path $PWD "gpu-test-package\epctx-cache"
+          New-Item -ItemType Directory -Force -Path $cacheDir | Out-Null
+
+          $failed = 0
+          Push-Location gpu-test-package\bin
+          foreach ($m in $models) {
+            $exportFile = "..\results-epctx-export\$($m.Name).txt"
+            $importFile = "..\results-epctx-import\$($m.Name).txt"
+            $ctxPath = Join-Path $cacheDir "$($m.BaseName)_ctx.onnx"
+            Remove-Item "$ctxPath*" -ErrorAction SilentlyContinue
+
+            Write-Host "=== EPContext export: $($m.Name) ==="
+            & .\onnxruntime_perf_test.exe `
+              --plugin_ep_libs "MorphiZenExecutionProvider|onnxruntime_morphizen_ep.dll" `
+              --plugin_eps "MorphiZenExecutionProvider" `
+              --plugin_ep_options "config_file|..\morphizen_config.json" `
+              -C "session.disable_cpu_ep_fallback|1 ep.context_enable|1 ep.context_embed_mode|0 ep.context_file_path|$ctxPath" `
+              -t 5 -c 1 -s `
+              $m.FullName 2>&1 | Tee-Object -FilePath $exportFile
+            if ($LASTEXITCODE -ne 0) {
+              Add-Content $exportFile "[ERROR] EPContext export failed"
+              $failed = 1
+              Remove-Item "$ctxPath*" -ErrorAction SilentlyContinue
+              continue
+            }
+            if (-not (Test-Path $ctxPath)) {
+              Add-Content $exportFile "[ERROR] _ctx.onnx not produced"
+              $failed = 1
+              continue
+            }
+
+            Write-Host "=== EPContext import: $($m.Name) ==="
+            & .\onnxruntime_perf_test.exe `
+              --plugin_ep_libs "MorphiZenExecutionProvider|onnxruntime_morphizen_ep.dll" `
+              --plugin_eps "MorphiZenExecutionProvider" `
+              --plugin_ep_options "config_file|..\morphizen_config.json" `
+              -C "session.disable_cpu_ep_fallback|1" `
+              -t 30 -c 1 -s `
+              $ctxPath 2>&1 | Tee-Object -FilePath $importFile
+            if ($LASTEXITCODE -ne 0) { $failed = 1 }
+
+            Remove-Item "$ctxPath*" -ErrorAction SilentlyContinue
+          }
+          Pop-Location
+          Remove-Item $cacheDir -Recurse -Force -ErrorAction SilentlyContinue
+          exit $failed
+
       # -----------------------------------------------------------------------
       # OGA benchmark: run model_benchmark against pre-placed LLM models.
       # Models are at ${{ runner.workspace }}/oga-models/<model>/
@@ -748,32 +826,53 @@ jobs:
           $sha = $rawSha.Substring(0, 7)
           $prNumber = "${{ github.event.pull_request.number }}"
 
-          # Build table rows from result files
-          $tableRows = ""
-          foreach ($f in (Get-ChildItem "$resultsDir/*.txt" -ErrorAction SilentlyContinue)) {
-            $model = $f.BaseName -replace '\.onnx$', ''
-            $content = Get-Content $f.FullName -Raw
-            $qpsMatch = [regex]::Match($content, 'Number of inferences per second:\s+([\d.]+)')
-            $sessMatch = [regex]::Match($content, 'Session creation time cost:\s+([\d.]+)\s+s')
-            $firstMatch = [regex]::Match($content, 'First inference time cost:\s+(\d+)\s+ms')
-            $cpuMatch = [regex]::Match($content, 'Avg CPU usage:\s+(\d+)\s+%')
-            $memMatch = [regex]::Match($content, 'Peak working set size:\s+(\d+)\s+bytes')
-            $sess = if ($sessMatch.Success) { $sessMatch.Groups[1].Value } else { "-" }
-            $first = if ($firstMatch.Success) { $firstMatch.Groups[1].Value } else { "-" }
-            $cpu = if ($cpuMatch.Success) { $cpuMatch.Groups[1].Value } else { "-" }
-            $memMB = if ($memMatch.Success) { "{0:F0}" -f ([double]$memMatch.Groups[1].Value / 1MB) } else { "-" }
-            if ($qpsMatch.Success) {
-              $qps = "{0:F2}" -f [double]$qpsMatch.Groups[1].Value
-              $tableRows += "| $model | $qps | $sess | $first | $cpu | $memMB |`n"
-            } else {
-              $tableRows += "| $model | failed | $sess | $first | $cpu | $memMB |`n"
+          # Helper: build table rows from a results dir.
+          # Each file: extract Number of inferences per second / Session
+          # creation / 1st infer / Avg CPU / Peak WS for the standard
+          # 6-column format (Model | QPS | Session (s) | 1st Infer (ms) |
+          # CPU% | Mem (MB)).
+          function Get-PerfRows($dir) {
+            $rows = ""
+            foreach ($f in (Get-ChildItem "$dir/*.txt" -ErrorAction SilentlyContinue)) {
+              $model = $f.BaseName -replace '\.onnx$', ''
+              $content = Get-Content $f.FullName -Raw
+              $qpsMatch = [regex]::Match($content, 'Number of inferences per second:\s+([\d.]+)')
+              $sessMatch = [regex]::Match($content, 'Session creation time cost:\s+([\d.]+)\s+s')
+              $firstMatch = [regex]::Match($content, 'First inference time cost:\s+(\d+)\s+ms')
+              $cpuMatch = [regex]::Match($content, 'Avg CPU usage:\s+(\d+)\s+%')
+              $memMatch = [regex]::Match($content, 'Peak working set size:\s+(\d+)\s+bytes')
+              $sess = if ($sessMatch.Success) { $sessMatch.Groups[1].Value } else { "-" }
+              $first = if ($firstMatch.Success) { $firstMatch.Groups[1].Value } else { "-" }
+              $cpu = if ($cpuMatch.Success) { $cpuMatch.Groups[1].Value } else { "-" }
+              $memMB = if ($memMatch.Success) { "{0:F0}" -f ([double]$memMatch.Groups[1].Value / 1MB) } else { "-" }
+              if ($qpsMatch.Success) {
+                $qps = "{0:F2}" -f [double]$qpsMatch.Groups[1].Value
+                $rows += "| $model | $qps | $sess | $first | $cpu | $memMB |`n"
+              } else {
+                $rows += "| $model | failed | $sess | $first | $cpu | $memMB |`n"
+              }
             }
+            return $rows
           }
+
+          # Build table rows from result files
+          $tableRows = Get-PerfRows $resultsDir
           if (-not $tableRows) { $tableRows = "| (no results) | - | - | - | - | - |`n" }
 
-          $header = "## MorphiZen EP Performance Results`n`n" +
-                    "| Model | QPS | Session (s) | 1st Infer (ms) | CPU% | Mem (MB) |`n" +
-                    "|-------|----:|----:|----:|----:|----:|`n"
+          $perfHeader = "| Model | QPS | Session (s) | 1st Infer (ms) | CPU% | Mem (MB) |`n" +
+                        "|-------|----:|----:|----:|----:|----:|`n"
+          $header = "## MorphiZen EP Performance Results`n`n" + $perfHeader
+
+          # EPContext export/import perf tables (full_model_seq128 only).
+          $epctxExportRows = Get-PerfRows "gpu-test-package/results-epctx-export"
+          $epctxImportRows = Get-PerfRows "gpu-test-package/results-epctx-import"
+          $epctxSection = ""
+          if ($epctxExportRows) {
+            $epctxSection += "`n## EPContext Export Performance`n`n" + $perfHeader + $epctxExportRows
+          }
+          if ($epctxImportRows) {
+            $epctxSection += "`n## EPContext Import Performance`n`n" + $perfHeader + $epctxImportRows
+          }
 
           # --- OGA benchmark results ---
           $ogaRows = ""
@@ -797,7 +896,7 @@ jobs:
           }
 
           $footer = "`nRun: [${{ github.run_number }}]($runUrl) - Commit: ``$sha``"
-          $summary = $header + $tableRows + $ogaSection + $footer
+          $summary = $header + $tableRows + $epctxSection + $ogaSection + $footer
 
           # Always write to step summary and log
           Write-Host $summary

--- a/backend-mlir-compiler/level-1-pass/src/MlirCompiler.cpp
+++ b/backend-mlir-compiler/level-1-pass/src/MlirCompiler.cpp
@@ -47,6 +47,8 @@ std::string build_compiler_options_json(const CompilationConfig &config) {
   json << "{";
   json << "\"opt_level\": " << config.optLevel;
   json << ", \"output_mode\": \"DLL\"";
+  json << ", \"skip_constant_data\": "
+       << (config.skipConstantData ? "true" : "false");
   json << "}";
   return json.str();
 }

--- a/backend-mlir-compiler/level-1-pass/src/MlirCompiler.h
+++ b/backend-mlir-compiler/level-1-pass/src/MlirCompiler.h
@@ -19,9 +19,19 @@ namespace hipdnn::level1pass {
 enum class ArtifactFormat { Native, LlvmIr };
 
 // Compilation configuration
+//
+// `skipConstantData` selects the OnnxToHip finalize output:
+//   * true  -> per-entry source (descriptors baked into __metadata_blob;
+//              MlirCustomOp ctor streams constants into the GPU blob)
+//   * false -> sidecar  (model.constants.bin + .json; MlirCustomOp ctor
+//              goes through inference_init -> init_with_fs bulk hipMemcpy)
+// The in-process EP path decides this inside pass_main::load_config based
+// on ep.context_enable; EPContext export forces sidecar. The struct default
+// (true / streaming) only applies to code paths that bypass load_config.
 struct CompilationConfig {
   ArtifactFormat artifactFormat;
   int optLevel;
+  bool skipConstantData = true;
 };
 
 // Compiled artifact (bytes + metadata)

--- a/backend-mlir-compiler/level-1-pass/src/pass_main.cpp
+++ b/backend-mlir-compiler/level-1-pass/src/pass_main.cpp
@@ -42,6 +42,10 @@ static CompilationConfig load_config(PassContext *ctx) {
   config.artifactFormat = ArtifactFormat::Native;
   config.optLevel = 2;
 
+  auto ep_ctx = ctx->get_session_config("ep.context_enable");
+  bool epctxExport = ep_ctx.has_value() && ep_ctx.value() == "1";
+  config.skipConstantData = !epctxExport;
+
   try {
     // Parse artifact format
     std::string artifact_format_str =
@@ -65,7 +69,11 @@ static CompilationConfig load_config(PassContext *ctx) {
 
   MY_LOG(1) << "Artifact format: "
             << (config.artifactFormat == ArtifactFormat::Native ? "native"
-                                                                : "llvm_ir");
+                                                                : "llvm_ir")
+            << "; skipConstantData="
+            << (config.skipConstantData ? "true" : "false")
+            << (epctxExport ? " (EPContext export -> sidecar)"
+                            : " (streaming default)");
 
   return config;
 }

--- a/docs/design/constant-handling-design.md
+++ b/docs/design/constant-handling-design.md
@@ -205,8 +205,9 @@ runtime reads `constants_filename` and per-constant offsets, then:
 
 1. Opens the configured constants file via `fs`.
 2. Reads the file size and allocates a single GPU buffer for the entire
-   constants blob (`hipMalloc`). On iGPU (integrated GPU), pinned host memory
-   (`hipHostMalloc`) is used instead and the GPU reads in-place without a copy.
+   constants blob (`hipMalloc`). Same path on both dGPU and iGPU — the
+   one-time copy cost at init is negligible compared to per-inference VRAM
+   access savings.
 3. Copies the file contents into the GPU buffer in one operation.
 4. Sets each per-constant GPU pointer to the stored offset within the buffer —
    no per-constant allocation or copy.

--- a/docs/technical-pipeline-walkthrough.md
+++ b/docs/technical-pipeline-walkthrough.md
@@ -571,8 +571,7 @@ struct RuntimeState {
   miopenHandle_t miopen_handle;    // MIOpen library handle (conv, activation, norm)
   hipblasLtHandle_t hipblas_handle;// hipBLASLt handle (matmul/GEMM)
 
-  void *gpu_constants_blob;        // Model weights on GPU (single allocation)
-  bool constants_blob_is_host;     // true = iGPU pinned memory, false = dGPU VRAM
+  void *gpu_constants_blob;        // Model weights on GPU (single allocation, VRAM)
   void **gpu_constants;            // Per-constant pointers into the blob
   size_t num_constants;
 

--- a/include/hip/Conversion/OnnxToHip/ConstantsIO.h
+++ b/include/hip/Conversion/OnnxToHip/ConstantsIO.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// Shared emit logic for the constants.bin sidecar.
+//
+// Both the ONNX->HIP conversion pass (standalone hip-compiler offline path)
+// and the MorphiZen EP level-1 pass (EPContext export path) produce the same
+// constants.bin layout. This header provides a single implementation they
+// call, preserving the streaming-with-1MB-tile pattern for splat constants so
+// no full-size expansion buffer is allocated during write.
+
+#ifndef HIP_CONVERSION_ONNXTOHIP_CONSTANTSIO_H
+#define HIP_CONVERSION_ONNXTOHIP_CONSTANTSIO_H
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace morphizen {
+class FileSystem;
+} // namespace morphizen
+
+namespace mlir {
+namespace hip {
+
+/// One constant's placement and source in the constants.bin layout.
+///
+/// Three source kinds are supported (mutually exclusive, decided by which
+/// fields are non-default):
+///   * mem-addr / inline:  `file_path` empty, `splat_elem_size == 0` →
+///                         `data` points at a `size`-byte buffer (MLIR raw
+///                         data, ORT mmap address, or caller-owned).
+///   * splat:              `file_path` empty, `splat_elem_size > 0` →
+///                         `data` points at a single element's bytes that
+///                         the writer tile-expands to `size` bytes.
+///   * file-ref:           `file_path` non-empty → writer fopens the file
+///                         and freads `size` bytes from `file_offset`. The
+///                         `data` pointer is ignored. This is the path that
+///                         lets the EP avoid mmap'ing multi-GB external
+///                         data into the system page cache.
+///
+/// `data` lifetime (when used) is the caller's responsibility and must
+/// cover the call to `writeConstantsBinToFileSystem`.
+struct ConstantEntry {
+  std::string name;
+  int64_t offset = 0;          // aligned offset in constants.bin
+  int64_t size = 0;            // total byte size after splat expansion
+  const void *data = nullptr;  // mmap addr / rawData.data() / owned buffer
+  int64_t splat_elem_size = 0; // 0 = data is already `size` bytes; >0 = splat
+  std::string file_path;       // non-empty: read from disk on demand
+  int64_t file_offset = 0;     // byte offset within file_path
+};
+
+/// Write a constants.bin with alignment padding and tiled splat expansion
+/// to a FileSystem entry. Streams via the writer's fwrite; for splat entries
+/// a 1 MB scratch tile buffer is reused across the iterated writes, so peak
+/// host memory is bounded regardless of individual constant size.
+///
+/// Returns true on success; false if the writer could not be opened or a
+/// splat entry has invalid element size.
+bool writeConstantsBinToFileSystem(morphizen::FileSystem *fs,
+                                   const std::string &filename,
+                                   const std::vector<ConstantEntry> &entries,
+                                   int64_t totalBlobSize);
+
+} // namespace hip
+} // namespace mlir
+
+#endif // HIP_CONVERSION_ONNXTOHIP_CONSTANTSIO_H

--- a/include/hip/Conversion/OnnxToHip/Passes.h
+++ b/include/hip/Conversion/OnnxToHip/Passes.h
@@ -25,7 +25,8 @@ std::unique_ptr<Pass> createConvertOnnxToHipPass();
 /// instead of a DiskFileSystem rooted at the output directory.
 std::unique_ptr<Pass> createConvertOnnxToHipPass(
     morphizen::FileSystem *fs,
-    int64_t minNumElements = kDefaultExternalizeMinNumElements);
+    int64_t minNumElements = kDefaultExternalizeMinNumElements,
+    bool skipConstantData = false);
 
 } // namespace hip
 } // namespace mlir

--- a/include/hip/Dialect/Transforms/Pipelines.h
+++ b/include/hip/Dialect/Transforms/Pipelines.h
@@ -42,6 +42,11 @@ struct OnnxToHipPipelineOptions
       llvm::cl::desc(
           "Minimum number of tensor elements to externalize (0 = disabled)"),
       llvm::cl::init(0)};
+  Option<bool> skipConstantData{
+      *this, "skip-constant-data",
+      llvm::cl::desc("Skip writing constant data to constants.bin (metadata "
+                     "only). Used for ORT EP live-compile path."),
+      llvm::cl::init(false)};
 };
 
 /// Pipeline options for the HIP-to-LLVM lowering pipeline.

--- a/lib/CInterface/CompilerAPI.cpp
+++ b/lib/CInterface/CompilerAPI.cpp
@@ -27,9 +27,11 @@ static const char *COMPILER_VERSION = "1.0.0";
 
 // Parse JSON into CompilationOptionsT (defined in
 // schemas/compilation_options.fbs). Key fields:
-//   opt_level      — LLVM optimization level 0-3 (default 2)
-//   output_mode    — DLL or LLVM_IR (default DLL)
-//   constants_file — externalized weights filename (default "constants.bin")
+//   opt_level          — LLVM optimization level 0-3 (default 2)
+//   output_mode        — DLL or LLVM_IR (default DLL)
+//   constants_file     — externalized weights filename (default
+//   "constants.bin") skip_constant_data — skip writing constant bytes (default
+//   false)
 static bool parseOptions(const char *options_json,
                          mlir::hip::CompilationOptionsT &opts,
                          std::string &error_message) {

--- a/lib/Compiler/CompilerDriver.cpp
+++ b/lib/Compiler/CompilerDriver.cpp
@@ -205,6 +205,7 @@ bool CompilerDriver::runMLIRPasses(
   mlir::hip::OnnxToHipPipelineOptions onnxToHipOpts;
   onnxToHipOpts.externalizeMinNumElements =
       mlir::hip::kDefaultExternalizeMinNumElements;
+  onnxToHipOpts.skipConstantData = options.skip_constant_data;
 
   if (hipdnnHandle_) {
     compiledGraphs_ =

--- a/lib/Conversion/OnnxToHip/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHip/CMakeLists.txt
@@ -5,6 +5,7 @@
 
 add_library(OnnxToHip STATIC
   OnnxToHip.cpp
+  ConstantsIO.cpp
   MatMulConversion.cpp
   TransposeConversion.cpp
   ElementwiseConversion.cpp

--- a/lib/Conversion/OnnxToHip/ConstantsIO.cpp
+++ b/lib/Conversion/OnnxToHip/ConstantsIO.cpp
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "hip/Conversion/OnnxToHip/ConstantsIO.h"
+#include "morphizen-foundation/file_io.hpp"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+namespace mlir {
+namespace hip {
+
+// Fills the gap between `pos` and `targetOffset` with zeros using a small
+// shared buffer; advances `pos`.
+static bool writePaddingTo(morphizen::FileWriter *writer, int64_t &pos,
+                           int64_t targetOffset) {
+  static constexpr size_t kZeroChunk = 4096;
+  static const char zeros[kZeroChunk] = {};
+  if (targetOffset < pos)
+    return false;
+  int64_t padding = targetOffset - pos;
+  while (padding > 0) {
+    size_t chunk = static_cast<size_t>(
+        std::min<int64_t>(padding, static_cast<int64_t>(kZeroChunk)));
+    writer->fwrite(zeros, chunk);
+    padding -= chunk;
+  }
+  pos = targetOffset;
+  return true;
+}
+
+// Tile-fills a 1 MB scratch buffer with the single element value, then
+// writes it repeatedly until `size` bytes have been emitted. Preserves the
+// historical OnnxToHip splat-write behavior, bounding peak host memory
+// independent of individual constant size.
+static void writeSplat(morphizen::FileWriter *writer, const void *elemBytes,
+                       int64_t elemSize, int64_t size) {
+  static constexpr size_t kSplatChunk = 1024 * 1024;
+  size_t elem = static_cast<size_t>(elemSize);
+  size_t bufSize =
+      (std::min(static_cast<size_t>(size), kSplatChunk) / elem) * elem;
+  if (bufSize == 0)
+    bufSize = elem;
+  std::vector<char> buf(bufSize);
+  for (size_t i = 0; i < bufSize; i += elem)
+    std::memcpy(buf.data() + i, elemBytes, elem);
+
+  size_t remaining = static_cast<size_t>(size);
+  while (remaining > 0) {
+    size_t toWrite = std::min(remaining, bufSize);
+    writer->fwrite(buf.data(), toWrite);
+    remaining -= toWrite;
+  }
+}
+
+namespace {
+// Keeps FILE* handles open across consecutive entries that read from the
+// same external-data file. With ORT-style external data layouts most or
+// all tensors of a model share one weights.data file, so caching avoids
+// hundreds of fopen/fclose round trips.
+struct FileHandleCache {
+  ~FileHandleCache() {
+    for (auto &kv : handles)
+      if (kv.second)
+        std::fclose(kv.second);
+  }
+  std::FILE *get(const std::string &path) {
+    auto it = handles.find(path);
+    if (it != handles.end())
+      return it->second;
+    std::FILE *f = std::fopen(path.c_str(), "rb");
+    handles.emplace(path, f);
+    return f;
+  }
+  std::unordered_map<std::string, std::FILE *> handles;
+};
+} // namespace
+
+// Streams `size` bytes from `file_path` at `file_offset` through a fixed
+// 1 MB buffer into the writer. Bounded peak host memory, identical pattern
+// to writeSplat so the constants.bin emission stays predictable.
+static bool writeFileRef(FileHandleCache &cache, morphizen::FileWriter *writer,
+                         const std::string &file_path, int64_t file_offset,
+                         int64_t size) {
+  static constexpr size_t kReadChunk = 1024 * 1024;
+  std::FILE *f = cache.get(file_path);
+  if (!f)
+    return false;
+#ifdef _WIN32
+  if (_fseeki64(f, file_offset, SEEK_SET) != 0)
+    return false;
+#else
+  if (std::fseek(f, static_cast<long>(file_offset), SEEK_SET) != 0)
+    return false;
+#endif
+  std::vector<char> buf(
+      std::min<size_t>(static_cast<size_t>(size), kReadChunk));
+  size_t remaining = static_cast<size_t>(size);
+  while (remaining > 0) {
+    size_t toRead = std::min(remaining, buf.size());
+    size_t got = std::fread(buf.data(), 1, toRead, f);
+    if (got != toRead)
+      return false;
+    writer->fwrite(buf.data(), got);
+    remaining -= got;
+  }
+  return true;
+}
+
+bool writeConstantsBinToFileSystem(morphizen::FileSystem *fs,
+                                   const std::string &filename,
+                                   const std::vector<ConstantEntry> &entries,
+                                   int64_t totalBlobSize) {
+  if (!fs)
+    return false;
+  auto writer = fs->create_writer_template(filename.c_str());
+  if (!writer)
+    return false;
+
+  FileHandleCache fileCache;
+
+  int64_t pos = 0;
+  for (const auto &e : entries) {
+    if (!writePaddingTo(writer.get(), pos, e.offset))
+      return false;
+    if (!e.file_path.empty()) {
+      if (!writeFileRef(fileCache, writer.get(), e.file_path, e.file_offset,
+                        e.size))
+        return false;
+    } else if (e.splat_elem_size > 0) {
+      writeSplat(writer.get(), e.data, e.splat_elem_size, e.size);
+    } else {
+      writer->fwrite(e.data, static_cast<size_t>(e.size));
+    }
+    pos += e.size;
+  }
+  // Trailing padding up to the declared total size, in case the final
+  // constant ended before the aligned blob boundary. Typically a no-op.
+  if (totalBlobSize > pos)
+    writePaddingTo(writer.get(), pos, totalBlobSize);
+  return true;
+}
+
+} // namespace hip
+} // namespace mlir

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -13,6 +13,7 @@
 
 #include "OnnxToHipUtils.h"
 
+#include "hip/Conversion/OnnxToHip/ConstantsIO.h"
 #include "hip/Support/DiskFileSystem.h"
 #include "hip/timing.h"
 #include "morphizen-foundation/file_io.hpp"
@@ -31,6 +32,9 @@
 #include "llvm/Support/raw_ostream.h"
 
 #include <chrono>
+#include <cstring>
+#include <fstream>
+#include <vector>
 
 #define DEBUG_TYPE "convert-onnx-to-hip"
 
@@ -76,31 +80,50 @@ static int64_t alignTo(int64_t value, int64_t alignment) {
 }
 
 /// Mutable state shared across calls to lowerOnnxConstants when
-/// externalization is enabled.
+/// externalization is enabled. Constants are collected here during the
+/// walk; the finalize step in runOnOperation emits either constants.bin
+/// (skipDataWrite=false) via the shared ConstantsIO helper, or per-entry
+/// source descriptors as module attrs (skipDataWrite=true) that
+/// GenerateInterface bakes into __metadata_blob.ConstantInfo.source.
 struct ExternalizationState {
-  std::unique_ptr<morphizen::FileWriter,
-                  morphizen::FileSystem::Deleter<morphizen::FileWriter>>
-      writer;
   llvm::json::Array manifestEntries;
   int64_t currentOffset = 0;
   int64_t constantIndex = 0;
   std::string binFileName;
   llvm::SmallVector<int64_t> constantSizes;
   llvm::SmallVector<int64_t> constantOffsets;
+  bool skipDataWrite = false;
+  llvm::SmallVector<std::string> constantNames;
+
+  // One descriptor per constant, in emission order. The descriptor encodes
+  // one of three sources:
+  //   * mem-addr / inline: `ptr` points at data owned elsewhere
+  //     (DenseElementsAttr rawData held by MLIRContext) and stays valid
+  //     through runOnOperation's end.
+  //   * splat: `splatElemSize > 0` and `ptr` points at the single element
+  //     bytes; the finalize emitter tile-expands on the fly.
+  //   * file-ref: `filePath` is non-empty; `fileOffset` is the byte offset
+  //     within that file. The runtime is expected to fread the data on
+  //     demand into a small staging buffer instead of mmap'ing the whole
+  //     external-data file. This is the path that avoids ORT mmap for
+  //     multi-GB models.
+  struct HostEntry {
+    const void *ptr = nullptr;
+    int64_t splatElemSize = 0;
+    std::string filePath; // empty unless file-ref
+    int64_t fileOffset = 0;
+  };
+  llvm::SmallVector<HostEntry> constantHostPtrs;
 };
 
-/// Write alignment padding to constants.bin and return the aligned byte
-/// offset where the next constant's data should begin.
+/// Advance `currentOffset` to the next aligned boundary. The actual
+/// padding bytes are emitted by the finalize step (writeConstantsBin*);
+/// in transfer-file mode padding is implicit in the recorded offsets.
 static int64_t writeAlignmentPadding(ExternalizationState *extState,
                                      int64_t alignment = 64) {
   int64_t aligned = llvm::alignTo(extState->currentOffset, alignment);
-  int64_t padding = aligned - extState->currentOffset;
-  if (padding > 0) {
-    llvm::SmallVector<char> zeros(padding, 0);
-    extState->writer->fwrite(zeros.data(), padding);
-    extState->currentOffset += padding;
-  }
-  return extState->currentOffset;
+  extState->currentOffset = aligned;
+  return aligned;
 }
 
 /// Shared bookkeeping after constant data has been written to constants.bin.
@@ -117,16 +140,31 @@ static void finalizeExternalizedConstant(mlir::ModuleOp module,
       mlir::MemRefType::get(tensorType.getShape(), tensorType.getElementType());
 
   std::string name = "hip_ext_constant_";
+  std::string onnxName;
   if (auto nodeNameAttr =
           constOp->getAttrOfType<mlir::StringAttr>("onnx_node_name")) {
+    onnxName = nodeNameAttr.getValue().str();
     std::string fragment = sanitizeForMlirIdentifier(nodeNameAttr.getValue());
     if (!fragment.empty())
       name += fragment + "_";
+  }
+  // Initializers have their tensor name in "node.outputs" (the output NodeArg
+  // name), not in "onnx_node_name" (the NodeProto.name which may be empty).
+  if (onnxName.empty()) {
+    if (auto outputsAttr =
+            constOp->getAttrOfType<mlir::ArrayAttr>("node.outputs")) {
+      if (outputsAttr.size() > 0) {
+        if (auto strAttr =
+                mlir::dyn_cast<mlir::StringAttr>(outputsAttr.getValue()[0]))
+          onnxName = strAttr.getValue().str();
+      }
+    }
   }
   name += std::to_string(extState->constantIndex);
 
   extState->constantSizes.push_back(byteSize);
   extState->constantOffsets.push_back(entryOffset);
+  extState->constantNames.push_back(onnxName);
 
   llvm::json::Array shapeArray;
   for (int64_t dim : tensorType.getShape())
@@ -178,7 +216,34 @@ static void externalizeConstant(mlir::ModuleOp module, mlir::Operation *constOp,
                                 const void *rawPtr, int64_t byteSize,
                                 ExternalizationState *extState) {
   int64_t entryOffset = writeAlignmentPadding(extState);
-  extState->writer->fwrite(rawPtr, byteSize);
+  // Always collect layout + host pointer. The finalize step decides whether
+  // to emit constants.bin (skipDataWrite=false) or module attrs encoding
+  // the per-constant source (skipDataWrite=true). DenseElementsAttr raw
+  // data / ORT mmap addresses
+  // remain valid through runOnOperation, so recording the pointer here is
+  // safe for both consumers.
+  ExternalizationState::HostEntry entry;
+  entry.ptr = rawPtr;
+  extState->constantHostPtrs.push_back(std::move(entry));
+  extState->currentOffset += byteSize;
+  finalizeExternalizedConstant(module, constOp, tensorType, byteSize,
+                               entryOffset, extState);
+}
+
+/// Record a file-ref entry: data lives on disk at (filePath, fileOffset)
+/// and must be fread by the runtime into a staging buffer at upload time.
+/// Avoids holding any of the data in host memory during compilation.
+static void externalizeFileRefConstant(mlir::ModuleOp module,
+                                       mlir::Operation *constOp,
+                                       mlir::RankedTensorType tensorType,
+                                       const std::string &filePath,
+                                       int64_t fileOffset, int64_t byteSize,
+                                       ExternalizationState *extState) {
+  int64_t entryOffset = writeAlignmentPadding(extState);
+  ExternalizationState::HostEntry entry;
+  entry.filePath = filePath;
+  entry.fileOffset = fileOffset;
+  extState->constantHostPtrs.push_back(std::move(entry));
   extState->currentOffset += byteSize;
   finalizeExternalizedConstant(module, constOp, tensorType, byteSize,
                                entryOffset, extState);
@@ -194,8 +259,11 @@ static void replaceWithArithConstant(mlir::Operation *constOp,
   constOp->erase();
 }
 
-/// Externalize a splat constant: expand the single element via chunked
-/// writes to avoid allocating the full tensor in memory.
+/// Externalize a splat constant: record only the single element bytes.
+/// The finalize step (constants.bin emit OR transfer-file emit) tiles the
+/// element value on the fly, so we never allocate a full-size buffer here.
+/// DenseElementsAttr's raw data is owned by the MLIRContext and stays
+/// valid through runOnOperation.
 static void externalizeSplatConstant(mlir::ModuleOp module,
                                      mlir::Operation *constOp,
                                      mlir::RankedTensorType tensorType,
@@ -203,86 +271,120 @@ static void externalizeSplatConstant(mlir::ModuleOp module,
                                      int64_t byteSize,
                                      ExternalizationState *extState) {
   auto rawData = valueAttr.getRawData();
-  constexpr size_t kSplatChunk = 1024 * 1024;
-  size_t elemSize = rawData.size();
-  size_t bufSize =
-      (std::min(static_cast<size_t>(byteSize), kSplatChunk) / elemSize) *
-      elemSize;
-  std::vector<char> buf(bufSize);
-  for (size_t i = 0; i < bufSize; i += elemSize)
-    std::memcpy(buf.data() + i, rawData.data(), elemSize);
-
   int64_t entryOffset = writeAlignmentPadding(extState);
-  size_t remaining = static_cast<size_t>(byteSize);
-  while (remaining > 0) {
-    size_t toWrite = std::min(remaining, bufSize);
-    extState->writer->fwrite(buf.data(), toWrite);
-    remaining -= toWrite;
-  }
+  ExternalizationState::HostEntry entry;
+  entry.ptr = rawData.data();
+  entry.splatElemSize = static_cast<int64_t>(rawData.size());
+  extState->constantHostPtrs.push_back(std::move(entry));
   extState->currentOffset += byteSize;
   finalizeExternalizedConstant(module, constOp, tensorType, byteSize,
                                entryOffset, extState);
 }
 
-/// Resolve an onnx.Constant that carries a `location` attribute
-/// (zero-copy external data emitted by the ORT bridge).
-/// The `offset` attribute holds a raw memory address (ORT tensor pointer
-/// cast to i64) and `size` holds the byte count.
+/// Resolve an onnx.Constant that carries a `location` attribute (zero-copy
+/// external data emitted by the ORT bridge). The `location` string selects
+/// one of two semantics:
 ///
-/// Input IR (produced by ir-converter-imp.cpp):
+///   * "*/_ORT_MEM_ADDR_/*"  -> `offset` is a raw memory address (ORT tensor
+///     pointer cast to i64) that the data lives at right now. Used for
+///     inline raw_data and (legacy) ORT mmap-resolved tensors.
+///   * <other string>        -> `offset` is a byte offset within the file
+///     at the given absolute path. Data is NOT in memory; the runtime is
+///     expected to fread it on demand. This is the path that avoids ORT
+///     mmap'ing multi-GB external-data files into the system page cache.
+///
+/// Input IR (produced by ir-converter-imp.cpp), mem-addr form:
 ///
 ///   %cst = "onnx.Constant"()
 ///       {location = "*/_ORT_MEM_ADDR_/*",
 ///        offset = 140695085056000 : i64,
 ///        size = 32 : i64} : () -> tensor<2x4xf32>
 ///
-/// Output IR when externalization is enabled (extState != nullptr):
+/// File-ref form:
 ///
-///   memref.global "private" @hip_ext_constant_0 : memref<2x4xf32>
-///       {alignment = 64 : i64,
-///        hip.external_data = {index = 0 : i64, offset = 0 : i64,
-///                             size = 32 : i64}}
-///   ...
-///   %0 = memref.get_global @hip_ext_constant_0 : memref<2x4xf32>
-///   %1 = bufferization.to_tensor %0 restrict
-///       : memref<2x4xf32> to tensor<2x4xf32>
+///   %cst = "onnx.Constant"()
+///       {location = "C:/.../weights.data",
+///        offset = 1048576 : i64,
+///        size = 33554432 : i64} : () -> tensor<...>
+///
+/// Output IR when externalization is enabled (extState != nullptr) is the
+/// same memref.global + bufferization.to_tensor bridge as in
+/// externalizeConstant; the only difference is what the transfer-file
+/// finalize step writes for this entry.
 ///
 /// Output IR when externalization is disabled (extState == nullptr):
 ///
 ///   %cst = arith.constant dense<[[1.0, 2.0, 3.0, 4.0], ...]>
 ///       : tensor<2x4xf32>
+static constexpr llvm::StringLiteral kOrtMemAddrTag = "*/_ORT_MEM_ADDR_/*";
+
 static mlir::LogicalResult
 resolveExternalLocationConstant(mlir::ModuleOp module, mlir::Operation *constOp,
                                 ExternalizationState *extState) {
+  auto locAttr = constOp->getAttrOfType<mlir::StringAttr>("location");
   auto offsetAttr = constOp->getAttrOfType<mlir::IntegerAttr>("offset");
   auto sizeAttr = constOp->getAttrOfType<mlir::IntegerAttr>("size");
-  if (!offsetAttr || !sizeAttr)
+  if (!locAttr || !offsetAttr || !sizeAttr)
     return constOp->emitError(
-        "onnx.Constant with location attribute missing offset or size");
+        "onnx.Constant with location attribute missing location/offset/size");
 
-  int64_t addr = offsetAttr.getInt();
+  int64_t offsetVal = offsetAttr.getInt();
   int64_t dataSize = sizeAttr.getInt();
-  if (addr == 0 || dataSize <= 0)
-    return constOp->emitError("onnx.Constant has invalid address/size");
-
-  const void *dataPtr =
-      reinterpret_cast<const void *>(static_cast<uintptr_t>(addr));
+  if (dataSize <= 0)
+    return constOp->emitError("onnx.Constant has invalid size");
 
   auto tensorType =
       mlir::dyn_cast<mlir::RankedTensorType>(constOp->getResult(0).getType());
   if (!tensorType)
     return constOp->emitError("external constant has non-ranked result type");
 
-  if (extState) {
-    externalizeConstant(module, constOp, tensorType, dataPtr, dataSize,
-                        extState);
-  } else {
-    auto rawData =
-        llvm::ArrayRef<char>(static_cast<const char *>(dataPtr), dataSize);
-    auto denseAttr =
-        mlir::DenseElementsAttr::getFromRawBuffer(tensorType, rawData);
-    replaceWithArithConstant(constOp, denseAttr);
+  llvm::StringRef location = locAttr.getValue();
+  bool isMemAddr = (location == kOrtMemAddrTag);
+
+  if (isMemAddr) {
+    if (offsetVal == 0)
+      return constOp->emitError("onnx.Constant mem-addr has null address");
+    const void *dataPtr =
+        reinterpret_cast<const void *>(static_cast<uintptr_t>(offsetVal));
+
+    if (extState) {
+      externalizeConstant(module, constOp, tensorType, dataPtr, dataSize,
+                          extState);
+    } else {
+      auto rawData =
+          llvm::ArrayRef<char>(static_cast<const char *>(dataPtr), dataSize);
+      auto denseAttr =
+          mlir::DenseElementsAttr::getFromRawBuffer(tensorType, rawData);
+      replaceWithArithConstant(constOp, denseAttr);
+    }
+    return mlir::success();
   }
+
+  // File-reference path: location is an absolute file path, offset is the
+  // byte offset within that file. Without externalization (offline / inline
+  // arith.constant test path) we still have to materialize the bytes; do a
+  // one-shot fread and feed them to DenseElementsAttr. The full streaming
+  // benefit only kicks in along the externalize path where a downstream
+  // consumer can stream tensor-by-tensor.
+  if (extState) {
+    externalizeFileRefConstant(module, constOp, tensorType, location.str(),
+                               offsetVal, dataSize, extState);
+    return mlir::success();
+  }
+
+  std::vector<char> buf(static_cast<size_t>(dataSize));
+  std::ifstream ifs(location.str(), std::ios::binary);
+  if (!ifs)
+    return constOp->emitError("failed to open external data file: ")
+           << location;
+  ifs.seekg(offsetVal);
+  ifs.read(buf.data(), dataSize);
+  if (!ifs)
+    return constOp->emitError("short read from external data file: ")
+           << location;
+  auto denseAttr = mlir::DenseElementsAttr::getFromRawBuffer(
+      tensorType, llvm::ArrayRef<char>(buf.data(), buf.size()));
+  replaceWithArithConstant(constOp, denseAttr);
   return mlir::success();
 }
 
@@ -488,13 +590,16 @@ struct ConvertOnnxToHipPass
     : public impl::ConvertOnnxToHipPassBase<ConvertOnnxToHipPass> {
   using ConvertOnnxToHipPassBase::ConvertOnnxToHipPassBase;
 
-  ConvertOnnxToHipPass(morphizen::FileSystem *fs, int64_t minNumElements)
-      : fileSystem_(fs), fsMinNumElements_(minNumElements) {}
+  ConvertOnnxToHipPass(morphizen::FileSystem *fs, int64_t minNumElements,
+                       bool skipConstantData = false)
+      : fileSystem_(fs), fsMinNumElements_(minNumElements),
+        skipConstantData_(skipConstantData) {}
 
   void runOnOperation() override;
 
   morphizen::FileSystem *fileSystem_ = nullptr;
   int64_t fsMinNumElements_ = 0;
+  bool skipConstantData_ = false;
 };
 
 void ConvertOnnxToHipPass::runOnOperation() {
@@ -536,20 +641,16 @@ void ConvertOnnxToHipPass::runOnOperation() {
 
   if (minElems > 0) {
     extState = std::make_unique<ExternalizationState>();
+    extState->skipDataWrite = skipConstantData_;
 
     std::string baseName = "model";
     if (auto sym = module->getAttrOfType<mlir::StringAttr>(
             mlir::SymbolTable::getSymbolAttrName()))
       baseName = sym.getValue().str();
     extState->binFileName = baseName + ".constants.bin";
-
-    extState->writer =
-        fs->create_writer_template(extState->binFileName.c_str());
-    if (!extState->writer) {
-      module.emitError("failed to open constants binary file via FileSystem: " +
-                       extState->binFileName);
-      return signalPassFailure();
-    }
+    // constants.bin is written in one streaming pass in finalize() via
+    // writeConstantsBinToFileSystem, after all offsets are known; no
+    // writer is opened here.
   }
 
   // Capture original function signatures as module metadata before lowering.
@@ -606,53 +707,176 @@ void ConvertOnnxToHipPass::runOnOperation() {
     }
   });
 
-  // Finalize externalization: release writer, write JSON manifest, set module
-  // attributes.
+  // Finalize externalization: emit the constants.bin sidecar or transfer
+  // file, write the JSON manifest, and stamp module attributes.
+  //
+  // Dual-path dispatch: even if the caller asked for skipDataWrite=true
+  // (streaming mode), any mem-addr entry in constantHostPtrs forces a
+  // downgrade back to the sidecar path. Mem-addr entries alias DenseAttr
+  // raw data living in the MLIRContext; their lifetime ends when the pass
+  // returns, so they cannot survive into the customop ctor's runtime
+  // streaming. The streaming path therefore only handles file-ref + splat
+  // (lifetimes both fully owned by the EP).
   if (extState && extState->constantIndex > 0) {
-    extState->writer.reset();
-
-    // Set hip.constants_file on the module so downstream passes/tools know
-    // where the sidecar lives.
+    // Module attributes shared across both emit modes.
     module->setAttr("hip.constants_file",
                     mlir::StringAttr::get(ctx, extState->binFileName));
-
-    // Emit hipdnn.constant_sizes and hipdnn.constant_offsets for the runtime.
     module->setAttr("hipdnn.constant_sizes",
                     mlir::DenseI64ArrayAttr::get(ctx, extState->constantSizes));
     module->setAttr(
         "hipdnn.constant_offsets",
         mlir::DenseI64ArrayAttr::get(ctx, extState->constantOffsets));
 
-    // Derive base name again for JSON path.
-    std::string baseName = "model";
-    if (auto sym = module->getAttrOfType<mlir::StringAttr>(
-            mlir::SymbolTable::getSymbolAttrName()))
-      baseName = sym.getValue().str();
-    std::string jsonPath = baseName + ".constants.json";
-
-    llvm::json::Object manifest;
-    manifest["version"] = 1;
-    manifest["binary_file"] = extState->binFileName;
-    manifest["num_constants"] = extState->constantIndex;
-    manifest["total_bytes"] = extState->currentOffset;
-    manifest["constants"] = std::move(extState->manifestEntries);
-
-    auto jsonWriter = fs->create_writer_template(jsonPath.c_str());
-    if (!jsonWriter) {
-      module.emitError("failed to open constants manifest via FileSystem: " +
-                       jsonPath);
-      return signalPassFailure();
+    bool effectiveSkip = extState->skipDataWrite;
+    if (effectiveSkip) {
+      bool hasMemAddr = false;
+      size_t memAddrCount = 0;
+      for (const auto &h : extState->constantHostPtrs) {
+        if (h.filePath.empty() && h.splatElemSize == 0) {
+          hasMemAddr = true;
+          ++memAddrCount;
+        }
+      }
+      if (hasMemAddr) {
+        effectiveSkip = false;
+        llvm::errs() << "[ConvertOnnxToHipPass] downgrade to sidecar: model "
+                        "contains "
+                     << memAddrCount
+                     << " mem-addr (inline / mmap-alias) tensor(s); "
+                        "streaming path requires pure file-ref + splat\n";
+      }
     }
-    std::string jsonStr;
-    llvm::raw_string_ostream jsonOs(jsonStr);
-    jsonOs << llvm::formatv("{0:2}", llvm::json::Value(std::move(manifest)));
-    jsonWriter->fwrite(jsonStr.data(), jsonStr.size());
 
-    LLVM_DEBUG(llvm::dbgs() << "externalized " << extState->constantIndex
-                            << " constants (" << extState->currentOffset
-                            << " bytes) to " << extState->binFileName << "\n");
-  } else if (extState) {
-    extState->writer.reset();
+    if (!effectiveSkip) {
+      // Stream constants.bin via the shared helper (preserves the 1 MB
+      // tile pattern for splats so peak host memory is bounded; file-ref
+      // entries stream from disk into the writer with no in-memory copy).
+      llvm::SmallVector<mlir::hip::ConstantEntry> entries;
+      entries.reserve(extState->constantHostPtrs.size());
+      for (size_t i = 0; i < extState->constantHostPtrs.size(); ++i) {
+        const auto &h = extState->constantHostPtrs[i];
+        mlir::hip::ConstantEntry e;
+        e.name = extState->constantNames[i];
+        e.offset = extState->constantOffsets[i];
+        e.size = extState->constantSizes[i];
+        e.data = h.ptr;
+        e.splat_elem_size = h.splatElemSize;
+        e.file_path = h.filePath;
+        e.file_offset = h.fileOffset;
+        entries.push_back(std::move(e));
+      }
+      if (!mlir::hip::writeConstantsBinToFileSystem(
+              fs, extState->binFileName,
+              std::vector<mlir::hip::ConstantEntry>(entries.begin(),
+                                                    entries.end()),
+              extState->currentOffset)) {
+        module.emitError(
+            "failed to write constants binary file via FileSystem: " +
+            extState->binFileName);
+        return signalPassFailure();
+      }
+
+      // JSON manifest (only meaningful when constants.bin is produced).
+      std::string baseName = "model";
+      if (auto sym = module->getAttrOfType<mlir::StringAttr>(
+              mlir::SymbolTable::getSymbolAttrName()))
+        baseName = sym.getValue().str();
+      std::string jsonPath = baseName + ".constants.json";
+
+      llvm::json::Object manifest;
+      manifest["version"] = 1;
+      manifest["binary_file"] = extState->binFileName;
+      manifest["num_constants"] = extState->constantIndex;
+      manifest["total_bytes"] = extState->currentOffset;
+      manifest["constants"] = std::move(extState->manifestEntries);
+
+      auto jsonWriter = fs->create_writer_template(jsonPath.c_str());
+      if (!jsonWriter) {
+        module.emitError("failed to open constants manifest via FileSystem: " +
+                         jsonPath);
+        return signalPassFailure();
+      }
+      std::string jsonStr;
+      llvm::raw_string_ostream jsonOs(jsonStr);
+      jsonOs << llvm::formatv("{0:2}", llvm::json::Value(std::move(manifest)));
+      jsonWriter->fwrite(jsonStr.data(), jsonStr.size());
+    } else if (!extState->constantHostPtrs.empty()) {
+      // Streaming mode: expose per-constant source descriptors as module
+      // attributes. GenerateInterface reads these and bakes them into
+      // HipModelMetaInfo.ConstantInfo.source (union of Splat / FileRef);
+      // the runtime then uploads each constant on demand from __metadata_blob.
+      //
+      // Mem-addr entries are unreachable here: the dispatch above downgrades
+      // any module containing a mem-addr alias back to the sidecar branch.
+      //
+      // Five parallel arrays, all indexed by constantIndex:
+      //   constant_source_kinds:      0=NONE, 1=Splat, 2=FileRef
+      //   constant_splat_elem_values: elem bytes left-packed into i64 (0 if not
+      //   splat) constant_splat_elem_sizes:  elem byte count (1/2/4/8; 0 if not
+      //   splat) constant_file_paths:        absolute OS path (empty string if
+      //   not file-ref) constant_file_offsets:      byte offset within file (0
+      //   if not file-ref)
+      int64_t count = static_cast<int64_t>(extState->constantHostPtrs.size());
+      llvm::SmallVector<int32_t> kinds;
+      kinds.reserve(count);
+      llvm::SmallVector<int64_t> splatValues;
+      splatValues.reserve(count);
+      llvm::SmallVector<int64_t> splatElemSizes;
+      splatElemSizes.reserve(count);
+      llvm::SmallVector<mlir::Attribute> filePaths;
+      filePaths.reserve(count);
+      llvm::SmallVector<int64_t> fileOffsets;
+      fileOffsets.reserve(count);
+
+      for (int64_t i = 0; i < count; ++i) {
+        const auto &entry = extState->constantHostPtrs[i];
+        int64_t splatValue = 0;
+        int64_t splatElem = 0;
+        std::string path;
+        int64_t fileOff = 0;
+        if (!entry.filePath.empty()) {
+          kinds.push_back(2); // FileRef
+          path = entry.filePath;
+          fileOff = entry.fileOffset;
+        } else if (entry.splatElemSize > 0) {
+          kinds.push_back(1); // Splat
+          splatElem = entry.splatElemSize;
+          // Left-pack up to 8 bytes of element data into a uint64 carrier
+          // so we can ship it through a DenseI64ArrayAttr.
+          size_t n = static_cast<size_t>(std::min<int64_t>(splatElem, 8));
+          std::memcpy(&splatValue, entry.ptr, n);
+        } else {
+          // Unreachable: mem-addr would have triggered the sidecar downgrade
+          // above. Emit error to fail fast if invariant breaks.
+          module.emitError(
+              "internal: mem-addr entry leaked into streaming source "
+              "descriptor (constant index: ")
+              << i << ")";
+          return signalPassFailure();
+        }
+        splatValues.push_back(splatValue);
+        splatElemSizes.push_back(splatElem);
+        filePaths.push_back(mlir::StringAttr::get(ctx, path));
+        fileOffsets.push_back(fileOff);
+      }
+
+      module->setAttr("hipdnn.constant_source_kinds",
+                      mlir::DenseI32ArrayAttr::get(ctx, kinds));
+      module->setAttr("hipdnn.constant_splat_elem_values",
+                      mlir::DenseI64ArrayAttr::get(ctx, splatValues));
+      module->setAttr("hipdnn.constant_splat_elem_sizes",
+                      mlir::DenseI64ArrayAttr::get(ctx, splatElemSizes));
+      module->setAttr("hipdnn.constant_file_paths",
+                      mlir::ArrayAttr::get(ctx, filePaths));
+      module->setAttr("hipdnn.constant_file_offsets",
+                      mlir::DenseI64ArrayAttr::get(ctx, fileOffsets));
+    }
+
+    LLVM_DEBUG(llvm::dbgs()
+               << "externalized " << extState->constantIndex << " constants ("
+               << extState->currentOffset << " bytes) to "
+               << extState->binFileName
+               << (effectiveSkip ? " (metadata only)" : "") << "\n");
   }
   logSubpass("finalize");
 
@@ -665,8 +889,10 @@ void ConvertOnnxToHipPass::runOnOperation() {
 } // namespace
 
 std::unique_ptr<mlir::Pass>
-createConvertOnnxToHipPass(morphizen::FileSystem *fs, int64_t minNumElements) {
-  return std::make_unique<ConvertOnnxToHipPass>(fs, minNumElements);
+createConvertOnnxToHipPass(morphizen::FileSystem *fs, int64_t minNumElements,
+                           bool skipConstantData) {
+  return std::make_unique<ConvertOnnxToHipPass>(fs, minNumElements,
+                                                skipConstantData);
 }
 
 } // namespace hip

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -793,11 +793,12 @@ void ConvertOnnxToHipPass::runOnOperation() {
       //
       // Six parallel arrays, all indexed by constantIndex:
       //   constant_source_kinds:        0=NONE, 1=Splat, 2=FileRef, 3=Sidecar
-      //   constant_splat_elem_values:   elem bytes packed into i64 (0 unless splat)
-      //   constant_splat_elem_sizes:    elem byte count 1/2/4/8 (0 unless splat)
-      //   constant_file_paths:          absolute OS path (empty unless file-ref)
-      //   constant_file_offsets:        byte offset within file (0 unless file-ref)
-      //   constant_sidecar_offsets:     byte offset within partial sidecar
+      //   constant_splat_elem_values:   elem bytes packed into i64 (0 unless
+      //   splat) constant_splat_elem_sizes:    elem byte count 1/2/4/8 (0
+      //   unless splat) constant_file_paths:          absolute OS path (empty
+      //   unless file-ref) constant_file_offsets:        byte offset within
+      //   file (0 unless file-ref) constant_sidecar_offsets:     byte offset
+      //   within partial sidecar
       //                                 (0 unless mem-addr / Sidecar)
       int64_t count = static_cast<int64_t>(extState->constantHostPtrs.size());
       llvm::SmallVector<int32_t> kinds(count, 0);
@@ -853,8 +854,8 @@ void ConvertOnnxToHipPass::runOnOperation() {
         llvm::errs() << "[ConvertOnnxToHipPass] hybrid: " << memAddrCount
                      << " mem-addr -> partial sidecar ("
                      << llvm::format("%.1f", sidecarPos / (1024.0 * 1024.0))
-                     << " MB), " << fileRefCount << " file-ref + "
-                     << splatCount << " splat -> streaming\n";
+                     << " MB), " << fileRefCount << " file-ref + " << splatCount
+                     << " splat -> streaming\n";
       } else {
         llvm::errs() << "[ConvertOnnxToHipPass] streaming: " << fileRefCount
                      << " file-ref + " << splatCount
@@ -877,8 +878,8 @@ void ConvertOnnxToHipPass::runOnOperation() {
           splatElemSizes[i] = entry.splatElemSize;
           // Left-pack up to 8 bytes of element data into a uint64 carrier
           // so we can ship it through a DenseI64ArrayAttr.
-          size_t n = static_cast<size_t>(
-              std::min<int64_t>(splatElemSizes[i], 8));
+          size_t n =
+              static_cast<size_t>(std::min<int64_t>(splatElemSizes[i], 8));
           std::memcpy(&splatValues[i], entry.ptr, n);
         } else {
           kinds[i] = 3; // Sidecar (mem-addr packed into partial sidecar)

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -707,18 +707,25 @@ void ConvertOnnxToHipPass::runOnOperation() {
     }
   });
 
-  // Finalize externalization: emit the constants.bin sidecar or transfer
-  // file, write the JSON manifest, and stamp module attributes.
+  // Finalize externalization: emit the constants.bin sidecar or per-entry
+  // source descriptors (or both, in hybrid mode), write the JSON manifest
+  // when a full sidecar is produced, and stamp module attributes.
   //
-  // Dual-path dispatch: even if the caller asked for skipDataWrite=true
-  // (streaming mode), any mem-addr entry in constantHostPtrs forces a
-  // downgrade back to the sidecar path. Mem-addr entries alias DenseAttr
-  // raw data living in the MLIRContext; their lifetime ends when the pass
-  // returns, so they cannot survive into the customop ctor's runtime
-  // streaming. The streaming path therefore only handles file-ref + splat
-  // (lifetimes both fully owned by the EP).
+  // Three emit modes:
+  //   * skipDataWrite=false  — full sidecar (Workflow A: EPContext export
+  //     + offline hip-compiler). All ConstantInfo.source remain NONE; the
+  //     runtime bulk-loads model.constants.bin and hipMemcpy's it once.
+  //   * skipDataWrite=true, no mem-addr entries — pure streaming. Per-entry
+  //     descriptors only (Splat / FileRef); no sidecar written.
+  //   * skipDataWrite=true, has mem-addr entries — hybrid. Mem-addr bytes
+  //     are packed into a *partial* sidecar at compact 64B-aligned offsets;
+  //     the descriptor for each mem-addr entry becomes SidecarSource with
+  //     its sidecar offset. file-ref / splat entries keep their streaming
+  //     descriptors. The runtime per-entry path uploads from a single
+  //     reusable staging buffer regardless of source mix, bounding host
+  //     peak to the largest single tensor instead of total constants size.
   if (extState && extState->constantIndex > 0) {
-    // Module attributes shared across both emit modes.
+    // Module attributes shared across all emit modes.
     module->setAttr("hip.constants_file",
                     mlir::StringAttr::get(ctx, extState->binFileName));
     module->setAttr("hipdnn.constant_sizes",
@@ -727,27 +734,7 @@ void ConvertOnnxToHipPass::runOnOperation() {
         "hipdnn.constant_offsets",
         mlir::DenseI64ArrayAttr::get(ctx, extState->constantOffsets));
 
-    bool effectiveSkip = extState->skipDataWrite;
-    if (effectiveSkip) {
-      bool hasMemAddr = false;
-      size_t memAddrCount = 0;
-      for (const auto &h : extState->constantHostPtrs) {
-        if (h.filePath.empty() && h.splatElemSize == 0) {
-          hasMemAddr = true;
-          ++memAddrCount;
-        }
-      }
-      if (hasMemAddr) {
-        effectiveSkip = false;
-        llvm::errs() << "[ConvertOnnxToHipPass] downgrade to sidecar: model "
-                        "contains "
-                     << memAddrCount
-                     << " mem-addr (inline / mmap-alias) tensor(s); "
-                        "streaming path requires pure file-ref + splat\n";
-      }
-    }
-
-    if (!effectiveSkip) {
+    if (!extState->skipDataWrite) {
       // Stream constants.bin via the shared helper (preserves the 1 MB
       // tile pattern for splats so peak host memory is bounded; file-ref
       // entries stream from disk into the writer with no in-memory copy).
@@ -801,63 +788,102 @@ void ConvertOnnxToHipPass::runOnOperation() {
       jsonOs << llvm::formatv("{0:2}", llvm::json::Value(std::move(manifest)));
       jsonWriter->fwrite(jsonStr.data(), jsonStr.size());
     } else if (!extState->constantHostPtrs.empty()) {
-      // Streaming mode: expose per-constant source descriptors as module
-      // attributes. GenerateInterface reads these and bakes them into
-      // HipModelMetaInfo.ConstantInfo.source (union of Splat / FileRef);
-      // the runtime then uploads each constant on demand from __metadata_blob.
+      // skipDataWrite=true: per-entry descriptors with optional partial
+      // sidecar for mem-addr entries (hybrid).
       //
-      // Mem-addr entries are unreachable here: the dispatch above downgrades
-      // any module containing a mem-addr alias back to the sidecar branch.
-      //
-      // Five parallel arrays, all indexed by constantIndex:
-      //   constant_source_kinds:      0=NONE, 1=Splat, 2=FileRef
-      //   constant_splat_elem_values: elem bytes left-packed into i64 (0 if not
-      //   splat) constant_splat_elem_sizes:  elem byte count (1/2/4/8; 0 if not
-      //   splat) constant_file_paths:        absolute OS path (empty string if
-      //   not file-ref) constant_file_offsets:      byte offset within file (0
-      //   if not file-ref)
+      // Six parallel arrays, all indexed by constantIndex:
+      //   constant_source_kinds:        0=NONE, 1=Splat, 2=FileRef, 3=Sidecar
+      //   constant_splat_elem_values:   elem bytes packed into i64 (0 unless splat)
+      //   constant_splat_elem_sizes:    elem byte count 1/2/4/8 (0 unless splat)
+      //   constant_file_paths:          absolute OS path (empty unless file-ref)
+      //   constant_file_offsets:        byte offset within file (0 unless file-ref)
+      //   constant_sidecar_offsets:     byte offset within partial sidecar
+      //                                 (0 unless mem-addr / Sidecar)
       int64_t count = static_cast<int64_t>(extState->constantHostPtrs.size());
-      llvm::SmallVector<int32_t> kinds;
-      kinds.reserve(count);
-      llvm::SmallVector<int64_t> splatValues;
-      splatValues.reserve(count);
-      llvm::SmallVector<int64_t> splatElemSizes;
-      splatElemSizes.reserve(count);
+      llvm::SmallVector<int32_t> kinds(count, 0);
+      llvm::SmallVector<int64_t> splatValues(count, 0);
+      llvm::SmallVector<int64_t> splatElemSizes(count, 0);
       llvm::SmallVector<mlir::Attribute> filePaths;
       filePaths.reserve(count);
-      llvm::SmallVector<int64_t> fileOffsets;
-      fileOffsets.reserve(count);
+      llvm::SmallVector<int64_t> fileOffsets(count, 0);
+      llvm::SmallVector<int64_t> sidecarOffsets(count, 0);
 
+      // Pass 1: collect mem-addr entries into a compact partial sidecar
+      // layout. Each entry is 64B-aligned within the sidecar (matches the
+      // GPU blob alignment used elsewhere, so writeConstantsBinToFileSystem
+      // emits identical zero padding logic).
+      constexpr int64_t kSidecarAlign = 64;
+      llvm::SmallVector<mlir::hip::ConstantEntry> partialEntries;
+      int64_t sidecarPos = 0;
+      int64_t memAddrCount = 0, fileRefCount = 0, splatCount = 0;
       for (int64_t i = 0; i < count; ++i) {
-        const auto &entry = extState->constantHostPtrs[i];
-        int64_t splatValue = 0;
-        int64_t splatElem = 0;
-        std::string path;
-        int64_t fileOff = 0;
-        if (!entry.filePath.empty()) {
-          kinds.push_back(2); // FileRef
-          path = entry.filePath;
-          fileOff = entry.fileOffset;
-        } else if (entry.splatElemSize > 0) {
-          kinds.push_back(1); // Splat
-          splatElem = entry.splatElemSize;
-          // Left-pack up to 8 bytes of element data into a uint64 carrier
-          // so we can ship it through a DenseI64ArrayAttr.
-          size_t n = static_cast<size_t>(std::min<int64_t>(splatElem, 8));
-          std::memcpy(&splatValue, entry.ptr, n);
+        const auto &h = extState->constantHostPtrs[i];
+        if (!h.filePath.empty()) {
+          ++fileRefCount;
+        } else if (h.splatElemSize > 0) {
+          ++splatCount;
         } else {
-          // Unreachable: mem-addr would have triggered the sidecar downgrade
-          // above. Emit error to fail fast if invariant breaks.
+          ++memAddrCount;
+          int64_t off = llvm::alignTo(sidecarPos, kSidecarAlign);
+          sidecarOffsets[i] = off;
+          mlir::hip::ConstantEntry e;
+          e.name = extState->constantNames[i];
+          e.offset = off;
+          e.size = extState->constantSizes[i];
+          e.data = h.ptr;
+          partialEntries.push_back(std::move(e));
+          sidecarPos = off + extState->constantSizes[i];
+        }
+      }
+
+      // Pass 2: write the partial sidecar (mem-addr bytes only). When
+      // there are no mem-addr entries the sidecar is omitted entirely
+      // (pure streaming model — runtime never opens constants_filename).
+      if (!partialEntries.empty()) {
+        if (!mlir::hip::writeConstantsBinToFileSystem(
+                fs, extState->binFileName,
+                std::vector<mlir::hip::ConstantEntry>(partialEntries.begin(),
+                                                      partialEntries.end()),
+                sidecarPos)) {
           module.emitError(
-              "internal: mem-addr entry leaked into streaming source "
-              "descriptor (constant index: ")
-              << i << ")";
+              "failed to write partial mem-addr sidecar via FileSystem: " +
+              extState->binFileName);
           return signalPassFailure();
         }
-        splatValues.push_back(splatValue);
-        splatElemSizes.push_back(splatElem);
+        llvm::errs() << "[ConvertOnnxToHipPass] hybrid: " << memAddrCount
+                     << " mem-addr -> partial sidecar ("
+                     << llvm::format("%.1f", sidecarPos / (1024.0 * 1024.0))
+                     << " MB), " << fileRefCount << " file-ref + "
+                     << splatCount << " splat -> streaming\n";
+      } else {
+        llvm::errs() << "[ConvertOnnxToHipPass] streaming: " << fileRefCount
+                     << " file-ref + " << splatCount
+                     << " splat -> per-entry descriptors\n";
+      }
+
+      // Pass 3: stamp per-entry source descriptors. mem-addr entries get
+      // their sidecarOffsets[i] from pass 1; the rest stay at 0 in that
+      // slot which is fine because GenerateInterface only reads it for
+      // kind==3 (Sidecar).
+      for (int64_t i = 0; i < count; ++i) {
+        const auto &entry = extState->constantHostPtrs[i];
+        std::string path;
+        if (!entry.filePath.empty()) {
+          kinds[i] = 2; // FileRef
+          path = entry.filePath;
+          fileOffsets[i] = entry.fileOffset;
+        } else if (entry.splatElemSize > 0) {
+          kinds[i] = 1; // Splat
+          splatElemSizes[i] = entry.splatElemSize;
+          // Left-pack up to 8 bytes of element data into a uint64 carrier
+          // so we can ship it through a DenseI64ArrayAttr.
+          size_t n = static_cast<size_t>(
+              std::min<int64_t>(splatElemSizes[i], 8));
+          std::memcpy(&splatValues[i], entry.ptr, n);
+        } else {
+          kinds[i] = 3; // Sidecar (mem-addr packed into partial sidecar)
+        }
         filePaths.push_back(mlir::StringAttr::get(ctx, path));
-        fileOffsets.push_back(fileOff);
       }
 
       module->setAttr("hipdnn.constant_source_kinds",
@@ -870,13 +896,16 @@ void ConvertOnnxToHipPass::runOnOperation() {
                       mlir::ArrayAttr::get(ctx, filePaths));
       module->setAttr("hipdnn.constant_file_offsets",
                       mlir::DenseI64ArrayAttr::get(ctx, fileOffsets));
+      module->setAttr("hipdnn.constant_sidecar_offsets",
+                      mlir::DenseI64ArrayAttr::get(ctx, sidecarOffsets));
     }
 
     LLVM_DEBUG(llvm::dbgs()
                << "externalized " << extState->constantIndex << " constants ("
                << extState->currentOffset << " bytes) to "
                << extState->binFileName
-               << (effectiveSkip ? " (metadata only)" : "") << "\n");
+               << (extState->skipDataWrite ? " (per-entry descriptors)" : "")
+               << "\n");
   }
   logSubpass("finalize");
 

--- a/lib/Dialect/Transforms/GenerateInterface.cpp
+++ b/lib/Dialect/Transforms/GenerateInterface.cpp
@@ -71,6 +71,22 @@ buildMetadataNative(ModuleOp module, const std::string &constantsFile) {
   auto constantOffsetsAttr =
       module->getAttrOfType<DenseI64ArrayAttr>("hipdnn.constant_offsets");
 
+  // Streaming-mode source descriptors. Present when OnnxToHip's finalize
+  // emitted per-constant source info (splat / file-ref). Absent in sidecar
+  // mode (EPContext export / has_mem_addr downgrade), in which case every
+  // ConstantInfo keeps source = NONE and runtime falls back to the bulk
+  // constants_filename read.
+  auto sourceKindsAttr =
+      module->getAttrOfType<DenseI32ArrayAttr>("hipdnn.constant_source_kinds");
+  auto splatValuesAttr = module->getAttrOfType<DenseI64ArrayAttr>(
+      "hipdnn.constant_splat_elem_values");
+  auto splatElemSizesAttr = module->getAttrOfType<DenseI64ArrayAttr>(
+      "hipdnn.constant_splat_elem_sizes");
+  auto filePathsAttr =
+      module->getAttrOfType<ArrayAttr>("hipdnn.constant_file_paths");
+  auto fileOffsetsAttr =
+      module->getAttrOfType<DenseI64ArrayAttr>("hipdnn.constant_file_offsets");
+
   mlir::hip::HipModelMetaInfoT meta;
   meta.version = 1;
   meta.constants_filename = constantsFile;
@@ -79,10 +95,36 @@ buildMetadataNative(ModuleOp module, const std::string &constantsFile) {
     auto sizes = constantSizesAttr.asArrayRef();
     auto offsets = constantOffsetsAttr ? constantOffsetsAttr.asArrayRef()
                                        : ArrayRef<int64_t>{};
+    auto kinds =
+        sourceKindsAttr ? sourceKindsAttr.asArrayRef() : ArrayRef<int32_t>{};
+    auto splatValues =
+        splatValuesAttr ? splatValuesAttr.asArrayRef() : ArrayRef<int64_t>{};
+    auto splatElemSizes = splatElemSizesAttr ? splatElemSizesAttr.asArrayRef()
+                                             : ArrayRef<int64_t>{};
+    auto fileOffsets =
+        fileOffsetsAttr ? fileOffsetsAttr.asArrayRef() : ArrayRef<int64_t>{};
     for (auto i : llvm::seq<size_t>(0, sizes.size())) {
       auto ci = std::make_unique<mlir::hip::ConstantInfoT>();
       ci->size = sizes[i];
       ci->offset = (i < offsets.size()) ? offsets[i] : 0;
+      int32_t kind = (i < kinds.size()) ? kinds[i] : 0;
+      if (kind == 1) {
+        // Splat: extract the left-packed elem bytes out of the i64 carrier.
+        auto splat = std::make_unique<mlir::hip::SplatSourceT>();
+        int64_t elemSize = (i < splatElemSizes.size()) ? splatElemSizes[i] : 0;
+        size_t n = static_cast<size_t>(std::min<int64_t>(elemSize, 8));
+        const auto *base = reinterpret_cast<const uint8_t *>(&splatValues[i]);
+        splat->elem_bytes.assign(base, base + n);
+        ci->source.Set(std::move(*splat));
+      } else if (kind == 2) {
+        auto fref = std::make_unique<mlir::hip::FileRefSourceT>();
+        if (filePathsAttr && i < filePathsAttr.size()) {
+          if (auto s = dyn_cast<StringAttr>(filePathsAttr.getValue()[i]))
+            fref->path = s.getValue().str();
+        }
+        fref->file_offset = (i < fileOffsets.size()) ? fileOffsets[i] : 0;
+        ci->source.Set(std::move(*fref));
+      }
       meta.constants.push_back(std::move(ci));
     }
   }

--- a/lib/Dialect/Transforms/GenerateInterface.cpp
+++ b/lib/Dialect/Transforms/GenerateInterface.cpp
@@ -72,10 +72,12 @@ buildMetadataNative(ModuleOp module, const std::string &constantsFile) {
       module->getAttrOfType<DenseI64ArrayAttr>("hipdnn.constant_offsets");
 
   // Streaming-mode source descriptors. Present when OnnxToHip's finalize
-  // emitted per-constant source info (splat / file-ref). Absent in sidecar
-  // mode (EPContext export / has_mem_addr downgrade), in which case every
-  // ConstantInfo keeps source = NONE and runtime falls back to the bulk
-  // constants_filename read.
+  // emitted per-constant source info (splat / file-ref / sidecar). Absent in
+  // full-sidecar mode (EPContext export), in which case every ConstantInfo
+  // keeps source = NONE and runtime falls back to the bulk constants_filename
+  // read. In hybrid mode (skipDataWrite=true with mem-addr entries) some
+  // constants carry SidecarSource pointing at a *partial* sidecar that holds
+  // only mem-addr bytes.
   auto sourceKindsAttr =
       module->getAttrOfType<DenseI32ArrayAttr>("hipdnn.constant_source_kinds");
   auto splatValuesAttr = module->getAttrOfType<DenseI64ArrayAttr>(
@@ -86,6 +88,8 @@ buildMetadataNative(ModuleOp module, const std::string &constantsFile) {
       module->getAttrOfType<ArrayAttr>("hipdnn.constant_file_paths");
   auto fileOffsetsAttr =
       module->getAttrOfType<DenseI64ArrayAttr>("hipdnn.constant_file_offsets");
+  auto sidecarOffsetsAttr = module->getAttrOfType<DenseI64ArrayAttr>(
+      "hipdnn.constant_sidecar_offsets");
 
   mlir::hip::HipModelMetaInfoT meta;
   meta.version = 1;
@@ -103,6 +107,8 @@ buildMetadataNative(ModuleOp module, const std::string &constantsFile) {
                                              : ArrayRef<int64_t>{};
     auto fileOffsets =
         fileOffsetsAttr ? fileOffsetsAttr.asArrayRef() : ArrayRef<int64_t>{};
+    auto sidecarOffsets = sidecarOffsetsAttr ? sidecarOffsetsAttr.asArrayRef()
+                                             : ArrayRef<int64_t>{};
     for (auto i : llvm::seq<size_t>(0, sizes.size())) {
       auto ci = std::make_unique<mlir::hip::ConstantInfoT>();
       ci->size = sizes[i];
@@ -124,6 +130,14 @@ buildMetadataNative(ModuleOp module, const std::string &constantsFile) {
         }
         fref->file_offset = (i < fileOffsets.size()) ? fileOffsets[i] : 0;
         ci->source.Set(std::move(*fref));
+      } else if (kind == 3) {
+        // Sidecar: mem-addr entry packed into HipModelMetaInfo.constants_filename
+        // at sidecar_offset by the OnnxToHip hybrid finalize. Runtime reads
+        // size bytes from that offset through the EP FileSystem.
+        auto side = std::make_unique<mlir::hip::SidecarSourceT>();
+        side->sidecar_offset =
+            (i < sidecarOffsets.size()) ? sidecarOffsets[i] : 0;
+        ci->source.Set(std::move(*side));
       }
       meta.constants.push_back(std::move(ci));
     }

--- a/lib/Dialect/Transforms/GenerateInterface.cpp
+++ b/lib/Dialect/Transforms/GenerateInterface.cpp
@@ -131,9 +131,10 @@ buildMetadataNative(ModuleOp module, const std::string &constantsFile) {
         fref->file_offset = (i < fileOffsets.size()) ? fileOffsets[i] : 0;
         ci->source.Set(std::move(*fref));
       } else if (kind == 3) {
-        // Sidecar: mem-addr entry packed into HipModelMetaInfo.constants_filename
-        // at sidecar_offset by the OnnxToHip hybrid finalize. Runtime reads
-        // size bytes from that offset through the EP FileSystem.
+        // Sidecar: mem-addr entry packed into
+        // HipModelMetaInfo.constants_filename at sidecar_offset by the
+        // OnnxToHip hybrid finalize. Runtime reads size bytes from that offset
+        // through the EP FileSystem.
         auto side = std::make_unique<mlir::hip::SidecarSourceT>();
         side->sidecar_offset =
             (i < sidecarOffsets.size()) ? sidecarOffsets[i] : 0;

--- a/lib/Dialect/Transforms/Pipelines.cpp
+++ b/lib/Dialect/Transforms/Pipelines.cpp
@@ -82,7 +82,7 @@ void mlir::hip::buildOnnxToHipPipeline(OpPassManager &pm,
 
   if (fs) {
     pm.addPass(mlir::hip::createConvertOnnxToHipPass(
-        fs, options.externalizeMinNumElements));
+        fs, options.externalizeMinNumElements, options.skipConstantData));
   } else {
     ConvertOnnxToHipPassOptions onnxToHipOpts;
     onnxToHipOpts.externalizeOutputDir = options.externalizeOutputDir;
@@ -107,7 +107,7 @@ void mlir::hip::buildOnnxToHipPipeline(OpPassManager &pm,
 
   if (fs) {
     pm.addPass(mlir::hip::createConvertOnnxToHipPass(
-        fs, options.externalizeMinNumElements));
+        fs, options.externalizeMinNumElements, options.skipConstantData));
   } else {
     ConvertOnnxToHipPassOptions onnxToHipOpts;
     onnxToHipOpts.externalizeOutputDir = options.externalizeOutputDir;

--- a/lib/HipDNNGraphRuntime/hipdnn_graph_runtime.cpp
+++ b/lib/HipDNNGraphRuntime/hipdnn_graph_runtime.cpp
@@ -43,9 +43,11 @@ struct RuntimeStateLayout {
   void *miopen_handle;
   void *hipblas_handle;
   void *gpu_constants_blob;
-  bool constants_blob_is_host;
   void **gpu_constants;
   size_t num_constants;
+  bool constants_is_shared;
+  void *shared_constants_mapping;
+  void *shared_constants_view;
   void *pool_base;
   size_t pool_size;
   size_t *buffer_offsets;

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -83,7 +83,9 @@ static void publish_shared_constants(RuntimeState *state, size_t total_size);
 static int bulk_load_constants(RuntimeState *state, morphizen::FileSystem *fs,
                                const char *constants_filename);
 static int per_entry_load_constants(RuntimeState *state,
-                                    const mlir::hip::HipModelMetaInfo *meta);
+                                    const mlir::hip::HipModelMetaInfo *meta,
+                                    morphizen::FileSystem *fs,
+                                    const char *constants_filename);
 
 int hipdnn_ep_state_init_with_fs(RuntimeState **out_state, void *fs,
                                  const void *metadata_blob, size_t blob_size) {
@@ -154,13 +156,17 @@ int hipdnn_ep_state_init_with_fs(RuntimeState **out_state, void *fs,
       break;
     }
   }
+  const char *constants_filename = "constants.bin";
+  if (meta->constants_filename())
+    constants_filename = meta->constants_filename()->c_str();
   int rc;
   if (anyPerEntry) {
-    rc = per_entry_load_constants(*out_state, meta);
+    // Hybrid path also goes through per-entry; SidecarSource entries open
+    // constants_filename through fs to fetch their slice on demand. Pure
+    // streaming (only Splat / FileRef) ignores fs/constants_filename.
+    rc = per_entry_load_constants(*out_state, meta, fileSystem,
+                                  constants_filename);
   } else {
-    const char *constants_filename = "constants.bin";
-    if (meta->constants_filename())
-      constants_filename = meta->constants_filename()->c_str();
     rc = bulk_load_constants(*out_state, fileSystem, constants_filename);
   }
   if (rc != 0) {
@@ -563,6 +569,88 @@ static int fref_fetch(FrefCache *c, int64_t file_offset, size_t size,
   return 0;
 }
 
+// Lazy reader for the partial mem-addr sidecar (hybrid mode). Opened
+// through the EP FileSystem on first SidecarSource entry; if the
+// FileSystem can mmap the sidecar we keep the base pointer so the case
+// becomes a memcpy + hipMemcpy (no extra fread). On non-mmap backends
+// we fall back to fread, which still wins because the per-entry staging
+// reuse keeps host peak bounded to the largest single tensor.
+struct SidecarReaderCache {
+  std::unique_ptr<morphizen::FileReader,
+                  morphizen::FileSystem::Deleter<morphizen::FileReader>>
+      reader;                    // default-init: null pointer, deleter unused
+  const uint8_t *mmap_base = nullptr; // non-null when reader->mmap() succeeded
+  size_t total_size = 0;
+  bool tried_open = false;
+};
+
+// Returns true on success (or no-op if already open). On first call
+// opens the sidecar through fs and tries mmap.
+static bool sidecar_cache_open(SidecarReaderCache *c, morphizen::FileSystem *fs,
+                               const char *constants_filename) {
+  if (c->tried_open)
+    return c->reader != nullptr;
+  c->tried_open = true;
+  if (!fs || !constants_filename) {
+    fprintf(stderr,
+            "per_entry: SidecarSource entry but fs / constants_filename "
+            "unavailable\n");
+    return false;
+  }
+  c->reader = fs->create_reader_template(constants_filename);
+  if (!c->reader) {
+    fprintf(stderr, "per_entry: failed to open partial sidecar %s\n",
+            constants_filename);
+    return false;
+  }
+  c->total_size = c->reader->size();
+  c->mmap_base = static_cast<const uint8_t *>(c->reader->mmap());
+  return true;
+}
+
+// Copy `size` bytes at `offset` from the partial sidecar into `staging`.
+static int sidecar_fetch(SidecarReaderCache *c, int64_t offset, size_t size,
+                         void *staging) {
+  if ((uint64_t)offset + size > (uint64_t)c->total_size) {
+    fprintf(stderr,
+            "per_entry: sidecar fetch out of range (offset=%lld size=%zu "
+            "total=%zu)\n",
+            (long long)offset, size, c->total_size);
+    return 1;
+  }
+  if (c->mmap_base) {
+    std::memcpy(staging, c->mmap_base + offset, size);
+    return 0;
+  }
+  // Non-mmap reader: rewind + skip + fread. morphizen::FileReader does
+  // not expose a seek primitive, so we read-and-discard up to offset.
+  // Sidecar is touched once per entry in entry order, so this still
+  // streams linearly through the file.
+  c->reader->rewind();
+  static constexpr size_t kSkipChunk = 64 * 1024;
+  uint8_t skip_buf[kSkipChunk];
+  uint64_t remaining_skip = (uint64_t)offset;
+  while (remaining_skip > 0) {
+    size_t toRead = (size_t)std::min<uint64_t>(remaining_skip, kSkipChunk);
+    size_t got = c->reader->fread(skip_buf, toRead);
+    if (got != toRead) {
+      fprintf(stderr,
+              "per_entry: sidecar skip short read (got %zu of %zu)\n",
+              got, toRead);
+      return 1;
+    }
+    remaining_skip -= toRead;
+  }
+  size_t got = c->reader->fread(staging, size);
+  if (got != size) {
+    fprintf(stderr,
+            "per_entry: sidecar payload short read (got %zu of %zu)\n",
+            got, size);
+    return 1;
+  }
+  return 0;
+}
+
 // Per-entry path: upload constants one tensor at a time driven by the
 // ConstantSource union embedded in __metadata_blob. Called when the
 // dispatch in hipdnn_ep_state_init_with_fs detected any constant with a
@@ -570,8 +658,14 @@ static int fref_fetch(FrefCache *c, int64_t file_offset, size_t size,
 // allocate_constants_blob; this function just fills it tensor-by-tensor
 // through a single reusable staging buffer, bounding host memory to the
 // largest single tensor.
+//
+// `fs` and `constants_filename` are only consulted by SidecarSource
+// entries (hybrid path). Pure streaming modules (only Splat / FileRef)
+// never open the sidecar.
 static int per_entry_load_constants(RuntimeState *state,
-                                    const mlir::hip::HipModelMetaInfo *meta) {
+                                    const mlir::hip::HipModelMetaInfo *meta,
+                                    morphizen::FileSystem *fs,
+                                    const char *constants_filename) {
   auto t_prev = timing_now();
 
   auto *constants = meta->constants();
@@ -598,6 +692,8 @@ static int per_entry_load_constants(RuntimeState *state,
 
   FrefCache fcache;
   fref_cache_init(&fcache);
+
+  SidecarReaderCache scache; // RAII; default-initialized above
 
   for (int64_t i = 0; i < count; ++i) {
     auto *c = constants->Get(i);
@@ -645,6 +741,28 @@ static int per_entry_load_constants(RuntimeState *state,
       }
       if (hipMemcpy(dst, staging, sz, hipMemcpyHostToDevice) != hipSuccess) {
         fprintf(stderr, "per_entry: hipMemcpy failed for file-ref entry %lld\n",
+                (long long)i);
+        free(staging);
+        fref_cache_release(&fcache);
+        return 1;
+      }
+      break;
+    }
+    case mlir::hip::ConstantSource::SidecarSource: {
+      auto *side = c->source_as_SidecarSource();
+      int64_t side_offset = side->sidecar_offset();
+      if (!sidecar_cache_open(&scache, fs, constants_filename)) {
+        free(staging);
+        fref_cache_release(&fcache);
+        return 1;
+      }
+      if (sidecar_fetch(&scache, side_offset, sz, staging) != 0) {
+        free(staging);
+        fref_cache_release(&fcache);
+        return 1;
+      }
+      if (hipMemcpy(dst, staging, sz, hipMemcpyHostToDevice) != hipSuccess) {
+        fprintf(stderr, "per_entry: hipMemcpy failed for sidecar entry %lld\n",
                 (long long)i);
         free(staging);
         fref_cache_release(&fcache);

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -15,15 +15,12 @@
 #include <cstdlib>
 #include <cstring>
 
-// Win32 API declarations for process-wide environment access and
-// shared constants cache (named shared memory + atomic ref counting).
-// Model DLLs link static CRT (libcmt.lib), so getenv() can't see _putenv()
-// changes from the host. GetEnvironmentVariableA reads the shared process
-// environment block instead.
+// Win32 API declarations for the OGA pipeline shared-constants cache
+// (named shared memory + atomic ref counting). Model DLLs link static
+// CRT, so kernel32 calls go through declared imports rather than
+// <windows.h> (which would pull a much larger surface).
 #ifdef _WIN32
 extern "C" {
-unsigned long __stdcall GetEnvironmentVariableA(const char *, char *,
-                                                unsigned long);
 void *__stdcall CreateFileMappingA(void *, void *, unsigned long, unsigned long,
                                    unsigned long, const char *);
 void *__stdcall OpenFileMappingA(unsigned long, int, const char *);
@@ -34,20 +31,26 @@ int __stdcall CloseHandle(void *);
 unsigned long __stdcall GetCurrentProcessId(void);
 }
 
-// Metadata stored in the named shared memory block.
-// The actual constants data lives in the hipHostMalloc/hipMalloc buffer;
-// this struct just holds the pointer, size, and atomic ref count.
+// Metadata block stored in the named shared memory. The actual constants
+// live in the publishing model's hipMalloc'd blob; this struct only
+// carries the GPU pointer + size + atomic ref count.
+//
+// NOTE: layout intentionally diverges from main: PR #109 had a `bool
+// is_host` here to support a hipHostMalloc fallback path on iGPU. We
+// dropped that path (constants blob is always hipMalloc'd VRAM), so
+// is_host is removed. Cross-DLL sharing relies on both publisher and
+// consumer using this same struct, which holds for OGA pipeline (both
+// model.dll built from the same hip-compiler).
 struct SharedConstantsMeta {
   void *blob_ptr;
   size_t blob_size;
-  bool is_host;
   volatile long ref_count;
 };
 
-// Atomic ref-count helpers. Model DLL bitcode is compiled by Clang/LLVM,
-// where InterlockedIncrement/Decrement are not linkable symbols (they're
-// MSVC intrinsics, not kernel32.lib exports). Use compiler builtins that
-// lower to LLVM IR atomicrmw instructions instead.
+// Atomic ref-count helpers. Model DLL bitcode is compiled by Clang/LLVM
+// where InterlockedIncrement/Decrement are not linkable symbols (MSVC
+// intrinsics, not kernel32 exports). Use compiler builtins that lower
+// to LLVM atomicrmw.
 #if defined(__clang__) || defined(__GNUC__)
 static inline long shm_ref_inc(volatile long *p) {
   return __sync_add_and_fetch(p, 1);
@@ -64,29 +67,136 @@ static inline long shm_ref_dec(volatile long *p) { return --(*p); }
 #define SHM_PAGE_READWRITE 0x04u
 #endif
 
+// Forward decl of static helpers defined later in this file.
+static int initialize_state_handles(RuntimeState **out_state);
+static int prepare_constants_array(RuntimeState *state,
+                                   const mlir::hip::HipModelMetaInfo *meta);
+static size_t
+compute_constants_total_size(const mlir::hip::HipModelMetaInfo *meta);
+static int hipmalloc_and_fixup(RuntimeState *state,
+                               const mlir::hip::HipModelMetaInfo *meta,
+                               size_t total_size);
+static bool try_attach_shared_constants(RuntimeState *state,
+                                        const mlir::hip::HipModelMetaInfo *meta,
+                                        size_t total_size);
+static void publish_shared_constants(RuntimeState *state, size_t total_size);
+static int bulk_load_constants(RuntimeState *state, morphizen::FileSystem *fs,
+                               const char *constants_filename);
+static int per_entry_load_constants(RuntimeState *state,
+                                    const mlir::hip::HipModelMetaInfo *meta);
+
 int hipdnn_ep_state_init_with_fs(RuntimeState **out_state, void *fs,
                                  const void *metadata_blob, size_t blob_size) {
   auto t0 = timing_now();
-  auto t_prev = t0;
 
   if (!out_state || !fs) {
     fprintf(stderr, "Invalid arguments to hipdnn_ep_state_init_with_fs\n");
     return 1;
   }
 
-  // Allocate context struct
+  if (int rc = initialize_state_handles(out_state); rc != 0) {
+    return rc;
+  }
+
+  if (!metadata_blob || blob_size == 0) {
+    TIMING_LOG("[Session] hipdnn_ep_state_init_with_fs total: %.3fs (no "
+               "constants)\n",
+               elapsed_since(t0));
+    return 0;
+  }
+
+  auto *meta = flatbuffers::GetRoot<mlir::hip::HipModelMetaInfo>(metadata_blob);
+  auto *constants = meta->constants();
+  int64_t count = constants ? (int64_t)constants->size() : 0;
+  if (count <= 0) {
+    TIMING_LOG("[Session] hipdnn_ep_state_init_with_fs total: %.3fs (no "
+               "constants)\n",
+               elapsed_since(t0));
+    return 0;
+  }
+
+  // 1. Pre-allocate the gpu_constants[] pointer array (cheap, needed by
+  //    both shared-cache hit and miss paths). num_constants is set here.
+  if (int rc = prepare_constants_array(*out_state, meta); rc != 0) {
+    hipdnn_ep_state_cleanup(*out_state);
+    *out_state = nullptr;
+    return rc;
+  }
+
+  // 2. Try to attach a process-wide shared constants blob (OGA pipeline
+  //    optimization: prefill+decode share the same constants, so the
+  //    second model can skip both hipMalloc and the data load entirely).
+  size_t total_size = compute_constants_total_size(meta);
+  if (try_attach_shared_constants(*out_state, meta, total_size)) {
+    TIMING_LOG("[Session] hipdnn_ep_state_init_with_fs total: %.3fs "
+               "(shared blob attached)\n",
+               elapsed_since(t0));
+    return 0;
+  }
+
+  // 3. Cache miss: allocate our own VRAM blob and fix up gpu_constants[i].
+  if (int rc = hipmalloc_and_fixup(*out_state, meta, total_size); rc != 0) {
+    hipdnn_ep_state_cleanup(*out_state);
+    *out_state = nullptr;
+    return rc;
+  }
+
+  auto *fileSystem = static_cast<morphizen::FileSystem *>(fs);
+
+  // 4. Dispatch by metadata semantics: if any constant carries a per-entry
+  //    source descriptor (Splat / FileRef), do per-tensor upload driven by
+  //    the source union. Otherwise fall back to the bulk sidecar path (used
+  //    by EPContext export / import and has_mem_addr downgrade).
+  bool anyPerEntry = false;
+  for (int64_t i = 0; i < count; ++i) {
+    if (constants->Get(i)->source_type() != mlir::hip::ConstantSource::NONE) {
+      anyPerEntry = true;
+      break;
+    }
+  }
+  int rc;
+  if (anyPerEntry) {
+    rc = per_entry_load_constants(*out_state, meta);
+  } else {
+    const char *constants_filename = "constants.bin";
+    if (meta->constants_filename())
+      constants_filename = meta->constants_filename()->c_str();
+    rc = bulk_load_constants(*out_state, fileSystem, constants_filename);
+  }
+  if (rc != 0) {
+    hipdnn_ep_state_cleanup(*out_state);
+    *out_state = nullptr;
+    return rc;
+  }
+
+  // 5. Publish the freshly loaded blob to the shared cache (best-effort;
+  //    failure means subsequent models won't be able to share).
+  publish_shared_constants(*out_state, total_size);
+
+  TIMING_LOG("[Session] hipdnn_ep_state_init_with_fs total: %.3fs\n",
+             elapsed_since(t0));
+  return 0;
+}
+
+// Shared initialization that brings up HIP device, stream, MIOpen and
+// hipBLASLt handles in a fresh RuntimeState. On any failure the partially
+// initialized state is released and a non-zero error code (matching the
+// historical exit codes 1-9) is returned. On success *out_state holds the
+// RuntimeState ready for constants_blob allocation; no constant memory has
+// been touched yet.
+static int initialize_state_handles(RuntimeState **out_state) {
+  auto t_prev = timing_now();
+
   RuntimeState *state = (RuntimeState *)malloc(sizeof(RuntimeState));
   if (!state) {
     fprintf(stderr, "Failed to allocate runtime state\n");
     return 1;
   }
 
-  // Initialize all fields to null for safe cleanup
   state->stream = nullptr;
   state->miopen_handle = nullptr;
   state->hipblas_handle = nullptr;
   state->gpu_constants_blob = nullptr;
-  state->constants_blob_is_host = false;
   state->gpu_constants = nullptr;
   state->num_constants = 0;
   state->constants_is_shared = false;
@@ -101,9 +211,6 @@ int hipdnn_ep_state_init_with_fs(RuntimeState **out_state, void *fs,
   state->hipdnn_handle = nullptr;
   state->hipdnn_graph_registry = nullptr;
 
-  // Explicitly initialize HIP device before any other operations
-  // This ensures device 0 is active and context is properly initialized
-  // Critical for DLL execution context where HIP may not auto-initialize
   int device_count = 0;
   if (hipGetDeviceCount(&device_count) != hipSuccess || device_count == 0) {
     fprintf(stderr, "Failed to get HIP device count or no devices available\n");
@@ -117,62 +224,8 @@ int hipdnn_ep_state_init_with_fs(RuntimeState **out_state, void *fs,
     return 3;
   }
 
-  // Verify device properties are accessible
-  // NOTE: Removed dummy hipMalloc/hipFree - let hipStreamCreate initialize
-  // context naturally. The dummy allocation was causing rocBLAS device
-  // enumeration to fail.
-  hipDeviceProp_t prop;
-  if (hipGetDeviceProperties(&prop, 0) != hipSuccess) {
-    fprintf(stderr, "Failed to get device properties for device 0\n");
-    free(state);
-    return 4;
-  }
-  RUNTIME_DEBUG_LOG("Device detected: %s (arch=%s)\n", prop.name,
-                    prop.gcnArchName);
-
-  // WORKAROUND: TheRock SDK Windows bug - gcnArchName is empty due to PAL
-  // backend. Root cause: Windows uses PAL (Platform Abstraction Layer) instead
-  // of HSA (Linux). PAL backend's isa.targetId() query returns empty string in
-  // DLL context. This causes rocBLAS to fail loading Tensile libraries
-  // (arch-specific kernels).
-  if (prop.gcnArchName[0] == '\0') {
-    fprintf(stderr, "\n=== CRITICAL: TheRock SDK Windows Bug Detected ===\n");
-    fprintf(stderr, "gcnArchName is EMPTY (should be 'gfx1100' for W7900)\n");
-    fprintf(stderr, "Root cause: PAL backend ISA query fails in DLL context\n");
-    fprintf(stderr, "Impact: rocBLAS/hipBLASLt cannot load arch-specific "
-                    "Tensile kernels\n\n");
-
-    const char *gfx_override = getenv("HSA_OVERRIDE_GFX_VERSION");
-    if (gfx_override && gfx_override[0] != '\0') {
-      fprintf(stderr,
-              "HSA_OVERRIDE_GFX_VERSION=%s (set, but may not work in DLL "
-              "context)\n",
-              gfx_override);
-    } else {
-      fprintf(stderr, "HSA_OVERRIDE_GFX_VERSION not set\n");
-      fprintf(stderr, "Recommended: export HSA_OVERRIDE_GFX_VERSION=11.0.0\n");
-      fprintf(stderr,
-              "(Note: This workaround may not fix DLL context issue)\n");
-    }
-
-    fprintf(stderr,
-            "\nKnown limitation: rocBLAS initialization will likely crash\n");
-    fprintf(stderr,
-            "Reason: rocBLAS cannot find TensileLibrary_<empty>.dat file\n");
-    fprintf(stderr,
-            "Workaround: Use standalone .exe instead of .dll execution\n");
-    fprintf(stderr, "Long-term fix: Report to ROCm/TheRock GitHub issues\n");
-    fprintf(stderr, "===================================================\n\n");
-  } else {
-    RUNTIME_DEBUG_LOG(
-        "gcnArchName properly populated: '%s' (initialization should "
-        "succeed)\n",
-        prop.gcnArchName);
-  }
-
   TIMING_LOG("[Session] HIP device init: %.3fs\n", record_elapsed(t_prev));
 
-  // Create HIP stream
   if (hipStreamCreate(&state->stream) != hipSuccess) {
     fprintf(stderr, "Failed to create HIP stream\n");
     free(state);
@@ -181,7 +234,6 @@ int hipdnn_ep_state_init_with_fs(RuntimeState **out_state, void *fs,
 
   TIMING_LOG("[Session] hipStreamCreate: %.3fs\n", record_elapsed(t_prev));
 
-  // Create MIOpen handle
   if (miopenCreate(&state->miopen_handle) != miopenStatusSuccess) {
     fprintf(stderr, "Failed to create MIOpen handle\n");
     if (state->stream)
@@ -190,7 +242,6 @@ int hipdnn_ep_state_init_with_fs(RuntimeState **out_state, void *fs,
     return 7;
   }
 
-  // Set stream for MIOpen handle
   if (miopenSetStream(state->miopen_handle, state->stream) !=
       miopenStatusSuccess) {
     fprintf(stderr, "Failed to set MIOpen stream\n");
@@ -203,7 +254,6 @@ int hipdnn_ep_state_init_with_fs(RuntimeState **out_state, void *fs,
 
   TIMING_LOG("[Session] MIOpen init: %.3fs\n", record_elapsed(t_prev));
 
-  // Create hipBLASLt handle
   if (hipblasLtCreate(&state->hipblas_handle) != HIPBLAS_STATUS_SUCCESS) {
     fprintf(stderr, "Failed to create hipBLASLt handle\n");
     miopenDestroy(state->miopen_handle);
@@ -216,251 +266,410 @@ int hipdnn_ep_state_init_with_fs(RuntimeState **out_state, void *fs,
   TIMING_LOG("[Session] hipBLASLt init: %.3fs\n", record_elapsed(t_prev));
 
   *out_state = state;
+  return 0;
+}
 
-  // Parse FlatBuffers blob to get constants_filename and constant_sizes
-  if (!metadata_blob || blob_size == 0) {
-    TIMING_LOG("[Session] hipdnn_ep_state_init_with_fs total: %.3fs (no "
-               "metadata)\n",
-               elapsed_since(t0));
-    return 0; // No metadata — no constants to load
-  }
-
-  auto *meta = flatbuffers::GetRoot<mlir::hip::HipModelMetaInfo>(metadata_blob);
-  auto *constants = meta->constants();
+// Allocate the gpu_constants[] pointer array (one slot per constant)
+// and record num_constants. This is a few KB at most and is needed by
+// both shared-cache hit and miss paths -- doing it up front lets
+// try_attach_shared_constants fix up the slots without an extra malloc.
+static int prepare_constants_array(RuntimeState *state,
+                                   const mlir::hip::HipModelMetaInfo *meta) {
+  auto *constants = meta ? meta->constants() : nullptr;
   int64_t count = constants ? (int64_t)constants->size() : 0;
-
   if (count <= 0) {
-    TIMING_LOG("[Session] hipdnn_ep_state_init_with_fs total: %.3fs (no "
-               "constants)\n",
-               elapsed_since(t0));
-    return 0; // No constants to load
+    return 0;
   }
-
-  const char *constants_filename = "constants.bin";
-  if (meta->constants_filename())
-    constants_filename = meta->constants_filename()->c_str();
-
-  // Allocate GPU constants pointer array
   state->gpu_constants =
       (void **)calloc(static_cast<size_t>(count), sizeof(void *));
   if (!state->gpu_constants) {
     fprintf(stderr, "Failed to allocate gpu_constants array\n");
-    hipdnn_ep_state_cleanup(state);
-    *out_state = nullptr;
     return 1;
   }
   state->num_constants = static_cast<size_t>(count);
+  return 0;
+}
 
-  // Open constants file via FileSystem
-  auto *fileSystem = static_cast<morphizen::FileSystem *>(fs);
-  auto reader = fileSystem->create_reader_template(constants_filename);
-  if (!reader) {
-    fprintf(stderr, "Failed to open %s via FileSystem\n", constants_filename);
-    hipdnn_ep_state_cleanup(state);
-    *out_state = nullptr;
+// Sum of max(end = offset + size) across all constants -- this is the
+// size of the single VRAM blob that backs gpu_constants_blob.
+static size_t
+compute_constants_total_size(const mlir::hip::HipModelMetaInfo *meta) {
+  auto *constants = meta ? meta->constants() : nullptr;
+  if (!constants)
+    return 0;
+  size_t total = 0;
+  for (int64_t i = 0, n = (int64_t)constants->size(); i < n; ++i) {
+    size_t end = static_cast<size_t>(constants->Get(i)->offset()) +
+                 static_cast<size_t>(constants->Get(i)->size());
+    if (end > total)
+      total = end;
+  }
+  return total;
+}
+
+// hipMalloc the VRAM blob and fix up gpu_constants[i] to point inside it.
+// Caller must have already invoked prepare_constants_array.
+static int hipmalloc_and_fixup(RuntimeState *state,
+                               const mlir::hip::HipModelMetaInfo *meta,
+                               size_t total_size) {
+  auto t_prev = timing_now();
+  if (hipMalloc(&state->gpu_constants_blob, total_size) != hipSuccess) {
+    fprintf(stderr, "hipMalloc failed for constants blob (%zu bytes)\n",
+            total_size);
     return 1;
   }
+  TIMING_LOG("[Session] hipMalloc VRAM: %.3fs (%zu bytes)\n",
+             record_elapsed(t_prev), total_size);
+  auto *constants = meta->constants();
+  for (int64_t i = 0, n = (int64_t)constants->size(); i < n; ++i) {
+    size_t offset = static_cast<size_t>(constants->Get(i)->offset());
+    state->gpu_constants[i] =
+        static_cast<char *>(state->gpu_constants_blob) + offset;
+  }
+  return 0;
+}
 
-  // Load the entire constants file as one blob, then point each
-  // gpu_constants[i] into it using the offset stored in ConstantInfo.
-  size_t total_size = reader->size();
+// Try to attach to a process-wide shared constants blob keyed by
+// (pid, total_size). On hit: state->gpu_constants_blob is set to the
+// shared GPU pointer, gpu_constants[i] are fixed up against it, and
+// state->constants_is_shared is set to true. The shared blob's
+// ref_count is incremented; cleanup decrements and only the last
+// reference frees the GPU memory.
+//
+// Cache key matches the "OGA prefill+decode share identical
+// model.constants.bin" invariant: same pid + same total_size implies
+// same content. If two models with the same total_size diverge in
+// content (rare), the consumer will silently get the wrong constants.
+//
+// Precondition: state->gpu_constants_blob == nullptr and
+// gpu_constants[] has been prepared. On miss / non-Windows: returns
+// false without touching state, caller proceeds with hipMalloc.
+static bool try_attach_shared_constants(RuntimeState *state,
+                                        const mlir::hip::HipModelMetaInfo *meta,
+                                        size_t total_size) {
+#ifndef _WIN32
+  (void)state;
+  (void)meta;
+  (void)total_size;
+  return false;
+#else
+  if (total_size == 0)
+    return false;
 
-  TIMING_LOG("[Session] Metadata parse + file open: %.3fs (%lld constants, %zu "
-             "bytes)\n",
-             record_elapsed(t_prev), (long long)count, total_size);
-
-  // --- Shared Constants Cache ---
-  // In OGA pipeline mode, prefill and decode models share the same
-  // constants.bin. The second model skips the expensive allocation+load
-  // by reusing the first model's blob via process-wide named shared memory.
-  bool constants_shared = false;
-
-#ifdef _WIN32
   char shm_name[128];
   snprintf(shm_name, sizeof(shm_name), "Local\\hipdnn_const_%lu_%zu",
            (unsigned long)GetCurrentProcessId(), total_size);
 
-  {
-    void *existing_map = OpenFileMappingA(SHM_FILE_MAP_ALL_ACCESS, 0, shm_name);
-    if (existing_map) {
-      auto *smeta = (SharedConstantsMeta *)MapViewOfFile(
-          existing_map, SHM_FILE_MAP_ALL_ACCESS, 0, 0,
-          sizeof(SharedConstantsMeta));
-      if (smeta && smeta->blob_size == total_size && smeta->blob_ptr) {
-        long new_ref = shm_ref_inc(&smeta->ref_count);
-        state->gpu_constants_blob = smeta->blob_ptr;
-        state->constants_blob_is_host = smeta->is_host;
-        state->constants_is_shared = true;
-        state->shared_constants_mapping = existing_map;
-        state->shared_constants_view = smeta;
-        fprintf(stderr,
-                "[SHARED_CONSTANTS] Reusing existing blob "
-                "(%zu bytes, ref_count=%ld)\n",
-                total_size, new_ref);
-        constants_shared = true;
-      } else {
-        if (smeta)
-          UnmapViewOfFile(smeta);
-        CloseHandle(existing_map);
-      }
-    }
+  void *existing_map = OpenFileMappingA(SHM_FILE_MAP_ALL_ACCESS, 0, shm_name);
+  if (!existing_map)
+    return false;
+
+  auto *smeta = (SharedConstantsMeta *)MapViewOfFile(
+      existing_map, SHM_FILE_MAP_ALL_ACCESS, 0, 0, sizeof(SharedConstantsMeta));
+  if (!smeta || smeta->blob_size != total_size || !smeta->blob_ptr) {
+    if (smeta)
+      UnmapViewOfFile(smeta);
+    CloseHandle(existing_map);
+    return false;
   }
-#endif
 
-  if (!constants_shared) {
-    bool is_igpu = (prop.integrated == 1);
+  long new_ref = shm_ref_inc(&smeta->ref_count);
 
-    // iGPU defaults to hipMalloc (VRAM) + hipMemcpy H2D, same as dGPU.
-    // The one-time copy cost at session init is negligible for production
-    // workloads; VRAM access is faster than host memory on every inference.
-    // Set HIPDNN_EP_IGPU_USE_HOST=1 to revert to legacy hipHostMalloc path.
-    const char *igpu_host_env = getenv("HIPDNN_EP_IGPU_USE_HOST");
-    bool force_host = is_igpu && igpu_host_env && igpu_host_env[0] == '1';
+  state->gpu_constants_blob = smeta->blob_ptr;
+  state->constants_is_shared = true;
+  state->shared_constants_mapping = existing_map;
+  state->shared_constants_view = smeta;
 
-    if (force_host) {
-      // Legacy iGPU path: hipHostMalloc (pinned host memory).
-      TIMING_LOG("[Session] iGPU: HIPDNN_EP_IGPU_USE_HOST=1, using "
-                 "hipHostMalloc (pinned host) path\n");
-      if (hipHostMalloc(&state->gpu_constants_blob, total_size,
-                        hipHostMallocDefault) != hipSuccess) {
-        fprintf(stderr, "hipHostMalloc failed for constants blob (%zu bytes)\n",
-                total_size);
-        hipdnn_ep_state_cleanup(state);
-        *out_state = nullptr;
-        return 1;
-      }
-
-      TIMING_LOG("[Session] hipHostMalloc: %.3fs (%zu bytes)\n",
-                 record_elapsed(t_prev), total_size);
-
-      const void *src = reader->mmap();
-      if (src) {
-        memcpy(state->gpu_constants_blob, src, total_size);
-      } else {
-        reader->rewind();
-        size_t bytes_read =
-            reader->fread(state->gpu_constants_blob, total_size);
-        if (bytes_read != total_size) {
-          fprintf(stderr, "Short read: got %zu of %zu bytes\n", bytes_read,
-                  total_size);
-          hipdnn_ep_state_cleanup(state);
-          *out_state = nullptr;
-          return 1;
-        }
-      }
-
-      TIMING_LOG("[Session] Read constants to pinned: %.3fs (%zu bytes, %s)\n",
-                 record_elapsed(t_prev), total_size,
-                 src ? "mmap+memcpy" : "fread");
-      state->constants_blob_is_host = true;
-
-    } else {
-      // VRAM path (default for both iGPU and dGPU): staging buffer + hipMemcpy.
-      if (is_igpu)
-        TIMING_LOG("[Session] iGPU: using hipMalloc (VRAM) + hipMemcpy path\n");
-
-      const void *src = reader->mmap();
-      void *cpu_buf = nullptr;
-
-      TIMING_LOG("[Session] VRAM path: mmap %s\n",
-                 src ? "succeeded" : "failed, using fread fallback");
-
-      if (!src) {
-        cpu_buf = malloc(total_size);
-        if (!cpu_buf) {
-          fprintf(stderr, "Failed to allocate staging buffer (%zu bytes)\n",
-                  total_size);
-          hipdnn_ep_state_cleanup(state);
-          *out_state = nullptr;
-          return 1;
-        }
-
-        TIMING_LOG("[Session] malloc staging buffer: %.3fs (%zu bytes)\n",
-                   record_elapsed(t_prev), total_size);
-
-        size_t bytes_read = reader->fread(cpu_buf, total_size);
-        if (bytes_read != total_size) {
-          fprintf(stderr, "Short read: got %zu of %zu bytes\n", bytes_read,
-                  total_size);
-          free(cpu_buf);
-          hipdnn_ep_state_cleanup(state);
-          *out_state = nullptr;
-          return 1;
-        }
-        src = cpu_buf;
-
-        TIMING_LOG("[Session] fread constants.bin: %.3fs (%zu bytes)\n",
-                   record_elapsed(t_prev), total_size);
-      }
-
-      if (hipMalloc(&state->gpu_constants_blob, total_size) != hipSuccess) {
-        fprintf(stderr, "hipMalloc failed for constants blob (%zu bytes)\n",
-                total_size);
-        free(cpu_buf);
-        hipdnn_ep_state_cleanup(state);
-        *out_state = nullptr;
-        return 1;
-      }
-
-      TIMING_LOG("[Session] hipMalloc VRAM: %.3fs (%zu bytes)\n",
-                 record_elapsed(t_prev), total_size);
-
-      if (hipMemcpy(state->gpu_constants_blob, src, total_size,
-                    hipMemcpyHostToDevice) != hipSuccess) {
-        fprintf(stderr, "hipMemcpy failed for constants blob\n");
-        free(cpu_buf);
-        hipdnn_ep_state_cleanup(state);
-        *out_state = nullptr;
-        return 1;
-      }
-
-      TIMING_LOG("[Session] hipMemcpy H2D: %.3fs (%zu bytes)\n",
-                 record_elapsed(t_prev), total_size);
-
-      free(cpu_buf); // no-op when mmap was used
-      state->constants_blob_is_host = false;
-    }
-
-#ifdef _WIN32
-    // Publish the newly loaded blob to the shared constants cache so that
-    // subsequent models in this process can skip the allocation+load.
-    {
-      void *new_map = CreateFileMappingA(
-          (void *)(intptr_t)-1, nullptr, SHM_PAGE_READWRITE, 0,
-          (unsigned long)sizeof(SharedConstantsMeta), shm_name);
-      if (new_map) {
-        auto *smeta = (SharedConstantsMeta *)MapViewOfFile(
-            new_map, SHM_FILE_MAP_ALL_ACCESS, 0, 0,
-            sizeof(SharedConstantsMeta));
-        if (smeta) {
-          smeta->blob_ptr = state->gpu_constants_blob;
-          smeta->blob_size = total_size;
-          smeta->is_host = state->constants_blob_is_host;
-          smeta->ref_count = 1;
-          state->shared_constants_mapping = new_map;
-          state->shared_constants_view = smeta;
-          fprintf(stderr, "[SHARED_CONSTANTS] Published new blob (%zu bytes)\n",
-                  total_size);
-        } else {
-          CloseHandle(new_map);
-        }
-      }
-    }
-#endif
-  } // end if (!constants_shared)
-
-  // Point each gpu_constants[i] into the blob using the stored offset
-  for (int64_t i = 0; i < count; ++i) {
+  auto *constants = meta->constants();
+  for (int64_t i = 0, n = (int64_t)constants->size(); i < n; ++i) {
     size_t offset = static_cast<size_t>(constants->Get(i)->offset());
     state->gpu_constants[i] =
         static_cast<char *>(state->gpu_constants_blob) + offset;
   }
 
-  TIMING_LOG("[Session] Pointer fixup: %.3fs (%lld constants)\n",
-             record_elapsed(t_prev), (long long)count);
-  TIMING_LOG("[Session] hipdnn_ep_state_init_with_fs total: %.3fs\n",
-             elapsed_since(t0));
+  fprintf(stderr,
+          "[SHARED_CONSTANTS] Reusing existing blob "
+          "(%zu bytes, ref_count=%ld)\n",
+          total_size, new_ref);
+  return true;
+#endif
+}
 
+// Publish the freshly loaded blob into the process-wide shared cache so
+// later models with the same total_size can attach. Best-effort:
+// failures are silently tolerated (the model still works, just no
+// sharing). On non-Windows: no-op.
+static void publish_shared_constants(RuntimeState *state, size_t total_size) {
+#ifndef _WIN32
+  (void)state;
+  (void)total_size;
+#else
+  if (total_size == 0)
+    return;
+
+  char shm_name[128];
+  snprintf(shm_name, sizeof(shm_name), "Local\\hipdnn_const_%lu_%zu",
+           (unsigned long)GetCurrentProcessId(), total_size);
+
+  void *new_map =
+      CreateFileMappingA((void *)(intptr_t)-1, nullptr, SHM_PAGE_READWRITE, 0,
+                         (unsigned long)sizeof(SharedConstantsMeta), shm_name);
+  if (!new_map)
+    return;
+
+  auto *smeta = (SharedConstantsMeta *)MapViewOfFile(
+      new_map, SHM_FILE_MAP_ALL_ACCESS, 0, 0, sizeof(SharedConstantsMeta));
+  if (!smeta) {
+    CloseHandle(new_map);
+    return;
+  }
+
+  smeta->blob_ptr = state->gpu_constants_blob;
+  smeta->blob_size = total_size;
+  smeta->ref_count = 1;
+  state->shared_constants_mapping = new_map;
+  state->shared_constants_view = smeta;
+  fprintf(stderr, "[SHARED_CONSTANTS] Published new blob (%zu bytes)\n",
+          total_size);
+#endif
+}
+
+// Load the entire constants sidecar as one blob and hipMemcpy it into the
+// pre-allocated gpu_constants_blob. Used when OnnxToHip wrote
+// model.constants.bin (non-streaming path: hip-compiler CLI, EPContext
+// import, mem-addr downgrade).
+static int bulk_load_constants(RuntimeState *state, morphizen::FileSystem *fs,
+                               const char *constants_filename) {
+  auto t_prev = timing_now();
+
+  auto reader = fs->create_reader_template(constants_filename);
+  if (!reader) {
+    fprintf(stderr, "Failed to open %s via FileSystem\n", constants_filename);
+    return 1;
+  }
+  size_t total_size = reader->size();
+
+  TIMING_LOG("[Session] open sidecar %s: %.3fs (%zu bytes)\n",
+             constants_filename, record_elapsed(t_prev), total_size);
+
+  const void *src = reader->mmap();
+  void *cpu_buf = nullptr;
+
+  TIMING_LOG("[Session] VRAM path: mmap %s\n",
+             src ? "succeeded" : "failed, using fread fallback");
+
+  if (!src) {
+    cpu_buf = malloc(total_size);
+    if (!cpu_buf) {
+      fprintf(stderr, "Failed to allocate staging buffer (%zu bytes)\n",
+              total_size);
+      return 1;
+    }
+    size_t bytes_read = reader->fread(cpu_buf, total_size);
+    if (bytes_read != total_size) {
+      fprintf(stderr, "Short read: got %zu of %zu bytes\n", bytes_read,
+              total_size);
+      free(cpu_buf);
+      return 1;
+    }
+    src = cpu_buf;
+    TIMING_LOG("[Session] fread constants.bin: %.3fs (%zu bytes)\n",
+               record_elapsed(t_prev), total_size);
+  }
+
+  if (hipMemcpy(state->gpu_constants_blob, src, total_size,
+                hipMemcpyHostToDevice) != hipSuccess) {
+    fprintf(stderr, "hipMemcpy failed for constants blob\n");
+    free(cpu_buf);
+    return 1;
+  }
+
+  TIMING_LOG("[Session] hipMemcpy H2D bulk: %.3fs (%zu bytes)\n",
+             record_elapsed(t_prev), total_size);
+
+  free(cpu_buf); // no-op when mmap was used
+  return 0;
+}
+
+// Per-process single-slot cache for the external-data file referenced by
+// streaming file-ref entries. LLM models typically have one giant
+// weights.data shared by all file-ref tensors, so a size-1 cache keeps
+// the FILE* open for the entire streaming loop. Different path closes
+// old and opens new.
+//
+// Uses stdio FILE* rather than morphizen::FileSystem because file-ref
+// sources (weights.data) are absolute OS paths authored by OnnxToHip
+// from ORT's external data info. PassContext's FileSystem only resolves
+// in-memory tar / cache entries, which weights.data is not.
+struct FrefCache {
+  char path[1024];
+  std::FILE *fp;
+};
+
+static void fref_cache_init(FrefCache *c) {
+  c->path[0] = '\0';
+  c->fp = nullptr;
+}
+
+static void fref_cache_release(FrefCache *c) {
+  if (c->fp) {
+    std::fclose(c->fp);
+    c->fp = nullptr;
+  }
+}
+
+// Ensure c->fp points at `path` (null-terminated C string; flatbuffer
+// String::c_str() is guaranteed null-terminated). Returns true on success.
+static bool fref_cache_open(FrefCache *c, const char *path) {
+  if (c->fp && std::strcmp(c->path, path) == 0) {
+    return true; // same path, reuse
+  }
+  fref_cache_release(c);
+  size_t path_len = std::strlen(path);
+  if (path_len + 1 > sizeof(c->path)) {
+    fprintf(stderr, "file-ref path too long (%zu bytes)\n", path_len);
+    return false;
+  }
+  memcpy(c->path, path, path_len + 1);
+  c->fp = std::fopen(c->path, "rb");
+  if (!c->fp) {
+    fprintf(stderr, "Failed to open file-ref source: %s\n", c->path);
+    return false;
+  }
+  return true;
+}
+
+// Copy `size` bytes at `file_offset` from cached FILE* into `staging`.
+static int fref_fetch(FrefCache *c, int64_t file_offset, size_t size,
+                      void *staging) {
+#ifdef _WIN32
+  if (_fseeki64(c->fp, file_offset, SEEK_SET) != 0) {
+    fprintf(stderr, "fref_fetch: fseek64 to %lld failed\n",
+            (long long)file_offset);
+    return 1;
+  }
+#else
+  if (std::fseek(c->fp, (long)file_offset, SEEK_SET) != 0) {
+    fprintf(stderr, "fref_fetch: fseek to %lld failed\n",
+            (long long)file_offset);
+    return 1;
+  }
+#endif
+  size_t got = std::fread(staging, 1, size, c->fp);
+  if (got != size) {
+    fprintf(stderr, "fref_fetch: short read (got %zu of %zu)\n", got, size);
+    return 1;
+  }
+  return 0;
+}
+
+// Per-entry path: upload constants one tensor at a time driven by the
+// ConstantSource union embedded in __metadata_blob. Called when the
+// dispatch in hipdnn_ep_state_init_with_fs detected any constant with a
+// non-NONE source. gpu_constants_blob is already allocated by
+// allocate_constants_blob; this function just fills it tensor-by-tensor
+// through a single reusable staging buffer, bounding host memory to the
+// largest single tensor.
+static int per_entry_load_constants(RuntimeState *state,
+                                    const mlir::hip::HipModelMetaInfo *meta) {
+  auto t_prev = timing_now();
+
+  auto *constants = meta->constants();
+  int64_t count = constants ? (int64_t)constants->size() : 0;
+
+  // Pre-scan for max tensor size -> one-shot staging alloc.
+  size_t max_tensor_size = 0;
+  for (int64_t i = 0; i < count; ++i) {
+    size_t sz = (size_t)constants->Get(i)->size();
+    if (sz > max_tensor_size)
+      max_tensor_size = sz;
+  }
+  uint8_t *staging =
+      max_tensor_size ? (uint8_t *)malloc(max_tensor_size) : nullptr;
+  if (max_tensor_size && !staging) {
+    fprintf(stderr, "per_entry: failed to alloc %zu bytes staging\n",
+            max_tensor_size);
+    return 1;
+  }
+
+  TIMING_LOG("[Session] per_entry pre-scan + staging alloc: %.3fs "
+             "(max tensor = %zu bytes, count = %lld)\n",
+             record_elapsed(t_prev), max_tensor_size, (long long)count);
+
+  FrefCache fcache;
+  fref_cache_init(&fcache);
+
+  for (int64_t i = 0; i < count; ++i) {
+    auto *c = constants->Get(i);
+    size_t sz = (size_t)c->size();
+    void *dst = static_cast<char *>(state->gpu_constants_blob) + c->offset();
+
+    switch (c->source_type()) {
+    case mlir::hip::ConstantSource::SplatSource: {
+      auto *splat = c->source_as_SplatSource();
+      auto *eb = splat->elem_bytes();
+      size_t elem_size = eb ? eb->size() : 0;
+      if (elem_size == 0 || elem_size > 8) {
+        fprintf(stderr, "per_entry: entry %lld invalid splat elem_size %zu\n",
+                (long long)i, elem_size);
+        free(staging);
+        fref_cache_release(&fcache);
+        return 1;
+      }
+      const uint8_t *elem_bytes = eb->data();
+      for (size_t off = 0; off < sz; off += elem_size) {
+        memcpy(staging + off, elem_bytes, elem_size);
+      }
+      if (hipMemcpy(dst, staging, sz, hipMemcpyHostToDevice) != hipSuccess) {
+        fprintf(stderr, "per_entry: hipMemcpy failed for splat entry %lld\n",
+                (long long)i);
+        free(staging);
+        fref_cache_release(&fcache);
+        return 1;
+      }
+      break;
+    }
+    case mlir::hip::ConstantSource::FileRefSource: {
+      auto *fref = c->source_as_FileRefSource();
+      const char *path = fref->path() ? fref->path()->c_str() : "";
+      int64_t file_offset = fref->file_offset();
+      if (!fref_cache_open(&fcache, path)) {
+        free(staging);
+        fref_cache_release(&fcache);
+        return 1;
+      }
+      if (fref_fetch(&fcache, file_offset, sz, staging) != 0) {
+        free(staging);
+        fref_cache_release(&fcache);
+        return 1;
+      }
+      if (hipMemcpy(dst, staging, sz, hipMemcpyHostToDevice) != hipSuccess) {
+        fprintf(stderr, "per_entry: hipMemcpy failed for file-ref entry %lld\n",
+                (long long)i);
+        free(staging);
+        fref_cache_release(&fcache);
+        return 1;
+      }
+      break;
+    }
+    default:
+      // NONE in a per-entry-mode module is invalid: the dispatch only
+      // calls us when at least one entry has a source, but every entry
+      // with source=NONE has no data anywhere for us to load.
+      fprintf(stderr,
+              "per_entry: entry %lld has source=NONE in per-entry mode\n",
+              (long long)i);
+      free(staging);
+      fref_cache_release(&fcache);
+      return 1;
+    }
+  }
+
+  TIMING_LOG("[Session] per_entry upload: %.3fs (%lld constants)\n",
+             record_elapsed(t_prev), (long long)count);
+
+  free(staging);
+  fref_cache_release(&fcache);
   return 0;
 }
 
@@ -500,10 +709,7 @@ int hipdnn_ep_state_cleanup(RuntimeState *state) {
       long remaining = shm_ref_dec(&smeta->ref_count);
       fprintf(stderr, "[SHARED_CONSTANTS] Cleanup: ref_count=%ld\n", remaining);
       if (remaining <= 0) {
-        if (state->constants_blob_is_host)
-          HIP_CLEANUP(hipHostFree(state->gpu_constants_blob));
-        else
-          HIP_CLEANUP(hipFree(state->gpu_constants_blob));
+        HIP_CLEANUP(hipFree(state->gpu_constants_blob));
       }
       UnmapViewOfFile(state->shared_constants_view);
       if (state->shared_constants_mapping)
@@ -511,10 +717,7 @@ int hipdnn_ep_state_cleanup(RuntimeState *state) {
     } else
 #endif
     {
-      if (state->constants_blob_is_host)
-        HIP_CLEANUP(hipHostFree(state->gpu_constants_blob));
-      else
-        HIP_CLEANUP(hipFree(state->gpu_constants_blob));
+      HIP_CLEANUP(hipFree(state->gpu_constants_blob));
     }
   }
   if (state->gpu_constants)

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -578,7 +578,7 @@ static int fref_fetch(FrefCache *c, int64_t file_offset, size_t size,
 struct SidecarReaderCache {
   std::unique_ptr<morphizen::FileReader,
                   morphizen::FileSystem::Deleter<morphizen::FileReader>>
-      reader;                    // default-init: null pointer, deleter unused
+      reader; // default-init: null pointer, deleter unused
   const uint8_t *mmap_base = nullptr; // non-null when reader->mmap() succeeded
   size_t total_size = 0;
   bool tried_open = false;
@@ -634,8 +634,7 @@ static int sidecar_fetch(SidecarReaderCache *c, int64_t offset, size_t size,
     size_t toRead = (size_t)std::min<uint64_t>(remaining_skip, kSkipChunk);
     size_t got = c->reader->fread(skip_buf, toRead);
     if (got != toRead) {
-      fprintf(stderr,
-              "per_entry: sidecar skip short read (got %zu of %zu)\n",
+      fprintf(stderr, "per_entry: sidecar skip short read (got %zu of %zu)\n",
               got, toRead);
       return 1;
     }
@@ -643,8 +642,7 @@ static int sidecar_fetch(SidecarReaderCache *c, int64_t offset, size_t size,
   }
   size_t got = c->reader->fread(staging, size);
   if (got != size) {
-    fprintf(stderr,
-            "per_entry: sidecar payload short read (got %zu of %zu)\n",
+    fprintf(stderr, "per_entry: sidecar payload short read (got %zu of %zu)\n",
             got, size);
     return 1;
   }

--- a/lib/Runtime/runtime_state_internal.h
+++ b/lib/Runtime/runtime_state_internal.h
@@ -29,17 +29,17 @@ struct RuntimeState {
   // Single allocation holding all constants as one blob.
   // gpu_constants[i] points into gpu_constants_blob at the offset stored in
   // ConstantInfo, so only one allocation/copy is needed at init time.
-  // On dGPU: hipMalloc (VRAM). On iGPU: hipHostMalloc (pinned system RAM,
-  // GPU reads in-place, no hipMemcpy needed).
+  // Always hipMalloc (VRAM) for both dGPU and iGPU.
   void *gpu_constants_blob;
-  bool constants_blob_is_host; // true = hipHostMalloc, false = hipMalloc
   void **gpu_constants;
   size_t num_constants;
 
-  // Shared constants support: in OGA pipeline mode, prefill and decode models
-  // share the same constants.bin. The second model reuses the first's blob
-  // via a process-wide named shared memory descriptor with atomic ref count.
-  bool constants_is_shared;       // true = reusing another model's blob
+  // OGA pipeline shared constants cache: prefill and decode models share
+  // the same constants blob via process-wide named shared memory + atomic
+  // ref count. Set by try_attach_shared_constants when reusing another
+  // model's blob; cleanup decrements ref_count and only the last
+  // reference frees the GPU memory.
+  bool constants_is_shared;
   void *shared_constants_mapping; // Win32 file mapping HANDLE
   void *shared_constants_view; // MapViewOfFile pointer (SharedConstantsMeta*)
 

--- a/schemas/compilation_options.fbs
+++ b/schemas/compilation_options.fbs
@@ -13,6 +13,7 @@ table CompilationOptions {
   output_mode: OutputMode = DLL;
   verbose: bool = false;
   constants_file: string = "constants.bin";
+  skip_constant_data: bool = false;
 }
 
 root_type CompilationOptions;

--- a/schemas/model_metadata.fbs
+++ b/schemas/model_metadata.fbs
@@ -8,9 +8,25 @@ table TensorInfo {
   element_size: int64;
 }
 
+// Per-constant source descriptor baked into __metadata_blob. When a
+// ConstantInfo.source is NONE, the runtime falls back to the bulk
+// sidecar read (constants_filename). Otherwise it uploads this
+// constant tensor-by-tensor using the source-specific payload.
+table SplatSource {
+  // Element bytes (1 / 2 / 4 / 8), tile-expanded to ConstantInfo.size
+  // at runtime.
+  elem_bytes: [ubyte];
+}
+table FileRefSource {
+  path:        string;  // absolute OS path to external data file
+  file_offset: int64;   // byte offset within that file
+}
+union ConstantSource { SplatSource, FileRefSource }
+
 table ConstantInfo {
   size:   int64;
   offset: int64;
+  source: ConstantSource;
 }
 
 table HipModelMetaInfo {

--- a/schemas/model_metadata.fbs
+++ b/schemas/model_metadata.fbs
@@ -21,7 +21,15 @@ table FileRefSource {
   path:        string;  // absolute OS path to external data file
   file_offset: int64;   // byte offset within that file
 }
-union ConstantSource { SplatSource, FileRefSource }
+// Hybrid path: a constant whose source could not be re-read on demand
+// (mem-addr alias of DenseAttr / OrtValue) was packed into the small
+// per-session sidecar. The runtime fetches `size` bytes at
+// `sidecar_offset` from HipModelMetaInfo.constants_filename through
+// the EP's FileSystem and uploads via the per-entry staging buffer.
+table SidecarSource {
+  sidecar_offset: int64; // byte offset within HipModelMetaInfo.constants_filename
+}
+union ConstantSource { SplatSource, FileRefSource, SidecarSource }
 
 table ConstantInfo {
   size:   int64;

--- a/test/lit/Conversion/onnx-to-hip/test_constant_location_missing_attrs.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_constant_location_missing_attrs.mlir
@@ -11,7 +11,7 @@
 
 // RUN: not hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s 2>&1 | FileCheck %s
 
-// CHECK: error: onnx.Constant with location attribute missing offset or size
+// CHECK: error: onnx.Constant with location attribute missing location/offset/size
 // CHECK-NEXT: %0 = "onnx.Constant"() {location = "*/_ORT_MEM_ADDR_/*"} : () -> tensor<2x4xf32>
 // CHECK-NEXT: ^
 

--- a/test/lit/Conversion/onnx-to-hip/test_constant_location_null_addr.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_constant_location_null_addr.mlir
@@ -10,7 +10,7 @@
 
 // RUN: not hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s 2>&1 | FileCheck %s
 
-// CHECK: error: onnx.Constant has invalid address/size
+// CHECK: error: onnx.Constant mem-addr has null address
 // CHECK-NEXT: %0 = "onnx.Constant"() {location = "*/_ORT_MEM_ADDR_/*", offset = 0 : i64, size = 32 : i64} : () -> tensor<2x4xf32>
 // CHECK-NEXT: ^
 


### PR DESCRIPTION
## 1. User workflows and the problem

PR132 serves two ORT EP user workflows:

**Workflow A — EPContext export + import (deployment)**

1. One-time export: `onnxruntime_perf_test ... -C "ep.context_enable|1 ep.context_embed_mode|0 ep.context_file_path|foo_ctx.onnx" -I model.onnx`
   - Produces `foo_ctx.onnx` (ONNX metadata shell) + `foo_ctx.onnx_MORPHIZEN.bin` (tar containing `model.dll` + `model.constants.bin`)
2. Deploy / re-launch: `onnxruntime_perf_test ... -I foo_ctx.onnx`
   - Skips compilation, mmap's the sidecar from the tar, single `hipMemcpy` to GPU

**Workflow B — In-process direct compile + run (development / one-shot)**

1. EP ingests the original `model.onnx` directly: `onnxruntime_perf_test ... -I model.onnx`
2. Compile + upload + infer on the fly; no persisted artifact

**The problem is in Workflow B** — two related but independent issues:

**B-1: slow session creation (primary pain point)**

On baseline, to hand constants over to the runtime, each `onnx.Constant`'s raw bytes are written one by one into an intermediate constants file during compilation; then at session-init the runtime reads that file back and copies it to GPU. The same N GB of data goes through the system **three times**: read original `weights.data` → write intermediate file → read intermediate file → hipMemcpy to GPU. For a 15 GB model, session creation takes **41.20 s** (measured on main `bfba96df` in CI) — users pay this cost on every cold start.

**B-2: high peak memory (amplification risk)**

Baseline runtime reads the whole constants blob into host RAM and issues a single `hipMemcpy` to GPU. At the peak moment, the host holds an N GB source while the GPU already has an N GB destination allocated; adding OS overhead the total is roughly **2N + 17 GB**. On a 48 GB APU, the 15 GB model measured at 15.22 GB Peak WS (near saturation); a 30 GB+ model scales linearly past 48 GB and OOMs.

**Workflow A's export stage exhibits the same compile-then-sidecar pattern** (baseline 53.37 s). A is not the primary scope of this PR — its purpose is to persist a portable sidecar for cross-machine deployment — but it picks up a ~12% export speedup (53.37 s → 46.91 s) as a side effect. Import (baseline 7.67 s, this PR 7.43 s) is unchanged.

## 2. Solution

### Architecture

```mermaid
flowchart TD
    subgraph compileBox [Compile time: OnnxToHip pass]
        direction LR
        Walk["Walk: classify each constant"] --> Decide{"Source kind"}
        Decide -->|"file-ref / splat"| Bake["Bake descriptor<br/>into model.dll metadata"]
        Decide -->|"mem-addr (inline / OrtValue alias)"| Pack["Pack bytes into<br/>partial sidecar +<br/>SidecarSource{sidecar_offset}"]
    end

    Bake --> Artifact["model.dll<br/>(+ partial sidecar<br/>when any mem-addr present)"]
    Pack --> Artifact

    Artifact --> Choose{"Any per-entry source?"}

    subgraph runtimeBox [Runtime: session-init]
        direction LR
        Choose -->|"Yes (Splat / FileRef / Sidecar mix)"| Stream["Per-tensor streaming<br/>through one staging buffer"]
        Choose -->|"No (Workflow A import)"| Bulk["Bulk: read full sidecar<br/>+ single hipMemcpy"]
    end
```

1. **OnnxToHip no longer `fwrite`s the whole constants blob at compile time**: the walk phase only records per-constant source descriptors. Splat and external file-ref entries become tiny in-metadata records; mem-addr entries (DenseAttr raw / OrtValue alias) get packed into a *partial* sidecar that holds only their bytes.
2. **All source info is baked directly into the build artifact**: via the `ConstantSource` union in `HipModelMetaInfo` (`SplatSource` / `FileRefSource` / `SidecarSource`), traveling with `model.dll`. The runtime dispatches per descriptor without probing for file existence.
3. **Runtime streams per descriptor**: at session-init, for each constant in order, fetch from its source (splat tile / file-ref fread / partial-sidecar fread) → `hipMemcpy` → reuse the same staging buffer. Peak host usage equals the size of the single largest tensor rather than the whole model.
4. **Hybrid sidecar for the mem-addr fallback**: previously, any mem-addr constant forced the entire pass to fall back to writing a full N GB sidecar — losing the streaming win for the file-ref + splat majority. The hybrid path keeps mem-addr entries on a compact 64B-aligned partial sidecar (typically MB-class for inline norms / biases), while file-ref and splat constants stay on the streaming path. The runtime per-entry loop handles all three source kinds through the same staging buffer.
5. **Bulk sidecar path preserved for Workflow A import**: when `__metadata_blob` carries no per-entry source (the EPContext export case), runtime still does the single `hipMemcpy` of the full sidecar — unchanged from main.
6. **Compatible with OGA pipeline shared cache**: integrates with the process-wide GPU constants cache introduced in main's PR #109 so prefill + decode can reuse the same GPU blob.

### Path dispatch

**Workflow B — in-process direct compile + run**

| Scenario                     | Trigger                                                                | Constants upload path                                                                                                | User-visible win                                                                |
| ---------------------------- | ---------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| Streaming path (typical LLM) | All constants are external `weights.data` (file-ref) or splat          | Per-tensor streaming driven by metadata descriptors (**primary win**)                                                | Session time -84%, host peak WS -92%                                            |
| Hybrid path (mixed sources)  | Some constants are mem-addr (inline raw_data / ORT-resolved OrtValue)  | mem-addr packed into a small partial sidecar with `SidecarSource{offset}`; file-ref + splat keep streaming           | Same staging-buffer profile as streaming; sidecar shrunk to mem-addr bytes only |

**Workflow A — EPContext export + import**

| Scenario | Trigger                                | Constants upload path                                     | User-visible win                                         |
| -------- | -------------------------------------- | --------------------------------------------------------- | -------------------------------------------------------- |
| Export   | `ep.context_enable=1` + `embed_mode=0` | Compile-time writes full sidecar into `_MORPHIZEN.bin` tar | Self-contained artifact; cross-machine independent       |
| Import   | Load `_ctx.onnx` directly              | Session-init reads the bulk sidecar from inside the tar   | Same behavior as main                                    |

## 3. Results

### Performance (`full_model_seq128.onnx`, 15 GB external data, measured in CI)

Peak WS values below use the same GiB convention as the CI `Publish perf results` step (PowerShell `1GB = 1024³`); MB values from the perf comment are divided by 1024.

Data sources:

- baseline: PR #142 (cherry-picks just the EPContext perf CI step onto origin/main), commit `60cc9d2`, CI run [24882748786](https://github.com/ROCm/onnx-hipdnn-ep/actions/runs/24882748786)
- this PR: commit `fa30493`, CI run [24881732447](https://github.com/ROCm/onnx-hipdnn-ep/actions/runs/24881732447)

**Workflow B — in-process direct compile + run (primary battleground)**

| Metric            | baseline (60cc9d2) | this PR (fa30493) | Delta    | Problem addressed  |
| ----------------- | ------------------ | ----------------- | -------- | ------------------ |
| Session creation  | 41.96 s            | **6.23 s**        | **-85%** | B-1 time (primary) |
| Peak WS           | 15.23 GB           | **1.21 GB**       | **-92%** | B-2 memory         |
| First inference   | 240 ms             | 244 ms            | ±2%      | (no regression)    |
| QPS               | 6.97               | 6.88              | -1%      | (no regression)    |

**Source of the B-1 speedup**: constants no longer round-trip through an intermediate file. The runtime reads the right offset in the original `weights.data` directly per metadata descriptors and `hipMemcpy`s to GPU. One pass through the filesystem instead of three — session time drops from 41.96 s to 6.23 s for the 15 GB model.

**Source of the B-2 Peak WS drop**: the runtime no longer slurps the entire constants blob into host RAM in one shot. It reuses a single staging buffer sized to the largest tensor (≈ 1.05 GB — the embedding weight — for `full_model_seq128`). Host usage scales with the largest single tensor rather than the total model size, so a 48 GB APU can now run 30 GB+ models (GPU VRAM is a separate constraint).

**Workflow A — EPContext export + import (deployment)**

| Metric            | baseline export | this PR export       | baseline import | this PR import       |
| ----------------- | --------------: | -------------------: | --------------: | -------------------: |
| Session creation  |         53.54 s |              48.23 s |          6.76 s |               6.80 s |
| Peak WS           |        15.22 GB |             15.22 GB |        15.26 GB |             15.26 GB |
| First inference   |          221 ms |               218 ms |          226 ms |               239 ms |
| QPS               |            7.32 |                 7.28 |            7.31 |                 7.32 |

A is flat overall: export picks up ~10% (one fewer detour in the sidecar-write path), Peak WS is byte-level unchanged (sub-MB diff vs baseline — within page-cache noise), and import is within noise (sub-50 ms session delta on 6.8 s baseline). The sidecar bake-and-mmap pattern is preserved for Workflow A — the value of this PR is making Workflow B substantially faster and cheaper **without disturbing A's artifact format or behavior**.

**OGA pipeline (end-to-end LLM, prefill + decode sharing the constants cache)**

| Model         | TTFT baseline | TTFT this PR | TPS baseline | TPS this PR | Peak Mem baseline | Peak Mem this PR | Mem Delta |
| ------------- | ------------: | -----------: | -----------: | ----------: | ----------------: | ---------------: | --------- |
| GPT-OSS-20B   |       146.7 ms |     146.7 ms |         56.3 |        55.8 |           12.06 GB |     **1.32 GB**   | **-89%**  |
| Llama-3.1-8B  |       150.8 ms |     153.4 ms |         10.1 |        10.0 |           15.28 GB |     **1.21 GB**   | **-92%**  |

OGA spawns separate prefill + decode model.dlls. With the per-tensor streaming path each one would still pay an N GB hipMemcpy on its own; the process-wide shared constants cache (PR #109, integrated here) lets the second model attach to the first's GPU blob, so OGA Peak Mem collapses to a single staging-buffer allocation rather than 2 × N GB. TTFT and TPS unchanged within noise — same kernels, same scheduling, only the constants-upload path differs.

### Architectural side effects

- **`HipModelMetaInfo` schema extension**: `ConstantInfo.source` becomes a three-way union of `SplatSource` / `FileRefSource` / `SidecarSource`, so the runtime dispatches on metadata semantics instead of probing for file existence.
- **Diff vs main**: 23 files, +1166/−424 (rebased on origin/main `bfba96df`).

### CI verification

- Windows Build (full pipeline): success
- Windows Build (Mock): success
- pre-commit: success
- gpu-test: all perf + L2 + OGA checks pass
- **New EPContext export+import perf step** (scoped to `full_model_seq128`), with two additional tables added to the "Publish perf results" step

### Dependencies

- MorphiZen #207 (external initializer info) — included via submodule pointer
- MorphiZen #206 (EP context attr-leak fix) — included via submodule pointer
