### PR TITLE
feat: Unified Memory Manager (Phase 1 + 2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,5 +153,8 @@ if(BUILD_HIP_TOOLS)
 
     # E2E integration tests (compile MLIR → DLL → execute)
     add_subdirectory(test/e2e)
+
+    # Memory Manager unit tests (GoogleTest)
+    add_subdirectory(test/unit/mm)
   endif()
 endif()

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -3,6 +3,7 @@
 # ** Licensed under the MIT License.
 ##
 
+add_subdirectory(MemoryManager)
 add_subdirectory(Dialect)
 option(BUILD_HIPDNN_GRAPH "Build hipDNN fused-graph support" OFF)
 set(HIPDNN_AVAILABLE OFF)

--- a/lib/MemoryManager/CMakeLists.txt
+++ b/lib/MemoryManager/CMakeLists.txt
@@ -1,0 +1,54 @@
+##
+# ** Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# ** Licensed under the MIT License.
+##
+
+# Unified Memory Manager library
+
+set(MM_SOURCES
+    mm_hal.cpp
+    mm_hal_host.cpp
+    mm_config.cpp
+    mm_core.cpp
+    mm_pool.cpp
+    mm_arena.cpp
+    mm_handle_table.cpp
+    mm_runtime_bridge.cpp
+    mm_free_list.cpp
+    mm_kv.cpp
+    mm_block_table.cpp
+)
+
+set(MM_HEADERS
+    mm_types.h
+    mm_hal.h
+    mm_config.h
+    mm_core.h
+    mm_pool.h
+    mm_arena.h
+    mm_internal.h
+    mm_handle_table.h
+)
+
+add_library(HipDnnEpMemoryManager STATIC ${MM_SOURCES} ${MM_HEADERS})
+
+target_include_directories(HipDnnEpMemoryManager
+    PUBLIC  ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+# HIP backend (conditional on real runtime)
+if(NOT BUILD_MOCK_RUNTIME)
+    find_package(hip QUIET)
+    if(TARGET hip::host)
+        target_sources(HipDnnEpMemoryManager PRIVATE mm_hal_hip.cpp)
+        target_compile_definitions(HipDnnEpMemoryManager PUBLIC MM_HAS_HIP)
+        target_link_libraries(HipDnnEpMemoryManager PRIVATE hip::host)
+    else()
+        message(WARNING "Memory Manager: hip::host not found, building without HIP backend")
+    endif()
+endif()
+
+# C++17 required for std::shared_mutex, structured bindings
+target_compile_features(HipDnnEpMemoryManager PUBLIC cxx_std_17)
+
+message(STATUS "Memory Manager: enabled (mock=${BUILD_MOCK_RUNTIME})")

--- a/lib/MemoryManager/mm_arena.cpp
+++ b/lib/MemoryManager/mm_arena.cpp
@@ -10,99 +10,98 @@ namespace mm {
 BfcAllocator::~BfcAllocator() { shutdown(); }
 
 int BfcAllocator::init(const mm_hal_t *hal, int device_id, size_t capacity) {
-    if (!hal || capacity == 0)
-        return MM_ERROR_INVALID_ARG;
+  if (!hal || capacity == 0)
+    return MM_ERROR_INVALID_ARG;
 
-    hal_ = hal;
-    device_id_ = device_id;
-    capacity_ = capacity;
+  hal_ = hal;
+  device_id_ = device_id;
+  capacity_ = capacity;
 
-    base_ = hal_->raw_alloc(device_id_, capacity_, kDefaultAlignment);
-    if (!base_)
-        return MM_ERROR_OUT_OF_MEMORY;
+  base_ = hal_->raw_alloc(device_id_, capacity_, kDefaultAlignment);
+  if (!base_)
+    return MM_ERROR_OUT_OF_MEMORY;
 
-    /* Start with one large free block covering the entire slab */
-    blocks_.push_back({0, capacity_, false});
-    used_bytes_ = 0;
-    return MM_OK;
+  /* Start with one large free block covering the entire slab */
+  blocks_.push_back({0, capacity_, false});
+  used_bytes_ = 0;
+  return MM_OK;
 }
 
 void *BfcAllocator::alloc(size_t size, size_t alignment) {
-    if (size == 0)
-        return nullptr;
+  if (size == 0)
+    return nullptr;
 
-    /* Round up size to alignment */
-    size_t aligned_size = (size + alignment - 1) & ~(alignment - 1);
+  /* Round up size to alignment */
+  size_t aligned_size = (size + alignment - 1) & ~(alignment - 1);
 
-    std::lock_guard<std::mutex> lock(mutex_);
+  std::lock_guard<std::mutex> lock(mutex_);
 
-    /* Best-fit search */
-    int best_idx = -1;
-    size_t best_size = SIZE_MAX;
-    for (int i = 0; i < (int)blocks_.size(); ++i) {
-        if (!blocks_[i].in_use && blocks_[i].size >= aligned_size) {
-            if (blocks_[i].size < best_size) {
-                best_size = blocks_[i].size;
-                best_idx = i;
-            }
-        }
+  /* Best-fit search */
+  int best_idx = -1;
+  size_t best_size = SIZE_MAX;
+  for (int i = 0; i < (int)blocks_.size(); ++i) {
+    if (!blocks_[i].in_use && blocks_[i].size >= aligned_size) {
+      if (blocks_[i].size < best_size) {
+        best_size = blocks_[i].size;
+        best_idx = i;
+      }
     }
+  }
 
-    if (best_idx < 0)
-        return nullptr; /* Out of memory */
+  if (best_idx < 0)
+    return nullptr; /* Out of memory */
 
-    Block &blk = blocks_[best_idx];
-    void *ptr = static_cast<char *>(base_) + blk.offset;
+  Block &blk = blocks_[best_idx];
+  void *ptr = static_cast<char *>(base_) + blk.offset;
 
-    /* Split if remainder is large enough */
-    if (blk.size > aligned_size + kDefaultAlignment) {
-        Block remainder{blk.offset + aligned_size,
-                        blk.size - aligned_size, false};
-        blk.size = aligned_size;
-        blocks_.insert(blocks_.begin() + best_idx + 1, remainder);
-    }
+  /* Split if remainder is large enough */
+  if (blk.size > aligned_size + kDefaultAlignment) {
+    Block remainder{blk.offset + aligned_size, blk.size - aligned_size, false};
+    blk.size = aligned_size;
+    blocks_.insert(blocks_.begin() + best_idx + 1, remainder);
+  }
 
-    blk.in_use = true;
-    used_bytes_ += blk.size;
-    return ptr;
+  blk.in_use = true;
+  used_bytes_ += blk.size;
+  return ptr;
 }
 
 void BfcAllocator::free(void *ptr) {
-    if (!ptr || !base_)
-        return;
+  if (!ptr || !base_)
+    return;
 
-    size_t offset = static_cast<char *>(ptr) - static_cast<char *>(base_);
+  size_t offset = static_cast<char *>(ptr) - static_cast<char *>(base_);
 
-    std::lock_guard<std::mutex> lock(mutex_);
+  std::lock_guard<std::mutex> lock(mutex_);
 
-    for (int i = 0; i < (int)blocks_.size(); ++i) {
-        if (blocks_[i].offset == offset && blocks_[i].in_use) {
-            blocks_[i].in_use = false;
-            used_bytes_ -= blocks_[i].size;
+  for (int i = 0; i < (int)blocks_.size(); ++i) {
+    if (blocks_[i].offset == offset && blocks_[i].in_use) {
+      blocks_[i].in_use = false;
+      used_bytes_ -= blocks_[i].size;
 
-            /* Coalesce with next block */
-            if (i + 1 < (int)blocks_.size() && !blocks_[i + 1].in_use) {
-                blocks_[i].size += blocks_[i + 1].size;
-                blocks_.erase(blocks_.begin() + i + 1);
-            }
-            /* Coalesce with previous block */
-            if (i > 0 && !blocks_[i - 1].in_use) {
-                blocks_[i - 1].size += blocks_[i].size;
-                blocks_.erase(blocks_.begin() + i);
-            }
-            return;
-        }
+      /* Coalesce with next block */
+      if (i + 1 < (int)blocks_.size() && !blocks_[i + 1].in_use) {
+        blocks_[i].size += blocks_[i + 1].size;
+        blocks_.erase(blocks_.begin() + i + 1);
+      }
+      /* Coalesce with previous block */
+      if (i > 0 && !blocks_[i - 1].in_use) {
+        blocks_[i - 1].size += blocks_[i].size;
+        blocks_.erase(blocks_.begin() + i);
+      }
+      return;
     }
+  }
 }
 
 void BfcAllocator::shutdown() {
-    if (base_ && hal_) {
-        hal_->raw_free(device_id_, base_);
-        base_ = nullptr;
-    }
-    blocks_.clear();
-    capacity_ = 0;
-    used_bytes_ = 0;
+  if (base_ && hal_) {
+    hal_->raw_free(device_id_, base_);
+    base_ = nullptr;
+  }
+  blocks_.clear();
+  capacity_ = 0;
+  used_bytes_ = 0;
 }
 
 /* ---- ArenaAllocator ---- */
@@ -110,140 +109,140 @@ void BfcAllocator::shutdown() {
 ArenaAllocator::~ArenaAllocator() { shutdown(); }
 
 uint32_t ArenaAllocator::size_class(size_t size) {
-    for (uint32_t c = 0; c < kArenaClassCount - 1; ++c) {
-        if (size < kClassBounds[c])
-            return c;
-    }
-    return kArenaClassCount - 1; /* BFC fallback */
+  for (uint32_t c = 0; c < kArenaClassCount - 1; ++c) {
+    if (size < kClassBounds[c])
+      return c;
+  }
+  return kArenaClassCount - 1; /* BFC fallback */
 }
 
 int ArenaAllocator::init(const mm_hal_t *hal, int device_id,
                          size_t total_budget, uint32_t num_classes) {
-    if (!hal || total_budget == 0)
-        return MM_ERROR_INVALID_ARG;
+  if (!hal || total_budget == 0)
+    return MM_ERROR_INVALID_ARG;
 
-    hal_ = hal;
-    device_id_ = device_id;
-    num_classes_ = std::min(num_classes, (uint32_t)kArenaClassCount);
+  hal_ = hal;
+  device_id_ = device_id;
+  num_classes_ = std::min(num_classes, (uint32_t)kArenaClassCount);
 
-    /*
-     * Budget split: 70% to BFC (large allocs), 30% split across arenas.
-     * This matches typical LLM workloads where workspace allocations
-     * dominate activation memory.
-     */
-    size_t bfc_budget = (total_budget * 7) / 10;
-    size_t arena_budget = total_budget - bfc_budget;
-    size_t per_arena = arena_budget / num_classes_;
+  /*
+   * Budget split: 70% to BFC (large allocs), 30% split across arenas.
+   * This matches typical LLM workloads where workspace allocations
+   * dominate activation memory.
+   */
+  size_t bfc_budget = (total_budget * 7) / 10;
+  size_t arena_budget = total_budget - bfc_budget;
+  size_t per_arena = arena_budget / num_classes_;
 
-    /* Initialize per-class arenas */
-    for (uint32_t c = 0; c < num_classes_; ++c) {
-        /* Larger classes get proportionally more memory */
-        size_t capacity = per_arena * (c + 1) / num_classes_;
-        if (capacity < 4096)
-            capacity = 4096;
+  /* Initialize per-class arenas */
+  for (uint32_t c = 0; c < num_classes_; ++c) {
+    /* Larger classes get proportionally more memory */
+    size_t capacity = per_arena * (c + 1) / num_classes_;
+    if (capacity < 4096)
+      capacity = 4096;
 
-        arenas_[c].base = hal_->raw_alloc(device_id_, capacity, kDefaultAlignment);
-        if (!arenas_[c].base) {
-            shutdown();
-            return MM_ERROR_OUT_OF_MEMORY;
-        }
-        arenas_[c].capacity = capacity;
-        arenas_[c].offset.store(0, std::memory_order_relaxed);
+    arenas_[c].base = hal_->raw_alloc(device_id_, capacity, kDefaultAlignment);
+    if (!arenas_[c].base) {
+      shutdown();
+      return MM_ERROR_OUT_OF_MEMORY;
     }
+    arenas_[c].capacity = capacity;
+    arenas_[c].offset.store(0, std::memory_order_relaxed);
+  }
 
-    /* Initialize BFC for large allocations */
-    if (bfc_budget > 0) {
-        int err = bfc_.init(hal_, device_id_, bfc_budget);
-        if (err != MM_OK) {
-            shutdown();
-            return err;
-        }
+  /* Initialize BFC for large allocations */
+  if (bfc_budget > 0) {
+    int err = bfc_.init(hal_, device_id_, bfc_budget);
+    if (err != MM_OK) {
+      shutdown();
+      return err;
     }
+  }
 
-    initialized_ = true;
-    return MM_OK;
+  initialized_ = true;
+  return MM_OK;
 }
 
 void *ArenaAllocator::alloc(size_t size, size_t alignment) {
-    if (!initialized_ || size == 0)
-        return nullptr;
+  if (!initialized_ || size == 0)
+    return nullptr;
 
-    uint32_t cls = size_class(size);
+  uint32_t cls = size_class(size);
 
-    /* BFC fallback for large allocations or class 7 */
-    if (cls >= num_classes_ || size >= kBfcThreshold)
-        return bfc_.alloc(size, alignment);
+  /* BFC fallback for large allocations or class 7 */
+  if (cls >= num_classes_ || size >= kBfcThreshold)
+    return bfc_.alloc(size, alignment);
 
-    /* Atomic bump allocation (lock-free) */
-    size_t aligned_size = (size + alignment - 1) & ~(alignment - 1);
-    Arena &arena = arenas_[cls];
+  /* Atomic bump allocation (lock-free) */
+  size_t aligned_size = (size + alignment - 1) & ~(alignment - 1);
+  Arena &arena = arenas_[cls];
 
-    size_t old_offset =
-        arena.offset.fetch_add(aligned_size, std::memory_order_relaxed);
-    if (old_offset + aligned_size > arena.capacity) {
-        /* Arena exhausted — fall back to BFC */
-        arena.offset.fetch_sub(aligned_size, std::memory_order_relaxed);
-        return bfc_.alloc(size, alignment);
-    }
+  size_t old_offset =
+      arena.offset.fetch_add(aligned_size, std::memory_order_relaxed);
+  if (old_offset + aligned_size > arena.capacity) {
+    /* Arena exhausted — fall back to BFC */
+    arena.offset.fetch_sub(aligned_size, std::memory_order_relaxed);
+    return bfc_.alloc(size, alignment);
+  }
 
-    return static_cast<char *>(arena.base) + old_offset;
+  return static_cast<char *>(arena.base) + old_offset;
 }
 
 void ArenaAllocator::free(void *ptr, size_t size) {
-    if (!ptr)
-        return;
+  if (!ptr)
+    return;
 
-    /* Check if this pointer belongs to BFC (not in any arena range) */
-    for (uint32_t c = 0; c < num_classes_; ++c) {
-        char *base = static_cast<char *>(arenas_[c].base);
-        if (ptr >= base && ptr < base + arenas_[c].capacity)
-            return; /* Arena allocs are freed in bulk via reset() */
-    }
+  /* Check if this pointer belongs to BFC (not in any arena range) */
+  for (uint32_t c = 0; c < num_classes_; ++c) {
+    char *base = static_cast<char *>(arenas_[c].base);
+    if (ptr >= base && ptr < base + arenas_[c].capacity)
+      return; /* Arena allocs are freed in bulk via reset() */
+  }
 
-    /* Must be a BFC allocation */
-    bfc_.free(ptr);
+  /* Must be a BFC allocation */
+  bfc_.free(ptr);
 }
 
 void ArenaAllocator::reset() {
-    for (uint32_t c = 0; c < num_classes_; ++c) {
-        arenas_[c].offset.store(0, std::memory_order_relaxed);
-    }
-    /* BFC allocations are not reset — they have explicit lifetimes */
+  for (uint32_t c = 0; c < num_classes_; ++c) {
+    arenas_[c].offset.store(0, std::memory_order_relaxed);
+  }
+  /* BFC allocations are not reset — they have explicit lifetimes */
 }
 
 void ArenaAllocator::shutdown() {
-    if (!hal_)
-        return;
+  if (!hal_)
+    return;
 
-    for (uint32_t c = 0; c < kArenaClassCount; ++c) {
-        if (arenas_[c].base) {
-            hal_->raw_free(device_id_, arenas_[c].base);
-            arenas_[c].base = nullptr;
-            arenas_[c].capacity = 0;
-            arenas_[c].offset.store(0, std::memory_order_relaxed);
-        }
+  for (uint32_t c = 0; c < kArenaClassCount; ++c) {
+    if (arenas_[c].base) {
+      hal_->raw_free(device_id_, arenas_[c].base);
+      arenas_[c].base = nullptr;
+      arenas_[c].capacity = 0;
+      arenas_[c].offset.store(0, std::memory_order_relaxed);
     }
+  }
 
-    bfc_.shutdown();
-    initialized_ = false;
+  bfc_.shutdown();
+  initialized_ = false;
 }
 
 size_t ArenaAllocator::used_bytes() const {
-    size_t total = 0;
-    for (uint32_t c = 0; c < num_classes_; ++c) {
-        total += arenas_[c].offset.load(std::memory_order_relaxed);
-    }
-    total += bfc_.used_bytes();
-    return total;
+  size_t total = 0;
+  for (uint32_t c = 0; c < num_classes_; ++c) {
+    total += arenas_[c].offset.load(std::memory_order_relaxed);
+  }
+  total += bfc_.used_bytes();
+  return total;
 }
 
 size_t ArenaAllocator::total_bytes() const {
-    size_t total = 0;
-    for (uint32_t c = 0; c < num_classes_; ++c) {
-        total += arenas_[c].capacity;
-    }
-    total += bfc_.total_bytes();
-    return total;
+  size_t total = 0;
+  for (uint32_t c = 0; c < num_classes_; ++c) {
+    total += arenas_[c].capacity;
+  }
+  total += bfc_.total_bytes();
+  return total;
 }
 
 } // namespace mm

--- a/lib/MemoryManager/mm_arena.cpp
+++ b/lib/MemoryManager/mm_arena.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
 #include "mm_arena.h"
 
 #include <algorithm>

--- a/lib/MemoryManager/mm_arena.cpp
+++ b/lib/MemoryManager/mm_arena.cpp
@@ -1,0 +1,249 @@
+#include "mm_arena.h"
+
+#include <algorithm>
+#include <cstring>
+
+namespace mm {
+
+/* ---- BfcAllocator ---- */
+
+BfcAllocator::~BfcAllocator() { shutdown(); }
+
+int BfcAllocator::init(const mm_hal_t *hal, int device_id, size_t capacity) {
+    if (!hal || capacity == 0)
+        return MM_ERROR_INVALID_ARG;
+
+    hal_ = hal;
+    device_id_ = device_id;
+    capacity_ = capacity;
+
+    base_ = hal_->raw_alloc(device_id_, capacity_, kDefaultAlignment);
+    if (!base_)
+        return MM_ERROR_OUT_OF_MEMORY;
+
+    /* Start with one large free block covering the entire slab */
+    blocks_.push_back({0, capacity_, false});
+    used_bytes_ = 0;
+    return MM_OK;
+}
+
+void *BfcAllocator::alloc(size_t size, size_t alignment) {
+    if (size == 0)
+        return nullptr;
+
+    /* Round up size to alignment */
+    size_t aligned_size = (size + alignment - 1) & ~(alignment - 1);
+
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    /* Best-fit search */
+    int best_idx = -1;
+    size_t best_size = SIZE_MAX;
+    for (int i = 0; i < (int)blocks_.size(); ++i) {
+        if (!blocks_[i].in_use && blocks_[i].size >= aligned_size) {
+            if (blocks_[i].size < best_size) {
+                best_size = blocks_[i].size;
+                best_idx = i;
+            }
+        }
+    }
+
+    if (best_idx < 0)
+        return nullptr; /* Out of memory */
+
+    Block &blk = blocks_[best_idx];
+    void *ptr = static_cast<char *>(base_) + blk.offset;
+
+    /* Split if remainder is large enough */
+    if (blk.size > aligned_size + kDefaultAlignment) {
+        Block remainder{blk.offset + aligned_size,
+                        blk.size - aligned_size, false};
+        blk.size = aligned_size;
+        blocks_.insert(blocks_.begin() + best_idx + 1, remainder);
+    }
+
+    blk.in_use = true;
+    used_bytes_ += blk.size;
+    return ptr;
+}
+
+void BfcAllocator::free(void *ptr) {
+    if (!ptr || !base_)
+        return;
+
+    size_t offset = static_cast<char *>(ptr) - static_cast<char *>(base_);
+
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    for (int i = 0; i < (int)blocks_.size(); ++i) {
+        if (blocks_[i].offset == offset && blocks_[i].in_use) {
+            blocks_[i].in_use = false;
+            used_bytes_ -= blocks_[i].size;
+
+            /* Coalesce with next block */
+            if (i + 1 < (int)blocks_.size() && !blocks_[i + 1].in_use) {
+                blocks_[i].size += blocks_[i + 1].size;
+                blocks_.erase(blocks_.begin() + i + 1);
+            }
+            /* Coalesce with previous block */
+            if (i > 0 && !blocks_[i - 1].in_use) {
+                blocks_[i - 1].size += blocks_[i].size;
+                blocks_.erase(blocks_.begin() + i);
+            }
+            return;
+        }
+    }
+}
+
+void BfcAllocator::shutdown() {
+    if (base_ && hal_) {
+        hal_->raw_free(device_id_, base_);
+        base_ = nullptr;
+    }
+    blocks_.clear();
+    capacity_ = 0;
+    used_bytes_ = 0;
+}
+
+/* ---- ArenaAllocator ---- */
+
+ArenaAllocator::~ArenaAllocator() { shutdown(); }
+
+uint32_t ArenaAllocator::size_class(size_t size) {
+    for (uint32_t c = 0; c < kArenaClassCount - 1; ++c) {
+        if (size < kClassBounds[c])
+            return c;
+    }
+    return kArenaClassCount - 1; /* BFC fallback */
+}
+
+int ArenaAllocator::init(const mm_hal_t *hal, int device_id,
+                         size_t total_budget, uint32_t num_classes) {
+    if (!hal || total_budget == 0)
+        return MM_ERROR_INVALID_ARG;
+
+    hal_ = hal;
+    device_id_ = device_id;
+    num_classes_ = std::min(num_classes, (uint32_t)kArenaClassCount);
+
+    /*
+     * Budget split: 70% to BFC (large allocs), 30% split across arenas.
+     * This matches typical LLM workloads where workspace allocations
+     * dominate activation memory.
+     */
+    size_t bfc_budget = (total_budget * 7) / 10;
+    size_t arena_budget = total_budget - bfc_budget;
+    size_t per_arena = arena_budget / num_classes_;
+
+    /* Initialize per-class arenas */
+    for (uint32_t c = 0; c < num_classes_; ++c) {
+        /* Larger classes get proportionally more memory */
+        size_t capacity = per_arena * (c + 1) / num_classes_;
+        if (capacity < 4096)
+            capacity = 4096;
+
+        arenas_[c].base = hal_->raw_alloc(device_id_, capacity, kDefaultAlignment);
+        if (!arenas_[c].base) {
+            shutdown();
+            return MM_ERROR_OUT_OF_MEMORY;
+        }
+        arenas_[c].capacity = capacity;
+        arenas_[c].offset.store(0, std::memory_order_relaxed);
+    }
+
+    /* Initialize BFC for large allocations */
+    if (bfc_budget > 0) {
+        int err = bfc_.init(hal_, device_id_, bfc_budget);
+        if (err != MM_OK) {
+            shutdown();
+            return err;
+        }
+    }
+
+    initialized_ = true;
+    return MM_OK;
+}
+
+void *ArenaAllocator::alloc(size_t size, size_t alignment) {
+    if (!initialized_ || size == 0)
+        return nullptr;
+
+    uint32_t cls = size_class(size);
+
+    /* BFC fallback for large allocations or class 7 */
+    if (cls >= num_classes_ || size >= kBfcThreshold)
+        return bfc_.alloc(size, alignment);
+
+    /* Atomic bump allocation (lock-free) */
+    size_t aligned_size = (size + alignment - 1) & ~(alignment - 1);
+    Arena &arena = arenas_[cls];
+
+    size_t old_offset =
+        arena.offset.fetch_add(aligned_size, std::memory_order_relaxed);
+    if (old_offset + aligned_size > arena.capacity) {
+        /* Arena exhausted — fall back to BFC */
+        arena.offset.fetch_sub(aligned_size, std::memory_order_relaxed);
+        return bfc_.alloc(size, alignment);
+    }
+
+    return static_cast<char *>(arena.base) + old_offset;
+}
+
+void ArenaAllocator::free(void *ptr, size_t size) {
+    if (!ptr)
+        return;
+
+    /* Check if this pointer belongs to BFC (not in any arena range) */
+    for (uint32_t c = 0; c < num_classes_; ++c) {
+        char *base = static_cast<char *>(arenas_[c].base);
+        if (ptr >= base && ptr < base + arenas_[c].capacity)
+            return; /* Arena allocs are freed in bulk via reset() */
+    }
+
+    /* Must be a BFC allocation */
+    bfc_.free(ptr);
+}
+
+void ArenaAllocator::reset() {
+    for (uint32_t c = 0; c < num_classes_; ++c) {
+        arenas_[c].offset.store(0, std::memory_order_relaxed);
+    }
+    /* BFC allocations are not reset — they have explicit lifetimes */
+}
+
+void ArenaAllocator::shutdown() {
+    if (!hal_)
+        return;
+
+    for (uint32_t c = 0; c < kArenaClassCount; ++c) {
+        if (arenas_[c].base) {
+            hal_->raw_free(device_id_, arenas_[c].base);
+            arenas_[c].base = nullptr;
+            arenas_[c].capacity = 0;
+            arenas_[c].offset.store(0, std::memory_order_relaxed);
+        }
+    }
+
+    bfc_.shutdown();
+    initialized_ = false;
+}
+
+size_t ArenaAllocator::used_bytes() const {
+    size_t total = 0;
+    for (uint32_t c = 0; c < num_classes_; ++c) {
+        total += arenas_[c].offset.load(std::memory_order_relaxed);
+    }
+    total += bfc_.used_bytes();
+    return total;
+}
+
+size_t ArenaAllocator::total_bytes() const {
+    size_t total = 0;
+    for (uint32_t c = 0; c < num_classes_; ++c) {
+        total += arenas_[c].capacity;
+    }
+    total += bfc_.total_bytes();
+    return total;
+}
+
+} // namespace mm

--- a/lib/MemoryManager/mm_arena.h
+++ b/lib/MemoryManager/mm_arena.h
@@ -34,14 +34,14 @@ static constexpr size_t kDefaultAlignment = 256;
 
 /* Class boundaries (upper limits, exclusive) */
 static constexpr size_t kClassBounds[kArenaClassCount] = {
-    1024,             /* 1 KB */
-    4 * 1024,         /* 4 KB */
-    16 * 1024,        /* 16 KB */
-    64 * 1024,        /* 64 KB */
-    256 * 1024,       /* 256 KB */
-    1024 * 1024,      /* 1 MB */
-    4 * 1024 * 1024,  /* 4 MB */
-    SIZE_MAX,         /* BFC */
+    1024,            /* 1 KB */
+    4 * 1024,        /* 4 KB */
+    16 * 1024,       /* 16 KB */
+    64 * 1024,       /* 64 KB */
+    256 * 1024,      /* 256 KB */
+    1024 * 1024,     /* 1 MB */
+    4 * 1024 * 1024, /* 4 MB */
+    SIZE_MAX,        /* BFC */
 };
 
 /*
@@ -50,79 +50,79 @@ static constexpr size_t kClassBounds[kArenaClassCount] = {
  */
 class BfcAllocator {
 public:
-    BfcAllocator() = default;
-    ~BfcAllocator();
+  BfcAllocator() = default;
+  ~BfcAllocator();
 
-    int init(const mm_hal_t *hal, int device_id, size_t capacity);
-    void *alloc(size_t size, size_t alignment = kDefaultAlignment);
-    void free(void *ptr);
-    void shutdown();
+  int init(const mm_hal_t *hal, int device_id, size_t capacity);
+  void *alloc(size_t size, size_t alignment = kDefaultAlignment);
+  void free(void *ptr);
+  void shutdown();
 
-    size_t used_bytes() const { return used_bytes_; }
-    size_t total_bytes() const { return capacity_; }
+  size_t used_bytes() const { return used_bytes_; }
+  size_t total_bytes() const { return capacity_; }
 
 private:
-    struct Block {
-        size_t offset;
-        size_t size;
-        bool   in_use;
-    };
+  struct Block {
+    size_t offset;
+    size_t size;
+    bool in_use;
+  };
 
-    const mm_hal_t *hal_ = nullptr;
-    int device_id_ = 0;
-    void *base_ = nullptr;
-    size_t capacity_ = 0;
-    size_t used_bytes_ = 0;
-    std::mutex mutex_;
-    std::vector<Block> blocks_;
+  const mm_hal_t *hal_ = nullptr;
+  int device_id_ = 0;
+  void *base_ = nullptr;
+  size_t capacity_ = 0;
+  size_t used_bytes_ = 0;
+  std::mutex mutex_;
+  std::vector<Block> blocks_;
 };
 
 class ArenaAllocator {
 public:
-    ArenaAllocator() = default;
-    ~ArenaAllocator();
+  ArenaAllocator() = default;
+  ~ArenaAllocator();
 
-    /*
-     * Initialize with HAL backend and per-class capacities.
-     * total_budget is split across size classes proportionally.
-     */
-    int init(const mm_hal_t *hal, int device_id, size_t total_budget,
-             uint32_t num_classes = kArenaClassCount);
+  /*
+   * Initialize with HAL backend and per-class capacities.
+   * total_budget is split across size classes proportionally.
+   */
+  int init(const mm_hal_t *hal, int device_id, size_t total_budget,
+           uint32_t num_classes = kArenaClassCount);
 
-    /*
-     * Allocate from the appropriate size class.
-     * Lock-free bump for classes 0-6, BFC for class 7.
-     */
-    void *alloc(size_t size, size_t alignment = kDefaultAlignment);
+  /*
+   * Allocate from the appropriate size class.
+   * Lock-free bump for classes 0-6, BFC for class 7.
+   */
+  void *alloc(size_t size, size_t alignment = kDefaultAlignment);
 
-    /* Free a previous allocation. For arenas, this is a no-op until reset. */
-    void free(void *ptr, size_t size);
+  /* Free a previous allocation. For arenas, this is a no-op until reset. */
+  void free(void *ptr, size_t size);
 
-    /* Reset all arenas to base. O(1). Used at step boundaries. */
-    void reset();
+  /* Reset all arenas to base. O(1). Used at step boundaries. */
+  void reset();
 
-    /* Shutdown and release all memory. */
-    void shutdown();
+  /* Shutdown and release all memory. */
+  void shutdown();
 
-    /* Determine which size class a given size falls into. */
-    static uint32_t size_class(size_t size);
+  /* Determine which size class a given size falls into. */
+  static uint32_t size_class(size_t size);
 
-    size_t used_bytes() const;
-    size_t total_bytes() const;
+  size_t used_bytes() const;
+  size_t total_bytes() const;
 
 private:
-    struct Arena {
-        void *base = nullptr;
-        size_t capacity = 0;
-        std::atomic<size_t> offset{0};
-    };
+  struct Arena {
+    void *base = nullptr;
+    size_t capacity = 0;
+    std::atomic<size_t> offset{0};
+  };
 
-    const mm_hal_t *hal_ = nullptr;
-    int device_id_ = 0;
-    uint32_t num_classes_ = 0;
-    Arena arenas_[kArenaClassCount];
-    BfcAllocator bfc_;
-    bool initialized_ = false;
+  const mm_hal_t *hal_ = nullptr;
+  int device_id_ = 0;
+  uint32_t num_classes_ = 0;
+  Arena arenas_[kArenaClassCount];
+  BfcAllocator bfc_;
+  bool initialized_ = false;
 };
 
 } // namespace mm

--- a/lib/MemoryManager/mm_arena.h
+++ b/lib/MemoryManager/mm_arena.h
@@ -1,0 +1,130 @@
+#ifndef MM_ARENA_H
+#define MM_ARENA_H
+
+#include "mm_hal.h"
+#include "mm_types.h"
+
+#include <atomic>
+#include <cstddef>
+#include <mutex>
+#include <vector>
+
+namespace mm {
+
+/*
+ * Size-class arena bump allocator with BFC fallback.
+ *
+ * 8 size classes covering exponential ranges:
+ *   Class 0: [0, 1 KB)
+ *   Class 1: [1 KB, 4 KB)
+ *   Class 2: [4 KB, 16 KB)
+ *   Class 3: [16 KB, 64 KB)
+ *   Class 4: [64 KB, 256 KB)
+ *   Class 5: [256 KB, 1 MB)
+ *   Class 6: [1 MB, 4 MB)
+ *   Class 7: [4 MB+) → BFC fallback
+ *
+ * Lock-free bump allocation via atomic fetch-add.
+ * Step-scoped reset: arena.reset() = O(1).
+ */
+
+static constexpr size_t kArenaClassCount = 8;
+static constexpr size_t kBfcThreshold = 4 * 1024 * 1024; /* 4 MB */
+static constexpr size_t kDefaultAlignment = 256;
+
+/* Class boundaries (upper limits, exclusive) */
+static constexpr size_t kClassBounds[kArenaClassCount] = {
+    1024,             /* 1 KB */
+    4 * 1024,         /* 4 KB */
+    16 * 1024,        /* 16 KB */
+    64 * 1024,        /* 64 KB */
+    256 * 1024,       /* 256 KB */
+    1024 * 1024,      /* 1 MB */
+    4 * 1024 * 1024,  /* 4 MB */
+    SIZE_MAX,         /* BFC */
+};
+
+/*
+ * BFC (Best-Fit with Coalescing) allocator for large allocations.
+ * Simple free-list based: best-fit allocation, coalesce adjacent on free.
+ */
+class BfcAllocator {
+public:
+    BfcAllocator() = default;
+    ~BfcAllocator();
+
+    int init(const mm_hal_t *hal, int device_id, size_t capacity);
+    void *alloc(size_t size, size_t alignment = kDefaultAlignment);
+    void free(void *ptr);
+    void shutdown();
+
+    size_t used_bytes() const { return used_bytes_; }
+    size_t total_bytes() const { return capacity_; }
+
+private:
+    struct Block {
+        size_t offset;
+        size_t size;
+        bool   in_use;
+    };
+
+    const mm_hal_t *hal_ = nullptr;
+    int device_id_ = 0;
+    void *base_ = nullptr;
+    size_t capacity_ = 0;
+    size_t used_bytes_ = 0;
+    std::mutex mutex_;
+    std::vector<Block> blocks_;
+};
+
+class ArenaAllocator {
+public:
+    ArenaAllocator() = default;
+    ~ArenaAllocator();
+
+    /*
+     * Initialize with HAL backend and per-class capacities.
+     * total_budget is split across size classes proportionally.
+     */
+    int init(const mm_hal_t *hal, int device_id, size_t total_budget,
+             uint32_t num_classes = kArenaClassCount);
+
+    /*
+     * Allocate from the appropriate size class.
+     * Lock-free bump for classes 0-6, BFC for class 7.
+     */
+    void *alloc(size_t size, size_t alignment = kDefaultAlignment);
+
+    /* Free a previous allocation. For arenas, this is a no-op until reset. */
+    void free(void *ptr, size_t size);
+
+    /* Reset all arenas to base. O(1). Used at step boundaries. */
+    void reset();
+
+    /* Shutdown and release all memory. */
+    void shutdown();
+
+    /* Determine which size class a given size falls into. */
+    static uint32_t size_class(size_t size);
+
+    size_t used_bytes() const;
+    size_t total_bytes() const;
+
+private:
+    struct Arena {
+        void *base = nullptr;
+        size_t capacity = 0;
+        std::atomic<size_t> offset{0};
+    };
+
+    const mm_hal_t *hal_ = nullptr;
+    int device_id_ = 0;
+    uint32_t num_classes_ = 0;
+    Arena arenas_[kArenaClassCount];
+    BfcAllocator bfc_;
+    bool initialized_ = false;
+};
+
+} // namespace mm
+
+#endif /* MM_ARENA_H */

--- a/lib/MemoryManager/mm_arena.h
+++ b/lib/MemoryManager/mm_arena.h
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
 #ifndef MM_ARENA_H
 #define MM_ARENA_H
 

--- a/lib/MemoryManager/mm_block_table.cpp
+++ b/lib/MemoryManager/mm_block_table.cpp
@@ -3,45 +3,39 @@
 
 namespace mm {
 
-void BlockTable::add_block(void *gpu_ptr) {
-    ptrs_.push_back(gpu_ptr);
-}
+void BlockTable::add_block(void *gpu_ptr) { ptrs_.push_back(gpu_ptr); }
 
-void **BlockTable::data() {
-    return ptrs_.empty() ? nullptr : ptrs_.data();
-}
+void **BlockTable::data() { return ptrs_.empty() ? nullptr : ptrs_.data(); }
 
 const void *const *BlockTable::data() const {
-    return ptrs_.empty() ? nullptr :
-           reinterpret_cast<const void *const *>(ptrs_.data());
+  return ptrs_.empty() ? nullptr
+                       : reinterpret_cast<const void *const *>(ptrs_.data());
 }
 
 uint32_t BlockTable::size() const {
-    return static_cast<uint32_t>(ptrs_.size());
+  return static_cast<uint32_t>(ptrs_.size());
 }
 
-void BlockTable::clear() {
-    ptrs_.clear();
-}
+void BlockTable::clear() { ptrs_.clear(); }
 
 int BlockTable::materialize_contiguous(void *dst, size_t block_size_bytes,
                                        const mm_hal_t *hal,
                                        mm_stream_t stream) const {
-    if (!dst || !hal || ptrs_.empty())
-        return MM_ERROR_INVALID_ARG;
+  if (!dst || !hal || ptrs_.empty())
+    return MM_ERROR_INVALID_ARG;
 
-    char *out = static_cast<char *>(dst);
-    for (size_t i = 0; i < ptrs_.size(); ++i) {
-        if (!ptrs_[i])
-            return MM_ERROR_INVALID_ARG;
+  char *out = static_cast<char *>(dst);
+  for (size_t i = 0; i < ptrs_.size(); ++i) {
+    if (!ptrs_[i])
+      return MM_ERROR_INVALID_ARG;
 
-        int err = hal->async_copy(out + i * block_size_bytes,
-                                  ptrs_[i], block_size_bytes,
-                                  MM_COPY_DEVICE_TO_DEVICE, stream, nullptr);
-        if (err != MM_OK)
-            return err;
-    }
-    return MM_OK;
+    int err =
+        hal->async_copy(out + i * block_size_bytes, ptrs_[i], block_size_bytes,
+                        MM_COPY_DEVICE_TO_DEVICE, stream, nullptr);
+    if (err != MM_OK)
+      return err;
+  }
+  return MM_OK;
 }
 
 } // namespace mm

--- a/lib/MemoryManager/mm_block_table.cpp
+++ b/lib/MemoryManager/mm_block_table.cpp
@@ -1,0 +1,47 @@
+#include "mm_block_table.h"
+#include "mm_hal.h"
+
+namespace mm {
+
+void BlockTable::add_block(void *gpu_ptr) {
+    ptrs_.push_back(gpu_ptr);
+}
+
+void **BlockTable::data() {
+    return ptrs_.empty() ? nullptr : ptrs_.data();
+}
+
+const void *const *BlockTable::data() const {
+    return ptrs_.empty() ? nullptr :
+           reinterpret_cast<const void *const *>(ptrs_.data());
+}
+
+uint32_t BlockTable::size() const {
+    return static_cast<uint32_t>(ptrs_.size());
+}
+
+void BlockTable::clear() {
+    ptrs_.clear();
+}
+
+int BlockTable::materialize_contiguous(void *dst, size_t block_size_bytes,
+                                       const mm_hal_t *hal,
+                                       mm_stream_t stream) const {
+    if (!dst || !hal || ptrs_.empty())
+        return MM_ERROR_INVALID_ARG;
+
+    char *out = static_cast<char *>(dst);
+    for (size_t i = 0; i < ptrs_.size(); ++i) {
+        if (!ptrs_[i])
+            return MM_ERROR_INVALID_ARG;
+
+        int err = hal->async_copy(out + i * block_size_bytes,
+                                  ptrs_[i], block_size_bytes,
+                                  MM_COPY_DEVICE_TO_DEVICE, stream, nullptr);
+        if (err != MM_OK)
+            return err;
+    }
+    return MM_OK;
+}
+
+} // namespace mm

--- a/lib/MemoryManager/mm_block_table.cpp
+++ b/lib/MemoryManager/mm_block_table.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
 #include "mm_block_table.h"
 #include "mm_hal.h"
 

--- a/lib/MemoryManager/mm_block_table.h
+++ b/lib/MemoryManager/mm_block_table.h
@@ -1,0 +1,52 @@
+#ifndef MM_BLOCK_TABLE_H
+#define MM_BLOCK_TABLE_H
+
+#include "mm_hal.h"
+#include "mm_types.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace mm {
+
+/*
+ * Block table: maps logical block indices to physical GPU pointers.
+ *
+ * Used by paged attention kernels to look up KV data scattered
+ * across non-contiguous physical blocks.
+ *
+ * Layout: block_table[i] = GPU pointer for logical block i.
+ */
+class BlockTable {
+public:
+    /* Append a block's GPU pointer to the table. */
+    void add_block(void *gpu_ptr);
+
+    /* Get the pointer array (for passing to kernels). */
+    void **data();
+    const void *const *data() const;
+
+    /* Number of entries. */
+    uint32_t size() const;
+
+    /* Clear the table. */
+    void clear();
+
+    /*
+     * Materialize all blocks into a contiguous buffer.
+     * Copies block_size_bytes from each block pointer into dst
+     * sequentially: dst[0..block_size), dst[block_size..2*block_size), ...
+     *
+     * Used as a bridge for existing GEMM kernels that expect contiguous KV.
+     * Returns 0 on success.
+     */
+    int materialize_contiguous(void *dst, size_t block_size_bytes,
+                               const mm_hal_t *hal, mm_stream_t stream) const;
+
+private:
+    std::vector<void *> ptrs_;
+};
+
+} // namespace mm
+
+#endif /* MM_BLOCK_TABLE_H */

--- a/lib/MemoryManager/mm_block_table.h
+++ b/lib/MemoryManager/mm_block_table.h
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
 #ifndef MM_BLOCK_TABLE_H
 #define MM_BLOCK_TABLE_H
 

--- a/lib/MemoryManager/mm_block_table.h
+++ b/lib/MemoryManager/mm_block_table.h
@@ -19,32 +19,32 @@ namespace mm {
  */
 class BlockTable {
 public:
-    /* Append a block's GPU pointer to the table. */
-    void add_block(void *gpu_ptr);
+  /* Append a block's GPU pointer to the table. */
+  void add_block(void *gpu_ptr);
 
-    /* Get the pointer array (for passing to kernels). */
-    void **data();
-    const void *const *data() const;
+  /* Get the pointer array (for passing to kernels). */
+  void **data();
+  const void *const *data() const;
 
-    /* Number of entries. */
-    uint32_t size() const;
+  /* Number of entries. */
+  uint32_t size() const;
 
-    /* Clear the table. */
-    void clear();
+  /* Clear the table. */
+  void clear();
 
-    /*
-     * Materialize all blocks into a contiguous buffer.
-     * Copies block_size_bytes from each block pointer into dst
-     * sequentially: dst[0..block_size), dst[block_size..2*block_size), ...
-     *
-     * Used as a bridge for existing GEMM kernels that expect contiguous KV.
-     * Returns 0 on success.
-     */
-    int materialize_contiguous(void *dst, size_t block_size_bytes,
-                               const mm_hal_t *hal, mm_stream_t stream) const;
+  /*
+   * Materialize all blocks into a contiguous buffer.
+   * Copies block_size_bytes from each block pointer into dst
+   * sequentially: dst[0..block_size), dst[block_size..2*block_size), ...
+   *
+   * Used as a bridge for existing GEMM kernels that expect contiguous KV.
+   * Returns 0 on success.
+   */
+  int materialize_contiguous(void *dst, size_t block_size_bytes,
+                             const mm_hal_t *hal, mm_stream_t stream) const;
 
 private:
-    std::vector<void *> ptrs_;
+  std::vector<void *> ptrs_;
 };
 
 } // namespace mm

--- a/lib/MemoryManager/mm_config.cpp
+++ b/lib/MemoryManager/mm_config.cpp
@@ -1,0 +1,177 @@
+#include "mm_config.h"
+#include "mm_arena.h"
+#include "mm_internal.h"
+#include "mm_kv.h"
+
+#include <cstdio>
+
+namespace mm {
+
+static MmState g_state;
+
+MmState *mm_get_state() { return &g_state; }
+
+static int validate_config(const mm_config_t *config) {
+    if (config->kv_cache_fraction < 0.0f || config->kv_cache_fraction > 1.0f)
+        return MM_ERROR_INVALID_ARG;
+    if (config->high_watermark < 0.0f || config->high_watermark > 1.0f)
+        return MM_ERROR_INVALID_ARG;
+    if (config->critical_watermark < config->high_watermark)
+        return MM_ERROR_INVALID_ARG;
+    if (config->num_size_classes < 1 || config->num_size_classes > 16)
+        return MM_ERROR_INVALID_ARG;
+    return MM_OK;
+}
+
+} // namespace mm
+
+extern "C" {
+
+int mm_init(const mm_config_t *config) {
+    auto *s = mm::mm_get_state();
+
+    if (s->initialized.load(std::memory_order_acquire))
+        return MM_ERROR_ALREADY_INIT;
+
+    /* Apply config (or defaults) */
+    if (config) {
+        int err = mm::validate_config(config);
+        if (err != MM_OK)
+            return err;
+
+        s->config.gpu_memory_limit       = config->gpu_memory_limit;
+        s->config.kv_cache_fraction      = config->kv_cache_fraction;
+        s->config.kv_block_size_tokens   = config->kv_block_size_tokens;
+        s->config.max_tier               = config->max_tier;
+        s->config.enable_prefix_caching  = config->enable_prefix_caching;
+        s->config.enable_defrag          = config->enable_defrag;
+        s->config.num_size_classes       = config->num_size_classes;
+        s->config.high_watermark         = config->high_watermark;
+        s->config.critical_watermark     = config->critical_watermark;
+        s->config.default_kv_format      = config->default_kv_format;
+        s->config.pressure_kv_format     = config->pressure_kv_format;
+        s->config.critical_kv_format     = config->critical_kv_format;
+        s->config.enable_inline_quant    = config->enable_inline_quant;
+        s->config.enable_adaptive_transcode = config->enable_adaptive_transcode;
+    }
+    /* else: defaults from MmConfig struct are fine */
+
+    /* Get HAL — must have been registered before init */
+    s->hal = mm_hal_get();
+    if (!s->hal)
+        return MM_ERROR_NOT_INIT;
+
+    /* Query GPU memory budget */
+    if (s->config.gpu_memory_limit == 0) {
+        s->total_gpu_memory = s->hal->get_total_memory(0);
+    } else {
+        s->total_gpu_memory = s->config.gpu_memory_limit;
+    }
+
+    /* Budget: activations get whatever is not reserved for KV cache.
+       Weight pool is allocated separately via mm_create_pool(). */
+    s->kv_cache_reserved = (size_t)(s->total_gpu_memory *
+                                    s->config.kv_cache_fraction);
+    s->activation_reserved = s->total_gpu_memory - s->kv_cache_reserved;
+
+    /* Initialize arena allocator for activations + scratch */
+    s->arena = new mm::ArenaAllocator();
+    int err = s->arena->init(s->hal, 0, s->activation_reserved,
+                             s->config.num_size_classes);
+    if (err != MM_OK) {
+        delete s->arena;
+        s->arena = nullptr;
+        return err;
+    }
+
+    /* Initialize KV cache block pool (if budget allows) */
+    if (s->kv_cache_reserved > 0) {
+        int kv_err = mm_kv_pool_init(s->kv_cache_reserved,
+                                     s->config.kv_block_size_tokens,
+                                     s->config.default_kv_format);
+        if (kv_err != MM_OK) {
+            /* Non-fatal: KV pool init failure doesn't block basic operation */
+            std::fprintf(stderr,
+                         "[MM] KV pool init failed (%d), paged KV disabled\n",
+                         kv_err);
+        }
+    }
+
+    s->initialized.store(true, std::memory_order_release);
+    return MM_OK;
+}
+
+void mm_shutdown(void) {
+    auto *s = mm::mm_get_state();
+
+    if (!s->initialized.load(std::memory_order_acquire))
+        return;
+
+    /* Destroy all active pools */
+    {
+        std::lock_guard<std::mutex> lock(s->pools_mutex);
+        for (auto *pool : s->pools) {
+            if (pool)
+                delete pool;
+        }
+        s->pools.clear();
+    }
+
+    /* Shutdown KV block pool */
+    mm_kv_pool_shutdown();
+
+    /* Shutdown arena */
+    if (s->arena) {
+        s->arena->shutdown();
+        delete s->arena;
+        s->arena = nullptr;
+    }
+
+    /* Clear handle table */
+    s->handles.clear();
+
+    /* Reset state */
+    s->hal = nullptr;
+    s->total_gpu_memory = 0;
+    s->weight_pool_reserved = 0;
+    s->kv_cache_reserved = 0;
+    s->activation_reserved = 0;
+    s->config = mm::MmConfig{};
+
+    s->initialized.store(false, std::memory_order_release);
+}
+
+void mm_dump_state(FILE *output) {
+    auto *s = mm::mm_get_state();
+    FILE *f = output ? output : stdout;
+
+    if (!s->initialized.load(std::memory_order_acquire)) {
+        std::fprintf(f, "Memory Manager: NOT INITIALIZED\n");
+        return;
+    }
+
+    std::fprintf(f, "=== Memory Manager State ===\n");
+    std::fprintf(f, "Total GPU memory: %zu bytes\n", s->total_gpu_memory);
+    std::fprintf(f, "KV cache reserved: %zu bytes\n", s->kv_cache_reserved);
+    std::fprintf(f, "Activation reserved: %zu bytes\n",
+                 s->activation_reserved);
+    std::fprintf(f, "Active handles: %zu\n", s->handles.active_count());
+
+    if (s->arena) {
+        std::fprintf(f, "Arena used: %zu / %zu bytes\n",
+                     s->arena->used_bytes(), s->arena->total_bytes());
+    }
+
+    std::fprintf(f, "Active pools: %zu\n", s->pools.size());
+
+    if (s->kv_pool) {
+        uint32_t total = mm_kv_total_block_count(MM_KV_FMT_FP16);
+        uint32_t free = mm_kv_free_block_count(MM_KV_FMT_FP16);
+        std::fprintf(f, "KV blocks: %u allocated, %u free, %u total\n",
+                     total - free, free, total);
+    }
+
+    std::fprintf(f, "============================\n");
+}
+
+} /* extern "C" */

--- a/lib/MemoryManager/mm_config.cpp
+++ b/lib/MemoryManager/mm_config.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
 #include "mm_config.h"
 #include "mm_arena.h"
 #include "mm_internal.h"

--- a/lib/MemoryManager/mm_config.cpp
+++ b/lib/MemoryManager/mm_config.cpp
@@ -12,15 +12,15 @@ static MmState g_state;
 MmState *mm_get_state() { return &g_state; }
 
 static int validate_config(const mm_config_t *config) {
-    if (config->kv_cache_fraction < 0.0f || config->kv_cache_fraction > 1.0f)
-        return MM_ERROR_INVALID_ARG;
-    if (config->high_watermark < 0.0f || config->high_watermark > 1.0f)
-        return MM_ERROR_INVALID_ARG;
-    if (config->critical_watermark < config->high_watermark)
-        return MM_ERROR_INVALID_ARG;
-    if (config->num_size_classes < 1 || config->num_size_classes > 16)
-        return MM_ERROR_INVALID_ARG;
-    return MM_OK;
+  if (config->kv_cache_fraction < 0.0f || config->kv_cache_fraction > 1.0f)
+    return MM_ERROR_INVALID_ARG;
+  if (config->high_watermark < 0.0f || config->high_watermark > 1.0f)
+    return MM_ERROR_INVALID_ARG;
+  if (config->critical_watermark < config->high_watermark)
+    return MM_ERROR_INVALID_ARG;
+  if (config->num_size_classes < 1 || config->num_size_classes > 16)
+    return MM_ERROR_INVALID_ARG;
+  return MM_OK;
 }
 
 } // namespace mm
@@ -28,150 +28,148 @@ static int validate_config(const mm_config_t *config) {
 extern "C" {
 
 int mm_init(const mm_config_t *config) {
-    auto *s = mm::mm_get_state();
+  auto *s = mm::mm_get_state();
 
-    if (s->initialized.load(std::memory_order_acquire))
-        return MM_ERROR_ALREADY_INIT;
+  if (s->initialized.load(std::memory_order_acquire))
+    return MM_ERROR_ALREADY_INIT;
 
-    /* Apply config (or defaults) */
-    if (config) {
-        int err = mm::validate_config(config);
-        if (err != MM_OK)
-            return err;
+  /* Apply config (or defaults) */
+  if (config) {
+    int err = mm::validate_config(config);
+    if (err != MM_OK)
+      return err;
 
-        s->config.gpu_memory_limit       = config->gpu_memory_limit;
-        s->config.kv_cache_fraction      = config->kv_cache_fraction;
-        s->config.kv_block_size_tokens   = config->kv_block_size_tokens;
-        s->config.max_tier               = config->max_tier;
-        s->config.enable_prefix_caching  = config->enable_prefix_caching;
-        s->config.enable_defrag          = config->enable_defrag;
-        s->config.num_size_classes       = config->num_size_classes;
-        s->config.high_watermark         = config->high_watermark;
-        s->config.critical_watermark     = config->critical_watermark;
-        s->config.default_kv_format      = config->default_kv_format;
-        s->config.pressure_kv_format     = config->pressure_kv_format;
-        s->config.critical_kv_format     = config->critical_kv_format;
-        s->config.enable_inline_quant    = config->enable_inline_quant;
-        s->config.enable_adaptive_transcode = config->enable_adaptive_transcode;
+    s->config.gpu_memory_limit = config->gpu_memory_limit;
+    s->config.kv_cache_fraction = config->kv_cache_fraction;
+    s->config.kv_block_size_tokens = config->kv_block_size_tokens;
+    s->config.max_tier = config->max_tier;
+    s->config.enable_prefix_caching = config->enable_prefix_caching;
+    s->config.enable_defrag = config->enable_defrag;
+    s->config.num_size_classes = config->num_size_classes;
+    s->config.high_watermark = config->high_watermark;
+    s->config.critical_watermark = config->critical_watermark;
+    s->config.default_kv_format = config->default_kv_format;
+    s->config.pressure_kv_format = config->pressure_kv_format;
+    s->config.critical_kv_format = config->critical_kv_format;
+    s->config.enable_inline_quant = config->enable_inline_quant;
+    s->config.enable_adaptive_transcode = config->enable_adaptive_transcode;
+  }
+  /* else: defaults from MmConfig struct are fine */
+
+  /* Get HAL — must have been registered before init */
+  s->hal = mm_hal_get();
+  if (!s->hal)
+    return MM_ERROR_NOT_INIT;
+
+  /* Query GPU memory budget */
+  if (s->config.gpu_memory_limit == 0) {
+    s->total_gpu_memory = s->hal->get_total_memory(0);
+  } else {
+    s->total_gpu_memory = s->config.gpu_memory_limit;
+  }
+
+  /* Budget: activations get whatever is not reserved for KV cache.
+     Weight pool is allocated separately via mm_create_pool(). */
+  s->kv_cache_reserved =
+      (size_t)(s->total_gpu_memory * s->config.kv_cache_fraction);
+  s->activation_reserved = s->total_gpu_memory - s->kv_cache_reserved;
+
+  /* Initialize arena allocator for activations + scratch */
+  s->arena = new mm::ArenaAllocator();
+  int err = s->arena->init(s->hal, 0, s->activation_reserved,
+                           s->config.num_size_classes);
+  if (err != MM_OK) {
+    delete s->arena;
+    s->arena = nullptr;
+    return err;
+  }
+
+  /* Initialize KV cache block pool (if budget allows) */
+  if (s->kv_cache_reserved > 0) {
+    int kv_err =
+        mm_kv_pool_init(s->kv_cache_reserved, s->config.kv_block_size_tokens,
+                        s->config.default_kv_format);
+    if (kv_err != MM_OK) {
+      /* Non-fatal: KV pool init failure doesn't block basic operation */
+      std::fprintf(stderr, "[MM] KV pool init failed (%d), paged KV disabled\n",
+                   kv_err);
     }
-    /* else: defaults from MmConfig struct are fine */
+  }
 
-    /* Get HAL — must have been registered before init */
-    s->hal = mm_hal_get();
-    if (!s->hal)
-        return MM_ERROR_NOT_INIT;
-
-    /* Query GPU memory budget */
-    if (s->config.gpu_memory_limit == 0) {
-        s->total_gpu_memory = s->hal->get_total_memory(0);
-    } else {
-        s->total_gpu_memory = s->config.gpu_memory_limit;
-    }
-
-    /* Budget: activations get whatever is not reserved for KV cache.
-       Weight pool is allocated separately via mm_create_pool(). */
-    s->kv_cache_reserved = (size_t)(s->total_gpu_memory *
-                                    s->config.kv_cache_fraction);
-    s->activation_reserved = s->total_gpu_memory - s->kv_cache_reserved;
-
-    /* Initialize arena allocator for activations + scratch */
-    s->arena = new mm::ArenaAllocator();
-    int err = s->arena->init(s->hal, 0, s->activation_reserved,
-                             s->config.num_size_classes);
-    if (err != MM_OK) {
-        delete s->arena;
-        s->arena = nullptr;
-        return err;
-    }
-
-    /* Initialize KV cache block pool (if budget allows) */
-    if (s->kv_cache_reserved > 0) {
-        int kv_err = mm_kv_pool_init(s->kv_cache_reserved,
-                                     s->config.kv_block_size_tokens,
-                                     s->config.default_kv_format);
-        if (kv_err != MM_OK) {
-            /* Non-fatal: KV pool init failure doesn't block basic operation */
-            std::fprintf(stderr,
-                         "[MM] KV pool init failed (%d), paged KV disabled\n",
-                         kv_err);
-        }
-    }
-
-    s->initialized.store(true, std::memory_order_release);
-    return MM_OK;
+  s->initialized.store(true, std::memory_order_release);
+  return MM_OK;
 }
 
 void mm_shutdown(void) {
-    auto *s = mm::mm_get_state();
+  auto *s = mm::mm_get_state();
 
-    if (!s->initialized.load(std::memory_order_acquire))
-        return;
+  if (!s->initialized.load(std::memory_order_acquire))
+    return;
 
-    /* Destroy all active pools */
-    {
-        std::lock_guard<std::mutex> lock(s->pools_mutex);
-        for (auto *pool : s->pools) {
-            if (pool)
-                delete pool;
-        }
-        s->pools.clear();
+  /* Destroy all active pools */
+  {
+    std::lock_guard<std::mutex> lock(s->pools_mutex);
+    for (auto *pool : s->pools) {
+      if (pool)
+        delete pool;
     }
+    s->pools.clear();
+  }
 
-    /* Shutdown KV block pool */
-    mm_kv_pool_shutdown();
+  /* Shutdown KV block pool */
+  mm_kv_pool_shutdown();
 
-    /* Shutdown arena */
-    if (s->arena) {
-        s->arena->shutdown();
-        delete s->arena;
-        s->arena = nullptr;
-    }
+  /* Shutdown arena */
+  if (s->arena) {
+    s->arena->shutdown();
+    delete s->arena;
+    s->arena = nullptr;
+  }
 
-    /* Clear handle table */
-    s->handles.clear();
+  /* Clear handle table */
+  s->handles.clear();
 
-    /* Reset state */
-    s->hal = nullptr;
-    s->total_gpu_memory = 0;
-    s->weight_pool_reserved = 0;
-    s->kv_cache_reserved = 0;
-    s->activation_reserved = 0;
-    s->config = mm::MmConfig{};
+  /* Reset state */
+  s->hal = nullptr;
+  s->total_gpu_memory = 0;
+  s->weight_pool_reserved = 0;
+  s->kv_cache_reserved = 0;
+  s->activation_reserved = 0;
+  s->config = mm::MmConfig{};
 
-    s->initialized.store(false, std::memory_order_release);
+  s->initialized.store(false, std::memory_order_release);
 }
 
 void mm_dump_state(FILE *output) {
-    auto *s = mm::mm_get_state();
-    FILE *f = output ? output : stdout;
+  auto *s = mm::mm_get_state();
+  FILE *f = output ? output : stdout;
 
-    if (!s->initialized.load(std::memory_order_acquire)) {
-        std::fprintf(f, "Memory Manager: NOT INITIALIZED\n");
-        return;
-    }
+  if (!s->initialized.load(std::memory_order_acquire)) {
+    std::fprintf(f, "Memory Manager: NOT INITIALIZED\n");
+    return;
+  }
 
-    std::fprintf(f, "=== Memory Manager State ===\n");
-    std::fprintf(f, "Total GPU memory: %zu bytes\n", s->total_gpu_memory);
-    std::fprintf(f, "KV cache reserved: %zu bytes\n", s->kv_cache_reserved);
-    std::fprintf(f, "Activation reserved: %zu bytes\n",
-                 s->activation_reserved);
-    std::fprintf(f, "Active handles: %zu\n", s->handles.active_count());
+  std::fprintf(f, "=== Memory Manager State ===\n");
+  std::fprintf(f, "Total GPU memory: %zu bytes\n", s->total_gpu_memory);
+  std::fprintf(f, "KV cache reserved: %zu bytes\n", s->kv_cache_reserved);
+  std::fprintf(f, "Activation reserved: %zu bytes\n", s->activation_reserved);
+  std::fprintf(f, "Active handles: %zu\n", s->handles.active_count());
 
-    if (s->arena) {
-        std::fprintf(f, "Arena used: %zu / %zu bytes\n",
-                     s->arena->used_bytes(), s->arena->total_bytes());
-    }
+  if (s->arena) {
+    std::fprintf(f, "Arena used: %zu / %zu bytes\n", s->arena->used_bytes(),
+                 s->arena->total_bytes());
+  }
 
-    std::fprintf(f, "Active pools: %zu\n", s->pools.size());
+  std::fprintf(f, "Active pools: %zu\n", s->pools.size());
 
-    if (s->kv_pool) {
-        uint32_t total = mm_kv_total_block_count(MM_KV_FMT_FP16);
-        uint32_t free = mm_kv_free_block_count(MM_KV_FMT_FP16);
-        std::fprintf(f, "KV blocks: %u allocated, %u free, %u total\n",
-                     total - free, free, total);
-    }
+  if (s->kv_pool) {
+    uint32_t total = mm_kv_total_block_count(MM_KV_FMT_FP16);
+    uint32_t free = mm_kv_free_block_count(MM_KV_FMT_FP16);
+    std::fprintf(f, "KV blocks: %u allocated, %u free, %u total\n",
+                 total - free, free, total);
+  }
 
-    std::fprintf(f, "============================\n");
+  std::fprintf(f, "============================\n");
 }
 
 } /* extern "C" */

--- a/lib/MemoryManager/mm_config.h
+++ b/lib/MemoryManager/mm_config.h
@@ -1,0 +1,56 @@
+#ifndef MM_CONFIG_H
+#define MM_CONFIG_H
+
+#include "mm_types.h"
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    /* Core memory limits */
+    size_t         gpu_memory_limit;      /* 0 = auto-detect */
+    float          kv_cache_fraction;     /* [0,1], default 0.90 */
+    uint32_t       kv_block_size_tokens;  /* default 16 */
+    mm_tier_t      max_tier;              /* deepest tier to use */
+
+    /* Feature toggles */
+    bool           enable_prefix_caching;
+    bool           enable_defrag;
+    uint32_t       num_size_classes;      /* arena size classes, default 8 */
+
+    /* Pressure watermarks */
+    float          high_watermark;        /* 0.90: trigger background eviction */
+    float          critical_watermark;    /* 0.95: trigger sync eviction */
+
+    /* Adaptive compression */
+    mm_kv_format_t default_kv_format;
+    mm_kv_format_t pressure_kv_format;
+    mm_kv_format_t critical_kv_format;
+    bool           enable_inline_quant;
+    bool           enable_adaptive_transcode;
+} mm_config_t;
+
+/*
+ * Initialize the memory manager. Must be called before any other mm_* call.
+ * Pass NULL for default configuration.
+ * Returns MM_OK on success, negative error code on failure.
+ */
+int mm_init(const mm_config_t *config);
+
+/*
+ * Shutdown and release all resources. Safe to call even if not initialized.
+ */
+void mm_shutdown(void);
+
+/*
+ * Dump internal state for debugging. Pass NULL for stdout.
+ */
+void mm_dump_state(FILE *output);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MM_CONFIG_H */

--- a/lib/MemoryManager/mm_config.h
+++ b/lib/MemoryManager/mm_config.h
@@ -9,27 +9,27 @@ extern "C" {
 #endif
 
 typedef struct {
-    /* Core memory limits */
-    size_t         gpu_memory_limit;      /* 0 = auto-detect */
-    float          kv_cache_fraction;     /* [0,1], default 0.90 */
-    uint32_t       kv_block_size_tokens;  /* default 16 */
-    mm_tier_t      max_tier;              /* deepest tier to use */
+  /* Core memory limits */
+  size_t gpu_memory_limit;       /* 0 = auto-detect */
+  float kv_cache_fraction;       /* [0,1], default 0.90 */
+  uint32_t kv_block_size_tokens; /* default 16 */
+  mm_tier_t max_tier;            /* deepest tier to use */
 
-    /* Feature toggles */
-    bool           enable_prefix_caching;
-    bool           enable_defrag;
-    uint32_t       num_size_classes;      /* arena size classes, default 8 */
+  /* Feature toggles */
+  bool enable_prefix_caching;
+  bool enable_defrag;
+  uint32_t num_size_classes; /* arena size classes, default 8 */
 
-    /* Pressure watermarks */
-    float          high_watermark;        /* 0.90: trigger background eviction */
-    float          critical_watermark;    /* 0.95: trigger sync eviction */
+  /* Pressure watermarks */
+  float high_watermark;     /* 0.90: trigger background eviction */
+  float critical_watermark; /* 0.95: trigger sync eviction */
 
-    /* Adaptive compression */
-    mm_kv_format_t default_kv_format;
-    mm_kv_format_t pressure_kv_format;
-    mm_kv_format_t critical_kv_format;
-    bool           enable_inline_quant;
-    bool           enable_adaptive_transcode;
+  /* Adaptive compression */
+  mm_kv_format_t default_kv_format;
+  mm_kv_format_t pressure_kv_format;
+  mm_kv_format_t critical_kv_format;
+  bool enable_inline_quant;
+  bool enable_adaptive_transcode;
 } mm_config_t;
 
 /*

--- a/lib/MemoryManager/mm_config.h
+++ b/lib/MemoryManager/mm_config.h
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
 #ifndef MM_CONFIG_H
 #define MM_CONFIG_H
 

--- a/lib/MemoryManager/mm_core.cpp
+++ b/lib/MemoryManager/mm_core.cpp
@@ -6,92 +6,91 @@ extern "C" {
 
 mm_handle_t mm_alloc(size_t size, mm_alloc_hints_t hints,
                      mm_stream_t /*stream*/) {
-    auto *s = mm::mm_get_state();
-    if (!s->initialized.load(std::memory_order_acquire))
-        return MM_INVALID_HANDLE;
+  auto *s = mm::mm_get_state();
+  if (!s->initialized.load(std::memory_order_acquire))
+    return MM_INVALID_HANDLE;
 
-    void *ptr = nullptr;
+  void *ptr = nullptr;
 
-    switch (hints.mem_class) {
-    case MM_CLASS_ACTIVATION:
-    case MM_CLASS_SCRATCH:
-        if (!s->arena)
-            return MM_INVALID_HANDLE;
-        ptr = s->arena->alloc(size,
-                              hints.alignment > 0 ? hints.alignment : 256);
-        break;
+  switch (hints.mem_class) {
+  case MM_CLASS_ACTIVATION:
+  case MM_CLASS_SCRATCH:
+    if (!s->arena)
+      return MM_INVALID_HANDLE;
+    ptr = s->arena->alloc(size, hints.alignment > 0 ? hints.alignment : 256);
+    break;
 
-    case MM_CLASS_WEIGHT:
-        /* Weights must use mm_create_pool() */
-        return MM_INVALID_HANDLE;
+  case MM_CLASS_WEIGHT:
+    /* Weights must use mm_create_pool() */
+    return MM_INVALID_HANDLE;
 
-    case MM_CLASS_KV_CACHE:
-        /* KV cache must use mm_kv_alloc_block() (Phase 2) */
-        return MM_INVALID_HANDLE;
+  case MM_CLASS_KV_CACHE:
+    /* KV cache must use mm_kv_alloc_block() (Phase 2) */
+    return MM_INVALID_HANDLE;
 
-    default:
-        return MM_INVALID_HANDLE;
-    }
+  default:
+    return MM_INVALID_HANDLE;
+  }
 
-    if (!ptr)
-        return MM_INVALID_HANDLE;
+  if (!ptr)
+    return MM_INVALID_HANDLE;
 
-    return s->handles.insert(ptr, size, hints.mem_class);
+  return s->handles.insert(ptr, size, hints.mem_class);
 }
 
 void mm_free(mm_handle_t handle, mm_stream_t /*stream*/) {
-    auto *s = mm::mm_get_state();
-    if (!s->initialized.load(std::memory_order_acquire))
-        return;
+  auto *s = mm::mm_get_state();
+  if (!s->initialized.load(std::memory_order_acquire))
+    return;
 
-    auto *entry = s->handles.remove(handle);
-    if (!entry)
-        return;
+  auto *entry = s->handles.remove(handle);
+  if (!entry)
+    return;
 
-    switch (entry->mem_class) {
-    case MM_CLASS_ACTIVATION:
-    case MM_CLASS_SCRATCH:
-        if (s->arena)
-            s->arena->free(entry->ptr, entry->size);
-        break;
-    default:
-        break;
-    }
+  switch (entry->mem_class) {
+  case MM_CLASS_ACTIVATION:
+  case MM_CLASS_SCRATCH:
+    if (s->arena)
+      s->arena->free(entry->ptr, entry->size);
+    break;
+  default:
+    break;
+  }
 }
 
 void *mm_get_ptr(mm_handle_t handle, mm_device_t /*device*/) {
-    auto *s = mm::mm_get_state();
-    if (!s->initialized.load(std::memory_order_acquire))
-        return nullptr;
+  auto *s = mm::mm_get_state();
+  if (!s->initialized.load(std::memory_order_acquire))
+    return nullptr;
 
-    auto *entry = s->handles.lookup(handle);
-    if (!entry)
-        return nullptr;
+  auto *entry = s->handles.lookup(handle);
+  if (!entry)
+    return nullptr;
 
-    return entry->ptr;
+  return entry->ptr;
 }
 
 void mm_prefetch(mm_handle_t /*handle*/, mm_tier_t /*target_tier*/) {
-    /* Phase 3: tier migration */
+  /* Phase 3: tier migration */
 }
 
 mm_alloc_info_t mm_query(mm_handle_t handle) {
-    mm_alloc_info_t info = {};
+  mm_alloc_info_t info = {};
 
-    auto *s = mm::mm_get_state();
-    if (!s->initialized.load(std::memory_order_acquire))
-        return info;
-
-    auto *entry = s->handles.lookup(handle);
-    if (!entry)
-        return info;
-
-    info.current_tier = entry->tier;
-    info.mem_class = entry->mem_class;
-    info.size = entry->size;
-    info.ref_count = entry->ref_count;
-    info.resident_device = MM_DEVICE_GPU_0;
+  auto *s = mm::mm_get_state();
+  if (!s->initialized.load(std::memory_order_acquire))
     return info;
+
+  auto *entry = s->handles.lookup(handle);
+  if (!entry)
+    return info;
+
+  info.current_tier = entry->tier;
+  info.mem_class = entry->mem_class;
+  info.size = entry->size;
+  info.ref_count = entry->ref_count;
+  info.resident_device = MM_DEVICE_GPU_0;
+  return info;
 }
 
 } /* extern "C" */

--- a/lib/MemoryManager/mm_core.cpp
+++ b/lib/MemoryManager/mm_core.cpp
@@ -1,0 +1,97 @@
+#include "mm_core.h"
+#include "mm_arena.h"
+#include "mm_internal.h"
+
+extern "C" {
+
+mm_handle_t mm_alloc(size_t size, mm_alloc_hints_t hints,
+                     mm_stream_t /*stream*/) {
+    auto *s = mm::mm_get_state();
+    if (!s->initialized.load(std::memory_order_acquire))
+        return MM_INVALID_HANDLE;
+
+    void *ptr = nullptr;
+
+    switch (hints.mem_class) {
+    case MM_CLASS_ACTIVATION:
+    case MM_CLASS_SCRATCH:
+        if (!s->arena)
+            return MM_INVALID_HANDLE;
+        ptr = s->arena->alloc(size,
+                              hints.alignment > 0 ? hints.alignment : 256);
+        break;
+
+    case MM_CLASS_WEIGHT:
+        /* Weights must use mm_create_pool() */
+        return MM_INVALID_HANDLE;
+
+    case MM_CLASS_KV_CACHE:
+        /* KV cache must use mm_kv_alloc_block() (Phase 2) */
+        return MM_INVALID_HANDLE;
+
+    default:
+        return MM_INVALID_HANDLE;
+    }
+
+    if (!ptr)
+        return MM_INVALID_HANDLE;
+
+    return s->handles.insert(ptr, size, hints.mem_class);
+}
+
+void mm_free(mm_handle_t handle, mm_stream_t /*stream*/) {
+    auto *s = mm::mm_get_state();
+    if (!s->initialized.load(std::memory_order_acquire))
+        return;
+
+    auto *entry = s->handles.remove(handle);
+    if (!entry)
+        return;
+
+    switch (entry->mem_class) {
+    case MM_CLASS_ACTIVATION:
+    case MM_CLASS_SCRATCH:
+        if (s->arena)
+            s->arena->free(entry->ptr, entry->size);
+        break;
+    default:
+        break;
+    }
+}
+
+void *mm_get_ptr(mm_handle_t handle, mm_device_t /*device*/) {
+    auto *s = mm::mm_get_state();
+    if (!s->initialized.load(std::memory_order_acquire))
+        return nullptr;
+
+    auto *entry = s->handles.lookup(handle);
+    if (!entry)
+        return nullptr;
+
+    return entry->ptr;
+}
+
+void mm_prefetch(mm_handle_t /*handle*/, mm_tier_t /*target_tier*/) {
+    /* Phase 3: tier migration */
+}
+
+mm_alloc_info_t mm_query(mm_handle_t handle) {
+    mm_alloc_info_t info = {};
+
+    auto *s = mm::mm_get_state();
+    if (!s->initialized.load(std::memory_order_acquire))
+        return info;
+
+    auto *entry = s->handles.lookup(handle);
+    if (!entry)
+        return info;
+
+    info.current_tier = entry->tier;
+    info.mem_class = entry->mem_class;
+    info.size = entry->size;
+    info.ref_count = entry->ref_count;
+    info.resident_device = MM_DEVICE_GPU_0;
+    return info;
+}
+
+} /* extern "C" */

--- a/lib/MemoryManager/mm_core.cpp
+++ b/lib/MemoryManager/mm_core.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
 #include "mm_core.h"
 #include "mm_arena.h"
 #include "mm_internal.h"

--- a/lib/MemoryManager/mm_core.h
+++ b/lib/MemoryManager/mm_core.h
@@ -1,0 +1,47 @@
+#ifndef MM_CORE_H
+#define MM_CORE_H
+
+#include "mm_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Allocate memory with classification hints.
+ * Routes to the appropriate sub-allocator based on mem_class:
+ *   ACTIVATION → arena bump allocator
+ *   SCRATCH    → arena (small) or BFC (large)
+ *   WEIGHT     → error (use mm_create_pool instead)
+ *   KV_CACHE   → error (use mm_kv_alloc_block instead, Phase 2)
+ *
+ * Returns MM_INVALID_HANDLE on failure.
+ */
+mm_handle_t mm_alloc(size_t size, mm_alloc_hints_t hints, mm_stream_t stream);
+
+/*
+ * Release an allocation. The handle becomes invalid after this call.
+ */
+void mm_free(mm_handle_t handle, mm_stream_t stream);
+
+/*
+ * Get a device-accessible pointer for the allocation.
+ * Returns NULL if handle is invalid.
+ */
+void *mm_get_ptr(mm_handle_t handle, mm_device_t device);
+
+/*
+ * Prefetch an allocation to a specific tier (async).
+ */
+void mm_prefetch(mm_handle_t handle, mm_tier_t target_tier);
+
+/*
+ * Query allocation metadata.
+ */
+mm_alloc_info_t mm_query(mm_handle_t handle);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MM_CORE_H */

--- a/lib/MemoryManager/mm_core.h
+++ b/lib/MemoryManager/mm_core.h
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
 #ifndef MM_CORE_H
 #define MM_CORE_H
 

--- a/lib/MemoryManager/mm_free_list.cpp
+++ b/lib/MemoryManager/mm_free_list.cpp
@@ -5,93 +5,94 @@ namespace mm {
 FreeList::~FreeList() { shutdown(); }
 
 void FreeList::init(uint32_t capacity) {
-    capacity_ = capacity;
-    /* Over-allocate: each block can be pushed at most once, but we need
-       extra nodes if push/pop interleave heavily. 2x is safe. */
-    uint32_t num_nodes = capacity * 2;
-    nodes_ = new Node[num_nodes];
-    for (uint32_t i = 0; i < num_nodes; ++i) {
-        nodes_[i].block_index = UINT32_MAX;
-        nodes_[i].next = UINT32_MAX;
-    }
-    head_.store(UINT32_MAX, std::memory_order_relaxed);
-    free_nodes_head_.store(UINT32_MAX, std::memory_order_relaxed);
-    next_node_.store(0, std::memory_order_relaxed);
-    count_.store(0, std::memory_order_relaxed);
+  capacity_ = capacity;
+  /* Over-allocate: each block can be pushed at most once, but we need
+     extra nodes if push/pop interleave heavily. 2x is safe. */
+  uint32_t num_nodes = capacity * 2;
+  nodes_ = new Node[num_nodes];
+  for (uint32_t i = 0; i < num_nodes; ++i) {
+    nodes_[i].block_index = UINT32_MAX;
+    nodes_[i].next = UINT32_MAX;
+  }
+  head_.store(UINT32_MAX, std::memory_order_relaxed);
+  free_nodes_head_.store(UINT32_MAX, std::memory_order_relaxed);
+  next_node_.store(0, std::memory_order_relaxed);
+  count_.store(0, std::memory_order_relaxed);
 }
 
 uint32_t FreeList::alloc_node() {
-    /* Try the recycled node pool first */
-    uint32_t idx = free_nodes_head_.load(std::memory_order_acquire);
-    while (idx != UINT32_MAX) {
-        uint32_t next = nodes_[idx].next;
-        if (free_nodes_head_.compare_exchange_weak(idx, next,
-                std::memory_order_acq_rel, std::memory_order_acquire))
-            return idx;
-    }
-    /* Allocate from pre-allocated array */
-    uint32_t new_idx = next_node_.fetch_add(1, std::memory_order_relaxed);
-    if (new_idx >= capacity_ * 2)
-        return UINT32_MAX; /* Exhausted */
-    return new_idx;
+  /* Try the recycled node pool first */
+  uint32_t idx = free_nodes_head_.load(std::memory_order_acquire);
+  while (idx != UINT32_MAX) {
+    uint32_t next = nodes_[idx].next;
+    if (free_nodes_head_.compare_exchange_weak(
+            idx, next, std::memory_order_acq_rel, std::memory_order_acquire))
+      return idx;
+  }
+  /* Allocate from pre-allocated array */
+  uint32_t new_idx = next_node_.fetch_add(1, std::memory_order_relaxed);
+  if (new_idx >= capacity_ * 2)
+    return UINT32_MAX; /* Exhausted */
+  return new_idx;
 }
 
 void FreeList::free_node(uint32_t idx) {
-    uint32_t old_head = free_nodes_head_.load(std::memory_order_acquire);
-    do {
-        nodes_[idx].next = old_head;
-    } while (!free_nodes_head_.compare_exchange_weak(old_head, idx,
-                std::memory_order_acq_rel, std::memory_order_acquire));
+  uint32_t old_head = free_nodes_head_.load(std::memory_order_acquire);
+  do {
+    nodes_[idx].next = old_head;
+  } while (!free_nodes_head_.compare_exchange_weak(
+      old_head, idx, std::memory_order_acq_rel, std::memory_order_acquire));
 }
 
 bool FreeList::push(uint32_t block_index) {
-    uint32_t node_idx = alloc_node();
-    if (node_idx == UINT32_MAX)
-        return false;
+  uint32_t node_idx = alloc_node();
+  if (node_idx == UINT32_MAX)
+    return false;
 
-    nodes_[node_idx].block_index = block_index;
+  nodes_[node_idx].block_index = block_index;
 
-    uint32_t old_head = head_.load(std::memory_order_acquire);
-    do {
-        nodes_[node_idx].next = old_head;
-    } while (!head_.compare_exchange_weak(old_head, node_idx,
-                std::memory_order_acq_rel, std::memory_order_acquire));
+  uint32_t old_head = head_.load(std::memory_order_acquire);
+  do {
+    nodes_[node_idx].next = old_head;
+  } while (!head_.compare_exchange_weak(old_head, node_idx,
+                                        std::memory_order_acq_rel,
+                                        std::memory_order_acquire));
 
-    count_.fetch_add(1, std::memory_order_relaxed);
-    return true;
+  count_.fetch_add(1, std::memory_order_relaxed);
+  return true;
 }
 
 uint32_t FreeList::pop() {
-    uint32_t idx = head_.load(std::memory_order_acquire);
-    while (idx != UINT32_MAX) {
-        uint32_t next = nodes_[idx].next;
-        if (head_.compare_exchange_weak(idx, next,
-                std::memory_order_acq_rel, std::memory_order_acquire)) {
-            uint32_t block_index = nodes_[idx].block_index;
-            free_node(idx);
-            count_.fetch_sub(1, std::memory_order_relaxed);
-            return block_index;
-        }
+  uint32_t idx = head_.load(std::memory_order_acquire);
+  while (idx != UINT32_MAX) {
+    uint32_t next = nodes_[idx].next;
+    if (head_.compare_exchange_weak(idx, next, std::memory_order_acq_rel,
+                                    std::memory_order_acquire)) {
+      uint32_t block_index = nodes_[idx].block_index;
+      free_node(idx);
+      count_.fetch_sub(1, std::memory_order_relaxed);
+      return block_index;
     }
-    return UINT32_MAX; /* Empty */
+  }
+  return UINT32_MAX; /* Empty */
 }
 
 bool FreeList::empty() const {
-    return head_.load(std::memory_order_acquire) == UINT32_MAX;
+  return head_.load(std::memory_order_acquire) == UINT32_MAX;
 }
 
 uint32_t FreeList::count() const {
-    return count_.load(std::memory_order_relaxed);
+  return count_.load(std::memory_order_relaxed);
 }
 
 void FreeList::shutdown() {
-    delete[] nodes_;
-    nodes_ = nullptr;
-    capacity_ = 0;
-    head_.store(UINT32_MAX, std::memory_order_relaxed);
-    free_nodes_head_.store(UINT32_MAX, std::memory_order_relaxed);
-    next_node_.store(0, std::memory_order_relaxed);
-    count_.store(0, std::memory_order_relaxed);
+  delete[] nodes_;
+  nodes_ = nullptr;
+  capacity_ = 0;
+  head_.store(UINT32_MAX, std::memory_order_relaxed);
+  free_nodes_head_.store(UINT32_MAX, std::memory_order_relaxed);
+  next_node_.store(0, std::memory_order_relaxed);
+  count_.store(0, std::memory_order_relaxed);
 }
 
 } // namespace mm

--- a/lib/MemoryManager/mm_free_list.cpp
+++ b/lib/MemoryManager/mm_free_list.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
 #include "mm_free_list.h"
 
 namespace mm {

--- a/lib/MemoryManager/mm_free_list.cpp
+++ b/lib/MemoryManager/mm_free_list.cpp
@@ -1,0 +1,97 @@
+#include "mm_free_list.h"
+
+namespace mm {
+
+FreeList::~FreeList() { shutdown(); }
+
+void FreeList::init(uint32_t capacity) {
+    capacity_ = capacity;
+    /* Over-allocate: each block can be pushed at most once, but we need
+       extra nodes if push/pop interleave heavily. 2x is safe. */
+    uint32_t num_nodes = capacity * 2;
+    nodes_ = new Node[num_nodes];
+    for (uint32_t i = 0; i < num_nodes; ++i) {
+        nodes_[i].block_index = UINT32_MAX;
+        nodes_[i].next = UINT32_MAX;
+    }
+    head_.store(UINT32_MAX, std::memory_order_relaxed);
+    free_nodes_head_.store(UINT32_MAX, std::memory_order_relaxed);
+    next_node_.store(0, std::memory_order_relaxed);
+    count_.store(0, std::memory_order_relaxed);
+}
+
+uint32_t FreeList::alloc_node() {
+    /* Try the recycled node pool first */
+    uint32_t idx = free_nodes_head_.load(std::memory_order_acquire);
+    while (idx != UINT32_MAX) {
+        uint32_t next = nodes_[idx].next;
+        if (free_nodes_head_.compare_exchange_weak(idx, next,
+                std::memory_order_acq_rel, std::memory_order_acquire))
+            return idx;
+    }
+    /* Allocate from pre-allocated array */
+    uint32_t new_idx = next_node_.fetch_add(1, std::memory_order_relaxed);
+    if (new_idx >= capacity_ * 2)
+        return UINT32_MAX; /* Exhausted */
+    return new_idx;
+}
+
+void FreeList::free_node(uint32_t idx) {
+    uint32_t old_head = free_nodes_head_.load(std::memory_order_acquire);
+    do {
+        nodes_[idx].next = old_head;
+    } while (!free_nodes_head_.compare_exchange_weak(old_head, idx,
+                std::memory_order_acq_rel, std::memory_order_acquire));
+}
+
+bool FreeList::push(uint32_t block_index) {
+    uint32_t node_idx = alloc_node();
+    if (node_idx == UINT32_MAX)
+        return false;
+
+    nodes_[node_idx].block_index = block_index;
+
+    uint32_t old_head = head_.load(std::memory_order_acquire);
+    do {
+        nodes_[node_idx].next = old_head;
+    } while (!head_.compare_exchange_weak(old_head, node_idx,
+                std::memory_order_acq_rel, std::memory_order_acquire));
+
+    count_.fetch_add(1, std::memory_order_relaxed);
+    return true;
+}
+
+uint32_t FreeList::pop() {
+    uint32_t idx = head_.load(std::memory_order_acquire);
+    while (idx != UINT32_MAX) {
+        uint32_t next = nodes_[idx].next;
+        if (head_.compare_exchange_weak(idx, next,
+                std::memory_order_acq_rel, std::memory_order_acquire)) {
+            uint32_t block_index = nodes_[idx].block_index;
+            free_node(idx);
+            count_.fetch_sub(1, std::memory_order_relaxed);
+            return block_index;
+        }
+    }
+    return UINT32_MAX; /* Empty */
+}
+
+bool FreeList::empty() const {
+    return head_.load(std::memory_order_acquire) == UINT32_MAX;
+}
+
+uint32_t FreeList::count() const {
+    return count_.load(std::memory_order_relaxed);
+}
+
+void FreeList::shutdown() {
+    delete[] nodes_;
+    nodes_ = nullptr;
+    capacity_ = 0;
+    head_.store(UINT32_MAX, std::memory_order_relaxed);
+    free_nodes_head_.store(UINT32_MAX, std::memory_order_relaxed);
+    next_node_.store(0, std::memory_order_relaxed);
+    count_.store(0, std::memory_order_relaxed);
+}
+
+} // namespace mm

--- a/lib/MemoryManager/mm_free_list.h
+++ b/lib/MemoryManager/mm_free_list.h
@@ -18,50 +18,50 @@ namespace mm {
  */
 class FreeList {
 public:
-    FreeList() = default;
-    ~FreeList();
+  FreeList() = default;
+  ~FreeList();
 
-    /* Initialize with capacity. Pre-allocates node storage. */
-    void init(uint32_t capacity);
+  /* Initialize with capacity. Pre-allocates node storage. */
+  void init(uint32_t capacity);
 
-    /* Push a block index onto the free list. Returns true on success. */
-    bool push(uint32_t block_index);
+  /* Push a block index onto the free list. Returns true on success. */
+  bool push(uint32_t block_index);
 
-    /* Pop a block index from the free list. Returns UINT32_MAX if empty. */
-    uint32_t pop();
+  /* Pop a block index from the free list. Returns UINT32_MAX if empty. */
+  uint32_t pop();
 
-    /* Check if the free list is empty. */
-    bool empty() const;
+  /* Check if the free list is empty. */
+  bool empty() const;
 
-    /* Number of items currently in the free list. */
-    uint32_t count() const;
+  /* Number of items currently in the free list. */
+  uint32_t count() const;
 
-    /* Release all storage. */
-    void shutdown();
+  /* Release all storage. */
+  void shutdown();
 
 private:
-    struct Node {
-        uint32_t block_index;
-        uint32_t next; /* index into nodes_ array, UINT32_MAX = end */
-    };
+  struct Node {
+    uint32_t block_index;
+    uint32_t next; /* index into nodes_ array, UINT32_MAX = end */
+  };
 
-    Node *nodes_ = nullptr;
-    uint32_t capacity_ = 0;
+  Node *nodes_ = nullptr;
+  uint32_t capacity_ = 0;
 
-    /* Head of the free list (index into nodes_). UINT32_MAX = empty. */
-    std::atomic<uint32_t> head_{UINT32_MAX};
+  /* Head of the free list (index into nodes_). UINT32_MAX = empty. */
+  std::atomic<uint32_t> head_{UINT32_MAX};
 
-    /* Free node pool for recycling Node structs */
-    std::atomic<uint32_t> free_nodes_head_{UINT32_MAX};
+  /* Free node pool for recycling Node structs */
+  std::atomic<uint32_t> free_nodes_head_{UINT32_MAX};
 
-    /* Count of items in the list */
-    std::atomic<uint32_t> count_{0};
+  /* Count of items in the list */
+  std::atomic<uint32_t> count_{0};
 
-    /* Next node index to allocate from the pre-allocated array */
-    std::atomic<uint32_t> next_node_{0};
+  /* Next node index to allocate from the pre-allocated array */
+  std::atomic<uint32_t> next_node_{0};
 
-    uint32_t alloc_node();
-    void free_node(uint32_t idx);
+  uint32_t alloc_node();
+  void free_node(uint32_t idx);
 };
 
 } // namespace mm

--- a/lib/MemoryManager/mm_free_list.h
+++ b/lib/MemoryManager/mm_free_list.h
@@ -1,0 +1,69 @@
+#ifndef MM_FREE_LIST_H
+#define MM_FREE_LIST_H
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+
+namespace mm {
+
+/*
+ * Lock-free LIFO (stack) free list using atomic CAS.
+ *
+ * Each node stores a block index. Push/pop are O(1) and wait-free
+ * for the common uncontended case.
+ *
+ * Intended for KV block pool per-format free lists where allocation
+ * latency must be < 100 ns.
+ */
+class FreeList {
+public:
+    FreeList() = default;
+    ~FreeList();
+
+    /* Initialize with capacity. Pre-allocates node storage. */
+    void init(uint32_t capacity);
+
+    /* Push a block index onto the free list. Returns true on success. */
+    bool push(uint32_t block_index);
+
+    /* Pop a block index from the free list. Returns UINT32_MAX if empty. */
+    uint32_t pop();
+
+    /* Check if the free list is empty. */
+    bool empty() const;
+
+    /* Number of items currently in the free list. */
+    uint32_t count() const;
+
+    /* Release all storage. */
+    void shutdown();
+
+private:
+    struct Node {
+        uint32_t block_index;
+        uint32_t next; /* index into nodes_ array, UINT32_MAX = end */
+    };
+
+    Node *nodes_ = nullptr;
+    uint32_t capacity_ = 0;
+
+    /* Head of the free list (index into nodes_). UINT32_MAX = empty. */
+    std::atomic<uint32_t> head_{UINT32_MAX};
+
+    /* Free node pool for recycling Node structs */
+    std::atomic<uint32_t> free_nodes_head_{UINT32_MAX};
+
+    /* Count of items in the list */
+    std::atomic<uint32_t> count_{0};
+
+    /* Next node index to allocate from the pre-allocated array */
+    std::atomic<uint32_t> next_node_{0};
+
+    uint32_t alloc_node();
+    void free_node(uint32_t idx);
+};
+
+} // namespace mm
+
+#endif /* MM_FREE_LIST_H */

--- a/lib/MemoryManager/mm_free_list.h
+++ b/lib/MemoryManager/mm_free_list.h
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
 #ifndef MM_FREE_LIST_H
 #define MM_FREE_LIST_H
 

--- a/lib/MemoryManager/mm_hal.cpp
+++ b/lib/MemoryManager/mm_hal.cpp
@@ -4,18 +4,16 @@
 static const mm_hal_t *g_hal = nullptr;
 
 int mm_hal_register(const mm_hal_t *hal) {
-    if (!hal)
-        return MM_ERROR_INVALID_ARG;
+  if (!hal)
+    return MM_ERROR_INVALID_ARG;
 
-    /* Validate required function pointers */
-    if (!hal->raw_alloc || !hal->raw_free || !hal->get_device_count ||
-        !hal->get_total_memory || !hal->get_free_memory)
-        return MM_ERROR_INVALID_ARG;
+  /* Validate required function pointers */
+  if (!hal->raw_alloc || !hal->raw_free || !hal->get_device_count ||
+      !hal->get_total_memory || !hal->get_free_memory)
+    return MM_ERROR_INVALID_ARG;
 
-    g_hal = hal;
-    return MM_OK;
+  g_hal = hal;
+  return MM_OK;
 }
 
-const mm_hal_t *mm_hal_get(void) {
-    return g_hal;
-}
+const mm_hal_t *mm_hal_get(void) { return g_hal; }

--- a/lib/MemoryManager/mm_hal.cpp
+++ b/lib/MemoryManager/mm_hal.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
 #include "mm_hal.h"
 #include <cstring>
 

--- a/lib/MemoryManager/mm_hal.cpp
+++ b/lib/MemoryManager/mm_hal.cpp
@@ -1,0 +1,21 @@
+#include "mm_hal.h"
+#include <cstring>
+
+static const mm_hal_t *g_hal = nullptr;
+
+int mm_hal_register(const mm_hal_t *hal) {
+    if (!hal)
+        return MM_ERROR_INVALID_ARG;
+
+    /* Validate required function pointers */
+    if (!hal->raw_alloc || !hal->raw_free || !hal->get_device_count ||
+        !hal->get_total_memory || !hal->get_free_memory)
+        return MM_ERROR_INVALID_ARG;
+
+    g_hal = hal;
+    return MM_OK;
+}
+
+const mm_hal_t *mm_hal_get(void) {
+    return g_hal;
+}

--- a/lib/MemoryManager/mm_hal.h
+++ b/lib/MemoryManager/mm_hal.h
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
 #ifndef MM_HAL_H
 #define MM_HAL_H
 

--- a/lib/MemoryManager/mm_hal.h
+++ b/lib/MemoryManager/mm_hal.h
@@ -1,0 +1,70 @@
+#ifndef MM_HAL_H
+#define MM_HAL_H
+
+#include "mm_types.h"
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define MM_DEVICE_NAME_MAX 64
+
+typedef struct {
+    char        name[MM_DEVICE_NAME_MAX];
+    mm_device_t type;
+    size_t      total_memory;
+    size_t      free_memory;
+} mm_device_info_t;
+
+typedef struct {
+    /* Device discovery */
+    int   (*get_device_count)(void);
+    int   (*get_device_info)(int device_id, mm_device_info_t *info);
+
+    /* Raw allocation (synchronous) */
+    void *(*raw_alloc)(int device_id, size_t size, size_t alignment);
+    void  (*raw_free)(int device_id, void *ptr);
+
+    /* Stream-ordered allocation */
+    void *(*stream_alloc)(int device_id, size_t size, mm_stream_t stream);
+    void  (*stream_free)(int device_id, void *ptr, mm_stream_t stream);
+
+    /* Async data transfer */
+    int   (*async_copy)(void *dst, const void *src, size_t size,
+                        mm_copy_kind_t kind, mm_stream_t stream,
+                        mm_fence_t *fence);
+
+    /* Synchronous memset */
+    int   (*memset)(void *ptr, int value, size_t size, mm_stream_t stream);
+
+    /* Stream synchronization */
+    int   (*stream_sync)(mm_stream_t stream);
+
+    /* Device memory info */
+    size_t (*get_total_memory)(int device_id);
+    size_t (*get_free_memory)(int device_id);
+
+    /* Host (pinned) memory for DRAM tier */
+    void *(*host_alloc)(size_t size, size_t alignment);
+    void  (*host_free)(void *ptr);
+} mm_hal_t;
+
+/* Register a HAL backend. Must be called before mm_init(). */
+int mm_hal_register(const mm_hal_t *hal);
+
+/* Get the currently registered HAL (for internal use). */
+const mm_hal_t *mm_hal_get(void);
+
+/* Built-in HAL backends */
+const mm_hal_t *mm_hal_host_get(void);
+
+#ifdef MM_HAS_HIP
+const mm_hal_t *mm_hal_hip_get(void);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MM_HAL_H */

--- a/lib/MemoryManager/mm_hal.h
+++ b/lib/MemoryManager/mm_hal.h
@@ -11,43 +11,42 @@ extern "C" {
 #define MM_DEVICE_NAME_MAX 64
 
 typedef struct {
-    char        name[MM_DEVICE_NAME_MAX];
-    mm_device_t type;
-    size_t      total_memory;
-    size_t      free_memory;
+  char name[MM_DEVICE_NAME_MAX];
+  mm_device_t type;
+  size_t total_memory;
+  size_t free_memory;
 } mm_device_info_t;
 
 typedef struct {
-    /* Device discovery */
-    int   (*get_device_count)(void);
-    int   (*get_device_info)(int device_id, mm_device_info_t *info);
+  /* Device discovery */
+  int (*get_device_count)(void);
+  int (*get_device_info)(int device_id, mm_device_info_t *info);
 
-    /* Raw allocation (synchronous) */
-    void *(*raw_alloc)(int device_id, size_t size, size_t alignment);
-    void  (*raw_free)(int device_id, void *ptr);
+  /* Raw allocation (synchronous) */
+  void *(*raw_alloc)(int device_id, size_t size, size_t alignment);
+  void (*raw_free)(int device_id, void *ptr);
 
-    /* Stream-ordered allocation */
-    void *(*stream_alloc)(int device_id, size_t size, mm_stream_t stream);
-    void  (*stream_free)(int device_id, void *ptr, mm_stream_t stream);
+  /* Stream-ordered allocation */
+  void *(*stream_alloc)(int device_id, size_t size, mm_stream_t stream);
+  void (*stream_free)(int device_id, void *ptr, mm_stream_t stream);
 
-    /* Async data transfer */
-    int   (*async_copy)(void *dst, const void *src, size_t size,
-                        mm_copy_kind_t kind, mm_stream_t stream,
-                        mm_fence_t *fence);
+  /* Async data transfer */
+  int (*async_copy)(void *dst, const void *src, size_t size,
+                    mm_copy_kind_t kind, mm_stream_t stream, mm_fence_t *fence);
 
-    /* Synchronous memset */
-    int   (*memset)(void *ptr, int value, size_t size, mm_stream_t stream);
+  /* Synchronous memset */
+  int (*memset)(void *ptr, int value, size_t size, mm_stream_t stream);
 
-    /* Stream synchronization */
-    int   (*stream_sync)(mm_stream_t stream);
+  /* Stream synchronization */
+  int (*stream_sync)(mm_stream_t stream);
 
-    /* Device memory info */
-    size_t (*get_total_memory)(int device_id);
-    size_t (*get_free_memory)(int device_id);
+  /* Device memory info */
+  size_t (*get_total_memory)(int device_id);
+  size_t (*get_free_memory)(int device_id);
 
-    /* Host (pinned) memory for DRAM tier */
-    void *(*host_alloc)(size_t size, size_t alignment);
-    void  (*host_free)(void *ptr);
+  /* Host (pinned) memory for DRAM tier */
+  void *(*host_alloc)(size_t size, size_t alignment);
+  void (*host_free)(void *ptr);
 } mm_hal_t;
 
 /* Register a HAL backend. Must be called before mm_init(). */

--- a/lib/MemoryManager/mm_hal_hip.cpp
+++ b/lib/MemoryManager/mm_hal_hip.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
 #include "mm_hal.h"
 
 #ifdef MM_HAS_HIP

--- a/lib/MemoryManager/mm_hal_hip.cpp
+++ b/lib/MemoryManager/mm_hal_hip.cpp
@@ -2,177 +2,174 @@
 
 #ifdef MM_HAS_HIP
 
-#include <hip/hip_runtime.h>
 #include <cstring>
+#include <hip/hip_runtime.h>
 
 /* ROCm/HIP HAL backend — wraps HIP runtime API. */
 
 static int hip_get_device_count(void) {
-    int count = 0;
-    if (hipGetDeviceCount(&count) != hipSuccess)
-        return 0;
-    return count;
+  int count = 0;
+  if (hipGetDeviceCount(&count) != hipSuccess)
+    return 0;
+  return count;
 }
 
 static int hip_get_device_info(int device_id, mm_device_info_t *info) {
-    if (!info)
-        return MM_ERROR_INVALID_ARG;
+  if (!info)
+    return MM_ERROR_INVALID_ARG;
 
-    hipDeviceProp_t props;
-    if (hipGetDeviceProperties(&props, device_id) != hipSuccess)
-        return MM_ERROR_HAL_FAILURE;
+  hipDeviceProp_t props;
+  if (hipGetDeviceProperties(&props, device_id) != hipSuccess)
+    return MM_ERROR_HAL_FAILURE;
 
-    std::strncpy(info->name, props.name, MM_DEVICE_NAME_MAX - 1);
-    info->name[MM_DEVICE_NAME_MAX - 1] = '\0';
-    info->type = (mm_device_t)device_id;
-    info->total_memory = props.totalGlobalMem;
+  std::strncpy(info->name, props.name, MM_DEVICE_NAME_MAX - 1);
+  info->name[MM_DEVICE_NAME_MAX - 1] = '\0';
+  info->type = (mm_device_t)device_id;
+  info->total_memory = props.totalGlobalMem;
 
-    size_t free_mem = 0, total_mem = 0;
-    int prev_device = 0;
-    hipGetDevice(&prev_device);
-    hipSetDevice(device_id);
-    hipMemGetInfo(&free_mem, &total_mem);
-    hipSetDevice(prev_device);
-    info->free_memory = free_mem;
+  size_t free_mem = 0, total_mem = 0;
+  int prev_device = 0;
+  hipGetDevice(&prev_device);
+  hipSetDevice(device_id);
+  hipMemGetInfo(&free_mem, &total_mem);
+  hipSetDevice(prev_device);
+  info->free_memory = free_mem;
 
-    return MM_OK;
+  return MM_OK;
 }
 
 static void *hip_raw_alloc(int device_id, size_t size, size_t /*alignment*/) {
-    if (size == 0)
-        return nullptr;
+  if (size == 0)
+    return nullptr;
 
-    int prev_device = 0;
-    hipGetDevice(&prev_device);
-    hipSetDevice(device_id);
+  int prev_device = 0;
+  hipGetDevice(&prev_device);
+  hipSetDevice(device_id);
 
-    void *ptr = nullptr;
-    hipError_t err = hipMalloc(&ptr, size);
+  void *ptr = nullptr;
+  hipError_t err = hipMalloc(&ptr, size);
 
-    hipSetDevice(prev_device);
-    return (err == hipSuccess) ? ptr : nullptr;
+  hipSetDevice(prev_device);
+  return (err == hipSuccess) ? ptr : nullptr;
 }
 
 static void hip_raw_free(int device_id, void *ptr) {
-    if (!ptr)
-        return;
-    int prev_device = 0;
-    hipGetDevice(&prev_device);
-    hipSetDevice(device_id);
-    hipFree(ptr);
-    hipSetDevice(prev_device);
+  if (!ptr)
+    return;
+  int prev_device = 0;
+  hipGetDevice(&prev_device);
+  hipSetDevice(device_id);
+  hipFree(ptr);
+  hipSetDevice(prev_device);
 }
 
-static void *hip_stream_alloc(int device_id, size_t size,
-                              mm_stream_t stream) {
-    if (size == 0)
-        return nullptr;
+static void *hip_stream_alloc(int device_id, size_t size, mm_stream_t stream) {
+  if (size == 0)
+    return nullptr;
 
-    int prev_device = 0;
-    hipGetDevice(&prev_device);
-    hipSetDevice(device_id);
+  int prev_device = 0;
+  hipGetDevice(&prev_device);
+  hipSetDevice(device_id);
 
-    void *ptr = nullptr;
-    hipError_t err =
-        hipMallocAsync(&ptr, size, reinterpret_cast<hipStream_t>(stream));
-    if (err != hipSuccess) {
-        /* Fall back to synchronous alloc */
-        err = hipMalloc(&ptr, size);
-    }
+  void *ptr = nullptr;
+  hipError_t err =
+      hipMallocAsync(&ptr, size, reinterpret_cast<hipStream_t>(stream));
+  if (err != hipSuccess) {
+    /* Fall back to synchronous alloc */
+    err = hipMalloc(&ptr, size);
+  }
 
-    hipSetDevice(prev_device);
-    return (err == hipSuccess) ? ptr : nullptr;
+  hipSetDevice(prev_device);
+  return (err == hipSuccess) ? ptr : nullptr;
 }
 
 static void hip_stream_free(int device_id, void *ptr, mm_stream_t stream) {
-    if (!ptr)
-        return;
-    int prev_device = 0;
-    hipGetDevice(&prev_device);
-    hipSetDevice(device_id);
+  if (!ptr)
+    return;
+  int prev_device = 0;
+  hipGetDevice(&prev_device);
+  hipSetDevice(device_id);
 
-    hipError_t err =
-        hipFreeAsync(ptr, reinterpret_cast<hipStream_t>(stream));
-    if (err != hipSuccess) {
-        hipFree(ptr);
-    }
+  hipError_t err = hipFreeAsync(ptr, reinterpret_cast<hipStream_t>(stream));
+  if (err != hipSuccess) {
+    hipFree(ptr);
+  }
 
-    hipSetDevice(prev_device);
+  hipSetDevice(prev_device);
 }
 
 static int hip_async_copy(void *dst, const void *src, size_t size,
                           mm_copy_kind_t kind, mm_stream_t stream,
                           mm_fence_t * /*fence*/) {
-    hipMemcpyKind hk;
-    switch (kind) {
-    case MM_COPY_HOST_TO_DEVICE:   hk = hipMemcpyHostToDevice;   break;
-    case MM_COPY_DEVICE_TO_HOST:   hk = hipMemcpyDeviceToHost;   break;
-    case MM_COPY_DEVICE_TO_DEVICE: hk = hipMemcpyDeviceToDevice; break;
-    case MM_COPY_HOST_TO_HOST:     hk = hipMemcpyHostToHost;     break;
-    default: return MM_ERROR_INVALID_ARG;
-    }
+  hipMemcpyKind hk;
+  switch (kind) {
+  case MM_COPY_HOST_TO_DEVICE:
+    hk = hipMemcpyHostToDevice;
+    break;
+  case MM_COPY_DEVICE_TO_HOST:
+    hk = hipMemcpyDeviceToHost;
+    break;
+  case MM_COPY_DEVICE_TO_DEVICE:
+    hk = hipMemcpyDeviceToDevice;
+    break;
+  case MM_COPY_HOST_TO_HOST:
+    hk = hipMemcpyHostToHost;
+    break;
+  default:
+    return MM_ERROR_INVALID_ARG;
+  }
 
-    hipError_t err = hipMemcpyAsync(dst, src, size, hk,
-                                    reinterpret_cast<hipStream_t>(stream));
-    return (err == hipSuccess) ? MM_OK : MM_ERROR_HAL_FAILURE;
+  hipError_t err =
+      hipMemcpyAsync(dst, src, size, hk, reinterpret_cast<hipStream_t>(stream));
+  return (err == hipSuccess) ? MM_OK : MM_ERROR_HAL_FAILURE;
 }
 
-static int hip_memset(void *ptr, int value, size_t size,
-                      mm_stream_t stream) {
-    hipError_t err = hipMemsetAsync(ptr, value, size,
-                                    reinterpret_cast<hipStream_t>(stream));
-    return (err == hipSuccess) ? MM_OK : MM_ERROR_HAL_FAILURE;
+static int hip_memset(void *ptr, int value, size_t size, mm_stream_t stream) {
+  hipError_t err =
+      hipMemsetAsync(ptr, value, size, reinterpret_cast<hipStream_t>(stream));
+  return (err == hipSuccess) ? MM_OK : MM_ERROR_HAL_FAILURE;
 }
 
 static int hip_stream_sync(mm_stream_t stream) {
-    hipError_t err =
-        hipStreamSynchronize(reinterpret_cast<hipStream_t>(stream));
-    return (err == hipSuccess) ? MM_OK : MM_ERROR_HAL_FAILURE;
+  hipError_t err = hipStreamSynchronize(reinterpret_cast<hipStream_t>(stream));
+  return (err == hipSuccess) ? MM_OK : MM_ERROR_HAL_FAILURE;
 }
 
 static size_t hip_get_total_memory(int device_id) {
-    hipDeviceProp_t props;
-    if (hipGetDeviceProperties(&props, device_id) != hipSuccess)
-        return 0;
-    return props.totalGlobalMem;
+  hipDeviceProp_t props;
+  if (hipGetDeviceProperties(&props, device_id) != hipSuccess)
+    return 0;
+  return props.totalGlobalMem;
 }
 
 static size_t hip_get_free_memory(int device_id) {
-    size_t free_mem = 0, total_mem = 0;
-    int prev_device = 0;
-    hipGetDevice(&prev_device);
-    hipSetDevice(device_id);
-    hipMemGetInfo(&free_mem, &total_mem);
-    hipSetDevice(prev_device);
-    return free_mem;
+  size_t free_mem = 0, total_mem = 0;
+  int prev_device = 0;
+  hipGetDevice(&prev_device);
+  hipSetDevice(device_id);
+  hipMemGetInfo(&free_mem, &total_mem);
+  hipSetDevice(prev_device);
+  return free_mem;
 }
 
 static void *hip_host_alloc(size_t size, size_t /*alignment*/) {
-    if (size == 0)
-        return nullptr;
-    void *ptr = nullptr;
-    hipError_t err = hipHostMalloc(&ptr, size);
-    return (err == hipSuccess) ? ptr : nullptr;
+  if (size == 0)
+    return nullptr;
+  void *ptr = nullptr;
+  hipError_t err = hipHostMalloc(&ptr, size);
+  return (err == hipSuccess) ? ptr : nullptr;
 }
 
 static void hip_host_free(void *ptr) {
-    if (ptr)
-        hipHostFree(ptr);
+  if (ptr)
+    hipHostFree(ptr);
 }
 
 static const mm_hal_t g_hip_hal = {
-    hip_get_device_count,
-    hip_get_device_info,
-    hip_raw_alloc,
-    hip_raw_free,
-    hip_stream_alloc,
-    hip_stream_free,
-    hip_async_copy,
-    hip_memset,
-    hip_stream_sync,
-    hip_get_total_memory,
-    hip_get_free_memory,
-    hip_host_alloc,
+    hip_get_device_count, hip_get_device_info, hip_raw_alloc,
+    hip_raw_free,         hip_stream_alloc,    hip_stream_free,
+    hip_async_copy,       hip_memset,          hip_stream_sync,
+    hip_get_total_memory, hip_get_free_memory, hip_host_alloc,
     hip_host_free,
 };
 

--- a/lib/MemoryManager/mm_hal_hip.cpp
+++ b/lib/MemoryManager/mm_hal_hip.cpp
@@ -1,0 +1,181 @@
+#include "mm_hal.h"
+
+#ifdef MM_HAS_HIP
+
+#include <hip/hip_runtime.h>
+#include <cstring>
+
+/* ROCm/HIP HAL backend — wraps HIP runtime API. */
+
+static int hip_get_device_count(void) {
+    int count = 0;
+    if (hipGetDeviceCount(&count) != hipSuccess)
+        return 0;
+    return count;
+}
+
+static int hip_get_device_info(int device_id, mm_device_info_t *info) {
+    if (!info)
+        return MM_ERROR_INVALID_ARG;
+
+    hipDeviceProp_t props;
+    if (hipGetDeviceProperties(&props, device_id) != hipSuccess)
+        return MM_ERROR_HAL_FAILURE;
+
+    std::strncpy(info->name, props.name, MM_DEVICE_NAME_MAX - 1);
+    info->name[MM_DEVICE_NAME_MAX - 1] = '\0';
+    info->type = (mm_device_t)device_id;
+    info->total_memory = props.totalGlobalMem;
+
+    size_t free_mem = 0, total_mem = 0;
+    int prev_device = 0;
+    hipGetDevice(&prev_device);
+    hipSetDevice(device_id);
+    hipMemGetInfo(&free_mem, &total_mem);
+    hipSetDevice(prev_device);
+    info->free_memory = free_mem;
+
+    return MM_OK;
+}
+
+static void *hip_raw_alloc(int device_id, size_t size, size_t /*alignment*/) {
+    if (size == 0)
+        return nullptr;
+
+    int prev_device = 0;
+    hipGetDevice(&prev_device);
+    hipSetDevice(device_id);
+
+    void *ptr = nullptr;
+    hipError_t err = hipMalloc(&ptr, size);
+
+    hipSetDevice(prev_device);
+    return (err == hipSuccess) ? ptr : nullptr;
+}
+
+static void hip_raw_free(int device_id, void *ptr) {
+    if (!ptr)
+        return;
+    int prev_device = 0;
+    hipGetDevice(&prev_device);
+    hipSetDevice(device_id);
+    hipFree(ptr);
+    hipSetDevice(prev_device);
+}
+
+static void *hip_stream_alloc(int device_id, size_t size,
+                              mm_stream_t stream) {
+    if (size == 0)
+        return nullptr;
+
+    int prev_device = 0;
+    hipGetDevice(&prev_device);
+    hipSetDevice(device_id);
+
+    void *ptr = nullptr;
+    hipError_t err =
+        hipMallocAsync(&ptr, size, reinterpret_cast<hipStream_t>(stream));
+    if (err != hipSuccess) {
+        /* Fall back to synchronous alloc */
+        err = hipMalloc(&ptr, size);
+    }
+
+    hipSetDevice(prev_device);
+    return (err == hipSuccess) ? ptr : nullptr;
+}
+
+static void hip_stream_free(int device_id, void *ptr, mm_stream_t stream) {
+    if (!ptr)
+        return;
+    int prev_device = 0;
+    hipGetDevice(&prev_device);
+    hipSetDevice(device_id);
+
+    hipError_t err =
+        hipFreeAsync(ptr, reinterpret_cast<hipStream_t>(stream));
+    if (err != hipSuccess) {
+        hipFree(ptr);
+    }
+
+    hipSetDevice(prev_device);
+}
+
+static int hip_async_copy(void *dst, const void *src, size_t size,
+                          mm_copy_kind_t kind, mm_stream_t stream,
+                          mm_fence_t * /*fence*/) {
+    hipMemcpyKind hk;
+    switch (kind) {
+    case MM_COPY_HOST_TO_DEVICE:   hk = hipMemcpyHostToDevice;   break;
+    case MM_COPY_DEVICE_TO_HOST:   hk = hipMemcpyDeviceToHost;   break;
+    case MM_COPY_DEVICE_TO_DEVICE: hk = hipMemcpyDeviceToDevice; break;
+    case MM_COPY_HOST_TO_HOST:     hk = hipMemcpyHostToHost;     break;
+    default: return MM_ERROR_INVALID_ARG;
+    }
+
+    hipError_t err = hipMemcpyAsync(dst, src, size, hk,
+                                    reinterpret_cast<hipStream_t>(stream));
+    return (err == hipSuccess) ? MM_OK : MM_ERROR_HAL_FAILURE;
+}
+
+static int hip_memset(void *ptr, int value, size_t size,
+                      mm_stream_t stream) {
+    hipError_t err = hipMemsetAsync(ptr, value, size,
+                                    reinterpret_cast<hipStream_t>(stream));
+    return (err == hipSuccess) ? MM_OK : MM_ERROR_HAL_FAILURE;
+}
+
+static int hip_stream_sync(mm_stream_t stream) {
+    hipError_t err =
+        hipStreamSynchronize(reinterpret_cast<hipStream_t>(stream));
+    return (err == hipSuccess) ? MM_OK : MM_ERROR_HAL_FAILURE;
+}
+
+static size_t hip_get_total_memory(int device_id) {
+    hipDeviceProp_t props;
+    if (hipGetDeviceProperties(&props, device_id) != hipSuccess)
+        return 0;
+    return props.totalGlobalMem;
+}
+
+static size_t hip_get_free_memory(int device_id) {
+    size_t free_mem = 0, total_mem = 0;
+    int prev_device = 0;
+    hipGetDevice(&prev_device);
+    hipSetDevice(device_id);
+    hipMemGetInfo(&free_mem, &total_mem);
+    hipSetDevice(prev_device);
+    return free_mem;
+}
+
+static void *hip_host_alloc(size_t size, size_t /*alignment*/) {
+    if (size == 0)
+        return nullptr;
+    void *ptr = nullptr;
+    hipError_t err = hipHostMalloc(&ptr, size);
+    return (err == hipSuccess) ? ptr : nullptr;
+}
+
+static void hip_host_free(void *ptr) {
+    if (ptr)
+        hipHostFree(ptr);
+}
+
+static const mm_hal_t g_hip_hal = {
+    hip_get_device_count,
+    hip_get_device_info,
+    hip_raw_alloc,
+    hip_raw_free,
+    hip_stream_alloc,
+    hip_stream_free,
+    hip_async_copy,
+    hip_memset,
+    hip_stream_sync,
+    hip_get_total_memory,
+    hip_get_free_memory,
+    hip_host_alloc,
+    hip_host_free,
+};
+
+const mm_hal_t *mm_hal_hip_get(void) { return &g_hip_hal; }
+
+#endif /* MM_HAS_HIP */

--- a/lib/MemoryManager/mm_hal_host.cpp
+++ b/lib/MemoryManager/mm_hal_host.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
 #include "mm_hal.h"
 #include <cstdlib>
 #include <cstring>

--- a/lib/MemoryManager/mm_hal_host.cpp
+++ b/lib/MemoryManager/mm_hal_host.cpp
@@ -7,96 +7,88 @@
 static int host_get_device_count(void) { return 1; }
 
 static int host_get_device_info(int device_id, mm_device_info_t *info) {
-    if (device_id != 0 || !info)
-        return MM_ERROR_INVALID_ARG;
-    std::strncpy(info->name, "CPU-Host", MM_DEVICE_NAME_MAX);
-    info->type = MM_DEVICE_CPU;
-    info->total_memory = (size_t)16 * 1024 * 1024 * 1024; /* 16 GB nominal */
-    info->free_memory  = (size_t)16 * 1024 * 1024 * 1024;
-    return MM_OK;
+  if (device_id != 0 || !info)
+    return MM_ERROR_INVALID_ARG;
+  std::strncpy(info->name, "CPU-Host", MM_DEVICE_NAME_MAX);
+  info->type = MM_DEVICE_CPU;
+  info->total_memory = (size_t)16 * 1024 * 1024 * 1024; /* 16 GB nominal */
+  info->free_memory = (size_t)16 * 1024 * 1024 * 1024;
+  return MM_OK;
 }
 
 static void *host_raw_alloc(int /*device_id*/, size_t size, size_t alignment) {
-    if (size == 0)
-        return nullptr;
+  if (size == 0)
+    return nullptr;
 #ifdef _WIN32
-    return _aligned_malloc(size, alignment > 0 ? alignment : 64);
+  return _aligned_malloc(size, alignment > 0 ? alignment : 64);
 #else
-    void *ptr = nullptr;
-    if (posix_memalign(&ptr, alignment > 0 ? alignment : 64, size) != 0)
-        return nullptr;
-    return ptr;
+  void *ptr = nullptr;
+  if (posix_memalign(&ptr, alignment > 0 ? alignment : 64, size) != 0)
+    return nullptr;
+  return ptr;
 #endif
 }
 
 static void host_raw_free(int /*device_id*/, void *ptr) {
 #ifdef _WIN32
-    _aligned_free(ptr);
+  _aligned_free(ptr);
 #else
-    free(ptr);
+  free(ptr);
 #endif
 }
 
 static void *host_stream_alloc(int device_id, size_t size,
                                mm_stream_t /*stream*/) {
-    return host_raw_alloc(device_id, size, 64);
+  return host_raw_alloc(device_id, size, 64);
 }
 
 static void host_stream_free(int /*device_id*/, void *ptr,
                              mm_stream_t /*stream*/) {
 #ifdef _WIN32
-    _aligned_free(ptr);
+  _aligned_free(ptr);
 #else
-    free(ptr);
+  free(ptr);
 #endif
 }
 
 static int host_async_copy(void *dst, const void *src, size_t size,
                            mm_copy_kind_t /*kind*/, mm_stream_t /*stream*/,
                            mm_fence_t * /*fence*/) {
-    if (!dst || !src)
-        return MM_ERROR_INVALID_ARG;
-    std::memcpy(dst, src, size);
-    return MM_OK;
+  if (!dst || !src)
+    return MM_ERROR_INVALID_ARG;
+  std::memcpy(dst, src, size);
+  return MM_OK;
 }
 
 static int host_memset(void *ptr, int value, size_t size,
                        mm_stream_t /*stream*/) {
-    if (!ptr)
-        return MM_ERROR_INVALID_ARG;
-    std::memset(ptr, value, size);
-    return MM_OK;
+  if (!ptr)
+    return MM_ERROR_INVALID_ARG;
+  std::memset(ptr, value, size);
+  return MM_OK;
 }
 
 static int host_stream_sync(mm_stream_t /*stream*/) { return MM_OK; }
 
 static size_t host_get_total_memory(int /*device_id*/) {
-    return (size_t)16 * 1024 * 1024 * 1024;
+  return (size_t)16 * 1024 * 1024 * 1024;
 }
 
 static size_t host_get_free_memory(int /*device_id*/) {
-    return (size_t)16 * 1024 * 1024 * 1024;
+  return (size_t)16 * 1024 * 1024 * 1024;
 }
 
 static void *host_host_alloc(size_t size, size_t alignment) {
-    return host_raw_alloc(0, size, alignment);
+  return host_raw_alloc(0, size, alignment);
 }
 
 static void host_host_free(void *ptr) { host_raw_free(0, ptr); }
 
 static const mm_hal_t g_host_hal = {
-    host_get_device_count,
-    host_get_device_info,
-    host_raw_alloc,
-    host_raw_free,
-    host_stream_alloc,
-    host_stream_free,
-    host_async_copy,
-    host_memset,
-    host_stream_sync,
-    host_get_total_memory,
-    host_get_free_memory,
-    host_host_alloc,
+    host_get_device_count, host_get_device_info, host_raw_alloc,
+    host_raw_free,         host_stream_alloc,    host_stream_free,
+    host_async_copy,       host_memset,          host_stream_sync,
+    host_get_total_memory, host_get_free_memory, host_host_alloc,
     host_host_free,
 };
 

--- a/lib/MemoryManager/mm_hal_host.cpp
+++ b/lib/MemoryManager/mm_hal_host.cpp
@@ -1,0 +1,103 @@
+#include "mm_hal.h"
+#include <cstdlib>
+#include <cstring>
+
+/* CPU/host HAL backend — for mock runtime and unit tests. */
+
+static int host_get_device_count(void) { return 1; }
+
+static int host_get_device_info(int device_id, mm_device_info_t *info) {
+    if (device_id != 0 || !info)
+        return MM_ERROR_INVALID_ARG;
+    std::strncpy(info->name, "CPU-Host", MM_DEVICE_NAME_MAX);
+    info->type = MM_DEVICE_CPU;
+    info->total_memory = (size_t)16 * 1024 * 1024 * 1024; /* 16 GB nominal */
+    info->free_memory  = (size_t)16 * 1024 * 1024 * 1024;
+    return MM_OK;
+}
+
+static void *host_raw_alloc(int /*device_id*/, size_t size, size_t alignment) {
+    if (size == 0)
+        return nullptr;
+#ifdef _WIN32
+    return _aligned_malloc(size, alignment > 0 ? alignment : 64);
+#else
+    void *ptr = nullptr;
+    if (posix_memalign(&ptr, alignment > 0 ? alignment : 64, size) != 0)
+        return nullptr;
+    return ptr;
+#endif
+}
+
+static void host_raw_free(int /*device_id*/, void *ptr) {
+#ifdef _WIN32
+    _aligned_free(ptr);
+#else
+    free(ptr);
+#endif
+}
+
+static void *host_stream_alloc(int device_id, size_t size,
+                               mm_stream_t /*stream*/) {
+    return host_raw_alloc(device_id, size, 64);
+}
+
+static void host_stream_free(int /*device_id*/, void *ptr,
+                             mm_stream_t /*stream*/) {
+#ifdef _WIN32
+    _aligned_free(ptr);
+#else
+    free(ptr);
+#endif
+}
+
+static int host_async_copy(void *dst, const void *src, size_t size,
+                           mm_copy_kind_t /*kind*/, mm_stream_t /*stream*/,
+                           mm_fence_t * /*fence*/) {
+    if (!dst || !src)
+        return MM_ERROR_INVALID_ARG;
+    std::memcpy(dst, src, size);
+    return MM_OK;
+}
+
+static int host_memset(void *ptr, int value, size_t size,
+                       mm_stream_t /*stream*/) {
+    if (!ptr)
+        return MM_ERROR_INVALID_ARG;
+    std::memset(ptr, value, size);
+    return MM_OK;
+}
+
+static int host_stream_sync(mm_stream_t /*stream*/) { return MM_OK; }
+
+static size_t host_get_total_memory(int /*device_id*/) {
+    return (size_t)16 * 1024 * 1024 * 1024;
+}
+
+static size_t host_get_free_memory(int /*device_id*/) {
+    return (size_t)16 * 1024 * 1024 * 1024;
+}
+
+static void *host_host_alloc(size_t size, size_t alignment) {
+    return host_raw_alloc(0, size, alignment);
+}
+
+static void host_host_free(void *ptr) { host_raw_free(0, ptr); }
+
+static const mm_hal_t g_host_hal = {
+    host_get_device_count,
+    host_get_device_info,
+    host_raw_alloc,
+    host_raw_free,
+    host_stream_alloc,
+    host_stream_free,
+    host_async_copy,
+    host_memset,
+    host_stream_sync,
+    host_get_total_memory,
+    host_get_free_memory,
+    host_host_alloc,
+    host_host_free,
+};
+
+const mm_hal_t *mm_hal_host_get(void) { return &g_host_hal; }

--- a/lib/MemoryManager/mm_handle_table.cpp
+++ b/lib/MemoryManager/mm_handle_table.cpp
@@ -6,59 +6,59 @@ HandleTable::HandleTable() = default;
 
 mm_handle_t HandleTable::insert(void *ptr, size_t size,
                                 mm_memory_class_t mem_class, mm_tier_t tier) {
-    uint64_t id = next_id_.fetch_add(1, std::memory_order_relaxed);
+  uint64_t id = next_id_.fetch_add(1, std::memory_order_relaxed);
 
-    HandleEntry entry{};
-    entry.ptr = ptr;
-    entry.size = size;
-    entry.mem_class = mem_class;
-    entry.tier = tier;
-    entry.ref_count = 1;
-    entry.active = true;
+  HandleEntry entry{};
+  entry.ptr = ptr;
+  entry.size = size;
+  entry.mem_class = mem_class;
+  entry.tier = tier;
+  entry.ref_count = 1;
+  entry.active = true;
 
-    std::lock_guard<std::mutex> lock(mutex_);
-    /* Handle ID maps to index = id - 1 (since IDs start at 1) */
-    if (id - 1 >= entries_.size())
-        entries_.resize(id, HandleEntry{});
-    entries_[id - 1] = entry;
-    return static_cast<mm_handle_t>(id);
+  std::lock_guard<std::mutex> lock(mutex_);
+  /* Handle ID maps to index = id - 1 (since IDs start at 1) */
+  if (id - 1 >= entries_.size())
+    entries_.resize(id, HandleEntry{});
+  entries_[id - 1] = entry;
+  return static_cast<mm_handle_t>(id);
 }
 
 HandleEntry *HandleTable::lookup(mm_handle_t handle) {
-    if (handle == MM_INVALID_HANDLE)
-        return nullptr;
-    uint64_t idx = handle - 1;
-    std::lock_guard<std::mutex> lock(mutex_);
-    if (idx >= entries_.size() || !entries_[idx].active)
-        return nullptr;
-    return &entries_[idx];
+  if (handle == MM_INVALID_HANDLE)
+    return nullptr;
+  uint64_t idx = handle - 1;
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (idx >= entries_.size() || !entries_[idx].active)
+    return nullptr;
+  return &entries_[idx];
 }
 
 HandleEntry *HandleTable::remove(mm_handle_t handle) {
-    if (handle == MM_INVALID_HANDLE)
-        return nullptr;
-    uint64_t idx = handle - 1;
-    std::lock_guard<std::mutex> lock(mutex_);
-    if (idx >= entries_.size() || !entries_[idx].active)
-        return nullptr;
-    entries_[idx].active = false;
-    return &entries_[idx];
+  if (handle == MM_INVALID_HANDLE)
+    return nullptr;
+  uint64_t idx = handle - 1;
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (idx >= entries_.size() || !entries_[idx].active)
+    return nullptr;
+  entries_[idx].active = false;
+  return &entries_[idx];
 }
 
 size_t HandleTable::active_count() const {
-    std::lock_guard<std::mutex> lock(mutex_);
-    size_t count = 0;
-    for (const auto &e : entries_) {
-        if (e.active)
-            ++count;
-    }
-    return count;
+  std::lock_guard<std::mutex> lock(mutex_);
+  size_t count = 0;
+  for (const auto &e : entries_) {
+    if (e.active)
+      ++count;
+  }
+  return count;
 }
 
 void HandleTable::clear() {
-    std::lock_guard<std::mutex> lock(mutex_);
-    entries_.clear();
-    next_id_.store(1, std::memory_order_relaxed);
+  std::lock_guard<std::mutex> lock(mutex_);
+  entries_.clear();
+  next_id_.store(1, std::memory_order_relaxed);
 }
 
 } // namespace mm

--- a/lib/MemoryManager/mm_handle_table.cpp
+++ b/lib/MemoryManager/mm_handle_table.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
 #include "mm_handle_table.h"
 
 namespace mm {

--- a/lib/MemoryManager/mm_handle_table.cpp
+++ b/lib/MemoryManager/mm_handle_table.cpp
@@ -1,0 +1,64 @@
+#include "mm_handle_table.h"
+
+namespace mm {
+
+HandleTable::HandleTable() = default;
+
+mm_handle_t HandleTable::insert(void *ptr, size_t size,
+                                mm_memory_class_t mem_class, mm_tier_t tier) {
+    uint64_t id = next_id_.fetch_add(1, std::memory_order_relaxed);
+
+    HandleEntry entry{};
+    entry.ptr = ptr;
+    entry.size = size;
+    entry.mem_class = mem_class;
+    entry.tier = tier;
+    entry.ref_count = 1;
+    entry.active = true;
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    /* Handle ID maps to index = id - 1 (since IDs start at 1) */
+    if (id - 1 >= entries_.size())
+        entries_.resize(id, HandleEntry{});
+    entries_[id - 1] = entry;
+    return static_cast<mm_handle_t>(id);
+}
+
+HandleEntry *HandleTable::lookup(mm_handle_t handle) {
+    if (handle == MM_INVALID_HANDLE)
+        return nullptr;
+    uint64_t idx = handle - 1;
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (idx >= entries_.size() || !entries_[idx].active)
+        return nullptr;
+    return &entries_[idx];
+}
+
+HandleEntry *HandleTable::remove(mm_handle_t handle) {
+    if (handle == MM_INVALID_HANDLE)
+        return nullptr;
+    uint64_t idx = handle - 1;
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (idx >= entries_.size() || !entries_[idx].active)
+        return nullptr;
+    entries_[idx].active = false;
+    return &entries_[idx];
+}
+
+size_t HandleTable::active_count() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    size_t count = 0;
+    for (const auto &e : entries_) {
+        if (e.active)
+            ++count;
+    }
+    return count;
+}
+
+void HandleTable::clear() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    entries_.clear();
+    next_id_.store(1, std::memory_order_relaxed);
+}
+
+} // namespace mm

--- a/lib/MemoryManager/mm_handle_table.h
+++ b/lib/MemoryManager/mm_handle_table.h
@@ -1,0 +1,50 @@
+#ifndef MM_HANDLE_TABLE_H
+#define MM_HANDLE_TABLE_H
+
+#include "mm_types.h"
+
+#include <atomic>
+#include <mutex>
+#include <vector>
+
+namespace mm {
+
+struct HandleEntry {
+    void             *ptr;
+    size_t            size;
+    mm_memory_class_t mem_class;
+    mm_tier_t         tier;
+    uint32_t          ref_count;
+    bool              active;
+};
+
+class HandleTable {
+public:
+    HandleTable();
+
+    /* Insert a new entry, returns a monotonically increasing handle. */
+    mm_handle_t insert(void *ptr, size_t size, mm_memory_class_t mem_class,
+                       mm_tier_t tier = MM_TIER_HBM);
+
+    /* Lookup by handle. Returns nullptr if invalid/removed. */
+    HandleEntry *lookup(mm_handle_t handle);
+
+    /* Remove an entry. Returns the entry data before removal.
+       Returns nullptr if handle was already invalid. */
+    HandleEntry *remove(mm_handle_t handle);
+
+    /* Number of active entries. */
+    size_t active_count() const;
+
+    /* Clear all entries. */
+    void clear();
+
+private:
+    mutable std::mutex mutex_;
+    std::vector<HandleEntry> entries_;
+    std::atomic<uint64_t> next_id_{1}; /* 0 is MM_INVALID_HANDLE */
+};
+
+} // namespace mm
+
+#endif /* MM_HANDLE_TABLE_H */

--- a/lib/MemoryManager/mm_handle_table.h
+++ b/lib/MemoryManager/mm_handle_table.h
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
 #ifndef MM_HANDLE_TABLE_H
 #define MM_HANDLE_TABLE_H
 

--- a/lib/MemoryManager/mm_handle_table.h
+++ b/lib/MemoryManager/mm_handle_table.h
@@ -10,39 +10,39 @@
 namespace mm {
 
 struct HandleEntry {
-    void             *ptr;
-    size_t            size;
-    mm_memory_class_t mem_class;
-    mm_tier_t         tier;
-    uint32_t          ref_count;
-    bool              active;
+  void *ptr;
+  size_t size;
+  mm_memory_class_t mem_class;
+  mm_tier_t tier;
+  uint32_t ref_count;
+  bool active;
 };
 
 class HandleTable {
 public:
-    HandleTable();
+  HandleTable();
 
-    /* Insert a new entry, returns a monotonically increasing handle. */
-    mm_handle_t insert(void *ptr, size_t size, mm_memory_class_t mem_class,
-                       mm_tier_t tier = MM_TIER_HBM);
+  /* Insert a new entry, returns a monotonically increasing handle. */
+  mm_handle_t insert(void *ptr, size_t size, mm_memory_class_t mem_class,
+                     mm_tier_t tier = MM_TIER_HBM);
 
-    /* Lookup by handle. Returns nullptr if invalid/removed. */
-    HandleEntry *lookup(mm_handle_t handle);
+  /* Lookup by handle. Returns nullptr if invalid/removed. */
+  HandleEntry *lookup(mm_handle_t handle);
 
-    /* Remove an entry. Returns the entry data before removal.
-       Returns nullptr if handle was already invalid. */
-    HandleEntry *remove(mm_handle_t handle);
+  /* Remove an entry. Returns the entry data before removal.
+     Returns nullptr if handle was already invalid. */
+  HandleEntry *remove(mm_handle_t handle);
 
-    /* Number of active entries. */
-    size_t active_count() const;
+  /* Number of active entries. */
+  size_t active_count() const;
 
-    /* Clear all entries. */
-    void clear();
+  /* Clear all entries. */
+  void clear();
 
 private:
-    mutable std::mutex mutex_;
-    std::vector<HandleEntry> entries_;
-    std::atomic<uint64_t> next_id_{1}; /* 0 is MM_INVALID_HANDLE */
+  mutable std::mutex mutex_;
+  std::vector<HandleEntry> entries_;
+  std::atomic<uint64_t> next_id_{1}; /* 0 is MM_INVALID_HANDLE */
 };
 
 } // namespace mm

--- a/lib/MemoryManager/mm_internal.h
+++ b/lib/MemoryManager/mm_internal.h
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
 #ifndef MM_INTERNAL_H
 #define MM_INTERNAL_H
 

--- a/lib/MemoryManager/mm_internal.h
+++ b/lib/MemoryManager/mm_internal.h
@@ -1,0 +1,66 @@
+#ifndef MM_INTERNAL_H
+#define MM_INTERNAL_H
+
+#include "mm_handle_table.h"
+#include "mm_hal.h"
+#include "mm_types.h"
+
+#include <atomic>
+#include <mutex>
+#include <vector>
+
+namespace mm {
+
+/* Forward declarations */
+class ArenaAllocator;
+class StaticPoolManager;
+class KvBlockPool;
+
+/* Configuration with defaults applied */
+struct MmConfig {
+    size_t         gpu_memory_limit       = 0; /* 0 = auto-detect */
+    float          kv_cache_fraction      = 0.90f;
+    uint32_t       kv_block_size_tokens   = 16;
+    mm_tier_t      max_tier               = MM_TIER_DRAM;
+    bool           enable_prefix_caching  = true;
+    bool           enable_defrag          = true;
+    uint32_t       num_size_classes       = 8;
+    float          high_watermark         = 0.90f;
+    float          critical_watermark     = 0.95f;
+    mm_kv_format_t default_kv_format      = MM_KV_FMT_FP16;
+    mm_kv_format_t pressure_kv_format     = MM_KV_FMT_TURBOQUANT_4;
+    mm_kv_format_t critical_kv_format     = MM_KV_FMT_TURBOQUANT_3;
+    bool           enable_inline_quant    = false;
+    bool           enable_adaptive_transcode = true;
+};
+
+/* Singleton state for the memory manager */
+struct MmState {
+    std::atomic<bool> initialized{false};
+    MmConfig config;
+    const mm_hal_t *hal = nullptr;
+
+    /* Handle registry for all allocations */
+    HandleTable handles;
+
+    /* Sub-allocators (owned, created during init) */
+    ArenaAllocator *arena = nullptr;
+    KvBlockPool *kv_pool = nullptr;
+
+    /* Active pools (created via mm_create_pool) */
+    std::mutex pools_mutex;
+    std::vector<StaticPoolManager *> pools;
+
+    /* Memory budget */
+    size_t total_gpu_memory = 0;
+    size_t weight_pool_reserved = 0;
+    size_t kv_cache_reserved = 0;
+    size_t activation_reserved = 0;
+};
+
+/* Access the global singleton. Never returns nullptr after mm_init(). */
+MmState *mm_get_state();
+
+} // namespace mm
+
+#endif /* MM_INTERNAL_H */

--- a/lib/MemoryManager/mm_internal.h
+++ b/lib/MemoryManager/mm_internal.h
@@ -1,8 +1,8 @@
 #ifndef MM_INTERNAL_H
 #define MM_INTERNAL_H
 
-#include "mm_handle_table.h"
 #include "mm_hal.h"
+#include "mm_handle_table.h"
 #include "mm_types.h"
 
 #include <atomic>
@@ -18,44 +18,44 @@ class KvBlockPool;
 
 /* Configuration with defaults applied */
 struct MmConfig {
-    size_t         gpu_memory_limit       = 0; /* 0 = auto-detect */
-    float          kv_cache_fraction      = 0.90f;
-    uint32_t       kv_block_size_tokens   = 16;
-    mm_tier_t      max_tier               = MM_TIER_DRAM;
-    bool           enable_prefix_caching  = true;
-    bool           enable_defrag          = true;
-    uint32_t       num_size_classes       = 8;
-    float          high_watermark         = 0.90f;
-    float          critical_watermark     = 0.95f;
-    mm_kv_format_t default_kv_format      = MM_KV_FMT_FP16;
-    mm_kv_format_t pressure_kv_format     = MM_KV_FMT_TURBOQUANT_4;
-    mm_kv_format_t critical_kv_format     = MM_KV_FMT_TURBOQUANT_3;
-    bool           enable_inline_quant    = false;
-    bool           enable_adaptive_transcode = true;
+  size_t gpu_memory_limit = 0; /* 0 = auto-detect */
+  float kv_cache_fraction = 0.90f;
+  uint32_t kv_block_size_tokens = 16;
+  mm_tier_t max_tier = MM_TIER_DRAM;
+  bool enable_prefix_caching = true;
+  bool enable_defrag = true;
+  uint32_t num_size_classes = 8;
+  float high_watermark = 0.90f;
+  float critical_watermark = 0.95f;
+  mm_kv_format_t default_kv_format = MM_KV_FMT_FP16;
+  mm_kv_format_t pressure_kv_format = MM_KV_FMT_TURBOQUANT_4;
+  mm_kv_format_t critical_kv_format = MM_KV_FMT_TURBOQUANT_3;
+  bool enable_inline_quant = false;
+  bool enable_adaptive_transcode = true;
 };
 
 /* Singleton state for the memory manager */
 struct MmState {
-    std::atomic<bool> initialized{false};
-    MmConfig config;
-    const mm_hal_t *hal = nullptr;
+  std::atomic<bool> initialized{false};
+  MmConfig config;
+  const mm_hal_t *hal = nullptr;
 
-    /* Handle registry for all allocations */
-    HandleTable handles;
+  /* Handle registry for all allocations */
+  HandleTable handles;
 
-    /* Sub-allocators (owned, created during init) */
-    ArenaAllocator *arena = nullptr;
-    KvBlockPool *kv_pool = nullptr;
+  /* Sub-allocators (owned, created during init) */
+  ArenaAllocator *arena = nullptr;
+  KvBlockPool *kv_pool = nullptr;
 
-    /* Active pools (created via mm_create_pool) */
-    std::mutex pools_mutex;
-    std::vector<StaticPoolManager *> pools;
+  /* Active pools (created via mm_create_pool) */
+  std::mutex pools_mutex;
+  std::vector<StaticPoolManager *> pools;
 
-    /* Memory budget */
-    size_t total_gpu_memory = 0;
-    size_t weight_pool_reserved = 0;
-    size_t kv_cache_reserved = 0;
-    size_t activation_reserved = 0;
+  /* Memory budget */
+  size_t total_gpu_memory = 0;
+  size_t weight_pool_reserved = 0;
+  size_t kv_cache_reserved = 0;
+  size_t activation_reserved = 0;
 };
 
 /* Access the global singleton. Never returns nullptr after mm_init(). */

--- a/lib/MemoryManager/mm_kv.cpp
+++ b/lib/MemoryManager/mm_kv.cpp
@@ -1,0 +1,347 @@
+#include "mm_kv.h"
+#include "mm_block_table.h"
+#include "mm_free_list.h"
+#include "mm_hal.h"
+#include "mm_internal.h"
+
+#include <cstdio>
+#include <cstring>
+#include <mutex>
+#include <vector>
+
+namespace mm {
+
+/*
+ * Internal representation of a KV block.
+ * Stored in a flat array indexed by block handle - 1.
+ */
+struct KvBlock {
+    void              *gpu_ptr = nullptr;  /* Physical GPU memory */
+    mm_kv_block_desc_t desc = {};          /* Format descriptor */
+    uint32_t           ref_count = 0;      /* CoW reference count (mutex-protected) */
+    bool               active = false;     /* In use (not on free list) */
+    size_t             size_bytes = 0;     /* Block size in bytes */
+};
+
+/*
+ * KV Block Pool: manages a slab of GPU memory subdivided into
+ * fixed-size blocks. Per-format free lists for O(1) alloc/free.
+ */
+class KvBlockPool {
+public:
+    KvBlockPool() = default;
+    ~KvBlockPool() { shutdown(); }
+
+    int init(const mm_hal_t *hal, int device_id,
+             size_t total_budget, uint32_t block_size_tokens,
+             mm_kv_format_t default_format);
+
+    mm_kv_block_t alloc_block(mm_kv_block_desc_t desc);
+    void free_block(mm_kv_block_t handle);
+    mm_kv_block_t fork_block(mm_kv_block_t handle);
+
+    KvBlock *lookup(mm_kv_block_t handle);
+
+    uint32_t free_count(mm_kv_format_t format) const;
+    uint32_t total_count() const;
+
+    void shutdown();
+
+private:
+    const mm_hal_t *hal_ = nullptr;
+    int device_id_ = 0;
+
+    /* Slab: single contiguous GPU allocation split into blocks */
+    void *slab_base_ = nullptr;
+    size_t slab_size_ = 0;
+
+    /* Block metadata */
+    std::vector<KvBlock> blocks_;
+    uint32_t total_blocks_ = 0;
+    size_t block_size_bytes_ = 0;
+    uint32_t block_size_tokens_ = 0;
+
+    /* Per-format free lists */
+    FreeList free_list_; /* Single format for now (Phase 2 uses FP16 only) */
+    mm_kv_format_t default_format_ = MM_KV_FMT_FP16;
+
+    /* Handle generation (1-based, offset from a base to avoid collisions
+       with pool handles) */
+    static constexpr uint64_t kKvHandleBase = 0x4B560000; /* "KV" prefix */
+
+    std::mutex mutex_; /* Protects block metadata writes */
+
+    size_t compute_block_size(const mm_kv_block_desc_t &desc) const;
+};
+
+size_t KvBlockPool::compute_block_size(const mm_kv_block_desc_t &desc) const {
+    /* Block stores K and V for block_size_tokens tokens.
+       Size = block_size_tokens * num_kv_heads * head_dim * bytes_per_element * 2 (K+V) */
+    size_t bytes_per_elem = 2; /* FP16 default */
+    switch (desc.format) {
+    case MM_KV_FMT_FP16:         bytes_per_elem = 2; break;
+    case MM_KV_FMT_FP8_E4M3:    bytes_per_elem = 1; break;
+    case MM_KV_FMT_INT4:         bytes_per_elem = 1; break; /* approximate */
+    case MM_KV_FMT_TURBOQUANT_4: bytes_per_elem = 1; break;
+    case MM_KV_FMT_TURBOQUANT_3: bytes_per_elem = 1; break;
+    case MM_KV_FMT_TURBOQUANT_2: bytes_per_elem = 1; break;
+    }
+
+    if (desc.bytes_per_token > 0) {
+        /* Use explicit bytes_per_token if provided */
+        return (size_t)desc.block_size_tokens * desc.bytes_per_token * 2; /* K+V */
+    }
+
+    return (size_t)desc.block_size_tokens * desc.num_kv_heads *
+           desc.head_dim * bytes_per_elem * 2; /* K+V */
+}
+
+int KvBlockPool::init(const mm_hal_t *hal, int device_id,
+                      size_t total_budget, uint32_t block_size_tokens,
+                      mm_kv_format_t default_format) {
+    if (!hal || total_budget == 0)
+        return MM_ERROR_INVALID_ARG;
+
+    hal_ = hal;
+    device_id_ = device_id;
+    block_size_tokens_ = block_size_tokens;
+    default_format_ = default_format;
+
+    /* Use a default block size for pool initialization.
+       Typical: 16 tokens * 4 kv_heads * 128 head_dim * 2 bytes * 2 (K+V) = 32KB */
+    block_size_bytes_ = (size_t)block_size_tokens * 4 * 128 * 2 * 2;
+    if (block_size_bytes_ < 256)
+        block_size_bytes_ = 256;
+
+    /* Align block size to 256 bytes */
+    block_size_bytes_ = (block_size_bytes_ + 255) & ~(size_t)255;
+
+    /* Calculate number of blocks that fit in budget */
+    total_blocks_ = (uint32_t)(total_budget / block_size_bytes_);
+    if (total_blocks_ == 0)
+        return MM_ERROR_INVALID_ARG;
+
+    slab_size_ = (size_t)total_blocks_ * block_size_bytes_;
+
+    /* Allocate slab */
+    slab_base_ = hal_->raw_alloc(device_id_, slab_size_, 256);
+    if (!slab_base_)
+        return MM_ERROR_OUT_OF_MEMORY;
+
+    /* Initialize block metadata */
+    blocks_.resize(total_blocks_);
+    for (uint32_t i = 0; i < total_blocks_; ++i) {
+        blocks_[i].gpu_ptr = static_cast<char *>(slab_base_) +
+                             (size_t)i * block_size_bytes_;
+        blocks_[i].desc = {};
+        blocks_[i].desc.format = default_format_;
+        blocks_[i].desc.block_size_tokens = block_size_tokens_;
+        blocks_[i].ref_count = 0;
+        blocks_[i].active = false;
+        blocks_[i].size_bytes = block_size_bytes_;
+    }
+
+    /* Initialize free list and push all blocks */
+    free_list_.init(total_blocks_);
+    for (uint32_t i = 0; i < total_blocks_; ++i) {
+        free_list_.push(i);
+    }
+
+    return MM_OK;
+}
+
+mm_kv_block_t KvBlockPool::alloc_block(mm_kv_block_desc_t desc) {
+    uint32_t idx = free_list_.pop();
+    if (idx == UINT32_MAX)
+        return MM_INVALID_BLOCK; /* Pool exhausted */
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    blocks_[idx].desc = desc;
+    blocks_[idx].desc.block_size_tokens = block_size_tokens_;
+    blocks_[idx].ref_count = 1;
+    blocks_[idx].active = true;
+    blocks_[idx].size_bytes = compute_block_size(desc);
+    if (blocks_[idx].size_bytes > block_size_bytes_)
+        blocks_[idx].size_bytes = block_size_bytes_;
+
+    return static_cast<mm_kv_block_t>(kKvHandleBase + idx + 1);
+}
+
+void KvBlockPool::free_block(mm_kv_block_t handle) {
+    if (handle == MM_INVALID_BLOCK || handle <= kKvHandleBase)
+        return;
+
+    uint32_t idx = (uint32_t)(handle - kKvHandleBase - 1);
+    if (idx >= total_blocks_)
+        return;
+
+    /* Decrement ref count; only return to free list when it hits 0 */
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (blocks_[idx].ref_count == 0)
+        return; /* Double free — safe no-op */
+    blocks_[idx].ref_count--;
+    if (blocks_[idx].ref_count == 0 && blocks_[idx].active) {
+        blocks_[idx].active = false;
+        free_list_.push(idx);
+    }
+}
+
+mm_kv_block_t KvBlockPool::fork_block(mm_kv_block_t handle) {
+    if (handle == MM_INVALID_BLOCK || handle <= kKvHandleBase)
+        return MM_INVALID_BLOCK;
+
+    uint32_t idx = (uint32_t)(handle - kKvHandleBase - 1);
+    if (idx >= total_blocks_ || !blocks_[idx].active)
+        return MM_INVALID_BLOCK;
+
+    /* CoW: increment ref count, return same handle */
+    std::lock_guard<std::mutex> lock(mutex_);
+    blocks_[idx].ref_count++;
+    return handle;
+}
+
+KvBlock *KvBlockPool::lookup(mm_kv_block_t handle) {
+    if (handle == MM_INVALID_BLOCK || handle <= kKvHandleBase)
+        return nullptr;
+
+    uint32_t idx = (uint32_t)(handle - kKvHandleBase - 1);
+    if (idx >= total_blocks_ || !blocks_[idx].active)
+        return nullptr;
+
+    return &blocks_[idx];
+}
+
+uint32_t KvBlockPool::free_count(mm_kv_format_t /*format*/) const {
+    return free_list_.count();
+}
+
+uint32_t KvBlockPool::total_count() const {
+    return total_blocks_;
+}
+
+void KvBlockPool::shutdown() {
+    if (slab_base_ && hal_) {
+        hal_->raw_free(device_id_, slab_base_);
+        slab_base_ = nullptr;
+    }
+    free_list_.shutdown();
+    blocks_.clear();
+    total_blocks_ = 0;
+    slab_size_ = 0;
+}
+
+/* Global KV pool accessor (stored in MmState, see mm_config.cpp) */
+static KvBlockPool *get_kv_pool() {
+    auto *s = mm_get_state();
+    if (!s || !s->initialized.load(std::memory_order_acquire))
+        return nullptr;
+    return s->kv_pool;
+}
+
+} // namespace mm
+
+/* ---- C API Implementation ---- */
+
+extern "C" {
+
+mm_kv_block_t mm_kv_alloc_block(mm_kv_block_desc_t desc,
+                                mm_stream_t /*stream*/) {
+    auto *pool = mm::get_kv_pool();
+    if (!pool)
+        return MM_INVALID_BLOCK;
+    return pool->alloc_block(desc);
+}
+
+void mm_kv_free_block(mm_kv_block_t block, mm_stream_t /*stream*/) {
+    auto *pool = mm::get_kv_pool();
+    if (pool)
+        pool->free_block(block);
+}
+
+void **mm_kv_get_block_table(const mm_kv_block_t *blocks, uint32_t num_blocks,
+                             mm_device_t /*device*/) {
+    auto *pool = mm::get_kv_pool();
+    if (!pool || !blocks || num_blocks == 0)
+        return nullptr;
+
+    void **table = static_cast<void **>(malloc(sizeof(void *) * num_blocks));
+    if (!table)
+        return nullptr;
+
+    for (uint32_t i = 0; i < num_blocks; ++i) {
+        auto *blk = pool->lookup(blocks[i]);
+        table[i] = blk ? blk->gpu_ptr : nullptr;
+    }
+
+    return table;
+}
+
+mm_kv_block_desc_t mm_kv_get_format(mm_kv_block_t block) {
+    mm_kv_block_desc_t desc = {};
+    auto *pool = mm::get_kv_pool();
+    if (!pool)
+        return desc;
+
+    auto *blk = pool->lookup(block);
+    if (blk)
+        desc = blk->desc;
+    return desc;
+}
+
+mm_kv_block_t mm_kv_fork_block(mm_kv_block_t source) {
+    auto *pool = mm::get_kv_pool();
+    if (!pool)
+        return MM_INVALID_BLOCK;
+    return pool->fork_block(source);
+}
+
+void *mm_kv_get_block_ptr(mm_kv_block_t block) {
+    auto *pool = mm::get_kv_pool();
+    if (!pool)
+        return nullptr;
+
+    auto *blk = pool->lookup(block);
+    return blk ? blk->gpu_ptr : nullptr;
+}
+
+uint32_t mm_kv_free_block_count(mm_kv_format_t format) {
+    auto *pool = mm::get_kv_pool();
+    return pool ? pool->free_count(format) : 0;
+}
+
+uint32_t mm_kv_total_block_count(mm_kv_format_t /*format*/) {
+    auto *pool = mm::get_kv_pool();
+    return pool ? pool->total_count() : 0;
+}
+
+int mm_kv_pool_init(size_t total_budget, uint32_t block_size_tokens,
+                    mm_kv_format_t default_format) {
+    auto *s = mm::mm_get_state();
+    if (!s || !s->hal)
+        return MM_ERROR_NOT_INIT;
+    if (total_budget == 0)
+        return MM_OK; /* No KV cache requested */
+
+    s->kv_pool = new mm::KvBlockPool();
+    int err = s->kv_pool->init(s->hal, 0, total_budget,
+                               block_size_tokens, default_format);
+    if (err != MM_OK) {
+        delete s->kv_pool;
+        s->kv_pool = nullptr;
+        return err;
+    }
+    return MM_OK;
+}
+
+void mm_kv_pool_shutdown(void) {
+    auto *s = mm::mm_get_state();
+    if (!s)
+        return;
+    if (s->kv_pool) {
+        s->kv_pool->shutdown();
+        delete s->kv_pool;
+        s->kv_pool = nullptr;
+    }
+}
+
+} /* extern "C" */

--- a/lib/MemoryManager/mm_kv.cpp
+++ b/lib/MemoryManager/mm_kv.cpp
@@ -16,11 +16,11 @@ namespace mm {
  * Stored in a flat array indexed by block handle - 1.
  */
 struct KvBlock {
-    void              *gpu_ptr = nullptr;  /* Physical GPU memory */
-    mm_kv_block_desc_t desc = {};          /* Format descriptor */
-    uint32_t           ref_count = 0;      /* CoW reference count (mutex-protected) */
-    bool               active = false;     /* In use (not on free list) */
-    size_t             size_bytes = 0;     /* Block size in bytes */
+  void *gpu_ptr = nullptr;      /* Physical GPU memory */
+  mm_kv_block_desc_t desc = {}; /* Format descriptor */
+  uint32_t ref_count = 0;       /* CoW reference count (mutex-protected) */
+  bool active = false;          /* In use (not on free list) */
+  size_t size_bytes = 0;        /* Block size in bytes */
 };
 
 /*
@@ -29,213 +29,224 @@ struct KvBlock {
  */
 class KvBlockPool {
 public:
-    KvBlockPool() = default;
-    ~KvBlockPool() { shutdown(); }
+  KvBlockPool() = default;
+  ~KvBlockPool() { shutdown(); }
 
-    int init(const mm_hal_t *hal, int device_id,
-             size_t total_budget, uint32_t block_size_tokens,
-             mm_kv_format_t default_format);
+  int init(const mm_hal_t *hal, int device_id, size_t total_budget,
+           uint32_t block_size_tokens, mm_kv_format_t default_format);
 
-    mm_kv_block_t alloc_block(mm_kv_block_desc_t desc);
-    void free_block(mm_kv_block_t handle);
-    mm_kv_block_t fork_block(mm_kv_block_t handle);
+  mm_kv_block_t alloc_block(mm_kv_block_desc_t desc);
+  void free_block(mm_kv_block_t handle);
+  mm_kv_block_t fork_block(mm_kv_block_t handle);
 
-    KvBlock *lookup(mm_kv_block_t handle);
+  KvBlock *lookup(mm_kv_block_t handle);
 
-    uint32_t free_count(mm_kv_format_t format) const;
-    uint32_t total_count() const;
+  uint32_t free_count(mm_kv_format_t format) const;
+  uint32_t total_count() const;
 
-    void shutdown();
+  void shutdown();
 
 private:
-    const mm_hal_t *hal_ = nullptr;
-    int device_id_ = 0;
+  const mm_hal_t *hal_ = nullptr;
+  int device_id_ = 0;
 
-    /* Slab: single contiguous GPU allocation split into blocks */
-    void *slab_base_ = nullptr;
-    size_t slab_size_ = 0;
+  /* Slab: single contiguous GPU allocation split into blocks */
+  void *slab_base_ = nullptr;
+  size_t slab_size_ = 0;
 
-    /* Block metadata */
-    std::vector<KvBlock> blocks_;
-    uint32_t total_blocks_ = 0;
-    size_t block_size_bytes_ = 0;
-    uint32_t block_size_tokens_ = 0;
+  /* Block metadata */
+  std::vector<KvBlock> blocks_;
+  uint32_t total_blocks_ = 0;
+  size_t block_size_bytes_ = 0;
+  uint32_t block_size_tokens_ = 0;
 
-    /* Per-format free lists */
-    FreeList free_list_; /* Single format for now (Phase 2 uses FP16 only) */
-    mm_kv_format_t default_format_ = MM_KV_FMT_FP16;
+  /* Per-format free lists */
+  FreeList free_list_; /* Single format for now (Phase 2 uses FP16 only) */
+  mm_kv_format_t default_format_ = MM_KV_FMT_FP16;
 
-    /* Handle generation (1-based, offset from a base to avoid collisions
-       with pool handles) */
-    static constexpr uint64_t kKvHandleBase = 0x4B560000; /* "KV" prefix */
+  /* Handle generation (1-based, offset from a base to avoid collisions
+     with pool handles) */
+  static constexpr uint64_t kKvHandleBase = 0x4B560000; /* "KV" prefix */
 
-    std::mutex mutex_; /* Protects block metadata writes */
+  std::mutex mutex_; /* Protects block metadata writes */
 
-    size_t compute_block_size(const mm_kv_block_desc_t &desc) const;
+  size_t compute_block_size(const mm_kv_block_desc_t &desc) const;
 };
 
 size_t KvBlockPool::compute_block_size(const mm_kv_block_desc_t &desc) const {
-    /* Block stores K and V for block_size_tokens tokens.
-       Size = block_size_tokens * num_kv_heads * head_dim * bytes_per_element * 2 (K+V) */
-    size_t bytes_per_elem = 2; /* FP16 default */
-    switch (desc.format) {
-    case MM_KV_FMT_FP16:         bytes_per_elem = 2; break;
-    case MM_KV_FMT_FP8_E4M3:    bytes_per_elem = 1; break;
-    case MM_KV_FMT_INT4:         bytes_per_elem = 1; break; /* approximate */
-    case MM_KV_FMT_TURBOQUANT_4: bytes_per_elem = 1; break;
-    case MM_KV_FMT_TURBOQUANT_3: bytes_per_elem = 1; break;
-    case MM_KV_FMT_TURBOQUANT_2: bytes_per_elem = 1; break;
-    }
+  /* Block stores K and V for block_size_tokens tokens.
+     Size = block_size_tokens * num_kv_heads * head_dim * bytes_per_element * 2
+     (K+V) */
+  size_t bytes_per_elem = 2; /* FP16 default */
+  switch (desc.format) {
+  case MM_KV_FMT_FP16:
+    bytes_per_elem = 2;
+    break;
+  case MM_KV_FMT_FP8_E4M3:
+    bytes_per_elem = 1;
+    break;
+  case MM_KV_FMT_INT4:
+    bytes_per_elem = 1;
+    break; /* approximate */
+  case MM_KV_FMT_TURBOQUANT_4:
+    bytes_per_elem = 1;
+    break;
+  case MM_KV_FMT_TURBOQUANT_3:
+    bytes_per_elem = 1;
+    break;
+  case MM_KV_FMT_TURBOQUANT_2:
+    bytes_per_elem = 1;
+    break;
+  }
 
-    if (desc.bytes_per_token > 0) {
-        /* Use explicit bytes_per_token if provided */
-        return (size_t)desc.block_size_tokens * desc.bytes_per_token * 2; /* K+V */
-    }
+  if (desc.bytes_per_token > 0) {
+    /* Use explicit bytes_per_token if provided */
+    return (size_t)desc.block_size_tokens * desc.bytes_per_token * 2; /* K+V */
+  }
 
-    return (size_t)desc.block_size_tokens * desc.num_kv_heads *
-           desc.head_dim * bytes_per_elem * 2; /* K+V */
+  return (size_t)desc.block_size_tokens * desc.num_kv_heads * desc.head_dim *
+         bytes_per_elem * 2; /* K+V */
 }
 
-int KvBlockPool::init(const mm_hal_t *hal, int device_id,
-                      size_t total_budget, uint32_t block_size_tokens,
+int KvBlockPool::init(const mm_hal_t *hal, int device_id, size_t total_budget,
+                      uint32_t block_size_tokens,
                       mm_kv_format_t default_format) {
-    if (!hal || total_budget == 0)
-        return MM_ERROR_INVALID_ARG;
+  if (!hal || total_budget == 0)
+    return MM_ERROR_INVALID_ARG;
 
-    hal_ = hal;
-    device_id_ = device_id;
-    block_size_tokens_ = block_size_tokens;
-    default_format_ = default_format;
+  hal_ = hal;
+  device_id_ = device_id;
+  block_size_tokens_ = block_size_tokens;
+  default_format_ = default_format;
 
-    /* Use a default block size for pool initialization.
-       Typical: 16 tokens * 4 kv_heads * 128 head_dim * 2 bytes * 2 (K+V) = 32KB */
-    block_size_bytes_ = (size_t)block_size_tokens * 4 * 128 * 2 * 2;
-    if (block_size_bytes_ < 256)
-        block_size_bytes_ = 256;
+  /* Use a default block size for pool initialization.
+     Typical: 16 tokens * 4 kv_heads * 128 head_dim * 2 bytes * 2 (K+V) = 32KB
+   */
+  block_size_bytes_ = (size_t)block_size_tokens * 4 * 128 * 2 * 2;
+  if (block_size_bytes_ < 256)
+    block_size_bytes_ = 256;
 
-    /* Align block size to 256 bytes */
-    block_size_bytes_ = (block_size_bytes_ + 255) & ~(size_t)255;
+  /* Align block size to 256 bytes */
+  block_size_bytes_ = (block_size_bytes_ + 255) & ~(size_t)255;
 
-    /* Calculate number of blocks that fit in budget */
-    total_blocks_ = (uint32_t)(total_budget / block_size_bytes_);
-    if (total_blocks_ == 0)
-        return MM_ERROR_INVALID_ARG;
+  /* Calculate number of blocks that fit in budget */
+  total_blocks_ = (uint32_t)(total_budget / block_size_bytes_);
+  if (total_blocks_ == 0)
+    return MM_ERROR_INVALID_ARG;
 
-    slab_size_ = (size_t)total_blocks_ * block_size_bytes_;
+  slab_size_ = (size_t)total_blocks_ * block_size_bytes_;
 
-    /* Allocate slab */
-    slab_base_ = hal_->raw_alloc(device_id_, slab_size_, 256);
-    if (!slab_base_)
-        return MM_ERROR_OUT_OF_MEMORY;
+  /* Allocate slab */
+  slab_base_ = hal_->raw_alloc(device_id_, slab_size_, 256);
+  if (!slab_base_)
+    return MM_ERROR_OUT_OF_MEMORY;
 
-    /* Initialize block metadata */
-    blocks_.resize(total_blocks_);
-    for (uint32_t i = 0; i < total_blocks_; ++i) {
-        blocks_[i].gpu_ptr = static_cast<char *>(slab_base_) +
-                             (size_t)i * block_size_bytes_;
-        blocks_[i].desc = {};
-        blocks_[i].desc.format = default_format_;
-        blocks_[i].desc.block_size_tokens = block_size_tokens_;
-        blocks_[i].ref_count = 0;
-        blocks_[i].active = false;
-        blocks_[i].size_bytes = block_size_bytes_;
-    }
+  /* Initialize block metadata */
+  blocks_.resize(total_blocks_);
+  for (uint32_t i = 0; i < total_blocks_; ++i) {
+    blocks_[i].gpu_ptr =
+        static_cast<char *>(slab_base_) + (size_t)i * block_size_bytes_;
+    blocks_[i].desc = {};
+    blocks_[i].desc.format = default_format_;
+    blocks_[i].desc.block_size_tokens = block_size_tokens_;
+    blocks_[i].ref_count = 0;
+    blocks_[i].active = false;
+    blocks_[i].size_bytes = block_size_bytes_;
+  }
 
-    /* Initialize free list and push all blocks */
-    free_list_.init(total_blocks_);
-    for (uint32_t i = 0; i < total_blocks_; ++i) {
-        free_list_.push(i);
-    }
+  /* Initialize free list and push all blocks */
+  free_list_.init(total_blocks_);
+  for (uint32_t i = 0; i < total_blocks_; ++i) {
+    free_list_.push(i);
+  }
 
-    return MM_OK;
+  return MM_OK;
 }
 
 mm_kv_block_t KvBlockPool::alloc_block(mm_kv_block_desc_t desc) {
-    uint32_t idx = free_list_.pop();
-    if (idx == UINT32_MAX)
-        return MM_INVALID_BLOCK; /* Pool exhausted */
+  uint32_t idx = free_list_.pop();
+  if (idx == UINT32_MAX)
+    return MM_INVALID_BLOCK; /* Pool exhausted */
 
-    std::lock_guard<std::mutex> lock(mutex_);
-    blocks_[idx].desc = desc;
-    blocks_[idx].desc.block_size_tokens = block_size_tokens_;
-    blocks_[idx].ref_count = 1;
-    blocks_[idx].active = true;
-    blocks_[idx].size_bytes = compute_block_size(desc);
-    if (blocks_[idx].size_bytes > block_size_bytes_)
-        blocks_[idx].size_bytes = block_size_bytes_;
+  std::lock_guard<std::mutex> lock(mutex_);
+  blocks_[idx].desc = desc;
+  blocks_[idx].desc.block_size_tokens = block_size_tokens_;
+  blocks_[idx].ref_count = 1;
+  blocks_[idx].active = true;
+  blocks_[idx].size_bytes = compute_block_size(desc);
+  if (blocks_[idx].size_bytes > block_size_bytes_)
+    blocks_[idx].size_bytes = block_size_bytes_;
 
-    return static_cast<mm_kv_block_t>(kKvHandleBase + idx + 1);
+  return static_cast<mm_kv_block_t>(kKvHandleBase + idx + 1);
 }
 
 void KvBlockPool::free_block(mm_kv_block_t handle) {
-    if (handle == MM_INVALID_BLOCK || handle <= kKvHandleBase)
-        return;
+  if (handle == MM_INVALID_BLOCK || handle <= kKvHandleBase)
+    return;
 
-    uint32_t idx = (uint32_t)(handle - kKvHandleBase - 1);
-    if (idx >= total_blocks_)
-        return;
+  uint32_t idx = (uint32_t)(handle - kKvHandleBase - 1);
+  if (idx >= total_blocks_)
+    return;
 
-    /* Decrement ref count; only return to free list when it hits 0 */
-    std::lock_guard<std::mutex> lock(mutex_);
-    if (blocks_[idx].ref_count == 0)
-        return; /* Double free — safe no-op */
-    blocks_[idx].ref_count--;
-    if (blocks_[idx].ref_count == 0 && blocks_[idx].active) {
-        blocks_[idx].active = false;
-        free_list_.push(idx);
-    }
+  /* Decrement ref count; only return to free list when it hits 0 */
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (blocks_[idx].ref_count == 0)
+    return; /* Double free — safe no-op */
+  blocks_[idx].ref_count--;
+  if (blocks_[idx].ref_count == 0 && blocks_[idx].active) {
+    blocks_[idx].active = false;
+    free_list_.push(idx);
+  }
 }
 
 mm_kv_block_t KvBlockPool::fork_block(mm_kv_block_t handle) {
-    if (handle == MM_INVALID_BLOCK || handle <= kKvHandleBase)
-        return MM_INVALID_BLOCK;
+  if (handle == MM_INVALID_BLOCK || handle <= kKvHandleBase)
+    return MM_INVALID_BLOCK;
 
-    uint32_t idx = (uint32_t)(handle - kKvHandleBase - 1);
-    if (idx >= total_blocks_ || !blocks_[idx].active)
-        return MM_INVALID_BLOCK;
+  uint32_t idx = (uint32_t)(handle - kKvHandleBase - 1);
+  if (idx >= total_blocks_ || !blocks_[idx].active)
+    return MM_INVALID_BLOCK;
 
-    /* CoW: increment ref count, return same handle */
-    std::lock_guard<std::mutex> lock(mutex_);
-    blocks_[idx].ref_count++;
-    return handle;
+  /* CoW: increment ref count, return same handle */
+  std::lock_guard<std::mutex> lock(mutex_);
+  blocks_[idx].ref_count++;
+  return handle;
 }
 
 KvBlock *KvBlockPool::lookup(mm_kv_block_t handle) {
-    if (handle == MM_INVALID_BLOCK || handle <= kKvHandleBase)
-        return nullptr;
+  if (handle == MM_INVALID_BLOCK || handle <= kKvHandleBase)
+    return nullptr;
 
-    uint32_t idx = (uint32_t)(handle - kKvHandleBase - 1);
-    if (idx >= total_blocks_ || !blocks_[idx].active)
-        return nullptr;
+  uint32_t idx = (uint32_t)(handle - kKvHandleBase - 1);
+  if (idx >= total_blocks_ || !blocks_[idx].active)
+    return nullptr;
 
-    return &blocks_[idx];
+  return &blocks_[idx];
 }
 
 uint32_t KvBlockPool::free_count(mm_kv_format_t /*format*/) const {
-    return free_list_.count();
+  return free_list_.count();
 }
 
-uint32_t KvBlockPool::total_count() const {
-    return total_blocks_;
-}
+uint32_t KvBlockPool::total_count() const { return total_blocks_; }
 
 void KvBlockPool::shutdown() {
-    if (slab_base_ && hal_) {
-        hal_->raw_free(device_id_, slab_base_);
-        slab_base_ = nullptr;
-    }
-    free_list_.shutdown();
-    blocks_.clear();
-    total_blocks_ = 0;
-    slab_size_ = 0;
+  if (slab_base_ && hal_) {
+    hal_->raw_free(device_id_, slab_base_);
+    slab_base_ = nullptr;
+  }
+  free_list_.shutdown();
+  blocks_.clear();
+  total_blocks_ = 0;
+  slab_size_ = 0;
 }
 
 /* Global KV pool accessor (stored in MmState, see mm_config.cpp) */
 static KvBlockPool *get_kv_pool() {
-    auto *s = mm_get_state();
-    if (!s || !s->initialized.load(std::memory_order_acquire))
-        return nullptr;
-    return s->kv_pool;
+  auto *s = mm_get_state();
+  if (!s || !s->initialized.load(std::memory_order_acquire))
+    return nullptr;
+  return s->kv_pool;
 }
 
 } // namespace mm
@@ -246,102 +257,102 @@ extern "C" {
 
 mm_kv_block_t mm_kv_alloc_block(mm_kv_block_desc_t desc,
                                 mm_stream_t /*stream*/) {
-    auto *pool = mm::get_kv_pool();
-    if (!pool)
-        return MM_INVALID_BLOCK;
-    return pool->alloc_block(desc);
+  auto *pool = mm::get_kv_pool();
+  if (!pool)
+    return MM_INVALID_BLOCK;
+  return pool->alloc_block(desc);
 }
 
 void mm_kv_free_block(mm_kv_block_t block, mm_stream_t /*stream*/) {
-    auto *pool = mm::get_kv_pool();
-    if (pool)
-        pool->free_block(block);
+  auto *pool = mm::get_kv_pool();
+  if (pool)
+    pool->free_block(block);
 }
 
 void **mm_kv_get_block_table(const mm_kv_block_t *blocks, uint32_t num_blocks,
                              mm_device_t /*device*/) {
-    auto *pool = mm::get_kv_pool();
-    if (!pool || !blocks || num_blocks == 0)
-        return nullptr;
+  auto *pool = mm::get_kv_pool();
+  if (!pool || !blocks || num_blocks == 0)
+    return nullptr;
 
-    void **table = static_cast<void **>(malloc(sizeof(void *) * num_blocks));
-    if (!table)
-        return nullptr;
+  void **table = static_cast<void **>(malloc(sizeof(void *) * num_blocks));
+  if (!table)
+    return nullptr;
 
-    for (uint32_t i = 0; i < num_blocks; ++i) {
-        auto *blk = pool->lookup(blocks[i]);
-        table[i] = blk ? blk->gpu_ptr : nullptr;
-    }
+  for (uint32_t i = 0; i < num_blocks; ++i) {
+    auto *blk = pool->lookup(blocks[i]);
+    table[i] = blk ? blk->gpu_ptr : nullptr;
+  }
 
-    return table;
+  return table;
 }
 
 mm_kv_block_desc_t mm_kv_get_format(mm_kv_block_t block) {
-    mm_kv_block_desc_t desc = {};
-    auto *pool = mm::get_kv_pool();
-    if (!pool)
-        return desc;
-
-    auto *blk = pool->lookup(block);
-    if (blk)
-        desc = blk->desc;
+  mm_kv_block_desc_t desc = {};
+  auto *pool = mm::get_kv_pool();
+  if (!pool)
     return desc;
+
+  auto *blk = pool->lookup(block);
+  if (blk)
+    desc = blk->desc;
+  return desc;
 }
 
 mm_kv_block_t mm_kv_fork_block(mm_kv_block_t source) {
-    auto *pool = mm::get_kv_pool();
-    if (!pool)
-        return MM_INVALID_BLOCK;
-    return pool->fork_block(source);
+  auto *pool = mm::get_kv_pool();
+  if (!pool)
+    return MM_INVALID_BLOCK;
+  return pool->fork_block(source);
 }
 
 void *mm_kv_get_block_ptr(mm_kv_block_t block) {
-    auto *pool = mm::get_kv_pool();
-    if (!pool)
-        return nullptr;
+  auto *pool = mm::get_kv_pool();
+  if (!pool)
+    return nullptr;
 
-    auto *blk = pool->lookup(block);
-    return blk ? blk->gpu_ptr : nullptr;
+  auto *blk = pool->lookup(block);
+  return blk ? blk->gpu_ptr : nullptr;
 }
 
 uint32_t mm_kv_free_block_count(mm_kv_format_t format) {
-    auto *pool = mm::get_kv_pool();
-    return pool ? pool->free_count(format) : 0;
+  auto *pool = mm::get_kv_pool();
+  return pool ? pool->free_count(format) : 0;
 }
 
 uint32_t mm_kv_total_block_count(mm_kv_format_t /*format*/) {
-    auto *pool = mm::get_kv_pool();
-    return pool ? pool->total_count() : 0;
+  auto *pool = mm::get_kv_pool();
+  return pool ? pool->total_count() : 0;
 }
 
 int mm_kv_pool_init(size_t total_budget, uint32_t block_size_tokens,
                     mm_kv_format_t default_format) {
-    auto *s = mm::mm_get_state();
-    if (!s || !s->hal)
-        return MM_ERROR_NOT_INIT;
-    if (total_budget == 0)
-        return MM_OK; /* No KV cache requested */
+  auto *s = mm::mm_get_state();
+  if (!s || !s->hal)
+    return MM_ERROR_NOT_INIT;
+  if (total_budget == 0)
+    return MM_OK; /* No KV cache requested */
 
-    s->kv_pool = new mm::KvBlockPool();
-    int err = s->kv_pool->init(s->hal, 0, total_budget,
-                               block_size_tokens, default_format);
-    if (err != MM_OK) {
-        delete s->kv_pool;
-        s->kv_pool = nullptr;
-        return err;
-    }
-    return MM_OK;
+  s->kv_pool = new mm::KvBlockPool();
+  int err = s->kv_pool->init(s->hal, 0, total_budget, block_size_tokens,
+                             default_format);
+  if (err != MM_OK) {
+    delete s->kv_pool;
+    s->kv_pool = nullptr;
+    return err;
+  }
+  return MM_OK;
 }
 
 void mm_kv_pool_shutdown(void) {
-    auto *s = mm::mm_get_state();
-    if (!s)
-        return;
-    if (s->kv_pool) {
-        s->kv_pool->shutdown();
-        delete s->kv_pool;
-        s->kv_pool = nullptr;
-    }
+  auto *s = mm::mm_get_state();
+  if (!s)
+    return;
+  if (s->kv_pool) {
+    s->kv_pool->shutdown();
+    delete s->kv_pool;
+    s->kv_pool = nullptr;
+  }
 }
 
 } /* extern "C" */

--- a/lib/MemoryManager/mm_kv.cpp
+++ b/lib/MemoryManager/mm_kv.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
 #include "mm_kv.h"
 #include "mm_block_table.h"
 #include "mm_free_list.h"

--- a/lib/MemoryManager/mm_kv.h
+++ b/lib/MemoryManager/mm_kv.h
@@ -1,0 +1,86 @@
+#ifndef MM_KV_H
+#define MM_KV_H
+
+#include "mm_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Allocate a paged KV cache block.
+ *
+ * Blocks are fixed-size (block_size_tokens * bytes_per_token * num_kv_heads * head_dim * 2).
+ * Allocated from a per-format lock-free free list. O(1) via atomic CAS.
+ *
+ * Returns MM_INVALID_BLOCK on failure (pool exhausted).
+ */
+mm_kv_block_t mm_kv_alloc_block(mm_kv_block_desc_t desc, mm_stream_t stream);
+
+/*
+ * Free a KV cache block. Decrements ref_count; returns to free list when
+ * ref_count reaches 0. Double-free is a safe no-op.
+ */
+void mm_kv_free_block(mm_kv_block_t block, mm_stream_t stream);
+
+/*
+ * Build a block table: array of device pointers for paged attention.
+ * Caller provides an array of block handles; returns a host-allocated
+ * array of void* pointing to each block's GPU memory.
+ *
+ * The returned pointer must be freed by the caller via free().
+ * Returns NULL on failure.
+ */
+void **mm_kv_get_block_table(const mm_kv_block_t *blocks, uint32_t num_blocks,
+                             mm_device_t device);
+
+/*
+ * Query the format descriptor of a block.
+ * Returns a zero-initialized desc if block is invalid.
+ */
+mm_kv_block_desc_t mm_kv_get_format(mm_kv_block_t block);
+
+/*
+ * Copy-on-write fork: increments ref_count on the source block and
+ * returns a new handle pointing to the same physical memory.
+ *
+ * Used for beam search and speculative decoding where multiple
+ * hypotheses share a prefix.
+ *
+ * Returns MM_INVALID_BLOCK on failure.
+ */
+mm_kv_block_t mm_kv_fork_block(mm_kv_block_t source);
+
+/*
+ * Get the GPU pointer for a KV block (for direct kernel access).
+ * Returns NULL if block is invalid.
+ */
+void *mm_kv_get_block_ptr(mm_kv_block_t block);
+
+/*
+ * Get the number of free blocks available for a given format.
+ */
+uint32_t mm_kv_free_block_count(mm_kv_format_t format);
+
+/*
+ * Get the total number of blocks allocated for a given format.
+ */
+uint32_t mm_kv_total_block_count(mm_kv_format_t format);
+
+/*
+ * Initialize the KV block pool. Called by mm_init().
+ * Allocates a slab of total_budget bytes and subdivides into blocks.
+ */
+int mm_kv_pool_init(size_t total_budget, uint32_t block_size_tokens,
+                    mm_kv_format_t default_format);
+
+/*
+ * Shutdown the KV block pool. Called by mm_shutdown().
+ */
+void mm_kv_pool_shutdown(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MM_KV_H */

--- a/lib/MemoryManager/mm_kv.h
+++ b/lib/MemoryManager/mm_kv.h
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
 #ifndef MM_KV_H
 #define MM_KV_H
 

--- a/lib/MemoryManager/mm_kv.h
+++ b/lib/MemoryManager/mm_kv.h
@@ -10,8 +10,9 @@ extern "C" {
 /*
  * Allocate a paged KV cache block.
  *
- * Blocks are fixed-size (block_size_tokens * bytes_per_token * num_kv_heads * head_dim * 2).
- * Allocated from a per-format lock-free free list. O(1) via atomic CAS.
+ * Blocks are fixed-size (block_size_tokens * bytes_per_token * num_kv_heads *
+ * head_dim * 2). Allocated from a per-format lock-free free list. O(1) via
+ * atomic CAS.
  *
  * Returns MM_INVALID_BLOCK on failure (pool exhausted).
  */

--- a/lib/MemoryManager/mm_pool.cpp
+++ b/lib/MemoryManager/mm_pool.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
 #include "mm_pool.h"
 #include "mm_internal.h"
 

--- a/lib/MemoryManager/mm_pool.cpp
+++ b/lib/MemoryManager/mm_pool.cpp
@@ -1,0 +1,122 @@
+#include "mm_pool.h"
+#include "mm_internal.h"
+
+#include <cstring>
+#include <vector>
+
+namespace mm {
+
+class StaticPoolManager {
+public:
+    StaticPoolManager() = default;
+    ~StaticPoolManager() { destroy(); }
+
+    int create(const mm_hal_t *hal, const mm_static_plan_t *plan) {
+        if (!hal || !plan || plan->num_entries == 0)
+            return MM_ERROR_INVALID_ARG;
+
+        hal_ = hal;
+        device_id_ = (plan->device == MM_DEVICE_CPU) ? 0 : (int)plan->device;
+        total_size_ = plan->total_size;
+
+        /* Single HAL allocation */
+        base_ptr_ = hal_->raw_alloc(device_id_, total_size_,
+                                    256 /* default alignment */);
+        if (!base_ptr_)
+            return MM_ERROR_OUT_OF_MEMORY;
+
+        /* Build O(1) offset lookup table */
+        entries_.resize(plan->num_entries);
+        for (uint32_t i = 0; i < plan->num_entries; ++i) {
+            entries_[plan->entries[i].tensor_id] = {
+                plan->entries[i].offset,
+                plan->entries[i].size,
+                plan->entries[i].alignment,
+            };
+        }
+
+        return MM_OK;
+    }
+
+    void *get_ptr(uint32_t tensor_id) {
+        if (tensor_id >= entries_.size() || !base_ptr_)
+            return nullptr;
+        return static_cast<char *>(base_ptr_) + entries_[tensor_id].offset;
+    }
+
+    void destroy() {
+        if (base_ptr_ && hal_) {
+            hal_->raw_free(device_id_, base_ptr_);
+            base_ptr_ = nullptr;
+        }
+        entries_.clear();
+    }
+
+    size_t total_size() const { return total_size_; }
+
+private:
+    struct Entry {
+        size_t offset;
+        size_t size;
+        size_t alignment;
+    };
+
+    const mm_hal_t *hal_ = nullptr;
+    int device_id_ = 0;
+    void *base_ptr_ = nullptr;
+    size_t total_size_ = 0;
+    std::vector<Entry> entries_;
+};
+
+} // namespace mm
+
+extern "C" {
+
+mm_pool_t mm_create_pool(const mm_static_plan_t *plan) {
+    auto *s = mm::mm_get_state();
+    if (!s->initialized.load(std::memory_order_acquire))
+        return MM_INVALID_POOL;
+    if (!plan)
+        return MM_INVALID_POOL;
+
+    auto *pool = new mm::StaticPoolManager();
+    int err = pool->create(s->hal, plan);
+    if (err != MM_OK) {
+        delete pool;
+        return MM_INVALID_POOL;
+    }
+
+    /* Register the pool and return its index + 1 as handle */
+    std::lock_guard<std::mutex> lock(s->pools_mutex);
+    s->pools.push_back(pool);
+    return static_cast<mm_pool_t>(s->pools.size());
+}
+
+void *mm_pool_get_ptr(mm_pool_t pool, uint32_t tensor_id) {
+    auto *s = mm::mm_get_state();
+    if (pool == MM_INVALID_POOL || pool == 0)
+        return nullptr;
+
+    std::lock_guard<std::mutex> lock(s->pools_mutex);
+    size_t idx = pool - 1;
+    if (idx >= s->pools.size() || !s->pools[idx])
+        return nullptr;
+
+    return s->pools[idx]->get_ptr(tensor_id);
+}
+
+void mm_destroy_pool(mm_pool_t pool) {
+    auto *s = mm::mm_get_state();
+    if (pool == MM_INVALID_POOL || pool == 0)
+        return;
+
+    std::lock_guard<std::mutex> lock(s->pools_mutex);
+    size_t idx = pool - 1;
+    if (idx >= s->pools.size() || !s->pools[idx])
+        return;
+
+    delete s->pools[idx];
+    s->pools[idx] = nullptr;
+}
+
+} /* extern "C" */

--- a/lib/MemoryManager/mm_pool.cpp
+++ b/lib/MemoryManager/mm_pool.cpp
@@ -8,64 +8,64 @@ namespace mm {
 
 class StaticPoolManager {
 public:
-    StaticPoolManager() = default;
-    ~StaticPoolManager() { destroy(); }
+  StaticPoolManager() = default;
+  ~StaticPoolManager() { destroy(); }
 
-    int create(const mm_hal_t *hal, const mm_static_plan_t *plan) {
-        if (!hal || !plan || plan->num_entries == 0)
-            return MM_ERROR_INVALID_ARG;
+  int create(const mm_hal_t *hal, const mm_static_plan_t *plan) {
+    if (!hal || !plan || plan->num_entries == 0)
+      return MM_ERROR_INVALID_ARG;
 
-        hal_ = hal;
-        device_id_ = (plan->device == MM_DEVICE_CPU) ? 0 : (int)plan->device;
-        total_size_ = plan->total_size;
+    hal_ = hal;
+    device_id_ = (plan->device == MM_DEVICE_CPU) ? 0 : (int)plan->device;
+    total_size_ = plan->total_size;
 
-        /* Single HAL allocation */
-        base_ptr_ = hal_->raw_alloc(device_id_, total_size_,
-                                    256 /* default alignment */);
-        if (!base_ptr_)
-            return MM_ERROR_OUT_OF_MEMORY;
+    /* Single HAL allocation */
+    base_ptr_ =
+        hal_->raw_alloc(device_id_, total_size_, 256 /* default alignment */);
+    if (!base_ptr_)
+      return MM_ERROR_OUT_OF_MEMORY;
 
-        /* Build O(1) offset lookup table */
-        entries_.resize(plan->num_entries);
-        for (uint32_t i = 0; i < plan->num_entries; ++i) {
-            entries_[plan->entries[i].tensor_id] = {
-                plan->entries[i].offset,
-                plan->entries[i].size,
-                plan->entries[i].alignment,
-            };
-        }
-
-        return MM_OK;
+    /* Build O(1) offset lookup table */
+    entries_.resize(plan->num_entries);
+    for (uint32_t i = 0; i < plan->num_entries; ++i) {
+      entries_[plan->entries[i].tensor_id] = {
+          plan->entries[i].offset,
+          plan->entries[i].size,
+          plan->entries[i].alignment,
+      };
     }
 
-    void *get_ptr(uint32_t tensor_id) {
-        if (tensor_id >= entries_.size() || !base_ptr_)
-            return nullptr;
-        return static_cast<char *>(base_ptr_) + entries_[tensor_id].offset;
-    }
+    return MM_OK;
+  }
 
-    void destroy() {
-        if (base_ptr_ && hal_) {
-            hal_->raw_free(device_id_, base_ptr_);
-            base_ptr_ = nullptr;
-        }
-        entries_.clear();
-    }
+  void *get_ptr(uint32_t tensor_id) {
+    if (tensor_id >= entries_.size() || !base_ptr_)
+      return nullptr;
+    return static_cast<char *>(base_ptr_) + entries_[tensor_id].offset;
+  }
 
-    size_t total_size() const { return total_size_; }
+  void destroy() {
+    if (base_ptr_ && hal_) {
+      hal_->raw_free(device_id_, base_ptr_);
+      base_ptr_ = nullptr;
+    }
+    entries_.clear();
+  }
+
+  size_t total_size() const { return total_size_; }
 
 private:
-    struct Entry {
-        size_t offset;
-        size_t size;
-        size_t alignment;
-    };
+  struct Entry {
+    size_t offset;
+    size_t size;
+    size_t alignment;
+  };
 
-    const mm_hal_t *hal_ = nullptr;
-    int device_id_ = 0;
-    void *base_ptr_ = nullptr;
-    size_t total_size_ = 0;
-    std::vector<Entry> entries_;
+  const mm_hal_t *hal_ = nullptr;
+  int device_id_ = 0;
+  void *base_ptr_ = nullptr;
+  size_t total_size_ = 0;
+  std::vector<Entry> entries_;
 };
 
 } // namespace mm
@@ -73,50 +73,50 @@ private:
 extern "C" {
 
 mm_pool_t mm_create_pool(const mm_static_plan_t *plan) {
-    auto *s = mm::mm_get_state();
-    if (!s->initialized.load(std::memory_order_acquire))
-        return MM_INVALID_POOL;
-    if (!plan)
-        return MM_INVALID_POOL;
+  auto *s = mm::mm_get_state();
+  if (!s->initialized.load(std::memory_order_acquire))
+    return MM_INVALID_POOL;
+  if (!plan)
+    return MM_INVALID_POOL;
 
-    auto *pool = new mm::StaticPoolManager();
-    int err = pool->create(s->hal, plan);
-    if (err != MM_OK) {
-        delete pool;
-        return MM_INVALID_POOL;
-    }
+  auto *pool = new mm::StaticPoolManager();
+  int err = pool->create(s->hal, plan);
+  if (err != MM_OK) {
+    delete pool;
+    return MM_INVALID_POOL;
+  }
 
-    /* Register the pool and return its index + 1 as handle */
-    std::lock_guard<std::mutex> lock(s->pools_mutex);
-    s->pools.push_back(pool);
-    return static_cast<mm_pool_t>(s->pools.size());
+  /* Register the pool and return its index + 1 as handle */
+  std::lock_guard<std::mutex> lock(s->pools_mutex);
+  s->pools.push_back(pool);
+  return static_cast<mm_pool_t>(s->pools.size());
 }
 
 void *mm_pool_get_ptr(mm_pool_t pool, uint32_t tensor_id) {
-    auto *s = mm::mm_get_state();
-    if (pool == MM_INVALID_POOL || pool == 0)
-        return nullptr;
+  auto *s = mm::mm_get_state();
+  if (pool == MM_INVALID_POOL || pool == 0)
+    return nullptr;
 
-    std::lock_guard<std::mutex> lock(s->pools_mutex);
-    size_t idx = pool - 1;
-    if (idx >= s->pools.size() || !s->pools[idx])
-        return nullptr;
+  std::lock_guard<std::mutex> lock(s->pools_mutex);
+  size_t idx = pool - 1;
+  if (idx >= s->pools.size() || !s->pools[idx])
+    return nullptr;
 
-    return s->pools[idx]->get_ptr(tensor_id);
+  return s->pools[idx]->get_ptr(tensor_id);
 }
 
 void mm_destroy_pool(mm_pool_t pool) {
-    auto *s = mm::mm_get_state();
-    if (pool == MM_INVALID_POOL || pool == 0)
-        return;
+  auto *s = mm::mm_get_state();
+  if (pool == MM_INVALID_POOL || pool == 0)
+    return;
 
-    std::lock_guard<std::mutex> lock(s->pools_mutex);
-    size_t idx = pool - 1;
-    if (idx >= s->pools.size() || !s->pools[idx])
-        return;
+  std::lock_guard<std::mutex> lock(s->pools_mutex);
+  size_t idx = pool - 1;
+  if (idx >= s->pools.size() || !s->pools[idx])
+    return;
 
-    delete s->pools[idx];
-    s->pools[idx] = nullptr;
+  delete s->pools[idx];
+  s->pools[idx] = nullptr;
 }
 
 } /* extern "C" */

--- a/lib/MemoryManager/mm_pool.h
+++ b/lib/MemoryManager/mm_pool.h
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
 #ifndef MM_POOL_H
 #define MM_POOL_H
 

--- a/lib/MemoryManager/mm_pool.h
+++ b/lib/MemoryManager/mm_pool.h
@@ -1,0 +1,34 @@
+#ifndef MM_POOL_H
+#define MM_POOL_H
+
+#include "mm_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Create a static memory pool from a compiler-generated plan.
+ * Performs a single HAL allocation of plan->total_size bytes and builds
+ * an O(1) offset lookup table.
+ * Returns MM_INVALID_POOL on failure.
+ */
+mm_pool_t mm_create_pool(const mm_static_plan_t *plan);
+
+/*
+ * Get the device pointer for a tensor within the pool.
+ * O(1) array index lookup — no allocator call.
+ * Returns NULL if pool or tensor_id is invalid.
+ */
+void *mm_pool_get_ptr(mm_pool_t pool, uint32_t tensor_id);
+
+/*
+ * Destroy a pool and release its underlying memory.
+ */
+void mm_destroy_pool(mm_pool_t pool);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MM_POOL_H */

--- a/lib/MemoryManager/mm_runtime_bridge.cpp
+++ b/lib/MemoryManager/mm_runtime_bridge.cpp
@@ -1,0 +1,184 @@
+#include "mm_runtime_bridge.h"
+#include "mm_internal.h"
+
+#include <cstdio>
+
+/* Bridge state (workspace handle tracking) */
+static mm_handle_t g_workspace_handle = MM_INVALID_HANDLE;
+static void *g_workspace_ptr = nullptr;
+static size_t g_workspace_size = 0;
+static mm_stream_t g_stream = 0;
+
+extern "C" {
+
+int mm_bridge_init(size_t gpu_memory_limit, mm_stream_t hip_stream) {
+    g_stream = hip_stream;
+
+    /* Register the appropriate HAL backend */
+#ifdef MM_HAS_HIP
+    int err = mm_hal_register(mm_hal_hip_get());
+#else
+    int err = mm_hal_register(mm_hal_host_get());
+#endif
+    if (err != MM_OK) {
+        std::fprintf(stderr, "[MM Bridge] HAL registration failed: %d\n", err);
+        return err;
+    }
+
+    /* Initialize MM with configuration */
+    mm_config_t config = {};
+    config.gpu_memory_limit = gpu_memory_limit;
+    config.kv_cache_fraction = 0.0f; /* Phase 1: no KV cache reservation yet */
+    config.kv_block_size_tokens = 16;
+    config.max_tier = MM_TIER_DRAM;
+    config.enable_prefix_caching = false; /* Phase 3 */
+    config.enable_defrag = false;
+    config.num_size_classes = 8;
+    config.high_watermark = 0.90f;
+    config.critical_watermark = 0.95f;
+    config.default_kv_format = MM_KV_FMT_FP16;
+    config.pressure_kv_format = MM_KV_FMT_TURBOQUANT_4;
+    config.critical_kv_format = MM_KV_FMT_TURBOQUANT_3;
+    config.enable_inline_quant = false;
+    config.enable_adaptive_transcode = false;
+
+    err = mm_init(&config);
+    if (err != MM_OK) {
+        std::fprintf(stderr, "[MM Bridge] mm_init failed: %d\n", err);
+        return err;
+    }
+
+    return MM_OK;
+}
+
+void mm_bridge_shutdown(void) {
+    /* Free workspace if allocated */
+    if (g_workspace_handle != MM_INVALID_HANDLE) {
+        mm_free(g_workspace_handle, g_stream);
+        g_workspace_handle = MM_INVALID_HANDLE;
+        g_workspace_ptr = nullptr;
+        g_workspace_size = 0;
+    }
+
+    mm_shutdown();
+}
+
+mm_pool_t mm_bridge_pool_init(size_t pool_size,
+                              const size_t *buffer_offsets,
+                              size_t num_buffers) {
+    if (pool_size == 0)
+        return MM_INVALID_POOL;
+
+    /* Build the static plan from the compiler-generated offsets */
+    auto *entries = new mm_buffer_entry_t[num_buffers];
+    for (size_t i = 0; i < num_buffers; ++i) {
+        entries[i].tensor_id = (uint32_t)i;
+        entries[i].offset = buffer_offsets[i];
+        entries[i].size = 0; /* Size not tracked per-entry in current compiler */
+        entries[i].alignment = 256;
+    }
+
+    mm_static_plan_t plan = {};
+    plan.total_size = pool_size;
+    plan.mem_class = MM_CLASS_WEIGHT;
+    plan.device = MM_DEVICE_GPU_0;
+    plan.num_entries = (uint32_t)num_buffers;
+    plan.entries = entries;
+
+    mm_pool_t pool = mm_create_pool(&plan);
+
+    delete[] entries;
+
+    if (pool == MM_INVALID_POOL) {
+        std::fprintf(stderr,
+                     "[MM Bridge] mm_create_pool failed for %zu bytes\n",
+                     pool_size);
+    }
+
+    return pool;
+}
+
+void *mm_bridge_pool_get_buffer(mm_pool_t pool, size_t index) {
+    return mm_pool_get_ptr(pool, (uint32_t)index);
+}
+
+void *mm_bridge_pool_get_base(mm_pool_t pool) {
+    /* Return the pointer for tensor_id 0 (the base of the pool) */
+    return mm_pool_get_ptr(pool, 0);
+}
+
+void mm_bridge_pool_destroy(mm_pool_t pool) {
+    mm_destroy_pool(pool);
+}
+
+void *mm_bridge_tensor_alloc(size_t size_bytes) {
+    if (size_bytes == 0)
+        return nullptr;
+
+    mm_alloc_hints_t hints = {};
+    hints.mem_class = MM_CLASS_ACTIVATION;
+    hints.lifetime = MM_LIFETIME_STEP;
+    hints.alignment = 256;
+
+    mm_handle_t handle = mm_alloc(size_bytes, hints, g_stream);
+    if (handle == MM_INVALID_HANDLE)
+        return nullptr;
+
+    return mm_get_ptr(handle, MM_DEVICE_GPU_0);
+}
+
+void mm_bridge_tensor_release(void *ptr, size_t size_bytes) {
+    (void)ptr;
+    (void)size_bytes;
+    /* Arena allocations are freed in bulk via reset.
+       For Phase 1, individual frees are no-ops within the arena. */
+}
+
+void *mm_bridge_workspace_ensure(size_t needed_size) {
+    if (needed_size == 0)
+        return g_workspace_ptr;
+
+    if (g_workspace_size >= needed_size)
+        return g_workspace_ptr;
+
+    /* Free old workspace */
+    if (g_workspace_handle != MM_INVALID_HANDLE) {
+        mm_free(g_workspace_handle, g_stream);
+        g_workspace_handle = MM_INVALID_HANDLE;
+        g_workspace_ptr = nullptr;
+        g_workspace_size = 0;
+    }
+
+    /* Allocate new, larger workspace */
+    mm_alloc_hints_t hints = {};
+    hints.mem_class = MM_CLASS_SCRATCH;
+    hints.lifetime = MM_LIFETIME_REQUEST;
+    hints.alignment = 256;
+
+    g_workspace_handle = mm_alloc(needed_size, hints, g_stream);
+    if (g_workspace_handle == MM_INVALID_HANDLE) {
+        std::fprintf(stderr,
+                     "[MM Bridge] workspace alloc failed for %zu bytes\n",
+                     needed_size);
+        return nullptr;
+    }
+
+    g_workspace_ptr = mm_get_ptr(g_workspace_handle, MM_DEVICE_GPU_0);
+    g_workspace_size = needed_size;
+    return g_workspace_ptr;
+}
+
+void *mm_bridge_workspace_get(void) {
+    return g_workspace_ptr;
+}
+
+size_t mm_bridge_workspace_size(void) {
+    return g_workspace_size;
+}
+
+int mm_bridge_is_initialized(void) {
+    auto *s = mm::mm_get_state();
+    return s->initialized.load(std::memory_order_acquire) ? 1 : 0;
+}
+
+} /* extern "C" */

--- a/lib/MemoryManager/mm_runtime_bridge.cpp
+++ b/lib/MemoryManager/mm_runtime_bridge.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
 #include "mm_runtime_bridge.h"
 #include "mm_internal.h"
 

--- a/lib/MemoryManager/mm_runtime_bridge.cpp
+++ b/lib/MemoryManager/mm_runtime_bridge.cpp
@@ -12,173 +12,164 @@ static mm_stream_t g_stream = 0;
 extern "C" {
 
 int mm_bridge_init(size_t gpu_memory_limit, mm_stream_t hip_stream) {
-    g_stream = hip_stream;
+  g_stream = hip_stream;
 
-    /* Register the appropriate HAL backend */
+  /* Register the appropriate HAL backend */
 #ifdef MM_HAS_HIP
-    int err = mm_hal_register(mm_hal_hip_get());
+  int err = mm_hal_register(mm_hal_hip_get());
 #else
-    int err = mm_hal_register(mm_hal_host_get());
+  int err = mm_hal_register(mm_hal_host_get());
 #endif
-    if (err != MM_OK) {
-        std::fprintf(stderr, "[MM Bridge] HAL registration failed: %d\n", err);
-        return err;
-    }
+  if (err != MM_OK) {
+    std::fprintf(stderr, "[MM Bridge] HAL registration failed: %d\n", err);
+    return err;
+  }
 
-    /* Initialize MM with configuration */
-    mm_config_t config = {};
-    config.gpu_memory_limit = gpu_memory_limit;
-    config.kv_cache_fraction = 0.0f; /* Phase 1: no KV cache reservation yet */
-    config.kv_block_size_tokens = 16;
-    config.max_tier = MM_TIER_DRAM;
-    config.enable_prefix_caching = false; /* Phase 3 */
-    config.enable_defrag = false;
-    config.num_size_classes = 8;
-    config.high_watermark = 0.90f;
-    config.critical_watermark = 0.95f;
-    config.default_kv_format = MM_KV_FMT_FP16;
-    config.pressure_kv_format = MM_KV_FMT_TURBOQUANT_4;
-    config.critical_kv_format = MM_KV_FMT_TURBOQUANT_3;
-    config.enable_inline_quant = false;
-    config.enable_adaptive_transcode = false;
+  /* Initialize MM with configuration */
+  mm_config_t config = {};
+  config.gpu_memory_limit = gpu_memory_limit;
+  config.kv_cache_fraction = 0.0f; /* Phase 1: no KV cache reservation yet */
+  config.kv_block_size_tokens = 16;
+  config.max_tier = MM_TIER_DRAM;
+  config.enable_prefix_caching = false; /* Phase 3 */
+  config.enable_defrag = false;
+  config.num_size_classes = 8;
+  config.high_watermark = 0.90f;
+  config.critical_watermark = 0.95f;
+  config.default_kv_format = MM_KV_FMT_FP16;
+  config.pressure_kv_format = MM_KV_FMT_TURBOQUANT_4;
+  config.critical_kv_format = MM_KV_FMT_TURBOQUANT_3;
+  config.enable_inline_quant = false;
+  config.enable_adaptive_transcode = false;
 
-    err = mm_init(&config);
-    if (err != MM_OK) {
-        std::fprintf(stderr, "[MM Bridge] mm_init failed: %d\n", err);
-        return err;
-    }
+  err = mm_init(&config);
+  if (err != MM_OK) {
+    std::fprintf(stderr, "[MM Bridge] mm_init failed: %d\n", err);
+    return err;
+  }
 
-    return MM_OK;
+  return MM_OK;
 }
 
 void mm_bridge_shutdown(void) {
-    /* Free workspace if allocated */
-    if (g_workspace_handle != MM_INVALID_HANDLE) {
-        mm_free(g_workspace_handle, g_stream);
-        g_workspace_handle = MM_INVALID_HANDLE;
-        g_workspace_ptr = nullptr;
-        g_workspace_size = 0;
-    }
+  /* Free workspace if allocated */
+  if (g_workspace_handle != MM_INVALID_HANDLE) {
+    mm_free(g_workspace_handle, g_stream);
+    g_workspace_handle = MM_INVALID_HANDLE;
+    g_workspace_ptr = nullptr;
+    g_workspace_size = 0;
+  }
 
-    mm_shutdown();
+  mm_shutdown();
 }
 
-mm_pool_t mm_bridge_pool_init(size_t pool_size,
-                              const size_t *buffer_offsets,
+mm_pool_t mm_bridge_pool_init(size_t pool_size, const size_t *buffer_offsets,
                               size_t num_buffers) {
-    if (pool_size == 0)
-        return MM_INVALID_POOL;
+  if (pool_size == 0)
+    return MM_INVALID_POOL;
 
-    /* Build the static plan from the compiler-generated offsets */
-    auto *entries = new mm_buffer_entry_t[num_buffers];
-    for (size_t i = 0; i < num_buffers; ++i) {
-        entries[i].tensor_id = (uint32_t)i;
-        entries[i].offset = buffer_offsets[i];
-        entries[i].size = 0; /* Size not tracked per-entry in current compiler */
-        entries[i].alignment = 256;
-    }
+  /* Build the static plan from the compiler-generated offsets */
+  auto *entries = new mm_buffer_entry_t[num_buffers];
+  for (size_t i = 0; i < num_buffers; ++i) {
+    entries[i].tensor_id = (uint32_t)i;
+    entries[i].offset = buffer_offsets[i];
+    entries[i].size = 0; /* Size not tracked per-entry in current compiler */
+    entries[i].alignment = 256;
+  }
 
-    mm_static_plan_t plan = {};
-    plan.total_size = pool_size;
-    plan.mem_class = MM_CLASS_WEIGHT;
-    plan.device = MM_DEVICE_GPU_0;
-    plan.num_entries = (uint32_t)num_buffers;
-    plan.entries = entries;
+  mm_static_plan_t plan = {};
+  plan.total_size = pool_size;
+  plan.mem_class = MM_CLASS_WEIGHT;
+  plan.device = MM_DEVICE_GPU_0;
+  plan.num_entries = (uint32_t)num_buffers;
+  plan.entries = entries;
 
-    mm_pool_t pool = mm_create_pool(&plan);
+  mm_pool_t pool = mm_create_pool(&plan);
 
-    delete[] entries;
+  delete[] entries;
 
-    if (pool == MM_INVALID_POOL) {
-        std::fprintf(stderr,
-                     "[MM Bridge] mm_create_pool failed for %zu bytes\n",
-                     pool_size);
-    }
+  if (pool == MM_INVALID_POOL) {
+    std::fprintf(stderr, "[MM Bridge] mm_create_pool failed for %zu bytes\n",
+                 pool_size);
+  }
 
-    return pool;
+  return pool;
 }
 
 void *mm_bridge_pool_get_buffer(mm_pool_t pool, size_t index) {
-    return mm_pool_get_ptr(pool, (uint32_t)index);
+  return mm_pool_get_ptr(pool, (uint32_t)index);
 }
 
 void *mm_bridge_pool_get_base(mm_pool_t pool) {
-    /* Return the pointer for tensor_id 0 (the base of the pool) */
-    return mm_pool_get_ptr(pool, 0);
+  /* Return the pointer for tensor_id 0 (the base of the pool) */
+  return mm_pool_get_ptr(pool, 0);
 }
 
-void mm_bridge_pool_destroy(mm_pool_t pool) {
-    mm_destroy_pool(pool);
-}
+void mm_bridge_pool_destroy(mm_pool_t pool) { mm_destroy_pool(pool); }
 
 void *mm_bridge_tensor_alloc(size_t size_bytes) {
-    if (size_bytes == 0)
-        return nullptr;
+  if (size_bytes == 0)
+    return nullptr;
 
-    mm_alloc_hints_t hints = {};
-    hints.mem_class = MM_CLASS_ACTIVATION;
-    hints.lifetime = MM_LIFETIME_STEP;
-    hints.alignment = 256;
+  mm_alloc_hints_t hints = {};
+  hints.mem_class = MM_CLASS_ACTIVATION;
+  hints.lifetime = MM_LIFETIME_STEP;
+  hints.alignment = 256;
 
-    mm_handle_t handle = mm_alloc(size_bytes, hints, g_stream);
-    if (handle == MM_INVALID_HANDLE)
-        return nullptr;
+  mm_handle_t handle = mm_alloc(size_bytes, hints, g_stream);
+  if (handle == MM_INVALID_HANDLE)
+    return nullptr;
 
-    return mm_get_ptr(handle, MM_DEVICE_GPU_0);
+  return mm_get_ptr(handle, MM_DEVICE_GPU_0);
 }
 
 void mm_bridge_tensor_release(void *ptr, size_t size_bytes) {
-    (void)ptr;
-    (void)size_bytes;
-    /* Arena allocations are freed in bulk via reset.
-       For Phase 1, individual frees are no-ops within the arena. */
+  (void)ptr;
+  (void)size_bytes;
+  /* Arena allocations are freed in bulk via reset.
+     For Phase 1, individual frees are no-ops within the arena. */
 }
 
 void *mm_bridge_workspace_ensure(size_t needed_size) {
-    if (needed_size == 0)
-        return g_workspace_ptr;
-
-    if (g_workspace_size >= needed_size)
-        return g_workspace_ptr;
-
-    /* Free old workspace */
-    if (g_workspace_handle != MM_INVALID_HANDLE) {
-        mm_free(g_workspace_handle, g_stream);
-        g_workspace_handle = MM_INVALID_HANDLE;
-        g_workspace_ptr = nullptr;
-        g_workspace_size = 0;
-    }
-
-    /* Allocate new, larger workspace */
-    mm_alloc_hints_t hints = {};
-    hints.mem_class = MM_CLASS_SCRATCH;
-    hints.lifetime = MM_LIFETIME_REQUEST;
-    hints.alignment = 256;
-
-    g_workspace_handle = mm_alloc(needed_size, hints, g_stream);
-    if (g_workspace_handle == MM_INVALID_HANDLE) {
-        std::fprintf(stderr,
-                     "[MM Bridge] workspace alloc failed for %zu bytes\n",
-                     needed_size);
-        return nullptr;
-    }
-
-    g_workspace_ptr = mm_get_ptr(g_workspace_handle, MM_DEVICE_GPU_0);
-    g_workspace_size = needed_size;
+  if (needed_size == 0)
     return g_workspace_ptr;
-}
 
-void *mm_bridge_workspace_get(void) {
+  if (g_workspace_size >= needed_size)
     return g_workspace_ptr;
+
+  /* Free old workspace */
+  if (g_workspace_handle != MM_INVALID_HANDLE) {
+    mm_free(g_workspace_handle, g_stream);
+    g_workspace_handle = MM_INVALID_HANDLE;
+    g_workspace_ptr = nullptr;
+    g_workspace_size = 0;
+  }
+
+  /* Allocate new, larger workspace */
+  mm_alloc_hints_t hints = {};
+  hints.mem_class = MM_CLASS_SCRATCH;
+  hints.lifetime = MM_LIFETIME_REQUEST;
+  hints.alignment = 256;
+
+  g_workspace_handle = mm_alloc(needed_size, hints, g_stream);
+  if (g_workspace_handle == MM_INVALID_HANDLE) {
+    std::fprintf(stderr, "[MM Bridge] workspace alloc failed for %zu bytes\n",
+                 needed_size);
+    return nullptr;
+  }
+
+  g_workspace_ptr = mm_get_ptr(g_workspace_handle, MM_DEVICE_GPU_0);
+  g_workspace_size = needed_size;
+  return g_workspace_ptr;
 }
 
-size_t mm_bridge_workspace_size(void) {
-    return g_workspace_size;
-}
+void *mm_bridge_workspace_get(void) { return g_workspace_ptr; }
+
+size_t mm_bridge_workspace_size(void) { return g_workspace_size; }
 
 int mm_bridge_is_initialized(void) {
-    auto *s = mm::mm_get_state();
-    return s->initialized.load(std::memory_order_acquire) ? 1 : 0;
+  auto *s = mm::mm_get_state();
+  return s->initialized.load(std::memory_order_acquire) ? 1 : 0;
 }
 
 } /* extern "C" */

--- a/lib/MemoryManager/mm_runtime_bridge.h
+++ b/lib/MemoryManager/mm_runtime_bridge.h
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
 #ifndef MM_RUNTIME_BRIDGE_H
 #define MM_RUNTIME_BRIDGE_H
 

--- a/lib/MemoryManager/mm_runtime_bridge.h
+++ b/lib/MemoryManager/mm_runtime_bridge.h
@@ -55,8 +55,7 @@ void mm_bridge_shutdown(void);
  * Drop-in replacement for hipdnn_ep_pool_init().
  * Returns the mm_pool_t handle (stored in RuntimeState).
  */
-mm_pool_t mm_bridge_pool_init(size_t pool_size,
-                              const size_t *buffer_offsets,
+mm_pool_t mm_bridge_pool_init(size_t pool_size, const size_t *buffer_offsets,
                               size_t num_buffers);
 
 /*

--- a/lib/MemoryManager/mm_runtime_bridge.h
+++ b/lib/MemoryManager/mm_runtime_bridge.h
@@ -1,0 +1,117 @@
+#ifndef MM_RUNTIME_BRIDGE_H
+#define MM_RUNTIME_BRIDGE_H
+
+/*
+ * Bridge layer between the existing HipDNN EP runtime and the Unified
+ * Memory Manager.
+ *
+ * This header provides drop-in replacements for the runtime's memory
+ * operations. The integration strategy is:
+ *
+ * 1. The runtime calls mm_bridge_init() during hipdnn_ep_state_init_with_fs()
+ *    to initialize the MM with the appropriate HAL backend.
+ *
+ * 2. pool_alloc/pool_release in hipdnn_ep_runtime_tensor.cpp are replaced
+ *    with mm_bridge_tensor_alloc/mm_bridge_tensor_release.
+ *
+ * 3. hipdnn_ep_pool_init() calls mm_bridge_pool_init() to create a static
+ *    pool via mm_create_pool().
+ *
+ * 4. hipdnn_ep_state_ensure_workspace() calls mm_bridge_workspace_alloc()
+ *    to route workspace through mm_alloc(SCRATCH).
+ *
+ * 5. mm_bridge_shutdown() is called during hipdnn_ep_state_cleanup().
+ *
+ * All functions are C-linkage for compatibility with the generated LLVM IR.
+ */
+
+#include "mm_config.h"
+#include "mm_core.h"
+#include "mm_hal.h"
+#include "mm_pool.h"
+#include "mm_types.h"
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Initialize the MM bridge. Called once during state_init.
+ * gpu_memory_limit: 0 for auto-detect.
+ * hip_stream: the HIP stream cast to uint64_t (mm_stream_t).
+ * Returns MM_OK on success.
+ */
+int mm_bridge_init(size_t gpu_memory_limit, mm_stream_t hip_stream);
+
+/*
+ * Shutdown the MM bridge. Called during state_cleanup.
+ */
+void mm_bridge_shutdown(void);
+
+/*
+ * Create a static pool from compiler-generated offsets.
+ * Drop-in replacement for hipdnn_ep_pool_init().
+ * Returns the mm_pool_t handle (stored in RuntimeState).
+ */
+mm_pool_t mm_bridge_pool_init(size_t pool_size,
+                              const size_t *buffer_offsets,
+                              size_t num_buffers);
+
+/*
+ * Get a buffer pointer from the static pool.
+ * Drop-in replacement for hipdnn_ep_get_buffer_from_pool().
+ */
+void *mm_bridge_pool_get_buffer(mm_pool_t pool, size_t index);
+
+/*
+ * Get pool base pointer (for MemoryLowering.cpp compatibility).
+ * Drop-in replacement for hipdnn_ep_get_pool_base().
+ */
+void *mm_bridge_pool_get_base(mm_pool_t pool);
+
+/*
+ * Destroy a static pool.
+ */
+void mm_bridge_pool_destroy(mm_pool_t pool);
+
+/*
+ * Allocate a GPU buffer for tensor I/O.
+ * Drop-in replacement for pool_alloc() in hipdnn_ep_runtime_tensor.cpp.
+ */
+void *mm_bridge_tensor_alloc(size_t size_bytes);
+
+/*
+ * Release a GPU buffer for tensor I/O.
+ * Drop-in replacement for pool_release() in hipdnn_ep_runtime_tensor.cpp.
+ */
+void mm_bridge_tensor_release(void *ptr, size_t size_bytes);
+
+/*
+ * Ensure workspace of at least needed_size bytes.
+ * Drop-in replacement for hipdnn_ep_state_ensure_workspace().
+ * Returns the workspace pointer, or NULL on failure.
+ */
+void *mm_bridge_workspace_ensure(size_t needed_size);
+
+/*
+ * Get current workspace pointer (for operator use).
+ */
+void *mm_bridge_workspace_get(void);
+
+/*
+ * Get current workspace size.
+ */
+size_t mm_bridge_workspace_size(void);
+
+/*
+ * Check if MM bridge is initialized.
+ */
+int mm_bridge_is_initialized(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MM_RUNTIME_BRIDGE_H */

--- a/lib/MemoryManager/mm_types.h
+++ b/lib/MemoryManager/mm_types.h
@@ -1,0 +1,139 @@
+#ifndef MM_TYPES_H
+#define MM_TYPES_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ---- Opaque Handles ---- */
+
+typedef uint64_t mm_handle_t;
+typedef uint64_t mm_pool_t;
+typedef uint64_t mm_stream_t;
+typedef uint64_t mm_kv_block_t;
+typedef uint64_t mm_fence_t;
+
+#define MM_INVALID_HANDLE ((mm_handle_t)0)
+#define MM_INVALID_POOL   ((mm_pool_t)0)
+#define MM_INVALID_BLOCK  ((mm_kv_block_t)0)
+
+/* ---- Enums ---- */
+
+typedef enum {
+    MM_CLASS_WEIGHT     = 0,
+    MM_CLASS_ACTIVATION = 1,
+    MM_CLASS_KV_CACHE   = 2,
+    MM_CLASS_SCRATCH    = 3,
+} mm_memory_class_t;
+
+typedef enum {
+    MM_LIFETIME_STATIC    = 0,
+    MM_LIFETIME_REQUEST   = 1,
+    MM_LIFETIME_STEP      = 2,
+    MM_LIFETIME_TRANSIENT = 3,
+} mm_lifetime_t;
+
+typedef enum {
+    MM_ACCESS_SEQUENTIAL  = 0,
+    MM_ACCESS_RANDOM      = 1,
+    MM_ACCESS_WRITE_ONCE  = 2,
+    MM_ACCESS_READ_MOSTLY = 3,
+} mm_access_pattern_t;
+
+typedef enum {
+    MM_DEVICE_GPU_0 = 0,
+    MM_DEVICE_GPU_1 = 1,
+    MM_DEVICE_GPU_2 = 2,
+    MM_DEVICE_GPU_3 = 3,
+    MM_DEVICE_NPU   = 16,
+    MM_DEVICE_CPU   = 32,
+    MM_DEVICE_ANY   = 255,
+} mm_device_t;
+
+typedef enum {
+    MM_TIER_HBM     = 0,
+    MM_TIER_DRAM    = 1,
+    MM_TIER_SSD     = 2,
+    MM_TIER_NETWORK = 3,
+} mm_tier_t;
+
+typedef enum {
+    MM_KV_FMT_FP16         = 0,
+    MM_KV_FMT_FP8_E4M3     = 1,
+    MM_KV_FMT_INT4         = 2,
+    MM_KV_FMT_TURBOQUANT_4 = 3,
+    MM_KV_FMT_TURBOQUANT_3 = 4,
+    MM_KV_FMT_TURBOQUANT_2 = 5,
+} mm_kv_format_t;
+
+typedef enum {
+    MM_COPY_HOST_TO_DEVICE = 0,
+    MM_COPY_DEVICE_TO_HOST = 1,
+    MM_COPY_DEVICE_TO_DEVICE = 2,
+    MM_COPY_HOST_TO_HOST = 3,
+} mm_copy_kind_t;
+
+/* ---- Error Codes ---- */
+
+#define MM_OK                  0
+#define MM_ERROR_NOT_INIT     -1
+#define MM_ERROR_ALREADY_INIT -2
+#define MM_ERROR_INVALID_ARG  -3
+#define MM_ERROR_OUT_OF_MEMORY -4
+#define MM_ERROR_HAL_FAILURE  -5
+
+/* ---- Structs ---- */
+
+typedef struct {
+    mm_memory_class_t   mem_class;
+    mm_lifetime_t       lifetime;
+    mm_access_pattern_t access_pattern;
+    mm_device_t         device_affinity;
+    size_t              alignment;
+    bool                shareable;
+    size_t              size_hint_max;
+} mm_alloc_hints_t;
+
+typedef struct {
+    mm_tier_t         current_tier;
+    mm_memory_class_t mem_class;
+    size_t            size;
+    uint32_t          ref_count;
+    mm_device_t       resident_device;
+} mm_alloc_info_t;
+
+typedef struct {
+    uint32_t tensor_id;
+    size_t   offset;
+    size_t   size;
+    size_t   alignment;
+} mm_buffer_entry_t;
+
+typedef struct {
+    size_t              total_size;
+    mm_memory_class_t   mem_class;
+    mm_device_t         device;
+    uint32_t            num_entries;
+    mm_buffer_entry_t  *entries;
+} mm_static_plan_t;
+
+typedef struct {
+    mm_kv_format_t format;
+    uint32_t       block_size_tokens;
+    uint32_t       num_kv_heads;
+    uint32_t       head_dim;
+    uint32_t       num_layers;
+    size_t         bytes_per_token;
+    bool           has_qjl_residual;
+    uint32_t       polar_bits;
+} mm_kv_block_desc_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MM_TYPES_H */

--- a/lib/MemoryManager/mm_types.h
+++ b/lib/MemoryManager/mm_types.h
@@ -18,118 +18,118 @@ typedef uint64_t mm_kv_block_t;
 typedef uint64_t mm_fence_t;
 
 #define MM_INVALID_HANDLE ((mm_handle_t)0)
-#define MM_INVALID_POOL   ((mm_pool_t)0)
-#define MM_INVALID_BLOCK  ((mm_kv_block_t)0)
+#define MM_INVALID_POOL ((mm_pool_t)0)
+#define MM_INVALID_BLOCK ((mm_kv_block_t)0)
 
 /* ---- Enums ---- */
 
 typedef enum {
-    MM_CLASS_WEIGHT     = 0,
-    MM_CLASS_ACTIVATION = 1,
-    MM_CLASS_KV_CACHE   = 2,
-    MM_CLASS_SCRATCH    = 3,
+  MM_CLASS_WEIGHT = 0,
+  MM_CLASS_ACTIVATION = 1,
+  MM_CLASS_KV_CACHE = 2,
+  MM_CLASS_SCRATCH = 3,
 } mm_memory_class_t;
 
 typedef enum {
-    MM_LIFETIME_STATIC    = 0,
-    MM_LIFETIME_REQUEST   = 1,
-    MM_LIFETIME_STEP      = 2,
-    MM_LIFETIME_TRANSIENT = 3,
+  MM_LIFETIME_STATIC = 0,
+  MM_LIFETIME_REQUEST = 1,
+  MM_LIFETIME_STEP = 2,
+  MM_LIFETIME_TRANSIENT = 3,
 } mm_lifetime_t;
 
 typedef enum {
-    MM_ACCESS_SEQUENTIAL  = 0,
-    MM_ACCESS_RANDOM      = 1,
-    MM_ACCESS_WRITE_ONCE  = 2,
-    MM_ACCESS_READ_MOSTLY = 3,
+  MM_ACCESS_SEQUENTIAL = 0,
+  MM_ACCESS_RANDOM = 1,
+  MM_ACCESS_WRITE_ONCE = 2,
+  MM_ACCESS_READ_MOSTLY = 3,
 } mm_access_pattern_t;
 
 typedef enum {
-    MM_DEVICE_GPU_0 = 0,
-    MM_DEVICE_GPU_1 = 1,
-    MM_DEVICE_GPU_2 = 2,
-    MM_DEVICE_GPU_3 = 3,
-    MM_DEVICE_NPU   = 16,
-    MM_DEVICE_CPU   = 32,
-    MM_DEVICE_ANY   = 255,
+  MM_DEVICE_GPU_0 = 0,
+  MM_DEVICE_GPU_1 = 1,
+  MM_DEVICE_GPU_2 = 2,
+  MM_DEVICE_GPU_3 = 3,
+  MM_DEVICE_NPU = 16,
+  MM_DEVICE_CPU = 32,
+  MM_DEVICE_ANY = 255,
 } mm_device_t;
 
 typedef enum {
-    MM_TIER_HBM     = 0,
-    MM_TIER_DRAM    = 1,
-    MM_TIER_SSD     = 2,
-    MM_TIER_NETWORK = 3,
+  MM_TIER_HBM = 0,
+  MM_TIER_DRAM = 1,
+  MM_TIER_SSD = 2,
+  MM_TIER_NETWORK = 3,
 } mm_tier_t;
 
 typedef enum {
-    MM_KV_FMT_FP16         = 0,
-    MM_KV_FMT_FP8_E4M3     = 1,
-    MM_KV_FMT_INT4         = 2,
-    MM_KV_FMT_TURBOQUANT_4 = 3,
-    MM_KV_FMT_TURBOQUANT_3 = 4,
-    MM_KV_FMT_TURBOQUANT_2 = 5,
+  MM_KV_FMT_FP16 = 0,
+  MM_KV_FMT_FP8_E4M3 = 1,
+  MM_KV_FMT_INT4 = 2,
+  MM_KV_FMT_TURBOQUANT_4 = 3,
+  MM_KV_FMT_TURBOQUANT_3 = 4,
+  MM_KV_FMT_TURBOQUANT_2 = 5,
 } mm_kv_format_t;
 
 typedef enum {
-    MM_COPY_HOST_TO_DEVICE = 0,
-    MM_COPY_DEVICE_TO_HOST = 1,
-    MM_COPY_DEVICE_TO_DEVICE = 2,
-    MM_COPY_HOST_TO_HOST = 3,
+  MM_COPY_HOST_TO_DEVICE = 0,
+  MM_COPY_DEVICE_TO_HOST = 1,
+  MM_COPY_DEVICE_TO_DEVICE = 2,
+  MM_COPY_HOST_TO_HOST = 3,
 } mm_copy_kind_t;
 
 /* ---- Error Codes ---- */
 
-#define MM_OK                  0
-#define MM_ERROR_NOT_INIT     -1
+#define MM_OK 0
+#define MM_ERROR_NOT_INIT -1
 #define MM_ERROR_ALREADY_INIT -2
-#define MM_ERROR_INVALID_ARG  -3
+#define MM_ERROR_INVALID_ARG -3
 #define MM_ERROR_OUT_OF_MEMORY -4
-#define MM_ERROR_HAL_FAILURE  -5
+#define MM_ERROR_HAL_FAILURE -5
 
 /* ---- Structs ---- */
 
 typedef struct {
-    mm_memory_class_t   mem_class;
-    mm_lifetime_t       lifetime;
-    mm_access_pattern_t access_pattern;
-    mm_device_t         device_affinity;
-    size_t              alignment;
-    bool                shareable;
-    size_t              size_hint_max;
+  mm_memory_class_t mem_class;
+  mm_lifetime_t lifetime;
+  mm_access_pattern_t access_pattern;
+  mm_device_t device_affinity;
+  size_t alignment;
+  bool shareable;
+  size_t size_hint_max;
 } mm_alloc_hints_t;
 
 typedef struct {
-    mm_tier_t         current_tier;
-    mm_memory_class_t mem_class;
-    size_t            size;
-    uint32_t          ref_count;
-    mm_device_t       resident_device;
+  mm_tier_t current_tier;
+  mm_memory_class_t mem_class;
+  size_t size;
+  uint32_t ref_count;
+  mm_device_t resident_device;
 } mm_alloc_info_t;
 
 typedef struct {
-    uint32_t tensor_id;
-    size_t   offset;
-    size_t   size;
-    size_t   alignment;
+  uint32_t tensor_id;
+  size_t offset;
+  size_t size;
+  size_t alignment;
 } mm_buffer_entry_t;
 
 typedef struct {
-    size_t              total_size;
-    mm_memory_class_t   mem_class;
-    mm_device_t         device;
-    uint32_t            num_entries;
-    mm_buffer_entry_t  *entries;
+  size_t total_size;
+  mm_memory_class_t mem_class;
+  mm_device_t device;
+  uint32_t num_entries;
+  mm_buffer_entry_t *entries;
 } mm_static_plan_t;
 
 typedef struct {
-    mm_kv_format_t format;
-    uint32_t       block_size_tokens;
-    uint32_t       num_kv_heads;
-    uint32_t       head_dim;
-    uint32_t       num_layers;
-    size_t         bytes_per_token;
-    bool           has_qjl_residual;
-    uint32_t       polar_bits;
+  mm_kv_format_t format;
+  uint32_t block_size_tokens;
+  uint32_t num_kv_heads;
+  uint32_t head_dim;
+  uint32_t num_layers;
+  size_t bytes_per_token;
+  bool has_qjl_residual;
+  uint32_t polar_bits;
 } mm_kv_block_desc_t;
 
 #ifdef __cplusplus

--- a/lib/MemoryManager/mm_types.h
+++ b/lib/MemoryManager/mm_types.h
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
 #ifndef MM_TYPES_H
 #define MM_TYPES_H
 

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -163,6 +163,9 @@ macro(compile_to_bitcode SOURCE_FILE OUTPUT_BC)
         endforeach()
     endif()
 
+    # Add Memory Manager headers
+    list(APPEND COMPILE_FLAGS "-I" "${CMAKE_SOURCE_DIR}/lib/MemoryManager")
+
     # Add implementation directory
     if(NOT BUILD_MOCK_RUNTIME)
         list(APPEND COMPILE_FLAGS "-I" "${CMAKE_CURRENT_SOURCE_DIR}/real")
@@ -175,6 +178,7 @@ macro(compile_to_bitcode SOURCE_FILE OUTPUT_BC)
             message(STATUS "Adding TheRock includes for ${OUTPUT_BC}: ${THEROCK_DIST}/include")
             list(APPEND COMPILE_FLAGS "-I" "${THEROCK_DIST}/include")
             list(APPEND COMPILE_FLAGS "-D__HIP_PLATFORM_AMD__")
+            list(APPEND COMPILE_FLAGS "-DMM_HAS_HIP")
         endif()
     else()
         list(APPEND COMPILE_FLAGS "-I" "${CMAKE_CURRENT_SOURCE_DIR}/mock")
@@ -229,6 +233,20 @@ if(NOT BUILD_MOCK_RUNTIME)
     compile_to_bitcode(real/test_hip_from_dll.cpp test_hip_from_dll.bc)
     compile_to_bitcode(real/gemm.cpp runtime_gemm.bc)
 
+    # Memory Manager modules (compiled to bitcode for DLL linking)
+    compile_to_bitcode(../MemoryManager/mm_hal.cpp mm_hal.bc)
+    compile_to_bitcode(../MemoryManager/mm_hal_host.cpp mm_hal_host.bc)
+    compile_to_bitcode(../MemoryManager/mm_hal_hip.cpp mm_hal_hip.bc)
+    compile_to_bitcode(../MemoryManager/mm_handle_table.cpp mm_handle_table.bc)
+    compile_to_bitcode(../MemoryManager/mm_config.cpp mm_config.bc)
+    compile_to_bitcode(../MemoryManager/mm_core.cpp mm_core.bc)
+    compile_to_bitcode(../MemoryManager/mm_pool.cpp mm_pool.bc)
+    compile_to_bitcode(../MemoryManager/mm_arena.cpp mm_arena.bc)
+    compile_to_bitcode(../MemoryManager/mm_runtime_bridge.cpp mm_runtime_bridge.bc)
+    compile_to_bitcode(../MemoryManager/mm_free_list.cpp mm_free_list.bc)
+    compile_to_bitcode(../MemoryManager/mm_kv.cpp mm_kv.bc)
+    compile_to_bitcode(../MemoryManager/mm_block_table.cpp mm_block_table.bc)
+
     set(RUNTIME_BC_MODULES
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_state.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_tensor.bc
@@ -250,6 +268,18 @@ if(NOT BUILD_MOCK_RUNTIME)
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_qmoe.bc
         ${CMAKE_CURRENT_BINARY_DIR}/test_hip_from_dll.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_gemm.bc
+        ${CMAKE_CURRENT_BINARY_DIR}/mm_hal.bc
+        ${CMAKE_CURRENT_BINARY_DIR}/mm_hal_host.bc
+        ${CMAKE_CURRENT_BINARY_DIR}/mm_hal_hip.bc
+        ${CMAKE_CURRENT_BINARY_DIR}/mm_handle_table.bc
+        ${CMAKE_CURRENT_BINARY_DIR}/mm_config.bc
+        ${CMAKE_CURRENT_BINARY_DIR}/mm_core.bc
+        ${CMAKE_CURRENT_BINARY_DIR}/mm_pool.bc
+        ${CMAKE_CURRENT_BINARY_DIR}/mm_arena.bc
+        ${CMAKE_CURRENT_BINARY_DIR}/mm_runtime_bridge.bc
+        ${CMAKE_CURRENT_BINARY_DIR}/mm_free_list.bc
+        ${CMAKE_CURRENT_BINARY_DIR}/mm_kv.bc
+        ${CMAKE_CURRENT_BINARY_DIR}/mm_block_table.bc
     )
 else()
     # Mock runtime for testing without GPU

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -8,6 +8,8 @@
 #include "hipdnn_ep_runtime.h"
 #include "runtime_state_internal.h"
 
+#include "mm_runtime_bridge.h"
+
 #include "model_metadata_generated.h"
 #include "morphizen-foundation/file_io.hpp"
 
@@ -48,6 +50,7 @@ int hipdnn_ep_state_init_with_fs(RuntimeState **out_state, void *fs,
   state->workspace_size = 0;
   state->hipdnn_handle = nullptr;
   state->hipdnn_graph_registry = nullptr;
+  state->mm_initialized = false;
 
   // Explicitly initialize HIP device before any other operations
   // This ensures device 0 is active and context is properly initialized
@@ -174,6 +177,22 @@ int hipdnn_ep_state_init_with_fs(RuntimeState **out_state, void *fs,
   }
 
   TIMING_LOG("[Session] hipBLASLt init: %.3fs\n", record_elapsed(t_prev));
+
+  // Initialize Unified Memory Manager
+  {
+    mm_stream_t mm_stream = reinterpret_cast<mm_stream_t>(state->stream);
+    int mm_err = mm_bridge_init(0 /* auto-detect GPU memory */, mm_stream);
+    if (mm_err == MM_OK) {
+      state->mm_initialized = true;
+      RUNTIME_DEBUG_LOG("[MM] Memory Manager initialized successfully\n");
+    } else {
+      // Non-fatal: fall back to legacy allocation paths
+      RUNTIME_DEBUG_LOG("[MM] Memory Manager init failed (%d), using legacy\n",
+                        mm_err);
+    }
+  }
+
+  TIMING_LOG("[Session] Memory Manager init: %.3fs\n", record_elapsed(t_prev));
 
   *out_state = state;
 
@@ -370,14 +389,24 @@ int hipdnn_ep_state_cleanup(RuntimeState *state) {
     HIP_CLEANUP(hipStreamSynchronize(state->stream));
   }
 
-  // Free shared workspace (if allocated)
-  if (state->workspace) {
-    HIP_CLEANUP(hipFree(state->workspace));
-  }
-
-  // Free memory pool (if allocated)
-  if (state->pool_base) {
-    HIP_CLEANUP(hipFree(state->pool_base));
+  // Shutdown Memory Manager (frees pool and workspace internally)
+  if (state->mm_initialized) {
+    RUNTIME_DEBUG_LOG("[MM] Shutting down Memory Manager\n");
+    mm_bridge_shutdown();
+    state->mm_initialized = false;
+    // Clear legacy pointers (MM owned them)
+    state->workspace = nullptr;
+    state->workspace_size = 0;
+    state->pool_base = nullptr;
+    state->pool_size = 0;
+  } else {
+    // Legacy cleanup
+    if (state->workspace) {
+      HIP_CLEANUP(hipFree(state->workspace));
+    }
+    if (state->pool_base) {
+      HIP_CLEANUP(hipFree(state->pool_base));
+    }
   }
   if (state->buffer_offsets) {
     free(state->buffer_offsets);
@@ -448,22 +477,46 @@ int hipdnn_ep_pool_init(RuntimeState *state, size_t pool_size,
     return 1;
   }
 
-  // Allocate the memory pool
+  // Route through Memory Manager when available
+  if (state->mm_initialized) {
+    mm_pool_t pool = mm_bridge_pool_init(pool_size, buffer_offsets, num_buffers);
+    if (pool == MM_INVALID_POOL && pool_size > 0) {
+      fprintf(stderr, "[MM] Pool init failed for %zu bytes, falling back\n",
+              pool_size);
+      goto legacy_path;
+    }
+    // Store MM pool handle — use pool_base to store the handle for retrieval
+    // and keep buffer_offsets for hipdnn_ep_get_buffer_from_pool compatibility.
+    state->pool_base = (void *)(uintptr_t)pool;
+    state->pool_size = pool_size;
+    state->num_buffers = num_buffers;
+    state->buffer_offsets = nullptr;
+    if (num_buffers > 0 && buffer_offsets) {
+      state->buffer_offsets = (size_t *)malloc(sizeof(size_t) * num_buffers);
+      if (state->buffer_offsets)
+        memcpy(state->buffer_offsets, buffer_offsets,
+               sizeof(size_t) * num_buffers);
+    }
+    RUNTIME_DEBUG_LOG("[MM] Pool initialized via mm_create_pool: %zu bytes, %zu buffers\n",
+                      pool_size, num_buffers);
+    return 0;
+  }
+
+legacy_path:
+  // Legacy path: direct hipMalloc
   if (pool_size > 0) {
     if (hipMalloc(&state->pool_base, pool_size) != hipSuccess) {
       fprintf(stderr, "Failed to allocate memory pool of size %zu bytes\n",
               pool_size);
-      return 2; // Pool allocation failed
+      return 2;
     }
   } else {
     state->pool_base = nullptr;
   }
 
-  // Store pool metadata
   state->pool_size = pool_size;
   state->num_buffers = num_buffers;
 
-  // Copy buffer offsets array
   if (num_buffers > 0 && buffer_offsets) {
     state->buffer_offsets = (size_t *)malloc(sizeof(size_t) * num_buffers);
     if (!state->buffer_offsets) {
@@ -472,14 +525,14 @@ int hipdnn_ep_pool_init(RuntimeState *state, size_t pool_size,
         HIP_CLEANUP(hipFree(state->pool_base));
         state->pool_base = nullptr;
       }
-      return 1; // Allocation failed
+      return 1;
     }
     memcpy(state->buffer_offsets, buffer_offsets, sizeof(size_t) * num_buffers);
   } else {
     state->buffer_offsets = nullptr;
   }
 
-  return 0; // Success
+  return 0;
 }
 
 void *hipdnn_ep_get_buffer_from_pool(RuntimeState *state, size_t index) {
@@ -494,7 +547,13 @@ void *hipdnn_ep_get_buffer_from_pool(RuntimeState *state, size_t index) {
     return nullptr;
   }
 
-  // Return pointer at pool_base + offset
+  // Route through MM when available
+  if (state->mm_initialized) {
+    mm_pool_t pool = (mm_pool_t)(uintptr_t)state->pool_base;
+    return mm_bridge_pool_get_buffer(pool, index);
+  }
+
+  // Legacy path: pool_base + offset
   char *pool_ptr = static_cast<char *>(state->pool_base);
   size_t offset = state->buffer_offsets[index];
   return pool_ptr + offset;
@@ -505,6 +564,13 @@ void *hipdnn_ep_get_pool_base(RuntimeState *state) {
     fprintf(stderr, "Invalid state parameter to hipdnn_ep_get_pool_base\n");
     return nullptr;
   }
+
+  // Route through MM when available
+  if (state->mm_initialized) {
+    mm_pool_t pool = (mm_pool_t)(uintptr_t)state->pool_base;
+    return mm_bridge_pool_get_base(pool);
+  }
+
   return state->pool_base;
 }
 
@@ -528,7 +594,24 @@ int hipdnn_ep_state_ensure_workspace(RuntimeState *state, size_t needed_size) {
   if (state->workspace_size >= needed_size)
     return 0;
 
-  // Grow: free old, allocate new
+  // Route through MM when available
+  if (state->mm_initialized) {
+    void *ws = mm_bridge_workspace_ensure(needed_size);
+    if (!ws) {
+      fprintf(stderr,
+              "[MM] workspace ensure failed for %zu bytes, falling back\n",
+              needed_size);
+      goto legacy_path;
+    }
+    state->workspace = ws;
+    state->workspace_size = needed_size;
+    RUNTIME_DEBUG_LOG("[MM] Workspace allocated via mm_alloc(SCRATCH): %zu bytes\n",
+                      needed_size);
+    return 0;
+  }
+
+legacy_path:
+  // Legacy path: grow via hipMalloc
   if (state->workspace) {
     HIP_CLEANUP(hipFree(state->workspace));
     state->workspace = nullptr;

--- a/lib/Runtime/hipdnn_ep_runtime_tensor.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_tensor.cpp
@@ -7,6 +7,8 @@
 #include "hipdnn_ep_runtime.h"
 #include "runtime_state_internal.h"
 
+#include "mm_runtime_bridge.h"
+
 #include <cassert>
 #include <cstdio>
 #include <cstring>
@@ -84,6 +86,18 @@ static std::unordered_map<size_t, std::vector<void *>> g_gpu_buffer_pool;
 
 static void *pool_alloc(size_t size_bytes) {
   assert(size_bytes > 0 && "pool_alloc: size_bytes must be positive");
+
+  // Route through Memory Manager when available
+  if (mm_bridge_is_initialized()) {
+    void *ptr = mm_bridge_tensor_alloc(size_bytes);
+    if (ptr) {
+      RUNTIME_DEBUG_LOG("[MM] tensor_alloc via arena: %zu bytes -> %p\n",
+                        size_bytes, ptr);
+      return ptr;
+    }
+    // Fall through to legacy on failure
+  }
+
   auto it = g_gpu_buffer_pool.find(size_bytes);
   if (it != g_gpu_buffer_pool.end() && !it->second.empty()) {
     void *ptr = it->second.back();
@@ -98,8 +112,18 @@ static void *pool_alloc(size_t size_bytes) {
 
 static void pool_release(void *ptr, size_t size_bytes) {
   assert(size_bytes > 0 && "pool_release: size_bytes must be positive");
-  if (ptr)
-    g_gpu_buffer_pool[size_bytes].push_back(ptr);
+  if (!ptr)
+    return;
+
+  // Route through Memory Manager when available
+  if (mm_bridge_is_initialized()) {
+    RUNTIME_DEBUG_LOG("[MM] tensor_release via arena: %zu bytes <- %p\n",
+                      size_bytes, ptr);
+    mm_bridge_tensor_release(ptr, size_bytes);
+    return;
+  }
+
+  g_gpu_buffer_pool[size_bytes].push_back(ptr);
 }
 
 // Element size is read from tensor_t.element_size (set by EP caller)

--- a/lib/Runtime/runtime_state_internal.h
+++ b/lib/Runtime/runtime_state_internal.h
@@ -54,6 +54,12 @@ struct RuntimeState {
   // cleaned up here)
   void *hipdnn_handle;
   void *hipdnn_graph_registry;
+
+  // Unified Memory Manager state.
+  // When mm_initialized is true, memory operations route through the MM API.
+  // The legacy fields above (pool_base, workspace, etc.) remain for
+  // backward compatibility with existing generated code.
+  bool mm_initialized;
 };
 
 #endif // HIPDNN_EP_RUNTIME_STATE_INTERNAL_H

--- a/test/unit/mm/CMakeLists.txt
+++ b/test/unit/mm/CMakeLists.txt
@@ -1,0 +1,40 @@
+##
+# ** Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# ** Licensed under the MIT License.
+##
+
+# Memory Manager unit tests (GoogleTest)
+
+include(FetchContent)
+FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG        v1.15.2
+)
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+enable_testing()
+
+set(MM_TEST_SOURCES
+    test_hal.cpp
+    test_handle_table.cpp
+    test_lifecycle.cpp
+    test_pool.cpp
+    test_arena.cpp
+    test_core.cpp
+    test_free_list.cpp
+    test_kv_block.cpp
+    test_kv_fork.cpp
+    test_block_table.cpp
+)
+
+add_executable(mm_tests ${MM_TEST_SOURCES})
+
+target_link_libraries(mm_tests PRIVATE
+    HipDnnEpMemoryManager
+    GTest::gtest_main
+)
+
+include(GoogleTest)
+gtest_discover_tests(mm_tests)

--- a/test/unit/mm/test_arena.cpp
+++ b/test/unit/mm/test_arena.cpp
@@ -1,0 +1,95 @@
+#include "mm_arena.h"
+#include "mm_hal.h"
+#include <gtest/gtest.h>
+#include <set>
+#include <thread>
+#include <vector>
+
+class ArenaTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        hal = mm_hal_host_get();
+        ASSERT_EQ(arena.init(hal, 0, 16 * 1024 * 1024, 8), MM_OK);
+    }
+    void TearDown() override { arena.shutdown(); }
+
+    const mm_hal_t *hal = nullptr;
+    mm::ArenaAllocator arena;
+};
+
+TEST_F(ArenaTest, BumpAlloc) {
+    void *p1 = arena.alloc(512);
+    void *p2 = arena.alloc(512);
+    ASSERT_NE(p1, nullptr);
+    ASSERT_NE(p2, nullptr);
+    EXPECT_NE(p1, p2);
+}
+
+TEST_F(ArenaTest, SizeClassRouting) {
+    EXPECT_EQ(mm::ArenaAllocator::size_class(100), 0u);     /* <1KB → class 0 */
+    EXPECT_EQ(mm::ArenaAllocator::size_class(1024), 1u);    /* 1KB → class 1 */
+    EXPECT_EQ(mm::ArenaAllocator::size_class(4096), 2u);    /* 4KB → class 2 */
+    EXPECT_EQ(mm::ArenaAllocator::size_class(100000), 4u);  /* 100KB → class 4 */
+    EXPECT_EQ(mm::ArenaAllocator::size_class(5000000), 7u); /* 5MB → class 7 (BFC) */
+}
+
+TEST_F(ArenaTest, StepReset) {
+    void *p1 = arena.alloc(256);
+    ASSERT_NE(p1, nullptr);
+    size_t used_before = arena.used_bytes();
+    EXPECT_GT(used_before, 0u);
+
+    arena.reset();
+    /* After reset, arena bump pointers are back to 0 */
+    /* (BFC allocations are not affected by reset) */
+
+    void *p2 = arena.alloc(256);
+    ASSERT_NE(p2, nullptr);
+    /* p2 should reuse the same memory as p1 in the same class */
+    EXPECT_EQ(p1, p2);
+}
+
+TEST_F(ArenaTest, BfcFallbackForLargeAlloc) {
+    void *ptr = arena.alloc(8 * 1024 * 1024); /* 8 MB → BFC */
+    ASSERT_NE(ptr, nullptr);
+    arena.free(ptr, 8 * 1024 * 1024);
+}
+
+TEST_F(ArenaTest, ConcurrentBumpNoOverlap) {
+    constexpr int kThreads = 4;
+    constexpr int kAllocsPerThread = 50;
+    constexpr size_t kAllocSize = 256; /* Must be >= kDefaultAlignment to get unique bumps */
+
+    std::vector<std::vector<void *>> results(kThreads);
+    std::vector<std::thread> threads;
+
+    for (int t = 0; t < kThreads; ++t) {
+        threads.emplace_back([this, &results, t, kAllocsPerThread, kAllocSize]() {
+            for (int i = 0; i < kAllocsPerThread; ++i) {
+                void *p = arena.alloc(kAllocSize);
+                ASSERT_NE(p, nullptr);
+                results[t].push_back(p);
+            }
+        });
+    }
+
+    for (auto &th : threads)
+        th.join();
+
+    /* Verify no two allocations overlap */
+    std::set<void *> all_ptrs;
+    for (const auto &vec : results) {
+        for (void *p : vec) {
+            auto [_, inserted] = all_ptrs.insert(p);
+            EXPECT_TRUE(inserted) << "Duplicate allocation pointer detected";
+        }
+    }
+    EXPECT_EQ(all_ptrs.size(), (size_t)(kThreads * kAllocsPerThread));
+}
+
+TEST_F(ArenaTest, UsedBytesTracking) {
+    size_t before = arena.used_bytes();
+    arena.alloc(1024);
+    size_t after = arena.used_bytes();
+    EXPECT_GT(after, before);
+}

--- a/test/unit/mm/test_arena.cpp
+++ b/test/unit/mm/test_arena.cpp
@@ -7,89 +7,91 @@
 
 class ArenaTest : public ::testing::Test {
 protected:
-    void SetUp() override {
-        hal = mm_hal_host_get();
-        ASSERT_EQ(arena.init(hal, 0, 16 * 1024 * 1024, 8), MM_OK);
-    }
-    void TearDown() override { arena.shutdown(); }
+  void SetUp() override {
+    hal = mm_hal_host_get();
+    ASSERT_EQ(arena.init(hal, 0, 16 * 1024 * 1024, 8), MM_OK);
+  }
+  void TearDown() override { arena.shutdown(); }
 
-    const mm_hal_t *hal = nullptr;
-    mm::ArenaAllocator arena;
+  const mm_hal_t *hal = nullptr;
+  mm::ArenaAllocator arena;
 };
 
 TEST_F(ArenaTest, BumpAlloc) {
-    void *p1 = arena.alloc(512);
-    void *p2 = arena.alloc(512);
-    ASSERT_NE(p1, nullptr);
-    ASSERT_NE(p2, nullptr);
-    EXPECT_NE(p1, p2);
+  void *p1 = arena.alloc(512);
+  void *p2 = arena.alloc(512);
+  ASSERT_NE(p1, nullptr);
+  ASSERT_NE(p2, nullptr);
+  EXPECT_NE(p1, p2);
 }
 
 TEST_F(ArenaTest, SizeClassRouting) {
-    EXPECT_EQ(mm::ArenaAllocator::size_class(100), 0u);     /* <1KB → class 0 */
-    EXPECT_EQ(mm::ArenaAllocator::size_class(1024), 1u);    /* 1KB → class 1 */
-    EXPECT_EQ(mm::ArenaAllocator::size_class(4096), 2u);    /* 4KB → class 2 */
-    EXPECT_EQ(mm::ArenaAllocator::size_class(100000), 4u);  /* 100KB → class 4 */
-    EXPECT_EQ(mm::ArenaAllocator::size_class(5000000), 7u); /* 5MB → class 7 (BFC) */
+  EXPECT_EQ(mm::ArenaAllocator::size_class(100), 0u);    /* <1KB → class 0 */
+  EXPECT_EQ(mm::ArenaAllocator::size_class(1024), 1u);   /* 1KB → class 1 */
+  EXPECT_EQ(mm::ArenaAllocator::size_class(4096), 2u);   /* 4KB → class 2 */
+  EXPECT_EQ(mm::ArenaAllocator::size_class(100000), 4u); /* 100KB → class 4 */
+  EXPECT_EQ(mm::ArenaAllocator::size_class(5000000),
+            7u); /* 5MB → class 7 (BFC) */
 }
 
 TEST_F(ArenaTest, StepReset) {
-    void *p1 = arena.alloc(256);
-    ASSERT_NE(p1, nullptr);
-    size_t used_before = arena.used_bytes();
-    EXPECT_GT(used_before, 0u);
+  void *p1 = arena.alloc(256);
+  ASSERT_NE(p1, nullptr);
+  size_t used_before = arena.used_bytes();
+  EXPECT_GT(used_before, 0u);
 
-    arena.reset();
-    /* After reset, arena bump pointers are back to 0 */
-    /* (BFC allocations are not affected by reset) */
+  arena.reset();
+  /* After reset, arena bump pointers are back to 0 */
+  /* (BFC allocations are not affected by reset) */
 
-    void *p2 = arena.alloc(256);
-    ASSERT_NE(p2, nullptr);
-    /* p2 should reuse the same memory as p1 in the same class */
-    EXPECT_EQ(p1, p2);
+  void *p2 = arena.alloc(256);
+  ASSERT_NE(p2, nullptr);
+  /* p2 should reuse the same memory as p1 in the same class */
+  EXPECT_EQ(p1, p2);
 }
 
 TEST_F(ArenaTest, BfcFallbackForLargeAlloc) {
-    void *ptr = arena.alloc(8 * 1024 * 1024); /* 8 MB → BFC */
-    ASSERT_NE(ptr, nullptr);
-    arena.free(ptr, 8 * 1024 * 1024);
+  void *ptr = arena.alloc(8 * 1024 * 1024); /* 8 MB → BFC */
+  ASSERT_NE(ptr, nullptr);
+  arena.free(ptr, 8 * 1024 * 1024);
 }
 
 TEST_F(ArenaTest, ConcurrentBumpNoOverlap) {
-    constexpr int kThreads = 4;
-    constexpr int kAllocsPerThread = 50;
-    constexpr size_t kAllocSize = 256; /* Must be >= kDefaultAlignment to get unique bumps */
+  constexpr int kThreads = 4;
+  constexpr int kAllocsPerThread = 50;
+  constexpr size_t kAllocSize =
+      256; /* Must be >= kDefaultAlignment to get unique bumps */
 
-    std::vector<std::vector<void *>> results(kThreads);
-    std::vector<std::thread> threads;
+  std::vector<std::vector<void *>> results(kThreads);
+  std::vector<std::thread> threads;
 
-    for (int t = 0; t < kThreads; ++t) {
-        threads.emplace_back([this, &results, t, kAllocsPerThread, kAllocSize]() {
-            for (int i = 0; i < kAllocsPerThread; ++i) {
-                void *p = arena.alloc(kAllocSize);
-                ASSERT_NE(p, nullptr);
-                results[t].push_back(p);
-            }
-        });
+  for (int t = 0; t < kThreads; ++t) {
+    threads.emplace_back([this, &results, t, kAllocsPerThread, kAllocSize]() {
+      for (int i = 0; i < kAllocsPerThread; ++i) {
+        void *p = arena.alloc(kAllocSize);
+        ASSERT_NE(p, nullptr);
+        results[t].push_back(p);
+      }
+    });
+  }
+
+  for (auto &th : threads)
+    th.join();
+
+  /* Verify no two allocations overlap */
+  std::set<void *> all_ptrs;
+  for (const auto &vec : results) {
+    for (void *p : vec) {
+      auto [_, inserted] = all_ptrs.insert(p);
+      EXPECT_TRUE(inserted) << "Duplicate allocation pointer detected";
     }
-
-    for (auto &th : threads)
-        th.join();
-
-    /* Verify no two allocations overlap */
-    std::set<void *> all_ptrs;
-    for (const auto &vec : results) {
-        for (void *p : vec) {
-            auto [_, inserted] = all_ptrs.insert(p);
-            EXPECT_TRUE(inserted) << "Duplicate allocation pointer detected";
-        }
-    }
-    EXPECT_EQ(all_ptrs.size(), (size_t)(kThreads * kAllocsPerThread));
+  }
+  EXPECT_EQ(all_ptrs.size(), (size_t)(kThreads * kAllocsPerThread));
 }
 
 TEST_F(ArenaTest, UsedBytesTracking) {
-    size_t before = arena.used_bytes();
-    arena.alloc(1024);
-    size_t after = arena.used_bytes();
-    EXPECT_GT(after, before);
+  size_t before = arena.used_bytes();
+  arena.alloc(1024);
+  size_t after = arena.used_bytes();
+  EXPECT_GT(after, before);
 }

--- a/test/unit/mm/test_arena.cpp
+++ b/test/unit/mm/test_arena.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
 #include "mm_arena.h"
 #include "mm_hal.h"
 #include <gtest/gtest.h>

--- a/test/unit/mm/test_block_table.cpp
+++ b/test/unit/mm/test_block_table.cpp
@@ -1,0 +1,122 @@
+#include "mm_block_table.h"
+#include "mm_config.h"
+#include "mm_hal.h"
+#include "mm_kv.h"
+#include <gtest/gtest.h>
+#include <cstring>
+
+class BlockTableTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        mm_hal_register(mm_hal_host_get());
+        mm_config_t config = {};
+        config.gpu_memory_limit = 64 * 1024 * 1024;
+        config.kv_cache_fraction = 0.5f;
+        config.kv_block_size_tokens = 16;
+        config.num_size_classes = 4;
+        config.high_watermark = 0.90f;
+        config.critical_watermark = 0.95f;
+        config.default_kv_format = MM_KV_FMT_FP16;
+        ASSERT_EQ(mm_init(&config), MM_OK);
+    }
+    void TearDown() override { mm_shutdown(); }
+
+    mm_kv_block_desc_t make_desc() {
+        mm_kv_block_desc_t desc = {};
+        desc.format = MM_KV_FMT_FP16;
+        desc.block_size_tokens = 16;
+        desc.num_kv_heads = 4;
+        desc.head_dim = 128;
+        return desc;
+    }
+};
+
+TEST_F(BlockTableTest, BuildTable) {
+    mm::BlockTable table;
+    EXPECT_EQ(table.size(), 0u);
+
+    mm_kv_block_t blk1 = mm_kv_alloc_block(make_desc(), 0);
+    mm_kv_block_t blk2 = mm_kv_alloc_block(make_desc(), 0);
+    ASSERT_NE(blk1, MM_INVALID_BLOCK);
+    ASSERT_NE(blk2, MM_INVALID_BLOCK);
+
+    table.add_block(mm_kv_get_block_ptr(blk1));
+    table.add_block(mm_kv_get_block_ptr(blk2));
+
+    EXPECT_EQ(table.size(), 2u);
+    EXPECT_NE(table.data(), nullptr);
+    EXPECT_NE(table.data()[0], nullptr);
+    EXPECT_NE(table.data()[1], nullptr);
+    EXPECT_NE(table.data()[0], table.data()[1]);
+
+    mm_kv_free_block(blk1, 0);
+    mm_kv_free_block(blk2, 0);
+}
+
+TEST_F(BlockTableTest, ClearTable) {
+    mm::BlockTable table;
+
+    mm_kv_block_t blk = mm_kv_alloc_block(make_desc(), 0);
+    ASSERT_NE(blk, MM_INVALID_BLOCK);
+
+    table.add_block(mm_kv_get_block_ptr(blk));
+    EXPECT_EQ(table.size(), 1u);
+
+    table.clear();
+    EXPECT_EQ(table.size(), 0u);
+
+    mm_kv_free_block(blk, 0);
+}
+
+TEST_F(BlockTableTest, MaterializeContiguous) {
+    /* Allocate 3 blocks and write distinct patterns */
+    constexpr int N = 3;
+    mm_kv_block_t blocks[N];
+    for (int i = 0; i < N; ++i) {
+        blocks[i] = mm_kv_alloc_block(make_desc(), 0);
+        ASSERT_NE(blocks[i], MM_INVALID_BLOCK);
+        /* Write pattern: block 0 = 0xAA, block 1 = 0xBB, block 2 = 0xCC */
+        void *ptr = mm_kv_get_block_ptr(blocks[i]);
+        ASSERT_NE(ptr, nullptr);
+        std::memset(ptr, 0xAA + i * 0x11, 256);
+    }
+
+    /* Build block table */
+    mm::BlockTable table;
+    for (int i = 0; i < N; ++i)
+        table.add_block(mm_kv_get_block_ptr(blocks[i]));
+
+    /* Materialize into contiguous buffer */
+    size_t block_size = 256;
+    std::vector<unsigned char> dst(N * block_size, 0);
+    const mm_hal_t *hal = mm_hal_host_get();
+    int err = table.materialize_contiguous(dst.data(), block_size, hal, 0);
+    EXPECT_EQ(err, MM_OK);
+
+    /* Verify patterns are contiguous */
+    EXPECT_EQ(dst[0], 0xAA);
+    EXPECT_EQ(dst[block_size], 0xBB);
+    EXPECT_EQ(dst[2 * block_size], 0xCC);
+
+    for (int i = 0; i < N; ++i)
+        mm_kv_free_block(blocks[i], 0);
+}
+
+TEST_F(BlockTableTest, GetBlockTableAPI) {
+    constexpr int N = 4;
+    mm_kv_block_t blocks[N];
+    for (int i = 0; i < N; ++i) {
+        blocks[i] = mm_kv_alloc_block(make_desc(), 0);
+        ASSERT_NE(blocks[i], MM_INVALID_BLOCK);
+    }
+
+    void **table = mm_kv_get_block_table(blocks, N, MM_DEVICE_GPU_0);
+    ASSERT_NE(table, nullptr);
+
+    for (int i = 0; i < N; ++i)
+        EXPECT_NE(table[i], nullptr);
+
+    free(table);
+    for (int i = 0; i < N; ++i)
+        mm_kv_free_block(blocks[i], 0);
+}

--- a/test/unit/mm/test_block_table.cpp
+++ b/test/unit/mm/test_block_table.cpp
@@ -2,121 +2,121 @@
 #include "mm_config.h"
 #include "mm_hal.h"
 #include "mm_kv.h"
-#include <gtest/gtest.h>
 #include <cstring>
+#include <gtest/gtest.h>
 
 class BlockTableTest : public ::testing::Test {
 protected:
-    void SetUp() override {
-        mm_hal_register(mm_hal_host_get());
-        mm_config_t config = {};
-        config.gpu_memory_limit = 64 * 1024 * 1024;
-        config.kv_cache_fraction = 0.5f;
-        config.kv_block_size_tokens = 16;
-        config.num_size_classes = 4;
-        config.high_watermark = 0.90f;
-        config.critical_watermark = 0.95f;
-        config.default_kv_format = MM_KV_FMT_FP16;
-        ASSERT_EQ(mm_init(&config), MM_OK);
-    }
-    void TearDown() override { mm_shutdown(); }
+  void SetUp() override {
+    mm_hal_register(mm_hal_host_get());
+    mm_config_t config = {};
+    config.gpu_memory_limit = 64 * 1024 * 1024;
+    config.kv_cache_fraction = 0.5f;
+    config.kv_block_size_tokens = 16;
+    config.num_size_classes = 4;
+    config.high_watermark = 0.90f;
+    config.critical_watermark = 0.95f;
+    config.default_kv_format = MM_KV_FMT_FP16;
+    ASSERT_EQ(mm_init(&config), MM_OK);
+  }
+  void TearDown() override { mm_shutdown(); }
 
-    mm_kv_block_desc_t make_desc() {
-        mm_kv_block_desc_t desc = {};
-        desc.format = MM_KV_FMT_FP16;
-        desc.block_size_tokens = 16;
-        desc.num_kv_heads = 4;
-        desc.head_dim = 128;
-        return desc;
-    }
+  mm_kv_block_desc_t make_desc() {
+    mm_kv_block_desc_t desc = {};
+    desc.format = MM_KV_FMT_FP16;
+    desc.block_size_tokens = 16;
+    desc.num_kv_heads = 4;
+    desc.head_dim = 128;
+    return desc;
+  }
 };
 
 TEST_F(BlockTableTest, BuildTable) {
-    mm::BlockTable table;
-    EXPECT_EQ(table.size(), 0u);
+  mm::BlockTable table;
+  EXPECT_EQ(table.size(), 0u);
 
-    mm_kv_block_t blk1 = mm_kv_alloc_block(make_desc(), 0);
-    mm_kv_block_t blk2 = mm_kv_alloc_block(make_desc(), 0);
-    ASSERT_NE(blk1, MM_INVALID_BLOCK);
-    ASSERT_NE(blk2, MM_INVALID_BLOCK);
+  mm_kv_block_t blk1 = mm_kv_alloc_block(make_desc(), 0);
+  mm_kv_block_t blk2 = mm_kv_alloc_block(make_desc(), 0);
+  ASSERT_NE(blk1, MM_INVALID_BLOCK);
+  ASSERT_NE(blk2, MM_INVALID_BLOCK);
 
-    table.add_block(mm_kv_get_block_ptr(blk1));
-    table.add_block(mm_kv_get_block_ptr(blk2));
+  table.add_block(mm_kv_get_block_ptr(blk1));
+  table.add_block(mm_kv_get_block_ptr(blk2));
 
-    EXPECT_EQ(table.size(), 2u);
-    EXPECT_NE(table.data(), nullptr);
-    EXPECT_NE(table.data()[0], nullptr);
-    EXPECT_NE(table.data()[1], nullptr);
-    EXPECT_NE(table.data()[0], table.data()[1]);
+  EXPECT_EQ(table.size(), 2u);
+  EXPECT_NE(table.data(), nullptr);
+  EXPECT_NE(table.data()[0], nullptr);
+  EXPECT_NE(table.data()[1], nullptr);
+  EXPECT_NE(table.data()[0], table.data()[1]);
 
-    mm_kv_free_block(blk1, 0);
-    mm_kv_free_block(blk2, 0);
+  mm_kv_free_block(blk1, 0);
+  mm_kv_free_block(blk2, 0);
 }
 
 TEST_F(BlockTableTest, ClearTable) {
-    mm::BlockTable table;
+  mm::BlockTable table;
 
-    mm_kv_block_t blk = mm_kv_alloc_block(make_desc(), 0);
-    ASSERT_NE(blk, MM_INVALID_BLOCK);
+  mm_kv_block_t blk = mm_kv_alloc_block(make_desc(), 0);
+  ASSERT_NE(blk, MM_INVALID_BLOCK);
 
-    table.add_block(mm_kv_get_block_ptr(blk));
-    EXPECT_EQ(table.size(), 1u);
+  table.add_block(mm_kv_get_block_ptr(blk));
+  EXPECT_EQ(table.size(), 1u);
 
-    table.clear();
-    EXPECT_EQ(table.size(), 0u);
+  table.clear();
+  EXPECT_EQ(table.size(), 0u);
 
-    mm_kv_free_block(blk, 0);
+  mm_kv_free_block(blk, 0);
 }
 
 TEST_F(BlockTableTest, MaterializeContiguous) {
-    /* Allocate 3 blocks and write distinct patterns */
-    constexpr int N = 3;
-    mm_kv_block_t blocks[N];
-    for (int i = 0; i < N; ++i) {
-        blocks[i] = mm_kv_alloc_block(make_desc(), 0);
-        ASSERT_NE(blocks[i], MM_INVALID_BLOCK);
-        /* Write pattern: block 0 = 0xAA, block 1 = 0xBB, block 2 = 0xCC */
-        void *ptr = mm_kv_get_block_ptr(blocks[i]);
-        ASSERT_NE(ptr, nullptr);
-        std::memset(ptr, 0xAA + i * 0x11, 256);
-    }
+  /* Allocate 3 blocks and write distinct patterns */
+  constexpr int N = 3;
+  mm_kv_block_t blocks[N];
+  for (int i = 0; i < N; ++i) {
+    blocks[i] = mm_kv_alloc_block(make_desc(), 0);
+    ASSERT_NE(blocks[i], MM_INVALID_BLOCK);
+    /* Write pattern: block 0 = 0xAA, block 1 = 0xBB, block 2 = 0xCC */
+    void *ptr = mm_kv_get_block_ptr(blocks[i]);
+    ASSERT_NE(ptr, nullptr);
+    std::memset(ptr, 0xAA + i * 0x11, 256);
+  }
 
-    /* Build block table */
-    mm::BlockTable table;
-    for (int i = 0; i < N; ++i)
-        table.add_block(mm_kv_get_block_ptr(blocks[i]));
+  /* Build block table */
+  mm::BlockTable table;
+  for (int i = 0; i < N; ++i)
+    table.add_block(mm_kv_get_block_ptr(blocks[i]));
 
-    /* Materialize into contiguous buffer */
-    size_t block_size = 256;
-    std::vector<unsigned char> dst(N * block_size, 0);
-    const mm_hal_t *hal = mm_hal_host_get();
-    int err = table.materialize_contiguous(dst.data(), block_size, hal, 0);
-    EXPECT_EQ(err, MM_OK);
+  /* Materialize into contiguous buffer */
+  size_t block_size = 256;
+  std::vector<unsigned char> dst(N * block_size, 0);
+  const mm_hal_t *hal = mm_hal_host_get();
+  int err = table.materialize_contiguous(dst.data(), block_size, hal, 0);
+  EXPECT_EQ(err, MM_OK);
 
-    /* Verify patterns are contiguous */
-    EXPECT_EQ(dst[0], 0xAA);
-    EXPECT_EQ(dst[block_size], 0xBB);
-    EXPECT_EQ(dst[2 * block_size], 0xCC);
+  /* Verify patterns are contiguous */
+  EXPECT_EQ(dst[0], 0xAA);
+  EXPECT_EQ(dst[block_size], 0xBB);
+  EXPECT_EQ(dst[2 * block_size], 0xCC);
 
-    for (int i = 0; i < N; ++i)
-        mm_kv_free_block(blocks[i], 0);
+  for (int i = 0; i < N; ++i)
+    mm_kv_free_block(blocks[i], 0);
 }
 
 TEST_F(BlockTableTest, GetBlockTableAPI) {
-    constexpr int N = 4;
-    mm_kv_block_t blocks[N];
-    for (int i = 0; i < N; ++i) {
-        blocks[i] = mm_kv_alloc_block(make_desc(), 0);
-        ASSERT_NE(blocks[i], MM_INVALID_BLOCK);
-    }
+  constexpr int N = 4;
+  mm_kv_block_t blocks[N];
+  for (int i = 0; i < N; ++i) {
+    blocks[i] = mm_kv_alloc_block(make_desc(), 0);
+    ASSERT_NE(blocks[i], MM_INVALID_BLOCK);
+  }
 
-    void **table = mm_kv_get_block_table(blocks, N, MM_DEVICE_GPU_0);
-    ASSERT_NE(table, nullptr);
+  void **table = mm_kv_get_block_table(blocks, N, MM_DEVICE_GPU_0);
+  ASSERT_NE(table, nullptr);
 
-    for (int i = 0; i < N; ++i)
-        EXPECT_NE(table[i], nullptr);
+  for (int i = 0; i < N; ++i)
+    EXPECT_NE(table[i], nullptr);
 
-    free(table);
-    for (int i = 0; i < N; ++i)
-        mm_kv_free_block(blocks[i], 0);
+  free(table);
+  for (int i = 0; i < N; ++i)
+    mm_kv_free_block(blocks[i], 0);
 }

--- a/test/unit/mm/test_block_table.cpp
+++ b/test/unit/mm/test_block_table.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
 #include "mm_block_table.h"
 #include "mm_config.h"
 #include "mm_hal.h"

--- a/test/unit/mm/test_core.cpp
+++ b/test/unit/mm/test_core.cpp
@@ -1,132 +1,132 @@
 #include "mm_config.h"
 #include "mm_core.h"
 #include "mm_hal.h"
-#include <gtest/gtest.h>
 #include <cstring>
+#include <gtest/gtest.h>
 
 class CoreTest : public ::testing::Test {
 protected:
-    void SetUp() override {
-        mm_hal_register(mm_hal_host_get());
-        mm_config_t config = {};
-        config.gpu_memory_limit = 64 * 1024 * 1024;
-        config.kv_cache_fraction = 0.5f;
-        config.num_size_classes = 8;
-        config.high_watermark = 0.90f;
-        config.critical_watermark = 0.95f;
-        ASSERT_EQ(mm_init(&config), MM_OK);
-    }
-    void TearDown() override { mm_shutdown(); }
+  void SetUp() override {
+    mm_hal_register(mm_hal_host_get());
+    mm_config_t config = {};
+    config.gpu_memory_limit = 64 * 1024 * 1024;
+    config.kv_cache_fraction = 0.5f;
+    config.num_size_classes = 8;
+    config.high_watermark = 0.90f;
+    config.critical_watermark = 0.95f;
+    ASSERT_EQ(mm_init(&config), MM_OK);
+  }
+  void TearDown() override { mm_shutdown(); }
 };
 
 TEST_F(CoreTest, AllocFreeActivation) {
-    mm_alloc_hints_t hints = {};
-    hints.mem_class = MM_CLASS_ACTIVATION;
-    hints.lifetime = MM_LIFETIME_STEP;
+  mm_alloc_hints_t hints = {};
+  hints.mem_class = MM_CLASS_ACTIVATION;
+  hints.lifetime = MM_LIFETIME_STEP;
 
-    mm_handle_t h = mm_alloc(4096, hints, 0);
-    ASSERT_NE(h, MM_INVALID_HANDLE);
+  mm_handle_t h = mm_alloc(4096, hints, 0);
+  ASSERT_NE(h, MM_INVALID_HANDLE);
 
-    void *ptr = mm_get_ptr(h, MM_DEVICE_GPU_0);
-    ASSERT_NE(ptr, nullptr);
+  void *ptr = mm_get_ptr(h, MM_DEVICE_GPU_0);
+  ASSERT_NE(ptr, nullptr);
 
-    /* Write and verify */
-    std::memset(ptr, 0xCD, 4096);
-    EXPECT_EQ(static_cast<unsigned char *>(ptr)[0], 0xCD);
+  /* Write and verify */
+  std::memset(ptr, 0xCD, 4096);
+  EXPECT_EQ(static_cast<unsigned char *>(ptr)[0], 0xCD);
 
-    mm_free(h, 0);
+  mm_free(h, 0);
 }
 
 TEST_F(CoreTest, AllocFreeScratch) {
-    mm_alloc_hints_t hints = {};
-    hints.mem_class = MM_CLASS_SCRATCH;
-    hints.lifetime = MM_LIFETIME_TRANSIENT;
+  mm_alloc_hints_t hints = {};
+  hints.mem_class = MM_CLASS_SCRATCH;
+  hints.lifetime = MM_LIFETIME_TRANSIENT;
 
-    mm_handle_t h = mm_alloc(2048, hints, 0);
-    ASSERT_NE(h, MM_INVALID_HANDLE);
+  mm_handle_t h = mm_alloc(2048, hints, 0);
+  ASSERT_NE(h, MM_INVALID_HANDLE);
 
-    void *ptr = mm_get_ptr(h, MM_DEVICE_GPU_0);
-    ASSERT_NE(ptr, nullptr);
+  void *ptr = mm_get_ptr(h, MM_DEVICE_GPU_0);
+  ASSERT_NE(ptr, nullptr);
 
-    mm_free(h, 0);
+  mm_free(h, 0);
 }
 
 TEST_F(CoreTest, AllocWeightFails) {
-    mm_alloc_hints_t hints = {};
-    hints.mem_class = MM_CLASS_WEIGHT;
-    mm_handle_t h = mm_alloc(1024, hints, 0);
-    EXPECT_EQ(h, MM_INVALID_HANDLE);
+  mm_alloc_hints_t hints = {};
+  hints.mem_class = MM_CLASS_WEIGHT;
+  mm_handle_t h = mm_alloc(1024, hints, 0);
+  EXPECT_EQ(h, MM_INVALID_HANDLE);
 }
 
 TEST_F(CoreTest, AllocKvCacheFails) {
-    mm_alloc_hints_t hints = {};
-    hints.mem_class = MM_CLASS_KV_CACHE;
-    mm_handle_t h = mm_alloc(1024, hints, 0);
-    EXPECT_EQ(h, MM_INVALID_HANDLE);
+  mm_alloc_hints_t hints = {};
+  hints.mem_class = MM_CLASS_KV_CACHE;
+  mm_handle_t h = mm_alloc(1024, hints, 0);
+  EXPECT_EQ(h, MM_INVALID_HANDLE);
 }
 
 TEST_F(CoreTest, QueryInfo) {
-    mm_alloc_hints_t hints = {};
-    hints.mem_class = MM_CLASS_ACTIVATION;
-    hints.lifetime = MM_LIFETIME_STEP;
+  mm_alloc_hints_t hints = {};
+  hints.mem_class = MM_CLASS_ACTIVATION;
+  hints.lifetime = MM_LIFETIME_STEP;
 
-    mm_handle_t h = mm_alloc(8192, hints, 0);
-    ASSERT_NE(h, MM_INVALID_HANDLE);
+  mm_handle_t h = mm_alloc(8192, hints, 0);
+  ASSERT_NE(h, MM_INVALID_HANDLE);
 
-    mm_alloc_info_t info = mm_query(h);
-    EXPECT_EQ(info.mem_class, MM_CLASS_ACTIVATION);
-    EXPECT_EQ(info.size, 8192u);
-    EXPECT_EQ(info.ref_count, 1u);
-    EXPECT_EQ(info.current_tier, MM_TIER_HBM);
+  mm_alloc_info_t info = mm_query(h);
+  EXPECT_EQ(info.mem_class, MM_CLASS_ACTIVATION);
+  EXPECT_EQ(info.size, 8192u);
+  EXPECT_EQ(info.ref_count, 1u);
+  EXPECT_EQ(info.current_tier, MM_TIER_HBM);
 
-    mm_free(h, 0);
+  mm_free(h, 0);
 }
 
 TEST_F(CoreTest, GetPtrAfterFreeReturnsNull) {
-    mm_alloc_hints_t hints = {};
-    hints.mem_class = MM_CLASS_ACTIVATION;
+  mm_alloc_hints_t hints = {};
+  hints.mem_class = MM_CLASS_ACTIVATION;
 
-    mm_handle_t h = mm_alloc(1024, hints, 0);
-    ASSERT_NE(h, MM_INVALID_HANDLE);
+  mm_handle_t h = mm_alloc(1024, hints, 0);
+  ASSERT_NE(h, MM_INVALID_HANDLE);
 
-    mm_free(h, 0);
-    EXPECT_EQ(mm_get_ptr(h, MM_DEVICE_GPU_0), nullptr);
+  mm_free(h, 0);
+  EXPECT_EQ(mm_get_ptr(h, MM_DEVICE_GPU_0), nullptr);
 }
 
 TEST_F(CoreTest, InvalidHandleGetPtrReturnsNull) {
-    EXPECT_EQ(mm_get_ptr(MM_INVALID_HANDLE, MM_DEVICE_GPU_0), nullptr);
-    EXPECT_EQ(mm_get_ptr(9999, MM_DEVICE_GPU_0), nullptr);
+  EXPECT_EQ(mm_get_ptr(MM_INVALID_HANDLE, MM_DEVICE_GPU_0), nullptr);
+  EXPECT_EQ(mm_get_ptr(9999, MM_DEVICE_GPU_0), nullptr);
 }
 
 TEST_F(CoreTest, LargeAllocBfcFallback) {
-    mm_alloc_hints_t hints = {};
-    hints.mem_class = MM_CLASS_SCRATCH;
-    hints.lifetime = MM_LIFETIME_REQUEST;
+  mm_alloc_hints_t hints = {};
+  hints.mem_class = MM_CLASS_SCRATCH;
+  hints.lifetime = MM_LIFETIME_REQUEST;
 
-    /* 8 MB should go through BFC */
-    mm_handle_t h = mm_alloc(8 * 1024 * 1024, hints, 0);
-    ASSERT_NE(h, MM_INVALID_HANDLE);
+  /* 8 MB should go through BFC */
+  mm_handle_t h = mm_alloc(8 * 1024 * 1024, hints, 0);
+  ASSERT_NE(h, MM_INVALID_HANDLE);
 
-    void *ptr = mm_get_ptr(h, MM_DEVICE_GPU_0);
-    ASSERT_NE(ptr, nullptr);
+  void *ptr = mm_get_ptr(h, MM_DEVICE_GPU_0);
+  ASSERT_NE(ptr, nullptr);
 
-    mm_free(h, 0);
+  mm_free(h, 0);
 }
 
 TEST_F(CoreTest, MultipleAllocsDifferentPointers) {
-    mm_alloc_hints_t hints = {};
-    hints.mem_class = MM_CLASS_ACTIVATION;
+  mm_alloc_hints_t hints = {};
+  hints.mem_class = MM_CLASS_ACTIVATION;
 
-    mm_handle_t h1 = mm_alloc(1024, hints, 0);
-    mm_handle_t h2 = mm_alloc(1024, hints, 0);
-    ASSERT_NE(h1, MM_INVALID_HANDLE);
-    ASSERT_NE(h2, MM_INVALID_HANDLE);
-    EXPECT_NE(h1, h2);
+  mm_handle_t h1 = mm_alloc(1024, hints, 0);
+  mm_handle_t h2 = mm_alloc(1024, hints, 0);
+  ASSERT_NE(h1, MM_INVALID_HANDLE);
+  ASSERT_NE(h2, MM_INVALID_HANDLE);
+  EXPECT_NE(h1, h2);
 
-    void *p1 = mm_get_ptr(h1, MM_DEVICE_GPU_0);
-    void *p2 = mm_get_ptr(h2, MM_DEVICE_GPU_0);
-    EXPECT_NE(p1, p2);
+  void *p1 = mm_get_ptr(h1, MM_DEVICE_GPU_0);
+  void *p2 = mm_get_ptr(h2, MM_DEVICE_GPU_0);
+  EXPECT_NE(p1, p2);
 
-    mm_free(h1, 0);
-    mm_free(h2, 0);
+  mm_free(h1, 0);
+  mm_free(h2, 0);
 }

--- a/test/unit/mm/test_core.cpp
+++ b/test/unit/mm/test_core.cpp
@@ -1,0 +1,132 @@
+#include "mm_config.h"
+#include "mm_core.h"
+#include "mm_hal.h"
+#include <gtest/gtest.h>
+#include <cstring>
+
+class CoreTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        mm_hal_register(mm_hal_host_get());
+        mm_config_t config = {};
+        config.gpu_memory_limit = 64 * 1024 * 1024;
+        config.kv_cache_fraction = 0.5f;
+        config.num_size_classes = 8;
+        config.high_watermark = 0.90f;
+        config.critical_watermark = 0.95f;
+        ASSERT_EQ(mm_init(&config), MM_OK);
+    }
+    void TearDown() override { mm_shutdown(); }
+};
+
+TEST_F(CoreTest, AllocFreeActivation) {
+    mm_alloc_hints_t hints = {};
+    hints.mem_class = MM_CLASS_ACTIVATION;
+    hints.lifetime = MM_LIFETIME_STEP;
+
+    mm_handle_t h = mm_alloc(4096, hints, 0);
+    ASSERT_NE(h, MM_INVALID_HANDLE);
+
+    void *ptr = mm_get_ptr(h, MM_DEVICE_GPU_0);
+    ASSERT_NE(ptr, nullptr);
+
+    /* Write and verify */
+    std::memset(ptr, 0xCD, 4096);
+    EXPECT_EQ(static_cast<unsigned char *>(ptr)[0], 0xCD);
+
+    mm_free(h, 0);
+}
+
+TEST_F(CoreTest, AllocFreeScratch) {
+    mm_alloc_hints_t hints = {};
+    hints.mem_class = MM_CLASS_SCRATCH;
+    hints.lifetime = MM_LIFETIME_TRANSIENT;
+
+    mm_handle_t h = mm_alloc(2048, hints, 0);
+    ASSERT_NE(h, MM_INVALID_HANDLE);
+
+    void *ptr = mm_get_ptr(h, MM_DEVICE_GPU_0);
+    ASSERT_NE(ptr, nullptr);
+
+    mm_free(h, 0);
+}
+
+TEST_F(CoreTest, AllocWeightFails) {
+    mm_alloc_hints_t hints = {};
+    hints.mem_class = MM_CLASS_WEIGHT;
+    mm_handle_t h = mm_alloc(1024, hints, 0);
+    EXPECT_EQ(h, MM_INVALID_HANDLE);
+}
+
+TEST_F(CoreTest, AllocKvCacheFails) {
+    mm_alloc_hints_t hints = {};
+    hints.mem_class = MM_CLASS_KV_CACHE;
+    mm_handle_t h = mm_alloc(1024, hints, 0);
+    EXPECT_EQ(h, MM_INVALID_HANDLE);
+}
+
+TEST_F(CoreTest, QueryInfo) {
+    mm_alloc_hints_t hints = {};
+    hints.mem_class = MM_CLASS_ACTIVATION;
+    hints.lifetime = MM_LIFETIME_STEP;
+
+    mm_handle_t h = mm_alloc(8192, hints, 0);
+    ASSERT_NE(h, MM_INVALID_HANDLE);
+
+    mm_alloc_info_t info = mm_query(h);
+    EXPECT_EQ(info.mem_class, MM_CLASS_ACTIVATION);
+    EXPECT_EQ(info.size, 8192u);
+    EXPECT_EQ(info.ref_count, 1u);
+    EXPECT_EQ(info.current_tier, MM_TIER_HBM);
+
+    mm_free(h, 0);
+}
+
+TEST_F(CoreTest, GetPtrAfterFreeReturnsNull) {
+    mm_alloc_hints_t hints = {};
+    hints.mem_class = MM_CLASS_ACTIVATION;
+
+    mm_handle_t h = mm_alloc(1024, hints, 0);
+    ASSERT_NE(h, MM_INVALID_HANDLE);
+
+    mm_free(h, 0);
+    EXPECT_EQ(mm_get_ptr(h, MM_DEVICE_GPU_0), nullptr);
+}
+
+TEST_F(CoreTest, InvalidHandleGetPtrReturnsNull) {
+    EXPECT_EQ(mm_get_ptr(MM_INVALID_HANDLE, MM_DEVICE_GPU_0), nullptr);
+    EXPECT_EQ(mm_get_ptr(9999, MM_DEVICE_GPU_0), nullptr);
+}
+
+TEST_F(CoreTest, LargeAllocBfcFallback) {
+    mm_alloc_hints_t hints = {};
+    hints.mem_class = MM_CLASS_SCRATCH;
+    hints.lifetime = MM_LIFETIME_REQUEST;
+
+    /* 8 MB should go through BFC */
+    mm_handle_t h = mm_alloc(8 * 1024 * 1024, hints, 0);
+    ASSERT_NE(h, MM_INVALID_HANDLE);
+
+    void *ptr = mm_get_ptr(h, MM_DEVICE_GPU_0);
+    ASSERT_NE(ptr, nullptr);
+
+    mm_free(h, 0);
+}
+
+TEST_F(CoreTest, MultipleAllocsDifferentPointers) {
+    mm_alloc_hints_t hints = {};
+    hints.mem_class = MM_CLASS_ACTIVATION;
+
+    mm_handle_t h1 = mm_alloc(1024, hints, 0);
+    mm_handle_t h2 = mm_alloc(1024, hints, 0);
+    ASSERT_NE(h1, MM_INVALID_HANDLE);
+    ASSERT_NE(h2, MM_INVALID_HANDLE);
+    EXPECT_NE(h1, h2);
+
+    void *p1 = mm_get_ptr(h1, MM_DEVICE_GPU_0);
+    void *p2 = mm_get_ptr(h2, MM_DEVICE_GPU_0);
+    EXPECT_NE(p1, p2);
+
+    mm_free(h1, 0);
+    mm_free(h2, 0);
+}

--- a/test/unit/mm/test_core.cpp
+++ b/test/unit/mm/test_core.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
 #include "mm_config.h"
 #include "mm_core.h"
 #include "mm_hal.h"

--- a/test/unit/mm/test_free_list.cpp
+++ b/test/unit/mm/test_free_list.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
 #include "mm_free_list.h"
 #include <gtest/gtest.h>
 #include <set>

--- a/test/unit/mm/test_free_list.cpp
+++ b/test/unit/mm/test_free_list.cpp
@@ -1,0 +1,94 @@
+#include "mm_free_list.h"
+#include <gtest/gtest.h>
+#include <set>
+#include <thread>
+#include <vector>
+
+TEST(FreeListTest, PushPopLifo) {
+    mm::FreeList fl;
+    fl.init(16);
+
+    fl.push(10);
+    fl.push(20);
+    fl.push(30);
+
+    EXPECT_EQ(fl.pop(), 30u);
+    EXPECT_EQ(fl.pop(), 20u);
+    EXPECT_EQ(fl.pop(), 10u);
+
+    fl.shutdown();
+}
+
+TEST(FreeListTest, PopEmptyReturnsMax) {
+    mm::FreeList fl;
+    fl.init(4);
+
+    EXPECT_EQ(fl.pop(), UINT32_MAX);
+
+    fl.shutdown();
+}
+
+TEST(FreeListTest, CountTracking) {
+    mm::FreeList fl;
+    fl.init(16);
+
+    EXPECT_EQ(fl.count(), 0u);
+    fl.push(1);
+    fl.push(2);
+    EXPECT_EQ(fl.count(), 2u);
+
+    fl.pop();
+    EXPECT_EQ(fl.count(), 1u);
+
+    fl.pop();
+    EXPECT_EQ(fl.count(), 0u);
+    EXPECT_TRUE(fl.empty());
+
+    fl.shutdown();
+}
+
+TEST(FreeListTest, ConcurrentPushPop) {
+    mm::FreeList fl;
+    constexpr uint32_t kPerThread = 1000;
+    constexpr int kThreads = 4;
+    fl.init(kPerThread * kThreads);
+
+    /* Push kPerThread * kThreads items */
+    std::vector<std::thread> pushers;
+    for (int t = 0; t < kThreads; ++t) {
+        pushers.emplace_back([&fl, t, kPerThread]() {
+            for (uint32_t i = 0; i < kPerThread; ++i) {
+                EXPECT_TRUE(fl.push(t * kPerThread + i));
+            }
+        });
+    }
+    for (auto &th : pushers)
+        th.join();
+
+    EXPECT_EQ(fl.count(), kPerThread * kThreads);
+
+    /* Pop all items concurrently */
+    std::vector<std::vector<uint32_t>> results(kThreads);
+    std::vector<std::thread> poppers;
+    for (int t = 0; t < kThreads; ++t) {
+        poppers.emplace_back([&fl, &results, t, kPerThread]() {
+            for (uint32_t i = 0; i < kPerThread; ++i) {
+                uint32_t val = fl.pop();
+                if (val != UINT32_MAX)
+                    results[t].push_back(val);
+            }
+        });
+    }
+    for (auto &th : poppers)
+        th.join();
+
+    /* Verify no duplicates */
+    std::set<uint32_t> all;
+    for (const auto &v : results)
+        for (uint32_t x : v)
+            all.insert(x);
+
+    EXPECT_EQ(all.size(), (size_t)(kPerThread * kThreads));
+
+    fl.shutdown();
+}

--- a/test/unit/mm/test_free_list.cpp
+++ b/test/unit/mm/test_free_list.cpp
@@ -5,90 +5,90 @@
 #include <vector>
 
 TEST(FreeListTest, PushPopLifo) {
-    mm::FreeList fl;
-    fl.init(16);
+  mm::FreeList fl;
+  fl.init(16);
 
-    fl.push(10);
-    fl.push(20);
-    fl.push(30);
+  fl.push(10);
+  fl.push(20);
+  fl.push(30);
 
-    EXPECT_EQ(fl.pop(), 30u);
-    EXPECT_EQ(fl.pop(), 20u);
-    EXPECT_EQ(fl.pop(), 10u);
+  EXPECT_EQ(fl.pop(), 30u);
+  EXPECT_EQ(fl.pop(), 20u);
+  EXPECT_EQ(fl.pop(), 10u);
 
-    fl.shutdown();
+  fl.shutdown();
 }
 
 TEST(FreeListTest, PopEmptyReturnsMax) {
-    mm::FreeList fl;
-    fl.init(4);
+  mm::FreeList fl;
+  fl.init(4);
 
-    EXPECT_EQ(fl.pop(), UINT32_MAX);
+  EXPECT_EQ(fl.pop(), UINT32_MAX);
 
-    fl.shutdown();
+  fl.shutdown();
 }
 
 TEST(FreeListTest, CountTracking) {
-    mm::FreeList fl;
-    fl.init(16);
+  mm::FreeList fl;
+  fl.init(16);
 
-    EXPECT_EQ(fl.count(), 0u);
-    fl.push(1);
-    fl.push(2);
-    EXPECT_EQ(fl.count(), 2u);
+  EXPECT_EQ(fl.count(), 0u);
+  fl.push(1);
+  fl.push(2);
+  EXPECT_EQ(fl.count(), 2u);
 
-    fl.pop();
-    EXPECT_EQ(fl.count(), 1u);
+  fl.pop();
+  EXPECT_EQ(fl.count(), 1u);
 
-    fl.pop();
-    EXPECT_EQ(fl.count(), 0u);
-    EXPECT_TRUE(fl.empty());
+  fl.pop();
+  EXPECT_EQ(fl.count(), 0u);
+  EXPECT_TRUE(fl.empty());
 
-    fl.shutdown();
+  fl.shutdown();
 }
 
 TEST(FreeListTest, ConcurrentPushPop) {
-    mm::FreeList fl;
-    constexpr uint32_t kPerThread = 1000;
-    constexpr int kThreads = 4;
-    fl.init(kPerThread * kThreads);
+  mm::FreeList fl;
+  constexpr uint32_t kPerThread = 1000;
+  constexpr int kThreads = 4;
+  fl.init(kPerThread * kThreads);
 
-    /* Push kPerThread * kThreads items */
-    std::vector<std::thread> pushers;
-    for (int t = 0; t < kThreads; ++t) {
-        pushers.emplace_back([&fl, t, kPerThread]() {
-            for (uint32_t i = 0; i < kPerThread; ++i) {
-                EXPECT_TRUE(fl.push(t * kPerThread + i));
-            }
-        });
-    }
-    for (auto &th : pushers)
-        th.join();
+  /* Push kPerThread * kThreads items */
+  std::vector<std::thread> pushers;
+  for (int t = 0; t < kThreads; ++t) {
+    pushers.emplace_back([&fl, t, kPerThread]() {
+      for (uint32_t i = 0; i < kPerThread; ++i) {
+        EXPECT_TRUE(fl.push(t * kPerThread + i));
+      }
+    });
+  }
+  for (auto &th : pushers)
+    th.join();
 
-    EXPECT_EQ(fl.count(), kPerThread * kThreads);
+  EXPECT_EQ(fl.count(), kPerThread * kThreads);
 
-    /* Pop all items concurrently */
-    std::vector<std::vector<uint32_t>> results(kThreads);
-    std::vector<std::thread> poppers;
-    for (int t = 0; t < kThreads; ++t) {
-        poppers.emplace_back([&fl, &results, t, kPerThread]() {
-            for (uint32_t i = 0; i < kPerThread; ++i) {
-                uint32_t val = fl.pop();
-                if (val != UINT32_MAX)
-                    results[t].push_back(val);
-            }
-        });
-    }
-    for (auto &th : poppers)
-        th.join();
+  /* Pop all items concurrently */
+  std::vector<std::vector<uint32_t>> results(kThreads);
+  std::vector<std::thread> poppers;
+  for (int t = 0; t < kThreads; ++t) {
+    poppers.emplace_back([&fl, &results, t, kPerThread]() {
+      for (uint32_t i = 0; i < kPerThread; ++i) {
+        uint32_t val = fl.pop();
+        if (val != UINT32_MAX)
+          results[t].push_back(val);
+      }
+    });
+  }
+  for (auto &th : poppers)
+    th.join();
 
-    /* Verify no duplicates */
-    std::set<uint32_t> all;
-    for (const auto &v : results)
-        for (uint32_t x : v)
-            all.insert(x);
+  /* Verify no duplicates */
+  std::set<uint32_t> all;
+  for (const auto &v : results)
+    for (uint32_t x : v)
+      all.insert(x);
 
-    EXPECT_EQ(all.size(), (size_t)(kPerThread * kThreads));
+  EXPECT_EQ(all.size(), (size_t)(kPerThread * kThreads));
 
-    fl.shutdown();
+  fl.shutdown();
 }

--- a/test/unit/mm/test_hal.cpp
+++ b/test/unit/mm/test_hal.cpp
@@ -1,0 +1,88 @@
+#include "mm_hal.h"
+#include <gtest/gtest.h>
+#include <cstring>
+
+class HalHostTest : public ::testing::Test {
+protected:
+    void SetUp() override { hal = mm_hal_host_get(); }
+    const mm_hal_t *hal = nullptr;
+};
+
+TEST_F(HalHostTest, DeviceCountPositive) {
+    EXPECT_GE(hal->get_device_count(), 1);
+}
+
+TEST_F(HalHostTest, DeviceInfoValid) {
+    mm_device_info_t info = {};
+    int err = hal->get_device_info(0, &info);
+    EXPECT_EQ(err, MM_OK);
+    EXPECT_GT(info.total_memory, 0u);
+    EXPECT_GT(info.free_memory, 0u);
+    EXPECT_GT(std::strlen(info.name), 0u);
+}
+
+TEST_F(HalHostTest, RawAllocFreeRoundTrip) {
+    void *ptr = hal->raw_alloc(0, 4096, 64);
+    ASSERT_NE(ptr, nullptr);
+
+    /* Write pattern and verify */
+    std::memset(ptr, 0xAB, 4096);
+    EXPECT_EQ(static_cast<unsigned char *>(ptr)[0], 0xAB);
+    EXPECT_EQ(static_cast<unsigned char *>(ptr)[4095], 0xAB);
+
+    hal->raw_free(0, ptr);
+}
+
+TEST_F(HalHostTest, ZeroSizeAllocReturnsNull) {
+    void *ptr = hal->raw_alloc(0, 0, 64);
+    EXPECT_EQ(ptr, nullptr);
+}
+
+TEST_F(HalHostTest, AsyncCopyCorrectness) {
+    char src[256], dst[256];
+    std::memset(src, 0x42, sizeof(src));
+    std::memset(dst, 0x00, sizeof(dst));
+
+    int err = hal->async_copy(dst, src, sizeof(src),
+                              MM_COPY_HOST_TO_HOST, 0, nullptr);
+    EXPECT_EQ(err, MM_OK);
+    EXPECT_EQ(std::memcmp(src, dst, sizeof(src)), 0);
+}
+
+TEST_F(HalHostTest, MemsetWorks) {
+    void *ptr = hal->raw_alloc(0, 1024, 64);
+    ASSERT_NE(ptr, nullptr);
+
+    int err = hal->memset(ptr, 0xFF, 1024, 0);
+    EXPECT_EQ(err, MM_OK);
+    EXPECT_EQ(static_cast<unsigned char *>(ptr)[0], 0xFF);
+    EXPECT_EQ(static_cast<unsigned char *>(ptr)[1023], 0xFF);
+
+    hal->raw_free(0, ptr);
+}
+
+TEST_F(HalHostTest, HostAllocFree) {
+    void *ptr = hal->host_alloc(8192, 64);
+    ASSERT_NE(ptr, nullptr);
+    std::memset(ptr, 0xCD, 8192);
+    EXPECT_EQ(static_cast<unsigned char *>(ptr)[0], 0xCD);
+    hal->host_free(ptr);
+}
+
+TEST_F(HalHostTest, MemoryQueries) {
+    size_t total = hal->get_total_memory(0);
+    size_t free_mem = hal->get_free_memory(0);
+    EXPECT_GT(total, 0u);
+    EXPECT_GT(free_mem, 0u);
+}
+
+TEST_F(HalHostTest, RegisterAndGet) {
+    int err = mm_hal_register(hal);
+    EXPECT_EQ(err, MM_OK);
+    EXPECT_EQ(mm_hal_get(), hal);
+}
+
+TEST_F(HalHostTest, RegisterNullFails) {
+    int err = mm_hal_register(nullptr);
+    EXPECT_EQ(err, MM_ERROR_INVALID_ARG);
+}

--- a/test/unit/mm/test_hal.cpp
+++ b/test/unit/mm/test_hal.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
 #include "mm_hal.h"
 #include <cstring>
 #include <gtest/gtest.h>

--- a/test/unit/mm/test_hal.cpp
+++ b/test/unit/mm/test_hal.cpp
@@ -1,88 +1,88 @@
 #include "mm_hal.h"
-#include <gtest/gtest.h>
 #include <cstring>
+#include <gtest/gtest.h>
 
 class HalHostTest : public ::testing::Test {
 protected:
-    void SetUp() override { hal = mm_hal_host_get(); }
-    const mm_hal_t *hal = nullptr;
+  void SetUp() override { hal = mm_hal_host_get(); }
+  const mm_hal_t *hal = nullptr;
 };
 
 TEST_F(HalHostTest, DeviceCountPositive) {
-    EXPECT_GE(hal->get_device_count(), 1);
+  EXPECT_GE(hal->get_device_count(), 1);
 }
 
 TEST_F(HalHostTest, DeviceInfoValid) {
-    mm_device_info_t info = {};
-    int err = hal->get_device_info(0, &info);
-    EXPECT_EQ(err, MM_OK);
-    EXPECT_GT(info.total_memory, 0u);
-    EXPECT_GT(info.free_memory, 0u);
-    EXPECT_GT(std::strlen(info.name), 0u);
+  mm_device_info_t info = {};
+  int err = hal->get_device_info(0, &info);
+  EXPECT_EQ(err, MM_OK);
+  EXPECT_GT(info.total_memory, 0u);
+  EXPECT_GT(info.free_memory, 0u);
+  EXPECT_GT(std::strlen(info.name), 0u);
 }
 
 TEST_F(HalHostTest, RawAllocFreeRoundTrip) {
-    void *ptr = hal->raw_alloc(0, 4096, 64);
-    ASSERT_NE(ptr, nullptr);
+  void *ptr = hal->raw_alloc(0, 4096, 64);
+  ASSERT_NE(ptr, nullptr);
 
-    /* Write pattern and verify */
-    std::memset(ptr, 0xAB, 4096);
-    EXPECT_EQ(static_cast<unsigned char *>(ptr)[0], 0xAB);
-    EXPECT_EQ(static_cast<unsigned char *>(ptr)[4095], 0xAB);
+  /* Write pattern and verify */
+  std::memset(ptr, 0xAB, 4096);
+  EXPECT_EQ(static_cast<unsigned char *>(ptr)[0], 0xAB);
+  EXPECT_EQ(static_cast<unsigned char *>(ptr)[4095], 0xAB);
 
-    hal->raw_free(0, ptr);
+  hal->raw_free(0, ptr);
 }
 
 TEST_F(HalHostTest, ZeroSizeAllocReturnsNull) {
-    void *ptr = hal->raw_alloc(0, 0, 64);
-    EXPECT_EQ(ptr, nullptr);
+  void *ptr = hal->raw_alloc(0, 0, 64);
+  EXPECT_EQ(ptr, nullptr);
 }
 
 TEST_F(HalHostTest, AsyncCopyCorrectness) {
-    char src[256], dst[256];
-    std::memset(src, 0x42, sizeof(src));
-    std::memset(dst, 0x00, sizeof(dst));
+  char src[256], dst[256];
+  std::memset(src, 0x42, sizeof(src));
+  std::memset(dst, 0x00, sizeof(dst));
 
-    int err = hal->async_copy(dst, src, sizeof(src),
-                              MM_COPY_HOST_TO_HOST, 0, nullptr);
-    EXPECT_EQ(err, MM_OK);
-    EXPECT_EQ(std::memcmp(src, dst, sizeof(src)), 0);
+  int err =
+      hal->async_copy(dst, src, sizeof(src), MM_COPY_HOST_TO_HOST, 0, nullptr);
+  EXPECT_EQ(err, MM_OK);
+  EXPECT_EQ(std::memcmp(src, dst, sizeof(src)), 0);
 }
 
 TEST_F(HalHostTest, MemsetWorks) {
-    void *ptr = hal->raw_alloc(0, 1024, 64);
-    ASSERT_NE(ptr, nullptr);
+  void *ptr = hal->raw_alloc(0, 1024, 64);
+  ASSERT_NE(ptr, nullptr);
 
-    int err = hal->memset(ptr, 0xFF, 1024, 0);
-    EXPECT_EQ(err, MM_OK);
-    EXPECT_EQ(static_cast<unsigned char *>(ptr)[0], 0xFF);
-    EXPECT_EQ(static_cast<unsigned char *>(ptr)[1023], 0xFF);
+  int err = hal->memset(ptr, 0xFF, 1024, 0);
+  EXPECT_EQ(err, MM_OK);
+  EXPECT_EQ(static_cast<unsigned char *>(ptr)[0], 0xFF);
+  EXPECT_EQ(static_cast<unsigned char *>(ptr)[1023], 0xFF);
 
-    hal->raw_free(0, ptr);
+  hal->raw_free(0, ptr);
 }
 
 TEST_F(HalHostTest, HostAllocFree) {
-    void *ptr = hal->host_alloc(8192, 64);
-    ASSERT_NE(ptr, nullptr);
-    std::memset(ptr, 0xCD, 8192);
-    EXPECT_EQ(static_cast<unsigned char *>(ptr)[0], 0xCD);
-    hal->host_free(ptr);
+  void *ptr = hal->host_alloc(8192, 64);
+  ASSERT_NE(ptr, nullptr);
+  std::memset(ptr, 0xCD, 8192);
+  EXPECT_EQ(static_cast<unsigned char *>(ptr)[0], 0xCD);
+  hal->host_free(ptr);
 }
 
 TEST_F(HalHostTest, MemoryQueries) {
-    size_t total = hal->get_total_memory(0);
-    size_t free_mem = hal->get_free_memory(0);
-    EXPECT_GT(total, 0u);
-    EXPECT_GT(free_mem, 0u);
+  size_t total = hal->get_total_memory(0);
+  size_t free_mem = hal->get_free_memory(0);
+  EXPECT_GT(total, 0u);
+  EXPECT_GT(free_mem, 0u);
 }
 
 TEST_F(HalHostTest, RegisterAndGet) {
-    int err = mm_hal_register(hal);
-    EXPECT_EQ(err, MM_OK);
-    EXPECT_EQ(mm_hal_get(), hal);
+  int err = mm_hal_register(hal);
+  EXPECT_EQ(err, MM_OK);
+  EXPECT_EQ(mm_hal_get(), hal);
 }
 
 TEST_F(HalHostTest, RegisterNullFails) {
-    int err = mm_hal_register(nullptr);
-    EXPECT_EQ(err, MM_ERROR_INVALID_ARG);
+  int err = mm_hal_register(nullptr);
+  EXPECT_EQ(err, MM_ERROR_INVALID_ARG);
 }

--- a/test/unit/mm/test_handle_table.cpp
+++ b/test/unit/mm/test_handle_table.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
 #include "mm_handle_table.h"
 #include <gtest/gtest.h>
 #include <thread>

--- a/test/unit/mm/test_handle_table.cpp
+++ b/test/unit/mm/test_handle_table.cpp
@@ -4,72 +4,72 @@
 #include <vector>
 
 TEST(HandleTableTest, InsertAndLookup) {
-    mm::HandleTable table;
-    int dummy = 42;
-    mm_handle_t h = table.insert(&dummy, sizeof(dummy), MM_CLASS_ACTIVATION);
-    EXPECT_NE(h, MM_INVALID_HANDLE);
+  mm::HandleTable table;
+  int dummy = 42;
+  mm_handle_t h = table.insert(&dummy, sizeof(dummy), MM_CLASS_ACTIVATION);
+  EXPECT_NE(h, MM_INVALID_HANDLE);
 
-    auto *entry = table.lookup(h);
-    ASSERT_NE(entry, nullptr);
-    EXPECT_EQ(entry->ptr, &dummy);
-    EXPECT_EQ(entry->size, sizeof(dummy));
-    EXPECT_EQ(entry->mem_class, MM_CLASS_ACTIVATION);
-    EXPECT_TRUE(entry->active);
+  auto *entry = table.lookup(h);
+  ASSERT_NE(entry, nullptr);
+  EXPECT_EQ(entry->ptr, &dummy);
+  EXPECT_EQ(entry->size, sizeof(dummy));
+  EXPECT_EQ(entry->mem_class, MM_CLASS_ACTIVATION);
+  EXPECT_TRUE(entry->active);
 }
 
 TEST(HandleTableTest, MonotonicIds) {
-    mm::HandleTable table;
-    int a, b, c;
-    mm_handle_t h1 = table.insert(&a, 1, MM_CLASS_SCRATCH);
-    mm_handle_t h2 = table.insert(&b, 2, MM_CLASS_SCRATCH);
-    mm_handle_t h3 = table.insert(&c, 3, MM_CLASS_SCRATCH);
-    EXPECT_LT(h1, h2);
-    EXPECT_LT(h2, h3);
+  mm::HandleTable table;
+  int a, b, c;
+  mm_handle_t h1 = table.insert(&a, 1, MM_CLASS_SCRATCH);
+  mm_handle_t h2 = table.insert(&b, 2, MM_CLASS_SCRATCH);
+  mm_handle_t h3 = table.insert(&c, 3, MM_CLASS_SCRATCH);
+  EXPECT_LT(h1, h2);
+  EXPECT_LT(h2, h3);
 }
 
 TEST(HandleTableTest, RemoveInvalidatesHandle) {
-    mm::HandleTable table;
-    int dummy = 0;
-    mm_handle_t h = table.insert(&dummy, sizeof(dummy), MM_CLASS_ACTIVATION);
+  mm::HandleTable table;
+  int dummy = 0;
+  mm_handle_t h = table.insert(&dummy, sizeof(dummy), MM_CLASS_ACTIVATION);
 
-    auto *removed = table.remove(h);
-    ASSERT_NE(removed, nullptr);
-    EXPECT_EQ(removed->ptr, &dummy);
+  auto *removed = table.remove(h);
+  ASSERT_NE(removed, nullptr);
+  EXPECT_EQ(removed->ptr, &dummy);
 
-    /* Lookup after remove returns nullptr */
-    EXPECT_EQ(table.lookup(h), nullptr);
+  /* Lookup after remove returns nullptr */
+  EXPECT_EQ(table.lookup(h), nullptr);
 }
 
 TEST(HandleTableTest, LookupInvalidHandle) {
-    mm::HandleTable table;
-    EXPECT_EQ(table.lookup(MM_INVALID_HANDLE), nullptr);
-    EXPECT_EQ(table.lookup(999), nullptr);
+  mm::HandleTable table;
+  EXPECT_EQ(table.lookup(MM_INVALID_HANDLE), nullptr);
+  EXPECT_EQ(table.lookup(999), nullptr);
 }
 
 TEST(HandleTableTest, ActiveCount) {
-    mm::HandleTable table;
-    int a, b;
-    mm_handle_t h1 = table.insert(&a, 1, MM_CLASS_ACTIVATION);
-    table.insert(&b, 2, MM_CLASS_SCRATCH);
-    EXPECT_EQ(table.active_count(), 2u);
+  mm::HandleTable table;
+  int a, b;
+  mm_handle_t h1 = table.insert(&a, 1, MM_CLASS_ACTIVATION);
+  table.insert(&b, 2, MM_CLASS_SCRATCH);
+  EXPECT_EQ(table.active_count(), 2u);
 
-    table.remove(h1);
-    EXPECT_EQ(table.active_count(), 1u);
+  table.remove(h1);
+  EXPECT_EQ(table.active_count(), 1u);
 }
 
 TEST(HandleTableTest, StressInsertRemove) {
-    mm::HandleTable table;
-    constexpr int N = 10000;
-    std::vector<mm_handle_t> handles(N);
-    int data[1];
+  mm::HandleTable table;
+  constexpr int N = 10000;
+  std::vector<mm_handle_t> handles(N);
+  int data[1];
 
-    for (int i = 0; i < N; ++i)
-        handles[i] = table.insert(data, sizeof(data), MM_CLASS_ACTIVATION);
+  for (int i = 0; i < N; ++i)
+    handles[i] = table.insert(data, sizeof(data), MM_CLASS_ACTIVATION);
 
-    EXPECT_EQ(table.active_count(), (size_t)N);
+  EXPECT_EQ(table.active_count(), (size_t)N);
 
-    for (int i = 0; i < N; ++i)
-        table.remove(handles[i]);
+  for (int i = 0; i < N; ++i)
+    table.remove(handles[i]);
 
-    EXPECT_EQ(table.active_count(), 0u);
+  EXPECT_EQ(table.active_count(), 0u);
 }

--- a/test/unit/mm/test_handle_table.cpp
+++ b/test/unit/mm/test_handle_table.cpp
@@ -1,0 +1,75 @@
+#include "mm_handle_table.h"
+#include <gtest/gtest.h>
+#include <thread>
+#include <vector>
+
+TEST(HandleTableTest, InsertAndLookup) {
+    mm::HandleTable table;
+    int dummy = 42;
+    mm_handle_t h = table.insert(&dummy, sizeof(dummy), MM_CLASS_ACTIVATION);
+    EXPECT_NE(h, MM_INVALID_HANDLE);
+
+    auto *entry = table.lookup(h);
+    ASSERT_NE(entry, nullptr);
+    EXPECT_EQ(entry->ptr, &dummy);
+    EXPECT_EQ(entry->size, sizeof(dummy));
+    EXPECT_EQ(entry->mem_class, MM_CLASS_ACTIVATION);
+    EXPECT_TRUE(entry->active);
+}
+
+TEST(HandleTableTest, MonotonicIds) {
+    mm::HandleTable table;
+    int a, b, c;
+    mm_handle_t h1 = table.insert(&a, 1, MM_CLASS_SCRATCH);
+    mm_handle_t h2 = table.insert(&b, 2, MM_CLASS_SCRATCH);
+    mm_handle_t h3 = table.insert(&c, 3, MM_CLASS_SCRATCH);
+    EXPECT_LT(h1, h2);
+    EXPECT_LT(h2, h3);
+}
+
+TEST(HandleTableTest, RemoveInvalidatesHandle) {
+    mm::HandleTable table;
+    int dummy = 0;
+    mm_handle_t h = table.insert(&dummy, sizeof(dummy), MM_CLASS_ACTIVATION);
+
+    auto *removed = table.remove(h);
+    ASSERT_NE(removed, nullptr);
+    EXPECT_EQ(removed->ptr, &dummy);
+
+    /* Lookup after remove returns nullptr */
+    EXPECT_EQ(table.lookup(h), nullptr);
+}
+
+TEST(HandleTableTest, LookupInvalidHandle) {
+    mm::HandleTable table;
+    EXPECT_EQ(table.lookup(MM_INVALID_HANDLE), nullptr);
+    EXPECT_EQ(table.lookup(999), nullptr);
+}
+
+TEST(HandleTableTest, ActiveCount) {
+    mm::HandleTable table;
+    int a, b;
+    mm_handle_t h1 = table.insert(&a, 1, MM_CLASS_ACTIVATION);
+    table.insert(&b, 2, MM_CLASS_SCRATCH);
+    EXPECT_EQ(table.active_count(), 2u);
+
+    table.remove(h1);
+    EXPECT_EQ(table.active_count(), 1u);
+}
+
+TEST(HandleTableTest, StressInsertRemove) {
+    mm::HandleTable table;
+    constexpr int N = 10000;
+    std::vector<mm_handle_t> handles(N);
+    int data[1];
+
+    for (int i = 0; i < N; ++i)
+        handles[i] = table.insert(data, sizeof(data), MM_CLASS_ACTIVATION);
+
+    EXPECT_EQ(table.active_count(), (size_t)N);
+
+    for (int i = 0; i < N; ++i)
+        table.remove(handles[i]);
+
+    EXPECT_EQ(table.active_count(), 0u);
+}

--- a/test/unit/mm/test_kv_block.cpp
+++ b/test/unit/mm/test_kv_block.cpp
@@ -1,0 +1,135 @@
+#include "mm_config.h"
+#include "mm_hal.h"
+#include "mm_kv.h"
+#include <gtest/gtest.h>
+#include <vector>
+
+class KvBlockTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        mm_hal_register(mm_hal_host_get());
+        mm_config_t config = {};
+        config.gpu_memory_limit = 64 * 1024 * 1024;
+        config.kv_cache_fraction = 0.5f;
+        config.kv_block_size_tokens = 16;
+        config.num_size_classes = 4;
+        config.high_watermark = 0.90f;
+        config.critical_watermark = 0.95f;
+        config.default_kv_format = MM_KV_FMT_FP16;
+        ASSERT_EQ(mm_init(&config), MM_OK);
+    }
+    void TearDown() override { mm_shutdown(); }
+
+    mm_kv_block_desc_t make_desc() {
+        mm_kv_block_desc_t desc = {};
+        desc.format = MM_KV_FMT_FP16;
+        desc.block_size_tokens = 16;
+        desc.num_kv_heads = 4;
+        desc.head_dim = 128;
+        return desc;
+    }
+};
+
+TEST_F(KvBlockTest, AllocReturnsValidBlock) {
+    mm_kv_block_t blk = mm_kv_alloc_block(make_desc(), 0);
+    ASSERT_NE(blk, MM_INVALID_BLOCK);
+
+    void *ptr = mm_kv_get_block_ptr(blk);
+    EXPECT_NE(ptr, nullptr);
+
+    mm_kv_free_block(blk, 0);
+}
+
+TEST_F(KvBlockTest, FreeAndRecycle) {
+    mm_kv_block_t blk1 = mm_kv_alloc_block(make_desc(), 0);
+    ASSERT_NE(blk1, MM_INVALID_BLOCK);
+
+    uint32_t free_before = mm_kv_free_block_count(MM_KV_FMT_FP16);
+    mm_kv_free_block(blk1, 0);
+    uint32_t free_after = mm_kv_free_block_count(MM_KV_FMT_FP16);
+    EXPECT_EQ(free_after, free_before + 1);
+
+    /* Re-alloc should succeed (recycled block) */
+    mm_kv_block_t blk2 = mm_kv_alloc_block(make_desc(), 0);
+    EXPECT_NE(blk2, MM_INVALID_BLOCK);
+
+    mm_kv_free_block(blk2, 0);
+}
+
+TEST_F(KvBlockTest, FormatQueryMatchesDesc) {
+    mm_kv_block_desc_t desc = make_desc();
+    mm_kv_block_t blk = mm_kv_alloc_block(desc, 0);
+    ASSERT_NE(blk, MM_INVALID_BLOCK);
+
+    mm_kv_block_desc_t queried = mm_kv_get_format(blk);
+    EXPECT_EQ(queried.format, desc.format);
+    EXPECT_EQ(queried.num_kv_heads, desc.num_kv_heads);
+    EXPECT_EQ(queried.head_dim, desc.head_dim);
+
+    mm_kv_free_block(blk, 0);
+}
+
+TEST_F(KvBlockTest, BlockTablePointersDistinct) {
+    constexpr int N = 5;
+    mm_kv_block_t blocks[N];
+    for (int i = 0; i < N; ++i) {
+        blocks[i] = mm_kv_alloc_block(make_desc(), 0);
+        ASSERT_NE(blocks[i], MM_INVALID_BLOCK);
+    }
+
+    void **table = mm_kv_get_block_table(blocks, N, MM_DEVICE_GPU_0);
+    ASSERT_NE(table, nullptr);
+
+    /* All pointers should be distinct */
+    for (int i = 0; i < N; ++i) {
+        EXPECT_NE(table[i], nullptr);
+        for (int j = i + 1; j < N; ++j) {
+            EXPECT_NE(table[i], table[j]);
+        }
+    }
+
+    free(table);
+    for (int i = 0; i < N; ++i)
+        mm_kv_free_block(blocks[i], 0);
+}
+
+TEST_F(KvBlockTest, DoubleFreeIsSafe) {
+    mm_kv_block_t blk = mm_kv_alloc_block(make_desc(), 0);
+    ASSERT_NE(blk, MM_INVALID_BLOCK);
+
+    mm_kv_free_block(blk, 0);
+    mm_kv_free_block(blk, 0); /* Should not crash */
+}
+
+TEST_F(KvBlockTest, AllocExhaustsPool) {
+    std::vector<mm_kv_block_t> allocated;
+    uint32_t total = mm_kv_total_block_count(MM_KV_FMT_FP16);
+
+    /* Allocate all blocks */
+    for (uint32_t i = 0; i < total; ++i) {
+        mm_kv_block_t blk = mm_kv_alloc_block(make_desc(), 0);
+        if (blk == MM_INVALID_BLOCK)
+            break;
+        allocated.push_back(blk);
+    }
+
+    /* Pool should be exhausted */
+    EXPECT_EQ(mm_kv_free_block_count(MM_KV_FMT_FP16), 0u);
+
+    /* Next alloc should fail */
+    mm_kv_block_t fail = mm_kv_alloc_block(make_desc(), 0);
+    EXPECT_EQ(fail, MM_INVALID_BLOCK);
+
+    /* Free all */
+    for (auto blk : allocated)
+        mm_kv_free_block(blk, 0);
+}
+
+TEST_F(KvBlockTest, InvalidBlockOperations) {
+    EXPECT_EQ(mm_kv_get_block_ptr(MM_INVALID_BLOCK), nullptr);
+
+    mm_kv_block_desc_t desc = mm_kv_get_format(MM_INVALID_BLOCK);
+    EXPECT_EQ(desc.format, (mm_kv_format_t)0);
+
+    mm_kv_free_block(MM_INVALID_BLOCK, 0); /* Should not crash */
+}

--- a/test/unit/mm/test_kv_block.cpp
+++ b/test/unit/mm/test_kv_block.cpp
@@ -6,130 +6,130 @@
 
 class KvBlockTest : public ::testing::Test {
 protected:
-    void SetUp() override {
-        mm_hal_register(mm_hal_host_get());
-        mm_config_t config = {};
-        config.gpu_memory_limit = 64 * 1024 * 1024;
-        config.kv_cache_fraction = 0.5f;
-        config.kv_block_size_tokens = 16;
-        config.num_size_classes = 4;
-        config.high_watermark = 0.90f;
-        config.critical_watermark = 0.95f;
-        config.default_kv_format = MM_KV_FMT_FP16;
-        ASSERT_EQ(mm_init(&config), MM_OK);
-    }
-    void TearDown() override { mm_shutdown(); }
+  void SetUp() override {
+    mm_hal_register(mm_hal_host_get());
+    mm_config_t config = {};
+    config.gpu_memory_limit = 64 * 1024 * 1024;
+    config.kv_cache_fraction = 0.5f;
+    config.kv_block_size_tokens = 16;
+    config.num_size_classes = 4;
+    config.high_watermark = 0.90f;
+    config.critical_watermark = 0.95f;
+    config.default_kv_format = MM_KV_FMT_FP16;
+    ASSERT_EQ(mm_init(&config), MM_OK);
+  }
+  void TearDown() override { mm_shutdown(); }
 
-    mm_kv_block_desc_t make_desc() {
-        mm_kv_block_desc_t desc = {};
-        desc.format = MM_KV_FMT_FP16;
-        desc.block_size_tokens = 16;
-        desc.num_kv_heads = 4;
-        desc.head_dim = 128;
-        return desc;
-    }
+  mm_kv_block_desc_t make_desc() {
+    mm_kv_block_desc_t desc = {};
+    desc.format = MM_KV_FMT_FP16;
+    desc.block_size_tokens = 16;
+    desc.num_kv_heads = 4;
+    desc.head_dim = 128;
+    return desc;
+  }
 };
 
 TEST_F(KvBlockTest, AllocReturnsValidBlock) {
-    mm_kv_block_t blk = mm_kv_alloc_block(make_desc(), 0);
-    ASSERT_NE(blk, MM_INVALID_BLOCK);
+  mm_kv_block_t blk = mm_kv_alloc_block(make_desc(), 0);
+  ASSERT_NE(blk, MM_INVALID_BLOCK);
 
-    void *ptr = mm_kv_get_block_ptr(blk);
-    EXPECT_NE(ptr, nullptr);
+  void *ptr = mm_kv_get_block_ptr(blk);
+  EXPECT_NE(ptr, nullptr);
 
-    mm_kv_free_block(blk, 0);
+  mm_kv_free_block(blk, 0);
 }
 
 TEST_F(KvBlockTest, FreeAndRecycle) {
-    mm_kv_block_t blk1 = mm_kv_alloc_block(make_desc(), 0);
-    ASSERT_NE(blk1, MM_INVALID_BLOCK);
+  mm_kv_block_t blk1 = mm_kv_alloc_block(make_desc(), 0);
+  ASSERT_NE(blk1, MM_INVALID_BLOCK);
 
-    uint32_t free_before = mm_kv_free_block_count(MM_KV_FMT_FP16);
-    mm_kv_free_block(blk1, 0);
-    uint32_t free_after = mm_kv_free_block_count(MM_KV_FMT_FP16);
-    EXPECT_EQ(free_after, free_before + 1);
+  uint32_t free_before = mm_kv_free_block_count(MM_KV_FMT_FP16);
+  mm_kv_free_block(blk1, 0);
+  uint32_t free_after = mm_kv_free_block_count(MM_KV_FMT_FP16);
+  EXPECT_EQ(free_after, free_before + 1);
 
-    /* Re-alloc should succeed (recycled block) */
-    mm_kv_block_t blk2 = mm_kv_alloc_block(make_desc(), 0);
-    EXPECT_NE(blk2, MM_INVALID_BLOCK);
+  /* Re-alloc should succeed (recycled block) */
+  mm_kv_block_t blk2 = mm_kv_alloc_block(make_desc(), 0);
+  EXPECT_NE(blk2, MM_INVALID_BLOCK);
 
-    mm_kv_free_block(blk2, 0);
+  mm_kv_free_block(blk2, 0);
 }
 
 TEST_F(KvBlockTest, FormatQueryMatchesDesc) {
-    mm_kv_block_desc_t desc = make_desc();
-    mm_kv_block_t blk = mm_kv_alloc_block(desc, 0);
-    ASSERT_NE(blk, MM_INVALID_BLOCK);
+  mm_kv_block_desc_t desc = make_desc();
+  mm_kv_block_t blk = mm_kv_alloc_block(desc, 0);
+  ASSERT_NE(blk, MM_INVALID_BLOCK);
 
-    mm_kv_block_desc_t queried = mm_kv_get_format(blk);
-    EXPECT_EQ(queried.format, desc.format);
-    EXPECT_EQ(queried.num_kv_heads, desc.num_kv_heads);
-    EXPECT_EQ(queried.head_dim, desc.head_dim);
+  mm_kv_block_desc_t queried = mm_kv_get_format(blk);
+  EXPECT_EQ(queried.format, desc.format);
+  EXPECT_EQ(queried.num_kv_heads, desc.num_kv_heads);
+  EXPECT_EQ(queried.head_dim, desc.head_dim);
 
-    mm_kv_free_block(blk, 0);
+  mm_kv_free_block(blk, 0);
 }
 
 TEST_F(KvBlockTest, BlockTablePointersDistinct) {
-    constexpr int N = 5;
-    mm_kv_block_t blocks[N];
-    for (int i = 0; i < N; ++i) {
-        blocks[i] = mm_kv_alloc_block(make_desc(), 0);
-        ASSERT_NE(blocks[i], MM_INVALID_BLOCK);
+  constexpr int N = 5;
+  mm_kv_block_t blocks[N];
+  for (int i = 0; i < N; ++i) {
+    blocks[i] = mm_kv_alloc_block(make_desc(), 0);
+    ASSERT_NE(blocks[i], MM_INVALID_BLOCK);
+  }
+
+  void **table = mm_kv_get_block_table(blocks, N, MM_DEVICE_GPU_0);
+  ASSERT_NE(table, nullptr);
+
+  /* All pointers should be distinct */
+  for (int i = 0; i < N; ++i) {
+    EXPECT_NE(table[i], nullptr);
+    for (int j = i + 1; j < N; ++j) {
+      EXPECT_NE(table[i], table[j]);
     }
+  }
 
-    void **table = mm_kv_get_block_table(blocks, N, MM_DEVICE_GPU_0);
-    ASSERT_NE(table, nullptr);
-
-    /* All pointers should be distinct */
-    for (int i = 0; i < N; ++i) {
-        EXPECT_NE(table[i], nullptr);
-        for (int j = i + 1; j < N; ++j) {
-            EXPECT_NE(table[i], table[j]);
-        }
-    }
-
-    free(table);
-    for (int i = 0; i < N; ++i)
-        mm_kv_free_block(blocks[i], 0);
+  free(table);
+  for (int i = 0; i < N; ++i)
+    mm_kv_free_block(blocks[i], 0);
 }
 
 TEST_F(KvBlockTest, DoubleFreeIsSafe) {
-    mm_kv_block_t blk = mm_kv_alloc_block(make_desc(), 0);
-    ASSERT_NE(blk, MM_INVALID_BLOCK);
+  mm_kv_block_t blk = mm_kv_alloc_block(make_desc(), 0);
+  ASSERT_NE(blk, MM_INVALID_BLOCK);
 
-    mm_kv_free_block(blk, 0);
-    mm_kv_free_block(blk, 0); /* Should not crash */
+  mm_kv_free_block(blk, 0);
+  mm_kv_free_block(blk, 0); /* Should not crash */
 }
 
 TEST_F(KvBlockTest, AllocExhaustsPool) {
-    std::vector<mm_kv_block_t> allocated;
-    uint32_t total = mm_kv_total_block_count(MM_KV_FMT_FP16);
+  std::vector<mm_kv_block_t> allocated;
+  uint32_t total = mm_kv_total_block_count(MM_KV_FMT_FP16);
 
-    /* Allocate all blocks */
-    for (uint32_t i = 0; i < total; ++i) {
-        mm_kv_block_t blk = mm_kv_alloc_block(make_desc(), 0);
-        if (blk == MM_INVALID_BLOCK)
-            break;
-        allocated.push_back(blk);
-    }
+  /* Allocate all blocks */
+  for (uint32_t i = 0; i < total; ++i) {
+    mm_kv_block_t blk = mm_kv_alloc_block(make_desc(), 0);
+    if (blk == MM_INVALID_BLOCK)
+      break;
+    allocated.push_back(blk);
+  }
 
-    /* Pool should be exhausted */
-    EXPECT_EQ(mm_kv_free_block_count(MM_KV_FMT_FP16), 0u);
+  /* Pool should be exhausted */
+  EXPECT_EQ(mm_kv_free_block_count(MM_KV_FMT_FP16), 0u);
 
-    /* Next alloc should fail */
-    mm_kv_block_t fail = mm_kv_alloc_block(make_desc(), 0);
-    EXPECT_EQ(fail, MM_INVALID_BLOCK);
+  /* Next alloc should fail */
+  mm_kv_block_t fail = mm_kv_alloc_block(make_desc(), 0);
+  EXPECT_EQ(fail, MM_INVALID_BLOCK);
 
-    /* Free all */
-    for (auto blk : allocated)
-        mm_kv_free_block(blk, 0);
+  /* Free all */
+  for (auto blk : allocated)
+    mm_kv_free_block(blk, 0);
 }
 
 TEST_F(KvBlockTest, InvalidBlockOperations) {
-    EXPECT_EQ(mm_kv_get_block_ptr(MM_INVALID_BLOCK), nullptr);
+  EXPECT_EQ(mm_kv_get_block_ptr(MM_INVALID_BLOCK), nullptr);
 
-    mm_kv_block_desc_t desc = mm_kv_get_format(MM_INVALID_BLOCK);
-    EXPECT_EQ(desc.format, (mm_kv_format_t)0);
+  mm_kv_block_desc_t desc = mm_kv_get_format(MM_INVALID_BLOCK);
+  EXPECT_EQ(desc.format, (mm_kv_format_t)0);
 
-    mm_kv_free_block(MM_INVALID_BLOCK, 0); /* Should not crash */
+  mm_kv_free_block(MM_INVALID_BLOCK, 0); /* Should not crash */
 }

--- a/test/unit/mm/test_kv_block.cpp
+++ b/test/unit/mm/test_kv_block.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
 #include "mm_config.h"
 #include "mm_hal.h"
 #include "mm_kv.h"

--- a/test/unit/mm/test_kv_fork.cpp
+++ b/test/unit/mm/test_kv_fork.cpp
@@ -1,0 +1,108 @@
+#include "mm_config.h"
+#include "mm_hal.h"
+#include "mm_kv.h"
+#include <gtest/gtest.h>
+
+class KvForkTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        mm_hal_register(mm_hal_host_get());
+        mm_config_t config = {};
+        config.gpu_memory_limit = 64 * 1024 * 1024;
+        config.kv_cache_fraction = 0.5f;
+        config.kv_block_size_tokens = 16;
+        config.num_size_classes = 4;
+        config.high_watermark = 0.90f;
+        config.critical_watermark = 0.95f;
+        config.default_kv_format = MM_KV_FMT_FP16;
+        ASSERT_EQ(mm_init(&config), MM_OK);
+    }
+    void TearDown() override { mm_shutdown(); }
+
+    mm_kv_block_desc_t make_desc() {
+        mm_kv_block_desc_t desc = {};
+        desc.format = MM_KV_FMT_FP16;
+        desc.block_size_tokens = 16;
+        desc.num_kv_heads = 4;
+        desc.head_dim = 128;
+        return desc;
+    }
+};
+
+TEST_F(KvForkTest, ForkSharesPhysicalMemory) {
+    mm_kv_block_t blk = mm_kv_alloc_block(make_desc(), 0);
+    ASSERT_NE(blk, MM_INVALID_BLOCK);
+
+    void *ptr_orig = mm_kv_get_block_ptr(blk);
+    ASSERT_NE(ptr_orig, nullptr);
+
+    mm_kv_block_t forked = mm_kv_fork_block(blk);
+    ASSERT_NE(forked, MM_INVALID_BLOCK);
+
+    /* Fork shares same physical memory (CoW) */
+    void *ptr_forked = mm_kv_get_block_ptr(forked);
+    EXPECT_EQ(ptr_orig, ptr_forked);
+
+    mm_kv_free_block(blk, 0);
+    mm_kv_free_block(forked, 0);
+}
+
+TEST_F(KvForkTest, ForkSurvivesOriginalFree) {
+    mm_kv_block_t blk = mm_kv_alloc_block(make_desc(), 0);
+    ASSERT_NE(blk, MM_INVALID_BLOCK);
+
+    mm_kv_block_t forked = mm_kv_fork_block(blk);
+    ASSERT_NE(forked, MM_INVALID_BLOCK);
+
+    uint32_t free_before = mm_kv_free_block_count(MM_KV_FMT_FP16);
+
+    /* Free the original — forked still holds a reference */
+    mm_kv_free_block(blk, 0);
+
+    /* Block should NOT be returned to free list (forked still alive) */
+    uint32_t free_after = mm_kv_free_block_count(MM_KV_FMT_FP16);
+    EXPECT_EQ(free_before, free_after);
+
+    /* Forked block should still be valid */
+    void *ptr = mm_kv_get_block_ptr(forked);
+    EXPECT_NE(ptr, nullptr);
+
+    /* Now free forked — block goes back to free list */
+    mm_kv_free_block(forked, 0);
+    uint32_t free_final = mm_kv_free_block_count(MM_KV_FMT_FP16);
+    EXPECT_EQ(free_final, free_before + 1);
+}
+
+TEST_F(KvForkTest, MultipleForks) {
+    mm_kv_block_t blk = mm_kv_alloc_block(make_desc(), 0);
+    ASSERT_NE(blk, MM_INVALID_BLOCK);
+
+    /* Fork 5 times */
+    mm_kv_block_t forks[5];
+    for (int i = 0; i < 5; ++i) {
+        forks[i] = mm_kv_fork_block(blk);
+        ASSERT_NE(forks[i], MM_INVALID_BLOCK);
+    }
+
+    /* All share same pointer */
+    void *orig_ptr = mm_kv_get_block_ptr(blk);
+    for (int i = 0; i < 5; ++i) {
+        EXPECT_EQ(mm_kv_get_block_ptr(forks[i]), orig_ptr);
+    }
+
+    /* Free original + 4 forks — block should NOT return to free list */
+    uint32_t free_before = mm_kv_free_block_count(MM_KV_FMT_FP16);
+    mm_kv_free_block(blk, 0);
+    for (int i = 0; i < 4; ++i)
+        mm_kv_free_block(forks[i], 0);
+    EXPECT_EQ(mm_kv_free_block_count(MM_KV_FMT_FP16), free_before);
+
+    /* Free last fork — now block returns */
+    mm_kv_free_block(forks[4], 0);
+    EXPECT_EQ(mm_kv_free_block_count(MM_KV_FMT_FP16), free_before + 1);
+}
+
+TEST_F(KvForkTest, ForkInvalidBlockFails) {
+    mm_kv_block_t forked = mm_kv_fork_block(MM_INVALID_BLOCK);
+    EXPECT_EQ(forked, MM_INVALID_BLOCK);
+}

--- a/test/unit/mm/test_kv_fork.cpp
+++ b/test/unit/mm/test_kv_fork.cpp
@@ -5,104 +5,104 @@
 
 class KvForkTest : public ::testing::Test {
 protected:
-    void SetUp() override {
-        mm_hal_register(mm_hal_host_get());
-        mm_config_t config = {};
-        config.gpu_memory_limit = 64 * 1024 * 1024;
-        config.kv_cache_fraction = 0.5f;
-        config.kv_block_size_tokens = 16;
-        config.num_size_classes = 4;
-        config.high_watermark = 0.90f;
-        config.critical_watermark = 0.95f;
-        config.default_kv_format = MM_KV_FMT_FP16;
-        ASSERT_EQ(mm_init(&config), MM_OK);
-    }
-    void TearDown() override { mm_shutdown(); }
+  void SetUp() override {
+    mm_hal_register(mm_hal_host_get());
+    mm_config_t config = {};
+    config.gpu_memory_limit = 64 * 1024 * 1024;
+    config.kv_cache_fraction = 0.5f;
+    config.kv_block_size_tokens = 16;
+    config.num_size_classes = 4;
+    config.high_watermark = 0.90f;
+    config.critical_watermark = 0.95f;
+    config.default_kv_format = MM_KV_FMT_FP16;
+    ASSERT_EQ(mm_init(&config), MM_OK);
+  }
+  void TearDown() override { mm_shutdown(); }
 
-    mm_kv_block_desc_t make_desc() {
-        mm_kv_block_desc_t desc = {};
-        desc.format = MM_KV_FMT_FP16;
-        desc.block_size_tokens = 16;
-        desc.num_kv_heads = 4;
-        desc.head_dim = 128;
-        return desc;
-    }
+  mm_kv_block_desc_t make_desc() {
+    mm_kv_block_desc_t desc = {};
+    desc.format = MM_KV_FMT_FP16;
+    desc.block_size_tokens = 16;
+    desc.num_kv_heads = 4;
+    desc.head_dim = 128;
+    return desc;
+  }
 };
 
 TEST_F(KvForkTest, ForkSharesPhysicalMemory) {
-    mm_kv_block_t blk = mm_kv_alloc_block(make_desc(), 0);
-    ASSERT_NE(blk, MM_INVALID_BLOCK);
+  mm_kv_block_t blk = mm_kv_alloc_block(make_desc(), 0);
+  ASSERT_NE(blk, MM_INVALID_BLOCK);
 
-    void *ptr_orig = mm_kv_get_block_ptr(blk);
-    ASSERT_NE(ptr_orig, nullptr);
+  void *ptr_orig = mm_kv_get_block_ptr(blk);
+  ASSERT_NE(ptr_orig, nullptr);
 
-    mm_kv_block_t forked = mm_kv_fork_block(blk);
-    ASSERT_NE(forked, MM_INVALID_BLOCK);
+  mm_kv_block_t forked = mm_kv_fork_block(blk);
+  ASSERT_NE(forked, MM_INVALID_BLOCK);
 
-    /* Fork shares same physical memory (CoW) */
-    void *ptr_forked = mm_kv_get_block_ptr(forked);
-    EXPECT_EQ(ptr_orig, ptr_forked);
+  /* Fork shares same physical memory (CoW) */
+  void *ptr_forked = mm_kv_get_block_ptr(forked);
+  EXPECT_EQ(ptr_orig, ptr_forked);
 
-    mm_kv_free_block(blk, 0);
-    mm_kv_free_block(forked, 0);
+  mm_kv_free_block(blk, 0);
+  mm_kv_free_block(forked, 0);
 }
 
 TEST_F(KvForkTest, ForkSurvivesOriginalFree) {
-    mm_kv_block_t blk = mm_kv_alloc_block(make_desc(), 0);
-    ASSERT_NE(blk, MM_INVALID_BLOCK);
+  mm_kv_block_t blk = mm_kv_alloc_block(make_desc(), 0);
+  ASSERT_NE(blk, MM_INVALID_BLOCK);
 
-    mm_kv_block_t forked = mm_kv_fork_block(blk);
-    ASSERT_NE(forked, MM_INVALID_BLOCK);
+  mm_kv_block_t forked = mm_kv_fork_block(blk);
+  ASSERT_NE(forked, MM_INVALID_BLOCK);
 
-    uint32_t free_before = mm_kv_free_block_count(MM_KV_FMT_FP16);
+  uint32_t free_before = mm_kv_free_block_count(MM_KV_FMT_FP16);
 
-    /* Free the original — forked still holds a reference */
-    mm_kv_free_block(blk, 0);
+  /* Free the original — forked still holds a reference */
+  mm_kv_free_block(blk, 0);
 
-    /* Block should NOT be returned to free list (forked still alive) */
-    uint32_t free_after = mm_kv_free_block_count(MM_KV_FMT_FP16);
-    EXPECT_EQ(free_before, free_after);
+  /* Block should NOT be returned to free list (forked still alive) */
+  uint32_t free_after = mm_kv_free_block_count(MM_KV_FMT_FP16);
+  EXPECT_EQ(free_before, free_after);
 
-    /* Forked block should still be valid */
-    void *ptr = mm_kv_get_block_ptr(forked);
-    EXPECT_NE(ptr, nullptr);
+  /* Forked block should still be valid */
+  void *ptr = mm_kv_get_block_ptr(forked);
+  EXPECT_NE(ptr, nullptr);
 
-    /* Now free forked — block goes back to free list */
-    mm_kv_free_block(forked, 0);
-    uint32_t free_final = mm_kv_free_block_count(MM_KV_FMT_FP16);
-    EXPECT_EQ(free_final, free_before + 1);
+  /* Now free forked — block goes back to free list */
+  mm_kv_free_block(forked, 0);
+  uint32_t free_final = mm_kv_free_block_count(MM_KV_FMT_FP16);
+  EXPECT_EQ(free_final, free_before + 1);
 }
 
 TEST_F(KvForkTest, MultipleForks) {
-    mm_kv_block_t blk = mm_kv_alloc_block(make_desc(), 0);
-    ASSERT_NE(blk, MM_INVALID_BLOCK);
+  mm_kv_block_t blk = mm_kv_alloc_block(make_desc(), 0);
+  ASSERT_NE(blk, MM_INVALID_BLOCK);
 
-    /* Fork 5 times */
-    mm_kv_block_t forks[5];
-    for (int i = 0; i < 5; ++i) {
-        forks[i] = mm_kv_fork_block(blk);
-        ASSERT_NE(forks[i], MM_INVALID_BLOCK);
-    }
+  /* Fork 5 times */
+  mm_kv_block_t forks[5];
+  for (int i = 0; i < 5; ++i) {
+    forks[i] = mm_kv_fork_block(blk);
+    ASSERT_NE(forks[i], MM_INVALID_BLOCK);
+  }
 
-    /* All share same pointer */
-    void *orig_ptr = mm_kv_get_block_ptr(blk);
-    for (int i = 0; i < 5; ++i) {
-        EXPECT_EQ(mm_kv_get_block_ptr(forks[i]), orig_ptr);
-    }
+  /* All share same pointer */
+  void *orig_ptr = mm_kv_get_block_ptr(blk);
+  for (int i = 0; i < 5; ++i) {
+    EXPECT_EQ(mm_kv_get_block_ptr(forks[i]), orig_ptr);
+  }
 
-    /* Free original + 4 forks — block should NOT return to free list */
-    uint32_t free_before = mm_kv_free_block_count(MM_KV_FMT_FP16);
-    mm_kv_free_block(blk, 0);
-    for (int i = 0; i < 4; ++i)
-        mm_kv_free_block(forks[i], 0);
-    EXPECT_EQ(mm_kv_free_block_count(MM_KV_FMT_FP16), free_before);
+  /* Free original + 4 forks — block should NOT return to free list */
+  uint32_t free_before = mm_kv_free_block_count(MM_KV_FMT_FP16);
+  mm_kv_free_block(blk, 0);
+  for (int i = 0; i < 4; ++i)
+    mm_kv_free_block(forks[i], 0);
+  EXPECT_EQ(mm_kv_free_block_count(MM_KV_FMT_FP16), free_before);
 
-    /* Free last fork — now block returns */
-    mm_kv_free_block(forks[4], 0);
-    EXPECT_EQ(mm_kv_free_block_count(MM_KV_FMT_FP16), free_before + 1);
+  /* Free last fork — now block returns */
+  mm_kv_free_block(forks[4], 0);
+  EXPECT_EQ(mm_kv_free_block_count(MM_KV_FMT_FP16), free_before + 1);
 }
 
 TEST_F(KvForkTest, ForkInvalidBlockFails) {
-    mm_kv_block_t forked = mm_kv_fork_block(MM_INVALID_BLOCK);
-    EXPECT_EQ(forked, MM_INVALID_BLOCK);
+  mm_kv_block_t forked = mm_kv_fork_block(MM_INVALID_BLOCK);
+  EXPECT_EQ(forked, MM_INVALID_BLOCK);
 }

--- a/test/unit/mm/test_kv_fork.cpp
+++ b/test/unit/mm/test_kv_fork.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
 #include "mm_config.h"
 #include "mm_hal.h"
 #include "mm_kv.h"

--- a/test/unit/mm/test_lifecycle.cpp
+++ b/test/unit/mm/test_lifecycle.cpp
@@ -1,0 +1,71 @@
+#include "mm_config.h"
+#include "mm_core.h"
+#include "mm_hal.h"
+#include <gtest/gtest.h>
+
+class LifecycleTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        mm_hal_register(mm_hal_host_get());
+    }
+    void TearDown() override {
+        mm_shutdown();
+    }
+};
+
+TEST_F(LifecycleTest, InitWithDefaults) {
+    int err = mm_init(nullptr);
+    EXPECT_EQ(err, MM_OK);
+}
+
+TEST_F(LifecycleTest, InitWithConfig) {
+    mm_config_t config = {};
+    config.gpu_memory_limit = 64 * 1024 * 1024; /* 64 MB */
+    config.kv_cache_fraction = 0.50f;
+    config.kv_block_size_tokens = 16;
+    config.max_tier = MM_TIER_DRAM;
+    config.enable_prefix_caching = true;
+    config.enable_defrag = false;
+    config.num_size_classes = 8;
+    config.high_watermark = 0.85f;
+    config.critical_watermark = 0.95f;
+    config.default_kv_format = MM_KV_FMT_FP16;
+    config.pressure_kv_format = MM_KV_FMT_TURBOQUANT_4;
+    config.critical_kv_format = MM_KV_FMT_TURBOQUANT_3;
+    config.enable_inline_quant = false;
+    config.enable_adaptive_transcode = true;
+
+    int err = mm_init(&config);
+    EXPECT_EQ(err, MM_OK);
+}
+
+TEST_F(LifecycleTest, DoubleInitFails) {
+    ASSERT_EQ(mm_init(nullptr), MM_OK);
+    EXPECT_EQ(mm_init(nullptr), MM_ERROR_ALREADY_INIT);
+}
+
+TEST_F(LifecycleTest, ShutdownWithoutInitIsSafe) {
+    mm_shutdown(); /* Should not crash */
+}
+
+TEST_F(LifecycleTest, AllocBeforeInitFails) {
+    mm_alloc_hints_t hints = {};
+    hints.mem_class = MM_CLASS_ACTIVATION;
+    mm_handle_t h = mm_alloc(1024, hints, 0);
+    EXPECT_EQ(h, MM_INVALID_HANDLE);
+}
+
+TEST_F(LifecycleTest, InvalidConfigRejected) {
+    mm_config_t config = {};
+    config.kv_cache_fraction = 1.5f; /* invalid: > 1.0 */
+    config.num_size_classes = 8;
+    config.high_watermark = 0.90f;
+    config.critical_watermark = 0.95f;
+    EXPECT_EQ(mm_init(&config), MM_ERROR_INVALID_ARG);
+}
+
+TEST_F(LifecycleTest, ReinitAfterShutdown) {
+    ASSERT_EQ(mm_init(nullptr), MM_OK);
+    mm_shutdown();
+    EXPECT_EQ(mm_init(nullptr), MM_OK);
+}

--- a/test/unit/mm/test_lifecycle.cpp
+++ b/test/unit/mm/test_lifecycle.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
 #include "mm_config.h"
 #include "mm_core.h"
 #include "mm_hal.h"

--- a/test/unit/mm/test_lifecycle.cpp
+++ b/test/unit/mm/test_lifecycle.cpp
@@ -5,67 +5,63 @@
 
 class LifecycleTest : public ::testing::Test {
 protected:
-    void SetUp() override {
-        mm_hal_register(mm_hal_host_get());
-    }
-    void TearDown() override {
-        mm_shutdown();
-    }
+  void SetUp() override { mm_hal_register(mm_hal_host_get()); }
+  void TearDown() override { mm_shutdown(); }
 };
 
 TEST_F(LifecycleTest, InitWithDefaults) {
-    int err = mm_init(nullptr);
-    EXPECT_EQ(err, MM_OK);
+  int err = mm_init(nullptr);
+  EXPECT_EQ(err, MM_OK);
 }
 
 TEST_F(LifecycleTest, InitWithConfig) {
-    mm_config_t config = {};
-    config.gpu_memory_limit = 64 * 1024 * 1024; /* 64 MB */
-    config.kv_cache_fraction = 0.50f;
-    config.kv_block_size_tokens = 16;
-    config.max_tier = MM_TIER_DRAM;
-    config.enable_prefix_caching = true;
-    config.enable_defrag = false;
-    config.num_size_classes = 8;
-    config.high_watermark = 0.85f;
-    config.critical_watermark = 0.95f;
-    config.default_kv_format = MM_KV_FMT_FP16;
-    config.pressure_kv_format = MM_KV_FMT_TURBOQUANT_4;
-    config.critical_kv_format = MM_KV_FMT_TURBOQUANT_3;
-    config.enable_inline_quant = false;
-    config.enable_adaptive_transcode = true;
+  mm_config_t config = {};
+  config.gpu_memory_limit = 64 * 1024 * 1024; /* 64 MB */
+  config.kv_cache_fraction = 0.50f;
+  config.kv_block_size_tokens = 16;
+  config.max_tier = MM_TIER_DRAM;
+  config.enable_prefix_caching = true;
+  config.enable_defrag = false;
+  config.num_size_classes = 8;
+  config.high_watermark = 0.85f;
+  config.critical_watermark = 0.95f;
+  config.default_kv_format = MM_KV_FMT_FP16;
+  config.pressure_kv_format = MM_KV_FMT_TURBOQUANT_4;
+  config.critical_kv_format = MM_KV_FMT_TURBOQUANT_3;
+  config.enable_inline_quant = false;
+  config.enable_adaptive_transcode = true;
 
-    int err = mm_init(&config);
-    EXPECT_EQ(err, MM_OK);
+  int err = mm_init(&config);
+  EXPECT_EQ(err, MM_OK);
 }
 
 TEST_F(LifecycleTest, DoubleInitFails) {
-    ASSERT_EQ(mm_init(nullptr), MM_OK);
-    EXPECT_EQ(mm_init(nullptr), MM_ERROR_ALREADY_INIT);
+  ASSERT_EQ(mm_init(nullptr), MM_OK);
+  EXPECT_EQ(mm_init(nullptr), MM_ERROR_ALREADY_INIT);
 }
 
 TEST_F(LifecycleTest, ShutdownWithoutInitIsSafe) {
-    mm_shutdown(); /* Should not crash */
+  mm_shutdown(); /* Should not crash */
 }
 
 TEST_F(LifecycleTest, AllocBeforeInitFails) {
-    mm_alloc_hints_t hints = {};
-    hints.mem_class = MM_CLASS_ACTIVATION;
-    mm_handle_t h = mm_alloc(1024, hints, 0);
-    EXPECT_EQ(h, MM_INVALID_HANDLE);
+  mm_alloc_hints_t hints = {};
+  hints.mem_class = MM_CLASS_ACTIVATION;
+  mm_handle_t h = mm_alloc(1024, hints, 0);
+  EXPECT_EQ(h, MM_INVALID_HANDLE);
 }
 
 TEST_F(LifecycleTest, InvalidConfigRejected) {
-    mm_config_t config = {};
-    config.kv_cache_fraction = 1.5f; /* invalid: > 1.0 */
-    config.num_size_classes = 8;
-    config.high_watermark = 0.90f;
-    config.critical_watermark = 0.95f;
-    EXPECT_EQ(mm_init(&config), MM_ERROR_INVALID_ARG);
+  mm_config_t config = {};
+  config.kv_cache_fraction = 1.5f; /* invalid: > 1.0 */
+  config.num_size_classes = 8;
+  config.high_watermark = 0.90f;
+  config.critical_watermark = 0.95f;
+  EXPECT_EQ(mm_init(&config), MM_ERROR_INVALID_ARG);
 }
 
 TEST_F(LifecycleTest, ReinitAfterShutdown) {
-    ASSERT_EQ(mm_init(nullptr), MM_OK);
-    mm_shutdown();
-    EXPECT_EQ(mm_init(nullptr), MM_OK);
+  ASSERT_EQ(mm_init(nullptr), MM_OK);
+  mm_shutdown();
+  EXPECT_EQ(mm_init(nullptr), MM_OK);
 }

--- a/test/unit/mm/test_pool.cpp
+++ b/test/unit/mm/test_pool.cpp
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
 #include "mm_config.h"
 #include "mm_hal.h"
 #include "mm_pool.h"

--- a/test/unit/mm/test_pool.cpp
+++ b/test/unit/mm/test_pool.cpp
@@ -1,0 +1,120 @@
+#include "mm_config.h"
+#include "mm_hal.h"
+#include "mm_pool.h"
+#include <gtest/gtest.h>
+#include <cstring>
+
+class PoolTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        mm_hal_register(mm_hal_host_get());
+        mm_config_t config = {};
+        config.gpu_memory_limit = 64 * 1024 * 1024;
+        config.kv_cache_fraction = 0.5f;
+        config.num_size_classes = 4;
+        config.high_watermark = 0.90f;
+        config.critical_watermark = 0.95f;
+        ASSERT_EQ(mm_init(&config), MM_OK);
+    }
+    void TearDown() override { mm_shutdown(); }
+};
+
+TEST_F(PoolTest, CreateAndLookupTensors) {
+    mm_buffer_entry_t entries[] = {
+        {0, 0,    4096, 256},   /* tensor 0 at offset 0 */
+        {1, 4096, 2048, 256},   /* tensor 1 at offset 4096 */
+        {2, 8192, 1024, 256},   /* tensor 2 at offset 8192 */
+    };
+
+    mm_static_plan_t plan = {};
+    plan.total_size = 16384;
+    plan.mem_class = MM_CLASS_WEIGHT;
+    plan.device = MM_DEVICE_CPU;
+    plan.num_entries = 3;
+    plan.entries = entries;
+
+    mm_pool_t pool = mm_create_pool(&plan);
+    ASSERT_NE(pool, MM_INVALID_POOL);
+
+    void *p0 = mm_pool_get_ptr(pool, 0);
+    void *p1 = mm_pool_get_ptr(pool, 1);
+    void *p2 = mm_pool_get_ptr(pool, 2);
+
+    ASSERT_NE(p0, nullptr);
+    ASSERT_NE(p1, nullptr);
+    ASSERT_NE(p2, nullptr);
+
+    /* Verify offsets are correct (p1 = p0 + 4096, p2 = p0 + 8192) */
+    EXPECT_EQ(static_cast<char *>(p1) - static_cast<char *>(p0), 4096);
+    EXPECT_EQ(static_cast<char *>(p2) - static_cast<char *>(p0), 8192);
+
+    mm_destroy_pool(pool);
+}
+
+TEST_F(PoolTest, InvalidTensorIdReturnsNull) {
+    mm_buffer_entry_t entries[] = {{0, 0, 1024, 256}};
+    mm_static_plan_t plan = {};
+    plan.total_size = 1024;
+    plan.mem_class = MM_CLASS_WEIGHT;
+    plan.device = MM_DEVICE_CPU;
+    plan.num_entries = 1;
+    plan.entries = entries;
+
+    mm_pool_t pool = mm_create_pool(&plan);
+    ASSERT_NE(pool, MM_INVALID_POOL);
+
+    EXPECT_EQ(mm_pool_get_ptr(pool, 99), nullptr);
+
+    mm_destroy_pool(pool);
+}
+
+TEST_F(PoolTest, DestroyReleasesMemory) {
+    mm_buffer_entry_t entries[] = {{0, 0, 1024, 256}};
+    mm_static_plan_t plan = {};
+    plan.total_size = 1024;
+    plan.mem_class = MM_CLASS_WEIGHT;
+    plan.device = MM_DEVICE_CPU;
+    plan.num_entries = 1;
+    plan.entries = entries;
+
+    mm_pool_t pool = mm_create_pool(&plan);
+    ASSERT_NE(pool, MM_INVALID_POOL);
+
+    mm_destroy_pool(pool);
+    /* After destroy, get_ptr should return nullptr */
+    EXPECT_EQ(mm_pool_get_ptr(pool, 0), nullptr);
+}
+
+TEST_F(PoolTest, NullPlanFails) {
+    EXPECT_EQ(mm_create_pool(nullptr), MM_INVALID_POOL);
+}
+
+TEST_F(PoolTest, WriteAndReadData) {
+    mm_buffer_entry_t entries[] = {
+        {0, 0,    256, 256},
+        {1, 256,  256, 256},
+    };
+    mm_static_plan_t plan = {};
+    plan.total_size = 512;
+    plan.mem_class = MM_CLASS_WEIGHT;
+    plan.device = MM_DEVICE_CPU;
+    plan.num_entries = 2;
+    plan.entries = entries;
+
+    mm_pool_t pool = mm_create_pool(&plan);
+    ASSERT_NE(pool, MM_INVALID_POOL);
+
+    /* Write distinct patterns to each tensor */
+    std::memset(mm_pool_get_ptr(pool, 0), 0xAA, 256);
+    std::memset(mm_pool_get_ptr(pool, 1), 0xBB, 256);
+
+    /* Verify patterns are distinct and correct */
+    auto *t0 = static_cast<unsigned char *>(mm_pool_get_ptr(pool, 0));
+    auto *t1 = static_cast<unsigned char *>(mm_pool_get_ptr(pool, 1));
+    EXPECT_EQ(t0[0], 0xAA);
+    EXPECT_EQ(t0[255], 0xAA);
+    EXPECT_EQ(t1[0], 0xBB);
+    EXPECT_EQ(t1[255], 0xBB);
+
+    mm_destroy_pool(pool);
+}

--- a/test/unit/mm/test_pool.cpp
+++ b/test/unit/mm/test_pool.cpp
@@ -1,120 +1,120 @@
 #include "mm_config.h"
 #include "mm_hal.h"
 #include "mm_pool.h"
-#include <gtest/gtest.h>
 #include <cstring>
+#include <gtest/gtest.h>
 
 class PoolTest : public ::testing::Test {
 protected:
-    void SetUp() override {
-        mm_hal_register(mm_hal_host_get());
-        mm_config_t config = {};
-        config.gpu_memory_limit = 64 * 1024 * 1024;
-        config.kv_cache_fraction = 0.5f;
-        config.num_size_classes = 4;
-        config.high_watermark = 0.90f;
-        config.critical_watermark = 0.95f;
-        ASSERT_EQ(mm_init(&config), MM_OK);
-    }
-    void TearDown() override { mm_shutdown(); }
+  void SetUp() override {
+    mm_hal_register(mm_hal_host_get());
+    mm_config_t config = {};
+    config.gpu_memory_limit = 64 * 1024 * 1024;
+    config.kv_cache_fraction = 0.5f;
+    config.num_size_classes = 4;
+    config.high_watermark = 0.90f;
+    config.critical_watermark = 0.95f;
+    ASSERT_EQ(mm_init(&config), MM_OK);
+  }
+  void TearDown() override { mm_shutdown(); }
 };
 
 TEST_F(PoolTest, CreateAndLookupTensors) {
-    mm_buffer_entry_t entries[] = {
-        {0, 0,    4096, 256},   /* tensor 0 at offset 0 */
-        {1, 4096, 2048, 256},   /* tensor 1 at offset 4096 */
-        {2, 8192, 1024, 256},   /* tensor 2 at offset 8192 */
-    };
+  mm_buffer_entry_t entries[] = {
+      {0, 0, 4096, 256},    /* tensor 0 at offset 0 */
+      {1, 4096, 2048, 256}, /* tensor 1 at offset 4096 */
+      {2, 8192, 1024, 256}, /* tensor 2 at offset 8192 */
+  };
 
-    mm_static_plan_t plan = {};
-    plan.total_size = 16384;
-    plan.mem_class = MM_CLASS_WEIGHT;
-    plan.device = MM_DEVICE_CPU;
-    plan.num_entries = 3;
-    plan.entries = entries;
+  mm_static_plan_t plan = {};
+  plan.total_size = 16384;
+  plan.mem_class = MM_CLASS_WEIGHT;
+  plan.device = MM_DEVICE_CPU;
+  plan.num_entries = 3;
+  plan.entries = entries;
 
-    mm_pool_t pool = mm_create_pool(&plan);
-    ASSERT_NE(pool, MM_INVALID_POOL);
+  mm_pool_t pool = mm_create_pool(&plan);
+  ASSERT_NE(pool, MM_INVALID_POOL);
 
-    void *p0 = mm_pool_get_ptr(pool, 0);
-    void *p1 = mm_pool_get_ptr(pool, 1);
-    void *p2 = mm_pool_get_ptr(pool, 2);
+  void *p0 = mm_pool_get_ptr(pool, 0);
+  void *p1 = mm_pool_get_ptr(pool, 1);
+  void *p2 = mm_pool_get_ptr(pool, 2);
 
-    ASSERT_NE(p0, nullptr);
-    ASSERT_NE(p1, nullptr);
-    ASSERT_NE(p2, nullptr);
+  ASSERT_NE(p0, nullptr);
+  ASSERT_NE(p1, nullptr);
+  ASSERT_NE(p2, nullptr);
 
-    /* Verify offsets are correct (p1 = p0 + 4096, p2 = p0 + 8192) */
-    EXPECT_EQ(static_cast<char *>(p1) - static_cast<char *>(p0), 4096);
-    EXPECT_EQ(static_cast<char *>(p2) - static_cast<char *>(p0), 8192);
+  /* Verify offsets are correct (p1 = p0 + 4096, p2 = p0 + 8192) */
+  EXPECT_EQ(static_cast<char *>(p1) - static_cast<char *>(p0), 4096);
+  EXPECT_EQ(static_cast<char *>(p2) - static_cast<char *>(p0), 8192);
 
-    mm_destroy_pool(pool);
+  mm_destroy_pool(pool);
 }
 
 TEST_F(PoolTest, InvalidTensorIdReturnsNull) {
-    mm_buffer_entry_t entries[] = {{0, 0, 1024, 256}};
-    mm_static_plan_t plan = {};
-    plan.total_size = 1024;
-    plan.mem_class = MM_CLASS_WEIGHT;
-    plan.device = MM_DEVICE_CPU;
-    plan.num_entries = 1;
-    plan.entries = entries;
+  mm_buffer_entry_t entries[] = {{0, 0, 1024, 256}};
+  mm_static_plan_t plan = {};
+  plan.total_size = 1024;
+  plan.mem_class = MM_CLASS_WEIGHT;
+  plan.device = MM_DEVICE_CPU;
+  plan.num_entries = 1;
+  plan.entries = entries;
 
-    mm_pool_t pool = mm_create_pool(&plan);
-    ASSERT_NE(pool, MM_INVALID_POOL);
+  mm_pool_t pool = mm_create_pool(&plan);
+  ASSERT_NE(pool, MM_INVALID_POOL);
 
-    EXPECT_EQ(mm_pool_get_ptr(pool, 99), nullptr);
+  EXPECT_EQ(mm_pool_get_ptr(pool, 99), nullptr);
 
-    mm_destroy_pool(pool);
+  mm_destroy_pool(pool);
 }
 
 TEST_F(PoolTest, DestroyReleasesMemory) {
-    mm_buffer_entry_t entries[] = {{0, 0, 1024, 256}};
-    mm_static_plan_t plan = {};
-    plan.total_size = 1024;
-    plan.mem_class = MM_CLASS_WEIGHT;
-    plan.device = MM_DEVICE_CPU;
-    plan.num_entries = 1;
-    plan.entries = entries;
+  mm_buffer_entry_t entries[] = {{0, 0, 1024, 256}};
+  mm_static_plan_t plan = {};
+  plan.total_size = 1024;
+  plan.mem_class = MM_CLASS_WEIGHT;
+  plan.device = MM_DEVICE_CPU;
+  plan.num_entries = 1;
+  plan.entries = entries;
 
-    mm_pool_t pool = mm_create_pool(&plan);
-    ASSERT_NE(pool, MM_INVALID_POOL);
+  mm_pool_t pool = mm_create_pool(&plan);
+  ASSERT_NE(pool, MM_INVALID_POOL);
 
-    mm_destroy_pool(pool);
-    /* After destroy, get_ptr should return nullptr */
-    EXPECT_EQ(mm_pool_get_ptr(pool, 0), nullptr);
+  mm_destroy_pool(pool);
+  /* After destroy, get_ptr should return nullptr */
+  EXPECT_EQ(mm_pool_get_ptr(pool, 0), nullptr);
 }
 
 TEST_F(PoolTest, NullPlanFails) {
-    EXPECT_EQ(mm_create_pool(nullptr), MM_INVALID_POOL);
+  EXPECT_EQ(mm_create_pool(nullptr), MM_INVALID_POOL);
 }
 
 TEST_F(PoolTest, WriteAndReadData) {
-    mm_buffer_entry_t entries[] = {
-        {0, 0,    256, 256},
-        {1, 256,  256, 256},
-    };
-    mm_static_plan_t plan = {};
-    plan.total_size = 512;
-    plan.mem_class = MM_CLASS_WEIGHT;
-    plan.device = MM_DEVICE_CPU;
-    plan.num_entries = 2;
-    plan.entries = entries;
+  mm_buffer_entry_t entries[] = {
+      {0, 0, 256, 256},
+      {1, 256, 256, 256},
+  };
+  mm_static_plan_t plan = {};
+  plan.total_size = 512;
+  plan.mem_class = MM_CLASS_WEIGHT;
+  plan.device = MM_DEVICE_CPU;
+  plan.num_entries = 2;
+  plan.entries = entries;
 
-    mm_pool_t pool = mm_create_pool(&plan);
-    ASSERT_NE(pool, MM_INVALID_POOL);
+  mm_pool_t pool = mm_create_pool(&plan);
+  ASSERT_NE(pool, MM_INVALID_POOL);
 
-    /* Write distinct patterns to each tensor */
-    std::memset(mm_pool_get_ptr(pool, 0), 0xAA, 256);
-    std::memset(mm_pool_get_ptr(pool, 1), 0xBB, 256);
+  /* Write distinct patterns to each tensor */
+  std::memset(mm_pool_get_ptr(pool, 0), 0xAA, 256);
+  std::memset(mm_pool_get_ptr(pool, 1), 0xBB, 256);
 
-    /* Verify patterns are distinct and correct */
-    auto *t0 = static_cast<unsigned char *>(mm_pool_get_ptr(pool, 0));
-    auto *t1 = static_cast<unsigned char *>(mm_pool_get_ptr(pool, 1));
-    EXPECT_EQ(t0[0], 0xAA);
-    EXPECT_EQ(t0[255], 0xAA);
-    EXPECT_EQ(t1[0], 0xBB);
-    EXPECT_EQ(t1[255], 0xBB);
+  /* Verify patterns are distinct and correct */
+  auto *t0 = static_cast<unsigned char *>(mm_pool_get_ptr(pool, 0));
+  auto *t1 = static_cast<unsigned char *>(mm_pool_get_ptr(pool, 1));
+  EXPECT_EQ(t0[0], 0xAA);
+  EXPECT_EQ(t0[255], 0xAA);
+  EXPECT_EQ(t1[0], 0xBB);
+  EXPECT_EQ(t1[255], 0xBB);
 
-    mm_destroy_pool(pool);
+  mm_destroy_pool(pool);
 }


### PR DESCRIPTION
## Summary

- Introduce a hardware-abstracted Unified Memory Manager (UMM) that replaces all direct `hipMalloc`/`hipFree`/`hipMemcpy` calls in the runtime with a layered allocator architecture
- HAL abstraction layer with HIP and CPU backends, pluggable via function-pointer table
- Size-class arena bump allocator (8 classes, lock-free atomic fetch-add) with BFC fallback for large allocations
- Static pool manager for compiler-planned weight tensors (single HAL alloc + O(1) offset lookup)
- Paged KV cache block allocator with lock-free free lists, slab allocation, and Copy-on-Write fork for beam search/speculative decoding
- Block table builder with contiguous materialization bridge for existing GEMM kernels
- Fully wired into the runtime hot path: all tensor I/O, pool allocation, and workspace management route through MM
- 62 GoogleTest unit tests, 20/21 E2E model tests passing (unchanged baseline)

## Architecture

```
Existing Runtime (inference_init/compute/cleanup)
        ↓
    mm_* C API Surface (mm_runtime_bridge.h)
        ↓
┌──────────┬──────────────┬────────────┐
│ Static   │ Dynamic      │ KV Cache   │
│ Pool     │ Arena + BFC  │ (Paged)    │
├──────────┴──────────────┴────────────┤
│       Handle Table (ID registry)     │
├──────────────────────────────────────┤
│   Hardware Abstraction Layer (HAL)   │
├──────────┬───────────────────────────┤
│ CPU/Host │ ROCm/HIP                 │
└──────────┴───────────────────────────┘
```

## Test plan

- [x] 62 GoogleTest unit tests pass (HAL, handle table, lifecycle, pool, arena, core, free list, KV block, KV fork, block table)
- [x] 20/21 E2E model tests pass (`test_qmoe_model` is pre-existing failure)
- [x] Full build succeeds with MSVC + Clang bitcode pipeline
- [x] MM debug logging verified via `HIPDNN_EP_DEBUG=1` (shows init, pool, tensor alloc/free, workspace, shutdown)
- [ ] CI pipeline validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)