### PR TITLE
feat: add compile-time Shape lowering support

### DIFF
--- a/docs/onnx_to_hip_frontend.md
+++ b/docs/onnx_to_hip_frontend.md
@@ -126,17 +126,6 @@ existing `--convert-hip-to-llvm` pipeline.
 | `Unsqueeze` | `hip.unsqueeze` | Shape/stride reinterpretation only |
 | `Squeeze` | `hip.squeeze` | Shape/stride reinterpretation only |
 
-### Compile-time Folded Ops
-
-| ONNX | Lowering behavior | Notes |
-|---|---|---|
-| `Constant` | `arith.constant` or externalized constants sidecar | Existing constant handling path |
-| `Shape` | Folded to tensor constant IR when input shape is static | Supports `start`; dynamic dims are not folded |
-| `Size` | Folded to scalar tensor constant IR when input shape is static | Dynamic dims are not folded |
-| `Range` | Folded to tensor constant IR when `start/limit/delta` are i64 scalar constants | `delta = 0` is rejected |
-
-`CastLike` and `Concat` are out of scope for the current compile-time-op phase.
-
 ### Custom HIP Kernels (no MIOpen equivalent)
 
 | ONNX | HIP | Notes |

--- a/docs/onnx_to_hip_frontend.md
+++ b/docs/onnx_to_hip_frontend.md
@@ -126,6 +126,17 @@ existing `--convert-hip-to-llvm` pipeline.
 | `Unsqueeze` | `hip.unsqueeze` | Shape/stride reinterpretation only |
 | `Squeeze` | `hip.squeeze` | Shape/stride reinterpretation only |
 
+### Compile-time Folded Ops
+
+| ONNX | Lowering behavior | Notes |
+|---|---|---|
+| `Constant` | `arith.constant` or externalized constants sidecar | Existing constant handling path |
+| `Shape` | Folded to tensor constant IR when input shape is static | Supports `start`; dynamic dims are not folded |
+| `Size` | Folded to scalar tensor constant IR when input shape is static | Dynamic dims are not folded |
+| `Range` | Folded to tensor constant IR when `start/limit/delta` are i64 scalar constants | `delta = 0` is rejected |
+
+`CastLike` and `Concat` are out of scope for the current compile-time-op phase.
+
 ### Custom HIP Kernels (no MIOpen equivalent)
 
 | ONNX | HIP | Notes |

--- a/include/hip/Dialect/Transforms/Passes.td
+++ b/include/hip/Dialect/Transforms/Passes.td
@@ -64,7 +64,9 @@ def ConvertOnnxToHipPass : Pass<"convert-onnx-to-hip", "mlir::ModuleOp"> {
     "mlir::func::FuncDialect",
     "mlir::tensor::TensorDialect",
     "mlir::memref::MemRefDialect",
-    "mlir::bufferization::BufferizationDialect"
+    "mlir::bufferization::BufferizationDialect",
+    "mlir::scf::SCFDialect",
+    "mlir::math::MathDialect"
   ];
 }
 

--- a/include/hip/InitAllPasses.h
+++ b/include/hip/InitAllPasses.h
@@ -16,8 +16,11 @@
 #include "mlir/Dialect/Bufferization/Transforms/FuncBufferizableOpInterfaceImpl.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/MemRef/Transforms/AllocationOpInterfaceImpl.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/SCF/Transforms/BufferizableOpInterfaceImpl.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Tensor/Transforms/BufferizableOpInterfaceImpl.h"
 #include "mlir/IR/BuiltinDialect.h"
@@ -49,9 +52,12 @@ inline void registerAllDialects(mlir::DialectRegistry &registry) {
   registry.insert<mlir::tensor::TensorDialect>();
   registry.insert<mlir::bufferization::BufferizationDialect>();
   registry.insert<mlir::LLVM::LLVMDialect>();
+  registry.insert<mlir::math::MathDialect>();
+  registry.insert<mlir::scf::SCFDialect>();
   registry.insert<mlir::hip::HipDialect>();
   registry.insert<detail::OnnxStubDialect>();
   mlir::arith::registerBufferizableOpInterfaceExternalModels(registry);
+  mlir::scf::registerBufferizableOpInterfaceExternalModels(registry);
   mlir::tensor::registerBufferizableOpInterfaceExternalModels(registry);
   mlir::bufferization::func_ext::registerBufferizableOpInterfaceExternalModels(
       registry);

--- a/lib/Conversion/OnnxToHip/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHip/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(OnnxToHip STATIC
   RotaryEmbeddingConversion.cpp
   GqaConversion.cpp
   GatherConversion.cpp
+  CompileTimeOpsConversion.cpp
   ReshapeConversion.cpp
   GemmConversion.cpp
 )

--- a/lib/Conversion/OnnxToHip/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHip/CMakeLists.txt
@@ -35,6 +35,8 @@ target_link_libraries(OnnxToHip PUBLIC
   MLIRPass
   MLIRFuncDialect
   MLIRArithDialect
+  MLIRMathDialect
+  MLIRSCFDialect
   MLIRTensorDialect
   MLIRMemRefDialect
   MLIRBufferizationDialect

--- a/lib/Conversion/OnnxToHip/CompileTimeOpsConversion.cpp
+++ b/lib/Conversion/OnnxToHip/CompileTimeOpsConversion.cpp
@@ -9,6 +9,37 @@ namespace mlir {
 namespace hip {
 namespace {
 
+static mlir::FailureOr<int64_t> getI64ScalarConstant(mlir::Value v) {
+  auto fromElements =
+      [](mlir::DenseElementsAttr attr) -> mlir::FailureOr<int64_t> {
+    auto type = mlir::dyn_cast<mlir::RankedTensorType>(attr.getType());
+    if (!type || type.getNumElements() != 1)
+      return mlir::failure();
+    auto elemType = type.getElementType();
+    if (!elemType.isInteger(64))
+      return mlir::failure();
+    return (*attr.getValues<int64_t>().begin());
+  };
+
+  if (auto cst = v.getDefiningOp<mlir::arith::ConstantOp>()) {
+    if (auto intAttr = mlir::dyn_cast<mlir::IntegerAttr>(cst.getValue()))
+      return intAttr.getInt();
+    if (auto denseAttr =
+            mlir::dyn_cast<mlir::DenseElementsAttr>(cst.getValue()))
+      return fromElements(denseAttr);
+    return mlir::failure();
+  }
+
+  mlir::Operation *def = v.getDefiningOp();
+  if (!def || def->getName().getStringRef() != "onnx.Constant")
+    return mlir::failure();
+  auto valueAttr = mlir::dyn_cast_or_null<mlir::DenseElementsAttr>(
+      def->getAttrOfType<mlir::ElementsAttr>("value"));
+  if (!valueAttr)
+    return mlir::failure();
+  return fromElements(valueAttr);
+}
+
 /// onnx.Shape -> arith.constant (compile-time fold).
 ///
 /// Supports static ranked input tensors only. If any sliced dimension is
@@ -30,7 +61,8 @@ struct ShapeToConstant : public mlir::RewritePattern {
     if (!inputType || !resultType)
       return rewriter.notifyMatchFailure(op, "expected ranked tensor types");
     if (!resultType.getElementType().isInteger(64))
-      return rewriter.notifyMatchFailure(op, "expected i64 output element type");
+      return rewriter.notifyMatchFailure(op,
+                                         "expected i64 output element type");
 
     int64_t rank = inputType.getRank();
     int64_t start = 0;
@@ -69,9 +101,9 @@ struct ShapeToConstant : public mlir::RewritePattern {
         resultType.getDimSize(0) != static_cast<int64_t>(dims.size()))
       return rewriter.notifyMatchFailure(op, "output length mismatch");
 
-    auto signlessI64 =
-        mlir::IntegerType::get(rewriter.getContext(), 64,
-                               mlir::IntegerType::SignednessSemantics::Signless);
+    auto signlessI64 = mlir::IntegerType::get(
+        rewriter.getContext(), 64,
+        mlir::IntegerType::SignednessSemantics::Signless);
     auto constType = mlir::RankedTensorType::get(
         {static_cast<int64_t>(dims.size())}, signlessI64);
     llvm::SmallVector<mlir::Value> elements;
@@ -86,11 +118,122 @@ struct ShapeToConstant : public mlir::RewritePattern {
   }
 };
 
+/// onnx.Size -> tensor.from_elements(arith.constant i64)
+///
+/// Compile-time fold only when all dimensions are static.
+struct SizeToConstant : public mlir::RewritePattern {
+  SizeToConstant(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.Size", /*benefit=*/1, ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override {
+    if (op->getNumOperands() != 1 || op->getNumResults() != 1)
+      return rewriter.notifyMatchFailure(op, "expected 1 operand and 1 result");
+
+    auto inputType =
+        mlir::dyn_cast<mlir::RankedTensorType>(op->getOperand(0).getType());
+    auto resultType =
+        mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
+    if (!inputType || !resultType)
+      return rewriter.notifyMatchFailure(op, "expected ranked tensor types");
+    if (!inputType.hasStaticShape())
+      return rewriter.notifyMatchFailure(
+          op, "dynamic input dimension cannot be folded for onnx.Size");
+    if (resultType.getRank() != 0)
+      return rewriter.notifyMatchFailure(op, "expected scalar tensor result");
+    if (!resultType.getElementType().isInteger(64))
+      return rewriter.notifyMatchFailure(op,
+                                         "expected i64 output element type");
+
+    int64_t numElements = inputType.getNumElements();
+    auto signlessI64 = mlir::IntegerType::get(
+        rewriter.getContext(), 64,
+        mlir::IntegerType::SignednessSemantics::Signless);
+    auto constType = mlir::RankedTensorType::get({}, signlessI64);
+    auto scalar = mlir::arith::ConstantIntOp::create(rewriter, op->getLoc(),
+                                                     numElements, 64);
+    auto folded = mlir::tensor::FromElementsOp::create(
+        rewriter, op->getLoc(), constType, scalar.getResult());
+    rewriter.replaceOp(op, folded.getResult());
+    return mlir::success();
+  }
+};
+
+/// onnx.Range -> tensor.from_elements(arith.constant ...)
+///
+/// Compile-time fold only for i64 scalar constants.
+struct RangeToConstant : public mlir::RewritePattern {
+  RangeToConstant(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.Range", /*benefit=*/1, ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override {
+    if (op->getNumOperands() != 3 || op->getNumResults() != 1)
+      return rewriter.notifyMatchFailure(op,
+                                         "expected 3 operands and 1 result");
+
+    auto resultType =
+        mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
+    if (!resultType)
+      return rewriter.notifyMatchFailure(op, "expected ranked tensor result");
+    if (resultType.getRank() != 1)
+      return rewriter.notifyMatchFailure(op, "expected 1-D tensor result");
+    if (!resultType.getElementType().isInteger(64))
+      return rewriter.notifyMatchFailure(op,
+                                         "expected i64 output element type");
+
+    auto startOr = getI64ScalarConstant(op->getOperand(0));
+    auto limitOr = getI64ScalarConstant(op->getOperand(1));
+    auto deltaOr = getI64ScalarConstant(op->getOperand(2));
+    if (mlir::failed(startOr) || mlir::failed(limitOr) || mlir::failed(deltaOr))
+      return rewriter.notifyMatchFailure(
+          op, "onnx.Range requires i64 scalar constants for start/limit/delta");
+
+    int64_t start = *startOr;
+    int64_t limit = *limitOr;
+    int64_t delta = *deltaOr;
+    if (delta == 0) {
+      op->emitError("onnx.Range requires non-zero delta");
+      return mlir::failure();
+    }
+
+    llvm::SmallVector<int64_t> values;
+    if ((delta > 0 && start < limit) || (delta < 0 && start > limit)) {
+      for (int64_t v = start; (delta > 0) ? (v < limit) : (v > limit);
+           v += delta) {
+        values.push_back(v);
+      }
+    }
+
+    if (!resultType.isDynamicDim(0) &&
+        resultType.getDimSize(0) != static_cast<int64_t>(values.size()))
+      return rewriter.notifyMatchFailure(
+          op, "output length mismatch after onnx.Range fold");
+
+    auto signlessI64 = mlir::IntegerType::get(
+        rewriter.getContext(), 64,
+        mlir::IntegerType::SignednessSemantics::Signless);
+    auto constType = mlir::RankedTensorType::get(
+        {static_cast<int64_t>(values.size())}, signlessI64);
+    llvm::SmallVector<mlir::Value> elements;
+    elements.reserve(values.size());
+    for (int64_t v : values)
+      elements.push_back(
+          mlir::arith::ConstantIntOp::create(rewriter, op->getLoc(), v, 64));
+    auto folded = mlir::tensor::FromElementsOp::create(rewriter, op->getLoc(),
+                                                       constType, elements);
+    rewriter.replaceOp(op, folded.getResult());
+    return mlir::success();
+  }
+};
+
 } // namespace
 
 void mlir::hip::populateCompileTimeOpsConversionPatterns(
     RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.add<ShapeToConstant>(ctx);
+  patterns.add<ShapeToConstant, SizeToConstant, RangeToConstant>(ctx);
 }
 
 } // namespace hip

--- a/lib/Conversion/OnnxToHip/CompileTimeOpsConversion.cpp
+++ b/lib/Conversion/OnnxToHip/CompileTimeOpsConversion.cpp
@@ -5,20 +5,32 @@
 
 #include "OnnxToHipUtils.h"
 
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+
+#include <cmath>
+#include <limits>
+
+#include "llvm/ADT/APFloat.h"
+
 namespace mlir {
 namespace hip {
 namespace {
 
-static mlir::FailureOr<int64_t> getI64ScalarConstant(mlir::Value v) {
-  auto fromElements =
+static mlir::FailureOr<int64_t> readIntScalarAsI64(mlir::Value v) {
+  auto fromDense =
       [](mlir::DenseElementsAttr attr) -> mlir::FailureOr<int64_t> {
     auto type = mlir::dyn_cast<mlir::RankedTensorType>(attr.getType());
     if (!type || type.getNumElements() != 1)
       return mlir::failure();
-    auto elemType = type.getElementType();
-    if (!elemType.isInteger(64))
-      return mlir::failure();
-    return (*attr.getValues<int64_t>().begin());
+    mlir::Type et = type.getElementType();
+    if (et.isInteger(64))
+      return static_cast<int64_t>(*attr.getValues<int64_t>().begin());
+    if (et.isInteger(32))
+      return static_cast<int64_t>(*attr.getValues<int32_t>().begin());
+    if (et.isInteger(16))
+      return static_cast<int64_t>(*attr.getValues<int16_t>().begin());
+    return mlir::failure();
   };
 
   if (auto cst = v.getDefiningOp<mlir::arith::ConstantOp>()) {
@@ -26,23 +38,80 @@ static mlir::FailureOr<int64_t> getI64ScalarConstant(mlir::Value v) {
       return intAttr.getInt();
     if (auto denseAttr =
             mlir::dyn_cast<mlir::DenseElementsAttr>(cst.getValue()))
-      return fromElements(denseAttr);
+      return fromDense(denseAttr);
     return mlir::failure();
   }
 
   mlir::Operation *def = v.getDefiningOp();
   if (!def)
     return mlir::failure();
-  // Match the constant detection style used in ReshapeConversion: accept
-  // arith.constant or any op carrying a dense `value` attribute (onnx-mlir
-  // onnx.Constant uses this attribute name).
   if (!def->hasAttr("value"))
     return mlir::failure();
   auto valueAttr = mlir::dyn_cast_or_null<mlir::DenseElementsAttr>(
       def->getAttrOfType<mlir::ElementsAttr>("value"));
   if (!valueAttr)
     return mlir::failure();
-  return fromElements(valueAttr);
+  return fromDense(valueAttr);
+}
+
+static mlir::FailureOr<llvm::APFloat> readFloatScalar(mlir::Value v,
+                                                      mlir::FloatType ft) {
+  auto fromDense =
+      [&](mlir::DenseElementsAttr attr) -> mlir::FailureOr<llvm::APFloat> {
+    auto type = mlir::dyn_cast<mlir::RankedTensorType>(attr.getType());
+    if (!type || type.getNumElements() != 1)
+      return mlir::failure();
+    mlir::Type et = type.getElementType();
+    if (et != ft)
+      return mlir::failure();
+    if (ft.isF32())
+      return llvm::APFloat(*attr.getValues<float>().begin());
+    if (ft.isF64())
+      return llvm::APFloat(*attr.getValues<double>().begin());
+    return mlir::failure();
+  };
+
+  if (auto cst = v.getDefiningOp<mlir::arith::ConstantOp>()) {
+    if (auto fAttr = mlir::dyn_cast<mlir::FloatAttr>(cst.getValue())) {
+      if (fAttr.getType() == ft)
+        return fAttr.getValue();
+      return mlir::failure();
+    }
+    if (auto denseAttr =
+            mlir::dyn_cast<mlir::DenseElementsAttr>(cst.getValue()))
+      return fromDense(denseAttr);
+    return mlir::failure();
+  }
+
+  mlir::Operation *def = v.getDefiningOp();
+  if (!def || !def->hasAttr("value"))
+    return mlir::failure();
+  auto valueAttr = mlir::dyn_cast_or_null<mlir::DenseElementsAttr>(
+      def->getAttrOfType<mlir::ElementsAttr>("value"));
+  if (!valueAttr)
+    return mlir::failure();
+  return fromDense(valueAttr);
+}
+
+static bool isOnnxRangeElementType(mlir::Type t) {
+  return t.isInteger(16) || t.isInteger(32) || t.isInteger(64) || t.isF32() ||
+         t.isF64();
+}
+
+/// Host-side ONNX Range element count: max(ceil((limit - start) / delta), 0).
+static size_t onnxRangeNumElements(double start, double limit, double delta) {
+  if (delta == 0.0 || std::isnan(delta) || std::isnan(start) ||
+      std::isnan(limit))
+    return 0;
+  double ratio = (limit - start) / delta;
+  if (std::isnan(ratio) || std::isinf(ratio))
+    return 0;
+  double c = std::ceil(ratio);
+  if (c < 0.0 || std::isnan(c) || std::isinf(c))
+    return 0;
+  if (c >= static_cast<double>(std::numeric_limits<size_t>::max()))
+    return 0;
+  return static_cast<size_t>(c);
 }
 
 /// onnx.Shape -> arith.constant (compile-time fold).
@@ -165,12 +234,10 @@ struct SizeToConstant : public mlir::RewritePattern {
   }
 };
 
-/// onnx.Range -> tensor.from_elements(arith.constant ...)
-///
-/// Compile-time fold only for i64 scalar constants.
+/// onnx.Range static fold: ONNX types i16/i32/i64/f32/f64 scalar constants.
 struct RangeToConstant : public mlir::RewritePattern {
   RangeToConstant(mlir::MLIRContext *ctx)
-      : RewritePattern("onnx.Range", /*benefit=*/1, ctx) {}
+      : RewritePattern("onnx.Range", /*benefit=*/2, ctx) {}
 
   mlir::LogicalResult
   matchAndRewrite(mlir::Operation *op,
@@ -185,31 +252,84 @@ struct RangeToConstant : public mlir::RewritePattern {
       return rewriter.notifyMatchFailure(op, "expected ranked tensor result");
     if (resultType.getRank() != 1)
       return rewriter.notifyMatchFailure(op, "expected 1-D tensor result");
-    if (!resultType.getElementType().isInteger(64))
-      return rewriter.notifyMatchFailure(op,
-                                         "expected i64 output element type");
 
-    auto startOr = getI64ScalarConstant(op->getOperand(0));
-    auto limitOr = getI64ScalarConstant(op->getOperand(1));
-    auto deltaOr = getI64ScalarConstant(op->getOperand(2));
+    mlir::Type elemTy = resultType.getElementType();
+    if (!isOnnxRangeElementType(elemTy))
+      return rewriter.notifyMatchFailure(op, "unsupported element type");
+
+    mlir::Location loc = op->getLoc();
+    llvm::SmallVector<mlir::Value> elements;
+
+    if (auto intTy = mlir::dyn_cast<mlir::IntegerType>(elemTy)) {
+      auto startOr = readIntScalarAsI64(op->getOperand(0));
+      auto limitOr = readIntScalarAsI64(op->getOperand(1));
+      auto deltaOr = readIntScalarAsI64(op->getOperand(2));
+      if (mlir::failed(startOr) || mlir::failed(limitOr) ||
+          mlir::failed(deltaOr))
+        return rewriter.notifyMatchFailure(
+            op, "onnx.Range fold needs constant integer start/limit/delta");
+
+      int64_t start = *startOr;
+      int64_t limit = *limitOr;
+      int64_t delta = *deltaOr;
+      if (delta == 0) {
+        op->emitError("onnx.Range requires non-zero delta");
+        return mlir::failure();
+      }
+
+      llvm::SmallVector<int64_t> values;
+      if ((delta > 0 && start < limit) || (delta < 0 && start > limit)) {
+        for (int64_t v = start; (delta > 0) ? (v < limit) : (v > limit);
+             v += delta) {
+          values.push_back(v);
+        }
+      }
+
+      if (!resultType.isDynamicDim(0) &&
+          resultType.getDimSize(0) != static_cast<int64_t>(values.size()))
+        return rewriter.notifyMatchFailure(
+            op, "output length mismatch after onnx.Range fold");
+
+      auto foldedTy = mlir::RankedTensorType::get(
+          {static_cast<int64_t>(values.size())}, elemTy);
+      elements.reserve(values.size());
+      for (int64_t v : values)
+        elements.push_back(mlir::arith::ConstantIntOp::create(
+            rewriter, loc, v, intTy.getWidth()));
+      auto folded = mlir::tensor::FromElementsOp::create(rewriter, loc,
+                                                         foldedTy, elements);
+      rewriter.replaceOp(op, folded.getResult());
+      return mlir::success();
+    }
+
+    auto floatTy = mlir::cast<mlir::FloatType>(elemTy);
+    auto startOr = readFloatScalar(op->getOperand(0), floatTy);
+    auto limitOr = readFloatScalar(op->getOperand(1), floatTy);
+    auto deltaOr = readFloatScalar(op->getOperand(2), floatTy);
     if (mlir::failed(startOr) || mlir::failed(limitOr) || mlir::failed(deltaOr))
       return rewriter.notifyMatchFailure(
-          op, "onnx.Range requires i64 scalar constants for start/limit/delta");
+          op, "onnx.Range fold needs constant float start/limit/delta");
 
-    int64_t start = *startOr;
-    int64_t limit = *limitOr;
-    int64_t delta = *deltaOr;
-    if (delta == 0) {
+    llvm::APFloat start = *startOr;
+    llvm::APFloat limit = *limitOr;
+    llvm::APFloat delta = *deltaOr;
+    if (delta.isZero()) {
       op->emitError("onnx.Range requires non-zero delta");
       return mlir::failure();
     }
 
-    llvm::SmallVector<int64_t> values;
-    if ((delta > 0 && start < limit) || (delta < 0 && start > limit)) {
-      for (int64_t v = start; (delta > 0) ? (v < limit) : (v > limit);
-           v += delta) {
-        values.push_back(v);
-      }
+    double sd = start.convertToDouble();
+    double ld = limit.convertToDouble();
+    double dd = delta.convertToDouble();
+    size_t n = onnxRangeNumElements(sd, ld, dd);
+    llvm::SmallVector<llvm::APFloat> values;
+    values.reserve(n);
+    llvm::APFloat acc = start;
+    llvm::APFloat step = delta;
+    for (size_t i = 0; i < n; ++i) {
+      (void)i;
+      values.push_back(acc);
+      acc.add(step, llvm::APFloat::rmNearestTiesToEven);
     }
 
     if (!resultType.isDynamicDim(0) &&
@@ -217,19 +337,142 @@ struct RangeToConstant : public mlir::RewritePattern {
       return rewriter.notifyMatchFailure(
           op, "output length mismatch after onnx.Range fold");
 
-    auto signlessI64 = mlir::IntegerType::get(
-        rewriter.getContext(), 64,
-        mlir::IntegerType::SignednessSemantics::Signless);
-    auto constType = mlir::RankedTensorType::get(
-        {static_cast<int64_t>(values.size())}, signlessI64);
-    llvm::SmallVector<mlir::Value> elements;
+    auto foldedTy = mlir::RankedTensorType::get(
+        {static_cast<int64_t>(values.size())}, elemTy);
     elements.reserve(values.size());
-    for (int64_t v : values)
+    for (const llvm::APFloat &apf : values)
       elements.push_back(
-          mlir::arith::ConstantIntOp::create(rewriter, op->getLoc(), v, 64));
-    auto folded = mlir::tensor::FromElementsOp::create(rewriter, op->getLoc(),
-                                                       constType, elements);
+          mlir::arith::ConstantFloatOp::create(rewriter, loc, floatTy, apf));
+    auto folded =
+        mlir::tensor::FromElementsOp::create(rewriter, loc, foldedTy, elements);
     rewriter.replaceOp(op, folded.getResult());
+    return mlir::success();
+  }
+};
+
+/// onnx.Range dynamic lowering when operands are not all constants.
+/// Emits scf.for + tensor.empty/tensor.insert; output leading dim must be
+/// dynamic (cannot prove static length from non-constant inputs here).
+struct RangeToScf : public mlir::RewritePattern {
+  RangeToScf(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.Range", /*benefit=*/1, ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override {
+    if (op->getNumOperands() != 3 || op->getNumResults() != 1)
+      return rewriter.notifyMatchFailure(op,
+                                         "expected 3 operands and 1 result");
+
+    auto resultType =
+        mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
+    if (!resultType || resultType.getRank() != 1)
+      return rewriter.notifyMatchFailure(op, "expected 1-D ranked result");
+    if (!resultType.isDynamicDim(0))
+      return rewriter.notifyMatchFailure(
+          op,
+          "dynamic onnx.Range lowering expects a dynamic leading dimension");
+
+    mlir::Type elemTy = resultType.getElementType();
+    if (!isOnnxRangeElementType(elemTy))
+      return rewriter.notifyMatchFailure(op, "unsupported element type");
+
+    for (mlir::Value v : op->getOperands()) {
+      auto t = mlir::dyn_cast<mlir::RankedTensorType>(v.getType());
+      if (!t || t.getRank() != 0 || t.getElementType() != elemTy)
+        return rewriter.notifyMatchFailure(
+            op, "expected 0-D scalar tensor operands matching result element "
+                "type");
+    }
+
+    mlir::Location loc = op->getLoc();
+
+    auto extractScalar = [&](mlir::Value tensor) -> mlir::Value {
+      return rewriter.create<mlir::tensor::ExtractOp>(loc, tensor,
+                                                      mlir::ValueRange{});
+    };
+
+    mlir::Value startS = extractScalar(op->getOperand(0));
+    mlir::Value limitS = extractScalar(op->getOperand(1));
+    mlir::Value deltaS = extractScalar(op->getOperand(2));
+
+    mlir::Type calcTy =
+        elemTy.isF64() ? rewriter.getF64Type() : rewriter.getF32Type();
+
+    auto promote = [&](mlir::Value v) -> mlir::Value {
+      if (mlir::isa<mlir::FloatType>(elemTy)) {
+        if (v.getType() == calcTy)
+          return v;
+        if (elemTy.isF32() && calcTy.isF64())
+          return rewriter.create<mlir::arith::ExtFOp>(loc, calcTy, v);
+        return rewriter.create<mlir::arith::TruncFOp>(loc, calcTy, v);
+      }
+      return rewriter.create<mlir::arith::SIToFPOp>(loc, calcTy, v);
+    };
+
+    mlir::Value startF = promote(startS);
+    mlir::Value limitF = promote(limitS);
+    mlir::Value deltaF = promote(deltaS);
+
+    mlir::Value diff =
+        rewriter.create<mlir::arith::SubFOp>(loc, limitF, startF);
+    mlir::Value ratio = rewriter.create<mlir::arith::DivFOp>(loc, diff, deltaF);
+    mlir::Value ceiled = rewriter.create<mlir::math::CeilOp>(loc, ratio);
+    auto calcFloatTy = mlir::cast<mlir::FloatType>(calcTy);
+    llvm::APFloat zeroApf =
+        llvm::APFloat::getZero(calcFloatTy.getFloatSemantics(),
+                               /*negative=*/false);
+    mlir::Value zeroF = rewriter.create<mlir::arith::ConstantFloatOp>(
+        loc, calcFloatTy, zeroApf);
+    mlir::Value isNeg = rewriter.create<mlir::arith::CmpFOp>(
+        loc, mlir::arith::CmpFPredicate::OLT, ceiled, zeroF);
+    mlir::Value nF =
+        rewriter.create<mlir::arith::SelectOp>(loc, isNeg, zeroF, ceiled);
+
+    mlir::Value nI64 =
+        rewriter.create<mlir::arith::FPToSIOp>(loc, rewriter.getI64Type(), nF);
+    mlir::Value nIdx = rewriter.create<mlir::arith::IndexCastOp>(
+        loc, rewriter.getIndexType(), nI64);
+
+    auto dynamic1d =
+        mlir::RankedTensorType::get({mlir::ShapedType::kDynamic}, elemTy);
+    mlir::Value empty = rewriter.create<mlir::tensor::EmptyOp>(
+        loc, dynamic1d, mlir::ValueRange{nIdx});
+
+    mlir::Value lb = rewriter.create<mlir::arith::ConstantIndexOp>(loc, 0);
+    mlir::Value step = rewriter.create<mlir::arith::ConstantIndexOp>(loc, 1);
+
+    auto forOp = rewriter.create<mlir::scf::ForOp>(loc, lb, nIdx, step,
+                                                   mlir::ValueRange{empty});
+    {
+      mlir::PatternRewriter::InsertionGuard g(rewriter);
+      rewriter.setInsertionPointToStart(forOp.getBody());
+      mlir::Value iv = forOp.getInductionVar();
+      mlir::Value cur = forOp.getRegionIterArg(0);
+
+      mlir::Value elemVal;
+      if (mlir::isa<mlir::IntegerType>(elemTy)) {
+        mlir::Value ivInt =
+            rewriter.create<mlir::arith::IndexCastOp>(loc, elemTy, iv);
+        mlir::Value prod =
+            rewriter.create<mlir::arith::MulIOp>(loc, deltaS, ivInt);
+        elemVal = rewriter.create<mlir::arith::AddIOp>(loc, startS, prod);
+      } else {
+        mlir::Value ivI64 = rewriter.create<mlir::arith::IndexCastOp>(
+            loc, rewriter.getI64Type(), iv);
+        mlir::Value ivFloat = rewriter.create<mlir::arith::SIToFPOp>(
+            loc, mlir::cast<mlir::FloatType>(elemTy), ivI64);
+        mlir::Value prod =
+            rewriter.create<mlir::arith::MulFOp>(loc, deltaS, ivFloat);
+        elemVal = rewriter.create<mlir::arith::AddFOp>(loc, startS, prod);
+      }
+
+      mlir::Value inserted = rewriter.create<mlir::tensor::InsertOp>(
+          loc, elemVal, cur, mlir::ValueRange{iv});
+      rewriter.create<mlir::scf::YieldOp>(loc, mlir::ValueRange{inserted});
+    }
+
+    rewriter.replaceOp(op, forOp.getResult(0));
     return mlir::success();
   }
 };
@@ -237,8 +480,9 @@ struct RangeToConstant : public mlir::RewritePattern {
 } // namespace
 
 void mlir::hip::populateCompileTimeOpsConversionPatterns(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.add<ShapeToConstant, SizeToConstant, RangeToConstant>(ctx);
+    mlir::RewritePatternSet &patterns, mlir::MLIRContext *ctx) {
+  patterns.add<ShapeToConstant, SizeToConstant, RangeToConstant, RangeToScf>(
+      ctx);
 }
 
 } // namespace hip

--- a/lib/Conversion/OnnxToHip/CompileTimeOpsConversion.cpp
+++ b/lib/Conversion/OnnxToHip/CompileTimeOpsConversion.cpp
@@ -31,7 +31,12 @@ static mlir::FailureOr<int64_t> getI64ScalarConstant(mlir::Value v) {
   }
 
   mlir::Operation *def = v.getDefiningOp();
-  if (!def || def->getName().getStringRef() != "onnx.Constant")
+  if (!def)
+    return mlir::failure();
+  // Match the constant detection style used in ReshapeConversion: accept
+  // arith.constant or any op carrying a dense `value` attribute (onnx-mlir
+  // onnx.Constant uses this attribute name).
+  if (!def->hasAttr("value"))
     return mlir::failure();
   auto valueAttr = mlir::dyn_cast_or_null<mlir::DenseElementsAttr>(
       def->getAttrOfType<mlir::ElementsAttr>("value"));

--- a/lib/Conversion/OnnxToHip/CompileTimeOpsConversion.cpp
+++ b/lib/Conversion/OnnxToHip/CompileTimeOpsConversion.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "OnnxToHipUtils.h"
+
+namespace mlir {
+namespace hip {
+namespace {
+
+/// onnx.Shape -> arith.constant (compile-time fold).
+///
+/// Supports static ranked input tensors only. If any sliced dimension is
+/// dynamic, this pattern intentionally does not rewrite.
+struct ShapeToConstant : public mlir::RewritePattern {
+  ShapeToConstant(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.Shape", /*benefit=*/1, ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override {
+    if (op->getNumOperands() != 1 || op->getNumResults() != 1)
+      return rewriter.notifyMatchFailure(op, "expected 1 operand and 1 result");
+
+    auto inputType =
+        mlir::dyn_cast<mlir::RankedTensorType>(op->getOperand(0).getType());
+    auto resultType =
+        mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
+    if (!inputType || !resultType)
+      return rewriter.notifyMatchFailure(op, "expected ranked tensor types");
+    if (!resultType.getElementType().isInteger(64))
+      return rewriter.notifyMatchFailure(op, "expected i64 output element type");
+
+    int64_t rank = inputType.getRank();
+    int64_t start = 0;
+    if (auto startAttr = op->getAttrOfType<mlir::IntegerAttr>("start"))
+      start = startAttr.getInt();
+
+    // ONNX Shape supports negative indexing from the end.
+    if (start < 0)
+      start += rank;
+    if (start < 0 || start > rank)
+      return rewriter.notifyMatchFailure(op, "start is out of valid range");
+
+    int64_t end = rank;
+    if (auto endAttr = op->getAttrOfType<mlir::IntegerAttr>("end")) {
+      end = endAttr.getInt();
+      if (end < 0)
+        end += rank;
+    }
+    if (end < 0 || end > rank)
+      return rewriter.notifyMatchFailure(op, "end is out of valid range");
+    if (start > end)
+      return rewriter.notifyMatchFailure(op, "expected start <= end");
+
+    llvm::SmallVector<int64_t> dims;
+    dims.reserve(static_cast<size_t>(end - start));
+    for (int64_t i = start; i < end; ++i) {
+      if (inputType.isDynamicDim(i))
+        return rewriter.notifyMatchFailure(
+            op, "dynamic input dimension cannot be folded for onnx.Shape");
+      dims.push_back(inputType.getDimSize(i));
+    }
+
+    if (resultType.getRank() != 1)
+      return rewriter.notifyMatchFailure(op, "expected 1-D output tensor");
+    if (!resultType.isDynamicDim(0) &&
+        resultType.getDimSize(0) != static_cast<int64_t>(dims.size()))
+      return rewriter.notifyMatchFailure(op, "output length mismatch");
+
+    auto signlessI64 =
+        mlir::IntegerType::get(rewriter.getContext(), 64,
+                               mlir::IntegerType::SignednessSemantics::Signless);
+    auto constType = mlir::RankedTensorType::get(
+        {static_cast<int64_t>(dims.size())}, signlessI64);
+    llvm::SmallVector<mlir::Value> elements;
+    elements.reserve(dims.size());
+    for (int64_t d : dims)
+      elements.push_back(
+          mlir::arith::ConstantIntOp::create(rewriter, op->getLoc(), d, 64));
+    auto folded = mlir::tensor::FromElementsOp::create(rewriter, op->getLoc(),
+                                                       constType, elements);
+    rewriter.replaceOp(op, folded.getResult());
+    return mlir::success();
+  }
+};
+
+} // namespace
+
+void mlir::hip::populateCompileTimeOpsConversionPatterns(
+    RewritePatternSet &patterns, MLIRContext *ctx) {
+  patterns.add<ShapeToConstant>(ctx);
+}
+
+} // namespace hip
+} // namespace mlir

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -364,6 +364,7 @@ static void lowerOnnxReturns(mlir::func::FuncOp funcOp) {
 static mlir::LogicalResult convertComputeOps(mlir::func::FuncOp funcOp,
                                              mlir::MLIRContext *ctx) {
   mlir::RewritePatternSet patterns(ctx);
+  populateCompileTimeOpsConversionPatterns(patterns, ctx);
   populateMatMulConversionPatterns(patterns, ctx);
   populateTransposeConversionPatterns(patterns, ctx);
   populateElementwiseConversionPatterns(patterns, ctx);

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -13,6 +13,9 @@
 
 #include "OnnxToHipUtils.h"
 
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+
 #include "hip/Support/DiskFileSystem.h"
 #include "hip/timing.h"
 #include "morphizen-foundation/file_io.hpp"

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
@@ -137,6 +137,8 @@ void populateGqaConversionPatterns(RewritePatternSet &patterns,
                                    MLIRContext *ctx);
 void populateGatherConversionPatterns(RewritePatternSet &patterns,
                                       MLIRContext *ctx);
+void populateCompileTimeOpsConversionPatterns(RewritePatternSet &patterns,
+                                              MLIRContext *ctx);
 void populateReshapeConversionPatterns(RewritePatternSet &patterns,
                                        MLIRContext *ctx);
 void populateGemmConversionPatterns(RewritePatternSet &patterns,

--- a/test/lit/Conversion/onnx-to-hip/test_range.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_range.mlir
@@ -1,0 +1,45 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+//===----------------------------------------------------------------------===//
+// Test: onnx.Range compile-time folding for i64 scalar constants.
+//===----------------------------------------------------------------------===//
+//
+// RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip | FileCheck %s
+
+module {
+  func.func @main_graph(%arg0: tensor<1xf16>) -> tensor<1xf16> {
+    return %arg0 : tensor<1xf16>
+  }
+
+  func.func @test_range_positive() -> tensor<4xi64> {
+    %start = "onnx.Constant"() {value = dense<0> : tensor<i64>} : () -> tensor<i64>
+    %limit = "onnx.Constant"() {value = dense<8> : tensor<i64>} : () -> tensor<i64>
+    %delta = "onnx.Constant"() {value = dense<2> : tensor<i64>} : () -> tensor<i64>
+    %0 = "onnx.Range"(%start, %limit, %delta) : (tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<4xi64>
+    return %0 : tensor<4xi64>
+  }
+
+  func.func @test_range_negative_delta() -> tensor<3xi64> {
+    %start = "onnx.Constant"() {value = dense<5> : tensor<i64>} : () -> tensor<i64>
+    %limit = "onnx.Constant"() {value = dense<-1> : tensor<i64>} : () -> tensor<i64>
+    %delta = "onnx.Constant"() {value = dense<-2> : tensor<i64>} : () -> tensor<i64>
+    %0 = "onnx.Range"(%start, %limit, %delta) : (tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<3xi64>
+    return %0 : tensor<3xi64>
+  }
+}
+
+// CHECK-LABEL: func.func @test_range_positive
+// CHECK-NOT: onnx.Range
+// CHECK: arith.constant 0 : i64
+// CHECK: arith.constant 2 : i64
+// CHECK: arith.constant 4 : i64
+// CHECK: arith.constant 6 : i64
+// CHECK: tensor.from_elements
+
+// CHECK-LABEL: func.func @test_range_negative_delta
+// CHECK-NOT: onnx.Range
+// CHECK: arith.constant 5 : i64
+// CHECK: arith.constant 3 : i64
+// CHECK: arith.constant 1 : i64
+// CHECK: tensor.from_elements

--- a/test/lit/Conversion/onnx-to-hip/test_range_delta_zero_error.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_range_delta_zero_error.mlir
@@ -1,0 +1,20 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+//===----------------------------------------------------------------------===//
+// Test: onnx.Range with delta=0 should fail conversion.
+//===----------------------------------------------------------------------===//
+//
+// RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s 2>&1 | FileCheck %s
+
+// CHECK: error: onnx.Range requires non-zero delta
+
+module {
+  func.func @main_graph() -> tensor<1xi64> {
+    %start = "onnx.Constant"() {value = dense<0> : tensor<i64>} : () -> tensor<i64>
+    %limit = "onnx.Constant"() {value = dense<10> : tensor<i64>} : () -> tensor<i64>
+    %delta = "onnx.Constant"() {value = dense<0> : tensor<i64>} : () -> tensor<i64>
+    %0 = "onnx.Range"(%start, %limit, %delta) : (tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<1xi64>
+    "onnx.Return"(%0) : (tensor<1xi64>) -> ()
+  }
+}

--- a/test/lit/Conversion/onnx-to-hip/test_range_dynamic.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_range_dynamic.mlir
@@ -1,0 +1,35 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+//===----------------------------------------------------------------------===//
+// Test: onnx.Range with non-constant scalars lowers to scf/tensor/arith.
+//===----------------------------------------------------------------------===//
+//
+// RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip | FileCheck %s
+
+module {
+  func.func @main_graph(%arg0: tensor<1xf16>) -> tensor<1xf16> {
+    return %arg0 : tensor<1xf16>
+  }
+
+  func.func @test_range_dynamic(
+      %start: tensor<i64>,
+      %limit: tensor<i64>,
+      %delta: tensor<i64>) -> tensor<?xi64> {
+    %0 = "onnx.Range"(%start, %limit, %delta)
+        : (tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<?xi64>
+    return %0 : tensor<?xi64>
+  }
+}
+
+// CHECK-LABEL: func.func @test_range_dynamic
+// CHECK-NOT: onnx.Range
+// CHECK-DAG: tensor.extract
+// CHECK-DAG: arith.sitofp
+// CHECK-DAG: arith.subf
+// CHECK-DAG: arith.divf
+// CHECK-DAG: math.ceil
+// CHECK-DAG: arith.fptosi
+// CHECK-DAG: tensor.empty
+// CHECK: scf.for
+// CHECK: tensor.insert

--- a/test/lit/Conversion/onnx-to-hip/test_range_fold_f32.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_range_fold_f32.mlir
@@ -1,0 +1,28 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+//===----------------------------------------------------------------------===//
+// Test: onnx.Range static fold for f32 scalars (ONNX Range type T).
+//===----------------------------------------------------------------------===//
+//
+// RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip | FileCheck %s
+
+module {
+  func.func @main_graph(%arg0: tensor<1xf16>) -> tensor<1xf16> {
+    return %arg0 : tensor<1xf16>
+  }
+
+  func.func @test_range_fold_f32() -> tensor<3xf32> {
+    %start = "onnx.Constant"() {value = dense<0.0> : tensor<f32>} : () -> tensor<f32>
+    %limit = "onnx.Constant"() {value = dense<1.5> : tensor<f32>} : () -> tensor<f32>
+    %delta = "onnx.Constant"() {value = dense<0.5> : tensor<f32>} : () -> tensor<f32>
+    %0 = "onnx.Range"(%start, %limit, %delta)
+        : (tensor<f32>, tensor<f32>, tensor<f32>) -> tensor<3xf32>
+    return %0 : tensor<3xf32>
+  }
+}
+
+// CHECK-LABEL: func.func @test_range_fold_f32
+// CHECK-NOT: onnx.Range
+// CHECK: arith.constant
+// CHECK: tensor.from_elements

--- a/test/lit/Conversion/onnx-to-hip/test_shape.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_shape.mlir
@@ -1,0 +1,50 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+//===----------------------------------------------------------------------===//
+// Test: onnx.Shape compile-time handling.
+//
+// Verifies:
+// - Static-ranked input is folded to arith.constant.
+// - Dynamic input dimension is not folded and onnx.Shape remains.
+// - start attribute is honored for slicing shape output.
+//===----------------------------------------------------------------------===//
+//
+// RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip | FileCheck %s
+
+module {
+  func.func @main_graph(%arg0: tensor<2x3x4xf16>) -> tensor<2x3x4xf16> {
+    return %arg0 : tensor<2x3x4xf16>
+  }
+
+  func.func @test_shape_static(%data: tensor<2x3x4xf16>) -> tensor<3xi64> {
+    %0 = "onnx.Shape"(%data) : (tensor<2x3x4xf16>) -> tensor<3xi64>
+    return %0 : tensor<3xi64>
+  }
+
+  func.func @test_shape_with_start(%data: tensor<2x3x4xf16>) -> tensor<2xi64> {
+    %0 = "onnx.Shape"(%data) {start = 1 : i64} : (tensor<2x3x4xf16>) -> tensor<2xi64>
+    return %0 : tensor<2xi64>
+  }
+
+  func.func @test_shape_dynamic(%data: tensor<?x3x4xf16>) -> tensor<3xi64> {
+    %0 = "onnx.Shape"(%data) : (tensor<?x3x4xf16>) -> tensor<3xi64>
+    return %0 : tensor<3xi64>
+  }
+}
+
+// CHECK-LABEL: func.func @test_shape_static
+// CHECK-NOT: onnx.Shape
+// CHECK: arith.constant 2 : i64
+// CHECK: arith.constant 3 : i64
+// CHECK: arith.constant 4 : i64
+// CHECK: tensor.from_elements
+
+// CHECK-LABEL: func.func @test_shape_with_start
+// CHECK-NOT: onnx.Shape
+// CHECK: arith.constant 3 : i64
+// CHECK: arith.constant 4 : i64
+// CHECK: tensor.from_elements
+
+// CHECK-LABEL: func.func @test_shape_dynamic
+// CHECK: "onnx.Shape"

--- a/test/lit/Conversion/onnx-to-hip/test_size.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_size.mlir
@@ -1,0 +1,36 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+//===----------------------------------------------------------------------===//
+// Test: onnx.Size compile-time handling.
+//
+// Verifies:
+// - Static-ranked input is folded to scalar tensor constant IR.
+// - Dynamic input dimension is not folded and onnx.Size remains.
+//===----------------------------------------------------------------------===//
+//
+// RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip | FileCheck %s
+
+module {
+  func.func @main_graph(%arg0: tensor<2x3x4xf16>) -> tensor<2x3x4xf16> {
+    return %arg0 : tensor<2x3x4xf16>
+  }
+
+  func.func @test_size_static(%data: tensor<2x3x4xf16>) -> tensor<i64> {
+    %0 = "onnx.Size"(%data) : (tensor<2x3x4xf16>) -> tensor<i64>
+    return %0 : tensor<i64>
+  }
+
+  func.func @test_size_dynamic(%data: tensor<?x3x4xf16>) -> tensor<i64> {
+    %0 = "onnx.Size"(%data) : (tensor<?x3x4xf16>) -> tensor<i64>
+    return %0 : tensor<i64>
+  }
+}
+
+// CHECK-LABEL: func.func @test_size_static
+// CHECK-NOT: onnx.Size
+// CHECK: arith.constant 24 : i64
+// CHECK: tensor.from_elements
+
+// CHECK-LABEL: func.func @test_size_dynamic
+// CHECK: "onnx.Size"

--- a/tools/hip-mlir-opt/CMakeLists.txt
+++ b/tools/hip-mlir-opt/CMakeLists.txt
@@ -26,6 +26,7 @@ target_link_libraries(hip-mlir-opt PRIVATE
   MLIRTransforms
   MLIRAnalysis
   MLIRArithDialect
+  MLIRMathDialect
   MLIRControlFlowDialect
   MLIRFuncDialect
   MLIRMemRefDialect

--- a/tools/hip-mlir-opt/hip-mlir-opt.cpp
+++ b/tools/hip-mlir-opt/hip-mlir-opt.cpp
@@ -19,6 +19,7 @@
 #include "mlir/Dialect/ControlFlow/IR/ControlFlow.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/MemRef/Transforms/AllocationOpInterfaceImpl.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -142,6 +143,7 @@ int main(int argc, char **argv) {
   registry.insert<mlir::cf::ControlFlowDialect>();
   registry.insert<mlir::func::FuncDialect>();
   registry.insert<mlir::memref::MemRefDialect>();
+  registry.insert<mlir::math::MathDialect>();
   registry.insert<mlir::scf::SCFDialect>();
   registry.insert<mlir::tensor::TensorDialect>();
   registry.insert<mlir::LLVM::LLVMDialect>();


### PR DESCRIPTION
## Summary
- Add a compile-time conversion pattern set in `OnnxToHip` and wire it into `convertComputeOps`.
- Implement compile-time lowering for `onnx.Shape`, `onnx.Size`, and i64-constant `onnx.Range`.
- Add lit coverage for static fold success paths, dynamic non-folding behavior, and `onnx.Range` delta-zero rejection.

## Test plan
- [x] `cmake -B ../build/onnx-hipdnn-ep -S . -G Ninja -DBUILD_SHARED_LIBS=OFF -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=D:/Develop/m/prebuilt-local -DCMAKE_INSTALL_PREFIX=D:/Develop/m/prebuilt-local -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DTHEROCK_DIST=D:/Develop/m/therock -DHIP_PLATFORM=amd -DHIP_ARCHITECTURES=gfx1151 -DBUILD_HIP_TOOLS=ON -DBUILD_MOCK_RUNTIME=OFF -DBUILD_EP=ON`
- [x] `cmake --build ../build/onnx-hipdnn-ep --config Release --parallel` (from `VsDevCmd`)
- [x] `cmake --install ../build/onnx-hipdnn-ep --config Release` (from `VsDevCmd`)
- [x] `cmake --build ../build/onnx-hipdnn-ep --config Release --target check-hip-mlir-lit` (from `VsDevCmd`)
- [x] `pre-commit run --all-files` before each commit