### PR TITLE
fix: treat RotaryEmbedding attributes as optional per ONNX spec

### DIFF
--- a/lib/Conversion/OnnxToHip/RotaryEmbeddingConversion.cpp
+++ b/lib/Conversion/OnnxToHip/RotaryEmbeddingConversion.cpp
@@ -50,23 +50,18 @@ RotaryEmbeddingToHip::matchAndRewrite(mlir::Operation *op,
   mlir::Value cosCache = op->getOperand(2);
   mlir::Value sinCache = op->getOperand(3);
 
-  // Extract attributes
+  // All attributes are optional per the ONNX com.microsoft.RotaryEmbedding
+  // spec.  Defaults: interleaved=0, num_heads=0, rotary_embedding_dim=0.
+  // A value of 0 for num_heads / rotary_embedding_dim means "infer from
+  // tensor shapes".
   auto interleavedAttr = op->getAttrOfType<mlir::IntegerAttr>("interleaved");
-  if (!interleavedAttr)
-    return rewriter.notifyMatchFailure(op, "missing interleaved attribute");
-
   auto numHeadsAttr = op->getAttrOfType<mlir::IntegerAttr>("num_heads");
-  if (!numHeadsAttr)
-    return rewriter.notifyMatchFailure(op, "missing num_heads attribute");
-
   auto rotaryDimAttr =
       op->getAttrOfType<mlir::IntegerAttr>("rotary_embedding_dim");
-  if (!rotaryDimAttr)
-    return rewriter.notifyMatchFailure(
-        op, "missing rotary_embedding_dim attribute");
 
-  int64_t numHeadsVal = numHeadsAttr.getSInt();
-  int64_t rotaryDimVal = rotaryDimAttr.getSInt();
+  int64_t interleavedVal = interleavedAttr ? interleavedAttr.getSInt() : 0;
+  int64_t numHeadsVal = numHeadsAttr ? numHeadsAttr.getSInt() : 0;
+  int64_t rotaryDimVal = rotaryDimAttr ? rotaryDimAttr.getSInt() : 0;
 
   // ONNX com.microsoft.RotaryEmbedding: 0 means "infer from tensor shapes"
   //   cos_cache: [max_seq, rotary_dim/2] -> rotary_dim = last_dim * 2
@@ -96,8 +91,7 @@ RotaryEmbeddingToHip::matchAndRewrite(mlir::Operation *op,
   }
 
   // Convert to i64 attributes (using inferred or original values)
-  auto interleavedI64Attr =
-      rewriter.getI64IntegerAttr(interleavedAttr.getSInt());
+  auto interleavedI64Attr = rewriter.getI64IntegerAttr(interleavedVal);
   auto numHeadsI64Attr = rewriter.getI64IntegerAttr(numHeadsVal);
   auto rotaryDimI64Attr = rewriter.getI64IntegerAttr(rotaryDimVal);
 


### PR DESCRIPTION
## Summary

- Treat `interleaved`, `num_heads`, and `rotary_embedding_dim` as optional attributes (default 0) per the [com.microsoft.RotaryEmbedding spec](https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#commicrosoftrotaryembedding)
- Previously, models omitting these attributes caused `ConvertOnnxToHipPass` pattern match failure, falling back to CPU execution
- When absent, infer values from tensor shapes: `rotary_dim = cos_cache.shape[-1] * 2`, `num_heads = input.shape[-1] / rotary_dim`

## Test plan

- [x] Verified with `RotaryEmbedding_q_rotary_seq128.onnx` model via `onnxruntime_perf_test` - compilation succeeds and runs on GPU
- [x] Pre-commit checks passed (trailing-whitespace, lintrunner, licenseheaders, etc.)

Made with [Cursor](https://cursor.com)