### PR TITLE
fix(gqa): apply causal mask during decode when sliding-window is active

### DIFF
--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -603,7 +603,7 @@ static int gqa_forward_hipblaslt(
     // ---- Step 9: Causal Mask (fp32) + Softmax (fp32 -> fp16) ----
     int scoreF32BatchStride = static_cast<int>(sq * total_seq);
     int scoreFp16BatchStride = static_cast<int>(sq * total_seq);
-    if (sq > 1) {
+    if (sq > 1 || local_window_size > 0) {
       HIP_CHECK(hip_gqa_causal_mask_f32(
           stream, d_S_f32, static_cast<int>(B * H), static_cast<int>(total_seq),
           static_cast<int>(sq), scoreF32BatchStride, static_cast<int>(past_len),


### PR DESCRIPTION
## Summary

The causal-mask kernel launch in `gqa_forward_hipblaslt` was gated on
`sq > 1`, which only fires during prefill. During decode (`sq == 1`)
with a configured `local_window_size`, keys older than
`total_seq - local_window_size` must still be masked out; without the
mask those tokens leak into the softmax and degrade generation quality.

Extend the gate to `sq > 1 || local_window_size > 0` so sliding-window
decode runs the same causal/window mask path as prefill.
`hip_gqa_causal_mask_f32` already honors `past_len` and
`local_window_size` internally, so no kernel change is required.

## Change

- `lib/Runtime/real/gqa.cpp` — single-line gate extension (+1/-1).

## Test plan

- [x] Short-prompt `p128` generation on GPT-OSS-20B no longer shows the
      "leaked past-window tokens" pattern in decode output when sliding
      window is active.
- [ ] CI / perf jobs.
