### PR TITLE
feat: add per-op per-shape runtime profiler with CSV export

### DIFF
--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -210,6 +210,7 @@ compile_to_bitcode(hipdnn_ep_runtime_tensor.cpp runtime_tensor.bc)
 # Compile implementation-specific files
 if(NOT BUILD_MOCK_RUNTIME)
     # Real GPU runtime implementation
+    compile_to_bitcode(profiler.cpp runtime_profiler.bc)
     compile_to_bitcode(real/hip.cpp runtime_hip.bc)
     compile_to_bitcode(real/miopen.cpp runtime_miopen.bc)
     compile_to_bitcode(real/hipblas.cpp runtime_hipblas.bc)
@@ -234,6 +235,7 @@ if(NOT BUILD_MOCK_RUNTIME)
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_state.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_tensor.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_memory.bc
+        ${CMAKE_CURRENT_BINARY_DIR}/runtime_profiler.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_hip.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_miopen.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_hipblas.bc

--- a/lib/Runtime/debug_log.h
+++ b/lib/Runtime/debug_log.h
@@ -7,21 +7,45 @@
 // Runtime debug logging gated on HIPDNN_EP_DEBUG env var (default: off)
 // Set HIPDNN_EP_DEBUG=1 to enable all [Runtime DEBUG] output.
 // Set HIPDNN_EP_PERF=1 to enable only [PERF] timing breakdown per inference.
+//
+// On Windows, model DLLs link static CRT (libcmt.lib), so std::getenv()
+// can't see environment variables set by the host process.
+// GetEnvironmentVariableA reads the shared process environment block.
 #include <cstdio>
 #include <cstdlib>
 
+#ifdef _WIN32
+extern "C" unsigned long __stdcall GetEnvironmentVariableA(const char *,
+                                                           char *,
+                                                           unsigned long);
+#endif
+
 inline bool hipdnn_ep_debug_enabled() {
   static const bool enabled = [] {
+#ifdef _WIN32
+    char buf[8] = {};
+    unsigned long n =
+        GetEnvironmentVariableA("HIPDNN_EP_DEBUG", buf, sizeof(buf));
+    return n > 0 && buf[0] >= '1';
+#else
     const char *v = std::getenv("HIPDNN_EP_DEBUG");
     return v && v[0] >= '1';
+#endif
   }();
   return enabled;
 }
 
 inline bool hipdnn_ep_perf_enabled() {
   static const bool enabled = [] {
+#ifdef _WIN32
+    char buf[8] = {};
+    unsigned long n =
+        GetEnvironmentVariableA("HIPDNN_EP_PERF", buf, sizeof(buf));
+    return n > 0 && buf[0] >= '1';
+#else
     const char *v = std::getenv("HIPDNN_EP_PERF");
     return v && v[0] >= '1';
+#endif
   }();
   return enabled || hipdnn_ep_debug_enabled();
 }

--- a/lib/Runtime/profiler.cpp
+++ b/lib/Runtime/profiler.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "profiler.h"
+#include "real/runtime_types.h"
+
+// Single definition of the static member (not inline — avoids
+// per-module duplication when llvm-linked across bitcode modules).
+PerfState *PerfState::instance_ = nullptr;
+
+PerfTimer::~PerfTimer() {
+  if (!active_)
+    return;
+  // Sync stream to ensure GPU work is complete before measuring
+  if (stream_)
+    (void)hipStreamSynchronize(stream_);
+  auto end = std::chrono::steady_clock::now();
+  double ms =
+      std::chrono::duration<double, std::milli>(end - start_).count();
+  PerfState::get()->record(op_, shape_, ms);
+}

--- a/lib/Runtime/profiler.h
+++ b/lib/Runtime/profiler.h
@@ -1,0 +1,248 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#pragma once
+
+// Simple per-op, per-shape profiler for MorphizenEP runtime.
+// Always-on. Each wrap_* call is timed (with stream sync for GPU accuracy).
+// Raw per-invocation data is written to perf_profile.csv at process exit
+// with parsed dimension columns for easy filtering.
+
+#include "debug_log.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+struct RuntimeState;
+typedef struct ihipStream_t *hipStream_t;
+
+extern "C" void *hipdnn_ep_state_get_stream(RuntimeState *state);
+
+// ---------------------------------------------------------------------------
+// PerfRecord -- one measurement per wrap_* invocation
+// ---------------------------------------------------------------------------
+
+struct PerfRecord {
+  char op[32];
+  char shape[128];
+  double ms;
+};
+
+// ---------------------------------------------------------------------------
+// Shape parser: extract key=value pairs into named columns
+// ---------------------------------------------------------------------------
+
+struct ParsedDims {
+  int64_t M, N, K, batch, bits, blk;
+  int64_t n, mode, rows, hidden;
+  int64_t b, sq, skv, h, d;
+  int64_t heads, rot;
+  int64_t data, idx, out;
+  int64_t out_n, out_c, out_h, out_w;
+  int64_t op_code, bytes;
+  int64_t src, dst;
+  int64_t ch, seq, tok, experts;
+  int64_t tA, tB;
+
+  ParsedDims() { memset(this, 0, sizeof(*this)); }
+
+  // Parse "M=128,N=4096,K=4096,bits=4,blk=128" into fields
+  void parse(const char *shape) {
+    char buf[128];
+    snprintf(buf, sizeof(buf), "%s", shape);
+    // Manual tokenizer (no strtok dependency)
+    char *p = buf;
+    while (*p) {
+      char *key_start = p;
+      char *eq = nullptr;
+      // Find '=' or ',' or end
+      while (*p && *p != '=' && *p != ',') p++;
+      if (*p == '=') {
+        *p = '\0';
+        eq = p;
+        p++;
+        int64_t val = strtoll(p, &p, 10);
+        set(key_start, val);
+      }
+      // Skip comma
+      if (*p == ',') p++;
+    }
+  }
+
+private:
+  void set(const char *key, int64_t val) {
+    if (strcmp(key, "M") == 0)          M = val;
+    else if (strcmp(key, "N") == 0)     N = val;
+    else if (strcmp(key, "K") == 0)     K = val;
+    else if (strcmp(key, "batch") == 0) batch = val;
+    else if (strcmp(key, "bits") == 0)  bits = val;
+    else if (strcmp(key, "blk") == 0)   blk = val;
+    else if (strcmp(key, "n") == 0)     n = val;
+    else if (strcmp(key, "mode") == 0)  mode = val;
+    else if (strcmp(key, "rows") == 0)  rows = val;
+    else if (strcmp(key, "hidden") == 0) hidden = val;
+    else if (strcmp(key, "b") == 0)     b = val;
+    else if (strcmp(key, "sq") == 0)    sq = val;
+    else if (strcmp(key, "skv") == 0)   skv = val;
+    else if (strcmp(key, "h") == 0)     h = val;
+    else if (strcmp(key, "d") == 0)     d = val;
+    else if (strcmp(key, "heads") == 0) heads = val;
+    else if (strcmp(key, "rot") == 0)   rot = val;
+    else if (strcmp(key, "data") == 0)  data = val;
+    else if (strcmp(key, "idx") == 0)   idx = val;
+    else if (strcmp(key, "out") == 0)   out = val;
+    else if (strcmp(key, "out_n") == 0) out_n = val;
+    else if (strcmp(key, "out_c") == 0) out_c = val;
+    else if (strcmp(key, "out_h") == 0) out_h = val;
+    else if (strcmp(key, "out_w") == 0) out_w = val;
+    else if (strcmp(key, "op") == 0)    op_code = val;
+    else if (strcmp(key, "bytes") == 0) bytes = val;
+    else if (strcmp(key, "src") == 0)   src = val;
+    else if (strcmp(key, "dst") == 0)   dst = val;
+    else if (strcmp(key, "ch") == 0)    ch = val;
+    else if (strcmp(key, "seq") == 0)   seq = val;
+    else if (strcmp(key, "tok") == 0)   tok = val;
+    else if (strcmp(key, "experts") == 0) experts = val;
+    else if (strcmp(key, "tA") == 0)    tA = val;
+    else if (strcmp(key, "tB") == 0)    tB = val;
+  }
+};
+
+// ---------------------------------------------------------------------------
+// PerfState -- collects all records, writes CSV at process exit
+// ---------------------------------------------------------------------------
+
+class PerfState {
+  std::vector<PerfRecord> records_;
+
+public:
+  void record(const char *op, const char *shape, double ms) {
+    PerfRecord r;
+    snprintf(r.op, sizeof(r.op), "%s", op);
+    snprintf(r.shape, sizeof(r.shape), "%s", shape);
+    r.ms = ms;
+    records_.push_back(r);
+  }
+
+  void write_csv() {
+    if (records_.empty())
+      return;
+
+    FILE *csv = fopen("perf_profile.csv", "w");
+    if (!csv)
+      return;
+
+    // Header: raw fields + parsed dimension columns
+    fprintf(csv, "Index,Op,Shape,Time_ms,"
+                 "M,N,K,batch,bits,blk,"
+                 "n,mode,rows,hidden,"
+                 "b,sq,skv,h,d,"
+                 "heads,rot,"
+                 "data,idx,out,"
+                 "out_n,out_c,out_h,out_w,"
+                 "op_code,bytes,"
+                 "src,dst,"
+                 "ch,seq,tok,experts,"
+                 "tA,tB\n");
+
+    for (size_t i = 0; i < records_.size(); i++) {
+      auto &r = records_[i];
+      ParsedDims p;
+      p.parse(r.shape);
+
+      fprintf(csv,
+              "%zu,%s,\"%s\",%.4f,"
+              "%lld,%lld,%lld,%lld,%lld,%lld,"
+              "%lld,%lld,%lld,%lld,"
+              "%lld,%lld,%lld,%lld,%lld,"
+              "%lld,%lld,"
+              "%lld,%lld,%lld,"
+              "%lld,%lld,%lld,%lld,"
+              "%lld,%lld,"
+              "%lld,%lld,"
+              "%lld,%lld,%lld,%lld,"
+              "%lld,%lld\n",
+              i, r.op, r.shape, r.ms,
+              (long long)p.M, (long long)p.N, (long long)p.K,
+              (long long)p.batch, (long long)p.bits, (long long)p.blk,
+              (long long)p.n, (long long)p.mode,
+              (long long)p.rows, (long long)p.hidden,
+              (long long)p.b, (long long)p.sq, (long long)p.skv,
+              (long long)p.h, (long long)p.d,
+              (long long)p.heads, (long long)p.rot,
+              (long long)p.data, (long long)p.idx, (long long)p.out,
+              (long long)p.out_n, (long long)p.out_c,
+              (long long)p.out_h, (long long)p.out_w,
+              (long long)p.op_code, (long long)p.bytes,
+              (long long)p.src, (long long)p.dst,
+              (long long)p.ch, (long long)p.seq,
+              (long long)p.tok, (long long)p.experts,
+              (long long)p.tA, (long long)p.tB);
+    }
+
+    fclose(csv);
+    fprintf(stderr, "[PERF] CSV written: perf_profile.csv (%zu records)\n",
+            records_.size());
+  }
+
+  ~PerfState() { write_csv(); }
+
+  static PerfState *get() {
+    if (!instance_) {
+      instance_ = new PerfState();
+      std::atexit(cleanup);
+    }
+    return instance_;
+  }
+
+private:
+  static PerfState *instance_;
+  static void cleanup() {
+    if (instance_) {
+      delete instance_;
+      instance_ = nullptr;
+    }
+  }
+};
+
+// Defined in profiler.cpp (single definition across all bitcode modules)
+
+// ---------------------------------------------------------------------------
+// RAII Timer -- syncs stream when profiling to get accurate GPU time
+// ---------------------------------------------------------------------------
+
+class PerfTimer {
+  std::chrono::steady_clock::time_point start_;
+  hipStream_t stream_;
+  char op_[32];
+  char shape_[128];
+  bool active_;
+
+public:
+  PerfTimer(RuntimeState *state, const char *op, const char *shape)
+      : active_(true) {
+    if (!active_)
+      return;
+    snprintf(op_, sizeof(op_), "%s", op);
+    snprintf(shape_, sizeof(shape_), "%s", shape);
+    stream_ = static_cast<hipStream_t>(hipdnn_ep_state_get_stream(state));
+    start_ = std::chrono::steady_clock::now();
+  }
+
+  ~PerfTimer();
+};
+
+// ---------------------------------------------------------------------------
+// Macro for easy instrumentation
+// ---------------------------------------------------------------------------
+
+#define PERF_TIMER(state, op, shape_fmt, ...)                                  \
+  char _perf_shape_[128];                                                      \
+  snprintf(_perf_shape_, sizeof(_perf_shape_), shape_fmt, ##__VA_ARGS__);      \
+  PerfTimer _perf_timer_(state, op, _perf_shape_)

--- a/lib/Runtime/real/activation.cpp
+++ b/lib/Runtime/real/activation.cpp
@@ -4,6 +4,7 @@
  */
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../profiler.h"
 #include "cache_utils.h"
 #include "error_check_macros.h"
 #include "runtime_types.h"
@@ -154,6 +155,10 @@ int wrap_miopenActivationForward(RuntimeState *state, void *input, void *output,
     fprintf(stderr, "wrap_miopenActivationForward: null argument\n");
     return -1;
   }
+
+  PERF_TIMER(state, "Activation",
+             "n=%lld,mode=%lld",
+             (long long)num_elements, (long long)activation_mode);
 
   const char *act_name = hipdnn_ep_activation_name(activation_mode);
   const char *type_name = hipdnn_ep_datatype_name(data_type);

--- a/lib/Runtime/real/cast.cpp
+++ b/lib/Runtime/real/cast.cpp
@@ -4,6 +4,7 @@
  */
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../profiler.h"
 #include "hip_custom_kernels.h"
 
 #include <cstdio>
@@ -30,6 +31,11 @@ static int hipdnn_to_hip_dtype(int64_t hipdnn_type) {
 int wrap_cast(RuntimeState *state, void *input, void *output,
               int64_t num_elements, int64_t src_data_type,
               int64_t dst_data_type) {
+  PERF_TIMER(state, "Cast",
+             "n=%lld,src=%lld,dst=%lld",
+             (long long)num_elements, (long long)src_data_type,
+             (long long)dst_data_type);
+
   if (!state || !input || !output) {
     RUNTIME_DEBUG_LOG("[REAL] wrap_cast: null argument\n");
     return -1;

--- a/lib/Runtime/real/causal_conv_with_state.cpp
+++ b/lib/Runtime/real/causal_conv_with_state.cpp
@@ -4,6 +4,7 @@
  */
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../profiler.h"
 #include "runtime_types.h"
 
 #include <cassert>
@@ -41,6 +42,11 @@ int wrap_causal_conv_with_state(
     const void *bias, const void *past_state, void *output, void *present_state,
     int64_t batch_size, int64_t channels, int64_t seq_len, int64_t kernel_size,
     int64_t ndim, int64_t activation, int64_t element_size_bytes) {
+  PERF_TIMER(state, "CausalConv",
+             "b=%lld,ch=%lld,seq=%lld,k=%lld",
+             (long long)batch_size, (long long)channels,
+             (long long)seq_len, (long long)kernel_size);
+
   if (!state || !input || !weight || !output || !present_state) {
     fprintf(stderr, "wrap_causal_conv_with_state: null required argument\n");
     return -1;

--- a/lib/Runtime/real/elementwise.cpp
+++ b/lib/Runtime/real/elementwise.cpp
@@ -4,6 +4,7 @@
  */
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../profiler.h"
 #include "cache_utils.h"
 #include "error_check_macros.h"
 #include "hip_custom_kernels.h"
@@ -186,6 +187,11 @@ int wrap_miopenOpTensor(RuntimeState *state, void *lhs, void *rhs, void *output,
     return -1;
   }
 
+  PERF_TIMER(state, "ElementWise",
+             "out_n=%lld,out_c=%lld,out_h=%lld,out_w=%lld,op=%lld",
+             (long long)out_n, (long long)out_c,
+             (long long)out_h, (long long)out_w, (long long)tensor_op);
+
   const char *type_name = hipdnn_ep_datatype_name(data_type);
   const char *op_name = hipdnn_ep_tensor_op_name(tensor_op);
   RUNTIME_DEBUG_LOG("[REAL] wrap_miopenOpTensor: op=%s, "
@@ -256,6 +262,9 @@ int wrap_elementwise_sub(RuntimeState *state, void *lhs, void *rhs,
     fprintf(stderr, "wrap_elementwise_sub: null argument\n");
     return -1;
   }
+
+  PERF_TIMER(state, "ElemSub",
+             "n=%lld", (long long)num_elements);
 
   void *stream = hipdnn_ep_state_get_stream(state);
 

--- a/lib/Runtime/real/gather.cpp
+++ b/lib/Runtime/real/gather.cpp
@@ -4,6 +4,7 @@
  */
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../profiler.h"
 #include "hip_custom_kernels.h"
 #include "runtime_types.h"
 
@@ -13,6 +14,11 @@ int wrap_gather(RuntimeState *state, void *data, void *indices, void *output,
                 int64_t axis, int64_t data_num_elements,
                 int64_t indices_num_elements, int64_t output_num_elements,
                 int64_t element_size_bytes) {
+  PERF_TIMER(state, "Gather",
+             "data=%lld,idx=%lld,out=%lld",
+             (long long)data_num_elements, (long long)indices_num_elements,
+             (long long)output_num_elements);
+
   if (!state || !data || !indices || !output) {
     RUNTIME_DEBUG_LOG("[REAL] wrap_gather: null argument\n");
     return -1;

--- a/lib/Runtime/real/gemm.cpp
+++ b/lib/Runtime/real/gemm.cpp
@@ -4,6 +4,7 @@
  */
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../profiler.h"
 #include "error_check_macros.h"
 #include "runtime_types.h"
 
@@ -203,6 +204,11 @@ int wrap_gemm(RuntimeState *state, const void *A, const void *B, const void *C,
               void *output, int64_t M, int64_t N, int64_t K, float alpha,
               float beta, int64_t transA, int64_t transB, int64_t typeCode,
               int64_t cDim0, int64_t cDim1) {
+  PERF_TIMER(state, "Gemm",
+             "M=%lld,N=%lld,K=%lld,tA=%lld,tB=%lld",
+             (long long)M, (long long)N, (long long)K,
+             (long long)transA, (long long)transB);
+
   if (!state || !A || !B || !output) {
     fprintf(stderr, "wrap_gemm: invalid arguments\n");
     return -1;

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -5,6 +5,7 @@
 
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../profiler.h"
 #include "cache_utils.h"
 #include "error_check_macros.h"
 #include "hip_custom_kernels.h"
@@ -658,6 +659,12 @@ int wrap_group_query_attention(
     // (may differ from actual past token count for pre-allocated caches)
     int64_t batch_size, int64_t seq_len_q, int64_t seq_len_kv,
     int64_t past_buf_seq, int64_t head_dim, int64_t element_size_bytes) {
+
+  PERF_TIMER(state, "GQA",
+             "b=%lld,sq=%lld,skv=%lld,h=%lld,d=%lld",
+             (long long)batch_size, (long long)seq_len_q,
+             (long long)seq_len_kv, (long long)num_heads,
+             (long long)head_dim);
 
   if (!state) {
     fprintf(stderr, "wrap_group_query_attention: null state\n");

--- a/lib/Runtime/real/hip.cpp
+++ b/lib/Runtime/real/hip.cpp
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 #include "../hipdnn_ep_runtime.h"
+#include "../profiler.h"
 #include "runtime_types.h"
 
 #include <cstdio>

--- a/lib/Runtime/real/matmul.cpp
+++ b/lib/Runtime/real/matmul.cpp
@@ -4,6 +4,7 @@
  */
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../profiler.h"
 #include "cache_utils.h"
 #include "hip_custom_kernels.h"
 #include "runtime_types.h"
@@ -334,6 +335,10 @@ int wrap_hipblasLtMatmul(RuntimeState *state, const void *A, const void *B,
             (long long)elem_size);
     return -1;
   }
+
+  PERF_TIMER(state, "MatMul",
+             "M=%lld,N=%lld,K=%lld,batch=%lld",
+             (long long)M, (long long)N, (long long)K, (long long)batch_count);
 
   const char *type_name = (elem_size == 2) ? "f16" : "f32";
   RUNTIME_DEBUG_LOG("[REAL] wrap_hipblasLtMatmul: M=%lld, N=%lld, K=%lld, "

--- a/lib/Runtime/real/matmul_nbits.cpp
+++ b/lib/Runtime/real/matmul_nbits.cpp
@@ -4,6 +4,7 @@
  */
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../profiler.h"
 #include "error_check_macros.h"
 #include "hip_custom_kernels.h"
 
@@ -16,6 +17,11 @@ int wrap_matmul_nbits(RuntimeState *state, const void *A, const void *B,
                       const void *g_idx, const void *bias, void *output,
                       int64_t M, int64_t N, int64_t K, int64_t batch_count,
                       int64_t bits, int64_t block_size, int64_t elem_size) {
+  PERF_TIMER(state, "MatMulNBits",
+             "M=%lld,N=%lld,K=%lld,bits=%lld,blk=%lld",
+             (long long)M, (long long)N, (long long)K,
+             (long long)bits, (long long)block_size);
+
   if (!state || !A || !B || !scales || !output) {
     fprintf(stderr, "wrap_matmul_nbits: null argument\n");
     return -1;

--- a/lib/Runtime/real/memory.cpp
+++ b/lib/Runtime/real/memory.cpp
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 #include "../hipdnn_ep_runtime.h"
+#include "../profiler.h"
 #include "runtime_types.h"
 
 #include <cstdio>
@@ -11,6 +12,9 @@
 // Follows opaque RuntimeState pattern - extracts stream internally
 int wrap_hipMemcpyAsync(RuntimeState *state, void *dst_ptr, const void *src_ptr,
                         size_t size_bytes) {
+  PERF_TIMER(state, "MemcpyD2D",
+             "bytes=%llu", (unsigned long long)size_bytes);
+
   if (!state) {
     fprintf(stderr, "wrap_hipMemcpyAsync: null state\n");
     return -1;

--- a/lib/Runtime/real/qmoe.cpp
+++ b/lib/Runtime/real/qmoe.cpp
@@ -4,6 +4,7 @@
  */
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../profiler.h"
 #include "error_check_macros.h"
 #include "hip_custom_kernels.h"
 #include "runtime_types.h"
@@ -33,6 +34,11 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
               int64_t swiglu_fusion, int64_t activation_type,
               float activation_alpha, float activation_beta, float swiglu_limit,
               int64_t normalize_routing_weights, int64_t elem_size) {
+  PERF_TIMER(state, "QMoE",
+             "tok=%lld,hidden=%lld,experts=%lld",
+             (long long)num_tokens, (long long)hidden_size,
+             (long long)num_experts);
+
   if (!state || !input || !router_probs || !output) {
     fprintf(stderr, "wrap_qmoe: null argument\n");
     return -1;

--- a/lib/Runtime/real/reduce_sum.cpp
+++ b/lib/Runtime/real/reduce_sum.cpp
@@ -4,6 +4,7 @@
  */
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../profiler.h"
 #include "hip_custom_kernels.h"
 #include "runtime_types.h"
 
@@ -25,6 +26,10 @@ int wrap_reduce_sum(RuntimeState *state, void *data, void *axes, void *output,
                     int64_t data_num_elements, int64_t output_num_elements,
                     int64_t axes_num_elements, int64_t element_size_bytes,
                     int64_t keepdims, int64_t noop_with_empty_axes) {
+  PERF_TIMER(state, "ReduceSum",
+             "data=%lld,out=%lld",
+             (long long)data_num_elements, (long long)output_num_elements);
+
   if (!state || !data || !output) {
     RUNTIME_DEBUG_LOG("[REAL] wrap_reduce_sum: null argument\n");
     return -1;

--- a/lib/Runtime/real/rotary_embedding.cpp
+++ b/lib/Runtime/real/rotary_embedding.cpp
@@ -5,6 +5,7 @@
 
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../profiler.h"
 #include "hip_custom_kernels.h"
 
 #include <cstdio>
@@ -37,6 +38,11 @@ int wrap_rotary_embedding(RuntimeState *state, void *input, void *position_ids,
                           int64_t rotary_dim, int64_t input_num_elements,
                           int64_t cos_cache_num_elements,
                           int64_t element_size_bytes) {
+  PERF_TIMER(state, "RoPE",
+             "n=%lld,heads=%lld,rot=%lld",
+             (long long)input_num_elements, (long long)num_heads,
+             (long long)rotary_dim);
+
   if (!state) {
     fprintf(stderr, "wrap_rotary_embedding: null state\n");
     return -1;

--- a/lib/Runtime/real/simplified_layer_norm.cpp
+++ b/lib/Runtime/real/simplified_layer_norm.cpp
@@ -8,6 +8,7 @@
 
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../profiler.h"
 #include "cache_utils.h"
 #include "error_check_macros.h"
 #include "runtime_types.h"
@@ -139,6 +140,11 @@ int wrap_miopenT5LayerNormForward(RuntimeState *state, void *input, void *scale,
                                   int64_t scale_num_elements,
                                   int64_t element_size_bytes, int64_t axis,
                                   float epsilon, int64_t stash_type) {
+  PERF_TIMER(state, "LayerNorm",
+             "rows=%lld,hidden=%lld",
+             (long long)(input_num_elements / scale_num_elements),
+             (long long)scale_num_elements);
+
   if (!state || !input || !scale || !output) {
     fprintf(stderr, "Invalid arguments to wrap_miopenT5LayerNormForward\n");
     return -1;

--- a/lib/Runtime/real/skip_simplified_layer_norm.cpp
+++ b/lib/Runtime/real/skip_simplified_layer_norm.cpp
@@ -8,6 +8,7 @@
 
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../profiler.h"
 #include "cache_utils.h"
 #include "error_check_macros.h"
 #include "runtime_types.h"
@@ -168,6 +169,11 @@ int wrap_skip_simplified_layer_norm(RuntimeState *state, void *input,
                                     int64_t input_num_elements,
                                     int64_t gamma_num_elements,
                                     int64_t element_size_bytes, float epsilon) {
+  PERF_TIMER(state, "SkipLayerNorm",
+             "rows=%lld,hidden=%lld",
+             (long long)(input_num_elements / gamma_num_elements),
+             (long long)gamma_num_elements);
+
   if (!state || !input || !skip || !gamma || !output) {
     fprintf(stderr,
             "wrap_skip_simplified_layer_norm: null required argument\n");


### PR DESCRIPTION
Add simple always-on profiling to all wrap_* runtime functions. Each operator invocation is timed (with per-op hipStreamSynchronize for accurate GPU measurement) and recorded with its shape dimensions.

At process exit, raw per-invocation data is written to perf_profile.csv with parsed dimension columns (M, N, K, batch, bits, etc.) for easy filtering in Excel/Sheets by operator name and shape parameters.

Also fixes debug_log.h to use GetEnvironmentVariableA on Windows (static CRT can't see host env vars via std::getenv).

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
