### PR TITLE
Align QMoe with ONNX spec 

### DIFF
--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -310,7 +310,7 @@ def Hip_MatMulNBitsOp : Hip_DpsOp<"matmul_nbits", [AttrSizedOperandSegments]> {
 def Hip_QMoEOp : Hip_DpsOp<"qmoe", [AttrSizedOperandSegments]> {
   let summary = "Quantized Mixture-of-Experts (com.microsoft QMoE)";
   let description = [{
-    Implements the com.microsoft QMoE operator (inputs 7-14): quantized
+    Implements the com.microsoft QMoE operator (ONNX v1.25+ compatible): quantized
     Mixture-of-Experts with top-k expert routing and optional SwiGLU activation.
 
     Routes each token to its top-k experts, performs quantized linear
@@ -330,6 +330,7 @@ def Hip_QMoEOp : Hip_DpsOp<"qmoe", [AttrSizedOperandSegments]> {
       fc1_experts_bias, fc2_experts_bias: bias vectors (optional)
       fc3_*: unfused SwiGLU second GEMM weights/scales/bias (optional)
       fc1/fc2/fc3_zero_points: per-block zero points (optional)
+      router_weights: alternative aggregation weights (optional, ONNX v1.25+, takes precedence over router_probs)
 
     Uses destination-passing style: output buffer is provided as argument.
 
@@ -363,6 +364,7 @@ def Hip_QMoEOp : Hip_DpsOp<"qmoe", [AttrSizedOperandSegments]> {
     Optional<Hip_TensorOrMemRef>:$fc1_zero_points,        // fc1 dequant zero points
     Optional<Hip_TensorOrMemRef>:$fc2_zero_points,        // fc2 dequant zero points
     Optional<Hip_TensorOrMemRef>:$fc3_zero_points,        // fc3 dequant zero points
+    Optional<Hip_TensorOrMemRef>:$router_weights,         // [num_tokens, num_experts] alternative routing weights (ONNX v1.25+)
     Hip_TensorOrMemRef:$output,                 // DPS init [batch, seq, hidden]
     I64Attr:$expert_weight_bits,
     I64Attr:$k,
@@ -393,6 +395,7 @@ def Hip_QMoEOp : Hip_DpsOp<"qmoe", [AttrSizedOperandSegments]> {
     (`fc1_zero_points` `(` $fc1_zero_points^ `:` type($fc1_zero_points) `)`)?
     (`fc2_zero_points` `(` $fc2_zero_points^ `:` type($fc2_zero_points) `)`)?
     (`fc3_zero_points` `(` $fc3_zero_points^ `:` type($fc3_zero_points) `)`)?
+    (`router_weights` `(` $router_weights^ `:` type($router_weights) `)`)?
     `outs` `(` $output `:` type($output) `)`
     attr-dict (`:` type($result_tensors)^)?
   }];

--- a/lib/Conversion/HipToLLVM/QMoELowering.cpp
+++ b/lib/Conversion/HipToLLVM/QMoELowering.cpp
@@ -62,6 +62,8 @@ struct QMoEOpLowering : public ConvertOpToLLVMPattern<QMoEOp> {
         extractOptionalMemRefPtr(adaptor.getFc2ZeroPoints(), rewriter, loc);
     Value fc3ZpPtr =
         extractOptionalMemRefPtr(adaptor.getFc3ZeroPoints(), rewriter, loc);
+    Value routerWeightsPtr =
+        extractOptionalMemRefPtr(adaptor.getRouterWeights(), rewriter, loc);
     Value outputPtr = extractMemRefPtr(adaptor.getOutput(), rewriter, loc);
 
     auto inputType = cast<MemRefType>(op.getInput().getType());
@@ -120,10 +122,11 @@ struct QMoEOpLowering : public ConvertOpToLLVMPattern<QMoEOp> {
     Value normalizeVal = createI64Const(op.getNormalizeRoutingWeights());
     Value elemSizeVal = createI64Const(elemSize);
 
-    SmallVector<Type, 30> paramTypes = {
+    SmallVector<Type, 31> paramTypes = {
         ptrType, // state
         ptrType, // input
         ptrType, // router_probs
+        ptrType, // router_weights (nullable)
         ptrType, // fc1_weights
         ptrType, // fc1_scales
         ptrType, // fc1_bias (nullable)
@@ -159,9 +162,10 @@ struct QMoEOpLowering : public ConvertOpToLLVMPattern<QMoEOp> {
       return failure();
     }
 
-    SmallVector<Value, 30> args = {statePtr,
+    SmallVector<Value, 31> args = {statePtr,
                                    inputPtr,
                                    routerPtr,
+                                   routerWeightsPtr,
                                    fc1WeightsPtr,
                                    fc1ScalesPtr,
                                    fc1BiasPtr,

--- a/lib/Conversion/OnnxToHip/QMoEConversion.cpp
+++ b/lib/Conversion/OnnxToHip/QMoEConversion.cpp
@@ -5,6 +5,8 @@
 
 #include "OnnxToHipUtils.h"
 
+#include <limits>
+
 namespace mlir {
 namespace hip {
 namespace {
@@ -114,8 +116,12 @@ QMoEToHip::matchAndRewrite(mlir::Operation *op,
       betaFloatAttr ? betaFloatAttr : rewriter.getF32FloatAttr(0.0f);
 
   auto limitFloatAttr = op->getAttrOfType<mlir::FloatAttr>("swiglu_limit");
+  // ONNX spec: "It is infinite when limit is not provided"
+  // Match ONNX Runtime: std::numeric_limits<float>::infinity()
   auto swigluLimitAttr =
-      limitFloatAttr ? limitFloatAttr : rewriter.getF32FloatAttr(0.0f);
+      limitFloatAttr
+          ? limitFloatAttr
+          : rewriter.getF32FloatAttr(std::numeric_limits<float>::infinity());
 
   auto activationTypeStrAttr =
       op->getAttrOfType<mlir::StringAttr>("activation_type");

--- a/lib/Conversion/OnnxToHip/QMoEConversion.cpp
+++ b/lib/Conversion/OnnxToHip/QMoEConversion.cpp
@@ -75,6 +75,8 @@ QMoEToHip::matchAndRewrite(mlir::Operation *op,
   mlir::Value fc1ZeroPoints = getOptionalInput(11);
   mlir::Value fc2ZeroPoints = getOptionalInput(12);
   mlir::Value fc3ZeroPoints = getOptionalInput(13);
+  mlir::Value routerWeights =
+      getOptionalInput(14); // ONNX v1.25+ router_weights
 
   auto expertWeightBitsIntAttr =
       op->getAttrOfType<mlir::IntegerAttr>("expert_weight_bits");
@@ -104,7 +106,8 @@ QMoEToHip::matchAndRewrite(mlir::Operation *op,
 
   auto alphaFloatAttr = op->getAttrOfType<mlir::FloatAttr>("activation_alpha");
   auto activationAlphaAttr =
-      alphaFloatAttr ? alphaFloatAttr : rewriter.getF32FloatAttr(0.0f);
+      alphaFloatAttr ? alphaFloatAttr
+                     : rewriter.getF32FloatAttr(1.0f); // ONNX spec default: 1.0
 
   auto betaFloatAttr = op->getAttrOfType<mlir::FloatAttr>("activation_beta");
   auto activationBetaAttr =
@@ -127,9 +130,10 @@ QMoEToHip::matchAndRewrite(mlir::Operation *op,
       rewriter, loc, mlir::TypeRange{rt}, context, input, routerProbs,
       fc1Weights, fc1Scales, fc2Weights, fc2Scales, fc1Bias, fc2Bias,
       fc3Weights, fc3Scales, fc3Bias, fc1ZeroPoints, fc2ZeroPoints,
-      fc3ZeroPoints, init, expertWeightBitsAttr, kAttr, blockSizeAttr,
-      normalizeAttr, swigluFusionAttr, useSparseAttr, activationAlphaAttr,
-      activationBetaAttr, swigluLimitAttr, activationTypeAttr);
+      fc3ZeroPoints, routerWeights, init, expertWeightBitsAttr, kAttr,
+      blockSizeAttr, normalizeAttr, swigluFusionAttr, useSparseAttr,
+      activationAlphaAttr, activationBetaAttr, swigluLimitAttr,
+      activationTypeAttr);
   rewriter.replaceOp(op, hipOp->getResults());
   return mlir::success();
 }

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -554,6 +554,7 @@ int wrap_qmoe(
     RuntimeState *state,
     const void *input,           // [num_tokens, hidden_size]
     const void *router_probs,    // [num_tokens, num_experts]
+    const void *router_weights,  // (nullable) ONNX v1.25+ routing weights
     const void *fc1_weights,     // [num_experts, fusion*inter, hidden/pack]
     const void *fc1_scales,      // [num_experts, fusion*inter, hidden/bs]
     const void *fc1_bias,        // (nullable) [num_experts, fusion*inter]

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -785,15 +785,15 @@ int wrap_matmul_nbits(RuntimeState *state, const void *A, const void *B,
 }
 
 int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
-              const void *fc1_weights, const void *fc1_scales,
-              const void *fc1_bias, const void *fc2_weights,
-              const void *fc2_scales, const void *fc2_bias,
-              const void *fc3_weights, const void *fc3_scales,
-              const void *fc3_bias, const void *fc1_zero_points,
-              const void *fc2_zero_points, const void *fc3_zero_points,
-              void *output, int64_t num_tokens, int64_t hidden_size,
-              int64_t inter_size, int64_t num_experts, int64_t k,
-              int64_t expert_weight_bits, int64_t block_size,
+              const void *router_weights, const void *fc1_weights,
+              const void *fc1_scales, const void *fc1_bias,
+              const void *fc2_weights, const void *fc2_scales,
+              const void *fc2_bias, const void *fc3_weights,
+              const void *fc3_scales, const void *fc3_bias,
+              const void *fc1_zero_points, const void *fc2_zero_points,
+              const void *fc3_zero_points, void *output, int64_t num_tokens,
+              int64_t hidden_size, int64_t inter_size, int64_t num_experts,
+              int64_t k, int64_t expert_weight_bits, int64_t block_size,
               int64_t swiglu_fusion, int64_t activation_type,
               float activation_alpha, float activation_beta, float swiglu_limit,
               int64_t normalize_routing_weights, int64_t elem_size) {
@@ -819,10 +819,10 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
              (double)swiglu_limit, (long long)normalize_routing_weights,
              (long long)elem_size);
   MOCK_PRINT("[MOCK]   fc1_bias=%s, fc2_bias=%s, fc3_weights=%s, "
-             "fc1_zp=%s, fc2_zp=%s)\n",
+             "fc1_zp=%s, fc2_zp=%s, router_weights=%s)\n",
              fc1_bias ? "yes" : "null", fc2_bias ? "yes" : "null",
              fc3_weights ? "yes" : "null", fc1_zero_points ? "yes" : "null",
-             fc2_zero_points ? "yes" : "null");
+             fc2_zero_points ? "yes" : "null", router_weights ? "yes" : "null");
 
   return 0;
 }

--- a/lib/Runtime/real/qmoe.cpp
+++ b/lib/Runtime/real/qmoe.cpp
@@ -33,15 +33,12 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
               int64_t swiglu_fusion, int64_t activation_type,
               float activation_alpha, float activation_beta, float swiglu_limit,
               int64_t normalize_routing_weights, int64_t elem_size) {
-  if (!state || !input || !output) {
-    fprintf(stderr, "wrap_qmoe: null argument\n");
+  if (router_weights) {
+    fprintf(stderr, "wrap_qmoe: router_weights is not supported yet\n");
     return -1;
   }
-
-  // At least one of router_probs or router_weights must be provided
-  if (!router_probs && !router_weights) {
-    fprintf(stderr,
-            "wrap_qmoe: both router_probs and router_weights are null\n");
+  if (!state || !input || !router_probs || !output) {
+    fprintf(stderr, "wrap_qmoe: null argument\n");
     return -1;
   }
 
@@ -96,16 +93,11 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
   HIP_CHECK(hipMalloc(&d_token_ids, num_tokens * sizeof(int32_t)));
   HIP_CHECK(hipMalloc(&d_token_wts, num_tokens * elem_size));
 
-  // Use router_weights if provided, otherwise use router_probs
-  // router_weights takes precedence per ONNX Runtime v1.25+ specification
-  const void *router_input = router_weights ? router_weights : router_probs;
-
   RUNTIME_DEBUG_LOG("[REAL] wrap_qmoe: topk_routing(tokens=%lld, experts=%lld, "
-                    "k=%lld, normalize=%lld, using_router_weights=%d)\n",
+                    "k=%lld, normalize=%lld)\n",
                     (long long)num_tokens, (long long)num_experts, (long long)k,
-                    (long long)normalize_routing_weights,
-                    router_weights != nullptr);
-  HIP_CHECK(hip_qmoe_topk_routing(stream, router_input, d_expert_indices,
+                    (long long)normalize_routing_weights);
+  HIP_CHECK(hip_qmoe_topk_routing(stream, router_probs, d_expert_indices,
                                   d_expert_weights, num_tokens, num_experts, k,
                                   normalize_routing_weights, elem_size));
 

--- a/lib/Runtime/real/qmoe.cpp
+++ b/lib/Runtime/real/qmoe.cpp
@@ -21,20 +21,27 @@ struct TokenEntry {
 };
 
 int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
-              const void *fc1_weights, const void *fc1_scales,
-              const void *fc1_bias, const void *fc2_weights,
-              const void *fc2_scales, const void *fc2_bias,
-              const void *fc3_weights, const void *fc3_scales,
-              const void *fc3_bias, const void *fc1_zero_points,
-              const void *fc2_zero_points, const void *fc3_zero_points,
-              void *output, int64_t num_tokens, int64_t hidden_size,
-              int64_t inter_size, int64_t num_experts, int64_t k,
-              int64_t expert_weight_bits, int64_t block_size,
+              const void *router_weights, const void *fc1_weights,
+              const void *fc1_scales, const void *fc1_bias,
+              const void *fc2_weights, const void *fc2_scales,
+              const void *fc2_bias, const void *fc3_weights,
+              const void *fc3_scales, const void *fc3_bias,
+              const void *fc1_zero_points, const void *fc2_zero_points,
+              const void *fc3_zero_points, void *output, int64_t num_tokens,
+              int64_t hidden_size, int64_t inter_size, int64_t num_experts,
+              int64_t k, int64_t expert_weight_bits, int64_t block_size,
               int64_t swiglu_fusion, int64_t activation_type,
               float activation_alpha, float activation_beta, float swiglu_limit,
               int64_t normalize_routing_weights, int64_t elem_size) {
-  if (!state || !input || !router_probs || !output) {
+  if (!state || !input || !output) {
     fprintf(stderr, "wrap_qmoe: null argument\n");
+    return -1;
+  }
+
+  // At least one of router_probs or router_weights must be provided
+  if (!router_probs && !router_weights) {
+    fprintf(stderr,
+            "wrap_qmoe: both router_probs and router_weights are null\n");
     return -1;
   }
 
@@ -89,11 +96,16 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
   HIP_CHECK(hipMalloc(&d_token_ids, num_tokens * sizeof(int32_t)));
   HIP_CHECK(hipMalloc(&d_token_wts, num_tokens * elem_size));
 
+  // Use router_weights if provided, otherwise use router_probs
+  // router_weights takes precedence per ONNX Runtime v1.25+ specification
+  const void *router_input = router_weights ? router_weights : router_probs;
+
   RUNTIME_DEBUG_LOG("[REAL] wrap_qmoe: topk_routing(tokens=%lld, experts=%lld, "
-                    "k=%lld, normalize=%lld)\n",
+                    "k=%lld, normalize=%lld, using_router_weights=%d)\n",
                     (long long)num_tokens, (long long)num_experts, (long long)k,
-                    (long long)normalize_routing_weights);
-  HIP_CHECK(hip_qmoe_topk_routing(stream, router_probs, d_expert_indices,
+                    (long long)normalize_routing_weights,
+                    router_weights != nullptr);
+  HIP_CHECK(hip_qmoe_topk_routing(stream, router_input, d_expert_indices,
                                   d_expert_weights, num_tokens, num_experts, k,
                                   normalize_routing_weights, elem_size));
 


### PR DESCRIPTION
 ## Summary
 This PR fixes two critical issues with the QMoE operator to align with ONNXRuntime v1.25+ SPEC.
 
 **New Feature**
  -  Add `router_weights` input (ONNX v1.25+)  （Only OP define , not support runtime yet)
  
 **Critical Bug Fix**
   - `activation_alpha` default: 0.0 → 1.0 (broke SwiGLU)  
   -  `swiglu_limit` default: 0.0 → infinity (clamped values to zero)  
     

### ONNX Runtime Reference

**activation_alpha** (moe_base_cpu.h:52):
```cpp
activation_alpha_ = op_kernel_info.GetAttrOrDefault<float>("activation_alpha", 1.0f);
```

**swiglu_limit** (moe_base_cpu.h:53):
```cpp
swiglu_limit_ = op_kernel_info.GetAttrOrDefault<float>("swiglu_limit", 
    std::numeric_limits<float>::infinity());
```


