### PR TITLE
ci(windows): upgrade to Python 3.14 and package cp314 ORT/OGA wheels

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -458,24 +458,29 @@ jobs:
           cp "${{ runner.workspace }}/oga-artifacts/model_benchmark.exe" staging/bin/
           cp "${{ runner.workspace }}/oga-artifacts/onnxruntime-genai.dll" staging/bin/
 
+          # ---------------------------------------------------------------
+          # Python wheels (ORT + OGA cp314) — bundled into the same artifact
+          # under staging/wheels/ so downstream consumers download a single
+          # zip. Both wheels are cached inside prebuilt-local / oga-artifacts
+          # respectively, so cache hits restore them without re-running ORT
+          # or OGA from source.
+          # ---------------------------------------------------------------
+          mkdir -p staging/wheels
+          ORT_WHEEL=$(find "${{ runner.workspace }}/prebuilt-local/wheels" \
+            -name "onnxruntime_directml-*.whl" -type f | head -1)
+          OGA_WHEEL=$(find "${{ runner.workspace }}/oga-artifacts" \
+            -name "onnxruntime_genai_directml-*.whl" -type f | head -1)
+          if [ -z "$ORT_WHEEL" ] || [ -z "$OGA_WHEEL" ]; then
+            echo "ERROR: cp314 wheel(s) missing from cache"
+            echo "  ORT: $ORT_WHEEL"
+            echo "  OGA: $OGA_WHEEL"
+            exit 1
+          fi
+          cp "$ORT_WHEEL" staging/wheels/
+          cp "$OGA_WHEEL" staging/wheels/
+
           echo "=== Staged package contents ==="
           find staging/ -type f | sort
-
-      # -----------------------------------------------------------------------
-      # Upload Python wheels (ORT + OGA cp314) as a separate artifact so they
-      # can be downloaded independently from gpu-test-package. Both wheels are
-      # cached inside prebuilt-local / oga-artifacts respectively, so cache
-      # hits restore them without re-running ORT / OGA from-source builds.
-      # -----------------------------------------------------------------------
-      - name: Upload Python wheels
-        uses: actions/upload-artifact@v4
-        with:
-          name: python-wheels
-          path: |
-            ${{ runner.workspace }}/prebuilt-local/wheels/*.whl
-            ${{ runner.workspace }}/oga-artifacts/*.whl
-          retention-days: ${{ github.ref == 'refs/heads/main' && 14 || 3 }}
-          if-no-files-found: error
 
       - name: Upload GPU test package
         uses: actions/upload-artifact@v4

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: windows-latest
 
     env:
-      PREBUILT_CACHE_VERSION: "2"  # bump to invalidate prebuilt cache
+      PREBUILT_CACHE_VERSION: "3"  # bump to invalidate prebuilt cache (added cp314 wheels)
       LLVM_TAG: llvm-22.1.0-release
       FLATBUFFERS_TAG: flatbuffers-25.12.19-release
       PROTO_TAG: protobuf-34.0-release
@@ -116,10 +116,10 @@ jobs:
       # llvm-lit.py (from prebuilt) requires the lit pip package at runtime.
       # Pin Python to avoid mismatch with find_package(Python3) in CMake.
       # -----------------------------------------------------------------------
-      - name: Setup Python 3.12
+      - name: Setup Python 3.14
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Install pip dependencies
         run: pip install lit requests
@@ -165,7 +165,8 @@ jobs:
             --skip_tests ^
             --disable_memleak_checker ^
             --use_dml ^
-            --cmake_generator Ninja
+            --cmake_generator Ninja ^
+            --build_wheel
 
       - name: Install ORT into prebuilt-local
         if: steps.cache-prebuilt.outputs.cache-hit != 'true'
@@ -190,6 +191,18 @@ jobs:
             exit 1
           fi
           cp "$DML_DLL" "${{ runner.workspace }}/prebuilt-local/bin/"
+          # Cache the cp314 ORT Python wheel inside prebuilt-local so it
+          # rides the same cache key as the rest of the ORT artifacts.
+          # Output path: build-onnxruntime/Release/dist/onnxruntime_directml-1.24.3-cp314-cp314-win_amd64.whl
+          ORT_WHEEL=$(find "${{ runner.workspace }}/build-onnxruntime" \
+            -name "onnxruntime_directml-*.whl" -type f | head -1)
+          if [ -z "$ORT_WHEEL" ]; then
+            echo "ERROR: onnxruntime_directml wheel not found in build tree"
+            exit 1
+          fi
+          mkdir -p "${{ runner.workspace }}/prebuilt-local/wheels"
+          cp "$ORT_WHEEL" "${{ runner.workspace }}/prebuilt-local/wheels/"
+          echo "Cached ORT wheel: $(basename "$ORT_WHEEL")"
 
       # -----------------------------------------------------------------------
       # Download LLVM prebuilt (from wcy123/llvm-mlir-prebuilt releases)
@@ -348,7 +361,7 @@ jobs:
             --cmake_generator Ninja \
             --use_dml \
             --ort_home "$ORT_HOME" \
-            --skip_wheel --skip_tests --skip_examples \
+            --skip_tests --skip_examples \
             --parallel \
             --build_dir "${{ runner.workspace }}/build-oga" \
             --cmake_extra_defines \
@@ -359,6 +372,16 @@ jobs:
           OGA_OUT="${{ runner.workspace }}/build-oga/Release"
           cp "$OGA_OUT/benchmark/c/model_benchmark.exe" "${{ runner.workspace }}/oga-artifacts/"
           cp "$OGA_OUT/onnxruntime-genai.dll" "${{ runner.workspace }}/oga-artifacts/"
+          # Cache the cp314 OGA Python wheel alongside the other OGA artifacts.
+          # Output path: build-oga/Release/wheel/onnxruntime_genai_directml-0.13.0.dev0-cp314-cp314-win_amd64.whl
+          OGA_WHEEL=$(find "${{ runner.workspace }}/build-oga" \
+            -name "onnxruntime_genai_directml-*.whl" -type f | head -1)
+          if [ -z "$OGA_WHEEL" ]; then
+            echo "ERROR: onnxruntime_genai_directml wheel not found in build tree"
+            exit 1
+          fi
+          cp "$OGA_WHEEL" "${{ runner.workspace }}/oga-artifacts/"
+          echo "Cached OGA wheel: $(basename "$OGA_WHEEL")"
 
       # -----------------------------------------------------------------------
       # Stage GPU test package:
@@ -434,6 +457,22 @@ jobs:
 
           echo "=== Staged package contents ==="
           find staging/ -type f | sort
+
+      # -----------------------------------------------------------------------
+      # Upload Python wheels (ORT + OGA cp314) as a separate artifact so they
+      # can be downloaded independently from gpu-test-package. Both wheels are
+      # cached inside prebuilt-local / oga-artifacts respectively, so cache
+      # hits restore them without re-running ORT / OGA from-source builds.
+      # -----------------------------------------------------------------------
+      - name: Upload Python wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-wheels
+          path: |
+            ${{ runner.workspace }}/prebuilt-local/wheels/*.whl
+            ${{ runner.workspace }}/oga-artifacts/*.whl
+          retention-days: ${{ github.ref == 'refs/heads/main' && 14 || 3 }}
+          if-no-files-found: error
 
       - name: Upload GPU test package
         uses: actions/upload-artifact@v4

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -12,16 +12,19 @@ on:
   push:
     branches: [main]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
 permissions:
   contents: read
 
 jobs:
   build-windows:
     runs-on: windows-latest
+    # Cancel the build job when a newer commit lands on the same PR ref to
+    # save runner minutes. gpu-test deliberately does NOT inherit this rule
+    # (see its own concurrency block below) so an in-progress GPU run keeps
+    # going to completion even if a newer build supersedes it.
+    concurrency:
+      group: build-windows-${{ github.ref }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
     env:
       PREBUILT_CACHE_VERSION: "3"  # bump to invalidate prebuilt cache (added cp314 wheels)
@@ -488,6 +491,13 @@ jobs:
   gpu-test:
     needs: build-windows
     runs-on: StrixHalo
+    # Never cancel an in-progress GPU run: queue newer runs of the same ref
+    # behind it instead of killing the long-running perf / OGA / L2 suites.
+    # The self-hosted StrixHalo runner already serializes physically, so
+    # this group only adds explicit logical queueing for clarity.
+    concurrency:
+      group: gpu-test-${{ github.ref }}
+      cancel-in-progress: false
 
     permissions:
       contents: read

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -329,7 +329,11 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ${{ runner.workspace }}/oga-artifacts
-          key: oga-dml-${{ env.OGA_REF }}-ort${{ env.ONNXRUNTIME_VERSION }}
+          # Reuse PREBUILT_CACHE_VERSION as the OGA cache version too: when
+          # the OGA build outputs change shape (e.g. wheel added), bumping
+          # PREBUILT_CACHE_VERSION invalidates both ORT and OGA caches in
+          # one step instead of needing two separate version knobs.
+          key: oga-dml-v${{ env.PREBUILT_CACHE_VERSION }}-${{ env.OGA_REF }}-ort${{ env.ONNXRUNTIME_VERSION }}
 
       - name: Checkout OGA
         if: steps.cache-oga.outputs.cache-hit != 'true'


### PR DESCRIPTION
## 1. Problem

This PR addresses two unrelated Windows CI issues that share a single workflow file:

**P-1: CI testing needs cp314 ORT/OGA wheels.** Downstream CI / dev tooling consumes the `gpu-test-package` artifact and now needs `onnxruntime_directml` and `onnxruntime_genai_directml` wheels built for Python 3.14 (`cp314-cp314-win_amd64`). The current workflow only emits the from-source ORT/OGA C++ builds plus a runtime DLL/exe staging tree — no wheel is produced. Each consumer has to hand-build wheels outside CI, which both blocks fully-automated downstream test runs and risks drift between CI's ORT/OGA versions and what consumers actually install.

**P-2: GPU cancellation can hang the StrixHalo runner.** The workflow-level `concurrency.cancel-in-progress: ${{ github.event_name == 'pull_request' }}` cancels every job — including `gpu-test` — when a newer commit lands on the same PR. `gpu-test` chains `onnxruntime_perf_test` over multiple LLM models + OGA `model_benchmark` + L2 accuracy diff, often 20-40 min total with the GPU saturated. **Cancelling those jobs mid-execution does not always release the GPU cleanly** (perf_test / model_benchmark hold device handles, MorphiZen JIT-loaded DLLs hold lld-link state, etc.). The self-hosted StrixHalo runner ends up in a half-cancelled state and **subsequent jobs queued for the same runner never trigger** until someone manually kills the leftover processes — sometimes the runner has to be restarted. Net effect: a benign force-push on a PR can take the GPU runner offline.

## 2. Solution

**For P-1 — emit cp314 wheels alongside the existing source builds:**

```mermaid
flowchart LR
    py["setup-python 3.12 -> 3.14"]
    py --> ortBuild["build.bat + --build_wheel"]
    py --> ogaBuild["build.py without --skip_wheel"]
    ortBuild --> ortWhl["onnxruntime_directml-1.24.3-cp314-cp314-win_amd64.whl"]
    ogaBuild --> ogaWhl["onnxruntime_genai_directml-0.13.0.dev0-cp314-cp314-win_amd64.whl"]
    ortWhl --> stagingW["staging/wheels/"]
    ogaWhl --> stagingW
    stagingW --> upload["gpu-test-package artifact"]
```

1. Bump `actions/setup-python` from 3.12 to 3.14 — required so the wheel ABI tag is `cp314-cp314`. Pure plumbing, not an independent goal.
2. Append `--build_wheel` to ORT `build.bat` invocation. With `--use_dml` already in place, ORT's `setup.py` chooses `package_name = "onnxruntime-directml"` ([ORT setup.py L788](https://github.com/microsoft/onnxruntime/blob/v1.24.3/setup.py#L788)) and `bdist_wheel` writes the wheel to `build-onnxruntime/Release/dist/`.
3. Drop `--skip_wheel` from OGA `build.py` invocation. OGA's CMake `PyPackageBuild` target builds the wheel into `build-oga/Release/wheel/`. Package name is `onnxruntime-genai-directml` from `setup.py.in @TARGET_NAME@`, version `0.13.0.dev0` from PEP 440 normalization of `VERSION_INFO=0.13.0-dev`.
4. Cache each wheel inside its existing cache scope (`prebuilt-local/wheels/` for ORT, `oga-artifacts/` for OGA) so cache hits restore them without re-running source builds.
5. Bundle both wheels into `staging/wheels/` at the end of the existing `Stage GPU test package` step — they ride the existing `gpu-test-package` upload, no separate `python-wheels` artifact.
6. Bump `PREBUILT_CACHE_VERSION` `"2"` → `"3"` to invalidate caches that don't yet contain the wheel.

**For P-2 — never cancel in-flight gpu-test:**

| Job | concurrency.group | cancel-in-progress | Behavior |
|---|---|---|---|
| `build-windows` | `build-windows-${{ github.ref }}` | `${{ github.event_name == 'pull_request' }}` | Same as before — force-push to PR cancels old build (CPU-only, releases cleanly) |
| `gpu-test` | `gpu-test-${{ github.ref }}` | `false` | Newer runs on the same ref **queue** behind the in-progress one; in-flight perf_test / model_benchmark / L2 always run to completion, runner never hangs |

The workflow-level `concurrency` block is removed (it cancelled the entire run; per-job cancellation rules cannot survive workflow-level cancellation).

## 3. Results

### Final artifact layout

`gpu-test-package` artifact now contains an extra `wheels/` subfolder; downstream consumers download a single zip:

```
gpu-test-package/
  bin/                          # exes + dlls (existing)
  lib/                          # MSVC/WinSDK CRT libs (existing)
  morphizen_config.json         # EP config (existing)
  wheels/                       # NEW
    onnxruntime_directml-1.24.3-cp314-cp314-win_amd64.whl                   (23 MB)
    onnxruntime_genai_directml-0.13.0.dev0-cp314-cp314-win_amd64.whl        (2.4 MB)
```

### Local verification (Python 3.14.4)

Both wheel filenames + paths confirmed by running the same `build.bat` / `build.py` flags as the CI workflow. ORT build (`--build_wheel`) succeeded in 6.5 min on a clean tree; OGA build (without `--skip_wheel`) in 72 s. No Python 3.14 compatibility issues encountered — ORT's `build.py` auto-installs `wheel` / `setuptools` / `packaging` into the runner Python, OGA only needs the existing `requests` from the workflow's `pip install lit requests` step.

### gpu-test resilience

After this PR, force-pushing to a PR will:
- **Cancel** the in-progress `build-windows` (unchanged behavior — CPU-only, clean release).
- **Leave the in-progress `gpu-test` running to completion**, so the GPU never enters the hung half-cancelled state. The newly-triggered `gpu-test` for the new HEAD queues behind it (StrixHalo is a self-hosted single-instance runner, so this matches physical execution order).

### Diff scope

Single file: `.github/workflows/windows-build.yml`, +63 / -9 lines. No source / build / runtime changes; ORT / OGA pinned versions and onnx-hipdnn-ep build configuration remain untouched.

## Test plan

- [ ] `build-windows` green on cold cache (first run after `PREBUILT_CACHE_VERSION` bump): ORT + OGA build successfully on Python 3.14
- [ ] `gpu-test-package` artifact contains `wheels/` with both `.whl` files
- [ ] `build-windows` green on cache hit: subsequent runs restore the wheels from cache without re-building ORT/OGA from source
- [ ] `gpu-test` job still green: perf / OGA benchmark / L2 accuracy results unchanged
- [ ] Force-push to this PR while gpu-test is running: the in-flight gpu-test must continue to completion (no hung runner)
