### PR TITLE
feat: add slice op

### DIFF
--- a/3rd-party/custom_kernels/CMakeLists.txt
+++ b/3rd-party/custom_kernels/CMakeLists.txt
@@ -39,6 +39,7 @@ hip_add_library(hip_custom_kernels STATIC
     hip/reduce_sum_kernel.hip
     hip/matmul_nbits_kernel.hip
     hip/qmoe_kernel.hip
+    hip/slice_kernel.hip
     INCLUDE_DIRECTORIES
         ${CMAKE_CURRENT_SOURCE_DIR}/include
 )

--- a/3rd-party/custom_kernels/hip/slice_kernel.hip
+++ b/3rd-party/custom_kernels/hip/slice_kernel.hip
@@ -1,0 +1,215 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "hip_custom_kernels.h"
+#include "debug_log.h"
+
+#include <hip/hip_runtime.h>
+#include <cstdint>
+#include <cstdio>
+
+// Compile-time limits. Must match HIP_SLICE_MAX_RANK in hip_custom_kernels.h.
+static_assert(HIP_SLICE_MAX_RANK >= 1, "rank must be at least 1");
+
+// Metadata passed by value to the kernel. Keeping everything inside a POD
+// lets us stick to fixed-size buffers instead of allocating device memory
+// for per-launch shape/stride tables.
+struct SliceMeta {
+  int64_t input_shape[HIP_SLICE_MAX_RANK];
+  int64_t input_strides[HIP_SLICE_MAX_RANK];
+  int64_t output_strides[HIP_SLICE_MAX_RANK];
+  int32_t rank;
+  int32_t num_slice_entries;
+};
+
+// Element-level slice kernel. One thread per output element; the thread maps
+// its flat output index back into a coordinate using `output_strides`, then
+// transforms sliced axes via `axes[i] / starts[i] / steps[i]` (reading them
+// from device memory) into an input coordinate, and finally computes the
+// corresponding linear input offset via `input_strides`.
+template <typename T>
+__global__ void slice_kernel(
+    const T* __restrict__ data,
+    const int64_t* __restrict__ starts,
+    const int64_t* __restrict__ axes,   // nullable
+    const int64_t* __restrict__ steps,  // nullable
+    T* __restrict__ output,
+    SliceMeta meta,
+    int64_t output_num_elements) {
+  int64_t tid = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (tid >= output_num_elements) return;
+
+  int rank = meta.rank;
+
+  // 1. flat output index -> per-axis output coordinate
+  int64_t out_coord[HIP_SLICE_MAX_RANK];
+  {
+    int64_t rem = tid;
+    for (int i = 0; i < rank; ++i) {
+      int64_t stride = meta.output_strides[i];
+      int64_t c = (stride > 0) ? (rem / stride) : 0;
+      out_coord[i] = c;
+      rem -= c * stride;
+    }
+  }
+
+  // 2. default in_coord = out_coord for axes not covered by a slice entry
+  int64_t in_coord[HIP_SLICE_MAX_RANK];
+  for (int i = 0; i < rank; ++i) {
+    in_coord[i] = out_coord[i];
+  }
+
+  // 3. apply slice for each (starts[i], ends[i], axes[i], steps[i]) entry
+  for (int i = 0; i < meta.num_slice_entries; ++i) {
+    int64_t axis = axes ? axes[i] : static_cast<int64_t>(i);
+    if (axis < 0) axis += rank;
+    if (axis < 0 || axis >= rank) continue;
+
+    int64_t step = steps ? steps[i] : 1;
+    int64_t start = starts[i];
+    int64_t dim_size = meta.input_shape[axis];
+
+    if (start < 0) start += dim_size;
+    if (step >= 0) {
+      if (start < 0) start = 0;
+      if (start > dim_size) start = dim_size;
+    } else {
+      if (start < 0) start = -1;
+      if (start > dim_size - 1) start = dim_size - 1;
+    }
+
+    in_coord[axis] = start + out_coord[axis] * step;
+  }
+
+  // 4. compute linear input offset
+  int64_t in_offset = 0;
+  for (int i = 0; i < rank; ++i) {
+    in_offset += in_coord[i] * meta.input_strides[i];
+  }
+
+  output[tid] = data[in_offset];
+}
+
+// Compute row-major strides for a contiguous shape. strides[i] = prod(shape[i+1..]).
+// Assumes `rank <= HIP_SLICE_MAX_RANK`.
+static void compute_contiguous_strides(const int64_t* shape, int rank,
+                                       int64_t* strides) {
+  int64_t running = 1;
+  for (int i = rank - 1; i >= 0; --i) {
+    strides[i] = running;
+    running *= shape[i];
+  }
+}
+
+extern "C" int hip_slice(
+    void* stream,
+    const void* data,
+    const void* starts,
+    const void* /*ends*/,       // not used by the kernel; output shape already known
+    const void* axes,
+    const void* steps,
+    void* output,
+    const int64_t* input_shape,
+    const int64_t* output_shape,
+    int64_t rank,
+    int64_t num_slice_entries,
+    int64_t output_num_elements,
+    int element_size_bytes) {
+  if (output_num_elements <= 0) return 0;
+
+  if (!data || !output || !starts || !input_shape || !output_shape) {
+    fprintf(stderr, "[custom_kernels] hip_slice: null argument\n");
+    return -1;
+  }
+
+  if (rank <= 0 || rank > HIP_SLICE_MAX_RANK) {
+    fprintf(stderr,
+            "[custom_kernels] hip_slice: unsupported rank=%lld (max %d)\n",
+            (long long)rank, HIP_SLICE_MAX_RANK);
+    return -1;
+  }
+
+  if (num_slice_entries < 0 || num_slice_entries > rank) {
+    fprintf(stderr,
+            "[custom_kernels] hip_slice: invalid num_slice_entries=%lld for "
+            "rank=%lld\n",
+            (long long)num_slice_entries, (long long)rank);
+    return -1;
+  }
+
+  SliceMeta meta{};
+  meta.rank = static_cast<int32_t>(rank);
+  meta.num_slice_entries = static_cast<int32_t>(num_slice_entries);
+  for (int i = 0; i < static_cast<int>(rank); ++i) {
+    meta.input_shape[i] = input_shape[i];
+  }
+  compute_contiguous_strides(input_shape, static_cast<int>(rank),
+                             meta.input_strides);
+  compute_contiguous_strides(output_shape, static_cast<int>(rank),
+                             meta.output_strides);
+
+  hipStream_t hip_stream = static_cast<hipStream_t>(stream);
+  constexpr int kBlockSize = 256;
+  int grid_size = static_cast<int>(
+      (output_num_elements + kBlockSize - 1) / kBlockSize);
+
+  CUSTOM_KERNELS_DEBUG_LOG(
+      "[custom_kernels] hip_slice: rank=%lld, slice_entries=%lld, "
+      "output_num=%lld, elem_size=%d, grid=%d, block=%d\n",
+      (long long)rank, (long long)num_slice_entries,
+      (long long)output_num_elements, element_size_bytes, grid_size,
+      kBlockSize);
+
+  const int64_t* starts_ptr = static_cast<const int64_t*>(starts);
+  const int64_t* axes_ptr = static_cast<const int64_t*>(axes);
+  const int64_t* steps_ptr = static_cast<const int64_t*>(steps);
+
+  switch (element_size_bytes) {
+    case 1:
+      hipLaunchKernelGGL(slice_kernel<uint8_t>,
+                         dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
+                         static_cast<const uint8_t*>(data),
+                         starts_ptr, axes_ptr, steps_ptr,
+                         static_cast<uint8_t*>(output),
+                         meta, output_num_elements);
+      break;
+    case 2:
+      hipLaunchKernelGGL(slice_kernel<uint16_t>,
+                         dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
+                         static_cast<const uint16_t*>(data),
+                         starts_ptr, axes_ptr, steps_ptr,
+                         static_cast<uint16_t*>(output),
+                         meta, output_num_elements);
+      break;
+    case 4:
+      hipLaunchKernelGGL(slice_kernel<uint32_t>,
+                         dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
+                         static_cast<const uint32_t*>(data),
+                         starts_ptr, axes_ptr, steps_ptr,
+                         static_cast<uint32_t*>(output),
+                         meta, output_num_elements);
+      break;
+    case 8:
+      hipLaunchKernelGGL(slice_kernel<uint64_t>,
+                         dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
+                         static_cast<const uint64_t*>(data),
+                         starts_ptr, axes_ptr, steps_ptr,
+                         static_cast<uint64_t*>(output),
+                         meta, output_num_elements);
+      break;
+    default:
+      fprintf(stderr,
+              "[custom_kernels] hip_slice: unsupported element_size=%d\n",
+              element_size_bytes);
+      return -1;
+  }
+
+  hipError_t err = hipGetLastError();
+  if (err != hipSuccess) {
+    fprintf(stderr, "[custom_kernels] hip_slice launch failed: %s\n",
+            hipGetErrorString(err));
+  }
+  return static_cast<int>(err);
+}

--- a/3rd-party/custom_kernels/include/hip_custom_kernels.h
+++ b/3rd-party/custom_kernels/include/hip_custom_kernels.h
@@ -523,6 +523,54 @@ int hip_qmoe_scatter_add(
 int hip_gemm_wmma_fp16(void* stream, const void* A, const void* B,
                        void* C, int M, int K, int N);
 
+/* =========================================================================
+ * Slice (ONNX Slice, opset 13+)
+ * =========================================================================
+ *
+ * Produces a slice of `data` along multiple axes. Implements the ONNX Slice
+ * operator semantics, including negative indices and negative steps (reverse
+ * stepping).
+ *
+ * For each entry i in [0, num_slice_entries):
+ *   axis  = axes ? axes[i] : i  (normalized to [0, rank))
+ *   step  = steps ? steps[i] : 1
+ *   start = starts[i]            (normalized + clamped per ONNX rules)
+ * Output element at (o_0, ..., o_{rank-1}) reads
+ *   data[(o_0, ..., offsets applied along sliced axes ...)]
+ *
+ * Parameters:
+ *   stream              - hipStream_t cast to void*
+ *   data                - GPU source tensor
+ *   starts/ends         - GPU int64 tensors of length num_slice_entries
+ *   axes                - GPU int64 tensor (nullable, defaults to [0..rank))
+ *   steps               - GPU int64 tensor (nullable, defaults to all-1)
+ *   output              - GPU destination tensor
+ *   input_shape         - HOST int64 array, length `rank`, input dim sizes
+ *   output_shape        - HOST int64 array, length `rank`, output dim sizes
+ *   rank                - number of dimensions (same for input and output)
+ *   num_slice_entries   - length of starts/ends/axes/steps
+ *   output_num_elements - total output elements (kernel launch size)
+ *   element_size_bytes  - 1/2/4/8 (bool/int8/i32/f32/i64/...)
+ *
+ * Returns: 0 on success, non-zero on failure. Unsupported element sizes
+ * or ranks larger than HIP_SLICE_MAX_RANK are rejected.
+ */
+#define HIP_SLICE_MAX_RANK 8
+int hip_slice(
+    void* stream,
+    const void* data,
+    const void* starts,
+    const void* ends,
+    const void* axes,
+    const void* steps,
+    void* output,
+    const int64_t* input_shape,
+    const int64_t* output_shape,
+    int64_t rank,
+    int64_t num_slice_entries,
+    int64_t output_num_elements,
+    int element_size_bytes);
+
 #ifdef __cplusplus
 }
 #endif

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ This project demonstrates the integration of HIP (Heterogeneous-compute Interfac
 | Cast | Custom HIP Kernel |
 | ReduceSum | Custom HIP Kernel |
 | Gather | Custom HIP Kernel |
+| Slice | Custom HIP Kernel |
 | SimplifiedLayerNormalization | MIOpen |
 | SkipSimplifiedLayerNormalization (com.microsoft) | MIOpen |
 | RotaryEmbedding (com.microsoft) | Custom HIP Kernel |

--- a/include/hip/Dialect/IR/HipBufferize.h
+++ b/include/hip/Dialect/IR/HipBufferize.h
@@ -94,6 +94,7 @@ registerHipBufferizableOpInterfaceModels(DialectRegistry &registry) {
     HipDNNGraphOp::attachInterface<HipDstBufferizableModel<HipDNNGraphOp>>(
         *ctx);
     GemmOp::attachInterface<HipDstBufferizableModel<GemmOp>>(*ctx);
+    SliceOp::attachInterface<HipDstBufferizableModel<SliceOp>>(*ctx);
   });
 }
 

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -693,6 +693,69 @@ def Hip_GatherOp : Hip_DpsOp<"gather"> {
   }];
 }
 
+def Hip_SliceOp : Hip_DpsOp<"slice", [AttrSizedOperandSegments]> {
+  let summary = "Slice tensor along multiple axes (ONNX Slice)";
+  let description = [{
+    Produces a slice of the input tensor along multiple axes. Implements the
+    ONNX Slice operator (opset 13+).
+
+    Inputs:
+    - data (required): Tensor of data to extract slices from.
+    - starts (required): 1-D tensor of starting indices per entry in axes.
+    - ends (required): 1-D tensor of ending indices (exclusive) per entry.
+    - axes (optional): 1-D tensor of axes to apply starts/ends to.
+                       Defaults to [0, ..., r-1] when absent.
+    - steps (optional): 1-D tensor of slice steps. Defaults to all-1 when
+                        absent. Negative values mean reverse stepping.
+
+    Negative indices in starts/ends are normalized against the corresponding
+    dimension size by the runtime kernel. Clamping follows the ONNX rules
+    (positive stepping clamps to [0, dim]; negative stepping clamps to
+    [-1, dim-1]).
+
+    Uses destination-passing style: output buffer is provided as argument.
+
+    Example (basic slice):
+    ```mlir
+    hip.slice(%ctx) ins(%data, %starts, %ends :
+        memref<2x4xf32, 1>, memref<2xi64, 1>, memref<2xi64, 1>)
+        outs(%output : memref<1x2xf32, 1>)
+    ```
+
+    Example (with axes and steps):
+    ```mlir
+    hip.slice(%ctx) ins(%data, %starts, %ends, %axes, %steps :
+        memref<2x4xf32, 1>, memref<2xi64, 1>, memref<2xi64, 1>,
+        memref<2xi64, 1>, memref<2xi64, 1>)
+        outs(%output : memref<1x2xf32, 1>)
+    ```
+  }];
+
+  let arguments = (ins
+    Hip_ContextType:$ctx,
+    Hip_TensorOrMemRef:$data,
+    Hip_TensorOrMemRef:$starts,
+    Hip_TensorOrMemRef:$ends,
+    Optional<Hip_TensorOrMemRef>:$axes,
+    Optional<Hip_TensorOrMemRef>:$steps,
+    Hip_TensorOrMemRef:$output
+  );
+
+  let assemblyFormat = [{
+    `(` $ctx `)` `ins` `(`
+        $data `,` $starts `,` $ends
+        (`,` $axes^)?
+        (`,` $steps^)?
+        `:`
+        type($data) `,` type($starts) `,` type($ends)
+        (`,` type($axes)^)?
+        (`,` type($steps)^)?
+    `)`
+    `outs` `(` $output `:` type($output) `)`
+    attr-dict (`:` type($result_tensors)^)?
+  }];
+}
+
 def Hip_SiluOp : Hip_DpsOp<"silu"> {
   let summary = "SiLU activation: output = input * sigmoid(input)";
   let arguments = (ins

--- a/lib/Conversion/HipToLLVM/CMakeLists.txt
+++ b/lib/Conversion/HipToLLVM/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(HipToLLVM STATIC
   GraphLowering.cpp
   CausalConvWithStateLowering.cpp
   GemmLowering.cpp
+  SliceLowering.cpp
 )
 
 add_dependencies(HipToLLVM

--- a/lib/Conversion/HipToLLVM/HipToLLVM.cpp
+++ b/lib/Conversion/HipToLLVM/HipToLLVM.cpp
@@ -228,6 +228,7 @@ void ConvertHipToLLVMPass::runOnOperation() {
   populateGemmLoweringPatterns(typeConverter, patterns);
   populateGraphLoweringPatterns(typeConverter, patterns);
   populateCausalConvWithStateLoweringPatterns(typeConverter, patterns);
+  populateSliceLoweringPatterns(typeConverter, patterns);
 
   // Standard dialect lowerings
   // Bundle func/memref/arith/cf lowering with HIP lowering to minimize

--- a/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
+++ b/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
@@ -68,6 +68,7 @@ inline constexpr const char *kHipGetConstant = "hipdnn_ep_constant_get";
 inline constexpr const char *kHipDNNGraphExecute = "hipdnn_graph_execute";
 inline constexpr const char *kWrapCausalConvWithState =
     "wrap_causal_conv_with_state";
+inline constexpr const char *kWrapSlice = "wrap_slice";
 
 // LLVM memref descriptor struct field indices.
 // Layout: { allocatedPtr, alignedPtr, offset, sizes[rank], strides[rank] }
@@ -252,6 +253,8 @@ void populateCausalConvWithStateLoweringPatterns(
     const LLVMTypeConverter &converter, RewritePatternSet &patterns);
 void populateGemmLoweringPatterns(const LLVMTypeConverter &converter,
                                   RewritePatternSet &patterns);
+void populateSliceLoweringPatterns(const LLVMTypeConverter &converter,
+                                   RewritePatternSet &patterns);
 
 } // namespace hip
 } // namespace mlir

--- a/lib/Conversion/HipToLLVM/SliceLowering.cpp
+++ b/lib/Conversion/HipToLLVM/SliceLowering.cpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "HipToLLVMUtils.h"
+
+namespace mlir {
+namespace hip {
+namespace {
+
+//===----------------------------------------------------------------------===//
+// hip.slice(ctx)
+//   ins(data, starts, ends [, axes] [, steps])
+//   outs(output)
+// -> wrap_slice(state, data, starts, ends, axes (nullable), steps (nullable),
+//               output, input_shape_ptr, output_shape_ptr,
+//               rank, num_slice_entries, output_num_elements,
+//               element_size_bytes, data_type)
+//
+// `input_shape_ptr` / `output_shape_ptr` are stack-allocated i64 arrays of
+// length `rank`, populated from the memref descriptor (static dims become
+// compile-time constants; dynamic dims are read from the descriptor).
+//===----------------------------------------------------------------------===//
+
+struct SliceOpLowering : public ConvertOpToLLVMPattern<SliceOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(SliceOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    ModuleOp module = op->getParentOfType<ModuleOp>();
+    Type ptrType = getPtrType();
+    Type i32Type = rewriter.getI32Type();
+    Type i64Type = rewriter.getI64Type();
+
+    auto createI64Const = [&](int64_t value) -> Value {
+      return LLVM::ConstantOp::create(rewriter, loc, i64Type,
+                                      rewriter.getI64IntegerAttr(value));
+    };
+
+    // Extract pointers
+    Value statePtr = adaptor.getCtx();
+    Value dataPtr = extractMemRefPtr(adaptor.getData(), rewriter, loc);
+    Value startsPtr = extractMemRefPtr(adaptor.getStarts(), rewriter, loc);
+    Value endsPtr = extractMemRefPtr(adaptor.getEnds(), rewriter, loc);
+    Value axesPtr =
+        extractOptionalMemRefPtr(adaptor.getAxes(), rewriter, loc);
+    Value stepsPtr =
+        extractOptionalMemRefPtr(adaptor.getSteps(), rewriter, loc);
+    Value outputPtr = extractMemRefPtr(adaptor.getOutput(), rewriter, loc);
+
+    // Sanity-check types
+    auto dataType = cast<MemRefType>(op.getData().getType());
+    auto startsType = cast<MemRefType>(op.getStarts().getType());
+    auto outputType = cast<MemRefType>(op.getOutput().getType());
+
+    int64_t rank = dataType.getRank();
+    if (outputType.getRank() != rank)
+      return op.emitError(
+          "hip.slice input and output must have the same rank");
+
+    // Number of slicing entries = number of elements in starts.
+    Value numSliceEntries =
+        computeNumElements(startsType, adaptor.getStarts(), rewriter, loc);
+
+    // Rank/num_elements metadata
+    Value rankVal = createI64Const(rank);
+    Value outputNumElements =
+        computeNumElements(outputType, adaptor.getOutput(), rewriter, loc);
+
+    // Allocate stack buffers for input/output shape (i64 x rank).
+    Value arraySize = createI64Const(rank);
+    Value inputShapeBuf = LLVM::AllocaOp::create(
+        rewriter, loc, ptrType, i64Type, arraySize, /*alignment=*/8);
+    Value outputShapeBuf = LLVM::AllocaOp::create(
+        rewriter, loc, ptrType, i64Type, arraySize, /*alignment=*/8);
+
+    auto storeDim = [&](Value buf, int64_t dimIdx, Value dimVal) {
+      Value idx = createI64Const(dimIdx);
+      Value slot = LLVM::GEPOp::create(rewriter, loc, ptrType, i64Type, buf,
+                                       ValueRange{idx});
+      LLVM::StoreOp::create(rewriter, loc, dimVal, slot);
+    };
+
+    for (int64_t i = 0; i < rank; ++i) {
+      Value inDim =
+          getMemRefDimSize(dataType, i, adaptor.getData(), rewriter, loc);
+      Value outDim =
+          getMemRefDimSize(outputType, i, adaptor.getOutput(), rewriter, loc);
+      storeDim(inputShapeBuf, i, inDim);
+      storeDim(outputShapeBuf, i, outDim);
+    }
+
+    unsigned elementSizeBytes =
+        dataType.getElementType().getIntOrFloatBitWidth() / 8;
+    Value elemSizeVal = createI64Const(elementSizeBytes);
+    Value dataTypeVal =
+        createI64Const(getHipdnnDataType(dataType.getElementType()));
+
+    // int wrap_slice(RuntimeState* state,
+    //                void* data, void* starts, void* ends,
+    //                void* axes, void* steps, void* output,
+    //                const int64_t* input_shape,
+    //                const int64_t* output_shape,
+    //                int64_t rank, int64_t num_slice_entries,
+    //                int64_t output_num_elements,
+    //                int64_t element_size_bytes, int64_t data_type)
+    SmallVector<Type, 14> paramTypes = {
+        ptrType, // state
+        ptrType, // data
+        ptrType, // starts
+        ptrType, // ends
+        ptrType, // axes (nullable)
+        ptrType, // steps (nullable)
+        ptrType, // output
+        ptrType, // input_shape
+        ptrType, // output_shape
+        i64Type, // rank
+        i64Type, // num_slice_entries
+        i64Type, // output_num_elements
+        i64Type, // element_size_bytes
+        i64Type  // data_type
+    };
+
+    FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
+        rewriter, module, kWrapSlice, paramTypes, i32Type);
+    if (failed(funcOp))
+      return failure();
+
+    SmallVector<Value, 14> args = {statePtr,          dataPtr,
+                                   startsPtr,         endsPtr,
+                                   axesPtr,           stepsPtr,
+                                   outputPtr,         inputShapeBuf,
+                                   outputShapeBuf,    rankVal,
+                                   numSliceEntries,   outputNumElements,
+                                   elemSizeVal,       dataTypeVal};
+
+    LLVM::CallOp::create(rewriter, loc, *funcOp, args);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+} // namespace
+
+void mlir::hip::populateSliceLoweringPatterns(
+    const LLVMTypeConverter &converter, RewritePatternSet &patterns) {
+  patterns.add<SliceOpLowering>(converter);
+}
+
+} // namespace hip
+} // namespace mlir

--- a/lib/Conversion/OnnxToHip/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHip/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(OnnxToHip STATIC
   ReshapeConversion.cpp
   CausalConvWithStateConversion.cpp
   GemmConversion.cpp
+  SliceConversion.cpp
 )
 
 add_dependencies(OnnxToHip

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -381,6 +381,7 @@ static mlir::LogicalResult convertComputeOps(mlir::func::FuncOp funcOp,
   populateReshapeConversionPatterns(patterns, ctx);
   populateCausalConvWithStateConversionPatterns(patterns, ctx);
   populateGemmConversionPatterns(patterns, ctx);
+  populateSliceConversionPatterns(patterns, ctx);
 
   mlir::GreedyRewriteConfig config;
   config.setStrictness(mlir::GreedyRewriteStrictness::ExistingOps);

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
@@ -145,6 +145,8 @@ void populateCausalConvWithStateConversionPatterns(RewritePatternSet &patterns,
                                                    MLIRContext *ctx);
 void populateGemmConversionPatterns(RewritePatternSet &patterns,
                                     MLIRContext *ctx);
+void populateSliceConversionPatterns(RewritePatternSet &patterns,
+                                     MLIRContext *ctx);
 
 } // namespace hip
 } // namespace mlir

--- a/lib/Conversion/OnnxToHip/SliceConversion.cpp
+++ b/lib/Conversion/OnnxToHip/SliceConversion.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "OnnxToHipUtils.h"
+
+namespace mlir {
+namespace hip {
+namespace {
+
+//===----------------------------------------------------------------------===//
+// ONNX Slice -> HIP Slice
+//===----------------------------------------------------------------------===//
+//
+// ONNX Slice (opset 13+) operand order: data, starts, ends, [axes], [steps].
+// Optional `axes` and `steps` may be absent or materialized as `onnx.NoValue`
+// (a NoneType value). This pattern normalizes both cases into a hip.slice op
+// whose optional operands are simply omitted.
+//===----------------------------------------------------------------------===//
+
+struct SliceToHip : public mlir::RewritePattern {
+  SliceToHip(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.Slice", /*benefit=*/1, ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override {
+    auto ctxOrFailure = getContextArg(op, rewriter);
+    if (mlir::failed(ctxOrFailure))
+      return rewriter.notifyMatchFailure(op, "missing context argument");
+    mlir::Value context = *ctxOrFailure;
+
+    mlir::Location loc = op->getLoc();
+
+    unsigned numOperands = op->getNumOperands();
+    if (numOperands < 3 || numOperands > 5)
+      return rewriter.notifyMatchFailure(
+          op, "expected 3-5 operands for ONNX Slice");
+
+    mlir::Value data = op->getOperand(0);
+    mlir::Value starts = op->getOperand(1);
+    mlir::Value ends = op->getOperand(2);
+
+    auto isNoneOperand = [](mlir::Value v) {
+      return mlir::isa<mlir::NoneType>(v.getType());
+    };
+
+    mlir::Value axes = nullptr;
+    if (numOperands > 3 && !isNoneOperand(op->getOperand(3)))
+      axes = op->getOperand(3);
+
+    mlir::Value steps = nullptr;
+    if (numOperands > 4 && !isNoneOperand(op->getOperand(4)))
+      steps = op->getOperand(4);
+
+    auto resultType =
+        mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
+    if (!resultType)
+      return rewriter.notifyMatchFailure(op,
+                                         "Slice result must be a ranked tensor");
+
+    // Build DPS init tensor. Dynamic output dimensions cannot be inferred from
+    // the input tensor alone (they depend on starts/ends/steps), so only
+    // patterns with static output shapes are supported here.
+    if (!resultType.hasStaticShape())
+      return rewriter.notifyMatchFailure(
+          op, "dynamic output shapes are not yet supported by hip.slice");
+
+    mlir::Value init = mlir::tensor::EmptyOp::create(
+        rewriter, loc, resultType.getShape(), resultType.getElementType(),
+        mlir::ValueRange{});
+
+    auto hipOp = mlir::hip::SliceOp::create(rewriter, loc, resultType, context,
+                                            data, starts, ends, axes, steps,
+                                            init);
+
+    rewriter.replaceOp(op, hipOp->getResult(0));
+    return mlir::success();
+  }
+};
+
+} // namespace
+
+void mlir::hip::populateSliceConversionPatterns(RewritePatternSet &patterns,
+                                                MLIRContext *ctx) {
+  patterns.add<SliceToHip>(ctx);
+}
+
+} // namespace hip
+} // namespace mlir

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -507,6 +507,27 @@ void GatherOp::getEffects(
 }
 
 //===----------------------------------------------------------------------===//
+// SliceOp: ins(data, starts, ends, [axes], [steps]), outs(output)
+//===----------------------------------------------------------------------===//
+
+MutableOperandRange SliceOp::getDpsInitsMutable() {
+  // Count actual operands preceding the DPS init:
+  //   ctx(1) + data(1) + starts(1) + ends(1) [+ axes(0/1)] [+ steps(0/1)]
+  unsigned numInputs = 4; // ctx + data + starts + ends
+  if (getAxes())
+    ++numInputs;
+  if (getSteps())
+    ++numInputs;
+  return MutableOperandRange(*this, /*start=*/numInputs, /*length=*/1);
+}
+
+void SliceOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  emitDpsMemoryEffects(getDpsInputOperands(), getDpsInitsMutable(), effects);
+}
+
+//===----------------------------------------------------------------------===//
 // SiluOp: ins(input), outs(output)
 //===----------------------------------------------------------------------===//
 

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -225,6 +225,7 @@ if(NOT BUILD_MOCK_RUNTIME)
     compile_to_bitcode(real/cast.cpp runtime_cast.bc)
     compile_to_bitcode(real/gather.cpp runtime_gather.bc)
     compile_to_bitcode(real/reduce_sum.cpp runtime_reduce_sum.bc)
+    compile_to_bitcode(real/slice.cpp runtime_slice.bc)
     compile_to_bitcode(real/matmul_nbits.cpp runtime_matmul_nbits.bc)
     compile_to_bitcode(real/qmoe.cpp runtime_qmoe.bc)
     compile_to_bitcode(real/causal_conv_with_state.cpp runtime_causal_conv_with_state.bc)
@@ -249,6 +250,7 @@ if(NOT BUILD_MOCK_RUNTIME)
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_cast.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_gather.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_reduce_sum.bc
+        ${CMAKE_CURRENT_BINARY_DIR}/runtime_slice.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_matmul_nbits.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_qmoe.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_causal_conv_with_state.bc

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -485,6 +485,27 @@ int wrap_reduce_sum(RuntimeState *state, void *data, void *axes, void *output,
                     int64_t axes_num_elements, int64_t element_size_bytes,
                     int64_t keepdims, int64_t noop_with_empty_axes);
 
+// Slice operation wrapper (ONNX Slice, opset 13+)
+// Produces a slice of the input tensor along multiple axes.
+//   data:             input tensor GPU pointer
+//   starts/ends:      1-D tensors of starting/ending indices (device memory)
+//   axes:             nullable 1-D tensor selecting axes (defaults to [0..rank))
+//   steps:            nullable 1-D tensor of slice steps (defaults to all-1)
+//   output:           output tensor GPU pointer
+//   input_shape:      host array of i64, length rank, describing input dims
+//   output_shape:     host array of i64, length rank, describing output dims
+//   rank:             number of dimensions (same for input and output)
+//   num_slice_entries: number of elements in starts/ends (== axes size if axes)
+//   output_num_elements: total output elements (determines kernel launch)
+//   element_size_bytes:  bytes per element of `data` and `output`
+//   data_type:        HIPDNN_EP_DATATYPE_* enum (f32/f16/bf16/i32/i64)
+int wrap_slice(RuntimeState *state, const void *data, const void *starts,
+               const void *ends, const void *axes, const void *steps,
+               void *output, const int64_t *input_shape,
+               const int64_t *output_shape, int64_t rank,
+               int64_t num_slice_entries, int64_t output_num_elements,
+               int64_t element_size_bytes, int64_t data_type);
+
 // Cast operation wrapper (element type conversion)
 // src_data_type and dst_data_type are HIPDNN_EP_DATATYPE_* enum values.
 int wrap_cast(RuntimeState *state, void *input, void *output,

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -667,6 +667,33 @@ int wrap_reduce_sum(RuntimeState *state, void *data, void *axes, void *output,
   return 0;
 }
 
+int wrap_slice(RuntimeState *state, const void *data, const void *starts,
+               const void *ends, const void *axes, const void *steps,
+               void *output, const int64_t *input_shape,
+               const int64_t *output_shape, int64_t rank,
+               int64_t num_slice_entries, int64_t output_num_elements,
+               int64_t element_size_bytes, int64_t data_type) {
+  (void)data;
+  (void)starts;
+  (void)ends;
+  (void)output;
+  (void)input_shape;
+  (void)output_shape;
+  if (!state) {
+    fprintf(stderr, "Invalid state in wrap_slice\n");
+    return -1;
+  }
+
+  MOCK_PRINT(
+      "[MOCK] wrap_slice(rank=%lld, slice_entries=%lld, output_num=%lld, "
+      "element_size=%lld, data_type=%lld, axes=%s, steps=%s)\n",
+      (long long)rank, (long long)num_slice_entries,
+      (long long)output_num_elements, (long long)element_size_bytes,
+      (long long)data_type, axes ? "yes" : "no", steps ? "yes" : "no");
+
+  return 0;
+}
+
 int wrap_cast(RuntimeState *state, void *input, void *output,
               int64_t num_elements, int64_t src_data_type,
               int64_t dst_data_type) {

--- a/lib/Runtime/real/slice.cpp
+++ b/lib/Runtime/real/slice.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#include "../debug_log.h"
+#include "../hipdnn_ep_runtime.h"
+#include "hip_custom_kernels.h"
+#include "runtime_types.h"
+
+#include <cstdio>
+
+// ONNX Slice (opset 13+) -> hip_slice custom kernel.
+//
+// `axes` and `steps` are optional ONNX operands: when they are absent the
+// lowering passes nullptr and the kernel falls back to axes=[0..rank) and
+// steps=all-1. All tensor pointers other than `state`, `input_shape` and
+// `output_shape` point into device memory; `input_shape` and `output_shape`
+// are host arrays populated by the HipToLLVM lowering from the static
+// memref dims.
+int wrap_slice(RuntimeState *state, const void *data, const void *starts,
+               const void *ends, const void *axes, const void *steps,
+               void *output, const int64_t *input_shape,
+               const int64_t *output_shape, int64_t rank,
+               int64_t num_slice_entries, int64_t output_num_elements,
+               int64_t element_size_bytes, int64_t data_type) {
+  if (!state || !data || !starts || !ends || !output || !input_shape ||
+      !output_shape) {
+    RUNTIME_DEBUG_LOG("[REAL] wrap_slice: null argument\n");
+    return -1;
+  }
+
+  void *stream = hipdnn_ep_state_get_stream(state);
+
+  RUNTIME_DEBUG_LOG(
+      "[REAL] wrap_slice: rank=%lld, slice_entries=%lld, output_num=%lld, "
+      "elem_size=%lld, dtype=%lld, axes=%s, steps=%s -> calling hip_slice\n",
+      (long long)rank, (long long)num_slice_entries,
+      (long long)output_num_elements, (long long)element_size_bytes,
+      (long long)data_type, axes ? "yes" : "no", steps ? "yes" : "no");
+
+  return hip_slice(stream, data, starts, ends, axes, steps, output, input_shape,
+                   output_shape, rank, num_slice_entries, output_num_elements,
+                   static_cast<int>(element_size_bytes));
+}

--- a/test/lit/Conversion/hip-to-llvm/test_slice.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_slice.mlir
@@ -1,0 +1,107 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify HIP slice operation is correctly lowered to an LLVM call to the
+// wrap_slice runtime function.
+//
+// This test validates:
+// - hip.slice -> llvm.call @wrap_slice
+// - Type conversion: !hip.context -> !llvm.ptr
+// - Optional inputs (axes, steps) passed as pointers (null when absent)
+// - Stack-allocated i64 arrays for input/output shape metadata
+// - Dynamic dim extraction via llvm.extractvalue for dynamic tensors
+//
+// Expected call signature:
+//   wrap_slice(state, data, starts, ends, axes, steps, output,
+//              input_shape, output_shape, rank, num_slice_entries,
+//              output_num_elements, element_size_bytes, data_type)
+// ============================================================================
+
+// RUN: hip-mlir-opt %s --convert-hip-to-llvm | FileCheck %s
+
+module {
+  // Test 1: 3-operand slice (axes/steps absent).
+  func.func @test_slice_basic(
+      %ctx: !hip.context,
+      %data: memref<4x8xf32, 1>,
+      %starts: memref<2xi64, 1>,
+      %ends: memref<2xi64, 1>,
+      %output: memref<2x4xf32, 1>) {
+    // CHECK-LABEL: llvm.func @test_slice_basic
+    hip.slice(%ctx)
+        ins(%data, %starts, %ends :
+            memref<4x8xf32, 1>, memref<2xi64, 1>, memref<2xi64, 1>)
+        outs(%output : memref<2x4xf32, 1>)
+
+    // Stack buffers for input/output shape metadata.
+    // CHECK: llvm.alloca {{.*}} x i64
+    // CHECK: llvm.alloca {{.*}} x i64
+    // CHECK: llvm.call @wrap_slice({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64) -> i32
+
+    return
+  }
+
+  // Test 2: 4-operand slice (axes provided, steps absent).
+  func.func @test_slice_with_axes(
+      %ctx: !hip.context,
+      %data: memref<4x8xf32, 1>,
+      %starts: memref<1xi64, 1>,
+      %ends: memref<1xi64, 1>,
+      %axes: memref<1xi64, 1>,
+      %output: memref<4x4xf32, 1>) {
+    // CHECK-LABEL: llvm.func @test_slice_with_axes
+    hip.slice(%ctx)
+        ins(%data, %starts, %ends, %axes :
+            memref<4x8xf32, 1>, memref<1xi64, 1>, memref<1xi64, 1>,
+            memref<1xi64, 1>)
+        outs(%output : memref<4x4xf32, 1>)
+
+    // CHECK: llvm.call @wrap_slice({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64) -> i32
+
+    return
+  }
+
+  // Test 3: 5-operand slice (axes and steps provided).
+  func.func @test_slice_with_axes_and_steps(
+      %ctx: !hip.context,
+      %data: memref<4x8xf32, 1>,
+      %starts: memref<2xi64, 1>,
+      %ends: memref<2xi64, 1>,
+      %axes: memref<2xi64, 1>,
+      %steps: memref<2xi64, 1>,
+      %output: memref<2x4xf32, 1>) {
+    // CHECK-LABEL: llvm.func @test_slice_with_axes_and_steps
+    hip.slice(%ctx)
+        ins(%data, %starts, %ends, %axes, %steps :
+            memref<4x8xf32, 1>, memref<2xi64, 1>, memref<2xi64, 1>,
+            memref<2xi64, 1>, memref<2xi64, 1>)
+        outs(%output : memref<2x4xf32, 1>)
+
+    // CHECK: llvm.call @wrap_slice({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64) -> i32
+
+    return
+  }
+
+  // Test 4: Dynamic input shape. The data dims come from the memref descriptor.
+  func.func @test_slice_dynamic(
+      %ctx: !hip.context,
+      %data: memref<?x?xf32, 1>,
+      %starts: memref<2xi64, 1>,
+      %ends: memref<2xi64, 1>,
+      %output: memref<2x4xf32, 1>) {
+    // CHECK-LABEL: llvm.func @test_slice_dynamic
+    hip.slice(%ctx)
+        ins(%data, %starts, %ends :
+            memref<?x?xf32, 1>, memref<2xi64, 1>, memref<2xi64, 1>)
+        outs(%output : memref<2x4xf32, 1>)
+
+    // Dynamic dims extracted from the input descriptor (indices [3, 0..1]).
+    // CHECK: llvm.extractvalue {{.*}}[3, 0]
+    // CHECK: llvm.extractvalue {{.*}}[3, 1]
+    // CHECK: llvm.call @wrap_slice({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64) -> i32
+
+    return
+  }
+}

--- a/test/lit/Conversion/onnx-to-hip/test_slice.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_slice.mlir
@@ -1,0 +1,84 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify ONNX Slice is correctly lowered to hip.slice operation
+// in tensor-first mode.
+//
+// This test validates:
+// - Slice operation lowering (onnx.Slice -> hip.slice)
+// - 3-operand form: data, starts, ends (axes/steps defaulted)
+// - 4-operand form: data, starts, ends, axes
+// - 5-operand form: data, starts, ends, axes, steps
+// - onnx.NoValue handling for absent optional operands
+// - Proper !hip.context threading through operations
+// - Tensor-first DPS: tensor.empty() used as output init
+// ============================================================================
+
+// RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip | FileCheck %s
+
+module {
+  // ===== Test 1: 3-operand Slice (data, starts, ends only) =====
+  func.func @main_graph(%data: tensor<4x8xf32>, %starts: tensor<2xi64>, %ends: tensor<2xi64>) -> tensor<2x4xf32> {
+    // CHECK-LABEL: func.func @main_graph
+    // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[DATA:.*]]: tensor<4x8xf32>, %[[STARTS:.*]]: tensor<2xi64>, %[[ENDS:.*]]: tensor<2xi64>) -> tensor<2x4xf32>
+
+    %output = "onnx.Slice"(%data, %starts, %ends) : (tensor<4x8xf32>, tensor<2xi64>, tensor<2xi64>) -> tensor<2x4xf32>
+
+    // CHECK: %[[INIT:.*]] = tensor.empty() : tensor<2x4xf32>
+    // CHECK: hip.slice(%[[CTX]]) ins(%[[DATA]], %[[STARTS]], %[[ENDS]] : tensor<4x8xf32>, tensor<2xi64>, tensor<2xi64>) outs(%[[INIT]] : tensor<2x4xf32>)
+    // CHECK-NOT: onnx.Slice
+    // CHECK-NOT: hip.alloc
+
+    return %output : tensor<2x4xf32>
+  }
+
+  // ===== Test 2: 4-operand Slice (with axes) =====
+  func.func @test_slice_with_axes(%data: tensor<4x8xf32>, %starts: tensor<1xi64>, %ends: tensor<1xi64>, %axes: tensor<1xi64>) -> tensor<4x4xf32> {
+    // CHECK-LABEL: func.func @test_slice_with_axes
+    // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[DATA:.*]]: tensor<4x8xf32>, %[[STARTS:.*]]: tensor<1xi64>, %[[ENDS:.*]]: tensor<1xi64>, %[[AXES:.*]]: tensor<1xi64>) -> tensor<4x4xf32>
+
+    %output = "onnx.Slice"(%data, %starts, %ends, %axes) : (tensor<4x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<4x4xf32>
+
+    // CHECK: %[[INIT:.*]] = tensor.empty() : tensor<4x4xf32>
+    // CHECK: hip.slice(%[[CTX]]) ins(%[[DATA]], %[[STARTS]], %[[ENDS]], %[[AXES]] : tensor<4x8xf32>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) outs(%[[INIT]] : tensor<4x4xf32>)
+    // CHECK-NOT: onnx.Slice
+
+    return %output : tensor<4x4xf32>
+  }
+
+  // ===== Test 3: 5-operand Slice (with axes and steps) =====
+  func.func @test_slice_with_axes_and_steps(
+      %data: tensor<4x8xf32>, %starts: tensor<2xi64>, %ends: tensor<2xi64>,
+      %axes: tensor<2xi64>, %steps: tensor<2xi64>) -> tensor<2x4xf32> {
+    // CHECK-LABEL: func.func @test_slice_with_axes_and_steps
+    // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[DATA:.*]]: tensor<4x8xf32>, %[[STARTS:.*]]: tensor<2xi64>, %[[ENDS:.*]]: tensor<2xi64>, %[[AXES:.*]]: tensor<2xi64>, %[[STEPS:.*]]: tensor<2xi64>) -> tensor<2x4xf32>
+
+    %output = "onnx.Slice"(%data, %starts, %ends, %axes, %steps) : (tensor<4x8xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<2x4xf32>
+
+    // CHECK: %[[INIT:.*]] = tensor.empty() : tensor<2x4xf32>
+    // CHECK: hip.slice(%[[CTX]]) ins(%[[DATA]], %[[STARTS]], %[[ENDS]], %[[AXES]], %[[STEPS]] : tensor<4x8xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) outs(%[[INIT]] : tensor<2x4xf32>)
+    // CHECK-NOT: onnx.Slice
+
+    return %output : tensor<2x4xf32>
+  }
+
+  // ===== Test 4: onnx.NoValue for axes (steps provided) =====
+  func.func @test_slice_no_axes_with_steps(
+      %data: tensor<4x8xf32>, %starts: tensor<2xi64>, %ends: tensor<2xi64>,
+      %steps: tensor<2xi64>) -> tensor<2x4xf32> {
+    // CHECK-LABEL: func.func @test_slice_no_axes_with_steps
+    // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[DATA:.*]]: tensor<4x8xf32>, %[[STARTS:.*]]: tensor<2xi64>, %[[ENDS:.*]]: tensor<2xi64>, %[[STEPS:.*]]: tensor<2xi64>) -> tensor<2x4xf32>
+
+    %none = "onnx.NoValue"() {value} : () -> none
+    %output = "onnx.Slice"(%data, %starts, %ends, %none, %steps) : (tensor<4x8xf32>, tensor<2xi64>, tensor<2xi64>, none, tensor<2xi64>) -> tensor<2x4xf32>
+
+    // CHECK: %[[INIT:.*]] = tensor.empty() : tensor<2x4xf32>
+    // CHECK: hip.slice(%[[CTX]]) ins(%[[DATA]], %[[STARTS]], %[[ENDS]], %[[STEPS]] : tensor<4x8xf32>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) outs(%[[INIT]] : tensor<2x4xf32>)
+    // CHECK-NOT: onnx.Slice
+    // CHECK-NOT: onnx.NoValue
+
+    return %output : tensor<2x4xf32>
+  }
+}

--- a/tools/hip-mlir-opt/hip-mlir-opt.cpp
+++ b/tools/hip-mlir-opt/hip-mlir-opt.cpp
@@ -135,6 +135,8 @@ void registerHipBufferizableOpInterfaceModels(mlir::DialectRegistry &registry) {
         HipDstBufferizableModel<mlir::hip::CausalConvWithStateOp>>(*ctx);
     mlir::hip::HipDNNGraphOp::attachInterface<
         HipDstBufferizableModel<mlir::hip::HipDNNGraphOp>>(*ctx);
+    mlir::hip::SliceOp::attachInterface<
+        HipDstBufferizableModel<mlir::hip::SliceOp>>(*ctx);
   });
 }
 


### PR DESCRIPTION
## Motivation
ONNX `Slice` is a commonly used op for selecting a sub-tensor along
multiple axes. Add end-to-end support for it in the HIP execution provider so
models that depend on `Slice` can run on the HIP backend. Slice ops are used 
extensively in the qwen3.5B model.
## Details
- **Dialect**: New `hip.slice` op in `HipOps.td` using `AttrSizedOperandSegments`
  to model the optional `axes` / `steps` operands.
- **OnnxToHip**: New `SliceConversion.cpp` pattern that lowers `onnx.Slice`
  to `hip.slice`, normalizing both absent operands and `onnx.NoValue` placeholders.
- **HipToLLVM**: New `SliceLowering.cpp` that emits an `llvm.call @wrap_slice`,
  stack-allocating i64 shape arrays from the memref descriptors and passing
  `nullptr` for missing optional operands.
- **Runtime**: Added `wrap_slice` in `hipdnn_ep_runtime.h` with both the real
  implementation (`real/slice.cpp`) and a mock stub (`mock/mock_gpu.cpp`).
- **Kernel**: Added `slice_kernel.hip` — one thread per output element,
  reconstructs the per-axis output coordinate from the flat index, applies
  ONNX start/step/axes semantics (including negative indices and reverse
  stepping), and writes the corresponding input element.

## Test Plan
- [ ] all `lit` test passed
- [ ] The single op model cut from qwen3.5 ran successfully.
- [ ] The accuracy meets the requirements.
