### PR TITLE
Feat(tools): Add onnx-model-splitter toolkit (extract, verify, OGA export)

### DIFF
--- a/tools/onnx-model-splitter/README.md
+++ b/tools/onnx-model-splitter/README.md
@@ -13,6 +13,7 @@ and analysis. Supports LLM (text), Vision, and Embedding models.
 |--------|-------------|
 | `extract_submodels.py` | Main extraction tool — splits an ONNX model into `single_op`, `single_layer`, and `full_model` submodels with multiple dimension variants |
 | `export_chunk_model.py` | Export fixed-shape Llama prefill/decode ONNX variants with genai_config generation |
+| `compare_chunk_export_outputs.py` | Validate an `export_chunk_model.py` output directory: structural match of each prefill/decode ONNX pair plus `genai_config_*.json` filenames and pipeline I/O lists vs graphs |
 | `genai_config_pipeline_from_folder.py` | Generate `decoder-pipeline` style `genai_config.json` for ORT GenAI from an existing model folder |
 | `inspect_onnx.py` | Inspect ONNX model structure (inputs, outputs, nodes, op types, preprocessing chains) |
 | `verify_ort_inference.py` | Verify extracted models by running ORT inference with dummy inputs (subprocess-isolated) |
@@ -59,6 +60,18 @@ python export_chunk_model.py --model path/to/model.onnx --output /output/dir
 
 # Specify max context length
 python export_chunk_model.py --model path/to/model.onnx --output /output/dir --max-length 4096
+```
+
+### Compare chunk export outputs
+
+After `export_chunk_model.py`, run this on the **same output directory** to check that each `prefill_TAG.onnx` has a matching `decode_TAG.onnx` and `genai_config_TAG.json` (non-`*_dml`): same graph topology (node names, op types, edges), compatible dtypes (intermediate shapes may differ by design), aligned graph I/O except known prefill vs decode sequence axes, and consistent `past_*` / `present_*` shapes. Optional `--compare-intermediate-shapes` enforces identical tensor shapes on every edge.
+
+```bash
+python compare_chunk_export_outputs.py /path/to/export_chunk_model_output
+
+python compare_chunk_export_outputs.py /path/to/out --quiet
+
+python compare_chunk_export_outputs.py /path/to/out --compare-intermediate-shapes
 ```
 
 ### Generate genai_config
@@ -111,7 +124,9 @@ python verify_extraction.py /output/dir --skip-fixed-shape-check
 Assume the original model is at
 `C:\modelzoo\Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml`.
 
-### Step 1 — Extract submodels (single_op / single_layer / full_model)
+### Step 1 — Extract submodels into `space`
+
+#### 1a. Run extraction (single_op / single_layer / full_model)
 
 ```bash
 python extract_submodels.py ^
@@ -128,6 +143,20 @@ space/
 └── full_model/          # full model with dimension variants
 ```
 
+#### 1b. Verify `space` (structure + ORT smoke)
+
+Run from the directory that contains the scripts (or use full paths to `verify_extraction.py` / `verify_ort_inference.py`). Both commands should exit with code **0**.
+
+```bash
+python verify_extraction.py ^
+    C:\modelzoo\Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml\space
+
+python verify_ort_inference.py ^
+    C:\modelzoo\Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml\space
+```
+
+`verify_extraction.py` checks extracted `.onnx` layout, external data offsets, graph sanity, and (for fixed-shape filenames) shape consistency. `verify_ort_inference.py` loads each extracted model in a **subprocess** and runs ORT with dummy inputs. To skip fixed-shape dimension checks on the first script, add `--skip-fixed-shape-check` to the `verify_extraction.py` line.
+
 ### Step 2 — Export OGA prefill / decode variants
 
 #### 2a. Generate genai_config
@@ -140,7 +169,11 @@ python genai_config_pipeline_from_folder.py ^
 ```
 
 This produces `genai_config_pipeline.json` in the model folder, which is
-required by the next step.
+required by the next step. When prefill/decode ONNX files are discoverable under
+the model directory (or common subdirs such as `chunk/`), pipeline **input/output
+name lists** are taken from the graphs so bindings match the export (e.g. sparse KV
+or extra state tensors). Use `--no-onnx-io` to force template-only lists; `--onnx-subdir`
+prepends extra search paths relative to `model_dir`.
 
 #### 2b. Export prefill / decode ONNX
 
@@ -166,6 +199,13 @@ space/chunk/
 ├── genai_config_12200.json
 ├── ...
 └── model.onnx.data          # shared external weights
+```
+
+#### 2c. (Optional) Compare prefill / decode / genai artifacts
+
+```bash
+python compare_chunk_export_outputs.py ^
+    C:\modelzoo\Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml\space\chunk
 ```
 
 ## Supported Model Types

--- a/tools/onnx-model-splitter/README.md
+++ b/tools/onnx-model-splitter/README.md
@@ -1,3 +1,7 @@
+<!--
+Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+Licensed under the MIT License.
+-->
 # ONNX Model Splitter
 
 A set of tools for splitting ONNX models into submodels for performance testing

--- a/tools/onnx-model-splitter/README.md
+++ b/tools/onnx-model-splitter/README.md
@@ -7,15 +7,19 @@ and analysis. Supports LLM (text), Vision, and Embedding models.
 
 | Script | Description |
 |--------|-------------|
-| `extract_submodels.py` | Main extraction tool — splits an ONNX model into `single_op`, `single_layer`, and `full_model` submodels |
-| `inspect_onnx.py` | Inspect ONNX model structure (inputs, outputs, nodes, op types) |
-| `verify_ort_inference.py` | Verify extracted models by running ORT inference with dummy inputs |
-| `verify_extraction.py` | Verify extracted model files: sizes, graph structure, initializer integrity |
+| `extract_submodels.py` | Main extraction tool — splits an ONNX model into `single_op`, `single_layer`, and `full_model` submodels with multiple dimension variants |
+| `export_chunk_model.py` | Export fixed-shape Llama prefill/decode ONNX variants with genai_config generation |
+| `genai_config_pipeline_from_folder.py` | Generate `decoder-pipeline` style `genai_config.json` for ORT GenAI from an existing model folder |
+| `inspect_onnx.py` | Inspect ONNX model structure (inputs, outputs, nodes, op types, preprocessing chains) |
+| `verify_ort_inference.py` | Verify extracted models by running ORT inference with dummy inputs (subprocess-isolated) |
+| `verify_extraction.py` | Verify extracted model files: sizes, graph structure, initializer integrity, fixed-shape validation |
+| `_verify_one_model.py` | Subprocess worker for `verify_ort_inference.py` — loads one model and runs inference |
 
 ## Installation
 
 ```bash
-pip install -r requirements.txt
+pip install onnx onnxruntime numpy
+pip install onnxoptimizer  # optional but recommended
 ```
 
 > **Note:** `onnxoptimizer` is optional but recommended. When installed, fixed-shape
@@ -38,6 +42,26 @@ python extract_submodels.py --model path/to/model.onnx --only single_op
 
 # Extract only single_layer
 python extract_submodels.py --model path/to/model.onnx --only single_layer
+
+# Extract only full_model
+python extract_submodels.py --model path/to/model.onnx --only full_model
+```
+
+### Export prefill/decode variants
+
+```bash
+# Export prefill + decode ONNX with genai configs
+python export_chunk_model.py --model path/to/model.onnx --output /output/dir
+
+# Specify max context length
+python export_chunk_model.py --model path/to/model.onnx --output /output/dir --max-length 4096
+```
+
+### Generate genai_config
+
+```bash
+python genai_config_pipeline_from_folder.py path/to/model_folder \
+    --fixed-prompt-length 128 --max-length 4096
 ```
 
 ### Inspect a model
@@ -57,6 +81,9 @@ python inspect_onnx.py model.onnx --nodes --layer 0
 
 # Show op type statistics
 python inspect_onnx.py model.onnx --op-types
+
+# Find preprocessing chains (attention_mask, position_ids)
+python inspect_onnx.py model.onnx --find-chains
 ```
 
 ### Verify extracted models
@@ -68,85 +95,176 @@ python verify_ort_inference.py /output/dir
 # Verify only single_op models
 python verify_ort_inference.py /output/dir --mode single_op
 
-# Verify model file structure
+# Verify model file structure and fixed-shape correctness
 python verify_extraction.py /output/dir
+
+# Skip fixed-shape dimension checks
+python verify_extraction.py /output/dir --skip-fixed-shape-check
+```
+
+## End-to-End Example: Llama-3.1-8B
+
+Assume the original model is at
+`C:\modelzoo\Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml`.
+
+### Step 1 — Extract submodels (single_op / single_layer / full_model)
+
+```bash
+python extract_submodels.py ^
+    --model  C:\modelzoo\Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml\model.onnx ^
+    --output C:\modelzoo\Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml\space
+```
+
+Output:
+
+```
+space/
+├── single_op/           # one submodel per unique op type
+├── single_layer/        # layer 0 + pre/post processing
+└── full_model/          # full model with dimension variants
+```
+
+### Step 2 — Export OGA prefill / decode variants
+
+#### 2a. Generate genai_config
+
+```bash
+python genai_config_pipeline_from_folder.py ^
+    C:\modelzoo\Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml ^
+    --max-length 16384 ^
+    --fixed-prompt-length 12200
+```
+
+This produces `genai_config_pipeline.json` in the model folder, which is
+required by the next step.
+
+#### 2b. Export prefill / decode ONNX
+
+```bash
+python export_chunk_model.py ^
+    --model  C:\modelzoo\Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml\model.onnx ^
+    --output C:\modelzoo\Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml\space\chunk ^
+    -T C:\modelzoo\Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml\genai_config_pipeline.json
+```
+
+Output:
+
+```
+space/chunk/
+├── prefill_p128m16384.onnx
+├── decode_p128m16384.onnx
+├── prefill_p2048m16384.onnx
+├── decode_p2048m16384.onnx
+├── prefill_12200.onnx
+├── decode_12200.onnx
+├── genai_config_p128m16384.json
+├── genai_config_p2048m16384.json
+├── genai_config_12200.json
+├── ...
+└── model.onnx.data          # shared external weights
 ```
 
 ## Supported Model Types
 
 The extractor auto-detects the model type based on graph input names:
 
-| Model Type | Detection | Dimension Variants |
-|------------|-----------|-------------------|
-| **LLM** (text) | `inputs_embeds` or `input_ids` without `image_features` | `sequence_length`: 1, 128, 256, 512, 1024, 2048, 3072 |
-| **Vision** | `pixel_values` | `num_patches`: 1024, 1200, 2520, 3600, 4096, 8160 |
-| **Embedding** | `input_ids` + `image_features` | `sequence_length` × `num_logical_patches` combinations |
+| Model Type | Detection Rule | Dimension Variants |
+|------------|----------------|-------------------|
+| **LLM** (text) | Default (has `input_ids` or `inputs_embeds`) | `sequence_length`: 1, 128, 256, 512, 1024, 2048, 3072 |
+| **Vision** | Has `pixel_values` input | `num_patches`: 1024, 1200, 2520, 3600, 4096, 8160 |
+| **Embedding** | Has both `input_ids` and `image_features` | `sequence_length` x `num_logical_patches` (13 combinations) |
+
+Each model type produces **1 dynamic + N fixed** variants. The dynamic variant
+preserves symbolic dimension names; fixed variants replace them with concrete values.
 
 ## Output Structure
 
 ```
 output_dir/
-├── single_op/           # One submodel per unique op type
+├── single_op/              # One submodel per unique op type
 │   ├── MatMul/
 │   │   ├── MatMul_dynamic.onnx
 │   │   ├── MatMul_seq1.onnx
 │   │   ├── MatMul_seq128.onnx
 │   │   └── ...
-│   ├── Gemm_linear/
+│   ├── GroupQueryAttention/
 │   └── ...
-├── single_layer/        # One transformer layer + pre/post processing
+├── single_layer/           # One transformer/ViT layer + pre/post processing
 │   ├── single_layer_dynamic.onnx
 │   ├── single_layer_seq1.onnx
 │   ├── ...
-│   └── weights.data     # Shared weights (first variant only)
-└── full_model/          # Full model with fixed shapes
+│   └── <model>.onnx.data   # Shared external weights
+└── full_model/             # Full model with fixed shapes
     ├── full_model_dynamic.onnx
     ├── full_model_seq1.onnx
     ├── ...
-    └── weights.data
+    └── <model>.onnx.data   # Copied from original (not rewritten)
 ```
+
+> **External data naming**: The output `.data` filename matches the original model's
+> external data filename (e.g., `model.onnx.data`, `gemma-3-vision.onnx.data`).
 
 ## Extraction Details
 
 ### single_op
 
-Extracts one representative node per unique operation type. For LLM models,
-ops within repeated layers are deduplicated by type (e.g., one `MatMul` for all
-layers). Ops with shape-dependent behavior (e.g., `MatMulNBits` with different
-weight sizes) produce separate submodels.
+Extracts one representative node per unique operation type.
 
-For vision/embedding (flat) models, performance-significant ops (`Gemm`,
-`MatMul`, `Conv`, `LayerNormalization`, `Loop`, etc.) retain shape-based
-variants, while simple ops (`Add`, `Mul`, `Cast`, etc.) are deduplicated to a
-single representative.
+- **LLM models**: Ops within repeated layers are deduplicated — one per op type.
+  Non-layer ops with shape-dependent behavior (e.g., `MatMulNBits` with different
+  weight sizes) produce separate submodels.
+- **Vision / Embedding (flat) models**: Performance-significant ops (`Gemm`,
+  `MatMul`, `MatMulNBits`, `Conv`, `GroupQueryAttention`, `QMoE`,
+  `LayerNormalization`, etc.) retain shape-based variants, while simple ops
+  (`Add`, `Mul`, `Cast`, `Gather`, etc.) are deduplicated to a single representative.
 
 ### single_layer
 
-- **LLM**: Pre-layer constants + layer 0 + final norm + LM head
+- **LLM**: Pre-layer constants + layer 0 + final norm + LM head.
 - **Vision**: Pre-block processing (Conv3d, position encoding) + ViT block 0 +
   post-block processing (final norm, merger FC, token merging). Equivalent to
   running the full model with only 1 iteration of the repeated blocks.
-- **Embedding**: Not applicable (no layer structure)
+- **Embedding**: Not applicable (no layer structure).
 
 ### full_model
 
-- **LLM**: Full model with redundant branches removed, fixed sequence lengths
-- **Vision / Embedding**: Full model with fixed dimension variants (no node
-  removal)
+- **LLM**: Full model with redundant preprocessing branches removed
+  (`attention_mask → Shape → Gather → Cast` chain,
+  `input_ids → Shape → Gather → Unsqueeze → Concat → Reshape` chain).
+  The dynamic variant exposes `total_sequence_length` as a graph input for GQA;
+  fixed variants use a constant initializer.
+  External weight data is **copied** from the original (not re-serialized),
+  preserving exact binary identity and avoiding rewriting large `.data` files.
+- **Vision / Embedding**: Full model with fixed dimension variants (no node removal).
+
+### Config-based Dimensions
+
+When a `genai_config.json` exists alongside the model, the extractor automatically
+reads `num_attention_heads`, `num_key_value_heads`, `head_size`, and `hidden_size`
+from `model.decoder` and applies them as fixed dimension substitutions. This
+resolves symbolic dims like `num_attention_heads` in Reshape nodes without
+requiring manual configuration.
 
 ### Graph Optimizations
 
 For fixed-shape variants (all except `dynamic`), the following optimizations
 are applied automatically when `onnxoptimizer` is installed:
 
+- **Shape inference**: `onnx.shape_inference.infer_shapes()` resolves intermediate
+  symbolic dimensions (e.g., `u1`, `u2`) from known input shapes.
 - **eliminate_shape_gather**: Folds `Shape → Gather` chains into constants
-  when tensor shapes are fully known
+  when tensor shapes are fully known.
 - **eliminate_shape_op**: Removes `Shape` nodes whose outputs are unused
-  after gather elimination
-- **extract_constant_to_initializer**: Converts `Constant` nodes to
-  initializers
+  after gather elimination.
+- **extract_constant_to_initializer**: Converts inline `Constant` nodes to
+  initializers.
 - **eliminate_deadend / eliminate_unused_initializer**: Cleans up orphaned
-  nodes and weights
+  nodes and weights.
 
-This eliminates runtime shape-computation overhead (e.g., mrope Shape→Gather→
-Mul→Range chains in Attention layers).
+### Orphan Removal
+
+Before saving, the extractor automatically detects and removes:
+
+- **Orphan graph inputs**: Inputs declared in the graph but not consumed by any node.
+- **Orphan nodes**: Nodes whose outputs are not consumed by any downstream node
+  or graph output (iteratively removed until stable).

--- a/tools/onnx-model-splitter/README.md
+++ b/tools/onnx-model-splitter/README.md
@@ -1,0 +1,131 @@
+# ONNX Model Splitter
+
+A set of tools for splitting ONNX models into submodels for performance testing
+and analysis. Supports LLM (text), Vision, and Embedding models.
+
+## Overview
+
+| Script | Description |
+|--------|-------------|
+| `extract_submodels.py` | Main extraction tool — splits an ONNX model into `single_op`, `single_layer`, and `full_model` submodels |
+| `inspect_onnx.py` | Inspect ONNX model structure (inputs, outputs, nodes, op types) |
+| `verify_ort_inference.py` | Verify extracted models by running ORT inference with dummy inputs |
+| `verify_extraction.py` | Verify extracted model files: sizes, graph structure, initializer integrity |
+
+## Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+## Quick Start
+
+### Extract submodels
+
+```bash
+# Extract all (single_op + single_layer + full_model)
+python extract_submodels.py --model path/to/model.onnx
+
+# Extract to a custom output directory
+python extract_submodels.py --model path/to/model.onnx --output /output/dir
+
+# Extract only single_op
+python extract_submodels.py --model path/to/model.onnx --only single_op
+
+# Extract only single_layer
+python extract_submodels.py --model path/to/model.onnx --only single_layer
+```
+
+### Inspect a model
+
+```bash
+# Basic info (inputs, outputs, summary)
+python inspect_onnx.py model.onnx
+
+# List all nodes
+python inspect_onnx.py model.onnx --nodes
+
+# Filter by op type
+python inspect_onnx.py model.onnx --nodes --type-name MatMul
+
+# Filter by layer index
+python inspect_onnx.py model.onnx --nodes --layer 0
+
+# Show op type statistics
+python inspect_onnx.py model.onnx --op-types
+```
+
+### Verify extracted models
+
+```bash
+# Verify all extracted models via ORT inference
+python verify_ort_inference.py /output/dir
+
+# Verify only single_op models
+python verify_ort_inference.py /output/dir --mode single_op
+
+# Verify model file structure
+python verify_extraction.py /output/dir
+```
+
+## Supported Model Types
+
+The extractor auto-detects the model type based on graph input names:
+
+| Model Type | Detection | Dimension Variants |
+|------------|-----------|-------------------|
+| **LLM** (text) | `inputs_embeds` or `input_ids` without `image_features` | `sequence_length`: 1, 128, 256, 512, 1024, 2048, 3072 |
+| **Vision** | `pixel_values` | `num_patches`: 1024, 1200, 2520, 3600, 4096, 8160 |
+| **Embedding** | `input_ids` + `image_features` | `sequence_length` × `num_logical_patches` combinations |
+
+## Output Structure
+
+```
+output_dir/
+├── single_op/           # One submodel per unique op type
+│   ├── MatMul/
+│   │   ├── MatMul_dynamic.onnx
+│   │   ├── MatMul_seq1.onnx
+│   │   ├── MatMul_seq128.onnx
+│   │   └── ...
+│   ├── Gemm_linear/
+│   └── ...
+├── single_layer/        # One transformer layer + pre/post processing
+│   ├── single_layer_dynamic.onnx
+│   ├── single_layer_seq1.onnx
+│   ├── ...
+│   └── weights.data     # Shared weights (first variant only)
+└── full_model/          # Full model with fixed shapes
+    ├── full_model_dynamic.onnx
+    ├── full_model_seq1.onnx
+    ├── ...
+    └── weights.data
+```
+
+## Extraction Details
+
+### single_op
+
+Extracts one representative node per unique operation type. For LLM models,
+ops within repeated layers are deduplicated by type (e.g., one `MatMul` for all
+layers). Ops with shape-dependent behavior (e.g., `MatMulNBits` with different
+weight sizes) produce separate submodels.
+
+For vision/embedding (flat) models, performance-significant ops (`Gemm`,
+`MatMul`, `Conv`, `LayerNormalization`, `Loop`, etc.) retain shape-based
+variants, while simple ops (`Add`, `Mul`, `Cast`, etc.) are deduplicated to a
+single representative.
+
+### single_layer
+
+- **LLM**: Pre-layer constants + layer 0 + final norm + LM head
+- **Vision**: Pre-block processing (Conv3d, position encoding) + ViT block 0 +
+  post-block processing (final norm, merger FC, token merging). Equivalent to
+  running the full model with only 1 iteration of the repeated blocks.
+- **Embedding**: Not applicable (no layer structure)
+
+### full_model
+
+- **LLM**: Full model with redundant branches removed, fixed sequence lengths
+- **Vision / Embedding**: Full model with fixed dimension variants (no node
+  removal)

--- a/tools/onnx-model-splitter/README.md
+++ b/tools/onnx-model-splitter/README.md
@@ -18,6 +18,10 @@ and analysis. Supports LLM (text), Vision, and Embedding models.
 pip install -r requirements.txt
 ```
 
+> **Note:** `onnxoptimizer` is optional but recommended. When installed, fixed-shape
+> variants automatically run Shape/Gather constant folding to eliminate redundant
+> shape-computation nodes.
+
 ## Quick Start
 
 ### Extract submodels
@@ -129,3 +133,20 @@ single representative.
 - **LLM**: Full model with redundant branches removed, fixed sequence lengths
 - **Vision / Embedding**: Full model with fixed dimension variants (no node
   removal)
+
+### Graph Optimizations
+
+For fixed-shape variants (all except `dynamic`), the following optimizations
+are applied automatically when `onnxoptimizer` is installed:
+
+- **eliminate_shape_gather**: Folds `Shape → Gather` chains into constants
+  when tensor shapes are fully known
+- **eliminate_shape_op**: Removes `Shape` nodes whose outputs are unused
+  after gather elimination
+- **extract_constant_to_initializer**: Converts `Constant` nodes to
+  initializers
+- **eliminate_deadend / eliminate_unused_initializer**: Cleans up orphaned
+  nodes and weights
+
+This eliminates runtime shape-computation overhead (e.g., mrope Shape→Gather→
+Mul→Range chains in Attention layers).

--- a/tools/onnx-model-splitter/_verify_one_model.py
+++ b/tools/onnx-model-splitter/_verify_one_model.py
@@ -1,0 +1,77 @@
+"""Subprocess worker: load one ONNX model, run ORT inference, print result."""
+import sys
+import numpy as np
+import onnxruntime as ort
+
+
+def make_dummy_input(inp):
+    shape = []
+    for dim in inp.shape:
+        if isinstance(dim, str) or dim is None or dim == "" or dim == 0:
+            shape.append(1)
+        else:
+            try:
+                v = int(dim)
+                shape.append(v if v > 0 else 1)
+            except (ValueError, TypeError):
+                shape.append(1)
+
+    dtype_str = inp.type
+    if "float16" in dtype_str:
+        return np.zeros(shape, dtype=np.float16)
+    elif "float" in dtype_str:
+        return np.zeros(shape, dtype=np.float32)
+    elif "int64" in dtype_str:
+        return np.zeros(shape, dtype=np.int64)
+    elif "int32" in dtype_str:
+        return np.zeros(shape, dtype=np.int32)
+    elif "int8" in dtype_str:
+        return np.zeros(shape, dtype=np.int8)
+    elif "uint8" in dtype_str:
+        return np.zeros(shape, dtype=np.uint8)
+    elif "bool" in dtype_str:
+        return np.zeros(shape, dtype=np.bool_)
+    else:
+        return np.zeros(shape, dtype=np.float32)
+
+
+def main():
+    fpath = sys.argv[1]
+    verbose = "--verbose" in sys.argv
+
+    opts = ort.SessionOptions()
+    opts.log_severity_level = 3
+    try:
+        sess = ort.InferenceSession(fpath, sess_options=opts)
+    except Exception as e:
+        print(f"Session creation failed: {e}")
+        sys.exit(1)
+
+    feeds = {}
+    for inp in sess.get_inputs():
+        feeds[inp.name] = make_dummy_input(inp)
+        if verbose:
+            print(f"  input: {inp.name:50s} "
+                  f"shape={feeds[inp.name].shape} "
+                  f"dtype={feeds[inp.name].dtype}", file=sys.stderr)
+
+    try:
+        outputs = sess.run(None, feeds)
+    except Exception as e:
+        print(f"Inference failed: {e}")
+        sys.exit(1)
+
+    if verbose:
+        for i, out_meta in enumerate(sess.get_outputs()):
+            arr = outputs[i]
+            has_nan = (bool(np.isnan(arr).any())
+                       if np.issubdtype(arr.dtype, np.floating) else False)
+            print(f"  output: {out_meta.name:50s} "
+                  f"shape={arr.shape} dtype={arr.dtype} nan={has_nan}",
+                  file=sys.stderr)
+
+    print(f"{len(outputs)} outputs")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/onnx-model-splitter/_verify_one_model.py
+++ b/tools/onnx-model-splitter/_verify_one_model.py
@@ -1,3 +1,7 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
 """Subprocess worker: load one ONNX model, run ORT inference, print result."""
 import sys
 import numpy as np

--- a/tools/onnx-model-splitter/_verify_one_model.py
+++ b/tools/onnx-model-splitter/_verify_one_model.py
@@ -16,7 +16,13 @@ def make_dummy_input(inp):
             except (ValueError, TypeError):
                 shape.append(1)
 
+    name_lower = inp.name.lower()
     dtype_str = inp.type
+
+    if "attention_mask" in name_lower:
+        return np.ones(shape, dtype=np.int64 if "int64" in dtype_str
+                       else np.int32)
+
     if "float16" in dtype_str:
         return np.zeros(shape, dtype=np.float16)
     elif "float" in dtype_str:

--- a/tools/onnx-model-splitter/_verify_one_model.py
+++ b/tools/onnx-model-splitter/_verify_one_model.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 #
 """Subprocess worker: load one ONNX model, run ORT inference, print result."""
+
 import sys
 import numpy as np
 import onnxruntime as ort
@@ -24,8 +25,7 @@ def make_dummy_input(inp):
     dtype_str = inp.type
 
     if "attention_mask" in name_lower:
-        return np.ones(shape, dtype=np.int64 if "int64" in dtype_str
-                       else np.int32)
+        return np.ones(shape, dtype=np.int64 if "int64" in dtype_str else np.int32)
 
     if "float16" in dtype_str:
         return np.zeros(shape, dtype=np.float16)
@@ -61,9 +61,12 @@ def main():
     for inp in sess.get_inputs():
         feeds[inp.name] = make_dummy_input(inp)
         if verbose:
-            print(f"  input: {inp.name:50s} "
-                  f"shape={feeds[inp.name].shape} "
-                  f"dtype={feeds[inp.name].dtype}", file=sys.stderr)
+            print(
+                f"  input: {inp.name:50s} "
+                f"shape={feeds[inp.name].shape} "
+                f"dtype={feeds[inp.name].dtype}",
+                file=sys.stderr,
+            )
 
     try:
         outputs = sess.run(None, feeds)
@@ -74,11 +77,16 @@ def main():
     if verbose:
         for i, out_meta in enumerate(sess.get_outputs()):
             arr = outputs[i]
-            has_nan = (bool(np.isnan(arr).any())
-                       if np.issubdtype(arr.dtype, np.floating) else False)
-            print(f"  output: {out_meta.name:50s} "
-                  f"shape={arr.shape} dtype={arr.dtype} nan={has_nan}",
-                  file=sys.stderr)
+            has_nan = (
+                bool(np.isnan(arr).any())
+                if np.issubdtype(arr.dtype, np.floating)
+                else False
+            )
+            print(
+                f"  output: {out_meta.name:50s} "
+                f"shape={arr.shape} dtype={arr.dtype} nan={has_nan}",
+                file=sys.stderr,
+            )
 
     print(f"{len(outputs)} outputs")
 

--- a/tools/onnx-model-splitter/compare_chunk_export_outputs.py
+++ b/tools/onnx-model-splitter/compare_chunk_export_outputs.py
@@ -1,0 +1,776 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""
+Compare prefill / decode ONNX pairs and genai_config_*.json under an ``export_chunk_model.py`` output directory.
+
+For each stem ``TAG`` (from ``prefill_TAG.onnx``), expects:
+  - ``decode_TAG.onnx``
+  - ``genai_config_TAG.json`` (not ``*_dml.json``)
+
+Checks (prefill vs decode graphs):
+  - Same node count; same node names and ``op_type`` per name.
+  - Per node: same ordered input names and output names.
+  - **Default:** for each edge (same tensor name on both sides), only **element types** must
+    match; **shapes are not compared** on intermediates (prefill uses prompt length ``S``,
+    decode uses ``1`` - differences like ``[...,512,...]`` vs ``[...,1,...]`` are expected).
+  - ``--compare-intermediate-shapes``: also require identical shapes on every edge (verbose).
+  - ``GroupQueryAttention``: same wiring for the **total-sequence** input (0-based index **6**
+    when present); initializer payloads compared when relevant.
+  - Graph-level inputs/outputs: same names and order; **types** must match; **shapes** must match
+    except ``input_ids`` / ``inputs_embeds`` / ``position_ids`` (prefill prompt length vs decode
+    ``1``) and ``logits`` dim1 (other dims must match).
+  - ``past_key_values.*`` / ``present.*``: same shapes between prefill and decode.
+
+Also validates ``genai_config_TAG.json``:
+  - ``decoder.pipeline.prefill.filename`` / ``decode.filename`` match ``prefill_TAG.onnx`` /
+    ``decode_TAG.onnx``.
+  - If ``pipeline.*`` lists ``inputs`` / ``outputs``: compare the **prefix** (all names before the
+    first ``past_key_values.*`` or ``present.*``) to ONNX. If order differs but **Counter** matches,
+    emit a non-fatal note only (e.g. Gemma ``inputs_embeds`` vs ``attention_mask`` order vs template);
+    if the multiset differs, FAIL. The **past/present** tail is compared the same way (order-only
+    mismatch is a note).
+
+Usage:
+  python compare_chunk_export_outputs.py /path/to/export_chunk_model_output
+  python compare_chunk_export_outputs.py /path/to/out --quiet
+  python compare_chunk_export_outputs.py /path/to/out --compare-intermediate-shapes
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+import onnx
+from onnx import TensorProto, numpy_helper
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+if SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, SCRIPT_DIR)
+
+PAST_KV_IO_RE = re.compile(r"^past_key_values\.\d+\.(?:key|value)$")
+PRESENT_IO_RE = re.compile(r"^present\.\d+\.(?:key|value)$")
+
+# Prefill vs decode: these graph I/O tensors intentionally differ on the prompt / step axis.
+_GRAPH_IO_SEQ_AXIS_EXCEPTION_INPUTS = frozenset(
+    {"input_ids", "inputs_embeds", "position_ids"}
+)
+_GRAPH_IO_SEQ_AXIS_EXCEPTION_OUTPUTS = frozenset({"logits"})
+
+
+def _graph_io_tensor_compatible(
+    name: str,
+    ta: str,
+    sa: tuple,
+    tb: str,
+    sb: tuple,
+    *,
+    kind: str,
+) -> tuple[bool, str | None]:
+    """Return (ok, reason_if_bad). ``kind`` is ``'in'`` or ``'out'``."""
+    if ta != tb:
+        return False, f"dtype mismatch: {ta!r} vs {tb!r}"
+    if kind == "in" and name in _GRAPH_IO_SEQ_AXIS_EXCEPTION_INPUTS:
+        if len(sa) != len(sb):
+            return False, f"rank mismatch: {len(sa)} vs {len(sb)}"
+        if len(sa) >= 1 and sa[0] != sb[0]:
+            return False, f"batch dim shape[0] mismatch: {sa} vs {sb}"
+        return True, None
+    if kind == "out" and name in _GRAPH_IO_SEQ_AXIS_EXCEPTION_OUTPUTS:
+        if len(sa) == 3 and len(sb) == 3:
+            if sa[0] != sb[0] or sa[2] != sb[2]:
+                return (
+                    False,
+                    f"logits: only dim1 may differ; got prefill {sa} vs decode {sb}",
+                )
+            return True, None
+        return (
+            False,
+            f"logits: expected rank-3; got prefill rank {len(sa)} vs decode {len(sb)}",
+        )
+    if (ta, sa) != (tb, sb):
+        return False, f"prefill ({ta}, {sa}) vs decode ({tb}, {sb})"
+    return True, None
+
+
+def _dim_to_tuple(dim: onnx.TensorShapeProto.Dimension) -> tuple[str, int | str]:
+    if dim.dim_param:
+        return ("param", dim.dim_param)
+    return ("value", int(dim.dim_value))
+
+
+def _tensor_type_str(tt: onnx.TypeProto.Tensor) -> str:
+    return TensorProto.DataType.Name(tt.elem_type)
+
+
+def _tensor_info_from_type_proto(
+    tt: onnx.TypeProto.Tensor,
+) -> tuple[str, tuple[tuple[str, int | str], ...]]:
+    if not tt.HasField("elem_type"):
+        return ("UNKNOWN", ())
+    et = _tensor_type_str(tt)
+    shape = tuple(_dim_to_tuple(d) for d in tt.shape.dim)
+    return (et, shape)
+
+
+def tensor_meta_for_name(
+    graph: onnx.GraphProto, name: str
+) -> tuple[str, tuple[tuple[str, int | str], ...]] | None:
+    """Return (elem_type_name, shape_dims) or None if unresolved."""
+    for vi in graph.input:
+        if vi.name == name and vi.type.HasField("tensor_type"):
+            return _tensor_info_from_type_proto(vi.type.tensor_type)
+    for vi in graph.output:
+        if vi.name == name and vi.type.HasField("tensor_type"):
+            return _tensor_info_from_type_proto(vi.type.tensor_type)
+    for vi in graph.value_info:
+        if vi.name == name and vi.type.HasField("tensor_type"):
+            return _tensor_info_from_type_proto(vi.type.tensor_type)
+    for init in graph.initializer:
+        if init.name == name:
+            et = TensorProto.DataType.Name(init.data_type)
+            shape = tuple(("value", int(d)) for d in init.dims)
+            return (et, shape)
+    return None
+
+
+def _init_numpy(init: onnx.TensorProto) -> np.ndarray | None:
+    try:
+        return numpy_helper.to_array(init)
+    except Exception:
+        return None
+
+
+def initializer_payload_equal(
+    ga: onnx.GraphProto,
+    gb: onnx.GraphProto,
+    name: str,
+) -> tuple[bool, str]:
+    """True if both graphs have initializer ``name`` with identical dtype/shape/bytes."""
+    a = next((i for i in ga.initializer if i.name == name), None)
+    b = next((i for i in gb.initializer if i.name == name), None)
+    if a is None and b is None:
+        return True, "both absent"
+    if a is None or b is None:
+        return False, f"only one side has initializer {name!r}"
+    if a.data_type != b.data_type or list(a.dims) != list(b.dims):
+        return False, f"dtype/dims differ for {name!r}"
+    arr_a = _init_numpy(a)
+    arr_b = _init_numpy(b)
+    if arr_a is None or arr_b is None:
+        same = a.raw_data == b.raw_data
+        return same, "raw_data ok" if same else "raw_data differ"
+    if np.array_equal(arr_a, arr_b):
+        return True, "array_equal"
+    return False, f"values differ: {arr_a.ravel()[:4]} vs {arr_b.ravel()[:4]} ..."
+
+
+def gqa_total_input_compare(
+    na: onnx.NodeProto,
+    nb: onnx.NodeProto,
+    ga: onnx.GraphProto,
+    gb: onnx.GraphProto,
+) -> list[str]:
+    """Compare GroupQueryAttention total slot (``export_chunk_model`` uses 0-based index 6)."""
+    errs: list[str] = []
+    # Total sequence length is wired to input index 6 when the graph has that slot.
+    idx = 6 if len(na.input) > 6 and len(nb.input) > 6 else 5
+    if len(na.input) <= idx or len(nb.input) <= idx:
+        return [
+            f"GQA {na.name!r}: need input index {idx}, got len "
+            f"{len(na.input)} vs {len(nb.input)}"
+        ]
+    ia, ib = na.input[idx], nb.input[idx]
+    if ia != ib:
+        errs.append(f"GQA {na.name!r} input[{idx}] name: {ia!r} vs {ib!r}")
+        init_a = next((x for x in ga.initializer if x.name == ia), None)
+        init_b = next((x for x in gb.initializer if x.name == ib), None)
+        if init_a is not None and init_b is not None:
+            va, vb = _init_numpy(init_a), _init_numpy(init_b)
+            if va is not None and vb is not None and np.array_equal(va, vb):
+                errs[-1] += " (initializer values equal)"
+            elif va is not None and vb is not None:
+                errs.append(f"  initializer values differ for input[{idx}]")
+        return errs
+    if ia:
+        init_a = next((x for x in ga.initializer if x.name == ia), None)
+        init_b = next((x for x in gb.initializer if x.name == ib), None)
+        if init_a is not None and init_b is not None:
+            eq, detail = initializer_payload_equal(ga, gb, ia)
+            if not eq:
+                errs.append(f"GQA {na.name!r} input[{idx}]={ia!r}: {detail}")
+    return errs
+
+
+ISSUE_SECTION_ORDER = (
+    "load",
+    "graph_io",
+    "node_struct",
+    "edge_dtype",
+    "edge_shape",
+    "gqa",
+    "kv_cache",
+    "genai",
+    "misc",
+)
+ISSUE_SECTION_TITLE = {
+    "load": "load / read",
+    "graph_io": "graph I/O",
+    "node_struct": "node structure (name / op_type / wiring)",
+    "edge_dtype": "intermediate edge dtypes",
+    "edge_shape": "intermediate edge shapes (--compare-intermediate-shapes only)",
+    "gqa": "GroupQueryAttention total",
+    "kv_cache": "past_key_values / present",
+    "genai": "genai_config.json",
+    "misc": "other",
+}
+
+
+@dataclass
+class TripletReport:
+    stem: str
+    ok: bool = True
+    sections: dict[str, list[str]] = field(default_factory=lambda: defaultdict(list))
+
+    def add(self, section: str, msg: str, *, fatal: bool = True) -> None:
+        if section not in ISSUE_SECTION_ORDER:
+            section = "misc"
+        self.sections[section].append(msg)
+        if fatal:
+            self.ok = False
+
+
+def _nodes_by_name(graph: onnx.GraphProto) -> dict[str, onnx.NodeProto]:
+    out: dict[str, onnx.NodeProto] = {}
+    for i, n in enumerate(graph.node):
+        key = (n.name or "").strip()
+        if not key:
+            key = f"__unnamed_op{i}_{n.op_type}"
+        elif key in out:
+            key = f"{key}__idx{i}"
+        out[key] = n
+    return out
+
+
+def compare_graphs(
+    prefill: onnx.ModelProto,
+    decode: onnx.ModelProto,
+    rep: TripletReport,
+    *,
+    compare_intermediate_shapes: bool,
+) -> None:
+    ga, gb = prefill.graph, decode.graph
+
+    # Graph I/O
+    def io_list(g: onnx.GraphProto, kind: str) -> list[tuple[str, str, tuple]]:
+        seq = g.input if kind == "in" else g.output
+        out = []
+        for vi in seq:
+            if not vi.type.HasField("tensor_type"):
+                out.append((vi.name, "NON_TENSOR", ()))
+                continue
+            et, sh = _tensor_info_from_type_proto(vi.type.tensor_type)
+            out.append((vi.name, et, sh))
+        return out
+
+    ins_a, ins_b = io_list(ga, "in"), io_list(gb, "in")
+    outs_a, outs_b = io_list(ga, "out"), io_list(gb, "out")
+    if [x[0] for x in ins_a] != [x[0] for x in ins_b]:
+        rep.add(
+            "graph_io",
+            "graph input name order differs\n"
+            f"  prefill: {[x[0] for x in ins_a]}\n"
+            f"  decode:  {[x[0] for x in ins_b]}",
+        )
+    for (na, ta, sa), (nb, tb, sb) in zip(ins_a, ins_b):
+        if na != nb:
+            continue
+        ok_io, why = _graph_io_tensor_compatible(na, ta, sa, tb, sb, kind="in")
+        if not ok_io:
+            rep.add("graph_io", f"graph input {na!r}: {why}")
+
+    if [x[0] for x in outs_a] != [x[0] for x in outs_b]:
+        rep.add(
+            "graph_io",
+            "graph output name order differs\n"
+            f"  prefill: {[x[0] for x in outs_a]}\n"
+            f"  decode:  {[x[0] for x in outs_b]}",
+        )
+    for (na, ta, sa), (nb, tb, sb) in zip(outs_a, outs_b):
+        if na != nb:
+            continue
+        ok_io, why = _graph_io_tensor_compatible(na, ta, sa, tb, sb, kind="out")
+        if not ok_io:
+            rep.add("graph_io", f"graph output {na!r}: {why}")
+
+    if len(ga.node) != len(gb.node):
+        rep.add(
+            "node_struct",
+            f"node count mismatch: prefill {len(ga.node)} vs decode {len(gb.node)}",
+        )
+
+    ma, mb = _nodes_by_name(ga), _nodes_by_name(gb)
+    names_a, names_b = set(ma), set(mb)
+    only_a, only_b = sorted(names_a - names_b), sorted(names_b - names_a)
+    if only_a:
+        rep.add(
+            "node_struct",
+            f"nodes only in prefill ({len(only_a)}): "
+            f"{only_a[:20]}{'...' if len(only_a) > 20 else ''}",
+        )
+    if only_b:
+        rep.add(
+            "node_struct",
+            f"nodes only in decode ({len(only_b)}): "
+            f"{only_b[:20]}{'...' if len(only_b) > 20 else ''}",
+        )
+
+    for name in sorted(names_a & names_b):
+        na, nb = ma[name], mb[name]
+        if na.op_type != nb.op_type:
+            rep.add(
+                "node_struct",
+                f"node {name!r}: op_type {na.op_type!r} vs {nb.op_type!r}",
+            )
+            continue
+        if na.op_type == "GroupQueryAttention":
+            for msg in gqa_total_input_compare(na, nb, ga, gb):
+                rep.add("gqa", msg)
+        if list(na.input) != list(nb.input):
+            rep.add(
+                "node_struct",
+                f"node {name!r}: input list differs\n"
+                f"  prefill: {list(na.input)}\n"
+                f"  decode:  {list(nb.input)}",
+            )
+        else:
+            for ia, ib in zip(na.input, nb.input):
+                if not ia and not ib:
+                    continue
+                if ia != ib or not ia:
+                    continue
+                meta_a = tensor_meta_for_name(ga, ia)
+                meta_b = tensor_meta_for_name(gb, ib)
+                if compare_intermediate_shapes:
+                    if meta_a != meta_b:
+                        rep.add(
+                            "edge_shape",
+                            f"node {name!r} input {ia!r}: prefill {meta_a} vs decode {meta_b}",
+                        )
+                else:
+                    et_a = meta_a[0] if meta_a else None
+                    et_b = meta_b[0] if meta_b else None
+                    if et_a != et_b:
+                        rep.add(
+                            "edge_dtype",
+                            f"node {name!r} input {ia!r}: dtype prefill {et_a} vs decode {et_b}",
+                        )
+                    elif meta_a is None or meta_b is None:
+                        rep.add(
+                            "misc",
+                            f"node {name!r} input {ia!r}: missing type info on one side "
+                            f"(prefill meta={meta_a}, decode meta={meta_b})",
+                            fatal=False,
+                        )
+        if list(na.output) != list(nb.output):
+            rep.add(
+                "node_struct",
+                f"node {name!r}: output list differs\n"
+                f"  prefill: {list(na.output)}\n"
+                f"  decode:  {list(nb.output)}",
+            )
+        else:
+            for oa, ob in zip(na.output, nb.output):
+                if not oa and not ob:
+                    continue
+                if oa != ob or not oa:
+                    continue
+                meta_a = tensor_meta_for_name(ga, oa)
+                meta_b = tensor_meta_for_name(gb, ob)
+                if compare_intermediate_shapes:
+                    if meta_a != meta_b:
+                        rep.add(
+                            "edge_shape",
+                            f"node {name!r} output {oa!r}: prefill {meta_a} vs decode {meta_b}",
+                        )
+                else:
+                    et_a = meta_a[0] if meta_a else None
+                    et_b = meta_b[0] if meta_b else None
+                    if et_a != et_b:
+                        rep.add(
+                            "edge_dtype",
+                            f"node {name!r} output {oa!r}: dtype prefill {et_a} vs decode {et_b}",
+                        )
+                    elif meta_a is None or meta_b is None:
+                        rep.add(
+                            "misc",
+                            f"node {name!r} output {oa!r}: missing type info on one side "
+                            f"(prefill meta={meta_a}, decode meta={meta_b})",
+                            fatal=False,
+                        )
+
+    # past / present shapes by name
+    past_names = sorted(
+        {vi.name for vi in ga.input if PAST_KV_IO_RE.match(vi.name)}
+        & {vi.name for vi in gb.input if PAST_KV_IO_RE.match(vi.name)}
+    )
+    for nm in past_names:
+        ma_ = tensor_meta_for_name(ga, nm)
+        mb_ = tensor_meta_for_name(gb, nm)
+        if ma_ != mb_:
+            rep.add(
+                "kv_cache",
+                f"past {nm!r}: prefill {ma_} vs decode {mb_}",
+            )
+
+    pres_names = sorted(
+        {vi.name for vi in ga.output if PRESENT_IO_RE.match(vi.name)}
+        & {vi.name for vi in gb.output if PRESENT_IO_RE.match(vi.name)}
+    )
+    for nm in pres_names:
+        ma_ = tensor_meta_for_name(ga, nm)
+        mb_ = tensor_meta_for_name(gb, nm)
+        if ma_ != mb_:
+            rep.add(
+                "kv_cache",
+                f"present {nm!r}: prefill {ma_} vs decode {mb_}",
+            )
+
+
+def _describe_io_list_mismatch(
+    json_list: list[str],
+    onnx_list: list[str],
+) -> str:
+    """Human-readable diff for pipeline inputs/outputs vs graph I/O names."""
+    lj, lo = len(json_list), len(onnx_list)
+    lines: list[str] = [f"count json={lj} onnx={lo}"]
+    m = min(lj, lo)
+    if m == 0:
+        lines.append(f"json full: {json_list[:32]!r}")
+        lines.append(f"onnx full: {onnx_list[:32]!r}")
+        return "\n".join(lines)
+
+    mismatch_at: int | None = None
+    for i in range(m):
+        if json_list[i] != onnx_list[i]:
+            mismatch_at = i
+            break
+
+    if mismatch_at is None:
+        if lj == lo:
+            return "\n".join(
+                lines + ["(internal: lists should differ but are identical per index)"]
+            )
+        if json_list[:m] == onnx_list[:m]:
+            if lj > lo:
+                tail = json_list[m : m + 16]
+                lines.append(
+                    f"first {m} names match; json has {lj - lo} extra entries "
+                    f"(often template layer count > ONNX); extra head: {tail!r}"
+                )
+            else:
+                tail = onnx_list[m : m + 16]
+                lines.append(
+                    f"first {m} names match; onnx has {lo - lj} extra entries; extra head: {tail!r}"
+                )
+        return "\n".join(lines)
+
+    i = mismatch_at
+    lines.append(
+        f"first mismatch index i={i}: json={json_list[i]!r} onnx={onnx_list[i]!r}"
+    )
+    lo_c = max(0, i - 2)
+    hi_c = min(m, i + 5)
+    lines.append(f"  json slice [{lo_c}:{hi_c}]: {json_list[lo_c:hi_c]!r}")
+    lines.append(f"  onnx slice [{lo_c}:{hi_c}]: {onnx_list[lo_c:hi_c]!r}")
+
+    set_j, set_o = set(json_list), set(onnx_list)
+    only_j = sorted(set_j - set_o)
+    only_o = sorted(set_o - set_j)
+    if only_j or only_o:
+        lines.append(
+            "  set diff (ignore order/multiplicity): "
+            f"only in json {len(only_j)}, only in onnx {len(only_o)}"
+        )
+        if only_j[:12]:
+            lines.append(
+                f"    only json: {only_j[:12]!r}{'...' if len(only_j) > 12 else ''}"
+            )
+        if only_o[:12]:
+            lines.append(
+                f"    only onnx: {only_o[:12]!r}{'...' if len(only_o) > 12 else ''}"
+            )
+
+    return "\n".join(lines)
+
+
+def _split_io_prefix_and_kv(
+    names: list[str], *, is_input: bool
+) -> tuple[list[str], list[str]]:
+    """Split into (prefix before KV tensors, past_key_values.* or present.* tail)."""
+    if is_input:
+        for i, n in enumerate(names):
+            if n.startswith("past_key_values."):
+                return names[:i], names[i:]
+        return names, []
+    for i, n in enumerate(names):
+        if n.startswith("present."):
+            return names[:i], names[i:]
+    return names, []
+
+
+def validate_genai_json(
+    cfg: dict[str, Any],
+    stem: str,
+    rep: TripletReport,
+    *,
+    prefill_graph: onnx.GraphProto,
+    decode_graph: onnx.GraphProto,
+) -> None:
+    dec = cfg.get("model", {}).get("decoder", {})
+    pipe = dec.get("pipeline") or {}
+    pre = pipe.get("prefill") or {}
+    decp = pipe.get("decode") or {}
+    exp_pre, exp_dec = f"prefill_{stem}.onnx", f"decode_{stem}.onnx"
+    if pre.get("filename") != exp_pre:
+        rep.add(
+            "genai",
+            f"prefill.filename: expected {exp_pre!r}, got {pre.get('filename')!r}",
+        )
+    if decp.get("filename") != exp_dec:
+        rep.add(
+            "genai",
+            f"decode.filename: expected {exp_dec!r}, got {decp.get('filename')!r}",
+        )
+
+    def check_io_lists(
+        side: str, graph: onnx.GraphProto, block: dict[str, Any], kind: str
+    ) -> None:
+        key = "inputs" if kind == "in" else "outputs"
+        if key not in block or not isinstance(block[key], list):
+            return
+        listed = list(block[key])
+        actual = [x.name for x in (graph.input if kind == "in" else graph.output)]
+        is_in = kind == "in"
+        pre_j, kv_j = _split_io_prefix_and_kv(listed, is_input=is_in)
+        pre_o, kv_o = _split_io_prefix_and_kv(actual, is_input=is_in)
+        if pre_j != pre_o:
+            if Counter(pre_j) == Counter(pre_o) and len(pre_j) == len(pre_o):
+                rep.add(
+                    "genai",
+                    f"pipeline.{side}.{key}: prefix (before first past/present) **multiset** matches ONNX; "
+                    f"**order** only differs (e.g. ``inputs_embeds`` vs ``attention_mask``; safe if binding "
+                    f"by name). json: {pre_j!r} | onnx: {pre_o!r}",
+                    fatal=False,
+                )
+            else:
+                detail = _describe_io_list_mismatch(pre_j, pre_o)
+                rep.add(
+                    "genai",
+                    f"pipeline.{side}.{key} prefix vs ONNX: name multiset or length mismatch.\n{detail}\n"
+                    f"  hint: often ``input_ids`` / ``inputs_embeds`` / ``attention_mask`` / "
+                    f"``position_ids`` vs template.",
+                )
+                return
+        if Counter(kv_j) != Counter(kv_o):
+            detail = _describe_io_list_mismatch(kv_j, kv_o)
+            rep.add(
+                "genai",
+                f"pipeline.{side}.{key}: past_key_values.* / present.* name multiset vs ONNX mismatch.\n"
+                f"{detail}\n"
+                f"  hint: count/set diff often means template num_hidden_layers vs model layer count.",
+            )
+            return
+        if kv_j != kv_o:
+            rep.add(
+                "genai",
+                f"pipeline.{side}.{key}: past/present multiset matches ONNX; **list order** only differs "
+                f"(runtime usually binds by name). json first 8: {kv_j[:8]!r} | onnx first 8: {kv_o[:8]!r}",
+                fatal=False,
+            )
+
+    check_io_lists("prefill", prefill_graph, pre, "in")
+    check_io_lists("prefill", prefill_graph, pre, "out")
+    check_io_lists("decode", decode_graph, decp, "in")
+    check_io_lists("decode", decode_graph, decp, "out")
+
+
+def discover_triplets(root: str) -> list[tuple[str, str, str, str]]:
+    """Return list of (stem, prefill_path, decode_path, genai_json_path)."""
+    root = os.path.abspath(root)
+    out: list[tuple[str, str, str, str]] = []
+    if not os.path.isdir(root):
+        return out
+    for fn in sorted(os.listdir(root)):
+        if not fn.startswith("prefill_") or not fn.endswith(".onnx"):
+            continue
+        stem = fn[len("prefill_") : -len(".onnx")]
+        p_pre = os.path.join(root, fn)
+        p_dec = os.path.join(root, f"decode_{stem}.onnx")
+        p_js = os.path.join(root, f"genai_config_{stem}.json")
+        if stem.endswith("_dml"):
+            continue
+        if os.path.isfile(p_dec) and os.path.isfile(p_js):
+            out.append((stem, p_pre, p_dec, p_js))
+    return out
+
+
+def print_triplet_report(rep: TripletReport, *, per_section_cap: int) -> None:
+    status = "OK" if rep.ok else "FAIL"
+    print(f"[{status}] stem={rep.stem!r}")
+    total = sum(len(rep.sections[s]) for s in ISSUE_SECTION_ORDER)
+    if total == 0:
+        print("    (no issues)")
+        return
+    for sec in ISSUE_SECTION_ORDER:
+        lines = rep.sections.get(sec, [])
+        if not lines:
+            continue
+        title = ISSUE_SECTION_TITLE.get(sec, sec)
+        print(f"  --- {title} ({len(lines)}) ---")
+        shown = 0
+        for line in lines:
+            if shown >= per_section_cap:
+                rest = len(lines) - shown
+                if rest > 0:
+                    print(f"    ... {rest} more (raise --per-section-cap to show more)")
+                break
+            if len(line) > 220:
+                line = line[:217] + "..."
+            print(f"    - {line}")
+            shown += 1
+
+
+def run_one(
+    stem: str,
+    p_pre: str,
+    p_dec: str,
+    p_js: str,
+    *,
+    quiet: bool,
+    compare_intermediate_shapes: bool,
+    per_section_cap: int,
+) -> TripletReport:
+    rep = TripletReport(stem=stem)
+    try:
+        m_pre = onnx.load(p_pre, load_external_data=False)
+        m_dec = onnx.load(p_dec, load_external_data=False)
+    except Exception as e:
+        rep.add("load", f"failed to load ONNX: {e}")
+        return rep
+
+    compare_graphs(
+        m_pre,
+        m_dec,
+        rep,
+        compare_intermediate_shapes=compare_intermediate_shapes,
+    )
+
+    try:
+        with open(p_js, encoding="utf-8") as f:
+            cfg = json.load(f)
+    except Exception as e:
+        rep.add("load", f"failed to read genai JSON: {e}")
+        return rep
+
+    validate_genai_json(
+        cfg,
+        stem,
+        rep,
+        prefill_graph=m_pre.graph,
+        decode_graph=m_dec.graph,
+    )
+
+    if not quiet:
+        print_triplet_report(rep, per_section_cap=per_section_cap)
+    return rep
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Compare prefill/decode ONNX and genai_config under export_chunk_model output."
+    )
+    ap.add_argument(
+        "output_dir",
+        help="Directory written by export_chunk_model.py (-o / --output).",
+    )
+    ap.add_argument("--quiet", action="store_true", help="Only print summary line.")
+    ap.add_argument(
+        "--compare-intermediate-shapes",
+        action="store_true",
+        help="Also compare full shapes on every intermediate edge (default: dtype only; "
+        "prefill/decode seq dims often differ).",
+    )
+    ap.add_argument(
+        "--per-section-cap",
+        type=int,
+        default=25,
+        metavar="N",
+        help="Max detail lines per issue section (default: 25).",
+    )
+    args = ap.parse_args(argv)
+
+    root = os.path.abspath(args.output_dir)
+    if not os.path.isdir(root):
+        print(f"Not a directory: {root}", file=sys.stderr)
+        return 2
+
+    triplets = discover_triplets(root)
+    if not triplets:
+        print(
+            f"No complete triplets (prefill_*.onnx + decode_*.onnx + genai_config_*.json) in {root}"
+        )
+        return 1
+
+    covered_prefill = {f"prefill_{s}.onnx" for s, _, _, _ in triplets}
+    all_prefill = [
+        f for f in os.listdir(root) if f.startswith("prefill_") and f.endswith(".onnx")
+    ]
+    orphan_prefill = sorted(set(all_prefill) - covered_prefill)
+    if orphan_prefill and not args.quiet:
+        print(
+            "Note: prefill ONNX without matching decode+genai_config (skipped):",
+            ", ".join(orphan_prefill[:20])
+            + (" ..." if len(orphan_prefill) > 20 else ""),
+            file=sys.stderr,
+        )
+
+    reports: list[TripletReport] = []
+    for stem, p_pre, p_dec, p_js in triplets:
+        reports.append(
+            run_one(
+                stem,
+                p_pre,
+                p_dec,
+                p_js,
+                quiet=args.quiet,
+                compare_intermediate_shapes=args.compare_intermediate_shapes,
+                per_section_cap=max(1, args.per_section_cap),
+            )
+        )
+
+    n_ok = sum(1 for r in reports if r.ok)
+    n_fail = len(reports) - n_ok
+    failed_stems = [r.stem for r in reports if not r.ok]
+    fail_hint = f" failed: {', '.join(failed_stems[:16])}" + (
+        " ..." if len(failed_stems) > 16 else ""
+    )
+    print(
+        f"Summary: {n_ok}/{len(reports)} triplets passed, {n_fail} failed (dir={root})"
+        + (fail_hint if failed_stems else "")
+    )
+    return 0 if n_fail == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/onnx-model-splitter/compare_chunk_export_outputs.py
+++ b/tools/onnx-model-splitter/compare_chunk_export_outputs.py
@@ -54,10 +54,6 @@ import numpy as np
 import onnx
 from onnx import TensorProto, numpy_helper
 
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-if SCRIPT_DIR not in sys.path:
-    sys.path.insert(0, SCRIPT_DIR)
-
 PAST_KV_IO_RE = re.compile(r"^past_key_values\.\d+\.(?:key|value)$")
 PRESENT_IO_RE = re.compile(r"^present\.\d+\.(?:key|value)$")
 
@@ -181,9 +177,16 @@ def gqa_total_input_compare(
     ga: onnx.GraphProto,
     gb: onnx.GraphProto,
 ) -> list[str]:
-    """Compare GroupQueryAttention total slot (``export_chunk_model`` uses 0-based index 6)."""
+    """Compare GroupQueryAttention wiring for the **total sequence length** input slot.
+
+    This is **not** a generic GQA port detector: it follows the wiring contract produced by
+    ``export_chunk_model`` / chunk export in this repo. There, ``GroupQueryAttention`` exposes the
+    total-sequence tensor at **0-based input index 6** when the node has more than six inputs;
+    otherwise the same role is taken to be index **5**. If a graph uses a different op signature
+    (same input count but different semantics), this check may compare the wrong slot.
+    """
     errs: list[str] = []
-    # Total sequence length is wired to input index 6 when the graph has that slot.
+    # export_chunk_model chunk graphs: total-seq at index 6 when len(inputs) > 6, else 5.
     idx = 6 if len(na.input) > 6 and len(nb.input) > 6 else 5
     if len(na.input) <= idx or len(nb.input) <= idx:
         return [

--- a/tools/onnx-model-splitter/export_chunk_model.py
+++ b/tools/onnx-model-splitter/export_chunk_model.py
@@ -19,6 +19,10 @@ Export fixed-shape Llama prefill/decode ONNX variants.
   ``12200``.
   ``128`` and ``2048`` still keep their sliding-window variants ``prefill_pSm...``;
   ``12200`` is fixed-only (no ``p12200m...`` variant).
+  **Control fixed-prompt** (chunk=0 only, when ``128`` / ``2048`` appear in ``--seq-lens``):
+  ``prefill_128_m256.onnx`` / ``genai_config_128_m256.json`` (``context_length``/KV = 256,
+  ``fixed_prompt_length`` 128) and ``prefill_2k_m3072.onnx`` /
+  ``genai_config_2k_m3072.json`` (3072 / 2048; stem ``2k`` like other fixed 2048 files).
 - Prefill: default ``--seq-lens`` expands to 10 variants (two for ``128`` and ``2048`` plus
   the rest); Decode maps one-to-one with these variants.
 - input_ids: [1, S] (prefill) or [1, 1] (decode); attention_mask: [1, max_length];
@@ -316,21 +320,25 @@ def expand_export_variant_specs(
     max_length: int,
     *,
     decode_mode: bool,
-) -> list[tuple[str, dict[str, int], int, int | None]]:
+) -> list[tuple[str, dict[str, int], int, int | None, int | None]]:
     """Expand ``--seq-lens`` into the ONNX/genai variant list.
 
-    Each item is ``(file_stem, dim_map, genai_window_chunk, fixed_prompt_len)``:
+    Each item is
+    ``(file_stem, dim_map, genai_window_chunk, fixed_prompt_len, genai_context_length)``:
 
     - ``genai_window_chunk==0``: fixed-prompt JSON variant (writes ``fixed_prompt_length``);
       ``fixed_prompt_len`` is the corresponding sequence length.
     - ``genai_window_chunk>0``: sliding-window variant, ``window_size`` uses this value;
       ``fixed_prompt_len`` is ``None``.
+    - ``genai_context_length``: if not ``None``, JSON ``context_length`` /
+      ``search.max_length`` use this value (ONNX KV / mask dims follow ``dim_map``); if
+      ``None``, use CLI ``--max-length``.
     - ``12200`` only generates a fixed variant, no ``p12200m...`` sliding variant.
     - For fixed variants where ``S==2048``, stem is ``2k`` (e.g. ``prefill_2k.onnx``),
       while dimensions still use 2048.
     """
     ml = int(max_length)
-    out: list[tuple[str, dict[str, int], int, int | None]] = []
+    out: list[tuple[str, dict[str, int], int, int | None, int | None]] = []
     for s_raw in seq_lens:
         s = int(s_raw)
         if s != 12200:
@@ -347,7 +355,7 @@ def expand_export_variant_specs(
                     "past_sequence_length": ml,
                     "total_sequence_length": ml,
                 }
-            out.append((tag_sl, dm_sl, s, None))
+            out.append((tag_sl, dm_sl, s, None, None))
         if s in FIXED_PROMPT_SEQUENCE_LENS:
             tag_fx = fixed_prompt_filename_stem(s)
             if decode_mode:
@@ -362,7 +370,39 @@ def expand_export_variant_specs(
                     "past_sequence_length": ml,
                     "total_sequence_length": ml,
                 }
-            out.append((tag_fx, dm_fx, 0, s))
+            out.append((tag_fx, dm_fx, 0, s, None))
+            if s == 128:
+                ctrl_ml = 256
+                tag_ctrl = "128_m256"
+                if decode_mode:
+                    dm_ctrl = {
+                        "sequence_length": 1,
+                        "past_sequence_length": ctrl_ml,
+                        "total_sequence_length": ctrl_ml,
+                    }
+                else:
+                    dm_ctrl = {
+                        "sequence_length": 128,
+                        "past_sequence_length": ctrl_ml,
+                        "total_sequence_length": ctrl_ml,
+                    }
+                out.append((tag_ctrl, dm_ctrl, 0, 128, ctrl_ml))
+            if s == 2048:
+                ctrl_ml = 3072
+                tag_ctrl = "2k_m3072"
+                if decode_mode:
+                    dm_ctrl = {
+                        "sequence_length": 1,
+                        "past_sequence_length": ctrl_ml,
+                        "total_sequence_length": ctrl_ml,
+                    }
+                else:
+                    dm_ctrl = {
+                        "sequence_length": 2048,
+                        "past_sequence_length": ctrl_ml,
+                        "total_sequence_length": ctrl_ml,
+                    }
+                out.append((tag_ctrl, dm_ctrl, 0, 2048, ctrl_ml))
     return out
 
 
@@ -432,10 +472,11 @@ def write_genai_config_jsons(
         decode_onnx_path=decode_onnx_path,
     )
     specs = expand_export_variant_specs(seq_lens, max_length, decode_mode=False)
-    for tag, _dm, genai_chunk, fixed_prompt_len in specs:
+    for tag, _dm, genai_chunk, fixed_prompt_len, genai_ctx in specs:
+        ctx_len = genai_ctx if genai_ctx is not None else max_length
         cfg = copy.deepcopy(template)
         model = cfg.setdefault("model", {})
-        model["context_length"] = max_length
+        model["context_length"] = ctx_len
         dec = model.setdefault("decoder", {})
 
         if genai_chunk == 0:
@@ -447,7 +488,7 @@ def write_genai_config_jsons(
 
         dec["pipeline"]["prefill"]["filename"] = f"prefill_{tag}.onnx"
         dec["pipeline"]["decode"]["filename"] = f"decode_{tag}.onnx"
-        cfg["search"]["max_length"] = max_length
+        cfg["search"]["max_length"] = ctx_len
 
         # Fixed-prompt variant: ORT GenAI requires ``decoder.fixed_prompt_length``.
         # The template may not contain this key, so write it last to avoid losing it
@@ -910,7 +951,7 @@ class FixedCtxExtractor(SingleOpExtractor):
         specs = expand_export_variant_specs(
             self._seq_lens, ml, decode_mode=self._decode_mode
         )
-        return [(tag, dm) for tag, dm, _gc, _fp in specs]
+        return [(tag, dm) for tag, dm, _, _, _ in specs]
 
     def _save_variants(self, model, out_dir, _prefix):
         """``_prefix`` from parent (``full_model``) ignored; files use ``_export_prefix``."""
@@ -947,6 +988,10 @@ class FixedCtxExtractor(SingleOpExtractor):
         _printed_reuse_hint = False
 
         for idx, (vname, dim_map) in enumerate(self.variants):
+            if isinstance(dim_map, dict):
+                cache_len = int(dim_map["total_sequence_length"])
+            else:
+                cache_len = self._max_length
             eff_total_llm = (
                 total_seq_len_scalar_from_dim_map(dim_map)
                 if self.model_type == "llm"
@@ -982,21 +1027,21 @@ class FixedCtxExtractor(SingleOpExtractor):
             _apply_input_ids_mask_shapes(
                 model.graph,
                 input_ids_seq=ids_seq,
-                attention_second=self._max_length,
+                attention_second=cache_len,
             )
 
-            n_pk = _force_past_key_values_past_seq_dim(model.graph, self._max_length)
+            n_pk = _force_past_key_values_past_seq_dim(model.graph, cache_len)
             if n_pk and idx == 0:
                 print(
                     f"  past_key_values inputs with past_sequence_length="
-                    f"{self._max_length} (max_length): {n_pk}"
+                    f"{cache_len} (variant cache): {n_pk}"
                 )
 
-            n_pr = _force_present_kv_seq_dim(model.graph, self._max_length)
+            n_pr = _force_present_kv_seq_dim(model.graph, cache_len)
             if n_pr and idx == 0:
                 print(
                     f"  present.* outputs/value_info dim[2]="
-                    f"{self._max_length} (max_length): {n_pr} tensor(s)"
+                    f"{cache_len} (variant cache): {n_pr} tensor(s)"
                 )
 
             n_nodes, n_vi, n_in, n_init = _post_export_prune_unreachable(model)

--- a/tools/onnx-model-splitter/export_chunk_model.py
+++ b/tools/onnx-model-splitter/export_chunk_model.py
@@ -1,0 +1,1143 @@
+#!/usr/bin/env python3
+"""
+Export fixed-shape Llama prefill/decode ONNX variants.
+
+- batch_size = 1.
+- **max_length** (default 16384, CLI ``--max-length``): this matches the graph-level
+  meaning of past_sequence_length, total_sequence_length, the GQA total scalar, the
+  second dimension of attention_mask, and related shapes; it is not just another name
+  for "cache_len".
+- Except fixed-prompt variants, the ONNX / genai filename tag is ``p{chunk}m{max_length}``,
+  e.g. ``prefill_p128m16384.onnx`` and ``genai_config_p128m16384.json``.
+- **Fixed-prompt variants** (``decoder.fixed_prompt_length`` with no ``sliding_window``):
+  additionally export fixed ONNX / genai variants for ``S∈{128,2048,12200}``; the stem is
+  ``128``, ``2k`` (for ``S=2048``, while JSON ``fixed_prompt_length`` stays ``2048``), and
+  ``12200``.
+  ``128`` and ``2048`` still keep their sliding-window variants ``prefill_pSm...``;
+  ``12200`` is fixed-only (no ``p12200m...`` variant).
+- Prefill: default ``--seq-lens`` expands to 10 variants (two for ``128`` and ``2048`` plus
+  the rest); Decode maps one-to-one with these variants.
+- input_ids: [1, S] (prefill) or [1, 1] (decode); attention_mask: [1, max_length];
+  position_ids: [1, S] (prefill) or [1, 1] (decode), matching the current-step sequence.
+- past_key_values.*.key/value: the 3rd dimension is forced to max_length, with layout
+  [batch, num_kv_heads, past_sequence_length, head_size].
+- The 3rd dimension of ``present.*.key/value`` graph outputs and matching ``value_info``
+  is also forced to max_length (source ONNX often has concrete values like 256, and
+  symbolic substitution alone does not update those).
+- If GroupQueryAttention input 5 is ``attn_mask_reformat/.../Cast/output_0``, keep the
+  original edge and do not replace it with a seqlens constant.
+- If the original ``Constant fold/total_seq_len`` → ``total_seq_len_constant`` becomes
+  unreferenced after rewiring GQA total input, remove it to avoid duplicating the new
+  injected total constant; a backup copy is restored between variants for continued export.
+- Before saving each variant, run **dead-code elimination**: mark tensors reachable
+  backwards from ``graph.output``, remove nodes that cannot affect any output, trim
+  ``value_info``, drop unused ``graph.input``, and remove unreferenced ``initializer``s
+  (e.g. isolated Gather/Cast chains in ``attn_mask_subgraph``).
+- Prefill and Decode ONNX files are written **directly** under ``--output`` / ``-o`` (no
+  ``full_model/`` subfolder); external weight filenames and shard layout match the source
+  ONNX exactly (e.g. Llama
+  ``model.onnx.data``, GPT-OSS ``model_q4f16.onnx_data``, ``model_q4f16.onnx_data_1``, etc.).
+  If source has no external data, default remains ``model.onnx.data``. All variants share
+  the same external weight files: only the first variant writes blobs, later variants write
+  only their ``.onnx`` graph (no weight re-read, no ``*.data`` rewrite).
+  ONNX basenames are always ``prefill_{tag}.onnx`` or ``decode_{tag}.onnx`` (including when
+  ``extract_full_model`` takes the layered-graph path that used to emit ``full_model_``).
+  For multi-shard files (e.g. ``model_q4f16.onnx_data``, ``_1``, ...), repacking preserves
+  source ``location``/``offset`` and writes all mapped initializers (including pieces <1024B);
+  script-added unmapped initializers stay embedded in ``.onnx`` to avoid polluting shard 0.
+- If ``--model`` is provided and ``--no-genai-config`` is not set, write one
+  ``genai_config_{tag}.json`` per variant under ``--output`` (same folder as the ONNX).
+  The template path
+  must be provided via ``-T`` / ``--config-template`` (choose per model family; e.g. Llama
+  can use ``splite_onnx/genai_config.json`` in this repo). The script fills fields including
+  ``context_length``, prefill/decode filenames, and ``search.max_length``.
+  If the source ONNX does not contain ``QMoE`` nodes, also write
+  ``genai_config_{tag}_dml.json`` for the three fixed-prompt variants
+  (``genai_config_128.json``, ``genai_config_2k.json``, ``genai_config_12200.json``):
+  only ``decoder.session_options`` is switched to DirectML
+  (``provider_options: [{ "dml": { "device_id": "0" } }]``), all other fields match the
+  non-DML config.
+  For chunk=0 (fixed-prompt 128 / 2048 / 12200), ensure ``decoder.fixed_prompt_length``
+  exists (the template may omit it) and remove ``sliding_window``.
+  For chunk!=0, remove ``fixed_prompt_length`` and set ``sliding_window.window_size``.
+
+Reuses ``SingleOpExtractor.extract_full_model`` via subclass; shares small helpers
+with ``extract_submodels.py`` (total-seq initializer / fold Constant).
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import os
+import re
+import sys
+from typing import Any
+
+from collections import defaultdict
+from dataclasses import dataclass
+
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+import numpy as np
+import onnx
+from onnx import numpy_helper
+from onnx import TensorProto
+from onnx.external_data_helper import set_external_data
+
+from extract_submodels import (
+    BATCH_SIZE,
+    FOLD_TOTAL_SEQ_NODE_NAME,
+    TOTAL_SEQ_LEN_CONST_NAME,
+    TOTAL_SEQ_LEN_CONSTANT_OUT,
+    SingleOpExtractor,
+    _build_dim_subs,
+    patch_fold_total_seq_len_constant_value,
+    total_seq_len_scalar_from_dim_map,
+    upsert_total_seq_len_const_initializer,
+)
+
+
+DEFAULT_SEQ_LENS = (128, 256, 512, 1024, 2048, 3072, 4096, 12200)
+GQA_INIT_PREFIX = "gqa_ctxfix_"
+
+# Fallback when the source ONNX has no external-data initializers
+DEFAULT_EXTERNAL_WEIGHTS_FILENAME = "model.onnx.data"
+
+DEFAULT_GENAI_CONFIG_TEMPLATE = os.path.join(_SCRIPT_DIR, "genai_config.json")
+
+
+def _tensor_external_kv(tensor: onnx.TensorProto) -> dict[str, str]:
+    return {e.key: e.value for e in tensor.external_data}
+
+
+def _initializer_external_loc_off(
+    tensor: onnx.TensorProto,
+) -> tuple[str | None, int]:
+    """Return (location, offset) from TensorProto.external_data; offset 0 if absent."""
+    kv = _tensor_external_kv(tensor)
+    loc = kv.get("location")
+    if not loc:
+        return None, 0
+    off = int(kv["offset"]) if "offset" in kv else 0
+    return loc, off
+
+
+@dataclass(frozen=True)
+class ExternalDataLayout:
+    """How large initializers were split across files in the source ONNX."""
+
+    ordered_locations: tuple[str, ...]
+    init_to_location: dict[str, str]
+    init_pack_order: dict[str, tuple[int, int]]  # name -> (file_index, offset)
+
+
+def scan_external_data_layout(model_path: str) -> ExternalDataLayout | None:
+    """Scan ``model_path`` (load_external_data=False) for initializer external_data.
+
+    Returns ``None`` if no initializer uses external storage.
+    """
+    m = onnx.load(model_path, load_external_data=False)
+    rows: list[tuple[str, str, int]] = []
+    for init in m.graph.initializer:
+        loc, off = _initializer_external_loc_off(init)
+        if not loc:
+            continue
+        rows.append((init.name, loc, off))
+    if not rows:
+        return None
+
+    ordered: list[str] = []
+    for init in m.graph.initializer:
+        loc, _ = _initializer_external_loc_off(init)
+        if loc and loc not in ordered:
+            ordered.append(loc)
+    file_index = {loc: i for i, loc in enumerate(ordered)}
+    init_to_location = {name: loc for name, loc, _ in rows}
+    init_pack_order = {
+        name: (file_index[loc], off) for name, loc, off in rows
+    }
+    return ExternalDataLayout(
+        ordered_locations=tuple(ordered),
+        init_to_location=init_to_location,
+        init_pack_order=init_pack_order,
+    )
+
+
+def _stale_external_filenames(layout: ExternalDataLayout | None) -> list[str]:
+    """External weight basenames to remove in the output directory before a fresh export."""
+    names = {DEFAULT_EXTERNAL_WEIGHTS_FILENAME}
+    if layout:
+        names.update(layout.ordered_locations)
+    return sorted(names)
+
+
+def _tensor_raw_byte_len(t: onnx.TensorProto) -> int:
+    if not t.HasField("raw_data"):
+        return 0
+    return len(t.raw_data)
+
+
+def _needs_external_blob_rebuild(
+    model: onnx.ModelProto,
+    size_threshold: int,
+    layout: ExternalDataLayout | None,
+) -> bool:
+    """True if external blob(s) must be rewritten from ``raw_data``.
+
+    For **multi-shard** models (several ``*.onnx_data`` files), any initializer that
+    the source maps to a shard must be packed into blobs **regardless of size**;
+    skipping tensors under ``size_threshold`` would truncate shard 0 and desync
+    MD5 vs the original exporter. Single-shard / default path still uses
+    ``size_threshold`` like ``onnx.save``.
+    """
+    multi = layout is not None and len(layout.ordered_locations) > 1
+    for init in model.graph.initializer:
+        if not init.HasField("raw_data"):
+            continue
+        if multi and init.name in layout.init_to_location:
+            return True
+        if not multi and len(init.raw_data) >= size_threshold:
+            return True
+    return False
+
+
+def _save_onnx_external_aligned(
+    model: onnx.ModelProto,
+    onnx_path: str,
+    layout: ExternalDataLayout | None,
+    *,
+    size_threshold: int,
+) -> bool:
+    """Save ONNX; external weight filenames / multi-file split match ``layout`` (source).
+
+    Returns:
+        True if only the ``.onnx`` proto was written and existing external data files
+        were left unchanged (subsequent shape variants; fast path).
+    """
+    out_dir = os.path.dirname(onnx_path)
+    os.makedirs(out_dir, exist_ok=True)
+
+    if not _needs_external_blob_rebuild(model, size_threshold, layout):
+        onnx.save(model, onnx_path, save_as_external_data=False)
+        return True
+
+    if layout is None or len(layout.ordered_locations) == 1:
+        loc = (
+            layout.ordered_locations[0]
+            if layout
+            else DEFAULT_EXTERNAL_WEIGHTS_FILENAME
+        )
+        ext_path = os.path.join(out_dir, loc)
+        if os.path.isfile(ext_path):
+            os.remove(ext_path)
+        onnx.save(
+            model,
+            onnx_path,
+            save_as_external_data=True,
+            all_tensors_to_one_file=True,
+            location=loc,
+            size_threshold=size_threshold,
+        )
+        return False
+
+    def _sort_key(init: onnx.TensorProto) -> tuple:
+        fi, off = layout.init_pack_order[init.name]
+        return (fi, off, init.name)
+
+    # Pack exactly the tensors the source ONNX placed in each file (all sizes).
+    # Do not use size_threshold here: shard 0 often mixes sub-1024B tensors with
+    # large weights; omitting small tensors corrupts the first blob vs upstream.
+    # Initializers not listed in init_to_location (e.g. script-added GQA scalars)
+    # stay embedded in the .onnx — never append them into a shard.
+    by_loc: dict[str, list[onnx.TensorProto]] = defaultdict(list)
+    for init in model.graph.initializer:
+        if init.name not in layout.init_to_location:
+            continue
+        if not init.HasField("raw_data"):
+            continue
+        loc = layout.init_to_location[init.name]
+        by_loc[loc].append(init)
+
+    for loc in layout.ordered_locations:
+        lst = sorted(by_loc.get(loc, []), key=_sort_key)
+        if not lst:
+            continue
+        blob = b"".join(init.raw_data for init in lst)
+        fpath = os.path.join(out_dir, loc)
+        with open(fpath, "wb") as f:
+            f.write(blob)
+        off = 0
+        for init in lst:
+            chunk = init.raw_data
+            ln = len(chunk)
+            set_external_data(init, loc, off, ln)
+            off += ln
+            init.ClearField("raw_data")
+            init.data_location = TensorProto.EXTERNAL
+
+    onnx.save(model, onnx_path, save_as_external_data=False)
+    return False
+
+
+def variant_filename_tag(chunk: int, max_length: int) -> str:
+    """Stem segment ``p{chunk}m{max_length}`` (``m`` = max length label, no underscore)."""
+    return f"p{chunk}m{max_length}"
+
+
+# Besides sliding-window variants, also export numeric-stem fixed-prompt variants;
+# 12200 exists only in this fixed set (no p12200m sliding variant).
+FIXED_PROMPT_SEQUENCE_LENS: frozenset[int] = frozenset((128, 2048, 12200))
+
+
+def fixed_prompt_filename_stem(sequence_len: int) -> str:
+    """Stem for chunk=0 ONNX/genai filenames. ``2048`` → ``2k`` (shorter path segment)."""
+    s = int(sequence_len)
+    if s == 2048:
+        return "2k"
+    return str(s)
+
+
+def expand_export_variant_specs(
+    seq_lens: tuple[int, ...],
+    max_length: int,
+    *,
+    decode_mode: bool,
+) -> list[tuple[str, dict[str, int], int, int | None]]:
+    """Expand ``--seq-lens`` into the ONNX/genai variant list.
+
+    Each item is ``(file_stem, dim_map, genai_window_chunk, fixed_prompt_len)``:
+
+    - ``genai_window_chunk==0``: fixed-prompt JSON variant (writes ``fixed_prompt_length``);
+      ``fixed_prompt_len`` is the corresponding sequence length.
+    - ``genai_window_chunk>0``: sliding-window variant, ``window_size`` uses this value;
+      ``fixed_prompt_len`` is ``None``.
+    - ``12200`` only generates a fixed variant, no ``p12200m...`` sliding variant.
+    - For fixed variants where ``S==2048``, stem is ``2k`` (e.g. ``prefill_2k.onnx``),
+      while dimensions still use 2048.
+    """
+    ml = int(max_length)
+    out: list[tuple[str, dict[str, int], int, int | None]] = []
+    for s_raw in seq_lens:
+        s = int(s_raw)
+        if s != 12200:
+            tag_sl = variant_filename_tag(s, ml)
+            if decode_mode:
+                dm_sl = {
+                    "sequence_length": 1,
+                    "past_sequence_length": ml,
+                    "total_sequence_length": ml,
+                }
+            else:
+                dm_sl = {
+                    "sequence_length": s,
+                    "past_sequence_length": ml,
+                    "total_sequence_length": ml,
+                }
+            out.append((tag_sl, dm_sl, s, None))
+        if s in FIXED_PROMPT_SEQUENCE_LENS:
+            tag_fx = fixed_prompt_filename_stem(s)
+            if decode_mode:
+                dm_fx = {
+                    "sequence_length": 1,
+                    "past_sequence_length": ml,
+                    "total_sequence_length": ml,
+                }
+            else:
+                dm_fx = {
+                    "sequence_length": s,
+                    "past_sequence_length": ml,
+                    "total_sequence_length": ml,
+                }
+            out.append((tag_fx, dm_fx, 0, s))
+    return out
+
+
+# MoE quantized op type; if present, do not generate parallel DML profiles
+# (not meaningful to combine with MorphiZen-like EP configurations).
+QMoe_OP_TYPES: frozenset[str] = frozenset({"QMoE"})
+
+
+def _graph_contains_any_op_type(graph: onnx.GraphProto, op_types: frozenset[str]) -> bool:
+    return any(node.op_type in op_types for node in graph.node)
+
+
+def onnx_model_contains_qmoe(model_path: str) -> bool:
+    """Load ONNX without external weights; True if top-level graph contains ``QMoE``."""
+    if not model_path or not os.path.isfile(model_path):
+        return False
+    m = onnx.load(model_path, load_external_data=False)
+    return _graph_contains_any_op_type(m.graph, QMoe_OP_TYPES)
+
+
+def _emit_genai_dml_sidecars(
+    *,
+    prefill_onnx_path: str | None,
+    decode_onnx_path: str | None,
+) -> bool:
+    """True iff we should write ``*_dml.json`` for fixed-prompt variants (no QMoE in graphs)."""
+    if not prefill_onnx_path or not os.path.isfile(prefill_onnx_path):
+        return False
+    if onnx_model_contains_qmoe(prefill_onnx_path):
+        return False
+    if decode_onnx_path and os.path.isfile(decode_onnx_path):
+        if onnx_model_contains_qmoe(decode_onnx_path):
+            return False
+    return True
+
+
+def _decoder_session_options_dml() -> dict[str, Any]:
+    """Match ``genai_config_*_dml.json`` next to ONNX (DirectML only)."""
+    return {
+        "provider_options": [
+            {"dml": {"device_id": "0"}},
+        ],
+    }
+
+
+def write_genai_config_jsons(
+    output_dir: str,
+    max_length: int,
+    seq_lens: tuple[int, ...],
+    template_path: str,
+    *,
+    prefill_onnx_path: str | None = None,
+    decode_onnx_path: str | None = None,
+) -> list[str]:
+    """Write one ``genai_config_{tag}.json`` per variant into ``output_dir`` (``-o``)."""
+    if not os.path.isfile(template_path):
+        raise FileNotFoundError(f"genai_config template not found: {template_path}")
+
+    with open(template_path, encoding="utf-8") as f:
+        template = json.load(f)
+
+    written: list[str] = []
+    emit_dml = _emit_genai_dml_sidecars(
+        prefill_onnx_path=prefill_onnx_path,
+        decode_onnx_path=decode_onnx_path,
+    )
+    specs = expand_export_variant_specs(
+        seq_lens, max_length, decode_mode=False)
+    for tag, _dm, genai_chunk, fixed_prompt_len in specs:
+        cfg = copy.deepcopy(template)
+        model = cfg.setdefault("model", {})
+        model["context_length"] = max_length
+        dec = model.setdefault("decoder", {})
+
+        if genai_chunk == 0:
+            dec.pop("sliding_window", None)
+        else:
+            dec.pop("fixed_prompt_length", None)
+            sw = dec.setdefault("sliding_window", {})
+            sw["window_size"] = int(genai_chunk)
+
+        dec["pipeline"]["prefill"]["filename"] = f"prefill_{tag}.onnx"
+        dec["pipeline"]["decode"]["filename"] = f"decode_{tag}.onnx"
+        cfg["search"]["max_length"] = max_length
+
+        # Fixed-prompt variant: ORT GenAI requires ``decoder.fixed_prompt_length``.
+        # The template may not contain this key, so write it last to avoid losing it
+        # during deep-copy or subsequent edits.
+        if genai_chunk == 0 and fixed_prompt_len is not None:
+            dec["fixed_prompt_length"] = int(fixed_prompt_len)
+
+        os.makedirs(output_dir, exist_ok=True)
+        out_name = f"genai_config_{tag}.json"
+        out_path = os.path.join(output_dir, out_name)
+        with open(out_path, "w", encoding="utf-8") as f:
+            json.dump(cfg, f, indent=4, ensure_ascii=False)
+            f.write("\n")
+        written.append(out_path)
+
+        if (
+            emit_dml
+            and genai_chunk == 0
+            and fixed_prompt_len is not None
+            and int(fixed_prompt_len) in FIXED_PROMPT_SEQUENCE_LENS
+        ):
+            cfg_dml = copy.deepcopy(cfg)
+            dec_dml = cfg_dml.setdefault("model", {}).setdefault("decoder", {})
+            dec_dml["session_options"] = _decoder_session_options_dml()
+            dml_name = f"genai_config_{tag}_dml.json"
+            dml_path = os.path.join(output_dir, dml_name)
+            with open(dml_path, "w", encoding="utf-8") as f:
+                json.dump(cfg_dml, f, indent=4, ensure_ascii=False)
+                f.write("\n")
+            written.append(dml_path)
+
+    return written
+
+
+INPUT_IDS_NAME = "input_ids"
+ATTENTION_MASK_NAME = "attention_mask"
+POSITION_IDS_NAME = "position_ids"
+
+# ORT LLM: past_key_values.{i}.key / .value — axis 2 is past cache length
+PAST_KV_INPUT_RE = re.compile(r"^past_key_values\.\d+\.(?:key|value)$")
+# KV cache outputs: axis 2 must match max_length (concrete dims in source ONNX are not
+# updated by _set_vi_shape_ctx, which only resolves dim_param).
+PRESENT_IO_RE = re.compile(r"^present\.\d+\.(?:key|value)$")
+
+
+def _force_rank2_input_shape(vi, d0: int, d1: int):
+    """Set graph input ValueInfo to fixed rank-2 shape [d0, d1], keep elem_type."""
+    if not vi.type.HasField("tensor_type"):
+        return
+    tt = vi.type.tensor_type
+    del tt.shape.dim[:]
+    for v in (d0, d1):
+        dim = tt.shape.dim.add()
+        dim.dim_value = v
+
+
+def _apply_input_ids_mask_shapes(
+    graph: onnx.GraphProto,
+    input_ids_seq: int,
+    attention_second: int,
+):
+    """input_ids [1, seq], attention_mask [1, max_length], position_ids [1, seq]."""
+    for vi in graph.input:
+        if vi.name == INPUT_IDS_NAME:
+            _force_rank2_input_shape(vi, 1, input_ids_seq)
+        elif vi.name == ATTENTION_MASK_NAME:
+            _force_rank2_input_shape(vi, 1, attention_second)
+        elif vi.name == POSITION_IDS_NAME:
+            _force_rank2_input_shape(vi, 1, input_ids_seq)
+
+
+def _force_past_key_values_past_seq_dim(
+    graph: onnx.GraphProto,
+    past_sequence_length: int,
+) -> int:
+    """Set past_sequence_length (dim index 2) for all past_key_values inputs."""
+    n = 0
+    for vi in graph.input:
+        if not PAST_KV_INPUT_RE.match(vi.name):
+            continue
+        if not vi.type.HasField("tensor_type"):
+            continue
+        dims = vi.type.tensor_type.shape.dim
+        if len(dims) != 4:
+            continue
+        dims[0].ClearField("dim_param")
+        dims[0].dim_value = 1
+        dims[2].ClearField("dim_param")
+        dims[2].dim_value = past_sequence_length
+        n += 1
+    return n
+
+
+def _force_present_kv_seq_dim(graph: onnx.GraphProto, seq_dim: int) -> int:
+    """Set dim index 2 to ``seq_dim`` for all ``present.*.key/value`` graph outputs
+    and matching ``value_info`` (layout [batch, kv_heads, seq, head_size])."""
+    n = 0
+
+    def _fix_vi(vi):
+        nonlocal n
+        if not PRESENT_IO_RE.match(vi.name):
+            return
+        if not vi.type.HasField("tensor_type"):
+            return
+        dims = vi.type.tensor_type.shape.dim
+        if len(dims) != 4:
+            return
+        dims[2].ClearField("dim_param")
+        dims[2].dim_value = seq_dim
+        n += 1
+
+    for vi in graph.output:
+        _fix_vi(vi)
+    for vi in graph.value_info:
+        _fix_vi(vi)
+    return n
+
+
+def resolve_dim_param_ctx(param: str, dim_map) -> int | str:
+    """Like extract_submodels.resolve_dim_param, without int-dim_map fallback
+    that would wrongly substitute unknown symbols when dim_map is dict."""
+    subs = _build_dim_subs(dim_map)
+
+    has_op = any(c in param for c in ("*", "+", "-", "/", "(", ")"))
+    if has_op:
+        expr = param
+        for sym, val in sorted(subs.items(), key=lambda x: -len(x[0])):
+            expr = expr.replace(sym, str(val))
+        try:
+            return int(eval(expr))  # noqa: S307
+        except Exception:
+            return param
+
+    if param in subs:
+        return subs[param]
+
+    if "batch" in param and "seq" not in param:
+        return BATCH_SIZE
+
+    if isinstance(dim_map, int):
+        return dim_map
+
+    return param
+
+
+def _set_vi_shape_ctx(vi, dim_map):
+    if not vi.type.tensor_type.shape:
+        return
+    for dim in vi.type.tensor_type.shape.dim:
+        if dim.dim_param:
+            val = resolve_dim_param_ctx(dim.dim_param, dim_map)
+            if isinstance(val, int):
+                dim.ClearField("dim_param")
+                dim.dim_value = val
+
+
+def _sanitize(s: str, max_len: int = 64) -> str:
+    t = re.sub(r"[^a-zA-Z0-9_]", "_", s)
+    return t[:max_len] if t else "gqa"
+
+
+def _backup_gqa_nodes(model: onnx.ModelProto):
+    """(node_name, full input list copy) for each GroupQueryAttention.
+
+    Must use **names**, not node list indices: after ``_remove_orphan_fold_total_seq_len``
+    deletes ``fold/total_seq_len``, all following indices shift; restoring by stale
+    index would overwrite the wrong node (e.g. o_proj MatMul gets GQA's 9 inputs)."""
+    return [(n.name, list(n.input)) for n in model.graph.node
+            if n.op_type == "GroupQueryAttention"]
+
+
+def _restore_gqa_nodes(model: onnx.ModelProto, backup):
+    by_name = dict(backup)
+    for node in model.graph.node:
+        if node.name in by_name:
+            del node.input[:]
+            node.input.extend(by_name[node.name])
+
+
+def _remove_initializer_prefix(graph: onnx.GraphProto, prefix: str):
+    keep = [init for init in graph.initializer if not init.name.startswith(prefix)]
+    del graph.initializer[:]
+    graph.initializer.extend(keep)
+
+
+def _tensor_name_producer_index(graph: onnx.GraphProto) -> dict[str, int]:
+    """Map tensor name -> index of the node that defines it (last writer wins)."""
+    out: dict[str, int] = {}
+    for i, node in enumerate(graph.node):
+        for o in node.output:
+            if o:
+                out[o] = i
+    return out
+
+
+def _backward_needed_tensor_names(graph: onnx.GraphProto) -> set[str]:
+    """Tensor names that lie on some path from graph outputs backward through producers."""
+    producers = _tensor_name_producer_index(graph)
+    needed = {o.name for o in graph.output if o.name}
+    changed = True
+    while changed:
+        changed = False
+        for t in list(needed):
+            if t not in producers:
+                continue
+            node = graph.node[producers[t]]
+            for inp in node.input:
+                if inp and inp not in needed:
+                    needed.add(inp)
+                    changed = True
+    return needed
+
+
+def _remove_dead_nodes_one_pass(graph: onnx.GraphProto) -> int:
+    """Remove nodes none of whose outputs are in ``backward_needed``."""
+    needed = _backward_needed_tensor_names(graph)
+    kept: list[onnx.NodeProto] = []
+    removed = 0
+    for node in graph.node:
+        outs = [o for o in node.output if o]
+        if not outs:
+            kept.append(node)
+            continue
+        if any(o in needed for o in outs):
+            kept.append(node)
+        else:
+            removed += 1
+    if removed:
+        del graph.node[:]
+        graph.node.extend(kept)
+    return removed
+
+
+def _dce_remove_unreachable_nodes(graph: onnx.GraphProto) -> int:
+    """Iterative dead-code elimination until fixpoint."""
+    total = 0
+    while True:
+        n = _remove_dead_nodes_one_pass(graph)
+        total += n
+        if n == 0:
+            break
+    return total
+
+
+def _graph_live_tensor_names(graph: onnx.GraphProto) -> set[str]:
+    names = {i.name for i in graph.input if i.name}
+    names |= {o.name for o in graph.output if o.name}
+    names |= {t.name for t in graph.initializer}
+    for n in graph.node:
+        for t in n.input:
+            if t:
+                names.add(t)
+        for t in n.output:
+            if t:
+                names.add(t)
+    return names
+
+
+def _trim_value_info_to_live_tensors(graph: onnx.GraphProto) -> int:
+    """Drop value_info for tensors that no longer appear in the graph."""
+    live = _graph_live_tensor_names(graph)
+    keep = [vi for vi in graph.value_info if vi.name in live]
+    before = len(graph.value_info)
+    if len(keep) != before:
+        del graph.value_info[:]
+        graph.value_info.extend(keep)
+    return before - len(keep)
+
+
+def _remove_unused_graph_inputs(graph: onnx.GraphProto, needed: set[str]) -> int:
+    """Remove graph inputs not consumed on any path to a graph output (keep I/O aliases)."""
+    out_names = {o.name for o in graph.output if o.name}
+    drop_idx = []
+    for idx, inp in enumerate(graph.input):
+        name = inp.name
+        if not name or name in out_names:
+            continue
+        if name not in needed:
+            drop_idx.append(idx)
+    for idx in reversed(drop_idx):
+        del graph.input[idx]
+    return len(drop_idx)
+
+
+def _remove_unused_initializers(graph: onnx.GraphProto, needed: set[str]) -> int:
+    """Remove initializers whose names never appear in ``needed``."""
+    keep = [init for init in graph.initializer if init.name in needed]
+    removed = len(graph.initializer) - len(keep)
+    if removed:
+        del graph.initializer[:]
+        graph.initializer.extend(keep)
+    return removed
+
+
+def _post_export_prune_unreachable(model: onnx.ModelProto) -> tuple[int, int, int, int]:
+    """DCE + trim value_info + unused inputs + unused initializers.
+
+    Returns ``(nodes_removed, value_info_removed, inputs_removed, inits_removed)``.
+    """
+    graph = model.graph
+    n_nodes = _dce_remove_unreachable_nodes(graph)
+    n_vi = _trim_value_info_to_live_tensors(graph)
+    needed = _backward_needed_tensor_names(graph)
+    n_in = _remove_unused_graph_inputs(graph, needed)
+    n_init = _remove_unused_initializers(graph, needed)
+    return n_nodes, n_vi, n_in, n_init
+
+
+def _is_gqa_attn_mask_reformat_input(inp: str) -> bool:
+    """True if this GQA input is the shared attn_mask_reformat Cast output — must not replace."""
+    if not inp:
+        return False
+    if "attn_mask_reformat" in inp:
+        return True
+    if "attn_mask_subgraph" in inp and "Cast" in inp:
+        return True
+    return False
+
+
+def _patch_gqa_scalars(
+    model: onnx.ModelProto,
+    dim_map: dict,
+    name_prefix: str,
+) -> int:
+    """Optionally wire GroupQueryAttention total_sequence_length (input 6).
+
+    Llama-3.1 exports use input 5 for ``attn_mask_reformat/.../Cast/output_0``;
+    that edge must stay unchanged. Input 6 (e.g. ``total_seq_len_constant``)
+    is replaced with a scalar initializer = total_sequence_length from dim_map.
+
+    On graphs where input 5 is not the mask path (legacy seqlens_k), input 5
+    may still be patched with [sequence_length-1]."""
+    subs = _build_dim_subs(dim_map)
+    seq_len = int(subs["sequence_length"])
+    total_len = int(subs["total_sequence_length"])
+
+    patched = 0
+    for ni, node in enumerate(model.graph.node):
+        if node.op_type != "GroupQueryAttention":
+            continue
+        if len(node.input) <= 6:
+            continue
+        suf = _sanitize(node.name or f"nd{ni}")
+        sl = f"{name_prefix}n{ni}_{suf}_seqlens_k"
+        tl = f"{name_prefix}n{ni}_{suf}_total_seq"
+
+        new_inits = []
+
+        inp5 = node.input[5] if len(node.input) > 5 else ""
+        if inp5 and not _is_gqa_attn_mask_reformat_input(inp5):
+            node.input[5] = sl
+            new_inits.append(
+                numpy_helper.from_array(
+                    np.array([seq_len - 1], dtype=np.int32),
+                    name=sl,
+                )
+            )
+        if len(node.input) > 6 and node.input[6]:
+            node.input[6] = tl
+            new_inits.append(
+                numpy_helper.from_array(
+                    np.array(total_len, dtype=np.int32),
+                    name=tl,
+                )
+            )
+
+        for it in new_inits:
+            model.graph.initializer.append(it)
+            patched += 1
+    return patched
+
+
+def _snapshot_fold_total_seq_len_node(model: onnx.ModelProto):
+    """Copy of the original Constant that produces total_seq_len_constant (if present)."""
+    for n in model.graph.node:
+        if n.name == FOLD_TOTAL_SEQ_NODE_NAME and n.op_type == "Constant":
+            t = onnx.NodeProto()
+            t.CopyFrom(n)
+            return t
+    return None
+
+
+def _ensure_fold_total_seq_len_node(model: onnx.ModelProto, template):
+    """Re-insert Constant before each variant if it was removed in the previous save."""
+    if template is None:
+        return
+    if any(n.name == FOLD_TOTAL_SEQ_NODE_NAME for n in model.graph.node):
+        return
+    nc = onnx.NodeProto()
+    nc.CopyFrom(template)
+    model.graph.node.append(nc)
+
+
+def _tensor_refcount(graph: onnx.GraphProto, tensor_name: str) -> int:
+    n = 0
+    for node in graph.node:
+        for inp in node.input:
+            if inp == tensor_name:
+                n += 1
+    for out in graph.output:
+        if out.name == tensor_name:
+            n += 1
+    return n
+
+
+def _remove_orphan_fold_total_seq_len(model: onnx.ModelProto) -> bool:
+    """After GQA input 6 is rewired off total_seq_len_constant, remove dead Constant.
+
+    Original graphs use ``Constant fold/total_seq_len`` → ``total_seq_len_constant``.
+    Our GQA patch replaces input 6 with ``gqa_ctxfix_*_total_seq``, so the old
+    Constant becomes redundant — remove it from exported models to avoid confusion."""
+    if _tensor_refcount(model.graph, TOTAL_SEQ_LEN_CONSTANT_OUT) > 0:
+        return False
+    kept = [n for n in model.graph.node if n.name != FOLD_TOTAL_SEQ_NODE_NAME]
+    if len(kept) == len(model.graph.node):
+        return False
+    del model.graph.node[:]
+    model.graph.node.extend(kept)
+    # Drop stale value_info for the removed edge
+    vi_keep = [
+        v for v in model.graph.value_info
+        if v.name != TOTAL_SEQ_LEN_CONSTANT_OUT
+    ]
+    if len(vi_keep) != len(model.graph.value_info):
+        del model.graph.value_info[:]
+        model.graph.value_info.extend(vi_keep)
+    return True
+
+
+class FixedCtxExtractor(SingleOpExtractor):
+    """``prefill_{stem}.onnx`` / ``decode_{stem}.onnx`` — stem is ``pCHUNKmMAX`` or ``S`` (chunk=0)."""
+
+    def __init__(
+        self,
+        model_path: str,
+        output_dir: str | None = None,
+        *,
+        max_length: int = 16384,
+        seq_lens: tuple[int, ...] | None = None,
+        decode_mode: bool = False,
+        export_prefix: str = "prefill",
+    ):
+        self._max_length = max_length
+        self._seq_lens = seq_lens or DEFAULT_SEQ_LENS
+        self._decode_mode = decode_mode
+        self._export_prefix = export_prefix
+        super().__init__(model_path, output_dir=output_dir)
+        # Write ONNX (and shared external data) directly under ``-o``, not ``.../full_model/``.
+        self.full_model_dir = self.base_dir
+        self._ext_layout = scan_external_data_layout(model_path)
+
+    def _full_model_variant_onnx_basename(self, vname: str) -> str:
+        """Layered ``extract_full_model`` path must match flat exports: only prefill_/decode_."""
+        return f"{self._export_prefix}_{vname}.onnx"
+
+    def _get_variants(self):
+        ml = self._max_length
+        specs = expand_export_variant_specs(
+            self._seq_lens, ml, decode_mode=self._decode_mode)
+        return [(tag, dm) for tag, dm, _gc, _fp in specs]
+
+    def _save_variants(self, model, out_dir, _prefix):
+        """``_prefix`` from parent (``full_model``) ignored; files use ``_export_prefix``."""
+        os.makedirs(out_dir, exist_ok=True)
+        for fn in _stale_external_filenames(self._ext_layout):
+            p = os.path.join(out_dir, fn)
+            if os.path.isfile(p):
+                os.remove(p)
+
+        if self._ext_layout:
+            nloc = len(self._ext_layout.ordered_locations)
+            ex0 = self._ext_layout.ordered_locations[0]
+            print(f"  External data: {nloc} file(s) (from source), e.g. {ex0!r}")
+        else:
+            print(f"  External data: single file {DEFAULT_EXTERNAL_WEIGHTS_FILENAME!r} "
+                  f"(source has no external initializers)")
+
+        orig_in = {i.name: self._save_vi_shape(i) for i in model.graph.input}
+        orig_out = {o.name: self._save_vi_shape(o) for o in model.graph.output}
+        orig_vi = {v.name: self._save_vi_shape(v) for v in model.graph.value_info}
+
+        gqa_backup = _backup_gqa_nodes(model)
+        gqa_node_count = sum(
+            1 for n in model.graph.node if n.op_type == "GroupQueryAttention"
+        )
+        if gqa_node_count:
+            print(f"  GQA nodes: {gqa_node_count} (will patch seqlens/total per variant)")
+
+        fold_total_template = _snapshot_fold_total_seq_len_node(model)
+        _printed_reuse_hint = False
+
+        for idx, (vname, dim_map) in enumerate(self.variants):
+            eff_total_llm = (
+                total_seq_len_scalar_from_dim_map(dim_map)
+                if self.model_type == "llm" else None
+            )
+            _ensure_fold_total_seq_len_node(model, fold_total_template)
+            if eff_total_llm is not None:
+                patch_fold_total_seq_len_constant_value(model, eff_total_llm)
+            _remove_initializer_prefix(model.graph, GQA_INIT_PREFIX)
+            _restore_gqa_nodes(model, gqa_backup)
+
+            if eff_total_llm is not None:
+                upsert_total_seq_len_const_initializer(
+                    model.graph, eff_total_llm)
+
+            n_gqa_inits = _patch_gqa_scalars(model, dim_map, GQA_INIT_PREFIX)
+            if n_gqa_inits and idx == 0:
+                print(f"  Patched GQA initializer tensor(s): {n_gqa_inits}")
+
+            if _remove_orphan_fold_total_seq_len(model) and idx == 0:
+                print(f"  Removed orphan {FOLD_TOTAL_SEQ_NODE_NAME!r} "
+                      f"(output {TOTAL_SEQ_LEN_CONSTANT_OUT!r} unused after GQA total patch)")
+
+            for vi in list(model.graph.input) + list(model.graph.output) \
+                    + list(model.graph.value_info):
+                _set_vi_shape_ctx(vi, dim_map)
+
+            ids_seq = 1 if self._decode_mode else int(dim_map["sequence_length"])
+            _apply_input_ids_mask_shapes(
+                model.graph,
+                input_ids_seq=ids_seq,
+                attention_second=self._max_length,
+            )
+
+            n_pk = _force_past_key_values_past_seq_dim(
+                model.graph, self._max_length)
+            if n_pk and idx == 0:
+                print(f"  past_key_values inputs with past_sequence_length="
+                      f"{self._max_length} (max_length): {n_pk}")
+
+            n_pr = _force_present_kv_seq_dim(model.graph, self._max_length)
+            if n_pr and idx == 0:
+                print(f"  present.* outputs/value_info dim[2]="
+                      f"{self._max_length} (max_length): {n_pr} tensor(s)")
+
+            n_nodes, n_vi, n_in, n_init = _post_export_prune_unreachable(model)
+            if idx == 0 and (n_nodes or n_vi or n_in or n_init):
+                print(f"  Pruned unreachable: {n_nodes} node(s), {n_vi} value_info, "
+                      f"{n_in} unused input(s), {n_init} unused initializer(s)")
+
+            fname = f"{self._export_prefix}_{vname}.onnx"
+            path = os.path.join(out_dir, fname)
+            # Always use onnx.save (not raw SerializeToString). For multi-variant
+            # exports with external weights, SerializeToString() produced invalid
+            # graphs on idx>=1 (e.g. MatMul with 9 inputs / ORT schema errors) while
+            # idx==0 loaded fine.
+            graph_only = _save_onnx_external_aligned(
+                model, path, self._ext_layout, size_threshold=1024)
+            if graph_only and not _printed_reuse_hint:
+                print("  Reusing shared external weight file(s); later variants write "
+                      ".onnx only (no re-read / no blob rewrite).")
+                _printed_reuse_hint = True
+            print(f"  Saved: {path}")
+
+            for vi in model.graph.input:
+                self._restore_vi_shape(vi, orig_in.get(vi.name))
+            for vi in model.graph.output:
+                self._restore_vi_shape(vi, orig_out.get(vi.name))
+            for vi in model.graph.value_info:
+                self._restore_vi_shape(vi, orig_vi.get(vi.name))
+
+        _remove_initializer_prefix(model.graph, GQA_INIT_PREFIX)
+        _restore_gqa_nodes(model, gqa_backup)
+
+
+def run_export(
+    model_path: str,
+    output_dir: str,
+    max_length: int,
+    seq_lens: tuple[int, ...],
+    *,
+    decode_mode: bool = False,
+    export_prefix: str = "prefill",
+):
+    ext = FixedCtxExtractor(
+        model_path,
+        output_dir=output_dir,
+        max_length=max_length,
+        seq_lens=seq_lens,
+        decode_mode=decode_mode,
+        export_prefix=export_prefix,
+    )
+    ext.extract_full_model()
+
+
+def parse_seq_lens(s: str | None) -> tuple[int, ...]:
+    if not s:
+        return DEFAULT_SEQ_LENS
+    parts = [p.strip() for p in s.split(",") if p.strip()]
+    return tuple(int(p) for p in parts)
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description="Export Llama prefill/decode ONNX with fixed max_length "
+                    f"(default {16384}) and per-variant sequence lengths."
+    )
+    p.add_argument(
+        "--model",
+        required=True,
+        help="Path to source ONNX used for both prefill and decode exports.",
+    )
+    p.add_argument(
+        "-o",
+        "--output",
+        help="Output directory: ONNX and genai_config_*.json are written here (no subfolder).",
+    )
+    p.add_argument(
+        "-T",
+        "--config-template",
+        "--genai-config-template",
+        default=None,
+        metavar="PATH",
+        dest="config_template",
+        help=(
+            "Template used to generate genai_config_*.json (choose file per model family). "
+            f"Required unless --no-genai-config is set. Example (Llama template in this repo): {DEFAULT_GENAI_CONFIG_TEMPLATE}"
+        ),
+    )
+    p.add_argument(
+        "--no-genai-config",
+        action="store_true",
+        help="Do not write genai_config_*.json files.",
+    )
+    p.add_argument(
+        "--max-length",
+        "--cache-len",
+        type=int,
+        default=16384,
+        dest="max_length",
+        metavar="N",
+        help="max_length (e.g. 16384): past/total sequence dims, GQA total, attention_mask "
+             "second dim. --cache-len is an alias.",
+    )
+    p.add_argument(
+        "--seq-lens",
+        default=None,
+        help=f"Comma-separated sequence lengths (default {','.join(map(str, DEFAULT_SEQ_LENS))})",
+    )
+
+    args = p.parse_args()
+    if not args.output:
+        p.error("--output / -o is required")
+
+    write_genai = not args.no_genai_config
+    if write_genai:
+        if not args.config_template:
+            p.error(
+                "A template path is required when generating genai_config: "
+                "-T / --config-template / --genai-config-template PATH "
+                f"(example: {DEFAULT_GENAI_CONFIG_TEMPLATE}), "
+                "or pass --no-genai-config to skip generation."
+            )
+        cfg_tpl = os.path.abspath(args.config_template)
+        if not os.path.isfile(cfg_tpl):
+            p.error(f"GenAI config template file does not exist: {cfg_tpl}")
+    else:
+        cfg_tpl = (
+            os.path.abspath(args.config_template)
+            if args.config_template
+            else None
+        )
+
+    seq_lens = parse_seq_lens(args.seq_lens)
+    out = os.path.abspath(args.output)
+
+    model_abs = os.path.abspath(args.model)
+    if not os.path.isfile(model_abs):
+        p.error(f"Model file does not exist: {model_abs}")
+
+    print(f"=== Prefill (out={out}, prefill_*m{args.max_length}.onnx, etc.) ===")
+    run_export(
+        model_abs, out, args.max_length, seq_lens,
+        decode_mode=False,
+        export_prefix="prefill",
+    )
+    print(f"=== Decode (out={out}, decode_*m{args.max_length}.onnx, etc.) ===")
+    run_export(
+        model_abs, out, args.max_length, seq_lens,
+        decode_mode=True,
+        export_prefix="decode",
+    )
+
+    if write_genai:
+        print(f"=== genai_config_*.json → {out}/ ===")
+        print(f"  Template: {cfg_tpl}")
+        paths = write_genai_config_jsons(
+            out,
+            args.max_length,
+            seq_lens,
+            cfg_tpl,
+            prefill_onnx_path=model_abs,
+            decode_onnx_path=model_abs,
+        )
+        for q in paths:
+            print(f"  Wrote: {q}")
+
+    print("Done.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/onnx-model-splitter/export_chunk_model.py
+++ b/tools/onnx-model-splitter/export_chunk_model.py
@@ -73,6 +73,7 @@ from __future__ import annotations
 
 import argparse
 import copy
+import importlib.util
 import json
 import os
 import re
@@ -82,27 +83,36 @@ from typing import Any
 from collections import defaultdict
 from dataclasses import dataclass
 
-_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-if _SCRIPT_DIR not in sys.path:
-    sys.path.insert(0, _SCRIPT_DIR)
-
 import numpy as np
 import onnx
 from onnx import numpy_helper
 from onnx import TensorProto
 from onnx.external_data_helper import set_external_data
 
-from extract_submodels import (
-    BATCH_SIZE,
-    FOLD_TOTAL_SEQ_NODE_NAME,
-    TOTAL_SEQ_LEN_CONST_NAME,
-    TOTAL_SEQ_LEN_CONSTANT_OUT,
-    SingleOpExtractor,
-    _build_dim_subs,
-    patch_fold_total_seq_len_constant_value,
-    total_seq_len_scalar_from_dim_map,
-    upsert_total_seq_len_const_initializer,
-)
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def _load_extract_submodels():
+    """Load sibling ``extract_submodels.py`` without modifying ``sys.path``."""
+    path = os.path.join(_SCRIPT_DIR, "extract_submodels.py")
+    spec = importlib.util.spec_from_file_location("extract_submodels", path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load extract_submodels from {path!r}")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["extract_submodels"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_es = _load_extract_submodels()
+BATCH_SIZE = _es.BATCH_SIZE
+FOLD_TOTAL_SEQ_NODE_NAME = _es.FOLD_TOTAL_SEQ_NODE_NAME
+TOTAL_SEQ_LEN_CONSTANT_OUT = _es.TOTAL_SEQ_LEN_CONSTANT_OUT
+SingleOpExtractor = _es.SingleOpExtractor
+_build_dim_subs = _es._build_dim_subs
+patch_fold_total_seq_len_constant_value = _es.patch_fold_total_seq_len_constant_value
+total_seq_len_scalar_from_dim_map = _es.total_seq_len_scalar_from_dim_map
+upsert_total_seq_len_const_initializer = _es.upsert_total_seq_len_const_initializer
 
 
 DEFAULT_SEQ_LENS = (128, 256, 512, 1024, 2048, 3072, 4096, 12200)
@@ -161,9 +171,7 @@ def scan_external_data_layout(model_path: str) -> ExternalDataLayout | None:
             ordered.append(loc)
     file_index = {loc: i for i, loc in enumerate(ordered)}
     init_to_location = {name: loc for name, loc, _ in rows}
-    init_pack_order = {
-        name: (file_index[loc], off) for name, loc, off in rows
-    }
+    init_pack_order = {name: (file_index[loc], off) for name, loc, off in rows}
     return ExternalDataLayout(
         ordered_locations=tuple(ordered),
         init_to_location=init_to_location,
@@ -231,9 +239,7 @@ def _save_onnx_external_aligned(
 
     if layout is None or len(layout.ordered_locations) == 1:
         loc = (
-            layout.ordered_locations[0]
-            if layout
-            else DEFAULT_EXTERNAL_WEIGHTS_FILENAME
+            layout.ordered_locations[0] if layout else DEFAULT_EXTERNAL_WEIGHTS_FILENAME
         )
         ext_path = os.path.join(out_dir, loc)
         if os.path.isfile(ext_path):
@@ -365,7 +371,9 @@ def expand_export_variant_specs(
 QMoe_OP_TYPES: frozenset[str] = frozenset({"QMoE"})
 
 
-def _graph_contains_any_op_type(graph: onnx.GraphProto, op_types: frozenset[str]) -> bool:
+def _graph_contains_any_op_type(
+    graph: onnx.GraphProto, op_types: frozenset[str]
+) -> bool:
     return any(node.op_type in op_types for node in graph.node)
 
 
@@ -423,8 +431,7 @@ def write_genai_config_jsons(
         prefill_onnx_path=prefill_onnx_path,
         decode_onnx_path=decode_onnx_path,
     )
-    specs = expand_export_variant_specs(
-        seq_lens, max_length, decode_mode=False)
+    specs = expand_export_variant_specs(seq_lens, max_length, decode_mode=False)
     for tag, _dm, genai_chunk, fixed_prompt_len in specs:
         cfg = copy.deepcopy(template)
         model = cfg.setdefault("model", {})
@@ -608,8 +615,11 @@ def _backup_gqa_nodes(model: onnx.ModelProto):
     Must use **names**, not node list indices: after ``_remove_orphan_fold_total_seq_len``
     deletes ``fold/total_seq_len``, all following indices shift; restoring by stale
     index would overwrite the wrong node (e.g. o_proj MatMul gets GQA's 9 inputs)."""
-    return [(n.name, list(n.input)) for n in model.graph.node
-            if n.op_type == "GroupQueryAttention"]
+    return [
+        (n.name, list(n.input))
+        for n in model.graph.node
+        if n.op_type == "GroupQueryAttention"
+    ]
 
 
 def _restore_gqa_nodes(model: onnx.ModelProto, backup):
@@ -861,8 +871,7 @@ def _remove_orphan_fold_total_seq_len(model: onnx.ModelProto) -> bool:
     model.graph.node.extend(kept)
     # Drop stale value_info for the removed edge
     vi_keep = [
-        v for v in model.graph.value_info
-        if v.name != TOTAL_SEQ_LEN_CONSTANT_OUT
+        v for v in model.graph.value_info if v.name != TOTAL_SEQ_LEN_CONSTANT_OUT
     ]
     if len(vi_keep) != len(model.graph.value_info):
         del model.graph.value_info[:]
@@ -899,7 +908,8 @@ class FixedCtxExtractor(SingleOpExtractor):
     def _get_variants(self):
         ml = self._max_length
         specs = expand_export_variant_specs(
-            self._seq_lens, ml, decode_mode=self._decode_mode)
+            self._seq_lens, ml, decode_mode=self._decode_mode
+        )
         return [(tag, dm) for tag, dm, _gc, _fp in specs]
 
     def _save_variants(self, model, out_dir, _prefix):
@@ -915,8 +925,10 @@ class FixedCtxExtractor(SingleOpExtractor):
             ex0 = self._ext_layout.ordered_locations[0]
             print(f"  External data: {nloc} file(s) (from source), e.g. {ex0!r}")
         else:
-            print(f"  External data: single file {DEFAULT_EXTERNAL_WEIGHTS_FILENAME!r} "
-                  f"(source has no external initializers)")
+            print(
+                f"  External data: single file {DEFAULT_EXTERNAL_WEIGHTS_FILENAME!r} "
+                f"(source has no external initializers)"
+            )
 
         orig_in = {i.name: self._save_vi_shape(i) for i in model.graph.input}
         orig_out = {o.name: self._save_vi_shape(o) for o in model.graph.output}
@@ -927,7 +939,9 @@ class FixedCtxExtractor(SingleOpExtractor):
             1 for n in model.graph.node if n.op_type == "GroupQueryAttention"
         )
         if gqa_node_count:
-            print(f"  GQA nodes: {gqa_node_count} (will patch seqlens/total per variant)")
+            print(
+                f"  GQA nodes: {gqa_node_count} (will patch seqlens/total per variant)"
+            )
 
         fold_total_template = _snapshot_fold_total_seq_len_node(model)
         _printed_reuse_hint = False
@@ -935,7 +949,8 @@ class FixedCtxExtractor(SingleOpExtractor):
         for idx, (vname, dim_map) in enumerate(self.variants):
             eff_total_llm = (
                 total_seq_len_scalar_from_dim_map(dim_map)
-                if self.model_type == "llm" else None
+                if self.model_type == "llm"
+                else None
             )
             _ensure_fold_total_seq_len_node(model, fold_total_template)
             if eff_total_llm is not None:
@@ -944,19 +959,23 @@ class FixedCtxExtractor(SingleOpExtractor):
             _restore_gqa_nodes(model, gqa_backup)
 
             if eff_total_llm is not None:
-                upsert_total_seq_len_const_initializer(
-                    model.graph, eff_total_llm)
+                upsert_total_seq_len_const_initializer(model.graph, eff_total_llm)
 
             n_gqa_inits = _patch_gqa_scalars(model, dim_map, GQA_INIT_PREFIX)
             if n_gqa_inits and idx == 0:
                 print(f"  Patched GQA initializer tensor(s): {n_gqa_inits}")
 
             if _remove_orphan_fold_total_seq_len(model) and idx == 0:
-                print(f"  Removed orphan {FOLD_TOTAL_SEQ_NODE_NAME!r} "
-                      f"(output {TOTAL_SEQ_LEN_CONSTANT_OUT!r} unused after GQA total patch)")
+                print(
+                    f"  Removed orphan {FOLD_TOTAL_SEQ_NODE_NAME!r} "
+                    f"(output {TOTAL_SEQ_LEN_CONSTANT_OUT!r} unused after GQA total patch)"
+                )
 
-            for vi in list(model.graph.input) + list(model.graph.output) \
-                    + list(model.graph.value_info):
+            for vi in (
+                list(model.graph.input)
+                + list(model.graph.output)
+                + list(model.graph.value_info)
+            ):
                 _set_vi_shape_ctx(vi, dim_map)
 
             ids_seq = 1 if self._decode_mode else int(dim_map["sequence_length"])
@@ -966,21 +985,26 @@ class FixedCtxExtractor(SingleOpExtractor):
                 attention_second=self._max_length,
             )
 
-            n_pk = _force_past_key_values_past_seq_dim(
-                model.graph, self._max_length)
+            n_pk = _force_past_key_values_past_seq_dim(model.graph, self._max_length)
             if n_pk and idx == 0:
-                print(f"  past_key_values inputs with past_sequence_length="
-                      f"{self._max_length} (max_length): {n_pk}")
+                print(
+                    f"  past_key_values inputs with past_sequence_length="
+                    f"{self._max_length} (max_length): {n_pk}"
+                )
 
             n_pr = _force_present_kv_seq_dim(model.graph, self._max_length)
             if n_pr and idx == 0:
-                print(f"  present.* outputs/value_info dim[2]="
-                      f"{self._max_length} (max_length): {n_pr} tensor(s)")
+                print(
+                    f"  present.* outputs/value_info dim[2]="
+                    f"{self._max_length} (max_length): {n_pr} tensor(s)"
+                )
 
             n_nodes, n_vi, n_in, n_init = _post_export_prune_unreachable(model)
             if idx == 0 and (n_nodes or n_vi or n_in or n_init):
-                print(f"  Pruned unreachable: {n_nodes} node(s), {n_vi} value_info, "
-                      f"{n_in} unused input(s), {n_init} unused initializer(s)")
+                print(
+                    f"  Pruned unreachable: {n_nodes} node(s), {n_vi} value_info, "
+                    f"{n_in} unused input(s), {n_init} unused initializer(s)"
+                )
 
             fname = f"{self._export_prefix}_{vname}.onnx"
             path = os.path.join(out_dir, fname)
@@ -989,10 +1013,13 @@ class FixedCtxExtractor(SingleOpExtractor):
             # graphs on idx>=1 (e.g. MatMul with 9 inputs / ORT schema errors) while
             # idx==0 loaded fine.
             graph_only = _save_onnx_external_aligned(
-                model, path, self._ext_layout, size_threshold=1024)
+                model, path, self._ext_layout, size_threshold=1024
+            )
             if graph_only and not _printed_reuse_hint:
-                print("  Reusing shared external weight file(s); later variants write "
-                      ".onnx only (no re-read / no blob rewrite).")
+                print(
+                    "  Reusing shared external weight file(s); later variants write "
+                    ".onnx only (no re-read / no blob rewrite)."
+                )
                 _printed_reuse_hint = True
             print(f"  Saved: {path}")
 
@@ -1037,7 +1064,7 @@ def parse_seq_lens(s: str | None) -> tuple[int, ...]:
 def main():
     p = argparse.ArgumentParser(
         description="Export Llama prefill/decode ONNX with fixed max_length "
-                    f"(default {16384}) and per-variant sequence lengths."
+        f"(default {16384}) and per-variant sequence lengths."
     )
     p.add_argument(
         "--model",
@@ -1074,7 +1101,7 @@ def main():
         dest="max_length",
         metavar="N",
         help="max_length (e.g. 16384): past/total sequence dims, GQA total, attention_mask "
-             "second dim. --cache-len is an alias.",
+        "second dim. --cache-len is an alias.",
     )
     p.add_argument(
         "--seq-lens",
@@ -1100,9 +1127,7 @@ def main():
             p.error(f"GenAI config template file does not exist: {cfg_tpl}")
     else:
         cfg_tpl = (
-            os.path.abspath(args.config_template)
-            if args.config_template
-            else None
+            os.path.abspath(args.config_template) if args.config_template else None
         )
 
     seq_lens = parse_seq_lens(args.seq_lens)
@@ -1114,13 +1139,19 @@ def main():
 
     print(f"=== Prefill (out={out}, prefill_*m{args.max_length}.onnx, etc.) ===")
     run_export(
-        model_abs, out, args.max_length, seq_lens,
+        model_abs,
+        out,
+        args.max_length,
+        seq_lens,
         decode_mode=False,
         export_prefix="prefill",
     )
     print(f"=== Decode (out={out}, decode_*m{args.max_length}.onnx, etc.) ===")
     run_export(
-        model_abs, out, args.max_length, seq_lens,
+        model_abs,
+        out,
+        args.max_length,
+        seq_lens,
         decode_mode=True,
         export_prefix="decode",
     )

--- a/tools/onnx-model-splitter/export_chunk_model.py
+++ b/tools/onnx-model-splitter/export_chunk_model.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
 """
 Export fixed-shape Llama prefill/decode ONNX variants.
 

--- a/tools/onnx-model-splitter/extract_submodels.py
+++ b/tools/onnx-model-splitter/extract_submodels.py
@@ -1,3 +1,7 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
 """
 Universal ONNX submodel extractor for LLMs.
 

--- a/tools/onnx-model-splitter/extract_submodels.py
+++ b/tools/onnx-model-splitter/extract_submodels.py
@@ -31,7 +31,11 @@ Usage:
 
 import os
 import re
+import json
+import shutil
 import argparse
+from typing import Optional
+
 import numpy as np
 from collections import defaultdict, Counter
 
@@ -83,6 +87,9 @@ EMBEDDING_VARIANTS = [
 
 BATCH_SIZE = 1
 TOTAL_SEQ_LEN_CONST_NAME = "total_seq_len_const"
+# Llama exporters: ``Constant fold/total_seq_len`` → ``total_seq_len_constant`` (VI name).
+FOLD_TOTAL_SEQ_NODE_NAME = "fold/total_seq_len"
+TOTAL_SEQ_LEN_CONSTANT_OUT = "total_seq_len_constant"
 
 PERF_SIGNIFICANT_OPS = {
     "Gemm", "MatMul", "MatMulNBits", "Conv", "ConvTranspose",
@@ -525,10 +532,13 @@ def get_tensor_elem_type(vi_map, name):
     return TensorProto.FLOAT16
 
 
-def _build_dim_subs(dim_map):
+def _build_dim_subs(dim_map, extra=None):
     """Build substitution dict from a variant value.
-    Accepts int (seq_len), dict (dim_map), or None (dynamic)."""
+    Accepts int (seq_len), dict (dim_map), or None (dynamic).
+    extra: optional dict of additional constant dims (from config)."""
     subs = {"batch_size": BATCH_SIZE}
+    if extra:
+        subs.update(extra)
     if dim_map is None:
         return subs
     if isinstance(dim_map, int):
@@ -541,11 +551,12 @@ def _build_dim_subs(dim_map):
     return subs
 
 
-def resolve_dim_param(param, dim_map):
+def resolve_dim_param(param, dim_map, extra=None):
     """Evaluate a symbolic dim like 'batch_size * sequence_length'.
     dim_map: int (seq_len), dict, or None (keep symbolic).
+    extra: optional dict of additional constant dims (from config).
     Returns int if fully resolved, or the original string if not."""
-    subs = _build_dim_subs(dim_map)
+    subs = _build_dim_subs(dim_map, extra=extra)
 
     has_op = any(c in param for c in ("*", "+", "-", "/", "(", ")"))
     if has_op:
@@ -569,13 +580,57 @@ def resolve_dim_param(param, dim_map):
     return param
 
 
-def shape_to_dynamic_fixed(shape, dim_map):
+def total_seq_len_scalar_from_dim_map(dim_map) -> Optional[int]:
+    """Scalar total sequence length for ``total_seq_len_const`` / fold Constant (LLM)."""
+    if dim_map is None:
+        return None
+    if isinstance(dim_map, dict):
+        if "total_sequence_length" in dim_map:
+            return int(dim_map["total_sequence_length"])
+        if "sequence_length" in dim_map:
+            return int(dim_map["sequence_length"])
+        return None
+    if isinstance(dim_map, int):
+        return int(dim_map) if dim_map else None
+    return None
+
+
+def upsert_total_seq_len_const_initializer(
+    graph: onnx.GraphProto, value: int, *, name: str = TOTAL_SEQ_LEN_CONST_NAME,
+) -> None:
+    """Replace or append int32 scalar initializer ``total_seq_len_const`` = ``value``."""
+    new_init = numpy_helper.from_array(
+        np.array(int(value), dtype=np.int32),
+        name=name,
+    )
+    for i, init in enumerate(graph.initializer):
+        if init.name == name:
+            graph.initializer[i].CopyFrom(new_init)
+            return
+    graph.initializer.append(new_init)
+
+
+def patch_fold_total_seq_len_constant_value(model: onnx.ModelProto, value: int) -> bool:
+    """Set ``Constant fold/total_seq_len`` tensor value to ``value`` (int32) if present."""
+    for n in model.graph.node:
+        if n.name != FOLD_TOTAL_SEQ_NODE_NAME or n.op_type != "Constant":
+            continue
+        for attr in n.attribute:
+            if attr.name != "value" or attr.type != onnx.AttributeProto.TENSOR:
+                continue
+            new_t = numpy_helper.from_array(np.array(int(value), dtype=np.int32))
+            attr.t.CopyFrom(new_t)
+            return True
+    return False
+
+
+def shape_to_dynamic_fixed(shape, dim_map, extra=None):
     if shape is None:
         return None
     result = []
     for d in shape:
         if isinstance(d, str):
-            result.append(resolve_dim_param(d, dim_map))
+            result.append(resolve_dim_param(d, dim_map, extra=extra))
         else:
             result.append(d)
     return result
@@ -695,6 +750,7 @@ class SingleOpExtractor:
             print(f"Shape inference warning: {e}")
 
         self.graph = self.graph_model.graph
+        self._remove_orphan_inputs()
         self.init_map = get_initializer_map(self.graph)
         self.vi_map = get_value_info_map(self.graph)
         self.opset_imports = list(self.graph_model.opset_import)
@@ -715,7 +771,52 @@ class SingleOpExtractor:
         self.full_model = None
         self.ext_data_name = self._detect_ext_data_name()
         self.model_type = self._detect_model_type()
+        self.config_dims = self._load_config_dims()
         self.variants = self._get_variants()
+
+    def _remove_orphan_inputs(self):
+        """Remove graph inputs not consumed by any node (and not initializers).
+        Also remove orphan nodes whose outputs are not consumed by any
+        downstream node or graph output."""
+        consumed_tensors = set()
+        for node in self.graph.node:
+            for inp in node.input:
+                if inp:
+                    consumed_tensors.add(inp)
+
+        init_names = {init.name for init in self.graph.initializer}
+        orphan_inputs = [inp for inp in self.graph.input
+                         if inp.name not in consumed_tensors
+                         and inp.name not in init_names]
+        if orphan_inputs:
+            names = [inp.name for inp in orphan_inputs]
+            print(f"Removing orphan inputs: {names}")
+            for inp in orphan_inputs:
+                self.graph.input.remove(inp)
+
+        output_names = {o.name for o in self.graph.output}
+        changed = True
+        removed_total = 0
+        while changed:
+            changed = False
+            all_consumed = set()
+            for node in self.graph.node:
+                for inp in node.input:
+                    if inp:
+                        all_consumed.add(inp)
+            all_consumed |= output_names
+
+            dead = [n for n in self.graph.node
+                    if all(o not in all_consumed
+                           for o in n.output if o)]
+            if dead:
+                for n in dead:
+                    self.graph.node.remove(n)
+                removed_total += len(dead)
+                changed = True
+
+        if removed_total:
+            print(f"Removing orphan nodes:  {removed_total}")
 
     def _detect_ext_data_name(self):
         """Detect the external data filename from the input model's
@@ -740,6 +841,34 @@ class SingleOpExtractor:
             return "embedding"
         return "llm"
 
+    _CONFIG_DIM_KEYS = [
+        "num_attention_heads", "num_key_value_heads",
+        "head_size", "hidden_size",
+    ]
+
+    def _load_config_dims(self):
+        """Read genai_config.json next to the model and extract dimension
+        constants (num_attention_heads, num_key_value_heads, etc.)."""
+        model_dir = os.path.dirname(self.model_path)
+        cfg_path = os.path.join(model_dir, "genai_config.json")
+        if not os.path.isfile(cfg_path):
+            return {}
+        try:
+            with open(cfg_path, "r", encoding="utf-8") as f:
+                cfg = json.load(f)
+        except Exception:
+            return {}
+
+        decoder = cfg.get("model", {}).get("decoder", {})
+        dims = {}
+        for key in self._CONFIG_DIM_KEYS:
+            val = decoder.get(key)
+            if isinstance(val, int):
+                dims[key] = val
+        if dims:
+            print(f"Config dims:       {dims}")
+        return dims
+
     def _get_variants(self):
         if self.model_type == "vision":
             return VISION_VARIANTS
@@ -762,6 +891,10 @@ class SingleOpExtractor:
               f"(~{total / (1024 ** 3):.1f} GB)...")
         self.full_model = onnx.load(self.model_path)
         print("Full model loaded.")
+        saved_graph = self.graph
+        self.graph = self.full_model.graph
+        self._remove_orphan_inputs()
+        self.graph = saved_graph
         self.full_init_map = get_initializer_map(self.full_model.graph)
 
     def _get_initializer(self, name):
@@ -937,7 +1070,8 @@ class SingleOpExtractor:
                         node.input[list(clean_node.input).index(inp)])
                 if shape is None:
                     shape = [1]
-                adj = shape_to_dynamic_fixed(shape, dim_map)
+                adj = shape_to_dynamic_fixed(shape, dim_map,
+                                             extra=self.config_dims)
                 model_inputs.append(make_tensor_vi(inp, elem_type, adj))
 
             model_outputs = []
@@ -966,7 +1100,8 @@ class SingleOpExtractor:
                 if not out_vi.type.tensor_type.shape.dim:
                     shape, etype = self._resolve_input_info(out_vi.name)
                     if shape:
-                        adj = shape_to_dynamic_fixed(shape, dim_map)
+                        adj = shape_to_dynamic_fixed(shape, dim_map,
+                                                     extra=self.config_dims)
                         for d in adj:
                             dp = out_vi.type.tensor_type.shape.dim.add()
                             if isinstance(d, str):
@@ -1049,6 +1184,23 @@ class SingleOpExtractor:
             n += 1
         return f"{base}_{n}"
 
+    def _dedup_non_layer(self, non_layer_nodes):
+        """Deduplicate non-layer nodes the same way layer ops are deduped:
+        simple ops keep one per op_type, perf-significant ops keep one per
+        full signature (weight shape + input shape)."""
+        groups = defaultdict(list)
+        for node in non_layer_nodes:
+            if node.op_type in PERF_SIGNIFICANT_OPS:
+                wsig = get_weight_signature(node, self.init_map)
+                isig = get_input_shape_signature(node, self.vi_map)
+                nout = len([o for o in node.output if o])
+                key = (node.op_type, wsig, isig, nout)
+            else:
+                key = (node.op_type,)
+            groups[key].append(node)
+        return [self._pick_fp16_representative(vs)
+                for vs in groups.values()]
+
     def extract_all_single_ops(self):
         unique, non_layer = self._identify_unique_ops()
 
@@ -1067,10 +1219,12 @@ class SingleOpExtractor:
             self._extract_single_op(node, prefix, is_gqa=is_gqa)
 
         if non_layer:
+            deduped = self._dedup_non_layer(non_layer)
             print("\n" + "=" * 60)
-            print("Extracting non-layer ops...")
+            print(f"Extracting non-layer ops "
+                  f"({len(non_layer)} -> {len(deduped)} after dedup)...")
             print("=" * 60)
-            for node in non_layer:
+            for node in deduped:
                 prefix = self._get_name_prefix(node)
                 prefix = self._unique_prefix(prefix, used)
                 used.add(prefix)
@@ -1174,7 +1328,8 @@ class SingleOpExtractor:
                 shape = [1]
             model_inputs.append(
                 make_tensor_vi(inp, elem_type,
-                               shape_to_dynamic_fixed(shape, None)))
+                               shape_to_dynamic_fixed(
+                                   shape, None, extra=self.config_dims)))
 
         model_outputs = []
         for out in graph_output_names:
@@ -1183,7 +1338,8 @@ class SingleOpExtractor:
                 shape = [1]
             model_outputs.append(
                 make_tensor_vi(out, elem_type,
-                               shape_to_dynamic_fixed(shape, None)))
+                               shape_to_dynamic_fixed(
+                                   shape, None, extra=self.config_dims)))
 
         out_set = set(graph_output_names)
         in_set = set(graph_input_names)
@@ -1196,7 +1352,9 @@ class SingleOpExtractor:
                 if shape:
                     value_infos.append(
                         make_tensor_vi(o, elem_type,
-                                       shape_to_dynamic_fixed(shape, None)))
+                                       shape_to_dynamic_fixed(
+                                           shape, None,
+                                           extra=self.config_dims)))
 
         model = build_multi_node_model(
             nodes_copy, model_inputs, model_outputs,
@@ -1266,10 +1424,12 @@ class SingleOpExtractor:
             blocks.append((block_ends[k - 1] + 1, block_ends[k]))
         return blocks
 
-    def _collect_cast_deps(self, core_indices):
+    def _collect_cast_deps(self, core_indices, forbidden_inputs=None):
         """Given a set of node indices, expand to include Cast nodes that
-        the core nodes depend on (input Casts) or that consume their
-        outputs then feed back into the core (output Casts)."""
+        the core nodes depend on.  Skip Cast nodes whose inputs come from
+        forbidden_inputs (e.g. outputs of removed middle blocks)."""
+        if forbidden_inputs is None:
+            forbidden_inputs = frozenset()
         nodes = self.graph.node
         output_to_idx = {}
         for i, n in enumerate(nodes):
@@ -1293,11 +1453,12 @@ class SingleOpExtractor:
                 src = output_to_idx.get(inp)
                 if src is not None and src not in required:
                     if nodes[src].op_type == "Cast":
+                        cast_inputs = {ci for ci in nodes[src].input if ci}
+                        if cast_inputs & forbidden_inputs:
+                            continue
                         required.add(src)
                         queue.append(src)
         return sorted(required)
-
-    _LN_CAST_RE = re.compile(r"node_layer_norm.*cast", re.IGNORECASE)
 
     def _extract_vision_single_block(self):
         """Extract pre-block + one ViT block + post-block as single_layer
@@ -1321,13 +1482,19 @@ class SingleOpExtractor:
         pre_block = list(range(0, b0_start))
         block0_indices = list(range(b0_start, b0_end + 1))
 
-        post_block = []
-        for i in range(last_end + 1, len(nodes)):
-            if not self._LN_CAST_RE.search(nodes[i].name):
-                post_block.append(i)
+        post_block = [i for i in range(last_end + 1, len(nodes))
+                      if nodes[i].op_type != "Cast"]
+
+        middle_outputs = set()
+        for k in range(1, n_blocks - 1):
+            for i in range(blocks[k][0], blocks[k][1] + 1):
+                for o in nodes[i].output:
+                    if o:
+                        middle_outputs.add(o)
 
         core = pre_block + block0_indices + post_block
-        all_indices = self._collect_cast_deps(core)
+        all_indices = self._collect_cast_deps(core,
+                                              forbidden_inputs=middle_outputs)
 
         block0_output_names = set()
         for i in block0_indices:
@@ -1408,7 +1575,8 @@ class SingleOpExtractor:
             shape, elem_type = self._resolve_input_info(inp_name)
             if shape is None:
                 shape = [1]
-            adj = shape_to_dynamic_fixed(shape, None)
+            adj = shape_to_dynamic_fixed(shape, None,
+                                         extra=self.config_dims)
             model_inputs.append(make_tensor_vi(inp_name, elem_type, adj))
 
         model_outputs = []
@@ -1416,7 +1584,8 @@ class SingleOpExtractor:
             shape, elem_type = self._resolve_input_info(out_name)
             if shape is None:
                 shape = [1]
-            adj = shape_to_dynamic_fixed(shape, None)
+            adj = shape_to_dynamic_fixed(shape, None,
+                                         extra=self.config_dims)
             model_outputs.append(make_tensor_vi(out_name, elem_type, adj))
 
         small_inits = []
@@ -1448,7 +1617,9 @@ class SingleOpExtractor:
                 if shape:
                     value_infos.append(
                         make_tensor_vi(o, elem_type,
-                                       shape_to_dynamic_fixed(shape, None)))
+                                       shape_to_dynamic_fixed(
+                                           shape, None,
+                                           extra=self.config_dims)))
 
         model = build_multi_node_model(
             nodes_copy, model_inputs, model_outputs,
@@ -1480,8 +1651,11 @@ class SingleOpExtractor:
         print("Extracting full model...")
         print("=" * 60)
 
-        self._load_full_model()
-        model = self.full_model
+        model = onnx.load(self.model_path, load_external_data=False)
+        saved_graph = self.graph
+        self.graph = model.graph
+        self._remove_orphan_inputs()
+        self.graph = saved_graph
         a = self.analyzer
 
         deleted_tensors = set()
@@ -1518,7 +1692,7 @@ class SingleOpExtractor:
             for idx in reversed(orphaned_idx):
                 del model.graph.initializer[idx]
 
-        self._save_variants(model, self.full_model_dir, "full_model")
+        self._save_full_model_variants(model)
 
     # ════════════════════ variant saving ════════════════════
 
@@ -1529,6 +1703,90 @@ class SingleOpExtractor:
         "eliminate_deadend",
         "eliminate_unused_initializer",
     ]
+
+    def _full_model_variant_onnx_basename(self, vname: str) -> str:
+        """Basename under ``full_model/`` for the layered-graph export path."""
+        return f"full_model_{vname}.onnx"
+
+    def _save_full_model_variants(self, model):
+        """Save full_model variants reusing the original external data file.
+
+        The model must be loaded with load_external_data=False so that
+        initializer tensors still carry their original external_data
+        references (offset, length, location).  We copy the original
+        .data file once and only serialise the lightweight .onnx protos.
+        """
+        out_dir = self.full_model_dir
+        os.makedirs(out_dir, exist_ok=True)
+        data_name = self.ext_data_name
+
+        src_data = os.path.join(os.path.dirname(self.model_path), data_name)
+        dst_data = os.path.join(out_dir, data_name)
+        if os.path.isfile(src_data):
+            if os.path.abspath(src_data) != os.path.abspath(dst_data):
+                print(f"  Copying external data: {data_name} "
+                      f"({os.path.getsize(src_data) / (1024**3):.2f} GB)")
+                shutil.copy2(src_data, dst_data)
+            else:
+                print(f"  External data already in place: {data_name}")
+        else:
+            print(f"  WARNING: external data file not found: {src_data}")
+
+        orig_in = {i.name: self._save_vi_shape(i) for i in model.graph.input}
+        orig_out = {o.name: self._save_vi_shape(o)
+                    for o in model.graph.output}
+        orig_vi = {v.name: self._save_vi_shape(v)
+                   for v in model.graph.value_info}
+
+        has_tsl = any(
+            inp == TOTAL_SEQ_LEN_CONST_NAME
+            for node in model.graph.node for inp in node.input
+        ) and self.model_type == "llm"
+
+        for idx, (vname, dim_map) in enumerate(self.variants):
+            llm_total = (
+                total_seq_len_scalar_from_dim_map(dim_map)
+                if self.model_type == "llm" else None
+            )
+
+            if has_tsl:
+                if dim_map is None:
+                    for node in model.graph.node:
+                        for j, inp in enumerate(node.input):
+                            if inp == TOTAL_SEQ_LEN_CONST_NAME:
+                                node.input[j] = "total_sequence_length"
+                    tsl_vi = make_tensor_vi(
+                        "total_sequence_length", TensorProto.INT32, [1])
+                    model.graph.input.append(tsl_vi)
+                else:
+                    for node in model.graph.node:
+                        for j, inp in enumerate(node.input):
+                            if inp == "total_sequence_length":
+                                node.input[j] = TOTAL_SEQ_LEN_CONST_NAME
+                    to_rm = [i for i, vi in enumerate(model.graph.input)
+                             if vi.name == "total_sequence_length"]
+                    for i in reversed(to_rm):
+                        del model.graph.input[i]
+
+            if llm_total is not None and (not has_tsl or dim_map is not None):
+                patch_fold_total_seq_len_constant_value(model, llm_total)
+                upsert_total_seq_len_const_initializer(model.graph, llm_total)
+
+            for vi in list(model.graph.input) + list(model.graph.output) \
+                    + list(model.graph.value_info):
+                self._set_vi_shape(vi, dim_map, extra=self.config_dims)
+
+            path = os.path.join(out_dir, self._full_model_variant_onnx_basename(vname))
+            with open(path, "wb") as f:
+                f.write(model.SerializeToString())
+            print(f"  Saved: {path}")
+
+            for vi in model.graph.input:
+                self._restore_vi_shape(vi, orig_in.get(vi.name))
+            for vi in model.graph.output:
+                self._restore_vi_shape(vi, orig_out.get(vi.name))
+            for vi in model.graph.value_info:
+                self._restore_vi_shape(vi, orig_vi.get(vi.name))
 
     def _save_variants(self, model, out_dir, prefix):
         """Save variants with shared external data file."""
@@ -1546,27 +1804,18 @@ class SingleOpExtractor:
 
         for idx, (vname, dim_map) in enumerate(self.variants):
             if self.model_type == "llm":
-                eff = dim_map if isinstance(dim_map, int) and dim_map else 128
-                existing_idx = None
-                for i, init in enumerate(model.graph.initializer):
-                    if init.name == TOTAL_SEQ_LEN_CONST_NAME:
-                        existing_idx = i
-                        break
-                t = numpy_helper.from_array(
-                    np.array(eff, dtype=np.int32),
-                    name=TOTAL_SEQ_LEN_CONST_NAME)
-                if existing_idx is not None:
-                    model.graph.initializer[existing_idx].CopyFrom(t)
-                else:
-                    model.graph.initializer.append(t)
+                llm_total = total_seq_len_scalar_from_dim_map(dim_map)
+                if llm_total is not None:
+                    patch_fold_total_seq_len_constant_value(model, llm_total)
+                    upsert_total_seq_len_const_initializer(model.graph, llm_total)
 
             for vi in list(model.graph.input) + list(model.graph.output) \
                     + list(model.graph.value_info):
-                self._set_vi_shape(vi, dim_map)
+                self._set_vi_shape(vi, dim_map, extra=self.config_dims)
 
             save_model = model
-            if dim_map is not None and _HAS_OPTIMIZER:
-                save_model = self._fold_shapes(model)
+            if dim_map is not None:
+                save_model = self._reinfer_and_fold(model)
 
             path = os.path.join(out_dir, f"{prefix}_{vname}.onnx")
             if idx == 0:
@@ -1588,13 +1837,28 @@ class SingleOpExtractor:
                 self._restore_vi_shape(vi, orig_vi.get(vi.name))
 
     @classmethod
-    def _fold_shapes(cls, model):
-        """Run onnxoptimizer to eliminate Shape/Gather nodes on fixed-shape
-        variants.  Operates on a copy so the original model is not mutated."""
-        before = len(model.graph.node)
+    def _reinfer_and_fold(cls, model):
+        """Re-run shape inference on a fixed-shape variant to resolve
+        intermediate symbolic dims (u1, u2, ...), then optionally run
+        onnxoptimizer to eliminate Shape/Gather nodes."""
+        m = onnx.ModelProto()
+        m.CopyFrom(model)
+
         try:
-            opt = onnxoptimizer.optimize(model, cls._OPT_PASSES)
-            cls._fix_scalar_to_1d(opt)
+            m = onnx.shape_inference.infer_shapes(m)
+        except Exception:
+            del m.graph.value_info[:]
+            try:
+                m = onnx.shape_inference.infer_shapes(m)
+            except Exception as e:
+                print(f"    re-infer skipped: {e}")
+
+        if not _HAS_OPTIMIZER:
+            return m
+
+        before = len(m.graph.node)
+        try:
+            opt = onnxoptimizer.optimize(m, cls._OPT_PASSES)
             after = len(opt.graph.node)
             if after < before:
                 print(f"    shape-fold: {before} -> {after} nodes "
@@ -1602,80 +1866,7 @@ class SingleOpExtractor:
             return opt
         except Exception as e:
             print(f"    shape-fold skipped: {e}")
-            return model
-
-    @staticmethod
-    def _fix_scalar_to_1d(model):
-        """Fix 0-D scalar initializers/constants that should be 1-D int64[1].
-
-        onnxoptimizer's eliminate_shape_gather folds Shape→Gather into scalar
-        constants, but the original tensors were int64[1].  Scalar propagation
-        through element-wise ops (Mul, Add, Sub, …) can produce scalar outputs
-        that eventually feed into Concat, which requires >=1-D inputs.
-
-        Strategy: find all Concat inputs, trace upstream through element-wise
-        ops, and reshape every scalar initializer/Constant in those chains to
-        [1].
-        """
-        init_map = {init.name: init for init in model.graph.initializer}
-        out_to_node = {}
-        for node in model.graph.node:
-            for o in node.output:
-                if o:
-                    out_to_node[o] = node
-
-        needs_1d = set()
-        elementwise_ops = {
-            "Add", "Sub", "Mul", "Div", "Cast", "Neg", "Abs",
-            "Floor", "Ceil", "Unsqueeze", "Squeeze",
-        }
-        queue = []
-        for node in model.graph.node:
-            if node.op_type == "Concat":
-                for inp in node.input:
-                    if inp and inp not in needs_1d:
-                        needs_1d.add(inp)
-                        queue.append(inp)
-
-        while queue:
-            tensor_name = queue.pop()
-            producer = out_to_node.get(tensor_name)
-            if producer is None:
-                continue
-            if producer.op_type in elementwise_ops:
-                for inp in producer.input:
-                    if inp and inp not in needs_1d:
-                        needs_1d.add(inp)
-                        queue.append(inp)
-
-        fixed = 0
-        for name in needs_1d:
-            init = init_map.get(name)
-            if init is None:
-                continue
-            if len(init.dims) == 0:
-                arr = numpy_helper.to_array(init)
-                new_t = numpy_helper.from_array(arr.reshape(1), name=name)
-                init.CopyFrom(new_t)
-                fixed += 1
-
-        for node in model.graph.node:
-            if node.op_type != "Constant":
-                continue
-            out = node.output[0] if node.output else ""
-            if out not in needs_1d:
-                continue
-            for attr in node.attribute:
-                if attr.name == "value" \
-                        and attr.type == onnx.AttributeProto.TENSOR:
-                    if len(attr.t.dims) == 0:
-                        arr = numpy_helper.to_array(attr.t)
-                        new_t = numpy_helper.from_array(arr.reshape(1))
-                        attr.t.CopyFrom(new_t)
-                        fixed += 1
-
-        if fixed:
-            print(f"    scalar->1d fix: {fixed} tensor(s)")
+            return m
 
     # ── Shape helpers ──
 
@@ -1700,12 +1891,12 @@ class SingleOpExtractor:
                 dim.dim_value = val
 
     @staticmethod
-    def _set_vi_shape(vi, dim_map):
+    def _set_vi_shape(vi, dim_map, extra=None):
         if not vi.type.tensor_type.shape:
             return
         for dim in vi.type.tensor_type.shape.dim:
             if dim.dim_param:
-                val = resolve_dim_param(dim.dim_param, dim_map)
+                val = resolve_dim_param(dim.dim_param, dim_map, extra=extra)
                 if isinstance(val, int):
                     dim.ClearField("dim_param")
                     dim.dim_value = val

--- a/tools/onnx-model-splitter/extract_submodels.py
+++ b/tools/onnx-model-splitter/extract_submodels.py
@@ -48,6 +48,7 @@ from onnx import helper, TensorProto, numpy_helper
 
 try:
     import onnxoptimizer
+
     _HAS_OPTIMIZER = True
 except ImportError:
     _HAS_OPTIMIZER = False
@@ -96,12 +97,23 @@ FOLD_TOTAL_SEQ_NODE_NAME = "fold/total_seq_len"
 TOTAL_SEQ_LEN_CONSTANT_OUT = "total_seq_len_constant"
 
 PERF_SIGNIFICANT_OPS = {
-    "Gemm", "MatMul", "MatMulNBits", "Conv", "ConvTranspose",
-    "GroupQueryAttention", "LinearAttention", "QMoE",
-    "CausalConvWithState", "RotaryEmbedding",
-    "LayerNormalization", "SimplifiedLayerNormalization",
-    "SkipSimplifiedLayerNormalization", "BatchNormalization",
-    "LSTM", "GRU", "Loop",
+    "Gemm",
+    "MatMul",
+    "MatMulNBits",
+    "Conv",
+    "ConvTranspose",
+    "GroupQueryAttention",
+    "LinearAttention",
+    "QMoE",
+    "CausalConvWithState",
+    "RotaryEmbedding",
+    "LayerNormalization",
+    "SimplifiedLayerNormalization",
+    "SkipSimplifiedLayerNormalization",
+    "BatchNormalization",
+    "LSTM",
+    "GRU",
+    "Loop",
 }
 
 
@@ -203,17 +215,21 @@ class GraphAnalyzer:
         typical_count = Counter(layer_counts.values()).most_common(1)[0][0]
         threshold = max(typical_count * 0.4, 5)
         real_layers = sorted(
-            idx for idx, cnt in layer_counts.items() if cnt >= threshold)
+            idx for idx, cnt in layer_counts.items() if cnt >= threshold
+        )
         self.num_layers = len(real_layers)
         self.layer_indices = set(real_layers)
 
         layer_groups = defaultdict(list)
         for idx in real_layers:
             layer_groups[layer_counts[idx]].append(idx)
-        desc = ", ".join(f"{len(idxs)}x{cnt}-node" for cnt, idxs
-                         in sorted(layer_groups.items()))
-        print(f"  Layers: {self.num_layers} total "
-              f"(index {real_layers[0]}..{real_layers[-1]}, {desc})")
+        desc = ", ".join(
+            f"{len(idxs)}x{cnt}-node" for cnt, idxs in sorted(layer_groups.items())
+        )
+        print(
+            f"  Layers: {self.num_layers} total "
+            f"(index {real_layers[0]}..{real_layers[-1]}, {desc})"
+        )
 
     # ── Op type detection ──
 
@@ -225,7 +241,10 @@ class GraphAnalyzer:
             self.shape_diff_ops.add("MatMulNBits")
         else:
             for node in self.graph.node:
-                if node.op_type == "MatMul" and self.get_layer_index(node.name) is not None:
+                if (
+                    node.op_type == "MatMul"
+                    and self.get_layer_index(node.name) is not None
+                ):
                     if any(inp in self.init_names for inp in node.input):
                         self.shape_diff_ops.add("MatMul")
                         break
@@ -242,8 +261,11 @@ class GraphAnalyzer:
         chain = []
         current_tensor = start_tensor
         for op in expected_ops:
-            consumers = [n for n in self.input_to_nodes.get(current_tensor, [])
-                         if n.op_type == op]
+            consumers = [
+                n
+                for n in self.input_to_nodes.get(current_tensor, [])
+                if n.op_type == op
+            ]
             if len(consumers) != 1:
                 break
             node = consumers[0]
@@ -257,8 +279,11 @@ class GraphAnalyzer:
         """attention_mask -> Shape -> Gather -> Cast"""
         if "attention_mask" not in self.graph_input_names:
             return
-        shape_nodes = [n for n in self.input_to_nodes.get("attention_mask", [])
-                       if n.op_type == "Shape"]
+        shape_nodes = [
+            n
+            for n in self.input_to_nodes.get("attention_mask", [])
+            if n.op_type == "Shape"
+        ]
         for sn in shape_nodes:
             out = sn.output[0] if sn.output else None
             if not out:
@@ -276,14 +301,14 @@ class GraphAnalyzer:
         """input_ids -> Shape -> Gather -> Unsqueeze -> Concat -> Reshape"""
         if "input_ids" not in self.graph_input_names:
             return
-        shape_nodes = [n for n in self.input_to_nodes.get("input_ids", [])
-                       if n.op_type == "Shape"]
+        shape_nodes = [
+            n for n in self.input_to_nodes.get("input_ids", []) if n.op_type == "Shape"
+        ]
         for sn in shape_nodes:
             out = sn.output[0] if sn.output else None
             if not out:
                 continue
-            tail = self._follow_chain(
-                out, ["Gather", "Unsqueeze", "Concat", "Reshape"])
+            tail = self._follow_chain(out, ["Gather", "Unsqueeze", "Concat", "Reshape"])
             if len(tail) == 4:
                 chain = [sn] + tail
                 self.reshape_chain_output = chain[-1].output[0]
@@ -307,8 +332,7 @@ class GraphAnalyzer:
             if name in self.graph_input_names:
                 continue
             consumers = self.input_to_nodes.get(name, [])
-            non_deleted = [n for n in consumers
-                           if n.name not in self.nodes_to_delete]
+            non_deleted = [n for n in consumers if n.name not in self.nodes_to_delete]
             if not non_deleted and name in self.output_to_node:
                 producer = self.output_to_node[name]
                 if producer.op_type == "Constant":
@@ -342,8 +366,10 @@ class GraphAnalyzer:
     def _discover_lm_head(self):
         if "logits" in self.output_to_node:
             self.lm_head_node = self.output_to_node["logits"]
-            print(f"  LM head:         {self.lm_head_node.name} "
-                  f"({self.lm_head_node.op_type})")
+            print(
+                f"  LM head:         {self.lm_head_node.name} "
+                f"({self.lm_head_node.op_type})"
+            )
             return
         for node in reversed(list(self.graph.node)):
             if node.op_type in ("MatMul", "MatMulNBits"):
@@ -357,8 +383,11 @@ class GraphAnalyzer:
         """Trace backward from lm_head to find the final normalization."""
         if self.lm_head_node is None:
             return
-        norm_ops = {"SkipSimplifiedLayerNormalization",
-                    "SimplifiedLayerNormalization", "LayerNormalization"}
+        norm_ops = {
+            "SkipSimplifiedLayerNormalization",
+            "SimplifiedLayerNormalization",
+            "LayerNormalization",
+        }
         for inp in self.lm_head_node.input:
             if inp in self.init_names:
                 continue
@@ -418,8 +447,7 @@ class GraphAnalyzer:
                 if inp:
                     queue.append(inp)
 
-        self.pre_layer_nodes = [
-            n for n in self.graph.node if n.name in found_names]
+        self.pre_layer_nodes = [n for n in self.graph.node if n.name in found_names]
         print(f"  Pre-layer nodes: {len(self.pre_layer_nodes)}")
         for n in self.pre_layer_nodes:
             print(f"    {n.op_type:35s} {n.name}")
@@ -475,8 +503,12 @@ class GraphAnalyzer:
                 if inp in rewire:
                     continue
                 m = re.search(r"(layers?[./])(\d+)([/.])", inp)
-                if m and int(m.group(2)) not in (0,) and int(m.group(2)) in self.layer_indices:
-                    new_name = inp[:m.start(2)] + "0" + inp[m.end(2):]
+                if (
+                    m
+                    and int(m.group(2)) not in (0,)
+                    and int(m.group(2)) in self.layer_indices
+                ):
+                    new_name = inp[: m.start(2)] + "0" + inp[m.end(2) :]
                     rewire[inp] = new_name
         if rewire:
             print(f"  Final-norm rewire: {len(rewire)} tensor(s)")
@@ -495,7 +527,7 @@ class GraphAnalyzer:
         return int(m.group(1)) if m else None
 
     def _print_summary(self):
-        print(f"\n  === Discovery Summary ===")
+        print("\n  === Discovery Summary ===")
         print(f"  Layers:         {self.num_layers}")
         print(f"  Nodes to delete:{len(self.nodes_to_delete):>3d}")
         print(f"  Rewire map:     {self.rewire_map}")
@@ -525,8 +557,10 @@ def get_tensor_shape(vi_map, name):
     if name in vi_map:
         vi = vi_map[name]
         if vi.type.tensor_type.shape:
-            return [d.dim_param if d.dim_param else d.dim_value
-                    for d in vi.type.tensor_type.shape.dim]
+            return [
+                d.dim_param if d.dim_param else d.dim_value
+                for d in vi.type.tensor_type.shape.dim
+            ]
     return None
 
 
@@ -600,7 +634,10 @@ def total_seq_len_scalar_from_dim_map(dim_map) -> Optional[int]:
 
 
 def upsert_total_seq_len_const_initializer(
-    graph: onnx.GraphProto, value: int, *, name: str = TOTAL_SEQ_LEN_CONST_NAME,
+    graph: onnx.GraphProto,
+    value: int,
+    *,
+    name: str = TOTAL_SEQ_LEN_CONST_NAME,
 ) -> None:
     """Replace or append int32 scalar initializer ``total_seq_len_const`` = ``value``."""
     new_init = numpy_helper.from_array(
@@ -655,11 +692,17 @@ def make_tensor_vi(name, elem_type, shape):
     return vi
 
 
-def build_single_op_model(node, inputs, outputs, initializers,
-                          opsets, ir_version=7, value_infos=None):
+def build_single_op_model(
+    node, inputs, outputs, initializers, opsets, ir_version=7, value_infos=None
+):
     graph = helper.make_graph(
-        [node], "single_op_graph", inputs, outputs,
-        initializer=initializers, value_info=value_infos or [])
+        [node],
+        "single_op_graph",
+        inputs,
+        outputs,
+        initializer=initializers,
+        value_info=value_infos or [],
+    )
     model = helper.make_model(graph)
     model.ir_version = ir_version
     del model.opset_import[:]
@@ -670,11 +713,17 @@ def build_single_op_model(node, inputs, outputs, initializers,
     return model
 
 
-def build_multi_node_model(nodes, inputs, outputs, initializers,
-                           opsets, ir_version=7, value_infos=None):
+def build_multi_node_model(
+    nodes, inputs, outputs, initializers, opsets, ir_version=7, value_infos=None
+):
     graph = helper.make_graph(
-        nodes, "subgraph", inputs, outputs,
-        initializer=initializers, value_info=value_infos or [])
+        nodes,
+        "subgraph",
+        inputs,
+        outputs,
+        initializer=initializers,
+        value_info=value_infos or [],
+    )
     model = helper.make_model(graph)
     model.ir_version = ir_version
     del model.opset_import[:]
@@ -688,10 +737,18 @@ def build_multi_node_model(nodes, inputs, outputs, initializers,
 PROTOBUF_LIMIT = 1_800_000_000  # ~1.8 GB, safely below protobuf 2GB cap
 
 DTYPE_BYTE_SIZE = {
-    TensorProto.FLOAT: 4, TensorProto.UINT8: 1, TensorProto.INT8: 1,
-    TensorProto.UINT16: 2, TensorProto.INT16: 2, TensorProto.INT32: 4,
-    TensorProto.INT64: 8, TensorProto.BOOL: 1, TensorProto.FLOAT16: 2,
-    TensorProto.DOUBLE: 8, TensorProto.UINT32: 4, TensorProto.UINT64: 8,
+    TensorProto.FLOAT: 4,
+    TensorProto.UINT8: 1,
+    TensorProto.INT8: 1,
+    TensorProto.UINT16: 2,
+    TensorProto.INT16: 2,
+    TensorProto.INT32: 4,
+    TensorProto.INT64: 8,
+    TensorProto.BOOL: 1,
+    TensorProto.FLOAT16: 2,
+    TensorProto.DOUBLE: 8,
+    TensorProto.UINT32: 4,
+    TensorProto.UINT64: 8,
     TensorProto.BFLOAT16: 2,
 }
 
@@ -715,8 +772,7 @@ def save_model(model, path):
 
 
 def get_weight_signature(node, init_map):
-    return tuple(
-        tuple(init_map[inp].dims) for inp in node.input if inp in init_map)
+    return tuple(tuple(init_map[inp].dims) for inp in node.input if inp in init_map)
 
 
 def get_input_shape_signature(node, vi_map):
@@ -733,7 +789,6 @@ def get_input_shape_signature(node, vi_map):
 
 
 class SingleOpExtractor:
-
     def __init__(self, model_path, output_dir=None):
         self.model_path = model_path
         self.base_dir = output_dir or os.path.dirname(model_path)
@@ -747,8 +802,7 @@ class SingleOpExtractor:
 
         print("Running shape inference...")
         try:
-            self.graph_model = onnx.shape_inference.infer_shapes(
-                self.graph_model)
+            self.graph_model = onnx.shape_inference.infer_shapes(self.graph_model)
             print("Shape inference succeeded.")
         except Exception as e:
             print(f"Shape inference warning: {e}")
@@ -763,8 +817,7 @@ class SingleOpExtractor:
         for node in self.graph.node:
             if node.op_type == "Constant":
                 for attr in node.attribute:
-                    if attr.name == "value" \
-                            and attr.type == onnx.AttributeProto.TENSOR:
+                    if attr.name == "value" and attr.type == onnx.AttributeProto.TENSOR:
                         for out in node.output:
                             if out:
                                 self.constant_outputs[out] = attr.t
@@ -789,9 +842,11 @@ class SingleOpExtractor:
                     consumed_tensors.add(inp)
 
         init_names = {init.name for init in self.graph.initializer}
-        orphan_inputs = [inp for inp in self.graph.input
-                         if inp.name not in consumed_tensors
-                         and inp.name not in init_names]
+        orphan_inputs = [
+            inp
+            for inp in self.graph.input
+            if inp.name not in consumed_tensors and inp.name not in init_names
+        ]
         if orphan_inputs:
             names = [inp.name for inp in orphan_inputs]
             print(f"Removing orphan inputs: {names}")
@@ -810,9 +865,11 @@ class SingleOpExtractor:
                         all_consumed.add(inp)
             all_consumed |= output_names
 
-            dead = [n for n in self.graph.node
-                    if all(o not in all_consumed
-                           for o in n.output if o)]
+            dead = [
+                n
+                for n in self.graph.node
+                if all(o not in all_consumed for o in n.output if o)
+            ]
             if dead:
                 for n in dead:
                     self.graph.node.remove(n)
@@ -838,16 +895,18 @@ class SingleOpExtractor:
     def _detect_model_type(self):
         input_names = {inp.name for inp in self.graph.input}
         if "pixel_values" in input_names:
-            print(f"Model type: vision")
+            print("Model type: vision")
             return "vision"
         if "image_features" in input_names and "input_ids" in input_names:
-            print(f"Model type: embedding")
+            print("Model type: embedding")
             return "embedding"
         return "llm"
 
     _CONFIG_DIM_KEYS = [
-        "num_attention_heads", "num_key_value_heads",
-        "head_size", "hidden_size",
+        "num_attention_heads",
+        "num_key_value_heads",
+        "head_size",
+        "hidden_size",
     ]
 
     def _load_config_dims(self):
@@ -888,11 +947,9 @@ class SingleOpExtractor:
         model_dir = os.path.dirname(self.model_path)
         total = os.path.getsize(self.model_path)
         for f in os.listdir(model_dir):
-            if f.endswith((".data", ".bin")) and f != os.path.basename(
-                    self.model_path):
+            if f.endswith((".data", ".bin")) and f != os.path.basename(self.model_path):
                 total += os.path.getsize(os.path.join(model_dir, f))
-        print(f"Loading full model with weights "
-              f"(~{total / (1024 ** 3):.1f} GB)...")
+        print(f"Loading full model with weights (~{total / (1024**3):.1f} GB)...")
         self.full_model = onnx.load(self.model_path)
         print("Full model loaded.")
         saved_graph = self.graph
@@ -973,8 +1030,7 @@ class SingleOpExtractor:
             else:
                 non_layer_nodes.append(node)
 
-        unique = {k: self._pick_fp16_representative(vs)
-                  for k, vs in layer_ops.items()}
+        unique = {k: self._pick_fp16_representative(vs) for k, vs in layer_ops.items()}
 
         mode_label = "Unique ops (flat)" if flat_mode else "Unique layer ops"
         print(f"\n{mode_label}: {len(unique)}")
@@ -989,8 +1045,9 @@ class SingleOpExtractor:
     def _get_name_prefix(self, node, key=None):
         """Generate semantic name for the op folder."""
         op_type = node.op_type
-        need_suffix = (op_type in self.analyzer.shape_diff_ops
-                       or not self.analyzer.has_layers)
+        need_suffix = (
+            op_type in self.analyzer.shape_diff_ops or not self.analyzer.has_layers
+        )
         if not need_suffix:
             return op_type
         if not node.name:
@@ -1071,11 +1128,11 @@ class SingleOpExtractor:
                 shape, elem_type = self._resolve_input_info(inp)
                 if shape is None:
                     shape, elem_type = self._resolve_input_info(
-                        node.input[list(clean_node.input).index(inp)])
+                        node.input[list(clean_node.input).index(inp)]
+                    )
                 if shape is None:
                     shape = [1]
-                adj = shape_to_dynamic_fixed(shape, dim_map,
-                                             extra=self.config_dims)
+                adj = shape_to_dynamic_fixed(shape, dim_map, extra=self.config_dims)
                 model_inputs.append(make_tensor_vi(inp, elem_type, adj))
 
             model_outputs = []
@@ -1088,12 +1145,17 @@ class SingleOpExtractor:
 
             if is_gqa:
                 initializers.extend(
-                    self._make_gqa_constant_inputs(actual_node, dim_map))
+                    self._make_gqa_constant_inputs(actual_node, dim_map)
+                )
 
             model = build_single_op_model(
-                actual_node, model_inputs, model_outputs,
-                initializers, self.opset_imports,
-                ir_version=self.ir_version)
+                actual_node,
+                model_inputs,
+                model_outputs,
+                initializers,
+                self.opset_imports,
+                ir_version=self.ir_version,
+            )
 
             try:
                 model = onnx.shape_inference.infer_shapes(model)
@@ -1104,8 +1166,9 @@ class SingleOpExtractor:
                 if not out_vi.type.tensor_type.shape.dim:
                     shape, etype = self._resolve_input_info(out_vi.name)
                     if shape:
-                        adj = shape_to_dynamic_fixed(shape, dim_map,
-                                                     extra=self.config_dims)
+                        adj = shape_to_dynamic_fixed(
+                            shape, dim_map, extra=self.config_dims
+                        )
                         for d in adj:
                             dp = out_vi.type.tensor_type.shape.dim.add()
                             if isinstance(d, str):
@@ -1118,8 +1181,7 @@ class SingleOpExtractor:
             os.makedirs(op_dir, exist_ok=True)
 
             if large_init_names:
-                self._save_with_external_weights(
-                    model, fpath, large_init_names)
+                self._save_with_external_weights(model, fpath, large_init_names)
             else:
                 save_model(model, fpath)
 
@@ -1145,9 +1207,11 @@ class SingleOpExtractor:
                 ext_init.data_type = tensor.data_type
                 ext_init.dims.extend(tensor.dims)
                 ext_init.data_location = TensorProto.EXTERNAL
-                for k, v in [("location", data_file),
-                             ("offset", str(offset)),
-                             ("length", str(length))]:
+                for k, v in [
+                    ("location", data_file),
+                    ("offset", str(offset)),
+                    ("length", str(length)),
+                ]:
                     kv = ext_init.external_data.add()
                     kv.key = k
                     kv.value = v
@@ -1171,12 +1235,18 @@ class SingleOpExtractor:
 
         if len(inputs) > 5 and inputs[5]:
             node.input[5] = "seqlens_k"
-            inits.append(numpy_helper.from_array(
-                np.array([eff - 1], dtype=np.int32), name="seqlens_k"))
+            inits.append(
+                numpy_helper.from_array(
+                    np.array([eff - 1], dtype=np.int32), name="seqlens_k"
+                )
+            )
         if len(inputs) > 6 and inputs[6]:
             node.input[6] = "total_seq_len"
-            inits.append(numpy_helper.from_array(
-                np.array(eff, dtype=np.int32), name="total_seq_len"))
+            inits.append(
+                numpy_helper.from_array(
+                    np.array(eff, dtype=np.int32), name="total_seq_len"
+                )
+            )
         return inits
 
     def _unique_prefix(self, base, used):
@@ -1202,15 +1272,17 @@ class SingleOpExtractor:
             else:
                 key = (node.op_type,)
             groups[key].append(node)
-        return [self._pick_fp16_representative(vs)
-                for vs in groups.values()]
+        return [self._pick_fp16_representative(vs) for vs in groups.values()]
 
     def extract_all_single_ops(self):
         unique, non_layer = self._identify_unique_ops()
 
         print("\n" + "=" * 60)
-        label = "Extracting ops..." if not self.analyzer.has_layers \
+        label = (
+            "Extracting ops..."
+            if not self.analyzer.has_layers
             else "Extracting layer ops..."
+        )
         print(label)
         print("=" * 60)
         used = set()
@@ -1225,8 +1297,10 @@ class SingleOpExtractor:
         if non_layer:
             deduped = self._dedup_non_layer(non_layer)
             print("\n" + "=" * 60)
-            print(f"Extracting non-layer ops "
-                  f"({len(non_layer)} -> {len(deduped)} after dedup)...")
+            print(
+                f"Extracting non-layer ops "
+                f"({len(non_layer)} -> {len(deduped)} after dedup)..."
+            )
             print("=" * 60)
             for node in deduped:
                 prefix = self._get_name_prefix(node)
@@ -1251,16 +1325,17 @@ class SingleOpExtractor:
 
         a = self.analyzer
 
-        layer0_nodes = [n for n in self.graph.node
-                        if a.get_layer_index(n.name) == 0]
+        layer0_nodes = [n for n in self.graph.node if a.get_layer_index(n.name) == 0]
 
         post_nodes = list(a.post_layer_nodes)
 
         all_nodes = list(a.pre_layer_nodes) + layer0_nodes + post_nodes
-        print(f"Total nodes: {len(all_nodes)} "
-              f"(pre={len(a.pre_layer_nodes)}, "
-              f"layer0={len(layer0_nodes)}, "
-              f"post={len(post_nodes)})")
+        print(
+            f"Total nodes: {len(all_nodes)} "
+            f"(pre={len(a.pre_layer_nodes)}, "
+            f"layer0={len(layer0_nodes)}, "
+            f"post={len(post_nodes)})"
+        )
 
         input_rewire = dict(a.rewire_map)
         fnr = a.compute_final_norm_rewire()
@@ -1291,8 +1366,7 @@ class SingleOpExtractor:
             elif inp not in graph_input_names:
                 graph_input_names.append(inp)
 
-        graph_output_names = self._detect_single_layer_outputs(
-            all_nodes, all_outputs)
+        graph_output_names = self._detect_single_layer_outputs(all_nodes, all_outputs)
 
         print(f"Inputs:  {graph_input_names}")
         print(f"Outputs: {graph_output_names}")
@@ -1322,8 +1396,11 @@ class SingleOpExtractor:
             it.name = cname
             small_inits.append(it)
 
-        small_inits.append(numpy_helper.from_array(
-            np.array(128, dtype=np.int32), name=TOTAL_SEQ_LEN_CONST_NAME))
+        small_inits.append(
+            numpy_helper.from_array(
+                np.array(128, dtype=np.int32), name=TOTAL_SEQ_LEN_CONST_NAME
+            )
+        )
 
         model_inputs = []
         for inp in graph_input_names:
@@ -1331,9 +1408,12 @@ class SingleOpExtractor:
             if shape is None:
                 shape = [1]
             model_inputs.append(
-                make_tensor_vi(inp, elem_type,
-                               shape_to_dynamic_fixed(
-                                   shape, None, extra=self.config_dims)))
+                make_tensor_vi(
+                    inp,
+                    elem_type,
+                    shape_to_dynamic_fixed(shape, None, extra=self.config_dims),
+                )
+            )
 
         model_outputs = []
         for out in graph_output_names:
@@ -1341,9 +1421,12 @@ class SingleOpExtractor:
             if shape is None:
                 shape = [1]
             model_outputs.append(
-                make_tensor_vi(out, elem_type,
-                               shape_to_dynamic_fixed(
-                                   shape, None, extra=self.config_dims)))
+                make_tensor_vi(
+                    out,
+                    elem_type,
+                    shape_to_dynamic_fixed(shape, None, extra=self.config_dims),
+                )
+            )
 
         out_set = set(graph_output_names)
         in_set = set(graph_input_names)
@@ -1355,19 +1438,28 @@ class SingleOpExtractor:
                 shape, elem_type = self._resolve_input_info(o)
                 if shape:
                     value_infos.append(
-                        make_tensor_vi(o, elem_type,
-                                       shape_to_dynamic_fixed(
-                                           shape, None,
-                                           extra=self.config_dims)))
+                        make_tensor_vi(
+                            o,
+                            elem_type,
+                            shape_to_dynamic_fixed(shape, None, extra=self.config_dims),
+                        )
+                    )
 
         model = build_multi_node_model(
-            nodes_copy, model_inputs, model_outputs,
-            small_inits, self.opset_imports,
-            ir_version=self.ir_version, value_infos=value_infos)
+            nodes_copy,
+            model_inputs,
+            model_outputs,
+            small_inits,
+            self.opset_imports,
+            ir_version=self.ir_version,
+            value_infos=value_infos,
+        )
 
         if large_inits:
-            print(f"  {len(large_inits)} oversized initializer(s), "
-                  f"adding via direct assignment")
+            print(
+                f"  {len(large_inits)} oversized initializer(s), "
+                f"adding via direct assignment"
+            )
             for init in large_inits:
                 new_init = model.graph.initializer.add()
                 new_init.name = init.name
@@ -1392,8 +1484,7 @@ class SingleOpExtractor:
                     if out and out in graph_out_names and out not in outputs:
                         outputs.append(out)
         if not outputs:
-            fallback = [o.name for o in self.graph.output
-                        if o.name in all_outputs]
+            fallback = [o.name for o in self.graph.output if o.name in all_outputs]
             outputs = fallback[:5]
         return outputs
 
@@ -1405,11 +1496,13 @@ class SingleOpExtractor:
         nodes = self.graph.node
         block_ends = []
         for i in range(len(nodes) - 4):
-            if (nodes[i].op_type == "LayerNormalization"
-                    and nodes[i + 1].op_type == "Gemm"
-                    and nodes[i + 2].op_type == "Gelu"
-                    and nodes[i + 3].op_type == "Gemm"
-                    and nodes[i + 4].op_type == "Add"):
+            if (
+                nodes[i].op_type == "LayerNormalization"
+                and nodes[i + 1].op_type == "Gemm"
+                and nodes[i + 2].op_type == "Gelu"
+                and nodes[i + 3].op_type == "Gemm"
+                and nodes[i + 4].op_type == "Add"
+            ):
                 block_ends.append(i + 4)
         if len(block_ends) < 2:
             return None
@@ -1451,8 +1544,12 @@ class SingleOpExtractor:
             idx = queue.pop(0)
             n = nodes[idx]
             for inp in n.input:
-                if not inp or inp in init_names \
-                        or inp in graph_in or inp in const_names:
+                if (
+                    not inp
+                    or inp in init_names
+                    or inp in graph_in
+                    or inp in const_names
+                ):
                     continue
                 src = output_to_idx.get(inp)
                 if src is not None and src not in required:
@@ -1477,8 +1574,10 @@ class SingleOpExtractor:
         n_blocks = len(blocks)
         b0_start, b0_end = blocks[0]
         last_end = blocks[-1][1]
-        print(f"Extracting vision single block ({n_blocks} blocks detected, "
-              f"block 0: nodes [{b0_start}..{b0_end}])...")
+        print(
+            f"Extracting vision single block ({n_blocks} blocks detected, "
+            f"block 0: nodes [{b0_start}..{b0_end}])..."
+        )
         print("=" * 60)
 
         nodes = self.graph.node
@@ -1486,8 +1585,9 @@ class SingleOpExtractor:
         pre_block = list(range(0, b0_start))
         block0_indices = list(range(b0_start, b0_end + 1))
 
-        post_block = [i for i in range(last_end + 1, len(nodes))
-                      if nodes[i].op_type != "Cast"]
+        post_block = [
+            i for i in range(last_end + 1, len(nodes)) if nodes[i].op_type != "Cast"
+        ]
 
         middle_outputs = set()
         for k in range(1, n_blocks - 1):
@@ -1497,8 +1597,7 @@ class SingleOpExtractor:
                         middle_outputs.add(o)
 
         core = pre_block + block0_indices + post_block
-        all_indices = self._collect_cast_deps(core,
-                                              forbidden_inputs=middle_outputs)
+        all_indices = self._collect_cast_deps(core, forbidden_inputs=middle_outputs)
 
         block0_output_names = set()
         for i in block0_indices:
@@ -1522,17 +1621,18 @@ class SingleOpExtractor:
         for idx in all_indices:
             n = nodes[idx]
             for inp_name in n.input:
-                if inp_name and inp_name in last_block_outputs \
-                        and inp_name not in block0_output_names:
+                if (
+                    inp_name
+                    and inp_name in last_block_outputs
+                    and inp_name not in block0_output_names
+                ):
                     input_rewire[inp_name] = b0_main_out
 
         self._load_full_model()
         fm_nodes = list(self.full_model.graph.node)
-        fm_init_map = {init.name: init
-                       for init in self.full_model.graph.initializer}
+        fm_init_map = {init.name: init for init in self.full_model.graph.initializer}
 
-        all_nodes_list = [fm_nodes[i] for i in all_indices
-                          if i < len(fm_nodes)]
+        all_nodes_list = [fm_nodes[i] for i in all_indices if i < len(fm_nodes)]
 
         all_outputs_set = set()
         for n in all_nodes_list:
@@ -1540,7 +1640,6 @@ class SingleOpExtractor:
                 if o:
                     all_outputs_set.add(o)
 
-        orig_graph_in = {inp.name for inp in self.graph.input}
         init_names = set()
         const_names = set()
         graph_input_names = []
@@ -1558,10 +1657,13 @@ class SingleOpExtractor:
 
         graph_output_names = [o.name for o in self.graph.output]
 
-        n_cast = len(all_indices) - len(pre_block) \
-            - len(block0_indices) - len(post_block)
-        print(f"  Pre-block: {len(pre_block)}, block 0: {len(block0_indices)}, "
-              f"post-block: {len(post_block)}, Cast deps: {n_cast}")
+        n_cast = (
+            len(all_indices) - len(pre_block) - len(block0_indices) - len(post_block)
+        )
+        print(
+            f"  Pre-block: {len(pre_block)}, block 0: {len(block0_indices)}, "
+            f"post-block: {len(post_block)}, Cast deps: {n_cast}"
+        )
         print(f"  Inputs:  {graph_input_names}")
         print(f"  Outputs: {graph_output_names}")
 
@@ -1579,8 +1681,7 @@ class SingleOpExtractor:
             shape, elem_type = self._resolve_input_info(inp_name)
             if shape is None:
                 shape = [1]
-            adj = shape_to_dynamic_fixed(shape, None,
-                                         extra=self.config_dims)
+            adj = shape_to_dynamic_fixed(shape, None, extra=self.config_dims)
             model_inputs.append(make_tensor_vi(inp_name, elem_type, adj))
 
         model_outputs = []
@@ -1588,8 +1689,7 @@ class SingleOpExtractor:
             shape, elem_type = self._resolve_input_info(out_name)
             if shape is None:
                 shape = [1]
-            adj = shape_to_dynamic_fixed(shape, None,
-                                         extra=self.config_dims)
+            adj = shape_to_dynamic_fixed(shape, None, extra=self.config_dims)
             model_outputs.append(make_tensor_vi(out_name, elem_type, adj))
 
         small_inits = []
@@ -1620,15 +1720,22 @@ class SingleOpExtractor:
                 shape, elem_type = self._resolve_input_info(o)
                 if shape:
                     value_infos.append(
-                        make_tensor_vi(o, elem_type,
-                                       shape_to_dynamic_fixed(
-                                           shape, None,
-                                           extra=self.config_dims)))
+                        make_tensor_vi(
+                            o,
+                            elem_type,
+                            shape_to_dynamic_fixed(shape, None, extra=self.config_dims),
+                        )
+                    )
 
         model = build_multi_node_model(
-            nodes_copy, model_inputs, model_outputs,
-            small_inits, self.opset_imports,
-            ir_version=self.ir_version, value_infos=value_infos)
+            nodes_copy,
+            model_inputs,
+            model_outputs,
+            small_inits,
+            self.opset_imports,
+            ir_version=self.ir_version,
+            value_infos=value_infos,
+        )
 
         if large_inits:
             print(f"  {len(large_inits)} oversized initializer(s)")
@@ -1649,8 +1756,7 @@ class SingleOpExtractor:
             print("Extracting fixed-shape variants (flat model)...")
             print("=" * 60)
             self._load_full_model()
-            self._save_variants(
-                self.full_model, self.full_model_dir, "full_model")
+            self._save_variants(self.full_model, self.full_model_dir, "full_model")
             return
         print("Extracting full model...")
         print("=" * 60)
@@ -1669,8 +1775,7 @@ class SingleOpExtractor:
                     if o:
                         deleted_tensors.add(o)
 
-        keep = [n for n in model.graph.node
-                if n.name not in a.nodes_to_delete]
+        keep = [n for n in model.graph.node if n.name not in a.nodes_to_delete]
         del model.graph.node[:]
         model.graph.node.extend(keep)
 
@@ -1679,8 +1784,7 @@ class SingleOpExtractor:
                 if inp in a.rewire_map:
                     node.input[i] = a.rewire_map[inp]
 
-        vis = [vi for vi in model.graph.value_info
-               if vi.name not in deleted_tensors]
+        vis = [vi for vi in model.graph.value_info if vi.name not in deleted_tensors]
         del model.graph.value_info[:]
         model.graph.value_info.extend(vis)
 
@@ -1689,8 +1793,11 @@ class SingleOpExtractor:
             for inp in node.input:
                 if inp:
                     used_inputs.add(inp)
-        orphaned_idx = [i for i, init in enumerate(model.graph.initializer)
-                        if init.name not in used_inputs]
+        orphaned_idx = [
+            i
+            for i, init in enumerate(model.graph.initializer)
+            if init.name not in used_inputs
+        ]
         if orphaned_idx:
             print(f"  Removing {len(orphaned_idx)} orphaned initializer(s)")
             for idx in reversed(orphaned_idx):
@@ -1728,8 +1835,10 @@ class SingleOpExtractor:
         dst_data = os.path.join(out_dir, data_name)
         if os.path.isfile(src_data):
             if os.path.abspath(src_data) != os.path.abspath(dst_data):
-                print(f"  Copying external data: {data_name} "
-                      f"({os.path.getsize(src_data) / (1024**3):.2f} GB)")
+                print(
+                    f"  Copying external data: {data_name} "
+                    f"({os.path.getsize(src_data) / (1024**3):.2f} GB)"
+                )
                 shutil.copy2(src_data, dst_data)
             else:
                 print(f"  External data already in place: {data_name}")
@@ -1737,20 +1846,23 @@ class SingleOpExtractor:
             print(f"  WARNING: external data file not found: {src_data}")
 
         orig_in = {i.name: self._save_vi_shape(i) for i in model.graph.input}
-        orig_out = {o.name: self._save_vi_shape(o)
-                    for o in model.graph.output}
-        orig_vi = {v.name: self._save_vi_shape(v)
-                   for v in model.graph.value_info}
+        orig_out = {o.name: self._save_vi_shape(o) for o in model.graph.output}
+        orig_vi = {v.name: self._save_vi_shape(v) for v in model.graph.value_info}
 
-        has_tsl = any(
-            inp == TOTAL_SEQ_LEN_CONST_NAME
-            for node in model.graph.node for inp in node.input
-        ) and self.model_type == "llm"
+        has_tsl = (
+            any(
+                inp == TOTAL_SEQ_LEN_CONST_NAME
+                for node in model.graph.node
+                for inp in node.input
+            )
+            and self.model_type == "llm"
+        )
 
         for idx, (vname, dim_map) in enumerate(self.variants):
             llm_total = (
                 total_seq_len_scalar_from_dim_map(dim_map)
-                if self.model_type == "llm" else None
+                if self.model_type == "llm"
+                else None
             )
 
             if has_tsl:
@@ -1760,15 +1872,19 @@ class SingleOpExtractor:
                             if inp == TOTAL_SEQ_LEN_CONST_NAME:
                                 node.input[j] = "total_sequence_length"
                     tsl_vi = make_tensor_vi(
-                        "total_sequence_length", TensorProto.INT32, [1])
+                        "total_sequence_length", TensorProto.INT32, [1]
+                    )
                     model.graph.input.append(tsl_vi)
                 else:
                     for node in model.graph.node:
                         for j, inp in enumerate(node.input):
                             if inp == "total_sequence_length":
                                 node.input[j] = TOTAL_SEQ_LEN_CONST_NAME
-                    to_rm = [i for i, vi in enumerate(model.graph.input)
-                             if vi.name == "total_sequence_length"]
+                    to_rm = [
+                        i
+                        for i, vi in enumerate(model.graph.input)
+                        if vi.name == "total_sequence_length"
+                    ]
                     for i in reversed(to_rm):
                         del model.graph.input[i]
 
@@ -1776,8 +1892,11 @@ class SingleOpExtractor:
                 patch_fold_total_seq_len_constant_value(model, llm_total)
                 upsert_total_seq_len_const_initializer(model.graph, llm_total)
 
-            for vi in list(model.graph.input) + list(model.graph.output) \
-                    + list(model.graph.value_info):
+            for vi in (
+                list(model.graph.input)
+                + list(model.graph.output)
+                + list(model.graph.value_info)
+            ):
                 self._set_vi_shape(vi, dim_map, extra=self.config_dims)
 
             path = os.path.join(out_dir, self._full_model_variant_onnx_basename(vname))
@@ -1801,10 +1920,8 @@ class SingleOpExtractor:
             os.remove(stale)
 
         orig_in = {i.name: self._save_vi_shape(i) for i in model.graph.input}
-        orig_out = {o.name: self._save_vi_shape(o)
-                    for o in model.graph.output}
-        orig_vi = {v.name: self._save_vi_shape(v)
-                   for v in model.graph.value_info}
+        orig_out = {o.name: self._save_vi_shape(o) for o in model.graph.output}
+        orig_vi = {v.name: self._save_vi_shape(v) for v in model.graph.value_info}
 
         for idx, (vname, dim_map) in enumerate(self.variants):
             if self.model_type == "llm":
@@ -1813,8 +1930,11 @@ class SingleOpExtractor:
                     patch_fold_total_seq_len_constant_value(model, llm_total)
                     upsert_total_seq_len_const_initializer(model.graph, llm_total)
 
-            for vi in list(model.graph.input) + list(model.graph.output) \
-                    + list(model.graph.value_info):
+            for vi in (
+                list(model.graph.input)
+                + list(model.graph.output)
+                + list(model.graph.value_info)
+            ):
                 self._set_vi_shape(vi, dim_map, extra=self.config_dims)
 
             save_model = model
@@ -1823,11 +1943,14 @@ class SingleOpExtractor:
 
             path = os.path.join(out_dir, f"{prefix}_{vname}.onnx")
             if idx == 0:
-                onnx.save(save_model, path,
-                          save_as_external_data=True,
-                          all_tensors_to_one_file=True,
-                          location=data_name,
-                          size_threshold=1024)
+                onnx.save(
+                    save_model,
+                    path,
+                    save_as_external_data=True,
+                    all_tensors_to_one_file=True,
+                    location=data_name,
+                    size_threshold=1024,
+                )
             else:
                 with open(path, "wb") as f:
                     f.write(save_model.SerializeToString())
@@ -1865,8 +1988,7 @@ class SingleOpExtractor:
             opt = onnxoptimizer.optimize(m, cls._OPT_PASSES)
             after = len(opt.graph.node)
             if after < before:
-                print(f"    shape-fold: {before} -> {after} nodes "
-                      f"(-{before - after})")
+                print(f"    shape-fold: {before} -> {after} nodes (-{before - after})")
             return opt
         except Exception as e:
             print(f"    shape-fold skipped: {e}")
@@ -1876,11 +1998,12 @@ class SingleOpExtractor:
 
     @staticmethod
     def _save_vi_shape(vi):
-        if not vi.type.tensor_type.shape \
-                or len(vi.type.tensor_type.shape.dim) == 0:
+        if not vi.type.tensor_type.shape or len(vi.type.tensor_type.shape.dim) == 0:
             return None
-        return [("param", d.dim_param) if d.dim_param else ("value", d.dim_value)
-                for d in vi.type.tensor_type.shape.dim]
+        return [
+            ("param", d.dim_param) if d.dim_param else ("value", d.dim_value)
+            for d in vi.type.tensor_type.shape.dim
+        ]
 
     @staticmethod
     def _restore_vi_shape(vi, saved):
@@ -1922,14 +2045,17 @@ class SingleOpExtractor:
 def main():
     parser = argparse.ArgumentParser(
         description="Universal ONNX submodel extractor for LLMs "
-                    "(auto-discovers graph topology)")
-    parser.add_argument("--model", required=True,
-                        help="Path to model.onnx")
-    parser.add_argument("--output", default=None,
-                        help="Output directory (default: same as model)")
-    parser.add_argument("--only",
-                        choices=["single_op", "single_layer", "full_model"],
-                        help="Run only a specific extraction step")
+        "(auto-discovers graph topology)"
+    )
+    parser.add_argument("--model", required=True, help="Path to model.onnx")
+    parser.add_argument(
+        "--output", default=None, help="Output directory (default: same as model)"
+    )
+    parser.add_argument(
+        "--only",
+        choices=["single_op", "single_layer", "full_model"],
+        help="Run only a specific extraction step",
+    )
     args = parser.parse_args()
 
     extractor = SingleOpExtractor(args.model, output_dir=args.output)

--- a/tools/onnx-model-splitter/extract_submodels.py
+++ b/tools/onnx-model-splitter/extract_submodels.py
@@ -9,8 +9,8 @@ Tested with: Qwen2.5 (FP16), DeepSeek-R1 (INT4), Mistral-7B (INT4).
 
 Produces:
   single_op/<OpType>/<name>_<variant>.onnx   (8 variants each)
-  single_layer/single_layer_<variant>.onnx   (8 variants, shared weights.data)
-  full_model/full_model_<variant>.onnx       (8 variants, shared weights.data)
+  single_layer/single_layer_<variant>.onnx   (8 variants, shared ext data)
+  full_model/full_model_<variant>.onnx       (8 variants, shared ext data)
 
 Variants: dynamic, seq1, seq128, seq256, seq512, seq1024, seq2048, seq3072
 
@@ -37,6 +37,12 @@ from collections import defaultdict, Counter
 
 import onnx
 from onnx import helper, TensorProto, numpy_helper
+
+try:
+    import onnxoptimizer
+    _HAS_OPTIMIZER = True
+except ImportError:
+    _HAS_OPTIMIZER = False
 
 SEQ_VARIANTS = [
     ("dynamic", None),
@@ -707,8 +713,22 @@ class SingleOpExtractor:
         self.analyzer.analyze()
 
         self.full_model = None
+        self.ext_data_name = self._detect_ext_data_name()
         self.model_type = self._detect_model_type()
         self.variants = self._get_variants()
+
+    def _detect_ext_data_name(self):
+        """Detect the external data filename from the input model's
+        initializers so we can reuse it in the output."""
+        for init in self.graph.initializer:
+            if init.data_location == TensorProto.EXTERNAL:
+                for entry in init.external_data:
+                    if entry.key == "location":
+                        print(f"External data:     {entry.value}")
+                        return entry.value
+        default = os.path.basename(self.model_path) + ".data"
+        print(f"External data:     {default} (default)")
+        return default
 
     def _detect_model_type(self):
         input_names = {inp.name for inp in self.graph.input}
@@ -1502,10 +1522,19 @@ class SingleOpExtractor:
 
     # ════════════════════ variant saving ════════════════════
 
+    _OPT_PASSES = [
+        "eliminate_shape_gather",
+        "eliminate_shape_op",
+        "extract_constant_to_initializer",
+        "eliminate_deadend",
+        "eliminate_unused_initializer",
+    ]
+
     def _save_variants(self, model, out_dir, prefix):
-        """Save variants with shared weights.data."""
+        """Save variants with shared external data file."""
         os.makedirs(out_dir, exist_ok=True)
-        stale = os.path.join(out_dir, "weights.data")
+        data_name = self.ext_data_name
+        stale = os.path.join(out_dir, data_name)
         if os.path.exists(stale):
             os.remove(stale)
 
@@ -1535,16 +1564,20 @@ class SingleOpExtractor:
                     + list(model.graph.value_info):
                 self._set_vi_shape(vi, dim_map)
 
+            save_model = model
+            if dim_map is not None and _HAS_OPTIMIZER:
+                save_model = self._fold_shapes(model)
+
             path = os.path.join(out_dir, f"{prefix}_{vname}.onnx")
             if idx == 0:
-                onnx.save(model, path,
+                onnx.save(save_model, path,
                           save_as_external_data=True,
                           all_tensors_to_one_file=True,
-                          location="weights.data",
+                          location=data_name,
                           size_threshold=1024)
             else:
                 with open(path, "wb") as f:
-                    f.write(model.SerializeToString())
+                    f.write(save_model.SerializeToString())
             print(f"  Saved: {path}")
 
             for vi in model.graph.input:
@@ -1553,6 +1586,96 @@ class SingleOpExtractor:
                 self._restore_vi_shape(vi, orig_out.get(vi.name))
             for vi in model.graph.value_info:
                 self._restore_vi_shape(vi, orig_vi.get(vi.name))
+
+    @classmethod
+    def _fold_shapes(cls, model):
+        """Run onnxoptimizer to eliminate Shape/Gather nodes on fixed-shape
+        variants.  Operates on a copy so the original model is not mutated."""
+        before = len(model.graph.node)
+        try:
+            opt = onnxoptimizer.optimize(model, cls._OPT_PASSES)
+            cls._fix_scalar_to_1d(opt)
+            after = len(opt.graph.node)
+            if after < before:
+                print(f"    shape-fold: {before} -> {after} nodes "
+                      f"(-{before - after})")
+            return opt
+        except Exception as e:
+            print(f"    shape-fold skipped: {e}")
+            return model
+
+    @staticmethod
+    def _fix_scalar_to_1d(model):
+        """Fix 0-D scalar initializers/constants that should be 1-D int64[1].
+
+        onnxoptimizer's eliminate_shape_gather folds Shape→Gather into scalar
+        constants, but the original tensors were int64[1].  Scalar propagation
+        through element-wise ops (Mul, Add, Sub, …) can produce scalar outputs
+        that eventually feed into Concat, which requires >=1-D inputs.
+
+        Strategy: find all Concat inputs, trace upstream through element-wise
+        ops, and reshape every scalar initializer/Constant in those chains to
+        [1].
+        """
+        init_map = {init.name: init for init in model.graph.initializer}
+        out_to_node = {}
+        for node in model.graph.node:
+            for o in node.output:
+                if o:
+                    out_to_node[o] = node
+
+        needs_1d = set()
+        elementwise_ops = {
+            "Add", "Sub", "Mul", "Div", "Cast", "Neg", "Abs",
+            "Floor", "Ceil", "Unsqueeze", "Squeeze",
+        }
+        queue = []
+        for node in model.graph.node:
+            if node.op_type == "Concat":
+                for inp in node.input:
+                    if inp and inp not in needs_1d:
+                        needs_1d.add(inp)
+                        queue.append(inp)
+
+        while queue:
+            tensor_name = queue.pop()
+            producer = out_to_node.get(tensor_name)
+            if producer is None:
+                continue
+            if producer.op_type in elementwise_ops:
+                for inp in producer.input:
+                    if inp and inp not in needs_1d:
+                        needs_1d.add(inp)
+                        queue.append(inp)
+
+        fixed = 0
+        for name in needs_1d:
+            init = init_map.get(name)
+            if init is None:
+                continue
+            if len(init.dims) == 0:
+                arr = numpy_helper.to_array(init)
+                new_t = numpy_helper.from_array(arr.reshape(1), name=name)
+                init.CopyFrom(new_t)
+                fixed += 1
+
+        for node in model.graph.node:
+            if node.op_type != "Constant":
+                continue
+            out = node.output[0] if node.output else ""
+            if out not in needs_1d:
+                continue
+            for attr in node.attribute:
+                if attr.name == "value" \
+                        and attr.type == onnx.AttributeProto.TENSOR:
+                    if len(attr.t.dims) == 0:
+                        arr = numpy_helper.to_array(attr.t)
+                        new_t = numpy_helper.from_array(arr.reshape(1))
+                        attr.t.CopyFrom(new_t)
+                        fixed += 1
+
+        if fixed:
+            print(f"    scalar->1d fix: {fixed} tensor(s)")
 
     # ── Shape helpers ──
 

--- a/tools/onnx-model-splitter/extract_submodels.py
+++ b/tools/onnx-model-splitter/extract_submodels.py
@@ -1,0 +1,1629 @@
+"""
+Universal ONNX submodel extractor for LLMs.
+
+Auto-discovers graph topology — no hardcoded node names needed.
+Works with any model following the standard LLM pattern:
+  embed_tokens -> N transformer layers -> final_norm -> lm_head
+
+Tested with: Qwen2.5 (FP16), DeepSeek-R1 (INT4), Mistral-7B (INT4).
+
+Produces:
+  single_op/<OpType>/<name>_<variant>.onnx   (8 variants each)
+  single_layer/single_layer_<variant>.onnx   (8 variants, shared weights.data)
+  full_model/full_model_<variant>.onnx       (8 variants, shared weights.data)
+
+Variants: dynamic, seq1, seq128, seq256, seq512, seq1024, seq2048, seq3072
+
+Rules applied to all extractions:
+  - Delete branch: attention_mask -> Shape -> Gather -> Cast
+  - Delete branch: input_ids -> Shape -> Gather -> Unsqueeze -> Concat -> Reshape
+    (only if present; e.g. absent in DeepSeek)
+  - Connect position_ids directly to RotaryEmbedding (when Reshape chain exists)
+  - Replace GQA total_seq_len with constant = sequence_length
+  - Orphaned Constant/initializer nodes are auto-removed
+  - 8 variants: 1 dynamic + 7 fixed seq lengths; batch_size fixed to 1
+
+Usage:
+  python extract_submodels.py --model path/to/model.onnx
+  python extract_submodels.py --model path/to/model.onnx --only single_op
+  python extract_submodels.py --model path/to/model.onnx --output /out/dir
+"""
+
+import os
+import re
+import argparse
+import numpy as np
+from collections import defaultdict, Counter
+
+import onnx
+from onnx import helper, TensorProto, numpy_helper
+
+SEQ_VARIANTS = [
+    ("dynamic", None),
+    ("seq1", 1),
+    ("seq128", 128),
+    ("seq256", 256),
+    ("seq512", 512),
+    ("seq1024", 1024),
+    ("seq2048", 2048),
+    ("seq3072", 3072),
+]
+
+VISION_VARIANTS = [
+    ("dynamic", None),
+    ("np1024", {"num_patches": 1024, "num_logical_patches": 256}),
+    ("np1200", {"num_patches": 1200, "num_logical_patches": 300}),
+    ("np2520", {"num_patches": 2520, "num_logical_patches": 630}),
+    ("np3600", {"num_patches": 3600, "num_logical_patches": 900}),
+    ("np4096", {"num_patches": 4096, "num_logical_patches": 1024}),
+    ("np8160", {"num_patches": 8160, "num_logical_patches": 2040}),
+]
+
+EMBEDDING_VARIANTS = [
+    ("dynamic", None),
+    ("seq1_if0", {"sequence_length": 1, "num_logical_patches": 0}),
+    ("seq1_if2040", {"sequence_length": 1, "num_logical_patches": 2040}),
+    ("seq128_if0", {"sequence_length": 128, "num_logical_patches": 0}),
+    ("seq128_if2040", {"sequence_length": 128, "num_logical_patches": 2040}),
+    ("seq512_if0", {"sequence_length": 512, "num_logical_patches": 0}),
+    ("seq512_if2040", {"sequence_length": 512, "num_logical_patches": 2040}),
+    ("seq1024_if0", {"sequence_length": 1024, "num_logical_patches": 0}),
+    ("seq1024_if2040", {"sequence_length": 1024, "num_logical_patches": 2040}),
+    ("seq2048_if0", {"sequence_length": 2048, "num_logical_patches": 0}),
+    ("seq2048_if2040", {"sequence_length": 2048, "num_logical_patches": 2040}),
+    ("seq3072_if0", {"sequence_length": 3072, "num_logical_patches": 0}),
+    ("seq3072_if2040", {"sequence_length": 3072, "num_logical_patches": 2040}),
+]
+
+BATCH_SIZE = 1
+TOTAL_SEQ_LEN_CONST_NAME = "total_seq_len_const"
+
+PERF_SIGNIFICANT_OPS = {
+    "Gemm", "MatMul", "MatMulNBits", "Conv", "ConvTranspose",
+    "GroupQueryAttention", "LinearAttention", "QMoE",
+    "CausalConvWithState", "RotaryEmbedding",
+    "LayerNormalization", "SimplifiedLayerNormalization",
+    "SkipSimplifiedLayerNormalization", "BatchNormalization",
+    "LSTM", "GRU", "Loop",
+}
+
+
+# ─────────────────────── Graph Analyzer ───────────────────────
+
+
+class GraphAnalyzer:
+    """Auto-discover graph topology patterns for LLM ONNX models.
+
+    Discovers:
+      - Number of transformer layers
+      - Preprocessing chains to delete (attn_mask, position_ids reshape)
+      - Key structural nodes (embed_tokens, final_norm, lm_head)
+      - Op type configuration (MatMul vs MatMulNBits, RotaryEmbedding)
+      - Tensor rewiring map
+      - Pre-layer dependency nodes (via backward traversal from layer 0)
+    """
+
+    LAYER_PATTERN = re.compile(r"/layers?[./](\d+)[/.]")
+
+    def __init__(self, graph):
+        self.graph = graph
+
+        self.output_to_node = {}
+        self.input_to_nodes = defaultdict(list)
+        self.node_by_name = {}
+        for node in graph.node:
+            if node.name:
+                self.node_by_name[node.name] = node
+            for out in node.output:
+                if out:
+                    self.output_to_node[out] = node
+            for inp in node.input:
+                if inp:
+                    self.input_to_nodes[inp].append(node)
+
+        self.graph_input_names = {inp.name for inp in graph.input}
+        self.init_names = {init.name for init in graph.initializer}
+
+        self.constant_outputs = {}
+        for node in graph.node:
+            if node.op_type == "Constant":
+                for attr in node.attribute:
+                    if attr.name == "value" and attr.type == onnx.AttributeProto.TENSOR:
+                        for out in node.output:
+                            if out:
+                                self.constant_outputs[out] = attr.t
+
+        self.num_layers = 0
+        self.layer_indices = set()
+        self.nodes_to_delete = set()
+        self.deleted_outputs = set()
+        self.rewire_map = {}
+        self.attn_mask_chain_output = None
+        self.reshape_chain_output = None
+        self.embed_node = None
+        self.final_norm_node = None
+        self.lm_head_node = None
+        self.shape_diff_ops = set()
+        self.pre_layer_nodes = []
+        self.post_layer_nodes = []
+
+    @property
+    def has_layers(self):
+        return self.num_layers > 0
+
+    def analyze(self):
+        print("\n=== Auto-discovering graph topology ===")
+        self._detect_layers()
+        if not self.has_layers:
+            print("  Flat model (no layer structure) — single_op only")
+            self._print_summary()
+            return
+        self._detect_op_types()
+        self._discover_attn_mask_chain()
+        self._discover_position_ids_chain()
+        self._find_orphaned_constants()
+        self._compute_deleted_outputs()
+        self._build_rewire_map()
+        self._discover_embed_tokens()
+        self._discover_lm_head()
+        self._discover_final_norm()
+        self._discover_post_layer_nodes()
+        self._discover_pre_layer_nodes()
+        self._print_summary()
+
+    # ── Layer detection ──
+
+    def _detect_layers(self):
+        layer_counts = Counter()
+        for node in self.graph.node:
+            m = self.LAYER_PATTERN.search(node.name)
+            if m:
+                layer_counts[int(m.group(1))] += 1
+        if not layer_counts:
+            print("  No layer pattern found in node names")
+            return
+
+        typical_count = Counter(layer_counts.values()).most_common(1)[0][0]
+        threshold = max(typical_count * 0.4, 5)
+        real_layers = sorted(
+            idx for idx, cnt in layer_counts.items() if cnt >= threshold)
+        self.num_layers = len(real_layers)
+        self.layer_indices = set(real_layers)
+
+        layer_groups = defaultdict(list)
+        for idx in real_layers:
+            layer_groups[layer_counts[idx]].append(idx)
+        desc = ", ".join(f"{len(idxs)}x{cnt}-node" for cnt, idxs
+                         in sorted(layer_groups.items()))
+        print(f"  Layers: {self.num_layers} total "
+              f"(index {real_layers[0]}..{real_layers[-1]}, {desc})")
+
+    # ── Op type detection ──
+
+    def _detect_op_types(self):
+        op_types = {n.op_type for n in self.graph.node}
+        self.shape_diff_ops = set()
+
+        if "MatMulNBits" in op_types:
+            self.shape_diff_ops.add("MatMulNBits")
+        else:
+            for node in self.graph.node:
+                if node.op_type == "MatMul" and self.get_layer_index(node.name) is not None:
+                    if any(inp in self.init_names for inp in node.input):
+                        self.shape_diff_ops.add("MatMul")
+                        break
+
+        if "RotaryEmbedding" in op_types:
+            self.shape_diff_ops.add("RotaryEmbedding")
+
+        print(f"  Shape-diff ops: {self.shape_diff_ops or 'none'}")
+
+    # ── Chain discovery ──
+
+    def _follow_chain(self, start_tensor, expected_ops):
+        """Follow a chain of ops from a tensor. Returns list of matched nodes."""
+        chain = []
+        current_tensor = start_tensor
+        for op in expected_ops:
+            consumers = [n for n in self.input_to_nodes.get(current_tensor, [])
+                         if n.op_type == op]
+            if len(consumers) != 1:
+                break
+            node = consumers[0]
+            chain.append(node)
+            current_tensor = node.output[0] if node.output else None
+            if current_tensor is None:
+                break
+        return chain
+
+    def _discover_attn_mask_chain(self):
+        """attention_mask -> Shape -> Gather -> Cast"""
+        if "attention_mask" not in self.graph_input_names:
+            return
+        shape_nodes = [n for n in self.input_to_nodes.get("attention_mask", [])
+                       if n.op_type == "Shape"]
+        for sn in shape_nodes:
+            out = sn.output[0] if sn.output else None
+            if not out:
+                continue
+            tail = self._follow_chain(out, ["Gather", "Cast"])
+            if len(tail) == 2:
+                chain = [sn] + tail
+                self.attn_mask_chain_output = chain[-1].output[0]
+                for n in chain:
+                    self.nodes_to_delete.add(n.name)
+                print(f"  Attn-mask chain: {' -> '.join(n.op_type for n in chain)}")
+                return
+
+    def _discover_position_ids_chain(self):
+        """input_ids -> Shape -> Gather -> Unsqueeze -> Concat -> Reshape"""
+        if "input_ids" not in self.graph_input_names:
+            return
+        shape_nodes = [n for n in self.input_to_nodes.get("input_ids", [])
+                       if n.op_type == "Shape"]
+        for sn in shape_nodes:
+            out = sn.output[0] if sn.output else None
+            if not out:
+                continue
+            tail = self._follow_chain(
+                out, ["Gather", "Unsqueeze", "Concat", "Reshape"])
+            if len(tail) == 4:
+                chain = [sn] + tail
+                self.reshape_chain_output = chain[-1].output[0]
+                for n in chain:
+                    self.nodes_to_delete.add(n.name)
+                print(f"  Pos-ids chain:   {' -> '.join(n.op_type for n in chain)}")
+                return
+        print("  Pos-ids chain:   (not present)")
+
+    def _find_orphaned_constants(self):
+        """Remove Constant/initializer nodes used only by deleted nodes."""
+        if not self.nodes_to_delete:
+            return
+        deleted_inputs = set()
+        for node in self.graph.node:
+            if node.name in self.nodes_to_delete:
+                for inp in node.input:
+                    if inp:
+                        deleted_inputs.add(inp)
+        for name in deleted_inputs:
+            if name in self.graph_input_names:
+                continue
+            consumers = self.input_to_nodes.get(name, [])
+            non_deleted = [n for n in consumers
+                           if n.name not in self.nodes_to_delete]
+            if not non_deleted and name in self.output_to_node:
+                producer = self.output_to_node[name]
+                if producer.op_type == "Constant":
+                    self.nodes_to_delete.add(producer.name)
+                    print(f"  Orphaned const:  {producer.name}")
+
+    def _compute_deleted_outputs(self):
+        for node in self.graph.node:
+            if node.name in self.nodes_to_delete:
+                for out in node.output:
+                    if out:
+                        self.deleted_outputs.add(out)
+
+    def _build_rewire_map(self):
+        if self.attn_mask_chain_output:
+            self.rewire_map[self.attn_mask_chain_output] = TOTAL_SEQ_LEN_CONST_NAME
+        if self.reshape_chain_output:
+            self.rewire_map[self.reshape_chain_output] = "position_ids"
+
+    # ── Key node discovery ──
+
+    def _discover_embed_tokens(self):
+        if "input_ids" not in self.graph_input_names:
+            return
+        for node in self.input_to_nodes.get("input_ids", []):
+            if node.op_type == "Gather" and node.name not in self.nodes_to_delete:
+                self.embed_node = node
+                print(f"  Embed tokens:    {node.name}")
+                return
+
+    def _discover_lm_head(self):
+        if "logits" in self.output_to_node:
+            self.lm_head_node = self.output_to_node["logits"]
+            print(f"  LM head:         {self.lm_head_node.name} "
+                  f"({self.lm_head_node.op_type})")
+            return
+        for node in reversed(list(self.graph.node)):
+            if node.op_type in ("MatMul", "MatMulNBits"):
+                idx = self.get_layer_index(node.name)
+                if idx is None or idx not in self.layer_indices:
+                    self.lm_head_node = node
+                    print(f"  LM head:         {node.name} ({node.op_type})")
+                    return
+
+    def _discover_final_norm(self):
+        """Trace backward from lm_head to find the final normalization."""
+        if self.lm_head_node is None:
+            return
+        norm_ops = {"SkipSimplifiedLayerNormalization",
+                    "SimplifiedLayerNormalization", "LayerNormalization"}
+        for inp in self.lm_head_node.input:
+            if inp in self.init_names:
+                continue
+            if inp not in self.output_to_node:
+                continue
+            p = self.output_to_node[inp]
+            if p.op_type in norm_ops:
+                self.final_norm_node = p
+                print(f"  Final norm:      {p.name} ({p.op_type})")
+                return
+            for inp2 in p.input:
+                if inp2 in self.output_to_node:
+                    p2 = self.output_to_node[inp2]
+                    if p2.op_type in norm_ops:
+                        self.final_norm_node = p2
+                        print(f"  Final norm:      {p2.name} ({p2.op_type})")
+                        return
+
+    # ── Pre-layer backward traversal ──
+
+    def _discover_pre_layer_nodes(self):
+        """Find all non-layer nodes required by layer 0 via backward BFS."""
+        layer0_names = set()
+        layer0_inputs = set()
+        for node in self.graph.node:
+            if self.get_layer_index(node.name) == 0:
+                layer0_names.add(node.name)
+                for inp in node.input:
+                    if inp:
+                        layer0_inputs.add(inp)
+
+        visited = set()
+        found_names = set()
+        queue = list(layer0_inputs)
+
+        while queue:
+            t = queue.pop()
+            if t in visited:
+                continue
+            visited.add(t)
+            if t in self.graph_input_names or t in self.init_names:
+                continue
+            if t in self.deleted_outputs:
+                continue
+            if t not in self.output_to_node:
+                continue
+            producer = self.output_to_node[t]
+            if producer.name in layer0_names or producer.name in self.nodes_to_delete:
+                continue
+            idx = self.get_layer_index(producer.name)
+            if idx is not None and idx > 0:
+                continue
+            if producer.name in found_names:
+                continue
+            found_names.add(producer.name)
+            for inp in producer.input:
+                if inp:
+                    queue.append(inp)
+
+        self.pre_layer_nodes = [
+            n for n in self.graph.node if n.name in found_names]
+        print(f"  Pre-layer nodes: {len(self.pre_layer_nodes)}")
+        for n in self.pre_layer_nodes:
+            print(f"    {n.op_type:35s} {n.name}")
+
+    # ── Post-layer node discovery ──
+
+    def _discover_post_layer_nodes(self):
+        """BFS backward from lm_head to find all nodes between
+        the last real layer and the graph outputs (final_norm layer + lm_head)."""
+        if not self.lm_head_node:
+            self.post_layer_nodes = []
+            return
+
+        visited = set()
+        found = []
+        queue = [self.lm_head_node]
+
+        while queue:
+            node = queue.pop(0)
+            if node.name in visited:
+                continue
+            visited.add(node.name)
+            if node.name in self.nodes_to_delete:
+                continue
+
+            idx = self.get_layer_index(node.name)
+            if idx is not None and idx in self.layer_indices:
+                continue
+
+            found.append(node)
+            for inp in node.input:
+                if inp and inp in self.output_to_node:
+                    producer = self.output_to_node[inp]
+                    if producer.name not in visited:
+                        queue.append(producer)
+
+        node_order = {n.name: i for i, n in enumerate(self.graph.node)}
+        found.sort(key=lambda n: node_order.get(n.name, 0))
+        self.post_layer_nodes = found
+        print(f"  Post-layer nodes: {len(found)}")
+        for n in found:
+            print(f"    {n.op_type:35s} {n.name}")
+
+    # ── Final-norm rewiring for single_layer ──
+
+    def compute_final_norm_rewire(self):
+        """Map post-layer inputs from last-layer tensors to layer-0 equivalents."""
+        rewire = {}
+        for node in self.post_layer_nodes:
+            for inp in node.input:
+                if not inp or inp in self.init_names:
+                    continue
+                if inp in rewire:
+                    continue
+                m = re.search(r"(layers?[./])(\d+)([/.])", inp)
+                if m and int(m.group(2)) not in (0,) and int(m.group(2)) in self.layer_indices:
+                    new_name = inp[:m.start(2)] + "0" + inp[m.end(2):]
+                    rewire[inp] = new_name
+        if rewire:
+            print(f"  Final-norm rewire: {len(rewire)} tensor(s)")
+            for old, new in rewire.items():
+                print(f"    {old}  ->  {new}")
+        else:
+            print("  Final-norm rewire: none needed")
+        return rewire
+
+    # ── Utilities ──
+
+    def get_layer_index(self, node_name):
+        if not node_name:
+            return None
+        m = self.LAYER_PATTERN.search(node_name)
+        return int(m.group(1)) if m else None
+
+    def _print_summary(self):
+        print(f"\n  === Discovery Summary ===")
+        print(f"  Layers:         {self.num_layers}")
+        print(f"  Nodes to delete:{len(self.nodes_to_delete):>3d}")
+        print(f"  Rewire map:     {self.rewire_map}")
+        print(f"  Shape-diff ops: {self.shape_diff_ops}")
+        print()
+
+
+# ─────────────────────── Helper functions ───────────────────────
+
+
+def get_initializer_map(graph):
+    return {init.name: init for init in graph.initializer}
+
+
+def get_value_info_map(graph):
+    vi = {}
+    for v in graph.value_info:
+        vi[v.name] = v
+    for v in graph.input:
+        vi[v.name] = v
+    for v in graph.output:
+        vi[v.name] = v
+    return vi
+
+
+def get_tensor_shape(vi_map, name):
+    if name in vi_map:
+        vi = vi_map[name]
+        if vi.type.tensor_type.shape:
+            return [d.dim_param if d.dim_param else d.dim_value
+                    for d in vi.type.tensor_type.shape.dim]
+    return None
+
+
+def get_tensor_elem_type(vi_map, name):
+    if name in vi_map:
+        return vi_map[name].type.tensor_type.elem_type
+    return TensorProto.FLOAT16
+
+
+def _build_dim_subs(dim_map):
+    """Build substitution dict from a variant value.
+    Accepts int (seq_len), dict (dim_map), or None (dynamic)."""
+    subs = {"batch_size": BATCH_SIZE}
+    if dim_map is None:
+        return subs
+    if isinstance(dim_map, int):
+        seq_len = dim_map
+        subs["sequence_length"] = seq_len
+        subs["total_sequence_length"] = seq_len
+        subs["past_sequence_length"] = seq_len
+        return subs
+    subs.update(dim_map)
+    return subs
+
+
+def resolve_dim_param(param, dim_map):
+    """Evaluate a symbolic dim like 'batch_size * sequence_length'.
+    dim_map: int (seq_len), dict, or None (keep symbolic).
+    Returns int if fully resolved, or the original string if not."""
+    subs = _build_dim_subs(dim_map)
+
+    has_op = any(c in param for c in ("*", "+", "-", "/", "(", ")"))
+    if has_op:
+        expr = param
+        for sym, val in sorted(subs.items(), key=lambda x: -len(x[0])):
+            expr = expr.replace(sym, str(val))
+        try:
+            return int(eval(expr))  # noqa: S307
+        except Exception:
+            return param
+
+    if param in subs:
+        return subs[param]
+
+    if "batch" in param and "seq" not in param:
+        return BATCH_SIZE
+
+    if isinstance(dim_map, int):
+        return dim_map
+
+    return param
+
+
+def shape_to_dynamic_fixed(shape, dim_map):
+    if shape is None:
+        return None
+    result = []
+    for d in shape:
+        if isinstance(d, str):
+            result.append(resolve_dim_param(d, dim_map))
+        else:
+            result.append(d)
+    return result
+
+
+def make_tensor_vi(name, elem_type, shape):
+    tp = onnx.TypeProto()
+    tp.tensor_type.elem_type = elem_type
+    for d in shape:
+        dp = tp.tensor_type.shape.dim.add()
+        if isinstance(d, str):
+            dp.dim_param = d
+        else:
+            dp.dim_value = d
+    vi = onnx.ValueInfoProto()
+    vi.name = name
+    vi.type.CopyFrom(tp)
+    return vi
+
+
+def build_single_op_model(node, inputs, outputs, initializers,
+                          opsets, ir_version=7, value_infos=None):
+    graph = helper.make_graph(
+        [node], "single_op_graph", inputs, outputs,
+        initializer=initializers, value_info=value_infos or [])
+    model = helper.make_model(graph)
+    model.ir_version = ir_version
+    del model.opset_import[:]
+    for oi in opsets:
+        new_oi = model.opset_import.add()
+        new_oi.domain = oi.domain
+        new_oi.version = oi.version
+    return model
+
+
+def build_multi_node_model(nodes, inputs, outputs, initializers,
+                           opsets, ir_version=7, value_infos=None):
+    graph = helper.make_graph(
+        nodes, "subgraph", inputs, outputs,
+        initializer=initializers, value_info=value_infos or [])
+    model = helper.make_model(graph)
+    model.ir_version = ir_version
+    del model.opset_import[:]
+    for oi in opsets:
+        new_oi = model.opset_import.add()
+        new_oi.domain = oi.domain
+        new_oi.version = oi.version
+    return model
+
+
+PROTOBUF_LIMIT = 1_800_000_000  # ~1.8 GB, safely below protobuf 2GB cap
+
+DTYPE_BYTE_SIZE = {
+    TensorProto.FLOAT: 4, TensorProto.UINT8: 1, TensorProto.INT8: 1,
+    TensorProto.UINT16: 2, TensorProto.INT16: 2, TensorProto.INT32: 4,
+    TensorProto.INT64: 8, TensorProto.BOOL: 1, TensorProto.FLOAT16: 2,
+    TensorProto.DOUBLE: 8, TensorProto.UINT32: 4, TensorProto.UINT64: 8,
+    TensorProto.BFLOAT16: 2,
+}
+
+
+def estimate_tensor_bytes(tensor_meta):
+    """Estimate byte size from dims and data_type (works without raw_data)."""
+    elem = DTYPE_BYTE_SIZE.get(tensor_meta.data_type, 4)
+    n = 1
+    for d in tensor_meta.dims:
+        n *= d
+    return n * elem
+
+
+def save_model(model, path):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    onnx.save(model, path)
+    print(f"  Saved: {path}")
+
+
+# ─────────────────── Weight / input shape signatures ───────────────────
+
+
+def get_weight_signature(node, init_map):
+    return tuple(
+        tuple(init_map[inp].dims) for inp in node.input if inp in init_map)
+
+
+def get_input_shape_signature(node, vi_map):
+    sig = []
+    for inp in node.input:
+        if inp and inp in vi_map:
+            s = get_tensor_shape(vi_map, inp)
+            if s is not None:
+                sig.append(tuple(d for d in s if isinstance(d, int) and d > 0))
+    return tuple(sig)
+
+
+# ─────────────────────── Extractor ───────────────────────
+
+
+class SingleOpExtractor:
+
+    def __init__(self, model_path, output_dir=None):
+        self.model_path = model_path
+        self.base_dir = output_dir or os.path.dirname(model_path)
+        self.single_op_dir = os.path.join(self.base_dir, "single_op")
+        self.single_layer_dir = os.path.join(self.base_dir, "single_layer")
+        self.full_model_dir = os.path.join(self.base_dir, "full_model")
+
+        print("Loading model graph (no weights)...")
+        self.graph_model = onnx.load(model_path, load_external_data=False)
+        self.ir_version = self.graph_model.ir_version
+
+        print("Running shape inference...")
+        try:
+            self.graph_model = onnx.shape_inference.infer_shapes(
+                self.graph_model)
+            print("Shape inference succeeded.")
+        except Exception as e:
+            print(f"Shape inference warning: {e}")
+
+        self.graph = self.graph_model.graph
+        self.init_map = get_initializer_map(self.graph)
+        self.vi_map = get_value_info_map(self.graph)
+        self.opset_imports = list(self.graph_model.opset_import)
+
+        self.constant_outputs = {}
+        for node in self.graph.node:
+            if node.op_type == "Constant":
+                for attr in node.attribute:
+                    if attr.name == "value" \
+                            and attr.type == onnx.AttributeProto.TENSOR:
+                        for out in node.output:
+                            if out:
+                                self.constant_outputs[out] = attr.t
+
+        self.analyzer = GraphAnalyzer(self.graph)
+        self.analyzer.analyze()
+
+        self.full_model = None
+        self.model_type = self._detect_model_type()
+        self.variants = self._get_variants()
+
+    def _detect_model_type(self):
+        input_names = {inp.name for inp in self.graph.input}
+        if "pixel_values" in input_names:
+            print(f"Model type: vision")
+            return "vision"
+        if "image_features" in input_names and "input_ids" in input_names:
+            print(f"Model type: embedding")
+            return "embedding"
+        return "llm"
+
+    def _get_variants(self):
+        if self.model_type == "vision":
+            return VISION_VARIANTS
+        if self.model_type == "embedding":
+            return EMBEDDING_VARIANTS
+        return SEQ_VARIANTS
+
+    # ── Full model loading ──
+
+    def _load_full_model(self):
+        if self.full_model is not None:
+            return
+        model_dir = os.path.dirname(self.model_path)
+        total = os.path.getsize(self.model_path)
+        for f in os.listdir(model_dir):
+            if f.endswith((".data", ".bin")) and f != os.path.basename(
+                    self.model_path):
+                total += os.path.getsize(os.path.join(model_dir, f))
+        print(f"Loading full model with weights "
+              f"(~{total / (1024 ** 3):.1f} GB)...")
+        self.full_model = onnx.load(self.model_path)
+        print("Full model loaded.")
+        self.full_init_map = get_initializer_map(self.full_model.graph)
+
+    def _get_initializer(self, name):
+        self._load_full_model()
+        return self.full_init_map.get(name)
+
+    def _resolve_input_info(self, name):
+        if not name:
+            return None, None
+        if name in self.init_map:
+            init = self.init_map[name]
+            return list(init.dims), init.data_type
+        shape = get_tensor_shape(self.vi_map, name)
+        elem_type = get_tensor_elem_type(self.vi_map, name)
+        return shape, elem_type
+
+    # ════════════════════ single_op ════════════════════
+
+    def _pick_fp16_representative(self, candidates):
+        """Among candidates for the same unique key, prefer fp16 inputs."""
+        if len(candidates) == 1:
+            return candidates[0]
+        best = candidates[0]
+        best_score = -1
+        for node in candidates:
+            fp16 = 0
+            total = 0
+            for inp in node.input:
+                vi = self.vi_map.get(inp)
+                if vi and vi.type.tensor_type.elem_type:
+                    total += 1
+                    if vi.type.tensor_type.elem_type == TensorProto.FLOAT16:
+                        fp16 += 1
+            score = fp16 / max(total, 1)
+            if score > best_score:
+                best_score = score
+                best = node
+        return best
+
+    def _identify_unique_ops(self):
+        a = self.analyzer
+        layer_ops = defaultdict(list)
+        non_layer_nodes = []
+
+        flat_mode = not a.has_layers
+
+        for node in self.graph.node:
+            if node.name in a.nodes_to_delete or node.op_type == "Constant":
+                continue
+
+            if flat_mode:
+                if node.op_type in PERF_SIGNIFICANT_OPS:
+                    wsig = get_weight_signature(node, self.init_map)
+                    isig = get_input_shape_signature(node, self.vi_map)
+                    nout = len([o for o in node.output if o])
+                    key = (node.op_type, wsig, isig, nout)
+                else:
+                    key = (node.op_type,)
+                layer_ops[key].append(node)
+                continue
+
+            idx = a.get_layer_index(node.name)
+            if idx is not None and idx in a.layer_indices:
+                if node.op_type in a.shape_diff_ops:
+                    wsig = get_weight_signature(node, self.init_map)
+                    isig = get_input_shape_signature(node, self.vi_map)
+                    nout = len([o for o in node.output if o])
+                    key = (node.op_type, wsig, isig, nout)
+                else:
+                    key = (node.op_type,)
+                layer_ops[key].append(node)
+            else:
+                non_layer_nodes.append(node)
+
+        unique = {k: self._pick_fp16_representative(vs)
+                  for k, vs in layer_ops.items()}
+
+        mode_label = "Unique ops (flat)" if flat_mode else "Unique layer ops"
+        print(f"\n{mode_label}: {len(unique)}")
+        for k, n in unique.items():
+            print(f"  {k[0]:30s} {n.name}")
+        if non_layer_nodes:
+            print(f"Non-layer nodes:  {len(non_layer_nodes)}")
+            for n in non_layer_nodes:
+                print(f"  {n.op_type:30s} {n.name}")
+        return unique, non_layer_nodes
+
+    def _get_name_prefix(self, node, key=None):
+        """Generate semantic name for the op folder."""
+        op_type = node.op_type
+        need_suffix = (op_type in self.analyzer.shape_diff_ops
+                       or not self.analyzer.has_layers)
+        if not need_suffix:
+            return op_type
+        if not node.name:
+            return op_type
+
+        clean = re.sub(r"^/?model/", "", node.name)
+        clean = re.sub(r"^/", "", clean)
+        clean = re.sub(r"(layers?|blocks?)\.\d+/", "", clean)
+        clean = re.sub(r"^node_", "", clean)
+        parts = clean.split("/")
+
+        trail = parts[-1] if parts else ""
+        op_base = op_type.replace("NBits", "")
+        if trail.startswith(op_base) or trail == op_type:
+            parts = parts[:-1]
+
+        if self.analyzer.get_layer_index(node.name) is not None:
+            parts = [p for p in parts if p not in ("attn", "mlp", "self_attn")]
+
+        if parts and parts[-1]:
+            suffix = re.sub(r"[^a-zA-Z0-9_]", "_", parts[-1])
+            return f"{op_type}_{suffix}"
+        return op_type
+
+    def _extract_single_op(self, node, name_prefix, is_gqa=False):
+        op_dir = os.path.join(self.single_op_dir, name_prefix)
+
+        clean_node = onnx.NodeProto()
+        clean_node.CopyFrom(node)
+
+        for i, inp in enumerate(clean_node.input):
+            if inp in self.analyzer.rewire_map:
+                clean_node.input[i] = self.analyzer.rewire_map[inp]
+
+        init_names = set()
+        const_names = set()
+        large_init_names = set()
+        for inp in clean_node.input:
+            if not inp:
+                continue
+            if inp in self.init_map:
+                init_names.add(inp)
+                if estimate_tensor_bytes(self.init_map[inp]) > PROTOBUF_LIMIT:
+                    large_init_names.add(inp)
+            elif inp in self.constant_outputs:
+                const_names.add(inp)
+
+        output_names = [o for o in node.output if o]
+
+        for variant_name, dim_map in self.variants:
+            model_inputs = []
+            initializers = []
+            seen_inputs = set()
+
+            for inp in clean_node.input:
+                if not inp:
+                    continue
+                if inp in seen_inputs:
+                    continue
+                seen_inputs.add(inp)
+                if inp in init_names:
+                    if inp in large_init_names:
+                        continue
+                    it = self._get_initializer(inp)
+                    if it:
+                        initializers.append(it)
+                    continue
+                if inp in const_names:
+                    t = self.constant_outputs[inp]
+                    it = TensorProto()
+                    it.CopyFrom(t)
+                    it.name = inp
+                    initializers.append(it)
+                    continue
+                if is_gqa and self._is_gqa_constant_input(clean_node, inp):
+                    continue
+
+                shape, elem_type = self._resolve_input_info(inp)
+                if shape is None:
+                    shape, elem_type = self._resolve_input_info(
+                        node.input[list(clean_node.input).index(inp)])
+                if shape is None:
+                    shape = [1]
+                adj = shape_to_dynamic_fixed(shape, dim_map)
+                model_inputs.append(make_tensor_vi(inp, elem_type, adj))
+
+            model_outputs = []
+            for out in output_names:
+                _, elem_type = self._resolve_input_info(out)
+                model_outputs.append(make_tensor_vi(out, elem_type or 1, []))
+
+            actual_node = onnx.NodeProto()
+            actual_node.CopyFrom(clean_node)
+
+            if is_gqa:
+                initializers.extend(
+                    self._make_gqa_constant_inputs(actual_node, dim_map))
+
+            model = build_single_op_model(
+                actual_node, model_inputs, model_outputs,
+                initializers, self.opset_imports,
+                ir_version=self.ir_version)
+
+            try:
+                model = onnx.shape_inference.infer_shapes(model)
+            except Exception:
+                pass
+
+            for out_vi in model.graph.output:
+                if not out_vi.type.tensor_type.shape.dim:
+                    shape, etype = self._resolve_input_info(out_vi.name)
+                    if shape:
+                        adj = shape_to_dynamic_fixed(shape, dim_map)
+                        for d in adj:
+                            dp = out_vi.type.tensor_type.shape.dim.add()
+                            if isinstance(d, str):
+                                dp.dim_param = d
+                            else:
+                                dp.dim_value = d
+
+            fname = f"{name_prefix}_{variant_name}.onnx"
+            fpath = os.path.join(op_dir, fname)
+            os.makedirs(op_dir, exist_ok=True)
+
+            if large_init_names:
+                self._save_with_external_weights(
+                    model, fpath, large_init_names)
+            else:
+                save_model(model, fpath)
+
+    def _save_with_external_weights(self, model, path, large_weight_names):
+        """Save model with oversized weights in a separate .data file."""
+        data_file = os.path.basename(path).replace(".onnx", ".data")
+        data_path = os.path.join(os.path.dirname(path), data_file)
+
+        with open(data_path, "wb") as f:
+            for wname in large_weight_names:
+                tensor = self._get_initializer(wname)
+                if tensor is None:
+                    continue
+                offset = f.tell()
+                raw = tensor.raw_data
+                if not raw:
+                    raw = numpy_helper.to_array(tensor).tobytes()
+                f.write(raw)
+                length = len(raw)
+
+                ext_init = TensorProto()
+                ext_init.name = wname
+                ext_init.data_type = tensor.data_type
+                ext_init.dims.extend(tensor.dims)
+                ext_init.data_location = TensorProto.EXTERNAL
+                for k, v in [("location", data_file),
+                             ("offset", str(offset)),
+                             ("length", str(length))]:
+                    kv = ext_init.external_data.add()
+                    kv.key = k
+                    kv.value = v
+                model.graph.initializer.append(ext_init)
+
+        with open(path, "wb") as f:
+            f.write(model.SerializeToString())
+        print(f"  Saved: {path} (+{data_file})")
+
+    @staticmethod
+    def _is_gqa_constant_input(node, input_name):
+        inputs = list(node.input)
+        idx = inputs.index(input_name) if input_name in inputs else -1
+        return idx in (5, 6)
+
+    @staticmethod
+    def _make_gqa_constant_inputs(node, dim_map):
+        inputs = list(node.input)
+        inits = []
+        eff = dim_map if isinstance(dim_map, int) and dim_map else 128
+
+        if len(inputs) > 5 and inputs[5]:
+            node.input[5] = "seqlens_k"
+            inits.append(numpy_helper.from_array(
+                np.array([eff - 1], dtype=np.int32), name="seqlens_k"))
+        if len(inputs) > 6 and inputs[6]:
+            node.input[6] = "total_seq_len"
+            inits.append(numpy_helper.from_array(
+                np.array(eff, dtype=np.int32), name="total_seq_len"))
+        return inits
+
+    def _unique_prefix(self, base, used):
+        """Return a unique folder name, appending _2, _3, ... if needed."""
+        if base not in used:
+            return base
+        n = 2
+        while f"{base}_{n}" in used:
+            n += 1
+        return f"{base}_{n}"
+
+    def extract_all_single_ops(self):
+        unique, non_layer = self._identify_unique_ops()
+
+        print("\n" + "=" * 60)
+        label = "Extracting ops..." if not self.analyzer.has_layers \
+            else "Extracting layer ops..."
+        print(label)
+        print("=" * 60)
+        used = set()
+        for key, node in unique.items():
+            prefix = self._get_name_prefix(node, key)
+            prefix = self._unique_prefix(prefix, used)
+            used.add(prefix)
+            is_gqa = node.op_type == "GroupQueryAttention"
+            print(f"\nExtracting {prefix}...")
+            self._extract_single_op(node, prefix, is_gqa=is_gqa)
+
+        if non_layer:
+            print("\n" + "=" * 60)
+            print("Extracting non-layer ops...")
+            print("=" * 60)
+            for node in non_layer:
+                prefix = self._get_name_prefix(node)
+                prefix = self._unique_prefix(prefix, used)
+                used.add(prefix)
+                print(f"\nExtracting {prefix}...")
+                self._extract_single_op(node, prefix, is_gqa=False)
+
+    # ════════════════════ single_layer ════════════════════
+
+    def extract_single_layer(self):
+        print("\n" + "=" * 60)
+        if not self.analyzer.has_layers:
+            if self.model_type == "vision":
+                self._extract_vision_single_block()
+            else:
+                print("Skipping single_layer: no layer structure detected")
+                print("=" * 60)
+            return
+        print("Extracting single layer (embed + layer 0 + final_norm + lm_head)...")
+        print("=" * 60)
+
+        a = self.analyzer
+
+        layer0_nodes = [n for n in self.graph.node
+                        if a.get_layer_index(n.name) == 0]
+
+        post_nodes = list(a.post_layer_nodes)
+
+        all_nodes = list(a.pre_layer_nodes) + layer0_nodes + post_nodes
+        print(f"Total nodes: {len(all_nodes)} "
+              f"(pre={len(a.pre_layer_nodes)}, "
+              f"layer0={len(layer0_nodes)}, "
+              f"post={len(post_nodes)})")
+
+        input_rewire = dict(a.rewire_map)
+        fnr = a.compute_final_norm_rewire()
+        input_rewire.update(fnr)
+
+        all_outputs = set()
+        all_inputs_ordered = []
+        for node in all_nodes:
+            for o in node.output:
+                if o:
+                    all_outputs.add(o)
+            for i in node.input:
+                if i:
+                    all_inputs_ordered.append(input_rewire.get(i, i))
+
+        init_names = set()
+        const_names = set()
+        graph_input_names = []
+        for inp in all_inputs_ordered:
+            if inp in all_outputs:
+                continue
+            if inp in self.init_map:
+                init_names.add(inp)
+            elif inp in self.constant_outputs:
+                const_names.add(inp)
+            elif inp == TOTAL_SEQ_LEN_CONST_NAME:
+                continue
+            elif inp not in graph_input_names:
+                graph_input_names.append(inp)
+
+        graph_output_names = self._detect_single_layer_outputs(
+            all_nodes, all_outputs)
+
+        print(f"Inputs:  {graph_input_names}")
+        print(f"Outputs: {graph_output_names}")
+
+        nodes_copy = []
+        for n in all_nodes:
+            nc = onnx.NodeProto()
+            nc.CopyFrom(n)
+            for i, inp in enumerate(nc.input):
+                if inp in input_rewire:
+                    nc.input[i] = input_rewire[inp]
+            nodes_copy.append(nc)
+
+        small_inits = []
+        large_inits = []
+        for iname in init_names:
+            it = self._get_initializer(iname)
+            if it:
+                if estimate_tensor_bytes(self.init_map[iname]) > PROTOBUF_LIMIT:
+                    large_inits.append(it)
+                else:
+                    small_inits.append(it)
+        for cname in const_names:
+            t = self.constant_outputs[cname]
+            it = TensorProto()
+            it.CopyFrom(t)
+            it.name = cname
+            small_inits.append(it)
+
+        small_inits.append(numpy_helper.from_array(
+            np.array(128, dtype=np.int32), name=TOTAL_SEQ_LEN_CONST_NAME))
+
+        model_inputs = []
+        for inp in graph_input_names:
+            shape, elem_type = self._resolve_input_info(inp)
+            if shape is None:
+                shape = [1]
+            model_inputs.append(
+                make_tensor_vi(inp, elem_type,
+                               shape_to_dynamic_fixed(shape, None)))
+
+        model_outputs = []
+        for out in graph_output_names:
+            shape, elem_type = self._resolve_input_info(out)
+            if shape is None:
+                shape = [1]
+            model_outputs.append(
+                make_tensor_vi(out, elem_type,
+                               shape_to_dynamic_fixed(shape, None)))
+
+        out_set = set(graph_output_names)
+        in_set = set(graph_input_names)
+        value_infos = []
+        for node in all_nodes:
+            for o in node.output:
+                if not o or o in out_set or o in in_set or o not in all_outputs:
+                    continue
+                shape, elem_type = self._resolve_input_info(o)
+                if shape:
+                    value_infos.append(
+                        make_tensor_vi(o, elem_type,
+                                       shape_to_dynamic_fixed(shape, None)))
+
+        model = build_multi_node_model(
+            nodes_copy, model_inputs, model_outputs,
+            small_inits, self.opset_imports,
+            ir_version=self.ir_version, value_infos=value_infos)
+
+        if large_inits:
+            print(f"  {len(large_inits)} oversized initializer(s), "
+                  f"adding via direct assignment")
+            for init in large_inits:
+                new_init = model.graph.initializer.add()
+                new_init.name = init.name
+                new_init.data_type = init.data_type
+                new_init.dims.extend(init.dims)
+                new_init.raw_data = init.raw_data
+
+        self._save_variants(model, self.single_layer_dir, "single_layer")
+
+    def _detect_single_layer_outputs(self, all_nodes, all_outputs):
+        """Auto-detect outputs: logits + all layer-0 graph outputs (present states)."""
+        outputs = []
+        a = self.analyzer
+        graph_out_names = {o.name for o in self.graph.output}
+        if a.lm_head_node:
+            for out in a.lm_head_node.output:
+                if out and out in all_outputs:
+                    outputs.append(out)
+        for node in all_nodes:
+            if a.get_layer_index(node.name) == 0:
+                for out in node.output:
+                    if out and out in graph_out_names and out not in outputs:
+                        outputs.append(out)
+        if not outputs:
+            fallback = [o.name for o in self.graph.output
+                        if o.name in all_outputs]
+            outputs = fallback[:5]
+        return outputs
+
+    # ════════════════════ vision single block ════════════════════
+
+    def _find_vision_blocks(self):
+        """Find repeating ViT block boundaries via FFN residual pattern:
+        LayerNorm -> Gemm -> Gelu -> Gemm -> Add."""
+        nodes = self.graph.node
+        block_ends = []
+        for i in range(len(nodes) - 4):
+            if (nodes[i].op_type == "LayerNormalization"
+                    and nodes[i + 1].op_type == "Gemm"
+                    and nodes[i + 2].op_type == "Gelu"
+                    and nodes[i + 3].op_type == "Gemm"
+                    and nodes[i + 4].op_type == "Add"):
+                block_ends.append(i + 4)
+        if len(block_ends) < 2:
+            return None
+
+        gap = block_ends[1] - block_ends[0]
+        first_start = None
+        for i in range(max(0, block_ends[0] - gap - 10), block_ends[0]):
+            if nodes[i].op_type == "LayerNormalization":
+                first_start = i
+                break
+        if first_start is None:
+            return None
+
+        blocks = [(first_start, block_ends[0])]
+        for k in range(1, len(block_ends)):
+            blocks.append((block_ends[k - 1] + 1, block_ends[k]))
+        return blocks
+
+    def _collect_cast_deps(self, core_indices):
+        """Given a set of node indices, expand to include Cast nodes that
+        the core nodes depend on (input Casts) or that consume their
+        outputs then feed back into the core (output Casts)."""
+        nodes = self.graph.node
+        output_to_idx = {}
+        for i, n in enumerate(nodes):
+            for o in n.output:
+                if o:
+                    output_to_idx[o] = i
+
+        init_names = set(self.init_map.keys())
+        graph_in = {inp.name for inp in self.graph.input}
+        const_names = set(self.constant_outputs.keys())
+
+        required = set(core_indices)
+        queue = list(core_indices)
+        while queue:
+            idx = queue.pop(0)
+            n = nodes[idx]
+            for inp in n.input:
+                if not inp or inp in init_names \
+                        or inp in graph_in or inp in const_names:
+                    continue
+                src = output_to_idx.get(inp)
+                if src is not None and src not in required:
+                    if nodes[src].op_type == "Cast":
+                        required.add(src)
+                        queue.append(src)
+        return sorted(required)
+
+    _LN_CAST_RE = re.compile(r"node_layer_norm.*cast", re.IGNORECASE)
+
+    def _extract_vision_single_block(self):
+        """Extract pre-block + one ViT block + post-block as single_layer
+        (equivalent to the full model with only 1 iteration of the
+        repeated blocks)."""
+        blocks = self._find_vision_blocks()
+        if not blocks:
+            print("Skipping single_layer: no repeating ViT blocks found")
+            print("=" * 60)
+            return
+
+        n_blocks = len(blocks)
+        b0_start, b0_end = blocks[0]
+        last_end = blocks[-1][1]
+        print(f"Extracting vision single block ({n_blocks} blocks detected, "
+              f"block 0: nodes [{b0_start}..{b0_end}])...")
+        print("=" * 60)
+
+        nodes = self.graph.node
+
+        pre_block = list(range(0, b0_start))
+        block0_indices = list(range(b0_start, b0_end + 1))
+
+        post_block = []
+        for i in range(last_end + 1, len(nodes)):
+            if not self._LN_CAST_RE.search(nodes[i].name):
+                post_block.append(i)
+
+        core = pre_block + block0_indices + post_block
+        all_indices = self._collect_cast_deps(core)
+
+        block0_output_names = set()
+        for i in block0_indices:
+            for o in nodes[i].output:
+                if o:
+                    block0_output_names.add(o)
+
+        last_block_outputs = set()
+        for i in range(blocks[-1][0], blocks[-1][1] + 1):
+            for o in nodes[i].output:
+                if o:
+                    last_block_outputs.add(o)
+
+        b0_main_out = None
+        for o in nodes[b0_end].output:
+            if o:
+                b0_main_out = o
+                break
+
+        input_rewire = {}
+        for idx in all_indices:
+            n = nodes[idx]
+            for inp_name in n.input:
+                if inp_name and inp_name in last_block_outputs \
+                        and inp_name not in block0_output_names:
+                    input_rewire[inp_name] = b0_main_out
+
+        self._load_full_model()
+        fm_nodes = list(self.full_model.graph.node)
+        fm_init_map = {init.name: init
+                       for init in self.full_model.graph.initializer}
+
+        all_nodes_list = [fm_nodes[i] for i in all_indices
+                          if i < len(fm_nodes)]
+
+        all_outputs_set = set()
+        for n in all_nodes_list:
+            for o in n.output:
+                if o:
+                    all_outputs_set.add(o)
+
+        orig_graph_in = {inp.name for inp in self.graph.input}
+        init_names = set()
+        const_names = set()
+        graph_input_names = []
+        for n in all_nodes_list:
+            for inp in n.input:
+                actual = input_rewire.get(inp, inp)
+                if not actual or actual in all_outputs_set:
+                    continue
+                if actual in fm_init_map:
+                    init_names.add(actual)
+                elif actual in self.constant_outputs:
+                    const_names.add(actual)
+                elif actual not in graph_input_names:
+                    graph_input_names.append(actual)
+
+        graph_output_names = [o.name for o in self.graph.output]
+
+        n_cast = len(all_indices) - len(pre_block) \
+            - len(block0_indices) - len(post_block)
+        print(f"  Pre-block: {len(pre_block)}, block 0: {len(block0_indices)}, "
+              f"post-block: {len(post_block)}, Cast deps: {n_cast}")
+        print(f"  Inputs:  {graph_input_names}")
+        print(f"  Outputs: {graph_output_names}")
+
+        nodes_copy = []
+        for n in all_nodes_list:
+            nc = onnx.NodeProto()
+            nc.CopyFrom(n)
+            for i, inp in enumerate(nc.input):
+                if inp in input_rewire:
+                    nc.input[i] = input_rewire[inp]
+            nodes_copy.append(nc)
+
+        model_inputs = []
+        for inp_name in graph_input_names:
+            shape, elem_type = self._resolve_input_info(inp_name)
+            if shape is None:
+                shape = [1]
+            adj = shape_to_dynamic_fixed(shape, None)
+            model_inputs.append(make_tensor_vi(inp_name, elem_type, adj))
+
+        model_outputs = []
+        for out_name in graph_output_names:
+            shape, elem_type = self._resolve_input_info(out_name)
+            if shape is None:
+                shape = [1]
+            adj = shape_to_dynamic_fixed(shape, None)
+            model_outputs.append(make_tensor_vi(out_name, elem_type, adj))
+
+        small_inits = []
+        large_inits = []
+        for name in init_names:
+            it = fm_init_map.get(name)
+            if it is None:
+                continue
+            if estimate_tensor_bytes(it) > PROTOBUF_LIMIT:
+                large_inits.append(it)
+            else:
+                small_inits.append(it)
+
+        for name in const_names:
+            t = self.constant_outputs[name]
+            it = TensorProto()
+            it.CopyFrom(t)
+            it.name = name
+            small_inits.append(it)
+
+        value_infos = []
+        out_set = set(graph_output_names)
+        in_set = set(graph_input_names)
+        for n in all_nodes_list:
+            for o in n.output:
+                if not o or o in out_set or o in in_set:
+                    continue
+                shape, elem_type = self._resolve_input_info(o)
+                if shape:
+                    value_infos.append(
+                        make_tensor_vi(o, elem_type,
+                                       shape_to_dynamic_fixed(shape, None)))
+
+        model = build_multi_node_model(
+            nodes_copy, model_inputs, model_outputs,
+            small_inits, self.opset_imports,
+            ir_version=self.ir_version, value_infos=value_infos)
+
+        if large_inits:
+            print(f"  {len(large_inits)} oversized initializer(s)")
+            for init in large_inits:
+                new_init = model.graph.initializer.add()
+                new_init.name = init.name
+                new_init.data_type = init.data_type
+                new_init.dims.extend(init.dims)
+                new_init.raw_data = init.raw_data
+
+        self._save_variants(model, self.single_layer_dir, "single_layer")
+
+    # ════════════════════ full_model ════════════════════
+
+    def extract_full_model(self):
+        print("\n" + "=" * 60)
+        if not self.analyzer.has_layers:
+            print("Extracting fixed-shape variants (flat model)...")
+            print("=" * 60)
+            self._load_full_model()
+            self._save_variants(
+                self.full_model, self.full_model_dir, "full_model")
+            return
+        print("Extracting full model...")
+        print("=" * 60)
+
+        self._load_full_model()
+        model = self.full_model
+        a = self.analyzer
+
+        deleted_tensors = set()
+        for node in model.graph.node:
+            if node.name in a.nodes_to_delete:
+                for o in node.output:
+                    if o:
+                        deleted_tensors.add(o)
+
+        keep = [n for n in model.graph.node
+                if n.name not in a.nodes_to_delete]
+        del model.graph.node[:]
+        model.graph.node.extend(keep)
+
+        for node in model.graph.node:
+            for i, inp in enumerate(node.input):
+                if inp in a.rewire_map:
+                    node.input[i] = a.rewire_map[inp]
+
+        vis = [vi for vi in model.graph.value_info
+               if vi.name not in deleted_tensors]
+        del model.graph.value_info[:]
+        model.graph.value_info.extend(vis)
+
+        used_inputs = set()
+        for node in model.graph.node:
+            for inp in node.input:
+                if inp:
+                    used_inputs.add(inp)
+        orphaned_idx = [i for i, init in enumerate(model.graph.initializer)
+                        if init.name not in used_inputs]
+        if orphaned_idx:
+            print(f"  Removing {len(orphaned_idx)} orphaned initializer(s)")
+            for idx in reversed(orphaned_idx):
+                del model.graph.initializer[idx]
+
+        self._save_variants(model, self.full_model_dir, "full_model")
+
+    # ════════════════════ variant saving ════════════════════
+
+    def _save_variants(self, model, out_dir, prefix):
+        """Save variants with shared weights.data."""
+        os.makedirs(out_dir, exist_ok=True)
+        stale = os.path.join(out_dir, "weights.data")
+        if os.path.exists(stale):
+            os.remove(stale)
+
+        orig_in = {i.name: self._save_vi_shape(i) for i in model.graph.input}
+        orig_out = {o.name: self._save_vi_shape(o)
+                    for o in model.graph.output}
+        orig_vi = {v.name: self._save_vi_shape(v)
+                   for v in model.graph.value_info}
+
+        for idx, (vname, dim_map) in enumerate(self.variants):
+            if self.model_type == "llm":
+                eff = dim_map if isinstance(dim_map, int) and dim_map else 128
+                existing_idx = None
+                for i, init in enumerate(model.graph.initializer):
+                    if init.name == TOTAL_SEQ_LEN_CONST_NAME:
+                        existing_idx = i
+                        break
+                t = numpy_helper.from_array(
+                    np.array(eff, dtype=np.int32),
+                    name=TOTAL_SEQ_LEN_CONST_NAME)
+                if existing_idx is not None:
+                    model.graph.initializer[existing_idx].CopyFrom(t)
+                else:
+                    model.graph.initializer.append(t)
+
+            for vi in list(model.graph.input) + list(model.graph.output) \
+                    + list(model.graph.value_info):
+                self._set_vi_shape(vi, dim_map)
+
+            path = os.path.join(out_dir, f"{prefix}_{vname}.onnx")
+            if idx == 0:
+                onnx.save(model, path,
+                          save_as_external_data=True,
+                          all_tensors_to_one_file=True,
+                          location="weights.data",
+                          size_threshold=1024)
+            else:
+                with open(path, "wb") as f:
+                    f.write(model.SerializeToString())
+            print(f"  Saved: {path}")
+
+            for vi in model.graph.input:
+                self._restore_vi_shape(vi, orig_in.get(vi.name))
+            for vi in model.graph.output:
+                self._restore_vi_shape(vi, orig_out.get(vi.name))
+            for vi in model.graph.value_info:
+                self._restore_vi_shape(vi, orig_vi.get(vi.name))
+
+    # ── Shape helpers ──
+
+    @staticmethod
+    def _save_vi_shape(vi):
+        if not vi.type.tensor_type.shape \
+                or len(vi.type.tensor_type.shape.dim) == 0:
+            return None
+        return [("param", d.dim_param) if d.dim_param else ("value", d.dim_value)
+                for d in vi.type.tensor_type.shape.dim]
+
+    @staticmethod
+    def _restore_vi_shape(vi, saved):
+        if saved is None:
+            return
+        for dim, (kind, val) in zip(vi.type.tensor_type.shape.dim, saved):
+            if kind == "param":
+                dim.ClearField("dim_value")
+                dim.dim_param = val
+            else:
+                dim.ClearField("dim_param")
+                dim.dim_value = val
+
+    @staticmethod
+    def _set_vi_shape(vi, dim_map):
+        if not vi.type.tensor_type.shape:
+            return
+        for dim in vi.type.tensor_type.shape.dim:
+            if dim.dim_param:
+                val = resolve_dim_param(dim.dim_param, dim_map)
+                if isinstance(val, int):
+                    dim.ClearField("dim_param")
+                    dim.dim_value = val
+
+    # ── run ──
+
+    def run(self):
+        self.extract_all_single_ops()
+        self.extract_single_layer()
+        self.extract_full_model()
+        print("\n" + "=" * 60)
+        print("Done!")
+        print("=" * 60)
+
+
+# ─────────────────────── main ───────────────────────
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Universal ONNX submodel extractor for LLMs "
+                    "(auto-discovers graph topology)")
+    parser.add_argument("--model", required=True,
+                        help="Path to model.onnx")
+    parser.add_argument("--output", default=None,
+                        help="Output directory (default: same as model)")
+    parser.add_argument("--only",
+                        choices=["single_op", "single_layer", "full_model"],
+                        help="Run only a specific extraction step")
+    args = parser.parse_args()
+
+    extractor = SingleOpExtractor(args.model, output_dir=args.output)
+    if args.only == "single_op":
+        extractor.extract_all_single_ops()
+    elif args.only == "single_layer":
+        extractor.extract_single_layer()
+    elif args.only == "full_model":
+        extractor.extract_full_model()
+    else:
+        extractor.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/onnx-model-splitter/genai_config_pipeline_from_folder.py
+++ b/tools/onnx-model-splitter/genai_config_pipeline_from_folder.py
@@ -32,6 +32,14 @@ side so the tool still produces a usable template.
 Fully custom main-input names with neither pattern above must provide an ONNX input name
 string array in ``model.decoder.pipeline.prefill.inputs``.
 
+When ``model_dir`` is passed to the builder (CLI default), if ``prefill_*.onnx`` and
+``decode_*.onnx`` are found (search: ``model_dir``, then ``chunk/``, ``full_model/``,
+``export_fixed_ctx/full_model/``, plus any ``--onnx-subdir`` prefixes), **I/O name lists
+are read from the ONNX graphs** so sparse KV / extra state tensors / binding order match
+the exported model (e.g. Qwen3.5). If ONNX is missing or ``onnx`` is not installed, the
+script falls back to template lists derived from ``decoder.inputs``. Use ``--no-onnx-io``
+to force templates only.
+
 The output is a **template**: ``decoder`` always includes both
 ``fixed_prompt_length`` and ``sliding_window``
 (``window_size`` equals ``fixed_prompt_length`` and contains ``alignment: "left"``),
@@ -49,6 +57,57 @@ from typing import Any
 
 # Keep chunk==0 naming consistent with export_llama_fixed_ctx.py variants.
 CHUNK_ZERO_STEM = "12200"
+
+# Relative to model_dir when resolving prefill/decode ONNX paths (first existing file wins).
+_DEFAULT_ONNX_SEARCH_SUBDIRS: tuple[str, ...] = (
+    ".",
+    "chunk",
+    "full_model",
+    os.path.join("export_fixed_ctx", "full_model"),
+)
+
+
+def _find_onnx_path(
+    model_dir: str,
+    onnx_basename: str,
+    search_subdirs: tuple[str, ...],
+) -> str | None:
+    """Return absolute path to ``onnx_basename`` under ``model_dir`` / subdirs, or None."""
+    root = os.path.abspath(model_dir)
+    raw = str(onnx_basename).strip()
+    base = os.path.basename(raw)
+    if not base:
+        return None
+    if os.path.isabs(raw) and os.path.isfile(raw):
+        return raw
+    if base != os.path.basename(os.path.normpath(raw)):
+        return None
+    for sub in search_subdirs:
+        sub_path = os.path.normpath(os.path.join(root, sub))
+        try:
+            if os.path.commonpath([root, sub_path]) != root:
+                continue
+        except ValueError:
+            continue
+        cand = os.path.join(sub_path, base)
+        if os.path.isfile(cand):
+            return cand
+    return None
+
+
+def _onnx_graph_io_lists(onnx_path: str) -> tuple[list[str], list[str]]:
+    """Graph input and output tensor names in ONNX order (``load_external_data=False``)."""
+    try:
+        import onnx
+    except ImportError as e:
+        raise ImportError(
+            "The 'onnx' package is required to read I/O names from ONNX files "
+            "(pip install onnx), or pass --no-onnx-io to use template lists only."
+        ) from e
+
+    model = onnx.load(onnx_path, load_external_data=False)
+    g = model.graph
+    return [vi.name for vi in g.input], [vi.name for vi in g.output]
 
 
 def _default_stem(fixed_prompt: int, max_length: int) -> str:
@@ -308,7 +367,10 @@ def build_pipeline_config(
     prefill_filename: str,
     decode_filename: str,
     session_options_override: dict[str, Any] | None,
-) -> dict[str, Any]:
+    model_dir: str | None = None,
+    read_onnx_io: bool = True,
+    onnx_io_search_subdirs: tuple[str, ...] | None = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
     extracted = _extract_decoder_fields(src_flat)
     tok = extracted["model_partial"]
     dec = extracted["decoder_partial"]
@@ -351,8 +413,19 @@ def build_pipeline_config(
                 continue
             session_opts[k] = copy.deepcopy(v)
 
+    meta: dict[str, Any] = {
+        "pipeline_io_source": "template",
+        "onnx_prefill_path": None,
+        "onnx_decode_path": None,
+    }
+    pin: list[str] | None = None
+    pout: list[str] | None = None
+    pin_decode: list[str] | None = None
+    pout_decode: list[str] | None = None
+
     if isinstance(pin_src, list) and pin_src:
         pin = list(pin_src)
+        meta["pipeline_io_source"] = "source_config"
         if isinstance(por_src, list) and por_src:
             pout = list(por_src)
         else:
@@ -365,18 +438,35 @@ def build_pipeline_config(
             pout_decode = list(dor_src)
         else:
             pout_decode = list(pout)
-    elif layout in (INPUT_LAYOUT_FULL_IDS, INPUT_LAYOUT_EMBEDS):
-        pin = _pipeline_inputs_from_decoder_templates(inputs_tmpl, int(n_layers))
-        pout = _pipeline_outputs_from_layer_count(int(n_layers))
-        pin_decode = list(pin)
-        pout_decode = list(pout)
     else:
-        raise ValueError(
-            "Cannot infer main model inputs from decoder.inputs (neither input_ids nor "
-            "inputs_embeds found): provide an ONNX input-name list (string array) in "
-            "model.decoder.pipeline.prefill.inputs; optional decode.inputs / "
-            "prefill.outputs / decode.outputs are also supported."
-        )
+        subdirs = onnx_io_search_subdirs or _DEFAULT_ONNX_SEARCH_SUBDIRS
+        if read_onnx_io and model_dir:
+            pp = _find_onnx_path(model_dir, prefill_filename, subdirs)
+            dp = _find_onnx_path(model_dir, decode_filename, subdirs)
+            if pp and dp:
+                try:
+                    pin, pout = _onnx_graph_io_lists(pp)
+                    pin_decode, pout_decode = _onnx_graph_io_lists(dp)
+                    meta["pipeline_io_source"] = "onnx"
+                    meta["onnx_prefill_path"] = pp
+                    meta["onnx_decode_path"] = dp
+                except Exception as exc:  # noqa: BLE001
+                    meta["onnx_read_error"] = str(exc)
+                    pin = pout = pin_decode = pout_decode = None
+
+        if pin is None and layout in (INPUT_LAYOUT_FULL_IDS, INPUT_LAYOUT_EMBEDS):
+            pin = _pipeline_inputs_from_decoder_templates(inputs_tmpl, int(n_layers))
+            pout = _pipeline_outputs_from_layer_count(int(n_layers))
+            pin_decode = list(pin)
+            pout_decode = list(pout)
+            if meta.get("pipeline_io_source") != "source_config":
+                meta["pipeline_io_source"] = "template"
+        elif pin is None:
+            raise ValueError(
+                "Cannot infer pipeline I/O: no decoder.pipeline.prefill.inputs in source; "
+                "ONNX files for prefill/decode were not found or could not be read; and "
+                "decoder.inputs has neither input_ids nor inputs_embeds for template lists."
+            )
 
     # Keep key order aligned with Llama decoder-pipeline configs in this repo for cleaner diffs.
     decoder: dict[str, Any] = {
@@ -446,7 +536,7 @@ def build_pipeline_config(
                 search[k] = v
         search["max_length"] = int(max_length)
 
-    return {"model": model_out, "search": search}
+    return {"model": model_out, "search": search}, meta
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -505,6 +595,19 @@ def main(argv: list[str] | None = None) -> int:
         metavar="PATH",
         help="JSON object: merge additional keys after fixed session_options (same as genai_config_12200)",
     )
+    p.add_argument(
+        "--no-onnx-io",
+        action="store_true",
+        help="Do not read pipeline prefill/decode I/O from ONNX; use template lists only.",
+    )
+    p.add_argument(
+        "--onnx-subdir",
+        action="append",
+        default=None,
+        dest="onnx_subdirs_append",
+        metavar="RELDIR",
+        help="Prepend RELDIR to ONNX search dirs (relative to model_dir). Repeatable.",
+    )
     args = p.parse_args(argv)
 
     model_dir = os.path.abspath(args.model_dir)
@@ -540,13 +643,23 @@ def main(argv: list[str] | None = None) -> int:
         if not isinstance(session_override, dict):
             raise ValueError("session-options-json root must be an object")
 
-    out_cfg = build_pipeline_config(
+    onnx_sd: tuple[str, ...] | None = None
+    if args.onnx_subdirs_append:
+        onnx_sd = tuple(
+            str(x).strip() for x in args.onnx_subdirs_append if str(x).strip()
+        )
+        onnx_sd = onnx_sd + _DEFAULT_ONNX_SEARCH_SUBDIRS
+
+    out_cfg, io_meta = build_pipeline_config(
         src_root,
         fixed_prompt_length=fixed_p,
         max_length=max_len,
         prefill_filename=prefill_fn,
         decode_filename=decode_fn,
         session_options_override=session_override,
+        model_dir=model_dir,
+        read_onnx_io=not args.no_onnx_io,
+        onnx_io_search_subdirs=onnx_sd,
     )
 
     out_path = args.output or os.path.join(model_dir, "genai_config_pipeline.json")
@@ -558,6 +671,13 @@ def main(argv: list[str] | None = None) -> int:
 
     print(f"wrote: {out_path}")
     print(f"  stem={stem} prefill={prefill_fn} decode={decode_fn} max_length={max_len}")
+    src = io_meta.get("pipeline_io_source", "?")
+    print(f"  pipeline_io_source={src}")
+    if src == "onnx":
+        print(f"  onnx_prefill={io_meta.get('onnx_prefill_path')}")
+        print(f"  onnx_decode={io_meta.get('onnx_decode_path')}")
+    elif io_meta.get("onnx_read_error"):
+        print(f"  onnx_read_error={io_meta.get('onnx_read_error')}")
     return 0
 
 

--- a/tools/onnx-model-splitter/genai_config_pipeline_from_folder.py
+++ b/tools/onnx-model-splitter/genai_config_pipeline_from_folder.py
@@ -21,13 +21,14 @@ Default output: ``<model_dir>/genai_config_pipeline.json`` (override with ``-o``
 and `provider_options` is forced to ``[{"MorphiZenEP": {}}]``.
 Optional `--session-options-json` only merges other keys and never overrides those two.
 
-Standard text-only LLM (`input_ids`): missing keys are filled with common defaults,
-and ``pipeline.inputs`` is generated in
-``input_ids → attention_mask → position_ids → past_*`` order.
-Embedded-input models (Qwen3.5 / Gemma3, etc.): `decoder.inputs` uses
-``inputs_embeds``, ``attention_mask``, ``position_ids``, ``past_*`` without `input_ids`;
-the script generates pipeline lists in
-``inputs_embeds → attention_mask → position_ids → past_*`` order.
+For ``decoder.inputs`` / ``decoder.outputs``: **keys absent in the source are not
+back-filled** from Llama-style defaults (e.g. gptoss without ``position_ids`` stays
+without it; partial ``outputs`` stays partial). ``pipeline.inputs`` order follows only
+bindings present: ``input_ids`` or ``inputs_embeds``, then optional ``attention_mask`` /
+``position_ids``, then ``past_*`` (``past_key_names`` / ``past_value_names`` are still
+required when auto-building lists). If ``decoder.inputs`` or ``decoder.outputs`` is
+missing or empty (e.g. bare HF ``config.json``), the full default maps are used for that
+side so the tool still produces a usable template.
 Fully custom main-input names with neither pattern above must provide an ONNX input name
 string array in ``model.decoder.pipeline.prefill.inputs``.
 
@@ -91,6 +92,10 @@ def _merge_decoder_io_templates(
 ) -> tuple[dict[str, str], dict[str, str], str]:
     """Merge ``decoder.inputs`` / ``outputs`` templates.
 
+    Source ``inputs`` / ``outputs`` dicts: keys are **not** back-filled from defaults.
+    If ``inputs`` (or ``outputs``) is missing, non-dict, or has no non-empty values after
+    filtering, the full default map is used for that side only.
+
     Returns:
         ``(merged_inputs, merged_outputs, input_layout_kind)``, where
         ``input_layout_kind`` is ``full_ids`` | ``embeds`` | ``custom``.
@@ -100,9 +105,8 @@ def _merge_decoder_io_templates(
         for k, v in outputs.items():
             if v is not None and str(v).strip() != "":
                 merged_out[str(k)] = str(v)
-    for k, v in _DEFAULT_DECODER_OUTPUTS.items():
-        if k not in merged_out:
-            merged_out[k] = v
+    if not merged_out:
+        merged_out = dict(_DEFAULT_DECODER_OUTPUTS)
 
     if inputs is None:
         return dict(_DEFAULT_DECODER_INPUTS), merged_out, INPUT_LAYOUT_FULL_IDS
@@ -119,25 +123,11 @@ def _merge_decoder_io_templates(
         return dict(_DEFAULT_DECODER_INPUTS), merged_out, INPUT_LAYOUT_FULL_IDS
 
     if merged_in.get("inputs_embeds"):
-        for k in (
-            "attention_mask",
-            "position_ids",
-            "past_key_names",
-            "past_value_names",
-        ):
-            if k not in merged_in:
-                merged_in[k] = _DEFAULT_DECODER_INPUTS[k]
         return merged_in, merged_out, INPUT_LAYOUT_EMBEDS
 
     if merged_in.get("input_ids"):
-        for k, v in _DEFAULT_DECODER_INPUTS.items():
-            if k not in merged_in:
-                merged_in[k] = v
         return merged_in, merged_out, INPUT_LAYOUT_FULL_IDS
 
-    for k in ("past_key_names", "past_value_names"):
-        if k not in merged_in:
-            merged_in[k] = _DEFAULT_DECODER_INPUTS[k]
     return merged_in, merged_out, INPUT_LAYOUT_CUSTOM
 
 
@@ -348,16 +338,11 @@ def build_pipeline_config(
         if not inputs_tmpl.get(key):
             raise ValueError(f"decoder.inputs incomplete, missing: {key}")
     if layout == INPUT_LAYOUT_FULL_IDS:
-        for key in ("input_ids", "attention_mask", "position_ids"):
-            if not inputs_tmpl.get(key):
-                raise ValueError(f"decoder.inputs incomplete, missing: {key}")
+        if not inputs_tmpl.get("input_ids"):
+            raise ValueError("decoder.inputs incomplete, missing: input_ids")
     elif layout == INPUT_LAYOUT_EMBEDS:
-        for key in ("inputs_embeds", "attention_mask", "position_ids"):
-            if not inputs_tmpl.get(key):
-                raise ValueError(f"decoder.inputs incomplete, missing: {key}")
-    for key in ("logits", "present_key_names", "present_value_names"):
-        if not outputs_tmpl.get(key):
-            raise ValueError(f"decoder.outputs incomplete, missing: {key}")
+        if not inputs_tmpl.get("inputs_embeds"):
+            raise ValueError("decoder.inputs incomplete, missing: inputs_embeds")
 
     session_opts = _canonical_morphizen_session_options()
     if session_options_override:

--- a/tools/onnx-model-splitter/genai_config_pipeline_from_folder.py
+++ b/tools/onnx-model-splitter/genai_config_pipeline_from_folder.py
@@ -1,0 +1,567 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Read structural metadata from `genai_config.json` (or another JSON) in a model folder,
+then generate a `decoder-pipeline` style `genai_config.json` for ORT GenAI.
+
+Typical usage (folder contains a single-model `model.onnx` config; prepare prefill/decode ONNX files separately)::
+
+    python genai_config_pipeline_from_folder.py D:\\path\\Llama-3.1-8B-awq-g128-int4-onnx-directml \\
+        --fixed-prompt-length 128 --max-length 4096
+
+Default output: ``<model_dir>/genai_config_pipeline.json`` (override with ``-o``).
+
+`decoder.session_options` follows the same shape as
+`Llama-3.1-8B/genai_config_12200.json`:
+`session.disable_cpu_ep_fallback` is forced to ``"1"``,
+and `provider_options` is forced to ``[{"MorphiZenEP": {}}]``.
+Optional `--session-options-json` only merges other keys and never overrides those two.
+
+Standard text-only LLM (`input_ids`): missing keys are filled with common defaults,
+and ``pipeline.inputs`` is generated in
+``input_ids → attention_mask → position_ids → past_*`` order.
+Embedded-input models (Qwen3.5 / Gemma3, etc.): `decoder.inputs` uses
+``inputs_embeds``, ``attention_mask``, ``position_ids``, ``past_*`` without `input_ids`;
+the script generates pipeline lists in
+``inputs_embeds → attention_mask → position_ids → past_*`` order.
+Fully custom main-input names with neither pattern above must provide an ONNX input name
+string array in ``model.decoder.pipeline.prefill.inputs``.
+
+The output is a **template**: ``decoder`` always includes both
+``fixed_prompt_length`` and ``sliding_window``
+(``window_size`` equals ``fixed_prompt_length`` and contains ``alignment: "left"``),
+so it can be adjusted manually afterward.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import os
+import sys
+from typing import Any
+
+# Keep chunk==0 naming consistent with export_llama_fixed_ctx.py variants.
+CHUNK_ZERO_STEM = "12200"
+
+
+def _default_stem(fixed_prompt: int, max_length: int) -> str:
+    if fixed_prompt == 12200:
+        return CHUNK_ZERO_STEM
+    return f"p{fixed_prompt}m{max_length}"
+
+
+def _canonical_morphizen_session_options() -> dict[str, Any]:
+    """Match ``decoder.session_options`` from ``genai_config_12200.json``."""
+    return {
+        "session.disable_cpu_ep_fallback": "1",
+        "provider_options": [{"MorphiZenEP": {}}],
+    }
+
+
+# ORT GenAI decoder.inputs / decoder.outputs naming templates
+# (aligned with Llama genai_config files in this repo).
+_DEFAULT_DECODER_INPUTS: dict[str, str] = {
+    "input_ids": "input_ids",
+    "attention_mask": "attention_mask",
+    "position_ids": "position_ids",
+    "past_key_names": "past_key_values.%d.key",
+    "past_value_names": "past_key_values.%d.value",
+}
+_DEFAULT_DECODER_OUTPUTS: dict[str, str] = {
+    "logits": "logits",
+    "present_key_names": "present.%d.key",
+    "present_value_names": "present.%d.value",
+}
+
+# decoder.inputs layout kinds (for validation and pipeline.inputs auto-ordering).
+INPUT_LAYOUT_FULL_IDS = "full_ids"
+INPUT_LAYOUT_EMBEDS = "embeds"
+INPUT_LAYOUT_CUSTOM = "custom"
+
+
+def _merge_decoder_io_templates(
+    inputs: dict[str, Any] | None,
+    outputs: dict[str, Any] | None,
+) -> tuple[dict[str, str], dict[str, str], str]:
+    """Merge ``decoder.inputs`` / ``outputs`` templates.
+
+    Returns:
+        ``(merged_inputs, merged_outputs, input_layout_kind)``, where
+        ``input_layout_kind`` is ``full_ids`` | ``embeds`` | ``custom``.
+    """
+    merged_out: dict[str, str] = {}
+    if isinstance(outputs, dict):
+        for k, v in outputs.items():
+            if v is not None and str(v).strip() != "":
+                merged_out[str(k)] = str(v)
+    for k, v in _DEFAULT_DECODER_OUTPUTS.items():
+        if k not in merged_out:
+            merged_out[k] = v
+
+    if inputs is None:
+        return dict(_DEFAULT_DECODER_INPUTS), merged_out, INPUT_LAYOUT_FULL_IDS
+
+    if not isinstance(inputs, dict):
+        return dict(_DEFAULT_DECODER_INPUTS), merged_out, INPUT_LAYOUT_FULL_IDS
+
+    merged_in: dict[str, str] = {}
+    for k, v in inputs.items():
+        if v is not None and str(v).strip() != "":
+            merged_in[str(k)] = str(v)
+
+    if not merged_in:
+        return dict(_DEFAULT_DECODER_INPUTS), merged_out, INPUT_LAYOUT_FULL_IDS
+
+    if merged_in.get("inputs_embeds"):
+        for k in ("attention_mask", "position_ids", "past_key_names", "past_value_names"):
+            if k not in merged_in:
+                merged_in[k] = _DEFAULT_DECODER_INPUTS[k]
+        return merged_in, merged_out, INPUT_LAYOUT_EMBEDS
+
+    if merged_in.get("input_ids"):
+        for k, v in _DEFAULT_DECODER_INPUTS.items():
+            if k not in merged_in:
+                merged_in[k] = v
+        return merged_in, merged_out, INPUT_LAYOUT_FULL_IDS
+
+    for k in ("past_key_names", "past_value_names"):
+        if k not in merged_in:
+            merged_in[k] = _DEFAULT_DECODER_INPUTS[k]
+    return merged_in, merged_out, INPUT_LAYOUT_CUSTOM
+
+
+def _extract_pipeline_io_lists_from_decoder(
+    dec: dict[str, Any],
+) -> tuple[list[str] | None, list[str] | None, list[str] | None, list[str] | None]:
+    """Read prefill/decode input/output lists from ``decoder.pipeline`` when present."""
+    pipe = dec.get("pipeline")
+    if not isinstance(pipe, dict):
+        return None, None, None, None
+    pre = pipe.get("prefill")
+    dblk = pipe.get("decode")
+    pin = por = din = dor = None
+    if isinstance(pre, dict):
+        if isinstance(pre.get("inputs"), list) and pre["inputs"]:
+            pin = [str(x) for x in pre["inputs"]]
+        if isinstance(pre.get("outputs"), list) and pre["outputs"]:
+            por = [str(x) for x in pre["outputs"]]
+    if isinstance(dblk, dict):
+        if isinstance(dblk.get("inputs"), list) and dblk["inputs"]:
+            din = [str(x) for x in dblk["inputs"]]
+        if isinstance(dblk.get("outputs"), list) and dblk["outputs"]:
+            dor = [str(x) for x in dblk["outputs"]]
+    return pin, por, din, dor
+
+
+def _pipeline_io_lists(num_hidden_layers: int) -> tuple[list[str], list[str]]:
+    """Prefill/decode I/O name lists matching existing Llama pipeline configs."""
+    return (
+        _pipeline_inputs_from_decoder_templates(
+            dict(_DEFAULT_DECODER_INPUTS), num_hidden_layers),
+        _pipeline_outputs_from_layer_count(num_hidden_layers),
+    )
+
+
+def _pipeline_outputs_from_layer_count(num_hidden_layers: int) -> list[str]:
+    outputs: list[str] = ["logits"]
+    for i in range(num_hidden_layers):
+        outputs.append(f"present.{i}.key")
+        outputs.append(f"present.{i}.value")
+    return outputs
+
+
+def _pipeline_inputs_from_decoder_templates(
+    inputs_tmpl: dict[str, str],
+    num_hidden_layers: int,
+) -> list[str]:
+    """Generate ONNX input-name order from ``decoder.inputs`` bindings (embeds-first for Qwen/Gemma)."""
+    pin: list[str] = []
+    if inputs_tmpl.get("inputs_embeds"):
+        pin.append(inputs_tmpl["inputs_embeds"])
+    elif inputs_tmpl.get("input_ids"):
+        pin.append(inputs_tmpl["input_ids"])
+    for k in ("attention_mask", "position_ids"):
+        v = inputs_tmpl.get(k)
+        if v:
+            pin.append(v)
+    pk = inputs_tmpl.get("past_key_names") or _DEFAULT_DECODER_INPUTS["past_key_names"]
+    pv = inputs_tmpl.get("past_value_names") or _DEFAULT_DECODER_INPUTS["past_value_names"]
+    for i in range(num_hidden_layers):
+        pin.append(pk % i)
+        pin.append(pv % i)
+    return pin
+
+
+def _load_json(path: str) -> dict[str, Any]:
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, dict):
+        raise ValueError(f"JSON root must be an object: {path}")
+    return data
+
+
+def _find_config_file(model_dir: str, config_name: str | None) -> str:
+    if config_name:
+        p = os.path.join(model_dir, config_name)
+        if not os.path.isfile(p):
+            raise FileNotFoundError(f"Specified config file not found: {p}")
+        return p
+    candidates = ["genai_config.json", "config.json"]
+    for name in candidates:
+        p = os.path.join(model_dir, name)
+        if os.path.isfile(p):
+            return p
+    raise FileNotFoundError(
+        f"Neither genai_config.json nor config.json was found in directory: {model_dir}"
+    )
+
+
+def _extract_decoder_fields(src: dict[str, Any]) -> dict[str, Any]:
+    """Extract decoder/architecture fields from GenAI or HuggingFace-style configs."""
+    model = src.get("model")
+    if isinstance(model, dict) and isinstance(model.get("decoder"), dict):
+        dec = model["decoder"]
+        pin0, por0, din0, dor0 = _extract_pipeline_io_lists_from_decoder(dec)
+        raw_in = dec.get("inputs")
+        raw_out = dec.get("outputs")
+        merged_in, merged_out, layout_kind = _merge_decoder_io_templates(
+            raw_in if isinstance(raw_in, dict) else None,
+            raw_out if isinstance(raw_out, dict) else None,
+        )
+        out = {
+            "head_size": dec.get("head_size"),
+            "hidden_size": dec.get("hidden_size"),
+            "num_attention_heads": dec.get("num_attention_heads"),
+            "num_key_value_heads": dec.get("num_key_value_heads"),
+            "num_hidden_layers": dec.get("num_hidden_layers"),
+            "inputs": merged_in,
+            "outputs": merged_out,
+            "session_options": copy.deepcopy(dec.get("session_options")),
+            "input_layout_kind": layout_kind,
+            "prefill_pipeline_inputs": pin0,
+            "prefill_pipeline_outputs": por0,
+            "decode_pipeline_inputs": din0,
+            "decode_pipeline_outputs": dor0,
+        }
+        tok = {
+            "bos_token_id": model.get("bos_token_id"),
+            "eos_token_id": model.get("eos_token_id"),
+            "pad_token_id": model.get("pad_token_id"),
+            "vocab_size": model.get("vocab_size"),
+            "context_length": model.get("context_length"),
+        }
+        return {"model_partial": tok, "decoder_partial": out}
+
+    # HuggingFace config.json (without nested decoder section)
+    n_layers = src.get("num_hidden_layers")
+    n_heads = src.get("num_attention_heads")
+    n_kv = src.get("num_key_value_heads", n_heads)
+    hidden = src.get("hidden_size")
+    head_size = None
+    if hidden is not None and n_heads:
+        try:
+            head_size = int(hidden) // int(n_heads)
+        except (TypeError, ZeroDivisionError):
+            head_size = None
+    merged_in, merged_out, layout_hf = _merge_decoder_io_templates(None, None)
+    dec = {
+        "head_size": head_size,
+        "hidden_size": hidden,
+        "num_attention_heads": n_heads,
+        "num_key_value_heads": n_kv,
+        "num_hidden_layers": n_layers,
+        "inputs": merged_in,
+        "outputs": merged_out,
+        "session_options": None,
+        "input_layout_kind": layout_hf,
+        "prefill_pipeline_inputs": None,
+        "prefill_pipeline_outputs": None,
+        "decode_pipeline_inputs": None,
+        "decode_pipeline_outputs": None,
+    }
+    tok = {
+        "bos_token_id": src.get("bos_token_id"),
+        "eos_token_id": src.get("eos_token_id"),
+        "pad_token_id": src.get("pad_token_id"),
+        "vocab_size": src.get("vocab_size"),
+        "context_length": src.get("max_position_embeddings"),
+    }
+    return {"model_partial": tok, "decoder_partial": dec}
+
+
+def _validate_required(d: dict[str, Any], label: str) -> None:
+    missing = [k for k, v in d.items() if v is None]
+    if missing:
+        raise ValueError(f"{label} missing fields: {', '.join(missing)}")
+
+
+def build_pipeline_config(
+    src_flat: dict[str, Any],
+    *,
+    fixed_prompt_length: int,
+    max_length: int,
+    prefill_filename: str,
+    decode_filename: str,
+    session_options_override: dict[str, Any] | None,
+) -> dict[str, Any]:
+    extracted = _extract_decoder_fields(src_flat)
+    tok = extracted["model_partial"]
+    dec = extracted["decoder_partial"]
+
+    n_layers = dec["num_hidden_layers"]
+    _validate_required(
+        {
+            "num_hidden_layers": n_layers,
+            "head_size": dec["head_size"],
+            "hidden_size": dec["hidden_size"],
+            "num_attention_heads": dec["num_attention_heads"],
+            "num_key_value_heads": dec["num_key_value_heads"],
+            "vocab_size": tok["vocab_size"],
+        },
+        "building pipeline config",
+    )
+
+    inputs_tmpl = dec["inputs"] or {}
+    outputs_tmpl = dec["outputs"] or {}
+    layout = str(dec.get("input_layout_kind") or INPUT_LAYOUT_FULL_IDS)
+    pin_src = dec.get("prefill_pipeline_inputs")
+    por_src = dec.get("prefill_pipeline_outputs")
+    din_src = dec.get("decode_pipeline_inputs")
+    dor_src = dec.get("decode_pipeline_outputs")
+
+    for key in ("past_key_names", "past_value_names"):
+        if not inputs_tmpl.get(key):
+            raise ValueError(f"decoder.inputs incomplete, missing: {key}")
+    if layout == INPUT_LAYOUT_FULL_IDS:
+        for key in ("input_ids", "attention_mask", "position_ids"):
+            if not inputs_tmpl.get(key):
+                raise ValueError(f"decoder.inputs incomplete, missing: {key}")
+    elif layout == INPUT_LAYOUT_EMBEDS:
+        for key in ("inputs_embeds", "attention_mask", "position_ids"):
+            if not inputs_tmpl.get(key):
+                raise ValueError(f"decoder.inputs incomplete, missing: {key}")
+    for key in ("logits", "present_key_names", "present_value_names"):
+        if not outputs_tmpl.get(key):
+            raise ValueError(f"decoder.outputs incomplete, missing: {key}")
+
+    session_opts = _canonical_morphizen_session_options()
+    if session_options_override:
+        for k, v in session_options_override.items():
+            if k in ("session.disable_cpu_ep_fallback", "provider_options"):
+                continue
+            session_opts[k] = copy.deepcopy(v)
+
+    if isinstance(pin_src, list) and pin_src:
+        pin = list(pin_src)
+        if isinstance(por_src, list) and por_src:
+            pout = list(por_src)
+        else:
+            pout = _pipeline_outputs_from_layer_count(int(n_layers))
+        if isinstance(din_src, list) and din_src:
+            pin_decode = list(din_src)
+        else:
+            pin_decode = list(pin)
+        if isinstance(dor_src, list) and dor_src:
+            pout_decode = list(dor_src)
+        else:
+            pout_decode = list(pout)
+    elif layout in (INPUT_LAYOUT_FULL_IDS, INPUT_LAYOUT_EMBEDS):
+        pin = _pipeline_inputs_from_decoder_templates(inputs_tmpl, int(n_layers))
+        pout = _pipeline_outputs_from_layer_count(int(n_layers))
+        pin_decode = list(pin)
+        pout_decode = list(pout)
+    else:
+        raise ValueError(
+            "Cannot infer main model inputs from decoder.inputs (neither input_ids nor "
+            "inputs_embeds found): provide an ONNX input-name list (string array) in "
+            "model.decoder.pipeline.prefill.inputs; optional decode.inputs / "
+            "prefill.outputs / decode.outputs are also supported."
+        )
+
+    # Keep key order aligned with Llama decoder-pipeline configs in this repo for cleaner diffs.
+    decoder: dict[str, Any] = {
+        "head_size": dec["head_size"],
+        "hidden_size": dec["hidden_size"],
+        "num_attention_heads": dec["num_attention_heads"],
+        "num_key_value_heads": dec["num_key_value_heads"],
+        "num_hidden_layers": dec["num_hidden_layers"],
+    }
+    fp = int(fixed_prompt_length)
+    decoder["fixed_prompt_length"] = fp
+    decoder["sliding_window"] = {
+        "window_size": fp,
+        "alignment": "left",
+        "slide_inputs": True,
+        "slide_key_value_cache": False,
+    }
+    decoder["session_options"] = session_opts
+    decoder["inputs"] = inputs_tmpl
+    decoder["outputs"] = outputs_tmpl
+    decoder["pipeline"] = {
+        "prefill": {
+            "filename": prefill_filename,
+            "run_on_prompt": True,
+            "run_on_token_gen": False,
+            "inputs": pin,
+            "outputs": pout,
+        },
+        "decode": {
+            "filename": decode_filename,
+            "run_on_prompt": False,
+            "run_on_token_gen": True,
+            "inputs": pin_decode,
+            "outputs": pout_decode,
+        },
+    }
+
+    model_out: dict[str, Any] = {
+        "bos_token_id": tok["bos_token_id"],
+        "eos_token_id": tok["eos_token_id"],
+        "pad_token_id": tok["pad_token_id"],
+        "vocab_size": tok["vocab_size"],
+        "context_length": int(max_length),
+        "type": "decoder-pipeline",
+        "decoder": decoder,
+    }
+
+    search = {
+        "diversity_penalty": 0.0,
+        "do_sample": True,
+        "early_stopping": True,
+        "length_penalty": 1.0,
+        "max_length": int(max_length),
+        "min_length": 0,
+        "no_repeat_ngram_size": 0,
+        "num_beams": 1,
+        "num_return_sequences": 1,
+        "past_present_share_buffer": True,
+        "repetition_penalty": 1.0,
+        "temperature": 0.6,
+        "top_k": 1,
+        "top_p": 0.9,
+    }
+    if isinstance(src_flat.get("search"), dict):
+        for k, v in src_flat["search"].items():
+            if k in search:
+                search[k] = v
+        search["max_length"] = int(max_length)
+
+    return {"model": model_out, "search": search}
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description="Read model-folder config and generate decoder-pipeline genai_config.json",
+    )
+    p.add_argument(
+        "model_dir",
+        help="Model directory (must contain genai_config.json, or use --input-config)",
+    )
+    p.add_argument(
+        "-o",
+        "--output",
+        help="Output JSON path (default: <model_dir>/genai_config_pipeline.json)",
+    )
+    p.add_argument(
+        "--input-config",
+        metavar="NAME",
+        help="Config filename under model_dir (default auto-detect: genai_config.json or config.json)",
+    )
+    p.add_argument(
+        "--fixed-prompt-length",
+        type=int,
+        default=128,
+        metavar="P",
+        help="decoder.fixed_prompt_length; sliding_window.window_size uses the same value (default 128).",
+    )
+    p.add_argument(
+        "--max-length",
+        type=int,
+        default=None,
+        metavar="M",
+        help="model.context_length and search.max_length (default from source context_length/max_position_embeddings)",
+    )
+    p.add_argument(
+        "--stem",
+        default=None,
+        help="Variant filename stem used for default prefill/decode names: "
+        "prefill_{stem}.onnx / decode_{stem}.onnx; if omitted, auto-generate "
+        "p{P}m{M} (or 12200 when P=12200)",
+    )
+    p.add_argument(
+        "--prefill",
+        dest="prefill_filename",
+        default=None,
+        help="Override prefill ONNX filename (default prefill_{stem}.onnx)",
+    )
+    p.add_argument(
+        "--decode",
+        dest="decode_filename",
+        default=None,
+        help="Override decode ONNX filename (default decode_{stem}.onnx)",
+    )
+    p.add_argument(
+        "--session-options-json",
+        metavar="PATH",
+        help="JSON object: merge additional keys after fixed session_options (same as genai_config_12200)",
+    )
+    args = p.parse_args(argv)
+
+    model_dir = os.path.abspath(args.model_dir)
+    if not os.path.isdir(model_dir):
+        print(f"error: not a directory: {model_dir}", file=sys.stderr)
+        return 2
+
+    cfg_path = _find_config_file(model_dir, args.input_config)
+    src_root = _load_json(cfg_path)
+
+    max_len = args.max_length
+    if max_len is None:
+        model = src_root.get("model")
+        if isinstance(model, dict) and model.get("context_length") is not None:
+            max_len = int(model["context_length"])
+        elif src_root.get("max_position_embeddings") is not None:
+            max_len = int(src_root["max_position_embeddings"])
+        else:
+            print(
+                "error: cannot infer max_length; pass --max-length",
+                file=sys.stderr,
+            )
+            return 2
+
+    fixed_p = int(args.fixed_prompt_length)
+    stem = args.stem or _default_stem(fixed_p, max_len)
+    prefill_fn = args.prefill_filename or f"prefill_{stem}.onnx"
+    decode_fn = args.decode_filename or f"decode_{stem}.onnx"
+
+    session_override = None
+    if args.session_options_json:
+        session_override = _load_json(args.session_options_json)
+        if not isinstance(session_override, dict):
+            raise ValueError("session-options-json root must be an object")
+
+    out_cfg = build_pipeline_config(
+        src_root,
+        fixed_prompt_length=fixed_p,
+        max_length=max_len,
+        prefill_filename=prefill_fn,
+        decode_filename=decode_fn,
+        session_options_override=session_override,
+    )
+
+    out_path = args.output or os.path.join(model_dir, "genai_config_pipeline.json")
+    out_path = os.path.abspath(out_path)
+    os.makedirs(os.path.dirname(out_path) or ".", exist_ok=True)
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(out_cfg, f, indent=4, ensure_ascii=False)
+        f.write("\n")
+
+    print(f"wrote: {out_path}")
+    print(f"  stem={stem} prefill={prefill_fn} decode={decode_fn} max_length={max_len}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/onnx-model-splitter/genai_config_pipeline_from_folder.py
+++ b/tools/onnx-model-splitter/genai_config_pipeline_from_folder.py
@@ -119,7 +119,12 @@ def _merge_decoder_io_templates(
         return dict(_DEFAULT_DECODER_INPUTS), merged_out, INPUT_LAYOUT_FULL_IDS
 
     if merged_in.get("inputs_embeds"):
-        for k in ("attention_mask", "position_ids", "past_key_names", "past_value_names"):
+        for k in (
+            "attention_mask",
+            "position_ids",
+            "past_key_names",
+            "past_value_names",
+        ):
             if k not in merged_in:
                 merged_in[k] = _DEFAULT_DECODER_INPUTS[k]
         return merged_in, merged_out, INPUT_LAYOUT_EMBEDS
@@ -163,7 +168,8 @@ def _pipeline_io_lists(num_hidden_layers: int) -> tuple[list[str], list[str]]:
     """Prefill/decode I/O name lists matching existing Llama pipeline configs."""
     return (
         _pipeline_inputs_from_decoder_templates(
-            dict(_DEFAULT_DECODER_INPUTS), num_hidden_layers),
+            dict(_DEFAULT_DECODER_INPUTS), num_hidden_layers
+        ),
         _pipeline_outputs_from_layer_count(num_hidden_layers),
     )
 
@@ -191,7 +197,10 @@ def _pipeline_inputs_from_decoder_templates(
         if v:
             pin.append(v)
     pk = inputs_tmpl.get("past_key_names") or _DEFAULT_DECODER_INPUTS["past_key_names"]
-    pv = inputs_tmpl.get("past_value_names") or _DEFAULT_DECODER_INPUTS["past_value_names"]
+    pv = (
+        inputs_tmpl.get("past_value_names")
+        or _DEFAULT_DECODER_INPUTS["past_value_names"]
+    )
     for i in range(num_hidden_layers):
         pin.append(pk % i)
         pin.append(pv % i)

--- a/tools/onnx-model-splitter/genai_config_pipeline_from_folder.py
+++ b/tools/onnx-model-splitter/genai_config_pipeline_from_folder.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
 """
 Read structural metadata from `genai_config.json` (or another JSON) in a model folder,
 then generate a `decoder-pipeline` style `genai_config.json` for ORT GenAI.

--- a/tools/onnx-model-splitter/inspect_onnx.py
+++ b/tools/onnx-model-splitter/inspect_onnx.py
@@ -1,3 +1,7 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
 """
 Inspect ONNX model structure: list graph inputs, outputs, nodes,
 initializers, and optionally dump node details.

--- a/tools/onnx-model-splitter/inspect_onnx.py
+++ b/tools/onnx-model-splitter/inspect_onnx.py
@@ -1,0 +1,259 @@
+"""
+Inspect ONNX model structure: list graph inputs, outputs, nodes,
+initializers, and optionally dump node details.
+
+Usage:
+  python inspect_onnx.py <model.onnx>
+  python inspect_onnx.py <model.onnx> --nodes              # list all nodes
+  python inspect_onnx.py <model.onnx> --nodes --layer 0     # only show layer 0 nodes
+  python inspect_onnx.py <model.onnx> --node-name "/model/layers.0/attn/q_proj/MatMul"
+  python inspect_onnx.py <model.onnx> --nodes --type-name Add  # only show Add nodes
+  python inspect_onnx.py <model.onnx> --op-types            # count by op type
+  python inspect_onnx.py <model.onnx> --find-chains         # find common preprocessing chains
+"""
+
+import os
+import sys
+import argparse
+from collections import Counter
+
+import onnx
+from onnx import numpy_helper
+
+
+def load_model(path):
+    print(f"Loading {path} ...")
+    m = onnx.load(path, load_external_data=False)
+    print(f"  IR version:  {m.ir_version}")
+    print(f"  Opset:       {[(o.domain or 'ai.onnx', o.version) for o in m.opset_import]}")
+    return m
+
+
+def show_io(m):
+    g = m.graph
+    print(f"\nGraph: {g.name}")
+
+    print(f"\nInputs ({len(g.input)}):")
+    for inp in g.input:
+        dims = []
+        if inp.type.tensor_type.shape:
+            for d in inp.type.tensor_type.shape.dim:
+                if d.dim_param:
+                    dims.append(d.dim_param)
+                elif d.dim_value > 0:
+                    dims.append(str(d.dim_value))
+                else:
+                    dims.append("?")
+        elem = inp.type.tensor_type.elem_type
+        print(f"  {inp.name:60s} dtype={elem:>2d}  shape=[{', '.join(dims)}]")
+
+    print(f"\nOutputs ({len(g.output)}):")
+    for out in g.output:
+        dims = []
+        if out.type.tensor_type.shape:
+            for d in out.type.tensor_type.shape.dim:
+                if d.dim_param:
+                    dims.append(d.dim_param)
+                elif d.dim_value > 0:
+                    dims.append(str(d.dim_value))
+                else:
+                    dims.append("?")
+        elem = out.type.tensor_type.elem_type
+        print(f"  {out.name:60s} dtype={elem:>2d}  shape=[{', '.join(dims)}]")
+
+    print(f"\nInitializers: {len(g.initializer)}")
+    print(f"Nodes:        {len(g.node)}")
+
+    detect_layers(g)
+
+
+def detect_layers(g):
+    """Detect transformer layers by scanning node names for layer index patterns."""
+    import re
+    pattern = re.compile(r"/layers?[./](\d+)[/.]")
+
+    layer_node_counts = Counter()
+    layer_sample_nodes = {}
+    for n in g.node:
+        match = pattern.search(n.name)
+        if match:
+            idx = int(match.group(1))
+            layer_node_counts[idx] += 1
+            if idx not in layer_sample_nodes:
+                layer_sample_nodes[idx] = []
+            layer_sample_nodes[idx].append((n.op_type, n.name))
+
+    if not layer_node_counts:
+        for n in g.node:
+            match = re.search(r"_layer_?(\d+)_", n.name, re.IGNORECASE)
+            if match:
+                idx = int(match.group(1))
+                layer_node_counts[idx] += 1
+                if idx not in layer_sample_nodes:
+                    layer_sample_nodes[idx] = []
+                layer_sample_nodes[idx].append((n.op_type, n.name))
+
+    if not layer_node_counts:
+        print("Layers:       (not detected)")
+        return
+
+    all_indices = sorted(layer_node_counts.keys())
+    min_l, max_l = all_indices[0], all_indices[-1]
+    total = len(all_indices)
+    contiguous = (max_l - min_l + 1) == total
+
+    counts = [layer_node_counts[i] for i in all_indices]
+    majority_count = Counter(counts).most_common(1)[0][0]
+    normal_layers = [i for i in all_indices if layer_node_counts[i] == majority_count]
+    outlier_layers = [i for i in all_indices if layer_node_counts[i] != majority_count]
+
+    num_normal = len(normal_layers)
+    print(f"Layers:       {num_normal}  (index {normal_layers[0]}..{normal_layers[-1]}, "
+          f"{majority_count} nodes per layer"
+          f"{'' if contiguous and not outlier_layers else ', see below'})")
+
+    if outlier_layers:
+        print(f"              + {len(outlier_layers)} outlier(s) with different node count:")
+        for idx in outlier_layers:
+            cnt = layer_node_counts[idx]
+            nodes = layer_sample_nodes[idx]
+            node_desc = ", ".join(f"{op}" for op, _ in nodes[:3])
+            if len(nodes) > 3:
+                node_desc += f" ... (+{len(nodes)-3} more)"
+            print(f"                layer {idx}: {cnt} node(s) - {node_desc}")
+    elif not contiguous:
+        missing = [i for i in range(min_l, max_l + 1) if i not in layer_node_counts]
+        print(f"              missing indices: {missing}")
+
+
+def show_nodes(m, layer_filter=None, type_name=None):
+    g = m.graph
+    type_lower = type_name.lower() if type_name else None
+    matched = []
+    for i, n in enumerate(g.node):
+        if layer_filter is not None:
+            if f"/layers.{layer_filter}/" not in n.name and f"/layer.{layer_filter}/" not in n.name:
+                continue
+        if type_lower is not None and n.op_type.lower() != type_lower:
+            continue
+        matched.append((i, n))
+
+    label = f"Nodes (showing {len(matched)}/{len(g.node)})" if (layer_filter is not None or type_name) \
+        else f"Nodes ({len(g.node)})"
+    print(f"\n{label}:")
+    for i, n in matched:
+        domain = f"[{n.domain}]" if n.domain else ""
+        print(
+            f"  {i:>5d}  {n.op_type:40s} {domain:25s} "
+            f"name={n.name}"
+        )
+        for j, inp_name in enumerate(n.input):
+            print(f"         in[{j}]: {inp_name}")
+        for j, out_name in enumerate(n.output):
+            print(f"         out[{j}]: {out_name}")
+
+
+def show_node_detail(m, node_name):
+    g = m.graph
+    for n in g.node:
+        if n.name == node_name:
+            domain = f"[{n.domain}]" if n.domain else ""
+            print(f"\nNode: {n.name}")
+            print(f"  op_type: {n.op_type} {domain}")
+            print(f"  inputs ({len(n.input)}):")
+            for j, inp_name in enumerate(n.input):
+                print(f"    [{j}] {inp_name}")
+            print(f"  outputs ({len(n.output)}):")
+            for j, out_name in enumerate(n.output):
+                print(f"    [{j}] {out_name}")
+            if n.attribute:
+                print(f"  attributes ({len(n.attribute)}):")
+                for a in n.attribute:
+                    if a.type == onnx.AttributeProto.INT:
+                        print(f"    {a.name} = {a.i}")
+                    elif a.type == onnx.AttributeProto.FLOAT:
+                        print(f"    {a.name} = {a.f}")
+                    elif a.type == onnx.AttributeProto.STRING:
+                        print(f"    {a.name} = {a.s.decode()}")
+                    elif a.type == onnx.AttributeProto.INTS:
+                        print(f"    {a.name} = {list(a.ints)}")
+                    elif a.type == onnx.AttributeProto.FLOATS:
+                        print(f"    {a.name} = {list(a.floats)}")
+                    else:
+                        print(f"    {a.name} (type={a.type})")
+            return
+    print(f"  Node '{node_name}' not found")
+
+
+def show_op_types(m):
+    g = m.graph
+    counter = Counter(n.op_type for n in g.node)
+    print(f"\nOp type counts ({len(counter)} types, {len(g.node)} total nodes):")
+    for op, cnt in counter.most_common():
+        print(f"  {op:40s} {cnt:>5d}")
+
+
+def find_chains(m):
+    """Find common preprocessing chains that might need deletion."""
+    g = m.graph
+    out_to_node = {}
+    for n in g.node:
+        for o in n.output:
+            out_to_node[o] = n
+
+    input_names = {inp.name for inp in g.input}
+
+    print("\n--- Chains starting from graph inputs ---")
+    for inp in g.input:
+        consumers = [n for n in g.node if inp.name in n.input]
+        for c in consumers:
+            if c.op_type in ("Shape", "Gather", "Reshape", "Cast"):
+                chain = [f"{inp.name} ->"]
+                current = c
+                for _ in range(10):
+                    chain.append(f"{current.op_type}({current.name})")
+                    next_consumers = [
+                        n2 for n2 in g.node
+                        if any(o in n2.input for o in current.output)
+                        and n2.op_type in ("Shape", "Gather", "Cast", "Unsqueeze", "Concat", "Reshape", "Sub", "Add")
+                    ]
+                    if len(next_consumers) == 1:
+                        chain.append(" -> ")
+                        current = next_consumers[0]
+                    else:
+                        break
+                print("  " + "".join(chain))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Inspect ONNX model structure")
+    parser.add_argument("model", type=str, help="Path to .onnx file")
+    parser.add_argument("--nodes", action="store_true", help="List all nodes")
+    parser.add_argument("--layer", type=int, default=None, help="Filter nodes by layer index")
+    parser.add_argument("--node-name", type=str, default=None, help="Show detail for a specific node")
+    parser.add_argument("--type-name", type=str, default=None,
+                        help="Filter --nodes by op_type (case-insensitive), e.g. --type-name Add")
+    parser.add_argument("--op-types", action="store_true", help="Count nodes by op type")
+    parser.add_argument("--find-chains", action="store_true", help="Find preprocessing chains from inputs")
+    args = parser.parse_args()
+
+    m = load_model(args.model)
+    show_io(m)
+
+    if args.op_types:
+        show_op_types(m)
+    if args.type_name and not args.nodes:
+        args.nodes = True
+    if args.nodes:
+        show_nodes(m, layer_filter=args.layer, type_name=args.type_name)
+    if args.node_name:
+        show_node_detail(m, args.node_name)
+    if args.find_chains:
+        find_chains(m)
+
+    if not (args.nodes or args.node_name or args.op_types or args.find_chains):
+        print("\nTip: use --nodes, --op-types, --node-name, or --find-chains for more details")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/onnx-model-splitter/inspect_onnx.py
+++ b/tools/onnx-model-splitter/inspect_onnx.py
@@ -16,20 +16,19 @@ Usage:
   python inspect_onnx.py <model.onnx> --find-chains         # find common preprocessing chains
 """
 
-import os
-import sys
 import argparse
 from collections import Counter
 
 import onnx
-from onnx import numpy_helper
 
 
 def load_model(path):
     print(f"Loading {path} ...")
     m = onnx.load(path, load_external_data=False)
     print(f"  IR version:  {m.ir_version}")
-    print(f"  Opset:       {[(o.domain or 'ai.onnx', o.version) for o in m.opset_import]}")
+    print(
+        f"  Opset:       {[(o.domain or 'ai.onnx', o.version) for o in m.opset_import]}"
+    )
     return m
 
 
@@ -74,6 +73,7 @@ def show_io(m):
 def detect_layers(g):
     """Detect transformer layers by scanning node names for layer index patterns."""
     import re
+
     pattern = re.compile(r"/layers?[./](\d+)[/.]")
 
     layer_node_counts = Counter()
@@ -112,18 +112,22 @@ def detect_layers(g):
     outlier_layers = [i for i in all_indices if layer_node_counts[i] != majority_count]
 
     num_normal = len(normal_layers)
-    print(f"Layers:       {num_normal}  (index {normal_layers[0]}..{normal_layers[-1]}, "
-          f"{majority_count} nodes per layer"
-          f"{'' if contiguous and not outlier_layers else ', see below'})")
+    print(
+        f"Layers:       {num_normal}  (index {normal_layers[0]}..{normal_layers[-1]}, "
+        f"{majority_count} nodes per layer"
+        f"{'' if contiguous and not outlier_layers else ', see below'})"
+    )
 
     if outlier_layers:
-        print(f"              + {len(outlier_layers)} outlier(s) with different node count:")
+        print(
+            f"              + {len(outlier_layers)} outlier(s) with different node count:"
+        )
         for idx in outlier_layers:
             cnt = layer_node_counts[idx]
             nodes = layer_sample_nodes[idx]
             node_desc = ", ".join(f"{op}" for op, _ in nodes[:3])
             if len(nodes) > 3:
-                node_desc += f" ... (+{len(nodes)-3} more)"
+                node_desc += f" ... (+{len(nodes) - 3} more)"
             print(f"                layer {idx}: {cnt} node(s) - {node_desc}")
     elif not contiguous:
         missing = [i for i in range(min_l, max_l + 1) if i not in layer_node_counts]
@@ -136,21 +140,24 @@ def show_nodes(m, layer_filter=None, type_name=None):
     matched = []
     for i, n in enumerate(g.node):
         if layer_filter is not None:
-            if f"/layers.{layer_filter}/" not in n.name and f"/layer.{layer_filter}/" not in n.name:
+            if (
+                f"/layers.{layer_filter}/" not in n.name
+                and f"/layer.{layer_filter}/" not in n.name
+            ):
                 continue
         if type_lower is not None and n.op_type.lower() != type_lower:
             continue
         matched.append((i, n))
 
-    label = f"Nodes (showing {len(matched)}/{len(g.node)})" if (layer_filter is not None or type_name) \
+    label = (
+        f"Nodes (showing {len(matched)}/{len(g.node)})"
+        if (layer_filter is not None or type_name)
         else f"Nodes ({len(g.node)})"
+    )
     print(f"\n{label}:")
     for i, n in matched:
         domain = f"[{n.domain}]" if n.domain else ""
-        print(
-            f"  {i:>5d}  {n.op_type:40s} {domain:25s} "
-            f"name={n.name}"
-        )
+        print(f"  {i:>5d}  {n.op_type:40s} {domain:25s} name={n.name}")
         for j, inp_name in enumerate(n.input):
             print(f"         in[{j}]: {inp_name}")
         for j, out_name in enumerate(n.output):
@@ -205,8 +212,6 @@ def find_chains(m):
         for o in n.output:
             out_to_node[o] = n
 
-    input_names = {inp.name for inp in g.input}
-
     print("\n--- Chains starting from graph inputs ---")
     for inp in g.input:
         consumers = [n for n in g.node if inp.name in n.input]
@@ -217,9 +222,20 @@ def find_chains(m):
                 for _ in range(10):
                     chain.append(f"{current.op_type}({current.name})")
                     next_consumers = [
-                        n2 for n2 in g.node
+                        n2
+                        for n2 in g.node
                         if any(o in n2.input for o in current.output)
-                        and n2.op_type in ("Shape", "Gather", "Cast", "Unsqueeze", "Concat", "Reshape", "Sub", "Add")
+                        and n2.op_type
+                        in (
+                            "Shape",
+                            "Gather",
+                            "Cast",
+                            "Unsqueeze",
+                            "Concat",
+                            "Reshape",
+                            "Sub",
+                            "Add",
+                        )
                     ]
                     if len(next_consumers) == 1:
                         chain.append(" -> ")
@@ -233,12 +249,26 @@ def main():
     parser = argparse.ArgumentParser(description="Inspect ONNX model structure")
     parser.add_argument("model", type=str, help="Path to .onnx file")
     parser.add_argument("--nodes", action="store_true", help="List all nodes")
-    parser.add_argument("--layer", type=int, default=None, help="Filter nodes by layer index")
-    parser.add_argument("--node-name", type=str, default=None, help="Show detail for a specific node")
-    parser.add_argument("--type-name", type=str, default=None,
-                        help="Filter --nodes by op_type (case-insensitive), e.g. --type-name Add")
-    parser.add_argument("--op-types", action="store_true", help="Count nodes by op type")
-    parser.add_argument("--find-chains", action="store_true", help="Find preprocessing chains from inputs")
+    parser.add_argument(
+        "--layer", type=int, default=None, help="Filter nodes by layer index"
+    )
+    parser.add_argument(
+        "--node-name", type=str, default=None, help="Show detail for a specific node"
+    )
+    parser.add_argument(
+        "--type-name",
+        type=str,
+        default=None,
+        help="Filter --nodes by op_type (case-insensitive), e.g. --type-name Add",
+    )
+    parser.add_argument(
+        "--op-types", action="store_true", help="Count nodes by op type"
+    )
+    parser.add_argument(
+        "--find-chains",
+        action="store_true",
+        help="Find preprocessing chains from inputs",
+    )
     args = parser.parse_args()
 
     m = load_model(args.model)
@@ -256,7 +286,9 @@ def main():
         find_chains(m)
 
     if not (args.nodes or args.node_name or args.op_types or args.find_chains):
-        print("\nTip: use --nodes, --op-types, --node-name, or --find-chains for more details")
+        print(
+            "\nTip: use --nodes, --op-types, --node-name, or --find-chains for more details"
+        )
 
 
 if __name__ == "__main__":

--- a/tools/onnx-model-splitter/requirements.txt
+++ b/tools/onnx-model-splitter/requirements.txt
@@ -1,0 +1,3 @@
+onnx>=1.16.0
+onnxruntime>=1.18.0
+numpy>=1.24.0

--- a/tools/onnx-model-splitter/requirements.txt
+++ b/tools/onnx-model-splitter/requirements.txt
@@ -1,3 +1,4 @@
 onnx>=1.16.0
 onnxruntime>=1.18.0
+onnxoptimizer>=0.3.0
 numpy>=1.24.0

--- a/tools/onnx-model-splitter/verify_extraction.py
+++ b/tools/onnx-model-splitter/verify_extraction.py
@@ -120,7 +120,8 @@ def _collect_fixed_variant_shape_issues(model):
         if len(bad_nodes) > 24:
             head += f", ... (+{len(bad_nodes) - 24} more)"
         lines.append(
-            f"      nodes consuming unfixed tensors ({len(bad_nodes)}): {head}")
+            f"      nodes consuming unfixed tensors ({len(bad_nodes)}): {head}"
+        )
 
     return lines
 
@@ -172,8 +173,7 @@ def _phase2_shape_normality_issues(model):
 
     residual = _collect_fixed_variant_shape_issues(inferred)
     if residual:
-        lines.append(
-            "      [phase-2] after inference, still unfixed or invalid dims:")
+        lines.append("      [phase-2] after inference, still unfixed or invalid dims:")
         lines.extend(residual)
     return lines
 
@@ -213,13 +213,13 @@ def verify_single_op(d, check_fixed_shapes=True, check_shape_inference=True):
             try:
                 m = onnx.load(fpath, load_external_data=False)
                 n_nodes = len(m.graph.node)
-                n_inits = len(m.graph.initializer)
                 if n_nodes == 0:
                     print(f"    WARNING: {folder}/{f} has 0 nodes!")
                     all_ok = False
                 if check_fixed_shapes and not _is_dynamic_variant_filename(f):
                     ok_shape, entries = _run_two_phase_shape_checks(
-                        m, run_phase2=check_shape_inference)
+                        m, run_phase2=check_shape_inference
+                    )
                     if not ok_shape:
                         print(f"    SHAPE (fixed variant): {folder}/{f}")
                         for _, line in entries:
@@ -232,8 +232,9 @@ def verify_single_op(d, check_fixed_shapes=True, check_shape_inference=True):
     return all_ok
 
 
-def verify_external_data_dir(d, label, check_fixed_shapes=True,
-                             check_shape_inference=True):
+def verify_external_data_dir(
+    d, label, check_fixed_shapes=True, check_shape_inference=True
+):
     """Verify a directory with external weights (single_layer or full_model)."""
     if not os.path.exists(d):
         print("  [NOT FOUND]")
@@ -245,11 +246,11 @@ def verify_external_data_dir(d, label, check_fixed_shapes=True,
         onnx_files = sorted([f for f in os.listdir(d) if f.endswith(".onnx")])
         for f in onnx_files:
             sz = os.path.getsize(os.path.join(d, f))
-            print(f"    {f:45s} {sz / (1024*1024):.1f} MB")
+            print(f"    {f:45s} {sz / (1024 * 1024):.1f} MB")
         return True
 
     weights_size = os.path.getsize(weights_path)
-    if weights_size > 1024 ** 3:
+    if weights_size > 1024**3:
         print(f"  weights.data: {weights_size / (1024**3):.2f} GB")
     else:
         print(f"  weights.data: {weights_size / (1024**2):.1f} MB")
@@ -304,7 +305,8 @@ def verify_external_data_dir(d, label, check_fixed_shapes=True,
 
         if check_fixed_shapes and not _is_dynamic_variant_filename(f):
             ok_shape, entries = _run_two_phase_shape_checks(
-                m, run_phase2=check_shape_inference)
+                m, run_phase2=check_shape_inference
+            )
             if not ok_shape:
                 all_ok = False
                 print(f"    SHAPE (fixed variant): {f}")
@@ -312,7 +314,9 @@ def verify_external_data_dir(d, label, check_fixed_shapes=True,
                     print(line)
 
     if all_ok:
-        print(f"  >> ALL OFFSETS VALID (max_end = weights.data size: {max_end == weights_size})")
+        print(
+            f"  >> ALL OFFSETS VALID (max_end = weights.data size: {max_end == weights_size})"
+        )
     else:
         print("  >> ERRORS FOUND!")
 
@@ -321,17 +325,21 @@ def verify_external_data_dir(d, label, check_fixed_shapes=True,
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Verify extracted ONNX models (single_op, single_layer, full_model)")
+        description="Verify extracted ONNX models (single_op, single_layer, full_model)"
+    )
     parser.add_argument(
-        "output_dir", type=str,
+        "output_dir",
+        type=str,
         help="Base output directory containing single_op/, single_layer/, full_model/",
     )
     parser.add_argument(
-        "--skip-fixed-shape-check", action="store_true",
+        "--skip-fixed-shape-check",
+        action="store_true",
         help="Do not verify that non-_dynamic.onnx files have fully fixed tensor shapes",
     )
     parser.add_argument(
-        "--skip-shape-inference-check", action="store_true",
+        "--skip-shape-inference-check",
+        action="store_true",
         help="After phase-1 passes, skip ONNX shape_inference + check_model (phase-2)",
     )
     args = parser.parse_args()
@@ -361,7 +369,8 @@ def main():
     print("single_layer")
     print("=" * 70)
     ok = verify_external_data_dir(
-        os.path.join(base, "single_layer"), "single_layer",
+        os.path.join(base, "single_layer"),
+        "single_layer",
         check_fixed_shapes=check_shapes,
         check_shape_inference=check_infer if check_shapes else False,
     )
@@ -373,7 +382,8 @@ def main():
     print("full_model")
     print("=" * 70)
     ok = verify_external_data_dir(
-        os.path.join(base, "full_model"), "full_model",
+        os.path.join(base, "full_model"),
+        "full_model",
         check_fixed_shapes=check_shapes,
         check_shape_inference=check_infer if check_shapes else False,
     )

--- a/tools/onnx-model-splitter/verify_extraction.py
+++ b/tools/onnx-model-splitter/verify_extraction.py
@@ -1,3 +1,7 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
 """
 Verify extracted ONNX models: check file sizes, weights.data offsets,
 graph structure (nodes, inputs, outputs), initializer integrity, and for

--- a/tools/onnx-model-splitter/verify_extraction.py
+++ b/tools/onnx-model-splitter/verify_extraction.py
@@ -1,0 +1,177 @@
+"""
+Verify extracted ONNX models: check file sizes, weights.data offsets,
+graph structure (nodes, inputs, outputs), and initializer integrity.
+
+Usage:
+  python verify_extraction.py <output_dir>
+  python verify_extraction.py D:\liuc\0-modelzoo\llm\Qwen2.5-14B-Instruct-fp16\Qwen2.5-14B-Instruct\space
+"""
+
+import os
+import sys
+import argparse
+
+import onnx
+
+
+def verify_single_op(d):
+    """Verify single_op directory structure."""
+    if not os.path.exists(d):
+        print("  [NOT FOUND]")
+        return True
+
+    folders = sorted([f for f in os.listdir(d) if os.path.isdir(os.path.join(d, f))])
+    print(f"  {len(folders)} folders:")
+    for f in folders:
+        cnt = len([x for x in os.listdir(os.path.join(d, f)) if x.endswith(".onnx")])
+        print(f"    {f:50s} ({cnt} onnx files)")
+
+    all_ok = True
+    for folder in folders:
+        folder_path = os.path.join(d, folder)
+        for f in sorted(os.listdir(folder_path)):
+            if not f.endswith(".onnx"):
+                continue
+            fpath = os.path.join(folder_path, f)
+            try:
+                m = onnx.load(fpath, load_external_data=False)
+                n_nodes = len(m.graph.node)
+                n_inits = len(m.graph.initializer)
+                if n_nodes == 0:
+                    print(f"    WARNING: {folder}/{f} has 0 nodes!")
+                    all_ok = False
+            except Exception as e:
+                print(f"    ERROR loading {folder}/{f}: {e}")
+                all_ok = False
+
+    return all_ok
+
+
+def verify_external_data_dir(d, label):
+    """Verify a directory with external weights (single_layer or full_model)."""
+    if not os.path.exists(d):
+        print("  [NOT FOUND]")
+        return True
+
+    weights_path = os.path.join(d, "weights.data")
+    if not os.path.exists(weights_path):
+        print("  [No weights.data file]")
+        onnx_files = sorted([f for f in os.listdir(d) if f.endswith(".onnx")])
+        for f in onnx_files:
+            sz = os.path.getsize(os.path.join(d, f))
+            print(f"    {f:45s} {sz / (1024*1024):.1f} MB")
+        return True
+
+    weights_size = os.path.getsize(weights_path)
+    if weights_size > 1024 ** 3:
+        print(f"  weights.data: {weights_size / (1024**3):.2f} GB")
+    else:
+        print(f"  weights.data: {weights_size / (1024**2):.1f} MB")
+
+    all_ok = True
+    onnx_files = sorted([f for f in os.listdir(d) if f.endswith(".onnx")])
+
+    for f in onnx_files:
+        fpath = os.path.join(d, f)
+        try:
+            m = onnx.load(fpath, load_external_data=False)
+        except Exception as e:
+            print(f"    {f:45s} ERROR loading: {e}")
+            all_ok = False
+            continue
+
+        n_nodes = len(m.graph.node)
+        n_inputs = len(m.graph.input)
+        n_outputs = len(m.graph.output)
+
+        ext_count = 0
+        emb_count = 0
+        max_end = 0
+        bad_count = 0
+
+        for init in m.graph.initializer:
+            ext = {e.key: e.value for e in init.external_data}
+            if ext:
+                ext_count += 1
+                offset = int(ext.get("offset", 0))
+                length = int(ext.get("length", 0))
+                end = offset + length
+                if end > max_end:
+                    max_end = end
+                if end > weights_size:
+                    bad_count += 1
+            else:
+                emb_count += 1
+
+        if bad_count > 0:
+            status = f"ERROR: {bad_count} tensors out of bounds!"
+            all_ok = False
+        else:
+            status = "OK"
+
+        print(
+            f"    {f:40s} nodes={n_nodes:>4d}  in={n_inputs:>3d}  "
+            f"out={n_outputs:>3d}  ext={ext_count}  emb={emb_count}  "
+            f"max_end={max_end:>15d}  {status}"
+        )
+
+    if all_ok:
+        print(f"  >> ALL OFFSETS VALID (max_end = weights.data size: {max_end == weights_size})")
+    else:
+        print("  >> ERRORS FOUND!")
+
+    return all_ok
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Verify extracted ONNX models (single_op, single_layer, full_model)")
+    parser.add_argument(
+        "output_dir", type=str,
+        help="Base output directory containing single_op/, single_layer/, full_model/",
+    )
+    args = parser.parse_args()
+
+    base = args.output_dir
+    if not os.path.isdir(base):
+        print(f"ERROR: {base} is not a directory")
+        sys.exit(1)
+
+    overall_ok = True
+
+    print("=" * 70)
+    print("single_op")
+    print("=" * 70)
+    ok = verify_single_op(os.path.join(base, "single_op"))
+    if not ok:
+        overall_ok = False
+    print()
+
+    print("=" * 70)
+    print("single_layer")
+    print("=" * 70)
+    ok = verify_external_data_dir(os.path.join(base, "single_layer"), "single_layer")
+    if not ok:
+        overall_ok = False
+    print()
+
+    print("=" * 70)
+    print("full_model")
+    print("=" * 70)
+    ok = verify_external_data_dir(os.path.join(base, "full_model"), "full_model")
+    if not ok:
+        overall_ok = False
+    print()
+
+    print("=" * 70)
+    if overall_ok:
+        print("RESULT: ALL CHECKS PASSED")
+    else:
+        print("RESULT: SOME CHECKS FAILED")
+    print("=" * 70)
+
+    sys.exit(0 if overall_ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/onnx-model-splitter/verify_extraction.py
+++ b/tools/onnx-model-splitter/verify_extraction.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 #
 """
-Verify extracted ONNX models: check file sizes, weights.data offsets,
+Verify extracted ONNX models: check file sizes, external data offsets,
 graph structure (nodes, inputs, outputs), initializer integrity, and for
 non-dynamic variants (filenames not ending with _dynamic.onnx):
   (1) phase-1 static scan: no symbolic / invalid dims on declared types;
@@ -144,6 +144,16 @@ def _graph_initializers_use_external_data(graph):
     return any(bool(init.external_data) for init in graph.initializer)
 
 
+def _detect_ext_data_name_from_graph(graph):
+    """Read the external data filename from the first external initializer."""
+    for init in graph.initializer:
+        if init.external_data:
+            for entry in init.external_data:
+                if entry.key == "location":
+                    return entry.value
+    return None
+
+
 def _check_model_failure_is_extended_op_only(exc):
     """onnx.checker only knows built-in ops; MS ORT ops fail with 'No Op registered'."""
     msg = str(exc).lower()
@@ -240,24 +250,38 @@ def verify_external_data_dir(
         print("  [NOT FOUND]")
         return True
 
-    weights_path = os.path.join(d, "weights.data")
-    if not os.path.exists(weights_path):
-        print("  [No weights.data file]")
-        onnx_files = sorted([f for f in os.listdir(d) if f.endswith(".onnx")])
+    onnx_files = sorted([f for f in os.listdir(d) if f.endswith(".onnx")])
+
+    weights_name = None
+    for f in onnx_files:
+        try:
+            m = onnx.load(os.path.join(d, f), load_external_data=False)
+            weights_name = _detect_ext_data_name_from_graph(m.graph)
+            if weights_name:
+                break
+        except Exception:
+            continue
+
+    if not weights_name:
+        print("  [No external data referenced by any .onnx file]")
         for f in onnx_files:
             sz = os.path.getsize(os.path.join(d, f))
             print(f"    {f:45s} {sz / (1024 * 1024):.1f} MB")
         return True
 
+    weights_path = os.path.join(d, weights_name)
+    if not os.path.exists(weights_path):
+        print(f"  ERROR: external data file {weights_name!r} not found!")
+        return False
+
     weights_size = os.path.getsize(weights_path)
     if weights_size > 1024**3:
-        print(f"  weights.data: {weights_size / (1024**3):.2f} GB")
+        print(f"  {weights_name}: {weights_size / (1024**3):.2f} GB")
     else:
-        print(f"  weights.data: {weights_size / (1024**2):.1f} MB")
+        print(f"  {weights_name}: {weights_size / (1024**2):.1f} MB")
 
     all_ok = True
-    onnx_files = sorted([f for f in os.listdir(d) if f.endswith(".onnx")])
-    max_end = 0
+    global_max_end = 0
 
     for f in onnx_files:
         fpath = os.path.join(d, f)
@@ -302,6 +326,8 @@ def verify_external_data_dir(
             f"out={n_outputs:>3d}  ext={ext_count}  emb={emb_count}  "
             f"max_end={max_end:>15d}  {status}"
         )
+        if max_end > global_max_end:
+            global_max_end = max_end
 
         if check_fixed_shapes and not _is_dynamic_variant_filename(f):
             ok_shape, entries = _run_two_phase_shape_checks(
@@ -315,7 +341,7 @@ def verify_external_data_dir(
 
     if all_ok:
         print(
-            f"  >> ALL OFFSETS VALID (max_end = weights.data size: {max_end == weights_size})"
+            f"  >> ALL OFFSETS VALID (max_end = {weights_name} size: {global_max_end == weights_size})"
         )
     else:
         print("  >> ERRORS FOUND!")

--- a/tools/onnx-model-splitter/verify_extraction.py
+++ b/tools/onnx-model-splitter/verify_extraction.py
@@ -1,20 +1,193 @@
 """
 Verify extracted ONNX models: check file sizes, weights.data offsets,
-graph structure (nodes, inputs, outputs), and initializer integrity.
+graph structure (nodes, inputs, outputs), initializer integrity, and for
+non-dynamic variants (filenames not ending with _dynamic.onnx):
+  (1) phase-1 static scan: no symbolic / invalid dims on declared types;
+  (2) only if phase-1 passes: phase-2 ONNX shape_inference (strict when
+      supported), onnx.checker when applicable, then a second fixed-dim scan.
+      check_model is skipped (not failed) for extended ops onnx does not
+      register (e.g. SimplifiedLayerNormalization); ORT may still run them.
 
 Usage:
   python verify_extraction.py <output_dir>
-  python verify_extraction.py D:\liuc\0-modelzoo\llm\Qwen2.5-14B-Instruct-fp16\Qwen2.5-14B-Instruct\space
+  python verify_extraction.py D:/liuc/0-modelzoo/llm/.../space
+  python verify_extraction.py <output_dir> --skip-fixed-shape-check
+  python verify_extraction.py <output_dir> --skip-shape-inference-check
 """
 
 import os
 import sys
 import argparse
+from collections import defaultdict
 
 import onnx
 
 
-def verify_single_op(d):
+def _is_dynamic_variant_filename(filename):
+    """extract_submodels names variants as <stem>_<variant>.onnx; dynamic is *_dynamic.onnx."""
+    return filename.endswith("_dynamic.onnx")
+
+
+def _tensor_shape_dim_issues(shape):
+    """Return human-readable issues for one TensorShapeProto (tensor dims)."""
+    if not shape.dim:
+        return []
+    out = []
+    for i, d in enumerate(shape.dim):
+        if d.dim_param:
+            out.append(f"dim[{i}] symbolic={d.dim_param!r}")
+        elif d.dim_value < 0:
+            out.append(f"dim[{i}] dim_value={d.dim_value}")
+        elif d.dim_value == 0:
+            out.append(f"dim[{i}] dim_value=0 (unspecified)")
+    return out
+
+
+def _vi_tensor_shape_issues(vi):
+    if not vi.type.HasField("tensor_type"):
+        return []
+    tt = vi.type.tensor_type
+    if not tt.HasField("shape"):
+        return ["missing tensor_type.shape"]
+    return _tensor_shape_dim_issues(tt.shape)
+
+
+def _build_vi_map(graph):
+    """Same merge order as extract_submodels.get_value_info_map."""
+    vi = {}
+    for v in graph.value_info:
+        vi[v.name] = v
+    for v in graph.input:
+        vi[v.name] = v
+    for v in graph.output:
+        vi[v.name] = v
+    return vi
+
+
+def _collect_fixed_variant_shape_issues(model):
+    """For fixed-shape ONNX files: list tensors / nodes that still have unfixed dims."""
+    g = model.graph
+    tensor_issues = defaultdict(list)
+    init_by_name = {init.name: init for init in g.initializer}
+    vi_map = _build_vi_map(g)
+
+    def _add(name, issues):
+        if not issues or not name:
+            return
+        for x in issues:
+            if x not in tensor_issues[name]:
+                tensor_issues[name].append(x)
+
+    for vi in g.input:
+        _add(vi.name, _vi_tensor_shape_issues(vi))
+    for vi in g.output:
+        _add(vi.name, _vi_tensor_shape_issues(vi))
+    for vi in g.value_info:
+        _add(vi.name, _vi_tensor_shape_issues(vi))
+
+    for name, init in init_by_name.items():
+        idims = []
+        for i, d in enumerate(init.dims):
+            if d <= 0:
+                idims.append(f"dims[{i}]={d}")
+        _add(name, idims)
+
+    for node in g.node:
+        for inp in node.input:
+            if not inp or inp in init_by_name:
+                continue
+            vi = vi_map.get(inp)
+            if vi is None:
+                continue
+            _add(inp, _vi_tensor_shape_issues(vi))
+
+    lines = []
+    for name in sorted(tensor_issues):
+        issues = tensor_issues[name]
+        if issues:
+            lines.append(f"      tensor {name!r}: {', '.join(issues)}")
+
+    bad_nodes = []
+    for node in g.node:
+        if any(inp and inp in tensor_issues for inp in node.input):
+            bad_nodes.append(f"{node.name}({node.op_type})")
+    if bad_nodes:
+        head = ", ".join(bad_nodes[:24])
+        if len(bad_nodes) > 24:
+            head += f", ... (+{len(bad_nodes) - 24} more)"
+        lines.append(
+            f"      nodes consuming unfixed tensors ({len(bad_nodes)}): {head}")
+
+    return lines
+
+
+def _infer_shapes_for_check(model):
+    """Return inferred model; ONNX uses check_type (not check_types)."""
+    infer = onnx.shape_inference.infer_shapes
+    try:
+        return infer(model, check_type=True, strict_mode=True)
+    except TypeError:
+        pass
+    try:
+        return infer(model, check_type=True)
+    except TypeError:
+        pass
+    return infer(model)
+
+
+def _graph_initializers_use_external_data(graph):
+    return any(bool(init.external_data) for init in graph.initializer)
+
+
+def _check_model_failure_is_extended_op_only(exc):
+    """onnx.checker only knows built-in ops; MS ORT ops fail with 'No Op registered'."""
+    msg = str(exc).lower()
+    return (
+        "no op registered" in msg
+        or "no schema registered" in msg
+        or "is not a registered function" in msg
+    )
+
+
+def _phase2_shape_normality_issues(model):
+    """After phase-1 passed: ONNX shape inference + checker + residual unfixed dims."""
+    lines = []
+    try:
+        inferred = _infer_shapes_for_check(model)
+    except Exception as e:
+        lines.append(f"      [phase-2] shape_inference failed: {e}")
+        return lines
+
+    if not _graph_initializers_use_external_data(inferred.graph):
+        try:
+            onnx.checker.check_model(inferred, full_check=False)
+        except Exception as e:
+            if not _check_model_failure_is_extended_op_only(e):
+                lines.append(f"      [phase-2] check_model failed: {e}")
+                return lines
+
+    residual = _collect_fixed_variant_shape_issues(inferred)
+    if residual:
+        lines.append(
+            "      [phase-2] after inference, still unfixed or invalid dims:")
+        lines.extend(residual)
+    return lines
+
+
+def _run_two_phase_shape_checks(model, run_phase2=True):
+    """Phase 1: fixed dims on disk graph. Phase 2: only if phase 1 is clean."""
+    phase1 = _collect_fixed_variant_shape_issues(model)
+    if phase1:
+        return False, [("phase-1", x) for x in phase1]
+    if not run_phase2:
+        return True, []
+    phase2 = _phase2_shape_normality_issues(model)
+    if phase2:
+        return False, [("phase-2", x) for x in phase2]
+    return True, []
+
+
+def verify_single_op(d, check_fixed_shapes=True, check_shape_inference=True):
     """Verify single_op directory structure."""
     if not os.path.exists(d):
         print("  [NOT FOUND]")
@@ -40,6 +213,14 @@ def verify_single_op(d):
                 if n_nodes == 0:
                     print(f"    WARNING: {folder}/{f} has 0 nodes!")
                     all_ok = False
+                if check_fixed_shapes and not _is_dynamic_variant_filename(f):
+                    ok_shape, entries = _run_two_phase_shape_checks(
+                        m, run_phase2=check_shape_inference)
+                    if not ok_shape:
+                        print(f"    SHAPE (fixed variant): {folder}/{f}")
+                        for _, line in entries:
+                            print(line)
+                        all_ok = False
             except Exception as e:
                 print(f"    ERROR loading {folder}/{f}: {e}")
                 all_ok = False
@@ -47,7 +228,8 @@ def verify_single_op(d):
     return all_ok
 
 
-def verify_external_data_dir(d, label):
+def verify_external_data_dir(d, label, check_fixed_shapes=True,
+                             check_shape_inference=True):
     """Verify a directory with external weights (single_layer or full_model)."""
     if not os.path.exists(d):
         print("  [NOT FOUND]")
@@ -70,6 +252,7 @@ def verify_external_data_dir(d, label):
 
     all_ok = True
     onnx_files = sorted([f for f in os.listdir(d) if f.endswith(".onnx")])
+    max_end = 0
 
     for f in onnx_files:
         fpath = os.path.join(d, f)
@@ -115,6 +298,15 @@ def verify_external_data_dir(d, label):
             f"max_end={max_end:>15d}  {status}"
         )
 
+        if check_fixed_shapes and not _is_dynamic_variant_filename(f):
+            ok_shape, entries = _run_two_phase_shape_checks(
+                m, run_phase2=check_shape_inference)
+            if not ok_shape:
+                all_ok = False
+                print(f"    SHAPE (fixed variant): {f}")
+                for _, line in entries:
+                    print(line)
+
     if all_ok:
         print(f"  >> ALL OFFSETS VALID (max_end = weights.data size: {max_end == weights_size})")
     else:
@@ -130,7 +322,17 @@ def main():
         "output_dir", type=str,
         help="Base output directory containing single_op/, single_layer/, full_model/",
     )
+    parser.add_argument(
+        "--skip-fixed-shape-check", action="store_true",
+        help="Do not verify that non-_dynamic.onnx files have fully fixed tensor shapes",
+    )
+    parser.add_argument(
+        "--skip-shape-inference-check", action="store_true",
+        help="After phase-1 passes, skip ONNX shape_inference + check_model (phase-2)",
+    )
     args = parser.parse_args()
+    check_shapes = not args.skip_fixed_shape_check
+    check_infer = not args.skip_shape_inference_check
 
     base = args.output_dir
     if not os.path.isdir(base):
@@ -142,7 +344,11 @@ def main():
     print("=" * 70)
     print("single_op")
     print("=" * 70)
-    ok = verify_single_op(os.path.join(base, "single_op"))
+    ok = verify_single_op(
+        os.path.join(base, "single_op"),
+        check_fixed_shapes=check_shapes,
+        check_shape_inference=check_infer if check_shapes else False,
+    )
     if not ok:
         overall_ok = False
     print()
@@ -150,7 +356,11 @@ def main():
     print("=" * 70)
     print("single_layer")
     print("=" * 70)
-    ok = verify_external_data_dir(os.path.join(base, "single_layer"), "single_layer")
+    ok = verify_external_data_dir(
+        os.path.join(base, "single_layer"), "single_layer",
+        check_fixed_shapes=check_shapes,
+        check_shape_inference=check_infer if check_shapes else False,
+    )
     if not ok:
         overall_ok = False
     print()
@@ -158,7 +368,11 @@ def main():
     print("=" * 70)
     print("full_model")
     print("=" * 70)
-    ok = verify_external_data_dir(os.path.join(base, "full_model"), "full_model")
+    ok = verify_external_data_dir(
+        os.path.join(base, "full_model"), "full_model",
+        check_fixed_shapes=check_shapes,
+        check_shape_inference=check_infer if check_shapes else False,
+    )
     if not ok:
         overall_ok = False
     print()

--- a/tools/onnx-model-splitter/verify_ort_inference.py
+++ b/tools/onnx-model-splitter/verify_ort_inference.py
@@ -1,0 +1,143 @@
+r"""
+Verify extracted ONNX models by running ORT inference with dummy inputs.
+Checks that models load successfully and produce valid outputs.
+
+Each model is tested in a subprocess so that native ORT crashes
+(e.g. access violations) don't kill the whole verification run.
+
+Usage:
+  python verify_ort_inference.py <output_dir> [--mode single_op|single_layer|full_model]
+
+Examples:
+  python verify_ort_inference.py D:\liuc\0-modelzoo\llm\model\space
+  python verify_ort_inference.py D:\liuc\0-modelzoo\llm\model\space --mode single_op
+"""
+
+import os
+import sys
+import json
+import argparse
+import subprocess
+
+
+def _run_in_subprocess(fpath, verbose=False, timeout=300):
+    """Run ORT inference for a single model in an isolated subprocess."""
+    script = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                          "_verify_one_model.py")
+    cmd = [sys.executable, script, fpath]
+    if verbose:
+        cmd.append("--verbose")
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        return False, "TIMEOUT (exceeded {}s)".format(timeout)
+
+    stdout = result.stdout.strip()
+    if result.returncode != 0:
+        if result.returncode < 0 or result.returncode > 100:
+            return False, "ORT crashed (exit code {})".format(result.returncode)
+        return False, stdout if stdout else "exit code {}".format(result.returncode)
+    return True, stdout
+
+
+def _collect_onnx_files_single_op(d):
+    """Yield (display_label, full_path) for each onnx in single_op subfolders."""
+    if not os.path.isdir(d):
+        return
+    for folder in sorted(os.listdir(d)):
+        folder_path = os.path.join(d, folder)
+        if not os.path.isdir(folder_path):
+            continue
+        for f in sorted(os.listdir(folder_path)):
+            if f.endswith(".onnx"):
+                yield f"{folder}/{f}", os.path.join(folder_path, f)
+
+
+def _collect_onnx_files_flat(d):
+    """Yield (display_label, full_path) for each onnx directly in dir."""
+    if not os.path.isdir(d):
+        return
+    for f in sorted(os.listdir(d)):
+        if f.endswith(".onnx"):
+            yield f, os.path.join(d, f)
+
+
+def verify_dir(d, collector, verbose=False):
+    if not os.path.isdir(d):
+        print("  [NOT FOUND]")
+        return True
+
+    files = list(collector(d))
+    if not files:
+        print("  (no .onnx files found)")
+        return True
+
+    all_ok = True
+    total = len(files)
+    passed = 0
+
+    for label, fpath in files:
+        print(f"    testing {label} ...", end="", flush=True)
+        ok, msg = _run_in_subprocess(fpath, verbose=verbose)
+        status = "PASS" if ok else "FAIL"
+        if ok:
+            passed += 1
+        else:
+            all_ok = False
+        print(f"\r    [{status}] {label:50s} {msg}")
+
+    print(f"  >> {passed}/{total} passed")
+    return all_ok
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Verify extracted ONNX models via ORT inference")
+    parser.add_argument(
+        "output_dir", type=str,
+        help="Base output directory containing single_op/, single_layer/, full_model/",
+    )
+    parser.add_argument(
+        "--mode", type=str, default=None,
+        choices=["single_op", "single_layer", "full_model"],
+        help="Only verify a specific mode (default: all)",
+    )
+    parser.add_argument(
+        "--verbose", "-v", action="store_true",
+        help="Print detailed input/output info for each model",
+    )
+    args = parser.parse_args()
+
+    base = args.output_dir
+    if not os.path.isdir(base):
+        print(f"ERROR: {base} is not a directory")
+        sys.exit(1)
+
+    modes = [args.mode] if args.mode else ["single_op", "single_layer", "full_model"]
+    overall_ok = True
+
+    for mode in modes:
+        print("=" * 70)
+        print(mode)
+        print("=" * 70)
+        d = os.path.join(base, mode)
+        collector = _collect_onnx_files_single_op if mode == "single_op" \
+            else _collect_onnx_files_flat
+        ok = verify_dir(d, collector, verbose=args.verbose)
+        if not ok:
+            overall_ok = False
+        print()
+
+    print("=" * 70)
+    if overall_ok:
+        print("RESULT: ALL ORT INFERENCE CHECKS PASSED")
+    else:
+        print("RESULT: SOME CHECKS FAILED")
+    print("=" * 70)
+
+    sys.exit(0 if overall_ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/onnx-model-splitter/verify_ort_inference.py
+++ b/tools/onnx-model-splitter/verify_ort_inference.py
@@ -1,3 +1,7 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
 r"""
 Verify extracted ONNX models by running ORT inference with dummy inputs.
 Checks that models load successfully and produce valid outputs.

--- a/tools/onnx-model-splitter/verify_ort_inference.py
+++ b/tools/onnx-model-splitter/verify_ort_inference.py
@@ -19,21 +19,20 @@ Examples:
 
 import os
 import sys
-import json
 import argparse
 import subprocess
 
 
 def _run_in_subprocess(fpath, verbose=False, timeout=300):
     """Run ORT inference for a single model in an isolated subprocess."""
-    script = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                          "_verify_one_model.py")
+    script = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "_verify_one_model.py"
+    )
     cmd = [sys.executable, script, fpath]
     if verbose:
         cmd.append("--verbose")
     try:
-        result = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=timeout)
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
     except subprocess.TimeoutExpired:
         return False, "TIMEOUT (exceeded {}s)".format(timeout)
 
@@ -97,18 +96,24 @@ def verify_dir(d, collector, verbose=False):
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Verify extracted ONNX models via ORT inference")
+        description="Verify extracted ONNX models via ORT inference"
+    )
     parser.add_argument(
-        "output_dir", type=str,
+        "output_dir",
+        type=str,
         help="Base output directory containing single_op/, single_layer/, full_model/",
     )
     parser.add_argument(
-        "--mode", type=str, default=None,
+        "--mode",
+        type=str,
+        default=None,
         choices=["single_op", "single_layer", "full_model"],
         help="Only verify a specific mode (default: all)",
     )
     parser.add_argument(
-        "--verbose", "-v", action="store_true",
+        "--verbose",
+        "-v",
+        action="store_true",
         help="Print detailed input/output info for each model",
     )
     args = parser.parse_args()
@@ -126,8 +131,11 @@ def main():
         print(mode)
         print("=" * 70)
         d = os.path.join(base, mode)
-        collector = _collect_onnx_files_single_op if mode == "single_op" \
+        collector = (
+            _collect_onnx_files_single_op
+            if mode == "single_op"
             else _collect_onnx_files_flat
+        )
         ok = verify_dir(d, collector, verbose=args.verbose)
         if not ok:
             overall_ok = False


### PR DESCRIPTION
## Motivation

End-to-end ONNX models are large and contain many operators, which makes performance work and regression analysis expensive. This PR adds an **ONNX model splitting and validation toolkit** under `tools/onnx-model-splitter/` to:

- Split models into **single_op**, **single_layer**, and **full_model** submodels for targeted benchmarking and debugging.
- Auto-detect **LLM (text)**, **Vision**, and **Embedding**-style graphs and emit reasonable **shape / dimension variants** (including for `full_model`).
- Provide **structure checks**, **fixed-shape validation**, and **ONNX Runtime inference smoke tests** (subprocess-isolated) so bad extractions are less likely to enter test workflows.
- Support ORT GenAI / fixed-context workflows with **prefill/decode ONNX export** and **decoder-pipeline style `genai_config` generation**, aligned with the end-to-end example in `README.md`.
- **Validate `export_chunk_model.py` output directories** by comparing each **prefill / decode** ONNX pair (graph structure, dtypes, allowed shape differences) and checking **`genai_config_*.json`** filenames and pipeline I/O lists against the graphs (`compare_chunk_export_outputs.py`).

## Technical Details

Adds directory: `tools/onnx-model-splitter/`.

| Component | Description |
|-----------|-------------|
| `extract_submodels.py` | Main entry: splits by mode; output layout is documented in `README.md` (`single_op/`, `single_layer/`, `full_model/`, etc.). Supports multiple dimension variants and graph-specific rules (e.g. attention-mask chains, GQA `total_seq_len` handling—see script and README). |
| `export_chunk_model.py` | Exports **fixed max_length / sequence-length** **prefill** and **decode** ONNX variants from a full Llama-style model; optional **`genai_config`** generation (including fixed-prompt-length scenarios). Reuses logic from co-located `extract_submodels.py` via **`importlib`** (no `sys.path` mutation). |
| `compare_chunk_export_outputs.py` | Run on an **`export_chunk_model.py` output directory**: for each stem `TAG` from `prefill_TAG.onnx`, expects matching `decode_TAG.onnx` and `genai_config_TAG.json` (non-`*_dml`). Compares prefill vs decode graphs (node topology, edges, dtypes; **intermediate shapes optional** via `--compare-intermediate-shapes`), graph I/O with documented exceptions for prefill vs decode sequence axes, `past_*` / `present_*` shape alignment, and validates pipeline filenames / I/O name lists in JSON vs ONNX (order multiset; non-fatal notes on order-only mismatches when appropriate). |
| `genai_config_pipeline_from_folder.py` | Reads structural metadata from a model folder’s `genai_config.json` (or another JSON) and emits a **decoder-pipeline** style **`genai_config`** for ORT GenAI (`fixed_prompt_length`, `max_length`, session / provider options, etc.). When discoverable **prefill/decode ONNX** exist under the model dir (and common subdirs such as `chunk/`), **pipeline input/output name lists** can be read from the graphs so bindings match exports (e.g. sparse KV / extra state tensors); **`--no-onnx-io`** forces template-only lists; repeatable **`--onnx-subdir`** extends search paths. |
| `inspect_onnx.py` | Inspect inputs/outputs, nodes, op-type stats; optional filters by op type, layer index, etc.; **`--find-chains`** for common preprocessing chains (e.g. `attention_mask`, `position_ids`). |
| `verify_ort_inference.py` | Smoke-test extracted models with **ORT + dummy inputs**; **one subprocess per model** so native crashes do not abort the whole run. |
| `verify_extraction.py` | Validate sizes, graph structure, initializer integrity; **fixed-shape checks** for fixed-shape variants (optional **`--skip-fixed-shape-check`**). |
| `_verify_one_model.py` | Subprocess **worker** used by `verify_ort_inference.py` (load one model, run inference). |
| `requirements.txt` | Optional consolidated Python dependencies; `README.md` also documents **`pip install onnx onnxruntime numpy`** and recommends optional **`onnxoptimizer`** for shape-related constant folding on fixed-shape variants. |
| `README.md` | Install steps, CLI examples, supported model types, output layout; includes an **end-to-end Llama-3.1-8B** walkthrough (extract → verify `space` → pipeline `genai_config` → export prefill/decode → optional **compare** on `chunk/`). |

**Dependencies / usage:** Python 3; install per `README.md` (or `pip install -r requirements.txt` if kept in sync). Scripts can be invoked by path from any working directory as shown in the README. This is a **standalone tool directory** and does not change the existing C++/MLIR build path.

## Test Plan

1. **Environment:** `cd tools/onnx-model-splitter` and install per `README.md` (`onnx`, `onnxruntime`, `numpy`; optionally `onnxoptimizer`), or `pip install -r requirements.txt` if appropriate.
2. **Extraction:** Run `python extract_submodels.py --model <path>` on a target `model.onnx` (optionally `--only single_op`, `single_layer`, or `full_model`). Confirm outputs match `README.md`.
3. **Inspection:** Run `python inspect_onnx.py <model.onnx>`; optionally `--find-chains` and sanity-check I/O and node listing.
4. **Validation:** On the extraction output directory, run `python verify_extraction.py <out_dir>` and `python verify_ort_inference.py <out_dir>`; confirm both exit successfully; exercise `--skip-fixed-shape-check` if needed.
5. **Export / GenAI config:** Follow the **End-to-End Example** in `README.md` using `genai_config_pipeline_from_folder.py` and `export_chunk_model.py` (including `--max-length`, `-T` template, etc.); confirm generated ONNX and JSON paths/names match the doc.
6. **Compare chunk exports:** On the **`export_chunk_model.py` output directory** (e.g. `space/chunk` from the README), run `python compare_chunk_export_outputs.py <dir>`; confirm exit code **0**. Optionally run with `--compare-intermediate-shapes` for stricter shape checks.
7. **CI:** Confirm **pre-commit** (lintrunner / ruff, licenseheaders, etc.) passes on the PR branch.