### PR TITLE
perf: operator/I/O profiling, PERF breakdown, skip-buffer I/O cache (DRAFT)

### DIFF
--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -206,6 +206,7 @@ endmacro()
 # Compile shared implementation files
 compile_to_bitcode(hipdnn_ep_runtime_state.cpp runtime_state.bc)
 compile_to_bitcode(hipdnn_ep_runtime_tensor.cpp runtime_tensor.bc)
+compile_to_bitcode(operator_profile.cpp runtime_operator_profile.bc)
 
 # Compile implementation-specific files
 if(NOT BUILD_MOCK_RUNTIME)
@@ -234,6 +235,7 @@ if(NOT BUILD_MOCK_RUNTIME)
     set(RUNTIME_BC_MODULES
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_state.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_tensor.bc
+        ${CMAKE_CURRENT_BINARY_DIR}/runtime_operator_profile.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_memory.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_hip.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_miopen.bc
@@ -264,6 +266,7 @@ else()
     set(RUNTIME_BC_MODULES
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_state.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_tensor.bc
+        ${CMAKE_CURRENT_BINARY_DIR}/runtime_operator_profile.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_memory.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_mock.bc
         ${CMAKE_CURRENT_BINARY_DIR}/test_hip_from_dll.bc

--- a/lib/Runtime/debug_log.h
+++ b/lib/Runtime/debug_log.h
@@ -6,9 +6,16 @@
 #pragma once
 // Runtime debug logging gated on HIPDNN_EP_DEBUG env var (default: off)
 // Set HIPDNN_EP_DEBUG=1 to enable all [Runtime DEBUG] output.
-// Set HIPDNN_EP_PERF=1 to enable only [PERF] timing breakdown per inference.
+// Set HIPDNN_EP_PERF=1 to enable [PERF] aggregate (wall + GPU breakdown).
+// Set HIPDNN_EP_PERF_EACH=1 to additionally emit per-inference [PERF] rows.
+// Set HIPDNN_EP_PERF_WARMUP=N to bucket the first N inferences of each
+//   session as "warmup" in BOTH the [PERF] and [OP_PROFILE] aggregates so
+//   their kernel-selection / JIT / autotune cost does not pollute the
+//   steady-state averages. Default: 1. Set 0 to disable the split.
 #include <cstdio>
 #include <cstdlib>
+
+struct RuntimeState;
 
 inline bool hipdnn_ep_debug_enabled() {
   static const bool enabled = [] {
@@ -25,6 +32,33 @@ inline bool hipdnn_ep_perf_enabled() {
   }();
   return enabled || hipdnn_ep_debug_enabled();
 }
+
+// Number of leading inferences (per session) to bucket as "warmup". The
+// first call into the EP triggers all kinds of one-time work -- hipBLASLt
+// heuristic search, MIOpen kernel finder cache fills, hipRTC JIT, the
+// first hipMalloc growth, runtime constant H2D, etc. -- that is irrelevant
+// to steady-state behavior and skews avg/p50 if mixed in. We still RECORD
+// these inferences so the user can see exactly how expensive warmup was;
+// they just don't contribute to the steady-state numbers.
+//
+// Shared by both PERF (hipdnn_ep_runtime_tensor.cpp) and OP_PROFILE
+// (operator_profile.cpp) so the two aggregates partition identically and
+// their averages can be compared directly.
+inline unsigned hipdnn_ep_perf_warmup_count() {
+  static const unsigned n = [] {
+    const char *v = std::getenv("HIPDNN_EP_PERF_WARMUP");
+    if (!v || !*v)
+      return 1u;
+    int parsed = std::atoi(v);
+    return parsed < 0 ? 0u : static_cast<unsigned>(parsed);
+  }();
+  return n;
+}
+
+// Implemented in hipdnn_ep_runtime_tensor.cpp. Drives the final inference
+// rollup (using `state`'s stream to record the closing d2h_end marker) and
+// prints the aggregate PERF summary. Safe to call when PERF is disabled.
+extern "C" void hipdnn_ep_perf_flush_and_print(RuntimeState *state);
 
 #define RUNTIME_DEBUG_LOG(fmt, ...)                                            \
   do {                                                                         \

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -6,6 +6,7 @@
 #include "hip/timing.h"
 #include "hip_cleanup.h"
 #include "hipdnn_ep_runtime.h"
+#include "operator_profile.h"
 #include "runtime_state_internal.h"
 
 #include "model_metadata_generated.h"
@@ -100,6 +101,7 @@ int hipdnn_ep_state_init_with_fs(RuntimeState **out_state, void *fs,
   state->workspace_size = 0;
   state->hipdnn_handle = nullptr;
   state->hipdnn_graph_registry = nullptr;
+  state->io_cache = nullptr;
 
   // Explicitly initialize HIP device before any other operations
   // This ensures device 0 is active and context is properly initialized
@@ -476,6 +478,22 @@ int hipdnn_ep_state_cleanup(RuntimeState *state) {
   // Synchronize stream to ensure all GPU operations complete
   if (state->stream) {
     HIP_CLEANUP(hipStreamSynchronize(state->stream));
+  }
+
+  // Drain any remaining per-operator profiling events and emit the lifetime
+  // summary. Must happen after stream sync so the events have completed.
+  hipdnn_ep::op_profile_print_summary_and_reset();
+
+  // Roll up the last open inference (if any) and dump the [PERF] aggregate.
+  // Mirrors op_profile: the generated inference_compute does not call
+  // hipdnn_ep_stream_sync today, so this is the deterministic flush point
+  // for the wall-clock + GPU breakdown reference.
+  hipdnn_ep_perf_flush_and_print(state);
+
+  // Destroy the I/O cache (frees any persistent GPU buffers it owns). Must
+  // happen after stream sync so no in-flight kernel references these buffers.
+  if (state->io_cache) {
+    hipdnn_ep_io_cache_destroy(state);
   }
 
   // Free shared workspace (if allocated)

--- a/lib/Runtime/hipdnn_ep_runtime_tensor.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_tensor.cpp
@@ -5,12 +5,16 @@
 #include "debug_log.h"
 #include "hip_cleanup.h"
 #include "hipdnn_ep_runtime.h"
+#include "operator_profile.h"
 #include "runtime_state_internal.h"
 
 #include <cassert>
+#include <chrono>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 // Fallback element size when tensor metadata is missing (covers fp32).
@@ -18,59 +22,472 @@ static constexpr size_t kDefaultElementSize = 4;
 //===----------------------------------------------------------------------===//
 // Per-Inference Performance Measurement (gated on HIPDNN_EP_PERF)
 //===----------------------------------------------------------------------===//
-// Records hipEvents on the GPU stream at phase boundaries to measure:
-//   H2D  = time for all host-to-device async copies
-//   Compute = time for main_graph GPU kernel dispatches
-//   D2H  = time for all device-to-host async copies + stream sync
+// Reports a wall-clock "total runtime time" reference per inference plus a
+// GPU-stream breakdown (H2D / Compute / D2H). Useful for triangulating
+// against TTFT/TPS at the benchmark level and against op/io profile sums.
 //
-// Phase boundaries are detected by tracking the first call to each function
-// type in the per-inference sequence:
-//   prepare_input(0)  -> H2D start
-//   prepare_output(0) -> H2D end / compute start
-//   finalize_output(0)-> compute end / D2H start
-//   stream_sync()     -> D2H end, then log results
+// The two clocks bracket DIFFERENT intervals -- this is intentional and the
+// gap between them is itself informative:
+//
+//   Wall = host_end - host_start   (host monotonic clock, chrono)
+//     host_start: prepare_input(0) entry
+//     host_end:   last finalize_output return -- i.e. the moment the EP
+//                 finished QUEUEING all GPU work and returned to OGA.
+//                 NOT the moment that work has FINISHED on the GPU.
+//
+//   GPU stream = elapsed(h2d_start, d2h_end)   (GPU timer, hipEventElapsedTime)
+//     h2d_start: queued at prepare_input(0); fires when the GPU processes
+//                the first H2D dispatch.
+//     d2h_end:   re-recorded at every D2H finalize_output (last write wins);
+//                fires when the GPU finishes the last D2H copy.
+//
+// Interpretation of (Wall - GPU):
+//   > 0  "Other"   = host-side framework overhead the operator/io profilers
+//                    cannot see (synchronous reads, dispatch, error checks,
+//                    PERF/op-profile bookkeeping itself, etc.).
+//   < 0  "Overlap" = host returned to OGA before GPU finished draining the
+//                    stream. The magnitude is how much GPU work was still
+//                    in flight after host_end -- i.e. how much the host
+//                    pipelined ahead of the GPU. A persistent overlap is
+//                    THE signature of a GPU-bound steady state: speeding
+//                    up host-side work cannot help, only kernels can.
+//
+// Note that the OLD design anchored host_end to the NEXT prepare_input(0)
+// on the same model. By construction that made host_end >= T_d2h_end, so
+// "Other" was always >= 0 and frequently pinned to ~0 -- giving the false
+// impression of "100% GPU bound, no host overlap". The new design samples
+// host_end at the last finalize_output, which exposes real overlap.
+//
+// Per-inference event flow on the runtime stream:
+//   prepare_input(0)        -> H2D start  (and Wall start, via chrono)
+//   prepare_output(0)       -> H2D end / Compute start
+//   first finalize_output   -> D2H start  (Compute end; idempotent)
+//   every D2H finalize_*    -> D2H end re-recorded after the real D2H
+//                              (last write wins; cache-claim path skipped
+//                              to avoid stamping on an idle stream)
+//   every finalize_output   -> host_end sampled (last write wins; both
+//                              real-D2H AND cache-claim paths)
+//   state_cleanup / atexit  -> drain queue, print aggregate per session
+//
+// CRITICAL: closing each inference at the LAST finalize_output (rather than
+// at the next prepare_input(0)) is what makes Wall meaningful for sparse-
+// call models. In OGA's chunked decoder pipeline the prompt model is only
+// invoked once per benchmark iteration (~52 s apart), so anchoring
+// host_end / d2h_end to "next prepare_input on this model" would inflate
+// Wall by the entire decode phase between calls. Re-recording on every
+// finalize_output is essentially free (each call costs one chrono read
+// plus, on the real-D2H path, one hipEventRecord on a stream that is
+// already busy with D2Hs) and naturally pins the close marker to the
+// very last D2H completion of the inference.
+//
+// All HIP events are RECORDED inline (no synchronization) and their elapsed
+// times are READ in a single batch at end of run. This deliberately avoids
+// hipEventSynchronize per inference because that would force CPU/GPU
+// serialization and distort the very Wall number we are trying to measure.
+//
+// Warmup handling: the first N inferences are bucketed separately so kernel-
+// selection / autotuning / JIT / hipBLASLt heuristic-search cost is reported
+// but does not pollute steady-state averages. Controlled by
+// HIPDNN_EP_PERF_WARMUP=N (default 1).
+//
+// Env vars:
+//   HIPDNN_EP_PERF=1       -> enable measurement, print aggregate at exit
+//   HIPDNN_EP_PERF_EACH=1  -> additionally print per-inference rows (verbose)
+//   HIPDNN_EP_PERF_WARMUP=N -> bucket first N inferences as warmup (default 1)
 
-struct PerfState {
+struct PerfPending {
+  // GPU phase markers (all on the same stream).
   hipEvent_t h2d_start = nullptr;
   hipEvent_t h2d_end = nullptr;
   hipEvent_t d2h_start = nullptr;
   hipEvent_t d2h_end = nullptr;
+  // Host wall-clock bracket. host_start is sampled at prepare_input(0);
+  // host_end is sampled at every finalize_output (last write wins). If no
+  // finalize_output was called, perf_close_current_inference() falls back
+  // to the late-close path.
+  std::chrono::steady_clock::time_point host_start{};
+  std::chrono::steady_clock::time_point host_end{};
+  bool host_end_set = false;
+  // Per-inference IO sizes seen by prepare_input / finalize_output. Used to
+  // sanity-check against the IO profile and to populate aggregate stats.
   size_t h2d_bytes = 0;
   size_t h2d_count = 0;
   size_t d2h_bytes = 0;
   size_t d2h_count = 0;
-  unsigned inference_num = 0;
-  bool initialized = false;
 };
-static PerfState g_perf;
 
-static void perf_ensure_events() {
-  if (g_perf.initialized)
-    return;
-  if (hipEventCreate(&g_perf.h2d_start) != hipSuccess ||
-      hipEventCreate(&g_perf.h2d_end) != hipSuccess ||
-      hipEventCreate(&g_perf.d2h_start) != hipSuccess ||
-      hipEventCreate(&g_perf.d2h_end) != hipSuccess) {
-    fprintf(stderr, "[PERF] WARNING: hipEventCreate failed, disabling PERF\n");
-    if (g_perf.h2d_start) {
-      (void)hipEventDestroy(g_perf.h2d_start);
-      g_perf.h2d_start = nullptr;
-    }
-    if (g_perf.h2d_end) {
-      (void)hipEventDestroy(g_perf.h2d_end);
-      g_perf.h2d_end = nullptr;
-    }
-    if (g_perf.d2h_start) {
-      (void)hipEventDestroy(g_perf.d2h_start);
-      g_perf.d2h_start = nullptr;
-    }
-    if (g_perf.d2h_end) {
-      (void)hipEventDestroy(g_perf.d2h_end);
-      g_perf.d2h_end = nullptr;
-    }
-    return;
+struct PerfAggregate {
+  unsigned count = 0;
+  double wall_ms = 0.0;
+  double h2d_ms = 0.0;
+  double compute_ms = 0.0;
+  double d2h_ms = 0.0;
+  size_t h2d_count = 0;
+  size_t h2d_bytes = 0;
+  size_t d2h_count = 0;
+  size_t d2h_bytes = 0;
+};
+
+// Pool of recyclable hipEvents to avoid hipEventCreate/Destroy churn.
+static std::vector<hipEvent_t> g_perf_event_pool;
+// Closed inferences waiting to have their event timings read at end of run.
+static std::vector<PerfPending> g_perf_queue;
+// The currently-open inference being recorded in real time.
+static PerfPending g_perf_current;
+static bool g_perf_current_valid = false;
+// Stashed for the atexit dump, since we no longer get a RuntimeState there.
+static void *g_perf_last_stream = nullptr;
+// Per-session aggregates: separate buckets for warmup vs steady-state so
+// the kernel-selection / JIT cost of the first inferences doesn't pollute
+// the steady-state averages. See HIPDNN_EP_PERF_WARMUP.
+//
+// These are RESET after each perf_flush_and_print() so chunked-pipeline
+// models -- where each ONNX session (prompt model, decoder model, ...)
+// triggers its own state_cleanup -- produce one PERF block per session
+// rather than one cumulative blob across the whole process.
+static PerfAggregate g_perf_warmup_agg;
+static PerfAggregate g_perf_steady_agg;
+// Counts how many state_cleanup / atexit prints have happened. Used to
+// label each PERF block ("session #1", "session #2", ...) so the user can
+// match them up against OGA's prompt vs decoder model.
+static unsigned g_perf_session_index = 0;
+
+static bool hipdnn_ep_perf_each_enabled() {
+  static const bool enabled = [] {
+    const char *v = std::getenv("HIPDNN_EP_PERF_EACH");
+    return v && v[0] >= '1';
+  }();
+  return enabled;
+}
+
+// hipdnn_ep_perf_warmup_count() lives in debug_log.h so OP_PROFILE can use
+// the same value -- both reports must partition warmup vs steady identically
+// or their averages won't be directly comparable.
+
+static hipEvent_t perf_acquire_event() {
+  if (!g_perf_event_pool.empty()) {
+    hipEvent_t e = g_perf_event_pool.back();
+    g_perf_event_pool.pop_back();
+    return e;
   }
-  g_perf.initialized = true;
+  hipEvent_t e = nullptr;
+  if (hipEventCreate(&e) != hipSuccess)
+    return nullptr;
+  return e;
+}
+
+static void perf_release_event(hipEvent_t e) {
+  if (e)
+    g_perf_event_pool.push_back(e);
+}
+
+// Forward declarations for the rollup helpers.
+static void perf_close_current_inference(void *stream);
+static void perf_drain_and_aggregate();
+static void perf_print_aggregate();
+static void perf_atexit_dump();
+
+// Begin a new pending inference at prepare_input(index=0). If an inference
+// is still open (e.g., something happened that prevented finalize_output
+// from running, or this is the first call into a new model), close it first.
+static void perf_begin_inference(void *stream) {
+  if (!hipdnn_ep_perf_enabled())
+    return;
+  g_perf_last_stream = stream;
+
+  // If the previous inference is still open here, finalize_output never
+  // closed it (rare). Close it now via the late-close path.
+  if (g_perf_current_valid)
+    perf_close_current_inference(stream);
+
+  // Allocate a fresh set of events for the new inference.
+  g_perf_current = PerfPending{};
+  g_perf_current.h2d_start = perf_acquire_event();
+  g_perf_current.h2d_end = perf_acquire_event();
+  g_perf_current.d2h_start = perf_acquire_event();
+  g_perf_current.d2h_end = perf_acquire_event();
+  g_perf_current.host_start = std::chrono::steady_clock::now();
+  g_perf_current_valid = true;
+
+  // Register the atexit dump exactly once on the first PERF-enabled call.
+  static bool atexit_registered = false;
+  if (!atexit_registered) {
+    std::atexit(perf_atexit_dump);
+    atexit_registered = true;
+  }
+
+  if (g_perf_current.h2d_start)
+    (void)hipEventRecord(g_perf_current.h2d_start,
+                         static_cast<hipStream_t>(stream));
+}
+
+static void perf_record_h2d_end(void *stream) {
+  if (!g_perf_current_valid)
+    return;
+  if (g_perf_current.h2d_end)
+    (void)hipEventRecord(g_perf_current.h2d_end,
+                         static_cast<hipStream_t>(stream));
+}
+
+// Idempotent: only the FIRST finalize_output of an inference actually
+// records the d2h_start marker. Subsequent calls just return.
+static void perf_record_d2h_start(void *stream) {
+  if (!g_perf_current_valid)
+    return;
+  if (g_perf_current.d2h_count != 0)
+    return;
+  if (g_perf_current.d2h_start)
+    (void)hipEventRecord(g_perf_current.d2h_start,
+                         static_cast<hipStream_t>(stream));
+}
+
+static void perf_count_h2d(size_t bytes) {
+  if (!g_perf_current_valid)
+    return;
+  g_perf_current.h2d_bytes += bytes;
+  g_perf_current.h2d_count++;
+}
+
+static void perf_count_d2h(size_t bytes) {
+  if (!g_perf_current_valid)
+    return;
+  g_perf_current.d2h_bytes += bytes;
+  g_perf_current.d2h_count++;
+}
+
+// Sample host_end (last write wins). Cheap (~100 ns chrono read), called
+// from every finalize_output -- including the IoCache fast path that
+// returns without touching the stream -- so it stays accurate regardless
+// of whether the LAST finalize did a real D2H or just a cache claim.
+static inline void perf_touch_host_end() {
+  if (!g_perf_current_valid)
+    return;
+  g_perf_current.host_end = std::chrono::steady_clock::now();
+  g_perf_current.host_end_set = true;
+}
+
+// Re-record d2h_end on the stream (last write wins). Only called from the
+// finalize path that actually queued an async D2H -- recording on an idle
+// stream would back-fill d2h_end with a timestamp from "much later than
+// the actual last D2H" and inflate d2h_ms by stream-idle time. By
+// re-recording right after each real hipMemcpyAsync, the FINAL stored
+// timestamp is exactly "right after the last D2H of the inference".
+//
+// IMPORTANT: this is what avoids the prompt-model-Wall=52s bug. Anchoring
+// the close to "next prepare_input on the same model" fails for sparse
+// callers (prompt model called once per benchmark iteration with 255
+// decode calls in between).
+static inline void perf_record_d2h_end(void *stream) {
+  if (!g_perf_current_valid)
+    return;
+  if (g_perf_current.d2h_end && stream)
+    (void)hipEventRecord(g_perf_current.d2h_end,
+                         static_cast<hipStream_t>(stream));
+}
+
+// Late-close path: only used when the current inference somehow reaches a
+// teardown boundary (next prepare_input on a sparse model, state_cleanup,
+// atexit) without finalize_output ever having closed it. In that case we
+// stamp the close markers now -- accuracy is degraded for those rare
+// inferences (Wall will include framework idle time after the last call)
+// but at least the data is not lost.
+static void perf_close_current_inference(void *stream) {
+  if (!g_perf_current_valid)
+    return;
+  if (!g_perf_current.host_end_set) {
+    if (g_perf_current.d2h_end && stream)
+      (void)hipEventRecord(g_perf_current.d2h_end,
+                           static_cast<hipStream_t>(stream));
+    g_perf_current.host_end = std::chrono::steady_clock::now();
+    g_perf_current.host_end_set = true;
+  }
+  g_perf_queue.push_back(g_perf_current);
+  g_perf_current = PerfPending{};
+  g_perf_current_valid = false;
+}
+
+// Add a pending inference to the right aggregate bucket and (if EACH is on)
+// emit a per-inference row.
+static void perf_aggregate_one(unsigned idx, const PerfPending &p,
+                               double wall_ms, float h2d_ms, float compute_ms,
+                               float d2h_ms) {
+  PerfAggregate &agg = (idx < hipdnn_ep_perf_warmup_count())
+                           ? g_perf_warmup_agg
+                           : g_perf_steady_agg;
+  agg.count++;
+  agg.wall_ms += wall_ms;
+  agg.h2d_ms += h2d_ms;
+  agg.compute_ms += compute_ms;
+  agg.d2h_ms += d2h_ms;
+  agg.h2d_count += p.h2d_count;
+  agg.h2d_bytes += p.h2d_bytes;
+  agg.d2h_count += p.d2h_count;
+  agg.d2h_bytes += p.d2h_bytes;
+
+  if (hipdnn_ep_perf_each_enabled()) {
+    double gpu_ms = static_cast<double>(h2d_ms) +
+                    static_cast<double>(compute_ms) +
+                    static_cast<double>(d2h_ms);
+    // delta = Wall - GPU. Sign matters:
+    //   delta > 0 -> "Other": host-side overhead the profilers can't see
+    //                (sync, framework, dispatch).
+    //   delta < 0 -> "Overlap": host returned before GPU finished. The
+    //                magnitude is how much GPU work was still in flight
+    //                after host_end (i.e. how much the host pipelined
+    //                ahead of the GPU). Indicates a GPU-bound steady state.
+    double delta_ms = wall_ms - gpu_ms;
+    fprintf(stderr,
+            "[PERF] inference #%u%s:  Wall %.3f ms  (GPU %.3f ms = "
+            "H2D %.3f + Compute %.3f + D2H %.3f, %s %.3f)\n",
+            idx + 1,
+            idx < hipdnn_ep_perf_warmup_count() ? " [warmup]" : "", wall_ms,
+            gpu_ms, (double)h2d_ms, (double)compute_ms, (double)d2h_ms,
+            delta_ms >= 0.0 ? "Other" : "Overlap",
+            delta_ms >= 0.0 ? delta_ms : -delta_ms);
+  }
+}
+
+// At end of run, sync once on the very last d2h_end event, walk the queue,
+// query elapsed times, partition into warmup / steady aggregates, recycle
+// events.
+static void perf_drain_and_aggregate() {
+  if (g_perf_queue.empty())
+    return;
+
+  // Single sync point: wait for all queued GPU work to drain so all event
+  // timestamps are valid.
+  hipEvent_t last_end = g_perf_queue.back().d2h_end;
+  if (last_end)
+    (void)hipEventSynchronize(last_end);
+
+  for (size_t i = 0; i < g_perf_queue.size(); ++i) {
+    auto &p = g_perf_queue[i];
+    double wall_ms = std::chrono::duration<double, std::milli>(p.host_end -
+                                                                p.host_start)
+                          .count();
+    if (wall_ms < 0.0)
+      wall_ms = 0.0;
+
+    float h2d_ms = 0.0f, compute_ms = 0.0f, d2h_ms = 0.0f;
+    if (p.h2d_start && p.h2d_end)
+      (void)hipEventElapsedTime(&h2d_ms, p.h2d_start, p.h2d_end);
+    if (p.h2d_end && p.d2h_start)
+      (void)hipEventElapsedTime(&compute_ms, p.h2d_end, p.d2h_start);
+    if (p.d2h_start && p.d2h_end)
+      (void)hipEventElapsedTime(&d2h_ms, p.d2h_start, p.d2h_end);
+    if (h2d_ms < 0.0f)
+      h2d_ms = 0.0f;
+    if (compute_ms < 0.0f)
+      compute_ms = 0.0f;
+    if (d2h_ms < 0.0f)
+      d2h_ms = 0.0f;
+
+    perf_aggregate_one(static_cast<unsigned>(i), p, wall_ms, h2d_ms,
+                       compute_ms, d2h_ms);
+
+    // Recycle events back to the pool for reuse.
+    perf_release_event(p.h2d_start);
+    perf_release_event(p.h2d_end);
+    perf_release_event(p.d2h_start);
+    perf_release_event(p.d2h_end);
+  }
+  g_perf_queue.clear();
+}
+
+// Print one aggregate block. Internal helper used by perf_print_aggregate().
+static void perf_print_one_aggregate(const char *label, const PerfAggregate &a) {
+  if (a.count == 0)
+    return;
+  double n = static_cast<double>(a.count);
+  double gpu_total = a.h2d_ms + a.compute_ms + a.d2h_ms;
+  // Wall - GPU. Sign carries information:
+  //   delta > 0 -> host-side framework overhead the op/io profilers can't see
+  //                (sync points, dispatch, sampling, etc.). Reported as
+  //                "Other (Wall - GPU)".
+  //   delta < 0 -> host returned to OGA before the GPU finished draining the
+  //                stream. Magnitude is how much the host was pipelined ahead
+  //                of the GPU on average. Reported as "Overlap (GPU - Wall)".
+  //                A persistent overlap indicates the workload is GPU-bound:
+  //                speeding up host-side work won't help.
+  double delta_total = a.wall_ms - gpu_total;
+  double mb_h2d = static_cast<double>(a.h2d_bytes) / (1024.0 * 1024.0);
+  double mb_d2h = static_cast<double>(a.d2h_bytes) / (1024.0 * 1024.0);
+
+  // Use Wall as the percentage base for "Other" (host overhead share of Wall)
+  // and GPU as the base for "Overlap" (how much GPU work overlapped with the
+  // *next* inference's host work, i.e. is hidden by pipelining).
+  const char *delta_label =
+      delta_total >= 0.0 ? "Other (Wall - GPU)" : "Overlap (GPU - Wall)";
+  double delta_abs = delta_total >= 0.0 ? delta_total : -delta_total;
+  double delta_pct_base = delta_total >= 0.0 ? a.wall_ms : gpu_total;
+  double delta_pct =
+      delta_pct_base > 0.0 ? (delta_abs / delta_pct_base * 100.0) : 0.0;
+
+  fprintf(stderr,
+          "[PERF] %s over %u inference(s):\n"
+          "  Wall (CPU clock):       %10.2f ms total / %8.3f ms avg\n"
+          "  GPU stream (H2D+C+D2H): %10.2f ms total / %8.3f ms avg "
+          "(%.1f%% of Wall)\n"
+          "    H2D:                  %10.2f ms total / %8.3f ms avg "
+          "(%zu tensors, %.1f MB)\n"
+          "    Compute (kernels):    %10.2f ms total / %8.3f ms avg\n"
+          "    D2H:                  %10.2f ms total / %8.3f ms avg "
+          "(%zu tensors, %.1f MB)\n"
+          "  %-22s  %10.2f ms total / %8.3f ms avg (%.1f%%)\n",
+          label, a.count, a.wall_ms, a.wall_ms / n, gpu_total, gpu_total / n,
+          a.wall_ms > 0 ? (gpu_total / a.wall_ms * 100.0) : 0.0, a.h2d_ms,
+          a.h2d_ms / n, a.h2d_count, mb_h2d, a.compute_ms, a.compute_ms / n,
+          a.d2h_ms, a.d2h_ms / n, a.d2h_count, mb_d2h, delta_label, delta_abs,
+          delta_abs / n, delta_pct);
+}
+
+// Print the per-session aggregate(s) and reset for the next session.
+//
+// We label this print with a session index so the user can match each PERF
+// block to the corresponding ONNX session in OGA's chunked pipeline (e.g.,
+// session #1 = prompt model, session #2 = decoder model). After printing,
+// the aggregates are zeroed -- subsequent inferences (from a different
+// session whose state_cleanup has not yet been called) accumulate fresh.
+static void perf_print_aggregate() {
+  if (g_perf_warmup_agg.count == 0 && g_perf_steady_agg.count == 0)
+    return;
+
+  ++g_perf_session_index;
+  char header[128];
+  std::snprintf(header, sizeof(header),
+                "session #%u WARMUP (first inferences, kernel selection / "
+                "JIT / autotune)",
+                g_perf_session_index);
+  perf_print_one_aggregate(header, g_perf_warmup_agg);
+  std::snprintf(header, sizeof(header),
+                "session #%u STEADY-STATE (post-warmup)",
+                g_perf_session_index);
+  perf_print_one_aggregate(header, g_perf_steady_agg);
+
+  g_perf_warmup_agg = PerfAggregate{};
+  g_perf_steady_agg = PerfAggregate{};
+}
+
+// Process-exit handler: best-effort drain of the queue and aggregate print.
+static void perf_atexit_dump() {
+  if (!hipdnn_ep_perf_enabled())
+    return;
+  if (g_perf_current_valid && g_perf_last_stream)
+    perf_close_current_inference(g_perf_last_stream);
+  perf_drain_and_aggregate();
+  perf_print_aggregate();
+}
+
+// Public entry point for state_cleanup. Drains the queue and prints. The
+// caller is expected to have already called hipStreamSynchronize(stream)
+// before invoking this so the events are guaranteed to be valid.
+extern "C" void hipdnn_ep_perf_flush_and_print(RuntimeState *state) {
+  if (!hipdnn_ep_perf_enabled())
+    return;
+  if (g_perf_current_valid && state)
+    perf_close_current_inference(state->stream);
+  perf_drain_and_aggregate();
+  perf_print_aggregate();
 }
 
 //===----------------------------------------------------------------------===//
@@ -100,6 +517,152 @@ static void pool_release(void *ptr, size_t size_bytes) {
   assert(size_bytes > 0 && "pool_release: size_bytes must be positive");
   if (ptr)
     g_gpu_buffer_pool[size_bytes].push_back(ptr);
+}
+
+//===----------------------------------------------------------------------===//
+// I/O Cache: skip H2D + D2H for `past_present_share_buffer` tensors (PERF)
+//===----------------------------------------------------------------------===//
+// PERF-VERIFICATION MODE: skips both H2D and D2H on cache_claim. This is
+// faster than the correct PIN+D2H variant but produces incorrect outputs
+// in OGA's chunked decoder pipeline because each compiled MLIR DLL has
+// its own copy of the file-scope statics below -- prefill's installs are
+// invisible to decode and vice versa. Use only to put a number on the
+// upper bound of what an I/O cache could buy.
+//
+// Architecture: process-global cache (one shared map keyed by host_ptr),
+// with per-state refcount tracking so persistent buffers are reclaimed
+// when the last referencing state is destroyed.
+//
+// Gate: HIPDNN_EP_IO_CACHE (default=ON, set to "0" to disable).
+
+struct IoCacheEntry {
+  void *gpu_ptr;
+  size_t size_bytes;
+};
+
+// Process-global cache: keyed by host_ptr. Owns the pinned GPU buffers.
+// "Process-global" is aspirational -- because the runtime is statically
+// linked into each MLIR-compiled DLL, each DLL gets its own copy of these
+// statics. That's why this mode produces wrong output in chunked
+// pipelines; see header comment.
+static std::unordered_map<const void *, IoCacheEntry> g_io_cache_persistent;
+
+// Refcount keyed by host_ptr. One reference per RuntimeState that has
+// observed the host_ptr as an input. Decremented on state_cleanup; the
+// persistent entry is freed when count hits zero.
+static std::unordered_map<const void *, int> g_io_cache_refcount;
+
+// Per-state tracker: history of host_ptrs we've refcount-bumped (so we
+// can decrement on cleanup) and the alive set for the current call (so
+// finalize_output can detect input/output aliasing).
+struct IoCache {
+  std::unordered_set<const void *> tracked_keys;
+  std::unordered_set<const void *> current_inputs;
+};
+
+static bool io_cache_enabled() {
+  // Read once at process startup, log the resolved state to stderr so it is
+  // visible in benchmark logs alongside other runtime toggles.
+  static const bool enabled = [] {
+    const char *v = std::getenv("HIPDNN_EP_IO_CACHE");
+    bool on = !v || v[0] != '0';
+    fprintf(stderr,
+            "[Runtime] HIPDNN_EP_IO_CACHE=%s (I/O cache %s, mode=global)\n",
+            v ? v : "<unset>", on ? "ENABLED" : "DISABLED");
+    return on;
+  }();
+  return enabled;
+}
+
+static IoCache *io_cache_get(RuntimeState *state) {
+  if (!state)
+    return nullptr;
+  if (!state->io_cache)
+    state->io_cache = new IoCache();
+  return static_cast<IoCache *>(state->io_cache);
+}
+
+// Bump the global refcount for host_ptr the first time this state sees it.
+// Idempotent on repeat calls within the same state.
+static void io_cache_track(IoCache *cache, const void *host_ptr) {
+  if (!cache || !host_ptr)
+    return;
+  if (cache->tracked_keys.insert(host_ptr).second) {
+    g_io_cache_refcount[host_ptr]++;
+  }
+}
+
+// Look up a host_ptr in the global cache. Returns the entry on HIT; on
+// size mismatch, evicts the stale entry (returning its GPU buffer to the
+// pool) and returns nullptr (caller will alloc + H2D).
+static const IoCacheEntry *io_cache_lookup(const void *host_ptr,
+                                           size_t size_bytes) {
+  if (!host_ptr)
+    return nullptr;
+  auto it = g_io_cache_persistent.find(host_ptr);
+  if (it == g_io_cache_persistent.end())
+    return nullptr;
+  if (it->second.size_bytes != size_bytes) {
+    RUNTIME_DEBUG_LOG(
+        "[Runtime DEBUG] io_cache EVICT (size change) host=%p gpu=%p "
+        "old_size=%zu new_size=%zu\n",
+        host_ptr, it->second.gpu_ptr, it->second.size_bytes, size_bytes);
+    pool_release(it->second.gpu_ptr, it->second.size_bytes);
+    g_io_cache_persistent.erase(it);
+    return nullptr;
+  }
+  return &it->second;
+}
+
+// Install/overwrite a global cache entry. The OLD gpu_ptr (if any) is NOT
+// pool_released here: it is still referenced by THIS call's input
+// TensorBuffer at install time, and free_input will release it (its
+// gpu_ptr no longer matches the cache).
+static void io_cache_install(const void *host_ptr, void *gpu_ptr,
+                             size_t size_bytes) {
+  g_io_cache_persistent[host_ptr] = IoCacheEntry{gpu_ptr, size_bytes};
+}
+
+// True iff the global cache currently holds gpu_ptr under host_ptr. Used
+// by free_input to decide whether the cache still owns the buffer.
+static bool io_cache_owns(const void *host_ptr, const void *gpu_ptr) {
+  if (!host_ptr || !gpu_ptr)
+    return false;
+  auto it = g_io_cache_persistent.find(host_ptr);
+  return it != g_io_cache_persistent.end() && it->second.gpu_ptr == gpu_ptr;
+}
+
+// Invoked from hipdnn_ep_state_cleanup via runtime_state_internal.h.
+// Decrements the global refcount for every host_ptr this state tracked.
+// When the last reference is dropped, the persistent GPU entry (if any)
+// is pool_released.
+//
+// Caller MUST have synchronized this state's stream first so no in-flight
+// kernel still references the buffers we are about to release. (See
+// hipdnn_ep_state_cleanup which calls hipStreamSynchronize before us.)
+void hipdnn_ep_io_cache_destroy(RuntimeState *state) {
+  if (!state || !state->io_cache)
+    return;
+  auto *cache = static_cast<IoCache *>(state->io_cache);
+  for (const void *host_ptr : cache->tracked_keys) {
+    auto rc_it = g_io_cache_refcount.find(host_ptr);
+    if (rc_it == g_io_cache_refcount.end())
+      continue;
+    if (--rc_it->second <= 0) {
+      auto p_it = g_io_cache_persistent.find(host_ptr);
+      if (p_it != g_io_cache_persistent.end()) {
+        RUNTIME_DEBUG_LOG(
+            "[Runtime DEBUG] io_cache GC host=%p gpu=%p size=%zu "
+            "(last referencing state destroyed)\n",
+            host_ptr, p_it->second.gpu_ptr, p_it->second.size_bytes);
+        pool_release(p_it->second.gpu_ptr, p_it->second.size_bytes);
+        g_io_cache_persistent.erase(p_it);
+      }
+      g_io_cache_refcount.erase(rc_it);
+    }
+  }
+  delete cache;
+  state->io_cache = nullptr;
 }
 
 // Element size is read from tensor_t.element_size (set by EP caller)
@@ -299,38 +862,113 @@ int hipdnn_ep_tensor_prepare_input(RuntimeState *state, span_t *inputs,
       "size_bytes=%zu\n",
       index, tensor->rank, element_size, size_bytes);
 
-  // Allocate GPU buffer (pool reuses across inferences)
-  void *gpu_ptr = pool_alloc(size_bytes);
-  if (!gpu_ptr) {
-    fprintf(stderr,
-            "hipdnn_ep_tensor_prepare_input: failed to allocate %zu bytes\n",
-            size_bytes);
-    return HIPDNN_EP_ERR_GPU_ALLOC_FAILED;
+  // PERF: close the previous inference (queues d2h_end on the stream) and
+  // open a new one. No synchronization here -- elapsed times are read in a
+  // single batch at end of run by perf_drain_and_aggregate(), so this hot
+  // path stays fully asynchronous and doesn't distort the Wall measurement.
+  if (index == 0)
+    perf_begin_inference(state->stream);
+
+  // OP_PROFILE: flush previous inference's per-operator events at the start
+  // of a new inference. Generated inference_compute() does not currently call
+  // hipdnn_ep_stream_sync(), so we drive the flush from the input-prep phase.
+  if (index == 0) {
+    hipdnn_ep::op_profile_flush_inference();
   }
 
-  // PERF: record H2D start on first input
-  if (hipdnn_ep_perf_enabled() && index == 0) {
-    perf_ensure_events();
-    g_perf.h2d_bytes = 0;
-    g_perf.h2d_count = 0;
-    g_perf.d2h_bytes = 0;
-    g_perf.d2h_count = 0;
-    (void)hipEventRecord(g_perf.h2d_start,
-                         static_cast<hipStream_t>(state->stream));
+  // I/O cache lookup (past_present_share_buffer fast-path). On the first
+  // input of a call, refresh the alive set of host pointers so
+  // finalize_output can detect input/output aliasing, and refcount-track
+  // each host_ptr in the global cache for GC on state cleanup.
+  IoCache *io_cache = io_cache_enabled() ? io_cache_get(state) : nullptr;
+  if (io_cache && index == 0) {
+    io_cache->current_inputs.clear();
+    io_cache->current_inputs.reserve(inputs->count);
+    for (size_t i = 0; i < inputs->count; ++i) {
+      if (inputs->data[i].data) {
+        io_cache->current_inputs.insert(inputs->data[i].data);
+        io_cache_track(io_cache, inputs->data[i].data);
+      }
+    }
+
+    // Generation-boundary GC: when OGA recreates a generator the KV host
+    // buffers from the previous generator are freed and a fresh set is
+    // passed in. The persistent cache still holds 64 entries keyed by the
+    // now-freed host pointers, each pinning a 32 MiB GPU buffer. Without
+    // this sweep those entries accumulate every iteration (2 GiB per DLL
+    // per iteration) and OOM by iter 1.
+    //
+    // Any persistent entry whose host_ptr is NOT in this call's alive set
+    // is stale: hipFree the GPU buffer (return it to the OS, not the pool
+    // -- the pool is per-size-class and would just hold the buffer
+    // indefinitely) and erase the bookkeeping. We must sync the stream
+    // first because the previous call's main_graph may still be writing
+    // to the cached output buffer (cache_claim path skips D2H, so there
+    // is no implicit sync from a finalize_output hipMemcpyAsync either).
+    std::vector<const void *> stale_keys;
+    for (const auto &kv : g_io_cache_persistent) {
+      if (io_cache->current_inputs.count(kv.first) == 0) {
+        stale_keys.push_back(kv.first);
+      }
+    }
+    if (!stale_keys.empty()) {
+      if (state->stream) {
+        hipStreamSynchronize(static_cast<hipStream_t>(state->stream));
+      }
+      for (const void *key : stale_keys) {
+        auto it = g_io_cache_persistent.find(key);
+        if (it != g_io_cache_persistent.end()) {
+          RUNTIME_DEBUG_LOG(
+              "[Runtime DEBUG] io_cache GC (gen boundary) host=%p gpu=%p "
+              "size=%zu\n",
+              key, it->second.gpu_ptr, it->second.size_bytes);
+          hipFree(it->second.gpu_ptr);
+          g_io_cache_persistent.erase(it);
+        }
+        g_io_cache_refcount.erase(key);
+        io_cache->tracked_keys.erase(key);
+      }
+    }
   }
 
-  // H2D transfer
-  if (hipMemcpyAsync(gpu_ptr, tensor->data, size_bytes, hipMemcpyHostToDevice,
-                     static_cast<hipStream_t>(state->stream)) != hipSuccess) {
-    fprintf(stderr, "hipdnn_ep_tensor_prepare_input: H2D transfer failed\n");
-    HIP_CLEANUP(hipFree(gpu_ptr));
-    return HIPDNN_EP_ERR_H2D_TRANSFER_FAILED;
+  void *gpu_ptr = nullptr;
+  bool cache_hit = false;
+  if (io_cache) {
+    if (const auto *entry = io_cache_lookup(tensor->data, size_bytes)) {
+      gpu_ptr = entry->gpu_ptr;
+      cache_hit = true;
+      RUNTIME_DEBUG_LOG(
+          "[Runtime DEBUG] prepare_input[%zu]: io_cache HIT host=%p gpu=%p "
+          "size=%zu (skipping H2D)\n",
+          index, tensor->data, gpu_ptr, size_bytes);
+    }
   }
 
-  // PERF: accumulate H2D bytes
-  if (hipdnn_ep_perf_enabled()) {
-    g_perf.h2d_bytes += size_bytes;
-    g_perf.h2d_count++;
+  if (!cache_hit) {
+    gpu_ptr = pool_alloc(size_bytes);
+    if (!gpu_ptr) {
+      fprintf(stderr,
+              "hipdnn_ep_tensor_prepare_input: failed to allocate %zu bytes\n",
+              size_bytes);
+      return HIPDNN_EP_ERR_GPU_ALLOC_FAILED;
+    }
+
+    // H2D transfer (instrumented; `io_h2d_input` shows up in the I/O table
+    // when HIPDNN_EP_OP_PROFILE=1 along with bytes moved and bandwidth).
+    {
+      HIPDNN_EP_IO_PROFILE_SCOPE(state, "io_h2d_input", size_bytes);
+      if (hipMemcpyAsync(gpu_ptr, tensor->data, size_bytes,
+                         hipMemcpyHostToDevice,
+                         static_cast<hipStream_t>(state->stream)) !=
+          hipSuccess) {
+        fprintf(stderr,
+                "hipdnn_ep_tensor_prepare_input: H2D transfer failed\n");
+        HIP_CLEANUP(hipFree(gpu_ptr));
+        return HIPDNN_EP_ERR_H2D_TRANSFER_FAILED;
+      }
+    }
+
+    perf_count_h2d(size_bytes);
   }
 
   // Populate output buffer
@@ -420,11 +1058,11 @@ int hipdnn_ep_tensor_prepare_output(RuntimeState *state, span_t *outputs,
       "size_bytes=%zu\n",
       index, tensor->rank, element_size, size_bytes);
 
-  // PERF: record H2D end on first output alloc (after all H2D copies queued)
-  if (hipdnn_ep_perf_enabled() && index == 0 && g_perf.initialized) {
-    (void)hipEventRecord(g_perf.h2d_end,
-                         static_cast<hipStream_t>(state->stream));
-  }
+  // PERF: H2D-end / Compute-start marker. The first prepare_output is
+  // called after all prepare_input H2D copies have been queued, so this is
+  // a clean phase boundary on the stream.
+  if (index == 0)
+    perf_record_h2d_end(state->stream);
 
   // Allocate GPU buffer (pool reuses across inferences)
   void *gpu_ptr = pool_alloc(size_bytes);
@@ -460,28 +1098,64 @@ int hipdnn_ep_tensor_finalize_output(RuntimeState *state,
 
   int result = HIPDNN_EP_SUCCESS;
 
-  // PERF: record D2H start on first output finalize (after all compute)
-  if (hipdnn_ep_perf_enabled() && g_perf.d2h_count == 0 && g_perf.initialized) {
-    (void)hipEventRecord(g_perf.d2h_start,
-                         static_cast<hipStream_t>(state->stream));
+  // I/O cache decision: if this output shares its host buffer with an
+  // input of the same call (past_present_share_buffer), PIN the GPU
+  // buffer in the global cache and SKIP D2H entirely. Wrong output for
+  // chunked pipelines (multi-DLL load splits the global) but fastest --
+  // intended for perf-bound verification only.
+  IoCache *io_cache = io_cache_enabled() ? io_cache_get(state) : nullptr;
+  bool cache_claim =
+      io_cache && io_cache->current_inputs.count(buffer->host_ptr) > 0;
+
+  if (cache_claim) {
+    // PERF: still close out the inference cleanly. There's no real D2H,
+    // so re-record d2h markers on this very call so post-finalize
+    // host_end / aggregate Wall stay coherent for sparse-call models
+    // (e.g. the prompt model). d2h_ms will aggregate ~0 for claimed
+    // buffers, which is the intended behavior.
+    perf_record_d2h_start(state->stream);
+    perf_record_d2h_end(state->stream);
+    perf_touch_host_end();
+
+    io_cache_install(buffer->host_ptr, buffer->gpu_ptr, buffer->size_bytes);
+    RUNTIME_DEBUG_LOG(
+        "[Runtime DEBUG] finalize_output: io_cache PIN host=%p gpu=%p "
+        "size=%zu (D2H SKIPPED, global cache owns it)\n",
+        buffer->host_ptr, buffer->gpu_ptr, buffer->size_bytes);
+    buffer->gpu_ptr = nullptr; // cache now owns this GPU buffer
+    return result;
   }
 
-  // D2H transfer (async -- sync happens once after all outputs)
-  if (hipMemcpyAsync(buffer->host_ptr, buffer->gpu_ptr, buffer->size_bytes,
-                     hipMemcpyDeviceToHost,
-                     static_cast<hipStream_t>(state->stream)) != hipSuccess) {
-    fprintf(stderr, "hipdnn_ep_tensor_finalize_output: D2H transfer failed\n");
-    result = HIPDNN_EP_ERR_D2H_TRANSFER_FAILED;
-    // Continue to cleanup even on error (best-effort)
+  // PERF: D2H-start / Compute-end marker. Idempotent -- only the first
+  // finalize of this inference actually queues the event.
+  perf_record_d2h_start(state->stream);
+
+  // D2H transfer (async -- sync happens once after all outputs).
+  // Instrumented: shows up as `io_d2h_output` in the profiler I/O table.
+  {
+    HIPDNN_EP_IO_PROFILE_SCOPE(state, "io_d2h_output", buffer->size_bytes);
+    if (hipMemcpyAsync(buffer->host_ptr, buffer->gpu_ptr, buffer->size_bytes,
+                       hipMemcpyDeviceToHost,
+                       static_cast<hipStream_t>(state->stream)) !=
+        hipSuccess) {
+      fprintf(stderr,
+              "hipdnn_ep_tensor_finalize_output: D2H transfer failed\n");
+      result = HIPDNN_EP_ERR_D2H_TRANSFER_FAILED;
+      // Continue to cleanup even on error (best-effort)
+    }
   }
 
-  // PERF: accumulate D2H bytes
-  if (hipdnn_ep_perf_enabled()) {
-    g_perf.d2h_bytes += buffer->size_bytes;
-    g_perf.d2h_count++;
-  }
+  perf_count_d2h(buffer->size_bytes);
+  // Re-record d2h_end on the stream right after queueing the real D2H, and
+  // sample host_end. Both are last-write-wins, so after the LAST finalize
+  // of this inference d2h_end fires immediately after the final D2H copy
+  // and host_end pins to "right after the EP's last bookkeeping return".
+  // This is what makes Wall and d2h_ms accurate for sparse-call models
+  // (e.g. the prompt model in OGA's chunked decoder pipeline).
+  perf_record_d2h_end(state->stream);
+  perf_touch_host_end();
 
-  // Return buffer to pool
+  // Return buffer to pool (non-claimed outputs).
   pool_release(buffer->gpu_ptr, buffer->size_bytes);
   buffer->gpu_ptr = nullptr;
 
@@ -489,48 +1163,22 @@ int hipdnn_ep_tensor_finalize_output(RuntimeState *state,
 }
 
 // Synchronize GPU stream once (called after all finalize_output calls).
+//
+// In the current generated inference_compute, this function is not driven
+// on the steady-state path -- the next inference's prepare_input(0)
+// implicitly orders work via the shared stream. PERF deliberately does NOT
+// roll up here, because per-inference rollup would require per-inference
+// hipEventSynchronize and that would force CPU/GPU serialization.
 int hipdnn_ep_stream_sync(RuntimeState *state) {
   if (!state) {
     fprintf(stderr, "hipdnn_ep_stream_sync: null state\n");
     return HIPDNN_EP_ERR_NULL_POINTER;
   }
-
-  // PERF: record D2H end event (after all D2H copies queued)
-  if (hipdnn_ep_perf_enabled() && g_perf.initialized) {
-    (void)hipEventRecord(g_perf.d2h_end,
-                         static_cast<hipStream_t>(state->stream));
-  }
-
   if (hipStreamSynchronize(static_cast<hipStream_t>(state->stream)) !=
       hipSuccess) {
     fprintf(stderr, "hipdnn_ep_stream_sync: stream sync failed\n");
     return HIPDNN_EP_ERR_STREAM_SYNC_FAILED;
   }
-
-  // PERF: compute and log timing breakdown
-  if (hipdnn_ep_perf_enabled() && g_perf.initialized) {
-    float h2d_ms = 0, compute_ms = 0, d2h_ms = 0;
-    (void)hipEventElapsedTime(&h2d_ms, g_perf.h2d_start, g_perf.h2d_end);
-    (void)hipEventElapsedTime(&compute_ms, g_perf.h2d_end, g_perf.d2h_start);
-    (void)hipEventElapsedTime(&d2h_ms, g_perf.d2h_start, g_perf.d2h_end);
-    float total_ms = h2d_ms + compute_ms + d2h_ms;
-
-    g_perf.inference_num++;
-    fprintf(stderr,
-            "[PERF] inference #%u:\n"
-            "  H2D:     %zu tensors, %zu bytes (%.1f MB), %.2f ms\n"
-            "  Compute: %.2f ms\n"
-            "  D2H:     %zu tensors, %zu bytes (%.1f MB), %.2f ms\n"
-            "  Total:   %.2f ms  (H2D %.1f%% | Compute %.1f%% | D2H %.1f%%)\n",
-            g_perf.inference_num, g_perf.h2d_count, g_perf.h2d_bytes,
-            (double)g_perf.h2d_bytes / (1024.0 * 1024.0), h2d_ms, compute_ms,
-            g_perf.d2h_count, g_perf.d2h_bytes,
-            (double)g_perf.d2h_bytes / (1024.0 * 1024.0), d2h_ms, total_ms,
-            total_ms > 0 ? (h2d_ms / total_ms * 100.0) : 0.0,
-            total_ms > 0 ? (compute_ms / total_ms * 100.0) : 0.0,
-            total_ms > 0 ? (d2h_ms / total_ms * 100.0) : 0.0);
-  }
-
   return HIPDNN_EP_SUCCESS;
 }
 
@@ -539,6 +1187,22 @@ void hipdnn_ep_tensor_free_input(RuntimeState *state, TensorBuffer *buffer) {
   if (!buffer) {
     fprintf(stderr, "hipdnn_ep_tensor_free_input: null buffer\n");
     return;
+  }
+
+  // If the global I/O cache currently owns this exact GPU buffer under
+  // this host pointer, leave it alone -- it will serve as a future
+  // prepare_input HIT (in this session, or any session that happens to
+  // share the same statics). The cache owns the buffer's lifetime; it is
+  // released either when a later finalize_output overwrites the entry
+  // (the displaced gpu_ptr is pool_released here on the *next*
+  // free_input, since by then it no longer matches the cache) or when
+  // the last referencing state is destroyed (handled in
+  // hipdnn_ep_io_cache_destroy via refcount).
+  if (state && io_cache_enabled() && buffer->host_ptr && buffer->gpu_ptr) {
+    if (io_cache_owns(buffer->host_ptr, buffer->gpu_ptr)) {
+      buffer->gpu_ptr = nullptr;
+      return;
+    }
   }
 
   // Return buffer to pool

--- a/lib/Runtime/hipdnn_ep_runtime_tensor.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_tensor.cpp
@@ -339,9 +339,8 @@ static void perf_aggregate_one(unsigned idx, const PerfPending &p,
     fprintf(stderr,
             "[PERF] inference #%u%s:  Wall %.3f ms  (GPU %.3f ms = "
             "H2D %.3f + Compute %.3f + D2H %.3f, %s %.3f)\n",
-            idx + 1,
-            idx < hipdnn_ep_perf_warmup_count() ? " [warmup]" : "", wall_ms,
-            gpu_ms, (double)h2d_ms, (double)compute_ms, (double)d2h_ms,
+            idx + 1, idx < hipdnn_ep_perf_warmup_count() ? " [warmup]" : "",
+            wall_ms, gpu_ms, (double)h2d_ms, (double)compute_ms, (double)d2h_ms,
             delta_ms >= 0.0 ? "Other" : "Overlap",
             delta_ms >= 0.0 ? delta_ms : -delta_ms);
   }
@@ -362,9 +361,9 @@ static void perf_drain_and_aggregate() {
 
   for (size_t i = 0; i < g_perf_queue.size(); ++i) {
     auto &p = g_perf_queue[i];
-    double wall_ms = std::chrono::duration<double, std::milli>(p.host_end -
-                                                                p.host_start)
-                          .count();
+    double wall_ms =
+        std::chrono::duration<double, std::milli>(p.host_end - p.host_start)
+            .count();
     if (wall_ms < 0.0)
       wall_ms = 0.0;
 
@@ -382,8 +381,8 @@ static void perf_drain_and_aggregate() {
     if (d2h_ms < 0.0f)
       d2h_ms = 0.0f;
 
-    perf_aggregate_one(static_cast<unsigned>(i), p, wall_ms, h2d_ms,
-                       compute_ms, d2h_ms);
+    perf_aggregate_one(static_cast<unsigned>(i), p, wall_ms, h2d_ms, compute_ms,
+                       d2h_ms);
 
     // Recycle events back to the pool for reuse.
     perf_release_event(p.h2d_start);
@@ -395,7 +394,8 @@ static void perf_drain_and_aggregate() {
 }
 
 // Print one aggregate block. Internal helper used by perf_print_aggregate().
-static void perf_print_one_aggregate(const char *label, const PerfAggregate &a) {
+static void perf_print_one_aggregate(const char *label,
+                                     const PerfAggregate &a) {
   if (a.count == 0)
     return;
   double n = static_cast<double>(a.count);
@@ -460,8 +460,7 @@ static void perf_print_aggregate() {
                 g_perf_session_index);
   perf_print_one_aggregate(header, g_perf_warmup_agg);
   std::snprintf(header, sizeof(header),
-                "session #%u STEADY-STATE (post-warmup)",
-                g_perf_session_index);
+                "session #%u STEADY-STATE (post-warmup)", g_perf_session_index);
   perf_print_one_aggregate(header, g_perf_steady_agg);
 
   g_perf_warmup_agg = PerfAggregate{};
@@ -520,54 +519,145 @@ static void pool_release(void *ptr, size_t size_bytes) {
 }
 
 //===----------------------------------------------------------------------===//
-// I/O Cache: skip H2D + D2H for `past_present_share_buffer` tensors (PERF)
+// I/O Cache: skip H2D + (steady-decode) D2H for rank-4 KV tensors
 //===----------------------------------------------------------------------===//
-// PERF-VERIFICATION MODE: skips both H2D and D2H on cache_claim. This is
-// faster than the correct PIN+D2H variant but produces incorrect outputs
-// in OGA's chunked decoder pipeline because each compiled MLIR DLL has
-// its own copy of the file-scope statics below -- prefill's installs are
-// invisible to decode and vice versa. Use only to put a number on the
-// upper bound of what an I/O cache could buy.
+// CORRECT VARIANT (PIN+selective-D2H, rank-4 only, per-state).
 //
-// Architecture: process-global cache (one shared map keyed by host_ptr),
-// with per-state refcount tracking so persistent buffers are reclaimed
-// when the last referencing state is destroyed.
+// OGA with past_present_share_buffer=true passes the same host OrtValue
+// as both the "past_key_N" input and the "present_key_N" output. Without
+// a cache the runtime copies that buffer H2D at every prepare_input step.
+// For Mistral-7B at ctx=16384 that is ~2 GiB of redundant PCIe traffic
+// per token.
 //
-// Gate: HIPDNN_EP_IO_CACHE (default=ON, set to "0" to disable).
+// Design constraints for this variant:
+//   1. Cache only rank-4 tensors. OGA's KV cache tensors are shaped
+//      [batch, num_kv_heads, seq_len, head_size] (rank 4); all other
+//      inputs (input_ids, attention_mask, position_ids) are rank <=2 and
+//      intentionally not cached -- they change every step and their host
+//      contents must be read every time.
+//   2. Per-state. Each RuntimeState owns its own map; prefill's cache
+//      and decode's cache do not share. In OGA's chunked decoder
+//      pipeline prefill and decode load distinct MLIR DLLs so the caches
+//      would already be separate via file-scope statics, but keeping the
+//      cache inside the state makes that intent explicit (and still
+//      works correctly if multiple states share a DLL).
+//   3. First use reads from host (CPU source of truth). The cache
+//      installs a GPU buffer only on cache_claim (input/output alias);
+//      a session that has not yet seen the host_ptr MISSes, pool_allocs,
+//      and H2Ds.
+//
+// Correctness invariant: D2H runs whenever the host buffer is the
+// downstream source of truth, and H2D runs whenever the host buffer may
+// have been mutated between calls. Concretely:
+//   * Prefill calls ALWAYS do both H2D and D2H on rank-4 cache_claim
+//     outputs (cache serves only as an allocation reuse mechanism --
+//     no bandwidth savings). Rationale: in chat mode the prompt is
+//     split into multiple prefill chunks that may span many turns, and
+//     OGA can freely mutate the KV host buffers between chunks (KV
+//     trimming, sliding-window rotation, new-turn prompt ingestion).
+//     Skipping either direction would desync host and GPU.
+//   * Decode calls skip H2D on rank-4 cache HITs (GPU is authoritative
+//     in steady state) and skip D2H when every rank-4 input was a HIT
+//     (the session hands KV off to itself via the cache, no external
+//     observer reads the host buffer). The first decode call of each
+//     generator is all-MISS (gen-boundary GC cleared the previous
+//     generator's entries), so H2D runs to pull prefill's output into
+//     the cache and D2H runs to preserve the invariant cheaply.
+//
+// The net effect: prefill -> decode handoff, chunked-prefill correctness,
+// and multi-turn chat all stay correct; logits are identical to the no-
+// cache path; steady-state decode still avoids ~2 GiB of H2D+D2H
+// traffic per token.
+//
+// Prefill vs decode detection: at prepare_input(idx==0) we pick the
+// smallest last-dim across rank>=2 non-KV inputs. Decode always has a
+// rank>=2 input with last_dim == 1 (input_ids / position_ids carry one
+// new token); prefill's corresponding inputs carry the chunk so their
+// last_dim is chunk_size > 1. This is model-agnostic for GenAI-style
+// decoder pipelines; ambiguous cases default to prefill (the safe
+// choice -- just turns off the skip, no correctness risk).
+//
+// Operations:
+//   - prepare_input(idx==0):
+//       * Build the alive set (current_inputs) from ALL of this call's
+//         rank-4 inputs. Non-rank-4 inputs are not tracked since they
+//         are never cached.
+//       * Generation-boundary GC: any cache entry whose host_ptr is NOT
+//         in current_inputs is stale (the previous OgaGenerator's KV
+//         buffers were freed). hipStreamSynchronize and hipFree them so
+//         VRAM actually returns to the OS before this call allocates.
+//       * Mode detection: is_prefill := min rank>=2 non-KV last_dim > 1.
+//       * Steady-decode detection: skip_rank4_d2h := !is_prefill AND
+//         every rank-4 input is already in the cache (all HITs).
+//         Consumed by finalize_output.
+//   - prepare_input (per-tensor):
+//       * If tensor->rank != 4: skip the cache, pool_alloc + H2D as
+//         before.
+//       * If tensor->rank == 4: look up host_ptr in this state's cache.
+//           HIT in decode : reuse gpu_ptr, skip H2D.
+//           HIT in prefill: reuse gpu_ptr, RUN H2D (host may have
+//                           changed between chunks / turns).
+//           MISS          : pool_alloc + H2D.
+//   - finalize_output:
+//       * cache_claim = (rank == 4) && (host_ptr in current_inputs).
+//       * Skip D2H when cache_claim && skip_rank4_d2h (decode steady
+//         state only); otherwise run it. Prefill forces D2H via
+//         skip_rank4_d2h=false.
+//       * On cache_claim install (host_ptr -> gpu_ptr) in this state's
+//         cache. Otherwise pool_release.
+//   - free_input:
+//       * If this state's cache now holds (host_ptr, gpu_ptr), leave it
+//         alone. Otherwise pool_release.
+//   - state_cleanup:
+//       * hipFree every entry's GPU buffer (stream was already synced by
+//         hipdnn_ep_state_cleanup).
+//
+// Gate: HIPDNN_EP_IO_CACHE (default=ON, set to "0" to disable for A/B
+// comparisons against the no-cache path).
 
 struct IoCacheEntry {
   void *gpu_ptr;
   size_t size_bytes;
 };
 
-// Process-global cache: keyed by host_ptr. Owns the pinned GPU buffers.
-// "Process-global" is aspirational -- because the runtime is statically
-// linked into each MLIR-compiled DLL, each DLL gets its own copy of these
-// statics. That's why this mode produces wrong output in chunked
-// pipelines; see header comment.
-static std::unordered_map<const void *, IoCacheEntry> g_io_cache_persistent;
-
-// Refcount keyed by host_ptr. One reference per RuntimeState that has
-// observed the host_ptr as an input. Decremented on state_cleanup; the
-// persistent entry is freed when count hits zero.
-static std::unordered_map<const void *, int> g_io_cache_refcount;
-
-// Per-state tracker: history of host_ptrs we've refcount-bumped (so we
-// can decrement on cleanup) and the alive set for the current call (so
-// finalize_output can detect input/output aliasing).
+// Per-state cache. Keyed by host_ptr; one map per RuntimeState.
 struct IoCache {
-  std::unordered_set<const void *> tracked_keys;
+  std::unordered_map<const void *, IoCacheEntry> entries;
+  // Alive set of rank-4 input host pointers for the in-flight call.
+  // Refreshed at prepare_input(idx==0) and consumed by finalize_output to
+  // detect input/output aliasing (cache_claim).
   std::unordered_set<const void *> current_inputs;
+  // True when this call looks like prefill (multi-token input chunk).
+  // Determined at prepare_input(idx==0) from input shapes: decode always
+  // has at least one rank>=2 non-KV input with last_dim == 1 (the single
+  // new token), while prefill carries the chunk so min last_dim > 1.
+  // Prefill forces both H2D (host may have been mutated since last
+  // call) and D2H (hand off correct KV to the next prefill chunk /
+  // decode / turn) on rank-4 cache_claim outputs. Default is prefill
+  // (safe: just turns off the skip, no correctness risk).
+  bool is_prefill = true;
+  // True when EVERY rank-4 input of this call was already in the cache
+  // (all HITs, post gen-boundary GC) AND this call is decode. That only
+  // happens once this state has been running its own decode loop --
+  // every prefill call, the first call of every new generator, and any
+  // call with a fresh rank-4 input leave this false. When true,
+  // finalize_output can skip D2H for rank-4 cache_claim outputs: the
+  // decode session hands off to itself via the cache, and no external
+  // observer reads the host KV buffer in that steady state, so keeping
+  // the host buffer in sync is pure bandwidth waste. Computed at
+  // prepare_input(idx==0).
+  bool skip_rank4_d2h = false;
 };
 
 static bool io_cache_enabled() {
-  // Read once at process startup, log the resolved state to stderr so it is
-  // visible in benchmark logs alongside other runtime toggles.
+  // Read once at process startup, log the resolved state to stderr so it
+  // is visible in benchmark logs alongside other runtime toggles.
   static const bool enabled = [] {
     const char *v = std::getenv("HIPDNN_EP_IO_CACHE");
     bool on = !v || v[0] != '0';
     fprintf(stderr,
-            "[Runtime] HIPDNN_EP_IO_CACHE=%s (I/O cache %s, mode=global)\n",
+            "[Runtime] HIPDNN_EP_IO_CACHE=%s (I/O cache %s, "
+            "mode=pin+d2h, rank-4 only, per-state)\n",
             v ? v : "<unset>", on ? "ENABLED" : "DISABLED");
     return on;
   }();
@@ -582,84 +672,67 @@ static IoCache *io_cache_get(RuntimeState *state) {
   return static_cast<IoCache *>(state->io_cache);
 }
 
-// Bump the global refcount for host_ptr the first time this state sees it.
-// Idempotent on repeat calls within the same state.
-static void io_cache_track(IoCache *cache, const void *host_ptr) {
-  if (!cache || !host_ptr)
-    return;
-  if (cache->tracked_keys.insert(host_ptr).second) {
-    g_io_cache_refcount[host_ptr]++;
-  }
-}
-
-// Look up a host_ptr in the global cache. Returns the entry on HIT; on
-// size mismatch, evicts the stale entry (returning its GPU buffer to the
-// pool) and returns nullptr (caller will alloc + H2D).
-static const IoCacheEntry *io_cache_lookup(const void *host_ptr,
+// Look up a host_ptr in this state's cache. Returns the entry on HIT; on
+// size mismatch, evicts the stale entry (hipFree) and returns nullptr
+// (the caller will pool_alloc + H2D).
+static const IoCacheEntry *io_cache_lookup(IoCache *cache, const void *host_ptr,
                                            size_t size_bytes) {
-  if (!host_ptr)
+  if (!cache || !host_ptr)
     return nullptr;
-  auto it = g_io_cache_persistent.find(host_ptr);
-  if (it == g_io_cache_persistent.end())
+  auto it = cache->entries.find(host_ptr);
+  if (it == cache->entries.end())
     return nullptr;
   if (it->second.size_bytes != size_bytes) {
     RUNTIME_DEBUG_LOG(
         "[Runtime DEBUG] io_cache EVICT (size change) host=%p gpu=%p "
         "old_size=%zu new_size=%zu\n",
         host_ptr, it->second.gpu_ptr, it->second.size_bytes, size_bytes);
-    pool_release(it->second.gpu_ptr, it->second.size_bytes);
-    g_io_cache_persistent.erase(it);
+    hipFree(it->second.gpu_ptr);
+    cache->entries.erase(it);
     return nullptr;
   }
   return &it->second;
 }
 
-// Install/overwrite a global cache entry. The OLD gpu_ptr (if any) is NOT
-// pool_released here: it is still referenced by THIS call's input
-// TensorBuffer at install time, and free_input will release it (its
-// gpu_ptr no longer matches the cache).
-static void io_cache_install(const void *host_ptr, void *gpu_ptr,
-                             size_t size_bytes) {
-  g_io_cache_persistent[host_ptr] = IoCacheEntry{gpu_ptr, size_bytes};
+// Install/overwrite a cache entry in this state's cache. The OLD gpu_ptr
+// (if any) is NOT released here: it is still referenced by THIS call's
+// input TensorBuffer at install time, and free_input releases it (its
+// gpu_ptr no longer matches the cache's new entry).
+static void io_cache_install(IoCache *cache, const void *host_ptr,
+                             void *gpu_ptr, size_t size_bytes) {
+  if (!cache)
+    return;
+  cache->entries[host_ptr] = IoCacheEntry{gpu_ptr, size_bytes};
 }
 
-// True iff the global cache currently holds gpu_ptr under host_ptr. Used
-// by free_input to decide whether the cache still owns the buffer.
-static bool io_cache_owns(const void *host_ptr, const void *gpu_ptr) {
-  if (!host_ptr || !gpu_ptr)
+// True iff this state's cache currently holds gpu_ptr under host_ptr.
+// Used by free_input to decide whether the cache still owns the buffer
+// (skip release) or has moved on (pool_release).
+static bool io_cache_owns(IoCache *cache, const void *host_ptr,
+                          const void *gpu_ptr) {
+  if (!cache || !host_ptr || !gpu_ptr)
     return false;
-  auto it = g_io_cache_persistent.find(host_ptr);
-  return it != g_io_cache_persistent.end() && it->second.gpu_ptr == gpu_ptr;
+  auto it = cache->entries.find(host_ptr);
+  return it != cache->entries.end() && it->second.gpu_ptr == gpu_ptr;
 }
 
 // Invoked from hipdnn_ep_state_cleanup via runtime_state_internal.h.
-// Decrements the global refcount for every host_ptr this state tracked.
-// When the last reference is dropped, the persistent GPU entry (if any)
-// is pool_released.
+// Releases every cached GPU buffer. hipFree (not pool_release) because
+// at state teardown there is no later consumer within this DLL; we want
+// VRAM to return to the OS, not sit in an orphaned pool.
 //
-// Caller MUST have synchronized this state's stream first so no in-flight
-// kernel still references the buffers we are about to release. (See
+// Caller MUST have synchronized this state's stream first so no
+// in-flight kernel still references the buffers. (See
 // hipdnn_ep_state_cleanup which calls hipStreamSynchronize before us.)
 void hipdnn_ep_io_cache_destroy(RuntimeState *state) {
   if (!state || !state->io_cache)
     return;
   auto *cache = static_cast<IoCache *>(state->io_cache);
-  for (const void *host_ptr : cache->tracked_keys) {
-    auto rc_it = g_io_cache_refcount.find(host_ptr);
-    if (rc_it == g_io_cache_refcount.end())
-      continue;
-    if (--rc_it->second <= 0) {
-      auto p_it = g_io_cache_persistent.find(host_ptr);
-      if (p_it != g_io_cache_persistent.end()) {
-        RUNTIME_DEBUG_LOG(
-            "[Runtime DEBUG] io_cache GC host=%p gpu=%p size=%zu "
-            "(last referencing state destroyed)\n",
-            host_ptr, p_it->second.gpu_ptr, p_it->second.size_bytes);
-        pool_release(p_it->second.gpu_ptr, p_it->second.size_bytes);
-        g_io_cache_persistent.erase(p_it);
-      }
-      g_io_cache_refcount.erase(rc_it);
-    }
+  for (const auto &kv : cache->entries) {
+    RUNTIME_DEBUG_LOG("[Runtime DEBUG] io_cache GC host=%p gpu=%p size=%zu "
+                      "(state destroyed)\n",
+                      kv.first, kv.second.gpu_ptr, kv.second.size_bytes);
+    hipFree(kv.second.gpu_ptr);
   }
   delete cache;
   state->io_cache = nullptr;
@@ -876,37 +949,38 @@ int hipdnn_ep_tensor_prepare_input(RuntimeState *state, span_t *inputs,
     hipdnn_ep::op_profile_flush_inference();
   }
 
-  // I/O cache lookup (past_present_share_buffer fast-path). On the first
-  // input of a call, refresh the alive set of host pointers so
-  // finalize_output can detect input/output aliasing, and refcount-track
-  // each host_ptr in the global cache for GC on state cleanup.
+  // I/O cache plumbing (past_present_share_buffer fast-path, rank-4 only).
+  // On the first input of a call, refresh the alive set from THIS call's
+  // rank-4 inputs so finalize_output can detect cache_claim (input/output
+  // aliasing) and so the generation-boundary sweep below knows which
+  // host_ptrs are still live.
   IoCache *io_cache = io_cache_enabled() ? io_cache_get(state) : nullptr;
   if (io_cache && index == 0) {
     io_cache->current_inputs.clear();
     io_cache->current_inputs.reserve(inputs->count);
     for (size_t i = 0; i < inputs->count; ++i) {
-      if (inputs->data[i].data) {
-        io_cache->current_inputs.insert(inputs->data[i].data);
-        io_cache_track(io_cache, inputs->data[i].data);
+      const tensor_t &t = inputs->data[i];
+      if (t.data && t.rank == 4) {
+        io_cache->current_inputs.insert(t.data);
       }
     }
 
     // Generation-boundary GC: when OGA recreates a generator the KV host
     // buffers from the previous generator are freed and a fresh set is
-    // passed in. The persistent cache still holds 64 entries keyed by the
-    // now-freed host pointers, each pinning a 32 MiB GPU buffer. Without
-    // this sweep those entries accumulate every iteration (2 GiB per DLL
-    // per iteration) and OOM by iter 1.
+    // passed in. The cache still holds 32 entries (per rank-4 input)
+    // keyed by the now-freed host pointers, each pinning a 32 MiB GPU
+    // buffer. Without this sweep those entries accumulate every
+    // iteration (~1 GiB per session per iteration) and OOM a few iters
+    // in.
     //
-    // Any persistent entry whose host_ptr is NOT in this call's alive set
-    // is stale: hipFree the GPU buffer (return it to the OS, not the pool
-    // -- the pool is per-size-class and would just hold the buffer
-    // indefinitely) and erase the bookkeeping. We must sync the stream
-    // first because the previous call's main_graph may still be writing
-    // to the cached output buffer (cache_claim path skips D2H, so there
-    // is no implicit sync from a finalize_output hipMemcpyAsync either).
+    // Any cache entry whose host_ptr is NOT in this call's rank-4 alive
+    // set is stale: hipFree the GPU buffer (return VRAM to the OS; the
+    // per-size-class pool would just hold it indefinitely) and erase
+    // the bookkeeping. We must hipStreamSynchronize first because the
+    // previous call's main_graph may still be writing to the cached
+    // output buffer when we enter this new call.
     std::vector<const void *> stale_keys;
-    for (const auto &kv : g_io_cache_persistent) {
+    for (const auto &kv : io_cache->entries) {
       if (io_cache->current_inputs.count(kv.first) == 0) {
         stale_keys.push_back(kv.first);
       }
@@ -916,35 +990,86 @@ int hipdnn_ep_tensor_prepare_input(RuntimeState *state, span_t *inputs,
         hipStreamSynchronize(static_cast<hipStream_t>(state->stream));
       }
       for (const void *key : stale_keys) {
-        auto it = g_io_cache_persistent.find(key);
-        if (it != g_io_cache_persistent.end()) {
+        auto it = io_cache->entries.find(key);
+        if (it != io_cache->entries.end()) {
           RUNTIME_DEBUG_LOG(
               "[Runtime DEBUG] io_cache GC (gen boundary) host=%p gpu=%p "
               "size=%zu\n",
               key, it->second.gpu_ptr, it->second.size_bytes);
           hipFree(it->second.gpu_ptr);
-          g_io_cache_persistent.erase(it);
+          io_cache->entries.erase(it);
         }
-        g_io_cache_refcount.erase(key);
-        io_cache->tracked_keys.erase(key);
       }
     }
+
+    // Prefill vs decode detection: decode always has at least one
+    // rank>=2 non-KV input with last_dim == 1 (input_ids / position_ids
+    // carry a single new token), while prefill's corresponding inputs
+    // carry a chunk so min last_dim > 1. Skip rank-0 / rank-1 inputs
+    // (scalars / step-length) since they do not distinguish, and skip
+    // rank-4 inputs (KV slabs are shaped to max_seq in both modes).
+    // Default to prefill on ambiguity -- prefill semantics are strictly
+    // safer (no skip), just slower.
+    int64_t min_last_dim = -1;
+    for (size_t i = 0; i < inputs->count; ++i) {
+      const tensor_t &t = inputs->data[i];
+      if (!t.data || !t.shape || t.rank < 2 || t.rank == 4)
+        continue;
+      int64_t last = t.shape[t.rank - 1];
+      if (min_last_dim < 0 || last < min_last_dim)
+        min_last_dim = last;
+    }
+    io_cache->is_prefill = (min_last_dim != 1);
+
+    // Steady-decode detection: true iff this call is decode AND every
+    // rank-4 input of this call is already in the cache (post-GC). In
+    // that state the session is running its own decode loop and
+    // finalize_output may skip D2H for rank-4 cache_claim outputs.
+    // False on any MISS, on prefill (every call, across all turns and
+    // chunks), and on the first decode call of each new generator.
+    bool all_hit = !io_cache->current_inputs.empty();
+    for (const void *host_ptr : io_cache->current_inputs) {
+      if (io_cache->entries.find(host_ptr) == io_cache->entries.end()) {
+        all_hit = false;
+        break;
+      }
+    }
+    io_cache->skip_rank4_d2h = all_hit && !io_cache->is_prefill;
   }
 
+  // Only rank-4 tensors (KV slabs) are cached. Everything else takes the
+  // MISS path below unconditionally: input_ids / attention_mask /
+  // position_ids change every step, and a stale cache HIT would break
+  // correctness.
+  //
+  // Two independent decisions on a rank-4 HIT:
+  //   gpu_from_cache: reuse the cached GPU buffer instead of pool_alloc
+  //                   (always true on HIT -- saves ~32 MiB / slab on
+  //                   every call and avoids alloc churn).
+  //   skip_h2d      : skip the host->device copy (only safe when this
+  //                   state owns the GPU data authoritatively, i.e.
+  //                   decode steady state). Prefill always re-copies
+  //                   because the host buffer may have been mutated
+  //                   since the last call (chat-turn rotation, chunk
+  //                   handoff, OGA-side KV trimming).
   void *gpu_ptr = nullptr;
-  bool cache_hit = false;
-  if (io_cache) {
-    if (const auto *entry = io_cache_lookup(tensor->data, size_bytes)) {
+  bool gpu_from_cache = false;
+  bool skip_h2d = false;
+  if (io_cache && tensor->rank == 4) {
+    if (const auto *entry =
+            io_cache_lookup(io_cache, tensor->data, size_bytes)) {
       gpu_ptr = entry->gpu_ptr;
-      cache_hit = true;
+      gpu_from_cache = true;
+      skip_h2d = !io_cache->is_prefill;
       RUNTIME_DEBUG_LOG(
           "[Runtime DEBUG] prepare_input[%zu]: io_cache HIT host=%p gpu=%p "
-          "size=%zu (skipping H2D)\n",
-          index, tensor->data, gpu_ptr, size_bytes);
+          "size=%zu (rank=4, H2D %s)\n",
+          index, tensor->data, gpu_ptr, size_bytes,
+          skip_h2d ? "skipped (decode)" : "forced (prefill)");
     }
   }
 
-  if (!cache_hit) {
+  if (!gpu_from_cache) {
     gpu_ptr = pool_alloc(size_bytes);
     if (!gpu_ptr) {
       fprintf(stderr,
@@ -952,22 +1077,22 @@ int hipdnn_ep_tensor_prepare_input(RuntimeState *state, span_t *inputs,
               size_bytes);
       return HIPDNN_EP_ERR_GPU_ALLOC_FAILED;
     }
+  }
 
+  if (!skip_h2d) {
     // H2D transfer (instrumented; `io_h2d_input` shows up in the I/O table
     // when HIPDNN_EP_OP_PROFILE=1 along with bytes moved and bandwidth).
-    {
-      HIPDNN_EP_IO_PROFILE_SCOPE(state, "io_h2d_input", size_bytes);
-      if (hipMemcpyAsync(gpu_ptr, tensor->data, size_bytes,
-                         hipMemcpyHostToDevice,
-                         static_cast<hipStream_t>(state->stream)) !=
-          hipSuccess) {
-        fprintf(stderr,
-                "hipdnn_ep_tensor_prepare_input: H2D transfer failed\n");
+    HIPDNN_EP_IO_PROFILE_SCOPE(state, "io_h2d_input", size_bytes);
+    if (hipMemcpyAsync(gpu_ptr, tensor->data, size_bytes, hipMemcpyHostToDevice,
+                       static_cast<hipStream_t>(state->stream)) != hipSuccess) {
+      fprintf(stderr, "hipdnn_ep_tensor_prepare_input: H2D transfer failed\n");
+      if (!gpu_from_cache) {
+        // Only free pool-allocated buffers on error; the cache still
+        // owns cached GPU buffers regardless of the H2D outcome.
         HIP_CLEANUP(hipFree(gpu_ptr));
-        return HIPDNN_EP_ERR_H2D_TRANSFER_FAILED;
       }
+      return HIPDNN_EP_ERR_H2D_TRANSFER_FAILED;
     }
-
     perf_count_h2d(size_bytes);
   }
 
@@ -1098,64 +1223,79 @@ int hipdnn_ep_tensor_finalize_output(RuntimeState *state,
 
   int result = HIPDNN_EP_SUCCESS;
 
-  // I/O cache decision: if this output shares its host buffer with an
-  // input of the same call (past_present_share_buffer), PIN the GPU
-  // buffer in the global cache and SKIP D2H entirely. Wrong output for
-  // chunked pipelines (multi-DLL load splits the global) but fastest --
-  // intended for perf-bound verification only.
+  // I/O cache decision:
+  //   cache_claim: install in the state's cache iff caching is enabled,
+  //                this output is rank 4 (KV slab), AND its host_ptr
+  //                aliases an input of the same call
+  //                (past_present_share_buffer).
+  //   D2H skip  : additionally skip D2H iff cache_claim AND the state
+  //                is in steady-decode mode (decode call AND every
+  //                rank-4 input of this call was a cache HIT post
+  //                gen-boundary GC, see skip_rank4_d2h).
+  //                Rationale: in steady-decode, the session hands KV
+  //                off to itself on the next call via the cache, and
+  //                no other session reads the host buffer -- so D2H is
+  //                pure waste. Prefill ALWAYS runs D2H (is_prefill
+  //                forces skip_rank4_d2h=false) because the next prefill
+  //                chunk, the next chat turn, or the decode handoff all
+  //                read KV from the host buffer. The first decode call
+  //                of each new generator is all-MISS too, which forces
+  //                D2H there and keeps the invariant cheaply.
   IoCache *io_cache = io_cache_enabled() ? io_cache_get(state) : nullptr;
-  bool cache_claim =
-      io_cache && io_cache->current_inputs.count(buffer->host_ptr) > 0;
-
-  if (cache_claim) {
-    // PERF: still close out the inference cleanly. There's no real D2H,
-    // so re-record d2h markers on this very call so post-finalize
-    // host_end / aggregate Wall stay coherent for sparse-call models
-    // (e.g. the prompt model). d2h_ms will aggregate ~0 for claimed
-    // buffers, which is the intended behavior.
-    perf_record_d2h_start(state->stream);
-    perf_record_d2h_end(state->stream);
-    perf_touch_host_end();
-
-    io_cache_install(buffer->host_ptr, buffer->gpu_ptr, buffer->size_bytes);
-    RUNTIME_DEBUG_LOG(
-        "[Runtime DEBUG] finalize_output: io_cache PIN host=%p gpu=%p "
-        "size=%zu (D2H SKIPPED, global cache owns it)\n",
-        buffer->host_ptr, buffer->gpu_ptr, buffer->size_bytes);
-    buffer->gpu_ptr = nullptr; // cache now owns this GPU buffer
-    return result;
-  }
+  bool cache_claim = io_cache && buffer->rank == 4 &&
+                     io_cache->current_inputs.count(buffer->host_ptr) > 0;
+  bool skip_d2h = cache_claim && io_cache->skip_rank4_d2h;
 
   // PERF: D2H-start / Compute-end marker. Idempotent -- only the first
   // finalize of this inference actually queues the event.
   perf_record_d2h_start(state->stream);
 
-  // D2H transfer (async -- sync happens once after all outputs).
-  // Instrumented: shows up as `io_d2h_output` in the profiler I/O table.
-  {
+  if (!skip_d2h) {
+    // D2H transfer (async -- sync happens once after all outputs).
+    // Instrumented: shows up as `io_d2h_output` in the profiler I/O
+    // table.
     HIPDNN_EP_IO_PROFILE_SCOPE(state, "io_d2h_output", buffer->size_bytes);
     if (hipMemcpyAsync(buffer->host_ptr, buffer->gpu_ptr, buffer->size_bytes,
                        hipMemcpyDeviceToHost,
-                       static_cast<hipStream_t>(state->stream)) !=
-        hipSuccess) {
+                       static_cast<hipStream_t>(state->stream)) != hipSuccess) {
       fprintf(stderr,
               "hipdnn_ep_tensor_finalize_output: D2H transfer failed\n");
       result = HIPDNN_EP_ERR_D2H_TRANSFER_FAILED;
       // Continue to cleanup even on error (best-effort)
     }
+    perf_count_d2h(buffer->size_bytes);
   }
 
-  perf_count_d2h(buffer->size_bytes);
-  // Re-record d2h_end on the stream right after queueing the real D2H, and
-  // sample host_end. Both are last-write-wins, so after the LAST finalize
-  // of this inference d2h_end fires immediately after the final D2H copy
+  // Re-record d2h_end on the stream right after queueing the real D2H
+  // (or right here on the skip path), and sample host_end. Both are
+  // last-write-wins, so after the LAST finalize of this inference
+  // d2h_end fires immediately after the final D2H copy (or skip-marker)
   // and host_end pins to "right after the EP's last bookkeeping return".
   // This is what makes Wall and d2h_ms accurate for sparse-call models
   // (e.g. the prompt model in OGA's chunked decoder pipeline).
   perf_record_d2h_end(state->stream);
   perf_touch_host_end();
 
-  // Return buffer to pool (non-claimed outputs).
+  if (cache_claim) {
+    // Hand ownership of the GPU buffer to the cache. The PREVIOUS entry
+    // under this host_ptr (if any) was consumed as an input earlier in
+    // this call; free_input will pool_release it because its gpu_ptr
+    // no longer matches the cache's new entry.
+    io_cache_install(io_cache, buffer->host_ptr, buffer->gpu_ptr,
+                     buffer->size_bytes);
+    RUNTIME_DEBUG_LOG(
+        "[Runtime DEBUG] finalize_output: io_cache PIN host=%p gpu=%p "
+        "size=%zu (rank=4, D2H %s, cache owns it)\n",
+        buffer->host_ptr, buffer->gpu_ptr, buffer->size_bytes,
+        skip_d2h ? "SKIPPED (steady decode)"
+                 : (io_cache->is_prefill ? "ran (prefill)"
+                                         : "ran (decode first call)"));
+    buffer->gpu_ptr = nullptr; // cache now owns this GPU buffer
+    return result;
+  }
+
+  // Non-cached output (rank != 4 or host_ptr not in alive set): return
+  // the buffer to the pool.
   pool_release(buffer->gpu_ptr, buffer->size_bytes);
   buffer->gpu_ptr = nullptr;
 
@@ -1189,17 +1329,21 @@ void hipdnn_ep_tensor_free_input(RuntimeState *state, TensorBuffer *buffer) {
     return;
   }
 
-  // If the global I/O cache currently owns this exact GPU buffer under
-  // this host pointer, leave it alone -- it will serve as a future
-  // prepare_input HIT (in this session, or any session that happens to
-  // share the same statics). The cache owns the buffer's lifetime; it is
-  // released either when a later finalize_output overwrites the entry
-  // (the displaced gpu_ptr is pool_released here on the *next*
-  // free_input, since by then it no longer matches the cache) or when
-  // the last referencing state is destroyed (handled in
-  // hipdnn_ep_io_cache_destroy via refcount).
-  if (state && io_cache_enabled() && buffer->host_ptr && buffer->gpu_ptr) {
-    if (io_cache_owns(buffer->host_ptr, buffer->gpu_ptr)) {
+  // If THIS state's I/O cache currently owns this (host_ptr, gpu_ptr)
+  // pair, leave it alone -- it will serve as a future prepare_input HIT
+  // within this same state. The cache, not the per-call TensorBuffer,
+  // owns the buffer's lifetime; it is released either when a later
+  // finalize_output overwrites the entry (the displaced gpu_ptr is
+  // pool_released here on the *next* free_input, since by then it no
+  // longer matches the cache) or when the state is destroyed (handled
+  // in hipdnn_ep_io_cache_destroy).
+  //
+  // Only rank-4 buffers can be cached, so this check is skipped for
+  // scalar/rank-2/rank-3 inputs to avoid a pointless hashmap lookup.
+  if (state && state->io_cache && io_cache_enabled() && buffer->rank == 4 &&
+      buffer->host_ptr && buffer->gpu_ptr) {
+    auto *io_cache = static_cast<IoCache *>(state->io_cache);
+    if (io_cache_owns(io_cache, buffer->host_ptr, buffer->gpu_ptr)) {
       buffer->gpu_ptr = nullptr;
       return;
     }

--- a/lib/Runtime/operator_profile.cpp
+++ b/lib/Runtime/operator_profile.cpp
@@ -150,104 +150,97 @@ void format_bytes(char *out, size_t out_size, size_t bytes) {
     std::snprintf(out, out_size, "%.2f %s", v, units[u]);
 }
 
-// Print one bucket's compute + I/O tables. Used by print_summary() to emit
-// the warmup section and the steady-state section back-to-back.
+// Print one bucket as a single unified table mixing compute operators and
+// I/O (memcpy) entries. Sorted by total_ms descending regardless of kind,
+// so the hot rows float to the top regardless of whether they're kernels
+// or transfers. Compute rows leave the I/O-specific columns blank; I/O
+// rows populate all columns.
+//
+// %total is computed over the combined (compute + I/O) grand total so
+// percentages sum to 100 across the whole table and directly indicate
+// where the inference is spending its time. The TOTAL footer also
+// reports an aggregate I/O-bandwidth column computed from the I/O subset
+// only (bandwidth averaged across compute+I/O time would be meaningless).
 void print_one_bucket(FILE *out,
                       const std::unordered_map<std::string, OpStats> &m) {
   if (m.empty())
     return;
 
-  // Partition into compute operators and I/O entries so each can be reported
-  // with the columns most useful to it (I/O gets a bandwidth column).
-  std::vector<std::pair<std::string, OpStats>> ops, ios;
-  ops.reserve(m.size());
-  ios.reserve(m.size());
-  for (const auto &kv : m) {
-    if (kv.second.is_io)
-      ios.push_back(kv);
-    else
-      ops.push_back(kv);
-  }
+  std::vector<std::pair<std::string, OpStats>> rows;
+  rows.reserve(m.size());
+  for (const auto &kv : m)
+    rows.push_back(kv);
+  std::sort(rows.begin(), rows.end(),
+            [](const std::pair<std::string, OpStats> &a,
+               const std::pair<std::string, OpStats> &b) {
+              return a.second.total_ms > b.second.total_ms;
+            });
 
-  auto sort_by_total = [](std::vector<std::pair<std::string, OpStats>> &v) {
-    std::sort(v.begin(), v.end(),
-              [](const std::pair<std::string, OpStats> &a,
-                 const std::pair<std::string, OpStats> &b) {
-                return a.second.total_ms > b.second.total_ms;
-              });
-  };
-  sort_by_total(ops);
-  sort_by_total(ios);
-
-  // ---- Operator (compute) table ----
-  if (!ops.empty()) {
-    double grand_total_ms = 0.0;
-    size_t grand_count = 0;
-    for (const auto &kv : ops) {
-      grand_total_ms += kv.second.total_ms;
-      grand_count += kv.second.count;
-    }
-    fprintf(out, "  %-32s %8s %10s %10s %10s %10s %7s\n", "operator", "count",
-            "total_ms", "avg_ms", "min_ms", "max_ms", "%total");
-    for (const auto &kv : ops) {
-      const auto &s = kv.second;
-      double avg_ms =
-          s.count ? (s.total_ms / static_cast<double>(s.count)) : 0.0;
-      double pct = grand_total_ms > 0.0
-                       ? (s.total_ms / grand_total_ms * 100.0)
-                       : 0.0;
-      fprintf(out, "  %-32s %8zu %10.3f %10.3f %10.3f %10.3f %6.1f%%\n",
-              kv.first.c_str(), s.count, s.total_ms, avg_ms, s.min_ms, s.max_ms,
-              pct);
-    }
-    fprintf(out, "  %-32s %8zu %10.3f\n", "TOTAL", grand_count, grand_total_ms);
-  }
-
-  // ---- I/O (memcpy) table ----
-  if (!ios.empty()) {
-    double io_total_ms = 0.0;
-    size_t io_total_count = 0;
-    size_t io_total_bytes = 0;
-    for (const auto &kv : ios) {
+  double grand_total_ms = 0.0;
+  size_t grand_count = 0;
+  double io_total_ms = 0.0;
+  size_t io_total_bytes = 0;
+  for (const auto &kv : rows) {
+    grand_total_ms += kv.second.total_ms;
+    grand_count += kv.second.count;
+    if (kv.second.is_io) {
       io_total_ms += kv.second.total_ms;
-      io_total_count += kv.second.count;
       io_total_bytes += kv.second.total_bytes;
     }
-    fprintf(out, "  --- I/O (memcpy) ---\n");
-    fprintf(out, "  %-32s %8s %10s %10s %14s %10s %7s\n", "io_path", "count",
-            "total_ms", "avg_ms", "total_bytes", "GB/s", "%total");
-    for (const auto &kv : ios) {
-      const auto &s = kv.second;
-      double avg_ms =
-          s.count ? (s.total_ms / static_cast<double>(s.count)) : 0.0;
-      // Bandwidth: total_bytes / total_seconds, expressed in GB/s (1e9).
+  }
+
+  fprintf(out,
+          "  %-32s %8s %10s %10s %10s %10s %14s %10s %7s\n", "name", "count",
+          "total_ms", "avg_ms", "min_ms", "max_ms", "bytes", "GB/s",
+          "%total");
+  for (const auto &kv : rows) {
+    const auto &s = kv.second;
+    double avg_ms = s.count ? (s.total_ms / static_cast<double>(s.count)) : 0.0;
+    double pct =
+        grand_total_ms > 0.0 ? (s.total_ms / grand_total_ms * 100.0) : 0.0;
+    if (s.is_io) {
+      char bytes_str[24];
+      format_bytes(bytes_str, sizeof(bytes_str), s.total_bytes);
+      // Per-row bandwidth: total_bytes / total_seconds, in GB/s (1e9).
       double gbs = (s.total_ms > 0.0)
                        ? (static_cast<double>(s.total_bytes) /
                           (s.total_ms * 1.0e6))
                        : 0.0;
-      double pct =
-          io_total_ms > 0.0 ? (s.total_ms / io_total_ms * 100.0) : 0.0;
-      char bytes_str[24];
-      format_bytes(bytes_str, sizeof(bytes_str), s.total_bytes);
-      fprintf(out, "  %-32s %8zu %10.3f %10.3f %14s %10.2f %6.1f%%\n",
-              kv.first.c_str(), s.count, s.total_ms, avg_ms, bytes_str, gbs,
-              pct);
+      fprintf(out,
+              "  %-32s %8zu %10.3f %10.3f %10.3f %10.3f %14s %10.2f "
+              "%6.1f%%\n",
+              kv.first.c_str(), s.count, s.total_ms, avg_ms, s.min_ms, s.max_ms,
+              bytes_str, gbs, pct);
+    } else {
+      fprintf(out,
+              "  %-32s %8zu %10.3f %10.3f %10.3f %10.3f %14s %10s %6.1f%%\n",
+              kv.first.c_str(), s.count, s.total_ms, avg_ms, s.min_ms, s.max_ms,
+              "-", "-", pct);
     }
+  }
+
+  // Footer: combined TOTAL across compute + I/O. The GB/s column is
+  // computed only over I/O rows -- averaging bandwidth across kernel time
+  // would be meaningless -- and left blank when no I/O was recorded.
+  if (io_total_bytes > 0) {
     char bytes_str[24];
     format_bytes(bytes_str, sizeof(bytes_str), io_total_bytes);
-    double total_gbs =
+    double io_gbs =
         io_total_ms > 0.0
             ? (static_cast<double>(io_total_bytes) / (io_total_ms * 1.0e6))
             : 0.0;
-    fprintf(out, "  %-32s %8zu %10.3f %10s %14s %10.2f\n", "TOTAL",
-            io_total_count, io_total_ms, "", bytes_str, total_gbs);
+    fprintf(out, "  %-32s %8zu %10.3f %10s %10s %10s %14s %10.2f\n", "TOTAL",
+            grand_count, grand_total_ms, "", "", "", bytes_str, io_gbs);
+  } else {
+    fprintf(out, "  %-32s %8zu %10.3f\n", "TOTAL", grand_count, grand_total_ms);
   }
 }
 
 // Print the full session aggregate -- a warmup block followed by a steady-
-// state block, each with its own compute + I/O tables. The session label
-// ("session #N") matches the [PERF] session label so warmup / steady
-// counts line up across the two reports for the same model.
+// state block, each a single unified table mixing compute and I/O rows.
+// The session label ("session #N") matches the [PERF] session label so
+// warmup / steady counts line up across the two reports for the same
+// model.
 void print_summary(FILE *out, unsigned session_index,
                    const OpAggregate &agg) {
   if (agg.empty())

--- a/lib/Runtime/operator_profile.cpp
+++ b/lib/Runtime/operator_profile.cpp
@@ -1,0 +1,480 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "operator_profile.h"
+#include "debug_log.h"
+#include "hipdnn_ep_runtime.h"
+#include "runtime_types.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace hipdnn_ep {
+namespace {
+
+// Per-operator running statistics. Used for both compute and I/O entries.
+// `total_bytes`/`is_io` are zero/false for compute ops and populated for I/O.
+struct OpStats {
+  size_t count = 0;
+  double total_ms = 0.0;
+  double min_ms = 0.0; // initialized lazily on first sample
+  double max_ms = 0.0;
+  size_t total_bytes = 0;
+  bool is_io = false;
+};
+
+// Wrap a {warmup, steady, count} triple so the rest of the file can keep
+// passing one logical "aggregate" around.
+struct OpAggregate {
+  std::unordered_map<std::string, OpStats> warmup;
+  std::unordered_map<std::string, OpStats> steady;
+  // Inferences that contributed to each bucket. Used for the report header
+  // ("over N warmup + M steady inference(s)").
+  unsigned warmup_count = 0;
+  unsigned steady_count = 0;
+
+  bool empty() const { return warmup.empty() && steady.empty(); }
+  void clear() {
+    warmup.clear();
+    steady.clear();
+    warmup_count = 0;
+    steady_count = 0;
+  }
+};
+
+// One pending start/end event pair recorded by op_profile_scope_*.
+struct PendingEvent {
+  const char *name; // points to static storage (typically __func__)
+  hipEvent_t start;
+  hipEvent_t end;
+  size_t bytes; // 0 for compute ops, transfer size for I/O ops
+  bool is_io;
+};
+
+// HIP event recycling pool. hipEventCreate is not free, so we keep a list of
+// reusable events and only allocate when the pool is empty.
+struct EventPool {
+  std::vector<hipEvent_t> free_list;
+
+  hipEvent_t acquire() {
+    if (!free_list.empty()) {
+      hipEvent_t e = free_list.back();
+      free_list.pop_back();
+      return e;
+    }
+    hipEvent_t e = nullptr;
+    if (hipEventCreate(&e) != hipSuccess)
+      return nullptr;
+    return e;
+  }
+
+  void release(hipEvent_t e) {
+    if (e)
+      free_list.push_back(e);
+  }
+
+  void destroy_all() {
+    for (auto e : free_list) {
+      if (e)
+        (void)hipEventDestroy(e);
+    }
+    free_list.clear();
+  }
+};
+
+// All globals are accessed from a single host thread (the runtime is not
+// thread-safe per RuntimeState), so no locking is required.
+static std::vector<PendingEvent> g_pending;
+// Per-session aggregate (reset on each op_profile_print_summary_and_reset).
+// In OGA's chunked decoder pipeline this corresponds to the prompt model and
+// the decoder model getting their own [OP_PROFILE] block, mirroring [PERF].
+static OpAggregate g_aggregate;
+static EventPool g_event_pool;
+// Index of the inference whose events are currently in g_pending. Used to
+// route those events to the warmup or steady bucket when they're flushed.
+// Resets to 0 when a session aggregate is printed so the next session's
+// warmup_count first inferences land in its warmup bucket.
+static unsigned g_inference_idx = 0;
+// Counter for the [OP_PROFILE] block heading. Mirrors g_perf_session_index
+// in hipdnn_ep_runtime_tensor.cpp so the user can pair op-profile and perf
+// blocks one-to-one.
+static unsigned g_session_index = 0;
+
+// Stash the most recently recorded "end" event so flush_inference can
+// hipEventSynchronize on a single event to ensure ALL prior events on the
+// stream have completed (events on the same stream complete in record order).
+static hipEvent_t g_last_end_event = nullptr;
+
+void update_stats(OpStats &s, double ms, size_t bytes, bool is_io) {
+  // hipEventElapsedTime can return small negative values (~few us) when the
+  // start/end events resolve at the same GPU clock tick. Clamp to 0 so the
+  // running min/total cannot drift below zero.
+  if (ms < 0.0)
+    ms = 0.0;
+  if (s.count == 0) {
+    s.min_ms = ms;
+    s.max_ms = ms;
+  } else {
+    if (ms < s.min_ms)
+      s.min_ms = ms;
+    if (ms > s.max_ms)
+      s.max_ms = ms;
+  }
+  s.count++;
+  s.total_ms += ms;
+  s.total_bytes += bytes;
+  if (is_io)
+    s.is_io = true;
+}
+
+// Format a byte count as a short human-readable string (e.g. "1.45 GiB").
+// Uses a fixed-size buffer so callers can embed it in fprintf without heap.
+void format_bytes(char *out, size_t out_size, size_t bytes) {
+  const char *units[] = {"B", "KiB", "MiB", "GiB", "TiB"};
+  double v = static_cast<double>(bytes);
+  unsigned u = 0;
+  while (v >= 1024.0 && u + 1 < sizeof(units) / sizeof(units[0])) {
+    v /= 1024.0;
+    ++u;
+  }
+  if (u == 0)
+    std::snprintf(out, out_size, "%zu %s", bytes, units[u]);
+  else
+    std::snprintf(out, out_size, "%.2f %s", v, units[u]);
+}
+
+// Print one bucket's compute + I/O tables. Used by print_summary() to emit
+// the warmup section and the steady-state section back-to-back.
+void print_one_bucket(FILE *out,
+                      const std::unordered_map<std::string, OpStats> &m) {
+  if (m.empty())
+    return;
+
+  // Partition into compute operators and I/O entries so each can be reported
+  // with the columns most useful to it (I/O gets a bandwidth column).
+  std::vector<std::pair<std::string, OpStats>> ops, ios;
+  ops.reserve(m.size());
+  ios.reserve(m.size());
+  for (const auto &kv : m) {
+    if (kv.second.is_io)
+      ios.push_back(kv);
+    else
+      ops.push_back(kv);
+  }
+
+  auto sort_by_total = [](std::vector<std::pair<std::string, OpStats>> &v) {
+    std::sort(v.begin(), v.end(),
+              [](const std::pair<std::string, OpStats> &a,
+                 const std::pair<std::string, OpStats> &b) {
+                return a.second.total_ms > b.second.total_ms;
+              });
+  };
+  sort_by_total(ops);
+  sort_by_total(ios);
+
+  // ---- Operator (compute) table ----
+  if (!ops.empty()) {
+    double grand_total_ms = 0.0;
+    size_t grand_count = 0;
+    for (const auto &kv : ops) {
+      grand_total_ms += kv.second.total_ms;
+      grand_count += kv.second.count;
+    }
+    fprintf(out, "  %-32s %8s %10s %10s %10s %10s %7s\n", "operator", "count",
+            "total_ms", "avg_ms", "min_ms", "max_ms", "%total");
+    for (const auto &kv : ops) {
+      const auto &s = kv.second;
+      double avg_ms =
+          s.count ? (s.total_ms / static_cast<double>(s.count)) : 0.0;
+      double pct = grand_total_ms > 0.0
+                       ? (s.total_ms / grand_total_ms * 100.0)
+                       : 0.0;
+      fprintf(out, "  %-32s %8zu %10.3f %10.3f %10.3f %10.3f %6.1f%%\n",
+              kv.first.c_str(), s.count, s.total_ms, avg_ms, s.min_ms, s.max_ms,
+              pct);
+    }
+    fprintf(out, "  %-32s %8zu %10.3f\n", "TOTAL", grand_count, grand_total_ms);
+  }
+
+  // ---- I/O (memcpy) table ----
+  if (!ios.empty()) {
+    double io_total_ms = 0.0;
+    size_t io_total_count = 0;
+    size_t io_total_bytes = 0;
+    for (const auto &kv : ios) {
+      io_total_ms += kv.second.total_ms;
+      io_total_count += kv.second.count;
+      io_total_bytes += kv.second.total_bytes;
+    }
+    fprintf(out, "  --- I/O (memcpy) ---\n");
+    fprintf(out, "  %-32s %8s %10s %10s %14s %10s %7s\n", "io_path", "count",
+            "total_ms", "avg_ms", "total_bytes", "GB/s", "%total");
+    for (const auto &kv : ios) {
+      const auto &s = kv.second;
+      double avg_ms =
+          s.count ? (s.total_ms / static_cast<double>(s.count)) : 0.0;
+      // Bandwidth: total_bytes / total_seconds, expressed in GB/s (1e9).
+      double gbs = (s.total_ms > 0.0)
+                       ? (static_cast<double>(s.total_bytes) /
+                          (s.total_ms * 1.0e6))
+                       : 0.0;
+      double pct =
+          io_total_ms > 0.0 ? (s.total_ms / io_total_ms * 100.0) : 0.0;
+      char bytes_str[24];
+      format_bytes(bytes_str, sizeof(bytes_str), s.total_bytes);
+      fprintf(out, "  %-32s %8zu %10.3f %10.3f %14s %10.2f %6.1f%%\n",
+              kv.first.c_str(), s.count, s.total_ms, avg_ms, bytes_str, gbs,
+              pct);
+    }
+    char bytes_str[24];
+    format_bytes(bytes_str, sizeof(bytes_str), io_total_bytes);
+    double total_gbs =
+        io_total_ms > 0.0
+            ? (static_cast<double>(io_total_bytes) / (io_total_ms * 1.0e6))
+            : 0.0;
+    fprintf(out, "  %-32s %8zu %10.3f %10s %14s %10.2f\n", "TOTAL",
+            io_total_count, io_total_ms, "", bytes_str, total_gbs);
+  }
+}
+
+// Print the full session aggregate -- a warmup block followed by a steady-
+// state block, each with its own compute + I/O tables. The session label
+// ("session #N") matches the [PERF] session label so warmup / steady
+// counts line up across the two reports for the same model.
+void print_summary(FILE *out, unsigned session_index,
+                   const OpAggregate &agg) {
+  if (agg.empty())
+    return;
+  if (agg.warmup_count > 0 && !agg.warmup.empty()) {
+    fprintf(out,
+            "[OP_PROFILE] session #%u WARMUP (first %u inference(s), "
+            "kernel selection / JIT / autotune):\n",
+            session_index, agg.warmup_count);
+    print_one_bucket(out, agg.warmup);
+  }
+  if (agg.steady_count > 0 && !agg.steady.empty()) {
+    fprintf(out,
+            "[OP_PROFILE] session #%u STEADY-STATE over %u inference(s):\n",
+            session_index, agg.steady_count);
+    print_one_bucket(out, agg.steady);
+  }
+}
+
+} // namespace
+
+// Pick the correct bucket (warmup or steady) for the inference currently
+// being flushed. The split point matches PERF's: the first
+// hipdnn_ep_perf_warmup_count() inferences in this session go to warmup.
+static std::unordered_map<std::string, OpStats> &
+bucket_for_current_inference() {
+  return (g_inference_idx < hipdnn_ep_perf_warmup_count()) ? g_aggregate.warmup
+                                                            : g_aggregate.steady;
+}
+
+// Process-exit handler: dump whatever aggregate has accumulated since the last
+// state_cleanup. Without this, work performed during the benchmark warmup +
+// timed iterations never reaches stderr because the OGA model_benchmark holds
+// the EP sessions alive until process exit, and DLL unload is not guaranteed
+// to drive state_cleanup.
+static void op_profile_atexit_dump() {
+  if (g_pending.empty() && g_aggregate.empty())
+    return;
+
+  // Best-effort flush of leftover events. We deliberately don't call
+  // hipEventSynchronize here -- the runtime stream may already be invalid at
+  // process exit. Just consume what we have.
+  if (!g_pending.empty()) {
+    auto &bucket = bucket_for_current_inference();
+    for (auto &e : g_pending) {
+      float ms = 0.0f;
+      if (hipEventElapsedTime(&ms, e.start, e.end) == hipSuccess)
+        update_stats(bucket[std::string(e.name)], static_cast<double>(ms),
+                     e.bytes, e.is_io);
+    }
+    // Count this incomplete tail as one extra inference on the right side.
+    if (g_inference_idx < hipdnn_ep_perf_warmup_count())
+      g_aggregate.warmup_count++;
+    else
+      g_aggregate.steady_count++;
+    g_pending.clear();
+    g_last_end_event = nullptr;
+  }
+
+  if (!g_aggregate.empty()) {
+    ++g_session_index;
+    print_summary(stderr, g_session_index, g_aggregate);
+  }
+  g_aggregate.clear();
+}
+
+bool op_profile_enabled() {
+  static const bool enabled = [] {
+    const char *v = std::getenv("HIPDNN_EP_OP_PROFILE");
+    bool on = v && v[0] >= '1';
+    if (on)
+      std::atexit(op_profile_atexit_dump);
+    return on;
+  }();
+  return enabled;
+}
+
+// When HIPDNN_EP_OP_PROFILE_EACH=1 is set, print a summary table after every
+// inference. Off by default because LLM decode produces hundreds of inferences
+// per benchmark run and the per-inference output would drown out other logs;
+// the lifetime aggregate dumped at state_cleanup is usually enough.
+static bool op_profile_each_enabled() {
+  static const bool enabled = [] {
+    const char *v = std::getenv("HIPDNN_EP_OP_PROFILE_EACH");
+    return v && v[0] >= '1';
+  }();
+  return enabled;
+}
+
+void *op_profile_scope_begin(RuntimeState *state, const char * /*name*/) {
+  if (!op_profile_enabled() || !state)
+    return nullptr;
+  void *raw_stream = hipdnn_ep_state_get_stream(state);
+  if (!raw_stream)
+    return nullptr;
+  hipEvent_t start = g_event_pool.acquire();
+  if (!start)
+    return nullptr;
+  if (hipEventRecord(start, static_cast<hipStream_t>(raw_stream)) !=
+      hipSuccess) {
+    g_event_pool.release(start);
+    return nullptr;
+  }
+  return start;
+}
+
+// Internal helper shared by op and io scope_end to avoid duplicating the
+// event-recording boilerplate. `bytes`/`is_io` are stamped onto the
+// PendingEvent so the flush stage can route compute and I/O entries to the
+// correct table.
+static void scope_end_impl(RuntimeState *state, const char *name, void *token,
+                           size_t bytes, bool is_io) {
+  if (!token)
+    return;
+  hipEvent_t start = static_cast<hipEvent_t>(token);
+  if (!state) {
+    g_event_pool.release(start);
+    return;
+  }
+  void *raw_stream = hipdnn_ep_state_get_stream(state);
+  if (!raw_stream) {
+    g_event_pool.release(start);
+    return;
+  }
+  hipEvent_t end = g_event_pool.acquire();
+  if (!end) {
+    g_event_pool.release(start);
+    return;
+  }
+  if (hipEventRecord(end, static_cast<hipStream_t>(raw_stream)) !=
+      hipSuccess) {
+    g_event_pool.release(start);
+    g_event_pool.release(end);
+    return;
+  }
+
+  PendingEvent ev;
+  ev.name = name ? name : "<unknown>";
+  ev.start = start;
+  ev.end = end;
+  ev.bytes = bytes;
+  ev.is_io = is_io;
+  g_pending.push_back(ev);
+  g_last_end_event = end;
+}
+
+void op_profile_scope_end(RuntimeState *state, const char *name, void *token) {
+  scope_end_impl(state, name, token, /*bytes=*/0, /*is_io=*/false);
+}
+
+void *op_profile_io_scope_begin(RuntimeState *state, const char *name,
+                                size_t /*bytes*/) {
+  // Begin-side is identical to the compute scope -- we just record a HIP
+  // event. The byte count is stamped at end-time on the PendingEvent so
+  // the flush stage can route it to the I/O table.
+  return op_profile_scope_begin(state, name);
+}
+
+void op_profile_io_scope_end(RuntimeState *state, const char *name, void *token,
+                             size_t bytes) {
+  scope_end_impl(state, name, token, bytes, /*is_io=*/true);
+}
+
+void op_profile_flush_inference() {
+  if (!op_profile_enabled())
+    return;
+  if (g_pending.empty())
+    return;
+
+  // Wait until the last event has completed -- this implies all previous
+  // events on the same stream have also completed, so all hipEventElapsedTime
+  // queries below will return a valid result.
+  if (g_last_end_event)
+    (void)hipEventSynchronize(g_last_end_event);
+
+  const bool emit_each = op_profile_each_enabled();
+  const bool is_warmup = g_inference_idx < hipdnn_ep_perf_warmup_count();
+  auto &bucket = is_warmup ? g_aggregate.warmup : g_aggregate.steady;
+
+  std::unordered_map<std::string, OpStats> per_inference;
+  for (auto &e : g_pending) {
+    float ms = 0.0f;
+    if (hipEventElapsedTime(&ms, e.start, e.end) == hipSuccess) {
+      const std::string key(e.name);
+      if (emit_each)
+        update_stats(per_inference[key], static_cast<double>(ms), e.bytes,
+                     e.is_io);
+      update_stats(bucket[key], static_cast<double>(ms), e.bytes, e.is_io);
+    }
+    g_event_pool.release(e.start);
+    g_event_pool.release(e.end);
+  }
+  g_pending.clear();
+  g_last_end_event = nullptr;
+
+  if (is_warmup)
+    g_aggregate.warmup_count++;
+  else
+    g_aggregate.steady_count++;
+  g_inference_idx++;
+
+  if (emit_each) {
+    char header[64];
+    std::snprintf(header, sizeof(header), "[OP_PROFILE] inference #%u%s:",
+                  g_inference_idx, is_warmup ? " [warmup]" : "");
+    fprintf(stderr, "%s\n", header);
+    print_one_bucket(stderr, per_inference);
+  }
+}
+
+// Drain leftovers, print the per-session aggregate (warmup + steady), and
+// reset the session-local counters so the NEXT session's first inferences
+// land in its own warmup bucket. Mirrors PERF's per-session behavior.
+void op_profile_print_summary_and_reset() {
+  // Drain any leftover events so their resources are released even when
+  // profiling is being turned off mid-flight.
+  if (!g_pending.empty())
+    op_profile_flush_inference();
+
+  if (op_profile_enabled() && !g_aggregate.empty()) {
+    ++g_session_index;
+    print_summary(stderr, g_session_index, g_aggregate);
+  }
+
+  g_aggregate.clear();
+  g_inference_idx = 0;
+  g_event_pool.destroy_all();
+}
+
+} // namespace hipdnn_ep

--- a/lib/Runtime/operator_profile.h
+++ b/lib/Runtime/operator_profile.h
@@ -24,10 +24,13 @@
 //
 // At session_cleanup the WARMUP and STEADY-STATE buckets are emitted as
 // separate "[OP_PROFILE] session #N WARMUP" / "STEADY-STATE" tables. Each
-// bucket additionally splits compute operators from I/O (memcpy) entries so
-// I/O can be reported with a bandwidth column. Splitting warmup off keeps
-// hipBLASLt heuristic search, MIOpen kernel-finder cache fills, hipRTC JIT
-// and the first hipMalloc growth from inflating the steady-state averages.
+// table mixes compute operators and I/O (memcpy) entries sorted together
+// by total_ms descending, with I/O-specific columns (bytes, GB/s) blank
+// for compute rows. This lets the user spot hot rows regardless of kind
+// and see what fraction of inference time is I/O vs compute at a glance.
+// Splitting warmup off keeps hipBLASLt heuristic search, MIOpen
+// kernel-finder cache fills, hipRTC JIT, and the first hipMalloc growth
+// from inflating the steady-state averages.
 //
 //===----------------------------------------------------------------------===//
 
@@ -55,9 +58,11 @@ void *op_profile_scope_begin(RuntimeState *state, const char *name);
 void op_profile_scope_end(RuntimeState *state, const char *name, void *token);
 
 // I/O variant: like op_profile_scope_begin/end, but also records the byte
-// count moved by the operation. The reporter prints a separate "I/O" table
-// with bandwidth (GB/s = total_bytes / total_ms / 1e6) so memcpy-style ops
-// get their own throughput column instead of polluting the operator table.
+// count moved by the operation. In the unified report these entries
+// share the same table as compute operators, with extra bytes and GB/s
+// columns populated (GB/s = total_bytes / total_ms / 1e6). Sorting is by
+// total_ms so memcpy hotspots float to the top right alongside kernel
+// hotspots.
 //
 // Use for wrap_<op>() functions whose primary work is a memory transfer
 // (H2D/D2H/D2D), and for the framework's per-input/per-output transfers.

--- a/lib/Runtime/operator_profile.h
+++ b/lib/Runtime/operator_profile.h
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+//===- operator_profile.h - Per-operator GPU timing instrumentation ------===//
+//
+// Lightweight HIP-event based profiler that reports per-operator wall-clock
+// time on the runtime stream.
+//
+// Enable by setting environment variable HIPDNN_EP_OP_PROFILE=1 before
+// loading the EP. When disabled, the OpScope constructor/destructor are
+// effectively no-ops (a single cached-bool branch in the dynamic library).
+//
+// Per inference, the profiler records a (start, end) hipEvent pair around
+// each wrap_<op>(...) call, accumulates them in a pending list, and on the
+// next inference boundary (or session cleanup):
+//   1. Synchronizes on the last recorded event so all prior events are valid
+//   2. Reads elapsed times via hipEventElapsedTime
+//   3. Routes the sample into the per-session WARMUP or STEADY-STATE bucket
+//      based on inference index (controlled by HIPDNN_EP_PERF_WARMUP, the
+//      same env var used by [PERF] -- the two reports partition identically)
+//   4. Returns the events to a recyclable pool
+//
+// At session_cleanup the WARMUP and STEADY-STATE buckets are emitted as
+// separate "[OP_PROFILE] session #N WARMUP" / "STEADY-STATE" tables. Each
+// bucket additionally splits compute operators from I/O (memcpy) entries so
+// I/O can be reported with a bandwidth column. Splitting warmup off keeps
+// hipBLASLt heuristic search, MIOpen kernel-finder cache fills, hipRTC JIT
+// and the first hipMalloc growth from inflating the steady-state averages.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HIPDNN_EP_OPERATOR_PROFILE_H
+#define HIPDNN_EP_OPERATOR_PROFILE_H
+
+#include <cstddef>
+
+struct RuntimeState;
+
+namespace hipdnn_ep {
+
+// True when HIPDNN_EP_OP_PROFILE env var is set to a non-zero value at
+// process startup. Cached on first call.
+bool op_profile_enabled();
+
+// Begin a timed scope on the runtime's GPU stream. Records a hipEvent.
+// `name` must point to a C string with static storage duration (typically
+// __func__). Returns an opaque token to pair with op_profile_scope_end.
+// Returns nullptr when profiling is disabled or the event could not be
+// recorded -- callers must always pair with op_profile_scope_end regardless.
+void *op_profile_scope_begin(RuntimeState *state, const char *name);
+
+// End the timed scope opened by op_profile_scope_begin.
+void op_profile_scope_end(RuntimeState *state, const char *name, void *token);
+
+// I/O variant: like op_profile_scope_begin/end, but also records the byte
+// count moved by the operation. The reporter prints a separate "I/O" table
+// with bandwidth (GB/s = total_bytes / total_ms / 1e6) so memcpy-style ops
+// get their own throughput column instead of polluting the operator table.
+//
+// Use for wrap_<op>() functions whose primary work is a memory transfer
+// (H2D/D2H/D2D), and for the framework's per-input/per-output transfers.
+void *op_profile_io_scope_begin(RuntimeState *state, const char *name,
+                                size_t bytes);
+void op_profile_io_scope_end(RuntimeState *state, const char *name, void *token,
+                             size_t bytes);
+
+// Sync pending events, aggregate them into per-operator stats for the
+// current inference, print a summary, and recycle the events. Safe to call
+// when nothing is pending.
+//
+// The runtime invokes this at the start of each new inference (so the
+// previous inference's events have completed when their elapsed time is
+// queried) and again from state_cleanup.
+void op_profile_flush_inference();
+
+// Print the lifetime summary across all inferences and reset the
+// accumulator. Frees pooled hipEvents. Called from state_cleanup.
+void op_profile_print_summary_and_reset();
+
+// RAII guard inserted at the top of each wrap_<op>() function.
+class OpScope {
+public:
+  OpScope(RuntimeState *state, const char *name)
+      : state_(state), name_(name),
+        token_(op_profile_scope_begin(state, name)) {}
+  ~OpScope() { op_profile_scope_end(state_, name_, token_); }
+  OpScope(const OpScope &) = delete;
+  OpScope &operator=(const OpScope &) = delete;
+
+private:
+  RuntimeState *state_;
+  const char *name_;
+  void *token_;
+};
+
+// RAII guard for memory-copy operations. Records bytes alongside time so
+// the reporter can compute bandwidth.
+class IoScope {
+public:
+  IoScope(RuntimeState *state, const char *name, size_t bytes)
+      : state_(state), name_(name), bytes_(bytes),
+        token_(op_profile_io_scope_begin(state, name, bytes)) {}
+  ~IoScope() { op_profile_io_scope_end(state_, name_, token_, bytes_); }
+  IoScope(const IoScope &) = delete;
+  IoScope &operator=(const IoScope &) = delete;
+
+private:
+  RuntimeState *state_;
+  const char *name_;
+  size_t bytes_;
+  void *token_;
+};
+
+} // namespace hipdnn_ep
+
+// Convenience macro: declares an OpScope using __func__ as the operator name.
+// Use at the top of every wrap_<op>(RuntimeState *state, ...) function body.
+#define HIPDNN_EP_OP_PROFILE_SCOPE(state)                                      \
+  hipdnn_ep::OpScope _hipdnn_ep_op_scope((state), __func__)
+
+// Convenience macro for memory-copy sites. `name` must be a static C string
+// (e.g. a string literal) and `bytes` is the size of the transfer in bytes.
+// Records both elapsed time and bytes moved for bandwidth reporting.
+#define HIPDNN_EP_IO_PROFILE_SCOPE(state, name, bytes)                         \
+  hipdnn_ep::IoScope _hipdnn_ep_io_scope((state), (name), (bytes))
+
+#endif // HIPDNN_EP_OPERATOR_PROFILE_H

--- a/lib/Runtime/real/activation.cpp
+++ b/lib/Runtime/real/activation.cpp
@@ -4,6 +4,7 @@
  */
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../operator_profile.h"
 #include "cache_utils.h"
 #include "error_check_macros.h"
 #include "runtime_types.h"
@@ -154,6 +155,7 @@ int wrap_miopenActivationForward(RuntimeState *state, void *input, void *output,
     fprintf(stderr, "wrap_miopenActivationForward: null argument\n");
     return -1;
   }
+  HIPDNN_EP_OP_PROFILE_SCOPE(state);
 
   const char *act_name = hipdnn_ep_activation_name(activation_mode);
   const char *type_name = hipdnn_ep_datatype_name(data_type);

--- a/lib/Runtime/real/cast.cpp
+++ b/lib/Runtime/real/cast.cpp
@@ -4,6 +4,7 @@
  */
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../operator_profile.h"
 #include "hip_custom_kernels.h"
 
 #include <cstdio>
@@ -34,6 +35,7 @@ int wrap_cast(RuntimeState *state, void *input, void *output,
     RUNTIME_DEBUG_LOG("[REAL] wrap_cast: null argument\n");
     return -1;
   }
+  HIPDNN_EP_OP_PROFILE_SCOPE(state);
 
   void *stream = hipdnn_ep_state_get_stream(state);
 

--- a/lib/Runtime/real/causal_conv_with_state.cpp
+++ b/lib/Runtime/real/causal_conv_with_state.cpp
@@ -4,6 +4,7 @@
  */
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../operator_profile.h"
 #include "runtime_types.h"
 
 #include <cassert>
@@ -45,6 +46,7 @@ int wrap_causal_conv_with_state(
     fprintf(stderr, "wrap_causal_conv_with_state: null required argument\n");
     return -1;
   }
+  HIPDNN_EP_OP_PROFILE_SCOPE(state);
 
   RUNTIME_DEBUG_LOG("[REAL] wrap_causal_conv_with_state: batch=%lld, "
                     "channels=%lld, seq_len=%lld, kernel=%lld, ndim=%lld, "

--- a/lib/Runtime/real/elementwise.cpp
+++ b/lib/Runtime/real/elementwise.cpp
@@ -4,6 +4,7 @@
  */
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../operator_profile.h"
 #include "cache_utils.h"
 #include "error_check_macros.h"
 #include "hip_custom_kernels.h"
@@ -185,6 +186,7 @@ int wrap_miopenOpTensor(RuntimeState *state, void *lhs, void *rhs, void *output,
     fprintf(stderr, "wrap_miopenOpTensor: null argument\n");
     return -1;
   }
+  HIPDNN_EP_OP_PROFILE_SCOPE(state);
 
   const char *type_name = hipdnn_ep_datatype_name(data_type);
   const char *op_name = hipdnn_ep_tensor_op_name(tensor_op);
@@ -256,6 +258,7 @@ int wrap_elementwise_sub(RuntimeState *state, void *lhs, void *rhs,
     fprintf(stderr, "wrap_elementwise_sub: null argument\n");
     return -1;
   }
+  HIPDNN_EP_OP_PROFILE_SCOPE(state);
 
   void *stream = hipdnn_ep_state_get_stream(state);
 

--- a/lib/Runtime/real/gather.cpp
+++ b/lib/Runtime/real/gather.cpp
@@ -4,6 +4,7 @@
  */
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../operator_profile.h"
 #include "hip_custom_kernels.h"
 #include "runtime_types.h"
 
@@ -17,6 +18,7 @@ int wrap_gather(RuntimeState *state, void *data, void *indices, void *output,
     RUNTIME_DEBUG_LOG("[REAL] wrap_gather: null argument\n");
     return -1;
   }
+  HIPDNN_EP_OP_PROFILE_SCOPE(state);
 
   void *stream = hipdnn_ep_state_get_stream(state);
 

--- a/lib/Runtime/real/gemm.cpp
+++ b/lib/Runtime/real/gemm.cpp
@@ -4,6 +4,7 @@
  */
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../operator_profile.h"
 #include "error_check_macros.h"
 #include "runtime_types.h"
 
@@ -207,6 +208,7 @@ int wrap_gemm(RuntimeState *state, const void *A, const void *B, const void *C,
     fprintf(stderr, "wrap_gemm: invalid arguments\n");
     return -1;
   }
+  HIPDNN_EP_OP_PROFILE_SCOPE(state);
 
   hipblasLtHandle_t handle =
       static_cast<hipblasLtHandle_t>(hipdnn_ep_state_get_hipblas_handle(state));

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -15,7 +15,6 @@
 #include <cassert>
 #include <cmath>
 #include <cstdio>
-#include <cstdlib>
 #include <cstring>
 #include <functional>
 #include <unordered_map>
@@ -23,33 +22,6 @@
 
 #define HIP_CHECK(cmd) HIP_CHECK_GOTO(cmd, cleanup)
 #define HIPBLAS_CHECK(cmd) HIPBLAS_CHECK_GOTO(cmd, cleanup)
-
-//===----------------------------------------------------------------------===//
-// Fused-decode dispatch toggle
-//===----------------------------------------------------------------------===//
-// HIPDNN_EP_GQA_FUSED (default 1):
-//   1 / unset -> use the fused decode kernel (hip_gqa_fused_decode) when
-//                eligible (sq == 1, d in {64, 128, 256}, no sliding window /
-//                head sink / smooth softmax). This is the fast path.
-//   0         -> force ALL GQA calls -- decode included -- through the
-//                decomposed hipBLASLt pipeline. Useful for bit-for-bit
-//                comparison against the pre-fused-kernel baseline (e.g.
-//                output-quality regression triage) and for isolating any
-//                accuracy difference introduced by the fused kernel.
-//
-// Read once at process startup so the dispatch decision is uniform across
-// every call and the resolved state is visible in the runtime banner.
-static bool gqa_fused_enabled() {
-  static const bool enabled = [] {
-    const char *v = std::getenv("HIPDNN_EP_GQA_FUSED");
-    bool on = !v || v[0] != '0';
-    fprintf(stderr,
-            "[Runtime] HIPDNN_EP_GQA_FUSED=%s (fused decode %s)\n",
-            v ? v : "<unset>", on ? "ENABLED" : "DISABLED");
-    return on;
-  }();
-  return enabled;
-}
 
 //===----------------------------------------------------------------------===//
 // hipBLASLt layout helper
@@ -302,15 +274,10 @@ static int gqa_forward_hipblaslt(
   // All prefill (sq > 1) goes through the decomposed hipBLASLt path where
   // auto-tuned GEMMs outperform fixed WMMA tiling and all ORT GQA features
   // (sliding window, smooth softmax, head sink) are supported.
-  //
-  // Set HIPDNN_EP_GQA_FUSED=0 to force decode through the decomposed path
-  // as well, e.g. for output-quality bisection against the pre-fused-kernel
-  // baseline.
   //===--------------------------------------------------------------------===//
   bool fused_d = (d == 64 || d == 128 || d == 256);
-  if (gqa_fused_enabled() && fused_d && sq == 1 && key && value &&
-      present_key && present_value && local_window_size == 0 && !head_sink &&
-      !use_smooth_softmax) {
+  if (fused_d && sq == 1 && key && value && present_key && present_value &&
+      local_window_size == 0 && !head_sink && !use_smooth_softmax) {
     const void *qSrc = query;
     const void *kSrc = key;
 

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -5,6 +5,7 @@
 
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../operator_profile.h"
 #include "cache_utils.h"
 #include "error_check_macros.h"
 #include "hip_custom_kernels.h"
@@ -14,6 +15,7 @@
 #include <cassert>
 #include <cmath>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <functional>
 #include <unordered_map>
@@ -21,6 +23,33 @@
 
 #define HIP_CHECK(cmd) HIP_CHECK_GOTO(cmd, cleanup)
 #define HIPBLAS_CHECK(cmd) HIPBLAS_CHECK_GOTO(cmd, cleanup)
+
+//===----------------------------------------------------------------------===//
+// Fused-decode dispatch toggle
+//===----------------------------------------------------------------------===//
+// HIPDNN_EP_GQA_FUSED (default 1):
+//   1 / unset -> use the fused decode kernel (hip_gqa_fused_decode) when
+//                eligible (sq == 1, d in {64, 128, 256}, no sliding window /
+//                head sink / smooth softmax). This is the fast path.
+//   0         -> force ALL GQA calls -- decode included -- through the
+//                decomposed hipBLASLt pipeline. Useful for bit-for-bit
+//                comparison against the pre-fused-kernel baseline (e.g.
+//                output-quality regression triage) and for isolating any
+//                accuracy difference introduced by the fused kernel.
+//
+// Read once at process startup so the dispatch decision is uniform across
+// every call and the resolved state is visible in the runtime banner.
+static bool gqa_fused_enabled() {
+  static const bool enabled = [] {
+    const char *v = std::getenv("HIPDNN_EP_GQA_FUSED");
+    bool on = !v || v[0] != '0';
+    fprintf(stderr,
+            "[Runtime] HIPDNN_EP_GQA_FUSED=%s (fused decode %s)\n",
+            v ? v : "<unset>", on ? "ENABLED" : "DISABLED");
+    return on;
+  }();
+  return enabled;
+}
 
 //===----------------------------------------------------------------------===//
 // hipBLASLt layout helper
@@ -273,10 +302,15 @@ static int gqa_forward_hipblaslt(
   // All prefill (sq > 1) goes through the decomposed hipBLASLt path where
   // auto-tuned GEMMs outperform fixed WMMA tiling and all ORT GQA features
   // (sliding window, smooth softmax, head sink) are supported.
+  //
+  // Set HIPDNN_EP_GQA_FUSED=0 to force decode through the decomposed path
+  // as well, e.g. for output-quality bisection against the pre-fused-kernel
+  // baseline.
   //===--------------------------------------------------------------------===//
   bool fused_d = (d == 64 || d == 128 || d == 256);
-  if (fused_d && sq == 1 && key && value && present_key && present_value &&
-      local_window_size == 0 && !head_sink && !use_smooth_softmax) {
+  if (gqa_fused_enabled() && fused_d && sq == 1 && key && value &&
+      present_key && present_value && local_window_size == 0 && !head_sink &&
+      !use_smooth_softmax) {
     const void *qSrc = query;
     const void *kSrc = key;
 
@@ -663,6 +697,7 @@ int wrap_group_query_attention(
     fprintf(stderr, "wrap_group_query_attention: null state\n");
     return -1;
   }
+  HIPDNN_EP_OP_PROFILE_SCOPE(state);
   if (!query || !output) {
     fprintf(stderr, "wrap_group_query_attention: null required argument\n");
     return -1;

--- a/lib/Runtime/real/matmul.cpp
+++ b/lib/Runtime/real/matmul.cpp
@@ -4,6 +4,7 @@
  */
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../operator_profile.h"
 #include "cache_utils.h"
 #include "hip_custom_kernels.h"
 #include "runtime_types.h"
@@ -318,6 +319,7 @@ int wrap_hipblasLtMatmul(RuntimeState *state, const void *A, const void *B,
     fprintf(stderr, "Invalid arguments to wrap_hipblasLtMatmul\n");
     return -1;
   }
+  HIPDNN_EP_OP_PROFILE_SCOPE(state);
 
   hipblasLtHandle_t handle =
       static_cast<hipblasLtHandle_t>(hipdnn_ep_state_get_hipblas_handle(state));

--- a/lib/Runtime/real/matmul_nbits.cpp
+++ b/lib/Runtime/real/matmul_nbits.cpp
@@ -4,6 +4,7 @@
  */
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../operator_profile.h"
 #include "error_check_macros.h"
 #include "hip_custom_kernels.h"
 
@@ -20,6 +21,7 @@ int wrap_matmul_nbits(RuntimeState *state, const void *A, const void *B,
     fprintf(stderr, "wrap_matmul_nbits: null argument\n");
     return -1;
   }
+  HIPDNN_EP_OP_PROFILE_SCOPE(state);
 
   RUNTIME_DEBUG_LOG("[REAL] wrap_matmul_nbits(M=%lld, N=%lld, K=%lld, "
                     "batch=%lld, bits=%lld, block_size=%lld, elem_size=%lld, "

--- a/lib/Runtime/real/memory.cpp
+++ b/lib/Runtime/real/memory.cpp
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 #include "../hipdnn_ep_runtime.h"
+#include "../operator_profile.h"
 #include "runtime_types.h"
 
 #include <cstdio>
@@ -22,6 +23,9 @@ int wrap_hipMemcpyAsync(RuntimeState *state, void *dst_ptr, const void *src_ptr,
   if (size_bytes == 0) {
     return 0; // No-op for zero-sized copy
   }
+  // Use the I/O profile scope so this D2D shows up in the I/O table with
+  // bandwidth, separate from the compute-op table.
+  HIPDNN_EP_IO_PROFILE_SCOPE(state, __func__, size_bytes);
 
   // Extract stream from opaque RuntimeState using accessor function
   // (Maintains abstraction barrier - no direct field access)

--- a/lib/Runtime/real/miopen.cpp
+++ b/lib/Runtime/real/miopen.cpp
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 #include "../hipdnn_ep_runtime.h"
+#include "../operator_profile.h"
 #include "error_check_macros.h"
 #include "runtime_types.h"
 
@@ -110,6 +111,7 @@ int wrap_miopenConvolutionForward(
     fprintf(stderr, "Invalid arguments to wrap_miopenConvolutionForward\n");
     return -1;
   }
+  HIPDNN_EP_OP_PROFILE_SCOPE(state);
 
   // Extract handle and stream from opaque RuntimeState via accessor functions
   // (Maintains abstraction barrier - no direct field access)

--- a/lib/Runtime/real/power.cpp
+++ b/lib/Runtime/real/power.cpp
@@ -4,6 +4,7 @@
  */
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../operator_profile.h"
 #include "cache_utils.h"
 #include "error_check_macros.h"
 #include "hip_custom_kernels.h"
@@ -247,6 +248,7 @@ int wrap_power(RuntimeState *state, void *input, void *output,
     fprintf(stderr, "wrap_power: null argument\n");
     return -1;
   }
+  HIPDNN_EP_OP_PROFILE_SCOPE(state);
 
   // hip.reciprocal lowers to wrap_power(…, 0, 1, -1).
   if (alpha == 0.0 && beta == 1.0 && gamma == -1.0)

--- a/lib/Runtime/real/qmoe.cpp
+++ b/lib/Runtime/real/qmoe.cpp
@@ -4,6 +4,7 @@
  */
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../operator_profile.h"
 #include "error_check_macros.h"
 #include "hip_custom_kernels.h"
 #include "runtime_types.h"
@@ -37,6 +38,7 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
     fprintf(stderr, "wrap_qmoe: null argument\n");
     return -1;
   }
+  HIPDNN_EP_OP_PROFILE_SCOPE(state);
 
   if (swiglu_fusion != 1) {
     fprintf(stderr, "wrap_qmoe: only swiglu_fusion=1 supported, got %lld\n",

--- a/lib/Runtime/real/reduce_sum.cpp
+++ b/lib/Runtime/real/reduce_sum.cpp
@@ -4,6 +4,7 @@
  */
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../operator_profile.h"
 #include "hip_custom_kernels.h"
 #include "runtime_types.h"
 
@@ -29,6 +30,7 @@ int wrap_reduce_sum(RuntimeState *state, void *data, void *axes, void *output,
     RUNTIME_DEBUG_LOG("[REAL] wrap_reduce_sum: null argument\n");
     return -1;
   }
+  HIPDNN_EP_OP_PROFILE_SCOPE(state);
 
   // Handle noop_with_empty_axes: if axes is empty and noop_with_empty_axes is
   // 1, copy input to output without reduction

--- a/lib/Runtime/real/rotary_embedding.cpp
+++ b/lib/Runtime/real/rotary_embedding.cpp
@@ -5,6 +5,7 @@
 
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../operator_profile.h"
 #include "hip_custom_kernels.h"
 
 #include <cstdio>
@@ -41,6 +42,7 @@ int wrap_rotary_embedding(RuntimeState *state, void *input, void *position_ids,
     fprintf(stderr, "wrap_rotary_embedding: null state\n");
     return -1;
   }
+  HIPDNN_EP_OP_PROFILE_SCOPE(state);
 
   void *stream = hipdnn_ep_state_get_stream(state);
   if (!stream) {

--- a/lib/Runtime/real/simplified_layer_norm.cpp
+++ b/lib/Runtime/real/simplified_layer_norm.cpp
@@ -8,6 +8,7 @@
 
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../operator_profile.h"
 #include "cache_utils.h"
 #include "error_check_macros.h"
 #include "runtime_types.h"
@@ -143,6 +144,7 @@ int wrap_miopenT5LayerNormForward(RuntimeState *state, void *input, void *scale,
     fprintf(stderr, "Invalid arguments to wrap_miopenT5LayerNormForward\n");
     return -1;
   }
+  HIPDNN_EP_OP_PROFILE_SCOPE(state);
 
   miopenHandle_t handle =
       static_cast<miopenHandle_t>(hipdnn_ep_state_get_miopen_handle(state));

--- a/lib/Runtime/real/skip_simplified_layer_norm.cpp
+++ b/lib/Runtime/real/skip_simplified_layer_norm.cpp
@@ -8,6 +8,7 @@
 
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../operator_profile.h"
 #include "cache_utils.h"
 #include "error_check_macros.h"
 #include "runtime_types.h"
@@ -173,6 +174,7 @@ int wrap_skip_simplified_layer_norm(RuntimeState *state, void *input,
             "wrap_skip_simplified_layer_norm: null required argument\n");
     return -1;
   }
+  HIPDNN_EP_OP_PROFILE_SCOPE(state);
 
   miopenHandle_t handle =
       static_cast<miopenHandle_t>(hipdnn_ep_state_get_miopen_handle(state));

--- a/lib/Runtime/runtime_state_internal.h
+++ b/lib/Runtime/runtime_state_internal.h
@@ -61,6 +61,20 @@ struct RuntimeState {
   // cleaned up here)
   void *hipdnn_handle;
   void *hipdnn_graph_registry;
+
+  // Per-inference I/O cache for `past_present_share_buffer` optimization.
+  // Opaque `IoCache*` (defined in hipdnn_ep_runtime_tensor.cpp). When the same
+  // host pointer is passed as both an input (e.g. past_key) and an output
+  // (e.g. present_key) of the same inference, the EP skips the H2D/D2H round
+  // trip and keeps the tensor resident on GPU across calls. Saves several
+  // GiB per decode step on large-context models with `past_present_share_buffer=true`.
+  void *io_cache;
 };
+
+// Internal helper: destroy the io_cache attached to `state` (releases any
+// persistent GPU buffers it owns, back to the shared GPU buffer pool). Safe
+// to call when `state->io_cache` is null.
+// Defined in hipdnn_ep_runtime_tensor.cpp.
+void hipdnn_ep_io_cache_destroy(RuntimeState *state);
 
 #endif // HIPDNN_EP_RUNTIME_STATE_INTERNAL_H


### PR DESCRIPTION
## Summary

Adds runtime instrumentation and an experimental I/O cache for characterizing and reducing per-inference overhead on the OGA decoder-pipeline path. **Draft because the I/O cache as implemented produces incorrect output in chunked pipelines** (see Caveat below); the instrumentation pieces are independently useful.

### Instrumentation (gated, off by default)

- **Per-operator GPU timing** (`HIPDNN_EP_OP_PROFILE` / `HIPDNN_EP_OP_PROFILE_EACH`): RAII `OpScope` around every `wrap_*` call records `hipEvent` timings on the EP stream and prints per-op aggregates at session cleanup.
- **I/O profiling** (`IoScope`): tracks `hipMemcpy` bytes alongside time so the per-op table also reports H2D/D2H bandwidth (GB/s).
- **Wall-clock + GPU-stream PERF breakdown** (`HIPDNN_EP_PERF` / `HIPDNN_EP_PERF_EACH`): per-inference H2D / Compute / D2H GPU time and host wall time, with explicit `Other` (host overhead) vs `Overlap` (host pipelined ahead of GPU) buckets. Sparse-call models (e.g. the prompt model in OGA's chunked pipeline) are handled by anchoring `d2h_end` / `host_end` to the *last* `finalize_output` of an inference.
- **Warmup vs steady-state aggregation** (`HIPDNN_EP_PERF_WARMUP`): the first N inferences (default 1) bucket separately for both PERF and OP_PROFILE, so kernel-selection / cache-warmup cost doesn't contaminate steady-state numbers.

### GQA toggle

- `HIPDNN_EP_GQA_FUSED` forces the decode path through the decomposed hipBLASLt route instead of the fused decode kernel — useful for output-equivalence comparisons against the legacy path.

### Skip-buffer I/O cache (`HIPDNN_EP_IO_CACHE`, default ON)

`past_present_share_buffer=true` means OGA passes the same host `OrtValue` as both `past_key_N` input and `present_key_N` output. Without a cache the runtime copies that buffer H2D every `prepare_input` — about 2 GiB of redundant PCIe traffic per token at Mistral-7B / ctx=16384.

- **Pin-on-claim**: `finalize_output` detects the alias case, installs the GPU buffer in a process-static map keyed by `host_ptr`, and skips D2H. The next `prepare_input` matches by `host_ptr` and skips H2D too.
- **Generation-boundary GC**: at `prepare_input(idx==0)` any cache entry whose `host_ptr` is **not** in this call's alive set is stale (the previous `OgaGenerator`'s host buffers were freed). Stream-sync once, `hipFree` the GPU buffer (returning VRAM to the OS, not the size-class freelist), and erase the bookkeeping. Without this sweep the cache accumulates ~2 GiB per DLL per benchmark iteration and OOMs by iter 1.

### Caveat (the reason this is a draft)

The "global" cache statics are **per-DLL** because the EP runtime is statically linked into each MLIR-compiled model DLL. In OGA's chunked decoder pipeline the prefill and decode sessions load distinct DLLs, so the cache does **not** actually share across them. With D2H skipped on `cache_claim`, the decode session's first `prepare_input` reads the host buffer that prefill never wrote back, producing incorrect output.

The implementation is intended for measuring the upper-bound TPS achievable by a true shared-memory cache. Correct alternatives:

1. **PIN+D2H** (per-state, always D2H on claim): correct everywhere; cuts H2D bandwidth in half but pays the full D2H cost. Reverted in the conversation history; ~OOMs at this model size due to per-state duplication. Could be made fit by being more aggressive about pool eviction.
2. **Process-global named-shared-memory cache**: like the existing constants cache. Skips both H2D and D2H across DLLs. Requires Win32 plumbing similar to `hipdnn_ep_runtime_state.cpp`'s `SharedConstantsMeta`.
3. **In-place buffer reuse**: for `past_present_share_buffer` aliases, use the same GPU buffer for input and output (eliminates the pool ping-pong). Requires kernels to be safe under aliased read/write.

## Files

- `operator_profile.{h,cpp}`: `OpScope` / `IoScope`, op-level event ring buffer, summary printer (added to `CMakeLists.txt`).
- `hipdnn_ep_runtime_tensor.cpp`: PERF breakdown, IoCache, generation-boundary GC, GPU buffer pool.
- `hipdnn_ep_runtime_state.cpp`: state cleanup orders stream sync -> op_profile flush -> perf flush -> io_cache_destroy.
- `runtime_state_internal.h`: `io_cache` opaque slot on `RuntimeState`.
- `real/*.cpp`: `HIPDNN_EP_OP_PROFILE_SCOPE` wrapped around each operator body.
- `real/gqa.cpp`: `HIPDNN_EP_GQA_FUSED` gate around the fused decode path.
- `debug_log.h`: PERF / OP_PROFILE log helpers.

## Environment variables

| Variable | Default | Effect |
| --- | --- | --- |
| `HIPDNN_EP_OP_PROFILE` | 0 | Enable per-operator GPU timing aggregates at cleanup. |
| `HIPDNN_EP_OP_PROFILE_EACH` | 0 | Print every operator timing (verbose). |
| `HIPDNN_EP_PERF` | 0 | Enable wall-clock + GPU-stream PERF breakdown aggregate. |
| `HIPDNN_EP_PERF_EACH` | 0 | Print per-inference PERF lines (verbose). |
| `HIPDNN_EP_PERF_WARMUP` | 1 | Number of warmup inferences to bucket separately for PERF/OP_PROFILE. |
| `HIPDNN_EP_IO_CACHE` | 1 | Skip H2D + D2H for `past_present_share_buffer` tensors. |
| `HIPDNN_EP_GQA_FUSED` | 1 | Use the fused decode kernel; set to 0 to force the decomposed hipBLASLt path. |

## Test plan

- [ ] Run `model_benchmark` end-to-end on the Mistral-7B decoder-pipeline config (`genai_config_p128m16384.json`) with `HIPDNN_EP_IO_CACHE=0` and verify correct generated text + baseline TPS.
- [ ] Re-run with `HIPDNN_EP_IO_CACHE=1` and verify all 5 benchmark iterations complete (no OOM thanks to generation-boundary GC) and capture the upper-bound TPS. Output will be wrong; that's expected per the Caveat.
- [ ] Re-run with `HIPDNN_EP_IO_CACHE=1 HIPDNN_EP_PERF=1 HIPDNN_EP_PERF_WARMUP=1` and confirm steady-state PERF table shows H2D and D2H ~0 for cached KV layers.
- [ ] Re-run with `HIPDNN_EP_OP_PROFILE=1 HIPDNN_EP_PERF_WARMUP=1` and confirm WARMUP and STEADY-STATE buckets are reported separately.
- [ ] Re-run with `HIPDNN_EP_GQA_FUSED=0` and verify decode output matches the pre-fused legacy path.
- [ ] Smoke test on a non-chunked model (e.g. Llama-3.1-8B) to confirm nothing regresses for single-session pipelines.
