### PR TITLE
feat: add Unified Memory Manager (UMM) library and integrate into Runtime

### DIFF
--- a/include/mm/mm.h
+++ b/include/mm/mm.h
@@ -1,21 +1,16 @@
 /*
  * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Licensed under the MIT License.
- *
- * mm.h — Convenience umbrella header for the Unified Memory Manager.
- *
- * Including this single header gives access to the complete public API:
- * types, error codes, configuration, HAL interface, and core functions.
  */
 
 #ifndef MM_H
 #define MM_H
 
-#include "mm_types.h"
-#include "mm_error.h"
-#include "mm_config.h"
-#include "mm_hal.h"
 #include "mm_api.h"
+#include "mm_config.h"
+#include "mm_error.h"
+#include "mm_hal.h"
 #include "mm_pool.h"
+#include "mm_types.h"
 
 #endif /* MM_H */

--- a/include/mm/mm_api.h
+++ b/include/mm/mm_api.h
@@ -1,30 +1,14 @@
 /*
  * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Licensed under the MIT License.
- *
- * mm_api.h — Public API for the Unified Memory Manager (UMM).
- *
- * Lifecycle:
- *   1. Call mm_init() once at startup with a config (or NULL for defaults).
- *   2. Use mm_alloc() / mm_free() / mm_get_ptr() / mm_query() during inference.
- *   3. Call mm_shutdown() at teardown to release all resources.
- *
- * Thread safety:
- *   All functions are thread-safe. The handle table uses a mutex internally.
- *   Metrics counters are atomic (lock-free reads via mm_metrics_snapshot()).
- *
- * Error handling:
- *   Functions that can fail return mm_status_t. Functions that return handles
- *   use MM_HANDLE_INVALID to signal failure. Check mm_status_string() for
- *   human-readable error descriptions.
  */
 
 #ifndef MM_API_H
 #define MM_API_H
 
-#include "mm_types.h"
-#include "mm_error.h"
 #include "mm_config.h"
+#include "mm_error.h"
+#include "mm_types.h"
 #include <stdio.h>
 
 #ifdef __cplusplus
@@ -48,7 +32,7 @@ extern "C" {
  * @return MM_OK on success, MM_ERR_ALREADY_INIT if already initialized,
  *         or MM_ERR_HAL_FAILURE if the device could not be set.
  */
-mm_status_t mm_init(const mm_config_t* config);
+mm_status_t mm_init(const mm_config_t *config);
 
 /**
  * Shut down the memory manager and release all resources.
@@ -88,7 +72,7 @@ int mm_is_initialized(void);
  * @return A valid handle on success, MM_HANDLE_INVALID on failure (OOM,
  *         not initialized, or invalid arguments).
  */
-mm_handle_t mm_alloc(size_t size, const mm_alloc_hints_t* hints,
+mm_handle_t mm_alloc(size_t size, const mm_alloc_hints_t *hints,
                      mm_stream_t stream);
 
 /**
@@ -113,7 +97,7 @@ mm_status_t mm_free(mm_handle_t handle, mm_stream_t stream);
  * @param handle A valid handle returned by mm_alloc().
  * @return The device pointer, or NULL if the handle is invalid.
  */
-void* mm_get_ptr(mm_handle_t handle);
+void *mm_get_ptr(mm_handle_t handle);
 
 /**
  * Query metadata for an active allocation.
@@ -123,7 +107,7 @@ void* mm_get_ptr(mm_handle_t handle);
  * @return MM_OK on success, MM_ERR_INVALID_HANDLE if the handle is not
  *         active, or MM_ERR_NOT_INITIALIZED.
  */
-mm_status_t mm_query(mm_handle_t handle, mm_alloc_info_t* info);
+mm_status_t mm_query(mm_handle_t handle, mm_alloc_info_t *info);
 
 /* ============================ Diagnostics ================================ */
 
@@ -135,7 +119,15 @@ mm_status_t mm_query(mm_handle_t handle, mm_alloc_info_t* info);
  *
  * @param output File stream to write to (e.g., stderr). Must not be NULL.
  */
-void mm_dump_state(FILE* output);
+void mm_dump_state(FILE *output);
+
+/**
+ * Check whether debug logging is enabled.
+ *
+ * @return 1 if debug logging was enabled in the config passed to mm_init(),
+ *         0 otherwise (including when not initialized).
+ */
+int mm_debug_enabled(void);
 
 /* ============================== Metrics ================================== */
 

--- a/include/mm/mm_config.h
+++ b/include/mm/mm_config.h
@@ -1,11 +1,6 @@
 /*
  * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Licensed under the MIT License.
- *
- * mm_config.h — Configuration for the Unified Memory Manager.
- *
- * Pass an mm_config_t to mm_init() to control device selection, alignment,
- * and debug logging. Use mm_config_default() for sensible defaults.
  */
 
 #ifndef MM_CONFIG_H
@@ -15,7 +10,7 @@
 
 #ifdef _MSC_VER
 #pragma warning(push)
-#pragma warning(disable: 4996)  /* getenv deprecation */
+#pragma warning(disable : 4996) /* getenv deprecation */
 #endif
 #include <stdlib.h>
 
@@ -33,11 +28,12 @@ extern "C" {
  *                       Default: 256 (matches GPU cache line size).
  *   enable_debug_log  — If non-zero, print debug messages (alloc/free events,
  *                       leak warnings) to stderr. Default: 0 (off).
- * --------------------------------------------------------------------------- */
+ * ---------------------------------------------------------------------------
+ */
 typedef struct {
-    mm_device_t device_id;
-    size_t      default_alignment;
-    int         enable_debug_log;
+  mm_device_t device_id;
+  size_t default_alignment;
+  int enable_debug_log;
 } mm_config_t;
 
 /**
@@ -46,12 +42,12 @@ typedef struct {
  * Set environment variable MM_DEBUG_LOG=1 to enable debug logging.
  */
 static inline mm_config_t mm_config_default(void) {
-    mm_config_t c;
-    c.device_id = 0;
-    c.default_alignment = 256;
-    const char* dbg = getenv("MM_DEBUG_LOG");
-    c.enable_debug_log = (dbg && dbg[0] != '0' && dbg[0] != '\0') ? 1 : 0;
-    return c;
+  mm_config_t c;
+  c.device_id = 0;
+  c.default_alignment = 256;
+  const char *dbg = getenv("MM_DEBUG_LOG");
+  c.enable_debug_log = (dbg && dbg[0] != '0' && dbg[0] != '\0') ? 1 : 0;
+  return c;
 }
 
 #ifdef __cplusplus

--- a/include/mm/mm_error.h
+++ b/include/mm/mm_error.h
@@ -1,11 +1,6 @@
 /*
  * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Licensed under the MIT License.
- *
- * mm_error.h — Error codes for the Unified Memory Manager.
- *
- * All UMM API functions that can fail return mm_status_t. Functions that
- * return handles use MM_HANDLE_INVALID to signal failure instead.
  */
 
 #ifndef MM_ERROR_H
@@ -27,16 +22,17 @@ extern "C" {
  *   MM_ERR_INVALID_ARGUMENT — A function argument is invalid (e.g., size == 0).
  *   MM_ERR_HAL_FAILURE    — The HAL backend returned a non-OOM error.
  *   MM_ERR_DOUBLE_FREE    — mm_free() called on an already-freed handle.
- * --------------------------------------------------------------------------- */
+ * ---------------------------------------------------------------------------
+ */
 typedef enum {
-    MM_OK                   =  0,
-    MM_ERR_NOT_INITIALIZED  = -1,
-    MM_ERR_ALREADY_INIT     = -2,
-    MM_ERR_INVALID_HANDLE   = -3,
-    MM_ERR_OUT_OF_MEMORY    = -4,
-    MM_ERR_INVALID_ARGUMENT = -5,
-    MM_ERR_HAL_FAILURE      = -6,
-    MM_ERR_DOUBLE_FREE      = -7
+  MM_OK = 0,
+  MM_ERR_NOT_INITIALIZED = -1,
+  MM_ERR_ALREADY_INIT = -2,
+  MM_ERR_INVALID_HANDLE = -3,
+  MM_ERR_OUT_OF_MEMORY = -4,
+  MM_ERR_INVALID_ARGUMENT = -5,
+  MM_ERR_HAL_FAILURE = -6,
+  MM_ERR_DOUBLE_FREE = -7
 } mm_status_t;
 
 /**
@@ -45,7 +41,7 @@ typedef enum {
  *
  * Example: mm_status_string(MM_ERR_OUT_OF_MEMORY) => "out of memory"
  */
-const char* mm_status_string(mm_status_t status);
+const char *mm_status_string(mm_status_t status);
 
 #ifdef __cplusplus
 }

--- a/include/mm/mm_hal.h
+++ b/include/mm/mm_hal.h
@@ -1,26 +1,13 @@
 /*
  * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Licensed under the MIT License.
- *
- * mm_hal.h — Hardware Abstraction Layer for the Unified Memory Manager.
- *
- * The HAL is a function-pointer vtable that isolates all GPU-specific calls
- * behind a single indirection point. Two backends are provided:
- *
- *   mm_hal_rocm() — Real ROCm/HIP backend (hipMalloc, hipFree, etc.).
- *   mm_hal_mock() — Host-only mock backend (malloc/free). No GPU required.
- *                   Follows the existing lib/Runtime/mock/ pattern.
- *
- * The active HAL is selected at mm_init() time (build-time flag MM_USE_MOCK_HAL
- * controls the default). The function-pointer cost is negligible — one indirect
- * call per hipMalloc, not per kernel launch.
  */
 
 #ifndef MM_HAL_H
 #define MM_HAL_H
 
-#include "mm_types.h"
 #include "mm_error.h"
+#include "mm_types.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -47,23 +34,23 @@ extern "C" {
  * Device queries:
  *   get_free_mem — Query available and total device memory (in bytes).
  *   set_device   — Set the active GPU device for the calling thread.
- * --------------------------------------------------------------------------- */
+ * ---------------------------------------------------------------------------
+ */
 typedef struct {
-    mm_status_t (*malloc)(void** ptr, size_t size);
-    mm_status_t (*free)(void* ptr);
-    mm_status_t (*memcpy_h2d)(void* dst, const void* src, size_t size,
-                              mm_stream_t stream);
-    mm_status_t (*memcpy_d2h)(void* dst, const void* src, size_t size,
-                              mm_stream_t stream);
-    mm_status_t (*memset)(void* ptr, int value, size_t size,
-                          mm_stream_t stream);
+  mm_status_t (*malloc)(void **ptr, size_t size);
+  mm_status_t (*free)(void *ptr);
+  mm_status_t (*memcpy_h2d)(void *dst, const void *src, size_t size,
+                            mm_stream_t stream);
+  mm_status_t (*memcpy_d2h)(void *dst, const void *src, size_t size,
+                            mm_stream_t stream);
+  mm_status_t (*memset)(void *ptr, int value, size_t size, mm_stream_t stream);
 
-    mm_status_t (*stream_create)(mm_stream_t* stream);
-    mm_status_t (*stream_destroy)(mm_stream_t stream);
-    mm_status_t (*stream_sync)(mm_stream_t stream);
+  mm_status_t (*stream_create)(mm_stream_t *stream);
+  mm_status_t (*stream_destroy)(mm_stream_t stream);
+  mm_status_t (*stream_sync)(mm_stream_t stream);
 
-    mm_status_t (*get_free_mem)(size_t* free_bytes, size_t* total_bytes);
-    mm_status_t (*set_device)(mm_device_t device);
+  mm_status_t (*get_free_mem)(size_t *free_bytes, size_t *total_bytes);
+  mm_status_t (*set_device)(mm_device_t device);
 } mm_hal_t;
 
 /**
@@ -75,7 +62,7 @@ typedef struct {
  *
  * Only available when MM_USE_MOCK_HAL is NOT defined at build time.
  */
-const mm_hal_t* mm_hal_rocm(void);
+const mm_hal_t *mm_hal_rocm(void);
 
 /**
  * Returns the mock HAL vtable.
@@ -84,7 +71,7 @@ const mm_hal_t* mm_hal_rocm(void);
  * Streams are dummy pointers (create allocates a byte, destroy frees it).
  * Useful for unit testing the memory manager on machines without a GPU.
  */
-const mm_hal_t* mm_hal_mock(void);
+const mm_hal_t *mm_hal_mock(void);
 
 #ifdef __cplusplus
 }

--- a/include/mm/mm_pool.h
+++ b/include/mm/mm_pool.h
@@ -1,35 +1,13 @@
 /*
  * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Licensed under the MIT License.
- *
- * mm_pool.h — Static Pool allocator for the Unified Memory Manager.
- *
- * A static pool performs a single large GPU allocation and subdivides it into
- * named sub-buffers via a compile-time offset table. This matches the pattern
- * used by the MLIR PoolAllocs pass, which packs non-overlapping temporary
- * allocations into a single contiguous buffer.
- *
- * Usage:
- *   // Compiler produces an offset table at compile time
- *   size_t offsets[] = {0, 1024, 3072};
- *   mm_static_plan_t plan = {4096, offsets, 3};
- *
- *   mm_pool_t pool = mm_pool_create(&plan);
- *   void* buf0 = mm_pool_get_ptr(pool, 0);  // base + 0
- *   void* buf1 = mm_pool_get_ptr(pool, 1);  // base + 1024
- *   void* buf2 = mm_pool_get_ptr(pool, 2);  // base + 3072
- *   mm_pool_destroy(pool);
- *
- * Thread safety: Pool creation and destruction are NOT thread-safe (they are
- * called once at init/cleanup time). Get operations are safe for concurrent
- * reads.
  */
 
 #ifndef MM_POOL_H
 #define MM_POOL_H
 
-#include "mm_types.h"
 #include "mm_error.h"
+#include "mm_types.h"
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -37,7 +15,7 @@ extern "C" {
 #endif
 
 /** Opaque pool handle. */
-typedef struct mm_pool_s* mm_pool_t;
+typedef struct mm_pool_s *mm_pool_t;
 
 /* ---------------------------------------------------------------------------
  * mm_static_plan_t — Compile-time memory plan
@@ -51,11 +29,12 @@ typedef struct mm_pool_s* mm_pool_t;
  *   offsets      — Array of byte offsets for each sub-buffer within the pool.
  *                  Caller retains ownership; the pool copies this array.
  *   num_entries  — Number of sub-buffers (length of offsets array).
- * --------------------------------------------------------------------------- */
+ * ---------------------------------------------------------------------------
+ */
 typedef struct {
-    size_t        total_size;
-    const size_t* offsets;
-    uint32_t      num_entries;
+  size_t total_size;
+  const size_t *offsets;
+  uint32_t num_entries;
 } mm_static_plan_t;
 
 /**
@@ -68,7 +47,7 @@ typedef struct {
  * @param plan  The memory plan. Must not be NULL. plan->total_size must be > 0.
  * @return Pool handle on success, NULL on failure (OOM or invalid args).
  */
-mm_pool_t mm_pool_create(const mm_static_plan_t* plan);
+mm_pool_t mm_pool_create(const mm_static_plan_t *plan);
 
 /**
  * Get the raw device pointer for a sub-buffer by index.
@@ -79,7 +58,7 @@ mm_pool_t mm_pool_create(const mm_static_plan_t* plan);
  * @param index  Sub-buffer index (0-based, must be < num_entries).
  * @return Device pointer, or NULL if pool is NULL or index is out of bounds.
  */
-void* mm_pool_get_ptr(mm_pool_t pool, uint32_t index);
+void *mm_pool_get_ptr(mm_pool_t pool, uint32_t index);
 
 /**
  * Get the pool base pointer.
@@ -90,7 +69,7 @@ void* mm_pool_get_ptr(mm_pool_t pool, uint32_t index);
  * @param pool  Pool handle.
  * @return Base device pointer, or NULL if pool is NULL.
  */
-void* mm_pool_get_base(mm_pool_t pool);
+void *mm_pool_get_base(mm_pool_t pool);
 
 /**
  * Get the total pool size in bytes.

--- a/include/mm/mm_types.h
+++ b/include/mm/mm_types.h
@@ -1,19 +1,13 @@
 /*
  * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Licensed under the MIT License.
- *
- * mm_types.h — Core type definitions for the Unified Memory Manager (UMM).
- *
- * This header defines the vocabulary types shared across all UMM components:
- * handles, memory classification, lifetime hints, allocation metadata, and
- * metrics. It has no dependencies beyond C99 stdint/stddef.
  */
 
 #ifndef MM_TYPES_H
 #define MM_TYPES_H
 
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -29,7 +23,8 @@ extern "C" {
  *
  * Handles are monotonically increasing and never reused, which makes double-
  * free detection trivial (remove returns false if handle not found).
- * --------------------------------------------------------------------------- */
+ * ---------------------------------------------------------------------------
+ */
 typedef uint64_t mm_handle_t;
 
 /** Sentinel value indicating an invalid or failed allocation. */
@@ -40,15 +35,17 @@ typedef uint64_t mm_handle_t;
  *
  * Wraps the backend-specific stream type (e.g., hipStream_t on ROCm).
  * Pass NULL for synchronous operations or when the stream is not relevant.
- * --------------------------------------------------------------------------- */
-typedef void* mm_stream_t;
+ * ---------------------------------------------------------------------------
+ */
+typedef void *mm_stream_t;
 
 /* ---------------------------------------------------------------------------
  * mm_device_t — Device identifier
  *
  * Non-negative values identify GPU ordinals (0, 1, ...).
  * MM_DEVICE_HOST (-1) identifies host (CPU) memory.
- * --------------------------------------------------------------------------- */
+ * ---------------------------------------------------------------------------
+ */
 typedef int32_t mm_device_t;
 #define MM_DEVICE_GPU0 0
 #define MM_DEVICE_HOST (-1)
@@ -65,13 +62,14 @@ typedef int32_t mm_device_t;
  *   ACTIVATION — Intermediate tensors. Short-lived, arena-allocated.
  *   KV_CACHE   — Attention key-value cache. Request-scoped, paged blocks.
  *   SCRATCH    — Kernel workspace. Per-stream, reusable ring buffer.
- * --------------------------------------------------------------------------- */
+ * ---------------------------------------------------------------------------
+ */
 typedef enum {
-    MM_CLASS_GENERIC    = 0,
-    MM_CLASS_WEIGHT     = 1,
-    MM_CLASS_ACTIVATION = 2,
-    MM_CLASS_KV_CACHE   = 3,
-    MM_CLASS_SCRATCH    = 4
+  MM_CLASS_GENERIC = 0,
+  MM_CLASS_WEIGHT = 1,
+  MM_CLASS_ACTIVATION = 2,
+  MM_CLASS_KV_CACHE = 3,
+  MM_CLASS_SCRATCH = 4
 } mm_class_t;
 
 /* ---------------------------------------------------------------------------
@@ -84,12 +82,13 @@ typedef enum {
  *   REQUEST   — Lives for one inference request (seconds to minutes).
  *   STEP      — Lives for one decode step (freed after each generated token).
  *   TRANSIENT — Lives for a single kernel or fused operator group.
- * --------------------------------------------------------------------------- */
+ * ---------------------------------------------------------------------------
+ */
 typedef enum {
-    MM_LIFETIME_STATIC    = 0,
-    MM_LIFETIME_REQUEST   = 1,
-    MM_LIFETIME_STEP      = 2,
-    MM_LIFETIME_TRANSIENT = 3
+  MM_LIFETIME_STATIC = 0,
+  MM_LIFETIME_REQUEST = 1,
+  MM_LIFETIME_STEP = 2,
+  MM_LIFETIME_TRANSIENT = 3
 } mm_lifetime_t;
 
 /* ---------------------------------------------------------------------------
@@ -103,11 +102,12 @@ typedef enum {
  *   lifetime   — Expected lifetime (default: MM_LIFETIME_TRANSIENT).
  *   alignment  — Required byte alignment. 0 means use the config default
  *                (typically 256 bytes, matching GPU cache line size).
- * --------------------------------------------------------------------------- */
+ * ---------------------------------------------------------------------------
+ */
 typedef struct {
-    mm_class_t    mem_class;
-    mm_lifetime_t lifetime;
-    size_t        alignment;
+  mm_class_t mem_class;
+  mm_lifetime_t lifetime;
+  size_t alignment;
 } mm_alloc_hints_t;
 
 /* ---------------------------------------------------------------------------
@@ -124,14 +124,15 @@ typedef struct {
  *   mem_class — The memory class specified at allocation time.
  *   lifetime  — The lifetime hint specified at allocation time.
  *   device    — The device on which memory was allocated.
- * --------------------------------------------------------------------------- */
+ * ---------------------------------------------------------------------------
+ */
 typedef struct {
-    mm_handle_t   handle;
-    void*         ptr;
-    size_t        size;
-    mm_class_t    mem_class;
-    mm_lifetime_t lifetime;
-    mm_device_t   device;
+  mm_handle_t handle;
+  void *ptr;
+  size_t size;
+  mm_class_t mem_class;
+  mm_lifetime_t lifetime;
+  mm_device_t device;
 } mm_alloc_info_t;
 
 /* ---------------------------------------------------------------------------
@@ -147,13 +148,14 @@ typedef struct {
  *   free_count            — Total number of mm_free() calls since init/reset.
  *   active_count          — Number of currently live allocations
  *                           (alloc_count - free_count).
- * --------------------------------------------------------------------------- */
+ * ---------------------------------------------------------------------------
+ */
 typedef struct {
-    size_t   total_allocated_bytes;
-    size_t   peak_allocated_bytes;
-    uint64_t alloc_count;
-    uint64_t free_count;
-    uint64_t active_count;
+  size_t total_allocated_bytes;
+  size_t peak_allocated_bytes;
+  uint64_t alloc_count;
+  uint64_t free_count;
+  uint64_t active_count;
 } mm_metrics_snapshot_t;
 
 #ifdef __cplusplus

--- a/lib/MemoryManager/hal_mock.cpp
+++ b/lib/MemoryManager/hal_mock.cpp
@@ -1,91 +1,77 @@
 /*
  * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Licensed under the MIT License.
- *
- * Mock HAL backend — uses malloc/free/memcpy instead of GPU calls.
- * No GPU hardware required. Useful for unit testing.
  */
 
 #include "mm/mm_hal.h"
 #include <cstdlib>
 #include <cstring>
 
-static mm_status_t mock_malloc(void** ptr, size_t size) {
-    if (!ptr || size == 0)
-        return MM_ERR_INVALID_ARGUMENT;
-    *ptr = std::malloc(size);
-    return *ptr ? MM_OK : MM_ERR_OUT_OF_MEMORY;
+static mm_status_t mock_malloc(void **ptr, size_t size) {
+  if (!ptr || size == 0)
+    return MM_ERR_INVALID_ARGUMENT;
+  *ptr = std::malloc(size);
+  return *ptr ? MM_OK : MM_ERR_OUT_OF_MEMORY;
 }
 
-static mm_status_t mock_free(void* ptr) {
-    std::free(ptr);
-    return MM_OK;
+static mm_status_t mock_free(void *ptr) {
+  std::free(ptr);
+  return MM_OK;
 }
 
-static mm_status_t mock_memcpy_h2d(void* dst, const void* src, size_t size,
+static mm_status_t mock_memcpy_h2d(void *dst, const void *src, size_t size,
                                    mm_stream_t /*stream*/) {
-    if (!dst || !src)
-        return MM_ERR_INVALID_ARGUMENT;
-    std::memcpy(dst, src, size);
-    return MM_OK;
+  if (!dst || !src)
+    return MM_ERR_INVALID_ARGUMENT;
+  std::memcpy(dst, src, size);
+  return MM_OK;
 }
 
-static mm_status_t mock_memcpy_d2h(void* dst, const void* src, size_t size,
+static mm_status_t mock_memcpy_d2h(void *dst, const void *src, size_t size,
                                    mm_stream_t /*stream*/) {
-    if (!dst || !src)
-        return MM_ERR_INVALID_ARGUMENT;
-    std::memcpy(dst, src, size);
-    return MM_OK;
+  if (!dst || !src)
+    return MM_ERR_INVALID_ARGUMENT;
+  std::memcpy(dst, src, size);
+  return MM_OK;
 }
 
-static mm_status_t mock_memset(void* ptr, int value, size_t size,
+static mm_status_t mock_memset(void *ptr, int value, size_t size,
                                mm_stream_t /*stream*/) {
-    if (!ptr)
-        return MM_ERR_INVALID_ARGUMENT;
-    std::memset(ptr, value, size);
-    return MM_OK;
+  if (!ptr)
+    return MM_ERR_INVALID_ARGUMENT;
+  std::memset(ptr, value, size);
+  return MM_OK;
 }
 
-static mm_status_t mock_stream_create(mm_stream_t* stream) {
-    if (!stream)
-        return MM_ERR_INVALID_ARGUMENT;
-    *stream = std::malloc(1);
-    return *stream ? MM_OK : MM_ERR_OUT_OF_MEMORY;
+static mm_status_t mock_stream_create(mm_stream_t *stream) {
+  if (!stream)
+    return MM_ERR_INVALID_ARGUMENT;
+  *stream = std::malloc(1);
+  return *stream ? MM_OK : MM_ERR_OUT_OF_MEMORY;
 }
 
 static mm_status_t mock_stream_destroy(mm_stream_t stream) {
-    std::free(stream);
-    return MM_OK;
+  std::free(stream);
+  return MM_OK;
 }
 
-static mm_status_t mock_stream_sync(mm_stream_t /*stream*/) {
-    return MM_OK;
+static mm_status_t mock_stream_sync(mm_stream_t /*stream*/) { return MM_OK; }
+
+static mm_status_t mock_get_free_mem(size_t *free_bytes, size_t *total_bytes) {
+  if (!free_bytes || !total_bytes)
+    return MM_ERR_INVALID_ARGUMENT;
+  *total_bytes = (size_t)16 * 1024 * 1024 * 1024; /* 16 GB simulated */
+  *free_bytes = *total_bytes;
+  return MM_OK;
 }
 
-static mm_status_t mock_get_free_mem(size_t* free_bytes, size_t* total_bytes) {
-    if (!free_bytes || !total_bytes)
-        return MM_ERR_INVALID_ARGUMENT;
-    *total_bytes = (size_t)16 * 1024 * 1024 * 1024; /* 16 GB simulated */
-    *free_bytes  = *total_bytes;
-    return MM_OK;
-}
+static mm_status_t mock_set_device(mm_device_t /*device*/) { return MM_OK; }
 
-static mm_status_t mock_set_device(mm_device_t /*device*/) {
-    return MM_OK;
-}
-
-const mm_hal_t* mm_hal_mock(void) {
-    static const mm_hal_t vtable = {
-        mock_malloc,
-        mock_free,
-        mock_memcpy_h2d,
-        mock_memcpy_d2h,
-        mock_memset,
-        mock_stream_create,
-        mock_stream_destroy,
-        mock_stream_sync,
-        mock_get_free_mem,
-        mock_set_device
-    };
-    return &vtable;
+const mm_hal_t *mm_hal_mock(void) {
+  static const mm_hal_t vtable = {mock_malloc,         mock_free,
+                                  mock_memcpy_h2d,     mock_memcpy_d2h,
+                                  mock_memset,         mock_stream_create,
+                                  mock_stream_destroy, mock_stream_sync,
+                                  mock_get_free_mem,   mock_set_device};
+  return &vtable;
 }

--- a/lib/MemoryManager/hal_rocm.cpp
+++ b/lib/MemoryManager/hal_rocm.cpp
@@ -1,120 +1,110 @@
 /*
  * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Licensed under the MIT License.
- *
- * ROCm HAL backend — wraps HIP runtime API calls.
- * Only compiled when MM_USE_MOCK_HAL is NOT defined.
  */
 
 #ifndef MM_USE_MOCK_HAL
 
 #include "mm/mm_hal.h"
-#include <hip/hip_runtime.h>
 #include <atomic>
+#include <hip/hip_runtime.h>
 
 static std::atomic<bool> g_is_igpu{false};
 
-static mm_status_t rocm_malloc(void** ptr, size_t size) {
-    if (!ptr || size == 0)
-        return MM_ERR_INVALID_ARGUMENT;
-    hipError_t err;
-    if (g_is_igpu.load(std::memory_order_relaxed))
-        err = hipHostMalloc(ptr, size, hipHostMallocDefault);
-    else
-        err = hipMalloc(ptr, size);
-    if (err == hipErrorOutOfMemory)
-        return MM_ERR_OUT_OF_MEMORY;
-    return (err == hipSuccess) ? MM_OK : MM_ERR_HAL_FAILURE;
+static mm_status_t rocm_malloc(void **ptr, size_t size) {
+  if (!ptr || size == 0)
+    return MM_ERR_INVALID_ARGUMENT;
+  hipError_t err;
+  if (g_is_igpu.load(std::memory_order_relaxed))
+    err = hipHostMalloc(ptr, size, hipHostMallocDefault);
+  else
+    err = hipMalloc(ptr, size);
+  if (err == hipErrorOutOfMemory)
+    return MM_ERR_OUT_OF_MEMORY;
+  return (err == hipSuccess) ? MM_OK : MM_ERR_HAL_FAILURE;
 }
 
-static mm_status_t rocm_free(void* ptr) {
-    hipError_t err;
-    if (g_is_igpu.load(std::memory_order_relaxed))
-        err = hipHostFree(ptr);
-    else
-        err = hipFree(ptr);
-    return (err == hipSuccess) ? MM_OK : MM_ERR_HAL_FAILURE;
+static mm_status_t rocm_free(void *ptr) {
+  hipError_t err;
+  if (g_is_igpu.load(std::memory_order_relaxed))
+    err = hipHostFree(ptr);
+  else
+    err = hipFree(ptr);
+  return (err == hipSuccess) ? MM_OK : MM_ERR_HAL_FAILURE;
 }
 
-static mm_status_t rocm_memcpy_h2d(void* dst, const void* src, size_t size,
+static mm_status_t rocm_memcpy_h2d(void *dst, const void *src, size_t size,
                                    mm_stream_t stream) {
-    if (!dst || !src)
-        return MM_ERR_INVALID_ARGUMENT;
-    hipStream_t s = static_cast<hipStream_t>(stream);
-    hipError_t err = hipMemcpyAsync(dst, src, size, hipMemcpyHostToDevice, s);
-    return (err == hipSuccess) ? MM_OK : MM_ERR_HAL_FAILURE;
+  if (!dst || !src)
+    return MM_ERR_INVALID_ARGUMENT;
+  hipStream_t s = static_cast<hipStream_t>(stream);
+  hipError_t err = hipMemcpyAsync(dst, src, size, hipMemcpyHostToDevice, s);
+  return (err == hipSuccess) ? MM_OK : MM_ERR_HAL_FAILURE;
 }
 
-static mm_status_t rocm_memcpy_d2h(void* dst, const void* src, size_t size,
+static mm_status_t rocm_memcpy_d2h(void *dst, const void *src, size_t size,
                                    mm_stream_t stream) {
-    if (!dst || !src)
-        return MM_ERR_INVALID_ARGUMENT;
-    hipStream_t s = static_cast<hipStream_t>(stream);
-    hipError_t err = hipMemcpyAsync(dst, src, size, hipMemcpyDeviceToHost, s);
-    return (err == hipSuccess) ? MM_OK : MM_ERR_HAL_FAILURE;
+  if (!dst || !src)
+    return MM_ERR_INVALID_ARGUMENT;
+  hipStream_t s = static_cast<hipStream_t>(stream);
+  hipError_t err = hipMemcpyAsync(dst, src, size, hipMemcpyDeviceToHost, s);
+  return (err == hipSuccess) ? MM_OK : MM_ERR_HAL_FAILURE;
 }
 
-static mm_status_t rocm_memset(void* ptr, int value, size_t size,
+static mm_status_t rocm_memset(void *ptr, int value, size_t size,
                                mm_stream_t stream) {
-    if (!ptr)
-        return MM_ERR_INVALID_ARGUMENT;
-    hipStream_t s = static_cast<hipStream_t>(stream);
-    hipError_t err = hipMemsetAsync(ptr, value, size, s);
-    return (err == hipSuccess) ? MM_OK : MM_ERR_HAL_FAILURE;
+  if (!ptr)
+    return MM_ERR_INVALID_ARGUMENT;
+  hipStream_t s = static_cast<hipStream_t>(stream);
+  hipError_t err = hipMemsetAsync(ptr, value, size, s);
+  return (err == hipSuccess) ? MM_OK : MM_ERR_HAL_FAILURE;
 }
 
-static mm_status_t rocm_stream_create(mm_stream_t* stream) {
-    if (!stream)
-        return MM_ERR_INVALID_ARGUMENT;
-    hipStream_t s;
-    hipError_t err = hipStreamCreate(&s);
-    if (err != hipSuccess)
-        return MM_ERR_HAL_FAILURE;
-    *stream = static_cast<mm_stream_t>(s);
-    return MM_OK;
+static mm_status_t rocm_stream_create(mm_stream_t *stream) {
+  if (!stream)
+    return MM_ERR_INVALID_ARGUMENT;
+  hipStream_t s;
+  hipError_t err = hipStreamCreate(&s);
+  if (err != hipSuccess)
+    return MM_ERR_HAL_FAILURE;
+  *stream = static_cast<mm_stream_t>(s);
+  return MM_OK;
 }
 
 static mm_status_t rocm_stream_destroy(mm_stream_t stream) {
-    hipError_t err = hipStreamDestroy(static_cast<hipStream_t>(stream));
-    return (err == hipSuccess) ? MM_OK : MM_ERR_HAL_FAILURE;
+  hipError_t err = hipStreamDestroy(static_cast<hipStream_t>(stream));
+  return (err == hipSuccess) ? MM_OK : MM_ERR_HAL_FAILURE;
 }
 
 static mm_status_t rocm_stream_sync(mm_stream_t stream) {
-    hipError_t err = hipStreamSynchronize(static_cast<hipStream_t>(stream));
-    return (err == hipSuccess) ? MM_OK : MM_ERR_HAL_FAILURE;
+  hipError_t err = hipStreamSynchronize(static_cast<hipStream_t>(stream));
+  return (err == hipSuccess) ? MM_OK : MM_ERR_HAL_FAILURE;
 }
 
-static mm_status_t rocm_get_free_mem(size_t* free_bytes, size_t* total_bytes) {
-    if (!free_bytes || !total_bytes)
-        return MM_ERR_INVALID_ARGUMENT;
-    hipError_t err = hipMemGetInfo(free_bytes, total_bytes);
-    return (err == hipSuccess) ? MM_OK : MM_ERR_HAL_FAILURE;
+static mm_status_t rocm_get_free_mem(size_t *free_bytes, size_t *total_bytes) {
+  if (!free_bytes || !total_bytes)
+    return MM_ERR_INVALID_ARGUMENT;
+  hipError_t err = hipMemGetInfo(free_bytes, total_bytes);
+  return (err == hipSuccess) ? MM_OK : MM_ERR_HAL_FAILURE;
 }
 
 static mm_status_t rocm_set_device(mm_device_t device) {
-    hipError_t err = hipSetDevice(device);
-    if (err != hipSuccess)
-        return MM_ERR_HAL_FAILURE;
-    hipDeviceProp_t prop;
-    if (hipGetDeviceProperties(&prop, device) == hipSuccess)
-        g_is_igpu.store(prop.integrated == 1, std::memory_order_relaxed);
-    return MM_OK;
+  hipError_t err = hipSetDevice(device);
+  if (err != hipSuccess)
+    return MM_ERR_HAL_FAILURE;
+  hipDeviceProp_t prop;
+  if (hipGetDeviceProperties(&prop, device) == hipSuccess)
+    g_is_igpu.store(prop.integrated == 1, std::memory_order_relaxed);
+  return MM_OK;
 }
 
-const mm_hal_t* mm_hal_rocm(void) {
-    static const mm_hal_t vtable = {
-        rocm_malloc,
-        rocm_free,
-        rocm_memcpy_h2d,
-        rocm_memcpy_d2h,
-        rocm_memset,
-        rocm_stream_create,
-        rocm_stream_destroy,
-        rocm_stream_sync,
-        rocm_get_free_mem,
-        rocm_set_device
-    };
-    return &vtable;
+const mm_hal_t *mm_hal_rocm(void) {
+  static const mm_hal_t vtable = {rocm_malloc,         rocm_free,
+                                  rocm_memcpy_h2d,     rocm_memcpy_d2h,
+                                  rocm_memset,         rocm_stream_create,
+                                  rocm_stream_destroy, rocm_stream_sync,
+                                  rocm_get_free_mem,   rocm_set_device};
+  return &vtable;
 }
 
 #endif /* !MM_USE_MOCK_HAL */

--- a/lib/MemoryManager/handle_table.cpp
+++ b/lib/MemoryManager/handle_table.cpp
@@ -5,44 +5,44 @@
 
 #include "handle_table.h"
 
-mm_handle_t HandleTable::insert(void* ptr, size_t size, mm_class_t mem_class,
+mm_handle_t HandleTable::insert(void *ptr, size_t size, mm_class_t mem_class,
                                 mm_lifetime_t lifetime, mm_device_t device) {
-    std::lock_guard<std::mutex> lock(mutex_);
-    mm_handle_t handle = next_handle_++;
+  std::lock_guard<std::mutex> lock(mutex_);
+  mm_handle_t handle = next_handle_++;
 
-    mm_alloc_info_t info;
-    info.handle   = handle;
-    info.ptr      = ptr;
-    info.size     = size;
-    info.mem_class = mem_class;
-    info.lifetime  = lifetime;
-    info.device    = device;
+  mm_alloc_info_t info;
+  info.handle = handle;
+  info.ptr = ptr;
+  info.size = size;
+  info.mem_class = mem_class;
+  info.lifetime = lifetime;
+  info.device = device;
 
-    table_[handle] = info;
-    return handle;
+  table_[handle] = info;
+  return handle;
 }
 
-bool HandleTable::lookup(mm_handle_t handle, mm_alloc_info_t* info) const {
-    std::lock_guard<std::mutex> lock(mutex_);
-    auto it = table_.find(handle);
-    if (it == table_.end())
-        return false;
-    if (info)
-        *info = it->second;
-    return true;
+bool HandleTable::lookup(mm_handle_t handle, mm_alloc_info_t *info) const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto it = table_.find(handle);
+  if (it == table_.end())
+    return false;
+  if (info)
+    *info = it->second;
+  return true;
 }
 
 bool HandleTable::remove(mm_handle_t handle) {
-    std::lock_guard<std::mutex> lock(mutex_);
-    return table_.erase(handle) > 0;
+  std::lock_guard<std::mutex> lock(mutex_);
+  return table_.erase(handle) > 0;
 }
 
 size_t HandleTable::size() const {
-    std::lock_guard<std::mutex> lock(mutex_);
-    return table_.size();
+  std::lock_guard<std::mutex> lock(mutex_);
+  return table_.size();
 }
 
 void HandleTable::clear() {
-    std::lock_guard<std::mutex> lock(mutex_);
-    table_.clear();
+  std::lock_guard<std::mutex> lock(mutex_);
+  table_.clear();
 }

--- a/lib/MemoryManager/handle_table.h
+++ b/lib/MemoryManager/handle_table.h
@@ -1,16 +1,6 @@
 /*
  * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Licensed under the MIT License.
- *
- * handle_table.h — Internal thread-safe handle-to-metadata map.
- *
- * NOT part of the public API. Used only by mm_core.cpp.
- *
- * Design:
- *   - Monotonically increasing 64-bit handles (0 = invalid, never reused).
- *   - Single std::mutex for simplicity. The critical section is O(1) map
- *     ops, so contention is negligible at typical allocation rates.
- *   - Detects double-free: remove() returns false if handle not found.
  */
 
 #ifndef MM_HANDLE_TABLE_H
@@ -22,34 +12,33 @@
 
 class HandleTable {
 public:
-    /** Insert a new allocation record. Returns the assigned handle. */
-    mm_handle_t insert(void* ptr, size_t size, mm_class_t mem_class,
-                       mm_lifetime_t lifetime, mm_device_t device);
+  /** Insert a new allocation record. Returns the assigned handle. */
+  mm_handle_t insert(void *ptr, size_t size, mm_class_t mem_class,
+                     mm_lifetime_t lifetime, mm_device_t device);
 
-    /** Look up by handle. Returns true and fills *info if found. */
-    bool lookup(mm_handle_t handle, mm_alloc_info_t* info) const;
+  /** Look up by handle. Returns true and fills *info if found. */
+  bool lookup(mm_handle_t handle, mm_alloc_info_t *info) const;
 
-    /** Remove by handle. Returns true if found, false on double-free. */
-    bool remove(mm_handle_t handle);
+  /** Remove by handle. Returns true if found, false on double-free. */
+  bool remove(mm_handle_t handle);
 
-    /** Number of active allocations. */
-    size_t size() const;
+  /** Number of active allocations. */
+  size_t size() const;
 
-    /** Iterate all active allocations. Holds the lock for the duration. */
-    template<typename Fn>
-    void for_each(Fn&& fn) const {
-        std::lock_guard<std::mutex> lock(mutex_);
-        for (const auto& kv : table_)
-            fn(kv.second);
-    }
+  /** Iterate all active allocations. Holds the lock for the duration. */
+  template <typename Fn> void for_each(Fn &&fn) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (const auto &kv : table_)
+      fn(kv.second);
+  }
 
-    /** Remove all entries (used by mm_shutdown). */
-    void clear();
+  /** Remove all entries (used by mm_shutdown). */
+  void clear();
 
 private:
-    mutable std::mutex mutex_;
-    std::unordered_map<mm_handle_t, mm_alloc_info_t> table_;
-    uint64_t next_handle_ = 1;
+  mutable std::mutex mutex_;
+  std::unordered_map<mm_handle_t, mm_alloc_info_t> table_;
+  uint64_t next_handle_ = 1;
 };
 
 #endif /* MM_HANDLE_TABLE_H */

--- a/lib/MemoryManager/mm_core.cpp
+++ b/lib/MemoryManager/mm_core.cpp
@@ -1,275 +1,278 @@
 /*
  * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Licensed under the MIT License.
- *
- * mm_core.cpp — Core UMM implementation.
- *
- * Owns the global memory manager state: HAL vtable pointer, handle table,
- * configuration, and atomic metric counters. All public mm_* functions are
- * implemented here.
  */
 
+#include "handle_table.h"
 #include "mm/mm_api.h"
 #include "mm/mm_hal.h"
-#include "handle_table.h"
 
 #include <atomic>
 #include <cstdio>
 #include <cstring>
 
-static const char* class_name(mm_class_t c) {
-    switch (c) {
-    case MM_CLASS_GENERIC:    return "GENERIC";
-    case MM_CLASS_WEIGHT:     return "WEIGHT";
-    case MM_CLASS_ACTIVATION: return "ACTIVATION";
-    case MM_CLASS_KV_CACHE:   return "KV_CACHE";
-    case MM_CLASS_SCRATCH:    return "SCRATCH";
-    default:                  return "UNKNOWN";
-    }
+static const char *class_name(mm_class_t c) {
+  switch (c) {
+  case MM_CLASS_GENERIC:
+    return "GENERIC";
+  case MM_CLASS_WEIGHT:
+    return "WEIGHT";
+  case MM_CLASS_ACTIVATION:
+    return "ACTIVATION";
+  case MM_CLASS_KV_CACHE:
+    return "KV_CACHE";
+  case MM_CLASS_SCRATCH:
+    return "SCRATCH";
+  default:
+    return "UNKNOWN";
+  }
 }
 
-static const char* lifetime_name(mm_lifetime_t l) {
-    switch (l) {
-    case MM_LIFETIME_STATIC:    return "STATIC";
-    case MM_LIFETIME_REQUEST:   return "REQUEST";
-    case MM_LIFETIME_STEP:      return "STEP";
-    case MM_LIFETIME_TRANSIENT: return "TRANSIENT";
-    default:                    return "UNKNOWN";
-    }
+static const char *lifetime_name(mm_lifetime_t l) {
+  switch (l) {
+  case MM_LIFETIME_STATIC:
+    return "STATIC";
+  case MM_LIFETIME_REQUEST:
+    return "REQUEST";
+  case MM_LIFETIME_STEP:
+    return "STEP";
+  case MM_LIFETIME_TRANSIENT:
+    return "TRANSIENT";
+  default:
+    return "UNKNOWN";
+  }
 }
 
 /* Global state — file-scoped, not exported. */
 static struct {
-    const mm_hal_t*       hal;
-    HandleTable           handles;
-    mm_config_t           config;
-    bool                  initialized;
+  const mm_hal_t *hal;
+  HandleTable handles;
+  mm_config_t config;
+  bool initialized;
 
-    std::atomic<size_t>   total_allocated_bytes{0};
-    std::atomic<size_t>   peak_allocated_bytes{0};
-    std::atomic<uint64_t> alloc_count{0};
-    std::atomic<uint64_t> free_count{0};
+  std::atomic<size_t> total_allocated_bytes{0};
+  std::atomic<size_t> peak_allocated_bytes{0};
+  std::atomic<uint64_t> alloc_count{0};
+  std::atomic<uint64_t> free_count{0};
 } g_mm;
 
 static size_t align_up(size_t value, size_t alignment) {
-    return (value + alignment - 1) & ~(alignment - 1);
+  return (value + alignment - 1) & ~(alignment - 1);
 }
 
 static void update_peak() {
-    size_t current = g_mm.total_allocated_bytes.load(std::memory_order_relaxed);
-    size_t peak = g_mm.peak_allocated_bytes.load(std::memory_order_relaxed);
-    while (current > peak) {
-        if (g_mm.peak_allocated_bytes.compare_exchange_weak(
-                peak, current, std::memory_order_relaxed))
-            break;
-    }
+  size_t current = g_mm.total_allocated_bytes.load(std::memory_order_relaxed);
+  size_t peak = g_mm.peak_allocated_bytes.load(std::memory_order_relaxed);
+  while (current > peak) {
+    if (g_mm.peak_allocated_bytes.compare_exchange_weak(
+            peak, current, std::memory_order_relaxed))
+      break;
+  }
 }
 
 /* ============================= Lifecycle ================================= */
 
-mm_status_t mm_init(const mm_config_t* config) {
-    if (g_mm.initialized)
-        return MM_ERR_ALREADY_INIT;
+mm_status_t mm_init(const mm_config_t *config) {
+  if (g_mm.initialized)
+    return MM_ERR_ALREADY_INIT;
 
-    if (config)
-        g_mm.config = *config;
-    else
-        g_mm.config = mm_config_default();
+  if (config)
+    g_mm.config = *config;
+  else
+    g_mm.config = mm_config_default();
 
 #ifdef MM_USE_MOCK_HAL
-    g_mm.hal = mm_hal_mock();
+  g_mm.hal = mm_hal_mock();
 #else
-    g_mm.hal = mm_hal_rocm();
+  g_mm.hal = mm_hal_rocm();
 #endif
 
-    mm_status_t st = g_mm.hal->set_device(g_mm.config.device_id);
-    if (st != MM_OK)
-        return st;
+  mm_status_t st = g_mm.hal->set_device(g_mm.config.device_id);
+  if (st != MM_OK)
+    return st;
 
-    g_mm.total_allocated_bytes.store(0, std::memory_order_relaxed);
-    g_mm.peak_allocated_bytes.store(0, std::memory_order_relaxed);
-    g_mm.alloc_count.store(0, std::memory_order_relaxed);
-    g_mm.free_count.store(0, std::memory_order_relaxed);
+  g_mm.total_allocated_bytes.store(0, std::memory_order_relaxed);
+  g_mm.peak_allocated_bytes.store(0, std::memory_order_relaxed);
+  g_mm.alloc_count.store(0, std::memory_order_relaxed);
+  g_mm.free_count.store(0, std::memory_order_relaxed);
 
-    g_mm.initialized = true;
+  g_mm.initialized = true;
 
-    if (g_mm.config.enable_debug_log)
-        fprintf(stderr, "[UMM] initialized (device=%d, alignment=%zu)\n",
-                g_mm.config.device_id, g_mm.config.default_alignment);
+  if (g_mm.config.enable_debug_log)
+    fprintf(stderr, "[UMM] initialized (device=%d, alignment=%zu)\n",
+            g_mm.config.device_id, g_mm.config.default_alignment);
 
-    return MM_OK;
+  return MM_OK;
 }
 
 void mm_shutdown(void) {
-    if (!g_mm.initialized)
-        return;
+  if (!g_mm.initialized)
+    return;
 
-    size_t leaked = g_mm.handles.size();
-    if (leaked > 0) {
-        if (g_mm.config.enable_debug_log)
-            fprintf(stderr, "[UMM] shutdown: freeing %zu leaked allocation(s)\n",
-                    leaked);
+  size_t leaked = g_mm.handles.size();
+  if (leaked > 0) {
+    if (g_mm.config.enable_debug_log)
+      fprintf(stderr, "[UMM] shutdown: freeing %zu leaked allocation(s)\n",
+              leaked);
 
-        g_mm.handles.for_each([](const mm_alloc_info_t& info) {
-            if (g_mm.config.enable_debug_log)
-                fprintf(stderr, "[UMM]   leaked: handle=%llu ptr=%p size=%zu class=%s\n",
-                        (unsigned long long)info.handle, info.ptr, info.size,
-                        class_name(info.mem_class));
-            g_mm.hal->free(info.ptr);
-        });
-    }
+    g_mm.handles.for_each([](const mm_alloc_info_t &info) {
+      if (g_mm.config.enable_debug_log)
+        fprintf(stderr,
+                "[UMM]   leaked: handle=%llu ptr=%p size=%zu class=%s\n",
+                (unsigned long long)info.handle, info.ptr, info.size,
+                class_name(info.mem_class));
+      g_mm.hal->free(info.ptr);
+    });
+  }
 
-    g_mm.handles.clear();
-    g_mm.total_allocated_bytes.store(0, std::memory_order_relaxed);
-    g_mm.peak_allocated_bytes.store(0, std::memory_order_relaxed);
-    g_mm.alloc_count.store(0, std::memory_order_relaxed);
-    g_mm.free_count.store(0, std::memory_order_relaxed);
-    g_mm.hal = nullptr;
-    g_mm.initialized = false;
+  g_mm.handles.clear();
+  g_mm.total_allocated_bytes.store(0, std::memory_order_relaxed);
+  g_mm.peak_allocated_bytes.store(0, std::memory_order_relaxed);
+  g_mm.alloc_count.store(0, std::memory_order_relaxed);
+  g_mm.free_count.store(0, std::memory_order_relaxed);
+  g_mm.hal = nullptr;
+  g_mm.initialized = false;
 }
 
-int mm_is_initialized(void) {
-    return g_mm.initialized ? 1 : 0;
-}
+int mm_is_initialized(void) { return g_mm.initialized ? 1 : 0; }
 
 /* ============================ Allocation ================================= */
 
-mm_handle_t mm_alloc(size_t size, const mm_alloc_hints_t* hints,
+mm_handle_t mm_alloc(size_t size, const mm_alloc_hints_t *hints,
                      mm_stream_t /*stream*/) {
-    if (!g_mm.initialized)
-        return MM_HANDLE_INVALID;
-    if (size == 0)
-        return MM_HANDLE_INVALID;
+  if (!g_mm.initialized)
+    return MM_HANDLE_INVALID;
+  if (size == 0)
+    return MM_HANDLE_INVALID;
 
-    mm_class_t    mem_class = MM_CLASS_GENERIC;
-    mm_lifetime_t lifetime  = MM_LIFETIME_TRANSIENT;
-    size_t        alignment = g_mm.config.default_alignment;
+  mm_class_t mem_class = MM_CLASS_GENERIC;
+  mm_lifetime_t lifetime = MM_LIFETIME_TRANSIENT;
+  size_t alignment = g_mm.config.default_alignment;
 
-    if (hints) {
-        mem_class = hints->mem_class;
-        lifetime  = hints->lifetime;
-        if (hints->alignment > 0)
-            alignment = hints->alignment;
-    }
+  if (hints) {
+    mem_class = hints->mem_class;
+    lifetime = hints->lifetime;
+    if (hints->alignment > 0)
+      alignment = hints->alignment;
+  }
 
-    size_t aligned_size = align_up(size, alignment);
+  size_t aligned_size = align_up(size, alignment);
 
-    void* ptr = nullptr;
-    mm_status_t st = g_mm.hal->malloc(&ptr, aligned_size);
-    if (st != MM_OK || !ptr)
-        return MM_HANDLE_INVALID;
+  void *ptr = nullptr;
+  mm_status_t st = g_mm.hal->malloc(&ptr, aligned_size);
+  if (st != MM_OK || !ptr)
+    return MM_HANDLE_INVALID;
 
-    mm_handle_t handle = g_mm.handles.insert(
-        ptr, aligned_size, mem_class, lifetime, g_mm.config.device_id);
+  mm_handle_t handle = g_mm.handles.insert(ptr, aligned_size, mem_class,
+                                           lifetime, g_mm.config.device_id);
 
-    g_mm.total_allocated_bytes.fetch_add(aligned_size, std::memory_order_relaxed);
-    g_mm.alloc_count.fetch_add(1, std::memory_order_relaxed);
-    update_peak();
+  g_mm.total_allocated_bytes.fetch_add(aligned_size, std::memory_order_relaxed);
+  g_mm.alloc_count.fetch_add(1, std::memory_order_relaxed);
+  update_peak();
 
-    if (g_mm.config.enable_debug_log)
-        fprintf(stderr, "[UMM] alloc: handle=%llu size=%zu (aligned=%zu) class=%s\n",
-                (unsigned long long)handle, size, aligned_size,
-                class_name(mem_class));
+  if (g_mm.config.enable_debug_log)
+    fprintf(
+        stderr, "[UMM] alloc: handle=%llu size=%zu (aligned=%zu) class=%s\n",
+        (unsigned long long)handle, size, aligned_size, class_name(mem_class));
 
-    return handle;
+  return handle;
 }
 
 mm_status_t mm_free(mm_handle_t handle, mm_stream_t /*stream*/) {
-    if (!g_mm.initialized)
-        return MM_ERR_NOT_INITIALIZED;
-    if (handle == MM_HANDLE_INVALID)
-        return MM_ERR_INVALID_HANDLE;
+  if (!g_mm.initialized)
+    return MM_ERR_NOT_INITIALIZED;
+  if (handle == MM_HANDLE_INVALID)
+    return MM_ERR_INVALID_HANDLE;
 
-    mm_alloc_info_t info;
-    if (!g_mm.handles.lookup(handle, &info))
-        return MM_ERR_INVALID_HANDLE;
+  mm_alloc_info_t info;
+  if (!g_mm.handles.lookup(handle, &info))
+    return MM_ERR_INVALID_HANDLE;
 
-    if (!g_mm.handles.remove(handle))
-        return MM_ERR_DOUBLE_FREE;
+  if (!g_mm.handles.remove(handle))
+    return MM_ERR_DOUBLE_FREE;
 
-    g_mm.hal->free(info.ptr);
-    g_mm.total_allocated_bytes.fetch_sub(info.size, std::memory_order_relaxed);
-    g_mm.free_count.fetch_add(1, std::memory_order_relaxed);
+  g_mm.hal->free(info.ptr);
+  g_mm.total_allocated_bytes.fetch_sub(info.size, std::memory_order_relaxed);
+  g_mm.free_count.fetch_add(1, std::memory_order_relaxed);
 
-    if (g_mm.config.enable_debug_log)
-        fprintf(stderr, "[UMM] free: handle=%llu size=%zu class=%s\n",
-                (unsigned long long)handle, info.size,
-                class_name(info.mem_class));
+  if (g_mm.config.enable_debug_log)
+    fprintf(stderr, "[UMM] free: handle=%llu size=%zu class=%s\n",
+            (unsigned long long)handle, info.size, class_name(info.mem_class));
 
-    return MM_OK;
+  return MM_OK;
 }
 
-void* mm_get_ptr(mm_handle_t handle) {
-    if (!g_mm.initialized)
-        return nullptr;
+void *mm_get_ptr(mm_handle_t handle) {
+  if (!g_mm.initialized)
+    return nullptr;
 
-    mm_alloc_info_t info;
-    if (!g_mm.handles.lookup(handle, &info))
-        return nullptr;
-    return info.ptr;
+  mm_alloc_info_t info;
+  if (!g_mm.handles.lookup(handle, &info))
+    return nullptr;
+  return info.ptr;
 }
 
-mm_status_t mm_query(mm_handle_t handle, mm_alloc_info_t* info) {
-    if (!g_mm.initialized)
-        return MM_ERR_NOT_INITIALIZED;
-    if (!info)
-        return MM_ERR_INVALID_ARGUMENT;
+mm_status_t mm_query(mm_handle_t handle, mm_alloc_info_t *info) {
+  if (!g_mm.initialized)
+    return MM_ERR_NOT_INITIALIZED;
+  if (!info)
+    return MM_ERR_INVALID_ARGUMENT;
 
-    if (!g_mm.handles.lookup(handle, info))
-        return MM_ERR_INVALID_HANDLE;
-    return MM_OK;
+  if (!g_mm.handles.lookup(handle, info))
+    return MM_ERR_INVALID_HANDLE;
+  return MM_OK;
 }
 
 /* ============================ Diagnostics ================================ */
 
-void mm_dump_state(FILE* output) {
-    if (!output)
-        return;
+void mm_dump_state(FILE *output) {
+  if (!output)
+    return;
 
-    mm_metrics_snapshot_t m = mm_metrics_snapshot();
+  mm_metrics_snapshot_t m = mm_metrics_snapshot();
 
+  fprintf(output,
+          "=== UMM State Dump ===\n"
+          "  Initialized:  %s\n"
+          "  Active allocs: %llu\n"
+          "  Total bytes:   %zu\n"
+          "  Peak bytes:    %zu\n"
+          "  Alloc count:   %llu\n"
+          "  Free count:    %llu\n"
+          "  ---\n",
+          g_mm.initialized ? "yes" : "no", (unsigned long long)m.active_count,
+          m.total_allocated_bytes, m.peak_allocated_bytes,
+          (unsigned long long)m.alloc_count, (unsigned long long)m.free_count);
+
+  if (!g_mm.initialized)
+    return;
+
+  g_mm.handles.for_each([output](const mm_alloc_info_t &info) {
     fprintf(output,
-            "=== UMM State Dump ===\n"
-            "  Initialized:  %s\n"
-            "  Active allocs: %llu\n"
-            "  Total bytes:   %zu\n"
-            "  Peak bytes:    %zu\n"
-            "  Alloc count:   %llu\n"
-            "  Free count:    %llu\n"
-            "  ---\n",
-            g_mm.initialized ? "yes" : "no",
-            (unsigned long long)m.active_count,
-            m.total_allocated_bytes,
-            m.peak_allocated_bytes,
-            (unsigned long long)m.alloc_count,
-            (unsigned long long)m.free_count);
+            "  handle=%llu ptr=%p size=%zu class=%s lifetime=%s device=%d\n",
+            (unsigned long long)info.handle, info.ptr, info.size,
+            class_name(info.mem_class), lifetime_name(info.lifetime),
+            info.device);
+  });
 
-    if (!g_mm.initialized)
-        return;
-
-    g_mm.handles.for_each([output](const mm_alloc_info_t& info) {
-        fprintf(output, "  handle=%llu ptr=%p size=%zu class=%s lifetime=%s device=%d\n",
-                (unsigned long long)info.handle, info.ptr, info.size,
-                class_name(info.mem_class), lifetime_name(info.lifetime),
-                info.device);
-    });
-
-    fprintf(output, "======================\n");
+  fprintf(output, "======================\n");
 }
 
 /* ============================== Metrics ================================== */
 
 mm_metrics_snapshot_t mm_metrics_snapshot(void) {
-    mm_metrics_snapshot_t snap;
-    snap.total_allocated_bytes = g_mm.total_allocated_bytes.load(std::memory_order_relaxed);
-    snap.peak_allocated_bytes  = g_mm.peak_allocated_bytes.load(std::memory_order_relaxed);
-    snap.alloc_count           = g_mm.alloc_count.load(std::memory_order_relaxed);
-    snap.free_count            = g_mm.free_count.load(std::memory_order_relaxed);
-    snap.active_count          = snap.alloc_count - snap.free_count;
-    return snap;
+  mm_metrics_snapshot_t snap;
+  snap.total_allocated_bytes =
+      g_mm.total_allocated_bytes.load(std::memory_order_relaxed);
+  snap.peak_allocated_bytes =
+      g_mm.peak_allocated_bytes.load(std::memory_order_relaxed);
+  snap.alloc_count = g_mm.alloc_count.load(std::memory_order_relaxed);
+  snap.free_count = g_mm.free_count.load(std::memory_order_relaxed);
+  snap.active_count = snap.alloc_count - snap.free_count;
+  return snap;
 }
 
 void mm_metrics_reset(void) {
-    g_mm.alloc_count.store(0, std::memory_order_relaxed);
-    g_mm.free_count.store(0, std::memory_order_relaxed);
+  g_mm.alloc_count.store(0, std::memory_order_relaxed);
+  g_mm.free_count.store(0, std::memory_order_relaxed);
 }

--- a/lib/MemoryManager/mm_error.cpp
+++ b/lib/MemoryManager/mm_error.cpp
@@ -5,16 +5,25 @@
 
 #include "mm/mm_error.h"
 
-const char* mm_status_string(mm_status_t status) {
-    switch (status) {
-    case MM_OK:                  return "ok";
-    case MM_ERR_NOT_INITIALIZED: return "not initialized";
-    case MM_ERR_ALREADY_INIT:    return "already initialized";
-    case MM_ERR_INVALID_HANDLE:  return "invalid handle";
-    case MM_ERR_OUT_OF_MEMORY:   return "out of memory";
-    case MM_ERR_INVALID_ARGUMENT:return "invalid argument";
-    case MM_ERR_HAL_FAILURE:     return "HAL failure";
-    case MM_ERR_DOUBLE_FREE:     return "double free";
-    default:                     return "unknown error";
-    }
+const char *mm_status_string(mm_status_t status) {
+  switch (status) {
+  case MM_OK:
+    return "ok";
+  case MM_ERR_NOT_INITIALIZED:
+    return "not initialized";
+  case MM_ERR_ALREADY_INIT:
+    return "already initialized";
+  case MM_ERR_INVALID_HANDLE:
+    return "invalid handle";
+  case MM_ERR_OUT_OF_MEMORY:
+    return "out of memory";
+  case MM_ERR_INVALID_ARGUMENT:
+    return "invalid argument";
+  case MM_ERR_HAL_FAILURE:
+    return "HAL failure";
+  case MM_ERR_DOUBLE_FREE:
+    return "double free";
+  default:
+    return "unknown error";
+  }
 }

--- a/lib/MemoryManager/mm_pool.cpp
+++ b/lib/MemoryManager/mm_pool.cpp
@@ -1,8 +1,6 @@
 /*
  * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Licensed under the MIT License.
- *
- * mm_pool.cpp — Static Pool allocator implementation.
  */
 
 #include "mm/mm_pool.h"
@@ -11,81 +9,77 @@
 #include <cstring>
 
 struct mm_pool_s {
-    void*       base;
-    size_t      total_size;
-    size_t*     offsets;
-    uint32_t    num_entries;
-    mm_handle_t handle;
+  void *base;
+  size_t total_size;
+  size_t *offsets;
+  uint32_t num_entries;
+  mm_handle_t handle;
 };
 
-mm_pool_t mm_pool_create(const mm_static_plan_t* plan) {
-    if (!plan || plan->total_size == 0)
-        return nullptr;
+mm_pool_t mm_pool_create(const mm_static_plan_t *plan) {
+  if (!plan || plan->total_size == 0)
+    return nullptr;
 
-    mm_alloc_hints_t hints;
-    hints.mem_class = MM_CLASS_WEIGHT;
-    hints.lifetime  = MM_LIFETIME_STATIC;
-    hints.alignment = 0;
+  mm_alloc_hints_t hints;
+  hints.mem_class = MM_CLASS_WEIGHT;
+  hints.lifetime = MM_LIFETIME_STATIC;
+  hints.alignment = 0;
 
-    mm_handle_t h = mm_alloc(plan->total_size, &hints, nullptr);
-    if (h == MM_HANDLE_INVALID)
-        return nullptr;
+  mm_handle_t h = mm_alloc(plan->total_size, &hints, nullptr);
+  if (h == MM_HANDLE_INVALID)
+    return nullptr;
 
-    void* base = mm_get_ptr(h);
-    if (!base) {
-        mm_free(h, nullptr);
-        return nullptr;
+  void *base = mm_get_ptr(h);
+  if (!base) {
+    mm_free(h, nullptr);
+    return nullptr;
+  }
+
+  auto *pool = static_cast<mm_pool_s *>(std::malloc(sizeof(mm_pool_s)));
+  if (!pool) {
+    mm_free(h, nullptr);
+    return nullptr;
+  }
+
+  pool->base = base;
+  pool->total_size = plan->total_size;
+  pool->handle = h;
+  pool->num_entries = plan->num_entries;
+  pool->offsets = nullptr;
+
+  if (plan->num_entries > 0 && plan->offsets) {
+    size_t offsets_bytes = sizeof(size_t) * plan->num_entries;
+    pool->offsets = static_cast<size_t *>(std::malloc(offsets_bytes));
+    if (!pool->offsets) {
+      mm_free(h, nullptr);
+      std::free(pool);
+      return nullptr;
     }
+    std::memcpy(pool->offsets, plan->offsets, offsets_bytes);
+  }
 
-    auto* pool = static_cast<mm_pool_s*>(std::malloc(sizeof(mm_pool_s)));
-    if (!pool) {
-        mm_free(h, nullptr);
-        return nullptr;
-    }
-
-    pool->base       = base;
-    pool->total_size  = plan->total_size;
-    pool->handle      = h;
-    pool->num_entries = plan->num_entries;
-    pool->offsets     = nullptr;
-
-    if (plan->num_entries > 0 && plan->offsets) {
-        size_t offsets_bytes = sizeof(size_t) * plan->num_entries;
-        pool->offsets = static_cast<size_t*>(std::malloc(offsets_bytes));
-        if (!pool->offsets) {
-            mm_free(h, nullptr);
-            std::free(pool);
-            return nullptr;
-        }
-        std::memcpy(pool->offsets, plan->offsets, offsets_bytes);
-    }
-
-    return pool;
+  return pool;
 }
 
-void* mm_pool_get_ptr(mm_pool_t pool, uint32_t index) {
-    if (!pool || index >= pool->num_entries)
-        return nullptr;
-    return static_cast<char*>(pool->base) + pool->offsets[index];
+void *mm_pool_get_ptr(mm_pool_t pool, uint32_t index) {
+  if (!pool || index >= pool->num_entries)
+    return nullptr;
+  return static_cast<char *>(pool->base) + pool->offsets[index];
 }
 
-void* mm_pool_get_base(mm_pool_t pool) {
-    return pool ? pool->base : nullptr;
-}
+void *mm_pool_get_base(mm_pool_t pool) { return pool ? pool->base : nullptr; }
 
-size_t mm_pool_get_size(mm_pool_t pool) {
-    return pool ? pool->total_size : 0;
-}
+size_t mm_pool_get_size(mm_pool_t pool) { return pool ? pool->total_size : 0; }
 
 uint32_t mm_pool_get_num_entries(mm_pool_t pool) {
-    return pool ? pool->num_entries : 0;
+  return pool ? pool->num_entries : 0;
 }
 
 void mm_pool_destroy(mm_pool_t pool) {
-    if (!pool)
-        return;
-    if (pool->handle != MM_HANDLE_INVALID)
-        mm_free(pool->handle, nullptr);
-    std::free(pool->offsets);
-    std::free(pool);
+  if (!pool)
+    return;
+  if (pool->handle != MM_HANDLE_INVALID)
+    mm_free(pool->handle, nullptr);
+  std::free(pool->offsets);
+  std::free(pool);
 }

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -416,13 +416,12 @@ int hipdnn_ep_state_init_with_fs(RuntimeState **out_state, void *fs,
       {
         mm_alloc_hints_t mm_hints;
         mm_hints.mem_class = MM_CLASS_WEIGHT;
-        mm_hints.lifetime  = MM_LIFETIME_STATIC;
+        mm_hints.lifetime = MM_LIFETIME_STATIC;
         mm_hints.alignment = 0;
         state->mm_constants_handle =
             (uint64_t)mm_alloc(total_size, &mm_hints, nullptr);
         if (state->mm_constants_handle == 0) {
-          fprintf(stderr,
-                  "mm_alloc failed for constants blob (%zu bytes)\n",
+          fprintf(stderr, "mm_alloc failed for constants blob (%zu bytes)\n",
                   total_size);
           free(cpu_buf);
           hipdnn_ep_state_cleanup(state);
@@ -633,8 +632,8 @@ int hipdnn_ep_pool_init(RuntimeState *state, size_t pool_size,
 
   // Use UMM static pool: single allocation + offset table
   mm_static_plan_t plan;
-  plan.total_size  = pool_size;
-  plan.offsets     = buffer_offsets;
+  plan.total_size = pool_size;
+  plan.offsets = buffer_offsets;
   plan.num_entries = (uint32_t)num_buffers;
 
   mm_pool_t pool = mm_pool_create(&plan);
@@ -718,7 +717,7 @@ int hipdnn_ep_state_ensure_workspace(RuntimeState *state, size_t needed_size) {
 
   mm_alloc_hints_t hints;
   hints.mem_class = MM_CLASS_SCRATCH;
-  hints.lifetime  = MM_LIFETIME_REQUEST;
+  hints.lifetime = MM_LIFETIME_REQUEST;
   hints.alignment = 0;
 
   mm_handle_t h = mm_alloc(needed_size, &hints, nullptr);

--- a/lib/Runtime/runtime_state_internal.h
+++ b/lib/Runtime/runtime_state_internal.h
@@ -67,9 +67,9 @@ struct RuntimeState {
   // These fields use plain C types (uint64_t/void*) instead of mm_handle_t/
   // mm_pool_t to avoid including UMM headers in bitcode-compiled code.
   // The values are numerically identical to the UMM types.
-  void *mm_pool_opaque;          // mm_pool_t for the activation buffer pool
-  uint64_t mm_constants_handle;  // mm_handle_t for constants blob (VRAM path)
-  uint64_t mm_workspace_handle;  // mm_handle_t for workspace
+  void *mm_pool_opaque;         // mm_pool_t for the activation buffer pool
+  uint64_t mm_constants_handle; // mm_handle_t for constants blob (VRAM path)
+  uint64_t mm_workspace_handle; // mm_handle_t for workspace
 };
 
 #endif // HIPDNN_EP_RUNTIME_STATE_INTERNAL_H

--- a/lib/Runtime/vulkan/matmul_nbits.cpp
+++ b/lib/Runtime/vulkan/matmul_nbits.cpp
@@ -1,10 +1,6 @@
 /*
  * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Licensed under the MIT License.
- *
- * Vulkan runtime wrapper for MatMulNBits.
- * Drop-in replacement for lib/Runtime/real/matmul_nbits.cpp — same signature,
- * dispatches to Vulkan compute shader via GPU-pointer mode (zero-copy on UMA).
  */
 
 #include "../hipdnn_ep_runtime.h"
@@ -18,19 +14,18 @@ int wrap_matmul_nbits(RuntimeState *state, const void *A, const void *B,
                       int64_t M, int64_t N, int64_t K, int64_t batch_count,
                       int64_t bits, int64_t block_size, int64_t elem_size) {
 
-    if (!A || !B || !scales || !output) {
-        fprintf(stderr, "wrap_matmul_nbits[vulkan]: null argument\n");
-        return -1;
-    }
+  if (!A || !B || !scales || !output) {
+    fprintf(stderr, "wrap_matmul_nbits[vulkan]: null argument\n");
+    return -1;
+  }
 
-    if (g_idx) {
-        fprintf(stderr, "wrap_matmul_nbits[vulkan]: g_idx not supported\n");
-        return -1;
-    }
+  if (g_idx) {
+    fprintf(stderr, "wrap_matmul_nbits[vulkan]: g_idx not supported\n");
+    return -1;
+  }
 
-    // In the EP flow, all pointers are GPU-resident (from hipMalloc/pool).
-    // Use the zero-copy GPU-pointer mode for optimal performance.
-    return vulkan_matmul_nbits_gpu(A, B, scales, zero_points, bias, output,
-                                   M, N, K, batch_count, bits, block_size,
-                                   elem_size);
+  // In the EP flow, all pointers are GPU-resident (from hipMalloc/pool).
+  // Use the zero-copy GPU-pointer mode for optimal performance.
+  return vulkan_matmul_nbits_gpu(A, B, scales, zero_points, bias, output, M, N,
+                                 K, batch_count, bits, block_size, elem_size);
 }

--- a/test/mm/test_hal_mock.cpp
+++ b/test/mm/test_hal_mock.cpp
@@ -1,8 +1,6 @@
 /*
  * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Licensed under the MIT License.
- *
- * test_hal_mock — Exercise every function in the mock HAL vtable.
  */
 
 #include "mm/mm_hal.h"
@@ -10,60 +8,70 @@
 #include <cstdio>
 #include <cstring>
 
-#define ASSERT_OK(expr) do { mm_status_t s_ = (expr); assert(s_ == MM_OK); (void)s_; } while(0)
-#define ASSERT_ERR(expr, code) do { mm_status_t s_ = (expr); assert(s_ == (code)); (void)s_; } while(0)
+#define ASSERT_OK(expr)                                                        \
+  do {                                                                         \
+    mm_status_t s_ = (expr);                                                   \
+    assert(s_ == MM_OK);                                                       \
+    (void)s_;                                                                  \
+  } while (0)
+#define ASSERT_ERR(expr, code)                                                 \
+  do {                                                                         \
+    mm_status_t s_ = (expr);                                                   \
+    assert(s_ == (code));                                                      \
+    (void)s_;                                                                  \
+  } while (0)
 
 int main() {
-    const mm_hal_t* hal = mm_hal_mock();
-    assert(hal != nullptr);
+  const mm_hal_t *hal = mm_hal_mock();
+  assert(hal != nullptr);
 
-    /* malloc / free */
-    void* ptr = nullptr;
-    ASSERT_OK(hal->malloc(&ptr, 1024));
-    assert(ptr != nullptr);
-    ASSERT_OK(hal->free(ptr));
+  /* malloc / free */
+  void *ptr = nullptr;
+  ASSERT_OK(hal->malloc(&ptr, 1024));
+  assert(ptr != nullptr);
+  ASSERT_OK(hal->free(ptr));
 
-    /* malloc zero size => error */
-    void* bad = nullptr;
-    ASSERT_ERR(hal->malloc(&bad, 0), MM_ERR_INVALID_ARGUMENT);
+  /* malloc zero size => error */
+  void *bad = nullptr;
+  ASSERT_ERR(hal->malloc(&bad, 0), MM_ERR_INVALID_ARGUMENT);
 
-    /* memcpy round-trip */
-    void* gpu = nullptr;
-    ASSERT_OK(hal->malloc(&gpu, 256));
+  /* memcpy round-trip */
+  void *gpu = nullptr;
+  ASSERT_OK(hal->malloc(&gpu, 256));
 
-    unsigned char src[256];
-    for (int i = 0; i < 256; i++)
-        src[i] = (unsigned char)i;
+  unsigned char src[256];
+  for (int i = 0; i < 256; i++)
+    src[i] = (unsigned char)i;
 
-    ASSERT_OK(hal->memcpy_h2d(gpu, src, 256, nullptr));
+  ASSERT_OK(hal->memcpy_h2d(gpu, src, 256, nullptr));
 
-    unsigned char dst[256] = {};
-    ASSERT_OK(hal->memcpy_d2h(dst, gpu, 256, nullptr));
-    assert(memcmp(src, dst, 256) == 0);
+  unsigned char dst[256] = {};
+  ASSERT_OK(hal->memcpy_d2h(dst, gpu, 256, nullptr));
+  assert(memcmp(src, dst, 256) == 0);
 
-    /* memset */
-    ASSERT_OK(hal->memset(gpu, 0xAB, 256, nullptr));
-    unsigned char check[256] = {};
-    ASSERT_OK(hal->memcpy_d2h(check, gpu, 256, nullptr));
-    for (int i = 0; i < 256; i++)
-        assert(check[i] == 0xAB);
+  /* memset */
+  ASSERT_OK(hal->memset(gpu, 0xAB, 256, nullptr));
+  unsigned char check[256] = {};
+  ASSERT_OK(hal->memcpy_d2h(check, gpu, 256, nullptr));
+  for (int i = 0; i < 256; i++)
+    assert(check[i] == 0xAB);
 
-    ASSERT_OK(hal->free(gpu));
+  ASSERT_OK(hal->free(gpu));
 
-    /* stream create / sync / destroy */
-    mm_stream_t stream = nullptr;
-    ASSERT_OK(hal->stream_create(&stream));
-    assert(stream != nullptr);
-    ASSERT_OK(hal->stream_sync(stream));
-    ASSERT_OK(hal->stream_destroy(stream));
+  /* stream create / sync / destroy */
+  mm_stream_t stream = nullptr;
+  ASSERT_OK(hal->stream_create(&stream));
+  assert(stream != nullptr);
+  ASSERT_OK(hal->stream_sync(stream));
+  ASSERT_OK(hal->stream_destroy(stream));
 
-    /* device queries */
-    size_t free_bytes = 0, total_bytes = 0;
-    ASSERT_OK(hal->get_free_mem(&free_bytes, &total_bytes));
-    assert(total_bytes > 0);
+  /* device queries */
+  size_t free_bytes = 0, total_bytes = 0;
+  ASSERT_OK(hal->get_free_mem(&free_bytes, &total_bytes));
+  assert(total_bytes > 0);
 
-    ASSERT_OK(hal->set_device(0));
+  ASSERT_OK(hal->set_device(0));
 
-    printf("test_hal_mock: PASSED\n");
-    return 0;
+  printf("test_hal_mock: PASSED\n");
+  return 0;
 }

--- a/test/mm/test_handle_table.cpp
+++ b/test/mm/test_handle_table.cpp
@@ -1,8 +1,6 @@
 /*
  * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Licensed under the MIT License.
- *
- * test_handle_table — Correctness and concurrency tests for HandleTable.
  */
 
 #include "mm/mm_types.h"
@@ -17,104 +15,104 @@
 #include <vector>
 
 static void test_basic_ops() {
-    HandleTable table;
+  HandleTable table;
 
-    char dummy1, dummy2, dummy3;
+  char dummy1, dummy2, dummy3;
 
-    mm_handle_t h1 = table.insert(&dummy1, 100, MM_CLASS_GENERIC,
-                                  MM_LIFETIME_TRANSIENT, MM_DEVICE_GPU0);
-    mm_handle_t h2 = table.insert(&dummy2, 200, MM_CLASS_WEIGHT,
-                                  MM_LIFETIME_STATIC, MM_DEVICE_GPU0);
-    mm_handle_t h3 = table.insert(&dummy3, 300, MM_CLASS_ACTIVATION,
-                                  MM_LIFETIME_STEP, MM_DEVICE_GPU0);
+  mm_handle_t h1 = table.insert(&dummy1, 100, MM_CLASS_GENERIC,
+                                MM_LIFETIME_TRANSIENT, MM_DEVICE_GPU0);
+  mm_handle_t h2 = table.insert(&dummy2, 200, MM_CLASS_WEIGHT,
+                                MM_LIFETIME_STATIC, MM_DEVICE_GPU0);
+  mm_handle_t h3 = table.insert(&dummy3, 300, MM_CLASS_ACTIVATION,
+                                MM_LIFETIME_STEP, MM_DEVICE_GPU0);
 
-    assert(h1 != MM_HANDLE_INVALID);
-    assert(h2 != MM_HANDLE_INVALID);
-    assert(h3 != MM_HANDLE_INVALID);
-    assert(h1 != h2 && h2 != h3);
-    assert(h1 < h2 && h2 < h3); /* monotonically increasing */
-    assert(table.size() == 3);
+  assert(h1 != MM_HANDLE_INVALID);
+  assert(h2 != MM_HANDLE_INVALID);
+  assert(h3 != MM_HANDLE_INVALID);
+  assert(h1 != h2 && h2 != h3);
+  assert(h1 < h2 && h2 < h3); /* monotonically increasing */
+  assert(table.size() == 3);
 
-    /* lookup */
-    mm_alloc_info_t info;
-    assert(table.lookup(h1, &info));
-    assert(info.handle == h1);
-    assert(info.ptr == &dummy1);
-    assert(info.size == 100);
-    assert(info.mem_class == MM_CLASS_GENERIC);
+  /* lookup */
+  mm_alloc_info_t info;
+  assert(table.lookup(h1, &info));
+  assert(info.handle == h1);
+  assert(info.ptr == &dummy1);
+  assert(info.size == 100);
+  assert(info.mem_class == MM_CLASS_GENERIC);
 
-    assert(table.lookup(h2, &info));
-    assert(info.mem_class == MM_CLASS_WEIGHT);
-    assert(info.lifetime == MM_LIFETIME_STATIC);
+  assert(table.lookup(h2, &info));
+  assert(info.mem_class == MM_CLASS_WEIGHT);
+  assert(info.lifetime == MM_LIFETIME_STATIC);
 
-    /* remove */
-    assert(table.remove(h2));
-    assert(table.size() == 2);
-    assert(!table.lookup(h2, &info));
+  /* remove */
+  assert(table.remove(h2));
+  assert(table.size() == 2);
+  assert(!table.lookup(h2, &info));
 
-    /* double-free detection */
-    assert(!table.remove(h2));
+  /* double-free detection */
+  assert(!table.remove(h2));
 
-    /* invalid handle lookup */
-    assert(!table.lookup(MM_HANDLE_INVALID, &info));
-    assert(!table.lookup(9999, &info));
+  /* invalid handle lookup */
+  assert(!table.lookup(MM_HANDLE_INVALID, &info));
+  assert(!table.lookup(9999, &info));
 
-    /* clear */
-    table.clear();
-    assert(table.size() == 0);
-    assert(!table.lookup(h1, nullptr));
+  /* clear */
+  table.clear();
+  assert(table.size() == 0);
+  assert(!table.lookup(h1, nullptr));
 
-    printf("  basic_ops: ok\n");
+  printf("  basic_ops: ok\n");
 }
 
 static void test_for_each() {
-    HandleTable table;
-    char dummies[5];
-    for (int i = 0; i < 5; i++)
-        table.insert(&dummies[i], (size_t)(i + 1) * 64,
-                     MM_CLASS_GENERIC, MM_LIFETIME_TRANSIENT, MM_DEVICE_GPU0);
+  HandleTable table;
+  char dummies[5];
+  for (int i = 0; i < 5; i++)
+    table.insert(&dummies[i], (size_t)(i + 1) * 64, MM_CLASS_GENERIC,
+                 MM_LIFETIME_TRANSIENT, MM_DEVICE_GPU0);
 
-    size_t total = 0;
-    int count = 0;
-    table.for_each([&](const mm_alloc_info_t& info) {
-        total += info.size;
-        count++;
-    });
-    assert(count == 5);
-    assert(total == (1 + 2 + 3 + 4 + 5) * 64);
+  size_t total = 0;
+  int count = 0;
+  table.for_each([&](const mm_alloc_info_t &info) {
+    total += info.size;
+    count++;
+  });
+  assert(count == 5);
+  assert(total == (1 + 2 + 3 + 4 + 5) * 64);
 
-    table.clear();
-    printf("  for_each: ok\n");
+  table.clear();
+  printf("  for_each: ok\n");
 }
 
 static void test_concurrent_insert() {
-    HandleTable table;
-    const int threads = 4;
-    const int per_thread = 1000;
+  HandleTable table;
+  const int threads = 4;
+  const int per_thread = 1000;
 
-    std::vector<std::thread> workers;
-    for (int t = 0; t < threads; t++) {
-        workers.emplace_back([&table, per_thread]() {
-            char dummy;
-            for (int i = 0; i < per_thread; i++)
-                table.insert(&dummy, 64, MM_CLASS_GENERIC,
-                             MM_LIFETIME_TRANSIENT, MM_DEVICE_GPU0);
-        });
-    }
+  std::vector<std::thread> workers;
+  for (int t = 0; t < threads; t++) {
+    workers.emplace_back([&table, per_thread]() {
+      char dummy;
+      for (int i = 0; i < per_thread; i++)
+        table.insert(&dummy, 64, MM_CLASS_GENERIC, MM_LIFETIME_TRANSIENT,
+                     MM_DEVICE_GPU0);
+    });
+  }
 
-    for (auto& w : workers)
-        w.join();
+  for (auto &w : workers)
+    w.join();
 
-    assert(table.size() == (size_t)(threads * per_thread));
-    table.clear();
-    printf("  concurrent_insert: ok\n");
+  assert(table.size() == (size_t)(threads * per_thread));
+  table.clear();
+  printf("  concurrent_insert: ok\n");
 }
 
 int main() {
-    printf("test_handle_table:\n");
-    test_basic_ops();
-    test_for_each();
-    test_concurrent_insert();
-    printf("test_handle_table: PASSED\n");
-    return 0;
+  printf("test_handle_table:\n");
+  test_basic_ops();
+  test_for_each();
+  test_concurrent_insert();
+  printf("test_handle_table: PASSED\n");
+  return 0;
 }

--- a/test/mm/test_mm_core.cpp
+++ b/test/mm/test_mm_core.cpp
@@ -1,210 +1,218 @@
 /*
  * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Licensed under the MIT License.
- *
- * test_mm_core — End-to-end tests for the UMM core API using mock HAL.
  */
 
 #include "mm/mm.h"
 #include <cassert>
 #include <cstdio>
 
-#define ASSERT_OK(expr) do { mm_status_t s_ = (expr); assert(s_ == MM_OK); (void)s_; } while(0)
-#define ASSERT_ERR(expr, code) do { mm_status_t s_ = (expr); assert(s_ == (code)); (void)s_; } while(0)
+#define ASSERT_OK(expr)                                                        \
+  do {                                                                         \
+    mm_status_t s_ = (expr);                                                   \
+    assert(s_ == MM_OK);                                                       \
+    (void)s_;                                                                  \
+  } while (0)
+#define ASSERT_ERR(expr, code)                                                 \
+  do {                                                                         \
+    mm_status_t s_ = (expr);                                                   \
+    assert(s_ == (code));                                                      \
+    (void)s_;                                                                  \
+  } while (0)
 
 static void test_lifecycle() {
-    /* Not initialized yet */
-    assert(mm_is_initialized() == 0);
+  /* Not initialized yet */
+  assert(mm_is_initialized() == 0);
 
-    /* Init with defaults */
-    ASSERT_OK(mm_init(NULL));
-    assert(mm_is_initialized() == 1);
+  /* Init with defaults */
+  ASSERT_OK(mm_init(NULL));
+  assert(mm_is_initialized() == 1);
 
-    /* Double init is an error */
-    ASSERT_ERR(mm_init(NULL), MM_ERR_ALREADY_INIT);
+  /* Double init is an error */
+  ASSERT_ERR(mm_init(NULL), MM_ERR_ALREADY_INIT);
 
-    /* Shutdown */
-    mm_shutdown();
-    assert(mm_is_initialized() == 0);
+  /* Shutdown */
+  mm_shutdown();
+  assert(mm_is_initialized() == 0);
 
-    /* Re-init after shutdown */
-    mm_config_t cfg = mm_config_default();
-    cfg.enable_debug_log = 1;
-    ASSERT_OK(mm_init(&cfg));
-    mm_shutdown();
+  /* Re-init after shutdown */
+  mm_config_t cfg = mm_config_default();
+  cfg.enable_debug_log = 1;
+  ASSERT_OK(mm_init(&cfg));
+  mm_shutdown();
 
-    printf("  lifecycle: ok\n");
+  printf("  lifecycle: ok\n");
 }
 
 static void test_alloc_free() {
-    ASSERT_OK(mm_init(NULL));
+  ASSERT_OK(mm_init(NULL));
 
-    /* Basic alloc */
-    mm_handle_t h = mm_alloc(1024, NULL, NULL);
-    assert(h != MM_HANDLE_INVALID);
+  /* Basic alloc */
+  mm_handle_t h = mm_alloc(1024, NULL, NULL);
+  assert(h != MM_HANDLE_INVALID);
 
-    /* get_ptr */
-    void* ptr = mm_get_ptr(h);
-    assert(ptr != NULL);
+  /* get_ptr */
+  void *ptr = mm_get_ptr(h);
+  assert(ptr != NULL);
 
-    /* query */
-    mm_alloc_info_t info;
-    ASSERT_OK(mm_query(h, &info));
-    assert(info.handle == h);
-    assert(info.ptr == ptr);
-    assert(info.size >= 1024);
-    assert(info.mem_class == MM_CLASS_GENERIC);
-    assert(info.lifetime == MM_LIFETIME_TRANSIENT);
-    assert(info.device == 0);
+  /* query */
+  mm_alloc_info_t info;
+  ASSERT_OK(mm_query(h, &info));
+  assert(info.handle == h);
+  assert(info.ptr == ptr);
+  assert(info.size >= 1024);
+  assert(info.mem_class == MM_CLASS_GENERIC);
+  assert(info.lifetime == MM_LIFETIME_TRANSIENT);
+  assert(info.device == 0);
 
-    /* free */
-    ASSERT_OK(mm_free(h, NULL));
+  /* free */
+  ASSERT_OK(mm_free(h, NULL));
 
-    /* double free */
-    ASSERT_ERR(mm_free(h, NULL), MM_ERR_INVALID_HANDLE);
+  /* double free */
+  ASSERT_ERR(mm_free(h, NULL), MM_ERR_INVALID_HANDLE);
 
-    /* get_ptr after free */
-    assert(mm_get_ptr(h) == NULL);
+  /* get_ptr after free */
+  assert(mm_get_ptr(h) == NULL);
 
-    /* query after free */
-    ASSERT_ERR(mm_query(h, &info), MM_ERR_INVALID_HANDLE);
+  /* query after free */
+  ASSERT_ERR(mm_query(h, &info), MM_ERR_INVALID_HANDLE);
 
-    mm_shutdown();
-    printf("  alloc_free: ok\n");
+  mm_shutdown();
+  printf("  alloc_free: ok\n");
 }
 
 static void test_alloc_with_hints() {
-    ASSERT_OK(mm_init(NULL));
+  ASSERT_OK(mm_init(NULL));
 
-    mm_alloc_hints_t hints;
-    hints.mem_class = MM_CLASS_WEIGHT;
-    hints.lifetime  = MM_LIFETIME_STATIC;
-    hints.alignment = 512;
+  mm_alloc_hints_t hints;
+  hints.mem_class = MM_CLASS_WEIGHT;
+  hints.lifetime = MM_LIFETIME_STATIC;
+  hints.alignment = 512;
 
-    mm_handle_t h = mm_alloc(100, &hints, NULL);
-    assert(h != MM_HANDLE_INVALID);
+  mm_handle_t h = mm_alloc(100, &hints, NULL);
+  assert(h != MM_HANDLE_INVALID);
 
-    mm_alloc_info_t info;
-    ASSERT_OK(mm_query(h, &info));
-    assert(info.mem_class == MM_CLASS_WEIGHT);
-    assert(info.lifetime == MM_LIFETIME_STATIC);
-    assert(info.size >= 100);
-    /* size should be aligned to 512 */
-    assert(info.size % 512 == 0);
+  mm_alloc_info_t info;
+  ASSERT_OK(mm_query(h, &info));
+  assert(info.mem_class == MM_CLASS_WEIGHT);
+  assert(info.lifetime == MM_LIFETIME_STATIC);
+  assert(info.size >= 100);
+  /* size should be aligned to 512 */
+  assert(info.size % 512 == 0);
 
-    ASSERT_OK(mm_free(h, NULL));
-    mm_shutdown();
-    printf("  alloc_with_hints: ok\n");
+  ASSERT_OK(mm_free(h, NULL));
+  mm_shutdown();
+  printf("  alloc_with_hints: ok\n");
 }
 
 static void test_zero_size_alloc() {
-    ASSERT_OK(mm_init(NULL));
+  ASSERT_OK(mm_init(NULL));
 
-    mm_handle_t h = mm_alloc(0, NULL, NULL);
-    assert(h == MM_HANDLE_INVALID);
+  mm_handle_t h = mm_alloc(0, NULL, NULL);
+  assert(h == MM_HANDLE_INVALID);
 
-    mm_shutdown();
-    printf("  zero_size_alloc: ok\n");
+  mm_shutdown();
+  printf("  zero_size_alloc: ok\n");
 }
 
 static void test_not_initialized() {
-    /* All ops should fail gracefully when not initialized */
-    assert(mm_alloc(1024, NULL, NULL) == MM_HANDLE_INVALID);
-    ASSERT_ERR(mm_free(1, NULL), MM_ERR_NOT_INITIALIZED);
-    assert(mm_get_ptr(1) == NULL);
+  /* All ops should fail gracefully when not initialized */
+  assert(mm_alloc(1024, NULL, NULL) == MM_HANDLE_INVALID);
+  ASSERT_ERR(mm_free(1, NULL), MM_ERR_NOT_INITIALIZED);
+  assert(mm_get_ptr(1) == NULL);
 
-    mm_alloc_info_t info;
-    ASSERT_ERR(mm_query(1, &info), MM_ERR_NOT_INITIALIZED);
+  mm_alloc_info_t info;
+  ASSERT_ERR(mm_query(1, &info), MM_ERR_NOT_INITIALIZED);
 
-    printf("  not_initialized: ok\n");
+  printf("  not_initialized: ok\n");
 }
 
 static void test_metrics() {
-    ASSERT_OK(mm_init(NULL));
+  ASSERT_OK(mm_init(NULL));
 
-    mm_metrics_snapshot_t snap = mm_metrics_snapshot();
-    assert(snap.alloc_count == 0);
-    assert(snap.free_count == 0);
-    assert(snap.active_count == 0);
-    assert(snap.total_allocated_bytes == 0);
+  mm_metrics_snapshot_t snap = mm_metrics_snapshot();
+  assert(snap.alloc_count == 0);
+  assert(snap.free_count == 0);
+  assert(snap.active_count == 0);
+  assert(snap.total_allocated_bytes == 0);
 
-    mm_handle_t h1 = mm_alloc(1024, NULL, NULL);
-    mm_handle_t h2 = mm_alloc(2048, NULL, NULL);
-    mm_handle_t h3 = mm_alloc(512, NULL, NULL);
+  mm_handle_t h1 = mm_alloc(1024, NULL, NULL);
+  mm_handle_t h2 = mm_alloc(2048, NULL, NULL);
+  mm_handle_t h3 = mm_alloc(512, NULL, NULL);
 
-    snap = mm_metrics_snapshot();
-    assert(snap.alloc_count == 3);
-    assert(snap.free_count == 0);
-    assert(snap.active_count == 3);
-    assert(snap.total_allocated_bytes > 0);
-    assert(snap.peak_allocated_bytes > 0);
+  snap = mm_metrics_snapshot();
+  assert(snap.alloc_count == 3);
+  assert(snap.free_count == 0);
+  assert(snap.active_count == 3);
+  assert(snap.total_allocated_bytes > 0);
+  assert(snap.peak_allocated_bytes > 0);
 
-    size_t peak_before = snap.peak_allocated_bytes;
+  size_t peak_before = snap.peak_allocated_bytes;
 
-    ASSERT_OK(mm_free(h2, NULL));
-    snap = mm_metrics_snapshot();
-    assert(snap.alloc_count == 3);
-    assert(snap.free_count == 1);
-    assert(snap.active_count == 2);
-    /* peak should not decrease after free */
-    assert(snap.peak_allocated_bytes == peak_before);
+  ASSERT_OK(mm_free(h2, NULL));
+  snap = mm_metrics_snapshot();
+  assert(snap.alloc_count == 3);
+  assert(snap.free_count == 1);
+  assert(snap.active_count == 2);
+  /* peak should not decrease after free */
+  assert(snap.peak_allocated_bytes == peak_before);
 
-    /* reset counters */
-    mm_metrics_reset();
-    snap = mm_metrics_snapshot();
-    assert(snap.alloc_count == 0);
-    assert(snap.free_count == 0);
+  /* reset counters */
+  mm_metrics_reset();
+  snap = mm_metrics_snapshot();
+  assert(snap.alloc_count == 0);
+  assert(snap.free_count == 0);
 
-    ASSERT_OK(mm_free(h1, NULL));
-    ASSERT_OK(mm_free(h3, NULL));
-    mm_shutdown();
-    printf("  metrics: ok\n");
+  ASSERT_OK(mm_free(h1, NULL));
+  ASSERT_OK(mm_free(h3, NULL));
+  mm_shutdown();
+  printf("  metrics: ok\n");
 }
 
 static void test_dump_state() {
-    ASSERT_OK(mm_init(NULL));
+  ASSERT_OK(mm_init(NULL));
 
-    mm_handle_t h1 = mm_alloc(256, NULL, NULL);
-    mm_alloc_hints_t hints = {MM_CLASS_WEIGHT, MM_LIFETIME_STATIC, 0};
-    mm_handle_t h2 = mm_alloc(1024, &hints, NULL);
+  mm_handle_t h1 = mm_alloc(256, NULL, NULL);
+  mm_alloc_hints_t hints = {MM_CLASS_WEIGHT, MM_LIFETIME_STATIC, 0};
+  mm_handle_t h2 = mm_alloc(1024, &hints, NULL);
 
-    /* Just verify it doesn't crash */
-    mm_dump_state(stderr);
+  /* Just verify it doesn't crash */
+  mm_dump_state(stderr);
 
-    ASSERT_OK(mm_free(h1, NULL));
-    ASSERT_OK(mm_free(h2, NULL));
-    mm_shutdown();
-    printf("  dump_state: ok\n");
+  ASSERT_OK(mm_free(h1, NULL));
+  ASSERT_OK(mm_free(h2, NULL));
+  mm_shutdown();
+  printf("  dump_state: ok\n");
 }
 
 static void test_leak_detection() {
-    mm_config_t cfg = mm_config_default();
-    cfg.enable_debug_log = 1;
-    ASSERT_OK(mm_init(&cfg));
+  mm_config_t cfg = mm_config_default();
+  cfg.enable_debug_log = 1;
+  ASSERT_OK(mm_init(&cfg));
 
-    /* Allocate but don't free — shutdown should warn and clean up */
-    mm_alloc(512, NULL, NULL);
-    mm_alloc(1024, NULL, NULL);
+  /* Allocate but don't free — shutdown should warn and clean up */
+  mm_alloc(512, NULL, NULL);
+  mm_alloc(1024, NULL, NULL);
 
-    fprintf(stderr, "[TEST] Expecting leak warnings below:\n");
-    mm_shutdown();
+  fprintf(stderr, "[TEST] Expecting leak warnings below:\n");
+  mm_shutdown();
 
-    /* Verify clean state after shutdown */
-    assert(mm_is_initialized() == 0);
+  /* Verify clean state after shutdown */
+  assert(mm_is_initialized() == 0);
 
-    printf("  leak_detection: ok\n");
+  printf("  leak_detection: ok\n");
 }
 
 int main() {
-    printf("test_mm_core:\n");
-    test_lifecycle();
-    test_alloc_free();
-    test_alloc_with_hints();
-    test_zero_size_alloc();
-    test_not_initialized();
-    test_metrics();
-    test_dump_state();
-    test_leak_detection();
-    printf("test_mm_core: PASSED\n");
-    return 0;
+  printf("test_mm_core:\n");
+  test_lifecycle();
+  test_alloc_free();
+  test_alloc_with_hints();
+  test_zero_size_alloc();
+  test_not_initialized();
+  test_metrics();
+  test_dump_state();
+  test_leak_detection();
+  printf("test_mm_core: PASSED\n");
+  return 0;
 }

--- a/test/mm/test_mm_pool.cpp
+++ b/test/mm/test_mm_pool.cpp
@@ -1,8 +1,6 @@
 /*
  * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Licensed under the MIT License.
- *
- * test_mm_pool — Tests for the Static Pool allocator.
  */
 
 #include "mm/mm.h"
@@ -10,154 +8,159 @@
 #include <cstdio>
 #include <cstring>
 
-#define ASSERT_OK(expr) do { mm_status_t s_ = (expr); assert(s_ == MM_OK); (void)s_; } while(0)
+#define ASSERT_OK(expr)                                                        \
+  do {                                                                         \
+    mm_status_t s_ = (expr);                                                   \
+    assert(s_ == MM_OK);                                                       \
+    (void)s_;                                                                  \
+  } while (0)
 
 static void test_basic_pool() {
-    ASSERT_OK(mm_init(NULL));
+  ASSERT_OK(mm_init(NULL));
 
-    size_t offsets[] = {0, 256, 512, 1024};
-    mm_static_plan_t plan;
-    plan.total_size  = 2048;
-    plan.offsets     = offsets;
-    plan.num_entries = 4;
+  size_t offsets[] = {0, 256, 512, 1024};
+  mm_static_plan_t plan;
+  plan.total_size = 2048;
+  plan.offsets = offsets;
+  plan.num_entries = 4;
 
-    mm_pool_t pool = mm_pool_create(&plan);
-    assert(pool != NULL);
+  mm_pool_t pool = mm_pool_create(&plan);
+  assert(pool != NULL);
 
-    /* base pointer */
-    void* base = mm_pool_get_base(pool);
-    assert(base != NULL);
+  /* base pointer */
+  void *base = mm_pool_get_base(pool);
+  assert(base != NULL);
 
-    /* size and count */
-    assert(mm_pool_get_size(pool) >= 2048);
-    assert(mm_pool_get_num_entries(pool) == 4);
+  /* size and count */
+  assert(mm_pool_get_size(pool) >= 2048);
+  assert(mm_pool_get_num_entries(pool) == 4);
 
-    /* sub-buffer pointers */
-    void* p0 = mm_pool_get_ptr(pool, 0);
-    void* p1 = mm_pool_get_ptr(pool, 1);
-    void* p2 = mm_pool_get_ptr(pool, 2);
-    void* p3 = mm_pool_get_ptr(pool, 3);
+  /* sub-buffer pointers */
+  void *p0 = mm_pool_get_ptr(pool, 0);
+  void *p1 = mm_pool_get_ptr(pool, 1);
+  void *p2 = mm_pool_get_ptr(pool, 2);
+  void *p3 = mm_pool_get_ptr(pool, 3);
 
-    assert(p0 == base);
-    assert(p1 == (char*)base + 256);
-    assert(p2 == (char*)base + 512);
-    assert(p3 == (char*)base + 1024);
+  assert(p0 == base);
+  assert(p1 == (char *)base + 256);
+  assert(p2 == (char *)base + 512);
+  assert(p3 == (char *)base + 1024);
 
-    /* out of bounds */
-    assert(mm_pool_get_ptr(pool, 4) == NULL);
-    assert(mm_pool_get_ptr(pool, 999) == NULL);
+  /* out of bounds */
+  assert(mm_pool_get_ptr(pool, 4) == NULL);
+  assert(mm_pool_get_ptr(pool, 999) == NULL);
 
-    /* write and read back through sub-buffers (mock HAL uses real memory) */
-    memset(p0, 0xAA, 256);
-    memset(p1, 0xBB, 256);
-    unsigned char* c0 = (unsigned char*)p0;
-    unsigned char* c1 = (unsigned char*)p1;
-    assert(c0[0] == 0xAA && c0[255] == 0xAA);
-    assert(c1[0] == 0xBB && c1[255] == 0xBB);
+  /* write and read back through sub-buffers (mock HAL uses real memory) */
+  memset(p0, 0xAA, 256);
+  memset(p1, 0xBB, 256);
+  unsigned char *c0 = (unsigned char *)p0;
+  unsigned char *c1 = (unsigned char *)p1;
+  assert(c0[0] == 0xAA && c0[255] == 0xAA);
+  assert(c1[0] == 0xBB && c1[255] == 0xBB);
 
-    mm_pool_destroy(pool);
-    mm_shutdown();
-    printf("  basic_pool: ok\n");
+  mm_pool_destroy(pool);
+  mm_shutdown();
+  printf("  basic_pool: ok\n");
 }
 
 static void test_empty_offsets() {
-    ASSERT_OK(mm_init(NULL));
+  ASSERT_OK(mm_init(NULL));
 
-    /* Pool with no sub-buffers (just raw allocation) */
-    mm_static_plan_t plan;
-    plan.total_size  = 4096;
-    plan.offsets     = NULL;
-    plan.num_entries = 0;
+  /* Pool with no sub-buffers (just raw allocation) */
+  mm_static_plan_t plan;
+  plan.total_size = 4096;
+  plan.offsets = NULL;
+  plan.num_entries = 0;
 
-    mm_pool_t pool = mm_pool_create(&plan);
-    assert(pool != NULL);
+  mm_pool_t pool = mm_pool_create(&plan);
+  assert(pool != NULL);
 
-    assert(mm_pool_get_base(pool) != NULL);
-    assert(mm_pool_get_size(pool) >= 4096);
-    assert(mm_pool_get_num_entries(pool) == 0);
-    assert(mm_pool_get_ptr(pool, 0) == NULL);
+  assert(mm_pool_get_base(pool) != NULL);
+  assert(mm_pool_get_size(pool) >= 4096);
+  assert(mm_pool_get_num_entries(pool) == 0);
+  assert(mm_pool_get_ptr(pool, 0) == NULL);
 
-    mm_pool_destroy(pool);
-    mm_shutdown();
-    printf("  empty_offsets: ok\n");
+  mm_pool_destroy(pool);
+  mm_shutdown();
+  printf("  empty_offsets: ok\n");
 }
 
 static void test_null_safety() {
-    /* All getters should return safely with NULL */
-    assert(mm_pool_get_ptr(NULL, 0) == NULL);
-    assert(mm_pool_get_base(NULL) == NULL);
-    assert(mm_pool_get_size(NULL) == 0);
-    assert(mm_pool_get_num_entries(NULL) == 0);
+  /* All getters should return safely with NULL */
+  assert(mm_pool_get_ptr(NULL, 0) == NULL);
+  assert(mm_pool_get_base(NULL) == NULL);
+  assert(mm_pool_get_size(NULL) == 0);
+  assert(mm_pool_get_num_entries(NULL) == 0);
 
-    /* destroy NULL is a no-op */
-    mm_pool_destroy(NULL);
+  /* destroy NULL is a no-op */
+  mm_pool_destroy(NULL);
 
-    /* create with NULL plan */
-    assert(mm_pool_create(NULL) == NULL);
+  /* create with NULL plan */
+  assert(mm_pool_create(NULL) == NULL);
 
-    /* create with zero size */
-    mm_static_plan_t plan = {0, NULL, 0};
-    assert(mm_pool_create(&plan) == NULL);
+  /* create with zero size */
+  mm_static_plan_t plan = {0, NULL, 0};
+  assert(mm_pool_create(&plan) == NULL);
 
-    printf("  null_safety: ok\n");
+  printf("  null_safety: ok\n");
 }
 
 static void test_metrics_tracking() {
-    ASSERT_OK(mm_init(NULL));
+  ASSERT_OK(mm_init(NULL));
 
-    mm_metrics_snapshot_t snap0 = mm_metrics_snapshot();
+  mm_metrics_snapshot_t snap0 = mm_metrics_snapshot();
 
-    size_t offsets[] = {0, 1024};
-    mm_static_plan_t plan = {2048, offsets, 2};
-    mm_pool_t pool = mm_pool_create(&plan);
-    assert(pool != NULL);
+  size_t offsets[] = {0, 1024};
+  mm_static_plan_t plan = {2048, offsets, 2};
+  mm_pool_t pool = mm_pool_create(&plan);
+  assert(pool != NULL);
 
-    mm_metrics_snapshot_t snap1 = mm_metrics_snapshot();
-    assert(snap1.alloc_count == snap0.alloc_count + 1);
-    assert(snap1.total_allocated_bytes > snap0.total_allocated_bytes);
+  mm_metrics_snapshot_t snap1 = mm_metrics_snapshot();
+  assert(snap1.alloc_count == snap0.alloc_count + 1);
+  assert(snap1.total_allocated_bytes > snap0.total_allocated_bytes);
 
-    mm_pool_destroy(pool);
+  mm_pool_destroy(pool);
 
-    mm_metrics_snapshot_t snap2 = mm_metrics_snapshot();
-    assert(snap2.free_count == snap0.free_count + 1);
+  mm_metrics_snapshot_t snap2 = mm_metrics_snapshot();
+  assert(snap2.free_count == snap0.free_count + 1);
 
-    mm_shutdown();
-    printf("  metrics_tracking: ok\n");
+  mm_shutdown();
+  printf("  metrics_tracking: ok\n");
 }
 
 static void test_multiple_pools() {
-    ASSERT_OK(mm_init(NULL));
+  ASSERT_OK(mm_init(NULL));
 
-    size_t off1[] = {0, 512};
-    mm_static_plan_t plan1 = {1024, off1, 2};
+  size_t off1[] = {0, 512};
+  mm_static_plan_t plan1 = {1024, off1, 2};
 
-    size_t off2[] = {0, 256, 768};
-    mm_static_plan_t plan2 = {2048, off2, 3};
+  size_t off2[] = {0, 256, 768};
+  mm_static_plan_t plan2 = {2048, off2, 3};
 
-    mm_pool_t p1 = mm_pool_create(&plan1);
-    mm_pool_t p2 = mm_pool_create(&plan2);
-    assert(p1 != NULL && p2 != NULL);
+  mm_pool_t p1 = mm_pool_create(&plan1);
+  mm_pool_t p2 = mm_pool_create(&plan2);
+  assert(p1 != NULL && p2 != NULL);
 
-    /* Pools have independent base pointers */
-    assert(mm_pool_get_base(p1) != mm_pool_get_base(p2));
+  /* Pools have independent base pointers */
+  assert(mm_pool_get_base(p1) != mm_pool_get_base(p2));
 
-    /* Each pool's offsets work independently */
-    assert(mm_pool_get_ptr(p1, 1) == (char*)mm_pool_get_base(p1) + 512);
-    assert(mm_pool_get_ptr(p2, 2) == (char*)mm_pool_get_base(p2) + 768);
+  /* Each pool's offsets work independently */
+  assert(mm_pool_get_ptr(p1, 1) == (char *)mm_pool_get_base(p1) + 512);
+  assert(mm_pool_get_ptr(p2, 2) == (char *)mm_pool_get_base(p2) + 768);
 
-    mm_pool_destroy(p1);
-    mm_pool_destroy(p2);
-    mm_shutdown();
-    printf("  multiple_pools: ok\n");
+  mm_pool_destroy(p1);
+  mm_pool_destroy(p2);
+  mm_shutdown();
+  printf("  multiple_pools: ok\n");
 }
 
 int main() {
-    printf("test_mm_pool: starting\n");
-    test_null_safety();
-    test_basic_pool();
-    test_empty_offsets();
-    test_metrics_tracking();
-    test_multiple_pools();
-    printf("test_mm_pool: PASSED\n");
-    return 0;
+  printf("test_mm_pool: starting\n");
+  test_null_safety();
+  test_basic_pool();
+  test_empty_offsets();
+  test_metrics_tracking();
+  test_multiple_pools();
+  printf("test_mm_pool: PASSED\n");
+  return 0;
 }

--- a/test/mm/test_mm_types.cpp
+++ b/test/mm/test_mm_types.cpp
@@ -1,9 +1,6 @@
 /*
  * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Licensed under the MIT License.
- *
- * test_mm_types — Verify that all public headers compile and types are
- *                 correctly sized.
  */
 
 #include "mm/mm.h"
@@ -11,38 +8,38 @@
 #include <cstdio>
 
 int main() {
-    /* Handle type must be 64 bits */
-    static_assert(sizeof(mm_handle_t) == 8, "mm_handle_t must be 8 bytes");
+  /* Handle type must be 64 bits */
+  static_assert(sizeof(mm_handle_t) == 8, "mm_handle_t must be 8 bytes");
 
-    /* Invalid handle sentinel */
-    assert(MM_HANDLE_INVALID == 0);
+  /* Invalid handle sentinel */
+  assert(MM_HANDLE_INVALID == 0);
 
-    /* Config defaults */
-    mm_config_t cfg = mm_config_default();
-    assert(cfg.device_id == 0);
-    assert(cfg.default_alignment == 256);
-    assert(cfg.enable_debug_log == 0);
+  /* Config defaults */
+  mm_config_t cfg = mm_config_default();
+  assert(cfg.device_id == 0);
+  assert(cfg.default_alignment == 256);
+  assert(cfg.enable_debug_log == 0);
 
-    /* Enum values */
-    assert(MM_CLASS_GENERIC == 0);
-    assert(MM_CLASS_SCRATCH == 4);
-    assert(MM_LIFETIME_STATIC == 0);
-    assert(MM_LIFETIME_TRANSIENT == 3);
+  /* Enum values */
+  assert(MM_CLASS_GENERIC == 0);
+  assert(MM_CLASS_SCRATCH == 4);
+  assert(MM_LIFETIME_STATIC == 0);
+  assert(MM_LIFETIME_TRANSIENT == 3);
 
-    /* Hints struct zero-init */
-    mm_alloc_hints_t hints = {};
-    assert(hints.mem_class == MM_CLASS_GENERIC);
-    assert(hints.alignment == 0);
+  /* Hints struct zero-init */
+  mm_alloc_hints_t hints = {};
+  assert(hints.mem_class == MM_CLASS_GENERIC);
+  assert(hints.alignment == 0);
 
-    /* Metrics struct zero-init */
-    mm_metrics_snapshot_t metrics = {};
-    assert(metrics.alloc_count == 0);
-    assert(metrics.active_count == 0);
+  /* Metrics struct zero-init */
+  mm_metrics_snapshot_t metrics = {};
+  assert(metrics.alloc_count == 0);
+  assert(metrics.active_count == 0);
 
-    /* Error string */
-    assert(mm_status_string(MM_OK) != nullptr);
-    assert(mm_status_string(MM_ERR_OUT_OF_MEMORY) != nullptr);
+  /* Error string */
+  assert(mm_status_string(MM_OK) != nullptr);
+  assert(mm_status_string(MM_ERR_OUT_OF_MEMORY) != nullptr);
 
-    printf("test_mm_types: PASSED\n");
-    return 0;
+  printf("test_mm_types: PASSED\n");
+  return 0;
 }


### PR DESCRIPTION
## Motivation

The execution provider runtime currently allocates and frees GPU memory ad-hoc through direct HIP calls scattered across the code. This makes it hard to track peak usage, enforce alignment policies, support pooled/static allocation for weight tensors, or swap in alternative backends (e.g. mock for testing). A centralized Memory Manager (MM) layer fixes this.

## Technical Details

### New library: `lib/MemoryManager/` (`libMemoryManager`)

A C-ABI memory management library under `include/mm/`:

- **`mm_types.h`** — Core types: `mm_handle_t`, `mm_stream_t`, `mm_device_t`, `mm_class_t` (generic/weight/activation/kv-cache/scratch), `mm_lifetime_t`, `mm_alloc_hints_t`, `mm_alloc_info_t`, `mm_stats_t`
- **`mm_error.h`** — Error codes (`MM_OK`, `MM_ERR_*`) and `mm_status_string()`
- **`mm_config.h`** — `mm_config_t` struct with device ID, alignment, debug-log flag; `mm_config_default()` helper
- **`mm_hal.h`** — `mm_hal_t` vtable interface (malloc, free, memcpy h2d/d2h, memset, stream, device query); `mm_hal_rocm()` and `mm_hal_mock()` factory functions
- **`mm_api.h`** — Public runtime API: `mm_init`, `mm_shutdown`, `mm_alloc`, `mm_free`, `mm_get_ptr`, `mm_query`, `mm_dump_state`, `mm_get_stats`
- **`mm_pool.h`** — Static pool allocator (`mm_pool_t`) for fixed-layout weight tensors planned at model-load time

Implementations:
- `mm_core.cpp` — Global singleton, handle table integration, alloc/free/query
- `mm_error.cpp` — `mm_status_string()` lookup table
- `mm_pool.cpp` — Static pool: single HAL allocation, slot offset table, `mm_pool_get_ptr`/`mm_pool_get_base`
- `handle_table.cpp/.h` — Dense handle-to-metadata map (open-addressing, lock-free reads)
- `hal_rocm.cpp` — HIP-backed HAL implementation
- `hal_mock.cpp` — CPU `malloc`/`free`-backed HAL for unit tests (no ROCm dependency)

### Runtime integration (`lib/Runtime/`)

- `hipdnn_ep_runtime_state.cpp` — Runtime now calls `mm_init` / `mm_shutdown`; weight loading uses `mm_alloc` + `mm_get_ptr` instead of raw `hipMalloc`
- `runtime_state_internal.h` — Exposes `mm_handle_t` fields alongside raw pointers for transition period

### Unit tests (`test/mm/`)

Full GTest coverage for: hal_mock, handle_table, mm_core (alloc/free/query/stats), mm_pool (layout, ptr arithmetic), and mm_types (size/alignment).

## Test Plan

- [x] `build-windows-mock` CI: builds `libMemoryManager` + tests with mock HAL (no ROCm required)
- [x] `build-windows` CI: full build including ROCm HAL
- [x] Unit tests in `test/mm/` cover all public API paths
- [x] `pre-commit` (clang-format + licenseheaders) passes on all changed files

## Test Result

All unit tests pass locally with the mock HAL build. CI checks triggered on push.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.