### PR TITLE
feat: add GELU activation operator support

### DIFF
--- a/3rd-party/custom_kernels/CMakeLists.txt
+++ b/3rd-party/custom_kernels/CMakeLists.txt
@@ -34,6 +34,7 @@ hip_add_library(hip_custom_kernels STATIC
     hip/elementwise_sub_kernel.hip
     hip/elementwise_reciprocal_kernel.hip
     hip/elementwise_sqrt_kernel.hip
+    hip/elementwise_gelu_kernel.hip
     hip/cast_kernel.hip
     hip/gather_kernel.hip
     hip/reduce_sum_kernel.hip

--- a/3rd-party/custom_kernels/hip/elementwise_gelu_kernel.hip
+++ b/3rd-party/custom_kernels/hip/elementwise_gelu_kernel.hip
@@ -1,0 +1,217 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "hip_custom_kernels.h"
+#include "debug_log.h"
+
+#include <hip/hip_bf16.h>
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+#include <cstdint>
+#include <cstdio>
+
+//===----------------------------------------------------------------------===//
+// Type Traits for Unified GELU Implementation
+//===----------------------------------------------------------------------===//
+
+// Compute type: the precision used for GELU calculations
+// f32/f16/bf16 use float, f64 uses double
+template <typename T> struct GeluTraits;
+
+template <> struct GeluTraits<float> {
+  using ComputeType = float;
+  using ConstType = float;
+  static constexpr ConstType kSqrt2OverPi = 0.7978845608f;     // sqrt(2/pi)
+  static constexpr ConstType kCoeff = 0.044715f;               // tanh approx coeff
+  static constexpr ConstType kSqrt2Inv = 0.7071067811865476f; // 1/sqrt(2)
+
+  __device__ static inline ComputeType load(float x) { return x; }
+  __device__ static inline float store(ComputeType x) { return x; }
+  __device__ static inline ComputeType tanh_fn(ComputeType x) { return tanhf(x); }
+  __device__ static inline ComputeType erf_fn(ComputeType x) { return erff(x); }
+};
+
+template <> struct GeluTraits<__half> {
+  using ComputeType = float;
+  using ConstType = float;
+  static constexpr ConstType kSqrt2OverPi = 0.7978845608f;
+  static constexpr ConstType kCoeff = 0.044715f;
+  static constexpr ConstType kSqrt2Inv = 0.7071067811865476f;
+
+  __device__ static inline ComputeType load(__half x) { return __half2float(x); }
+  __device__ static inline __half store(ComputeType x) { return __float2half(x); }
+  __device__ static inline ComputeType tanh_fn(ComputeType x) { return tanhf(x); }
+  __device__ static inline ComputeType erf_fn(ComputeType x) { return erff(x); }
+};
+
+template <> struct GeluTraits<__hip_bfloat16> {
+  using ComputeType = float;
+  using ConstType = float;
+  static constexpr ConstType kSqrt2OverPi = 0.7978845608f;
+  static constexpr ConstType kCoeff = 0.044715f;
+  static constexpr ConstType kSqrt2Inv = 0.7071067811865476f;
+
+  __device__ static inline ComputeType load(__hip_bfloat16 x) { return __bfloat162float(x); }
+  __device__ static inline __hip_bfloat16 store(ComputeType x) { return __float2bfloat16(x); }
+  __device__ static inline ComputeType tanh_fn(ComputeType x) { return tanhf(x); }
+  __device__ static inline ComputeType erf_fn(ComputeType x) { return erff(x); }
+};
+
+template <> struct GeluTraits<double> {
+  using ComputeType = double;
+  using ConstType = double;
+  static constexpr ConstType kSqrt2OverPi = 0.7978845608028654; // sqrt(2/pi)
+  static constexpr ConstType kCoeff = 0.044715;
+  static constexpr ConstType kSqrt2Inv = 0.7071067811865476;
+
+  __device__ static inline ComputeType load(double x) { return x; }
+  __device__ static inline double store(ComputeType x) { return x; }
+  __device__ static inline ComputeType tanh_fn(ComputeType x) { return tanh(x); }
+  __device__ static inline ComputeType erf_fn(ComputeType x) { return erf(x); }
+};
+
+//===----------------------------------------------------------------------===//
+// Unified GELU Device Function (shared computation logic)
+//===----------------------------------------------------------------------===//
+
+template <typename T>
+__device__ __forceinline__ T compute_gelu(T input_val, int64_t approximate) {
+  using Traits = GeluTraits<T>;
+  using ComputeType = typename Traits::ComputeType;
+
+  ComputeType x = Traits::load(input_val);
+  ComputeType result;
+
+  if (approximate == 1) {
+    // GELU tanh approximation: 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))
+    ComputeType x3 = x * x * x;
+    ComputeType tanh_arg = Traits::kSqrt2OverPi * (x + Traits::kCoeff * x3);
+    result = ComputeType(0.5) * x * (ComputeType(1.0) + Traits::tanh_fn(tanh_arg));
+  } else {
+    // GELU exact (erf): x * 0.5 * (1.0 + erf(x / sqrt(2.0)))
+    result = x * ComputeType(0.5) * (ComputeType(1.0) + Traits::erf_fn(x * Traits::kSqrt2Inv));
+  }
+
+  return Traits::store(result);
+}
+
+//===----------------------------------------------------------------------===//
+// Specialized GELU Kernels (using shared device function)
+//===----------------------------------------------------------------------===//
+
+__global__ void elementwise_gelu_f32_kernel(const float *__restrict__ input,
+                                            float *__restrict__ output,
+                                            int64_t num_elements,
+                                            int64_t approximate) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < num_elements) {
+    output[idx] = compute_gelu<float>(input[idx], approximate);
+  }
+}
+
+__global__ void elementwise_gelu_f16_kernel(const __half *__restrict__ input,
+                                            __half *__restrict__ output,
+                                            int64_t num_elements,
+                                            int64_t approximate) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < num_elements) {
+    output[idx] = compute_gelu<__half>(input[idx], approximate);
+  }
+}
+
+__global__ void elementwise_gelu_bf16_kernel(const __hip_bfloat16 *__restrict__ input,
+                                             __hip_bfloat16 *__restrict__ output,
+                                             int64_t num_elements,
+                                             int64_t approximate) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < num_elements) {
+    output[idx] = compute_gelu<__hip_bfloat16>(input[idx], approximate);
+  }
+}
+
+__global__ void elementwise_gelu_f64_kernel(const double *__restrict__ input,
+                                            double *__restrict__ output,
+                                            int64_t num_elements,
+                                            int64_t approximate) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < num_elements) {
+    output[idx] = compute_gelu<double>(input[idx], approximate);
+  }
+}
+
+extern "C" int hip_elementwise_gelu(void *stream, const void *input,
+                                    void *output, int64_t num_elements,
+                                    int hip_dtype, int64_t approximate) {
+  if (num_elements <= 0)
+    return 0;
+
+  hipStream_t hip_stream = static_cast<hipStream_t>(stream);
+  constexpr int kBlockSize = 256;
+  int grid_size =
+      static_cast<int>((num_elements + kBlockSize - 1) / kBlockSize);
+
+  const char *mode = (approximate == 1) ? "tanh" : "erf";
+
+  switch (hip_dtype) {
+  case HIP_DTYPE_FLOAT32:
+    CUSTOM_KERNELS_DEBUG_LOG(
+        "[custom_kernels] hip_elementwise_gelu: f32, approximate=%s, "
+        "num_elements=%lld, grid=%d, block=%d\n",
+        mode, (long long)num_elements, grid_size, kBlockSize);
+    hipLaunchKernelGGL(elementwise_gelu_f32_kernel,
+                         dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
+                         static_cast<const float *>(input),
+                         static_cast<float *>(output), num_elements,
+                         approximate);
+    break;
+  case HIP_DTYPE_FLOAT16:
+    CUSTOM_KERNELS_DEBUG_LOG(
+        "[custom_kernels] hip_elementwise_gelu: f16, approximate=%s, "
+        "num_elements=%lld, grid=%d, block=%d\n",
+        mode, (long long)num_elements, grid_size, kBlockSize);
+    hipLaunchKernelGGL(elementwise_gelu_f16_kernel,
+                         dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
+                         static_cast<const __half *>(input),
+                         static_cast<__half *>(output), num_elements,
+                         approximate);
+    break;
+  case HIP_DTYPE_BFLOAT16:
+    CUSTOM_KERNELS_DEBUG_LOG(
+        "[custom_kernels] hip_elementwise_gelu: bf16, approximate=%s, "
+        "num_elements=%lld, grid=%d, block=%d\n",
+        mode, (long long)num_elements, grid_size, kBlockSize);
+    hipLaunchKernelGGL(elementwise_gelu_bf16_kernel,
+                         dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
+                         static_cast<const __hip_bfloat16 *>(input),
+                         static_cast<__hip_bfloat16 *>(output), num_elements,
+                         approximate);
+    break;
+  case HIP_DTYPE_FLOAT64:
+    CUSTOM_KERNELS_DEBUG_LOG(
+        "[custom_kernels] hip_elementwise_gelu: f64, approximate=%s, "
+        "num_elements=%lld, grid=%d, block=%d\n",
+        mode, (long long)num_elements, grid_size, kBlockSize);
+    hipLaunchKernelGGL(elementwise_gelu_f64_kernel,
+                         dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
+                         static_cast<const double *>(input),
+                         static_cast<double *>(output), num_elements,
+                         approximate);
+    break;
+  default:
+    fprintf(stderr,
+            "[custom_kernels] hip_elementwise_gelu: unsupported "
+            "dtype=%d\n",
+            hip_dtype);
+    return -1;
+  }
+
+  hipError_t err = hipGetLastError();
+  if (err != hipSuccess) {
+    fprintf(stderr,
+            "[custom_kernels] hip_elementwise_gelu launch failed: %s\n",
+            hipGetErrorString(err));
+  }
+  return static_cast<int>(err);
+}

--- a/3rd-party/custom_kernels/hip/elementwise_gelu_kernel.hip
+++ b/3rd-party/custom_kernels/hip/elementwise_gelu_kernel.hip
@@ -3,6 +3,25 @@
  * Licensed under the MIT License.
  */
 
+//===----------------------------------------------------------------------===//
+// Custom GELU Kernel Implementation
+//===----------------------------------------------------------------------===//
+//
+// This file implements GELU (Gaussian Error Linear Unit) activation using
+// a custom HIP kernel rather than MIOpen library calls.
+//
+// Rationale for custom kernel:
+//   MIOpen does not provide native GELU activation support as of ROCm 6.x.
+//   The available miopenActivationForward() supports SIGMOID, RELU, TANH,
+//   CLIPPED_RELU, ELU, and IDENTITY, but not GELU.
+//
+// Future considerations:
+//   If future MIOpen versions add GELU support (miopenActivationMode_t_GELU),
+//   consider migrating to the library implementation for potential hardware-
+//   specific optimizations and reduced maintenance burden.
+//
+//===----------------------------------------------------------------------===//
+
 #include "hip_custom_kernels.h"
 #include "debug_log.h"
 

--- a/3rd-party/custom_kernels/include/hip_custom_kernels.h
+++ b/3rd-party/custom_kernels/include/hip_custom_kernels.h
@@ -109,6 +109,45 @@ int hip_elementwise_sqrt(
     int hip_dtype);
 
 /* =========================================================================
+ * Elementwise GELU (Gaussian Error Linear Unit)
+ * =========================================================================
+ *
+ * Element-wise GELU activation via HIP with support for exact and approximate modes.
+ *
+ * Approximate mode (approximate=1, tanh):
+ *   Formula: GELU(x) ≈ 0.5 * x * (1 + tanh(sqrt(2/π) * (x + 0.044715 * x³)))
+ *   Standard approximation used in PyTorch, TensorFlow, and ONNX.
+ *
+ * Exact mode (approximate=0, erf, default):
+ *   Formula: GELU(x) = x * 0.5 * (1.0 + erf(x / sqrt(2.0)))
+ *   Matches ONNX Gelu operator spec exactly.
+ *
+ * Parameters:
+ *   stream       - hipStream_t cast to void*
+ *   input        - GPU pointer to input
+ *   output       - GPU pointer to output
+ *   num_elements - number of elements
+ *   hip_dtype    - data type (HIP_DTYPE_FLOAT32, HIP_DTYPE_FLOAT16,
+ *                  HIP_DTYPE_BFLOAT16, HIP_DTYPE_FLOAT64)
+ *   approximate  - 0 for exact (erf), 1 for tanh approximation
+ *
+ * Supported data types (per ONNX spec):
+ *   - HIP_DTYPE_FLOAT32 (float32)
+ *   - HIP_DTYPE_FLOAT16 (float16)
+ *   - HIP_DTYPE_BFLOAT16 (bfloat16)
+ *   - HIP_DTYPE_FLOAT64 (double/float64)
+ *
+ * Returns: 0 on success (hipSuccess), non-zero hipError_t on failure
+ */
+int hip_elementwise_gelu(
+    void* stream,
+    const void* input,
+    void* output,
+    int64_t num_elements,
+    int hip_dtype,
+    int64_t approximate);
+
+/* =========================================================================
  * Rotary Position Embedding (RoPE)
  * =========================================================================
  *

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This project demonstrates the integration of HIP (Heterogeneous-compute Interfac
 - **MLIR Compiler Pipeline**: ONNX dialect → HIP dialect → LLVM IR → native DLL
 - **MIOpen Integration**: Conv, Softmax, RMS Norm, Mul, Sigmoid, Softplus, CausalConvWithState via MIOpen library
 - **hipBLASLt MatMul**: High-performance matrix multiplication
-- **Custom HIP Kernels**: GQA, RoPE, Cast, Sub, Gather, ReduceSum, Reciprocal, Sqrt
+- **Custom HIP Kernels**: GQA, RoPE, Cast, Sub, Gather, ReduceSum, Reciprocal, Sqrt, GELU
 - **Memory Pool Optimization**: `hip-pool-allocs` pass packs allocations into a single grow-on-demand buffer
 - **Constant Externalization**: Large model weights stored in sidecar `.constants.bin` files
 - **Mock Runtime**: GPU-free development and testing with `BUILD_MOCK_RUNTIME=ON`
@@ -33,6 +33,7 @@ This project demonstrates the integration of HIP (Heterogeneous-compute Interfac
 | Add | MIOpen |
 | Sigmoid | MIOpen |
 | Softplus | MIOpen |
+| Gelu | Custom HIP kernel |
 | Reciprocal | Custom HIP kernel |
 | Sqrt | Custom HIP kernel |
 | Sub | Custom HIP Kernel |

--- a/include/hip/Dialect/IR/HipBufferize.h
+++ b/include/hip/Dialect/IR/HipBufferize.h
@@ -82,6 +82,7 @@ registerHipBufferizableOpInterfaceModels(DialectRegistry &registry) {
     CastOp::attachInterface<HipDstBufferizableModel<CastOp>>(*ctx);
     SigmoidOp::attachInterface<HipDstBufferizableModel<SigmoidOp>>(*ctx);
     SoftplusOp::attachInterface<HipDstBufferizableModel<SoftplusOp>>(*ctx);
+    GeluOp::attachInterface<HipDstBufferizableModel<GeluOp>>(*ctx);
     ReciprocalOp::attachInterface<HipDstBufferizableModel<ReciprocalOp>>(*ctx);
     SqrtOp::attachInterface<HipDstBufferizableModel<SqrtOp>>(*ctx);
     SubOp::attachInterface<HipDstBufferizableModel<SubOp>>(*ctx);

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -765,6 +765,42 @@ def Hip_SoftplusOp : Hip_DpsOp<"softplus"> {
   }];
 }
 
+def Hip_GeluOp : Hip_DpsOp<"gelu"> {
+  let summary = "GELU activation (Gaussian Error Linear Unit)";
+  let description = [{
+    Applies the GELU activation function element-wise.
+    Implements the ONNX Gelu operator with support for both exact and approximate modes.
+
+    Approximate mode (approximate="tanh"):
+      Y ≈ 0.5 * X * (1 + tanh(sqrt(2/π) * (X + 0.044715 * X³)))
+
+    Exact mode (approximate="none", default):
+      Y = X * 0.5 * (1.0 + erf(X / sqrt(2.0)))
+
+    Uses destination-passing style: output buffer is provided as argument.
+
+    Example:
+    ```mlir
+    hip.gelu(%ctx) ins(%x : memref<1x128x768xf16, 1>)
+                   outs(%y : memref<1x128x768xf16, 1>)
+                   {approximate = "tanh"}
+    ```
+  }];
+
+  let arguments = (ins
+    Hip_ContextType:$ctx,
+    Hip_TensorOrMemRef:$input,
+    Hip_TensorOrMemRef:$output,
+    DefaultValuedAttr<StrAttr, "\"none\"">:$approximate
+  );
+
+  let assemblyFormat = [{
+    `(` $ctx `)` `ins` `(` $input `:` type($input) `)`
+    `outs` `(` $output `:` type($output) `)`
+    attr-dict (`:` type($result_tensors)^)?
+  }];
+}
+
 def Hip_ReciprocalOp : Hip_DpsOp<"reciprocal"> {
   let summary = "Element-wise reciprocal: y = 1/x";
   let description = [{

--- a/lib/Conversion/HipToLLVM/ActivationLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ActivationLowering.cpp
@@ -132,6 +132,90 @@ struct SoftplusOpLowering : public ConvertOpToLLVMPattern<SoftplusOp> {
   }
 };
 
+// hip.gelu(ctx, input, output)
+//   -> wrap_gelu(state, input, output, num_elements, data_type, approximate)
+// Uses custom HIP kernel (hip_elementwise_gelu) instead of MIOpen.
+// Supports static and dynamic shapes (computes num_elements at runtime).
+// Supports data types: f32, f16, bf16, f64 (per ONNX Gelu spec).
+// Supports approximate modes: "none" (erf) and "tanh".
+struct GeluOpLowering : public ConvertOpToLLVMPattern<GeluOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(GeluOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    ModuleOp module = op->getParentOfType<ModuleOp>();
+    Type ptrType = LLVM::LLVMPointerType::get(rewriter.getContext(), 0);
+    Type i32Type = rewriter.getI32Type();
+    Type i64Type = rewriter.getI64Type();
+
+    // Helper to create i64 constants
+    auto createI64Const = [&](int64_t value) -> Value {
+      return LLVM::ConstantOp::create(rewriter, loc, i64Type,
+                                      rewriter.getI64IntegerAttr(value));
+    };
+
+    // Extract pointers
+    Value statePtr = adaptor.getCtx();
+    Value inputPtr = extractMemRefPtr(adaptor.getInput(), rewriter, loc);
+    Value outputPtr = extractMemRefPtr(adaptor.getOutput(), rewriter, loc);
+
+    auto outputType = cast<MemRefType>(op.getOutput().getType());
+
+    // Compute num_elements (supports dynamic shapes)
+    Value numElements = createI64Const(1);
+    MemRefDescriptor outputDesc(adaptor.getOutput());
+
+    for (auto dimIdx : llvm::seq<int64_t>(outputType.getRank())) {
+      Value dimSize;
+      if (outputType.isDynamicDim(dimIdx)) {
+        dimSize = outputDesc.size(rewriter, loc, dimIdx);
+      } else {
+        dimSize = createI64Const(outputType.getDimSize(dimIdx));
+      }
+      numElements = LLVM::MulOp::create(rewriter, loc, numElements, dimSize);
+    }
+
+    // Get data type enum (f32=0, f16=1, bf16=2, i32=3, i64=4, i8=5, f64=6)
+    Type elemType = outputType.getElementType();
+    int64_t dataType = getHipdnnDataType(elemType);
+
+    // Validate: only f32, f16, bf16, f64 are supported (per ONNX Gelu spec)
+    if (dataType < 0 || (dataType > 2 && dataType != 6)) {
+      std::string errorMsg;
+      llvm::raw_string_ostream os(errorMsg);
+      os << "unsupported element type '" << elemType
+         << "' for GELU. Only f32, f16, bf16, and f64 are supported";
+      return rewriter.notifyMatchFailure(op, os.str());
+    }
+
+    Value dataTypeVal = createI64Const(dataType);
+
+    // Get approximate mode: "none" -> 0, "tanh" -> 1
+    std::string approximateStr = op.getApproximate().str();
+    int64_t approximateMode = (approximateStr == "tanh") ? 1 : 0;
+    Value approximateModeVal = createI64Const(approximateMode);
+
+    // int wrap_gelu(RuntimeState* state, void* input, void* output,
+    //               int64_t num_elements, int64_t data_type, int64_t approximate)
+    SmallVector<Type, 6> paramTypes = {ptrType, ptrType, ptrType,
+                                       i64Type, i64Type, i64Type};
+
+    FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
+        rewriter, module, kWrapGelu, paramTypes, i32Type);
+    if (failed(funcOp))
+      return failure();
+
+    SmallVector<Value, 6> args = {statePtr, inputPtr, outputPtr, numElements,
+                                  dataTypeVal, approximateModeVal};
+
+    LLVM::CallOp::create(rewriter, loc, *funcOp, args);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 // hip.silu(handle, input, output)
 struct SiluOpLowering : public ConvertOpToLLVMPattern<SiluOp> {
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
@@ -207,8 +291,8 @@ struct MiopenSoftmaxOpLowering
 
 void mlir::hip::populateActivationLoweringPatterns(
     const LLVMTypeConverter &converter, RewritePatternSet &patterns) {
-  patterns.add<SigmoidOpLowering, SoftplusOpLowering, SiluOpLowering,
-               MiopenSoftmaxOpLowering>(converter);
+  patterns.add<SigmoidOpLowering, SoftplusOpLowering, GeluOpLowering,
+               SiluOpLowering, MiopenSoftmaxOpLowering>(converter);
 }
 
 } // namespace hip

--- a/lib/Conversion/HipToLLVM/ActivationLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ActivationLowering.cpp
@@ -198,7 +198,8 @@ struct GeluOpLowering : public ConvertOpToLLVMPattern<GeluOp> {
     Value approximateModeVal = createI64Const(approximateMode);
 
     // int wrap_gelu(RuntimeState* state, void* input, void* output,
-    //               int64_t num_elements, int64_t data_type, int64_t approximate)
+    //               int64_t num_elements, int64_t data_type, int64_t
+    //               approximate)
     SmallVector<Type, 6> paramTypes = {ptrType, ptrType, ptrType,
                                        i64Type, i64Type, i64Type};
 
@@ -207,8 +208,8 @@ struct GeluOpLowering : public ConvertOpToLLVMPattern<GeluOp> {
     if (failed(funcOp))
       return failure();
 
-    SmallVector<Value, 6> args = {statePtr, inputPtr, outputPtr, numElements,
-                                  dataTypeVal, approximateModeVal};
+    SmallVector<Value, 6> args = {statePtr,    inputPtr,    outputPtr,
+                                  numElements, dataTypeVal, approximateModeVal};
 
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
     rewriter.eraseOp(op);

--- a/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
+++ b/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
@@ -52,7 +52,8 @@ inline constexpr const char *kHipTranspose = "hip_transpose";
 inline constexpr const char *kWrapGather = "wrap_gather";
 inline constexpr const char *kHipSilu = "hip_silu";
 inline constexpr const char *kWrapMiopenActivationForward =
-    "wrap_miopenActivationForward"; // hip.sigmoid
+    "wrap_miopenActivationForward";                   // hip.sigmoid
+inline constexpr const char *kWrapGelu = "wrap_gelu"; // hip.gelu
 inline constexpr const char *kWrapElementwiseSub = "wrap_elementwise_sub";
 inline constexpr const char *kWrapRotaryEmbedding = "wrap_rotary_embedding";
 inline constexpr const char *kWrapMiopenOpTensor =
@@ -100,6 +101,8 @@ inline int64_t getHipdnnDataType(Type elemType) {
     return 4; // HIPDNN_EP_DATATYPE_INT64
   if (elemType.isInteger(8))
     return 5; // HIPDNN_EP_DATATYPE_INT8
+  if (elemType.isF64())
+    return 6; // HIPDNN_EP_DATATYPE_DOUBLE
   return -1;
 }
 

--- a/lib/Conversion/OnnxToHip/ActivationConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ActivationConversion.cpp
@@ -96,11 +96,47 @@ SoftplusToHip::matchAndRewrite(mlir::Operation *op,
   return mlir::success();
 }
 
+/// onnx.Gelu -> hip.gelu
+struct GeluToHip : public mlir::RewritePattern {
+  GeluToHip(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.Gelu", /*benefit=*/1, ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override;
+};
+
+mlir::LogicalResult
+GeluToHip::matchAndRewrite(mlir::Operation *op,
+                           mlir::PatternRewriter &rewriter) const {
+  auto ctxOrFailure = getContextArg(op, rewriter);
+  if (mlir::failed(ctxOrFailure))
+    return mlir::failure();
+  mlir::Value context = *ctxOrFailure;
+
+  mlir::Location loc = op->getLoc();
+  mlir::Value input = op->getOperand(0);
+  auto resultType =
+      mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
+  mlir::Value init = createEmptyTensor(rewriter, loc, resultType, input);
+
+  // Extract approximate attribute from ONNX op (default to "none")
+  mlir::StringAttr approximateAttr = rewriter.getStringAttr("none");
+  if (auto attr = op->getAttrOfType<mlir::StringAttr>("approximate")) {
+    approximateAttr = attr;
+  }
+
+  auto hipOp = mlir::hip::GeluOp::create(rewriter, loc, resultType, context,
+                                         input, init, approximateAttr);
+  rewriter.replaceOp(op, hipOp->getResult(0));
+  return mlir::success();
+}
+
 } // namespace
 
 void mlir::hip::populateActivationConversionPatterns(
     RewritePatternSet &patterns, MLIRContext *ctx) {
-  patterns.add<SoftmaxToHip, SigmoidToHip, SoftplusToHip>(ctx);
+  patterns.add<SoftmaxToHip, SigmoidToHip, SoftplusToHip, GeluToHip>(ctx);
 }
 
 } // namespace hip

--- a/lib/Conversion/OnnxToHip/ActivationConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ActivationConversion.cpp
@@ -120,9 +120,16 @@ GeluToHip::matchAndRewrite(mlir::Operation *op,
       mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
   mlir::Value init = createEmptyTensor(rewriter, loc, resultType, input);
 
-  // Extract approximate attribute from ONNX op (default to "none")
+  // Extract and validate approximate attribute from ONNX op (default to "none")
   mlir::StringAttr approximateAttr = rewriter.getStringAttr("none");
   if (auto attr = op->getAttrOfType<mlir::StringAttr>("approximate")) {
+    llvm::StringRef approxValue = attr.getValue();
+    // Only "none" and "tanh" are valid per ONNX Gelu spec
+    if (approxValue != "none" && approxValue != "tanh") {
+      return rewriter.notifyMatchFailure(op, "invalid approximate attribute '" +
+                                                 approxValue.str() +
+                                                 "', must be 'none' or 'tanh'");
+    }
     approximateAttr = attr;
   }
 

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -554,6 +554,19 @@ void SoftplusOp::getEffects(
         &effects) {
   emitDpsMemoryEffects(getDpsInputOperands(), getDpsInitsMutable(), effects);
 }
+
+//===----------------------------------------------------------------------===//
+// GeluOp: ins(input), outs(output)
+//===----------------------------------------------------------------------===//
+
+MutableOperandRange GeluOp::getDpsInitsMutable() { return getOutputMutable(); }
+
+void GeluOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  emitDpsMemoryEffects(getDpsInputOperands(), getDpsInitsMutable(), effects);
+}
+
 //===----------------------------------------------------------------------===//
 // ReciprocalOp: ins(x), outs(y)
 //===----------------------------------------------------------------------===//

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -35,6 +35,8 @@ extern "C" {
 #define HIPDNN_EP_DATATYPE_BFLOAT16 2 // bf16, 2 bytes
 #define HIPDNN_EP_DATATYPE_INT32 3    // i32, 4 bytes
 #define HIPDNN_EP_DATATYPE_INT64 4    // i64, 8 bytes
+#define HIPDNN_EP_DATATYPE_INT8 5     // i8, 1 byte
+#define HIPDNN_EP_DATATYPE_DOUBLE 6   // f64, 8 bytes
 
 //===----------------------------------------------------------------------===//
 // Backend-Independent Tensor Operation Identifiers
@@ -76,6 +78,10 @@ static inline int64_t hipdnn_ep_datatype_size(int64_t data_type) {
     return 4;
   case HIPDNN_EP_DATATYPE_INT64:
     return 8;
+  case HIPDNN_EP_DATATYPE_INT8:
+    return 1;
+  case HIPDNN_EP_DATATYPE_DOUBLE:
+    return 8;
   default:
     return -1;
   }
@@ -93,6 +99,10 @@ static inline const char *hipdnn_ep_datatype_name(int64_t data_type) {
     return "i32";
   case HIPDNN_EP_DATATYPE_INT64:
     return "i64";
+  case HIPDNN_EP_DATATYPE_INT8:
+    return "i8";
+  case HIPDNN_EP_DATATYPE_DOUBLE:
+    return "f64";
   default:
     return "unknown";
   }
@@ -497,6 +507,13 @@ int wrap_cast(RuntimeState *state, void *input, void *output,
 int wrap_miopenActivationForward(RuntimeState *state, void *input, void *output,
                                  int64_t num_elements, int64_t data_type,
                                  int64_t activation_mode);
+
+// GELU activation wrapper (uses custom HIP kernel)
+// Applies GELU element-wise with support for exact or approximate mode
+// data_type: HIPDNN_EP_DATATYPE_* (supports FLOAT, HALF, BFLOAT16, DOUBLE)
+// approximate: 0 = exact (erf), 1 = tanh approximation
+int wrap_gelu(RuntimeState *state, void *input, void *output,
+              int64_t num_elements, int64_t data_type, int64_t approximate);
 
 // Rotary embedding operation wrapper
 int wrap_rotary_embedding(RuntimeState *state, void *input, void *position_ids,

--- a/lib/Runtime/real/activation.cpp
+++ b/lib/Runtime/real/activation.cpp
@@ -7,6 +7,7 @@
 #include "cache_utils.h"
 #include "error_check_macros.h"
 #include "runtime_types.h"
+#include "hip_custom_kernels.h"
 
 #include <cstdio>
 #include <functional>
@@ -193,5 +194,71 @@ int wrap_miopenActivationForward(RuntimeState *state, void *input, void *output,
 
   RUNTIME_DEBUG_LOG(
       "[REAL] wrap_miopenActivationForward: completed successfully\n");
+  return 0;
+}
+
+//===----------------------------------------------------------------------===//
+// GELU Activation (Custom HIP Kernel)
+//===----------------------------------------------------------------------===//
+//
+// Applies GELU activation using custom HIP kernel (hip_elementwise_gelu).
+// Supports two modes (per ONNX Gelu spec):
+//   - Exact (erf):  GELU(x) = x * 0.5 * (1.0 + erf(x / sqrt(2.0)))
+//   - Tanh approx:  GELU(x) ≈ 0.5 * x * (1 + tanh(sqrt(2/π) * (x + 0.044715 * x³)))
+// Supports data types: f32, f16, bf16, f64.
+// MIOpen does not support GELU activation, so we use a custom kernel.
+//===----------------------------------------------------------------------===//
+
+static int hipdnn_ep_to_hip_dtype_elementwise_unary(int64_t data_type) {
+  switch (data_type) {
+  case HIPDNN_EP_DATATYPE_FLOAT:
+    return HIP_DTYPE_FLOAT32;
+  case HIPDNN_EP_DATATYPE_HALF:
+    return HIP_DTYPE_FLOAT16;
+  case HIPDNN_EP_DATATYPE_BFLOAT16:
+    return HIP_DTYPE_BFLOAT16;
+  case HIPDNN_EP_DATATYPE_DOUBLE:
+    return HIP_DTYPE_FLOAT64;
+  default:
+    return -1;
+  }
+}
+
+int wrap_gelu(RuntimeState *state, void *input, void *output,
+              int64_t num_elements, int64_t data_type, int64_t approximate) {
+  if (!state || !input || !output) {
+    fprintf(stderr, "[REAL] wrap_gelu: null argument\n");
+    return -1;
+  }
+
+  void *stream = hipdnn_ep_state_get_stream(state);
+  int hip_dtype = hipdnn_ep_to_hip_dtype_elementwise_unary(data_type);
+
+  if (hip_dtype < 0) {
+    fprintf(stderr, "[REAL] wrap_gelu: unsupported data_type %lld\n",
+            (long long)data_type);
+    return -1;
+  }
+
+  const char *type_name = hipdnn_ep_datatype_name(data_type);
+  int64_t elem_size = hipdnn_ep_datatype_size(data_type);
+  const char *mode_name = (approximate == 1) ? "tanh" : "erf";
+  RUNTIME_DEBUG_LOG("[REAL] wrap_gelu: num_elements=%lld, data_type=%s(%lld), "
+                    "approximate=%s(%lld), element_size=%lld bytes, "
+                    "total_size=%lld bytes\n",
+                    (long long)num_elements, type_name, (long long)data_type,
+                    mode_name, (long long)approximate, (long long)elem_size,
+                    (long long)(num_elements * elem_size));
+
+  // Call custom HIP kernel with approximate mode
+  int result = hip_elementwise_gelu(stream, input, output, num_elements,
+                                    hip_dtype, approximate);
+
+  if (result != 0) {
+    fprintf(stderr, "[REAL] wrap_gelu: kernel launch failed (%d)\n", result);
+    return -1;
+  }
+
+  RUNTIME_DEBUG_LOG("[REAL] wrap_gelu: completed successfully\n");
   return 0;
 }

--- a/lib/Runtime/real/activation.cpp
+++ b/lib/Runtime/real/activation.cpp
@@ -6,8 +6,8 @@
 #include "../hipdnn_ep_runtime.h"
 #include "cache_utils.h"
 #include "error_check_macros.h"
-#include "runtime_types.h"
 #include "hip_custom_kernels.h"
+#include "runtime_types.h"
 
 #include <cstdio>
 #include <functional>
@@ -204,7 +204,8 @@ int wrap_miopenActivationForward(RuntimeState *state, void *input, void *output,
 // Applies GELU activation using custom HIP kernel (hip_elementwise_gelu).
 // Supports two modes (per ONNX Gelu spec):
 //   - Exact (erf):  GELU(x) = x * 0.5 * (1.0 + erf(x / sqrt(2.0)))
-//   - Tanh approx:  GELU(x) ≈ 0.5 * x * (1 + tanh(sqrt(2/π) * (x + 0.044715 * x³)))
+//   - Tanh approx:  GELU(x) ≈ 0.5 * x * (1 + tanh(sqrt(2/π) * (x + 0.044715 *
+//   x³)))
 // Supports data types: f32, f16, bf16, f64.
 // MIOpen does not support GELU activation, so we use a custom kernel.
 //===----------------------------------------------------------------------===//

--- a/test/lit/Conversion/onnx-to-hip/test_gelu.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_gelu.mlir
@@ -1,0 +1,89 @@
+// RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip | FileCheck %s
+
+module {
+  func.func @main_graph(%arg0: tensor<1x128x768xf16>) -> tensor<1x128x768xf16> {
+    return %arg0 : tensor<1x128x768xf16>
+  }
+
+  // Test 1: Basic GELU with f32
+  // CHECK-LABEL: func.func @test_gelu_f32
+  // CHECK-NOT: onnx.Gelu
+  // CHECK: hip.gelu
+  func.func @test_gelu_f32(%input: tensor<1x1024xf32>) -> tensor<1x1024xf32> {
+    %output = "onnx.Gelu"(%input) : (tensor<1x1024xf32>) -> tensor<1x1024xf32>
+    return %output : tensor<1x1024xf32>
+  }
+
+  // Test 2: GELU with f16
+  // CHECK-LABEL: func.func @test_gelu_f16
+  // CHECK-NOT: onnx.Gelu
+  // CHECK: hip.gelu
+  func.func @test_gelu_f16(%input: tensor<1x128x768xf16>) -> tensor<1x128x768xf16> {
+    %output = "onnx.Gelu"(%input) : (tensor<1x128x768xf16>) -> tensor<1x128x768xf16>
+    return %output : tensor<1x128x768xf16>
+  }
+
+  // Test 3: GELU with bf16
+  // CHECK-LABEL: func.func @test_gelu_bf16
+  // CHECK-NOT: onnx.Gelu
+  // CHECK: hip.gelu
+  func.func @test_gelu_bf16(%input: tensor<2x512xbf16>) -> tensor<2x512xbf16> {
+    %output = "onnx.Gelu"(%input) : (tensor<2x512xbf16>) -> tensor<2x512xbf16>
+    return %output : tensor<2x512xbf16>
+  }
+
+  // Test 4: GELU with dynamic shape
+  // CHECK-LABEL: func.func @test_gelu_dynamic
+  // CHECK-NOT: onnx.Gelu
+  // CHECK: hip.gelu
+  func.func @test_gelu_dynamic(%input: tensor<?x?xf32>) -> tensor<?x?xf32> {
+    %output = "onnx.Gelu"(%input) : (tensor<?x?xf32>) -> tensor<?x?xf32>
+    return %output : tensor<?x?xf32>
+  }
+
+  // Test 5: GELU with 4D tensor (batch, seq_len, hidden_dim)
+  // CHECK-LABEL: func.func @test_gelu_4d
+  // CHECK-NOT: onnx.Gelu
+  // CHECK: hip.gelu
+  func.func @test_gelu_4d(%input: tensor<2x128x12x64xf16>) -> tensor<2x128x12x64xf16> {
+    %output = "onnx.Gelu"(%input) : (tensor<2x128x12x64xf16>) -> tensor<2x128x12x64xf16>
+    return %output : tensor<2x128x12x64xf16>
+  }
+
+  // Test 6: GELU with 1D tensor
+  // CHECK-LABEL: func.func @test_gelu_1d
+  // CHECK-NOT: onnx.Gelu
+  // CHECK: hip.gelu
+  func.func @test_gelu_1d(%input: tensor<768xf32>) -> tensor<768xf32> {
+    %output = "onnx.Gelu"(%input) : (tensor<768xf32>) -> tensor<768xf32>
+    return %output : tensor<768xf32>
+  }
+
+  // Test 7: GELU with approximate="tanh"
+  // CHECK-LABEL: func.func @test_gelu_approximate_tanh
+  // CHECK-NOT: onnx.Gelu
+  // CHECK: hip.gelu{{.*}}approximate = "tanh"
+  func.func @test_gelu_approximate_tanh(%input: tensor<1x1024xf32>) -> tensor<1x1024xf32> {
+    %output = "onnx.Gelu"(%input) {approximate = "tanh"} : (tensor<1x1024xf32>) -> tensor<1x1024xf32>
+    return %output : tensor<1x1024xf32>
+  }
+
+  // Test 8: GELU with approximate="none" (exact erf, default)
+  // CHECK-LABEL: func.func @test_gelu_approximate_none
+  // CHECK-NOT: onnx.Gelu
+  // CHECK: hip.gelu
+  // CHECK-NOT: approximate
+  func.func @test_gelu_approximate_none(%input: tensor<1x1024xf32>) -> tensor<1x1024xf32> {
+    %output = "onnx.Gelu"(%input) {approximate = "none"} : (tensor<1x1024xf32>) -> tensor<1x1024xf32>
+    return %output : tensor<1x1024xf32>
+  }
+
+  // Test 9: GELU with f64 (double) - ONNX spec compliance
+  // CHECK-LABEL: func.func @test_gelu_f64
+  // CHECK-NOT: onnx.Gelu
+  // CHECK: hip.gelu
+  func.func @test_gelu_f64(%input: tensor<1x1024xf64>) -> tensor<1x1024xf64> {
+    %output = "onnx.Gelu"(%input) : (tensor<1x1024xf64>) -> tensor<1x1024xf64>
+    return %output : tensor<1x1024xf64>
+  }
+}

--- a/test/lit/e2e/test_gelu_model.mlir
+++ b/test/lit/e2e/test_gelu_model.mlir
@@ -1,0 +1,23 @@
+// RUN: hip-mlir-opt %s --hipdnn-pipeline | FileCheck %s
+
+module {
+  // Simple model: apply GELU to input
+  func.func @main_graph(%arg0: tensor<1x128x768xf16>) -> tensor<1x128x768xf16> {
+    %gelu = "onnx.Gelu"(%arg0) : (tensor<1x128x768xf16>) -> tensor<1x128x768xf16>
+    return %gelu : tensor<1x128x768xf16>
+  }
+}
+
+// Verify ONNX op is removed
+// CHECK-NOT: onnx.Gelu
+
+// Verify HIP op is removed (lowered to LLVM)
+// CHECK-NOT: hip.gelu
+
+// Verify runtime call is present
+// CHECK: llvm.call @wrap_gelu
+
+// Verify interface functions are generated
+// CHECK: llvm.func @inference_init
+// CHECK: llvm.func @inference_compute
+// CHECK: llvm.func @inference_cleanup

--- a/tools/hip-mlir-opt/hip-mlir-opt.cpp
+++ b/tools/hip-mlir-opt/hip-mlir-opt.cpp
@@ -119,6 +119,8 @@ void registerHipBufferizableOpInterfaceModels(mlir::DialectRegistry &registry) {
         HipDstBufferizableModel<mlir::hip::SigmoidOp>>(*ctx);
     mlir::hip::SoftplusOp::attachInterface<
         HipDstBufferizableModel<mlir::hip::SoftplusOp>>(*ctx);
+    mlir::hip::GeluOp::attachInterface<
+        HipDstBufferizableModel<mlir::hip::GeluOp>>(*ctx);
     mlir::hip::ReciprocalOp::attachInterface<
         HipDstBufferizableModel<mlir::hip::ReciprocalOp>>(*ctx);
     mlir::hip::SqrtOp::attachInterface<

--- a/tools/hip-onnx-runner/hip-onnx-runner.cpp
+++ b/tools/hip-onnx-runner/hip-onnx-runner.cpp
@@ -234,7 +234,8 @@ static uint16_t float_to_fp16_bits(float f) {
   return static_cast<uint16_t>((sign >> 16) | nonsign);
 }
 
-// BFloat16 -> float32 (simple: copy sign bit + upper 7 bits of exponent/mantissa to f32).
+// BFloat16 -> float32 (simple: copy sign bit + upper 7 bits of
+// exponent/mantissa to f32).
 static float bf16_bits_to_float(uint16_t bf16) {
   uint32_t bits = static_cast<uint32_t>(bf16) << 16;
   float result;
@@ -742,7 +743,8 @@ static int run_l2norm_output_dumps(const std::string &dir1_str,
       std::cerr
           << fn
           << ": missing or unknown type tag; expected name ending with _fp32, "
-             "_fp16, _fp64, _bf16, _i64, _i32, _i16, _i8, _u8, or _u16 before .bin\n";
+             "_fp16, _fp64, _bf16, _i64, _i32, _i16, _i8, _u8, or _u16 before "
+             ".bin\n";
       return 1;
     }
     // Bitwise-equal buffers => L2 is 0 (fast path).

--- a/tools/hip-onnx-runner/hip-onnx-runner.cpp
+++ b/tools/hip-onnx-runner/hip-onnx-runner.cpp
@@ -73,6 +73,10 @@ static size_t element_byte_size(ONNXTensorElementDataType t) {
     return 4;
   case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:
     return 2;
+  case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE:
+    return 8;
+  case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16:
+    return 2;
   case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64:
     return 8;
   case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32:
@@ -110,6 +114,10 @@ static const char *onnx_elem_type_tag(ONNXTensorElementDataType t) {
     return "fp32";
   case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:
     return "fp16";
+  case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE:
+    return "fp64";
+  case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16:
+    return "bf16";
   case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64:
     return "i64";
   case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32:
@@ -222,6 +230,25 @@ static uint16_t float_to_fp16_bits(float f) {
   return static_cast<uint16_t>((sign >> 16) | nonsign);
 }
 
+// BFloat16 -> float32 (simple: copy sign bit + upper 7 bits of exponent/mantissa to f32).
+static float bf16_bits_to_float(uint16_t bf16) {
+  uint32_t bits = static_cast<uint32_t>(bf16) << 16;
+  float result;
+  std::memcpy(&result, &bits, sizeof(result));
+  return result;
+}
+
+// float32 -> BFloat16 bits (round-to-nearest-even truncation).
+static uint16_t float_to_bf16_bits(float f) {
+  uint32_t bits;
+  std::memcpy(&bits, &f, sizeof(bits));
+  // Round to nearest even: check if we need to round up
+  uint32_t lsb = (bits >> 16) & 1;
+  uint32_t rounding_bias = 0x7fff + lsb;
+  bits += rounding_bias;
+  return static_cast<uint16_t>(bits >> 16);
+}
+
 // Random fill matching element type (do not reinterpret float bits as
 // int/fp16). Integers: uniform over the full representable range of each type.
 // Float32/fp16: keep a modest interval (same order as the old float-only path)
@@ -254,6 +281,20 @@ static void fill_random_input_buffer(char *dst, size_t nbytes,
     const size_t n = nbytes / sizeof(uint16_t);
     for (size_t i = 0; i < n; ++i)
       p[i] = float_to_fp16_bits(fdist(rng));
+    return;
+  }
+  case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE: {
+    auto *p = reinterpret_cast<double *>(dst);
+    const size_t n = nbytes / sizeof(double);
+    for (size_t i = 0; i < n; ++i)
+      p[i] = static_cast<double>(fdist(rng));
+    return;
+  }
+  case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16: {
+    auto *p = reinterpret_cast<uint16_t *>(dst);
+    const size_t n = nbytes / sizeof(uint16_t);
+    for (size_t i = 0; i < n; ++i)
+      p[i] = float_to_bf16_bits(fdist(rng));
     return;
   }
   case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64: {
@@ -518,6 +559,37 @@ static bool squared_l2_diff_elementwise(
     for (size_t i = 0; i < n; ++i) {
       const float fa = fp16_bits_to_float(pa[i]);
       const float fb = fp16_bits_to_float(pb[i]);
+      if (!std::isfinite(static_cast<double>(fa)) ||
+          !std::isfinite(static_cast<double>(fb))) {
+        skipped_nonfinite++;
+        continue;
+      }
+      const double d = static_cast<double>(fa) - static_cast<double>(fb);
+      s += d * d;
+      used_elems++;
+    }
+    break;
+  }
+  case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE: {
+    const auto *pa = reinterpret_cast<const double *>(a.data());
+    const auto *pb = reinterpret_cast<const double *>(b.data());
+    for (size_t i = 0; i < n; ++i) {
+      if (!std::isfinite(pa[i]) || !std::isfinite(pb[i])) {
+        skipped_nonfinite++;
+        continue;
+      }
+      const double d = pa[i] - pb[i];
+      s += d * d;
+      used_elems++;
+    }
+    break;
+  }
+  case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16: {
+    const auto *pa = reinterpret_cast<const uint16_t *>(a.data());
+    const auto *pb = reinterpret_cast<const uint16_t *>(b.data());
+    for (size_t i = 0; i < n; ++i) {
+      const float fa = bf16_bits_to_float(pa[i]);
+      const float fb = bf16_bits_to_float(pb[i]);
       if (!std::isfinite(static_cast<double>(fa)) ||
           !std::isfinite(static_cast<double>(fb))) {
         skipped_nonfinite++;

--- a/tools/hip-onnx-runner/hip-onnx-runner.cpp
+++ b/tools/hip-onnx-runner/hip-onnx-runner.cpp
@@ -376,6 +376,12 @@ static bool ort_tensor_raw_bytes(const Ort::Value &v, const void *&out_ptr,
   case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:
     out_ptr = v.GetTensorData<Ort::Float16_t>();
     return true;
+  case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE:
+    out_ptr = v.GetTensorData<double>();
+    return true;
+  case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16:
+    out_ptr = v.GetTensorData<Ort::BFloat16_t>();
+    return true;
   case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64:
     out_ptr = v.GetTensorData<int64_t>();
     return true;

--- a/tools/hip-onnx-runner/hip-onnx-runner.cpp
+++ b/tools/hip-onnx-runner/hip-onnx-runner.cpp
@@ -142,6 +142,10 @@ static bool type_tag_to_onnx(const std::string &tag,
     out = ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT;
   else if (tag == "fp16")
     out = ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16;
+  else if (tag == "fp64")
+    out = ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE;
+  else if (tag == "bf16")
+    out = ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16;
   else if (tag == "i64")
     out = ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64;
   else if (tag == "i32")
@@ -738,7 +742,7 @@ static int run_l2norm_output_dumps(const std::string &dir1_str,
       std::cerr
           << fn
           << ": missing or unknown type tag; expected name ending with _fp32, "
-             "_fp16, _i64, _i32, _i16, _i8, _u8, or _u16 before .bin\n";
+             "_fp16, _fp64, _bf16, _i64, _i32, _i16, _i8, _u8, or _u16 before .bin\n";
       return 1;
     }
     // Bitwise-equal buffers => L2 is 0 (fast path).


### PR DESCRIPTION
## Summary

Implements GELU (Gaussian Error Linear Unit) activation operator using a custom HIP kernel. GELU is widely used in transformer models (BERT, GPT) and is essential for modern neural network inference.

### Why custom HIP Kernel
- MIOpen does not provide native GELU support as of ROCm 6.x

## GELU Formulas

**1. Exact (erf mode):** ： GELU(x) = x * 0.5 * (1.0 + erf(x / sqrt(2.0)))

**2. Tanh approximation (fast mode):**：  GELU(x) ≈ 0.5 * x * (1 + tanh(sqrt(2/π) * (x + 0.044715 * x³)))

## Implementation

- 4-stage pipeline: `onnx.Gelu → hip.gelu → wrap_gelu() → HIP kernel`
- Template-based kernel design with GeluTraits pattern
- Type-specific optimizations (f16/bf16 compute in f32)
- MIOpen does not support GELU, hence custom kernel approach

## Features

- **Data types:** f32, f16, bf16, f64 (per ONNX spec)
- **Approximate modes:** "none" (exact erf) and "tanh" (fast approximation)
- **Dynamic shape support** with runtime num_elements calculation
- **DPS interface** (Destination-Passing Style) for bufferization

## Test Coverage:
- ✅ 9 comprehensive LIT tests covering all data types (f32, f16, bf16, f64)
- ✅ Tests for both approximate modes ("none", "tanh")
- ✅ Dynamic and static shape coverage
- ✅ 1D, 2D, 4D tensor tests
- ✅ End-to-end pipeline validation