### PR TITLE
feat: enable GPU memory pipeline for OGA m=16384 KV cache

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -36,7 +36,7 @@ jobs:
       THEROCK_VERSION: therock-dist-windows-gfx1151-7.11.0
       SCCACHE_GHA_ENABLED: "true"
       OGA_REPO: AMDmoore/onnxruntime-genai
-      OGA_REF: 5b547c7ec3be521d8590ae0c5f3e0ac450af0b7a
+      OGA_REF: c4fc2873abe020438e5cf8289b161fb6747554e5
       # ilammy/msvc-dev-cmd and mozilla-actions/sccache-action have no
       # Node.js 24 releases yet; allow Node.js 20 until they are updated.
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -36,7 +36,7 @@ jobs:
       THEROCK_VERSION: therock-dist-windows-gfx1151-7.11.0
       SCCACHE_GHA_ENABLED: "true"
       OGA_REPO: AMDmoore/onnxruntime-genai
-      OGA_REF: c4fc2873abe020438e5cf8289b161fb6747554e5
+      OGA_REF: 220b79ff0f19501957b56c40eb2a0089bf3d97c9
       # ilammy/msvc-dev-cmd and mozilla-actions/sccache-action have no
       # Node.js 24 releases yet; allow Node.js 20 until they are updated.
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -36,7 +36,7 @@ jobs:
       THEROCK_VERSION: therock-dist-windows-gfx1151-7.11.0
       SCCACHE_GHA_ENABLED: "true"
       OGA_REPO: AMDmoore/onnxruntime-genai
-      OGA_REF: 220b79ff0f19501957b56c40eb2a0089bf3d97c9
+      OGA_REF: c886da303a669377e2dcbb306c06a55da9355731
       # ilammy/msvc-dev-cmd and mozilla-actions/sccache-action have no
       # Node.js 24 releases yet; allow Node.js 20 until they are updated.
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"

--- a/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
+++ b/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
@@ -138,10 +138,17 @@ TensorData marshal_input_tensors(OrtKernelContext *context,
     data.tensors[i].rank = data.shapes[i].size();
     data.tensors[i].element_size =
         ort_element_size(tensor_info.GetElementType());
+    // Carry the OrtValue's OrtMemoryInfoDeviceType straight into
+    // tensor_t.memory_type (the enum values are 1:1, see custom_op_mlir.hpp).
+    // prepare_input fast-paths TENSOR_MEMORY_GPU into an alias (no H2D copy);
+    // CPU / FPGA / NPU fall through to the legacy host H2D path.
+    data.tensors[i].memory_type =
+        static_cast<int>(input_tensor.GetTensorMemoryInfo().GetDeviceType());
 
     MY_LOG(3) << "Input[" << i << "] (ort_idx=" << ort_idx
               << "): rank=" << data.tensors[i].rank
-              << " element_size=" << data.tensors[i].element_size;
+              << " element_size=" << data.tensors[i].element_size
+              << " memory_type=" << data.tensors[i].memory_type;
   }
 
   data.span.data = data.tensors.data();
@@ -213,10 +220,17 @@ TensorData marshal_output_tensors(
     data.tensors[i].shape = data.shapes[i].data();
     data.tensors[i].rank = data.shapes[i].size();
     data.tensors[i].element_size = onnx_elem_type_size(output_meta.elem_type());
+    // Same memory-type carry-over as inputs (lets finalize_output skip the
+    // per-inference D2H when ORT pre-allocated the output OrtValue in our
+    // morphizen GPU-mapped memory; matters for present_key/value sharing
+    // buffers with past_key/value under past_present_share_buffer=true).
+    data.tensors[i].memory_type =
+        static_cast<int>(output_tensor.GetTensorMemoryInfo().GetDeviceType());
 
     MY_LOG(3) << "Output[" << i << "] (ort_idx=" << ort_idx
               << "): rank=" << data.tensors[i].rank
-              << " element_size=" << data.tensors[i].element_size;
+              << " element_size=" << data.tensors[i].element_size
+              << " memory_type=" << data.tensors[i].memory_type;
   }
 
   data.span.data = data.tensors.data();

--- a/backend-mlir-compiler/custom-op-mlir/src/custom_op_mlir.hpp
+++ b/backend-mlir-compiler/custom-op-mlir/src/custom_op_mlir.hpp
@@ -42,9 +42,13 @@ enum {
 // Memory ownership: caller-owned. `memory_type` selects the data pointer's
 // placement (see the enum above) and tells the DLL whether to copy or alias.
 //
-// IMPORTANT: this layout is duplicated as `tensor_t` in
-// `lib/Runtime/hipdnn_ep_runtime.h` (extern-C version consumed by the
-// MLIR-compiled model.dll). Keep the two definitions byte-for-byte identical.
+// tensor_t is the wire-protocol ABI between three components that are
+// intentionally kept decoupled (compiler-emitted model.dll, EP runtime
+// DLL, hip-test-dll harness), so we re-declare it here instead of
+// sharing a header. The static_assert block below catches any layout
+// drift at compile time. Sibling copies live at:
+//   * `lib/Runtime/hipdnn_ep_runtime.h`            (extern-C, EP runtime)
+//   * `tools/hip-test-dll/hip-test-dll.cpp`        (test driver, local)
 struct tensor_t {
   void *data;     // Pointer to contiguous tensor data (caller-owned)
   int64_t *shape; // Pointer to shape array of length `rank` (caller-owned)
@@ -53,15 +57,12 @@ struct tensor_t {
   int memory_type;     // One of TENSOR_MEMORY_CPU / _GPU / _FPGA / _NPU
 };
 
-// Compile-time guard against silent layout drift between the three places
-// that duplicate this struct (this header, lib/Runtime/hipdnn_ep_runtime.h,
-// tools/hip-test-dll/hip-test-dll.cpp). The same three asserts live in all
-// three files; if you reorder/add/remove a field in one place you have to
-// touch all three or one of these will fire at build time.
-//
-// We assert per-field offsets, not raw sizeof(tensor_t), because trailing
-// padding after `memory_type` is compiler-defined and not part of what the
-// MLIR-emitted model.dll actually reads.
+// Compile-time guard for the wire-protocol ABI described above. The same
+// three asserts live in each of the three sibling headers; if you reorder
+// / add / remove a field in one copy and forget to mirror it in the others,
+// at least one of them fails to build. Per-field offsets (not raw sizeof)
+// because trailing padding after `memory_type` is compiler-defined and not
+// part of what model.dll actually reads.
 static_assert(offsetof(tensor_t, data) == 0,
               "tensor_t.data must remain the first field");
 static_assert(offsetof(tensor_t, shape) == sizeof(void *),

--- a/backend-mlir-compiler/custom-op-mlir/src/custom_op_mlir.hpp
+++ b/backend-mlir-compiler/custom-op-mlir/src/custom_op_mlir.hpp
@@ -13,13 +13,44 @@ namespace mlir_compilation {
 // Data structures — C-compatible, stable ABI
 // ============================================================================
 
+// Memory placement of a tensor's `data` pointer. Carried as an int in
+// tensor_t so the enum is forward-compatible without breaking the on-the-wire
+// ABI between marshalling (onnxruntime_morphizen_ep.dll) and the MLIR-compiled
+// model.dll.
+//
+// IMPORTANT: values are 1:1 with ORT's OrtMemoryInfoDeviceType
+// (onnxruntime_c_api.h). MlirCustomOp can therefore write the ORT value
+// straight into tensor_t.memory_type with no remapping. Today the runtime
+// only special-cases TENSOR_MEMORY_GPU (alias path); CPU / FPGA / NPU all
+// fall through to the legacy host H2D / D2H path, preserving existing
+// behaviour for hip-test-dll, hip-onnx-runner, and any other host-input
+// caller.
+//
+// Must match the matching enum in `lib/Runtime/hipdnn_ep_runtime.h`.
+enum {
+  TENSOR_MEMORY_CPU = 0, // == OrtMemoryInfoDeviceType_CPU
+  TENSOR_MEMORY_GPU = 1, // == OrtMemoryInfoDeviceType_GPU  (alias path; only
+                         // mode optimized today)
+  TENSOR_MEMORY_FPGA =
+      2, // == OrtMemoryInfoDeviceType_FPGA (treated as host today)
+  TENSOR_MEMORY_NPU =
+      3, // == OrtMemoryInfoDeviceType_NPU  (treated as host today)
+};
+
 // Describes a single tensor passed across the DLL boundary.
-// All memory is caller-owned CPU memory; the DLL copies H2D/D2H internally.
+//
+// Memory ownership: caller-owned. `memory_type` selects the data pointer's
+// placement (see the enum above) and tells the DLL whether to copy or alias.
+//
+// IMPORTANT: this layout is duplicated as `tensor_t` in
+// `lib/Runtime/hipdnn_ep_runtime.h` (extern-C version consumed by the
+// MLIR-compiled model.dll). Keep the two definitions byte-for-byte identical.
 struct tensor_t {
-  void *data; // Pointer to contiguous tensor data (CPU memory, caller-owned)
+  void *data;     // Pointer to contiguous tensor data (caller-owned)
   int64_t *shape; // Pointer to shape array of length `rank` (caller-owned)
   size_t rank;    // Number of dimensions (must match the compiled model's rank)
   size_t element_size; // Bytes per element (e.g. 4=float32, 2=float16, 8=int64)
+  int memory_type;     // One of TENSOR_MEMORY_CPU / _GPU / _FPGA / _NPU
 };
 
 // A contiguous array of tensor_t descriptors (inputs or outputs).

--- a/backend-mlir-compiler/custom-op-mlir/src/custom_op_mlir.hpp
+++ b/backend-mlir-compiler/custom-op-mlir/src/custom_op_mlir.hpp
@@ -53,6 +53,24 @@ struct tensor_t {
   int memory_type;     // One of TENSOR_MEMORY_CPU / _GPU / _FPGA / _NPU
 };
 
+// Compile-time guard against silent layout drift between the three places
+// that duplicate this struct (this header, lib/Runtime/hipdnn_ep_runtime.h,
+// tools/hip-test-dll/hip-test-dll.cpp). The same three asserts live in all
+// three files; if you reorder/add/remove a field in one place you have to
+// touch all three or one of these will fire at build time.
+//
+// We assert per-field offsets, not raw sizeof(tensor_t), because trailing
+// padding after `memory_type` is compiler-defined and not part of what the
+// MLIR-emitted model.dll actually reads.
+static_assert(offsetof(tensor_t, data) == 0,
+              "tensor_t.data must remain the first field");
+static_assert(offsetof(tensor_t, shape) == sizeof(void *),
+              "tensor_t.shape moved -- update all three tensor_t copies");
+static_assert(offsetof(tensor_t, memory_type) ==
+                  offsetof(tensor_t, element_size) + sizeof(size_t),
+              "tensor_t.memory_type moved -- update all three tensor_t "
+              "copies");
+
 // A contiguous array of tensor_t descriptors (inputs or outputs).
 struct span_t {
   tensor_t *data; // Pointer to array of tensor_t

--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -78,5 +78,34 @@ set(morphizen_OUTPUT_NAME "onnxruntime_morphizen_ep" CACHE STRING "Set output na
 set(MORPHIZEN_VERSEION_INFO_FILE "${CMAKE_CURRENT_BINARY_DIR}/version.txt")
 set(MORPHIZEN_JSON_CONFIG_FILE "${CMAKE_CURRENT_SOURCE_DIR}/etc/morphizen_config.json")
 
+# Compile a hipHostMalloc(Mapped|Coherent)-based OrtAllocator + DataTransfer
+# into the EP factory so that all EP consumers (hip-onnx-runner, perf_test,
+# OGA via ORT) place tensors in GPU-mapped memory rather than host RAM. This
+# is what lets OGA recognise MorphiZen EP as a GPU device and skip the full
+# H2D/D2H copy of the KV cache on every decode step.
+#
+# Mock builds (BUILD_MOCK_RUNTIME=ON, the CMake default) intentionally don't
+# require ROCm/TheRock, so the morphizen ort-bridge `find_package(hip)` would
+# fail. Leave the option at its standalone-MorphiZen default (OFF) for those
+# builds. For real builds we also need to seed HIP_PLATFORM here, before the
+# add_subdirectory(3rd-party/morphizen) below triggers find_package(hip),
+# because TheRock's hip-config.cmake errors out on "Unexpected HIP_PLATFORM"
+# otherwise. (3rd-party/custom_kernels/cmake/hip_utils.cmake also seeds it,
+# but that subdir is added later in the top-level CMakeLists.txt.)
+#
+# This deps.cmake is included from the top-level CMakeLists.txt before its
+# own `option(BUILD_MOCK_RUNTIME ...)` declaration, so we re-declare the
+# same option here (option() is idempotent — keeps the value if already set
+# on the command line via -DBUILD_MOCK_RUNTIME=...). Keep the default in
+# sync with the top-level declaration.
+option(BUILD_MOCK_RUNTIME "Build mock runtime (no GPU required)" ON)
+
+if(NOT BUILD_MOCK_RUNTIME)
+  if(NOT DEFINED HIP_PLATFORM)
+    set(HIP_PLATFORM "amd" CACHE STRING "HIP platform (amd or nvidia)")
+  endif()
+  set(morphizen_ENABLE_HIP_GPU_ALLOCATOR ON CACHE BOOL "enable hipHostMalloc-based OrtAllocator + DataTransfer in MorphiZen EP factory (requires HIP runtime)" FORCE)
+endif()
+
 # Add morphizen subdirectory (after all options are set)
 add_subdirectory(3rd-party/morphizen)

--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -78,33 +78,39 @@ set(morphizen_OUTPUT_NAME "onnxruntime_morphizen_ep" CACHE STRING "Set output na
 set(MORPHIZEN_VERSEION_INFO_FILE "${CMAKE_CURRENT_BINARY_DIR}/version.txt")
 set(MORPHIZEN_JSON_CONFIG_FILE "${CMAKE_CURRENT_SOURCE_DIR}/etc/morphizen_config.json")
 
-# Compile a hipHostMalloc(Mapped|Coherent)-based OrtAllocator + DataTransfer
-# into the EP factory so that all EP consumers (hip-onnx-runner, perf_test,
-# OGA via ORT) place tensors in GPU-mapped memory rather than host RAM. This
-# is what lets OGA recognise MorphiZen EP as a GPU device and skip the full
-# H2D/D2H copy of the KV cache on every decode step.
+# Cross-wire BUILD_MOCK_RUNTIME (this project) <-> morphizen's HIP GPU
+# allocator option so the same build invocation does the right thing on
+# both sides:
 #
-# Mock builds (BUILD_MOCK_RUNTIME=ON, the CMake default) intentionally don't
-# require ROCm/TheRock, so the morphizen ort-bridge `find_package(hip)` would
-# fail. Leave the option at its standalone-MorphiZen default (OFF) for those
-# builds. For real builds we also need to seed HIP_PLATFORM here, before the
-# add_subdirectory(3rd-party/morphizen) below triggers find_package(hip),
-# because TheRock's hip-config.cmake errors out on "Unexpected HIP_PLATFORM"
-# otherwise. (3rd-party/custom_kernels/cmake/hip_utils.cmake also seeds it,
-# but that subdir is added later in the top-level CMakeLists.txt.)
+#   * Real build (BUILD_MOCK_RUNTIME=OFF): we want morphizen's HIP allocator,
+#     which means find_package(hip) needs HIP_PLATFORM seeded *before*
+#     add_subdirectory(3rd-party/morphizen) below; otherwise TheRock's
+#     hip-config.cmake errors out with "Unexpected HIP_PLATFORM:".
+#     (3rd-party/custom_kernels/cmake/hip_utils.cmake seeds it too, but
+#     that subdir is added later in the top-level CMakeLists.txt.)
+#     Morphizen's option default is already ON, so we don't have to FORCE
+#     it -- but we don't actively turn it off either.
+#
+#   * Mock build (BUILD_MOCK_RUNTIME=ON, the project default): the toolchain
+#     by definition has no ROCm SDK, so find_package(hip REQUIRED) inside
+#     morphizen's ort-bridge would fail at configure time. Force morphizen's
+#     allocator OFF so the EP DLL still compiles in mock mode (it just won't
+#     register a HIP-backed allocator -- which is fine, mock can't run on
+#     GPU anyway). Morphizen's own configure-time WARNING for ORT_BRIDGE +
+#     ALLOCATOR=OFF is the expected, advertised-behavior signal here.
 #
 # This deps.cmake is included from the top-level CMakeLists.txt before its
-# own `option(BUILD_MOCK_RUNTIME ...)` declaration, so we re-declare the
-# same option here (option() is idempotent — keeps the value if already set
-# on the command line via -DBUILD_MOCK_RUNTIME=...). Keep the default in
-# sync with the top-level declaration.
+# own `option(BUILD_MOCK_RUNTIME ...)` declaration, so we re-declare it
+# here (option() keeps the value if already set on the command line via
+# -DBUILD_MOCK_RUNTIME=...). Keep the default in sync with the top-level.
 option(BUILD_MOCK_RUNTIME "Build mock runtime (no GPU required)" ON)
 
-if(NOT BUILD_MOCK_RUNTIME)
+if(BUILD_MOCK_RUNTIME)
+  set(morphizen_ENABLE_HIP_GPU_ALLOCATOR OFF CACHE BOOL "disabled in mock builds (no ROCm SDK available)" FORCE)
+else()
   if(NOT DEFINED HIP_PLATFORM)
     set(HIP_PLATFORM "amd" CACHE STRING "HIP platform (amd or nvidia)")
   endif()
-  set(morphizen_ENABLE_HIP_GPU_ALLOCATOR ON CACHE BOOL "enable hipHostMalloc-based OrtAllocator + DataTransfer in MorphiZen EP factory (requires HIP runtime)" FORCE)
 endif()
 
 # Add morphizen subdirectory (after all options are set)

--- a/lib/Runtime/debug_log.h
+++ b/lib/Runtime/debug_log.h
@@ -19,15 +19,31 @@ inline bool hipdnn_ep_debug_enabled() {
 }
 
 inline bool hipdnn_ep_perf_enabled() {
+  // PERF intentionally does NOT inherit from HIPDNN_EP_DEBUG: enabling PERF
+  // forces a hipStreamSynchronize on every inference (so hipEventElapsedTime
+  // can sample the H2D / Compute / D2H phases), which serializes the GPU
+  // pipeline and skews measurements. Users who only want the per-call
+  // [Runtime DEBUG] traces should not pay that cost.
   static const bool enabled = [] {
     const char *v = std::getenv("HIPDNN_EP_PERF");
     return v && v[0] >= '1';
   }();
-  return enabled || hipdnn_ep_debug_enabled();
+  return enabled;
 }
 
 #define RUNTIME_DEBUG_LOG(fmt, ...)                                            \
   do {                                                                         \
     if (hipdnn_ep_debug_enabled())                                             \
+      fprintf(stderr, fmt, ##__VA_ARGS__);                                     \
+  } while (0)
+
+// Conditional fprintf to stderr, gated on HIPDNN_EP_PERF only (DEBUG does
+// not enable PERF; see hipdnn_ep_perf_enabled() above for why). Used by the
+// per-inference [PERF] timing breakdown emitted from
+// hipdnn_ep_runtime_tensor.cpp. Arguments are only evaluated when PERF is
+// enabled, so leaving HIPDNN_EP_PERF unset has zero overhead.
+#define RUNTIME_PERF_LOG(fmt, ...)                                             \
+  do {                                                                         \
+    if (hipdnn_ep_perf_enabled())                                              \
       fprintf(stderr, fmt, ##__VA_ARGS__);                                     \
   } while (0)

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -213,12 +213,44 @@ int hipdnn_ep_pool_init(RuntimeState *state, size_t pool_size,
 // Inference API Types (for generated interface)
 //===----------------------------------------------------------------------===//
 
-// Represents a tensor with host data and shape information
+// Memory placement of a tensor's `data` pointer. Values are 1:1 with ORT's
+// OrtMemoryInfoDeviceType (onnxruntime_c_api.h) so MlirCustomOp can write
+// the ORT value straight into tensor_t.memory_type with no remapping.
+//
+// Today the runtime only special-cases TENSOR_MEMORY_GPU (alias path,
+// avoids the per-inference H2D / D2H copy on AMD APU iGPU mapped-pinned
+// memory). CPU / FPGA / NPU all fall through to the legacy host H2D / D2H
+// path, preserving existing behaviour for hip-test-dll, hip-onnx-runner,
+// and any other host-input caller.
+//
+// Must match the matching enum in
+// `backend-mlir-compiler/custom-op-mlir/src/custom_op_mlir.hpp`.
+enum {
+  TENSOR_MEMORY_CPU = 0, // == OrtMemoryInfoDeviceType_CPU
+  TENSOR_MEMORY_GPU = 1, // == OrtMemoryInfoDeviceType_GPU  (alias path; only
+                         // mode optimized today)
+  TENSOR_MEMORY_FPGA =
+      2, // == OrtMemoryInfoDeviceType_FPGA (treated as host today)
+  TENSOR_MEMORY_NPU =
+      3, // == OrtMemoryInfoDeviceType_NPU  (treated as host today)
+};
+
+// Represents a tensor with data pointer and shape information.
+//
+// Memory ownership: caller-owned. `memory_type` selects the data pointer's
+// placement (see the enum above) and tells prepare_input/finalize_output
+// whether to copy H2D/D2H or alias the caller's GPU-accessible buffer.
+//
+// IMPORTANT: this layout is duplicated as `tensor_t` in
+// `backend-mlir-compiler/custom-op-mlir/src/custom_op_mlir.hpp` (C++ version
+// consumed by MlirCustomOp marshalling). Keep the two definitions
+// byte-for-byte identical.
 typedef struct {
-  void *data;          // Host data pointer
+  void *data;          // Data pointer (host or GPU-accessible per memory_type)
   int64_t *shape;      // Array of dimension sizes
   size_t rank;         // Number of dimensions
   size_t element_size; // Bytes per element (e.g. 4=float32, 2=float16, 8=int64)
+  int memory_type;     // One of TENSOR_MEMORY_CPU / _GPU / _FPGA / _NPU
 } tensor_t;
 
 // Represents a span of tensors (inputs or outputs)
@@ -230,12 +262,17 @@ typedef struct {
 // Represents a prepared tensor with GPU buffer and metadata
 // Used internally by tensor preparation helpers
 typedef struct {
-  void *gpu_ptr;      // GPU memory (allocated or from pool)
+  void *gpu_ptr;      // GPU memory (allocated, from pool, or aliased)
   void *host_ptr;     // Host memory (from tensor_t.data)
   int64_t *shape_ptr; // Shape array (from tensor_t.shape) for memref building
   size_t rank;        // Tensor rank (for validation)
   size_t size_bytes;  // Buffer size
   bool is_pooled;     // Internal: true if from pool, false if allocated
+  // Internal: true if gpu_ptr aliases caller's GPU-accessible memory
+  // (tensor_t.memory_type == TENSOR_MEMORY_GPU). When set, finalize_output
+  // skips the D2H copy and free_input skips pool_release/hipFree because
+  // the memory is owned by the caller, not by us.
+  bool is_aliased;
 } TensorBuffer;
 
 //===----------------------------------------------------------------------===//

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -253,6 +253,25 @@ typedef struct {
   int memory_type;     // One of TENSOR_MEMORY_CPU / _GPU / _FPGA / _NPU
 } tensor_t;
 
+// Compile-time guard against silent layout drift between the three places
+// that duplicate this struct (this header,
+// backend-mlir-compiler/custom-op-mlir/src/custom_op_mlir.hpp, and
+// tools/hip-test-dll/hip-test-dll.cpp). The same three asserts live in all
+// three files; if you reorder/add/remove a field in one place you have to
+// touch all three or one of these will fire at build time.
+//
+// We assert per-field offsets, not raw sizeof(tensor_t), because trailing
+// padding after `memory_type` is compiler-defined and not part of what the
+// MLIR-emitted model.dll actually reads.
+static_assert(offsetof(tensor_t, data) == 0,
+              "tensor_t.data must remain the first field");
+static_assert(offsetof(tensor_t, shape) == sizeof(void *),
+              "tensor_t.shape moved -- update all three tensor_t copies");
+static_assert(offsetof(tensor_t, memory_type) ==
+                  offsetof(tensor_t, element_size) + sizeof(size_t),
+              "tensor_t.memory_type moved -- update all three tensor_t "
+              "copies");
+
 // Represents a span of tensors (inputs or outputs)
 typedef struct {
   tensor_t *data; // Array of tensors

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -241,10 +241,14 @@ enum {
 // placement (see the enum above) and tells prepare_input/finalize_output
 // whether to copy H2D/D2H or alias the caller's GPU-accessible buffer.
 //
-// IMPORTANT: this layout is duplicated as `tensor_t` in
-// `backend-mlir-compiler/custom-op-mlir/src/custom_op_mlir.hpp` (C++ version
-// consumed by MlirCustomOp marshalling). Keep the two definitions
-// byte-for-byte identical.
+// tensor_t is the wire-protocol ABI between three components that are
+// intentionally kept decoupled (compiler-emitted model.dll, EP runtime
+// DLL, hip-test-dll harness), so we re-declare it here instead of
+// sharing a header. The static_assert block below catches any layout
+// drift at compile time. Sibling copies live at:
+//   * `backend-mlir-compiler/custom-op-mlir/src/custom_op_mlir.hpp` (compiler)
+//   * `tools/hip-test-dll/hip-test-dll.cpp`                         (test
+//   driver)
 typedef struct {
   void *data;          // Data pointer (host or GPU-accessible per memory_type)
   int64_t *shape;      // Array of dimension sizes
@@ -253,16 +257,12 @@ typedef struct {
   int memory_type;     // One of TENSOR_MEMORY_CPU / _GPU / _FPGA / _NPU
 } tensor_t;
 
-// Compile-time guard against silent layout drift between the three places
-// that duplicate this struct (this header,
-// backend-mlir-compiler/custom-op-mlir/src/custom_op_mlir.hpp, and
-// tools/hip-test-dll/hip-test-dll.cpp). The same three asserts live in all
-// three files; if you reorder/add/remove a field in one place you have to
-// touch all three or one of these will fire at build time.
-//
-// We assert per-field offsets, not raw sizeof(tensor_t), because trailing
-// padding after `memory_type` is compiler-defined and not part of what the
-// MLIR-emitted model.dll actually reads.
+// Compile-time guard for the wire-protocol ABI described above. The same
+// three asserts live in each of the three sibling headers; if you reorder
+// / add / remove a field in one copy and forget to mirror it in the others,
+// at least one of them fails to build. Per-field offsets (not raw sizeof)
+// because trailing padding after `memory_type` is compiler-defined and not
+// part of what model.dll actually reads.
 static_assert(offsetof(tensor_t, data) == 0,
               "tensor_t.data must remain the first field");
 static_assert(offsetof(tensor_t, shape) == sizeof(void *),

--- a/lib/Runtime/hipdnn_ep_runtime_tensor.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_tensor.cpp
@@ -296,41 +296,85 @@ int hipdnn_ep_tensor_prepare_input(RuntimeState *state, span_t *inputs,
 
   RUNTIME_DEBUG_LOG(
       "[Runtime DEBUG] prepare_input[%zu]: rank=%zu element_size=%zu "
-      "size_bytes=%zu\n",
-      index, tensor->rank, element_size, size_bytes);
+      "size_bytes=%zu memory_type=%d\n",
+      index, tensor->rank, element_size, size_bytes, tensor->memory_type);
 
-  // Allocate GPU buffer (pool reuses across inferences)
-  void *gpu_ptr = pool_alloc(size_bytes);
-  if (!gpu_ptr) {
-    fprintf(stderr,
-            "hipdnn_ep_tensor_prepare_input: failed to allocate %zu bytes\n",
-            size_bytes);
-    return HIPDNN_EP_ERR_GPU_ALLOC_FAILED;
+  // Fast path: caller already placed `data` in GPU-accessible memory
+  // (TENSOR_MEMORY_GPU), so we alias the buffer instead of pool_alloc + H2D.
+  // This is the path that eliminates the per-decode 2 GB KV-cache H2D copy
+  // when OGA's MorphiZenEP device interface allocated KV cache via our
+  // hipHostMalloc(Mapped|Coherent) allocator (path A). The caller still owns
+  // the buffer; finalize_output / free_input must skip pool_release in
+  // this case (gated by TensorBuffer.is_aliased).
+  //
+  // Other memory_type values (CPU / FPGA / NPU) fall through to the legacy
+  // host H2D path below — preserves behaviour for hip-test-dll,
+  // hip-onnx-runner, and the OGA path-B-only configuration where KV cache
+  // still lives in host RAM.
+  const bool alias_caller_buffer = (tensor->memory_type == TENSOR_MEMORY_GPU);
+  void *gpu_ptr = nullptr;
+  if (alias_caller_buffer) {
+    gpu_ptr = tensor->data;
+  } else {
+    // Allocate GPU buffer (pool reuses across inferences)
+    gpu_ptr = pool_alloc(size_bytes);
+    if (!gpu_ptr) {
+      fprintf(stderr,
+              "hipdnn_ep_tensor_prepare_input: failed to allocate %zu bytes\n",
+              size_bytes);
+      return HIPDNN_EP_ERR_GPU_ALLOC_FAILED;
+    }
   }
 
-  // PERF: record H2D start on first input
+  // PERF: at the start of each new inference, flush the previous inference's
+  // timing breakdown (one line, easy to grep) and open a new window. We
+  // piggy-back on prepare_input(0) instead of using a dedicated sync hook
+  // because main_graph IR doesn't emit one.
   if (hipdnn_ep_perf_enabled() && index == 0) {
     perf_ensure_events();
+    // Flush the previous inference's window (if any). inference_num > 0
+    // means we've already record(h2d_start)'d at least once, so the events
+    // are valid to query. Using inference_num instead of "h2d_count > 0"
+    // keeps this working under Option A, where every input may take the
+    // alias fast path and accumulate zero H2D bytes.
+    if (g_perf.initialized && g_perf.inference_num > 0) {
+      (void)hipStreamSynchronize(static_cast<hipStream_t>(state->stream));
+      float h2d_ms = 0, compute_ms = 0, d2h_ms = 0;
+      (void)hipEventElapsedTime(&h2d_ms, g_perf.h2d_start, g_perf.h2d_end);
+      (void)hipEventElapsedTime(&compute_ms, g_perf.h2d_end, g_perf.d2h_start);
+      (void)hipEventElapsedTime(&d2h_ms, g_perf.d2h_start, g_perf.d2h_end);
+      const float total_ms = h2d_ms + compute_ms + d2h_ms;
+      RUNTIME_PERF_LOG("[PERF] #%u: H2D %zut/%.1fMB/%.2fms | Compute %.2fms | "
+                       "D2H %zut/%.1fMB/%.2fms | Total %.2fms\n",
+                       g_perf.inference_num, g_perf.h2d_count,
+                       g_perf.h2d_bytes / 1048576.0, h2d_ms, compute_ms,
+                       g_perf.d2h_count, g_perf.d2h_bytes / 1048576.0, d2h_ms,
+                       total_ms);
+    }
     g_perf.h2d_bytes = 0;
     g_perf.h2d_count = 0;
     g_perf.d2h_bytes = 0;
     g_perf.d2h_count = 0;
     (void)hipEventRecord(g_perf.h2d_start,
                          static_cast<hipStream_t>(state->stream));
+    g_perf.inference_num++; // marks "window opened"; flush above guards on this
   }
 
-  // H2D transfer
-  if (hipMemcpyAsync(gpu_ptr, tensor->data, size_bytes, hipMemcpyHostToDevice,
-                     static_cast<hipStream_t>(state->stream)) != hipSuccess) {
-    fprintf(stderr, "hipdnn_ep_tensor_prepare_input: H2D transfer failed\n");
-    HIP_CLEANUP(hipFree(gpu_ptr));
-    return HIPDNN_EP_ERR_H2D_TRANSFER_FAILED;
-  }
+  // H2D transfer (skipped on the alias fast path — caller's buffer is
+  // already GPU-accessible, no copy needed).
+  if (!alias_caller_buffer) {
+    if (hipMemcpyAsync(gpu_ptr, tensor->data, size_bytes, hipMemcpyHostToDevice,
+                       static_cast<hipStream_t>(state->stream)) != hipSuccess) {
+      fprintf(stderr, "hipdnn_ep_tensor_prepare_input: H2D transfer failed\n");
+      HIP_CLEANUP(hipFree(gpu_ptr));
+      return HIPDNN_EP_ERR_H2D_TRANSFER_FAILED;
+    }
 
-  // PERF: accumulate H2D bytes
-  if (hipdnn_ep_perf_enabled()) {
-    g_perf.h2d_bytes += size_bytes;
-    g_perf.h2d_count++;
+    // PERF: accumulate H2D bytes (only the actual copy, not aliased buffers)
+    if (hipdnn_ep_perf_enabled()) {
+      g_perf.h2d_bytes += size_bytes;
+      g_perf.h2d_count++;
+    }
   }
 
   // Populate output buffer
@@ -340,6 +384,7 @@ int hipdnn_ep_tensor_prepare_input(RuntimeState *state, span_t *inputs,
   out_buffer->rank = tensor->rank;
   out_buffer->size_bytes = size_bytes;
   out_buffer->is_pooled = false;
+  out_buffer->is_aliased = alias_caller_buffer;
 
   check_gcnarch("AFTER prepare_input");
   return HIPDNN_EP_SUCCESS;
@@ -417,8 +462,8 @@ int hipdnn_ep_tensor_prepare_output(RuntimeState *state, span_t *outputs,
 
   RUNTIME_DEBUG_LOG(
       "[Runtime DEBUG] prepare_output[%zu]: rank=%zu element_size=%zu "
-      "size_bytes=%zu\n",
-      index, tensor->rank, element_size, size_bytes);
+      "size_bytes=%zu memory_type=%d\n",
+      index, tensor->rank, element_size, size_bytes, tensor->memory_type);
 
   // PERF: record H2D end on first output alloc (after all H2D copies queued)
   if (hipdnn_ep_perf_enabled() && index == 0 && g_perf.initialized) {
@@ -426,13 +471,24 @@ int hipdnn_ep_tensor_prepare_output(RuntimeState *state, span_t *outputs,
                          static_cast<hipStream_t>(state->stream));
   }
 
-  // Allocate GPU buffer (pool reuses across inferences)
-  void *gpu_ptr = pool_alloc(size_bytes);
-  if (!gpu_ptr) {
-    fprintf(stderr,
-            "hipdnn_ep_tensor_prepare_output: failed to allocate %zu bytes\n",
-            size_bytes);
-    return HIPDNN_EP_ERR_GPU_ALLOC_FAILED;
+  // Fast path: caller's output OrtValue is in GPU-accessible memory, alias
+  // it so the kernel writes directly into the caller's buffer and we can
+  // skip both the pool_alloc here and the D2H copy in finalize_output. For
+  // OGA path A this hits on present_key/present_value tensors that share
+  // buffers with past_key/past_value (past_present_share_buffer=true).
+  const bool alias_caller_buffer = (tensor->memory_type == TENSOR_MEMORY_GPU);
+  void *gpu_ptr = nullptr;
+  if (alias_caller_buffer) {
+    gpu_ptr = tensor->data;
+  } else {
+    // Allocate GPU buffer (pool reuses across inferences)
+    gpu_ptr = pool_alloc(size_bytes);
+    if (!gpu_ptr) {
+      fprintf(stderr,
+              "hipdnn_ep_tensor_prepare_output: failed to allocate %zu bytes\n",
+              size_bytes);
+      return HIPDNN_EP_ERR_GPU_ALLOC_FAILED;
+    }
   }
 
   // Populate output buffer
@@ -442,6 +498,7 @@ int hipdnn_ep_tensor_prepare_output(RuntimeState *state, span_t *outputs,
   out_buffer->rank = tensor->rank;
   out_buffer->size_bytes = size_bytes;
   out_buffer->is_pooled = false;
+  out_buffer->is_aliased = alias_caller_buffer;
 
   return HIPDNN_EP_SUCCESS;
 }
@@ -460,30 +517,53 @@ int hipdnn_ep_tensor_finalize_output(RuntimeState *state,
 
   int result = HIPDNN_EP_SUCCESS;
 
-  // PERF: record D2H start on first output finalize (after all compute)
+  // PERF: record D2H start on first output finalize (after all compute).
+  // We always record, even on the alias fast path, so the [PERF] D2H window
+  // is well-defined; aliased outputs just don't add bytes to the accumulator.
   if (hipdnn_ep_perf_enabled() && g_perf.d2h_count == 0 && g_perf.initialized) {
     (void)hipEventRecord(g_perf.d2h_start,
                          static_cast<hipStream_t>(state->stream));
   }
 
-  // D2H transfer (async -- sync happens once after all outputs)
-  if (hipMemcpyAsync(buffer->host_ptr, buffer->gpu_ptr, buffer->size_bytes,
-                     hipMemcpyDeviceToHost,
-                     static_cast<hipStream_t>(state->stream)) != hipSuccess) {
-    fprintf(stderr, "hipdnn_ep_tensor_finalize_output: D2H transfer failed\n");
-    result = HIPDNN_EP_ERR_D2H_TRANSFER_FAILED;
-    // Continue to cleanup even on error (best-effort)
+  // D2H transfer (async -- sync happens once after all outputs).
+  // Skipped on the alias fast path: gpu_ptr already points into the caller's
+  // GPU-accessible host_ptr (same physical pages on AMD APU mapped pinned
+  // memory), so the kernel has already written the result; no copy needed.
+  if (!buffer->is_aliased) {
+    if (hipMemcpyAsync(buffer->host_ptr, buffer->gpu_ptr, buffer->size_bytes,
+                       hipMemcpyDeviceToHost,
+                       static_cast<hipStream_t>(state->stream)) != hipSuccess) {
+      fprintf(stderr,
+              "hipdnn_ep_tensor_finalize_output: D2H transfer failed\n");
+      result = HIPDNN_EP_ERR_D2H_TRANSFER_FAILED;
+      // Continue to cleanup even on error (best-effort)
+    }
+
+    // PERF: accumulate D2H bytes (only the actual copies, not aliased)
+    if (hipdnn_ep_perf_enabled()) {
+      g_perf.d2h_bytes += buffer->size_bytes;
+      g_perf.d2h_count++;
+    }
   }
 
-  // PERF: accumulate D2H bytes
-  if (hipdnn_ep_perf_enabled()) {
-    g_perf.d2h_bytes += buffer->size_bytes;
-    g_perf.d2h_count++;
+  // PERF: re-record d2h_end after every finalize_output (aliased or not).
+  // The "real" last call wins; in-between records are cheap and let us avoid
+  // having to know which finalize_output is the last one (the MLIR-emitted
+  // main_graph does not signal end-of-inference back to us, see
+  // prepare_input flush logic).
+  if (hipdnn_ep_perf_enabled() && g_perf.initialized) {
+    (void)hipEventRecord(g_perf.d2h_end,
+                         static_cast<hipStream_t>(state->stream));
   }
 
-  // Return buffer to pool
-  pool_release(buffer->gpu_ptr, buffer->size_bytes);
+  // Return buffer to pool only if we own it. Aliased buffers are owned by
+  // the caller (e.g. OGA's KV cache OrtValue under path A); freeing them
+  // would corrupt the caller's allocation.
+  if (!buffer->is_aliased) {
+    pool_release(buffer->gpu_ptr, buffer->size_bytes);
+  }
   buffer->gpu_ptr = nullptr;
+  buffer->is_aliased = false;
 
   return result;
 }
@@ -536,14 +616,20 @@ int hipdnn_ep_stream_sync(RuntimeState *state) {
 
 // Release input tensor buffer (no D2H transfer needed)
 void hipdnn_ep_tensor_free_input(RuntimeState *state, TensorBuffer *buffer) {
+  (void)state;
   if (!buffer) {
     fprintf(stderr, "hipdnn_ep_tensor_free_input: null buffer\n");
     return;
   }
 
-  // Return buffer to pool
-  pool_release(buffer->gpu_ptr, buffer->size_bytes);
+  // Return buffer to pool only if we own it. Aliased buffers are owned by
+  // the caller (e.g. OGA's KV cache OrtValue under path A); freeing them
+  // would corrupt the caller's allocation.
+  if (!buffer->is_aliased) {
+    pool_release(buffer->gpu_ptr, buffer->size_bytes);
+  }
   buffer->gpu_ptr = nullptr;
+  buffer->is_aliased = false;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Runtime/hipdnn_ep_runtime_tensor.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_tensor.cpp
@@ -330,6 +330,24 @@ int hipdnn_ep_tensor_prepare_input(RuntimeState *state, span_t *inputs,
   // timing breakdown (one line, easy to grep) and open a new window. We
   // piggy-back on prepare_input(0) instead of using a dedicated sync hook
   // because main_graph IR doesn't emit one.
+  //
+  // PERF mode trade-off (intentional, not a bug): the hipStreamSynchronize
+  // below is *required* to make hipEventElapsedTime return valid per-phase
+  // numbers (the H2D / Compute / D2H events are async-recorded on the GPU
+  // stream and only become measurable once the stream has drained). The
+  // cost is that each inference's stream is forced to fully serialise
+  // before the next inference can submit work, which kills the natural
+  // pipeline overlap between consecutive inferences and *artificially
+  // lowers the measured TPS* compared to a normal run. So:
+  //
+  //   * HIPDNN_EP_PERF=1 -- accurate per-phase breakdown, sub-real TPS.
+  //     Use when you need the H2D / Compute / D2H split.
+  //   * HIPDNN_EP_DEBUG=1 -- log-only, no sync, real-throughput TPS.
+  //     Use when you want traces but care about wall-clock perf.
+  //
+  // PERF intentionally no longer inherits from DEBUG (see
+  // hipdnn_ep_perf_enabled() in debug_log.h) so adding debug printfs
+  // doesn't silently re-impose the sync penalty.
   if (hipdnn_ep_perf_enabled() && index == 0) {
     perf_ensure_events();
     // Flush the previous inference's window (if any). inference_num > 0

--- a/tools/hip-test-dll/hip-test-dll.cpp
+++ b/tools/hip-test-dll/hip-test-dll.cpp
@@ -23,6 +23,7 @@
 #endif
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -56,6 +57,25 @@ typedef struct {
   size_t element_size; // Bytes per element (e.g. 4=float32, 2=float16, 8=int64)
   int memory_type;     // TENSOR_MEMORY_CPU / _GPU / _FPGA / _NPU
 } tensor_t;
+
+// Compile-time guard against silent layout drift between the three places
+// that duplicate this struct (this file,
+// backend-mlir-compiler/custom-op-mlir/src/custom_op_mlir.hpp, and
+// lib/Runtime/hipdnn_ep_runtime.h). The same three asserts live in all
+// three files; if you reorder/add/remove a field in one place you have to
+// touch all three or one of these will fire at build time.
+//
+// We assert per-field offsets, not raw sizeof(tensor_t), because trailing
+// padding after `memory_type` is compiler-defined and not part of what the
+// MLIR-emitted model.dll actually reads.
+static_assert(offsetof(tensor_t, data) == 0,
+              "tensor_t.data must remain the first field");
+static_assert(offsetof(tensor_t, shape) == sizeof(void *),
+              "tensor_t.shape moved -- update all three tensor_t copies");
+static_assert(offsetof(tensor_t, memory_type) ==
+                  offsetof(tensor_t, element_size) + sizeof(size_t),
+              "tensor_t.memory_type moved -- update all three tensor_t "
+              "copies");
 
 typedef struct {
   tensor_t *data; // Array of tensors

--- a/tools/hip-test-dll/hip-test-dll.cpp
+++ b/tools/hip-test-dll/hip-test-dll.cpp
@@ -40,9 +40,14 @@ typedef int (*InferenceComputeFunc)(void *state, void *inputs, void *outputs);
 typedef int (*InferenceCleanupFunc)(void *state);
 typedef const char *(*InferenceGetMetadataJsonFunc)(void);
 
-// Tensor structures matching hipdnn_ep_runtime.h. Keep in sync with the
-// definitions there (and with custom_op_mlir.hpp); the layout is the
-// on-the-wire ABI between marshalling and the MLIR-compiled model.dll.
+// Local copy of the tensor_t wire-protocol ABI -- the three components
+// (compiler-emitted model.dll, EP runtime DLL, this hip-test-dll harness)
+// are intentionally kept decoupled, so we re-declare the struct here
+// instead of sharing a header. The static_assert block below catches
+// any layout drift between the three copies. Sibling copies live at:
+//   * `backend-mlir-compiler/custom-op-mlir/src/custom_op_mlir.hpp` (compiler)
+//   * `lib/Runtime/hipdnn_ep_runtime.h`                             (EP
+//   runtime)
 enum {
   TENSOR_MEMORY_CPU = 0,  // == OrtMemoryInfoDeviceType_CPU
   TENSOR_MEMORY_GPU = 1,  // == OrtMemoryInfoDeviceType_GPU
@@ -58,16 +63,12 @@ typedef struct {
   int memory_type;     // TENSOR_MEMORY_CPU / _GPU / _FPGA / _NPU
 } tensor_t;
 
-// Compile-time guard against silent layout drift between the three places
-// that duplicate this struct (this file,
-// backend-mlir-compiler/custom-op-mlir/src/custom_op_mlir.hpp, and
-// lib/Runtime/hipdnn_ep_runtime.h). The same three asserts live in all
-// three files; if you reorder/add/remove a field in one place you have to
-// touch all three or one of these will fire at build time.
-//
-// We assert per-field offsets, not raw sizeof(tensor_t), because trailing
-// padding after `memory_type` is compiler-defined and not part of what the
-// MLIR-emitted model.dll actually reads.
+// Compile-time guard for the wire-protocol ABI described above. The same
+// three asserts live in each of the three sibling headers; if you reorder
+// / add / remove a field in one copy and forget to mirror it in the others,
+// at least one of them fails to build. Per-field offsets (not raw sizeof)
+// because trailing padding after `memory_type` is compiler-defined and not
+// part of what model.dll actually reads.
 static_assert(offsetof(tensor_t, data) == 0,
               "tensor_t.data must remain the first field");
 static_assert(offsetof(tensor_t, shape) == sizeof(void *),

--- a/tools/hip-test-dll/hip-test-dll.cpp
+++ b/tools/hip-test-dll/hip-test-dll.cpp
@@ -39,12 +39,22 @@ typedef int (*InferenceComputeFunc)(void *state, void *inputs, void *outputs);
 typedef int (*InferenceCleanupFunc)(void *state);
 typedef const char *(*InferenceGetMetadataJsonFunc)(void);
 
-// Tensor structures matching hipdnn_ep_runtime.h
+// Tensor structures matching hipdnn_ep_runtime.h. Keep in sync with the
+// definitions there (and with custom_op_mlir.hpp); the layout is the
+// on-the-wire ABI between marshalling and the MLIR-compiled model.dll.
+enum {
+  TENSOR_MEMORY_CPU = 0,  // == OrtMemoryInfoDeviceType_CPU
+  TENSOR_MEMORY_GPU = 1,  // == OrtMemoryInfoDeviceType_GPU
+  TENSOR_MEMORY_FPGA = 2, // == OrtMemoryInfoDeviceType_FPGA
+  TENSOR_MEMORY_NPU = 3,  // == OrtMemoryInfoDeviceType_NPU
+};
+
 typedef struct {
-  void *data;          // Host data pointer
+  void *data;          // Data pointer (host or GPU-accessible per memory_type)
   int64_t *shape;      // Array of dimension sizes
   size_t rank;         // Number of dimensions
   size_t element_size; // Bytes per element (e.g. 4=float32, 2=float16, 8=int64)
+  int memory_type;     // TENSOR_MEMORY_CPU / _GPU / _FPGA / _NPU
 } tensor_t;
 
 typedef struct {
@@ -417,6 +427,7 @@ int main(int argc, char **argv) {
     tensor.shape = input_shape_storage.back().data();
     tensor.rank = input_shape_storage.back().size();
     tensor.element_size = input_elem_sizes[i];
+    tensor.memory_type = TENSOR_MEMORY_CPU; // host buffers, runtime does H2D
     input_tensors.push_back(tensor);
   }
 
@@ -440,6 +451,7 @@ int main(int argc, char **argv) {
     tensor.shape = output_shape_storage.back().data();
     tensor.rank = output_shape_storage.back().size();
     tensor.element_size = output_elem_sizes[i];
+    tensor.memory_type = TENSOR_MEMORY_CPU; // host buffers, runtime does D2H
     output_tensors.push_back(tensor);
   }
 


### PR DESCRIPTION
## Summary

Wires the EP, the morphizen factory, and the OGA fork together so OGA's KV cache lives in **GPU-mapped pinned memory** instead of host RAM, fixing the 7B / 14B int4 `max_length=16384` TPS regression where every decode step was paying ~4 GB of `hipMemcpyAsync H2D + D2H` for a buffer that didn't change.

- **Mistral-7B int4 m=16384**: `3.94 → 15.92 TPS` (**+304%**)
- **Phi4-14B  int4 m=16384**: `2.12 → 13.18 TPS` (**+522%**)
- `[PERF]` confirms H2D / D2H are ~0 ms / 0 MB on aliased decode steps; the remaining gap is ORT plugin-EP routing + OGA framework overhead (out of scope here).

## Root cause

OGA in `m=16384` mode pre-allocates the KV cache for `max_length` tokens (2 GB on Mistral-7B int4, 5.7 GB on Phi4-14B int4) on its **primary device**. Because OGA didn't know about MorphiZenEP, that primary device defaulted to **CPU**, so every decode token did:

```
prepare_input  : hipMemcpyAsync H2D 2 GB  (past_key/value)
compute        : ~50 ms
finalize_output: hipMemcpyAsync D2H 2 GB  (present_key/value)
```

H2D + D2H accounted for ~82 % of inference time — root-caused via the per-call `[PERF]` telemetry rebuilt in this PR.

## Solution (three-layer fix)

| Layer | Change | Where |
|---|---|---|
| **OGA fork** | Add `DeviceType::MorphiZenEP` so OGA actually allocates the KV cache through our EP allocator | [AMDmoore/onnxruntime-genai#8](https://github.com/AMDmoore/onnxruntime-genai/pull/8) (`OGA_REF` bumped to `c4fc287`) |
| **MorphiZen EP factory** | `hipHostMalloc(Mapped\|Coherent)` `OrtAllocator` + `HipDataTransferImpl`, register the EP as an AMD GPU device by default | [ROCm/MorphiZen#208](https://github.com/ROCm/MorphiZen/pull/208) (submodule bump to `e6ca655`) |
| **EP runtime** *(this PR)* | tensor_t / TensorBuffer ABI gains `memory_type` + `is_aliased`; `prepare_*` aliases caller's GPU buffer; `finalize_output` / `free_input` skip D2H / pool_release when aliased | `lib/Runtime/hipdnn_ep_runtime_tensor.cpp`, `lib/Runtime/hipdnn_ep_runtime.h`, `backend-mlir-compiler/.../custom_op_mlir.hpp`, `backend-mlir-compiler/.../MlirCustomOp.cpp` |

Plus:

- **PERF telemetry fix** — `HIPDNN_EP_PERF` no longer inherits from `HIPDNN_EP_DEBUG` (PERF forces `hipStreamSynchronize` on every inference, which serialises the pipeline and skews measurements). New `RUNTIME_PERF_LOG` macro for the per-inference `[PERF]` line. Dump moved from the dead `hipdnn_ep_stream_sync` hook into `prepare_input(0)`, where it actually fires under the MLIR-emitted `main_graph` (which never calls `stream_sync`). `finalize_output` always re-records `d2h_end` so the window is well-defined when every output is aliased.
- **Build wiring** — `cmake/deps.cmake` forces `morphizen_ENABLE_HIP_GPU_ALLOCATOR=ON` in the parent build (`find_package(hip)` is already a runtime dependency); standalone MorphiZen builds keep the option `OFF`.
- **Test surface** — `hip-test-dll.cpp` explicitly stamps inputs / outputs with `TENSOR_MEMORY_CPU` so it keeps using the legacy host H2D / D2H path unchanged. CPU / FPGA / NPU `memory_type`s also fall through to the legacy path, so `hip-onnx-runner` and any other host-input caller are unaffected.

## Validation

Strix Halo, gfx1151, `m=16384`, `prompt_length=127`, `model_benchmark.exe`:

| Model | wall TPS before | wall TPS after | gain |
|---|---:|---:|---:|
| Mistral-7B int4 | 3.94 | **15.92** | +304 % |
| Phi4-14B  int4  | 2.12 | **13.18** | +522 % |

Sample `[PERF]` line on Mistral-7B int4 m=16384 after the fix:

```
[PERF] #42: H2D 0t/0.0MB/0.00ms | Compute 47.31ms | D2H 0t/0.0MB/0.00ms | Total 47.31ms
```

Compare to the same model before the fix (manual `KV_DBG` instrumentation):

```
H2D ~2048 MB / ~120 ms | Compute ~50 ms | D2H ~2048 MB / ~120 ms | Total ~290 ms
```

i.e. the per-decode 4 GB round-trip is now zero, and the remaining wall-clock cost matches the per-op GEMM theoretical limit.

## Dependencies (do not merge until both land)

- ROCm/MorphiZen#208 — submodule bump target (`e6ca655`)
- AMDmoore/onnxruntime-genai#8 — `OGA_REF` target (`c4fc287`)

CI on this PR will fail until both merge to their respective `main` branches and we re-point the submodule / `OGA_REF` to the post-merge commits. Marking as draft for now.

## Test plan

- [ ] Wait for ROCm/MorphiZen#208 to merge, then re-point submodule `3rd-party/morphizen` to the merge commit on `main`.
- [ ] Wait for AMDmoore/onnxruntime-genai#8 to merge, then re-point `OGA_REF` in `.github/workflows/windows-build.yml` to the merge commit on the OGA fork.
- [ ] CI green on Windows build (existing matrix).
- [ ] Re-run `model_benchmark.exe` Mistral-7B int4 / Phi4-14B int4 m=16384 on Strix Halo and confirm TPS within ~5 % of the numbers in this PR.
- [ ] `hip-test-dll` smoke run (host-input legacy path) on a small model — confirms the alias fast path doesn't regress non-OGA callers.

