### PR TITLE
 fix: support uint8 packed nibble zero_points in MatMulNBits WMMA/GEMV paths

### DIFF
--- a/3rd-party/custom_kernels/hip/matmul_nbits_kernel.hip
+++ b/3rd-party/custom_kernels/hip/matmul_nbits_kernel.hip
@@ -1386,6 +1386,64 @@ __global__ void matmul_nbits_add_bias_rowmajor(
  * Section 4: Host-side launcher (extern "C")
  * ======================================================================= */
 
+/* =======================================================================
+ * Section 4a: uint8 packed nibble zero_points -> FP16 conversion
+ *
+ * ONNX MatMulNBits uint8 packed format:  [N, ceil(groups_k/2)]
+ *   Each byte holds two 4-bit zero_points:  low nibble = zp[2*i],
+ *                                           high nibble = zp[2*i+1]
+ * Output FP16 format: [N, groups_k]
+ * ======================================================================= */
+
+__global__ void unpack_zp_u8_to_fp16_kernel(
+    const unsigned char* __restrict__ zp_packed,
+    _Float16* __restrict__ zp_fp16,
+    int N, int groups_k, int packed_cols)
+{
+    int n  = static_cast<int>(blockIdx.y);
+    int g2 = static_cast<int>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (n >= N || g2 >= packed_cols) return;
+
+    unsigned char packed = zp_packed[n * packed_cols + g2];
+    int g_lo = g2 * 2;
+    int g_hi = g_lo + 1;
+
+    zp_fp16[n * groups_k + g_lo] = static_cast<_Float16>(packed & 0xF);
+    if (g_hi < groups_k)
+        zp_fp16[n * groups_k + g_hi] = static_cast<_Float16>(packed >> 4);
+}
+
+static _Float16* g_zp_fp16_buf = nullptr;
+static size_t    g_zp_fp16_buf_elems = 0;
+
+static _Float16* ensureZpFp16Buffer(size_t need) {
+    if (g_zp_fp16_buf && g_zp_fp16_buf_elems >= need) return g_zp_fp16_buf;
+    if (g_zp_fp16_buf) hipFree(g_zp_fp16_buf);
+    hipMalloc(&g_zp_fp16_buf, need * sizeof(_Float16));
+    g_zp_fp16_buf_elems = need;
+    return g_zp_fp16_buf;
+}
+
+static const _Float16* convertZpToFp16(
+    hipStream_t stream,
+    const void* zp_packed_ptr,
+    int N, int groups_k)
+{
+    int packed_cols = (groups_k + 1) / 2;
+    size_t fp16_elems = static_cast<size_t>(N) * groups_k;
+    _Float16* zp_fp16 = ensureZpFp16Buffer(fp16_elems);
+
+    constexpr int THR = 256;
+    dim3 grid(static_cast<unsigned>((packed_cols + THR - 1) / THR),
+              static_cast<unsigned>(N));
+    dim3 block(THR);
+    hipLaunchKernelGGL(unpack_zp_u8_to_fp16_kernel,
+                       grid, block, 0, stream,
+                       static_cast<const unsigned char*>(zp_packed_ptr),
+                       zp_fp16, N, groups_k, packed_cols);
+    return zp_fp16;
+}
+
 extern "C" int hip_matmul_nbits(
     void* stream,
     const void* A,
@@ -1398,7 +1456,8 @@ extern "C" int hip_matmul_nbits(
     int64_t batch_count,
     int64_t bits,
     int64_t block_size,
-    int64_t element_size_bytes) {
+    int64_t element_size_bytes,
+    int64_t zp_elem_size) {
   if (bits != 4) {
     fprintf(stderr,
             "[custom_kernels] hip_matmul_nbits: only bits=4 supported, "
@@ -1418,6 +1477,17 @@ extern "C" int hip_matmul_nbits(
   }
 
   hipStream_t hip_stream = static_cast<hipStream_t>(stream);
+
+  // Convert uint8 packed nibble zero_points to FP16 for WMMA/GEMV-col-major
+  // paths which require FP16 zero_points. Row-major GEMV and naive fallback
+  // read uint8 directly and don't need this conversion.
+  const void* zp_for_fp16_paths = zero_points;
+  bool wmma_data_format_pre = (batch_count == 1) && (K % 32 == 0);
+  if (zero_points && zp_elem_size == 1 && wmma_data_format_pre) {
+    int ngk = static_cast<int>((K + block_size - 1) / block_size);
+    zp_for_fp16_paths = convertZpToFp16(
+        hip_stream, zero_points, static_cast<int>(N), ngk);
+  }
 
   /* -------------------------------------------------------------------
    * WMMA data format: batch==1 && K%32==0
@@ -1450,7 +1520,7 @@ extern "C" int hip_matmul_nbits(
     const auto* a_ptr = static_cast<const _Float16*>(A);
     const auto* b_ptr = static_cast<const unsigned char*>(B);
     const auto* s_ptr = static_cast<const _Float16*>(scales);
-    const auto* z_ptr = static_cast<const _Float16*>(zero_points);
+    const auto* z_ptr = static_cast<const _Float16*>(zp_for_fp16_paths);
 
     // WMMA writes row-major C directly to caller's output buffer (ldc = N)
     auto* out_ptr = static_cast<_Float16*>(output);
@@ -1534,7 +1604,7 @@ extern "C" int hip_matmul_nbits(
 
     const auto* b_u = static_cast<const uint8_t*>(B);
     const auto* s_h = static_cast<const __half*>(scales);
-    const auto* z_u = static_cast<const uint8_t*>(zero_points);
+    const auto* z_u = static_cast<const uint8_t*>(zp_for_fp16_paths);
     const auto* b_h = static_cast<const __half*>(bias);
 
     int config_id = getOrTuneGemvConfig(

--- a/3rd-party/custom_kernels/include/hip_custom_kernels.h
+++ b/3rd-party/custom_kernels/include/hip_custom_kernels.h
@@ -412,7 +412,8 @@ int hip_matmul_nbits(
     int64_t batch_count,
     int64_t bits,
     int64_t block_size,
-    int64_t element_size_bytes);
+    int64_t element_size_bytes,
+    int64_t zp_elem_size);  // 1=uint8 packed nibbles, 2=fp16
 
 /* =========================================================================
  * QMoE Sub-Kernels

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -293,7 +293,8 @@ def Hip_MatMulNBitsOp : Hip_DpsOp<"matmul_nbits", [AttrSizedOperandSegments]> {
     I64Attr:$N,
     I64Attr:$bits,
     I64Attr:$block_size,
-    I64Attr:$accuracy_level
+    I64Attr:$accuracy_level,
+    I64Attr:$zp_elem_size  // zero_points element size: 1=uint8 packed, 2=fp16
   );
 
   let assemblyFormat = [{

--- a/lib/Conversion/HipToLLVM/MatMulNBitsLowering.cpp
+++ b/lib/Conversion/HipToLLVM/MatMulNBitsLowering.cpp
@@ -61,8 +61,9 @@ struct MatMulNBitsOpLowering : public ConvertOpToLLVMPattern<MatMulNBitsOp> {
     Value bits = createI64Const(op.getBits());
     Value blockSize = createI64Const(op.getBlockSize());
     Value elemSizeVal = createI64Const(elemSize);
+    Value zpElemSizeVal = createI64Const(op.getZpElemSize());
 
-    SmallVector<Type, 15> paramTypes = {
+    SmallVector<Type, 16> paramTypes = {
         ptrType, // state
         ptrType, // A
         ptrType, // B
@@ -77,7 +78,8 @@ struct MatMulNBitsOpLowering : public ConvertOpToLLVMPattern<MatMulNBitsOp> {
         i64Type, // batch_count
         i64Type, // bits
         i64Type, // block_size
-        i64Type  // elem_size
+        i64Type, // elem_size
+        i64Type  // zp_elem_size
     };
 
     FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
@@ -86,10 +88,22 @@ struct MatMulNBitsOpLowering : public ConvertOpToLLVMPattern<MatMulNBitsOp> {
       return failure();
     }
 
-    SmallVector<Value, 15> args = {
-        statePtr, APtr,    BPtr,      scalesPtr, zeroPointsPtr,
-        gIdxPtr,  biasPtr, outputPtr, m,         n,
-        k,        batch,   bits,      blockSize, elemSizeVal};
+    SmallVector<Value, 16> args = {statePtr,
+                                   APtr,
+                                   BPtr,
+                                   scalesPtr,
+                                   zeroPointsPtr,
+                                   gIdxPtr,
+                                   biasPtr,
+                                   outputPtr,
+                                   m,
+                                   n,
+                                   k,
+                                   batch,
+                                   bits,
+                                   blockSize,
+                                   elemSizeVal,
+                                   zpElemSizeVal};
 
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
     rewriter.eraseOp(op);

--- a/lib/Conversion/OnnxToHip/MatMulNBitsConversion.cpp
+++ b/lib/Conversion/OnnxToHip/MatMulNBitsConversion.cpp
@@ -84,13 +84,37 @@ MatMulNBitsToHip::matchAndRewrite(mlir::Operation *op,
   auto accuracyLevelAttr = rewriter.getI64IntegerAttr(
       accuracyIntAttr ? accuracyIntAttr.getSInt() : 0);
 
+  // Validate and detect zero_points element type.
+  // Supported formats:
+  //   - uint8 (i8): packed uint4 nibbles, two zero_points per byte
+  //   - fp16  (f16): one zero_point per element
+  // Reject anything else at compile time to avoid silent precision bugs.
+  int64_t zpElemSize = 2; // default: fp16 (when zeroPoints is absent)
+  if (zeroPoints) {
+    auto zpTy = mlir::cast<mlir::ShapedType>(zeroPoints.getType());
+    mlir::Type elemTy = zpTy.getElementType();
+    if (elemTy.isInteger(8)) {
+      zpElemSize = 1; // uint8 container holding packed uint4 nibbles
+    } else if (elemTy.isF16()) {
+      zpElemSize = 2;
+    } else {
+      std::string msg;
+      llvm::raw_string_ostream os(msg);
+      os << "MatMulNBits: unsupported zero_points element type: ";
+      elemTy.print(os);
+      os << ". Expected i8 (packed uint4) or f16";
+      return rewriter.notifyMatchFailure(op, msg);
+    }
+  }
+  auto zpElemSizeAttr = rewriter.getI64IntegerAttr(zpElemSize);
+
   auto rt = mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
   mlir::Value init = createEmptyTensor(rewriter, loc, rt, A);
 
   auto hipOp = mlir::hip::MatMulNBitsOp::create(
       rewriter, loc, mlir::TypeRange{rt}, context, A, B, scales, zeroPoints,
       gIdx, bias, init, KAttr, NAttr, bitsAttr, blockSizeAttr,
-      accuracyLevelAttr);
+      accuracyLevelAttr, zpElemSizeAttr);
   rewriter.replaceOp(op, hipOp->getResults());
   return mlir::success();
 }

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -544,7 +544,8 @@ int wrap_matmul_nbits(
     int64_t batch_count,     // number of batches
     int64_t bits,            // quantization bits (e.g. 4)
     int64_t block_size,      // quantization block size
-    int64_t elem_size);      // element size in bytes
+    int64_t elem_size,       // element size in bytes
+    int64_t zp_elem_size);   // zero_points element size: 1=uint8 packed, 2=fp16
 
 // QMoE operation wrapper (quantized Mixture-of-Experts)
 // Routes tokens to top-k experts, performs quantized MLP per expert,

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -767,7 +767,8 @@ int wrap_matmul_nbits(RuntimeState *state, const void *A, const void *B,
                       const void *scales, const void *zero_points,
                       const void *g_idx, const void *bias, void *output,
                       int64_t M, int64_t N, int64_t K, int64_t batch_count,
-                      int64_t bits, int64_t block_size, int64_t elem_size) {
+                      int64_t bits, int64_t block_size, int64_t elem_size,
+                      int64_t zp_elem_size) {
   if (!state) {
     fprintf(stderr, "Invalid state in wrap_matmul_nbits\n");
     return -1;

--- a/lib/Runtime/real/matmul_nbits.cpp
+++ b/lib/Runtime/real/matmul_nbits.cpp
@@ -15,7 +15,8 @@ int wrap_matmul_nbits(RuntimeState *state, const void *A, const void *B,
                       const void *scales, const void *zero_points,
                       const void *g_idx, const void *bias, void *output,
                       int64_t M, int64_t N, int64_t K, int64_t batch_count,
-                      int64_t bits, int64_t block_size, int64_t elem_size) {
+                      int64_t bits, int64_t block_size, int64_t elem_size,
+                      int64_t zp_elem_size) {
   if (!state || !A || !B || !scales || !output) {
     fprintf(stderr, "wrap_matmul_nbits: null argument\n");
     return -1;
@@ -23,12 +24,12 @@ int wrap_matmul_nbits(RuntimeState *state, const void *A, const void *B,
 
   RUNTIME_DEBUG_LOG("[REAL] wrap_matmul_nbits(M=%lld, N=%lld, K=%lld, "
                     "batch=%lld, bits=%lld, block_size=%lld, elem_size=%lld, "
-                    "zero_points=%s, g_idx=%s, bias=%s)\n",
+                    "zp_elem_size=%lld, zero_points=%s, g_idx=%s, bias=%s)\n",
                     (long long)M, (long long)N, (long long)K,
                     (long long)batch_count, (long long)bits,
                     (long long)block_size, (long long)elem_size,
-                    zero_points ? "yes" : "null", g_idx ? "yes" : "null",
-                    bias ? "yes" : "null");
+                    (long long)zp_elem_size, zero_points ? "yes" : "null",
+                    g_idx ? "yes" : "null", bias ? "yes" : "null");
 
   void *stream = hipdnn_ep_state_get_stream(state);
   if (!stream) {
@@ -43,7 +44,8 @@ int wrap_matmul_nbits(RuntimeState *state, const void *A, const void *B,
 
   int result = 0;
   HIP_CHECK(hip_matmul_nbits(stream, A, B, scales, zero_points, bias, output, M,
-                             N, K, batch_count, bits, block_size, elem_size));
+                             N, K, batch_count, bits, block_size, elem_size,
+                             zp_elem_size));
 
 cleanup:
   return result;

--- a/lib/Runtime/real/qmoe.cpp
+++ b/lib/Runtime/real/qmoe.cpp
@@ -178,7 +178,8 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
       HIP_CHECK(hip_matmul_nbits(stream, d_gather_buf, fc1_w_e, fc1_s_e,
                                  fc1_zp_e, fc1_b_e, d_fc1_buf, count,
                                  fusion_inter, hidden_size, 1,
-                                 expert_weight_bits, block_size, elem_size));
+                                 expert_weight_bits, block_size, elem_size,
+                                 /*zp_elem_size=*/1));
 
       RUNTIME_DEBUG_LOG("[REAL] wrap_qmoe: expert %lld: swiglu(alpha=%.3f, "
                         "beta=%.3f, limit=%.1f)\n",
@@ -207,7 +208,7 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
       HIP_CHECK(hip_matmul_nbits(stream, d_act_buf, fc2_w_e, fc2_s_e, fc2_zp_e,
                                  fc2_b_e, d_fc2_buf, count, hidden_size,
                                  inter_size, 1, expert_weight_bits, block_size,
-                                 elem_size));
+                                 elem_size, /*zp_elem_size=*/1));
 
       RUNTIME_DEBUG_LOG("[REAL] wrap_qmoe: expert %lld: scatter_add\n",
                         (long long)e);

--- a/test/lit/Conversion/hip-to-llvm/test_matmul_nbits.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_matmul_nbits.mlir
@@ -30,17 +30,18 @@ module {
         memref<5120x90xf16, 1>)
         outs(%output : memref<1x128x5120xf16, 1>)
         {K = 2880 : i64, N = 5120 : i64, bits = 4 : i64,
-         block_size = 32 : i64, accuracy_level = 4 : i64}
+         block_size = 32 : i64, accuracy_level = 4 : i64,
+         zp_elem_size = 0 : i64}
     return
   }
 
   // CHECK-LABEL: llvm.func @test_matmul_nbits_basic
   // CHECK: llvm.call @wrap_matmul_nbits({{.*}}) :
   // CHECK-SAME: (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr,
-  // CHECK-SAME:  i64, i64, i64, i64, i64, i64, i64) -> i32
-  // Verify 15 parameters:
+  // CHECK-SAME:  i64, i64, i64, i64, i64, i64, i64, i64) -> i32
+  // Verify 16 parameters:
   // - 8 pointers: state, A, B, scales, zero_points(null), g_idx(null), bias(null), output
-  // - 7 i64: M=128, N=5120, K=2880, batch_count=1, bits=4, block_size=32, elem_size=2
+  // - 8 i64: M=128, N=5120, K=2880, batch_count=1, bits=4, block_size=32, elem_size=2, zp_elem_size=0
 
   // ===== Test 2: MatMulNBits with zero_points =====
 
@@ -56,14 +57,15 @@ module {
         zero_points(%zp : memref<5120x90xui8, 1>)
         outs(%output : memref<1x128x5120xf16, 1>)
         {K = 2880 : i64, N = 5120 : i64, bits = 4 : i64,
-         block_size = 32 : i64, accuracy_level = 4 : i64}
+         block_size = 32 : i64, accuracy_level = 4 : i64,
+         zp_elem_size = 1 : i64}
     return
   }
 
   // CHECK-LABEL: llvm.func @test_matmul_nbits_with_zp
   // CHECK: llvm.call @wrap_matmul_nbits({{.*}}) :
   // CHECK-SAME: (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr,
-  // CHECK-SAME:  i64, i64, i64, i64, i64, i64, i64) -> i32
+  // CHECK-SAME:  i64, i64, i64, i64, i64, i64, i64, i64) -> i32
 
   // ===== Test 3: 2D MatMulNBits (no batch dimension) =====
 
@@ -77,13 +79,14 @@ module {
         memref<5120x90xf16, 1>)
         outs(%output : memref<128x5120xf16, 1>)
         {K = 2880 : i64, N = 5120 : i64, bits = 4 : i64,
-         block_size = 32 : i64, accuracy_level = 4 : i64}
+         block_size = 32 : i64, accuracy_level = 4 : i64,
+         zp_elem_size = 0 : i64}
     return
   }
 
   // CHECK-LABEL: llvm.func @test_matmul_nbits_2d
   // CHECK: llvm.call @wrap_matmul_nbits({{.*}}) :
   // CHECK-SAME: (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr,
-  // CHECK-SAME:  i64, i64, i64, i64, i64, i64, i64) -> i32
+  // CHECK-SAME:  i64, i64, i64, i64, i64, i64, i64, i64) -> i32
   // M=128, batch_count=1 (2D: no batch dims)
 }


### PR DESCRIPTION
## Summary

* ONNX MatMulNBits models with RTN quantization store zero_points as uint8 packed nibbles (two 4-bit values per byte). The WMMA and GEMV col-major kernel paths were incorrectly casting these uint8 bytes as fp16 pointers, reading garbage zero_point values and producing NaN outputs.
* Added `zp_elem_size` attribute through the full compiler-to-runtime pipeline (OnnxToHip -> HipOps -> HipToLLVM -> Runtime -> GPU kernel) to detect and correctly unpack uint8 packed nibble zero_points to fp16 before use.
* Added compile-time validation to reject unsupported zero_points element types early.

## Test plan

* [x] Qwen2.5-Coder-14B-instruct-rtn-128gs model: MorphiZen EP output matches DML EP baseline (previously produced garbled/NaN output)
* [x] Greedy decoding (top_k=1) produces coherent, contextually correct text for 128 generated tokens
* [x] pre-commit hooks pass
