### PR TITLE
fix(gemm,qmoe): MIOpen broadcast contract + QMoE block_size handling

### DIFF
--- a/lib/Conversion/OnnxToHip/QMoEConversion.cpp
+++ b/lib/Conversion/OnnxToHip/QMoEConversion.cpp
@@ -88,9 +88,38 @@ QMoEToHip::matchAndRewrite(mlir::Operation *op,
   auto kIntAttr = op->getAttrOfType<mlir::IntegerAttr>("k");
   auto kAttr = rewriter.getI64IntegerAttr(kIntAttr ? kIntAttr.getSInt() : 1);
 
+  // ms.QMoE's `block_size` attribute is documented as optional (no spec
+  // default) and is omitted by some quantization tools (e.g. AWQ exports of
+  // gpt-oss-120b). Without it `wrap_qmoe` later divides by zero. When the
+  // attribute is absent or non-positive, derive block_size from the
+  // FC1 (gate_up_proj) scales tensor: scales has shape
+  //     [num_experts, output_features, k_blocks_fc1]
+  // with k_blocks_fc1 = ceil(hidden_size / block_size) and the activation
+  // input has shape [..., hidden_size]. So
+  //     block_size = ceil(hidden_size / k_blocks_fc1)
+  // which gives the exact value when the model uses an even split (the
+  // common case).
   auto blockSizeIntAttr = op->getAttrOfType<mlir::IntegerAttr>("block_size");
-  auto blockSizeAttr = rewriter.getI64IntegerAttr(
-      blockSizeIntAttr ? blockSizeIntAttr.getSInt() : 0);
+  int64_t blockSizeValue = blockSizeIntAttr ? blockSizeIntAttr.getSInt() : 0;
+  if (blockSizeValue <= 0) {
+    auto inputType = mlir::dyn_cast<mlir::RankedTensorType>(input.getType());
+    auto scalesType =
+        mlir::dyn_cast<mlir::RankedTensorType>(fc1Scales.getType());
+    if (inputType && scalesType && inputType.getRank() > 0 &&
+        scalesType.getRank() > 0) {
+      int64_t hiddenDim = inputType.getShape().back();
+      int64_t kBlocksDim = scalesType.getShape().back();
+      if (hiddenDim > 0 && kBlocksDim > 0) {
+        blockSizeValue = (hiddenDim + kBlocksDim - 1) / kBlocksDim;
+      }
+    }
+  }
+  if (blockSizeValue <= 0) {
+    return rewriter.notifyMatchFailure(
+        op, "QMoE: missing `block_size` attribute and cannot infer it from "
+            "input/fc1_scales tensor shapes");
+  }
+  auto blockSizeAttr = rewriter.getI64IntegerAttr(blockSizeValue);
 
   auto normIntAttr =
       op->getAttrOfType<mlir::IntegerAttr>("normalize_routing_weights");

--- a/lib/Runtime/real/gemm.cpp
+++ b/lib/Runtime/real/gemm.cpp
@@ -111,6 +111,18 @@ static bool resolveGemmMiopenType(int64_t typeCode, miopenDataType_t &dt) {
   }
 }
 
+// MIOpen contract for miopenOpTensor: the A-operand descriptor and the
+// destination descriptor must have *identical* shapes; only the B operand may
+// broadcast. The previous implementation passed the small bias descriptor
+// (cDesc) as both A and B while the destination was the full-output descriptor,
+// which MIOpen rejected with "A and C Tensors do not match" (status 7) any time
+// the bias actually needed broadcasting (e.g. a [1,N] bias onto [M,N]).
+//
+// Fix: zero the output buffer, then compute
+//     output = 1.0 * output + beta * broadcast(C)
+// so the A operand and destination both use outDesc and only B (the bias)
+// broadcasts. Pre-zeroing avoids dependency on uninitialized output (which
+// could contain NaNs that 1.0*NaN would propagate).
 static int broadcastBiasToOutput(RuntimeState *state, const void *C,
                                  void *output, int64_t M, int64_t N,
                                  int64_t cDim0, int64_t cDim1, float beta,
@@ -122,6 +134,13 @@ static int broadcastBiasToOutput(RuntimeState *state, const void *C,
     return -1;
   }
 
+  hipStream_t stream =
+      static_cast<hipStream_t>(hipdnn_ep_state_get_stream(state));
+  if (!stream) {
+    fprintf(stderr, "wrap_gemm: broadcastBiasToOutput: null stream\n");
+    return -1;
+  }
+
   miopenDataType_t dt;
   if (!resolveGemmMiopenType(typeCode, dt)) {
     fprintf(stderr,
@@ -130,10 +149,25 @@ static int broadcastBiasToOutput(RuntimeState *state, const void *C,
     return -1;
   }
 
+  size_t elemSize = (typeCode == kTypeFloat64)   ? 8
+                    : (typeCode == kTypeFloat32) ? 4
+                                                 : 2; // fp16 / bf16
+
   RUNTIME_DEBUG_LOG("[REAL] wrap_gemm: broadcastBiasToOutput C[%lld,%lld] -> "
                     "[%lld,%lld], beta=%f\n",
                     (long long)cDim0, (long long)cDim1, (long long)M,
                     (long long)N, beta);
+
+  // Pre-zero the destination so 1.0*output contributes 0 in the op below.
+  size_t outBytes = static_cast<size_t>(M) * static_cast<size_t>(N) * elemSize;
+  hipError_t hipErr = hipMemsetAsync(output, 0, outBytes, stream);
+  if (hipErr != hipSuccess) {
+    fprintf(stderr,
+            "wrap_gemm: broadcastBiasToOutput: hipMemsetAsync(%zu bytes) "
+            "failed (%d): %s\n",
+            outBytes, (int)hipErr, hipGetErrorString(hipErr));
+    return -1;
+  }
 
   miopenTensorDescriptor_t cDesc = nullptr;
   miopenTensorDescriptor_t outDesc = nullptr;
@@ -147,15 +181,18 @@ static int broadcastBiasToOutput(RuntimeState *state, const void *C,
   MIOPEN_CHECK(miopenSet4dTensorDescriptor(
       outDesc, dt, 1, 1, static_cast<int>(M), static_cast<int>(N)));
 
-  // output = beta * (C + 0 * C) + 0 * output = beta * C_broadcast
+  // output = 1.0 * output + beta * broadcast(C) + 0 * output
+  //        = beta * broadcast(C)              (since output was zeroed)
   if (typeCode == kTypeFloat64) {
-    double alpha1 = static_cast<double>(beta), alpha2 = 0.0, beta_c = 0.0;
-    MIOPEN_CHECK(miopenOpTensor(handle, miopenTensorOpAdd, &alpha1, cDesc, C,
-                                &alpha2, cDesc, C, &beta_c, outDesc, output));
+    double alpha1 = 1.0, alpha2 = static_cast<double>(beta), beta_c = 0.0;
+    MIOPEN_CHECK(miopenOpTensor(handle, miopenTensorOpAdd, &alpha1, outDesc,
+                                output, &alpha2, cDesc, C, &beta_c, outDesc,
+                                output));
   } else {
-    float alpha1 = beta, alpha2 = 0.0f, beta_c = 0.0f;
-    MIOPEN_CHECK(miopenOpTensor(handle, miopenTensorOpAdd, &alpha1, cDesc, C,
-                                &alpha2, cDesc, C, &beta_c, outDesc, output));
+    float alpha1 = 1.0f, alpha2 = beta, beta_c = 0.0f;
+    MIOPEN_CHECK(miopenOpTensor(handle, miopenTensorOpAdd, &alpha1, outDesc,
+                                output, &alpha2, cDesc, C, &beta_c, outDesc,
+                                output));
   }
 
 cleanup:

--- a/lib/Runtime/real/qmoe.cpp
+++ b/lib/Runtime/real/qmoe.cpp
@@ -55,10 +55,32 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
   }
 
   RUNTIME_DEBUG_LOG("[REAL] wrap_qmoe(tokens=%lld, hidden=%lld, inter=%lld, "
-                    "experts=%lld, k=%lld, bits=%lld, elem=%lld)\n",
+                    "experts=%lld, k=%lld, bits=%lld, block=%lld, elem=%lld)\n",
                     (long long)num_tokens, (long long)hidden_size,
                     (long long)inter_size, (long long)num_experts, (long long)k,
-                    (long long)expert_weight_bits, (long long)elem_size);
+                    (long long)expert_weight_bits, (long long)block_size,
+                    (long long)elem_size);
+
+  // Guard against pathological metadata: block_size==0 would otherwise crash
+  // with STATUS_INTEGER_DIVIDE_BY_ZERO inside the k_blocks computations below
+  // (and produces invalid quant layouts even at >0 if not a multiple of 2).
+  if (block_size <= 0 || (block_size & 1) != 0) {
+    fprintf(stderr,
+            "wrap_qmoe: invalid block_size=%lld (must be a positive even "
+            "value matching the weights' quant block layout)\n",
+            (long long)block_size);
+    return -1;
+  }
+  if (hidden_size <= 0 || inter_size <= 0 || num_experts <= 0 || k <= 0 ||
+      num_tokens <= 0 || elem_size <= 0) {
+    fprintf(stderr,
+            "wrap_qmoe: invalid sizes (tokens=%lld hidden=%lld inter=%lld "
+            "experts=%lld k=%lld elem=%lld)\n",
+            (long long)num_tokens, (long long)hidden_size,
+            (long long)inter_size, (long long)num_experts, (long long)k,
+            (long long)elem_size);
+    return -1;
+  }
 
   void *stream = hipdnn_ep_state_get_stream(state);
   if (!stream) {


### PR DESCRIPTION
## Summary
Two bug fixes in the JIT-compiled runtime that together unblock execution of the gpt-oss-120b single-layer dump:

1. **`broadcastBiasToOutput` (`lib/Runtime/real/gemm.cpp`)** — satisfy MIOpen's `miopenOpTensor` contract that the A‑operand descriptor must match the destination descriptor (only the B operand may broadcast). The old code passed the small bias descriptor (`cDesc`) for both A and B while the destination used the full output descriptor (`outDesc`), so MIOpen returned `A and C Tensors do not match` (status 7) at `gemm.cpp:158` whenever the bias actually needed broadcasting (e.g. `[1,N]` onto `[M,N]`). Crashed any graph in which ORT's `MatMulAddFusion` emitted a `Gemm` with broadcastable bias — most notably the MoE router MatMul.

   ```c
   // Before
   miopenOpTensor(handle, miopenTensorOpAdd,
                  &alpha1, cDesc, C, &alpha2, cDesc, C,   // A & B = bias  (small)
                  &beta_c, outDesc, output);              // dest          (full)
   // After: zero output, then
   miopenOpTensor(handle, miopenTensorOpAdd,
                  &alpha1, outDesc, output,    // A = dest, full shape
                  &alpha2, cDesc,   C,         // B = bias, broadcasts
                  &beta_c, outDesc, output);   // dest = output
   // => output = 1.0 * 0 + beta * broadcast(C) + 0 * 0 = beta * broadcast(C)
   ```

2. **QMoE `block_size` (`lib/Conversion/OnnxToHip/QMoEConversion.cpp` + `lib/Runtime/real/qmoe.cpp`)** — the `com.microsoft.QMoE` `block_size` attribute is documented as optional and is omitted by some quantization tools (e.g. AWQ exports of gpt-oss-120b). The conversion silently defaulted it to `0`, which made `wrap_qmoe` divide by zero in `(hidden_size + block_size - 1) / block_size` and crash with `STATUS_INTEGER_DIVIDE_BY_ZERO` (`0xC0000094`). Derive `block_size` from the FC1 (gate_up_proj) scales tensor shape when the attribute is missing — `scales` has shape `[num_experts, output_features, k_blocks_fc1]` with `k_blocks_fc1 = ceil(hidden_size / block_size)`, so `block_size = ceil(hidden_size / k_blocks_fc1)` gives the exact value for evenly‑split layouts (the common case; gpt-oss-120b yields `block_size = 32`). Fail conversion with a clear MLIR diagnostic when neither the attribute nor the shapes provide it. Add an early-return guard in `wrap_qmoe` so future regressions surface as a readable `fprintf` rather than a Windows DEP exception.

## Test plan

Verified on Strix Halo (gfx1151) with `onnxruntime_perf_test` running the gpt-oss-120b dumps:

### `single_op/QMoE/QMoE_seq*` (8 variants)
| variant | before | after |
|---|---|---|
| `QMoE_seq1` | crash `0xC0000094` in `wrap_qmoe` | **passes**, 1.07 ms |
| `QMoE_seq128` | crash `0xC0000094` | **passes**, 3.43 ms |
| `QMoE_seq256` | crash `0xC0000094` | **passes**, 7.85 ms |
| `QMoE_seq512` | crash `0xC0000094` | **passes**, 11.4 ms |
| `QMoE_seq1024` | crash `0xC0000094` | **passes**, 20.9 ms |
| `QMoE_seq2048` | crash `0xC0000094` | **passes**, 41.8 ms |
| `QMoE_seq3072` | crash `0xC0000094` | **passes**, 64.5 ms |
| `QMoE_dynamic` | EP rejects (`invalid tensor dimension size`) | unchanged (separate, pre-existing bug) |

### `single_layer/single_layer_seq128.onnx`
- **before**: `MIOpen Error: A and C Tensors do not match` at `gemm.cpp:158` → process crash
- **after**: completes inference (`exit=0`), 6.54 ms. Two pre-existing failures still log warnings but are non-fatal:
  - `wrap_group_query_attention: gqa_forward failed (rc=-1)` (pre-existing)
  - `hipBLAS error: hipblasLtMatmulAlgoGetHeuristic ... gemm.cpp:370 (status=3)` for the lm_head shape `M=128 N=201088 K=2880` (pre-existing — already reproducible on `single_layer_seq1` before this PR)

## Notes for reviewers
- Two-file fix for (1) and two-file fix for (2). No public API changes.
- Single-op QMoE tests under `single_op/QMoE/*` now pass, which gives focused coverage for the new code path. The current QMoE LIT/E2E tests don't exercise a model without an explicit `block_size`; consider adding one.
- Issues exposed but not fixed here: (a) `wrap_group_query_attention`'s GQA failure on the gpt-oss-120b layer, (b) `hipblasLtMatmulAlgoGetHeuristic` returning `INVALID_VALUE` for the lm_head shape `M=128 N=201088 K=2880` and the small router shape `M=128 N=128 K=2880`. Tracked separately.
