### PR TITLE
[Update] onnx-model-splitter: quick chunk export, --all matrix, tiered shape verify

### DIFF
--- a/tools/onnx-model-splitter/README.md
+++ b/tools/onnx-model-splitter/README.md
@@ -12,114 +12,34 @@ and analysis. Supports LLM (text), Vision, and Embedding models.
 | Script | Description |
 |--------|-------------|
 | `extract_submodels.py` | Main extraction tool — splits an ONNX model into `single_op`, `single_layer`, and `full_model` submodels with multiple dimension variants |
-| `export_chunk_model.py` | Export fixed-shape Llama prefill/decode ONNX variants with genai_config generation |
+| `export_chunk_model.py` | Export fixed-shape Llama prefill/decode ONNX variants with genai_config generation. **Default:** one sliding `p512…` prefill/decode pair only; pass **`--all`** for the full sequence-length matrix (`DEFAULT_SEQ_LENS` in code) and derived fixed-prompt / control stems |
 | `compare_chunk_export_outputs.py` | Validate an `export_chunk_model.py` output directory: structural match of each prefill/decode ONNX pair plus `genai_config_*.json` filenames and pipeline I/O lists vs graphs |
 | `genai_config_pipeline_from_folder.py` | Generate `decoder-pipeline` style `genai_config.json` for ORT GenAI from an existing model folder |
 | `inspect_onnx.py` | Inspect ONNX model structure (inputs, outputs, nodes, op types, preprocessing chains) |
 | `verify_ort_inference.py` | Verify extracted models by running ORT inference with dummy inputs (subprocess-isolated) |
-| `verify_extraction.py` | Verify extracted model files: sizes, graph structure, initializer integrity, fixed-shape validation |
+| `verify_extraction.py` | Verify extracted model files: sizes, graph structure, initializer integrity; fixed-shape **phase-1** scan and optional **phase-2** `shape_inference` + `check_model` (unless `--skip-shape-inference-check`). Use `--skip-fixed-shape-check` to skip fixed-shape checks entirely |
 | `_verify_one_model.py` | Subprocess worker for `verify_ort_inference.py` — loads one model and runs inference |
 
 ## Installation
 
+**Recommended:** use an isolated **Conda** environment so `onnx` / `onnxruntime` versions stay consistent with other projects on the same machine.
+
 ```bash
-pip install onnx onnxruntime numpy
-pip install onnxoptimizer  # optional but recommended
+conda create -n onnx-splitter python=3.11 -y
+conda activate onnx-splitter
 ```
 
-> **Note:** `onnxoptimizer` is optional but recommended. When installed, fixed-shape
-> variants automatically run Shape/Gather constant folding to eliminate redundant
-> shape-computation nodes.
+Then install dependencies (same packages if you use `venv` + `pip` instead):
+
+```bash
+pip install -r requirements.txt
+```
 
 ## Quick Start
 
-### Extract submodels
+End-to-end flow on one machine: **extract** submodels into `space`, **verify** them, build **decoder-pipeline** `genai_config`, **export** prefill/decode ONNX into `space\chunk` (the walkthrough uses **`--all`** so `chunk/` lists every variant; omit it for the default single `p512…` sliding pair only), then optionally **compare** exports. Uses a concrete **Llama-3.1-8B** Windows tree (`^` line continuation for `cmd`); adapt paths to your layout.
 
-```bash
-# Extract all (single_op + single_layer + full_model)
-python extract_submodels.py --model path/to/model.onnx
-
-# Extract to a custom output directory
-python extract_submodels.py --model path/to/model.onnx --output /output/dir
-
-# Extract only single_op
-python extract_submodels.py --model path/to/model.onnx --only single_op
-
-# Extract only single_layer
-python extract_submodels.py --model path/to/model.onnx --only single_layer
-
-# Extract only full_model
-python extract_submodels.py --model path/to/model.onnx --only full_model
-```
-
-### Export prefill/decode variants
-
-```bash
-# Export prefill + decode ONNX with genai configs
-python export_chunk_model.py --model path/to/model.onnx --output /output/dir
-
-# Specify max context length
-python export_chunk_model.py --model path/to/model.onnx --output /output/dir --max-length 4096
-```
-
-### Compare chunk export outputs
-
-After `export_chunk_model.py`, run this on the **same output directory** to check that each `prefill_TAG.onnx` has a matching `decode_TAG.onnx` and `genai_config_TAG.json` (non-`*_dml`): same graph topology (node names, op types, edges), compatible dtypes (intermediate shapes may differ by design), aligned graph I/O except known prefill vs decode sequence axes, and consistent `past_*` / `present_*` shapes. Optional `--compare-intermediate-shapes` enforces identical tensor shapes on every edge.
-
-```bash
-python compare_chunk_export_outputs.py /path/to/export_chunk_model_output
-
-python compare_chunk_export_outputs.py /path/to/out --quiet
-
-python compare_chunk_export_outputs.py /path/to/out --compare-intermediate-shapes
-```
-
-### Generate genai_config
-
-```bash
-python genai_config_pipeline_from_folder.py path/to/model_folder \
-    --fixed-prompt-length 128 --max-length 4096
-```
-
-### Inspect a model
-
-```bash
-# Basic info (inputs, outputs, summary)
-python inspect_onnx.py model.onnx
-
-# List all nodes
-python inspect_onnx.py model.onnx --nodes
-
-# Filter by op type
-python inspect_onnx.py model.onnx --nodes --type-name MatMul
-
-# Filter by layer index
-python inspect_onnx.py model.onnx --nodes --layer 0
-
-# Show op type statistics
-python inspect_onnx.py model.onnx --op-types
-
-# Find preprocessing chains (attention_mask, position_ids)
-python inspect_onnx.py model.onnx --find-chains
-```
-
-### Verify extracted models
-
-```bash
-# Verify all extracted models via ORT inference
-python verify_ort_inference.py /output/dir
-
-# Verify only single_op models
-python verify_ort_inference.py /output/dir --mode single_op
-
-# Verify model file structure and fixed-shape correctness
-python verify_extraction.py /output/dir
-
-# Skip fixed-shape dimension checks
-python verify_extraction.py /output/dir --skip-fixed-shape-check
-```
-
-## End-to-End Example: Llama-3.1-8B
+### Walkthrough: Llama-3.1-8B (Windows)
 
 Assume the original model is at
 `C:\modelzoo\Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml`.
@@ -143,7 +63,7 @@ space/
 └── full_model/          # full model with dimension variants
 ```
 
-#### 1b. Verify `space` (structure + ORT smoke)
+#### 1b. (Optional) Verify `space` (structure + ORT smoke)
 
 Run from the directory that contains the scripts (or use full paths to `verify_extraction.py` / `verify_ort_inference.py`). Both commands should exit with code **0**.
 
@@ -155,7 +75,7 @@ python verify_ort_inference.py ^
     C:\modelzoo\Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml\space
 ```
 
-`verify_extraction.py` checks extracted `.onnx` layout, external data offsets, graph sanity, and (for fixed-shape filenames) shape consistency. `verify_ort_inference.py` loads each extracted model in a **subprocess** and runs ORT with dummy inputs. To skip fixed-shape dimension checks on the first script, add `--skip-fixed-shape-check` to the `verify_extraction.py` line.
+`verify_extraction.py` checks extracted `.onnx` layout, external data offsets, graph sanity, and (for fixed-shape filenames) a two-phase shape check: static dims first, then optional ONNX `shape_inference` / `check_model` when phase-1 passes. `verify_ort_inference.py` loads each extracted model in a **subprocess** and runs ORT with dummy inputs. Add `--skip-fixed-shape-check` to skip fixed-shape checks, or `--skip-shape-inference-check` to keep phase-1 but skip phase-2.
 
 ### Step 2 — Export OGA prefill / decode variants
 
@@ -181,10 +101,13 @@ prepends extra search paths relative to `model_dir`.
 python export_chunk_model.py ^
     --model  C:\modelzoo\Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml\model.onnx ^
     --output C:\modelzoo\Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml\space\chunk ^
-    -T C:\modelzoo\Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml\genai_config_pipeline.json
+    -T C:\modelzoo\Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml\genai_config_pipeline.json ^
+    --all
 ```
 
-Output:
+`--all` exports the **full** variant matrix (multiple `prefill_*` / `decode_*` / `genai_config_*` files). Omit `--all` for a **quick** export: a single default `p512…` prefill/decode pair and matching `genai_config` (plus shared weights).
+
+Output (with `--all`):
 
 ```
 space/chunk/
@@ -206,6 +129,101 @@ space/chunk/
 ```bash
 python compare_chunk_export_outputs.py ^
     C:\modelzoo\Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml\space\chunk
+```
+
+## Script CLI reference
+
+Copy-paste examples for **each** Python entry point using generic paths. For a full pipeline in order, see **Quick Start** above.
+
+### `extract_submodels.py`
+
+```bash
+# Extract all (single_op + single_layer + full_model)
+python extract_submodels.py --model path/to/model.onnx
+
+# Extract to a custom output directory
+python extract_submodels.py --model path/to/model.onnx --output /output/dir
+
+# Extract only single_op
+python extract_submodels.py --model path/to/model.onnx --only single_op
+
+# Extract only single_layer
+python extract_submodels.py --model path/to/model.onnx --only single_layer
+
+# Extract only full_model
+python extract_submodels.py --model path/to/model.onnx --only full_model
+```
+
+### `export_chunk_model.py`
+
+Required: `--model`, `-o` / `--output`. With genai JSON (default), also pass **`-T` / `--config-template`** unless `--no-genai-config`.
+
+```bash
+# Quick export: single default sliding pair + genai_config (needs -T)
+python export_chunk_model.py --model path/to/model.onnx -o /output/dir -T path/to/genai_template.json
+
+# Full variant matrix (same stems as a “full” split export)
+python export_chunk_model.py --model path/to/model.onnx -o /output/dir -T path/to/genai_template.json --all
+```
+
+### `compare_chunk_export_outputs.py`
+
+After `export_chunk_model.py`, run on the **same output directory** to check that each `prefill_TAG.onnx` has a matching `decode_TAG.onnx` and `genai_config_TAG.json` (non-`*_dml`): same graph topology (node names, op types, edges), compatible dtypes (intermediate shapes may differ by design), aligned graph I/O except known prefill vs decode sequence axes, and consistent `past_*` / `present_*` shapes. Optional `--compare-intermediate-shapes` enforces identical tensor shapes on every edge.
+
+```bash
+python compare_chunk_export_outputs.py /path/to/export_chunk_model_output
+
+python compare_chunk_export_outputs.py /path/to/out --quiet
+
+python compare_chunk_export_outputs.py /path/to/out --compare-intermediate-shapes
+```
+
+### `genai_config_pipeline_from_folder.py`
+
+```bash
+python genai_config_pipeline_from_folder.py path/to/model_folder \
+    --fixed-prompt-length 128 --max-length 4096
+```
+
+### `inspect_onnx.py`
+
+```bash
+# Basic info (inputs, outputs, summary)
+python inspect_onnx.py model.onnx
+
+# List all nodes
+python inspect_onnx.py model.onnx --nodes
+
+# Filter by op type
+python inspect_onnx.py model.onnx --nodes --type-name MatMul
+
+# Filter by layer index
+python inspect_onnx.py model.onnx --nodes --layer 0
+
+# Show op type statistics
+python inspect_onnx.py model.onnx --op-types
+
+# Find preprocessing chains (attention_mask, position_ids)
+python inspect_onnx.py model.onnx --find-chains
+```
+
+### `verify_ort_inference.py` / `verify_extraction.py`
+
+```bash
+# Verify all extracted models via ORT inference
+python verify_ort_inference.py /output/dir
+
+# Verify only single_op models
+python verify_ort_inference.py /output/dir --mode single_op
+
+# Verify model file structure and fixed-shape correctness
+python verify_extraction.py /output/dir
+
+# Skip fixed-shape dimension checks (phase-1 + phase-2 off for shapes)
+python verify_extraction.py /output/dir --skip-fixed-shape-check
+
+# Keep phase-1 fixed-shape scan; skip ONNX shape_inference / check_model (phase-2)
+python verify_extraction.py /output/dir --skip-shape-inference-check
 ```
 
 ## Supported Model Types

--- a/tools/onnx-model-splitter/export_chunk_model.py
+++ b/tools/onnx-model-splitter/export_chunk_model.py
@@ -942,7 +942,9 @@ class FixedCtxExtractor(SingleOpExtractor):
         export_prefix: str = "prefill",
     ):
         self._max_length = max_length
-        self._seq_lens = seq_lens if seq_lens is not None else DEFAULT_QUICK_EXPORT_SEQ_LENS
+        self._seq_lens = (
+            seq_lens if seq_lens is not None else DEFAULT_QUICK_EXPORT_SEQ_LENS
+        )
         self._decode_mode = decode_mode
         self._export_prefix = export_prefix
         super().__init__(model_path, output_dir=output_dir)

--- a/tools/onnx-model-splitter/export_chunk_model.py
+++ b/tools/onnx-model-splitter/export_chunk_model.py
@@ -19,12 +19,17 @@ Export fixed-shape Llama prefill/decode ONNX variants.
   ``12200``.
   ``128`` and ``2048`` still keep their sliding-window variants ``prefill_pSm...``;
   ``12200`` is fixed-only (no ``p12200m...`` variant).
-  **Control fixed-prompt** (chunk=0 only, when ``128`` / ``2048`` appear in ``--seq-lens``):
+  **Control fixed-prompt** (chunk=0 only, when ``128`` / ``2048`` appear in the full export
+  matrix ``DEFAULT_SEQ_LENS`` used with ``--all``):
   ``prefill_128_m256.onnx`` / ``genai_config_128_m256.json`` (``context_length``/KV = 256,
   ``fixed_prompt_length`` 128) and ``prefill_2k_m3072.onnx`` /
   ``genai_config_2k_m3072.json`` (3072 / 2048; stem ``2k`` like other fixed 2048 files).
-- Prefill: default ``--seq-lens`` expands to 10 variants (two for ``128`` and ``2048`` plus
-  the rest); Decode maps one-to-one with these variants.
+- **Default (no ``--all``):** export a single sliding-window variant only:
+  ``prefill_p512m{max_length}.onnx``, ``decode_p512m{max_length}.onnx``, and
+  ``genai_config_p512m{max_length}.json`` (plus shared external weights as today).
+- **With ``--all``:** export the full fixed matrix (same tuple as ``DEFAULT_SEQ_LENS`` in
+  code: ``128,256,512,1024,2048,3072,4096,12200`` and their expanded variants); decode
+  maps one-to-one with prefill.
 - input_ids: [1, S] (prefill) or [1, 1] (decode); attention_mask: [1, max_length];
   position_ids: [1, S] (prefill) or [1, 1] (decode), matching the current-step sequence.
 - past_key_values.*.key/value: the 3rd dimension is forced to max_length, with layout
@@ -119,7 +124,10 @@ total_seq_len_scalar_from_dim_map = _es.total_seq_len_scalar_from_dim_map
 upsert_total_seq_len_const_initializer = _es.upsert_total_seq_len_const_initializer
 
 
+# Full export matrix when CLI ``--all`` is set (not configurable).
 DEFAULT_SEQ_LENS = (128, 256, 512, 1024, 2048, 3072, 4096, 12200)
+# Default quick export: one sliding variant ``p512m{max_length}`` only.
+DEFAULT_QUICK_EXPORT_SEQ_LENS = (512,)
 GQA_INIT_PREFIX = "gqa_ctxfix_"
 
 # Fallback when the source ONNX has no external-data initializers
@@ -321,7 +329,7 @@ def expand_export_variant_specs(
     *,
     decode_mode: bool,
 ) -> list[tuple[str, dict[str, int], int, int | None, int | None]]:
-    """Expand ``--seq-lens`` into the ONNX/genai variant list.
+    """Expand a sequence-length tuple into the ONNX/genai variant list.
 
     Each item is
     ``(file_stem, dim_map, genai_window_chunk, fixed_prompt_len, genai_context_length)``:
@@ -934,7 +942,7 @@ class FixedCtxExtractor(SingleOpExtractor):
         export_prefix: str = "prefill",
     ):
         self._max_length = max_length
-        self._seq_lens = seq_lens or DEFAULT_SEQ_LENS
+        self._seq_lens = seq_lens if seq_lens is not None else DEFAULT_QUICK_EXPORT_SEQ_LENS
         self._decode_mode = decode_mode
         self._export_prefix = export_prefix
         super().__init__(model_path, output_dir=output_dir)
@@ -1099,17 +1107,14 @@ def run_export(
     ext.extract_full_model()
 
 
-def parse_seq_lens(s: str | None) -> tuple[int, ...]:
-    if not s:
-        return DEFAULT_SEQ_LENS
-    parts = [p.strip() for p in s.split(",") if p.strip()]
-    return tuple(int(p) for p in parts)
-
-
 def main():
     p = argparse.ArgumentParser(
-        description="Export Llama prefill/decode ONNX with fixed max_length "
-        f"(default {16384}) and per-variant sequence lengths."
+        description=(
+            "Export Llama prefill/decode ONNX with fixed max_length "
+            f"(default {16384}). By default exports only the "
+            f"p512m{{max_length}} pair plus genai_config; pass --all for the full "
+            f"variant matrix ({', '.join(map(str, DEFAULT_SEQ_LENS))} and expanded stems)."
+        )
     )
     p.add_argument(
         "--model",
@@ -1149,9 +1154,13 @@ def main():
         "second dim. --cache-len is an alias.",
     )
     p.add_argument(
-        "--seq-lens",
-        default=None,
-        help=f"Comma-separated sequence lengths (default {','.join(map(str, DEFAULT_SEQ_LENS))})",
+        "--all",
+        action="store_true",
+        help=(
+            "Export the full variant matrix (sequence lengths "
+            f"{', '.join(map(str, DEFAULT_SEQ_LENS))} and all derived fixed-prompt / "
+            "control stems). Default is a single sliding variant p512m{max_length} only."
+        ),
     )
 
     args = p.parse_args()
@@ -1175,14 +1184,15 @@ def main():
             os.path.abspath(args.config_template) if args.config_template else None
         )
 
-    seq_lens = parse_seq_lens(args.seq_lens)
+    seq_lens = DEFAULT_SEQ_LENS if args.all else DEFAULT_QUICK_EXPORT_SEQ_LENS
     out = os.path.abspath(args.output)
 
     model_abs = os.path.abspath(args.model)
     if not os.path.isfile(model_abs):
         p.error(f"Model file does not exist: {model_abs}")
 
-    print(f"=== Prefill (out={out}, prefill_*m{args.max_length}.onnx, etc.) ===")
+    mode = "full matrix (--all)" if args.all else "quick (p512 only)"
+    print(f"=== Prefill ({mode}, out={out}, max_length={args.max_length}) ===")
     run_export(
         model_abs,
         out,
@@ -1191,7 +1201,7 @@ def main():
         decode_mode=False,
         export_prefix="prefill",
     )
-    print(f"=== Decode (out={out}, decode_*m{args.max_length}.onnx, etc.) ===")
+    print(f"=== Decode ({mode}, out={out}, max_length={args.max_length}) ===")
     run_export(
         model_abs,
         out,

--- a/tools/onnx-model-splitter/verify_extraction.py
+++ b/tools/onnx-model-splitter/verify_extraction.py
@@ -127,17 +127,40 @@ def _collect_fixed_variant_shape_issues(model):
 
 
 def _infer_shapes_for_check(model):
-    """Return inferred model; ONNX uses check_type (not check_types)."""
+    """Return inferred model with graceful fallback across ONNX APIs.
+
+    Newer ONNX builds accept ``strict_mode=True`` and are useful to catch
+    hard mismatches. Some real-world exports still carry stale ValueInfo
+    annotations (for example Constant rank metadata) that only fail in strict
+    mode while regular infer_shapes succeeds. For verification we therefore
+    progressively relax inference before giving up.
+    """
     infer = onnx.shape_inference.infer_shapes
+    first_error = None
+
     try:
         return infer(model, check_type=True, strict_mode=True)
     except TypeError:
+        # Older ONNX doesn't expose strict_mode.
         pass
+    except Exception as e:
+        first_error = e
+
     try:
         return infer(model, check_type=True)
     except TypeError:
+        # Older ONNX doesn't expose check_type.
         pass
-    return infer(model)
+    except Exception as e:
+        if first_error is None:
+            first_error = e
+
+    try:
+        return infer(model)
+    except Exception as e:
+        if first_error is not None:
+            raise first_error from e
+        raise
 
 
 def _graph_initializers_use_external_data(graph):


### PR DESCRIPTION
## Motivation

**`export_chunk_model.py`**  
Per updated product requirements, the chunk exporter should default to a **single** representative sliding-window prefill/decode pair (and matching `genai_config`) instead of always emitting the full sequence-length matrix. Full-matrix export remains available when explicitly requested.

**`verify_extraction.py`**  
Fix **false positives** for some models during extraction verification.

**`README.md`**  
Align user-facing docs with the new export default, optional full-matrix flow, environment setup, and the two-phase verify behavior and flags.

## Technical Details

**`export_chunk_model.py`**

- **By default:** export only the single sliding-window variant tied to **512** (`p512m{max_length}` prefill/decode and matching `genai_config`).
- **Only with `--all`:** export the **full** variant matrix from the built-in sequence-length set.