### PR TITLE
feat: per-op GPU profiling, crash handlers, GQA fixes, and Python test infra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,9 @@ Thumbs.db
 .cline/
 .cursor/
 
+# Claude Code local settings (machine-specific)
+.claude/settings.local.json
+
 # Additional IDE/editor files
 *.sublime-project
 *.sublime-workspace
@@ -115,3 +118,9 @@ dump_log.txt
 # Local build scripts (contain machine-specific paths)
 setup_and_configure.ps1
 build_and_install.ps1
+
+# build.py install directory
+install/
+
+# ONNX model files (large, downloaded on demand)
+models/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,297 @@
+<!--
+Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+Licensed under the MIT License.
+-->
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+**MANDATORY:** When a session produces new critical observations (build gotchas, API patterns, model quirks, test conventions), update this file and relevant `docs/*` files before finishing. **Any code change that affects behavior documented in `docs/` or `docs/design/` must update those docs in the same session — never leave them stale.** Always check `docs/design/*` for design documents that reference renamed symbols, changed APIs, updated metrics, or modified architecture. This is the single source of truth — do not use `.claude/memory` or external memory files.
+
+## Project Overview
+
+ONNX HIP DNN Execution Provider — an MLIR compiler that converts ONNX models into AMD GPU-accelerated DLLs via a HIP dialect, targeting MIOpen, hipBLASLt, and custom HIP kernels. Integrates into ONNX Runtime through the MorphiZen Execution Provider framework.
+
+## Build Commands
+
+### Quick start (recommended)
+
+`build.py` automates everything: downloads dependencies (TheRock, LLVM/MLIR, Protobuf, FlatBuffers, ONNX Runtime), detects VS2022 and GPU, configures, builds, and installs. All artifacts go under `install/`.
+
+```bash
+# One-time: create conda environment
+conda env create -f environment.yml
+conda activate hipdnn-ep
+
+# Build (from any shell — VS Developer Prompt not required)
+python build.py                # full build
+python build.py --skip-build   # download deps only
+python build.py --clean        # wipe install/ and start fresh
+```
+
+`build.py` auto-detects VS2022 via `vswhere.exe`, injects MSVC environment, detects GPU architecture via `amdgpu-arch.exe`, and selects real vs mock runtime accordingly. Idempotent — skips already-completed steps.
+
+Output layout:
+- `install/therock/` — TheRock ROCm SDK
+- `install/deps/` — prebuilt LLVM/MLIR/Protobuf/FlatBuffers
+- `install/onnxruntime/` — ONNX Runtime binaries
+- `install/build/` — CMake build directory
+- `install/dist/` — final installed binaries
+
+### Run tests
+
+```bash
+# All tests
+ctest --test-dir install/build -C RelWithDebInfo
+
+# LIT tests only (MLIR pass verification)
+ctest --test-dir install/build -C RelWithDebInfo -R MorphizenMLIRLitTests
+
+# Python tests (performance benchmarks, integration)
+pytest test/python -v -s
+```
+
+### Lint / format
+
+```bash
+lintrunner -a                    # format changed files
+lintrunner -a --all-files        # format all files
+pre-commit run --all-files       # all hooks (whitespace, license, clang-format, ruff)
+```
+
+### Manual CMake (advanced)
+
+For manual builds without `build.py`, see the cmake invocations in `build.py`'s `configure_and_build()`. Key variables:
+
+| Variable | Purpose |
+|----------|---------|
+| `CMAKE_PREFIX_PATH` | Semicolon-separated: deps dir + ORT dir |
+| `THEROCK_DIST` | Path to TheRock ROCm SDK |
+| `HIP_ARCHITECTURES` | GPU target (e.g. `gfx1150`). **Mandatory** for real runtime |
+| `BUILD_HIP_TOOLS` | Build MLIR compiler tools |
+| `BUILD_EP` | Build MorphiZen Execution Provider |
+| `BUILD_MOCK_RUNTIME` | Use CPU stubs instead of GPU runtime |
+
+## Critical Build Gotchas
+
+- **Conda env is a prerequisite.** `build.py` expects tools (cmake, ninja, sccache, lit) from the `hipdnn-ep` conda env to be on PATH.
+- **HIP_ARCHITECTURES must match the GPU.** Omitting or mismatching causes silent build success but runtime crashes (`0xC0000005` in `hipLaunchKernel`). `build.py` auto-detects via `amdgpu-arch.exe`.
+- **CRT must be Release /MT.** Pre-built LLVM/MLIR use static Release CRT. Debug (`/MTd`) or dynamic (`/MD`) produces linker errors.
+- **Static CRT means separate CRT per DLL.** Model DLLs compiled with `/MT` have their own CRT instance — `std::getenv()` cannot see env vars set by the host process. Use `GetEnvironmentVariableA()` (Win32 API) instead. See `debug_log.h` for the pattern.
+- **DIA SDK junction** may be needed: prebuilt LLVM hardcodes `C:\msvsn2022` for DIA SDK path. `build.py` creates this automatically.
+- **sccache + RelWithDebInfo**: CMakeLists.txt swaps `/Zi` → `/Z7` and disables incremental linking to prevent PDB file contention during parallel builds.
+- **TheRock DLLs on PATH at runtime.** Compiled model DLLs link against `amdhip64_7.dll`, `MIOpen.dll`, etc. from `install/therock/bin/`. Add that directory to PATH before running `hip-onnx-runner` or any compiled model.
+- **Models must have static shapes.** The MLIR compiler does not support dynamic/symbolic tensor dimensions. Convert models to fixed shapes before use (see Test Models section).
+- **ORT version must match pip.** `build.py` pins `ORT_VERSION` to match the pip `onnxruntime-directml` package. The MorphiZen EP DLL checks the ORT API version at registration; a mismatch (e.g. EP built against API v25 vs pip API v24) causes segfault. When upgrading, update `ORT_VERSION` in `build.py` and `onnxruntime-directml` in pip in lockstep.
+- **Runtime functions called from generated code need `extern "C"` linkage.** Declare them in `hipdnn_ep_runtime.h` (which wraps everything in `extern "C"`). Without this, Clang produces C++-mangled names in the bitcode but `GenerateInterface.cpp` emits unmangled references — causing link failures.
+- **Stale compiled-model DLLs after runtime changes.** Compiled model DLLs embed the runtime bitcode from build time. The MorphiZen cache key is based on the ONNX graph hash, not the runtime version — so changing runtime `.cpp` files (or custom kernels) and rebuilding does NOT invalidate cached models. After rebuilding, delete stale DLLs manually: `rm "$TEMP"/morphizen_mlir_*` (bash) or `del %TEMP%\morphizen_mlir_*` (cmd).
+- **Bitcode DEPENDS list must include all headers.** The `compile_to_bitcode` macro in `lib/Runtime/CMakeLists.txt` uses a `DEPENDS` list to track when recompilation is needed. Every header that a runtime `.cpp` file `#include`s must be listed there — otherwise, editing the header doesn't rebuild the bitcode, and compiled models silently use stale runtime code. When adding a new `#include` to a runtime `.cpp` file, always update the `DEPENDS` list in the macro.
+- **Linker byproducts not cleaned up.** `CompilerDriver::cleanupIntermediates()` removes `.ll` and `.obj` files after linking, but LLD also creates `.lib`, `.pdb`, and `.exp` byproducts alongside each `.dll`. These accumulate in `%TEMP%` (hundreds of files over time). Known issue — fix requires extending `cleanupIntermediates()` in `CompilerDriver.cpp`.
+
+## Architecture
+
+### Compilation Pipeline
+
+```
+ONNX (.onnx) → [onnx-to-hip-pipeline] → HIP dialect → [bufferize + optimize] → [hip-to-llvm-pipeline] → LLVM IR → link → model.dll + constants.bin
+```
+
+Key passes in order:
+1. `hip-add-context-arg` — inject `!hip.context` argument
+2. `convert-onnx-to-hip` — ONNX ops to HIP dialect ops (externalizes large constants to `.constants.bin`)
+3. `one-shot-bufferize` — tensor semantics to memref (buffer) semantics
+4. `buffer-deallocation` + `hip-optimize-memrefs` — liveness-based buffer reuse
+5. `hip-pool-allocs` — pack all allocations into a single grow-on-demand GPU buffer
+6. `hip-lower-allocs` — `memref.alloc` to `hip.alloc`/`hip.free`
+7. `convert-hip-to-llvm` — HIP ops to runtime C API calls
+8. `generate-interface` — emit `inference_init`/`inference_compute`/`inference_cleanup` entry points
+
+### Three-layer lowering
+
+| Layer | Location | What it does |
+|-------|----------|--------------|
+| ONNX → HIP | `lib/Conversion/OnnxToHip/` | Pattern-matches ONNX ops by name (no onnx-mlir dependency) and emits HIP dialect ops |
+| HIP dialect | `lib/Dialect/` | Custom MLIR dialect with ops for MIOpen, hipBLASLt, and custom kernels; TableGen-defined |
+| HIP → LLVM | `lib/Conversion/HipToLLVM/` | Lowers HIP ops to C API calls into the runtime library |
+
+### Runtime
+
+- **Real** (`lib/Runtime/real/`): GPU execution via MIOpen, hipBLASLt, custom HIP kernels. Linked as bitcode into the compiled DLL.
+- **Mock** (`lib/Runtime/mock/`): CPU stubs for GPU-free development/testing. Enabled with `BUILD_MOCK_RUNTIME=ON`.
+
+### Generated DLL entry points
+
+`GenerateInterface.cpp` emits three functions into each compiled model DLL:
+- `inference_init` — allocates RuntimeState, loads constants
+- `inference_compute` — the hot path: prepare_input → prepare_output → main_graph → finalize_output → stream_sync → free_input
+- `inference_cleanup` — destroys RuntimeState
+
+Runtime functions called from generated code must be declared in `hipdnn_ep_runtime.h` (extern "C") and listed in `getRuntimeFuncSpecs()` in `GenerateInterface.cpp`.
+
+### Backend integration (MorphiZen EP)
+
+`backend-mlir-compiler/` bridges this compiler to ONNX Runtime:
+- **Level-1 pass** dispatches to Level-2 passes for per-op pattern matching
+- **Custom Op** executes compiled DLLs at inference time with a shared HIP stream
+- All ops on the same stream — no explicit synchronization needed between MIOpen/hipBLASLt/kernel calls
+
+### Tools
+
+| Tool | Purpose |
+|------|---------|
+| `hip-mlir-opt` | MLIR optimizer with all HIP passes registered |
+| `hip-compiler` | End-to-end ONNX → DLL compiler CLI |
+| `hip-test-dll` | Load and execute a compiled DLL |
+| `hip-inspect-dll` | Inspect DLL metadata (FlatBuffers) |
+| `hip-onnx-runner` | Run ONNX models via HIP EP |
+
+## Adding a New Operator
+
+Each operator spans three layers — follow existing patterns:
+
+1. **ONNX → HIP conversion**: add `lib/Conversion/OnnxToHip/<Op>Conversion.cpp`, register in `OnnxToHip.cpp`
+2. **HIP dialect op**: define in `include/hip/Dialect/HipOps.td` (TableGen), add C++ verification in `lib/Dialect/IR/`
+3. **HIP → LLVM lowering**: add `lib/Conversion/HipToLLVM/<Op>Lowering.cpp`, register in `HipToLLVM.cpp`
+4. **Runtime function**: implement in `lib/Runtime/real/<op>.cpp` and `lib/Runtime/mock/mock_gpu.cpp`
+5. **Custom kernel** (if needed): add `.hip` file in `3rd-party/custom_kernels/`, declare in `hip_custom_kernels.h`
+6. **LIT test**: add `.mlir` test in `test/lit/`
+
+Zero-cost shape ops (Reshape, Squeeze, Unsqueeze) lower through standard MLIR `tensor.expand_shape`/`tensor.collapse_shape` and need no runtime support.
+
+## Test Models
+
+ONNX models live under `models/<model-name>/` (gitignored). Python perf tests auto-download models on first run.
+
+**Fixed-shape requirement:** The compiler requires all tensor dimensions to be static. Models with dynamic dimensions (e.g. `batch_size`, `sequence_length`) must be converted to fixed shapes before use. The perf test fixtures handle this automatically via `fix_shapes()` in `test/python/conftest.py`.
+
+| Model | Quant | Layers | KV Heads | Head Dim | Size | Source |
+|-------|-------|--------|----------|----------|------|--------|
+| Llama-3.2-1B-Instruct | q4f16 | 16 | 8 | 64 | ~1.1 GB | [onnx-community/Llama-3.2-1B-Instruct-ONNX](https://huggingface.co/onnx-community/Llama-3.2-1B-Instruct-ONNX) |
+| Meta-Llama-3.1-8B-Instruct | INT4 | 32 | 8 | 128 | ~5.3 GB | [onnx-community/Meta-Llama-3.1-8B-Instruct-ONNX-DirectML-GenAI-INT4](https://huggingface.co/onnx-community/Meta-Llama-3.1-8B-Instruct-ONNX-DirectML-GenAI-INT4) |
+
+**Note:** The 8B model has `position_ids` as an additional input (not present in the 1B model).
+
+### Running with hip-onnx-runner
+
+```cmd
+rem From the repo root — TheRock ROCm DLLs must be on PATH for compiled model DLLs to load
+set PATH=%CD%\install\therock\bin;%PATH%
+install\dist\bin\hip-onnx-runner.exe -m models\Llama-3.2-1B-Instruct\model_q4f16_fixed.onnx
+```
+
+**Important:** `hip-onnx-runner` fills inputs with random data by default. For models with GQA, this produces garbage `seqlens_k` values and GQA failures. Use `-i <dir>` to provide valid binary input files (see `test/python/` for how the perf tests generate correct inputs).
+
+## Python Performance Tests
+
+Tests in `test/python/` compare single-token decode latency across three EPs using the **same** ORT Python API:
+
+```bash
+pytest test/python/test_llama1b.py -v -s   # 1B model
+pytest test/python/test_llama8b.py -v -s   # 8B model
+```
+
+**Structure:** `conftest.py` has shared utilities (`download`, `fix_shapes`, `run_timed`, `report`, `compare_outputs`, `register_morphizen_ep`, `LlamaModelConfig`, `make_llama_inputs`, `run_timed_iobinding`). Each test file owns its model config (HF URLs, filenames, `LlamaModelConfig`). Adding a new model = new test file following the same pattern.
+
+**IOBinding for MorphiZen EP tests:** MorphiZen EP perf tests use `run_timed_iobinding` which binds the same `OrtValue` to both the past KV input and present KV output. The runtime detects matching host pointers and reuses the same GPU allocation, so `past_key_gpu == present_key_gpu`. This makes GQA skip the per-layer D2H + `hipStreamSynchronize` stall (the `past_key != present_key` condition is false).
+
+**KV cache shape convention:** Both `past_sequence_length` and `total_sequence_length` are set to `max_seq_len` (128) in the dim map. This makes past and present KV tensors the same shape, enabling shared buffer detection in the runtime.
+
+### MorphiZen EP from Python
+
+The MorphiZen EP is loaded via ORT's dynamic EP registration API (not `get_available_providers()`):
+
+```python
+import onnxruntime as ort
+ort.register_execution_provider_library("MorphiZenExecutionProvider", str(ep_dll))
+from onnxruntime.capi._pybind_state import get_ep_devices
+devices = [d for d in get_ep_devices() if d.ep_name == "MorphiZenExecutionProvider"]
+so = ort.SessionOptions()
+so.add_provider_for_devices(devices, {})
+sess = ort.InferenceSession(model_path, sess_options=so)
+```
+
+**Both `install/dist/bin` and `install/therock/bin` must be on PATH** for the EP DLL to find `hip-compiler.dll` and ROCm runtime DLLs.
+
+## Performance Profiling
+
+Set `HIPDNN_EP_PERF=1` to enable two levels of profiling output (to stderr):
+
+1. **Phase-level timing** — H2D, Compute, D2H, Sync breakdown per inference (existing)
+2. **Per-operator GPU profiling** — GPU and CPU time per operator, grouped by op name with shape sub-rows, sorted by GPU time descending
+
+```bash
+HIPDNN_EP_PERF=1 pytest test/python/test_llama8b.py -v -s
+```
+
+When disabled (default), profiling is zero-overhead: `std::optional` guards prevent `hipEvent` creation.
+
+### Architecture
+
+- Per-op profiling uses RAII scope guards (`OpProfileScope`, `OpProfileCpuScope`) that record `hipEvent_t` start/stop pairs on the HIP stream. Events are resolved in bulk after `hipStreamSynchronize` — no per-op sync.
+- Profiling state lives in `RuntimeState->op_profile` (opaque `void*`), not globals — each inference session has its own state. Two-level data model: `OpEntry` (per op name) → `ShapeEntry` (per shape string).
+- Key files: `op_profile.h` (RAII scopes + macros), `op_profile.cpp` (state + printing), `debug_log.h` (env var check)
+- Each operator wrapper adds one line: `OP_PROFILE("opname", shape_lambda, state)` or `OP_PROFILE_CPU("opname", state)`. The shape lambda is only invoked when profiling is active — zero `snprintf` overhead on the hot path.
+
+### Llama 8B baseline (gfx1150, single-token decode, April 2026)
+
+CPU time tracks host-side overhead — GPU ops should show near-zero CPU time (all async), with `stream_sync` capturing the full CPU wait. Non-zero CPU on a GPU op indicates an unexpected `hipStreamSynchronize` in its code path.
+
+| Operator | Calls | GPU (ms) | CPU (ms) | GPU % |
+|----------|------:|---------:|---------:|------:|
+| matmul_nbits | 225 | 66.3 | 0.4 | 77.7% |
+|   m=1,n=14336,k=4096 | 64 | 30.1 | 0.1 | 35.3% |
+|   m=1,n=4096,k=14336 | 32 | 13.6 | 0.1 | 15.9% |
+|   m=1,n=4096,k=4096 | 64 | 11.8 | 0.1 | 13.8% |
+|   m=1,n=1024,k=4096 | 64 | 5.5 | 0.1 | 6.4% |
+|   m=1,n=128256,k=4096 | 1 | 3.5 | 0.0 | 4.1% |
+| skip_layernorm (1x4096) | 64 | 4.8 | 0.3 | 5.6% |
+| gqa (b=1,sq=1,skv=128,h=32,d=128) | 32 | 4.3 | 0.1 | 5.0% |
+| rotary_emb | 64 | 3.9 | 0.1 | 4.6% |
+|   h=32,d=128 | 32 | 2.1 | 0.1 | 2.5% |
+|   h=8,d=128 | 32 | 1.8 | 0.1 | 2.1% |
+| elementwise (1x1x1x14336) | 64 | 2.8 | 0.2 | 3.3% |
+| activation (n=14336) | 32 | 2.2 | 0.1 | 2.6% |
+| stream_sync | 1 | n/a | 85.0 | n/a |
+| **TOTAL** | | **85.3** | **87.6** | |
+
+End-to-end: **~67 ms avg** (14.9 tok/s)
+
+**GQA fused decode path:** For single-token decode (`sq==1`) with supported head dimensions (`d∈{64,128,256}`), GQA uses a fused custom HIP kernel path (rope + KV append + fused attention decode). This path is fully async — no D2H copies, no per-layer sync. The `local_window_size` attribute must be `<= 0` (ONNX uses `-1` for no windowing). The decomposed hipBLASLt path (used for prefill or unsupported configs) falls back to D2H + sync per layer.
+
+**Shared buffer detection:** The runtime (`hipdnn_ep_runtime_tensor.cpp`) detects when an output's host pointer matches a previously-prepared input's host pointer (IOBinding with shared OrtValue for past/present KV cache). It reuses the same GPU allocation so `past_key_gpu == present_key_gpu`, which makes GQA skip the per-layer D2H `seqlens_k` copy + `hipStreamSynchronize` in the decomposed path.
+
+**GQA path selection:** With shared buffers, `past_key == present_key` at the GPU level → the `need_host_past_len` condition (`past_key && past_key != present_key`) is false → no D2H copy, no `hipStreamSynchronize` per layer. The concat path (which requires host-side `past_len`) is only triggered when `past_key != present_key`.
+
+**Runtime state:** Buffer pool, shared-buffer detection map, and GQA GEMM descriptor cache are all per-session (stored in `RuntimeState` as opaque pointers), not globals. This supports concurrent inference sessions.
+
+## Crash Reporting (cpptrace)
+
+All executables and DLLs register crash handlers via `hip::install_crash_handlers()` (`lib/Support/CrashHandler.h`). On crash, a stack trace is printed to stderr.
+
+Three handlers are installed (guarded by `std::call_once`):
+1. `cpptrace::register_terminate_handler()` — uncaught C++ exceptions
+2. `std::signal(SIGABRT, ...)` — `abort()` calls
+3. `AddVectoredExceptionHandler()` (Windows) — SEH exceptions (`0xC0000000` prefix, excludes invalid-handle and stack-overflow)
+
+Always enabled — no environment variable needed. The `CrashHandler.h` header is private (lives in `lib/Support/`, not installed).
+
+**Integration points:**
+- **Compiler tools** (`BUILD_HIP_TOOLS`): link `HipSupport` library, call at top of `main()` or in `DllMain`
+- **EP DLL** (`BUILD_EP`): `CrashHandler.cpp` compiled into level-1-pass static lib (whole-archived into EP DLL), called in `CreateEpFactories()`
+- **hip-onnx-runner**: `CrashHandler.cpp` compiled directly into the executable
+
+**Dependency:** cpptrace v0.8.3 fetched via FetchContent (in `CMakeLists.txt` for `BUILD_HIP_TOOLS`, in `cmake/deps.cmake` for `BUILD_EP`).
+
+## Code Conventions
+
+- C++ 17, formatted with clang-format 16. Python formatted with ruff.
+- MIT license headers enforced by pre-commit hook (template: `LICENSES/license.txt`).
+- `3rd-party/` is excluded from all linting.
+- Design documents live in `docs/design/`.
+- Use MorphiZen C++ wrappers (`morphizen_cxx::NodeConstRef`, etc.) for graph/node APIs — do not use raw ONNX protobuf methods.
+- The ONNX-to-HIP conversion uses MLIR's generic `Operation` API to match ops by name — no onnx-mlir headers required.
+- Always use `python build.py` to build — never suggest manual cmake invocations unless specifically asked.
+- Use `onnxruntime-genai-directml` (not plain or CUDA variant) when installing genai tools.
+- **MANDATORY:** Do not use `.claude/memory`. All persistent knowledge belongs in this file or `docs/`.
+- **Comments on non-obvious code are mandatory.** When adding or fixing code whose behavior isn't self-explanatory — especially workarounds, spec quirks, or subtle correctness invariants — add a short comment explaining *why*. Examples: ONNX convention differences (`local_window_size=-1` meaning "disabled"), shared-buffer detection rationale, or why a condition uses `<=` instead of `==`. Don't comment obvious code; do comment anything a reader might question.
+- When an approach fails, revert immediately and completely — no partial experimental code left in the tree. Prefer runtime-only fixes (`lib/Runtime/real/`) over cross-cutting changes spanning compiler + interface + runtime. If a multi-layer fix doesn't work after one attempt, revert and reassess.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,9 +254,9 @@ CPU time tracks host-side overhead — GPU ops should show near-zero CPU time (a
 | elementwise (1x1x1x14336) | 64 | 2.1 | 0.1 | 2.6% |
 | **TOTAL** | | **79.9** | **0.9** | |
 
-End-to-end: **~57 ms avg** (17.5 tok/s)
+End-to-end: **~59 ms avg** (17.0 tok/s)
 
-Profiling overhead (event pool): ~35 ms (+60%), from 972 `hipEventRecord` + 486 `hipEventElapsedTime` calls. This is the inherent cost of GPU timing instrumentation.
+Profiling overhead (event pool): ~34 ms (+58%), from 972 `hipEventRecord` + 486 `hipEventElapsedTime` calls. This is the inherent cost of GPU timing instrumentation. With profiling on: ~93 ms avg (10.7 tok/s).
 
 **GQA fused decode path:** For single-token decode (`sq==1`) with supported head dimensions (`d∈{64,128,256}`), GQA uses a fused custom HIP kernel path (rope + KV append + fused attention decode). This path is fully async — no D2H copies, no per-layer sync. The `local_window_size` attribute must be `<= 0` (ONNX uses `-1` for no windowing). The decomposed hipBLASLt path (used for prefill or unsupported configs) falls back to D2H + sync per layer.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,9 +192,9 @@ pytest test/python/test_llama8b.py -v -s   # 8B model
 
 **Structure:** `conftest.py` has shared utilities (`download`, `fix_shapes`, `run_timed`, `report`, `compare_outputs`, `register_morphizen_ep`, `LlamaModelConfig`, `make_llama_inputs`, `run_timed_iobinding`). Each test file owns its model config (HF URLs, filenames, `LlamaModelConfig`). Adding a new model = new test file following the same pattern.
 
-**IOBinding for MorphiZen EP tests:** MorphiZen EP perf tests use `run_timed_iobinding` which binds the same `OrtValue` to both the past KV input and present KV output. The runtime detects matching host pointers and reuses the same GPU allocation, so `past_key_gpu == present_key_gpu`. This makes GQA skip the per-layer D2H + `hipStreamSynchronize` stall (the `past_key != present_key` condition is false).
+**IOBinding with device memory for MorphiZen EP tests:** MorphiZen EP perf tests use `run_timed_iobinding(..., use_device_memory=True)` which allocates KV cache OrtValues via the EP's `hipHostMalloc` GPU allocator (`device_type="gpu", vendor_id=0x1002`). The runtime sees `memory_type == TENSOR_MEMORY_GPU` and aliases the buffer directly (zero-copy). The same OrtValue is bound to both past KV input and present KV output, so `past_key_gpu == present_key_gpu` — GQA skips the per-layer D2H + `hipStreamSynchronize` stall.
 
-**KV cache shape convention:** Both `past_sequence_length` and `total_sequence_length` are set to `max_seq_len` (128) in the dim map. This makes past and present KV tensors the same shape, enabling shared buffer detection in the runtime.
+**KV cache shape convention:** Both `past_sequence_length` and `total_sequence_length` are set to `max_seq_len` (128) in the dim map. This makes past and present KV tensors the same shape, enabling the memory_type aliasing fast path in the runtime.
 
 ### MorphiZen EP from Python
 
@@ -223,13 +223,14 @@ Set `HIPDNN_EP_PERF=1` to enable two levels of profiling output (to stderr):
 HIPDNN_EP_PERF=1 pytest test/python/test_llama8b.py -v -s
 ```
 
-When disabled (default), profiling is zero-overhead: `std::optional` guards prevent `hipEvent` creation.
+When disabled (default), profiling is zero-overhead: `hipdnn_ep_perf_enabled()` is a `static const bool` checked once, and `std::optional` guards prevent any GPU event or string operations.
 
 ### Architecture
 
 - Per-op profiling uses RAII scope guards (`OpProfileScope`, `OpProfileCpuScope`) that record `hipEvent_t` start/stop pairs on the HIP stream. Events are resolved in bulk after `hipStreamSynchronize` — no per-op sync.
+- **Event pool**: HIP events are pre-allocated in `OpProfileState` and reused across inferences — no `hipEventCreate/Destroy` per operator call. The pool grows on demand but never shrinks.
 - Profiling state lives in `RuntimeState->op_profile` (opaque `void*`), not globals — each inference session has its own state. Two-level data model: `OpEntry` (per op name) → `ShapeEntry` (per shape string).
-- Key files: `op_profile.h` (RAII scopes + macros), `op_profile.cpp` (state + printing), `debug_log.h` (env var check)
+- Key files: `op_profile.h` (RAII scopes + macros), `op_profile.cpp` (state + event pool + printing), `debug_log.h` (env var check)
 - Each operator wrapper adds one line: `OP_PROFILE("opname", shape_lambda, state)` or `OP_PROFILE_CPU("opname", state)`. The shape lambda is only invoked when profiling is active — zero `snprintf` overhead on the hot path.
 
 ### Llama 8B baseline (gfx1150, single-token decode, April 2026)
@@ -238,31 +239,32 @@ CPU time tracks host-side overhead — GPU ops should show near-zero CPU time (a
 
 | Operator | Calls | GPU (ms) | CPU (ms) | GPU % |
 |----------|------:|---------:|---------:|------:|
-| matmul_nbits | 225 | 66.3 | 0.4 | 77.7% |
-|   m=1,n=14336,k=4096 | 64 | 30.1 | 0.1 | 35.3% |
-|   m=1,n=4096,k=14336 | 32 | 13.6 | 0.1 | 15.9% |
-|   m=1,n=4096,k=4096 | 64 | 11.8 | 0.1 | 13.8% |
-|   m=1,n=1024,k=4096 | 64 | 5.5 | 0.1 | 6.4% |
-|   m=1,n=128256,k=4096 | 1 | 3.5 | 0.0 | 4.1% |
-| skip_layernorm (1x4096) | 64 | 4.8 | 0.3 | 5.6% |
-| gqa (b=1,sq=1,skv=128,h=32,d=128) | 32 | 4.3 | 0.1 | 5.0% |
-| rotary_emb | 64 | 3.9 | 0.1 | 4.6% |
-|   h=32,d=128 | 32 | 2.1 | 0.1 | 2.5% |
-|   h=8,d=128 | 32 | 1.8 | 0.1 | 2.1% |
-| elementwise (1x1x1x14336) | 64 | 2.8 | 0.2 | 3.3% |
-| activation (n=14336) | 32 | 2.2 | 0.1 | 2.6% |
-| stream_sync | 1 | n/a | 85.0 | n/a |
-| **TOTAL** | | **85.3** | **87.6** | |
+| matmul_nbits | 225 | 62.3 | 0.3 | 78.0% |
+|   m=1,n=14336,k=4096 | 64 | 27.6 | 0.1 | 34.6% |
+|   m=1,n=4096,k=14336 | 32 | 12.9 | 0.0 | 16.1% |
+|   m=1,n=4096,k=4096 | 64 | 11.7 | 0.1 | 14.6% |
+|   m=1,n=1024,k=4096 | 64 | 5.9 | 0.1 | 7.4% |
+|   m=1,n=128256,k=4096 | 1 | 4.3 | 0.0 | 5.3% |
+| skip_layernorm (1x4096) | 64 | 5.2 | 0.3 | 6.5% |
+| rotary_emb | 64 | 4.2 | 0.1 | 5.3% |
+|   h=32,d=128 | 32 | 2.3 | 0.0 | 2.9% |
+|   h=8,d=128 | 32 | 1.9 | 0.0 | 2.4% |
+| gqa (b=1,sq=1,skv=128,h=32,d=128) | 32 | 3.9 | 0.1 | 4.9% |
+| activation (n=14336) | 32 | 2.2 | 0.1 | 2.7% |
+| elementwise (1x1x1x14336) | 64 | 2.1 | 0.1 | 2.6% |
+| **TOTAL** | | **79.9** | **0.9** | |
 
-End-to-end: **~67 ms avg** (14.9 tok/s)
+End-to-end: **~57 ms avg** (17.5 tok/s)
+
+Profiling overhead (event pool): ~35 ms (+60%), from 972 `hipEventRecord` + 486 `hipEventElapsedTime` calls. This is the inherent cost of GPU timing instrumentation.
 
 **GQA fused decode path:** For single-token decode (`sq==1`) with supported head dimensions (`d∈{64,128,256}`), GQA uses a fused custom HIP kernel path (rope + KV append + fused attention decode). This path is fully async — no D2H copies, no per-layer sync. The `local_window_size` attribute must be `<= 0` (ONNX uses `-1` for no windowing). The decomposed hipBLASLt path (used for prefill or unsupported configs) falls back to D2H + sync per layer.
 
-**Shared buffer detection:** The runtime (`hipdnn_ep_runtime_tensor.cpp`) detects when an output's host pointer matches a previously-prepared input's host pointer (IOBinding with shared OrtValue for past/present KV cache). It reuses the same GPU allocation so `past_key_gpu == present_key_gpu`, which makes GQA skip the per-layer D2H `seqlens_k` copy + `hipStreamSynchronize` in the decomposed path.
+**GPU memory aliasing:** When the EP's `hipHostMalloc` allocator is used (OGA or IOBinding with `device_type="gpu"`), KV cache tensors arrive with `memory_type == TENSOR_MEMORY_GPU`. The runtime aliases them directly — zero H2D/D2H. This makes `past_key_gpu == present_key_gpu`, so GQA skips the per-layer D2H `seqlens_k` copy + `hipStreamSynchronize` in the decomposed path.
 
-**GQA path selection:** With shared buffers, `past_key == present_key` at the GPU level → the `need_host_past_len` condition (`past_key && past_key != present_key`) is false → no D2H copy, no `hipStreamSynchronize` per layer. The concat path (which requires host-side `past_len`) is only triggered when `past_key != present_key`.
+**GQA path selection:** With aliased GPU buffers, `past_key == present_key` at the GPU level → the `need_host_past_len` condition (`past_key && past_key != present_key`) is false → no D2H copy, no `hipStreamSynchronize` per layer. The concat path (which requires host-side `past_len`) is only triggered when `past_key != present_key`.
 
-**Runtime state:** Buffer pool, shared-buffer detection map, and GQA GEMM descriptor cache are all per-session (stored in `RuntimeState` as opaque pointers), not globals. This supports concurrent inference sessions.
+**Runtime state:** Buffer pool and GQA GEMM descriptor cache are per-session (stored in `RuntimeState` as opaque pointers), not globals. This supports concurrent inference sessions.
 
 ## Crash Reporting (cpptrace)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,20 @@ project(
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Use /Z7 (embedded debug info) instead of /Zi (shared PDB) so that parallel
+# compilations under sccache don't fight over a single .pdb file (C1041).
+# Also disable incremental linking to avoid .ilk file contention (LNK1104).
+if(MSVC)
+  foreach(lang C CXX)
+    foreach(config DEBUG RELWITHDEBINFO)
+      string(REPLACE "/Zi" "/Z7" CMAKE_${lang}_FLAGS_${config} "${CMAKE_${lang}_FLAGS_${config}}")
+    endforeach()
+  endforeach()
+  foreach(type EXE SHARED MODULE)
+    string(REPLACE "/INCREMENTAL" "/INCREMENTAL:NO" CMAKE_${type}_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_${type}_LINKER_FLAGS_RELWITHDEBINFO}")
+  endforeach()
+endif()
+
 # ==============================================================================
 # TheRock ROCm SDK Configuration
 # ==============================================================================
@@ -77,6 +91,22 @@ if(BUILD_HIP_TOOLS)
   find_package(LLVM REQUIRED CONFIG)
   find_package(MLIR REQUIRED CONFIG)
   find_package(flatbuffers REQUIRED CONFIG)
+
+  # cpptrace for crash backtraces
+  include(FetchContent)
+  set(_saved_bsl_cpptrace ${BUILD_SHARED_LIBS})
+  set(BUILD_SHARED_LIBS OFF)
+  if(WIN32)
+    set(CPPTRACE_UNWIND_WITH_WINAPI ON CACHE BOOL "" FORCE)
+    set(CPPTRACE_UNWIND_WITH_DBGHELP OFF CACHE BOOL "" FORCE)
+  endif()
+  FetchContent_Declare(
+    cpptrace
+    GIT_REPOSITORY https://github.com/jeremy-rifkin/cpptrace.git
+    GIT_TAG v0.8.3
+  )
+  FetchContent_MakeAvailable(cpptrace)
+  set(BUILD_SHARED_LIBS ${_saved_bsl_cpptrace})
 
   message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
   message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")

--- a/backend-mlir-compiler/level-1-pass/CMakeLists.txt
+++ b/backend-mlir-compiler/level-1-pass/CMakeLists.txt
@@ -15,6 +15,7 @@ set(LIB_NAME morphizen-level1-pass-mlir-compiler)
 add_library(${LIB_NAME} STATIC
     src/pass_main.cpp
     src/MlirCompiler.cpp
+    ${CMAKE_SOURCE_DIR}/lib/Support/CrashHandler.cpp
 )
 
 # Link dependencies
@@ -22,6 +23,7 @@ target_link_libraries(${LIB_NAME} PRIVATE
     morphizen::morphizen-core-static
     glog::glog
     mlir_compilation_proto  # Shared protobuf library
+    cpptrace::cpptrace
     # NOTE: hip-compiler.dll is loaded dynamically at runtime, not linked
 )
 
@@ -30,6 +32,7 @@ target_include_directories(${LIB_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/src
     ${CMAKE_CURRENT_BINARY_DIR}/..  # For generated proto headers from parent
     ${CMAKE_SOURCE_DIR}/include     # Shared project headers (timing.h, etc.)
+    ${CMAKE_SOURCE_DIR}/lib/Support # CrashHandler.h
 )
 
 target_compile_definitions(${LIB_NAME} PRIVATE

--- a/build.py
+++ b/build.py
@@ -1,0 +1,499 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""Build automation for onnx-hipdnn-ep.
+
+Downloads dependencies and builds the project:
+  1. Downloads and extracts TheRock ROCm SDK
+  2. Downloads and extracts prebuilt LLVM/MLIR/FlatBuffers/Protobuf
+  3. Downloads and extracts ONNX Runtime pre-built binaries
+  4. Configures, builds, and installs via CMake
+
+All artifacts are placed under install/ in the project root.
+
+Prerequisite: activate the conda environment first:
+    conda env create -f environment.yml   # one-time
+    conda activate hipdnn-ep
+
+Usage:
+    python build.py                # Full setup + build
+    python build.py --skip-build   # Setup only (download deps)
+    python build.py --clean        # Remove install/ and start fresh
+"""
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+import urllib.request
+import zipfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+INSTALL = ROOT / "install"
+CACHE = INSTALL / "_cache"
+THEROCK = INSTALL / "therock"
+DEPS = INSTALL / "deps"
+ORT = INSTALL / "onnxruntime"
+BUILD = INSTALL / "build"
+DIST = INSTALL / "dist"
+
+THEROCK_URL = (
+    "https://repo.amd.com/rocm/tarball/therock-dist-windows-gfx1150-7.11.0.tar.gz"
+)
+
+# Prebuilt deps — keep in sync with scripts/setup-prebuilt.sh
+_PREBUILT_BASE = "https://github.com/wcy123/llvm-mlir-prebuilt/releases/download"
+_PREBUILTS = [
+    ("llvm-22.1.0-release", "llvm-22.1.0-release-windows-x64.zip"),
+    ("protobuf-34.0-release", "protobuf-34.0-release-windows-x64.zip"),
+    ("flatbuffers-25.12.19-release", "flatbuffers-25.12.19-release-windows-x64.zip"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def log(msg):
+    print(f"[build] {msg}")
+
+
+def download(url, dest):
+    """Download *url* to *dest* with a progress indicator. Skips if cached."""
+    if dest.exists():
+        log(f"  Cached: {dest.name}")
+        return
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_suffix(dest.suffix + ".part")
+    log(f"  Downloading {dest.name} ...")
+
+    def _progress(block, block_size, total):
+        done = block * block_size
+        if total > 0:
+            pct = min(100.0, done * 100.0 / total)
+            print(
+                f"\r  {done / 1048576:.1f} / {total / 1048576:.1f} MB ({pct:.0f}%)",
+                end="",
+                flush=True,
+            )
+
+    try:
+        urllib.request.urlretrieve(url, str(tmp), reporthook=_progress)
+        print()
+        tmp.rename(dest)
+    except Exception as exc:
+        print()
+        tmp.unlink(missing_ok=True)
+        raise RuntimeError(f"Download failed: {url}") from exc
+
+
+def _tar_extract(archive, dest, *, strip=0):
+    """Extract a tar archive, optionally stripping leading path components."""
+    log(f"  Extracting {archive.name} -> {dest} ...")
+    dest.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(archive, "r:*") as tar:
+        for member in tar:
+            p = Path(member.name)
+            if p.is_absolute() or ".." in p.parts:
+                continue
+            if strip:
+                parts = p.parts
+                if len(parts) <= strip:
+                    continue
+                member.name = str(Path(*parts[strip:]))
+            try:
+                if sys.version_info >= (3, 12):
+                    tar.extract(member, dest, filter="data")
+                else:
+                    tar.extract(member, dest)
+            except (OSError, PermissionError):
+                pass
+
+
+def _zip_extract(archive, dest, *, strip=0):
+    """Extract a zip archive, optionally stripping leading path components."""
+    log(f"  Extracting {archive.name} -> {dest} ...")
+    dest.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(archive) as zf:
+        for info in zf.infolist():
+            if info.is_dir():
+                continue
+            p = Path(info.filename)
+            if strip:
+                parts = p.parts
+                if len(parts) <= strip:
+                    continue
+                out = dest / Path(*parts[strip:])
+            else:
+                out = dest / p
+            out.parent.mkdir(parents=True, exist_ok=True)
+            with zf.open(info) as src, open(out, "wb") as dst:
+                shutil.copyfileobj(src, dst)
+
+
+# ---------------------------------------------------------------------------
+# TheRock ROCm SDK
+# ---------------------------------------------------------------------------
+
+
+def fetch_therock():
+    log("Setting up TheRock ROCm SDK ...")
+    sentinel = THEROCK / ".ok"
+    if sentinel.exists():
+        log("  Already installed.")
+        return
+    archive = CACHE / "therock.tar.gz"
+    download(THEROCK_URL, archive)
+    if THEROCK.exists():
+        shutil.rmtree(THEROCK)
+    _tar_extract(archive, THEROCK, strip=1)
+    sentinel.touch()
+    log("  TheRock SDK ready.")
+
+
+# ---------------------------------------------------------------------------
+# Prebuilt LLVM / MLIR / Protobuf / FlatBuffers
+# Tags and assets mirror scripts/setup-prebuilt.sh — keep in sync.
+# ---------------------------------------------------------------------------
+
+
+def fetch_prebuilt_deps():
+    log("Setting up prebuilt dependencies (LLVM, Protobuf, FlatBuffers) ...")
+    for tag, asset in _PREBUILTS:
+        sentinel = DEPS / f".{tag}.ok"
+        if sentinel.exists():
+            log(f"  {tag}: already installed.")
+            continue
+        url = f"{_PREBUILT_BASE}/{tag}/{asset}"
+        archive = CACHE / asset
+        download(url, archive)
+        _zip_extract(archive, DEPS)
+        sentinel.touch()
+        log(f"  {tag}: done.")
+
+
+# ---------------------------------------------------------------------------
+# ONNX Runtime
+# ---------------------------------------------------------------------------
+
+ORT_VERSION = "1.24.4"  # must match pip onnxruntime-directml for Python API compat
+
+
+def fetch_onnxruntime():
+    log("Setting up ONNX Runtime ...")
+    sentinel = ORT / ".ok"
+    if sentinel.exists():
+        _generate_ort_cmake_config()
+        log("  Already installed.")
+        return
+
+    version = ORT_VERSION
+    log(f"  Target version: {version}")
+
+    target = f"onnxruntime-win-x64-{version}.zip"
+    url = (
+        f"https://github.com/microsoft/onnxruntime/releases/download/"
+        f"v{version}/{target}"
+    )
+
+    archive = CACHE / target
+    download(url, archive)
+    if ORT.exists():
+        shutil.rmtree(ORT)
+    _zip_extract(archive, ORT, strip=1)
+    _generate_ort_cmake_config()
+    sentinel.touch()
+    log(f"  ONNX Runtime {version} ready.")
+
+
+def _generate_ort_cmake_config():
+    """Create a CMake config so find_package(onnxruntime CONFIG) works."""
+    cmake_dir = ORT / "lib" / "cmake" / "onnxruntime"
+    cmake_dir.mkdir(parents=True, exist_ok=True)
+    config = cmake_dir / "onnxruntimeConfig.cmake"
+    config.write_text("""\
+# Auto-generated by build.py for pre-built ONNX Runtime binaries.
+get_filename_component(_ort_root "${CMAKE_CURRENT_LIST_DIR}/../../.." ABSOLUTE)
+
+if(NOT TARGET onnxruntime::onnxruntime)
+  add_library(onnxruntime::onnxruntime SHARED IMPORTED)
+  set_target_properties(onnxruntime::onnxruntime PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${_ort_root}/include"
+    IMPORTED_IMPLIB "${_ort_root}/lib/onnxruntime.lib"
+    IMPORTED_LOCATION "${_ort_root}/lib/onnxruntime.dll"
+  )
+endif()
+
+set(onnxruntime_FOUND TRUE)
+""")
+
+
+# ---------------------------------------------------------------------------
+# Build
+# ---------------------------------------------------------------------------
+
+
+def _ensure_submodules():
+    log("  Checking git submodules ...")
+    r = subprocess.run(
+        ["git", "submodule", "status", "--recursive"],
+        capture_output=True,
+        text=True,
+        cwd=str(ROOT),
+    )
+    uninitialized = any(
+        line.strip().startswith("-") for line in r.stdout.splitlines() if line.strip()
+    )
+    if uninitialized:
+        log("  Initializing submodules ...")
+        subprocess.run(
+            ["git", "submodule", "update", "--init", "--recursive"],
+            check=True,
+            cwd=str(ROOT),
+        )
+    else:
+        log("  Submodules OK.")
+
+
+def _ensure_dia_sdk_junction():
+    """Create C:\\msvsn2022 junction if needed (LLVM prebuilt hardcoded path)."""
+    junction = Path("C:/msvsn2022")
+    if junction.exists():
+        return
+    vswhere = (
+        Path(os.environ.get("ProgramFiles(x86)", "C:/Program Files (x86)"))
+        / "Microsoft Visual Studio"
+        / "Installer"
+        / "vswhere.exe"
+    )
+    if not vswhere.exists():
+        log("  WARNING: vswhere not found — cannot create DIA SDK junction.")
+        return
+    r = subprocess.run(
+        [str(vswhere), "-latest", "-property", "installationPath"],
+        capture_output=True,
+        text=True,
+    )
+    vs_path = r.stdout.strip()
+    if not vs_path:
+        log("  WARNING: No Visual Studio installation found.")
+        return
+    log(f"  Creating DIA SDK junction: C:\\msvsn2022 -> {vs_path}")
+    try:
+        subprocess.run(
+            ["cmd", "/c", "mklink", "/J", "C:\\msvsn2022", vs_path],
+            check=True,
+            capture_output=True,
+        )
+    except subprocess.CalledProcessError:
+        log("  WARNING: mklink failed (may need admin). See docs/quick_start.md.")
+
+
+def _detect_gpu_arch():
+    exe = THEROCK / "lib" / "llvm" / "bin" / "amdgpu-arch.exe"
+    if not exe.exists():
+        return None
+    try:
+        r = subprocess.run(
+            [str(exe)],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        lines = r.stdout.strip().splitlines()
+        return lines[0].strip() if lines else None
+    except Exception:
+        return None
+
+
+def _ensure_msvc_env():
+    """Detect VS2022 and inject its x64 environment into this process."""
+    if shutil.which("cl"):
+        return
+    log("  cl.exe not on PATH — locating Visual Studio ...")
+    vswhere = (
+        Path(os.environ.get("ProgramFiles(x86)", "C:/Program Files (x86)"))
+        / "Microsoft Visual Studio"
+        / "Installer"
+        / "vswhere.exe"
+    )
+    if not vswhere.exists():
+        log("  ERROR: vswhere.exe not found. Install Visual Studio 2022.")
+        sys.exit(1)
+    r = subprocess.run(
+        [str(vswhere), "-latest", "-property", "installationPath"],
+        capture_output=True,
+        text=True,
+    )
+    vs_path = r.stdout.strip()
+    if not vs_path:
+        log("  ERROR: No Visual Studio installation found.")
+        sys.exit(1)
+    vcvarsall = Path(vs_path) / "VC" / "Auxiliary" / "Build" / "vcvarsall.bat"
+    if not vcvarsall.exists():
+        log(f"  ERROR: vcvarsall.bat not found at {vcvarsall}")
+        sys.exit(1)
+    log(f"  Sourcing MSVC environment from {vs_path} ...")
+    # Run vcvarsall and dump the resulting environment
+    r = subprocess.run(
+        ["cmd", "/C", "call", str(vcvarsall), "x64", "&&", "set"],
+        capture_output=True,
+        text=True,
+    )
+    if r.returncode != 0:
+        log("  ERROR: vcvarsall.bat failed.")
+        sys.exit(1)
+    for line in r.stdout.splitlines():
+        if "=" in line:
+            key, _, value = line.partition("=")
+            os.environ[key] = value
+    if not shutil.which("cl"):
+        log("  ERROR: cl.exe still not found after sourcing vcvarsall.bat.")
+        sys.exit(1)
+    # Restart sccache so the daemon inherits the MSVC environment (cl.exe
+    # depends on DLLs that must be on PATH for CreateProcess to succeed).
+    if shutil.which("sccache"):
+        subprocess.run(["sccache", "--stop-server"], capture_output=True)
+    log("  MSVC environment ready.")
+
+
+def configure_and_build():
+    log("Building onnx-hipdnn-ep ...")
+
+    _ensure_msvc_env()
+    for tool in ("cmake", "ninja"):
+        if not shutil.which(tool):
+            log(f"  ERROR: {tool} not found. Run: conda activate hipdnn-ep")
+            sys.exit(1)
+
+    _ensure_submodules()
+    _ensure_dia_sdk_junction()
+
+    BUILD.mkdir(parents=True, exist_ok=True)
+
+    # -- cmake configure args --
+    prefix_paths = [str(DEPS)]
+    if (ORT / ".ok").exists():
+        prefix_paths.append(str(ORT))
+
+    cmake_args = [
+        "cmake",
+        "-S",
+        str(ROOT),
+        "-B",
+        str(BUILD),
+        "-G",
+        "Ninja",
+        "-DBUILD_SHARED_LIBS=OFF",
+        "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+        "-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded",
+        f"-DCMAKE_PREFIX_PATH={';'.join(prefix_paths)}",
+        f"-DCMAKE_INSTALL_PREFIX={DIST}",
+        "-DBUILD_HIP_TOOLS=ON",
+        "-DBUILD_EP=ON",
+    ]
+
+    if shutil.which("sccache"):
+        cmake_args += [
+            "-DCMAKE_C_COMPILER_LAUNCHER=sccache",
+            "-DCMAKE_CXX_COMPILER_LAUNCHER=sccache",
+        ]
+
+    cmake_args.append(f"-DPython3_EXECUTABLE={sys.executable}")
+
+    # Real runtime (TheRock + detected GPU) vs mock
+    therock_ready = (THEROCK / ".ok").exists()
+    if therock_ready:
+        gpu_arch = _detect_gpu_arch()
+        if gpu_arch:
+            log(f"  GPU architecture: {gpu_arch}")
+            cmake_args += [
+                f"-DTHEROCK_DIST={THEROCK}",
+                "-DHIP_PLATFORM=amd",
+                f"-DHIP_ARCHITECTURES={gpu_arch}",
+                "-DBUILD_MOCK_RUNTIME=OFF",
+            ]
+        else:
+            log("  No GPU detected — using mock runtime.")
+            cmake_args.append("-DBUILD_MOCK_RUNTIME=ON")
+    else:
+        log("  TheRock not installed — using mock runtime.")
+        cmake_args.append("-DBUILD_MOCK_RUNTIME=ON")
+
+    # -- configure --
+    log("  Configuring ...")
+    subprocess.run(cmake_args, check=True)
+
+    # -- build --
+    log("  Compiling ...")
+    subprocess.run(
+        ["cmake", "--build", str(BUILD), "--config", "RelWithDebInfo", "--parallel"],
+        check=True,
+    )
+
+    # -- install --
+    log("  Installing ...")
+    subprocess.run(
+        ["cmake", "--install", str(BUILD), "--config", "RelWithDebInfo"],
+        check=True,
+    )
+
+    log(f"  Done. Installed to: {DIST}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Build automation for onnx-hipdnn-ep",
+    )
+    parser.add_argument(
+        "--clean",
+        action="store_true",
+        help="Remove install/ directory and start fresh",
+    )
+    parser.add_argument(
+        "--skip-build",
+        action="store_true",
+        help="Only download dependencies, do not build",
+    )
+    args = parser.parse_args()
+
+    if args.clean:
+        if INSTALL.exists():
+            log(f"Removing {INSTALL} ...")
+            shutil.rmtree(INSTALL)
+        log("Clean complete.")
+        return
+
+    fetch_therock()
+    fetch_prebuilt_deps()
+    fetch_onnxruntime()
+
+    if args.skip_build:
+        log("")
+        log("Setup complete (build skipped).")
+    else:
+        configure_and_build()
+        log("")
+        log("Setup + build complete!")
+
+    log(f"  TheRock SDK:    {THEROCK}")
+    log(f"  Dependencies:   {DEPS}")
+    log(f"  ONNX Runtime:   {ORT}")
+    if not args.skip_build:
+        log(f"  Build output:   {BUILD}")
+        log(f"  Install dir:    {DIST}")
+
+
+if __name__ == "__main__":
+    main()

--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -113,5 +113,20 @@ else()
   endif()
 endif()
 
+# cpptrace for crash backtraces
+set(_saved_bsl_cpptrace ${BUILD_SHARED_LIBS})
+set(BUILD_SHARED_LIBS OFF)
+if(WIN32)
+  set(CPPTRACE_UNWIND_WITH_WINAPI ON CACHE BOOL "" FORCE)
+  set(CPPTRACE_UNWIND_WITH_DBGHELP OFF CACHE BOOL "" FORCE)
+endif()
+FetchContent_Declare(
+  cpptrace
+  GIT_REPOSITORY https://github.com/jeremy-rifkin/cpptrace.git
+  GIT_TAG v0.8.3
+)
+FetchContent_MakeAvailable(cpptrace)
+set(BUILD_SHARED_LIBS ${_saved_bsl_cpptrace})
+
 # Add morphizen subdirectory (after all options are set)
 add_subdirectory(3rd-party/morphizen)

--- a/dll/CMakeLists.txt
+++ b/dll/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(hip-compiler-dll SHARED
 # Link against CInterface library (which pulls in all dependencies)
 target_link_libraries(hip-compiler-dll PRIVATE
     HipCInterface
+    HipSupport
 )
 
 # Include directories for C API headers

--- a/dll/dll_main.cpp
+++ b/dll/dll_main.cpp
@@ -14,10 +14,14 @@
 #ifdef _WIN32
 #include <windows.h>
 
+#include "CrashHandler.h"
+
 BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call,
                       LPVOID lpReserved) {
   switch (ul_reason_for_call) {
   case DLL_PROCESS_ATTACH:
+    hip::install_crash_handlers("hip-compiler");
+    break;
   case DLL_THREAD_ATTACH:
   case DLL_THREAD_DETACH:
   case DLL_PROCESS_DETACH:

--- a/docs/design/per-op-profiling.md
+++ b/docs/design/per-op-profiling.md
@@ -127,6 +127,22 @@ int wrap_new_op(RuntimeState *state, ..., int64_t M, int64_t N, ...) {
 
 Use `OP_PROFILE_CPU` instead for operations that don't launch GPU kernels (e.g., `stream_sync`). The shape lambda is only called when profiling is active, so there is no `snprintf` overhead on the hot path.
 
+## Future optimization ideas
+
+Current profiling-on overhead is ~35 ms (+60%) on Llama 8B, from 972 `hipEventRecord` + 486 `hipEventElapsedTime` HIP driver calls. Three approaches to reduce this further:
+
+### Two-tier profiling (recommended next step)
+
+`HIPDNN_EP_PERF=1` → CPU-only timing (`steady_clock::now()`, no GPU events). `HIPDNN_EP_PERF=2` → full GPU events (current behavior). CPU-only mode has near-zero overhead and still catches the most important signal: unexpected `hipStreamSynchronize` stalls showing up as high CPU time on a GPU op. Per-op GPU breakdown is lost, but total GPU time is available from the phase-level H2D/Compute/D2H timing.
+
+### Sampling
+
+Only instrument every Nth inference (e.g., `HIPDNN_EP_PERF=10` → profile 1 in 10). The event pool and resolve logic stay the same, the `OP_PROFILE` emplace is just skipped most of the time. Amortized overhead drops to ~3.5 ms.
+
+### Fuse adjacent events
+
+Many ops share a stop→start boundary (op N's stop event immediately precedes op N+1's start event on the same stream). Instead of 2 events at the boundary, use 1 event as both — record a single "fence" event between ops and compute elapsed time as `fence[i+1] - fence[i]`. Cuts `hipEventRecord` calls roughly in half (from 972 to ~487).
+
 ## Build dependency: bitcode recompilation
 
 The `compile_to_bitcode` macro in `lib/Runtime/CMakeLists.txt` has a `DEPENDS` list that controls when bitcode is recompiled. **All headers included by runtime `.cpp` files must appear in this list.** Missing a header means changes to it don't trigger recompilation, producing stale bitcode that gets linked into compiled model DLLs.

--- a/docs/design/per-op-profiling.md
+++ b/docs/design/per-op-profiling.md
@@ -1,0 +1,133 @@
+<!--
+Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+Licensed under the MIT License.
+-->
+# Per-Operator GPU Profiling
+
+## Overview
+
+Per-operator GPU profiling measures GPU and CPU time for each runtime wrapper function (matmul, GQA, conv, etc.). Enabled by `HIPDNN_EP_PERF=1`, it extends the existing phase-level profiling (H2D/Compute/D2H) with a per-operator breakdown grouped by operator name, sorted by GPU time descending.
+
+## Design
+
+### Zero-overhead when disabled
+
+Each operator wrapper contains one macro call:
+
+```cpp
+int wrap_hipblasLtMatmul(RuntimeState *state, ..., int64_t M, int64_t N, int64_t K, ...) {
+  OP_PROFILE("matmul", [&] {
+    char b[64];
+    snprintf(b, sizeof(b), "%lldx%lldx%lld", (long long)M, (long long)N, (long long)K);
+    return std::string(b);
+  }, state);
+  // ... operator implementation ...
+}
+```
+
+The macro expands to a `std::optional<OpProfileScope>` that is only populated when `hipdnn_ep_perf_enabled()` returns true. The second argument is a callable (typically a lambda) that returns the shape string — it is only invoked when profiling is active, so `snprintf` and string construction have zero overhead when disabled.
+
+### Per-shape profiling
+
+All operators pass a shape-producing lambda as the second parameter. The profiling table groups entries by op name, with indented sub-rows for each distinct shape.
+
+### Deferred GPU synchronization
+
+GPU events are recorded but not synchronized per-operator. Instead:
+
+1. Each `OpProfileScope` records `hipEventRecord(start)` in its constructor and `hipEventRecord(stop)` in its destructor, both on the existing HIP stream.
+2. Events are stored in a `pending` vector inside `OpProfileState`.
+3. After `hipStreamSynchronize` completes (in `hipdnn_ep_stream_sync`), all pending events are resolved in bulk via `hipEventElapsedTime` and accumulated into a two-level profile map (op → shapes).
+
+This avoids per-operator GPU synchronization overhead.
+
+### State ownership
+
+Profiling state is per-inference-session, not global:
+
+```
+RuntimeState
+  └── void *op_profile  →  OpProfileState (two-level map + pending events)
+```
+
+- Created in `hipdnn_ep_state_init_with_fs()` (only when PERF enabled)
+- Reset at the start of each inference (`prepare_input` with index==0)
+- Resolved and printed in `hipdnn_ep_stream_sync()` after GPU sync
+- Destroyed in `hipdnn_ep_state_cleanup()`
+
+### Output format
+
+```
+[PERF] =========================================================================
+[PERF]                                  calls  gpu (ms)  cpu (ms)  gpu %
+[PERF]  matmul_nbits                      225      66.3       0.4  77.7%
+[PERF]    m=1,n=14336,k=4096               64      30.1       0.1  35.3%
+[PERF]    m=1,n=4096,k=14336               32      13.6       0.1  15.9%
+[PERF]    m=1,n=4096,k=4096                64      11.8       0.1  13.8%
+[PERF]    m=1,n=1024,k=4096                64       5.5       0.1   6.4%
+[PERF]    m=1,n=128256,k=4096               1       3.5       0.0   4.1%
+[PERF]  skip_layernorm                     64       4.8       0.3   5.6%
+[PERF]    1x4096                           64       4.8       0.3   5.6%
+[PERF]  gqa                                32       4.3       0.1   5.0%
+[PERF]    b=1,sq=1,skv=128,h=32,d=128      32       4.3       0.1   5.0%
+[PERF]  rotary_emb                         64       3.9       0.1   4.6%
+[PERF]    h=32,d=128                       32       2.1       0.1   2.5%
+[PERF]    h=8,d=128                        32       1.8       0.1   2.1%
+[PERF]  elementwise                        64       2.8       0.2   3.3%
+[PERF]    1x1x1x14336                      64       2.8       0.2   3.3%
+[PERF]  activation                         32       2.2       0.1   2.6%
+[PERF]    n=14336                          32       2.2       0.1   2.6%
+[PERF]  stream_sync                         1       n/a      85.0    n/a
+[PERF]  TOTAL                                      85.3      87.6
+[PERF] =========================================================================
+```
+
+Sorted by GPU time descending. CPU-only operations (e.g. `stream_sync`) are listed at the bottom with `n/a` for GPU columns. The `gpu %` column shows each op's share of total GPU time. Shape sub-rows are indented under their parent op.
+
+### Interpreting CPU time
+
+CPU time measures wall-clock time from `OpProfileScope` construction to destruction — the host-side cost of each operator call. For correctly async GPU ops, this should be near-zero (~0.1ms) because `hipEventRecord` returns immediately. Only `stream_sync` should show significant CPU time (the full GPU pipeline wait).
+
+**Non-zero CPU time on a GPU op signals an unexpected `hipStreamSynchronize` in its code path.** For example, GQA's decomposed path (separate past/present KV buffers) does a D2H copy + `hipStreamSynchronize` per layer to read `seqlens_k` on the host. With 32 layers (Llama 8B), this adds ~95ms of CPU stall. The fused decode path avoids this entirely when shared buffer detection ensures `past_key_gpu == present_key_gpu`.
+
+Use the CPU column as a diagnostic: if an op that should be fully async shows >1ms CPU time, look for synchronization calls in its code path.
+
+## File layout
+
+| File | Role |
+|------|------|
+| `lib/Runtime/op_profile.h` | RAII scope guards (`OpProfileScope`, `OpProfileCpuScope`), `OP_PROFILE`/`OP_PROFILE_CPU` macros |
+| `lib/Runtime/op_profile.cpp` | `OpProfileState` struct (two-level: OpEntry → ShapeEntry), create/destroy/reset/resolve/print |
+| `lib/Runtime/debug_log.h` | `hipdnn_ep_perf_enabled()` — env var check (uses Win32 API on Windows) |
+| `lib/Runtime/runtime_state_internal.h` | `void *op_profile` field in `RuntimeState` |
+| `lib/Runtime/hipdnn_ep_runtime.h` | `hipdnn_ep_state_get_op_profile()` accessor |
+| `lib/Runtime/real/*.cpp` | One `OP_PROFILE`/`OP_PROFILE_CPU` call per wrapper function |
+
+## Adding profiling to a new operator
+
+Add two lines to the wrapper function:
+
+```cpp
+#include "../op_profile.h"
+
+int wrap_new_op(RuntimeState *state, ..., int64_t M, int64_t N, ...) {
+  OP_PROFILE("new_op", [&] {
+    char b[64];
+    snprintf(b, sizeof(b), "%lldx%lld", (long long)M, (long long)N);
+    return std::string(b);
+  }, state);
+  // ... implementation ...
+}
+```
+
+Use `OP_PROFILE_CPU` instead for operations that don't launch GPU kernels (e.g., `stream_sync`). The shape lambda is only called when profiling is active, so there is no `snprintf` overhead on the hot path.
+
+## Build dependency: bitcode recompilation
+
+The `compile_to_bitcode` macro in `lib/Runtime/CMakeLists.txt` has a `DEPENDS` list that controls when bitcode is recompiled. **All headers included by runtime `.cpp` files must appear in this list.** Missing a header means changes to it don't trigger recompilation, producing stale bitcode that gets linked into compiled model DLLs.
+
+For profiling, both `op_profile.h` and `debug_log.h` must be in the `DEPENDS` list. The stale-DLL problem is compounded by MorphiZen's cache key being based on the ONNX graph hash, not the runtime bitcode version — so stale DLLs persist until manually deleted (`del %TEMP%\morphizen_mlir_*`).
+
+## Windows static CRT caveat
+
+Model DLLs are compiled with static CRT (`/MT`), which gives each DLL its own CRT instance. `std::getenv()` inside the DLL cannot see environment variables set by the host process. `debug_log.h` uses `GetEnvironmentVariableA()` (Win32 API) instead, which reads the shared process environment block.

--- a/docs/design/per-op-profiling.md
+++ b/docs/design/per-op-profiling.md
@@ -36,10 +36,16 @@ All operators pass a shape-producing lambda as the second parameter. The profili
 GPU events are recorded but not synchronized per-operator. Instead:
 
 1. Each `OpProfileScope` records `hipEventRecord(start)` in its constructor and `hipEventRecord(stop)` in its destructor, both on the existing HIP stream.
-2. Events are stored in a `pending` vector inside `OpProfileState`.
+2. Pending entries (name, shape, event pool index, CPU time) are stored in a vector inside `OpProfileState`.
 3. After `hipStreamSynchronize` completes (in `hipdnn_ep_stream_sync`), all pending events are resolved in bulk via `hipEventElapsedTime` and accumulated into a two-level profile map (op → shapes).
 
 This avoids per-operator GPU synchronization overhead.
+
+### Event pool
+
+HIP events are pre-allocated in `OpProfileState::eventPool` and reused across inferences. `op_profile_acquire_event_pair()` returns the next available index; if the pool is exhausted, a new pair is created and appended. The pool grows on demand but never shrinks — after the first inference, all subsequent inferences reuse existing events with zero `hipEventCreate`/`hipEventDestroy` calls.
+
+For Llama 8B (486 operator calls per inference), this eliminates 972 `hipEventCreate` + 972 `hipEventDestroy` per inference. Measured overhead dropped from +56 ms (93%) to +35 ms (60%) compared to profiling-off baseline.
 
 ### State ownership
 
@@ -60,35 +66,34 @@ RuntimeState
 ```
 [PERF] =========================================================================
 [PERF]                                  calls  gpu (ms)  cpu (ms)  gpu %
-[PERF]  matmul_nbits                      225      66.3       0.4  77.7%
-[PERF]    m=1,n=14336,k=4096               64      30.1       0.1  35.3%
-[PERF]    m=1,n=4096,k=14336               32      13.6       0.1  15.9%
-[PERF]    m=1,n=4096,k=4096                64      11.8       0.1  13.8%
-[PERF]    m=1,n=1024,k=4096                64       5.5       0.1   6.4%
-[PERF]    m=1,n=128256,k=4096               1       3.5       0.0   4.1%
-[PERF]  skip_layernorm                     64       4.8       0.3   5.6%
-[PERF]    1x4096                           64       4.8       0.3   5.6%
-[PERF]  gqa                                32       4.3       0.1   5.0%
-[PERF]    b=1,sq=1,skv=128,h=32,d=128      32       4.3       0.1   5.0%
-[PERF]  rotary_emb                         64       3.9       0.1   4.6%
-[PERF]    h=32,d=128                       32       2.1       0.1   2.5%
-[PERF]    h=8,d=128                        32       1.8       0.1   2.1%
-[PERF]  elementwise                        64       2.8       0.2   3.3%
-[PERF]    1x1x1x14336                      64       2.8       0.2   3.3%
-[PERF]  activation                         32       2.2       0.1   2.6%
-[PERF]    n=14336                          32       2.2       0.1   2.6%
-[PERF]  stream_sync                         1       n/a      85.0    n/a
-[PERF]  TOTAL                                      85.3      87.6
+[PERF]  matmul_nbits                      225      62.3       0.3  78.0%
+[PERF]    m=1,n=14336,k=4096               64      27.6       0.1  34.6%
+[PERF]    m=1,n=4096,k=14336               32      12.9       0.0  16.1%
+[PERF]    m=1,n=4096,k=4096                64      11.7       0.1  14.6%
+[PERF]    m=1,n=1024,k=4096                64       5.9       0.1   7.4%
+[PERF]    m=1,n=128256,k=4096               1       4.3       0.0   5.3%
+[PERF]  skip_layernorm                     64       5.2       0.3   6.5%
+[PERF]    1x4096                           64       5.2       0.3   6.5%
+[PERF]  rotary_emb                         64       4.2       0.1   5.3%
+[PERF]    h=32,d=128                       32       2.3       0.0   2.9%
+[PERF]    h=8,d=128                        32       1.9       0.0   2.4%
+[PERF]  gqa                                32       3.9       0.1   4.9%
+[PERF]    b=1,sq=1,skv=128,h=32,d=128      32       3.9       0.1   4.9%
+[PERF]  activation                         32       2.2       0.1   2.7%
+[PERF]    n=14336                          32       2.2       0.1   2.7%
+[PERF]  elementwise                        64       2.1       0.1   2.6%
+[PERF]    1x1x1x14336                      64       2.1       0.1   2.6%
+[PERF]  TOTAL                                      79.9       0.9
 [PERF] =========================================================================
 ```
 
-Sorted by GPU time descending. CPU-only operations (e.g. `stream_sync`) are listed at the bottom with `n/a` for GPU columns. The `gpu %` column shows each op's share of total GPU time. Shape sub-rows are indented under their parent op.
+Sorted by GPU time descending. The `gpu %` column shows each op's share of total GPU time. Shape sub-rows are indented under their parent op.
 
 ### Interpreting CPU time
 
-CPU time measures wall-clock time from `OpProfileScope` construction to destruction — the host-side cost of each operator call. For correctly async GPU ops, this should be near-zero (~0.1ms) because `hipEventRecord` returns immediately. Only `stream_sync` should show significant CPU time (the full GPU pipeline wait).
+CPU time measures wall-clock time from `OpProfileScope` construction to destruction — the host-side cost of each operator call. For correctly async GPU ops, this should be near-zero (~0.1ms) because `hipEventRecord` returns immediately.
 
-**Non-zero CPU time on a GPU op signals an unexpected `hipStreamSynchronize` in its code path.** For example, GQA's decomposed path (separate past/present KV buffers) does a D2H copy + `hipStreamSynchronize` per layer to read `seqlens_k` on the host. With 32 layers (Llama 8B), this adds ~95ms of CPU stall. The fused decode path avoids this entirely when shared buffer detection ensures `past_key_gpu == present_key_gpu`.
+**Non-zero CPU time on a GPU op signals an unexpected `hipStreamSynchronize` in its code path.** For example, GQA's decomposed path (separate past/present KV buffers) does a D2H copy + `hipStreamSynchronize` per layer to read `seqlens_k` on the host. With 32 layers (Llama 8B), this adds ~87ms of CPU stall. The fused decode path (used when `memory_type == TENSOR_MEMORY_GPU` enables aliasing so `past_key_gpu == present_key_gpu`) avoids this entirely — total CPU time drops to 0.1 ms for all 32 GQA layers.
 
 Use the CPU column as a diagnostic: if an op that should be fully async shows >1ms CPU time, look for synchronization calls in its code path.
 
@@ -97,7 +102,7 @@ Use the CPU column as a diagnostic: if an op that should be fully async shows >1
 | File | Role |
 |------|------|
 | `lib/Runtime/op_profile.h` | RAII scope guards (`OpProfileScope`, `OpProfileCpuScope`), `OP_PROFILE`/`OP_PROFILE_CPU` macros |
-| `lib/Runtime/op_profile.cpp` | `OpProfileState` struct (two-level: OpEntry → ShapeEntry), create/destroy/reset/resolve/print |
+| `lib/Runtime/op_profile.cpp` | `OpProfileState` struct (event pool + two-level: OpEntry → ShapeEntry), create/destroy/reset/resolve/print |
 | `lib/Runtime/debug_log.h` | `hipdnn_ep_perf_enabled()` — env var check (uses Win32 API on Windows) |
 | `lib/Runtime/runtime_state_internal.h` | `void *op_profile` field in `RuntimeState` |
 | `lib/Runtime/hipdnn_ep_runtime.h` | `hipdnn_ep_state_get_op_profile()` accessor |

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,26 @@
+##
+## Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+## Licensed under the MIT License.
+##
+name: hipdnn-ep
+channels:
+  - conda-forge
+dependencies:
+  - python>=3.10
+  - cmake>=3.20
+  - ninja
+  - sccache
+  - gh
+  - pip
+  - pip:
+    - lit
+    - lintrunner==0.12.7
+    - lintrunner-adapters==0.12.4
+    - ruff==0.11.9
+    - clang-format==16.0.1
+    - pre-commit
+    - licenseheaders==0.8.8
+    - pytest
+    - onnx
+    - onnx_ir
+    - onnxruntime-genai-directml

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -3,6 +3,7 @@
 # ** Licensed under the MIT License.
 ##
 
+add_subdirectory(Support)
 add_subdirectory(Dialect)
 option(BUILD_HIPDNN_GRAPH "Build hipDNN fused-graph support" OFF)
 set(HIPDNN_AVAILABLE OFF)

--- a/lib/Dialect/Transforms/GenerateInterface.cpp
+++ b/lib/Dialect/Transforms/GenerateInterface.cpp
@@ -446,6 +446,7 @@ private:
         {"hipdnn_ep_tensor_buffer_get_rank", i64, {ptr}},
         {"hipdnn_ep_tensor_buffer_get_size_bytes", i64, {ptr}},
         {"hipdnn_ep_state_init_with_fs", i32, {ptr, ptr, ptr, i64}},
+        {"hipdnn_ep_stream_sync", i32, {ptr}},
     };
   }
 
@@ -709,6 +710,8 @@ private:
     auto freeInputFunc =
         module.lookupSymbol<LLVM::LLVMFuncOp>("hipdnn_ep_tensor_free_input");
 
+    auto streamSyncFunc =
+        module.lookupSymbol<LLVM::LLVMFuncOp>("hipdnn_ep_stream_sync");
     auto getGpuPtrFunc = module.lookupSymbol<LLVM::LLVMFuncOp>(
         "hipdnn_ep_tensor_buffer_get_gpu_ptr");
     auto getShapePtrFunc = module.lookupSymbol<LLVM::LLVMFuncOp>(
@@ -869,6 +872,10 @@ private:
                            ValueRange{state, bufferPtr}, errorCodePtr,
                            errorCleanupBlock, funcOp);
     }
+
+    // Synchronize GPU stream (prints PERF timing + per-op profile when enabled)
+    emitErrorCheckedCall(builder, loc, streamSyncFunc, ValueRange{state},
+                         errorCodePtr, errorCleanupBlock, funcOp);
 
     // Free input tensors
     for (auto i : llvm::seq<size_t>(0, numInputs)) {

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -196,6 +196,8 @@ macro(compile_to_bitcode SOURCE_FILE OUTPUT_BC)
                 -o ${CMAKE_CURRENT_BINARY_DIR}/${OUTPUT_BC}
         DEPENDS ${SOURCE_FILE}
                 ${CMAKE_CURRENT_SOURCE_DIR}/hipdnn_ep_runtime.h
+                ${CMAKE_CURRENT_SOURCE_DIR}/op_profile.h
+                ${CMAKE_CURRENT_SOURCE_DIR}/debug_log.h
                 ${CMAKE_BINARY_DIR}/schemas/model_metadata_generated.h
         COMMENT "Compiling ${SOURCE_FILE} to bitcode"
         VERBATIM
@@ -206,6 +208,7 @@ endmacro()
 # Compile shared implementation files
 compile_to_bitcode(hipdnn_ep_runtime_state.cpp runtime_state.bc)
 compile_to_bitcode(hipdnn_ep_runtime_tensor.cpp runtime_tensor.bc)
+compile_to_bitcode(op_profile.cpp runtime_op_profile.bc)
 
 # Compile implementation-specific files
 if(NOT BUILD_MOCK_RUNTIME)
@@ -234,6 +237,7 @@ if(NOT BUILD_MOCK_RUNTIME)
     set(RUNTIME_BC_MODULES
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_state.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_tensor.bc
+        ${CMAKE_CURRENT_BINARY_DIR}/runtime_op_profile.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_memory.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_hip.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_miopen.bc
@@ -264,6 +268,7 @@ else()
     set(RUNTIME_BC_MODULES
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_state.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_tensor.bc
+        ${CMAKE_CURRENT_BINARY_DIR}/runtime_op_profile.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_memory.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_mock.bc
         ${CMAKE_CURRENT_BINARY_DIR}/test_hip_from_dll.bc

--- a/lib/Runtime/debug_log.h
+++ b/lib/Runtime/debug_log.h
@@ -10,10 +10,31 @@
 #include <cstdio>
 #include <cstdlib>
 
+#ifdef _WIN32
+// Static CRT (/MT) DLLs have their own CRT env — _dupenv_s can't see env vars
+// set by the host process. Use Win32 API to read the real process environment.
+extern "C" __declspec(
+    dllimport) unsigned long __stdcall GetEnvironmentVariableA(const char *,
+                                                               char *,
+                                                               unsigned long);
+
+namespace detail {
+inline bool check_env(const char *name) {
+  char buf[8];
+  unsigned long n = GetEnvironmentVariableA(name, buf, sizeof(buf));
+  return n > 0 && buf[0] >= '1';
+}
+} // namespace detail
+#endif
+
 inline bool hipdnn_ep_debug_enabled() {
   static const bool enabled = [] {
+#ifdef _WIN32
+    return detail::check_env("HIPDNN_EP_DEBUG");
+#else
     const char *v = std::getenv("HIPDNN_EP_DEBUG");
     return v && v[0] >= '1';
+#endif
   }();
   return enabled;
 }
@@ -25,8 +46,12 @@ inline bool hipdnn_ep_perf_enabled() {
   // pipeline and skews measurements. Users who only want the per-call
   // [Runtime DEBUG] traces should not pay that cost.
   static const bool enabled = [] {
+#ifdef _WIN32
+    return detail::check_env("HIPDNN_EP_PERF");
+#else
     const char *v = std::getenv("HIPDNN_EP_PERF");
     return v && v[0] >= '1';
+#endif
   }();
   return enabled;
 }

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -369,6 +369,13 @@ int hipdnn_ep_tensor_finalize_output(RuntimeState *state, TensorBuffer *buffer);
 //   buffer: TensorBuffer from prepare_input
 void hipdnn_ep_tensor_free_input(RuntimeState *state, TensorBuffer *buffer);
 
+// Per-operator profiling state accessor (OpProfileState*, gated on
+// HIPDNN_EP_PERF)
+void *hipdnn_ep_state_get_op_profile(RuntimeState *state);
+
+// GQA GEMM cache lifecycle (managed by RuntimeState)
+void hipdnn_ep_gqa_gemm_cache_destroy(void *cache);
+
 // TensorBuffer Field Accessors (Opaque Pattern)
 //===----------------------------------------------------------------------===//
 //

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -369,6 +369,10 @@ int hipdnn_ep_tensor_finalize_output(RuntimeState *state, TensorBuffer *buffer);
 //   buffer: TensorBuffer from prepare_input
 void hipdnn_ep_tensor_free_input(RuntimeState *state, TensorBuffer *buffer);
 
+// Synchronize the GPU stream and print PERF/profile timing (if enabled).
+// Called by generated code after finalize_output, before free_input.
+int hipdnn_ep_stream_sync(RuntimeState *state);
+
 // Per-operator profiling state accessor (OpProfileState*, gated on
 // HIPDNN_EP_PERF)
 void *hipdnn_ep_state_get_op_profile(RuntimeState *state);

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -6,6 +6,7 @@
 #include "hip/timing.h"
 #include "hip_cleanup.h"
 #include "hipdnn_ep_runtime.h"
+#include "op_profile.h"
 #include "runtime_state_internal.h"
 
 #include "model_metadata_generated.h"
@@ -214,6 +215,8 @@ static int initialize_state_handles(RuntimeState **out_state) {
   state->num_buffers = 0;
   state->workspace = nullptr;
   state->workspace_size = 0;
+  state->gqa_gemm_cache = nullptr;
+  state->op_profile = hipdnn_ep_perf_enabled() ? op_profile_create() : nullptr;
   state->hipdnn_handle = nullptr;
   state->hipdnn_graph_registry = nullptr;
 
@@ -839,6 +842,18 @@ int hipdnn_ep_state_cleanup(RuntimeState *state) {
   if (state->gpu_constants)
     free(state->gpu_constants);
 
+  // Free GQA GEMM descriptor cache
+  if (state->gqa_gemm_cache) {
+    hipdnn_ep_gqa_gemm_cache_destroy(state->gqa_gemm_cache);
+    state->gqa_gemm_cache = nullptr;
+  }
+
+  // Free op profiling state
+  if (state->op_profile) {
+    op_profile_destroy(static_cast<OpProfileState *>(state->op_profile));
+    state->op_profile = nullptr;
+  }
+
   // Destroy hipBLASLt handle
   if (state->hipblas_handle) {
     hipblasLtDestroy(state->hipblas_handle);
@@ -879,6 +894,10 @@ void *hipdnn_ep_state_get_miopen_handle(RuntimeState *state) {
 
 void *hipdnn_ep_state_get_hipblas_handle(RuntimeState *state) {
   return state ? static_cast<void *>(state->hipblas_handle) : nullptr;
+}
+
+void *hipdnn_ep_state_get_op_profile(RuntimeState *state) {
+  return state ? state->op_profile : nullptr;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Runtime/hipdnn_ep_runtime_tensor.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_tensor.cpp
@@ -5,6 +5,7 @@
 #include "debug_log.h"
 #include "hip_cleanup.h"
 #include "hipdnn_ep_runtime.h"
+#include "op_profile.h"
 #include "runtime_state_internal.h"
 
 #include <cassert>
@@ -375,6 +376,7 @@ int hipdnn_ep_tensor_prepare_input(RuntimeState *state, span_t *inputs,
     g_perf.d2h_count = 0;
     (void)hipEventRecord(g_perf.h2d_start,
                          static_cast<hipStream_t>(state->stream));
+    op_profile_reset(static_cast<OpProfileState *>(state->op_profile));
     g_perf.inference_num++; // marks "window opened"; flush above guards on this
   }
 
@@ -627,6 +629,8 @@ int hipdnn_ep_stream_sync(RuntimeState *state) {
             total_ms > 0 ? (h2d_ms / total_ms * 100.0) : 0.0,
             total_ms > 0 ? (compute_ms / total_ms * 100.0) : 0.0,
             total_ms > 0 ? (d2h_ms / total_ms * 100.0) : 0.0);
+    auto *op_ps = static_cast<OpProfileState *>(state->op_profile);
+    op_profile_resolve_and_print(op_ps);
   }
 
   return HIPDNN_EP_SUCCESS;

--- a/lib/Runtime/op_profile.cpp
+++ b/lib/Runtime/op_profile.cpp
@@ -1,0 +1,206 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "op_profile.h"
+#include <algorithm>
+#include <cstdio>
+#include <map>
+#include <string>
+#include <vector>
+
+struct OpProfileState {
+  struct ShapeEntry {
+    std::string shape;
+    double gpuMs = 0;
+    double cpuMs = 0;
+    int64_t count = 0;
+  };
+  struct OpEntry {
+    std::string name;
+    bool hasGpu = false;
+    std::map<std::string, ShapeEntry> shapes;
+    double totalGpuMs = 0;
+    double totalCpuMs = 0;
+    int64_t totalCount = 0;
+  };
+  struct PendingEvent {
+    std::string name;
+    std::string shape;
+    hipEvent_t start;
+    hipEvent_t stop;
+    double cpuMs;
+  };
+  std::map<std::string, OpEntry> profile;
+  std::vector<PendingEvent> pending;
+  bool active = false;
+};
+
+OpProfileState *op_profile_create() { return new OpProfileState; }
+
+void op_profile_destroy(OpProfileState *ps) {
+  if (!ps)
+    return;
+  for (auto &ev : ps->pending) {
+    hipEventDestroy(ev.start);
+    hipEventDestroy(ev.stop);
+  }
+  delete ps;
+}
+
+void op_profile_reset(OpProfileState *ps) {
+  if (!ps)
+    return;
+  ps->profile.clear();
+  for (auto &ev : ps->pending) {
+    hipEventDestroy(ev.start);
+    hipEventDestroy(ev.stop);
+  }
+  ps->pending.clear();
+  ps->active = true;
+}
+
+bool op_profile_is_active(OpProfileState *ps) { return ps && ps->active; }
+
+void op_profile_add_pending(OpProfileState *ps, const std::string &name,
+                            const std::string &shape, hipEvent_t start,
+                            hipEvent_t stop, double cpuMs) {
+  if (!ps)
+    return;
+  ps->pending.push_back({name, shape, start, stop, cpuMs});
+}
+
+void op_profile_add_cpu(OpProfileState *ps, const std::string &name,
+                        double cpuMs) {
+  if (!ps)
+    return;
+  auto &op = ps->profile[name];
+  if (op.name.empty())
+    op.name = name;
+  auto &sh = op.shapes[""];
+  sh.cpuMs += cpuMs;
+  sh.count++;
+  op.totalCpuMs += cpuMs;
+  op.totalCount++;
+}
+
+void op_profile_resolve_and_print(OpProfileState *ps) {
+  if (!ps)
+    return;
+
+  for (auto &ev : ps->pending) {
+    float gpuMs = 0.0f;
+    hipEventElapsedTime(&gpuMs, ev.start, ev.stop);
+    auto &op = ps->profile[ev.name];
+    if (op.name.empty())
+      op.name = ev.name;
+    op.hasGpu = true;
+    auto &sh = op.shapes[ev.shape];
+    if (sh.shape.empty() && !ev.shape.empty())
+      sh.shape = ev.shape;
+    sh.gpuMs += gpuMs;
+    sh.cpuMs += ev.cpuMs;
+    sh.count++;
+    op.totalGpuMs += gpuMs;
+    op.totalCpuMs += ev.cpuMs;
+    op.totalCount++;
+    hipEventDestroy(ev.start);
+    hipEventDestroy(ev.stop);
+  }
+  ps->pending.clear();
+
+  if (ps->profile.empty())
+    return;
+
+  struct OpRow {
+    std::string name;
+    bool hasGpu;
+    double totalGpuMs;
+    double totalCpuMs;
+    int64_t totalCount;
+    std::vector<OpProfileState::ShapeEntry> shapes;
+  };
+
+  std::vector<OpRow> rows;
+  int maxNameLen = 22;
+  for (auto &[_, op] : ps->profile) {
+    OpRow row;
+    row.name = op.name;
+    row.hasGpu = op.hasGpu;
+    row.totalGpuMs = op.totalGpuMs;
+    row.totalCpuMs = op.totalCpuMs;
+    row.totalCount = op.totalCount;
+    if ((int)row.name.size() > maxNameLen)
+      maxNameLen = (int)row.name.size();
+    for (auto &[_, sh] : op.shapes) {
+      row.shapes.push_back(sh);
+      int shapeNameLen = sh.shape.empty() ? 0 : (int)sh.shape.size() + 2;
+      if (shapeNameLen > maxNameLen)
+        maxNameLen = shapeNameLen;
+    }
+    std::sort(
+        row.shapes.begin(), row.shapes.end(),
+        [](const OpProfileState::ShapeEntry &a,
+           const OpProfileState::ShapeEntry &b) { return a.gpuMs > b.gpuMs; });
+    rows.push_back(std::move(row));
+  }
+
+  // GPU ops sorted by GPU time desc, then CPU-only ops sorted by CPU time desc
+  std::sort(rows.begin(), rows.end(), [](const OpRow &a, const OpRow &b) {
+    if (a.hasGpu != b.hasGpu)
+      return a.hasGpu;
+    if (a.hasGpu)
+      return a.totalGpuMs > b.totalGpuMs;
+    return a.totalCpuMs > b.totalCpuMs;
+  });
+
+  double grandTotalGpuMs = 0, grandTotalCpuMs = 0;
+  for (auto &r : rows) {
+    if (r.hasGpu)
+      grandTotalGpuMs += r.totalGpuMs;
+    grandTotalCpuMs += r.totalCpuMs;
+  }
+
+  int lineWidth = maxNameLen + 2 + 5 + 1 + 9 + 1 + 9 + 1 + 6;
+  fprintf(stderr, "\n[PERF] ");
+  for (int i = 0; i < lineWidth; ++i)
+    fputc('=', stderr);
+  fputc('\n', stderr);
+  fprintf(stderr, "[PERF]  %-*s %5s %9s %9s %6s\n", maxNameLen, "", "calls",
+          "gpu (ms)", "cpu (ms)", "gpu %");
+
+  for (auto &r : rows) {
+    if (r.hasGpu) {
+      double pct =
+          grandTotalGpuMs > 0 ? r.totalGpuMs / grandTotalGpuMs * 100 : 0;
+      fprintf(stderr, "[PERF]  %-*s %5lld %9.1f %9.1f %5.1f%%\n", maxNameLen,
+              r.name.c_str(), (long long)r.totalCount, r.totalGpuMs,
+              r.totalCpuMs, pct);
+    } else {
+      fprintf(stderr, "[PERF]  %-*s %5lld %9s %9.1f %6s\n", maxNameLen,
+              r.name.c_str(), (long long)r.totalCount, "n/a", r.totalCpuMs,
+              "n/a");
+    }
+    // Print shape sub-rows if there are shapes (non-empty shape key)
+    bool hasShapes = r.shapes.size() > 1 ||
+                     (r.shapes.size() == 1 && !r.shapes[0].shape.empty());
+    if (hasShapes) {
+      for (auto &sh : r.shapes) {
+        if (sh.shape.empty())
+          continue;
+        double pct = grandTotalGpuMs > 0 ? sh.gpuMs / grandTotalGpuMs * 100 : 0;
+        fprintf(stderr, "[PERF]    %-*s %5lld %9.1f %9.1f %5.1f%%\n",
+                maxNameLen - 2, sh.shape.c_str(), (long long)sh.count, sh.gpuMs,
+                sh.cpuMs, pct);
+      }
+    }
+  }
+  fprintf(stderr, "[PERF]  %-*s %5s %9.1f %9.1f\n", maxNameLen, "TOTAL", "",
+          grandTotalGpuMs, grandTotalCpuMs);
+  fprintf(stderr, "[PERF] ");
+  for (int i = 0; i < lineWidth; ++i)
+    fputc('=', stderr);
+  fprintf(stderr, "\n\n");
+  ps->profile.clear();
+}

--- a/lib/Runtime/op_profile.cpp
+++ b/lib/Runtime/op_profile.cpp
@@ -28,10 +28,19 @@ struct OpProfileState {
   struct PendingEvent {
     std::string name;
     std::string shape;
-    hipEvent_t start;
-    hipEvent_t stop;
+    int eventIndex;
     double cpuMs;
   };
+
+  // Pre-allocated event pool: each pair is (start, stop).
+  // Grows on demand but never shrinks — avoids hipEventCreate/Destroy per op.
+  struct EventPair {
+    hipEvent_t start;
+    hipEvent_t stop;
+  };
+  std::vector<EventPair> eventPool;
+  int nextEventIndex = 0;
+
   std::map<std::string, OpEntry> profile;
   std::vector<PendingEvent> pending;
   bool active = false;
@@ -42,9 +51,9 @@ OpProfileState *op_profile_create() { return new OpProfileState; }
 void op_profile_destroy(OpProfileState *ps) {
   if (!ps)
     return;
-  for (auto &ev : ps->pending) {
-    hipEventDestroy(ev.start);
-    hipEventDestroy(ev.stop);
+  for (auto &ep : ps->eventPool) {
+    hipEventDestroy(ep.start);
+    hipEventDestroy(ep.stop);
   }
   delete ps;
 }
@@ -53,22 +62,38 @@ void op_profile_reset(OpProfileState *ps) {
   if (!ps)
     return;
   ps->profile.clear();
-  for (auto &ev : ps->pending) {
-    hipEventDestroy(ev.start);
-    hipEventDestroy(ev.stop);
-  }
   ps->pending.clear();
+  ps->nextEventIndex = 0;
   ps->active = true;
 }
 
 bool op_profile_is_active(OpProfileState *ps) { return ps && ps->active; }
 
+int op_profile_acquire_event_pair(OpProfileState *ps) {
+  int idx = ps->nextEventIndex++;
+  if (idx >= (int)ps->eventPool.size()) {
+    OpProfileState::EventPair ep;
+    hipEventCreateWithFlags(&ep.start, hipEventDefault);
+    hipEventCreateWithFlags(&ep.stop, hipEventDefault);
+    ps->eventPool.push_back(ep);
+  }
+  return idx;
+}
+
+hipEvent_t op_profile_get_start_event(OpProfileState *ps, int index) {
+  return ps->eventPool[index].start;
+}
+
+hipEvent_t op_profile_get_stop_event(OpProfileState *ps, int index) {
+  return ps->eventPool[index].stop;
+}
+
 void op_profile_add_pending(OpProfileState *ps, const std::string &name,
-                            const std::string &shape, hipEvent_t start,
-                            hipEvent_t stop, double cpuMs) {
+                            const std::string &shape, int eventIndex,
+                            double cpuMs) {
   if (!ps)
     return;
-  ps->pending.push_back({name, shape, start, stop, cpuMs});
+  ps->pending.push_back({name, shape, eventIndex, cpuMs});
 }
 
 void op_profile_add_cpu(OpProfileState *ps, const std::string &name,
@@ -91,7 +116,8 @@ void op_profile_resolve_and_print(OpProfileState *ps) {
 
   for (auto &ev : ps->pending) {
     float gpuMs = 0.0f;
-    hipEventElapsedTime(&gpuMs, ev.start, ev.stop);
+    hipEventElapsedTime(&gpuMs, ps->eventPool[ev.eventIndex].start,
+                        ps->eventPool[ev.eventIndex].stop);
     auto &op = ps->profile[ev.name];
     if (op.name.empty())
       op.name = ev.name;
@@ -105,8 +131,6 @@ void op_profile_resolve_and_print(OpProfileState *ps) {
     op.totalGpuMs += gpuMs;
     op.totalCpuMs += ev.cpuMs;
     op.totalCount++;
-    hipEventDestroy(ev.start);
-    hipEventDestroy(ev.stop);
   }
   ps->pending.clear();
 
@@ -146,7 +170,6 @@ void op_profile_resolve_and_print(OpProfileState *ps) {
     rows.push_back(std::move(row));
   }
 
-  // GPU ops sorted by GPU time desc, then CPU-only ops sorted by CPU time desc
   std::sort(rows.begin(), rows.end(), [](const OpRow &a, const OpRow &b) {
     if (a.hasGpu != b.hasGpu)
       return a.hasGpu;
@@ -182,7 +205,6 @@ void op_profile_resolve_and_print(OpProfileState *ps) {
               r.name.c_str(), (long long)r.totalCount, "n/a", r.totalCpuMs,
               "n/a");
     }
-    // Print shape sub-rows if there are shapes (non-empty shape key)
     bool hasShapes = r.shapes.size() > 1 ||
                      (r.shapes.size() == 1 && !r.shapes[0].shape.empty());
     if (hasShapes) {

--- a/lib/Runtime/op_profile.cpp
+++ b/lib/Runtime/op_profile.cpp
@@ -73,8 +73,8 @@ int op_profile_acquire_event_pair(OpProfileState *ps) {
   int idx = ps->nextEventIndex++;
   if (idx >= (int)ps->eventPool.size()) {
     OpProfileState::EventPair ep;
-    hipEventCreateWithFlags(&ep.start, hipEventDefault);
-    hipEventCreateWithFlags(&ep.stop, hipEventDefault);
+    hipEventCreate(&ep.start);
+    hipEventCreate(&ep.stop);
     ps->eventPool.push_back(ep);
   }
   return idx;

--- a/lib/Runtime/op_profile.h
+++ b/lib/Runtime/op_profile.h
@@ -24,11 +24,14 @@ void op_profile_destroy(OpProfileState *ps);
 void op_profile_reset(OpProfileState *ps);
 void op_profile_resolve_and_print(OpProfileState *ps);
 void op_profile_add_pending(OpProfileState *ps, const std::string &name,
-                            const std::string &shape, hipEvent_t start,
-                            hipEvent_t stop, double cpuMs);
+                            const std::string &shape, int eventIndex,
+                            double cpuMs);
 void op_profile_add_cpu(OpProfileState *ps, const std::string &name,
                         double cpuMs);
 bool op_profile_is_active(OpProfileState *ps);
+int op_profile_acquire_event_pair(OpProfileState *ps);
+hipEvent_t op_profile_get_start_event(OpProfileState *ps, int index);
+hipEvent_t op_profile_get_stop_event(OpProfileState *ps, int index);
 
 struct OpProfileCpuScope {
   OpProfileState *ps;
@@ -54,26 +57,24 @@ struct OpProfileScope {
   OpProfileState *ps;
   std::string name;
   std::string shape;
-  hipEvent_t start, stop;
+  int eventIndex;
   hipStream_t stream;
   std::chrono::steady_clock::time_point cpuStart;
 
   OpProfileScope(OpProfileState *p, std::string n, std::string sh,
-                 hipStream_t s)
-      : ps(p), name(std::move(n)), shape(std::move(sh)), stream(s),
-        cpuStart(std::chrono::steady_clock::now()) {
-    hipEventCreate(&start);
-    hipEventCreate(&stop);
-    hipEventRecord(start, stream);
+                 hipStream_t s, int evIdx)
+      : ps(p), name(std::move(n)), shape(std::move(sh)), eventIndex(evIdx),
+        stream(s), cpuStart(std::chrono::steady_clock::now()) {
+    hipEventRecord(op_profile_get_start_event(ps, eventIndex), stream);
   }
 
   ~OpProfileScope() {
-    hipEventRecord(stop, stream);
+    hipEventRecord(op_profile_get_stop_event(ps, eventIndex), stream);
     double ms = std::chrono::duration<double, std::milli>(
                     std::chrono::steady_clock::now() - cpuStart)
                     .count();
     if (ps)
-      op_profile_add_pending(ps, name, shape, start, stop, ms);
+      op_profile_add_pending(ps, name, shape, eventIndex, ms);
   }
 
   OpProfileScope(const OpProfileScope &) = delete;
@@ -87,8 +88,10 @@ struct OpProfileScope {
         hipdnn_ep_state_get_op_profile(state_arg));                            \
     auto *_stream =                                                            \
         static_cast<hipStream_t>(hipdnn_ep_state_get_stream(state_arg));       \
-    if (_ps && _stream && op_profile_is_active(_ps))                           \
-      _opProf.emplace(_ps, opname, (shape_fn)(), _stream);                     \
+    if (_ps && _stream && op_profile_is_active(_ps)) {                         \
+      int _evIdx = op_profile_acquire_event_pair(_ps);                         \
+      _opProf.emplace(_ps, opname, (shape_fn)(), _stream, _evIdx);             \
+    }                                                                          \
   }
 
 #define OP_PROFILE_CPU(opname, state_arg)                                      \

--- a/lib/Runtime/op_profile.h
+++ b/lib/Runtime/op_profile.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#pragma once
+// Per-operator GPU profiling (gated on HIPDNN_EP_PERF env var).
+//
+// Usage: add OP_PROFILE("opname", shape_lambda, state) at the top of each
+// runtime wrapper. The shape_lambda is a callable returning std::string,
+// invoked only when profiling is active — zero overhead when disabled.
+
+#include "debug_log.h"
+#include "hipdnn_ep_runtime.h"
+#include "runtime_types.h"
+#include <chrono>
+#include <optional>
+#include <string>
+
+struct OpProfileState;
+
+OpProfileState *op_profile_create();
+void op_profile_destroy(OpProfileState *ps);
+void op_profile_reset(OpProfileState *ps);
+void op_profile_resolve_and_print(OpProfileState *ps);
+void op_profile_add_pending(OpProfileState *ps, const std::string &name,
+                            const std::string &shape, hipEvent_t start,
+                            hipEvent_t stop, double cpuMs);
+void op_profile_add_cpu(OpProfileState *ps, const std::string &name,
+                        double cpuMs);
+bool op_profile_is_active(OpProfileState *ps);
+
+struct OpProfileCpuScope {
+  OpProfileState *ps;
+  std::string name;
+  std::chrono::steady_clock::time_point cpuStart;
+
+  OpProfileCpuScope(OpProfileState *p, std::string n)
+      : ps(p), name(std::move(n)), cpuStart(std::chrono::steady_clock::now()) {}
+
+  ~OpProfileCpuScope() {
+    double ms = std::chrono::duration<double, std::milli>(
+                    std::chrono::steady_clock::now() - cpuStart)
+                    .count();
+    if (ps)
+      op_profile_add_cpu(ps, name, ms);
+  }
+
+  OpProfileCpuScope(const OpProfileCpuScope &) = delete;
+  OpProfileCpuScope &operator=(const OpProfileCpuScope &) = delete;
+};
+
+struct OpProfileScope {
+  OpProfileState *ps;
+  std::string name;
+  std::string shape;
+  hipEvent_t start, stop;
+  hipStream_t stream;
+  std::chrono::steady_clock::time_point cpuStart;
+
+  OpProfileScope(OpProfileState *p, std::string n, std::string sh,
+                 hipStream_t s)
+      : ps(p), name(std::move(n)), shape(std::move(sh)), stream(s),
+        cpuStart(std::chrono::steady_clock::now()) {
+    hipEventCreate(&start);
+    hipEventCreate(&stop);
+    hipEventRecord(start, stream);
+  }
+
+  ~OpProfileScope() {
+    hipEventRecord(stop, stream);
+    double ms = std::chrono::duration<double, std::milli>(
+                    std::chrono::steady_clock::now() - cpuStart)
+                    .count();
+    if (ps)
+      op_profile_add_pending(ps, name, shape, start, stop, ms);
+  }
+
+  OpProfileScope(const OpProfileScope &) = delete;
+  OpProfileScope &operator=(const OpProfileScope &) = delete;
+};
+
+#define OP_PROFILE(opname, shape_fn, state_arg)                                \
+  std::optional<OpProfileScope> _opProf;                                       \
+  if (hipdnn_ep_perf_enabled()) {                                              \
+    auto *_ps = static_cast<OpProfileState *>(                                 \
+        hipdnn_ep_state_get_op_profile(state_arg));                            \
+    auto *_stream =                                                            \
+        static_cast<hipStream_t>(hipdnn_ep_state_get_stream(state_arg));       \
+    if (_ps && _stream && op_profile_is_active(_ps))                           \
+      _opProf.emplace(_ps, opname, (shape_fn)(), _stream);                     \
+  }
+
+#define OP_PROFILE_CPU(opname, state_arg)                                      \
+  std::optional<OpProfileCpuScope> _opProfCpu;                                 \
+  if (hipdnn_ep_perf_enabled()) {                                              \
+    auto *_ps = static_cast<OpProfileState *>(                                 \
+        hipdnn_ep_state_get_op_profile(state_arg));                            \
+    if (_ps)                                                                   \
+      _opProfCpu.emplace(_ps, opname);                                         \
+  }

--- a/lib/Runtime/real/activation.cpp
+++ b/lib/Runtime/real/activation.cpp
@@ -4,6 +4,7 @@
  */
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../op_profile.h"
 #include "cache_utils.h"
 #include "error_check_macros.h"
 #include "hip_custom_kernels.h"
@@ -151,6 +152,14 @@ cache_done:
 int wrap_miopenActivationForward(RuntimeState *state, void *input, void *output,
                                  int64_t num_elements, int64_t data_type,
                                  int64_t activation_mode) {
+  OP_PROFILE(
+      "activation",
+      [&] {
+        char b[64];
+        snprintf(b, sizeof(b), "n=%lld", (long long)num_elements);
+        return std::string(b);
+      },
+      state);
   if (!state || !input || !output) {
     fprintf(stderr, "wrap_miopenActivationForward: null argument\n");
     return -1;
@@ -227,6 +236,14 @@ static int hipdnn_ep_to_hip_dtype_elementwise_unary(int64_t data_type) {
 
 int wrap_gelu(RuntimeState *state, void *input, void *output,
               int64_t num_elements, int64_t data_type, int64_t approximate) {
+  OP_PROFILE(
+      "gelu",
+      [&] {
+        char b[64];
+        snprintf(b, sizeof(b), "n=%lld", (long long)num_elements);
+        return std::string(b);
+      },
+      state);
   if (!state || !input || !output) {
     fprintf(stderr, "[REAL] wrap_gelu: null argument\n");
     return -1;

--- a/lib/Runtime/real/cast.cpp
+++ b/lib/Runtime/real/cast.cpp
@@ -4,6 +4,7 @@
  */
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../op_profile.h"
 #include "hip_custom_kernels.h"
 
 #include <cstdio>
@@ -30,6 +31,14 @@ static int hipdnn_to_hip_dtype(int64_t hipdnn_type) {
 int wrap_cast(RuntimeState *state, void *input, void *output,
               int64_t num_elements, int64_t src_data_type,
               int64_t dst_data_type) {
+  OP_PROFILE(
+      "cast",
+      [&] {
+        char b[64];
+        snprintf(b, sizeof(b), "n=%lld", (long long)num_elements);
+        return std::string(b);
+      },
+      state);
   if (!state || !input || !output) {
     RUNTIME_DEBUG_LOG("[REAL] wrap_cast: null argument\n");
     return -1;

--- a/lib/Runtime/real/causal_conv_with_state.cpp
+++ b/lib/Runtime/real/causal_conv_with_state.cpp
@@ -4,6 +4,7 @@
  */
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../op_profile.h"
 #include "runtime_types.h"
 
 #include <cassert>
@@ -41,6 +42,16 @@ int wrap_causal_conv_with_state(
     const void *bias, const void *past_state, void *output, void *present_state,
     int64_t batch_size, int64_t channels, int64_t seq_len, int64_t kernel_size,
     int64_t ndim, int64_t activation, int64_t element_size_bytes) {
+  OP_PROFILE(
+      "causal_conv",
+      [&] {
+        char b[64];
+        snprintf(b, sizeof(b), "%lldx%lldx%lld,k=%lld", (long long)batch_size,
+                 (long long)channels, (long long)seq_len,
+                 (long long)kernel_size);
+        return std::string(b);
+      },
+      state);
   if (!state || !input || !weight || !output || !present_state) {
     fprintf(stderr, "wrap_causal_conv_with_state: null required argument\n");
     return -1;

--- a/lib/Runtime/real/elementwise.cpp
+++ b/lib/Runtime/real/elementwise.cpp
@@ -4,6 +4,7 @@
  */
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../op_profile.h"
 #include "cache_utils.h"
 #include "error_check_macros.h"
 #include "hip_custom_kernels.h"
@@ -181,6 +182,15 @@ int wrap_miopenOpTensor(RuntimeState *state, void *lhs, void *rhs, void *output,
                         int64_t rhs_h, int64_t rhs_w, int64_t out_n,
                         int64_t out_c, int64_t out_h, int64_t out_w,
                         int64_t data_type, int64_t tensor_op) {
+  OP_PROFILE(
+      "elementwise",
+      [&] {
+        char b[64];
+        snprintf(b, sizeof(b), "%lldx%lldx%lldx%lld", (long long)out_n,
+                 (long long)out_c, (long long)out_h, (long long)out_w);
+        return std::string(b);
+      },
+      state);
   if (!state || !lhs || !rhs || !output) {
     fprintf(stderr, "wrap_miopenOpTensor: null argument\n");
     return -1;
@@ -252,6 +262,14 @@ int wrap_miopenOpTensor(RuntimeState *state, void *lhs, void *rhs, void *output,
 int wrap_elementwise_sub(RuntimeState *state, void *lhs, void *rhs,
                          void *output, int64_t num_elements,
                          int64_t element_size_bytes) {
+  OP_PROFILE(
+      "sub",
+      [&] {
+        char b[64];
+        snprintf(b, sizeof(b), "n=%lld", (long long)num_elements);
+        return std::string(b);
+      },
+      state);
   if (!state || !lhs || !rhs || !output) {
     fprintf(stderr, "wrap_elementwise_sub: null argument\n");
     return -1;

--- a/lib/Runtime/real/gather.cpp
+++ b/lib/Runtime/real/gather.cpp
@@ -4,6 +4,7 @@
  */
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../op_profile.h"
 #include "hip_custom_kernels.h"
 #include "runtime_types.h"
 
@@ -13,6 +14,14 @@ int wrap_gather(RuntimeState *state, void *data, void *indices, void *output,
                 int64_t axis, int64_t data_num_elements,
                 int64_t indices_num_elements, int64_t output_num_elements,
                 int64_t element_size_bytes) {
+  OP_PROFILE(
+      "gather",
+      [&] {
+        char b[64];
+        snprintf(b, sizeof(b), "n=%lld", (long long)output_num_elements);
+        return std::string(b);
+      },
+      state);
   if (!state || !data || !indices || !output) {
     RUNTIME_DEBUG_LOG("[REAL] wrap_gather: null argument\n");
     return -1;

--- a/lib/Runtime/real/gemm.cpp
+++ b/lib/Runtime/real/gemm.cpp
@@ -4,6 +4,7 @@
  */
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../op_profile.h"
 #include "error_check_macros.h"
 #include "runtime_types.h"
 
@@ -246,6 +247,15 @@ int wrap_gemm(RuntimeState *state, const void *A, const void *B, const void *C,
               void *output, int64_t M, int64_t N, int64_t K, float alpha,
               float beta, int64_t transA, int64_t transB, int64_t typeCode,
               int64_t cDim0, int64_t cDim1) {
+  OP_PROFILE(
+      "gemm",
+      [&] {
+        char b[64];
+        snprintf(b, sizeof(b), "m=%lld,n=%lld,k=%lld", (long long)M,
+                 (long long)N, (long long)K);
+        return std::string(b);
+      },
+      state);
   if (!state || !A || !B || !output) {
     fprintf(stderr, "wrap_gemm: invalid arguments\n");
     return -1;

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -5,6 +5,8 @@
 
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../op_profile.h"
+#include "../runtime_state_internal.h"
 #include "cache_utils.h"
 #include "error_check_macros.h"
 #include "hip_custom_kernels.h"
@@ -82,18 +84,23 @@ struct GqaGemmCacheEntry {
   size_t workspace_size;      // workspace bytes required by algo
 };
 
-static std::unordered_map<GqaGemmKey, GqaGemmCacheEntry, GqaGemmKeyHash>
-    g_gqa_gemm_cache;
+struct GqaGemmCache {
+  std::unordered_map<GqaGemmKey, GqaGemmCacheEntry, GqaGemmKeyHash> entries;
+};
 
-/// Look up or create cached hipBLASLt descriptors + algorithm for a GEMM shape.
-/// On first call for a given key, creates all descriptors, queries the
-/// heuristic, and caches the result. Returns nullptr on any API failure
-/// (partially created descriptors are cleaned up).
-static const GqaGemmCacheEntry *queryOrCreateGemmState(hipblasLtHandle_t handle,
+static GqaGemmCache *get_gemm_cache(RuntimeState *state) {
+  if (!state->gqa_gemm_cache)
+    state->gqa_gemm_cache = new GqaGemmCache;
+  return static_cast<GqaGemmCache *>(state->gqa_gemm_cache);
+}
+
+static const GqaGemmCacheEntry *queryOrCreateGemmState(RuntimeState *state,
+                                                       hipblasLtHandle_t handle,
                                                        const GqaGemmKey &key) {
   assert(handle && "queryOrCreateGemmState: null handle");
-  auto it = g_gqa_gemm_cache.find(key);
-  if (it != g_gqa_gemm_cache.end())
+  auto *cache = get_gemm_cache(state);
+  auto it = cache->entries.find(key);
+  if (it != cache->entries.end())
     return &it->second;
 
   int64_t m = key.m, n = key.n, k = key.k;
@@ -188,7 +195,7 @@ cache_fail:
   return nullptr;
 
 cache_done:
-  auto [ins, _] = g_gqa_gemm_cache.emplace(key, entry);
+  auto [ins, _] = cache->entries.emplace(key, entry);
   return &ins->second;
 }
 
@@ -275,8 +282,10 @@ static int gqa_forward_hipblaslt(
   // (sliding window, smooth softmax, head sink) are supported.
   //===--------------------------------------------------------------------===//
   bool fused_d = (d == 64 || d == 128 || d == 256);
+  // ONNX uses local_window_size=-1 for "no sliding window"; <= 0 means
+  // disabled.
   if (fused_d && sq == 1 && key && value && present_key && present_value &&
-      local_window_size == 0 && !head_sink && !use_smooth_softmax) {
+      local_window_size <= 0 && !head_sink && !use_smooth_softmax) {
     const void *qSrc = query;
     const void *kSrc = key;
 
@@ -495,11 +504,11 @@ static int gqa_forward_hipblaslt(
   GqaGemmKey valueKey{d,     sq,    total_seq,
                       B * H, false, false}; // outputFp32=false
   const GqaGemmCacheEntry *scoreState =
-      queryOrCreateGemmState(ltHandle, scoreKey);
+      queryOrCreateGemmState(state, ltHandle, scoreKey);
   if (!scoreState)
     return -1;
   const GqaGemmCacheEntry *valueState =
-      queryOrCreateGemmState(ltHandle, valueKey);
+      queryOrCreateGemmState(state, ltHandle, valueKey);
   if (!valueState)
     return -1;
 
@@ -678,6 +687,17 @@ int wrap_group_query_attention(
     // (may differ from actual past token count for pre-allocated caches)
     int64_t batch_size, int64_t seq_len_q, int64_t seq_len_kv,
     int64_t past_buf_seq, int64_t head_dim, int64_t element_size_bytes) {
+  OP_PROFILE(
+      "gqa",
+      [&] {
+        char b[64];
+        snprintf(b, sizeof(b), "b=%lld,sq=%lld,skv=%lld,h=%lld,d=%lld",
+                 (long long)batch_size, (long long)seq_len_q,
+                 (long long)seq_len_kv, (long long)num_heads,
+                 (long long)head_dim);
+        return std::string(b);
+      },
+      state);
 
   if (!state) {
     fprintf(stderr, "wrap_group_query_attention: null state\n");
@@ -815,4 +835,23 @@ int wrap_group_query_attention(
   }
 
   return rc;
+}
+
+void hipdnn_ep_gqa_gemm_cache_destroy(void *cache_ptr) {
+  auto *cache = static_cast<GqaGemmCache *>(cache_ptr);
+  if (!cache)
+    return;
+  for (auto &[k, e] : cache->entries) {
+    if (e.layD)
+      hipblasLtMatrixLayoutDestroy(e.layD);
+    if (e.layC)
+      hipblasLtMatrixLayoutDestroy(e.layC);
+    if (e.layB)
+      hipblasLtMatrixLayoutDestroy(e.layB);
+    if (e.layA)
+      hipblasLtMatrixLayoutDestroy(e.layA);
+    if (e.desc)
+      hipblasLtMatmulDescDestroy(e.desc);
+  }
+  delete cache;
 }

--- a/lib/Runtime/real/matmul.cpp
+++ b/lib/Runtime/real/matmul.cpp
@@ -4,6 +4,7 @@
  */
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../op_profile.h"
 #include "cache_utils.h"
 #include "hip_custom_kernels.h"
 #include "runtime_types.h"
@@ -350,6 +351,15 @@ static void autotuneMatmul(hipblasLtHandle_t handle, hipStream_t stream,
 int wrap_hipblasLtMatmul(RuntimeState *state, const void *A, const void *B,
                          void *output, int64_t M, int64_t N, int64_t K,
                          int64_t batch_count, int64_t elem_size) {
+  OP_PROFILE(
+      "matmul",
+      [&] {
+        char b[64];
+        snprintf(b, sizeof(b), "m=%lld,n=%lld,k=%lld", (long long)M,
+                 (long long)N, (long long)K);
+        return std::string(b);
+      },
+      state);
   if (!state || !A || !B || !output) {
     fprintf(stderr, "Invalid arguments to wrap_hipblasLtMatmul\n");
     return -1;

--- a/lib/Runtime/real/matmul_nbits.cpp
+++ b/lib/Runtime/real/matmul_nbits.cpp
@@ -4,6 +4,7 @@
  */
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../op_profile.h"
 #include "error_check_macros.h"
 #include "hip_custom_kernels.h"
 
@@ -17,6 +18,15 @@ int wrap_matmul_nbits(RuntimeState *state, const void *A, const void *B,
                       int64_t M, int64_t N, int64_t K, int64_t batch_count,
                       int64_t bits, int64_t block_size, int64_t elem_size,
                       int64_t zp_elem_size) {
+  OP_PROFILE(
+      "matmul_nbits",
+      [&] {
+        char b[64];
+        snprintf(b, sizeof(b), "m=%lld,n=%lld,k=%lld", (long long)M,
+                 (long long)N, (long long)K);
+        return std::string(b);
+      },
+      state);
   if (!state || !A || !B || !scales || !output) {
     fprintf(stderr, "wrap_matmul_nbits: null argument\n");
     return -1;

--- a/lib/Runtime/real/memory.cpp
+++ b/lib/Runtime/real/memory.cpp
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 #include "../hipdnn_ep_runtime.h"
+#include "../op_profile.h"
 #include "runtime_types.h"
 
 #include <cstdio>
@@ -11,6 +12,7 @@
 // Follows opaque RuntimeState pattern - extracts stream internally
 int wrap_hipMemcpyAsync(RuntimeState *state, void *dst_ptr, const void *src_ptr,
                         size_t size_bytes) {
+  OP_PROFILE_CPU("memcpy_d2d", state);
   if (!state) {
     fprintf(stderr, "wrap_hipMemcpyAsync: null state\n");
     return -1;

--- a/lib/Runtime/real/miopen.cpp
+++ b/lib/Runtime/real/miopen.cpp
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 #include "../hipdnn_ep_runtime.h"
+#include "../op_profile.h"
 #include "error_check_macros.h"
 #include "runtime_types.h"
 
@@ -106,6 +107,17 @@ int wrap_miopenConvolutionForward(
     int64_t kernel_h, int64_t kernel_w, int64_t stride_h, int64_t stride_w,
     int64_t pad_top, int64_t pad_left, int64_t pad_bottom, int64_t pad_right,
     int64_t dilation_h, int64_t dilation_w, int64_t group) {
+  OP_PROFILE(
+      "conv",
+      [&] {
+        char b[64];
+        snprintf(b, sizeof(b), "%lldx%lldx%lldx%lld,k=%lldx%lldx%lld",
+                 (long long)input_n, (long long)input_c, (long long)input_h,
+                 (long long)input_w, (long long)weights_k, (long long)kernel_h,
+                 (long long)kernel_w);
+        return std::string(b);
+      },
+      state);
   if (!state || !input || !weights || !output) {
     fprintf(stderr, "Invalid arguments to wrap_miopenConvolutionForward\n");
     return -1;

--- a/lib/Runtime/real/power.cpp
+++ b/lib/Runtime/real/power.cpp
@@ -4,6 +4,7 @@
  */
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../op_profile.h"
 #include "cache_utils.h"
 #include "error_check_macros.h"
 #include "hip_custom_kernels.h"
@@ -243,6 +244,14 @@ int launchSqrtHip(RuntimeState *state, void *input, void *output,
 int wrap_power(RuntimeState *state, void *input, void *output,
                int64_t num_elements, int64_t data_type, double alpha,
                double beta, double gamma) {
+  OP_PROFILE(
+      "power",
+      [&] {
+        char b[64];
+        snprintf(b, sizeof(b), "n=%lld", (long long)num_elements);
+        return std::string(b);
+      },
+      state);
   if (!state || !input || !output) {
     fprintf(stderr, "wrap_power: null argument\n");
     return -1;

--- a/lib/Runtime/real/qmoe.cpp
+++ b/lib/Runtime/real/qmoe.cpp
@@ -4,6 +4,7 @@
  */
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../op_profile.h"
 #include "error_check_macros.h"
 #include "hip_custom_kernels.h"
 #include "runtime_types.h"
@@ -33,6 +34,16 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
               int64_t swiglu_fusion, int64_t activation_type,
               float activation_alpha, float activation_beta, float swiglu_limit,
               int64_t normalize_routing_weights, int64_t elem_size) {
+  OP_PROFILE(
+      "qmoe",
+      [&] {
+        char b[64];
+        snprintf(b, sizeof(b), "%lldx%lldx%lld,e=%lld", (long long)num_tokens,
+                 (long long)hidden_size, (long long)inter_size,
+                 (long long)num_experts);
+        return std::string(b);
+      },
+      state);
   if (router_weights) {
     fprintf(stderr, "wrap_qmoe: router_weights is not supported yet\n");
     return -1;

--- a/lib/Runtime/real/reduce_sum.cpp
+++ b/lib/Runtime/real/reduce_sum.cpp
@@ -4,6 +4,7 @@
  */
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../op_profile.h"
 #include "hip_custom_kernels.h"
 #include "runtime_types.h"
 
@@ -25,6 +26,15 @@ int wrap_reduce_sum(RuntimeState *state, void *data, void *axes, void *output,
                     int64_t data_num_elements, int64_t output_num_elements,
                     int64_t axes_num_elements, int64_t element_size_bytes,
                     int64_t keepdims, int64_t noop_with_empty_axes) {
+  OP_PROFILE(
+      "reduce_sum",
+      [&] {
+        char b[64];
+        snprintf(b, sizeof(b), "%lld->%lld", (long long)data_num_elements,
+                 (long long)output_num_elements);
+        return std::string(b);
+      },
+      state);
   if (!state || !data || !output) {
     RUNTIME_DEBUG_LOG("[REAL] wrap_reduce_sum: null argument\n");
     return -1;

--- a/lib/Runtime/real/rotary_embedding.cpp
+++ b/lib/Runtime/real/rotary_embedding.cpp
@@ -5,6 +5,7 @@
 
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../op_profile.h"
 #include "hip_custom_kernels.h"
 
 #include <cstdio>
@@ -37,6 +38,15 @@ int wrap_rotary_embedding(RuntimeState *state, void *input, void *position_ids,
                           int64_t rotary_dim, int64_t input_num_elements,
                           int64_t cos_cache_num_elements,
                           int64_t element_size_bytes) {
+  OP_PROFILE(
+      "rotary_emb",
+      [&] {
+        char b[64];
+        snprintf(b, sizeof(b), "h=%lld,d=%lld", (long long)num_heads,
+                 (long long)rotary_dim);
+        return std::string(b);
+      },
+      state);
   if (!state) {
     fprintf(stderr, "wrap_rotary_embedding: null state\n");
     return -1;

--- a/lib/Runtime/real/simplified_layer_norm.cpp
+++ b/lib/Runtime/real/simplified_layer_norm.cpp
@@ -8,6 +8,7 @@
 
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../op_profile.h"
 #include "cache_utils.h"
 #include "error_check_macros.h"
 #include "runtime_types.h"
@@ -139,6 +140,18 @@ int wrap_miopenT5LayerNormForward(RuntimeState *state, void *input, void *scale,
                                   int64_t scale_num_elements,
                                   int64_t element_size_bytes, int64_t axis,
                                   float epsilon, int64_t stash_type) {
+  OP_PROFILE(
+      "layernorm",
+      [&] {
+        char b[64];
+        snprintf(b, sizeof(b), "%lldx%lld",
+                 (long long)(scale_num_elements > 0
+                                 ? input_num_elements / scale_num_elements
+                                 : 0),
+                 (long long)scale_num_elements);
+        return std::string(b);
+      },
+      state);
   if (!state || !input || !scale || !output) {
     fprintf(stderr, "Invalid arguments to wrap_miopenT5LayerNormForward\n");
     return -1;

--- a/lib/Runtime/real/skip_simplified_layer_norm.cpp
+++ b/lib/Runtime/real/skip_simplified_layer_norm.cpp
@@ -8,6 +8,7 @@
 
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../op_profile.h"
 #include "cache_utils.h"
 #include "error_check_macros.h"
 #include "runtime_types.h"
@@ -168,6 +169,18 @@ int wrap_skip_simplified_layer_norm(RuntimeState *state, void *input,
                                     int64_t input_num_elements,
                                     int64_t gamma_num_elements,
                                     int64_t element_size_bytes, float epsilon) {
+  OP_PROFILE(
+      "skip_layernorm",
+      [&] {
+        char b[64];
+        snprintf(b, sizeof(b), "%lldx%lld",
+                 (long long)(gamma_num_elements > 0
+                                 ? input_num_elements / gamma_num_elements
+                                 : 0),
+                 (long long)gamma_num_elements);
+        return std::string(b);
+      },
+      state);
   if (!state || !input || !skip || !gamma || !output) {
     fprintf(stderr,
             "wrap_skip_simplified_layer_norm: null required argument\n");

--- a/lib/Runtime/runtime_state_internal.h
+++ b/lib/Runtime/runtime_state_internal.h
@@ -54,6 +54,14 @@ struct RuntimeState {
   void *workspace;
   size_t workspace_size;
 
+  // GQA GEMM descriptor cache (GqaGemmCache*) for the decomposed path.
+  // Caches hipBLASLt descriptors + algorithms by GEMM shape.
+  void *gqa_gemm_cache;
+
+  // Per-operator profiling state (OpProfileState*, gated on HIPDNN_EP_PERF).
+  // Allocated in state_init, freed in state_cleanup.
+  void *op_profile;
+
   // hipDNN graph execution support.
   // Set by EP via hipdnn_graph_runtime_attach() after inference_init().
   // hipdnn_handle: hipdnnHandle_t cast to void* (owned by EP, not cleaned up

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -1,0 +1,12 @@
+##
+# ** Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# ** Licensed under the MIT License.
+##
+
+add_library(HipSupport STATIC CrashHandler.cpp)
+
+target_include_directories(HipSupport PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(HipSupport PUBLIC cpptrace::cpptrace)

--- a/lib/Support/CrashHandler.cpp
+++ b/lib/Support/CrashHandler.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "CrashHandler.h"
+
+#include <cpptrace/cpptrace.hpp>
+#include <csignal>
+#include <iostream>
+#include <mutex>
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#endif
+
+namespace hip {
+
+static const char *g_component_name = "hip";
+
+void install_crash_handlers(const char *component_name) {
+  static std::once_flag flag;
+  std::call_once(flag, [component_name] {
+    g_component_name = component_name;
+
+    cpptrace::register_terminate_handler();
+
+    std::signal(SIGABRT, [](int) {
+      std::cerr << "\n=== " << g_component_name << ": abort() ===" << std::endl;
+      cpptrace::generate_trace().print(std::cerr);
+    });
+
+#ifdef _WIN32
+    AddVectoredExceptionHandler(TRUE, [](EXCEPTION_POINTERS *info) -> LONG {
+      static thread_local bool in_handler = false;
+      const auto code = info->ExceptionRecord->ExceptionCode;
+      if (!in_handler && (code & 0xF0000000) == 0xC0000000 &&
+          code != 0xC0000008 && code != 0xC00000FE) {
+        in_handler = true;
+        std::cerr << "\n=== " << g_component_name << ": exception 0x"
+                  << std::hex << code << " at "
+                  << info->ExceptionRecord->ExceptionAddress << std::dec
+                  << " ===" << std::endl;
+        cpptrace::generate_raw_trace().resolve().print(std::cerr);
+        in_handler = false;
+      }
+      return EXCEPTION_CONTINUE_SEARCH;
+    });
+#endif
+  });
+}
+
+} // namespace hip

--- a/lib/Support/CrashHandler.h
+++ b/lib/Support/CrashHandler.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#ifndef HIP_SUPPORT_CRASHHANDLER_H
+#define HIP_SUPPORT_CRASHHANDLER_H
+
+namespace hip {
+void install_crash_handlers(const char *component_name);
+} // namespace hip
+
+#endif // HIP_SUPPORT_CRASHHANDLER_H

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -212,13 +212,25 @@ def make_llama_inputs(cfg: LlamaModelConfig) -> dict:
     return inputs
 
 
+AMD_VENDOR_ID = 0x1002
+
+
 def run_timed_iobinding(
-    sess, inputs, cfg: LlamaModelConfig, warmup=NUM_WARMUP, runs=NUM_RUNS
+    sess,
+    inputs,
+    cfg: LlamaModelConfig,
+    warmup=NUM_WARMUP,
+    runs=NUM_RUNS,
+    use_device_memory=False,
 ):
     """Run inference using IOBinding with shared past/present KV cache buffers.
 
     Binds the same OrtValue to both past_key_values.N.{key,value} (input) and
     present.N.{key,value} (output) so the runtime sees past_ptr == present_ptr.
+
+    When use_device_memory=True, KV cache OrtValues are allocated via the EP's
+    GPU allocator (hipHostMalloc on AMD iGPU) so the runtime sees
+    memory_type==TENSOR_MEMORY_GPU and aliases them directly — zero H2D/D2H.
     """
     io = sess.io_binding()
 
@@ -226,9 +238,17 @@ def run_timed_iobinding(
     kv_cache = {}
     for i in range(cfg.num_kv_layers):
         for kind in ("key", "value"):
-            kv_cache[(i, kind)] = ort.OrtValue.ortvalue_from_numpy(
-                np.zeros(kv_shape, dtype=np.float16)
-            )
+            if use_device_memory:
+                kv_cache[(i, kind)] = ort.OrtValue.ortvalue_from_shape_and_type(
+                    list(kv_shape),
+                    np.float16,
+                    device_type="gpu",
+                    vendor_id=AMD_VENDOR_ID,
+                )
+            else:
+                kv_cache[(i, kind)] = ort.OrtValue.ortvalue_from_numpy(
+                    np.zeros(kv_shape, dtype=np.float16)
+                )
 
     _ORT_TYPE_MAP = {
         "tensor(float16)": np.float16,

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -1,0 +1,280 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""Shared fixtures and helpers for Python performance tests."""
+
+import os
+import pathlib
+import time
+import urllib.request
+from dataclasses import dataclass
+
+import numpy as np
+import onnxruntime as ort
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+
+NUM_WARMUP = 1
+NUM_RUNS = 3
+
+EP_DLL_NAME = "onnxruntime_morphizen_ep.dll"
+EP_REGISTRATION_NAME = "MorphiZenExecutionProvider"
+
+_morphizen_registered = False
+
+
+# ── Model download / shape fixing ────────────────────────────────────────────
+
+
+def download(url: str, dest: pathlib.Path) -> None:
+    print(f"  Downloading {url}")
+    urllib.request.urlretrieve(url, str(dest))
+    mb = dest.stat().st_size / (1024 * 1024)
+    print(f"  Saved {dest.name} ({mb:.1f} MB)")
+
+
+def fix_shapes(src: pathlib.Path, dst: pathlib.Path, dim_map: dict) -> None:
+    import onnx
+
+    m = onnx.load(str(src), load_external_data=False)
+    for tensor in list(m.graph.input) + list(m.graph.output) + list(m.graph.value_info):
+        if not tensor.type.tensor_type.HasField("shape"):
+            continue
+        for d in tensor.type.tensor_type.shape.dim:
+            if d.dim_param in dim_map:
+                v = dim_map[d.dim_param]
+                d.Clear()
+                d.dim_value = v
+    onnx.save(m, str(dst), save_as_external_data=False)
+    print(f"  Fixed-shape model -> {dst.name}")
+
+
+# ── Perf helpers ─────────────────────────────────────────────────────────────
+
+
+def run_timed(session, inputs, warmup=NUM_WARMUP, runs=NUM_RUNS):
+    for _ in range(warmup):
+        session.run(None, inputs)
+    times = []
+    for _ in range(runs):
+        t0 = time.perf_counter()
+        session.run(None, inputs)
+        times.append(time.perf_counter() - t0)
+    return times
+
+
+def report(label, times_sec):
+    ms = [t * 1000 for t in times_sec]
+    avg, std = np.mean(ms), np.std(ms)
+    print(f"\n{'=' * 60}")
+    print(f"{label}  ({len(ms)} runs)")
+    print(f"  Avg: {avg:8.2f} ms  (std: {std:.2f})")
+    print(f"  Min: {min(ms):8.2f} ms")
+    print(f"  Max: {max(ms):8.2f} ms")
+    print(f"  Tokens/sec: {1000 / avg:.1f}")
+    print(f"{'=' * 60}")
+    return avg
+
+
+def compare_outputs(ref_outputs, test_outputs, output_names, label):
+    """Compare test EP outputs against CPU reference. Returns (passed, report_str)."""
+    lines = []
+    all_ok = True
+    for i, name in enumerate(output_names):
+        ref = ref_outputs[i].astype(np.float32).flatten()
+        test = test_outputs[i].astype(np.float32).flatten()
+
+        if ref.shape != test.shape:
+            lines.append(f"  {name}: SHAPE MISMATCH {ref.shape} vs {test.shape}")
+            all_ok = False
+            continue
+
+        finite = np.isfinite(ref) & np.isfinite(test)
+        ref_f, test_f = ref[finite], test[finite]
+        n_skipped = int(ref.size - np.count_nonzero(finite))
+
+        if ref_f.size == 0:
+            lines.append(f"  {name}: no finite elements to compare  [SKIP]")
+            continue
+
+        max_abs = float(np.max(np.abs(ref_f - test_f)))
+
+        ref_norm = np.linalg.norm(ref_f)
+        diff_norm = np.linalg.norm(ref_f - test_f)
+        rel_l2 = float(diff_norm / ref_norm) if ref_norm > 0 else 0.0
+
+        dot = np.dot(ref_f, test_f)
+        norms = np.linalg.norm(ref_f) * np.linalg.norm(test_f)
+        cosine = float(dot / norms) if norms > 0 else 1.0
+
+        ok = cosine > 0.95
+        if not ok:
+            all_ok = False
+        status = "OK" if ok else "FAIL"
+
+        skip_note = f"  skipped={n_skipped}" if n_skipped else ""
+        lines.append(
+            f"  {name}: cosine={cosine:.6f}  rel_L2={rel_l2:.4e}"
+            f"  max_abs={max_abs:.4e}{skip_note}  [{status}]"
+        )
+
+    header = f"\n{'=' * 60}\n{label} accuracy vs CPU\n"
+    body = "\n".join(lines)
+    footer = f"\n{'=' * 60}"
+    report_str = header + body + footer
+    print(report_str)
+    return all_ok, report_str
+
+
+def get_amd_dml_providers():
+    """Return DML provider list targeting the AMD GPU, falling back to default."""
+    if "DmlExecutionProvider" not in ort.get_available_providers():
+        return None
+    try:
+        import subprocess
+
+        r = subprocess.run(
+            [
+                "powershell",
+                "-Command",
+                "Get-CimInstance Win32_VideoController | Select-Object -ExpandProperty Name",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        for i, line in enumerate(r.stdout.strip().splitlines()):
+            if "AMD" in line.upper() or "RADEON" in line.upper():
+                print(f"  DirectML: using device {i} ({line.strip()})")
+                return [
+                    ("DmlExecutionProvider", {"device_id": str(i)}),
+                    "CPUExecutionProvider",
+                ]
+    except Exception:
+        pass
+    return ["DmlExecutionProvider", "CPUExecutionProvider"]
+
+
+def register_morphizen_ep(repo_root):
+    """Register the MorphiZen EP library with ONNX Runtime (once per process)."""
+    global _morphizen_registered
+
+    dist_bin = repo_root / "install" / "dist" / "bin"
+    therock_bin = repo_root / "install" / "therock" / "bin"
+    ep_dll = dist_bin / EP_DLL_NAME
+
+    if not ep_dll.exists():
+        return None
+
+    for d in [dist_bin, therock_bin]:
+        if d.exists() and str(d) not in os.environ.get("PATH", ""):
+            os.environ["PATH"] = str(d) + os.pathsep + os.environ.get("PATH", "")
+
+    if not _morphizen_registered:
+        ort.register_execution_provider_library(EP_REGISTRATION_NAME, str(ep_dll))
+        _morphizen_registered = True
+
+    from onnxruntime.capi._pybind_state import get_ep_devices
+
+    devices = get_ep_devices()
+    return [d for d in devices if d.ep_name == EP_REGISTRATION_NAME]
+
+
+# ── IOBinding helpers ────────────────────────────────────────────────────────
+
+
+@dataclass
+class LlamaModelConfig:
+    num_kv_layers: int
+    num_kv_heads: int
+    head_dim: int
+    max_seq_len: int
+    has_position_ids: bool = False
+
+
+def make_llama_inputs(cfg: LlamaModelConfig) -> dict:
+    """Create decode-step inputs for a Llama model with pre-allocated KV cache."""
+    inputs = {
+        "input_ids": np.array([[1]], dtype=np.int64),
+        "attention_mask": np.ones((1, cfg.max_seq_len), dtype=np.int64),
+    }
+    if cfg.has_position_ids:
+        inputs["position_ids"] = np.array([[cfg.max_seq_len - 1]], dtype=np.int64)
+    for i in range(cfg.num_kv_layers):
+        inputs[f"past_key_values.{i}.key"] = np.zeros(
+            (1, cfg.num_kv_heads, cfg.max_seq_len, cfg.head_dim), dtype=np.float16
+        )
+        inputs[f"past_key_values.{i}.value"] = np.zeros(
+            (1, cfg.num_kv_heads, cfg.max_seq_len, cfg.head_dim), dtype=np.float16
+        )
+    return inputs
+
+
+def run_timed_iobinding(
+    sess, inputs, cfg: LlamaModelConfig, warmup=NUM_WARMUP, runs=NUM_RUNS
+):
+    """Run inference using IOBinding with shared past/present KV cache buffers.
+
+    Binds the same OrtValue to both past_key_values.N.{key,value} (input) and
+    present.N.{key,value} (output) so the runtime sees past_ptr == present_ptr.
+    """
+    io = sess.io_binding()
+
+    kv_shape = (1, cfg.num_kv_heads, cfg.max_seq_len, cfg.head_dim)
+    kv_cache = {}
+    for i in range(cfg.num_kv_layers):
+        for kind in ("key", "value"):
+            kv_cache[(i, kind)] = ort.OrtValue.ortvalue_from_numpy(
+                np.zeros(kv_shape, dtype=np.float16)
+            )
+
+    _ORT_TYPE_MAP = {
+        "tensor(float16)": np.float16,
+        "tensor(float)": np.float32,
+        "tensor(int64)": np.int64,
+        "tensor(int32)": np.int32,
+    }
+
+    output_vals = {}
+    for o in sess.get_outputs():
+        if o.name.startswith("present."):
+            continue
+        dtype = _ORT_TYPE_MAP.get(o.type, np.float32)
+        output_vals[o.name] = ort.OrtValue.ortvalue_from_shape_and_type(o.shape, dtype)
+
+    def bind_all():
+        io.clear_binding_inputs()
+        io.clear_binding_outputs()
+        for name, arr in inputs.items():
+            if name.startswith("past_key_values"):
+                continue
+            io.bind_ortvalue_input(name, ort.OrtValue.ortvalue_from_numpy(arr))
+        for i in range(cfg.num_kv_layers):
+            for kind in ("key", "value"):
+                val = kv_cache[(i, kind)]
+                io.bind_ortvalue_input(f"past_key_values.{i}.{kind}", val)
+                io.bind_ortvalue_output(f"present.{i}.{kind}", val)
+        for name, val in output_vals.items():
+            io.bind_ortvalue_output(name, val)
+
+    for _ in range(warmup):
+        bind_all()
+        sess.run_with_iobinding(io)
+
+    times = []
+    for _ in range(runs):
+        bind_all()
+        t0 = time.perf_counter()
+        sess.run_with_iobinding(io)
+        times.append(time.perf_counter() - t0)
+    return times
+
+
+# ── Shared fixtures ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="session")
+def repo_root():
+    return REPO_ROOT

--- a/test/python/test_llama1b.py
+++ b/test/python/test_llama1b.py
@@ -1,0 +1,127 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""Compare single-token decode latency: MorphiZen EP vs DirectML vs CPU.
+
+Model: Llama-3.2-1B-Instruct (q4f16) — 16 layers, 8 KV heads, head_dim 64.
+Uses IOBinding with shared KV cache buffers (past==present) to match OGA behavior.
+"""
+
+import onnxruntime as ort
+import pytest
+
+from conftest import (
+    REPO_ROOT,
+    LlamaModelConfig,
+    compare_outputs,
+    download,
+    fix_shapes,
+    get_amd_dml_providers,
+    make_llama_inputs,
+    register_morphizen_ep,
+    report,
+    run_timed,
+    run_timed_iobinding,
+)
+
+# ── Model config ─────────────────────────────────────────────────────────────
+
+_MODEL_DIR = REPO_ROOT / "models" / "Llama-3.2-1B-Instruct"
+_ONNX_FILE = "model_q4f16.onnx"
+_DATA_FILE = "model_q4f16.onnx_data"
+_FIXED_FILE = "model_q4f16_fixed_kv128.onnx"
+_HF_BASE = (
+    "https://huggingface.co/onnx-community/Llama-3.2-1B-Instruct-ONNX/resolve/main/onnx"
+)
+
+_CFG = LlamaModelConfig(
+    num_kv_layers=16,
+    num_kv_heads=8,
+    head_dim=64,
+    max_seq_len=128,
+)
+_DIM_MAP = {
+    "batch_size": 1,
+    "sequence_length": 1,
+    "past_sequence_length": _CFG.max_seq_len,
+    "total_sequence_length": _CFG.max_seq_len,
+}
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="session")
+def fixed_model_path():
+    _MODEL_DIR.mkdir(parents=True, exist_ok=True)
+    onnx_path = _MODEL_DIR / _ONNX_FILE
+    data_path = _MODEL_DIR / _DATA_FILE
+    fixed_path = _MODEL_DIR / _FIXED_FILE
+
+    if not onnx_path.exists():
+        download(f"{_HF_BASE}/{_ONNX_FILE}", onnx_path)
+    if not data_path.exists():
+        download(f"{_HF_BASE}/{_DATA_FILE}", data_path)
+    if not fixed_path.exists():
+        fix_shapes(onnx_path, fixed_path, _DIM_MAP)
+
+    return str(fixed_path)
+
+
+# ── Tests ────────────────────────────────────────────────────────────────────
+
+
+class TestLlama1BPerformance:
+    def test_dml_inference(self, fixed_model_path):
+        """Single-token decode latency — DirectML EP (AMD GPU)."""
+        providers = get_amd_dml_providers()
+        if providers is None:
+            pytest.skip("DmlExecutionProvider not available")
+
+        sess = ort.InferenceSession(fixed_model_path, providers=providers)
+        times = run_timed(sess, make_llama_inputs(_CFG))
+        report("DirectML", times)
+
+    def test_morphizen_ep_inference(self, fixed_model_path, repo_root):
+        """Single-token decode latency — MorphiZen (HIP DNN) EP."""
+        devices = register_morphizen_ep(repo_root)
+        if not devices:
+            pytest.skip("MorphiZen EP not found — run build.py first")
+
+        so = ort.SessionOptions()
+        so.add_provider_for_devices(devices, {})
+        sess = ort.InferenceSession(fixed_model_path, sess_options=so)
+
+        times = run_timed_iobinding(sess, make_llama_inputs(_CFG), _CFG)
+        report("MorphiZen EP", times)
+
+    def test_morphizen_ep_accuracy(self, fixed_model_path, repo_root):
+        """MorphiZen EP output accuracy vs CPU reference."""
+        devices = register_morphizen_ep(repo_root)
+        if not devices:
+            pytest.skip("MorphiZen EP not found — run build.py first")
+
+        inputs = make_llama_inputs(_CFG)
+
+        cpu_sess = ort.InferenceSession(
+            fixed_model_path, providers=["CPUExecutionProvider"]
+        )
+        ref = cpu_sess.run(None, inputs)
+        output_names = [o.name for o in cpu_sess.get_outputs()]
+
+        so = ort.SessionOptions()
+        so.add_provider_for_devices(devices, {})
+        ep_sess = ort.InferenceSession(fixed_model_path, sess_options=so)
+        test = ep_sess.run(None, inputs)
+
+        ok, _ = compare_outputs(ref, test, output_names, "MorphiZen EP (1B)")
+        assert ok, "MorphiZen EP accuracy check failed — see report above"
+
+    def test_cpu_inference(self, fixed_model_path):
+        """Single-token decode latency — CPU baseline."""
+        sess = ort.InferenceSession(
+            fixed_model_path, providers=["CPUExecutionProvider"]
+        )
+        times = run_timed(sess, make_llama_inputs(_CFG))
+        report("CPU (baseline)", times)

--- a/test/python/test_llama1b.py
+++ b/test/python/test_llama1b.py
@@ -93,7 +93,9 @@ class TestLlama1BPerformance:
         so.add_provider_for_devices(devices, {})
         sess = ort.InferenceSession(fixed_model_path, sess_options=so)
 
-        times = run_timed_iobinding(sess, make_llama_inputs(_CFG), _CFG)
+        times = run_timed_iobinding(
+            sess, make_llama_inputs(_CFG), _CFG, use_device_memory=True
+        )
         report("MorphiZen EP", times)
 
     def test_morphizen_ep_accuracy(self, fixed_model_path, repo_root):

--- a/test/python/test_llama8b.py
+++ b/test/python/test_llama8b.py
@@ -95,7 +95,9 @@ class TestLlama8BPerformance:
         so.add_provider_for_devices(devices, {})
         sess = ort.InferenceSession(fixed_model_path_8b, sess_options=so)
 
-        times = run_timed_iobinding(sess, make_llama_inputs(_CFG), _CFG)
+        times = run_timed_iobinding(
+            sess, make_llama_inputs(_CFG), _CFG, use_device_memory=True
+        )
         report("MorphiZen EP (8B)", times)
 
     def test_morphizen_ep_accuracy(self, fixed_model_path_8b, repo_root):

--- a/test/python/test_llama8b.py
+++ b/test/python/test_llama8b.py
@@ -1,0 +1,129 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""Compare single-token decode latency: MorphiZen EP vs DirectML vs CPU.
+
+Model: Meta-Llama-3.1-8B-Instruct (INT4) — 32 layers, 8 KV heads, head_dim 128.
+Uses IOBinding with shared KV cache buffers (past==present) to match OGA behavior.
+"""
+
+import onnxruntime as ort
+import pytest
+
+from conftest import (
+    REPO_ROOT,
+    LlamaModelConfig,
+    compare_outputs,
+    download,
+    fix_shapes,
+    get_amd_dml_providers,
+    make_llama_inputs,
+    register_morphizen_ep,
+    report,
+    run_timed,
+    run_timed_iobinding,
+)
+
+# ── Model config ─────────────────────────────────────────────────────────────
+
+_MODEL_DIR = REPO_ROOT / "models" / "Meta-Llama-3.1-8B-Instruct"
+_ONNX_FILE = "model.onnx"
+_DATA_FILE = "model.onnx.data"
+_FIXED_FILE = "model_fixed_kv128.onnx"
+_HF_BASE = (
+    "https://huggingface.co/onnx-community/"
+    "Meta-Llama-3.1-8B-Instruct-ONNX-DirectML-GenAI-INT4/resolve/main"
+)
+
+_CFG = LlamaModelConfig(
+    num_kv_layers=32,
+    num_kv_heads=8,
+    head_dim=128,
+    max_seq_len=128,
+    has_position_ids=True,
+)
+_DIM_MAP = {
+    "batch_size": 1,
+    "sequence_length": 1,
+    "past_sequence_length": _CFG.max_seq_len,
+    "total_sequence_length": _CFG.max_seq_len,
+}
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="session")
+def fixed_model_path_8b():
+    _MODEL_DIR.mkdir(parents=True, exist_ok=True)
+    onnx_path = _MODEL_DIR / _ONNX_FILE
+    data_path = _MODEL_DIR / _DATA_FILE
+    fixed_path = _MODEL_DIR / _FIXED_FILE
+
+    if not onnx_path.exists():
+        download(f"{_HF_BASE}/{_ONNX_FILE}", onnx_path)
+    if not data_path.exists():
+        download(f"{_HF_BASE}/{_DATA_FILE}", data_path)
+    if not fixed_path.exists():
+        fix_shapes(onnx_path, fixed_path, _DIM_MAP)
+
+    return str(fixed_path)
+
+
+# ── Tests ────────────────────────────────────────────────────────────────────
+
+
+class TestLlama8BPerformance:
+    def test_dml_inference(self, fixed_model_path_8b):
+        """Single-token decode latency — DirectML EP (AMD GPU)."""
+        providers = get_amd_dml_providers()
+        if providers is None:
+            pytest.skip("DmlExecutionProvider not available")
+
+        sess = ort.InferenceSession(fixed_model_path_8b, providers=providers)
+        times = run_timed(sess, make_llama_inputs(_CFG))
+        report("DirectML (8B)", times)
+
+    def test_morphizen_ep_inference(self, fixed_model_path_8b, repo_root):
+        """Single-token decode latency — MorphiZen (HIP DNN) EP."""
+        devices = register_morphizen_ep(repo_root)
+        if not devices:
+            pytest.skip("MorphiZen EP not found — run build.py first")
+
+        so = ort.SessionOptions()
+        so.add_provider_for_devices(devices, {})
+        sess = ort.InferenceSession(fixed_model_path_8b, sess_options=so)
+
+        times = run_timed_iobinding(sess, make_llama_inputs(_CFG), _CFG)
+        report("MorphiZen EP (8B)", times)
+
+    def test_morphizen_ep_accuracy(self, fixed_model_path_8b, repo_root):
+        """MorphiZen EP output accuracy vs CPU reference."""
+        devices = register_morphizen_ep(repo_root)
+        if not devices:
+            pytest.skip("MorphiZen EP not found — run build.py first")
+
+        inputs = make_llama_inputs(_CFG)
+
+        cpu_sess = ort.InferenceSession(
+            fixed_model_path_8b, providers=["CPUExecutionProvider"]
+        )
+        ref = cpu_sess.run(None, inputs)
+        output_names = [o.name for o in cpu_sess.get_outputs()]
+
+        so = ort.SessionOptions()
+        so.add_provider_for_devices(devices, {})
+        ep_sess = ort.InferenceSession(fixed_model_path_8b, sess_options=so)
+        test = ep_sess.run(None, inputs)
+
+        ok, _ = compare_outputs(ref, test, output_names, "MorphiZen EP (8B)")
+        assert ok, "MorphiZen EP accuracy check failed — see report above"
+
+    def test_cpu_inference(self, fixed_model_path_8b):
+        """Single-token decode latency — CPU baseline."""
+        sess = ort.InferenceSession(
+            fixed_model_path_8b, providers=["CPUExecutionProvider"]
+        )
+        times = run_timed(sess, make_llama_inputs(_CFG))
+        report("CPU baseline (8B)", times)

--- a/tools/hip-compiler/CMakeLists.txt
+++ b/tools/hip-compiler/CMakeLists.txt
@@ -4,6 +4,7 @@
 ##
 
 add_executable(hip-compiler hip-compiler.cpp)
+set_target_properties(hip-compiler PROPERTIES PDB_NAME "hip-compiler-cli")
 
 add_dependencies(hip-compiler
   HipDialectIncGen
@@ -15,6 +16,7 @@ add_dependencies(hip-compiler
 target_link_libraries(hip-compiler PRIVATE
   LibHipCompiler
   LLVMSupport
+  HipSupport
 )
 
 target_include_directories(hip-compiler PRIVATE

--- a/tools/hip-compiler/hip-compiler.cpp
+++ b/tools/hip-compiler/hip-compiler.cpp
@@ -8,7 +8,10 @@
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include "CrashHandler.h"
+
 int main(int argc, char **argv) {
+  hip::install_crash_handlers("hip-compiler");
   std::string inputFilename;
   std::string outputDll;
 

--- a/tools/hip-inspect-dll/CMakeLists.txt
+++ b/tools/hip-inspect-dll/CMakeLists.txt
@@ -12,6 +12,7 @@ llvm_map_components_to_libnames(llvm_libs Support)
 
 target_link_libraries(hip-inspect-dll
   PRIVATE
+  HipSupport
   ${llvm_libs}
 )
 

--- a/tools/hip-inspect-dll/hip-inspect-dll.cpp
+++ b/tools/hip-inspect-dll/hip-inspect-dll.cpp
@@ -17,6 +17,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "../common/DllLoader.h"
+#include "CrashHandler.h"
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4244) // Conversion warnings in LLVM JSON.h
@@ -151,6 +152,7 @@ static void printHelp(const char *argv0) {
 }
 
 int main(int argc, char **argv) {
+  hip::install_crash_handlers("hip-inspect-dll");
   std::string dllPath;
   bool dumpJson = false;
 

--- a/tools/hip-mlir-opt/CMakeLists.txt
+++ b/tools/hip-mlir-opt/CMakeLists.txt
@@ -13,6 +13,7 @@ add_dependencies(hip-mlir-opt
 )
 
 target_link_libraries(hip-mlir-opt PRIVATE
+  HipSupport
   LibHipCompiler
   HipDialectIR
   HipDialectTransforms

--- a/tools/hip-mlir-opt/hip-mlir-opt.cpp
+++ b/tools/hip-mlir-opt/hip-mlir-opt.cpp
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+#include "CrashHandler.h"
 #include "hip/Dialect/IR/HipDialect.h"
 #include "hip/Dialect/Transforms/Passes.h"
 #include "hip/Dialect/Transforms/Pipelines.h"
@@ -143,6 +144,7 @@ void registerHipBufferizableOpInterfaceModels(mlir::DialectRegistry &registry) {
 } // namespace
 
 int main(int argc, char **argv) {
+  hip::install_crash_handlers("hip-mlir-opt");
   mlir::DialectRegistry registry;
   registry.insert<mlir::BuiltinDialect>();
   registry.insert<mlir::arith::ArithDialect>();

--- a/tools/hip-onnx-runner/CMakeLists.txt
+++ b/tools/hip-onnx-runner/CMakeLists.txt
@@ -9,16 +9,21 @@ if(NOT onnxruntime_FOUND)
   return()
 endif()
 
-add_executable(hip-onnx-runner hip-onnx-runner.cpp)
+add_executable(hip-onnx-runner
+  hip-onnx-runner.cpp
+  ${CMAKE_SOURCE_DIR}/lib/Support/CrashHandler.cpp
+)
 
 target_compile_features(hip-onnx-runner PRIVATE cxx_std_17)
 
 target_include_directories(hip-onnx-runner PRIVATE
   ${CMAKE_SOURCE_DIR}/include  # Shared project headers (timing.h, etc.)
+  ${CMAKE_SOURCE_DIR}/lib/Support  # CrashHandler.h
 )
 
 target_link_libraries(hip-onnx-runner PRIVATE
   onnxruntime::onnxruntime
+  cpptrace::cpptrace
 )
 
 install(TARGETS hip-onnx-runner

--- a/tools/hip-onnx-runner/hip-onnx-runner.cpp
+++ b/tools/hip-onnx-runner/hip-onnx-runner.cpp
@@ -34,6 +34,7 @@ Options:
 
 #include <onnxruntime_cxx_api.h>
 
+#include "CrashHandler.h"
 #include "hip/timing.h"
 #include <algorithm>
 #include <cctype>
@@ -795,6 +796,7 @@ static int run_l2norm_output_dumps(const std::string &dir1_str,
 // ---------------------------------------------------------------------------
 
 int main(int argc, char *argv[]) {
+  hip::install_crash_handlers("hip-onnx-runner");
   MiniOptions mo;
   mo.add_option("m", "model", "Path to .onnx model", "");
   mo.add_option("L", "l2norm",

--- a/tools/hip-test-dll/CMakeLists.txt
+++ b/tools/hip-test-dll/CMakeLists.txt
@@ -13,6 +13,7 @@ llvm_map_components_to_libnames(llvm_libs Support)
 
 target_link_libraries(hip-test-dll
   PRIVATE
+  HipSupport
   ${llvm_libs}
 )
 

--- a/tools/hip-test-dll/hip-test-dll.cpp
+++ b/tools/hip-test-dll/hip-test-dll.cpp
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "../common/DllLoader.h"
+#include "CrashHandler.h"
 #include "hip/Support/DiskFileSystem.h"
 #ifdef _MSC_VER
 #pragma warning(push)
@@ -306,6 +307,7 @@ static bool parseMetadata(const char *json_str, std::vector<TensorMeta> &inputs,
 }
 
 int main(int argc, char **argv) {
+  hip::install_crash_handlers("hip-test-dll");
   if (argc < 2) {
     std::cerr << "Usage: " << argv[0]
               << " <model.dll> [--input-shape INDEX=DIMS;...] [--iterations N] "


### PR DESCRIPTION
## Summary

  - **Per-operator GPU profiling** (`HIPDNN_EP_PERF=1`): RAII `OP_PROFILE` macro records HIP event timings across all 17 runtime ops, prints grouped table with shape sub-rows at stream sync. Zero overhead when disabled.
  - **Crash handlers**: cpptrace-based stack traces on unhandled exceptions, registered in EP DLL and all 6 CLI tools.
  - **GQA fixes**: per-session GEMM descriptor cache (was global), `local_window_size <= 0` fix (ONNX uses `-1` for no windowing), `stream_sync` wired into generated MLIR interface.
  - **Device memory in tests**: IOBinding tests use EP's `hipHostMalloc` GPU allocator for KV cache — enables `memory_type` aliasing (zero H2D/D2H, GQA CPU overhead drops from 87 ms to 0.1 ms).
  - **Python test infra**: `conftest.py` (IOBinding, model download, accuracy comparison), Llama 1B/8B benchmarks, `build.py` wrapper, `CLAUDE.md`, `environment.yml`.
  - **Win32 env var fix**: `debug_log.h` uses `GetEnvironmentVariableA` instead of `_dupenv_s` for static CRT compatibility.

  ## Performance (Llama 3.1 8B INT4, single-token decode, gfx1150)

  | | Latency (ms) | Throughput (tok/s) |
  |---|---:|---:|
  | **Baseline** (decomposed GQA path) | ~83 | 12.0 |
  | **With fix** (fused GQA decode path) | ~67 | 14.9 |
  | **Improvement** | **19% faster** | **+25%** |

  The fused decode path (rope + KV append + attention in one kernel) eliminates the decomposed hipBLASLt GEMM sequence and its associated D2H synchronization overhead.

  ### Per-op profiling breakdown

  ```
      [PERF] inference #3:
       H2D:     67 tensors, 16778256 bytes (16.0 MB), 1.00 ms
       Compute: 87.63 ms
       D2H:     65 tensors, 17033728 bytes (16.2 MB), 7.30 ms
       Total:   95.94 ms  (H2D 1.0% | Compute 91.3% | D2H 7.6%)

     [PERF] ===============================================================
     [PERF]                                calls  gpu (ms)  cpu (ms)  gpu %
     [PERF]  matmul_nbits                    225      66.0       0.5  77.0%
     [PERF]    m=1,n=14336,k=4096             64      29.1       0.1  33.9%
     [PERF]    m=1,n=4096,k=14336             32      14.0       0.1  16.4%
     [PERF]    m=1,n=4096,k=4096              64      12.9       0.1  15.1%
     [PERF]    m=1,n=1024,k=4096              64       6.2       0.2   7.2%
     [PERF]    m=1,n=128256,k=4096             1       3.8       0.0   4.4%
     [PERF]  skip_layernorm                   64       5.3       0.3   6.2%
     [PERF]    1x4096                         64       5.3       0.3   6.2%
     [PERF]  rotary_emb                       64       4.3       0.1   5.0%
     [PERF]    h=32,d=128                     32       2.2       0.1   2.6%
     [PERF]    h=8,d=128                      32       2.1       0.1   2.4%
     [PERF]  gqa                              32       4.3       0.1   5.0%
     [PERF]    b=1,sq=1,skv=128,h=32,d=128    32       4.3       0.1   5.0%
     [PERF]  elementwise                      64       3.3       0.2   3.8%
     [PERF]    1x1x1x14336                    64       3.3       0.2   3.8%
     [PERF]  activation                       32       2.2       0.1   2.5%
     [PERF]    n=14336                        32       2.2       0.1   2.5%
     [PERF]  reduce_sum                        1       0.1       0.0   0.1%
     [PERF]    128->1                          1       0.1       0.0   0.1%
     [PERF]  layernorm                         1       0.1       0.0   0.1%
     [PERF]    1x4096                          1       0.1       0.0   0.1%
     [PERF]  cast                              1       0.1       0.0   0.1%
     [PERF]    n=1                             1       0.1       0.0   0.1%
     [PERF]  gather                            1       0.1       0.0   0.1%
     [PERF]    n=4096                          1       0.1       0.0   0.1%
     [PERF]  sub                               1       0.1       0.0   0.1%
     [PERF]    n=1                             1       0.1       0.0   0.1%
     [PERF]  stream_sync                       1       n/a      85.8    n/a
     [PERF]  TOTAL                                    85.7      87.2
     [PERF] ===============================================================
  ```

  ## Test plan

  - [x] `python build.py` — clean build
  - [x] `pytest test_llama8b.py::test_morphizen_ep_accuracy` — all 65 outputs cosine > 0.999995
  - [x] `pytest test_llama8b.py::test_morphizen_ep_inference` — 89 ms avg, zero H2D/D2H
  - [x] `HIPDNN_EP_PERF=1` — per-op profiling table prints correctly, no CPU overhead on GPU ops