### PR TITLE
fix(gemm,qmoe,gqa,matmul): unblock gpt-oss-120b end-to-end (4 fixes)

### DIFF
--- a/lib/Conversion/OnnxToHip/QMoEConversion.cpp
+++ b/lib/Conversion/OnnxToHip/QMoEConversion.cpp
@@ -88,9 +88,38 @@ QMoEToHip::matchAndRewrite(mlir::Operation *op,
   auto kIntAttr = op->getAttrOfType<mlir::IntegerAttr>("k");
   auto kAttr = rewriter.getI64IntegerAttr(kIntAttr ? kIntAttr.getSInt() : 1);
 
+  // ms.QMoE's `block_size` attribute is documented as optional (no spec
+  // default) and is omitted by some quantization tools (e.g. AWQ exports of
+  // gpt-oss-120b). Without it `wrap_qmoe` later divides by zero. When the
+  // attribute is absent or non-positive, derive block_size from the
+  // FC1 (gate_up_proj) scales tensor: scales has shape
+  //     [num_experts, output_features, k_blocks_fc1]
+  // with k_blocks_fc1 = ceil(hidden_size / block_size) and the activation
+  // input has shape [..., hidden_size]. So
+  //     block_size = ceil(hidden_size / k_blocks_fc1)
+  // which gives the exact value when the model uses an even split (the
+  // common case).
   auto blockSizeIntAttr = op->getAttrOfType<mlir::IntegerAttr>("block_size");
-  auto blockSizeAttr = rewriter.getI64IntegerAttr(
-      blockSizeIntAttr ? blockSizeIntAttr.getSInt() : 0);
+  int64_t blockSizeValue = blockSizeIntAttr ? blockSizeIntAttr.getSInt() : 0;
+  if (blockSizeValue <= 0) {
+    auto inputType = mlir::dyn_cast<mlir::RankedTensorType>(input.getType());
+    auto scalesType =
+        mlir::dyn_cast<mlir::RankedTensorType>(fc1Scales.getType());
+    if (inputType && scalesType && inputType.getRank() > 0 &&
+        scalesType.getRank() > 0) {
+      int64_t hiddenDim = inputType.getShape().back();
+      int64_t kBlocksDim = scalesType.getShape().back();
+      if (hiddenDim > 0 && kBlocksDim > 0) {
+        blockSizeValue = (hiddenDim + kBlocksDim - 1) / kBlocksDim;
+      }
+    }
+  }
+  if (blockSizeValue <= 0) {
+    return rewriter.notifyMatchFailure(
+        op, "QMoE: missing `block_size` attribute and cannot infer it from "
+            "input/fc1_scales tensor shapes");
+  }
+  auto blockSizeAttr = rewriter.getI64IntegerAttr(blockSizeValue);
 
   auto normIntAttr =
       op->getAttrOfType<mlir::IntegerAttr>("normalize_routing_weights");

--- a/lib/Runtime/real/gemm.cpp
+++ b/lib/Runtime/real/gemm.cpp
@@ -111,6 +111,18 @@ static bool resolveGemmMiopenType(int64_t typeCode, miopenDataType_t &dt) {
   }
 }
 
+// MIOpen contract for miopenOpTensor: the A-operand descriptor and the
+// destination descriptor must have *identical* shapes; only the B operand may
+// broadcast. The previous implementation passed the small bias descriptor
+// (cDesc) as both A and B while the destination was the full-output descriptor,
+// which MIOpen rejected with "A and C Tensors do not match" (status 7) any time
+// the bias actually needed broadcasting (e.g. a [1,N] bias onto [M,N]).
+//
+// Fix: zero the output buffer, then compute
+//     output = 1.0 * output + beta * broadcast(C)
+// so the A operand and destination both use outDesc and only B (the bias)
+// broadcasts. Pre-zeroing avoids dependency on uninitialized output (which
+// could contain NaNs that 1.0*NaN would propagate).
 static int broadcastBiasToOutput(RuntimeState *state, const void *C,
                                  void *output, int64_t M, int64_t N,
                                  int64_t cDim0, int64_t cDim1, float beta,
@@ -122,6 +134,13 @@ static int broadcastBiasToOutput(RuntimeState *state, const void *C,
     return -1;
   }
 
+  hipStream_t stream =
+      static_cast<hipStream_t>(hipdnn_ep_state_get_stream(state));
+  if (!stream) {
+    fprintf(stderr, "wrap_gemm: broadcastBiasToOutput: null stream\n");
+    return -1;
+  }
+
   miopenDataType_t dt;
   if (!resolveGemmMiopenType(typeCode, dt)) {
     fprintf(stderr,
@@ -130,10 +149,25 @@ static int broadcastBiasToOutput(RuntimeState *state, const void *C,
     return -1;
   }
 
+  size_t elemSize = (typeCode == kTypeFloat64)   ? 8
+                    : (typeCode == kTypeFloat32) ? 4
+                                                 : 2; // fp16 / bf16
+
   RUNTIME_DEBUG_LOG("[REAL] wrap_gemm: broadcastBiasToOutput C[%lld,%lld] -> "
                     "[%lld,%lld], beta=%f\n",
                     (long long)cDim0, (long long)cDim1, (long long)M,
                     (long long)N, beta);
+
+  // Pre-zero the destination so 1.0*output contributes 0 in the op below.
+  size_t outBytes = static_cast<size_t>(M) * static_cast<size_t>(N) * elemSize;
+  hipError_t hipErr = hipMemsetAsync(output, 0, outBytes, stream);
+  if (hipErr != hipSuccess) {
+    fprintf(stderr,
+            "wrap_gemm: broadcastBiasToOutput: hipMemsetAsync(%zu bytes) "
+            "failed (%d): %s\n",
+            outBytes, (int)hipErr, hipGetErrorString(hipErr));
+    return -1;
+  }
 
   miopenTensorDescriptor_t cDesc = nullptr;
   miopenTensorDescriptor_t outDesc = nullptr;
@@ -147,15 +181,18 @@ static int broadcastBiasToOutput(RuntimeState *state, const void *C,
   MIOPEN_CHECK(miopenSet4dTensorDescriptor(
       outDesc, dt, 1, 1, static_cast<int>(M), static_cast<int>(N)));
 
-  // output = beta * (C + 0 * C) + 0 * output = beta * C_broadcast
+  // output = 1.0 * output + beta * broadcast(C) + 0 * output
+  //        = beta * broadcast(C)              (since output was zeroed)
   if (typeCode == kTypeFloat64) {
-    double alpha1 = static_cast<double>(beta), alpha2 = 0.0, beta_c = 0.0;
-    MIOPEN_CHECK(miopenOpTensor(handle, miopenTensorOpAdd, &alpha1, cDesc, C,
-                                &alpha2, cDesc, C, &beta_c, outDesc, output));
+    double alpha1 = 1.0, alpha2 = static_cast<double>(beta), beta_c = 0.0;
+    MIOPEN_CHECK(miopenOpTensor(handle, miopenTensorOpAdd, &alpha1, outDesc,
+                                output, &alpha2, cDesc, C, &beta_c, outDesc,
+                                output));
   } else {
-    float alpha1 = beta, alpha2 = 0.0f, beta_c = 0.0f;
-    MIOPEN_CHECK(miopenOpTensor(handle, miopenTensorOpAdd, &alpha1, cDesc, C,
-                                &alpha2, cDesc, C, &beta_c, outDesc, output));
+    float alpha1 = 1.0f, alpha2 = beta, beta_c = 0.0f;
+    MIOPEN_CHECK(miopenOpTensor(handle, miopenTensorOpAdd, &alpha1, outDesc,
+                                output, &alpha2, cDesc, C, &beta_c, outDesc,
+                                output));
   }
 
 cleanup:

--- a/lib/Runtime/real/gemm.cpp
+++ b/lib/Runtime/real/gemm.cpp
@@ -78,6 +78,12 @@ struct GemmCacheKeyHash {
 struct GemmCacheEntry {
   hipblasLtMatmulAlgo_t algo;
   size_t workspace_size;
+  // True if no heuristic algorithm could be found and we should fall back to
+  // hipblasLtMatmul(..., algo=nullptr, ws=nullptr, ws_size=0). This unblocks
+  // outlier shapes where gfx1151's Tensile library has no tile (e.g. router
+  // M=128 N=128 K=2880 and lm_head M=128 N=201088 K=2880) but the default
+  // internal kernel still works.
+  bool use_default_algo = false;
 };
 
 static std::unordered_map<GemmCacheKey, GemmCacheEntry, GemmCacheKeyHash>
@@ -355,35 +361,65 @@ int wrap_gemm(RuntimeState *state, const void *A, const void *B, const void *C,
         matmul_desc, HIPBLASLT_MATMUL_DESC_TRANSB, &opB, sizeof(opB)));
   }
 
-  // Algorithm selection with caching
+  // Algorithm selection with caching.
+  //
+  // hipblasLtMatmulAlgoGetHeuristic is sensitive to (workspace_limit,
+  // request_count): for outlier shapes such as the gpt-oss-120b MoE router
+  // (M=128 N=128 K=2880) and lm_head (M=128 N=201088 K=2880) the default
+  // (256MB, 1) returns HIPBLAS_STATUS_INVALID_VALUE on gfx1151's Tensile
+  // library because no tiled algorithm satisfies the leading-dimension /
+  // small-N constraints. Try a small escalation ladder so common outlier
+  // shapes pick up a non-tiled or larger-candidate-set algorithm:
+  //   1. (256MB, 1)         original behaviour
+  //   2. (0,     1)         force non-workspace algo
+  //                          (often unblocks narrow N or huge ld)
+  //   3. (256MB, 16)        broader candidate sweep
+  //   4. (0,     16)        non-workspace + broader sweep
   if (it == g_gemm_algo_cache.end()) {
-    HIPBLAS_CHECK(hipblasLtMatmulPreferenceCreate(&pref));
-    const size_t max_ws = 256ULL << 20; // 256 MB
-    HIPBLAS_CHECK(hipblasLtMatmulPreferenceSetAttribute(
-        pref, HIPBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES, &max_ws,
-        sizeof(max_ws)));
-
-    hipblasLtMatmulHeuristicResult_t heur;
+    constexpr int kMaxCandidates = 16;
+    hipblasLtMatmulHeuristicResult_t heurs[kMaxCandidates];
     int returned = 0;
-    HIPBLAS_CHECK(hipblasLtMatmulAlgoGetHeuristic(
-        handle, matmul_desc, matA_layout, matB_layout, matC_layout, matC_layout,
-        pref, 1, &heur, &returned));
-    hipblasLtMatmulPreferenceDestroy(pref);
-    pref = nullptr;
 
-    if (returned == 0) {
-      fprintf(stderr,
-              "wrap_gemm: no algorithm found for M=%lld N=%lld K=%lld "
-              "transA=%lld transB=%lld typeCode=%lld\n",
-              (long long)M, (long long)N, (long long)K, (long long)transA,
-              (long long)transB, (long long)typeCode);
-      result = -1;
-      goto cleanup;
-    }
+    auto try_heuristic = [&](size_t ws_bytes, int req_count) -> bool {
+      hipblasLtMatmulPreference_t local_pref = nullptr;
+      if (hipblasLtMatmulPreferenceCreate(&local_pref) !=
+          HIPBLAS_STATUS_SUCCESS) {
+        return false;
+      }
+      hipblasLtMatmulPreferenceSetAttribute(
+          local_pref, HIPBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES, &ws_bytes,
+          sizeof(ws_bytes));
+      returned = 0;
+      hipblasStatus_t st = hipblasLtMatmulAlgoGetHeuristic(
+          handle, matmul_desc, matA_layout, matB_layout, matC_layout,
+          matC_layout, local_pref, req_count, heurs, &returned);
+      hipblasLtMatmulPreferenceDestroy(local_pref);
+      return st == HIPBLAS_STATUS_SUCCESS && returned > 0;
+    };
+
+    bool ok = try_heuristic(256ULL << 20, 1) || try_heuristic(0, 1) ||
+              try_heuristic(256ULL << 20, kMaxCandidates) ||
+              try_heuristic(0, kMaxCandidates);
 
     GemmCacheEntry entry;
-    entry.algo = heur.algo;
-    entry.workspace_size = heur.workspaceSize;
+    if (ok) {
+      entry.algo = heurs[0].algo;
+      entry.workspace_size = heurs[0].workspaceSize;
+      entry.use_default_algo = false;
+    } else {
+      // Final fallback: let hipBLASLt pick its internal default kernel by
+      // passing algo=nullptr at call time. This is what hipblas.cpp's fp32
+      // GEMM already does unconditionally and it's the documented escape
+      // hatch when the heuristic can't satisfy the layout constraints.
+      fprintf(stderr,
+              "wrap_gemm: no algorithm from heuristic for M=%lld N=%lld "
+              "K=%lld transA=%lld transB=%lld typeCode=%lld; falling back "
+              "to default algo (algo=nullptr, ws=0)\n",
+              (long long)M, (long long)N, (long long)K, (long long)transA,
+              (long long)transB, (long long)typeCode);
+      entry.workspace_size = 0;
+      entry.use_default_algo = true;
+    }
     it = g_gemm_algo_cache.emplace(key, entry).first;
 
     RUNTIME_DEBUG_LOG("[REAL] wrap_gemm: cached algo for M=%lld N=%lld K=%lld "
@@ -402,23 +438,28 @@ int wrap_gemm(RuntimeState *state, const void *A, const void *B, const void *C,
       }
     }
 
-    void *ws_ptr = hipdnn_ep_state_get_workspace(state);
-    size_t ws_size = hipdnn_ep_state_get_workspace_size(state);
+    void *ws_ptr = cached.use_default_algo
+                       ? nullptr
+                       : hipdnn_ep_state_get_workspace(state);
+    size_t ws_size =
+        cached.use_default_algo ? 0 : hipdnn_ep_state_get_workspace_size(state);
+    hipblasLtMatmulAlgo_t *algo_ptr =
+        cached.use_default_algo
+            ? nullptr
+            : const_cast<hipblasLtMatmulAlgo_t *>(&cached.algo);
 
     if (typeCode == kTypeFloat64) {
       double alpha_d = static_cast<double>(alpha);
       double beta_d = static_cast<double>(effective_beta);
       HIPBLAS_CHECK(hipblasLtMatmul(
           handle, matmul_desc, &alpha_d, B, matA_layout, A, matB_layout,
-          &beta_d, effective_C, matC_layout, output, matC_layout,
-          const_cast<hipblasLtMatmulAlgo_t *>(&cached.algo), ws_ptr, ws_size,
-          stream));
+          &beta_d, effective_C, matC_layout, output, matC_layout, algo_ptr,
+          ws_ptr, ws_size, stream));
     } else {
       HIPBLAS_CHECK(hipblasLtMatmul(
           handle, matmul_desc, &alpha, B, matA_layout, A, matB_layout,
           &effective_beta, effective_C, matC_layout, output, matC_layout,
-          const_cast<hipblasLtMatmulAlgo_t *>(&cached.algo), ws_ptr, ws_size,
-          stream));
+          algo_ptr, ws_ptr, ws_size, stream));
     }
   }
 

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -297,19 +297,27 @@ static int gqa_forward_hipblaslt(
         return -1;
       }
 
-      int64_t total_seq = static_cast<int64_t>(seqlens_k_val) + 1;
-      int64_t past_len_check = total_seq - sq;
-      if (total_seq < 1 || past_len_check < 0 || total_seq > present_seq ||
-          past_len_check > past_buf_seq) {
-        fprintf(stderr,
-                "gqa_forward_hipblaslt (fused decode): invalid "
-                "seqlens_k[0]+1=%lld (sq=%lld, past_len=%lld, "
-                "present_seq=%lld, past_buf_seq=%lld)\n",
-                (long long)total_seq, (long long)sq, (long long)past_len_check,
-                (long long)present_seq, (long long)past_buf_seq);
-        return -1;
+      // ORT prefill sentinel: when there is no past KV yet, the producer
+      // initialises seqlens_k[b] to -1 (so seqlens_k[b]+1 == 0). Treat that
+      // as a fresh prefill (past_len=0) instead of rejecting it as invalid.
+      if (seqlens_k_val < 0) {
+        past_len = 0;
+      } else {
+        int64_t total_seq = static_cast<int64_t>(seqlens_k_val) + 1;
+        int64_t past_len_check = total_seq - sq;
+        if (total_seq < 1 || past_len_check < 0 || total_seq > present_seq ||
+            past_len_check > past_buf_seq) {
+          fprintf(stderr,
+                  "gqa_forward_hipblaslt (fused decode): invalid "
+                  "seqlens_k[0]+1=%lld (sq=%lld, past_len=%lld, "
+                  "present_seq=%lld, past_buf_seq=%lld)\n",
+                  (long long)total_seq, (long long)sq,
+                  (long long)past_len_check, (long long)present_seq,
+                  (long long)past_buf_seq);
+          return -1;
+        }
+        past_len = past_len_check;
       }
-      past_len = past_len_check;
     } else if (!seqlens_k_ptr) {
       past_len = skv - sq;
     }
@@ -402,17 +410,25 @@ static int gqa_forward_hipblaslt(
       if (hipStreamSynchronize(stream) != hipSuccess)
         return -1;
     }
-    total_seq = static_cast<int64_t>(seqlens_k_val) + 1;
-    past_len = total_seq - sq;
-    if (total_seq < 1 || past_len < 0 || total_seq > present_seq ||
-        past_len > past_buf_seq) {
-      fprintf(stderr,
-              "gqa_forward_hipblaslt: invalid seqlens_k[0]+1=%lld "
-              "(sq=%lld, past_len=%lld, present_seq=%lld, "
-              "past_buf_seq=%lld)\n",
-              (long long)total_seq, (long long)sq, (long long)past_len,
-              (long long)present_seq, (long long)past_buf_seq);
-      return -1;
+    // ORT prefill sentinel: when there is no past KV yet, the producer
+    // initialises seqlens_k[b] to -1. Treat that as a fresh prefill
+    // (past_len=0, total_seq=sq) instead of rejecting it as invalid.
+    if (seqlens_k_val < 0) {
+      total_seq = sq;
+      past_len = 0;
+    } else {
+      total_seq = static_cast<int64_t>(seqlens_k_val) + 1;
+      past_len = total_seq - sq;
+      if (total_seq < 1 || past_len < 0 || total_seq > present_seq ||
+          past_len > past_buf_seq) {
+        fprintf(stderr,
+                "gqa_forward_hipblaslt: invalid seqlens_k[0]+1=%lld "
+                "(sq=%lld, past_len=%lld, present_seq=%lld, "
+                "past_buf_seq=%lld)\n",
+                (long long)total_seq, (long long)sq, (long long)past_len,
+                (long long)present_seq, (long long)past_buf_seq);
+        return -1;
+      }
     }
   }
   if (past_len < 0)

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -300,6 +300,7 @@ static int gqa_forward_hipblaslt(
       // ORT prefill sentinel: when there is no past KV yet, the producer
       // initialises seqlens_k[b] to -1 (so seqlens_k[b]+1 == 0). Treat that
       // as a fresh prefill (past_len=0) instead of rejecting it as invalid.
+      // IR fixture: test/lit/Conversion/onnx-to-hip/test_gqa_prefill_sentinel.mlir
       if (seqlens_k_val < 0) {
         past_len = 0;
       } else {
@@ -413,6 +414,7 @@ static int gqa_forward_hipblaslt(
     // ORT prefill sentinel: when there is no past KV yet, the producer
     // initialises seqlens_k[b] to -1. Treat that as a fresh prefill
     // (past_len=0, total_seq=sq) instead of rejecting it as invalid.
+    // IR fixture: test/lit/Conversion/onnx-to-hip/test_gqa_prefill_sentinel.mlir
     if (seqlens_k_val < 0) {
       total_seq = sq;
       past_len = 0;

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -300,7 +300,8 @@ static int gqa_forward_hipblaslt(
       // ORT prefill sentinel: when there is no past KV yet, the producer
       // initialises seqlens_k[b] to -1 (so seqlens_k[b]+1 == 0). Treat that
       // as a fresh prefill (past_len=0) instead of rejecting it as invalid.
-      // IR fixture: test/lit/Conversion/onnx-to-hip/test_gqa_prefill_sentinel.mlir
+      // IR fixture:
+      // test/lit/Conversion/onnx-to-hip/test_gqa_prefill_sentinel.mlir
       if (seqlens_k_val < 0) {
         past_len = 0;
       } else {
@@ -414,7 +415,8 @@ static int gqa_forward_hipblaslt(
     // ORT prefill sentinel: when there is no past KV yet, the producer
     // initialises seqlens_k[b] to -1. Treat that as a fresh prefill
     // (past_len=0, total_seq=sq) instead of rejecting it as invalid.
-    // IR fixture: test/lit/Conversion/onnx-to-hip/test_gqa_prefill_sentinel.mlir
+    // IR fixture:
+    // test/lit/Conversion/onnx-to-hip/test_gqa_prefill_sentinel.mlir
     if (seqlens_k_val < 0) {
       total_seq = sq;
       past_len = 0;

--- a/lib/Runtime/real/matmul.cpp
+++ b/lib/Runtime/real/matmul.cpp
@@ -71,6 +71,11 @@ struct MatmulCacheEntry {
   bool tuned;
   int num_candidates;
   size_t max_candidate_workspace;
+  // True if no heuristic algorithm could be found and we should fall back to
+  // hipblasLtMatmul(..., algo=nullptr, ws=nullptr, ws_size=0). Lets gfx1151
+  // outliers (e.g. lm_head M=128 N=201088 K=2880) use hipBLASLt's internal
+  // default kernel when its Tensile library has no matching tile.
+  bool use_default_algo;
   hipblasLtMatmulHeuristicResult_t candidates[MAX_ALGO_CANDIDATES];
 };
 
@@ -138,45 +143,76 @@ static MatmulCacheEntry *queryOrCreateMatmul(hipblasLtHandle_t handle,
         sizeof(sC)));
   }
 
-  MATMUL_CACHE_CHECK(hipblasLtMatmulPreferenceCreate(&pref));
-  {
-    const size_t max_ws = kMaxWorkspaceBytes;
-    MATMUL_CACHE_CHECK(hipblasLtMatmulPreferenceSetAttribute(
-        pref, HIPBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES, &max_ws,
-        sizeof(max_ws)));
-  }
-
+  // Algorithm selection with escalating fallback.
+  //
+  // hipblasLtMatmulAlgoGetHeuristic is sensitive to (workspace_limit,
+  // request_count): for outlier shapes such as the gpt-oss-120b lm_head
+  // (M=128 N=201088 K=2880, ld=N) it returns 0 algorithms / status 3 with
+  // the default (256MB, 1) on gfx1151's Tensile library because no tiled
+  // algorithm satisfies the leading-dimension constraint. Try a small
+  // escalation ladder so common outlier shapes pick up a non-tiled or
+  // larger-candidate-set algorithm:
+  //   1. (256MB, requested)   original behaviour
+  //   2. (0,     requested)   force non-workspace (often unblocks huge ld)
+  //   3. (256MB, MAX)         broader candidate sweep
+  //   4. (0,     MAX)         non-workspace + broader sweep
   {
     bool do_autotune = autotune_enabled();
     int request_count = do_autotune ? MAX_ALGO_CANDIDATES : 1;
 
     int returned = 0;
-    hipblasLtMatmulAlgoGetHeuristic(handle, entry.desc, entry.layA, entry.layB,
-                                    entry.layC, entry.layC, pref, request_count,
-                                    entry.candidates, &returned);
-    hipblasLtMatmulPreferenceDestroy(pref);
-    pref = nullptr;
+    auto try_heuristic = [&](size_t ws_bytes, int req_count) -> bool {
+      hipblasLtMatmulPreference_t local_pref = nullptr;
+      if (hipblasLtMatmulPreferenceCreate(&local_pref) !=
+          HIPBLAS_STATUS_SUCCESS) {
+        return false;
+      }
+      hipblasLtMatmulPreferenceSetAttribute(
+          local_pref, HIPBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES, &ws_bytes,
+          sizeof(ws_bytes));
+      returned = 0;
+      hipblasStatus_t s = hipblasLtMatmulAlgoGetHeuristic(
+          handle, entry.desc, entry.layA, entry.layB, entry.layC, entry.layC,
+          local_pref, req_count, entry.candidates, &returned);
+      hipblasLtMatmulPreferenceDestroy(local_pref);
+      return s == HIPBLAS_STATUS_SUCCESS && returned > 0;
+    };
 
-    if (returned == 0) {
+    bool ok = try_heuristic(kMaxWorkspaceBytes, request_count) ||
+              try_heuristic(0, request_count) ||
+              try_heuristic(kMaxWorkspaceBytes, MAX_ALGO_CANDIDATES) ||
+              try_heuristic(0, MAX_ALGO_CANDIDATES);
+
+    if (!ok) {
+      // Final fallback: let hipBLASLt pick its internal default kernel by
+      // passing algo=nullptr at call time. This keeps the cached layout/desc
+      // so we don't pay create cost again, but avoids the heuristic on a
+      // shape gfx1151's Tensile library has no tile for.
       fprintf(stderr,
-              "queryOrCreateMatmul: no algo for M=%lld N=%lld K=%lld "
-              "batch=%lld\n",
+              "queryOrCreateMatmul: no algo from heuristic for M=%lld "
+              "N=%lld K=%lld batch=%lld; falling back to default algo "
+              "(algo=nullptr, ws=0)\n",
               (long long)M, (long long)N, (long long)K,
               (long long)key.batch_count);
-      goto cache_fail;
-    }
-
-    entry.num_candidates = returned;
-    entry.algo = entry.candidates[0].algo;
-    entry.workspace_size = entry.candidates[0].workspaceSize;
-
-    if (do_autotune) {
-      for (int i = 0; i < returned; i++)
-        entry.max_candidate_workspace = std::max(
-            entry.max_candidate_workspace, entry.candidates[i].workspaceSize);
-      entry.tuned = (returned <= 1);
-    } else {
+      entry.num_candidates = 0;
+      entry.workspace_size = 0;
+      entry.max_candidate_workspace = 0;
+      entry.use_default_algo = true;
       entry.tuned = true;
+    } else {
+      entry.num_candidates = returned;
+      entry.algo = entry.candidates[0].algo;
+      entry.workspace_size = entry.candidates[0].workspaceSize;
+      entry.use_default_algo = false;
+
+      if (do_autotune) {
+        for (int i = 0; i < returned; i++)
+          entry.max_candidate_workspace = std::max(
+              entry.max_candidate_workspace, entry.candidates[i].workspaceSize);
+        entry.tuned = (returned <= 1);
+      } else {
+        entry.tuned = true;
+      }
     }
   }
 
@@ -373,13 +409,21 @@ int wrap_hipblasLtMatmul(RuntimeState *state, const void *A, const void *B,
   float alpha = 1.0f;
   float beta = 0.0f;
 
+  // For shapes the heuristic could not satisfy (use_default_algo), pass
+  // algo=nullptr and zero workspace to let hipBLASLt use its internal default.
+  hipblasLtMatmulAlgo_t *algo_ptr =
+      cached->use_default_algo
+          ? nullptr
+          : const_cast<hipblasLtMatmulAlgo_t *>(&cached->algo);
+  void *call_ws_ptr = cached->use_default_algo ? nullptr : ws_ptr;
+  size_t call_ws_size = cached->use_default_algo ? 0 : ws_size;
+
   hipblasStatus_t st =
       hipblasLtMatmul(handle, cached->desc, &alpha, B,
                       cached->layA,    // "A" = B (row->col trick)
                       A, cached->layB, // "B" = A (row->col trick)
                       &beta, output, cached->layC, output, cached->layC,
-                      const_cast<hipblasLtMatmulAlgo_t *>(&cached->algo),
-                      ws_ptr, ws_size, stream);
+                      algo_ptr, call_ws_ptr, call_ws_size, stream);
 
   if (st != HIPBLAS_STATUS_SUCCESS) {
     fprintf(stderr, "wrap_hipblasLtMatmul: hipblasLtMatmul failed (%d)\n", st);

--- a/lib/Runtime/real/qmoe.cpp
+++ b/lib/Runtime/real/qmoe.cpp
@@ -55,10 +55,32 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
   }
 
   RUNTIME_DEBUG_LOG("[REAL] wrap_qmoe(tokens=%lld, hidden=%lld, inter=%lld, "
-                    "experts=%lld, k=%lld, bits=%lld, elem=%lld)\n",
+                    "experts=%lld, k=%lld, bits=%lld, block=%lld, elem=%lld)\n",
                     (long long)num_tokens, (long long)hidden_size,
                     (long long)inter_size, (long long)num_experts, (long long)k,
-                    (long long)expert_weight_bits, (long long)elem_size);
+                    (long long)expert_weight_bits, (long long)block_size,
+                    (long long)elem_size);
+
+  // Guard against pathological metadata: block_size==0 would otherwise crash
+  // with STATUS_INTEGER_DIVIDE_BY_ZERO inside the k_blocks computations below
+  // (and produces invalid quant layouts even at >0 if not a multiple of 2).
+  if (block_size <= 0 || (block_size & 1) != 0) {
+    fprintf(stderr,
+            "wrap_qmoe: invalid block_size=%lld (must be a positive even "
+            "value matching the weights' quant block layout)\n",
+            (long long)block_size);
+    return -1;
+  }
+  if (hidden_size <= 0 || inter_size <= 0 || num_experts <= 0 || k <= 0 ||
+      num_tokens <= 0 || elem_size <= 0) {
+    fprintf(stderr,
+            "wrap_qmoe: invalid sizes (tokens=%lld hidden=%lld inter=%lld "
+            "experts=%lld k=%lld elem=%lld)\n",
+            (long long)num_tokens, (long long)hidden_size,
+            (long long)inter_size, (long long)num_experts, (long long)k,
+            (long long)elem_size);
+    return -1;
+  }
 
   void *stream = hipdnn_ep_state_get_stream(state);
   if (!stream) {

--- a/lib/Runtime/real/qmoe.cpp
+++ b/lib/Runtime/real/qmoe.cpp
@@ -201,11 +201,10 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
       // `packed_cols = (groups_k + 1) / 2` in
       // 3rd-party/custom_kernels/hip/matmul_nbits_kernel.hip and the
       // hard-coded `zp_elem_size = 1` we pass to hip_matmul_nbits below.
-      const void *fc1_zp_e = fc1_zero_points
-                                 ? static_cast<const char *>(fc1_zero_points) +
-                                       e * fusion_inter *
-                                           ((k_blocks_fc1 + 1) / 2)
-                                 : nullptr;
+      const void *fc1_zp_e =
+          fc1_zero_points ? static_cast<const char *>(fc1_zero_points) +
+                                e * fusion_inter * ((k_blocks_fc1 + 1) / 2)
+                          : nullptr;
       const void *fc1_b_e = fc1_bias ? static_cast<const char *>(fc1_bias) +
                                            e * fusion_inter * elem_size
                                      : nullptr;
@@ -233,11 +232,10 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
       const char *fc2_s_e = static_cast<const char *>(fc2_scales) +
                             e * hidden_size * k_blocks_fc2 * elem_size;
       // See fc1_zp_e comment above -- same packed-nibble layout for fc2.
-      const void *fc2_zp_e = fc2_zero_points
-                                 ? static_cast<const char *>(fc2_zero_points) +
-                                       e * hidden_size *
-                                           ((k_blocks_fc2 + 1) / 2)
-                                 : nullptr;
+      const void *fc2_zp_e =
+          fc2_zero_points ? static_cast<const char *>(fc2_zero_points) +
+                                e * hidden_size * ((k_blocks_fc2 + 1) / 2)
+                          : nullptr;
       const void *fc2_b_e = fc2_bias ? static_cast<const char *>(fc2_bias) +
                                            e * hidden_size * elem_size
                                      : nullptr;

--- a/lib/Runtime/real/qmoe.cpp
+++ b/lib/Runtime/real/qmoe.cpp
@@ -189,9 +189,22 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
                             e * fusion_inter * k_blocks_fc1 * blob_size_fc1;
       const char *fc1_s_e = static_cast<const char *>(fc1_scales) +
                             e * fusion_inter * k_blocks_fc1 * elem_size;
+      // Per-expert ZP slice: ONNX MatMulNBits with bits=4 stores
+      // zero_points as uint8 packed nibbles (two 4-bit values per byte),
+      // so the per-row size is ceil(k_blocks/2) bytes, NOT k_blocks. Using
+      // the unpacked stride here makes expert e read ZPs from a region 2x
+      // too large, overshooting into the next expert's bytes; downstream
+      // dequantization grows ~10x per MoE layer until fp16 overflows
+      // (router_probs becomes Inf -> SSLN T5LN emits NaN -> topk routing
+      // returns -1 for every token -> 0/N experts active from layer ~3 on
+      // -> garbage logits). Matches `convertZpToFp16`'s
+      // `packed_cols = (groups_k + 1) / 2` in
+      // 3rd-party/custom_kernels/hip/matmul_nbits_kernel.hip and the
+      // hard-coded `zp_elem_size = 1` we pass to hip_matmul_nbits below.
       const void *fc1_zp_e = fc1_zero_points
                                  ? static_cast<const char *>(fc1_zero_points) +
-                                       e * fusion_inter * k_blocks_fc1
+                                       e * fusion_inter *
+                                           ((k_blocks_fc1 + 1) / 2)
                                  : nullptr;
       const void *fc1_b_e = fc1_bias ? static_cast<const char *>(fc1_bias) +
                                            e * fusion_inter * elem_size
@@ -219,9 +232,11 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
                             e * hidden_size * k_blocks_fc2 * blob_size_fc2;
       const char *fc2_s_e = static_cast<const char *>(fc2_scales) +
                             e * hidden_size * k_blocks_fc2 * elem_size;
+      // See fc1_zp_e comment above -- same packed-nibble layout for fc2.
       const void *fc2_zp_e = fc2_zero_points
                                  ? static_cast<const char *>(fc2_zero_points) +
-                                       e * hidden_size * k_blocks_fc2
+                                       e * hidden_size *
+                                           ((k_blocks_fc2 + 1) / 2)
                                  : nullptr;
       const void *fc2_b_e = fc2_bias ? static_cast<const char *>(fc2_bias) +
                                            e * hidden_size * elem_size

--- a/test/lit/Conversion/hip-to-llvm/test_qmoe_packed_zp.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_qmoe_packed_zp.mlir
@@ -1,0 +1,110 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify hip.qmoe with optional fc1_zero_points and fc2_zero_points operands
+// is correctly lowered to llvm.call @wrap_qmoe with non-null ZP pointers.
+//
+// This test validates:
+// - Pointer extraction for optional ZP operands when present (non-null)
+// - Spec-correct uint8 packed-nibble ZP layout for bits=4:
+//     memref<num_experts x output_features x ceil(k_blocks/2) x ui8>
+//   The runtime then strides by `e * N * ceil(k_blocks/2)` per expert
+//   (lib/Runtime/real/qmoe.cpp, fix in commit 0918fdf).
+// - Companion to the existing test_qmoe.mlir (which exercises bias-only and
+//   no-optional-operands paths). Together they cover the {fc1_b, fc2_b,
+//   fc1_zp, fc2_zp} optional-operand matrix.
+// ============================================================================
+
+// RUN: hip-mlir-opt --convert-hip-to-llvm %s | FileCheck %s
+
+module {
+  // ===== Test 1: QMoE with fc1 + fc2 zero_points (no biases) =====
+  //
+  // ZP shape uses spec-correct ceil(k_blocks/2) packing: ceil(90/2) = 45.
+
+  func.func @test_qmoe_with_zp(%ctx: !hip.context,
+      %input: memref<1x128x2880xf16, 1>,
+      %router: memref<128x32xf16, 1>,
+      %fc1_w: memref<32x5760x1440xui8, 1>,
+      %fc1_s: memref<32x5760x90xf16, 1>,
+      %fc2_w: memref<32x2880x1440xui8, 1>,
+      %fc2_s: memref<32x2880x90xf16, 1>,
+      %fc1_zp: memref<32x5760x45xui8, 1>,
+      %fc2_zp: memref<32x2880x45xui8, 1>,
+      %output: memref<1x128x2880xf16, 1>) {
+    hip.qmoe(%ctx) ins(
+        %input, %router,
+        %fc1_w, %fc1_s,
+        %fc2_w, %fc2_s :
+        memref<1x128x2880xf16, 1>, memref<128x32xf16, 1>,
+        memref<32x5760x1440xui8, 1>, memref<32x5760x90xf16, 1>,
+        memref<32x2880x1440xui8, 1>, memref<32x2880x90xf16, 1>)
+        fc1_zero_points(%fc1_zp : memref<32x5760x45xui8, 1>)
+        fc2_zero_points(%fc2_zp : memref<32x2880x45xui8, 1>)
+        outs(%output : memref<1x128x2880xf16, 1>)
+        {expert_weight_bits = 4 : i64, k = 4 : i64, block_size = 32 : i64,
+         normalize_routing_weights = 1 : i64, swiglu_fusion = 1 : i64,
+         use_sparse_mixer = 0 : i64,
+         activation_alpha = 1.702000e+00 : f32, activation_beta = 1.000000e+00 : f32,
+         swiglu_limit = 7.000000e+00 : f32, activation_type = "swiglu"}
+    return
+  }
+
+  // CHECK-LABEL: llvm.func @test_qmoe_with_zp
+  // CHECK: llvm.call @wrap_qmoe({{.*}}) :
+  // CHECK-SAME: (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr,
+  // CHECK-SAME:  !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr,
+  // CHECK-SAME:  i64, i64, i64, i64, i64, i64, i64, i64, i64, f32, f32, f32, i64, i64) -> i32
+  // Verify 30 parameters (same shape as test_qmoe.mlir):
+  // - 16 pointers: state, input, router, fc1_w, fc1_s, fc1_b(null), fc2_w, fc2_s, fc2_b(null),
+  //                fc3_w(null), fc3_s(null), fc3_b(null), fc1_zp, fc2_zp, fc3_zp(null), output
+  // - 11 i64 + 3 f32 attributes
+  // The fc1_zp / fc2_zp pointers MUST be non-null (extracted from the memref
+  // descriptors), unlike the all-null path covered by test_qmoe.mlir.
+
+  // ===== Test 2: QMoE with all four optional operands (biases + ZPs) =====
+  //
+  // Exercises the operand-segment grouping when both bias and ZP groups are
+  // active simultaneously - this is the gpt-oss-120b prefill shape.
+
+  func.func @test_qmoe_with_bias_and_zp(%ctx: !hip.context,
+      %input: memref<1x128x2880xf16, 1>,
+      %router: memref<128x32xf16, 1>,
+      %fc1_w: memref<32x5760x1440xui8, 1>,
+      %fc1_s: memref<32x5760x90xf16, 1>,
+      %fc2_w: memref<32x2880x1440xui8, 1>,
+      %fc2_s: memref<32x2880x90xf16, 1>,
+      %fc1_b: memref<32x5760xf16, 1>,
+      %fc2_b: memref<32x2880xf16, 1>,
+      %fc1_zp: memref<32x5760x45xui8, 1>,
+      %fc2_zp: memref<32x2880x45xui8, 1>,
+      %output: memref<1x128x2880xf16, 1>) {
+    hip.qmoe(%ctx) ins(
+        %input, %router,
+        %fc1_w, %fc1_s,
+        %fc2_w, %fc2_s :
+        memref<1x128x2880xf16, 1>, memref<128x32xf16, 1>,
+        memref<32x5760x1440xui8, 1>, memref<32x5760x90xf16, 1>,
+        memref<32x2880x1440xui8, 1>, memref<32x2880x90xf16, 1>)
+        fc1_bias(%fc1_b : memref<32x5760xf16, 1>)
+        fc2_bias(%fc2_b : memref<32x2880xf16, 1>)
+        fc1_zero_points(%fc1_zp : memref<32x5760x45xui8, 1>)
+        fc2_zero_points(%fc2_zp : memref<32x2880x45xui8, 1>)
+        outs(%output : memref<1x128x2880xf16, 1>)
+        {expert_weight_bits = 4 : i64, k = 4 : i64, block_size = 32 : i64,
+         normalize_routing_weights = 1 : i64, swiglu_fusion = 1 : i64,
+         use_sparse_mixer = 0 : i64,
+         activation_alpha = 1.702000e+00 : f32, activation_beta = 1.000000e+00 : f32,
+         swiglu_limit = 7.000000e+00 : f32, activation_type = "swiglu"}
+    return
+  }
+
+  // CHECK-LABEL: llvm.func @test_qmoe_with_bias_and_zp
+  // CHECK: llvm.call @wrap_qmoe({{.*}}) :
+  // CHECK-SAME: (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr,
+  // CHECK-SAME:  !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr,
+  // CHECK-SAME:  i64, i64, i64, i64, i64, i64, i64, i64, i64, f32, f32, f32, i64, i64) -> i32
+  // 16 pointers, four of which (fc1_b, fc2_b, fc1_zp, fc2_zp) must be non-null.
+}

--- a/test/lit/Conversion/onnx-to-hip/test_gqa_prefill_sentinel.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_gqa_prefill_sentinel.mlir
@@ -1,0 +1,81 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Document and lock-in the contract that ORT's GQA producer may pass a
+// `seqlens_k` constant tensor of all `-1` to signal a fresh prefill (no past
+// KV cache yet). The runtime fix in commit ecd443f makes
+// `gqa_forward_hipblaslt` treat `seqlens_k_val < 0` as `past_len = 0` instead
+// of rejecting it as an invalid index.
+//
+// This is an IR-level fixture only - the conversion pass does not interpret
+// the contents of `seqlens_k`. The runtime branch is exercised by the
+// MatMulNBits/GQA accuracy tests in CI; here we simply prove the conversion
+// continues to lower the op cleanly when `seqlens_k` is a constant -1
+// (encoded as i32 splat 0xFFFFFFFF).
+//
+// Companion runtime: lib/Runtime/real/gqa.cpp `if (seqlens_k_val < 0)`
+// branch (around lines 305 and 418) - see the in-source comment that
+// references this test.
+// ============================================================================
+
+// RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
+
+module {
+  // ===========================================================================
+  // Test: GQA prefill with seqlens_k = constant -1 (fresh prefill sentinel)
+  // ===========================================================================
+  //
+  // Shapes mirror Test 2 in test_gqa.mlir (packed-QKV prefill, sq=128) but
+  // with `seqlens_k` materialised as a constant -1 tensor instead of being a
+  // function argument. The lit test verifies the conversion still lowers
+  // cleanly to hip.gqa; the runtime sentinel branch is what actually consumes
+  // the value.
+  func.func @test_gqa_prefill_sentinel(
+      %query: tensor<1x128x12288xf16>,
+      %past_key: tensor<1x8x0x128xf16>,
+      %past_value: tensor<1x8x0x128xf16>,
+      %total_seq_len: tensor<i32>)
+      -> (tensor<1x128x4096xf16>, tensor<1x8x128x128xf16>, tensor<1x8x128x128xf16>) {
+
+    // CHECK-LABEL: func.func @test_gqa_prefill_sentinel
+    // CHECK-SAME: (%[[CTX:.*]]: !hip.context,
+
+    // ORT prefill sentinel: seqlens_k[b] = -1 means "no past KV yet, this
+    // is the first prefill step". onnx int32 splat -1 == dense<-1>.
+    %seqlens_k = "onnx.Constant"() {value = dense<-1> : tensor<1xi32>} : () -> tensor<1xi32>
+
+    %none_key = "onnx.NoValue"() {value} : () -> none
+    %none_value = "onnx.NoValue"() {value} : () -> none
+    %none1 = "onnx.NoValue"() {value} : () -> none
+    %none2 = "onnx.NoValue"() {value} : () -> none
+
+    %out:3 = "onnx.Custom"(%query, %none_key, %none_value, %past_key, %past_value,
+                            %seqlens_k, %total_seq_len, %none1, %none2)
+        <{function_name = "GroupQueryAttention"}>
+        {domain_name = "com.microsoft",
+         num_heads = 32 : si64,
+         kv_num_heads = 8 : si64,
+         scale = 0.0883883461 : f32,
+         softcap = 0.000000e+00 : f32,
+         do_rotary = 0 : si64,
+         rotary_interleaved = 0 : si64}
+        : (tensor<1x128x12288xf16>, none, none,
+           tensor<1x8x0x128xf16>, tensor<1x8x0x128xf16>,
+           tensor<1xi32>, tensor<i32>, none, none)
+        -> (tensor<1x128x4096xf16>, tensor<1x8x128x128xf16>, tensor<1x8x128x128xf16>)
+
+    // The constant -1 must reach the conversion intact and the op must
+    // lower cleanly to hip.gqa. We do not need to inspect the constant
+    // value in the lowered IR - it is consumed at runtime.
+    // CHECK: onnx.Constant
+    // CHECK-SAME: dense<-1> : tensor<1xi32>
+    // CHECK: hip.gqa(%[[CTX]])
+    // CHECK-SAME: kv_num_heads = 8
+    // CHECK-SAME: num_heads = 32
+    // CHECK-NOT: onnx.Custom
+
+    return %out#0, %out#1, %out#2 : tensor<1x128x4096xf16>, tensor<1x8x128x128xf16>, tensor<1x8x128x128xf16>
+  }
+}

--- a/test/lit/Conversion/onnx-to-hip/test_qmoe_no_block_size.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_qmoe_no_block_size.mlir
@@ -1,0 +1,94 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify the QMoE conversion derives `block_size` from operand shapes when
+// the attribute is missing on the ONNX custom op (regression coverage for
+// commit 3c503f5 "QMoEConversion: derive block_size from fc1_scales when
+// the attribute is absent").
+//
+// AWQ exports of gpt-oss-120b (and similar models) omit the `block_size`
+// attribute from QMoE nodes; without this derivation `wrap_qmoe` later
+// divides by zero. The conversion derives:
+//
+//     block_size = ceil(hidden_size / k_blocks)
+//
+// where `hidden_size = input.shape.back()` and
+// `k_blocks = fc1_scales.shape.back()`.
+//
+// This test validates two shape configurations:
+//   1. Per-group: fc1_scales [E, N, 90], hidden=2880 -> block_size = 32
+//   2. Per-channel: fc1_scales [E, N, 1], hidden=2880 -> block_size = 2880
+//      (succeeds in the conversion pass; runtime guard in
+//      lib/Runtime/real/qmoe.cpp may further restrict it)
+// ============================================================================
+
+// RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
+
+module {
+  // ===== Test 1: Per-group scales [E, N, 90], derive block_size = 32 =====
+  //
+  // Note: NO `block_size` attribute on the onnx.Custom op below. The
+  // conversion must derive it from input.shape.back()=2880 divided by
+  // fc1_scales.shape.back()=90, yielding 32.
+  func.func @main_graph(
+      %input: tensor<1x128x2880xf16>,
+      %router_probs: tensor<128x32xf16>) -> tensor<1x128x2880xf16> {
+    %fc1_w = "onnx.Constant"() {value = dense<1> : tensor<32x5760x1440xui8>} : () -> tensor<32x5760x1440xui8>
+    %fc1_s = "onnx.Constant"() {value = dense<1.000000e+00> : tensor<32x5760x90xf16>} : () -> tensor<32x5760x90xf16>
+    %fc2_w = "onnx.Constant"() {value = dense<1> : tensor<32x2880x1440xui8>} : () -> tensor<32x2880x1440xui8>
+    %fc2_s = "onnx.Constant"() {value = dense<1.000000e+00> : tensor<32x2880x90xf16>} : () -> tensor<32x2880x90xf16>
+    %Y = "onnx.Custom"(%input, %router_probs, %fc1_w, %fc1_s, %fc2_w, %fc2_s) {
+      function_name = "QMoE",
+      domain_name = "com.microsoft",
+      activation_alpha = 1.702000e+00 : f32, activation_beta = 1.000000e+00 : f32,
+      activation_type = "swiglu",
+      expert_weight_bits = 4 : si64, k = 4 : si64,
+      normalize_routing_weights = 1 : si64, swiglu_fusion = 1 : si64,
+      swiglu_limit = 7.000000e+00 : f32, use_sparse_mixer = 0 : si64,
+      onnx_node_name = "QMoE_no_block_size_per_group"
+    } : (tensor<1x128x2880xf16>, tensor<128x32xf16>,
+         tensor<32x5760x1440xui8>, tensor<32x5760x90xf16>,
+         tensor<32x2880x1440xui8>, tensor<32x2880x90xf16>) -> tensor<1x128x2880xf16>
+    return %Y : tensor<1x128x2880xf16>
+  }
+
+  // CHECK-LABEL: func.func @main_graph
+  // CHECK: hip.qmoe
+  // CHECK-SAME: block_size = 32
+  // CHECK-NOT: onnx.Custom
+
+  // ===== Test 2: Per-channel scales [E, N, 1], derive block_size = 2880 =====
+  //
+  // With one scale per output row (k_blocks=1), the derived block_size
+  // collapses to hidden_size. Conversion still succeeds; this documents the
+  // contract that the pass is shape-driven and does not impose its own
+  // even/positive constraint on the derived value (the runtime does).
+  func.func @test_per_channel(
+      %input: tensor<1x128x2880xf16>,
+      %router_probs: tensor<128x32xf16>) -> tensor<1x128x2880xf16> {
+    %fc1_w = "onnx.Constant"() {value = dense<1> : tensor<32x5760x1440xui8>} : () -> tensor<32x5760x1440xui8>
+    %fc1_s = "onnx.Constant"() {value = dense<1.000000e+00> : tensor<32x5760x1xf16>} : () -> tensor<32x5760x1xf16>
+    %fc2_w = "onnx.Constant"() {value = dense<1> : tensor<32x2880x1440xui8>} : () -> tensor<32x2880x1440xui8>
+    %fc2_s = "onnx.Constant"() {value = dense<1.000000e+00> : tensor<32x2880x1xf16>} : () -> tensor<32x2880x1xf16>
+    %Y = "onnx.Custom"(%input, %router_probs, %fc1_w, %fc1_s, %fc2_w, %fc2_s) {
+      function_name = "QMoE",
+      domain_name = "com.microsoft",
+      activation_alpha = 1.702000e+00 : f32, activation_beta = 1.000000e+00 : f32,
+      activation_type = "swiglu",
+      expert_weight_bits = 4 : si64, k = 4 : si64,
+      normalize_routing_weights = 1 : si64, swiglu_fusion = 1 : si64,
+      swiglu_limit = 7.000000e+00 : f32, use_sparse_mixer = 0 : si64,
+      onnx_node_name = "QMoE_no_block_size_per_channel"
+    } : (tensor<1x128x2880xf16>, tensor<128x32xf16>,
+         tensor<32x5760x1440xui8>, tensor<32x5760x1xf16>,
+         tensor<32x2880x1440xui8>, tensor<32x2880x1xf16>) -> tensor<1x128x2880xf16>
+    return %Y : tensor<1x128x2880xf16>
+  }
+
+  // CHECK-LABEL: func.func @test_per_channel
+  // CHECK: hip.qmoe
+  // CHECK-SAME: block_size = 2880
+  // CHECK-NOT: onnx.Custom
+}

--- a/test/lit/Conversion/onnx-to-hip/test_qmoe_packed_zp.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_qmoe_packed_zp.mlir
@@ -1,0 +1,109 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify ONNX QMoE custom op with optional zero_points operands (asymmetric
+// quantization) is correctly lowered to hip.qmoe in tensor-first mode.
+//
+// This test validates:
+// - QMoE lowering with both fc1_zero_points and fc2_zero_points operands
+//   present (operand indices 11 and 12 of the 14-input ONNX schema)
+// - Spec-correct uint8 packed-nibble zero_points layout for bits=4:
+//     shape [num_experts, output_features, ceil(k_blocks/2)]
+//   (NOT the unpacked [num_experts, output_features, k_blocks] layout)
+// - The fc3_* slots (operand indices 8, 9, 10) are correctly bypassed via
+//   onnx.NoValue placeholders so the ZP operands land at the right indices
+// - Both ZP operands are propagated through the conversion to the hip.qmoe
+//   `fc1_zero_points` and `fc2_zero_points` operand groups
+//
+// Companion runtime: lib/Runtime/real/qmoe.cpp slices these per-expert with
+// stride `e * N * ((k_blocks + 1) / 2)` matching the packed-nibble layout
+// (commit 0918fdf "fix(qmoe): use packed-nibble stride for per-expert
+// zero_points slice").
+// ============================================================================
+
+// RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
+
+module {
+  // ===== QMoE with fc1 and fc2 zero_points (no biases, no fc3) =====
+  //
+  // Shapes (matching gpt-oss-120b family but with num_experts=32 for brevity):
+  //   input          : [1, 128, 2880]                       hidden_size = 2880
+  //   router_probs   : [128, 32]                            num_experts = 32
+  //   fc1 weights    : [32, 5760, 1440]  packed uint4       fusion_inter = 5760
+  //                                                         k_blocks * blob = 90*16 = 1440
+  //   fc1 scales     : [32, 5760, 90]    fp16, per-group    k_blocks = 90
+  //   fc1 zero_points: [32, 5760, 45]    uint8 packed nibbles, ceil(90/2) = 45
+  //   fc2 weights    : [32, 2880, 1440]
+  //   fc2 scales     : [32, 2880, 90]
+  //   fc2 zero_points: [32, 2880, 45]
+  //
+  // ONNX QMoE operand order (14 slots, missing optional ones use onnx.NoValue):
+  //   [0]  input
+  //   [1]  router_probs
+  //   [2]  fc1_weights
+  //   [3]  fc1_scales
+  //   [4]  fc1_bias        (none here)
+  //   [5]  fc2_weights
+  //   [6]  fc2_scales
+  //   [7]  fc2_bias        (none here)
+  //   [8]  fc3_weights     (none - swiglu_fusion=1)
+  //   [9]  fc3_scales      (none - swiglu_fusion=1)
+  //   [10] fc3_bias        (none - swiglu_fusion=1)
+  //   [11] fc1_zero_points (PRESENT)
+  //   [12] fc2_zero_points (PRESENT)
+  //   [13] fc3_zero_points (none - swiglu_fusion=1)
+  func.func @main_graph(
+      %input: tensor<1x128x2880xf16>,
+      %router_probs: tensor<128x32xf16>) -> tensor<1x128x2880xf16> {
+    %fc1_w = "onnx.Constant"() {value = dense<1> : tensor<32x5760x1440xui8>} : () -> tensor<32x5760x1440xui8>
+    %fc1_s = "onnx.Constant"() {value = dense<1.000000e+00> : tensor<32x5760x90xf16>} : () -> tensor<32x5760x90xf16>
+    %fc2_w = "onnx.Constant"() {value = dense<1> : tensor<32x2880x1440xui8>} : () -> tensor<32x2880x1440xui8>
+    %fc2_s = "onnx.Constant"() {value = dense<1.000000e+00> : tensor<32x2880x90xf16>} : () -> tensor<32x2880x90xf16>
+    // Spec-correct packed-nibble layout: ceil(k_blocks/2) = ceil(90/2) = 45
+    %fc1_zp = "onnx.Constant"() {value = dense<8> : tensor<32x5760x45xui8>} : () -> tensor<32x5760x45xui8>
+    %fc2_zp = "onnx.Constant"() {value = dense<8> : tensor<32x2880x45xui8>} : () -> tensor<32x2880x45xui8>
+    // None placeholders for fc1_bias, fc2_bias, fc3_w, fc3_s, fc3_bias
+    %none_fc1b = "onnx.NoValue"() {value} : () -> none
+    %none_fc2b = "onnx.NoValue"() {value} : () -> none
+    %none_fc3w = "onnx.NoValue"() {value} : () -> none
+    %none_fc3s = "onnx.NoValue"() {value} : () -> none
+    %none_fc3b = "onnx.NoValue"() {value} : () -> none
+    %Y = "onnx.Custom"(%input, %router_probs,
+                        %fc1_w, %fc1_s, %none_fc1b,
+                        %fc2_w, %fc2_s, %none_fc2b,
+                        %none_fc3w, %none_fc3s, %none_fc3b,
+                        %fc1_zp, %fc2_zp) {
+      function_name = "QMoE",
+      domain_name = "com.microsoft",
+      activation_alpha = 1.702000e+00 : f32, activation_beta = 1.000000e+00 : f32,
+      activation_type = "swiglu",
+      block_size = 32 : si64, expert_weight_bits = 4 : si64, k = 4 : si64,
+      normalize_routing_weights = 1 : si64, swiglu_fusion = 1 : si64,
+      swiglu_limit = 7.000000e+00 : f32, use_sparse_mixer = 0 : si64,
+      onnx_node_name = "QMoE_packed_zp"
+    } : (tensor<1x128x2880xf16>, tensor<128x32xf16>,
+         tensor<32x5760x1440xui8>, tensor<32x5760x90xf16>, none,
+         tensor<32x2880x1440xui8>, tensor<32x2880x90xf16>, none,
+         none, none, none,
+         tensor<32x5760x45xui8>, tensor<32x2880x45xui8>) -> tensor<1x128x2880xf16>
+    return %Y : tensor<1x128x2880xf16>
+  }
+
+  // CHECK-LABEL: func.func @main_graph
+  // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[INPUT:.*]]: tensor<1x128x2880xf16>, %[[ROUTER:.*]]: tensor<128x32xf16>)
+  // CHECK: %[[INIT:.*]] = tensor.empty() : tensor<1x128x2880xf16>
+  // CHECK: hip.qmoe(%[[CTX]]) ins(
+  // CHECK-SAME: tensor<1x128x2880xf16>, tensor<128x32xf16>,
+  // CHECK-SAME: tensor<32x5760x1440xui8>, tensor<32x5760x90xf16>,
+  // CHECK-SAME: tensor<32x2880x1440xui8>, tensor<32x2880x90xf16>)
+  // The packed-nibble zero_points must reach hip.qmoe's named operand groups
+  // with their spec-correct shapes preserved.
+  // CHECK-SAME: fc1_zero_points(%{{.*}} : tensor<32x5760x45xui8>)
+  // CHECK-SAME: fc2_zero_points(%{{.*}} : tensor<32x2880x45xui8>)
+  // CHECK-SAME: outs(%[[INIT]] : tensor<1x128x2880xf16>)
+  // CHECK-SAME: expert_weight_bits = 4
+  // CHECK-SAME: k = 4
+  // CHECK-NOT: onnx.Custom
+}


### PR DESCRIPTION
## Summary

Four fixes that together unblock gpt-oss-120b end-to-end through the MorphiZen EP. They walk together because each downstream bug only becomes reachable after the upstream one is fixed: the runtime aborts before fix 2 without fix 1, and so on. After all four, the model executes all 36 transformer layers without aborting and without any cascade-to-NaN inside the inference. (One unfixed accuracy gap remains and is summarized in the [Out of scope](#out-of-scope) section.)

---

### 1. MIOpen broadcast contract — `lib/Runtime/real/gemm.cpp` (commit `3c503f5`, also in #165)

**What went wrong.** `broadcastBiasToOutput` called `miopenOpTensor` with `cDesc` (the small bias) for both A and B, but MIOpen requires the A-operand descriptor to equal the destination descriptor. Result: `A and C Tensors do not match` (status 7) at `gemm.cpp:158` for any broadcastable bias — notably the MoE router MatMul.

**What I did.** Pre-zero the destination, then compute `output = 1.0*output + beta*broadcast(C)` with `aDesc == outDesc == cDesc(dest)` and only the bias broadcasting on the B side.

---

### 2. QMoE `block_size` derivation — `lib/Conversion/OnnxToHip/QMoEConversion.cpp`, `lib/Runtime/real/qmoe.cpp` (commit `3c503f5`)

**What went wrong.** `QMoE`'s `block_size` attribute is documented as optional; AWQ exports of gpt-oss-120b omit it. The conversion pass defaulted it silently to 0, causing `STATUS_INTEGER_DIVIDE_BY_ZERO` (`0xC0000094`) inside `wrap_qmoe`'s `k_blocks` computations.

**What I did.** Derive `block_size = ceil(hidden_size / k_blocks_fc1)` from the FC1 (gate_up_proj) scales tensor shape when the attribute is missing. Add a runtime guard so any future regression surfaces as a readable error instead of a divide-by-zero exception.

---

### 3. GQA prefill sentinel + hipBLASLt heuristic fallback — `lib/Runtime/real/{gqa,gemm,matmul}.cpp` (commit `ecd443f`)

**What went wrong.**
- *GQA prefill:* ORT passes `seqlens_k[b] = -1` on the first prefill step (no past KV). Both `gqa_forward_hipblaslt` branches computed `total_seq = -1+1 = 0` and `past_len = -sq` and rejected with `invalid seqlens_k[0]+1=0`.
- *hipBLASLt heuristic:* `hipblasLtMatmulAlgoGetHeuristic` returns 0 algorithms / status 3 for outlier shapes on gfx1151's Tensile library — MoE router MatMul (`M=128 N=128 K=2880`, very small N) and lm_head MatMul (`M=128 N=201088 K=2880`, very large N).

**What I did.**
- Treat `seqlens_k_val < 0` as a fresh prefill (`past_len=0`, `total_seq=sq`) in both fused-decode and decomposed branches; non-prefill validation still runs for any non-negative value.
- Replace the single `(workspace=256MB, request=1)` heuristic call with a 4-rung escalation ladder; if every rung returns 0 algorithms, store `use_default_algo=true` and pass `algo=nullptr` to `hipblasLtMatmul`. Same change in `wrap_gemm` and `wrap_hipblasLtMatmul`.

| Heuristic rung | Workspace | Request count | Why it can help |
|---|---|---|---|
| 1 | 256 MB | 1 | original behaviour |
| 2 | 0 | 1 | force non-workspace algo (often unblocks narrow-N and huge-`ld` shapes) |
| 3 | 256 MB | MAX | broader candidate sweep |
| 4 | 0 | MAX | non-workspace + broader sweep |
| 5 | (cache fallback) | n/a | `use_default_algo = true`, pass `algo = nullptr` to `hipblasLtMatmul` |

---

### 4. QMoE per-expert zero-point stride — `lib/Runtime/real/qmoe.cpp` (commits `0918fdf`, `42587e0`)

**What went wrong.** ONNX `MatMulNBits` with `bits=4` stores `zero_points` as uint8 packed nibbles (two 4-bit values per byte). `qmoe.cpp`'s per-expert pointer arithmetic for `fc1_zp_e`/`fc2_zp_e` was striding by `N * k_blocks` bytes (the unpacked layout) instead of `N * ceil(k_blocks/2)` bytes. Combined with #162's correct kernel-side unpack, every expert past index 0 read ZPs from a region 2× too large — overshooting into the next expert's bytes. Dequantized weight magnitudes grew ~10× per MoE layer until fp16 overflow; `router_probs` became NaN; `topk_routing` returned -1 for every token; **0 active experts from layer ~3 onward**; garbage logits.

**What I did.** Use `e * N * ((k_blocks + 1) / 2)` for both `fc1_zp_e` and `fc2_zp_e`, matching the kernel's `convertZpToFp16` formula `packed_cols = (groups_k + 1) / 2` and the hard-coded `zp_elem_size = 1` already passed to `hip_matmul_nbits`. Verified locally on gpt-oss-120b prefill: qmoe per-layer output magnitudes are now stable (no exponential growth, no fp16 overflow inside MoE), all 36 MoE layers route healthily (`50–110/128` active per call, was `0/128` from layer 3+).

---

## Out of scope

**fp16 residual stream overflow at deep layers.** After all four fixes, gpt-oss-120b runs all 36 layers without NaN inside `wrap_qmoe`/routing, but generated text is still ASCII noise because `down_proj.scales` carry AWQ outliers that grow with depth (max scale: layer 0 = 0.6 → layer 6 = 12.8 → layer 28 = **548**). The resulting matmul outputs accumulate past fp16's ±65 504 ceiling in the residual stream by layer ~35. `hip_matmul_nbits` is verified correct (EP-vs-CPU-vs-numpy across all gpt-oss shapes and outlier scales up to 100). Recommended fix: switch the residual-path buffers from fp16 to bf16. Detailed analysis + 3-fix comparison + recommended migration plan in the [comment thread](#issuecomment-4342725564).

A separate topk-routing kernel out-of-bounds reachable when `router_probs` contains pathological values (exposed by `hip-onnx-runner`'s random generator) is **resolved by fix 4** — the cascade was caused by upstream NaN, not by `topk_routing` itself.

