### PR TITLE
perf(gqa): no-expand decode fast path + unified pipeline + amortized workspace

### DIFF
--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -993,6 +993,22 @@ int hipdnn_ep_state_ensure_workspace(RuntimeState *state, size_t needed_size) {
   if (state->workspace_size >= needed_size)
     return 0;
 
+  // Amortize growth: when enlarging an existing workspace, round the new
+  // size up to at least 1.5x the current buffer. Callers whose request
+  // size grows monotonically by a small increment per inference (e.g. the
+  // GQA decode path, which sizes S buffers to B*H*total_seq and adds B*H
+  // elements per token) would otherwise trigger a hipStreamSynchronize +
+  // hipFree + hipMalloc cycle on every decode step; with the 1.5x factor
+  // that drops to O(log N) reallocations over the whole generation.
+  // Cold-start (no existing workspace) keeps the exact requested size so
+  // warmup doesn't silently double large initial allocations.
+  size_t alloc_size = needed_size;
+  if (state->workspace_size > 0) {
+    size_t grown = state->workspace_size + state->workspace_size / 2; // 1.5x
+    if (grown > alloc_size)
+      alloc_size = grown;
+  }
+
   // Grow: free old, allocate new.
   // Sync the stream first to ensure no in-flight kernel is still using the
   // old workspace buffer (prevents use-after-free on async GPU execution).
@@ -1005,17 +1021,18 @@ int hipdnn_ep_state_ensure_workspace(RuntimeState *state, size_t needed_size) {
     state->workspace_size = 0;
   }
 
-  if (hipMalloc(&state->workspace, needed_size) != hipSuccess) {
+  if (hipMalloc(&state->workspace, alloc_size) != hipSuccess) {
     fprintf(
         stderr,
         "hipdnn_ep_state_ensure_workspace: hipMalloc failed for %zu bytes\n",
-        needed_size);
+        alloc_size);
     return -1;
   }
 
-  state->workspace_size = needed_size;
-  RUNTIME_DEBUG_LOG("[workspace] Allocated shared workspace: %zu bytes\n",
-                    needed_size);
+  state->workspace_size = alloc_size;
+  RUNTIME_DEBUG_LOG(
+      "[workspace] Allocated shared workspace: %zu bytes (requested %zu)\n",
+      alloc_size, needed_size);
   return 0;
 }
 

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -16,6 +16,7 @@
 #include <cassert>
 #include <cmath>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <functional>
 #include <unordered_map>
@@ -23,6 +24,31 @@
 
 #define HIP_CHECK(cmd) HIP_CHECK_GOTO(cmd, cleanup)
 #define HIPBLAS_CHECK(cmd) HIPBLAS_CHECK_GOTO(cmd, cleanup)
+
+// Env-var gate for the group-batched "no-expand" decode fast path.
+// When HIPDNN_EP_GQA_NO_EXPAND=1 (default), the decode (sq==1) call into
+// gqa_forward_hipblaslt switches to a group-batched hipBLASLt pipeline that:
+//   * reads K / V directly from the BNSD [B, G, skv, d] cache (no
+//     expand_kv_k / expand_kv_v kernel launches), and
+//   * reads Q and writes O directly from / to the BSHD [B, sq=1, H, d]
+//     host tensors (no q_transpose / o_transpose, since sq==1 makes BSHD
+//     and BNSD bit-identical in memory).
+// Both Score and Value GEMMs are batched over G (B==1 only) with explicit
+// per-operand strides so a single strided-batched matmul covers all KV
+// groups without materializing an HPG-expanded copy:
+//   A (K or V):  stride = present_seq * d   (one BNSD group matrix)
+//   B (Q or S):  stride = HPG * d           (score) / HPG * skv (value)
+//   C (S or O):  stride = HPG * total_seq   (score) / HPG * d (value)
+// Produces S / O bit-identical (modulo fp16 rounding in a different GEMM
+// tile schedule) to the expand+transpose path. Set HIPDNN_EP_GQA_NO_EXPAND=0
+// to fall back to the original pipeline for A/B testing.
+static bool gqa_no_expand_enabled() {
+  static const bool enabled = [] {
+    const char *v = std::getenv("HIPDNN_EP_GQA_NO_EXPAND");
+    return !v || std::strcmp(v, "0") != 0;
+  }();
+  return enabled;
+}
 
 //===----------------------------------------------------------------------===//
 // hipBLASLt layout helper
@@ -55,9 +81,19 @@ struct GqaGemmKey {
   int64_t m, n, k, batch;
   bool transA; // true for Score GEMM (K^T * Q), false for Value GEMM (V * S)
   bool outputFp32; // true to use HIP_R_32F for C/D layouts (Score GEMM)
+  // Optional explicit per-operand batch strides (in elements). A value of 0
+  // means "use the default dense stride" (m*k for A, n*k for B, n*m for C/D).
+  // Non-zero values override the default and enable batch layouts that differ
+  // from the packed-batched layout -- used by the no-expand decode path where
+  // K/V are shared across HPG heads (stride = present_seq*d across G groups)
+  // while Q/O advance by HPG entries per group (stride = HPG*d or HPG*skv).
+  int64_t strideA;
+  int64_t strideB;
+  int64_t strideC;
   bool operator==(const GqaGemmKey &o) const {
     return m == o.m && n == o.n && k == o.k && batch == o.batch &&
-           transA == o.transA && outputFp32 == o.outputFp32;
+           transA == o.transA && outputFp32 == o.outputFp32 &&
+           strideA == o.strideA && strideB == o.strideB && strideC == o.strideC;
   }
 };
 
@@ -70,6 +106,9 @@ struct GqaGemmKeyHash {
     hash_combine_val(h, k.batch);
     hash_combine_val(h, k.transA);
     hash_combine_val(h, k.outputFp32);
+    hash_combine_val(h, k.strideA);
+    hash_combine_val(h, k.strideB);
+    hash_combine_val(h, k.strideC);
     return h;
   }
 };
@@ -130,21 +169,25 @@ static const GqaGemmCacheEntry *queryOrCreateGemmState(RuntimeState *state,
   }
 
   {
+    int64_t strideA = key.strideA != 0 ? key.strideA : m * k;
+    int64_t strideB = key.strideB != 0 ? key.strideB : n * k;
+    int64_t strideC = key.strideC != 0 ? key.strideC : n * m;
+
     int64_t a_rows = key.transA ? k : m;
     int64_t a_cols = key.transA ? m : k;
     GQA_CACHE_CHECK(hipblasLtMatrixLayoutCreate(&entry.layA, HIP_R_16F, a_rows,
                                                 a_cols, a_rows));
-    GQA_CACHE_CHECK(setLayoutBatch(entry.layA, batch, m * k));
+    GQA_CACHE_CHECK(setLayoutBatch(entry.layA, batch, strideA));
 
     GQA_CACHE_CHECK(
         hipblasLtMatrixLayoutCreate(&entry.layB, HIP_R_16F, k, n, k));
-    GQA_CACHE_CHECK(setLayoutBatch(entry.layB, batch, n * k));
+    GQA_CACHE_CHECK(setLayoutBatch(entry.layB, batch, strideB));
 
     hipDataType outType = key.outputFp32 ? HIP_R_32F : HIP_R_16F;
     GQA_CACHE_CHECK(hipblasLtMatrixLayoutCreate(&entry.layC, outType, m, n, m));
-    GQA_CACHE_CHECK(setLayoutBatch(entry.layC, batch, n * m));
+    GQA_CACHE_CHECK(setLayoutBatch(entry.layC, batch, strideC));
     GQA_CACHE_CHECK(hipblasLtMatrixLayoutCreate(&entry.layD, outType, m, n, m));
-    GQA_CACHE_CHECK(setLayoutBatch(entry.layD, batch, n * m));
+    GQA_CACHE_CHECK(setLayoutBatch(entry.layD, batch, strideC));
   }
 
   GQA_CACHE_CHECK(hipblasLtMatmulPreferenceCreate(&pref));
@@ -448,6 +491,158 @@ static int gqa_forward_hipblaslt(
     past_len = 0;
 
   bool packed_qkv = (key == nullptr && value == nullptr);
+
+  //===--------------------------------------------------------------------===//
+  // Decode fast path: group-batched hipBLASLt with no expand, no Q/O transpose
+  //
+  // Active only when:
+  //   * sq == 1 (single-token decode)
+  //   * B == 1 (single batch; strided-batched GEMM can't express B*G with
+  //     heterogeneous strides in one call, and we want to avoid host-side
+  //     loops that defeat the purpose of collapsing launches)
+  //   * key != nullptr && value != nullptr (not packed QKV -- we need Q, K, V
+  //     as separate buffers; packed splits would need an extra kernel)
+  //   * present_key != nullptr && present_value != nullptr (we always read
+  //     K/V from the present cache; update_kv_cache makes that valid both
+  //     for in-place (past==present) and concat (past!=present) paths)
+  //   * !need_rope (external rotary, which is the norm for Mistral/Llama
+  //     GQA where do_rotary=0 on the op and RoPE is a separate op upstream)
+  //   * !use_smooth_softmax && head_sink == nullptr (shared softmax kernel
+  //     handles these but they're not on the decode hot path for now)
+  //
+  // All other cases (prefill sq>1, packed QKV, rope, smooth softmax) fall
+  // through to the original expand + transpose pipeline below.
+  //===--------------------------------------------------------------------===//
+  if (gqa_no_expand_enabled() && sq == 1 && B == 1 && key && value &&
+      present_key && present_value && !need_rope && !use_smooth_softmax &&
+      !head_sink && !packed_qkv) {
+    int64_t HPG = H / G;
+
+    // Score GEMM: C = K^T @ Q  with layouts
+    //   A = K  [d x total_seq] col-major (first total_seq rows/cols used,
+    //          buffer is [d x present_seq]); stride across G = present_seq*d
+    //   B = Q  [d x HPG]       col-major, stride across G = HPG*d
+    //   C = S  [total_seq x HPG] col-major fp32, stride across G =
+    //   HPG*total_seq
+    // Batch = G (since B==1). strideA uses present_seq (the buffer
+    // dimension of the BNSD cache, typically max_length) so we step over
+    // full cache pages between groups even though the GEMM only consumes
+    // the first total_seq tokens per page.
+    GqaGemmKey scoreKey{/*m=*/total_seq,
+                        /*n=*/HPG,
+                        /*k=*/d,
+                        /*batch=*/G,
+                        /*transA=*/true,
+                        /*outputFp32=*/true,
+                        /*strideA=*/present_seq * d,
+                        /*strideB=*/HPG * d,
+                        /*strideC=*/HPG * total_seq};
+
+    // Value GEMM: C = V @ S  with layouts
+    //   A = V  [d x total_seq] col-major (buffer [d x present_seq]);
+    //          stride across G = present_seq*d
+    //   B = S  [total_seq x HPG] col-major fp16 (softmax output, tightly
+    //          packed in our workspace); stride = HPG*total_seq
+    //   C = O  [d x HPG]         col-major fp16, stride = HPG*d
+    // Writes directly into the user's BSHD output tensor: for sq==1 the
+    // [B=1, sq=1, H, d] memory layout is bit-identical to [B=1, G, HPG, d],
+    // so no output transpose is needed.
+    GqaGemmKey valueKey{/*m=*/d,
+                        /*n=*/HPG,
+                        /*k=*/total_seq,
+                        /*batch=*/G,
+                        /*transA=*/false,
+                        /*outputFp32=*/false,
+                        /*strideA=*/present_seq * d,
+                        /*strideB=*/HPG * total_seq,
+                        /*strideC=*/HPG * d};
+
+    const GqaGemmCacheEntry *scoreStateNX =
+        queryOrCreateGemmState(ltHandle, scoreKey);
+    if (!scoreStateNX)
+      return -1;
+    const GqaGemmCacheEntry *valueStateNX =
+        queryOrCreateGemmState(ltHandle, valueKey);
+    if (!valueStateNX)
+      return -1;
+
+    // Workspace layout: [S_f32 | S_fp16 | gemm_ws].
+    // S shape is [B=1, G, HPG, total_seq] which is bit-identical to
+    // [B*H, sq=1, total_seq], so the existing softmax kernel can read /
+    // write these buffers with total_head_queries = B*H*sq = H and
+    // batch stride = total_seq. No layout conversion needed.
+    size_t S_f32_bytes = static_cast<size_t>(B) * H * total_seq * sizeof(float);
+    size_t S_fp16_bytes = static_cast<size_t>(B) * H * total_seq * elem_sz;
+    size_t gemm_ws =
+        std::max(scoreStateNX->workspace_size, valueStateNX->workspace_size);
+    size_t total_needed = S_f32_bytes + S_fp16_bytes + gemm_ws;
+    if (hipdnn_ep_state_ensure_workspace(state, total_needed) != 0)
+      return -1;
+
+    char *ws = static_cast<char *>(hipdnn_ep_state_get_workspace(state));
+    size_t ws_total = hipdnn_ep_state_get_workspace_size(state);
+    void *d_S_f32 = ws;
+    void *d_S_fp16 = ws + S_f32_bytes;
+    void *gemm_ws_ptr = ws + S_f32_bytes + S_fp16_bytes;
+    size_t gemm_ws_bytes = ws_total - (S_f32_bytes + S_fp16_bytes);
+
+    // Steps 4-5: KV Cache Update (append new key/value into cache in-place
+    // when past==present, or concat past into present otherwise). seqlens_k
+    // is passed so the append kernel reads past_len on-device; past_len
+    // here is only used by the concat branch.
+    if (update_kv_cache(stream, past_key, past_value, key, value, present_key,
+                        present_value, static_cast<int>(B),
+                        static_cast<int>(past_len), static_cast<int>(sq),
+                        static_cast<int>(G), static_cast<int>(d),
+                        static_cast<int>(past_buf_seq),
+                        static_cast<int>(present_seq), seqlens_k_ptr) != 0)
+      return -1;
+
+    // Step 8: Score GEMM (group-batched, fp16 in, fp32 out).
+    float scoreAlpha = scale;
+    float beta = 0.0f;
+    hipblasLtMatmulAlgo_t sAlgo = scoreStateNX->algo;
+    if (hipblasLtMatmul(ltHandle, scoreStateNX->desc, &scoreAlpha, present_key,
+                        scoreStateNX->layA, query, scoreStateNX->layB, &beta,
+                        d_S_f32, scoreStateNX->layC, d_S_f32,
+                        scoreStateNX->layD, &sAlgo, gemm_ws_ptr, gemm_ws_bytes,
+                        stream) != HIPBLAS_STATUS_SUCCESS) {
+      fprintf(stderr, "gqa_forward_hipblaslt (no-expand): score GEMM failed\n");
+      return -1;
+    }
+
+    // Step 9: Softmax (fp32 -> fp16). Reinterpret [B, G, HPG, total_seq] as
+    // [B*H, 1, total_seq] -- same memory, no kernel change.
+    int scoreBatchStride = static_cast<int>(total_seq);
+    if (hip_gqa_softmax_f32_to_f16(
+            stream, d_S_f32, d_S_fp16, static_cast<int>(B * H * sq),
+            static_cast<int>(total_seq), static_cast<int>(sq), scoreBatchStride,
+            scoreBatchStride, /*head_sink=*/nullptr, static_cast<int>(H),
+            /*use_smooth_softmax=*/0) != 0)
+      return -1;
+
+    // Step 10: Value GEMM (group-batched, fp16 in, fp16 out).
+    // Writes directly to `output` which is the user's BSHD [B=1, sq=1, H, d]
+    // buffer -- same memory as [B=1, G, HPG, d].
+    float valAlpha = 1.0f;
+    hipblasLtMatmulAlgo_t vAlgo = valueStateNX->algo;
+    if (hipblasLtMatmul(ltHandle, valueStateNX->desc, &valAlpha, present_value,
+                        valueStateNX->layA, d_S_fp16, valueStateNX->layB, &beta,
+                        output, valueStateNX->layC, output, valueStateNX->layD,
+                        &vAlgo, gemm_ws_ptr, gemm_ws_bytes,
+                        stream) != HIPBLAS_STATUS_SUCCESS) {
+      fprintf(stderr, "gqa_forward_hipblaslt (no-expand): value GEMM failed\n");
+      return -1;
+    }
+
+    RUNTIME_DEBUG_LOG(
+        "[REAL] GQA no-expand decode: B=%lld sq=1 total_seq=%lld H=%lld "
+        "G=%lld HPG=%lld d=%lld\n",
+        (long long)B, (long long)total_seq, (long long)H, (long long)G,
+        (long long)HPG, (long long)d);
+    return 0;
+  }
+  // Falls through to the original expand + transpose pipeline below.
 
   // ---- Workspace layout ----
   // All temp buffers are packed contiguously into the shared workspace,

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -25,27 +25,49 @@
 #define HIP_CHECK(cmd) HIP_CHECK_GOTO(cmd, cleanup)
 #define HIPBLAS_CHECK(cmd) HIPBLAS_CHECK_GOTO(cmd, cleanup)
 
-// Env-var gate for the group-batched "no-expand" decode fast path.
-// When HIPDNN_EP_GQA_NO_EXPAND=1 (default), the decode (sq==1) call into
-// gqa_forward_hipblaslt switches to a group-batched hipBLASLt pipeline that:
-//   * reads K / V directly from the BNSD [B, G, skv, d] cache (no
-//     expand_kv_k / expand_kv_v kernel launches), and
-//   * reads Q and writes O directly from / to the BSHD [B, sq=1, H, d]
-//     host tensors (no q_transpose / o_transpose, since sq==1 makes BSHD
-//     and BNSD bit-identical in memory).
-// Both Score and Value GEMMs are batched over G (B==1 only) with explicit
-// per-operand strides so a single strided-batched matmul covers all KV
-// groups without materializing an HPG-expanded copy:
-//   A (K or V):  stride = present_seq * d   (one BNSD group matrix)
-//   B (Q or S):  stride = HPG * d           (score) / HPG * skv (value)
-//   C (S or O):  stride = HPG * total_seq   (score) / HPG * d (value)
-// Produces S / O bit-identical (modulo fp16 rounding in a different GEMM
-// tile schedule) to the expand+transpose path. Set HIPDNN_EP_GQA_NO_EXPAND=0
-// to fall back to the original pipeline for A/B testing.
+// Env-var gate for the group-batched "no-expand" hipBLASLt GQA pipeline.
+// When HIPDNN_EP_GQA_NO_EXPAND=1 (default) the Score and Value GEMMs read
+// K and V directly from the BNSD [B, G, skv, d] present cache using
+// strided-batched mode with batch = B*G and per-operand batch strides:
+//   A (K or V):  stride = present_seq * d       (one BNSD group matrix)
+//   B (Q or S):  stride = HPG * sq * d          (score)
+//                         HPG * sq * total_seq  (value)
+//   C (S or O):  stride = HPG * sq * total_seq  (score)
+//                         HPG * sq * d          (value)
+// This eliminates the explicit expand_kv_k / expand_kv_v kernels and the
+// B*H*total_seq*d fp16 scratch buffers they wrote into.
+//
+// At sq == 1 (decode) BSHD [B, 1, H, d] and BNSD [B, H, 1, d] share the
+// same memory, so Q and O are also read / written in place (no
+// Q-transpose / O-transpose kernels). At sq > 1 (prefill) the Q-transpose
+// and O-transpose kernels still run because the two layouts diverge.
+//
+// Output is S / O bit-identical (modulo fp16 rounding in a different GEMM
+// tile schedule) to the expand + transpose path. Set
+// HIPDNN_EP_GQA_NO_EXPAND=0 to fall back fully for A/B testing.
 static bool gqa_no_expand_enabled() {
   static const bool enabled = [] {
     const char *v = std::getenv("HIPDNN_EP_GQA_NO_EXPAND");
     return !v || std::strcmp(v, "0") != 0;
+  }();
+  return enabled;
+}
+
+// Env-var gate for enabling the no-expand path on prefill (sq > 1).
+// Default off: today only decode (sq == 1) takes the no-expand fast path,
+// matching the verified pre-step-2 behaviour. Set
+// HIPDNN_EP_GQA_NO_EXPAND_PREFILL=1 to opt prefill into the same
+// group-batched pipeline -- same strides as decode, but with Q/O transpose
+// kernels kept in place because BSHD and BNSD diverge at sq > 1.
+//
+// Keeping this behind a separate flag lets us A/B just the new prefill
+// behaviour without touching decode. Once verified across model families
+// (Mistral / Llama / GPT-OSS / ...), this can be folded into the main
+// HIPDNN_EP_GQA_NO_EXPAND flag.
+static bool gqa_no_expand_prefill_enabled() {
+  static const bool enabled = [] {
+    const char *v = std::getenv("HIPDNN_EP_GQA_NO_EXPAND_PREFILL");
+    return v && std::strcmp(v, "0") != 0;
   }();
   return enabled;
 }
@@ -493,156 +515,111 @@ static int gqa_forward_hipblaslt(
   bool packed_qkv = (key == nullptr && value == nullptr);
 
   //===--------------------------------------------------------------------===//
-  // Decode fast path: group-batched hipBLASLt with no expand, no Q/O transpose
+  // Unified hipBLASLt GQA pipeline (shared by expand and no-expand paths)
   //
-  // Active only when:
-  //   * sq == 1 (single-token decode)
-  //   * B == 1 (single batch; strided-batched GEMM can't express B*G with
-  //     heterogeneous strides in one call, and we want to avoid host-side
-  //     loops that defeat the purpose of collapsing launches)
-  //   * key != nullptr && value != nullptr (not packed QKV -- we need Q, K, V
-  //     as separate buffers; packed splits would need an extra kernel)
-  //   * present_key != nullptr && present_value != nullptr (we always read
-  //     K/V from the present cache; update_kv_cache makes that valid both
-  //     for in-place (past==present) and concat (past!=present) paths)
-  //   * !need_rope (external rotary, which is the norm for Mistral/Llama
-  //     GQA where do_rotary=0 on the op and RoPE is a separate op upstream)
-  //   * !use_smooth_softmax && head_sink == nullptr (shared softmax kernel
-  //     handles these but they're not on the decode hot path for now)
+  // Two orthogonal knobs control the layout choices for the two GEMMs:
   //
-  // All other cases (prefill sq>1, packed QKV, rope, smooth softmax) fall
-  // through to the original expand + transpose pipeline below.
+  //   use_no_expand : when true, Score reads K and Value reads V directly
+  //                   from the BNSD cache (present_key / present_value) and
+  //                   both GEMMs use strided-batched mode with batch = B*G
+  //                   plus per-operand strides to broadcast each KV group
+  //                   across its HPG queries. When false (original path)
+  //                   expand_kv_* duplicates the G groups into H heads in
+  //                   d_Kexp / d_Vexp and both GEMMs run with dense batch
+  //                   = B*H. The no-expand flavour skips two kernels and
+  //                   two B*H*total_seq*d fp16 scratch buffers.
+  //
+  //   need_transpose: true when sq > 1. The BSHD (Q, output) and BNSD
+  //                   (GEMM-native) layouts only coincide when sq == 1,
+  //                   so for prefill we still need a Q-transpose before
+  //                   Score and an O-transpose after Value. For decode
+  //                   (sq == 1) both transposes are pure pointer
+  //                   reinterpretations and the kernels are skipped.
+  //
+  // Gate rationale: the no-expand path is correctness-orthogonal to most
+  // GQA features -- packed-QKV split runs in Step 0 and redirects qSrc /
+  // kSrc / vSrc; RoPE runs in Steps 1-2 and redirects them again; the
+  // softmax / causal-mask kernels see S in the same BNSD [B, H, sq,
+  // total_seq] layout regardless of which GEMM flavour produced it; and
+  // the strided-batched GEMM addressing is correct for any B and any sq
+  // (I walked the stride math for both dimensions separately before
+  // dropping their gates). The only hard correctness requirement is that
+  // present_key / present_value be valid BNSD caches the GEMMs can read
+  // directly -- everything else is just pipeline plumbing that works
+  // identically across the two flavours.
+  //
+  // Prefill (sq > 1) is additionally guarded by
+  // HIPDNN_EP_GQA_NO_EXPAND_PREFILL (default off) so the new behaviour can
+  // be verified in isolation -- with the prefill flag off the path is
+  // byte-identical to the pre-step-2 decode-only gate. Once prefill is
+  // verified across model families this extra gate can be removed.
+  //
+  // Pointer plumbing:
+  //   Score A (K):  use_no_expand ? present_key  : d_Kexp
+  //   Score B (Q):  need_transpose ? d_Qtrans    : qSrc  (BSHD == BNSD @sq=1)
+  //   Value A (V):  use_no_expand ? present_value: d_Vexp
+  //   Value C (O):  need_transpose ? d_O         : output
   //===--------------------------------------------------------------------===//
-  if (gqa_no_expand_enabled() && sq == 1 && B == 1 && key && value &&
-      present_key && present_value && !need_rope && !use_smooth_softmax &&
-      !head_sink && !packed_qkv) {
-    int64_t HPG = H / G;
 
-    // Score GEMM: C = K^T @ Q  with layouts
-    //   A = K  [d x total_seq] col-major (first total_seq rows/cols used,
-    //          buffer is [d x present_seq]); stride across G = present_seq*d
-    //   B = Q  [d x HPG]       col-major, stride across G = HPG*d
-    //   C = S  [total_seq x HPG] col-major fp32, stride across G =
-    //   HPG*total_seq
-    // Batch = G (since B==1). strideA uses present_seq (the buffer
-    // dimension of the BNSD cache, typically max_length) so we step over
-    // full cache pages between groups even though the GEMM only consumes
-    // the first total_seq tokens per page.
-    GqaGemmKey scoreKey{/*m=*/total_seq,
-                        /*n=*/HPG,
-                        /*k=*/d,
-                        /*batch=*/G,
-                        /*transA=*/true,
-                        /*outputFp32=*/true,
-                        /*strideA=*/present_seq * d,
-                        /*strideB=*/HPG * d,
-                        /*strideC=*/HPG * total_seq};
+  bool use_no_expand = gqa_no_expand_enabled() && present_key &&
+                       present_value &&
+                       (sq == 1 || gqa_no_expand_prefill_enabled());
+  bool need_transpose = (sq > 1);
 
-    // Value GEMM: C = V @ S  with layouts
-    //   A = V  [d x total_seq] col-major (buffer [d x present_seq]);
-    //          stride across G = present_seq*d
-    //   B = S  [total_seq x HPG] col-major fp16 (softmax output, tightly
-    //          packed in our workspace); stride = HPG*total_seq
-    //   C = O  [d x HPG]         col-major fp16, stride = HPG*d
-    // Writes directly into the user's BSHD output tensor: for sq==1 the
-    // [B=1, sq=1, H, d] memory layout is bit-identical to [B=1, G, HPG, d],
-    // so no output transpose is needed.
-    GqaGemmKey valueKey{/*m=*/d,
-                        /*n=*/HPG,
-                        /*k=*/total_seq,
-                        /*batch=*/G,
-                        /*transA=*/false,
-                        /*outputFp32=*/false,
-                        /*strideA=*/present_seq * d,
-                        /*strideB=*/HPG * total_seq,
-                        /*strideC=*/HPG * d};
-
-    const GqaGemmCacheEntry *scoreStateNX =
-        queryOrCreateGemmState(ltHandle, scoreKey);
-    if (!scoreStateNX)
-      return -1;
-    const GqaGemmCacheEntry *valueStateNX =
-        queryOrCreateGemmState(ltHandle, valueKey);
-    if (!valueStateNX)
-      return -1;
-
-    // Workspace layout: [S_f32 | S_fp16 | gemm_ws].
-    // S shape is [B=1, G, HPG, total_seq] which is bit-identical to
-    // [B*H, sq=1, total_seq], so the existing softmax kernel can read /
-    // write these buffers with total_head_queries = B*H*sq = H and
-    // batch stride = total_seq. No layout conversion needed.
-    size_t S_f32_bytes = static_cast<size_t>(B) * H * total_seq * sizeof(float);
-    size_t S_fp16_bytes = static_cast<size_t>(B) * H * total_seq * elem_sz;
-    size_t gemm_ws =
-        std::max(scoreStateNX->workspace_size, valueStateNX->workspace_size);
-    size_t total_needed = S_f32_bytes + S_fp16_bytes + gemm_ws;
-    if (hipdnn_ep_state_ensure_workspace(state, total_needed) != 0)
-      return -1;
-
-    char *ws = static_cast<char *>(hipdnn_ep_state_get_workspace(state));
-    size_t ws_total = hipdnn_ep_state_get_workspace_size(state);
-    void *d_S_f32 = ws;
-    void *d_S_fp16 = ws + S_f32_bytes;
-    void *gemm_ws_ptr = ws + S_f32_bytes + S_fp16_bytes;
-    size_t gemm_ws_bytes = ws_total - (S_f32_bytes + S_fp16_bytes);
-
-    // Steps 4-5: KV Cache Update (append new key/value into cache in-place
-    // when past==present, or concat past into present otherwise). seqlens_k
-    // is passed so the append kernel reads past_len on-device; past_len
-    // here is only used by the concat branch.
-    if (update_kv_cache(stream, past_key, past_value, key, value, present_key,
-                        present_value, static_cast<int>(B),
-                        static_cast<int>(past_len), static_cast<int>(sq),
-                        static_cast<int>(G), static_cast<int>(d),
-                        static_cast<int>(past_buf_seq),
-                        static_cast<int>(present_seq), seqlens_k_ptr) != 0)
-      return -1;
-
-    // Step 8: Score GEMM (group-batched, fp16 in, fp32 out).
-    float scoreAlpha = scale;
-    float beta = 0.0f;
-    hipblasLtMatmulAlgo_t sAlgo = scoreStateNX->algo;
-    if (hipblasLtMatmul(ltHandle, scoreStateNX->desc, &scoreAlpha, present_key,
-                        scoreStateNX->layA, query, scoreStateNX->layB, &beta,
-                        d_S_f32, scoreStateNX->layC, d_S_f32,
-                        scoreStateNX->layD, &sAlgo, gemm_ws_ptr, gemm_ws_bytes,
-                        stream) != HIPBLAS_STATUS_SUCCESS) {
-      fprintf(stderr, "gqa_forward_hipblaslt (no-expand): score GEMM failed\n");
-      return -1;
-    }
-
-    // Step 9: Softmax (fp32 -> fp16). Reinterpret [B, G, HPG, total_seq] as
-    // [B*H, 1, total_seq] -- same memory, no kernel change.
-    int scoreBatchStride = static_cast<int>(total_seq);
-    if (hip_gqa_softmax_f32_to_f16(
-            stream, d_S_f32, d_S_fp16, static_cast<int>(B * H * sq),
-            static_cast<int>(total_seq), static_cast<int>(sq), scoreBatchStride,
-            scoreBatchStride, /*head_sink=*/nullptr, static_cast<int>(H),
-            /*use_smooth_softmax=*/0) != 0)
-      return -1;
-
-    // Step 10: Value GEMM (group-batched, fp16 in, fp16 out).
-    // Writes directly to `output` which is the user's BSHD [B=1, sq=1, H, d]
-    // buffer -- same memory as [B=1, G, HPG, d].
-    float valAlpha = 1.0f;
-    hipblasLtMatmulAlgo_t vAlgo = valueStateNX->algo;
-    if (hipblasLtMatmul(ltHandle, valueStateNX->desc, &valAlpha, present_value,
-                        valueStateNX->layA, d_S_fp16, valueStateNX->layB, &beta,
-                        output, valueStateNX->layC, output, valueStateNX->layD,
-                        &vAlgo, gemm_ws_ptr, gemm_ws_bytes,
-                        stream) != HIPBLAS_STATUS_SUCCESS) {
-      fprintf(stderr, "gqa_forward_hipblaslt (no-expand): value GEMM failed\n");
-      return -1;
-    }
-
-    RUNTIME_DEBUG_LOG(
-        "[REAL] GQA no-expand decode: B=%lld sq=1 total_seq=%lld H=%lld "
-        "G=%lld HPG=%lld d=%lld\n",
-        (long long)B, (long long)total_seq, (long long)H, (long long)G,
-        (long long)HPG, (long long)d);
-    return 0;
+  // GEMM descriptor keys. The no-expand flavour uses explicit per-operand
+  // strides (non-zero stride fields); the expand flavour leaves them zero
+  // so queryOrCreateGemmState falls back to the dense packed-batch defaults.
+  GqaGemmKey scoreKey, valueKey;
+  if (use_no_expand) {
+    // Score: C[total_seq, HPG*sq] = K^T[d,total_seq] * Q[d, HPG*sq] per
+    // (b, g) pair. strideA steps over the buffer page (present_seq*d) even
+    // though only the first total_seq tokens are read, which lets the
+    // descriptor stay stable across token steps.
+    scoreKey = {/*m=*/total_seq,
+                /*n=*/HPG * sq,
+                /*k=*/d,
+                /*batch=*/B * G,
+                /*transA=*/true,
+                /*outputFp32=*/true,
+                /*strideA=*/present_seq * d,
+                /*strideB=*/HPG * sq * d,
+                /*strideC=*/HPG * sq * total_seq};
+    // Value: C[d, HPG*sq] = V[d, total_seq] * S[total_seq, HPG*sq] per
+    // (b, g) pair, writing into BNSD [B, G, HPG, sq, d] which at sq==1
+    // coincides with BSHD [B, 1, H, d].
+    valueKey = {/*m=*/d,
+                /*n=*/HPG * sq,
+                /*k=*/total_seq,
+                /*batch=*/B * G,
+                /*transA=*/false,
+                /*outputFp32=*/false,
+                /*strideA=*/present_seq * d,
+                /*strideB=*/HPG * sq * total_seq,
+                /*strideC=*/HPG * sq * d};
+  } else {
+    scoreKey = {total_seq,     sq, d, B * H, true, true,
+                /*strideA=*/0,
+                /*strideB=*/0,
+                /*strideC=*/0};
+    valueKey = {d,
+                sq,
+                total_seq,
+                B * H,
+                false,
+                false,
+                /*strideA=*/0,
+                /*strideB=*/0,
+                /*strideC=*/0};
   }
-  // Falls through to the original expand + transpose pipeline below.
+
+  const GqaGemmCacheEntry *scoreState =
+      queryOrCreateGemmState(state, ltHandle, scoreKey);
+  if (!scoreState)
+    return -1;
+  const GqaGemmCacheEntry *valueState =
+      queryOrCreateGemmState(state, ltHandle, valueKey);
+  if (!valueState)
+    return -1;
 
   // ---- Workspace layout ----
   // All temp buffers are packed contiguously into the shared workspace,
@@ -650,20 +627,28 @@ static int gqa_forward_hipblaslt(
   // hipMalloc/hipFree -- after the first inference the workspace is
   // already large enough and reuse is zero-cost.
   //
-  // Layout: [Qtrans | Kexp | Vexp | S | O | Qroped? | Kroped? | Qsplit? |
-  // Ksplit? | Vsplit? | GEMM ws]
+  // Layout: [Qtrans? | Kexp? | Vexp? | S_f32 | S_fp16 | O? | Qroped? |
+  // Kroped? | Qsplit? | Ksplit? | Vsplit? | GEMM ws]
+  //
+  // Qtrans / O are only allocated when need_transpose is true.
+  // Kexp / Vexp are only allocated when use_no_expand is false.
+  // S_f32 and S_fp16 are always allocated (softmax is on every path).
 
-  size_t Qtrans_bytes = static_cast<size_t>(B) * H * sq * d * elem_sz;
-  size_t Kexp_bytes = static_cast<size_t>(B) * H * total_seq * d * elem_sz;
+  size_t Qtrans_bytes =
+      need_transpose ? static_cast<size_t>(B) * H * sq * d * elem_sz : 0;
+  size_t Kexp_bytes =
+      use_no_expand ? 0 : static_cast<size_t>(B) * H * total_seq * d * elem_sz;
+  size_t Vexp_bytes = Kexp_bytes;
   size_t S_f32_bytes =
       static_cast<size_t>(B) * H * sq * total_seq * sizeof(float);
   size_t S_fp16_bytes = static_cast<size_t>(B) * H * sq * total_seq * elem_sz;
-  size_t O_bytes = static_cast<size_t>(B) * H * sq * d * elem_sz;
+  size_t O_bytes =
+      need_transpose ? static_cast<size_t>(B) * H * sq * d * elem_sz : 0;
 
   size_t off_Qtrans = 0;
   size_t off_Kexp = off_Qtrans + Qtrans_bytes;
   size_t off_Vexp = off_Kexp + Kexp_bytes;
-  size_t off_S_f32 = off_Vexp + Kexp_bytes;
+  size_t off_S_f32 = off_Vexp + Vexp_bytes;
   size_t off_S_fp16 = off_S_f32 + S_f32_bytes;
   size_t off_O = off_S_fp16 + S_fp16_bytes;
   size_t temp_end = off_O + O_bytes;
@@ -692,21 +677,6 @@ static int gqa_forward_hipblaslt(
     temp_end = off_Vsplit + K_bytes;
   }
 
-  // Query or create cached GEMM descriptors + algorithms. On first call for
-  // a given shape the descriptors and layouts are created and the heuristic
-  // is queried; subsequent calls reuse the cached state.
-  GqaGemmKey scoreKey{total_seq, sq, d, B * H, true, true}; // outputFp32=true
-  GqaGemmKey valueKey{d,     sq,    total_seq,
-                      B * H, false, false}; // outputFp32=false
-  const GqaGemmCacheEntry *scoreState =
-      queryOrCreateGemmState(state, ltHandle, scoreKey);
-  if (!scoreState)
-    return -1;
-  const GqaGemmCacheEntry *valueState =
-      queryOrCreateGemmState(state, ltHandle, valueKey);
-  if (!valueState)
-    return -1;
-
   int result = 0;
 
   // Single workspace allocation: temp buffers + GEMM workspace
@@ -721,12 +691,12 @@ static int gqa_forward_hipblaslt(
     char *ws = static_cast<char *>(hipdnn_ep_state_get_workspace(state));
     size_t ws_total = hipdnn_ep_state_get_workspace_size(state);
 
-    void *d_Qtrans = ws + off_Qtrans;
-    void *d_Kexp = ws + off_Kexp;
-    void *d_Vexp = ws + off_Vexp;
+    void *d_Qtrans = need_transpose ? (ws + off_Qtrans) : nullptr;
+    void *d_Kexp = use_no_expand ? nullptr : (ws + off_Kexp);
+    void *d_Vexp = use_no_expand ? nullptr : (ws + off_Vexp);
     void *d_S_f32 = ws + off_S_f32;
     void *d_S_fp16 = ws + off_S_fp16;
-    void *d_O = ws + off_O;
+    void *d_O = need_transpose ? (ws + off_O) : nullptr;
 
     void *gemm_ws_ptr = ws + temp_end;
     size_t gemm_ws_bytes = ws_total - temp_end;
@@ -778,28 +748,37 @@ static int gqa_forward_hipblaslt(
     }
 
     // ---- Step 3: Q Transpose BSHD [B,S,H,d] -> BNSD [B,H,S,d] ----
-    HIP_CHECK(hip_gqa_transpose_mid_dims(
-        stream, qSrc, d_Qtrans, static_cast<int>(B), static_cast<int>(sq),
-        static_cast<int>(H), static_cast<int>(d)));
+    // Skipped for sq == 1 because BSHD [B, 1, H, d] and BNSD [B, H, 1, d]
+    // are bit-identical in memory -- the Score GEMM can read qSrc directly.
+    if (need_transpose) {
+      HIP_CHECK(hip_gqa_transpose_mid_dims(
+          stream, qSrc, d_Qtrans, static_cast<int>(B), static_cast<int>(sq),
+          static_cast<int>(H), static_cast<int>(d)));
+    }
 
     // ---- Steps 4-5: KV Cache Update ----
     // The concat/append kernels write the valid range [0, total_seq) in full;
     // positions [total_seq, present_seq) are never read downstream (expand_kv
     // is called with copy_elems = total_seq * d), so the unused tail is left
     // untouched to avoid redundant memory bandwidth during prefill.
+    //
+    // For the no-expand path we hand seqlens_k_ptr to the append kernel so
+    // it can resolve past_len on-device, avoiding a D2H stall on every
+    // decode step. The expand path has already consumed total_seq host-side
+    // above, so it passes nullptr to preserve the pre-refactor behaviour.
     if (present_key && present_value) {
       HIP_CHECK(update_kv_cache(
           stream, past_key, past_value, kSrc, vSrc, present_key, present_value,
           static_cast<int>(B), static_cast<int>(past_len), static_cast<int>(sq),
           static_cast<int>(G), static_cast<int>(d),
           static_cast<int>(past_buf_seq), static_cast<int>(present_seq),
-          nullptr));
+          use_no_expand ? seqlens_k_ptr : nullptr));
     }
 
     // ---- Steps 6-7: KV Expand [B*G, present_seq, d] -> [B*H, total_seq, d]
-    // Source reads from present_key with buffer stride present_seq*d; dest
-    // uses total_seq*d since GEMM only operates on total_seq tokens.
-    {
+    // Skipped in no-expand mode: the Score / Value GEMMs read K/V directly
+    // from the BNSD cache via per-operand batch strides instead.
+    if (!use_no_expand) {
       const void *kCache = present_key ? present_key : key;
       const void *vCache = present_value ? present_value : value;
       int kvSrcStride = static_cast<int>(present_seq * d);
@@ -815,16 +794,25 @@ static int gqa_forward_hipblaslt(
     }
 
     // ---- Step 8: Score GEMM (fp16 in, fp32 out) ----
+    // A = K : no-expand reads the BNSD cache (present_key) directly;
+    //         the expand path reads the already-duplicated d_Kexp.
+    // B = Q : need_transpose reads d_Qtrans (BNSD); at sq==1 qSrc points
+    //         straight at the BSHD input which shares memory with BNSD.
+    const void *scoreA = use_no_expand ? present_key : d_Kexp;
+    const void *scoreB = need_transpose ? d_Qtrans : qSrc;
     float scoreAlpha = scale;
     float beta = 0.0f;
     hipblasLtMatmulAlgo_t sAlgo = scoreState->algo;
 
     HIPBLAS_CHECK(hipblasLtMatmul(
-        ltHandle, scoreState->desc, &scoreAlpha, d_Kexp, scoreState->layA,
-        d_Qtrans, scoreState->layB, &beta, d_S_f32, scoreState->layC, d_S_f32,
+        ltHandle, scoreState->desc, &scoreAlpha, scoreA, scoreState->layA,
+        scoreB, scoreState->layB, &beta, d_S_f32, scoreState->layC, d_S_f32,
         scoreState->layD, &sAlgo, gemm_ws_ptr, gemm_ws_bytes, stream));
 
     // ---- Step 9: Causal Mask (fp32) + Softmax (fp32 -> fp16) ----
+    // Both kernels treat S as [B*H, sq, total_seq] with head_stride
+    // sq*total_seq, which is the layout produced by both GEMM flavours
+    // (the no-expand strided-batched output lands in BNSD order too).
     int scoreF32BatchStride = static_cast<int>(sq * total_seq);
     int scoreFp16BatchStride = static_cast<int>(sq * total_seq);
     if (sq > 1 || local_window_size > 0) {
@@ -840,18 +828,34 @@ static int gqa_forward_hipblaslt(
         static_cast<int>(use_smooth_softmax)));
 
     // ---- Step 10: Value GEMM (fp16 in, fp16 out) ----
+    // A = V : no-expand reads present_value directly; expand reads d_Vexp.
+    // C = O : need_transpose writes d_O (BNSD), later transposed to output;
+    //         at sq==1 the GEMM writes directly to the caller's output
+    //         buffer because BSHD and BNSD coincide.
+    const void *valueA = use_no_expand ? present_value : d_Vexp;
+    void *valueC = need_transpose ? d_O : output;
     float valAlpha = 1.0f;
     hipblasLtMatmulAlgo_t vAlgo = valueState->algo;
 
     HIPBLAS_CHECK(hipblasLtMatmul(
-        ltHandle, valueState->desc, &valAlpha, d_Vexp, valueState->layA,
-        d_S_fp16, valueState->layB, &beta, d_O, valueState->layC, d_O,
+        ltHandle, valueState->desc, &valAlpha, valueA, valueState->layA,
+        d_S_fp16, valueState->layB, &beta, valueC, valueState->layC, valueC,
         valueState->layD, &vAlgo, gemm_ws_ptr, gemm_ws_bytes, stream));
 
     // ---- Step 11: O Transpose BNSD [B,H,S,d] -> BSHD [B,S,H,d] ----
-    HIP_CHECK(hip_gqa_transpose_mid_dims(
-        stream, d_O, output, static_cast<int>(B), static_cast<int>(H),
-        static_cast<int>(sq), static_cast<int>(d)));
+    // Skipped at sq == 1 -- the Value GEMM already wrote into `output`.
+    if (need_transpose) {
+      HIP_CHECK(hip_gqa_transpose_mid_dims(
+          stream, d_O, output, static_cast<int>(B), static_cast<int>(H),
+          static_cast<int>(sq), static_cast<int>(d)));
+    }
+
+    RUNTIME_DEBUG_LOG(
+        "[REAL] GQA hipBLASLt: B=%lld sq=%lld total_seq=%lld H=%lld G=%lld "
+        "d=%lld no_expand=%d transpose=%d\n",
+        (long long)B, (long long)sq, (long long)total_seq, (long long)H,
+        (long long)G, (long long)d, static_cast<int>(use_no_expand),
+        static_cast<int>(need_transpose));
   }
 
 cleanup:


### PR DESCRIPTION
## Summary

- Add a group-batched "no-expand" GQA pipeline that reads K/V directly from the BNSD KV cache via hipBLASLt strided-batched GEMM, eliminating the `expand_kv_k` / `expand_kv_v` kernel launches and their `B*H*total_seq*d` fp16 scratch buffers. At `sq == 1` (decode) the Q/O transposes are also skipped because BSHD and BNSD share memory. Gated by `HIPDNN_EP_GQA_NO_EXPAND` (default **on**); A/B against the expand path with `HIPDNN_EP_GQA_NO_EXPAND=0`.
- Unify the expand and no-expand pipelines into a single parameterized path controlled by two orthogonal flags (`use_no_expand`, `need_transpose`), and simplify the activation gate down to the correctness-only minimum (env flag + `present_key`/`present_value` + `sq == 1` or the prefill opt-in).
- Introduce `HIPDNN_EP_GQA_NO_EXPAND_PREFILL` (default **off**) to opt `sq > 1` (prefill) into the no-expand pipeline for A/B experimentation, without changing the shipped prefill behaviour.
- Amortize the shared runtime workspace with a 1.5× growth factor so monotonically-growing decode requests (S buffers sized to `B*H*total_seq` per step) no longer trigger a `hipStreamSynchronize` + `hipFree` + `hipMalloc` cycle on every token. Cold-start keeps the exact requested size.

## Changes Overview

### `lib/Runtime/real/gqa.cpp`

- **No-expand pipeline**. Score and Value GEMMs use `batch = B * G` with explicit per-operand batch strides:
  - A (K or V) stride = `present_seq * d` — walks one BNSD group matrix per batch, stepping over the pre-allocated cache page so the descriptor stays stable across decode steps.
  - B (Q or S) stride = `HPG * sq * d` (Score) / `HPG * sq * total_seq` (Value) — packs the `HPG` queries of a group into the GEMM's N dimension; the HPG replication is consumed inside the GEMM rather than by duplicating K/V in memory.
  - C (S or O) stride = `HPG * sq * total_seq` (Score) / `HPG * sq * d` (Value) — byte-identical layout to the expand path's BNSD `[B, H, sq, *]` output, so downstream softmax / causal-mask / O-transpose kernels are reused unmodified.
- **`gqa_no_expand_enabled()` helper** reads `HIPDNN_EP_GQA_NO_EXPAND` once via a static initializer; default true when the env var is unset or not `"0"`.
- **`gqa_no_expand_prefill_enabled()` helper** reads `HIPDNN_EP_GQA_NO_EXPAND_PREFILL` once; default false.
- **Unified pipeline**. Replaces the previous dedicated no-expand decode block and the original expand+transpose pipeline with a single path controlled by:
  - `use_no_expand` — selects strided-batched GEMM with `batch = B*G` and the no-expand strides above (`true`) vs. dense `batch = B*H` with expand-kv workspace buffers (`false`).
  - `need_transpose` — true when `sq > 1`, keeping the Q-transpose before Score and the O-transpose after Value; false at `sq == 1` because BSHD and BNSD coincide in memory.
- **Pointer plumbing**. Score A = `use_no_expand ? present_key : d_Kexp`; Score B = `need_transpose ? d_Qtrans : qSrc`; Value A = `use_no_expand ? present_value : d_Vexp`; Value C = `need_transpose ? d_O : output`.
- **Workspace layout** now conditionally allocates buffers — `Qtrans` / `O` only when `need_transpose`, `Kexp` / `Vexp` only when not `use_no_expand`, `S_f32` / `S_fp16` always. RoPE and packed-QKV-split scratch regions are unchanged.
- **Gate simplification**. The previous 9-clause decode guard (`sq==1`, `B==1`, non-null `key`/`value`, `present_key`/`present_value`, `!need_rope`, `!use_smooth_softmax`, null `head_sink`, `!packed_qkv`) collapses to `gqa_no_expand_enabled() && present_key && present_value && (sq == 1 || gqa_no_expand_prefill_enabled())`. Rationale:
  - Packed-QKV split (Step 0) and RoPE (Steps 1–2) already run upstream and redirect `qSrc` / `kSrc` / `vSrc` before the GEMM sees them — they don't interact with the GEMM flavour.
  - Smooth softmax and head-sink run inside the shared softmax kernel on the same BNSD S tensor both flavours produce, so they're orthogonal.
  - `sq == 1` is still required for *skipping the transposes* (enforced by `need_transpose`) but not for correctness of the strided-batched GEMM; `sq > 1` is now supported via the prefill flag.
  - `B == 1` is no longer required — the GEMM batch is now `B * G`.

### `lib/Runtime/hipdnn_ep_runtime_state.cpp`

- `hipdnn_ep_state_ensure_workspace` now grows to `max(needed_size, 1.5 × current)` whenever an existing workspace is being enlarged. Cold-start (no existing workspace) still allocates exactly `needed_size` to avoid silently doubling the first large allocation during warmup. Debug log prints both the allocated size and the requested size.

## Behaviour Summary

| Stage | `HIPDNN_EP_GQA_NO_EXPAND` | `HIPDNN_EP_GQA_NO_EXPAND_PREFILL` | Path taken |
|---|---|---|---|
| Decode (`sq == 1`) | default (on) | — | **no-expand**, no Q/O transpose |
| Prefill (`sq > 1`) | default (on) | default (off) | **expand** + Q/O transpose (unchanged) |
| Decode | `0` | — | expand + Q/O transpose (baseline) |
| Prefill | default (on) | `1` | no-expand + Q/O transpose (opt-in A/B) |

## Test plan

- Build verified.
- Pre-commit hooks run on modified files (trailing whitespace, EOL, mixed line endings, merge conflicts, lintrunner, license headers) — all passed.
- E2E runtime tests executed on Mistral-7B across four configurations, all producing byte-identical logits against the pre-change expand baseline:
  - Pre-change expand (reference).
  - No-expand decode only (`HIPDNN_EP_GQA_NO_EXPAND=1`, `HIPDNN_EP_GQA_NO_EXPAND_PREFILL=0`).
  - Decode-only no-expand post unification (same env, post-refactor binary).
  - Prefill opt-in (`HIPDNN_EP_GQA_NO_EXPAND=1`, `HIPDNN_EP_GQA_NO_EXPAND_PREFILL=1`).
- Workspace amortization verified: steady-state decode no longer invokes `hipFree` / `hipMalloc` on incremental `total_seq` growth (confirmed via operator profiling showing the reallocation stalls only at initial warmup and log-spaced growth points).