### PR TITLE
feat: add float32/float16 bidirectional cast kernel support

### DIFF
--- a/3rd-party/custom_kernels/hip/cast_kernel.hip
+++ b/3rd-party/custom_kernels/hip/cast_kernel.hip
@@ -7,6 +7,7 @@
 #include "debug_log.h"
 
 #include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
 #include <cstdint>
 #include <cstdio>
 
@@ -17,6 +18,26 @@ __global__ void cast_i64_to_i32_kernel(
   int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   if (idx < num_elements) {
     output[idx] = static_cast<int32_t>(input[idx]);
+  }
+}
+
+__global__ void cast_f32_to_f16_kernel(
+    const float* __restrict__ input,
+    __half* __restrict__ output,
+    int64_t num_elements) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < num_elements) {
+    output[idx] = __float2half(input[idx]);
+  }
+}
+
+__global__ void cast_f16_to_f32_kernel(
+    const __half* __restrict__ input,
+    float* __restrict__ output,
+    int64_t num_elements) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < num_elements) {
+    output[idx] = __half2float(input[idx]);
   }
 }
 
@@ -37,11 +58,28 @@ extern "C" int hip_cast(
     CUSTOM_KERNELS_DEBUG_LOG("[custom_kernels] hip_cast: INT64->INT32, "
             "num_elements=%lld, grid=%d, block=%d\n",
             (long long)num_elements, grid_size, kBlockSize);
-
     hipLaunchKernelGGL(cast_i64_to_i32_kernel,
                        dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
                        static_cast<const int64_t*>(input),
                        static_cast<int32_t*>(output),
+                       num_elements);
+  } else if (input_dtype == HIP_DTYPE_FLOAT32 && output_dtype == HIP_DTYPE_FLOAT16) {
+    CUSTOM_KERNELS_DEBUG_LOG("[custom_kernels] hip_cast: FLOAT32->FLOAT16, "
+            "num_elements=%lld, grid=%d, block=%d\n",
+            (long long)num_elements, grid_size, kBlockSize);
+    hipLaunchKernelGGL(cast_f32_to_f16_kernel,
+                       dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const float*>(input),
+                       static_cast<__half*>(output),
+                       num_elements);
+  } else if (input_dtype == HIP_DTYPE_FLOAT16 && output_dtype == HIP_DTYPE_FLOAT32) {
+    CUSTOM_KERNELS_DEBUG_LOG("[custom_kernels] hip_cast: FLOAT16->FLOAT32, "
+            "num_elements=%lld, grid=%d, block=%d\n",
+            (long long)num_elements, grid_size, kBlockSize);
+    hipLaunchKernelGGL(cast_f16_to_f32_kernel,
+                       dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const __half*>(input),
+                       static_cast<float*>(output),
                        num_elements);
   } else {
     fprintf(stderr,


### PR DESCRIPTION
## Summary
- Add float32 to float16 and float16 to float32 HIP cast kernels
- Previously only INT64->INT32 was supported, causing runtime failures on models with mixed-precision Cast operations (e.g. Gemma 3 has 276 fp32/fp16 Cast nodes for LayerNorm)
- New kernels use __float2half / __half2float intrinsics

## Test plan
- [x] Gemma 3 4B model: 128 no-chunk benchmark passes with correct output
- [x] Gemma 3 4B model: p512 chunk benchmark passes with correct output
- [x] No unsupported conversion warnings in output
- [ ] CI build and LIT tests pass

Made with [Cursor](https://cursor.com)