### PR TITLE
test(qmoe,gqa): fix lit fixtures from #168 that never actually fired

### DIFF
--- a/test/lit/Conversion/onnx-to-hip/test_gqa_prefill_sentinel.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_gqa_prefill_sentinel.mlir
@@ -32,14 +32,15 @@ module {
   // function argument. The lit test verifies the conversion still lowers
   // cleanly to hip.gqa; the runtime sentinel branch is what actually consumes
   // the value.
-  func.func @test_gqa_prefill_sentinel(
+  // Function must be named @main_graph for --hip-add-context-arg to fire.
+  func.func @main_graph(
       %query: tensor<1x128x12288xf16>,
       %past_key: tensor<1x8x0x128xf16>,
       %past_value: tensor<1x8x0x128xf16>,
       %total_seq_len: tensor<i32>)
       -> (tensor<1x128x4096xf16>, tensor<1x8x128x128xf16>, tensor<1x8x128x128xf16>) {
 
-    // CHECK-LABEL: func.func @test_gqa_prefill_sentinel
+    // CHECK-LABEL: func.func @main_graph
     // CHECK-SAME: (%[[CTX:.*]]: !hip.context,
 
     // ORT prefill sentinel: seqlens_k[b] = -1 means "no past KV yet, this
@@ -67,10 +68,9 @@ module {
         -> (tensor<1x128x4096xf16>, tensor<1x8x128x128xf16>, tensor<1x8x128x128xf16>)
 
     // The constant -1 must reach the conversion intact and the op must
-    // lower cleanly to hip.gqa. We do not need to inspect the constant
-    // value in the lowered IR - it is consumed at runtime.
-    // CHECK: onnx.Constant
-    // CHECK-SAME: dense<-1> : tensor<1xi32>
+    // lower cleanly to hip.gqa. The onnx.Constant is folded to
+    // arith.constant; the value must be preserved verbatim.
+    // CHECK: arith.constant dense<-1> : tensor<1xi32>
     // CHECK: hip.gqa(%[[CTX]])
     // CHECK-SAME: kv_num_heads = 8
     // CHECK-SAME: num_heads = 32

--- a/test/lit/Conversion/onnx-to-hip/test_qmoe_no_block_size.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_qmoe_no_block_size.mlir
@@ -39,7 +39,11 @@ module {
     %fc1_s = "onnx.Constant"() {value = dense<1.000000e+00> : tensor<32x5760x90xf16>} : () -> tensor<32x5760x90xf16>
     %fc2_w = "onnx.Constant"() {value = dense<1> : tensor<32x2880x1440xui8>} : () -> tensor<32x2880x1440xui8>
     %fc2_s = "onnx.Constant"() {value = dense<1.000000e+00> : tensor<32x2880x90xf16>} : () -> tensor<32x2880x90xf16>
-    %Y = "onnx.Custom"(%input, %router_probs, %fc1_w, %fc1_s, %fc2_w, %fc2_s) {
+    // QMoE conversion requires >= 7 operands; insert a NoValue at the
+    // fc1_bias slot (operand index 4) so we satisfy the count without
+    // adding a real bias tensor.
+    %none_fc1b = "onnx.NoValue"() {value} : () -> none
+    %Y = "onnx.Custom"(%input, %router_probs, %fc1_w, %fc1_s, %none_fc1b, %fc2_w, %fc2_s) {
       function_name = "QMoE",
       domain_name = "com.microsoft",
       activation_alpha = 1.702000e+00 : f32, activation_beta = 1.000000e+00 : f32,
@@ -49,7 +53,7 @@ module {
       swiglu_limit = 7.000000e+00 : f32, use_sparse_mixer = 0 : si64,
       onnx_node_name = "QMoE_no_block_size_per_group"
     } : (tensor<1x128x2880xf16>, tensor<128x32xf16>,
-         tensor<32x5760x1440xui8>, tensor<32x5760x90xf16>,
+         tensor<32x5760x1440xui8>, tensor<32x5760x90xf16>, none,
          tensor<32x2880x1440xui8>, tensor<32x2880x90xf16>) -> tensor<1x128x2880xf16>
     return %Y : tensor<1x128x2880xf16>
   }
@@ -72,7 +76,8 @@ module {
     %fc1_s = "onnx.Constant"() {value = dense<1.000000e+00> : tensor<32x5760x1xf16>} : () -> tensor<32x5760x1xf16>
     %fc2_w = "onnx.Constant"() {value = dense<1> : tensor<32x2880x1440xui8>} : () -> tensor<32x2880x1440xui8>
     %fc2_s = "onnx.Constant"() {value = dense<1.000000e+00> : tensor<32x2880x1xf16>} : () -> tensor<32x2880x1xf16>
-    %Y = "onnx.Custom"(%input, %router_probs, %fc1_w, %fc1_s, %fc2_w, %fc2_s) {
+    %none_fc1b = "onnx.NoValue"() {value} : () -> none
+    %Y = "onnx.Custom"(%input, %router_probs, %fc1_w, %fc1_s, %none_fc1b, %fc2_w, %fc2_s) {
       function_name = "QMoE",
       domain_name = "com.microsoft",
       activation_alpha = 1.702000e+00 : f32, activation_beta = 1.000000e+00 : f32,
@@ -82,7 +87,7 @@ module {
       swiglu_limit = 7.000000e+00 : f32, use_sparse_mixer = 0 : si64,
       onnx_node_name = "QMoE_no_block_size_per_channel"
     } : (tensor<1x128x2880xf16>, tensor<128x32xf16>,
-         tensor<32x5760x1440xui8>, tensor<32x5760x1xf16>,
+         tensor<32x5760x1440xui8>, tensor<32x5760x1xf16>, none,
          tensor<32x2880x1440xui8>, tensor<32x2880x1xf16>) -> tensor<1x128x2880xf16>
     return %Y : tensor<1x128x2880xf16>
   }


### PR DESCRIPTION
## Summary

Fixes the two lit fixtures landed in #168 that were committed without ever being run against `hip-mlir-opt`. They appeared green in the original PR because **the conversion was never triggered** -- so the `CHECK:` lines for the lowered op were scanning IR that never existed.
