### PR TITLE
fix(hip): materialize contiguous temporaries for strided memref operands

### DIFF
--- a/include/hip/Dialect/Transforms/Passes.td
+++ b/include/hip/Dialect/Transforms/Passes.td
@@ -103,6 +103,43 @@ def OptimizeMemRefsPass : Pass<"hip-optimize-memrefs", "mlir::func::FuncOp"> {
   ];
 }
 
+def PromoteStridedHipOperandsPass
+    : Pass<"hip-promote-strided-operands", "mlir::func::FuncOp"> {
+  let summary = "Materialize contiguous temporaries for non-canonical memref "
+                "operands of hip.* ops";
+  let description = [{
+    Walks every DestinationStyleOpInterface op in the `hip` dialect.  For
+    each input (DPS-input) operand whose memref type has a non-identity
+    layout (non-zero offset or non-contiguous strides), inserts:
+
+    ```mlir
+    %tmp = memref.alloc() : memref<...identity-layout...>
+    memref.copy %strided, %tmp : ..., ...
+    // consumer is rewritten to read from %tmp instead of %strided
+    memref.dealloc %tmp : memref<...identity-layout...>
+    ```
+
+    DPS-init (output) operands are left untouched: in this pipeline they are
+    always either fresh `memref.alloc` results or function arguments under
+    `IdentityLayoutMap`, so they are guaranteed contiguous by construction.
+
+    The pass exists to bridge the contract gap between the IR (which can
+    represent strided memrefs faithfully via memref.subview) and the HIP
+    runtime call ABI (which receives a single bare pointer with no offset /
+    strides channel).  Without this promotion, hip.* runtime calls silently
+    read the base of the parent buffer instead of the intended slice.
+
+    Recommended pipeline position:
+      hip-optimize-memrefs -> hip-promote-strided-operands -> hip-pool-allocs
+
+    This placement ensures the new transient allocations are routed through
+    the HIP memory pool instead of producing extra hipMalloc calls.
+  }];
+  let dependentDialects = [
+    "mlir::memref::MemRefDialect"
+  ];
+}
+
 def PoolAllocsPass : Pass<"hip-pool-allocs", "mlir::func::FuncOp"> {
   let summary = "Pool memref.alloc ops into a grow-on-demand i8 byte buffer";
   let description = [{

--- a/lib/Conversion/HipToLLVM/ActivationLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ActivationLowering.cpp
@@ -43,8 +43,8 @@ lowerMiopenActivation(OpType op, typename OpType::Adaptor adaptor,
 
   // Extract pointers
   Value statePtr = adaptor.getCtx();
-  Value inputPtr = extractMemRefPtr(adaptor.getX(), rewriter, loc);
-  Value outputPtr = extractMemRefPtr(adaptor.getY(), rewriter, loc);
+  Value inputPtr = extractContiguousMemRefPtr(adaptor.getX(), rewriter, loc);
+  Value outputPtr = extractContiguousMemRefPtr(adaptor.getY(), rewriter, loc);
 
   auto outputType = cast<MemRefType>(op.getY().getType());
 
@@ -158,8 +158,8 @@ struct GeluOpLowering : public ConvertOpToLLVMPattern<GeluOp> {
 
     // Extract pointers
     Value statePtr = adaptor.getCtx();
-    Value inputPtr = extractMemRefPtr(adaptor.getInput(), rewriter, loc);
-    Value outputPtr = extractMemRefPtr(adaptor.getOutput(), rewriter, loc);
+    Value inputPtr = extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc);
+    Value outputPtr = extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
 
     auto outputType = cast<MemRefType>(op.getOutput().getType());
 
@@ -236,8 +236,8 @@ struct SiluOpLowering : public ConvertOpToLLVMPattern<SiluOp> {
       return failure();
 
     SmallVector<Value> args = {
-        adaptor.getCtx(), extractMemRefPtr(adaptor.getInput(), rewriter, loc),
-        extractMemRefPtr(adaptor.getOutput(), rewriter, loc)};
+        adaptor.getCtx(), extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc),
+        extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc)};
 
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
     rewriter.eraseOp(op);
@@ -279,8 +279,8 @@ struct MiopenSoftmaxOpLowering
                                  inputDesc.size(rewriter, loc, i));
 
     SmallVector<Value> args = {
-        adaptor.getCtx(), extractMemRefPtr(adaptor.getInput(), rewriter, loc),
-        extractMemRefPtr(adaptor.getOutput(), rewriter, loc), rows, cols};
+        adaptor.getCtx(), extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc),
+        extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc), rows, cols};
 
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
     rewriter.eraseOp(op);

--- a/lib/Conversion/HipToLLVM/ActivationLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ActivationLowering.cpp
@@ -158,8 +158,10 @@ struct GeluOpLowering : public ConvertOpToLLVMPattern<GeluOp> {
 
     // Extract pointers
     Value statePtr = adaptor.getCtx();
-    Value inputPtr = extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc);
-    Value outputPtr = extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
+    Value inputPtr =
+        extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc);
+    Value outputPtr =
+        extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
 
     auto outputType = cast<MemRefType>(op.getOutput().getType());
 
@@ -236,7 +238,8 @@ struct SiluOpLowering : public ConvertOpToLLVMPattern<SiluOp> {
       return failure();
 
     SmallVector<Value> args = {
-        adaptor.getCtx(), extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc),
+        adaptor.getCtx(),
+        extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc),
         extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc)};
 
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
@@ -279,8 +282,10 @@ struct MiopenSoftmaxOpLowering
                                  inputDesc.size(rewriter, loc, i));
 
     SmallVector<Value> args = {
-        adaptor.getCtx(), extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc),
-        extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc), rows, cols};
+        adaptor.getCtx(),
+        extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc),
+        extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc), rows,
+        cols};
 
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
     rewriter.eraseOp(op);

--- a/lib/Conversion/HipToLLVM/CastLowering.cpp
+++ b/lib/Conversion/HipToLLVM/CastLowering.cpp
@@ -34,8 +34,8 @@ struct CastOpLowering : public ConvertOpToLLVMPattern<CastOp> {
     // Extract pointers using alignedPtr (respects memref.view offsets)
 
     Value statePtr = adaptor.getCtx();
-    Value inputPtr = extractMemRefPtr(adaptor.getInput(), rewriter, loc);
-    Value outputPtr = extractMemRefPtr(adaptor.getOutput(), rewriter, loc);
+    Value inputPtr = extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc);
+    Value outputPtr = extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
 
     auto inputType = cast<MemRefType>(op.getInput().getType());
     auto outputType = cast<MemRefType>(op.getOutput().getType());

--- a/lib/Conversion/HipToLLVM/CastLowering.cpp
+++ b/lib/Conversion/HipToLLVM/CastLowering.cpp
@@ -34,8 +34,10 @@ struct CastOpLowering : public ConvertOpToLLVMPattern<CastOp> {
     // Extract pointers using alignedPtr (respects memref.view offsets)
 
     Value statePtr = adaptor.getCtx();
-    Value inputPtr = extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc);
-    Value outputPtr = extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
+    Value inputPtr =
+        extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc);
+    Value outputPtr =
+        extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
 
     auto inputType = cast<MemRefType>(op.getInput().getType());
     auto outputType = cast<MemRefType>(op.getOutput().getType());

--- a/lib/Conversion/HipToLLVM/CausalConvWithStateLowering.cpp
+++ b/lib/Conversion/HipToLLVM/CausalConvWithStateLowering.cpp
@@ -40,18 +40,18 @@ struct CausalConvWithStateOpLowering
 
     // Extract pointers
     Value statePtr = adaptor.getCtx();
-    Value inputPtr = extractMemRefPtr(adaptor.getInput(), rewriter, loc);
-    Value weightPtr = extractMemRefPtr(adaptor.getWeight(), rewriter, loc);
+    Value inputPtr = extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc);
+    Value weightPtr = extractContiguousMemRefPtr(adaptor.getWeight(), rewriter, loc);
     Value biasPtr = adaptor.getBias()
-                        ? extractMemRefPtr(adaptor.getBias(), rewriter, loc)
+                        ? extractContiguousMemRefPtr(adaptor.getBias(), rewriter, loc)
                         : nullPtr;
     Value pastStatePtr =
         adaptor.getPastState()
-            ? extractMemRefPtr(adaptor.getPastState(), rewriter, loc)
+            ? extractContiguousMemRefPtr(adaptor.getPastState(), rewriter, loc)
             : nullPtr;
-    Value outputPtr = extractMemRefPtr(adaptor.getOutput(), rewriter, loc);
+    Value outputPtr = extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
     Value presentStatePtr =
-        extractMemRefPtr(adaptor.getPresentState(), rewriter, loc);
+        extractContiguousMemRefPtr(adaptor.getPresentState(), rewriter, loc);
 
     // Extract shape info from input memref: (batch, channels, L) for ndim=1
     auto inputType = cast<MemRefType>(op.getInput().getType());

--- a/lib/Conversion/HipToLLVM/CausalConvWithStateLowering.cpp
+++ b/lib/Conversion/HipToLLVM/CausalConvWithStateLowering.cpp
@@ -40,16 +40,20 @@ struct CausalConvWithStateOpLowering
 
     // Extract pointers
     Value statePtr = adaptor.getCtx();
-    Value inputPtr = extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc);
-    Value weightPtr = extractContiguousMemRefPtr(adaptor.getWeight(), rewriter, loc);
-    Value biasPtr = adaptor.getBias()
-                        ? extractContiguousMemRefPtr(adaptor.getBias(), rewriter, loc)
-                        : nullPtr;
+    Value inputPtr =
+        extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc);
+    Value weightPtr =
+        extractContiguousMemRefPtr(adaptor.getWeight(), rewriter, loc);
+    Value biasPtr =
+        adaptor.getBias()
+            ? extractContiguousMemRefPtr(adaptor.getBias(), rewriter, loc)
+            : nullPtr;
     Value pastStatePtr =
         adaptor.getPastState()
             ? extractContiguousMemRefPtr(adaptor.getPastState(), rewriter, loc)
             : nullPtr;
-    Value outputPtr = extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
+    Value outputPtr =
+        extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
     Value presentStatePtr =
         extractContiguousMemRefPtr(adaptor.getPresentState(), rewriter, loc);
 

--- a/lib/Conversion/HipToLLVM/ConvLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ConvLowering.cpp
@@ -72,9 +72,12 @@ struct ConvOpLowering : public ConvertOpToLLVMPattern<ConvOp> {
 
     // Extract memref pointers (aligned pointers from descriptors)
     Value statePtr = adaptor.getCtx(); // RuntimeState* (opaque)
-    Value inputPtr = extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc);
-    Value weightsPtr = extractContiguousMemRefPtr(adaptor.getWeights(), rewriter, loc);
-    Value outputPtr = extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
+    Value inputPtr =
+        extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc);
+    Value weightsPtr =
+        extractContiguousMemRefPtr(adaptor.getWeights(), rewriter, loc);
+    Value outputPtr =
+        extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
 
     // Handle optional bias
     Value biasPtr;

--- a/lib/Conversion/HipToLLVM/ConvLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ConvLowering.cpp
@@ -72,14 +72,14 @@ struct ConvOpLowering : public ConvertOpToLLVMPattern<ConvOp> {
 
     // Extract memref pointers (aligned pointers from descriptors)
     Value statePtr = adaptor.getCtx(); // RuntimeState* (opaque)
-    Value inputPtr = extractMemRefPtr(adaptor.getInput(), rewriter, loc);
-    Value weightsPtr = extractMemRefPtr(adaptor.getWeights(), rewriter, loc);
-    Value outputPtr = extractMemRefPtr(adaptor.getOutput(), rewriter, loc);
+    Value inputPtr = extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc);
+    Value weightsPtr = extractContiguousMemRefPtr(adaptor.getWeights(), rewriter, loc);
+    Value outputPtr = extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
 
     // Handle optional bias
     Value biasPtr;
     if (adaptor.getBias()) {
-      biasPtr = extractMemRefPtr(adaptor.getBias(), rewriter, loc);
+      biasPtr = extractContiguousMemRefPtr(adaptor.getBias(), rewriter, loc);
     } else {
       // Pass null pointer if no bias
       biasPtr = LLVM::ZeroOp::create(rewriter, loc, ptrType);

--- a/lib/Conversion/HipToLLVM/ElementwiseLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ElementwiseLowering.cpp
@@ -58,9 +58,9 @@ struct MiopenBinaryOpLowering : public ConvertOpToLLVMPattern<OpTy> {
     Value numB = computeNumElements(bType, adaptor.getB(), rewriter, loc);
 
     SmallVector<Value> args = {adaptor.getCtx(),
-                               extractMemRefPtr(adaptor.getA(), rewriter, loc),
-                               extractMemRefPtr(adaptor.getB(), rewriter, loc),
-                               extractMemRefPtr(adaptor.getC(), rewriter, loc),
+                               extractContiguousMemRefPtr(adaptor.getA(), rewriter, loc),
+                               extractContiguousMemRefPtr(adaptor.getB(), rewriter, loc),
+                               extractContiguousMemRefPtr(adaptor.getC(), rewriter, loc),
                                numA,
                                numB};
 
@@ -133,9 +133,9 @@ struct ElementwiseOpLowering : public ConvertOpToLLVMPattern<OpTy> {
       return failure();
 
     SmallVector<Value, 18> args = {
-        adaptor.getCtx(), extractMemRefPtr(adaptor.getLhs(), rewriter, loc),
-        extractMemRefPtr(adaptor.getRhs(), rewriter, loc),
-        extractMemRefPtr(adaptor.getOutput(), rewriter, loc)};
+        adaptor.getCtx(), extractContiguousMemRefPtr(adaptor.getLhs(), rewriter, loc),
+        extractContiguousMemRefPtr(adaptor.getRhs(), rewriter, loc),
+        extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc)};
     args.append(lhsDims.begin(), lhsDims.end());
     args.append(rhsDims.begin(), rhsDims.end());
     args.append(outDims.begin(), outDims.end());
@@ -188,9 +188,9 @@ struct SubOpLowering : public ConvertOpToLLVMPattern<SubOp> {
     };
 
     Value statePtr = adaptor.getCtx();
-    Value lhsPtr = extractMemRefPtr(adaptor.getLhs(), rewriter, loc);
-    Value rhsPtr = extractMemRefPtr(adaptor.getRhs(), rewriter, loc);
-    Value outputPtr = extractMemRefPtr(adaptor.getOutput(), rewriter, loc);
+    Value lhsPtr = extractContiguousMemRefPtr(adaptor.getLhs(), rewriter, loc);
+    Value rhsPtr = extractContiguousMemRefPtr(adaptor.getRhs(), rewriter, loc);
+    Value outputPtr = extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
 
     auto outputType = cast<MemRefType>(op.getOutput().getType());
 

--- a/lib/Conversion/HipToLLVM/ElementwiseLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ElementwiseLowering.cpp
@@ -57,12 +57,13 @@ struct MiopenBinaryOpLowering : public ConvertOpToLLVMPattern<OpTy> {
     Value numA = computeNumElements(aType, adaptor.getA(), rewriter, loc);
     Value numB = computeNumElements(bType, adaptor.getB(), rewriter, loc);
 
-    SmallVector<Value> args = {adaptor.getCtx(),
-                               extractContiguousMemRefPtr(adaptor.getA(), rewriter, loc),
-                               extractContiguousMemRefPtr(adaptor.getB(), rewriter, loc),
-                               extractContiguousMemRefPtr(adaptor.getC(), rewriter, loc),
-                               numA,
-                               numB};
+    SmallVector<Value> args = {
+        adaptor.getCtx(),
+        extractContiguousMemRefPtr(adaptor.getA(), rewriter, loc),
+        extractContiguousMemRefPtr(adaptor.getB(), rewriter, loc),
+        extractContiguousMemRefPtr(adaptor.getC(), rewriter, loc),
+        numA,
+        numB};
 
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
     rewriter.eraseOp(op);
@@ -133,7 +134,8 @@ struct ElementwiseOpLowering : public ConvertOpToLLVMPattern<OpTy> {
       return failure();
 
     SmallVector<Value, 18> args = {
-        adaptor.getCtx(), extractContiguousMemRefPtr(adaptor.getLhs(), rewriter, loc),
+        adaptor.getCtx(),
+        extractContiguousMemRefPtr(adaptor.getLhs(), rewriter, loc),
         extractContiguousMemRefPtr(adaptor.getRhs(), rewriter, loc),
         extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc)};
     args.append(lhsDims.begin(), lhsDims.end());
@@ -190,7 +192,8 @@ struct SubOpLowering : public ConvertOpToLLVMPattern<SubOp> {
     Value statePtr = adaptor.getCtx();
     Value lhsPtr = extractContiguousMemRefPtr(adaptor.getLhs(), rewriter, loc);
     Value rhsPtr = extractContiguousMemRefPtr(adaptor.getRhs(), rewriter, loc);
-    Value outputPtr = extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
+    Value outputPtr =
+        extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
 
     auto outputType = cast<MemRefType>(op.getOutput().getType());
 

--- a/lib/Conversion/HipToLLVM/GatherLowering.cpp
+++ b/lib/Conversion/HipToLLVM/GatherLowering.cpp
@@ -23,9 +23,12 @@ struct GatherOpLowering : public ConvertOpToLLVMPattern<GatherOp> {
     Type i64Type = rewriter.getI64Type();
 
     Value statePtr = adaptor.getCtx();
-    Value dataPtr = extractContiguousMemRefPtr(adaptor.getData(), rewriter, loc);
-    Value indicesPtr = extractContiguousMemRefPtr(adaptor.getIndices(), rewriter, loc);
-    Value outputPtr = extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
+    Value dataPtr =
+        extractContiguousMemRefPtr(adaptor.getData(), rewriter, loc);
+    Value indicesPtr =
+        extractContiguousMemRefPtr(adaptor.getIndices(), rewriter, loc);
+    Value outputPtr =
+        extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
 
     // Compute data_num_elements
     auto dataType = cast<MemRefType>(op.getData().getType());

--- a/lib/Conversion/HipToLLVM/GatherLowering.cpp
+++ b/lib/Conversion/HipToLLVM/GatherLowering.cpp
@@ -23,9 +23,9 @@ struct GatherOpLowering : public ConvertOpToLLVMPattern<GatherOp> {
     Type i64Type = rewriter.getI64Type();
 
     Value statePtr = adaptor.getCtx();
-    Value dataPtr = extractMemRefPtr(adaptor.getData(), rewriter, loc);
-    Value indicesPtr = extractMemRefPtr(adaptor.getIndices(), rewriter, loc);
-    Value outputPtr = extractMemRefPtr(adaptor.getOutput(), rewriter, loc);
+    Value dataPtr = extractContiguousMemRefPtr(adaptor.getData(), rewriter, loc);
+    Value indicesPtr = extractContiguousMemRefPtr(adaptor.getIndices(), rewriter, loc);
+    Value outputPtr = extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
 
     // Compute data_num_elements
     auto dataType = cast<MemRefType>(op.getData().getType());

--- a/lib/Conversion/HipToLLVM/GemmLowering.cpp
+++ b/lib/Conversion/HipToLLVM/GemmLowering.cpp
@@ -45,11 +45,14 @@ struct GemmOpLowering : public ConvertOpToLLVMPattern<GemmOp> {
     Value typeCodeVal = createI64Const(typeCode);
 
     Value statePtr = adaptor.getCtx();
-    Value input_A_ptr = extractContiguousMemRefPtr(adaptor.getInputA(), rewriter, loc);
-    Value input_B_ptr = extractContiguousMemRefPtr(adaptor.getInputB(), rewriter, loc);
+    Value input_A_ptr =
+        extractContiguousMemRefPtr(adaptor.getInputA(), rewriter, loc);
+    Value input_B_ptr =
+        extractContiguousMemRefPtr(adaptor.getInputB(), rewriter, loc);
     Value input_C_ptr =
         extractOptionalMemRefPtr(adaptor.getInputC(), rewriter, loc);
-    Value output_ptr = extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
+    Value output_ptr =
+        extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
 
     Value alpha = LLVM::ConstantOp::create(
         rewriter, loc, f32Type,

--- a/lib/Conversion/HipToLLVM/GemmLowering.cpp
+++ b/lib/Conversion/HipToLLVM/GemmLowering.cpp
@@ -45,11 +45,11 @@ struct GemmOpLowering : public ConvertOpToLLVMPattern<GemmOp> {
     Value typeCodeVal = createI64Const(typeCode);
 
     Value statePtr = adaptor.getCtx();
-    Value input_A_ptr = extractMemRefPtr(adaptor.getInputA(), rewriter, loc);
-    Value input_B_ptr = extractMemRefPtr(adaptor.getInputB(), rewriter, loc);
+    Value input_A_ptr = extractContiguousMemRefPtr(adaptor.getInputA(), rewriter, loc);
+    Value input_B_ptr = extractContiguousMemRefPtr(adaptor.getInputB(), rewriter, loc);
     Value input_C_ptr =
         extractOptionalMemRefPtr(adaptor.getInputC(), rewriter, loc);
-    Value output_ptr = extractMemRefPtr(adaptor.getOutput(), rewriter, loc);
+    Value output_ptr = extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
 
     Value alpha = LLVM::ConstantOp::create(
         rewriter, loc, f32Type,

--- a/lib/Conversion/HipToLLVM/GqaLowering.cpp
+++ b/lib/Conversion/HipToLLVM/GqaLowering.cpp
@@ -49,8 +49,10 @@ struct GqaOpLowering : public ConvertOpToLLVMPattern<GqaOp> {
     Value statePtr = adaptor.getCtx();
 
     // Required inputs
-    Value queryPtr = extractContiguousMemRefPtr(adaptor.getQuery(), rewriter, loc);
-    Value seqlensKPtr = extractContiguousMemRefPtr(adaptor.getSeqlensK(), rewriter, loc);
+    Value queryPtr =
+        extractContiguousMemRefPtr(adaptor.getQuery(), rewriter, loc);
+    Value seqlensKPtr =
+        extractContiguousMemRefPtr(adaptor.getSeqlensK(), rewriter, loc);
     Value totalSeqLenPtr =
         extractContiguousMemRefPtr(adaptor.getTotalSeqLen(), rewriter, loc);
 
@@ -68,7 +70,8 @@ struct GqaOpLowering : public ConvertOpToLLVMPattern<GqaOp> {
     Value vScalePtr = getMemRefPtrOrNull(adaptor.getVScale());
 
     // Output pointers
-    Value outputPtr = extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
+    Value outputPtr =
+        extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
     Value presentKeyPtr =
         extractContiguousMemRefPtr(adaptor.getPresentKey(), rewriter, loc);
     Value presentValuePtr =

--- a/lib/Conversion/HipToLLVM/GqaLowering.cpp
+++ b/lib/Conversion/HipToLLVM/GqaLowering.cpp
@@ -41,7 +41,7 @@ struct GqaOpLowering : public ConvertOpToLLVMPattern<GqaOp> {
     auto getMemRefPtrOrNull = [&](Value memref) -> Value {
       if (!memref)
         return nullPtr;
-      return extractMemRefPtr(memref, rewriter, loc);
+      return extractContiguousMemRefPtr(memref, rewriter, loc);
     };
 
     // === Extract all inputs (required + optional) ===
@@ -49,10 +49,10 @@ struct GqaOpLowering : public ConvertOpToLLVMPattern<GqaOp> {
     Value statePtr = adaptor.getCtx();
 
     // Required inputs
-    Value queryPtr = extractMemRefPtr(adaptor.getQuery(), rewriter, loc);
-    Value seqlensKPtr = extractMemRefPtr(adaptor.getSeqlensK(), rewriter, loc);
+    Value queryPtr = extractContiguousMemRefPtr(adaptor.getQuery(), rewriter, loc);
+    Value seqlensKPtr = extractContiguousMemRefPtr(adaptor.getSeqlensK(), rewriter, loc);
     Value totalSeqLenPtr =
-        extractMemRefPtr(adaptor.getTotalSeqLen(), rewriter, loc);
+        extractContiguousMemRefPtr(adaptor.getTotalSeqLen(), rewriter, loc);
 
     // Optional inputs (may be nullptr)
     Value keyPtr = getMemRefPtrOrNull(adaptor.getKey());
@@ -68,11 +68,11 @@ struct GqaOpLowering : public ConvertOpToLLVMPattern<GqaOp> {
     Value vScalePtr = getMemRefPtrOrNull(adaptor.getVScale());
 
     // Output pointers
-    Value outputPtr = extractMemRefPtr(adaptor.getOutput(), rewriter, loc);
+    Value outputPtr = extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
     Value presentKeyPtr =
-        extractMemRefPtr(adaptor.getPresentKey(), rewriter, loc);
+        extractContiguousMemRefPtr(adaptor.getPresentKey(), rewriter, loc);
     Value presentValuePtr =
-        extractMemRefPtr(adaptor.getPresentValue(), rewriter, loc);
+        extractContiguousMemRefPtr(adaptor.getPresentValue(), rewriter, loc);
     Value outputQkPtr = getMemRefPtrOrNull(adaptor.getOutputQk());
 
     // === Extract attributes ===

--- a/lib/Conversion/HipToLLVM/GraphLowering.cpp
+++ b/lib/Conversion/HipToLLVM/GraphLowering.cpp
@@ -105,7 +105,8 @@ struct HipDNNGraphOpLowering : public ConvertOpToLLVMPattern<HipDNNGraphOp> {
 
     // Store aligned_ptr from each memref descriptor
     for (int32_t i : llvm::seq<int32_t>(numInputs)) {
-      Value ptr = extractContiguousMemRefPtr(adaptor.getInputs()[i], rewriter, loc);
+      Value ptr =
+          extractContiguousMemRefPtr(adaptor.getInputs()[i], rewriter, loc);
       Value idxVal = LLVM::ConstantOp::create(rewriter, loc, i32Type,
                                               rewriter.getI32IntegerAttr(i));
       Value gepPtr =
@@ -113,7 +114,8 @@ struct HipDNNGraphOpLowering : public ConvertOpToLLVMPattern<HipDNNGraphOp> {
       LLVM::StoreOp::create(rewriter, loc, ptr, gepPtr);
     }
     for (int32_t i : llvm::seq<int32_t>(numOutputs)) {
-      Value ptr = extractContiguousMemRefPtr(adaptor.getOutputs()[i], rewriter, loc);
+      Value ptr =
+          extractContiguousMemRefPtr(adaptor.getOutputs()[i], rewriter, loc);
       Value idxVal = LLVM::ConstantOp::create(
           rewriter, loc, i32Type, rewriter.getI32IntegerAttr(numInputs + i));
       Value gepPtr =

--- a/lib/Conversion/HipToLLVM/GraphLowering.cpp
+++ b/lib/Conversion/HipToLLVM/GraphLowering.cpp
@@ -105,7 +105,7 @@ struct HipDNNGraphOpLowering : public ConvertOpToLLVMPattern<HipDNNGraphOp> {
 
     // Store aligned_ptr from each memref descriptor
     for (int32_t i : llvm::seq<int32_t>(numInputs)) {
-      Value ptr = extractMemRefPtr(adaptor.getInputs()[i], rewriter, loc);
+      Value ptr = extractContiguousMemRefPtr(adaptor.getInputs()[i], rewriter, loc);
       Value idxVal = LLVM::ConstantOp::create(rewriter, loc, i32Type,
                                               rewriter.getI32IntegerAttr(i));
       Value gepPtr =
@@ -113,7 +113,7 @@ struct HipDNNGraphOpLowering : public ConvertOpToLLVMPattern<HipDNNGraphOp> {
       LLVM::StoreOp::create(rewriter, loc, ptr, gepPtr);
     }
     for (int32_t i : llvm::seq<int32_t>(numOutputs)) {
-      Value ptr = extractMemRefPtr(adaptor.getOutputs()[i], rewriter, loc);
+      Value ptr = extractContiguousMemRefPtr(adaptor.getOutputs()[i], rewriter, loc);
       Value idxVal = LLVM::ConstantOp::create(
           rewriter, loc, i32Type, rewriter.getI32IntegerAttr(numInputs + i));
       Value gepPtr =

--- a/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
+++ b/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
@@ -171,8 +171,8 @@ inline Value extractOptionalMemRefPtr(Value memrefDesc,
 // measurably expensive and the underlying library natively accepts strides).
 // No in-tree callers today.
 inline MemRefDescriptor
-extractMemRefDescriptor(Value memrefDesc,
-                        ConversionPatternRewriter &rewriter, Location loc) {
+extractMemRefDescriptor(Value memrefDesc, ConversionPatternRewriter &rewriter,
+                        Location loc) {
   (void)rewriter;
   (void)loc;
   return MemRefDescriptor(memrefDesc);

--- a/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
+++ b/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
@@ -116,12 +116,25 @@ enum class TensorOp : int64_t {
 
 // Helper: extract the aligned data pointer from a converted memref descriptor,
 // casting to address space 0 if needed.
+//
+// PRECONDITION: the source memref must have an identity layout (zero offset,
+// contiguous strides).  The returned pointer is alignedPtr only — offset and
+// strides are dropped on the floor.  Calling this on a strided/offset memref
+// (e.g., the result of memref.subview) silently produces a pointer to the
+// base of the parent buffer, not the slice.
+//
+// The --hip-promote-strided-operands pass enforces this precondition for
+// hip.* DPS-input operands by materializing contiguous temporaries upstream.
+// Direct callers (outside the standard hip.* lowering path) must guarantee
+// it themselves; if you need the descriptor's offset / strides, use
+// extractMemRefDescriptor below.
+//
 // Uses alignedPtr (not allocatedPtr) so that memref.view offsets into a memory
 // pool are respected -- each view has the same allocatedPtr but a distinct
 // alignedPtr.
-inline Value extractMemRefPtr(Value memrefDesc,
-                              ConversionPatternRewriter &rewriter,
-                              Location loc) {
+inline Value extractContiguousMemRefPtr(Value memrefDesc,
+                                        ConversionPatternRewriter &rewriter,
+                                        Location loc) {
   Value ptr = MemRefDescriptor(memrefDesc).alignedPtr(rewriter, loc);
   auto ptrTy = cast<LLVM::LLVMPointerType>(ptr.getType());
   if (ptrTy.getAddressSpace() != 0)
@@ -133,17 +146,36 @@ inline Value extractMemRefPtr(Value memrefDesc,
 
 // Returns the aligned pointer for an optional memref operand, or a null
 // pointer if the operand is absent.
+//
+// Same identity-layout precondition as extractContiguousMemRefPtr.
 inline Value extractOptionalMemRefPtr(Value memrefDesc,
                                       ConversionPatternRewriter &rewriter,
                                       Location loc) {
   Value result;
   if (memrefDesc) {
-    result = extractMemRefPtr(memrefDesc, rewriter, loc);
+    result = extractContiguousMemRefPtr(memrefDesc, rewriter, loc);
   } else {
     result = LLVM::ZeroOp::create(
         rewriter, loc, LLVM::LLVMPointerType::get(rewriter.getContext(), 0));
   }
   return result;
+}
+
+// Returns the full LLVM memref descriptor wrapper for \p memrefDesc, exposing
+// allocatedPtr / alignedPtr / offset / sizes / strides via MemRefDescriptor's
+// accessors.  Use this when a runtime call needs to honor the slice (offset,
+// per-dim strides) instead of treating the operand as contiguous.
+//
+// Reserved for future per-op zero-copy lowerings (hot ops where the upstream
+// promote-then-copy materialization in --hip-promote-strided-operands is
+// measurably expensive and the underlying library natively accepts strides).
+// No in-tree callers today.
+inline MemRefDescriptor
+extractMemRefDescriptor(Value memrefDesc,
+                        ConversionPatternRewriter &rewriter, Location loc) {
+  (void)rewriter;
+  (void)loc;
+  return MemRefDescriptor(memrefDesc);
 }
 
 // Helper: get a single memref dimension as an i64 Value, using a compile-time

--- a/lib/Conversion/HipToLLVM/MatMulNBitsLowering.cpp
+++ b/lib/Conversion/HipToLLVM/MatMulNBitsLowering.cpp
@@ -31,14 +31,14 @@ struct MatMulNBitsOpLowering : public ConvertOpToLLVMPattern<MatMulNBitsOp> {
     };
 
     Value statePtr = adaptor.getHandle();
-    Value APtr = extractMemRefPtr(adaptor.getA(), rewriter, loc);
-    Value BPtr = extractMemRefPtr(adaptor.getB(), rewriter, loc);
-    Value scalesPtr = extractMemRefPtr(adaptor.getScales(), rewriter, loc);
+    Value APtr = extractContiguousMemRefPtr(adaptor.getA(), rewriter, loc);
+    Value BPtr = extractContiguousMemRefPtr(adaptor.getB(), rewriter, loc);
+    Value scalesPtr = extractContiguousMemRefPtr(adaptor.getScales(), rewriter, loc);
     Value zeroPointsPtr =
         extractOptionalMemRefPtr(adaptor.getZeroPoints(), rewriter, loc);
     Value gIdxPtr = extractOptionalMemRefPtr(adaptor.getGIdx(), rewriter, loc);
     Value biasPtr = extractOptionalMemRefPtr(adaptor.getBias(), rewriter, loc);
-    Value outputPtr = extractMemRefPtr(adaptor.getOutput(), rewriter, loc);
+    Value outputPtr = extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
 
     auto AType = cast<MemRefType>(op.getA().getType());
     int64_t ARank = AType.getRank();

--- a/lib/Conversion/HipToLLVM/MatMulNBitsLowering.cpp
+++ b/lib/Conversion/HipToLLVM/MatMulNBitsLowering.cpp
@@ -33,12 +33,14 @@ struct MatMulNBitsOpLowering : public ConvertOpToLLVMPattern<MatMulNBitsOp> {
     Value statePtr = adaptor.getHandle();
     Value APtr = extractContiguousMemRefPtr(adaptor.getA(), rewriter, loc);
     Value BPtr = extractContiguousMemRefPtr(adaptor.getB(), rewriter, loc);
-    Value scalesPtr = extractContiguousMemRefPtr(adaptor.getScales(), rewriter, loc);
+    Value scalesPtr =
+        extractContiguousMemRefPtr(adaptor.getScales(), rewriter, loc);
     Value zeroPointsPtr =
         extractOptionalMemRefPtr(adaptor.getZeroPoints(), rewriter, loc);
     Value gIdxPtr = extractOptionalMemRefPtr(adaptor.getGIdx(), rewriter, loc);
     Value biasPtr = extractOptionalMemRefPtr(adaptor.getBias(), rewriter, loc);
-    Value outputPtr = extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
+    Value outputPtr =
+        extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
 
     auto AType = cast<MemRefType>(op.getA().getType());
     int64_t ARank = AType.getRank();

--- a/lib/Conversion/HipToLLVM/MatmulLowering.cpp
+++ b/lib/Conversion/HipToLLVM/MatmulLowering.cpp
@@ -36,7 +36,8 @@ struct MatmulOpLowering : public ConvertOpToLLVMPattern<MatmulOp> {
     Value statePtr = adaptor.getCtx();
     Value APtr = extractContiguousMemRefPtr(adaptor.getA(), rewriter, loc);
     Value BPtr = extractContiguousMemRefPtr(adaptor.getB(), rewriter, loc);
-    Value outputPtr = extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
+    Value outputPtr =
+        extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
 
     // Get memref types and shapes
     auto AType = cast<MemRefType>(op.getA().getType());

--- a/lib/Conversion/HipToLLVM/MatmulLowering.cpp
+++ b/lib/Conversion/HipToLLVM/MatmulLowering.cpp
@@ -34,9 +34,9 @@ struct MatmulOpLowering : public ConvertOpToLLVMPattern<MatmulOp> {
 
     // Extract pointers
     Value statePtr = adaptor.getCtx();
-    Value APtr = extractMemRefPtr(adaptor.getA(), rewriter, loc);
-    Value BPtr = extractMemRefPtr(adaptor.getB(), rewriter, loc);
-    Value outputPtr = extractMemRefPtr(adaptor.getOutput(), rewriter, loc);
+    Value APtr = extractContiguousMemRefPtr(adaptor.getA(), rewriter, loc);
+    Value BPtr = extractContiguousMemRefPtr(adaptor.getB(), rewriter, loc);
+    Value outputPtr = extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
 
     // Get memref types and shapes
     auto AType = cast<MemRefType>(op.getA().getType());

--- a/lib/Conversion/HipToLLVM/NormLowering.cpp
+++ b/lib/Conversion/HipToLLVM/NormLowering.cpp
@@ -27,9 +27,12 @@ struct RmsNormOpLowering : public ConvertOpToLLVMPattern<RmsNormOp> {
 
     // Extract pointers
     Value statePtr = adaptor.getCtx();
-    Value inputPtr = extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc);
-    Value scalePtr = extractContiguousMemRefPtr(adaptor.getScale(), rewriter, loc);
-    Value outputPtr = extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
+    Value inputPtr =
+        extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc);
+    Value scalePtr =
+        extractContiguousMemRefPtr(adaptor.getScale(), rewriter, loc);
+    Value outputPtr =
+        extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
 
     // Compute num_elements with dynamic shape support
     auto inputType = cast<MemRefType>(op.getInput().getType());
@@ -108,16 +111,20 @@ struct SkipRmsNormOpLowering : public ConvertOpToLLVMPattern<SkipRmsNormOp> {
 
     // Extract pointers
     Value statePtr = adaptor.getCtx();
-    Value inputPtr = extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc);
-    Value skipPtr = extractContiguousMemRefPtr(adaptor.getSkip(), rewriter, loc);
-    Value gammaPtr = extractContiguousMemRefPtr(adaptor.getGamma(), rewriter, loc);
+    Value inputPtr =
+        extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc);
+    Value skipPtr =
+        extractContiguousMemRefPtr(adaptor.getSkip(), rewriter, loc);
+    Value gammaPtr =
+        extractContiguousMemRefPtr(adaptor.getGamma(), rewriter, loc);
     Value biasPtr = getMemRefPtrOrNull(adaptor.getBias());
     // DPS outputs: outputs[0]=output, outputs[1]=input_skip_bias_sum (optional)
     auto outputs = adaptor.getOutputs();
     Value outputPtr = extractContiguousMemRefPtr(outputs[0], rewriter, loc);
-    Value skipOutputPtr = outputs.size() > 1
-                              ? extractContiguousMemRefPtr(outputs[1], rewriter, loc)
-                              : nullPtr;
+    Value skipOutputPtr =
+        outputs.size() > 1
+            ? extractContiguousMemRefPtr(outputs[1], rewriter, loc)
+            : nullPtr;
 
     // Compute num_elements for input and gamma
     auto inputType = cast<MemRefType>(op.getInput().getType());

--- a/lib/Conversion/HipToLLVM/NormLowering.cpp
+++ b/lib/Conversion/HipToLLVM/NormLowering.cpp
@@ -27,9 +27,9 @@ struct RmsNormOpLowering : public ConvertOpToLLVMPattern<RmsNormOp> {
 
     // Extract pointers
     Value statePtr = adaptor.getCtx();
-    Value inputPtr = extractMemRefPtr(adaptor.getInput(), rewriter, loc);
-    Value scalePtr = extractMemRefPtr(adaptor.getScale(), rewriter, loc);
-    Value outputPtr = extractMemRefPtr(adaptor.getOutput(), rewriter, loc);
+    Value inputPtr = extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc);
+    Value scalePtr = extractContiguousMemRefPtr(adaptor.getScale(), rewriter, loc);
+    Value outputPtr = extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
 
     // Compute num_elements with dynamic shape support
     auto inputType = cast<MemRefType>(op.getInput().getType());
@@ -103,20 +103,20 @@ struct SkipRmsNormOpLowering : public ConvertOpToLLVMPattern<SkipRmsNormOp> {
     auto getMemRefPtrOrNull = [&](Value memref) -> Value {
       if (!memref)
         return nullPtr;
-      return extractMemRefPtr(memref, rewriter, loc);
+      return extractContiguousMemRefPtr(memref, rewriter, loc);
     };
 
     // Extract pointers
     Value statePtr = adaptor.getCtx();
-    Value inputPtr = extractMemRefPtr(adaptor.getInput(), rewriter, loc);
-    Value skipPtr = extractMemRefPtr(adaptor.getSkip(), rewriter, loc);
-    Value gammaPtr = extractMemRefPtr(adaptor.getGamma(), rewriter, loc);
+    Value inputPtr = extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc);
+    Value skipPtr = extractContiguousMemRefPtr(adaptor.getSkip(), rewriter, loc);
+    Value gammaPtr = extractContiguousMemRefPtr(adaptor.getGamma(), rewriter, loc);
     Value biasPtr = getMemRefPtrOrNull(adaptor.getBias());
     // DPS outputs: outputs[0]=output, outputs[1]=input_skip_bias_sum (optional)
     auto outputs = adaptor.getOutputs();
-    Value outputPtr = extractMemRefPtr(outputs[0], rewriter, loc);
+    Value outputPtr = extractContiguousMemRefPtr(outputs[0], rewriter, loc);
     Value skipOutputPtr = outputs.size() > 1
-                              ? extractMemRefPtr(outputs[1], rewriter, loc)
+                              ? extractContiguousMemRefPtr(outputs[1], rewriter, loc)
                               : nullPtr;
 
     // Compute num_elements for input and gamma

--- a/lib/Conversion/HipToLLVM/PowerLowering.cpp
+++ b/lib/Conversion/HipToLLVM/PowerLowering.cpp
@@ -51,8 +51,8 @@ struct PowerOpLowering : public ConvertOpToLLVMPattern<OpTy> {
     };
 
     Value statePtr = adaptor.getCtx();
-    Value inputPtr = extractMemRefPtr(adaptor.getX(), rewriter, loc);
-    Value outputPtr = extractMemRefPtr(adaptor.getY(), rewriter, loc);
+    Value inputPtr = extractContiguousMemRefPtr(adaptor.getX(), rewriter, loc);
+    Value outputPtr = extractContiguousMemRefPtr(adaptor.getY(), rewriter, loc);
 
     auto outputType = dyn_cast<MemRefType>(op.getY().getType());
     if (!outputType)

--- a/lib/Conversion/HipToLLVM/QMoELowering.cpp
+++ b/lib/Conversion/HipToLLVM/QMoELowering.cpp
@@ -36,16 +36,18 @@ struct QMoEOpLowering : public ConvertOpToLLVMPattern<QMoEOp> {
     };
 
     Value statePtr = adaptor.getHandle();
-    Value inputPtr = extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc);
-    Value routerPtr = extractContiguousMemRefPtr(adaptor.getRouterProbs(), rewriter, loc);
-    Value fc1WeightsPtr =
-        extractContiguousMemRefPtr(adaptor.getFc1ExpertsWeights(), rewriter, loc);
+    Value inputPtr =
+        extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc);
+    Value routerPtr =
+        extractContiguousMemRefPtr(adaptor.getRouterProbs(), rewriter, loc);
+    Value fc1WeightsPtr = extractContiguousMemRefPtr(
+        adaptor.getFc1ExpertsWeights(), rewriter, loc);
     Value fc1ScalesPtr =
         extractContiguousMemRefPtr(adaptor.getFc1Scales(), rewriter, loc);
     Value fc1BiasPtr =
         extractOptionalMemRefPtr(adaptor.getFc1ExpertsBias(), rewriter, loc);
-    Value fc2WeightsPtr =
-        extractContiguousMemRefPtr(adaptor.getFc2ExpertsWeights(), rewriter, loc);
+    Value fc2WeightsPtr = extractContiguousMemRefPtr(
+        adaptor.getFc2ExpertsWeights(), rewriter, loc);
     Value fc2ScalesPtr =
         extractContiguousMemRefPtr(adaptor.getFc2Scales(), rewriter, loc);
     Value fc2BiasPtr =
@@ -64,7 +66,8 @@ struct QMoEOpLowering : public ConvertOpToLLVMPattern<QMoEOp> {
         extractOptionalMemRefPtr(adaptor.getFc3ZeroPoints(), rewriter, loc);
     Value routerWeightsPtr =
         extractOptionalMemRefPtr(adaptor.getRouterWeights(), rewriter, loc);
-    Value outputPtr = extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
+    Value outputPtr =
+        extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
 
     auto inputType = cast<MemRefType>(op.getInput().getType());
     auto routerType = cast<MemRefType>(op.getRouterProbs().getType());

--- a/lib/Conversion/HipToLLVM/QMoELowering.cpp
+++ b/lib/Conversion/HipToLLVM/QMoELowering.cpp
@@ -36,18 +36,18 @@ struct QMoEOpLowering : public ConvertOpToLLVMPattern<QMoEOp> {
     };
 
     Value statePtr = adaptor.getHandle();
-    Value inputPtr = extractMemRefPtr(adaptor.getInput(), rewriter, loc);
-    Value routerPtr = extractMemRefPtr(adaptor.getRouterProbs(), rewriter, loc);
+    Value inputPtr = extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc);
+    Value routerPtr = extractContiguousMemRefPtr(adaptor.getRouterProbs(), rewriter, loc);
     Value fc1WeightsPtr =
-        extractMemRefPtr(adaptor.getFc1ExpertsWeights(), rewriter, loc);
+        extractContiguousMemRefPtr(adaptor.getFc1ExpertsWeights(), rewriter, loc);
     Value fc1ScalesPtr =
-        extractMemRefPtr(adaptor.getFc1Scales(), rewriter, loc);
+        extractContiguousMemRefPtr(adaptor.getFc1Scales(), rewriter, loc);
     Value fc1BiasPtr =
         extractOptionalMemRefPtr(adaptor.getFc1ExpertsBias(), rewriter, loc);
     Value fc2WeightsPtr =
-        extractMemRefPtr(adaptor.getFc2ExpertsWeights(), rewriter, loc);
+        extractContiguousMemRefPtr(adaptor.getFc2ExpertsWeights(), rewriter, loc);
     Value fc2ScalesPtr =
-        extractMemRefPtr(adaptor.getFc2Scales(), rewriter, loc);
+        extractContiguousMemRefPtr(adaptor.getFc2Scales(), rewriter, loc);
     Value fc2BiasPtr =
         extractOptionalMemRefPtr(adaptor.getFc2ExpertsBias(), rewriter, loc);
     Value fc3WeightsPtr =
@@ -64,7 +64,7 @@ struct QMoEOpLowering : public ConvertOpToLLVMPattern<QMoEOp> {
         extractOptionalMemRefPtr(adaptor.getFc3ZeroPoints(), rewriter, loc);
     Value routerWeightsPtr =
         extractOptionalMemRefPtr(adaptor.getRouterWeights(), rewriter, loc);
-    Value outputPtr = extractMemRefPtr(adaptor.getOutput(), rewriter, loc);
+    Value outputPtr = extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
 
     auto inputType = cast<MemRefType>(op.getInput().getType());
     auto routerType = cast<MemRefType>(op.getRouterProbs().getType());

--- a/lib/Conversion/HipToLLVM/ReduceSumLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ReduceSumLowering.cpp
@@ -33,9 +33,9 @@ struct ReduceSumOpLowering : public ConvertOpToLLVMPattern<ReduceSumOp> {
 
     // Extract pointers using alignedPtr
     Value statePtr = adaptor.getCtx();
-    Value dataPtr = extractMemRefPtr(adaptor.getData(), rewriter, loc);
-    Value axesPtr = extractMemRefPtr(adaptor.getAxes(), rewriter, loc);
-    Value outputPtr = extractMemRefPtr(adaptor.getOutput(), rewriter, loc);
+    Value dataPtr = extractContiguousMemRefPtr(adaptor.getData(), rewriter, loc);
+    Value axesPtr = extractContiguousMemRefPtr(adaptor.getAxes(), rewriter, loc);
+    Value outputPtr = extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
 
     auto dataType = cast<MemRefType>(op.getData().getType());
     auto axesType = cast<MemRefType>(op.getAxes().getType());

--- a/lib/Conversion/HipToLLVM/ReduceSumLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ReduceSumLowering.cpp
@@ -33,9 +33,12 @@ struct ReduceSumOpLowering : public ConvertOpToLLVMPattern<ReduceSumOp> {
 
     // Extract pointers using alignedPtr
     Value statePtr = adaptor.getCtx();
-    Value dataPtr = extractContiguousMemRefPtr(adaptor.getData(), rewriter, loc);
-    Value axesPtr = extractContiguousMemRefPtr(adaptor.getAxes(), rewriter, loc);
-    Value outputPtr = extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
+    Value dataPtr =
+        extractContiguousMemRefPtr(adaptor.getData(), rewriter, loc);
+    Value axesPtr =
+        extractContiguousMemRefPtr(adaptor.getAxes(), rewriter, loc);
+    Value outputPtr =
+        extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
 
     auto dataType = cast<MemRefType>(op.getData().getType());
     auto axesType = cast<MemRefType>(op.getAxes().getType());

--- a/lib/Conversion/HipToLLVM/RopeLowering.cpp
+++ b/lib/Conversion/HipToLLVM/RopeLowering.cpp
@@ -24,11 +24,11 @@ struct RopeOpLowering : public ConvertOpToLLVMPattern<RopeOp> {
 
     // Extract pointers
     Value statePtr = adaptor.getCtx();
-    Value inputPtr = extractMemRefPtr(adaptor.getInput(), rewriter, loc);
-    Value posIdsPtr = extractMemRefPtr(adaptor.getPositionIds(), rewriter, loc);
-    Value cosCachePtr = extractMemRefPtr(adaptor.getCosCache(), rewriter, loc);
-    Value sinCachePtr = extractMemRefPtr(adaptor.getSinCache(), rewriter, loc);
-    Value outputPtr = extractMemRefPtr(adaptor.getOutput(), rewriter, loc);
+    Value inputPtr = extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc);
+    Value posIdsPtr = extractContiguousMemRefPtr(adaptor.getPositionIds(), rewriter, loc);
+    Value cosCachePtr = extractContiguousMemRefPtr(adaptor.getCosCache(), rewriter, loc);
+    Value sinCachePtr = extractContiguousMemRefPtr(adaptor.getSinCache(), rewriter, loc);
+    Value outputPtr = extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
 
     // Extract attributes as constants
     Value interleaved = LLVM::ConstantOp::create(

--- a/lib/Conversion/HipToLLVM/RopeLowering.cpp
+++ b/lib/Conversion/HipToLLVM/RopeLowering.cpp
@@ -24,11 +24,16 @@ struct RopeOpLowering : public ConvertOpToLLVMPattern<RopeOp> {
 
     // Extract pointers
     Value statePtr = adaptor.getCtx();
-    Value inputPtr = extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc);
-    Value posIdsPtr = extractContiguousMemRefPtr(adaptor.getPositionIds(), rewriter, loc);
-    Value cosCachePtr = extractContiguousMemRefPtr(adaptor.getCosCache(), rewriter, loc);
-    Value sinCachePtr = extractContiguousMemRefPtr(adaptor.getSinCache(), rewriter, loc);
-    Value outputPtr = extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
+    Value inputPtr =
+        extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc);
+    Value posIdsPtr =
+        extractContiguousMemRefPtr(adaptor.getPositionIds(), rewriter, loc);
+    Value cosCachePtr =
+        extractContiguousMemRefPtr(adaptor.getCosCache(), rewriter, loc);
+    Value sinCachePtr =
+        extractContiguousMemRefPtr(adaptor.getSinCache(), rewriter, loc);
+    Value outputPtr =
+        extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
 
     // Extract attributes as constants
     Value interleaved = LLVM::ConstantOp::create(

--- a/lib/Conversion/HipToLLVM/TransposeLowering.cpp
+++ b/lib/Conversion/HipToLLVM/TransposeLowering.cpp
@@ -53,8 +53,8 @@ struct TransposeOpLowering : public ConvertOpToLLVMPattern<TransposeOp> {
 
     SmallVector<Value> args = {
         adaptor.getCtx(),
-        extractMemRefPtr(adaptor.getInput(), rewriter, loc),
-        extractMemRefPtr(adaptor.getOutput(), rewriter, loc),
+        extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc),
+        extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc),
         rankVal,
         adaptor.getDim0(),
         adaptor.getDim1(),

--- a/lib/Dialect/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Transforms/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(HipDialectTransforms STATIC
   OptimizeMemRefs.cpp
   Pipelines.cpp
   PoolAllocs.cpp
+  PromoteStridedHipOperands.cpp
   ResolveExternConstants.cpp
 )
 

--- a/lib/Dialect/Transforms/Pipelines.cpp
+++ b/lib/Dialect/Transforms/Pipelines.cpp
@@ -55,6 +55,20 @@ static void buildOnnxToHipPipelineTail(OpPassManager &pm) {
 
   // 6. HIP-specific buffer optimizations
   pm.addNestedPass<func::FuncOp>(hip::createOptimizeMemRefsPass());
+
+  // 6a. Promote strided memref operands of hip.* ops to contiguous
+  //     temporaries.  Required because the HIP runtime call ABI (used by
+  //     --convert-hip-to-llvm) only forwards a bare alignedPtr per memref
+  //     operand and has no channel for offset / per-dim strides; without
+  //     this pass, hip.* ops that consume memref.subview results read the
+  //     base of the parent buffer rather than the slice.
+  //
+  //     Placement: after OptimizeMemRefs (so we don't fight its
+  //     subview-folding) and before PoolAllocs (so the new transient
+  //     memref.alloc / memref.dealloc pairs flow through pool views and do
+  //     not trigger extra hipMalloc calls per inference).
+  pm.addNestedPass<func::FuncOp>(hip::createPromoteStridedHipOperandsPass());
+
   pm.addNestedPass<func::FuncOp>(hip::createPoolAllocsPass());
 
   // 7. Lower remaining bufferization ops to memref

--- a/lib/Dialect/Transforms/PromoteStridedHipOperands.cpp
+++ b/lib/Dialect/Transforms/PromoteStridedHipOperands.cpp
@@ -1,0 +1,182 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- PromoteStridedHipOperands.cpp - Strided -> contiguous copy ---------===//
+//
+// Materializes a contiguous temporary buffer for any DPS-input memref operand
+// of a hip.* op that has a non-identity layout (non-zero offset or
+// non-contiguous strides).
+//
+// Why this pass exists
+// --------------------
+// The HIP runtime call ABI used by --convert-hip-to-llvm receives a single
+// bare pointer per memref operand (see extractContiguousMemRefPtr in
+// HipToLLVMUtils.h).  There is no parameter on the wrapper signatures for
+// per-dimension strides or for a base offset.  When a hip op consumes a
+// strided memref (e.g., the result of memref.subview from onnx.Split), the
+// wrapper would otherwise read the parent buffer from its base, ignoring the
+// slice — silently producing wrong results.
+//
+// Rather than grow every wrapper signature and every backing library call
+// site to accept (offset, strides[]), we promote upstream: insert a fresh
+// contiguous alloc, copy the strided source into it, and rewrite the
+// consumer's operand.  This mirrors upstream linalg::promoteSubViews and
+// preserves a clean "hip.* ops always see contiguous memrefs" invariant.
+//
+// DPS-init (output) operands
+// --------------------------
+// Outs are left untouched.  In this pipeline they always come from either:
+//   (a) memref.alloc() introduced by --one-shot-bufferize (identity layout),
+//       or
+//   (b) function arguments forced to identity layout by IdentityLayoutMap at
+//       function boundaries.
+// Either way they are guaranteed contiguous by construction.
+//
+// Pipeline placement
+// ------------------
+// Run between hip-optimize-memrefs and hip-pool-allocs (see Pipelines.cpp).
+// PoolAllocs replaces every memref.alloc with a memref.view into the pool
+// and erases deallocs whose target is a view, so the new transient buffers
+// fold cleanly into the existing pool — no extra hipMalloc per inference.
+//
+//===----------------------------------------------------------------------===//
+
+#include "hip/Dialect/IR/HipDialect.h"
+#include "hip/Dialect/Transforms/Passes.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/Interfaces/DestinationStyleOpInterface.h"
+
+#include "llvm/ADT/Statistic.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "hip-promote-strided-operands"
+
+STATISTIC(NumOperandsPromoted,
+          "Number of strided hip.* DPS-input operands promoted to contiguous");
+
+namespace mlir {
+namespace hip {
+
+#define GEN_PASS_DEF_PROMOTESTRIDEDHIPOPERANDSPASS
+#include "hip/Dialect/Transforms/Passes.h.inc"
+
+namespace {
+
+/// Returns true iff \p type's layout is non-identity, i.e., the memref has
+/// either a non-zero offset or non-contiguous strides.  Identity-layout
+/// memrefs (no layout attribute, or a strided<> attribute that happens to be
+/// canonical) are reported as contiguous.
+static bool isNonIdentityMemRef(MemRefType type) {
+  return !type.getLayout().isIdentity();
+}
+
+/// Builds a memref type with the same shape, element type, and memory space
+/// as \p src but with identity layout.
+static MemRefType makeContiguousType(MemRefType src) {
+  return MemRefType::get(src.getShape(), src.getElementType(),
+                         /*layout=*/MemRefLayoutAttrInterface{},
+                         src.getMemorySpace());
+}
+
+/// Collects SSA values for each dynamic dimension of \p src (in dim order).
+/// Emits memref.dim ops at the current insertion point of \p builder.
+static SmallVector<Value> collectDynamicSizes(OpBuilder &builder, Location loc,
+                                              Value src, MemRefType type) {
+  SmallVector<Value> sizes;
+  for (int64_t i : llvm::seq<int64_t>(type.getRank())) {
+    if (type.isDynamicDim(i))
+      sizes.push_back(memref::DimOp::create(builder, loc, src, i));
+  }
+  return sizes;
+}
+
+/// Materializes a contiguous temporary for \p strided just before \p consumer
+/// and rewrites \p use to point at it.  Returns the new contiguous buffer so
+/// the caller can place a paired dealloc.
+///
+/// Resulting IR (alloc + copy only):
+///   %tmp = memref.alloc(%dyn0, %dyn1, ...) : memref<...identity...>
+///   memref.copy %strided, %tmp
+///   <consumer rewritten to read %tmp>
+static Value materializeContiguousCopy(OpOperand &use, Operation *consumer) {
+  Value strided = use.get();
+  auto stridedType = cast<MemRefType>(strided.getType());
+  MemRefType contiguousType = makeContiguousType(stridedType);
+
+  OpBuilder builder(consumer);
+  Location loc = consumer->getLoc();
+
+  SmallVector<Value> dynSizes =
+      collectDynamicSizes(builder, loc, strided, stridedType);
+
+  auto allocOp =
+      memref::AllocOp::create(builder, loc, contiguousType, dynSizes);
+  memref::CopyOp::create(builder, loc, strided, allocOp.getResult());
+
+  use.set(allocOp.getResult());
+
+  ++NumOperandsPromoted;
+  LLVM_DEBUG(llvm::dbgs() << "  promoted " << stridedType << " -> "
+                          << contiguousType << " before " << consumer->getName()
+                          << "\n");
+
+  return allocOp.getResult();
+}
+
+struct PromoteStridedHipOperandsPass
+    : public impl::PromoteStridedHipOperandsPassBase<
+          PromoteStridedHipOperandsPass> {
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<memref::MemRefDialect>();
+  }
+
+  void runOnOperation() override;
+};
+
+void PromoteStridedHipOperandsPass::runOnOperation() {
+  func::FuncOp funcOp = getOperation();
+  if (funcOp.empty())
+    return;
+
+  // Collect candidate consumers first so that rewriting (which inserts new
+  // ops) does not invalidate the walk.
+  SmallVector<DestinationStyleOpInterface> consumers;
+  funcOp.walk([&](DestinationStyleOpInterface dpsOp) {
+    Operation *op = dpsOp.getOperation();
+    if (op->getDialect() != op->getContext()->getLoadedDialect<HipDialect>())
+      return;
+    consumers.push_back(dpsOp);
+  });
+
+  for (DestinationStyleOpInterface dpsOp : consumers) {
+    Operation *consumer = dpsOp.getOperation();
+    SmallVector<Value> tmps;
+    for (OpOperand *input : dpsOp.getDpsInputOperands()) {
+      auto type = dyn_cast<MemRefType>(input->get().getType());
+      if (!type || !isNonIdentityMemRef(type))
+        continue;
+      tmps.push_back(materializeContiguousCopy(*input, consumer));
+    }
+
+    // Emit deallocs in the same order as the allocations (TA, TB, ...).
+    // Without anchoring, repeated `setInsertionPointAfter(consumer)` would
+    // push each new dealloc directly after the consumer, reversing the
+    // sequence.  Advancing the anchor preserves source order and makes the
+    // IR easier to read in tests / dumps.
+    Operation *anchor = consumer;
+    OpBuilder builder(consumer);
+    for (Value tmp : tmps) {
+      builder.setInsertionPointAfter(anchor);
+      anchor = memref::DeallocOp::create(builder, consumer->getLoc(), tmp);
+    }
+  }
+}
+
+} // namespace
+} // namespace hip
+} // namespace mlir

--- a/test/lit/Dialect/hip-promote-strided-operands.mlir
+++ b/test/lit/Dialect/hip-promote-strided-operands.mlir
@@ -1,0 +1,264 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+//===----------------------------------------------------------------------===//
+// FileCheck tests for --hip-promote-strided-operands.
+//
+// The pass inserts memref.alloc + memref.copy + memref.dealloc for any
+// DPS-input memref operand of a hip.* op whose layout is non-identity
+// (non-zero offset or non-contiguous strides).  DPS-init (output) operands
+// and already-contiguous inputs are left untouched.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt --hip-promote-strided-operands %s | FileCheck %s
+
+// ----------------------------------------------------------------------------
+// Positive: strided subview feeding hip.sigmoid is promoted to a contiguous
+// alloc, copied in, consumed, then deallocated after the consumer.
+//
+// Models the bug pattern from onnx.Split -> onnx.Sigmoid: bufferization
+// produces memref.subview with offset/stride layout, which would otherwise
+// be silently flattened to a base pointer at LLVM lowering time.
+// ----------------------------------------------------------------------------
+// CHECK-LABEL: func.func @sigmoid_promotes_strided_input
+// CHECK-SAME:    (%[[CTX:.*]]: !hip.context,
+// CHECK-SAME:     %[[SRC:.*]]: memref<1x128x2048xf16>,
+// CHECK-SAME:     %[[OUT:.*]]: memref<1x128x1024xf16>)
+// CHECK:         %[[SV:.*]] = memref.subview %[[SRC]]
+// CHECK:         %[[TMP:.*]] = memref.alloc() : memref<1x128x1024xf16>
+// CHECK:         memref.copy %[[SV]], %[[TMP]]
+// CHECK:         hip.sigmoid(%[[CTX]]) ins(%[[TMP]] : memref<1x128x1024xf16>) outs(%[[OUT]] : memref<1x128x1024xf16>)
+// CHECK:         memref.dealloc %[[TMP]]
+// CHECK:         return
+func.func @sigmoid_promotes_strided_input(
+    %ctx: !hip.context,
+    %src: memref<1x128x2048xf16>,
+    %out: memref<1x128x1024xf16>) {
+  %sv = memref.subview %src[0, 0, 1024][1, 128, 1024][1, 1, 1]
+      : memref<1x128x2048xf16>
+        to memref<1x128x1024xf16, strided<[262144, 2048, 1], offset: 1024>>
+  hip.sigmoid(%ctx)
+    ins(%sv : memref<1x128x1024xf16, strided<[262144, 2048, 1], offset: 1024>>)
+    outs(%out : memref<1x128x1024xf16>)
+  return
+}
+
+// ----------------------------------------------------------------------------
+// Negative: a hip.sigmoid with an already-contiguous (identity-layout) input
+// is not rewritten.
+// ----------------------------------------------------------------------------
+// CHECK-LABEL: func.func @sigmoid_contiguous_input_untouched
+// CHECK-SAME:    (%[[CTX:.*]]: !hip.context,
+// CHECK-SAME:     %[[IN:.*]]: memref<1x128x1024xf16>,
+// CHECK-SAME:     %[[OUT:.*]]: memref<1x128x1024xf16>)
+// CHECK-NOT:     memref.alloc
+// CHECK-NOT:     memref.copy
+// CHECK:         hip.sigmoid(%[[CTX]]) ins(%[[IN]] : memref<1x128x1024xf16>) outs(%[[OUT]] : memref<1x128x1024xf16>)
+// CHECK-NOT:     memref.dealloc
+// CHECK:         return
+func.func @sigmoid_contiguous_input_untouched(
+    %ctx: !hip.context,
+    %in: memref<1x128x1024xf16>,
+    %out: memref<1x128x1024xf16>) {
+  hip.sigmoid(%ctx) ins(%in : memref<1x128x1024xf16>)
+                    outs(%out : memref<1x128x1024xf16>)
+  return
+}
+
+// ----------------------------------------------------------------------------
+// Multiple strided inputs: a hip.add with two subview operands gets two
+// independent promotions (separate allocs, copies, and deallocs).
+// ----------------------------------------------------------------------------
+// CHECK-LABEL: func.func @add_promotes_both_inputs
+// CHECK:         %[[SVA:.*]] = memref.subview
+// CHECK:         %[[SVB:.*]] = memref.subview
+// CHECK:         %[[TA:.*]] = memref.alloc() : memref<1x128x1024xf16>
+// CHECK:         memref.copy %[[SVA]], %[[TA]]
+// CHECK:         %[[TB:.*]] = memref.alloc() : memref<1x128x1024xf16>
+// CHECK:         memref.copy %[[SVB]], %[[TB]]
+// CHECK:         hip.add{{.*}}ins(%[[TA]], %[[TB]]
+// CHECK:         memref.dealloc %[[TA]]
+// CHECK:         memref.dealloc %[[TB]]
+func.func @add_promotes_both_inputs(
+    %ctx: !hip.context,
+    %a: memref<1x128x2048xf16>,
+    %b: memref<1x128x2048xf16>,
+    %out: memref<1x128x1024xf16>) {
+  %sva = memref.subview %a[0, 0, 0][1, 128, 1024][1, 1, 1]
+      : memref<1x128x2048xf16>
+        to memref<1x128x1024xf16, strided<[262144, 2048, 1]>>
+  %svb = memref.subview %b[0, 0, 1024][1, 128, 1024][1, 1, 1]
+      : memref<1x128x2048xf16>
+        to memref<1x128x1024xf16, strided<[262144, 2048, 1], offset: 1024>>
+  hip.add(%ctx)
+    ins(%sva, %svb : memref<1x128x1024xf16, strided<[262144, 2048, 1]>>,
+                     memref<1x128x1024xf16, strided<[262144, 2048, 1], offset: 1024>>)
+    outs(%out : memref<1x128x1024xf16>)
+  return
+}
+
+// ----------------------------------------------------------------------------
+// DPS-init (output) operand is left untouched even when its type carries an
+// explicit strided layout.  Outs are guaranteed contiguous by construction in
+// this pipeline; promoting them would also change observable behavior because
+// the consumer writes through the operand (the strided slice is the intended
+// destination, not a temporary to copy back).
+// ----------------------------------------------------------------------------
+// CHECK-LABEL: func.func @strided_output_left_alone
+// CHECK:         %[[SV:.*]] = memref.subview
+// CHECK-NOT:     memref.alloc
+// CHECK-NOT:     memref.copy
+// CHECK:         hip.sigmoid({{.*}}) ins({{.*}}) outs(%[[SV]]
+// CHECK-NOT:     memref.dealloc
+func.func @strided_output_left_alone(
+    %ctx: !hip.context,
+    %in: memref<1x128x1024xf16>,
+    %dst: memref<1x128x2048xf16>) {
+  %sv_out = memref.subview %dst[0, 0, 1024][1, 128, 1024][1, 1, 1]
+      : memref<1x128x2048xf16>
+        to memref<1x128x1024xf16, strided<[262144, 2048, 1], offset: 1024>>
+  hip.sigmoid(%ctx)
+    ins(%in : memref<1x128x1024xf16>)
+    outs(%sv_out : memref<1x128x1024xf16, strided<[262144, 2048, 1], offset: 1024>>)
+  return
+}
+
+// ----------------------------------------------------------------------------
+// Function-argument with a strided layout (no defining op) is still promoted.
+//
+// This is the key generality difference vs upstream linalg::promoteSubViews,
+// which keys on `isa<memref::SubViewOp>(operand.getDefiningOp())` and would
+// miss this case.  Our predicate is type-based, so any non-identity layout
+// triggers promotion regardless of how it was produced.
+// ----------------------------------------------------------------------------
+// CHECK-LABEL: func.func @func_arg_strided_promoted
+// CHECK-SAME:    (%[[CTX:.*]]: !hip.context,
+// CHECK-SAME:     %[[SRC:.*]]: memref<1x128x1024xf16, strided<[262144, 2048, 1], offset: 1024>>,
+// CHECK-SAME:     %[[OUT:.*]]: memref<1x128x1024xf16>)
+// CHECK:         %[[TMP:.*]] = memref.alloc() : memref<1x128x1024xf16>
+// CHECK:         memref.copy %[[SRC]], %[[TMP]]
+// CHECK:         hip.sigmoid(%[[CTX]]) ins(%[[TMP]] : memref<1x128x1024xf16>) outs(%[[OUT]] : memref<1x128x1024xf16>)
+// CHECK:         memref.dealloc %[[TMP]]
+func.func @func_arg_strided_promoted(
+    %ctx: !hip.context,
+    %src: memref<1x128x1024xf16, strided<[262144, 2048, 1], offset: 1024>>,
+    %out: memref<1x128x1024xf16>) {
+  hip.sigmoid(%ctx)
+    ins(%src : memref<1x128x1024xf16, strided<[262144, 2048, 1], offset: 1024>>)
+    outs(%out : memref<1x128x1024xf16>)
+  return
+}
+
+// ----------------------------------------------------------------------------
+// memref.reinterpret_cast with a non-zero offset produces a non-identity
+// layout that must be promoted.
+//
+// Models the pattern from hip-optimize-memrefs buffer-reuse: a single backing
+// allocation can be re-bound at multiple offsets for non-overlapping live
+// ranges.  When the resulting reinterpret_cast carries a non-zero offset, our
+// pass must materialize a contiguous temporary just like the subview case.
+// ----------------------------------------------------------------------------
+// CHECK-LABEL: func.func @reinterpret_cast_with_offset_promoted
+// CHECK:         %[[RC:.*]] = memref.reinterpret_cast
+// CHECK:         %[[TMP:.*]] = memref.alloc() : memref<1x128x1024xf16>
+// CHECK:         memref.copy %[[RC]], %[[TMP]]
+// CHECK:         hip.sigmoid({{.*}}) ins(%[[TMP]] : memref<1x128x1024xf16>)
+// CHECK:         memref.dealloc %[[TMP]]
+func.func @reinterpret_cast_with_offset_promoted(
+    %ctx: !hip.context,
+    %src: memref<1x128x4096xf16>,
+    %out: memref<1x128x1024xf16>) {
+  %rc = memref.reinterpret_cast %src
+      to offset: [131072], sizes: [1, 128, 1024], strides: [131072, 1024, 1]
+      : memref<1x128x4096xf16>
+        to memref<1x128x1024xf16, strided<[131072, 1024, 1], offset: 131072>>
+  hip.sigmoid(%ctx)
+    ins(%rc : memref<1x128x1024xf16, strided<[131072, 1024, 1], offset: 131072>>)
+    outs(%out : memref<1x128x1024xf16>)
+  return
+}
+
+// ----------------------------------------------------------------------------
+// Dynamic shape: collectDynamicSizes() must emit one memref.dim per dynamic
+// dimension and forward those sizes to memref.alloc.
+//
+// Source has a dynamic outer dim and a dynamic offset (after subview).  The
+// promoted alloc keeps the dynamic shape under identity layout and needs the
+// dim sizes as operands.
+// ----------------------------------------------------------------------------
+// CHECK-LABEL: func.func @dynamic_shape_promoted
+// CHECK:         %[[SV:.*]] = memref.subview
+// CHECK:         %[[DIM:.*]] = memref.dim %[[SV]]
+// CHECK:         %[[TMP:.*]] = memref.alloc(%[[DIM]]) : memref<?x128xf16>
+// CHECK:         memref.copy %[[SV]], %[[TMP]]
+// CHECK:         hip.sigmoid({{.*}}) ins(%[[TMP]] : memref<?x128xf16>)
+// CHECK:         memref.dealloc %[[TMP]]
+func.func @dynamic_shape_promoted(
+    %ctx: !hip.context,
+    %src: memref<?x128xf16>,
+    %out: memref<?x128xf16>,
+    %off: index,
+    %sz: index) {
+  %sv = memref.subview %src[%off, 0][%sz, 128][1, 1]
+      : memref<?x128xf16>
+        to memref<?x128xf16, strided<[128, 1], offset: ?>>
+  hip.sigmoid(%ctx)
+    ins(%sv : memref<?x128xf16, strided<[128, 1], offset: ?>>)
+    outs(%out : memref<?x128xf16>)
+  return
+}
+
+// ----------------------------------------------------------------------------
+// Memory-space preservation: the promoted alloc must inherit the memory
+// space of the strided source, not silently fall back to the default space.
+//
+// makeContiguousType(src) preserves src.getMemorySpace() — this test pins the
+// behavior so a future refactor of that helper can't drop memory spaces.
+// ----------------------------------------------------------------------------
+// CHECK-LABEL: func.func @memory_space_preserved
+// CHECK:         memref.alloc() : memref<1x128x1024xf16, 1>
+func.func @memory_space_preserved(
+    %ctx: !hip.context,
+    %src: memref<1x128x2048xf16, 1>,
+    %out: memref<1x128x1024xf16, 1>) {
+  %sv = memref.subview %src[0, 0, 1024][1, 128, 1024][1, 1, 1]
+      : memref<1x128x2048xf16, 1>
+        to memref<1x128x1024xf16, strided<[262144, 2048, 1], offset: 1024>, 1>
+  hip.sigmoid(%ctx)
+    ins(%sv : memref<1x128x1024xf16, strided<[262144, 2048, 1], offset: 1024>, 1>)
+    outs(%out : memref<1x128x1024xf16, 1>)
+  return
+}
+
+// ----------------------------------------------------------------------------
+// Mixed inputs: only the strided operand is promoted; the already-contiguous
+// operand is passed through unchanged.  Validates that the per-operand
+// decision in the input loop doesn't over- or under-promote.
+// ----------------------------------------------------------------------------
+// CHECK-LABEL: func.func @mixed_strided_and_contiguous_inputs
+// CHECK-SAME:    (%[[CTX:.*]]: !hip.context,
+// CHECK-SAME:     %[[A:.*]]: memref<1x128x2048xf16>,
+// CHECK-SAME:     %[[B:.*]]: memref<1x128x1024xf16>,
+// CHECK-SAME:     %[[OUT:.*]]: memref<1x128x1024xf16>)
+// CHECK:         %[[SV:.*]] = memref.subview %[[A]]
+// CHECK:         %[[TMP:.*]] = memref.alloc() : memref<1x128x1024xf16>
+// CHECK:         memref.copy %[[SV]], %[[TMP]]
+// CHECK-NOT:     memref.alloc
+// CHECK-NOT:     memref.copy
+// CHECK:         hip.add(%[[CTX]]) ins(%[[TMP]], %[[B]]
+// CHECK:         memref.dealloc %[[TMP]]
+// CHECK-NOT:     memref.dealloc
+func.func @mixed_strided_and_contiguous_inputs(
+    %ctx: !hip.context,
+    %a: memref<1x128x2048xf16>,
+    %b: memref<1x128x1024xf16>,
+    %out: memref<1x128x1024xf16>) {
+  %sv = memref.subview %a[0, 0, 1024][1, 128, 1024][1, 1, 1]
+      : memref<1x128x2048xf16>
+        to memref<1x128x1024xf16, strided<[262144, 2048, 1], offset: 1024>>
+  hip.add(%ctx)
+    ins(%sv, %b : memref<1x128x1024xf16, strided<[262144, 2048, 1], offset: 1024>>,
+                  memref<1x128x1024xf16>)
+    outs(%out : memref<1x128x1024xf16>)
+  return
+}


### PR DESCRIPTION
## Summary

Adds a new MLIR pass `--hip-promote-strided-operands` that walks every `DestinationStyleOpInterface` op in the `hip` dialect and, for each input memref operand whose layout is non-identity (non-zero offset or non-contiguous strides), inserts a `memref.alloc` + `memref.copy` + `memref.dealloc` sequence to materialize a contiguous temporary.

This closes a silent-corruption gap between MLIR (which can faithfully represent strided memrefs via `memref.subview`) and the HIP runtime call ABI used by `--convert-hip-to-llvm` (which receives only a single bare pointer per memref operand, with no channel for offset or per-dimension strides).

## Why

The HIP runtime wrappers extract just `aligned_ptr` from the LLVM memref descriptor (`extractMemRefPtr` in `HipToLLVMUtils.h`). When a `hip.*` op consumes a strided memref — for example, the result of `memref.subview` produced by `onnx.Split` lowering — the wrapper would otherwise read the parent buffer from its base, ignoring the slice and silently producing wrong results. This was reported on `Split -> Sigmoid` as roughly a 10x L2 error vs CPU.

## What

1. **New pass** at `lib/Dialect/Transforms/PromoteStridedHipOperands.cpp`. Predicate is type-based (`!type.getLayout().isIdentity()`), so it catches strided values regardless of how they were produced — `memref.subview`, `memref.reinterpret_cast` with a non-zero offset, function args carrying a `strided<>` layout, etc.

2. **Pipeline placement**: between `hip-optimize-memrefs` and `hip-pool-allocs` in `Pipelines.cpp`, so the new transient buffers fold cleanly into the existing memory pool — no extra `hipMalloc` per inference.

3. **Helper rename**: `extractMemRefPtr` -> `extractContiguousMemRefPtr` in `HipToLLVMUtils.h` and across 17 `*Lowering.cpp` files, to make the contiguous-only contract explicit at every call site. Also adds an `extractMemRefDescriptor` helper that returns the full descriptor (no callers in this PR; reserved for future per-op zero-copy lowerings).

4. **DPS-init operands are intentionally left alone**. Outputs are guaranteed contiguous by construction in this pipeline (fresh `memref.alloc` from bufferization or function args under `IdentityLayoutMap`), and promoting them would change observable behavior because the consumer writes through them.

This mirrors upstream `linalg::promoteSubViews` in spirit, but with a generalized type-based predicate that catches non-subview-produced strided values and a single-purpose, focused implementation.

## Compiler IR walkthrough


**Full IR dump:** https://gist.github.com/fhanuman/8612bcfdacd24281652613e84cfe5933

The three stages below are the ones that show the new pass at work and confirm it folds cleanly into the existing pool allocation.

<details>
<summary><b>Before <code>--hip-promote-strided-operands</code></b> — strided subviews feed <code>hip.sigmoid</code> directly (this is what would silently corrupt at LLVM lowering)</summary>

```mlir
module attributes {hipdnn.input_count = 1 : i64, ...} {
  func.func @main_graph(%arg0: !hip.context,
                        %arg1: memref<1x128x2048xf16> {onnx.name = "X"},
                        %arg2: memref<1x128x1024xf16> {bufferize.result},
                        %arg3: memref<1x128x1024xf16> {bufferize.result})
      attributes {onnx.graph.name = "split_sigmoid_test"} {
    %subview = memref.subview %arg1[0, 0, 0] [1, 128, 1024] [1, 1, 1]
        : memref<1x128x2048xf16>
          to memref<1x128x1024xf16, strided<[262144, 2048, 1]>>
    %subview_0 = memref.subview %arg1[0, 0, 1024] [1, 128, 1024] [1, 1, 1]
        : memref<1x128x2048xf16>
          to memref<1x128x1024xf16, strided<[262144, 2048, 1], offset: 1024>>
    %cast = memref.cast %subview_0
        : memref<1x128x1024xf16, strided<[262144, 2048, 1], offset: 1024>>
          to memref<1x128x1024xf16, strided<[262144, 2048, 1], offset: ?>>
    hip.sigmoid(%arg0)
      ins(%subview : memref<1x128x1024xf16, strided<[262144, 2048, 1]>>)
      outs(%arg2 : memref<1x128x1024xf16>)
    hip.sigmoid(%arg0)
      ins(%cast : memref<1x128x1024xf16, strided<[262144, 2048, 1], offset: ?>>)
      outs(%arg3 : memref<1x128x1024xf16>)
    return
  }
}
```

Note both `hip.sigmoid` ops receive a `strided<>` memref. At LLVM lowering, `extractMemRefPtr` would extract only `aligned_ptr` from the descriptor and discard the offset/strides — so the second sigmoid would read from offset 0 of `%arg1` instead of offset 1024. That is the bug.

</details>

<details>
<summary><b>After <code>--hip-promote-strided-operands</code></b> — <code>memref.alloc</code> + <code>memref.copy</code> materialize a contiguous temporary; consumer is rewritten to read from it; paired <code>memref.dealloc</code> after</summary>

```mlir
module attributes {hipdnn.input_count = 1 : i64, ...} {
  func.func @main_graph(%arg0: !hip.context,
                        %arg1: memref<1x128x2048xf16> {onnx.name = "X"},
                        %arg2: memref<1x128x1024xf16> {bufferize.result},
                        %arg3: memref<1x128x1024xf16> {bufferize.result})
      attributes {onnx.graph.name = "split_sigmoid_test"} {
    %subview = memref.subview %arg1[0, 0, 0] [1, 128, 1024] [1, 1, 1]
        : memref<1x128x2048xf16>
          to memref<1x128x1024xf16, strided<[262144, 2048, 1]>>
    %subview_0 = memref.subview %arg1[0, 0, 1024] [1, 128, 1024] [1, 1, 1]
        : memref<1x128x2048xf16>
          to memref<1x128x1024xf16, strided<[262144, 2048, 1], offset: 1024>>
    %cast = memref.cast %subview_0
        : memref<1x128x1024xf16, strided<[262144, 2048, 1], offset: 1024>>
          to memref<1x128x1024xf16, strided<[262144, 2048, 1], offset: ?>>

    %alloc = memref.alloc() : memref<1x128x1024xf16>
    memref.copy %subview, %alloc
        : memref<1x128x1024xf16, strided<[262144, 2048, 1]>>
          to memref<1x128x1024xf16>
    hip.sigmoid(%arg0)
      ins(%alloc : memref<1x128x1024xf16>)
      outs(%arg2 : memref<1x128x1024xf16>)
    memref.dealloc %alloc : memref<1x128x1024xf16>

    %alloc_1 = memref.alloc() : memref<1x128x1024xf16>
    memref.copy %cast, %alloc_1
        : memref<1x128x1024xf16, strided<[262144, 2048, 1], offset: ?>>
          to memref<1x128x1024xf16>
    hip.sigmoid(%arg0)
      ins(%alloc_1 : memref<1x128x1024xf16>)
      outs(%arg3 : memref<1x128x1024xf16>)
    memref.dealloc %alloc_1 : memref<1x128x1024xf16>

    return
  }
}
```

Each `hip.sigmoid` now reads from a fresh contiguous buffer. `memref.copy` lowers via `mlir_memref_copy` runtime which honors the source strides correctly. The `memref.subview` ops survive but become inputs to `memref.copy` only — they never reach a HIP runtime call.

</details>

<details>
<summary><b>After <code>--hip-pool-allocs</code></b> — the new <code>memref.alloc</code>s fold into the pool as <code>memref.view</code>s; zero extra <code>hipMalloc</code> per inference</summary>

```mlir
module attributes {hipdnn.buffer_count = 2 : i64,
                   hipdnn.buffer_offsets = [0, 0],
                   hipdnn.pool_size = 262144 : i64, ...} {
  func.func @main_graph(%arg0: !hip.context,
                        %arg1: memref<1x128x2048xf16> {onnx.name = "X"},
                        %arg2: memref<1x128x1024xf16> {bufferize.result},
                        %arg3: memref<1x128x1024xf16> {bufferize.result})
      attributes {onnx.graph.name = "split_sigmoid_test"} {
    %subview = memref.subview %arg1[0, 0, 0] [1, 128, 1024] [1, 1, 1]
        : memref<1x128x2048xf16>
          to memref<1x128x1024xf16, strided<[262144, 2048, 1]>>
    %subview_0 = memref.subview %arg1[0, 0, 1024] [1, 128, 1024] [1, 1, 1]
        : memref<1x128x2048xf16>
          to memref<1x128x1024xf16, strided<[262144, 2048, 1], offset: 1024>>
    %cast = memref.cast %subview_0 : ... to memref<1x128x1024xf16, strided<[262144, 2048, 1], offset: ?>>

    %c262144 = arith.constant 262144 : index
    %0 = hip.get_pool(%arg0, %c262144) : memref<?xi8>
    %c0 = arith.constant 0 : index
    %c0_1 = arith.constant 0 : index

    %view = memref.view %0[%c0][] : memref<?xi8> to memref<1x128x1024xf16>
    memref.copy %subview, %view
        : memref<1x128x1024xf16, strided<[262144, 2048, 1]>>
          to memref<1x128x1024xf16>
    hip.sigmoid(%arg0) ins(%view : memref<1x128x1024xf16>) outs(%arg2 : memref<1x128x1024xf16>)

    %view_2 = memref.view %0[%c0_1][] : memref<?xi8> to memref<1x128x1024xf16>
    memref.copy %cast, %view_2
        : memref<1x128x1024xf16, strided<[262144, 2048, 1], offset: ?>>
          to memref<1x128x1024xf16>
    hip.sigmoid(%arg0) ins(%view_2 : memref<1x128x1024xf16>) outs(%arg3 : memref<1x128x1024xf16>)
    return
  }
}
```

The two `memref.alloc`s introduced by the new pass have become `memref.view %pool[offset]` ops sharing the existing 256 KiB pool (offsets 0 and 0 — the lifetimes don't overlap). The deallocs are gone (pool views are managed by `hip.get_pool`). At inference time, this is a single `hip.get_pool` call followed by view arithmetic — no `hipMalloc` overhead per call.

</details>

## Notes for reviewers

- The pass is a safety net: zero cost on models that don't need it (e.g., the Llama-3-8B export above), strictly correct on models that do.
- The 17-file rename of `extractMemRefPtr` -> `extractContiguousMemRefPtr` is mechanical and intentional. It enforces the "contiguous-only" contract at every call site so future lowerings can't silently regress on strided inputs.
- The new pass file is ~180 LOC of focused logic; full rationale is in the file header block.
