### PR TITLE
ci: update OGA ref to latest feat/oga_hipdnn_experiment with VLM support

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -36,7 +36,7 @@ jobs:
       THEROCK_VERSION: therock-dist-windows-gfx1151-7.11.0
       SCCACHE_GHA_ENABLED: "true"
       OGA_REPO: AMDmoore/onnxruntime-genai
-      OGA_REF: c886da303a669377e2dcbb306c06a55da9355731
+      OGA_REF: e38a9db551afa67d47da368a895be597f13d8426
       # ilammy/msvc-dev-cmd and mozilla-actions/sccache-action have no
       # Node.js 24 releases yet; allow Node.js 20 until they are updated.
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"


### PR DESCRIPTION
## Summary

- Update OGA_REF in CI workflow from `c886da30` to `e38a9db5` (latest `feat/oga_hipdnn_experiment`)
- Includes fix for SupportsPrimaryDevice() to support VLM pipeline models (e.g. Gemma 3) where embedding runs on CPU EP

## Test plan

- [x] Gemma 3 4B verified locally: output correct, TTFT 112ms, TPS 20 tokens/s, memory ~7.15GB
- [x] Chunk mode (p512m16384, 2k prompt) verified: TTFT 1.4s, TPS 14 tokens/s
- [ ] CI workflow should build OGA with the updated ref successfully
