### PR TITLE
feat(matmul-nbits): PR #174 sign-extend kernels + runtime weight pre-shift (rebased on main)

### DIFF
--- a/3rd-party/custom_kernels/hip/matmul_nbits_kernel.hip
+++ b/3rd-party/custom_kernels/hip/matmul_nbits_kernel.hip
@@ -765,15 +765,12 @@ void GemmFp16U4Impl(
                     bv[6] = static_cast<_Float16>((pf_b4 >> 24) & 0xFu) * s16 + nzs;
                     bv[7] = static_cast<_Float16>((pf_b4 >> 28)       ) * s16 + nzs;
                 } else {
-                    _Float16 nzs = (_Float16)(-8) * s16;
-                    bv[0] = static_cast<_Float16>((pf_b4      ) & 0xFu) * s16 + nzs;
-                    bv[1] = static_cast<_Float16>((pf_b4 >>  4) & 0xFu) * s16 + nzs;
-                    bv[2] = static_cast<_Float16>((pf_b4 >>  8) & 0xFu) * s16 + nzs;
-                    bv[3] = static_cast<_Float16>((pf_b4 >> 12) & 0xFu) * s16 + nzs;
-                    bv[4] = static_cast<_Float16>((pf_b4 >> 16) & 0xFu) * s16 + nzs;
-                    bv[5] = static_cast<_Float16>((pf_b4 >> 20) & 0xFu) * s16 + nzs;
-                    bv[6] = static_cast<_Float16>((pf_b4 >> 24) & 0xFu) * s16 + nzs;
-                    bv[7] = static_cast<_Float16>((pf_b4 >> 28)       ) * s16 + nzs;
+                    #define S4(shift) static_cast<_Float16>(((int((pf_b4 >> (shift)) & 0xFu) << 28) >> 28)) * s16
+                    bv[0] = S4( 0); bv[1] = S4( 4);
+                    bv[2] = S4( 8); bv[3] = S4(12);
+                    bv[4] = S4(16); bv[5] = S4(20);
+                    bv[6] = S4(24); bv[7] = S4(28);
+                    #undef S4
                 }
                 *reinterpret_cast<uint2*>(&smB[buf][b_col][b_k8])     = *reinterpret_cast<uint2*>(&bv[0]);
                 *reinterpret_cast<uint2*>(&smB[buf][b_col][b_k8 + 4]) = *reinterpret_cast<uint2*>(&bv[4]);

--- a/3rd-party/custom_kernels/hip/matmul_nbits_kernel.hip
+++ b/3rd-party/custom_kernels/hip/matmul_nbits_kernel.hip
@@ -38,6 +38,7 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 
 /* =======================================================================
  * Section 1: Naive fallback kernel (row-major, any alignment, batched)
@@ -1254,6 +1255,59 @@ static _Float16* ensureDqBuffer(int N, int K) {
     return g_dq_buf;
 }
 
+/* -----------------------------------------------------------------------
+ * Weight pre-shift state (PR 174 companion / POC)
+ *
+ * PR 174 changed the no-zp dequant path (HAS_ZP=false / USE_ZEROS=false)
+ * to read each nibble as signed int4 via sign-extend, *assuming* the
+ * caller has already folded the default zp = 8 into the weight bytes
+ * (q' = q - 8 mod 16, equivalent to per-byte XOR 0x88). The MLIR /
+ * compile-time pipeline does not yet emit pre-shifted weights, so this
+ * runtime helper does the XOR in-place on the GPU constant blob the
+ * first time we observe each B pointer with zero_points == nullptr.
+ *
+ * Subsequent calls observing the same B pointer skip the XOR. The XOR
+ * kernel is launched on the same stream as the GEMM, so HIP stream
+ * ordering guarantees the GEMM sees the pre-shifted bytes (no host
+ * sync needed).
+ *
+ * The set is cleared by hip_matmul_nbits_release_buffers so that
+ * cold-cache benchmarks (test_matmul_nbits.cpp --cold-cache) re-run
+ * the XOR each round.
+ * ----------------------------------------------------------------------- */
+__global__ void weight_pre_shift_xor_0x88_kernel(
+    unsigned char* __restrict__ B, size_t n_bytes)
+{
+    size_t i = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (i < n_bytes) B[i] ^= 0x88;
+}
+
+static std::unordered_set<const void*> g_pre_shifted_weights;
+static std::mutex g_pre_shift_mutex;
+
+static void preShiftWeightIfFirstSeen(
+    hipStream_t stream, const void* B, int64_t N, int64_t K)
+{
+    if (B == nullptr) return;
+    {
+        std::lock_guard<std::mutex> lock(g_pre_shift_mutex);
+        if (!g_pre_shifted_weights.insert(B).second) return;
+    }
+    size_t n_bytes = static_cast<size_t>(N) * static_cast<size_t>(K / 2);
+    if (n_bytes == 0) return;
+    constexpr int THR = 256;
+    unsigned blocks = static_cast<unsigned>((n_bytes + THR - 1) / THR);
+    hipLaunchKernelGGL(weight_pre_shift_xor_0x88_kernel,
+                       dim3(blocks), dim3(THR), 0, stream,
+                       const_cast<unsigned char*>(
+                           static_cast<const unsigned char*>(B)),
+                       n_bytes);
+    CUSTOM_KERNELS_DEBUG_LOG(
+        "[custom_kernels] hip_matmul_nbits pre-shift weight "
+        "(N=%lld K=%lld bytes=%zu)\n",
+        (long long)N, (long long)K, n_bytes);
+}
+
 static int tuneWmmaConfig(
     hipStream_t stream,
     int M, int N, int K,
@@ -1485,6 +1539,15 @@ extern "C" int hip_matmul_nbits(
 
   hipStream_t hip_stream = static_cast<hipStream_t>(stream);
 
+  // PR 174 companion: when zero_points is null, all kernel paths assume
+  // the weight has been pre-folded with the default zp=8 (each byte
+  // XOR 0x88 -> nibbles become signed int4 q'=q-8). Since the compile-
+  // time pipeline does not emit pre-shifted weights yet, do the XOR
+  // in-place on the GPU constant the first time we see each B pointer.
+  if (zero_points == nullptr) {
+    preShiftWeightIfFirstSeen(hip_stream, B, N, K);
+  }
+
   // Convert uint8 packed nibble zero_points to FP16 for WMMA/GEMV-col-major
   // paths which require FP16 zero_points. Row-major GEMV and naive fallback
   // read uint8 directly and don't need this conversion.
@@ -1705,4 +1768,8 @@ extern "C" int hip_matmul_nbits(
 
 extern "C" void hip_matmul_nbits_release_buffers() {
   if (g_dq_buf) { hipFree(g_dq_buf); g_dq_buf = nullptr; g_dq_buf_elems = 0; }
+  {
+    std::lock_guard<std::mutex> lock(g_pre_shift_mutex);
+    g_pre_shifted_weights.clear();
+  }
 }

--- a/3rd-party/custom_kernels/hip/matmul_nbits_kernel.hip
+++ b/3rd-party/custom_kernels/hip/matmul_nbits_kernel.hip
@@ -14,16 +14,15 @@
  * Internally auto-dispatched to one of three execution paths:
  *
  *   1. RDNA3 WMMA fast path (batch==1, K%32==0, M>=16):
- *      Transposes A/C to col-major internally, then uses WMMA intrinsics
- *      with double-buffered shared memory, grid swizzling, and inline-asm
- *      batched dequant. Requires gfx11xx/gfx12xx.
+ *      Row-major A/C, WMMA intrinsics with double-buffered shared memory,
+ *      grid swizzling, and inline-asm batched dequant.
+ *      Requires gfx11xx/gfx12xx.
  *
- *   2. GEMV col-major path (batch==1, K%32==0, M<16):
- *      Transposes A/C internally (skipped for M=1). K-parallel reduction
- *      GEMV with COL_MAJOR=true, autotuned (BLOCK_SIZE, TILE_N).
+ *   2. GEMV row-major path (batch==1, K%32==0, M<16):
+ *      Row-major GEMV, autotuned (BLOCK_SIZE, TILE_N).
  *
  *   3. Naive fallback (arbitrary alignment, batched):
- *      Row-major kernels, uint8 zero points.
+ *      Row-major kernels.
  *
  * When zero_points is NULL, dequantization uses the ONNX MatMulNBits
  * default zp = 2^(bits-1) (= 8 for bits=4) to match the CPU EP (MLAS).
@@ -64,6 +63,8 @@ __global__ void matmul_nbits_kernel(
   int64_t k_blocks = (K + block_size - 1) / block_size;
   int64_t blob_size = block_size / 2;
 
+  const __half* zp_fp16 = reinterpret_cast<const __half*>(zp);
+
   float acc = 0.0f;
   const __half* a_row = A + batch * M * K + m * K;
   const uint8_t* b_row = B + n * (K / 2);
@@ -72,7 +73,7 @@ __global__ void matmul_nbits_kernel(
   for (int64_t blk = 0; blk < k_blocks; blk++) {
     float scale_val = static_cast<float>(s_row[blk]);
     float zp_val = (zp != nullptr)
-                       ? static_cast<float>(zp[n * k_blocks + blk])
+                       ? static_cast<float>(zp_fp16[n * k_blocks + blk])
                        : 8.0f;
 
     int64_t k_start = blk * block_size;
@@ -126,7 +127,7 @@ __global__ void matmul_nbits_kernel(
  * Launch: grid(ceil(N/TILE_N), M, batch), block(BLOCK_SIZE)
  * ======================================================================= */
 
-template <int BLOCK_SIZE, int TILE_N, bool COL_MAJOR = false>
+template <int BLOCK_SIZE, int TILE_N, bool HAS_ZP = true>
 __global__ void matmul_nbits_gemv_kernel(
     const __half* __restrict__ A,
     const uint8_t* __restrict__ B,
@@ -139,7 +140,7 @@ __global__ void matmul_nbits_gemv_kernel(
 {
     const int64_t n_base = static_cast<int64_t>(blockIdx.x) * TILE_N;
     const int64_t m      = blockIdx.y;
-    const int64_t batch  = COL_MAJOR ? 0 : blockIdx.z;
+    const int64_t batch  = blockIdx.z;
     const int tid        = threadIdx.x;
 
     if (m >= M) return;
@@ -148,18 +149,9 @@ __global__ void matmul_nbits_gemv_kernel(
     const int     bs_shift = __builtin_ctzll(
                                  static_cast<unsigned long long>(block_size));
 
-    const __half* a_base;
-    int64_t       a_stride;
-    if constexpr (COL_MAJOR) {
-        a_base   = A + m;
-        a_stride = M;
-    } else {
-        a_base   = A + batch * M * K + m * K;
-        a_stride = 1;
-    }
+    const __half* a_base = A + batch * M * K + m * K;
 
-    [[maybe_unused]] const __half* zp_fp16 =
-        COL_MAJOR ? reinterpret_cast<const __half*>(zp) : nullptr;
+    const __half* zp_fp16 = reinterpret_cast<const __half*>(zp);
 
     const uint8_t* b_base_arr[TILE_N];
     const __half*  s_rows[TILE_N];
@@ -178,19 +170,12 @@ __global__ void matmul_nbits_gemv_kernel(
     for (int tn = 0; tn < TILE_N; tn++)
         partial[tn] = 0.0f;
 
-    const bool has_zp = (zp != nullptr);
-
-    // Helper: read zero-point for (n_idx, grp) — FP16 when COL_MAJOR
     auto read_zp = [&](int64_t nidx, int64_t grp) __attribute__((always_inline)) -> float {
-        if constexpr (COL_MAJOR)
-            return static_cast<float>(zp_fp16[nidx * k_blocks + grp]);
-        else
-            return static_cast<float>(zp[nidx * k_blocks + grp]);
+        return static_cast<float>(zp_fp16[nidx * k_blocks + grp]);
     };
 
-    // Helper: read A element at K-offset
     auto read_a = [&](int64_t k_off) __attribute__((always_inline)) -> float {
-        return static_cast<float>(a_base[k_off * a_stride]);
+        return static_cast<float>(a_base[k_off]);
     };
 
     // ---- Phase 1: 16-nibble (64-bit) vectorized main loop ----
@@ -200,12 +185,9 @@ __global__ void matmul_nbits_gemv_kernel(
         const int64_t k16 = idx * 16;
 
         float a_vals[16];
-        float a_sum = 0.0f;
 #pragma unroll
-        for (int i = 0; i < 16; i++) {
+        for (int i = 0; i < 16; i++)
             a_vals[i] = read_a(k16 + i);
-            a_sum += a_vals[i];
-        }
 
         const int64_t grp = k16 >> bs_shift;
 
@@ -221,20 +203,28 @@ __global__ void matmul_nbits_gemv_kernel(
 #pragma unroll
         for (int tn = 0; tn < TILE_N; tn++) {
             float dot = 0.0f;
+            if constexpr (HAS_ZP) {
 #pragma unroll
-            for (int i = 0; i < 8; i++)
-                dot += a_vals[i] *
-                       static_cast<float>((b_pk[tn].x >> (i * 4)) & 0xF);
+                for (int i = 0; i < 8; i++)
+                    dot += a_vals[i] *
+                           static_cast<float>((b_pk[tn].x >> (i * 4)) & 0xF);
 #pragma unroll
-            for (int i = 0; i < 8; i++)
-                dot += a_vals[8 + i] *
-                       static_cast<float>((b_pk[tn].y >> (i * 4)) & 0xF);
-
-            if (has_zp) {
-                float zv = read_zp(n_idx[tn], grp);
-                partial[tn] += dot * sv[tn] - a_sum * zv * sv[tn];
+                for (int i = 0; i < 8; i++)
+                    dot += a_vals[8 + i] *
+                           static_cast<float>((b_pk[tn].y >> (i * 4)) & 0xF);
+                partial[tn] += dot * sv[tn];
             } else {
-                partial[tn] += dot * sv[tn] - a_sum * 8.0f * sv[tn];
+#pragma unroll
+                for (int i = 0; i < 8; i++) {
+                    int nib = (b_pk[tn].x >> (i * 4)) & 0xF;
+                    dot += a_vals[i] * static_cast<float>((nib << 28) >> 28);
+                }
+#pragma unroll
+                for (int i = 0; i < 8; i++) {
+                    int nib = (b_pk[tn].y >> (i * 4)) & 0xF;
+                    dot += a_vals[8 + i] * static_cast<float>((nib << 28) >> 28);
+                }
+                partial[tn] += dot * sv[tn];
             }
         }
     }
@@ -248,12 +238,9 @@ __global__ void matmul_nbits_gemv_kernel(
             const int64_t k8 = k8_base + idx2 * 8;
 
             float a_vals[8];
-            float a_sum = 0.0f;
 #pragma unroll
-            for (int i = 0; i < 8; i++) {
+            for (int i = 0; i < 8; i++)
                 a_vals[i] = read_a(k8 + i);
-                a_sum += a_vals[i];
-            }
 
             const int64_t grp = k8 >> bs_shift;
 
@@ -264,16 +251,19 @@ __global__ void matmul_nbits_gemv_kernel(
                                       &b_base_arr[tn][k8 / 2]);
 
                 float dot = 0.0f;
+                if constexpr (HAS_ZP) {
 #pragma unroll
-                for (int i = 0; i < 8; i++)
-                    dot += a_vals[i] *
-                           static_cast<float>((packed >> (i * 4)) & 0xF);
-
-                if (has_zp) {
-                    float zv = read_zp(n_idx[tn], grp);
-                    partial[tn] += dot * sv - a_sum * zv * sv;
+                    for (int i = 0; i < 8; i++)
+                        dot += a_vals[i] *
+                               static_cast<float>((packed >> (i * 4)) & 0xF);
+                    partial[tn] += dot * sv;
                 } else {
-                    partial[tn] += dot * sv - a_sum * 8.0f * sv;
+#pragma unroll
+                    for (int i = 0; i < 8; i++) {
+                        int nib = (packed >> (i * 4)) & 0xF;
+                        dot += a_vals[i] * static_cast<float>((nib << 28) >> 28);
+                    }
+                    partial[tn] += dot * sv;
                 }
             }
         }
@@ -291,12 +281,17 @@ __global__ void matmul_nbits_gemv_kernel(
 #pragma unroll
             for (int tn = 0; tn < TILE_N; tn++) {
                 float sv = static_cast<float>(s_rows[tn][grp]);
-                float zv = has_zp ? read_zp(n_idx[tn], grp) : 8.0f;
                 uint8_t packed = b_base_arr[tn][k / 2];
-                float   qval   = (nibble == 0)
-                                   ? static_cast<float>(packed & 0xF)
-                                   : static_cast<float>(packed >> 4);
-                partial[tn] += a_val * (qval - zv) * sv;
+                float qval = (nibble == 0)
+                               ? static_cast<float>(packed & 0xF)
+                               : static_cast<float>(packed >> 4);
+                if constexpr (HAS_ZP) {
+                    partial[tn] += a_val * qval * sv;
+                } else {
+                    int nib = static_cast<int>(qval);
+                    float s4 = static_cast<float>((nib << 28) >> 28);
+                    partial[tn] += a_val * s4 * sv;
+                }
             }
         }
     }
@@ -324,6 +319,29 @@ __global__ void matmul_nbits_gemv_kernel(
     __syncthreads();
 
     if (warp_id == 0) {
+        [[maybe_unused]] float zp_correction[TILE_N];
+        if constexpr (HAS_ZP) {
+#pragma unroll
+            for (int tn = 0; tn < TILE_N; tn++)
+                zp_correction[tn] = 0.0f;
+            if (lane_id == 0) {
+                for (int64_t g = 0; g < k_blocks; g++) {
+                    int64_t k_start = g * block_size;
+                    int64_t k_end   = k_start + block_size;
+                    if (k_end > K) k_end = K;
+                    float a_sum = 0.0f;
+                    for (int64_t k = k_start; k < k_end; k++)
+                        a_sum += static_cast<float>(a_base[k]);
+#pragma unroll
+                    for (int tn = 0; tn < TILE_N; tn++) {
+                        float sv = static_cast<float>(s_rows[tn][g]);
+                        float zv = read_zp(n_idx[tn], g);
+                        zp_correction[tn] += a_sum * zv * sv;
+                    }
+                }
+            }
+        }
+
 #pragma unroll
         for (int tn = 0; tn < TILE_N; tn++) {
             float val = (lane_id < num_warps)
@@ -334,13 +352,12 @@ __global__ void matmul_nbits_gemv_kernel(
             if (lane_id == 0) {
                 int64_t n = n_base + tn;
                 if (n < N) {
+                    if constexpr (HAS_ZP)
+                        val -= zp_correction[tn];
                     if (bias)
                         val += static_cast<float>(bias[n]);
-                    if constexpr (COL_MAJOR)
-                        output[n * M + m] = static_cast<__half>(val);
-                    else
-                        output[batch * M * N + m * N + n] =
-                            static_cast<__half>(val);
+                    output[batch * M * N + m * N + n] =
+                        static_cast<__half>(val);
                 }
             }
         }
@@ -374,17 +391,17 @@ static void launchGemvConfig(
     const __half* bi, __half* out,
     int64_t M, int64_t N, int64_t K,
     int64_t batch, int64_t bs,
-    bool col_major = false)
+    bool has_zp = true)
 {
     auto& c = kGemvConfigs[config_id];
     dim3 grid(static_cast<unsigned>((N + c.tile_n - 1) / c.tile_n),
               static_cast<unsigned>(M),
-              static_cast<unsigned>(col_major ? 1 : batch));
+              static_cast<unsigned>(batch));
     dim3 block(c.threads);
 
 #define GEMV_CASE(ID, BS, TN) \
     case ID: \
-        if (col_major) \
+        if (has_zp) \
             hipLaunchKernelGGL( \
                 HIP_KERNEL_NAME(matmul_nbits_gemv_kernel<BS, TN, true>), \
                 grid, block, 0, stream, A, B, sc, zp, bi, out, M, N, K, bs); \
@@ -424,7 +441,7 @@ static int tuneGemvConfig(
     const __half* bi, __half* out,
     int64_t M, int64_t N, int64_t K,
     int64_t batch, int64_t bs,
-    bool col_major = false)
+    bool has_zp = true)
 {
     hipEvent_t ev0, ev1;
     hipEventCreate(&ev0);
@@ -441,12 +458,12 @@ static int tuneGemvConfig(
 
         for (int w = 0; w < WARMUP; w++)
             launchGemvConfig(cid, stream, A, B, sc, zp, bi, out,
-                             M, N, K, batch, bs, col_major);
+                             M, N, K, batch, bs, has_zp);
 
         hipEventRecord(ev0, stream);
         for (int i = 0; i < ITERS; i++)
             launchGemvConfig(cid, stream, A, B, sc, zp, bi, out,
-                             M, N, K, batch, bs, col_major);
+                             M, N, K, batch, bs, has_zp);
         hipEventRecord(ev1, stream);
         hipEventSynchronize(ev1);
 
@@ -468,9 +485,9 @@ static int tuneGemvConfig(
     hipEventDestroy(ev1);
 
     CUSTOM_KERNELS_DEBUG_LOG(
-        "[custom_kernels] GEMV autotune: M=%lld N=%lld K=%lld bs=%lld col_major=%d -> "
+        "[custom_kernels] GEMV autotune: M=%lld N=%lld K=%lld bs=%lld -> "
         "best config[%d] threads=%d tile_n=%d (%.4f ms/iter)\n",
-        (long long)M, (long long)N, (long long)K, (long long)bs, col_major,
+        (long long)M, (long long)N, (long long)K, (long long)bs,
         best_id, kGemvConfigs[best_id].threads,
         kGemvConfigs[best_id].tile_n, best_ms / ITERS);
 
@@ -481,10 +498,10 @@ static std::unordered_map<std::string, int> gemv_cache;
 static std::mutex gemv_tune_mutex;
 
 static std::string gemvCacheKey(int64_t M, int64_t N, int64_t K, int64_t bs,
-                                bool col_major = false) {
+                                bool has_zp = true) {
     return std::to_string(M) + "_" + std::to_string(N) + "_" +
            std::to_string(K) + "_" + std::to_string(bs) + "_" +
-           (col_major ? "1" : "0");
+           (has_zp ? "1" : "0");
 }
 
 static int getOrTuneGemvConfig(
@@ -494,9 +511,9 @@ static int getOrTuneGemvConfig(
     const __half* bi, __half* out,
     int64_t M, int64_t N, int64_t K,
     int64_t batch, int64_t bs,
-    bool col_major = false)
+    bool has_zp = true)
 {
-    std::string key = gemvCacheKey(M, N, K, bs, col_major);
+    std::string key = gemvCacheKey(M, N, K, bs, has_zp);
 
     std::lock_guard<std::mutex> lock(gemv_tune_mutex);
 
@@ -505,7 +522,7 @@ static int getOrTuneGemvConfig(
         return it->second;
 
     int best = tuneGemvConfig(stream, A, B, sc, zp, bi, out,
-                               M, N, K, batch, bs, col_major);
+                               M, N, K, batch, bs, has_zp);
     gemv_cache[key] = best;
 
     CUSTOM_KERNELS_DEBUG_LOG(
@@ -960,6 +977,9 @@ static constexpr WmmaConfig kWmmaConfigs[] = {
     // --- WT_M=2, WT_N=1 fused (BN=32 — optimized for small N) ---
     { 64,  32,  4, true, 2, 1}, { 64,  32,  8, true, 2, 1},
     {128,  32,  4, true, 2, 1}, {128,  32,  8, true, 2, 1},
+    // --- WT_M=1, WT_N=2 fused (BM=32 — tall-N tile, maximizes A reuse) ---
+    { 32,  64,  2, true, 1, 2}, { 32,  64,  4, true, 1, 2},
+    { 32,  64,  8, true, 1, 2}, { 32,  64, 16, true, 1, 2},
     // --- separate dequant + fp16 GEMM ---
     { 64,  64,  2, false}, { 64,  64,  4, false}, { 64,  64,  8, false}, { 64,  64, 16, false},
     { 64, 128,  2, false}, { 64, 128,  4, false}, { 64, 128,  8, false}, { 64, 128, 16, false},
@@ -974,6 +994,9 @@ static constexpr WmmaConfig kWmmaConfigs[] = {
     // --- WT_M=2, WT_N=1 separate dequant (BN=32 — for small N) ---
     { 64,  32,  4, false, 2, 1}, { 64,  32,  8, false, 2, 1},
     {128,  32,  4, false, 2, 1}, {128,  32,  8, false, 2, 1},
+    // --- WT_M=1, WT_N=2 separate dequant (BM=32 — tall-N tile) ---
+    { 32,  64,  2, false, 1, 2}, { 32,  64,  4, false, 1, 2},
+    { 32,  64,  8, false, 1, 2}, { 32,  64, 16, false, 1, 2},
 };
 static constexpr int kNumWmmaConfigs =
     static_cast<int>(sizeof(kWmmaConfigs) / sizeof(kWmmaConfigs[0]));
@@ -1059,18 +1082,39 @@ static void launchWmmaConfig(
     if (need_bc) FP16_GEMM_LAUNCH_WT21(BM_V, BN_V, true); \
     else         FP16_GEMM_LAUNCH_WT21(BM_V, BN_V, false)
 
+#define FP16_GEMM_LAUNCH_WT12(BM_V, BN_V, BC_V) do { \
+    constexpr int WM_ = BM_V / (1 * 16); \
+    constexpr int WN_ = BN_V / (2 * 16); \
+    constexpr int THR_ = WM_ * WN_ * 32; \
+    dim3 grid_(static_cast<unsigned>((N + BN_V - 1) / BN_V), \
+               static_cast<unsigned>((M + BM_V - 1) / BM_V)); \
+    dim3 block_(THR_); \
+    hipLaunchKernelGGL( \
+        HIP_KERNEL_NAME(MatMulNBitsFp16GEMM<BM_V, BN_V, 1, 2, 8, BC_V>), \
+        grid_, block_, 0, stream, \
+        M, N, K, A, lda, B_fp16_buf, C, ldc, c.swizzle_n); \
+} while(0)
+
+#define FP16_TILE_CASE_WT12(BM_V, BN_V) \
+    if (need_bc) FP16_GEMM_LAUNCH_WT12(BM_V, BN_V, true); \
+    else         FP16_GEMM_LAUNCH_WT12(BM_V, BN_V, false)
+
         if      (c.wt_m == 4 && c.bm == 256 && c.bn == 128)
                                                   FP16_TILE_CASE_WT4(256, 128);
         else if (c.wt_n == 1 && c.bm == 128 && c.bn == 32)
                                                   FP16_TILE_CASE_WT21(128, 32);
         else if (c.wt_n == 1 && c.bm ==  64 && c.bn == 32)
                                                   FP16_TILE_CASE_WT21( 64, 32);
+        else if (c.wt_m == 1 && c.bm ==  32 && c.bn == 64)
+                                                  FP16_TILE_CASE_WT12( 32, 64);
         else if (c.bm ==  64 && c.bn ==  64) FP16_TILE_CASE( 64,  64);
         else if (c.bm ==  64 && c.bn == 128) FP16_TILE_CASE( 64, 128);
         else if (c.bm == 128 && c.bn ==  64) FP16_TILE_CASE(128,  64);
         else if (c.bm == 128 && c.bn == 256) FP16_TILE_CASE(128, 256);
         else                                  FP16_TILE_CASE(128, 128);
 
+#undef FP16_TILE_CASE_WT12
+#undef FP16_GEMM_LAUNCH_WT12
 #undef FP16_TILE_CASE_WT21
 #undef FP16_GEMM_LAUNCH_WT21
 #undef FP16_TILE_CASE_WT4
@@ -1152,18 +1196,46 @@ static void launchWmmaConfig(
     if (need_bc) WMMA_LAUNCH_WT21(BM_V, BN_V, true); \
     else         WMMA_LAUNCH_WT21(BM_V, BN_V, false)
 
+#define WMMA_LAUNCH_WT12(BM_V, BN_V, BC_V) do { \
+    constexpr int WM_ = BM_V / (1 * 16); \
+    constexpr int WN_ = BN_V / (2 * 16); \
+    constexpr int THR_ = WM_ * WN_ * 32; \
+    dim3 grid_(static_cast<unsigned>((N + BN_V - 1) / BN_V), \
+               static_cast<unsigned>((M + BM_V - 1) / BM_V)); \
+    dim3 block_(THR_); \
+    if (has_zp) { \
+        hipLaunchKernelGGL( \
+            HIP_KERNEL_NAME(MatMulNBitsWMMA_ZP<BM_V, BN_V, 1, 2, 8, BC_V>), \
+            grid_, block_, 0, stream, \
+            M, N, K, A, lda, B, scales, zeros, gs, ngk, C, ldc, c.swizzle_n); \
+    } else { \
+        hipLaunchKernelGGL( \
+            HIP_KERNEL_NAME(MatMulNBitsWMMA_NoZP<BM_V, BN_V, 1, 2, 8, BC_V>), \
+            grid_, block_, 0, stream, \
+            M, N, K, A, lda, B, scales, zeros, gs, ngk, C, ldc, c.swizzle_n); \
+    } \
+} while(0)
+
+#define WMMA_TILE_CASE_WT12(BM_V, BN_V) \
+    if (need_bc) WMMA_LAUNCH_WT12(BM_V, BN_V, true); \
+    else         WMMA_LAUNCH_WT12(BM_V, BN_V, false)
+
     if      (c.wt_m == 4 && c.bm == 256 && c.bn == 128)
                                               WMMA_TILE_CASE_WT4(256, 128);
     else if (c.wt_n == 1 && c.bm == 128 && c.bn == 32)
                                               WMMA_TILE_CASE_WT21(128, 32);
     else if (c.wt_n == 1 && c.bm ==  64 && c.bn == 32)
                                               WMMA_TILE_CASE_WT21( 64, 32);
+    else if (c.wt_m == 1 && c.bm ==  32 && c.bn == 64)
+                                              WMMA_TILE_CASE_WT12( 32, 64);
     else if (c.bm ==  64 && c.bn ==  64) WMMA_TILE_CASE( 64,  64);
     else if (c.bm ==  64 && c.bn == 128) WMMA_TILE_CASE( 64, 128);
     else if (c.bm == 128 && c.bn ==  64) WMMA_TILE_CASE(128,  64);
     else if (c.bm == 128 && c.bn == 256) WMMA_TILE_CASE(128, 256);
     else                                  WMMA_TILE_CASE(128, 128);
 
+#undef WMMA_TILE_CASE_WT12
+#undef WMMA_LAUNCH_WT12
 #undef WMMA_TILE_CASE_WT21
 #undef WMMA_LAUNCH_WT21
 #undef WMMA_TILE_CASE_WT4
@@ -1183,82 +1255,6 @@ static _Float16* ensureDqBuffer(int N, int K) {
     hipMalloc(&g_dq_buf, need * sizeof(_Float16));
     g_dq_buf_elems = need;
     return g_dq_buf;
-}
-
-/* -----------------------------------------------------------------------
- * GPU 2-D FP16 transpose + scratch buffer helpers
- *
- * transpose2d_fp16_kernel: transposes a [rows x cols] row-major matrix
- * into a [cols x rows] row-major matrix (equivalent to col-major view).
- * Used to convert row-major ONNX tensors to the col-major layout that
- * WMMA / GEMV kernels expect, and to convert results back.
- * ----------------------------------------------------------------------- */
-
-__global__ void transpose2d_fp16_kernel(
-    const _Float16* __restrict__ src,
-    _Float16* __restrict__ dst,
-    int rows, int cols)
-{
-    constexpr int TILE = 32;
-    __shared__ _Float16 tile[TILE][TILE + 1];
-
-    int bx = blockIdx.x * TILE;
-    int by = blockIdx.y * TILE;
-
-    int x = bx + threadIdx.x;
-    int y = by + threadIdx.y;
-
-    for (int j = 0; j < TILE; j += blockDim.y) {
-        int yy = y + j;
-        if (x < cols && yy < rows)
-            tile[threadIdx.y + j][threadIdx.x] = src[yy * cols + x];
-    }
-    __syncthreads();
-
-    x = by + threadIdx.x;
-    y = bx + threadIdx.y;
-    for (int j = 0; j < TILE; j += blockDim.y) {
-        int yy = y + j;
-        if (x < rows && yy < cols)
-            dst[yy * rows + x] = tile[threadIdx.x][threadIdx.y + j];
-    }
-}
-
-static void launchTranspose2DFp16(hipStream_t stream,
-                                  const void* src, void* dst,
-                                  int rows, int cols)
-{
-    constexpr int TILE = 32;
-    dim3 block(TILE, 8);
-    dim3 grid((cols + TILE - 1) / TILE, (rows + TILE - 1) / TILE);
-    hipLaunchKernelGGL(transpose2d_fp16_kernel, grid, block, 0, stream,
-                       static_cast<const _Float16*>(src),
-                       static_cast<_Float16*>(dst),
-                       rows, cols);
-}
-
-static _Float16* g_a_col_buf = nullptr;
-static size_t    g_a_col_buf_elems = 0;
-
-static _Float16* ensureAColBuffer(int M, int K) {
-    size_t need = static_cast<size_t>(M) * K;
-    if (g_a_col_buf && g_a_col_buf_elems >= need) return g_a_col_buf;
-    if (g_a_col_buf) hipFree(g_a_col_buf);
-    hipMalloc(&g_a_col_buf, need * sizeof(_Float16));
-    g_a_col_buf_elems = need;
-    return g_a_col_buf;
-}
-
-static _Float16* g_out_col_buf = nullptr;
-static size_t    g_out_col_buf_elems = 0;
-
-static _Float16* ensureOutColBuffer(int M, int N) {
-    size_t need = static_cast<size_t>(M) * N;
-    if (g_out_col_buf && g_out_col_buf_elems >= need) return g_out_col_buf;
-    if (g_out_col_buf) hipFree(g_out_col_buf);
-    hipMalloc(&g_out_col_buf, need * sizeof(_Float16));
-    g_out_col_buf_elems = need;
-    return g_out_col_buf;
 }
 
 static int tuneWmmaConfig(
@@ -1284,6 +1280,14 @@ static int tuneWmmaConfig(
     for (int cid = 0; cid < kNumWmmaConfigs; cid++) {
         auto& cfg = kWmmaConfigs[cid];
         if (cfg.bn < 64 && N > 2 * cfg.bn) continue;
+
+        // BK_T = bm / (wt_m * wt_n).  When BK_T > group_size the fused
+        // dequant applies a single scale to K-positions that span multiple
+        // quant groups, producing wrong results.  Skip such configs.
+        if (cfg.fused) {
+            int bk_t = cfg.bm / (cfg.wt_m * cfg.wt_n);
+            if (bk_t > gs) continue;
+        }
 
         for (int w = 0; w < WARMUP; w++)
             launchWmmaConfig(cid, stream, M, N, K, A, lda, B,
@@ -1444,6 +1448,12 @@ static const _Float16* convertZpToFp16(
     return zp_fp16;
 }
 
+static char g_last_tune_info[128] = "none";
+
+extern "C" const char* hip_matmul_nbits_last_tune_info() {
+    return g_last_tune_info;
+}
+
 extern "C" int hip_matmul_nbits(
     void* stream,
     const void* A,
@@ -1498,7 +1508,7 @@ extern "C" int hip_matmul_nbits(
    * zero_points (if not NULL) must be FP16 [N, num_groups_k].
    *
    * When M >= kBlockDim (16): WMMA intrinsics (RDNA3 fast path)
-   * When M <  kBlockDim:      GEMV kernel with COL_MAJOR=true
+   * When M <  kBlockDim:      GEMV kernel (row-major, autotuned)
    * ------------------------------------------------------------------- */
   bool wmma_data_format = (batch_count == 1) && (K % 32 == 0);
 
@@ -1529,6 +1539,14 @@ extern "C" int hip_matmul_nbits(
     int wmma_cfg = getOrTuneWmmaConfig(
         hip_stream, iM, iN, iK, a_ptr, lda, b_ptr,
         s_ptr, z_ptr, gs, ngk, out_ptr, ldc, has_zp);
+
+    {
+        auto& cc = kWmmaConfigs[wmma_cfg];
+        snprintf(g_last_tune_info, sizeof(g_last_tune_info),
+                 "%s bm=%d bn=%d wt=%d,%d sw=%d",
+                 cc.fused ? "fused" : "dq+gem",
+                 cc.bm, cc.bn, cc.wt_m, cc.wt_n, cc.swizzle_n);
+    }
 
     _Float16* dq_buf = kWmmaConfigs[wmma_cfg].fused
                            ? nullptr : ensureDqBuffer(iN, iK);
@@ -1566,74 +1584,45 @@ extern "C" int hip_matmul_nbits(
   }
 
   /* -------------------------------------------------------------------
-   * GEMV path with col-major data — small M, WMMA data format
+   * GEMV path — small M, WMMA data format
    *
-   * When batch==1, K%32==0, but M < kBlockDim: internally transpose
-   * A row->col and output col->row so the caller sees row-major I/O.
-   * GEMV kernel runs with COL_MAJOR=true for K-parallel reduction.
+   * When batch==1, K%32==0, but M < kBlockDim: row-major GEMV with
+   * autotuned (BLOCK_SIZE, TILE_N). Zero points are FP16 (same as API).
    * ------------------------------------------------------------------- */
   if (wmma_data_format && M < kBlockDim) {
     CUSTOM_KERNELS_DEBUG_LOG(
-        "[custom_kernels] hip_matmul_nbits: GEMV col-major path M=%lld "
-        "N=%lld K=%lld bs=%lld zp=%s bias=%s\n",
-        (long long)M, (long long)N, (long long)K,
-        (long long)block_size,
-        zero_points ? "yes" : "null", bias ? "yes" : "null");
+        "[custom_kernels] hip_matmul_nbits: GEMV row-major M=%lld "
+        "N=%lld K=%lld bs=%lld zp=%s\n",
+        (long long)M, (long long)N, (long long)K, (long long)block_size,
+        zero_points ? "yes" : "null");
 
-    int iM = static_cast<int>(M);
-    int iN = static_cast<int>(N);
-    int iK = static_cast<int>(K);
-
-    // Row-major A [M, K] -> col-major (skip if M==1: row/col identical)
-    const __half* a_col;
-    if (M > 1) {
-      _Float16* a_buf = ensureAColBuffer(iM, iK);
-      launchTranspose2DFp16(hip_stream, A, a_buf, iM, iK);
-      a_col = reinterpret_cast<const __half*>(a_buf);
-    } else {
-      a_col = static_cast<const __half*>(A);
-    }
-
-    // GEMV output to col-major scratch (skip if M==1)
-    __half* o_col;
-    if (M > 1) {
-      o_col = reinterpret_cast<__half*>(ensureOutColBuffer(iM, iN));
-    } else {
-      o_col = static_cast<__half*>(output);
-    }
-
+    const auto* a_h = static_cast<const __half*>(A);
     const auto* b_u = static_cast<const uint8_t*>(B);
     const auto* s_h = static_cast<const __half*>(scales);
     const auto* z_u = static_cast<const uint8_t*>(zp_for_fp16_paths);
     const auto* b_h = static_cast<const __half*>(bias);
+    auto*       o_h = static_cast<__half*>(output);
+
+    bool gemv_has_zp = (z_u != nullptr);
 
     int config_id = getOrTuneGemvConfig(
-        hip_stream, a_col, b_u, s_h, z_u, b_h, o_col,
-        M, N, K, 1, block_size, /*col_major=*/true);
+        hip_stream, a_h, b_u, s_h, z_u, b_h, o_h,
+        M, N, K, 1, block_size, gemv_has_zp);
+
+    snprintf(g_last_tune_info, sizeof(g_last_tune_info),
+             "gemv-row t=%d tn=%d",
+             kGemvConfigs[config_id].threads,
+             kGemvConfigs[config_id].tile_n);
 
     launchGemvConfig(config_id, hip_stream,
-                     a_col, b_u, s_h, z_u, b_h, o_col,
-                     M, N, K, 1, block_size, /*col_major=*/true);
+                     a_h, b_u, s_h, z_u, b_h, o_h,
+                     M, N, K, 1, block_size, gemv_has_zp);
 
     hipError_t err = hipGetLastError();
     if (err != hipSuccess) {
       fprintf(stderr,
-              "[custom_kernels] hip_matmul_nbits GEMV col-major launch "
-              "failed: %s\n",
+              "[custom_kernels] hip_matmul_nbits GEMV launch failed: %s\n",
               hipGetErrorString(err));
-      return static_cast<int>(err);
-    }
-
-    // Col-major output -> row-major (skip if M==1)
-    if (M > 1) {
-      launchTranspose2DFp16(hip_stream, o_col, output, iN, iM);
-      err = hipGetLastError();
-      if (err != hipSuccess) {
-        fprintf(stderr,
-                "[custom_kernels] hip_matmul_nbits GEMV out-transpose "
-                "failed: %s\n",
-                hipGetErrorString(err));
-      }
     }
     return static_cast<int>(err);
   }
@@ -1641,7 +1630,7 @@ extern "C" int hip_matmul_nbits(
   /* -------------------------------------------------------------------
    * GEMV path — small M, row-major data (non-WMMA format)
    *
-   * For small M (≤ kBlockDim) with row-major A and uint8 zero points.
+   * For small M (≤ kBlockDim) with row-major A and FP16 zero points.
    * On the first call for each (M,N,K,block_size) shape, all configs
    * are benchmarked and the fastest is cached for subsequent calls.
    * ------------------------------------------------------------------- */
@@ -1660,13 +1649,20 @@ extern "C" int hip_matmul_nbits(
     const auto* b_h = static_cast<const __half*>(bias);
     auto*       o_h = static_cast<__half*>(output);
 
+    bool gemv_has_zp = (z_u != nullptr);
+
     int config_id = getOrTuneGemvConfig(
         hip_stream, a_h, b_u, s_h, z_u, b_h, o_h,
-        M, N, K, batch_count, block_size);
+        M, N, K, batch_count, block_size, gemv_has_zp);
+
+    snprintf(g_last_tune_info, sizeof(g_last_tune_info),
+             "gemv-row t=%d tn=%d",
+             kGemvConfigs[config_id].threads,
+             kGemvConfigs[config_id].tile_n);
 
     launchGemvConfig(config_id, hip_stream,
                      a_h, b_u, s_h, z_u, b_h, o_h,
-                     M, N, K, batch_count, block_size);
+                     M, N, K, batch_count, block_size, gemv_has_zp);
 
     hipError_t err = hipGetLastError();
     if (err != hipSuccess) {
@@ -1680,6 +1676,7 @@ extern "C" int hip_matmul_nbits(
   /* -------------------------------------------------------------------
    * Naive fallback (row-major, batched, uint8 zero points)
    * ------------------------------------------------------------------- */
+  snprintf(g_last_tune_info, sizeof(g_last_tune_info), "naive");
   CUSTOM_KERNELS_DEBUG_LOG(
       "[custom_kernels] hip_matmul_nbits: naive fallback M=%lld N=%lld K=%lld "
       "batch=%lld bits=%lld bs=%lld elem=%lld zp=%s bias=%s\n",
@@ -1707,4 +1704,8 @@ extern "C" int hip_matmul_nbits(
             hipGetErrorString(err));
   }
   return static_cast<int>(err);
+}
+
+extern "C" void hip_matmul_nbits_release_buffers() {
+  if (g_dq_buf) { hipFree(g_dq_buf); g_dq_buf = nullptr; g_dq_buf_elems = 0; }
 }

--- a/3rd-party/custom_kernels/include/hip_custom_kernels.h
+++ b/3rd-party/custom_kernels/include/hip_custom_kernels.h
@@ -454,6 +454,13 @@ int hip_matmul_nbits(
     int64_t element_size_bytes,
     int64_t zp_elem_size);  // 1=uint8 packed nibbles, 2=fp16
 
+/* Release internal scratch buffers (transpose / dequant).
+ * Useful for benchmarking cold-cache scenarios. */
+void hip_matmul_nbits_release_buffers(void);
+
+/* Returns a string describing the autotune config used by the last call. */
+const char* hip_matmul_nbits_last_tune_info(void);
+
 /* =========================================================================
  * QMoE Sub-Kernels
  * =========================================================================

--- a/3rd-party/custom_kernels/test/example/gemm_bf16u4/Makefile
+++ b/3rd-party/custom_kernels/test/example/gemm_bf16u4/Makefile
@@ -207,6 +207,9 @@ gendata_model:
 test_model: gendata_model direct
 	$(call RUN_CMD,$(TARGET_DIRECT)) --model $(MODEL_JSON) --data-root $(MODEL_DATA_DIR) --group-size $(GS) $(CXX_NZ_FLAG)
 
+test_model_cold: gendata_model direct
+	$(call RUN_CMD,$(TARGET_DIRECT)) --model $(MODEL_JSON) --data-root $(MODEL_DATA_DIR) --group-size $(GS) $(CXX_NZ_FLAG) --cold-cache
+
 # Benchmark M=512..3072 at K=2880, N=201088 (no zeros)
 bench_large_n:
 	$(MAKE) test SIZE=512x2880x201088 GS=128 NO_ZEROS=1
@@ -216,4 +219,4 @@ bench_large_n:
 
 FORCE:
 
-.PHONY: all lib direct clean run run_lib run_custom gendata gendata_model test test_lib test_real test_all test_model bench_large_n FORCE
+.PHONY: all lib direct clean run run_lib run_custom gendata gendata_model test test_lib test_real test_all test_model test_model_cold bench_large_n FORCE

--- a/3rd-party/custom_kernels/test/example/gemm_bf16u4/gen_matmul_nbits_data.py
+++ b/3rd-party/custom_kernels/test/example/gemm_bf16u4/gen_matmul_nbits_data.py
@@ -67,6 +67,8 @@ def main():
     B_even = B_uint4[:, 0::2]
     B_odd  = B_uint4[:, 1::2]
     B_packed = (B_even | (B_odd << 4)).astype(np.uint8)
+    if args.no_zeros:
+        B_packed ^= 0x88
 
     scales = np.random.uniform(0.01, 0.05, (N, num_groups_k)).astype(np.float16)
 

--- a/3rd-party/custom_kernels/test/example/gemm_bf16u4/test_matmul_nbits.cpp
+++ b/3rd-party/custom_kernels/test/example/gemm_bf16u4/test_matmul_nbits.cpp
@@ -87,17 +87,32 @@ static bool readBin(const std::string& path, std::vector<T>& data, size_t count)
 }
 
 // ============================================================
+// Theoretical peaks — auto-detected from hipDeviceProp_t in main()
+//   WMMA FP16: 512 FLOP/CU/cycle (2× VALU)
+//   VALU FP16: 256 FLOP/CU/cycle (packed FP16)
+// ============================================================
+static double g_peak_wmma_gflops = 0;
+static double g_peak_valu_gflops = 0;
+static double g_peak_bw_gbs     = 0;
+static double g_wmma_ridge_ai   = 0;
+static double g_valu_ridge_ai   = 0;
+
+// ============================================================
 // Benchmark helpers
 // ============================================================
+static bool g_cold_cache = false;
+
 static int calibrateIters(double warmup_ms, int warmup_count,
                           double target_ms = 2000.0, int lo = 5, int hi = 200)
 {
+    if(g_cold_cache) return 1;
     double per_iter = warmup_ms / warmup_count;
     if(per_iter <= 0) return lo;
     return std::max(lo, std::min(hi, static_cast<int>(target_ms / per_iter)));
 }
 
-constexpr int NROUNDS = 5;
+static constexpr int NROUNDS      = 5;
+static constexpr int NROUNDS_COLD = 11;
 
 struct MeasureResult {
     double median_ms;
@@ -105,35 +120,74 @@ struct MeasureResult {
     double max_ms;
 };
 
+static void* g_l2_polluter = nullptr;
+static size_t g_l2_polluter_bytes = 32 * 1024 * 1024; // default 32 MB, updated from prop
+
+static void ensureL2Polluter()
+{
+    if(!g_l2_polluter)
+        hipMalloc(&g_l2_polluter, g_l2_polluter_bytes);
+}
+
+static void flushL2(hipStream_t stream)
+{
+    hipMemsetAsync(g_l2_polluter, 0x42, g_l2_polluter_bytes, stream);
+}
+
 static MeasureResult measureMedian(hipStream_t stream, int niters,
                                    const std::function<void()>& launch)
 {
     hipEvent_t ev0, ev1;
     hipEventCreate(&ev0);
     hipEventCreate(&ev1);
-    std::vector<float> round_ms(NROUNDS);
-    for(int r = 0; r < NROUNDS; r++)
+
+    const int nrounds = g_cold_cache ? NROUNDS_COLD : NROUNDS;
+    std::vector<float> round_ms(nrounds);
+
+    if(g_cold_cache)
+        ensureL2Polluter();
+
+    for(int r = 0; r < nrounds; r++)
     {
-        hipEventRecord(ev0, stream);
-        for(int i = 0; i < niters; i++)
+        if(g_cold_cache)
+        {
+            flushL2(stream);
+            hip_matmul_nbits_release_buffers();
+            hipStreamSynchronize(stream);
+
+            hipEventRecord(ev0, stream);
             launch();
-        hipEventRecord(ev1, stream);
-        hipEventSynchronize(ev1);
-        hipEventElapsedTime(&round_ms[r], ev0, ev1);
+            hipEventRecord(ev1, stream);
+            hipEventSynchronize(ev1);
+            hipEventElapsedTime(&round_ms[r], ev0, ev1);
+        }
+        else
+        {
+            hipEventRecord(ev0, stream);
+            for(int i = 0; i < niters; i++)
+                launch();
+            hipEventRecord(ev1, stream);
+            hipEventSynchronize(ev1);
+            hipEventElapsedTime(&round_ms[r], ev0, ev1);
+        }
     }
     hipEventDestroy(ev0);
     hipEventDestroy(ev1);
 
-    std::cout << "\n  [debug] per-round raw (ms): ";
-    for(int r = 0; r < NROUNDS; r++)
-        std::cout << std::fixed << std::setprecision(2) << round_ms[r] << " ";
-    std::cout << "  (per-iter: ";
-    for(int r = 0; r < NROUNDS; r++)
-        std::cout << std::fixed << std::setprecision(3) << round_ms[r] / niters << " ";
-    std::cout << ")" << std::endl;
+    std::cout << "\n  [debug] " << nrounds << " rounds (ms):";
+    for(int r = 0; r < nrounds; r++)
+        std::cout << " " << std::fixed << std::setprecision(3) << round_ms[r];
+    if(!g_cold_cache)
+    {
+        std::cout << "  (per-iter:";
+        for(int r = 0; r < nrounds; r++)
+            std::cout << " " << std::setprecision(3) << round_ms[r] / niters;
+        std::cout << ")";
+    }
+    std::cout << std::endl;
 
     std::sort(round_ms.begin(), round_ms.end());
-    return {round_ms[NROUNDS / 2], round_ms[0], round_ms[NROUNDS - 1]};
+    return {round_ms[nrounds / 2], round_ms[0], round_ms[nrounds - 1]};
 }
 
 // ============================================================
@@ -421,10 +475,11 @@ bool test_matmul_nbits(int M, int N, int K, int group_size,
             1,         // batch_count
             4,         // bits
             group_size,// block_size
-            2);        // element_size_bytes (fp16)
+            2,         // element_size_bytes (fp16)
+            use_zeros ? 2 : 0);
     };
 
-    constexpr int PRE_WARMUP = 2000;
+    int PRE_WARMUP = g_cold_cache ? 10 : 2000;
     std::cout << "  Pre-warmup (" << PRE_WARMUP << " iters)..." << std::flush;
     auto pw0 = std::chrono::steady_clock::now();
     for(int w = 0; w < PRE_WARMUP; w++)
@@ -449,7 +504,8 @@ bool test_matmul_nbits(int M, int N, int K, int group_size,
             nullptr,
             d_C,
             M, N, K,
-            1, 4, group_size, 2);
+            1, 4, group_size, 2,
+            use_zeros ? 2 : 0);
         if(status != 0) break;
     }
     HIP_CHECK(hipStreamSynchronize(stream));
@@ -477,6 +533,11 @@ bool test_matmul_nbits(int M, int N, int K, int group_size,
               << std::flush;
     auto mr = measureMedian(stream, niters, launch_kernel);
 
+    std::string tune = hip_matmul_nbits_last_tune_info();
+    bool is_wmma     = (tune.find("gemv") == std::string::npos);
+    double peak_gf   = is_wmma ? g_peak_wmma_gflops : g_peak_valu_gflops;
+    double ridge_ai  = peak_gf / g_peak_bw_gbs;
+
     double avg_ms    = mr.median_ms / niters;
     double gflops    = (2.0 * M * N * K) / (avg_ms * 1e6);
     double mem_bytes = static_cast<double>(countA) * 2 + static_cast<double>(countB)
@@ -484,16 +545,27 @@ bool test_matmul_nbits(int M, int N, int K, int group_size,
                      + (use_zeros ? static_cast<double>(countZ) * 2 : 0.0)
                      + static_cast<double>(countC) * 2;
     double bw_gbs    = mem_bytes * niters / (mr.median_ms * 1e6);
+    double ai        = (2.0 * M * N * K) / mem_bytes;
+    double roofline  = std::min(peak_gf, ai * g_peak_bw_gbs);
+    double pct_roof  = gflops / roofline * 100.0;
+    double pct_bw    = bw_gbs / g_peak_bw_gbs * 100.0;
     double range_pct = (mr.max_ms - mr.min_ms) / mr.median_ms * 100.0;
+    const char* bound = (ai < ridge_ai) ? "BW" : "FLOPs";
 
     std::cout << " done" << std::endl;
-    std::cout << "\n  === Performance ===" << std::endl;
-    std::cout << std::fixed << std::setprecision(3);
+    std::cout << "\n  === Performance (" << (is_wmma ? "WMMA" : "VALU") << " peak="
+              << std::fixed << std::setprecision(0) << peak_gf << " GFLOPS) ===" << std::endl;
+    std::cout << std::fixed;
+    std::cout << "  Kernel: " << tune << std::endl;
     std::cout << "  Median: "
-              << std::setprecision(6) << avg_ms << " ms, "
-              << gflops << " GFLOPS, "
-              << bw_gbs << " GB/s" << std::endl;
-    std::cout << "  Range:  " << mr.min_ms / niters << " ~ " << mr.max_ms / niters
+              << std::setprecision(6) << avg_ms << " ms" << std::endl;
+    std::cout << "  GFLOPS: " << std::setprecision(2) << gflops
+              << " / " << roofline << " (" << std::setprecision(1) << pct_roof << "% roofline)" << std::endl;
+    std::cout << "  BW:     " << std::setprecision(2) << bw_gbs
+              << " / " << g_peak_bw_gbs << " GB/s (" << std::setprecision(1) << pct_bw << "%)" << std::endl;
+    std::cout << "  AI:     " << std::setprecision(1) << ai
+              << " FLOP/byte -> " << bound << "-bound (ridge=" << ridge_ai << ")" << std::endl;
+    std::cout << "  Range:  " << std::setprecision(6) << mr.min_ms / niters << " ~ " << mr.max_ms / niters
               << " ms  (jitter " << std::setprecision(1) << range_pct << "%)" << std::endl;
 
     std::vector<__half> h_C(countC);
@@ -568,9 +640,14 @@ struct ShapeResult {
     double median_ms;
     double gflops;
     double bw_gbs;
+    double ai;
+    double roofline_gflops;
+    double pct_roofline;
+    double pct_bw;
     bool   pass;
     int    errors;
     int    checked;
+    std::string tune_info;
 };
 
 static int runModelSweep(const std::string& json_path, int group_size,
@@ -636,7 +713,7 @@ static int runModelSweep(const std::string& json_path, int group_size,
             {
                 std::cerr << "  ERROR: cannot read data from " << shape_dir << "/" << std::endl;
                 std::cerr << "  Run: make gendata_model  to generate all data first" << std::endl;
-                results.push_back({M, K, N, 0, 0, 0, false, -1, 0});
+                results.push_back({M, K, N, 0, 0, 0, 0, 0, 0, 0, false, -1, 0, "N/A"});
                 continue;
             }
             std::cout << "  Loaded data from " << shape_dir << "/" << std::endl;
@@ -664,13 +741,14 @@ static int runModelSweep(const std::string& json_path, int group_size,
             auto launch = [&]() {
                 hip_matmul_nbits(stream, dA, dB, dS,
                                  use_zeros ? dZ : nullptr, nullptr, dC,
-                                 M, N, K, 1, 4, group_size, 2);
+                                 M, N, K, 1, 4, group_size, 2,
+                                 use_zeros ? 2 : 0);
             };
 
             // Pre-warmup (once, on first successfully loaded shape)
             if(!warmup_done)
             {
-                constexpr int PRE_WARMUP = 200;
+                int PRE_WARMUP = g_cold_cache ? 10 : 200;
                 std::cout << "  Pre-warmup (" << PRE_WARMUP << " iters)..." << std::flush;
                 auto t0 = std::chrono::steady_clock::now();
                 for(int w = 0; w < PRE_WARMUP; w++)
@@ -693,7 +771,8 @@ static int runModelSweep(const std::string& json_path, int group_size,
             {
                 status = hip_matmul_nbits(stream, dA, dB, dS,
                                           use_zeros ? dZ : nullptr, nullptr, dC,
-                                          M, N, K, 1, 4, group_size, 2);
+                                          M, N, K, 1, 4, group_size, 2,
+                                          use_zeros ? 2 : 0);
                 if(status != 0) break;
             }
             HIP_CHECK(hipStreamSynchronize(stream));
@@ -703,7 +782,7 @@ static int runModelSweep(const std::string& json_path, int group_size,
             if(status != 0)
             {
                 std::cout << " FAILED (status=" << status << ")" << std::endl;
-                results.push_back({M, K, N, 0, 0, 0, false, -1, 0});
+                results.push_back({M, K, N, 0, 0, 0, 0, 0, 0, 0, false, -1, 0, "N/A"});
                 hipFree(dA); hipFree(dB); hipFree(dS);
                 if(dZ) hipFree(dZ); hipFree(dC);
                 continue;
@@ -717,6 +796,11 @@ static int runModelSweep(const std::string& json_path, int group_size,
                       << niters << " iters)..." << std::flush;
             auto mr = measureMedian(stream, niters, launch);
 
+            std::string tune = hip_matmul_nbits_last_tune_info();
+            bool is_wmma     = (tune.find("gemv") == std::string::npos);
+            double peak_gf   = is_wmma ? g_peak_wmma_gflops : g_peak_valu_gflops;
+            double ridge_ai  = peak_gf / g_peak_bw_gbs;
+
             double avg_ms    = mr.median_ms / niters;
             double gflops    = (2.0 * M * N * K) / (avg_ms * 1e6);
             double mem_bytes = (double)countA * 2 + (double)countB
@@ -724,12 +808,23 @@ static int runModelSweep(const std::string& json_path, int group_size,
                              + (use_zeros ? (double)countZ * 2 : 0.0)
                              + (double)countC * 2;
             double bw_gbs    = mem_bytes * niters / (mr.median_ms * 1e6);
+            double ai        = (2.0 * M * N * K) / mem_bytes;
+            double roofline  = std::min(peak_gf, ai * g_peak_bw_gbs);
+            double pct_roof  = gflops / roofline * 100.0;
+            double pct_bw    = bw_gbs / g_peak_bw_gbs * 100.0;
+            const char* bound = (ai < ridge_ai) ? "BW" : "FLOPs";
 
             std::cout << " done" << std::endl;
-            std::cout << "\n  === Performance ===" << std::endl;
+            std::cout << "\n  === Performance (" << (is_wmma ? "WMMA" : "VALU")
+                      << " peak=" << std::fixed << std::setprecision(0) << peak_gf << ") ===" << std::endl;
             std::cout << std::fixed << std::setprecision(6);
-            std::cout << "  Median: " << avg_ms << " ms, "
-                      << gflops << " GFLOPS, " << bw_gbs << " GB/s" << std::endl;
+            std::cout << "  Median: " << avg_ms << " ms" << std::endl;
+            std::cout << "  GFLOPS: " << std::setprecision(2) << gflops
+                      << " / " << roofline << " (" << std::setprecision(1) << pct_roof << "% roofline)" << std::endl;
+            std::cout << "  BW:     " << std::setprecision(2) << bw_gbs
+                      << " / " << g_peak_bw_gbs << " GB/s (" << std::setprecision(1) << pct_bw << "%)" << std::endl;
+            std::cout << "  AI:     " << std::setprecision(1) << ai
+                      << " FLOP/byte -> " << bound << "-bound" << std::endl;
 
             // Download and verify against Python reference
             std::vector<__half> h_C(countC);
@@ -769,7 +864,8 @@ static int runModelSweep(const std::string& json_path, int group_size,
             }
 
             results.push_back({M, K, N, avg_ms, gflops, bw_gbs,
-                               pass, errors, total});
+                               ai, roofline, pct_roof, pct_bw,
+                               pass, errors, total, tune});
 
             hipFree(dA); hipFree(dB); hipFree(dS);
             if(dZ) hipFree(dZ); hipFree(dC);
@@ -791,32 +887,48 @@ static int runModelSweep(const std::string& json_path, int group_size,
               << std::setw(7)  << "N"    << " | "
               << std::setw(11) << "Median(ms)"  << " | "
               << std::setw(9)  << "GFLOPS"  << " | "
+              << std::setw(10) << "Roofline"  << " | "
+              << std::setw(5)  << "Eff%"    << " | "
               << std::setw(8)  << "GB/s"    << " | "
-              << "Status" << std::endl;
-    std::cout << "-----+-------+-------+---------+-------------+-----------+----------+--------"
-              << std::endl;
+              << std::setw(5)  << "BW%"     << " | "
+              << std::setw(6)  << "AI"      << " | "
+              << std::setw(5)  << "Bound"   << " | "
+              << std::setw(6)  << "Status"  << " | "
+              << "Autotune" << std::endl;
+    std::cout << std::string(140, '-') << std::endl;
 
     int pass_count = 0, fail_count = 0;
     for(size_t i = 0; i < results.size(); i++)
     {
         auto& r = results[i];
         if(r.pass) pass_count++; else fail_count++;
+        bool wmma = (r.tune_info.find("gemv") == std::string::npos);
+        double ridge = wmma ? g_wmma_ridge_ai : g_valu_ridge_ai;
+        const char* b = (r.ai < ridge) ? "BW" : "FLOPs";
         std::cout << std::right << std::setw(4) << (i + 1) << " | "
                   << std::setw(5) << r.M << " | "
                   << std::setw(5) << r.K << " | "
                   << std::setw(7) << r.N << " | "
                   << std::setw(11) << std::fixed << std::setprecision(6) << r.median_ms << " | "
                   << std::setw(9)  << std::setprecision(2) << r.gflops << " | "
+                  << std::setw(10) << std::setprecision(2) << r.roofline_gflops << " | "
+                  << std::setw(4)  << std::setprecision(1) << r.pct_roofline << "%" << " | "
                   << std::setw(8)  << std::setprecision(2) << r.bw_gbs << " | "
-                  << (r.pass ? "PASS" : "FAIL") << std::endl;
+                  << std::setw(4)  << std::setprecision(1) << r.pct_bw << "%" << " | "
+                  << std::setw(6)  << std::setprecision(1) << r.ai << " | "
+                  << std::setw(5)  << b << " | "
+                  << std::setw(6)  << (r.pass ? "PASS" : "FAIL") << " | "
+                  << r.tune_info << std::endl;
     }
 
-    std::cout << "=========================================================================="
-              << std::endl;
+    std::cout << std::string(140, '=') << std::endl;
     std::cout << "Total: " << results.size() << " shapes, "
               << pass_count << " passed, " << fail_count << " failed" << std::endl;
-    std::cout << "=========================================================================="
-              << std::endl;
+    std::cout << "Theory: WMMA " << std::fixed << std::setprecision(0) << g_peak_wmma_gflops
+              << " / VALU " << g_peak_valu_gflops << " GFLOPS, BW " << g_peak_bw_gbs
+              << " GB/s, Ridge " << std::setprecision(1) << g_wmma_ridge_ai
+              << " / " << g_valu_ridge_ai << " FLOP/byte" << std::endl;
+    std::cout << std::string(140, '=') << std::endl;
 
     return (fail_count == 0) ? 0 : 1;
 }
@@ -828,14 +940,76 @@ int main(int argc, char* argv[])
 
     hipDeviceProp_t prop;
     HIP_CHECK(hipGetDeviceProperties(&prop, 0));
-    std::cout << "GPU: " << prop.name << " (arch: " << prop.gcnArchName << ")" << std::endl;
-
     std::string arch(prop.gcnArchName);
-    if(arch.find("gfx11") == std::string::npos && arch.find("gfx12") == std::string::npos)
+    bool is_rdna3_plus = (arch.find("gfx11") != std::string::npos ||
+                          arch.find("gfx12") != std::string::npos);
+
+    std::cout << "GPU: " << prop.name << " (arch: " << arch << ")" << std::endl;
+    std::cout << "  HW: " << prop.multiProcessorCount << " WGPs"
+              << ", GPU " << prop.clockRate / 1000 << " MHz"
+              << ", Mem " << prop.memoryClockRate / 1000 << " MHz"
+              << ", Bus " << prop.memoryBusWidth << "-bit"
+              << ", L2 " << prop.l2CacheSize / 1024 << " KB" << std::endl;
+
+    // RDNA 3/3.5: multiProcessorCount reports WGPs (each WGP = 2 CUs = 128 shaders)
+    //   VALU FP16 packed: 256 FLOP/CU/cycle → 512 FLOP/WGP/cycle
+    //   WMMA AI accel:    512 FLOP/CU/cycle → 1024 FLOP/WGP/cycle (AMD GPUOpen doc)
+    //   Official "FP16" spec (29.7T) = VALU only; WMMA peak = 2× VALU = 59.4T
+    int valu_per_mp = is_rdna3_plus ? 512 : 256;
+    g_peak_valu_gflops = prop.multiProcessorCount * (double)valu_per_mp
+                       * (prop.clockRate * 1e3) / 1e9;
+    g_peak_wmma_gflops = g_peak_valu_gflops * 2.0;
+
+    // HIP often mis-reports memory specs for iGPUs sharing system memory.
+    // Auto-detect, but fall back to 256 GB/s (LPDDR5X-8000 × 256-bit) if unreasonable.
+    double auto_bw = 2.0 * (prop.memoryClockRate * 1e3) * (prop.memoryBusWidth / 8.0) / 1e9;
+    constexpr double kDefaultBwGbs = 256.0;
+    if(auto_bw >= 128.0 && auto_bw <= 2048.0)
+        g_peak_bw_gbs = auto_bw;
+    else {
+        g_peak_bw_gbs = kDefaultBwGbs;
+        std::cout << "  NOTE: HIP reported BW " << std::fixed << std::setprecision(1)
+                  << auto_bw << " GB/s looks wrong, using default "
+                  << kDefaultBwGbs << " GB/s" << std::endl;
+    }
+
+    // Allow command-line overrides: --peak-bw=N  --peak-wmma=N  --peak-valu=N
+    for(int i = 1; i < argc; i++)
+    {
+        std::string arg(argv[i]);
+        if(arg == "--cold-cache")
+            g_cold_cache = true;
+        else if(arg.rfind("--peak-bw=", 0) == 0)
+            g_peak_bw_gbs = std::stod(arg.substr(10));
+        else if(arg.rfind("--peak-wmma=", 0) == 0)
+            g_peak_wmma_gflops = std::stod(arg.substr(12));
+        else if(arg.rfind("--peak-valu=", 0) == 0)
+            g_peak_valu_gflops = std::stod(arg.substr(12));
+    }
+
+    g_wmma_ridge_ai = g_peak_wmma_gflops / g_peak_bw_gbs;
+    g_valu_ridge_ai = g_peak_valu_gflops / g_peak_bw_gbs;
+
+    if(prop.l2CacheSize > 0)
+        g_l2_polluter_bytes = std::max((size_t)(prop.l2CacheSize * 2), (size_t)(32 * 1024 * 1024));
+
+    std::cout << std::fixed;
+    std::cout << "  Peak WMMA FP16: " << std::setprecision(0) << g_peak_wmma_gflops
+              << " GFLOPS (ridge " << std::setprecision(1) << g_wmma_ridge_ai << " FLOP/byte)" << std::endl;
+    std::cout << "  Peak VALU FP16: " << std::setprecision(0) << g_peak_valu_gflops
+              << " GFLOPS (ridge " << std::setprecision(1) << g_valu_ridge_ai << " FLOP/byte)" << std::endl;
+    std::cout << "  Peak BW: " << std::setprecision(1) << g_peak_bw_gbs << " GB/s" << std::endl;
+    std::cout << "  L2 flush: " << g_l2_polluter_bytes / (1024 * 1024) << " MB" << std::endl;
+
+    if(!is_rdna3_plus)
     {
         std::cerr << "WARNING: WMMA fast path requires RDNA3+ (gfx11xx/gfx12xx). "
                   << "Current arch: " << arch << std::endl;
     }
+
+    if(g_cold_cache)
+        std::cout << "*** COLD-CACHE mode: L2 flush + buffer release between each kernel call ***"
+                  << std::endl;
 
     // --- Check for --true-data mode ---
     std::string true_data_folder;


### PR DESCRIPTION
> **Stacked on top of #174 ΓÇö must merge #174 first.** Diff base in this PR is the #174 branch (`hipDNN_gemmfp16u4_perf_oga_nozp_zhanxipu`), so this PR only shows the +67 / -0 line POC change. If #174 is rebased onto main, please rebase this PR too.

## Problem

#174 changed the no-zp dequant path (`HAS_ZP=false` / `USE_ZEROS=false`) of `hip_matmul_nbits` to read each nibble as **signed int4 via sign-extend** (`(nib << 28) >> 28`), *assuming the caller has already folded the default `zp = 8` into the weight bytes*. The fold is the per-byte XOR `0x88`: each nibble `q Γêê [0, 15]` becomes `q' = q - 8 Γêê [-8, 7]` in 4-bit two's complement.

But **the compile-time pipeline (OnnxToHip / MLIR pass / `lowerOnnxConstants`) does not emit pre-shifted weights**. The only place doing the XOR today is the data generator [`gen_matmul_nbits_data.py:67-70`](https://github.com/ROCm/onnx-hipdnn-ep/blob/hipDNN_gemmfp16u4_perf_oga_nozp_zhanxipu/3rd-party/custom_kernels/test/example/gemm_bf16u4/gen_matmul_nbits_data.py#L67-L70), which is unit-test only.

So in the production path on top of #174, **any MatMulNBits op without a `zero_points` tensor** (e.g. GPT-OSS-20B `MatMulNBits_o_seq128.onnx`, the QMoE single-op tests from #134's reproduction section, and any model that relies on the ONNX MatMulNBits default `zp = 2^(bits-1)`) **would silently produce wrong results** ΓÇö the kernel sign-extends nibbles but the weight is still unsigned `q Γêê [0, 15]`, so each output is biased by `+8 * scale * a_sum`.

This blocks turning #174 on for any no-zp model.

## Solution

Add a runtime helper that does the XOR in-place on the GPU constant blob the first time we observe each `B` pointer with `zero_points == nullptr`.

```mermaid
flowchart TD
    A["hip_matmul_nbits call"] --> B{"zero_points == nullptr?"}
    B -->|yes| C["preShiftWeightIfFirstSeen B"]
    B -->|no| F["skip XOR: has-zp path untouched"]
    C --> D{"first time we see B?"}
    D -->|"yes, insert into set"| E["launch weight_pre_shift_xor_0x88_kernel on same hip_stream"]
    D -->|"no, already in set"| G[skip]
    E --> H["GEMM: PR #174 sign-extend kernel"]
    G --> H
    F --> H
```

Single file changed: `3rd-party/custom_kernels/hip/matmul_nbits_kernel.hip`, +67 / -0:

| Where | What |
|---|---|
| includes | `+ #include <unordered_set>` |
| after `g_dq_buf` block | new `weight_pre_shift_xor_0x88_kernel` GPU kernel + `g_pre_shifted_weights` set + `g_pre_shift_mutex` + `preShiftWeightIfFirstSeen` helper (53 lines incl. design comment) |
| `hip_matmul_nbits` entry | 9-line `if (zero_points == nullptr) preShiftWeightIfFirstSeen(...)` right after `hip_stream` is set up, before `zp_for_fp16_paths` is computed |
| `hip_matmul_nbits_release_buffers` | `g_pre_shifted_weights.clear()` so cold-cache benchmarks (`test_matmul_nbits.cpp --cold-cache`) re-run the XOR each round |

### Key invariants

- **No host sync.** The XOR kernel and the GEMM are launched on the same `hip_stream`; HIP intra-stream ordering guarantees the GEMM consumes the pre-shifted bytes.
- **In-place on `gpu_constants[i]` is safe.** `gpu_constants[i]` is a `hipMalloc`'d region inside the constant blob (PR #132 unified upload), which is GPU memory with read-write permissions. The host-side ORT `TensorProto` / mmap'd `weights.data` / `FrefCache` are independent read-only sources that have already been copied into this GPU buffer at session init.
- **has-zp paths are completely isolated.** The `if (zero_points == nullptr)` guard skips the XOR for any `MatMulNBits` with an explicit `zero_points` tensor (QMoE `fc1_zp_e` / `fc2_zp_e` from `wrap_qmoe`, Qwen2.5-Coder-14B-RTN, etc.) ΓÇö they continue to use the PR #174 `HAS_ZP=true` / `USE_ZEROS=true` paths.
- **Per-expert isolation in QMoE works automatically.** [`real/qmoe.cpp`](https://github.com/ROCm/onnx-hipdnn-ep/blob/main/lib/Runtime/real/qmoe.cpp) computes a distinct `fc1_w_e = fc1_weights + e * fusion_inter * k_blocks_fc1 * blob_size_fc1` per expert; each enters the set independently and gets one XOR. (QMoE today always passes a non-null `zp_e`, so the no-zp branch is never even hit; this is just defensive accounting.)
- **Cold-cache benchmark behaves correctly.** PR #174's `test_matmul_nbits.cpp --cold-cache` already calls `hip_matmul_nbits_release_buffers()` between rounds. This PR adds `g_pre_shifted_weights.clear()` to that release so each cold round re-issues the XOR ΓÇö measured cold cost includes the XOR.

## Results

- Build (`cmake --build D:/ROCm/build/onnx-hipdnn-ep --parallel + --target install`) green on local Windows / gfx1151 with `clang++ -Wc++17-extensions` warnings only (pre-existing in #174).
- `pre-commit run --all-files`: all hooks pass.
- End-to-end correctness / perf: **deferred to CI on this PR**. Locally, the validation flow is the standard one from #134's reproduction section:

  ```powershell
  $m = '\\WINAMD-9ETIJGLC\hipdnn\GPT-OSS-20B_space\single_op\MatMulNBits_o\MatMulNBits_o_seq128.onnx'
  hip-onnx-runner.exe -m $m -n -d 3
  hip-onnx-runner.exe -m $m -i .\MatMulNBits_o_seq128_cpu_i_dump -d 2
  hip-onnx-runner.exe -L .\MatMulNBits_o_seq128_o_dump,.\MatMulNBits_o_seq128_cpu_o_dump
  ```

## Test plan

- [ ] CI green on `feat/matmul-nbits-weight-preshift-poc` (windows-build + gpu-perf-accuracy-test if scheduled)
- [ ] `MatMulNBits_o_seq128.onnx` (M=128, WMMA + sign-extend `USE_ZEROS=false` path) Pearson > 0.999 vs CPU EP gold
- [ ] `MatMulNBits_o_seq1.onnx` (M=1, GEMV row-major + sign-extend `HAS_ZP=false` path) Pearson > 0.999 vs CPU EP gold
- [ ] `QMoE_seq128.onnx` (has-zp path ΓÇö must regress to baseline since `if (zero_points == nullptr)` should not fire) Pearson > 0.999 vs CPU EP gold
- [ ] OGA Llama-3.1-8B m=16384 6x token/s vs PR #141 baseline (with #174 + this POC vs without #174 reverted) ΓÇö see [`task-oga-gpu-memory-pipeline.mdc`](.cursor/rules/task-oga-gpu-memory-pipeline.mdc)

## Limitations / Follow-ups

- This is a **POC**. The right long-term home for the XOR is a compile-time MLIR pass (path A in the original plan): walk `hip.matmul_nbits` in the `ConvertOnnxToHipPass` ΓåÆ `ResolveExternConstants` window, fold the bytes into the `DenseElementsAttr` / mem-addr / file-ref source, and add an explicit `BoolAttr:$weight_pre_shifted` on `Hip_MatMulNBitsOp` so the kernel-side `zero_points == nullptr` ΓåÆ "weight already folded" implicit contract becomes explicit.
- This POC mutates a "constant" GPU buffer in place. It works because that buffer is `hipMalloc`'d (read-write) and only consumed by `hip_matmul_nbits`. If a future feature (e.g. multi-EP weight sharing) adds a second consumer that reads the raw uint4 weight, this assumption breaks.
- Does **not** address #174's has-zp branch reduction-time correction (`zp_correction[tn]` computed by lane 0 in O(K ┬╖ TILE_N)) ΓÇö that path may need separate perf evaluation against PR #141's inner-loop factored form on Qwen2.5-Coder-14B-RTN.

