### PR TITLE
feat(ep): graceful degradation when fp16 overflow poisons the runtime

### DIFF
--- a/3rd-party/custom_kernels/hip/qmoe_kernel.hip
+++ b/3rd-party/custom_kernels/hip/qmoe_kernel.hip
@@ -36,6 +36,40 @@ __global__ void topk_routing_kernel(
   const __half* logits = router_probs + token * num_experts;
   int ik = static_cast<int>(k < kMaxK ? k : kMaxK);
 
+  // -- Defensive non-finite-input guard ----------------------------------
+  // If the model upstream has overflowed fp16 (e.g. AWQ-quantised models
+  // whose outlier scales saturate the residual stream after enough layers)
+  // `router_probs` can arrive with NaN or +/-Inf elements. The softmax
+  // path below would then propagate NaN through the entire kernel; on
+  // some ROCm builds (gfx1151 + ROCm 7.11 has been observed) the kernel
+  // raises `hipErrorLaunchFailure (719)` instead of returning quiet NaN
+  // outputs, which puts the device into a sticky-error state and crashes
+  // the rest of inference inside hipBLASLt's error-recovery path.
+  //
+  // Short-circuit with a safe sentinel: write `expert_indices = -1` for
+  // every k slot. The host-side dispatch loop in `wrap_qmoe`
+  // (lib/Runtime/real/qmoe.cpp) already filters indices via
+  //     `if (eid >= 0 && eid < num_experts)`
+  // so -1 cleanly skips this token's per-expert dispatch. The benchmark
+  // produces wrong outputs (the residual was already poisoned upstream)
+  // but the GPU stays alive and inference completes deterministically
+  // instead of hard-crashing with 0xC0000005 inside libhipblaslt.
+  bool any_bad = false;
+  for (int64_t e = 0; e < num_experts; e++) {
+    float v = static_cast<float>(logits[e]);
+    if (v != v || v == HUGE_VALF || v == -HUGE_VALF) {
+      any_bad = true;
+      break;
+    }
+  }
+  if (any_bad) {
+    for (int i = 0; i < ik; i++) {
+      expert_indices[token * k + i] = -1;
+      expert_weights[token * k + i] = static_cast<__half>(0.0f);
+    }
+    return;
+  }
+
   // Pass 1: find max logit for numerically stable softmax
   float max_logit = -1e30f;
   for (int64_t e = 0; e < num_experts; e++) {

--- a/lib/Runtime/real/elementwise.cpp
+++ b/lib/Runtime/real/elementwise.cpp
@@ -182,6 +182,7 @@ int wrap_miopenOpTensor(RuntimeState *state, void *lhs, void *rhs, void *output,
                         int64_t rhs_h, int64_t rhs_w, int64_t out_n,
                         int64_t out_c, int64_t out_h, int64_t out_w,
                         int64_t data_type, int64_t tensor_op) {
+  HIPDNN_EP_BAIL_IF_DEAD();
   OP_PROFILE(
       "elementwise",
       [&] {

--- a/lib/Runtime/real/error_check_macros.h
+++ b/lib/Runtime/real/error_check_macros.h
@@ -5,10 +5,59 @@
 #ifndef HIPDNN_EP_ERROR_CHECK_MACROS_H
 #define HIPDNN_EP_ERROR_CHECK_MACROS_H
 
+#include <atomic>
 #include <cstdio>
 #include <hip/hip_runtime.h>
 #include <hipblaslt/hipblaslt.h>
 #include <miopen/miopen.h>
+
+//===----------------------------------------------------------------------===//
+// Sticky-error short-circuit
+//===----------------------------------------------------------------------===//
+//
+// Once any HIP / MIOpen / hipBLASLt call returns hipErrorLaunchFailure (719)
+// or one of its peers, the GPU device is in a sticky-error state: every
+// subsequent API call will fail, and some library error paths (notably
+// hipBLASLt's TensileLite epilogue-string lookup on TheRock 7.11) will
+// raise 0xC0000005 inside `strlen` instead of returning a clean status
+// code, making the failure look like a library-internal corruption.
+//
+// To convert that catastrophic surface into a recoverable one, the EP
+// flips the flag below the first time a launch failure is observed. Every
+// `wrap_*` entrypoint then checks the flag at entry via
+// `HIPDNN_EP_BAIL_IF_DEAD()` and short-circuits to `return -1` immediately.
+// Net effect: the benchmark process exits with a non-zero status and a
+// single "device error" log line instead of a 0xC0000005 stack trace
+// through hipBLASLt internals -- which makes the failure recoverable for
+// the host runtime (clean cleanup of all allocations) and triagable for
+// CI (single diagnostic line vs. an opaque segfault).
+//
+// The flag is a C++17 inline variable so all translation units share a
+// single instance.
+//===----------------------------------------------------------------------===//
+inline std::atomic<bool> g_hipdnn_ep_device_dead{false};
+
+inline bool hipdnn_ep_is_device_dead() {
+  return g_hipdnn_ep_device_dead.load(std::memory_order_acquire);
+}
+
+inline void hipdnn_ep_mark_device_dead(const char *src, int line,
+                                       const char *cause) {
+  bool was = g_hipdnn_ep_device_dead.exchange(true, std::memory_order_acq_rel);
+  if (!was) {
+    fprintf(stderr,
+            "*** HIPDNN_EP: device entered sticky error state at %s:%d (%s); "
+            "subsequent wrap_* calls will short-circuit ***\n",
+            src, line, cause);
+  }
+}
+
+#define HIPDNN_EP_BAIL_IF_DEAD()                                               \
+  do {                                                                         \
+    if (hipdnn_ep_is_device_dead()) {                                          \
+      return -1;                                                               \
+    }                                                                          \
+  } while (0)
 
 //===----------------------------------------------------------------------===//
 // Error Checking Macros with Goto Cleanup Pattern
@@ -38,6 +87,11 @@
     if (status != miopenStatusSuccess) {                                       \
       fprintf(stderr, "MIOpen error: %s failed at %s:%d (status=%d)\n", #expr, \
               __FILE__, __LINE__, status);                                     \
+      /* MIOpen status 7 (StatusInternalError) on this stack always means     \
+         a HIP launch failure underneath -- mark the device dead so          \
+         subsequent wrap_* calls short-circuit (see top of this header). */  \
+      if (status == 7)                                                         \
+        hipdnn_ep_mark_device_dead(__FILE__, __LINE__, "MIOpen status 7");    \
       result = -1;                                                             \
       goto label;                                                              \
     }                                                                          \
@@ -49,6 +103,11 @@
     if (error != hipSuccess) {                                                 \
       fprintf(stderr, "HIP error: %s failed at %s:%d: %s\n", #expr, __FILE__,  \
               __LINE__, hipGetErrorString(error));                             \
+      if (error == hipErrorLaunchFailure ||                                    \
+          error == hipErrorIllegalAddress ||                                   \
+          error == hipErrorContextIsDestroyed)                                 \
+        hipdnn_ep_mark_device_dead(__FILE__, __LINE__,                         \
+                                   hipGetErrorName(error));                    \
       result = -1;                                                             \
       goto label;                                                              \
     }                                                                          \
@@ -60,6 +119,10 @@
     if (status != HIPBLAS_STATUS_SUCCESS) {                                    \
       fprintf(stderr, "hipBLAS error: %s failed at %s:%d (status=%d)\n",       \
               #expr, __FILE__, __LINE__, status);                              \
+      if (status == HIPBLAS_STATUS_INTERNAL_ERROR ||                          \
+          status == HIPBLAS_STATUS_NOT_INITIALIZED)                           \
+        hipdnn_ep_mark_device_dead(__FILE__, __LINE__,                        \
+                                   "hipBLAS internal/not-initialised");      \
       result = -1;                                                             \
       goto label;                                                              \
     }                                                                          \

--- a/lib/Runtime/real/gemm.cpp
+++ b/lib/Runtime/real/gemm.cpp
@@ -247,6 +247,7 @@ int wrap_gemm(RuntimeState *state, const void *A, const void *B, const void *C,
               void *output, int64_t M, int64_t N, int64_t K, float alpha,
               float beta, int64_t transA, int64_t transB, int64_t typeCode,
               int64_t cDim0, int64_t cDim1) {
+  HIPDNN_EP_BAIL_IF_DEAD();
   OP_PROFILE(
       "gemm",
       [&] {

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -886,6 +886,7 @@ int wrap_group_query_attention(
     // (may differ from actual past token count for pre-allocated caches)
     int64_t batch_size, int64_t seq_len_q, int64_t seq_len_kv,
     int64_t past_buf_seq, int64_t head_dim, int64_t element_size_bytes) {
+  HIPDNN_EP_BAIL_IF_DEAD();
   OP_PROFILE(
       "gqa",
       [&] {

--- a/lib/Runtime/real/matmul.cpp
+++ b/lib/Runtime/real/matmul.cpp
@@ -6,6 +6,7 @@
 #include "../hipdnn_ep_runtime.h"
 #include "../op_profile.h"
 #include "cache_utils.h"
+#include "error_check_macros.h"
 #include "hip_custom_kernels.h"
 #include "runtime_types.h"
 
@@ -351,6 +352,7 @@ static void autotuneMatmul(hipblasLtHandle_t handle, hipStream_t stream,
 int wrap_hipblasLtMatmul(RuntimeState *state, const void *A, const void *B,
                          void *output, int64_t M, int64_t N, int64_t K,
                          int64_t batch_count, int64_t elem_size) {
+  HIPDNN_EP_BAIL_IF_DEAD();
   OP_PROFILE(
       "matmul",
       [&] {

--- a/lib/Runtime/real/matmul_nbits.cpp
+++ b/lib/Runtime/real/matmul_nbits.cpp
@@ -18,6 +18,7 @@ int wrap_matmul_nbits(RuntimeState *state, const void *A, const void *B,
                       int64_t M, int64_t N, int64_t K, int64_t batch_count,
                       int64_t bits, int64_t block_size, int64_t elem_size,
                       int64_t zp_elem_size) {
+  HIPDNN_EP_BAIL_IF_DEAD();
   OP_PROFILE(
       "matmul_nbits",
       [&] {

--- a/lib/Runtime/real/qmoe.cpp
+++ b/lib/Runtime/real/qmoe.cpp
@@ -34,6 +34,7 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
               int64_t swiglu_fusion, int64_t activation_type,
               float activation_alpha, float activation_beta, float swiglu_limit,
               int64_t normalize_routing_weights, int64_t elem_size) {
+  HIPDNN_EP_BAIL_IF_DEAD();
   OP_PROFILE(
       "qmoe",
       [&] {

--- a/lib/Runtime/real/skip_simplified_layer_norm.cpp
+++ b/lib/Runtime/real/skip_simplified_layer_norm.cpp
@@ -169,6 +169,7 @@ int wrap_skip_simplified_layer_norm(RuntimeState *state, void *input,
                                     int64_t input_num_elements,
                                     int64_t gamma_num_elements,
                                     int64_t element_size_bytes, float epsilon) {
+  HIPDNN_EP_BAIL_IF_DEAD();
   OP_PROFILE(
       "skip_layernorm",
       [&] {


### PR DESCRIPTION
## 1. Verified root cause

`gpt-oss-120b in_12200,chunk_512` chain:

1. AWQ outlier scales (max=548 by layer 28) saturate fp16 residual stream by layer ~35; SSLN overflows to `Inf` and `miopenT5LayerNormForward` propagates `NaN` into `wrap_qmoe`'s `router_probs`.
2. On gfx1151+ROCm 7.11, `hip_qmoe_topk_routing_kernel` raises `hipErrorLaunchFailure (719)` on NaN logits (other HW returns `-1` indices that the host filters cleanly). Surfaces at `qmoe.cpp:143` D2H of `d_expert_indices`.
3. Sticky 719 -> next `wrap_gemm -> hipblasLtMatmul` enters TensileLite error-recovery, `strlen` on null -> `0xC0000005`. Visible CI stack looks like a hipBLASLt corruption; actually two ops upstream.

## 2. How the fix confirms the root cause

| Fix | Confirms |
|---|---|
| **(a)** NaN/Inf guard at entry of `topk_routing_kernel` ([qmoe_kernel.hip](3rd-party/custom_kernels/hip/qmoe_kernel.hip)) | `qmoe.cpp:143` failure point disappears -> topk was the originating kernel |
| **(b)** Sticky-error short-circuit ([error_check_macros.h](lib/Runtime/real/error_check_macros.h) + `HIPDNN_EP_BAIL_IF_DEAD()` in 7 wrappers) | `0xC0000005` in hipBLASLt strlen disappears -> it was a downstream-of-broken-device symptom, not a hipBLASLt bug |

Pre-fix: process segfault, no metrics. Post-fix: 127/128 generated tokens complete, metrics reported, single diagnostic line, exit code 1.

## 3. Why no merge

Fixes the symptom, not the bug. Output is still garbage tokens because the fp16 residual stream still overflows -- the actual fix is a different quantisation (`bits=8` or AWQ with smoothing) or bf16 residual (see `REMAINING_ISSUE_fp16_overflow.md` from #168).

Merging would convert the loud segfault into a quiet exit-1, masking the accuracy bug. Submitting for visibility into the EP-side mitigation, not as a merge candidate.
