### PR TITLE
<test>: zp=16 perf attribution A/B (8 -> 16 in matmul-nbits no-zp defaults)

### DIFF
--- a/3rd-party/custom_kernels/hip/matmul_nbits_kernel.hip
+++ b/3rd-party/custom_kernels/hip/matmul_nbits_kernel.hip
@@ -73,7 +73,7 @@ __global__ void matmul_nbits_kernel(
     float scale_val = static_cast<float>(s_row[blk]);
     float zp_val = (zp != nullptr)
                        ? static_cast<float>(zp[n * k_blocks + blk])
-                       : 8.0f;
+                       : 16.0f;
 
     int64_t k_start = blk * block_size;
     int64_t k_end = k_start + block_size;
@@ -234,7 +234,7 @@ __global__ void matmul_nbits_gemv_kernel(
                 float zv = read_zp(n_idx[tn], grp);
                 partial[tn] += dot * sv[tn] - a_sum * zv * sv[tn];
             } else {
-                partial[tn] += dot * sv[tn] - a_sum * 8.0f * sv[tn];
+                partial[tn] += dot * sv[tn] - a_sum * 16.0f * sv[tn];
             }
         }
     }
@@ -273,7 +273,7 @@ __global__ void matmul_nbits_gemv_kernel(
                     float zv = read_zp(n_idx[tn], grp);
                     partial[tn] += dot * sv - a_sum * zv * sv;
                 } else {
-                    partial[tn] += dot * sv - a_sum * 8.0f * sv;
+                    partial[tn] += dot * sv - a_sum * 16.0f * sv;
                 }
             }
         }
@@ -291,7 +291,7 @@ __global__ void matmul_nbits_gemv_kernel(
 #pragma unroll
             for (int tn = 0; tn < TILE_N; tn++) {
                 float sv = static_cast<float>(s_rows[tn][grp]);
-                float zv = has_zp ? read_zp(n_idx[tn], grp) : 8.0f;
+                float zv = has_zp ? read_zp(n_idx[tn], grp) : 16.0f;
                 uint8_t packed = b_base_arr[tn][k / 2];
                 float   qval   = (nibble == 0)
                                    ? static_cast<float>(packed & 0xF)
@@ -550,7 +550,7 @@ __global__ void dequant_u4_to_fp16(
 
     int grp = k8 / group_size;
     _Float16 scale = scales[n * num_groups_k + grp];
-    _Float16 zp    = zeros ? zeros[n * num_groups_k + grp] : (_Float16)8;
+    _Float16 zp    = zeros ? zeros[n * num_groups_k + grp] : (_Float16)16;
 
     uint32_t four = *reinterpret_cast<const uint32_t*>(
         &B_packed[n * (K / 2) + k8 / 2]);
@@ -748,7 +748,7 @@ void GemmFp16U4Impl(
                     bv[6] = static_cast<_Float16>((pf_b4 >> 24) & 0xFu) * s16 + nzs;
                     bv[7] = static_cast<_Float16>((pf_b4 >> 28)       ) * s16 + nzs;
                 } else {
-                    _Float16 nzs = (_Float16)(-8) * s16;
+                    _Float16 nzs = (_Float16)(-16) * s16;
                     bv[0] = static_cast<_Float16>((pf_b4      ) & 0xFu) * s16 + nzs;
                     bv[1] = static_cast<_Float16>((pf_b4 >>  4) & 0xFu) * s16 + nzs;
                     bv[2] = static_cast<_Float16>((pf_b4 >>  8) & 0xFu) * s16 + nzs;

--- a/3rd-party/custom_kernels/hip/matmul_nbits_kernel.hip
+++ b/3rd-party/custom_kernels/hip/matmul_nbits_kernel.hip
@@ -73,7 +73,7 @@ __global__ void matmul_nbits_kernel(
     float scale_val = static_cast<float>(s_row[blk]);
     float zp_val = (zp != nullptr)
                        ? static_cast<float>(zp[n * k_blocks + blk])
-                       : 16.0f;
+                       : 8.0f;
 
     int64_t k_start = blk * block_size;
     int64_t k_end = k_start + block_size;
@@ -234,7 +234,7 @@ __global__ void matmul_nbits_gemv_kernel(
                 float zv = read_zp(n_idx[tn], grp);
                 partial[tn] += dot * sv[tn] - a_sum * zv * sv[tn];
             } else {
-                partial[tn] += dot * sv[tn] - a_sum * 16.0f * sv[tn];
+                partial[tn] += dot * sv[tn] - a_sum * 8.0f * sv[tn];
             }
         }
     }
@@ -273,7 +273,7 @@ __global__ void matmul_nbits_gemv_kernel(
                     float zv = read_zp(n_idx[tn], grp);
                     partial[tn] += dot * sv - a_sum * zv * sv;
                 } else {
-                    partial[tn] += dot * sv - a_sum * 16.0f * sv;
+                    partial[tn] += dot * sv - a_sum * 8.0f * sv;
                 }
             }
         }
@@ -291,7 +291,7 @@ __global__ void matmul_nbits_gemv_kernel(
 #pragma unroll
             for (int tn = 0; tn < TILE_N; tn++) {
                 float sv = static_cast<float>(s_rows[tn][grp]);
-                float zv = has_zp ? read_zp(n_idx[tn], grp) : 16.0f;
+                float zv = has_zp ? read_zp(n_idx[tn], grp) : 8.0f;
                 uint8_t packed = b_base_arr[tn][k / 2];
                 float   qval   = (nibble == 0)
                                    ? static_cast<float>(packed & 0xF)
@@ -550,7 +550,7 @@ __global__ void dequant_u4_to_fp16(
 
     int grp = k8 / group_size;
     _Float16 scale = scales[n * num_groups_k + grp];
-    _Float16 zp    = zeros ? zeros[n * num_groups_k + grp] : (_Float16)16;
+    _Float16 zp    = zeros ? zeros[n * num_groups_k + grp] : (_Float16)8;
 
     uint32_t four = *reinterpret_cast<const uint32_t*>(
         &B_packed[n * (K / 2) + k8 / 2]);
@@ -748,7 +748,7 @@ void GemmFp16U4Impl(
                     bv[6] = static_cast<_Float16>((pf_b4 >> 24) & 0xFu) * s16 + nzs;
                     bv[7] = static_cast<_Float16>((pf_b4 >> 28)       ) * s16 + nzs;
                 } else {
-                    _Float16 nzs = (_Float16)(-16) * s16;
+                    _Float16 nzs = (_Float16)(-8) * s16;
                     bv[0] = static_cast<_Float16>((pf_b4      ) & 0xFu) * s16 + nzs;
                     bv[1] = static_cast<_Float16>((pf_b4 >>  4) & 0xFu) * s16 + nzs;
                     bv[2] = static_cast<_Float16>((pf_b4 >>  8) & 0xFu) * s16 + nzs;

--- a/lib/Runtime/real/matmul_nbits.cpp
+++ b/lib/Runtime/real/matmul_nbits.cpp
@@ -9,7 +9,9 @@
 #include "hip_custom_kernels.h"
 
 #include <cmath>
+#include <cstdint>
 #include <cstdio>
+#include <cstring>
 #include <vector>
 
 #define HIP_CHECK(cmd) HIP_CHECK_GOTO(cmd, cleanup)
@@ -18,7 +20,41 @@
 // output tensor. Capped at the first kZpDebugMatmulMaxLogged calls per thread
 // so the CI log stays parseable. Used to pin where Inf/NaN first appears in
 // the forward pass under the zp=16 toggle (see PR #186 / commit 0f0fade).
+//
+// Note: this file is compiled to bitcode and JIT-linked at runtime by morphizen.
+// The runtime link does NOT include compiler-rt, so we cannot use _Float16 or
+// __half conversions (those emit a __extendhfsf2 reference). Instead we read
+// fp16 as raw uint16_t and decode by bit manipulation.
 static constexpr int64_t kZpDebugMatmulMaxLogged = 600;
+
+static inline bool fp16_bits_is_nan(uint16_t h) {
+  return ((h >> 10) & 0x1FU) == 0x1FU && (h & 0x3FFU) != 0U;
+}
+
+static inline bool fp16_bits_is_inf(uint16_t h) {
+  return ((h >> 10) & 0x1FU) == 0x1FU && (h & 0x3FFU) == 0U;
+}
+
+// IEEE 754 binary16 -> binary32. Treats fp16 subnormals as 0 (good enough for
+// max-abs tracking; subnormals are below 6e-5 and irrelevant for overflow
+// detection). NaN/Inf should be filtered out by the callers above before
+// invoking this.
+static inline float fp16_bits_to_float(uint16_t h) {
+  uint32_t sign = static_cast<uint32_t>(h & 0x8000U) << 16;
+  uint32_t exp = static_cast<uint32_t>((h >> 10) & 0x1FU);
+  uint32_t mant = static_cast<uint32_t>(h & 0x3FFU);
+  uint32_t out;
+  if (exp == 0U) {
+    out = sign;
+  } else if (exp == 0x1FU) {
+    out = sign | 0x7F800000U | (mant << 13);
+  } else {
+    out = sign | ((exp + 127U - 15U) << 23) | (mant << 13);
+  }
+  float f;
+  std::memcpy(&f, &out, sizeof(f));
+  return f;
+}
 
 static void log_matmul_nbits_stats(RuntimeState *state, const void *output,
                                    int64_t M, int64_t N, int64_t K,
@@ -57,15 +93,15 @@ static void log_matmul_nbits_stats(RuntimeState *state, const void *output,
   int64_t inf_count = 0;
   float max_abs = 0.0f;
   if (elem_size == 2) {
-    const _Float16 *p = reinterpret_cast<const _Float16 *>(host_buf.data());
+    const uint16_t *p = reinterpret_cast<const uint16_t *>(host_buf.data());
     for (size_t i = 0; i < total_elems; i++) {
-      float v = static_cast<float>(p[i]);
-      if (std::isnan(v)) {
+      uint16_t h = p[i];
+      if (fp16_bits_is_nan(h)) {
         nan_count++;
-      } else if (std::isinf(v)) {
+      } else if (fp16_bits_is_inf(h)) {
         inf_count++;
       } else {
-        float a = std::fabs(v);
+        float a = std::fabs(fp16_bits_to_float(h));
         if (a > max_abs) {
           max_abs = a;
         }

--- a/lib/Runtime/real/matmul_nbits.cpp
+++ b/lib/Runtime/real/matmul_nbits.cpp
@@ -8,9 +8,95 @@
 #include "error_check_macros.h"
 #include "hip_custom_kernels.h"
 
+#include <cmath>
 #include <cstdio>
+#include <vector>
 
 #define HIP_CHECK(cmd) HIP_CHECK_GOTO(cmd, cleanup)
+
+// ZP_DEBUG_MATMUL: synchronous D2H copy + CPU stats scan over the matmul_nbits
+// output tensor. Capped at the first kZpDebugMatmulMaxLogged calls per thread
+// so the CI log stays parseable. Used to pin where Inf/NaN first appears in
+// the forward pass under the zp=16 toggle (see PR #186 / commit 0f0fade).
+static constexpr int64_t kZpDebugMatmulMaxLogged = 600;
+
+static void log_matmul_nbits_stats(RuntimeState *state, const void *output,
+                                   int64_t M, int64_t N, int64_t K,
+                                   int64_t batch_count, int64_t elem_size,
+                                   bool has_zp) {
+  static thread_local int64_t s_matmul_call_seq = 0;
+  int64_t call_seq = s_matmul_call_seq++;
+  if (call_seq >= kZpDebugMatmulMaxLogged) {
+    return;
+  }
+  if (!state || !output) {
+    return;
+  }
+  void *stream = hipdnn_ep_state_get_stream(state);
+  if (!stream) {
+    return;
+  }
+  hipStream_t hip_stream = static_cast<hipStream_t>(stream);
+
+  size_t total_elems = static_cast<size_t>(M * N * batch_count);
+  size_t total_bytes = total_elems * static_cast<size_t>(elem_size);
+  if (total_elems == 0 || total_bytes == 0) {
+    return;
+  }
+
+  std::vector<char> host_buf(total_bytes);
+  if (hipMemcpyAsync(host_buf.data(), output, total_bytes,
+                     hipMemcpyDeviceToHost, hip_stream) != hipSuccess) {
+    return;
+  }
+  if (hipStreamSynchronize(hip_stream) != hipSuccess) {
+    return;
+  }
+
+  int64_t nan_count = 0;
+  int64_t inf_count = 0;
+  float max_abs = 0.0f;
+  if (elem_size == 2) {
+    const _Float16 *p = reinterpret_cast<const _Float16 *>(host_buf.data());
+    for (size_t i = 0; i < total_elems; i++) {
+      float v = static_cast<float>(p[i]);
+      if (std::isnan(v)) {
+        nan_count++;
+      } else if (std::isinf(v)) {
+        inf_count++;
+      } else {
+        float a = std::fabs(v);
+        if (a > max_abs) {
+          max_abs = a;
+        }
+      }
+    }
+  } else if (elem_size == 4) {
+    const float *p = reinterpret_cast<const float *>(host_buf.data());
+    for (size_t i = 0; i < total_elems; i++) {
+      float v = p[i];
+      if (std::isnan(v)) {
+        nan_count++;
+      } else if (std::isinf(v)) {
+        inf_count++;
+      } else {
+        float a = std::fabs(v);
+        if (a > max_abs) {
+          max_abs = a;
+        }
+      }
+    }
+  } else {
+    return;
+  }
+
+  fprintf(stderr,
+          "[ZP_DEBUG_MATMUL] seq=%lld M=%lld N=%lld K=%lld zp=%s "
+          "max_abs=%.3f nan=%lld inf=%lld total=%lld\n",
+          (long long)call_seq, (long long)M, (long long)N, (long long)K,
+          has_zp ? "yes" : "null", max_abs, (long long)nan_count,
+          (long long)inf_count, (long long)total_elems);
+}
 
 int wrap_matmul_nbits(RuntimeState *state, const void *A, const void *B,
                       const void *scales, const void *zero_points,
@@ -56,6 +142,9 @@ int wrap_matmul_nbits(RuntimeState *state, const void *A, const void *B,
   HIP_CHECK(hip_matmul_nbits(stream, A, B, scales, zero_points, bias, output, M,
                              N, K, batch_count, bits, block_size, elem_size,
                              zp_elem_size));
+
+  log_matmul_nbits_stats(state, output, M, N, K, batch_count, elem_size,
+                         zero_points != nullptr);
 
 cleanup:
   return result;

--- a/lib/Runtime/real/qmoe.cpp
+++ b/lib/Runtime/real/qmoe.cpp
@@ -147,12 +147,15 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
     HIP_CHECK(hipStreamSynchronize(hip_stream));
 
     std::vector<std::vector<TokenEntry>> expert_tokens(num_experts);
+    int64_t num_invalid = 0;
     for (int64_t t = 0; t < num_tokens; t++) {
       for (int64_t s = 0; s < k; s++) {
         int32_t eid = h_indices[t * k + s];
         if (eid >= 0 && eid < num_experts) {
           expert_tokens[eid].push_back(
               {static_cast<int32_t>(t), static_cast<int32_t>(s)});
+        } else {
+          num_invalid++;
         }
       }
     }
@@ -168,6 +171,12 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
     }
     RUNTIME_DEBUG_LOG("[REAL] wrap_qmoe: %lld/%lld experts active\n",
                       (long long)active_experts, (long long)num_experts);
+    fprintf(stderr,
+            "[ZP_DEBUG_QMOE] active=%lld/%lld invalid=%lld/%lld tokens=%lld "
+            "k=%lld\n",
+            (long long)active_experts, (long long)num_experts,
+            (long long)num_invalid, (long long)(num_tokens * k),
+            (long long)num_tokens, (long long)k);
 
     for (int64_t e = 0; e < num_experts; e++) {
       int64_t count = static_cast<int64_t>(expert_tokens[e].size());

--- a/lib/Runtime/real/qmoe.cpp
+++ b/lib/Runtime/real/qmoe.cpp
@@ -155,18 +155,6 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
           expert_tokens[eid].push_back(
               {static_cast<int32_t>(t), static_cast<int32_t>(s)});
         } else {
-          // CASCADE-SUPPRESSION A/B (PR #186 test branch only): when
-          // topk_routing returns -1 for a slot (e.g. NaN router logits leave
-          // top_idx at its init value, see topk_routing_kernel in
-          // 3rd-party/custom_kernels/hip/qmoe_kernel.hip), route the slot
-          // round-robin across experts. This forces the expert FFNs to
-          // actually execute even though numerics are broken, isolating
-          // "QMoE-skip wall-time savings" from any potential kernel-level
-          // speedup of MatMulNBits at zp=16. Only enabled on
-          // fhanuman/test-zp16-perf-attribution; would not ship.
-          int64_t fallback_eid = (t * k + s) % num_experts;
-          expert_tokens[fallback_eid].push_back(
-              {static_cast<int32_t>(t), static_cast<int32_t>(s)});
           num_invalid++;
         }
       }

--- a/lib/Runtime/real/qmoe.cpp
+++ b/lib/Runtime/real/qmoe.cpp
@@ -155,6 +155,18 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
           expert_tokens[eid].push_back(
               {static_cast<int32_t>(t), static_cast<int32_t>(s)});
         } else {
+          // CASCADE-SUPPRESSION A/B (PR #186 test branch only): when
+          // topk_routing returns -1 for a slot (e.g. NaN router logits leave
+          // top_idx at its init value, see topk_routing_kernel in
+          // 3rd-party/custom_kernels/hip/qmoe_kernel.hip), route the slot
+          // round-robin across experts. This forces the expert FFNs to
+          // actually execute even though numerics are broken, isolating
+          // "QMoE-skip wall-time savings" from any potential kernel-level
+          // speedup of MatMulNBits at zp=16. Only enabled on
+          // fhanuman/test-zp16-perf-attribution; would not ship.
+          int64_t fallback_eid = (t * k + s) % num_experts;
+          expert_tokens[fallback_eid].push_back(
+              {static_cast<int32_t>(t), static_cast<int32_t>(s)});
           num_invalid++;
         }
       }

--- a/lib/Runtime/real/qmoe.cpp
+++ b/lib/Runtime/real/qmoe.cpp
@@ -171,9 +171,12 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
     }
     RUNTIME_DEBUG_LOG("[REAL] wrap_qmoe: %lld/%lld experts active\n",
                       (long long)active_experts, (long long)num_experts);
+    static thread_local int64_t s_qmoe_call_seq = 0;
+    int64_t call_seq = s_qmoe_call_seq++;
     fprintf(stderr,
-            "[ZP_DEBUG_QMOE] active=%lld/%lld invalid=%lld/%lld tokens=%lld "
-            "k=%lld\n",
+            "[ZP_DEBUG_QMOE] seq=%lld active=%lld/%lld invalid=%lld/%lld "
+            "tokens=%lld k=%lld\n",
+            (long long)call_seq,
             (long long)active_experts, (long long)num_experts,
             (long long)num_invalid, (long long)(num_tokens * k),
             (long long)num_tokens, (long long)k);


### PR DESCRIPTION
## Purpose

**Perf-attribution A/B only. DO NOT MERGE. Outputs are intentionally wrong.**

This PR exists solely to surface, inside team CI, the ~2x decode-TPS swing that Pu Zhanxing reported : on top of `main`, changing every no-zp default-zp constant from `8` to `16` in `matmul_nbits_kernel.hip` flips GPT-OSS-20B p128 from ~35 TPS to ~77 TPS, with `zp=16` producing wrong outputs (zp=16 is non-spec; ONNX MatMulNBits default is `2^(bits-1) = 8` for 4-bit). 

## What changed

`3rd-party/custom_kernels/hip/matmul_nbits_kernel.hip`, 6 sites, all of the form `8 -> 16` in the no-zp default branch:

| Line | Path hit by | Edit |
|---|---|---|
| 76  | naive default               | `: 8.0f` -> `: 16.0f` |
| 237 | GEMV 16-nibble bias correction (decode hot) | `a_sum * 8.0f * sv[tn]` -> `a_sum * 16.0f * sv[tn]` |
| 276 | GEMV  8-nibble bias correction (decode hot) | `a_sum * 8.0f * sv` -> `a_sum * 16.0f * sv` |
| 294 | GEMV tail default (decode hot) | `: 8.0f` -> `: 16.0f` |
| 553 | WMMA dequant default (prefill hot) | `(_Float16)8` -> `(_Float16)16` |
| 751 | WMMA inline-asm NZS pre-compute (prefill hot) | `(_Float16)(-8) * s16` -> `(_Float16)(-16) * s16` |

`has_zp == true` paths (real `zero_points` tensor present) are untouched, so QMoE / Qwen2.5-Coder-14B-RTN behavior is unchanged.

## What we expect from CI

OGA Benchmark Results table (`gpu-perf-accuracy-test` job) for `f4d045f + this commit`:

- **GPT-OSS-20B p128**: TPS ~70-80 (matching the ~77.3 TPS Pu observed at zp=16 on PR #182 — see his screenshot in the Teams thread)
- **Llama-3.1-8B**: TPS ~12 (matches both PR #182 and PR #184 — gap is GPT-OSS-specific)

Single-op MatMulNBits / QMoE L2: huge (zp=16 is wrong). This is expected and not a bug to fix.

Compared against `main` HEAD's baseline run (same build, same harness): the delta is the answer to Pareek's question.

## Hypothesis matrix this confirms

The 4-way disambiguation:

| H | Hypothesis | Confirming evidence in CI run |
|---|---|---|
| H1 | Kernel FLOPs / ALU cost differ | matmul_nbits per-call wrap-time differs (would show in `HIPDNN_EP_PROFILE` if enabled) |
| **H2** | **OGA timing artifact "when precision is fine"** | **kernel times equal; OGA wall-clock differs (Pu's stated suspicion)** |
| H3 | Token-content downstream | non-matmul ops (lm_head, gqa, layer_norm) shift |
| H4 | Path selection | matmul_nbits call counts differ |

CI alone gives us TPS + L2; H2 vs H3 vs H1 separation needs `HIPDNN_EP_PROFILE=1` data. We may follow up on this PR with an env-var-only workflow tweak if CI numbers don't disambiguate.

## Refs

- Teams 4/30 04:49 AM, Pu Zhanxing
- Pu's PR with zp=16 + sign-extend kernel: #182
- Our preshift-fold PR (separate workstream): #184
- Investigation skill: `.cursor/skills/perf-investigation/SKILL.md`
