### PR TITLE
perf: GQA smart-dispatch + seqlens_k cache + per-Compute timing infra

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -35,14 +35,8 @@ jobs:
       GTEST_VERSION: "1.15.0"
       THEROCK_VERSION: therock-dist-windows-gfx1151-7.11.0
       SCCACHE_GHA_ENABLED: "true"
-      # OGA fork carrying the IoBinding decode optimization that routes
-      # session.Run through OrtIoBinding -- required for the asym
-      # Llama-3.1-8B AWQ p=2048 9.66 -> 28.77 tok/s number reported in the
-      # PR body. Once the IoBinding change lands upstream
-      # (microsoft/onnxruntime-genai), revert OGA_REPO to AMDmoore (or the
-      # canonical AMD fork) and OGA_REF to the merged commit.
-      OGA_REPO: fhanuman/onnxruntime-genai
-      OGA_REF: 36acb4a9afd76273c180a6b45f3029e3ed419d54
+      OGA_REPO: AMDmoore/onnxruntime-genai
+      OGA_REF: 2615301864b4d2397231d443865cb96111cc5fc2
       # ilammy/msvc-dev-cmd and mozilla-actions/sccache-action have no
       # Node.js 24 releases yet; allow Node.js 20 until they are updated.
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -35,8 +35,8 @@ jobs:
       GTEST_VERSION: "1.15.0"
       THEROCK_VERSION: therock-dist-windows-gfx1151-7.11.0
       SCCACHE_GHA_ENABLED: "true"
-      OGA_REPO: AMDmoore/onnxruntime-genai
-      OGA_REF: e38a9db551afa67d47da368a895be597f13d8426
+      OGA_REPO: fhanuman/onnxruntime-genai
+      OGA_REF: 36acb4a9afd76273c180a6b45f3029e3ed419d54
       # ilammy/msvc-dev-cmd and mozilla-actions/sccache-action have no
       # Node.js 24 releases yet; allow Node.js 20 until they are updated.
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -35,6 +35,12 @@ jobs:
       GTEST_VERSION: "1.15.0"
       THEROCK_VERSION: therock-dist-windows-gfx1151-7.11.0
       SCCACHE_GHA_ENABLED: "true"
+      # OGA fork carrying the IoBinding decode optimization that routes
+      # session.Run through OrtIoBinding -- required for the asym
+      # Llama-3.1-8B AWQ p=2048 9.66 -> 28.77 tok/s number reported in the
+      # PR body. Once the IoBinding change lands upstream
+      # (microsoft/onnxruntime-genai), revert OGA_REPO to AMDmoore (or the
+      # canonical AMD fork) and OGA_REF to the merged commit.
       OGA_REPO: fhanuman/onnxruntime-genai
       OGA_REF: 36acb4a9afd76273c180a6b45f3029e3ed419d54
       # ilammy/msvc-dev-cmd and mozilla-actions/sccache-action have no

--- a/backend-mlir-compiler/custom-op-mlir/CMakeLists.txt
+++ b/backend-mlir-compiler/custom-op-mlir/CMakeLists.txt
@@ -13,7 +13,11 @@ find_package(glog CONFIG REQUIRED)
 # MlirCustomOp.cpp's HIPDNN_EP_PERF instrumentation (hipEvent*, hipStream_t,
 # hipDeviceSynchronize). THEROCK_DIST is on CMAKE_PREFIX_PATH, so hip::host
 # resolves without reordering the parent add_subdirectory sequence.
-find_package(hip CONFIG REQUIRED)
+# Mock builds have no HIP SDK; the PERF path is compiled out via
+# BUILD_MOCK_RUNTIME.
+if(NOT BUILD_MOCK_RUNTIME)
+  find_package(hip CONFIG REQUIRED)
+endif()
 
 # Create custom op library
 set(LIB_NAME morphizen-custom-op-mlir)
@@ -26,13 +30,19 @@ add_library(${LIB_NAME} STATIC
 # Define MORPHIZEN_CUSTOM_OP for conditional compilation
 target_compile_definitions(${LIB_NAME} PRIVATE "MORPHIZEN_CUSTOM_OP=1")
 
+if(BUILD_MOCK_RUNTIME)
+  target_compile_definitions(${LIB_NAME} PRIVATE "BUILD_MOCK_RUNTIME=1")
+endif()
+
 # Link dependencies
 target_link_libraries(${LIB_NAME} PRIVATE
   morphizen::morphizen-core-static
   glog::glog
   mlir_compilation_proto  # Shared protobuf metadata library
-  hip::host               # hipEvent_t, hipStream_t, hipDeviceSynchronize (PERF)
 )
+if(NOT BUILD_MOCK_RUNTIME)
+  target_link_libraries(${LIB_NAME} PRIVATE hip::host)
+endif()
 
 # Include directories
 target_include_directories(${LIB_NAME} PRIVATE

--- a/backend-mlir-compiler/custom-op-mlir/CMakeLists.txt
+++ b/backend-mlir-compiler/custom-op-mlir/CMakeLists.txt
@@ -9,6 +9,12 @@ message(STATUS "Configuring MLIR Custom Op")
 # Find dependencies
 find_package(glog CONFIG REQUIRED)
 
+# HIP runtime headers + amdhip64 import library are needed by
+# MlirCustomOp.cpp's HIPDNN_EP_PERF instrumentation (hipEvent*, hipStream_t,
+# hipDeviceSynchronize). THEROCK_DIST is on CMAKE_PREFIX_PATH, so hip::host
+# resolves without reordering the parent add_subdirectory sequence.
+find_package(hip CONFIG REQUIRED)
+
 # Create custom op library
 set(LIB_NAME morphizen-custom-op-mlir)
 add_library(${LIB_NAME} STATIC
@@ -25,6 +31,7 @@ target_link_libraries(${LIB_NAME} PRIVATE
   morphizen::morphizen-core-static
   glog::glog
   mlir_compilation_proto  # Shared protobuf metadata library
+  hip::host               # hipEvent_t, hipStream_t, hipDeviceSynchronize (PERF)
 )
 
 # Include directories

--- a/backend-mlir-compiler/custom-op-mlir/src/InferenceState.cpp
+++ b/backend-mlir-compiler/custom-op-mlir/src/InferenceState.cpp
@@ -10,6 +10,7 @@
 #include "morphizen/env_config.hpp"
 #include "morphizen/morphizen.hpp"
 #include "morphizen/plugin.hpp"
+#include <cstddef>
 #include <cstdio>
 #include <cstdlib>
 #include <filesystem>
@@ -41,7 +42,35 @@ namespace mlir_compilation::customop {
 InferenceState::InferenceState(PrivateTag, void *state,
                                std::unique_ptr<morphizen::Plugin> plugin,
                                const std::string &temp_dll_path)
-    : state_(state), plugin_(std::move(plugin)), temp_dll_path_(temp_dll_path) {
+    : state_(state), plugin_(std::move(plugin)), temp_dll_path_(temp_dll_path),
+      begin_compute_fn_(nullptr) {
+  // F-A: Cache the begin_compute symbol so the per-Compute() invocation is a
+  // single indirect call. Older model.dlls do not export this symbol; in that
+  // case we leave begin_compute_fn_ null and begin_compute() becomes a no-op.
+  if (plugin_) {
+    begin_compute_fn_ =
+        plugin_->get_method<void, void *>("hipdnn_ep_runtime_begin_compute");
+    MY_LOG(2) << "F-A begin_compute symbol "
+              << (begin_compute_fn_ ? "resolved" : "not exported (no-op)");
+  }
+  // F-A safety net: warn loudly if the user enabled the seqlens_k cache but
+  // the model.dll predates the patch. Without an invalidation hook the cache
+  // would survive across forward passes and the gqa.cpp readback would
+  // return token-1 values for tokens 2..N, producing silently wrong logits.
+  // Detected once at session creation so the user gets an actionable signal
+  // before observing decode output corruption.
+  if (!begin_compute_fn_) {
+    const char *env = std::getenv("HIPDNN_EP_GQA_CACHE_SEQLENS");
+    if (env && env[0] != '0') {
+      LOG(WARNING)
+          << "HIPDNN_EP_GQA_CACHE_SEQLENS=" << env
+          << " is set, but the loaded model.dll does not export "
+             "hipdnn_ep_runtime_begin_compute. Per-Compute() cache "
+             "invalidation will not happen and decode output will be "
+             "incorrect from token 2 onward. Either unset the env var or "
+             "rebuild the model.dll with the F-A runtime patch.";
+    }
+  }
 }
 
 std::unique_ptr<InferenceState>
@@ -145,6 +174,41 @@ int InferenceState::compute(span_t *inputs, span_t *outputs) const {
     return -1;
   }
   return compute_fn(state_, inputs, outputs);
+}
+
+void InferenceState::begin_compute() const {
+  if (begin_compute_fn_ && state_) {
+    begin_compute_fn_(state_);
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Diagnostic-only stream accessor.
+//
+// state_ is the opaque handle returned by inference_init() in the JIT-compiled
+// model.dll.  That DLL's implementation of inference_init allocates a
+// RuntimeState (see lib/Runtime/runtime_state_internal.h) and returns it as
+// void*.  RuntimeState's first field is `hipStream_t stream`, so a first-field
+// cast gives us the stream without a codegen change or a DLL export.
+//
+// The EP DLL and the JIT model.dll's linked-in runtime bitcode are built from
+// the same commit of the same tree, so layout is consistent by construction.
+// If RuntimeState ever gains a field before `stream`, this returns garbage
+// silently; we'd notice via absurd hipEventElapsedTime readings.  Acceptable
+// for a diagnostic (HIPDNN_EP_PERF) instrumentation.
+// ----------------------------------------------------------------------------
+namespace {
+struct RuntimeStateHead {
+  void *stream; // mirrors RuntimeState::stream (hipStream_t is pointer-sized)
+};
+static_assert(sizeof(void *) == 8, "expected 64-bit target");
+static_assert(offsetof(RuntimeStateHead, stream) == 0,
+              "RuntimeState layout invariant: stream must be first field");
+} // namespace
+
+void *InferenceState::get_stream_raw() const {
+  return state_ ? reinterpret_cast<RuntimeStateHead *>(state_)->stream
+                : nullptr;
 }
 
 } // namespace mlir_compilation::customop

--- a/backend-mlir-compiler/custom-op-mlir/src/InferenceState.cpp
+++ b/backend-mlir-compiler/custom-op-mlir/src/InferenceState.cpp
@@ -44,31 +44,37 @@ InferenceState::InferenceState(PrivateTag, void *state,
                                const std::string &temp_dll_path)
     : state_(state), plugin_(std::move(plugin)), temp_dll_path_(temp_dll_path),
       begin_compute_fn_(nullptr) {
-  // F-A: Cache the begin_compute symbol so the per-Compute() invocation is a
-  // single indirect call. Older model.dlls do not export this symbol; in that
-  // case we leave begin_compute_fn_ null and begin_compute() becomes a no-op.
+  // Cache the begin_compute symbol so the per-Compute() invocation is a
+  // single indirect call. Older model.dlls do not export this symbol; in
+  // that case we leave begin_compute_fn_ null and begin_compute() becomes
+  // a no-op.
   if (plugin_) {
     begin_compute_fn_ =
         plugin_->get_method<void, void *>("hipdnn_ep_runtime_begin_compute");
-    MY_LOG(2) << "F-A begin_compute symbol "
+    MY_LOG(2) << "begin_compute symbol "
               << (begin_compute_fn_ ? "resolved" : "not exported (no-op)");
   }
-  // F-A safety net: warn loudly if the user enabled the seqlens_k cache but
-  // the model.dll predates the patch. Without an invalidation hook the cache
-  // would survive across forward passes and the gqa.cpp readback would
-  // return token-1 values for tokens 2..N, producing silently wrong logits.
-  // Detected once at session creation so the user gets an actionable signal
-  // before observing decode output corruption.
+  // Safety net: warn loudly when the seqlens_k cache is effectively on
+  // but the model.dll predates the begin_compute export. Without the
+  // invalidation hook the cache would survive across forward passes and
+  // the gqa.cpp readback would return token-1 values for tokens 2..N,
+  // producing silently wrong logits. The cache defaults to on, so this
+  // fires unless the user has explicitly set HIPDNN_EP_GQA_CACHE_SEQLENS=0.
+  // Detected once at session creation so the user gets an actionable
+  // signal before observing decode output corruption.
   if (!begin_compute_fn_) {
     const char *env = std::getenv("HIPDNN_EP_GQA_CACHE_SEQLENS");
-    if (env && env[0] != '0') {
-      LOG(WARNING)
-          << "HIPDNN_EP_GQA_CACHE_SEQLENS=" << env
-          << " is set, but the loaded model.dll does not export "
-             "hipdnn_ep_runtime_begin_compute. Per-Compute() cache "
-             "invalidation will not happen and decode output will be "
-             "incorrect from token 2 onward. Either unset the env var or "
-             "rebuild the model.dll with the F-A runtime patch.";
+    const bool cache_enabled = !env || env[0] != '0';
+    if (cache_enabled) {
+      LOG(WARNING) << "GQA seqlens_k cache is enabled "
+                   << "(HIPDNN_EP_GQA_CACHE_SEQLENS="
+                   << (env ? env : "<unset, default 1>")
+                   << "), but the loaded model.dll does not export "
+                      "hipdnn_ep_runtime_begin_compute. Per-Compute() cache "
+                      "invalidation will not happen and decode output will be "
+                      "incorrect from token 2 onward. Either set "
+                      "HIPDNN_EP_GQA_CACHE_SEQLENS=0 or rebuild the model.dll "
+                      "with a runtime that exports the hook.";
     }
   }
 }

--- a/backend-mlir-compiler/custom-op-mlir/src/InferenceState.h
+++ b/backend-mlir-compiler/custom-op-mlir/src/InferenceState.h
@@ -41,13 +41,13 @@ public:
   // Execute inference computation
   int compute(span_t *inputs, span_t *outputs) const;
 
-  // F-A: Mark the start of a new forward pass before inference_compute. If
-  // the model.dll exports hipdnn_ep_runtime_begin_compute (resolved once in
-  // create()) it is invoked to invalidate per-Compute() runtime caches such
-  // as the GQA seqlens_k cache. On older model.dlls the symbol is absent
-  // and this call is a no-op -- callers must therefore not enable
-  // HIPDNN_EP_GQA_CACHE_SEQLENS=1 against such a DLL (the cache would
-  // survive across forward passes and return stale total_seq values).
+  // Mark the start of a new forward pass before inference_compute. If the
+  // model.dll exports hipdnn_ep_runtime_begin_compute (resolved once in
+  // create()) it is invoked to invalidate per-Compute() runtime caches
+  // such as the GQA seqlens_k cache. On older model.dlls the symbol is
+  // absent and this call is a no-op -- such DLLs must be paired with
+  // HIPDNN_EP_GQA_CACHE_SEQLENS=0 (the cache is on by default; create()
+  // logs a LOG(WARNING) when it detects the mismatch).
   void begin_compute() const;
 
   // Diagnostic-only accessor: returns the hipStream_t used by
@@ -81,10 +81,10 @@ private:
   // Temporary DLL file path (deleted in destructor)
   std::string temp_dll_path_;
 
-  // F-A: cached function pointer for hipdnn_ep_runtime_begin_compute.
-  // Resolved once in create() so begin_compute() avoids a per-call
-  // GetProcAddress / dlsym round-trip on the decode hot path. Null when the
-  // model.dll predates the F-A export.
+  // Cached function pointer for hipdnn_ep_runtime_begin_compute. Resolved
+  // once in create() so begin_compute() avoids a per-call GetProcAddress /
+  // dlsym round-trip on the decode hot path. Null when the model.dll
+  // predates the export.
   using BeginComputeFn = void (*)(void *);
   BeginComputeFn begin_compute_fn_;
 };

--- a/backend-mlir-compiler/custom-op-mlir/src/InferenceState.h
+++ b/backend-mlir-compiler/custom-op-mlir/src/InferenceState.h
@@ -41,6 +41,25 @@ public:
   // Execute inference computation
   int compute(span_t *inputs, span_t *outputs) const;
 
+  // F-A: Mark the start of a new forward pass before inference_compute. If
+  // the model.dll exports hipdnn_ep_runtime_begin_compute (resolved once in
+  // create()) it is invoked to invalidate per-Compute() runtime caches such
+  // as the GQA seqlens_k cache. On older model.dlls the symbol is absent
+  // and this call is a no-op -- callers must therefore not enable
+  // HIPDNN_EP_GQA_CACHE_SEQLENS=1 against such a DLL (the cache would
+  // survive across forward passes and return stale total_seq values).
+  void begin_compute() const;
+
+  // Diagnostic-only accessor: returns the hipStream_t used by inference_compute,
+  // as a void*.  Relies on RuntimeState (lib/Runtime/runtime_state_internal.h)
+  // keeping hipStream_t as its first field; the cast is encapsulated in
+  // InferenceState.cpp with a static_assert on pointer size.  Returning void*
+  // keeps hip headers out of this public header.
+  //
+  // Intended for HIPDNN_EP_PERF instrumentation in MlirCustomOp::Compute().
+  // Callers reinterpret_cast to hipStream_t (itself a void* on amdhip64).
+  void *get_stream_raw() const;
+
   // Public constructor gated by PrivateTag: use create() factory instead.
   // PrivateTag is declared private below — external callers cannot form one.
   struct PrivateTag;
@@ -60,6 +79,13 @@ private:
 
   // Temporary DLL file path (deleted in destructor)
   std::string temp_dll_path_;
+
+  // F-A: cached function pointer for hipdnn_ep_runtime_begin_compute.
+  // Resolved once in create() so begin_compute() avoids a per-call
+  // GetProcAddress / dlsym round-trip on the decode hot path. Null when the
+  // model.dll predates the F-A export.
+  using BeginComputeFn = void (*)(void *);
+  BeginComputeFn begin_compute_fn_;
 };
 
 } // namespace mlir_compilation::customop

--- a/backend-mlir-compiler/custom-op-mlir/src/InferenceState.h
+++ b/backend-mlir-compiler/custom-op-mlir/src/InferenceState.h
@@ -50,11 +50,12 @@ public:
   // survive across forward passes and return stale total_seq values).
   void begin_compute() const;
 
-  // Diagnostic-only accessor: returns the hipStream_t used by inference_compute,
-  // as a void*.  Relies on RuntimeState (lib/Runtime/runtime_state_internal.h)
-  // keeping hipStream_t as its first field; the cast is encapsulated in
-  // InferenceState.cpp with a static_assert on pointer size.  Returning void*
-  // keeps hip headers out of this public header.
+  // Diagnostic-only accessor: returns the hipStream_t used by
+  // inference_compute, as a void*.  Relies on RuntimeState
+  // (lib/Runtime/runtime_state_internal.h) keeping hipStream_t as its first
+  // field; the cast is encapsulated in InferenceState.cpp with a static_assert
+  // on pointer size.  Returning void* keeps hip headers out of this public
+  // header.
   //
   // Intended for HIPDNN_EP_PERF instrumentation in MlirCustomOp::Compute().
   // Callers reinterpret_cast to hipStream_t (itself a void* on amdhip64).

--- a/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
+++ b/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
@@ -17,6 +17,15 @@
 // Component headers
 #include "InferenceState.h"
 
+// HIPDNN_EP_PERF instrumentation dependencies
+#include <hip/hip_runtime_api.h>
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <mutex>
+#include <vector>
+
 // Environment parameters (global scope, before namespace)
 DEF_ENV_PARAM(MORPHIZEN_DEBUG_MLIR_BACKEND, "0")
 
@@ -302,6 +311,138 @@ std::vector<uint8_t> load_artifact_from_epcontext(
 }
 } // anonymous namespace
 
+// ============================================================================
+// HIPDNN_EP_PERF: per-inference CPU + GPU timing for MlirCustomOp::Compute().
+//
+// When HIPDNN_EP_PERF is set to "1" (or higher) at process start, every
+// Compute() call emits one [PERF] line to stderr and a [PERF SUMMARY] block
+// on DLL unload.  The breakdown intentionally splits:
+//
+//   wall            = total CPU time spent inside Compute (incl. post-compute
+//                     fence); closest analog to OGA's reported decode latency
+//   marshal_in      = CPU time building input tensor_t span from ORT context
+//   marshal_out     = CPU time building output tensor_t span from ORT context
+//   compute_cpu     = CPU wall time across inference_state_->compute() (host
+//                     dispatch + synchronous kernel launches)
+//   gpu             = hipEvent-measured GPU time across the same compute()
+//                     call on the EP stream
+//   fence_residual  = CPU time blocked in hipDeviceSynchronize() issued AFTER
+//                     compute() returns; non-zero means compute() returned
+//                     with async GPU work still outstanding
+//
+// Interpretation grid for the decode gap vs llama.cpp Vulkan:
+//   compute_cpu >> gpu       -> host dispatch / launch overhead dominates
+//                               (per-kernel hipLaunchKernel cost, bitcode
+//                               trampolines, or glue code in model.dll)
+//   fence_residual >> 0      -> compute() is queueing async GPU work; the
+//                               host returns early and we under-count GPU
+//                               per call
+//   gpu close to llama.cpp   -> kernels themselves are not the problem;
+//                               the gap is in launch/dispatch / glue
+//   gpu >> llama.cpp         -> kernels are the problem (GEMM, MatMulNBits,
+//                               attention, etc.)
+//
+// Overhead when disabled: ~0 (single branch on a cached bool).
+// Overhead when enabled:  ~25us/call (hipEventCreate+Record+Sync+Destroy +
+//   one hipDeviceSynchronize + one fprintf) - negligible vs decode cost.
+// ============================================================================
+namespace {
+
+bool perf_enabled() {
+  static const bool enabled = [] {
+    const char *v = std::getenv("HIPDNN_EP_PERF");
+    return v && v[0] >= '1' && v[0] <= '9';
+  }();
+  return enabled;
+}
+
+struct PerfSample {
+  double wall_ms;
+  double marshal_in_ms;
+  double marshal_out_ms;
+  double compute_cpu_ms;
+  double gpu_ms;
+  double fence_residual_ms;
+};
+
+class PerfCollector {
+public:
+  void record(const PerfSample &s) {
+    std::lock_guard<std::mutex> g(mu_);
+    samples_.push_back(s);
+    const size_t idx = samples_.size();
+    std::fprintf(stderr,
+                 "[PERF] #%zu wall=%.3f marshal_in=%.3f marshal_out=%.3f "
+                 "compute_cpu=%.3f gpu=%.3f fence_residual=%.3f (ms)\n",
+                 idx, s.wall_ms, s.marshal_in_ms, s.marshal_out_ms,
+                 s.compute_cpu_ms, s.gpu_ms, s.fence_residual_ms);
+    std::fflush(stderr);
+  }
+
+  void dump_summary() {
+    std::lock_guard<std::mutex> g(mu_);
+    if (samples_.empty()) {
+      return;
+    }
+    std::fprintf(stderr, "[PERF SUMMARY] total_inferences=%zu\n",
+                 samples_.size());
+    print_stats("wall_ms", &PerfSample::wall_ms);
+    print_stats("marshal_in_ms", &PerfSample::marshal_in_ms);
+    print_stats("marshal_out_ms", &PerfSample::marshal_out_ms);
+    print_stats("compute_cpu_ms", &PerfSample::compute_cpu_ms);
+    print_stats("gpu_ms", &PerfSample::gpu_ms);
+    print_stats("fence_residual_ms", &PerfSample::fence_residual_ms);
+    std::fflush(stderr);
+  }
+
+private:
+  // Called with mu_ held.
+  void print_stats(const char *name, double PerfSample::*field) {
+    std::vector<double> v;
+    v.reserve(samples_.size());
+    double sum = 0.0;
+    for (const auto &s : samples_) {
+      v.push_back(s.*field);
+      sum += s.*field;
+    }
+    std::sort(v.begin(), v.end());
+    const double min = v.front();
+    const double max = v.back();
+    const double median = v[v.size() / 2];
+    // p99 index is clamped to back() for small sample counts.
+    const size_t p99_idx = (v.size() * 99) / 100;
+    const double p99 = v[p99_idx < v.size() ? p99_idx : v.size() - 1];
+    const double mean = sum / static_cast<double>(v.size());
+    std::fprintf(stderr,
+                 "[PERF SUMMARY] %-18s  min=%.3f  mean=%.3f  median=%.3f  "
+                 "p99=%.3f  max=%.3f\n",
+                 name, min, mean, median, p99, max);
+  }
+
+  std::mutex mu_;
+  std::vector<PerfSample> samples_;
+};
+
+// Declared at namespace scope *before* g_perf_printer so that construction
+// order (declaration order within a TU) guarantees g_perf_printer is
+// destroyed first at DLL unload, while g_perf_collector is still alive for
+// its dump_summary() call.
+PerfCollector g_perf_collector;
+
+PerfCollector &perf_collector() { return g_perf_collector; }
+
+// Dumps the summary at DLL unload.  See ordering note above.
+struct PerfSummaryPrinter {
+  ~PerfSummaryPrinter() {
+    if (perf_enabled()) {
+      g_perf_collector.dump_summary();
+    }
+  }
+};
+PerfSummaryPrinter g_perf_printer;
+
+} // anonymous namespace
+
 MlirCustomOp::MlirCustomOp(
     std::shared_ptr<const morphizen::PassContext> context,
     const std::shared_ptr<morphizen::MetaDefProto> &meta_def,
@@ -328,15 +469,85 @@ MlirCustomOp::MlirCustomOp(
 void MlirCustomOp::Compute(const OrtApi *api, OrtKernelContext *context) const {
   MY_LOG(2) << "MlirCustomOp::Compute() called";
 
+  // F-A: Tell the runtime that a new forward pass is starting so per-Compute()
+  // caches (currently the GQA seqlens_k cache) are invalidated. No-op if the
+  // model.dll predates the F-A export -- but in that case
+  // HIPDNN_EP_GQA_CACHE_SEQLENS=1 must not be set, otherwise stale values
+  // would survive across forward passes. The call is a single cached indirect
+  // dispatch, so leaving it on the fast path costs ~1 ns.
+  inference_state_->begin_compute();
+
+  if (!perf_enabled()) {
+    // --- Fast path: original behaviour, no timing overhead. ---
+    auto inputs = marshal_input_tensors(context, input_index_map_);
+    auto outputs =
+        marshal_output_tensors(context, metadata_.outputs(), output_index_map_);
+
+    int ret = inference_state_->compute(&inputs.span, &outputs.span);
+    if (ret != 0) {
+      LOG(ERROR) << "inference_compute() failed with code: " << ret;
+      // TODO: Throw ORT exception
+    }
+
+    MY_LOG(2) << "Compute completed successfully";
+    return;
+  }
+
+  // --- HIPDNN_EP_PERF path: wall + per-phase + GPU timing. ---
+  using clock = std::chrono::steady_clock;
+  auto elapsed_ms = [](clock::time_point a, clock::time_point b) {
+    return std::chrono::duration<double, std::milli>(b - a).count();
+  };
+
+  const auto t_enter = clock::now();
   auto inputs = marshal_input_tensors(context, input_index_map_);
+  const auto t_after_in = clock::now();
   auto outputs =
       marshal_output_tensors(context, metadata_.outputs(), output_index_map_);
+  const auto t_after_out = clock::now();
 
-  int ret = inference_state_->compute(&inputs.span, &outputs.span);
+  // Stream used by inference_compute (first field of RuntimeState).  May be
+  // the default stream (hipStream_t(0)) — hipEvent APIs accept that fine.
+  auto stream =
+      static_cast<hipStream_t>(inference_state_->get_stream_raw());
+
+  // HIP error codes are intentionally discarded below: any failure here only
+  // corrupts diagnostic numbers, never the inference result.  Casting to void
+  // also suppresses C4834 ([[nodiscard]] discarded) under MSVC /W4.
+  hipEvent_t ev_start = nullptr, ev_stop = nullptr;
+  (void)hipEventCreate(&ev_start);
+  (void)hipEventCreate(&ev_stop);
+  (void)hipEventRecord(ev_start, stream);
+
+  const int ret = inference_state_->compute(&inputs.span, &outputs.span);
+  const auto t_after_compute = clock::now();
+
+  (void)hipEventRecord(ev_stop, stream);
+  // hipDeviceSynchronize() is the fence: measures residual async work left
+  // on any stream after compute() returned.  For correctly-synchronous
+  // dispatch paths this should be ~0.
+  (void)hipDeviceSynchronize();
+  const auto t_after_fence = clock::now();
+
+  float gpu_ms_f = 0.0f;
+  (void)hipEventSynchronize(ev_stop);
+  (void)hipEventElapsedTime(&gpu_ms_f, ev_start, ev_stop);
+  (void)hipEventDestroy(ev_start);
+  (void)hipEventDestroy(ev_stop);
+
   if (ret != 0) {
     LOG(ERROR) << "inference_compute() failed with code: " << ret;
     // TODO: Throw ORT exception
   }
+
+  PerfSample s;
+  s.wall_ms = elapsed_ms(t_enter, t_after_fence);
+  s.marshal_in_ms = elapsed_ms(t_enter, t_after_in);
+  s.marshal_out_ms = elapsed_ms(t_after_in, t_after_out);
+  s.compute_cpu_ms = elapsed_ms(t_after_out, t_after_compute);
+  s.gpu_ms = static_cast<double>(gpu_ms_f);
+  s.fence_residual_ms = elapsed_ms(t_after_compute, t_after_fence);
+  perf_collector().record(s);
 
   MY_LOG(2) << "Compute completed successfully";
 }

--- a/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
+++ b/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
@@ -18,7 +18,9 @@
 #include "InferenceState.h"
 
 // HIPDNN_EP_PERF instrumentation dependencies
+#ifndef BUILD_MOCK_RUNTIME
 #include <hip/hip_runtime_api.h>
+#endif
 #include <algorithm>
 #include <chrono>
 #include <cstdio>
@@ -349,11 +351,15 @@ std::vector<uint8_t> load_artifact_from_epcontext(
 namespace {
 
 bool perf_enabled() {
+#ifdef BUILD_MOCK_RUNTIME
+  return false;
+#else
   static const bool enabled = [] {
     const char *v = std::getenv("HIPDNN_EP_PERF");
     return v && v[0] >= '1' && v[0] <= '9';
   }();
   return enabled;
+#endif
 }
 
 struct PerfSample {
@@ -493,6 +499,7 @@ void MlirCustomOp::Compute(const OrtApi *api, OrtKernelContext *context) const {
     return;
   }
 
+#ifndef BUILD_MOCK_RUNTIME
   // --- HIPDNN_EP_PERF path: wall + per-phase + GPU timing. ---
   using clock = std::chrono::steady_clock;
   auto elapsed_ms = [](clock::time_point a, clock::time_point b) {
@@ -508,8 +515,7 @@ void MlirCustomOp::Compute(const OrtApi *api, OrtKernelContext *context) const {
 
   // Stream used by inference_compute (first field of RuntimeState).  May be
   // the default stream (hipStream_t(0)) — hipEvent APIs accept that fine.
-  auto stream =
-      static_cast<hipStream_t>(inference_state_->get_stream_raw());
+  auto stream = static_cast<hipStream_t>(inference_state_->get_stream_raw());
 
   // HIP error codes are intentionally discarded below: any failure here only
   // corrupts diagnostic numbers, never the inference result.  Casting to void
@@ -550,6 +556,7 @@ void MlirCustomOp::Compute(const OrtApi *api, OrtKernelContext *context) const {
   perf_collector().record(s);
 
   MY_LOG(2) << "Compute completed successfully";
+#endif // BUILD_MOCK_RUNTIME
 }
 
 } // namespace mlir_compilation

--- a/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
+++ b/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
@@ -475,12 +475,14 @@ MlirCustomOp::MlirCustomOp(
 void MlirCustomOp::Compute(const OrtApi *api, OrtKernelContext *context) const {
   MY_LOG(2) << "MlirCustomOp::Compute() called";
 
-  // F-A: Tell the runtime that a new forward pass is starting so per-Compute()
-  // caches (currently the GQA seqlens_k cache) are invalidated. No-op if the
-  // model.dll predates the F-A export -- but in that case
-  // HIPDNN_EP_GQA_CACHE_SEQLENS=1 must not be set, otherwise stale values
-  // would survive across forward passes. The call is a single cached indirect
-  // dispatch, so leaving it on the fast path costs ~1 ns.
+  // Tell the runtime that a new forward pass is starting so per-Compute()
+  // caches (currently the GQA seqlens_k cache) are invalidated. No-op if
+  // the model.dll predates the begin_compute export -- but in that case
+  // the cache must be disabled via HIPDNN_EP_GQA_CACHE_SEQLENS=0
+  // (default-on), otherwise stale values would survive across forward
+  // passes. The mismatch is detected at session creation and produces a
+  // LOG(WARNING). The call is a single cached indirect dispatch, so
+  // leaving it on the fast path costs ~1 ns.
   inference_state_->begin_compute();
 
   if (!perf_enabled()) {

--- a/lib/Compiler/CompilerDriver.cpp
+++ b/lib/Compiler/CompilerDriver.cpp
@@ -168,16 +168,14 @@ bool CompilerDriver::compileImpl(mlir::ModuleOp module,
   //   inference_init/compute/cleanup       — runtime entry points
   //   inference_get_metadata_json          — model metadata query
   //   test_hip_from_dll                    — diagnostic hook for test-model-dll
-  //   hipdnn_ep_runtime_begin_compute      — F-A per-Compute() cache invalidation
+  //   hipdnn_ep_runtime_begin_compute      — F-A per-Compute() cache
+  //   invalidation
   //                                          hook (called from EP-side
   //                                          MlirCustomOp::Compute() entry)
   std::vector<std::string> export_symbols = {
-      "inference_init",
-      "inference_compute",
-      "inference_cleanup",
-      "inference_get_metadata_json",
-      "test_hip_from_dll",
-      "hipdnn_ep_runtime_begin_compute"};
+      "inference_init",    "inference_compute",
+      "inference_cleanup", "inference_get_metadata_json",
+      "test_hip_from_dll", "hipdnn_ep_runtime_begin_compute"};
   std::vector<std::string> libraries;
   std::vector<std::string> library_paths;
   discoverLibraries(libraries, library_paths);

--- a/lib/Compiler/CompilerDriver.cpp
+++ b/lib/Compiler/CompilerDriver.cpp
@@ -168,8 +168,7 @@ bool CompilerDriver::compileImpl(mlir::ModuleOp module,
   //   inference_init/compute/cleanup       — runtime entry points
   //   inference_get_metadata_json          — model metadata query
   //   test_hip_from_dll                    — diagnostic hook for test-model-dll
-  //   hipdnn_ep_runtime_begin_compute      — F-A per-Compute() cache
-  //   invalidation
+  //   hipdnn_ep_runtime_begin_compute      — per-Compute() cache invalidation
   //                                          hook (called from EP-side
   //                                          MlirCustomOp::Compute() entry)
   std::vector<std::string> export_symbols = {

--- a/lib/Compiler/CompilerDriver.cpp
+++ b/lib/Compiler/CompilerDriver.cpp
@@ -165,12 +165,19 @@ bool CompilerDriver::compileImpl(mlir::ModuleOp module,
   logPhase("compileToObject");
 
   // Symbols exported from the generated DLL:
-  //   inference_init/compute/cleanup — runtime entry points
-  //   inference_get_metadata_json    — model metadata query
-  //   test_hip_from_dll              — diagnostic hook for test-model-dll
+  //   inference_init/compute/cleanup       — runtime entry points
+  //   inference_get_metadata_json          — model metadata query
+  //   test_hip_from_dll                    — diagnostic hook for test-model-dll
+  //   hipdnn_ep_runtime_begin_compute      — F-A per-Compute() cache invalidation
+  //                                          hook (called from EP-side
+  //                                          MlirCustomOp::Compute() entry)
   std::vector<std::string> export_symbols = {
-      "inference_init", "inference_compute", "inference_cleanup",
-      "inference_get_metadata_json", "test_hip_from_dll"};
+      "inference_init",
+      "inference_compute",
+      "inference_cleanup",
+      "inference_get_metadata_json",
+      "test_hip_from_dll",
+      "hipdnn_ep_runtime_begin_compute"};
   std::vector<std::string> libraries;
   std::vector<std::string> library_paths;
   discoverLibraries(libraries, library_paths);

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -208,6 +208,14 @@ void *hipdnn_ep_state_get_workspace(RuntimeState *state);
 size_t hipdnn_ep_state_get_workspace_size(RuntimeState *state);
 int hipdnn_ep_state_ensure_workspace(RuntimeState *state, size_t needed_size);
 
+// F-A: Mark the start of a new Compute() call. Invalidates per-forward-pass
+// caches such as the GQA seqlens_k cache (see runtime_state_internal.h).
+// Called by the EP-side MlirCustomOp::Compute() entry once per inference;
+// safe to call unconditionally (cheap: writes a single bool). Required for
+// HIPDNN_EP_GQA_CACHE_SEQLENS=1 to be correct -- without this hook the cache
+// would persist across forward passes and return stale values.
+void hipdnn_ep_runtime_begin_compute(RuntimeState *state);
+
 // Initialize memory pool in runtime state
 // Called by generated inference_init after creating RuntimeState
 // Parameters:

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -208,12 +208,13 @@ void *hipdnn_ep_state_get_workspace(RuntimeState *state);
 size_t hipdnn_ep_state_get_workspace_size(RuntimeState *state);
 int hipdnn_ep_state_ensure_workspace(RuntimeState *state, size_t needed_size);
 
-// F-A: Mark the start of a new Compute() call. Invalidates per-forward-pass
+// Mark the start of a new Compute() call. Invalidates per-forward-pass
 // caches such as the GQA seqlens_k cache (see runtime_state_internal.h).
 // Called by the EP-side MlirCustomOp::Compute() entry once per inference;
 // safe to call unconditionally (cheap: writes a single bool). Required for
-// HIPDNN_EP_GQA_CACHE_SEQLENS=1 to be correct -- without this hook the cache
-// would persist across forward passes and return stale values.
+// the GQA seqlens_k cache (default on, set HIPDNN_EP_GQA_CACHE_SEQLENS=0
+// to disable) to be correct -- without this hook the cache would persist
+// across forward passes and return stale values.
 void hipdnn_ep_runtime_begin_compute(RuntimeState *state);
 
 // Initialize memory pool in runtime state

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -219,6 +219,9 @@ static int initialize_state_handles(RuntimeState **out_state) {
   state->op_profile = hipdnn_ep_perf_enabled() ? op_profile_create() : nullptr;
   state->hipdnn_handle = nullptr;
   state->hipdnn_graph_registry = nullptr;
+  state->seqlens_k_cached_valid = false;
+  state->seqlens_k_cached_val = 0;
+  state->seqlens_k_cached_ptr = nullptr;
 
   int device_count = 0;
   if (hipGetDeviceCount(&device_count) != hipSuccess || device_count == 0) {
@@ -898,6 +901,27 @@ void *hipdnn_ep_state_get_hipblas_handle(RuntimeState *state) {
 
 void *hipdnn_ep_state_get_op_profile(RuntimeState *state) {
   return state ? state->op_profile : nullptr;
+}
+
+// F-A: Per-Compute() cache invalidation hook. Today this only resets the
+// GQA seqlens_k cache; future per-forward-pass caches should be cleared
+// here as well so the EP-side hook stays a single call.
+//
+// __declspec(dllexport) matches the convention in real/test_hip_from_dll.cpp
+// (belt-and-suspenders with the .def export list in CompilerDriver.cpp) and
+// guarantees the symbol survives LLVM optimization in the compiled
+// model.dll, which dlsym/GetProcAddress resolves it from.
+extern "C"
+#ifdef _WIN32
+    __declspec(dllexport)
+#endif
+        void
+        hipdnn_ep_runtime_begin_compute(RuntimeState *state) {
+  if (!state) {
+    return;
+  }
+  state->seqlens_k_cached_valid = false;
+  state->seqlens_k_cached_ptr = nullptr;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -915,8 +915,7 @@ extern "C"
 #ifdef _WIN32
     __declspec(dllexport)
 #endif
-        void
-        hipdnn_ep_runtime_begin_compute(RuntimeState *state) {
+    void hipdnn_ep_runtime_begin_compute(RuntimeState *state) {
   if (!state) {
     return;
   }

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -915,7 +915,7 @@ extern "C"
 #ifdef _WIN32
     __declspec(dllexport)
 #endif
-    void hipdnn_ep_runtime_begin_compute(RuntimeState *state) {
+        void hipdnn_ep_runtime_begin_compute(RuntimeState *state) {
   if (!state) {
     return;
   }

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -903,9 +903,9 @@ void *hipdnn_ep_state_get_op_profile(RuntimeState *state) {
   return state ? state->op_profile : nullptr;
 }
 
-// F-A: Per-Compute() cache invalidation hook. Today this only resets the
-// GQA seqlens_k cache; future per-forward-pass caches should be cleared
-// here as well so the EP-side hook stays a single call.
+// Per-Compute() cache invalidation hook. Today this only resets the GQA
+// seqlens_k cache; future per-forward-pass caches should be cleared here
+// as well so the EP-side hook stays a single call.
 //
 // __declspec(dllexport) matches the convention in real/test_hip_from_dll.cpp
 // (belt-and-suspenders with the .def export list in CompilerDriver.cpp) and

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -13,6 +13,7 @@
 #include "runtime_types.h"
 
 #include <algorithm>
+#include <atomic>
 #include <cassert>
 #include <cmath>
 #include <cstdio>
@@ -70,6 +71,130 @@ static bool gqa_no_expand_prefill_enabled() {
     return v && std::strcmp(v, "0") != 0;
   }();
   return enabled;
+}
+
+// Env-var gate to force decode through the decomposed hipBLASLt pipeline
+// instead of the fused custom kernel hip_gqa_fused_decode. Default off
+// (fused path is preferred). Set HIPDNN_EP_GQA_DISABLE_FUSED_DECODE=1 to
+// A/B against decomposed at sq==1 -- useful for measuring whether the
+// custom fused kernel is actually faster than hipBLASLt's auto-tuned GEMMs
+// at decode shapes. See docs/decode-optimizations.md (F0 section).
+static bool gqa_fused_decode_disabled() {
+  static const bool disabled = [] {
+    const char *v = std::getenv("HIPDNN_EP_GQA_DISABLE_FUSED_DECODE");
+    return v && std::strcmp(v, "0") != 0;
+  }();
+  return disabled;
+}
+
+// F-A: Env-var gate to cache seqlens_k_val across the GQA layers in a single
+// forward pass. Default off. Set HIPDNN_EP_GQA_CACHE_SEQLENS=1 to skip the
+// per-layer hipMemcpyAsync(D2H) + hipStreamSynchronize on the decomposed path
+// after the first GQA call -- a 32-layer Llama decode then issues one D2H
+// instead of 32, eliminating ~30-45 ms/token of pipeline stalls on Strix Halo.
+//
+// Correctness depends on the EP-side MlirCustomOp::Compute() invoking
+// hipdnn_ep_runtime_begin_compute(state) at the start of each forward pass to
+// invalidate the cache. Older model.dlls without that symbol exported must
+// not enable this flag (the cache would survive across forward passes and
+// return stale total_seq values). See docs/decode-optimizations.md (F-A
+// section).
+static bool gqa_cache_seqlens_enabled() {
+  static const bool enabled = [] {
+    const char *v = std::getenv("HIPDNN_EP_GQA_CACHE_SEQLENS");
+    return v && std::strcmp(v, "0") != 0;
+  }();
+  return enabled;
+}
+
+// Smart-dispatch threshold for GQA decode (sq == 1). When total_seq exceeds
+// this value, dispatch routes through the decomposed hipBLASLt pipeline
+// instead of the fused custom kernel hip_gqa_fused_decode. The fused kernel
+// uses a serial-over-time scheme with cross-wave reductions on the critical
+// path of every iteration, so it loses to the GEMM-based decomposed path on
+// long sequences (measured ~12x slower at total_seq~=2048 on Strix Halo).
+//
+// Default 256 is a starter value pending the threshold sweep documented in
+// docs/decode-optimizations.md (smart-dispatch section). Set
+// HIPDNN_EP_GQA_FUSED_DECODE_MAX_T=N to override (or set a very large value
+// like 999999 to effectively disable smart-dispatch and preserve the
+// pre-smart-dispatch always-fused-when-eligible behaviour for A/B testing).
+static int gqa_fused_decode_max_t() {
+  static const int max_t = [] {
+    const char *v = std::getenv("HIPDNN_EP_GQA_FUSED_DECODE_MAX_T");
+    if (!v || !*v) {
+      return 256;
+    }
+    char *end = nullptr;
+    long parsed = std::strtol(v, &end, 10);
+    if (end == v || parsed <= 0) {
+      return 256;
+    }
+    return static_cast<int>(parsed);
+  }();
+  return max_t;
+}
+
+// Sentinel returned by read_seqlens_k_for_dispatch when the pre-dispatch
+// read is not applicable (multi-batch or missing seqlens_k_ptr) or failed
+// (D2H copy / stream sync error). Outside the valid range of real
+// seqlens_k values (-1 is ORT's prefill sentinel; 0..max_seq are real).
+// Callers must treat this as "no pre-read available" and fall back to the
+// legacy per-call D2H readback site they already implement.
+static constexpr int32_t kSeqlensKNotRead = -2;
+
+// Read seqlens_k_val from device (or F-A cache) once per call before the
+// fused/decomposed dispatch decision. Two purposes:
+//   1. Give the smart-dispatch heuristic access to total_seq for the
+//      decode case (sq == 1) so it can compare against
+//      gqa_fused_decode_max_t().
+//   2. Populate the F-A per-Compute() cache for B == 1 so subsequent GQA
+//      layers within the same forward pass reuse the value with zero D2H.
+//
+// Applies to B == 1 regardless of sq (both prefill and decode share the
+// same seqlens_k pointer and benefit from caching). On B != 1 we return
+// kSeqlensKNotRead because per-batch validation in the multi-batch path
+// requires reading every entry; the legacy readback site there handles it.
+//
+// Behaviour:
+//   - F-A enabled and cache hit:  zero D2H, return cached value.
+//   - F-A enabled and cache miss: one D2H + sync, populate cache, return.
+//   - F-A disabled:               one D2H + sync, return (no cache write).
+//   - B != 1, !seqlens_k_ptr, or D2H/sync failure:
+//                                 return kSeqlensKNotRead.
+//
+// The returned int32_t is the raw device value: -1 is ORT's prefill
+// sentinel (callers map it to total_seq=sq, past_len=0); 0..max_seq is
+// the live (total_seq - 1).
+static int32_t read_seqlens_k_for_dispatch(hipStream_t stream,
+                                           const void *seqlens_k_ptr,
+                                           int64_t B, RuntimeState *state) {
+  if (!seqlens_k_ptr || B != 1) {
+    return kSeqlensKNotRead;
+  }
+
+  if (gqa_cache_seqlens_enabled() && state &&
+      state->seqlens_k_cached_valid &&
+      state->seqlens_k_cached_ptr == seqlens_k_ptr) {
+    return state->seqlens_k_cached_val;
+  }
+
+  int32_t seqlens_k_val = 0;
+  if (hipMemcpyAsync(&seqlens_k_val, seqlens_k_ptr, sizeof(int32_t),
+                     hipMemcpyDeviceToHost, stream) != hipSuccess) {
+    return kSeqlensKNotRead;
+  }
+  if (hipStreamSynchronize(stream) != hipSuccess) {
+    return kSeqlensKNotRead;
+  }
+
+  if (gqa_cache_seqlens_enabled() && state) {
+    state->seqlens_k_cached_val = seqlens_k_val;
+    state->seqlens_k_cached_ptr = seqlens_k_ptr;
+    state->seqlens_k_cached_valid = true;
+  }
+
+  return seqlens_k_val;
 }
 
 //===----------------------------------------------------------------------===//
@@ -346,11 +471,47 @@ static int gqa_forward_hipblaslt(
   // auto-tuned GEMMs outperform fixed WMMA tiling and all ORT GQA features
   // (sliding window, smooth softmax, head sink) are supported.
   //===--------------------------------------------------------------------===//
+  // Pre-dispatch read of seqlens_k (or F-A cache lookup for B==1).
+  // Applies to both prefill (sq>1) and decode (sq==1) for B==1 -- both
+  // share the same seqlens_k pointer and benefit from F-A caching. The
+  // result is reused by the fused-path need_host_past_len block
+  // (eliminating its inline D2H) and the decomposed-path readback site
+  // (consumed unconditionally instead of issuing its own D2H). On B>1
+  // this returns kSeqlensKNotRead and both downstream paths fall back to
+  // their legacy per-call reads. Stored in seqlens_k_pre; total_seq_pre
+  // is the derived total_seq (-1 means unknown / not applicable).
+  int32_t seqlens_k_pre =
+      read_seqlens_k_for_dispatch(stream, seqlens_k_ptr, B, state);
+  int64_t total_seq_pre = -1;
+  if (seqlens_k_pre != kSeqlensKNotRead) {
+    // -1 is ORT's prefill sentinel: total_seq=sq, past_len=0. Real values
+    // are 0..max_seq; total_seq = seqlens_k_val + 1.
+    total_seq_pre = (seqlens_k_pre < 0)
+                        ? sq
+                        : static_cast<int64_t>(seqlens_k_pre) + 1;
+  }
+
   bool fused_d = (d == 64 || d == 128 || d == 256);
+
+  // Smart dispatch: the fused decode kernel serializes over the time
+  // dimension (cross-wave reduction tree on the critical path of every
+  // iteration). For total_seq above gqa_fused_decode_max_t() the GEMM-based
+  // decomposed path wins (~12x at total_seq=2048 on Strix Halo). When we
+  // can't read total_seq (B>1, no seqlens_k, or D2H failure), default to
+  // permitting fused -- preserves bit-for-bit behaviour on workloads that
+  // pass the predicate today.
+  bool size_ok_for_fused =
+      (total_seq_pre < 0) ||
+      (total_seq_pre <= static_cast<int64_t>(gqa_fused_decode_max_t()));
+
   // ONNX uses local_window_size=-1 for "no sliding window"; <= 0 means
   // disabled.
-  if (fused_d && sq == 1 && key && value && present_key && present_value &&
-      local_window_size <= 0 && !head_sink && !use_smooth_softmax) {
+  bool fused_predicate =
+      (!gqa_fused_decode_disabled() && fused_d && sq == 1 && key && value &&
+       present_key && present_value && local_window_size <= 0 && !head_sink &&
+       !use_smooth_softmax && size_ok_for_fused);
+
+  if (fused_predicate) {
     const void *qSrc = query;
     const void *kSrc = key;
 
@@ -362,13 +523,22 @@ static int gqa_forward_hipblaslt(
     bool need_host_past_len =
         seqlens_k_ptr && past_key && past_key != present_key;
     if (need_host_past_len) {
+      // Reuse the value the pre-dispatch helper already read above. Fall
+      // back to a per-call D2H + sync only when the pre-read was not
+      // applicable (multi-batch, or copy/sync failure). For the asym
+      // Llama decode hot path (B==1, sq==1) the pre-read is always
+      // applicable, so this branch becomes pure host arithmetic.
       int32_t seqlens_k_val = 0;
-      if (hipMemcpyAsync(&seqlens_k_val, seqlens_k_ptr, sizeof(int32_t),
-                         hipMemcpyDeviceToHost, stream) != hipSuccess) {
-        return -1;
-      }
-      if (hipStreamSynchronize(stream) != hipSuccess) {
-        return -1;
+      if (seqlens_k_pre != kSeqlensKNotRead) {
+        seqlens_k_val = seqlens_k_pre;
+      } else {
+        if (hipMemcpyAsync(&seqlens_k_val, seqlens_k_ptr, sizeof(int32_t),
+                           hipMemcpyDeviceToHost, stream) != hipSuccess) {
+          return -1;
+        }
+        if (hipStreamSynchronize(stream) != hipSuccess) {
+          return -1;
+        }
       }
 
       // ORT prefill sentinel: when there is no past KV yet, the producer
@@ -457,11 +627,19 @@ static int gqa_forward_hipblaslt(
 
   // D2H readback of seqlens_k is required here because hipBLASLt descriptor
   // creation and workspace sizing are host-side APIs that need total_seq.
+  // For B == 1 the value was already read (and F-A-cached) by the
+  // pre-dispatch helper above; we just consume seqlens_k_pre. The B > 1
+  // branch keeps the legacy per-call read because per-batch validation
+  // requires reading every entry and we have no validated multi-batch
+  // decode workload yet.
   int64_t total_seq = skv;
   int64_t past_len = skv - sq;
   if (seqlens_k_ptr) {
     int32_t seqlens_k_val = 0;
-    if (B > 1) {
+
+    if (seqlens_k_pre != kSeqlensKNotRead) {
+      seqlens_k_val = seqlens_k_pre;
+    } else if (B > 1) {
       std::vector<int32_t> seqlens_k_host(B);
       if (hipMemcpyAsync(seqlens_k_host.data(), seqlens_k_ptr,
                          B * sizeof(int32_t), hipMemcpyDeviceToHost,
@@ -480,12 +658,16 @@ static int gqa_forward_hipblaslt(
         }
       }
     } else {
+      // Defensive fallback for B == 1 when the pre-dispatch helper bailed
+      // out (D2H or sync failure). Rare path; not cached because the same
+      // failure mode would have prevented the helper from caching too.
       if (hipMemcpyAsync(&seqlens_k_val, seqlens_k_ptr, sizeof(int32_t),
                          hipMemcpyDeviceToHost, stream) != hipSuccess)
         return -1;
       if (hipStreamSynchronize(stream) != hipSuccess)
         return -1;
     }
+
     // ORT prefill sentinel: when there is no past KV yet, the producer
     // initialises seqlens_k[b] to -1. Treat that as a fresh prefill
     // (past_len=0, total_seq=sq) instead of rejecting it as invalid.

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -13,7 +13,6 @@
 #include "runtime_types.h"
 
 #include <algorithm>
-#include <atomic>
 #include <cassert>
 #include <cmath>
 #include <cstdio>
@@ -78,7 +77,7 @@ static bool gqa_no_expand_prefill_enabled() {
 // (fused path is preferred). Set HIPDNN_EP_GQA_DISABLE_FUSED_DECODE=1 to
 // A/B against decomposed at sq==1 -- useful for measuring whether the
 // custom fused kernel is actually faster than hipBLASLt's auto-tuned GEMMs
-// at decode shapes. See docs/decode-optimizations.md (F0 section).
+// at decode shapes.
 static bool gqa_fused_decode_disabled() {
   static const bool disabled = [] {
     const char *v = std::getenv("HIPDNN_EP_GQA_DISABLE_FUSED_DECODE");
@@ -87,22 +86,27 @@ static bool gqa_fused_decode_disabled() {
   return disabled;
 }
 
-// F-A: Env-var gate to cache seqlens_k_val across the GQA layers in a single
-// forward pass. Default off. Set HIPDNN_EP_GQA_CACHE_SEQLENS=1 to skip the
-// per-layer hipMemcpyAsync(D2H) + hipStreamSynchronize on the decomposed path
-// after the first GQA call -- a 32-layer Llama decode then issues one D2H
-// instead of 32, eliminating ~30-45 ms/token of pipeline stalls on Strix Halo.
+// Env-var gate to cache seqlens_k_val across the GQA layers in a single
+// forward pass. Default ON. Caching skips the per-layer
+// hipMemcpyAsync(D2H) + hipStreamSynchronize on the decomposed path after
+// the first GQA call -- a 32-layer Llama decode then issues one D2H
+// instead of 32, eliminating ~30-45 ms/token of pipeline stalls on Strix
+// Halo. Set HIPDNN_EP_GQA_CACHE_SEQLENS=0 to disable (escape hatch for
+// running against an older model.dll without the begin_compute export, or
+// for A/B measurement).
 //
 // Correctness depends on the EP-side MlirCustomOp::Compute() invoking
-// hipdnn_ep_runtime_begin_compute(state) at the start of each forward pass to
-// invalidate the cache. Older model.dlls without that symbol exported must
-// not enable this flag (the cache would survive across forward passes and
-// return stale total_seq values). See docs/decode-optimizations.md (F-A
-// section).
+// hipdnn_ep_runtime_begin_compute(state) at the start of each forward
+// pass to invalidate the cache. Older model.dlls without that symbol
+// exported are detected at session creation and produce a LOG(WARNING)
+// directing the user to set HIPDNN_EP_GQA_CACHE_SEQLENS=0 (otherwise the
+// cache would survive across forward passes and return stale total_seq
+// values).
 static bool gqa_cache_seqlens_enabled() {
   static const bool enabled = [] {
     const char *v = std::getenv("HIPDNN_EP_GQA_CACHE_SEQLENS");
-    return v && std::strcmp(v, "0") != 0;
+    // Default on; explicit "0" disables.
+    return !v || std::strcmp(v, "0") != 0;
   }();
   return enabled;
 }
@@ -114,8 +118,7 @@ static bool gqa_cache_seqlens_enabled() {
 // path of every iteration, so it loses to the GEMM-based decomposed path on
 // long sequences (measured ~12x slower at total_seq~=2048 on Strix Halo).
 //
-// Default 256 is a starter value pending the threshold sweep documented in
-// docs/decode-optimizations.md (smart-dispatch section). Set
+// Default 256 is a starter value pending a full threshold sweep. Set
 // HIPDNN_EP_GQA_FUSED_DECODE_MAX_T=N to override (or set a very large value
 // like 999999 to effectively disable smart-dispatch and preserve the
 // pre-smart-dispatch always-fused-when-eligible behaviour for A/B testing).
@@ -143,12 +146,13 @@ static int gqa_fused_decode_max_t() {
 // legacy per-call D2H readback site they already implement.
 static constexpr int32_t kSeqlensKNotRead = -2;
 
-// Read seqlens_k_val from device (or F-A cache) once per call before the
-// fused/decomposed dispatch decision. Two purposes:
+// Read seqlens_k_val from device (or the per-Compute() cache when
+// HIPDNN_EP_GQA_CACHE_SEQLENS=1) once per call before the fused/decomposed
+// dispatch decision. Two purposes:
 //   1. Give the smart-dispatch heuristic access to total_seq for the
 //      decode case (sq == 1) so it can compare against
 //      gqa_fused_decode_max_t().
-//   2. Populate the F-A per-Compute() cache for B == 1 so subsequent GQA
+//   2. Populate the per-Compute() cache for B == 1 so subsequent GQA
 //      layers within the same forward pass reuse the value with zero D2H.
 //
 // Applies to B == 1 regardless of sq (both prefill and decode share the
@@ -157,11 +161,11 @@ static constexpr int32_t kSeqlensKNotRead = -2;
 // requires reading every entry; the legacy readback site there handles it.
 //
 // Behaviour:
-//   - F-A enabled and cache hit:  zero D2H, return cached value.
-//   - F-A enabled and cache miss: one D2H + sync, populate cache, return.
-//   - F-A disabled:               one D2H + sync, return (no cache write).
+//   - cache enabled and hit:    zero D2H, return cached value.
+//   - cache enabled and miss:   one D2H + sync, populate cache, return.
+//   - cache disabled:           one D2H + sync, return (no cache write).
 //   - B != 1, !seqlens_k_ptr, or D2H/sync failure:
-//                                 return kSeqlensKNotRead.
+//                               return kSeqlensKNotRead.
 //
 // The returned int32_t is the raw device value: -1 is ORT's prefill
 // sentinel (callers map it to total_seq=sq, past_len=0); 0..max_seq is
@@ -470,15 +474,16 @@ static int gqa_forward_hipblaslt(
   // auto-tuned GEMMs outperform fixed WMMA tiling and all ORT GQA features
   // (sliding window, smooth softmax, head sink) are supported.
   //===--------------------------------------------------------------------===//
-  // Pre-dispatch read of seqlens_k (or F-A cache lookup for B==1).
-  // Applies to both prefill (sq>1) and decode (sq==1) for B==1 -- both
-  // share the same seqlens_k pointer and benefit from F-A caching. The
-  // result is reused by the fused-path need_host_past_len block
-  // (eliminating its inline D2H) and the decomposed-path readback site
-  // (consumed unconditionally instead of issuing its own D2H). On B>1
-  // this returns kSeqlensKNotRead and both downstream paths fall back to
-  // their legacy per-call reads. Stored in seqlens_k_pre; total_seq_pre
-  // is the derived total_seq (-1 means unknown / not applicable).
+  // Pre-dispatch read of seqlens_k (or per-Compute() cache lookup for B==1
+  // when HIPDNN_EP_GQA_CACHE_SEQLENS=1). Applies to both prefill (sq>1) and
+  // decode (sq==1) for B==1 -- both share the same seqlens_k pointer and
+  // benefit from caching. The result is reused by the fused-path
+  // need_host_past_len block (eliminating its inline D2H) and the
+  // decomposed-path readback site (consumed unconditionally instead of
+  // issuing its own D2H). On B>1 this returns kSeqlensKNotRead and both
+  // downstream paths fall back to their legacy per-call reads. Stored in
+  // seqlens_k_pre; total_seq_pre is the derived total_seq (-1 means
+  // unknown / not applicable).
   int32_t seqlens_k_pre =
       read_seqlens_k_for_dispatch(stream, seqlens_k_ptr, B, state);
   int64_t total_seq_pre = -1;
@@ -625,11 +630,11 @@ static int gqa_forward_hipblaslt(
 
   // D2H readback of seqlens_k is required here because hipBLASLt descriptor
   // creation and workspace sizing are host-side APIs that need total_seq.
-  // For B == 1 the value was already read (and F-A-cached) by the
-  // pre-dispatch helper above; we just consume seqlens_k_pre. The B > 1
-  // branch keeps the legacy per-call read because per-batch validation
-  // requires reading every entry and we have no validated multi-batch
-  // decode workload yet.
+  // For B == 1 the value was already read (and cached when
+  // HIPDNN_EP_GQA_CACHE_SEQLENS=1) by the pre-dispatch helper above; we
+  // just consume seqlens_k_pre. The B > 1 branch keeps the legacy per-call
+  // read because per-batch validation requires reading every entry and we
+  // have no validated multi-batch decode workload yet.
   int64_t total_seq = skv;
   int64_t past_len = skv - sq;
   if (seqlens_k_ptr) {

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -167,14 +167,13 @@ static constexpr int32_t kSeqlensKNotRead = -2;
 // sentinel (callers map it to total_seq=sq, past_len=0); 0..max_seq is
 // the live (total_seq - 1).
 static int32_t read_seqlens_k_for_dispatch(hipStream_t stream,
-                                           const void *seqlens_k_ptr,
-                                           int64_t B, RuntimeState *state) {
+                                           const void *seqlens_k_ptr, int64_t B,
+                                           RuntimeState *state) {
   if (!seqlens_k_ptr || B != 1) {
     return kSeqlensKNotRead;
   }
 
-  if (gqa_cache_seqlens_enabled() && state &&
-      state->seqlens_k_cached_valid &&
+  if (gqa_cache_seqlens_enabled() && state && state->seqlens_k_cached_valid &&
       state->seqlens_k_cached_ptr == seqlens_k_ptr) {
     return state->seqlens_k_cached_val;
   }
@@ -486,9 +485,8 @@ static int gqa_forward_hipblaslt(
   if (seqlens_k_pre != kSeqlensKNotRead) {
     // -1 is ORT's prefill sentinel: total_seq=sq, past_len=0. Real values
     // are 0..max_seq; total_seq = seqlens_k_val + 1.
-    total_seq_pre = (seqlens_k_pre < 0)
-                        ? sq
-                        : static_cast<int64_t>(seqlens_k_pre) + 1;
+    total_seq_pre =
+        (seqlens_k_pre < 0) ? sq : static_cast<int64_t>(seqlens_k_pre) + 1;
   }
 
   bool fused_d = (d == 64 || d == 128 || d == 256);

--- a/lib/Runtime/runtime_state_internal.h
+++ b/lib/Runtime/runtime_state_internal.h
@@ -70,20 +70,22 @@ struct RuntimeState {
   void *hipdnn_handle;
   void *hipdnn_graph_registry;
 
-  // F-A: Per-Compute() cache for seqlens_k_val (decode hot path).
+  // Per-Compute() cache for seqlens_k_val (decode hot path).
   //
   // Decode runs 32 GQA layers per token, all reading the same seqlens_k
   // from device memory. The decomposed-path readback in gqa.cpp issues a
   // hipMemcpyAsync(D2H) + hipStreamSynchronize per layer (31 redundant
   // pipeline stalls, ~30-45 ms/token on Strix Halo with the asym Llama
-  // sliding-window path). With HIPDNN_EP_GQA_CACHE_SEQLENS=1 the first
-  // GQA in a forward pass populates the cache and the remaining 31
-  // layers reuse it.
+  // sliding-window path). The cache is on by default
+  // (HIPDNN_EP_GQA_CACHE_SEQLENS=1, set to 0 to disable): the first GQA
+  // in a forward pass populates the cache and the remaining 31 layers
+  // reuse it.
   //
   // Invalidated by hipdnn_ep_runtime_begin_compute() at the start of each
   // Compute(), called from the EP-side MlirCustomOp::Compute() entry.
   // If the symbol is not exported (older model.dll), invalidation does
-  // not happen and the cache is unsafe -- the env var must remain unset.
+  // not happen and the cache is unsafe -- the EP logs a warning at
+  // session creation and the user must set HIPDNN_EP_GQA_CACHE_SEQLENS=0.
   bool seqlens_k_cached_valid;
   int32_t seqlens_k_cached_val;
   const void *seqlens_k_cached_ptr;

--- a/lib/Runtime/runtime_state_internal.h
+++ b/lib/Runtime/runtime_state_internal.h
@@ -69,6 +69,24 @@ struct RuntimeState {
   // cleaned up here)
   void *hipdnn_handle;
   void *hipdnn_graph_registry;
+
+  // F-A: Per-Compute() cache for seqlens_k_val (decode hot path).
+  //
+  // Decode runs 32 GQA layers per token, all reading the same seqlens_k
+  // from device memory. The decomposed-path readback in gqa.cpp issues a
+  // hipMemcpyAsync(D2H) + hipStreamSynchronize per layer (31 redundant
+  // pipeline stalls, ~30-45 ms/token on Strix Halo with the asym Llama
+  // sliding-window path). With HIPDNN_EP_GQA_CACHE_SEQLENS=1 the first
+  // GQA in a forward pass populates the cache and the remaining 31
+  // layers reuse it.
+  //
+  // Invalidated by hipdnn_ep_runtime_begin_compute() at the start of each
+  // Compute(), called from the EP-side MlirCustomOp::Compute() entry.
+  // If the symbol is not exported (older model.dll), invalidation does
+  // not happen and the cache is unsafe -- the env var must remain unset.
+  bool seqlens_k_cached_valid;
+  int32_t seqlens_k_cached_val;
+  const void *seqlens_k_cached_ptr;
 };
 
 #endif // HIPDNN_EP_RUNTIME_STATE_INTERNAL_H


### PR DESCRIPTION
## Summary

Three decode-perf changes that close ~70% of the asym Llama-3.1-8B AWQ gap to llama.cpp Vulkan on Strix Halo (gfx1151). The two GQA changes ship default-on; the perf instrumentation is opt-in.

- **GQA seqlens_k cache** (default on; `HIPDNN_EP_GQA_CACHE_SEQLENS=0` to disable). Caches `seqlens_k_val` once per forward pass: a 32-layer Llama decode issues 1 D2H instead of 32, eliminating ~30-45 ms/token of pipeline stalls. New `hipdnn_ep_runtime_begin_compute()` hook is exported from `model.dll` and called from `MlirCustomOp::Compute()` to invalidate the cache. Older `model.dll` without the hook triggers a `LOG(WARNING)` at session creation directing the user to set `=0`.
- **GQA smart-dispatch** (default on; `HIPDNN_EP_GQA_FUSED_DECODE_MAX_T=N` to tune, default 256). Routes decode to the decomposed hipBLASLt path when `total_seq > 256`. The fused decode kernel serializes over time with cross-wave reductions (~12x slower than GEMM-based decomposed at total_seq=2048). Short prompts stay on the fused fast path. `HIPDNN_EP_GQA_DISABLE_FUSED_DECODE=1` retained as a manual A/B override.
- **Per-`Compute()` perf instrumentation** (`HIPDNN_EP_PERF=1`, default off). CPU + GPU bracket timing around `inference_state_->compute()`. Emits `[PERF]` per call and `[PERF SUMMARY]` at unload, splitting wall / marshal / compute_cpu / gpu / fence_residual. ~25 us/call when on; zero overhead when off.

## Validation (Strix Halo gfx1151)

- Asym Llama-3.1-8B AWQ p=2048 m=16384: **9.66 -> 28.77 tok/s (+197%)** with this PR's defaults plus `OGA_USE_IO_BINDING=1`.
- Sym Llama-3.1-8B AWQ p=2048: +59.3% TPS from the OGA IoBinding optimization alone.
- `ctest` E2E: pass; no GQA fixture regressions.

The OGA IoBinding optimization lives in `fhanuman/onnxruntime-genai @ 36acb4a` and is pinned via the workflow `OGA_REPO`/`OGA_REF` (commented inline). Once the change lands upstream the pin reverts to the canonical AMD fork.

We need the following OGA changes to reproduce the performance numbers here:

https://github.com/AMDmoore/onnxruntime-genai/pull/10

Also, please see below confluence page for the benchmarking numbers:

https://amd.atlassian.net/wiki/spaces/AISW/pages/1667157596/Performance+improvements
