### PR TITLE
update ort to 1.25.1

### DIFF
--- a/.github/workflows/windows-build-mock.yml
+++ b/.github/workflows/windows-build-mock.yml
@@ -27,7 +27,7 @@ jobs:
       LLVM_TAG: llvm-22.1.0-release
       FLATBUFFERS_TAG: flatbuffers-25.12.19-release
       PROTO_TAG: protobuf-34.0-release
-      ONNXRUNTIME_VERSION: "1.24.3"
+      ONNXRUNTIME_VERSION: "1.25.1"
       GTEST_VERSION: "1.15.0"
       SCCACHE_GHA_ENABLED: "true"
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -31,7 +31,7 @@ jobs:
       LLVM_TAG: llvm-22.1.0-release
       FLATBUFFERS_TAG: flatbuffers-25.12.19-release
       PROTO_TAG: protobuf-34.0-release
-      ONNXRUNTIME_VERSION: "1.24.3"
+      ONNXRUNTIME_VERSION: "1.25.1"
       GTEST_VERSION: "1.15.0"
       THEROCK_VERSION: therock-dist-windows-gfx1151-7.11.0
       SCCACHE_GHA_ENABLED: "true"
@@ -196,7 +196,7 @@ jobs:
           cp "$DML_DLL" "${{ runner.workspace }}/prebuilt-local/bin/"
           # Cache the cp314 ORT Python wheel inside prebuilt-local so it
           # rides the same cache key as the rest of the ORT artifacts.
-          # Output path: build-onnxruntime/Release/dist/onnxruntime_directml-1.24.3-cp314-cp314-win_amd64.whl
+          # Output path: build-onnxruntime/Release/dist/onnxruntime_directml-1.25.1-cp314-cp314-win_amd64.whl
           ORT_WHEEL=$(find "${{ runner.workspace }}/build-onnxruntime" \
             -name "onnxruntime_directml-*.whl" -type f | head -1)
           if [ -z "$ORT_WHEEL" ]; then

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -76,8 +76,8 @@ FlatBuffers version conflicts (ORT bundles its own FlatBuffers).
 
 ```bash
 cd ..  # Go to workspace directory (parent of project root)
-# recommand use release branch, such as rel-1.24.3
-git clone -b rel-1.24.3 https://github.com/Microsoft/onnxruntime.git
+# recommand use release branch, such as rel-1.25.1
+git clone -b rel-1.25.1 https://github.com/Microsoft/onnxruntime.git
 cd onnxruntime
 ```
 


### PR DESCRIPTION
## Motivation

ORT 1.25.1 added some new ops from QW 3.5, and we need to update it to support this model.


## Test Plan

- [ ] Use ort:1.25.1 and perform regression testing in the model.

## Test Result



## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
