### PR TITLE
fix: restore stream_sync call in inference_compute

### DIFF
--- a/lib/Dialect/Transforms/GenerateInterface.cpp
+++ b/lib/Dialect/Transforms/GenerateInterface.cpp
@@ -446,6 +446,7 @@ private:
         {"hipdnn_ep_tensor_buffer_get_rank", i64, {ptr}},
         {"hipdnn_ep_tensor_buffer_get_size_bytes", i64, {ptr}},
         {"hipdnn_ep_state_init_with_fs", i32, {ptr, ptr, ptr, i64}},
+        {"hipdnn_ep_stream_sync", i32, {ptr}},
         {"hipdnn_ep_state_reset_error_flag", i32, {ptr}},
         {"hipdnn_ep_state_read_and_clear_error_flag", i32, {ptr}},
     };
@@ -667,7 +668,9 @@ private:
   ///     // 5. Call @main_graph(%state, %input_memrefs, %output_memrefs)
   ///     // 6. For each output: call hipdnn_ep_tensor_finalize_output,
   ///     error-check
-  ///     // 7. Free input TensorBuffers
+  ///     // 7. Call hipdnn_ep_stream_sync (GPU sync + PERF profiling output)
+  ///     // 8. Read device-side error flag
+  ///     // 9. Free input TensorBuffers
   ///     // On error: store error code, free inputs, return error
   ///   }
   void generateInferenceCompute(ModuleOp module, ArrayAttr inputShapes,
@@ -717,6 +720,8 @@ private:
         "hipdnn_ep_tensor_buffer_get_shape_ptr");
     auto resetErrorFlagFunc = module.lookupSymbol<LLVM::LLVMFuncOp>(
         "hipdnn_ep_state_reset_error_flag");
+    auto streamSyncFunc =
+        module.lookupSymbol<LLVM::LLVMFuncOp>("hipdnn_ep_stream_sync");
     auto readErrorFlagFunc = module.lookupSymbol<LLVM::LLVMFuncOp>(
         "hipdnn_ep_state_read_and_clear_error_flag");
 
@@ -879,6 +884,11 @@ private:
                            ValueRange{state, bufferPtr}, errorCodePtr,
                            errorCleanupBlock, funcOp);
     }
+
+    // Synchronize GPU stream after all D2H copies are queued. Also prints
+    // PERF phase timing and per-op profile when HIPDNN_EP_PERF is enabled.
+    emitErrorCheckedCall(builder, loc, streamSyncFunc, ValueRange{state},
+                         errorCodePtr, errorCleanupBlock, funcOp);
 
     // Read aggregated device-side runtime error flag (no extra hot-path sync in
     // operator wrappers; check occurs at interface boundary).

--- a/test/lit/Transforms/GenerateInterface/test_basic_interface.mlir
+++ b/test/lit/Transforms/GenerateInterface/test_basic_interface.mlir
@@ -35,6 +35,8 @@
 // CHECK:   llvm.call @hipdnn_ep_tensor_prepare_output
 // CHECK:   llvm.call @main_graph
 // CHECK:   llvm.call @hipdnn_ep_tensor_finalize_output
+// CHECK:   llvm.call @hipdnn_ep_stream_sync
+// CHECK:   llvm.call @hipdnn_ep_state_read_and_clear_error_flag
 
 // --- inference_cleanup calls state cleanup ---
 // CHECK-LABEL: llvm.func @inference_cleanup


### PR DESCRIPTION
## Summary
- The Range Op commit (c0a8d5e, #140) accidentally removed the \hipdnn_ep_stream_sync\ call from \GenerateInterface.cpp\, replacing it with only \hipdnn_ep_state_read_and_clear_error_flag\.
- This removed the only call site for \op_profile_resolve_and_print()\, causing per-operator GPU profiling data (\HIPDNN_EP_PERF=1\) to silently disappear -- events were recorded but never resolved or printed.
- Fix: restore \stream_sync\ before \ead_error_flag\ so both profiling output and error flag checking work correctly.

## Changes
- \lib/Dialect/Transforms/GenerateInterface.cpp\: Add \hipdnn_ep_stream_sync\ to runtime func declarations and emit the call in \inference_compute\ between finalize_output and read_error_flag.
- \	est/lit/Transforms/GenerateInterface/test_basic_interface.mlir\: Add CHECK lines for \stream_sync\ and \ead_and_clear_error_flag\ calls.

## Test plan
- [ ] LIT test \	est_basic_interface.mlir\ passes (verifies stream_sync is emitted)
- [ ] Run with \HIPDNN_EP_PERF=1\ and confirm per-op profiling data is printed after each inference

Made with [Cursor](https://cursor.com)