### PR TITLE
perf: skip autotune for QMoE matmul_nbits

### DIFF
--- a/3rd-party/custom_kernels/hip/matmul_nbits_kernel.hip
+++ b/3rd-party/custom_kernels/hip/matmul_nbits_kernel.hip
@@ -477,6 +477,11 @@ static int tuneGemvConfig(
     return best_id;
 }
 
+// Heuristic GEMV config: config 0 is the simplest safe default.
+static int pickDefaultGemvConfig() {
+    return 0;
+}
+
 static std::unordered_map<std::string, int> gemv_cache;
 static std::mutex gemv_tune_mutex;
 
@@ -494,7 +499,8 @@ static int getOrTuneGemvConfig(
     const __half* bi, __half* out,
     int64_t M, int64_t N, int64_t K,
     int64_t batch, int64_t bs,
-    bool col_major = false)
+    bool col_major = false,
+    bool skip_autotune = false)
 {
     std::string key = gemvCacheKey(M, N, K, bs, col_major);
 
@@ -504,14 +510,22 @@ static int getOrTuneGemvConfig(
     if (it != gemv_cache.end())
         return it->second;
 
-    int best = tuneGemvConfig(stream, A, B, sc, zp, bi, out,
+    int best;
+    if (skip_autotune) {
+        best = pickDefaultGemvConfig();
+        CUSTOM_KERNELS_DEBUG_LOG(
+            "[custom_kernels] GEMV heuristic: key=\"%s\" -> config[%d] "
+            "(skipped autotune)\n",
+            key.c_str(), best);
+    } else {
+        best = tuneGemvConfig(stream, A, B, sc, zp, bi, out,
                                M, N, K, batch, bs, col_major);
+        CUSTOM_KERNELS_DEBUG_LOG(
+            "[custom_kernels] GEMV cache: stored key=\"%s\" -> config[%d] "
+            "(cache size=%zu)\n",
+            key.c_str(), best, gemv_cache.size());
+    }
     gemv_cache[key] = best;
-
-    CUSTOM_KERNELS_DEBUG_LOG(
-        "[custom_kernels] GEMV cache: stored key=\"%s\" -> config[%d] "
-        "(cache size=%zu)\n",
-        key.c_str(), best, gemv_cache.size());
 
     return best;
 }
@@ -1334,6 +1348,15 @@ static std::string wmmaCacheKey(int M, int N, int K, int gs, bool has_zp) {
            (has_zp ? "1" : "0");
 }
 
+// Heuristic WMMA config selection: fused 128x128 swizzle_n=8 is a
+// reasonable middle-ground for most QMoE shapes (M~16-512, N=5760, K=2880).
+static int pickDefaultWmmaConfig(int M, int N) {
+    // Config 14 = {128, 128, 8, fused} — good balance for medium M
+    // Config 6  = { 64, 128, 8, fused} — better for smaller M
+    if (M <= 64) return 6;
+    return 14;
+}
+
 static int getOrTuneWmmaConfig(
     hipStream_t stream,
     int M, int N, int K,
@@ -1341,7 +1364,8 @@ static int getOrTuneWmmaConfig(
     const unsigned char* B,
     const _Float16* scales, const _Float16* zeros,
     int gs, int ngk,
-    _Float16* C, int ldc, bool has_zp)
+    _Float16* C, int ldc, bool has_zp,
+    bool skip_autotune = false)
 {
     std::string key = wmmaCacheKey(M, N, K, gs, has_zp);
 
@@ -1351,14 +1375,22 @@ static int getOrTuneWmmaConfig(
     if (it != wmma_cache.end())
         return it->second;
 
-    int best = tuneWmmaConfig(stream, M, N, K, A, lda, B,
+    int best;
+    if (skip_autotune) {
+        best = pickDefaultWmmaConfig(M, N);
+        CUSTOM_KERNELS_DEBUG_LOG(
+            "[custom_kernels] WMMA heuristic: key=\"%s\" -> config[%d] "
+            "(skipped autotune)\n",
+            key.c_str(), best);
+    } else {
+        best = tuneWmmaConfig(stream, M, N, K, A, lda, B,
                                scales, zeros, gs, ngk, C, ldc, has_zp);
+        CUSTOM_KERNELS_DEBUG_LOG(
+            "[custom_kernels] WMMA cache: stored key=\"%s\" -> config[%d] "
+            "(cache size=%zu)\n",
+            key.c_str(), best, wmma_cache.size());
+    }
     wmma_cache[key] = best;
-
-    CUSTOM_KERNELS_DEBUG_LOG(
-        "[custom_kernels] WMMA cache: stored key=\"%s\" -> config[%d] "
-        "(cache size=%zu)\n",
-        key.c_str(), best, wmma_cache.size());
 
     return best;
 }
@@ -1457,7 +1489,8 @@ extern "C" int hip_matmul_nbits(
     int64_t bits,
     int64_t block_size,
     int64_t element_size_bytes,
-    int64_t zp_elem_size) {
+    int64_t zp_elem_size,
+    int64_t skip_autotune) {
   if (bits != 4) {
     fprintf(stderr,
             "[custom_kernels] hip_matmul_nbits: only bits=4 supported, "
@@ -1501,6 +1534,7 @@ extern "C" int hip_matmul_nbits(
    * When M <  kBlockDim:      GEMV kernel with COL_MAJOR=true
    * ------------------------------------------------------------------- */
   bool wmma_data_format = (batch_count == 1) && (K % 32 == 0);
+  bool skip_at = (skip_autotune != 0);
 
   if (wmma_data_format && M >= kBlockDim) {
     CUSTOM_KERNELS_DEBUG_LOG(
@@ -1527,8 +1561,8 @@ extern "C" int hip_matmul_nbits(
 
     bool has_zp = (z_ptr != nullptr);
     int wmma_cfg = getOrTuneWmmaConfig(
-        hip_stream, iM, iN, iK, a_ptr, lda, b_ptr,
-        s_ptr, z_ptr, gs, ngk, out_ptr, ldc, has_zp);
+              hip_stream, iM, iN, iK, a_ptr, lda, b_ptr,
+              s_ptr, z_ptr, gs, ngk, out_ptr, ldc, has_zp, skip_at);
 
     _Float16* dq_buf = kWmmaConfigs[wmma_cfg].fused
                            ? nullptr : ensureDqBuffer(iN, iK);
@@ -1608,8 +1642,8 @@ extern "C" int hip_matmul_nbits(
     const auto* b_h = static_cast<const __half*>(bias);
 
     int config_id = getOrTuneGemvConfig(
-        hip_stream, a_col, b_u, s_h, z_u, b_h, o_col,
-        M, N, K, 1, block_size, /*col_major=*/true);
+              hip_stream, a_col, b_u, s_h, z_u, b_h, o_col,
+              M, N, K, 1, block_size, /*col_major=*/true, skip_at);
 
     launchGemvConfig(config_id, hip_stream,
                      a_col, b_u, s_h, z_u, b_h, o_col,
@@ -1661,8 +1695,9 @@ extern "C" int hip_matmul_nbits(
     auto*       o_h = static_cast<__half*>(output);
 
     int config_id = getOrTuneGemvConfig(
-        hip_stream, a_h, b_u, s_h, z_u, b_h, o_h,
-        M, N, K, batch_count, block_size);
+              hip_stream, a_h, b_u, s_h, z_u, b_h, o_h,
+              M, N, K, batch_count, block_size,
+              /*col_major=*/false, skip_at);
 
     launchGemvConfig(config_id, hip_stream,
                      a_h, b_u, s_h, z_u, b_h, o_h,

--- a/3rd-party/custom_kernels/include/hip_custom_kernels.h
+++ b/3rd-party/custom_kernels/include/hip_custom_kernels.h
@@ -487,7 +487,8 @@ int hip_matmul_nbits(
     int64_t bits,
     int64_t block_size,
     int64_t element_size_bytes,
-    int64_t zp_elem_size);  // 1=uint8 packed nibbles, 2=fp16
+    int64_t zp_elem_size,            // 1=uint8 packed nibbles, 2=fp16
+    int64_t skip_autotune);          // 0=autotune (default), 1=use heuristic
 
 /* =========================================================================
  * QMoE Sub-Kernels

--- a/docs/design/baseline-vs-approach-a-comparison.md
+++ b/docs/design/baseline-vs-approach-a-comparison.md
@@ -1,0 +1,199 @@
+<!--
+Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+Licensed under the MIT License.
+-->
+
+# Baseline vs Approach A: Per-Iteration Per-Chunk Comparison
+
+Test config: GPT-OSS-120B, gfx1151, chunk_size=512, prompt=2048 (4 chunks),
+`-r 5 -w 1`, `HIPDNN_EP_PERF=1`. All times in **milliseconds** (GPU time from op profiling).
+
+## 1. Per-Iteration Per-Chunk TOTAL GPU Time (ms)
+
+### Baseline
+
+| Iteration | Chunk 1 | Chunk 2 | Chunk 3 | Chunk 4 | **Sum (TTFT)** |
+|-----------|--------:|--------:|--------:|--------:|---------------:|
+| WARMUP | 50,935 | 18,618 | 16,171 | 31,916 | 117,641 |
+| iter 1 | 6,199 | 7,547 | 5,167 | 10,847 | **29,759** |
+| iter 2 | 5,776 | 6,800 | 9,205 | 8,569 | **30,349** |
+| iter 3 | 2,852 | 5,521 | 3,832 | 4,774 | **16,978** |
+| iter 4 | 2,575 | 4,302 | 9,855 | 6,689 | **23,420** |
+| iter 5 | 2,230 | 2,601 | 1,217 | 4,388 | **10,436** |
+| **Avg (1–5)** | **3,926** | **5,354** | **5,855** | **7,053** | **22,188** |
+| Stddev | 1,793 | 1,886 | 3,370 | 2,571 | 7,625 |
+
+### Approach A (skip_autotune)
+
+| Iteration | Chunk 1 | Chunk 2 | Chunk 3 | Chunk 4 | **Sum (TTFT)** |
+|-----------|--------:|--------:|--------:|--------:|---------------:|
+| WARMUP | 3,277 | 2,015 | 2,024 | 2,011 | 9,328 |
+| iter 1 | 1,836 | 2,024 | 2,001 | 1,953 | **7,815** |
+| iter 2 | 1,923 | 1,832 | 1,926 | 1,682 | **7,362** |
+| iter 3 | 1,962 | 1,929 | 1,984 | 1,554 | **7,429** |
+| iter 4 | 1,969 | 1,894 | 2,002 | 1,843 | **7,709** |
+| iter 5 | 1,771 | 1,765 | 1,836 | 1,828 | **7,199** |
+| **Avg (1–5)** | **1,892** | **1,889** | **1,950** | **1,772** | **7,503** |
+| Stddev | 80 | 95 | 66 | 149 | 227 |
+
+### Per-Chunk Speedup (avg)
+
+| | Chunk 1 | Chunk 2 | Chunk 3 | Chunk 4 | **Total** |
+|--|--------:|--------:|--------:|--------:|----------:|
+| Baseline avg | 3,926 | 5,354 | 5,855 | 7,053 | 22,188 |
+| Approach A avg | 1,892 | 1,889 | 1,950 | 1,772 | 7,503 |
+| **Speedup** | **2.1×** | **2.8×** | **3.0×** | **4.0×** | **3.0×** |
+
+Baseline gets slower from Chunk 1 → Chunk 4 because later chunks encounter
+new M values requiring additional autotune runs. Approach A is flat across
+all chunks (~1.8–1.95s) since heuristic selection has no warm-up cost.
+
+## 2. Decode TPS Per Iteration
+
+| Iteration | Baseline (ms/tok) | Baseline TPS | Approach A (ms/tok) | Approach A TPS |
+|-----------|------------------:|-------------:|--------------------:|---------------:|
+| WARMUP | 46.4 | 21.5 | 42.9 | 23.3 |
+| iter 1 | 45.9 | 21.8 | 42.5 | 23.5 |
+| iter 2 | 45.9 | 21.8 | 44.4 | 22.5 |
+| iter 3 | 45.9 | 21.8 | 44.4 | 22.5 |
+| iter 4 | 44.6 | 22.4 | 43.1 | 23.2 |
+| iter 5 | 44.5 | 22.5 | 42.4 | 23.6 |
+| **Avg (1–5)** | **45.4** | **22.0** | **43.4** | **23.1** |
+
+Decode TPS improves ~5% with Approach A. Decode calls QMoE with M=1 per
+expert; heuristic selection avoids the first-call autotune overhead.
+
+## 3. Op-Level Breakdown Per Chunk (avg over 5 measured iterations)
+
+### Chunk 1
+
+| Operator | Baseline GPU | B % | A GPU | A % | GPU Speedup |
+|----------|------------:|----:|------:|----:|------------:|
+| qmoe/fc1 | 2,814 | 71.7% | 1,573 | 83.1% | 1.8× |
+| qmoe/fc2 | 789 | 20.1% | 10 | 0.5% | **79×** |
+| qmoe/h2d | 140 | 3.6% | 128 | 6.8% | 1.1× |
+| qmoe/gather | 70 | 1.8% | 68 | 3.6% | 1.0× |
+| elementwise | 30 | 0.8% | 30 | 1.6% | 1.0× |
+| matmul (LM head) | 26 | 0.7% | 25 | 1.3% | 1.0× |
+| matmul_nbits (attn) | 21 | 0.5% | 19 | 1.0% | 1.1× |
+| qmoe/d2h_sync | 12 | 0.3% | 15 | 0.8% | 0.8× |
+| gemm (router) | 7 | 0.2% | 9 | 0.5% | — |
+| skip_layernorm | 6 | 0.1% | 6 | 0.3% | 1.0× |
+| qmoe/swiglu | 3 | 0.1% | 3 | 0.1% | 1.0× |
+| gqa | 3 | 0.1% | 3 | 0.2% | 1.0× |
+| qmoe/scatter | 2 | 0.1% | 2 | 0.1% | 1.0× |
+| **TOTAL** | **3,926** | **100%** | **1,892** | **100%** | **2.1×** |
+
+### Chunk 2
+
+| Operator | Baseline GPU | B % | A GPU | A % | GPU Speedup |
+|----------|------------:|----:|------:|----:|------------:|
+| qmoe/fc1 | 3,798 | 70.9% | 1,547 | 81.9% | 2.5× |
+| qmoe/fc2 | 1,221 | 22.8% | 10 | 0.5% | **122×** |
+| qmoe/h2d | 149 | 2.8% | 151 | 8.0% | 1.0× |
+| qmoe/gather | 70 | 1.3% | 67 | 3.6% | 1.0× |
+| elementwise | 30 | 0.6% | 31 | 1.6% | 1.0× |
+| matmul (LM head) | 26 | 0.5% | 25 | 1.3% | 1.0× |
+| matmul_nbits (attn) | 21 | 0.4% | 19 | 1.0% | 1.1× |
+| qmoe/d2h_sync | 14 | 0.3% | 13 | 0.7% | 1.1× |
+| gqa | 6 | 0.1% | 6 | 0.3% | 1.0× |
+| gemm (router) | 6 | 0.1% | 7 | 0.4% | — |
+| skip_layernorm | 6 | 0.1% | 6 | 0.3% | 1.0× |
+| qmoe/swiglu | 4 | 0.1% | 3 | 0.1% | 1.3× |
+| qmoe/scatter | 2 | 0.0% | 2 | 0.1% | 1.0× |
+| **TOTAL** | **5,354** | **100%** | **1,889** | **100%** | **2.8×** |
+
+### Chunk 3
+
+| Operator | Baseline GPU | B % | A GPU | A % | GPU Speedup |
+|----------|------------:|----:|------:|----:|------------:|
+| qmoe/fc1 | 4,177 | 71.3% | 1,615 | 82.8% | 2.6× |
+| qmoe/fc2 | 1,355 | 23.1% | 12 | 0.6% | **113×** |
+| qmoe/h2d | 137 | 2.3% | 139 | 7.1% | 1.0× |
+| qmoe/gather | 69 | 1.2% | 68 | 3.5% | 1.0× |
+| elementwise | 30 | 0.5% | 31 | 1.6% | 1.0× |
+| matmul (LM head) | 25 | 0.4% | 25 | 1.3% | 1.0× |
+| matmul_nbits (attn) | 21 | 0.4% | 19 | 1.0% | 1.1× |
+| qmoe/d2h_sync | 12 | 0.2% | 14 | 0.7% | 0.9× |
+| gqa | 8 | 0.1% | 8 | 0.4% | 1.0× |
+| gemm (router) | 6 | 0.1% | 7 | 0.3% | — |
+| skip_layernorm | 6 | 0.1% | 6 | 0.3% | 1.0× |
+| qmoe/swiglu | 4 | 0.1% | 3 | 0.1% | 1.3× |
+| qmoe/scatter | 2 | 0.0% | 2 | 0.1% | 1.0× |
+| **TOTAL** | **5,855** | **100%** | **1,950** | **100%** | **3.0×** |
+
+### Chunk 4
+
+| Operator | Baseline GPU | B % | A GPU | A % | GPU Speedup |
+|----------|------------:|----:|------:|----:|------------:|
+| qmoe/fc1 | 5,018 | 71.1% | 1,450 | 81.9% | 3.5× |
+| qmoe/fc2 | 1,704 | 24.2% | 11 | 0.6% | **155×** |
+| qmoe/h2d | 142 | 2.0% | 128 | 7.2% | 1.1× |
+| qmoe/gather | 69 | 1.0% | 64 | 3.6% | 1.1× |
+| elementwise | 30 | 0.4% | 30 | 1.7% | 1.0× |
+| matmul (LM head) | 26 | 0.4% | 25 | 1.4% | 1.0× |
+| matmul_nbits (attn) | 21 | 0.3% | 19 | 1.1% | 1.1× |
+| qmoe/d2h_sync | 14 | 0.2% | 14 | 0.8% | 1.0× |
+| gqa | 10 | 0.1% | 10 | 0.6% | 1.0× |
+| gemm (router) | 5 | 0.1% | 7 | 0.4% | — |
+| skip_layernorm | 6 | 0.1% | 6 | 0.3% | 1.0× |
+| qmoe/swiglu | 4 | 0.1% | 3 | 0.1% | 1.3× |
+| qmoe/scatter | 2 | 0.0% | 2 | 0.1% | 1.0× |
+| **TOTAL** | **7,053** | **100%** | **1,772** | **100%** | **4.0×** |
+
+## 4. QMoE Phase Summary (avg across all 4 chunks, measured iterations)
+
+| Phase | Baseline GPU | B % of Total | B % of QMoE | A GPU | A % of Total | A % of QMoE | Speedup |
+|-------|------------:|------------:|------------:|------:|------------:|------------:|--------:|
+| qmoe/fc1 | 3,952 | 71.3% | 72.5% | 1,545 | 82.2% | 86.8% | 2.6× |
+| qmoe/fc2 | 1,267 | 22.8% | 23.2% | 11 | 0.6% | 0.6% | **115×** |
+| qmoe/h2d | 142 | 2.6% | 2.6% | 137 | 7.3% | 7.7% | 1.0× |
+| qmoe/gather | 69 | 1.2% | 1.3% | 67 | 3.6% | 3.8% | 1.0× |
+| qmoe/d2h_sync | 13 | 0.2% | 0.2% | 14 | 0.7% | 0.8% | — |
+| qmoe/swiglu | 3 | 0.1% | 0.1% | 3 | 0.2% | 0.2% | 1.0× |
+| qmoe/scatter | 2 | 0.0% | 0.0% | 2 | 0.1% | 0.1% | 1.0× |
+| qmoe/alloc | 1 | 0.0% | 0.0% | 1 | 0.1% | 0.1% | 1.0× |
+| qmoe/topk | 1 | 0.0% | 0.0% | 1 | 0.1% | 0.1% | 1.0× |
+| **QMoE subtotal** | **5,450** | **98.2%** | **100%** | **1,780** | **94.8%** | **100%** | **3.1×** |
+| **TOTAL (all ops)** | **5,547** | **100%** | | **1,876** | **100%** | | **3.0×** |
+
+### fc1/fc2 Percentage Shift
+
+| | Baseline | Approach A |
+|--|--------:|----------:|
+| fc1 % of TOTAL | 71.3% | 82.2% |
+| fc2 % of TOTAL | 22.8% | 0.6% |
+| fc1+fc2 % of TOTAL | **94.1%** | **82.8%** |
+| fc1 : fc2 ratio | 3.1 : 1 | 140 : 1 |
+
+Baseline fc1+fc2 together account for 94% of total prefill time. After
+skip_autotune, fc2 drops to negligible (0.6%) because its actual compute
+is trivial — baseline fc2 was almost entirely autotune overhead. fc1
+remains dominant at 82% of total, now representing pure GPU compute.
+
+## 5. Observations
+
+1. **fc2 is the biggest winner** — 115× speedup because baseline fc2 spends
+   almost all its time in autotune (60+ configs × `hipEventSynchronize` per
+   unique M). With skip_autotune, fc2's actual compute is trivial (~10ms for
+   ~3200 calls across 36 layers).
+
+2. **fc1 improves 2.6× but is still the dominant cost** — even without
+   autotune, fc1 takes ~1.5s per chunk (83% of Approach A's total). fc1's
+   output dimension is 5760 (2× inter_size for SwiGLU) vs fc2's 2880.
+
+3. **Baseline later chunks are progressively slower** — Chunk 4 is 1.8× slower
+   than Chunk 1 because different expert-token distributions expose new M values
+   requiring additional autotune. Approach A chunks are uniformly ~1.9s.
+
+4. **TTFT variance eliminated** — Baseline stddev 7,625ms (34% of mean),
+   Approach A stddev 227ms (3% of mean). The autotune warm-up pattern is
+   non-deterministic across iterations.
+
+5. **Non-QMoE ops unchanged** — elementwise, matmul_nbits (attention),
+   skip_layernorm, gqa all show identical times, confirming the change is
+   isolated to QMoE.
+
+6. **h2d CPU is higher in Approach A** — because GPU finishes faster, the
+   profiling scope captures more CPU-side `hipMemcpyAsync` launch overhead.
+   GPU h2d time is the same (~130–150ms).

--- a/docs/design/qmoe-profiling-analysis.md
+++ b/docs/design/qmoe-profiling-analysis.md
@@ -1,0 +1,456 @@
+<!--
+Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+Licensed under the MIT License.
+-->
+
+# QMoE Profiling Analysis — GPT-OSS-120B on gfx1151
+
+## Test Configuration
+
+| Parameter | Value |
+|-----------|-------|
+| Model | GPT-OSS-120B (w-uint4-pergroup-asym-awq, fp16 activations) |
+| GPU | gfx1151 (RDNA 3.5) |
+| TheRock SDK | 7.11.0 |
+| Chunk size | 512 tokens |
+| Prompt | 2048 tokens (4 × 512 chunks) |
+| Generation | 128 tokens |
+| Profiling | `HIPDNN_EP_PERF=1` |
+
+### Model Architecture
+
+| Parameter | Value |
+|-----------|-------|
+| Layers | 36 |
+| Hidden size | 2880 |
+| Intermediate size | 2880 |
+| Experts | 128 per layer |
+| Top-k | 2 |
+| Query heads | 64, head dim 64 (total attention dim = 4096) |
+| KV heads | 8 (GQA ratio = 8) |
+| Vocab | 201,088 |
+| Weight quantization | 4-bit (MatMulNBits) for attention projections and expert FFNs |
+| Router | fp16 GEMM (not quantized) |
+
+## Per-Layer Operator Flow
+
+Each of the 36 transformer layers executes the following sequence:
+
+```
+Input
+  │
+  ├─► [1] skip_layernorm (pre-attention)
+  │     512×2880
+  │
+  ├─► [2] matmul_nbits — QKV projection
+  │     m=512, n=5120, k=2880
+  │     (Q=4096 + K=512 + V=512 = 5120, packed)
+  │
+  ├─► [3] gqa — Grouped Query Attention
+  │     batch=1, seq=512, kv_len=16384, heads=64, dim=64
+  │
+  ├─► [4] matmul_nbits — Output projection
+  │     m=512, n=2880, k=4096
+  │
+  ├─► [5] elementwise — Residual add
+  │     512×2880
+  │
+  ├─► [6] skip_layernorm (pre-MoE)
+  │     512×2880
+  │
+  ├─► [7] gemm — Router (fp16)
+  │     m=512, n=128, k=2880
+  │
+  ├─► [8] QMoE fused op ──────────────────────────────────
+  │     │
+  │     ├─ [8a] topk routing (GPU kernel)
+  │     ├─ [8b] D2H sync — copy expert assignments to host + hipStreamSynchronize
+  │     ├─ [8c] alloc — 8× hipMalloc for scratch buffers
+  │     │
+  │     └─ for each active expert (avg ~74 of 128):
+  │          ├─ [8d] H2D — upload token_ids + weights
+  │          ├─ [8e] gather — extract token subset from input
+  │          ├─ [8f] fc1 — matmul_nbits: [count, 2880] × [5760, 2880]ᵀ → [count, 5760]
+  │          ├─ [8g] swiglu — SiLU(gate) ⊙ up → [count, 2880]
+  │          ├─ [8h] fc2 — matmul_nbits: [count, 2880] × [2880, 2880]ᵀ → [count, 2880]
+  │          └─ [8i] scatter_add — weighted accumulate to output
+  │
+  └─► [9] elementwise — Residual add
+        512×2880
+```
+
+Final ops (executed once after all 36 layers):
+
+```
+  ├─► layernorm (final)           512×2880
+  └─► matmul (LM head, fp16)     m=512, n=201088, k=2880
+```
+
+## Prefill Profiling Results (First 512-Token Chunk)
+
+Total compute time: **31,362 ms**
+
+### Full Operator Breakdown
+
+| Operator | Calls | GPU (ms) | CPU (ms) | GPU % |
+|----------|------:|----------:|----------:|------:|
+| **qmoe/fc1** | 2669 | **20,973** | 20,228 | **68.9%** |
+| **qmoe/fc2** | 2669 | **7,762** | 7,801 | **25.5%** |
+| matmul_nbits (attention) | 72 | 1,278 | 1,250 | 4.2% |
+| — QKV: m=512,n=5120,k=2880 | 36 | 646 | 616 | 2.1% |
+| — O proj: m=512,n=2880,k=4096 | 36 | 632 | 634 | 2.1% |
+| gqa | 36 | 115 | 116 | 0.4% |
+| qmoe/h2d | 2669 | 102 | 1,571 | 0.3% |
+| qmoe/gather | 2669 | 53 | 5 | 0.2% |
+| qmoe/d2h_sync | 36 | 45 | 222 | 0.1% |
+| elementwise | 72 | 35 | 5 | 0.1% |
+| matmul (LM head) | 1 | 25 | 0.2 | 0.1% |
+| skip_layernorm | 72 | 13 | 10 | 0.0% |
+| qmoe/swiglu | 2669 | 11 | 5 | 0.0% |
+| layernorm | 1 | 11 | 10 | 0.0% |
+| gemm (router) | 36 | 7 | 3 | 0.0% |
+| qmoe/alloc | 36 | 3 | 7 | 0.0% |
+| qmoe/scatter | 2669 | 2 | 5 | 0.0% |
+| qmoe/topk | 36 | 1 | 1 | 0.0% |
+| **TOTAL** | | **30,450** | | |
+
+### QMoE Phase Summary
+
+| Phase | GPU (ms) | GPU % of QMoE | Note |
+|-------|----------:|--------------:|------|
+| fc1 (matmul_nbits) | 20,973 | 72.5% | n=5760 (2× inter for SwiGLU fusion) |
+| fc2 (matmul_nbits) | 7,762 | 26.8% | n=2880 |
+| h2d (per-expert) | 102 | 0.4% | 2669 small memcpy launches |
+| gather | 53 | 0.2% | |
+| d2h_sync | 45 | 0.2% | includes hipStreamSynchronize |
+| swiglu | 11 | 0.0% | |
+| alloc | 3 | 0.0% | |
+| scatter | 2 | 0.0% | |
+| topk | 1 | 0.0% | |
+| **Total QMoE** | **28,952** | **100%** | **95.1% of total prefill** |
+
+### fc1 Shape Distribution (Prefill, 512 Tokens)
+
+The 2669 fc1 calls span a wide range of `m` values (tokens per expert), from 1 to 217:
+
+| Tokens per expert (m) | Expert count | Typical GPU time per call |
+|-----------------------:|-------------:|--------------------------:|
+| 1–5 | ~800 | 0.2–0.6 ms |
+| 6–15 | ~700 | 0.8–4.0 ms |
+| 16–50 | ~600 | 4–9 ms |
+| 51–100 | ~300 | 60–70 ms |
+| 100–217 | ~50 | 70–340 ms |
+
+Most expert invocations have small `m` (few tokens), but the long tail of large experts dominates total time.
+
+## Decode Profiling Results (Single Token, Steady State)
+
+Total compute time: **~21.5 ms** per token (~14.5 tok/s)
+
+| Operator | Calls | GPU (ms) | CPU (ms) | GPU % |
+|----------|------:|----------:|----------:|------:|
+| matmul_nbits (attention) | 72 | 6.4 | 0.2 | 29.6% |
+| matmul (LM head) | 1 | 5.1 | 0.0 | 23.8% |
+| gqa | 36 | 3.8 | 1.7 | 17.9% |
+| qmoe/d2h_sync | 36 | 2.2 | 18.6 | 10.0% |
+| elementwise | 72 | 2.0 | 0.2 | 9.2% |
+| skip_layernorm | 72 | 1.0 | 0.6 | 4.8% |
+| qmoe/alloc | 36 | 0.8 | 0.5 | 3.4% |
+| gemm (router) | 36 | 0.0 | 0.6 | 0.1% |
+| qmoe/topk | 36 | 0.0 | 0.1 | 0.1% |
+| **TOTAL** | | **21.5** | | |
+
+In decode, QMoE fc1/fc2 are sub-millisecond per expert (m=1) and don't appear
+in the aggregated table. The bottleneck shifts to attention matmul_nbits (30%)
+and the LM head matmul (24%).
+
+Note: `qmoe/d2h_sync` has 2.2 ms GPU but **18.6 ms CPU** in decode — the
+`hipStreamSynchronize` blocks the CPU for 18.6 ms while waiting for prior GPU
+work to complete (topk routing + memcpy). This is the most expensive QMoE
+overhead in decode.
+
+## Key Observations
+
+1. **QMoE fc1 + fc2 account for 94.4% of prefill GPU time.** The `hip_matmul_nbits`
+   kernel is the sole bottleneck. All other operations combined are < 6%.
+
+2. **fc1 is 2.7× slower than fc2** because fc1's output dimension is 5760
+   (2 × inter_size, SwiGLU fusion packs gate and up projections) vs fc2's 2880.
+
+3. **GPU time ≈ CPU time** for fc1/fc2, indicating near-synchronous execution.
+   Root cause: the `hip_matmul_nbits` autotune mechanism benchmarks all
+   kernel configurations on first call per `(M,N,K,block_size)` shape.
+   QMoE produces ~100+ unique M values in a 512-token chunk, triggering
+   ~12,000 `hipEventSynchronize` calls during the first prefill chunk
+   (see "Root Cause Analysis" section below for details).
+
+4. **Expert loop is fully serial.** The current implementation iterates over
+   128 experts sequentially, calling `hip_matmul_nbits` individually for each.
+   With 512 tokens and k=2, approximately 74 experts are active per layer,
+   each processing an average of ~14 tokens (but highly variable: 1 to 217).
+
+5. **Per-expert H2D overhead** (`qmoe/h2d`): 102 ms GPU but **1,571 ms CPU**.
+   The 2669 small `hipMemcpyAsync` calls accumulate significant CPU-side launch
+   overhead (~0.6 ms each).
+
+6. **hipMalloc per layer** (`qmoe/alloc`): 36 calls × 8 allocations each. Only
+   2.5 ms GPU / 7 ms CPU — not a bottleneck currently, but unnecessary
+   repeated allocation on every layer invocation.
+
+## Benchmark Results: Baseline vs Approach A (skip_autotune)
+
+All benchmarks: `-r 5 -w 1` (5 measured iterations, 1 warmup), `HIPDNN_EP_PERF=1`,
+prompt=2048 tokens (4 × 512-token chunks), generation=128 tokens.
+
+**Approach A**: `skip_autotune=1` for QMoE fc1/fc2 calls only. Uses heuristic
+kernel selection (`pickDefaultWmmaConfig` / `pickDefaultGemvConfig`) instead of
+benchmarking all configs. Attention `matmul_nbits` unchanged (still autotunes).
+No `bucketM`.
+
+### High-Level Metrics
+
+| Metric | Baseline | Approach A | Speedup |
+|--------|--------:|-----------:|--------:|
+| TTFT avg (ms) | 22,188 | 7,503 | **3.0×** |
+| TTFT stddev (ms) | 7,625 | 227 | 33.6× more stable |
+| TTFT p50 (ms) | 23,420 | 7,429 | 3.2× |
+| Decode TPS (avg) | 22.0 | 23.1 | 1.05× |
+| Warmup TTFT (ms) | 117,641 | 9,328 | **12.6×** |
+| E2E avg (ms) | 40,623 | 26,470 | 1.5× |
+| Output quality | Coherent | Coherent | — |
+| Errors/NaN/Inf | None | None | — |
+
+### Per-Iteration TTFT (GPU time, ms)
+
+| Iteration | Baseline | Approach A |
+|-----------|--------:|-----------:|
+| WARMUP | 117,641 | 9,328 |
+| iter 1 | 29,759 | 7,815 |
+| iter 2 | 30,349 | 7,362 |
+| iter 3 | 16,978 | 7,429 |
+| iter 4 | 23,420 | 7,709 |
+| iter 5 | 10,436 | 7,199 |
+
+Baseline TTFT varies 10.4–30.3s due to autotune cache warming across
+iterations. Approach A is stable at 7.2–7.8s because heuristic selection
+is deterministic — no autotune overhead at all.
+
+### Per-Chunk TTFT Breakdown (avg over 5 measured iterations, ms)
+
+| Chunk | Baseline | Approach A | Speedup |
+|-------|--------:|-----------:|--------:|
+| Chunk 1 | 3,926 | 1,892 | 2.1× |
+| Chunk 2 | 5,354 | 1,889 | 2.8× |
+| Chunk 3 | 5,855 | 1,950 | 3.0× |
+| Chunk 4 | 7,053 | 1,772 | 4.0× |
+
+Baseline chunks get progressively slower because later chunks encounter
+new M values not yet in the autotune cache (different expert-token
+distributions per chunk). Approach A chunks are consistent (~1.8–1.9s)
+since no autotune occurs.
+
+### Op-Level Comparison (Chunk 1, avg over 5 iters)
+
+| Operator | Baseline GPU | Approach A GPU | Speedup |
+|----------|------------:|--------------:|--------:|
+| qmoe/fc1 | 2,814 ms | 1,573 ms | 1.8× |
+| qmoe/fc2 | 789 ms | 10 ms | **79×** |
+| qmoe/h2d | 140 ms | 128 ms | 1.1× |
+| qmoe/gather | 70 ms | 68 ms | 1.0× |
+| elementwise | 30 ms | 30 ms | 1.0× |
+| matmul (LM head) | 26 ms | 25 ms | 1.0× |
+| matmul_nbits (attn) | 21 ms | 19 ms | 1.1× |
+| qmoe/d2h_sync | 12 ms | 15 ms | 0.8× |
+| gemm (router) | 7 ms | 9 ms | 0.8× |
+| skip_layernorm | 6 ms | 6 ms | 1.0× |
+| qmoe/swiglu | 3 ms | 3 ms | 1.0× |
+| gqa | 3 ms | 3 ms | 1.0× |
+| qmoe/scatter | 2 ms | 2 ms | 1.0× |
+| **TOTAL** | **3,926** | **1,892** | **2.1×** |
+
+The fc2 79× speedup is because baseline fc2 runs autotune on ~100 unique
+M values (each running 60+ kernel configs × 6 launches). Approach A just
+runs the actual computation once per call.
+
+fc1 shows a smaller 1.8× improvement. In baseline, fc1 autotuning likely
+overlaps with fc2 (same M values already cached for fc1 by the time fc2
+runs). In Approach A, fc1 is the pure GPU compute time for 3218 expert
+calls.
+
+### CPU Time Analysis
+
+| Phase | Baseline CPU | Approach A CPU |
+|-------|------------:|---------------:|
+| qmoe/fc1 | 1,942 ms | **15 ms** |
+| qmoe/fc2 | 800 ms | **13 ms** |
+| qmoe/h2d | 2,024 ms | 3,029 ms |
+
+Baseline fc1/fc2 CPU time is high because `hipEventSynchronize` in autotune
+blocks the CPU. Approach A CPU is near-zero — pure async kernel launch overhead.
+
+h2d CPU is *higher* in Approach A (3,029 vs 2,024 ms) because the GPU
+finishes faster, making `hipMemcpyAsync` CPU overhead more visible in the
+profiling timeline.
+
+### Validation Summary
+
+| Check | Result |
+|-------|--------|
+| Errors in log (grep for error/ERROR/NaN/Inf) | **None** |
+| QMoE phases present in all 4 chunks × 5 iters | **Yes** |
+| Expert call counts (fc1 calls per chunk) | 3042–3254 (consistent with baseline 3208–3257) |
+| Output text quality | Coherent, same pattern as baseline |
+| Decode TPS | 23.1 (slightly better than baseline 22.0) |
+
+## Root Cause Analysis: CPU Time ≈ GPU Time in fc1/fc2
+
+### The Problem
+
+The profiling data shows CPU time nearly equals GPU time for `qmoe/fc1`
+(20,228 ms CPU vs 20,973 ms GPU) and `qmoe/fc2` (7,801 ms vs 7,762 ms).
+If kernel launches were truly asynchronous, CPU time would be a small fraction
+of GPU time (just launch overhead). Near-equality means the CPU blocks on
+almost every kernel launch.
+
+### Root Cause: Per-Shape Autotune with `hipEventSynchronize`
+
+The `hip_matmul_nbits` function
+(`3rd-party/custom_kernels/hip/matmul_nbits_kernel.hip`) has an autotune
+mechanism that benchmarks all kernel configurations on the first call for
+each unique `(M, N, K, block_size)` shape:
+
+**WMMA path** (M ≥ 16): `getOrTuneWmmaConfig()` — benchmarks **60+
+configurations**, each running 1 warmup + 5 timed iterations, with
+`hipEventSynchronize(ev1)` per config. That's ~360 kernel launches and
+~60 `hipEventSynchronize` calls per unique shape.
+
+**GEMV path** (M < 16): `getOrTuneGemvConfig()` — benchmarks **28
+configurations** with the same pattern. ~168 kernel launches and ~28
+`hipEventSynchronize` calls per unique shape.
+
+### Why QMoE Triggers Massive Autotune
+
+QMoE calls `hip_matmul_nbits` with varying `M = count` (tokens assigned
+to each expert). In a 512-token prefill chunk with 128 experts per layer:
+
+- `M` ranges from **1 to 217** across 2669 expert invocations
+- There are **~100+ unique M values** (see shape distribution)
+- fc1 shape `(M, 5760, 2880)` and fc2 shape `(M, 2880, 2880)` each
+  produce ~100 unique autotune keys
+- Total autotune overhead: ~200 unique shapes × (60 configs × 6 launches
+  × `hipEventSynchronize`) ≈ **~72,000 kernel launches + ~12,000
+  synchronization points** during the first prefill chunk
+
+The `hipEventSynchronize` calls are the critical bottleneck — each one
+blocks the CPU until the GPU completes all preceding work, destroying
+any pipeline parallelism.
+
+### GEMV Col-Major Path Adds Extra Overhead
+
+For experts with M < 16 (the majority — ~800 of 2669 calls have M ≤ 5),
+the GEMV col-major path additionally:
+
+1. Calls `ensureAColBuffer()` → may trigger `hipMalloc` on size change
+2. Launches `transpose2d_fp16_kernel` to convert A from row → col-major
+3. Launches the GEMV kernel
+4. Launches `transpose2d_fp16_kernel` again to convert output back
+
+These extra transpose kernels double the kernel launch count for small-M
+experts.
+
+### Global Static Buffers Cause Reallocation Churn
+
+`hip_matmul_nbits` uses global static buffers (`g_dq_buf`, `g_a_col_buf`,
+`g_out_col_buf`, `g_zp_fp16_buf`) that grow on demand via `hipMalloc`/
+`hipFree`. When QMoE alternates between experts with different M values,
+these buffers may need resizing, adding more synchronous GPU memory
+operations.
+
+### Summary
+
+| Factor | Impact |
+|--------|--------|
+| Per-shape autotune (hipEventSynchronize) | **Primary** — ~12,000 sync points in first chunk |
+| Extra transposes for M < 16 | **Moderate** — doubles kernel count for small experts |
+| Global buffer reallocation | **Minor** — only triggers on size increase |
+| Mutex lock in autotune cache | **Negligible** — QMoE is single-threaded |
+
+## Comparative Analysis: Attention matmul_nbits vs QMoE matmul_nbits
+
+Both attention projections and QMoE expert FFNs call the same
+`hip_matmul_nbits` function, which uses the same autotune mechanism.
+Both exhibit CPU ≈ GPU time:
+
+| Caller | Calls | GPU (ms) | CPU (ms) | CPU/GPU |
+|--------|------:|---------:|---------:|--------:|
+| matmul_nbits (attention) | 72 | 1,278 | 1,250 | 97.8% |
+| qmoe/fc1 | 2,669 | 20,973 | 20,228 | 96.4% |
+| qmoe/fc2 | 2,669 | 7,762 | 7,801 | 100.5% |
+
+The critical difference is the **number of unique shapes** that trigger
+autotune:
+
+### Attention matmul_nbits: 2 Unique Shapes
+
+Attention projections use fixed dimensions across all 36 layers:
+
+| Shape | Calls | Autotune runs |
+|-------|------:|--------------:|
+| QKV: m=512, n=5120, k=2880 | 36 | **1** (layer 0 only) |
+| O proj: m=512, n=2880, k=4096 | 36 | **1** (layer 0 only) |
+| **Total** | **72** | **2** |
+
+After layer 0 warms the cache, the remaining 70 calls across layers 1–35
+are all cache hits. The autotune cost is amortized over 72 calls.
+
+### QMoE matmul_nbits: ~200 Unique Shapes
+
+QMoE's `M = count` (tokens per expert) varies from 1 to 217. Each
+unique M value produces a distinct autotune cache key for both fc1 and fc2:
+
+| Shape family | N | K | Unique M values | Autotune runs |
+|-------------|---:|----:|----------------:|--------------:|
+| fc1 | 5,760 | 2,880 | ~100 | ~100 |
+| fc2 | 2,880 | 2,880 | ~100 | ~100 |
+| **Total** | | | | **~200** |
+
+The autotune cache (`matmul_nbits_kernel.hip` L480, L1328) is keyed by
+`"M_N_K_blocksize"` — identical N, K, block_size but different M values
+produce different keys:
+
+```
+"1_5760_2880_32_0"    → autotune (28 configs × hipEventSynchronize)
+"2_5760_2880_32_0"    → autotune
+"3_5760_2880_32_0"    → autotune
+...
+"217_5760_2880_32_0"  → autotune
+```
+
+### Autotune Cost Comparison
+
+| | Attention | QMoE |
+|--|--:|--:|
+| Total calls | 72 | 5,338 |
+| Unique shapes | 2 | ~200 |
+| Autotune runs | 2 | ~200 |
+| hipEventSynchronize (est.) | ~120 | **~12,000** |
+| Autotune kernel launches (est.) | ~720 | **~72,000** |
+| Autotune calls / total calls | 2.8% | 3.7% |
+
+Despite similar autotune-to-total-call ratios, the absolute count of
+synchronization points differs by **100×**. Each `hipEventSynchronize`
+blocks the CPU until the GPU completes all preceding work, making the
+autotune overhead the dominant cost in QMoE's prefill latency.
+
+### Additional Overhead: GEMV Col-Major Transpose
+
+For experts with M < 16 (~800 of 2669 calls), `hip_matmul_nbits` takes
+the GEMV col-major path which launches extra transpose kernels:
+
+1. `transpose2d_fp16_kernel`: A row-major → col-major (skipped for M=1)
+2. `matmul_nbits_gemv_kernel`: the actual GEMV
+3. `transpose2d_fp16_kernel`: output col-major → row-major (skipped for M=1)
+
+For M=2..15, each matmul_nbits call launches **3 kernels** instead of 1.
+Attention matmul_nbits (M=512) always takes the WMMA path and never
+needs transposes.

--- a/lib/Runtime/op_profile.h
+++ b/lib/Runtime/op_profile.h
@@ -94,6 +94,32 @@ struct OpProfileScope {
     }                                                                          \
   }
 
+// Sub-op profiling: call OP_PROFILE_INIT once at function top to extract
+// profiling state, then wrap each phase in a { OP_PROFILE_PHASE(...); ... }
+// block.  Each phase appears as a separate row in the profiling output.
+// Use block scopes so the same variable name can be reused across phases.
+#define OP_PROFILE_INIT(state_arg)                                             \
+  OpProfileState *_opProfPs = nullptr;                                         \
+  hipStream_t _opProfStream = nullptr;                                         \
+  do {                                                                         \
+    if (hipdnn_ep_perf_enabled()) {                                            \
+      _opProfPs = static_cast<OpProfileState *>(                               \
+          hipdnn_ep_state_get_op_profile(state_arg));                          \
+      _opProfStream =                                                          \
+          static_cast<hipStream_t>(hipdnn_ep_state_get_stream(state_arg));     \
+      if (!(_opProfPs && _opProfStream && op_profile_is_active(_opProfPs)))    \
+        _opProfPs = nullptr;                                                   \
+    }                                                                          \
+  } while (0)
+
+#define OP_PROFILE_PHASE(opname, shape_fn)                                     \
+  std::optional<OpProfileScope> _opProfPhase;                                  \
+  if (_opProfPs) {                                                             \
+    int _evIdx = op_profile_acquire_event_pair(_opProfPs);                     \
+    _opProfPhase.emplace(_opProfPs, opname, (shape_fn)(), _opProfStream,       \
+                         _evIdx);                                              \
+  }
+
 #define OP_PROFILE_CPU(opname, state_arg)                                      \
   std::optional<OpProfileCpuScope> _opProfCpu;                                 \
   if (hipdnn_ep_perf_enabled()) {                                              \

--- a/lib/Runtime/real/matmul_nbits.cpp
+++ b/lib/Runtime/real/matmul_nbits.cpp
@@ -55,7 +55,7 @@ int wrap_matmul_nbits(RuntimeState *state, const void *A, const void *B,
   int result = 0;
   HIP_CHECK(hip_matmul_nbits(stream, A, B, scales, zero_points, bias, output, M,
                              N, K, batch_count, bits, block_size, elem_size,
-                             zp_elem_size));
+                             zp_elem_size, /*skip_autotune=*/0));
 
 cleanup:
   return result;

--- a/lib/Runtime/real/qmoe.cpp
+++ b/lib/Runtime/real/qmoe.cpp
@@ -34,16 +34,17 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
               int64_t swiglu_fusion, int64_t activation_type,
               float activation_alpha, float activation_beta, float swiglu_limit,
               int64_t normalize_routing_weights, int64_t elem_size) {
-  OP_PROFILE(
-      "qmoe",
-      [&] {
-        char b[64];
-        snprintf(b, sizeof(b), "%lldx%lldx%lld,e=%lld", (long long)num_tokens,
-                 (long long)hidden_size, (long long)inter_size,
-                 (long long)num_experts);
-        return std::string(b);
-      },
-      state);
+  OP_PROFILE_INIT(state);
+
+  // Shape string reused across sub-phases
+  auto _qmoe_shape = [&] {
+    char b[64];
+    snprintf(b, sizeof(b), "%lldx%lldx%lld,e=%lld", (long long)num_tokens,
+             (long long)hidden_size, (long long)inter_size,
+             (long long)num_experts);
+    return std::string(b);
+  };
+
   if (router_weights) {
     fprintf(stderr, "wrap_qmoe: router_weights is not supported yet\n");
     return -1;
@@ -117,34 +118,43 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
   void *d_token_ids = nullptr;
   void *d_token_wts = nullptr;
 
-  HIP_CHECK(hipMalloc(&d_expert_indices, num_tokens * k * sizeof(int32_t)));
-  HIP_CHECK(hipMalloc(&d_expert_weights, num_tokens * k * elem_size));
-  HIP_CHECK(hipMalloc(&d_gather_buf, num_tokens * hidden_size * elem_size));
-  HIP_CHECK(hipMalloc(&d_fc1_buf, num_tokens * fusion_inter * elem_size));
-  HIP_CHECK(hipMalloc(&d_act_buf, num_tokens * inter_size * elem_size));
-  HIP_CHECK(hipMalloc(&d_fc2_buf, num_tokens * hidden_size * elem_size));
-  HIP_CHECK(hipMalloc(&d_token_ids, num_tokens * sizeof(int32_t)));
-  HIP_CHECK(hipMalloc(&d_token_wts, num_tokens * elem_size));
+  {
+    OP_PROFILE_PHASE("qmoe/alloc", _qmoe_shape);
+    HIP_CHECK(hipMalloc(&d_expert_indices, num_tokens * k * sizeof(int32_t)));
+    HIP_CHECK(hipMalloc(&d_expert_weights, num_tokens * k * elem_size));
+    HIP_CHECK(hipMalloc(&d_gather_buf, num_tokens * hidden_size * elem_size));
+    HIP_CHECK(hipMalloc(&d_fc1_buf, num_tokens * fusion_inter * elem_size));
+    HIP_CHECK(hipMalloc(&d_act_buf, num_tokens * inter_size * elem_size));
+    HIP_CHECK(hipMalloc(&d_fc2_buf, num_tokens * hidden_size * elem_size));
+    HIP_CHECK(hipMalloc(&d_token_ids, num_tokens * sizeof(int32_t)));
+    HIP_CHECK(hipMalloc(&d_token_wts, num_tokens * elem_size));
+  }
 
   RUNTIME_DEBUG_LOG("[REAL] wrap_qmoe: topk_routing(tokens=%lld, experts=%lld, "
                     "k=%lld, normalize=%lld)\n",
                     (long long)num_tokens, (long long)num_experts, (long long)k,
                     (long long)normalize_routing_weights);
-  HIP_CHECK(hip_qmoe_topk_routing(stream, router_probs, d_expert_indices,
-                                  d_expert_weights, num_tokens, num_experts, k,
-                                  normalize_routing_weights, elem_size));
+  {
+    OP_PROFILE_PHASE("qmoe/topk", _qmoe_shape);
+    HIP_CHECK(hip_qmoe_topk_routing(stream, router_probs, d_expert_indices,
+                                    d_expert_weights, num_tokens, num_experts, k,
+                                    normalize_routing_weights, elem_size));
+  }
 
   {
     std::vector<int32_t> h_indices(num_tokens * k);
     std::vector<char> h_weights(num_tokens * k * elem_size);
 
-    HIP_CHECK(hipMemcpyAsync(h_indices.data(), d_expert_indices,
-                             num_tokens * k * sizeof(int32_t),
-                             hipMemcpyDeviceToHost, hip_stream));
-    HIP_CHECK(hipMemcpyAsync(h_weights.data(), d_expert_weights,
-                             num_tokens * k * elem_size, hipMemcpyDeviceToHost,
-                             hip_stream));
-    HIP_CHECK(hipStreamSynchronize(hip_stream));
+    {
+      OP_PROFILE_PHASE("qmoe/d2h_sync", _qmoe_shape);
+      HIP_CHECK(hipMemcpyAsync(h_indices.data(), d_expert_indices,
+                               num_tokens * k * sizeof(int32_t),
+                               hipMemcpyDeviceToHost, hip_stream));
+      HIP_CHECK(hipMemcpyAsync(h_weights.data(), d_expert_weights,
+                               num_tokens * k * elem_size,
+                               hipMemcpyDeviceToHost, hip_stream));
+      HIP_CHECK(hipStreamSynchronize(hip_stream));
+    }
 
     std::vector<std::vector<TokenEntry>> expert_tokens(num_experts);
     for (int64_t t = 0; t < num_tokens; t++) {
@@ -185,16 +195,31 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
                elem_size);
       }
 
-      HIP_CHECK(hipMemcpyAsync(d_token_ids, h_ids.data(),
-                               count * sizeof(int32_t), hipMemcpyHostToDevice,
-                               hip_stream));
-      HIP_CHECK(hipMemcpyAsync(d_token_wts, h_wts_e.data(), count * elem_size,
-                               hipMemcpyHostToDevice, hip_stream));
+      auto _expert_shape = [&] {
+        char b[96];
+        snprintf(b, sizeof(b), "e=%lld,t=%lld,%lldx%lld", (long long)e,
+                 (long long)count, (long long)count, (long long)hidden_size);
+        return std::string(b);
+      };
+
+      {
+        OP_PROFILE_PHASE("qmoe/h2d", _expert_shape);
+        HIP_CHECK(hipMemcpyAsync(d_token_ids, h_ids.data(),
+                                 count * sizeof(int32_t), hipMemcpyHostToDevice,
+                                 hip_stream));
+        HIP_CHECK(hipMemcpyAsync(d_token_wts, h_wts_e.data(),
+                                 count * elem_size, hipMemcpyHostToDevice,
+                                 hip_stream));
+      }
 
       RUNTIME_DEBUG_LOG("[REAL] wrap_qmoe: expert %lld: %lld tokens - gather\n",
                         (long long)e, (long long)count);
-      HIP_CHECK(hip_qmoe_gather_tokens(stream, input, d_gather_buf, d_token_ids,
-                                       hidden_size, count, elem_size));
+      {
+        OP_PROFILE_PHASE("qmoe/gather", _expert_shape);
+        HIP_CHECK(hip_qmoe_gather_tokens(stream, input, d_gather_buf,
+                                         d_token_ids, hidden_size, count,
+                                         elem_size));
+      }
 
       const char *fc1_w_e = static_cast<const char *>(fc1_weights) +
                             e * fusion_inter * k_blocks_fc1 * blob_size_fc1;
@@ -224,19 +249,36 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
                         "[%lld x %lld] -> [%lld x %lld]\n",
                         (long long)e, (long long)count, (long long)hidden_size,
                         (long long)count, (long long)fusion_inter);
-      HIP_CHECK(hip_matmul_nbits(stream, d_gather_buf, fc1_w_e, fc1_s_e,
-                                 fc1_zp_e, fc1_b_e, d_fc1_buf, count,
-                                 fusion_inter, hidden_size, 1,
-                                 expert_weight_bits, block_size, elem_size,
-                                 /*zp_elem_size=*/1));
+      {
+        auto _fc1_shape = [&] {
+          char b[96];
+          snprintf(b, sizeof(b), "m=%lld,n=%lld,k=%lld", (long long)count,
+                   (long long)fusion_inter, (long long)hidden_size);
+          return std::string(b);
+        };
+        OP_PROFILE_PHASE("qmoe/fc1", _fc1_shape);
+        HIP_CHECK(hip_matmul_nbits(stream, d_gather_buf, fc1_w_e, fc1_s_e,
+                                   fc1_zp_e, fc1_b_e, d_fc1_buf, count,
+                                   fusion_inter, hidden_size, 1,
+                                   expert_weight_bits, block_size, elem_size,
+                                   /*zp_elem_size=*/1,
+                                   /*skip_autotune=*/1));
+      }
 
       RUNTIME_DEBUG_LOG("[REAL] wrap_qmoe: expert %lld: swiglu(alpha=%.3f, "
                         "beta=%.3f, limit=%.1f)\n",
                         (long long)e, (double)activation_alpha,
                         (double)activation_beta, (double)swiglu_limit);
-      HIP_CHECK(hip_qmoe_swiglu(stream, d_fc1_buf, d_act_buf, count, inter_size,
-                                activation_alpha, activation_beta, swiglu_limit,
-                                elem_size));
+      {
+        OP_PROFILE_PHASE("qmoe/swiglu", [&] {
+          char b[64];
+          snprintf(b, sizeof(b), "n=%lld", (long long)inter_size);
+          return std::string(b);
+        });
+        HIP_CHECK(hip_qmoe_swiglu(stream, d_fc1_buf, d_act_buf, count,
+                                  inter_size, activation_alpha, activation_beta,
+                                  swiglu_limit, elem_size));
+      }
 
       const char *fc2_w_e = static_cast<const char *>(fc2_weights) +
                             e * hidden_size * k_blocks_fc2 * blob_size_fc2;
@@ -255,16 +297,30 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
                         "[%lld x %lld] -> [%lld x %lld]\n",
                         (long long)e, (long long)count, (long long)inter_size,
                         (long long)count, (long long)hidden_size);
-      HIP_CHECK(hip_matmul_nbits(stream, d_act_buf, fc2_w_e, fc2_s_e, fc2_zp_e,
-                                 fc2_b_e, d_fc2_buf, count, hidden_size,
-                                 inter_size, 1, expert_weight_bits, block_size,
-                                 elem_size, /*zp_elem_size=*/1));
+      {
+        auto _fc2_shape = [&] {
+          char b[96];
+          snprintf(b, sizeof(b), "m=%lld,n=%lld,k=%lld", (long long)count,
+                   (long long)hidden_size, (long long)inter_size);
+          return std::string(b);
+        };
+        OP_PROFILE_PHASE("qmoe/fc2", _fc2_shape);
+        HIP_CHECK(hip_matmul_nbits(stream, d_act_buf, fc2_w_e, fc2_s_e,
+                                   fc2_zp_e, fc2_b_e, d_fc2_buf, count,
+                                   hidden_size, inter_size, 1,
+                                   expert_weight_bits, block_size, elem_size,
+                                   /*zp_elem_size=*/1,
+                                   /*skip_autotune=*/1));
+      }
 
       RUNTIME_DEBUG_LOG("[REAL] wrap_qmoe: expert %lld: scatter_add\n",
                         (long long)e);
-      HIP_CHECK(hip_qmoe_scatter_add(stream, output, d_fc2_buf, d_token_ids,
-                                     d_token_wts, hidden_size, count,
-                                     elem_size));
+      {
+        OP_PROFILE_PHASE("qmoe/scatter", _expert_shape);
+        HIP_CHECK(hip_qmoe_scatter_add(stream, output, d_fc2_buf, d_token_ids,
+                                       d_token_wts, hidden_size, count,
+                                       elem_size));
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Add heuristic kernel selection (`skip_autotune`) for QMoE fc1/fc2 `matmul_nbits` calls, bypassing per-shape autotuning
- Add QMoE sub-phase profiling (fc1, fc2, h2d, gather, swiglu, scatter, etc.)
- Add `OP_PROFILE_INIT`/`OP_PROFILE_PHASE` macros for sub-operator profiling

## Results (GPT-OSS-120B, gfx1151, 2048-token prompt, -r 5)

| Metric | Baseline | Approach A | Speedup |
|--------|--------:|-----------:|--------:|
| TTFT avg (ms) | 22,188 | 7,503 | 3.0x |
| TTFT stddev (ms) | 7,625 | 227 | 33.6x more stable |
| Decode TPS | 22.0 | 23.1 | 1.05x |
| Warmup TTFT (ms) | 117,641 | 9,328 | 12.6x |

See `docs/design/baseline-vs-approach-a-comparison.md` for full per-iteration per-chunk data.

## Test plan

- [x] Run baseline -r 5 with PERF=1, verify output correctness
- [x] Run Approach A -r 5 with PERF=1, verify output correctness
- [x] Verify no errors/NaN/Inf in logs
- [x] Verify all QMoE phases present in all chunks and iterations
- [x] Verify expert call counts consistent between baseline and Approach A
- [ ] Run with PERF=0 to measure true TTFT without profiling overhead
- [ ] LIT tests pass
