### PR TITLE
feat(matmul_nbits): add naive bits=8 path

### DIFF
--- a/3rd-party/custom_kernels/hip/matmul_nbits_kernel.hip
+++ b/3rd-party/custom_kernels/hip/matmul_nbits_kernel.hip
@@ -101,6 +101,67 @@ __global__ void matmul_nbits_kernel(
 }
 
 /* =======================================================================
+ * Section 1a: Naive int8 fallback kernel (row-major, any alignment, batched)
+ *
+ * ONNX MatMulNBits with bits=8 layout (no nibble packing):
+ *   B      : uint8 [N, K]                     (1 byte per weight)
+ *   scales : fp16  [N, num_groups_k]
+ *   zeros  : uint8 [N, num_groups_k]          (or NULL, default zp=128)
+ *
+ * Dequant per element:
+ *   w_fp = (uint8_w - zp) * scale
+ *
+ * Each thread computes one C[m, n] across all batches via blockIdx.z.
+ * Mirrors matmul_nbits_kernel (int4) so behaviour and debug shape are
+ * symmetric; chosen as the first int8 path because it has no alignment
+ * or shape constraints and immediately unblocks Qwen3.5-style models
+ * that mix bits=4 and bits=8 in the same graph.
+ * ======================================================================= */
+
+__global__ void matmul_nbits_kernel_i8(
+    const __half* __restrict__ A,
+    const uint8_t* __restrict__ B,
+    const __half* __restrict__ scales,
+    const uint8_t* __restrict__ zp,
+    const __half* __restrict__ bias,
+    __half* __restrict__ output,
+    int64_t M, int64_t N, int64_t K,
+    int64_t block_size) {
+  int64_t n = static_cast<int64_t>(blockIdx.x) * kBlockDim + threadIdx.x;
+  int64_t m = static_cast<int64_t>(blockIdx.y) * kBlockDim + threadIdx.y;
+  int64_t batch = blockIdx.z;
+
+  if (m >= M || n >= N) return;
+
+  int64_t k_blocks = (K + block_size - 1) / block_size;
+
+  float acc = 0.0f;
+  const __half*  a_row = A + batch * M * K + m * K;
+  const uint8_t* b_row = B + n * K;
+  const __half*  s_row = scales + n * k_blocks;
+
+  for (int64_t blk = 0; blk < k_blocks; blk++) {
+    float scale_val = static_cast<float>(s_row[blk]);
+    float zp_val    = (zp != nullptr)
+                          ? static_cast<float>(zp[n * k_blocks + blk])
+                          : 128.0f;
+
+    int64_t k_start = blk * block_size;
+    int64_t k_end   = k_start + block_size;
+    if (k_end > K) k_end = K;
+    const uint8_t* b_block = b_row + k_start;
+
+    for (int64_t k = k_start; k < k_end; k++) {
+      float qval = static_cast<float>(b_block[k - k_start]);
+      acc += static_cast<float>(a_row[k]) * (qval - zp_val) * scale_val;
+    }
+  }
+
+  if (bias) acc += static_cast<float>(bias[n]);
+  output[batch * M * N + m * N + n] = static_cast<__half>(acc);
+}
+
+/* =======================================================================
  * Section 1b: GEMV-style kernel for small M (autotuned, vectorized)
  *
  * Template parameters:
@@ -1458,10 +1519,10 @@ extern "C" int hip_matmul_nbits(
     int64_t block_size,
     int64_t element_size_bytes,
     int64_t zp_elem_size) {
-  if (bits != 4) {
+  if (bits != 4 && bits != 8) {
     fprintf(stderr,
-            "[custom_kernels] hip_matmul_nbits: only bits=4 supported, "
-            "got %lld\n",
+            "[custom_kernels] hip_matmul_nbits: only bits=4 or bits=8 "
+            "supported, got %lld\n",
             (long long)bits);
     return -1;
   }
@@ -1477,6 +1538,52 @@ extern "C" int hip_matmul_nbits(
   }
 
   hipStream_t hip_stream = static_cast<hipStream_t>(stream);
+
+  /* -------------------------------------------------------------------
+   * bits=8 path: ONNX MatMulNBits with int8 weights uses an unpacked
+   * [N, K] uint8 layout (no nibble packing) and default zp=128. None of
+   * the bit-twiddling int4 fast paths apply, so dispatch directly to
+   * the dedicated int8 naive kernel. Models that mix bits=4 and bits=8
+   * in the same graph (e.g. Qwen3.5-MoE int8 lm_head with int4 expert
+   * weights) hit this branch only for the int8 ops; the int4 ops
+   * continue through the WMMA / GEMV fast paths below.
+   * ------------------------------------------------------------------- */
+  if (bits == 8) {
+    if (zero_points && zp_elem_size != 1) {
+      fprintf(stderr,
+              "[custom_kernels] hip_matmul_nbits bits=8: zero_points must "
+              "be uint8 (zp_elem_size=1), got zp_elem_size=%lld\n",
+              (long long)zp_elem_size);
+      return -1;
+    }
+    CUSTOM_KERNELS_DEBUG_LOG(
+        "[custom_kernels] hip_matmul_nbits: int8 naive M=%lld N=%lld K=%lld "
+        "batch=%lld bs=%lld zp=%s bias=%s\n",
+        (long long)M, (long long)N, (long long)K, (long long)batch_count,
+        (long long)block_size, zero_points ? "yes" : "null",
+        bias ? "yes" : "null");
+
+    dim3 blk(kBlockDim, kBlockDim);
+    dim3 grd(static_cast<unsigned>((N + kBlockDim - 1) / kBlockDim),
+             static_cast<unsigned>((M + kBlockDim - 1) / kBlockDim),
+             static_cast<unsigned>(batch_count));
+
+    hipLaunchKernelGGL(
+        matmul_nbits_kernel_i8, grd, blk, 0, hip_stream,
+        static_cast<const __half*>(A), static_cast<const uint8_t*>(B),
+        static_cast<const __half*>(scales),
+        static_cast<const uint8_t*>(zero_points),
+        static_cast<const __half*>(bias), static_cast<__half*>(output),
+        M, N, K, block_size);
+
+    hipError_t err = hipGetLastError();
+    if (err != hipSuccess) {
+      fprintf(stderr,
+              "[custom_kernels] hip_matmul_nbits int8 launch failed: %s\n",
+              hipGetErrorString(err));
+    }
+    return static_cast<int>(err);
+  }
 
   // Convert uint8 packed nibble zero_points to FP16 for WMMA/GEMV-col-major
   // paths which require FP16 zero_points. Row-major GEMV and naive fallback

--- a/3rd-party/custom_kernels/include/hip_custom_kernels.h
+++ b/3rd-party/custom_kernels/include/hip_custom_kernels.h
@@ -450,18 +450,25 @@ int hip_range(
  * MatMulNBits (Fused Dequant + MatMul)
  * =========================================================================
  *
- * Computes Y = A @ dequant(B)^T + bias, where B holds packed int4 weights.
+ * Computes Y = A @ dequant(B)^T + bias, where B holds packed quantized
+ * weights.  Supports bits=4 (packed nibbles) and bits=8 (1 byte per
+ * weight); other widths return an error.
  *
  * Dequantization (per-block): dequant = (quant_val - zero_point) * scale
  * For 4-bit: lower nibble = first value, upper nibble = second.
- * Default zero_point = 8 (when zero_points is NULL).
+ *            Default zero_point = 8 (when zero_points is NULL).
+ * For 8-bit: B is unpacked uint8 of shape [N, K]; zero_points (when
+ *            provided) is uint8 [N, k_blocks]; default zero_point = 128.
  *
  * Parameters:
  *   stream             - hipStream_t cast to void*
  *   A                  - GPU [batch, M, K]
- *   B                  - GPU [N, k_blocks, blob_size] uint8 packed int4
+ *   B                  - GPU packed weights:
+ *                          bits=4: [N, k_blocks, blob_size] uint8 packed int4
+ *                          bits=8: [N, K] uint8 (no packing)
  *   scales             - GPU [N, k_blocks] (same type as A)
- *   zero_points        - GPU [N, k_blocks] uint8 (nullable, default zp=8)
+ *   zero_points        - GPU [N, k_blocks] uint8 (nullable; default zp=8
+ *                        for bits=4, zp=128 for bits=8)
  *   bias               - GPU [N] (nullable, same type as A)
  *   output             - GPU [batch, M, N]
  *   M                  - rows per batch


### PR DESCRIPTION
## Summary

- Add a naive `bits=8` path to `MatMulNBits` so models that mix `bits=4`
  and `bits=8` ops in the same graph (e.g. Qwen3.5-35B-A3B
  `int4_rtn_128gs`, where 150 of the `MatMulNBits` ops use `bits=8`,
  and Qwen3.5-9B-rtn-int4-int8-128gs, where 192 of 249 ops use
  `bits=8`) no longer fail at runtime with the previous `bits != 4`
  reject.
- The `bits=4` fast paths (WMMA / GEMV / hipBLASLt) are completely
  untouched: `bits=8` is dispatched in an early-exit block at the top
  of `hip_matmul_nbits`, so existing `bits=4` models keep their
  autotuned behaviour bit-for-bit.
- Naive-first by design: ONNX `bits=8` stores `B` as unpacked `uint8
  [N, K]` with default zero point 128, which doesn't match any of the
  packed-nibble fast-path layouts. A dedicated naive int8 kernel is
  the smallest correct change that unblocks Qwen3.5-style mixed-bit
  models; faster int8 paths can layer on top later.

## Changes Overview

`3rd-party/custom_kernels/hip/matmul_nbits_kernel.hip`
- New `matmul_nbits_kernel_i8` mirroring `matmul_nbits_kernel`
  (the existing int4 naive kernel): row-major, any-alignment,
  batched via `blockIdx.z`, fp32 accumulation, optional bias,
  optional per-block `uint8` zero points (default 128 when
  `zero_points` is null). `B` layout is `[N, k_blocks, block_size]`
  `uint8` with no nibble packing.
- Relax the launcher gate from `bits != 4` to
  `bits != 4 && bits != 8`.
- New `if (bits == 8)` early-exit block at the top of
  `hip_matmul_nbits` that:
  - Validates `zp_elem_size == 1` when `zero_points` is provided.
  - Launches `matmul_nbits_kernel_i8` with the same `kBlockDim`
    grid layout the int4 fallback uses.
  - Logs a `[custom_kernels] hip_matmul_nbits: int8 naive ...` line
    so the dispatch path is visible during runtime debugging.

`3rd-party/custom_kernels/include/hip_custom_kernels.h`
- Update the `MatMulNBits` API header doc to spell out the dual
  `bits=4` / `bits=8` contract: differing `B` layout (packed vs
  unpacked) and differing default zero point (8 vs 128).

## Test plan

- Build verified.
- Numeric precision tests passed: 18 new `bits=8` cases pinning every
  canonical 8-bit shape observed in two real Qwen3.5 model variants:
  - Qwen3.5-35B-A3B (MoE, 4 shapes) — router 2048→32,
    expert_up 2048→8192, attn_out 2048→4096, attn_qkv 4096→2048.
  - Qwen3.5-9B-rtn-int4-int8-128gs (dense, 5 shapes) — router
    4096→32, attn 4096→4096, up_proj 4096→8192, gate_up 4096→12288,
    down_proj 12288→4096.

  Each shape is exercised at `seq_len ∈ {1, 128}` (small-M / wide-M),
  all with `block_size=128`. Every case matches the CPU reference
  with cosine ≥ 0.999992.
- Regression: 24 of 25 existing `bits=4` `MatMulNBits` numeric
  precision tests continue to pass; the one pre-existing flaky
  `bits=4` WMMA case (`router_gpt_oss_shape[128]`) is unaffected
  by this change (runtime log confirms it never enters the int8
  path).

## Follow-ups (out of scope)

- GEMV-style int8 fast path for decode (`M=1`).
- WMMA / hipBLASLt int8 path for prefill (`M ≥ 16`).
- Autotuning + caching for int8 like int4 already has.
