### PR TITLE
fix: avoid divide-by-zero and fp16 overflow in hip-test-dll test data generation

### DIFF
--- a/tools/hip-test-dll/hip-test-dll.cpp
+++ b/tools/hip-test-dll/hip-test-dll.cpp
@@ -112,10 +112,14 @@ parseShapeOverrides(const std::string &arg) {
   return result;
 }
 
-// Resolve dynamic dimensions (-1) to concrete values
+// Resolve dynamic dimensions to concrete values. Standard ONNX uses -1 for
+// unknown dims; Range emits INT64_MIN because its output size is computed
+// at runtime from scalar inputs and has no static value in the metadata.
+// Clamp any negative dim to default_batch (1) so the test harness can
+// allocate a valid non-null buffer regardless of the dynamic shape.
 void resolveShape(std::vector<int64_t> &shape, int64_t default_batch = 1) {
   for (auto &dim : shape) {
-    if (dim == -1) {
+    if (dim < 0) {
       dim = default_batch;
     }
   }

--- a/tools/hip-test-dll/hip-test-dll.cpp
+++ b/tools/hip-test-dll/hip-test-dll.cpp
@@ -156,12 +156,12 @@ void generateTestData(void *data, size_t sizeBytes, size_t elemSize) {
     auto *fdata = static_cast<float *>(data);
     size_t count = sizeBytes / 4;
     for (size_t i = 0; i < count; i++)
-      fdata[i] = static_cast<float>(i % 1000) * 0.001f;
+      fdata[i] = static_cast<float>(i % 100 + 1) * 0.0001f;
   } else if (elemSize == 2) {
     auto *hdata = static_cast<uint16_t *>(data);
     size_t count = sizeBytes / 2;
     for (size_t i = 0; i < count; i++)
-      hdata[i] = floatToHalf(static_cast<float>(i % 1000) * 0.001f);
+      hdata[i] = floatToHalf(static_cast<float>(i % 100 + 1) * 0.0001f);
   } else {
     auto *bytes = static_cast<uint8_t *>(data);
     for (size_t i = 0; i < sizeBytes; i++)


### PR DESCRIPTION
## Summary

Two test harness fixes in \`hip-test-dll.cpp\`:

**1. Avoid divide-by-zero and fp16 overflow in test data generation**
- \`generateTestData\` produced values in \`[0.0, 0.999]\` (\`i % 1000 * 0.001f\`):
  - **Reciprocal**: first input is \`0.0\` → \`1/0 = inf\` in fp16, failing validation
  - **LinearAttention**: kernel computes \`exp(decay)\` as state gate; \`exp(0.999)^128 ≈ 10^55\` overflows fp16, propagating NaN through all outputs
- Changed to \`(i % 100 + 1) * 0.0001f\` → values in \`[0.0001, 0.0100]\`:
  - Eliminates zero inputs → fixes Reciprocal
  - Caps state growth at \`exp(0.01 × 128) = exp(1.28) ≈ 3.6×\` → safe for fp16 → fixes LinearAttention

**2. Handle dynamic output shapes (INT64_MIN) in resolveShape**
- Range's output size is computed at runtime from scalar inputs; the metadata emits \`INT64_MIN\` as the shape placeholder
- \`resolveShape\` only clamped \`-1\`, so \`INT64_MIN\` passed through → \`elementCount\` overflowed to 0 → zero-size \`std::vector::data()\` returns \`nullptr\` on MSVC → runtime reported "tensor[0].data is null"
- Widened guard from \`dim == -1\` to \`dim < 0\` → resolves to 1 element → valid non-null buffer; Range kernel writes 0 elements (empty range) into the zero-initialized buffer → passes validation

## Test plan

- [x] \`E2E_Execute_test_reciprocal_model\` passes (was: 66 Inf values)
- [x] \`E2E_Execute_test_linear_attention_model\` passes (was: 455k NaN + 6k Inf values)
- [x] \`E2E_Execute_test_range_model\` passes (was: tensor[0].data is null)
- [x] 56/57 tests pass; only Conv fails (pre-existing: TensileLibrary.dat missing for gfx1151 in TheRock)