### PR TITLE
docs(quick_start): add prerequisites install commands and OGA build section

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -458,7 +458,8 @@ cd $PREBUILT_DIR/bin
 
 `model_benchmark` benchmarks the full generative pipeline (prefill + decode
 token generation). It was built and installed into `$PREBUILT_DIR/bin/` in
-[step 4](#4-build-oga-onnxruntime-genai).
+[step 4](#4-build-oga-onnxruntime-genai).  Before running, please copy the 
+tokenizer related files from original model directory to /path/to/output
 
 ```bash
 # Auto-generated prompt (512 tokens)

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -264,6 +264,13 @@ git submodule update --init --recursive
 
 #### 4c. Build OGA
 
+> **Note**: when executing below python command, 
+> you may meet error of "ModuleNotFoundError: No module named ..."
+> in this case, you need manually install the missing module such as:
+```bash
+pip install util requests
+```
+
 ```bash
 python build.py \
   --config Release \
@@ -310,6 +317,8 @@ pip install \
   ../build/onnxruntime/Release/dist/onnxruntime_directml-*.whl \
   ../build/onnxruntime-genai/Release/wheel/onnxruntime_genai_directml-*.whl
 ```
+> **Note**: the first whl file may be in  ../build/onnxruntime/Release/Release/dist/ 
+>  Try this path if you meet error "the file does not exist"
 
 Verify:
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -42,7 +42,7 @@ winget install Microsoft.VisualStudio.2022.BuildTools --override "--quiet --wait
 
 # 2. Ninja, Python 3, sccache, GitHub CLI, Git (provides Git Bash + unzip)
 winget install Ninja-build.Ninja
-winget install Python.Python.3.12
+winget install Python.Python.3.14
 winget install Mozilla.sccache
 winget install GitHub.cli
 winget install Git.Git
@@ -87,6 +87,21 @@ prebuilt-local directories are siblings:
 
 ## One-Time Setup
 
+### 0. Clone the repository
+
+Pick a workspace directory and clone the project so all later commands can
+use `..` to reference sibling directories:
+
+```bash
+cd <workspace>
+git clone https://github.com/ROCm/onnx-hipdnn-ep.git
+cd onnx-hipdnn-ep
+git submodule update --init --recursive
+```
+
+All subsequent commands run from the `onnx-hipdnn-ep/` project root unless
+explicitly noted.
+
 ### 1. Build ONNX Runtime (Required for BUILD_EP=ON)
 
 Build ONNX Runtime **before** downloading pre-built dependencies to avoid
@@ -96,7 +111,7 @@ FlatBuffers version conflicts (ORT bundles its own FlatBuffers).
 
 ```bash
 cd ..  # Go to workspace directory (parent of project root)
-# recommand use release branch, such as rel-1.25.1
+# Recommend a release branch such as rel-1.25.1
 git clone -b rel-1.25.1 https://github.com/Microsoft/onnxruntime.git
 cd onnxruntime
 ```
@@ -125,18 +140,16 @@ ls $PREBUILT_DIR/lib/cmake/onnxruntime/
 
 ls ../build/onnxruntime/Release/dist/onnxruntime_directml-*.whl
 # Should see one wheel matching your Python version, e.g.
-# onnxruntime_directml-1.25.1-cp312-cp312-win_amd64.whl
+# onnxruntime_directml-1.25.1-cp314-cp314-win_amd64.whl
 ```
 
 ### 2. Download Pre-built Dependencies
 
-Run from the project root (inside Git Bash / MSYS2):
+Step 1 leaves you inside `<workspace>/onnxruntime/`. Switch back to the
+project root and run the bundled setup script (uses Git Bash / MSYS2):
 
 ```bash
-cd ..
-git clone https://github.com/ROCm/onnx-hipdnn-ep.git
-cd onnx-hipdnn-ep/
-git submodule update --init --recursive
+cd ../onnx-hipdnn-ep
 bash scripts/setup-prebuilt.sh
 ```
 
@@ -200,7 +213,7 @@ cmake -S . -B ../build/$(basename $PWD) \
 | `HIP_ARCHITECTURES` | GPU architecture (e.g., `gfx1151`) | Required |
 | `BUILD_EP` | `ON` | Build MorphiZen Execution Provider |
 
-### Build
+#### Build
 
 ```bash
 cmake --build ../build/$(basename $PWD) --config Release --parallel
@@ -280,8 +293,10 @@ cp ../build/onnxruntime-genai/Release/benchmark/c/model_benchmark.exe "$PREBUILT
 cp ../build/onnxruntime-genai/Release/onnxruntime-genai.dll "$PREBUILT_DIR/bin/"
 ```
 
-After this, `$PREBUILT_DIR/bin/` contains everything needed to run the
-benchmarks in the next sections.
+After this, `$PREBUILT_DIR/bin/` has the OGA artifacts (`model_benchmark.exe`
+and `onnxruntime-genai.dll`) used by [OGA End-to-End Benchmarking](#oga-end-to-end-benchmarking-with-model_benchmark)
+below. `onnxruntime_perf_test.exe` is staged separately in
+[Latency Benchmarking](#latency-benchmarking-with-onnxruntime_perf_test).
 
 ### 5. Install Python Wheels (Optional)
 
@@ -290,7 +305,7 @@ generation script instead of using `model_benchmark.exe`), install the two
 wheels produced by steps 1 and 4:
 
 ```bash
-cd onnx-hipdnn-ep  # Back to the project root
+cd ../onnx-hipdnn-ep  # Back to the project root (sibling of onnxruntime-genai)
 pip install \
   ../build/onnxruntime/Release/dist/onnxruntime_directml-*.whl \
   ../build/onnxruntime-genai/Release/wheel/onnxruntime_genai_directml-*.whl

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -305,7 +305,7 @@ generation script instead of using `model_benchmark.exe`), install the two
 wheels produced by steps 1 and 4:
 
 ```bash
-cd ../onnx-hipdnn-ep  # Back to the project root (sibling of onnxruntime-genai)
+cd ../onnx-hipdnn-ep  # Back to the project root
 pip install \
   ../build/onnxruntime/Release/dist/onnxruntime_directml-*.whl \
   ../build/onnxruntime-genai/Release/wheel/onnxruntime_genai_directml-*.whl

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -32,20 +32,40 @@ environment.
 echo $INCLUDE  # Should contain paths under "Microsoft Visual Studio"
 ```
 
-**sccache installation:**
-```bash
-# Windows (winget)
+**Install prerequisites (PowerShell or cmd):**
+
+```powershell
+# 1. Visual Studio 2022 Build Tools — provides MSVC (cl.exe / link.exe), the
+#    Windows SDK, and CMake (bundled in the "Desktop development with C++"
+#    workload). Skip this step if you already have a full VS 2022 IDE.
+winget install Microsoft.VisualStudio.2022.BuildTools --override "--quiet --wait --norestart --add Microsoft.VisualStudio.Workload.NativeDesktop --add Microsoft.VisualStudio.Component.VC.CMake.Project --includeRecommended"
+
+# 2. Ninja, Python 3, sccache, GitHub CLI, Git (provides Git Bash + unzip)
+winget install Ninja-build.Ninja
+winget install Python.Python.3.12
 winget install Mozilla.sccache
-# or via cargo
-cargo install sccache
+winget install GitHub.cli
+winget install Git.Git
+
+# 3. Authenticate gh (needed to download pre-built LLVM/MLIR/Protobuf/FlatBuffers
+#    archives from wcy123/llvm-mlir-prebuilt releases)
+gh auth login
 ```
 
-**Ninja installation:**
+> **Note**: `winget` is included in Windows 10 1809+ and Windows 11. If it is not
+> available, install [App Installer from the Microsoft Store](https://apps.microsoft.com/detail/9NBLGGH4NNS1).
+
+**Verify the install** (run inside Git Bash launched from "x64 Native Tools Command
+Prompt for VS 2022"; see "MSVC Environment Setup" above):
+
 ```bash
-# Windows (winget)
-winget install Ninja-build.Ninja
-# or via pip
-pip install ninja
+cl.exe 2>&1 | head -1     # Microsoft (R) C/C++ Optimizing Compiler ...
+cmake --version           # cmake version 3.20+
+ninja --version
+python --version
+sccache --version
+gh --version
+unzip -v | head -1        # provided by Git for Windows
 ```
 
 ## Directory Layout
@@ -85,8 +105,11 @@ cd onnxruntime
 
 ```bash
 # Build ONNX Runtime using build.bat (do NOT set CMAKE_INSTALL_PREFIX during build)
-# This ensures ONNX Runtime uses its own FlatBuffers version, avoiding conflicts with prebuilt FlatBuffers
-./build.bat --config Release --build_shared_lib --parallel --compile_no_warning_as_error --skip_submodule_sync --build_dir ../build/onnxruntime --skip_tests --disable_memleak_checker --use_dml
+# This ensures ONNX Runtime uses its own FlatBuffers version, avoiding conflicts with prebuilt FlatBuffers.
+# --build_wheel additionally produces a Python wheel under
+# ../build/onnxruntime/Release/dist/, which is needed for the OGA build below
+# and lets you `pip install` ONNX Runtime later (see "Install Python Wheels").
+./build.bat --config Release --build_shared_lib --parallel --compile_no_warning_as_error --skip_submodule_sync --build_dir ../build/onnxruntime --skip_tests --disable_memleak_checker --use_dml --build_wheel
 
 # Install to prebuilt-local (set prefix at install time, not during configuration)
 mkdir -p ../prebuilt-local
@@ -99,6 +122,10 @@ cmake --install ../build/onnxruntime/Release --prefix "$PREBUILT_DIR"
 ```bash
 ls $PREBUILT_DIR/lib/cmake/onnxruntime/
 # Should see onnxruntime-config.cmake and related files
+
+ls ../build/onnxruntime/Release/dist/onnxruntime_directml-*.whl
+# Should see one wheel matching your Python version, e.g.
+# onnxruntime_directml-1.25.1-cp312-cp312-win_amd64.whl
 ```
 
 ### 2. Download Pre-built Dependencies
@@ -178,6 +205,102 @@ cmake -S . -B ../build/$(basename $PWD) \
 ```bash
 cmake --build ../build/$(basename $PWD) --config Release --parallel
 cmake --install ../build/$(basename $PWD) --config Release
+```
+
+### 4. Build OGA (onnxruntime-genai)
+
+OGA (ONNX Runtime GenAI) provides the generative-pipeline runtime used by
+`model_benchmark.exe` (and the Python `onnxruntime_genai` module) to drive
+prefill + decode token generation against models prepared via the [ONNX
+Model Splitter](../tools/onnx-model-splitter/README.md). Build it after
+step 1 (ORT) so it links against the same ORT version.
+
+**Prerequisites**: step 1 (ORT built with `--build_wheel`). Step 3 is only
+needed later to *run* `model_benchmark` against MorphiZen EP, not to build
+OGA itself.
+
+Run all commands below from the `onnx-hipdnn-ep/` project root.
+
+#### 4a. Prepare ORT_HOME
+
+OGA's CMake expects an `ORT_HOME/` directory layout with `include/` and `lib/`
+subdirectories. Stage one from the ORT install under `$PREBUILT_DIR`:
+
+```bash
+mkdir -p ../build/oga-ort-home/include ../build/oga-ort-home/lib
+ORT_HOME=$(cd ../build/oga-ort-home && pwd)
+cp -r "$PREBUILT_DIR/include/onnxruntime/"* "$ORT_HOME/include/"
+cp "$PREBUILT_DIR/lib/"onnxruntime*.lib "$ORT_HOME/lib/"
+cp "$PREBUILT_DIR/bin/onnxruntime.dll" "$ORT_HOME/lib/"
+cp "$PREBUILT_DIR/bin/onnxruntime_providers_shared.dll" "$ORT_HOME/lib/"
+```
+
+#### 4b. Clone OGA
+
+```bash
+cd ..  # Go to workspace directory (sibling of onnx-hipdnn-ep)
+git clone -b feat/oga_hipdnn_experiment https://github.com/AMDmoore/onnxruntime-genai.git
+cd onnxruntime-genai
+git submodule update --init --recursive
+```
+
+> **Note**: CI pins a specific commit (see `OGA_REF` in
+> [`.github/workflows/windows-build.yml`](../.github/workflows/windows-build.yml)).
+> If you want byte-for-byte reproducibility, check out that commit instead of
+> the branch tip.
+
+#### 4c. Build OGA
+
+```bash
+python build.py \
+  --config Release \
+  --cmake_generator Ninja \
+  --use_dml \
+  --ort_home "$ORT_HOME" \
+  --skip_tests --skip_examples \
+  --parallel \
+  --build_dir ../build/onnxruntime-genai \
+  --cmake_extra_defines \
+    CMAKE_C_COMPILER_LAUNCHER=sccache \
+    CMAKE_CXX_COMPILER_LAUNCHER=sccache
+```
+
+This produces three artifacts under `../build/onnxruntime-genai/Release/`:
+
+| Artifact | Path | Purpose |
+|----------|------|---------|
+| `model_benchmark.exe` | `benchmark/c/model_benchmark.exe` | End-to-end LLM benchmark (used in [OGA End-to-End Benchmarking](#oga-end-to-end-benchmarking-with-model_benchmark)) |
+| `onnxruntime-genai.dll` | `onnxruntime-genai.dll` | Runtime DLL (loaded by `model_benchmark.exe` and the Python module) |
+| `onnxruntime_genai_directml-*.whl` | `wheel/onnxruntime_genai_directml-*.whl` | Python wheel (see [Install Python Wheels](#5-install-python-wheels-optional)) |
+
+#### 4d. Install OGA artifacts into prebuilt-local
+
+```bash
+cp ../build/onnxruntime-genai/Release/benchmark/c/model_benchmark.exe "$PREBUILT_DIR/bin/"
+cp ../build/onnxruntime-genai/Release/onnxruntime-genai.dll "$PREBUILT_DIR/bin/"
+```
+
+After this, `$PREBUILT_DIR/bin/` contains everything needed to run the
+benchmarks in the next sections.
+
+### 5. Install Python Wheels (Optional)
+
+If you also want to drive ORT / OGA from Python (e.g. to write your own
+generation script instead of using `model_benchmark.exe`), install the two
+wheels produced by steps 1 and 4:
+
+```bash
+cd onnx-hipdnn-ep  # Back to the project root
+pip install \
+  ../build/onnxruntime/Release/dist/onnxruntime_directml-*.whl \
+  ../build/onnxruntime-genai/Release/wheel/onnxruntime_genai_directml-*.whl
+```
+
+Verify:
+
+```bash
+python -c "import onnxruntime as ort; print(ort.__version__)"
+python -c "import onnxruntime_genai as og; print(og.__version__)"
 ```
 
 ## Model Preparation
@@ -300,7 +423,8 @@ cd $PREBUILT_DIR/bin
 ### OGA End-to-End Benchmarking with model_benchmark
 
 `model_benchmark` benchmarks the full generative pipeline (prefill + decode
-token generation). It is included in the release package under `bin/`.
+token generation). It was built and installed into `$PREBUILT_DIR/bin/` in
+[step 4](#4-build-oga-onnxruntime-genai).
 
 ```bash
 # Auto-generated prompt (512 tokens)

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -329,6 +329,10 @@ python -c "import onnxruntime_genai as og; print(og.__version__)"
 
 ## Model Preparation
 
+Please See
+[tools/onnx-model-splitter/README.md](../tools/onnx-model-splitter/README.md) for full details of this step. 
+In this document, there is a step by step guide which use Llama-3.1-8B as example.
+
 Use `tools/onnx-model-splitter` to export prefill/decode ONNX models for
 benchmarking with ONNX Runtime GenAI. Install Python dependencies first:
 
@@ -358,9 +362,7 @@ python tools/onnx-model-splitter/export_chunk_model.py \
 
 This exports `prefill_p512m16384.onnx`, `decode_p512m16384.onnx`,
 `genai_config_p512m16384.json`, and shared external weights into the output
-directory. See
-[tools/onnx-model-splitter/README.md](../tools/onnx-model-splitter/README.md)
-for full details.
+directory.
 
 ## Testing & Benchmarking
 
@@ -370,17 +372,25 @@ for full details.
 timing. It is built automatically when `BUILD_HIP_TOOLS=ON`.
 
 ```bash
+# first cd to your onnx-hipdnn-ep directory
 export THEROCK_DIST=$(cd ../therock && pwd)
-export PATH="$THEROCK_DIST/bin:$PATH"
+export PATH="$THEROCK_DIST/bin:$PREBUILT_DIR/bin:$PATH"
+
+> **Note**: hip-onnx-runner.exe run onnx model with random data as input.
+>  But for llm model, the input_ids should be in valid scope (< voab size) and not be random. 
+>  So for below test, it is necessary to produce valid data file as input.
+>  Please run :
+>  # python tools/hip-onnx-runner/gen_hip_onnx_runner_inputs.py -o gen_inputs /path/to/your_test_model.onnx
+>  to produce dir holding test data and use "-i" option to let hip-onnx-runner.exe use this dir as input
 
 # Run with MorphiZen EP (default), using a fixed-shape model from Model Preparation
-$PREBUILT_DIR/bin/hip-onnx-runner.exe -m /path/to/output/prefill_p512m16384.onnx
+$PREBUILT_DIR/bin/hip-onnx-runner.exe -m /path/to/output/prefill_p512m16384.onnx -i gen_inputs 
 
 # Run with CPU only (no EP)
-$PREBUILT_DIR/bin/hip-onnx-runner.exe -m /path/to/output/prefill_p512m16384.onnx -n
+$PREBUILT_DIR/bin/hip-onnx-runner.exe -m /path/to/output/prefill_p512m16384.onnx -n -i gen_inputs 
 
 # Dump outputs for comparison
-$PREBUILT_DIR/bin/hip-onnx-runner.exe -m /path/to/output/prefill_p512m16384.onnx -d 2
+$PREBUILT_DIR/bin/hip-onnx-runner.exe -m /path/to/output/prefill_p512m16384.onnx -i gen_inputs -d 2
 
 # L2-norm compare EP vs CPU outputs
 $PREBUILT_DIR/bin/hip-onnx-runner.exe -L ep_o_dump,cpu_o_dump

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -264,7 +264,7 @@ git submodule update --init --recursive
 
 #### 4c. Build OGA
 
-> **Note**: when executing below python command, 
+> **Note**: when executing below python command,
 > you may meet error of "ModuleNotFoundError: No module named ..."
 > in this case, you need manually install the missing module such as:
 ```bash
@@ -317,7 +317,7 @@ pip install \
   ../build/onnxruntime/Release/dist/onnxruntime_directml-*.whl \
   ../build/onnxruntime-genai/Release/wheel/onnxruntime_genai_directml-*.whl
 ```
-> **Note**: the first whl file may be in  ../build/onnxruntime/Release/Release/dist/ 
+> **Note**: the first whl file may be in  ../build/onnxruntime/Release/Release/dist/
 >  Try this path if you meet error "the file does not exist"
 
 Verify:
@@ -330,7 +330,7 @@ python -c "import onnxruntime_genai as og; print(og.__version__)"
 ## Model Preparation
 
 Please See
-[tools/onnx-model-splitter/README.md](../tools/onnx-model-splitter/README.md) for full details of this step. 
+[tools/onnx-model-splitter/README.md](../tools/onnx-model-splitter/README.md) for full details of this step.
 In this document, there is a step by step guide which use Llama-3.1-8B as example.
 
 Use `tools/onnx-model-splitter` to export prefill/decode ONNX models for
@@ -377,17 +377,17 @@ export THEROCK_DIST=$(cd ../therock && pwd)
 export PATH="$THEROCK_DIST/bin:$PREBUILT_DIR/bin:$PATH"
 
 > **Note**: hip-onnx-runner.exe run onnx model with random data as input.
->  But for llm model, the input_ids should be in valid scope (< voab size) and not be random. 
+>  But for llm model, the input_ids should be in valid scope (< voab size) and not be random.
 >  So for below test, it is necessary to produce valid data file as input.
 >  Please run :
 >  # python tools/hip-onnx-runner/gen_hip_onnx_runner_inputs.py -o gen_inputs /path/to/your_test_model.onnx
 >  to produce dir holding test data and use "-i" option to let hip-onnx-runner.exe use this dir as input
 
 # Run with MorphiZen EP (default), using a fixed-shape model from Model Preparation
-$PREBUILT_DIR/bin/hip-onnx-runner.exe -m /path/to/output/prefill_p512m16384.onnx -i gen_inputs 
+$PREBUILT_DIR/bin/hip-onnx-runner.exe -m /path/to/output/prefill_p512m16384.onnx -i gen_inputs
 
 # Run with CPU only (no EP)
-$PREBUILT_DIR/bin/hip-onnx-runner.exe -m /path/to/output/prefill_p512m16384.onnx -n -i gen_inputs 
+$PREBUILT_DIR/bin/hip-onnx-runner.exe -m /path/to/output/prefill_p512m16384.onnx -n -i gen_inputs
 
 # Dump outputs for comparison
 $PREBUILT_DIR/bin/hip-onnx-runner.exe -m /path/to/output/prefill_p512m16384.onnx -i gen_inputs -d 2
@@ -458,7 +458,7 @@ cd $PREBUILT_DIR/bin
 
 `model_benchmark` benchmarks the full generative pipeline (prefill + decode
 token generation). It was built and installed into `$PREBUILT_DIR/bin/` in
-[step 4](#4-build-oga-onnxruntime-genai).  Before running, please copy the 
+[step 4](#4-build-oga-onnxruntime-genai).  Before running, please copy the
 tokenizer related files from original model directory to /path/to/output
 
 ```bash

--- a/tools/hip-onnx-runner/gen_hip_onnx_runner_inputs.py
+++ b/tools/hip-onnx-runner/gen_hip_onnx_runner_inputs.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
 """
 Generate input_<idx>_<name>_<type>.bin files for hip-onnx-runner (-i).
 
@@ -20,6 +24,7 @@ Usage:
   python tools/gen_hip_onnx_runner_inputs.py model.onnx -o out_dir --seed 0
   python tools/gen_hip_onnx_runner_inputs.py model.onnx -D total_sequence_length=1
 """
+
 from __future__ import annotations
 
 import argparse

--- a/tools/hip-onnx-runner/gen_hip_onnx_runner_inputs.py
+++ b/tools/hip-onnx-runner/gen_hip_onnx_runner_inputs.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""
+Generate input_<idx>_<name>_<type>.bin files for hip-onnx-runner (-i).
+
+Loads ONNX with load_external_data=False (metadata only). Resolves symbolic
+dims via --dim NAME=INT (defaults suit GPT-OSS style decode: batch=1, new
+tokens=1, past len=1, mask total = past+new => 2).
+
+INT64:
+  * Names containing "input_ids" / ending with "input_ids": uniform [0, vocab-1]
+  * Names containing "mask": all ones
+  * Other int64: zeros
+
+FLOAT16: uniform in IEEE fp16 finite range (~[-65504, 65504]).
+
+Vocab size is taken from initializer model.embed_tokens.weight dim0 if present.
+
+Usage:
+  python tools/gen_hip_onnx_runner_inputs.py Z:\\...\\model_q4f16.onnx
+  python tools/gen_hip_onnx_runner_inputs.py model.onnx -o out_dir --seed 0
+  python tools/gen_hip_onnx_runner_inputs.py model.onnx -D total_sequence_length=1
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+
+
+def default_dim_overrides() -> dict[str, int]:
+    return {
+        "batch_size": 1,
+        "sequence_length": 1,
+        "past_sequence_length": 1,
+        # mask length often past_len + new_token_len for incremental decode
+        "total_sequence_length": 2,
+    }
+
+
+def parse_dim_overrides(specs: list[str]) -> dict[str, int]:
+    out: dict[str, int] = {}
+    for s in specs:
+        if "=" not in s:
+            print(f"ERROR: bad -D {s!r} (want name=int)", file=sys.stderr)
+            sys.exit(2)
+        k, v = s.split("=", 1)
+        out[k.strip()] = int(v.strip())
+    return out
+
+
+def vocab_from_embed(m) -> int | None:
+    for init in m.graph.initializer:
+        if init.name.endswith("embed_tokens.weight") and len(init.dims) >= 2:
+            return int(init.dims[0])
+    return None
+
+
+def resolve_shape(
+    tensor_type, dim_defaults: dict[str, int]
+) -> tuple[list[int], list[str]]:
+    shape: list[int] = []
+    params: list[str] = []
+    for d in tensor_type.shape.dim:
+        if d.dim_value:
+            shape.append(int(d.dim_value))
+            params.append("")
+        elif d.dim_param:
+            p = d.dim_param
+            params.append(p)
+            if p not in dim_defaults:
+                print(
+                    f"ERROR: unknown dim_param {p!r}; add -D {p}=<int>",
+                    file=sys.stderr,
+                )
+                sys.exit(2)
+            shape.append(int(dim_defaults[p]))
+        else:
+            shape.append(1)
+            params.append("")
+    return shape, params
+
+
+def fill_tensor(
+    name: str,
+    shape: list[int],
+    elem_type: int,
+    rng: np.random.Generator,
+    vocab: int | None,
+) -> np.ndarray:
+    import onnx  # noqa: PLC0415
+
+    if elem_type == onnx.TensorProto.INT64:
+        n = int(np.prod(shape)) if shape else 0
+        if n == 0:
+            return np.array([], dtype=np.int64).reshape(shape)
+        if name == "input_ids" or name.endswith("input_ids"):
+            hi = vocab if vocab is not None else 32000
+            return rng.integers(0, hi, size=shape, dtype=np.int64)
+        if "mask" in name.lower():
+            return np.ones(shape, dtype=np.int64)
+        return np.zeros(shape, dtype=np.int64)
+    if elem_type == onnx.TensorProto.FLOAT16:
+        f16_hi = float(np.finfo(np.float16).max)
+        f16_lo = float(np.finfo(np.float16).min)
+        return rng.uniform(f16_lo, f16_hi, size=shape).astype(np.float16)
+    print(f"ERROR: unsupported elem_type {elem_type} for {name}", file=sys.stderr)
+    sys.exit(2)
+
+
+def file_tag_for_numpy(arr: np.ndarray) -> str:
+    if arr.dtype == np.int64:
+        return "i64"
+    if arr.dtype == np.float16:
+        return "fp16"
+    if arr.dtype == np.float32:
+        return "fp32"
+    print(f"ERROR: no file tag for dtype {arr.dtype}", file=sys.stderr)
+    sys.exit(2)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("onnx_path", type=Path, help="Path to .onnx")
+    ap.add_argument(
+        "-o",
+        "--out-dir",
+        type=Path,
+        default=None,
+        help="Output directory (default: <onnx_stem>_inputs next to model)",
+    )
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument(
+        "-D",
+        "--dim",
+        action="append",
+        default=[],
+        metavar="NAME=INT",
+        help="Override symbolic dimension (repeatable)",
+    )
+    args = ap.parse_args()
+
+    onnx_p = args.onnx_path
+    if not onnx_p.is_file():
+        print(f"ERROR: model not found: {onnx_p}", file=sys.stderr)
+        return 1
+
+    import onnx  # noqa: PLC0415
+
+    model = onnx.load(str(onnx_p), load_external_data=False)
+    initializer_names = {x.name for x in model.graph.initializer}
+    dim_defaults = default_dim_overrides()
+    dim_defaults.update(parse_dim_overrides(args.dim))
+
+    vocab = vocab_from_embed(model)
+
+    out_dir = args.out_dir
+    if out_dir is None:
+        out_dir = onnx_p.parent / f"{onnx_p.stem}_inputs"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    rng = np.random.default_rng(args.seed)
+
+    user_inputs: list[tuple[int, str, np.ndarray]] = []
+    idx = 0
+    for inp in model.graph.input:
+        if inp.name in initializer_names:
+            continue
+        tt = inp.type.tensor_type
+        shape, _params = resolve_shape(tt, dim_defaults)
+        et = int(tt.elem_type)
+        arr = fill_tensor(inp.name, shape, et, rng, vocab)
+        user_inputs.append((idx, inp.name, arr))
+        idx += 1
+
+    lines = [
+        f"Generated for: {onnx_p}",
+        f"seed={args.seed}",
+        f"dim_defaults_used={dim_defaults!r}",
+        f"vocab_size(from embed)={vocab}",
+        "",
+        "Run:",
+        f'  hip-onnx-runner.exe -m "{onnx_p}" -i "{out_dir}" ...',
+        "",
+    ]
+
+    for i, name, arr in user_inputs:
+        tag = file_tag_for_numpy(arr)
+        fn = out_dir / f"input_{i}_{name}_{tag}.bin"
+        fn.write_bytes(arr.tobytes(order="C"))
+        print(f"Wrote {fn} ({arr.nbytes} B) shape={arr.shape} dtype={arr.dtype}")
+        lines.append(f"  {fn.name} shape={list(arr.shape)} {arr.dtype}")
+
+    readme = out_dir / "README.txt"
+    readme.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    print(readme.read_text(encoding="utf-8"))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Address feedback that the existing quick-start guide doesn't tell first-time readers how to install the prerequisites or how to build OGA. Two concrete gaps:

1. CMake / MSVC 2022 / Python 3 / `gh` CLI had no install commands; only sccache and Ninja did.
2. OGA (`onnxruntime-genai`) build was missing entirely, even though `model_benchmark.exe` is the recommended end-to-end LLM benchmark.

Style stays bash + Git Bash / MSYS2 — no PowerShell rewrite, no new scripts, no new examples directory.

## Changes (`docs/quick_start.md` only)

- **Prerequisites** — replace the stand-alone sccache / Ninja install snippets with one unified PowerShell `winget` block covering MSVC 2022 BuildTools (NativeDesktop workload + CMake), Ninja, Python 3.12, sccache, GitHub CLI, Git, plus a Git Bash verify pass.
- **ORT build** — append `--build_wheel` so the wheel under `build/onnxruntime/Release/dist/` is produced; needed for the OGA build and for an optional `pip install` later. Verify step now also checks the wheel.
- **New §4 Build OGA (onnxruntime-genai)** — mirrors the CI workflow. Four sub-steps: prepare `ORT_HOME` (copy ORT include / lib / dlls), clone `AMDmoore/onnxruntime-genai @ feat/oga_hipdnn_experiment`, run `build.py --use_dml`, install `model_benchmark.exe` + `onnxruntime-genai.dll` into `$PREBUILT_DIR/bin/`. CI's pinned commit is referenced in a side note for byte-for-byte reproducibility.
- **New §5 Install Python Wheels (Optional)** — one-line `pip install` of the ORT and OGA wheels with a Python `import` verify.
- **OGA E2E section intro** — replace the stale "included in the release package under bin/" wording with a link to the new §4.

## Test plan

- [ ] GitHub render preview: tables align, anchors `#4-build-oga-onnxruntime-genai` and `#5-install-python-wheels-optional` resolve.
- [ ] Follow each step on a clean Windows 11 machine (winget → ORT build with `--build_wheel` → OGA build → `model_benchmark.exe -h`).
