### PR TITLE
feat(decode): causal_conv seq_len=1 fast path + matmul_nbits bits=8 GEMV/WMMA

### DIFF
--- a/3rd-party/custom_kernels/CMakeLists.txt
+++ b/3rd-party/custom_kernels/CMakeLists.txt
@@ -44,6 +44,7 @@ hip_add_library(hip_custom_kernels STATIC
     hip/qmoe_kernel.hip
     hip/linear_attention_kernel.hip
     hip/transpose_kernel.hip
+    hip/causal_conv_step_kernel.hip
     INCLUDE_DIRECTORIES
         ${CMAKE_CURRENT_SOURCE_DIR}/include
 )

--- a/3rd-party/custom_kernels/hip/causal_conv_step_kernel.hip
+++ b/3rd-party/custom_kernels/hip/causal_conv_step_kernel.hip
@@ -1,0 +1,289 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <cstdint>
+#include <cstdio>
+#include <cmath>
+#include <type_traits>
+
+#include "hip_custom_kernels.h"
+
+//===----------------------------------------------------------------------===//
+// hip_causal_conv_step_decode -- single-step fused causal depthwise 1D conv.
+//
+// Replaces the MIOpen "build virtual buffer with hipMemcpy2DAsync, run
+// depthwise conv, run bias + SiLU as separate ops" chain for the seq_len == 1
+// decode path. Single launch, one block per (batch, channel), each thread is
+// responsible for one channel.
+//
+// At decode the math is laughably small:
+//   per channel: read k-1 past-state elements + 1 input element + k weights,
+//   compute k FMAs, optional bias, optional SiLU, write 1 output + k-1 state.
+//
+// On a Mamba/Gated DeltaNet block with C=8192, k=4 this is ~96 KB of VRAM
+// reads and ~16 KB of VRAM writes. Runs in ~1-20 µs end-to-end.
+//
+// We unroll on kernel_size at the call site (template <int K>) so the inner
+// loops collapse to a fixed small number of FMAs and the per-thread state
+// register array is statically sized.
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+template <typename T> __device__ __forceinline__ float to_f32(T x);
+template <> __device__ __forceinline__ float to_f32(float x) { return x; }
+template <> __device__ __forceinline__ float to_f32(__half x) {
+    return __half2float(x);
+}
+
+template <typename T> __device__ __forceinline__ T from_f32(float x);
+template <> __device__ __forceinline__ float from_f32(float x) { return x; }
+template <> __device__ __forceinline__ __half from_f32(float x) {
+    return __float2half(x);
+}
+
+// Per-(b,c) thread:
+//   1) Loads past_state[b,c,0..K-2] into registers (or zeros if past is null).
+//   2) Loads input[b,c,0], weight[c,0,0..K-1], optional bias[c].
+//   3) Computes the conv dot product in fp32.
+//   4) Applies optional SiLU.
+//   5) Writes output[b,c,0] and present_state[b,c,0..K-2].
+//
+// Memory layout (matches wrap_causal_conv_with_state):
+//   input,  output         flat [b*C + c]                 (one element/plane)
+//   past_state, present_state  flat [(b*C + c)*(K-1) + j]
+//   weight                     flat [c*K + j]
+//   bias                       flat [c]
+template <typename T, int K, int HAS_BIAS, int ACT_SILU>
+__global__ void causal_conv_step_kernel(
+    const T* __restrict__ input,
+    const T* __restrict__ weight,
+    const T* __restrict__ bias,
+    const T* __restrict__ past_state,
+    T* __restrict__ output,
+    T* __restrict__ present_state,
+    int batch_size,
+    int channels) {
+
+    // One thread per (b, c) plane. Grid = ceil(B*C / blockDim.x).
+    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    const int total = batch_size * channels;
+    if (idx >= total)
+        return;
+
+    // (b, c) for this thread
+    const int c = idx % channels;
+    // const int b = idx / channels;  // not needed beyond `idx`
+
+    // Load past_state[b,c,0..K-2] into a small register array. K is a template
+    // constant so this unrolls fully and `state[]` lives in registers.
+    constexpr int STATE_LEN = K - 1;
+    float state[STATE_LEN > 0 ? STATE_LEN : 1];
+    if (past_state != nullptr) {
+        const T* ps = past_state + static_cast<int64_t>(idx) * STATE_LEN;
+        #pragma unroll
+        for (int j = 0; j < STATE_LEN; ++j)
+            state[j] = to_f32<T>(ps[j]);
+    } else {
+        #pragma unroll
+        for (int j = 0; j < STATE_LEN; ++j)
+            state[j] = 0.0f;
+    }
+
+    // Load input[b,c,0] and weight[c,0,0..K-1] (weight is per-channel only).
+    const float x = to_f32<T>(input[idx]);
+    float w[K];
+    {
+        const T* wp = weight + static_cast<int64_t>(c) * K;
+        #pragma unroll
+        for (int j = 0; j < K; ++j)
+            w[j] = to_f32<T>(wp[j]);
+    }
+
+    // Conv dot product: virtual = [past_state[0..K-2], x]
+    //   y = sum_{j=0..K-2} w[j] * state[j] + w[K-1] * x
+    float y = w[K - 1] * x;
+    #pragma unroll
+    for (int j = 0; j < STATE_LEN; ++j)
+        y += w[j] * state[j];
+
+    if (HAS_BIAS)
+        y += to_f32<T>(bias[c]);
+
+    if (ACT_SILU) {
+        // SiLU(y) = y * sigmoid(y) = y / (1 + exp(-y))
+        const float s = 1.0f / (1.0f + expf(-y));
+        y *= s;
+    }
+
+    output[idx] = from_f32<T>(y);
+
+    // Shift state forward by one timestep:
+    //   present_state[b,c,0..K-3] = past_state[b,c,1..K-2]
+    //   present_state[b,c,K-2]    = x
+    if (STATE_LEN > 0) {
+        T* nps = present_state + static_cast<int64_t>(idx) * STATE_LEN;
+        #pragma unroll
+        for (int j = 0; j < STATE_LEN - 1; ++j)
+            nps[j] = from_f32<T>(state[j + 1]);
+        nps[STATE_LEN - 1] = from_f32<T>(x);
+    }
+}
+
+// Dispatcher: stamps out the small cross-product of (T, K, HAS_BIAS,
+// ACT_SILU) template instantiations we actually use at runtime. Only the K
+// values currently observed in supported models (Mamba uses k=4) need fast
+// paths; we provide k in {2,3,4,5,6,7,8} for future hybrids.
+template <typename T>
+hipError_t launch_for_K(
+    int K, hipStream_t stream,
+    const T* input, const T* weight, const T* bias, const T* past_state,
+    T* output, T* present_state,
+    int batch_size, int channels, int has_bias, int act_silu) {
+
+    const int total = batch_size * channels;
+    const int block = 256;
+    const int grid = (total + block - 1) / block;
+
+    auto launch = [&](auto k_const, auto bias_const, auto act_const) {
+        constexpr int Kc = decltype(k_const)::value;
+        constexpr int Bc = decltype(bias_const)::value;
+        constexpr int Ac = decltype(act_const)::value;
+        hipLaunchKernelGGL(
+            (causal_conv_step_kernel<T, Kc, Bc, Ac>),
+            dim3(grid), dim3(block), 0, stream,
+            input, weight, bias, past_state, output, present_state,
+            batch_size, channels);
+        return hipGetLastError();
+    };
+
+    // Compile-time switch on K so we get fully-unrolled inner loops.
+#define DISPATCH_K_BIAS_ACT(KVAL)                                             \
+    case KVAL: {                                                              \
+        using K_t = std::integral_constant<int, KVAL>;                        \
+        if (has_bias && act_silu)                                             \
+            return launch(K_t{},                                              \
+                          std::integral_constant<int, 1>{},                   \
+                          std::integral_constant<int, 1>{});                  \
+        if (has_bias)                                                         \
+            return launch(K_t{},                                              \
+                          std::integral_constant<int, 1>{},                   \
+                          std::integral_constant<int, 0>{});                  \
+        if (act_silu)                                                         \
+            return launch(K_t{},                                              \
+                          std::integral_constant<int, 0>{},                   \
+                          std::integral_constant<int, 1>{});                  \
+        return launch(K_t{},                                                  \
+                      std::integral_constant<int, 0>{},                       \
+                      std::integral_constant<int, 0>{});                      \
+    }
+
+    switch (K) {
+        DISPATCH_K_BIAS_ACT(1)
+        DISPATCH_K_BIAS_ACT(2)
+        DISPATCH_K_BIAS_ACT(3)
+        DISPATCH_K_BIAS_ACT(4)
+        DISPATCH_K_BIAS_ACT(5)
+        DISPATCH_K_BIAS_ACT(6)
+        DISPATCH_K_BIAS_ACT(7)
+        DISPATCH_K_BIAS_ACT(8)
+        default:
+            return hipErrorInvalidValue;
+    }
+#undef DISPATCH_K_BIAS_ACT
+}
+
+} // namespace
+
+extern "C" int hip_causal_conv_step_decode(
+    void* stream,
+    const void* input,
+    const void* weight,
+    const void* bias,
+    const void* past_state,
+    void* output,
+    void* present_state,
+    int64_t batch_size,
+    int64_t channels,
+    int64_t kernel_size,
+    int64_t activation,
+    int64_t element_size_bytes) {
+
+    if (!input || !weight || !output || !present_state) {
+        fprintf(stderr,
+                "[custom_kernels] hip_causal_conv_step_decode: null required "
+                "pointer (input=%p weight=%p output=%p present_state=%p)\n",
+                input, weight, output, present_state);
+        return -1;
+    }
+    if (batch_size <= 0 || channels <= 0) {
+        fprintf(stderr,
+                "[custom_kernels] hip_causal_conv_step_decode: invalid "
+                "batch=%lld channels=%lld\n",
+                (long long)batch_size, (long long)channels);
+        return -1;
+    }
+    if (kernel_size < 1 || kernel_size > 8) {
+        fprintf(stderr,
+                "[custom_kernels] hip_causal_conv_step_decode: kernel_size=%lld "
+                "outside supported range [1,8]\n",
+                (long long)kernel_size);
+        return -1;
+    }
+    if (activation != 0 && activation != 1) {
+        fprintf(stderr,
+                "[custom_kernels] hip_causal_conv_step_decode: unsupported "
+                "activation=%lld (0=none, 1=SiLU)\n",
+                (long long)activation);
+        return -1;
+    }
+
+    hipStream_t s = static_cast<hipStream_t>(stream);
+    const int K = static_cast<int>(kernel_size);
+    const int B = static_cast<int>(batch_size);
+    const int C = static_cast<int>(channels);
+    const int has_bias = bias ? 1 : 0;
+    const int act_silu = (activation == 1) ? 1 : 0;
+
+    hipError_t err;
+    if (element_size_bytes == 4) {
+        err = launch_for_K<float>(
+            K, s,
+            static_cast<const float*>(input),
+            static_cast<const float*>(weight),
+            static_cast<const float*>(bias),
+            static_cast<const float*>(past_state),
+            static_cast<float*>(output),
+            static_cast<float*>(present_state),
+            B, C, has_bias, act_silu);
+    } else if (element_size_bytes == 2) {
+        err = launch_for_K<__half>(
+            K, s,
+            static_cast<const __half*>(input),
+            static_cast<const __half*>(weight),
+            static_cast<const __half*>(bias),
+            static_cast<const __half*>(past_state),
+            static_cast<__half*>(output),
+            static_cast<__half*>(present_state),
+            B, C, has_bias, act_silu);
+    } else {
+        fprintf(stderr,
+                "[custom_kernels] hip_causal_conv_step_decode: unsupported "
+                "element_size_bytes=%lld (expect 2 or 4)\n",
+                (long long)element_size_bytes);
+        return -1;
+    }
+
+    if (err != hipSuccess) {
+        fprintf(stderr,
+                "[custom_kernels] hip_causal_conv_step_decode: launch failed "
+                "(%s)\n",
+                hipGetErrorString(err));
+        return static_cast<int>(err);
+    }
+    return 0;
+}

--- a/3rd-party/custom_kernels/hip/matmul_nbits_kernel.hip
+++ b/3rd-party/custom_kernels/hip/matmul_nbits_kernel.hip
@@ -162,6 +162,252 @@ __global__ void matmul_nbits_kernel_i8(
 }
 
 /* =======================================================================
+ * Section 1a-gemv: GEMV-style kernel for int8 weights (autotuned)
+ *
+ * Mirrors the int4 GEMV kernel below (Section 1b) but specialized for the
+ * MatMulNBits bits=8 layout:
+ *   B is uint8 [N, K] (one byte per weight, no nibble packing)
+ *   default zp = 128 (= 2^(bits-1) per the ONNX MatMulNBits spec)
+ *   no col-major / WMMA-compat path: int8 always runs row-major.
+ *
+ * Each threadblock computes TILE_N output elements at row m, sharing the
+ * same A row across the N dimension. BLOCK_SIZE threads cooperate on the
+ * K reduction via warp shuffle + shared mem (identical to int4 path).
+ *
+ * Key optimizations carried over from int4:
+ *   - 16-byte main loop (uint4 = 128 bits): 16 weights per global txn
+ *   - Load-compute separation: B loads issued before FMA compute
+ *   - Factored dequant:  dot*scale - a_sum*zp*scale
+ *     (for w=int8: same identity as nibble; saves the per-element zp
+ *     subtract by hoisting it out of the K-inner loop -- ~30% fewer
+ *     fp32 ops in the FMA tree)
+ *   - Bit-shift group index (block_size is power-of-2; gated at dispatch)
+ *
+ * Constraint: requires block_size >= 16 (so a 16-element vector lies in one
+ * group). The Qwen3.5 int8 ops use block_size=128, which satisfies this.
+ * Smaller block_size falls back to the naive int8 kernel above.
+ *
+ * Launch: grid(ceil(N/TILE_N), M, batch), block(BLOCK_SIZE)
+ * ======================================================================= */
+
+template <int BLOCK_SIZE, int TILE_N>
+__global__ void matmul_nbits_gemv_kernel_i8(
+    const __half* __restrict__ A,
+    const uint8_t* __restrict__ B,
+    const __half* __restrict__ scales,
+    const uint8_t* __restrict__ zp,
+    const __half* __restrict__ bias,
+    __half* __restrict__ output,
+    int64_t M, int64_t N, int64_t K,
+    int64_t block_size)
+{
+    const int64_t n_base = static_cast<int64_t>(blockIdx.x) * TILE_N;
+    const int64_t m      = blockIdx.y;
+    const int64_t batch  = blockIdx.z;
+    const int tid        = threadIdx.x;
+
+    if (m >= M) return;
+
+    const int64_t k_blocks = (K + block_size - 1) / block_size;
+    const int     bs_shift = __builtin_ctzll(
+                                 static_cast<unsigned long long>(block_size));
+
+    // Row-major A only (no COL_MAJOR variant -- int8 has no WMMA path).
+    const __half* a_base   = A + batch * M * K + m * K;
+
+    // Per-tile-N column pointers (clamped to N-1 for OOB lanes; the
+    // out-of-bounds tile guards in the writeback skip those results).
+    const uint8_t* b_base_arr[TILE_N];
+    const __half*  s_rows[TILE_N];
+    int64_t        n_idx[TILE_N];
+#pragma unroll
+    for (int tn = 0; tn < TILE_N; tn++) {
+        int64_t n  = n_base + tn;
+        int64_t sn = (n < N) ? n : 0;
+        n_idx[tn]  = sn;
+        b_base_arr[tn] = B + sn * K;
+        s_rows[tn] = scales + sn * k_blocks;
+    }
+
+    float partial[TILE_N];
+#pragma unroll
+    for (int tn = 0; tn < TILE_N; tn++)
+        partial[tn] = 0.0f;
+
+    const bool has_zp = (zp != nullptr);
+
+    // ---- Phase 1: 16-byte (128-bit / uint4) vectorized main loop ----
+    // 16 weights per global memory transaction; matches the 16-nibble loop
+    // in the int4 kernel but at twice the bytes-per-iter (since each
+    // weight is now a full byte).
+    const int64_t num_u128 = K / 16;
+    for (int64_t idx = static_cast<int64_t>(tid); idx < num_u128;
+         idx += static_cast<int64_t>(BLOCK_SIZE)) {
+        const int64_t k16 = idx * 16;
+
+        float a_vals[16];
+        float a_sum = 0.0f;
+#pragma unroll
+        for (int i = 0; i < 16; i++) {
+            a_vals[i] = static_cast<float>(a_base[k16 + i]);
+            a_sum += a_vals[i];
+        }
+
+        // 16-byte chunks lie in one group iff block_size >= 16 (precondition).
+        const int64_t grp = k16 >> bs_shift;
+
+        // 16-byte (uint4) loads from each of TILE_N B columns.
+        uint4 b_pk[TILE_N];
+        float sv[TILE_N];
+#pragma unroll
+        for (int tn = 0; tn < TILE_N; tn++) {
+            b_pk[tn] = *reinterpret_cast<const uint4*>(
+                            &b_base_arr[tn][k16]);
+            sv[tn]   = static_cast<float>(s_rows[tn][grp]);
+        }
+
+#pragma unroll
+        for (int tn = 0; tn < TILE_N; tn++) {
+            // Decode 16 uint8 weights from the four 32-bit lanes of the
+            // uint4 vector. Each uint32 holds 4 bytes (little-endian).
+            float dot = 0.0f;
+#pragma unroll
+            for (int i = 0; i < 4; i++)
+                dot += a_vals[i] *
+                       static_cast<float>((b_pk[tn].x >> (i * 8)) & 0xFFu);
+#pragma unroll
+            for (int i = 0; i < 4; i++)
+                dot += a_vals[4 + i] *
+                       static_cast<float>((b_pk[tn].y >> (i * 8)) & 0xFFu);
+#pragma unroll
+            for (int i = 0; i < 4; i++)
+                dot += a_vals[8 + i] *
+                       static_cast<float>((b_pk[tn].z >> (i * 8)) & 0xFFu);
+#pragma unroll
+            for (int i = 0; i < 4; i++)
+                dot += a_vals[12 + i] *
+                       static_cast<float>((b_pk[tn].w >> (i * 8)) & 0xFFu);
+
+            if (has_zp) {
+                float zv = static_cast<float>(zp[n_idx[tn] * k_blocks + grp]);
+                partial[tn] += dot * sv[tn] - a_sum * zv * sv[tn];
+            } else {
+                // ONNX MatMulNBits default zp for bits=8 is 2^(bits-1) = 128.
+                partial[tn] += dot * sv[tn] - a_sum * 128.0f * sv[tn];
+            }
+        }
+    }
+
+    // ---- Phase 2: 8-byte (uint2 / 64-bit) middle loop (K%16 remainder) ----
+    {
+        const int64_t k_after_p1 = num_u128 * 16;
+        const int64_t num_u64_m  = (K - k_after_p1) / 8;
+        for (int64_t idx2 = static_cast<int64_t>(tid); idx2 < num_u64_m;
+             idx2 += static_cast<int64_t>(BLOCK_SIZE)) {
+            const int64_t k8 = k_after_p1 + idx2 * 8;
+
+            float a_vals[8];
+            float a_sum = 0.0f;
+#pragma unroll
+            for (int i = 0; i < 8; i++) {
+                a_vals[i] = static_cast<float>(a_base[k8 + i]);
+                a_sum += a_vals[i];
+            }
+
+            const int64_t grp = k8 >> bs_shift;
+
+#pragma unroll
+            for (int tn = 0; tn < TILE_N; tn++) {
+                float sv = static_cast<float>(s_rows[tn][grp]);
+                uint2 packed = *reinterpret_cast<const uint2*>(
+                                    &b_base_arr[tn][k8]);
+
+                float dot = 0.0f;
+#pragma unroll
+                for (int i = 0; i < 4; i++)
+                    dot += a_vals[i] *
+                           static_cast<float>((packed.x >> (i * 8)) & 0xFFu);
+#pragma unroll
+                for (int i = 0; i < 4; i++)
+                    dot += a_vals[4 + i] *
+                           static_cast<float>((packed.y >> (i * 8)) & 0xFFu);
+
+                if (has_zp) {
+                    float zv = static_cast<float>(
+                                   zp[n_idx[tn] * k_blocks + grp]);
+                    partial[tn] += dot * sv - a_sum * zv * sv;
+                } else {
+                    partial[tn] += dot * sv - a_sum * 128.0f * sv;
+                }
+            }
+        }
+    }
+
+    // ---- Phase 3: scalar tail (K%8 remainder) ----
+    {
+        const int64_t k_tail = (K / 8) * 8;
+        for (int64_t k = k_tail + static_cast<int64_t>(tid);
+             k < K; k += static_cast<int64_t>(BLOCK_SIZE)) {
+            const float   a_val = static_cast<float>(a_base[k]);
+            const int64_t grp   = k >> bs_shift;
+
+#pragma unroll
+            for (int tn = 0; tn < TILE_N; tn++) {
+                float sv = static_cast<float>(s_rows[tn][grp]);
+                float zv = has_zp
+                              ? static_cast<float>(
+                                    zp[n_idx[tn] * k_blocks + grp])
+                              : 128.0f;
+                float qval = static_cast<float>(b_base_arr[tn][k]);
+                partial[tn] += a_val * (qval - zv) * sv;
+            }
+        }
+    }
+
+    // --- Reduction: warp shuffle then shared memory (mirrors int4 path) ---
+    const int wave_size = __builtin_amdgcn_wavefrontsize();
+    const int warp_id   = tid / wave_size;
+    const int lane_id   = tid % wave_size;
+    const int num_warps = BLOCK_SIZE / wave_size;
+
+#pragma unroll
+    for (int tn = 0; tn < TILE_N; tn++) {
+        for (int offset = wave_size >> 1; offset > 0; offset >>= 1)
+            partial[tn] += __shfl_down(partial[tn], offset);
+    }
+
+    constexpr int MAX_WARPS = BLOCK_SIZE / 32;
+    __shared__ float warp_sums[TILE_N * MAX_WARPS];
+
+    if (lane_id == 0) {
+#pragma unroll
+        for (int tn = 0; tn < TILE_N; tn++)
+            warp_sums[tn * MAX_WARPS + warp_id] = partial[tn];
+    }
+    __syncthreads();
+
+    if (warp_id == 0) {
+#pragma unroll
+        for (int tn = 0; tn < TILE_N; tn++) {
+            float val = (lane_id < num_warps)
+                            ? warp_sums[tn * MAX_WARPS + lane_id] : 0.0f;
+            for (int offset = wave_size >> 1; offset > 0; offset >>= 1)
+                val += __shfl_down(val, offset);
+
+            if (lane_id == 0) {
+                int64_t n = n_base + tn;
+                if (n < N) {
+                    if (bias)
+                        val += static_cast<float>(bias[n]);
+                    output[batch * M * N + m * N + n] =
+                        static_cast<__half>(val);
+                }
+            }
+        }
+    }
+}
+
+/* =======================================================================
  * Section 1b: GEMV-style kernel for small M (autotuned, vectorized)
  *
  * Template parameters:
@@ -573,6 +819,162 @@ static int getOrTuneGemvConfig(
         "[custom_kernels] GEMV cache: stored key=\"%s\" -> config[%d] "
         "(cache size=%zu)\n",
         key.c_str(), best, gemv_cache.size());
+
+    return best;
+}
+
+/* -----------------------------------------------------------------------
+ * GEMV (int8) Autotune: dispatch, benchmark, cache
+ *
+ * Reuses kGemvConfigs (28 configs of BLOCK_SIZE x TILE_N) and the same
+ * autotune mechanics as the int4 path, but launches the int8 GEMV kernel
+ * matmul_nbits_gemv_kernel_i8 instead. A separate cache is used because
+ * the int8 kernel's per-config performance ranking differs from int4 (B
+ * is 2x larger at fp16-equivalent footprint, the inner loop has half as
+ * many decode shifts, and zp is read directly as uint8 rather than
+ * unpacked first).
+ * ----------------------------------------------------------------------- */
+
+static void launchGemvConfigI8(
+    int config_id, hipStream_t stream,
+    const __half* A, const uint8_t* B,
+    const __half* sc, const uint8_t* zp,
+    const __half* bi, __half* out,
+    int64_t M, int64_t N, int64_t K,
+    int64_t batch, int64_t bs)
+{
+    auto& c = kGemvConfigs[config_id];
+    dim3 grid(static_cast<unsigned>((N + c.tile_n - 1) / c.tile_n),
+              static_cast<unsigned>(M),
+              static_cast<unsigned>(batch));
+    dim3 block(c.threads);
+
+#define GEMV_I8_CASE(ID, BS, TN) \
+    case ID: \
+        hipLaunchKernelGGL( \
+            HIP_KERNEL_NAME(matmul_nbits_gemv_kernel_i8<BS, TN>), \
+            grid, block, 0, stream, A, B, sc, zp, bi, out, M, N, K, bs); \
+        break
+
+    switch (config_id) {
+        GEMV_I8_CASE( 0,  64,  1);  GEMV_I8_CASE( 1,  64,  2);
+        GEMV_I8_CASE( 2,  64,  4);  GEMV_I8_CASE( 3,  64,  8);
+        GEMV_I8_CASE( 4,  64, 16);
+        GEMV_I8_CASE( 5, 128,  1);  GEMV_I8_CASE( 6, 128,  2);
+        GEMV_I8_CASE( 7, 128,  4);  GEMV_I8_CASE( 8, 128,  8);
+        GEMV_I8_CASE( 9, 128, 16);
+        GEMV_I8_CASE(10, 256,  1);  GEMV_I8_CASE(11, 256,  2);
+        GEMV_I8_CASE(12, 256,  4);  GEMV_I8_CASE(13, 256,  8);
+        GEMV_I8_CASE(14, 256, 16);
+        GEMV_I8_CASE(15, 512,  1);  GEMV_I8_CASE(16, 512,  2);
+        GEMV_I8_CASE(17, 512,  4);  GEMV_I8_CASE(18, 512,  8);
+        GEMV_I8_CASE(19, 512, 16);
+        GEMV_I8_CASE(20, 1024,  1); GEMV_I8_CASE(21, 1024,  2);
+        GEMV_I8_CASE(22, 1024,  4); GEMV_I8_CASE(23, 1024,  8);
+        GEMV_I8_CASE(24, 1024, 16);
+        GEMV_I8_CASE(25,  64, 32);  GEMV_I8_CASE(26, 128, 32);
+        GEMV_I8_CASE(27, 256, 32);
+        default: break;
+    }
+#undef GEMV_I8_CASE
+}
+
+static int tuneGemvConfigI8(
+    hipStream_t stream,
+    const __half* A, const uint8_t* B,
+    const __half* sc, const uint8_t* zp,
+    const __half* bi, __half* out,
+    int64_t M, int64_t N, int64_t K,
+    int64_t batch, int64_t bs)
+{
+    hipEvent_t ev0, ev1;
+    hipEventCreate(&ev0);
+    hipEventCreate(&ev1);
+
+    float best_ms = 1e30f;
+    int   best_id = 8; // 128 threads, TILE_N=8 -- safe default for typical N
+    constexpr int WARMUP = 1;
+    constexpr int ITERS  = 5;
+
+    for (int cid = 0; cid < kNumGemvConfigs; cid++) {
+        auto& cfg = kGemvConfigs[cid];
+        if (cfg.tile_n >= 32 && N < 1024) continue;
+
+        for (int w = 0; w < WARMUP; w++)
+            launchGemvConfigI8(cid, stream, A, B, sc, zp, bi, out,
+                               M, N, K, batch, bs);
+
+        hipEventRecord(ev0, stream);
+        for (int i = 0; i < ITERS; i++)
+            launchGemvConfigI8(cid, stream, A, B, sc, zp, bi, out,
+                               M, N, K, batch, bs);
+        hipEventRecord(ev1, stream);
+        hipEventSynchronize(ev1);
+
+        float ms = 0.0f;
+        hipEventElapsedTime(&ms, ev0, ev1);
+
+        CUSTOM_KERNELS_DEBUG_LOG(
+            "[custom_kernels]   i8 config[%2d] threads=%3d tile_n=%d : %.4f ms\n",
+            cid, kGemvConfigs[cid].threads, kGemvConfigs[cid].tile_n,
+            ms / ITERS);
+
+        if (ms < best_ms) {
+            best_ms = ms;
+            best_id = cid;
+        }
+    }
+
+    hipEventDestroy(ev0);
+    hipEventDestroy(ev1);
+
+    CUSTOM_KERNELS_DEBUG_LOG(
+        "[custom_kernels] GEMV-i8 autotune: M=%lld N=%lld K=%lld bs=%lld -> "
+        "best config[%d] threads=%d tile_n=%d (%.4f ms/iter)\n",
+        (long long)M, (long long)N, (long long)K, (long long)bs,
+        best_id, kGemvConfigs[best_id].threads,
+        kGemvConfigs[best_id].tile_n, best_ms / ITERS);
+
+    return best_id;
+}
+
+static std::unordered_map<std::string, int> gemv_i8_cache;
+static std::mutex gemv_i8_tune_mutex;
+
+static std::string gemvI8CacheKey(int64_t M, int64_t N, int64_t K,
+                                   int64_t bs, bool has_zp) {
+    // has_zp affects the inner loop (one global ZP read per iter), so
+    // configs may rank differently with vs without -- key on it.
+    return std::to_string(M) + "_" + std::to_string(N) + "_" +
+           std::to_string(K) + "_" + std::to_string(bs) + "_" +
+           (has_zp ? "1" : "0");
+}
+
+static int getOrTuneGemvConfigI8(
+    hipStream_t stream,
+    const __half* A, const uint8_t* B,
+    const __half* sc, const uint8_t* zp,
+    const __half* bi, __half* out,
+    int64_t M, int64_t N, int64_t K,
+    int64_t batch, int64_t bs)
+{
+    const bool has_zp = (zp != nullptr);
+    std::string key = gemvI8CacheKey(M, N, K, bs, has_zp);
+
+    std::lock_guard<std::mutex> lock(gemv_i8_tune_mutex);
+
+    auto it = gemv_i8_cache.find(key);
+    if (it != gemv_i8_cache.end())
+        return it->second;
+
+    int best = tuneGemvConfigI8(stream, A, B, sc, zp, bi, out,
+                                 M, N, K, batch, bs);
+    gemv_i8_cache[key] = best;
+
+    CUSTOM_KERNELS_DEBUG_LOG(
+        "[custom_kernels] GEMV-i8 cache: stored key=\"%s\" -> config[%d] "
+        "(cache size=%zu)\n",
+        key.c_str(), best, gemv_i8_cache.size());
 
     return best;
 }
@@ -1425,6 +1827,505 @@ static int getOrTuneWmmaConfig(
 }
 
 /* =======================================================================
+ * Section 2c: WMMA kernel for int8 weights (fused dequant)
+ *
+ * Mirrors GemmFp16U4Impl above, but specialized for the bits=8 layout:
+ *   B      : uint8 [N, K]                       (one byte per weight)
+ *   scales : fp16  [N, num_groups_k]
+ *   zeros  : uint8 [N, num_groups_k]            (or NULL, default zp=128)
+ *
+ * The shared-memory tile pipeline, double buffering, register prefetch,
+ * grid swizzle, and writeback are all identical to the int4 path. Two
+ * differences:
+ *
+ *   1. B byte indexing: per-thread base is `b_n_g * K + b_k8` (each weight
+ *      is a full byte, no nibble packing), and the K-step advance is
+ *      `t` bytes (not `t/2`).
+ *
+ *   2. Per-thread B load is 8 bytes (uint2 = 64-bit) for 8 elements,
+ *      versus 4 bytes (uint32_t) for 8 nibbles in int4. The
+ *      `THR * 8 == BN * BK` invariant -- 8 elements per thread per
+ *      K-step -- is preserved, so the tile/warp shape math is unchanged.
+ *
+ *   3. ZP is read as uint8 directly (not pre-converted to fp16) since the
+ *      nibble unpack of int4 zeros isn't needed. Zero is applied via the
+ *      same `neg_zs = -zp * scale` precomputation, just with a uint8
+ *      source.
+ *
+ * Default zp follows the ONNX MatMulNBits spec: 2^(bits-1) = 128 for
+ * bits=8, baked into the USE_ZEROS=false branch as a constexpr.
+ * ======================================================================= */
+
+template <int BM_T, int BN_T, int WT_M, int WT_N, bool USE_ZEROS,
+          bool BOUNDS_CHECK = false>
+__device__ __forceinline__
+void GemmFp16I8Impl(
+    int M, int N, int K,
+    const _Float16* __restrict__ A, int lda,
+    const unsigned char* __restrict__ B,
+    const _Float16* __restrict__ scales,
+    const unsigned char* __restrict__ zeros,
+    int group_size, int num_groups_k,
+    _Float16* __restrict__ C, int ldc,
+    int swizzle_n = 4)
+{
+    constexpr int WM_L   = BM_T / (WT_M * 16);
+    constexpr int WN_L   = BN_T / (WT_N * 16);
+    constexpr int THR_L  = WM_L * WN_L * 32;
+    constexpr int BK_T   = BM_T / (WT_M * WT_N);
+
+    constexpr int PAD_K   = 2;
+    constexpr int K_STR   = BK_T + PAD_K;
+    constexpr int A_VL    = (BM_T * BK_T) / (THR_L * 4);
+    constexpr int A_GRP_K = BK_T / 2;
+    constexpr int K_STEPS = BK_T / WMMA_TILE;
+
+    static_assert(A_VL >= 1, "A_VL must be >= 1");
+    static_assert(THR_L * 8 == BN_T * BK_T,
+                  "B loading balance: THR*8 must equal BN*BK");
+
+    __shared__ _Float16 smA[2][BM_T][K_STR];
+    __shared__ _Float16 smB[2][BN_T][K_STR];
+
+    const int tid  = threadIdx.x;
+    const int wid  = tid / 32;
+    const int lid  = tid % 32;
+    const int lane = lid % 16;
+    const int sub  = lid / 16;
+    const int wrow = wid / WN_L;
+    const int wcol = wid % WN_L;
+
+    const int n_tiles  = gridDim.x;
+    const int m_tiles  = gridDim.y;
+    const int block_id = blockIdx.y * n_tiles + blockIdx.x;
+    const int sw       = (n_tiles >= swizzle_n) ? swizzle_n : n_tiles;
+    const int super    = block_id / (sw * m_tiles);
+    const int rem      = block_id % (sw * m_tiles);
+    int by             = rem / sw;
+    int bx             = super * sw + rem % sw;
+    if (bx >= n_tiles) {
+        bx = block_id % n_tiles;
+        by = block_id / n_tiles;
+    }
+    const int row0 = by * BM_T;
+    const int col0 = bx * BN_T;
+
+    // Each thread is responsible for an 8-element K-strip in one of the BN
+    // columns. With THR*8 == BN*BK, threads divide neatly into
+    // (BN columns) x (BK/8 K-strips per column).
+    constexpr int B_COL_SHIFT = __builtin_ctz(BK_T / 8);
+    const int b_col       = tid >> B_COL_SHIFT;
+    const int b_sub       = tid & ((1 << B_COL_SHIFT) - 1);
+    const int b_k8        = b_sub << 3;
+    const int b_n_g_raw   = col0 + b_col;
+    const bool b_valid    = BOUNDS_CHECK ? (b_n_g_raw < N) : true;
+    const int b_n_g       = (BOUNDS_CHECK && !b_valid) ? 0 : b_n_g_raw;
+
+    // Per-thread base offsets (constant across the K-loop).
+    const int b_elem_base = b_n_g * K + b_k8;
+    const int b_gid_base  = b_n_g * num_groups_k;
+    int      cached_k_grp = -1;
+    int      next_grp_k   = 0;
+    _Float16 cached_s     = 0;
+    _Float16 neg_zs       = 0;
+
+    float8 acc[WT_M][WT_N];
+#pragma unroll
+    for (int i = 0; i < WT_M; i++)
+#pragma unroll
+        for (int j = 0; j < WT_N; j++)
+#pragma unroll
+            for (int e = 0; e < 8; e++)
+                acc[i][j][e] = 0.0f;
+
+    // Register prefetch slots, mirroring the int4 path.
+    uint32_t pf_a1[A_VL], pf_a2[A_VL];
+    int      pf_am[A_VL], pf_ak[A_VL];
+    uint2    pf_b8 = {0, 0};
+
+    auto issueLoads = [&](int t) __attribute__((always_inline)) {
+#pragma unroll
+        for (int ld = 0; ld < A_VL; ld++) {
+            int vid    = tid + ld * THR_L;
+            pf_ak[ld]  = (vid % A_GRP_K) * 2;
+            pf_am[ld]  = (vid / A_GRP_K) * 2;
+            if constexpr (!BOUNDS_CHECK) {
+                pf_a1[ld] = *reinterpret_cast<const uint32_t*>(
+                                  &A[(row0 + pf_am[ld]) * lda + t + pf_ak[ld]]);
+                pf_a2[ld] = *reinterpret_cast<const uint32_t*>(
+                                  &A[(row0 + pf_am[ld] + 1) * lda + t + pf_ak[ld]]);
+            } else {
+                int row_a = row0 + pf_am[ld];
+                if (row_a + 1 < M) {
+                    pf_a1[ld] = *reinterpret_cast<const uint32_t*>(
+                                      &A[row_a * lda + t + pf_ak[ld]]);
+                    pf_a2[ld] = *reinterpret_cast<const uint32_t*>(
+                                      &A[(row_a + 1) * lda + t + pf_ak[ld]]);
+                } else if (row_a < M) {
+                    pf_a1[ld] = *reinterpret_cast<const uint32_t*>(
+                                      &A[row_a * lda + t + pf_ak[ld]]);
+                    pf_a2[ld] = 0;
+                } else {
+                    pf_a1[ld] = 0;
+                    pf_a2[ld] = 0;
+                }
+            }
+        }
+
+        if (b_valid) {
+            // Load 8 bytes (= 8 int8 weights) per K-step. K-step is `t`,
+            // and per-thread offset within the step is `b_k8`. The base
+            // already includes b_k8, so the byte address is `b_elem_base + t`.
+            pf_b8 = *reinterpret_cast<const uint2*>(&B[b_elem_base + t]);
+
+            // Group/scale stepping: K-step is `t` (in elements). When `t`
+            // crosses a group boundary, advance the cached scale and (if
+            // present) the cached -zp*scale precomputation.
+            if (__builtin_expect(t >= next_grp_k, 0)) {
+                cached_k_grp++;
+                next_grp_k += group_size;
+                cached_s = scales[cached_k_grp + b_gid_base];
+                if constexpr (USE_ZEROS) {
+                    _Float16 zp_h = static_cast<_Float16>(
+                                        zeros[cached_k_grp + b_gid_base]);
+                    neg_zs = -zp_h * cached_s;
+                } else {
+                    // ONNX default zp = 2^(bits-1) = 128 for bits=8.
+                    neg_zs = (_Float16)(-128) * cached_s;
+                }
+            }
+        }
+    };
+
+    auto storeToShared = [&](int buf) __attribute__((always_inline)) {
+        if (b_valid) {
+            _Float16 s16 = cached_s;
+            _Float16 nzs = neg_zs;
+            _Float16 bv[8];
+
+            // Decode 8 uint8 weights from the two 32-bit lanes of pf_b8.
+            // For each byte: bv[i] = (byte) * scale + (-zp * scale)
+            //                       = (byte - zp) * scale
+            // The factored form lets the FMA tree fuse mul+add into one op.
+            bv[0] = static_cast<_Float16>((pf_b8.x      ) & 0xFFu) * s16 + nzs;
+            bv[1] = static_cast<_Float16>((pf_b8.x >>  8) & 0xFFu) * s16 + nzs;
+            bv[2] = static_cast<_Float16>((pf_b8.x >> 16) & 0xFFu) * s16 + nzs;
+            bv[3] = static_cast<_Float16>((pf_b8.x >> 24)        ) * s16 + nzs;
+            bv[4] = static_cast<_Float16>((pf_b8.y      ) & 0xFFu) * s16 + nzs;
+            bv[5] = static_cast<_Float16>((pf_b8.y >>  8) & 0xFFu) * s16 + nzs;
+            bv[6] = static_cast<_Float16>((pf_b8.y >> 16) & 0xFFu) * s16 + nzs;
+            bv[7] = static_cast<_Float16>((pf_b8.y >> 24)        ) * s16 + nzs;
+
+            *reinterpret_cast<uint2*>(&smB[buf][b_col][b_k8])     =
+                *reinterpret_cast<uint2*>(&bv[0]);
+            *reinterpret_cast<uint2*>(&smB[buf][b_col][b_k8 + 4]) =
+                *reinterpret_cast<uint2*>(&bv[4]);
+        } else {
+            uint2 zero2 = {0, 0};
+            *reinterpret_cast<uint2*>(&smB[buf][b_col][b_k8])     = zero2;
+            *reinterpret_cast<uint2*>(&smB[buf][b_col][b_k8 + 4]) = zero2;
+        }
+
+#pragma unroll
+        for (int ld = 0; ld < A_VL; ld++) {
+            *reinterpret_cast<uint32_t*>(&smA[buf][pf_am[ld]    ][pf_ak[ld]]) =
+                pf_a1[ld];
+            *reinterpret_cast<uint32_t*>(&smA[buf][pf_am[ld] + 1][pf_ak[ld]]) =
+                pf_a2[ld];
+        }
+    };
+
+    auto computeWMMA = [&](int buf) __attribute__((always_inline)) {
+#pragma unroll
+        for (int ks = 0; ks < K_STEPS; ks++) {
+            half16 b_frag[WT_N];
+#pragma unroll
+            for (int wn = 0; wn < WT_N; wn++) {
+                int noff              = (wcol * WT_N + wn) * WMMA_TILE;
+                uint32_t* dst         = reinterpret_cast<uint32_t*>(&b_frag[wn]);
+                const uint32_t* src   = reinterpret_cast<const uint32_t*>(
+                    &smB[buf][noff + lane][ks * WMMA_TILE]);
+#pragma unroll
+                for (int i = 0; i < 8; i++)
+                    dst[i] = src[i];
+            }
+#pragma unroll
+            for (int wm = 0; wm < WT_M; wm++) {
+                int moff              = (wrow * WT_M + wm) * WMMA_TILE;
+                half16 a_frag;
+                uint32_t* dst         = reinterpret_cast<uint32_t*>(&a_frag);
+                const uint32_t* src   = reinterpret_cast<const uint32_t*>(
+                    &smA[buf][moff + lane][ks * WMMA_TILE]);
+#pragma unroll
+                for (int i = 0; i < 8; i++)
+                    dst[i] = src[i];
+
+#pragma unroll
+                for (int wn = 0; wn < WT_N; wn++)
+                    acc[wm][wn] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(
+                        a_frag, b_frag[wn], acc[wm][wn]);
+            }
+        }
+    };
+
+    issueLoads(0);
+    storeToShared(0);
+    __syncthreads();
+
+    int buf = 0;
+    for (int t = BK_T; t < K; t += BK_T) {
+        int nxt = 1 - buf;
+        issueLoads(t);
+        computeWMMA(buf);
+        storeToShared(nxt);
+        __syncthreads();
+        buf = nxt;
+    }
+    computeWMMA(buf);
+
+#pragma unroll
+    for (int wm = 0; wm < WT_M; wm++) {
+        int mbase = row0 + (wrow * WT_M + wm) * WMMA_TILE;
+#pragma unroll
+        for (int wn = 0; wn < WT_N; wn++) {
+            int nbase = col0 + (wcol * WT_N + wn) * WMMA_TILE;
+#pragma unroll
+            for (int e = 0; e < 8; e++) {
+                int r = e * 2 + sub;
+                if constexpr (BOUNDS_CHECK) {
+                    if (mbase + r < M && nbase + lane < N)
+                        __builtin_nontemporal_store(
+                            (_Float16)acc[wm][wn][e],
+                            &C[(mbase + r) * ldc + nbase + lane]);
+                } else {
+                    __builtin_nontemporal_store(
+                        (_Float16)acc[wm][wn][e],
+                        &C[(mbase + r) * ldc + nbase + lane]);
+                }
+            }
+        }
+    }
+}
+
+/* int8 WMMA entry kernels: fused dequant only (no separate-DQ variant in v1) */
+
+template <int BM_T = 128, int BN_T = 128, int WT_M = 2, int WT_N = 2,
+          int WAVES_EU = 8, bool BC = false>
+__global__
+__attribute__((amdgpu_flat_work_group_size(
+    GEMM_WG_SZ(BM_T, BN_T, WT_M, WT_N),
+    GEMM_WG_SZ(BM_T, BN_T, WT_M, WT_N))))
+__attribute__((amdgpu_waves_per_eu(WAVES_EU)))
+void MatMulNBitsWMMA_I8_NoZP(
+    int M, int N, int K,
+    const _Float16* __restrict__ A, int lda,
+    const unsigned char* __restrict__ B,
+    const _Float16* __restrict__ scales,
+    const unsigned char* __restrict__ zeros,
+    int group_size, int num_groups_k,
+    _Float16* __restrict__ C, int ldc,
+    int swizzle_n = 4)
+{
+    GemmFp16I8Impl<BM_T, BN_T, WT_M, WT_N, false, BC>(
+        M, N, K, A, lda, B, scales, zeros,
+        group_size, num_groups_k, C, ldc, swizzle_n);
+}
+
+template <int BM_T = 128, int BN_T = 128, int WT_M = 2, int WT_N = 2,
+          int WAVES_EU = 8, bool BC = false>
+__global__
+__attribute__((amdgpu_flat_work_group_size(
+    GEMM_WG_SZ(BM_T, BN_T, WT_M, WT_N),
+    GEMM_WG_SZ(BM_T, BN_T, WT_M, WT_N))))
+__attribute__((amdgpu_waves_per_eu(WAVES_EU)))
+void MatMulNBitsWMMA_I8_ZP(
+    int M, int N, int K,
+    const _Float16* __restrict__ A, int lda,
+    const unsigned char* __restrict__ B,
+    const _Float16* __restrict__ scales,
+    const unsigned char* __restrict__ zeros,
+    int group_size, int num_groups_k,
+    _Float16* __restrict__ C, int ldc,
+    int swizzle_n = 4)
+{
+    GemmFp16I8Impl<BM_T, BN_T, WT_M, WT_N, true, BC>(
+        M, N, K, A, lda, B, scales, zeros,
+        group_size, num_groups_k, C, ldc, swizzle_n);
+}
+
+/* -----------------------------------------------------------------------
+ * WMMA-i8 Autotune: subset of the int4 fused tile shapes
+ *
+ * v1 ships a fused-only path -- no separate-dequant int8 variant -- so
+ * the table is the fused subset of kWmmaConfigs. The WT_M=4 (256x128) and
+ * WT_N=1 (BN=32) special tile shapes are omitted in v1; the basic
+ * 64x64..128x256 sweep covers Qwen3.5-MoE int8 shapes (N in {32, 2048,
+ * 4096, 8192}, K=2048) without them.
+ * ----------------------------------------------------------------------- */
+
+struct WmmaConfigI8 {
+    int bm, bn;
+    int swizzle_n;
+};
+
+static constexpr WmmaConfigI8 kWmmaI8Configs[] = {
+    { 64,  64,  2}, { 64,  64,  4}, { 64,  64,  8}, { 64,  64, 16},
+    { 64, 128,  2}, { 64, 128,  4}, { 64, 128,  8}, { 64, 128, 16},
+    {128,  64,  2}, {128,  64,  4}, {128,  64,  8}, {128,  64, 16},
+    {128, 128,  2}, {128, 128,  4}, {128, 128,  8}, {128, 128, 16},
+    {128, 128, 32}, {128, 128, 64},
+    {128, 256,  4}, {128, 256,  8}, {128, 256, 16}, {128, 256, 32},
+};
+static constexpr int kNumWmmaI8Configs =
+    static_cast<int>(sizeof(kWmmaI8Configs) / sizeof(kWmmaI8Configs[0]));
+
+static void launchWmmaConfigI8(
+    int config_id, hipStream_t stream,
+    int M, int N, int K,
+    const _Float16* A, int lda,
+    const unsigned char* B,
+    const _Float16* scales, const unsigned char* zeros,
+    int gs, int ngk,
+    _Float16* C, int ldc, bool has_zp)
+{
+    auto& c = kWmmaI8Configs[config_id];
+    bool need_bc = (M % c.bm != 0) || (N % c.bn != 0);
+
+#define WMMA_I8_LAUNCH(BM_V, BN_V, BC_V) do {                                 \
+    constexpr int WM_  = BM_V / (2 * 16);                                     \
+    constexpr int WN_  = BN_V / (2 * 16);                                     \
+    constexpr int THR_ = WM_ * WN_ * 32;                                      \
+    dim3 grid_(static_cast<unsigned>((N + BN_V - 1) / BN_V),                  \
+               static_cast<unsigned>((M + BM_V - 1) / BM_V));                 \
+    dim3 block_(THR_);                                                        \
+    if (has_zp) {                                                             \
+        hipLaunchKernelGGL(                                                   \
+            HIP_KERNEL_NAME(                                                  \
+                MatMulNBitsWMMA_I8_ZP<BM_V, BN_V, 2, 2, 8, BC_V>),            \
+            grid_, block_, 0, stream,                                         \
+            M, N, K, A, lda, B, scales, zeros, gs, ngk, C, ldc, c.swizzle_n); \
+    } else {                                                                  \
+        hipLaunchKernelGGL(                                                   \
+            HIP_KERNEL_NAME(                                                  \
+                MatMulNBitsWMMA_I8_NoZP<BM_V, BN_V, 2, 2, 8, BC_V>),          \
+            grid_, block_, 0, stream,                                         \
+            M, N, K, A, lda, B, scales, zeros, gs, ngk, C, ldc, c.swizzle_n); \
+    }                                                                         \
+} while (0)
+
+#define WMMA_I8_TILE_CASE(BM_V, BN_V) \
+    if (need_bc) WMMA_I8_LAUNCH(BM_V, BN_V, true);  \
+    else         WMMA_I8_LAUNCH(BM_V, BN_V, false)
+
+         if (c.bm ==  64 && c.bn ==  64) WMMA_I8_TILE_CASE( 64,  64);
+    else if (c.bm ==  64 && c.bn == 128) WMMA_I8_TILE_CASE( 64, 128);
+    else if (c.bm == 128 && c.bn ==  64) WMMA_I8_TILE_CASE(128,  64);
+    else if (c.bm == 128 && c.bn == 256) WMMA_I8_TILE_CASE(128, 256);
+    else                                  WMMA_I8_TILE_CASE(128, 128);
+
+#undef WMMA_I8_TILE_CASE
+#undef WMMA_I8_LAUNCH
+}
+
+static int tuneWmmaConfigI8(
+    hipStream_t stream,
+    int M, int N, int K,
+    const _Float16* A, int lda,
+    const unsigned char* B,
+    const _Float16* scales, const unsigned char* zeros,
+    int gs, int ngk,
+    _Float16* C, int ldc, bool has_zp)
+{
+    hipEvent_t ev0, ev1;
+    hipEventCreate(&ev0);
+    hipEventCreate(&ev1);
+
+    float best_ms = 1e30f;
+    int   best_id = 12; // 128x128 sw=2: a safe default for typical N>=64
+    constexpr int WARMUP = 1;
+    constexpr int ITERS  = 5;
+
+    for (int cid = 0; cid < kNumWmmaI8Configs; cid++) {
+        auto& cfg = kWmmaI8Configs[cid];
+        // Skip large BN tiles when N is too small to benefit.
+        if (cfg.bn > N * 2) continue;
+
+        for (int w = 0; w < WARMUP; w++)
+            launchWmmaConfigI8(cid, stream, M, N, K, A, lda, B,
+                               scales, zeros, gs, ngk, C, ldc, has_zp);
+
+        hipEventRecord(ev0, stream);
+        for (int i = 0; i < ITERS; i++)
+            launchWmmaConfigI8(cid, stream, M, N, K, A, lda, B,
+                               scales, zeros, gs, ngk, C, ldc, has_zp);
+        hipEventRecord(ev1, stream);
+        hipEventSynchronize(ev1);
+
+        float ms = 0.0f;
+        hipEventElapsedTime(&ms, ev0, ev1);
+
+        CUSTOM_KERNELS_DEBUG_LOG(
+            "[custom_kernels]   wmma-i8 config[%2d] bm=%3d bn=%3d sw=%d : %.4f ms\n",
+            cid, cfg.bm, cfg.bn, cfg.swizzle_n, ms / ITERS);
+
+        if (ms < best_ms) {
+            best_ms = ms;
+            best_id = cid;
+        }
+    }
+
+    hipEventDestroy(ev0);
+    hipEventDestroy(ev1);
+
+    CUSTOM_KERNELS_DEBUG_LOG(
+        "[custom_kernels] WMMA-i8 autotune: M=%d N=%d K=%d gs=%d zp=%s -> "
+        "best config[%d] bm=%d bn=%d sw=%d (%.4f ms/iter)\n",
+        M, N, K, gs, has_zp ? "yes" : "no",
+        best_id, kWmmaI8Configs[best_id].bm, kWmmaI8Configs[best_id].bn,
+        kWmmaI8Configs[best_id].swizzle_n, best_ms / ITERS);
+
+    return best_id;
+}
+
+static std::unordered_map<std::string, int> wmma_i8_cache;
+static std::mutex wmma_i8_tune_mutex;
+
+static std::string wmmaI8CacheKey(int M, int N, int K, int gs, bool has_zp) {
+    return std::to_string(M) + "_" + std::to_string(N) + "_" +
+           std::to_string(K) + "_" + std::to_string(gs) + "_" +
+           (has_zp ? "1" : "0");
+}
+
+static int getOrTuneWmmaConfigI8(
+    hipStream_t stream,
+    int M, int N, int K,
+    const _Float16* A, int lda,
+    const unsigned char* B,
+    const _Float16* scales, const unsigned char* zeros,
+    int gs, int ngk,
+    _Float16* C, int ldc, bool has_zp)
+{
+    std::string key = wmmaI8CacheKey(M, N, K, gs, has_zp);
+
+    std::lock_guard<std::mutex> lock(wmma_i8_tune_mutex);
+
+    auto it = wmma_i8_cache.find(key);
+    if (it != wmma_i8_cache.end())
+        return it->second;
+
+    int best = tuneWmmaConfigI8(stream, M, N, K, A, lda, B,
+                                 scales, zeros, gs, ngk, C, ldc, has_zp);
+    wmma_i8_cache[key] = best;
+
+    CUSTOM_KERNELS_DEBUG_LOG(
+        "[custom_kernels] WMMA-i8 cache: stored key=\"%s\" -> config[%d] "
+        "(cache size=%zu)\n",
+        key.c_str(), best, wmma_i8_cache.size());
+
+    return best;
+}
+
+/* =======================================================================
  * Section 3: Post-WMMA bias addition (row-major output)
  *
  * C is row-major [M x N] with ldc = N.
@@ -1556,25 +2457,111 @@ extern "C" int hip_matmul_nbits(
               (long long)zp_elem_size);
       return -1;
     }
-    CUSTOM_KERNELS_DEBUG_LOG(
-        "[custom_kernels] hip_matmul_nbits: int8 naive M=%lld N=%lld K=%lld "
-        "batch=%lld bs=%lld zp=%s bias=%s\n",
-        (long long)M, (long long)N, (long long)K, (long long)batch_count,
-        (long long)block_size, zero_points ? "yes" : "null",
-        bias ? "yes" : "null");
 
-    dim3 blk(kBlockDim, kBlockDim);
-    dim3 grd(static_cast<unsigned>((N + kBlockDim - 1) / kBlockDim),
-             static_cast<unsigned>((M + kBlockDim - 1) / kBlockDim),
-             static_cast<unsigned>(batch_count));
+    // Three int8 paths, in priority order:
+    //
+    //   1. WMMA-i8 fast path (M >= 16, batch=1, K%32==0, group_size % 32 == 0
+    //      and >= 32): autotuned 16x16x16 fp16 WMMA tiles with fused
+    //      dequant. Used for prefill-shaped GEMMs (Qwen3.5-MoE int8
+    //      lm_head, expert up/gate projections at seq_len > 1).
+    //   2. GEMV-i8 path (block_size >= 16): autotuned BLOCK_SIZE x TILE_N
+    //      reduction, vectorized B loads. Used for decode (M=1) and small-M
+    //      shapes that don't meet WMMA's M>=16 threshold.
+    //   3. Naive fallback: thread-per-element kernel for unusual shapes
+    //      that fail both gates above.
+    //
+    // The WMMA path's group_size gate enforces group_size >= BK_T and
+    // group_size % BK_T == 0 for all configs in kWmmaI8Configs (max BK_T =
+    // 32, min = 16), so groups always align with K-step boundaries inside
+    // the kernel. Common quantization (gs in {32, 64, 128}) satisfies it.
+    constexpr int kI8GemvMinBs = 16;
+    const bool wmma_data_format = (batch_count == 1) && (K % 32 == 0);
+    const bool use_wmma_i8 =
+        wmma_data_format && (M >= kBlockDim) &&
+        (block_size >= 32) && (block_size % 32 == 0);
+    const bool use_gemv_i8 = !use_wmma_i8 && (block_size >= kI8GemvMinBs);
 
-    hipLaunchKernelGGL(
-        matmul_nbits_kernel_i8, grd, blk, 0, hip_stream,
-        static_cast<const __half*>(A), static_cast<const uint8_t*>(B),
-        static_cast<const __half*>(scales),
-        static_cast<const uint8_t*>(zero_points),
-        static_cast<const __half*>(bias), static_cast<__half*>(output),
-        M, N, K, block_size);
+    if (use_wmma_i8) {
+      int iM  = static_cast<int>(M);
+      int iN  = static_cast<int>(N);
+      int iK  = static_cast<int>(K);
+      int gs  = static_cast<int>(block_size);
+      int ngk = static_cast<int>((K + block_size - 1) / block_size);
+      int lda = iK;
+      int ldc = iN;
+
+      const auto* a_ptr  = static_cast<const _Float16*>(A);
+      const auto* b_ptr  = static_cast<const unsigned char*>(B);
+      const auto* s_ptr  = static_cast<const _Float16*>(scales);
+      const auto* z_ptr  = static_cast<const unsigned char*>(zero_points);
+      auto*       o_ptr  = static_cast<_Float16*>(output);
+
+      bool has_zp = (z_ptr != nullptr);
+      int cfg_id = getOrTuneWmmaConfigI8(
+          hip_stream, iM, iN, iK, a_ptr, lda, b_ptr,
+          s_ptr, z_ptr, gs, ngk, o_ptr, ldc, has_zp);
+
+      CUSTOM_KERNELS_DEBUG_LOG(
+          "[custom_kernels] hip_matmul_nbits: int8 WMMA M=%d N=%d K=%d "
+          "bs=%d zp=%s bias=%s cfg=%d\n",
+          iM, iN, iK, gs, has_zp ? "yes" : "null",
+          bias ? "yes" : "null", cfg_id);
+
+      launchWmmaConfigI8(cfg_id, hip_stream, iM, iN, iK, a_ptr, lda, b_ptr,
+                         s_ptr, z_ptr, gs, ngk, o_ptr, ldc, has_zp);
+
+      // Bias is added as a separate row-major pass (same kernel as int4 WMMA).
+      if (bias) {
+        dim3 bias_grid(static_cast<unsigned>((iN + 255) / 256),
+                       static_cast<unsigned>(iM));
+        dim3 bias_block(256);
+        hipLaunchKernelGGL(
+            matmul_nbits_add_bias_rowmajor, bias_grid, bias_block,
+            0, hip_stream,
+            o_ptr, static_cast<const _Float16*>(bias), iM, iN, ldc);
+      }
+    } else if (use_gemv_i8) {
+      const auto* a_ptr  = static_cast<const __half*>(A);
+      const auto* b_ptr  = static_cast<const uint8_t*>(B);
+      const auto* sc_ptr = static_cast<const __half*>(scales);
+      const auto* zp_ptr = static_cast<const uint8_t*>(zero_points);
+      const auto* bi_ptr = static_cast<const __half*>(bias);
+      auto*       o_ptr  = static_cast<__half*>(output);
+
+      int cfg_id = getOrTuneGemvConfigI8(
+          hip_stream, a_ptr, b_ptr, sc_ptr, zp_ptr, bi_ptr, o_ptr,
+          M, N, K, batch_count, block_size);
+
+      CUSTOM_KERNELS_DEBUG_LOG(
+          "[custom_kernels] hip_matmul_nbits: int8 GEMV M=%lld N=%lld "
+          "K=%lld batch=%lld bs=%lld zp=%s bias=%s cfg=%d\n",
+          (long long)M, (long long)N, (long long)K, (long long)batch_count,
+          (long long)block_size, zero_points ? "yes" : "null",
+          bias ? "yes" : "null", cfg_id);
+
+      launchGemvConfigI8(cfg_id, hip_stream, a_ptr, b_ptr, sc_ptr, zp_ptr,
+                         bi_ptr, o_ptr, M, N, K, batch_count, block_size);
+    } else {
+      CUSTOM_KERNELS_DEBUG_LOG(
+          "[custom_kernels] hip_matmul_nbits: int8 naive M=%lld N=%lld K=%lld "
+          "batch=%lld bs=%lld zp=%s bias=%s\n",
+          (long long)M, (long long)N, (long long)K, (long long)batch_count,
+          (long long)block_size, zero_points ? "yes" : "null",
+          bias ? "yes" : "null");
+
+      dim3 blk(kBlockDim, kBlockDim);
+      dim3 grd(static_cast<unsigned>((N + kBlockDim - 1) / kBlockDim),
+               static_cast<unsigned>((M + kBlockDim - 1) / kBlockDim),
+               static_cast<unsigned>(batch_count));
+
+      hipLaunchKernelGGL(
+          matmul_nbits_kernel_i8, grd, blk, 0, hip_stream,
+          static_cast<const __half*>(A), static_cast<const uint8_t*>(B),
+          static_cast<const __half*>(scales),
+          static_cast<const uint8_t*>(zero_points),
+          static_cast<const __half*>(bias), static_cast<__half*>(output),
+          M, N, K, block_size);
+    }
 
     hipError_t err = hipGetLastError();
     if (err != hipSuccess) {

--- a/3rd-party/custom_kernels/include/hip_custom_kernels.h
+++ b/3rd-party/custom_kernels/include/hip_custom_kernels.h
@@ -782,6 +782,58 @@ int hip_linear_attention_decode(
     int64_t type);
 
 /* =========================================================================
+ * Causal Depthwise 1D Conv -- single-step "decode" path
+ * =========================================================================
+ *
+ * Fused fast path for the seq_len == 1 case of CausalConvWithState used by
+ * Mamba / Gated DeltaNet decoders. Replaces the MIOpen virtual-buffer +
+ * convolution + bias + activation chain with one compute kernel that:
+ *   - reads past_state[b,c,0..k-2] (or zero if past_state==nullptr),
+ *   - reads input[b,c,0],
+ *   - computes the depthwise convolution dot product:
+ *       output[b,c,0] = sum_{j=0..k-2} weight[c,0,j] * past_state[b,c,j]
+ *                     + weight[c,0,k-1] * input[b,c,0]
+ *                     + (bias ? bias[c] : 0)
+ *   - applies optional SiLU (activation == 1):
+ *       output[b,c,0] *= 1 / (1 + exp(-output[b,c,0]))
+ *   - writes the new state by shifting forward by one step:
+ *       present_state[b,c,0..k-3] = past_state[b,c,1..k-2]
+ *       present_state[b,c,k-2]    = input[b,c,0]
+ *
+ * Bypasses hipMemcpy2DAsync entirely: at decode-shape (rows=B*C, width=k-1
+ * elements) the 2D copy has thousands of pathologically thin rows and is
+ * massively slower than a single launch with the same arithmetic.
+ *
+ * Shapes (matching wrap_causal_conv_with_state layout):
+ *   input         [B, C, 1]           (past_state is [B, C, k-1])
+ *   weight        [C, 1, k]           (depthwise: one k-tap filter per channel)
+ *   bias          [C] or nullptr
+ *   output        [B, C, 1]
+ *   past_state    [B, C, k-1] or nullptr (treated as zeros)
+ *   present_state [B, C, k-1]
+ *
+ * Constraints:
+ *   - kernel_size in [1, 8]   (k-1 fits in a small register array)
+ *   - element_size_bytes in {2, 4} (fp16 or fp32; matches wrapper validation)
+ *   - activation in {0, 1}   (0=none, 1=SiLU)
+ *
+ * Returns: 0 on success, non-zero on failure.
+ */
+int hip_causal_conv_step_decode(
+    void* stream,
+    const void* input,
+    const void* weight,
+    const void* bias,
+    const void* past_state,
+    void* output,
+    void* present_state,
+    int64_t batch_size,
+    int64_t channels,
+    int64_t kernel_size,
+    int64_t activation,
+    int64_t element_size_bytes);
+
+/* =========================================================================
  * WMMA GEMM (Small-M Matrix Multiply via Wave Matrix Multiply-Accumulate)
  * =========================================================================
  *

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -198,6 +198,10 @@ macro(compile_to_bitcode SOURCE_FILE OUTPUT_BC)
                 ${CMAKE_CURRENT_SOURCE_DIR}/hipdnn_ep_runtime.h
                 ${CMAKE_CURRENT_SOURCE_DIR}/op_profile.h
                 ${CMAKE_CURRENT_SOURCE_DIR}/debug_log.h
+                ${CMAKE_CURRENT_SOURCE_DIR}/runtime_state_internal.h
+                ${CMAKE_CURRENT_SOURCE_DIR}/runtime_types.h
+                ${CMAKE_CURRENT_SOURCE_DIR}/real/cache_utils.h
+                ${CMAKE_SOURCE_DIR}/3rd-party/custom_kernels/include/hip_custom_kernels.h
                 ${CMAKE_BINARY_DIR}/schemas/model_metadata_generated.h
         COMMENT "Compiling ${SOURCE_FILE} to bitcode"
         VERBATIM

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -163,7 +163,12 @@ macro(compile_to_bitcode SOURCE_FILE OUTPUT_BC)
         endforeach()
     endif()
 
-    # Add implementation directory
+    # Add implementation directory and collect impl-specific deps. Both
+    # `real/` and `mock/` ship their own `runtime_types.h` (resolved via the
+    # -I flag below), so the DEPENDS list must reference whichever copy the
+    # active build will actually compile against. `cache_utils.h` and the
+    # custom-kernels header only exist for the real GPU runtime.
+    set(IMPL_DEPS "")
     if(NOT BUILD_MOCK_RUNTIME)
         list(APPEND COMPILE_FLAGS "-I" "${CMAKE_CURRENT_SOURCE_DIR}/real")
 
@@ -176,8 +181,15 @@ macro(compile_to_bitcode SOURCE_FILE OUTPUT_BC)
             list(APPEND COMPILE_FLAGS "-I" "${THEROCK_DIST}/include")
             list(APPEND COMPILE_FLAGS "-D__HIP_PLATFORM_AMD__")
         endif()
+
+        list(APPEND IMPL_DEPS
+            ${CMAKE_CURRENT_SOURCE_DIR}/real/runtime_types.h
+            ${CMAKE_CURRENT_SOURCE_DIR}/real/cache_utils.h
+            ${CMAKE_SOURCE_DIR}/3rd-party/custom_kernels/include/hip_custom_kernels.h)
     else()
         list(APPEND COMPILE_FLAGS "-I" "${CMAKE_CURRENT_SOURCE_DIR}/mock")
+        list(APPEND IMPL_DEPS
+            ${CMAKE_CURRENT_SOURCE_DIR}/mock/runtime_types.h)
     endif()
 
     add_custom_command(
@@ -199,9 +211,7 @@ macro(compile_to_bitcode SOURCE_FILE OUTPUT_BC)
                 ${CMAKE_CURRENT_SOURCE_DIR}/op_profile.h
                 ${CMAKE_CURRENT_SOURCE_DIR}/debug_log.h
                 ${CMAKE_CURRENT_SOURCE_DIR}/runtime_state_internal.h
-                ${CMAKE_CURRENT_SOURCE_DIR}/runtime_types.h
-                ${CMAKE_CURRENT_SOURCE_DIR}/real/cache_utils.h
-                ${CMAKE_SOURCE_DIR}/3rd-party/custom_kernels/include/hip_custom_kernels.h
+                ${IMPL_DEPS}
                 ${CMAKE_BINARY_DIR}/schemas/model_metadata_generated.h
         COMMENT "Compiling ${SOURCE_FILE} to bitcode"
         VERBATIM

--- a/lib/Runtime/debug_log.h
+++ b/lib/Runtime/debug_log.h
@@ -39,18 +39,42 @@ inline bool hipdnn_ep_debug_enabled() {
   return enabled;
 }
 
+// Sync-isolated profiling mode (HIPDNN_EP_PERF_ISOLATE=1). Inserts a
+// hipStreamSynchronize at every OP_PROFILE scope boundary so each op's
+// reported GPU time is its true standalone runtime, with no carry-over from
+// prior queued work. Implies HIPDNN_EP_PERF=1. Kills concurrency by design;
+// only useful as a diagnostic to find ops whose real cost is being masked by
+// stream-queue depth in normal profiling.
+inline bool hipdnn_ep_perf_isolate_enabled() {
+  static const bool enabled = [] {
+#ifdef _WIN32
+    return detail::check_env("HIPDNN_EP_PERF_ISOLATE");
+#else
+    const char *v = std::getenv("HIPDNN_EP_PERF_ISOLATE");
+    return v && v[0] >= '1';
+#endif
+  }();
+  return enabled;
+}
+
 inline bool hipdnn_ep_perf_enabled() {
   // PERF intentionally does NOT inherit from HIPDNN_EP_DEBUG: enabling PERF
   // forces a hipStreamSynchronize on every inference (so hipEventElapsedTime
   // can sample the H2D / Compute / D2H phases), which serializes the GPU
   // pipeline and skews measurements. Users who only want the per-call
   // [Runtime DEBUG] traces should not pay that cost.
+  // ISOLATE implies PERF.
   static const bool enabled = [] {
 #ifdef _WIN32
-    return detail::check_env("HIPDNN_EP_PERF");
+    if (detail::check_env("HIPDNN_EP_PERF"))
+      return true;
+    return detail::check_env("HIPDNN_EP_PERF_ISOLATE");
 #else
     const char *v = std::getenv("HIPDNN_EP_PERF");
-    return v && v[0] >= '1';
+    if (v && v[0] >= '1')
+      return true;
+    const char *v2 = std::getenv("HIPDNN_EP_PERF_ISOLATE");
+    return v2 && v2[0] >= '1';
 #endif
   }();
   return enabled;

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -395,6 +395,9 @@ void *hipdnn_ep_state_get_op_profile(RuntimeState *state);
 // GQA GEMM cache lifecycle (managed by RuntimeState)
 void hipdnn_ep_gqa_gemm_cache_destroy(void *cache);
 
+// CausalConvWithState descriptor/algo cache lifecycle (managed by RuntimeState)
+void hipdnn_ep_causal_conv_cache_destroy(void *cache);
+
 // TensorBuffer Field Accessors (Opaque Pattern)
 //===----------------------------------------------------------------------===//
 //

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -216,6 +216,7 @@ static int initialize_state_handles(RuntimeState **out_state) {
   state->workspace = nullptr;
   state->workspace_size = 0;
   state->gqa_gemm_cache = nullptr;
+  state->causal_conv_cache = nullptr;
   state->op_profile = hipdnn_ep_perf_enabled() ? op_profile_create() : nullptr;
   state->device_error_flag = nullptr;
   state->hipdnn_handle = nullptr;
@@ -879,6 +880,12 @@ int hipdnn_ep_state_cleanup(RuntimeState *state) {
   if (state->gqa_gemm_cache) {
     hipdnn_ep_gqa_gemm_cache_destroy(state->gqa_gemm_cache);
     state->gqa_gemm_cache = nullptr;
+  }
+
+  // Free CausalConvWithState descriptor/algo cache
+  if (state->causal_conv_cache) {
+    hipdnn_ep_causal_conv_cache_destroy(state->causal_conv_cache);
+    state->causal_conv_cache = nullptr;
   }
 
   // Free op profiling state

--- a/lib/Runtime/op_profile.h
+++ b/lib/Runtime/op_profile.h
@@ -64,12 +64,21 @@ struct OpProfileScope {
   OpProfileScope(OpProfileState *p, std::string n, std::string sh,
                  hipStream_t s, int evIdx)
       : ps(p), name(std::move(n)), shape(std::move(sh)), eventIndex(evIdx),
-        stream(s), cpuStart(std::chrono::steady_clock::now()) {
+        stream(s) {
+    // Sync-isolated diagnostic mode: drain the stream BEFORE we start timing,
+    // so this op's reported GPU time excludes any work queued ahead of us.
+    // Pairs with the post-stop sync in the destructor to give standalone
+    // per-op timings (concurrency is killed by design -- diagnostic only).
+    if (hipdnn_ep_perf_isolate_enabled())
+      hipStreamSynchronize(stream);
+    cpuStart = std::chrono::steady_clock::now();
     hipEventRecord(op_profile_get_start_event(ps, eventIndex), stream);
   }
 
   ~OpProfileScope() {
     hipEventRecord(op_profile_get_stop_event(ps, eventIndex), stream);
+    if (hipdnn_ep_perf_isolate_enabled())
+      hipStreamSynchronize(stream);
     double ms = std::chrono::duration<double, std::milli>(
                     std::chrono::steady_clock::now() - cpuStart)
                     .count();

--- a/lib/Runtime/real/causal_conv_with_state.cpp
+++ b/lib/Runtime/real/causal_conv_with_state.cpp
@@ -5,6 +5,9 @@
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
 #include "../op_profile.h"
+#include "../runtime_state_internal.h"
+#include "cache_utils.h"
+#include "hip_custom_kernels.h"
 #include "runtime_types.h"
 
 #include <cassert>
@@ -12,6 +15,8 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <functional>
+#include <unordered_map>
 
 //===----------------------------------------------------------------------===//
 // CausalConvWithState: Stateful Causal Depthwise Convolution
@@ -32,6 +37,157 @@
 //   4. Optional SiLU activation: output = output * sigmoid(output)
 //===----------------------------------------------------------------------===//
 
+//===----------------------------------------------------------------------===//
+// Per-shape MIOpen descriptor + algorithm cache
+//
+// The compiled model has fully static shapes, so for a given layer the tuple
+// (dt, B, C, virtual_len, seq_len, k, has_bias, has_act) is invariant for
+// every Compute() call. Without this cache we would:
+//   - create+destroy 4-6 MIOpen descriptors per call,
+//   - call miopenInitConvolutionDescriptor + GroupCount per call,
+//   - run miopenFindConvolutionForwardAlgorithm (which actually launches
+//     candidate kernels and synchronizes) per call.
+//
+// All of that is amortized to once per shape per session here.
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+struct CausalConvKey {
+  int64_t dt;          // miopenDataType_t value
+  int64_t batch;       // B
+  int64_t channels;    // C
+  int64_t virtual_len; // state_len + seq_len
+  int64_t seq_len;     // L
+  int64_t kernel_size; // k
+  int64_t has_bias;    // 0 / 1
+  int64_t activation;  // 0 = none, 1 = SiLU
+
+  bool operator==(const CausalConvKey &o) const {
+    return dt == o.dt && batch == o.batch && channels == o.channels &&
+           virtual_len == o.virtual_len && seq_len == o.seq_len &&
+           kernel_size == o.kernel_size && has_bias == o.has_bias &&
+           activation == o.activation;
+  }
+};
+
+struct CausalConvKeyHash {
+  size_t operator()(const CausalConvKey &k) const {
+    size_t h = 0;
+    hash_combine_val(h, k.dt);
+    hash_combine_val(h, k.batch);
+    hash_combine_val(h, k.channels);
+    hash_combine_val(h, k.virtual_len);
+    hash_combine_val(h, k.seq_len);
+    hash_combine_val(h, k.kernel_size);
+    hash_combine_val(h, k.has_bias);
+    hash_combine_val(h, k.activation);
+    return h;
+  }
+};
+
+struct CausalConvCacheEntry {
+  miopenTensorDescriptor_t inDesc = nullptr;
+  miopenTensorDescriptor_t wDesc = nullptr;
+  miopenTensorDescriptor_t outDesc = nullptr;
+  miopenTensorDescriptor_t biasDesc = nullptr; // null if has_bias == 0
+  miopenConvolutionDescriptor_t convDesc = nullptr;
+  miopenActivationDescriptor_t actDesc = nullptr; // null if activation == 0
+  miopenConvFwdAlgorithm_t algo;                  // valid iff algo_valid
+  size_t algo_workspace_size = 0;                 // workspace bytes for algo
+  bool algo_valid = false;
+};
+
+struct CausalConvCache {
+  std::unordered_map<CausalConvKey, CausalConvCacheEntry, CausalConvKeyHash>
+      entries;
+};
+
+CausalConvCache *get_causal_conv_cache(RuntimeState *state) {
+  if (!state->causal_conv_cache)
+    state->causal_conv_cache = new CausalConvCache;
+  return static_cast<CausalConvCache *>(state->causal_conv_cache);
+}
+
+// Build the static (shape-only) descriptors. The convolution algorithm and its
+// workspace size are filled in lazily on first use, once the input/output
+// pointers are known (Find requires real device buffers).
+miopenStatus_t buildEntryDescriptors(CausalConvCacheEntry &e,
+                                     miopenDataType_t dt, int64_t B, int64_t C,
+                                     int64_t virtual_len, int64_t seq_len,
+                                     int64_t kernel_size, bool has_bias,
+                                     int64_t activation) {
+  miopenStatus_t st;
+#define CC_TRY(call)                                                           \
+  do {                                                                         \
+    st = (call);                                                               \
+    if (st != miopenStatusSuccess)                                             \
+      return st;                                                               \
+  } while (0)
+
+  CC_TRY(miopenCreateTensorDescriptor(&e.inDesc));
+  CC_TRY(miopenCreateTensorDescriptor(&e.wDesc));
+  CC_TRY(miopenCreateTensorDescriptor(&e.outDesc));
+  CC_TRY(miopenCreateConvolutionDescriptor(&e.convDesc));
+
+  CC_TRY(miopenSet4dTensorDescriptor(e.inDesc, dt, static_cast<int>(B),
+                                     static_cast<int>(C), 1,
+                                     static_cast<int>(virtual_len)));
+  CC_TRY(miopenSet4dTensorDescriptor(e.wDesc, dt, static_cast<int>(C), 1, 1,
+                                     static_cast<int>(kernel_size)));
+  CC_TRY(miopenSet4dTensorDescriptor(e.outDesc, dt, static_cast<int>(B),
+                                     static_cast<int>(C), 1,
+                                     static_cast<int>(seq_len)));
+
+  CC_TRY(miopenInitConvolutionDescriptor(e.convDesc, miopenConvolution,
+                                         /*pad_h=*/0, /*pad_w=*/0,
+                                         /*stride_h=*/1, /*stride_w=*/1,
+                                         /*dilation_h=*/1, /*dilation_w=*/1));
+  CC_TRY(miopenSetConvolutionGroupCount(e.convDesc, static_cast<int>(C)));
+
+  if (has_bias) {
+    CC_TRY(miopenCreateTensorDescriptor(&e.biasDesc));
+    CC_TRY(miopenSet4dTensorDescriptor(e.biasDesc, dt, 1, static_cast<int>(C),
+                                       1, 1));
+  }
+
+  if (activation == 1) {
+    CC_TRY(miopenCreateActivationDescriptor(&e.actDesc));
+    CC_TRY(miopenSetActivationDescriptor(e.actDesc, miopenActivationLOGISTIC,
+                                         0.0, 0.0, 0.0));
+  }
+
+#undef CC_TRY
+  return miopenStatusSuccess;
+}
+
+void destroyEntry(CausalConvCacheEntry &e) {
+  if (e.actDesc)
+    miopenDestroyActivationDescriptor(e.actDesc);
+  if (e.biasDesc)
+    miopenDestroyTensorDescriptor(e.biasDesc);
+  if (e.convDesc)
+    miopenDestroyConvolutionDescriptor(e.convDesc);
+  if (e.outDesc)
+    miopenDestroyTensorDescriptor(e.outDesc);
+  if (e.wDesc)
+    miopenDestroyTensorDescriptor(e.wDesc);
+  if (e.inDesc)
+    miopenDestroyTensorDescriptor(e.inDesc);
+  e = CausalConvCacheEntry{};
+}
+
+} // namespace
+
+void hipdnn_ep_causal_conv_cache_destroy(void *cache_ptr) {
+  auto *cache = static_cast<CausalConvCache *>(cache_ptr);
+  if (!cache)
+    return;
+  for (auto &kv : cache->entries)
+    destroyEntry(kv.second);
+  delete cache;
+}
+
 // SiLU(x) = x * sigmoid(x) = x / (1 + exp(-x))
 template <typename T> static inline T silu(T x) {
   return x / (static_cast<T>(1) + std::exp(-x));
@@ -42,6 +198,49 @@ int wrap_causal_conv_with_state(
     const void *bias, const void *past_state, void *output, void *present_state,
     int64_t batch_size, int64_t channels, int64_t seq_len, int64_t kernel_size,
     int64_t ndim, int64_t activation, int64_t element_size_bytes) {
+  // ---- Cheap, configuration-level validation FIRST. None of these touch the
+  // device, so do them before any allocation or descriptor work to avoid
+  // ad-hoc cleanup paths (and to keep the OP_PROFILE scope tight around the
+  // actual GPU work).
+  if (!state || !input || !weight || !output || !present_state) {
+    fprintf(stderr, "wrap_causal_conv_with_state: null required argument\n");
+    return -1;
+  }
+
+  if (ndim != 1) {
+    fprintf(stderr,
+            "wrap_causal_conv_with_state: ndim=%lld not yet supported "
+            "(only ndim=1)\n",
+            (long long)ndim);
+    return -1;
+  }
+
+  miopenDataType_t dt;
+  if (element_size_bytes == 4)
+    dt = miopenFloat;
+  else if (element_size_bytes == 2)
+    dt = miopenHalf;
+  else {
+    fprintf(stderr,
+            "wrap_causal_conv_with_state: unsupported element_size %lld\n",
+            (long long)element_size_bytes);
+    return -1;
+  }
+
+  hipStream_t stream =
+      static_cast<hipStream_t>(hipdnn_ep_state_get_stream(state));
+  if (!stream) {
+    fprintf(stderr, "wrap_causal_conv_with_state: null stream\n");
+    return -1;
+  }
+
+  miopenHandle_t handle =
+      static_cast<miopenHandle_t>(hipdnn_ep_state_get_miopen_handle(state));
+  if (!handle) {
+    fprintf(stderr, "wrap_causal_conv_with_state: null MIOpen handle\n");
+    return -1;
+  }
+
   OP_PROFILE(
       "causal_conv",
       [&] {
@@ -52,10 +251,6 @@ int wrap_causal_conv_with_state(
         return std::string(b);
       },
       state);
-  if (!state || !input || !weight || !output || !present_state) {
-    fprintf(stderr, "wrap_causal_conv_with_state: null required argument\n");
-    return -1;
-  }
 
   RUNTIME_DEBUG_LOG("[REAL] wrap_causal_conv_with_state: batch=%lld, "
                     "channels=%lld, seq_len=%lld, kernel=%lld, ndim=%lld, "
@@ -64,119 +259,203 @@ int wrap_causal_conv_with_state(
                     (long long)seq_len, (long long)kernel_size, (long long)ndim,
                     (long long)activation, (long long)element_size_bytes);
 
-  hipStream_t stream =
-      static_cast<hipStream_t>(hipdnn_ep_state_get_stream(state));
-  if (!stream) {
-    fprintf(stderr, "wrap_causal_conv_with_state: null stream\n");
-    return -1;
-  }
-
-  // Currently only ndim=1 is implemented
-  if (ndim != 1) {
-    fprintf(stderr,
-            "wrap_causal_conv_with_state: ndim=%lld not yet supported "
-            "(only ndim=1)\n",
-            (long long)ndim);
-    return -1;
-  }
-
-  int64_t state_len = kernel_size - 1; // k-1
-  int64_t virtual_len = state_len + seq_len;
-
-  // Allocate temporary buffer for the virtual input on device:
-  // shape (batch, channels, state_len + seq_len) = (B, C, k-1+L)
-  int64_t virtual_size =
-      batch_size * channels * virtual_len * element_size_bytes;
-  void *virtual_buf = nullptr;
-  hipError_t err = hipMalloc(&virtual_buf, virtual_size);
-  if (err != hipSuccess || !virtual_buf) {
-    fprintf(stderr,
-            "wrap_causal_conv_with_state: hipMalloc failed for "
-            "virtual buffer (%lld bytes)\n",
-            (long long)virtual_size);
-    return -1;
-  }
-
-  // Fill virtual buffer: [past_state | input] per (batch, channel)
-  // past_state shape: (B, C, k-1) or nullptr (zero-fill)
-  // input shape: (B, C, L)
-  for (int64_t b = 0; b < batch_size; ++b) {
-    for (int64_t c = 0; c < channels; ++c) {
-      int64_t bc = b * channels + c;
-      char *dst_base = static_cast<char *>(virtual_buf) +
-                       bc * virtual_len * element_size_bytes;
-
-      // Copy past_state portion (first k-1 elements)
-      if (past_state) {
-        const char *ps_src = static_cast<const char *>(past_state) +
-                             bc * state_len * element_size_bytes;
-        hipMemcpyAsync(dst_base, ps_src, state_len * element_size_bytes,
-                       hipMemcpyDeviceToDevice, stream);
-      } else {
-        hipMemsetAsync(dst_base, 0, state_len * element_size_bytes, stream);
-      }
-
-      // Copy input portion (last L elements)
-      const char *in_src =
-          static_cast<const char *>(input) + bc * seq_len * element_size_bytes;
-      hipMemcpyAsync(dst_base + state_len * element_size_bytes, in_src,
-                     seq_len * element_size_bytes, hipMemcpyDeviceToDevice,
-                     stream);
-    }
-  }
-
-  // Extract present_state: last (k-1) positions from the virtual input
-  // present_state[b,c,:] = virtual[b,c, seq_len : seq_len + k-1]
-  for (int64_t b = 0; b < batch_size; ++b) {
-    for (int64_t c = 0; c < channels; ++c) {
-      int64_t bc = b * channels + c;
-      const char *src = static_cast<const char *>(virtual_buf) +
-                        (bc * virtual_len + seq_len) * element_size_bytes;
-      char *dst = static_cast<char *>(present_state) +
-                  bc * state_len * element_size_bytes;
-      hipMemcpyAsync(dst, src, state_len * element_size_bytes,
-                     hipMemcpyDeviceToDevice, stream);
-    }
-  }
-
-  // Perform depthwise causal convolution on the GPU.
-  // We use MIOpen convolution with group=channels for depthwise conv.
-  // Input to MIOpen: virtual_buf as (B, C, 1, virtual_len) [4D for MIOpen]
-  // Weight: (C, 1, 1, k) [depthwise: group=C, each filter sees 1 channel]
-  // Output: (B, C, 1, L)
+  // ---- Fast path: single-step decode (seq_len==1, k<=8) -------------------
+  // The MIOpen path requires building a "virtual" buffer of shape
+  // (B, C, k-1+L) by concatenating past_state and input, then running a
+  // depthwise conv on it. For decode (L=1) the concat alone is dominated by
+  // the per-row hipMemcpy2DAsync overhead -- thousands of rows × ~k bytes
+  // each is a degenerate DMA shape and runs ~7 ms on this iGPU instead of
+  // microseconds (see commit history / profiling notes).
   //
-  // We use the existing miopenConvolutionForward for this.
-  miopenHandle_t handle =
-      static_cast<miopenHandle_t>(hipdnn_ep_state_get_miopen_handle(state));
-  if (!handle) {
-    hipFree(virtual_buf);
-    fprintf(stderr, "wrap_causal_conv_with_state: null MIOpen handle\n");
-    return -1;
+  // The single-step custom kernel skips the virtual buffer, the conv API,
+  // and the bias / activation chain entirely: one block-grid that reads
+  // past_state and input directly, computes the dot product in registers,
+  // applies optional SiLU, and writes output and present_state. Empirical
+  // result: ~17 µs/call vs ~7 ms/call.
+  //
+  // Only enabled for shapes the kernel actually supports (k in [1,8],
+  // activation in {0=none, 1=SiLU}, fp16/fp32). Anything outside falls
+  // through to the MIOpen path below, which handles prefill and any odd
+  // hybrid shapes correctly.
+  if (seq_len == 1 && kernel_size >= 1 && kernel_size <= 8 &&
+      (activation == 0 || activation == 1) &&
+      (element_size_bytes == 2 || element_size_bytes == 4)) {
+    int rc = hip_causal_conv_step_decode(
+        stream, input, weight, bias, past_state, output, present_state,
+        batch_size, channels, kernel_size, activation, element_size_bytes);
+    if (rc != 0) {
+      fprintf(stderr,
+              "wrap_causal_conv_with_state: hip_causal_conv_step_decode "
+              "failed (%d)\n",
+              rc);
+      return -1;
+    }
+    RUNTIME_DEBUG_LOG(
+        "[REAL] wrap_causal_conv_with_state: completed via fast decode\n");
+    return 0;
   }
 
-  // Determine MIOpen data type
-  miopenDataType_t dt;
-  if (element_size_bytes == 4)
-    dt = miopenFloat;
-  else if (element_size_bytes == 2)
-    dt = miopenHalf;
-  else {
-    hipFree(virtual_buf);
+  const int64_t state_len = kernel_size - 1; // k-1
+  const int64_t virtual_len = state_len + seq_len;
+  const int64_t bc_rows = batch_size * channels;
+
+  // ---- Look up (or lazily create) descriptors and algorithm for this shape.
+  CausalConvKey key{static_cast<int64_t>(dt),
+                    batch_size,
+                    channels,
+                    virtual_len,
+                    seq_len,
+                    kernel_size,
+                    bias ? 1 : 0,
+                    activation};
+
+  auto *cache = get_causal_conv_cache(state);
+  CausalConvCacheEntry *entry = nullptr;
+  {
+    auto it = cache->entries.find(key);
+    if (it == cache->entries.end()) {
+      CausalConvCacheEntry fresh;
+      miopenStatus_t st = buildEntryDescriptors(
+          fresh, dt, batch_size, channels, virtual_len, seq_len, kernel_size,
+          bias != nullptr, activation);
+      if (st != miopenStatusSuccess) {
+        fprintf(stderr,
+                "wrap_causal_conv_with_state: MIOpen descriptor "
+                "creation failed (%d)\n",
+                static_cast<int>(st));
+        destroyEntry(fresh);
+        return -1;
+      }
+      entry = &cache->entries.emplace(key, std::move(fresh)).first->second;
+    } else {
+      entry = &it->second;
+    }
+  }
+
+  // ---- Pack all per-call temporary buffers into the shared workspace, so
+  // there is no per-call hipMalloc/hipFree (those serialize with the device).
+  //
+  // Layout:
+  //   [virtual_buf : virtual_size][sigmoid_buf : sigmoid_size]
+  // sigmoid_buf only exists when activation == 1 (SiLU) and is the same size
+  // as the output tensor.
+  const size_t virtual_size =
+      static_cast<size_t>(bc_rows * virtual_len * element_size_bytes);
+  const size_t sigmoid_size =
+      (activation == 1)
+          ? static_cast<size_t>(bc_rows * seq_len * element_size_bytes)
+          : 0;
+
+  // Convolution workspace size: on a cache hit we already know the exact size
+  // the chosen algorithm needs (perfResult.memory from the original Find).
+  // On a cache miss we ask MIOpen for an upper bound so Find has space to
+  // benchmark candidate algorithms; it then reports the actual algo memory
+  // back to us, which we cache for subsequent calls.
+  size_t conv_workspace_size;
+  if (entry->algo_valid) {
+    conv_workspace_size = entry->algo_workspace_size;
+  } else {
+    miopenStatus_t st = miopenConvolutionForwardGetWorkSpaceSize(
+        handle, entry->wDesc, entry->inDesc, entry->convDesc, entry->outDesc,
+        &conv_workspace_size);
+    if (st != miopenStatusSuccess) {
+      fprintf(stderr,
+              "wrap_causal_conv_with_state: GetWorkSpaceSize failed (%d)\n",
+              static_cast<int>(st));
+      return -1;
+    }
+  }
+
+  const size_t total_ws = virtual_size + sigmoid_size + conv_workspace_size;
+  if (total_ws > 0 && hipdnn_ep_state_ensure_workspace(state, total_ws) != 0) {
     fprintf(stderr,
-            "wrap_causal_conv_with_state: unsupported element_size "
-            "%lld\n",
-            (long long)element_size_bytes);
+            "wrap_causal_conv_with_state: ensure_workspace(%zu) failed\n",
+            total_ws);
+    return -1;
+  }
+  char *ws_base = static_cast<char *>(hipdnn_ep_state_get_workspace(state));
+  void *virtual_buf = ws_base;
+  void *sigmoid_buf =
+      (activation == 1) ? static_cast<void *>(ws_base + virtual_size) : nullptr;
+  void *conv_workspace =
+      (conv_workspace_size > 0)
+          ? static_cast<void *>(ws_base + virtual_size + sigmoid_size)
+          : nullptr;
+
+  // ---- Build the virtual buffer using *pitched* 2D copies, replacing the
+  // O(B*C) host launch loops. Each plane (b,c) occupies one row of the
+  // virtual buffer, of length virtual_len; we copy past_state (or zeros) into
+  // the first state_len columns and input into the trailing seq_len columns.
+  //
+  // height = B * C   (one row per (batch, channel) plane)
+  // dpitch = virtual_len * elem_size  (stride between rows in virtual_buf)
+  hipError_t herr;
+  const size_t es = static_cast<size_t>(element_size_bytes);
+  const size_t dpitch = static_cast<size_t>(virtual_len) * es;
+  const size_t height = static_cast<size_t>(bc_rows);
+
+  // First state_len columns of every row: past_state, or zeros if absent.
+  if (past_state) {
+    herr = hipMemcpy2DAsync(virtual_buf, dpitch, past_state,
+                            static_cast<size_t>(state_len) * es,
+                            static_cast<size_t>(state_len) * es, height,
+                            hipMemcpyDeviceToDevice, stream);
+    if (herr != hipSuccess) {
+      fprintf(stderr,
+              "wrap_causal_conv_with_state: hipMemcpy2DAsync(past_state) "
+              "failed (%d)\n",
+              static_cast<int>(herr));
+      return -1;
+    }
+  } else {
+    // hipMemset2DAsync zeros a (width × height) sub-rectangle of a pitched
+    // buffer, leaving the trailing seq_len columns untouched (those are
+    // overwritten by the input copy below).
+    herr =
+        hipMemset2DAsync(virtual_buf, dpitch, 0,
+                         static_cast<size_t>(state_len) * es, height, stream);
+    if (herr != hipSuccess) {
+      fprintf(stderr,
+              "wrap_causal_conv_with_state: hipMemset2DAsync(past_state) "
+              "failed (%d)\n",
+              static_cast<int>(herr));
+      return -1;
+    }
+  }
+
+  // Trailing seq_len columns of every row: input.
+  herr = hipMemcpy2DAsync(static_cast<char *>(virtual_buf) +
+                              static_cast<size_t>(state_len) * es,
+                          dpitch, input, static_cast<size_t>(seq_len) * es,
+                          static_cast<size_t>(seq_len) * es, height,
+                          hipMemcpyDeviceToDevice, stream);
+  if (herr != hipSuccess) {
+    fprintf(stderr,
+            "wrap_causal_conv_with_state: hipMemcpy2DAsync(input) "
+            "failed (%d)\n",
+            static_cast<int>(herr));
     return -1;
   }
 
-  // Create tensor descriptors (4D: N, C, H, W)
-  miopenTensorDescriptor_t inDesc = nullptr, wDesc = nullptr, outDesc = nullptr;
-  miopenTensorDescriptor_t biasDesc = nullptr;
-  miopenConvolutionDescriptor_t convDesc = nullptr;
-  miopenActivationDescriptor_t actDesc = nullptr;
-  void *sigmoid_buf = nullptr;
+  // Extract present_state: the last state_len columns of every row of
+  // virtual_buf (positions [seq_len, seq_len+state_len)). Single 2D copy.
+  herr = hipMemcpy2DAsync(present_state, static_cast<size_t>(state_len) * es,
+                          static_cast<char *>(virtual_buf) +
+                              static_cast<size_t>(seq_len) * es,
+                          dpitch, static_cast<size_t>(state_len) * es, height,
+                          hipMemcpyDeviceToDevice, stream);
+  if (herr != hipSuccess) {
+    fprintf(stderr,
+            "wrap_causal_conv_with_state: hipMemcpy2DAsync(present_state) "
+            "failed (%d)\n",
+            static_cast<int>(herr));
+    return -1;
+  }
+
+  // ---- Convolution. On the first call for this shape, run Find once and
+  // remember the algorithm + its workspace size in the cache; subsequent
+  // calls go straight to miopenConvolutionForward with the cached algorithm.
   miopenStatus_t mst;
-  int ret = 0;
 
 #define CAUSAL_MIOPEN_CHECK(call)                                              \
   do {                                                                         \
@@ -186,129 +465,68 @@ int wrap_causal_conv_with_state(
               "wrap_causal_conv_with_state: MIOpen error %d at "               \
               "%s:%d\n",                                                       \
               mst, __FILE__, __LINE__);                                        \
-      ret = -1;                                                                \
-      goto cleanup;                                                            \
+      return -1;                                                               \
     }                                                                          \
   } while (0)
 
-  CAUSAL_MIOPEN_CHECK(miopenCreateTensorDescriptor(&inDesc));
-  CAUSAL_MIOPEN_CHECK(miopenCreateTensorDescriptor(&wDesc));
-  CAUSAL_MIOPEN_CHECK(miopenCreateTensorDescriptor(&outDesc));
-  CAUSAL_MIOPEN_CHECK(miopenCreateConvolutionDescriptor(&convDesc));
-
-  // Input: (B, C, 1, virtual_len)
-  CAUSAL_MIOPEN_CHECK(miopenSet4dTensorDescriptor(
-      inDesc, dt, static_cast<int>(batch_size), static_cast<int>(channels), 1,
-      static_cast<int>(virtual_len)));
-
-  // Weight: (C, 1, 1, kernel_size) for depthwise (group=C)
-  CAUSAL_MIOPEN_CHECK(
-      miopenSet4dTensorDescriptor(wDesc, dt, static_cast<int>(channels), 1, 1,
-                                  static_cast<int>(kernel_size)));
-
-  // Output: (B, C, 1, seq_len)
-  CAUSAL_MIOPEN_CHECK(miopenSet4dTensorDescriptor(
-      outDesc, dt, static_cast<int>(batch_size), static_cast<int>(channels), 1,
-      static_cast<int>(seq_len)));
-
-  // Convolution: pad=(0,0), stride=(1,1), dilation=(1,1), group=channels
-  CAUSAL_MIOPEN_CHECK(
-      miopenInitConvolutionDescriptor(convDesc, miopenConvolution,
-                                      /*pad_h=*/0, /*pad_w=*/0,
-                                      /*stride_h=*/1, /*stride_w=*/1,
-                                      /*dilation_h=*/1, /*dilation_w=*/1));
-  CAUSAL_MIOPEN_CHECK(
-      miopenSetConvolutionGroupCount(convDesc, static_cast<int>(channels)));
-
-  {
-    // Find algorithm
+  if (!entry->algo_valid) {
     miopenConvAlgoPerf_t perfResult;
     int returnedAlgoCount = 0;
-    size_t wsSize = 0;
-    CAUSAL_MIOPEN_CHECK(miopenConvolutionForwardGetWorkSpaceSize(
-        handle, wDesc, inDesc, convDesc, outDesc, &wsSize));
-
-    void *workspace = nullptr;
-    if (wsSize > 0) {
-      if (hipdnn_ep_state_ensure_workspace(state, wsSize) != 0) {
-        ret = -1;
-        goto cleanup;
-      }
-      workspace = hipdnn_ep_state_get_workspace(state);
-    }
-
     CAUSAL_MIOPEN_CHECK(miopenFindConvolutionForwardAlgorithm(
-        handle, inDesc, virtual_buf, wDesc, weight, convDesc, outDesc, output,
-        /*requestAlgoCount=*/1, &returnedAlgoCount, &perfResult, workspace,
-        wsSize, /*exhaustiveSearch=*/false));
+        handle, entry->inDesc, virtual_buf, entry->wDesc, weight,
+        entry->convDesc, entry->outDesc, output,
+        /*requestAlgoCount=*/1, &returnedAlgoCount, &perfResult, conv_workspace,
+        conv_workspace_size, /*exhaustiveSearch=*/false));
+    if (returnedAlgoCount <= 0) {
+      fprintf(stderr,
+              "wrap_causal_conv_with_state: Find returned no algorithms\n");
+      return -1;
+    }
+    entry->algo = perfResult.fwd_algo;
+    // perfResult.memory is the actual workspace the chosen algo needs (often
+    // smaller than the upper bound from GetWorkSpaceSize).
+    entry->algo_workspace_size = perfResult.memory;
+    entry->algo_valid = true;
+    // Find already executed the chosen algorithm with the live tensors as a
+    // benchmarking pass, but its outputs are not guaranteed to be the final
+    // result we want -- re-run the forward once below using the cached algo.
+  }
 
+  {
     float alpha = 1.0f, beta = 0.0f;
     CAUSAL_MIOPEN_CHECK(miopenConvolutionForward(
-        handle, &alpha, inDesc, virtual_buf, wDesc, weight, convDesc,
-        perfResult.fwd_algo, &beta, outDesc, output, workspace, wsSize));
+        handle, &alpha, entry->inDesc, virtual_buf, entry->wDesc, weight,
+        entry->convDesc, entry->algo, &beta, entry->outDesc, output,
+        conv_workspace, entry->algo_workspace_size));
   }
 
-  // Add bias if present
   if (bias) {
-    CAUSAL_MIOPEN_CHECK(miopenCreateTensorDescriptor(&biasDesc));
-    CAUSAL_MIOPEN_CHECK(miopenSet4dTensorDescriptor(
-        biasDesc, dt, 1, static_cast<int>(channels), 1, 1));
     float alpha_bias = 1.0f, beta_bias = 0.0f;
     CAUSAL_MIOPEN_CHECK(miopenOpTensor(handle, miopenTensorOpAdd, &alpha_bias,
-                                       outDesc, output, &alpha_bias, biasDesc,
-                                       bias, &beta_bias, outDesc, output));
+                                       entry->outDesc, output, &alpha_bias,
+                                       entry->biasDesc, bias, &beta_bias,
+                                       entry->outDesc, output));
   }
 
-  // Apply activation (SiLU/Swish)
+  // SiLU(x) = x * sigmoid(x). MIOpen has no fused SILU in this build, so we
+  // compute sigmoid into the workspace-resident sigmoid_buf and then multiply
+  // in place. (The temp buffer is reused across calls -- no hipMalloc.)
   if (activation == 1) {
-    // SiLU(x) = x * sigmoid(x)
-    int64_t output_size = batch_size * channels * seq_len * element_size_bytes;
-    err = hipMalloc(&sigmoid_buf, output_size);
-    if (err != hipSuccess || !sigmoid_buf) {
-      fprintf(stderr, "wrap_causal_conv_with_state: hipMalloc failed for "
-                      "sigmoid buffer\n");
-      ret = -1;
-      goto cleanup;
-    }
-
-    CAUSAL_MIOPEN_CHECK(miopenCreateActivationDescriptor(&actDesc));
-    CAUSAL_MIOPEN_CHECK(miopenSetActivationDescriptor(
-        actDesc, miopenActivationLOGISTIC, 0.0, 0.0, 0.0));
-
     float alpha_act = 1.0f, beta_act = 0.0f;
-    CAUSAL_MIOPEN_CHECK(miopenActivationForward(handle, actDesc, &alpha_act,
-                                                outDesc, output, &beta_act,
-                                                outDesc, sigmoid_buf));
+    CAUSAL_MIOPEN_CHECK(miopenActivationForward(
+        handle, entry->actDesc, &alpha_act, entry->outDesc, output, &beta_act,
+        entry->outDesc, sigmoid_buf));
 
     float alpha_mul = 1.0f, beta_mul = 0.0f;
-    CAUSAL_MIOPEN_CHECK(miopenOpTensor(
-        handle, miopenTensorOpMul, &alpha_mul, outDesc, output, &alpha_mul,
-        outDesc, sigmoid_buf, &beta_mul, outDesc, output));
+    CAUSAL_MIOPEN_CHECK(miopenOpTensor(handle, miopenTensorOpMul, &alpha_mul,
+                                       entry->outDesc, output, &alpha_mul,
+                                       entry->outDesc, sigmoid_buf, &beta_mul,
+                                       entry->outDesc, output));
   }
-
-cleanup:
-  if (actDesc)
-    miopenDestroyActivationDescriptor(actDesc);
-  if (sigmoid_buf)
-    hipFree(sigmoid_buf);
-  if (biasDesc)
-    miopenDestroyTensorDescriptor(biasDesc);
-  if (convDesc)
-    miopenDestroyConvolutionDescriptor(convDesc);
-  if (outDesc)
-    miopenDestroyTensorDescriptor(outDesc);
-  if (wDesc)
-    miopenDestroyTensorDescriptor(wDesc);
-  if (inDesc)
-    miopenDestroyTensorDescriptor(inDesc);
-  if (virtual_buf)
-    hipFree(virtual_buf);
 
 #undef CAUSAL_MIOPEN_CHECK
 
-  if (ret == 0) {
-    RUNTIME_DEBUG_LOG(
-        "[REAL] wrap_causal_conv_with_state: completed successfully\n");
-  }
-  return ret;
+  RUNTIME_DEBUG_LOG(
+      "[REAL] wrap_causal_conv_with_state: completed successfully\n");
+  return 0;
 }

--- a/lib/Runtime/real/linear_attention.cpp
+++ b/lib/Runtime/real/linear_attention.cpp
@@ -5,6 +5,7 @@
 
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../op_profile.h"
 #include "error_check_macros.h"
 #include "hip_custom_kernels.h"
 #include "runtime_types.h"
@@ -32,6 +33,17 @@ extern "C" int wrap_linear_attention(
     int64_t decay_per_key_dim, int64_t beta_per_head, float scale,
     int64_t chunk_size, int64_t update_rule, int64_t B, int64_t seq_len,
     int64_t dk, int64_t dv, int64_t type) {
+  OP_PROFILE(
+      "linear_attention",
+      [&] {
+        char b[64];
+        snprintf(b, sizeof(b),
+                 "b=%lld,sq=%lld,hq=%lld,hkv=%lld,dk=%lld,dv=%lld",
+                 (long long)B, (long long)seq_len, (long long)Hq,
+                 (long long)Hkv, (long long)dk, (long long)dv);
+        return std::string(b);
+      },
+      state);
 
   RUNTIME_DEBUG_LOG("[linear_attention] enter: B=%lld seq_len=%lld "
                     "q_heads=%lld kv_heads=%lld n_k=%lld d_k=%lld d_v=%lld "

--- a/lib/Runtime/runtime_state_internal.h
+++ b/lib/Runtime/runtime_state_internal.h
@@ -58,6 +58,13 @@ struct RuntimeState {
   // Caches hipBLASLt descriptors + algorithms by GEMM shape.
   void *gqa_gemm_cache;
 
+  // CausalConvWithState MIOpen descriptor + algorithm cache
+  // (CausalConvCache*). Caches MIOpen tensor / convolution / bias / activation
+  // descriptors and the heuristic-selected forward algorithm by shape, so that
+  // miopenFindConvolutionForwardAlgorithm runs only once per shape rather than
+  // every layer × every token.
+  void *causal_conv_cache;
+
   // Per-operator profiling state (OpProfileState*, gated on HIPDNN_EP_PERF).
   // Allocated in state_init, freed in state_cleanup.
   void *op_profile;


### PR DESCRIPTION
## Summary

Stacked under #194. Two operator-level optimisations for Qwen3.5-style decode:

1. **`CausalConvWithState`** — fused HIP fast path for `seq_len=1` decode and per-call overhead reduction in the existing MIOpen path. At chunk-opt decode shape (B=1, C=8192, K=4, SiLU, fp16) the operator now consumes ~0.1 ms of GPU time per inference instead of ~173 ms, removing the dominant contributor to single-token decode latency for Gated DeltaNet style blocks (Mamba / Qwen3.5-35B-A3B's 30 `CausalConvWithState` ops).
2. **`MatMulNBits` `bits=8`** — autotuned GEMV (decode) and WMMA (prefill) fast paths that mirror the existing `bits=4` design. Profiling on Qwen3.5 int8 ops showed `matmul_nbits` dominating prefill time at <1 TFLOPS because the previously-shipped naive bits=8 kernel is one-thread-per-output with no shared memory, no tiling, and no vectorization. The new paths use the same shared-memory tile pipeline, register prefetch, grid swizzle, and per-shape autotune cache as the bits=4 path.

The two pieces share this PR because they were diagnosed together: the high CPU time originally attributed to `linear_attention` was stream backpressure from these two GPU bottlenecks. With both fixed, the picture clears up. (Profiling instrumentation that made this diagnosis possible lands here too — see Profiling additions below.)

## Changes Overview

### Custom HIP kernels

- `3rd-party/custom_kernels/hip/causal_conv_step_kernel.hip` (new): launches one thread per `(batch, channel)`, computes a fully-unrolled K-tap depthwise conv in fp32 with optional bias / SiLU, then writes the shifted state back. Supports `K ∈ [1,8]` and fp16 / fp32.
- `3rd-party/custom_kernels/hip/matmul_nbits_kernel.hip`:
  - **GEMV-i8** (`matmul_nbits_gemv_kernel_i8`, M < 16, decode): autotuned BLOCK_SIZE × TILE_N reduction with 16-byte vectorized B loads (`uint4` → 16 `uint8` per load), factored dequantization (`acc += A * B * scale - sumA * zp * scale`) and warp shuffle reduction. Mirrors `getOrTuneGemvConfig` for bits=4. Gated on `block_size >= 16` so a 16-element vector lies entirely within one quant group.
  - **WMMA-i8** (`GemmFp16I8Impl` + `MatMulNBitsWMMA_I8_NoZP` / `MatMulNBitsWMMA_I8_ZP`, M ≥ 16, prefill): autotuned 16×16×16 fp16 WMMA tiles with fused dequant in shared memory, double-buffered register prefetch pipeline, and grid swizzle. Mirrors `GemmFp16U4Impl` line for line, with a `uint2` (8-byte) per-thread B load instead of a `uint32_t` (8-nibble) load and default zp=128 per the ONNX MatMulNBits spec for bits=8. Gated on `batch=1`, `K%32==0`, `block_size>=32` and `block_size%32==0` so quant groups always align with K-step boundaries inside the kernel.
  - Naive bits=8 kernel kept as fallback for shapes that fail both gates.
  - Each path keeps its own autotune cache keyed on `(M, N, K, gs, has_zp)`.
- `3rd-party/custom_kernels/include/hip_custom_kernels.h`: declares `hip_causal_conv_step_decode` with full doc-comment of the supported gate.
- `3rd-party/custom_kernels/CMakeLists.txt`: registers the new `causal_conv_step_kernel.hip`.

### Runtime integration

- `lib/Runtime/real/causal_conv_with_state.cpp`:
  - Fast-path branch at the top of `wrap_causal_conv_with_state` for `seq_len == 1 && K ∈ [1,8] && activation ∈ {none, silu} && element_size_bytes ∈ {2,4}`. Falls through to MIOpen for all other shapes.
  - Replaces the `B*C` `hipMemcpyAsync` loops that built the virtual buffer with three `hipMemcpy2DAsync` calls (past-state init, input copy, present extract).
  - Routes the temporary virtual / sigmoid buffers through the shared workspace (`hipdnn_ep_state_ensure_workspace`) instead of per-call `hipMalloc` / `hipFree`.
  - Caches MIOpen tensor / convolution / bias / activation descriptors and the heuristic-selected forward algorithm by shape so `miopenFindConvolutionForwardAlgorithm` runs once per shape instead of every layer × every token. Cache lifetime is owned by `RuntimeState`.
- `lib/Runtime/runtime_state_internal.h`: adds `causal_conv_cache` slot to `RuntimeState`.
- `lib/Runtime/hipdnn_ep_runtime.h`: declares `hipdnn_ep_causal_conv_cache_destroy`.
- `lib/Runtime/hipdnn_ep_runtime_state.cpp`: initialises and frees the cache from `RuntimeState` lifecycle hooks.
- `lib/Runtime/CMakeLists.txt`: extends the bitcode `DEPENDS` list to include `runtime_state_internal.h`, `runtime_types.h`, `real/cache_utils.h`, and the new `hip_custom_kernels.h`, so editing any of them invalidates the bitcode.

### Profiling additions

- `lib/Runtime/real/linear_attention.cpp`: adds `OP_PROFILE` scope at entry, so `linear_attention` shows up in the per-op profile alongside the other custom-kernel ops.
- `lib/Runtime/op_profile.h`: when `HIPDNN_EP_PERF_ISOLATE=1`, the `OpProfileScope` constructor / destructor wrap their `hipEventRecord` calls in `hipStreamSynchronize` so each op's reported GPU time is its standalone runtime (kills concurrency by design — diagnostic only).
- `lib/Runtime/debug_log.h`: adds `hipdnn_ep_perf_isolate_enabled()` and makes it imply `HIPDNN_EP_PERF`.

## Test plan

- [x] Build verified (no errors; only pre-existing protobuf LNK4217 warnings).
- [x] **`CausalConvWithState` numeric precision tests passed**: 8/8 in `test_causal_conv_with_state.py`.
  - Decode shapes (`seq_len=1`) which exercise the new custom kernel match the CPU reference bit-for-bit (`max_diff = 0.000e+00`) on both `output` and `present_state`:
    - `(1, 32, 1, K=4, silu)`
    - `(1, 8192, 1, K=4, silu)` — chunk-opt decode shape used by Qwen3.5-35B
  - MIOpen prefill shapes pass within `atol=2e-3 / 5e-3`:
    - `(1, 32, 16, K=4, silu/none)`
    - `(1, 32, 512, K=4, silu/none)` (added in companion test PR)
    - `(1, 8192, 128, K=4, silu)`
    - `(1, 8192, 512, K=4, silu)` — chunk-opt prefill shape
  - `present_state` is bit-exact across all 8 cases (no arithmetic on that output path).
- [x] **`MatMulNBits` bits=8 numeric precision tests passed** for the new GEMV-i8 and WMMA-i8 paths (`test_matmul_nbits_qwen35b_*_int8` and `test_matmul_nbits_qwen9b_*_int8` in `test_matmul_nbits.py`):
  - Prefill shape M=128, N=8192, K=2048, gs=128, zp=default (Qwen3.5-35B expert up): WMMA-i8 autotune picks `bm=128 bn=256 sw=8` at 0.77 ms/iter; cosine = 0.999992 vs CPU reference, max_diff = 0.117 (atol=0.2, cos≥0.9995 — well within).
  - Prefill shape M=512 same (M, N, K): autotune picks `bm=128 bn=256 sw=16` at 2.01 ms/iter.
  - Decode shape M=1 routes through GEMV-i8; same autotune+cache pattern as bits=4 GEMV.
- [x] Static analysis: all 30 `CausalConvWithState` ops in `Qwen3.5-35B-A3B_int4_rtn_128gs_cuda/text.onnx` match the fast-path gate at decode shape (`C=8192, K=4, silu, fp16, ndim=1`); all 30 fall back to the optimised MIOpen path at prefill shape.
- [x] Pre-commit hooks: `trim trailing whitespace`, `fix end of files`, `lintrunner`, `licenseheaders` all pass on the staged files.
