### PR TITLE
ci: enable repo CI on release_* branches

### DIFF
--- a/.github/workflows/gpu-perf-accuracy-test.yml
+++ b/.github/workflows/gpu-perf-accuracy-test.yml
@@ -55,8 +55,11 @@ jobs:
           }
 
       # -----------------------------------------------------------------
-      # Download the pre-built gpu-test-package artifact from the
-      # latest successful main build of the Windows Build workflow.
+      # Download the pre-built gpu-test-package artifact from the latest
+      # successful Windows Build run on the same branch this workflow was
+      # dispatched against (e.g. release_0_1_0 GPU runs pull release_0_1_0
+      # build artifacts, not main). github.ref_name is the short branch name
+      # for workflow_dispatch triggered against a branch ref.
       # -----------------------------------------------------------------
       - name: Download gpu-test-package
         uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
@@ -64,7 +67,7 @@ jobs:
           workflow: windows-build.yml
           name: gpu-test-package
           path: gpu-test-package
-          branch: main
+          branch: ${{ github.ref_name }}
           workflow_conclusion: success
           if_no_artifact_found: fail
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,7 +7,7 @@ name: pre-commit
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [main, "release_*"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/windows-build-mock.yml
+++ b/.github/workflows/windows-build-mock.yml
@@ -10,7 +10,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
   push:
-    branches: [main]
+    branches: [main, "release_*"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -10,7 +10,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
   push:
-    branches: [main]
+    branches: [main, "release_*"]
 
 permissions:
   contents: read
@@ -491,7 +491,7 @@ jobs:
         with:
           name: gpu-test-package
           path: staging/
-          retention-days: ${{ github.ref == 'refs/heads/main' && 14 || 3 }}
+          retention-days: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release_')) && 14 || 3 }}
 
   # ---------------------------------------------------------------------------
   # GPU test job: runs on the self-hosted machine with a real AMD GPU.


### PR DESCRIPTION
## Summary

`onnx-hipdnn-ep` currently wires all GitHub Actions workflows to `main` only, so pushes to `release_0_1_0` (and future `release_x_y_z`) do **not** trigger CI builds, mock builds, pre-commit, or the manually-dispatched GPU perf/accuracy test. This PR enables the same coverage on `release_*` branches without touching `main` behavior.

PRs against any base branch already trigger CI (`pull_request` is unscoped), so this change only fills the push-side gap.

## Changes

- **`pre-commit.yml`**, **`windows-build-mock.yml`**, **`windows-build.yml`**: extend `push.branches` from `[main]` to `[main, release_*]`.
- **`windows-build.yml`** (artifact retention): apply the same 14-day retention used on `main` to `release_*` builds (3 days otherwise). The GPU perf/accuracy workflow depends on the build artifact being available later, so a short retention on release branches would break manual GPU runs.
- **`gpu-perf-accuracy-test.yml`**: replace hardcoded `branch: main` with `${{ github.ref_name }}` so that a `workflow_dispatch` against `release_0_1_0` downloads the matching branch's `gpu-test-package` instead of always pulling from `main`.

Diff is intentionally minimal — purely YAML, no logic change.

## Test plan

- [ ] Merge to `main` first; main CI should be unchanged (push events on `main` still match `[main, release_*]`).
- [ ] Cherry-pick the merged commit onto `release_0_1_0`. Pushing to `release_0_1_0` should trigger `pre-commit`, `Windows Build`, and `Windows Build (Mock)`.
- [ ] After a successful `Windows Build` run on `release_0_1_0`, manually dispatch `GPU Performance & Accuracy Test` against `release_0_1_0`; the workflow should pick up the artifact uploaded by the release build (not `main`).
- [ ] Verify the `gpu-test-package` artifact uploaded from `release_0_1_0` shows 14-day retention on the Actions UI.

## Follow-up

Once merged here, this commit can be cherry-picked onto `release_0_1_0` with `git cherry-pick <sha>`.