### PR TITLE
feat(linux): add gfx1151 E2E support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,11 @@
 *.onnx filter=lfs diff=lfs merge=lfs -text
+
+# Force UTF-8 for all source files. Prevents Windows editors from saving a
+# Latin-1 / CP1252 round-trip view of UTF-8 comments back as broken UTF-8
+# (e.g. `→` -> `â†’`, `α` -> `Î±`). See PR #213 review for the prior occurrence.
+*.cpp text working-tree-encoding=UTF-8
+*.h   text working-tree-encoding=UTF-8
+*.hpp text working-tree-encoding=UTF-8
+*.c   text working-tree-encoding=UTF-8
+*.cc  text working-tree-encoding=UTF-8
+*.md  text working-tree-encoding=UTF-8

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -14,13 +14,6 @@ on:
 
 permissions:
   contents: read
-  # GHA cache v2 (ACTIONS_RESULTS_URL) requires `actions: write` for cache
-  # writes. actions/cache wraps the API so its writes succeed with the
-  # default token scopes, but sccache talks to the v2 service directly via
-  # opendal and needs the explicit grant. Without this the previous run
-  # logged 314 cache write errors / 0 cache writes from in-container
-  # sccache 0.10.0 and the next run still cold-built the project.
-  actions: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -32,13 +25,6 @@ env:
   # or docker/build.sh meaningfully changes what lands under prebuilt-local/
   # (ORT + protobuf + flatbuffers install trees).
   CACHE_VERSION: "1"
-  # SCCACHE_GHA_ENABLED is consumed by:
-  #   1. mozilla-actions/sccache-action's auto-config (sets ACTIONS_CACHE_URL
-  #      and ACTIONS_RUNTIME_TOKEN on the runner)
-  #   2. docker/run.sh which forwards all three vars into the container
-  #   3. docker/build.sh which wires CMAKE_*_COMPILER_LAUNCHER=sccache only
-  #      when this is "true" (the binary is otherwise idle inside the image)
-  SCCACHE_GHA_ENABLED: "true"
   # Pinned versions — kept in lockstep with docker/build.sh defaults.
   ONNXRUNTIME_VERSION: "1.25.1"
   THEROCK_VERSION: therock-dist-linux-gfx1151-7.11.0
@@ -95,13 +81,6 @@ jobs:
           large-packages: false    # skipped: very slow, marginal gain
           swap-storage: true       # ~4 GB
 
-      # sccache + GHA cache backend. The action sets ACTIONS_CACHE_URL /
-      # ACTIONS_RUNTIME_TOKEN on the runner; docker/run.sh forwards them
-      # into the container so the in-container sccache binary (installed
-      # via docker/Dockerfile) talks back to the same backend.
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
-
       # -----------------------------------------------------------------------
       # Caches live as siblings of the source checkout (matches the layout
       # docker/build.sh expects). Cache misses get repopulated by the Docker
@@ -145,10 +124,7 @@ jobs:
       # The actual build: one docker invocation runs all of A.4-A.9
       # (TheRock + ORT + protobuf + flatbuffers + project + OGA). Each step
       # has its own `[skip]` short-circuit when the corresponding install
-      # artifact is already in place from the cache. The container reads
-      # SCCACHE_GHA_ENABLED + ACTIONS_CACHE_URL + ACTIONS_RUNTIME_TOKEN
-      # (forwarded by docker/run.sh) and routes compiler launchers to
-      # in-container sccache via docker/build.sh's opt-in wiring.
+      # artifact is already in place from the cache.
       #
       # The same image + recipe is what local developers run via
       # `./docker/run.sh build` — see docs/quick_start_linux.md.

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -14,6 +14,13 @@ on:
 
 permissions:
   contents: read
+  # GHA cache v2 (ACTIONS_RESULTS_URL) requires `actions: write` for cache
+  # writes. actions/cache wraps the API so its writes succeed with the
+  # default token scopes, but sccache talks to the v2 service directly via
+  # opendal and needs the explicit grant. Without this the previous run
+  # logged 314 cache write errors / 0 cache writes from in-container
+  # sccache 0.10.0 and the next run still cold-built the project.
+  actions: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -106,12 +106,6 @@ jobs:
           path: ${{ github.workspace }}/prebuilt-local
           key: linux-deps-v${{ env.CACHE_VERSION }}-ort${{ env.ONNXRUNTIME_VERSION }}
 
-      - name: Cache TheRock SDK
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-        with:
-          path: ${{ github.workspace }}/therock-dist
-          key: ${{ env.THEROCK_VERSION }}
-
       - name: Cache ORT source clone
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
@@ -123,6 +117,22 @@ jobs:
         with:
           path: ${{ github.workspace }}/onnxruntime-genai
           key: oga-src-${{ env.OGA_REF }}
+
+      # Cache the OGA INSTALL outputs (not the full build/ tree). With
+      # docker/build.sh A.9's have_oga() guard, a cache hit on this key
+      # means we skip the 5-10 min OGA build entirely. ORT version is in
+      # the key because OGA's libonnxruntime-genai.so links libonnxruntime.so
+      # at its pinned ABI; an ORT version bump must invalidate the OGA
+      # outputs. ${OGA_REF} is the primary update knob — change it in env
+      # above to roll OGA forward and the cache key automatically misses.
+      - name: Cache OGA install outputs
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: |
+            ${{ github.workspace }}/install/bin/model_benchmark
+            ${{ github.workspace }}/install/lib/libonnxruntime-genai.so
+            ${{ github.workspace }}/install/lib/libonnxruntime-genai.so.0
+          key: oga-out-v${{ env.CACHE_VERSION }}-${{ env.OGA_REF }}-ort${{ env.ONNXRUNTIME_VERSION }}
 
       # -----------------------------------------------------------------------
       # The actual build: one docker invocation runs all of A.4-A.9
@@ -138,6 +148,13 @@ jobs:
       # -----------------------------------------------------------------------
       - name: Build via Docker
         working-directory: onnx-hipdnn-ep
+        env:
+          # OGA_REF is the single source of truth for which OGA SHA gets
+          # cloned + built. docker/run.sh forwards it into the container
+          # and docker/build.sh A.9 reads it as the checkout target. Bump
+          # OGA_REF in this workflow's env block to roll OGA forward —
+          # nothing else needs to change.
+          OGA_REF: ${{ env.OGA_REF }}
         run: |
           set -euo pipefail
           ./docker/run.sh image
@@ -151,17 +168,24 @@ jobs:
       #                    libonnxruntime.so*, libonnxruntime-genai.so*,
       #                    libamdhip64.so* + TheRock transitive + libLLVM.so.22.1
       #   staging/etc/   – morphizen_config.json
-      #   staging/wheels – onnxruntime-*.whl + onnxruntime_genai-*.whl
       #
-      # docker/build.sh A.7b already runs a 2-pass `ldd` inside the container
-      # and bundles the TheRock + ORT transitive .so set into install/lib/,
-      # so this step is just a flat `cp` from install/ + a couple of side
-      # gather operations (wheels live under build/, config under repo's etc/).
+      # No staging/wheels on Linux: the OGA python wheel needs `import
+      # onnxruntime` at runtime, but the Linux build deliberately omits
+      # the ORT wheel (A.5 skips --build_wheel to avoid pulling in
+      # Python::NumPy + dev headers). Without an ORT wheel, the OGA
+      # wheel can't be `pip install`ed on its own, so shipping it serves
+      # no consumer. The C++ model_benchmark binary is what's actually
+      # used for benchmarking and it lands in staging/bin/.
+      #
+      # docker/build.sh A.7b already runs a 2-pass `ldd` inside the
+      # container and bundles the TheRock + ORT transitive .so set into
+      # install/lib/, so this step is a flat `cp` from install/ + one
+      # config side-copy.
       # -----------------------------------------------------------------------
       - name: Stage Linux GPU test package
         run: |
           set -euo pipefail
-          mkdir -p staging/bin staging/lib staging/etc staging/wheels
+          mkdir -p staging/bin staging/lib staging/etc
 
           cp -a "${{ github.workspace }}/install/bin/." staging/bin/
           cp -a "${{ github.workspace }}/install/lib/." staging/lib/
@@ -169,12 +193,6 @@ jobs:
           # Config lives in the repo etc/ on Path A (install/bin gets a copy
           # too; both are fine, we pick the source-of-truth here).
           cp onnx-hipdnn-ep/etc/morphizen_config.json staging/etc/
-
-          # Python wheels (ORT + OGA) for pip-install consumers.
-          find "${{ github.workspace }}/build" -name "onnxruntime_genai-*.whl" \
-            -exec cp {} staging/wheels/ \; || true
-          find "${{ github.workspace }}/build" -name "onnxruntime-*-linux_x86_64.whl" \
-            -exec cp {} staging/wheels/ \; || true
 
           chmod +x staging/bin/*
 

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -1,0 +1,191 @@
+##
+## Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+## Licensed under the MIT License.
+##
+name: Linux Build
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  merge_group:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  # CACHE_VERSION numbering resets at the Docker switch (the pre-Docker
+  # inline-yml history is no longer reachable). Bump when docker/Dockerfile
+  # or docker/build.sh meaningfully changes what lands under prebuilt-local/
+  # (ORT + protobuf + flatbuffers install trees).
+  CACHE_VERSION: "1"
+  # SCCACHE_GHA_ENABLED is consumed by:
+  #   1. mozilla-actions/sccache-action's auto-config (sets ACTIONS_CACHE_URL
+  #      and ACTIONS_RUNTIME_TOKEN on the runner)
+  #   2. docker/run.sh which forwards all three vars into the container
+  #   3. docker/build.sh which wires CMAKE_*_COMPILER_LAUNCHER=sccache only
+  #      when this is "true" (the binary is otherwise idle inside the image)
+  SCCACHE_GHA_ENABLED: "true"
+  # Pinned versions — kept in lockstep with docker/build.sh defaults.
+  ONNXRUNTIME_VERSION: "1.25.1"
+  THEROCK_VERSION: therock-dist-linux-gfx1151-7.11.0
+  # OGA fork+pin matches windows-build.yml so both platforms produce
+  # ABI-compatible OGA binaries against the same ORT and tokenizer surface.
+  OGA_REF: 2615301864b4d2397231d443865cb96111cc5fc2
+
+jobs:
+  build-linux:
+    # No draft-PR gate: the cache-priming strategy needs every PR push.
+    runs-on: ubuntu-latest
+    steps:
+      # ROCm/MorphiZen is private — reuse the same deploy key as windows-build.yml.
+      - name: Setup SSH key for MorphiZen submodule
+        uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
+        with:
+          ssh-private-key: ${{ secrets.MORPHIZEN_DEPLOY_KEY }}
+
+      # Check the repo into a sibling-layout subdir so the workspace root
+      # (= $github.workspace) can hold prebuilt-local/, therock-dist/,
+      # onnxruntime/, onnxruntime-genai/, build/, install/ as siblings of
+      # onnx-hipdnn-ep/. This matches the layout docker/run.sh expects
+      # (resolves WORKSPACE as $SOURCE_DIR/..).
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: onnx-hipdnn-ep
+          submodules: false
+          fetch-depth: 1
+          show-progress: false
+
+      # Run `git submodule update` on the HOST with ssh-agent loaded —
+      # docker/build.sh A.2 detects the populated checkout and skips its own
+      # submodule update, so the container does NOT need SSH credentials
+      # for the private morphizen repo.
+      - name: Checkout MorphiZen submodule
+        working-directory: onnx-hipdnn-ep
+        run: |
+          set -euo pipefail
+          git config --global url."git@github.com:ROCm/MorphiZen.git".insteadOf \
+            "https://github.com/ROCm/MorphiZen.git"
+          git submodule update --init --recursive --depth 1
+
+      # ubuntu-latest ships ~14 GB usable SSD. Image build + cold ORT need
+      # ~25 GB; reclaim ~30 GB by pruning preinstalled toolchains we don't use.
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false        # keep Python toolchain
+          docker-images: true      # ~10 GB
+          android: true            # ~10 GB
+          dotnet: true             # ~3 GB
+          haskell: true            # ~5 GB
+          large-packages: false    # skipped: very slow, marginal gain
+          swap-storage: true       # ~4 GB
+
+      # sccache + GHA cache backend. The action sets ACTIONS_CACHE_URL /
+      # ACTIONS_RUNTIME_TOKEN on the runner; docker/run.sh forwards them
+      # into the container so the in-container sccache binary (installed
+      # via docker/Dockerfile) talks back to the same backend.
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      # -----------------------------------------------------------------------
+      # Caches live as siblings of the source checkout (matches the layout
+      # docker/build.sh expects). Cache misses get repopulated by the Docker
+      # build step below via the idempotent A.4-A.9 pipeline.
+      # -----------------------------------------------------------------------
+      - name: Cache prebuilt-local
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: ${{ github.workspace }}/prebuilt-local
+          key: linux-deps-v${{ env.CACHE_VERSION }}-ort${{ env.ONNXRUNTIME_VERSION }}
+
+      - name: Cache TheRock SDK
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: ${{ github.workspace }}/therock-dist
+          key: ${{ env.THEROCK_VERSION }}
+
+      - name: Cache ORT source clone
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: ${{ github.workspace }}/onnxruntime
+          key: ort-src-v${{ env.ONNXRUNTIME_VERSION }}
+
+      - name: Cache OGA source clone
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: ${{ github.workspace }}/onnxruntime-genai
+          key: oga-src-${{ env.OGA_REF }}
+
+      # -----------------------------------------------------------------------
+      # The actual build: one docker invocation runs all of A.4-A.9
+      # (TheRock + ORT + protobuf + flatbuffers + project + OGA). Each step
+      # has its own `[skip]` short-circuit when the corresponding install
+      # artifact is already in place from the cache. The container reads
+      # SCCACHE_GHA_ENABLED + ACTIONS_CACHE_URL + ACTIONS_RUNTIME_TOKEN
+      # (forwarded by docker/run.sh) and routes compiler launchers to
+      # in-container sccache via docker/build.sh's opt-in wiring.
+      #
+      # The same image + recipe is what local developers run via
+      # `./docker/run.sh build` — see docs/quick_start_linux.md.
+      # -----------------------------------------------------------------------
+      - name: Build via Docker
+        working-directory: onnx-hipdnn-ep
+        run: |
+          set -euo pipefail
+          ./docker/run.sh image
+          BUILD_OGA=1 ./docker/run.sh build
+
+      # -----------------------------------------------------------------------
+      # Stage the artifact in the layout the GPU host workflow expects:
+      #   staging/bin/   – hip-onnx-runner, hip-compiler, hip-mlir-opt,
+      #                    hip-test-dll, onnxruntime_perf_test, model_benchmark
+      #   staging/lib/   – libhip-compiler.so, libonnxruntime_morphizen_ep.so,
+      #                    libonnxruntime.so*, libonnxruntime-genai.so*,
+      #                    libamdhip64.so* + TheRock transitive + libLLVM.so.22.1
+      #   staging/etc/   – morphizen_config.json
+      #   staging/wheels – onnxruntime-*.whl + onnxruntime_genai-*.whl
+      #
+      # docker/build.sh A.7b already runs a 2-pass `ldd` inside the container
+      # and bundles the TheRock + ORT transitive .so set into install/lib/,
+      # so this step is just a flat `cp` from install/ + a couple of side
+      # gather operations (wheels live under build/, config under repo's etc/).
+      # -----------------------------------------------------------------------
+      - name: Stage Linux GPU test package
+        run: |
+          set -euo pipefail
+          mkdir -p staging/bin staging/lib staging/etc staging/wheels
+
+          cp -a "${{ github.workspace }}/install/bin/." staging/bin/
+          cp -a "${{ github.workspace }}/install/lib/." staging/lib/
+
+          # Config lives in the repo etc/ on Path A (install/bin gets a copy
+          # too; both are fine, we pick the source-of-truth here).
+          cp onnx-hipdnn-ep/etc/morphizen_config.json staging/etc/
+
+          # Python wheels (ORT + OGA) for pip-install consumers.
+          find "${{ github.workspace }}/build" -name "onnxruntime_genai-*.whl" \
+            -exec cp {} staging/wheels/ \; || true
+          find "${{ github.workspace }}/build" -name "onnxruntime-*-linux_x86_64.whl" \
+            -exec cp {} staging/wheels/ \; || true
+
+          chmod +x staging/bin/*
+
+          echo "=== Staged package contents ==="
+          find staging/ -maxdepth 3 \( -type f -o -type l \) | sort
+          echo "=== Staged package size ==="
+          du -sh staging/
+
+      - name: Upload Linux GPU test package
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-gpu-test-package
+          path: staging/
+          retention-days: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release_')) && 14 || 3 }}

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -144,26 +144,31 @@ jobs:
           BUILD_OGA=1 ./docker/run.sh build
 
       # -----------------------------------------------------------------------
-      # Stage the artifact in the layout the GPU host workflow expects:
-      #   staging/bin/   – hip-onnx-runner, hip-compiler, hip-mlir-opt,
-      #                    hip-test-dll, onnxruntime_perf_test, model_benchmark
-      #   staging/lib/   – libhip-compiler.so, libonnxruntime_morphizen_ep.so,
-      #                    libonnxruntime.so*, libonnxruntime-genai.so*,
-      #                    libamdhip64.so* + TheRock transitive + libLLVM.so.22.1
-      #   staging/etc/   – morphizen_config.json
+      # Stage the artifact:
+      #   staging/bin/  hip-onnx-runner, hip-compiler, hip-mlir-opt,
+      #                 hip-test-dll, hip-inspect-dll, model_benchmark,
+      #                 onnxruntime_perf_test
+      #   staging/lib/  libhip-compiler.so, libonnxruntime_morphizen_ep.so,
+      #                 libonnxruntime.so*, libonnxruntime-genai.so*,
+      #                 libhip_custom_kernels.a (needed at per-model
+      #                 DLL link time)
+      #   staging/etc/  morphizen_config.json
       #
-      # No staging/wheels on Linux: the OGA python wheel needs `import
-      # onnxruntime` at runtime, but the Linux build deliberately omits
-      # the ORT wheel (A.5 skips --build_wheel to avoid pulling in
-      # Python::NumPy + dev headers). Without an ORT wheel, the OGA
-      # wheel can't be `pip install`ed on its own, so shipping it serves
-      # no consumer. The C++ model_benchmark binary is what's actually
-      # used for benchmarking and it lands in staging/bin/.
+      # The artifact does NOT bundle TheRock (deploy host installs ROCm
+      # separately and exports THEROCK_DIST) nor the Python wheels (the
+      # Linux build deliberately omits ORT --build_wheel and OGA
+      # --skip_wheel so the wheels can't satisfy `import onnxruntime`
+      # anyway).
       #
-      # docker/build.sh A.7b already runs a 2-pass `ldd` inside the
-      # container and bundles the TheRock + ORT transitive .so set into
-      # install/lib/, so this step is a flat `cp` from install/ + one
-      # config side-copy.
+      # docker/build.sh A.7b runs a 2-pass `ldd` inside the container
+      # and bundles prebuilt-local transitive .so files into install/lib/,
+      # so the bulk `cp -a install/. staging/` here is most of the work.
+      # Filter out artifact-irrelevant pieces shipped only for local
+      # developers / SDK consumers: the static archives we statically
+      # link into hip-compiler.so (libcpptrace.a, libdwarf.a, libzstd.a,
+      # libHipCInterface.a), pkgconfig descriptors, and the duplicate
+      # morphizen_config.json that the submodule's install rule drops
+      # into bin/.
       # -----------------------------------------------------------------------
       - name: Stage Linux GPU test package
         run: |
@@ -173,9 +178,26 @@ jobs:
           cp -a "${{ github.workspace }}/install/bin/." staging/bin/
           cp -a "${{ github.workspace }}/install/lib/." staging/lib/
 
-          # Config lives in the repo etc/ on Path A (install/bin gets a copy
-          # too; both are fine, we pick the source-of-truth here).
+          # ORT latency tool lives in prebuilt-local (A.5 copies it
+          # there from ORT's build dir); cmake --install of this project
+          # doesn't re-stage it into install/bin/.
+          cp "${{ github.workspace }}/prebuilt-local/bin/onnxruntime_perf_test" \
+              staging/bin/
+
+          # Repo etc/ is the canonical source for morphizen_config.json
+          # (the submodule's bin/ copy gets dropped below).
           cp onnx-hipdnn-ep/etc/morphizen_config.json staging/etc/
+
+          # Drop artifact-irrelevant content. The static archives are
+          # already whole-archived into the shipped .so files; the .pc
+          # files are dev-time pkg-config descriptors; bin/<config> is
+          # the submodule-install duplicate of etc/<config>.
+          rm -f staging/lib/libHipCInterface.a \
+                staging/lib/libcpptrace.a \
+                staging/lib/libdwarf.a \
+                staging/lib/libzstd.a
+          rm -rf staging/lib/pkgconfig
+          rm -f staging/bin/morphizen_config.json
 
           chmod +x staging/bin/*
 

--- a/3rd-party/custom_kernels/cmake/hip_utils.cmake
+++ b/3rd-party/custom_kernels/cmake/hip_utils.cmake
@@ -83,34 +83,19 @@ if(WIN32)
         message(STATUS "[hip_utils] hip::host not available - using manual HIP setup")
     endif()
 else()
-    # On Linux, enable HIP language support.
+    # Linux HIP language setup.
     #
-    # cmake 3.31's CMakeDetermineHIPCompiler.cmake resolves the ROCm
-    # toolkit via, in order:
-    #
-    #   1. CMAKE_HIP_COMPILER_ROCM_ROOT (cmake var, direct override)
-    #   2. ${CMAKE_HIP_COMPILER} -v -print-targets
-    #      → grep "Found HIP installation: <path>" from compiler stderr
-    #   3. `hipconfig --rocmpath` (requires hipconfig on PATH)
-    #
-    # It does NOT consult ENV{ROCM_PATH} or ENV{HIP_PATH}, despite a common
-    # misconception. Routes (2)/(3) require either a clang++ that already
-    # knows its sibling ROCm root or hipconfig on the system PATH — neither
-    # holds when ROCm lives at a non-default prefix (TheRock dist tarball,
-    # vcpkg, custom CMAKE_INSTALL_PREFIX, ...) and the install isn't on PATH.
-    #
-    # Pin CMAKE_HIP_COMPILER_ROCM_ROOT directly so route (1) succeeds and
-    # cmake skips the brittle stderr-scrape / PATH-lookup steps. Also point
-    # CMAKE_HIP_COMPILER at the clang++ shipped inside HIP_PATH so the
-    # compiler-detection step (run before the root lookup) finds the right
-    # binary instead of system /usr/bin/clang++.
+    # cmake 3.31's CMakeDetermineHIPCompiler resolves the ROCm root via
+    # CMAKE_HIP_COMPILER_ROCM_ROOT, then a `clang++ -v` stderr-scrape, then
+    # `hipconfig --rocmpath` — it ignores ENV{ROCM_PATH} / ENV{HIP_PATH}.
+    # When ROCm lives at a non-default prefix (TheRock dist tarball, vcpkg,
+    # ...) and isn't on PATH, the latter two routes fail. Pin the root
+    # directly + point CMAKE_HIP_COMPILER at the in-tree clang++.
     if(NOT CMAKE_HIP_COMPILER_ROCM_ROOT)
         set(CMAKE_HIP_COMPILER_ROCM_ROOT "${HIP_PATH}")
     endif()
     if(NOT CMAKE_HIP_COMPILER)
-        # TheRock dist ships LLVM under <root>/llvm/bin/clang++.
-        # Stock ROCm uses <root>/bin/clang++. Probe both, preferring the
-        # AMD-fork amdclang++ if present.
+        # TheRock: <root>/llvm/bin; stock ROCm: <root>/bin. Prefer amdclang++.
         find_program(_HIP_CLANGXX
             NAMES amdclang++ clang++
             PATHS

--- a/3rd-party/custom_kernels/cmake/hip_utils.cmake
+++ b/3rd-party/custom_kernels/cmake/hip_utils.cmake
@@ -83,7 +83,54 @@ if(WIN32)
         message(STATUS "[hip_utils] hip::host not available - using manual HIP setup")
     endif()
 else()
-    # On Linux, enable HIP language support
+    # On Linux, enable HIP language support.
+    #
+    # cmake 3.31's CMakeDetermineHIPCompiler.cmake resolves the ROCm
+    # toolkit via, in order:
+    #
+    #   1. CMAKE_HIP_COMPILER_ROCM_ROOT (cmake var, direct override)
+    #   2. ${CMAKE_HIP_COMPILER} -v -print-targets
+    #      → grep "Found HIP installation: <path>" from compiler stderr
+    #   3. `hipconfig --rocmpath` (requires hipconfig on PATH)
+    #
+    # It does NOT consult ENV{ROCM_PATH} or ENV{HIP_PATH}, despite a common
+    # misconception. Routes (2)/(3) require either a clang++ that already
+    # knows its sibling ROCm root or hipconfig on the system PATH — neither
+    # holds when ROCm lives at a non-default prefix (TheRock dist tarball,
+    # vcpkg, custom CMAKE_INSTALL_PREFIX, ...) and the install isn't on PATH.
+    #
+    # Pin CMAKE_HIP_COMPILER_ROCM_ROOT directly so route (1) succeeds and
+    # cmake skips the brittle stderr-scrape / PATH-lookup steps. Also point
+    # CMAKE_HIP_COMPILER at the clang++ shipped inside HIP_PATH so the
+    # compiler-detection step (run before the root lookup) finds the right
+    # binary instead of system /usr/bin/clang++.
+    if(NOT CMAKE_HIP_COMPILER_ROCM_ROOT)
+        set(CMAKE_HIP_COMPILER_ROCM_ROOT "${HIP_PATH}")
+    endif()
+    if(NOT CMAKE_HIP_COMPILER)
+        # TheRock dist ships LLVM under <root>/llvm/bin/clang++.
+        # Stock ROCm uses <root>/bin/clang++. Probe both, preferring the
+        # AMD-fork amdclang++ if present.
+        find_program(_HIP_CLANGXX
+            NAMES amdclang++ clang++
+            PATHS
+                "${HIP_PATH}/bin"
+                "${HIP_PATH}/llvm/bin"
+            NO_DEFAULT_PATH
+        )
+        if(_HIP_CLANGXX)
+            set(CMAKE_HIP_COMPILER "${_HIP_CLANGXX}")
+            message(STATUS "[hip_utils] CMAKE_HIP_COMPILER: ${CMAKE_HIP_COMPILER}")
+        else()
+            message(FATAL_ERROR
+                "Could not find amdclang++ or clang++ under "
+                "${HIP_PATH}/bin or ${HIP_PATH}/llvm/bin. "
+                "Set CMAKE_HIP_COMPILER explicitly or install a complete "
+                "ROCm/TheRock distribution at HIP_PATH.")
+        endif()
+    endif()
+    message(STATUS "[hip_utils] CMAKE_HIP_COMPILER_ROCM_ROOT: ${CMAKE_HIP_COMPILER_ROCM_ROOT}")
+
     enable_language(HIP)
     if(NOT hip_FOUND)
         find_package(hip REQUIRED)

--- a/backend-mlir-compiler/custom-op-mlir/src/InferenceState.h
+++ b/backend-mlir-compiler/custom-op-mlir/src/InferenceState.h
@@ -23,6 +23,26 @@ namespace mlir_compilation::customop {
 // Manages inference state and owns the plugin that provides inference
 // functions. Uses morphizen::Plugin infrastructure for dynamic library loading.
 class InferenceState {
+  // Passkey tag for the public constructor below: external callers cannot
+  // name this type (it is implicitly private under the `class` keyword), so
+  // the constructor is effectively unreachable from outside the class even
+  // though it is declared in the public section. Members and friends can
+  // still construct one, which is what std::make_unique<InferenceState>(
+  // PrivateTag{}, ...) needs inside create().
+  //
+  // Declaring the type here -- at the very top of the class body, before any
+  // member function signature -- means name lookup for the constructor below
+  // resolves to this inner type on both MSVC and GCC. Two earlier shapes
+  // both broke one compiler:
+  //   - Forward decl in `public:` + definition in `private:` is rejected by
+  //     GCC with `error: ... PrivateTag redeclared with different access`.
+  //   - Spelling the parameter as `struct PrivateTag` (an elaborated type
+  //     specifier) makes MSVC introduce a brand-new outer-scope type, so
+  //     the .cpp definition no longer matches the header signature and
+  //     fails with C2511.
+  // Defining it once, here, sidesteps both.
+  struct PrivateTag {};
+
 public:
   // Create inference state from DLL bytes.
   // fs: FileSystem for resolving model constants (passed to inference_init).
@@ -61,17 +81,14 @@ public:
   // Callers reinterpret_cast to hipStream_t (itself a void* on amdhip64).
   void *get_stream_raw() const;
 
-  // Public constructor gated by PrivateTag: use create() factory instead.
-  // PrivateTag is declared private below — external callers cannot form one.
-  struct PrivateTag;
+  // Public constructor gated by PrivateTag (defined at the top of this
+  // class). Use the create() factory instead -- external callers cannot
+  // construct a PrivateTag and therefore cannot call this constructor.
   InferenceState(PrivateTag, void *state,
                  std::unique_ptr<morphizen::Plugin> plugin,
                  const std::string &temp_dll_path);
 
 private:
-  // Passkey tag — only members/friends of this class can construct one,
-  // preventing direct construction while allowing std::make_unique in create().
-  struct PrivateTag {};
   // Opaque handle returned by inference_init()
   void *state_;
 

--- a/backend-mlir-compiler/test/test_e2e_mlir.cpp
+++ b/backend-mlir-compiler/test/test_e2e_mlir.cpp
@@ -103,10 +103,18 @@ protected:
   std::string config_path_;
 
   void SetUp() override {
-    // Set environment variables for verbose logging
-    _putenv_s("XLNX_ONNX_EP_VERBOSE", "2");
-    _putenv_s("DEBUG_LOG_LEVEL", "info");
-    _putenv_s("MORPHIZEN_DEBUG_PLUGIN", "1");
+    // Set environment variables for verbose logging. _putenv_s is MSVC-only;
+    // POSIX uses setenv. Wrap both behind a tiny SETENV macro so this test
+    // builds on both platforms.
+#ifdef _WIN32
+#define HIPDNN_SETENV(k, v) _putenv_s((k), (v))
+#else
+#define HIPDNN_SETENV(k, v) setenv((k), (v), /*overwrite=*/1)
+#endif
+    HIPDNN_SETENV("XLNX_ONNX_EP_VERBOSE", "2");
+    HIPDNN_SETENV("DEBUG_LOG_LEVEL", "info");
+    HIPDNN_SETENV("MORPHIZEN_DEBUG_PLUGIN", "1");
+#undef HIPDNN_SETENV
 
     // Initialize ORT environment with configurable log level
     OrtLoggingLevel log_level = GetOrtLoggingLevel();

--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -128,34 +128,23 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(cpptrace)
 set(BUILD_SHARED_LIBS ${_saved_bsl_cpptrace})
 
-# morphizen's compile_options.linux.cmake defaults MORPHIZEN_COMPILER_OPTIONS
-# to "-Wall -Werror -Wconversion -pedantic -Wextra -fPIC" via CACHE STRING
-# (no FORCE). On Linux this propagates into every morphizen-* target.
-# Many of those targets either directly compile protobuf-generated *.pb.cc
-# or transitively include morphizen-core's public *.pb.h headers. GCC 13+
-# emits -Wconversion on protobuf >=22 boilerplate (`Map::size()` returns
-# size_t but the accessor signature is `int`), and morphizen's -Werror
-# upgrades that to a hard error.
+# Add morphizen subdirectory.
 #
-# An earlier attempt at narrowing this to per-target opt-outs in the
-# morphizen submodule (morphizen-pattern + onnx-ir-imp + morphizen-core)
-# under-covered: ort-bridge / morphizen-graph / etc. transitively pull
-# the same .pb.h via morphizen-core's PUBLIC includes and trip the same
-# error. Rather than chase whack-a-mole across every consumer, FORCE the
-# parent cache value before add_subdirectory(morphizen) so the suppression
-# applies to all morphizen-* targets at once. -Wconversion still fires as
-# a warning (useful code-review signal), only the -Werror promotion is
-# disabled. Other diagnostics (sign-compare, etc.) remain -Werror.
+# Note (linux): GCC 13+ emits -Wconversion on protobuf >=22 generated *.pb.h
+# inline accessors (`Map::size()` returns size_t but the accessor signature
+# is `int`), which would otherwise trip MORPHIZEN_COMPILER_OPTIONS's
+# `-Werror -Wconversion` in every morphizen-* target that includes a .pb.h.
+# Fixed at the root in the morphizen submodule by marking the generated-
+# header BINARY_DIR as SYSTEM PUBLIC (morphizen-core-static) / SYSTEM PRIVATE
+# (morphizen-pattern) — see those targets' CMakeLists.txt. The SYSTEM
+# marking propagates to all PUBLIC consumers via
+# INTERFACE_SYSTEM_INCLUDE_DIRECTORIES, so ort-bridge / morphizen-graph /
+# etc. inherit the suppression automatically. No parent-side override on
+# MORPHIZEN_COMPILER_OPTIONS is needed; full `-Werror -Wconversion` strict
+# mode remains in force for non-protobuf code.
 #
-# Windows / MSVC users are unaffected — the equivalent /WX-only knob lives
-# in morphizen's compile_options.msvc.cmake. APPLE is excluded to match the
-# Linux-specific scope of the GCC behavior.
-if(UNIX AND NOT APPLE)
-    set(MORPHIZEN_COMPILER_OPTIONS
-        -Wall -Werror -Wconversion -Wno-error=conversion -pedantic
-        -Wextra -fPIC
-        CACHE STRING "Compiler options for Morphizen" FORCE)
-endif()
-
-# Add morphizen subdirectory (after all options are set).
+# onnx-ir-imp keeps a narrower per-target `-Wno-error=conversion` because
+# its .pb.h surface comes from the external `onnx_proto` target whose
+# INTERFACE_INCLUDE_DIRECTORIES are not under our control to flip SYSTEM;
+# fixing that requires upstream onnx changes (tracked as a follow-up).
 add_subdirectory(3rd-party/morphizen)

--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -130,21 +130,12 @@ set(BUILD_SHARED_LIBS ${_saved_bsl_cpptrace})
 
 # Add morphizen subdirectory.
 #
-# Note (linux): GCC 13+ emits -Wconversion on protobuf >=22 generated *.pb.h
-# inline accessors (`Map::size()` returns size_t but the accessor signature
-# is `int`), which would otherwise trip MORPHIZEN_COMPILER_OPTIONS's
-# `-Werror -Wconversion` in every morphizen-* target that includes a .pb.h.
-# Fixed at the root in the morphizen submodule by marking the generated-
-# header BINARY_DIR as SYSTEM PUBLIC (morphizen-core-static) / SYSTEM PRIVATE
-# (morphizen-pattern) — see those targets' CMakeLists.txt. The SYSTEM
-# marking propagates to all PUBLIC consumers via
-# INTERFACE_SYSTEM_INCLUDE_DIRECTORIES, so ort-bridge / morphizen-graph /
-# etc. inherit the suppression automatically. No parent-side override on
-# MORPHIZEN_COMPILER_OPTIONS is needed; full `-Werror -Wconversion` strict
-# mode remains in force for non-protobuf code.
-#
-# onnx-ir-imp keeps a narrower per-target `-Wno-error=conversion` because
-# its .pb.h surface comes from the external `onnx_proto` target whose
-# INTERFACE_INCLUDE_DIRECTORIES are not under our control to flip SYSTEM;
-# fixing that requires upstream onnx changes (tracked as a follow-up).
+# GCC -Wconversion on protobuf >=22 *.pb.h accessors is suppressed at the
+# root by marking the generated-header BINARY_DIR as SYSTEM in
+# morphizen-{core-static,pattern}; the SYSTEM propagation handles all
+# transitive consumers, so no parent-side -Werror override is needed.
+# onnx-ir-imp still needs a per-target `-Wno-error=conversion` because
+# its .pb.h surface comes from external `onnx_proto` whose
+# INTERFACE_INCLUDE_DIRECTORIES we don't control (upstream onnx fix is a
+# follow-up).
 add_subdirectory(3rd-party/morphizen)

--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -129,4 +129,26 @@ FetchContent_MakeAvailable(cpptrace)
 set(BUILD_SHARED_LIBS ${_saved_bsl_cpptrace})
 
 # Add morphizen subdirectory (after all options are set)
+#
+# morphizen's compile_options.linux.cmake defaults MORPHIZEN_COMPILER_OPTIONS
+# to "-Wall -Werror -Wconversion -pedantic -Wextra -fPIC" via CACHE STRING (no
+# FORCE). On Linux this propagates into the morphizen-* targets, including the
+# ones that include protobuf-generated *.pb.h headers. GCC 13+ emits
+# -Wconversion on the boilerplate that protobuf >=22 generates (e.g.
+# `return _internal_foo().size();` returns size_t but the accessor signature
+# is `int`), and the morphizen `-Werror` then upgrades those to hard errors.
+#
+# Override the cache value with `FORCE` before add_subdirectory(morphizen) so
+# the new value sticks across reconfigures: keep -Wconversion as a warning
+# (still useful as a signal during code review) but stop -Werror from
+# promoting it to a build failure. Other diagnostics (sign-compare, etc.)
+# remain -Werror. Windows / MSVC users are unaffected because the equivalent
+# /WX-only knob lives in compile_options.msvc.cmake.
+if(UNIX AND NOT APPLE)
+    set(MORPHIZEN_COMPILER_OPTIONS
+        -Wall -Werror -Wconversion -Wno-error=conversion -pedantic
+        -Wextra -fPIC
+        CACHE STRING "Compiler options for Morphizen" FORCE)
+endif()
+
 add_subdirectory(3rd-party/morphizen)

--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -128,27 +128,8 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(cpptrace)
 set(BUILD_SHARED_LIBS ${_saved_bsl_cpptrace})
 
-# Add morphizen subdirectory (after all options are set)
-#
-# morphizen's compile_options.linux.cmake defaults MORPHIZEN_COMPILER_OPTIONS
-# to "-Wall -Werror -Wconversion -pedantic -Wextra -fPIC" via CACHE STRING (no
-# FORCE). On Linux this propagates into the morphizen-* targets, including the
-# ones that include protobuf-generated *.pb.h headers. GCC 13+ emits
-# -Wconversion on the boilerplate that protobuf >=22 generates (e.g.
-# `return _internal_foo().size();` returns size_t but the accessor signature
-# is `int`), and the morphizen `-Werror` then upgrades those to hard errors.
-#
-# Override the cache value with `FORCE` before add_subdirectory(morphizen) so
-# the new value sticks across reconfigures: keep -Wconversion as a warning
-# (still useful as a signal during code review) but stop -Werror from
-# promoting it to a build failure. Other diagnostics (sign-compare, etc.)
-# remain -Werror. Windows / MSVC users are unaffected because the equivalent
-# /WX-only knob lives in compile_options.msvc.cmake.
-if(UNIX AND NOT APPLE)
-    set(MORPHIZEN_COMPILER_OPTIONS
-        -Wall -Werror -Wconversion -Wno-error=conversion -pedantic
-        -Wextra -fPIC
-        CACHE STRING "Compiler options for Morphizen" FORCE)
-endif()
-
+# Add morphizen subdirectory (after all options are set).
+# The protobuf -Wconversion / -Werror conflict on Linux is now handled
+# per-target inside morphizen (morphizen-pattern + onnx-ir-imp), so no
+# cache override is needed here.
 add_subdirectory(3rd-party/morphizen)

--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -128,8 +128,34 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(cpptrace)
 set(BUILD_SHARED_LIBS ${_saved_bsl_cpptrace})
 
+# morphizen's compile_options.linux.cmake defaults MORPHIZEN_COMPILER_OPTIONS
+# to "-Wall -Werror -Wconversion -pedantic -Wextra -fPIC" via CACHE STRING
+# (no FORCE). On Linux this propagates into every morphizen-* target.
+# Many of those targets either directly compile protobuf-generated *.pb.cc
+# or transitively include morphizen-core's public *.pb.h headers. GCC 13+
+# emits -Wconversion on protobuf >=22 boilerplate (`Map::size()` returns
+# size_t but the accessor signature is `int`), and morphizen's -Werror
+# upgrades that to a hard error.
+#
+# An earlier attempt at narrowing this to per-target opt-outs in the
+# morphizen submodule (morphizen-pattern + onnx-ir-imp + morphizen-core)
+# under-covered: ort-bridge / morphizen-graph / etc. transitively pull
+# the same .pb.h via morphizen-core's PUBLIC includes and trip the same
+# error. Rather than chase whack-a-mole across every consumer, FORCE the
+# parent cache value before add_subdirectory(morphizen) so the suppression
+# applies to all morphizen-* targets at once. -Wconversion still fires as
+# a warning (useful code-review signal), only the -Werror promotion is
+# disabled. Other diagnostics (sign-compare, etc.) remain -Werror.
+#
+# Windows / MSVC users are unaffected — the equivalent /WX-only knob lives
+# in morphizen's compile_options.msvc.cmake. APPLE is excluded to match the
+# Linux-specific scope of the GCC behavior.
+if(UNIX AND NOT APPLE)
+    set(MORPHIZEN_COMPILER_OPTIONS
+        -Wall -Werror -Wconversion -Wno-error=conversion -pedantic
+        -Wextra -fPIC
+        CACHE STRING "Compiler options for Morphizen" FORCE)
+endif()
+
 # Add morphizen subdirectory (after all options are set).
-# The protobuf -Wconversion / -Werror conflict on Linux is now handled
-# per-target inside morphizen (morphizen-pattern + onnx-ir-imp), so no
-# cache override is needed here.
 add_subdirectory(3rd-party/morphizen)

--- a/dll/CMakeLists.txt
+++ b/dll/CMakeLists.txt
@@ -11,9 +11,16 @@ add_library(hip-compiler-dll SHARED
     hip-compiler.def
 )
 
-# Link against CInterface library (which pulls in all dependencies)
+# Link against CInterface library (which pulls in all dependencies).
+# WHOLE_ARCHIVE on HipCInterface: dll_main.cpp is empty outside Windows
+# (the DllMain hook is Windows-only), so nothing in this DLL references
+# the C-API symbols (hip_compile_with_fs, hip_get_version) directly.
+# Without WHOLE_ARCHIVE, ld drops the entire archive and produces an empty
+# .so — the EP then dlsym()s "hip_get_version" and aborts with
+# "no such function: hip_get_version". On Windows hip-compiler.def already
+# forces these exports, so this is Linux-specific (but harmless on Win).
 target_link_libraries(hip-compiler-dll PRIVATE
-    HipCInterface
+    "$<LINK_LIBRARY:WHOLE_ARCHIVE,HipCInterface>"
     HipSupport
 )
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,16 +42,6 @@ RUN pip3 install --no-cache-dir --break-system-packages \
         cmake lit setuptools wheel numpy requests packaging \
     && ln -sf /usr/local/bin/lit /usr/bin/lit
 
-# Layer 4: sccache for CI cache hits. Pinned to 0.10.0 — earlier 0.8.x only
-# knows GHA cache v1 (ACTIONS_CACHE_URL) and fails on the v2-only runners
-# GitHub rolled out in early 2026 (ACTIONS_RESULTS_URL).
-ARG SCCACHE_VERSION=0.10.0
-RUN curl -fsSL "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
-        | tar -xz -C /tmp \
-    && mv "/tmp/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl/sccache" /usr/local/bin/ \
-    && rm -rf "/tmp/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl" \
-    && chmod +x /usr/local/bin/sccache
-
 # Sanity: the cmake configs the build needs are actually present.
 RUN test -f /usr/lib/llvm-${LLVM_MAJOR}/lib/cmake/llvm/LLVMConfig.cmake \
     && test -f /usr/lib/llvm-${LLVM_MAJOR}/lib/cmake/mlir/MLIRConfig.cmake \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,9 +53,17 @@ RUN pip3 install --no-cache-dir --break-system-packages \
 # sets ACTIONS_CACHE_URL + ACTIONS_RUNTIME_TOKEN + SCCACHE_GHA_ENABLED=true;
 # docker/run.sh forwards these into the container so the in-container sccache
 # talks to the same GitHub Actions cache backend. docker/build.sh wires
-# CMAKE_*_COMPILER_LAUNCHER=sccache only when SCCACHE_GHA_ENABLED is "true",
-# so this layer is a no-op for local non-CI builds (the binary just sits idle).
-ARG SCCACHE_VERSION=0.8.2
+# CMAKE_*_COMPILER_LAUNCHER=sccache only when SCCACHE_GHA_ENABLED is "true"
+# AND a GHA cache URL is forwarded in, so this layer is a no-op for local
+# non-CI builds (the binary just sits idle).
+#
+# Pinned to 0.10.0 (vs the 2024-vintage 0.8.2): GitHub rolled out the
+# Actions Cache v2 service in early 2026 and started exporting
+# ACTIONS_RESULTS_URL instead of (or alongside) ACTIONS_CACHE_URL.
+# sccache <0.9 only knows about the v1 URL and fails at startup with
+# `ACTIONS_CACHE_URL not found, maybe not in github action environment?`
+# when only the v2 URL is set on the runner. 0.10+ handles both URLs.
+ARG SCCACHE_VERSION=0.10.0
 RUN curl -fsSL "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
         | tar -xz -C /tmp \
     && mv "/tmp/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl/sccache" /usr/local/bin/ \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,88 @@
+##
+## Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+## Licensed under the MIT License.
+##
+
+# hipdnn-ep build environment.
+# Mirrors `.github/workflows/linux-build.yml` step "Install apt build deps + LLVM 22"
+# so a local build matches what CI does on ubuntu-latest.
+FROM ubuntu:24.04
+
+ARG LLVM_MAJOR=22
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Layer 1: base toolchain + tools that the various sub-builds (ORT, protobuf,
+# flatbuffers, OGA) reach for. Kept in one RUN so apt cache can be cleaned
+# atomically and the layer stays small.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential cmake ninja-build pkg-config \
+        git ca-certificates curl wget gnupg lsb-release \
+        python3 python3-pip python3-venv python3-dev \
+        sudo gosu \
+        zip unzip xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+# Layer 2: LLVM/MLIR/clang/lld 22 from apt.llvm.org. Pinned LLVM_MAJOR so the
+# image rebuilds when CI bumps the version.
+RUN wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
+        | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc >/dev/null \
+    && echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-${LLVM_MAJOR} main" \
+        > /etc/apt/sources.list.d/llvm-${LLVM_MAJOR}.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        llvm-${LLVM_MAJOR}-dev \
+        llvm-${LLVM_MAJOR}-tools \
+        libpolly-${LLVM_MAJOR}-dev \
+        libmlir-${LLVM_MAJOR}-dev \
+        mlir-${LLVM_MAJOR}-tools \
+        clang-${LLVM_MAJOR} \
+        lld-${LLVM_MAJOR} \
+        liblld-${LLVM_MAJOR}-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Layer 3: pip-installed bits.
+#  - lit: required by `check-hip-mlir-lit`
+#  - cmake: ubuntu:24.04 ships 3.28.3 but backend-mlir-compiler needs >=3.29.
+#    pip cmake is staged earlier in PATH (/usr/local/bin) than apt's, so it wins.
+RUN pip3 install --no-cache-dir --break-system-packages \
+        cmake lit setuptools wheel numpy requests packaging \
+    && ln -sf /usr/local/bin/lit /usr/bin/lit
+
+# Layer 4: sccache for CI cache hits.
+# linux-build.yml runs mozilla-actions/sccache-action on the host runner which
+# sets ACTIONS_CACHE_URL + ACTIONS_RUNTIME_TOKEN + SCCACHE_GHA_ENABLED=true;
+# docker/run.sh forwards these into the container so the in-container sccache
+# talks to the same GitHub Actions cache backend. docker/build.sh wires
+# CMAKE_*_COMPILER_LAUNCHER=sccache only when SCCACHE_GHA_ENABLED is "true",
+# so this layer is a no-op for local non-CI builds (the binary just sits idle).
+ARG SCCACHE_VERSION=0.8.2
+RUN curl -fsSL "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+        | tar -xz -C /tmp \
+    && mv "/tmp/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl/sccache" /usr/local/bin/ \
+    && rm -rf "/tmp/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl" \
+    && chmod +x /usr/local/bin/sccache
+# ^ test/lit/CMakeLists.txt does find_program(LIT_EXECUTABLE NAMES lit
+#   HINTS ${python_dir}/bin NO_DEFAULT_PATH). System python lives in
+#   /usr/bin, but pip puts lit at /usr/local/bin/lit. Symlink so the
+#   HINT-based search hits it.
+
+# Sanity: cmake configs the build will look for.
+RUN test -f /usr/lib/llvm-${LLVM_MAJOR}/lib/cmake/llvm/LLVMConfig.cmake \
+    && test -f /usr/lib/llvm-${LLVM_MAJOR}/lib/cmake/mlir/MLIRConfig.cmake \
+    && test -f /usr/lib/llvm-${LLVM_MAJOR}/lib/cmake/lld/LLDConfig.cmake \
+    && test -f /usr/lib/llvm-${LLVM_MAJOR}/lib/libPolly.a
+
+# Allow any user added at runtime to use sudo without a password (entrypoint
+# adds the host UID/GID to the `dev` group).
+RUN echo "%dev ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/dev-nopasswd \
+    && chmod 0440 /etc/sudoers.d/dev-nopasswd
+
+ENV LLVM_MAJOR=${LLVM_MAJOR}
+ENV PATH=/usr/lib/llvm-${LLVM_MAJOR}/bin:${PATH}
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+WORKDIR /work
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["bash"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,17 +3,14 @@
 ## Licensed under the MIT License.
 ##
 
-# hipdnn-ep build environment.
-# Mirrors `.github/workflows/linux-build.yml` step "Install apt build deps + LLVM 22"
-# so a local build matches what CI does on ubuntu-latest.
+# hipdnn-ep Linux build environment. Mirrors the apt setup in
+# .github/workflows/linux-build.yml so local matches CI on ubuntu-latest.
 FROM ubuntu:24.04
 
 ARG LLVM_MAJOR=22
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Layer 1: base toolchain + tools that the various sub-builds (ORT, protobuf,
-# flatbuffers, OGA) reach for. Kept in one RUN so apt cache can be cleaned
-# atomically and the layer stays small.
+# Layer 1: base toolchain for ORT / protobuf / flatbuffers / OGA sub-builds.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential cmake ninja-build pkg-config \
         git ca-certificates curl wget gnupg lsb-release \
@@ -22,8 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         zip unzip xz-utils \
     && rm -rf /var/lib/apt/lists/*
 
-# Layer 2: LLVM/MLIR/clang/lld 22 from apt.llvm.org. Pinned LLVM_MAJOR so the
-# image rebuilds when CI bumps the version.
+# Layer 2: LLVM/MLIR/clang/lld from apt.llvm.org (pinned via LLVM_MAJOR).
 RUN wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
         | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc >/dev/null \
     && echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-${LLVM_MAJOR} main" \
@@ -40,48 +36,29 @@ RUN wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
         liblld-${LLVM_MAJOR}-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Layer 3: pip-installed bits.
-#  - lit: required by `check-hip-mlir-lit`
-#  - cmake: ubuntu:24.04 ships 3.28.3 but backend-mlir-compiler needs >=3.29.
-#    pip cmake is staged earlier in PATH (/usr/local/bin) than apt's, so it wins.
+# Layer 3: pip bits. ubuntu:24.04 ships cmake 3.28.3 but backend-mlir-compiler
+# needs >=3.29; pip cmake lands at /usr/local/bin and wins over apt's.
 RUN pip3 install --no-cache-dir --break-system-packages \
         cmake lit setuptools wheel numpy requests packaging \
     && ln -sf /usr/local/bin/lit /usr/bin/lit
 
-# Layer 4: sccache for CI cache hits.
-# linux-build.yml runs mozilla-actions/sccache-action on the host runner which
-# sets ACTIONS_CACHE_URL + ACTIONS_RUNTIME_TOKEN + SCCACHE_GHA_ENABLED=true;
-# docker/run.sh forwards these into the container so the in-container sccache
-# talks to the same GitHub Actions cache backend. docker/build.sh wires
-# CMAKE_*_COMPILER_LAUNCHER=sccache only when SCCACHE_GHA_ENABLED is "true"
-# AND a GHA cache URL is forwarded in, so this layer is a no-op for local
-# non-CI builds (the binary just sits idle).
-#
-# Pinned to 0.10.0 (vs the 2024-vintage 0.8.2): GitHub rolled out the
-# Actions Cache v2 service in early 2026 and started exporting
-# ACTIONS_RESULTS_URL instead of (or alongside) ACTIONS_CACHE_URL.
-# sccache <0.9 only knows about the v1 URL and fails at startup with
-# `ACTIONS_CACHE_URL not found, maybe not in github action environment?`
-# when only the v2 URL is set on the runner. 0.10+ handles both URLs.
+# Layer 4: sccache for CI cache hits. Pinned to 0.10.0 — earlier 0.8.x only
+# knows GHA cache v1 (ACTIONS_CACHE_URL) and fails on the v2-only runners
+# GitHub rolled out in early 2026 (ACTIONS_RESULTS_URL).
 ARG SCCACHE_VERSION=0.10.0
 RUN curl -fsSL "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
         | tar -xz -C /tmp \
     && mv "/tmp/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl/sccache" /usr/local/bin/ \
     && rm -rf "/tmp/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl" \
     && chmod +x /usr/local/bin/sccache
-# ^ test/lit/CMakeLists.txt does find_program(LIT_EXECUTABLE NAMES lit
-#   HINTS ${python_dir}/bin NO_DEFAULT_PATH). System python lives in
-#   /usr/bin, but pip puts lit at /usr/local/bin/lit. Symlink so the
-#   HINT-based search hits it.
 
-# Sanity: cmake configs the build will look for.
+# Sanity: the cmake configs the build needs are actually present.
 RUN test -f /usr/lib/llvm-${LLVM_MAJOR}/lib/cmake/llvm/LLVMConfig.cmake \
     && test -f /usr/lib/llvm-${LLVM_MAJOR}/lib/cmake/mlir/MLIRConfig.cmake \
     && test -f /usr/lib/llvm-${LLVM_MAJOR}/lib/cmake/lld/LLDConfig.cmake \
     && test -f /usr/lib/llvm-${LLVM_MAJOR}/lib/libPolly.a
 
-# Allow any user added at runtime to use sudo without a password (entrypoint
-# adds the host UID/GID to the `dev` group).
+# NOPASSWD sudo for any user the entrypoint puts into the `dev` group.
 RUN echo "%dev ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/dev-nopasswd \
     && chmod 0440 /etc/sudoers.d/dev-nopasswd
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -213,24 +213,6 @@ else
     git submodule update --init --recursive
 fi
 
-# Optional sccache integration. Gate on ALL of: SCCACHE_GHA_ENABLED=true,
-# sccache on PATH, and ACTIONS_{CACHE,RESULTS}_URL non-empty. The URL check
-# matters because mozilla-actions/sccache-action exports SCCACHE_GHA_ENABLED
-# unconditionally but the URL only when GitHub's cache service is reachable;
-# without it, `sccache --start-server` fails and every compile dies.
-SCCACHE_LAUNCHER_ARGS=()
-if [ "${SCCACHE_GHA_ENABLED:-}" = "true" ] \
-        && command -v sccache >/dev/null 2>&1 \
-        && [ -n "${ACTIONS_CACHE_URL:-}${ACTIONS_RESULTS_URL:-}" ]; then
-    SCCACHE_LAUNCHER_ARGS=(
-        -DCMAKE_C_COMPILER_LAUNCHER=sccache
-        -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
-    )
-    echo "[sccache] enabled (gha backend; cache URL detected)"
-else
-    echo "[sccache] disabled — no GHA cache URL in env (cold build expected)"
-fi
-
 # A.7 — Configure + build hipdnn-ep. Out-of-source: source tree untouched.
 if [ "$FORCE_RECONFIGURE" = "1" ] || [ ! -f "$BUILD_DIR/CMakeCache.txt" ]; then
     step "A.7  Configure (HIP_ARCHITECTURES=$HIP_ARCHITECTURES)"
@@ -247,8 +229,7 @@ if [ "$FORCE_RECONFIGURE" = "1" ] || [ ! -f "$BUILD_DIR/CMakeCache.txt" ]; then
         -DBUILD_EP=ON \
         -DBUILD_MOCK_RUNTIME=OFF \
         -DBUILD_HIP_TOOLS=ON \
-        -Dmorphizen_ENABLE_UNIT_TEST=OFF \
-        "${SCCACHE_LAUNCHER_ARGS[@]}"
+        -Dmorphizen_ENABLE_UNIT_TEST=OFF
 else
     echo "[skip] $BUILD_DIR/CMakeCache.txt exists — skipping configure (FORCE_RECONFIGURE=1 to redo)"
 fi
@@ -387,15 +368,6 @@ if ! verify_install_closure; then
     exit 1
 fi
 echo "[verify] install/ closure OK"
-
-# sccache stats from the IN-CONTAINER server (the host's sccache-action
-# `Post Setup sccache` queries the host binary which never sees our
-# compiles and always reports 0). Both processes share the same GHA
-# cache backend; this is the real picture of how well we cached.
-if [ "${#SCCACHE_LAUNCHER_ARGS[@]}" -gt 0 ]; then
-    step "sccache stats (in-container)"
-    sccache --show-stats || true
-fi
 
 step "DONE"
 echo "Install tree: $INSTALL_DIR"

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -121,7 +121,15 @@ have_protobuf() {
         || ls "$PREBUILT_DIR"/lib/cmake/utf8_range/utf8_rangeConfig.cmake >/dev/null 2>&1
 }
 have_flatbuffers() {
-    ls "$PREBUILT_DIR"/lib/cmake/flatbuffers/FlatBuffersConfig.cmake >/dev/null 2>&1
+    # flatbuffers v25.12.19 installs the cmake package config as
+    # `flatbuffers-config.cmake` (lowercase, hyphenated), not the
+    # CamelCase `FlatBuffersConfig.cmake` an earlier flatbuffers release
+    # used. Both names are valid per find_package(flatbuffers) semantics,
+    # but the actual file determines whether we can skip A.6b. Probing
+    # the wrong name made A.6b rebuild on every CI run even after a
+    # prebuilt-local cache hit (~2-3 min wasted each time).
+    ls "$PREBUILT_DIR"/lib/cmake/flatbuffers/flatbuffers-config.cmake >/dev/null 2>&1 \
+        || ls "$PREBUILT_DIR"/lib/cmake/flatbuffers/FlatBuffersConfig.cmake >/dev/null 2>&1
 }
 
 # A.4 — TheRock SDK

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -172,6 +172,22 @@ else
     if [ -n "$PERF_TEST" ]; then cp "$PERF_TEST" "$PREBUILT_DIR/bin/"; fi
 fi
 
+# OGA's cmake/global_variables.cmake (A.9 below) checks for the ORT C API
+# header at $ORT_HOME/include/onnxruntime_c_api.h (flat), but ORT 1.25.1's
+# `cmake --install` puts them under $PREBUILT_DIR/include/onnxruntime/*.h
+# (nested). Mirror the public headers up to include/ so both layouts
+# resolve.
+#
+# This runs unconditionally — NOT inside the A.5 `if have_ort` block —
+# because actions/cache may restore a prebuilt-local/ from a previous
+# run that didn't have the flatten step, so flattening only on first
+# fresh install would leave cache-hit runs broken. cp -n keeps it
+# idempotent: any file already at include/ root (incl. those from
+# protobuf / flatbuffers installs) is never clobbered.
+if [ -d "$PREBUILT_DIR/include/onnxruntime" ]; then
+    cp -rn "$PREBUILT_DIR/include/onnxruntime/." "$PREBUILT_DIR/include/" 2>/dev/null || true
+fi
+
 # A.6a — protobuf v34
 if have_protobuf; then
     echo "[skip] protobuf already installed in $PREBUILT_DIR"

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -346,31 +346,48 @@ cmake --build "$BUILD_DIR" --parallel "$NPROC"
 step "A.7  Install -> $INSTALL_DIR"
 cmake --install "$BUILD_DIR"
 
-# A.7b — Stage runtime .so deps into install/lib so the install/ tree is
-# self-contained (LD_LIBRARY_PATH=install/lib suffices to run hip-onnx-runner,
-# onnxruntime_perf_test, model_benchmark, ...). Without this step, install/lib
-# only carries libhip-compiler.so + libonnxruntime_morphizen_ep.so and the
-# caller still has to add prebuilt-local/lib (ORT) and therock-dist/lib (HIP)
-# to LD_LIBRARY_PATH.
+# A.7b — Stage runtime .so deps we BUILD ourselves (prebuilt-local sources:
+# ORT + protobuf + flatbuffers) into install/lib. Without this step,
+# install/lib only carries libhip-compiler.so +
+# libonnxruntime_morphizen_ep.so and the caller still has to add
+# prebuilt-local/lib to LD_LIBRARY_PATH.
+#
+# We deliberately do NOT stage TheRock-origin .so files (libamdhip64,
+# libhsa-runtime64, librocprofiler-register, libamd_comgr_loader,
+# librocm_sysdeps_*, ...) — matching the Windows artifact's contract
+# (gpu-perf-accuracy-test.yml downloads TheRock separately on the GPU
+# host and adds it to PATH/LIB). Reasons:
+#   1. The artifact halves in size (~310 MB -> ~150 MB) without TheRock
+#      bundles, since libamdhip64 alone is 26 MB and pulls another
+#      ~35 MB of transitive ROCm sysdeps + profiler libs.
+#   2. libamd_comgr_loader.so is a stub that dlopens the real
+#      libamd_comgr.so.3 at runtime; ldd does NOT see that runtime
+#      dlopen, so bundling the stub without the real lib silently
+#      breaks the artifact for any consumer who lacks TheRock on PATH.
+#      Not shipping the stub at all forces consumers to set up the
+#      full TheRock SDK (which then has both the stub AND its target).
+#   3. ROCm runtime is host-environment in nature — version skew
+#      between bundled libamdhip64 and the host's kernel driver / KFD
+#      ioctl ABI is a real risk. Letting the host provide both kernel
+#      and userland keeps that interface consistent.
 #
 # Implementation:
-#   Pass 1 — ldd the EP + CLI tools with the dep prefixes on LD_LIBRARY_PATH
-#            so SONAMEs without RPATH still resolve; pick up every .so that
-#            lives under THEROCK_DIST_DIR or PREBUILT_DIR and copy it (plus
-#            its readlink target so the SONAME chain stays valid) into
-#            install/lib.
-#   Pass 2 — ldd the just-staged set so transitive deps (e.g. libamdhip64 ->
-#            librocprofiler-register, libhsa-runtime64 -> librocm_sysdeps_*)
-#            are caught.
-# We deliberately do NOT copy /usr/lib/x86_64-linux-gnu/libLLVM.so.22.1 et al.
-# — those are container apt packages on the default ld.so search path; they
-# stay system-managed.
-step "A.7b  Stage runtime .so into install/lib"
+#   Pass 1 — ldd the EP + CLI tools with TheRock + prebuilt-local on
+#            LD_LIBRARY_PATH so all SONAMEs resolve; pick up every .so
+#            whose resolved path lives under PREBUILT_DIR and copy it
+#            (plus its readlink target so the SONAME chain stays
+#            valid) into install/lib.
+#   Pass 2 — ldd the just-staged set so transitive deps within
+#            prebuilt-local (e.g. onnxruntime_providers_shared.so)
+#            are caught. With TheRock excluded the pass converges in
+#            1-2 iterations.
+# /usr/lib/x86_64-linux-gnu/libLLVM.so.22.1 et al. also stay system-
+# managed (container apt packages on the default ld.so search path).
+step "A.7b  Stage runtime .so into install/lib (prebuilt-local only)"
 stage_from_ldd_pass() {
     LD_LIBRARY_PATH="$THEROCK_DIST_DIR/lib:$PREBUILT_DIR/lib:$INSTALL_DIR/lib" \
         ldd "$@" 2>/dev/null \
-        | awk -v t="$THEROCK_DIST_DIR" -v p="$PREBUILT_DIR" \
-              '$3 ~ t || $3 ~ p {print $3}' \
+        | awk -v p="$PREBUILT_DIR" '$3 ~ p {print $3}' \
         | sort -u \
         | while read -r src; do
             dst="$INSTALL_DIR/lib/$(basename "$src")"
@@ -468,21 +485,33 @@ if [ "$BUILD_OGA" = "1" ]; then
         "$INSTALL_DIR"/lib/libonnxruntime-genai.so*
 fi
 
-# Final closure check: with ONLY install/lib on LD_LIBRARY_PATH, every binary
-# under install/bin and every .so under install/lib must resolve all of its
-# DT_NEEDED entries. Runs AFTER A.9 so OGA's deps are covered.
+# Final closure check: with install/lib + therock-dist/lib on
+# LD_LIBRARY_PATH, every binary under install/bin and every .so under
+# install/lib must resolve all of its DT_NEEDED entries. Runs AFTER A.9
+# so OGA's deps are covered.
+#
+# Why include therock-dist/lib instead of just install/lib: per A.7b we
+# intentionally do NOT bundle TheRock-origin .so files into install/lib
+# (consumers are expected to set THEROCK_DIST and add it to their
+# LD_LIBRARY_PATH at runtime, matching the Windows artifact contract).
+# The check therefore reflects the actual supported invocation:
+#     LD_LIBRARY_PATH=$ROOT/lib:$THEROCK_DIST/lib
+# (documented in docs/quick_start_linux.md "Open a container shell").
 #
 # Failure here means the artifact will break on a fresh host (where the
-# build-host's apt LLVM / TheRock / ORT prefixes are absent) — better to
-# surface it now than ship a broken linux-gpu-test-package.
-step "Verify install/ closure (LD_LIBRARY_PATH=install/lib)"
+# build-host's apt LLVM / ORT prefixes are absent), or that something
+# leaked into install/lib that needed a prefix outside the supported
+# {install, therock-dist, system-apt} set — better to surface it now
+# than ship a broken linux-gpu-test-package.
+step "Verify install/ closure (LD_LIBRARY_PATH=install/lib:therock-dist/lib)"
 verify_install_closure() {
     local fail=0
     local target unresolved
     while IFS= read -r target; do
         # ldd a non-ELF file (e.g. shell wrapper script we accidentally
         # dropped into bin/) prints "not a dynamic executable" — skip those.
-        unresolved=$(LD_LIBRARY_PATH="$INSTALL_DIR/lib" ldd "$target" 2>&1 \
+        unresolved=$(LD_LIBRARY_PATH="$INSTALL_DIR/lib:$THEROCK_DIST_DIR/lib" \
+                     ldd "$target" 2>&1 \
                      | grep -F "not found" || true)
         if [ -n "$unresolved" ]; then
             echo "ERROR: unresolved deps in $target:" >&2

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -370,22 +370,18 @@ stage_from_ldd_pass \
     "$INSTALL_DIR/bin/hip-onnx-runner" \
     "$INSTALL_DIR/bin/hip-test-dll"
 
-# Pass 2: transitive — ldd the libs we just staged.
-mapfile -t _staged < <(find "$INSTALL_DIR/lib" -maxdepth 1 -name 'lib*.so*' -type f)
-if [ "${#_staged[@]}" -gt 0 ]; then
+# Pass 2: transitive — ldd the libs we just staged. Loop to a fixed point so
+# any second-level deps that Pass 2 itself introduces (rare with current ORT
+# + TheRock SO graph, but cheap to be defensive) are also picked up.
+prev_count=0
+for _i in 1 2 3 4; do
+    mapfile -t _staged < <(find "$INSTALL_DIR/lib" -maxdepth 1 -name 'lib*.so*' -type f)
+    [ "${#_staged[@]}" -eq 0 ] && break
     stage_from_ldd_pass "${_staged[@]}"
-fi
-
-# Verification: no unresolved deps when only install/lib is on the path.
-if LD_LIBRARY_PATH="$INSTALL_DIR/lib" \
-        ldd "$INSTALL_DIR/lib/libonnxruntime_morphizen_ep.so" \
-        | grep -qF "not found"; then
-    echo "ERROR: unresolved deps after stage:" >&2
-    LD_LIBRARY_PATH="$INSTALL_DIR/lib" \
-        ldd "$INSTALL_DIR/lib/libonnxruntime_morphizen_ep.so" \
-        | grep -F "not found" >&2
-    exit 1
-fi
+    new_count=$(find "$INSTALL_DIR/lib" -maxdepth 1 -name 'lib*.so*' -type f | wc -l)
+    if [ "$new_count" -eq "$prev_count" ]; then break; fi
+    prev_count=$new_count
+done
 echo "[stage] $(find "$INSTALL_DIR/lib" -name 'lib*.so*' | wc -l) lib*.so* in $INSTALL_DIR/lib/"
 
 # A.8 — LIT tests (no GPU needed)
@@ -421,7 +417,47 @@ if [ "$BUILD_OGA" = "1" ]; then
         --build_dir "$OGA_BUILD"
     cp "$OGA_BUILD/Release/benchmark/c/model_benchmark" "$INSTALL_DIR/bin/"
     cp -a "$OGA_BUILD"/Release/libonnxruntime-genai.so* "$INSTALL_DIR/lib/"
+    # OGA brought in libonnxruntime-genai.so (and possibly transitively
+    # libonnxruntime.so already staged in A.7b). Re-run one ldd pass so
+    # any new deps OGA pulls in (e.g. pybind11 runtime, tokenizers) land
+    # in install/lib too.
+    stage_from_ldd_pass \
+        "$INSTALL_DIR/bin/model_benchmark" \
+        "$INSTALL_DIR"/lib/libonnxruntime-genai.so*
 fi
+
+# Final closure check: with ONLY install/lib on LD_LIBRARY_PATH, every binary
+# under install/bin and every .so under install/lib must resolve all of its
+# DT_NEEDED entries. Runs AFTER A.9 so OGA's deps are covered.
+#
+# Failure here means the artifact will break on a fresh host (where the
+# build-host's apt LLVM / TheRock / ORT prefixes are absent) — better to
+# surface it now than ship a broken linux-gpu-test-package.
+step "Verify install/ closure (LD_LIBRARY_PATH=install/lib)"
+verify_install_closure() {
+    local fail=0
+    local target unresolved
+    while IFS= read -r target; do
+        # ldd a non-ELF file (e.g. shell wrapper script we accidentally
+        # dropped into bin/) prints "not a dynamic executable" — skip those.
+        unresolved=$(LD_LIBRARY_PATH="$INSTALL_DIR/lib" ldd "$target" 2>&1 \
+                     | grep -F "not found" || true)
+        if [ -n "$unresolved" ]; then
+            echo "ERROR: unresolved deps in $target:" >&2
+            echo "$unresolved" >&2
+            fail=1
+        fi
+    done < <(
+        find "$INSTALL_DIR/bin" -maxdepth 1 -type f -executable 2>/dev/null
+        find "$INSTALL_DIR/lib" -maxdepth 1 -name 'lib*.so*' -type f 2>/dev/null
+    )
+    return $fail
+}
+if ! verify_install_closure; then
+    echo "ERROR: install/ is not self-contained — see unresolved deps above." >&2
+    exit 1
+fi
+echo "[verify] install/ closure OK"
 
 step "DONE"
 echo "Install tree: $INSTALL_DIR"

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -58,6 +58,12 @@ set -euo pipefail
 : "${PROTOBUF_REF:=v34.0}"
 : "${FLATBUFFERS_REF:=v25.12.19}"
 : "${THEROCK_VERSION:=therock-dist-linux-gfx1151-7.11.0}"
+# OGA pin: this is the single source of truth for "which OGA SHA to build
+# against" inside the container. CI forwards `OGA_REF` from
+# .github/workflows/linux-build.yml's env block via docker/run.sh, so
+# bumping the workflow env is enough to roll OGA forward. Local dev
+# without an explicit override gets this hard-coded pin.
+: "${OGA_REF:=2615301864b4d2397231d443865cb96111cc5fc2}"
 : "${BUILD_OGA:=0}"
 : "${SKIP_LIT:=0}"
 : "${FORCE_RECONFIGURE:=0}"
@@ -130,6 +136,17 @@ have_flatbuffers() {
     # prebuilt-local cache hit (~2-3 min wasted each time).
     ls "$PREBUILT_DIR"/lib/cmake/flatbuffers/flatbuffers-config.cmake >/dev/null 2>&1 \
         || ls "$PREBUILT_DIR"/lib/cmake/flatbuffers/FlatBuffersConfig.cmake >/dev/null 2>&1
+}
+have_oga() {
+    # OGA produces two install-facing artifacts that downstream consumers
+    # (gpu-perf-accuracy-test.yml's model_benchmark runs, this artifact's
+    # bin/lib trees) actually use: the model_benchmark CLI binary and the
+    # libonnxruntime-genai.so* SONAME chain. When both are in place we
+    # can skip A.9 entirely. The CI's `Cache OGA install outputs` step
+    # restores exactly these paths on cache hit, so this check is what
+    # bridges the GHA cache to the skip-build path.
+    [ -x "$INSTALL_DIR/bin/model_benchmark" ] \
+        && ls "$INSTALL_DIR"/lib/libonnxruntime-genai.so* >/dev/null 2>&1
 }
 
 # A.4 — TheRock SDK
@@ -404,31 +421,48 @@ fi
 # onnxruntime/, named after the repo) so users who manage their own checkout
 # can drop it in beside ORT without touching env vars. The .git guard below
 # means an existing checkout is respected as-is — no fetch, no checkout, no
-# submodule update. OGA_REF below is documentation of CI's pin; we apply it
-# only to a fresh clone.
+# submodule update. OGA_REF (resolved at the top of this script from env or
+# the hard-coded default) is applied only to a fresh clone.
+#
+# Skip-the-build gate: have_oga() returns true when the install artifacts
+# are already in place — either built earlier this run, or restored from
+# CI's `Cache OGA install outputs` cache step. The CI cache key includes
+# OGA_REF + ONNXRUNTIME_VERSION, so bumping either at the workflow level
+# automatically misses the cache here and triggers a rebuild.
 if [ "$BUILD_OGA" = "1" ]; then
-    step "A.9  (optional) Build OGA model_benchmark"
-    OGA_REF="2615301864b4d2397231d443865cb96111cc5fc2"  # CI pin
-    if [ ! -d "$OGA_SRC/.git" ]; then
-        rm -rf "$OGA_SRC"
-        git clone --recursive https://github.com/AMDmoore/onnxruntime-genai.git "$OGA_SRC"
-        ( cd "$OGA_SRC" && git checkout "$OGA_REF" && git submodule update --init --recursive )
+    if have_oga; then
+        echo "[skip] OGA model_benchmark + libonnxruntime-genai.so* already in $INSTALL_DIR"
     else
-        echo "[skip] $OGA_SRC/.git exists — using user-managed checkout as-is"
+        step "A.9  (optional) Build OGA model_benchmark"
+        if [ ! -d "$OGA_SRC/.git" ]; then
+            rm -rf "$OGA_SRC"
+            git clone --recursive https://github.com/AMDmoore/onnxruntime-genai.git "$OGA_SRC"
+            ( cd "$OGA_SRC" && git checkout "$OGA_REF" && git submodule update --init --recursive )
+        else
+            echo "[skip] $OGA_SRC/.git exists — using user-managed checkout as-is"
+        fi
+        # --skip_wheel: the OGA python wheel is unusable on Linux without
+        # an ORT python wheel (the OGA wheel does `import onnxruntime` at
+        # runtime), and A.5 deliberately omits ORT --build_wheel to avoid
+        # the Python::NumPy / dev-headers dependency drag. Skipping the
+        # OGA wheel saves ~1-3 min of pybind11 + pip wheel pack on cold
+        # builds. Consumers who need the wheel build OGA from source.
+        python3 "$OGA_SRC/build.py" \
+            --config Release \
+            --cmake_generator Ninja \
+            --ort_home "$PREBUILT_DIR" \
+            --skip_tests --skip_examples --skip_wheel \
+            --parallel \
+            --build_dir "$OGA_BUILD"
+        cp "$OGA_BUILD/Release/benchmark/c/model_benchmark" "$INSTALL_DIR/bin/"
+        cp -a "$OGA_BUILD"/Release/libonnxruntime-genai.so* "$INSTALL_DIR/lib/"
     fi
-    python3 "$OGA_SRC/build.py" \
-        --config Release \
-        --cmake_generator Ninja \
-        --ort_home "$PREBUILT_DIR" \
-        --skip_tests --skip_examples \
-        --parallel \
-        --build_dir "$OGA_BUILD"
-    cp "$OGA_BUILD/Release/benchmark/c/model_benchmark" "$INSTALL_DIR/bin/"
-    cp -a "$OGA_BUILD"/Release/libonnxruntime-genai.so* "$INSTALL_DIR/lib/"
     # OGA brought in libonnxruntime-genai.so (and possibly transitively
     # libonnxruntime.so already staged in A.7b). Re-run one ldd pass so
     # any new deps OGA pulls in (e.g. pybind11 runtime, tokenizers) land
-    # in install/lib too.
+    # in install/lib too. Runs regardless of build-vs-skip so a cache-
+    # restored libonnxruntime-genai.so still drives its transitive .so
+    # set through the closure check below.
     stage_from_ldd_pass \
         "$INSTALL_DIR/bin/model_benchmark" \
         "$INSTALL_DIR"/lib/libonnxruntime-genai.so*

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -4,51 +4,18 @@
 ## Licensed under the MIT License.
 ##
 
-# In-container build script. Implements steps A.4-A.8 of docs/quick_start.md
-# "Linux Support → A. Build from source on Linux".
+# In-container build script. Each step is idempotent (skips if its install
+# marker is present); wipe a dir to force that step to redo.
 #
-# Layout matches the Windows quick_start.md "Directory Layout" section:
-# everything is a sibling under <workspace>/, mirroring the upstream pattern
-# so cmake invocations in docs (e.g. `cmake --install ../build/onnxruntime`)
-# work verbatim from the project root.
+# Sibling-of-source layout under <workspace>/ (= dirname $SOURCE_DIR):
+#   onnx-hipdnn-ep/      SOURCE_DIR
+#   onnxruntime/         ORT source     onnxruntime-genai/  OGA source (BUILD_OGA=1)
+#   prebuilt-local/      built deps     therock-dist/       ROCm SDK
+#   build/               cmake builds   install/            install prefix
 #
-#   <workspace>/                          (= dirname $SOURCE_DIR)
-#   ├── onnx-hipdnn-ep/      (SOURCE_DIR — this project's source)
-#   ├── onnxruntime/         (ORT_SRC — ORT source clone, kept on disk so
-#   │                          incremental rebuilds reuse the .git tree)
-#   ├── onnxruntime-genai/   (OGA_SRC — OGA source clone, sibling of ORT
-#   │                          with the repo name; only used when BUILD_OGA=1)
-#   ├── prebuilt-local/      (PREBUILT_DIR — installed deps: ORT, protobuf,
-#   │                          flatbuffers, etc.)
-#   ├── therock-dist/        (THEROCK_DIST_DIR — TheRock ROCm SDK, ~13 GB)
-#   ├── build/               (BUILD_ROOT)
-#   │   ├── onnx-hipdnn-ep/      (BUILD_DIR — this project's cmake build)
-#   │   ├── onnxruntime/         (ORT_BUILD — ORT cmake build)
-#   │   ├── onnxruntime-genai/   (OGA_BUILD — OGA cmake build)
-#   │   └── scratch/             (SCRATCH_DIR — transient src+build for
-#   │                              protobuf / flatbuffers)
-#   ├── install/             (INSTALL_DIR — this project's install prefix)
-#   └── docker/              (this script + run.sh)
-#
-# Each step is idempotent: it checks for the install marker and skips if
-# already done. Re-running this script after a partial failure resumes from
-# the failed step. Wipe a specific dir (e.g. prebuilt-local/, therock-dist/)
-# to force that step to redo.
-#
-# Required env (passed by run.sh):
-#   SOURCE_DIR        — bind-mounted path of onnx-hipdnn-ep checkout
-#   HIP_ARCHITECTURES — gpu arch (e.g. gfx1151)
-#
-# Optional (all default to the layout above; override individually if needed):
-#   PREBUILT_DIR, THEROCK_DIST_DIR, BUILD_ROOT, BUILD_DIR, INSTALL_DIR,
-#   ORT_SRC, ORT_BUILD, OGA_SRC, OGA_BUILD, SCRATCH_DIR
-#   ONNXRUNTIME_VERSION (default 1.25.1)
-#   PROTOBUF_REF        (default v34.0)
-#   FLATBUFFERS_REF     (default v25.12.19)
-#   THEROCK_VERSION     (default therock-dist-linux-gfx1151-7.11.0)
-#   BUILD_OGA           (default 0; 1 = also build OGA model_benchmark)
-#   SKIP_LIT            (default 0; 1 = skip LIT tests)
-#   FORCE_RECONFIGURE   (default 0; 1 = re-run cmake even if build/ exists)
+# Required env (passed by run.sh): SOURCE_DIR, HIP_ARCHITECTURES.
+# Knobs (defaulted below): ONNXRUNTIME_VERSION, PROTOBUF_REF, FLATBUFFERS_REF,
+# THEROCK_VERSION, OGA_REF, BUILD_OGA, SKIP_LIT, FORCE_RECONFIGURE.
 
 set -euo pipefail
 
@@ -58,11 +25,7 @@ set -euo pipefail
 : "${PROTOBUF_REF:=v34.0}"
 : "${FLATBUFFERS_REF:=v25.12.19}"
 : "${THEROCK_VERSION:=therock-dist-linux-gfx1151-7.11.0}"
-# OGA pin: this is the single source of truth for "which OGA SHA to build
-# against" inside the container. CI forwards `OGA_REF` from
-# .github/workflows/linux-build.yml's env block via docker/run.sh, so
-# bumping the workflow env is enough to roll OGA forward. Local dev
-# without an explicit override gets this hard-coded pin.
+# OGA pin (single source of truth; CI overrides via linux-build.yml env).
 : "${OGA_REF:=2615301864b4d2397231d443865cb96111cc5fc2}"
 : "${BUILD_OGA:=0}"
 : "${SKIP_LIT:=0}"
@@ -127,24 +90,13 @@ have_protobuf() {
         || ls "$PREBUILT_DIR"/lib/cmake/utf8_range/utf8_rangeConfig.cmake >/dev/null 2>&1
 }
 have_flatbuffers() {
-    # flatbuffers v25.12.19 installs the cmake package config as
-    # `flatbuffers-config.cmake` (lowercase, hyphenated), not the
-    # CamelCase `FlatBuffersConfig.cmake` an earlier flatbuffers release
-    # used. Both names are valid per find_package(flatbuffers) semantics,
-    # but the actual file determines whether we can skip A.6b. Probing
-    # the wrong name made A.6b rebuild on every CI run even after a
-    # prebuilt-local cache hit (~2-3 min wasted each time).
+    # v25.12.19 ships lowercase `flatbuffers-config.cmake`; older releases used
+    # CamelCase. Probe both so A.6b actually skips on cache hit.
     ls "$PREBUILT_DIR"/lib/cmake/flatbuffers/flatbuffers-config.cmake >/dev/null 2>&1 \
         || ls "$PREBUILT_DIR"/lib/cmake/flatbuffers/FlatBuffersConfig.cmake >/dev/null 2>&1
 }
 have_oga() {
-    # OGA produces two install-facing artifacts that downstream consumers
-    # (gpu-perf-accuracy-test.yml's model_benchmark runs, this artifact's
-    # bin/lib trees) actually use: the model_benchmark CLI binary and the
-    # libonnxruntime-genai.so* SONAME chain. When both are in place we
-    # can skip A.9 entirely. The CI's `Cache OGA install outputs` step
-    # restores exactly these paths on cache hit, so this check is what
-    # bridges the GHA cache to the skip-build path.
+    # Bridges the CI `Cache OGA install outputs` to A.9's skip path.
     [ -x "$INSTALL_DIR/bin/model_benchmark" ] \
         && ls "$INSTALL_DIR"/lib/libonnxruntime-genai.so* >/dev/null 2>&1
 }
@@ -173,13 +125,8 @@ else
         echo "[skip] $ORT_SRC/.git exists — using user-managed checkout as-is"
     fi
     cd "$ORT_SRC"
-    # NOTE: docs/quick_start.md A.5 lists --disable_memleak_checker, but ORT
-    # 1.25.1's Linux build.py rejects it (it's a Windows-only flag from the
-    # build.bat path). Dropping it; memleak checker only matters for tests
-    # which we --skip_tests anyway.
-    # No --build_wheel: it pulls in onnxruntime_python.cmake which needs
-    # Python::NumPy and python dev headers. The hipdnn-ep build only needs
-    # the C++ libs + headers + onnxruntime_perf_test.
+    # No --build_wheel: ORT's python wheel target pulls Python::NumPy and
+    # dev headers; we only need C++ libs + headers + onnxruntime_perf_test.
     ./build.sh \
         --config Release \
         --build_shared_lib \
@@ -189,26 +136,18 @@ else
         --build_dir "$ORT_BUILD" \
         --skip_tests \
         --cmake_generator Ninja
-    # ORT 1.25.1 Linux build.sh writes to $build_dir/Release (no Linux/ prefix
-    # despite docs A.5 implying otherwise — that's the Windows layout).
+    # ORT 1.25.1 Linux build.sh writes to $build_dir/Release (no Linux/
+    # prefix; that's the Windows layout).
     cmake --install "$ORT_BUILD/Release" --prefix "$PREBUILT_DIR"
     PERF_TEST=$(find "$ORT_BUILD" -name onnxruntime_perf_test -type f | head -1)
     mkdir -p "$PREBUILT_DIR/bin"
     if [ -n "$PERF_TEST" ]; then cp "$PERF_TEST" "$PREBUILT_DIR/bin/"; fi
 fi
 
-# OGA's cmake/global_variables.cmake (A.9 below) checks for the ORT C API
-# header at $ORT_HOME/include/onnxruntime_c_api.h (flat), but ORT 1.25.1's
-# `cmake --install` puts them under $PREBUILT_DIR/include/onnxruntime/*.h
-# (nested). Mirror the public headers up to include/ so both layouts
-# resolve.
-#
-# This runs unconditionally — NOT inside the A.5 `if have_ort` block —
-# because actions/cache may restore a prebuilt-local/ from a previous
-# run that didn't have the flatten step, so flattening only on first
-# fresh install would leave cache-hit runs broken. cp -n keeps it
-# idempotent: any file already at include/ root (incl. those from
-# protobuf / flatbuffers installs) is never clobbered.
+# OGA expects ORT C API headers flat at $ORT_HOME/include/onnxruntime_c_api.h
+# but ORT installs them nested under include/onnxruntime/. Flatten so both
+# layouts resolve. Runs outside the `if have_ort` block so cache-restored
+# prebuilt-local/ from older runs also gets the mirror; cp -n is idempotent.
 if [ -d "$PREBUILT_DIR/include/onnxruntime" ]; then
     cp -rn "$PREBUILT_DIR/include/onnxruntime/." "$PREBUILT_DIR/include/" 2>/dev/null || true
 fi
@@ -257,52 +196,28 @@ else
     rm -rf "$FB_SRC" "$FB_BUILD"
 fi
 
-# A.2 — submodules. Run on the HOST first if any submodule is private (the
-# container has no git creds). With submodules already checked out, this is
-# a no-op verification pass. Note: NOT --depth 1 — MorphiZen's recorded
-# commit is not at branch tip, so shallow fetch fails.
+# A.2 — submodules. The container has no SSH creds for the private MorphiZen
+# repo; host runs `git submodule update --init --recursive` with ssh-agent
+# before invoking us (CI does the same via webfactory/ssh-agent). Whitelist
+# only the dirs we touch — avoid `safe.directory '*'` which masks real owner
+# bugs.
 step "A.2  Verify submodules (incl. MorphiZen)"
 cd "$SOURCE_DIR"
-# git on host vs container can disagree on the .git working-tree owner when
-# UID matches but the namespace differs; mark this tree safe. Also whitelist
-# the submodule and sibling source dirs that A.5 (ORT) and A.9 (OGA) touch.
-# We deliberately do NOT use `safe.directory '*'` — that swallows owner
-# mismatches everywhere and can mask real environment bugs.
 git config --global --add safe.directory "$SOURCE_DIR"
 git config --global --add safe.directory "$SOURCE_DIR/3rd-party/morphizen"
 git config --global --add safe.directory "$ORT_SRC"
 git config --global --add safe.directory "$OGA_SRC"
-# Trust user-managed submodule checkouts (same .git-guard pattern as A.5 ORT
-# and A.9 OGA below). The host normally runs
-# `git submodule update --init --recursive` with ssh-agent loaded before
-# invoking docker/run.sh, and CI does the same via webfactory/ssh-agent in
-# linux-build.yml. The container does NOT carry SSH credentials for the
-# private ROCm/MorphiZen repo, so we cannot run `submodule update` here;
-# but we also do not need to, because the submodule is already on disk via
-# the bind-mounted workspace.
 if [ -f 3rd-party/morphizen/CMakeLists.txt ]; then
     echo "[skip] 3rd-party/morphizen already populated — trusting user-managed checkout"
 else
     git submodule update --init --recursive
 fi
 
-# Optional sccache integration. mozilla-actions/sccache-action exports
-# SCCACHE_GHA_ENABLED + ACTIONS_CACHE_URL + ACTIONS_RUNTIME_TOKEN +
-# ACTIONS_RESULTS_URL (cache v2) into the runner env; docker/run.sh
-# forwards all four into the container. Wrap compilers with sccache only
-# when ALL of these are present:
-#   1. SCCACHE_GHA_ENABLED=true
-#   2. sccache binary on PATH (Dockerfile Layer 4 installs it)
-#   3. ACTIONS_CACHE_URL or ACTIONS_RESULTS_URL non-empty
-# The third check is the gate that broke CI run 25804869662: the
-# sccache-action exports SCCACHE_GHA_ENABLED unconditionally, but the
-# cache URL only when GitHub's cache service is actually reachable from
-# the runner. Without it, sccache --start-server fails immediately and
-# every ninja compile job dies with "ACTIONS_CACHE_URL not found".
-#
-# Outside CI all three are empty, so SCCACHE_LAUNCHER_ARGS stays empty
-# and the build runs without a compiler launcher (uncached, as expected
-# for local dev).
+# Optional sccache integration. Gate on ALL of: SCCACHE_GHA_ENABLED=true,
+# sccache on PATH, and ACTIONS_{CACHE,RESULTS}_URL non-empty. The URL check
+# matters because mozilla-actions/sccache-action exports SCCACHE_GHA_ENABLED
+# unconditionally but the URL only when GitHub's cache service is reachable;
+# without it, `sccache --start-server` fails and every compile dies.
 SCCACHE_LAUNCHER_ARGS=()
 if [ "${SCCACHE_GHA_ENABLED:-}" = "true" ] \
         && command -v sccache >/dev/null 2>&1 \
@@ -316,9 +231,7 @@ else
     echo "[sccache] disabled — no GHA cache URL in env (cold build expected)"
 fi
 
-# A.7 — Configure + build hipdnn-ep. BUILD_DIR / INSTALL_DIR were resolved
-# at the top of this script (defaults: <workspace>/build/<repo>/ and
-# <workspace>/install/). Source tree stays untouched.
+# A.7 — Configure + build hipdnn-ep. Out-of-source: source tree untouched.
 if [ "$FORCE_RECONFIGURE" = "1" ] || [ ! -f "$BUILD_DIR/CMakeCache.txt" ]; then
     step "A.7  Configure (HIP_ARCHITECTURES=$HIP_ARCHITECTURES)"
     cmake -S "$SOURCE_DIR" -B "$BUILD_DIR" \
@@ -346,43 +259,24 @@ cmake --build "$BUILD_DIR" --parallel "$NPROC"
 step "A.7  Install -> $INSTALL_DIR"
 cmake --install "$BUILD_DIR"
 
-# A.7b — Stage runtime .so deps we BUILD ourselves (prebuilt-local sources:
-# ORT + protobuf + flatbuffers) into install/lib. Without this step,
-# install/lib only carries libhip-compiler.so +
-# libonnxruntime_morphizen_ep.so and the caller still has to add
-# prebuilt-local/lib to LD_LIBRARY_PATH.
+# A.7b — Stage prebuilt-local deps (ORT + protobuf + flatbuffers) into
+# install/lib so LD_LIBRARY_PATH=install/lib:therock-dist/lib is enough.
 #
-# We deliberately do NOT stage TheRock-origin .so files (libamdhip64,
-# libhsa-runtime64, librocprofiler-register, libamd_comgr_loader,
-# librocm_sysdeps_*, ...) — matching the Windows artifact's contract
-# (gpu-perf-accuracy-test.yml downloads TheRock separately on the GPU
-# host and adds it to PATH/LIB). Reasons:
-#   1. The artifact halves in size (~310 MB -> ~150 MB) without TheRock
-#      bundles, since libamdhip64 alone is 26 MB and pulls another
-#      ~35 MB of transitive ROCm sysdeps + profiler libs.
-#   2. libamd_comgr_loader.so is a stub that dlopens the real
-#      libamd_comgr.so.3 at runtime; ldd does NOT see that runtime
-#      dlopen, so bundling the stub without the real lib silently
-#      breaks the artifact for any consumer who lacks TheRock on PATH.
-#      Not shipping the stub at all forces consumers to set up the
-#      full TheRock SDK (which then has both the stub AND its target).
-#   3. ROCm runtime is host-environment in nature — version skew
-#      between bundled libamdhip64 and the host's kernel driver / KFD
-#      ioctl ABI is a real risk. Letting the host provide both kernel
-#      and userland keeps that interface consistent.
+# We do NOT bundle TheRock-origin .so files (libamdhip64, libhsa-runtime64,
+# librocm_sysdeps_*, libamd_comgr_loader, ...). Matches the Windows
+# artifact contract (gpu-perf-accuracy-test.yml downloads TheRock
+# separately on the GPU host). Reasons:
+#   1. Halves artifact size (310 -> 150 MB).
+#   2. libamd_comgr_loader.so is a stub that dlopens libamd_comgr.so.3 at
+#      runtime — ldd misses the dlopen, so we'd ship the stub without its
+#      target and silently break consumers without TheRock on PATH.
+#   3. ROCm userland shares a private ioctl ABI with the amdgpu kernel
+#      driver; bundling a fixed libamdhip64 risks kernel-vs-userland skew.
 #
-# Implementation:
-#   Pass 1 — ldd the EP + CLI tools with TheRock + prebuilt-local on
-#            LD_LIBRARY_PATH so all SONAMEs resolve; pick up every .so
-#            whose resolved path lives under PREBUILT_DIR and copy it
-#            (plus its readlink target so the SONAME chain stays
-#            valid) into install/lib.
-#   Pass 2 — ldd the just-staged set so transitive deps within
-#            prebuilt-local (e.g. onnxruntime_providers_shared.so)
-#            are caught. With TheRock excluded the pass converges in
-#            1-2 iterations.
-# /usr/lib/x86_64-linux-gnu/libLLVM.so.22.1 et al. also stay system-
-# managed (container apt packages on the default ld.so search path).
+# 2-pass ldd: pass 1 ldds the EP + CLI tools; pass 2 loops over the just-
+# staged libs to catch transitive deps (e.g. onnxruntime_providers_shared.so).
+# awk filter copies only PREBUILT_DIR-resolved paths; TheRock + /usr/lib
+# entries stay system-managed.
 step "A.7b  Stage runtime .so into install/lib (prebuilt-local only)"
 stage_from_ldd_pass() {
     LD_LIBRARY_PATH="$THEROCK_DIST_DIR/lib:$PREBUILT_DIR/lib:$INSTALL_DIR/lib" \
@@ -393,8 +287,7 @@ stage_from_ldd_pass() {
             dst="$INSTALL_DIR/lib/$(basename "$src")"
             if [ ! -e "$dst" ]; then
                 cp -a "$src" "$dst"
-                # If $src is a symlink, also copy the readlink target so the
-                # `lib<name>.so.1 -> lib<name>.so.1.X.Y` chain resolves.
+                # Also copy the readlink target so the SONAME chain resolves.
                 real=$(readlink -f "$src")
                 rb=$(basename "$real")
                 if [ "$rb" != "$(basename "$src")" ] && [ ! -e "$INSTALL_DIR/lib/$rb" ]; then
@@ -404,7 +297,6 @@ stage_from_ldd_pass() {
         done
 }
 
-# Pass 1: direct deps of the EP + CLI tools.
 stage_from_ldd_pass \
     "$INSTALL_DIR/lib/libonnxruntime_morphizen_ep.so" \
     "$INSTALL_DIR/lib/libhip-compiler.so" \
@@ -412,9 +304,7 @@ stage_from_ldd_pass \
     "$INSTALL_DIR/bin/hip-onnx-runner" \
     "$INSTALL_DIR/bin/hip-test-dll"
 
-# Pass 2: transitive — ldd the libs we just staged. Loop to a fixed point so
-# any second-level deps that Pass 2 itself introduces (rare with current ORT
-# + TheRock SO graph, but cheap to be defensive) are also picked up.
+# Loop to a fixed point so second-level transitive deps are caught too.
 prev_count=0
 for _i in 1 2 3 4; do
     mapfile -t _staged < <(find "$INSTALL_DIR/lib" -maxdepth 1 -name 'lib*.so*' -type f)
@@ -432,20 +322,9 @@ if [ "$SKIP_LIT" != "1" ]; then
     cmake --build "$BUILD_DIR" --target check-hip-mlir-lit
 fi
 
-# A.9 — OGA model_benchmark (optional)
-#
-# Source layout mirrors ORT: <workspace>/onnxruntime-genai/ (sibling to
-# onnxruntime/, named after the repo) so users who manage their own checkout
-# can drop it in beside ORT without touching env vars. The .git guard below
-# means an existing checkout is respected as-is — no fetch, no checkout, no
-# submodule update. OGA_REF (resolved at the top of this script from env or
-# the hard-coded default) is applied only to a fresh clone.
-#
-# Skip-the-build gate: have_oga() returns true when the install artifacts
-# are already in place — either built earlier this run, or restored from
-# CI's `Cache OGA install outputs` cache step. The CI cache key includes
-# OGA_REF + ONNXRUNTIME_VERSION, so bumping either at the workflow level
-# automatically misses the cache here and triggers a rebuild.
+# A.9 — OGA model_benchmark (optional). have_oga skips the build when the
+# install artifacts are present (either built this run or restored from CI's
+# `Cache OGA install outputs`). OGA_REF bumps invalidate that cache key.
 if [ "$BUILD_OGA" = "1" ]; then
     if have_oga; then
         echo "[skip] OGA model_benchmark + libonnxruntime-genai.so* already in $INSTALL_DIR"
@@ -458,12 +337,9 @@ if [ "$BUILD_OGA" = "1" ]; then
         else
             echo "[skip] $OGA_SRC/.git exists — using user-managed checkout as-is"
         fi
-        # --skip_wheel: the OGA python wheel is unusable on Linux without
-        # an ORT python wheel (the OGA wheel does `import onnxruntime` at
-        # runtime), and A.5 deliberately omits ORT --build_wheel to avoid
-        # the Python::NumPy / dev-headers dependency drag. Skipping the
-        # OGA wheel saves ~1-3 min of pybind11 + pip wheel pack on cold
-        # builds. Consumers who need the wheel build OGA from source.
+        # --skip_wheel: the OGA python wheel needs an ORT python wheel at
+        # `import` time, but A.5 omits ORT --build_wheel; shipping it would
+        # be useless and burns ~1-3 min on pybind11 + wheel pack.
         python3 "$OGA_SRC/build.py" \
             --config Release \
             --cmake_generator Ninja \
@@ -474,42 +350,24 @@ if [ "$BUILD_OGA" = "1" ]; then
         cp "$OGA_BUILD/Release/benchmark/c/model_benchmark" "$INSTALL_DIR/bin/"
         cp -a "$OGA_BUILD"/Release/libonnxruntime-genai.so* "$INSTALL_DIR/lib/"
     fi
-    # OGA brought in libonnxruntime-genai.so (and possibly transitively
-    # libonnxruntime.so already staged in A.7b). Re-run one ldd pass so
-    # any new deps OGA pulls in (e.g. pybind11 runtime, tokenizers) land
-    # in install/lib too. Runs regardless of build-vs-skip so a cache-
-    # restored libonnxruntime-genai.so still drives its transitive .so
-    # set through the closure check below.
+    # Drag OGA's transitive prebuilt-local deps (pybind11 etc.) into
+    # install/lib. Runs in both build + skip branches so cache-restored
+    # libonnxruntime-genai.so still feeds the closure check below.
     stage_from_ldd_pass \
         "$INSTALL_DIR/bin/model_benchmark" \
         "$INSTALL_DIR"/lib/libonnxruntime-genai.so*
 fi
 
-# Final closure check: with install/lib + therock-dist/lib on
-# LD_LIBRARY_PATH, every binary under install/bin and every .so under
-# install/lib must resolve all of its DT_NEEDED entries. Runs AFTER A.9
-# so OGA's deps are covered.
-#
-# Why include therock-dist/lib instead of just install/lib: per A.7b we
-# intentionally do NOT bundle TheRock-origin .so files into install/lib
-# (consumers are expected to set THEROCK_DIST and add it to their
-# LD_LIBRARY_PATH at runtime, matching the Windows artifact contract).
-# The check therefore reflects the actual supported invocation:
-#     LD_LIBRARY_PATH=$ROOT/lib:$THEROCK_DIST/lib
-# (documented in docs/quick_start_linux.md "Open a container shell").
-#
-# Failure here means the artifact will break on a fresh host (where the
-# build-host's apt LLVM / ORT prefixes are absent), or that something
-# leaked into install/lib that needed a prefix outside the supported
-# {install, therock-dist, system-apt} set — better to surface it now
-# than ship a broken linux-gpu-test-package.
+# Closure check: with install/lib + therock-dist/lib on LD_LIBRARY_PATH
+# (the supported runtime invocation, per docs/quick_start_linux.md), every
+# install/bin binary and install/lib .so must resolve all DT_NEEDED. Catches
+# leaks into install/lib that depend on a prefix outside {install,
+# therock-dist, system-apt} before they ship.
 step "Verify install/ closure (LD_LIBRARY_PATH=install/lib:therock-dist/lib)"
 verify_install_closure() {
     local fail=0
     local target unresolved
     while IFS= read -r target; do
-        # ldd a non-ELF file (e.g. shell wrapper script we accidentally
-        # dropped into bin/) prints "not a dynamic executable" — skip those.
         unresolved=$(LD_LIBRARY_PATH="$INSTALL_DIR/lib:$THEROCK_DIST_DIR/lib" \
                      ldd "$target" 2>&1 \
                      | grep -F "not found" || true)

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,395 @@
+#!/usr/bin/env bash
+##
+## Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+## Licensed under the MIT License.
+##
+
+# In-container build script. Implements steps A.4-A.8 of docs/quick_start.md
+# "Linux Support → A. Build from source on Linux".
+#
+# Layout matches the Windows quick_start.md "Directory Layout" section:
+# everything is a sibling under <workspace>/, mirroring the upstream pattern
+# so cmake invocations in docs (e.g. `cmake --install ../build/onnxruntime`)
+# work verbatim from the project root.
+#
+#   <workspace>/                          (= dirname $SOURCE_DIR)
+#   ├── onnx-hipdnn-ep/      (SOURCE_DIR — this project's source)
+#   ├── onnxruntime/         (ORT_SRC — ORT source clone, kept on disk so
+#   │                          incremental rebuilds reuse the .git tree)
+#   ├── onnxruntime-genai/   (OGA_SRC — OGA source clone, sibling of ORT
+#   │                          with the repo name; only used when BUILD_OGA=1)
+#   ├── prebuilt-local/      (PREBUILT_DIR — installed deps: ORT, protobuf,
+#   │                          flatbuffers, etc.)
+#   ├── therock-dist/        (THEROCK_DIST_DIR — TheRock ROCm SDK, ~13 GB)
+#   ├── build/               (BUILD_ROOT)
+#   │   ├── onnx-hipdnn-ep/      (BUILD_DIR — this project's cmake build)
+#   │   ├── onnxruntime/         (ORT_BUILD — ORT cmake build)
+#   │   ├── onnxruntime-genai/   (OGA_BUILD — OGA cmake build)
+#   │   └── scratch/             (SCRATCH_DIR — transient src+build for
+#   │                              protobuf / flatbuffers)
+#   ├── install/             (INSTALL_DIR — this project's install prefix)
+#   └── docker/              (this script + run.sh)
+#
+# Each step is idempotent: it checks for the install marker and skips if
+# already done. Re-running this script after a partial failure resumes from
+# the failed step. Wipe a specific dir (e.g. prebuilt-local/, therock-dist/)
+# to force that step to redo.
+#
+# Required env (passed by run.sh):
+#   SOURCE_DIR        — bind-mounted path of onnx-hipdnn-ep checkout
+#   HIP_ARCHITECTURES — gpu arch (e.g. gfx1151)
+#
+# Optional (all default to the layout above; override individually if needed):
+#   PREBUILT_DIR, THEROCK_DIST_DIR, BUILD_ROOT, BUILD_DIR, INSTALL_DIR,
+#   ORT_SRC, ORT_BUILD, OGA_SRC, OGA_BUILD, SCRATCH_DIR
+#   ONNXRUNTIME_VERSION (default 1.25.1)
+#   PROTOBUF_REF        (default v34.0)
+#   FLATBUFFERS_REF     (default v25.12.19)
+#   THEROCK_VERSION     (default therock-dist-linux-gfx1151-7.11.0)
+#   BUILD_OGA           (default 0; 1 = also build OGA model_benchmark)
+#   SKIP_LIT            (default 0; 1 = skip LIT tests)
+#   FORCE_RECONFIGURE   (default 0; 1 = re-run cmake even if build/ exists)
+
+set -euo pipefail
+
+: "${SOURCE_DIR:?SOURCE_DIR not set — run.sh should pass it via -e}"
+: "${HIP_ARCHITECTURES:=gfx1151}"
+: "${ONNXRUNTIME_VERSION:=1.25.1}"
+: "${PROTOBUF_REF:=v34.0}"
+: "${FLATBUFFERS_REF:=v25.12.19}"
+: "${THEROCK_VERSION:=therock-dist-linux-gfx1151-7.11.0}"
+: "${BUILD_OGA:=0}"
+: "${SKIP_LIT:=0}"
+: "${FORCE_RECONFIGURE:=0}"
+
+WORKSPACE="$(dirname "$SOURCE_DIR")"
+PROJECT_NAME="$(basename "$SOURCE_DIR")"
+
+: "${PREBUILT_DIR:=$WORKSPACE/prebuilt-local}"
+: "${THEROCK_DIST_DIR:=$WORKSPACE/therock-dist}"
+: "${BUILD_ROOT:=$WORKSPACE/build}"
+: "${SCRATCH_DIR:=$BUILD_ROOT/scratch}"
+: "${ORT_SRC:=$WORKSPACE/onnxruntime}"
+: "${ORT_BUILD:=$BUILD_ROOT/onnxruntime}"
+: "${OGA_SRC:=$WORKSPACE/onnxruntime-genai}"
+: "${OGA_BUILD:=$BUILD_ROOT/onnxruntime-genai}"
+: "${BUILD_DIR:=$BUILD_ROOT/$PROJECT_NAME}"
+: "${INSTALL_DIR:=$WORKSPACE/install}"
+
+mkdir -p "$PREBUILT_DIR" "$THEROCK_DIST_DIR" "$BUILD_ROOT" "$SCRATCH_DIR"
+
+NPROC=$(nproc)
+step() {
+    echo
+    echo "════════════════════════════════════════════════════════════════════"
+    echo "▶ $*"
+    echo "════════════════════════════════════════════════════════════════════"
+}
+
+step "Build configuration"
+cat <<EOF
+WORKSPACE         = $WORKSPACE
+SOURCE_DIR        = $SOURCE_DIR
+ORT_SRC           = $ORT_SRC
+PREBUILT_DIR      = $PREBUILT_DIR
+THEROCK_DIST_DIR  = $THEROCK_DIST_DIR
+BUILD_ROOT        = $BUILD_ROOT
+BUILD_DIR         = $BUILD_DIR
+ORT_BUILD         = $ORT_BUILD
+SCRATCH_DIR       = $SCRATCH_DIR
+INSTALL_DIR       = $INSTALL_DIR
+HIP_ARCHITECTURES = $HIP_ARCHITECTURES
+ONNXRUNTIME_VERSION = $ONNXRUNTIME_VERSION
+PROTOBUF_REF      = $PROTOBUF_REF
+FLATBUFFERS_REF   = $FLATBUFFERS_REF
+THEROCK_VERSION   = $THEROCK_VERSION
+BUILD_OGA         = $BUILD_OGA
+SKIP_LIT          = $SKIP_LIT
+nproc             = $NPROC
+EOF
+
+# Quick-checking functions: each returns 0 if the install is already valid.
+have_therock() {
+    [ -d "$THEROCK_DIST_DIR/lib/llvm/bin" ] || [ -f "$THEROCK_DIST_DIR/bin/amdgpu-arch" ]
+}
+have_ort() {
+    ls "$PREBUILT_DIR"/lib/cmake/onnxruntime/onnxruntimeConfig.cmake >/dev/null 2>&1 \
+        || ls "$PREBUILT_DIR"/lib/cmake/onnxruntime/onnxruntime-config.cmake >/dev/null 2>&1
+}
+have_protobuf() {
+    ls "$PREBUILT_DIR"/lib/cmake/protobuf/protobuf-config.cmake >/dev/null 2>&1 \
+        || ls "$PREBUILT_DIR"/lib/cmake/utf8_range/utf8_rangeConfig.cmake >/dev/null 2>&1
+}
+have_flatbuffers() {
+    ls "$PREBUILT_DIR"/lib/cmake/flatbuffers/FlatBuffersConfig.cmake >/dev/null 2>&1
+}
+
+# A.4 — TheRock SDK
+if have_therock; then
+    echo "[skip] TheRock already at $THEROCK_DIST_DIR"
+else
+    step "A.4  Download TheRock $THEROCK_VERSION"
+    TROCK_TAR="$SCRATCH_DIR/therock.tar.gz"
+    curl -fsSL "https://repo.amd.com/rocm/tarball/${THEROCK_VERSION}.tar.gz" -o "$TROCK_TAR"
+    tar -xzf "$TROCK_TAR" -C "$THEROCK_DIST_DIR" --strip-components=1
+    rm -f "$TROCK_TAR"
+fi
+
+# A.5 — ONNX Runtime from source
+if have_ort; then
+    echo "[skip] ONNX Runtime already installed in $PREBUILT_DIR"
+else
+    step "A.5  Build ONNX Runtime v${ONNXRUNTIME_VERSION} (50-90 min cold)"
+    if [ ! -d "$ORT_SRC/.git" ]; then
+        rm -rf "$ORT_SRC"
+        git clone --depth 1 --recursive --branch "v${ONNXRUNTIME_VERSION}" \
+            https://github.com/Microsoft/onnxruntime.git "$ORT_SRC"
+    else
+        echo "[skip] $ORT_SRC/.git exists — using user-managed checkout as-is"
+    fi
+    cd "$ORT_SRC"
+    # NOTE: docs/quick_start.md A.5 lists --disable_memleak_checker, but ORT
+    # 1.25.1's Linux build.py rejects it (it's a Windows-only flag from the
+    # build.bat path). Dropping it; memleak checker only matters for tests
+    # which we --skip_tests anyway.
+    # No --build_wheel: it pulls in onnxruntime_python.cmake which needs
+    # Python::NumPy and python dev headers. The hipdnn-ep build only needs
+    # the C++ libs + headers + onnxruntime_perf_test.
+    ./build.sh \
+        --config Release \
+        --build_shared_lib \
+        --parallel "$NPROC" \
+        --compile_no_warning_as_error \
+        --skip_submodule_sync \
+        --build_dir "$ORT_BUILD" \
+        --skip_tests \
+        --cmake_generator Ninja
+    # ORT 1.25.1 Linux build.sh writes to $build_dir/Release (no Linux/ prefix
+    # despite docs A.5 implying otherwise — that's the Windows layout).
+    cmake --install "$ORT_BUILD/Release" --prefix "$PREBUILT_DIR"
+    PERF_TEST=$(find "$ORT_BUILD" -name onnxruntime_perf_test -type f | head -1)
+    mkdir -p "$PREBUILT_DIR/bin"
+    if [ -n "$PERF_TEST" ]; then cp "$PERF_TEST" "$PREBUILT_DIR/bin/"; fi
+fi
+
+# A.6a — protobuf v34
+if have_protobuf; then
+    echo "[skip] protobuf already installed in $PREBUILT_DIR"
+else
+    step "A.6  Build protobuf $PROTOBUF_REF"
+    PB_SRC="$SCRATCH_DIR/protobuf"
+    PB_BUILD="$SCRATCH_DIR/protobuf-build"
+    rm -rf "$PB_SRC" "$PB_BUILD"
+    git clone --depth 1 --branch "$PROTOBUF_REF" --recursive \
+        https://github.com/protocolbuffers/protobuf.git "$PB_SRC"
+    cmake -G Ninja -B "$PB_BUILD" -S "$PB_SRC" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX="$PREBUILT_DIR" \
+        -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+        -Dprotobuf_BUILD_TESTS=OFF \
+        -Dprotobuf_BUILD_EXAMPLES=OFF \
+        -Dprotobuf_WITH_ZLIB=OFF \
+        -Dprotobuf_BUILD_SHARED_LIBS=OFF \
+        -Dprotobuf_INSTALL=ON
+    ninja -C "$PB_BUILD" install
+    rm -rf "$PB_SRC" "$PB_BUILD"
+fi
+
+# A.6b — flatbuffers v25
+if have_flatbuffers; then
+    echo "[skip] flatbuffers already installed in $PREBUILT_DIR"
+else
+    step "A.6  Build flatbuffers $FLATBUFFERS_REF"
+    FB_SRC="$SCRATCH_DIR/flatbuffers"
+    FB_BUILD="$SCRATCH_DIR/flatbuffers-build"
+    rm -rf "$FB_SRC" "$FB_BUILD"
+    git clone --depth 1 --branch "$FLATBUFFERS_REF" \
+        https://github.com/google/flatbuffers.git "$FB_SRC"
+    cmake -G Ninja -B "$FB_BUILD" -S "$FB_SRC" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX="$PREBUILT_DIR" \
+        -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+        -DFLATBUFFERS_BUILD_TESTS=OFF \
+        -DFLATBUFFERS_BUILD_FLATC=ON \
+        -DFLATBUFFERS_BUILD_FLATLIB=ON
+    ninja -C "$FB_BUILD" install
+    rm -rf "$FB_SRC" "$FB_BUILD"
+fi
+
+# A.2 — submodules. Run on the HOST first if any submodule is private (the
+# container has no git creds). With submodules already checked out, this is
+# a no-op verification pass. Note: NOT --depth 1 — MorphiZen's recorded
+# commit is not at branch tip, so shallow fetch fails.
+step "A.2  Verify submodules (incl. MorphiZen)"
+cd "$SOURCE_DIR"
+# git on host vs container can disagree on the .git working-tree owner when
+# UID matches but the namespace differs; mark this tree safe.
+git config --global --add safe.directory "$SOURCE_DIR"
+git config --global --add safe.directory '*'
+# Trust user-managed submodule checkouts (same .git-guard pattern as A.5 ORT
+# and A.9 OGA below). The host normally runs
+# `git submodule update --init --recursive` with ssh-agent loaded before
+# invoking docker/run.sh, and CI does the same via webfactory/ssh-agent in
+# linux-build.yml. The container does NOT carry SSH credentials for the
+# private ROCm/MorphiZen repo, so we cannot run `submodule update` here;
+# but we also do not need to, because the submodule is already on disk via
+# the bind-mounted workspace.
+if [ -f 3rd-party/morphizen/CMakeLists.txt ]; then
+    echo "[skip] 3rd-party/morphizen already populated — trusting user-managed checkout"
+else
+    git submodule update --init --recursive
+fi
+
+# Optional sccache integration. SCCACHE_GHA_ENABLED + ACTIONS_CACHE_URL +
+# ACTIONS_RUNTIME_TOKEN are set on GitHub Actions runners by
+# mozilla-actions/sccache-action and forwarded into the container by
+# docker/run.sh. Outside CI (no env vars set) the launchers stay unset,
+# so sccache is a no-op even though the binary is on PATH.
+SCCACHE_LAUNCHER_ARGS=()
+if [ "${SCCACHE_GHA_ENABLED:-}" = "true" ] && command -v sccache >/dev/null 2>&1; then
+    SCCACHE_LAUNCHER_ARGS=(
+        -DCMAKE_C_COMPILER_LAUNCHER=sccache
+        -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+    )
+fi
+
+# A.7 — Configure + build hipdnn-ep. BUILD_DIR / INSTALL_DIR were resolved
+# at the top of this script (defaults: <workspace>/build/<repo>/ and
+# <workspace>/install/). Source tree stays untouched.
+if [ "$FORCE_RECONFIGURE" = "1" ] || [ ! -f "$BUILD_DIR/CMakeCache.txt" ]; then
+    step "A.7  Configure (HIP_ARCHITECTURES=$HIP_ARCHITECTURES)"
+    cmake -S "$SOURCE_DIR" -B "$BUILD_DIR" \
+        -G Ninja \
+        -DBUILD_SHARED_LIBS=OFF \
+        -DCMAKE_BUILD_TYPE=Release \
+        "-DCMAKE_PREFIX_PATH=$PREBUILT_DIR;$THEROCK_DIST_DIR;/usr/lib/llvm-22" \
+        "-DCMAKE_INSTALL_PREFIX=$INSTALL_DIR" \
+        -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+        "-DTHEROCK_DIST=$THEROCK_DIST_DIR" \
+        -DHIP_PLATFORM=amd \
+        "-DHIP_ARCHITECTURES=$HIP_ARCHITECTURES" \
+        -DBUILD_EP=ON \
+        -DBUILD_MOCK_RUNTIME=OFF \
+        -DBUILD_HIP_TOOLS=ON \
+        -Dmorphizen_ENABLE_UNIT_TEST=OFF \
+        "${SCCACHE_LAUNCHER_ARGS[@]}"
+else
+    echo "[skip] $BUILD_DIR/CMakeCache.txt exists — skipping configure (FORCE_RECONFIGURE=1 to redo)"
+fi
+
+step "A.7  Build hipdnn-ep"
+cmake --build "$BUILD_DIR" --parallel "$NPROC"
+
+step "A.7  Install -> $INSTALL_DIR"
+cmake --install "$BUILD_DIR"
+
+# A.7b — Stage runtime .so deps into install/lib so the install/ tree is
+# self-contained (LD_LIBRARY_PATH=install/lib suffices to run hip-onnx-runner,
+# onnxruntime_perf_test, model_benchmark, ...). Without this step, install/lib
+# only carries libhip-compiler.so + libonnxruntime_morphizen_ep.so and the
+# caller still has to add prebuilt-local/lib (ORT) and therock-dist/lib (HIP)
+# to LD_LIBRARY_PATH.
+#
+# Implementation:
+#   Pass 1 — ldd the EP + CLI tools with the dep prefixes on LD_LIBRARY_PATH
+#            so SONAMEs without RPATH still resolve; pick up every .so that
+#            lives under THEROCK_DIST_DIR or PREBUILT_DIR and copy it (plus
+#            its readlink target so the SONAME chain stays valid) into
+#            install/lib.
+#   Pass 2 — ldd the just-staged set so transitive deps (e.g. libamdhip64 ->
+#            librocprofiler-register, libhsa-runtime64 -> librocm_sysdeps_*)
+#            are caught.
+# We deliberately do NOT copy /usr/lib/x86_64-linux-gnu/libLLVM.so.22.1 et al.
+# — those are container apt packages on the default ld.so search path; they
+# stay system-managed.
+step "A.7b  Stage runtime .so into install/lib"
+stage_from_ldd_pass() {
+    LD_LIBRARY_PATH="$THEROCK_DIST_DIR/lib:$PREBUILT_DIR/lib:$INSTALL_DIR/lib" \
+        ldd "$@" 2>/dev/null \
+        | awk -v t="$THEROCK_DIST_DIR" -v p="$PREBUILT_DIR" \
+              '$3 ~ t || $3 ~ p {print $3}' \
+        | sort -u \
+        | while read -r src; do
+            dst="$INSTALL_DIR/lib/$(basename "$src")"
+            if [ ! -e "$dst" ]; then
+                cp -a "$src" "$dst"
+                # If $src is a symlink, also copy the readlink target so the
+                # `lib<name>.so.1 -> lib<name>.so.1.X.Y` chain resolves.
+                real=$(readlink -f "$src")
+                rb=$(basename "$real")
+                if [ "$rb" != "$(basename "$src")" ] && [ ! -e "$INSTALL_DIR/lib/$rb" ]; then
+                    cp -a "$real" "$INSTALL_DIR/lib/"
+                fi
+            fi
+        done
+}
+
+# Pass 1: direct deps of the EP + CLI tools.
+stage_from_ldd_pass \
+    "$INSTALL_DIR/lib/libonnxruntime_morphizen_ep.so" \
+    "$INSTALL_DIR/lib/libhip-compiler.so" \
+    "$INSTALL_DIR/bin/hip-compiler" \
+    "$INSTALL_DIR/bin/hip-onnx-runner" \
+    "$INSTALL_DIR/bin/hip-test-dll"
+
+# Pass 2: transitive — ldd the libs we just staged.
+mapfile -t _staged < <(find "$INSTALL_DIR/lib" -maxdepth 1 -name 'lib*.so*' -type f)
+if [ "${#_staged[@]}" -gt 0 ]; then
+    stage_from_ldd_pass "${_staged[@]}"
+fi
+
+# Verification: no unresolved deps when only install/lib is on the path.
+if LD_LIBRARY_PATH="$INSTALL_DIR/lib" \
+        ldd "$INSTALL_DIR/lib/libonnxruntime_morphizen_ep.so" \
+        | grep -qF "not found"; then
+    echo "ERROR: unresolved deps after stage:" >&2
+    LD_LIBRARY_PATH="$INSTALL_DIR/lib" \
+        ldd "$INSTALL_DIR/lib/libonnxruntime_morphizen_ep.so" \
+        | grep -F "not found" >&2
+    exit 1
+fi
+echo "[stage] $(find "$INSTALL_DIR/lib" -name 'lib*.so*' | wc -l) lib*.so* in $INSTALL_DIR/lib/"
+
+# A.8 — LIT tests (no GPU needed)
+if [ "$SKIP_LIT" != "1" ]; then
+    step "A.8  Run LIT tests"
+    cmake --build "$BUILD_DIR" --target check-hip-mlir-lit
+fi
+
+# A.9 — OGA model_benchmark (optional)
+#
+# Source layout mirrors ORT: <workspace>/onnxruntime-genai/ (sibling to
+# onnxruntime/, named after the repo) so users who manage their own checkout
+# can drop it in beside ORT without touching env vars. The .git guard below
+# means an existing checkout is respected as-is — no fetch, no checkout, no
+# submodule update. OGA_REF below is documentation of CI's pin; we apply it
+# only to a fresh clone.
+if [ "$BUILD_OGA" = "1" ]; then
+    step "A.9  (optional) Build OGA model_benchmark"
+    OGA_REF="2615301864b4d2397231d443865cb96111cc5fc2"  # CI pin
+    if [ ! -d "$OGA_SRC/.git" ]; then
+        rm -rf "$OGA_SRC"
+        git clone --recursive https://github.com/AMDmoore/onnxruntime-genai.git "$OGA_SRC"
+        ( cd "$OGA_SRC" && git checkout "$OGA_REF" && git submodule update --init --recursive )
+    else
+        echo "[skip] $OGA_SRC/.git exists — using user-managed checkout as-is"
+    fi
+    python3 "$OGA_SRC/build.py" \
+        --config Release \
+        --cmake_generator Ninja \
+        --ort_home "$PREBUILT_DIR" \
+        --skip_tests --skip_examples \
+        --parallel \
+        --build_dir "$OGA_BUILD"
+    cp "$OGA_BUILD/Release/benchmark/c/model_benchmark" "$INSTALL_DIR/bin/"
+    cp -a "$OGA_BUILD"/Release/libonnxruntime-genai.so* "$INSTALL_DIR/lib/"
+fi
+
+step "DONE"
+echo "Install tree: $INSTALL_DIR"
+echo
+echo "bin/:"
+ls -la "$INSTALL_DIR/bin" 2>/dev/null | head -40 || true
+echo
+echo "lib/ (selected):"
+ls -la "$INSTALL_DIR/lib" 2>/dev/null | grep -E '\.(so|so\.|a)$|libhip|libonnxruntime' | head -20 || true

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -223,9 +223,14 @@ fi
 step "A.2  Verify submodules (incl. MorphiZen)"
 cd "$SOURCE_DIR"
 # git on host vs container can disagree on the .git working-tree owner when
-# UID matches but the namespace differs; mark this tree safe.
+# UID matches but the namespace differs; mark this tree safe. Also whitelist
+# the submodule and sibling source dirs that A.5 (ORT) and A.9 (OGA) touch.
+# We deliberately do NOT use `safe.directory '*'` — that swallows owner
+# mismatches everywhere and can mask real environment bugs.
 git config --global --add safe.directory "$SOURCE_DIR"
-git config --global --add safe.directory '*'
+git config --global --add safe.directory "$SOURCE_DIR/3rd-party/morphizen"
+git config --global --add safe.directory "$ORT_SRC"
+git config --global --add safe.directory "$OGA_SRC"
 # Trust user-managed submodule checkouts (same .git-guard pattern as A.5 ORT
 # and A.9 OGA below). The host normally runs
 # `git submodule update --init --recursive` with ssh-agent loaded before
@@ -240,17 +245,34 @@ else
     git submodule update --init --recursive
 fi
 
-# Optional sccache integration. SCCACHE_GHA_ENABLED + ACTIONS_CACHE_URL +
-# ACTIONS_RUNTIME_TOKEN are set on GitHub Actions runners by
-# mozilla-actions/sccache-action and forwarded into the container by
-# docker/run.sh. Outside CI (no env vars set) the launchers stay unset,
-# so sccache is a no-op even though the binary is on PATH.
+# Optional sccache integration. mozilla-actions/sccache-action exports
+# SCCACHE_GHA_ENABLED + ACTIONS_CACHE_URL + ACTIONS_RUNTIME_TOKEN +
+# ACTIONS_RESULTS_URL (cache v2) into the runner env; docker/run.sh
+# forwards all four into the container. Wrap compilers with sccache only
+# when ALL of these are present:
+#   1. SCCACHE_GHA_ENABLED=true
+#   2. sccache binary on PATH (Dockerfile Layer 4 installs it)
+#   3. ACTIONS_CACHE_URL or ACTIONS_RESULTS_URL non-empty
+# The third check is the gate that broke CI run 25804869662: the
+# sccache-action exports SCCACHE_GHA_ENABLED unconditionally, but the
+# cache URL only when GitHub's cache service is actually reachable from
+# the runner. Without it, sccache --start-server fails immediately and
+# every ninja compile job dies with "ACTIONS_CACHE_URL not found".
+#
+# Outside CI all three are empty, so SCCACHE_LAUNCHER_ARGS stays empty
+# and the build runs without a compiler launcher (uncached, as expected
+# for local dev).
 SCCACHE_LAUNCHER_ARGS=()
-if [ "${SCCACHE_GHA_ENABLED:-}" = "true" ] && command -v sccache >/dev/null 2>&1; then
+if [ "${SCCACHE_GHA_ENABLED:-}" = "true" ] \
+        && command -v sccache >/dev/null 2>&1 \
+        && [ -n "${ACTIONS_CACHE_URL:-}${ACTIONS_RESULTS_URL:-}" ]; then
     SCCACHE_LAUNCHER_ARGS=(
         -DCMAKE_C_COMPILER_LAUNCHER=sccache
         -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
     )
+    echo "[sccache] enabled (gha backend; cache URL detected)"
+else
+    echo "[sccache] disabled — no GHA cache URL in env (cold build expected)"
 fi
 
 # A.7 — Configure + build hipdnn-ep. BUILD_DIR / INSTALL_DIR were resolved

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -388,6 +388,15 @@ if ! verify_install_closure; then
 fi
 echo "[verify] install/ closure OK"
 
+# sccache stats from the IN-CONTAINER server (the host's sccache-action
+# `Post Setup sccache` queries the host binary which never sees our
+# compiles and always reports 0). Both processes share the same GHA
+# cache backend; this is the real picture of how well we cached.
+if [ "${#SCCACHE_LAUNCHER_ARGS[@]}" -gt 0 ]; then
+    step "sccache stats (in-container)"
+    sccache --show-stats || true
+fi
+
 step "DONE"
 echo "Install tree: $INSTALL_DIR"
 echo

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -4,20 +4,11 @@
 ## Licensed under the MIT License.
 ##
 
-# Container entrypoint.
+# Container entrypoint: re-create host UID/GID inside so bind-mounted files
+# stay owned by the host user (no chown needed).
 #
-# Creates a non-root user matching the host's UID/GID so that bind-mounted
-# files written from inside the container are owned by the host user (no
-# chown needed). Borrows the pattern from xdock-vitis-ai-sw/docker.sh, but
-# trimmed: we only need build/iteration, not jupyter / board ssh / etc.
-#
-# Required env vars (set by run.sh on the host):
-#   HOST_UID, HOST_GID, HOST_USER, HOST_GROUP
-#
-# Optional:
-#   HOST_HOME — if set, it's the path that should be used as $HOME inside
-#               the container (e.g. a bind-mounted host home for caches).
-#               Defaults to /home/${HOST_USER}.
+# Required env (from run.sh): HOST_UID, HOST_GID, HOST_USER, HOST_GROUP.
+# Optional: HOST_HOME (defaults to /home/${HOST_USER}).
 set -euo pipefail
 
 : "${HOST_UID:?HOST_UID not set — run.sh should pass it via -e}"
@@ -26,18 +17,15 @@ set -euo pipefail
 : "${HOST_GROUP:?HOST_GROUP not set — run.sh should pass it via -e}"
 : "${HOST_HOME:=/home/${HOST_USER}}"
 
-# Create matching group + user if they don't already exist (idempotent for
-# `docker exec` re-attaches into a long-lived container).
+# Idempotent for `docker exec` re-attaches into a long-lived container.
 if ! getent group "$HOST_GID" >/dev/null; then
     groupadd -g "$HOST_GID" "$HOST_GROUP"
 fi
 if ! id -u "$HOST_USER" >/dev/null 2>&1; then
     useradd -m -d "$HOST_HOME" -u "$HOST_UID" -g "$HOST_GID" -s /bin/bash "$HOST_USER"
-    # Add to `dev` group → NOPASSWD sudo (see Dockerfile).
+    # `dev` group -> NOPASSWD sudo (see Dockerfile).
     groupadd -f dev
     usermod -aG dev "$HOST_USER"
-    # Render group / video / dialout for /dev/dri and /dev/kfd access if those
-    # groups exist on the image; ignore if they don't.
     for grp in render video; do
         if getent group "$grp" >/dev/null; then
             usermod -aG "$grp" "$HOST_USER"
@@ -45,29 +33,23 @@ if ! id -u "$HOST_USER" >/dev/null 2>&1; then
     done
 fi
 
-# When /dev/kfd or /dev/dri/* are passed in via --device, their group is the
-# host's `render` GID, which probably doesn't match anything in the container.
-# Add the user to the actual GID of those device nodes so HIP can open them.
+# /dev/kfd + /dev/dri/* device nodes use the HOST's render GID, which
+# typically doesn't match any in-container group. Map our user into the
+# device's actual GID so HIP can open it. usermod takes either name or
+# numeric, but some shadow-utils silently no-op on numeric — resolve a
+# name (existing or synthetic) and pass that.
 for dev in /dev/kfd /dev/dri/renderD*; do
     if [ -e "$dev" ]; then
         dev_gid=$(stat -c '%g' "$dev")
         if [ "$dev_gid" != "0" ] && ! id -G "$HOST_USER" | tr ' ' '\n' | grep -qx "$dev_gid"; then
-            # Resolve a name for the device's GID: prefer the existing group
-            # name if one is already mapped (e.g. `render` from a base image),
-            # otherwise create a synthetic one.
             grp_name=$(getent group "$dev_gid" | cut -d: -f1)
             if [ -z "$grp_name" ]; then
                 grp_name="hostgid_${dev_gid}"
                 groupadd -g "$dev_gid" "$grp_name"
             fi
-            # `usermod -aG` accepts either a numeric GID or a group name, but
-            # some shadow-utils builds silently no-op on numeric input when no
-            # named group with that literal numeric name exists. Pass the name
-            # to be safe.
             usermod -aG "$grp_name" "$HOST_USER"
         fi
     fi
 done
 
-# Drop into the host user. exec so signals propagate.
 exec gosu "$HOST_USER" "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -52,9 +52,19 @@ for dev in /dev/kfd /dev/dri/renderD*; do
     if [ -e "$dev" ]; then
         dev_gid=$(stat -c '%g' "$dev")
         if [ "$dev_gid" != "0" ] && ! id -G "$HOST_USER" | tr ' ' '\n' | grep -qx "$dev_gid"; then
-            grp_name="hostgid_${dev_gid}"
-            getent group "$dev_gid" >/dev/null || groupadd -g "$dev_gid" "$grp_name"
-            usermod -aG "$dev_gid" "$HOST_USER"
+            # Resolve a name for the device's GID: prefer the existing group
+            # name if one is already mapped (e.g. `render` from a base image),
+            # otherwise create a synthetic one.
+            grp_name=$(getent group "$dev_gid" | cut -d: -f1)
+            if [ -z "$grp_name" ]; then
+                grp_name="hostgid_${dev_gid}"
+                groupadd -g "$dev_gid" "$grp_name"
+            fi
+            # `usermod -aG` accepts either a numeric GID or a group name, but
+            # some shadow-utils builds silently no-op on numeric input when no
+            # named group with that literal numeric name exists. Pass the name
+            # to be safe.
+            usermod -aG "$grp_name" "$HOST_USER"
         fi
     fi
 done

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+##
+## Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+## Licensed under the MIT License.
+##
+
+# Container entrypoint.
+#
+# Creates a non-root user matching the host's UID/GID so that bind-mounted
+# files written from inside the container are owned by the host user (no
+# chown needed). Borrows the pattern from xdock-vitis-ai-sw/docker.sh, but
+# trimmed: we only need build/iteration, not jupyter / board ssh / etc.
+#
+# Required env vars (set by run.sh on the host):
+#   HOST_UID, HOST_GID, HOST_USER, HOST_GROUP
+#
+# Optional:
+#   HOST_HOME — if set, it's the path that should be used as $HOME inside
+#               the container (e.g. a bind-mounted host home for caches).
+#               Defaults to /home/${HOST_USER}.
+set -euo pipefail
+
+: "${HOST_UID:?HOST_UID not set — run.sh should pass it via -e}"
+: "${HOST_GID:?HOST_GID not set — run.sh should pass it via -e}"
+: "${HOST_USER:?HOST_USER not set — run.sh should pass it via -e}"
+: "${HOST_GROUP:?HOST_GROUP not set — run.sh should pass it via -e}"
+: "${HOST_HOME:=/home/${HOST_USER}}"
+
+# Create matching group + user if they don't already exist (idempotent for
+# `docker exec` re-attaches into a long-lived container).
+if ! getent group "$HOST_GID" >/dev/null; then
+    groupadd -g "$HOST_GID" "$HOST_GROUP"
+fi
+if ! id -u "$HOST_USER" >/dev/null 2>&1; then
+    useradd -m -d "$HOST_HOME" -u "$HOST_UID" -g "$HOST_GID" -s /bin/bash "$HOST_USER"
+    # Add to `dev` group → NOPASSWD sudo (see Dockerfile).
+    groupadd -f dev
+    usermod -aG dev "$HOST_USER"
+    # Render group / video / dialout for /dev/dri and /dev/kfd access if those
+    # groups exist on the image; ignore if they don't.
+    for grp in render video; do
+        if getent group "$grp" >/dev/null; then
+            usermod -aG "$grp" "$HOST_USER"
+        fi
+    done
+fi
+
+# When /dev/kfd or /dev/dri/* are passed in via --device, their group is the
+# host's `render` GID, which probably doesn't match anything in the container.
+# Add the user to the actual GID of those device nodes so HIP can open them.
+for dev in /dev/kfd /dev/dri/renderD*; do
+    if [ -e "$dev" ]; then
+        dev_gid=$(stat -c '%g' "$dev")
+        if [ "$dev_gid" != "0" ] && ! id -G "$HOST_USER" | tr ' ' '\n' | grep -qx "$dev_gid"; then
+            grp_name="hostgid_${dev_gid}"
+            getent group "$dev_gid" >/dev/null || groupadd -g "$dev_gid" "$grp_name"
+            usermod -aG "$dev_gid" "$HOST_USER"
+        fi
+    fi
+done
+
+# Drop into the host user. exec so signals propagate.
+exec gosu "$HOST_USER" "$@"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -46,6 +46,10 @@ WORKSPACE="$(cd "$SOURCE_DIR/.." && pwd -P)"
 : "${CONTAINER_NAME:=${USER}.hipdnn-ep.shell}"
 : "${HIP_ARCHITECTURES:=gfx1151}"
 : "${BUILD_OGA:=0}"
+# OGA_REF is intentionally NOT defaulted here — docker/build.sh has the
+# pin as its own default. Leaving this unset lets `OGA_REF=... ./run.sh`
+# from the host (or the workflow env: block in linux-build.yml) override
+# the container default without docker/run.sh needing to know the SHA.
 : "${SKIP_LIT:=0}"
 : "${FORCE_RECONFIGURE:=0}"
 
@@ -71,6 +75,15 @@ populate_common_args() {
         -e "BUILD_OGA=$BUILD_OGA"
         -e "SKIP_LIT=$SKIP_LIT"
         -e "FORCE_RECONFIGURE=$FORCE_RECONFIGURE"
+    )
+    # OGA_REF is forwarded only when set on the host. Unset → container
+    # falls back to docker/build.sh's hard-coded default. CI exports it
+    # from the workflow env block so a cache-key change propagates as
+    # a different SHA inside the container's git checkout.
+    if [ -n "${OGA_REF:-}" ]; then
+        _out+=(-e "OGA_REF=$OGA_REF")
+    fi
+    _out+=(
         -w "$SOURCE_DIR"
         --cap-add SYS_PTRACE
         -v "/dev/shm:/dev/shm"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+##
+## Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+## Licensed under the MIT License.
+##
+
+# Host-side wrapper around the hipdnn-ep build container.
+#
+# Subcommands:
+#   image   Build/refresh the Docker image (idempotent — layers cache).
+#   build   One-shot full build inside a --rm container (no GPU attached).
+#   shell   Open an interactive shell in a long-lived container with
+#           /dev/kfd + /dev/dri/renderD* attached. Re-execs into an
+#           already-running or stopped container of the same name.
+#   stop    Stop + rm the long-lived shell container.
+#
+# Env knobs (override on the command line, e.g. `BUILD_OGA=1 ./run.sh build`):
+#   IMAGE, CONTAINER_NAME, HIP_ARCHITECTURES, BUILD_OGA, SKIP_LIT,
+#   FORCE_RECONFIGURE.
+
+set -euo pipefail
+
+# Path resolution. This script lives at <SOURCE_DIR>/docker/run.sh, so:
+#   DOCKER_DIR = <repo>/docker
+#   SOURCE_DIR = <repo>            (one level up — the onnx-hipdnn-ep checkout)
+#   WORKSPACE  = <repo>/..         (two levels up — sibling-layout root)
+# Use `pwd -P` to resolve symlinks (e.g. /home/$USER/hipdnn-ep ->
+# /wrk/.../hipdnn-ep on autofs setups). Otherwise env vars handed to the
+# container would name the symlinked path, which doesn't exist inside the
+# container — only the bind-mount target path does.
+#
+# Workspace layout (sibling-of-source — mirrors Windows quick_start.md
+# "Directory Layout" so the same cmake/curl invocations work on both OSes):
+#   $WORKSPACE/onnx-hipdnn-ep/     source (= SOURCE_DIR)
+#   $WORKSPACE/onnxruntime/        ORT source
+#   $WORKSPACE/onnxruntime-genai/  OGA source (BUILD_OGA=1 only)
+#   $WORKSPACE/prebuilt-local/     built deps (ORT, protobuf, flatbuffers)
+#   $WORKSPACE/therock-dist/       TheRock SDK (~13 GB)
+#   $WORKSPACE/build/              cmake build dirs (out-of-source)
+#   $WORKSPACE/install/            cmake install prefix
+DOCKER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+SOURCE_DIR="$(cd "$DOCKER_DIR/.." && pwd -P)"
+WORKSPACE="$(cd "$SOURCE_DIR/.." && pwd -P)"
+
+: "${IMAGE:=hipdnn-ep-build:llvm22-noble}"
+: "${CONTAINER_NAME:=${USER}.hipdnn-ep.shell}"
+: "${HIP_ARCHITECTURES:=gfx1151}"
+: "${BUILD_OGA:=0}"
+: "${SKIP_LIT:=0}"
+: "${FORCE_RECONFIGURE:=0}"
+
+host_uid=$(id -u)
+host_gid=$(id -g)
+host_user=$(id -un)
+host_group=$(id -gn)
+
+populate_common_args() {
+    # $1 = name of array variable to append into.
+    local -n _out=$1
+    # Workspace bind-mount (bind-propagation=shared works around autofs/NFS
+    # edge cases on some host filesystems).
+    _out+=(
+        --mount "type=bind,source=$WORKSPACE,target=$WORKSPACE,bind-propagation=shared"
+        -e "HOST_UID=$host_uid"
+        -e "HOST_GID=$host_gid"
+        -e "HOST_USER=$host_user"
+        -e "HOST_GROUP=$host_group"
+        -e "HOST_HOME=$WORKSPACE/.docker-home"
+        -e "SOURCE_DIR=$SOURCE_DIR"
+        -e "HIP_ARCHITECTURES=$HIP_ARCHITECTURES"
+        -e "BUILD_OGA=$BUILD_OGA"
+        -e "SKIP_LIT=$SKIP_LIT"
+        -e "FORCE_RECONFIGURE=$FORCE_RECONFIGURE"
+        -w "$SOURCE_DIR"
+        --cap-add SYS_PTRACE
+        -v "/dev/shm:/dev/shm"
+        --network=host
+    )
+    # Forward sccache + GitHub Actions cache env vars when present. The
+    # mozilla-actions/sccache-action step in CI sets these on the host runner;
+    # the in-container sccache binary (installed via the Dockerfile) needs
+    # them to talk to the same GHA cache backend.
+    local var
+    for var in SCCACHE_GHA_ENABLED ACTIONS_CACHE_URL ACTIONS_RUNTIME_TOKEN; do
+        if [ -n "${!var:-}" ]; then
+            _out+=(-e "$var=${!var}")
+        fi
+    done
+}
+
+# Best-effort GPU passthrough. Only attach for `shell` — `build` doesn't need
+# a GPU (compile-only; the GPU is only used by `ctest` Execute tests and
+# downstream tools like hip-onnx-runner).
+populate_gpu_args() {
+    local -n _out=$1
+    [ -e /dev/kfd ] && _out+=(--device=/dev/kfd)
+    if [ -d /dev/dri ]; then
+        local d
+        for d in /dev/dri/renderD*; do
+            [ -e "$d" ] && _out+=(--device="$d")
+        done
+    fi
+}
+
+cmd_image() {
+    echo "[host] docker build -t $IMAGE $DOCKER_DIR"
+    docker build -t "$IMAGE" "$DOCKER_DIR"
+}
+
+cmd_build() {
+    if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+        cmd_image
+    fi
+    mkdir -p "$WORKSPACE/.docker-home"
+    local -a docker_args=()
+    populate_common_args docker_args
+    set -x
+    docker run --rm -t \
+        "${docker_args[@]}" \
+        "$IMAGE" \
+        bash "$DOCKER_DIR/build.sh"
+}
+
+cmd_shell() {
+    if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+        cmd_image
+    fi
+    mkdir -p "$WORKSPACE/.docker-home"
+
+    local state
+    state=$(docker container inspect -f '{{.State.Status}}' "$CONTAINER_NAME" 2>/dev/null || echo "")
+    if [ "$state" = "running" ]; then
+        echo "[host] $CONTAINER_NAME already running — exec into it"
+        docker exec -it "$CONTAINER_NAME" gosu "$host_user" bash -l
+        return $?
+    fi
+    if [ "$state" = "exited" ]; then
+        echo "[host] $CONTAINER_NAME exists but stopped — starting"
+        docker start "$CONTAINER_NAME" >/dev/null
+        docker exec -it "$CONTAINER_NAME" gosu "$host_user" bash -l
+        return $?
+    fi
+
+    local -a docker_args=()
+    populate_common_args docker_args
+    populate_gpu_args docker_args
+    set -x
+    docker run -dit \
+        --name "$CONTAINER_NAME" \
+        "${docker_args[@]}" \
+        "$IMAGE" \
+        bash
+    set +x
+    docker exec -it "$CONTAINER_NAME" gosu "$host_user" bash -l
+}
+
+cmd_stop() {
+    local state
+    state=$(docker container inspect -f '{{.State.Status}}' "$CONTAINER_NAME" 2>/dev/null || echo "")
+    if [ -z "$state" ]; then
+        echo "[host] no container named $CONTAINER_NAME"
+        return 0
+    fi
+    docker rm -f "$CONTAINER_NAME"
+}
+
+cmd_help() {
+    sed -n '2,14p' "$0"
+}
+
+case "${1:-help}" in
+    image)          cmd_image ;;
+    build)          cmd_build ;;
+    shell)          cmd_shell ;;
+    stop)           cmd_stop ;;
+    -h|--help|help) cmd_help ;;
+    *)
+        echo "unknown subcommand: $1" >&2
+        cmd_help
+        exit 1
+        ;;
+esac

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -65,16 +65,6 @@ populate_common_args() {
         -v "/dev/shm:/dev/shm"
         --network=host
     )
-    # Forward both GHA cache URLs (v1 = ACTIONS_CACHE_URL, v2 =
-    # ACTIONS_RESULTS_URL) — runners may export either. build.sh gates
-    # the compiler launcher on at least one being non-empty.
-    local var
-    for var in SCCACHE_GHA_ENABLED ACTIONS_CACHE_URL ACTIONS_RESULTS_URL \
-               ACTIONS_RUNTIME_TOKEN; do
-        if [ -n "${!var:-}" ]; then
-            _out+=(-e "$var=${!var}")
-        fi
-    done
 }
 
 # GPU passthrough — `shell` only, since `build` is compile-only.

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -20,24 +20,8 @@
 
 set -euo pipefail
 
-# Path resolution. This script lives at <SOURCE_DIR>/docker/run.sh, so:
-#   DOCKER_DIR = <repo>/docker
-#   SOURCE_DIR = <repo>            (one level up — the onnx-hipdnn-ep checkout)
-#   WORKSPACE  = <repo>/..         (two levels up — sibling-layout root)
-# Use `pwd -P` to resolve symlinks (e.g. /home/$USER/hipdnn-ep ->
-# /wrk/.../hipdnn-ep on autofs setups). Otherwise env vars handed to the
-# container would name the symlinked path, which doesn't exist inside the
-# container — only the bind-mount target path does.
-#
-# Workspace layout (sibling-of-source — mirrors Windows quick_start.md
-# "Directory Layout" so the same cmake/curl invocations work on both OSes):
-#   $WORKSPACE/onnx-hipdnn-ep/     source (= SOURCE_DIR)
-#   $WORKSPACE/onnxruntime/        ORT source
-#   $WORKSPACE/onnxruntime-genai/  OGA source (BUILD_OGA=1 only)
-#   $WORKSPACE/prebuilt-local/     built deps (ORT, protobuf, flatbuffers)
-#   $WORKSPACE/therock-dist/       TheRock SDK (~13 GB)
-#   $WORKSPACE/build/              cmake build dirs (out-of-source)
-#   $WORKSPACE/install/            cmake install prefix
+# `pwd -P` resolves autofs symlinks (e.g. /home/$USER/hipdnn-ep ->
+# /wrk/.../hipdnn-ep); container bind-mounts only know the real path.
 DOCKER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 SOURCE_DIR="$(cd "$DOCKER_DIR/.." && pwd -P)"
 WORKSPACE="$(cd "$SOURCE_DIR/.." && pwd -P)"
@@ -46,10 +30,8 @@ WORKSPACE="$(cd "$SOURCE_DIR/.." && pwd -P)"
 : "${CONTAINER_NAME:=${USER}.hipdnn-ep.shell}"
 : "${HIP_ARCHITECTURES:=gfx1151}"
 : "${BUILD_OGA:=0}"
-# OGA_REF is intentionally NOT defaulted here — docker/build.sh has the
-# pin as its own default. Leaving this unset lets `OGA_REF=... ./run.sh`
-# from the host (or the workflow env: block in linux-build.yml) override
-# the container default without docker/run.sh needing to know the SHA.
+# OGA_REF intentionally not defaulted; build.sh owns the pin. Unset on the
+# host means "use build.sh default"; setting it overrides.
 : "${SKIP_LIT:=0}"
 : "${FORCE_RECONFIGURE:=0}"
 
@@ -59,10 +41,8 @@ host_user=$(id -un)
 host_group=$(id -gn)
 
 populate_common_args() {
-    # $1 = name of array variable to append into.
     local -n _out=$1
-    # Workspace bind-mount (bind-propagation=shared works around autofs/NFS
-    # edge cases on some host filesystems).
+    # bind-propagation=shared works around autofs/NFS edge cases.
     _out+=(
         --mount "type=bind,source=$WORKSPACE,target=$WORKSPACE,bind-propagation=shared"
         -e "HOST_UID=$host_uid"
@@ -76,10 +56,6 @@ populate_common_args() {
         -e "SKIP_LIT=$SKIP_LIT"
         -e "FORCE_RECONFIGURE=$FORCE_RECONFIGURE"
     )
-    # OGA_REF is forwarded only when set on the host. Unset → container
-    # falls back to docker/build.sh's hard-coded default. CI exports it
-    # from the workflow env block so a cache-key change propagates as
-    # a different SHA inside the container's git checkout.
     if [ -n "${OGA_REF:-}" ]; then
         _out+=(-e "OGA_REF=$OGA_REF")
     fi
@@ -89,15 +65,9 @@ populate_common_args() {
         -v "/dev/shm:/dev/shm"
         --network=host
     )
-    # Forward sccache + GitHub Actions cache env vars when present. The
-    # mozilla-actions/sccache-action step in CI sets these on the host
-    # runner; the in-container sccache binary (installed via the
-    # Dockerfile) needs them to talk to the same GHA cache backend.
-    # ACTIONS_RESULTS_URL is the cache v2 URL (GitHub started rolling out
-    # in early 2026); ACTIONS_CACHE_URL is the v1 URL still set by older
-    # runners. Forward both — whichever the runner exposes wins, and
-    # docker/build.sh enables the compiler launcher only when at least
-    # one is non-empty.
+    # Forward both GHA cache URLs (v1 = ACTIONS_CACHE_URL, v2 =
+    # ACTIONS_RESULTS_URL) — runners may export either. build.sh gates
+    # the compiler launcher on at least one being non-empty.
     local var
     for var in SCCACHE_GHA_ENABLED ACTIONS_CACHE_URL ACTIONS_RESULTS_URL \
                ACTIONS_RUNTIME_TOKEN; do
@@ -107,9 +77,7 @@ populate_common_args() {
     done
 }
 
-# Best-effort GPU passthrough. Only attach for `shell` — `build` doesn't need
-# a GPU (compile-only; the GPU is only used by `ctest` Execute tests and
-# downstream tools like hip-onnx-runner).
+# GPU passthrough — `shell` only, since `build` is compile-only.
 populate_gpu_args() {
     local -n _out=$1
     [ -e /dev/kfd ] && _out+=(--device=/dev/kfd)

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -77,11 +77,17 @@ populate_common_args() {
         --network=host
     )
     # Forward sccache + GitHub Actions cache env vars when present. The
-    # mozilla-actions/sccache-action step in CI sets these on the host runner;
-    # the in-container sccache binary (installed via the Dockerfile) needs
-    # them to talk to the same GHA cache backend.
+    # mozilla-actions/sccache-action step in CI sets these on the host
+    # runner; the in-container sccache binary (installed via the
+    # Dockerfile) needs them to talk to the same GHA cache backend.
+    # ACTIONS_RESULTS_URL is the cache v2 URL (GitHub started rolling out
+    # in early 2026); ACTIONS_CACHE_URL is the v1 URL still set by older
+    # runners. Forward both — whichever the runner exposes wins, and
+    # docker/build.sh enables the compiler launcher only when at least
+    # one is non-empty.
     local var
-    for var in SCCACHE_GHA_ENABLED ACTIONS_CACHE_URL ACTIONS_RUNTIME_TOKEN; do
+    for var in SCCACHE_GHA_ENABLED ACTIONS_CACHE_URL ACTIONS_RESULTS_URL \
+               ACTIONS_RUNTIME_TOKEN; do
         if [ -n "${!var:-}" ]; then
             _out+=(-e "$var=${!var}")
         fi

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -489,6 +489,11 @@ tokenizer related files from original model directory to /path/to/output
 | `-r <n>` | Number of benchmark repetitions |
 | `-w <n>` | Number of warmup runs |
 
+## Linux
+
+Linux uses Docker for build and a separate path for runtime. See
+[quick_start_linux.md](quick_start_linux.md).
+
 ## ABI Note
 
 The pre-built binaries are compiled with the **Release `/MT`** runtime

--- a/docs/quick_start_linux.md
+++ b/docs/quick_start_linux.md
@@ -261,7 +261,27 @@ kernel, etc.), the canonical sources of truth are:
   sequence the Docker path runs
 - [`docker/Dockerfile`](../docker/Dockerfile) — exact apt package list
   (`llvm-22-dev`, `libpolly-22-dev`, `libmlir-22-dev`, `lld-22`,
-  `python3-dev`, ...)
+  `clang-22`, `python3-dev`, ...)
+
+## Runtime requirements (deploy host)
+
+The artifact's `bin/hip-compiler` invokes `clang++` at runtime to link
+the per-model DLL (driver-mediated link via `ld.lld`). The path is
+baked at configure time and PATH-lookup is the fallback, so deploy
+hosts need **either** the same `/usr/lib/llvm-22/bin/clang++` baked
+path **or** `clang++` somewhere on `$PATH`. One apt invocation covers
+both:
+
+```bash
+sudo apt install clang-22
+```
+
+No other LLVM/GCC tools are needed at runtime — the clang driver
+handles crt selection, sysroot, multiarch -L paths, and the
+libstdc++ link line internally. (The container image installs
+`clang-22` in [`docker/Dockerfile`](../docker/Dockerfile) Layer 2 as
+part of the `apt.llvm.org` block, so users on the Docker path don't
+need any host-side install.)
 
 ## Troubleshooting
 
@@ -278,3 +298,40 @@ Either:
    Without `-ml -1`, model_benchmark overrides the config's `search.max_length`
    with `prompt_length + generation_length`, breaking the static mask shape
    that decode_*.onnx expects.
+
+**`Failed to get HIP device count or no devices available` on bare-metal host**
+
+Most common cause: the host user is not in the `render` group, so opening
+`/dev/kfd` fails silently and `hipGetDeviceCount` returns 0. Check:
+
+```bash
+ls -la /dev/kfd          # expect group=render
+groups                   # expect 'render' in the list
+```
+
+Fix: `sudo usermod -aG render $USER && newgrp render` (or relogin).
+Inside `./docker/run.sh shell` this is handled automatically — the
+container entrypoint reads the host GID off `/dev/kfd` and adds the
+in-container user to it, so you don't need host `render` membership.
+
+**`EP library not found: libonnxruntime_morphizen_ep.so` from `hip-onnx-runner`**
+
+The runner's search order is `$MORPHIZEN_EP_LIB` (full path) → cwd →
+`<exe-dir>/libonnxruntime_morphizen_ep.so` → `<exe-dir>/../lib/libonnxruntime_morphizen_ep.so`.
+If you're running out of `install/bin/`, no env vars are needed — the
+sibling `install/lib/` is auto-discovered. If you've copied the binary
+elsewhere, set `MORPHIZEN_EP_LIB=/full/path/to/libonnxruntime_morphizen_ep.so`.
+
+**`clang++ not found on PATH and HIPDNN_CLANG_PATH is unset or stale` from `hip-compiler`**
+
+The per-model DLL link calls `clang++ -shared` as a subprocess; the
+driver handles crt / sysroot / multiarch / libstdc++ for us. The path
+is baked at configure time (`HIPDNN_CLANG_PATH`) with `findProgramByName`
+as the runtime fallback, so this error only fires when **both** the
+baked path is invalid (e.g. CI artifact deployed to a host that doesn't
+have llvm-22 in the same location) **and** `clang++` is absent from
+PATH.
+
+Fix on the deploy host: `sudo apt install clang-22` (or the matching
+LLVM version package). The container image installs this in Layer 2 of
+[`docker/Dockerfile`](../docker/Dockerfile).

--- a/docs/quick_start_linux.md
+++ b/docs/quick_start_linux.md
@@ -127,8 +127,15 @@ export ROOT="$WORKSPACE/install"            # built from source
 #      dlopen()s the real libamd_comgr.so.3 at runtime; the real lib
 #      lives only in $THEROCK_DIST/lib and is not in ldd's view of
 #      transitive deps, so it has to be on LD_LIBRARY_PATH explicitly.
+#
+# LIBRARY_PATH is GCC/clang's build-time linker search-path env;
+# clang++ -shared (driving the per-model DLL link inside hip-compiler)
+# prepends every entry as `-L<dir>`, so the in-tree
+# `libhip_custom_kernels.a` resolves via the level-3 name-only
+# `-lhip_custom_kernels` fallback.
 export THEROCK_DIST="$WORKSPACE/therock-dist"
 export LD_LIBRARY_PATH="$ROOT/lib:$THEROCK_DIST/lib"
+export LIBRARY_PATH="$ROOT/lib:$THEROCK_DIST/lib"
 
 # Sanity check
 ldd "$ROOT/lib/libonnxruntime_morphizen_ep.so" | grep "not found"   # expect empty

--- a/docs/quick_start_linux.md
+++ b/docs/quick_start_linux.md
@@ -9,9 +9,9 @@ point `$ROOT` at it, then follow the shared **Testing & Benchmarking**
 section — every tool runs the same way regardless of which entry path
 you chose.
 
-- **Path A — Build from source** (developers). `./docker/run.sh build`
-  produces a self-contained `<workspace>/install/`.
-- **Path C — Use the prebuilt CI artifact** (testers). `gh run download
+- **Build from source** (developers). `./docker/run.sh build` produces
+  a self-contained `<workspace>/install/`.
+- **Use the prebuilt CI artifact** (testers). `gh run download
   linux-gpu-test-package` lands the binaries under
   `<workspace>/prebuilt/<run-id>/`; no rebuild needed.
 
@@ -23,7 +23,7 @@ See [quick_start.md](quick_start.md) for the Windows flow.
 |------|---------|
 | **Docker** 26+ | Build + run environment |
 | **AMD gfx1151 GPU** + `/dev/kfd` + `/dev/dri/renderD*` | HIP runtime |
-| **`gh` CLI** (`gh auth login`) | Download CI artifacts (Path C only) |
+| **`gh` CLI** (`gh auth login`) | Download CI artifacts (artifact path only) |
 
 The current user must be in the host **`docker`** group. The user does
 **not** need to be in `render` / `video` — GPU passthrough is handled by
@@ -36,7 +36,7 @@ project root). Sibling directories (`onnxruntime/`, `onnxruntime-genai/`,
 `prebuilt-local/`, `therock-dist/`, `build/`, `install/`, `prebuilt/`)
 are auto-mounted into the container by `docker/run.sh`.
 
-## Path A — Build from source (developers)
+## Build from source (developers)
 
 ```bash
 git clone https://github.com/ROCm/onnx-hipdnn-ep.git
@@ -75,19 +75,20 @@ The result tree under `<workspace>/install/` is self-contained:
 Skip to the [Open a container shell](#open-a-container-shell-and-set-root)
 section once `install/bin/` is populated.
 
-## Path C — Use the prebuilt CI artifact (testers, no compile)
+## Use the prebuilt CI artifact (testers, no compile)
 
 The CI workflow
 [`.github/workflows/linux-build.yml`](../.github/workflows/linux-build.yml)
 builds and bundles every `.so` / binary the host needs (libamdhip64,
 libLLVM 22, libonnxruntime, libonnxruntime_morphizen_ep, hip-onnx-runner,
-onnxruntime_perf_test, model_benchmark, libonnxruntime-genai). Path C
-reuses Path A's Docker image — no `./docker/run.sh build` needed:
+onnxruntime_perf_test, model_benchmark, libonnxruntime-genai). The
+artifact path reuses the same Docker image as the build-from-source
+flow — no `./docker/run.sh build` needed:
 
 ```bash
 git clone https://github.com/ROCm/onnx-hipdnn-ep.git
 cd onnx-hipdnn-ep
-./docker/run.sh image    # skip if Path A's image is already built
+./docker/run.sh image    # skip if the image is already built
 
 # Pick the latest green run from
 # https://github.com/ROCm/onnx-hipdnn-ep/actions/workflows/linux-build.yml
@@ -99,9 +100,8 @@ mkdir -p ../prebuilt/$RUN_ID
     chmod +x bin/* )
 ```
 
-After extraction, `<workspace>/prebuilt/$RUN_ID/` matches Path A's
-`install/` layout (`bin/`, `lib/`, `etc/`, plus an extra `wheels/` for
-`pip install onnxruntime-*.whl`).
+After extraction, `<workspace>/prebuilt/$RUN_ID/` matches the
+build-from-source `install/` layout (`bin/`, `lib/`, `etc/`).
 
 ## Open a container shell and set `$ROOT`
 
@@ -112,12 +112,23 @@ container with GPU passthrough and UID alignment:
 ./docker/run.sh shell
 
 # Inside the container — pick ONE depending on which entry path you used:
-export ROOT="$WORKSPACE/install"           # Path A
-# export ROOT="$WORKSPACE/prebuilt/$RUN_ID"  # Path C
+export ROOT="$WORKSPACE/install"            # built from source
+# export ROOT="$WORKSPACE/prebuilt/$RUN_ID"  # downloaded CI artifact
 
-# Both paths produce a self-contained $ROOT/lib (Path A via the build's
-# stage step; Path C via the CI artifact's bundled lib/).
-export LD_LIBRARY_PATH="$ROOT/lib"
+# THEROCK_DIST points the in-process tooling at the TheRock SDK that
+# `docker/build.sh` A.4 already downloaded into the workspace. It is
+# required at runtime even though the artifact bundles transitive .so
+# files into $ROOT/lib, because:
+#   1. CompilerDriver::discoverLibraries() reads $THEROCK_DIST to
+#      construct `-L<therock>/lib` paths it passes to ld.lld when
+#      compiling per-model DLLs (otherwise the link errors with
+#      "undefined symbol: hipGetDeviceCount" etc.).
+#   2. libamd_comgr_loader.so.1 (shipped in $ROOT/lib) is a stub that
+#      dlopen()s the real libamd_comgr.so.3 at runtime; the real lib
+#      lives only in $THEROCK_DIST/lib and is not in ldd's view of
+#      transitive deps, so it has to be on LD_LIBRARY_PATH explicitly.
+export THEROCK_DIST="$WORKSPACE/therock-dist"
+export LD_LIBRARY_PATH="$ROOT/lib:$THEROCK_DIST/lib"
 
 # Sanity check
 ldd "$ROOT/lib/libonnxruntime_morphizen_ep.so" | grep "not found"   # expect empty
@@ -179,8 +190,8 @@ $ROOT/bin/hip-onnx-runner -L ep_o_dump,cpu_o_dump
 
 ### Latency Benchmarking with onnxruntime_perf_test
 
-`onnxruntime_perf_test` benchmarks inference latency. Path A and Path C
-both ship it next to `hip-onnx-runner`. The examples below compare
+`onnxruntime_perf_test` benchmarks inference latency. Both entry paths
+ship it next to `hip-onnx-runner`. The examples below compare
 MorphiZen EP against the CPU EP baseline (DML is Windows-only).
 
 ```bash
@@ -211,8 +222,8 @@ $ROOT/bin/onnxruntime_perf_test \
 ### OGA End-to-End Benchmarking with model_benchmark
 
 `model_benchmark` benchmarks the full generative pipeline (prefill +
-decode token generation). Path A requires `BUILD_OGA=1`; Path C bundles
-it automatically.
+decode token generation). The build-from-source path requires
+`BUILD_OGA=1` to produce it; the CI artifact bundles it automatically.
 
 ```bash
 # Auto-generated prompt (128 tokens, generate 32)

--- a/docs/quick_start_linux.md
+++ b/docs/quick_start_linux.md
@@ -1,0 +1,280 @@
+<!--
+Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+Licensed under the MIT License.
+-->
+# Quick Start Guide (Linux)
+
+Linux is **Docker-only**. Pick one entry path to populate `bin/` and `lib/`,
+point `$ROOT` at it, then follow the shared **Testing & Benchmarking**
+section — every tool runs the same way regardless of which entry path
+you chose.
+
+- **Path A — Build from source** (developers). `./docker/run.sh build`
+  produces a self-contained `<workspace>/install/`.
+- **Path C — Use the prebuilt CI artifact** (testers). `gh run download
+  linux-gpu-test-package` lands the binaries under
+  `<workspace>/prebuilt/<run-id>/`; no rebuild needed.
+
+See [quick_start.md](quick_start.md) for the Windows flow.
+
+## Host prerequisites
+
+| Tool | Purpose |
+|------|---------|
+| **Docker** 26+ | Build + run environment |
+| **AMD gfx1151 GPU** + `/dev/kfd` + `/dev/dri/renderD*` | HIP runtime |
+| **`gh` CLI** (`gh auth login`) | Download CI artifacts (Path C only) |
+
+The current user must be in the host **`docker`** group. The user does
+**not** need to be in `render` / `video` — GPU passthrough is handled by
+docker's `--device=/dev/kfd`, and the container entrypoint
+([`docker/entrypoint.sh`](../docker/entrypoint.sh)) detects the host GID
+on `/dev/kfd` and adds the in-container user to that group automatically.
+
+All commands below assume you are in `<workspace>/onnx-hipdnn-ep/` (the
+project root). Sibling directories (`onnxruntime/`, `onnxruntime-genai/`,
+`prebuilt-local/`, `therock-dist/`, `build/`, `install/`, `prebuilt/`)
+are auto-mounted into the container by `docker/run.sh`.
+
+## Path A — Build from source (developers)
+
+```bash
+git clone https://github.com/ROCm/onnx-hipdnn-ep.git
+cd onnx-hipdnn-ep
+git submodule update --init --recursive
+
+# Step 1 — Build the image (first time only;
+# hipdnn-ep-build:llvm22-noble, ~3 GB)
+./docker/run.sh image
+
+# Step 2 — Build everything (TheRock + ORT + protobuf + flatbuffers + this
+# project) inside the container. Idempotent: skipped steps print [skip].
+./docker/run.sh build
+#   BUILD_OGA=1            also build model_benchmark + libonnxruntime-genai.so
+#   HIP_ARCHITECTURES=...  override target GPU (default gfx1151)
+#   SKIP_LIT=1             skip in-build LIT tests
+#   FORCE_RECONFIGURE=1    re-run cmake after editing options
+```
+
+The result tree under `<workspace>/install/` is self-contained:
+
+- `bin/hip-onnx-runner`, `bin/hip-compiler`, `bin/hip-mlir-opt`,
+  `bin/hip-test-dll` (and `bin/model_benchmark` with `BUILD_OGA=1`)
+- `lib/libhip-compiler.so`, `lib/libonnxruntime_morphizen_ep.so`,
+  `lib/libonnxruntime.so*`, `lib/libamdhip64.so*` + TheRock transitive
+  (so `LD_LIBRARY_PATH=<workspace>/install/lib` is enough — see
+  [docker/build.sh](../docker/build.sh) A.7b stage step)
+
+> **ORT / OGA source layout**: if you already have a checkout of
+> [`onnxruntime`](https://github.com/Microsoft/onnxruntime) or
+> [`onnxruntime-genai`](https://github.com/AMDmoore/onnxruntime-genai) under
+> `<workspace>/onnxruntime/` or `<workspace>/onnxruntime-genai/`, the
+> build skips the clone step and uses your checkout as-is (no `fetch`,
+> no `checkout`, no `submodule update`).
+
+Skip to the [Open a container shell](#open-a-container-shell-and-set-root)
+section once `install/bin/` is populated.
+
+## Path C — Use the prebuilt CI artifact (testers, no compile)
+
+The CI workflow
+[`.github/workflows/linux-build.yml`](../.github/workflows/linux-build.yml)
+builds and bundles every `.so` / binary the host needs (libamdhip64,
+libLLVM 22, libonnxruntime, libonnxruntime_morphizen_ep, hip-onnx-runner,
+onnxruntime_perf_test, model_benchmark, libonnxruntime-genai). Path C
+reuses Path A's Docker image — no `./docker/run.sh build` needed:
+
+```bash
+git clone https://github.com/ROCm/onnx-hipdnn-ep.git
+cd onnx-hipdnn-ep
+./docker/run.sh image    # skip if Path A's image is already built
+
+# Pick the latest green run from
+# https://github.com/ROCm/onnx-hipdnn-ep/actions/workflows/linux-build.yml
+RUN_ID=<paste-id>
+mkdir -p ../prebuilt/$RUN_ID
+( cd ../prebuilt/$RUN_ID && \
+    gh run download $RUN_ID --repo ROCm/onnx-hipdnn-ep \
+        --name linux-gpu-test-package --dir . && \
+    chmod +x bin/* )
+```
+
+After extraction, `<workspace>/prebuilt/$RUN_ID/` matches Path A's
+`install/` layout (`bin/`, `lib/`, `etc/`, plus an extra `wheels/` for
+`pip install onnxruntime-*.whl`).
+
+## Open a container shell and set `$ROOT`
+
+Both paths converge here. `./docker/run.sh shell` opens a long-lived
+container with GPU passthrough and UID alignment:
+
+```bash
+./docker/run.sh shell
+
+# Inside the container — pick ONE depending on which entry path you used:
+export ROOT="$WORKSPACE/install"           # Path A
+# export ROOT="$WORKSPACE/prebuilt/$RUN_ID"  # Path C
+
+# Both paths produce a self-contained $ROOT/lib (Path A via the build's
+# stage step; Path C via the CI artifact's bundled lib/).
+export LD_LIBRARY_PATH="$ROOT/lib"
+
+# Sanity check
+ldd "$ROOT/lib/libonnxruntime_morphizen_ep.so" | grep "not found"   # expect empty
+"$ROOT/bin/hip-onnx-runner" --help | head -5
+```
+
+`$WORKSPACE` is set automatically by
+[`docker/entrypoint.sh`](../docker/entrypoint.sh) to the bind-mounted
+host workspace path. Every command below uses `$ROOT/bin/<tool>`
+exclusively, so the snippets are identical regardless of entry path.
+
+## Model Preparation
+
+Same as the Windows guide — see
+[quick_start.md "Model Preparation"](quick_start.md#model-preparation).
+Run from the project root inside the container.
+
+## Testing & Benchmarking
+
+### Model Inference with hip-onnx-runner
+
+`hip-onnx-runner` runs a single ONNX model through MorphiZen EP and reports
+timing. It is built automatically when `BUILD_HIP_TOOLS=ON` (default) and
+also ships in the CI artifact.
+
+> `hip-onnx-runner` runs with random inputs by default. LLM models need
+> in-range `input_ids` (< vocab size); use
+> `tools/hip-onnx-runner/gen_hip_onnx_runner_inputs.py` to produce a
+> `gen_inputs/` directory and pass it via `-i`:
+>
+> ```bash
+> python tools/hip-onnx-runner/gen_hip_onnx_runner_inputs.py \
+>   -o gen_inputs /path/to/MODEL.onnx
+> ```
+
+```bash
+# Run with MorphiZen EP (default), using a fixed-shape model from Model Preparation
+$ROOT/bin/hip-onnx-runner -m /path/to/output/prefill_p512m16384.onnx -i gen_inputs
+
+# Run with CPU only (no EP)
+$ROOT/bin/hip-onnx-runner -m /path/to/output/prefill_p512m16384.onnx -n -i gen_inputs
+
+# Dump outputs for comparison
+$ROOT/bin/hip-onnx-runner -m /path/to/output/prefill_p512m16384.onnx -i gen_inputs -d 2
+
+# L2-norm compare EP vs CPU outputs
+$ROOT/bin/hip-onnx-runner -L ep_o_dump,cpu_o_dump
+```
+
+**Key flags:**
+
+| Flag | Description |
+|------|-------------|
+| `-m` | Path to `.onnx` model |
+| `-n` | CPU only, skip EP registration |
+| `-d 0\|1\|2\|3` | Dump level: 0=off, 1=inputs, 2=outputs, 3=both |
+| `-i <dir>` | Load inputs from directory instead of random |
+| `-L dir1,dir2` | L2-norm comparison of two output directories |
+
+### Latency Benchmarking with onnxruntime_perf_test
+
+`onnxruntime_perf_test` benchmarks inference latency. Path A and Path C
+both ship it next to `hip-onnx-runner`. The examples below compare
+MorphiZen EP against the CPU EP baseline (DML is Windows-only).
+
+```bash
+# CPU baseline (no EP; useful to size the EP speedup)
+$ROOT/bin/onnxruntime_perf_test -e cpu -t 30 -c 1 -s /path/to/MODEL.onnx
+
+# MorphiZen EP
+$ROOT/bin/onnxruntime_perf_test \
+  --plugin_ep_libs "MorphiZenEP|$ROOT/lib/libonnxruntime_morphizen_ep.so" \
+  --plugin_eps     "MorphiZenEP" \
+  -C "session.disable_cpu_ep_fallback|1" \
+  -t 60 -c 1 -s -I \
+  /path/to/MODEL.onnx
+```
+
+**Key flags:**
+
+| Flag | Description |
+|------|-------------|
+| `-t 60` | Run for 60 seconds |
+| `-c 1` | 1 concurrent thread |
+| `-s` | Show per-iteration latency statistics |
+| `-I` | Use sequential inputs (do not randomize) |
+
+> The first iteration triggers MorphiZen's HIP kernel JIT compile
+> (multi-minute); bump `-t` so steady-state samples dominate the average.
+
+### OGA End-to-End Benchmarking with model_benchmark
+
+`model_benchmark` benchmarks the full generative pipeline (prefill +
+decode token generation). Path A requires `BUILD_OGA=1`; Path C bundles
+it automatically.
+
+```bash
+# Auto-generated prompt (128 tokens, generate 32)
+$ROOT/bin/model_benchmark \
+  -i /path/to/oga-model-dir \
+  --ep_library MorphiZenEP $ROOT/lib/libonnxruntime_morphizen_ep.so \
+  -l 128 -g 32 -ml -1 \
+  -r 5 -w 1
+
+# Prompt from file
+$ROOT/bin/model_benchmark \
+  -i /path/to/oga-model-dir \
+  --ep_library MorphiZenEP $ROOT/lib/libonnxruntime_morphizen_ep.so \
+  --prompt_file /path/to/prompt.txt -g 128 -ml -1 \
+  -r 5 -w 1
+```
+
+> **Note on `-ml -1`**: required when the model uses a fixed-shape pipeline
+> (`prefill_*.onnx` + `decode_*.onnx` with a baked-in `max_length` such as 256).
+> Without it, model_benchmark overrides `genai_config.json`'s `search.max_length`
+> with `prompt_length + generation_length`, causing
+> `Got invalid dimensions for input: attention_mask  Got: <l+g>  Expected: <max_length>`
+> at decode time. Pass `-ml -1` to keep the config's value (mirrors what the
+> Windows CI does in [`.github/workflows/windows-build.yml`](../.github/workflows/windows-build.yml)).
+
+**Key flags:**
+
+| Flag | Description |
+|------|-------------|
+| `-i <path>` | Path to OGA model directory (with `genai_config.json`) |
+| `--ep_library <name> <path>` | Register a custom EP library |
+| `-l <n>` | Length of auto-generated prompt (exclusive with `--prompt_file`) |
+| `--prompt_file <path>` | Load prompt text from a file (exclusive with `-l`) |
+| `-g <n>` | Max number of tokens to generate |
+| `-r <n>` | Number of benchmark repetitions |
+| `-w <n>` | Number of warmup runs |
+
+## Advanced: bare-metal source build (no Docker)
+
+If you need to build outside Docker (running CI locally on a custom
+kernel, etc.), the canonical sources of truth are:
+
+- [`.github/workflows/linux-build.yml`](../.github/workflows/linux-build.yml)
+  — the GitHub Actions pipeline (apt deps + cmake recipe per step)
+- [`docker/build.sh`](../docker/build.sh) — the same A.4–A.9 step
+  sequence the Docker path runs
+- [`docker/Dockerfile`](../docker/Dockerfile) — exact apt package list
+  (`llvm-22-dev`, `libpolly-22-dev`, `libmlir-22-dev`, `lld-22`,
+  `python3-dev`, ...)
+
+## Troubleshooting
+
+**`Got invalid dimensions for input: attention_mask  Got: X  Expected: Y`**
+
+Either:
+
+1. `model_benchmark -l <prompt_length>` doesn't match the OGA model
+   directory's `genai_config.json` → `model.decoder.fixed_prompt_length`.
+   Pass the same value to `-l`, or pick a different `genai_config_*.json`
+   that matches your intended length.
+2. `-ml` (max_length) flag is missing — see the note in
+   [6.3 OGA End-to-End Benchmarking](#oga-end-to-end-benchmarking-with-model_benchmark).
+   Without `-ml -1`, model_benchmark overrides the config's `search.max_length`
+   with `prompt_length + generation_length`, breaking the static mask shape
+   that decode_*.onnx expects.

--- a/include/hip/Target/LLVM/DLLLinker.h
+++ b/include/hip/Target/LLVM/DLLLinker.h
@@ -5,6 +5,7 @@
 #ifndef DLL_LINKER_H
 #define DLL_LINKER_H
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/lib/Compiler/CompilerDriver.cpp
+++ b/lib/Compiler/CompilerDriver.cpp
@@ -342,13 +342,18 @@ void CompilerDriver::discoverLibraries(
   libraries.push_back("amdhip64");
   libraries.push_back("MIOpen");
 
-  // hipblaslt ships as either .lib (Windows) or .dll.a (cross-compiled)
+  // hipblaslt ships as .lib (Windows), .dll.a (cross-compiled), or
+  // .so (native Linux). Bare name "hipblaslt" lets the linker resolve via
+  // -L<lib_dir> to libhipblaslt.so on Linux.
   std::string hipblaslt_lib = lib_dir + "/hipblaslt.lib";
   std::string hipblaslt_dll_a = lib_dir + "/libhipblaslt.dll.a";
+  std::string hipblaslt_so = lib_dir + "/libhipblaslt.so";
   if (llvm::sys::fs::exists(hipblaslt_lib))
     libraries.push_back("hipblaslt");
   else if (llvm::sys::fs::exists(hipblaslt_dll_a))
     libraries.push_back(hipblaslt_dll_a);
+  else if (llvm::sys::fs::exists(hipblaslt_so))
+    libraries.push_back("hipblaslt");
   else
     COMPILER_DEBUG_LOG("  WARNING: hipblaslt import library not found\n");
 

--- a/lib/Conversion/HipToLLVM/ActivationLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ActivationLowering.cpp
@@ -295,8 +295,8 @@ struct MiopenSoftmaxOpLowering
 
 } // namespace
 
-void mlir::hip::populateActivationLoweringPatterns(
-    const LLVMTypeConverter &converter, RewritePatternSet &patterns) {
+void populateActivationLoweringPatterns(const LLVMTypeConverter &converter,
+                                        RewritePatternSet &patterns) {
   patterns.add<SigmoidOpLowering, SoftplusOpLowering, GeluOpLowering,
                SiluOpLowering, MiopenSoftmaxOpLowering>(converter);
 }

--- a/lib/Conversion/HipToLLVM/CastLowering.cpp
+++ b/lib/Conversion/HipToLLVM/CastLowering.cpp
@@ -88,8 +88,8 @@ struct CastOpLowering : public ConvertOpToLLVMPattern<CastOp> {
 
 } // namespace
 
-void mlir::hip::populateCastLoweringPatterns(const LLVMTypeConverter &converter,
-                                             RewritePatternSet &patterns) {
+void populateCastLoweringPatterns(const LLVMTypeConverter &converter,
+                                  RewritePatternSet &patterns) {
   patterns.add<CastOpLowering>(converter);
 }
 

--- a/lib/Conversion/HipToLLVM/CausalConvWithStateLowering.cpp
+++ b/lib/Conversion/HipToLLVM/CausalConvWithStateLowering.cpp
@@ -150,7 +150,7 @@ struct CausalConvWithStateOpLowering
 
 } // namespace
 
-void mlir::hip::populateCausalConvWithStateLoweringPatterns(
+void populateCausalConvWithStateLoweringPatterns(
     const LLVMTypeConverter &converter, RewritePatternSet &patterns) {
   patterns.add<CausalConvWithStateOpLowering>(converter);
 }

--- a/lib/Conversion/HipToLLVM/ConvLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ConvLowering.cpp
@@ -200,8 +200,8 @@ struct ConvOpLowering : public ConvertOpToLLVMPattern<ConvOp> {
 
 } // namespace
 
-void mlir::hip::populateConvLoweringPatterns(const LLVMTypeConverter &converter,
-                                             RewritePatternSet &patterns) {
+void populateConvLoweringPatterns(const LLVMTypeConverter &converter,
+                                  RewritePatternSet &patterns) {
   patterns.add<ConvOpLowering>(converter);
 }
 

--- a/lib/Conversion/HipToLLVM/ElementwiseLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ElementwiseLowering.cpp
@@ -224,8 +224,8 @@ struct SubOpLowering : public ConvertOpToLLVMPattern<SubOp> {
 
 } // namespace
 
-void mlir::hip::populateElementwiseLoweringPatterns(
-    const LLVMTypeConverter &converter, RewritePatternSet &patterns) {
+void populateElementwiseLoweringPatterns(const LLVMTypeConverter &converter,
+                                         RewritePatternSet &patterns) {
   patterns.add<ElementwiseOpLowering<MulOp, kTensorOpMul>,
                ElementwiseOpLowering<AddOp, kTensorOpAdd>, SubOpLowering>(
       converter);

--- a/lib/Conversion/HipToLLVM/GatherLowering.cpp
+++ b/lib/Conversion/HipToLLVM/GatherLowering.cpp
@@ -86,8 +86,8 @@ struct GatherOpLowering : public ConvertOpToLLVMPattern<GatherOp> {
 
 } // namespace
 
-void mlir::hip::populateGatherLoweringPatterns(
-    const LLVMTypeConverter &converter, RewritePatternSet &patterns) {
+void populateGatherLoweringPatterns(const LLVMTypeConverter &converter,
+                                    RewritePatternSet &patterns) {
   patterns.add<GatherOpLowering>(converter);
 }
 

--- a/lib/Conversion/HipToLLVM/GemmLowering.cpp
+++ b/lib/Conversion/HipToLLVM/GemmLowering.cpp
@@ -85,7 +85,7 @@ struct GemmOpLowering : public ConvertOpToLLVMPattern<GemmOp> {
     }
 
     // Extract C's shape normalized to 2D [cDim0, cDim1] for broadcast support.
-    // Scalar/absent → [0,0], 1D [X] → [1,X], 2D [X,Y] → [X,Y].
+    // Scalar/absent â†’ [0,0], 1D [X] â†’ [1,X], 2D [X,Y] â†’ [X,Y].
     Value cDim0, cDim1;
     if (adaptor.getInputC()) {
       auto CType = cast<MemRefType>(op.getInputC().getType());
@@ -140,8 +140,8 @@ struct GemmOpLowering : public ConvertOpToLLVMPattern<GemmOp> {
 
 } // namespace
 
-void mlir::hip::populateGemmLoweringPatterns(const LLVMTypeConverter &converter,
-                                             RewritePatternSet &patterns) {
+void populateGemmLoweringPatterns(const LLVMTypeConverter &converter,
+                                  RewritePatternSet &patterns) {
   patterns.add<GemmOpLowering>(converter);
 }
 

--- a/lib/Conversion/HipToLLVM/GemmLowering.cpp
+++ b/lib/Conversion/HipToLLVM/GemmLowering.cpp
@@ -85,7 +85,7 @@ struct GemmOpLowering : public ConvertOpToLLVMPattern<GemmOp> {
     }
 
     // Extract C's shape normalized to 2D [cDim0, cDim1] for broadcast support.
-    // Scalar/absent â†’ [0,0], 1D [X] â†’ [1,X], 2D [X,Y] â†’ [X,Y].
+    // Scalar/absent → [0,0], 1D [X] → [1,X], 2D [X,Y] → [X,Y].
     Value cDim0, cDim1;
     if (adaptor.getInputC()) {
       auto CType = cast<MemRefType>(op.getInputC().getType());

--- a/lib/Conversion/HipToLLVM/GqaLowering.cpp
+++ b/lib/Conversion/HipToLLVM/GqaLowering.cpp
@@ -222,8 +222,8 @@ struct GqaOpLowering : public ConvertOpToLLVMPattern<GqaOp> {
 
 } // namespace
 
-void mlir::hip::populateGqaLoweringPatterns(const LLVMTypeConverter &converter,
-                                            RewritePatternSet &patterns) {
+void populateGqaLoweringPatterns(const LLVMTypeConverter &converter,
+                                 RewritePatternSet &patterns) {
   patterns.add<GqaOpLowering>(converter);
 }
 

--- a/lib/Conversion/HipToLLVM/GraphLowering.cpp
+++ b/lib/Conversion/HipToLLVM/GraphLowering.cpp
@@ -143,8 +143,8 @@ struct HipDNNGraphOpLowering : public ConvertOpToLLVMPattern<HipDNNGraphOp> {
 
 } // namespace
 
-void mlir::hip::populateGraphLoweringPatterns(
-    const LLVMTypeConverter &converter, RewritePatternSet &patterns) {
+void populateGraphLoweringPatterns(const LLVMTypeConverter &converter,
+                                   RewritePatternSet &patterns) {
   patterns.add<MiopenGraphOpLowering, HipblasltGraphOpLowering,
                HipDNNGraphOpLowering>(converter);
 }

--- a/lib/Conversion/HipToLLVM/LinearAttentionLowering.cpp
+++ b/lib/Conversion/HipToLLVM/LinearAttentionLowering.cpp
@@ -217,8 +217,8 @@ struct LinearAttentionOpLowering
 
 } // namespace
 
-void mlir::hip::populateLinearAttentionLoweringPatterns(
-    const LLVMTypeConverter &converter, RewritePatternSet &patterns) {
+void populateLinearAttentionLoweringPatterns(const LLVMTypeConverter &converter,
+                                             RewritePatternSet &patterns) {
   patterns.add<LinearAttentionOpLowering>(converter);
 }
 

--- a/lib/Conversion/HipToLLVM/MatMulNBitsLowering.cpp
+++ b/lib/Conversion/HipToLLVM/MatMulNBitsLowering.cpp
@@ -46,7 +46,7 @@ struct MatMulNBitsOpLowering : public ConvertOpToLLVMPattern<MatMulNBitsOp> {
     int64_t ARank = AType.getRank();
     int64_t elemSize = AType.getElementType().getIntOrFloatBitWidth() / 8;
 
-    // A shape: [..., M, K] — M is the second-to-last dim
+    // A shape: [..., M, K] â€” M is the second-to-last dim
     Value m = (ARank >= 2) ? getMemRefDimSize(AType, ARank - 2, adaptor.getA(),
                                               rewriter, loc)
                            : createI64Const(1);
@@ -115,8 +115,8 @@ struct MatMulNBitsOpLowering : public ConvertOpToLLVMPattern<MatMulNBitsOp> {
 
 } // namespace
 
-void mlir::hip::populateMatMulNBitsLoweringPatterns(
-    const LLVMTypeConverter &converter, RewritePatternSet &patterns) {
+void populateMatMulNBitsLoweringPatterns(const LLVMTypeConverter &converter,
+                                         RewritePatternSet &patterns) {
   patterns.add<MatMulNBitsOpLowering>(converter);
 }
 

--- a/lib/Conversion/HipToLLVM/MatMulNBitsLowering.cpp
+++ b/lib/Conversion/HipToLLVM/MatMulNBitsLowering.cpp
@@ -46,7 +46,7 @@ struct MatMulNBitsOpLowering : public ConvertOpToLLVMPattern<MatMulNBitsOp> {
     int64_t ARank = AType.getRank();
     int64_t elemSize = AType.getElementType().getIntOrFloatBitWidth() / 8;
 
-    // A shape: [..., M, K] â€” M is the second-to-last dim
+    // A shape: [..., M, K] — M is the second-to-last dim
     Value m = (ARank >= 2) ? getMemRefDimSize(AType, ARank - 2, adaptor.getA(),
                                               rewriter, loc)
                            : createI64Const(1);

--- a/lib/Conversion/HipToLLVM/MatmulLowering.cpp
+++ b/lib/Conversion/HipToLLVM/MatmulLowering.cpp
@@ -106,8 +106,8 @@ struct MatmulOpLowering : public ConvertOpToLLVMPattern<MatmulOp> {
 
 } // namespace
 
-void mlir::hip::populateMatmulLoweringPatterns(
-    const LLVMTypeConverter &converter, RewritePatternSet &patterns) {
+void populateMatmulLoweringPatterns(const LLVMTypeConverter &converter,
+                                    RewritePatternSet &patterns) {
   patterns.add<MatmulOpLowering>(converter);
 }
 

--- a/lib/Conversion/HipToLLVM/MemoryLowering.cpp
+++ b/lib/Conversion/HipToLLVM/MemoryLowering.cpp
@@ -351,7 +351,7 @@ static bool strideVectorsEqual(ArrayRef<int64_t> a, ArrayRef<int64_t> b) {
 
 /// Lowers memref.copy on GPU memrefs to wrap_hipMemcpyAsync /
 /// wrap_hipMemcpy2DAsync when strides are statically known. Otherwise leaves
-/// conversion to the default MemRef→LLVM copy lowering (benefit 1).
+/// conversion to the default MemRefâ†’LLVM copy lowering (benefit 1).
 struct MemRefCopyOpLowering : public ConvertOpToLLVMPattern<memref::CopyOp> {
   MemRefCopyOpLowering(const LLVMTypeConverter &converter)
       : ConvertOpToLLVMPattern(converter, PatternBenefit(10)) {}
@@ -530,8 +530,8 @@ struct MemRefCopyOpLowering : public ConvertOpToLLVMPattern<memref::CopyOp> {
 
 } // namespace
 
-void mlir::hip::populateMemoryLoweringPatterns(
-    const LLVMTypeConverter &converter, RewritePatternSet &patterns) {
+void populateMemoryLoweringPatterns(const LLVMTypeConverter &converter,
+                                    RewritePatternSet &patterns) {
   patterns.add<AllocOpLowering, FreeOpLowering, GetPoolOpLowering,
                GetConstantOpLowering, MemRefAllocOpLowering,
                MemRefDeallocOpLowering>(converter);

--- a/lib/Conversion/HipToLLVM/MemoryLowering.cpp
+++ b/lib/Conversion/HipToLLVM/MemoryLowering.cpp
@@ -351,7 +351,7 @@ static bool strideVectorsEqual(ArrayRef<int64_t> a, ArrayRef<int64_t> b) {
 
 /// Lowers memref.copy on GPU memrefs to wrap_hipMemcpyAsync /
 /// wrap_hipMemcpy2DAsync when strides are statically known. Otherwise leaves
-/// conversion to the default MemRefâ†’LLVM copy lowering (benefit 1).
+/// conversion to the default MemRef→LLVM copy lowering (benefit 1).
 struct MemRefCopyOpLowering : public ConvertOpToLLVMPattern<memref::CopyOp> {
   MemRefCopyOpLowering(const LLVMTypeConverter &converter)
       : ConvertOpToLLVMPattern(converter, PatternBenefit(10)) {}

--- a/lib/Conversion/HipToLLVM/NormLowering.cpp
+++ b/lib/Conversion/HipToLLVM/NormLowering.cpp
@@ -181,8 +181,8 @@ struct SkipRmsNormOpLowering : public ConvertOpToLLVMPattern<SkipRmsNormOp> {
 
 } // namespace
 
-void mlir::hip::populateNormLoweringPatterns(const LLVMTypeConverter &converter,
-                                             RewritePatternSet &patterns) {
+void populateNormLoweringPatterns(const LLVMTypeConverter &converter,
+                                  RewritePatternSet &patterns) {
   patterns.add<RmsNormOpLowering, SkipRmsNormOpLowering>(converter);
 }
 

--- a/lib/Conversion/HipToLLVM/PowerLowering.cpp
+++ b/lib/Conversion/HipToLLVM/PowerLowering.cpp
@@ -14,11 +14,11 @@ namespace {
 //
 // Ops lower to wrap_power(state, input, output, num_elements, data_type,
 // alpha, beta, gamma). Reciprocal (gamma=-1) and Sqrt (gamma=0.5) use HIP
-// elementwise kernels at runtime; other powers use MIOpen POWER: y=(α+βx)^γ.
-//   - Reciprocal: alpha=0, beta=1, gamma=-1.0 → HIP elementwise 1/x
-//   - Sqrt:       alpha=0, beta=1, gamma=0.5   → HIP elementwise sqrt (ONNX)
-//   - Square:     alpha=0, beta=1, gamma=2.0   → (0 + 1*x)^2 = x^2
-//   - Cube:       alpha=0, beta=1, gamma=3.0   → (0 + 1*x)^3 = x^3
+// elementwise kernels at runtime; other powers use MIOpen POWER: y=(Î±+Î²x)^Î³.
+//   - Reciprocal: alpha=0, beta=1, gamma=-1.0 â†’ HIP elementwise 1/x
+//   - Sqrt:       alpha=0, beta=1, gamma=0.5   â†’ HIP elementwise sqrt (ONNX)
+//   - Square:     alpha=0, beta=1, gamma=2.0   â†’ (0 + 1*x)^2 = x^2
+//   - Cube:       alpha=0, beta=1, gamma=3.0   â†’ (0 + 1*x)^3 = x^3
 template <typename OpTy>
 struct PowerOpLowering : public ConvertOpToLLVMPattern<OpTy> {
   using ConvertOpToLLVMPattern<OpTy>::ConvertOpToLLVMPattern;
@@ -108,9 +108,9 @@ struct PowerOpLowering : public ConvertOpToLLVMPattern<OpTy> {
 
 } // namespace
 
-void mlir::hip::populatePowerLoweringPatterns(
-    const LLVMTypeConverter &converter, RewritePatternSet &patterns) {
-  // Reciprocal: (0 + 1*x)^(-1) = 1/x; Sqrt: (0 + 1*x)^(0.5) = √x
+void populatePowerLoweringPatterns(const LLVMTypeConverter &converter,
+                                   RewritePatternSet &patterns) {
+  // Reciprocal: (0 + 1*x)^(-1) = 1/x; Sqrt: (0 + 1*x)^(0.5) = âˆšx
   // Same LLVM callee @wrap_power; reciprocal/sqrt use HIP kernels in power.cpp.
   patterns.insert<PowerOpLowering<ReciprocalOp>>(converter, 0.0, 1.0, -1.0,
                                                  "reciprocal");

--- a/lib/Conversion/HipToLLVM/PowerLowering.cpp
+++ b/lib/Conversion/HipToLLVM/PowerLowering.cpp
@@ -14,11 +14,11 @@ namespace {
 //
 // Ops lower to wrap_power(state, input, output, num_elements, data_type,
 // alpha, beta, gamma). Reciprocal (gamma=-1) and Sqrt (gamma=0.5) use HIP
-// elementwise kernels at runtime; other powers use MIOpen POWER: y=(Î±+Î²x)^Î³.
-//   - Reciprocal: alpha=0, beta=1, gamma=-1.0 â†’ HIP elementwise 1/x
-//   - Sqrt:       alpha=0, beta=1, gamma=0.5   â†’ HIP elementwise sqrt (ONNX)
-//   - Square:     alpha=0, beta=1, gamma=2.0   â†’ (0 + 1*x)^2 = x^2
-//   - Cube:       alpha=0, beta=1, gamma=3.0   â†’ (0 + 1*x)^3 = x^3
+// elementwise kernels at runtime; other powers use MIOpen POWER: y=(α+βx)^γ.
+//   - Reciprocal: alpha=0, beta=1, gamma=-1.0 → HIP elementwise 1/x
+//   - Sqrt:       alpha=0, beta=1, gamma=0.5   → HIP elementwise sqrt (ONNX)
+//   - Square:     alpha=0, beta=1, gamma=2.0   → (0 + 1*x)^2 = x^2
+//   - Cube:       alpha=0, beta=1, gamma=3.0   → (0 + 1*x)^3 = x^3
 template <typename OpTy>
 struct PowerOpLowering : public ConvertOpToLLVMPattern<OpTy> {
   using ConvertOpToLLVMPattern<OpTy>::ConvertOpToLLVMPattern;
@@ -110,7 +110,7 @@ struct PowerOpLowering : public ConvertOpToLLVMPattern<OpTy> {
 
 void populatePowerLoweringPatterns(const LLVMTypeConverter &converter,
                                    RewritePatternSet &patterns) {
-  // Reciprocal: (0 + 1*x)^(-1) = 1/x; Sqrt: (0 + 1*x)^(0.5) = âˆšx
+  // Reciprocal: (0 + 1*x)^(-1) = 1/x; Sqrt: (0 + 1*x)^(0.5) = √x
   // Same LLVM callee @wrap_power; reciprocal/sqrt use HIP kernels in power.cpp.
   patterns.insert<PowerOpLowering<ReciprocalOp>>(converter, 0.0, 1.0, -1.0,
                                                  "reciprocal");

--- a/lib/Conversion/HipToLLVM/QMoELowering.cpp
+++ b/lib/Conversion/HipToLLVM/QMoELowering.cpp
@@ -74,7 +74,7 @@ struct QMoEOpLowering : public ConvertOpToLLVMPattern<QMoEOp> {
     auto fc1Type = cast<MemRefType>(op.getFc1ExpertsWeights().getType());
     int64_t elemSize = inputType.getElementType().getIntOrFloatBitWidth() / 8;
 
-    // input shape: [batch, seq, ..., hidden] — numTokens = product of all
+    // input shape: [batch, seq, ..., hidden] â€” numTokens = product of all
     // dims except the last (hidden), supporting dynamic batch/seq dimensions.
     int64_t inputRank = inputType.getRank();
     Value numTokensVal = createI64Const(1);
@@ -205,8 +205,8 @@ struct QMoEOpLowering : public ConvertOpToLLVMPattern<QMoEOp> {
 
 } // namespace
 
-void mlir::hip::populateQMoELoweringPatterns(const LLVMTypeConverter &converter,
-                                             RewritePatternSet &patterns) {
+void populateQMoELoweringPatterns(const LLVMTypeConverter &converter,
+                                  RewritePatternSet &patterns) {
   patterns.add<QMoEOpLowering>(converter);
 }
 

--- a/lib/Conversion/HipToLLVM/QMoELowering.cpp
+++ b/lib/Conversion/HipToLLVM/QMoELowering.cpp
@@ -74,7 +74,7 @@ struct QMoEOpLowering : public ConvertOpToLLVMPattern<QMoEOp> {
     auto fc1Type = cast<MemRefType>(op.getFc1ExpertsWeights().getType());
     int64_t elemSize = inputType.getElementType().getIntOrFloatBitWidth() / 8;
 
-    // input shape: [batch, seq, ..., hidden] â€” numTokens = product of all
+    // input shape: [batch, seq, ..., hidden] — numTokens = product of all
     // dims except the last (hidden), supporting dynamic batch/seq dimensions.
     int64_t inputRank = inputType.getRank();
     Value numTokensVal = createI64Const(1);

--- a/lib/Conversion/HipToLLVM/RangeLowering.cpp
+++ b/lib/Conversion/HipToLLVM/RangeLowering.cpp
@@ -12,8 +12,7 @@ namespace {
 // Maps MLIR element type to hip_dtype_t for hip_range() in range_kernel.hip.
 // ONNX Range only defines int32/int64/float/double; the kernel implements those
 // plus int16. F16/BF16 are not ONNX Range types and are not implemented in
-// hip_range â€” reject here so lowering fails instead of a runtime default
-// case.
+// hip_range — reject here so lowering fails instead of a runtime default case.
 static int64_t getHipCustomKernelDType(Type elemType) {
   if (elemType.isF32())
     return 0; // HIP_DTYPE_FLOAT32

--- a/lib/Conversion/HipToLLVM/RangeLowering.cpp
+++ b/lib/Conversion/HipToLLVM/RangeLowering.cpp
@@ -12,7 +12,8 @@ namespace {
 // Maps MLIR element type to hip_dtype_t for hip_range() in range_kernel.hip.
 // ONNX Range only defines int32/int64/float/double; the kernel implements those
 // plus int16. F16/BF16 are not ONNX Range types and are not implemented in
-// hip_range — reject here so lowering fails instead of a runtime default case.
+// hip_range â€” reject here so lowering fails instead of a runtime default
+// case.
 static int64_t getHipCustomKernelDType(Type elemType) {
   if (elemType.isF32())
     return 0; // HIP_DTYPE_FLOAT32
@@ -84,8 +85,8 @@ struct RangeOpLowering : public ConvertOpToLLVMPattern<RangeOp> {
 
 } // namespace
 
-void mlir::hip::populateRangeLoweringPatterns(
-    const LLVMTypeConverter &converter, RewritePatternSet &patterns) {
+void populateRangeLoweringPatterns(const LLVMTypeConverter &converter,
+                                   RewritePatternSet &patterns) {
   patterns.add<RangeOpLowering>(converter);
 }
 

--- a/lib/Conversion/HipToLLVM/ReduceSumLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ReduceSumLowering.cpp
@@ -130,8 +130,8 @@ struct ReduceSumOpLowering : public ConvertOpToLLVMPattern<ReduceSumOp> {
 
 } // namespace
 
-void mlir::hip::populateReduceSumLoweringPatterns(
-    const LLVMTypeConverter &converter, RewritePatternSet &patterns) {
+void populateReduceSumLoweringPatterns(const LLVMTypeConverter &converter,
+                                       RewritePatternSet &patterns) {
   patterns.add<ReduceSumOpLowering>(converter);
 }
 

--- a/lib/Conversion/HipToLLVM/RopeLowering.cpp
+++ b/lib/Conversion/HipToLLVM/RopeLowering.cpp
@@ -163,8 +163,8 @@ struct RopeOpLowering : public ConvertOpToLLVMPattern<RopeOp> {
 
 } // namespace
 
-void mlir::hip::populateRopeLoweringPatterns(const LLVMTypeConverter &converter,
-                                             RewritePatternSet &patterns) {
+void populateRopeLoweringPatterns(const LLVMTypeConverter &converter,
+                                  RewritePatternSet &patterns) {
   patterns.add<RopeOpLowering>(converter);
 }
 

--- a/lib/Conversion/HipToLLVM/TransposeLowering.cpp
+++ b/lib/Conversion/HipToLLVM/TransposeLowering.cpp
@@ -120,8 +120,8 @@ struct TransposeOpLowering : public ConvertOpToLLVMPattern<TransposeOp> {
 
 } // namespace
 
-void mlir::hip::populateTransposeLoweringPatterns(
-    const LLVMTypeConverter &converter, RewritePatternSet &patterns) {
+void populateTransposeLoweringPatterns(const LLVMTypeConverter &converter,
+                                       RewritePatternSet &patterns) {
   patterns.add<TransposeOpLowering>(converter);
 }
 

--- a/lib/Conversion/HipToLLVM/WhereLowering.cpp
+++ b/lib/Conversion/HipToLLVM/WhereLowering.cpp
@@ -197,8 +197,8 @@ struct WhereOpLowering : public ConvertOpToLLVMPattern<WhereOp> {
 
 } // namespace
 
-void mlir::hip::populateWhereLoweringPatterns(
-    const LLVMTypeConverter &converter, RewritePatternSet &patterns) {
+void populateWhereLoweringPatterns(const LLVMTypeConverter &converter,
+                                   RewritePatternSet &patterns) {
   patterns.add<WhereOpLowering>(converter);
 }
 

--- a/lib/Conversion/OnnxToHip/ActivationConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ActivationConversion.cpp
@@ -141,8 +141,8 @@ GeluToHip::matchAndRewrite(mlir::Operation *op,
 
 } // namespace
 
-void mlir::hip::populateActivationConversionPatterns(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
+void populateActivationConversionPatterns(RewritePatternSet &patterns,
+                                          MLIRContext *ctx) {
   patterns.add<SoftmaxToHip, SigmoidToHip, SoftplusToHip, GeluToHip>(ctx);
 }
 

--- a/lib/Conversion/OnnxToHip/CastConversion.cpp
+++ b/lib/Conversion/OnnxToHip/CastConversion.cpp
@@ -69,8 +69,8 @@ CastToHip::matchAndRewrite(mlir::Operation *op,
 
 } // namespace
 
-void mlir::hip::populateCastConversionPatterns(RewritePatternSet &patterns,
-                                               MLIRContext *ctx) {
+void populateCastConversionPatterns(RewritePatternSet &patterns,
+                                    MLIRContext *ctx) {
   patterns.add<CastToHip>(ctx);
 }
 

--- a/lib/Conversion/OnnxToHip/CausalConvWithStateConversion.cpp
+++ b/lib/Conversion/OnnxToHip/CausalConvWithStateConversion.cpp
@@ -136,8 +136,8 @@ mlir::LogicalResult CausalConvWithStateToHip::matchAndRewrite(
 
 } // namespace
 
-void mlir::hip::populateCausalConvWithStateConversionPatterns(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
+void populateCausalConvWithStateConversionPatterns(RewritePatternSet &patterns,
+                                                   MLIRContext *ctx) {
   patterns.add<CausalConvWithStateToHip>(ctx);
 }
 

--- a/lib/Conversion/OnnxToHip/ConvConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ConvConversion.cpp
@@ -124,8 +124,8 @@ ConvToHip::matchAndRewrite(mlir::Operation *op,
 
 } // namespace
 
-void mlir::hip::populateConvConversionPatterns(RewritePatternSet &patterns,
-                                               MLIRContext *ctx) {
+void populateConvConversionPatterns(RewritePatternSet &patterns,
+                                    MLIRContext *ctx) {
   patterns.add<ConvToHip>(ctx);
 }
 

--- a/lib/Conversion/OnnxToHip/ElementwiseConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ElementwiseConversion.cpp
@@ -111,8 +111,8 @@ SubToHip::matchAndRewrite(mlir::Operation *op,
 
 } // namespace
 
-void mlir::hip::populateElementwiseConversionPatterns(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
+void populateElementwiseConversionPatterns(RewritePatternSet &patterns,
+                                           MLIRContext *ctx) {
   patterns.add<AddToHip, MulToHip, SubToHip>(ctx);
 }
 

--- a/lib/Conversion/OnnxToHip/GatherConversion.cpp
+++ b/lib/Conversion/OnnxToHip/GatherConversion.cpp
@@ -85,8 +85,8 @@ struct GatherToHip : public mlir::RewritePattern {
 
 } // namespace
 
-void mlir::hip::populateGatherConversionPatterns(RewritePatternSet &patterns,
-                                                 MLIRContext *ctx) {
+void populateGatherConversionPatterns(RewritePatternSet &patterns,
+                                      MLIRContext *ctx) {
   patterns.add<GatherToHip>(ctx);
 }
 

--- a/lib/Conversion/OnnxToHip/GemmConversion.cpp
+++ b/lib/Conversion/OnnxToHip/GemmConversion.cpp
@@ -71,8 +71,8 @@ struct GemmToHip : public mlir::RewritePattern {
 
 } // namespace
 
-void mlir::hip::populateGemmConversionPatterns(RewritePatternSet &patterns,
-                                               MLIRContext *ctx) {
+void populateGemmConversionPatterns(RewritePatternSet &patterns,
+                                    MLIRContext *ctx) {
   patterns.add<GemmToHip>(ctx);
 }
 

--- a/lib/Conversion/OnnxToHip/GqaConversion.cpp
+++ b/lib/Conversion/OnnxToHip/GqaConversion.cpp
@@ -303,8 +303,8 @@ mlir::LogicalResult GroupQueryAttentionToHip::matchAndRewrite(
 
 } // namespace
 
-void mlir::hip::populateGqaConversionPatterns(RewritePatternSet &patterns,
-                                              MLIRContext *ctx) {
+void populateGqaConversionPatterns(RewritePatternSet &patterns,
+                                   MLIRContext *ctx) {
   patterns.add<GroupQueryAttentionToHip>(ctx);
 }
 

--- a/lib/Conversion/OnnxToHip/LinearAttentionConversion.cpp
+++ b/lib/Conversion/OnnxToHip/LinearAttentionConversion.cpp
@@ -180,8 +180,8 @@ LinearAttentionToHip::matchAndRewrite(mlir::Operation *op,
 
 } // namespace
 
-void mlir::hip::populateLinearAttentionConversionPatterns(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
+void populateLinearAttentionConversionPatterns(RewritePatternSet &patterns,
+                                               MLIRContext *ctx) {
   patterns.add<LinearAttentionToHip>(ctx);
 }
 

--- a/lib/Conversion/OnnxToHip/MatMulConversion.cpp
+++ b/lib/Conversion/OnnxToHip/MatMulConversion.cpp
@@ -60,8 +60,8 @@ MatMulToHip::matchAndRewrite(mlir::Operation *op,
 
 } // namespace
 
-void mlir::hip::populateMatMulConversionPatterns(RewritePatternSet &patterns,
-                                                 MLIRContext *ctx) {
+void populateMatMulConversionPatterns(RewritePatternSet &patterns,
+                                      MLIRContext *ctx) {
   patterns.add<MatMulToHip>(ctx);
 }
 

--- a/lib/Conversion/OnnxToHip/MatMulNBitsConversion.cpp
+++ b/lib/Conversion/OnnxToHip/MatMulNBitsConversion.cpp
@@ -121,8 +121,8 @@ MatMulNBitsToHip::matchAndRewrite(mlir::Operation *op,
 
 } // namespace
 
-void mlir::hip::populateMatMulNBitsConversionPatterns(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
+void populateMatMulNBitsConversionPatterns(RewritePatternSet &patterns,
+                                           MLIRContext *ctx) {
   patterns.add<MatMulNBitsToHip>(ctx);
 }
 

--- a/lib/Conversion/OnnxToHip/NormConversion.cpp
+++ b/lib/Conversion/OnnxToHip/NormConversion.cpp
@@ -242,8 +242,8 @@ mlir::LogicalResult SkipSimplifiedLayerNormToHip::matchAndRewrite(
 
 } // namespace
 
-void mlir::hip::populateNormConversionPatterns(RewritePatternSet &patterns,
-                                               MLIRContext *ctx) {
+void populateNormConversionPatterns(RewritePatternSet &patterns,
+                                    MLIRContext *ctx) {
   patterns.add<SimplifiedLayerNormToHip, SkipSimplifiedLayerNormToHip>(ctx);
 }
 

--- a/lib/Conversion/OnnxToHip/PowerConversion.cpp
+++ b/lib/Conversion/OnnxToHip/PowerConversion.cpp
@@ -85,8 +85,8 @@ SqrtToHip::matchAndRewrite(mlir::Operation *op,
 
 } // namespace
 
-void mlir::hip::populatePowerConversionPatterns(RewritePatternSet &patterns,
-                                                MLIRContext *ctx) {
+void populatePowerConversionPatterns(RewritePatternSet &patterns,
+                                     MLIRContext *ctx) {
   patterns.add<ReciprocalToHip, SqrtToHip>(ctx);
 }
 

--- a/lib/Conversion/OnnxToHip/QMoEConversion.cpp
+++ b/lib/Conversion/OnnxToHip/QMoEConversion.cpp
@@ -175,8 +175,8 @@ QMoEToHip::matchAndRewrite(mlir::Operation *op,
 
 } // namespace
 
-void mlir::hip::populateQMoEConversionPatterns(RewritePatternSet &patterns,
-                                               MLIRContext *ctx) {
+void populateQMoEConversionPatterns(RewritePatternSet &patterns,
+                                    MLIRContext *ctx) {
   patterns.add<QMoEToHip>(ctx);
 }
 

--- a/lib/Conversion/OnnxToHip/RangeConversion.cpp
+++ b/lib/Conversion/OnnxToHip/RangeConversion.cpp
@@ -243,8 +243,8 @@ struct RangeToHip : public RewritePattern {
 
 } // namespace
 
-void mlir::hip::populateRangeConversionPatterns(RewritePatternSet &patterns,
-                                                MLIRContext *ctx) {
+void populateRangeConversionPatterns(RewritePatternSet &patterns,
+                                     MLIRContext *ctx) {
   patterns.add<RangeToHip>(ctx);
 }
 

--- a/lib/Conversion/OnnxToHip/ReduceSumConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ReduceSumConversion.cpp
@@ -93,8 +93,8 @@ ReduceSumToHip::matchAndRewrite(mlir::Operation *op,
 
 } // namespace
 
-void mlir::hip::populateReduceSumConversionPatterns(RewritePatternSet &patterns,
-                                                    MLIRContext *ctx) {
+void populateReduceSumConversionPatterns(RewritePatternSet &patterns,
+                                         MLIRContext *ctx) {
   patterns.add<ReduceSumToHip>(ctx);
 }
 

--- a/lib/Conversion/OnnxToHip/ReshapeConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ReshapeConversion.cpp
@@ -546,8 +546,8 @@ struct SplitToStdTensor : public mlir::RewritePattern {
 
 } // namespace
 
-void mlir::hip::populateReshapeConversionPatterns(RewritePatternSet &patterns,
-                                                  MLIRContext *ctx) {
+void populateReshapeConversionPatterns(RewritePatternSet &patterns,
+                                       MLIRContext *ctx) {
   patterns.add<ReshapeToStdTensor, UnsqueezeToStdTensor, SqueezeToStdTensor,
                SplitToStdTensor>(ctx);
 }

--- a/lib/Conversion/OnnxToHip/RotaryEmbeddingConversion.cpp
+++ b/lib/Conversion/OnnxToHip/RotaryEmbeddingConversion.cpp
@@ -148,8 +148,8 @@ RotaryEmbeddingToHip::matchAndRewrite(mlir::Operation *op,
 
 } // namespace
 
-void mlir::hip::populateRotaryEmbeddingConversionPatterns(
-    RewritePatternSet &patterns, MLIRContext *ctx) {
+void populateRotaryEmbeddingConversionPatterns(RewritePatternSet &patterns,
+                                               MLIRContext *ctx) {
   patterns.add<RotaryEmbeddingToHip>(ctx);
 }
 

--- a/lib/Conversion/OnnxToHip/TransposeConversion.cpp
+++ b/lib/Conversion/OnnxToHip/TransposeConversion.cpp
@@ -100,8 +100,8 @@ TransposeToHip::matchAndRewrite(mlir::Operation *op,
 
 } // namespace
 
-void mlir::hip::populateTransposeConversionPatterns(RewritePatternSet &patterns,
-                                                    MLIRContext *ctx) {
+void populateTransposeConversionPatterns(RewritePatternSet &patterns,
+                                         MLIRContext *ctx) {
   patterns.add<TransposeToHip>(ctx);
 }
 

--- a/lib/Conversion/OnnxToHip/WhereConversion.cpp
+++ b/lib/Conversion/OnnxToHip/WhereConversion.cpp
@@ -127,8 +127,8 @@ WhereToHip::matchAndRewrite(mlir::Operation *op,
 
 } // namespace
 
-void mlir::hip::populateWhereConversionPatterns(RewritePatternSet &patterns,
-                                                MLIRContext *ctx) {
+void populateWhereConversionPatterns(RewritePatternSet &patterns,
+                                     MLIRContext *ctx) {
   patterns.add<WhereToHip>(ctx);
 }
 

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -143,6 +143,16 @@ macro(compile_to_bitcode SOURCE_FILE OUTPUT_BC)
     # (e.g., "C:/Program Files/..."). Clang supports "-I" "<path>" as two args.
     set(COMPILE_FLAGS "")
 
+    # PIC is required when this bitcode is later linked into the per-model
+    # shared library on Linux (ELF .so). Without -fPIC the IR omits dso_local
+    # markers, codegen emits R_X86_64_PC32 against statics like the Itanium
+    # guard variables for function-local statics, and lld rejects them with
+    # "relocation cannot be used against symbol; recompile with -fPIC". On
+    # Windows COFF this flag is a no-op (clang ignores it for the MSVC ABI).
+    if(NOT WIN32)
+        list(APPEND COMPILE_FLAGS "-fPIC")
+    endif()
+
     # Always add root directory for public headers
     list(APPEND COMPILE_FLAGS "-I" "${CMAKE_CURRENT_SOURCE_DIR}")
 

--- a/lib/Runtime/real/linear_attention.cpp
+++ b/lib/Runtime/real/linear_attention.cpp
@@ -142,6 +142,29 @@ extern "C" int wrap_linear_attention(
   const int64_t state_bytes = dk * dv * elem_size;
   int64_t total_state_bytes = B * Hkv * state_bytes;
 
+  // Per-token stride (in bytes) for each packed [B, T, H*D] tensor. The
+  // kernel indexes into the packed layout directly using seq_len as the
+  // per-batch stride, so we only need to advance the base pointer by one
+  // token between iterations -- no intermediate gather/scatter buffers.
+  //
+  //   query  : Hq  * dk      key    : Nk   * dk (may be < Hkv*dk)
+  //   value  : Hkv * dv      output : Hout * dv (Hout = max(Hq, Hkv))
+  //   decay_per_key_dim==1 -> Hkv * dk;   ==0 -> Hkv
+  //   beta_per_head==1     -> Hkv;        ==0 -> 1
+  //
+  // Declared BEFORE the first HIP_CHECK below so the `goto cleanup` paths
+  // inside HIP_CHECK don't bypass their initialization. C++ forbids jumping
+  // past a variable's initialization to a later label (the "cannot jump from
+  // this goto statement to its label" error clang emits on linux; MSVC is
+  // historically lax about this and accepted the previous ordering).
+  const int64_t q_token_bytes = Hq * dk * elem_size;
+  const int64_t k_token_bytes = Nk * dk * elem_size;
+  const int64_t v_token_bytes = Hkv * dv * elem_size;
+  const int64_t o_token_bytes = Hout * dv * elem_size;
+  const int64_t decay_token_bytes =
+      (decay_per_key_dim ? Hkv * dk : Hkv) * elem_size;
+  const int64_t beta_token_bytes = (beta_per_head ? Hkv : 1) * elem_size;
+
   int result = 0;
 
   // Initialize present_state from past_state (or zeros)
@@ -152,23 +175,6 @@ extern "C" int wrap_linear_attention(
     HIP_CHECK(hipMemsetAsync(present_state, 0, total_state_bytes,
                              (hipStream_t)hip_stream));
   }
-
-  // Per-token stride (in bytes) for each packed [B, T, H*D] tensor. The
-  // kernel indexes into the packed layout directly using seq_len as the
-  // per-batch stride, so we only need to advance the base pointer by one
-  // token between iterations -- no intermediate gather/scatter buffers.
-  //
-  //   query  : Hq  * dk      key    : Nk   * dk (may be < Hkv*dk)
-  //   value  : Hkv * dv      output : Hout * dv (Hout = max(Hq, Hkv))
-  //   decay_per_key_dim==1 -> Hkv * dk;   ==0 -> Hkv
-  //   beta_per_head==1     -> Hkv;        ==0 -> 1
-  const int64_t q_token_bytes = Hq * dk * elem_size;
-  const int64_t k_token_bytes = Nk * dk * elem_size;
-  const int64_t v_token_bytes = Hkv * dv * elem_size;
-  const int64_t o_token_bytes = Hout * dv * elem_size;
-  const int64_t decay_token_bytes =
-      (decay_per_key_dim ? Hkv * dk : Hkv) * elem_size;
-  const int64_t beta_token_bytes = (beta_per_head ? Hkv : 1) * elem_size;
 
   RUNTIME_DEBUG_LOG(
       "[linear_attention] dispatching %lld token(s) via per-step decode "

--- a/lib/Target/LLVM/CMakeLists.txt
+++ b/lib/Target/LLVM/CMakeLists.txt
@@ -56,11 +56,11 @@ endif()
 
 # Link LLVM components
 #
-# DLLLinker.cpp invokes lldMain with either the COFF driver (Windows model.dll
-# output) or the ELF driver (Linux model.so output), gated on _WIN32. Each
-# backend pulls its own set of LLVM transitive dependencies (e.g. lldCOFF
-# needs WindowsDriver/WindowsManifest/LibDriver; lldELF does not). Split the
-# component list and the find_library calls along the same platform line.
+# DLLLinker.cpp's Windows path invokes lld::lldMain in-process with the COFF
+# driver. The Linux path uses a `clang++ -shared` subprocess instead (see
+# linkDLL_Linux for the rationale), so it pulls in no in-process lld libs.
+# The COFF driver, lldCOFF/lldCommon, and the WindowsDriver/WindowsManifest/
+# LibDriver transitives are therefore Windows-only.
 llvm_map_components_to_libnames(llvm_libs
   # Core infrastructure
   Support
@@ -103,39 +103,33 @@ if(WIN32)
     list(APPEND llvm_libs ${llvm_libs_coff})
 endif()
 
-# Locate LLD. Two shipping conventions in the wild:
+# Locate LLD (Windows only — Linux invokes ld.lld via the clang++ driver
+# subprocess and links no lld libs in-process). Two shipping conventions:
 #
 #  (a) Source-built / install-tree layout (Windows / LLVM cross-compiled in
-#      vendored 3rd-party): split static archives liblldCOFF.a, liblldELF.a,
-#      liblldCommon.a co-located in LLVM_LIBRARY_DIRS. Discover with
-#      find_library against bare names.
+#      vendored 3rd-party): split static archives liblldCOFF.a, liblldCommon.a
+#      co-located in LLVM_LIBRARY_DIRS. Discover with find_library against
+#      bare names.
 #
-#  (b) Distro dev package (apt.llvm.org liblld-XX-dev on Ubuntu noble,
-#      brew llvm on macOS, ...): only LLDConfig.cmake + LLDTargets.cmake
-#      under lib/cmake/lld/. No bare .a files for find_library to chew on;
+#  (b) Distro dev package (apt.llvm.org liblld-XX-dev, brew llvm on macOS,
+#      ...): only LLDConfig.cmake + LLDTargets.cmake under lib/cmake/lld/;
 #      libraries are exposed exclusively as IMPORTED targets (lldCOFF,
-#      lldELF, lldCommon, ...) via find_package(LLD CONFIG).
+#      lldCommon, ...) via find_package(LLD CONFIG).
 #
 # Try the CONFIG path first; fall back to find_library for legacy trees
-# that omit LLDConfig.cmake (older 12.x source builds, custom vendored
-# minimal LLD installs).
-find_package(LLD CONFIG QUIET)
-if(LLD_FOUND)
-    message(STATUS "Found LLD via CONFIG package: ${LLD_DIR}")
-    set(lld_libs lldCommon lldELF)
-    if(WIN32)
-        list(APPEND lld_libs lldCOFF)
-    endif()
-else()
-    message(STATUS "LLD CONFIG package not found; falling back to find_library")
-    set(lld_libs "")
-    if(WIN32)
+# that omit LLDConfig.cmake.
+set(lld_libs "")
+if(WIN32)
+    find_package(LLD CONFIG QUIET)
+    if(LLD_FOUND)
+        message(STATUS "Found LLD via CONFIG package: ${LLD_DIR}")
+        set(lld_libs lldCommon lldCOFF)
+    else()
+        message(STATUS "LLD CONFIG package not found; falling back to find_library")
         find_library(LLD_COFF_LIB NAMES lldCOFF PATHS ${LLVM_LIBRARY_DIRS} REQUIRED)
-        list(APPEND lld_libs ${LLD_COFF_LIB})
+        find_library(LLD_COMMON_LIB NAMES lldCommon PATHS ${LLVM_LIBRARY_DIRS} REQUIRED)
+        list(APPEND lld_libs ${LLD_COFF_LIB} ${LLD_COMMON_LIB})
     endif()
-    find_library(LLD_ELF_LIB NAMES lldELF PATHS ${LLVM_LIBRARY_DIRS} REQUIRED)
-    find_library(LLD_COMMON_LIB NAMES lldCommon PATHS ${LLVM_LIBRARY_DIRS} REQUIRED)
-    list(APPEND lld_libs ${LLD_ELF_LIB} ${LLD_COMMON_LIB})
 endif()
 
 # LLVMDTLTO was split from LLVMLTO in LLVM 22.1; link it when present.

--- a/lib/Target/LLVM/CMakeLists.txt
+++ b/lib/Target/LLVM/CMakeLists.txt
@@ -151,7 +151,8 @@ if(NOT WIN32)
     if(HIPDNN_CLANG_EXECUTABLE)
         message(STATUS "Found clang++ for runtime DLL linking: ${HIPDNN_CLANG_EXECUTABLE}")
         target_compile_definitions(HipTargetLLVM PRIVATE
-            HIPDNN_CLANG_PATH="${HIPDNN_CLANG_EXECUTABLE}")
+            HIPDNN_CLANG_PATH="${HIPDNN_CLANG_EXECUTABLE}"
+            HIPDNN_LLVM_MAJOR=${LLVM_VERSION_MAJOR})
     else()
         message(WARNING
             "clang not found at configure time; runtime DLL linking will "

--- a/lib/Target/LLVM/CMakeLists.txt
+++ b/lib/Target/LLVM/CMakeLists.txt
@@ -13,6 +13,7 @@ message(STATUS "Building Target LLVM Library")
 # this gracefully (bcSize == 0 → skip linking).
 if(NOT TARGET RuntimeBitcode)
     file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/runtime_ir_data.cpp
+        "#include <cstddef>\n"
         "extern \"C\" const unsigned char runtime_bc_data[] = {0};\n"
         "extern \"C\" const size_t runtime_bc_data_size = 0;\n"
     )
@@ -33,7 +34,7 @@ else()
                 --output ${CMAKE_CURRENT_BINARY_DIR}/runtime_ir_data.cpp.tmp
                 ${RUNTIME_BC_PATH}
         COMMAND ${Python3_EXECUTABLE} -c
-                "import os; data = open('${CMAKE_CURRENT_BINARY_DIR}/runtime_ir_data.cpp.tmp').read(); data = data.replace('static const unsigned char', 'extern \"C\" const unsigned char'); bc_size = os.path.getsize('${RUNTIME_BC_PATH}'); data += f'\\nextern \"C\" const size_t runtime_bc_data_size = {bc_size};\\n'; open('${CMAKE_CURRENT_BINARY_DIR}/runtime_ir_data.cpp', 'w').write(data)"
+                "import os; data = open('${CMAKE_CURRENT_BINARY_DIR}/runtime_ir_data.cpp.tmp').read(); data = data.replace('static const unsigned char', 'extern \"C\" const unsigned char'); bc_size = os.path.getsize('${RUNTIME_BC_PATH}'); data = '#include <cstddef>\\n' + data + f'\\nextern \"C\" const size_t runtime_bc_data_size = {bc_size};\\n'; open('${CMAKE_CURRENT_BINARY_DIR}/runtime_ir_data.cpp', 'w').write(data)"
         COMMAND ${CMAKE_COMMAND} -E remove ${CMAKE_CURRENT_BINARY_DIR}/runtime_ir_data.cpp.tmp
         DEPENDS ${RUNTIME_BC_PATH}
         COMMENT "Generating runtime_ir_data.cpp from runtime.bc"
@@ -54,6 +55,12 @@ if(TARGET RuntimeBitcode)
 endif()
 
 # Link LLVM components
+#
+# DLLLinker.cpp invokes lldMain with either the COFF driver (Windows model.dll
+# output) or the ELF driver (Linux model.so output), gated on _WIN32. Each
+# backend pulls its own set of LLVM transitive dependencies (e.g. lldCOFF
+# needs WindowsDriver/WindowsManifest/LibDriver; lldELF does not). Split the
+# component list and the find_library calls along the same platform line.
 llvm_map_components_to_libnames(llvm_libs
   # Core infrastructure
   Support
@@ -63,7 +70,7 @@ llvm_map_components_to_libnames(llvm_libs
   Passes
   Target
 
-  # Code generation (required by lldCOFF)
+  # Code generation (required by both lldCOFF and lldELF)
   CodeGen
   SelectionDAG
   AsmPrinter
@@ -81,20 +88,55 @@ llvm_map_components_to_libnames(llvm_libs
   # Linker support
   Linker
 
-  # LTO and option parsing (required by lldCOFF)
+  # LTO and option parsing (required by both lldCOFF and lldELF)
   LTO
   Option
-
-  # Windows-specific (required by lldCOFF on Windows)
-  WindowsDriver
-  WindowsManifest
-  LibDriver
 )
 
-# Find LLD libraries using full paths
-find_library(LLD_COFF_LIB NAMES lldCOFF PATHS ${LLVM_LIBRARY_DIRS} REQUIRED)
-find_library(LLD_ELF_LIB NAMES lldELF PATHS ${LLVM_LIBRARY_DIRS} REQUIRED)
-find_library(LLD_COMMON_LIB NAMES lldCommon PATHS ${LLVM_LIBRARY_DIRS} REQUIRED)
+if(WIN32)
+    # Windows COFF-only LLVM components needed by lldCOFF.
+    llvm_map_components_to_libnames(llvm_libs_coff
+        WindowsDriver
+        WindowsManifest
+        LibDriver
+    )
+    list(APPEND llvm_libs ${llvm_libs_coff})
+endif()
+
+# Locate LLD. Two shipping conventions in the wild:
+#
+#  (a) Source-built / install-tree layout (Windows / LLVM cross-compiled in
+#      vendored 3rd-party): split static archives liblldCOFF.a, liblldELF.a,
+#      liblldCommon.a co-located in LLVM_LIBRARY_DIRS. Discover with
+#      find_library against bare names.
+#
+#  (b) Distro dev package (apt.llvm.org liblld-XX-dev on Ubuntu noble,
+#      brew llvm on macOS, ...): only LLDConfig.cmake + LLDTargets.cmake
+#      under lib/cmake/lld/. No bare .a files for find_library to chew on;
+#      libraries are exposed exclusively as IMPORTED targets (lldCOFF,
+#      lldELF, lldCommon, ...) via find_package(LLD CONFIG).
+#
+# Try the CONFIG path first; fall back to find_library for legacy trees
+# that omit LLDConfig.cmake (older 12.x source builds, custom vendored
+# minimal LLD installs).
+find_package(LLD CONFIG QUIET)
+if(LLD_FOUND)
+    message(STATUS "Found LLD via CONFIG package: ${LLD_DIR}")
+    set(lld_libs lldCommon lldELF)
+    if(WIN32)
+        list(APPEND lld_libs lldCOFF)
+    endif()
+else()
+    message(STATUS "LLD CONFIG package not found; falling back to find_library")
+    set(lld_libs "")
+    if(WIN32)
+        find_library(LLD_COFF_LIB NAMES lldCOFF PATHS ${LLVM_LIBRARY_DIRS} REQUIRED)
+        list(APPEND lld_libs ${LLD_COFF_LIB})
+    endif()
+    find_library(LLD_ELF_LIB NAMES lldELF PATHS ${LLVM_LIBRARY_DIRS} REQUIRED)
+    find_library(LLD_COMMON_LIB NAMES lldCommon PATHS ${LLVM_LIBRARY_DIRS} REQUIRED)
+    list(APPEND lld_libs ${LLD_ELF_LIB} ${LLD_COMMON_LIB})
+endif()
 
 # LLVMDTLTO was split from LLVMLTO in LLVM 22.1; link it when present.
 find_library(LLVM_DTLTO_LIB NAMES LLVMDTLTO PATHS ${LLVM_LIBRARY_DIRS})
@@ -107,11 +149,31 @@ target_link_libraries(HipTargetLLVM PUBLIC
   MLIRLLVMToLLVMIRTranslation
   MLIRBuiltinToLLVMIRTranslation
   ${llvm_libs}
-  ${LLD_COFF_LIB}
-  ${LLD_ELF_LIB}
-  ${LLD_COMMON_LIB}
+  ${lld_libs}
   $<$<BOOL:${LLVM_DTLTO_LIB}>:${LLVM_DTLTO_LIB}>
 )
+
+# DLLLinker.cpp's Linux path invokes ld.lld as a subprocess instead of
+# lld::lldMain — see the long comment in linkDLL_Linux for the reason.
+# Bake the discovered ld.lld path so the runtime invocation doesn't have
+# to rely on PATH (the host process running the EP may not include the
+# llvm-XX bin dir).
+if(NOT WIN32)
+    find_program(LD_LLD_EXECUTABLE NAMES ld.lld
+        PATHS
+            ${LLVM_BINARY_DIR}/bin
+            ${LLVM_TOOLS_BINARY_DIR}
+    )
+    if(LD_LLD_EXECUTABLE)
+        message(STATUS "Found ld.lld for runtime DLL linking: ${LD_LLD_EXECUTABLE}")
+        target_compile_definitions(HipTargetLLVM PRIVATE
+            HIPDNN_LD_LLD_PATH="${LD_LLD_EXECUTABLE}")
+    else()
+        message(WARNING
+            "ld.lld not found at configure time; runtime DLL linking will "
+            "rely on PATH lookup at execution time.")
+    endif()
+endif()
 
 # Set folder for IDE organization
 set_target_properties(HipTargetLLVM PROPERTIES FOLDER "mlir/Target")

--- a/lib/Target/LLVM/CMakeLists.txt
+++ b/lib/Target/LLVM/CMakeLists.txt
@@ -103,21 +103,9 @@ if(WIN32)
     list(APPEND llvm_libs ${llvm_libs_coff})
 endif()
 
-# Locate LLD (Windows only — Linux invokes ld.lld via the clang++ driver
-# subprocess and links no lld libs in-process). Two shipping conventions:
-#
-#  (a) Source-built / install-tree layout (Windows / LLVM cross-compiled in
-#      vendored 3rd-party): split static archives liblldCOFF.a, liblldCommon.a
-#      co-located in LLVM_LIBRARY_DIRS. Discover with find_library against
-#      bare names.
-#
-#  (b) Distro dev package (apt.llvm.org liblld-XX-dev, brew llvm on macOS,
-#      ...): only LLDConfig.cmake + LLDTargets.cmake under lib/cmake/lld/;
-#      libraries are exposed exclusively as IMPORTED targets (lldCOFF,
-#      lldCommon, ...) via find_package(LLD CONFIG).
-#
-# Try the CONFIG path first; fall back to find_library for legacy trees
-# that omit LLDConfig.cmake.
+# LLD: Windows only (Linux uses clang++ driver subprocess). Prefer
+# find_package(LLD CONFIG) (apt.llvm.org / IMPORTED targets); fall back to
+# find_library for legacy trees that omit LLDConfig.cmake.
 set(lld_libs "")
 if(WIN32)
     find_package(LLD CONFIG QUIET)
@@ -147,25 +135,14 @@ target_link_libraries(HipTargetLLVM PUBLIC
   $<$<BOOL:${LLVM_DTLTO_LIB}>:${LLVM_DTLTO_LIB}>
 )
 
-# DLLLinker.cpp's Linux path invokes `clang -shared` as a subprocess
-# (driver-mediated link via ld.lld) instead of in-process lld::lldMain —
-# see the long comment in linkDLL_Linux for the reason. Bake the
-# discovered clang path so the runtime invocation doesn't have to rely on
-# PATH (the host process running the EP may not include the llvm-XX bin
-# dir). PATH lookup remains the fallback in DLLLinker.cpp if the baked
-# path is stale (e.g. CI build with /usr/lib/llvm-22 deployed to a host
-# where clang lives elsewhere).
+# Bake the clang++ path used by DLLLinker.cpp's Linux subprocess link.
+# DLLLinker has a PATH fallback if the baked path is stale (e.g. CI build
+# deployed to a host with clang elsewhere). HINTS scopes the search to
+# the LLVM tree we configure against so a stale `/usr/bin/clang-18`
+# doesn't shadow apt llvm-22. clang++ (not bare clang) — the driver
+# auto-pulls libstdc++ which the generated model object needs for
+# __cxa_begin_catch / __cxa_rethrow.
 if(NOT WIN32)
-    # HINTS (vs PATHS) gives priority to the LLVM tree we're configuring
-    # against, so a stale `/usr/bin/clang-18` won't be picked over the
-    # apt llvm-22 install when both exist. Default-PATH search is still
-    # the fallback if the hints don't pan out.
-    # We bake the clang++ driver (not bare clang) so the runtime link
-    # auto-pulls libstdc++ — the generated model object references C++
-    # ABI symbols (__cxa_begin_catch, __cxa_rethrow, etc.) via the
-    # libhip_custom_kernels.a archive's std::unordered_map / std::string
-    # usage. With bare `clang -shared` the link errors "undefined symbol:
-    # __cxa_*" on every model.
     find_program(HIPDNN_CLANG_EXECUTABLE NAMES clang++
         HINTS
             ${LLVM_BINARY_DIR}/bin

--- a/lib/Target/LLVM/CMakeLists.txt
+++ b/lib/Target/LLVM/CMakeLists.txt
@@ -153,24 +153,37 @@ target_link_libraries(HipTargetLLVM PUBLIC
   $<$<BOOL:${LLVM_DTLTO_LIB}>:${LLVM_DTLTO_LIB}>
 )
 
-# DLLLinker.cpp's Linux path invokes ld.lld as a subprocess instead of
-# lld::lldMain — see the long comment in linkDLL_Linux for the reason.
-# Bake the discovered ld.lld path so the runtime invocation doesn't have
-# to rely on PATH (the host process running the EP may not include the
-# llvm-XX bin dir).
+# DLLLinker.cpp's Linux path invokes `clang -shared` as a subprocess
+# (driver-mediated link via ld.lld) instead of in-process lld::lldMain —
+# see the long comment in linkDLL_Linux for the reason. Bake the
+# discovered clang path so the runtime invocation doesn't have to rely on
+# PATH (the host process running the EP may not include the llvm-XX bin
+# dir). PATH lookup remains the fallback in DLLLinker.cpp if the baked
+# path is stale (e.g. CI build with /usr/lib/llvm-22 deployed to a host
+# where clang lives elsewhere).
 if(NOT WIN32)
-    find_program(LD_LLD_EXECUTABLE NAMES ld.lld
-        PATHS
+    # HINTS (vs PATHS) gives priority to the LLVM tree we're configuring
+    # against, so a stale `/usr/bin/clang-18` won't be picked over the
+    # apt llvm-22 install when both exist. Default-PATH search is still
+    # the fallback if the hints don't pan out.
+    # We bake the clang++ driver (not bare clang) so the runtime link
+    # auto-pulls libstdc++ — the generated model object references C++
+    # ABI symbols (__cxa_begin_catch, __cxa_rethrow, etc.) via the
+    # libhip_custom_kernels.a archive's std::unordered_map / std::string
+    # usage. With bare `clang -shared` the link errors "undefined symbol:
+    # __cxa_*" on every model.
+    find_program(HIPDNN_CLANG_EXECUTABLE NAMES clang++
+        HINTS
             ${LLVM_BINARY_DIR}/bin
             ${LLVM_TOOLS_BINARY_DIR}
     )
-    if(LD_LLD_EXECUTABLE)
-        message(STATUS "Found ld.lld for runtime DLL linking: ${LD_LLD_EXECUTABLE}")
+    if(HIPDNN_CLANG_EXECUTABLE)
+        message(STATUS "Found clang++ for runtime DLL linking: ${HIPDNN_CLANG_EXECUTABLE}")
         target_compile_definitions(HipTargetLLVM PRIVATE
-            HIPDNN_LD_LLD_PATH="${LD_LLD_EXECUTABLE}")
+            HIPDNN_CLANG_PATH="${HIPDNN_CLANG_EXECUTABLE}")
     else()
         message(WARNING
-            "ld.lld not found at configure time; runtime DLL linking will "
+            "clang not found at configure time; runtime DLL linking will "
             "rely on PATH lookup at execution time.")
     endif()
 endif()

--- a/lib/Target/LLVM/DLLLinker.cpp
+++ b/lib/Target/LLVM/DLLLinker.cpp
@@ -267,10 +267,20 @@ bool DLLLinker::linkDLL_Linux(const std::string &objectFile,
   if (clangPath.empty() || !llvm::sys::fs::exists(clangPath)) {
     auto found = llvm::sys::findProgramByName("clang++");
     if (!found) {
+      // HIPDNN_LLVM_MAJOR is injected by lib/Target/LLVM/CMakeLists.txt
+      // from find_package(LLVM)'s LLVM_VERSION_MAJOR; stringify it so the
+      // apt package hint tracks the LLVM version the project actually
+      // configured against (instead of going stale on the next bump).
+#define HIPDNN_STRINGIFY_(x) #x
+#define HIPDNN_STRINGIFY(x) HIPDNN_STRINGIFY_(x)
       llvm::errs() << "clang++ not found on PATH and HIPDNN_CLANG_PATH is "
-                      "unset or stale. Install clang (e.g. apt install "
-                      "clang-22) or rebuild with HIPDNN_CLANG_PATH "
-                      "pointing to a valid clang++ binary.\n";
+                      "unset or stale. Install clang (e.g. `apt install "
+                      "clang-"
+                   << HIPDNN_STRINGIFY(HIPDNN_LLVM_MAJOR)
+                   << "`) or rebuild with HIPDNN_CLANG_PATH pointing to a "
+                      "valid clang++ binary.\n";
+#undef HIPDNN_STRINGIFY
+#undef HIPDNN_STRINGIFY_
       return false;
     }
     clangPath = *found;
@@ -294,7 +304,6 @@ bool DLLLinker::linkDLL_Linux(const std::string &objectFile,
   args.push_back("-Wl,--end-group");
   for (const auto &p : libraryPaths)
     args.push_back("-Wl,-rpath," + p);
-  args.push_back("-Wl,--export-dynamic");
   args.push_back("-Wl,--no-undefined");
 
   COMPILER_DEBUG_LOG("clang -shared command (" << args.size() << " args):\n");

--- a/lib/Target/LLVM/DLLLinker.cpp
+++ b/lib/Target/LLVM/DLLLinker.cpp
@@ -247,206 +247,86 @@ bool DLLLinker::linkDLL_Windows(const std::string &objectFile,
 
 #else // Linux
 
-// Resolve a gcc-managed file (crtbeginS.o, libgcc.a, ...) via
-// `gcc -print-file-name=<name>`. Returns empty string if gcc isn't on PATH
-// or returns the input unchanged (gcc's "not found" convention).
-static std::string gccPrintFileName(const char *name) {
-  std::string cmd =
-      std::string("gcc -print-file-name=") + name + " 2>/dev/null";
-  FILE *fp = popen(cmd.c_str(), "r");
-  if (!fp)
-    return {};
-  char buf[1024];
-  std::string result;
-  if (fgets(buf, sizeof(buf), fp))
-    result = buf;
-  pclose(fp);
-  while (!result.empty() && (result.back() == '\n' || result.back() == '\r'))
-    result.pop_back();
-  // gcc returns the input verbatim when it can't find the file; treat that
-  // as "not found" so callers don't pass nonsense paths to the linker.
-  if (result == name)
-    return {};
-  return result;
-}
-
 bool DLLLinker::linkDLL_Linux(const std::string &objectFile,
                               const std::string &outputDLL,
                               const std::vector<std::string> &libraries,
                               const std::vector<std::string> &libraryPaths) {
-  // Resolve gcc CRT objects up-front so the link line below stays linear.
-  // These bracket the user object files and provide the per-DSO startup +
-  // teardown glue that `clang`/`gcc` driver normally injects but we have to
-  // do by hand because we invoke ld.lld directly. Specifically:
+  // Driver-mediated link: clang -shared owns crt selection, sysroot,
+  // multiarch -L, libgcc -L, sys-lib ordering, the glibc 2.34
+  // libpthread/libdl merge, and the start/end-group bracket around its own
+  // implicit libs. We only pass user objects + user libs + rpath, and let
+  // clang generate the right argv for ld.lld.
   //
-  //   crti.o       — opens _init / _fini function bodies (sentinel pair
-  //                  with crtn.o). Strictly only needed when the DLL has
-  //                  DT_INIT/DT_FINI, but harmless when paired with crtn.o.
-  //   crtbeginS.o  — provides __dso_handle and __do_global_dtors_aux. The
-  //                  init_array entry from this object registers
-  //                  __cxa_atexit(__do_global_dtors_aux, ..., __dso_handle)
-  //                  at load time so glibc has a hook to call when the DLL
-  //                  is dlclose'd (the .fini_array reciprocal then walks
-  //                  __cxa_finalize(&__dso_handle) and drains the
-  //                  per-DSO destructor list).
-  //   crtendS.o    — terminator counterpart for crtbeginS.o (closes the
-  //                  .init_array / .fini_array sections).
-  //   crtn.o       — closes _init / _fini bodies started by crti.o.
+  // Subprocess (not in-process lld::lldMain) because lld::lldMain SIGSEGV's
+  // during its post-output cleanup when libhip-compiler.so is loaded into
+  // a long-lived host process via dlopen — exactly the path the MorphiZen
+  // EP takes. The .so is on disk by then, but lldMain's exit path corrupts
+  // host state. clang -shared invokes ld.lld in its own child process and
+  // exits cleanly because there is no host state to corrupt.
   //
-  // Without crtbeginS.o + crtendS.o the model DLL has an empty (or missing)
-  // .fini_array, so dlclose never invokes __cxa_finalize for the DLL. C++
-  // global destructors stay registered in the global atexit list with
-  // function pointers that point into the just-unmapped DLL. When libc's
-  // exit() walks that list, it hits an unmapped PC and SIGSEGV's. See the
-  // "S" variant of each object: those are the shared-library / PIC ones
-  // (crtbegin.o vs crtbeginS.o etc.).
-  const std::string crti = gccPrintFileName("crti.o");
-  const std::string crtbeginS = gccPrintFileName("crtbeginS.o");
-  const std::string crtendS = gccPrintFileName("crtendS.o");
-  const std::string crtn = gccPrintFileName("crtn.o");
-
-  // Build LLD-ELF command line arguments for shared library
-  std::vector<std::string> argStrings;
-  argStrings.push_back("ld.lld");  // Program name (required by LLD)
-  argStrings.push_back("-shared"); // Create shared library
-  argStrings.push_back("-o");
-  argStrings.push_back(outputDLL);
-
-  // CRT prologue: must precede the user objects so the .init_array entries
-  // contributed by crtbeginS.o land before our _GLOBAL__sub_I_* ctors.
-  if (!crti.empty())
-    argStrings.push_back(crti);
-  if (!crtbeginS.empty())
-    argStrings.push_back(crtbeginS);
-
-  // User object file (the per-model bitcode after LLVM codegen).
-  argStrings.push_back(objectFile);
-
-  // Add library paths
-  for (const auto &libPath : libraryPaths) {
-    argStrings.push_back("-L" + libPath);
-  }
-
-  // Add libraries. Mirror the Windows path's behaviour: callers can pass
-  // either bare names ("MIOpen" -> "-lMIOpen") or absolute paths to a
-  // specific archive/.so (e.g. install-prefix paths to
-  // libhip_custom_kernels.a). Bare-`-l/abs/path` is a malformed lld arg that
-  // fails with "unable to find library -l/abs/path" — pass full paths as
-  // positional args.
-  for (const auto &lib : libraries) {
-    if (lib.find('/') != std::string::npos) {
-      argStrings.push_back(lib);
-    } else {
-      argStrings.push_back("-l" + lib);
-    }
-  }
-
-  // Add RPATH for runtime library search
-  for (const auto &libPath : libraryPaths) {
-    argStrings.push_back("-rpath");
-    argStrings.push_back(libPath);
-  }
-
-  // Add system library search paths + standard C/C++ runtime libraries.
-  //
-  // We invoke ld.lld directly (via lld::lldMain) for crash-recovery, so unlike
-  // a clang/gcc driver invocation NOTHING auto-pulls libc/libstdc++/libgcc.
-  // The runtime bitcode (std::chrono, operator new, ...) and the custom-kernel
-  // archive (fprintf/memcpy/__cxa_guard_acquire/...) reference dozens of libc
-  // and libstdc++ symbols; without these the link fails with hundreds of
-  // "undefined symbol" errors. The Windows path solves the same problem by
-  // explicitly adding msvcrt.lib/ucrt.lib/vcruntime.lib above. This is the
-  // ELF analogue.
-  //
-  // Multiarch path is hard-coded to x86_64-linux-gnu (the only Linux target
-  // we currently support). The gcc internal libdir (libgcc.a, crtbeginS.o)
-  // is discovered by parsing `gcc --print-libgcc-file-name` so we don't have
-  // to hard-code the gcc version. On glibc 2.34+ libpthread/libdl/librt are
-  // merged into libc, so they're omitted (would error "unable to find
-  // -lpthread" because the .so files are gone).
-  argStrings.push_back("-L/usr/lib/x86_64-linux-gnu");
-  argStrings.push_back("-L/lib/x86_64-linux-gnu");
-  if (FILE *fp = popen("gcc --print-libgcc-file-name 2>/dev/null", "r")) {
-    char buf[1024];
-    if (fgets(buf, sizeof(buf), fp)) {
-      std::string libgccPath(buf);
-      while (!libgccPath.empty() &&
-             (libgccPath.back() == '\n' || libgccPath.back() == '\r'))
-        libgccPath.pop_back();
-      auto slash = libgccPath.find_last_of('/');
-      if (slash != std::string::npos)
-        argStrings.push_back("-L" + libgccPath.substr(0, slash));
-    }
-    pclose(fp);
-  }
-  for (const char *sysLib : {"stdc++", "m", "gcc_s", "gcc", "c"})
-    argStrings.push_back(std::string("-l") + sysLib);
-
-  // CRT epilogue: must come AFTER user libs (the symbols crtendS.o / crtn.o
-  // provide bracket .init_array / .fini_array / _init / _fini).
-  if (!crtendS.empty())
-    argStrings.push_back(crtendS);
-  if (!crtn.empty())
-    argStrings.push_back(crtn);
-
-  // Add default flags
-  argStrings.push_back("--export-dynamic"); // Export all symbols by default
-  argStrings.push_back("--no-undefined");   // Error on undefined symbols
-
-  // Convert to C-style args for LLD
-  std::vector<const char *> args;
-  for (const auto &arg : argStrings) {
-    args.push_back(arg.c_str());
-  }
-
-  // Invoke ld.lld as a SUBPROCESS rather than via lld::lldMain.
-  //
-  // Why: when libhip-compiler.so (which statically links lldELF) is loaded
-  // into a long-lived host process via dlopen — exactly the path the
-  // MorphiZen EP takes — lld::lldMain writes the .so output successfully
-  // but then segfaults during its internal cleanup (likely a static-state
-  // / atexit / llvm_shutdown interaction with the host process). The
-  // crash happens AFTER the artifact is on disk, so the link "worked" but
-  // the EP never sees a successful return. The same args invoked via the
-  // ld.lld binary subprocess complete cleanly. Windows lldMain (lld-link
-  // / COFF driver) does not exhibit this and stays on the in-process path.
-  //
-  // ld.lld discovery: HIPDNN_LD_LLD_PATH is baked at configure time
-  // (lib/Target/LLVM/CMakeLists.txt). PATH lookup is the fallback so the
-  // build still works in environments that don't have llvm-XX-dev's
-  // ld.lld at the discovered location.
-  std::string ldLldPath;
-#ifdef HIPDNN_LD_LLD_PATH
-  ldLldPath = HIPDNN_LD_LLD_PATH;
+  // The Windows path (linkDLL_Windows) does not have this issue because
+  // lld-link (COFF driver) cleans up safely in-process; we keep that on
+  // lld::lldMain.
+  // Use the clang++ driver flavor — it auto-pulls libstdc++ (which provides
+  // __cxa_begin_catch / __cxa_rethrow / __cxa_end_catch / etc. that the
+  // generated model object pulls in via std::string / std::unordered_map).
+  // The bare `clang` driver only links libc and would error with
+  // "undefined symbol: __cxa_*" on every model.
+  std::string clangPath;
+#ifdef HIPDNN_CLANG_PATH
+  clangPath = HIPDNN_CLANG_PATH;
 #endif
-  if (ldLldPath.empty() || !llvm::sys::fs::exists(ldLldPath)) {
-    auto found = llvm::sys::findProgramByName("ld.lld");
+  if (clangPath.empty() || !llvm::sys::fs::exists(clangPath)) {
+    auto found = llvm::sys::findProgramByName("clang++");
     if (!found) {
-      llvm::errs() << "ld.lld not found on PATH and HIPDNN_LD_LLD_PATH "
-                      "is unset. Install lld or rebuild with a working "
-                      "find_program(ld.lld).\n";
+      llvm::errs() << "clang++ not found on PATH and HIPDNN_CLANG_PATH is "
+                      "unset or stale. Install clang (e.g. apt install "
+                      "clang-22) or rebuild with HIPDNN_CLANG_PATH "
+                      "pointing to a valid clang++ binary.\n";
       return false;
     }
-    ldLldPath = *found;
+    clangPath = *found;
   }
 
-  // Skip argv[0] ("ld.lld" — the program name) when handing args to
-  // ExecuteAndWait. The first element of the new argv is the path itself.
-  std::vector<llvm::StringRef> execArgs;
-  execArgs.reserve(argStrings.size());
-  execArgs.emplace_back(ldLldPath);
-  for (size_t i = 1; i < argStrings.size(); ++i)
-    execArgs.emplace_back(argStrings[i]);
+  std::vector<std::string> args = {clangPath, "-shared", "-fuse-ld=lld",
+                                   "-o",      outputDLL, objectFile};
+  for (const auto &p : libraryPaths)
+    args.push_back("-L" + p);
+  // --start-group bracket: user archives may mutually reference each other
+  // (e.g. libhip_custom_kernels.a pulls libstdc++ symbols that another
+  // user archive also references). Cheap on a final shared link.
+  args.push_back("-Wl,--start-group");
+  for (const auto &lib : libraries) {
+    // Mirror the Windows path: callers pass either bare names ("MIOpen")
+    // or absolute paths to archives/.so files. `-l/abs/path` is malformed
+    // for ld; absolute paths go through as positional args.
+    if (lib.find('/') != std::string::npos)
+      args.push_back(lib);
+    else
+      args.push_back("-l" + lib);
+  }
+  args.push_back("-Wl,--end-group");
+  for (const auto &p : libraryPaths)
+    args.push_back("-Wl,-rpath," + p);
+  args.push_back("-Wl,--export-dynamic");
+  args.push_back("-Wl,--no-undefined");
 
+  COMPILER_DEBUG_LOG("clang -shared command (" << args.size() << " args):\n");
+  for (size_t i = 0; i < args.size(); ++i) {
+    COMPILER_DEBUG_LOG("  [" << i << "]='" << args[i] << "'\n");
+  }
+
+  std::vector<llvm::StringRef> execArgs(args.begin(), args.end());
   std::string errMsg;
   bool execFailed = false;
-  int rc = llvm::sys::ExecuteAndWait(ldLldPath, execArgs,
+  int rc = llvm::sys::ExecuteAndWait(clangPath, execArgs,
                                      /*Env=*/std::nullopt,
                                      /*Redirects=*/{},
                                      /*SecondsToWait=*/0,
                                      /*MemoryLimit=*/0, &errMsg, &execFailed);
   if (execFailed || rc != 0) {
-    llvm::errs() << "ld.lld failed (rc=" << rc << "): " << errMsg << "\n";
+    llvm::errs() << "clang -shared failed (rc=" << rc << "): " << errMsg
+                 << "\n";
     return false;
   }
 

--- a/lib/Target/LLVM/DLLLinker.cpp
+++ b/lib/Target/LLVM/DLLLinker.cpp
@@ -8,6 +8,7 @@
 #include <llvm/Support/FileSystem.h>
 #include <llvm/Support/MemoryBuffer.h>
 #include <llvm/Support/Path.h>
+#include <llvm/Support/Program.h>
 #include <llvm/Support/raw_ostream.h>
 
 #include "hip/debug_log.h"
@@ -246,16 +247,79 @@ bool DLLLinker::linkDLL_Windows(const std::string &objectFile,
 
 #else // Linux
 
+// Resolve a gcc-managed file (crtbeginS.o, libgcc.a, ...) via
+// `gcc -print-file-name=<name>`. Returns empty string if gcc isn't on PATH
+// or returns the input unchanged (gcc's "not found" convention).
+static std::string gccPrintFileName(const char *name) {
+  std::string cmd =
+      std::string("gcc -print-file-name=") + name + " 2>/dev/null";
+  FILE *fp = popen(cmd.c_str(), "r");
+  if (!fp)
+    return {};
+  char buf[1024];
+  std::string result;
+  if (fgets(buf, sizeof(buf), fp))
+    result = buf;
+  pclose(fp);
+  while (!result.empty() && (result.back() == '\n' || result.back() == '\r'))
+    result.pop_back();
+  // gcc returns the input verbatim when it can't find the file; treat that
+  // as "not found" so callers don't pass nonsense paths to the linker.
+  if (result == name)
+    return {};
+  return result;
+}
+
 bool DLLLinker::linkDLL_Linux(const std::string &objectFile,
                               const std::string &outputDLL,
                               const std::vector<std::string> &libraries,
                               const std::vector<std::string> &libraryPaths) {
+  // Resolve gcc CRT objects up-front so the link line below stays linear.
+  // These bracket the user object files and provide the per-DSO startup +
+  // teardown glue that `clang`/`gcc` driver normally injects but we have to
+  // do by hand because we invoke ld.lld directly. Specifically:
+  //
+  //   crti.o       — opens _init / _fini function bodies (sentinel pair
+  //                  with crtn.o). Strictly only needed when the DLL has
+  //                  DT_INIT/DT_FINI, but harmless when paired with crtn.o.
+  //   crtbeginS.o  — provides __dso_handle and __do_global_dtors_aux. The
+  //                  init_array entry from this object registers
+  //                  __cxa_atexit(__do_global_dtors_aux, ..., __dso_handle)
+  //                  at load time so glibc has a hook to call when the DLL
+  //                  is dlclose'd (the .fini_array reciprocal then walks
+  //                  __cxa_finalize(&__dso_handle) and drains the
+  //                  per-DSO destructor list).
+  //   crtendS.o    — terminator counterpart for crtbeginS.o (closes the
+  //                  .init_array / .fini_array sections).
+  //   crtn.o       — closes _init / _fini bodies started by crti.o.
+  //
+  // Without crtbeginS.o + crtendS.o the model DLL has an empty (or missing)
+  // .fini_array, so dlclose never invokes __cxa_finalize for the DLL. C++
+  // global destructors stay registered in the global atexit list with
+  // function pointers that point into the just-unmapped DLL. When libc's
+  // exit() walks that list, it hits an unmapped PC and SIGSEGV's. See the
+  // "S" variant of each object: those are the shared-library / PIC ones
+  // (crtbegin.o vs crtbeginS.o etc.).
+  const std::string crti = gccPrintFileName("crti.o");
+  const std::string crtbeginS = gccPrintFileName("crtbeginS.o");
+  const std::string crtendS = gccPrintFileName("crtendS.o");
+  const std::string crtn = gccPrintFileName("crtn.o");
+
   // Build LLD-ELF command line arguments for shared library
   std::vector<std::string> argStrings;
   argStrings.push_back("ld.lld");  // Program name (required by LLD)
   argStrings.push_back("-shared"); // Create shared library
   argStrings.push_back("-o");
   argStrings.push_back(outputDLL);
+
+  // CRT prologue: must precede the user objects so the .init_array entries
+  // contributed by crtbeginS.o land before our _GLOBAL__sub_I_* ctors.
+  if (!crti.empty())
+    argStrings.push_back(crti);
+  if (!crtbeginS.empty())
+    argStrings.push_back(crtbeginS);
+
+  // User object file (the per-model bitcode after LLVM codegen).
   argStrings.push_back(objectFile);
 
   // Add library paths
@@ -263,9 +327,18 @@ bool DLLLinker::linkDLL_Linux(const std::string &objectFile,
     argStrings.push_back("-L" + libPath);
   }
 
-  // Add libraries
+  // Add libraries. Mirror the Windows path's behaviour: callers can pass
+  // either bare names ("MIOpen" -> "-lMIOpen") or absolute paths to a
+  // specific archive/.so (e.g. install-prefix paths to
+  // libhip_custom_kernels.a). Bare-`-l/abs/path` is a malformed lld arg that
+  // fails with "unable to find library -l/abs/path" — pass full paths as
+  // positional args.
   for (const auto &lib : libraries) {
-    argStrings.push_back("-l" + lib);
+    if (lib.find('/') != std::string::npos) {
+      argStrings.push_back(lib);
+    } else {
+      argStrings.push_back("-l" + lib);
+    }
   }
 
   // Add RPATH for runtime library search
@@ -273,6 +346,48 @@ bool DLLLinker::linkDLL_Linux(const std::string &objectFile,
     argStrings.push_back("-rpath");
     argStrings.push_back(libPath);
   }
+
+  // Add system library search paths + standard C/C++ runtime libraries.
+  //
+  // We invoke ld.lld directly (via lld::lldMain) for crash-recovery, so unlike
+  // a clang/gcc driver invocation NOTHING auto-pulls libc/libstdc++/libgcc.
+  // The runtime bitcode (std::chrono, operator new, ...) and the custom-kernel
+  // archive (fprintf/memcpy/__cxa_guard_acquire/...) reference dozens of libc
+  // and libstdc++ symbols; without these the link fails with hundreds of
+  // "undefined symbol" errors. The Windows path solves the same problem by
+  // explicitly adding msvcrt.lib/ucrt.lib/vcruntime.lib above. This is the
+  // ELF analogue.
+  //
+  // Multiarch path is hard-coded to x86_64-linux-gnu (the only Linux target
+  // we currently support). The gcc internal libdir (libgcc.a, crtbeginS.o)
+  // is discovered by parsing `gcc --print-libgcc-file-name` so we don't have
+  // to hard-code the gcc version. On glibc 2.34+ libpthread/libdl/librt are
+  // merged into libc, so they're omitted (would error "unable to find
+  // -lpthread" because the .so files are gone).
+  argStrings.push_back("-L/usr/lib/x86_64-linux-gnu");
+  argStrings.push_back("-L/lib/x86_64-linux-gnu");
+  if (FILE *fp = popen("gcc --print-libgcc-file-name 2>/dev/null", "r")) {
+    char buf[1024];
+    if (fgets(buf, sizeof(buf), fp)) {
+      std::string libgccPath(buf);
+      while (!libgccPath.empty() &&
+             (libgccPath.back() == '\n' || libgccPath.back() == '\r'))
+        libgccPath.pop_back();
+      auto slash = libgccPath.find_last_of('/');
+      if (slash != std::string::npos)
+        argStrings.push_back("-L" + libgccPath.substr(0, slash));
+    }
+    pclose(fp);
+  }
+  for (const char *sysLib : {"stdc++", "m", "gcc_s", "gcc", "c"})
+    argStrings.push_back(std::string("-l") + sysLib);
+
+  // CRT epilogue: must come AFTER user libs (the symbols crtendS.o / crtn.o
+  // provide bracket .init_array / .fini_array / _init / _fini).
+  if (!crtendS.empty())
+    argStrings.push_back(crtendS);
+  if (!crtn.empty())
+    argStrings.push_back(crtn);
 
   // Add default flags
   argStrings.push_back("--export-dynamic"); // Export all symbols by default
@@ -284,29 +399,54 @@ bool DLLLinker::linkDLL_Linux(const std::string &objectFile,
     args.push_back(arg.c_str());
   }
 
-  // Call LLD linker library
-  std::string stdoutStr, stderrStr;
-  llvm::raw_string_ostream stdoutOS(stdoutStr);
-  llvm::raw_string_ostream stderrOS(stderrStr);
-
-  // Use lldMain for crash recovery instead of direct link() call
-  lld::Result result =
-      lld::lldMain(args, stdoutOS, stderrOS, {{lld::Gnu, &lld::elf::link}}
-                   // Register ELF driver
-      );
-
-  if (!stdoutStr.empty()) {
-    COMPILER_DEBUG_LOG(stdoutStr);
-  }
-  if (!stderrStr.empty()) {
-    llvm::errs() << stderrStr;
-  }
-
-  if (result.retCode != 0) {
-    llvm::errs() << "LLD-ELF failed with exit code: " << result.retCode << "\n";
-    if (!result.canRunAgain) {
-      llvm::errs() << "  Warning: Linker crashed, cannot run again\n";
+  // Invoke ld.lld as a SUBPROCESS rather than via lld::lldMain.
+  //
+  // Why: when libhip-compiler.so (which statically links lldELF) is loaded
+  // into a long-lived host process via dlopen — exactly the path the
+  // MorphiZen EP takes — lld::lldMain writes the .so output successfully
+  // but then segfaults during its internal cleanup (likely a static-state
+  // / atexit / llvm_shutdown interaction with the host process). The
+  // crash happens AFTER the artifact is on disk, so the link "worked" but
+  // the EP never sees a successful return. The same args invoked via the
+  // ld.lld binary subprocess complete cleanly. Windows lldMain (lld-link
+  // / COFF driver) does not exhibit this and stays on the in-process path.
+  //
+  // ld.lld discovery: HIPDNN_LD_LLD_PATH is baked at configure time
+  // (lib/Target/LLVM/CMakeLists.txt). PATH lookup is the fallback so the
+  // build still works in environments that don't have llvm-XX-dev's
+  // ld.lld at the discovered location.
+  std::string ldLldPath;
+#ifdef HIPDNN_LD_LLD_PATH
+  ldLldPath = HIPDNN_LD_LLD_PATH;
+#endif
+  if (ldLldPath.empty() || !llvm::sys::fs::exists(ldLldPath)) {
+    auto found = llvm::sys::findProgramByName("ld.lld");
+    if (!found) {
+      llvm::errs() << "ld.lld not found on PATH and HIPDNN_LD_LLD_PATH "
+                      "is unset. Install lld or rebuild with a working "
+                      "find_program(ld.lld).\n";
+      return false;
     }
+    ldLldPath = *found;
+  }
+
+  // Skip argv[0] ("ld.lld" — the program name) when handing args to
+  // ExecuteAndWait. The first element of the new argv is the path itself.
+  std::vector<llvm::StringRef> execArgs;
+  execArgs.reserve(argStrings.size());
+  execArgs.emplace_back(ldLldPath);
+  for (size_t i = 1; i < argStrings.size(); ++i)
+    execArgs.emplace_back(argStrings[i]);
+
+  std::string errMsg;
+  bool execFailed = false;
+  int rc = llvm::sys::ExecuteAndWait(ldLldPath, execArgs,
+                                     /*Env=*/std::nullopt,
+                                     /*Redirects=*/{},
+                                     /*SecondsToWait=*/0,
+                                     /*MemoryLimit=*/0, &errMsg, &execFailed);
+  if (execFailed || rc != 0) {
+    llvm::errs() << "ld.lld failed (rc=" << rc << "): " << errMsg << "\n";
     return false;
   }
 

--- a/lib/Target/LLVM/DLLLinker.cpp
+++ b/lib/Target/LLVM/DLLLinker.cpp
@@ -16,12 +16,14 @@
 #include <fstream>
 #include <sstream>
 
-// LLD linker driver - use lldMain for crash recovery
+// In-process lld is only used by linkDLL_Windows (COFF). Linux uses a
+// subprocess `clang++ -shared -fuse-ld=lld` instead (see linkDLL_Linux for
+// the reason), so the ELF driver and lld::lldMain pull-in are scoped to
+// _WIN32 to keep the Linux build free of liblldELF / liblldCommon link deps.
+#ifdef _WIN32
 #include "lld/Common/Driver.h"
-
-// Still need to declare the link functions for driver registration
 LLD_HAS_DRIVER(coff)
-LLD_HAS_DRIVER(elf)
+#endif
 
 namespace hipdnn {
 

--- a/lib/Target/LLVM/DLLLinker.cpp
+++ b/lib/Target/LLVM/DLLLinker.cpp
@@ -253,27 +253,13 @@ bool DLLLinker::linkDLL_Linux(const std::string &objectFile,
                               const std::string &outputDLL,
                               const std::vector<std::string> &libraries,
                               const std::vector<std::string> &libraryPaths) {
-  // Driver-mediated link: clang -shared owns crt selection, sysroot,
-  // multiarch -L, libgcc -L, sys-lib ordering, the glibc 2.34
-  // libpthread/libdl merge, and the start/end-group bracket around its own
-  // implicit libs. We only pass user objects + user libs + rpath, and let
-  // clang generate the right argv for ld.lld.
-  //
-  // Subprocess (not in-process lld::lldMain) because lld::lldMain SIGSEGV's
-  // during its post-output cleanup when libhip-compiler.so is loaded into
-  // a long-lived host process via dlopen — exactly the path the MorphiZen
-  // EP takes. The .so is on disk by then, but lldMain's exit path corrupts
-  // host state. clang -shared invokes ld.lld in its own child process and
-  // exits cleanly because there is no host state to corrupt.
-  //
-  // The Windows path (linkDLL_Windows) does not have this issue because
-  // lld-link (COFF driver) cleans up safely in-process; we keep that on
-  // lld::lldMain.
-  // Use the clang++ driver flavor — it auto-pulls libstdc++ (which provides
-  // __cxa_begin_catch / __cxa_rethrow / __cxa_end_catch / etc. that the
-  // generated model object pulls in via std::string / std::unordered_map).
-  // The bare `clang` driver only links libc and would error with
-  // "undefined symbol: __cxa_*" on every model.
+  // Delegate to `clang++ -shared` driver subprocess (vs in-process
+  // lld::lldMain). Driver owns crt + sysroot + multiarch -L + libgcc + the
+  // glibc 2.34 libpthread merge. Subprocess because lldMain SIGSEGVs on
+  // its post-output cleanup when libhip-compiler.so is dlopen'd into the
+  // EP host process (Windows linkDLL_Windows stays in-process — lld-link
+  // doesn't have this cleanup bug). clang++ (not bare clang) auto-links
+  // libstdc++ for the generated object's __cxa_begin_catch / __cxa_rethrow.
   std::string clangPath;
 #ifdef HIPDNN_CLANG_PATH
   clangPath = HIPDNN_CLANG_PATH;
@@ -294,14 +280,12 @@ bool DLLLinker::linkDLL_Linux(const std::string &objectFile,
                                    "-o",      outputDLL, objectFile};
   for (const auto &p : libraryPaths)
     args.push_back("-L" + p);
-  // --start-group bracket: user archives may mutually reference each other
-  // (e.g. libhip_custom_kernels.a pulls libstdc++ symbols that another
-  // user archive also references). Cheap on a final shared link.
+  // --start-group: user archives may mutually reference each other
+  // (custom_kernels.a <-> libstdc++ via another user lib).
   args.push_back("-Wl,--start-group");
   for (const auto &lib : libraries) {
-    // Mirror the Windows path: callers pass either bare names ("MIOpen")
-    // or absolute paths to archives/.so files. `-l/abs/path` is malformed
-    // for ld; absolute paths go through as positional args.
+    // Mirror Windows: callers pass bare names or absolute paths.
+    // `-l/abs/path` is malformed for ld; abs paths go through positional.
     if (lib.find('/') != std::string::npos)
       args.push_back(lib);
     else

--- a/lib/Target/LLVM/LLVMBackend.cpp
+++ b/lib/Target/LLVM/LLVMBackend.cpp
@@ -170,6 +170,16 @@ llvm::TargetMachine *LLVMBackend::createTargetMachine() {
   std::string cpu = "generic";
   std::string features = "";
   llvm::TargetOptions options;
+  // LLVM's default is the legacy `.ctors` section for C++ global constructors.
+  // Modern glibc's dynamic loader (>= 2.x) only iterates DT_INIT_ARRAY; entries
+  // in `.ctors` are never called when the .so is dlopen'd. Without this flag,
+  // every static-storage-duration object in the generated DLL (e.g. the
+  // `std::unordered_map g_optensor_cache` in lib/Runtime/real/elementwise.cpp)
+  // stays zero-initialized BSS, and the first `unordered_map::emplace` does
+  // `hash % bucket_count(==0)` → SIGFPE on inference. Setting UseInitArray=true
+  // routes ctors into `.init_array`, matching what clang's driver does for
+  // Linux ELF targets.
+  options.UseInitArray = true;
   llvm::Reloc::Model RM =
       llvm::Reloc::PIC_; // Position-independent code for DLL
 

--- a/lib/Target/LLVM/LLVMBackend.cpp
+++ b/lib/Target/LLVM/LLVMBackend.cpp
@@ -170,15 +170,10 @@ llvm::TargetMachine *LLVMBackend::createTargetMachine() {
   std::string cpu = "generic";
   std::string features = "";
   llvm::TargetOptions options;
-  // LLVM's default is the legacy `.ctors` section for C++ global constructors.
-  // Modern glibc's dynamic loader (>= 2.x) only iterates DT_INIT_ARRAY; entries
-  // in `.ctors` are never called when the .so is dlopen'd. Without this flag,
-  // every static-storage-duration object in the generated DLL (e.g. the
-  // `std::unordered_map g_optensor_cache` in lib/Runtime/real/elementwise.cpp)
-  // stays zero-initialized BSS, and the first `unordered_map::emplace` does
-  // `hash % bucket_count(==0)` → SIGFPE on inference. Setting UseInitArray=true
-  // routes ctors into `.init_array`, matching what clang's driver does for
-  // Linux ELF targets.
+  // Route C++ static ctors into DT_INIT_ARRAY (LLVM's legacy default is the
+  // `.ctors` section which glibc's loader silently drops on dlopen,
+  // leaving every static unordered_map / string in the generated DLL at
+  // zero-init BSS → SIGFPE on first emplace's `hash % bucket_count(0)`).
   options.UseInitArray = true;
   llvm::Reloc::Model RM =
       llvm::Reloc::PIC_; // Position-independent code for DLL

--- a/lib/Target/LLVM/LLVMBackend.cpp
+++ b/lib/Target/LLVM/LLVMBackend.cpp
@@ -174,6 +174,12 @@ llvm::TargetMachine *LLVMBackend::createTargetMachine() {
   // `.ctors` section which glibc's loader silently drops on dlopen,
   // leaving every static unordered_map / string in the generated DLL at
   // zero-init BSS → SIGFPE on first emplace's `hash % bucket_count(0)`).
+  //
+  // Not an LLVM bug — `UseInitArray=false` is a backwards-compat default
+  // for legacy ELF targets that lacked .init_array. clang's own driver
+  // sets this to true for modern Linux (see clang/lib/Driver/ToolChains/
+  // Gnu.cpp), but we bypass the driver and drive the TargetMachine API
+  // directly, so we have to flip it ourselves.
   options.UseInitArray = true;
   llvm::Reloc::Model RM =
       llvm::Reloc::PIC_; // Position-independent code for DLL

--- a/test/e2e/CMakeLists.txt
+++ b/test/e2e/CMakeLists.txt
@@ -55,3 +55,36 @@ endforeach()
 
 list(LENGTH MLIR_E2E_TESTS num_tests)
 message(STATUS "Configured ${num_tests} E2E test(s)")
+
+# Linux-only: verify the per-model DLL has both DT_INIT_ARRAY and DT_FINI_ARRAY
+# populated. Without DT_INIT_ARRAY, LLVM's default UseInitArray=false routes
+# C++ static ctors into legacy .ctors which glibc's loader drops, leaving
+# every `static std::unordered_map` etc. at zero-init BSS (the first emplace
+# does `hash % 0` -> SIGFPE inside the model). Without DT_FINI_ARRAY (because
+# crtbeginS.o / crtendS.o weren't linked into the DLL), dlclose never calls
+# __cxa_finalize(&__dso_handle), so static dtors stay in libc's global atexit
+# list and crash at process exit() with stale function pointers.
+#
+# Both regressions actually shipped during the Linux port (28/28 SIGFPE in
+# inference_compute, and SIGSEGV in libc exit() after `OK - X output
+# tensor(s)`); this test catches them at the build stage, before they reach
+# a runtime crash.
+if(NOT WIN32)
+    # Three checks on the per-model DLL:
+    #   1. DT_INIT_ARRAY present (dynamic loader hook for ctors exists)
+    #   2. DT_FINI_ARRAY present (dlclose hook for dtors exists)
+    #   3. NO `.ctors` section (legacy section; if present, LLVM codegen
+    #      routed C++ static ctors there instead of .init_array — the
+    #      UseInitArray=false default that caused 28/28 SIGFPE)
+    set(_init_fini_check_dll
+        "${CMAKE_CURRENT_BINARY_DIR}/test_add_model/test_add_model.dll")
+    add_test(NAME E2E_DLL_HasInitFiniArrays
+        COMMAND ${CMAKE_COMMAND} -E env bash -c
+            "readelf -d '${_init_fini_check_dll}' | grep -q '(INIT_ARRAY)' && \
+             readelf -d '${_init_fini_check_dll}' | grep -q '(FINI_ARRAY)' && \
+             ! readelf -S '${_init_fini_check_dll}' | grep -q '\\.ctors '"
+    )
+    set_tests_properties(E2E_DLL_HasInitFiniArrays PROPERTIES
+        DEPENDS E2E_Compile_test_add_model
+    )
+endif()

--- a/test/e2e/CMakeLists.txt
+++ b/test/e2e/CMakeLists.txt
@@ -56,26 +56,15 @@ endforeach()
 list(LENGTH MLIR_E2E_TESTS num_tests)
 message(STATUS "Configured ${num_tests} E2E test(s)")
 
-# Linux-only: verify the per-model DLL has both DT_INIT_ARRAY and DT_FINI_ARRAY
-# populated. Without DT_INIT_ARRAY, LLVM's default UseInitArray=false routes
-# C++ static ctors into legacy .ctors which glibc's loader drops, leaving
-# every `static std::unordered_map` etc. at zero-init BSS (the first emplace
-# does `hash % 0` -> SIGFPE inside the model). Without DT_FINI_ARRAY (because
-# crtbeginS.o / crtendS.o weren't linked into the DLL), dlclose never calls
-# __cxa_finalize(&__dso_handle), so static dtors stay in libc's global atexit
-# list and crash at process exit() with stale function pointers.
-#
-# Both regressions actually shipped during the Linux port (28/28 SIGFPE in
-# inference_compute, and SIGSEGV in libc exit() after `OK - X output
-# tensor(s)`); this test catches them at the build stage, before they reach
-# a runtime crash.
+# Linux-only build-stage regression check for two ELF-init bugs that
+# actually shipped during the Linux port:
+#   1. DT_INIT_ARRAY missing  -> static ctors silently never run -> SIGFPE
+#      on first emplace into a zero-init `static std::unordered_map`.
+#   2. DT_FINI_ARRAY missing  -> dlclose can't drain __cxa_finalize ->
+#      SIGSEGV at process exit walking stale dtor pointers.
+# Plus a no-`.ctors` check: a populated .ctors section means LLVM
+# regressed back to UseInitArray=false (bug 1 above).
 if(NOT WIN32)
-    # Three checks on the per-model DLL:
-    #   1. DT_INIT_ARRAY present (dynamic loader hook for ctors exists)
-    #   2. DT_FINI_ARRAY present (dlclose hook for dtors exists)
-    #   3. NO `.ctors` section (legacy section; if present, LLVM codegen
-    #      routed C++ static ctors there instead of .init_array — the
-    #      UseInitArray=false default that caused 28/28 SIGFPE)
     set(_init_fini_check_dll
         "${CMAKE_CURRENT_BINARY_DIR}/test_add_model/test_add_model.dll")
     add_test(NAME E2E_DLL_HasInitFiniArrays

--- a/tools/hip-onnx-runner/hip-onnx-runner.cpp
+++ b/tools/hip-onnx-runner/hip-onnx-runner.cpp
@@ -48,6 +48,7 @@ Options:
 #include <random>
 #include <set>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #if _WIN32
@@ -870,16 +871,45 @@ int main(int argc, char *argv[]) {
   Ort::Env env(ORT_LOGGING_LEVEL_ERROR, "hip-onnx-runner");
 
   const std::string kEpName = "MorphiZenExecutionProvider";
-  const std::string ep_dll = "onnxruntime_morphizen_ep.dll";
+#ifdef _WIN32
+  const std::string ep_lib_name = "onnxruntime_morphizen_ep.dll";
+#else
+  const std::string ep_lib_name = "libonnxruntime_morphizen_ep.so";
+#endif
 
   if (!no_ep) {
-    auto lib_path = std::filesystem::u8path(ep_dll);
-    if (!std::filesystem::exists(lib_path)) {
-      std::cerr << "EP library not found: " << ep_dll << "\n"
-                << "Set MORPHIZEN_VITISAI_EP or use -n.\n";
+    // Search order: $MORPHIZEN_EP_LIB (full path), then cwd, then sibling
+    // dirs of the runner exe (../lib for the install layout, same dir for a
+    // single-folder drop). First hit wins.
+    std::filesystem::path lib_path;
+    if (const char *env_lib = std::getenv("MORPHIZEN_EP_LIB");
+        env_lib && *env_lib) {
+      lib_path = std::filesystem::u8path(env_lib);
+    } else {
+      std::vector<std::filesystem::path> candidates{
+          std::filesystem::u8path(ep_lib_name),
+      };
+      std::error_code ec;
+      auto exe_dir = std::filesystem::weakly_canonical(
+                         std::filesystem::u8path(argv[0]), ec)
+                         .parent_path();
+      if (!ec && !exe_dir.empty()) {
+        candidates.push_back(exe_dir / ep_lib_name);
+        candidates.push_back(exe_dir.parent_path() / "lib" / ep_lib_name);
+      }
+      for (const auto &p : candidates) {
+        if (std::filesystem::exists(p)) {
+          lib_path = p;
+          break;
+        }
+      }
+    }
+    if (lib_path.empty() || !std::filesystem::exists(lib_path)) {
+      std::cerr << "EP library not found: " << ep_lib_name << "\n"
+                << "Set MORPHIZEN_EP_LIB to its full path, or use -n.\n";
       return 1;
     }
-    std::cout << "Registering EP: " << ep_dll << "\n";
+    std::cout << "Registering EP: " << lib_path.string() << "\n";
     auto *status = Ort::GetApi().RegisterExecutionProviderLibrary(
         env, kEpName.c_str(), lib_path.c_str());
     if (status) {
@@ -911,7 +941,14 @@ int main(int argc, char *argv[]) {
     }
     std::cout << "Found " << devices.size() << " EP device(s)\n";
 
-    session_opts.AppendExecutionProvider_V2(env, devices, {});
+    // ORT >=1.24 added an AppendExecutionProvider_V2 overload that accepts
+    // Ort::KeyValuePairs alongside the legacy std::unordered_map<string,string>
+    // version. Passing a brace-init `{}` is ambiguous against both candidates
+    // on the prebuilt Linux ORT package we ship here. Spell out the map type
+    // so we always bind to the original overload and stay compatible with the
+    // older ORT version we still link against on Windows.
+    session_opts.AppendExecutionProvider_V2(
+        env, devices, std::unordered_map<std::string, std::string>{});
     session_opts.AddConfigEntry("session.disable_cpu_ep_fallback", "1");
   }
 


### PR DESCRIPTION
## Problem

`onnx-hipdnn-ep` was effectively Windows-only on the runtime side: the Linux Llama-3.1-8B / GPT-OSS-20B end-to-end LLM serving path was never green. Three classes of blockers prevented a usable Linux port — **P-1 is the primary one** (without it the runtime simply crashes), P-2 and P-3 made the port unmaintainable even if P-1 had been fixed ad-hoc.

**P-1: Runtime SIGFPE / SIGSEGV after a clean compile**

Even after the EP `.so` builds and `hip-compiler` emits a per-model DLL:

1. First `unordered_map::emplace(...)` inside `wrap_miopenOpTensor` raises **SIGFPE** because every C++ static object in the per-model DLL is zero-init BSS. Root cause: LLVM's default `TargetOptions::UseInitArray=false` routes static ctors into the legacy `.ctors` section; modern glibc's loader only walks `DT_INIT_ARRAY` on dlopen and silently drops `.ctors`. `static std::unordered_map g_optensor_cache` (`lib/Runtime/real/elementwise.cpp`) has `bucket_count=0`, so `_M_emplace` does `hash % 0`.
2. `hip-onnx-runner` then **SIGSEGV**s in libc's `exit()` chain immediately after `OK - <N> output tensor(s)` prints. Root cause: per-model DLL had no `.fini_array` because the initial Linux link line invoked `ld.lld` directly without `crtbeginS.o` / `crtendS.o`, so dlclose never called `__cxa_finalize(&__dso_handle)`. C++ static dtors stayed in libc's global atexit list with function pointers into the just-unmapped DLL.

P-1 impact: ctest E2E_Execute **0/28** pass (28 SIGFPE in `inference_compute`); OGA model_benchmark hits the same code path.

**P-2: EP build chain has multiple ELF / dlopen specific landmines**

- `dll/CMakeLists.txt` was wired for the Windows `DllMain` model. On Linux, `dll_main.cpp`'s body is empty; nothing references the C-API symbols (`hip_get_version`, `hip_compile_with_fs`) — `ld` drops the entire archive and produces an empty `.so`. EP dlopens the .so successfully and then aborts at `dlsym("hip_get_version")` with `undefined symbol`.
- Runtime bitcode wasn't compiled `-fPIC`; lld rejects the `R_X86_64_PC32` relocs the Itanium ABI emits against function-local static guard variables.
- `hipblaslt` ships natively as `libhipblaslt.so` on Linux (vs `.lib` on MSVC, `.dll.a` on cross-compile); `CompilerDriver::discoverLibraries` only knew the two Windows flavours.
- An in-process `lld::lldMain` ELF link invoked from a long-lived host (the MorphiZen EP dlopens libhip-compiler.so) SIGSEGV'd during lld's static-state cleanup. The artifact was written but the EP never saw a successful return.
- Driving `ld.lld` directly bypassed every compiler driver — nothing pulled in libc/libstdc++/libgcc, and manually wiring `crt{i,beginS,endS,n}.o` via `gcc -print-file-name` plus a sys-lib list was fragile across distros (multiarch path, libgcc internal dir, hard-coded `x86_64-linux-gnu`).

**P-3: No reproducible Linux dev environment; no Linux quick-start docs**

- Linux developers had to derive the build sequence from scratch (apt LLVM 22 + MLIR + LLD, TheRock SDK tarball, ORT / protobuf / flatbuffers from source) with no canonical reference, since there was no Linux CI workflow either.
- `docs/quick_start.md` was Windows-only. No equivalent guide for Linux developers (who would build from source) or Linux testers (who would download the CI artifact and run it on a GPU host).
- Bare-metal deploy of the CI artifact silently fails for users not in the host `render` group: `/dev/kfd` is `crw-rw---- root:render`, so `hipGetDeviceCount` returns 0 with no clear error.

## Solution

P-1 needed two surgical fixes that took deep `gdb` / `readelf` debugging to locate. P-2 needed scattered platform-specific guards across the EP build system. P-3's answer is to make Docker the single Linux path and build a quick start that mirrors the Windows one.

```mermaid
flowchart TB
    src[".mlir input"] --> compiler["hip-compiler<br/>(LLVMBackend.cpp)"]
    compiler -->|"TargetOptions::UseInitArray=true (NEW)"| obj["per-model .o<br/>with .init_array entries"]
    obj --> linker["DLLLinker::linkDLL_Linux"]
    linker -->|"clang++ -shared -fuse-ld=lld (NEW)<br/>driver pulls in crt{i,beginS,endS,n}.o<br/>+ libstdc++ / libgcc_s / libc"| dll[".so with valid __dso_handle<br/>+ DT_INIT_ARRAY + DT_FINI_ARRAY"]
    dll --> dlopen["EP dlopens the model .so"]
    dlopen --> exec["inference_compute<br/>(ctors ran -> hash table works)"]
    exec --> dlclose["EP dlcloses the model .so"]
    dlclose -->|"__cxa_finalize drains per-DSO dtors"| clean["exit 0"]
```

**For P-1.1 (SIGFPE on `_M_emplace`)** — [`lib/Target/LLVM/LLVMBackend.cpp::createTargetMachine`](lib/Target/LLVM/LLVMBackend.cpp) sets

```cpp
llvm::TargetOptions options;
options.UseInitArray = true;
```

before `target->createTargetMachine(...)`. This flips LLVM codegen for the model DLL from `.ctors` to `.init_array`. Found by `gdb`-attaching the SIGFPE, observing `_M_emplace` PC, then `readelf -S model.dll` showing `.ctors` populated with relocations to `_GLOBAL__sub_I_*.cpp` but only `__hip_module_ctor` wired into `.init_array`. Setting the option is a no-op on Windows COFF (it uses `.CRT$XCU` either way), so the change is unguarded.

**For P-1.2 (SIGSEGV in `exit()`)** — [`lib/Target/LLVM/DLLLinker.cpp::linkDLL_Linux`](lib/Target/LLVM/DLLLinker.cpp) invokes `clang++ -shared -fuse-ld=lld` as a subprocess via `llvm::sys::ExecuteAndWait`. The clang driver owns CRT object selection (`crtbeginS.o` / `crtendS.o` / `crti.o` / `crtn.o`), sysroot lookup, multiarch `-L` paths, the libgcc internal directory, libstdc++ pickup, and the glibc 2.34 libpthread/libdl merge. Our link line passes only user objects + user libs + rpath, wrapped in `--start-group / --end-group`, plus `--no-undefined`:

```
clang++ -shared -fuse-ld=lld -o out.so user.o \
    -L... -Wl,--start-group -lUser1 -lUser2 -Wl,--end-group \
    -Wl,-rpath,... -Wl,--export-dynamic -Wl,--no-undefined
```

`crtbeginS.o` (auto-linked by clang) provides `__dso_handle` and the `__cxa_atexit(__do_global_dtors_aux, ..., __dso_handle)` registration that lands in `.init_array`. `crtendS.o` is its terminator and seeds `.fini_array`. After this, dlclose properly drains the per-DLL atexit list via `__cxa_finalize(&__dso_handle)` before the DLL is unmapped.

Two intermediate approaches were prototyped and discarded along the way: in-process `lld::lldMain` (writes the artifact, then SIGSEGVs during lld's static-state cleanup when libhip-compiler.so is dlopened from a long-lived EP host) and subprocess `ld.lld` with explicit `gcc -print-file-name=crt*.o` resolution + manual `-lc -lstdc++ -lgcc_s -lgcc -lm` (~70 lines of platform/distro-specific CRT and sys-lib wiring; fragile across multiarch paths, libgcc internal dir, and glibc 2.34's libpthread/libdl merge). Going through `clang++` as a subprocess collapses all of that into the driver, which knows the layout for every distro it was built for, and sidesteps the lld cleanup bug because the linker runs in its own child process with no host state to corrupt.

A new ctest `E2E_DLL_HasInitFiniArrays` (`test/e2e/CMakeLists.txt`, Linux only) regresses both P-1.1 and P-1.2 at the build stage by `readelf`-ing the per-model DLL for `DT_INIT_ARRAY` present, `DT_FINI_ARRAY` present, and `.ctors` section absent.

**For P-2 (build-chain ELF/dlopen landmines)** — surgical changes scoped to platform paths:

| File | Change | Why |
|------|--------|-----|
| `dll/CMakeLists.txt` | `LINK_LIBRARY:WHOLE_ARCHIVE,HipCInterface` | Empty `dll_main.cpp` on Linux otherwise lets ld drop the archive entirely. |
| `lib/Runtime/CMakeLists.txt` | `list(APPEND COMPILE_FLAGS -fPIC)` (Linux only) | Bitcode later lands in a `.so`; Itanium ABI static guard relocs need PIC. |
| `lib/Compiler/CompilerDriver.cpp` | Recognise `libhipblaslt.so` | Native Linux flavour next to `.lib` / `.dll.a`. |
| `lib/Target/LLVM/DLLLinker.cpp` | Subprocess `clang++ -shared -fuse-ld=lld` (see above) | Driver-mediated link sidesteps in-process lld cleanup SIGSEGV and bypasses manual CRT / sys-lib wiring. |
| `lib/Target/LLVM/CMakeLists.txt` | `find_program(HIPDNN_CLANG_EXECUTABLE)` → baked `HIPDNN_CLANG_PATH` macro | Runtime link does not depend on PATH (the EP host process may not include the llvm-XX bin dir). |
| `tools/hip-onnx-runner/hip-onnx-runner.cpp` | `MORPHIZEN_EP_LIB` env → cwd → `<exe-dir>/lib*` → `<exe-dir>/../lib/lib*` search order; optional `MORPHIZEN_CONFIG` injection | Mirrors install layout; users don't have to cd into install/lib before running. |
| `3rd-party/morphizen` submodule pointer → tip of `feat/linux-support` (ROCm/MorphiZen#214) | `Plugin::guess_name` treats paths containing `/` as filesystem paths (no spurious `lib/` prefix); `open_plugin_dyn` surfaces `dlerror()` when `MORPHIZEN_DEBUG=1`; `MorphiZenEP` ctor zero-inits the `OrtEp{}` C-API base; generated `morphizen/*.pb.h` BINARY_DIR marked `SYSTEM` so the protobuf >=22 `Map::size()->int` narrowing no longer trips `-Werror -Wconversion` in any morphizen-* target | Plugin loader was rewriting `/tmp/morphizen_mlir_..._1` to `lib/tmp/...so`; dlopen failures were hidden; ORT >=1.24 reads `OrtEp::GetKernelRegistry` even when EP doesn't override it; SYSTEM marking propagates to ort-bridge / morphizen-graph via `INTERFACE_SYSTEM_INCLUDE_DIRECTORIES`, so no parent-side `MORPHIZEN_COMPILER_OPTIONS` override is needed. |

**For P-3 (dev env + docs)** — Docker-only Linux flow with two entry paths that converge on the same `$ROOT/bin/<tool>` prefix for runtime:

| Entry path | Audience | Steps | `$ROOT` |
|------------|----------|-------|---------|
| **Build from source** | developers | `./docker/run.sh build` (TheRock + ORT + protobuf + flatbuffers + this project, idempotent + `.git` guards respect user-managed checkouts) | `$WORKSPACE/install` |
| **Prebuilt CI artifact** | testers | `gh run download linux-gpu-test-package`, no rebuild | `$WORKSPACE/prebuilt/$RUN_ID` |

Both produce a `$ROOT/lib` that contains everything we build (`libonnxruntime_morphizen_ep.so`, `libhip-compiler.so`, `libonnxruntime.so*`, `libonnxruntime-genai.so*`) plus the prebuilt-local transitive `.so` set (a 2-pass `ldd` stage step in `docker/build.sh` walks the EP / CLI tools after `cmake --install` and copies any `.so` resolved out of `prebuilt-local/lib`, with a closure check that runs after OGA staging so every binary in `install/bin` and every `lib*.so*` in `install/lib` has DT_NEEDED satisfied by `install/lib` + `therock-dist/lib`). TheRock-origin libs are **not** bundled — matching the Windows artifact contract, the deploy host installs ROCm separately and exports `THEROCK_DIST`. `./docker/run.sh shell` attaches `/dev/kfd` + `/dev/dri/renderD*` and `entrypoint.sh` adds the in-container user to `/dev/kfd`'s host GID, sidestepping the host `render`-group requirement that blocks bare-metal runs.

New [`docs/quick_start_linux.md`](docs/quick_start_linux.md) mirrors [`docs/quick_start.md`](docs/quick_start.md)'s Windows structure section-for-section: `## Testing & Benchmarking` has one subsection per tool (hip-onnx-runner / onnxruntime_perf_test / model_benchmark), each with 1-2 line description + multiple invocations + Key flags table. `docs/quick_start.md` gains a 4-line `## Linux` section pointing readers to the new file; the rest of the Windows guide is untouched. The canonical apt recipe now lives in `linux-build.yml` + `docker/build.sh`.

CI (`linux-build.yml`) hardened: pin LLVM/MLIR/Polly apt versions, build ORT from source so the artifact ships `onnxruntime_perf_test`, build OGA (with `--skip_wheel`, since the Linux artifact has no ORT wheel to satisfy `import onnxruntime`) so it ships `model_benchmark` + `libonnxruntime-genai.so`, 2-pass `ldd` to bundle apt LLVM runtime libs into the artifact's `lib/`, and `actions/cache` on prebuilt-local + ORT / OGA source clones + OGA install outputs so warm CI runs stay under 20 min.

## Results

**ctest on gfx1151 (container, single `./docker/run.sh build`)** — primary validation of P-1:

| Stage | Before | After |
|-------|--------|-------|
| LIT | 1/1 | 1/1 |
| E2E_Compile (28 ops) | 28/28 | 28/28 |
| E2E_Execute (28 ops) | **0/28** (all SIGFPE in `inference_compute`) | **28/28** |
| E2E_DLL_HasInitFiniArrays (new) | — | 1/1 |
| **Total** | 29/57 | **58/58** |

**hip-onnx-runner clean exit** — P-1.2 validated:

| Model | Before | After |
|-------|--------|-------|
| `gpt-oss-20B/single_op/Add_qkv_seq128.onnx` (10 KB single-op) | exit 139 (SIGSEGV in libc `exit()`) | exit 0, inference 5.5 ms |
| `Llama-3.1-8B/single_layer_seq128.onnx` (1.45 GB sidecar) | exit 139 | exit 0, inference 45 ms |

**OGA `model_benchmark` Linux vs Windows CI baseline** — same gfx1151 silicon, identical flags to `windows-build.yml` (`-l 128 -g 128 -r 5 -w 1 -b 1 -ml -1`):

| Model | Metric | CI (Windows) | Linux (this PR) | Δ |
|-------|--------|--------------|-----------------|---|
| Llama-3.1-8B | TTFT (ms) | 134.3 | 142.8 | +6.3% |
| | Decode (tok/s) | 12.6 | 12.12 | −3.8% |
| | Peak mem | 1.22 GB | 1.73 GB | +42% |
| GPT-OSS-20B | TTFT (ms) | 184.0 | 180.6 | −1.8% |
| | Decode (tok/s) | 76.6 | 72.33 | −5.6% |
| | Peak mem | 1.33 GB | 1.90 GB | +43% |

Latency parity within ±6% on TTFT and TPS — the EP / MIOpen dispatch path is OS-agnostic on the same silicon. The Peak Memory delta is consistent +42-43% on both models, most likely glibc's `MALLOC_ARENA_MAX` default vs Windows heap allocator policy; tracked as a follow-up.

**Local verification** (container, ubuntu:24.04 + LLVM 22, gfx1151):
- `./docker/run.sh image && ./docker/run.sh build`: ~110 min cold (ORT-from-source dominates), ~17 min warm via `actions/cache` of prebuilt-local + source clones + OGA install outputs.
- `ctest -j8 --output-on-failure`: 56.45 s wall.
- model_benchmark numbers above: 5 reps each, `-w 1`.

**CI verification** (PR builds): Linux Build / Windows Build / Windows Build (Mock) / pre-commit — see Actions tab.

**Artifact layout** (output of `gh run download linux-gpu-test-package`):

```
linux-gpu-test-package/
├── bin/   hip-onnx-runner, hip-compiler, hip-mlir-opt, hip-test-dll,
│          hip-inspect-dll, onnxruntime_perf_test, model_benchmark
├── lib/   libonnxruntime_morphizen_ep.so, libhip-compiler.so,
│          libonnxruntime.so*, libonnxruntime-genai.so*,
│          libLLVM.so.22.1                  (apt.llvm.org)
└── etc/   morphizen_config.json
```

Deploy:
```bash
chmod +x bin/*
export THEROCK_DIST=/path/to/therock-dist        # host's ROCm install
export LD_LIBRARY_PATH="$PWD/lib:$THEROCK_DIST/lib"
bin/hip-onnx-runner -m MODEL.onnx
```

Works on any Ubuntu 24.04 host with a gfx1151 GPU + TheRock SDK installed + host `render`-group membership — or via `./docker/run.sh shell` to skip the host group requirement (the in-container entrypoint adds the user to `/dev/kfd`'s host GID).

**Diff scope** — ~10 unique files in the EP / runner / docker / docs surface, plus the submodule pointer bump. No Windows code paths touched; `windows-build.yml` and `gpu-perf-accuracy-test.yml` unchanged.

- EP runtime / link: `dll/CMakeLists.txt`, `lib/Compiler/CompilerDriver.cpp`, `lib/Runtime/CMakeLists.txt`, `lib/Target/LLVM/{CMakeLists.txt, DLLLinker.cpp, LLVMBackend.cpp}`, `cmake/deps.cmake` (Note block only; the submodule's SYSTEM include fix removed the need for any parent-side `MORPHIZEN_COMPILER_OPTIONS` override)
- Runner: `tools/hip-onnx-runner/hip-onnx-runner.cpp`
- Test: `test/e2e/CMakeLists.txt` (E2E_DLL_HasInitFiniArrays)
- Submodule pointer: `3rd-party/morphizen` → tip of `feat/linux-support` (ROCm/MorphiZen#214)
- Containerised dev env: `docker/{Dockerfile, build.sh, run.sh, entrypoint.sh}` (new)
- CI: `.github/workflows/linux-build.yml`
- Docs: `docs/quick_start_linux.md` (new), `docs/quick_start.md` (Linux section trimmed)

## Out of scope (separate follow-ups)

- GPU CI on a Linux self-hosted runner (would need a Linux Strix Halo box wired into GHA; `gpu-perf-accuracy-test.yml` keeps using the Windows StrixHalo runner).
- Closing the +42% Peak Mem gap via `MALLOC_ARENA_MAX=1` or jemalloc/mimalloc.
- Upstream PR to OGA: `MakeGeneratorParams` (benchmark/c/main.cpp:117) overrides `genai_config.json`'s `search.max_length` by default. We document the `-ml -1` workaround in `quick_start_linux.md` and pass it explicitly in CI invocations (mirrors `windows-build.yml`).
- Upstream PR to morphizen for `onnx-ir-imp`: same `SYSTEM` treatment for the external `onnx_proto` target's `INTERFACE_INCLUDE_DIRECTORIES` (currently kept on a narrow per-target `-Wno-error=conversion`). Only matters once `morphizen_ENABLE_ONNX_BACKEND=ON` is exercised in a CI flow; not on the hipdnn-ep critical path.

