### PR TITLE
fix(runtime): abort on workspace hipMalloc failure

### DIFF
--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -1105,7 +1105,7 @@ int hipdnn_ep_state_ensure_workspace(RuntimeState *state, size_t needed_size) {
         stderr,
         "hipdnn_ep_state_ensure_workspace: hipMalloc failed for %zu bytes\n",
         alloc_size);
-    return -1;
+    std::abort();
   }
 
   state->workspace_size = alloc_size;


### PR DESCRIPTION
In `hipdnn_ep_state_ensure_workspace`, replace `return -1;` with `std::abort();` on `hipMalloc` failure.

The shared workspace can grow into the tens of GB on long single-shot prefill (`gpt-oss-120b` at `seq_len=12200` requests ~54 GB). Returning `-1` doesn't recover anything: the JIT'd `main_graph` ignores `wrap_*` return codes and the next `wrap_hipblasLtMatmul` faults inside `libhipblaslt`'s `TensileLite::LazySingleton` with a `0xC0000005` AV a few frames later. Aborting at the source point gives a deterministic exit; `CrashHandler`'s `SIGABRT` hook still prints a `cpptrace` so the OOM is diagnosable.

Other `hipMalloc` sites in the file (init-time error flag, constants blob, mem pool, qmoe scratch) are small fixed allocs and stay on `return -1`.
