### PR TITLE
feat: add lowering for com.microsoft.PagedAttention (stub runtime)

### DIFF
--- a/test/lit/Conversion/hip-to-llvm/test_paged_attention.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_paged_attention.mlir
@@ -38,6 +38,8 @@ module {
   func.func @test_paged_attention_dynamic_query(
       %ctx: !hip.context,
       %query: memref<?x128xf16, 1>,
+      %key: memref<?x128xf16, 1>,
+      %value: memref<?x128xf16, 1>,
       %key_cache: memref<8x16x2x16xf16, 1>,
       %value_cache: memref<8x16x2x16xf16, 1>,
       %cum_seq: memref<2xi32, 1>,
@@ -45,11 +47,11 @@ module {
       %block_table: memref<1x8xi32, 1>,
       %output: memref<?x128xf16, 1>) {
     hip.paged_attention(%ctx)
-        ins(%query, %key_cache, %value_cache, %cum_seq, %past_seqlens,
-            %block_table :
-            memref<?x128xf16, 1>, memref<8x16x2x16xf16, 1>,
-            memref<8x16x2x16xf16, 1>, memref<2xi32, 1>, memref<1xi32, 1>,
-            memref<1x8xi32, 1>)
+        ins(%query, %key, %value, %key_cache, %value_cache, %cum_seq,
+            %past_seqlens, %block_table :
+            memref<?x128xf16, 1>, memref<?x128xf16, 1>, memref<?x128xf16, 1>,
+            memref<8x16x2x16xf16, 1>, memref<8x16x2x16xf16, 1>,
+            memref<2xi32, 1>, memref<1xi32, 1>, memref<1x8xi32, 1>)
         outs(%output : memref<?x128xf16, 1>)
         {num_heads = 4 : i64, kv_num_heads = 2 : i64}
     return

--- a/test/lit/Conversion/onnx-to-hip/test_paged_attention.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_paged_attention.mlir
@@ -35,8 +35,9 @@ module {
 
     // CHECK: tensor.empty() : tensor<4x128xf16>
     // CHECK: hip.paged_attention(%[[CTX]])
-    // CHECK-SAME: num_heads = 4
+    // Attributes printed in alphabetical order by MLIR's attr-dict printer.
     // CHECK-SAME: kv_num_heads = 2
+    // CHECK-SAME: num_heads = 4
     // CHECK-NOT: onnx.Custom
 
     return %0 : tensor<4x128xf16>


### PR DESCRIPTION
## Motivation

Graphs that contain `com.microsoft.PagedAttention` (vLLM-style paged KV attention) currently fail to compile because no MLIR plumbing exists for that op. This PR wires the op end-to-end through the compiler pipeline so such models can be lowered, linked, and loaded. The actual GPU kernel is intentionally left as a stub — full paged-KV attention will land in a follow-up.

## Details

- **Dialect**: new `hip.paged_attention` op in `HipOps.td` (DPS + `AttrSizedOperandSegments`), covering all MS-spec inputs/attributes (optional `key`/`value` for packed QKV, optional `cos_cache`/`sin_cache`, optional `key_cache_out`/`value_cache_out`; `num_heads`, `kv_num_heads`, `do_rotary`, `rotary_interleaved`, `local_window_size`, `scale`, `softcap`).
- **OnnxToHip**: `PagedAttentionConversion.cpp` matches `onnx.Custom` with `function_name = "PagedAttention"` + `domain_name = "com.microsoft"`, normalizes attributes (auto-derives `scale = 1/sqrt(head_dim)` when 0), and emits `hip.paged_attention` with proper segment sizes for the optional inputs/outputs.
- **HipToLLVM**: `PagedAttentionLowering.cpp` lowers to a single `wrap_paged_attention` call, handling optional memref operands and dynamic `num_tokens` / `query_dim1`.
- **Runtime**: declared in `hipdnn_ep_runtime.h`; real impl (`real/paged_attention.cpp`) returns 0 (stub); mock impl (`mock/mock_gpu.cpp`) logs args and returns 0.
- **Bufferization / effects**: registered `HipDstBufferizableModel<PagedAttentionOp>` in both `HipBufferize.h` and `hip-mlir-opt.cpp`; implemented `getDpsInitsMutable()` and `getEffects()` in `HipDialect.cpp`.

## Test Plan

- [x] LIT `onnx-to-hip/test_paged_attention.mlir`: pattern match for static and dynamic packed-QKV shapes.
- [x] LIT `hip-to-llvm/test_paged_attention.mlir`: lowering to `wrap_paged_attention` (static + dynamic).
- [x] LIT `e2e/test_paged_attention_model.mlir`: full `--hipdnn-pipeline` produces `inference_init`/`compute`/`cleanup` and a `wrap_paged_attention` call, with no residual `onnx.Custom` / `onnx.NoValue`.
- [x] `cmake --build ... --config RelWithDebInfo --target install` succeeds.