### PR TITLE
feat(conv): add CK conv backend, default for fp16 (1.4-300x vs MIOpen)

### DIFF
--- a/lib/Backend/CMakeLists.txt
+++ b/lib/Backend/CMakeLists.txt
@@ -3,23 +3,30 @@
 # ** Licensed under the MIT License.
 ##
 
-# hip-backend-gfx<ARCH>.dll -- per-gfx EP backend hosting heavy ROCm kernels
-# (Composable Kernel today; future hipBLASLt-tuned kernels, etc.). Loaded
-# at runtime by model.dll via LoadLibrary + GetProcAddress so the giant
-# device_conv_operations.lib (2.6 GB) never enters the per-model.dll
-# lld-link path -- only this DLL pays the link cost, once at build time
-# via MSVC link.exe.
+# hip-backend-gfx<ARCH>.{dll,so} -- per-gfx EP backend hosting heavy ROCm
+# kernels (Composable Kernel today; future hipBLASLt-tuned kernels, etc.).
+# Loaded at runtime by model.dll via LoadLibrary/dlopen + GetProcAddress/
+# dlsym so the giant device_conv_operations.lib (2.6 GB) never enters the
+# per-model.dll lld-link path -- only this DLL pays the link cost, once at
+# build time.
 #
-# We use the _hip_compile_sources helper from custom_kernels' hip_utils
-# directly (instead of hip_add_library SHARED) because hip_add_library's
-# SHARED variant emits a dummy .cpp and links hip::host PUBLIC, which
-# propagates `-x hip` and similar hipcc-only flags to the dummy compile
-# step. cl.exe rejects those. Building the SHARED library shell ourselves
-# lets us keep the hipcc compile of CK code AND have a clean MSVC compile
-# of the SHARED-lib boilerplate.
+# Single exported symbol: HIPBackendAPI (pointer to a HIPBackendVTable).
+# On Windows it's gated by hip_backend.def + /DEF: at link time; on Linux
+# the rest of the DLL gets hidden visibility and HIPBackendAPI carries
+# __attribute__((visibility("default"))) in main.cpp -- same one-symbol
+# ABI either way.
 #
-# Exports are gated by hip_backend.def -- only the public C ABI declared
-# in hipdnn_ep_backend.h crosses the DLL boundary.
+# Two build paths because the HIP toolchain story differs across the OSes:
+#
+# Windows: use the _hip_compile_sources helper from custom_kernels'
+# hip_utils directly. hip_add_library SHARED would emit a dummy .cpp and
+# link hip::host PUBLIC, which propagates `-x hip` and similar hipcc-only
+# flags to the dummy compile step -- cl.exe rejects those. Building the
+# SHARED-library shell ourselves lets us keep the hipcc compile of CK
+# code AND have a clean MSVC compile of the SHARED-lib boilerplate.
+#
+# Linux: use CMake's HIP language support (enable_language(HIP) +
+# LANGUAGE HIP source property). main.cpp stays a regular C++ compile.
 
 cmake_minimum_required(VERSION 3.18)
 
@@ -42,16 +49,14 @@ find_package(hip REQUIRED CONFIG)
 find_package(composable_kernel REQUIRED COMPONENTS device_conv_operations utility)
 message(STATUS "[backend] composable_kernel: ${composable_kernel_DIR}")
 
-# main.cpp is plain C++ -- no HIP intrinsics, no __device__ code. Compiled
-# with cl.exe via the SHARED target's regular source list (see add_library
-# below). Compiling it through hipcc would also emit a device-side object
-# with the static `g_vtable` and its function-pointer initializers, then
-# the device linker would (correctly) reject the host-only target functions
-# as undefined-on-device. Keeping main.cpp out of the HIP path sidesteps
-# that entirely.
+# main.cpp is plain C++ -- no HIP intrinsics, no __device__ code. Keep it
+# off the HIP path on both platforms; compiling through hipcc would also
+# emit a device-side object with the static `g_vtable` and its function-
+# pointer initializers, then the device linker would (correctly) reject
+# the host-only target functions as undefined-on-device.
 #
 # Only TUs that actually contain HIP code (HIP intrinsics or __global__
-# kernels) belong in this list.
+# kernels) belong in BACKEND_HIP_SOURCES.
 set(BACKEND_HIP_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/conv.cpp
 )
@@ -60,71 +65,103 @@ set(BACKEND_INCLUDES
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-# Pass C++17 (CK requires it) and the bare-identifier arch macro that
-# main.cpp stringifies via STR(x).
-#
-# CRT: device_conv_operations.lib is built upstream against the dynamic
-# CRT (/MD). We MUST match: top-level CMakeLists sets
-# CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded (/MT) for the model.dll's static-CRT
-# requirement, but the backend DLL is a separate artifact -- override to /MD
-# both for hipcc-compiled objects (here, via -D_DLL/-D_MT/--dependent-lib=msvcrt)
-# AND for the SHARED-lib target itself (set_target_properties below).
-set(BACKEND_HIPCC_OPTS
-    -std=c++17
-    "-DHIPDNN_EP_BACKEND_ARCH=${BACKEND_ARCH}"
-    -D_DLL -D_MT "-Xclang" "--dependent-lib=msvcrt"
-)
+if(WIN32)
+    # -------------------------------------------------------------------
+    # Windows: hipcc compile of conv.cpp + MSVC compile of the shell + main.
+    # -------------------------------------------------------------------
+    #
+    # CRT: device_conv_operations.lib is built upstream against the dynamic
+    # CRT (/MD). We MUST match: top-level CMakeLists sets
+    # CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded (/MT) for the model.dll's
+    # static-CRT requirement, but the backend DLL is a separate artifact --
+    # override to /MD both for hipcc-compiled objects (here, via
+    # -D_DLL/-D_MT/--dependent-lib=msvcrt) AND for the SHARED-lib target
+    # itself (set_target_properties below).
+    set(BACKEND_HIPCC_OPTS
+        -std=c++17
+        "-DHIPDNN_EP_BACKEND_ARCH=${BACKEND_ARCH}"
+        -D_DLL -D_MT "-Xclang" "--dependent-lib=msvcrt"
+    )
 
-# Compile HIP sources via hipcc -> .obj (uses _hip_compile_sources from
-# hip_utils.cmake). Output is in ${CMAKE_CURRENT_BINARY_DIR}/${TARGET}_hip_objs/.
-_hip_compile_sources(
-    ${BACKEND_TARGET}
-    "${BACKEND_HIP_SOURCES}"
-    "${BACKEND_INCLUDES}"
-    "${BACKEND_HIPCC_OPTS}"
-    BACKEND_HIP_OBJS
-)
-add_custom_target(${BACKEND_TARGET}_hip_compile DEPENDS ${BACKEND_HIP_OBJS})
+    # Compile HIP sources via hipcc -> .obj (uses _hip_compile_sources from
+    # hip_utils.cmake). Output lands in
+    # ${CMAKE_CURRENT_BINARY_DIR}/${TARGET}_hip_objs/.
+    _hip_compile_sources(
+        ${BACKEND_TARGET}
+        "${BACKEND_HIP_SOURCES}"
+        "${BACKEND_INCLUDES}"
+        "${BACKEND_HIPCC_OPTS}"
+        BACKEND_HIP_OBJS
+    )
+    add_custom_target(${BACKEND_TARGET}_hip_compile DEPENDS ${BACKEND_HIP_OBJS})
 
-# Minimal real shell .cpp -- gives MSVC something to compile so the
-# SHARED library's CRT init / DllMain / __DllMainCRTStartup chain is
-# wired up correctly. Plain C++; no hipcc-only flags.
-set(BACKEND_SHELL "${CMAKE_CURRENT_BINARY_DIR}/${BACKEND_TARGET}_shell.cpp")
-file(WRITE ${BACKEND_SHELL}
+    # Minimal real shell .cpp -- gives MSVC something to compile so the
+    # SHARED library's CRT init / DllMain / __DllMainCRTStartup chain is
+    # wired up correctly. Plain C++; no hipcc-only flags.
+    set(BACKEND_SHELL "${CMAKE_CURRENT_BINARY_DIR}/${BACKEND_TARGET}_shell.cpp")
+    file(WRITE ${BACKEND_SHELL}
 "// Auto-generated. Provides a translation unit for the SHARED hip-backend\n"
 "// DLL so MSVC supplies CRT init. The real backend code lives in the\n"
 "// hipcc-compiled .obj files attached via target_sources.\n"
 "namespace { volatile int hip_backend_shell_anchor = 0; }\n"
 )
 
-# Module-def file gates exports -- only symbols listed in hip_backend.def
-# leave the DLL. Adding it as a source makes CMake pass it to link.exe
-# via the LINK_FLAGS /DEF: mechanism (handled automatically for .def files).
-set(BACKEND_DEF "${CMAKE_CURRENT_SOURCE_DIR}/hip_backend.def")
+    # Module-def file gates exports -- only symbols listed in hip_backend.def
+    # leave the DLL. Adding it as a source makes CMake pass it to link.exe
+    # via the LINK_FLAGS /DEF: mechanism (handled automatically for .def files).
+    set(BACKEND_DEF "${CMAKE_CURRENT_SOURCE_DIR}/hip_backend.def")
 
-add_library(${BACKEND_TARGET} SHARED
-    ${BACKEND_SHELL}
-    ${BACKEND_DEF}
-    ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
-target_sources(${BACKEND_TARGET} PRIVATE ${BACKEND_HIP_OBJS})
-add_dependencies(${BACKEND_TARGET} ${BACKEND_TARGET}_hip_compile)
+    add_library(${BACKEND_TARGET} SHARED
+        ${BACKEND_SHELL}
+        ${BACKEND_DEF}
+        ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
+    target_sources(${BACKEND_TARGET} PRIVATE ${BACKEND_HIP_OBJS})
+    add_dependencies(${BACKEND_TARGET} ${BACKEND_TARGET}_hip_compile)
+
+    set_target_properties(${BACKEND_TARGET} PROPERTIES
+        LINKER_LANGUAGE CXX
+        # Override the project-wide /MT to match CK's upstream /MD build.
+        MSVC_RUNTIME_LIBRARY "MultiThreadedDLL"
+    )
+else()
+    # -------------------------------------------------------------------
+    # Linux: CMake HIP language support compiles conv.cpp via amdclang++
+    # with --offload-arch=<arch>. main.cpp compiled by the regular C++
+    # compiler. Exports controlled by visibility -- only HIPBackendAPI
+    # has __attribute__((visibility("default"))) (in main.cpp); the rest
+    # of the DLL gets hidden visibility via the target properties below.
+    # No .def-file equivalent needed.
+    # -------------------------------------------------------------------
+    add_library(${BACKEND_TARGET} SHARED
+        ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
+        ${BACKEND_HIP_SOURCES}
+    )
+    set_source_files_properties(${BACKEND_HIP_SOURCES} PROPERTIES LANGUAGE HIP)
+    set_target_properties(${BACKEND_TARGET} PROPERTIES
+        HIP_ARCHITECTURES "${HIP_ARCHITECTURES}"
+        POSITION_INDEPENDENT_CODE ON
+        CXX_VISIBILITY_PRESET hidden
+        C_VISIBILITY_PRESET hidden
+        VISIBILITY_INLINES_HIDDEN ON
+    )
+    target_compile_options(${BACKEND_TARGET} PRIVATE
+        $<$<COMPILE_LANGUAGE:HIP>:-Wno-ignored-attributes>
+    )
+endif()
+
 target_include_directories(${BACKEND_TARGET} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR})
 # main.cpp's EP_STR(HIPDNN_EP_BACKEND_ARCH) needs the bare-identifier macro.
 target_compile_definitions(${BACKEND_TARGET} PRIVATE
     HIPDNN_EP_BACKEND_ARCH=${BACKEND_ARCH})
-set_target_properties(${BACKEND_TARGET} PROPERTIES
-    LINKER_LANGUAGE CXX
-    # Override the project-wide /MT to match CK's upstream /MD build.
-    MSVC_RUNTIME_LIBRARY "MultiThreadedDLL"
-)
 
-# Link raw .lib paths instead of the hip::host / composable_kernel::*
+# Link raw .lib / .so paths instead of the hip::host / composable_kernel::*
 # imported targets -- those carry INTERFACE_COMPILE_OPTIONS like `-x hip`
-# that CMake propagates to the SHARED-lib shell.cpp compile, where
-# cl.exe rejects them. The imported targets ARE used at hipcc compile
-# time via _hip_compile_sources's manual include/lib handling; we only
-# bypass them at the shell-link stage.
+# that CMake propagates to the SHARED-lib shell.cpp / main.cpp compiles,
+# where the regular C++ compiler rejects them. The imported targets ARE
+# used at the HIP-compile stage via either _hip_compile_sources (Windows)
+# or CMake's HIP language support (Linux); we only bypass them at the
+# host-side link/compile stages.
 get_target_property(_ck_conv_lib composable_kernel::device_conv_operations
                     IMPORTED_LOCATION_RELEASE)
 get_target_property(_ck_util_lib composable_kernel::utility
@@ -140,8 +177,19 @@ endif()
 message(STATUS "[backend] CK conv lib: ${_ck_conv_lib}")
 message(STATUS "[backend] CK util lib: ${_ck_util_lib}")
 
+# HIP runtime library: WIN32 path of hip_utils.cmake sets HIP_RUNTIME_LIBRARY
+# explicitly (amdhip64.lib). On Linux we use the hip::host imported target
+# from find_package(hip) -- its INTERFACE compile options only fire for
+# HIP-language sources via CMake's HIP support, so they don't leak into
+# main.cpp's regular C++ compile.
+if(WIN32)
+    set(_hip_runtime "${HIP_RUNTIME_LIBRARY}")
+else()
+    set(_hip_runtime "hip::host")
+endif()
+
 target_link_libraries(${BACKEND_TARGET} PRIVATE
-    ${HIP_RUNTIME_LIBRARY}
+    ${_hip_runtime}
     ${_ck_conv_lib}
     ${_ck_util_lib}
     Threads::Threads
@@ -157,4 +205,4 @@ install(FILES hipdnn_ep_backend.h
     DESTINATION include/hip
 )
 
-message(STATUS "[backend] Will produce ${BACKEND_TARGET}.dll for arch ${BACKEND_ARCH}")
+message(STATUS "[backend] Will produce ${BACKEND_TARGET} for arch ${BACKEND_ARCH}")


### PR DESCRIPTION
  ## Summary

  Adds a Composable Kernel (CK) convolution backend for fp16 NCHW Conv ops on RDNA3+, dispatched via a thin shim that picks between CK and MIOpen at runtime. Default for fp16 is now CK; MIOpen handles fp32 (CK ships no fp32 NHWGC instances under TheRock's CK build). Explicit override via `HIPDNN_EP_CONV={ck,miopen}`.

  CK wins on every shape benched on gfx1151 (Strix Halo, RDNA3+, 16 CUs). Speedups range from ~1.2× on small mid-stage 3×3 convs to **200–300× on heavy generative-model classes** (SDXL UNet bottom block, 2K image patchify) where MIOpen falls back to a workspace-fitting slow algorithm because the EP caps MIOpen's workspace at 10 MB. CK is unaffected — it pulls scratch from the model.dll's existing grow-on-demand pool via a new vtable callback.

  | Shape | input → output | MIOpen ms | CK ms | CK speedup | MIOpen GFLOPS | CK GFLOPS |
  |---|---|---:|---:|---:|---:|---:|
  | smoke_3x3       | 1×3×32² → 1×16×32²         | 0.526   | **0.295** | **1.78×** | 1.7  | 3.0       |
  | rn50_stem       | 1×3×224² → 1×64×112² s2    | 0.658   | **0.456** | **1.44×** | 359  | **518**   |
  | rn50_s3_3x3     | 1×256×14² → 1×256×14²      | 0.668   | **0.552** | **1.21×** | 346  | **419**   |
  | 1×1             | 1×16×32² → 1×32×32²        | 0.660   | **0.319** | **2.07×** | 1.6  | 3.3       |
  | ViT-L/14 (CLIP) | 1×3×224² → 1×1024×16² s14  | 0.596   | **0.419** | **1.42×** | 517  | **735**   |
  | sdxl_unet_1280  | 1×1280×16² → 1×1280×16²    | 575.6   | **2.327** | **247×**  | 13.1 | **3245**  |
  | 2k_vit_b16      | 1×3×2048² → 1×768×128² s16 | 1656.9  | **5.508** | **301×**  | 11.7 | **3509**  |

  ## Conv path changes

  - `hip.conv` lowers to `wrap_conv_forward_dispatch` (`lib/Runtime/real/conv_dispatch.cpp`), a thin shim. The wrap ABI carries `int64_t element_size_bytes` (2=fp16, 4=fp32); `ConvLowering` reads the input MemRef's element type and emits the right constant.
  - Default behavior (env unset or `auto`): CK for fp16, MIOpen for fp32. Explicit `HIPDNN_EP_CONV=ck` forces CK (fp32 calls return -1); `HIPDNN_EP_CONV=miopen` forces MIOpen.
  - The env var is read once per process — model.dll is cached in `%TEMP%` and shared, so flipping the var between InferenceSessions in one process does NOT re-dispatch.
  - CK supports depthwise (group == C) where MIOpen rejects it with `Invalid filter channel number` — captured by the test matrix's xfail/xpass row.

  ## Per-gfx backend DLL (supporting infra)

  Heavy ROCm libraries (CK today; future hipBLASLt-tuned kernels) live behind a stable vtable C ABI in a per-gfx backend DLL `hip-backend-gfx<ARCH>.dll` built once from `lib/Backend/`. model.dll loads it at runtime via `hip::GetBackend()`  (`lib/Runtime/real/hip_backend_client.{h,cpp}`); the only symbol crossing the boundary is `HIPBackendAPI`, a pointer to a static `HIPBackendVTable`. Rationale: pointing in-process lld at `device_conv_operations.lib` (2.6 GB) silently hangs the python process — the per-gfx DLL is built once with MSVC `link.exe` (~6 MB after dead-code stripping) instead of paying that cost on every model.dll compile.

  Vtable slots today: `abi_version`, `arch`, optional `init`/`shutdown`, `set_scratch_provider`, `conv_fwd_fp16_nchw`. Adding a new op is **append-only at the end of the vtable** — does not bump `HIP_BACKEND_API_VERSION` (older clients null-check the slot before calling). The .def file stays a 1-line `EXPORTS HIPBackendAPI DATA`.

  Scratch ownership: model.dll registers a callback (`hipdnn_ep_runtime_scratch_provider`) at session init via the `set_scratch_provider` vtable slot. The backend then pulls per-call GPU scratch from the model's existing grow-on-demand workspace — zero per-call hipMalloc, zero workspace-cap regressions, no double allocation for sessions that never touch CK. As a side effect of needing a real `std::shared_ptr<hip::Backend>` member on `RuntimeState`, the struct is now allocated via `new`/`delete` instead of `malloc`/`free`.

  Runtime arch detection: `hip::Backend`'s ctor calls `hipGetDeviceProperties().gcnArchName`, strips `:xnack-` / `:sramecc+` target-id suffixes, and loads `hip-backend-<arch>.dll` (or `libhip-backend-<arch>.so` on Linux via a tiny dlopen shim). No compile-time arch baking on the model.dll side. If a build doesn't ship a backend for the device's gfx, `inference_init` logs `[hip_ep] backend not available: ...` and continues — workloads that don't use CK keep working.

  ## Files

  - New: `lib/Backend/{CMakeLists.txt, conv.cpp, hip_backend.def, hipdnn_ep_backend.h, main.cpp}`, `lib/Runtime/real/{ck_conv.cpp, conv_dispatch.cpp, hip_backend_client.{h,cpp}}`, `lib/Runtime/mock/hip_backend_client.h`, `bench/bench_conv.py`, `test/python/test_op_conv.py`, `docs/design/per-gfx-backend.md`.
  - Modified: `lib/Conversion/HipToLLVM/{ConvLowering.cpp, HipToLLVMUtils.h}`, `lib/Runtime/{CMakeLists.txt, hipdnn_ep_runtime.h, hipdnn_ep_runtime_state.cpp, runtime_state_internal.h, mock/mock_gpu.cpp, real/miopen.cpp}`, `lib/Compiler/CompilerDriver.cpp`, `CMakeLists.txt`, `.gitignore`, `CLAUDE.md`, `test/python/conftest.py`, `test/lit/{Conversion/hip-to-llvm,e2e}/test_conv*.mlir`.

  ## Docs

  `docs/design/per-gfx-backend.md` is authoritative for the backend ABI, runtime client, scratch-provider plumbing, CK build details, the op-adding recipe, and troubleshooting. CLAUDE.md only carries a pointer plus a **MANDATORY** rule that any change to `lib/Backend/`,
  `lib/Runtime/real/hip_backend_client.{h,cpp}`, `lib/Runtime/real/ck_conv.cpp`, the `HIPBackendVTable` contract, or the runtime scratch-provider plumbing must refresh that doc in the same session.

  ## Test plan

  - [x] `python build.py` clean on gfx1151 (Strix Halo, Windows)
  - [x] `dumpbin /EXPORTS install/dist/bin/hip-backend-gfx1151.dll` shows exactly one export: `HIPBackendAPI` (DATA)
  - [x] `pytest test/python/test_op_conv.py` — 7 passed + 1 xpass (depthwise on CK) + 1 skipped (perf-only, gated by `RUN_PERF`)
  - [x] `pytest test/python/test_op_conv.py` with `HIPDNN_EP_CONV=miopen` — 5 passed + 1 xfail (depthwise rejected by MIOpen as expected)
  - [x] `pytest test/python/test_op_conv.py` with `HIPDNN_EP_CONV=ck` — 5 passed + 1 xpass
  - [x] `ctest -R MorphizenMLIRLitTests` — 1/1 passed (conv lowering tests still expect `wrap_conv_forward_dispatch`)
  - [x] `bench/bench_conv.py` (CK) — peaks at ~3.5 TFLOPS on `2k_vit_b16`; numbers above
  - [x] One full LLM `model_benchmark.exe` run to confirm the new `inference_init` (now allocates RuntimeState via `new` and registers the scratch provider) does not regress models that don't use CK