### PR TITLE
feat(build): add --build-vulkan flag for llama.cpp Vulkan baseline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -382,6 +382,37 @@ Always enabled — no environment variable needed. The `CrashHandler.h` header i
 
 **Dependency:** cpptrace v0.8.3 fetched via FetchContent (in `CMakeLists.txt` for `BUILD_HIP_TOOLS`, in `cmake/deps.cmake` for `BUILD_EP`).
 
+## Vulkan baseline (llama.cpp)
+
+`build.py --build-vulkan` fetches the LunarG Vulkan SDK and builds llama.cpp with `GGML_VULKAN=ON` for collecting Vulkan baseline numbers. Pinned versions for reproducibility: llama.cpp commit `683c5acb`, Vulkan SDK `1.4.341.1`. Idempotent — `.ok` sentinels, shares `install/_cache/` with the rest of `build.py`.
+
+```bash
+python build.py --build-vulkan   # full project build + Vulkan baseline
+```
+
+Outputs (under `install/`): `vulkan-sdk/` (silent install, user-writable, no admin), `llama.cpp/` (pinned source), `llama.cpp-build/` (Ninja build dir), `llama-vulkan/bin/` (`llama-bench.exe`, `llama-cli.exe`, `llama-server.exe`, `ggml-vulkan.dll`).
+
+**LunarG download URL gotcha.** The installer is `vulkansdk-windows-X64-{ver}.exe` (lowercase `vulkansdk`, `X64` token), NOT `VulkanSDK-{ver}-Installer.exe` — the latter returns 404. Append `?Human=true` to bypass LunarG's download-token throttling. The CDN also rejects the default Python `urllib` User-Agent — `_download_with_browser_ua()` in `build.py` installs a `Mozilla/5.0` opener for the Vulkan download only (other downloads keep the default UA).
+
+### Fair Vulkan benchmarking with llama-bench
+
+`-p N` runs prefill at length N; `-n M` runs decode of M tokens **starting from an empty KV cache regardless of `-p`**. So `llama-bench -p 4096 -n 128` reports pp4096 and tg128 as **two independent benchmarks** — the decode number is NOT "decode after a 4096-token prompt". Decode tps is essentially flat across `-p` values (44.7 t/s at both `-p 128` and `-p 4096` on the 8B Q4_K_M).
+
+To measure decode at realistic depth, use `-d N` / `--n-depth N` which pre-populates the KV cache with N tokens before the test runs. Multi-value works: `-n 128 -d 0,4096` reports tg128 @ d=0 and tg128 @ d=4096 in one invocation. Alternative: `-pg pp,tg` runs prefill-then-generation back-to-back as a single combined timing.
+
+### Llama 3.1 8B Q4_K_M Vulkan baseline (gfx1151, AMD Radeon 8060S Graphics, 2026-05-05)
+
+llama.cpp build `683c5acb`, AMD proprietary Vulkan driver, KHR_coopmat matrix cores, fp16+bf16, UMA. Model: `Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf` (4.58 GiB, 8.03 B params).
+
+| Test | t/s |
+|------|----:|
+| pp128 | 903.04 ± 4.08 |
+| pp4096 | 748.93 ± 0.30 |
+| tg128 @ d=0 | 44.71 ± 0.02 |
+| tg128 @ d=4096 | 30.87 ± 0.01 |
+
+Decode at d=4096 is ~31% slower than at d=0 due to attention cost scaling with KV cache depth.
+
 ## Code Conventions
 
 - C++ 17, formatted with clang-format 16. Python formatted with ruff.

--- a/build.py
+++ b/build.py
@@ -21,6 +21,8 @@ Usage:
     python build.py                # Full setup + build
     python build.py --skip-build   # Setup only (download deps)
     python build.py --clean        # Remove install/ and start fresh
+    python build.py --build-oga    # Also build the onnxruntime-genai fork
+    python build.py --build-vulkan # Also build the Vulkan baseline (llama.cpp)
 """
 
 import argparse
@@ -45,9 +47,24 @@ BUILD = INSTALL / "build"
 DIST = INSTALL / "dist"
 OGA_SOURCE = INSTALL / "oga-source"
 OGA_BUILD = INSTALL / "oga-build"
+VULKAN_SDK = INSTALL / "vulkan-sdk"
+LLAMACPP_SRC = INSTALL / "llama.cpp"
+LLAMACPP_BUILD = INSTALL / "llama.cpp-build"
+LLAMACPP_DIST = INSTALL / "llama-vulkan"
 
 THEROCK_URL = (
     "https://repo.amd.com/rocm/tarball/therock-dist-windows-gfx1151-7.11.0.tar.gz"
+)
+
+# Pinned llama.cpp commit + Vulkan SDK version for reproducible Vulkan baselines.
+LLAMACPP_REPO = "https://github.com/ggml-org/llama.cpp.git"
+LLAMACPP_REF = "683c5acb90478a9e7e20eb65a1bfee334635216d"
+VULKAN_VERSION = "1.4.341.1"
+VULKAN_INSTALLER_NAME = f"vulkansdk-windows-X64-{VULKAN_VERSION}.exe"
+# ?Human=true disables LunarG's download-token throttling for direct fetches.
+VULKAN_INSTALLER_URL = (
+    f"https://sdk.lunarg.com/sdk/download/{VULKAN_VERSION}/windows/"
+    f"{VULKAN_INSTALLER_NAME}?Human=true"
 )
 
 # Prebuilt deps — keep in sync with scripts/setup-prebuilt.sh
@@ -656,6 +673,180 @@ def build_oga():
 
 
 # ---------------------------------------------------------------------------
+# Vulkan baseline (llama.cpp built against the LunarG Vulkan SDK)
+# ---------------------------------------------------------------------------
+
+
+def _download_with_browser_ua(url, dest):
+    """Wrap download() with a Mozilla UA opener. LunarG's CDN returns 403/404
+    to the default Python urllib User-Agent."""
+    prev_opener = urllib.request._opener
+    opener = urllib.request.build_opener()
+    opener.addheaders = [("User-Agent", "Mozilla/5.0")]
+    urllib.request.install_opener(opener)
+    try:
+        download(url, dest)
+    finally:
+        urllib.request.install_opener(prev_opener)
+
+
+def fetch_vulkan_sdk():
+    log("Setting up Vulkan SDK ...")
+    sentinel = VULKAN_SDK / ".ok"
+    if sentinel.exists():
+        log("  Already installed.")
+        return
+
+    installer = CACHE / VULKAN_INSTALLER_NAME
+    _download_with_browser_ua(VULKAN_INSTALLER_URL, installer)
+
+    if VULKAN_SDK.exists():
+        shutil.rmtree(VULKAN_SDK)
+    VULKAN_SDK.mkdir(parents=True, exist_ok=True)
+
+    # Qt Installer Framework based; --root makes it install user-writable
+    # (no admin/UAC) and the silent flags suppress the GUI. Default component
+    # set covers what llama.cpp needs (Headers, Loader, glslc, validation).
+    log(f"  Running installer (silent) -> {VULKAN_SDK}")
+    r = subprocess.run(
+        [
+            str(installer),
+            "--root",
+            str(VULKAN_SDK),
+            "--accept-licenses",
+            "--default-answer",
+            "--confirm-command",
+            "install",
+        ]
+    )
+    if r.returncode != 0:
+        raise RuntimeError(
+            f"Vulkan SDK installer exited with code {r.returncode}. "
+            "If a UAC prompt was dismissed, re-run from an elevated shell."
+        )
+
+    must_exist = [
+        VULKAN_SDK / "Include" / "vulkan" / "vulkan.h",
+        VULKAN_SDK / "Lib" / "vulkan-1.lib",
+        VULKAN_SDK / "Bin" / "glslc.exe",
+    ]
+    missing = [p for p in must_exist if not p.exists()]
+    if missing:
+        raise RuntimeError(
+            "Vulkan SDK install looks incomplete. Missing:\n  "
+            + "\n  ".join(str(p) for p in missing)
+        )
+
+    sentinel.touch()
+    log(f"  Vulkan SDK {VULKAN_VERSION} ready.")
+
+
+def fetch_llamacpp():
+    log("Setting up llama.cpp source ...")
+    sentinel = LLAMACPP_SRC / ".ok"
+    if sentinel.exists():
+        # Verify the pinned commit is checked out — if HEAD moved we don't
+        # want to silently build the wrong thing.
+        head = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(LLAMACPP_SRC),
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        if head == LLAMACPP_REF:
+            log(f"  Already at pinned commit {LLAMACPP_REF[:8]}.")
+            return
+        log(f"  HEAD is {head[:8]}, expected {LLAMACPP_REF[:8]} — re-checking out.")
+
+    if not LLAMACPP_SRC.exists():
+        LLAMACPP_SRC.parent.mkdir(parents=True, exist_ok=True)
+        log(f"  Cloning {LLAMACPP_REPO} ...")
+        subprocess.run(
+            ["git", "clone", "--filter=blob:none", LLAMACPP_REPO, str(LLAMACPP_SRC)],
+            check=True,
+        )
+
+    log(f"  Fetching pinned commit {LLAMACPP_REF[:8]} ...")
+    subprocess.run(
+        ["git", "fetch", "--depth=1", "origin", LLAMACPP_REF],
+        cwd=str(LLAMACPP_SRC),
+        check=True,
+    )
+    subprocess.run(
+        ["git", "checkout", "--detach", LLAMACPP_REF],
+        cwd=str(LLAMACPP_SRC),
+        check=True,
+    )
+
+    sentinel.touch()
+    log("  llama.cpp ready.")
+
+
+def build_vulkan():
+    """Fetch the Vulkan SDK + llama.cpp source, then build llama.cpp with
+    GGML_VULKAN=ON. Installs binaries into install/llama-vulkan/bin."""
+    log("Building Vulkan baseline (llama.cpp) ...")
+
+    fetch_vulkan_sdk()
+    fetch_llamacpp()
+
+    _ensure_msvc_env()
+    for tool in ("cmake", "ninja"):
+        if not shutil.which(tool):
+            log(f"  ERROR: {tool} not found. Run: conda activate hipdnn-ep")
+            sys.exit(1)
+
+    # Make the SDK visible to CMake's FindVulkan via the standard env var.
+    os.environ["VULKAN_SDK"] = str(VULKAN_SDK)
+    os.environ["PATH"] = str(VULKAN_SDK / "Bin") + os.pathsep + os.environ["PATH"]
+
+    LLAMACPP_BUILD.mkdir(parents=True, exist_ok=True)
+
+    cmake_args = [
+        "cmake",
+        "-S",
+        str(LLAMACPP_SRC),
+        "-B",
+        str(LLAMACPP_BUILD),
+        "-G",
+        "Ninja",
+        "-DCMAKE_BUILD_TYPE=Release",
+        f"-DCMAKE_INSTALL_PREFIX={LLAMACPP_DIST}",
+        "-DGGML_VULKAN=ON",
+        "-DGGML_NATIVE=ON",
+        "-DGGML_CUDA=OFF",
+        "-DGGML_HIP=OFF",
+        "-DLLAMA_BUILD_TESTS=OFF",
+        "-DLLAMA_CURL=OFF",
+        f"-DVulkan_INCLUDE_DIR={VULKAN_SDK / 'Include'}",
+        f"-DVulkan_LIBRARY={VULKAN_SDK / 'Lib' / 'vulkan-1.lib'}",
+        f"-DVulkan_GLSLC_EXECUTABLE={VULKAN_SDK / 'Bin' / 'glslc.exe'}",
+    ]
+
+    if shutil.which("sccache"):
+        cmake_args += [
+            "-DCMAKE_C_COMPILER_LAUNCHER=sccache",
+            "-DCMAKE_CXX_COMPILER_LAUNCHER=sccache",
+        ]
+
+    log("  Configuring ...")
+    subprocess.run(cmake_args, check=True)
+
+    log("  Compiling ...")
+    subprocess.run(
+        ["cmake", "--build", str(LLAMACPP_BUILD), "--config", "Release"],
+        check=True,
+    )
+
+    log("  Installing ...")
+    subprocess.run(
+        ["cmake", "--install", str(LLAMACPP_BUILD), "--config", "Release"],
+        check=True,
+    )
+    log(f"  Vulkan baseline ready -> {LLAMACPP_DIST}")
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -678,6 +869,11 @@ def main():
         "--build-oga",
         action="store_true",
         help="Build and install onnxruntime-genai fork with MorphiZen EP device support",
+    )
+    parser.add_argument(
+        "--build-vulkan",
+        action="store_true",
+        help="Build the Vulkan baseline (llama.cpp + LunarG Vulkan SDK)",
     )
     args = parser.parse_args()
 
@@ -703,6 +899,9 @@ def main():
     if args.build_oga:
         build_oga()
 
+    if args.build_vulkan:
+        build_vulkan()
+
     log(f"  TheRock SDK:    {THEROCK}")
     log(f"  Dependencies:   {DEPS}")
     log(f"  ONNX Runtime:   {ORT}")
@@ -712,6 +911,10 @@ def main():
     if args.build_oga:
         log(f"  OGA source:     {OGA_SOURCE}")
         log(f"  OGA build:      {OGA_BUILD}")
+    if args.build_vulkan:
+        log(f"  Vulkan SDK:     {VULKAN_SDK}")
+        log(f"  llama.cpp src:  {LLAMACPP_SRC} (commit {LLAMACPP_REF[:8]})")
+        log(f"  Vulkan binaries:{LLAMACPP_DIST}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
  ## Summary

  - Adds `--build-vulkan` to `build.py` (mirrors `--build-oga`): downloads the LunarG Vulkan SDK 1.4.341.1 (silent, user-writable, no admin), clones llama.cpp at pinned commit `683c5acb`, and builds it with `GGML_VULKAN=ON`. All artifacts land under `install/` (`vulkan-sdk/`,
  `llama.cpp/`, `llama.cpp-build/`, `llama-vulkan/bin/`), sharing `install/_cache/` and reusing the existing `download()` + `_ensure_msvc_env()` helpers — no standalone script.
  - LunarG's CDN rejects the default Python `urllib` User-Agent and applies download-token throttling. `_download_with_browser_ua()` installs a `Mozilla/5.0` opener for the Vulkan download only and restores the previous opener afterwards, so the other downloads (TheRock, LLVM/MLIR, ORT) keep the default UA.
  - `CLAUDE.md` gains a `## Vulkan baseline (llama.cpp)` section before `## Code Conventions` documenting the LunarG installer-URL gotcha (`vulkansdk-windows-X64-{ver}.exe` + `?Human=true`), the llama-bench measurement rules (`-p` and `-n` are independent benches; use `-d N` for decode-at-depth), and the verified Llama 3.1 8B Q4_K_M baseline numbers on gfx1151 (pp128 903 t/s, pp4096 749 t/s, tg128 @ d=0 44.7 t/s, tg128 @ d=4096 30.9 t/s).

  ## Test plan

  - [x] `ruff check build.py` and `ruff format --check build.py` pass on the conda env Python (3.14, `hipdnn-ep`).
  - [x] `python build.py --help` lists `--build-vulkan` alongside `--build-oga`.
  - [x] `python build.py --skip-build --build-vulkan` on gfx1151 runs end-to-end: TheRock/deps/ORT sentinels honored, `fetch_vulkan_sdk` short-circuits on `.ok`, `fetch_llamacpp` validates `HEAD == LLAMACPP_REF`, MSVC env auto-injected via `vswhere`, cmake configure/build/install  succeed, summary prints all three Vulkan paths.
  - [x] Cold-path smoke: `install/llama-vulkan/bin/llama-bench.exe --help` initializes Vulkan and enumerates `AMD Radeon 8060S Graphics (AMD proprietary driver) | uma: 1 | fp16: 1 | bf16: 1 | matrix cores: KHR_coopmat` — confirms real link against the LunarG SDK and a working Vulkan driver path.