### PR TITLE
build(custom_kernels): drive hip_* exports from header via dllexport

### DIFF
--- a/3rd-party/custom_kernels/CMakeLists.txt
+++ b/3rd-party/custom_kernels/CMakeLists.txt
@@ -26,7 +26,9 @@ if(NOT HIP_ARCHITECTURES)
 endif()
 message(STATUS "[custom_kernels] Using HIP_ARCHITECTURES: ${HIP_ARCHITECTURES}")
 
-# Build the static library from HIP sources
+# HIP_CUSTOM_KERNELS_EXPORTS makes HIP_KERNEL_API in hip_custom_kernels.h
+# expand to __declspec(dllexport) (Windows) / default visibility (Linux)
+# for the kernel TUs only, so each .obj emits its own /EXPORT directive.
 hip_add_library(hip_custom_kernels STATIC
     hip/rope_kernel.hip
     hip/gqa_kernel.hip
@@ -47,6 +49,8 @@ hip_add_library(hip_custom_kernels STATIC
     hip/causal_conv_step_kernel.hip
     INCLUDE_DIRECTORIES
         ${CMAKE_CURRENT_SOURCE_DIR}/include
+    COMPILE_DEFINITIONS
+        HIP_CUSTOM_KERNELS_EXPORTS
 )
 
 # Export the library path for CompilerDriver to discover at model-compile time

--- a/3rd-party/custom_kernels/cmake/hip_utils.cmake
+++ b/3rd-party/custom_kernels/cmake/hip_utils.cmake
@@ -174,9 +174,11 @@ endfunction()
 
 #------------------------------------------------------------------------------
 # Internal: Compile HIP sources to object files (Windows only)
-# For multi-config generators, creates per-config object files
+# For multi-config generators, creates per-config object files.
+# COMPILE_DEFS items become -D<def> on the hipcc command line; needed because
+# add_custom_command bypasses target_compile_definitions on Windows.
 #------------------------------------------------------------------------------
-function(_hip_compile_sources TARGET_NAME HIP_SOURCES INCLUDE_DIRS COMPILE_OPTS OUTPUT_OBJS)
+function(_hip_compile_sources TARGET_NAME HIP_SOURCES INCLUDE_DIRS COMPILE_OPTS COMPILE_DEFS OUTPUT_OBJS)
     _hip_get_arch_flags(arch_flags)
 
     # Build include flags
@@ -186,6 +188,12 @@ function(_hip_compile_sources TARGET_NAME HIP_SOURCES INCLUDE_DIRS COMPILE_OPTS 
     list(APPEND include_flags "-I" "${HIP_INCLUDE_DIR}")
     foreach(dir ${INCLUDE_DIRS})
         list(APPEND include_flags "-I" "${dir}")
+    endforeach()
+
+    # Build preprocessor definition flags (`FOO` or `FOO=1` -> `-DFOO[=1]`).
+    set(define_flags "")
+    foreach(def ${COMPILE_DEFS})
+        list(APPEND define_flags "-D${def}")
     endforeach()
 
     # MSVC ABI compatibility flags
@@ -226,6 +234,7 @@ function(_hip_compile_sources TARGET_NAME HIP_SOURCES INCLUDE_DIRS COMPILE_OPTS 
                     -o "${output_obj}"
                     ${arch_flags}
                     ${include_flags}
+                    ${define_flags}
                     ${abi_flags}
                     ${warning_flags}
                     $<$<CONFIG:Debug>:-D_DEBUG>
@@ -265,6 +274,7 @@ function(_hip_compile_sources TARGET_NAME HIP_SOURCES INCLUDE_DIRS COMPILE_OPTS 
                     -o "${output_obj}"
                     ${arch_flags}
                     ${include_flags}
+                    ${define_flags}
                     ${abi_flags}
                     ${warning_flags}
                     ${build_flags}
@@ -295,7 +305,7 @@ endfunction()
 #------------------------------------------------------------------------------
 function(hip_add_executable TARGET_NAME)
     cmake_parse_arguments(ARG "" ""
-        "INCLUDE_DIRECTORIES;COMPILE_OPTIONS;LINK_LIBRARIES;DEPENDS" ${ARGN})
+        "INCLUDE_DIRECTORIES;COMPILE_OPTIONS;COMPILE_DEFINITIONS;LINK_LIBRARIES;DEPENDS" ${ARGN})
 
     # Remaining arguments are source files
     set(sources ${ARG_UNPARSED_ARGUMENTS})
@@ -326,7 +336,8 @@ function(hip_add_executable TARGET_NAME)
 
         # Compile HIP sources with hipcc
         _hip_compile_sources(${TARGET_NAME} "${sources}"
-            "${ARG_INCLUDE_DIRECTORIES}" "${all_compile_opts}" hip_objs)
+            "${ARG_INCLUDE_DIRECTORIES}" "${all_compile_opts}"
+            "${ARG_COMPILE_DEFINITIONS}" hip_objs)
 
         # Create custom target for HIP compilation
         add_custom_target(${TARGET_NAME}_hip_compile DEPENDS ${hip_objs})
@@ -383,7 +394,7 @@ endfunction()
 #------------------------------------------------------------------------------
 function(hip_add_library TARGET_NAME)
     cmake_parse_arguments(ARG "STATIC;SHARED" ""
-        "INCLUDE_DIRECTORIES;COMPILE_OPTIONS;LINK_LIBRARIES;DEPENDS" ${ARGN})
+        "INCLUDE_DIRECTORIES;COMPILE_OPTIONS;COMPILE_DEFINITIONS;LINK_LIBRARIES;DEPENDS" ${ARGN})
 
     # Determine library type
     if(ARG_SHARED)
@@ -421,7 +432,8 @@ function(hip_add_library TARGET_NAME)
 
         # Compile HIP sources with hipcc
         _hip_compile_sources(${TARGET_NAME} "${sources}"
-            "${ARG_INCLUDE_DIRECTORIES}" "${all_compile_opts}" hip_objs)
+            "${ARG_INCLUDE_DIRECTORIES}" "${all_compile_opts}"
+            "${ARG_COMPILE_DEFINITIONS}" hip_objs)
 
         # Create custom target for HIP compilation
         add_custom_target(${TARGET_NAME}_hip_compile DEPENDS ${hip_objs})
@@ -459,6 +471,13 @@ function(hip_add_library TARGET_NAME)
     # Apply user-specified options
     if(ARG_INCLUDE_DIRECTORIES)
         target_include_directories(${TARGET_NAME} PUBLIC ${ARG_INCLUDE_DIRECTORIES})
+    endif()
+
+    if(ARG_COMPILE_DEFINITIONS)
+        # PRIVATE: only the kernel TUs of this static lib should see these;
+        # they reach hipcc via `_hip_compile_sources` on Windows and via
+        # CMake's HIP language driver (this target property) on Linux.
+        target_compile_definitions(${TARGET_NAME} PRIVATE ${ARG_COMPILE_DEFINITIONS})
     endif()
 
     if(ARG_LINK_LIBRARIES)

--- a/3rd-party/custom_kernels/include/hip_custom_kernels.h
+++ b/3rd-party/custom_kernels/include/hip_custom_kernels.h
@@ -21,6 +21,25 @@
 
 #include <stdint.h>
 
+/*
+ * HIP_KERNEL_API: dllexport when compiling the kernel TUs (the static lib
+ * sets HIP_CUSTOM_KERNELS_EXPORTS PRIVATE), nothing in consumers that just
+ * include the header. Default ELF visibility on Linux. Lets this header be
+ * the single source of truth for which launchers are exported -- no .def
+ * file to keep in sync.
+ */
+#if defined(_WIN32)
+  #if defined(HIP_CUSTOM_KERNELS_EXPORTS)
+    #define HIP_KERNEL_API __declspec(dllexport)
+  #else
+    #define HIP_KERNEL_API
+  #endif
+#elif defined(__GNUC__) || defined(__clang__)
+  #define HIP_KERNEL_API __attribute__((visibility("default")))
+#else
+  #define HIP_KERNEL_API
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -63,7 +82,7 @@ typedef enum {
  * Currently supported types: HIP_DTYPE_INT64
  * Returns: 0 on success (hipSuccess), non-zero hipError_t on failure
  */
-int hip_elementwise_sub(
+HIP_KERNEL_API int hip_elementwise_sub(
     void* stream,
     const void* lhs,
     const void* rhs,
@@ -103,7 +122,7 @@ int hip_elementwise_sub(
  * HIP_DTYPE_BFLOAT16, HIP_DTYPE_INT32, HIP_DTYPE_INT64
  * Returns: 0 on success (hipSuccess), non-zero on failure (including rank > max)
  */
-int hip_elementwise_where(
+HIP_KERNEL_API int hip_elementwise_where(
     void* stream,
     const void* condition,
     const void* x,
@@ -127,7 +146,7 @@ int hip_elementwise_where(
  * Supported hip_dtype: HIP_DTYPE_FLOAT32, HIP_DTYPE_FLOAT16, HIP_DTYPE_BFLOAT16
  * Returns: 0 on success (hipSuccess), non-zero hipError_t on failure
  */
-int hip_elementwise_reciprocal(
+HIP_KERNEL_API int hip_elementwise_reciprocal(
     void* stream,
     const void* input,
     void* output,
@@ -146,7 +165,7 @@ int hip_elementwise_reciprocal(
  * Supported hip_dtype: HIP_DTYPE_FLOAT32, HIP_DTYPE_FLOAT16, HIP_DTYPE_BFLOAT16
  * Returns: 0 on success (hipSuccess), non-zero hipError_t on failure
  */
-int hip_elementwise_sqrt(
+HIP_KERNEL_API int hip_elementwise_sqrt(
     void* stream,
     const void* input,
     void* output,
@@ -184,7 +203,7 @@ int hip_elementwise_sqrt(
  *
  * Returns: 0 on success (hipSuccess), non-zero hipError_t on failure
  */
-int hip_elementwise_gelu(
+HIP_KERNEL_API int hip_elementwise_gelu(
     void* stream,
     const void* input,
     void* output,
@@ -238,7 +257,7 @@ int hip_elementwise_gelu(
  *
  * Returns: 0 on success, non-zero on error
  */
-int hip_rope_forward(
+HIP_KERNEL_API int hip_rope_forward(
     void* stream,
     const void* input,
     const void* position_ids,
@@ -272,7 +291,7 @@ int hip_rope_forward(
  * seqlens_k: optional device pointer [B] int32. When non-null, past_len is
  * derived from seqlens_k[b]+1-sq (per-batch) and the host past_len is ignored.
  * Pass NULL for host-side past_len. */
-int hip_gqa_kv_cache_append(
+HIP_KERNEL_API int hip_gqa_kv_cache_append(
     void* stream, const void* src, void* cache,
     int batch_size, int sq, int G, int d, int present_seq, int past_len,
     const void* seqlens_k);
@@ -284,7 +303,7 @@ int hip_gqa_kv_cache_append(
  * past_seq and present_seq are the actual sequence dimensions (strides) of the
  * respective buffers.  Handles the stride mismatch (past_seq != present_seq)
  * in a single kernel launch. */
-int hip_gqa_kv_cache_concat(
+HIP_KERNEL_API int hip_gqa_kv_cache_concat(
     void* stream, const void* past, const void* current, void* present,
     int batch_size, int past_len, int sq, int G, int d,
     int past_seq, int present_seq);
@@ -294,7 +313,7 @@ int hip_gqa_kv_cache_concat(
  * out[d+half] = in[d+half]*cos + in[d]*sin
  * seqlens_k: optional device pointer [B] int32. When non-null, past_len is
  * derived from seqlens_k[b]+1-seq_len and the host past_len is ignored. */
-int hip_gqa_rope(
+HIP_KERNEL_API int hip_gqa_rope(
     void* stream, const void* input, void* output,
     const void* cos_cache, const void* sin_cache,
     int batch_size, int seq_len, int num_heads,
@@ -303,33 +322,33 @@ int hip_gqa_rope(
 
 /* Transpose middle two dims of 4D tensor:
  * [B, dim1, dim2, D] -> [B, dim2, dim1, D] */
-int hip_gqa_transpose_mid_dims(
+HIP_KERNEL_API int hip_gqa_transpose_mid_dims(
     void* stream, const void* src, void* dst,
     int batch_size, int dim1, int dim2, int D);
 
 /* KV group expansion: replicate G groups -> H heads.
  * For head h, copies from group g = h / heads_per_group. */
-int hip_gqa_expand_kv(
+HIP_KERNEL_API int hip_gqa_expand_kv(
     void* stream, const void* src, void* dst,
     int total_heads, int heads_per_group,
     int src_stride, int dst_stride, int copy_elems);
 
 /* Split packed QKV [B*S, (H+2*G)*d] into separate Q, K, V buffers.
  * Q: [B*S, H*d], K: [B*S, G*d], V: [B*S, G*d] */
-int hip_gqa_split_qkv(
+HIP_KERNEL_API int hip_gqa_split_qkv(
     void* stream, const void* packed, void* Q, void* K, void* V,
     int batch_size, int seq_len, int num_heads, int kv_num_heads, int head_dim);
 
 /* Causal mask (prefill only): S[k,q] = -inf where k > past_len + q.
  * When local_window_size > 0, also masks k < past_len + q - local_window_size + 1. */
-int hip_gqa_causal_mask(
+HIP_KERNEL_API int hip_gqa_causal_mask(
     void* stream, void* S,
     int total_heads, int skv, int sq,
     int batch_stride, int past_len, int local_window_size);
 
 /* Causal mask on fp32 Score matrix.  Same semantics as hip_gqa_causal_mask
  * but operates on float* and writes -INFINITY instead of -65504. */
-int hip_gqa_causal_mask_f32(
+HIP_KERNEL_API int hip_gqa_causal_mask_f32(
     void* stream, void* S,
     int total_heads, int skv, int sq,
     int batch_stride, int past_len, int local_window_size);
@@ -340,7 +359,7 @@ int hip_gqa_causal_mask_f32(
  *   softmax_i = exp(x_i) / (exp(head_sink[h]) + sum_j exp(x_j))
  * When head_sink is null but use_smooth_softmax is set, uses sink = 0:
  *   softmax_i = exp(x_i) / (exp(0) + sum_j exp(x_j)) */
-int hip_gqa_softmax_inplace(
+HIP_KERNEL_API int hip_gqa_softmax_inplace(
     void* stream, void* data,
     int total_head_queries, int rows, int cols,
     int batch_stride, const void* head_sink, int num_heads,
@@ -349,7 +368,7 @@ int hip_gqa_softmax_inplace(
 /* Column-wise softmax: fp32 input -> fp16 output.
  * Reads fp32 Score matrix (no fp16 overflow/inf), writes fp16 probabilities.
  * input_batch_stride is in float elements, output_batch_stride in half elements. */
-int hip_gqa_softmax_f32_to_f16(
+HIP_KERNEL_API int hip_gqa_softmax_f32_to_f16(
     void* stream, const void* input_f32, void* output_f16,
     int total_head_queries, int rows, int cols,
     int input_batch_stride, int output_batch_stride,
@@ -364,7 +383,7 @@ int hip_gqa_softmax_f32_to_f16(
  * reads total_seq = seqlens_k[b]+1 as the loop bound (instead of skv).
  * NOTE: assumes wave32 (RDNA); not portable to CDNA/wave64 without changes
  * to the warp shuffle reduction tree. */
-int hip_gqa_fused_decode(
+HIP_KERNEL_API int hip_gqa_fused_decode(
     void* stream, const void* Q, const void* Kcache, const void* Vcache,
     void* O, int B, int H, int G, int d, int skv, int max_seq,
     float scale, const void* seqlens_k);
@@ -372,7 +391,7 @@ int hip_gqa_fused_decode(
 /* Fused GQA prefill (sq > 1, d == 128): Flash Attention 2 with WMMA
  * tile GEMMs and online softmax. Double-buffered KV tiles, causal mask.
  * Replaces steps 3, 6-11 of the decomposed pipeline. */
-int hip_gqa_fused_prefill(
+HIP_KERNEL_API int hip_gqa_fused_prefill(
     void* stream, const void* Q, const void* Kcache, const void* Vcache,
     void* O, int B, int H, int G, int sq, int skv, int max_seq, int past_len,
     float scale);
@@ -405,7 +424,7 @@ int hip_gqa_fused_prefill(
  * s_h = 0 for all heads. This is the gpt-oss-20b / Mistral-style attention
  * sink. The partials are unaffected; the term is folded in by the reduce
  * kernel. */
-int hip_gqa_flash_decode(
+HIP_KERNEL_API int hip_gqa_flash_decode(
     void* stream,
     const void* Q, const void* Kcache, const void* Vcache,
     void* O,
@@ -435,7 +454,7 @@ int hip_gqa_flash_decode(
  * Currently supported conversions: INT64 -> INT32
  * Returns: 0 on success, non-zero on failure
  */
-int hip_cast(
+HIP_KERNEL_API int hip_cast(
     void* stream,
     const void* input,
     void* output,
@@ -466,7 +485,7 @@ int hip_cast(
  * Supported element sizes: 2 (f16/bf16), 4 (f32/i32), 8 (i64/f64)
  * Returns: 0 on success, non-zero on failure
  */
-int hip_gather(
+HIP_KERNEL_API int hip_gather(
     void* stream,
     const void* data,
     const void* indices,
@@ -500,7 +519,7 @@ int hip_gather(
  *     final result is narrowed back to half.
  * Returns: 0 on success, non-zero on failure
  */
-int hip_reduce_sum(
+HIP_KERNEL_API int hip_reduce_sum(
     void* stream,
     const void* data,
     void* output,
@@ -532,7 +551,7 @@ int hip_reduce_sum(
  *                  HIP_DTYPE_FLOAT32, HIP_DTYPE_FLOAT64
  * Returns: 0 on success, non-zero on failure
  */
-int hip_range(
+HIP_KERNEL_API int hip_range(
     void* stream,
     const void* start,
     const void* limit,
@@ -568,7 +587,7 @@ int hip_range(
  *
  * Returns: 0 on success, non-zero hipError_t / -1 on failure.
  */
-int hip_transpose(
+HIP_KERNEL_API int hip_transpose(
     void* stream,
     const void* input,
     void* output,
@@ -613,7 +632,7 @@ int hip_transpose(
  *
  * Returns: 0 on success, non-zero on failure
  */
-int hip_matmul_nbits(
+HIP_KERNEL_API int hip_matmul_nbits(
     void* stream,
     const void* A,
     const void* B,
@@ -643,9 +662,9 @@ int hip_matmul_nbits(
  *   N:         output rows
  *   groups_k:  K / block_size (round-up)
  */
-void hip_matmul_nbits_unpack_zp_u8(
+HIP_KERNEL_API void hip_matmul_nbits_unpack_zp_u8(
     void* stream, const void* zp_packed, void* dst_u8, int N, int groups_k);
-void hip_matmul_nbits_convert_zp_fp16(
+HIP_KERNEL_API void hip_matmul_nbits_convert_zp_fp16(
     void* stream, const void* zp_packed, void* dst_fp16, int N, int groups_k);
 
 /* =========================================================================
@@ -665,7 +684,7 @@ void hip_matmul_nbits_convert_zp_fp16(
  *   expert_weights - GPU [num_tokens, k] (output, same type as probs)
  *   normalize      - 1 to normalize selected weights (sum-to-one)
  */
-int hip_qmoe_topk_routing(
+HIP_KERNEL_API int hip_qmoe_topk_routing(
     void* stream,
     const void* router_probs,
     void* expert_indices,
@@ -679,7 +698,7 @@ int hip_qmoe_topk_routing(
 /* Gather rows: gathered[i,:] = input[token_ids[i],:]
  *   token_ids - GPU [count] int32
  */
-int hip_qmoe_gather_tokens(
+HIP_KERNEL_API int hip_qmoe_gather_tokens(
     void* stream,
     const void* input,
     void* gathered,
@@ -691,7 +710,7 @@ int hip_qmoe_gather_tokens(
 /* In-place bias: data[i,j] += bias[j]
  *   No-op if bias is NULL.
  */
-int hip_qmoe_add_bias(
+HIP_KERNEL_API int hip_qmoe_add_bias(
     void* stream,
     void* data,
     const void* bias,
@@ -705,7 +724,7 @@ int hip_qmoe_add_bias(
  *   L = clamp(linear, -limit, limit)
  *   out = G * sigmoid(alpha*G) * (L + beta)
  */
-int hip_qmoe_swiglu(
+HIP_KERNEL_API int hip_qmoe_swiglu(
     void* stream,
     const void* input,
     void* output,
@@ -720,7 +739,7 @@ int hip_qmoe_swiglu(
  *   token_ids - GPU [count] int32
  *   weights   - GPU [count] (same type as output)
  */
-int hip_qmoe_scatter_add(
+HIP_KERNEL_API int hip_qmoe_scatter_add(
     void* stream,
     void* output,
     const void* expert_out,
@@ -747,7 +766,7 @@ int hip_qmoe_scatter_add(
  *
  * Constraints: fp16 only; num_experts <= 1024.
  */
-int hip_qmoe_bucket_tokens(
+HIP_KERNEL_API int hip_qmoe_bucket_tokens(
     void* stream,
     const void* expert_indices,
     const void* expert_weights,
@@ -788,7 +807,7 @@ int hip_qmoe_bucket_tokens(
  * Constraints: fp16 only (element_size_bytes == 2); hidden_size and
  * inter_size both multiples of 32; block_size > 0 and even.
  */
-int hip_qmoe_decode_fused(
+HIP_KERNEL_API int hip_qmoe_decode_fused(
     void* stream,
     const void* input,
     const void* expert_indices,
@@ -894,7 +913,7 @@ int hip_qmoe_decode_fused(
  *
  * Returns: 0 on success, non-zero on failure
  */
-int hip_linear_attention_decode(
+HIP_KERNEL_API int hip_linear_attention_decode(
     void* stream,
     const void* query,
     const void* key,
@@ -954,7 +973,7 @@ int hip_linear_attention_decode(
  *
  * Returns: 0 on success, non-zero on failure.
  */
-int hip_causal_conv_step_decode(
+HIP_KERNEL_API int hip_causal_conv_step_decode(
     void* stream,
     const void* input,
     const void* weight,
@@ -992,7 +1011,7 @@ int hip_causal_conv_step_decode(
  *
  * Returns: 0 on success, non-zero on failure
  */
-int hip_gemm_wmma_fp16(void* stream, const void* A, const void* B,
+HIP_KERNEL_API int hip_gemm_wmma_fp16(void* stream, const void* A, const void* B,
                        void* C, int M, int K, int N);
 
 #ifdef __cplusplus

--- a/docs/design/custom_kernel_design.md
+++ b/docs/design/custom_kernel_design.md
@@ -230,6 +230,8 @@ The `custom_kernels/CMakeLists.txt` install rules ensure that after `cmake --ins
 
 CompilerDriver discovers the `.lib` at model-compile time via the configured install prefix path, and passes it to DLLLinker alongside MIOpen/hipBLASLt import libs.
 
+Each launcher in `hip_custom_kernels.h` is declared with `HIP_KERNEL_API`, which expands to `__declspec(dllexport)` (Windows) / default ELF visibility (Linux) only when `HIP_CUSTOM_KERNELS_EXPORTS` is defined. The static lib's `CMakeLists.txt` sets that define PRIVATE so it applies only while compiling the kernel TUs; on Windows each kernel `.obj` therefore carries its own `/EXPORT:hip_xxx` directive in `.drectve`. The header is the single source of truth — adding `HIP_KERNEL_API` to a new launcher is the only per-kernel step needed; no `.def` file to maintain.
+
 ### 10. `custom_kernels/hip/matmul_nbits_kernel.hip`
 
 Implements MatMulNBits — fused dequant + matmul for INT4 packed weights (FP16 activations). This is the dominant operator in INT4 LLM decode (~78% of GPU time for Llama 8B).


### PR DESCRIPTION
## Why

After the upcoming bitcode pivot, the per-model `model.dll` no longer
exists -- per-model artifacts become bitcode JIT'd in-process by
`BitcodeJIT` inside `onnxruntime_morphizen_ep.dll`. The `hip_*` kernel
launchers, which today live in each `model.dll`, must therefore be
embedded in `onnxruntime_morphizen_ep.dll` and exported, so the JIT can
resolve them via `GetProcAddress`.

## How

`HIP_KERNEL_API` macro in `hip_custom_kernels.h` expands to
`__declspec(dllexport)` (Windows) / default ELF visibility (Linux) when
the kernel TUs are compiled, so each kernel `.obj` carries its own
`/EXPORT:hip_<name>` directive. The kernel header is the single source
of truth; no parallel `.def` to drift.

The kernels lib's `CMakeLists.txt` sets `HIP_CUSTOM_KERNELS_EXPORTS`
PRIVATE; `hip_utils.cmake` is extended with a `COMPILE_DEFINITIONS`
keyword that threads `-D<name>` through to the hipcc command line
(needed because the kernel `.obj`s are produced by `add_custom_command`,
not a CMake compile rule).

## No-op on `main`

This PR does not add the `WHOLE_ARCHIVE` link of `hip_custom_kernels`
into the EP DLL -- that lands with the bitcode PR. Until then the
`/EXPORT` directives never reach the EP DLL, so its export table is
unchanged.
