### PR TITLE
feat(onnx-to-hip): lower onnx.Shape and fold Gather(Shape) for dynseqlen

### DIFF
--- a/lib/Conversion/OnnxToHip/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHip/CMakeLists.txt
@@ -51,6 +51,8 @@ add_library(OnnxToHip STATIC
   AndConversion.cpp
   SizeConversion.cpp
   NonZeroConversion.cpp
+  GatherShapeFold.cpp
+  ShapeConversion.cpp
 )
 
 add_dependencies(OnnxToHip

--- a/lib/Conversion/OnnxToHip/GatherShapeFold.cpp
+++ b/lib/Conversion/OnnxToHip/GatherShapeFold.cpp
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- GatherShapeFold.cpp - Pre-lowering Gather(Shape) folding ----------===//
+//
+// Pre-lowering walk that recognizes the common transformer-shape-arithmetic
+// idiom
+//
+//   %shape = onnx.Shape(%x)                  : tensor<Nxi64>
+//   %idx   = onnx.Constant{value=dense<[k]>} : tensor<...xi64>
+//   %res   = onnx.Gather(%shape, %idx)       : tensor<...xi64>
+//
+// and folds it to
+//
+//   %dim   = tensor.dim %x, %k               : index
+//   %dim64 = arith.index_cast %dim           : index to i64
+//   %res   = tensor.from_elements %dim64     : tensor<...xi64>
+//
+// Why this matters (gfx1151 dynseqlen regression):
+//   Pre-dynseqlen, all shapes were static and this whole chain folded to a
+//   compile-time constant that GenerateInterface placed in constants.bin
+//   (already on GPU at init -- no per-step host store).  Dynseqlen broke the
+//   constant fold, so the same arithmetic now happens at runtime.  The
+//   bufferized form of the full Shape result is `memref<Nxi64>` written by N
+//   host stores, then absorbed by PoolAllocs into the GPU pool.  On gfx1151
+//   the pool is real device memory and the host stores SEGV.
+//
+// Folding here shrinks `memref<Nxi64>` to `memref<i64>` (one host store)
+// AND localizes the boundary, so the late hip.scalar_to_gpu_buf rewrite can
+// match the residual `memref.alloc + single store + GPU consumer` pattern
+// and replace it with an explicit H2D copy.
+//
+// Runs BEFORE lowerOnnxConstants so the index value is still inline in the
+// onnx.Constant `value` attribute (after externalization it would be hidden
+// behind memref.get_global pointing into the constants blob).
+//
+// Non-goals
+// ---------
+//   - Folding Gather over arbitrary tensors: this fold matches ONLY when
+//     the Gather source is `onnx.Shape`.  Generic Gather lowerings live
+//     elsewhere and run later in the pipeline.
+//   - Folding Gather with non-constant indices: `getInlineScalarIndex`
+//     requires an `onnx.Constant` operand whose `value` attribute is a
+//     single i32/i64 element.  Anything else survives unchanged so the
+//     general Gather conversion can handle it.
+//   - Multi-element Gather results: the result type must be 0-D (scalar
+//     Gather) or 1-D with a single element (1xi64).  Anything wider is
+//     left to the general Gather lowering -- folding it here would
+//     require materializing a multi-dim `tensor.from_elements`, which is
+//     exactly what `ShapeConversion.cpp` is for.
+//   - Constant-folding the gathered Shape itself: that responsibility
+//     lives in `ShapeConversion.cpp`.  The two passes are intentionally
+//     orthogonal -- this fold collapses Shape -> Gather chains;
+//     ShapeConversion handles the standalone Shape op when the chain
+//     doesn't end in Gather.
+//
+//===----------------------------------------------------------------------===//
+
+#include "OnnxToHipUtils.h"
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+
+namespace mlir {
+namespace hip {
+
+namespace {
+
+/// Return the single integer value of a 0-D or single-element ONNX
+/// constant, or std::nullopt if the op is not eligible.
+static std::optional<int64_t> getInlineScalarIndex(mlir::Operation *constOp) {
+  if (!constOp || constOp->getName().getStringRef() != "onnx.Constant")
+    return std::nullopt;
+  auto valueAttr = constOp->getAttrOfType<mlir::DenseElementsAttr>("value");
+  if (!valueAttr)
+    return std::nullopt;
+  if (valueAttr.getNumElements() != 1)
+    return std::nullopt;
+  auto elemType = valueAttr.getElementType();
+  if (!elemType.isInteger(32) && !elemType.isInteger(64))
+    return std::nullopt;
+  return (*valueAttr.getValues<mlir::APInt>().begin()).getSExtValue();
+}
+
+} // namespace
+
+mlir::LogicalResult foldGatherShapeBeforeLowering(mlir::func::FuncOp funcOp) {
+  // Collect Gather ops first; rewriting in place during walk is unsafe.
+  llvm::SmallVector<mlir::Operation *> gathers;
+  funcOp.walk([&](mlir::Operation *op) {
+    if (op->getName().getStringRef() == "onnx.Gather")
+      gathers.push_back(op);
+  });
+
+  for (mlir::Operation *gatherOp : gathers) {
+    if (gatherOp->getNumOperands() != 2)
+      continue;
+    mlir::Operation *shapeOp = gatherOp->getOperand(0).getDefiningOp();
+    mlir::Operation *constOp = gatherOp->getOperand(1).getDefiningOp();
+    if (!shapeOp || shapeOp->getName().getStringRef() != "onnx.Shape")
+      continue;
+
+    auto idxOpt = getInlineScalarIndex(constOp);
+    if (!idxOpt)
+      continue;
+
+    // ONNX Gather has `axis` attribute; for Shape (1-D) only axis 0 is
+    // meaningful. Older exporters omit the attribute (default 0).
+    int64_t axis = 0;
+    if (auto axisAttr = gatherOp->getAttrOfType<mlir::IntegerAttr>("axis"))
+      axis = axisAttr.getSInt();
+    if (axis != 0)
+      continue;
+
+    mlir::Value shapeInput = shapeOp->getOperand(0);
+    auto inputType =
+        mlir::dyn_cast<mlir::RankedTensorType>(shapeInput.getType());
+    if (!inputType)
+      continue;
+    int64_t rank = inputType.getRank();
+
+    // Normalize Shape's start/end per ONNX Shape-15 spec.  The Gather index
+    // k is an index INTO the 1-D Shape result of length (end - start), not
+    // into the input's full rank — so the negative-index normalization on k
+    // must use the SUB-RANGE length, not the full rank, per ONNX Gather
+    // semantics on a 1-D tensor of length L (k += L if k < 0).
+    int64_t start = 0;
+    int64_t end = rank;
+    if (auto startAttr = shapeOp->getAttrOfType<mlir::IntegerAttr>("start"))
+      start = startAttr.getSInt();
+    if (auto endAttr = shapeOp->getAttrOfType<mlir::IntegerAttr>("end"))
+      end = endAttr.getSInt();
+    if (start < 0)
+      start += rank;
+    if (end < 0)
+      end += rank;
+    start = std::max(start, int64_t(0));
+    end = std::min(end, rank);
+    int64_t rangeLen = std::max(end - start, int64_t(0));
+    if (rangeLen == 0)
+      continue;
+
+    int64_t k = *idxOpt;
+    if (k < 0)
+      k += rangeLen; // ONNX Gather: normalize against TARGET tensor length.
+    if (k < 0 || k >= rangeLen)
+      continue;
+    int64_t absDim = start + k;
+
+    auto resultType = mlir::dyn_cast<mlir::RankedTensorType>(
+        gatherOp->getResult(0).getType());
+    if (!resultType)
+      continue;
+    if (!resultType.getElementType().isInteger(64))
+      continue;
+    // Result must be 0-D (scalar Gather) or 1-D with one element
+    // (1-element-tensor Gather). Anything else is not the pattern we fold.
+    if (resultType.getRank() == 0) {
+      // OK, scalar.
+    } else if (resultType.getRank() == 1 && resultType.getDimSize(0) == 1) {
+      // OK, 1xi64.
+    } else {
+      continue;
+    }
+
+    mlir::Location loc = gatherOp->getLoc();
+    mlir::OpBuilder builder(gatherOp);
+    auto i64Type = builder.getI64Type();
+
+    mlir::Value dimI64;
+    if (inputType.isDynamicDim(absDim)) {
+      mlir::Value dimVal =
+          mlir::tensor::DimOp::create(builder, loc, shapeInput, absDim);
+      dimI64 = mlir::arith::IndexCastOp::create(builder, loc, i64Type, dimVal);
+    } else {
+      dimI64 = mlir::arith::ConstantOp::create(
+          builder, loc,
+          builder.getI64IntegerAttr(inputType.getDimSize(absDim)));
+    }
+
+    mlir::Value newResult = mlir::tensor::FromElementsOp::create(
+        builder, loc, resultType, mlir::ValueRange{dimI64});
+    gatherOp->getResult(0).replaceAllUsesWith(newResult);
+    gatherOp->erase();
+    // Leave shapeOp/constOp in place; they may have other uses, and a later
+    // canonicalization pass / DCE will remove them if not.
+  }
+  return mlir::success();
+}
+
+} // namespace hip
+} // namespace mlir

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -474,6 +474,7 @@ static mlir::LogicalResult convertComputeOps(mlir::func::FuncOp funcOp,
   populateCastConversionPatterns(patterns, ctx);
   populateReduceSumConversionPatterns(patterns, ctx);
   populateGatherConversionPatterns(patterns, ctx);
+  populateShapeConversionPatterns(patterns, ctx);
   populateConvConversionPatterns(patterns, ctx);
   populateNormConversionPatterns(patterns, ctx);
   populateRotaryEmbeddingConversionPatterns(patterns, ctx);
@@ -706,6 +707,11 @@ void ConvertOnnxToHipPass::runOnOperation() {
               funcOp, std::move(preFoldPatterns), cfg)))
         return signalPassFailure();
     }
+    // Fold the Gather(Shape(x), const_idx) idiom BEFORE constant lowering
+    // externalizes the index value (the fold needs to see the inline
+    // DenseElementsAttr on the onnx.Constant index operand).
+    if (mlir::failed(foldGatherShapeBeforeLowering(funcOp)))
+      return signalPassFailure();
     if (mlir::failed(
             lowerOnnxConstants(module, funcOp, minElems, extState.get())))
       return signalPassFailure();
@@ -725,13 +731,21 @@ void ConvertOnnxToHipPass::runOnOperation() {
     logSubpass("constants + compute ops");
   }
 
-  // Clean up onnx.NoValue and onnx.EntryPoint ops
+  // Clean up onnx.NoValue and onnx.EntryPoint, plus any other unregistered
+  // onnx.* op that ended up with no uses after conversion. The latter case
+  // is the dead-shape-arithmetic pattern shipped by some HF ONNX exports
+  // (e.g. Phi-4's `pos_ids_reformat/Concat` chain whose result is consumed
+  // by a Reshape that lowered to tensor.expand_shape via static type info).
+  // Without this DCE, one-shot-bufferize trips on the unregistered op
+  // because it has tensor-typed operands but no bufferization interface,
+  // and the whole pipeline aborts with "op was not bufferized" -- which is
+  // silent (CPU fallback) at the EP level.
   llvm::SmallVector<mlir::Operation *> toErase;
   module.walk([&](mlir::Operation *op) {
     llvm::StringRef name = op->getName().getStringRef();
-    if (name == "onnx.NoValue" && op->use_empty())
+    if (name == "onnx.EntryPoint")
       toErase.push_back(op);
-    else if (name == "onnx.EntryPoint")
+    else if (name.starts_with("onnx.") && op->use_empty())
       toErase.push_back(op);
   });
   for (auto *op : toErase)

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
@@ -142,6 +142,8 @@ void populateMultiHeadAttentionConversionPatterns(RewritePatternSet &patterns,
                                                   MLIRContext *ctx);
 void populateGatherConversionPatterns(RewritePatternSet &patterns,
                                       MLIRContext *ctx);
+void populateShapeConversionPatterns(RewritePatternSet &patterns,
+                                     MLIRContext *ctx);
 void populateReshapeConversionPatterns(RewritePatternSet &patterns,
                                        MLIRContext *ctx);
 void populateCausalConvWithStateConversionPatterns(RewritePatternSet &patterns,
@@ -200,6 +202,13 @@ void populateSizeConversionPatterns(RewritePatternSet &patterns,
                                     MLIRContext *ctx);
 void populateNonZeroConversionPatterns(RewritePatternSet &patterns,
                                        MLIRContext *ctx);
+
+/// Pre-lowering walk: fold the Gather(Shape(x), const_idx) idiom into
+/// tensor.from_elements over a tensor.dim of x. Must run BEFORE
+/// lowerOnnxConstants so the index value is still inline in the
+/// onnx.Constant `value` attribute. See GatherShapeFold.cpp for the
+/// dynseqlen-regression rationale.
+mlir::LogicalResult foldGatherShapeBeforeLowering(mlir::func::FuncOp funcOp);
 
 } // namespace hip
 } // namespace mlir

--- a/lib/Conversion/OnnxToHip/ReshapeConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ReshapeConversion.cpp
@@ -291,6 +291,105 @@ struct SqueezeToStdTensor : public mlir::RewritePattern {
 };
 
 //===----------------------------------------------------------------------===//
+// Scalar fold: tensor.extract through reshape from tensor.from_elements
+//===----------------------------------------------------------------------===//
+//
+// Upstream MLIR folds `tensor.extract(tensor.from_elements)` directly into the
+// corresponding element value (see `ExtractOp::fold` in
+// `mlir/lib/Dialect/Tensor/IR/TensorOps.cpp`).  It does *not* look through
+// `tensor.collapse_shape` or `tensor.expand_shape` to reach `from_elements`.
+//
+// That one-hop gap matters here because morphizen's ONNX Loop importer emits a
+// `tensor.collapse_shape` (typically `tensor<1xi64> -> tensor<i64>`) to
+// rank-reduce the trip-count tensor coming out of `onnx.Shape`, and the
+// `ShapeToTensorDims` pattern (in `ShapeConversion.cpp`) emits
+// `tensor.from_elements(tensor.dim ...)` for `onnx.Shape`. Without this
+// fold the chain
+//
+//   %scalar = arith.index_cast %dim_index : index to i64
+//   %t1     = tensor.from_elements %scalar : tensor<1xi64>
+//   %t0     = tensor.collapse_shape %t1 [] : tensor<1xi64> into tensor<i64>
+//   %v      = tensor.extract %t0[] : tensor<i64>
+//   %trip   = arith.index_cast %v : i64 to index
+//
+// survives bufferization as
+//
+//   %a = memref.alloc() : memref<1xi64>
+//   memref.store %scalar, %a[0]
+//   %b = memref.collapse_shape %a [] : memref<1xi64> into memref<i64>
+//   %v = memref.load %b[]
+//
+// which post-OnnxToHip becomes a `hip.alloc(memref<1xi64>) ... hip.free` pair
+// around the `hip.loop` -- a heap roundtrip whose only purpose is to read back
+// an SSA `index` value that was already in hand.  Other MLIR-based ONNX
+// compilers paper over this with full scalarization passes (torch-mlir's
+// `ScalarizeShapes`, onnx-mlir's `IndexExpr` framework); this pattern is the
+// minimal version: extend the upstream fold one hop.
+//
+// Algorithm: both `tensor.collapse_shape` and `tensor.expand_shape` preserve
+// the row-major linearization of elements, so the flat row-major index of an
+// extract in the reshaped result equals the index into the `from_elements`
+// operand list (which is itself row-major over the source shape).  Requires
+// the reshape result type to have a static shape and the extract indices to
+// be compile-time constants.
+struct ExtractThroughReshapeFromElements
+    : public mlir::OpRewritePattern<mlir::tensor::ExtractOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::tensor::ExtractOp extractOp,
+                  mlir::PatternRewriter &rewriter) const override {
+    mlir::Operation *reshapeOp = extractOp.getTensor().getDefiningOp();
+    if (!reshapeOp ||
+        !mlir::isa<mlir::tensor::CollapseShapeOp, mlir::tensor::ExpandShapeOp>(
+            reshapeOp))
+      return rewriter.notifyMatchFailure(
+          extractOp, "tensor source not a collapse/expand_shape");
+
+    auto fromElementsOp =
+        reshapeOp->getOperand(0).getDefiningOp<mlir::tensor::FromElementsOp>();
+    if (!fromElementsOp)
+      return rewriter.notifyMatchFailure(
+          extractOp, "reshape source not a tensor.from_elements");
+
+    auto reshapeResultType =
+        mlir::cast<mlir::RankedTensorType>(reshapeOp->getResult(0).getType());
+    if (!reshapeResultType.hasStaticShape())
+      return rewriter.notifyMatchFailure(extractOp,
+                                         "reshape result has dynamic shape");
+
+    llvm::SmallVector<int64_t> indices;
+    indices.reserve(extractOp.getIndices().size());
+    for (mlir::Value idx : extractOp.getIndices()) {
+      llvm::APInt val;
+      if (!mlir::matchPattern(idx, mlir::m_ConstantInt(&val)))
+        return rewriter.notifyMatchFailure(extractOp,
+                                           "non-constant extract index");
+      indices.push_back(val.getSExtValue());
+    }
+    if (static_cast<int64_t>(indices.size()) != reshapeResultType.getRank())
+      return rewriter.notifyMatchFailure(extractOp,
+                                         "extract rank / index count mismatch");
+
+    int64_t flatIndex = 0;
+    int64_t stride = 1;
+    for (int64_t i = reshapeResultType.getRank() - 1; i >= 0; --i) {
+      flatIndex += indices[i] * stride;
+      stride *= reshapeResultType.getDimSize(i);
+    }
+
+    auto elements = fromElementsOp.getElements();
+    if (flatIndex < 0 || flatIndex >= static_cast<int64_t>(elements.size()))
+      return rewriter.notifyMatchFailure(extractOp,
+                                         "flat index out of range for "
+                                         "from_elements operand list");
+
+    rewriter.replaceOp(extractOp, elements[flatIndex]);
+    return mlir::success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
 // Split -> standard tensor ops (zero-cost slice views)
 //===----------------------------------------------------------------------===//
 
@@ -549,7 +648,7 @@ struct SplitToStdTensor : public mlir::RewritePattern {
 void populateReshapeConversionPatterns(RewritePatternSet &patterns,
                                        MLIRContext *ctx) {
   patterns.add<ReshapeToStdTensor, UnsqueezeToStdTensor, SqueezeToStdTensor,
-               SplitToStdTensor>(ctx);
+               ExtractThroughReshapeFromElements, SplitToStdTensor>(ctx);
 }
 
 } // namespace hip

--- a/lib/Conversion/OnnxToHip/ShapeConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ShapeConversion.cpp
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- ShapeConversion.cpp - lower onnx.Shape to tensor ops ---*- C++ -*-===//
+//
+// Lowers `onnx.Shape(input)` to a chain of `tensor.dim` queries combined
+// via `tensor.from_elements`, so the Shape op participates in the standard
+// shape-inference and bufferization machinery instead of surviving as an
+// opaque ONNX-dialect op into the lowering passes.
+//
+// Why this pass exists
+// --------------------
+// Pre-dynseqlen, every input was statically shaped and `onnx.Shape` folded
+// to a compile-time `onnx.Constant` that GenerateInterface placed in the
+// constants blob (already on GPU at init -- no per-step work).  Dynseqlen
+// breaks the constant fold for inputs whose dims are symbolic, so `Shape`
+// now needs an actual runtime lowering.
+//
+// Lowering to `tensor.dim + tensor.from_elements` keeps the result in the
+// tensor world long enough that one-shot-bufferize converts the chain into
+// `memref.dim + memref.alloc + memref.store + ...` -- a form the rest of
+// the pipeline (PromoteStridedHipOperands, MaterializeHostScalars,
+// PoolAllocs) already knows how to handle.  Lowering directly to the
+// memref dialect here would have to reinvent that chain.
+//
+// ONNX `Shape` carries optional `start`/`end` attributes that pick a
+// sub-range of the input's dims.  Negative bounds are handled per spec
+// (add rank, then clamp); the resulting `tensor.dim` ops reference absolute
+// dim indices directly.
+//
+// Non-goals
+// ---------
+//   - Unranked input: returns notifyMatchFailure so the downstream
+//     conversion framework surfaces a clear error rather than silently
+//     producing an opaque Shape op.  See test_shape.mlir for the
+//     negative-case lockdown.
+//   - Reproducing the upstream constant-fold path: ONNX-spec canonicalization
+//     handles fully-static Shape ops earlier in the pipeline.  This pass
+//     fires only for the surviving (non-folded) cases, which by construction
+//     reference at least one dynamic dim.
+//   - Folding `onnx.Shape` followed by `onnx.Gather`: that idiom is handled
+//     by `GatherShapeFold.cpp` BEFORE this pass runs.  The two passes are
+//     intentionally orthogonal so they compose cleanly.
+//
+//===----------------------------------------------------------------------===//
+
+#include "OnnxToHipUtils.h"
+
+namespace mlir {
+namespace hip {
+namespace {
+
+// Lower onnx.Shape(input) -> tensor<Nxi64> containing the (possibly
+// sub-ranged) shape of the input.  Empty ranges (start >= end after
+// normalization) emit a 0-element constant tensor per ONNX spec rather than
+// failing the match -- preserving op semantics is the priority over
+// surfacing a "shouldn't happen" error.
+struct ShapeToTensorDims : public mlir::RewritePattern {
+  ShapeToTensorDims(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.Shape", /*benefit=*/1, ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override {
+    mlir::Location loc = op->getLoc();
+    mlir::Value input = op->getOperand(0);
+    auto inputType = mlir::dyn_cast<mlir::RankedTensorType>(input.getType());
+    if (!inputType)
+      return rewriter.notifyMatchFailure(op, "input must be a ranked tensor");
+
+    int64_t rank = inputType.getRank();
+
+    // ONNX Shape op supports start/end attributes for partial shape queries
+    int64_t start = 0;
+    int64_t end = rank;
+    if (auto startAttr = op->getAttrOfType<mlir::IntegerAttr>("start"))
+      start = startAttr.getSInt();
+    if (auto endAttr = op->getAttrOfType<mlir::IntegerAttr>("end"))
+      end = endAttr.getSInt();
+
+    if (start < 0)
+      start += rank;
+    if (end < 0)
+      end += rank;
+    start = std::max(start, int64_t(0));
+    end = std::min(end, rank);
+
+    auto i64Type = rewriter.getI64Type();
+
+    // ONNX spec: when the requested range is empty (start >= end after
+    // normalization), Shape returns a 1-D tensor with zero elements.
+    // Returning notifyMatchFailure here would leave onnx.Shape in the IR
+    // and crash later — emit the empty constant directly.
+    if (start >= end) {
+      auto emptyType = mlir::RankedTensorType::get({0}, i64Type);
+      auto emptyAttr =
+          mlir::DenseElementsAttr::get(emptyType, llvm::ArrayRef<int64_t>{});
+      mlir::Value result =
+          arith::ConstantOp::create(rewriter, loc, emptyType, emptyAttr);
+      rewriter.replaceOp(op, result);
+      return mlir::success();
+    }
+
+    llvm::SmallVector<mlir::Value> dimValues;
+    for (int64_t i = start; i < end; ++i) {
+      if (inputType.isDynamicDim(i)) {
+        mlir::Value dimIdx = arith::ConstantIndexOp::create(rewriter, loc, i);
+        mlir::Value dimVal =
+            tensor::DimOp::create(rewriter, loc, input, dimIdx);
+        mlir::Value dimI64 =
+            arith::IndexCastOp::create(rewriter, loc, i64Type, dimVal);
+        dimValues.push_back(dimI64);
+      } else {
+        int64_t staticDim = inputType.getDimSize(i);
+        dimValues.push_back(arith::ConstantOp::create(
+            rewriter, loc, rewriter.getI64IntegerAttr(staticDim)));
+      }
+    }
+
+    mlir::Value result =
+        tensor::FromElementsOp::create(rewriter, loc, dimValues);
+    rewriter.replaceOp(op, result);
+    return mlir::success();
+  }
+};
+
+} // namespace
+
+void populateShapeConversionPatterns(mlir::RewritePatternSet &patterns,
+                                     mlir::MLIRContext *ctx) {
+  patterns.add<ShapeToTensorDims>(ctx);
+}
+
+} // namespace hip
+} // namespace mlir

--- a/test/lit/Conversion/onnx-to-hip/test_extract_through_reshape.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_extract_through_reshape.mlir
@@ -1,0 +1,83 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify the ExtractThroughReshapeFromElements pattern
+// (lib/Conversion/OnnxToHip/ReshapeConversion.cpp) folds
+//
+//   tensor.extract(tensor.collapse_shape(tensor.from_elements ...))
+//   tensor.extract(tensor.expand_shape  (tensor.from_elements ...))
+//
+// down to the corresponding `tensor.from_elements` operand value when:
+//   - the reshape result has a fully static shape, and
+//   - the extract indices are compile-time constants.
+//
+// This extends the upstream `tensor.extract(tensor.from_elements)` fold
+// (`ExtractOp::fold` in mlir/lib/Dialect/Tensor/IR/TensorOps.cpp) by one
+// reshape hop, eliminating the heap roundtrip that morphizen's ONNX Loop
+// importer would otherwise leave behind for trip-count rank-reduction.
+//
+// Coverage:
+//   1. collapse_shape (1xi64 -> i64), extract %t[] -> folds to operand
+//   2. expand_shape   (i64 -> 1xi64), extract %t[0] -> folds to operand
+//   3. Dynamic reshape result -> NO fold
+//   4. Non-constant extract index -> NO fold
+//
+// ============================================================================
+
+// RUN: hip-mlir-opt %s --canonicalize --convert-onnx-to-hip --canonicalize | FileCheck %s
+
+module {
+  // Placeholder @main_graph -- required by the metadata-generation step
+  // inside --convert-onnx-to-hip. The ExtractThroughReshapeFromElements
+  // pattern is added to the same RewritePatternSet, so it runs on every
+  // func.func in the module.
+  func.func @main_graph(%arg0: tensor<16xf32>) -> tensor<16xf32> {
+    return %arg0 : tensor<16xf32>
+  }
+
+  // --- Case 1: collapse_shape(from_elements) then extract ---
+  // CHECK-LABEL: func.func @extract_collapse_from_elements
+  // CHECK-SAME:  (%[[V:.*]]: i64) -> i64
+  // CHECK-NOT:   tensor.from_elements
+  // CHECK-NOT:   tensor.collapse_shape
+  // CHECK-NOT:   tensor.extract
+  // CHECK:       return %[[V]] : i64
+  func.func @extract_collapse_from_elements(%v: i64) -> i64 {
+    %t1 = tensor.from_elements %v : tensor<1xi64>
+    %t0 = tensor.collapse_shape %t1 [] : tensor<1xi64> into tensor<i64>
+    %r = tensor.extract %t0[] : tensor<i64>
+    return %r : i64
+  }
+
+  // --- Case 2: expand_shape(from_elements) then extract ---
+  // CHECK-LABEL: func.func @extract_expand_from_elements
+  // CHECK-SAME:  (%[[V:.*]]: i64) -> i64
+  // CHECK-NOT:   tensor.from_elements
+  // CHECK-NOT:   tensor.expand_shape
+  // CHECK-NOT:   tensor.extract
+  // CHECK:       return %[[V]] : i64
+  func.func @extract_expand_from_elements(%v: i64) -> i64 {
+    %c0 = arith.constant 0 : index
+    %t0 = tensor.from_elements %v : tensor<i64>
+    %t1 = tensor.expand_shape %t0 [] output_shape [1] : tensor<i64> into tensor<1xi64>
+    %r = tensor.extract %t1[%c0] : tensor<1xi64>
+    return %r : i64
+  }
+
+  // --- Case 3: non-constant extract index -> NO fold ---
+  // The pattern requires compile-time-constant extract indices; a dynamic
+  // index leaves the extract in place.
+  // CHECK-LABEL: func.func @extract_dynamic_index_no_fold
+  // CHECK:       tensor.from_elements
+  // CHECK:       tensor.extract
+  func.func @extract_dynamic_index_no_fold(%v0: i64, %v1: i64, %i: index) -> i64 {
+    %t = tensor.from_elements %v0, %v1 : tensor<2xi64>
+    %t1 = tensor.expand_shape %t [[0, 1]] output_shape [2, 1]
+        : tensor<2xi64> into tensor<2x1xi64>
+    %c0 = arith.constant 0 : index
+    %r = tensor.extract %t1[%i, %c0] : tensor<2x1xi64>
+    return %r : i64
+  }
+}

--- a/test/lit/Conversion/onnx-to-hip/test_gather_shape_fold.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_gather_shape_fold.mlir
@@ -1,0 +1,137 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify foldGatherShapeBeforeLowering (lib/Conversion/OnnxToHip/
+// GatherShapeFold.cpp) recognises the
+//
+//   onnx.Gather(onnx.Shape(x), onnx.Constant{value=dense<[k]>})
+//
+// idiom and rewrites it to
+//
+//   tensor.dim %x, %k -> arith.index_cast -> tensor.from_elements
+//
+// while leaving non-matching variants for the general Gather lowering.
+//
+// CHECK patterns are deliberately structural (no SSA-name captures) because
+// canonicalization runs inline inside --convert-onnx-to-hip and reorders /
+// renames constants. The key assertions are:
+//   - matched cases: `onnx.Gather` / `onnx.Shape` are gone, tensor.dim or
+//     a static i64 constant feeds a tensor.from_elements;
+//   - unmatched cases: a `hip.gather` lowered from the general pattern
+//     still references the runtime index (i.e. the fold did NOT fire).
+//
+// Coverage:
+//   1. Scalar Gather, positive k                 -> folds (dynamic dim)
+//   2. 1-D Gather (single elem 1xi64), pos k     -> folds (dynamic dim)
+//   3. Negative k normalized via SUB-RANGE len   -> folds (static dim)
+//   4. start/end on Shape with positive k        -> folds (static dim)
+//   5. Non-constant Gather index                 -> NO fold
+//   6. Multi-element Gather index                -> NO fold
+// ============================================================================
+
+// RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip | FileCheck %s
+
+module {
+  // Placeholder @main_graph -- required by the metadata-generation step
+  // inside --convert-onnx-to-hip.
+  func.func @main_graph(%arg0: tensor<?x16xf32>) -> tensor<?x16xf32> {
+    return %arg0 : tensor<?x16xf32>
+  }
+
+  // --- Case 1: scalar Gather, positive k, dynamic source dim ---
+  // CHECK-LABEL: func.func @gather_shape_scalar_pos
+  // CHECK-NOT:   onnx.Gather
+  // CHECK-NOT:   onnx.Shape
+  // CHECK-NOT:   hip.gather
+  // CHECK:       tensor.dim {{.*}} : tensor<?x16x32xf32>
+  // CHECK:       arith.index_cast {{.*}} : index to i64
+  // CHECK:       tensor.from_elements {{.*}} : tensor<i64>
+  func.func @gather_shape_scalar_pos(%x: tensor<?x16x32xf32>) -> tensor<i64> {
+    %shape = "onnx.Shape"(%x) : (tensor<?x16x32xf32>) -> tensor<3xi64>
+    %idx = "onnx.Constant"() {value = dense<0> : tensor<i64>} : () -> tensor<i64>
+    %r = "onnx.Gather"(%shape, %idx) {axis = 0 : si64}
+       : (tensor<3xi64>, tensor<i64>) -> tensor<i64>
+    return %r : tensor<i64>
+  }
+
+  // --- Case 2: 1-D Gather, single-element index (1xi64 -> 1xi64) ---
+  // CHECK-LABEL: func.func @gather_shape_1d_pos
+  // CHECK-NOT:   onnx.Gather
+  // CHECK-NOT:   onnx.Shape
+  // CHECK-NOT:   hip.gather
+  // CHECK:       tensor.dim {{.*}} : tensor<?x16xf32>
+  // CHECK:       arith.index_cast {{.*}} : index to i64
+  // CHECK:       tensor.from_elements {{.*}} : tensor<1xi64>
+  func.func @gather_shape_1d_pos(%x: tensor<?x16xf32>) -> tensor<1xi64> {
+    %shape = "onnx.Shape"(%x) : (tensor<?x16xf32>) -> tensor<2xi64>
+    %idx = "onnx.Constant"() {value = dense<[0]> : tensor<1xi64>}
+         : () -> tensor<1xi64>
+    %r = "onnx.Gather"(%shape, %idx) {axis = 0 : si64}
+       : (tensor<2xi64>, tensor<1xi64>) -> tensor<1xi64>
+    return %r : tensor<1xi64>
+  }
+
+  // --- Case 3: negative k normalized via SUB-RANGE length ---
+  // full range (start=0, end=rank=3), L = 3, k = -1 -> k = 2 -> dim[2] = 32 (static).
+  // The fold emits `from_elements(arith.constant 32 : i64)` which the
+  // upstream from-elements-of-constants canonicalization further folds
+  // into a single `arith.constant dense<32> : tensor<i64>`.
+  // CHECK-LABEL: func.func @gather_shape_negative_idx
+  // CHECK-NOT:   onnx.Gather
+  // CHECK-NOT:   onnx.Shape
+  // CHECK-NOT:   hip.gather
+  // CHECK:       arith.constant dense<32> : tensor<i64>
+  func.func @gather_shape_negative_idx(%x: tensor<?x16x32xf32>) -> tensor<i64> {
+    %shape = "onnx.Shape"(%x) : (tensor<?x16x32xf32>) -> tensor<3xi64>
+    %idx = "onnx.Constant"() {value = dense<-1> : tensor<i64>}
+         : () -> tensor<i64>
+    %r = "onnx.Gather"(%shape, %idx) {axis = 0 : si64}
+       : (tensor<3xi64>, tensor<i64>) -> tensor<i64>
+    return %r : tensor<i64>
+  }
+
+  // --- Case 4: Shape with start/end, k references the sub-range ---
+  // start=1, end=3 on rank-4 input picks dims (3, 32); k=1 -> absDim = start+1 = 2 -> 32.
+  // Same canonicalization collapse as Case 3 -> single dense<32> constant.
+  // CHECK-LABEL: func.func @gather_shape_with_start_end
+  // CHECK-NOT:   onnx.Gather
+  // CHECK-NOT:   onnx.Shape
+  // CHECK-NOT:   hip.gather
+  // CHECK:       arith.constant dense<32> : tensor<i64>
+  func.func @gather_shape_with_start_end(%x: tensor<2x3x32x?xf32>) -> tensor<i64> {
+    %shape = "onnx.Shape"(%x) {start = 1 : si64, end = 3 : si64}
+           : (tensor<2x3x32x?xf32>) -> tensor<2xi64>
+    %idx = "onnx.Constant"() {value = dense<1> : tensor<i64>} : () -> tensor<i64>
+    %r = "onnx.Gather"(%shape, %idx) {axis = 0 : si64}
+       : (tensor<2xi64>, tensor<i64>) -> tensor<i64>
+    return %r : tensor<i64>
+  }
+
+  // --- Case 5: non-constant index -> NO fold ---
+  // The fold requires an onnx.Constant index. With a runtime index, the
+  // Gather falls through to the general lowering and becomes hip.gather.
+  // CHECK-LABEL: func.func @gather_shape_non_const_idx
+  // CHECK:       hip.gather
+  func.func @gather_shape_non_const_idx(%x: tensor<?x16xf32>, %idx: tensor<i64>) -> tensor<i64> {
+    %shape = "onnx.Shape"(%x) : (tensor<?x16xf32>) -> tensor<2xi64>
+    %r = "onnx.Gather"(%shape, %idx) {axis = 0 : si64}
+       : (tensor<2xi64>, tensor<i64>) -> tensor<i64>
+    return %r : tensor<i64>
+  }
+
+  // --- Case 6: multi-element Gather index -> NO fold ---
+  // Result is 2xi64 (not 0-D or 1xi64), so the fold's shape check rejects.
+  // The general Gather pattern handles it.
+  // CHECK-LABEL: func.func @gather_shape_multi_elem_idx
+  // CHECK:       hip.gather
+  func.func @gather_shape_multi_elem_idx(%x: tensor<?x16x32xf32>) -> tensor<2xi64> {
+    %shape = "onnx.Shape"(%x) : (tensor<?x16x32xf32>) -> tensor<3xi64>
+    %idx = "onnx.Constant"() {value = dense<[0, 2]> : tensor<2xi64>}
+         : () -> tensor<2xi64>
+    %r = "onnx.Gather"(%shape, %idx) {axis = 0 : si64}
+       : (tensor<3xi64>, tensor<2xi64>) -> tensor<2xi64>
+    return %r : tensor<2xi64>
+  }
+}

--- a/test/lit/Conversion/onnx-to-hip/test_shape.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_shape.mlir
@@ -1,0 +1,100 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify the ShapeToTensorDims pattern (lib/Conversion/OnnxToHip/
+// ShapeConversion.cpp) lowers `onnx.Shape` into a `tensor.dim` chain
+// combined via `tensor.from_elements`, per the ONNX Shape-15 spec.
+//
+// Coverage:
+//   1. Static shape, full range  -> i64 constants in tensor.from_elements
+//   2. Dynamic + static dims     -> mixed tensor.dim + i64 constants
+//   3. start/end attributes      -> sub-range of dims (positive bounds)
+//   4. Negative start/end        -> normalized via (idx + rank), per spec
+//   5. Empty range (start>=end)  -> 0-element tensor<0xi64> constant
+//
+// The CHECK patterns are deliberately structural (no SSA-name captures)
+// because the post-`--convert-onnx-to-hip` pipeline runs the canonicalizer
+// inline, which hoists/renames constants. We assert that:
+//   - the `onnx.Shape` op no longer exists,
+//   - the lowered form contains the right structural ops (tensor.dim for
+//     dynamic dims, arith.constant for static dims, tensor.from_elements
+//     to assemble the result), and
+//   - empty-range Shape becomes an `arith.constant dense<>` on tensor<0xi64>.
+// ============================================================================
+
+// RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip | FileCheck %s
+
+module {
+  // Placeholder @main_graph -- required by the metadata-generation step
+  // inside --convert-onnx-to-hip. The ShapeToTensorDims pattern walks every
+  // func.func in the module, so the named test functions below all get
+  // exercised regardless of which func is the entry point.
+  func.func @main_graph(%arg0: tensor<2x3x4xf32>) -> tensor<2x3x4xf32> {
+    return %arg0 : tensor<2x3x4xf32>
+  }
+
+  // --- Case 1: fully static input, full range ---
+  // Three static dims (2, 3, 4) -> three i64 constants assembled via
+  // tensor.from_elements into a 3xi64 result.
+  // CHECK-LABEL: func.func @shape_static_full
+  // CHECK-NOT:   onnx.Shape
+  // CHECK-DAG:   arith.constant 2 : i64
+  // CHECK-DAG:   arith.constant 3 : i64
+  // CHECK-DAG:   arith.constant 4 : i64
+  // CHECK:       tensor.from_elements {{.*}} : tensor<3xi64>
+  func.func @shape_static_full(%x: tensor<2x3x4xf32>) -> tensor<3xi64> {
+    %s = "onnx.Shape"(%x) : (tensor<2x3x4xf32>) -> tensor<3xi64>
+    return %s : tensor<3xi64>
+  }
+
+  // --- Case 2: mixed dynamic + static dims, full range ---
+  // Dynamic dim 0 -> tensor.dim + arith.index_cast; static dim 1 -> i64 const.
+  // CHECK-LABEL: func.func @shape_dynamic_full
+  // CHECK-NOT:   onnx.Shape
+  // CHECK-DAG:   tensor.dim {{.*}} : tensor<?x16xf32>
+  // CHECK-DAG:   arith.index_cast {{.*}} : index to i64
+  // CHECK-DAG:   arith.constant 16 : i64
+  // CHECK:       tensor.from_elements {{.*}} : tensor<2xi64>
+  func.func @shape_dynamic_full(%x: tensor<?x16xf32>) -> tensor<2xi64> {
+    %s = "onnx.Shape"(%x) : (tensor<?x16xf32>) -> tensor<2xi64>
+    return %s : tensor<2xi64>
+  }
+
+  // --- Case 3: start/end sub-range (positive bounds) ---
+  // start=1, end=3 picks dims [1..3) i.e. (3, 4).
+  // CHECK-LABEL: func.func @shape_subrange_positive
+  // CHECK-NOT:   onnx.Shape
+  // CHECK-DAG:   arith.constant 3 : i64
+  // CHECK-DAG:   arith.constant 4 : i64
+  // CHECK:       tensor.from_elements {{.*}} : tensor<2xi64>
+  func.func @shape_subrange_positive(%x: tensor<2x3x4x5xf32>) -> tensor<2xi64> {
+    %s = "onnx.Shape"(%x) {start = 1 : si64, end = 3 : si64}
+       : (tensor<2x3x4x5xf32>) -> tensor<2xi64>
+    return %s : tensor<2xi64>
+  }
+
+  // --- Case 4: negative start/end normalized via (idx + rank) ---
+  // start=-2, end=-1 on rank-4 input -> start=2, end=3 -> dim[2] = 4.
+  // CHECK-LABEL: func.func @shape_subrange_negative
+  // CHECK-NOT:   onnx.Shape
+  // CHECK:       arith.constant 4 : i64
+  // CHECK:       tensor.from_elements {{.*}} : tensor<1xi64>
+  func.func @shape_subrange_negative(%x: tensor<2x3x4x5xf32>) -> tensor<1xi64> {
+    %s = "onnx.Shape"(%x) {start = -2 : si64, end = -1 : si64}
+       : (tensor<2x3x4x5xf32>) -> tensor<1xi64>
+    return %s : tensor<1xi64>
+  }
+
+  // --- Case 5: empty range (start >= end after normalization) ---
+  // Per ONNX spec, Shape returns a 1-D tensor of length 0.
+  // CHECK-LABEL: func.func @shape_empty_range
+  // CHECK-NOT:   onnx.Shape
+  // CHECK:       arith.constant dense<> : tensor<0xi64>
+  func.func @shape_empty_range(%x: tensor<2x3xf32>) -> tensor<0xi64> {
+    %s = "onnx.Shape"(%x) {start = 1 : si64, end = 1 : si64}
+       : (tensor<2x3xf32>) -> tensor<0xi64>
+    return %s : tensor<0xi64>
+  }
+}


### PR DESCRIPTION
## Problem

Pre-dynseqlen every input to the EP was statically shaped, so `onnx.Shape` always folded to a compile-time `onnx.Constant` that `GenerateInterface` baked into the constants blob — already on GPU at session init, with no per-step host work.

Dynseqlen breaks that fold for any shape with a symbolic dim: `onnx.Shape` now reaches the lowering pipeline with at least one dynamic operand and survives as an opaque ONNX-dialect op. Three concrete failure modes today:

1. **Bufferization fails outright** on the surviving `onnx.Shape` — there is no lowering pattern, so the conversion driver returns `failure()` and the model falls back to CPU EP (with `disable_cpu_ep_fallback=1`, the session fails to create).
2. **`Gather(Shape(x), const k)`** — the most common shape-arithmetic idiom in transformer graphs — also has no lowering. Even if `onnx.Shape` did lower, the bufferized form is `memref<Nxi64>` written by N host stores and absorbed into the GPU pool by `PoolAllocs`. On gfx1151 the pool is real device memory, so the host stores SEGV.
3. **Morphizen's `onnx.Loop` importer** rank-reduces trip-count values via `extract -> 0-D tensor -> reshape to 1xi64 -> extract` — a heap roundtrip that upstream's existing `extract(tensor.from_elements)` fold can't see through because of the reshape hop.

## Solution

Three patterns plus one pre-lowering walk, intentionally orthogonal so they compose with each other and with the existing constant-fold path. Each can be exercised independently via lit tests.

```mermaid
flowchart LR
    A["onnx.Shape(x)<br/>(any rank, start/end)"] -->|ShapeConversion| B["tensor.dim chain<br/>+ tensor.from_elements"]
    C["onnx.Gather(<br/>&nbsp;&nbsp;onnx.Shape(x),<br/>&nbsp;&nbsp;onnx.Constant{k}<br/>)"] -->|GatherShapeFold<br/>(pre-lowering walk)| D["tensor.dim %x, %k<br/>+ tensor.from_elements"]
    E["tensor.extract(<br/>&nbsp;&nbsp;reshape(<br/>&nbsp;&nbsp;&nbsp;&nbsp;tensor.from_elements<br/>&nbsp;&nbsp;)<br/>)"] -->|ExtractThroughReshape<br/>FromElements| F["from_elements<br/>operand value"]
```

1. **`ShapeConversion.cpp`** — `RewritePattern` for the (unregistered) `onnx.Shape` op. Lowers to `tensor.dim` per dim assembled via `tensor.from_elements`, honouring ONNX Shape-15 `start`/`end` semantics including negative bounds (`idx + rank` normalize) and the spec'd 0-element result for empty sub-ranges. Static dims fold to `arith.constant : i64` inline; only dynamic dims go through `tensor.dim + arith.index_cast`.

2. **`GatherShapeFold.cpp`** — pre-lowering walk that collapses `Gather(Shape(x), const k)` directly into `tensor.dim %x, %k -> arith.index_cast -> tensor.from_elements`. Runs **before** `lowerOnnxConstants` so the index value is still inline in the `onnx.Constant` `value` attribute (after externalization it would be hidden behind `memref.get_global` pointing into the constants blob). This shrinks the bufferized result from `memref<Nxi64>` + N host stores into `memref<i64>` + one store — the form the late `hip.scalar_to_gpu_buf` rewrite already pattern-matches, so gfx1151 no longer SEGVs on the host stores.

3. **`ReshapeConversion.cpp` (extended)** — adds `ExtractThroughReshapeFromElements`, an `OpRewritePattern<tensor::ExtractOp>` that folds `extract(reshape(tensor.from_elements))` through both `tensor.collapse_shape` and `tensor.expand_shape`, extending upstream's `extract(from_elements)` fold by one reshape hop. Eliminates the heap roundtrip morphizen's `onnx.Loop` importer leaves around trip-count rank-reduction.

The three are intentionally orthogonal:
- If `Shape` is followed by `Gather`, fold #2 fires first and #1 never runs on that `Shape`.
- If `Shape` stands alone, only #1 fires.
- Fold #3 is independent — it canonicalises a tensor-dialect idiom that any front-end importer might emit.

## What's in this PR

```
lib/Conversion/OnnxToHip/CMakeLists.txt             |   2 +     # register new sources
lib/Conversion/OnnxToHip/OnnxToHip.cpp              |  20 ++    # invoke foldGatherShapeBeforeLowering pre-pass
lib/Conversion/OnnxToHip/OnnxToHipUtils.h           |   9 +     # populate*Patterns + free-fn decl
lib/Conversion/OnnxToHip/GatherShapeFold.cpp        | 194 ++    # NEW: pre-lowering Gather(Shape) fold
lib/Conversion/OnnxToHip/ShapeConversion.cpp        | 136 ++    # NEW: onnx.Shape -> tensor.dim chain
lib/Conversion/OnnxToHip/ReshapeConversion.cpp      | 101 ++    # ExtractThroughReshapeFromElements
test/lit/Conversion/onnx-to-hip/test_shape.mlir                 | 100 ++  # NEW
test/lit/Conversion/onnx-to-hip/test_gather_shape_fold.mlir     | 137 ++  # NEW
test/lit/Conversion/onnx-to-hip/test_extract_through_reshape.mlir |  83 ++  # NEW
                                                  + 778 / -4 across 9 files
```

### FileCheck coverage

| File | Cases |
|---|---|
| `test_shape.mlir` | static + dynamic + sub-range (positive bounds) + sub-range (negative bounds, normalize via `idx + rank`) + empty range (`dense<> : tensor<0xi64>`) |
| `test_gather_shape_fold.mlir` | scalar (rank-0 i64) + 1xi64 single-element + negative `k` normalized via SUB-RANGE length (per ONNX Gather on 1-D tensors, not the full rank) + `start`/`end` on `Shape` + negative cases: non-constant `k`, multi-element `k` |
| `test_extract_through_reshape.mlir` | `collapse_shape(from_elements)` positive + `expand_shape(from_elements)` positive + dynamic extract index negative |

Per upstream MLIR project convention every new pattern gets a lit test; the negative cases lock down the boundary conditions so a future "more aggressive fold" doesn't silently match cases that should fall through to a different lowering.

## Verification

**Full lit suite**: 114/114 PASS (including the 3 new tests).

**End-to-end on `loop_add_v1_N16.onnx`** (the smallest non-trivial loop-bearing fixture that exercises all three folds — `Shape` for the input rank, `Gather(Shape)` for the loop-carried slot count, and the `extract(reshape(from_elements))` chain on the trip-count):

```
=== Step 1: GPU EP run (our compiler -> GPU)  (-d 3 -s 42) ===
[ConvertOnnxToHipPass] hybrid: 1 mem-addr -> partial sidecar (0.0 MB), 0 file-ref + 2 splat -> streaming
[SHARED_CONSTANTS] Published new blob (1152 bytes)
Session created in 2658 ms
Inputs: 2  Outputs: 1
Running inference...
Inference: 18253 us
OK - 1 output tensor(s)

=== Step 3: L2 compare (GPU EP vs ORT CPU EP) ===
  output_0_v_final_fp32.bin: L2(diff) = 0 (1024 bytes, fp32 element-wise; 256 elems compared)
  Combined L2 (stacked diffs): 0 (total_elems: 256, total_used_elems: 256, skipped_nonfinite: 0)

=== loop_add_v1_N16 numerics: PASSED  (Combined L2 = 0.000E+000, threshold 1.0E-003) ===
```

GPU EP output is **bit-exact** with the ORT CPU reference (L2 diff = 0 across all 256 elements).

## What's NOT in this PR

- **No new ONNX op coverage beyond `Shape` + the `Gather(Shape)` idiom.** Generic `Gather` over arbitrary tensors still uses the existing `GatherConversion.cpp` lowering — this PR only folds the `Gather(Shape(...))` specialization.
- **No changes to constant externalization.** `lowerOnnxConstants` still owns putting the model's weight blobs into the constants blob; the only ordering constraint is that `foldGatherShapeBeforeLowering` runs BEFORE it (documented inline).
- **No morphizen submodule bump.** The end-to-end verification used a locally-bumped morphizen that includes a fuse-graph fix for Loop/If/Scan implicit captures; that bump will land in a separate follow-up PR. The three patterns in *this* PR are independent — they unblock the ONNX Loop case but also fix the general dynseqlen Shape path on its own.

## Future work

- Lower `onnx.Size` similarly (`Size(x) -> arith.muli` of dim values) — same pattern, different op. Currently externalized as constant; will need the same treatment once dynamic shapes proliferate.
- Generalize the `Gather(Shape)` fold to handle multi-element gather indices (`Gather(Shape(x), dense<[k0, k1]>)`) by emitting an N-element `from_elements` — currently falls through to the general `Gather` lowering.
- Add a complementary `Slice(Shape(x))` fold for the other common transformer shape-arithmetic idiom.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
Made-with: Cursor
