### PR TITLE
Add initial CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,61 @@
+# CODEOWNERS for ROCm/onnx-hipdnn-ep
+#
+# Format: <pattern> <owner1> <owner2> ...
+# Last-matching pattern wins. See:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Initial scope: compiler, runtime, public APIs, integration tests, design
+# docs. Build system, fixtures, examples, third-party submodules, and
+# top-level docs are intentionally left unowned and may be added later as
+# ownership stabilises.
+
+# ---------------------------------------------------------------------------
+# Compiler: MLIR dialects, conversion passes, transforms, compiler driver,
+# Level-1 pass, custom-op marshaller, lit tests, compiler-side tools.
+# Note: backend-mlir-compiler/custom-op-mlir/ is technically runtime-side
+# (the MlirCustomOp marshaller lives inside the EP DLL). Listed under the
+# compiler tree here because it shares the same owners today; split into
+# its own runtime entry if a runtime-only owner joins.
+# ---------------------------------------------------------------------------
+/lib/Compiler/                  @fhanuman @amd-mingw
+/lib/Conversion/                @fhanuman @amd-mingw
+/lib/Dialect/                   @fhanuman @amd-mingw
+/lib/Target/                    @fhanuman @amd-mingw
+/lib/CInterface/                @fhanuman @amd-mingw
+/include/hip/Compiler/          @fhanuman @amd-mingw
+/include/hip/Conversion/        @fhanuman @amd-mingw
+/include/hip/Dialect/           @fhanuman @amd-mingw
+/include/hip/Target/            @fhanuman @amd-mingw
+/include/hip/Support/           @fhanuman @amd-mingw
+/include/hip/InitAllPasses.h    @fhanuman @amd-mingw
+/include/hip/compiler_api.h     @fhanuman @amd-mingw
+/include/hip/compiler_types.h   @fhanuman @amd-mingw
+/backend-mlir-compiler/         @fhanuman @amd-mingw
+/morphizen_mlir_init/           @fhanuman @amd-mingw
+/schemas/                       @fhanuman @amd-mingw
+/test/lit/                      @fhanuman @amd-mingw
+/tools/hip-compiler/            @fhanuman @amd-mingw
+/tools/hip-mlir-opt/            @fhanuman @amd-mingw
+/tools/hip-inspect-dll/         @fhanuman @amd-mingw
+
+# ---------------------------------------------------------------------------
+# Runtime: EP runtime state, real/mock GPU backends, graph runtime, runtime
+# test tools that exercise the EP ABI.
+# ---------------------------------------------------------------------------
+/lib/Runtime/                   @fhanuman @amd-mingw
+/lib/HipDNNGraphRuntime/        @fhanuman @amd-mingw
+/tools/hip-onnx-runner/         @fhanuman @amd-mingw
+/tools/hip-test-dll/            @fhanuman @amd-mingw
+
+# ---------------------------------------------------------------------------
+# Shared: utilities and graph machinery used by both compiler and runtime.
+# ---------------------------------------------------------------------------
+/lib/Support/                   @fhanuman @amd-mingw
+/lib/HipDNNGraph/               @fhanuman @amd-mingw
+
+# ---------------------------------------------------------------------------
+# Tests + design docs: integration / accuracy / TPS coverage and
+# architecture decisions.
+# ---------------------------------------------------------------------------
+/test/python/                   @fhanuman @amd-mingw
+/docs/design/                   @fhanuman @amd-mingw


### PR DESCRIPTION
## Summary

Adds an initial `.github/CODEOWNERS` covering the compiler and runtime trees, paired with the `main` branch protection rule that was just enabled (PR + 1 approval + dismiss-stale). Extend this owners list after discussing with larger group.

Scope:

- **Compiler** (@fhanuman @amd-mingw): `lib/{Compiler,Conversion,Dialect,Target,CInterface}`, all of `include/hip/` except shared utilities, `backend-mlir-compiler/`, `morphizen_mlir_init/`, `schemas/`, `test/lit/`, compiler-side `tools/` (`hip-compiler`, `hip-mlir-opt`, `hip-inspect-dll`).
- **Runtime** (@fhanuman @amd-mingw): `lib/Runtime/`, `lib/HipDNNGraphRuntime/`, runtime test tools (`hip-onnx-runner`, `hip-test-dll`).
- **Shared** (@fhanuman @amd-mingw): `lib/Support/`, `lib/HipDNNGraph/`.
- **Integration tests + design docs** (@fhanuman @amd-mingw): `test/python/`, `docs/design/`.

Intentionally **left unowned for now**: build system (`cmake/`, `dll/`, top-level `CMakeLists.txt`, `build*.{py,ps1}`), fixtures (`examples/`, `oga_models/`, `SimpleTestModels/`, `etc/`), top-level docs (`docs/quick_start*`, `README.md`, ...), `test/e2e/`, `test/models/`, `tools/onnx-model-splitter/`, and `3rd-party/` submodules. Ownership for these can be expanded in follow-up PRs once the initial scope settles.

## Notes

- `backend-mlir-compiler/custom-op-mlir/` is technically runtime-side code (the `MlirCustomOp` marshaller lives inside the EP DLL). It is grouped under the compiler tree today because the owners overlap; the file header flags this for a future split when a runtime-only owner joins.
- This PR pairs with the new branch protection rule on `main`. The `require_code_owner_reviews` flag is currently **off** — turning it on is a separate follow-up so this CODEOWNERS file gets a chance to settle without blocking trivial PRs.

## Test plan

- [ ] Verify the file parses cleanly via the GitHub UI's CODEOWNERS validator (Settings → Branches → CODEOWNERS errors panel — should show 0 errors).
- [ ] Confirm both `@fhanuman` and `@amd-mingw` get auto-requested as reviewers when this PR opens (proves the syntax + handles are valid).
