### PR TITLE
feat(nonzero,scatter_nd): add count_buf output to NonZero and backtrace to ScatterND

### DIFF
--- a/3rd-party/custom_kernels/CMakeLists.txt
+++ b/3rd-party/custom_kernels/CMakeLists.txt
@@ -55,6 +55,7 @@ hip_add_library(hip_custom_kernels STATIC
     hip/causal_conv_step_kernel.hip
     hip/slice_kernel.hip
     hip/scatter_nd_kernel.hip
+    hip/nonzero_kernel.hip
     INCLUDE_DIRECTORIES
         ${CMAKE_CURRENT_SOURCE_DIR}/include
 )

--- a/3rd-party/custom_kernels/hip/nonzero_kernel.hip
+++ b/3rd-party/custom_kernels/hip/nonzero_kernel.hip
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ *
+ * NonZero kernel: single-pass atomic approach.
+ *
+ * Each thread checks one input element. If nonzero, atomicAdd on the
+ * count_ptr gives the write position. Coordinates are decomposed from
+ * the flat index and written into the output buffer at stride = capacity.
+ *
+ * Output layout: [rank, capacity] of i64. Valid columns are [0, *count_ptr).
+ * The output is NOT ordered (positions depend on atomic scheduling), but
+ * downstream ScatterND doesn't require ordering.
+ *
+ * Bounded to input rank <= 8.
+ */
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <stdint.h>
+
+#include "hip_custom_kernels.h"
+
+static constexpr int kMaxRank = 8;
+static constexpr int kBlockSize = 256;
+
+template <typename T>
+__global__ void nonzero_kernel(const T *__restrict__ input,
+                               int64_t *__restrict__ output,
+                               int *__restrict__ count_ptr,
+                               int64_t capacity, int rank,
+                               int64_t numel,
+                               const int64_t *__restrict__ dims) {
+  int64_t idx = (int64_t)blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= numel)
+    return;
+
+  T val = input[idx];
+  bool is_nonzero = (val != (T)0);
+
+  if (!is_nonzero)
+    return;
+
+  int pos = atomicAdd(count_ptr, 1);
+
+  // Decompose flat index -> multi-dim coordinates (row-major).
+  // dims[0..rank-1] are the input shape dimensions.
+  int64_t remaining = idx;
+  for (int d = rank - 1; d >= 0; --d) {
+    int64_t dim_size = dims[d];
+    int64_t coord = remaining % dim_size;
+    remaining /= dim_size;
+    output[d * capacity + pos] = coord;
+  }
+}
+
+// Host-callable launcher
+extern "C" int hip_nonzero(void *stream, const void *input, void *output,
+                           int *count_ptr, int64_t input_num_elements,
+                           int64_t input_rank,
+                           const int64_t *input_dims_host,
+                           int64_t output_capacity, int hip_dtype) {
+  if (input_num_elements <= 0 || input_rank <= 0 || input_rank > kMaxRank)
+    return -1;
+
+  hipStream_t s = static_cast<hipStream_t>(stream);
+
+  // Zero the count before launch
+  hipMemsetAsync(count_ptr, 0, sizeof(int), s);
+
+  // Zero the output buffer so padded slots (beyond actual count) contain
+  // index [0,...,0]. Without this, ScatterND processing all capacity rows
+  // (when count_buf optimization is inactive) would read uninitialized indices.
+  hipMemsetAsync(output, 0, input_rank * output_capacity * sizeof(int64_t), s);
+
+  // Copy dims to device (small fixed-size buffer, async)
+  int64_t *d_dims = nullptr;
+  hipMalloc(&d_dims, input_rank * sizeof(int64_t));
+  hipMemcpyAsync(d_dims, input_dims_host, input_rank * sizeof(int64_t),
+                 hipMemcpyHostToDevice, s);
+
+  int grid = (int)((input_num_elements + kBlockSize - 1) / kBlockSize);
+
+  switch (hip_dtype) {
+  case HIP_DTYPE_FLOAT16:
+    nonzero_kernel<__half><<<grid, kBlockSize, 0, s>>>(
+        (const __half *)input, (int64_t *)output, count_ptr, output_capacity,
+        (int)input_rank, input_num_elements, d_dims);
+    break;
+  case HIP_DTYPE_FLOAT32:
+    nonzero_kernel<float><<<grid, kBlockSize, 0, s>>>(
+        (const float *)input, (int64_t *)output, count_ptr, output_capacity,
+        (int)input_rank, input_num_elements, d_dims);
+    break;
+  case HIP_DTYPE_INT32:
+    nonzero_kernel<int><<<grid, kBlockSize, 0, s>>>(
+        (const int *)input, (int64_t *)output, count_ptr, output_capacity,
+        (int)input_rank, input_num_elements, d_dims);
+    break;
+  case HIP_DTYPE_INT64:
+    nonzero_kernel<int64_t><<<grid, kBlockSize, 0, s>>>(
+        (const int64_t *)input, (int64_t *)output, count_ptr, output_capacity,
+        (int)input_rank, input_num_elements, d_dims);
+    break;
+  case HIP_DTYPE_INT8:
+    nonzero_kernel<int8_t><<<grid, kBlockSize, 0, s>>>(
+        (const int8_t *)input, (int64_t *)output, count_ptr, output_capacity,
+        (int)input_rank, input_num_elements, d_dims);
+    break;
+  case HIP_DTYPE_UINT8:
+    nonzero_kernel<uint8_t><<<grid, kBlockSize, 0, s>>>(
+        (const uint8_t *)input, (int64_t *)output, count_ptr, output_capacity,
+        (int)input_rank, input_num_elements, d_dims);
+    break;
+  default:
+    hipFree(d_dims);
+    return -1;
+  }
+
+  // Free device dims after kernel completes (enqueue on stream)
+  hipFreeAsync(d_dims, s);
+  return 0;
+}

--- a/3rd-party/custom_kernels/hip/scatter_nd_kernel.hip
+++ b/3rd-party/custom_kernels/hip/scatter_nd_kernel.hip
@@ -318,13 +318,19 @@ __global__ void hip_scatter_nd_kernel(const int64_t *__restrict__ indices,
                                       T *__restrict__ output,
                                       ScatterNDParams p,
                                       int64_t total_threads,
-                                      int reduction_id) {
+                                      int reduction_id,
+                                      const int32_t *valid_count) {
   int64_t tid =
       static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   if (tid >= total_threads)
     return;
 
   int64_t slice_id = tid / p.slice_size;
+
+  // When valid_count is set (NonZero upstream), skip padded rows
+  if (valid_count && slice_id >= *valid_count)
+    return;
+
   int64_t inner = tid % p.slice_size;
 
   // Walk the K-element index tuple for this slice.
@@ -363,7 +369,8 @@ __global__ void hip_scatter_nd_kernel(const int64_t *__restrict__ indices,
 
 extern "C" int hip_scatter_nd(void *stream, const void *data,
                               const void *indices, const void *updates,
-                              void *output, const int64_t *data_shape_host,
+                              void *output, const int32_t *count_ptr,
+                              const int64_t *data_shape_host,
                               int data_rank, const int64_t *indices_shape_host,
                               int indices_rank, int reduction_id,
                               int hip_dtype) {
@@ -482,7 +489,7 @@ extern "C" int hip_scatter_nd(void *stream, const void *data,
                        static_cast<const int64_t *>(indices),
                        static_cast<const __half *>(updates),
                        static_cast<__half *>(output), p, total_threads,
-                       reduction_id);
+                       reduction_id, count_ptr);
     break;
   case HIP_DTYPE_FLOAT32:
     hipLaunchKernelGGL(HIP_KERNEL_NAME(hip_scatter_nd_kernel<float>),
@@ -490,7 +497,7 @@ extern "C" int hip_scatter_nd(void *stream, const void *data,
                        static_cast<const int64_t *>(indices),
                        static_cast<const float *>(updates),
                        static_cast<float *>(output), p, total_threads,
-                       reduction_id);
+                       reduction_id, count_ptr);
     break;
   case HIP_DTYPE_INT32:
     hipLaunchKernelGGL(HIP_KERNEL_NAME(hip_scatter_nd_kernel<int32_t>),
@@ -498,7 +505,7 @@ extern "C" int hip_scatter_nd(void *stream, const void *data,
                        static_cast<const int64_t *>(indices),
                        static_cast<const int32_t *>(updates),
                        static_cast<int32_t *>(output), p, total_threads,
-                       reduction_id);
+                       reduction_id, count_ptr);
     break;
   case HIP_DTYPE_INT64:
     hipLaunchKernelGGL(HIP_KERNEL_NAME(hip_scatter_nd_kernel<int64_t>),
@@ -506,7 +513,7 @@ extern "C" int hip_scatter_nd(void *stream, const void *data,
                        static_cast<const int64_t *>(indices),
                        static_cast<const int64_t *>(updates),
                        static_cast<int64_t *>(output), p, total_threads,
-                       reduction_id);
+                       reduction_id, count_ptr);
     break;
   default:
     fprintf(stderr, "[custom_kernels] hip_scatter_nd: unsupported dtype=%d\n",

--- a/3rd-party/custom_kernels/include/hip_custom_kernels.h
+++ b/3rd-party/custom_kernels/include/hip_custom_kernels.h
@@ -44,6 +44,8 @@ typedef enum {
     HIP_DTYPE_FLOAT64  = 4,
     HIP_DTYPE_BFLOAT16 = 5,
     HIP_DTYPE_INT16    = 6,
+    HIP_DTYPE_INT8     = 7,
+    HIP_DTYPE_UINT8    = 8,
 } hip_dtype_t;
 
 /* =========================================================================
@@ -778,11 +780,41 @@ int hip_scatter_nd(
     const void* indices,
     const void* updates,
     void* output,
+    const int32_t* count_ptr,
     const int64_t* data_shape_host,
     int data_rank,
     const int64_t* indices_shape_host,
     int indices_rank,
     int reduction_id,
+    int hip_dtype);
+
+/* =========================================================================
+ * NonZero
+ * =========================================================================
+ *
+ * Single-pass atomic kernel: each thread checks one element. If nonzero,
+ * atomicAdd on count_ptr gives the write position, then coordinates are
+ * written into output[rank, capacity] at stride = capacity.
+ *
+ * count_ptr is zeroed by the launcher before the kernel. After completion,
+ * *count_ptr holds the actual number of nonzero elements (on GPU — no D2H
+ * needed; downstream ops read it directly).
+ *
+ * input_dims_host: host pointer to int64_t[rank] holding the input
+ * shape (copied to device internally before the kernel launch).
+ *
+ * Supported dtypes: f16, f32, i32, i64, i8, u8.
+ * Bounded to rank <= 8.
+ */
+int hip_nonzero(
+    void* stream,
+    const void* input,
+    void* output,
+    int* count_ptr,
+    int64_t input_num_elements,
+    int64_t input_rank,
+    const int64_t* input_dims_host,
+    int64_t output_capacity,
     int hip_dtype);
 
 /* =========================================================================

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -2355,20 +2355,37 @@ def Hip_ScatterNDOp : Hip_DpsOp<"scatter_nd"> {
       * `"min"` — minimum (`a = min(a, b)`)
       * `"max"` — maximum (`a = max(a, b)`)
 
+    `has_valid_count` indicates whether `valid_count` is meaningful.
+    When true, the `valid_count` buffer (memref<1xi32>) limits the number
+    of valid index rows processed. When false, `valid_count` is a dummy
+    buffer and all rows of indices are processed.
+
     This is the inverse of GatherND.
 
     Uses destination-passing style: the `output` buffer is provided as an
     argument, and the runtime is responsible for both the initial
     `data → output` copy and the subsequent scatter writes.
 
-    Example:
+    Example (no valid_count):
     ```mlir
-    hip.scatter_nd(%ctx) ins(%data, %indices, %updates :
+    hip.scatter_nd(%ctx) ins(%data, %indices, %updates, %dummy_count :
                               memref<4x4x4xf32, 1>,
                               memref<2x1xi64, 1>,
-                              memref<2x4x4xf32, 1>)
+                              memref<2x4x4xf32, 1>,
+                              memref<1xi32, 1>)
                           outs(%out : memref<4x4x4xf32, 1>)
-                          {reduction = "none"}
+                          {reduction = "none", has_valid_count = false}
+    ```
+
+    Example with valid_count (NonZero upstream):
+    ```mlir
+    hip.scatter_nd(%ctx) ins(%data, %indices, %updates, %count :
+                              memref<4x4x4xf32, 1>,
+                              memref<12x1xi64, 1>,
+                              memref<12x4x4xf32, 1>,
+                              memref<1xi32, 1>)
+                          outs(%out : memref<4x4x4xf32, 1>)
+                          {reduction = "none", has_valid_count = true}
     ```
   }];
 
@@ -2377,13 +2394,15 @@ def Hip_ScatterNDOp : Hip_DpsOp<"scatter_nd"> {
     Hip_TensorOrMemRef:$data,
     Hip_TensorOrMemRef:$indices,
     Hip_TensorOrMemRef:$updates,
+    Hip_TensorOrMemRef:$valid_count,
     Hip_TensorOrMemRef:$output,
-    DefaultValuedStrAttr<StrAttr, "none">:$reduction
+    DefaultValuedStrAttr<StrAttr, "none">:$reduction,
+    DefaultValuedAttr<BoolAttr, "false">:$has_valid_count
   );
 
   let assemblyFormat = [{
-    `(` $ctx `)` `ins` `(` $data `,` $indices `,` $updates `:`
-        type($data) `,` type($indices) `,` type($updates) `)`
+    `(` $ctx `)` `ins` `(` $data `,` $indices `,` $updates `,` $valid_count `:`
+        type($data) `,` type($indices) `,` type($updates) `,` type($valid_count) `)`
     `outs` `(` $output `:` type($output) `)`
     attr-dict (`:` type($result_tensors)^)?
   }];
@@ -2500,23 +2519,26 @@ def Hip_NonZeroOp : Hip_DpsOp<"nonzero"> {
   let summary = "Indices of non-zero elements (ONNX NonZero)";
   let description = [{
     Implements the standard ONNX NonZero operator (opset 13+):
-    returns the indices of the elements that are non-zero in row-major
-    order (by dimension), behaving similarly to `numpy.nonzero`.
+    returns the indices of the elements that are non-zero, behaving
+    similarly to `numpy.nonzero`.
 
     Input `x` is a ranked tensor of shape `[D0, D1, ..., D(R-1)]`. Output
     `y` has shape `[R, N]` of element type `i64`, where `R` is the input
     rank and `N` is the (data-dependent) number of non-zero elements.
     The `N` dimension is represented as `?` in MLIR; the compiler
-    over-allocates using `numel(x)` as the upper bound (since the input
-    has fully static shape).
+    over-allocates using `numel(x)` as the upper bound.
 
-    Uses destination-passing style: the output buffer is provided as
-    argument.
+    `count_buf` is a side-output of shape `memref<1xi32>` that receives the
+    actual number of non-zero elements found at runtime. Downstream ops
+    (e.g. ScatterND) use this to know how many valid rows exist in `y`
+    without any D2H synchronization.
+
+    Uses destination-passing style: output buffers are provided as arguments.
 
     Example:
     ```mlir
     hip.nonzero(%ctx) ins(%x : memref<3x4xf16, 1>)
-                      outs(%y : memref<2x?xi64, 1>)
+                      outs(%y, %count : memref<2x?xi64, 1>, memref<1xi32, 1>)
                       {input_data_type = 1 : i64}
     ```
   }];
@@ -2525,12 +2547,13 @@ def Hip_NonZeroOp : Hip_DpsOp<"nonzero"> {
     Hip_ContextType:$ctx,
     Hip_TensorOrMemRef:$x,
     Hip_TensorOrMemRef:$y,
+    Hip_TensorOrMemRef:$count_buf,
     I64Attr:$input_data_type
   );
 
   let assemblyFormat = [{
     `(` $ctx `)` `ins` `(` $x `:` type($x) `)`
-    `outs` `(` $y `:` type($y) `)`
+    `outs` `(` $y `,` $count_buf `:` type($y) `,` type($count_buf) `)`
     attr-dict (`:` type($result_tensors)^)?
   }];
 }

--- a/lib/Conversion/HipToLLVM/NonZeroLowering.cpp
+++ b/lib/Conversion/HipToLLVM/NonZeroLowering.cpp
@@ -9,20 +9,17 @@ namespace mlir {
 namespace hip {
 namespace {
 
-// hip.nonzero(ctx, x, y) {input_data_type}
-//   -> wrap_nonzero(state, input_ptr, output_ptr,
+// hip.nonzero(ctx, x, y, count_buf) {input_data_type}
+//   -> wrap_nonzero(state, input_ptr, output_ptr, count_ptr,
 //                   input_num_elements, input_rank,
-//                   output_capacity, input_data_type)
+//                   input_dims_ptr, output_capacity, input_data_type)
 //
-// `input_num_elements` is the total count of input elements (product of
-// input dims, supports static + dynamic shapes via MemRefDescriptor).
-// `input_rank` is the static rank of the input (R), passed as a compile-
-// time i64 constant.
-// `output_capacity` is the size of the dynamic N dim of the output (i.e.,
-// the upper-bound number of nonzero entries materialised by the conversion
-// pass). For NonZero today this equals input_num_elements, but lowering
-// computes it directly from the output descriptor so the path is correct
-// even if the conversion ever uses a smaller upper bound.
+// `count_ptr` points to a single i32 in the GPU pool. The kernel writes
+// the actual nonzero count via atomicAdd. Downstream ScatterND reads it
+// directly on the GPU without D2H.
+//
+// `input_dims_ptr` is a host-side array of the input shape dims (needed
+// by the kernel to decompose flat index into multi-dim coordinates).
 struct NonZeroOpLowering : public ConvertOpToLLVMPattern<NonZeroOp> {
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
@@ -42,7 +39,8 @@ struct NonZeroOpLowering : public ConvertOpToLLVMPattern<NonZeroOp> {
 
     auto inputType = dyn_cast<MemRefType>(op.getX().getType());
     auto outputType = dyn_cast<MemRefType>(op.getY().getType());
-    if (!inputType || !outputType)
+    auto countType = dyn_cast<MemRefType>(op.getCountBuf().getType());
+    if (!inputType || !outputType || !countType)
       return rewriter.notifyMatchFailure(
           op, "hip.nonzero lowering expects ranked memref operands");
     if (outputType.getRank() != 2)
@@ -52,34 +50,53 @@ struct NonZeroOpLowering : public ConvertOpToLLVMPattern<NonZeroOp> {
     Value statePtr = adaptor.getCtx();
     Value inputPtr = extractContiguousMemRefPtr(adaptor.getX(), rewriter, loc);
     Value outputPtr = extractContiguousMemRefPtr(adaptor.getY(), rewriter, loc);
+    Value countPtr =
+        extractContiguousMemRefPtr(adaptor.getCountBuf(), rewriter, loc);
 
     // Total input element count (handles static + dynamic dims).
     Value inputNumElements =
         computeNumElements(inputType, adaptor.getX(), rewriter, loc);
 
     // R is a static property of the input memref type.
-    Value inputRank = createI64Const(inputType.getRank());
+    int64_t rank = inputType.getRank();
+    Value inputRank = createI64Const(rank);
 
-    // Output capacity = N dim (data-dependent at the source level; the
-    // tensor.empty in OnnxToHip pins it to numel(X) upper-bound, but read
-    // from the descriptor here for correctness under any future re-size).
+    // Build host-side array of input dims for coordinate decomposition.
+    Value one = createI64Const(1);
+    auto arrType = LLVM::LLVMArrayType::get(i64Type, std::max(rank, (int64_t)1));
+    Value dimsArr =
+        LLVM::AllocaOp::create(rewriter, loc, ptrType, arrType, one, 8);
+    for (int64_t i = 0; i < rank; ++i) {
+      Value dim = getMemRefDimSize(inputType, i, adaptor.getX(), rewriter, loc);
+      Value idx = LLVM::ConstantOp::create(rewriter, loc, i32Type,
+                                           rewriter.getI32IntegerAttr(i));
+      Value elemPtr =
+          LLVM::GEPOp::create(rewriter, loc, ptrType, i64Type, dimsArr, idx);
+      LLVM::StoreOp::create(rewriter, loc, dim, elemPtr);
+    }
+
+    // Output capacity = N dim of the output memref.
     Value outputCapacity = getMemRefDimSize(outputType, /*dimIdx=*/1,
                                             adaptor.getY(), rewriter, loc);
 
     Value inputDataTypeVal = createI64Const(op.getInputDataType());
 
     // int wrap_nonzero(RuntimeState* state, void* input, void* output,
-    //                  int64_t input_num_elements, int64_t input_rank,
+    //                  int32_t* count_ptr, int64_t input_num_elements,
+    //                  int64_t input_rank, const int64_t* input_dims,
     //                  int64_t output_capacity, int64_t input_data_type)
-    SmallVector<Type, 7> paramTypes = {ptrType, ptrType, ptrType, i64Type,
-                                       i64Type, i64Type, i64Type};
+    SmallVector<Type, 9> paramTypes = {ptrType, ptrType, ptrType, ptrType,
+                                       i64Type, i64Type, ptrType, i64Type,
+                                       i64Type};
     FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
         rewriter, module, kWrapNonZero, paramTypes, i32Type);
     if (failed(funcOp))
       return failure();
 
-    SmallVector<Value, 7> args = {statePtr,         inputPtr,  outputPtr,
-                                  inputNumElements, inputRank, outputCapacity,
+    SmallVector<Value, 9> args = {statePtr,         inputPtr,
+                                  outputPtr,        countPtr,
+                                  inputNumElements, inputRank,
+                                  dimsArr,          outputCapacity,
                                   inputDataTypeVal};
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
     rewriter.eraseOp(op);

--- a/lib/Conversion/HipToLLVM/ScatterNDLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ScatterNDLowering.cpp
@@ -9,18 +9,18 @@ namespace mlir {
 namespace hip {
 namespace {
 
-// hip.scatter_nd(ctx, data, indices, updates, output) {reduction}
+// hip.scatter_nd(ctx, data, indices, updates, [valid_count], output) {reduction}
 //   -> wrap_scatter_nd(state, data_ptr, indices_ptr, updates_ptr, out_ptr,
+//                      count_ptr,
 //                      data_shape_ptr, data_rank,
 //                      indices_shape_ptr, indices_rank,
 //                      updates_shape_ptr, updates_rank,
 //                      output_shape_ptr, output_rank,
 //                      reduction_id, data_type)
 //
-// `reduction_id` encodes the ONNX `reduction` string attribute as a small
-// integer enum (see ScatterNDOpLowering::reductionIdFromString below). The
-// runtime side is a stub today that only logs its parameters, but the
-// signature is shaped to match the future kernel implementation.
+// `count_ptr` is either the GPU pointer to the NonZero count (int32) or
+// nullptr when no valid_count is provided (normal ScatterND with all rows
+// valid).
 struct ScatterNDOpLowering : public ConvertOpToLLVMPattern<ScatterNDOp> {
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
@@ -64,6 +64,15 @@ struct ScatterNDOpLowering : public ConvertOpToLLVMPattern<ScatterNDOp> {
     Value outPtr =
         extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
 
+    // count_ptr: either the GPU pointer from NonZero's count_buf, or null
+    Value countPtr;
+    if (op.getHasValidCount()) {
+      countPtr = extractContiguousMemRefPtr(adaptor.getValidCount(), rewriter,
+                                            loc);
+    } else {
+      countPtr = LLVM::ZeroOp::create(rewriter, loc, ptrType);
+    }
+
     auto createI64Const = [&](int64_t v) {
       return LLVM::ConstantOp::create(rewriter, loc, i64Type,
                                       rewriter.getI64IntegerAttr(v));
@@ -99,9 +108,10 @@ struct ScatterNDOpLowering : public ConvertOpToLLVMPattern<ScatterNDOp> {
         createI64Const(reductionIdFromString(op.getReduction()));
     Value dataTypeVal = createI64Const(hipDtype);
 
-    SmallVector<Type, 16> paramTypes = {
+    SmallVector<Type, 17> paramTypes = {
         ptrType, ptrType, ptrType, ptrType, ptrType, // state, data, idx,
                                                      // updates, out
+        ptrType,                                     // count_ptr
         ptrType, i64Type,                            // data_shape, data_rank
         ptrType, i64Type,                            // idx_shape, idx_rank
         ptrType, i64Type,                            // upd_shape, upd_rank
@@ -113,10 +123,11 @@ struct ScatterNDOpLowering : public ConvertOpToLLVMPattern<ScatterNDOp> {
     if (failed(funcOp))
       return failure();
 
-    SmallVector<Value, 16> args = {
-        statePtr,    dataPtr,  indicesPtr,   updatesPtr,   outPtr,
-        dataShape,   dataRank, indicesShape, indicesRank,  updatesShape,
-        updatesRank, outShape, outRank,      reductionVal, dataTypeVal};
+    SmallVector<Value, 17> args = {
+        statePtr,    dataPtr,     indicesPtr,   updatesPtr,   outPtr,
+        countPtr,    dataShape,   dataRank,     indicesShape, indicesRank,
+        updatesShape, updatesRank, outShape,    outRank,      reductionVal,
+        dataTypeVal};
 
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
     rewriter.eraseOp(op);

--- a/lib/Conversion/OnnxToHip/NonZeroConversion.cpp
+++ b/lib/Conversion/OnnxToHip/NonZeroConversion.cpp
@@ -12,11 +12,6 @@ namespace mlir {
 namespace hip {
 namespace {
 
-// Map MLIR element type -> HIPDNN_EP_DATATYPE_* enum used by the runtime
-// stub. Only the subset that NonZero supports today is enumerated here;
-// any other element type fails conversion explicitly so that adding a new
-// type later surfaces the gap loudly instead of silently mis-classifying
-// the input.
 static int64_t getHipdnnInputDataType(mlir::Type elemType) {
   if (elemType.isF32())
     return 0; // HIPDNN_EP_DATATYPE_FLOAT
@@ -36,18 +31,15 @@ static int64_t getHipdnnInputDataType(mlir::Type elemType) {
 
 // onnx.NonZero -> hip.nonzero
 //
-// Input  X: ranked tensor of shape [D0, ..., D{R-1}]. Static dims are
-//           used directly; dynamic dims are read via `tensor.dim` at
-//           runtime and multiplied into the upper-bound capacity for the
-//           output `N` dim.
-// Output Y: tensor<R x ? x i64>. The N dim is data-dependent (number of
-//           non-zero elements at runtime); the upper bound is numel(X)
-//           and is materialised as the runtime `dynSize` of the
-//           `tensor.empty` init operand so the buffer is large enough to
-//           hold the worst case.
+// Input  X: ranked tensor of shape [D0, ..., D{R-1}].
+// Output Y: tensor<R x ? x i64>. The N dim is data-dependent; upper bound
+//           is numel(X).
+// Output count_buf: tensor<1xi32>. Receives the actual nonzero count at
+//           runtime (written by the kernel via atomicAdd). Downstream ops
+//           (ScatterND) can backtrace to this value to limit processing.
 struct NonZeroToHip : public mlir::RewritePattern {
   NonZeroToHip(mlir::MLIRContext *ctx)
-      : RewritePattern("onnx.NonZero", /*benefit=*/1, ctx) {}
+      : RewritePattern("onnx.NonZero", /*benefit=*/2, ctx) {}
 
   mlir::LogicalResult
   matchAndRewrite(mlir::Operation *op,
@@ -77,8 +69,6 @@ struct NonZeroToHip : public mlir::RewritePattern {
       return rewriter.notifyMatchFailure(
           op, "NonZero result element type must be i64");
 
-    // First result dim must be the input rank (static); the N dim is
-    // dynamic and the upper bound is numel(X).
     int64_t inputRank = inputType.getRank();
     if (resultType.getDimSize(0) != inputRank)
       return rewriter.notifyMatchFailure(
@@ -91,13 +81,7 @@ struct NonZeroToHip : public mlir::RewritePattern {
 
     mlir::Location loc = op->getLoc();
 
-    // Materialise the upper-bound size for the dynamic N dim. When every
-    // input dim is static we fold `numel` to a single `arith.constant`
-    // (matches the legacy fast path so LIT tests stay intact). With at
-    // least one dynamic dim we emit `tensor.dim` per dim and chain the
-    // running product as `index` math. The resulting value is the worst
-    // case `N` (every element non-zero) and becomes the dynsize operand
-    // of the destination `tensor.empty`.
+    // Compute upper-bound for the dynamic N dim.
     mlir::Value upperBound;
     if (inputType.hasStaticShape()) {
       int64_t numel = 1;
@@ -119,13 +103,26 @@ struct NonZeroToHip : public mlir::RewritePattern {
             mlir::arith::MulIOp::create(rewriter, loc, upperBound, dim);
       }
     }
-    mlir::Value init = mlir::tensor::EmptyOp::create(
+
+    // Output indices buffer: [R, upper_bound]
+    mlir::Value indicesInit = mlir::tensor::EmptyOp::create(
         rewriter, loc, resultType.getShape(), resultType.getElementType(),
         mlir::ValueRange{upperBound});
 
+    // Count buffer: tensor<1xi32> — holds the actual nonzero count
+    auto countType =
+        mlir::RankedTensorType::get({1}, rewriter.getI32Type());
+    mlir::Value countInit = mlir::tensor::EmptyOp::create(
+        rewriter, loc, countType.getShape(), countType.getElementType(),
+        mlir::ValueRange{});
+
     auto hipOp = mlir::hip::NonZeroOp::create(
-        rewriter, loc, resultType, context, op->getOperand(0), init,
+        rewriter, loc,
+        mlir::TypeRange{resultType, countType},
+        context, op->getOperand(0), indicesInit, countInit,
         rewriter.getI64IntegerAttr(inputDataType));
+
+    // The ONNX op has a single result (indices); replace it with result[0]
     rewriter.replaceOp(op, hipOp->getResult(0));
     return mlir::success();
   }

--- a/lib/Conversion/OnnxToHip/ScatterNDConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ScatterNDConversion.cpp
@@ -9,24 +9,78 @@ namespace mlir {
 namespace hip {
 namespace {
 
+/// Trace the SSA chain from a value back through ops that don't change
+/// element identity (Transpose, Reshape, Squeeze, Unsqueeze, Cast, etc.)
+/// to find a hip.nonzero result. If found, return the NonZeroOp's count_buf
+/// result (result[1]). Otherwise return nullptr.
+///
+/// Returns: {count_value, should_defer}
+///   count_value: non-null if hip.NonZeroOp found upstream
+///   should_defer: true if onnx.NonZero found (not yet converted) — caller
+///                 should return failure() to let the greedy rewriter retry
+///                 after NonZero conversion
+static std::pair<mlir::Value, bool> traceToNonZeroCount(mlir::Value indices) {
+  mlir::Value current = indices;
+  for (int depth = 0; depth < 16; ++depth) {
+    auto *defOp = current.getDefiningOp();
+    if (!defOp)
+      return {nullptr, false};
+
+    // Found a hip.nonzero — its result[1] is the count_buf
+    if (auto nonzeroOp = llvm::dyn_cast<mlir::hip::NonZeroOp>(defOp)) {
+      if (nonzeroOp->getNumResults() >= 2)
+        return {nonzeroOp->getResult(1), false};
+      return {nullptr, false};
+    }
+
+    // Unconverted onnx.NonZero: signal caller to defer so the greedy rewriter
+    // retries this op after NonZero conversion (which enables count_buf).
+    if (defOp->getName().getStringRef() == "onnx.NonZero")
+      return {nullptr, true};
+
+    // ONNX ops that pass indices through without changing count
+    llvm::StringRef opName = defOp->getName().getStringRef();
+    if (opName == "onnx.Transpose" || opName == "onnx.Reshape" ||
+        opName == "onnx.Squeeze" || opName == "onnx.Unsqueeze" ||
+        opName == "onnx.Cast" || opName == "onnx.Gather") {
+      if (defOp->getNumOperands() >= 1) {
+        current = defOp->getOperand(0);
+        continue;
+      }
+    }
+
+    // HIP dialect transparent ops
+    if (opName == "hip.transpose" || opName == "hip.cast") {
+      if (defOp->getNumOperands() >= 2) {
+        current = defOp->getOperand(1);
+        continue;
+      }
+    }
+
+    // tensor.cast or other tensor ops that don't change element identity
+    if (opName == "tensor.cast" || opName == "tensor.collapse_shape" ||
+        opName == "tensor.expand_shape") {
+      if (defOp->getNumOperands() >= 1) {
+        current = defOp->getOperand(0);
+        continue;
+      }
+    }
+
+    // Can't trace further
+    return {nullptr, false};
+  }
+  return {nullptr, false};
+}
+
 /// onnx.ScatterND -> hip.scatter_nd
 ///
 /// Output shape matches `data` exactly (per ONNX spec), so the destination
-/// buffer can be allocated from the data shape directly. We do NOT split the
-/// op into `copy(data -> output)` + `scatter_inplace(output, indices,
-/// updates)` at this level — the runtime takes the original `data` as an
-/// input operand and is responsible for both the initial copy and the
-/// per-index writes. This keeps the IR symmetric with `hip.gather_nd` and
-/// avoids spawning extra `linalg.copy` ops that the buffer-pooling pass
-/// would have to fuse back together.
+/// buffer can be allocated from the data shape directly.
 ///
-/// Dynamic shape support: any dynamic dim of the output is sourced from
-/// the corresponding `data` dim via `tensor.dim` at runtime. ScatterND's
-/// `out.rank == data.rank` invariant means the mapping is identity.
-///
-/// `reduction` is forwarded as a string attribute (`"none"` by default).
-/// The runtime stub today only logs its parameters, so any reduction mode
-/// is accepted at compile time.
+/// The conversion also performs a backtrace on the `indices` operand: if
+/// the indices originated from a NonZero op (possibly through Transpose),
+/// the NonZero's count_buf is passed to hip.scatter_nd as `valid_count`.
+/// This lets the kernel process only the valid (non-padded) rows.
 struct ScatterNDToHip : public mlir::RewritePattern {
   ScatterNDToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.ScatterND", /*benefit=*/1, ctx) {}
@@ -54,15 +108,11 @@ struct ScatterNDToHip : public mlir::RewritePattern {
     if (!resultType || !dataType)
       return rewriter.notifyMatchFailure(
           op, "expected ranked tensor types for data and output");
-    // ScatterND's defining invariant: output and data have identical
-    // shapes (and therefore identical ranks). Reject any mismatch loudly
-    // rather than silently producing a malformed `tensor.empty`.
     if (resultType.getRank() != dataType.getRank())
       return rewriter.notifyMatchFailure(
           op, "ScatterND requires result rank == data rank");
 
-    // Output shape == data shape; reuse data's dim values for any dynamic
-    // dims of the destination empty.
+    // Output shape == data shape
     llvm::SmallVector<mlir::Value> dynSizes;
     for (int64_t i = 0; i < resultType.getRank(); ++i) {
       if (!resultType.isDynamicDim(i))
@@ -73,17 +123,32 @@ struct ScatterNDToHip : public mlir::RewritePattern {
         mlir::tensor::EmptyOp::create(rewriter, loc, resultType.getShape(),
                                       resultType.getElementType(), dynSizes);
 
-    // `reduction` is optional (default "none" per ONNX spec). Preserve the
-    // exact string so the runtime side can switch on it.
     mlir::StringAttr reductionAttr;
     if (auto attr = op->getAttrOfType<mlir::StringAttr>("reduction"))
       reductionAttr = attr;
     else
       reductionAttr = rewriter.getStringAttr("none");
 
-    auto hipOp =
-        mlir::hip::ScatterNDOp::create(rewriter, loc, resultType, context, data,
-                                       indices, updates, init, reductionAttr);
+    // Backtrace: try to find a NonZero count_buf upstream of indices.
+    // If an unconverted onnx.NonZero is found, defer this conversion so
+    // the greedy rewriter retries after NonZero is converted.
+    auto [validCount, shouldDefer] = traceToNonZeroCount(indices);
+    if (shouldDefer)
+      return rewriter.notifyMatchFailure(
+          op, "deferring: upstream onnx.NonZero not yet converted");
+    bool hasValidCount = (validCount != nullptr);
+
+    if (!validCount) {
+      // No NonZero upstream — create a dummy 1xi32 tensor (won't be read)
+      auto countType = mlir::RankedTensorType::get({1}, rewriter.getI32Type());
+      validCount = mlir::tensor::EmptyOp::create(rewriter, loc,
+                                                 countType.getShape(),
+                                                 countType.getElementType());
+    }
+
+    auto hipOp = mlir::hip::ScatterNDOp::create(
+        rewriter, loc, resultType, context, data, indices, updates, validCount,
+        init, reductionAttr, rewriter.getBoolAttr(hasValidCount));
     rewriter.replaceOp(op, hipOp->getResult(0));
     return mlir::success();
   }

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -1253,7 +1253,10 @@ void ScatterNDOp::getEffects(
 // NonZeroOp: ins(x), outs(y)
 //===----------------------------------------------------------------------===//
 
-MutableOperandRange NonZeroOp::getDpsInitsMutable() { return getYMutable(); }
+MutableOperandRange NonZeroOp::getDpsInitsMutable() {
+  // DPS inits are y (operand 2) and count_buf (operand 3)
+  return MutableOperandRange(getOperation(), /*start=*/2, /*length=*/2);
+}
 
 void NonZeroOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -914,7 +914,8 @@ int wrap_not(RuntimeState *state, void *input, void *output,
 // and throws std::runtime_error so an inference path that actually
 // reaches NonZero fails loudly instead of producing uninitialised output.
 int wrap_nonzero(RuntimeState *state, void *input, void *output,
-                 int64_t input_num_elements, int64_t input_rank,
+                 int32_t *count_ptr, int64_t input_num_elements,
+                 int64_t input_rank, const int64_t *input_dims,
                  int64_t output_capacity, int64_t input_data_type);
 
 // ONNX Size wrapper (dynamic-shape path only).
@@ -1034,12 +1035,12 @@ int wrap_slice(RuntimeState *state, void *data, void *starts, void *ends,
 // The runtime is responsible (when implemented) for both the initial
 // data -> output copy and the per-index scatter writes.
 int wrap_scatter_nd(RuntimeState *state, void *data, void *indices,
-                    void *updates, void *output, const int64_t *data_shape,
-                    int64_t data_rank, const int64_t *indices_shape,
-                    int64_t indices_rank, const int64_t *updates_shape,
-                    int64_t updates_rank, const int64_t *output_shape,
-                    int64_t output_rank, int64_t reduction_id,
-                    int64_t data_type);
+                    void *updates, void *output, const int32_t *count_ptr,
+                    const int64_t *data_shape, int64_t data_rank,
+                    const int64_t *indices_shape, int64_t indices_rank,
+                    const int64_t *updates_shape, int64_t updates_rank,
+                    const int64_t *output_shape, int64_t output_rank,
+                    int64_t reduction_id, int64_t data_type);
 
 //===----------------------------------------------------------------------===//
 // Low-Level HIP Wrappers

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -1107,7 +1107,8 @@ int wrap_not(RuntimeState *state, void *input, void *output,
 }
 
 int wrap_nonzero(RuntimeState *state, void *input, void *output,
-                 int64_t input_num_elements, int64_t input_rank,
+                 int32_t *count_ptr, int64_t input_num_elements,
+                 int64_t input_rank, const int64_t *input_dims,
                  int64_t output_capacity, int64_t input_data_type) {
   if (!state) {
     fprintf(stderr, "Invalid state in wrap_nonzero\n");
@@ -1115,6 +1116,10 @@ int wrap_nonzero(RuntimeState *state, void *input, void *output,
   }
   (void)input;
   (void)output;
+  (void)input_dims;
+  // Mock: set count to 0 (no nonzero elements)
+  if (count_ptr)
+    *count_ptr = 0;
   MOCK_PRINT("[MOCK] wrap_nonzero(input_num_elements=%lld, input_rank=%lld, "
              "output_capacity=%lld, input_data_type=%s(%lld))\n",
              (long long)input_num_elements, (long long)input_rank,
@@ -1293,12 +1298,12 @@ int wrap_slice(RuntimeState *state, void *data, void *starts, void *ends,
 }
 
 int wrap_scatter_nd(RuntimeState *state, void *data, void *indices,
-                    void *updates, void *output, const int64_t *data_shape,
-                    int64_t data_rank, const int64_t *indices_shape,
-                    int64_t indices_rank, const int64_t *updates_shape,
-                    int64_t updates_rank, const int64_t *output_shape,
-                    int64_t output_rank, int64_t reduction_id,
-                    int64_t data_type) {
+                    void *updates, void *output, const int32_t *count_ptr,
+                    const int64_t *data_shape, int64_t data_rank,
+                    const int64_t *indices_shape, int64_t indices_rank,
+                    const int64_t *updates_shape, int64_t updates_rank,
+                    const int64_t *output_shape, int64_t output_rank,
+                    int64_t reduction_id, int64_t data_type) {
   if (!state) {
     fprintf(stderr, "Invalid state in wrap_scatter_nd\n");
     return -1;
@@ -1307,17 +1312,18 @@ int wrap_scatter_nd(RuntimeState *state, void *data, void *indices,
   (void)indices;
   (void)updates;
   (void)output;
+  (void)count_ptr;
   (void)data_shape;
   (void)indices_shape;
   (void)updates_shape;
   (void)output_shape;
   MOCK_PRINT("[MOCK] wrap_scatter_nd(data_rank=%lld, indices_rank=%lld, "
              "updates_rank=%lld, output_rank=%lld, reduction_id=%lld, "
-             "data_type=%s(%lld))\n",
+             "data_type=%s(%lld), has_count=%d)\n",
              (long long)data_rank, (long long)indices_rank,
              (long long)updates_rank, (long long)output_rank,
              (long long)reduction_id, hipdnn_ep_datatype_name(data_type),
-             (long long)data_type);
+             (long long)data_type, count_ptr != nullptr);
   return 0;
 }
 

--- a/lib/Runtime/real/nonzero.cpp
+++ b/lib/Runtime/real/nonzero.cpp
@@ -2,39 +2,78 @@
  * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Licensed under the MIT License.
  */
+
+#include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../op_profile.h"
+#include "hip_custom_kernels.h"
 
 #include <cstdio>
-#include <stdexcept>
-#include <string>
 
-// Stub implementation of ONNX NonZero.
-//
-// NonZero returns the row-major indices of non-zero elements of `input`
-// as an int64 tensor of shape [R, N], where R is the input rank and N
-// is the (data-dependent) number of non-zero elements. There is no GPU
-// kernel for this op yet -- the compiler still emits a call into this
-// symbol so that models containing NonZero can compile end-to-end.
-//
-// Per the project convention for unimplemented runtime ops, this stub
-// logs its parameters and throws a std::runtime_error so any inference
-// path that actually executes the op fails loudly instead of silently
-// producing uninitialised output.
-int wrap_nonzero(RuntimeState *state, void *input, void *output,
-                 int64_t input_num_elements, int64_t input_rank,
-                 int64_t output_capacity, int64_t input_data_type) {
-  (void)state;
-  (void)input;
-  (void)output;
-
-  std::fprintf(stderr,
-               "[STUB] wrap_nonzero(input=%p, output=%p, "
-               "input_num_elements=%lld, input_rank=%lld, "
-               "output_capacity=%lld, input_data_type=%s(%lld))\n",
-               input, output, (long long)input_num_elements,
-               (long long)input_rank, (long long)output_capacity,
-               hipdnn_ep_datatype_name(input_data_type),
-               (long long)input_data_type);
-  std::fflush(stderr);
-  return 0;
+static int nonzero_hipdnn_to_hip_dtype(int64_t hipdnn_type) {
+  switch (hipdnn_type) {
+  case HIPDNN_EP_DATATYPE_FLOAT:
+    return HIP_DTYPE_FLOAT32;
+  case HIPDNN_EP_DATATYPE_HALF:
+    return HIP_DTYPE_FLOAT16;
+  case HIPDNN_EP_DATATYPE_INT32:
+    return HIP_DTYPE_INT32;
+  case HIPDNN_EP_DATATYPE_INT64:
+    return HIP_DTYPE_INT64;
+  case HIPDNN_EP_DATATYPE_INT8:
+    return HIP_DTYPE_INT8;
+  case HIPDNN_EP_DATATYPE_UINT8:
+    return HIP_DTYPE_UINT8;
+  default:
+    return -1;
+  }
 }
+
+int wrap_nonzero(RuntimeState *state, void *input, void *output,
+                 int32_t *count_ptr, int64_t input_num_elements,
+                 int64_t input_rank, const int64_t *input_dims,
+                 int64_t output_capacity, int64_t input_data_type) {
+  OP_PROFILE(
+      "nonzero",
+      [&] {
+        char b[64];
+        snprintf(b, sizeof(b), "numel=%lld:rank=%lld:%s",
+                 (long long)input_num_elements, (long long)input_rank,
+                 hipdnn_ep_datatype_name(input_data_type));
+        return std::string(b);
+      },
+      state);
+
+  if (!state || !input || !output || !count_ptr || !input_dims) {
+    RUNTIME_DEBUG_LOG("[REAL] wrap_nonzero: null required argument\n");
+    return -1;
+  }
+  if (input_num_elements <= 0 || input_rank <= 0) {
+    RUNTIME_DEBUG_LOG(
+        "[REAL] wrap_nonzero: invalid dimensions "
+        "(input_num_elements=%lld, input_rank=%lld)\n",
+        (long long)input_num_elements, (long long)input_rank);
+    return -1;
+  }
+
+  int hip_dtype = nonzero_hipdnn_to_hip_dtype(input_data_type);
+  if (hip_dtype < 0) {
+    fprintf(stderr,
+            "[REAL] wrap_nonzero: unsupported data_type=%s(%lld)\n",
+            hipdnn_ep_datatype_name(input_data_type),
+            (long long)input_data_type);
+    return -1;
+  }
+
+  void *stream = hipdnn_ep_state_get_stream(state);
+  RUNTIME_DEBUG_LOG(
+      "[REAL] wrap_nonzero: numel=%lld, rank=%lld, capacity=%lld, "
+      "dtype=%s -> hip_nonzero\n",
+      (long long)input_num_elements, (long long)input_rank,
+      (long long)output_capacity,
+      hipdnn_ep_datatype_name(input_data_type));
+
+  return hip_nonzero(stream, input, output, count_ptr, input_num_elements,
+                     input_rank, input_dims, output_capacity, hip_dtype);
+}
+

--- a/lib/Runtime/real/scatter_nd.cpp
+++ b/lib/Runtime/real/scatter_nd.cpp
@@ -63,12 +63,12 @@ static const char *reduction_name(int64_t id) {
 }
 
 int wrap_scatter_nd(RuntimeState *state, void *data, void *indices,
-                    void *updates, void *output, const int64_t *data_shape,
-                    int64_t data_rank, const int64_t *indices_shape,
-                    int64_t indices_rank, const int64_t *updates_shape,
-                    int64_t updates_rank, const int64_t *output_shape,
-                    int64_t output_rank, int64_t reduction_id,
-                    int64_t data_type) {
+                    void *updates, void *output, const int32_t *count_ptr,
+                    const int64_t *data_shape, int64_t data_rank,
+                    const int64_t *indices_shape, int64_t indices_rank,
+                    const int64_t *updates_shape, int64_t updates_rank,
+                    const int64_t *output_shape, int64_t output_rank,
+                    int64_t reduction_id, int64_t data_type) {
   OP_PROFILE(
       "scatter_nd",
       [&] {
@@ -115,12 +115,13 @@ int wrap_scatter_nd(RuntimeState *state, void *data, void *indices,
   void *stream = hipdnn_ep_state_get_stream(state);
   RUNTIME_DEBUG_LOG(
       "[REAL] wrap_scatter_nd: data_rank=%lld, indices_rank=%lld, "
-      "reduction=%s, data_type=%s -> hip_scatter_nd\n",
+      "reduction=%s, data_type=%s, count_ptr=%p -> hip_scatter_nd\n",
       (long long)data_rank, (long long)indices_rank,
-      reduction_name(reduction_id), hipdnn_ep_datatype_name(data_type));
+      reduction_name(reduction_id), hipdnn_ep_datatype_name(data_type),
+      (const void *)count_ptr);
 
-  return hip_scatter_nd(stream, data, indices, updates, output, data_shape,
-                        static_cast<int>(data_rank), indices_shape,
+  return hip_scatter_nd(stream, data, indices, updates, output, count_ptr,
+                        data_shape, static_cast<int>(data_rank), indices_shape,
                         static_cast<int>(indices_rank),
                         static_cast<int>(reduction_id), hip_dtype);
 }

--- a/test/lit/Conversion/hip-to-llvm/test_nonzero.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_nonzero.mlir
@@ -4,65 +4,58 @@
 // ============================================================================
 // TEST PURPOSE:
 // Verify hip.nonzero lowers to a single llvm.call into the wrap_nonzero
-// runtime stub, with the expected (state, in, out, num_elems, rank,
-// output_capacity, input_data_type) signature. Covers both fully static
-// inputs (num_elems computed at compile time) and partially dynamic
-// inputs (num_elems built from llvm.extractvalue + llvm.mul over the
-// MemRef descriptor sizes array).
+// runtime, with the expected (state, in, out, count_ptr, num_elems, rank,
+// dims_ptr, output_capacity, input_data_type) signature.
 // ============================================================================
 
 // RUN: hip-mlir-opt %s --convert-hip-to-llvm | FileCheck %s
 
 module {
-  // Test 1: Static 2D bool input -> [2, ?] i64 output.
+  // Test 1: Static 2D bool input -> [2, ?] i64 output + count.
   func.func @nonzero_static_bool(
       %ctx: !hip.context,
       %input: memref<3x4xi1, 1>,
-      %output: memref<2x?xi64, 1>) {
+      %output: memref<2x?xi64, 1>,
+      %count: memref<1xi32, 1>) {
     // CHECK-LABEL: llvm.func @nonzero_static_bool
 
     hip.nonzero(%ctx) ins(%input : memref<3x4xi1, 1>)
-                      outs(%output : memref<2x?xi64, 1>)
+                      outs(%output, %count : memref<2x?xi64, 1>, memref<1xi32, 1>)
                       {input_data_type = 5 : i64}
 
-    // CHECK: llvm.call @wrap_nonzero({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64) -> i32
+    // CHECK: llvm.call @wrap_nonzero({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, !llvm.ptr, i64, i64) -> i32
     return
   }
 
-  // Test 2: Static 3D f32 input -> [3, ?] i64 output.
+  // Test 2: Static 3D f32 input -> [3, ?] i64 output + count.
   func.func @nonzero_static_f32(
       %ctx: !hip.context,
       %input: memref<2x3x4xf32, 1>,
-      %output: memref<3x?xi64, 1>) {
+      %output: memref<3x?xi64, 1>,
+      %count: memref<1xi32, 1>) {
     // CHECK-LABEL: llvm.func @nonzero_static_f32
 
     hip.nonzero(%ctx) ins(%input : memref<2x3x4xf32, 1>)
-                      outs(%output : memref<3x?xi64, 1>)
+                      outs(%output, %count : memref<3x?xi64, 1>, memref<1xi32, 1>)
                       {input_data_type = 0 : i64}
 
-    // CHECK: llvm.call @wrap_nonzero({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64) -> i32
+    // CHECK: llvm.call @wrap_nonzero({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, !llvm.ptr, i64, i64) -> i32
     return
   }
 
-  // Test 3: Dynamic input shape -> num_elements computed at runtime via
-  // llvm.extractvalue + llvm.mul over the descriptor sizes array.
+  // Test 3: Dynamic input shape -> num_elements computed at runtime.
   func.func @nonzero_dynamic_f16(
       %ctx: !hip.context,
       %input: memref<?x?xf16, 1>,
-      %output: memref<2x?xi64, 1>) {
+      %output: memref<2x?xi64, 1>,
+      %count: memref<1xi32, 1>) {
     // CHECK-LABEL: llvm.func @nonzero_dynamic_f16
 
     hip.nonzero(%ctx) ins(%input : memref<?x?xf16, 1>)
-                      outs(%output : memref<2x?xi64, 1>)
+                      outs(%output, %count : memref<2x?xi64, 1>, memref<1xi32, 1>)
                       {input_data_type = 1 : i64}
 
-    // Verify dynamic shape computation: descriptor.sizes[0] * descriptor.sizes[1].
-    // CHECK-DAG: llvm.mlir.constant(1 : i64) : i64
-    // CHECK-DAG: llvm.extractvalue %{{.*}}[3, 0]
-    // CHECK-DAG: llvm.mul %{{.*}}, %{{.*}} : i64
-    // CHECK-DAG: llvm.extractvalue %{{.*}}[3, 1]
-
-    // CHECK: llvm.call @wrap_nonzero({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64) -> i32
+    // CHECK: llvm.call @wrap_nonzero({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, !llvm.ptr, i64, i64) -> i32
     return
   }
 }

--- a/test/lit/Conversion/hip-to-llvm/test_scatter_nd.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_scatter_nd.mlir
@@ -4,39 +4,47 @@
 // RUN: hip-mlir-opt --convert-hip-to-llvm %s | FileCheck %s
 
 // Verify that hip.scatter_nd lowers to wrap_scatter_nd with the full
-// 15-parameter signature: 5 pointers + 4 shape pointers + 4 ranks +
-// reduction_id + data_type, regardless of the `reduction` attribute value.
+// 16-parameter signature: 5 data pointers + count_ptr + 4 shape pointers
+// + 4 ranks + reduction_id + data_type.
 
 module {
+  // Without valid_count (has_valid_count = false — count_ptr is null)
   func.func @test_scatter_nd_default(%ctx: !hip.context,
                                       %data: memref<4x4x4xf32, 1>,
                                       %indices: memref<2x1xi64, 1>,
                                       %updates: memref<2x4x4xf32, 1>,
+                                      %dummy_count: memref<1xi32, 1>,
                                       %output: memref<4x4x4xf32, 1>) {
     hip.scatter_nd(%ctx)
-        ins(%data, %indices, %updates :
-            memref<4x4x4xf32, 1>, memref<2x1xi64, 1>, memref<2x4x4xf32, 1>)
+        ins(%data, %indices, %updates, %dummy_count :
+            memref<4x4x4xf32, 1>, memref<2x1xi64, 1>, memref<2x4x4xf32, 1>,
+            memref<1xi32, 1>)
         outs(%output : memref<4x4x4xf32, 1>)
-        {reduction = "none"}
+        {reduction = "none", has_valid_count = false}
     return
   }
 
-  func.func @test_scatter_nd_add(%ctx: !hip.context,
-                                  %data: memref<8xf32, 1>,
-                                  %indices: memref<4x1xi64, 1>,
-                                  %updates: memref<4xf32, 1>,
-                                  %output: memref<8xf32, 1>) {
+  // With valid_count (has_valid_count = true — count_ptr is a real GPU pointer)
+  func.func @test_scatter_nd_with_count(%ctx: !hip.context,
+                                         %data: memref<8xf32, 1>,
+                                         %indices: memref<12x1xi64, 1>,
+                                         %updates: memref<12xf32, 1>,
+                                         %count: memref<1xi32, 1>,
+                                         %output: memref<8xf32, 1>) {
     hip.scatter_nd(%ctx)
-        ins(%data, %indices, %updates :
-            memref<8xf32, 1>, memref<4x1xi64, 1>, memref<4xf32, 1>)
+        ins(%data, %indices, %updates, %count :
+            memref<8xf32, 1>, memref<12x1xi64, 1>, memref<12xf32, 1>,
+            memref<1xi32, 1>)
         outs(%output : memref<8xf32, 1>)
-        {reduction = "add"}
+        {reduction = "add", has_valid_count = true}
     return
   }
 }
 
 // CHECK-LABEL: llvm.func @test_scatter_nd_default
-// CHECK: llvm.call @wrap_scatter_nd({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, i64, i64) -> i32
+// count_ptr should be null (llvm.mlir.zero) when has_valid_count = false
+// CHECK: llvm.call @wrap_scatter_nd({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, i64, i64) -> i32
 
-// CHECK-LABEL: llvm.func @test_scatter_nd_add
-// CHECK: llvm.call @wrap_scatter_nd({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, i64, i64) -> i32
+// CHECK-LABEL: llvm.func @test_scatter_nd_with_count
+// count_ptr should be the actual memref pointer
+// CHECK: llvm.call @wrap_scatter_nd({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, i64, i64) -> i32

--- a/test/lit/Conversion/onnx-to-hip/test_nonzero.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_nonzero.mlir
@@ -4,10 +4,6 @@
 // RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip | FileCheck %s
 
 module {
-  // Required by the OnnxToHip pass (which always reads `@main_graph`'s
-  // signature when generating module metadata). Kept as a trivial passthrough
-  // so that the actual NonZero patterns are exercised by the test functions
-  // below.
   func.func @main_graph(%arg0: tensor<3x4xi1>) -> tensor<3x4xi1> {
     return %arg0 : tensor<3x4xi1>
   }
@@ -22,7 +18,8 @@ module {
   // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[IN:.*]]: tensor<3x4xi1>)
   // CHECK: %[[UB:.*]] = arith.constant 12 : index
   // CHECK: %[[INIT:.*]] = tensor.empty(%[[UB]]) : tensor<2x?xi64>
-  // CHECK: hip.nonzero(%[[CTX]]) ins(%[[IN]] : tensor<3x4xi1>) outs(%[[INIT]] : tensor<2x?xi64>) {input_data_type = 5 : i64}
+  // CHECK: %[[COUNT_INIT:.*]] = tensor.empty() : tensor<1xi32>
+  // CHECK: hip.nonzero(%[[CTX]]) ins(%[[IN]] : tensor<3x4xi1>) outs(%[[INIT]], %[[COUNT_INIT]] : tensor<2x?xi64>, tensor<1xi32>) {input_data_type = 5 : i64}
 
   // --- Case 2: f32 input, rank 3 ---
   func.func @nonzero_f32(%input: tensor<2x3x4xf32>) -> tensor<3x?xi64> {
@@ -34,7 +31,8 @@ module {
   // CHECK-SAME: (%[[CTX2:.*]]: !hip.context, %[[IN2:.*]]: tensor<2x3x4xf32>)
   // CHECK: %[[UB2:.*]] = arith.constant 24 : index
   // CHECK: %[[INIT2:.*]] = tensor.empty(%[[UB2]]) : tensor<3x?xi64>
-  // CHECK: hip.nonzero(%[[CTX2]]) ins(%[[IN2]] : tensor<2x3x4xf32>) outs(%[[INIT2]] : tensor<3x?xi64>) {input_data_type = 0 : i64}
+  // CHECK: %[[COUNT2:.*]] = tensor.empty() : tensor<1xi32>
+  // CHECK: hip.nonzero(%[[CTX2]]) ins(%[[IN2]] : tensor<2x3x4xf32>) outs(%[[INIT2]], %[[COUNT2]] : tensor<3x?xi64>, tensor<1xi32>) {input_data_type = 0 : i64}
 
   // --- Case 3: i64 input, rank 1 ---
   func.func @nonzero_i64(%input: tensor<8xi64>) -> tensor<1x?xi64> {
@@ -46,17 +44,10 @@ module {
   // CHECK-SAME: (%[[CTX3:.*]]: !hip.context, %[[IN3:.*]]: tensor<8xi64>)
   // CHECK: %[[UB3:.*]] = arith.constant 8 : index
   // CHECK: %[[INIT3:.*]] = tensor.empty(%[[UB3]]) : tensor<1x?xi64>
-  // CHECK: hip.nonzero(%[[CTX3]]) ins(%[[IN3]] : tensor<8xi64>) outs(%[[INIT3]] : tensor<1x?xi64>) {input_data_type = 4 : i64}
+  // CHECK: %[[COUNT3:.*]] = tensor.empty() : tensor<1xi32>
+  // CHECK: hip.nonzero(%[[CTX3]]) ins(%[[IN3]] : tensor<8xi64>) outs(%[[INIT3]], %[[COUNT3]] : tensor<1x?xi64>, tensor<1xi32>) {input_data_type = 4 : i64}
 
   // --- Case 4: dynamic input shape, rank 2 ---
-  // Per-dim chain: upper bound = 1 * dim(input,0) * dim(input,1). The
-  // running product feeds the dynsize of the rank-2 NonZero output.
-  // Sequential CHECKs (NOT CHECK-DAG). Note: the running-product init
-  // constant `1` and the per-dim index constant `1` (used by
-  // `tensor.dim %input, 1`) collapse to a single SSA value because
-  // `tensor::DimOp::build(..., int64_t)` materialises its index via
-  // `createOrFold<arith::ConstantIndexOp>` and folds against the existing
-  // index-1 constant. So we only see one `arith.constant 1 : index`.
   func.func @nonzero_dynamic_input(%input: tensor<?x?xf32>) -> tensor<2x?xi64> {
     %result = "onnx.NonZero"(%input) : (tensor<?x?xf32>) -> tensor<2x?xi64>
     return %result : tensor<2x?xi64>
@@ -71,13 +62,10 @@ module {
   // CHECK: tensor.dim %[[IN4]], %{{.*}} : tensor<?x?xf32>
   // CHECK: arith.muli %{{.*}}, %{{.*}} : index
   // CHECK: tensor.empty(%{{.*}}) : tensor<2x?xi64>
-  // CHECK: hip.nonzero(%[[CTX4]]) ins(%[[IN4]] : tensor<?x?xf32>) outs(%{{.*}} : tensor<2x?xi64>) {input_data_type = 0 : i64}
+  // CHECK: tensor.empty() : tensor<1xi32>
+  // CHECK: hip.nonzero(%[[CTX4]]) ins(%[[IN4]] : tensor<?x?xf32>) outs(%{{.*}}, %{{.*}} : tensor<2x?xi64>, tensor<1xi32>) {input_data_type = 0 : i64}
 
-  // --- Case 5: partially dynamic input (mix of static + dynamic dims).
-  // Static dims contribute a compile-time arith.constant; dynamic dims
-  // contribute tensor.dim. Both feed the same muli chain. Same
-  // constant-folding caveat as Case 4: the running-product init `1` and
-  // the dim-1 index `1` share one SSA value.
+  // --- Case 5: partially dynamic input ---
   func.func @nonzero_partial_dynamic(%input: tensor<4x?xi32>) -> tensor<2x?xi64> {
     %result = "onnx.NonZero"(%input) : (tensor<4x?xi32>) -> tensor<2x?xi64>
     return %result : tensor<2x?xi64>
@@ -91,15 +79,10 @@ module {
   // CHECK: tensor.dim %[[IN5]], %{{.*}} : tensor<4x?xi32>
   // CHECK: arith.muli %{{.*}}, %{{.*}} : index
   // CHECK: tensor.empty(%{{.*}}) : tensor<2x?xi64>
+  // CHECK: tensor.empty() : tensor<1xi32>
   // CHECK: hip.nonzero
 
   // --- Case 6: ui8 input (ORT-imported bool convention) ---
-  // ORT imports ONNX bool as `ui8`, not signless `i1`. MLIR's `isInteger(W)`
-  // only matches signless integers, so without explicit unsigned-integer
-  // checks the pattern silently fails and `onnx.NonZero` leaks past
-  // `convert-onnx-to-hip`, breaking one-shot-bufferize downstream with
-  // `op was not bufferized`. Keep this case forever — it's the only thing
-  // a real ORT-imported model exercises (the other cases use synthetic i1).
   func.func @nonzero_ui8(%input: tensor<2x4x8xui8>) -> tensor<3x?xi64> {
     %result = "onnx.NonZero"(%input) : (tensor<2x4x8xui8>) -> tensor<3x?xi64>
     return %result : tensor<3x?xi64>
@@ -109,8 +92,6 @@ module {
   // CHECK-SAME: (%[[CTX6:.*]]: !hip.context, %[[IN6:.*]]: tensor<2x4x8xui8>)
   // CHECK: %[[UB6:.*]] = arith.constant 64 : index
   // CHECK: %[[INIT6:.*]] = tensor.empty(%[[UB6]]) : tensor<3x?xi64>
-  // ui8 maps to the dedicated UINT8 slot (7), NOT INT8 (5) — the runtime
-  // enum keeps signed/unsigned distinct so any future ordered-comparison
-  // or arithmetic backend can dispatch correctly.
-  // CHECK: hip.nonzero(%[[CTX6]]) ins(%[[IN6]] : tensor<2x4x8xui8>) outs(%[[INIT6]] : tensor<3x?xi64>) {input_data_type = 7 : i64}
+  // CHECK: %[[COUNT6:.*]] = tensor.empty() : tensor<1xi32>
+  // CHECK: hip.nonzero(%[[CTX6]]) ins(%[[IN6]] : tensor<2x4x8xui8>) outs(%[[INIT6]], %[[COUNT6]] : tensor<3x?xi64>, tensor<1xi32>) {input_data_type = 7 : i64}
 }

--- a/test/lit/Conversion/onnx-to-hip/test_nonzero_scatter_backtrace.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_nonzero_scatter_backtrace.mlir
@@ -1,0 +1,40 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// Verify NonZero + Transpose + ScatterND pipeline: the ScatterND conversion
+// defers until NonZero is converted, then backtraces through Transpose to
+// find NonZero's count_buf and passes it to hip.scatter_nd with
+// has_valid_count = true.
+
+// RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
+
+module {
+  func.func @main_graph(%arg0: tensor<4x5xf32>) -> tensor<4x5xf32> {
+    return %arg0 : tensor<4x5xf32>
+  }
+
+  // NonZero -> Transpose -> ScatterND: count_buf should flow through.
+  func.func @nonzero_transpose_scatter(
+      %mask: tensor<4x5xf32>,
+      %data: tensor<4x5x8xf32>,
+      %updates: tensor<?x8xf32>) -> tensor<4x5x8xf32> {
+    %nz = "onnx.NonZero"(%mask) : (tensor<4x5xf32>) -> tensor<2x?xi64>
+    %t = "onnx.Transpose"(%nz) {perm = [1, 0]} : (tensor<2x?xi64>) -> tensor<?x2xi64>
+    %out = "onnx.ScatterND"(%data, %t, %updates)
+        : (tensor<4x5x8xf32>, tensor<?x2xi64>, tensor<?x8xf32>) -> tensor<4x5x8xf32>
+    return %out : tensor<4x5x8xf32>
+  }
+
+  // CHECK-LABEL: func.func @nonzero_transpose_scatter
+  // CHECK-SAME: (%[[CTX:.*]]: !hip.context,
+
+  // NonZero produces indices + count_buf (DPS: result is separate from init)
+  // CHECK: %[[NZ:.*]]:2 = hip.nonzero(%[[CTX]]) ins({{.*}}) outs({{.*}} : {{.*}}, tensor<1xi32>)
+
+  // Transpose on the indices (result #0)
+  // CHECK: hip.transpose
+
+  // ScatterND uses NonZero's count result (#1) with has_valid_count = true
+  // CHECK: hip.scatter_nd(%[[CTX]]) ins({{.*}}, {{.*}}, {{.*}}, %[[NZ]]#1 :
+  // CHECK-SAME: {has_valid_count = true}
+}

--- a/test/lit/Conversion/onnx-to-hip/test_scatter_nd.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_scatter_nd.mlir
@@ -2,9 +2,6 @@
 // Licensed under the MIT License.
 
 // Verify onnx.ScatterND -> hip.scatter_nd conversion.
-// The runtime is a logging-only stub today (no kernel), but the IR shape
-// must still be correct so the bufferize / LLVM lowering passes stay
-// happy.
 
 // RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
 
@@ -14,9 +11,6 @@ module {
   }
 
   // 1-D ScatterND, default reduction ("none"), scalar updates.
-  // Note: `reduction = "none"` is the default value of a
-  // `DefaultValuedStrAttr` and is therefore elided by MLIR's pretty
-  // printer — the absence of the attribute in IR IS the "none" case.
   func.func @test_scatter_nd_1d_default(
       %data: tensor<8xf32>,
       %indices: tensor<4x1xi64>,
@@ -26,17 +20,16 @@ module {
         : (tensor<8xf32>, tensor<4x1xi64>, tensor<4xf32>) -> tensor<8xf32>
 
     // CHECK-NOT: onnx.ScatterND
-    // CHECK: tensor.empty() : tensor<8xf32>
+    // CHECK-DAG: tensor.empty() : tensor<8xf32>
+    // CHECK-DAG: tensor.empty() : tensor<1xi32>
     // CHECK: hip.scatter_nd({{.*}}) ins(
-    // CHECK-SAME: : tensor<8xf32>, tensor<4x1xi64>, tensor<4xf32>)
+    // CHECK-SAME: tensor<8xf32>, tensor<4x1xi64>, tensor<4xf32>, tensor<1xi32>)
     // CHECK-SAME: outs({{.*}} : tensor<8xf32>)
-    // CHECK-NOT: reduction
 
     return %r : tensor<8xf32>
   }
 
-  // 3-D ScatterND with k=1: each update is a 2-D slice (default reduction
-  // is elided — see note in @test_scatter_nd_1d_default above).
+  // 3-D ScatterND with k=1: each update is a 2-D slice.
   func.func @test_scatter_nd_3d_slice(
       %data: tensor<4x4x4xf32>,
       %indices: tensor<2x1xi64>,
@@ -48,9 +41,8 @@ module {
 
     // CHECK-NOT: onnx.ScatterND
     // CHECK: hip.scatter_nd({{.*}}) ins(
-    // CHECK-SAME: : tensor<4x4x4xf32>, tensor<2x1xi64>, tensor<2x4x4xf32>)
+    // CHECK-SAME: tensor<4x4x4xf32>, tensor<2x1xi64>, tensor<2x4x4xf32>, tensor<1xi32>)
     // CHECK-SAME: outs({{.*}} : tensor<4x4x4xf32>)
-    // CHECK-NOT: reduction
 
     return %r : tensor<4x4x4xf32>
   }
@@ -91,9 +83,7 @@ module {
     return %r : tensor<4x4xf32>
   }
 
-  // Dynamic data shape (output.rank == data.rank invariant): every
-  // dynamic output dim is sourced from the matching data dim via
-  // tensor.dim.
+  // Dynamic data shape
   func.func @test_scatter_nd_dyn_data(
       %data: tensor<?x?xf32>,
       %indices: tensor<2x2xi64>,
@@ -110,5 +100,5 @@ module {
   // CHECK-DAG: %[[A1:.*]] = arith.constant 1 : index
   // CHECK-DAG: %[[D1:.*]] = tensor.dim %[[D]], %[[A1]] : tensor<?x?xf32>
   // CHECK: tensor.empty(%[[D0]], %[[D1]]) : tensor<?x?xf32>
-  // CHECK: hip.scatter_nd({{.*}}) ins({{.*}}, {{.*}}, {{.*}} : tensor<?x?xf32>, tensor<2x2xi64>, tensor<2xf32>) outs({{.*}} : tensor<?x?xf32>)
+  // CHECK: hip.scatter_nd({{.*}}) ins({{.*}} : tensor<?x?xf32>, tensor<2x2xi64>, tensor<2xf32>, tensor<1xi32>) outs({{.*}} : tensor<?x?xf32>)
 }


### PR DESCRIPTION
## Summary

Add `count_buf` (tensor<1xi32>) as a second output to `hip.NonZero`, enabling downstream `ScatterND` to know the actual non-zero count without D2H synchronization. The ScatterND conversion backtraces through Transpose/Reshape/Cast to find the upstream NonZero's count_buf and passes it as `valid_count`.

### Key changes:

- **NonZero op** (`HipOps.td`): now produces two outputs — indices `[R, N]` and count_buf `[1xi32]`
- **NonZero kernel** (`nonzero_kernel.hip`): zero-initializes output buffer before launch (prevents UB on padded slots)
- **ScatterND conversion**: defers when unconverted `onnx.NonZero` is upstream, retries after NonZero conversion to capture `count_buf` via backtrace
- **ScatterND op** (`HipOps.td`): accepts `valid_count` input + `has_valid_count` attribute
- **Runtime**: both `wrap_nonzero` and `wrap_scatter_nd` updated to pass/receive `count_ptr`

### Correctness guarantees:

- When `has_valid_count = true`: ScatterND kernel processes only valid rows (0..count-1)
- When `has_valid_count = false`: ScatterND processes all rows (fallback for non-NonZero indices)
- NonZero output buffer zero-initialized: even if count_buf optimization is inactive, padded slots contain [0,...,0] indices (safe scatter to position 0)

## Test Plan

- [x] LIT: `onnx-to-hip/test_nonzero.mlir` — 6 cases (bool/f32/i64/ui8, static/dynamic/partial-dynamic input)
- [x] LIT: `onnx-to-hip/test_scatter_nd.mlir` — 5 cases (1D/3D, reduction variants, dynamic data)
- [x] LIT: `onnx-to-hip/test_nonzero_scatter_backtrace.mlir` — verifies count_buf flows through Transpose to ScatterND
- [x] LIT: `hip-to-llvm/test_nonzero.mlir` — lowering to wrap_nonzero call
- [x] LIT: `hip-to-llvm/test_scatter_nd.mlir` — lowering with/without valid_count
- [x] E2E: ScatterND standalone (static shapes, GPU execution)
- [x] E2E: NonZero + Transpose + ScatterND combined (sparse mask, bit-exact vs numpy reference)
