### PR TITLE
ci(experiment): measure onnx-hipdnn-ep cold build time without sccache

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -300,9 +300,10 @@ jobs:
             -DHIP_ARCHITECTURES=gfx1151 \
             -Dmorphizen_ENABLE_UNIT_TEST=OFF \
             -DBUILD_MOCK_RUNTIME=OFF \
-            -DCMAKE_DISABLE_FIND_PACKAGE_OpenSSL=ON \
-            -DCMAKE_C_COMPILER_LAUNCHER=sccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+            -DCMAKE_DISABLE_FIND_PACKAGE_OpenSSL=ON
+          # NOTE: sccache compiler launchers intentionally dropped here for a
+          # one-off measurement of the no-cache onnx-hipdnn-ep build time.
+          # Revert this hunk before merging.
 
 
       # -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

One-off CI experiment to measure the cold (no sccache) build time of `onnx-hipdnn-ep` on a `windows-latest` runner.

The onnx-hipdnn-ep cmake `Configure` step previously passed `-DCMAKE_C/CXX_COMPILER_LAUNCHER=sccache`. This PR drops those two flags so the subsequent `Build and Install` step compiles with raw `cl.exe` + `ninja`, no sccache lookup or store. The OGA cmake configure intentionally keeps sccache; only the onnx-hipdnn-ep step is affected so the measurement is isolated.

The "Setup sccache" step earlier in the job still runs (the OGA build still needs it), but with the cmake launcher flags gone, sccache is never invoked during the onnx-hipdnn-ep build.

## How to read the result

After the workflow runs, open `Windows Build` > `build-windows` > `Build and Install` step in the action log. Compare its elapsed time with the same step on a recent main run (where sccache was active). `core-ci.mdc` claims `~2.5 min` when sccache hits; this PR gives the no-cache baseline.

## Do not merge

This commit is for measurement only. Revert before any merge to main.
