### PR TITLE
feat(conversion): collapse Range tensor<1xT> operands to rank-0 scalars

### DIFF
--- a/include/hip/InitAllPasses.h
+++ b/include/hip/InitAllPasses.h
@@ -11,6 +11,7 @@
 #include "hip/Dialect/Transforms/Passes.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Arith/Transforms/BufferDeallocationOpInterfaceImpl.h"
 #include "mlir/Dialect/Arith/Transforms/BufferizableOpInterfaceImpl.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Bufferization/Transforms/FuncBufferizableOpInterfaceImpl.h"
@@ -52,6 +53,7 @@ inline void registerAllDialects(mlir::DialectRegistry &registry) {
   registry.insert<mlir::hip::HipDialect>();
   registry.insert<detail::OnnxStubDialect>();
   mlir::arith::registerBufferizableOpInterfaceExternalModels(registry);
+  mlir::arith::registerBufferDeallocationOpInterfaceExternalModels(registry);
   mlir::tensor::registerBufferizableOpInterfaceExternalModels(registry);
   mlir::bufferization::func_ext::registerBufferizableOpInterfaceExternalModels(
       registry);

--- a/lib/Conversion/OnnxToHip/RangeConversion.cpp
+++ b/lib/Conversion/OnnxToHip/RangeConversion.cpp
@@ -187,24 +187,44 @@ struct RangeToHip : public RewritePattern {
     if (!elemTy.isIntOrFloat())
       return rewriter.notifyMatchFailure(op, "unsupported element type");
 
-    for (Value v : op->getOperands()) {
-      auto t = dyn_cast<RankedTensorType>(v.getType());
-      if (!t || t.getRank() != 0 || t.getElementType() != elemTy)
-        return rewriter.notifyMatchFailure(
-            op, "expected 0-D operands matching result element type");
-    }
-
     Location loc = op->getLoc();
+    SmallVector<Value, 3> operands;
+    for (Value v : op->getOperands()) {
+      // Operand normalization: tensor<1xT> is collapsed to 0-D tensor<T> via
+      // tensor.collapse_shape; 0-D tensor<T> is used as-is. The resulting
+      // scalars feed hip.range (start/limit/delta). tensor.extract on each
+      // scalar drives build*RangeCount for the dynamic output length.
+      auto t = dyn_cast<RankedTensorType>(v.getType());
+      if (!t || t.getElementType() != elemTy)
+        return rewriter.notifyMatchFailure(op, "expected ranked tensor");
+      if (t.getRank() == 0) {
+        // 0-D operand(tensor<i64>)
+        operands.push_back(v);
+      } else if (t.getRank() == 1 && t.getDimSize(0) == 1) {
+        // 1-D operand with static length 1, convert to 0-D operand(tensor<i64>)
+        auto scalarTy = RankedTensorType::get({}, elemTy);
+        auto reassoc = getReassociationIndicesForReshape(t, scalarTy);
+        if (!reassoc)
+          return rewriter.notifyMatchFailure(
+              op, "cannot compute reshape reassociation");
+        operands.push_back(tensor::CollapseShapeOp::create(
+            rewriter, loc, scalarTy, v, *reassoc));
+      } else {
+        return rewriter.notifyMatchFailure(
+            op, "expected 0-D or tensor<1xT> operands matching result element "
+                "type");
+      }
+    }
 
     if (failed(verifyConstantDeltaNonZero(op, op->getOperand(2), elemTy)))
       return failure();
 
-    Value startE = tensor::ExtractOp::create(rewriter, loc, op->getOperand(0),
-                                             ValueRange{});
-    Value limitE = tensor::ExtractOp::create(rewriter, loc, op->getOperand(1),
-                                             ValueRange{});
-    Value deltaE = tensor::ExtractOp::create(rewriter, loc, op->getOperand(2),
-                                             ValueRange{});
+    Value startE =
+        tensor::ExtractOp::create(rewriter, loc, operands[0], ValueRange{});
+    Value limitE =
+        tensor::ExtractOp::create(rewriter, loc, operands[1], ValueRange{});
+    Value deltaE =
+        tensor::ExtractOp::create(rewriter, loc, operands[2], ValueRange{});
 
     Value len = llvm::TypeSwitch<Type, Value>(elemTy)
                     .Case<IntegerType>([&](IntegerType ity) {
@@ -233,9 +253,9 @@ struct RangeToHip : public RewritePattern {
                                      elemTy, ValueRange{});
     }
 
-    auto rangeOp = mlir::hip::RangeOp::create(
-        rewriter, loc, resultType, ctx, op->getOperand(0), op->getOperand(1),
-        op->getOperand(2), init);
+    auto rangeOp =
+        mlir::hip::RangeOp::create(rewriter, loc, resultType, ctx, operands[0],
+                                   operands[1], operands[2], init);
     rewriter.replaceOp(op, rangeOp->getResult(0));
     return success();
   }

--- a/test/lit/Conversion/onnx-to-hip/test_range.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_range.mlir
@@ -84,4 +84,19 @@ module {
   // CHECK-LABEL: func.func @test_range_empty_neg_f32
   // CHECK: tensor.empty
   // CHECK: hip.range
+
+  // ORT/HF often export scalar start/limit/delta as tensor<1xT>; collapse to 0-D before hip.range.
+  func.func @test_range_i32_1d_operands() -> tensor<4xi32> {
+    %s = arith.constant dense<2> : tensor<1xi32>
+    %l = arith.constant dense<10> : tensor<1xi32>
+    %d = arith.constant dense<2> : tensor<1xi32>
+    %r = "onnx.Range"(%s, %l, %d) : (tensor<1xi32>, tensor<1xi32>, tensor<1xi32>) -> tensor<4xi32>
+    return %r : tensor<4xi32>
+  }
+  // CHECK-LABEL: func.func @test_range_i32_1d_operands
+  // CHECK-COUNT-3: tensor.collapse_shape
+  // CHECK-SAME: tensor<1xi32> into tensor<i32>
+  // CHECK: tensor.empty
+  // CHECK: hip.range
+  // CHECK-NOT: onnx.Range
 }

--- a/test/lit/e2e/test_range_model_1d.mlir
+++ b/test/lit/e2e/test_range_model_1d.mlir
@@ -1,0 +1,24 @@
+// RUN: hip-mlir-opt %s --hipdnn-pipeline | FileCheck %s
+
+// Verifies end-to-end lowering for ONNX Range through custom-kernel runtime call.
+// 1. convert-onnx-to-hip: onnx.Range -> hip.range
+// 2. convert-hip-to-llvm: hip.range -> llvm.call @wrap_range
+// 3. generate-interface: inference_init/compute/cleanup/metadata
+
+// CHECK-DAG: llvm.func @wrap_range
+// CHECK-DAG: llvm.func @hipdnn_ep_state_reset_error_flag
+// CHECK-DAG: llvm.func @hipdnn_ep_state_read_and_clear_error_flag
+// CHECK-LABEL: llvm.func @inference_compute
+// CHECK: llvm.call @hipdnn_ep_state_reset_error_flag
+// CHECK: llvm.call @main_graph
+// CHECK: llvm.call @hipdnn_ep_state_read_and_clear_error_flag
+// CHECK-NOT: onnx.Range
+
+module {
+  func.func @main_graph(%arg0: tensor<1xi32>, %arg1: tensor<1xi32>, %arg2: tensor<1xi32>)
+    -> (tensor<?xi32> {onnx.name = "output"}) {
+    %0 = "onnx.Range"(%arg0, %arg1, %arg2) {onnx_node_name = "/range"} : (tensor<1xi32>, tensor<1xi32>, tensor<1xi32>) -> tensor<?xi32>
+    "onnx.Return"(%0) : (tensor<?xi32>) -> ()
+  }
+  "onnx.EntryPoint"() {func = @main_graph} : () -> ()
+}


### PR DESCRIPTION
## Motivation

ORT/HF often export Range start/limit/delta as tensor<1xT> while hip.range expects rank-0 tensors. So submitting this PR to support tensor<1xT>.

## Technical Details

### lib/Conversion/OnnxToHip/RangeConversion.cpp
Lower tensor<1xT> via tensor.collapse_shape before hip.range and keep compile-time delta==0 checks on the original operands.
### include/hip/InitAllPasses.h
Register arith BufferDeallocationOpInterface so the full bufferization pipeline succeeds after introducing collapse_shape on this path.
### test/lit/Conversion/onnx-to-hip/test_range.mlir & test/lit/e2e/test_range_model_1d.mlir
Add onnx-to-hip and e2e LIT coverage for static 1x1 operands.

## Test Plan
- [x] onnx-to-hip test
- [x] e2e LIT
