### PR TITLE
docs(contributing): add incremental development + AI tool use policies

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,132 @@
+<!--
+Thanks for contributing! Please skim the two policies this repo
+follows before requesting review (1-2 minutes each):
+
+  Incremental development:
+    https://llvm.org/docs/DeveloperPolicy.html#incremental-development
+  AI tool use:
+    https://llvm.org/docs/AIToolPolicy.html
+
+A short summary lives in CONTRIBUTING.md at the repo root. Each
+section below has an HTML comment explaining what to put in it; you
+can delete the comment after filling the section in.
+-->
+
+## Summary
+
+<!--
+1-3 sentences. What changed at a high level and what gap or bug it
+closes.
+-->
+
+## Why
+
+<!--
+Design rationale. What alternatives did you consider and why did you
+pick this one? This section is what reviewers use to skip ahead and
+agree with the design before reading the code. Even one paragraph is
+fine if the choice is obvious; for non-trivial design decisions, be
+explicit about the alternatives you rejected.
+-->
+
+## What
+
+<!--
+Numbered list of concrete changes, with file references. Useful
+shapes:
+
+1. **New pass / op / runtime helper** at `path/to/file.cpp`. <one
+   sentence on the contract; one sentence on the predicate or scope>.
+2. **Pipeline placement / call-site update**: <where it slots in and
+   why that placement>.
+3. **Helper rename / API change**: <one sentence>.
+4. **Intentional non-changes**: <things the reader will expect to see
+   touched that aren't, with the reason>.
+-->
+
+## Test plan
+
+<!--
+- Lit / pytest / runner commands you ran and the result (pass count,
+  numerics delta vs reference, etc).
+- Manual reproduction steps for behavioural changes (model name,
+  hardware, command).
+- For perf-sensitive changes, include a before/after table — see the
+  optional Performance section below.
+-->
+
+## Notes for reviewers
+
+<!--
+- Known limitations and what they would take to fix.
+- Follow-ups already planned (link the design issue / next PR).
+- Anything load-bearing that isn't obvious from the diff (invariants,
+  ABI assumptions, ordering constraints).
+- "None" is a valid answer if the PR is small and self-contained.
+-->
+
+<!--
+============================================================
+Optional sections — include when applicable. Delete this whole
+block if you don't need any of them.
+============================================================
+
+## Compiler IR walkthrough
+
+<details>
+<summary><b>Before</b> — short description</summary>
+
+```mlir
+// IR before this PR's pass / lowering
+```
+
+</details>
+
+<details>
+<summary><b>After</b> — short description</summary>
+
+```mlir
+// IR after this PR's pass / lowering
+```
+
+</details>
+
+## Performance
+
+<details>
+<summary>Short headline result (e.g. "22x over DML EP on …")</summary>
+
+| Metric | This PR | Baseline | Ratio |
+|---|---:|---:|---:|
+| Inferences/sec | … | … | … |
+| Mean latency | … | … | … |
+
+Hardware: gfxNNNN, model: <name>, build: <flags>.
+
+</details>
+
+============================================================
+-->
+
+## Checklist
+
+- [ ] **Incremental.** This PR is either standalone, or a planned step
+      in a documented series. If it exceeds ~500 LOC or ~10 files, the
+      Summary / Why explains why it cannot be split, OR links the
+      precursor PRs and the design issue. See:
+      https://llvm.org/docs/DeveloperPolicy.html#incremental-development
+- [ ] **AI policy.** If AI tools (Cursor, Claude, Copilot, etc.)
+      generated substantial code or text, the Summary discloses it,
+      the commit messages carry the trailers documented in
+      [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md#commit-message-trailers),
+      and you can defend each design decision in review without
+      re-prompting an LLM. See: https://llvm.org/docs/AIToolPolicy.html
+- [ ] **No `good first issue` automation.** This PR is not an AI-tool
+      fix to an issue tagged `good first issue` (those are reserved as
+      learning opportunities for new contributors).
+- [ ] **Reviews resolved.** All review-comment threads from prior
+      rounds are resolved (enforced by branch protection on `main`).
+- [ ] **CODEOWNERS routing.** Reviewers were assigned automatically by
+      [`CODEOWNERS`](../blob/main/.github/CODEOWNERS). If the change
+      touches a path outside the current ownership map, the PR
+      description names the operational owner.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,9 @@
 <!--
+Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+Licensed under the MIT License.
+-->
+
+<!--
 Thanks for contributing! Please skim the two policies this repo
 follows before requesting review (1-2 minutes each):
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -124,8 +124,9 @@ Hardware: gfxNNNN, model: <name>, build: <flags>.
       generated substantial code or text, the Summary discloses it,
       the commit messages carry the trailers documented in
       [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md#commit-message-trailers),
-      and you can defend each design decision in review without
-      re-prompting an LLM. See: https://llvm.org/docs/AIToolPolicy.html
+      and you can answer questions about each design decision in
+      review without delegating back to the tool. See:
+      https://llvm.org/docs/AIToolPolicy.html
 - [ ] **No `good first issue` automation.** This PR is not an AI-tool
       fix to an issue tagged `good first issue` (those are reserved as
       learning opportunities for new contributors).

--- a/.github/workflows/pr-policy-reminder.yml
+++ b/.github/workflows/pr-policy-reminder.yml
@@ -1,0 +1,78 @@
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+# Posts a single reminder comment on PR open with links to the
+# incremental-development and AI-tool-use policies. Also auto-labels
+# PRs that exceed the soft size threshold as `large-pr`. The bot does
+# NOT generate review content; it only posts static text and a label.
+# This is intentional — automated review verdicts are not allowed in
+# this repo (see CONTRIBUTING.md, "No automated reviews").
+
+name: PR policy reminder
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  remind:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post policy reminder
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const body = [
+              "Thanks for opening a PR!",
+              "",
+              "This repo follows two policies, summarised in",
+              "[`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md):",
+              "",
+              "- [Incremental development](https://llvm.org/docs/DeveloperPolicy.html#incremental-development) —",
+              "  small PRs, precursors first, document the series for big work.",
+              "- [AI tool use](https://llvm.org/docs/AIToolPolicy.html) —",
+              "  human in the loop, disclose substantial AI assistance, no",
+              "  automated review verdicts, no AI on `good first issue`s.",
+              "",
+              "Quick checks before requesting review:",
+              "",
+              "1. The Summary / Why sections explain *why* the change is",
+              "   reviewable in one sitting (or link the precursor / design",
+              "   issue if not).",
+              "2. If AI tools were used substantially, the PR description and",
+              "   commit trailers (`Co-Authored-By:`, `Made-with:`) disclose it.",
+              "3. You are confident enough in the change to defend each design",
+              "   decision in review without re-prompting an LLM.",
+              "",
+              "Reviewers will be assigned automatically via",
+              "[`CODEOWNERS`](../blob/main/.github/CODEOWNERS).",
+            ].join("\n");
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body,
+            });
+
+      - name: Label oversized PRs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const LOC_LIMIT = 500;
+            const FILE_LIMIT = 10;
+            const changedLoc = (pr.additions || 0) + (pr.deletions || 0);
+            const changedFiles = pr.changed_files || 0;
+            if (changedLoc > LOC_LIMIT || changedFiles > FILE_LIMIT) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                labels: ["large-pr"],
+              });
+            }

--- a/.github/workflows/pr-policy-reminder.yml
+++ b/.github/workflows/pr-policy-reminder.yml
@@ -1,6 +1,8 @@
-# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
-# Licensed under the MIT License.
-#
+##
+## Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+## Licensed under the MIT License.
+##
+
 # Posts a single reminder comment on PR open with links to the
 # incremental-development and AI-tool-use policies. Also auto-labels
 # PRs that exceed the soft size threshold as `large-pr`. The bot does

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,13 +50,13 @@ The points that bite hardest in this repo:
 > - Each change should be kept as small as possible. This simplifies
 >   your work (into a logical progression), simplifies code review and
 >   reduces the chance that you will get negative feedback on the
->   change.
+>   change. ...
 > - Large/invasive changes usually have a number of secondary changes
 >   that are required before the big change can be made (e.g. API
 >   cleanup, etc). These sorts of changes can often be done before the
 >   major change is done, independently of that work.
 > - Often, an independent precursor to a big change is to add a new API
->   and slowly migrate clients to use the new API.
+>   and slowly migrate clients to use the new API. ...
 
 ### What "small" means here
 
@@ -188,7 +188,7 @@ If a maintainer judges that a PR fits this pattern, they will:
    > tool-generated content, and requires additional justification
    > for why it is valuable enough to the project for us to review
    > it. Please see our developer policy on AI-generated
-   > contributions: <https://llvm.org/docs/AIToolPolicy.html>
+   > contributions: http://llvm.org/docs/AIToolPolicy.html
 
 3. Ask the contributor to either reduce the scope, split it into a
    series, or document why review cost is justified.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,9 +64,12 @@ The points that bite hardest in this repo:
   first) is the soft threshold. PRs above this get the `large-pr`
   label automatically as a reviewer signal — not a hard block.
 - A `large-pr` PR is acceptable when the work genuinely cannot be
-  split (a vendor drop, a generated file regen, a single test that
-  exercises many paths, a feature with irreducible cross-layer
-  coupling). The Summary / Why section must explain why.
+  split — typically a feature with irreducible cross-layer coupling
+  (compiler + runtime + tests that are only meaningful together), a
+  coordinated rename or signature change across many call sites
+  where splitting would leave the tree uncompilable between PRs, or
+  a single test that exercises many paths. The Summary / Why section
+  must explain why.
 - A `large-pr` PR that *could* have been split but wasn't may be
   marked `extractive` and asked to land as a series. See the
   [Extractive contributions](#extractive-contributions) section

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,12 +64,26 @@ The points that bite hardest in this repo:
   first) is the soft threshold. PRs above this get the `large-pr`
   label automatically as a reviewer signal — not a hard block.
 - A `large-pr` PR is acceptable when the work genuinely cannot be
-  split — typically a feature with irreducible cross-layer coupling
-  (compiler + runtime + tests that are only meaningful together), a
-  coordinated rename or signature change across many call sites
-  where splitting would leave the tree uncompilable between PRs, or
-  a single test that exercises many paths. The Summary / Why section
-  must explain why.
+  split. **Listing a category below is not a free pass** — the
+  Summary / Why section must explain *why this specific change*
+  couldn't be sliced further, naming the parts you considered
+  extracting (precursor refactors, build/CI bumps, isolated test
+  fixtures, separable increments) and why each one would not be
+  reviewable on its own. Categories that have carried justified
+  `large-pr` size on this repo:
+  - a feature with irreducible cross-layer coupling (compiler +
+    runtime + tests that are only meaningful together);
+  - a coordinated rename or signature change across many call sites
+    where splitting would leave the tree uncompilable between PRs;
+  - a single test that exercises many paths.
+  Reviewers retain the right to apply the `extractive` label even
+  when a category applies, if the slicing argument doesn't hold up.
+- **Hard ceiling.** PRs above 2,000 LOC or 30 files require a
+  pre-PR design discussion linked from the description — a GitHub
+  issue, a sync-meeting agenda item, or a Teams thread with the
+  affected reviewers. At that size, "explain why in the PR
+  description" stops being a useful review tool; the design needs
+  to be agreed on before code is written.
 - A `large-pr` PR that *could* have been split but wasn't may be
   marked `extractive` and asked to land as a series. See the
   [Extractive contributions](#extractive-contributions) section

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,9 +109,9 @@ Five points are load-bearing for this repo:
 
 You should be sufficiently confident in the change that asking a
 maintainer to review it is a good use of their time. Concretely:
-during review, you must be able to answer "why did you write it this
-way?" without re-prompting an LLM. If you cannot defend a design
-decision, the PR is not ready.
+during review, you must be able to answer questions about each
+design decision without delegating back to the tool. If you cannot,
+the PR is not ready.
 
 ### Disclose substantial AI assistance
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,278 @@
+<!--
+Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+Licensed under the MIT License.
+-->
+
+# Contributing to onnx-hipdnn-ep
+
+This repo follows two contribution policies adopted from the LLVM
+project, with small adaptations noted below. Every PR is expected to
+honour both. The list will grow over time; for now this is the minimum
+bar for opening a PR on `main`.
+
+- [Incremental Development](https://llvm.org/docs/DeveloperPolicy.html#incremental-development)
+- [AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html)
+
+If you have not contributed here before, please skim the two LLVM pages
+linked above before opening a PR. They are short. The rest of this
+document explains how those policies translate into concrete
+expectations for this repo.
+
+---
+
+## TL;DR
+
+1. **Keep PRs small.** Large feature work should be decomposed into a
+   series of independent PRs (precursors first, then the main change).
+   ~500 LOC / ~10 files is the soft threshold; bigger PRs need the
+   Summary section to explain why they cannot be split.
+2. **Human in the loop for AI-generated content.** You can use Cursor,
+   Claude, Copilot, or whatever helps you write code, but you are the
+   author and are accountable for the change. You must be able to
+   answer review questions about the work without delegating back to
+   the tool.
+3. **Disclose substantial AI usage.** Note it in the PR description
+   and use the commit message trailers documented in
+   [Commit message trailers](#commit-message-trailers) below.
+4. **Don't let AI tools fix `good first issue`s.** Those are reserved
+   as learning opportunities for new contributors.
+5. **Address every review comment.** Branch protection on `main`
+   requires every review-comment thread to be resolved before merge.
+
+---
+
+## Incremental development
+
+The full LLVM rationale is at
+<https://llvm.org/docs/DeveloperPolicy.html#incremental-development>.
+The points that bite hardest in this repo:
+
+> - Each change should be kept as small as possible. This simplifies
+>   your work (into a logical progression), simplifies code review and
+>   reduces the chance that you will get negative feedback on the
+>   change.
+> - Large/invasive changes usually have a number of secondary changes
+>   that are required before the big change can be made (e.g. API
+>   cleanup, etc). These sorts of changes can often be done before the
+>   major change is done, independently of that work.
+> - Often, an independent precursor to a big change is to add a new API
+>   and slowly migrate clients to use the new API.
+
+### What "small" means here
+
+- **~500 changed LOC** or **~10 changed files** (whichever is hit
+  first) is the soft threshold. PRs above this get the `large-pr`
+  label automatically as a reviewer signal — not a hard block.
+- A `large-pr` PR is acceptable when the work genuinely cannot be
+  split (a vendor drop, a generated file regen, a single test that
+  exercises many paths, a feature with irreducible cross-layer
+  coupling). The Summary / Why section must explain why.
+- A `large-pr` PR that *could* have been split but wasn't may be
+  marked `extractive` and asked to land as a series. See the
+  [Extractive contributions](#extractive-contributions) section
+  below.
+
+### How to split
+
+A typical decomposition for a feature that touches the compiler and
+the runtime (the most common shape in this repo):
+
+1. **Precursor PRs** — refactors that don't change behaviour but make
+   the main change reviewable: factor a helper, rename a symbol, add
+   a TableGen option, introduce a runtime export with an old-symbol
+   fallback. Each lands on its own. Tag them with the
+   `incremental-precursor` label.
+2. **First increment** — the smallest end-to-end change that does
+   something useful. Often "add the new pass / op behind a flag,
+   default off". Lands once tests cover it.
+3. **Subsequent increments** — flip the flag, migrate callers, remove
+   the old path. Each is a separate PR.
+
+If you are unsure how to slice a change, open a design issue first
+and tag a reviewer for input before writing code. This is much
+cheaper than discovering during PR review that the structure is
+wrong.
+
+---
+
+## AI tool use
+
+The full LLVM policy is at <https://llvm.org/docs/AIToolPolicy.html>.
+Five points are load-bearing for this repo:
+
+### Human in the loop
+
+> Contributors must read and review all LLM-generated code or text
+> before they ask other project members to review it. The contributor
+> is always the author and is fully accountable for their
+> contributions.
+
+You should be sufficiently confident in the change that asking a
+maintainer to review it is a good use of their time. Concretely:
+during review, you must be able to answer "why did you write it this
+way?" without re-prompting an LLM. If you cannot defend a design
+decision, the PR is not ready.
+
+### Disclose substantial AI assistance
+
+PR-level disclosure goes in the Summary section: a short note on which
+parts of the change were AI-assisted and how the output was validated.
+Commit-level disclosure goes via the trailers in
+[Commit message trailers](#commit-message-trailers) below.
+
+The threshold for "substantial" is judgment, but a useful rule of
+thumb: if a reviewer would reasonably want to know that an LLM
+produced this code in order to ask sharper questions about it,
+disclose it.
+
+### Write your own PR description
+
+Write the PR description yourself. Tools for translation,
+spell-check, or copy-editing are fine, but letting an LLM generate
+the entire description usually produces a longer, less-grounded
+text that doesn't match the actual code.
+
+### No automated reviews
+
+Following LLVM's stance, **automated review tools that publish
+comments without human approval are not allowed** in this repo. An
+opt-in tool that routes through a human reviewer is fine. Posting an
+LLM's review verdict directly on a PR is not.
+
+### `good first issue` is off-limits for AI
+
+Issues tagged `good first issue` are explicitly reserved as learning
+opportunities for new contributors. Per LLVM's policy, fully
+automating those PRs squanders the learning opportunity and adds
+little value to the project. **Do not use AI tools to fix issues
+labelled `good first issue`.**
+
+---
+
+## Extractive contributions
+
+LLVM defines an *extractive contribution* as one where the cost of
+reviewing it is greater than the project's benefit from merging it.
+In practice, the patterns we see most often:
+
+- A 5,000+ LOC PR touching the compiler, runtime, tests, and docs,
+  where the reviewer must hold the whole change in their head.
+- A "fixes everything" PR that bundles unrelated cleanups with a
+  feature change.
+- A PR that lands the output of an AI tool without the contributor
+  understanding the design enough to defend it in review.
+
+If a maintainer judges that a PR fits this pattern, they will:
+
+1. Apply the `extractive` label.
+2. Comment with the LLVM-standard request:
+
+   > This PR doesn't appear to comply with our policy on
+   > tool-generated content, and requires additional justification
+   > for why it is valuable enough to the project for us to review
+   > it. Please see our developer policy on AI-generated
+   > contributions: <https://llvm.org/docs/AIToolPolicy.html>
+
+3. Ask the contributor to either reduce the scope, split it into a
+   series, or document why review cost is justified.
+
+This is not a personal judgement on the contributor — it is a
+statement that *the shape of the patch* is not a good fit for the
+project's review capacity right now. The fix is almost always to
+split.
+
+---
+
+## PR description template
+
+Every PR is auto-populated with
+[`.github/pull_request_template.md`](.github/pull_request_template.md).
+The expected sections are:
+
+| Section | Always required? | What goes here |
+|---|---|---|
+| **Summary** | Yes | 1-3 sentences: what changed and what gap it closes. |
+| **Why** | Yes | Design rationale. Alternatives considered and why this one wins. |
+| **What** | Yes for non-trivial PRs | Numbered list of concrete changes with file references. |
+| **Test plan** | Yes | What you ran and the result. Numerics / TPS deltas where relevant. |
+| **Notes for reviewers** | Yes (use "None" if truly nothing) | Known limits, follow-ups, load-bearing invariants. |
+| **Compiler IR walkthrough** | Optional | For compiler-side changes — wrap before/after IR in a `<details>` block to keep the description scannable. |
+| **Performance** | Optional | For perf-sensitive changes — table comparing this PR vs baseline; mention hardware (gfx target, model, build flags). |
+
+You don't need every section on every PR. Small, single-purpose fixes
+can keep the description tight (Summary / Why / What / Test plan /
+Notes) and skip the optional sections entirely.
+
+---
+
+## Commit message trailers
+
+Every commit you author should carry these trailers in the body,
+separated from the message body by a blank line:
+
+```
+Co-Authored-By: <Tool or Person> <email>
+Made-with: <tool name>
+```
+
+Examples used today on this repo:
+
+```
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+Made-with: Cursor
+```
+
+```
+Co-Authored-By: Cursor <cursoragent@cursor.com>
+```
+
+Rules:
+
+- Capitalisation is exactly `Co-Authored-By` (not `Co-authored-by`)
+  for AI tool attribution. Both forms are accepted by GitHub for
+  display purposes, but match the existing convention for grep-ability.
+- The model name in the trailer should match the model that actually
+  did the work (e.g. `Claude Opus 4.7`, `Claude Sonnet 4.5`,
+  `GPT-5`, `Cursor`).
+- Add the trailer on **every** commit you author, including test,
+  perf-attribution, and revert commits.
+- For multi-author work between humans, use the standard
+  `Co-Authored-By:` form for each collaborator.
+
+If a commit you authored does not carry the trailer, you may amend
+locally before push; if it has already been pushed and reviewed, do
+not force-push to amend — leave it and add the trailer on the next
+commit.
+
+---
+
+## Other repo conventions
+
+- **Branch protection on `main`:** PR + 1 CODEOWNER approval, all
+  threads resolved, no force-push, no delete. Admins can bypass for
+  emergencies.
+- **CODEOWNERS:** see [`.github/CODEOWNERS`](.github/CODEOWNERS).
+  Every path is co-owned by at least three reviewers, so a single
+  person being unreachable does not block routing.
+- **Code style:** clang-format / black / lit-test conventions are
+  enforced by pre-commit. Run `pre-commit install` once per clone.
+- **Pre-existing pre-commit hooks must not be skipped** (no
+  `--no-verify`) unless explicitly approved by a reviewer.
+
+---
+
+## Labels
+
+Reviewers may apply these labels to give shared vocabulary:
+
+| Label | Meaning |
+|---|---|
+| `extractive` | Review cost > project benefit. Needs to be split or made smaller. |
+| `large-pr` | Auto-applied when a PR exceeds the soft size thresholds. Reviewer signal, not a block. |
+| `incremental-precursor` | Standalone refactor that unblocks a larger upcoming change. |
+| `ai-assisted` | Substantial AI-generated content disclosed in the PR. |
+| `breaking-change` | Potentially-breaking change to a public API or runtime ABI. Surface in release notes. |
+
+This list will grow as additional policies (release-notes discipline,
+breaking-change handling, RFC process) are added on top of the two
+starting policies above.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,17 @@ For prerequisites, environment setup, and step-by-step build instructions, see
 
 ---
 
+## Contributing
+
+This repo follows the LLVM project's
+[Incremental Development](https://llvm.org/docs/DeveloperPolicy.html#incremental-development)
+and [AI Tool Use](https://llvm.org/docs/AIToolPolicy.html) policies. Before
+opening a PR, please read [CONTRIBUTING.md](CONTRIBUTING.md) for the local
+specifics: PR sizing, AI-assistance disclosure, CODEOWNERS routing, and
+commit message trailers.
+
+---
+
 ## License
 
 Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.


### PR DESCRIPTION
## Summary

Adopts LLVM's [incremental-development](https://llvm.org/docs/DeveloperPolicy.html#incremental-development) and [AI-tool-use](https://llvm.org/docs/AIToolPolicy.html) policies as the starting set of contribution guidelines for this repo, with small local adaptations.

Scoped intentionally to these two policies; release-notes discipline, breaking-change handling, and an RFC process can be added in follow-ups.

## Why

We've started seeing PRs land that are larger than a reviewer can hold in their head, and contributors have asked how to disclose AI-tool-assisted work. Both questions are already answered well by LLVM's published policies, so adopting them is cheaper than writing our own and gives anyone who's worked on LLVM-adjacent projects familiar terms.

## What

1. **`CONTRIBUTING.md`** — the two policies, soft size thresholds (~500 LOC / ~10 files), how to split a large change, the PR description template, and the commit-trailer convention this repo already uses.
2. **`.github/pull_request_template.md`** — Summary / Why / What / Test plan / Notes for reviewers, plus optional collapsible sections for IR walkthrough and Performance. Each section has an HTML comment explaining what to put in it.
3. **`.github/workflows/pr-policy-reminder.yml`** — posts a one-time reminder comment on PR open and auto-labels oversize PRs as `large-pr`. Signal only, not a block. The bot does not generate review content (per the AI policy).
4. **`README.md`** — short "Contributing" section linking to `CONTRIBUTING.md`.

The 5 referenced labels (`large-pr`, `extractive`, `incremental-precursor`, `ai-assisted`, `breaking-change`) have been pre-created on the repo so the workflow's auto-label step works on day one.

## Test plan

Markdown renders verified locally. The PR template and reminder workflow take effect on the next PR opened after merge.

## Notes for reviewers

- The 500 LOC / 10 file threshold is a soft "explain it" bar, not a hard block. Auto-applied `large-pr` is a reviewer signal.
- Trailer convention kept as `Co-Authored-By:` / `Made-with:` (matches every commit on `main` today) instead of LLVM's `Assisted-by:`. Easy to revisit later.
- `pull_request_target` is needed so the workflow can label PRs from forks. The workflow does not check out PR code or run any PR-supplied scripts.
- `.github/`, `CONTRIBUTING.md`, `README.md` are not in CODEOWNERS today, so no reviewer was auto-assigned. Happy to add coverage for these in a follow-up if you want it.
