### PR TITLE
fix(onnx-to-hip): support onnx.Loop with cond_init=none

### DIFF
--- a/lib/Conversion/OnnxToHip/LoopOutline.cpp
+++ b/lib/Conversion/OnnxToHip/LoopOutline.cpp
@@ -23,9 +23,14 @@
 //   6. Replace the onnx.Loop op with hip.loop and erase it.
 //
 // Limitations of this initial version:
-//   - Requires M (trip count) and cond_init both present.  Missing-M
-//     (while-style infinite loop) and missing-cond (unconditional counted
-//     loop) variants are rejected with a clean diagnostic for now.
+//   - Missing-M (while-style infinite loop) is rejected.  Counted loops
+//     with `cond_init` absent (`onnx.NoValue` / `none` type) are
+//     supported: cond is synthesized as `arith.constant true : i1` and
+//     `cond_is_passthrough` is forced so the runtime takes the fast
+//     `hipdnn_ep_run_counted_loop` path (no per-iter cond readback).
+//     Per ONNX spec, missing cond means the loop runs M times with no
+//     conditional early exit -- the body's `cond_out` (if any) is
+//     ignored.
 //   - Scan outputs (results beyond the loop-carried slot count) are not
 //     yet supported; rejected with a clean diagnostic.
 //
@@ -216,13 +221,19 @@ LogicalResult OnnxLoopOutlinePass::outlineLoop(Operation *loopOp,
   Block &bodyBlock = bodyRegion.front();
 
   // ONNX Loop has the operand layout (M, cond_init, v_init_1, ..., v_init_N).
-  // We currently require M and cond_init both present.
+  // M (trip count) is currently required; cond_init is optional. Importers
+  // materialize a missing cond_init as `onnx.NoValue` (none type). When
+  // absent, ONNX semantics is "cond stays true forever; only
+  // max_trip_count terminates the loop". All downstream layers
+  // (hip.loop dialect cond_init=Optional<I1>, LoopOpLowering null
+  // handling, runtime fast-path) already accept that shape, so we
+  // synthesize an i1-true here and force cond_is_passthrough.
   unsigned numOperands = loopOp->getNumOperands();
   if (numOperands < 2)
-    return loopOp->emitOpError(
-        "onnx.Loop with missing M or cond_init not yet supported");
+    return loopOp->emitOpError("onnx.Loop with missing M not yet supported");
   Value mTensor = loopOp->getOperand(0);
   Value condInitTensor = loopOp->getOperand(1);
+  bool condInitIsNone = isa<NoneType>(condInitTensor.getType());
   ValueRange vInitTensors = loopOp->getOperands().drop_front(2);
   unsigned numLoopCarried = vInitTensors.size();
 
@@ -264,7 +275,9 @@ LogicalResult OnnxLoopOutlinePass::outlineLoop(Operation *loopOp,
     yieldCondOutSrc = defOp->getOperand(0);
   }
   BlockArgument condInArg = bodyBlock.getArgument(1);
-  bool condIsPassthrough = (yieldCondOutSrc == condInArg);
+  // When cond_init is none, ONNX spec says the body's cond_out is ignored;
+  // we force the fast counted-loop path regardless of what the body yields.
+  bool condIsPassthrough = condInitIsNone || (yieldCondOutSrc == condInArg);
   LLVM_DEBUG(llvm::dbgs() << "[onnx-loop-outline] cond_is_passthrough = "
                           << condIsPassthrough << "\n");
 
@@ -398,12 +411,21 @@ LogicalResult OnnxLoopOutlinePass::outlineLoop(Operation *loopOp,
     return loopOp->emitOpError("could not unbox M to index (expected "
                                "tensor<i64>, got ")
            << mTensor.getType() << ")";
-  FailureOr<Value> condI1 = unboxCondInit(outerBuilder, loc, condInitTensor);
-  if (failed(condI1))
-    return loopOp->emitOpError("could not unbox cond_init to i1 (expected "
-                               "0-D tensor<i1>, tensor<i8>, or tensor<ui8>, "
-                               "got ")
-           << condInitTensor.getType() << ")";
+  Value condI1Val;
+  if (condInitIsNone) {
+    // Synthesize i1-true; runtime takes counted-loop fast path and never
+    // reads it back. See file header "Limitations" comment.
+    condI1Val = arith::ConstantIntOp::create(outerBuilder, loc,
+                                             outerBuilder.getI1Type(), 1);
+  } else {
+    FailureOr<Value> condI1 = unboxCondInit(outerBuilder, loc, condInitTensor);
+    if (failed(condI1))
+      return loopOp->emitOpError("could not unbox cond_init to i1 (expected "
+                                 "0-D tensor<i1>, tensor<i8>, or tensor<ui8>, "
+                                 "got ")
+             << condInitTensor.getType() << ")";
+    condI1Val = *condI1;
+  }
 
   // hip.loop result types: same as the (loop-carried portion of) yield ops
   // minus the cond_out slot, i.e. the original onnx.Loop's result types.
@@ -414,7 +436,7 @@ LogicalResult OnnxLoopOutlinePass::outlineLoop(Operation *loopOp,
       /*v_final=*/hipLoopResultTypes,
       /*ctx=*/ctxVal,
       /*max_trip_count=*/*mIdx,
-      /*cond_init=*/*condI1,
+      /*cond_init=*/condI1Val,
       /*v_init=*/vInitTensors,
       /*captures=*/ValueRange(captureVals),
       /*body_func=*/FlatSymbolRefAttr::get(ctx, fnName),

--- a/test/lit/Conversion/onnx-to-hip/test_loop_outline.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_loop_outline.mlir
@@ -31,6 +31,10 @@
 // - Non-passthrough cond keeps cond_out in the body's return tuple and omits
 //   the `cond_is_passthrough` attribute, so the LLVM lowering picks the slow
 //   path `hipdnn_ep_run_loop` instead of `hipdnn_ep_run_counted_loop`
+// - Missing `cond_init` (operand is `onnx.NoValue` -> `none`) synthesizes an
+//   i1-true and forces `cond_is_passthrough` so the runtime takes the fast
+//   counted-loop path -- matches ONNX spec where missing cond means M is the
+//   only termination condition
 // ============================================================================
 
 // RUN: hip-mlir-opt --hip-add-context-arg --onnx-loop-outline --split-input-file %s | FileCheck %s
@@ -162,4 +166,50 @@ module {
   // CHECK: %[[ADD:.*]] = "onnx.Add"
   // CHECK: %[[NOT:.*]] = "onnx.Not"
   // CHECK: return %[[NOT]], %[[ADD]] : tensor<i1>, tensor<16xf32>
+}
+
+// -----
+
+// Test 4: missing cond_init (counted loop).  ONNX Loop spec marks operand 1
+// as optional; importers spell its absence as `onnx.NoValue` with `none`
+// type.  ONNX semantics is "cond stays true forever; only max_trip_count
+// terminates" so the body's yielded cond_out is ignored.  The outliner
+// synthesizes `arith.constant true : i1` for hip.loop's cond_init and
+// forces `cond_is_passthrough` -- the LLVM lowering then picks the fast
+// path `hipdnn_ep_run_counted_loop`, identical to a dynamically-detected
+// passthrough case.  Matches Qwen3.5 vision encoder loop topology.
+module {
+  func.func @main_graph_no_cond(%A: tensor<16xf32>, %B: tensor<16xf32>) -> tensor<16xf32> {
+    %M = "onnx.Constant"() {value = dense<4> : tensor<i64>} : () -> tensor<i64>
+    %cond_init = "onnx.NoValue"() {value} : () -> none
+    %v_final = "onnx.Loop"(%M, %cond_init, %A) ({
+    ^bb0(%iter: tensor<i64>, %cond_in: tensor<i1>, %acc_in: tensor<16xf32>):
+      %acc_out = "onnx.Add"(%acc_in, %B) : (tensor<16xf32>, tensor<16xf32>) -> tensor<16xf32>
+      %cond_out = "onnx.Constant"() {value = dense<1> : tensor<i1>} : () -> tensor<i1>
+      "onnx.Yield"(%cond_out, %acc_out) : (tensor<i1>, tensor<16xf32>) -> ()
+    }) : (tensor<i64>, none, tensor<16xf32>) -> tensor<16xf32>
+    return %v_final : tensor<16xf32>
+  }
+
+  // CHECK-LABEL: func.func @main_graph_no_cond
+  //
+  // Trip count folds as before; cond_init is synthesized (no source
+  // operand to fold).
+  // CHECK-DAG: %[[M_IDX:.*]] = arith.constant 4 : index
+  // CHECK-DAG: %[[TRUE:.*]] = arith.constant true
+  //
+  // hip.loop op: passthrough forced, 1 loop-carried (%A), 1 capture (%B).
+  // CHECK: hip.loop({{.*}}, %[[M_IDX]], %[[TRUE]])
+  // CHECK-SAME: cond_is_passthrough
+  // CHECK-SAME: num_loop_carried = 1 : i32
+  //
+  // Body func skips the cond return slot (passthrough mode).  cond_in arg
+  // is preserved as tensor<i1> (block-arg type copied verbatim).
+  // CHECK-LABEL: func.func private @main_graph_no_cond_loop_body_n0
+  // CHECK-SAME: %{{.*}}: tensor<i1>,
+  // CHECK-SAME: %[[V_IN:.*]]: tensor<16xf32>,
+  // CHECK-SAME: %[[CAP:.*]]: tensor<16xf32>) -> tensor<16xf32>
+  //
+  // CHECK: %[[ADD:.*]] = "onnx.Add"(%[[V_IN]], %[[CAP]])
+  // CHECK: return %[[ADD]] : tensor<16xf32>
 }


### PR DESCRIPTION
## Problem

ONNX Loop spec marks operand 1 (`cond_init`) as optional; importers materialize a missing cond_init as `onnx.NoValue` (none type). ONNX semantics when absent: cond stays true forever, only `max_trip_count` terminates the loop.

[`lib/Conversion/OnnxToHip/LoopOutline.cpp`](onnx-hipdnn-ep/lib/Conversion/OnnxToHip/LoopOutline.cpp) initial-version head comment explicitly listed missing-cond as an unsupported limitation, while every downstream layer was already cond=missing-ready:

- `Hip_LoopOp` dialect declares `cond_init` as `Optional<I1>`
- `LoopOpLowering` treats null `condInit` as i1-true
- runtime `hipdnn_ep_run_counted_loop` accepts any bool

Only the outlining-pass entry was the trip-wire.

Reference test case: Qwen3.5-9B vision encoder has 27 `onnx.Loop` nodes, all with `cond_init=missing`. Without this fix `perf_test` aborts at `LoopOutline::unboxCondInit` (`could not unbox cond_init to i1, got 'none'`) for every Loop in the graph.

## Solution

`lib/Conversion/OnnxToHip/LoopOutline.cpp` (~17 lines, no API change):

- Detect `condInitIsNone = isa<NoneType>(condInitTensor.getType())` after the operand binding step
- When cond_init is none, synthesize `arith.constant true : i1` for the hip.loop op's `cond_init` operand and force `cond_is_passthrough` so `LoopOpLowering` picks the fast `hipdnn_ep_run_counted_loop` path (no per-iter cond readback). Matches ONNX spec semantics: missing cond means cond_out is ignored and only `max_trip_count` terminates the loop
- Update file-header `Limitations` comment: missing-cond is now supported; missing-M (while-style) remains unsupported and continues to reject with a clean diagnostic
- LoopOutline call site uses `condI1Val` (new local) instead of `*condI1` so both branches share the downstream `LoopOp::create` call

`test/lit/Conversion/onnx-to-hip/test_loop_outline.mlir`: new Test 4 covering `cond_init=onnx.NoValue`: outlines into hip.loop with cond synthesized to `arith.constant true`, `cond_is_passthrough` UnitAttr set, body func skips the cond return slot. Added in-place to the existing 3-test fixture (i1 / ui8 / dynamic-cond) following the file's per-variant convention.

## Verification

- Full repo LIT: 203/203 PASS, including `test_loop_outline.mlir` 4 sub-tests + `test_loop_outline_invalid.mlir` + `hip-to-llvm/test_loop.mlir` (HipToLLVM Loop lowering)
- Local perf_test on Qwen3.5-9B `vision.onnx` (875 MB, 27 Loop, full dynamic-shape pipeline): the `could not unbox cond_init to i1` error is confirmed gone for all 27 Loop nodes. The next failure layer is unrelated (importer `value_info` fallback on Loop result types; tracked separately in ROCm/MorphiZen#225) and out of scope here

## Test plan

- [ ] Windows build CI green
- [ ] Linux build CI green
- [ ] gpu-perf-accuracy nightly does not regress on already-supported models (this PR's fix only touches the Loop-bearing path; non-Loop graphs go through the unchanged `else` branch in LoopOutline)
