### PR TITLE
Check THEROCK_DIST before downloading

### DIFF
--- a/build.py
+++ b/build.py
@@ -179,13 +179,13 @@ def _read_ci_env(*keys):
 def fetch_therock():
     # set THEROCK if the env var THEROCK_DIST is valid
     log("Looking for TheRock ROCm SDK via THEROCK_DIST ...")
-    custom_therock = os.environ.get('THEROCK_DIST')
+    custom_therock = os.environ.get("THEROCK_DIST")
     if custom_therock:
         therock_path = Path(custom_therock)
         if not therock_path.exists():
             log(f"  ERROR: THEROCK_DIST points to non-existent path: {therock_path}")
             sys.exit(1)
-        THEROCK=therock_path
+        THEROCK = therock_path
         log(f"  Using custom TheRock from THEROCK_DIST: {THEROCK}")
         return
 

--- a/build.py
+++ b/build.py
@@ -177,6 +177,18 @@ def _read_ci_env(*keys):
 
 
 def fetch_therock():
+    # set THEROCK if the env var THEROCK_DIST is valid
+    log("Looking for TheRock ROCm SDK via THEROCK_DIST ...")
+    custom_therock = os.environ.get('THEROCK_DIST')
+    if custom_therock:
+        therock_path = Path(custom_therock)
+        if not therock_path.exists():
+            log(f"  ERROR: THEROCK_DIST points to non-existent path: {therock_path}")
+            sys.exit(1)
+        THEROCK=therock_path
+        log(f"  Using custom TheRock from THEROCK_DIST: {THEROCK}")
+        return
+
     log("Setting up TheRock ROCm SDK ...")
     sentinel = THEROCK / ".ok"
     if sentinel.exists():


### PR DESCRIPTION
<!--
Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
Licensed under the MIT License.
-->

<!--
Thanks for contributing! Please skim the two policies this repo
follows before requesting review (1-2 minutes each):

  Incremental development:
    https://llvm.org/docs/DeveloperPolicy.html#incremental-development
  AI tool use:
    https://llvm.org/docs/AIToolPolicy.html

A short summary lives in CONTRIBUTING.md at the repo root. Each
section below has an HTML comment explaining what to put in it; you
can delete the comment after filling the section in.
-->

## Summary

Check THEROCK_DIST in fetch_therock(), before downloading TheRock.

THEROCK_DIST is a documented env var, not something added by this PR.

## Why

Currently, build.py will download its own copy of TheRock.  But, TheRock is shared by other modules.  In order for build.py to build binaries that are compatible with other modules that also build with TheRock, build.py should use the same folder. 

The env var THEROCK_DIST is used to point to the copy of the ROCm SDK for all modules to build with.  Make build.py use that env var.

## What

In fetch_therock(), first check for THEROCK_DIST.  If it is valid, assign it to the global variable THEROCK and return.  

## Test plan

- Run build.py without THEROCK_DIST being set.  Check that it behaves as before.  (downloads install/therock)
- Run build.py again without THEROCK_DIST being set.  Check that it does not download the folder again.
- Point THEROCK_DIST to a different ROCm SDK folder, run build.py.  Check the build log that it is using that folder.
- Point THEROCK_DIST to an invalid folder, run build.py.  Check that the build fails.

## Notes for reviewers

- Currently, build.py downloads the gfx1151 version of TheRock by default, so gfx1150 machines can build, but not run tests.  


## Checklist

- [X ] **Standalone.** This PR is standalone. See:
      https://llvm.org/docs/DeveloperPolicy.html#incremental-development
- [X] **AI policy.** AI tools generated some code (for a different PR, which was not accepted). See:
      https://llvm.org/docs/AIToolPolicy.html
- [X] **No `good first issue` automation.** This PR is not an AI-tool
      fix to an issue tagged `good first issue` (those are reserved as
      learning opportunities for new contributors).
- [X] **Reviews resolved.** All review-comment threads from prior
      rounds are resolved (enforced by branch protection on `main`).  
- [X] **CODEOWNERS routing.** Reviewers were assigned automatically by
      [`CODEOWNERS`](../blob/main/.github/CODEOWNERS). If the change
      touches a path outside the current ownership map, the PR
      description names the operational owner.
