### PR TITLE
feat: gate WMMA GEMM dispatch behind env

### DIFF
--- a/lib/Runtime/Kernels/hip/gemm_wmma_kernel.hip
+++ b/lib/Runtime/Kernels/hip/gemm_wmma_kernel.hip
@@ -51,7 +51,12 @@ static constexpr int kWmmaTile = 16;  // RDNA 3 WMMA tile dimension (16x16x16)
 //   TransB == true  : B is [N, K] row-major  (ONNX Gemm transB=1, i.e. nn.Linear
 //                     weight). For a fixed output column the K elements are then
 //                     contiguous, so the B fragment can be vector-loaded too.
-template<int KX, int KY, bool TransB>
+// FullTile == true is launched only when M is a multiple of KX*16 and N is a
+// multiple of KY*16, so every (row, col) this wave touches is in-bounds. That
+// lets the compiler drop all per-element edge checks on the load and store
+// paths, producing branch-free vector loads/stores. FullTile == false keeps the
+// guarded path for remainder tiles.
+template<int KX, int KY, bool TransB, bool FullTile>
 __global__ void __launch_bounds__(32)
 gemm_wmma_fp16_kernel(
     const _Float16* __restrict__ A,
@@ -81,7 +86,7 @@ gemm_wmma_fp16_kernel(
         #pragma unroll
         for (int x = 0; x < KX; ++x) {
             int row = m_base + x * kWmmaTile + lane;
-            if (row < M) {
+            if (FullTile || row < M) {
                 a_frag[x] = *reinterpret_cast<const half16*>(&A[row * K + k]);
             } else {
                 #pragma unroll
@@ -99,7 +104,7 @@ gemm_wmma_fp16_kernel(
             #pragma unroll
             for (int y = 0; y < KY; ++y) {
                 int col = n_base + y * kWmmaTile + lane;
-                if (col < N) {
+                if (FullTile || col < N) {
                     b_frag[y] = *reinterpret_cast<const half16*>(&B[col * K + k]);
                 } else {
                     #pragma unroll
@@ -116,8 +121,8 @@ gemm_wmma_fp16_kernel(
                 #pragma unroll
                 for (int y = 0; y < KY; ++y) {
                     int col = n_base + y * kWmmaTile + lane;
-                    b_frag[y][ele] = (col < N) ? B[(k + ele) * N + col]
-                                               : (_Float16)0;
+                    b_frag[y][ele] = (FullTile || col < N) ? B[(k + ele) * N + col]
+                                                           : (_Float16)0;
                 }
             }
         }
@@ -135,13 +140,130 @@ gemm_wmma_fp16_kernel(
         int c = n_base + y * kWmmaTile + lane;
         // bias is broadcast along M (one value per output column). Load it once
         // per column here; bv is 0 when no bias so the add below is unconditional.
-        float bv = (bias && c < N) ? (float)bias[c] : 0.0f;
+        float bv = (bias && (FullTile || c < N)) ? (float)bias[c] : 0.0f;
         #pragma unroll
         for (int x = 0; x < KX; ++x) {
             #pragma unroll
             for (int ele = 0; ele < 8; ++ele) {
                 int r = m_base + x * kWmmaTile + ele * 2 + pair;
-                if (r < M && c < N)
+                if (FullTile || (r < M && c < N))
+                    C[r * N + c] = (_Float16)(c_frag[y][x][ele] + bv);
+            }
+        }
+    }
+}
+
+//===----------------------------------------------------------------------===//
+// LDS-staged multi-wave variant (transB == 1 only)
+//===----------------------------------------------------------------------===//
+//
+// The single-wave kernel above re-reads the same A row-panel from global memory
+// once per N-tile and the same B col-panel once per M-tile, so a large GEMM
+// streams A and B from global many times. This variant groups WAVES_M x WAVES_N
+// waves into one block that cooperatively stages a single A panel [BM x 16] and
+// B panel [BN x 16] into LDS each k-step; every wave then reads its WMMA
+// fragments from LDS instead of global. Each k-panel is therefore fetched from
+// global exactly once per block instead of once per wave-tile.
+//
+// Numerics are bit-identical to the single-wave kernel: the per-wave a_frag /
+// b_frag index derivation and the WMMA accumulation order are unchanged; only
+// the *source* of the fragments (LDS vs global) differs. Restricted to
+// transB == 1 (B is [N,K], the nn.Linear weight layout) so the B panel is
+// contiguous along K and vector-loadable.
+//
+//   BM = WAVES_M * KX * 16   (block tile rows)
+//   BN = WAVES_N * KY * 16   (block tile cols)
+template <int KX, int KY, int WAVES_M, int WAVES_N, bool FullTile>
+__global__ void __launch_bounds__(WAVES_M* WAVES_N * 32)
+gemm_wmma_fp16_kernel_lds(
+    const _Float16* __restrict__ A,
+    const _Float16* __restrict__ B,
+    _Float16* __restrict__ C,
+    const _Float16* __restrict__ bias,
+    int M, int K, int N)
+{
+    constexpr int TPB = WAVES_M * WAVES_N * 32;
+    constexpr int BM = WAVES_M * KX * kWmmaTile;
+    constexpr int BN = WAVES_N * KY * kWmmaTile;
+
+    __shared__ _Float16 As[BM][kWmmaTile];
+    __shared__ _Float16 Bs[BN][kWmmaTile];
+
+    const int tid = threadIdx.x;
+    const int wid = tid / 32;          // wave index within block
+    const int lane = (tid % 32) % kWmmaTile;
+    const int pair = (tid % 32) / kWmmaTile;
+    const int wave_m = wid / WAVES_N;
+    const int wave_n = wid % WAVES_N;
+
+    const int m_block = blockIdx.y * BM;
+    const int n_block = blockIdx.x * BN;
+    const int m_base = m_block + wave_m * KX * kWmmaTile;
+    const int n_base = n_block + wave_n * KY * kWmmaTile;
+
+    half16 a_frag[KX];
+    half16 b_frag[KY];
+    float8 c_frag[KY][KX] = {};
+
+    for (int k = 0; k < K; k += kWmmaTile) {
+        // Cooperatively stage the A panel [BM x 16] into LDS.
+        #pragma unroll
+        for (int i = tid; i < BM; i += TPB) {
+            int row = m_block + i;
+            if (FullTile || row < M) {
+                *reinterpret_cast<half16*>(&As[i][0]) =
+                    *reinterpret_cast<const half16*>(&A[row * K + k]);
+            } else {
+                #pragma unroll
+                for (int ele = 0; ele < kWmmaTile; ++ele)
+                    As[i][ele] = (_Float16)0;
+            }
+        }
+        // Cooperatively stage the B panel [BN x 16] into LDS (transB == 1:
+        // B[col, k] is contiguous along K).
+        #pragma unroll
+        for (int i = tid; i < BN; i += TPB) {
+            int col = n_block + i;
+            if (FullTile || col < N) {
+                *reinterpret_cast<half16*>(&Bs[i][0]) =
+                    *reinterpret_cast<const half16*>(&B[col * K + k]);
+            } else {
+                #pragma unroll
+                for (int ele = 0; ele < kWmmaTile; ++ele)
+                    Bs[i][ele] = (_Float16)0;
+            }
+        }
+        __syncthreads();
+
+        #pragma unroll
+        for (int x = 0; x < KX; ++x)
+            a_frag[x] = *reinterpret_cast<const half16*>(
+                &As[wave_m * KX * kWmmaTile + x * kWmmaTile + lane][0]);
+        #pragma unroll
+        for (int y = 0; y < KY; ++y)
+            b_frag[y] = *reinterpret_cast<const half16*>(
+                &Bs[wave_n * KY * kWmmaTile + y * kWmmaTile + lane][0]);
+
+        #pragma unroll
+        for (int y = 0; y < KY; ++y)
+            #pragma unroll
+            for (int x = 0; x < KX; ++x)
+                c_frag[y][x] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(
+                                   a_frag[x], b_frag[y], c_frag[y][x]);
+
+        __syncthreads();  // protect LDS before the next k-panel overwrites it
+    }
+
+    #pragma unroll
+    for (int y = 0; y < KY; ++y) {
+        int c = n_base + y * kWmmaTile + lane;
+        float bv = (bias && (FullTile || c < N)) ? (float)bias[c] : 0.0f;
+        #pragma unroll
+        for (int x = 0; x < KX; ++x) {
+            #pragma unroll
+            for (int ele = 0; ele < 8; ++ele) {
+                int r = m_base + x * kWmmaTile + ele * 2 + pair;
+                if (FullTile || (r < M && c < N))
                     C[r * N + c] = (_Float16)(c_frag[y][x][ele] + bv);
             }
         }
@@ -193,17 +315,35 @@ int hip_gemm_wmma_fp16(void* stream, const void* A, const void* B,
     // ---- Launch ----
     constexpr int KX = 2;
     constexpr int KY = 4;
-    dim3 block(32);
-    dim3 grid((N + KY * kWmmaTile - 1) / (KY * kWmmaTile),
-              (M + KX * kWmmaTile - 1) / (KX * kWmmaTile));
+    auto A16 = (const _Float16*)A;
+    auto B16 = (const _Float16*)B;
+    auto O16 = (_Float16*)output;
+
     if (transB) {
-        gemm_wmma_fp16_kernel<KX, KY, true><<<grid, block, 0, (hipStream_t)stream>>>(
-            (const _Float16*)A, (const _Float16*)B, (_Float16*)output,
-            bias, M, K, N);
+        // transB == 1: use the LDS-staged multi-wave kernel, which cuts
+        // redundant global reads of the A/B panels. Block tile BM x BN with
+        // WAVES_M x WAVES_N waves.
+        constexpr int WAVES_M = 2;
+        constexpr int WAVES_N = 4;
+        constexpr int BM = WAVES_M * KX * kWmmaTile;  // 64
+        constexpr int BN = WAVES_N * KY * kWmmaTile;  // 128
+        dim3 block(WAVES_M * WAVES_N * 32);
+        dim3 grid((N + BN - 1) / BN, (M + BM - 1) / BM);
+        const bool full_tile = (M % BM == 0) && (N % BN == 0);
+        if (full_tile)
+            gemm_wmma_fp16_kernel_lds<KX, KY, WAVES_M, WAVES_N, true><<<grid, block, 0, (hipStream_t)stream>>>(A16, B16, O16, bias, M, K, N);
+        else
+            gemm_wmma_fp16_kernel_lds<KX, KY, WAVES_M, WAVES_N, false><<<grid, block, 0, (hipStream_t)stream>>>(A16, B16, O16, bias, M, K, N);
     } else {
-        gemm_wmma_fp16_kernel<KX, KY, false><<<grid, block, 0, (hipStream_t)stream>>>(
-            (const _Float16*)A, (const _Float16*)B, (_Float16*)output,
-            bias, M, K, N);
+        // transB == 0: keep the single-wave global-load kernel.
+        dim3 block(32);
+        dim3 grid((N + KY * kWmmaTile - 1) / (KY * kWmmaTile),
+                  (M + KX * kWmmaTile - 1) / (KX * kWmmaTile));
+        const bool full_tile = (M % (KX * kWmmaTile) == 0) && (N % (KY * kWmmaTile) == 0);
+        if (full_tile)
+            gemm_wmma_fp16_kernel<KX, KY, false, true><<<grid, block, 0, (hipStream_t)stream>>>(A16, B16, O16, bias, M, K, N);
+        else
+            gemm_wmma_fp16_kernel<KX, KY, false, false><<<grid, block, 0, (hipStream_t)stream>>>(A16, B16, O16, bias, M, K, N);
     }
     return hipGetLastError() == hipSuccess ? 0 : -1;
 }


### PR DESCRIPTION
# feat(wmma): full ONNX Gemm support in WMMA GEMM kernel

## Summary

Extend `hip_gemm_wmma_fp16` from a bare `C = A * B` kernel into a standard ONNX
Gemm entry point:

```
output[M,N] = alpha * op(A) * op(B) + beta * C
```

The kernel now covers the common ONNX Gemm / `nn.Linear` shapes directly on the
RDNA 3+ WMMA path, while transparently falling back to hipBLASLt for any
configuration it does not implement.

## Motivation

The previous WMMA kernel only computed `C = A * B` (no transpose, no bias, no
scaling), so the `wrap_gemm` dispatch had to gate on a very narrow case
(`transA == 0 && transB == 0 && C == nullptr && alpha == 1`). Most real Gemm
nodes — especially `nn.Linear` (which ships its weight as `transB = 1`) and
nodes with a row-broadcast bias — never qualified and always fell through to
hipBLASLt. This change makes the WMMA path applicable to those nodes and lets
all the configuration validation live next to the kernel.

## What changed

### `3rd-party/custom_kernels/hip/gemm_wmma_kernel.hip`
- New template parameter `bool TransB` selecting B layout:
  - `TransB == false`: B is `[K, N]` row-major (ONNX `transB = 0`).
  - `TransB == true`: B is `[N, K]` row-major (ONNX `transB = 1`, `nn.Linear`
    weight) — the K elements of a column are contiguous, so B is vector-loaded.
- Vectorized fragment loads: A is loaded as a single 32-byte `half16` per row
  instead of 16 scalar loads (B too when `TransB == 1`). The `transB == 0` path
  keeps the strided, already-coalesced scalar B load.
- Optional row-broadcast bias (`[N]` / `[1, N]`) folded into the output write.
- Host entry rewritten to the full ONNX Gemm signature and now performs
  capability + alignment validation:
  - returns `> 0` ("not handled, fall back") for unsupported configs,
  - returns `< 0` on launch error,
  - returns `0` when computed by WMMA.
- 32-byte base-pointer alignment guard for the vectorized loads (A always; B
  when `transB == 1`) — a misaligned base falls back instead of faulting.

### `3rd-party/custom_kernels/include/hip_custom_kernels.h`
- Updated the `hip_gemm_wmma_fp16` declaration and documentation to the new
  ONNX Gemm signature and the `> 0 / 0 / < 0` return contract.

### `lib/Runtime/real/gemm.cpp`
- `wrap_gemm` dispatch relaxed to gate only on `fp16 && K % 16 == 0 && N % 16 == 0`;
  all remaining ONNX Gemm attributes (transA / transB / alpha / beta / shape of
  C) are validated inside the kernel host function.
- `rc > 0` now falls through to hipBLASLt silently; `rc < 0` logs a launch error
  before falling back.

## Supported configurations (WMMA path)

| Attribute | Supported |
|-----------|-----------|
| dtype     | fp16 |
| `K`, `N`  | multiples of 16 |
| `transA`  | `0` only |
| `transB`  | `0` (B `[K,N]`) or `1` (B `[N,K]`) |
| `alpha`   | `1.0` |
| `beta`    | `1.0` |
| `C`       | absent, or row-broadcast bias `[N]` / `[1,N]` (`cDim0 == 1 && cDim1 == N`) |
| base ptr  | A 32-byte aligned (and B when `transB == 1`) |

Anything outside this set returns a positive code and `wrap_gemm` falls back to
hipBLASLt — behavior is always correct, only the fast path is conditional.

## Enabling / verifying
## HIPDNN_EP_GEMM_WMMA=1
- The WMMA path is opt-in via `HIPDNN_EP_GEMM_WMMA=1` (default: hipBLASLt).
- With `HIPDNN_EP_DEBUG=1`, a dispatched call logs
  `[REAL] wrap_gemm: dispatch=WMMA ...`.
- This is a custom-kernel change: after rebuilding, delete stale compiled model
  DLLs (`del %TEMP%\morphizen_mlir_*`) so the new bitcode is picked up.
- Validate correctness on the gfx1151 host (numeric tests), especially the
  `transB = 1` weight path that exercises the vectorized B load.


## Qwen3.5-9B-rtn-int4-int8-128gs-fp16-onnx-gpu_space\vision\single_op

Test models live under this path. The 6 Gemm folders exercised here:
`Gemm_linear`, `Gemm_linear_1`, `Gemm_linear_2`, `Gemm_linear_3`,
`Gemm_linear_108`, `Gemm_linear_109` (each with a `*_np1024.onnx` variant used
below). All are fp16, `transA=0`, `transB=1`, `alpha=beta=1`, with an `[N]` bias.

## Performance — np1024 variants (real workload, M = 1024/256)

WMMA=1 (this change) vs WMMA=0 (hipBLASLt). Throughput in inferences/sec
(higher is better), `-t 60 -c 1 -s`, fp16, all `transB=1` + `[N]` bias.
dynamic 
| Model (M×K×N) | hipBLASLt (WMMA=0) | WMMA=1 | Speedup |
|---|---|---|---|
Gemm_linear | 57.33 | 64.30 | +12.2%
Gemm_linear_1 | 57.56 | 62.03 | +7.8%
Gemm_linear_2 | 57.68 | 67.23 | +16.6%
Gemm_linear_3 | 56.22 | 62.60 | +11.3%
Gemm_linear_108 | 56.54 | 61.94 | +9.6%
Gemm_linear_109 | 61.53 | 61.95 | +0.7%


## Files

```
3rd-party/custom_kernels/hip/gemm_wmma_kernel.hip  | 136 +++++++++++++++---
3rd-party/custom_kernels/include/hip_custom_kernels.h |  45 ++++--
lib/Runtime/real/gemm.cpp                          |  38 +++---
3 files changed, 178 insertions(+), 41 deletions(-)
```
## Qwen3.5-9B Result

Model | Case | Performance |   |   |   |   |   |   | Accuracy |  
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
  |   | TTFT (s) |   | TPS |   | CPU Peak Memory (GB) | GPU Peak Memory (GB) | PPL |  
  |   | Baseline | Current | Baseline | Current | Baseline | Current | Baseline | Current | Baseline | Current
Qwen3.5-9B-fp16-ve-fp16-int4-text-gs32-dml | Prompt 2048 / Output 64 / genai_config_MorphiZenEP | 8.7115 | 8.8331(1.4%) | 26.92 | 26.59(-1.22%) | - | - | 18.6104 | 18.5544(-0.3%) |  



http://xsjnts.xilinx.com/ROCm/compare?baseline_job_name=daily_hipdnn_ep_oga&baseline_build_id=&your_job_name=daily_hipdnn_ep_oga&your_build_id=&base_url=http%3A%2F%2Fxsjnts.xilinx.com%2FROCm%2Fhipdnn-detail%3Fdatabase%3Ddevelopment%26collection%3Ddaily_hipdnn_ep_oga%26id%3D6a336aa3f427aacfec05a8cf&curr_url=http%3A%2F%2Fxsjnts.xilinx.com%2FROCm%2Fhipdnn-detail%3Fdatabase%3Ddevelopment%26collection%3Ddaily_hipdnn_ep_oga%26id%3D6a33b7ee6f8fae877a9b2eea

## Qwen3.5-35B Result



Model | Case | Performance |   |   |   |   |   |   | Accuracy
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
  |   | TTFT (s) |   | TPS |   | CPU Peak Memory (GB) | GPU Peak Memory (GB) | PPL
  |   | Baseline | Current | Baseline | Current | Baseline | Current | Baseline | Current | Baseline
Qwen3.5-35B-A3B-fp16-ve-fp16-int4-text-gs32-dml | Prompt 19 / Output 128 / genai_config_AMDGPU | 10.0933 | 10.0486(-0.44%) | 36.31 | 36.04(-0.74%) | 3.2668 | 3.2471(-0.6%) | 33.268 | 33.2083(-0.18%)
Qwen3.5-35B-A3B-fp16-ve-fp16-int4-text-gs32-dml | Prompt 128 / Output 128 / genai_config_AMDGPU | 10.4652 | 10.5123(0.45%) | 35.72 | 34.57(-3.23%) | 3.444 | 3.424(-0.58%) | 33.6613 | 33.6026(-0.17%)
Qwen3.5-35B-A3B-fp16-ve-fp16-int4-text-gs32-dml | Prompt 1400 / Output 128 / genai_config_AMDGPU | 17.7001 | 17.9126(1.2%) | 35.36 | 35.02(-0.97%) | 6.2434 | 6.1726(-1.13%) | 38.1267 | 38.0632(-0.17%)
Qwen3.5-35B-A3B-fp16-ve-fp16-int4-text-gs32-dml | Prompt 2048 / Output 128 / genai_config_AMDGPU | 21.5875 | 20.2741(-6.08%) | 33.46 | 35.1(4.92%) | 8.2449 | 8.184(-0.74%) | 40.144 | 40.0849(-0.15%)



http://xsjnts.xilinx.com/ROCm/compare?base_url=http%3A%2F%2Fxsjnts.xilinx.com%2FROCm%2Fhipdnn-detail%3Fdatabase%3Ddevelopment%26collection%3Ddaily_hipdnn_ep_oga%26id%3D6a3416a96f8fae877a9b3260&base_job=&base=&curr_url=http%3A%2F%2Fxsjnts.xilinx.com%2FROCm%2Fhipdnn-detail%3Fdatabase%3Ddevelopment%26collection%3Ddaily_hipdnn_ep_oga%26id%3D6a341be46f8fae877a9b326d&curr_job=&curr=