### PR TITLE
Revert "Check THEROCK_DIST before downloading (#255)"

### DIFF
--- a/build.py
+++ b/build.py
@@ -177,18 +177,6 @@ def _read_ci_env(*keys):
 
 
 def fetch_therock():
-    # set THEROCK if the env var THEROCK_DIST is valid
-    log("Looking for TheRock ROCm SDK via THEROCK_DIST ...")
-    custom_therock = os.environ.get("THEROCK_DIST")
-    if custom_therock:
-        therock_path = Path(custom_therock)
-        if not therock_path.exists():
-            log(f"  ERROR: THEROCK_DIST points to non-existent path: {therock_path}")
-            sys.exit(1)
-        THEROCK = therock_path
-        log(f"  Using custom TheRock from THEROCK_DIST: {THEROCK}")
-        return
-
     log("Setting up TheRock ROCm SDK ...")
     sentinel = THEROCK / ".ok"
     if sentinel.exists():


### PR DESCRIPTION
This reverts commit 3b0933d4d415aa79058f6be56a26a3fa08bc9d5f.
PR 255 https://github.com/ROCm/onnx-hipdnn-ep/pull/255

A bit of code was added after testing for the absence of THEROCK_DIST, which actually broke build.py in that case.  (python skills lacking)

(So the situation is back to where build.py will download its own copy of gfx1151 TheRock and build with that.  To build with gfx1150, it is necessary to 

1) replace the downloaded "install/therock" with a copy of the gfx1150 therock
2) create a file ".ok" in the copied-in "install/therock" (else build.py will remove it and download gfx1151 again).