### PR TITLE
feat(hip): shape inference infrastructure for HIP DPS ops (verifier + reify + propagation pass) -- 1/n

### DIFF
--- a/docs/design/hip-shape-inference.md
+++ b/docs/design/hip-shape-inference.md
@@ -161,11 +161,12 @@ Two related MLIR passes already exist:
   producer to keep the type chain well-formed).
 
 `--hip-infer-shapes` extends the same module-walk pattern with the
-DPS-aware producer refinement: when the outs operand is a `tensor.empty`,
-the pass rebuilds it with the new static shape and drops any dyn-dim
-operands that became static. Producers we don't know how to refine
-today (function args, other DPS ops higher in the chain) are skipped —
-the pass then leaves that result index at `?`.
+DPS-aware producer refinement: when the outs operand is a single-use
+`tensor.empty`, the pass rebuilds it with the new static shape and
+drops any dyn-dim operands that became static. Shared empties (more
+than one use) and producers we don't know how to refine today
+(function args, other DPS ops higher in the chain) are skipped — the
+pass then leaves that result index at `?`.
 
 The pass restricts itself to **HIP-dialect ops**. Non-HIP-dialect ops
 that also implement the reify interface (`tensor::EmptyOp`,

--- a/docs/design/hip-shape-inference.md
+++ b/docs/design/hip-shape-inference.md
@@ -11,14 +11,17 @@ machinery.
 
 ## Goals
 
-1. **Static verification.** Every HIP DPS op verifies that its `outs`
-   operand types are compatible with the shapes that fall out of the op
-   contract (matmul: `[..., M, K] @ [..., K, N] -> [..., M, N]`;
-   elementwise: NumPy broadcast over the inputs; etc).
+1. **Result types tracked through the converter.** Every HIP DPS op
+   declares `InferTypeOpInterface` so the converter can construct ops
+   without restating the result type at every callsite — the
+   auto-generated `Op::create` overload reads the result type(s) from
+   the `outs` operand types via `appendDpsResultIfTensor`. This keeps
+   the DPS contract `result_type == outs_operand_type` closed by
+   construction.
 2. **Reify dynamic dims.** When a result dim is `?` (`kDynamic`) at the
    type level but is computable in terms of operand dims, the op exposes
    that knowledge through upstream
-   `ReifyRankedShapedTypeOpInterface::reifyResultShapes`.  Downstream
+   `ReifyRankedShapedTypeOpInterface::reifyResultShapes`. Downstream
    `--resolve-shaped-type-result-dims` then folds `tensor.dim` of the
    result into either an `arith.constant` (static dims) or a
    `tensor.dim` of the relevant input (dynamic dims).
@@ -26,46 +29,75 @@ machinery.
    module, calls `reifyResultShapes` on every HIP-dialect op carrying
    the interface, and refines `?` dims in result types in place —
    including the DPS `outs` operand's `tensor.empty` producer, which is
-   necessary to keep the IR well-formed (DPS contract:
-   `result_type == outs_operand_type`). Wired into the production
+   necessary to keep the IR well-formed. Wired into the production
    pipeline immediately after `convert-onnx-to-hip` (see
    [Pipeline placement](#pipeline-placement)).
+4. **Static verification where it pays rent.** Ops with a non-trivial
+   static shape contract (canonical: `hip.matmul`'s
+   `[..., M, K] @ [..., K, N] -> [..., M, N]`) carry `let hasVerifier = 1`
+   and a per-op `verify()` driving the same shape helper used by Reify.
+   The default for new DPS ops is no verifier — the InferType-driven
+   `outs` typing already closes the DPS contract, and a Reify impl that
+   returns the wrong shape is caught by LIT cases under
+   `--hip-infer-shapes`.
 
-These three layers share **one** static shape function per op
-(`inferMatmulShape`, future `inferBroadcastShape`, ...). The verifier
-checks the result against the helper; reify lifts the helper's output
-into `OpFoldResult`s; the pass aggregates reify across the module.
+`hip.matmul` is the worked example that exercises all four layers.
+Other ops compose the layers from a small helper menu chosen by shape
+contract — `reifyElementwiseSameShape` (default), `reifyBroadcastShape`
+(NumPy broadcast), dedicated helpers for permutation / reduction /
+gather, fold-or-bail Tier-1 helpers for shape-arithmetic ops
+(`reifyPadShape` etc.), and the generic `reifyResultsFromDpsInits` for
+multi-result outs-lifting. See [How to add a new op](#how-to-add-a-new-op)
+for the table.
 
 ## Design rationale
 
-### Why `ReifyRankedShapedTypeOpInterface` and not a custom interface?
+### Why `InferTypeOpInterface` + `ReifyRankedShapedTypeOpInterface`?
 
 Upstream MLIR has three relevant interfaces:
 
-| Interface | Static shape | Dynamic shape | Used by |
+| Interface | Static shape | Dynamic shape | We use? |
 |---|---|---|---|
-| `InferTypeOpInterface` | yes (`inferReturnTypes`) | no | Type inference at op build time |
-| `InferShapedTypeOpInterface` | yes (`inferReturnTypeComponents`) | partial | Some ops (e.g. mhlo) |
-| `ReifyRankedShapedTypeOpInterface` | implicit (IntegerAttr) | yes (Value) | linalg, tensor::Pad, tensor::Concat |
+| `InferTypeOpInterface` | yes (`inferReturnTypes`) | no | **YES** |
+| `InferShapedTypeOpInterface` | yes (`inferReturnTypeComponents`) | partial | no |
+| `ReifyRankedShapedTypeOpInterface` | implicit (IntegerAttr) | yes (Value) | **YES** |
 
 For DPS ops the result type is **tautologically tied** to the `outs`
-operand type — you can't "infer" the result type from the inputs because
-the result type IS the outs type. `InferTypeOpInterface` is therefore
-not a fit: there's nothing for it to infer.
+operand type — the result type IS the outs type, so an interface has
+nothing to "infer" from the inputs in the classical sense. The job
+`InferTypeOpInterface` does for us is different and concrete: the
+**converter** still has to construct each op, and on the legacy
+`Op::create` builder path every callsite has to spell out the result
+type list explicitly even though it is just the (already typed)
+`outs` operand type echoed back. `inferReturnTypes` moves that
+boilerplate into the op once — the auto-generated `Op::create`
+overload reads the outs operand types from the operation state and
+produces the result types via `appendDpsResultIfTensor`. Every
+`OnnxToHip*Conversion.cpp` callsite then drops its explicit type
+list and relies on the inference. Memref-mode ops produce zero result
+types — the destination operand carries the writes via its memref
+descriptor and the SSA result list is empty.
 
-`ReifyRankedShapedTypeOpInterface` neatly steps around this: it lets the
-op describe its result *shape* (per-dim `OpFoldResult`) without trying to
-synthesise a result *type*. Static dims fall out as `IntegerAttr`,
-dynamic dims fall out as `tensor.dim` (or `memref.dim`) of the operand
-they depend on. Linalg's named ops use exactly this pattern; we reuse
-both the interface and the LLVM-project test pass that drives it
-(`--resolve-shaped-type-result-dims`) so our infrastructure does not
-fork.
+`ReifyRankedShapedTypeOpInterface` covers the orthogonal *dynamic-shape*
+job: per-dim `OpFoldResult`s for `--hip-infer-shapes` and the upstream
+test pass `--resolve-shaped-type-result-dims`. Static dims fall out as
+`IntegerAttr`, dynamic dims fall out as `tensor.dim` (or `memref.dim`)
+of the operand they depend on. Linalg's named ops use exactly this
+pattern; we reuse both the interface and the LLVM-project test pass so
+our infrastructure does not fork.
+
+The two interfaces compose cleanly with no overlap: InferType makes
+converters terse at op-construction time, Reify makes refinement work
+at module-walk time (`--hip-infer-shapes` calls reify, narrows result
+types in place, rebuilds outs producers). Verifier checks slot in on
+top — for ops with a non-trivial shape contract — sharing the same
+static shape helper (`inferMatmulShape`) that Reify lifts into
+`OpFoldResult`s.
 
 An earlier draft added a custom `HipShapeInferenceOpInterface` with an
 `inferOutputShape(...) -> SmallVector<int64_t>` static method. Dropped:
-the upstream interface and the static helper already cover both jobs
-(static check, dynamic reify), doubling up adds maintenance with no
+the two upstream interfaces above already cover both jobs (static type
+inference, dynamic dim reify), doubling up adds maintenance with no
 payoff, and the upstream test-pass machinery is the test surface for
 free.
 
@@ -159,16 +191,31 @@ substituting it into `Pipelines.cpp` and re-running the LIT suite.
 ```text
 include/hip/Dialect/IR/
   HipShapeUtils.h          -- public API: inferMatmulShape,
-                              verifyHipOpShape, reifyDimOrConstant
+                              verifyHipOpShape, appendDpsResultIfTensor,
+                              reifyDimOrConstant, reifyElementwiseSameShape,
+                              reifyBroadcastShape, reifyResultsFromDpsInits,
+                              and per-shape Tier-1 helpers (reifyPadShape,
+                              reifyTileShape, reifySliceShape,
+                              reifyExpandShape, reifyRangeShape,
+                              reifyTransposeByPerm, reifyGatherWithAxis,
+                              reifyGatherND, reifyReductionWithKeepdims)
   HipOps.td                -- per-op declares
-                              `DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>`
-                              and `let hasVerifier = 1`
+                              `DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>`
+                              and `DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>`;
+                              `let hasVerifier = 1` only when the op has a
+                              non-trivial shape contract (matmul today)
 
 lib/Dialect/IR/
   HipShapeUtils.cpp                -- implementations + diagnostics
-  HipDialect.cpp                   -- per-op `verify()`, `getEffects()`,
-                                      `getDpsInitsMutable()`, custom
-                                      builders / printers / parsers
+  HipDialect.cpp                   -- per-op `verify()` (matmul only as of
+                                      #264, plus `LoopOp::verify()`),
+                                      `getEffects()`, `getDpsInitsMutable()`,
+                                      custom builders / printers / parsers;
+                                      `LoopOp::inferReturnTypes` lives here
+                                      next to its peers (control-flow op,
+                                      not a DPS compute op)
+  HipResultTypeInferenceImpl.cpp   -- per-op `inferReturnTypes()`,
+                                      one `// <OpName>` section per op
   HipReifyResultShapesImpl.cpp     -- per-op `reifyResultShapes()`,
                                       one `// <OpName>` section per op
 
@@ -179,24 +226,32 @@ lib/Dialect/Transforms/
   InferShapesPass.cpp      -- module-level walk; DPS-aware refinement
 
 test/lit/Dialect/
-  hip-matmul-shape-verifier.mlir   -- verifier positive + negative
+  hip-matmul-shape-verifier.mlir   -- matmul shape-contract verifier
+                                       positive + negative cases
   hip-matmul-reify-shapes.mlir     -- driven by upstream
                                        `--resolve-shaped-type-result-dims`
-  hip-infer-shapes.mlir            -- propagation pass behaviour
+  hip-loop-verifier.mlir           -- `hip.loop` v_init / result type
+                                       contract (added by #261)
+  hip-infer-shapes.mlir            -- consolidated `--hip-infer-shapes`
+                                       LIT, one section per op rolled out
+                                       across #260 - #264
 ```
 
 ### Why the per-interface split
 
-`reifyResultShapes` lives in its own translation unit because it grows
-on a different schedule from the rest of an op's machinery. Verifiers,
-`getEffects`, `getDpsInitsMutable`, and op-local builders touch the op
-once and rarely need maintenance after that. Reify implementations are
+`reifyResultShapes` and `inferReturnTypes` each live in their own
+translation unit because they grow on a different schedule from the
+rest of an op's machinery. Verifiers, `getEffects`,
+`getDpsInitsMutable`, and op-local builders touch the op once and
+rarely need maintenance after that. Reify implementations are
 non-trivial shape arithmetic that benefits from being read alongside
 each other (every dynamic-shape op solves a small variant of the same
-"lift static dims to `IntegerAttr`, dynamic dims to `tensor.dim` of the
-right operand" problem). Keeping them together — and out of the
-already-large `HipDialect.cpp` — makes both files easier to navigate as
-the dialect picks up shape-inference support for more ops.
+"lift static dims to `IntegerAttr`, dynamic dims to `tensor.dim` of
+the right operand" problem). InferType implementations are typically
+mechanical (`appendDpsResultIfTensor` chained over outs operands) but
+multiply across every DPS op — keeping them together makes the "every
+op uniformly delegates to the same helper" pattern obvious. Both files
+follow the same one-`// <OpName>`-section-per-op convention.
 
 This mirrors IREE's LinalgExt convention (`LinalgExtOps.cpp` keeps
 verifiers / builders; `TilingInterfaceImpl.cpp` and
@@ -245,48 +300,115 @@ any change to `Pipelines.cpp`.
 
 ## How to add a new op
 
-A new HIP op participates in shape inference in **five** small edits,
-spread across the three files identified in the layout above. The
-matmul wiring is the canonical reference; the same pattern applies to
-every DPS compute op.
+A new HIP DPS op participates in shape inference in **four** small
+edits (TableGen + InferType + Reify + LIT), plus an **optional**
+verifier when the op has a non-trivial static shape contract. The
+matmul wiring is the canonical full-stack reference; for the rest of
+the dialect the InferType + Reify path (no verifier) is the realized
+pattern across #262 - #264.
 
-### 1. Add a shape helper (or reuse one)
+**Stack rollout context.** Infrastructure lands in #260 with `hip.matmul`
+as the worked example. #261 adds `InferTypeOpInterface` to `hip.loop`.
+#262 - #264 roll out the InferType + Reify pattern across 51 more DPS
+ops, picking from a small menu of reify helpers chosen by op shape
+contract — see step 3.
 
-In [HipShapeUtils.h](../../include/hip/Dialect/IR/HipShapeUtils.h), add a free
-function that takes the operand shapes (and any op-specific attrs) and
-returns the expected output shape vector. Use `ShapedType::kDynamic` for
-dims that the helper cannot compute, and emit a diagnostic via the
-supplied `emitError` callable on shape mismatch.
-
-```cpp
-// HipShapeUtils.h
-SmallVector<int64_t> inferBroadcastShape(
-    ArrayRef<int64_t> aShape, ArrayRef<int64_t> bShape,
-    function_ref<InFlightDiagnostic()> emitError);
-```
-
-If your op fits an existing helper (e.g. another matmul-shaped op, or
-another op with the same broadcast rules), just reuse it.
-
-### 2. Declare the interface in TableGen
+### 1. Declare the two interfaces in TableGen
 
 In [HipOps.td](../../include/hip/Dialect/IR/HipOps.td):
 
 ```tablegen
 def Hip_MyOp : Hip_DpsOp<"my_op", [
+    DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>,
     DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>
   ]> {
   // ... arguments, assemblyFormat ...
-  let hasVerifier = 1;
 }
 ```
 
 `Hip_DpsOp` already declares `DestinationStyleOpInterface` and emits the
-`Variadic<AnyRankedTensor>:$result_tensors` result for tensor mode.
+`Variadic<AnyRankedTensor>:$result_tensors` result for tensor mode. Add
+`let hasVerifier = 1;` only if the op has a non-trivial static shape
+contract worth verifying (matmul-style; default for new ops is no
+verifier — see step 5).
 
-### 3. Implement `verify()` in `HipDialect.cpp`
+### 2. Implement `inferReturnTypes()` in `HipResultTypeInferenceImpl.cpp`
 
-In [HipDialect.cpp](../../lib/Dialect/IR/HipDialect.cpp), under the
+Add a `// MyOp` section banner at the bottom of
+[HipResultTypeInferenceImpl.cpp](../../lib/Dialect/IR/HipResultTypeInferenceImpl.cpp).
+Single-result ops are typically a one-liner over the outs operand:
+
+```cpp
+LogicalResult MyOp::inferReturnTypes(
+    MLIRContext *ctx, std::optional<Location> loc, MyOp::Adaptor adaptor,
+    SmallVectorImpl<Type> &inferredReturnTypes) {
+  appendDpsResultIfTensor(adaptor.getOutput(), inferredReturnTypes);
+  return success();
+}
+```
+
+For multi-result ops, chain `appendDpsResultIfTensor` per outs operand;
+when the op carries `AttrSizedOperandSegments` and you would otherwise
+duplicate the chain, delegate to the generic helper used by
+`hip.gqa` / `hip.layer_norm` / `hip.multi_head_attention`:
+
+```cpp
+return reifyResultsFromDpsInits(*this, b, reifiedReturnShapes);
+```
+
+Memref-mode ops produce zero result types — `appendDpsResultIfTensor`
+is a no-op when the operand is a memref, so the same impl works for
+both modes.
+
+### 3. Implement `reifyResultShapes()` in `HipReifyResultShapesImpl.cpp`
+
+Add a `// MyOp` section banner at the bottom of
+[HipReifyResultShapesImpl.cpp](../../lib/Dialect/IR/HipReifyResultShapesImpl.cpp).
+Pick the reify helper that matches the op's shape contract:
+
+| Op shape contract | Helper |
+|---|---|
+| Result shape == operand shape (silu, sigmoid, cast, ...) | `reifyElementwiseSameShape` |
+| NumPy broadcast (add, mul, where, ...) | `reifyBroadcastShape` |
+| Permutation (`hip.transpose`) | `reifyTransposeByPerm` |
+| Reduction with `keepdims` (reduce_sum, reduce_max, ...) | `reifyReductionWithKeepdims` |
+| Gather along an axis (`hip.gather`, `hip.gather_nd`) | `reifyGatherWithAxis` / `reifyGatherND` |
+| Multi-result outs-lifting (gqa, attention, layer_norm, ...) | `reifyResultsFromDpsInits` (mirrors IREE's `LinalgExtOp::reifyResultShapes` default) |
+| Fold-or-bail shape arithmetic (pad, tile, slice, expand, range) | one of `reifyPadShape` / `reifyTileShape` / `reifySliceShape` / `reifyExpandShape` / `reifyRangeShape` (return `failure()` on non-foldable; the thunk falls through to outs-lifting) |
+| Matmul-shaped (`[..., M, K] @ [..., K, N] -> [..., M, N]`) | call `inferMatmulShape` to compute output extents, then `reifyDimOrConstant` per dim |
+
+If your op's contract is not in the table, write a new helper in
+`HipShapeUtils.{h,cpp}` and add a row.
+
+`reifyDimOrConstant` (used by the matmul-shaped row) returns
+`IntegerAttr` when the dim is static and a `tensor.dim` / `memref.dim`
+otherwise, mirroring upstream `linalg::createFoldedDimOp`.
+
+The interface declarations are already in TableGen (step 1), so no
+header / `attachInterface` changes are needed — the linker resolves
+each member function to whichever `.cpp` file defines it.
+
+### 4. Migrate converter callsites
+
+Drop the explicit `resultType` argument from the `Op::create` callsite
+in `lib/Conversion/OnnxToHip/<MyOp>Conversion.cpp`:
+
+```cpp
+// Before:
+hip::MyOp::create(b, loc, /*resultType=*/outsType, ctx, lhs, rhs, outs);
+// After:
+hip::MyOp::create(b, loc, ctx, lhs, rhs, outs);
+```
+
+The InferType-aware `Op::create` overload is auto-generated by ODS
+once `InferTypeOpInterface` is declared in step 1. Existing callers
+that still pass an explicit type list keep working — the migration is
+mechanical and per-op.
+
+### 5. (Optional) Verifier in `HipDialect.cpp`
+
+Only for ops with a non-trivial static shape contract — `hip.matmul`
+is the only such op as of #264. Implement `verify()` under the
 `// MyOp` section banner alongside the existing
 `getDpsInitsMutable()` / `getEffects()`:
 
@@ -301,7 +423,7 @@ LogicalResult MyOp::verify() {
   // the helper already issued a diagnostic.
   return mlir::hip::verifyHipOpShape(
       *this, [&]() -> SmallVector<SmallVector<int64_t>> {
-        SmallVector<int64_t> outShape = mlir::hip::broadcastShapes(
+        SmallVector<int64_t> outShape = mlir::hip::inferMatmulShape(
             getShapeOf(getA()), getShapeOf(getB()),
             [&]() { return this->emitOpError(); });
         if (outShape.empty())
@@ -311,48 +433,23 @@ LogicalResult MyOp::verify() {
 }
 ```
 
-### 4. Implement `reifyResultShapes()` in `HipReifyResultShapesImpl.cpp`
+Most new ops do **not** need this. The InferType-driven outs typing
+already closes the DPS contract by construction, and a Reify impl
+that returns the wrong shape is caught by LIT cases under
+`--hip-infer-shapes` (step 6).
 
-In [HipReifyResultShapesImpl.cpp](../../lib/Dialect/IR/HipReifyResultShapesImpl.cpp),
-add a new `// MyOp` section banner at the bottom of the file and place
-the impl underneath it:
+### 6. LIT coverage
 
-```cpp
-//===----------------------------------------------------------------------===//
-// MyOp
-//===----------------------------------------------------------------------===//
-
-LogicalResult MyOp::reifyResultShapes(
-    OpBuilder &b, ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
-  if (getNumResults() == 0)
-    return failure(); // memref mode -- no tensor result
-  // ... compute outShape via the same helper used in verify(), then for
-  //     each dim: reifyDimOrConstant(b, loc, outShape[d], operand,
-  //                                  operandDimIdx)
-  // ... reifiedReturnShapes.assign({std::move(dims)});
-  return success();
-}
-```
-
-`reifyDimOrConstant` returns `IntegerAttr` when the dim is static and a
-`tensor.dim` / `memref.dim` otherwise, mirroring upstream
-`linalg::createFoldedDimOp`.
-
-The interface declaration is already in TableGen (step 2), so no
-header / `attachInterface` changes are needed — the linker resolves the
-member function to whichever `.cpp` file defines it.
-
-### 5. (Optional) LIT coverage
-
-Add three small LIT tests under `test/lit/Dialect/`, modelled on the
-matmul ones:
-
-* `hip-<op>-shape-verifier.mlir`: positive + negative shape checks via
-  `--verify-diagnostics`.
-* `hip-<op>-reify-shapes.mlir`: drive `--resolve-shaped-type-result-dims`
-  and FileCheck that `tensor.dim` of the op result folds correctly.
-* (Optional) extend `test/lit/Dialect/hip-infer-shapes.mlir` with a case
-  that exercises `--hip-infer-shapes` on a chain involving the new op.
+Append cases to
+[test/lit/Dialect/hip-infer-shapes.mlir](../../test/lit/Dialect/hip-infer-shapes.mlir),
+one per shape pattern your op exercises (typically one static, one
+dynamic; for fold-or-bail Tier-1 ops also one non-foldable case with
+`CHECK-NOT: arith.subi` / `CHECK-NOT: arith.divsi` to guard the
+no-IR-bloat fallback contract). Per-op verifier / reify files
+(`hip-<op>-shape-verifier.mlir`, `hip-<op>-reify-shapes.mlir`) are
+reserved for ops complex enough to deserve their own file (matmul has
+both today; `hip.loop` has its own `hip-loop-verifier.mlir` for the
+v_init / result-type contract added by #261).
 
 ## Open extensions
 

--- a/docs/design/hip-shape-inference.md
+++ b/docs/design/hip-shape-inference.md
@@ -12,7 +12,9 @@ op into the same machinery.
 
 1. **Static verification.** Every HIP DPS op verifies that its `outs`
    operand types are compatible with the shapes that fall out of the op
-   contract (matmul: `[..., M, K] @ [..., K, N] -> [..., M, N]`;
+   contract (matmul: `[..., M, K] @ [..., K, N] -> [..., M, N]` over the
+   subset of shapes our codegen actually executes correctly — see
+   [`hip.matmul` codegen contract](#hipmatmul-codegen-contract);
    elementwise: NumPy broadcast over the inputs; etc).
 2. **Reify dynamic dims.** When a result dim is `?` (`kDynamic`) at the
    type level but is computable in terms of operand dims, the op exposes
@@ -377,3 +379,39 @@ then `tensor.collapse_shape` the result. Lowering (`MatmulLowering.cpp`)
 and runtime assume rank >= 2 today (indexing `aShape[rank-2]` and
 `bShape[rank-1]`); the verifier turns what would have been a
 silently-wrong hipBLASLt call into an explicit diagnostic.
+
+### `hip.matmul` codegen contract
+
+The verifier accepts only the subset of MatMul shape contracts that
+`MatMulConversion.cpp` + `MatmulLowering.cpp` execute correctly today:
+
+* 2D x 2D
+* ND x ND with same-rank batch dims (kDynamic-as-wildcard equality)
+* ND x 2D (rank-2 `B` re-used across all batches; codegen derives
+  `batchCount` from A's leading dims)
+
+Rejected at the verifier:
+
+* `B`'s rank > `A`'s rank — codegen derives result rank and `batchCount`
+  from A; a higher-rank `B` would be miscompiled.
+* Mixed ranks where `B` is not exactly rank-2 (e.g.
+  `[2,3,M,K] @ [3,K,N]`).
+* Per-dim batch broadcasting (`1` vs `>1`) — codegen reads A's batch
+  value verbatim, so a static `1` against a static `>1` would silently
+  produce the wrong result.
+
+Even the accepted ND x 2D path has a known runtime gap: hipBLASLt's
+`STRIDED_BATCH_OFFSET` for `B` is set to a non-zero value
+(`lib/Runtime/real/matmul.cpp`), which works for same-rank batched
+matmul but reads past `B`'s buffer when `B` is rank-2. None of the
+currently supported transformer models hit this path (every matmul is
+either 2D x 2D or same-rank batched), so the gap is latent. Fixing it
+requires a zero-stride layout for the broadcast side and a small
+runtime API extension; tracked as a follow-up alongside the verifier
+contract widening above.
+
+The strict subset is intentional: it gives the verifier a contract that
+codegen actually honors, so a future model that hits an unsupported
+shape gets a clean diagnostic instead of a silent miscompile. Widening
+this contract requires matching widening in `MatMulConversion`,
+`MatmulLowering`, and the runtime in lockstep.

--- a/docs/design/hip-shape-inference.md
+++ b/docs/design/hip-shape-inference.md
@@ -88,6 +88,17 @@ operands that became static. Producers we don't know how to refine
 today (function args, other DPS ops higher in the chain) are skipped —
 the pass then leaves that result index at `?`.
 
+The pass restricts itself to **HIP-dialect ops**. Upstream ops that
+also implement the reify interface (`tensor::EmptyOp`,
+`tensor::ExtractSliceOp`, `tensor::PadOp`, …) carry per-op invariants
+between operand SSA values and the result shape (e.g.
+`tensor.empty(%dyn)` requires the dynamic-size operand count to equal
+the number of `?` dims in the result). An in-place `result.setType()`
+narrow on those would desync those invariants, and we deliberately do
+not duplicate every upstream op's folder/canonicalizer surface here.
+The canonicalizer is the right tool for upstream-op refinement; this
+pass is for HIP DPS op result types only.
+
 ### Why DPS-aware?
 
 In a non-DPS world the pass could simply rewrite the op's result type
@@ -207,40 +218,31 @@ op name, listed in `lib/Dialect/IR/CMakeLists.txt`.
 
 ## Pipeline placement
 
-`--hip-infer-shapes` is **optional** and runs on `mlir::ModuleOp`. The
-recommended placement is between `convert-onnx-to-hip` and
-`one-shot-bufferize`:
+`--hip-infer-shapes` runs on `mlir::ModuleOp`, immediately after
+`convert-onnx-to-hip` and before `one-shot-bufferize`:
 
 ```text
 simplify-onnx -> hip-add-context-arg -> convert-onnx-to-hip
-              -> hip-infer-shapes (NEW, optional)
+              -> hip-infer-shapes
               -> one-shot-bufferize -> ...
 ```
 
-Refining tensor result types BEFORE bufferize propagates static dims
-through the alloc / pool sizing computations and removes spurious
-`memref.dim` ops at the top of the function.
+Wired in `lib/Dialect/Transforms/Pipelines.cpp` at the top of
+`buildOnnxToHipPipelineTail` (the shared post-conversion segment used
+by both `buildOnnxToHipPipeline` overloads), so every production
+compile path gets it.
 
-The pass is idempotent: a second invocation that finds no further
-refinements is a no-op.
-
-### Current pipeline status (intentionally dormant)
-
-`--hip-infer-shapes` is **registered for `hip-mlir-opt` (so LIT can
-exercise it) but NOT yet inserted into `lib/Dialect/Transforms/Pipelines.cpp`**.
-Reason: `hip.matmul` is the only op carrying
-`ReifyRankedShapedTypeOpInterface` today, so wiring the pass into the
-production pipeline now would walk every function for one-op coverage
-and yield no measurable refinement on the supported transformer
-models (whose matmul shapes are already fully static end-to-end after
-the symbolic-dim binding done in `MorphiZenEP::GetCapability`).
-
-The pass is intended to be enabled once a critical mass of HIP DPS ops
-(GQA, RmsNorm, SkipRmsNorm, Attention, RotaryEmbedding, ...) carry the
-interface. At that point the wiring is one line in
-`buildOnnxToHipPipeline` between `convert-onnx-to-hip` and
-`one-shot-bufferize`. Until then, the infrastructure is exercised
-exclusively through the LIT suite.
+Why this placement: refining tensor result types BEFORE bufferize
+propagates static dims through the alloc / pool sizing computations
+and removes spurious `memref.dim` ops at the top of the function. The
+pass is idempotent — a second invocation that finds no further
+refinements is a no-op — and it is also a no-op on functions whose ops
+either don't carry the interface or expose no further refinable dims,
+so it's safe to run unconditionally even today when only `hip.matmul`
+carries the interface. As more HIP DPS ops (GQA, RmsNorm,
+SkipRmsNorm, Attention, RotaryEmbedding, …) get
+`ReifyRankedShapedTypeOpInterface` impls, this wiring lets each new op
+participate without touching the pipeline definition.
 
 ## How to add a new op
 

--- a/docs/design/hip-shape-inference.md
+++ b/docs/design/hip-shape-inference.md
@@ -11,20 +11,26 @@ machinery.
 
 ## Goals
 
-1. **Result types tracked through the converter.** Every HIP DPS op
-   declares `InferTypeOpInterface` so the converter can construct ops
+1. **Result types tracked through the converter.** A HIP DPS op that
+   declares `InferTypeOpInterface` lets the converter construct it
    without restating the result type at every callsite — the
    auto-generated `Op::create` overload reads the result type(s) from
-   the `outs` operand types via `appendDpsResultIfTensor`. This keeps
-   the DPS contract `result_type == outs_operand_type` closed by
-   construction.
+   the `outs` operand types. This keeps the DPS contract
+   `result_type == outs_operand_type` closed by construction. `hip.matmul`
+   is the worked example on #260 (`autoInfer=1, declareInfer=1`); other
+   DPS ops migrate in #262 when the parameterized base flips its
+   defaults to opt every single-result op in.
 2. **Reify dynamic dims.** When a result dim is `?` (`kDynamic`) at the
    type level but is computable in terms of operand dims, the op exposes
-   that knowledge through upstream
+   that knowledge through
    `ReifyRankedShapedTypeOpInterface::reifyResultShapes`. Downstream
    `--resolve-shaped-type-result-dims` then folds `tensor.dim` of the
    result into either an `arith.constant` (static dims) or a
-   `tensor.dim` of the relevant input (dynamic dims).
+   `tensor.dim` of the relevant input (dynamic dims). The shared default
+   on `HipDpsOpInterface` (lifts from `getDpsInits()`) covers every
+   `Hip_DpsOp` whose result shape == outs shape; ops with tighter
+   contracts opt out via `autoReify=0` and ship a hand-written body in
+   `HipReifyResultShapesImpl.cpp`.
 3. **Module-level refinement.** The `--hip-infer-shapes` pass walks the
    module, calls `reifyResultShapes` on every HIP-dialect op carrying
    the interface, and refines `?` dims in result types in place —
@@ -46,15 +52,15 @@ Other ops compose the layers from a small helper menu chosen by shape
 contract — `reifyElementwiseSameShape` (default), `reifyBroadcastShape`
 (NumPy broadcast), dedicated helpers for permutation / reduction /
 gather, fold-or-bail Tier-1 helpers for shape-arithmetic ops
-(`reifyPadShape` etc.), and the generic `reifyResultsFromDpsInits` for
-multi-result outs-lifting. See [How to add a new op](#how-to-add-a-new-op)
-for the table.
+(`reifyPadShape` etc.). The "result shape == outs shape" case is the
+shared default on `HipDpsOpInterface`; no per-op helper is needed for
+it. See [How to add a new op](#how-to-add-a-new-op) for the table.
 
 ## Design rationale
 
 ### Why `InferTypeOpInterface` + `ReifyRankedShapedTypeOpInterface`?
 
-Upstream MLIR has three relevant interfaces:
+Three MLIR interfaces are relevant here:
 
 | Interface | Static shape | Dynamic shape | We use? |
 |---|---|---|---|
@@ -72,19 +78,62 @@ type list explicitly even though it is just the (already typed)
 `outs` operand type echoed back. `inferReturnTypes` moves that
 boilerplate into the op once — the auto-generated `Op::create`
 overload reads the outs operand types from the operation state and
-produces the result types via `appendDpsResultIfTensor`. Every
-`OnnxToHip*Conversion.cpp` callsite then drops its explicit type
-list and relies on the inference. Memref-mode ops produce zero result
-types — the destination operand carries the writes via its memref
-descriptor and the SSA result list is empty.
+produces the result types. The auto-emitted body reads the outs SSA
+value via the op's typed adaptor (named by `outsAccessor`, default
+`"Output"`); if the value is a `RankedTensorType` it is pushed as the
+single result type, otherwise (memref mode) zero result types are
+returned — matching the rule that memref-mode DPS ops have no SSA
+results because the destination operand carries the writes through
+its memref descriptor. Every `OnnxToHip*Conversion.cpp` callsite then
+drops its explicit type list and relies on the inference; the matmul
+converter is the worked example on #260 (see
+`lib/Conversion/OnnxToHip/MatMulConversion.cpp`).
+
+### `HipDpsOpInterface` (in-dialect marker + default reify)
+
+The two interfaces above describe **what** the op promises the rest
+of MLIR. To avoid 53× per-op restatements of the "reify-from-outs"
+body, the dialect adds an in-dialect marker interface,
+`HipDpsOpInterface` (declared in
+[include/hip/Dialect/IR/HipDpsOpInterface.td](../../include/hip/Dialect/IR/HipDpsOpInterface.td),
+body in [lib/Dialect/IR/HipDpsOpInterface.cpp](../../lib/Dialect/IR/HipDpsOpInterface.cpp)).
+It carries one shared default `reifyResultShapes` that walks
+`getDpsInits()` and lifts each init operand's shape via
+`tensor::getMixedSizes` / `memref::getMixedSizes` — the
+identity-on-DPS contract.
+
+`Hip_DpsOp` (the TableGen base class for every DPS op) auto-emits the
+per-op `ReifyRankedShapedTypeOpInterface::reifyResultShapes` dispatcher
+via `extraClassDefinition`, forwarding to that interface default. A
+3-bit parameter set on the base controls per-op opt-out:
+
+| Parameter | Default | Effect |
+|---|---|---|
+| `autoReify` | `1` | Auto-emit a per-op `reifyResultShapes` that delegates to `HipDpsOp::reifyResultShapes`. Set `0` for ops with a tighter contract (matmul) that provide a hand-written body in `HipReifyResultShapesImpl.cpp`. |
+| `autoInfer` | `0` (#260 default; #260 sets `1` on `hip.matmul` as the worked example, #262 flips the default) | Auto-emit a per-op `inferReturnTypes` that reads the result type from the outs operand. |
+| `declareInfer` | `0` (#260 default; #260 sets `1` on `hip.matmul`, #262 flips the default) | Declare `InferTypeOpInterface` on the op (so converters can use the inferred-type `Op::create` overload). |
+| `outsAccessor` | `"Output"` (37 ops) | ODS accessor name read by the auto-emitted `inferReturnTypes` body. Pass `"Y"` for ops with `$y` outs (12 ops), `"C"` for `hip.miopen.add` (`$C`), etc. |
+
+The shape: the interface owns the default body in a sibling `.cpp`
+file; per-op dispatchers are auto-emitted by TableGen from the
+dialect's DPS base class. The opt-out lever (`autoReify=0`) gives
+ops with a tighter shape contract — `[..., M, K] @ [..., K, N] ->
+[..., M, N]` for matmul, or value-dependent contracts like
+`hip.range` — a clean escape hatch with no boilerplate. Note that
+`autoReify` and `autoInfer` are orthogonal: `hip.matmul` keeps
+`autoReify=0` (runtime dim recovery from operand shapes) while taking
+`autoInfer=1, declareInfer=1` (construction-time result type comes
+verbatim from the typed outs operand). Most other ops with bespoke
+reify (`hip.range`, `hip.gemm`, `hip.qmoe`, `hip.matmul_nbits`) follow
+the same split on #262 onward.
 
 `ReifyRankedShapedTypeOpInterface` covers the orthogonal *dynamic-shape*
-job: per-dim `OpFoldResult`s for `--hip-infer-shapes` and the upstream
-test pass `--resolve-shaped-type-result-dims`. Static dims fall out as
+job: per-dim `OpFoldResult`s for `--hip-infer-shapes` and the test
+pass `--resolve-shaped-type-result-dims`. Static dims fall out as
 `IntegerAttr`, dynamic dims fall out as `tensor.dim` (or `memref.dim`)
-of the operand they depend on. Linalg's named ops use exactly this
-pattern; we reuse both the interface and the LLVM-project test pass so
-our infrastructure does not fork.
+of the operand they depend on. The interface and the test pass are
+both shipped by MLIR — the dialect plugs into them rather than
+forking equivalent infrastructure.
 
 The two interfaces compose cleanly with no overlap: InferType makes
 converters terse at op-construction time, Reify makes refinement work
@@ -96,14 +145,13 @@ static shape helper (`inferMatmulShape`) that Reify lifts into
 
 An earlier draft added a custom `HipShapeInferenceOpInterface` with an
 `inferOutputShape(...) -> SmallVector<int64_t>` static method. Dropped:
-the two upstream interfaces above already cover both jobs (static type
+the two MLIR interfaces above already cover both jobs (static type
 inference, dynamic dim reify), doubling up adds maintenance with no
-payoff, and the upstream test-pass machinery is the test surface for
-free.
+payoff, and the test-pass machinery is the test surface for free.
 
 ### Why a dedicated `--hip-infer-shapes` pass?
 
-Upstream MLIR ships two related passes:
+Two related MLIR passes already exist:
 
 * **`--reify-result-shapes`** (memref dialect, MLIR 22): only `tensor::Pad`
   / `tensor::Concat`; skips DPS ops by design.
@@ -112,23 +160,23 @@ Upstream MLIR ships two related passes:
   MLIR** and is not DPS-aware (it does not refine the `outs` operand's
   producer to keep the type chain well-formed).
 
-`--hip-infer-shapes` adapts the same pattern as upstream but adds the
+`--hip-infer-shapes` extends the same module-walk pattern with the
 DPS-aware producer refinement: when the outs operand is a `tensor.empty`,
 the pass rebuilds it with the new static shape and drops any dyn-dim
 operands that became static. Producers we don't know how to refine
 today (function args, other DPS ops higher in the chain) are skipped —
 the pass then leaves that result index at `?`.
 
-The pass restricts itself to **HIP-dialect ops**. Upstream ops that
-also implement the reify interface (`tensor::EmptyOp`,
+The pass restricts itself to **HIP-dialect ops**. Non-HIP-dialect ops
+that also implement the reify interface (`tensor::EmptyOp`,
 `tensor::ExtractSliceOp`, `tensor::PadOp`, …) carry per-op invariants
 between operand SSA values and the result shape (e.g.
 `tensor.empty(%dyn)` requires the dynamic-size operand count to equal
 the number of `?` dims in the result). An in-place `result.setType()`
 narrow on those would desync those invariants, and we deliberately do
-not duplicate every upstream op's folder/canonicalizer surface here.
-The canonicalizer is the right tool for upstream-op refinement; this
-pass is for HIP DPS op result types only.
+not duplicate those ops' folder/canonicalizer surface here. The
+canonicalizer is the right tool for non-HIP-op refinement; this pass
+is for HIP DPS op result types only.
 
 ### Why DPS-aware?
 
@@ -162,62 +210,105 @@ choice. See `refine_chained_matmul` in
 
 That said, the "barrier" is leaky in a *good* way: when the consumer's
 `reifyResultShapes` materialises `tensor.dim %cast, i` via
-`tensor::getMixedSize` (which uses `createOrFold`), upstream
+`tensor::getMixedSize` (which uses `createOrFold`),
 `tensor::DimOp::fold` looks through the cast and resolves to the
 underlying static size. So a chained DPS op whose operand is a cast of
 an already-refined value will still recover the static dim via the dim
 op, **without** giving up the cast-as-barrier on the `ins` edge type.
 The chained-matmul test exercises exactly this case.
 
-### Upstream helpers we lean on
+### MLIR helpers we lean on
 
 Where the implementation could be expressed via either a bespoke helper
-or an upstream one, it consistently picks upstream:
+or a library-provided one, it consistently picks the library helper:
 
-| Need | Upstream helper |
+| Need | Helper |
 |---|---|
 | Constant-int extraction from `OpFoldResult` | `mlir::getConstantIntValue(OpFoldResult)` (`mlir/Dialect/Utils/StaticValueUtils.h`) |
 | Re-typing a `RankedTensorType` while preserving encoding | `RankedTensorType::clone(ArrayRef<int64_t>)` (`mlir/IR/BuiltinTypeInterfaces.td` shared decl) |
 | `tensor.dim` of a value at a static-or-dynamic dim | `tensor::getMixedSize(OpBuilder &, Location, Value, int64_t)` |
-| IR mutation through an observable rewriter | `mlir::IRRewriter` (matches upstream `--reify-result-shapes`) |
+| IR mutation through an observable rewriter | `mlir::IRRewriter` |
 
-This keeps drift between the HIP pass and upstream `--reify-result-shapes`
-to a minimum: when MLIR upgrades drop a more general successor (e.g.
-`--infer-static-shapes`), retiring our pass should be mostly a matter of
-substituting it into `Pipelines.cpp` and re-running the LIT suite.
+This keeps the HIP pass aligned with the rest of the dialect surface:
+when a future MLIR release ships a more general successor pass (e.g.
+`--infer-static-shapes`), retiring `--hip-infer-shapes` should be
+mostly a matter of substituting the new pass into `Pipelines.cpp` and
+re-running the LIT suite.
 
 ## Component layout
 
 ```text
 include/hip/Dialect/IR/
-  HipShapeUtils.h          -- public API: inferMatmulShape,
-                              verifyHipOpShape, appendDpsResultIfTensor,
-                              reifyDimOrConstant, reifyElementwiseSameShape,
-                              reifyBroadcastShape, reifyResultsFromDpsInits,
-                              and per-shape Tier-1 helpers (reifyPadShape,
-                              reifyTileShape, reifySliceShape,
-                              reifyExpandShape, reifyRangeShape,
-                              reifyTransposeByPerm, reifyGatherWithAxis,
-                              reifyGatherND, reifyReductionWithKeepdims)
-  HipOps.td                -- per-op declares
-                              `DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>`
-                              and `DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>`;
-                              `let hasVerifier = 1` only when the op has a
-                              non-trivial shape contract (matmul today)
+  HipShapeUtils.h          -- public API: inferMatmulShape, verifyHipOpShape,
+                              reifyDimOrConstant. Helpers added by
+                              later phases of the cascade are listed in their
+                              respective PR plans (reifyElementwiseSameShape
+                              and reifyBroadcastShape land with the
+                              Hip_DpsOp_SameShape / Hip_DpsOp_Broadcast
+                              sub-bases in #262 / #263; per-shape Tier-1
+                              helpers reifyPadShape / reifyTileShape /
+                              reifySliceShape / reifyExpandShape /
+                              reifyRangeShape / reifyTransposeByPerm /
+                              reifyGatherWithAxis / reifyGatherND /
+                              reifyReductionWithKeepdims land with the
+                              bespoke-op cleanup in #264).
+  HipDpsOpInterface.td     -- in-dialect `HipDpsOp` interface declaration;
+                              carries the shared default `reifyResultShapes`
+                              that all `Hip_DpsOp`s inherit unless they opt
+                              out via `autoReify=0`
+  HipOps.td                -- `Hip_DpsOp` base auto-emits per-op
+                              `ReifyRankedShapedTypeOpInterface` dispatchers
+                              via `extraClassDefinition`, and from #260
+                              onward also auto-emits per-op
+                              `InferTypeOpInterface::inferReturnTypes` for
+                              ops that pass `autoInfer=1, declareInfer=1`
+                              (matmul today; the rest migrate in #262).
+                              Per-op defs only carry `autoReify=0` /
+                              `autoInfer=0` / `declareInfer=0` opt-outs and
+                              `outsAccessor` when the outs SSA name is not
+                              `$output`. `let hasVerifier = 1` only when the
+                              op has a non-trivial shape contract (matmul
+                              today).
 
 lib/Dialect/IR/
   HipShapeUtils.cpp                -- implementations + diagnostics
+  HipDpsOpInterface.cpp            -- shared default `reifyResultShapes`
+                                      body (walks `getDpsInits()`, lifts each
+                                      via `tensor::getMixedSizes` /
+                                      `memref::getMixedSizes`)
   HipDialect.cpp                   -- per-op `verify()` (matmul only as of
-                                      #264, plus `LoopOp::verify()`),
-                                      `getEffects()`, `getDpsInitsMutable()`,
-                                      custom builders / printers / parsers;
-                                      `LoopOp::inferReturnTypes` lives here
-                                      next to its peers (control-flow op,
+                                      #260, plus `LoopOp::verify()` added in
+                                      #261), `getEffects()`,
+                                      `getDpsInitsMutable()`, custom builders
+                                      / printers / parsers; `LoopOp::inferReturnTypes`
+                                      lives here next to its peers (control-flow op,
                                       not a DPS compute op)
-  HipResultTypeInferenceImpl.cpp   -- per-op `inferReturnTypes()`,
-                                      one `// <OpName>` section per op
-  HipReifyResultShapesImpl.cpp     -- per-op `reifyResultShapes()`,
-                                      one `// <OpName>` section per op
+  HipReifyResultShapesImpl.cpp     -- per-op `reifyResultShapes()` for ops
+                                      that opt out (`autoReify=0`), one
+                                      `// <OpName>` section per op. Matmul
+                                      is the only op in this file on #260;
+                                      `hip.range` / `hip.nonzero` / `hip.pad`
+                                      / `hip.tile` / `hip.expand` / `hip.slice`
+                                      / `hip.gather*` / `hip.reduce_*` /
+                                      `hip.transpose` / `hip.layer_norm` /
+                                      `hip.skip_rms_norm` / `hip.gqa` /
+                                      `hip.mha` / `hip.causal_conv_with_state`
+                                      / `hip.linear_attention` / `hip.hipdnn_graph`
+                                      join across #262-#264.
+
+  HipResultTypeInferenceImpl.cpp   -- (added in #262) per-op
+                                      `inferReturnTypes()` for ops that opt
+                                      out of the auto-emitted body
+                                      (`autoInfer=0`), one `// <OpName>`
+                                      section per op. Used by the variadic-out
+                                      ops (`layer_norm`, `skip_rms_norm`,
+                                      `hipdnn_graph`) and the multi-init ops
+                                      (`gqa`, `mha`, `linear_attention`,
+                                      `causal_conv_with_state`). Single-result
+                                      ops with bespoke reify (matmul, gemm,
+                                      qmoe, matmul_nbits) take the
+                                      auto-emitted `inferReturnTypes` body
+                                      and do NOT appear in this file.
 
 include/hip/Dialect/Transforms/
   Passes.td                -- `def InferShapesPass` registration
@@ -228,8 +319,9 @@ lib/Dialect/Transforms/
 test/lit/Dialect/
   hip-matmul-shape-verifier.mlir   -- matmul shape-contract verifier
                                        positive + negative cases
-  hip-matmul-reify-shapes.mlir     -- driven by upstream
+  hip-matmul-reify-shapes.mlir     -- driven by the
                                        `--resolve-shaped-type-result-dims`
+                                       test pass
   hip-loop-verifier.mlir           -- `hip.loop` v_init / result type
                                        contract (added by #261)
   hip-infer-shapes.mlir            -- consolidated `--hip-infer-shapes`
@@ -248,21 +340,17 @@ non-trivial shape arithmetic that benefits from being read alongside
 each other (every dynamic-shape op solves a small variant of the same
 "lift static dims to `IntegerAttr`, dynamic dims to `tensor.dim` of
 the right operand" problem). InferType implementations are typically
-mechanical (`appendDpsResultIfTensor` chained over outs operands) but
-multiply across every DPS op — keeping them together makes the "every
-op uniformly delegates to the same helper" pattern obvious. Both files
-follow the same one-`// <OpName>`-section-per-op convention.
+mechanical reads of the outs operand's type but multiply across every
+DPS op — keeping them together makes the "every op uniformly delegates
+to the same helper" pattern obvious. Both files follow the same
+one-`// <OpName>`-section-per-op convention.
 
-This mirrors IREE's LinalgExt convention (`LinalgExtOps.cpp` keeps
-verifiers / builders; `TilingInterfaceImpl.cpp` and
-`AggregatedOpInterfaceImpl.cpp` keep per-interface impls), which in
-turn descends from the same upstream split between
-`mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp` (op identity) and the
-various interface-impl `.cpp` files under
-`mlir/lib/Dialect/Linalg/Transforms/`. The interface impls are
-**member functions, not external models** — `attachInterface` /
-`ExternalModel<>` is only needed when implementing an interface from
-*outside* the op's owning dialect.
+The interface impls are **member functions, not external models** —
+`attachInterface` / `ExternalModel<>` is only needed when implementing
+an interface from *outside* the op's owning dialect. Inside the HIP
+dialect we own both the op and the interface impl, so a normal
+class-member definition in `HipReifyResultShapesImpl.cpp` /
+`HipResultTypeInferenceImpl.cpp` is the right shape.
 
 When a future interface accumulates enough impls to deserve the same
 treatment (e.g. a dialect-defined op interface, a tiling interface, or
@@ -300,110 +388,141 @@ any change to `Pipelines.cpp`.
 
 ## How to add a new op
 
-A new HIP DPS op participates in shape inference in **four** small
-edits (TableGen + InferType + Reify + LIT), plus an **optional**
-verifier when the op has a non-trivial static shape contract. The
-matmul wiring is the canonical full-stack reference; for the rest of
-the dialect the InferType + Reify path (no verifier) is the realized
-pattern across #262 - #264.
+For most new HIP DPS ops the recipe collapses to **two** edits:
+(1) declare the op via `Hip_DpsOp` in TableGen and (2) add a LIT case.
+The `Hip_DpsOp` base auto-emits a working `reifyResultShapes` so the op
+participates in dynamic-shape refinement without per-op `.cpp`
+boilerplate. Construction-time `inferReturnTypes` is also auto-emitted
+when the op opts in via `autoInfer=1, declareInfer=1` (matmul on #260;
+all single-result ops by default from #262). Verifier and per-op
+overrides remain optional escape hatches when the op has a shape
+contract tighter than "result_type == outs_operand_type".
 
-**Stack rollout context.** Infrastructure lands in #260 with `hip.matmul`
-as the worked example. #261 adds `InferTypeOpInterface` to `hip.loop`.
-#262 - #264 roll out the InferType + Reify pattern across 51 more DPS
-ops, picking from a small menu of reify helpers chosen by op shape
-contract — see step 3.
+**Stack rollout context.** Infrastructure lands in #260: the in-dialect
+`HipDpsOpInterface`, the parameterized `Hip_DpsOp` base, and matmul as
+the dual worked example — opt out of the default reify
+(`autoReify=0`, with a hand-written `MatmulOp::reifyResultShapes` that
+recovers M/K/N from operand shapes) AND opt in to auto-emitted
+inferReturnTypes (`autoInfer=1, declareInfer=1`, with the converter
+callsite dropped to the inferred-type `Op::create` overload). #261
+adds `InferTypeOpInterface` to `hip.loop` (region op, not DPS). #262
+flips `autoInfer=1` / `declareInfer=1` defaults and introduces the
+`Hip_DpsOp_SameShape` sub-base. #263 introduces `Hip_DpsOp_Broadcast`
+and migrates 23 ops. #264 cleans up the remaining bespoke ops.
 
-### 1. Declare the two interfaces in TableGen
+### 1. Declare the op in TableGen
 
 In [HipOps.td](../../include/hip/Dialect/IR/HipOps.td):
 
 ```tablegen
-def Hip_MyOp : Hip_DpsOp<"my_op", [
-    DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>,
-    DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>
-  ]> {
+def Hip_MyOp : Hip_DpsOp<"my_op"> {
   // ... arguments, assemblyFormat ...
 }
 ```
 
-`Hip_DpsOp` already declares `DestinationStyleOpInterface` and emits the
-`Variadic<AnyRankedTensor>:$result_tensors` result for tensor mode. Add
-`let hasVerifier = 1;` only if the op has a non-trivial static shape
-contract worth verifying (matmul-style; default for new ops is no
-verifier — see step 5).
+`Hip_DpsOp` declares `MemoryEffectsOpInterface`,
+`DestinationStyleOpInterface`, `HipDpsOpInterface`, and
+`ReifyRankedShapedTypeOpInterface` (with an auto-emitted body that
+forwards to the shared default), and emits the
+`Variadic<AnyRankedTensor>:$result_tensors` result for tensor mode.
+Pass `outsAccessor` when the DPS init operand SSA name is not
+`$output` (common for unary elementwise ops that use `$y`):
 
-### 2. Implement `inferReturnTypes()` in `HipResultTypeInferenceImpl.cpp`
-
-Add a `// MyOp` section banner at the bottom of
-[HipResultTypeInferenceImpl.cpp](../../lib/Dialect/IR/HipResultTypeInferenceImpl.cpp).
-Single-result ops are typically a one-liner over the outs operand:
-
-```cpp
-LogicalResult MyOp::inferReturnTypes(
-    MLIRContext *ctx, std::optional<Location> loc, MyOp::Adaptor adaptor,
-    SmallVectorImpl<Type> &inferredReturnTypes) {
-  appendDpsResultIfTensor(adaptor.getOutput(), inferredReturnTypes);
-  return success();
-}
+```tablegen
+def Hip_SigmoidOp : Hip_DpsOp<"sigmoid", /*traits=*/[],
+                              /*outsAccessor=*/"Y"> { /* ... */ }
 ```
 
-For multi-result ops, chain `appendDpsResultIfTensor` per outs operand;
-when the op carries `AttrSizedOperandSegments` and you would otherwise
-duplicate the chain, delegate to the generic helper used by
-`hip.gqa` / `hip.layer_norm` / `hip.multi_head_attention`:
+Add `let hasVerifier = 1;` only if the op has a non-trivial static
+shape contract worth verifying (matmul-style; default for new ops is
+no verifier — see step 4).
 
-```cpp
-return reifyResultsFromDpsInits(*this, b, reifiedReturnShapes);
-```
+### 2. (Optional) Per-op `reifyResultShapes` override
 
-Memref-mode ops produce zero result types — `appendDpsResultIfTensor`
-is a no-op when the operand is a memref, so the same impl works for
-both modes.
+Skip this step unless the op has a shape contract tighter than
+"result_type == outs_operand_type". The `Hip_DpsOp` base's
+auto-emitted body forwards to `HipDpsOp::reifyResultShapes` (in
+[lib/Dialect/IR/HipDpsOpInterface.cpp](../../lib/Dialect/IR/HipDpsOpInterface.cpp)),
+which walks `getDpsInits()` and lifts each via
+`tensor::getMixedSizes` / `memref::getMixedSizes`. For most ops this
+is exactly the right behavior: result shape == outs shape by DPS
+contract, and `--hip-infer-shapes` will narrow `?` dims in the result
+type from any static dims the outs operand carries.
 
-### 3. Implement `reifyResultShapes()` in `HipReifyResultShapesImpl.cpp`
-
-Add a `// MyOp` section banner at the bottom of
+If the op has a tighter contract — matmul-style
+`[..., M, K] @ [..., K, N] -> [..., M, N]`, or value-dependent
+contracts like `hip.range` — opt out via `autoReify=0` and add a
+`// MyOp` section banner at the bottom of
 [HipReifyResultShapesImpl.cpp](../../lib/Dialect/IR/HipReifyResultShapesImpl.cpp).
 Pick the reify helper that matches the op's shape contract:
 
-| Op shape contract | Helper |
-|---|---|
-| Result shape == operand shape (silu, sigmoid, cast, ...) | `reifyElementwiseSameShape` |
-| NumPy broadcast (add, mul, where, ...) | `reifyBroadcastShape` |
-| Permutation (`hip.transpose`) | `reifyTransposeByPerm` |
-| Reduction with `keepdims` (reduce_sum, reduce_max, ...) | `reifyReductionWithKeepdims` |
-| Gather along an axis (`hip.gather`, `hip.gather_nd`) | `reifyGatherWithAxis` / `reifyGatherND` |
-| Multi-result outs-lifting (gqa, attention, layer_norm, ...) | `reifyResultsFromDpsInits` (mirrors IREE's `LinalgExtOp::reifyResultShapes` default) |
-| Fold-or-bail shape arithmetic (pad, tile, slice, expand, range) | one of `reifyPadShape` / `reifyTileShape` / `reifySliceShape` / `reifyExpandShape` / `reifyRangeShape` (return `failure()` on non-foldable; the thunk falls through to outs-lifting) |
-| Matmul-shaped (`[..., M, K] @ [..., K, N] -> [..., M, N]`) | call `inferMatmulShape` to compute output extents, then `reifyDimOrConstant` per dim |
+| Op shape contract | Helper | Lands in |
+|---|---|---|
+| Result shape == outs operand shape (default) | (no helper — interface default in `HipDpsOpInterface.cpp`) | #260 |
+| Result shape == named INPUT operand shape (e.g. silu, rope, rms_norm) | `Hip_DpsOp_SameShape<input>` sub-base + `reifyElementwiseSameShape` | #262 |
+| NumPy broadcast (add, mul, where, ...) | `Hip_DpsOp_Broadcast<[...]>` sub-base + `reifyBroadcastShape` | #263 |
+| Permutation (`hip.transpose`) | `reifyTransposeByPerm` | #264 |
+| Reduction with `keepdims` (reduce_sum, reduce_max) | `reifyReductionWithKeepdims` | #264 |
+| Gather along an axis (`hip.gather`, `hip.gather_nd`) | `reifyGatherWithAxis` / `reifyGatherND` | #264 |
+| Multi-init outs-lifting (gqa, mha, layer_norm, ...) | hand-written body in `HipReifyResultShapesImpl.cpp` walking `getDpsInits()` | #262-#264 |
+| Fold-or-bail shape arithmetic (pad, tile, slice, expand, range) | one of `reifyPadShape` / `reifyTileShape` / `reifySliceShape` / `reifyExpandShape` / `reifyRangeShape` (return `failure()` on non-foldable; falls through to outs-lifting) | #264 |
+| Matmul-shaped (`[..., M, K] @ [..., K, N] -> [..., M, N]`) | call `inferMatmulShape` to compute output extents, then `reifyDimOrConstant` per dim | #260 (matmul) |
 
 If your op's contract is not in the table, write a new helper in
 `HipShapeUtils.{h,cpp}` and add a row.
 
 `reifyDimOrConstant` (used by the matmul-shaped row) returns
 `IntegerAttr` when the dim is static and a `tensor.dim` / `memref.dim`
-otherwise, mirroring upstream `linalg::createFoldedDimOp`.
+otherwise.
 
 The interface declarations are already in TableGen (step 1), so no
 header / `attachInterface` changes are needed — the linker resolves
 each member function to whichever `.cpp` file defines it.
 
-### 4. Migrate converter callsites
+### 3. Data-dependent shape contracts (`hip.range`, `hip.nonzero`, ...)
 
-Drop the explicit `resultType` argument from the `Op::create` callsite
-in `lib/Conversion/OnnxToHip/<MyOp>Conversion.cpp`:
+Some ops have output dims that depend on operand **values** (not
+operand types). `hip.range(start, end, step)` produces a 1D result
+whose extent is `(end - start) / step`; `hip.nonzero(input)` produces
+a 2D result whose first dim is the runtime count of nonzero entries
+in the input.
+
+The "fold-or-bail" Tier-1 helpers
+(`reifyRangeShape` etc.) handle this in two cases:
+
+1. **Constant value operands** — the helper folds `(end - start)` /
+   `step` into an `IntegerAttr` and refines the result dim
+   statically.
+2. **Non-foldable** — the helper returns `failure()`. The dispatcher
+   thunk then falls through to outs-lifting (the default), which
+   reads the dim from the outs operand. If the outs operand was
+   constructed via `tensor.empty(%dyn)` with the runtime extent as
+   a dynamic-size operand, downstream consumers see a `tensor.dim`
+   on the result that folds back to that operand.
+
+Ops where the runtime extent has no SSA representation at all (e.g.
+`hip.nonzero` whose count cannot be expressed before running the
+kernel) leave the dim as `?` — the only honest answer.
+
+### 4. Converter callsites (inferred-type `Op::create`)
+
+For ops with `declareInfer=1, autoInfer=1` (matmul on #260; all
+single-result `Hip_DpsOp`s by default from #262), drop the explicit
+`resultType` argument from the `Op::create` callsite in
+`lib/Conversion/OnnxToHip/<MyOp>Conversion.cpp`:
 
 ```cpp
 // Before:
 hip::MyOp::create(b, loc, /*resultType=*/outsType, ctx, lhs, rhs, outs);
-// After:
+// After (auto-emitted body reads outs.getType()):
 hip::MyOp::create(b, loc, ctx, lhs, rhs, outs);
 ```
 
 The InferType-aware `Op::create` overload is auto-generated by ODS
-once `InferTypeOpInterface` is declared in step 1. Existing callers
-that still pass an explicit type list keep working — the migration is
-mechanical and per-op.
+once `InferTypeOpInterface` is declared. Existing callers that still
+pass an explicit type list keep working — the migration is mechanical
+and per-op. See `lib/Conversion/OnnxToHip/MatMulConversion.cpp` for
+the worked example on #260.
 
 ### 5. (Optional) Verifier in `HipDialect.cpp`
 

--- a/docs/design/hip-shape-inference.md
+++ b/docs/design/hip-shape-inference.md
@@ -21,11 +21,14 @@ op into the same machinery.
    `--resolve-shaped-type-result-dims` then folds `tensor.dim` of the
    result into either an `arith.constant` (static dims) or a
    `tensor.dim` of the relevant input (dynamic dims).
-3. **Module-level refinement.** The optional `--hip-infer-shapes` pass
-   walks the module, calls `reifyResultShapes` on every op, and refines
-   `?` dims in result types in place — including the DPS `outs` operand's
-   `tensor.empty` producer, which is necessary to keep the IR
-   well-formed (DPS contract: `result_type == outs_operand_type`).
+3. **Module-level refinement.** The `--hip-infer-shapes` pass walks the
+   module, calls `reifyResultShapes` on every HIP-dialect op carrying
+   the interface, and refines `?` dims in result types in place —
+   including the DPS `outs` operand's `tensor.empty` producer, which is
+   necessary to keep the IR well-formed (DPS contract:
+   `result_type == outs_operand_type`). Wired into the production
+   pipeline immediately after `convert-onnx-to-hip` (see
+   [Pipeline placement](#pipeline-placement)).
 
 These three layers share **one** static shape function per op
 (`inferContractionShape`, future `broadcastShapes`, ...). The verifier
@@ -238,11 +241,11 @@ and removes spurious `memref.dim` ops at the top of the function. The
 pass is idempotent — a second invocation that finds no further
 refinements is a no-op — and it is also a no-op on functions whose ops
 either don't carry the interface or expose no further refinable dims,
-so it's safe to run unconditionally even today when only `hip.matmul`
-carries the interface. As more HIP DPS ops (GQA, RmsNorm,
-SkipRmsNorm, Attention, RotaryEmbedding, …) get
-`ReifyRankedShapedTypeOpInterface` impls, this wiring lets each new op
-participate without touching the pipeline definition.
+so it's safe to run unconditionally regardless of how much HIP-op
+coverage `ReifyRankedShapedTypeOpInterface` currently has. As more
+HIP DPS ops (GQA, RmsNorm, SkipRmsNorm, Attention, RotaryEmbedding,
+…) gain reify impls, the wiring lets each new op participate without
+any change to `Pipelines.cpp`.
 
 ## How to add a new op
 
@@ -359,6 +362,13 @@ matmul ones:
 
 The current first-pass coverage is intentionally narrow:
 
+* **Op coverage.** Only `hip.matmul` carries
+  `ReifyRankedShapedTypeOpInterface` today. Each additional HIP DPS op
+  that gets a reify impl participates in the pipeline-level pass for
+  free (no `Pipelines.cpp` change). Priority order, by frequency in
+  observed transformer graphs: GQA, RmsNorm, SkipRmsNorm,
+  RotaryEmbedding, MatMulNBits, then everything else. The recipe in
+  [How to add a new op](#how-to-add-a-new-op) is the canonical guide.
 * **`hip.matmul` rejects rank-1 operands.** The new verifier requires
   both `A` and `B` to have rank ≥ 2. ONNX `MatMul` semantics permit
   rank-1 operands (vector·matrix / matrix·vector) by implicitly

--- a/docs/design/hip-shape-inference.md
+++ b/docs/design/hip-shape-inference.md
@@ -4,9 +4,10 @@ Licensed under the MIT License.
 -->
 # HIP dialect shape inference
 
-This document explains how the HIP dialect represents and refines the
-shapes of its DPS (destination-passing-style) ops, and how to wire a new
-op into the same machinery.
+How HIP DPS (destination-passing-style) ops express their shape
+contract — verifier, `ReifyRankedShapedTypeOpInterface` impl,
+`--hip-infer-shapes` pass — and how to wire a new op into the same
+machinery.
 
 ## Goals
 
@@ -61,17 +62,12 @@ both the interface and the LLVM-project test pass that drives it
 (`--resolve-shaped-type-result-dims`) so our infrastructure does not
 fork.
 
-We considered a custom `HipShapeInferenceOpInterface` early on. The
-draft would have added a `inferOutputShape(...)` static method returning
-`SmallVector<int64_t>`. That would have given us a clean separator
-between "static helper used by the verifier" and "dynamic helper used by
-the canonicaliser". We dropped it because:
-
-* Both jobs are already covered by upstream interfaces — the static
-  helper is a free function in `HipShapeUtils`, and the dynamic helper
-  is the upstream interface method.
-* Doubling up the surface adds a maintenance gradient with no payoff.
-* The upstream test-pass machinery is the test surface for free.
+An earlier draft added a custom `HipShapeInferenceOpInterface` with an
+`inferOutputShape(...) -> SmallVector<int64_t>` static method. Dropped:
+the upstream interface and the static helper already cover both jobs
+(static check, dynamic reify), doubling up adds maintenance with no
+payoff, and the upstream test-pass machinery is the test surface for
+free.
 
 ### Why a dedicated `--hip-infer-shapes` pass?
 
@@ -235,14 +231,14 @@ Wired in `lib/Dialect/Transforms/Pipelines.cpp` at the top of
 by both `buildOnnxToHipPipeline` overloads), so every production
 compile path gets it.
 
-Why this placement: refining tensor result types BEFORE bufferize
-propagates static dims through the alloc / pool sizing computations
-and removes spurious `memref.dim` ops at the top of the function. The
-pass is idempotent — a second invocation that finds no further
-refinements is a no-op — and it is also a no-op on functions whose ops
-either don't carry the interface or expose no further refinable dims,
-so it's safe to run unconditionally regardless of how much HIP-op
-coverage `ReifyRankedShapedTypeOpInterface` currently has. As more
+Refining tensor result types BEFORE bufferize is what makes the pass
+pay rent: static dims then propagate through the alloc / pool sizing
+computations, and bufferize stops emitting `memref.dim` ops at the top
+of the function. The pass is idempotent (a second invocation that
+finds no further refinements is a no-op) and a no-op on functions
+whose ops either don't carry the interface or expose no further
+refinable dims — safe to run unconditionally regardless of how much
+HIP-op coverage the interface currently has. As more
 HIP DPS ops (GQA, RmsNorm, SkipRmsNorm, Attention, RotaryEmbedding,
 …) gain reify impls, the wiring lets each new op participate without
 any change to `Pipelines.cpp`.

--- a/docs/design/hip-shape-inference.md
+++ b/docs/design/hip-shape-inference.md
@@ -12,9 +12,7 @@ op into the same machinery.
 
 1. **Static verification.** Every HIP DPS op verifies that its `outs`
    operand types are compatible with the shapes that fall out of the op
-   contract (matmul: `[..., M, K] @ [..., K, N] -> [..., M, N]` over the
-   subset of shapes our codegen actually executes correctly — see
-   [`hip.matmul` codegen contract](#hipmatmul-codegen-contract);
+   contract (matmul: `[..., M, K] @ [..., K, N] -> [..., M, N]`;
    elementwise: NumPy broadcast over the inputs; etc).
 2. **Reify dynamic dims.** When a result dim is `?` (`kDynamic`) at the
    type level but is computable in terms of operand dims, the op exposes
@@ -379,39 +377,3 @@ then `tensor.collapse_shape` the result. Lowering (`MatmulLowering.cpp`)
 and runtime assume rank >= 2 today (indexing `aShape[rank-2]` and
 `bShape[rank-1]`); the verifier turns what would have been a
 silently-wrong hipBLASLt call into an explicit diagnostic.
-
-### `hip.matmul` codegen contract
-
-The verifier accepts only the subset of MatMul shape contracts that
-`MatMulConversion.cpp` + `MatmulLowering.cpp` execute correctly today:
-
-* 2D x 2D
-* ND x ND with same-rank batch dims (kDynamic-as-wildcard equality)
-* ND x 2D (rank-2 `B` re-used across all batches; codegen derives
-  `batchCount` from A's leading dims)
-
-Rejected at the verifier:
-
-* `B`'s rank > `A`'s rank — codegen derives result rank and `batchCount`
-  from A; a higher-rank `B` would be miscompiled.
-* Mixed ranks where `B` is not exactly rank-2 (e.g.
-  `[2,3,M,K] @ [3,K,N]`).
-* Per-dim batch broadcasting (`1` vs `>1`) — codegen reads A's batch
-  value verbatim, so a static `1` against a static `>1` would silently
-  produce the wrong result.
-
-Even the accepted ND x 2D path has a known runtime gap: hipBLASLt's
-`STRIDED_BATCH_OFFSET` for `B` is set to a non-zero value
-(`lib/Runtime/real/matmul.cpp`), which works for same-rank batched
-matmul but reads past `B`'s buffer when `B` is rank-2. None of the
-currently supported transformer models hit this path (every matmul is
-either 2D x 2D or same-rank batched), so the gap is latent. Fixing it
-requires a zero-stride layout for the broadcast side and a small
-runtime API extension; tracked as a follow-up alongside the verifier
-contract widening above.
-
-The strict subset is intentional: it gives the verifier a contract that
-codegen actually honors, so a future model that hits an unsupported
-shape gets a clean diagnostic instead of a silent miscompile. Widening
-this contract requires matching widening in `MatMulConversion`,
-`MatmulLowering`, and the runtime in lockstep.

--- a/docs/design/hip-shape-inference.md
+++ b/docs/design/hip-shape-inference.md
@@ -31,7 +31,7 @@ op into the same machinery.
    [Pipeline placement](#pipeline-placement)).
 
 These three layers share **one** static shape function per op
-(`inferContractionShape`, future `broadcastShapes`, ...). The verifier
+(`inferMatmulShape`, future `inferBroadcastShape`, ...). The verifier
 checks the result against the helper; reify lifts the helper's output
 into `OpFoldResult`s; the pass aggregates reify across the module.
 
@@ -162,7 +162,7 @@ substituting it into `Pipelines.cpp` and re-running the LIT suite.
 
 ```text
 include/hip/Dialect/IR/
-  HipShapeUtils.h          -- public API: inferContractionShape,
+  HipShapeUtils.h          -- public API: inferMatmulShape,
                               verifyHipOpShape, reifyDimOrConstant
   HipOps.td                -- per-op declares
                               `DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>`
@@ -264,13 +264,13 @@ supplied `emitError` callable on shape mismatch.
 
 ```cpp
 // HipShapeUtils.h
-SmallVector<int64_t> broadcastShapes(
+SmallVector<int64_t> inferBroadcastShape(
     ArrayRef<int64_t> aShape, ArrayRef<int64_t> bShape,
     function_ref<InFlightDiagnostic()> emitError);
 ```
 
-If your op fits an existing helper (e.g. another contraction shape),
-just reuse it.
+If your op fits an existing helper (e.g. another matmul-shaped op, or
+another op with the same broadcast rules), just reuse it.
 
 ### 2. Declare the interface in TableGen
 

--- a/docs/design/hip-shape-inference.md
+++ b/docs/design/hip-shape-inference.md
@@ -224,6 +224,24 @@ through the alloc / pool sizing computations and removes spurious
 The pass is idempotent: a second invocation that finds no further
 refinements is a no-op.
 
+### Current pipeline status (intentionally dormant)
+
+`--hip-infer-shapes` is **registered for `hip-mlir-opt` (so LIT can
+exercise it) but NOT yet inserted into `lib/Dialect/Transforms/Pipelines.cpp`**.
+Reason: `hip.matmul` is the only op carrying
+`ReifyRankedShapedTypeOpInterface` today, so wiring the pass into the
+production pipeline now would walk every function for one-op coverage
+and yield no measurable refinement on the supported transformer
+models (whose matmul shapes are already fully static end-to-end after
+the symbolic-dim binding done in `MorphiZenEP::GetCapability`).
+
+The pass is intended to be enabled once a critical mass of HIP DPS ops
+(GQA, RmsNorm, SkipRmsNorm, Attention, RotaryEmbedding, ...) carry the
+interface. At that point the wiring is one line in
+`buildOnnxToHipPipeline` between `convert-onnx-to-hip` and
+`one-shot-bufferize`. Until then, the infrastructure is exercised
+exclusively through the LIT suite.
+
 ## How to add a new op
 
 A new HIP op participates in shape inference in **five** small edits,
@@ -339,6 +357,21 @@ matmul ones:
 
 The current first-pass coverage is intentionally narrow:
 
+* **`hip.matmul` rejects rank-1 operands.** The new verifier requires
+  both `A` and `B` to have rank ≥ 2. ONNX `MatMul` semantics permit
+  rank-1 operands (vector·matrix / matrix·vector) by implicitly
+  promoting them to rank-2 with a unit dim and stripping the unit dim
+  from the result. None of the supported transformer models exercise
+  this case (every matmul in the supported model set is rank ≥ 2 and
+  was rank ≥ 2 before this PR). For models that do, the right fix is
+  in `lib/Conversion/OnnxToHip/MatMulConversion.cpp`: insert a
+  `tensor.expand_shape` to rank-2 before constructing `hip.matmul`,
+  then `tensor.collapse_shape` the result. The runtime / lowering
+  paths assume rank ≥ 2 today (`MatmulLowering.cpp` indexes
+  `aShape[rank-2]` for M, `bShape[rank-1]` for N), so without ONNX-spec
+  promotion in the converter a rank-1 `onnx.MatMul` would have
+  produced a silently-wrong hipBLASLt call before this PR — the
+  verifier turns that latent miscompile into an explicit diagnostic.
 * **Producer refinement is `tensor.empty` only.** Adding refinement for
   other "shape-malleable" producers (`bufferization.alloc_tensor`, other
   HIP DPS ops) is a follow-up. The cleanest extension is to teach the

--- a/docs/design/hip-shape-inference.md
+++ b/docs/design/hip-shape-inference.md
@@ -360,42 +360,20 @@ matmul ones:
 
 ## Open extensions
 
-The current first-pass coverage is intentionally narrow:
+The recipe in [How to add a new op](#how-to-add-a-new-op) is the canonical
+guide for adding shape inference to additional HIP DPS ops. Per-op rollout,
+dialect generalisation, and backward dim-origin tracing across `func.return`
+are tracked outside this document.
 
-* **Op coverage.** Only `hip.matmul` carries
-  `ReifyRankedShapedTypeOpInterface` today. Each additional HIP DPS op
-  that gets a reify impl participates in the pipeline-level pass for
-  free (no `Pipelines.cpp` change). Priority order, by frequency in
-  observed transformer graphs: GQA, RmsNorm, SkipRmsNorm,
-  RotaryEmbedding, MatMulNBits, then everything else. The recipe in
-  [How to add a new op](#how-to-add-a-new-op) is the canonical guide.
-* **`hip.matmul` rejects rank-1 operands.** The new verifier requires
-  both `A` and `B` to have rank ≥ 2. ONNX `MatMul` semantics permit
-  rank-1 operands (vector·matrix / matrix·vector) by implicitly
-  promoting them to rank-2 with a unit dim and stripping the unit dim
-  from the result. None of the supported transformer models exercise
-  this case (every matmul in the supported model set is rank ≥ 2 and
-  was rank ≥ 2 before this PR). For models that do, the right fix is
-  in `lib/Conversion/OnnxToHip/MatMulConversion.cpp`: insert a
-  `tensor.expand_shape` to rank-2 before constructing `hip.matmul`,
-  then `tensor.collapse_shape` the result. The runtime / lowering
-  paths assume rank ≥ 2 today (`MatmulLowering.cpp` indexes
-  `aShape[rank-2]` for M, `bShape[rank-1]` for N), so without ONNX-spec
-  promotion in the converter a rank-1 `onnx.MatMul` would have
-  produced a silently-wrong hipBLASLt call before this PR — the
-  verifier turns that latent miscompile into an explicit diagnostic.
-* **Producer refinement is `tensor.empty` only.** Adding refinement for
-  other "shape-malleable" producers (`bufferization.alloc_tensor`, other
-  HIP DPS ops) is a follow-up. The cleanest extension is to teach the
-  pass a small dispatch table keyed on the producer's op name.
-* **Element-type refinement is opt-in.** `verifyHipOpShape(... ,
-  checkElementType=true)` exists but is off by default; dtype-changing
-  ops (cast, equal, less, not, and) keep their op-local element-type
-  checks.
-* **Control-flow boundaries.** The pass does not propagate refined
-  types into `scf.if` / `scf.while` block argument types. That requires
-  a separate fixed-point pass keyed on `BranchOpInterface`.
-* **Auto-derived builders.** Once a few more ops carry the interface,
-  it becomes attractive to add a "shape-aware" op builder
-  (`MyOp::create(b, loc, ctx, A, B)` which derives the output type
-  automatically). Today every caller passes the explicit outs type.
+### `hip.matmul` rejects rank-1 operands
+
+The verifier requires both `A` and `B` to have rank >= 2. ONNX `MatMul`
+permits rank-1 operands (vector-matrix / matrix-vector) via implicit
+unit-dim promotion and result unit-dim stripping. None of the currently
+supported transformer models exercise this case. For future models that
+do, the fix belongs in `lib/Conversion/OnnxToHip/MatMulConversion.cpp`:
+insert a `tensor.expand_shape` to rank-2 before constructing `hip.matmul`,
+then `tensor.collapse_shape` the result. Lowering (`MatmulLowering.cpp`)
+and runtime assume rank >= 2 today (indexing `aShape[rank-2]` and
+`bShape[rank-1]`); the verifier turns what would have been a
+silently-wrong hipBLASLt call into an explicit diagnostic.

--- a/docs/design/hip-shape-inference.md
+++ b/docs/design/hip-shape-inference.md
@@ -1,0 +1,303 @@
+<!--
+Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+Licensed under the MIT License.
+-->
+# HIP dialect shape inference
+
+This document explains how the HIP dialect represents and refines the
+shapes of its DPS (destination-passing-style) ops, and how to wire a new
+op into the same machinery.
+
+## Goals
+
+1. **Static verification.** Every HIP DPS op verifies that its `outs`
+   operand types are compatible with the shapes that fall out of the op
+   contract (matmul: `[..., M, K] @ [..., K, N] -> [..., M, N]`;
+   elementwise: NumPy broadcast over the inputs; etc).
+2. **Reify dynamic dims.** When a result dim is `?` (`kDynamic`) at the
+   type level but is computable in terms of operand dims, the op exposes
+   that knowledge through upstream
+   `ReifyRankedShapedTypeOpInterface::reifyResultShapes`.  Downstream
+   `--resolve-shaped-type-result-dims` then folds `tensor.dim` of the
+   result into either an `arith.constant` (static dims) or a
+   `tensor.dim` of the relevant input (dynamic dims).
+3. **Module-level refinement.** The optional `--hip-infer-shapes` pass
+   walks the module, calls `reifyResultShapes` on every op, and refines
+   `?` dims in result types in place — including the DPS `outs` operand's
+   `tensor.empty` producer, which is necessary to keep the IR
+   well-formed (DPS contract: `result_type == outs_operand_type`).
+
+These three layers share **one** static shape function per op
+(`inferContractionShape`, future `broadcastShapes`, ...). The verifier
+checks the result against the helper; reify lifts the helper's output
+into `OpFoldResult`s; the pass aggregates reify across the module.
+
+## Design rationale
+
+### Why `ReifyRankedShapedTypeOpInterface` and not a custom interface?
+
+Upstream MLIR has three relevant interfaces:
+
+| Interface | Static shape | Dynamic shape | Used by |
+|---|---|---|---|
+| `InferTypeOpInterface` | yes (`inferReturnTypes`) | no | Type inference at op build time |
+| `InferShapedTypeOpInterface` | yes (`inferReturnTypeComponents`) | partial | Some ops (e.g. mhlo) |
+| `ReifyRankedShapedTypeOpInterface` | implicit (IntegerAttr) | yes (Value) | linalg, tensor::Pad, tensor::Concat |
+
+For DPS ops the result type is **tautologically tied** to the `outs`
+operand type — you can't "infer" the result type from the inputs because
+the result type IS the outs type. `InferTypeOpInterface` is therefore
+not a fit: there's nothing for it to infer.
+
+`ReifyRankedShapedTypeOpInterface` neatly steps around this: it lets the
+op describe its result *shape* (per-dim `OpFoldResult`) without trying to
+synthesise a result *type*. Static dims fall out as `IntegerAttr`,
+dynamic dims fall out as `tensor.dim` (or `memref.dim`) of the operand
+they depend on. Linalg's named ops use exactly this pattern; we reuse
+both the interface and the LLVM-project test pass that drives it
+(`--resolve-shaped-type-result-dims`) so our infrastructure does not
+fork.
+
+We considered a custom `HipShapeInferenceOpInterface` early on. The
+draft would have added a `inferOutputShape(...)` static method returning
+`SmallVector<int64_t>`. That would have given us a clean separator
+between "static helper used by the verifier" and "dynamic helper used by
+the canonicaliser". We dropped it because:
+
+* Both jobs are already covered by upstream interfaces — the static
+  helper is a free function in `HipShapeUtils`, and the dynamic helper
+  is the upstream interface method.
+* Doubling up the surface adds a maintenance gradient with no payoff.
+* The upstream test-pass machinery is the test surface for free.
+
+### Why a dedicated `--hip-infer-shapes` pass?
+
+Upstream MLIR ships two related passes:
+
+* **`--reify-result-shapes`** (memref dialect, MLIR 22): only `tensor::Pad`
+  / `tensor::Concat`; skips DPS ops by design.
+* **`--infer-static-shapes`** (newer): handles all
+  `ReifyRankedShapedTypeOpInterface` ops, but is **not in the pinned
+  MLIR** and is not DPS-aware (it does not refine the `outs` operand's
+  producer to keep the type chain well-formed).
+
+`--hip-infer-shapes` adapts the same pattern as upstream but adds the
+DPS-aware producer refinement: when the outs operand is a `tensor.empty`,
+the pass rebuilds it with the new static shape and drops any dyn-dim
+operands that became static. Producers we don't know how to refine
+today (function args, other DPS ops higher in the chain) are skipped —
+the pass then leaves that result index at `?`.
+
+### Why DPS-aware?
+
+In a non-DPS world the pass could simply rewrite the op's result type
+and call it a day. DPS ops require `result_type == outs_operand_type`,
+so refining the result without matching the outs producer triggers a
+verifier error.  The simplest DPS-aware refinement we can do safely is
+to refine `tensor.empty` producers: that op is a pure constructor with
+trivial type semantics and its dyn-dim operand list maps 1:1 to the
+result's dynamic dims.
+
+For other producers (function args, results of an op we don't refine),
+the pass bails out at that result index and leaves the type as written.
+
+### Per-op refinement, not whole-chain
+
+When refining op `A`'s result, the pass inserts a `tensor.cast` back to
+the original type for every non-DPS-init use of the new value. That
+cast is a propagation BARRIER: a downstream consumer `B` that reads `A`
+through a non-DPS edge sees the OLD type at its `ins`, so `B`'s own
+`reifyResultShapes` runs against the OLD operand type. `B` can still
+refine its result, but only through the static dims its own helper can
+deduce locally — it does **not** transitively inherit `A`'s narrowing.
+
+This is intentional: a transitive narrowing scheme would require either
+retyping the cast (cascading into every downstream signature) or
+trusting that consumers tolerate a more-static `ins` (false in
+general). Per-op refinement is the local, terminating, verifier-safe
+choice. See `refine_chained_matmul` in
+`test/lit/Dialect/hip-infer-shapes.mlir` for the canonical example.
+
+That said, the "barrier" is leaky in a *good* way: when the consumer's
+`reifyResultShapes` materialises `tensor.dim %cast, i` via
+`tensor::getMixedSize` (which uses `createOrFold`), upstream
+`tensor::DimOp::fold` looks through the cast and resolves to the
+underlying static size. So a chained DPS op whose operand is a cast of
+an already-refined value will still recover the static dim via the dim
+op, **without** giving up the cast-as-barrier on the `ins` edge type.
+The chained-matmul test exercises exactly this case.
+
+### Upstream helpers we lean on
+
+Where the implementation could be expressed via either a bespoke helper
+or an upstream one, it consistently picks upstream:
+
+| Need | Upstream helper |
+|---|---|
+| Constant-int extraction from `OpFoldResult` | `mlir::getConstantIntValue(OpFoldResult)` (`mlir/Dialect/Utils/StaticValueUtils.h`) |
+| Re-typing a `RankedTensorType` while preserving encoding | `RankedTensorType::clone(ArrayRef<int64_t>)` (`mlir/IR/BuiltinTypeInterfaces.td` shared decl) |
+| `tensor.dim` of a value at a static-or-dynamic dim | `tensor::getMixedSize(OpBuilder &, Location, Value, int64_t)` |
+| IR mutation through an observable rewriter | `mlir::IRRewriter` (matches upstream `--reify-result-shapes`) |
+
+This keeps drift between the HIP pass and upstream `--reify-result-shapes`
+to a minimum: when MLIR upgrades drop a more general successor (e.g.
+`--infer-static-shapes`), retiring our pass should be mostly a matter of
+substituting it into `Pipelines.cpp` and re-running the LIT suite.
+
+## Component layout
+
+```text
+include/hip/Dialect/IR/
+  HipShapeUtils.h          -- public API: inferContractionShape,
+                              verifyHipOpShape, reifyDimOrConstant
+  HipOps.td                -- per-op declares
+                              `DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>`
+                              and `let hasVerifier = 1`
+
+lib/Dialect/IR/
+  HipShapeUtils.cpp        -- implementations + diagnostics
+  HipDialect.cpp           -- per-op `verify()` + `reifyResultShapes()`
+
+include/hip/Dialect/Transforms/
+  Passes.td                -- `def InferShapesPass` registration
+
+lib/Dialect/Transforms/
+  InferShapesPass.cpp      -- module-level walk; DPS-aware refinement
+
+test/lit/Dialect/
+  hip-matmul-shape-verifier.mlir   -- verifier positive + negative
+  hip-matmul-reify-shapes.mlir     -- driven by upstream
+                                       `--resolve-shaped-type-result-dims`
+  hip-infer-shapes.mlir            -- propagation pass behaviour
+```
+
+## Pipeline placement
+
+`--hip-infer-shapes` is **optional** and runs on `mlir::ModuleOp`. The
+recommended placement is between `convert-onnx-to-hip` and
+`one-shot-bufferize`:
+
+```text
+simplify-onnx -> hip-add-context-arg -> convert-onnx-to-hip
+              -> hip-infer-shapes (NEW, optional)
+              -> one-shot-bufferize -> ...
+```
+
+Refining tensor result types BEFORE bufferize propagates static dims
+through the alloc / pool sizing computations and removes spurious
+`memref.dim` ops at the top of the function.
+
+The pass is idempotent: a second invocation that finds no further
+refinements is a no-op.
+
+## How to add a new op
+
+A new HIP op participates in shape inference in **three** small edits.
+The matmul wiring is the canonical reference; the same pattern applies
+to every DPS compute op.
+
+### 1. Add a shape helper (or reuse one)
+
+In [HipShapeUtils.h](../../include/hip/Dialect/IR/HipShapeUtils.h), add a free
+function that takes the operand shapes (and any op-specific attrs) and
+returns the expected output shape vector. Use `ShapedType::kDynamic` for
+dims that the helper cannot compute, and emit a diagnostic via the
+supplied `emitError` callable on shape mismatch.
+
+```cpp
+// HipShapeUtils.h
+SmallVector<int64_t> broadcastShapes(
+    ArrayRef<int64_t> aShape, ArrayRef<int64_t> bShape,
+    function_ref<InFlightDiagnostic()> emitError);
+```
+
+If your op fits an existing helper (e.g. another contraction shape),
+just reuse it.
+
+### 2. Declare the interface in TableGen
+
+In [HipOps.td](../../include/hip/Dialect/IR/HipOps.td):
+
+```tablegen
+def Hip_MyOp : Hip_DpsOp<"my_op", [
+    DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>
+  ]> {
+  // ... arguments, assemblyFormat ...
+  let hasVerifier = 1;
+}
+```
+
+`Hip_DpsOp` already declares `DestinationStyleOpInterface` and emits the
+`Variadic<AnyRankedTensor>:$result_tensors` result for tensor mode.
+
+### 3. Implement `verify()` and `reifyResultShapes()`
+
+In [HipDialect.cpp](../../lib/Dialect/IR/HipDialect.cpp), add the two methods
+next to your existing `getDpsInitsMutable()` / `getEffects()` impls:
+
+```cpp
+LogicalResult MyOp::verify() {
+  // Cross-cutting DPS contract check first.
+  if (failed(verifyDpsComputeOp(*this, {getA(), getB(), getOutput()},
+                                /*numInits=*/1)))
+    return failure();
+
+  // Static shape check via the shared helper. Empty result vector means
+  // the helper already issued a diagnostic.
+  return mlir::hip::verifyHipOpShape(
+      *this, [&]() -> SmallVector<SmallVector<int64_t>> {
+        SmallVector<int64_t> outShape = mlir::hip::broadcastShapes(
+            getShapeOf(getA()), getShapeOf(getB()),
+            [&]() { return this->emitOpError(); });
+        if (outShape.empty())
+          return {};
+        return {std::move(outShape)};
+      });
+}
+
+LogicalResult MyOp::reifyResultShapes(
+    OpBuilder &b, ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
+  if (getNumResults() == 0)
+    return failure(); // memref mode -- no tensor result
+  // ... compute outShape via the same helper, then for each dim:
+  //       reifyDimOrConstant(b, loc, outShape[d], operand, operandDimIdx)
+  // ... reifiedReturnShapes.assign({std::move(dims)});
+  return success();
+}
+```
+
+`reifyDimOrConstant` returns `IntegerAttr` when the dim is static and a
+`tensor.dim` / `memref.dim` otherwise, mirroring upstream
+`linalg::createFoldedDimOp`.
+
+### 4. (Optional) LIT coverage
+
+Add three small LIT tests under `test/lit/Dialect/`, modelled on the
+matmul ones:
+
+* `hip-<op>-shape-verifier.mlir`: positive + negative shape checks via
+  `--verify-diagnostics`.
+* `hip-<op>-reify-shapes.mlir`: drive `--resolve-shaped-type-result-dims`
+  and FileCheck that `tensor.dim` of the op result folds correctly.
+* (Optional) extend `test/lit/Dialect/hip-infer-shapes.mlir` with a case
+  that exercises `--hip-infer-shapes` on a chain involving the new op.
+
+## Open extensions
+
+The current first-pass coverage is intentionally narrow:
+
+* **Producer refinement is `tensor.empty` only.** Adding refinement for
+  other "shape-malleable" producers (`bufferization.alloc_tensor`, other
+  HIP DPS ops) is a follow-up. The cleanest extension is to teach the
+  pass a small dispatch table keyed on the producer's op name.
+* **Element-type refinement is opt-in.** `verifyHipOpShape(... ,
+  checkElementType=true)` exists but is off by default; dtype-changing
+  ops (cast, equal, less, not, and) keep their op-local element-type
+  checks.
+* **Control-flow boundaries.** The pass does not propagate refined
+  types into `scf.if` / `scf.while` block argument types. That requires
+  a separate fixed-point pass keyed on `BranchOpInterface`.
+* **Auto-derived builders.** Once a few more ops carry the interface,
+  it becomes attractive to add a "shape-aware" op builder
+  (`MyOp::create(b, loc, ctx, A, B)` which derives the output type
+  automatically). Today every caller passes the explicit outs type.

--- a/docs/design/hip-shape-inference.md
+++ b/docs/design/hip-shape-inference.md
@@ -155,8 +155,12 @@ include/hip/Dialect/IR/
                               and `let hasVerifier = 1`
 
 lib/Dialect/IR/
-  HipShapeUtils.cpp        -- implementations + diagnostics
-  HipDialect.cpp           -- per-op `verify()` + `reifyResultShapes()`
+  HipShapeUtils.cpp                -- implementations + diagnostics
+  HipDialect.cpp                   -- per-op `verify()`, `getEffects()`,
+                                      `getDpsInitsMutable()`, custom
+                                      builders / printers / parsers
+  HipReifyResultShapesImpl.cpp     -- per-op `reifyResultShapes()`,
+                                      one `// <OpName>` section per op
 
 include/hip/Dialect/Transforms/
   Passes.td                -- `def InferShapesPass` registration
@@ -170,6 +174,36 @@ test/lit/Dialect/
                                        `--resolve-shaped-type-result-dims`
   hip-infer-shapes.mlir            -- propagation pass behaviour
 ```
+
+### Why the per-interface split
+
+`reifyResultShapes` lives in its own translation unit because it grows
+on a different schedule from the rest of an op's machinery. Verifiers,
+`getEffects`, `getDpsInitsMutable`, and op-local builders touch the op
+once and rarely need maintenance after that. Reify implementations are
+non-trivial shape arithmetic that benefits from being read alongside
+each other (every dynamic-shape op solves a small variant of the same
+"lift static dims to `IntegerAttr`, dynamic dims to `tensor.dim` of the
+right operand" problem). Keeping them together — and out of the
+already-large `HipDialect.cpp` — makes both files easier to navigate as
+the dialect picks up shape-inference support for more ops.
+
+This mirrors IREE's LinalgExt convention (`LinalgExtOps.cpp` keeps
+verifiers / builders; `TilingInterfaceImpl.cpp` and
+`AggregatedOpInterfaceImpl.cpp` keep per-interface impls), which in
+turn descends from the same upstream split between
+`mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp` (op identity) and the
+various interface-impl `.cpp` files under
+`mlir/lib/Dialect/Linalg/Transforms/`. The interface impls are
+**member functions, not external models** — `attachInterface` /
+`ExternalModel<>` is only needed when implementing an interface from
+*outside* the op's owning dialect.
+
+When a future interface accumulates enough impls to deserve the same
+treatment (e.g. a dialect-defined op interface, a tiling interface, or
+a bufferization interface), follow the same pattern: a new
+`Hip<InterfaceName>Impl.cpp` next to the existing files, sectioned by
+op name, listed in `lib/Dialect/IR/CMakeLists.txt`.
 
 ## Pipeline placement
 
@@ -192,9 +226,10 @@ refinements is a no-op.
 
 ## How to add a new op
 
-A new HIP op participates in shape inference in **three** small edits.
-The matmul wiring is the canonical reference; the same pattern applies
-to every DPS compute op.
+A new HIP op participates in shape inference in **five** small edits,
+spread across the three files identified in the layout above. The
+matmul wiring is the canonical reference; the same pattern applies to
+every DPS compute op.
 
 ### 1. Add a shape helper (or reuse one)
 
@@ -230,10 +265,11 @@ def Hip_MyOp : Hip_DpsOp<"my_op", [
 `Hip_DpsOp` already declares `DestinationStyleOpInterface` and emits the
 `Variadic<AnyRankedTensor>:$result_tensors` result for tensor mode.
 
-### 3. Implement `verify()` and `reifyResultShapes()`
+### 3. Implement `verify()` in `HipDialect.cpp`
 
-In [HipDialect.cpp](../../lib/Dialect/IR/HipDialect.cpp), add the two methods
-next to your existing `getDpsInitsMutable()` / `getEffects()` impls:
+In [HipDialect.cpp](../../lib/Dialect/IR/HipDialect.cpp), under the
+`// MyOp` section banner alongside the existing
+`getDpsInitsMutable()` / `getEffects()`:
 
 ```cpp
 LogicalResult MyOp::verify() {
@@ -254,13 +290,26 @@ LogicalResult MyOp::verify() {
         return {std::move(outShape)};
       });
 }
+```
+
+### 4. Implement `reifyResultShapes()` in `HipReifyResultShapesImpl.cpp`
+
+In [HipReifyResultShapesImpl.cpp](../../lib/Dialect/IR/HipReifyResultShapesImpl.cpp),
+add a new `// MyOp` section banner at the bottom of the file and place
+the impl underneath it:
+
+```cpp
+//===----------------------------------------------------------------------===//
+// MyOp
+//===----------------------------------------------------------------------===//
 
 LogicalResult MyOp::reifyResultShapes(
     OpBuilder &b, ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
   if (getNumResults() == 0)
     return failure(); // memref mode -- no tensor result
-  // ... compute outShape via the same helper, then for each dim:
-  //       reifyDimOrConstant(b, loc, outShape[d], operand, operandDimIdx)
+  // ... compute outShape via the same helper used in verify(), then for
+  //     each dim: reifyDimOrConstant(b, loc, outShape[d], operand,
+  //                                  operandDimIdx)
   // ... reifiedReturnShapes.assign({std::move(dims)});
   return success();
 }
@@ -270,7 +319,11 @@ LogicalResult MyOp::reifyResultShapes(
 `tensor.dim` / `memref.dim` otherwise, mirroring upstream
 `linalg::createFoldedDimOp`.
 
-### 4. (Optional) LIT coverage
+The interface declaration is already in TableGen (step 2), so no
+header / `attachInterface` changes are needed — the linker resolves the
+member function to whichever `.cpp` file defines it.
+
+### 5. (Optional) LIT coverage
 
 Add three small LIT tests under `test/lit/Dialect/`, modelled on the
 matmul ones:

--- a/include/hip/Dialect/IR/CMakeLists.txt
+++ b/include/hip/Dialect/IR/CMakeLists.txt
@@ -13,6 +13,17 @@ mlir_tablegen(HipTypes.h.inc -gen-typedef-decls -typedefs-dialect=hip)
 mlir_tablegen(HipTypes.cpp.inc -gen-typedef-defs -typedefs-dialect=hip)
 add_public_tablegen_target(HipTypesIncGen)
 
+# HipDpsOpInterface: shared reify default for HIP DPS ops. Generated
+# before HipOps so ops can reference the interface in their TableGen
+# trait list. The `.h.inc` carries the interface class declaration and
+# the `.cpp.inc` carries the trait/concept method bindings; this file
+# pairs with `lib/Dialect/IR/HipDpsOpInterface.cpp` which includes the
+# `.cpp.inc` and provides the default `reifyResultShapes` body.
+set(LLVM_TARGET_DEFINITIONS HipDpsOpInterface.td)
+mlir_tablegen(HipDpsOpInterface.h.inc -gen-op-interface-decls)
+mlir_tablegen(HipDpsOpInterface.cpp.inc -gen-op-interface-defs)
+add_public_tablegen_target(HipDpsOpInterfaceIncGen)
+
 set(LLVM_TARGET_DEFINITIONS HipOps.td)
 mlir_tablegen(HipOps.h.inc -gen-op-decls)
 mlir_tablegen(HipOps.cpp.inc -gen-op-defs)

--- a/include/hip/Dialect/IR/HipDialect.h
+++ b/include/hip/Dialect/IR/HipDialect.h
@@ -20,8 +20,9 @@
 #define GET_TYPEDEF_CLASSES
 #include "hip/Dialect/IR/HipTypes.h.inc"
 
-// HipDpsOpInterface declares the `HipDpsOp` interface class. Must be
-// included before HipOps.h.inc so per-op definitions can reference it.
+// Generated header for the `HipDpsOp` C++ interface class (TableGen def
+// `HipDpsOpInterface`). Must precede HipOps.h.inc — every Hip_DpsOp's
+// generated declaration references `HipDpsOp::Trait`.
 #include "hip/Dialect/IR/HipDpsOpInterface.h.inc"
 
 #define GET_OP_CLASSES

--- a/include/hip/Dialect/IR/HipDialect.h
+++ b/include/hip/Dialect/IR/HipDialect.h
@@ -12,6 +12,7 @@
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/IR/Types.h"
 #include "mlir/Interfaces/DestinationStyleOpInterface.h"
+#include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
 #include "hip/Dialect/IR/HipDialect.h.inc"

--- a/include/hip/Dialect/IR/HipDialect.h
+++ b/include/hip/Dialect/IR/HipDialect.h
@@ -20,6 +20,10 @@
 #define GET_TYPEDEF_CLASSES
 #include "hip/Dialect/IR/HipTypes.h.inc"
 
+// HipDpsOpInterface declares the `HipDpsOp` interface class. Must be
+// included before HipOps.h.inc so per-op definitions can reference it.
+#include "hip/Dialect/IR/HipDpsOpInterface.h.inc"
+
 #define GET_OP_CLASSES
 #include "hip/Dialect/IR/HipOps.h.inc"
 

--- a/include/hip/Dialect/IR/HipDpsOpInterface.td
+++ b/include/hip/Dialect/IR/HipDpsOpInterface.td
@@ -1,0 +1,49 @@
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+
+#ifndef HIP_DPS_OP_INTERFACE
+#define HIP_DPS_OP_INTERFACE
+
+include "mlir/IR/OpBase.td"
+include "mlir/Interfaces/DestinationStyleOpInterface.td"
+
+def HipDpsOpInterface : OpInterface<"HipDpsOp", [DestinationStyleOpInterface]> {
+  let description = [{
+    Marker interface for HIP destination-passing-style compute ops. Carries
+    a single shared default `reifyResultShapes` body that walks
+    `DestinationStyleOpInterface::getDpsInits()` and lifts each init
+    operand's runtime shape via `tensor::getMixedSizes` (tensor mode) or
+    `memref::getMixedSizes` (memref mode). Ops with a tighter shape
+    contract -- e.g. matmul where the result shape can be computed from
+    `A.shape[-2]` / `B.shape[-1]` rather than from the outs operand -- opt
+    out by setting `autoReify=0` on `Hip_DpsOp` and providing a per-op
+    override.
+
+    The interface owns the default body in a sibling `.cpp` file, and
+    the per-op `ReifyRankedShapedTypeOpInterface::reifyResultShapes` is
+    a 3-line dispatcher auto-emitted from `Hip_DpsOp`'s
+    `extraClassDefinition`.
+  }];
+
+  let cppNamespace = "::mlir::hip";
+
+  let extraClassDeclaration = [{
+    /// Default reify implementation. Returns a per-result vector of
+    /// `OpFoldResult` -- static dims as `IntegerAttr`, dynamic dims as
+    /// `tensor.dim` / `memref.dim` of the corresponding outs operand.
+    /// Folds through `tensor.cast` because `tensor::DimOp::fold` peels
+    /// casts (via `foldTensorCast`) and the `DimOfCastOp` canonicalizer
+    /// rewrites `dim(cast(x), i)` into `dim(x, i)`. As a result, chained
+    /// refinement still recovers already-narrowed dims even across the
+    /// per-op refinement barrier (a `tensor.cast` on non-DPS-init uses)
+    /// inserted by `--hip-infer-shapes`. The cast peel is performed by
+    /// the folder/canonicalizer, not by `--hip-infer-shapes` itself.
+    ::mlir::LogicalResult reifyResultShapes(
+        ::mlir::OpBuilder &b,
+        ::mlir::ReifiedRankedShapedTypeDims &reifiedReturnShapes);
+  }];
+}
+
+#endif // HIP_DPS_OP_INTERFACE

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -320,11 +320,10 @@ def Hip_MatmulOp : Hip_DpsOp<"matmul", [
       output: [broadcast(A.batch, B.batch), M, N]
 
     `?` (kDynamic) is permitted on any dim and behaves as a wildcard for
-    verification; `reifyResultShapes` lifts dynamic dims into `tensor.dim` /
-    `memref.dim` of the corresponding operand so downstream
-    `--resolve-shaped-type-result-dims` can fold `tensor.dim` of the
-    `result_tensors` value to a concrete SSA dim. See
-    [docs/design/hip-shape-inference.md](docs/design/hip-shape-inference.md).
+    verification; `reifyResultShapes` lifts dynamic dims into `tensor.dim`
+    / `memref.dim` of the corresponding operand. See
+    [docs/design/hip-shape-inference.md](docs/design/hip-shape-inference.md)
+    for the dim-source contract and the consuming pipeline.
 
     Unlike hip.gemm, this has no alpha/beta/transA/transB/bias — it maps
     directly to onnx.MatMul semantics.

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -9,6 +9,7 @@
 include "hip/Dialect/IR/HipDialect.td"
 include "hip/Dialect/IR/HipTypes.td"
 include "mlir/Interfaces/DestinationStyleOpInterface.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/OpBase.td"
 include "mlir/IR/SymbolInterfaces.td"
@@ -301,13 +302,29 @@ def Hip_ConvOp : Hip_DpsOp<"conv"> {
 
 // ===== hipBLASLt ops =========================================================
 
-def Hip_MatmulOp : Hip_DpsOp<"matmul"> {
+def Hip_MatmulOp : Hip_DpsOp<"matmul", [
+    DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface,
+      ["reifyResultShapes"]>
+  ]> {
   let summary = "Matrix multiplication (supports batched N-D x N-D)";
   let description = [{
     Performs matrix multiplication: output = A @ B
-    Supports batched operation (leading dimensions are batch dimensions).
+    Supports batched operation (leading dimensions are batch dimensions
+    with NumPy-style broadcast).
 
     Uses destination-passing style: output buffer is provided as argument.
+
+    Shape contract:
+      A:      [..., M, K]
+      B:      [..., K, N]
+      output: [broadcast(A.batch, B.batch), M, N]
+
+    `?` (kDynamic) is permitted on any dim and behaves as a wildcard for
+    verification; `reifyResultShapes` lifts dynamic dims into `tensor.dim` /
+    `memref.dim` of the corresponding operand so downstream
+    `--resolve-shaped-type-result-dims` can fold `tensor.dim` of the
+    `result_tensors` value to a concrete SSA dim. See
+    [docs/design/hip-shape-inference.md](docs/design/hip-shape-inference.md).
 
     Unlike hip.gemm, this has no alpha/beta/transA/transB/bias — it maps
     directly to onnx.MatMul semantics.
@@ -339,6 +356,8 @@ def Hip_MatmulOp : Hip_DpsOp<"matmul"> {
     `outs` `(` $output `:` type($output) `)`
     attr-dict (`:` type($result_tensors)^)?
   }];
+
+  let hasVerifier = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -7,6 +7,7 @@
 #define HIP_OPS
 
 include "hip/Dialect/IR/HipDialect.td"
+include "hip/Dialect/IR/HipDpsOpInterface.td"
 include "hip/Dialect/IR/HipTypes.td"
 include "mlir/Interfaces/DestinationStyleOpInterface.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
@@ -18,16 +19,113 @@ class Hip_Op<string mnemonic, list<Trait> traits = []> :
     Op<Hip_Dialect, mnemonic, traits>;
 
 // Base class for all HIP destination-passing-style (DPS) compute ops.
-// Provides MemoryEffectsOpInterface, DestinationStyleOpInterface, and the
-// Variadic<AnyRankedTensor>:$result_tensors result (non-empty only at the
-// tensor level; empty after bufferization).
-class Hip_DpsOp<string mnemonic, list<Trait> traits = []> :
+//
+// Provides:
+//   - MemoryEffectsOpInterface
+//   - DestinationStyleOpInterface (`getDpsInitsMutable` is op-defined)
+//   - HipDpsOpInterface (carries the shared default `reifyResultShapes`)
+//   - ReifyRankedShapedTypeOpInterface (decl; body auto-emitted below)
+//   - Variadic<AnyRankedTensor>:$result_tensors (empty in memref mode)
+//
+// `extraClassDefinition` auto-emits per-op dispatchers via TableGen so
+// the bulk of HIP DPS ops contribute zero per-op `.cpp` boilerplate for
+// shape inference. The dispatchers are gated by `autoReify` /
+// `autoInfer` bits so bespoke ops (matmul, gemm, ...) opt out and
+// provide their own per-op bodies. See
+// `docs/design/hip-shape-inference.md` for the rationale.
+//
+// Parameters:
+//   `outsAccessor`  : ODS-generated accessor name for the DPS init
+//                     operand, used by the auto-emitted `inferReturnTypes`
+//                     body to read the result type from the outs operand.
+//                     Default `"Output"` matches the 37 ops whose outs is
+//                     named `$output`. Ops with `$y` pass `"Y"`, etc.
+//   `autoReify`     : when 1, emit a per-op `reifyResultShapes` that
+//                     forwards to the `HipDpsOpInterface` default. When 0,
+//                     the op author writes their own body in
+//                     `HipReifyResultShapesImpl.cpp`.
+//   `autoInfer`     : when 1, emit a per-op `inferReturnTypes` that
+//                     pushes the outs operand's tensor type into
+//                     `results` (or pushes nothing for memref mode, so
+//                     memref-mode ops correctly produce zero SSA
+//                     results). Default 0 on #260 -- only matmul opts
+//                     in as the worked example -- and flipped to 1 in
+//                     #262 so every single-result Hip_DpsOp inherits
+//                     it. `autoReify` and `autoInfer` are independent:
+//                     ops with bespoke runtime reify (matmul, gemm,
+//                     qmoe, matmul_nbits) still benefit from
+//                     auto-emitted `inferReturnTypes` because at
+//                     construction time the converter passes a typed
+//                     outs whose tensor type already encodes the result
+//                     shape.
+//   `declareInfer`  : when 1, declare `InferTypeOpInterface` on the op
+//                     so ODS emits the inferred-type `Op::create`
+//                     overload (lets converter callsites drop the
+//                     explicit `resultType` argument). Default 0 on
+//                     #260 -- matmul opts in -- and flipped to 1 in
+//                     #262 in lockstep with `autoInfer`.
+//
+// Generated dispatcher example (matmul, after Phase 1):
+//   - `extraClassDefinition` produces:
+//       LogicalResult MatmulOp::reifyResultShapes(...) {  // omitted: autoReify=0
+//       LogicalResult MatmulOp::inferReturnTypes(...) {   // emitted: autoInfer=1
+//         MatmulOp::Adaptor adaptor(operands, attrs, props, regions);
+//         Value outs = adaptor.getOutput();
+//         if (auto t = dyn_cast<RankedTensorType>(outs.getType()))
+//           results.push_back(t);
+//         return success();
+//       }
+//   - The reify body for matmul is hand-written in
+//     `HipReifyResultShapesImpl.cpp` (recovers M/K/N from operand
+//     shapes via `inferMatmulShape`, then `reifyDimOrConstant` per
+//     dim).
+class Hip_DpsOp<string mnemonic,
+                list<Trait> traits = [],
+                string outsAccessor = "Output",
+                bit autoReify = 1,
+                bit autoInfer = 0,
+                bit declareInfer = 0> :
     Hip_Op<mnemonic, !listconcat([
-      DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-      DeclareOpInterfaceMethods<DestinationStyleOpInterface,
-                                ["getDpsInitsMutable"]>
-    ], traits)> {
+        DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+        DeclareOpInterfaceMethods<DestinationStyleOpInterface,
+                                  ["getDpsInitsMutable"]>,
+        HipDpsOpInterface,
+        DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface,
+                                  ["reifyResultShapes"]>
+      ],
+      !if(declareInfer,
+          [DeclareOpInterfaceMethods<InferTypeOpInterface,
+                                     ["inferReturnTypes"]>],
+          []),
+      traits)> {
   let results = (outs Variadic<AnyRankedTensor>:$result_tensors);
+  let extraClassDefinition = !strconcat(
+    !if(autoReify, [{
+      ::mlir::LogicalResult $cppClass::reifyResultShapes(
+          ::mlir::OpBuilder &b,
+          ::mlir::ReifiedRankedShapedTypeDims &reified) {
+        return ::llvm::cast<::mlir::hip::HipDpsOp>(getOperation())
+            .reifyResultShapes(b, reified);
+      }
+    }], ""),
+    !if(autoInfer, !strconcat([{
+      ::llvm::LogicalResult $cppClass::inferReturnTypes(
+          ::mlir::MLIRContext *,
+          ::std::optional<::mlir::Location>,
+          ::mlir::ValueRange operands,
+          ::mlir::DictionaryAttr attrs,
+          ::mlir::OpaqueProperties props,
+          ::mlir::RegionRange regions,
+          ::llvm::SmallVectorImpl<::mlir::Type> &results) {
+        $cppClass::Adaptor adaptor(operands, attrs, props, regions);
+        ::mlir::Value outs = adaptor.get}], outsAccessor, [{();
+        if (auto t = ::llvm::dyn_cast<::mlir::RankedTensorType>(
+                outs.getType()))
+          results.push_back(t);
+        return ::mlir::success();
+      }
+    }]), "")
+  );
 }
 
 // Accepts both ranked tensor (pre-bufferization) and memref (post-bufferization).
@@ -302,10 +400,22 @@ def Hip_ConvOp : Hip_DpsOp<"conv"> {
 
 // ===== hipBLASLt ops =========================================================
 
-def Hip_MatmulOp : Hip_DpsOp<"matmul", [
-    DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface,
-      ["reifyResultShapes"]>
-  ]> {
+// `autoReify=0` opts out of the shared default reify body: matmul
+// recovers its result dims from operand shapes (M, K from A; K, N from
+// B) rather than echoing the outs shape, so the body is hand-written
+// in `HipReifyResultShapesImpl.cpp`. `autoInfer=1, declareInfer=1`
+// keep the op on the parameterized auto-emit path for
+// `inferReturnTypes` because at construction time the converter passes
+// a typed outs operand whose tensor type already encodes the result
+// shape -- the auto-emitted body just reads it back, so there is no
+// reason to write that boilerplate by hand. Matmul is the worked
+// example for the orthogonality of these two layers on #260; #262
+// extends the same split to gemm / qmoe / matmul_nbits.
+def Hip_MatmulOp : Hip_DpsOp<"matmul", /*traits=*/[],
+                             /*outsAccessor=*/"Output",
+                             /*autoReify=*/0,
+                             /*autoInfer=*/1,
+                             /*declareInfer=*/1> {
   let summary = "Matrix multiplication (supports batched N-D x N-D)";
   let description = [{
     Performs matrix multiplication: output = A @ B

--- a/include/hip/Dialect/IR/HipShapeUtils.h
+++ b/include/hip/Dialect/IR/HipShapeUtils.h
@@ -44,14 +44,12 @@ inferContractionShape(ArrayRef<int64_t> aShape, ArrayRef<int64_t> bShape,
 /// shape-arithmetic helper already emitted a diagnostic — this function
 /// returns `failure()` without re-emitting.
 ///
-/// When `checkElementType` is true, also asserts that every init operand's
-/// element type equals the first DPS-input operand's element type. Opt-in:
-/// dtype-changing ops (cast, equal, less, not, and) keep their own
-/// element-type checks in their op-local verifiers.
+/// Element-type checks are intentionally not handled here: dtype-changing
+/// ops (cast, equal, less, not, and) keep their own element-type checks in
+/// their op-local verifiers.
 LogicalResult verifyHipOpShape(
     Operation *op,
-    function_ref<SmallVector<SmallVector<int64_t>>()> computeExpected,
-    bool checkElementType = false);
+    function_ref<SmallVector<SmallVector<int64_t>>()> computeExpected);
 
 /// Build an `OpFoldResult` for one dimension of a result:
 ///   - if `staticDim` is not `kDynamic`, returns `b.getIndexAttr(staticDim)`

--- a/include/hip/Dialect/IR/HipShapeUtils.h
+++ b/include/hip/Dialect/IR/HipShapeUtils.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#ifndef HIP_DIALECT_IR_HIP_SHAPE_UTILS_H
+#define HIP_DIALECT_IR_HIP_SHAPE_UTILS_H
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Support/LogicalResult.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/STLFunctionalExtras.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace mlir {
+namespace hip {
+
+/// Compute the shape of `A @ B` for a matmul / contraction with NumPy-style
+/// batch broadcast over the leading dims. Last two dims of `aShape` are
+/// `[M, K]`; last two dims of `bShape` are `[K, N]`. Leading dims are
+/// broadcast (right-aligned, missing dims treated as 1).
+///
+/// Returns the inferred shape on success. Returns an empty `SmallVector` and
+/// emits a diagnostic via `emitError` on rank-, contraction-K-, or
+/// batch-broadcast mismatch.
+///
+/// `ShapedType::kDynamic` is treated as a wildcard:
+///   - K_a or K_b dynamic -> contraction match passes (result K is dropped
+///     anyway).
+///   - Any batch dim dynamic -> result batch dim is `kDynamic`.
+///   - 1 broadcasts against any dim.
+SmallVector<int64_t>
+inferContractionShape(ArrayRef<int64_t> aShape, ArrayRef<int64_t> bShape,
+                      function_ref<InFlightDiagnostic()> emitError);
+
+/// Verify that the actual `outs` operand shapes of a DPS HIP op match the
+/// shapes returned by `computeExpected`. `op` must implement
+/// `DestinationStyleOpInterface`.
+///
+/// `computeExpected` is invoked once and must return one shape per init
+/// operand (== one per `OpResult` for tensor mode; same count for memref
+/// mode, just no SSA result). An empty outer vector signals that the
+/// shape-arithmetic helper already emitted a diagnostic — this function
+/// returns `failure()` without re-emitting.
+///
+/// When `checkElementType` is true, also asserts that every init operand's
+/// element type equals the first DPS-input operand's element type. Opt-in:
+/// dtype-changing ops (cast, equal, less, not, and) keep their own
+/// element-type checks in their op-local verifiers.
+LogicalResult verifyHipOpShape(
+    Operation *op,
+    function_ref<SmallVector<SmallVector<int64_t>>()> computeExpected,
+    bool checkElementType = false);
+
+/// Build an `OpFoldResult` for one dimension of a result:
+///   - if `staticDim` is not `kDynamic`, returns `b.getIndexAttr(staticDim)`
+///     (no IR emitted).
+///   - otherwise emits `tensor.dim` / `memref.dim` against `source` at
+///     `sourceDim`. The dim op folds to an `arith.constant` automatically
+///     when `source.getType()` has a static size at `sourceDim`.
+///
+/// Functional equivalent of upstream `linalg::createFoldedDimOp` (inlined to
+/// avoid pulling a linalg dependency into the HIP dialect IR library).
+OpFoldResult reifyDimOrConstant(OpBuilder &b, Location loc, int64_t staticDim,
+                                Value source, int64_t sourceDim);
+
+} // namespace hip
+} // namespace mlir
+
+#endif // HIP_DIALECT_IR_HIP_SHAPE_UTILS_H

--- a/include/hip/Dialect/IR/HipShapeUtils.h
+++ b/include/hip/Dialect/IR/HipShapeUtils.h
@@ -16,27 +16,32 @@
 namespace mlir {
 namespace hip {
 
-/// Compute the shape of `A @ B` for a matmul / contraction with NumPy-style
-/// batch broadcast over the leading dims. Last two dims of `aShape` are
-/// `[M, K]`; last two dims of `bShape` are `[K, N]`. Leading dims are
-/// broadcast (right-aligned, missing dims treated as 1).
+/// Compute the shape of `A @ B` for a matmul / contraction. Last two dims
+/// of `aShape` are `[M, K]`; last two dims of `bShape` are `[K, N]`.
 ///
-/// Returns the inferred shape on success. Returns an empty `SmallVector` and
-/// emits a diagnostic via `emitError` on rank-, contraction-K-, or
-/// batch-broadcast mismatch.
+/// Accepts only the subset of MatMul shape contracts that
+/// `MatMulConversion.cpp` + `MatmulLowering.cpp` execute correctly today:
+///   - 2D x 2D
+///   - ND x ND with same-rank batch dims (kDynamic-as-wildcard equality)
+///   - ND x 2D (rank-2 `B` re-used across all batches)
+///
+/// Rejected (would be miscompiled by codegen):
+///   - `B`'s rank > `A`'s rank  (codegen derives result rank from A)
+///   - mixed ranks where `B` is not exactly 2 (e.g. `[2,3,M,K] @ [3,K,N]`)
+///   - per-dim batch broadcasting (`1` vs `>1`); codegen takes A's batch
+///     value verbatim, so a static `1` against a static `>1` is wrong.
 ///
 /// `ShapedType::kDynamic` is treated as a wildcard:
-///   - K_a or K_b dynamic -> contraction match passes (result K is dropped
-///     anyway).
-///   - Batch dim broadcast follows NumPy / TF / ONNX MatMul semantics
-///     (delegated to `mlir::OpTrait::util::getBroadcastedShape`):
-///       * 1 broadcasts against any dim.
-///       * dynamic + static>1 -> static (the dynamic side must be 1 or
-///         match the static side at runtime per the broadcast contract;
-///         taking the static side is the strictly-correct tightening).
-///       * dynamic + dynamic -> dynamic.
-///       * static + static, equal -> static; unequal and neither is 1
-///         -> error.
+///   - K_a or K_b dynamic -> contraction match passes.
+///   - Batch dim equality: dynamic + static -> static; dynamic + dynamic
+///     -> dynamic; static + static must be equal.
+///
+/// Returns the inferred shape on success. Returns an empty `SmallVector`
+/// and emits a diagnostic via `emitError` on any contract violation.
+///
+/// Widening this contract requires matching widening in
+/// `MatMulConversion`, `MatmulLowering`, and the runtime's
+/// `STRIDED_BATCH_OFFSET` layout (zero stride for the broadcast side).
 SmallVector<int64_t>
 inferContractionShape(ArrayRef<int64_t> aShape, ArrayRef<int64_t> bShape,
                       function_ref<InFlightDiagnostic()> emitError);

--- a/include/hip/Dialect/IR/HipShapeUtils.h
+++ b/include/hip/Dialect/IR/HipShapeUtils.h
@@ -58,8 +58,9 @@ LogicalResult verifyHipOpShape(
 ///     `sourceDim`. The dim op folds to an `arith.constant` automatically
 ///     when `source.getType()` has a static size at `sourceDim`.
 ///
-/// Functional equivalent of upstream `linalg::createFoldedDimOp` (inlined to
-/// avoid pulling a linalg dependency into the HIP dialect IR library).
+/// Implemented inline (and not as a thin wrapper around any external
+/// helper) to keep the HIP dialect IR library's link-time dependency
+/// surface minimal.
 OpFoldResult reifyDimOrConstant(OpBuilder &b, Location loc, int64_t staticDim,
                                 Value source, int64_t sourceDim);
 

--- a/include/hip/Dialect/IR/HipShapeUtils.h
+++ b/include/hip/Dialect/IR/HipShapeUtils.h
@@ -28,8 +28,15 @@ namespace hip {
 /// `ShapedType::kDynamic` is treated as a wildcard:
 ///   - K_a or K_b dynamic -> contraction match passes (result K is dropped
 ///     anyway).
-///   - Any batch dim dynamic -> result batch dim is `kDynamic`.
-///   - 1 broadcasts against any dim.
+///   - Batch dim broadcast follows NumPy / TF / ONNX MatMul semantics
+///     (delegated to `mlir::OpTrait::util::getBroadcastedShape`):
+///       * 1 broadcasts against any dim.
+///       * dynamic + static>1 -> static (the dynamic side must be 1 or
+///         match the static side at runtime per the broadcast contract;
+///         taking the static side is the strictly-correct tightening).
+///       * dynamic + dynamic -> dynamic.
+///       * static + static, equal -> static; unequal and neither is 1
+///         -> error.
 SmallVector<int64_t>
 inferContractionShape(ArrayRef<int64_t> aShape, ArrayRef<int64_t> bShape,
                       function_ref<InFlightDiagnostic()> emitError);

--- a/include/hip/Dialect/IR/HipShapeUtils.h
+++ b/include/hip/Dialect/IR/HipShapeUtils.h
@@ -16,32 +16,27 @@
 namespace mlir {
 namespace hip {
 
-/// Compute the shape of `A @ B` for a matmul / contraction. Last two dims
-/// of `aShape` are `[M, K]`; last two dims of `bShape` are `[K, N]`.
+/// Compute the shape of `A @ B` for a matmul / contraction with NumPy-style
+/// batch broadcast over the leading dims. Last two dims of `aShape` are
+/// `[M, K]`; last two dims of `bShape` are `[K, N]`. Leading dims are
+/// broadcast (right-aligned, missing dims treated as 1).
 ///
-/// Accepts only the subset of MatMul shape contracts that
-/// `MatMulConversion.cpp` + `MatmulLowering.cpp` execute correctly today:
-///   - 2D x 2D
-///   - ND x ND with same-rank batch dims (kDynamic-as-wildcard equality)
-///   - ND x 2D (rank-2 `B` re-used across all batches)
-///
-/// Rejected (would be miscompiled by codegen):
-///   - `B`'s rank > `A`'s rank  (codegen derives result rank from A)
-///   - mixed ranks where `B` is not exactly 2 (e.g. `[2,3,M,K] @ [3,K,N]`)
-///   - per-dim batch broadcasting (`1` vs `>1`); codegen takes A's batch
-///     value verbatim, so a static `1` against a static `>1` is wrong.
+/// Returns the inferred shape on success. Returns an empty `SmallVector` and
+/// emits a diagnostic via `emitError` on rank-, contraction-K-, or
+/// batch-broadcast mismatch.
 ///
 /// `ShapedType::kDynamic` is treated as a wildcard:
-///   - K_a or K_b dynamic -> contraction match passes.
-///   - Batch dim equality: dynamic + static -> static; dynamic + dynamic
-///     -> dynamic; static + static must be equal.
-///
-/// Returns the inferred shape on success. Returns an empty `SmallVector`
-/// and emits a diagnostic via `emitError` on any contract violation.
-///
-/// Widening this contract requires matching widening in
-/// `MatMulConversion`, `MatmulLowering`, and the runtime's
-/// `STRIDED_BATCH_OFFSET` layout (zero stride for the broadcast side).
+///   - K_a or K_b dynamic -> contraction match passes (result K is dropped
+///     anyway).
+///   - Batch dim broadcast follows NumPy / TF / ONNX MatMul semantics
+///     (delegated to `mlir::OpTrait::util::getBroadcastedShape`):
+///       * 1 broadcasts against any dim.
+///       * dynamic + static>1 -> static (the dynamic side must be 1 or
+///         match the static side at runtime per the broadcast contract;
+///         taking the static side is the strictly-correct tightening).
+///       * dynamic + dynamic -> dynamic.
+///       * static + static, equal -> static; unequal and neither is 1
+///         -> error.
 SmallVector<int64_t>
 inferContractionShape(ArrayRef<int64_t> aShape, ArrayRef<int64_t> bShape,
                       function_ref<InFlightDiagnostic()> emitError);

--- a/include/hip/Dialect/IR/HipShapeUtils.h
+++ b/include/hip/Dialect/IR/HipShapeUtils.h
@@ -16,18 +16,17 @@
 namespace mlir {
 namespace hip {
 
-/// Compute the shape of `A @ B` for a matmul / contraction with NumPy-style
-/// batch broadcast over the leading dims. Last two dims of `aShape` are
-/// `[M, K]`; last two dims of `bShape` are `[K, N]`. Leading dims are
-/// broadcast (right-aligned, missing dims treated as 1).
+/// Compute the shape of `A @ B` for matmul with NumPy-style batch broadcast
+/// over the leading dims. Last two dims of `aShape` are `[M, K]`; last two
+/// dims of `bShape` are `[K, N]`. Leading dims are broadcast (right-aligned,
+/// missing dims treated as 1).
 ///
 /// Returns the inferred shape on success. Returns an empty `SmallVector` and
-/// emits a diagnostic via `emitError` on rank-, contraction-K-, or
-/// batch-broadcast mismatch.
+/// emits a diagnostic via `emitError` on rank-, K-, or batch-broadcast
+/// mismatch.
 ///
 /// `ShapedType::kDynamic` is treated as a wildcard:
-///   - K_a or K_b dynamic -> contraction match passes (result K is dropped
-///     anyway).
+///   - K_a or K_b dynamic -> K match passes (result K is dropped anyway).
 ///   - Batch dim broadcast follows NumPy / TF / ONNX MatMul semantics
 ///     (delegated to `mlir::OpTrait::util::getBroadcastedShape`):
 ///       * 1 broadcasts against any dim.
@@ -38,8 +37,8 @@ namespace hip {
 ///       * static + static, equal -> static; unequal and neither is 1
 ///         -> error.
 SmallVector<int64_t>
-inferContractionShape(ArrayRef<int64_t> aShape, ArrayRef<int64_t> bShape,
-                      function_ref<InFlightDiagnostic()> emitError);
+inferMatmulShape(ArrayRef<int64_t> aShape, ArrayRef<int64_t> bShape,
+                 function_ref<InFlightDiagnostic()> emitError);
 
 /// Verify that the actual `outs` operand shapes of a DPS HIP op match the
 /// shapes returned by `computeExpected`. `op` must implement

--- a/include/hip/Dialect/IR/HipShapeUtils.h
+++ b/include/hip/Dialect/IR/HipShapeUtils.h
@@ -51,16 +51,18 @@ LogicalResult verifyHipOpShape(
     Operation *op,
     function_ref<SmallVector<SmallVector<int64_t>>()> computeExpected);
 
-/// Build an `OpFoldResult` for one dimension of a result:
+/// Build an `OpFoldResult` for one dimension of a reify-callable op's
+/// result:
 ///   - if `staticDim` is not `kDynamic`, returns `b.getIndexAttr(staticDim)`
 ///     (no IR emitted).
-///   - otherwise emits `tensor.dim` / `memref.dim` against `source` at
-///     `sourceDim`. The dim op folds to an `arith.constant` automatically
-///     when `source.getType()` has a static size at `sourceDim`.
+///   - otherwise emits `tensor.dim` against `source` at `sourceDim`. The
+///     dim op folds to an `arith.constant` automatically when
+///     `source.getType()` has a static size at `sourceDim`.
 ///
-/// Implemented inline (and not as a thin wrapper around any external
-/// helper) to keep the HIP dialect IR library's link-time dependency
-/// surface minimal.
+/// `source` is required to have `RankedTensorType` -- the
+/// `ReifyRankedShapedTypeOpInterface` contract restricts its callers to
+/// ops with tensor results, so memref-typed sources cannot reach a reify
+/// path today.
 OpFoldResult reifyDimOrConstant(OpBuilder &b, Location loc, int64_t staticDim,
                                 Value source, int64_t sourceDim);
 

--- a/include/hip/Dialect/Transforms/Passes.td
+++ b/include/hip/Dialect/Transforms/Passes.td
@@ -270,6 +270,68 @@ def LowerAllocsPass : Pass<"hip-lower-allocs", "mlir::func::FuncOp"> {
   ];
 }
 
+def InferShapesPass : Pass<"hip-infer-shapes", "mlir::ModuleOp"> {
+  let summary = "Refine dynamic dims in HIP DPS op result types via "
+                "`ReifyRankedShapedTypeOpInterface`";
+  let description = [{
+    Walks every op that implements `ReifyRankedShapedTypeOpInterface` and
+    has at least one `RankedTensorType` result (memref-mode DPS ops are
+    skipped). For each such op, calls `reifyResultShapes` to discover
+    static dim values that the op contract knows but the IR types still
+    spell as `?`, and refines:
+
+      1. The DPS `outs` operand's producer result type, when the producer
+         is a `tensor.empty` -- the only zero-cost refinement we can do
+         today. The tensor.empty is rebuilt with the refined shape; any
+         dynamic dim operands that became static are dropped.
+      2. The op's own result type, in place.
+      3. Each consumer whose operand type no longer matches: a
+         `tensor.cast` is inserted on the use-edge to bridge the new
+         (more-static) type back to the original type. DPS consumers
+         that take the refined value as their `outs` operand are
+         deliberately NOT cast back -- they will be refined in turn on
+         the same module walk (topo-ordered by IR position).
+
+    Why DPS-aware
+    -------------
+    The upstream `--reify-result-shapes` pass (memref dialect, MLIR 22)
+    only handles `tensor::PadOp` / `tensor::ConcatOp` and skips DPS ops;
+    a generic upstream "infer static shapes" pass exists in main but is
+    not in the pinned MLIR. This pass closes the gap for HIP DPS ops:
+    the outs operand carries the result type by spec, so refining the
+    op's result without matching the outs operand's producer would
+    produce a verifier error.
+
+    Pipeline placement
+    ------------------
+    Optional, runs after `convert-onnx-to-hip` and before
+    `one-shot-bufferize`. Refining tensor result types BEFORE bufferize
+    propagates static dims through the alloc / pool sizing computations
+    and removes spurious `memref.dim` ops that the legalisation chain
+    would otherwise leave at the top of the function.
+
+    Idempotent: a second invocation that finds no further refinements is
+    a no-op.
+
+    Example:
+    ```mlir
+    // before
+    %empty = tensor.empty(%dynM, %dynN) : tensor<?x?xf16>
+    %y = hip.matmul(%ctx) ins(%a, %b : tensor<2x4xf16>, tensor<4x8xf16>)
+                          outs(%empty : tensor<?x?xf16>) -> tensor<?x?xf16>
+
+    // after
+    %empty = tensor.empty() : tensor<2x8xf16>
+    %y = hip.matmul(%ctx) ins(%a, %b : tensor<2x4xf16>, tensor<4x8xf16>)
+                          outs(%empty : tensor<2x8xf16>) -> tensor<2x8xf16>
+    ```
+  }];
+  let dependentDialects = [
+    "mlir::hip::HipDialect",
+    "mlir::tensor::TensorDialect"
+  ];
+}
+
 def ResolveExternConstantsPass
     : Pass<"hip-resolve-extern-constants", "mlir::ModuleOp"> {
   let summary = "Replace extern memref.global constants with "

--- a/include/hip/Dialect/Transforms/Passes.td
+++ b/include/hip/Dialect/Transforms/Passes.td
@@ -303,11 +303,15 @@ def InferShapesPass : Pass<"hip-infer-shapes", "mlir::ModuleOp"> {
 
     Pipeline placement
     ------------------
-    Optional, runs after `convert-onnx-to-hip` and before
-    `one-shot-bufferize`. Refining tensor result types BEFORE bufferize
-    propagates static dims through the alloc / pool sizing computations
-    and removes spurious `memref.dim` ops that the legalisation chain
-    would otherwise leave at the top of the function.
+    Wired into `buildOnnxToHipPipelineTail` (the shared post-conversion
+    segment of `buildOnnxToHipPipeline`) immediately after
+    `convert-onnx-to-hip` and before `one-shot-bufferize`. Refining
+    tensor result types BEFORE bufferize propagates static dims through
+    the alloc / pool sizing computations and removes spurious
+    `memref.dim` ops that the legalisation chain would otherwise leave
+    at the top of the function. The pass is also a no-op when no op in
+    the function carries the interface (or when no further refinement
+    is possible), so it is safe to run unconditionally on every model.
 
     Idempotent: a second invocation that finds no further refinements is
     a no-op.

--- a/include/hip/Dialect/Transforms/Passes.td
+++ b/include/hip/Dialect/Transforms/Passes.td
@@ -294,13 +294,12 @@ def InferShapesPass : Pass<"hip-infer-shapes", "mlir::ModuleOp"> {
 
     Why DPS-aware
     -------------
-    The upstream `--reify-result-shapes` pass (memref dialect, MLIR 22)
-    only handles `tensor::PadOp` / `tensor::ConcatOp` and skips DPS ops;
-    a generic upstream "infer static shapes" pass exists in main but is
-    not in the pinned MLIR. This pass closes the gap for HIP DPS ops:
-    the outs operand carries the result type by spec, so refining the
-    op's result without matching the outs operand's producer would
-    produce a verifier error.
+    HIP DPS ops require `result_type == outs_operand_type`, so refining
+    the op's result without matching the outs operand's producer would
+    produce a verifier error. This pass handles the DPS contract by
+    rewriting the producer at the same time as the result type. See
+    [docs/design/hip-shape-inference.md](docs/design/hip-shape-inference.md)
+    for the full design discussion.
 
     Pipeline placement
     ------------------

--- a/lib/Conversion/OnnxToHip/MatMulConversion.cpp
+++ b/lib/Conversion/OnnxToHip/MatMulConversion.cpp
@@ -52,8 +52,13 @@ MatMulToHip::matchAndRewrite(mlir::Operation *op,
   mlir::Value init =
       mlir::tensor::EmptyOp::create(rewriter, loc, resultType.getShape(),
                                     resultType.getElementType(), dynSizes);
-  auto hipOp = mlir::hip::MatmulOp::create(rewriter, loc, resultType, context,
-                                           a, b, init);
+  // Inferred-type Op::create overload: result type is read from the typed
+  // outs operand via the auto-emitted MatmulOp::inferReturnTypes (HipOps.td
+  // base, autoInfer=1). Equivalent to passing `resultType` explicitly --
+  // outs.getType() == resultType by construction here -- but keeps the DPS
+  // contract `result_type == outs_operand_type` closed by ODS rather than
+  // restated at the callsite.
+  auto hipOp = mlir::hip::MatmulOp::create(rewriter, loc, context, a, b, init);
   rewriter.replaceOp(op, hipOp->getResult(0));
   return mlir::success();
 }

--- a/lib/Dialect/IR/CMakeLists.txt
+++ b/lib/Dialect/IR/CMakeLists.txt
@@ -5,6 +5,7 @@
 
 add_library(HipDialectIR STATIC
   HipDialect.cpp
+  HipShapeUtils.cpp
 )
 
 add_dependencies(HipDialectIR
@@ -18,4 +19,7 @@ target_link_libraries(HipDialectIR PUBLIC
   MLIRSupport
   MLIRDestinationStyleOpInterface
   MLIRFuncDialect
+  MLIRInferTypeOpInterface
+  MLIRTensorDialect
+  MLIRMemRefDialect
 )

--- a/lib/Dialect/IR/CMakeLists.txt
+++ b/lib/Dialect/IR/CMakeLists.txt
@@ -5,6 +5,7 @@
 
 add_library(HipDialectIR STATIC
   HipDialect.cpp
+  HipDpsOpInterface.cpp
   HipReifyResultShapesImpl.cpp
   HipShapeUtils.cpp
 )
@@ -12,6 +13,7 @@ add_library(HipDialectIR STATIC
 add_dependencies(HipDialectIR
   HipDialectIncGen
   HipTypesIncGen
+  HipDpsOpInterfaceIncGen
   HipOpsIncGen
 )
 

--- a/lib/Dialect/IR/CMakeLists.txt
+++ b/lib/Dialect/IR/CMakeLists.txt
@@ -5,6 +5,7 @@
 
 add_library(HipDialectIR STATIC
   HipDialect.cpp
+  HipReifyResultShapesImpl.cpp
   HipShapeUtils.cpp
 )
 

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -6,7 +6,6 @@
 #include "hip/Dialect/IR/HipDialect.h"
 
 #include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/Sequence.h"
 #include "llvm/ADT/TypeSwitch.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -433,97 +432,9 @@ LogicalResult MatmulOp::verify() {
       });
 }
 
-LogicalResult
-MatmulOp::reifyResultShapes(OpBuilder &b,
-                            ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
-  // Skip in memref mode: reify is for ranked tensor result types only and
-  // by interface contract is only called on ops with `RankedTensorType`
-  // results (see InferTypeOpInterface.td).
-  if (getNumResults() == 0)
-    return failure();
-
-  ArrayRef<int64_t> aShape = getShapeOf(getA());
-  ArrayRef<int64_t> bShape = getShapeOf(getB());
-  if (aShape.empty() || bShape.empty())
-    return failure();
-
-  // Recompute the static shape vector via the shared helper. By the time
-  // reify runs, verify() has already approved the shapes, so the error
-  // callback is unreachable in practice -- but we bail safely on empty()
-  // anyway, matching the upstream linalg pattern.
-  SmallVector<int64_t> outShape = mlir::hip::inferContractionShape(
-      aShape, bShape, [&]() { return this->emitOpError(); });
-  if (outShape.empty())
-    return failure();
-
-  // Lift each static dim to an IndexAttr; lift each dynamic dim to a
-  // dim-of-input. Choosing which input to dim against follows the matmul
-  // shape contract:
-  //   - last 2 dims (M, N): A.shape[-2], B.shape[-1]
-  //   - batch dims (broadcast): prefer the side that contributed the dim
-  //     (the non-1, non-dynamic side); fall back to A then B if both sides
-  //     are dynamic.
-  Location loc = getLoc();
-  Value A = getA();
-  Value B = getB();
-  size_t outRank = outShape.size();
-  size_t aRank = aShape.size();
-  size_t bRank = bShape.size();
-
-  SmallVector<OpFoldResult> dims;
-  dims.reserve(outRank);
-  for (size_t i : llvm::seq<size_t>(0, outRank)) {
-    if (i + 2 == outRank) {
-      // M dim: comes from A's [-2].
-      dims.push_back(mlir::hip::reifyDimOrConstant(b, loc, outShape[i], A,
-                                                   aRank - 2));
-      continue;
-    }
-    if (i + 1 == outRank) {
-      // N dim: comes from B's [-1].
-      dims.push_back(mlir::hip::reifyDimOrConstant(b, loc, outShape[i], B,
-                                                   bRank - 1));
-      continue;
-    }
-    // Batch dim: right-aligned over A's and B's batch shapes.
-    size_t batchRank = outRank - 2;
-    size_t aBatchRank = aRank >= 2 ? aRank - 2 : 0;
-    size_t bBatchRank = bRank >= 2 ? bRank - 2 : 0;
-    size_t aPad = batchRank - aBatchRank;
-    size_t bPad = batchRank - bBatchRank;
-    int64_t aDim = i < aPad ? 1 : aShape[i - aPad];
-    int64_t bDim = i < bPad ? 1 : bShape[i - bPad];
-
-    // Static result -> IntegerAttr (no IR).
-    if (!ShapedType::isDynamic(outShape[i])) {
-      dims.push_back(b.getIndexAttr(outShape[i]));
-      continue;
-    }
-    // Dynamic result -> dim of whichever input is the actual source. If A's
-    // side is 1 or out-of-range, B is the source; otherwise A. This keeps
-    // the emitted dim op tied to the operand whose runtime size determines
-    // the result, which is the invariant downstream folds rely on.
-    bool aSourceCanonical =
-        i >= aPad && aDim != 1; // A contributes when it's in range and not 1
-    bool bSourceCanonical = i >= bPad && bDim != 1;
-    if (aSourceCanonical) {
-      dims.push_back(mlir::hip::reifyDimOrConstant(b, loc, ShapedType::kDynamic,
-                                                   A, i - aPad));
-    } else if (bSourceCanonical) {
-      dims.push_back(mlir::hip::reifyDimOrConstant(b, loc, ShapedType::kDynamic,
-                                                   B, i - bPad));
-    } else if (i >= aPad) {
-      // Both sides are 1 / dynamic — A is in range, prefer it.
-      dims.push_back(mlir::hip::reifyDimOrConstant(b, loc, ShapedType::kDynamic,
-                                                   A, i - aPad));
-    } else {
-      dims.push_back(mlir::hip::reifyDimOrConstant(b, loc, ShapedType::kDynamic,
-                                                   B, i - bPad));
-    }
-  }
-  reifiedReturnShapes.assign({std::move(dims)});
-  return success();
-}
+// `MatmulOp::reifyResultShapes` lives in
+// `lib/Dialect/IR/HipReifyResultShapesImpl.cpp`. See the header banner in
+// that file and `docs/design/hip-shape-inference.md` for the rationale.
 
 //===----------------------------------------------------------------------===//
 // RmsNormOp: ins(input, scale), outs(output)

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -413,17 +413,17 @@ static ArrayRef<int64_t> getShapeOf(Value v) {
 LogicalResult MatmulOp::verify() {
   // First the cross-cutting DPS contract (all-tensor-or-all-memref +
   // result-count parity); failures here also rule out bogus operand types,
-  // so the contraction shape check below can rely on getShapeOf().
+  // so the matmul shape check below can rely on getShapeOf().
   if (failed(verifyDpsComputeOp(*this, {getA(), getB(), getOutput()},
                                 /*numInits=*/1)))
     return failure();
 
-  // Static shape check via the shared contraction helper. The lambda is
+  // Static shape check via the shared matmul helper. The lambda is
   // invoked once; it returns `{outputShape}` on success or `{}` on shape
   // mismatch (in which case it has already issued a diagnostic on `*this`).
   return mlir::hip::verifyHipOpShape(
       *this, [&]() -> SmallVector<SmallVector<int64_t>> {
-        SmallVector<int64_t> outShape = mlir::hip::inferContractionShape(
+        SmallVector<int64_t> outShape = mlir::hip::inferMatmulShape(
             getShapeOf(getA()), getShapeOf(getB()),
             [&]() { return this->emitOpError(); });
         if (outShape.empty())

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -423,9 +423,9 @@ LogicalResult MatmulOp::verify() {
   // mismatch (in which case it has already issued a diagnostic on `*this`).
   return mlir::hip::verifyHipOpShape(
       *this, [&]() -> SmallVector<SmallVector<int64_t>> {
-        SmallVector<int64_t> outShape = mlir::hip::inferMatmulShape(
-            getShapeOf(getA()), getShapeOf(getB()),
-            [&]() { return this->emitOpError(); });
+        SmallVector<int64_t> outShape =
+            mlir::hip::inferMatmulShape(getShapeOf(getA()), getShapeOf(getB()),
+                                        [&]() { return this->emitOpError(); });
         if (outShape.empty())
           return {};
         return {std::move(outShape)};

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -447,18 +447,13 @@ MatmulOp::reifyResultShapes(OpBuilder &b,
   if (aShape.empty() || bShape.empty())
     return failure();
 
-  // Recompute the static shape vector via the shared helper. We deliberately
-  // use a no-op error sink here: by the time reify runs, verify() has
-  // already approved the shapes, so any "error" path is unreachable. We
-  // bail out by returning failure() if the helper somehow produces empty,
-  // matching the upstream linalg pattern.
-  bool sawError = false;
+  // Recompute the static shape vector via the shared helper. By the time
+  // reify runs, verify() has already approved the shapes, so the error
+  // callback is unreachable in practice -- but we bail safely on empty()
+  // anyway, matching the upstream linalg pattern.
   SmallVector<int64_t> outShape = mlir::hip::inferContractionShape(
-      aShape, bShape, [&]() -> InFlightDiagnostic {
-        sawError = true;
-        return this->emitOpError();
-      });
-  if (sawError || outShape.empty())
+      aShape, bShape, [&]() { return this->emitOpError(); });
+  if (outShape.empty())
     return failure();
 
   // Lift each static dim to an IndexAttr; lift each dynamic dim to a

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -5,6 +5,8 @@
 
 #include "hip/Dialect/IR/HipDialect.h"
 
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/Sequence.h"
 #include "llvm/ADT/TypeSwitch.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -12,6 +14,8 @@
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/SymbolTable.h"
+
+#include "hip/Dialect/IR/HipShapeUtils.h"
 
 using namespace mlir;
 using namespace mlir::hip;
@@ -394,6 +398,136 @@ void MatmulOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
         &effects) {
   emitDpsMemoryEffects(getDpsInputOperands(), getDpsInitsMutable(), effects);
+}
+
+/// Read the shape of `v` if it is a `RankedTensorType` or `MemRefType`;
+/// returns an empty ArrayRef otherwise (caller must guard against this with
+/// `verifyDpsComputeOp`, which already rejects non-shaped data operands).
+static ArrayRef<int64_t> getShapeOf(Value v) {
+  if (auto t = dyn_cast<RankedTensorType>(v.getType()))
+    return t.getShape();
+  if (auto m = dyn_cast<MemRefType>(v.getType()))
+    return m.getShape();
+  return {};
+}
+
+LogicalResult MatmulOp::verify() {
+  // First the cross-cutting DPS contract (all-tensor-or-all-memref +
+  // result-count parity); failures here also rule out bogus operand types,
+  // so the contraction shape check below can rely on getShapeOf().
+  if (failed(verifyDpsComputeOp(*this, {getA(), getB(), getOutput()},
+                                /*numInits=*/1)))
+    return failure();
+
+  // Static shape check via the shared contraction helper. The lambda is
+  // invoked once; it returns `{outputShape}` on success or `{}` on shape
+  // mismatch (in which case it has already issued a diagnostic on `*this`).
+  return mlir::hip::verifyHipOpShape(
+      *this, [&]() -> SmallVector<SmallVector<int64_t>> {
+        SmallVector<int64_t> outShape = mlir::hip::inferContractionShape(
+            getShapeOf(getA()), getShapeOf(getB()),
+            [&]() { return this->emitOpError(); });
+        if (outShape.empty())
+          return {};
+        return {std::move(outShape)};
+      });
+}
+
+LogicalResult
+MatmulOp::reifyResultShapes(OpBuilder &b,
+                            ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
+  // Skip in memref mode: reify is for ranked tensor result types only and
+  // by interface contract is only called on ops with `RankedTensorType`
+  // results (see InferTypeOpInterface.td).
+  if (getNumResults() == 0)
+    return failure();
+
+  ArrayRef<int64_t> aShape = getShapeOf(getA());
+  ArrayRef<int64_t> bShape = getShapeOf(getB());
+  if (aShape.empty() || bShape.empty())
+    return failure();
+
+  // Recompute the static shape vector via the shared helper. We deliberately
+  // use a no-op error sink here: by the time reify runs, verify() has
+  // already approved the shapes, so any "error" path is unreachable. We
+  // bail out by returning failure() if the helper somehow produces empty,
+  // matching the upstream linalg pattern.
+  bool sawError = false;
+  SmallVector<int64_t> outShape = mlir::hip::inferContractionShape(
+      aShape, bShape, [&]() -> InFlightDiagnostic {
+        sawError = true;
+        return this->emitOpError();
+      });
+  if (sawError || outShape.empty())
+    return failure();
+
+  // Lift each static dim to an IndexAttr; lift each dynamic dim to a
+  // dim-of-input. Choosing which input to dim against follows the matmul
+  // shape contract:
+  //   - last 2 dims (M, N): A.shape[-2], B.shape[-1]
+  //   - batch dims (broadcast): prefer the side that contributed the dim
+  //     (the non-1, non-dynamic side); fall back to A then B if both sides
+  //     are dynamic.
+  Location loc = getLoc();
+  Value A = getA();
+  Value B = getB();
+  size_t outRank = outShape.size();
+  size_t aRank = aShape.size();
+  size_t bRank = bShape.size();
+
+  SmallVector<OpFoldResult> dims;
+  dims.reserve(outRank);
+  for (size_t i : llvm::seq<size_t>(0, outRank)) {
+    if (i + 2 == outRank) {
+      // M dim: comes from A's [-2].
+      dims.push_back(mlir::hip::reifyDimOrConstant(b, loc, outShape[i], A,
+                                                   aRank - 2));
+      continue;
+    }
+    if (i + 1 == outRank) {
+      // N dim: comes from B's [-1].
+      dims.push_back(mlir::hip::reifyDimOrConstant(b, loc, outShape[i], B,
+                                                   bRank - 1));
+      continue;
+    }
+    // Batch dim: right-aligned over A's and B's batch shapes.
+    size_t batchRank = outRank - 2;
+    size_t aBatchRank = aRank >= 2 ? aRank - 2 : 0;
+    size_t bBatchRank = bRank >= 2 ? bRank - 2 : 0;
+    size_t aPad = batchRank - aBatchRank;
+    size_t bPad = batchRank - bBatchRank;
+    int64_t aDim = i < aPad ? 1 : aShape[i - aPad];
+    int64_t bDim = i < bPad ? 1 : bShape[i - bPad];
+
+    // Static result -> IntegerAttr (no IR).
+    if (!ShapedType::isDynamic(outShape[i])) {
+      dims.push_back(b.getIndexAttr(outShape[i]));
+      continue;
+    }
+    // Dynamic result -> dim of whichever input is the actual source. If A's
+    // side is 1 or out-of-range, B is the source; otherwise A. This keeps
+    // the emitted dim op tied to the operand whose runtime size determines
+    // the result, which is the invariant downstream folds rely on.
+    bool aSourceCanonical =
+        i >= aPad && aDim != 1; // A contributes when it's in range and not 1
+    bool bSourceCanonical = i >= bPad && bDim != 1;
+    if (aSourceCanonical) {
+      dims.push_back(mlir::hip::reifyDimOrConstant(b, loc, ShapedType::kDynamic,
+                                                   A, i - aPad));
+    } else if (bSourceCanonical) {
+      dims.push_back(mlir::hip::reifyDimOrConstant(b, loc, ShapedType::kDynamic,
+                                                   B, i - bPad));
+    } else if (i >= aPad) {
+      // Both sides are 1 / dynamic — A is in range, prefer it.
+      dims.push_back(mlir::hip::reifyDimOrConstant(b, loc, ShapedType::kDynamic,
+                                                   A, i - aPad));
+    } else {
+      dims.push_back(mlir::hip::reifyDimOrConstant(b, loc, ShapedType::kDynamic,
+                                                   B, i - bPad));
+    }
+  }
+  reifiedReturnShapes.assign({std::move(dims)});
+  return success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/IR/HipDpsOpInterface.cpp
+++ b/lib/Dialect/IR/HipDpsOpInterface.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- HipDpsOpInterface.cpp - HipDpsOp default reify body ----------------===//
+//
+// Single shared default `reifyResultShapes` body for HIP DPS ops. Walks
+// `DestinationStyleOpInterface::getDpsInits()` and lifts each init's
+// runtime shape via `tensor::getMixedSizes` / `memref::getMixedSizes`.
+// Ops that need a tighter contract opt out via `autoReify=0` on
+// `Hip_DpsOp` and provide a per-op override in
+// `HipReifyResultShapesImpl.cpp`.
+//
+// See `docs/design/hip-shape-inference.md` for the design rationale and
+// the recipe for wiring a new op (or a new shape category) into the
+// pipeline.
+//
+//===----------------------------------------------------------------------===//
+
+#include "hip/Dialect/IR/HipDialect.h"
+
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/Interfaces/DestinationStyleOpInterface.h"
+#include "llvm/ADT/STLExtras.h"
+
+using namespace mlir;
+using namespace mlir::hip;
+
+namespace mlir::hip {
+#include "hip/Dialect/IR/HipDpsOpInterface.cpp.inc"
+} // namespace mlir::hip
+
+LogicalResult
+HipDpsOp::reifyResultShapes(OpBuilder &b,
+                            ReifiedRankedShapedTypeDims &reified) {
+  Operation *op = getOperation();
+  for (auto [idx, out] :
+       llvm::enumerate(cast<DestinationStyleOpInterface>(op).getDpsInits())) {
+    SmallVector<OpFoldResult> dims;
+    Type outType = out.getType();
+    if (isa<RankedTensorType>(outType))
+      dims = tensor::getMixedSizes(b, op->getLoc(), out);
+    else if (isa<MemRefType>(outType))
+      dims = memref::getMixedSizes(b, op->getLoc(), out);
+    else
+      return op->emitOpError("invalid type for DPS init #")
+             << idx << ": expected tensor or memref, got " << outType;
+    reified.emplace_back(std::move(dims));
+  }
+  return success();
+}

--- a/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
+++ b/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
@@ -121,14 +121,14 @@ MatmulOp::reifyResultShapes(OpBuilder &b,
   for (size_t i : llvm::seq<size_t>(0, outRank)) {
     if (i + 2 == outRank) {
       // M dim: comes from A's [-2].
-      dims.push_back(mlir::hip::reifyDimOrConstant(b, loc, outShape[i], A,
-                                                   aRank - 2));
+      dims.push_back(
+          mlir::hip::reifyDimOrConstant(b, loc, outShape[i], A, aRank - 2));
       continue;
     }
     if (i + 1 == outRank) {
       // N dim: comes from B's [-1].
-      dims.push_back(mlir::hip::reifyDimOrConstant(b, loc, outShape[i], B,
-                                                   bRank - 1));
+      dims.push_back(
+          mlir::hip::reifyDimOrConstant(b, loc, outShape[i], B, bRank - 1));
       continue;
     }
     // Batch dim: right-aligned over A's and B's batch shapes.

--- a/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
+++ b/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
@@ -28,7 +28,6 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Value.h"
-#include "mlir/Interfaces/InferTypeOpInterface.h"
 
 using namespace mlir;
 using namespace mlir::hip;

--- a/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
+++ b/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
@@ -40,10 +40,11 @@ ArrayRef<int64_t> getShapeOf(Value v) {
 //===----------------------------------------------------------------------===//
 // MatmulOp
 //
-// Reify uses `inferMatmulShape` to recompute the result shape, then
-// lifts each dim to an OpFoldResult: static -> IndexAttr, dynamic ->
-// tensor.dim of the operand that contributes the runtime size.
-// Source: M = A[-2], N = B[-1], batch dim = the broadcast-canonical side.
+// Reify recomputes the result shape via `inferMatmulShape`, then lifts
+// each dim to an OpFoldResult: static dims become `IndexAttr`; dynamic
+// dims become `tensor.dim` of whichever operand contributes the runtime
+// size — M from A[-2], N from B[-1], batch from the broadcast-canonical
+// side.
 //
 // Before:
 //   %m = hip.matmul ins(%a, %b : tensor<?x4096xf16>, tensor<4096x4096xf16>)

--- a/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
+++ b/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
@@ -88,8 +88,7 @@ MatmulOp::reifyResultShapes(OpBuilder &b,
                             ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
   // memref-mode matmul has no SSA results — by interface contract
   // `reifyResultShapes` is only called on ops with `RankedTensorType`
-  // results (see `InferTypeOpInterface.td`). Bail safely if invoked
-  // anyway.
+  // results. Bail safely if invoked anyway.
   if (getNumResults() == 0)
     return failure();
 
@@ -115,56 +114,41 @@ MatmulOp::reifyResultShapes(OpBuilder &b,
   size_t aRank = aShape.size();
   size_t bRank = bShape.size();
 
+  // Loop-invariant: right-alignment padding for A's and B's batch dims.
+  size_t batchRank = outRank - 2;
+  size_t aPad = batchRank - (aRank >= 2 ? aRank - 2 : 0);
+  size_t bPad = batchRank - (bRank >= 2 ? bRank - 2 : 0);
+
   SmallVector<OpFoldResult> dims;
   dims.reserve(outRank);
   for (size_t i : llvm::seq<size_t>(0, outRank)) {
+    // M dim: A[-2].
     if (i + 2 == outRank) {
-      // M dim: comes from A's [-2].
       dims.push_back(
           mlir::hip::reifyDimOrConstant(b, loc, outShape[i], A, aRank - 2));
       continue;
     }
+    // N dim: B[-1].
     if (i + 1 == outRank) {
-      // N dim: comes from B's [-1].
       dims.push_back(
           mlir::hip::reifyDimOrConstant(b, loc, outShape[i], B, bRank - 1));
       continue;
     }
-    // Batch dim: right-aligned over A's and B's batch shapes.
-    size_t batchRank = outRank - 2;
-    size_t aBatchRank = aRank >= 2 ? aRank - 2 : 0;
-    size_t bBatchRank = bRank >= 2 ? bRank - 2 : 0;
-    size_t aPad = batchRank - aBatchRank;
-    size_t bPad = batchRank - bBatchRank;
+    // Batch dim: pick whichever input contributes the runtime size. A
+    // contributes when it's in range AND its dim is not 1; B contributes
+    // symmetrically. When neither is canonical (both 1 / out-of-range /
+    // dynamic), prefer A when in range so downstream folds see a stable
+    // source. `reifyDimOrConstant` handles the static-vs-dynamic dispatch
+    // on `outShape[i]` -- no separate static-result fast path needed.
     int64_t aDim = i < aPad ? 1 : aShape[i - aPad];
     int64_t bDim = i < bPad ? 1 : bShape[i - bPad];
-
-    // Static result -> IntegerAttr (no IR).
-    if (!ShapedType::isDynamic(outShape[i])) {
-      dims.push_back(b.getIndexAttr(outShape[i]));
-      continue;
-    }
-    // Dynamic result -> dim of whichever input is the actual source. If A's
-    // side is 1 or out-of-range, B is the source; otherwise A. This keeps
-    // the emitted dim op tied to the operand whose runtime size determines
-    // the result, which is the invariant downstream folds rely on.
-    bool aSourceCanonical =
-        i >= aPad && aDim != 1; // A contributes when it's in range and not 1
-    bool bSourceCanonical = i >= bPad && bDim != 1;
-    if (aSourceCanonical) {
-      dims.push_back(mlir::hip::reifyDimOrConstant(b, loc, ShapedType::kDynamic,
-                                                   A, i - aPad));
-    } else if (bSourceCanonical) {
-      dims.push_back(mlir::hip::reifyDimOrConstant(b, loc, ShapedType::kDynamic,
-                                                   B, i - bPad));
-    } else if (i >= aPad) {
-      // Both sides are 1 / dynamic — A is in range, prefer it.
-      dims.push_back(mlir::hip::reifyDimOrConstant(b, loc, ShapedType::kDynamic,
-                                                   A, i - aPad));
-    } else {
-      dims.push_back(mlir::hip::reifyDimOrConstant(b, loc, ShapedType::kDynamic,
-                                                   B, i - bPad));
-    }
+    bool aCanonical = i >= aPad && aDim != 1;
+    bool bCanonical = i >= bPad && bDim != 1;
+    bool pickA = aCanonical || (!bCanonical && i >= aPad);
+    Value src = pickA ? A : B;
+    size_t srcDim = pickA ? i - aPad : i - bPad;
+    dims.push_back(
+        mlir::hip::reifyDimOrConstant(b, loc, outShape[i], src, srcDim));
   }
   reifiedReturnShapes.assign({std::move(dims)});
   return success();

--- a/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
+++ b/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
@@ -2,21 +2,11 @@
  * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Licensed under the MIT License.
  */
-//===----------------------------------------------------------------------===//
+//===- HipReifyResultShapesImpl.cpp ---------------------------------------===//
 //
-// Per-op `ReifyRankedShapedTypeOpInterface` implementations for HIP dialect.
-//
-// `HipDialect.cpp` hosts each op's verify(), getEffects(),
-// getDpsInitsMutable(), and any custom builders / printers / parsers. The
-// reify implementations live here so that the per-op shape arithmetic for
-// every dynamic-shape op can be read alongside each other, and so that
-// `HipDialect.cpp` stays focused on op identity as the dialect picks up
-// shape-inference support for more ops.
-//
-// Each op's reify lives under its own `// <OpName>` section banner below.
-// To wire shape inference for a new op, follow the recipe in
-// `docs/design/hip-shape-inference.md` — the `// <OpName>` section here is
-// step 4 of that recipe.
+// Per-op `ReifyRankedShapedTypeOpInterface` impls for HIP dialect ops. One
+// section per op below. See `docs/design/hip-shape-inference.md` for the
+// recipe to wire a new op.
 //
 //===----------------------------------------------------------------------===//
 
@@ -34,17 +24,9 @@ using namespace mlir::hip;
 
 namespace {
 
-/// Read the shape of `v` if it is a `RankedTensorType` or `MemRefType`;
-/// returns an empty `ArrayRef` otherwise. Reify entries below treat the
-/// empty case as a graceful bail-out (`failure()`); verify() guards the
-/// same property up front.
-///
-/// Duplicated as a file-local static here AND in `HipDialect.cpp` rather
-/// than promoted to `HipShapeUtils.h` — the helper is small enough that a
-/// local copy in each TU is clearer than expanding the public API surface,
-/// and the two callers may legitimately diverge in the future (e.g. the
-/// verify-side helper might want to reject non-shaped types up front,
-/// while the reify-side wants the silent bail-out it has today).
+/// Read the shape of `v` if shaped, else return empty (treated as a graceful
+/// bail-out by callers below). Duplicated in `HipDialect.cpp`; the two
+/// callers may diverge later (verify rejects non-shaped, reify bails).
 ArrayRef<int64_t> getShapeOf(Value v) {
   if (auto t = dyn_cast<RankedTensorType>(v.getType()))
     return t.getShape();
@@ -57,38 +39,25 @@ ArrayRef<int64_t> getShapeOf(Value v) {
 
 //===----------------------------------------------------------------------===//
 // MatmulOp
-//===----------------------------------------------------------------------===//
 //
-// Reify for `hip.matmul`. The inferred shape is recomputed from the operand
-// shapes via `inferContractionShape` (same helper that drives verify()) and
-// then lifted into `OpFoldResult`s: each static dim becomes an `IndexAttr`,
-// each dynamic dim becomes a `tensor.dim` / `memref.dim` of the operand
-// whose runtime size determines that dim.
-//
-// Source-of-dim contract:
-//   - last-2 dims (M, N): `M = A[-2]`, `N = B[-1]`
-//   - batch dims (right-aligned, broadcast over leading dims): prefer the
-//     side that contributes the dim (in-range and not 1). If both sides
-//     are dynamic the choice is fixed (A first, then B) so downstream folds
-//     see a stable shape source.
+// Reify uses `inferContractionShape` to recompute the result shape, then
+// lifts each dim to an OpFoldResult: static -> IndexAttr, dynamic ->
+// tensor.dim of the operand that contributes the runtime size.
+// Source: M = A[-2], N = B[-1], batch dim = the broadcast-canonical side.
 //
 // Before:
-//   %m = hip.matmul ins(%ctx, %a : !hip.context, tensor<?x4096xf16>),
-//                   ins(%b   : tensor<4096x4096xf16>),
+//   %m = hip.matmul ins(%a, %b : tensor<?x4096xf16>, tensor<4096x4096xf16>)
 //                   outs(%out : tensor<?x4096xf16>) -> tensor<?x4096xf16>
-//
-// After (reified shapes for the result of %m):
-//   //   dim 0 (dynamic M)  -> %d0 = tensor.dim %a, %c0 : tensor<?x4096xf16>
-//   //   dim 1 (static N)   -> 4096 : index
-//
+// After (reified result shape):
+//   dim 0 (dynamic M) -> %d0 = tensor.dim %a, %c0
+//   dim 1 (static N)  -> 4096 : index
 //===----------------------------------------------------------------------===//
 
 LogicalResult
 MatmulOp::reifyResultShapes(OpBuilder &b,
                             ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
-  // memref-mode matmul has no SSA results — by interface contract
-  // `reifyResultShapes` is only called on ops with `RankedTensorType`
-  // results. Bail safely if invoked anyway.
+  // memref-mode has no SSA results; reify is only called on tensor mode
+  // per interface contract, but bail defensively if invoked anyway.
   if (getNumResults() == 0)
     return failure();
 
@@ -97,11 +66,8 @@ MatmulOp::reifyResultShapes(OpBuilder &b,
   if (aShape.empty() || bShape.empty())
     return failure();
 
-  // Recompute the static shape vector via the shared helper. By the time
-  // reify runs, verify() has already approved the shapes, so the error
-  // callback is unreachable in practice — but bail safely on empty()
-  // anyway, in case a future caller invokes reify on an op that has not
-  // yet been through verification.
+  // Re-run the contraction-shape helper. verify() has already passed by reify
+  // time, but bail on empty() in case a pre-verify call sneaks in.
   SmallVector<int64_t> outShape = mlir::hip::inferContractionShape(
       aShape, bShape, [&]() { return this->emitOpError(); });
   if (outShape.empty())
@@ -134,12 +100,8 @@ MatmulOp::reifyResultShapes(OpBuilder &b,
           mlir::hip::reifyDimOrConstant(b, loc, outShape[i], B, bRank - 1));
       continue;
     }
-    // Batch dim: pick whichever input contributes the runtime size. A
-    // contributes when it's in range AND its dim is not 1; B contributes
-    // symmetrically. When neither is canonical (both 1 / out-of-range /
-    // dynamic), prefer A when in range so downstream folds see a stable
-    // source. `reifyDimOrConstant` handles the static-vs-dynamic dispatch
-    // on `outShape[i]` -- no separate static-result fast path needed.
+    // Batch dim: prefer the side that contributes the size (in range, not 1).
+    // When neither contributes, prefer A in range so folds see a stable source.
     int64_t aDim = i < aPad ? 1 : aShape[i - aPad];
     int64_t bDim = i < bPad ? 1 : bShape[i - bPad];
     bool aCanonical = i >= aPad && aDim != 1;

--- a/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
+++ b/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===----------------------------------------------------------------------===//
+//
+// Per-op `ReifyRankedShapedTypeOpInterface` implementations for HIP dialect.
+//
+// `HipDialect.cpp` hosts each op's verify(), getEffects(),
+// getDpsInitsMutable(), and any custom builders / printers / parsers. The
+// reify implementations live here so that the per-op shape arithmetic for
+// every dynamic-shape op can be read alongside each other, and so that
+// `HipDialect.cpp` stays focused on op identity as the dialect picks up
+// shape-inference support for more ops.
+//
+// Each op's reify lives under its own `// <OpName>` section banner below.
+// To wire shape inference for a new op, follow the recipe in
+// `docs/design/hip-shape-inference.md` — the `// <OpName>` section here is
+// step 4 of that recipe.
+//
+//===----------------------------------------------------------------------===//
+
+#include "hip/Dialect/IR/HipDialect.h"
+#include "hip/Dialect/IR/HipShapeUtils.h"
+
+#include "llvm/ADT/Sequence.h"
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Interfaces/InferTypeOpInterface.h"
+
+using namespace mlir;
+using namespace mlir::hip;
+
+namespace {
+
+/// Read the shape of `v` if it is a `RankedTensorType` or `MemRefType`;
+/// returns an empty `ArrayRef` otherwise. Reify entries below treat the
+/// empty case as a graceful bail-out (`failure()`); verify() guards the
+/// same property up front.
+///
+/// Duplicated as a file-local static here AND in `HipDialect.cpp` rather
+/// than promoted to `HipShapeUtils.h` — the helper is small enough that a
+/// local copy in each TU is clearer than expanding the public API surface,
+/// and the two callers may legitimately diverge in the future (e.g. the
+/// verify-side helper might want to reject non-shaped types up front,
+/// while the reify-side wants the silent bail-out it has today).
+ArrayRef<int64_t> getShapeOf(Value v) {
+  if (auto t = dyn_cast<RankedTensorType>(v.getType()))
+    return t.getShape();
+  if (auto m = dyn_cast<MemRefType>(v.getType()))
+    return m.getShape();
+  return {};
+}
+
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// MatmulOp
+//===----------------------------------------------------------------------===//
+//
+// Reify for `hip.matmul`. The inferred shape is recomputed from the operand
+// shapes via `inferContractionShape` (same helper that drives verify()) and
+// then lifted into `OpFoldResult`s: each static dim becomes an `IndexAttr`,
+// each dynamic dim becomes a `tensor.dim` / `memref.dim` of the operand
+// whose runtime size determines that dim.
+//
+// Source-of-dim contract:
+//   - last-2 dims (M, N): `M = A[-2]`, `N = B[-1]`
+//   - batch dims (right-aligned, broadcast over leading dims): prefer the
+//     side that contributes the dim (in-range and not 1). If both sides
+//     are dynamic the choice is fixed (A first, then B) so downstream folds
+//     see a stable shape source.
+//
+// Before:
+//   %m = hip.matmul ins(%ctx, %a : !hip.context, tensor<?x4096xf16>),
+//                   ins(%b   : tensor<4096x4096xf16>),
+//                   outs(%out : tensor<?x4096xf16>) -> tensor<?x4096xf16>
+//
+// After (reified shapes for the result of %m):
+//   //   dim 0 (dynamic M)  -> %d0 = tensor.dim %a, %c0 : tensor<?x4096xf16>
+//   //   dim 1 (static N)   -> 4096 : index
+//
+//===----------------------------------------------------------------------===//
+
+LogicalResult
+MatmulOp::reifyResultShapes(OpBuilder &b,
+                            ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
+  // memref-mode matmul has no SSA results — by interface contract
+  // `reifyResultShapes` is only called on ops with `RankedTensorType`
+  // results (see `InferTypeOpInterface.td`). Bail safely if invoked
+  // anyway.
+  if (getNumResults() == 0)
+    return failure();
+
+  ArrayRef<int64_t> aShape = getShapeOf(getA());
+  ArrayRef<int64_t> bShape = getShapeOf(getB());
+  if (aShape.empty() || bShape.empty())
+    return failure();
+
+  // Recompute the static shape vector via the shared helper. By the time
+  // reify runs, verify() has already approved the shapes, so the error
+  // callback is unreachable in practice — but bail safely on empty()
+  // anyway, in case a future caller invokes reify on an op that has not
+  // yet been through verification.
+  SmallVector<int64_t> outShape = mlir::hip::inferContractionShape(
+      aShape, bShape, [&]() { return this->emitOpError(); });
+  if (outShape.empty())
+    return failure();
+
+  Location loc = getLoc();
+  Value A = getA();
+  Value B = getB();
+  size_t outRank = outShape.size();
+  size_t aRank = aShape.size();
+  size_t bRank = bShape.size();
+
+  SmallVector<OpFoldResult> dims;
+  dims.reserve(outRank);
+  for (size_t i : llvm::seq<size_t>(0, outRank)) {
+    if (i + 2 == outRank) {
+      // M dim: comes from A's [-2].
+      dims.push_back(mlir::hip::reifyDimOrConstant(b, loc, outShape[i], A,
+                                                   aRank - 2));
+      continue;
+    }
+    if (i + 1 == outRank) {
+      // N dim: comes from B's [-1].
+      dims.push_back(mlir::hip::reifyDimOrConstant(b, loc, outShape[i], B,
+                                                   bRank - 1));
+      continue;
+    }
+    // Batch dim: right-aligned over A's and B's batch shapes.
+    size_t batchRank = outRank - 2;
+    size_t aBatchRank = aRank >= 2 ? aRank - 2 : 0;
+    size_t bBatchRank = bRank >= 2 ? bRank - 2 : 0;
+    size_t aPad = batchRank - aBatchRank;
+    size_t bPad = batchRank - bBatchRank;
+    int64_t aDim = i < aPad ? 1 : aShape[i - aPad];
+    int64_t bDim = i < bPad ? 1 : bShape[i - bPad];
+
+    // Static result -> IntegerAttr (no IR).
+    if (!ShapedType::isDynamic(outShape[i])) {
+      dims.push_back(b.getIndexAttr(outShape[i]));
+      continue;
+    }
+    // Dynamic result -> dim of whichever input is the actual source. If A's
+    // side is 1 or out-of-range, B is the source; otherwise A. This keeps
+    // the emitted dim op tied to the operand whose runtime size determines
+    // the result, which is the invariant downstream folds rely on.
+    bool aSourceCanonical =
+        i >= aPad && aDim != 1; // A contributes when it's in range and not 1
+    bool bSourceCanonical = i >= bPad && bDim != 1;
+    if (aSourceCanonical) {
+      dims.push_back(mlir::hip::reifyDimOrConstant(b, loc, ShapedType::kDynamic,
+                                                   A, i - aPad));
+    } else if (bSourceCanonical) {
+      dims.push_back(mlir::hip::reifyDimOrConstant(b, loc, ShapedType::kDynamic,
+                                                   B, i - bPad));
+    } else if (i >= aPad) {
+      // Both sides are 1 / dynamic — A is in range, prefer it.
+      dims.push_back(mlir::hip::reifyDimOrConstant(b, loc, ShapedType::kDynamic,
+                                                   A, i - aPad));
+    } else {
+      dims.push_back(mlir::hip::reifyDimOrConstant(b, loc, ShapedType::kDynamic,
+                                                   B, i - bPad));
+    }
+  }
+  reifiedReturnShapes.assign({std::move(dims)});
+  return success();
+}

--- a/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
+++ b/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
@@ -40,7 +40,7 @@ ArrayRef<int64_t> getShapeOf(Value v) {
 //===----------------------------------------------------------------------===//
 // MatmulOp
 //
-// Reify uses `inferContractionShape` to recompute the result shape, then
+// Reify uses `inferMatmulShape` to recompute the result shape, then
 // lifts each dim to an OpFoldResult: static -> IndexAttr, dynamic ->
 // tensor.dim of the operand that contributes the runtime size.
 // Source: M = A[-2], N = B[-1], batch dim = the broadcast-canonical side.
@@ -66,9 +66,9 @@ MatmulOp::reifyResultShapes(OpBuilder &b,
   if (aShape.empty() || bShape.empty())
     return failure();
 
-  // Re-run the contraction-shape helper. verify() has already passed by reify
+  // Re-run the matmul-shape helper. verify() has already passed by reify
   // time, but bail on empty() in case a pre-verify call sneaks in.
-  SmallVector<int64_t> outShape = mlir::hip::inferContractionShape(
+  SmallVector<int64_t> outShape = mlir::hip::inferMatmulShape(
       aShape, bShape, [&]() { return this->emitOpError(); });
   if (outShape.empty())
     return failure();

--- a/lib/Dialect/IR/HipShapeUtils.cpp
+++ b/lib/Dialect/IR/HipShapeUtils.cpp
@@ -128,10 +128,11 @@ LogicalResult mlir::hip::verifyHipOpShape(
     Operation *op,
     function_ref<SmallVector<SmallVector<int64_t>>()> computeExpected,
     bool checkElementType) {
-  auto dpsOp = dyn_cast<DestinationStyleOpInterface>(op);
-  if (!dpsOp)
-    return op->emitOpError(
-        "verifyHipOpShape requires DestinationStyleOpInterface");
+  // Required-by-construction: every op that wires up `verifyHipOpShape`
+  // also implements `DestinationStyleOpInterface` via TableGen. Asserting
+  // cast matches the upstream Linalg pattern in `verifyStructuredOpInterface`
+  // (`cast<LinalgOp>(op)` / `cast<IndexingMapOpInterface>(op)`).
+  auto dpsOp = cast<DestinationStyleOpInterface>(op);
 
   SmallVector<SmallVector<int64_t>> expected = computeExpected();
   // Empty outer vector: the shape helper failed and already issued a
@@ -139,11 +140,16 @@ LogicalResult mlir::hip::verifyHipOpShape(
   if (expected.empty())
     return failure();
 
+  // Programmer-error invariant: each shape helper returns one expected shape
+  // per DPS init operand by construction. Assert in debug builds (matches the
+  // upstream `assert(X.size() == Y.size() && "...")` idiom in
+  // `tensor::CastOp` folding); the `return failure()` keeps release builds
+  // safe by avoiding the out-of-bounds `expected[i]` in the loop below.
   auto inits = dpsOp.getDpsInits();
+  assert(expected.size() == inits.size() &&
+         "shape helper must produce one expected shape per DPS init operand");
   if (expected.size() != inits.size())
-    return op->emitOpError("internal: shape helper produced ")
-           << expected.size() << " expected shape(s) but op has "
-           << inits.size() << " init operand(s)";
+    return failure();
 
   for (auto [i, init] : llvm::enumerate(inits)) {
     auto initType = dyn_cast<ShapedType>(init.getType());

--- a/lib/Dialect/IR/HipShapeUtils.cpp
+++ b/lib/Dialect/IR/HipShapeUtils.cpp
@@ -45,7 +45,7 @@ std::string formatShape(ArrayRef<int64_t> shape) {
 } // namespace
 
 SmallVector<int64_t>
-mlir::hip::inferContractionShape(ArrayRef<int64_t> aShape,
+mlir::hip::inferMatmulShape(ArrayRef<int64_t> aShape,
                                  ArrayRef<int64_t> bShape,
                                  function_ref<InFlightDiagnostic()> emitError) {
   if (aShape.size() < 2) {

--- a/lib/Dialect/IR/HipShapeUtils.cpp
+++ b/lib/Dialect/IR/HipShapeUtils.cpp
@@ -105,9 +105,10 @@ LogicalResult mlir::hip::verifyHipOpShape(
     Operation *op,
     function_ref<SmallVector<SmallVector<int64_t>>()> computeExpected) {
   // Required-by-construction: every op that wires up `verifyHipOpShape`
-  // also implements `DestinationStyleOpInterface` via TableGen. Asserting
-  // cast matches the upstream Linalg pattern in `verifyStructuredOpInterface`
-  // (`cast<LinalgOp>(op)` / `cast<IndexingMapOpInterface>(op)`).
+  // also implements `DestinationStyleOpInterface` via TableGen. Use
+  // asserting `cast<>` to express that contract — a missing interface is
+  // a programmer error in the op's TableGen def, not a user-facing
+  // diagnostic.
   auto dpsOp = cast<DestinationStyleOpInterface>(op);
 
   SmallVector<SmallVector<int64_t>> expected = computeExpected();
@@ -117,10 +118,9 @@ LogicalResult mlir::hip::verifyHipOpShape(
     return failure();
 
   // Programmer-error invariant: each shape helper returns one expected shape
-  // per DPS init operand by construction. Assert in debug builds (matches the
-  // upstream `assert(X.size() == Y.size() && "...")` idiom in
-  // `tensor::CastOp` folding); the `return failure()` keeps release builds
-  // safe by avoiding the out-of-bounds `expected[i]` in the loop below.
+  // per DPS init operand by construction. Assert in debug builds; the
+  // `return failure()` keeps release builds safe by avoiding the
+  // out-of-bounds `expected[i]` in the loop below.
   auto inits = dpsOp.getDpsInits();
   assert(expected.size() == inits.size() &&
          "shape helper must produce one expected shape per DPS init operand");

--- a/lib/Dialect/IR/HipShapeUtils.cpp
+++ b/lib/Dialect/IR/HipShapeUtils.cpp
@@ -45,9 +45,8 @@ std::string formatShape(ArrayRef<int64_t> shape) {
 } // namespace
 
 SmallVector<int64_t>
-mlir::hip::inferMatmulShape(ArrayRef<int64_t> aShape,
-                                 ArrayRef<int64_t> bShape,
-                                 function_ref<InFlightDiagnostic()> emitError) {
+mlir::hip::inferMatmulShape(ArrayRef<int64_t> aShape, ArrayRef<int64_t> bShape,
+                            function_ref<InFlightDiagnostic()> emitError) {
   if (aShape.size() < 2) {
     emitError() << "matmul A must have rank >= 2, got rank " << aShape.size();
     return {};

--- a/lib/Dialect/IR/HipShapeUtils.cpp
+++ b/lib/Dialect/IR/HipShapeUtils.cpp
@@ -15,7 +15,6 @@
 #include "hip/Dialect/IR/HipShapeUtils.h"
 
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
-#include "mlir/Dialect/Traits.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Interfaces/DestinationStyleOpInterface.h"
 #include "llvm/ADT/STLExtras.h"
@@ -48,18 +47,44 @@ SmallVector<int64_t>
 mlir::hip::inferContractionShape(ArrayRef<int64_t> aShape,
                                  ArrayRef<int64_t> bShape,
                                  function_ref<InFlightDiagnostic()> emitError) {
-  if (aShape.size() < 2) {
-    emitError() << "matmul A must have rank >= 2, got rank " << aShape.size();
+  size_t aRank = aShape.size();
+  size_t bRank = bShape.size();
+  if (aRank < 2) {
+    emitError() << "matmul A must have rank >= 2, got rank " << aRank;
     return {};
   }
-  if (bShape.size() < 2) {
-    emitError() << "matmul B must have rank >= 2, got rank " << bShape.size();
+  if (bRank < 2) {
+    emitError() << "matmul B must have rank >= 2, got rank " << bRank;
     return {};
   }
 
-  int64_t M = aShape[aShape.size() - 2];
+  // Tightened contract: matches what `MatMulConversion.cpp` +
+  // `MatmulLowering.cpp` actually compute correctly today. Codegen
+  // derives result rank and batchCount from `A`, with optional `B`
+  // rank-2 broadcast (one matrix re-used across all batches). Anything
+  // wider — `B`'s rank > `A`'s rank, mixed ranks where `B` is not
+  // exactly rank-2, or per-dim batch broadcasting (`1` vs `>1`) —
+  // would be miscompiled by codegen + runtime, so the verifier rejects
+  // it here. Widening this contract requires matching widening in
+  // codegen and the runtime's strided-batch layout (zero stride for
+  // the broadcast side). Tracked under "Codegen contract" in
+  // `docs/design/hip-shape-inference.md`.
+  if (bRank > aRank) {
+    emitError() << "matmul B's rank (" << bRank << ") exceeds A's rank ("
+                << aRank
+                << "); B-side batch broadcasting is not supported by codegen";
+    return {};
+  }
+  if (aRank > bRank && bRank != 2) {
+    emitError() << "matmul mixed-rank operands require B to be rank-2 (got A "
+                   "rank "
+                << aRank << ", B rank " << bRank << ")";
+    return {};
+  }
+
+  int64_t M = aShape[aRank - 2];
   int64_t Ka = aShape.back();
-  int64_t Kb = bShape[bShape.size() - 2];
+  int64_t Kb = bShape[bRank - 2];
   int64_t N = bShape.back();
 
   // Contraction K must agree (kDynamic on either side is a wildcard).
@@ -69,15 +94,34 @@ mlir::hip::inferContractionShape(ArrayRef<int64_t> aShape,
     return {};
   }
 
-  // Batch broadcast (NumPy / ONNX MatMul) on the leading dims; see header
-  // for the full case table.
   ArrayRef<int64_t> aBatch = aShape.drop_back(2);
   ArrayRef<int64_t> bBatch = bShape.drop_back(2);
   SmallVector<int64_t> result;
-  if (!OpTrait::util::getBroadcastedShape(aBatch, bBatch, result)) {
-    emitError() << "matmul batch broadcast failure: A.batch="
-                << formatShape(aBatch) << " B.batch=" << formatShape(bBatch);
-    return {};
+  if (bBatch.empty()) {
+    // ND x 2D: result batch = A's batch (one matrix B re-used across all
+    // batches). Codegen path: MatmulLowering computes batchCount from A's
+    // leading dims and runtime treats B as zero-stride for the batch loop.
+    result.assign(aBatch.begin(), aBatch.end());
+  } else {
+    // Same-rank batched matmul: per-position batch dim equality.
+    // kDynamic on either side is a wildcard; if one side is static and
+    // the other dynamic, the static side is the strictly-correct
+    // tightening (the dynamic side must equal it at runtime).
+    assert(aBatch.size() == bBatch.size());
+    for (size_t i : llvm::seq<size_t>(0, aBatch.size())) {
+      int64_t ad = aBatch[i];
+      int64_t bd = bBatch[i];
+      bool aDyn = ShapedType::isDynamic(ad);
+      bool bDyn = ShapedType::isDynamic(bd);
+      if (!aDyn && !bDyn && ad != bd) {
+        emitError() << "matmul batch dim mismatch at position " << i
+                    << ": A=" << ad << " B=" << bd
+                    << "; per-dim batch broadcasting (1 vs >1) is not "
+                       "supported by codegen";
+        return {};
+      }
+      result.push_back(aDyn ? bd : ad);
+    }
   }
   result.reserve(result.size() + 2);
   result.push_back(M);

--- a/lib/Dialect/IR/HipShapeUtils.cpp
+++ b/lib/Dialect/IR/HipShapeUtils.cpp
@@ -69,12 +69,8 @@ mlir::hip::inferContractionShape(ArrayRef<int64_t> aShape,
     return {};
   }
 
-  // NumPy / ONNX MatMul batch broadcast: right-align, pad with 1, then
-  // per-dim equal-or-1 rule. Delegated to upstream MLIR's helper, which
-  // also implements the TF/ONNX-style "dynamic + static>1 -> static"
-  // tightening: a dynamic side that meets a static side > 1 must be
-  // either 1 (broadcast) or matching the static side at runtime, so the
-  // static side is the inferred result.
+  // Batch broadcast (NumPy / ONNX MatMul) on the leading dims; see header
+  // for the full case table.
   ArrayRef<int64_t> aBatch = aShape.drop_back(2);
   ArrayRef<int64_t> bBatch = bShape.drop_back(2);
   SmallVector<int64_t> result;
@@ -92,23 +88,17 @@ mlir::hip::inferContractionShape(ArrayRef<int64_t> aShape,
 LogicalResult mlir::hip::verifyHipOpShape(
     Operation *op,
     function_ref<SmallVector<SmallVector<int64_t>>()> computeExpected) {
-  // Required-by-construction: every op that wires up `verifyHipOpShape`
-  // also implements `DestinationStyleOpInterface` via TableGen. Use
-  // asserting `cast<>` to express that contract — a missing interface is
-  // a programmer error in the op's TableGen def, not a user-facing
-  // diagnostic.
+  // Asserting cast: every op wired to verifyHipOpShape also implements DPS
+  // via TableGen; a missing interface is a programmer error in the op def.
   auto dpsOp = cast<DestinationStyleOpInterface>(op);
 
+  // Empty outer vector means the shape helper already emitted a diagnostic.
   SmallVector<SmallVector<int64_t>> expected = computeExpected();
-  // Empty outer vector: the shape helper failed and already issued a
-  // diagnostic. Don't double-emit.
   if (expected.empty())
     return failure();
 
-  // Programmer-error invariant: each shape helper returns one expected shape
-  // per DPS init operand by construction. Assert in debug builds; the
-  // `return failure()` keeps release builds safe by avoiding the
-  // out-of-bounds `expected[i]` in the loop below.
+  // Each helper returns one shape per DPS init by construction; assert in
+  // debug, fail-safe in release to avoid OOB on `expected[i]` below.
   auto inits = dpsOp.getDpsInits();
   assert(expected.size() == inits.size() &&
          "shape helper must produce one expected shape per DPS init operand");
@@ -148,9 +138,7 @@ OpFoldResult mlir::hip::reifyDimOrConstant(OpBuilder &b, Location loc,
                                            int64_t sourceDim) {
   if (!ShapedType::isDynamic(staticDim))
     return b.getIndexAttr(staticDim);
-  // `ReifyRankedShapedTypeOpInterface` restricts reify callers to ops with
-  // tensor results, so `source` is always a `RankedTensorType` here. If a
-  // future op exposes reify on a memref result, add the `memref.dim`
-  // branch back together with an LIT case that exercises it.
+  // Reify interface restricts callers to tensor results; if a memref
+  // reify path is added later, also add a memref.dim branch + LIT case.
   return tensor::getMixedSize(b, loc, source, sourceDim);
 }

--- a/lib/Dialect/IR/HipShapeUtils.cpp
+++ b/lib/Dialect/IR/HipShapeUtils.cpp
@@ -164,5 +164,11 @@ OpFoldResult mlir::hip::reifyDimOrConstant(OpBuilder &b, Location loc,
     return tensor::getMixedSize(b, loc, source, sourceDim);
   // memref-mode operand: emit memref.dim. The op canonicalises to a
   // constant when the source memref type has a static size at sourceDim.
+  //
+  // Note: `reifyResultShapes` is only invoked on tensor-result ops
+  // (`ReifyRankedShapedTypeOpInterface` contract), and the
+  // `--hip-infer-shapes` pass walks only `RankedTensorType` results.
+  // No current caller reaches this branch — it's kept as defensive
+  // code in case a future op exposes reify on a memref result type.
   return memref::DimOp::create(b, loc, source, sourceDim).getResult();
 }

--- a/lib/Dialect/IR/HipShapeUtils.cpp
+++ b/lib/Dialect/IR/HipShapeUtils.cpp
@@ -14,7 +14,6 @@
 
 #include "hip/Dialect/IR/HipShapeUtils.h"
 
-#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Interfaces/DestinationStyleOpInterface.h"
@@ -161,15 +160,9 @@ OpFoldResult mlir::hip::reifyDimOrConstant(OpBuilder &b, Location loc,
                                            int64_t sourceDim) {
   if (!ShapedType::isDynamic(staticDim))
     return b.getIndexAttr(staticDim);
-  if (isa<RankedTensorType>(source.getType()))
-    return tensor::getMixedSize(b, loc, source, sourceDim);
-  // memref-mode operand: emit memref.dim. The op canonicalises to a
-  // constant when the source memref type has a static size at sourceDim.
-  //
-  // Note: `reifyResultShapes` is only invoked on tensor-result ops
-  // (`ReifyRankedShapedTypeOpInterface` contract), and the
-  // `--hip-infer-shapes` pass walks only `RankedTensorType` results.
-  // No current caller reaches this branch — it's kept as defensive
-  // code in case a future op exposes reify on a memref result type.
-  return memref::DimOp::create(b, loc, source, sourceDim).getResult();
+  // `ReifyRankedShapedTypeOpInterface` restricts reify callers to ops with
+  // tensor results, so `source` is always a `RankedTensorType` here. If a
+  // future op exposes reify on a memref result, add the `memref.dim`
+  // branch back together with an LIT case that exercises it.
+  return tensor::getMixedSize(b, loc, source, sourceDim);
 }

--- a/lib/Dialect/IR/HipShapeUtils.cpp
+++ b/lib/Dialect/IR/HipShapeUtils.cpp
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- HipShapeUtils.cpp - Shape arithmetic + verifier helpers ------------===//
+//
+// Single source of truth for the static shape of every HIP DPS op.  Each
+// shape category (contraction, elementwise broadcast, axis-driven reduction,
+// ...) lives here as one helper that returns a `SmallVector<int64_t>` where
+// each element is either a concrete dim or `ShapedType::kDynamic`. The same
+// helper is consumed by:
+//
+//   1. The op's `verify()` -- via `verifyHipOpShape`, which compares the
+//      computed shape against the actual `outs` operand types.
+//   2. The op's `reifyResultShapes()` -- which lifts the same dims into
+//      `OpFoldResult`s (IntegerAttr for static, tensor.dim/memref.dim
+//      for kDynamic) so downstream `--resolve-shaped-type-result-dims`
+//      / `--canonicalize` can fold `tensor.dim` of the op's result into
+//      a constant or a dim-of-input.
+//
+// Per-op `reifyResultShapes` impls live next to the op's other methods in
+// `HipDialect.cpp`. They call `inferContractionShape(...)` (or the
+// equivalent for their op family) and pair each entry with
+// `reifyDimOrConstant` to materialise the right `OpFoldResult`.
+//
+// Adding a new shape category
+// ---------------------------
+// Add a free function next to `inferContractionShape` (e.g.
+// `broadcastShapes` for elementwise NumPy broadcast, `inferReductionShape`
+// for axis-driven reduce ops). The new helper takes the operand shapes and
+// any op-specific attributes (axes, perm, ...), and emits a diagnostic
+// through the supplied `emitError` callable on shape mismatch. The op then
+// wires up its `verify()` and `reifyResultShapes()` to call it through
+// `verifyHipOpShape`.
+//
+//===----------------------------------------------------------------------===//
+
+#include "hip/Dialect/IR/HipShapeUtils.h"
+
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/Interfaces/DestinationStyleOpInterface.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/Sequence.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace mlir;
+using namespace mlir::hip;
+
+namespace {
+
+/// Pretty-print a shape vector with `?` for kDynamic. Used in diagnostics.
+std::string formatShape(ArrayRef<int64_t> shape) {
+  std::string out;
+  llvm::raw_string_ostream os(out);
+  os << "[";
+  llvm::interleaveComma(shape, os, [&](int64_t d) {
+    if (ShapedType::isDynamic(d))
+      os << "?";
+    else
+      os << d;
+  });
+  os << "]";
+  return os.str();
+}
+
+} // namespace
+
+SmallVector<int64_t> mlir::hip::inferContractionShape(
+    ArrayRef<int64_t> aShape, ArrayRef<int64_t> bShape,
+    function_ref<InFlightDiagnostic()> emitError) {
+  if (aShape.size() < 2) {
+    emitError() << "matmul A must have rank >= 2, got rank " << aShape.size();
+    return {};
+  }
+  if (bShape.size() < 2) {
+    emitError() << "matmul B must have rank >= 2, got rank " << bShape.size();
+    return {};
+  }
+
+  int64_t M = aShape[aShape.size() - 2];
+  int64_t Ka = aShape.back();
+  int64_t Kb = bShape[bShape.size() - 2];
+  int64_t N = bShape.back();
+
+  // Contraction K must agree (kDynamic on either side is a wildcard).
+  if (!ShapedType::isDynamic(Ka) && !ShapedType::isDynamic(Kb) && Ka != Kb) {
+    emitError() << "matmul contraction dim mismatch: A.shape[-1]=" << Ka
+                << " vs B.shape[-2]=" << Kb;
+    return {};
+  }
+
+  // NumPy-style batch broadcast: right-align, pad missing dims with 1.
+  ArrayRef<int64_t> aBatch = aShape.drop_back(2);
+  ArrayRef<int64_t> bBatch = bShape.drop_back(2);
+  size_t batchRank = std::max(aBatch.size(), bBatch.size());
+  size_t aPad = batchRank - aBatch.size();
+  size_t bPad = batchRank - bBatch.size();
+
+  SmallVector<int64_t> result;
+  result.reserve(batchRank + 2);
+  for (size_t i : llvm::seq<size_t>(0, batchRank)) {
+    int64_t aDim = i < aPad ? 1 : aBatch[i - aPad];
+    int64_t bDim = i < bPad ? 1 : bBatch[i - bPad];
+    int64_t resDim;
+    if (ShapedType::isDynamic(aDim) || ShapedType::isDynamic(bDim))
+      resDim = ShapedType::kDynamic;
+    else if (aDim == 1)
+      resDim = bDim;
+    else if (bDim == 1)
+      resDim = aDim;
+    else if (aDim == bDim)
+      resDim = aDim;
+    else {
+      emitError() << "matmul batch dim broadcast failure at index " << i
+                  << ": A=" << aDim << " B=" << bDim;
+      return {};
+    }
+    result.push_back(resDim);
+  }
+  result.push_back(M);
+  result.push_back(N);
+  return result;
+}
+
+LogicalResult mlir::hip::verifyHipOpShape(
+    Operation *op,
+    function_ref<SmallVector<SmallVector<int64_t>>()> computeExpected,
+    bool checkElementType) {
+  auto dpsOp = dyn_cast<DestinationStyleOpInterface>(op);
+  if (!dpsOp)
+    return op->emitOpError(
+        "verifyHipOpShape requires DestinationStyleOpInterface");
+
+  SmallVector<SmallVector<int64_t>> expected = computeExpected();
+  // Empty outer vector: the shape helper failed and already issued a
+  // diagnostic. Don't double-emit.
+  if (expected.empty())
+    return failure();
+
+  auto inits = dpsOp.getDpsInits();
+  if (expected.size() != inits.size())
+    return op->emitOpError("internal: shape helper produced ")
+           << expected.size() << " expected shape(s) but op has "
+           << inits.size() << " init operand(s)";
+
+  for (auto [i, init] : llvm::enumerate(inits)) {
+    auto initType = dyn_cast<ShapedType>(init.getType());
+    if (!initType)
+      return op->emitOpError("init #") << i << " is not a shaped type";
+    ArrayRef<int64_t> actualShape = initType.getShape();
+    ArrayRef<int64_t> expShape = expected[i];
+    if (actualShape.size() != expShape.size())
+      return op->emitOpError("rank mismatch on result #")
+             << i << ": expected rank " << expShape.size() << " "
+             << formatShape(expShape) << " but outs has rank "
+             << actualShape.size() << " " << formatShape(actualShape);
+    for (size_t d : llvm::seq<size_t>(0, actualShape.size())) {
+      // kDynamic on either side is a wildcard.
+      if (ShapedType::isDynamic(actualShape[d]) ||
+          ShapedType::isDynamic(expShape[d]))
+        continue;
+      if (actualShape[d] != expShape[d])
+        return op->emitOpError("dim ")
+               << d << " of result #" << i << " mismatch: expected "
+               << expShape[d] << " " << formatShape(expShape)
+               << " but outs has " << actualShape[d] << " "
+               << formatShape(actualShape);
+    }
+  }
+
+  if (checkElementType) {
+    auto inputs = dpsOp.getDpsInputs();
+    if (!inputs.empty()) {
+      if (auto inputType = dyn_cast<ShapedType>(inputs[0].getType())) {
+        Type expectedET = inputType.getElementType();
+        for (auto [i, init] : llvm::enumerate(inits)) {
+          auto initType = dyn_cast<ShapedType>(init.getType());
+          if (initType && initType.getElementType() != expectedET)
+            return op->emitOpError("element type mismatch on result #")
+                   << i << ": expected " << expectedET << " but got "
+                   << initType.getElementType();
+        }
+      }
+    }
+  }
+  return success();
+}
+
+OpFoldResult mlir::hip::reifyDimOrConstant(OpBuilder &b, Location loc,
+                                           int64_t staticDim, Value source,
+                                           int64_t sourceDim) {
+  if (!ShapedType::isDynamic(staticDim))
+    return b.getIndexAttr(staticDim);
+  if (isa<RankedTensorType>(source.getType()))
+    return tensor::getMixedSize(b, loc, source, sourceDim);
+  // memref-mode operand: emit memref.dim. The op canonicalises to a
+  // constant when the source memref type has a static size at sourceDim.
+  return memref::DimOp::create(b, loc, source, sourceDim).getResult();
+}

--- a/lib/Dialect/IR/HipShapeUtils.cpp
+++ b/lib/Dialect/IR/HipShapeUtils.cpp
@@ -15,6 +15,7 @@
 #include "hip/Dialect/IR/HipShapeUtils.h"
 
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Traits.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Interfaces/DestinationStyleOpInterface.h"
 #include "llvm/ADT/STLExtras.h"
@@ -68,34 +69,21 @@ mlir::hip::inferContractionShape(ArrayRef<int64_t> aShape,
     return {};
   }
 
-  // NumPy-style batch broadcast: right-align, pad missing dims with 1.
+  // NumPy / ONNX MatMul batch broadcast: right-align, pad with 1, then
+  // per-dim equal-or-1 rule. Delegated to upstream MLIR's helper, which
+  // also implements the TF/ONNX-style "dynamic + static>1 -> static"
+  // tightening: a dynamic side that meets a static side > 1 must be
+  // either 1 (broadcast) or matching the static side at runtime, so the
+  // static side is the inferred result.
   ArrayRef<int64_t> aBatch = aShape.drop_back(2);
   ArrayRef<int64_t> bBatch = bShape.drop_back(2);
-  size_t batchRank = std::max(aBatch.size(), bBatch.size());
-  size_t aPad = batchRank - aBatch.size();
-  size_t bPad = batchRank - bBatch.size();
-
   SmallVector<int64_t> result;
-  result.reserve(batchRank + 2);
-  for (size_t i : llvm::seq<size_t>(0, batchRank)) {
-    int64_t aDim = i < aPad ? 1 : aBatch[i - aPad];
-    int64_t bDim = i < bPad ? 1 : bBatch[i - bPad];
-    int64_t resDim;
-    if (ShapedType::isDynamic(aDim) || ShapedType::isDynamic(bDim))
-      resDim = ShapedType::kDynamic;
-    else if (aDim == 1)
-      resDim = bDim;
-    else if (bDim == 1)
-      resDim = aDim;
-    else if (aDim == bDim)
-      resDim = aDim;
-    else {
-      emitError() << "matmul batch dim broadcast failure at index " << i
-                  << ": A=" << aDim << " B=" << bDim;
-      return {};
-    }
-    result.push_back(resDim);
+  if (!OpTrait::util::getBroadcastedShape(aBatch, bBatch, result)) {
+    emitError() << "matmul batch broadcast failure: A.batch="
+                << formatShape(aBatch) << " B.batch=" << formatShape(bBatch);
+    return {};
   }
+  result.reserve(result.size() + 2);
   result.push_back(M);
   result.push_back(N);
   return result;

--- a/lib/Dialect/IR/HipShapeUtils.cpp
+++ b/lib/Dialect/IR/HipShapeUtils.cpp
@@ -4,34 +4,11 @@
  */
 //===- HipShapeUtils.cpp - Shape arithmetic + verifier helpers ------------===//
 //
-// Single source of truth for the static shape of every HIP DPS op.  Each
-// shape category (contraction, elementwise broadcast, axis-driven reduction,
-// ...) lives here as one helper that returns a `SmallVector<int64_t>` where
-// each element is either a concrete dim or `ShapedType::kDynamic`. The same
-// helper is consumed by:
-//
-//   1. The op's `verify()` -- via `verifyHipOpShape`, which compares the
-//      computed shape against the actual `outs` operand types.
-//   2. The op's `reifyResultShapes()` -- which lifts the same dims into
-//      `OpFoldResult`s (IntegerAttr for static, tensor.dim/memref.dim
-//      for kDynamic) so downstream `--resolve-shaped-type-result-dims`
-//      / `--canonicalize` can fold `tensor.dim` of the op's result into
-//      a constant or a dim-of-input.
-//
-// Per-op `reifyResultShapes` impls live next to the op's other methods in
-// `HipDialect.cpp`. They call `inferContractionShape(...)` (or the
-// equivalent for their op family) and pair each entry with
-// `reifyDimOrConstant` to materialise the right `OpFoldResult`.
-//
-// Adding a new shape category
-// ---------------------------
-// Add a free function next to `inferContractionShape` (e.g.
-// `broadcastShapes` for elementwise NumPy broadcast, `inferReductionShape`
-// for axis-driven reduce ops). The new helper takes the operand shapes and
-// any op-specific attributes (axes, perm, ...), and emits a diagnostic
-// through the supplied `emitError` callable on shape mismatch. The op then
-// wires up its `verify()` and `reifyResultShapes()` to call it through
-// `verifyHipOpShape`.
+// Implementation of the helpers declared in `HipShapeUtils.h`. See the
+// per-symbol Doxygen comments there for the API contract, and
+// `docs/design/hip-shape-inference.md` for the rationale, component
+// layout, and the recipe for wiring a new op (or a new shape category)
+// into the verify / reify / propagate pipeline.
 //
 //===----------------------------------------------------------------------===//
 
@@ -126,8 +103,7 @@ SmallVector<int64_t> mlir::hip::inferContractionShape(
 
 LogicalResult mlir::hip::verifyHipOpShape(
     Operation *op,
-    function_ref<SmallVector<SmallVector<int64_t>>()> computeExpected,
-    bool checkElementType) {
+    function_ref<SmallVector<SmallVector<int64_t>>()> computeExpected) {
   // Required-by-construction: every op that wires up `verifyHipOpShape`
   // also implements `DestinationStyleOpInterface` via TableGen. Asserting
   // cast matches the upstream Linalg pattern in `verifyStructuredOpInterface`
@@ -176,21 +152,6 @@ LogicalResult mlir::hip::verifyHipOpShape(
     }
   }
 
-  if (checkElementType) {
-    auto inputs = dpsOp.getDpsInputs();
-    if (!inputs.empty()) {
-      if (auto inputType = dyn_cast<ShapedType>(inputs[0].getType())) {
-        Type expectedET = inputType.getElementType();
-        for (auto [i, init] : llvm::enumerate(inits)) {
-          auto initType = dyn_cast<ShapedType>(init.getType());
-          if (initType && initType.getElementType() != expectedET)
-            return op->emitOpError("element type mismatch on result #")
-                   << i << ": expected " << expectedET << " but got "
-                   << initType.getElementType();
-        }
-      }
-    }
-  }
   return success();
 }
 

--- a/lib/Dialect/IR/HipShapeUtils.cpp
+++ b/lib/Dialect/IR/HipShapeUtils.cpp
@@ -15,6 +15,7 @@
 #include "hip/Dialect/IR/HipShapeUtils.h"
 
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Traits.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Interfaces/DestinationStyleOpInterface.h"
 #include "llvm/ADT/STLExtras.h"
@@ -47,44 +48,18 @@ SmallVector<int64_t>
 mlir::hip::inferContractionShape(ArrayRef<int64_t> aShape,
                                  ArrayRef<int64_t> bShape,
                                  function_ref<InFlightDiagnostic()> emitError) {
-  size_t aRank = aShape.size();
-  size_t bRank = bShape.size();
-  if (aRank < 2) {
-    emitError() << "matmul A must have rank >= 2, got rank " << aRank;
+  if (aShape.size() < 2) {
+    emitError() << "matmul A must have rank >= 2, got rank " << aShape.size();
     return {};
   }
-  if (bRank < 2) {
-    emitError() << "matmul B must have rank >= 2, got rank " << bRank;
-    return {};
-  }
-
-  // Tightened contract: matches what `MatMulConversion.cpp` +
-  // `MatmulLowering.cpp` actually compute correctly today. Codegen
-  // derives result rank and batchCount from `A`, with optional `B`
-  // rank-2 broadcast (one matrix re-used across all batches). Anything
-  // wider — `B`'s rank > `A`'s rank, mixed ranks where `B` is not
-  // exactly rank-2, or per-dim batch broadcasting (`1` vs `>1`) —
-  // would be miscompiled by codegen + runtime, so the verifier rejects
-  // it here. Widening this contract requires matching widening in
-  // codegen and the runtime's strided-batch layout (zero stride for
-  // the broadcast side). Tracked under "Codegen contract" in
-  // `docs/design/hip-shape-inference.md`.
-  if (bRank > aRank) {
-    emitError() << "matmul B's rank (" << bRank << ") exceeds A's rank ("
-                << aRank
-                << "); B-side batch broadcasting is not supported by codegen";
-    return {};
-  }
-  if (aRank > bRank && bRank != 2) {
-    emitError() << "matmul mixed-rank operands require B to be rank-2 (got A "
-                   "rank "
-                << aRank << ", B rank " << bRank << ")";
+  if (bShape.size() < 2) {
+    emitError() << "matmul B must have rank >= 2, got rank " << bShape.size();
     return {};
   }
 
-  int64_t M = aShape[aRank - 2];
+  int64_t M = aShape[aShape.size() - 2];
   int64_t Ka = aShape.back();
-  int64_t Kb = bShape[bRank - 2];
+  int64_t Kb = bShape[bShape.size() - 2];
   int64_t N = bShape.back();
 
   // Contraction K must agree (kDynamic on either side is a wildcard).
@@ -94,34 +69,15 @@ mlir::hip::inferContractionShape(ArrayRef<int64_t> aShape,
     return {};
   }
 
+  // Batch broadcast (NumPy / ONNX MatMul) on the leading dims; see header
+  // for the full case table.
   ArrayRef<int64_t> aBatch = aShape.drop_back(2);
   ArrayRef<int64_t> bBatch = bShape.drop_back(2);
   SmallVector<int64_t> result;
-  if (bBatch.empty()) {
-    // ND x 2D: result batch = A's batch (one matrix B re-used across all
-    // batches). Codegen path: MatmulLowering computes batchCount from A's
-    // leading dims and runtime treats B as zero-stride for the batch loop.
-    result.assign(aBatch.begin(), aBatch.end());
-  } else {
-    // Same-rank batched matmul: per-position batch dim equality.
-    // kDynamic on either side is a wildcard; if one side is static and
-    // the other dynamic, the static side is the strictly-correct
-    // tightening (the dynamic side must equal it at runtime).
-    assert(aBatch.size() == bBatch.size());
-    for (size_t i : llvm::seq<size_t>(0, aBatch.size())) {
-      int64_t ad = aBatch[i];
-      int64_t bd = bBatch[i];
-      bool aDyn = ShapedType::isDynamic(ad);
-      bool bDyn = ShapedType::isDynamic(bd);
-      if (!aDyn && !bDyn && ad != bd) {
-        emitError() << "matmul batch dim mismatch at position " << i
-                    << ": A=" << ad << " B=" << bd
-                    << "; per-dim batch broadcasting (1 vs >1) is not "
-                       "supported by codegen";
-        return {};
-      }
-      result.push_back(aDyn ? bd : ad);
-    }
+  if (!OpTrait::util::getBroadcastedShape(aBatch, bBatch, result)) {
+    emitError() << "matmul batch broadcast failure: A.batch="
+                << formatShape(aBatch) << " B.batch=" << formatShape(bBatch);
+    return {};
   }
   result.reserve(result.size() + 2);
   result.push_back(M);

--- a/lib/Dialect/IR/HipShapeUtils.cpp
+++ b/lib/Dialect/IR/HipShapeUtils.cpp
@@ -44,9 +44,10 @@ std::string formatShape(ArrayRef<int64_t> shape) {
 
 } // namespace
 
-SmallVector<int64_t> mlir::hip::inferContractionShape(
-    ArrayRef<int64_t> aShape, ArrayRef<int64_t> bShape,
-    function_ref<InFlightDiagnostic()> emitError) {
+SmallVector<int64_t>
+mlir::hip::inferContractionShape(ArrayRef<int64_t> aShape,
+                                 ArrayRef<int64_t> bShape,
+                                 function_ref<InFlightDiagnostic()> emitError) {
   if (aShape.size() < 2) {
     emitError() << "matmul A must have rank >= 2, got rank " << aShape.size();
     return {};

--- a/lib/Dialect/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Transforms/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(HipDialectTransforms STATIC
   AddHipContextArg.cpp
   BufferUtils.cpp
   GenerateInterface.cpp
+  InferShapesPass.cpp
   LowerAllocs.cpp
   MaterializeHostScalars.cpp
   OptimizeMemRefs.cpp
@@ -46,5 +47,7 @@ target_link_libraries(HipDialectTransforms PUBLIC
   MLIRFuncToLLVM
   MLIRAffineToStandard
   MLIRReconcileUnrealizedCasts
+  MLIRInferTypeOpInterface
+  MLIRTensorDialect
   flatbuffers::flatbuffers
 )

--- a/lib/Dialect/Transforms/InferShapesPass.cpp
+++ b/lib/Dialect/Transforms/InferShapesPass.cpp
@@ -84,32 +84,14 @@ static bool composeRefinedShape(ArrayRef<int64_t> cur,
   return refined;
 }
 
-/// Build a refined `tensor.empty` for `emptyOp` and attach it to the
-/// `outs` operand of `dpsOp` at `resultIdx`. Per-edge mutation: only the
-/// DPS-init operand is rewired; other users of `emptyOp` (if any) keep
-/// their original less-static type. The old `emptyOp` is left in place;
-/// canonicalization DCEs it if no live uses remain.
+/// Rebuild `emptyOp` with the refined shape. Dynamic-dim operands whose
+/// corresponding dim became static are dropped.
 ///
-/// `replaceOp` would rewire every user of `emptyOp` to the more-static
-/// new value, leaking the static type past the per-op refinement
-/// boundary that `refineOneResult` enforces with `tensor.cast` on the
-/// result side. The cast barrier is for non-DPS-init uses of the OP
-/// RESULT; producer-side leaks need a symmetric per-edge primitive.
-///
-/// Before:
-///   %e = tensor.empty(%d) : tensor<?xf16>
-///   %y = hip.foo outs(%e : tensor<?xf16>) : tensor<?xf16>
-///   <other_use>(%e)
-/// After (newShape narrows to tensor<8xf16> for hip.foo's outs):
-///   %e = tensor.empty(%d) : tensor<?xf16>          // unchanged
-///   <other_use>(%e)                                // unchanged
-///   %e2 = tensor.empty() : tensor<8xf16>
-///   %y = hip.foo outs(%e2 : tensor<8xf16>) : tensor<8xf16>
-static LogicalResult
-refineTensorEmptyProducer(RewriterBase &rewriter,
-                          DestinationStyleOpInterface dpsOp, unsigned resultIdx,
-                          tensor::EmptyOp emptyOp,
-                          ArrayRef<int64_t> newShape) {
+/// Before: %init = tensor.empty(%d0, %d1) : tensor<?x4x?xf16>; newShape=[2,4,8]
+/// After : %init = tensor.empty() : tensor<2x4x8xf16>
+static LogicalResult refineTensorEmptyProducer(RewriterBase &rewriter,
+                                               tensor::EmptyOp emptyOp,
+                                               ArrayRef<int64_t> newShape) {
   auto curType = emptyOp.getType();
   if (curType.getShape().size() != newShape.size())
     return failure();
@@ -133,8 +115,7 @@ refineTensorEmptyProducer(RewriterBase &rewriter,
   rewriter.setInsertionPoint(emptyOp);
   auto newEmpty =
       tensor::EmptyOp::create(rewriter, emptyOp.getLoc(), newType, newDyn);
-  // Per-edge rewire: only this DPS-init operand sees the new value.
-  dpsOp.getDpsInitsMutable()[resultIdx].set(newEmpty.getResult());
+  rewriter.replaceOp(emptyOp, newEmpty.getResult());
   ++NumProducersRefined;
   return success();
 }
@@ -166,8 +147,7 @@ static LogicalResult refineOneResult(RewriterBase &rewriter,
                         << ": outs producer is not tensor.empty\n");
       return failure();
     }
-    if (failed(refineTensorEmptyProducer(rewriter, dpsOp, resultIdx,
-                                         emptyProducer, newShape)))
+    if (failed(refineTensorEmptyProducer(rewriter, emptyProducer, newShape)))
       return failure();
   }
 

--- a/lib/Dialect/Transforms/InferShapesPass.cpp
+++ b/lib/Dialect/Transforms/InferShapesPass.cpp
@@ -74,10 +74,17 @@ static bool composeRefinedShape(ArrayRef<int64_t> cur,
   bool refined = false;
   out.assign(cur.begin(), cur.end());
   for (size_t d : llvm::seq<size_t>(0, cur.size())) {
-    if (!ShapedType::isDynamic(cur[d]))
+    std::optional<int64_t> reifCst = getConstantIntValue(reif[d]);
+    if (!ShapedType::isDynamic(cur[d])) {
+      // Static dim must agree with reify if reify gave a constant. A
+      // mismatch is an op-author bug in `reifyResultShapes` and would
+      // otherwise be silently swallowed by the pass.
+      assert((!reifCst || *reifCst == cur[d]) &&
+             "reifyResultShapes contradicts existing static dim");
       continue;
-    if (std::optional<int64_t> s = getConstantIntValue(reif[d])) {
-      out[d] = *s;
+    }
+    if (reifCst) {
+      out[d] = *reifCst;
       refined = true;
     }
   }
@@ -145,6 +152,16 @@ static LogicalResult refineOneResult(RewriterBase &rewriter,
     if (!emptyProducer) {
       LLVM_DEBUG(DBGS() << "skip " << op->getName() << " result #" << resultIdx
                         << ": outs producer is not tensor.empty\n");
+      return failure();
+    }
+    // Refining a shared `tensor.empty` would retype every sibling
+    // consumer's outs operand without retyping their result, breaking
+    // the DPS contract (outs.type == result.type) on the unrefined
+    // sibling. No converter aliases empties today; the guard makes the
+    // single-use invariant local to this pass.
+    if (!emptyProducer->hasOneUse()) {
+      LLVM_DEBUG(DBGS() << "skip " << op->getName() << " result #" << resultIdx
+                        << ": outs producer is a shared tensor.empty\n");
       return failure();
     }
     if (failed(refineTensorEmptyProducer(rewriter, emptyProducer, newShape)))

--- a/lib/Dialect/Transforms/InferShapesPass.cpp
+++ b/lib/Dialect/Transforms/InferShapesPass.cpp
@@ -185,10 +185,10 @@ static LogicalResult refineTensorEmptyProducer(RewriterBase &rewriter,
 /// Refine a single result of a single op. Returns success() iff at least
 /// one dim was narrowed; failure() means "nothing to do" or "couldn't
 /// safely refine here".
-static LogicalResult
-refineOneResult(RewriterBase &rewriter,
-                ReifyRankedShapedTypeOpInterface reifyOp, unsigned resultIdx,
-                ArrayRef<OpFoldResult> reifiedDims) {
+static LogicalResult refineOneResult(RewriterBase &rewriter,
+                                     ReifyRankedShapedTypeOpInterface reifyOp,
+                                     unsigned resultIdx,
+                                     ArrayRef<OpFoldResult> reifiedDims) {
   Operation *op = reifyOp.getOperation();
   auto curType = dyn_cast<RankedTensorType>(op->getResult(resultIdx).getType());
   if (!curType)

--- a/lib/Dialect/Transforms/InferShapesPass.cpp
+++ b/lib/Dialect/Transforms/InferShapesPass.cpp
@@ -86,7 +86,6 @@
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Interfaces/DestinationStyleOpInterface.h"
-#include "mlir/Interfaces/InferTypeOpInterface.h"
 
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/Sequence.h"

--- a/lib/Dialect/Transforms/InferShapesPass.cpp
+++ b/lib/Dialect/Transforms/InferShapesPass.cpp
@@ -1,0 +1,300 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- InferShapesPass.cpp - Static shape refinement for HIP DPS ops ------===//
+//
+// Module-level pass that drives `ReifyRankedShapedTypeOpInterface` on every
+// HIP op (and any other ranked-tensor-result op that implements the
+// interface) to refine `?` (kDynamic) dims in result types into concrete
+// integer dims, using the per-op `inferContractionShape`-style helpers as
+// the source of truth.
+//
+// DPS-aware
+// ---------
+// HIP DPS ops require `result_type == outs_operand_type`; refining the op's
+// result type without matching the outs operand's producer would produce a
+// verifier error.  This pass handles that by also rewriting the producer
+// when it is a `tensor.empty` (the only zero-cost refinement we can do
+// today: tensor.empty is a pure constructor that supports any rank / dyn-dim
+// arrangement, so we rebuild it with the new shape and drop any dynamic-dim
+// operands that became static).  Producers we don't know how to refine are
+// skipped, leaving the op's result type unchanged at that result index.
+//
+// Walk order and chained DPS ops
+// ------------------------------
+// Pre-collect candidates with `module.walk` (post-order). The walk order
+// gives us producers before consumers in a straight-line function. We
+// process candidates in that order and for each refined result we emit
+// exactly one `tensor.cast` that bridges the new (more-static) type back
+// to the original type for every non-DPS-init use; DPS-init uses are
+// skipped because for a DPS consumer `result_type == outs_operand_type`
+// is the spec contract -- if we cast on that edge, refining the consumer
+// would fail the "outs producer is tensor.empty" gate downstream.
+//
+// IMPORTANT: the cast is *the* propagation barrier, not a propagation
+// channel. A consumer reading the cast as an `ins` operand sees the OLD
+// type, so its own reify runs against the OLD operand type. Refinement
+// of the consumer's result therefore depends only on what the consumer's
+// own static reify can deduce from operand types it can still see -- it
+// does NOT transitively inherit the producer's narrowing across an `ins`
+// edge. Refinement is per-op, not whole-chain. This is intentional:
+// a transitive narrowing scheme would require either retyping the cast
+// (and re-checking every downstream signature) or skipping the cast on
+// trust (and breaking ops whose verify pins ins types). Per-op refinement
+// is the local, terminating, verifier-safe choice. See
+// `refine_chained_matmul` in test/lit/Dialect/hip-infer-shapes.mlir for
+// the canonical example.
+//
+// What this pass does NOT do
+// --------------------------
+//   * No control-flow analysis.  Result types inside `scf.if` / `scf.while`
+//     bodies are not propagated across the region boundary.  Block argument
+//     types stay as written.
+//   * No element-type refinement.  Only the shape (dim sizes) is touched.
+//   * No verifier replay.  Callers should run `mlir-opt --verify-diagnostics`
+//     once after this pass to confirm the refined IR still verifies.
+//
+// Example (matmul, dynamic batch becoming static)
+// -----------------------------------------------
+//
+// Before:
+//
+//   %empty = tensor.empty(%c2) : tensor<?x4x8xf16>
+//   %y = hip.matmul(%ctx) ins(%a, %b : tensor<2x4x4xf16>,
+//                                       tensor<4x8xf16>)
+//                          outs(%empty : tensor<?x4x8xf16>)
+//                          -> tensor<?x4x8xf16>
+//
+// After:
+//
+//   %empty = tensor.empty() : tensor<2x4x8xf16>
+//   %y = hip.matmul(%ctx) ins(%a, %b : tensor<2x4x4xf16>,
+//                                       tensor<4x8xf16>)
+//                          outs(%empty : tensor<2x4x8xf16>)
+//                          -> tensor<2x4x8xf16>
+//
+//===----------------------------------------------------------------------===//
+
+#include "hip/Dialect/IR/HipDialect.h"
+#include "hip/Dialect/Transforms/Passes.h"
+
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Interfaces/DestinationStyleOpInterface.h"
+#include "mlir/Interfaces/InferTypeOpInterface.h"
+
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/Sequence.h"
+#include "llvm/ADT/Statistic.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "hip-infer-shapes"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "] ")
+
+STATISTIC(NumResultsRefined,
+          "Number of op result types refined by --hip-infer-shapes");
+STATISTIC(NumProducersRefined,
+          "Number of tensor.empty producers rebuilt with a more-static shape");
+
+namespace mlir {
+namespace hip {
+
+#define GEN_PASS_DEF_INFERSHAPESPASS
+#include "hip/Dialect/Transforms/Passes.h.inc"
+
+namespace {
+
+/// Compose a refined shape vector from the current type's shape and the
+/// reified per-dim `OpFoldResult`s. For each dim, the existing static
+/// value is preserved; if the dim is currently `kDynamic` and the reified
+/// `OpFoldResult` is a constant integer, the constant replaces it.
+/// Returns true iff at least one dim moved from `kDynamic` to static.
+///
+/// Precondition: `cur.size() == reif.size()`. The
+/// `ReifyRankedShapedTypeOpInterface` contract guarantees one
+/// `OpFoldResult` per dim of the reified result; a mismatch signals a
+/// programmer error in the op's `reifyResultShapes` impl.
+static bool composeRefinedShape(ArrayRef<int64_t> cur,
+                                ArrayRef<OpFoldResult> reif,
+                                SmallVectorImpl<int64_t> &out) {
+  assert(cur.size() == reif.size() &&
+         "rank mismatch between current type and reified shape");
+  bool refined = false;
+  out.assign(cur.begin(), cur.end());
+  for (size_t d : llvm::seq<size_t>(0, cur.size())) {
+    if (!ShapedType::isDynamic(cur[d]))
+      continue;
+    if (std::optional<int64_t> s = getConstantIntValue(reif[d])) {
+      out[d] = *s;
+      refined = true;
+    }
+  }
+  return refined;
+}
+
+/// If `emptyOp`'s rank matches `newShape`, rebuild it with the refined
+/// shape and replace all uses; dynamic-dim operands whose corresponding
+/// dim has become static are dropped from the operand list.
+///
+/// Before: `%init = tensor.empty(%d0, %d1) : tensor<?x4x?xf16>`
+///         and newShape = [2, 4, 8]
+/// After : `%init = tensor.empty() : tensor<2x4x8xf16>`
+///
+/// Returns failure() and leaves the producer untouched on rank mismatch.
+static LogicalResult refineTensorEmptyProducer(RewriterBase &rewriter,
+                                               tensor::EmptyOp emptyOp,
+                                               ArrayRef<int64_t> newShape) {
+  auto curType = emptyOp.getType();
+  if (curType.getShape().size() != newShape.size())
+    return failure();
+
+  // Rebuild the dyn-dim operand list: keep an operand iff the dim was
+  // dynamic before AND remains dynamic after. We never see a "now-dynamic
+  // formerly-static" case because composeRefinedShape only narrows.
+  SmallVector<Value> newDyn;
+  unsigned operandIdx = 0;
+  for (size_t d : llvm::seq<size_t>(0, newShape.size())) {
+    bool curDynamic = curType.isDynamicDim(d);
+    bool newDynamic = ShapedType::isDynamic(newShape[d]);
+    if (curDynamic && !newDynamic) {
+      ++operandIdx;
+      continue;
+    }
+    if (curDynamic && newDynamic) {
+      newDyn.push_back(emptyOp.getDynamicSizes()[operandIdx++]);
+      continue;
+    }
+  }
+
+  // `clone(shape)` preserves the encoding attr (mirrors upstream
+  // `RankedTensorType::clone`); plain `RankedTensorType::get(shape, et)`
+  // would drop it.
+  auto newType = curType.clone(newShape);
+  rewriter.setInsertionPoint(emptyOp);
+  auto newEmpty =
+      tensor::EmptyOp::create(rewriter, emptyOp.getLoc(), newType, newDyn);
+  rewriter.replaceOp(emptyOp, newEmpty.getResult());
+  ++NumProducersRefined;
+  return success();
+}
+
+/// Refine a single result of a single op. Returns success() iff at least
+/// one dim was narrowed; failure() means "nothing to do" or "couldn't
+/// safely refine here".
+static LogicalResult
+refineOneResult(RewriterBase &rewriter,
+                ReifyRankedShapedTypeOpInterface reifyOp, unsigned resultIdx,
+                ArrayRef<OpFoldResult> reifiedDims) {
+  Operation *op = reifyOp.getOperation();
+  auto curType = dyn_cast<RankedTensorType>(op->getResult(resultIdx).getType());
+  if (!curType)
+    return failure();
+
+  SmallVector<int64_t> newShape;
+  if (!composeRefinedShape(curType.getShape(), reifiedDims, newShape))
+    return failure();
+
+  // For DPS ops, the spec contract is `result_type == outs_operand_type`.
+  // The only producer we can rebuild zero-cost today is `tensor.empty`;
+  // everything else (function args, results of other DPS ops, etc.) is
+  // left alone -- skipping is the verifier-safe choice.
+  auto dpsOp = dyn_cast<DestinationStyleOpInterface>(op);
+  if (dpsOp && resultIdx < dpsOp.getDpsInits().size()) {
+    Value outsOperand = dpsOp.getDpsInits()[resultIdx];
+    auto emptyProducer = outsOperand.getDefiningOp<tensor::EmptyOp>();
+    if (!emptyProducer) {
+      LLVM_DEBUG(DBGS() << "skip " << op->getName() << " result #" << resultIdx
+                        << ": outs producer is not tensor.empty\n");
+      return failure();
+    }
+    if (failed(refineTensorEmptyProducer(rewriter, emptyProducer, newShape)))
+      return failure();
+  }
+
+  // In-place type narrow on the op's result. We don't `rewriter.replaceOp`
+  // here because that would invalidate every existing use's `OpOperand`
+  // pointer before we get to insert the cast. Type-only mutation followed
+  // by selective cast insertion is the same pattern upstream
+  // `ReifyResultShapesPass` uses, just expressed in-place on the same op
+  // instead of via clone+replace (we don't need the clone since the op's
+  // operand list is unchanged).
+  Value result = op->getResult(resultIdx);
+  Type oldType = result.getType();
+  result.setType(curType.clone(newShape));
+  ++NumResultsRefined;
+
+  // Snapshot uses before mutation; iterating `result.getUses()` while
+  // simultaneously rewriting use edges is undefined.
+  SmallVector<OpOperand *> usesToCast;
+  for (OpOperand &use : result.getUses()) {
+    // DPS-init uses on the consumer are intentionally NOT cast: for a
+    // DPS consumer, `result_type == outs_operand_type` is the spec, so
+    // a cast on that edge would force us to also retype the consumer's
+    // result, fighting the same gate this pass enforces in the
+    // producer-refinement step above.
+    if (auto userDps = dyn_cast<DestinationStyleOpInterface>(use.getOwner())) {
+      if (userDps.isDpsInit(&use))
+        continue;
+    }
+    usesToCast.push_back(&use);
+  }
+  if (!usesToCast.empty()) {
+    rewriter.setInsertionPointAfter(op);
+    auto cast = tensor::CastOp::create(rewriter, op->getLoc(), oldType, result);
+    for (OpOperand *use : usesToCast)
+      use->set(cast.getResult());
+  }
+  return success();
+}
+
+struct InferShapesPass : public impl::InferShapesPassBase<InferShapesPass> {
+  // The TableGen `let dependentDialects = [...]` covers loading at pass-
+  // manager init, but stating it explicitly here too matches the style
+  // used elsewhere in this dialect (PromoteStridedHipOperands.cpp,
+  // PoolAllocs.cpp) and makes it grep-discoverable from the .cpp.
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<HipDialect, tensor::TensorDialect>();
+  }
+
+  void runOnOperation() override;
+};
+
+void InferShapesPass::runOnOperation() {
+  ModuleOp module = getOperation();
+
+  // Collect candidates first; mutating the IR mid-walk can re-trigger the
+  // walk on rebuilt ops or invalidate iterators. The walk is post-order
+  // by default, so consumers come after producers in `ops`; we then iterate
+  // forward, which gives producers-before-consumers (the safe order).
+  SmallVector<ReifyRankedShapedTypeOpInterface> ops;
+  module.walk([&](ReifyRankedShapedTypeOpInterface reifyOp) {
+    // memref-mode DPS ops have no tensor results: skip. Their shapes are
+    // pinned at bufferization time.
+    if (llvm::none_of(reifyOp.getOperation()->getResults(), [](Value v) {
+          return isa<RankedTensorType>(v.getType());
+        }))
+      return;
+    ops.push_back(reifyOp);
+  });
+
+  IRRewriter rewriter(&getContext());
+  for (ReifyRankedShapedTypeOpInterface reifyOp : ops) {
+    Operation *op = reifyOp.getOperation();
+    rewriter.setInsertionPoint(op);
+
+    ReifiedRankedShapedTypeDims reified;
+    if (failed(reifyOp.reifyResultShapes(rewriter, reified)))
+      continue;
+    if (reified.size() != op->getNumResults())
+      continue;
+
+    for (auto [resultIdx, dims] : llvm::enumerate(reified))
+      (void)refineOneResult(rewriter, reifyOp, resultIdx, dims);
+  }
+}
+
+} // namespace
+} // namespace hip
+} // namespace mlir

--- a/lib/Dialect/Transforms/InferShapesPass.cpp
+++ b/lib/Dialect/Transforms/InferShapesPass.cpp
@@ -84,14 +84,32 @@ static bool composeRefinedShape(ArrayRef<int64_t> cur,
   return refined;
 }
 
-/// Rebuild `emptyOp` with the refined shape. Dynamic-dim operands whose
-/// corresponding dim became static are dropped.
+/// Build a refined `tensor.empty` for `emptyOp` and attach it to the
+/// `outs` operand of `dpsOp` at `resultIdx`. Per-edge mutation: only the
+/// DPS-init operand is rewired; other users of `emptyOp` (if any) keep
+/// their original less-static type. The old `emptyOp` is left in place;
+/// canonicalization DCEs it if no live uses remain.
 ///
-/// Before: %init = tensor.empty(%d0, %d1) : tensor<?x4x?xf16>; newShape=[2,4,8]
-/// After : %init = tensor.empty() : tensor<2x4x8xf16>
-static LogicalResult refineTensorEmptyProducer(RewriterBase &rewriter,
-                                               tensor::EmptyOp emptyOp,
-                                               ArrayRef<int64_t> newShape) {
+/// `replaceOp` would rewire every user of `emptyOp` to the more-static
+/// new value, leaking the static type past the per-op refinement
+/// boundary that `refineOneResult` enforces with `tensor.cast` on the
+/// result side. The cast barrier is for non-DPS-init uses of the OP
+/// RESULT; producer-side leaks need a symmetric per-edge primitive.
+///
+/// Before:
+///   %e = tensor.empty(%d) : tensor<?xf16>
+///   %y = hip.foo outs(%e : tensor<?xf16>) : tensor<?xf16>
+///   <other_use>(%e)
+/// After (newShape narrows to tensor<8xf16> for hip.foo's outs):
+///   %e = tensor.empty(%d) : tensor<?xf16>          // unchanged
+///   <other_use>(%e)                                // unchanged
+///   %e2 = tensor.empty() : tensor<8xf16>
+///   %y = hip.foo outs(%e2 : tensor<8xf16>) : tensor<8xf16>
+static LogicalResult
+refineTensorEmptyProducer(RewriterBase &rewriter,
+                          DestinationStyleOpInterface dpsOp, unsigned resultIdx,
+                          tensor::EmptyOp emptyOp,
+                          ArrayRef<int64_t> newShape) {
   auto curType = emptyOp.getType();
   if (curType.getShape().size() != newShape.size())
     return failure();
@@ -115,7 +133,8 @@ static LogicalResult refineTensorEmptyProducer(RewriterBase &rewriter,
   rewriter.setInsertionPoint(emptyOp);
   auto newEmpty =
       tensor::EmptyOp::create(rewriter, emptyOp.getLoc(), newType, newDyn);
-  rewriter.replaceOp(emptyOp, newEmpty.getResult());
+  // Per-edge rewire: only this DPS-init operand sees the new value.
+  dpsOp.getDpsInitsMutable()[resultIdx].set(newEmpty.getResult());
   ++NumProducersRefined;
   return success();
 }
@@ -147,7 +166,8 @@ static LogicalResult refineOneResult(RewriterBase &rewriter,
                         << ": outs producer is not tensor.empty\n");
       return failure();
     }
-    if (failed(refineTensorEmptyProducer(rewriter, emptyProducer, newShape)))
+    if (failed(refineTensorEmptyProducer(rewriter, dpsOp, resultIdx,
+                                         emptyProducer, newShape)))
       return failure();
   }
 

--- a/lib/Dialect/Transforms/InferShapesPass.cpp
+++ b/lib/Dialect/Transforms/InferShapesPass.cpp
@@ -5,10 +5,13 @@
 //===- InferShapesPass.cpp - Static shape refinement for HIP DPS ops ------===//
 //
 // Module-level pass that drives `ReifyRankedShapedTypeOpInterface` on every
-// HIP op (and any other ranked-tensor-result op that implements the
-// interface) to refine `?` (kDynamic) dims in result types into concrete
-// integer dims, using the per-op `inferContractionShape`-style helpers as
-// the source of truth.
+// HIP-dialect op that implements it, to refine `?` (kDynamic) dims in
+// result types into concrete integer dims using the per-op
+// `inferContractionShape`-style helpers as the source of truth. Upstream
+// ops that happen to carry the interface (e.g. `tensor::EmptyOp`) are
+// intentionally skipped: they have their own folders / invariants between
+// operand SSA values and result shape that an in-place result-type narrow
+// here would desync, and they are not the target of this pass.
 //
 // DPS-aware
 // ---------
@@ -266,11 +269,27 @@ void InferShapesPass::runOnOperation() {
   // walk on rebuilt ops or invalidate iterators. The walk is post-order
   // by default, so consumers come after producers in `ops`; we then iterate
   // forward, which gives producers-before-consumers (the safe order).
+  //
+  // Restrict to HIP-dialect ops. Upstream ops that also implement
+  // `ReifyRankedShapedTypeOpInterface` (e.g. `tensor::EmptyOp`,
+  // `tensor::ExtractSliceOp`, `tensor::PadOp`) carry their own per-op
+  // invariants between operand SSA values and the result shape that
+  // an in-place result-type narrow here can desync — concretely, a
+  // `tensor.empty(%c12)` whose constant index operand makes the dim
+  // statically reifiable would have its result narrowed to fully static
+  // while the now-stale operand stayed in the operand list, tripping the
+  // op verifier with `incorrect number of dynamic sizes`. Refining
+  // upstream tensor ops is also out of charter for this pass — they are
+  // already canonicalised by their own folders before bufferize. Keep
+  // the contract tight: HIP DPS ops only.
   SmallVector<ReifyRankedShapedTypeOpInterface> ops;
   module.walk([&](ReifyRankedShapedTypeOpInterface reifyOp) {
+    Operation *op = reifyOp.getOperation();
+    if (op->getDialect() != op->getContext()->getLoadedDialect<HipDialect>())
+      return;
     // memref-mode DPS ops have no tensor results: skip. Their shapes are
     // pinned at bufferization time.
-    if (llvm::none_of(reifyOp.getOperation()->getResults(), [](Value v) {
+    if (llvm::none_of(op->getResults(), [](Value v) {
           return isa<RankedTensorType>(v.getType());
         }))
       return;

--- a/lib/Dialect/Transforms/InferShapesPass.cpp
+++ b/lib/Dialect/Transforms/InferShapesPass.cpp
@@ -168,9 +168,8 @@ static LogicalResult refineTensorEmptyProducer(RewriterBase &rewriter,
     }
   }
 
-  // `clone(shape)` preserves the encoding attr (mirrors upstream
-  // `RankedTensorType::clone`); plain `RankedTensorType::get(shape, et)`
-  // would drop it.
+  // `clone(shape)` preserves the encoding attr; plain
+  // `RankedTensorType::get(shape, elemType)` would drop it.
   auto newType = curType.clone(newShape);
   rewriter.setInsertionPoint(emptyOp);
   auto newEmpty =
@@ -216,10 +215,9 @@ refineOneResult(RewriterBase &rewriter,
   // In-place type narrow on the op's result. We don't `rewriter.replaceOp`
   // here because that would invalidate every existing use's `OpOperand`
   // pointer before we get to insert the cast. Type-only mutation followed
-  // by selective cast insertion is the same pattern upstream
-  // `ReifyResultShapesPass` uses, just expressed in-place on the same op
-  // instead of via clone+replace (we don't need the clone since the op's
-  // operand list is unchanged).
+  // by selective cast insertion on the use edges keeps the op (and its
+  // operand list) in place — there's no need for clone+replace because
+  // we are not changing operands.
   Value result = op->getResult(resultIdx);
   Type oldType = result.getType();
   result.setType(curType.clone(newShape));

--- a/lib/Dialect/Transforms/InferShapesPass.cpp
+++ b/lib/Dialect/Transforms/InferShapesPass.cpp
@@ -4,78 +4,26 @@
  */
 //===- InferShapesPass.cpp - Static shape refinement for HIP DPS ops ------===//
 //
-// Module-level pass that drives `ReifyRankedShapedTypeOpInterface` on every
-// HIP-dialect op that implements it, to refine `?` (kDynamic) dims in
-// result types into concrete integer dims using the per-op
-// `inferContractionShape`-style helpers as the source of truth. Upstream
-// ops that happen to carry the interface (e.g. `tensor::EmptyOp`) are
-// intentionally skipped: they have their own folders / invariants between
-// operand SSA values and result shape that an in-place result-type narrow
-// here would desync, and they are not the target of this pass.
+// Module-level pass: drive `ReifyRankedShapedTypeOpInterface` on every
+// HIP-dialect op that implements it, narrow `?` dims in the op's result
+// type, rebuild the `tensor.empty` producer of any refined DPS init, and
+// emit a `tensor.cast` barrier on every non-DPS-init use to preserve the
+// consumer's signature. Refinement is per-op, not whole-chain (the cast
+// is the barrier, not a propagation channel). Upstream interface ops
+// (e.g. `tensor::EmptyOp`) are intentionally skipped — they have their
+// own folders.
 //
-// DPS-aware
-// ---------
-// HIP DPS ops require `result_type == outs_operand_type`; refining the op's
-// result type without matching the outs operand's producer would produce a
-// verifier error.  This pass handles that by also rewriting the producer
-// when it is a `tensor.empty` (the only zero-cost refinement we can do
-// today: tensor.empty is a pure constructor that supports any rank / dyn-dim
-// arrangement, so we rebuild it with the new shape and drop any dynamic-dim
-// operands that became static).  Producers we don't know how to refine are
-// skipped, leaving the op's result type unchanged at that result index.
-//
-// Walk order and chained DPS ops
-// ------------------------------
-// Pre-collect candidates with `module.walk` (post-order). The walk order
-// gives us producers before consumers in a straight-line function. We
-// process candidates in that order and for each refined result we emit
-// exactly one `tensor.cast` that bridges the new (more-static) type back
-// to the original type for every non-DPS-init use; DPS-init uses are
-// skipped because for a DPS consumer `result_type == outs_operand_type`
-// is the spec contract -- if we cast on that edge, refining the consumer
-// would fail the "outs producer is tensor.empty" gate downstream.
-//
-// IMPORTANT: the cast is *the* propagation barrier, not a propagation
-// channel. A consumer reading the cast as an `ins` operand sees the OLD
-// type, so its own reify runs against the OLD operand type. Refinement
-// of the consumer's result therefore depends only on what the consumer's
-// own static reify can deduce from operand types it can still see -- it
-// does NOT transitively inherit the producer's narrowing across an `ins`
-// edge. Refinement is per-op, not whole-chain. This is intentional:
-// a transitive narrowing scheme would require either retyping the cast
-// (and re-checking every downstream signature) or skipping the cast on
-// trust (and breaking ops whose verify pins ins types). Per-op refinement
-// is the local, terminating, verifier-safe choice. See
-// `refine_chained_matmul` in test/lit/Dialect/hip-infer-shapes.mlir for
-// the canonical example.
-//
-// What this pass does NOT do
-// --------------------------
-//   * No control-flow analysis.  Result types inside `scf.if` / `scf.while`
-//     bodies are not propagated across the region boundary.  Block argument
-//     types stay as written.
-//   * No element-type refinement.  Only the shape (dim sizes) is touched.
-//   * No verifier replay.  Callers should run `mlir-opt --verify-diagnostics`
-//     once after this pass to confirm the refined IR still verifies.
-//
-// Example (matmul, dynamic batch becoming static)
-// -----------------------------------------------
+// See `docs/design/hip-shape-inference.md` for rationale, layout, and the
+// recipe for wiring a new op.
 //
 // Before:
-//
-//   %empty = tensor.empty(%c2) : tensor<?x4x8xf16>
-//   %y = hip.matmul(%ctx) ins(%a, %b : tensor<2x4x4xf16>,
-//                                       tensor<4x8xf16>)
-//                          outs(%empty : tensor<?x4x8xf16>)
-//                          -> tensor<?x4x8xf16>
-//
+//   %e = tensor.empty(%c2) : tensor<?x4x8xf16>
+//   %y = hip.matmul(%ctx) ins(%a, %b : tensor<2x4x4xf16>, tensor<4x8xf16>)
+//                         outs(%e : tensor<?x4x8xf16>) -> tensor<?x4x8xf16>
 // After:
-//
-//   %empty = tensor.empty() : tensor<2x4x8xf16>
-//   %y = hip.matmul(%ctx) ins(%a, %b : tensor<2x4x4xf16>,
-//                                       tensor<4x8xf16>)
-//                          outs(%empty : tensor<2x4x8xf16>)
-//                          -> tensor<2x4x8xf16>
+//   %e = tensor.empty() : tensor<2x4x8xf16>
+//   %y = hip.matmul(%ctx) ins(%a, %b : tensor<2x4x4xf16>, tensor<4x8xf16>)
+//                         outs(%e : tensor<2x4x8xf16>) -> tensor<2x4x8xf16>
 //
 //===----------------------------------------------------------------------===//
 
@@ -136,15 +84,11 @@ static bool composeRefinedShape(ArrayRef<int64_t> cur,
   return refined;
 }
 
-/// If `emptyOp`'s rank matches `newShape`, rebuild it with the refined
-/// shape and replace all uses; dynamic-dim operands whose corresponding
-/// dim has become static are dropped from the operand list.
+/// Rebuild `emptyOp` with the refined shape. Dynamic-dim operands whose
+/// corresponding dim became static are dropped.
 ///
-/// Before: `%init = tensor.empty(%d0, %d1) : tensor<?x4x?xf16>`
-///         and newShape = [2, 4, 8]
-/// After : `%init = tensor.empty() : tensor<2x4x8xf16>`
-///
-/// Returns failure() and leaves the producer untouched on rank mismatch.
+/// Before: %init = tensor.empty(%d0, %d1) : tensor<?x4x?xf16>; newShape=[2,4,8]
+/// After : %init = tensor.empty() : tensor<2x4x8xf16>
 static LogicalResult refineTensorEmptyProducer(RewriterBase &rewriter,
                                                tensor::EmptyOp emptyOp,
                                                ArrayRef<int64_t> newShape) {
@@ -152,12 +96,9 @@ static LogicalResult refineTensorEmptyProducer(RewriterBase &rewriter,
   if (curType.getShape().size() != newShape.size())
     return failure();
 
-  // Walk each dim; for dims that were dynamic in the OLD type, advance the
-  // operand cursor (every old-dynamic dim has exactly one operand). Keep
-  // that operand only if the dim is STILL dynamic post-refinement. Static
-  // dims (old or new) consume nothing from the operand list. We never see
-  // a "now-dynamic formerly-static" case because composeRefinedShape only
-  // narrows.
+  // For each old-dynamic dim, advance the operand cursor and keep the
+  // operand iff the dim is still dynamic. (composeRefinedShape only
+  // narrows, so we never see a static->dynamic transition.)
   SmallVector<Value> newDyn;
   unsigned operandIdx = 0;
   for (size_t d : llvm::seq<size_t>(0, newShape.size())) {
@@ -168,8 +109,8 @@ static LogicalResult refineTensorEmptyProducer(RewriterBase &rewriter,
     ++operandIdx;
   }
 
-  // `clone(shape)` preserves the encoding attr; plain
-  // `RankedTensorType::get(shape, elemType)` would drop it.
+  // `clone(shape)` preserves the encoding attr; `RankedTensorType::get`
+  // would drop it.
   auto newType = curType.clone(newShape);
   rewriter.setInsertionPoint(emptyOp);
   auto newEmpty =
@@ -195,10 +136,8 @@ static LogicalResult refineOneResult(RewriterBase &rewriter,
   if (!composeRefinedShape(curType.getShape(), reifiedDims, newShape))
     return failure();
 
-  // For DPS ops, the spec contract is `result_type == outs_operand_type`.
-  // The only producer we can rebuild zero-cost today is `tensor.empty`;
-  // everything else (function args, results of other DPS ops, etc.) is
-  // left alone -- skipping is the verifier-safe choice.
+  // DPS contract is `result_type == outs_operand_type`; only tensor.empty
+  // outs producers can be rebuilt zero-cost today, so we skip the rest.
   auto dpsOp = dyn_cast<DestinationStyleOpInterface>(op);
   if (dpsOp && resultIdx < dpsOp.getDpsInits().size()) {
     Value outsOperand = dpsOp.getDpsInits()[resultIdx];
@@ -212,26 +151,19 @@ static LogicalResult refineOneResult(RewriterBase &rewriter,
       return failure();
   }
 
-  // In-place type narrow on the op's result. We don't `rewriter.replaceOp`
-  // here because that would invalidate every existing use's `OpOperand`
-  // pointer before we get to insert the cast. Type-only mutation followed
-  // by selective cast insertion on the use edges keeps the op (and its
-  // operand list) in place — there's no need for clone+replace because
-  // we are not changing operands.
+  // In-place type mutation; can't replaceOp here because we still need the
+  // existing OpOperand pointers to insert casts on the use edges below.
   Value result = op->getResult(resultIdx);
   Type oldType = result.getType();
   result.setType(curType.clone(newShape));
   ++NumResultsRefined;
 
-  // Snapshot uses before mutation; iterating `result.getUses()` while
-  // simultaneously rewriting use edges is undefined.
+  // Snapshot uses before mutation (rewriting while iterating is UB). DPS-init
+  // uses skip the cast: result_type == outs_operand_type is the DPS contract,
+  // and casting on that edge would re-trigger the same producer-refinement
+  // gate on the consumer.
   SmallVector<OpOperand *> usesToCast;
   for (OpOperand &use : result.getUses()) {
-    // DPS-init uses on the consumer are intentionally NOT cast: for a
-    // DPS consumer, `result_type == outs_operand_type` is the spec, so
-    // a cast on that edge would force us to also retype the consumer's
-    // result, fighting the same gate this pass enforces in the
-    // producer-refinement step above.
     if (auto userDps = dyn_cast<DestinationStyleOpInterface>(use.getOwner())) {
       if (userDps.isDpsInit(&use))
         continue;
@@ -248,10 +180,7 @@ static LogicalResult refineOneResult(RewriterBase &rewriter,
 }
 
 struct InferShapesPass : public impl::InferShapesPassBase<InferShapesPass> {
-  // The TableGen `let dependentDialects = [...]` covers loading at pass-
-  // manager init, but stating it explicitly here too matches the style
-  // used elsewhere in this dialect (PromoteStridedHipOperands.cpp,
-  // PoolAllocs.cpp) and makes it grep-discoverable from the .cpp.
+  // Restated here (also in TableGen) to match other HIP passes' style.
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<HipDialect, tensor::TensorDialect>();
   }
@@ -262,30 +191,20 @@ struct InferShapesPass : public impl::InferShapesPassBase<InferShapesPass> {
 void InferShapesPass::runOnOperation() {
   ModuleOp module = getOperation();
 
-  // Collect candidates first; mutating the IR mid-walk can re-trigger the
-  // walk on rebuilt ops or invalidate iterators. The walk is post-order
-  // by default, so consumers come after producers in `ops`; we then iterate
-  // forward, which gives producers-before-consumers (the safe order).
+  // Collect first; mutating mid-walk would invalidate iterators. Post-order
+  // visits producers before consumers, the safe order for in-place result-
+  // type narrowing followed by cast insertion.
   //
-  // Restrict to HIP-dialect ops. Upstream ops that also implement
-  // `ReifyRankedShapedTypeOpInterface` (e.g. `tensor::EmptyOp`,
-  // `tensor::ExtractSliceOp`, `tensor::PadOp`) carry their own per-op
-  // invariants between operand SSA values and the result shape that
-  // an in-place result-type narrow here can desync — concretely, a
-  // `tensor.empty(%c12)` whose constant index operand makes the dim
-  // statically reifiable would have its result narrowed to fully static
-  // while the now-stale operand stayed in the operand list, tripping the
-  // op verifier with `incorrect number of dynamic sizes`. Refining
-  // upstream tensor ops is also out of charter for this pass — they are
-  // already canonicalised by their own folders before bufferize. Keep
-  // the contract tight: HIP DPS ops only.
+  // HIP-dialect ops only. Upstream ops with the same interface (e.g.
+  // tensor.empty) carry operand-shape invariants this pass would desync,
+  // and they have their own canonicalizers anyway.
   SmallVector<ReifyRankedShapedTypeOpInterface> ops;
   module.walk([&](ReifyRankedShapedTypeOpInterface reifyOp) {
     Operation *op = reifyOp.getOperation();
     if (op->getDialect() != op->getContext()->getLoadedDialect<HipDialect>())
       return;
-    // memref-mode DPS ops have no tensor results: skip. Their shapes are
-    // pinned at bufferization time.
+    // memref-mode DPS ops have no tensor results; their shapes are pinned
+    // at bufferization time.
     if (llvm::none_of(op->getResults(), [](Value v) {
           return isa<RankedTensorType>(v.getType());
         }))

--- a/lib/Dialect/Transforms/InferShapesPass.cpp
+++ b/lib/Dialect/Transforms/InferShapesPass.cpp
@@ -62,6 +62,10 @@ namespace {
 /// `OpFoldResult` is a constant integer, the constant replaces it.
 /// Returns true iff at least one dim moved from `kDynamic` to static.
 ///
+/// In debug builds, asserts that a constant reified dim agrees with an
+/// existing static dim — a contradiction signals a buggy
+/// `reifyResultShapes` impl on the op being refined.
+///
 /// Precondition: `cur.size() == reif.size()`. The
 /// `ReifyRankedShapedTypeOpInterface` contract guarantees one
 /// `OpFoldResult` per dim of the reified result; a mismatch signals a
@@ -157,8 +161,8 @@ static LogicalResult refineOneResult(RewriterBase &rewriter,
     // Refining a shared `tensor.empty` would retype every sibling
     // consumer's outs operand without retyping their result, breaking
     // the DPS contract (outs.type == result.type) on the unrefined
-    // sibling. No converter aliases empties today; the guard makes the
-    // single-use invariant local to this pass.
+    // sibling. No converter aliases empties today; the guard removes
+    // that as a correctness precondition for this pass.
     if (!emptyProducer->hasOneUse()) {
       LLVM_DEBUG(DBGS() << "skip " << op->getName() << " result #" << resultIdx
                         << ": outs producer is a shared tensor.empty\n");

--- a/lib/Dialect/Transforms/InferShapesPass.cpp
+++ b/lib/Dialect/Transforms/InferShapesPass.cpp
@@ -152,22 +152,20 @@ static LogicalResult refineTensorEmptyProducer(RewriterBase &rewriter,
   if (curType.getShape().size() != newShape.size())
     return failure();
 
-  // Rebuild the dyn-dim operand list: keep an operand iff the dim was
-  // dynamic before AND remains dynamic after. We never see a "now-dynamic
-  // formerly-static" case because composeRefinedShape only narrows.
+  // Walk each dim; for dims that were dynamic in the OLD type, advance the
+  // operand cursor (every old-dynamic dim has exactly one operand). Keep
+  // that operand only if the dim is STILL dynamic post-refinement. Static
+  // dims (old or new) consume nothing from the operand list. We never see
+  // a "now-dynamic formerly-static" case because composeRefinedShape only
+  // narrows.
   SmallVector<Value> newDyn;
   unsigned operandIdx = 0;
   for (size_t d : llvm::seq<size_t>(0, newShape.size())) {
-    bool curDynamic = curType.isDynamicDim(d);
-    bool newDynamic = ShapedType::isDynamic(newShape[d]);
-    if (curDynamic && !newDynamic) {
-      ++operandIdx;
+    if (!curType.isDynamicDim(d))
       continue;
-    }
-    if (curDynamic && newDynamic) {
-      newDyn.push_back(emptyOp.getDynamicSizes()[operandIdx++]);
-      continue;
-    }
+    if (ShapedType::isDynamic(newShape[d]))
+      newDyn.push_back(emptyOp.getDynamicSizes()[operandIdx]);
+    ++operandIdx;
   }
 
   // `clone(shape)` preserves the encoding attr; plain

--- a/lib/Dialect/Transforms/InferShapesPass.cpp
+++ b/lib/Dialect/Transforms/InferShapesPass.cpp
@@ -7,11 +7,11 @@
 // Module-level pass: drive `ReifyRankedShapedTypeOpInterface` on every
 // HIP-dialect op that implements it, narrow `?` dims in the op's result
 // type, rebuild the `tensor.empty` producer of any refined DPS init, and
-// emit a `tensor.cast` barrier on every non-DPS-init use to preserve the
-// consumer's signature. Refinement is per-op, not whole-chain (the cast
-// is the barrier, not a propagation channel). Upstream interface ops
-// (e.g. `tensor::EmptyOp`) are intentionally skipped — they have their
-// own folders.
+// emit a `tensor.cast` on every non-DPS-init use to preserve the
+// consumer's signature. The cast is a per-op propagation barrier:
+// downstream consumers refine locally against the OLD operand type,
+// no whole-chain narrowing. Upstream interface ops (e.g. `tensor::EmptyOp`)
+// are intentionally skipped — they have their own folders.
 //
 // See `docs/design/hip-shape-inference.md` for rationale, layout, and the
 // recipe for wiring a new op.

--- a/lib/Dialect/Transforms/Pipelines.cpp
+++ b/lib/Dialect/Transforms/Pipelines.cpp
@@ -23,6 +23,21 @@ using namespace mlir;
 
 /// Common tail of the ONNX-to-HIP pipeline after the OnnxToHip pass.
 static void buildOnnxToHipPipelineTail(OpPassManager &pm) {
+  // 1b. Refine `?` (kDynamic) dims on HIP DPS op result types using each
+  //     op's `ReifyRankedShapedTypeOpInterface` impl. Placed here so the
+  //     refinements propagate through bufferize and into pool / alloc
+  //     sizing computations downstream, and run BEFORE the unrefined
+  //     `?` dims would otherwise materialise as `memref.dim` ops on the
+  //     pool buffer at the top of the function.
+  //
+  //     Idempotent and a no-op on functions whose ops either don't carry
+  //     the interface or expose no further refinable dims — safe to run
+  //     unconditionally regardless of how many HIP ops currently
+  //     implement the interface. See `docs/design/hip-shape-inference.md`
+  //     for the design and `test/lit/Dialect/hip-infer-shapes.mlir` for
+  //     the reference cases.
+  pm.addPass(hip::createInferShapesPass());
+
   // 2. Bufferize tensor IR to memref IR
   //
   // Use IdentityLayoutMap for function boundaries: all EP inputs/outputs come

--- a/test/lit/Dialect/hip-dps-op-interface.mlir
+++ b/test/lit/Dialect/hip-dps-op-interface.mlir
@@ -1,0 +1,95 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --resolve-shaped-type-result-dims %s | FileCheck %s
+
+// What this file tests
+// --------------------
+// `HipDpsOp::reifyResultShapes` -- the SHARED default body carried by the
+// in-dialect `HipDpsOpInterface`. The TableGen base class `Hip_DpsOp`
+// auto-emits a per-op `ReifyRankedShapedTypeOpInterface::reifyResultShapes`
+// dispatcher that forwards to that default. The default walks
+// `getDpsInits()` and lifts each init operand's runtime shape via
+// `tensor::getMixedSizes` (tensor mode) / `memref::getMixedSizes` (memref
+// mode). This file pins that, for any non-opt-out op (i.e. autoReify=1, the
+// default), reify produces:
+//   - `IntegerAttr` for static dims (fold to `arith.constant`)
+//   - `tensor.dim %outs, %i` for dynamic dims
+//
+// `hip.silu` is the worked example -- a single-init same-shape elementwise
+// op with no per-op reify override on the #260 base. Other Hip_DpsOps with
+// the default (silu, sigmoid, rope, rms_norm, ...) follow the same contract
+// because they share the same auto-emitted dispatcher.
+//
+// What this file does NOT test
+// ----------------------------
+// `MatmulOp::reifyResultShapes` -- matmul opts out of the default
+// (`autoReify=0`) and provides a tighter contract that lifts dims from the
+// `A` / `B` ins operands instead of the outs. That is covered by
+// `hip-matmul-reify-shapes.mlir`.
+
+// CHECK-LABEL: func.func @silu_static
+// CHECK-DAG:   %[[C2:.*]] = arith.constant 2 : index
+// CHECK-DAG:   %[[C8:.*]] = arith.constant 8 : index
+// CHECK:       return %[[C2]], %[[C8]]
+func.func @silu_static(%ctx: !hip.context,
+                       %x: tensor<2x8xf16>,
+                       %y: tensor<2x8xf16>) -> (index, index) {
+  %r = hip.silu(%ctx) ins(%x : tensor<2x8xf16>)
+                      outs(%y : tensor<2x8xf16>) -> tensor<2x8xf16>
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %d0 = tensor.dim %r, %c0 : tensor<2x8xf16>
+  %d1 = tensor.dim %r, %c1 : tensor<2x8xf16>
+  return %d0, %d1 : index, index
+}
+
+// -----
+
+// Dynamic outs operand: dim folds to `tensor.dim %y, %i`. Static dim folds
+// to a constant. The `, %[[Y...]]: tensor<?x8xf16>)` regex anchors to the
+// LAST arg of `tensor<?x8xf16>` shape (i.e. the outs operand), since the
+// input shares the same shape and FileCheck would otherwise capture the
+// first one.
+// CHECK-LABEL: func.func @silu_dynamic
+// CHECK-SAME:   , %[[Y:[A-Za-z0-9_]+]]: tensor<?x8xf16>)
+// CHECK-DAG:   %[[C0:.*]] = arith.constant 0 : index
+// CHECK-DAG:   %[[C8:.*]] = arith.constant 8 : index
+// CHECK:       %[[D0:.*]] = tensor.dim %[[Y]], %[[C0]] : tensor<?x8xf16>
+// CHECK:       return %[[D0]], %[[C8]]
+func.func @silu_dynamic(%ctx: !hip.context,
+                        %x: tensor<?x8xf16>,
+                        %y: tensor<?x8xf16>) -> (index, index) {
+  %r = hip.silu(%ctx) ins(%x : tensor<?x8xf16>)
+                      outs(%y : tensor<?x8xf16>) -> tensor<?x8xf16>
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %d0 = tensor.dim %r, %c0 : tensor<?x8xf16>
+  %d1 = tensor.dim %r, %c1 : tensor<?x8xf16>
+  return %d0, %d1 : index, index
+}
+
+// -----
+
+// Mixed static + dynamic outs: confirms per-dim handling (constant for
+// static, tensor.dim for dynamic) on the same op invocation.
+// CHECK-LABEL: func.func @silu_mixed
+// CHECK-SAME:   , %[[Y:[A-Za-z0-9_]+]]: tensor<2x?x8xf16>)
+// CHECK-DAG:   %[[C2:.*]] = arith.constant 2 : index
+// CHECK-DAG:   %[[C1:.*]] = arith.constant 1 : index
+// CHECK-DAG:   %[[C8:.*]] = arith.constant 8 : index
+// CHECK:       %[[D1:.*]] = tensor.dim %[[Y]], %[[C1]] : tensor<2x?x8xf16>
+// CHECK:       return %[[C2]], %[[D1]], %[[C8]]
+func.func @silu_mixed(%ctx: !hip.context,
+                      %x: tensor<2x?x8xf16>,
+                      %y: tensor<2x?x8xf16>) -> (index, index, index) {
+  %r = hip.silu(%ctx) ins(%x : tensor<2x?x8xf16>)
+                      outs(%y : tensor<2x?x8xf16>) -> tensor<2x?x8xf16>
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %d0 = tensor.dim %r, %c0 : tensor<2x?x8xf16>
+  %d1 = tensor.dim %r, %c1 : tensor<2x?x8xf16>
+  %d2 = tensor.dim %r, %c2 : tensor<2x?x8xf16>
+  return %d0, %d1, %d2 : index, index, index
+}

--- a/test/lit/Dialect/hip-infer-shapes.mlir
+++ b/test/lit/Dialect/hip-infer-shapes.mlir
@@ -3,6 +3,40 @@
 
 // RUN: hip-mlir-opt --hip-infer-shapes %s | FileCheck %s
 
+// What this file tests
+// --------------------
+// The `--hip-infer-shapes` production pass (lib/Dialect/Transforms/
+// InferShapesPass.cpp) — i.e. the CONSUMER side of
+// `ReifyRankedShapedTypeOpInterface` for HIP ops. Specifically:
+//
+//   - composing a refined result type by combining the current type
+//     with the constant branches of each reified `OpFoldResult`
+//     (`refine_single_matmul`, `refine_chained_matmul`),
+//   - in-place SSA value-type narrowing and `tensor.empty` producer
+//     rebuild when the producer is a single-use `tensor.empty`
+//     (`refine_single_matmul`, `refine_chained_matmul`),
+//   - leaving the producer alone when it is something else
+//     (`skip_non_empty_producer`),
+//   - early-out on already-static results (`noop_on_static`),
+//   - filtering to ops in the `hip` dialect (`skip_non_hip_op`),
+//   - inserting `tensor.cast` barriers on non-DPS uses while exempting
+//     DPS-init uses so chains like
+//     `matmul -> tensor.empty -> matmul` propagate refinement through
+//     all links.
+//
+// What this file does NOT test
+// ----------------------------
+// The correctness of the `OpFoldResult`s produced by individual reify
+// implementations — in particular, the dynamic-dim branch of
+// `MatmulOp::reifyResultShapes` (which operand a dynamic dim is taken
+// from, and at which local dim index). This pass only consumes the
+// *constant* branch of each `OpFoldResult`; dynamic ones are silently
+// discarded. That branch is covered by `hip-matmul-reify-shapes.mlir`,
+// which uses upstream's `--resolve-shaped-type-result-dims` as a
+// generic producer-contract validator (the upstream pass materializes
+// every reified `OpFoldResult` — static and dynamic — into IR and is
+// not itself part of our production pipeline).
+
 // CHECK-LABEL: func.func @refine_single_matmul
 // CHECK:         %[[E:.*]] = tensor.empty() : tensor<2x8xf16>
 // CHECK:         %[[Y:.*]] = hip.matmul

--- a/test/lit/Dialect/hip-infer-shapes.mlir
+++ b/test/lit/Dialect/hip-infer-shapes.mlir
@@ -117,23 +117,26 @@ func.func @noop_on_static(%ctx: !hip.context,
 
 // -----
 
-// --- Non-DPS reify-implementing op: tensor.pad's result has dynamic dims at
-//     the type level (its `low`/`high` operands here are SSA values), but
-//     when those operands are constants in IR `tensor.pad`'s own reify
-//     resolves them to integer attrs. We want to confirm: (a) the pass
-//     does not regress on non-DPS ops (no producer rewrite applies, but
-//     the result type is refined and a cast is inserted for non-DPS
-//     uses), and (b) the pass coexists with other ops that already
-//     implement the reify interface.
-// CHECK-LABEL: func.func @refine_tensor_pad
+// --- The pass restricts itself to HIP-dialect ops. Upstream ops like
+//     `tensor.pad` (which also carry `ReifyRankedShapedTypeOpInterface`)
+//     are intentionally left alone: their per-op invariants between
+//     operands and result shape — e.g. `tensor.empty(%dyn)`'s "operand
+//     count == #dynamic dims" — would desync if this pass narrowed the
+//     result in place without mirror-rewriting the operand list, and we
+//     deliberately do not duplicate every upstream op's folder/canonicalizer
+//     surface here.
+//
+//     This case pins that contract: a `tensor.pad` whose
+//     reify-implementing impl could narrow `tensor<?x?xf16>` to
+//     `tensor<6x10xf16>` is left as-is.  Refining non-HIP ops is the
+//     canonicalizer's job, not this pass's.
+// CHECK-LABEL: func.func @skip_non_hip_op
 // CHECK:         %[[P:.*]] = tensor.pad
-// CHECK:         tensor<4x8xf16> to tensor<6x10xf16>
-// CHECK:         %[[CAST:.*]] = tensor.cast %[[P]]{{.*}}: tensor<6x10xf16> to tensor<?x?xf16>
-// CHECK:         return %[[CAST]] : tensor<?x?xf16>
-func.func @refine_tensor_pad(%a: tensor<4x8xf16>) -> tensor<?x?xf16> {
-  %c0 = arith.constant 0 : index
+// CHECK:         tensor<4x8xf16> to tensor<?x?xf16>
+// CHECK-NOT:     tensor.cast
+// CHECK:         return %[[P]] : tensor<?x?xf16>
+func.func @skip_non_hip_op(%a: tensor<4x8xf16>) -> tensor<?x?xf16> {
   %c1 = arith.constant 1 : index
-  %c2 = arith.constant 2 : index
   %cst = arith.constant 0.0 : f16
   %padded = tensor.pad %a low[%c1, %c1] high[%c1, %c1] {
     ^bb0(%i: index, %j: index):

--- a/test/lit/Dialect/hip-infer-shapes.mlir
+++ b/test/lit/Dialect/hip-infer-shapes.mlir
@@ -47,11 +47,10 @@ func.func @refine_single_matmul(%ctx: !hip.context,
 //     to keep the second matmul's signature well-formed.
 //
 //     Despite the cast on the ins edge, the second matmul still refines its
-//     M dim to 2 because `tensor.dim %cast, 0` folds through the cast (via
-//     upstream `tensor::DimOp::fold` / `foldTensorCast`) to the source's
-//     static dim — and our reify uses `tensor::getMixedSize`'s `createOrFold`
-//     form. Verifies that the per-op refinement in this pass cooperates
-//     correctly with upstream cast-folding instead of fighting it.
+//     M dim to 2 because `tensor.dim %cast, 0` folds through the cast to
+//     the source's static dim — `reifyDimOrConstant` emits the dim op via
+//     a folding builder. Verifies that the per-op refinement in this pass
+//     cooperates correctly with cast-folding instead of fighting it.
 // CHECK-LABEL: func.func @refine_chained_matmul
 // CHECK:         %[[E1:.*]] = tensor.empty() : tensor<2x8xf16>
 // CHECK:         %[[Y1:.*]] = hip.matmul
@@ -120,11 +119,12 @@ func.func @noop_on_static(%ctx: !hip.context,
 
 // --- Non-DPS reify-implementing op: tensor.pad's result has dynamic dims at
 //     the type level (its `low`/`high` operands here are SSA values), but
-//     when those operands are constants in IR the upstream pad reify
-//     resolves them to integer attrs. We want to confirm: (a) the pass does
-//     not regress on non-DPS ops (no producer rewrite applies, but the
-//     result type is refined and a cast is inserted for non-DPS uses), and
-//     (b) the pass coexists with upstream reify-supporting ops.
+//     when those operands are constants in IR `tensor.pad`'s own reify
+//     resolves them to integer attrs. We want to confirm: (a) the pass
+//     does not regress on non-DPS ops (no producer rewrite applies, but
+//     the result type is refined and a cast is inserted for non-DPS
+//     uses), and (b) the pass coexists with other ops that already
+//     implement the reify interface.
 // CHECK-LABEL: func.func @refine_tensor_pad
 // CHECK:         %[[P:.*]] = tensor.pad
 // CHECK:         tensor<4x8xf16> to tensor<6x10xf16>

--- a/test/lit/Dialect/hip-infer-shapes.mlir
+++ b/test/lit/Dialect/hip-infer-shapes.mlir
@@ -1,26 +1,8 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
-//
-//===----------------------------------------------------------------------===//
-// FileCheck tests for the `--hip-infer-shapes` propagation pass.
-//
-// The pass walks ops with `ReifyRankedShapedTypeOpInterface`, collects the
-// reified result shapes, and refines:
-//   1. The DPS outs operand's `tensor.empty` producer (the only refinable
-//      producer today),
-//   2. The op's own result type, in place,
-//   3. Each non-DPS use, by inserting a `tensor.cast` so consumers that
-//      expect the old type stay well-formed.
-//
-// DPS-outs use edges are NOT cast — chained DPS ops refine in turn on the
-// same module walk.
-//===----------------------------------------------------------------------===//
 
 // RUN: hip-mlir-opt --hip-infer-shapes %s | FileCheck %s
 
-// --- Single matmul with a fully-static result that the IR types still spell
-//     as `?` -> the empty producer + the matmul's result + the function
-//     return get refined to the static shape. ---
 // CHECK-LABEL: func.func @refine_single_matmul
 // CHECK:         %[[E:.*]] = tensor.empty() : tensor<2x8xf16>
 // CHECK:         %[[Y:.*]] = hip.matmul
@@ -40,17 +22,6 @@ func.func @refine_single_matmul(%ctx: !hip.context,
 
 // -----
 
-// --- Chained matmul: `A @ B @ C`. After the pass, both empties should be
-//     refined to their static shapes. The first matmul's result is now
-//     `tensor<2x8xf16>`, but the second matmul's `ins` operand was originally
-//     typed `tensor<?x?xf16>`; we insert a `tensor.cast` on that non-DPS edge
-//     to keep the second matmul's signature well-formed.
-//
-//     Despite the cast on the ins edge, the second matmul still refines its
-//     M dim to 2 because `tensor.dim %cast, 0` folds through the cast to
-//     the source's static dim — `reifyDimOrConstant` emits the dim op via
-//     a folding builder. Verifies that the per-op refinement in this pass
-//     cooperates correctly with cast-folding instead of fighting it.
 // CHECK-LABEL: func.func @refine_chained_matmul
 // CHECK:         %[[E1:.*]] = tensor.empty() : tensor<2x8xf16>
 // CHECK:         %[[Y1:.*]] = hip.matmul
@@ -80,8 +51,6 @@ func.func @refine_chained_matmul(%ctx: !hip.context,
 
 // -----
 
-// --- Outs producer is NOT a tensor.empty (here it's a function arg) -> the
-//     pass refuses to refine that result and leaves the IR untouched. ---
 // CHECK-LABEL: func.func @skip_non_empty_producer
 // CHECK:         hip.matmul
 // CHECK-SAME:    outs(%{{.*}} : tensor<?x?xf16>) : tensor<?x?xf16>
@@ -97,8 +66,6 @@ func.func @skip_non_empty_producer(%ctx: !hip.context,
 
 // -----
 
-// --- Idempotence: if the result type is already maximally static, the pass
-//     leaves the IR unchanged (no spurious tensor.cast). ---
 // CHECK-LABEL: func.func @noop_on_static
 // CHECK:         %[[E:.*]] = tensor.empty() : tensor<2x8xf16>
 // CHECK:         %[[Y:.*]] = hip.matmul
@@ -117,19 +84,9 @@ func.func @noop_on_static(%ctx: !hip.context,
 
 // -----
 
-// --- The pass restricts itself to HIP-dialect ops. Upstream ops like
-//     `tensor.pad` (which also carry `ReifyRankedShapedTypeOpInterface`)
-//     are intentionally left alone: their per-op invariants between
-//     operands and result shape — e.g. `tensor.empty(%dyn)`'s "operand
-//     count == #dynamic dims" — would desync if this pass narrowed the
-//     result in place without mirror-rewriting the operand list, and we
-//     deliberately do not duplicate every upstream op's folder/canonicalizer
-//     surface here.
-//
-//     This case pins that contract: a `tensor.pad` whose
-//     reify-implementing impl could narrow `tensor<?x?xf16>` to
-//     `tensor<6x10xf16>` is left as-is.  Refining non-HIP ops is the
-//     canonicalizer's job, not this pass's.
+// Pin that the pass restricts itself to HIP-dialect ops: refining a non-HIP
+// op like `tensor.pad` (which also implements ReifyRankedShapedTypeOpInterface)
+// is the canonicalizer's job, not this pass's.
 // CHECK-LABEL: func.func @skip_non_hip_op
 // CHECK:         %[[P:.*]] = tensor.pad
 // CHECK:         tensor<4x8xf16> to tensor<?x?xf16>

--- a/test/lit/Dialect/hip-infer-shapes.mlir
+++ b/test/lit/Dialect/hip-infer-shapes.mlir
@@ -84,6 +84,32 @@ func.func @noop_on_static(%ctx: !hip.context,
 
 // -----
 
+// Pin per-edge producer refinement: when a `tensor.empty` is shared between
+// the matmul's outs operand AND a non-DPS-init use (here, a func.return),
+// only the DPS-init edge is rewired to the more-static empty. The original
+// %e keeps `tensor<?x?xf16>` for the func.return — leaking the static type
+// past the per-op refinement boundary would invalidate the function
+// signature.
+// CHECK-LABEL: func.func @per_edge_refine_with_extra_empty_user
+// CHECK:         %[[E_NEW:.*]] = tensor.empty() : tensor<2x8xf16>
+// CHECK:         %[[E_OLD:.*]] = tensor.empty(%{{.*}}, %{{.*}}) : tensor<?x?xf16>
+// CHECK:         %[[Y:.*]] = hip.matmul
+// CHECK-SAME:      outs(%[[E_NEW]] : tensor<2x8xf16>) : tensor<2x8xf16>
+// CHECK:         %[[CAST:.*]] = tensor.cast %[[Y]] : tensor<2x8xf16> to tensor<?x?xf16>
+// CHECK:         return %[[CAST]], %[[E_OLD]] : tensor<?x?xf16>, tensor<?x?xf16>
+func.func @per_edge_refine_with_extra_empty_user(
+    %ctx: !hip.context, %a: tensor<2x4xf16>, %b: tensor<4x8xf16>,
+    %dM: index, %dN: index)
+    -> (tensor<?x?xf16>, tensor<?x?xf16>) {
+  %e = tensor.empty(%dM, %dN) : tensor<?x?xf16>
+  %y = hip.matmul(%ctx)
+    ins(%a, %b : tensor<2x4xf16>, tensor<4x8xf16>)
+    outs(%e : tensor<?x?xf16>) : tensor<?x?xf16>
+  return %y, %e : tensor<?x?xf16>, tensor<?x?xf16>
+}
+
+// -----
+
 // Pin that the pass restricts itself to HIP-dialect ops: refining a non-HIP
 // op like `tensor.pad` (which also implements ReifyRankedShapedTypeOpInterface)
 // is the canonicalizer's job, not this pass's.

--- a/test/lit/Dialect/hip-infer-shapes.mlir
+++ b/test/lit/Dialect/hip-infer-shapes.mlir
@@ -1,0 +1,143 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+//===----------------------------------------------------------------------===//
+// FileCheck tests for the `--hip-infer-shapes` propagation pass.
+//
+// The pass walks ops with `ReifyRankedShapedTypeOpInterface`, collects the
+// reified result shapes, and refines:
+//   1. The DPS outs operand's `tensor.empty` producer (the only refinable
+//      producer today),
+//   2. The op's own result type, in place,
+//   3. Each non-DPS use, by inserting a `tensor.cast` so consumers that
+//      expect the old type stay well-formed.
+//
+// DPS-outs use edges are NOT cast — chained DPS ops refine in turn on the
+// same module walk.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt --hip-infer-shapes %s | FileCheck %s
+
+// --- Single matmul with a fully-static result that the IR types still spell
+//     as `?` -> the empty producer + the matmul's result + the function
+//     return get refined to the static shape. ---
+// CHECK-LABEL: func.func @refine_single_matmul
+// CHECK:         %[[E:.*]] = tensor.empty() : tensor<2x8xf16>
+// CHECK:         %[[Y:.*]] = hip.matmul
+// CHECK-SAME:                  outs(%[[E]] : tensor<2x8xf16>) : tensor<2x8xf16>
+// CHECK:         %[[CAST:.*]] = tensor.cast %[[Y]] : tensor<2x8xf16> to tensor<?x?xf16>
+// CHECK:         return %[[CAST]] : tensor<?x?xf16>
+func.func @refine_single_matmul(%ctx: !hip.context,
+                                %a: tensor<2x4xf16>,
+                                %b: tensor<4x8xf16>,
+                                %dM: index, %dN: index) -> tensor<?x?xf16> {
+  %e = tensor.empty(%dM, %dN) : tensor<?x?xf16>
+  %y = hip.matmul(%ctx)
+    ins(%a, %b : tensor<2x4xf16>, tensor<4x8xf16>)
+    outs(%e : tensor<?x?xf16>) : tensor<?x?xf16>
+  return %y : tensor<?x?xf16>
+}
+
+// -----
+
+// --- Chained matmul: `A @ B @ C`. After the pass, both empties should be
+//     refined to their static shapes. The first matmul's result is now
+//     `tensor<2x8xf16>`, but the second matmul's `ins` operand was originally
+//     typed `tensor<?x?xf16>`; we insert a `tensor.cast` on that non-DPS edge
+//     to keep the second matmul's signature well-formed.
+//
+//     Despite the cast on the ins edge, the second matmul still refines its
+//     M dim to 2 because `tensor.dim %cast, 0` folds through the cast (via
+//     upstream `tensor::DimOp::fold` / `foldTensorCast`) to the source's
+//     static dim — and our reify uses `tensor::getMixedSize`'s `createOrFold`
+//     form. Verifies that the per-op refinement in this pass cooperates
+//     correctly with upstream cast-folding instead of fighting it.
+// CHECK-LABEL: func.func @refine_chained_matmul
+// CHECK:         %[[E1:.*]] = tensor.empty() : tensor<2x8xf16>
+// CHECK:         %[[Y1:.*]] = hip.matmul
+// CHECK-SAME:      outs(%[[E1]] : tensor<2x8xf16>) : tensor<2x8xf16>
+// CHECK:         %[[CAST:.*]] = tensor.cast %[[Y1]] : tensor<2x8xf16> to tensor<?x?xf16>
+// CHECK:         %[[E2:.*]] = tensor.empty() : tensor<2x16xf16>
+// CHECK:         %[[Y2:.*]] = hip.matmul
+// CHECK-SAME:      ins(%[[CAST]], %{{.*}} : tensor<?x?xf16>, tensor<8x16xf16>)
+// CHECK-SAME:      outs(%[[E2]] : tensor<2x16xf16>) : tensor<2x16xf16>
+func.func @refine_chained_matmul(%ctx: !hip.context,
+                                 %a: tensor<2x4xf16>,
+                                 %b: tensor<4x8xf16>,
+                                 %c: tensor<8x16xf16>,
+                                 %d1: index, %d2: index,
+                                 %d3: index, %d4: index)
+    -> tensor<?x?xf16> {
+  %e1 = tensor.empty(%d1, %d2) : tensor<?x?xf16>
+  %y1 = hip.matmul(%ctx)
+    ins(%a, %b : tensor<2x4xf16>, tensor<4x8xf16>)
+    outs(%e1 : tensor<?x?xf16>) : tensor<?x?xf16>
+  %e2 = tensor.empty(%d3, %d4) : tensor<?x?xf16>
+  %y2 = hip.matmul(%ctx)
+    ins(%y1, %c : tensor<?x?xf16>, tensor<8x16xf16>)
+    outs(%e2 : tensor<?x?xf16>) : tensor<?x?xf16>
+  return %y2 : tensor<?x?xf16>
+}
+
+// -----
+
+// --- Outs producer is NOT a tensor.empty (here it's a function arg) -> the
+//     pass refuses to refine that result and leaves the IR untouched. ---
+// CHECK-LABEL: func.func @skip_non_empty_producer
+// CHECK:         hip.matmul
+// CHECK-SAME:    outs(%{{.*}} : tensor<?x?xf16>) : tensor<?x?xf16>
+func.func @skip_non_empty_producer(%ctx: !hip.context,
+                                   %a: tensor<2x4xf16>,
+                                   %b: tensor<4x8xf16>,
+                                   %c: tensor<?x?xf16>) -> tensor<?x?xf16> {
+  %y = hip.matmul(%ctx)
+    ins(%a, %b : tensor<2x4xf16>, tensor<4x8xf16>)
+    outs(%c : tensor<?x?xf16>) : tensor<?x?xf16>
+  return %y : tensor<?x?xf16>
+}
+
+// -----
+
+// --- Idempotence: if the result type is already maximally static, the pass
+//     leaves the IR unchanged (no spurious tensor.cast). ---
+// CHECK-LABEL: func.func @noop_on_static
+// CHECK:         %[[E:.*]] = tensor.empty() : tensor<2x8xf16>
+// CHECK:         %[[Y:.*]] = hip.matmul
+// CHECK-SAME:      outs(%[[E]] : tensor<2x8xf16>) : tensor<2x8xf16>
+// CHECK-NOT:    tensor.cast
+// CHECK:         return %[[Y]] : tensor<2x8xf16>
+func.func @noop_on_static(%ctx: !hip.context,
+                          %a: tensor<2x4xf16>,
+                          %b: tensor<4x8xf16>) -> tensor<2x8xf16> {
+  %e = tensor.empty() : tensor<2x8xf16>
+  %y = hip.matmul(%ctx)
+    ins(%a, %b : tensor<2x4xf16>, tensor<4x8xf16>)
+    outs(%e : tensor<2x8xf16>) : tensor<2x8xf16>
+  return %y : tensor<2x8xf16>
+}
+
+// -----
+
+// --- Non-DPS reify-implementing op: tensor.pad's result has dynamic dims at
+//     the type level (its `low`/`high` operands here are SSA values), but
+//     when those operands are constants in IR the upstream pad reify
+//     resolves them to integer attrs. We want to confirm: (a) the pass does
+//     not regress on non-DPS ops (no producer rewrite applies, but the
+//     result type is refined and a cast is inserted for non-DPS uses), and
+//     (b) the pass coexists with upstream reify-supporting ops.
+// CHECK-LABEL: func.func @refine_tensor_pad
+// CHECK:         %[[P:.*]] = tensor.pad
+// CHECK:         tensor<4x8xf16> to tensor<6x10xf16>
+// CHECK:         %[[CAST:.*]] = tensor.cast %[[P]]{{.*}}: tensor<6x10xf16> to tensor<?x?xf16>
+// CHECK:         return %[[CAST]] : tensor<?x?xf16>
+func.func @refine_tensor_pad(%a: tensor<4x8xf16>) -> tensor<?x?xf16> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %cst = arith.constant 0.0 : f16
+  %padded = tensor.pad %a low[%c1, %c1] high[%c1, %c1] {
+    ^bb0(%i: index, %j: index):
+      tensor.yield %cst : f16
+  } : tensor<4x8xf16> to tensor<?x?xf16>
+  return %padded : tensor<?x?xf16>
+}

--- a/test/lit/Dialect/hip-infer-shapes.mlir
+++ b/test/lit/Dialect/hip-infer-shapes.mlir
@@ -84,32 +84,6 @@ func.func @noop_on_static(%ctx: !hip.context,
 
 // -----
 
-// Pin per-edge producer refinement: when a `tensor.empty` is shared between
-// the matmul's outs operand AND a non-DPS-init use (here, a func.return),
-// only the DPS-init edge is rewired to the more-static empty. The original
-// %e keeps `tensor<?x?xf16>` for the func.return — leaking the static type
-// past the per-op refinement boundary would invalidate the function
-// signature.
-// CHECK-LABEL: func.func @per_edge_refine_with_extra_empty_user
-// CHECK:         %[[E_NEW:.*]] = tensor.empty() : tensor<2x8xf16>
-// CHECK:         %[[E_OLD:.*]] = tensor.empty(%{{.*}}, %{{.*}}) : tensor<?x?xf16>
-// CHECK:         %[[Y:.*]] = hip.matmul
-// CHECK-SAME:      outs(%[[E_NEW]] : tensor<2x8xf16>) : tensor<2x8xf16>
-// CHECK:         %[[CAST:.*]] = tensor.cast %[[Y]] : tensor<2x8xf16> to tensor<?x?xf16>
-// CHECK:         return %[[CAST]], %[[E_OLD]] : tensor<?x?xf16>, tensor<?x?xf16>
-func.func @per_edge_refine_with_extra_empty_user(
-    %ctx: !hip.context, %a: tensor<2x4xf16>, %b: tensor<4x8xf16>,
-    %dM: index, %dN: index)
-    -> (tensor<?x?xf16>, tensor<?x?xf16>) {
-  %e = tensor.empty(%dM, %dN) : tensor<?x?xf16>
-  %y = hip.matmul(%ctx)
-    ins(%a, %b : tensor<2x4xf16>, tensor<4x8xf16>)
-    outs(%e : tensor<?x?xf16>) : tensor<?x?xf16>
-  return %y, %e : tensor<?x?xf16>, tensor<?x?xf16>
-}
-
-// -----
-
 // Pin that the pass restricts itself to HIP-dialect ops: refining a non-HIP
 // op like `tensor.pad` (which also implements ReifyRankedShapedTypeOpInterface)
 // is the canonicalizer's job, not this pass's.

--- a/test/lit/Dialect/hip-infer-shapes.mlir
+++ b/test/lit/Dialect/hip-infer-shapes.mlir
@@ -118,6 +118,36 @@ func.func @noop_on_static(%ctx: !hip.context,
 
 // -----
 
+// Pin the safety guard against refining a `tensor.empty` whose result is
+// used as the outs operand of more than one HIP op. Refinement of one
+// consumer's result would silently retype the shared empty (and thus
+// every other consumer's outs operand) without retyping the others'
+// results — breaking the DPS contract. No converter aliases empties
+// today, so the guard is purely defensive against a future regression.
+// CHECK-LABEL: func.func @skip_shared_empty_producer
+// CHECK:         %[[E:.*]] = tensor.empty(%{{.*}}, %{{.*}}) : tensor<?x?xf16>
+// CHECK:         %[[Y1:.*]] = hip.matmul
+// CHECK-SAME:      outs(%[[E]] : tensor<?x?xf16>) : tensor<?x?xf16>
+// CHECK:         %[[Y2:.*]] = hip.matmul
+// CHECK-SAME:      outs(%[[E]] : tensor<?x?xf16>) : tensor<?x?xf16>
+// CHECK-NOT:     tensor.empty()
+func.func @skip_shared_empty_producer(%ctx: !hip.context,
+                                      %a: tensor<2x4xf16>,
+                                      %b: tensor<4x8xf16>,
+                                      %d1: index, %d2: index)
+    -> (tensor<?x?xf16>, tensor<?x?xf16>) {
+  %shared = tensor.empty(%d1, %d2) : tensor<?x?xf16>
+  %y1 = hip.matmul(%ctx)
+    ins(%a, %b : tensor<2x4xf16>, tensor<4x8xf16>)
+    outs(%shared : tensor<?x?xf16>) : tensor<?x?xf16>
+  %y2 = hip.matmul(%ctx)
+    ins(%a, %b : tensor<2x4xf16>, tensor<4x8xf16>)
+    outs(%shared : tensor<?x?xf16>) : tensor<?x?xf16>
+  return %y1, %y2 : tensor<?x?xf16>, tensor<?x?xf16>
+}
+
+// -----
+
 // Pin that the pass restricts itself to HIP-dialect ops: refining a non-HIP
 // op like `tensor.pad` (which also implements ReifyRankedShapedTypeOpInterface)
 // is the canonicalizer's job, not this pass's.

--- a/test/lit/Dialect/hip-lower-allocs.mlir
+++ b/test/lit/Dialect/hip-lower-allocs.mlir
@@ -143,15 +143,15 @@ func.func @free_after_all_direct_users(
 func.func @view_alias_chain_free_placement(
     %ctx: !hip.context,
     %b: memref<64x64xf32, strided<[?, ?], offset: ?>>,
-    %out: memref<2x64x64xf32>) -> memref<2x64x64xf32> {
+    %out: memref<1x64x64xf32>) -> memref<1x64x64xf32> {
   %alloc0 = memref.alloc() {alignment = 64 : i64} : memref<2x64x64xf32>
   %sv = memref.subview %alloc0[0, 0, 0][1, 64, 64][1, 1, 1]
       : memref<2x64x64xf32> to memref<1x64x64xf32, strided<[4096, 64, 1]>>
   %cast = memref.cast %sv
       : memref<1x64x64xf32, strided<[4096, 64, 1]>>
         to memref<1x64x64xf32, strided<[?, ?, ?], offset: ?>>
-  hip.matmul(%ctx) ins(%cast, %b : memref<1x64x64xf32, strided<[?, ?, ?], offset: ?>>, memref<64x64xf32, strided<[?, ?], offset: ?>>) outs(%out : memref<2x64x64xf32>)
-  return %out : memref<2x64x64xf32>
+  hip.matmul(%ctx) ins(%cast, %b : memref<1x64x64xf32, strided<[?, ?, ?], offset: ?>>, memref<64x64xf32, strided<[?, ?], offset: ?>>) outs(%out : memref<1x64x64xf32>)
+  return %out : memref<1x64x64xf32>
 }
 
 // Pool pattern: after hip-pool-allocs, the function has a single memref.alloc

--- a/test/lit/Dialect/hip-matmul-reify-shapes.mlir
+++ b/test/lit/Dialect/hip-matmul-reify-shapes.mlir
@@ -1,0 +1,115 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+//===----------------------------------------------------------------------===//
+// FileCheck tests for `Hip_MatmulOp::reifyResultShapes`.
+//
+// `reifyResultShapes` lifts the statically-known dims of `hip.matmul` into
+// `OpFoldResult` (IntegerAttr for static dims; tensor.dim of the relevant
+// operand for kDynamic dims). It is exercised here through the upstream
+// `--resolve-shaped-type-result-dims` pass, which folds `tensor.dim` of an
+// op result into either a constant (for static result dims) or a
+// `tensor.dim` of an input (for dynamic dims that are resolved through
+// reify to one of the input operands).
+//
+// The reify implementation honours the matmul shape contract:
+//   M (penultimate dim)  -> dim of A at A.rank-2
+//   N (last dim)         -> dim of B at B.rank-1
+//   batch dim i          -> dim of A or B at the corresponding right-aligned
+//                           position; if either side has size 1 (broadcast)
+//                           or the side is out-of-range, the other side is
+//                           used.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt --resolve-shaped-type-result-dims %s | FileCheck %s
+
+// --- 2D matmul, fully static result -> tensor.dim folds to constants. ---
+// CHECK-LABEL: func.func @reify_2d_static
+// CHECK-DAG:   %[[C2:.*]] = arith.constant 2 : index
+// CHECK-DAG:   %[[C8:.*]] = arith.constant 8 : index
+// CHECK:       return %[[C2]], %[[C8]]
+func.func @reify_2d_static(%ctx: !hip.context,
+                           %a: tensor<2x4xf16>,
+                           %b: tensor<4x8xf16>,
+                           %c: tensor<2x8xf16>) -> (index, index) {
+  %r = hip.matmul(%ctx)
+    ins(%a, %b : tensor<2x4xf16>, tensor<4x8xf16>)
+    outs(%c : tensor<2x8xf16>) : tensor<2x8xf16>
+  %d0_idx = arith.constant 0 : index
+  %d1_idx = arith.constant 1 : index
+  %d0 = tensor.dim %r, %d0_idx : tensor<2x8xf16>
+  %d1 = tensor.dim %r, %d1_idx : tensor<2x8xf16>
+  return %d0, %d1 : index, index
+}
+
+// -----
+
+// --- Dynamic batch (M-side comes from A); reify routes tensor.dim through A. ---
+// CHECK-LABEL: func.func @reify_dynamic_batch
+// CHECK-SAME:   %[[A:[A-Za-z0-9_]+]]: tensor<?x4x8xf16>
+// CHECK-DAG:   %[[C0:.*]] = arith.constant 0 : index
+// CHECK-DAG:   %[[C4:.*]] = arith.constant 4 : index
+// CHECK-DAG:   %[[C16:.*]] = arith.constant 16 : index
+// CHECK:       %[[B0:.*]] = tensor.dim %[[A]], %[[C0]] : tensor<?x4x8xf16>
+// CHECK:       return %[[B0]], %[[C4]], %[[C16]]
+func.func @reify_dynamic_batch(%ctx: !hip.context,
+                               %a: tensor<?x4x8xf16>,
+                               %b: tensor<8x16xf16>,
+                               %c: tensor<?x4x16xf16>) -> (index, index, index) {
+  %r = hip.matmul(%ctx)
+    ins(%a, %b : tensor<?x4x8xf16>, tensor<8x16xf16>)
+    outs(%c : tensor<?x4x16xf16>) : tensor<?x4x16xf16>
+  %d0_idx = arith.constant 0 : index
+  %d1_idx = arith.constant 1 : index
+  %d2_idx = arith.constant 2 : index
+  %d0 = tensor.dim %r, %d0_idx : tensor<?x4x16xf16>
+  %d1 = tensor.dim %r, %d1_idx : tensor<?x4x16xf16>
+  %d2 = tensor.dim %r, %d2_idx : tensor<?x4x16xf16>
+  return %d0, %d1, %d2 : index, index, index
+}
+
+// -----
+
+// --- Dynamic M (penultimate dim of A); reify routes tensor.dim of dim-0 to A. ---
+// CHECK-LABEL: func.func @reify_dynamic_M
+// CHECK-SAME:   %[[A:[A-Za-z0-9_]+]]: tensor<?x4xf16>
+// CHECK-DAG:   %[[C0:.*]] = arith.constant 0 : index
+// CHECK-DAG:   %[[C8:.*]] = arith.constant 8 : index
+// CHECK:       %[[M:.*]] = tensor.dim %[[A]], %[[C0]] : tensor<?x4xf16>
+// CHECK:       return %[[M]], %[[C8]]
+func.func @reify_dynamic_M(%ctx: !hip.context,
+                           %a: tensor<?x4xf16>,
+                           %b: tensor<4x8xf16>,
+                           %c: tensor<?x8xf16>) -> (index, index) {
+  %r = hip.matmul(%ctx)
+    ins(%a, %b : tensor<?x4xf16>, tensor<4x8xf16>)
+    outs(%c : tensor<?x8xf16>) : tensor<?x8xf16>
+  %d0_idx = arith.constant 0 : index
+  %d1_idx = arith.constant 1 : index
+  %d0 = tensor.dim %r, %d0_idx : tensor<?x8xf16>
+  %d1 = tensor.dim %r, %d1_idx : tensor<?x8xf16>
+  return %d0, %d1 : index, index
+}
+
+// -----
+
+// --- Dynamic N (last dim of B); reify routes tensor.dim of dim-1 to B. ---
+// CHECK-LABEL: func.func @reify_dynamic_N
+// CHECK-SAME:   %[[A:[A-Za-z0-9_]+]]: tensor<2x4xf16>, %[[B:[A-Za-z0-9_]+]]: tensor<4x?xf16>
+// CHECK-DAG:   %[[C2:.*]] = arith.constant 2 : index
+// CHECK-DAG:   %[[C1:.*]] = arith.constant 1 : index
+// CHECK:       %[[N:.*]] = tensor.dim %[[B]], %[[C1]] : tensor<4x?xf16>
+// CHECK:       return %[[C2]], %[[N]]
+func.func @reify_dynamic_N(%ctx: !hip.context,
+                           %a: tensor<2x4xf16>,
+                           %b: tensor<4x?xf16>,
+                           %c: tensor<2x?xf16>) -> (index, index) {
+  %r = hip.matmul(%ctx)
+    ins(%a, %b : tensor<2x4xf16>, tensor<4x?xf16>)
+    outs(%c : tensor<2x?xf16>) : tensor<2x?xf16>
+  %d0_idx = arith.constant 0 : index
+  %d1_idx = arith.constant 1 : index
+  %d0 = tensor.dim %r, %d0_idx : tensor<2x?xf16>
+  %d1 = tensor.dim %r, %d1_idx : tensor<2x?xf16>
+  return %d0, %d1 : index, index
+}

--- a/test/lit/Dialect/hip-matmul-reify-shapes.mlir
+++ b/test/lit/Dialect/hip-matmul-reify-shapes.mlir
@@ -3,6 +3,35 @@
 
 // RUN: hip-mlir-opt --resolve-shaped-type-result-dims %s | FileCheck %s
 
+// What this file tests
+// --------------------
+// `MatmulOp::reifyResultShapes` (in lib/Dialect/IR/HipReifyResultShapesImpl.cpp)
+// — i.e. the PRODUCER side of `ReifyRankedShapedTypeOpInterface` for
+// `hip.matmul`. Validates that for any operand-shape combination (static,
+// dynamic batch, dynamic M, dynamic N, broadcast) it returns a correct
+// per-dim `OpFoldResult`: an `IntegerAttr` for static dims, and a
+// `tensor.dim` of the right operand at the right local index for dynamic dims.
+//
+// What this file does NOT test
+// ----------------------------
+// `--hip-infer-shapes` — the production pass that consumes these
+// `OpFoldResult`s to refine result types and rebuild `tensor.empty`
+// producers. Pass-level behavior (composeRefinedShape, cast barriers,
+// DPS-init exemption) is covered by `hip-infer-shapes.mlir`.
+//
+// Why this test exists in addition to the pass test
+// -------------------------------------------------
+// `--hip-infer-shapes` only consumes the *constant* branch of each
+// `OpFoldResult` (via `getConstantIntValue`); it silently discards
+// dynamic ones. A bug in reify's dynamic-dim source-picking (wrong
+// operand chosen, wrong local dim index, or a malformed `tensor.dim`
+// emitted) is therefore invisible to the pass test. Upstream's
+// `--resolve-shaped-type-result-dims` materializes every `OpFoldResult`
+// — static and dynamic — into IR that FileCheck can inspect, exposing
+// those bugs. The upstream pass is used here purely as a generic
+// producer-contract validator; it is not part of the production
+// pipeline.
+
 // CHECK-LABEL: func.func @reify_2d_static
 // CHECK-DAG:   %[[C2:.*]] = arith.constant 2 : index
 // CHECK-DAG:   %[[C8:.*]] = arith.constant 8 : index

--- a/test/lit/Dialect/hip-matmul-reify-shapes.mlir
+++ b/test/lit/Dialect/hip-matmul-reify-shapes.mlir
@@ -6,11 +6,11 @@
 //
 // `reifyResultShapes` lifts the statically-known dims of `hip.matmul` into
 // `OpFoldResult` (IntegerAttr for static dims; tensor.dim of the relevant
-// operand for kDynamic dims). It is exercised here through the upstream
-// `--resolve-shaped-type-result-dims` pass, which folds `tensor.dim` of an
-// op result into either a constant (for static result dims) or a
-// `tensor.dim` of an input (for dynamic dims that are resolved through
-// reify to one of the input operands).
+// operand for kDynamic dims). It is exercised here through the
+// `--resolve-shaped-type-result-dims` pass (see RUN line below), which
+// folds `tensor.dim` of an op result into either a constant (for static
+// result dims) or a `tensor.dim` of an input (for dynamic dims that are
+// resolved through reify to one of the input operands).
 //
 // The reify implementation honours the matmul shape contract:
 //   M (penultimate dim)  -> dim of A at A.rank-2

--- a/test/lit/Dialect/hip-matmul-reify-shapes.mlir
+++ b/test/lit/Dialect/hip-matmul-reify-shapes.mlir
@@ -1,29 +1,8 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
-//
-//===----------------------------------------------------------------------===//
-// FileCheck tests for `Hip_MatmulOp::reifyResultShapes`.
-//
-// `reifyResultShapes` lifts the statically-known dims of `hip.matmul` into
-// `OpFoldResult` (IntegerAttr for static dims; tensor.dim of the relevant
-// operand for kDynamic dims). It is exercised here through the
-// `--resolve-shaped-type-result-dims` pass (see RUN line below), which
-// folds `tensor.dim` of an op result into either a constant (for static
-// result dims) or a `tensor.dim` of an input (for dynamic dims that are
-// resolved through reify to one of the input operands).
-//
-// The reify implementation honours the matmul shape contract:
-//   M (penultimate dim)  -> dim of A at A.rank-2
-//   N (last dim)         -> dim of B at B.rank-1
-//   batch dim i          -> dim of A or B at the corresponding right-aligned
-//                           position; if either side has size 1 (broadcast)
-//                           or the side is out-of-range, the other side is
-//                           used.
-//===----------------------------------------------------------------------===//
 
 // RUN: hip-mlir-opt --resolve-shaped-type-result-dims %s | FileCheck %s
 
-// --- 2D matmul, fully static result -> tensor.dim folds to constants. ---
 // CHECK-LABEL: func.func @reify_2d_static
 // CHECK-DAG:   %[[C2:.*]] = arith.constant 2 : index
 // CHECK-DAG:   %[[C8:.*]] = arith.constant 8 : index
@@ -44,7 +23,6 @@ func.func @reify_2d_static(%ctx: !hip.context,
 
 // -----
 
-// --- Dynamic batch (M-side comes from A); reify routes tensor.dim through A. ---
 // CHECK-LABEL: func.func @reify_dynamic_batch
 // CHECK-SAME:   %[[A:[A-Za-z0-9_]+]]: tensor<?x4x8xf16>
 // CHECK-DAG:   %[[C0:.*]] = arith.constant 0 : index
@@ -70,7 +48,6 @@ func.func @reify_dynamic_batch(%ctx: !hip.context,
 
 // -----
 
-// --- Dynamic M (penultimate dim of A); reify routes tensor.dim of dim-0 to A. ---
 // CHECK-LABEL: func.func @reify_dynamic_M
 // CHECK-SAME:   %[[A:[A-Za-z0-9_]+]]: tensor<?x4xf16>
 // CHECK-DAG:   %[[C0:.*]] = arith.constant 0 : index
@@ -93,7 +70,6 @@ func.func @reify_dynamic_M(%ctx: !hip.context,
 
 // -----
 
-// --- Dynamic N (last dim of B); reify routes tensor.dim of dim-1 to B. ---
 // CHECK-LABEL: func.func @reify_dynamic_N
 // CHECK-SAME:   %[[A:[A-Za-z0-9_]+]]: tensor<2x4xf16>, %[[B:[A-Za-z0-9_]+]]: tensor<4x?xf16>
 // CHECK-DAG:   %[[C2:.*]] = arith.constant 2 : index
@@ -116,16 +92,12 @@ func.func @reify_dynamic_N(%ctx: !hip.context,
 
 // -----
 
-// --- Dynamic vs static>1 batch broadcast: A's batch dim is dynamic, B's is
-//     static-5, and the result type is intentionally left dynamic (`?x4x16`).
-//     Per NumPy / TF / ONNX MatMul broadcast contract, A's dynamic dim must
-//     be either 1 (broadcast) or 5 (matched) at runtime, so reify infers the
-//     batch dim from operand shapes as static-5 even though the result type
-//     itself is dynamic. tensor.dim of the result's batch dim therefore
-//     folds to the constant 5 (NOT a tensor.dim of A). This pins the
-//     "dynamic + static>1 -> static" tightening that we get for free by
-//     delegating batch broadcast to upstream MLIR's getBroadcastedShape
-//     helper (which implements TF / ONNX broadcast contract semantics).
+// Pin the "dynamic + static>1 -> static" tightening: A's batch dim is dynamic,
+// B's is static-5; per NumPy / TF / ONNX broadcast contract A must be 1 or 5
+// at runtime. Reify therefore picks the static side, so tensor.dim of the
+// result's batch dim folds to constant 5 (CHECK-NOT: tensor.dim) — even though
+// the result type is left as ?x4x16. Delegated to upstream
+// mlir::OpTrait::util::getBroadcastedShape.
 // CHECK-LABEL: func.func @reify_dyn_static_batch_broadcast
 // CHECK-NOT:   tensor.dim
 // CHECK-DAG:   %[[C5:.*]] = arith.constant 5 : index

--- a/test/lit/Dialect/hip-matmul-reify-shapes.mlir
+++ b/test/lit/Dialect/hip-matmul-reify-shapes.mlir
@@ -113,3 +113,37 @@ func.func @reify_dynamic_N(%ctx: !hip.context,
   %d1 = tensor.dim %r, %d1_idx : tensor<2x?xf16>
   return %d0, %d1 : index, index
 }
+
+// -----
+
+// --- Dynamic vs static>1 batch broadcast: A's batch dim is dynamic, B's is
+//     static-5, and the result type is intentionally left dynamic (`?x4x16`).
+//     Per NumPy / TF / ONNX MatMul broadcast contract, A's dynamic dim must
+//     be either 1 (broadcast) or 5 (matched) at runtime, so reify infers the
+//     batch dim from operand shapes as static-5 even though the result type
+//     itself is dynamic. tensor.dim of the result's batch dim therefore
+//     folds to the constant 5 (NOT a tensor.dim of A). This pins the
+//     "dynamic + static>1 -> static" tightening that we get for free by
+//     delegating batch broadcast to upstream MLIR's getBroadcastedShape
+//     helper (which implements TF / ONNX broadcast contract semantics).
+// CHECK-LABEL: func.func @reify_dyn_static_batch_broadcast
+// CHECK-NOT:   tensor.dim
+// CHECK-DAG:   %[[C5:.*]] = arith.constant 5 : index
+// CHECK-DAG:   %[[C4:.*]] = arith.constant 4 : index
+// CHECK-DAG:   %[[C16:.*]] = arith.constant 16 : index
+// CHECK:       return %[[C5]], %[[C4]], %[[C16]]
+func.func @reify_dyn_static_batch_broadcast(%ctx: !hip.context,
+                                            %a: tensor<?x4x8xf16>,
+                                            %b: tensor<5x8x16xf16>,
+                                            %c: tensor<?x4x16xf16>) -> (index, index, index) {
+  %r = hip.matmul(%ctx)
+    ins(%a, %b : tensor<?x4x8xf16>, tensor<5x8x16xf16>)
+    outs(%c : tensor<?x4x16xf16>) : tensor<?x4x16xf16>
+  %d0_idx = arith.constant 0 : index
+  %d1_idx = arith.constant 1 : index
+  %d2_idx = arith.constant 2 : index
+  %d0 = tensor.dim %r, %d0_idx : tensor<?x4x16xf16>
+  %d1 = tensor.dim %r, %d1_idx : tensor<?x4x16xf16>
+  %d2 = tensor.dim %r, %d2_idx : tensor<?x4x16xf16>
+  return %d0, %d1, %d2 : index, index, index
+}

--- a/test/lit/Dialect/hip-matmul-shape-verifier.mlir
+++ b/test/lit/Dialect/hip-matmul-shape-verifier.mlir
@@ -1,0 +1,166 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+//===----------------------------------------------------------------------===//
+// FileCheck tests for the static shape verifier on `hip.matmul`.
+//
+// `hip.matmul` is a destination-passing-style op whose contract is:
+//   A: [..., M, K]
+//   B: [..., K, N]
+//   output: [broadcast(A.batch, B.batch), M, N]
+//
+// The verifier (HipShapeUtils::verifyHipOpShape backed by
+// HipShapeUtils::inferContractionShape) accepts kDynamic on either side as
+// a wildcard and rejects any pair of statically-known dims that disagrees.
+//
+// The verifier ALSO inherits the cross-cutting all-tensor-or-all-memref
+// check from verifyDpsComputeOp; that path is exercised by other LIT
+// suites, so this file focuses on the contraction-specific checks.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt --split-input-file --verify-diagnostics %s | FileCheck %s
+
+// --- Positive: 2D matmul with all-static shapes accepts. ---
+// CHECK-LABEL: func.func @matmul_2d_static
+// CHECK:         hip.matmul
+func.func @matmul_2d_static(%ctx: !hip.context,
+                            %a: memref<128x4096xf32, 1>,
+                            %b: memref<4096x1024xf32, 1>,
+                            %c: memref<128x1024xf32, 1>) {
+  hip.matmul(%ctx)
+    ins(%a, %b : memref<128x4096xf32, 1>, memref<4096x1024xf32, 1>)
+    outs(%c : memref<128x1024xf32, 1>)
+  return
+}
+
+// -----
+
+// --- Positive: 3D batched matmul with broadcast batch ([2] x [] -> [2]). ---
+// CHECK-LABEL: func.func @matmul_3d_broadcast
+// CHECK:         hip.matmul
+func.func @matmul_3d_broadcast(%ctx: !hip.context,
+                               %a: memref<2x4x8xf16, 1>,
+                               %b: memref<8x16xf16, 1>,
+                               %c: memref<2x4x16xf16, 1>) {
+  hip.matmul(%ctx)
+    ins(%a, %b : memref<2x4x8xf16, 1>, memref<8x16xf16, 1>)
+    outs(%c : memref<2x4x16xf16, 1>)
+  return
+}
+
+// -----
+
+// --- Positive: kDynamic on every batch dim — wildcard, no error. ---
+// CHECK-LABEL: func.func @matmul_dynamic_batch
+// CHECK:         hip.matmul
+func.func @matmul_dynamic_batch(%ctx: !hip.context,
+                                %a: memref<?x4x8xf16, 1>,
+                                %b: memref<8x16xf16, 1>,
+                                %c: memref<?x4x16xf16, 1>) {
+  hip.matmul(%ctx)
+    ins(%a, %b : memref<?x4x8xf16, 1>, memref<8x16xf16, 1>)
+    outs(%c : memref<?x4x16xf16, 1>)
+  return
+}
+
+// -----
+
+// --- Positive: kDynamic on contraction K — wildcard, no error. ---
+// CHECK-LABEL: func.func @matmul_dynamic_k
+// CHECK:         hip.matmul
+func.func @matmul_dynamic_k(%ctx: !hip.context,
+                            %a: memref<2x?xf16, 1>,
+                            %b: memref<?x8xf16, 1>,
+                            %c: memref<2x8xf16, 1>) {
+  hip.matmul(%ctx)
+    ins(%a, %b : memref<2x?xf16, 1>, memref<?x8xf16, 1>)
+    outs(%c : memref<2x8xf16, 1>)
+  return
+}
+
+// -----
+
+// --- Negative: contraction K mismatch is rejected. ---
+func.func @matmul_k_mismatch(%ctx: !hip.context,
+                             %a: memref<2x4xf16, 1>,
+                             %b: memref<8x16xf16, 1>,
+                             %c: memref<2x16xf16, 1>) {
+  // expected-error @below {{matmul contraction dim mismatch: A.shape[-1]=4 vs B.shape[-2]=8}}
+  hip.matmul(%ctx)
+    ins(%a, %b : memref<2x4xf16, 1>, memref<8x16xf16, 1>)
+    outs(%c : memref<2x16xf16, 1>)
+  return
+}
+
+// -----
+
+// --- Negative: M (output dim 0 in 2D case) mismatches outs. ---
+func.func @matmul_m_mismatch(%ctx: !hip.context,
+                             %a: memref<2x4xf16, 1>,
+                             %b: memref<4x8xf16, 1>,
+                             %c: memref<3x8xf16, 1>) {
+  // expected-error @below {{dim 0 of result #0 mismatch: expected 2}}
+  hip.matmul(%ctx)
+    ins(%a, %b : memref<2x4xf16, 1>, memref<4x8xf16, 1>)
+    outs(%c : memref<3x8xf16, 1>)
+  return
+}
+
+// -----
+
+// --- Negative: N (output dim 1 in 2D case) mismatches outs. ---
+func.func @matmul_n_mismatch(%ctx: !hip.context,
+                             %a: memref<2x4xf16, 1>,
+                             %b: memref<4x8xf16, 1>,
+                             %c: memref<2x9xf16, 1>) {
+  // expected-error @below {{dim 1 of result #0 mismatch: expected 8}}
+  hip.matmul(%ctx)
+    ins(%a, %b : memref<2x4xf16, 1>, memref<4x8xf16, 1>)
+    outs(%c : memref<2x9xf16, 1>)
+  return
+}
+
+// -----
+
+// --- Negative: batch dim broadcast failure ([2] vs [3], neither is 1). ---
+func.func @matmul_batch_broadcast_fail(%ctx: !hip.context,
+                                       %a: memref<2x4x8xf16, 1>,
+                                       %b: memref<3x8x16xf16, 1>,
+                                       %c: memref<2x4x16xf16, 1>) {
+  // expected-error @below {{matmul batch dim broadcast failure}}
+  hip.matmul(%ctx)
+    ins(%a, %b : memref<2x4x8xf16, 1>, memref<3x8x16xf16, 1>)
+    outs(%c : memref<2x4x16xf16, 1>)
+  return
+}
+
+// -----
+
+// --- Negative: rank of outs disagrees with the expected output rank
+//     (broadcast(A.batch=[2], B.batch=[]) gives rank 3, but outs is rank 2). ---
+func.func @matmul_rank_mismatch(%ctx: !hip.context,
+                                %a: memref<2x4x8xf16, 1>,
+                                %b: memref<8x16xf16, 1>,
+                                %c: memref<4x16xf16, 1>) {
+  // expected-error @below {{rank mismatch on result #0: expected rank 3}}
+  hip.matmul(%ctx)
+    ins(%a, %b : memref<2x4x8xf16, 1>, memref<8x16xf16, 1>)
+    outs(%c : memref<4x16xf16, 1>)
+  return
+}
+
+// -----
+
+// --- Positive: tensor mode (pre-bufferization) with all-static shapes. ---
+// CHECK-LABEL: func.func @matmul_tensor_mode_static
+// CHECK:         hip.matmul
+func.func @matmul_tensor_mode_static(%ctx: !hip.context,
+                                     %a: tensor<2x4xf16>,
+                                     %b: tensor<4x8xf16>,
+                                     %c: tensor<2x8xf16>)
+    -> tensor<2x8xf16> {
+  %r = hip.matmul(%ctx)
+    ins(%a, %b : tensor<2x4xf16>, tensor<4x8xf16>)
+    outs(%c : tensor<2x8xf16>) : tensor<2x8xf16>
+  return %r : tensor<2x8xf16>
+}

--- a/test/lit/Dialect/hip-matmul-shape-verifier.mlir
+++ b/test/lit/Dialect/hip-matmul-shape-verifier.mlir
@@ -127,7 +127,7 @@ func.func @matmul_batch_broadcast_fail(%ctx: !hip.context,
                                        %a: memref<2x4x8xf16, 1>,
                                        %b: memref<3x8x16xf16, 1>,
                                        %c: memref<2x4x16xf16, 1>) {
-  // expected-error @below {{matmul batch dim broadcast failure}}
+  // expected-error @below {{matmul batch broadcast failure}}
   hip.matmul(%ctx)
     ins(%a, %b : memref<2x4x8xf16, 1>, memref<3x8x16xf16, 1>)
     outs(%c : memref<2x4x16xf16, 1>)

--- a/test/lit/Dialect/hip-matmul-shape-verifier.mlir
+++ b/test/lit/Dialect/hip-matmul-shape-verifier.mlir
@@ -102,7 +102,7 @@ func.func @matmul_batch_broadcast_fail(%ctx: !hip.context,
                                        %a: memref<2x4x8xf16, 1>,
                                        %b: memref<3x8x16xf16, 1>,
                                        %c: memref<2x4x16xf16, 1>) {
-  // expected-error @below {{matmul batch broadcast failure}}
+  // expected-error @below {{matmul batch dim mismatch at position 0: A=2 B=3}}
   hip.matmul(%ctx)
     ins(%a, %b : memref<2x4x8xf16, 1>, memref<3x8x16xf16, 1>)
     outs(%c : memref<2x4x16xf16, 1>)
@@ -119,6 +119,51 @@ func.func @matmul_rank_mismatch(%ctx: !hip.context,
   hip.matmul(%ctx)
     ins(%a, %b : memref<2x4x8xf16, 1>, memref<8x16xf16, 1>)
     outs(%c : memref<4x16xf16, 1>)
+  return
+}
+
+// -----
+
+// B's rank exceeds A's: codegen derives result rank from A and would
+// miscompute. Rejected.
+func.func @matmul_b_rank_exceeds_a(%ctx: !hip.context,
+                                   %a: memref<4x8xf16, 1>,
+                                   %b: memref<2x8x16xf16, 1>,
+                                   %c: memref<2x4x16xf16, 1>) {
+  // expected-error @below {{matmul B's rank (3) exceeds A's rank (2)}}
+  hip.matmul(%ctx)
+    ins(%a, %b : memref<4x8xf16, 1>, memref<2x8x16xf16, 1>)
+    outs(%c : memref<2x4x16xf16, 1>)
+  return
+}
+
+// -----
+
+// Mixed-rank operands where B isn't exactly 2D: codegen handles only the
+// `B == rank-2` broadcast case. Rejected.
+func.func @matmul_mixed_rank_b_not_2d(%ctx: !hip.context,
+                                      %a: memref<2x3x4x8xf16, 1>,
+                                      %b: memref<3x8x16xf16, 1>,
+                                      %c: memref<2x3x4x16xf16, 1>) {
+  // expected-error @below {{matmul mixed-rank operands require B to be rank-2 (got A rank 4, B rank 3)}}
+  hip.matmul(%ctx)
+    ins(%a, %b : memref<2x3x4x8xf16, 1>, memref<3x8x16xf16, 1>)
+    outs(%c : memref<2x3x4x16xf16, 1>)
+  return
+}
+
+// -----
+
+// Per-dim batch broadcasting (1 vs >1): codegen reads A's batch verbatim,
+// so result batch would be 1 instead of 2. Rejected.
+func.func @matmul_per_dim_broadcast_unsupported(%ctx: !hip.context,
+                                                %a: memref<1x4x8xf16, 1>,
+                                                %b: memref<2x8x16xf16, 1>,
+                                                %c: memref<2x4x16xf16, 1>) {
+  // expected-error @below {{matmul batch dim mismatch at position 0: A=1 B=2; per-dim batch broadcasting (1 vs >1) is not supported by codegen}}
+  hip.matmul(%ctx)
+    ins(%a, %b : memref<1x4x8xf16, 1>, memref<2x8x16xf16, 1>)
+    outs(%c : memref<2x4x16xf16, 1>)
   return
 }
 

--- a/test/lit/Dialect/hip-matmul-shape-verifier.mlir
+++ b/test/lit/Dialect/hip-matmul-shape-verifier.mlir
@@ -102,7 +102,7 @@ func.func @matmul_batch_broadcast_fail(%ctx: !hip.context,
                                        %a: memref<2x4x8xf16, 1>,
                                        %b: memref<3x8x16xf16, 1>,
                                        %c: memref<2x4x16xf16, 1>) {
-  // expected-error @below {{matmul batch dim mismatch at position 0: A=2 B=3}}
+  // expected-error @below {{matmul batch broadcast failure}}
   hip.matmul(%ctx)
     ins(%a, %b : memref<2x4x8xf16, 1>, memref<3x8x16xf16, 1>)
     outs(%c : memref<2x4x16xf16, 1>)
@@ -119,51 +119,6 @@ func.func @matmul_rank_mismatch(%ctx: !hip.context,
   hip.matmul(%ctx)
     ins(%a, %b : memref<2x4x8xf16, 1>, memref<8x16xf16, 1>)
     outs(%c : memref<4x16xf16, 1>)
-  return
-}
-
-// -----
-
-// B's rank exceeds A's: codegen derives result rank from A and would
-// miscompute. Rejected.
-func.func @matmul_b_rank_exceeds_a(%ctx: !hip.context,
-                                   %a: memref<4x8xf16, 1>,
-                                   %b: memref<2x8x16xf16, 1>,
-                                   %c: memref<2x4x16xf16, 1>) {
-  // expected-error @below {{matmul B's rank (3) exceeds A's rank (2)}}
-  hip.matmul(%ctx)
-    ins(%a, %b : memref<4x8xf16, 1>, memref<2x8x16xf16, 1>)
-    outs(%c : memref<2x4x16xf16, 1>)
-  return
-}
-
-// -----
-
-// Mixed-rank operands where B isn't exactly 2D: codegen handles only the
-// `B == rank-2` broadcast case. Rejected.
-func.func @matmul_mixed_rank_b_not_2d(%ctx: !hip.context,
-                                      %a: memref<2x3x4x8xf16, 1>,
-                                      %b: memref<3x8x16xf16, 1>,
-                                      %c: memref<2x3x4x16xf16, 1>) {
-  // expected-error @below {{matmul mixed-rank operands require B to be rank-2 (got A rank 4, B rank 3)}}
-  hip.matmul(%ctx)
-    ins(%a, %b : memref<2x3x4x8xf16, 1>, memref<3x8x16xf16, 1>)
-    outs(%c : memref<2x3x4x16xf16, 1>)
-  return
-}
-
-// -----
-
-// Per-dim batch broadcasting (1 vs >1): codegen reads A's batch verbatim,
-// so result batch would be 1 instead of 2. Rejected.
-func.func @matmul_per_dim_broadcast_unsupported(%ctx: !hip.context,
-                                                %a: memref<1x4x8xf16, 1>,
-                                                %b: memref<2x8x16xf16, 1>,
-                                                %c: memref<2x4x16xf16, 1>) {
-  // expected-error @below {{matmul batch dim mismatch at position 0: A=1 B=2; per-dim batch broadcasting (1 vs >1) is not supported by codegen}}
-  hip.matmul(%ctx)
-    ins(%a, %b : memref<1x4x8xf16, 1>, memref<2x8x16xf16, 1>)
-    outs(%c : memref<2x4x16xf16, 1>)
   return
 }
 

--- a/test/lit/Dialect/hip-matmul-shape-verifier.mlir
+++ b/test/lit/Dialect/hip-matmul-shape-verifier.mlir
@@ -1,26 +1,8 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
-//
-//===----------------------------------------------------------------------===//
-// FileCheck tests for the static shape verifier on `hip.matmul`.
-//
-// `hip.matmul` is a destination-passing-style op whose contract is:
-//   A: [..., M, K]
-//   B: [..., K, N]
-//   output: [broadcast(A.batch, B.batch), M, N]
-//
-// The verifier (HipShapeUtils::verifyHipOpShape backed by
-// HipShapeUtils::inferContractionShape) accepts kDynamic on either side as
-// a wildcard and rejects any pair of statically-known dims that disagrees.
-//
-// The verifier ALSO inherits the cross-cutting all-tensor-or-all-memref
-// check from verifyDpsComputeOp; that path is exercised by other LIT
-// suites, so this file focuses on the contraction-specific checks.
-//===----------------------------------------------------------------------===//
 
 // RUN: hip-mlir-opt --split-input-file --verify-diagnostics %s | FileCheck %s
 
-// --- Positive: 2D matmul with all-static shapes accepts. ---
 // CHECK-LABEL: func.func @matmul_2d_static
 // CHECK:         hip.matmul
 func.func @matmul_2d_static(%ctx: !hip.context,
@@ -35,7 +17,6 @@ func.func @matmul_2d_static(%ctx: !hip.context,
 
 // -----
 
-// --- Positive: 3D batched matmul with broadcast batch ([2] x [] -> [2]). ---
 // CHECK-LABEL: func.func @matmul_3d_broadcast
 // CHECK:         hip.matmul
 func.func @matmul_3d_broadcast(%ctx: !hip.context,
@@ -50,7 +31,6 @@ func.func @matmul_3d_broadcast(%ctx: !hip.context,
 
 // -----
 
-// --- Positive: kDynamic on every batch dim — wildcard, no error. ---
 // CHECK-LABEL: func.func @matmul_dynamic_batch
 // CHECK:         hip.matmul
 func.func @matmul_dynamic_batch(%ctx: !hip.context,
@@ -65,7 +45,6 @@ func.func @matmul_dynamic_batch(%ctx: !hip.context,
 
 // -----
 
-// --- Positive: kDynamic on contraction K — wildcard, no error. ---
 // CHECK-LABEL: func.func @matmul_dynamic_k
 // CHECK:         hip.matmul
 func.func @matmul_dynamic_k(%ctx: !hip.context,
@@ -80,7 +59,6 @@ func.func @matmul_dynamic_k(%ctx: !hip.context,
 
 // -----
 
-// --- Negative: contraction K mismatch is rejected. ---
 func.func @matmul_k_mismatch(%ctx: !hip.context,
                              %a: memref<2x4xf16, 1>,
                              %b: memref<8x16xf16, 1>,
@@ -94,7 +72,6 @@ func.func @matmul_k_mismatch(%ctx: !hip.context,
 
 // -----
 
-// --- Negative: M (output dim 0 in 2D case) mismatches outs. ---
 func.func @matmul_m_mismatch(%ctx: !hip.context,
                              %a: memref<2x4xf16, 1>,
                              %b: memref<4x8xf16, 1>,
@@ -108,7 +85,6 @@ func.func @matmul_m_mismatch(%ctx: !hip.context,
 
 // -----
 
-// --- Negative: N (output dim 1 in 2D case) mismatches outs. ---
 func.func @matmul_n_mismatch(%ctx: !hip.context,
                              %a: memref<2x4xf16, 1>,
                              %b: memref<4x8xf16, 1>,
@@ -122,7 +98,6 @@ func.func @matmul_n_mismatch(%ctx: !hip.context,
 
 // -----
 
-// --- Negative: batch dim broadcast failure ([2] vs [3], neither is 1). ---
 func.func @matmul_batch_broadcast_fail(%ctx: !hip.context,
                                        %a: memref<2x4x8xf16, 1>,
                                        %b: memref<3x8x16xf16, 1>,
@@ -136,8 +111,6 @@ func.func @matmul_batch_broadcast_fail(%ctx: !hip.context,
 
 // -----
 
-// --- Negative: rank of outs disagrees with the expected output rank
-//     (broadcast(A.batch=[2], B.batch=[]) gives rank 3, but outs is rank 2). ---
 func.func @matmul_rank_mismatch(%ctx: !hip.context,
                                 %a: memref<2x4x8xf16, 1>,
                                 %b: memref<8x16xf16, 1>,
@@ -151,7 +124,6 @@ func.func @matmul_rank_mismatch(%ctx: !hip.context,
 
 // -----
 
-// --- Positive: tensor mode (pre-bufferization) with all-static shapes. ---
 // CHECK-LABEL: func.func @matmul_tensor_mode_static
 // CHECK:         hip.matmul
 func.func @matmul_tensor_mode_static(%ctx: !hip.context,

--- a/test/lit/Dialect/hip-optimize-memrefs.mlir
+++ b/test/lit/Dialect/hip-optimize-memrefs.mlir
@@ -165,14 +165,14 @@ func.func @no_reuse_different_dynamic(
 func.func @subview_extends_lifetime(
     %ctx: !hip.context,
     %a: memref<2x64x64xf32, strided<[?, ?, ?], offset: ?>>,
-    %b: memref<64x64xf32, strided<[?, ?], offset: ?>>) -> memref<2x64x64xf32> {
+    %b: memref<64x64xf32, strided<[?, ?], offset: ?>>) -> memref<1x64x64xf32> {
   %alloc0 = memref.alloc() {alignment = 64 : i64} : memref<2x64x64xf32>
   hip.matmul(%ctx) ins(%a, %b : memref<2x64x64xf32, strided<[?, ?, ?], offset: ?>>, memref<64x64xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<2x64x64xf32>)
   %sv = memref.subview %alloc0[0, 0, 0][1, 64, 64][1, 1, 1] : memref<2x64x64xf32> to memref<1x64x64xf32, strided<[4096, 64, 1]>>
-  %alloc1 = memref.alloc() {alignment = 64 : i64} : memref<2x64x64xf32>
+  %alloc1 = memref.alloc() {alignment = 64 : i64} : memref<1x64x64xf32>
   %cast = memref.cast %sv : memref<1x64x64xf32, strided<[4096, 64, 1]>> to memref<1x64x64xf32, strided<[?, ?, ?], offset: ?>>
-  hip.matmul(%ctx) ins(%cast, %b : memref<1x64x64xf32, strided<[?, ?, ?], offset: ?>>, memref<64x64xf32, strided<[?, ?], offset: ?>>) outs(%alloc1 : memref<2x64x64xf32>)
-  return %alloc1 : memref<2x64x64xf32>
+  hip.matmul(%ctx) ins(%cast, %b : memref<1x64x64xf32, strided<[?, ?, ?], offset: ?>>, memref<64x64xf32, strided<[?, ?], offset: ?>>) outs(%alloc1 : memref<1x64x64xf32>)
+  return %alloc1 : memref<1x64x64xf32>
 }
 
 // No allocs to optimize -- pass should be a no-op.
@@ -195,11 +195,10 @@ func.func @no_allocs(
 // CHECK:         memref.alloc(){{.*}}: memref<64xf16>
 func.func @no_reuse_different_element_type(
     %ctx: !hip.context,
-    %a: memref<2x64x64xf32, strided<[?, ?, ?], offset: ?>>,
-    %b: memref<64x64xf32, strided<[?, ?], offset: ?>>,
+    %d: memref<64xf32>,
     %c: memref<64xf16>) -> memref<64xf16> {
   %alloc0 = memref.alloc() : memref<64xf32>
-  hip.matmul(%ctx) ins(%a, %b : memref<2x64x64xf32, strided<[?, ?, ?], offset: ?>>, memref<64x64xf32, strided<[?, ?], offset: ?>>) outs(%alloc0 : memref<64xf32>)
+  hip.miopen.softmax(%ctx) ins(%d : memref<64xf32>) outs(%alloc0 : memref<64xf32>)
   %alloc1 = memref.alloc() : memref<64xf16>
   hip.miopen.softmax(%ctx) ins(%c : memref<64xf16>) outs(%alloc1 : memref<64xf16>)
   return %alloc1 : memref<64xf16>

--- a/tools/hip-mlir-opt/hip-mlir-opt.cpp
+++ b/tools/hip-mlir-opt/hip-mlir-opt.cpp
@@ -22,6 +22,7 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/MemRef/Transforms/AllocationOpInterfaceImpl.h"
+#include "mlir/Dialect/MemRef/Transforms/Passes.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/SCF/Transforms/BufferizableOpInterfaceImpl.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
@@ -240,6 +241,11 @@ int main(int argc, char **argv) {
   mlir::registerSCFToControlFlowPass();
   mlir::registerConvertControlFlowToLLVMPass();
   mlir::registerReconcileUnrealizedCastsPass();
+  // --resolve-shaped-type-result-dims drives `tensor.dim` / `memref.dim`
+  // folding via `ReifyRankedShapedTypeOpInterface`. Registered for the
+  // hip-matmul-reify-shapes LIT and for end-to-end use after
+  // --hip-infer-shapes when callers want the dim ops collapsed too.
+  mlir::memref::registerResolveShapedTypeResultDimsPass();
   mlir::registerPass(
       []() -> std::unique_ptr<mlir::Pass> { return mlir::createCSEPass(); });
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {

--- a/tools/hip-mlir-opt/hip-mlir-opt.cpp
+++ b/tools/hip-mlir-opt/hip-mlir-opt.cpp
@@ -241,10 +241,9 @@ int main(int argc, char **argv) {
   mlir::registerSCFToControlFlowPass();
   mlir::registerConvertControlFlowToLLVMPass();
   mlir::registerReconcileUnrealizedCastsPass();
-  // --resolve-shaped-type-result-dims drives `tensor.dim` / `memref.dim`
-  // folding via `ReifyRankedShapedTypeOpInterface`. Registered for the
-  // hip-matmul-reify-shapes LIT and for end-to-end use after
-  // --hip-infer-shapes when callers want the dim ops collapsed too.
+  // Registered so that LIT tests and end-to-end pipelines can fold
+  // `tensor.dim` / `memref.dim` of HIP op results through the reify
+  // implementation. Used in `hip-matmul-reify-shapes.mlir`.
   mlir::memref::registerResolveShapedTypeResultDimsPass();
   mlir::registerPass(
       []() -> std::unique_ptr<mlir::Pass> { return mlir::createCSEPass(); });


### PR DESCRIPTION
Landing shape inference infrastructure for HIP DPS ops in a 6-PR cascade (#260-#265). This first PR adds three pieces: a static verifier on `hip.matmul`, a default `reifyResultShapes` body shared by every DPS op via a new in-dialect `HipDpsOpInterface`, and a module-level `--hip-infer-shapes` pass that refines `?` dims and rebuilds `tensor.empty` producers. `hip.matmul` is the worked example for both the bespoke-runtime-reify opt-out (`autoReify=0`) and the auto-emitted `inferReturnTypes` opt-in (`autoInfer=1, declareInfer=1`); the dialect's remaining 51 single-result DPS ops inherit the auto-emitted body when #262 flips the default.

**LOC delta (net): +959 source, +591 doc, +519 test.**

**Example MLIR that previously stayed dynamic** (chained matmul, both `tensor.empty` outs operands sized with dynamic SSA values that `convert-onnx-to-hip` could not statically resolve):

```mlir
// Before --hip-infer-shapes:
%e1 = tensor.empty(%d1, %d2) : tensor<?x?xf16>
%y1 = hip.matmul ins(%a, %b : tensor<2x4xf16>, tensor<4x8xf16>)
                 outs(%e1 : tensor<?x?xf16>) : tensor<?x?xf16>
%e2 = tensor.empty(%d3, %d4) : tensor<?x?xf16>
%y2 = hip.matmul ins(%y1, %c : tensor<?x?xf16>, tensor<8x16xf16>)
                 outs(%e2 : tensor<?x?xf16>) : tensor<?x?xf16>

// After:
%e1   = tensor.empty() : tensor<2x8xf16>          // dyn operands dropped
%y1   = hip.matmul ins(%a, %b : tensor<2x4xf16>, tensor<4x8xf16>)
                   outs(%e1 : tensor<2x8xf16>) : tensor<2x8xf16>
%cast = tensor.cast %y1 : tensor<2x8xf16> to tensor<?x?xf16>  // barrier
%e2   = tensor.empty() : tensor<2x16xf16>
%y2   = hip.matmul ins(%cast, %c : tensor<?x?xf16>, tensor<8x16xf16>)
                   outs(%e2 : tensor<2x16xf16>) : tensor<2x16xf16>
```

The second matmul's M dim is recovered as `2` even though `%cast` keeps its `ins`-edge type at `tensor<?x?xf16>` — `tensor::DimOp::fold` looks through the cast to the static-typed source, so reify recovers static dims without whole-chain narrowing.

**The fix:** four pieces sharing one shape helper for matmul, plus a TableGen-driven default reify for the rest of the dialect.

* `mlir::hip::inferMatmulShape` — shape contract `[..., M, K] @ [..., K, N] -> [..., M, N]`. Used by both `MatmulOp::verify` (driven by `verifyHipOpShape`, which compares the helper's output against the op's `outs` types with `kDynamic` as wildcard) and `MatmulOp::reifyResultShapes`.
* `HipDpsOpInterface` — new in-dialect interface owns the shared default `reifyResultShapes` body (walks `getDpsInits()`, lifts each init via `tensor::getMixedSizes` / `memref::getMixedSizes`). The parameterized `Hip_DpsOp` TableGen base auto-emits per-op dispatchers via `extraClassDefinition`, gated by an `autoReify` bit. 52 of 53 DPS ops gain a working `reifyResultShapes` for free; only `hip.matmul` opts out (`autoReify=0`) to keep its bespoke runtime body in `HipReifyResultShapesImpl.cpp` (recovers M/K/N from operand shapes, lifts each via `reifyDimOrConstant`).
* `MatmulOp::inferReturnTypes` — auto-emitted construction-time body via `autoInfer=1, declareInfer=1` (single opt-in on this PR; #262 flips the default for the remaining 51 single-result ops). The `MatMulConversion.cpp` callsite drops the explicit `resultType` from `Op::create` and uses the inferred-type overload. The two layers are orthogonal: bespoke runtime reify (recovers dims from operand shapes) coexists with auto-emitted construction-time `inferReturnTypes` (the typed outs operand already encodes the result shape, so the body just reads it back).
* `--hip-infer-shapes` — module-level pass after `convert-onnx-to-hip` (`Pipelines.cpp::buildOnnxToHipPipelineTail`). Walks reify-interface ops, refines `?` dims in place, rebuilds `tensor.empty` producers so the DPS contract `result_type == outs_type` stays satisfied. A `tensor.cast` on every non-DPS-init use is the per-op propagation barrier (rationale + pinned test in the [design doc](https://github.com/ROCm/onnx-hipdnn-ep/blob/fhanuman.shape_inference/docs/design/hip-shape-inference.md#per-op-refinement-not-whole-chain)).

LIT split into producer (`hip-matmul-reify-shapes.mlir`, driven by `--resolve-shaped-type-result-dims` — **not** in our pipeline, but the only consumer that materialises reify branches into FileCheck-able IR) vs consumer (`hip-infer-shapes.mlir`, driven by `--hip-infer-shapes` itself), plus a new [`hip-dps-op-interface.mlir`](https://github.com/ROCm/onnx-hipdnn-ep/blob/fhanuman.shape_inference/test/lit/Dialect/hip-dps-op-interface.mlir) that pins the interface-default body on `hip.silu` (static / dynamic / mixed shape). 206/206 LIT pass. Two pre-existing tests (`hip-lower-allocs.mlir`, `hip-optimize-memrefs.mlir`) are tightened where the old verifier accepted matmul shapes the new rank contract correctly rejects.

P.S. Rank-1 ONNX `MatMul` operands are explicitly rejected by the verifier today; the fix belongs in `MatMulConversion.cpp` (`tensor.expand_shape` to rank-2 around the `hip.matmul`). No supported model exercises this case.

**Stack overview** — this PR is the foundation; the rest of the cascade fans out from here. Each PR is independently shippable.

* **#260 (this PR):** `HipDpsOpInterface` + parameterized `Hip_DpsOp` base; verifier + reify + `--hip-infer-shapes` for `hip.matmul`.
* **#261:** `InferTypeOpInterface` on `Hip_LoopOp` (region op, orthogonal scaffolding).
* **#262:** flips `autoInfer=1, declareInfer=1` defaults; introduces `Hip_DpsOp_SameShape` sub-base; migrates `rope` / `rms_norm` and the matmul-shape-contract ops (`gemm`, `qmoe`, `matmul_nbits`) onto the auto-emitted `inferReturnTypes` body.
* **#263:** introduces `Hip_DpsOp_Broadcast` and migrates the 23 broadcast + same-shape elementwise ops.
* **#264:** cleans up the remaining bespoke shape ops (`pad`, `tile`, `expand`, `slice`, `range`, `gather*`, `reduce_*`, `transpose`) and the multi-init / variadic-out ops (`gqa`, `mha`, `linear_attention`, `causal_conv_with_state`, `layer_norm`, `skip_rms_norm`, `hipdnn_graph`); closes the reify surface across all 53 ops.
* **#265:** adds a LIT case exercising the interface-default body through `--hip-infer-shapes` end-to-end.
