### PR TITLE
feat(hip): InferTypeOpInterface on Hip_LoopOp returning v_init operand types -- 2/n

### DIFF
--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -203,6 +203,8 @@ def Hip_LoopOp : Hip_Op<"loop",
      DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
      DeclareOpInterfaceMethods<DestinationStyleOpInterface,
                                ["getDpsInitsMutable"]>,
+     DeclareOpInterfaceMethods<InferTypeOpInterface,
+                               ["inferReturnTypes"]>,
      DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
   let summary = "Outlined-body counted/conditional loop";
   let description = [{

--- a/lib/Conversion/OnnxToHip/LoopOutline.cpp
+++ b/lib/Conversion/OnnxToHip/LoopOutline.cpp
@@ -429,6 +429,20 @@ LogicalResult OnnxLoopOutlinePass::outlineLoop(Operation *loopOp,
 
   // hip.loop result types: same as the (loop-carried portion of) yield ops
   // minus the cond_out slot, i.e. the original onnx.Loop's result types.
+  //
+  // NOTE: For dynamic-shape exports (canonical trigger: vision-encoder ONNX
+  // exports where the body block args are left as rank-0 placeholders
+  // while v_init is rank-3 with `?` dims), the original onnx.Loop result
+  // types may disagree with v_init operand types -- the hip.loop verifier
+  // (HipOps.td:126-127) rejects in that case. The fix is recursive shape
+  // refinement on the outlined body func (Phase 2.5 / PR #265): once the
+  // body has refined arg / return / op types, migrate this construction
+  // to use the InferTypeOpInterface-aware LoopOp::create overload (drops
+  // the explicit result-types argument; LoopOp::inferReturnTypes sources
+  // them from v_init). Premature migration without body refinement leaves
+  // the body func signature under-refined while the hip.loop call site
+  // passes refined v_carry values -- type-mismatched at the LLVM lowering
+  // call boundary. Keep the explicit construction here until #265 ships.
   SmallVector<Type> hipLoopResultTypes(loopOp->getResultTypes());
 
   auto hipLoopOp = LoopOp::create(

--- a/lib/Conversion/OnnxToHip/LoopOutline.cpp
+++ b/lib/Conversion/OnnxToHip/LoopOutline.cpp
@@ -430,19 +430,19 @@ LogicalResult OnnxLoopOutlinePass::outlineLoop(Operation *loopOp,
   // hip.loop result types: same as the (loop-carried portion of) yield ops
   // minus the cond_out slot, i.e. the original onnx.Loop's result types.
   //
-  // NOTE: For dynamic-shape exports (canonical trigger: vision-encoder ONNX
-  // exports where the body block args are left as rank-0 placeholders
-  // while v_init is rank-3 with `?` dims), the original onnx.Loop result
-  // types may disagree with v_init operand types -- the hip.loop verifier
-  // (HipOps.td:126-127) rejects in that case. The fix is recursive shape
-  // refinement on the outlined body func (Phase 2.5 / PR #265): once the
-  // body has refined arg / return / op types, migrate this construction
-  // to use the InferTypeOpInterface-aware LoopOp::create overload (drops
-  // the explicit result-types argument; LoopOp::inferReturnTypes sources
-  // them from v_init). Premature migration without body refinement leaves
-  // the body func signature under-refined while the hip.loop call site
-  // passes refined v_carry values -- type-mismatched at the LLVM lowering
-  // call boundary. Keep the explicit construction here until #265 ships.
+  // For dynamic-shape exports the original onnx.Loop result types may
+  // disagree with v_init operand types — the hip.loop verifier rejects
+  // in that case (canonical trigger: vision-encoder ONNX exports that
+  // leave loop result types under-refined relative to v_init). The fix
+  // is recursive shape refinement on the outlined body func, which is
+  // follow-up work; once body arg / yield / op types agree with v_init,
+  // migrate this construction to the InferTypeOpInterface-aware
+  // LoopOp::create overload (drops the explicit result-types argument;
+  // LoopOp::inferReturnTypes sources them from v_init). Premature
+  // migration without body refinement leaves the body func signature
+  // under-refined while the hip.loop call site passes refined v_carry
+  // values — type-mismatched at the LLVM lowering call boundary. Keep
+  // the explicit construction here until that work lands.
   SmallVector<Type> hipLoopResultTypes(loopOp->getResultTypes());
 
   auto hipLoopOp = LoopOp::create(

--- a/lib/Conversion/OnnxToHip/LoopOutline.cpp
+++ b/lib/Conversion/OnnxToHip/LoopOutline.cpp
@@ -432,11 +432,12 @@ LogicalResult OnnxLoopOutlinePass::outlineLoop(Operation *loopOp,
   //
   // For dynamic-shape exports the original onnx.Loop result types may
   // disagree with v_init operand types — the hip.loop verifier rejects
-  // in that case (canonical trigger: vision-encoder ONNX exports that
-  // leave loop result types under-refined relative to v_init). The fix
-  // is recursive shape refinement on the outlined body func, which is
-  // follow-up work; once body arg / yield / op types agree with v_init,
-  // migrate this construction to the InferTypeOpInterface-aware
+  // in that case (canonical trigger: the importer leaves result / body
+  // block-arg types as rank-0 placeholders while upstream shape
+  // inference has already refined v_init to a richer dynamic shape).
+  // The fix is recursive shape refinement on the outlined body func,
+  // which is follow-up work; once body arg / yield / op types agree
+  // with v_init, migrate this construction to the InferTypeOpInterface-aware
   // LoopOp::create overload (drops the explicit result-types argument;
   // LoopOp::inferReturnTypes sources them from v_init). Premature
   // migration without body refinement leaves the body func signature

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -166,11 +166,11 @@ LogicalResult LoopOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 //
 // Memref-mode v_init produces 0 result types (DPS post-bufferization
 // convention; the verifier rejects mixed mode anyway).
-LogicalResult LoopOp::inferReturnTypes(
-    MLIRContext *context, std::optional<Location> location,
-    ValueRange operands, DictionaryAttr attributes,
-    OpaqueProperties properties, RegionRange regions,
-    SmallVectorImpl<Type> &inferredReturnTypes) {
+LogicalResult
+LoopOp::inferReturnTypes(MLIRContext *context, std::optional<Location> location,
+                         ValueRange operands, DictionaryAttr attributes,
+                         OpaqueProperties properties, RegionRange regions,
+                         SmallVectorImpl<Type> &inferredReturnTypes) {
   LoopOpAdaptor adaptor(operands, attributes, properties, regions);
   auto vInit = adaptor.getVInit();
   inferredReturnTypes.reserve(vInit.size());

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -156,6 +156,35 @@ LogicalResult LoopOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   return success();
 }
 
+// Result types are mechanically `v_init` operand types (verifier contract,
+// see verify() above and HipOps.td:126-127). Builders without explicit
+// result types pick this up automatically; ensures any new caller is
+// verifier-clean by construction.
+//
+// Status quo callers (notably LoopOutline.cpp's outlining) still pass
+// explicit result types and are unaffected. Migrating those to the
+// InferType-friendly builder requires upstream shape refinement on the
+// outlined body func (so body arg / yield / op types agree with v_init);
+// that work lives in Phase 2.5 / PR #265, which then flips LoopOutline
+// over to this path. Until then, this method only services NEW callers.
+//
+// Memref-mode v_init produces 0 result types (DPS post-bufferization
+// convention -- verifier rejects mixed mode anyway).
+LogicalResult LoopOp::inferReturnTypes(
+    MLIRContext *context, std::optional<Location> location,
+    ValueRange operands, DictionaryAttr attributes,
+    OpaqueProperties properties, RegionRange regions,
+    SmallVectorImpl<Type> &inferredReturnTypes) {
+  LoopOpAdaptor adaptor(operands, attributes, properties, regions);
+  auto vInit = adaptor.getVInit();
+  inferredReturnTypes.reserve(vInit.size());
+  for (Value v : vInit) {
+    if (isa<RankedTensorType>(v.getType()))
+      inferredReturnTypes.push_back(v.getType());
+  }
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // Helpers for DPS compute ops (custom parse/print, verify, interfaces)
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -156,20 +156,16 @@ LogicalResult LoopOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   return success();
 }
 
-// Result types are mechanically `v_init` operand types (verifier contract,
-// see verify() above and HipOps.td:126-127). Builders without explicit
-// result types pick this up automatically; ensures any new caller is
-// verifier-clean by construction.
-//
-// Status quo callers (notably LoopOutline.cpp's outlining) still pass
-// explicit result types and are unaffected. Migrating those to the
-// InferType-friendly builder requires upstream shape refinement on the
-// outlined body func (so body arg / yield / op types agree with v_init);
-// that work lives in Phase 2.5 / PR #265, which then flips LoopOutline
-// over to this path. Until then, this method only services NEW callers.
+// Result types are mechanically the `v_init` operand types — matches the
+// `LoopOp::verify` contract. Builders that omit explicit result types
+// pick this up automatically, so any new caller is verifier-clean by
+// construction. Existing callers that still pass explicit result types
+// (notably the onnx-loop outlining pass) are unaffected; migrating them
+// requires shape refinement on the outlined body func so body arg /
+// yield / op types agree with v_init, which is follow-up work.
 //
 // Memref-mode v_init produces 0 result types (DPS post-bufferization
-// convention -- verifier rejects mixed mode anyway).
+// convention; the verifier rejects mixed mode anyway).
 LogicalResult LoopOp::inferReturnTypes(
     MLIRContext *context, std::optional<Location> location,
     ValueRange operands, DictionaryAttr attributes,

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -157,12 +157,9 @@ LogicalResult LoopOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 }
 
 // Result types are mechanically the `v_init` operand types — matches the
-// `LoopOp::verify` contract. Builders that omit explicit result types
-// pick this up automatically, so any new caller is verifier-clean by
-// construction. Existing callers that still pass explicit result types
-// (notably the onnx-loop outlining pass) are unaffected; migrating them
-// requires shape refinement on the outlined body func so body arg /
-// yield / op types agree with v_init, which is follow-up work.
+// `LoopOp::verify` contract, so any caller that uses an InferType-aware
+// builder (operand types only, no explicit result types) is verifier-clean
+// by construction.
 //
 // Memref-mode v_init produces 0 result types (DPS post-bufferization
 // convention; the verifier rejects mixed mode anyway).

--- a/test/lit/Dialect/hip-loop-verifier.mlir
+++ b/test/lit/Dialect/hip-loop-verifier.mlir
@@ -1,30 +1,11 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
 
-// ============================================================================
-// TEST PURPOSE:
-// Pin the `hip.loop` verifier contract that result_type[i] must equal
-// v_init[i].getType() (HipDialect.cpp::LoopOp::verify, HipOps.td:126-127).
-// This is also the contract that `LoopOp::inferReturnTypes`
-// (InferTypeOpInterface) is engineered to preserve when a future caller
-// constructs a `hip.loop` via the InferType-aware builder without
-// supplying explicit result types -- the InferType impl simply returns
-// v_init operand types per result, which by definition agrees with this
-// verifier check.
-//
-// Coverage:
-//   1. Positive: refined dynamic v_init (rank-3 with `?` dims) +
-//      matching result type verifies cleanly.
-//   2. Negative: under-refined result type (rank-0) against refined
-//      rank-3 dynamic v_init triggers the canonical
-//      "result type #N must match v_init type #N" error -- this is the
-//      signature seen on dynamic-shape vision-encoder ONNX exports
-//      where the importer leaves loop result types under-refined
-//      relative to the v_init operands. The fix lives in PR #265
-//      (LoopOutline.cpp body refinement + InferType builder migration);
-//      this LIT pins the verifier so the fix can't silently regress.
-//   3. Positive: multi-v_init (mixed static + dynamic) verifies cleanly.
-// ============================================================================
+// Pin the `hip.loop` verifier contract that `result_type[i]` must equal
+// `v_init[i].getType()`. This is also the contract that
+// `LoopOp::inferReturnTypes` is engineered to preserve — the InferType
+// impl returns v_init operand types per result, which by definition
+// agrees with the verifier.
 
 // RUN: hip-mlir-opt --split-input-file --verify-diagnostics %s | FileCheck %s
 
@@ -52,11 +33,11 @@ func.func @loop_dynamic_v_init_ok(%ctx: !hip.context,
 
 // -----
 
-// Negative case -- canonical Qwen3.5-9B-vision-style mismatch: result
-// type is rank-0 (under-refined), v_init is rank-3 dynamic (refined).
-// `LoopOp::inferReturnTypes` would have produced rank-3 here; manually
-// supplying rank-0 is what the historical bug looked like before the
-// fix.
+// Negative case: result type is rank-0 (under-refined), v_init is rank-3
+// dynamic (refined). `LoopOp::inferReturnTypes` would have produced
+// rank-3 here; manually supplying rank-0 is the historical bug pattern
+// (canonical trigger: dynamic-shape vision-encoder exports that leave
+// loop result types under-refined relative to v_init operands).
 func.func private @loop_body_mismatch(%ctx: !hip.context,
                                       %iter: index,
                                       %cond_in: i1,

--- a/test/lit/Dialect/hip-loop-verifier.mlir
+++ b/test/lit/Dialect/hip-loop-verifier.mlir
@@ -36,8 +36,8 @@ func.func @loop_dynamic_v_init_ok(%ctx: !hip.context,
 // Negative case: result type is rank-0 (under-refined), v_init is rank-3
 // dynamic (refined). `LoopOp::inferReturnTypes` would have produced
 // rank-3 here; manually supplying rank-0 is the historical bug pattern
-// (canonical trigger: dynamic-shape vision-encoder exports that leave
-// loop result types under-refined relative to v_init operands).
+// (the importer leaves loop result types as rank-0 placeholders while
+// upstream shape inference has already refined v_init).
 func.func private @loop_body_mismatch(%ctx: !hip.context,
                                       %iter: index,
                                       %cond_in: i1,

--- a/test/lit/Dialect/hip-loop-verifier.mlir
+++ b/test/lit/Dialect/hip-loop-verifier.mlir
@@ -1,0 +1,101 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Pin the `hip.loop` verifier contract that result_type[i] must equal
+// v_init[i].getType() (HipDialect.cpp::LoopOp::verify, HipOps.td:126-127).
+// This is also the contract that `LoopOp::inferReturnTypes`
+// (InferTypeOpInterface) is engineered to preserve when a future caller
+// constructs a `hip.loop` via the InferType-aware builder without
+// supplying explicit result types -- the InferType impl simply returns
+// v_init operand types per result, which by definition agrees with this
+// verifier check.
+//
+// Coverage:
+//   1. Positive: refined dynamic v_init (rank-3 with `?` dims) +
+//      matching result type verifies cleanly.
+//   2. Negative: under-refined result type (rank-0) against refined
+//      rank-3 dynamic v_init triggers the canonical
+//      "result type #N must match v_init type #N" error -- this is the
+//      signature seen on dynamic-shape vision-encoder ONNX exports
+//      where the importer leaves loop result types under-refined
+//      relative to the v_init operands. The fix lives in PR #265
+//      (LoopOutline.cpp body refinement + InferType builder migration);
+//      this LIT pins the verifier so the fix can't silently regress.
+//   3. Positive: multi-v_init (mixed static + dynamic) verifies cleanly.
+// ============================================================================
+
+// RUN: hip-mlir-opt --split-input-file --verify-diagnostics %s | FileCheck %s
+
+// -----
+
+// CHECK-LABEL: func.func @loop_dynamic_v_init_ok
+// CHECK:         hip.loop
+func.func private @loop_body_dyn(%ctx: !hip.context,
+                                 %iter: index,
+                                 %cond_in: i1,
+                                 %v_in: tensor<?x?x?xf16>) -> tensor<?x?x?xf16> {
+  return %v_in : tensor<?x?x?xf16>
+}
+func.func @loop_dynamic_v_init_ok(%ctx: !hip.context,
+                                  %M: index,
+                                  %cond: i1,
+                                  %v: tensor<?x?x?xf16>) -> tensor<?x?x?xf16> {
+  %r = hip.loop(%ctx, %M, %cond)
+                 iter_args(%v : tensor<?x?x?xf16>)
+                 -> (tensor<?x?x?xf16>)
+                 body @loop_body_dyn
+                 {num_loop_carried = 1 : i32, cond_is_passthrough}
+  return %r : tensor<?x?x?xf16>
+}
+
+// -----
+
+// Negative case -- canonical Qwen3.5-9B-vision-style mismatch: result
+// type is rank-0 (under-refined), v_init is rank-3 dynamic (refined).
+// `LoopOp::inferReturnTypes` would have produced rank-3 here; manually
+// supplying rank-0 is what the historical bug looked like before the
+// fix.
+func.func private @loop_body_mismatch(%ctx: !hip.context,
+                                      %iter: index,
+                                      %cond_in: i1,
+                                      %v_in: tensor<f16>) -> tensor<f16> {
+  return %v_in : tensor<f16>
+}
+func.func @loop_v_init_result_mismatch(%ctx: !hip.context,
+                                       %M: index,
+                                       %cond: i1,
+                                       %v: tensor<?x?x?xf16>) -> tensor<f16> {
+  // expected-error @below {{result type #0 ('tensor<f16>') must match v_init type #0 ('tensor<?x?x?xf16>')}}
+  %r = hip.loop(%ctx, %M, %cond)
+                 iter_args(%v : tensor<?x?x?xf16>)
+                 -> (tensor<f16>)
+                 body @loop_body_mismatch
+                 {num_loop_carried = 1 : i32, cond_is_passthrough}
+  return %r : tensor<f16>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @loop_multi_v_init_ok
+// CHECK:         hip.loop
+func.func private @loop_body_multi(%ctx: !hip.context,
+                                   %iter: index,
+                                   %cond_in: i1,
+                                   %a_in: tensor<16xf32>,
+                                   %b_in: tensor<?xf32>) -> (tensor<16xf32>, tensor<?xf32>) {
+  return %a_in, %b_in : tensor<16xf32>, tensor<?xf32>
+}
+func.func @loop_multi_v_init_ok(%ctx: !hip.context,
+                                %M: index,
+                                %cond: i1,
+                                %a: tensor<16xf32>,
+                                %b: tensor<?xf32>) -> (tensor<16xf32>, tensor<?xf32>) {
+  %r:2 = hip.loop(%ctx, %M, %cond)
+                   iter_args(%a, %b : tensor<16xf32>, tensor<?xf32>)
+                   -> (tensor<16xf32>, tensor<?xf32>)
+                   body @loop_body_multi
+                   {num_loop_carried = 2 : i32, cond_is_passthrough}
+  return %r#0, %r#1 : tensor<16xf32>, tensor<?xf32>
+}


### PR DESCRIPTION
<!--
PR #261 description (final). Pipe via:
  gh pr edit 261 --body-file .cursor/note/pr261-description.md
-->

This PR adds `InferTypeOpInterface::inferReturnTypes` to `Hip_LoopOp`, returning one `RankedTensorType` per `v_init` operand. The `hip.loop` verifier requires `result_type[i] == v_init[i].getType()`, and this lets future callers construct `hip.loop` ops verifier-clean by construction. Stacks on top of #260.

**Example MLIR that triggers the verifier today:**

```mlir
func.func @loop_v_init_result_mismatch(%ctx: !hip.context,
                                       %M: index,
                                       %cond: i1,
                                       %v: tensor<?x?x?xf16>) -> tensor<f16> {
  // error: 'hip.loop' op result type #0 ('tensor<f16>') must match
  //        v_init type #0 ('tensor<?x?x?xf16>')
  %r = hip.loop(%ctx, %M, %cond)
                 iter_args(%v : tensor<?x?x?xf16>)
                 -> (tensor<f16>)
                 body @loop_body_mismatch
                 {num_loop_carried = 1 : i32, cond_is_passthrough}
  return %r : tensor<f16>
}
```

The dynamic-shape vision-encoder ONNX exports I have been working with hit this — the importer leaves rank-0 placeholders while `v_init` is `tensor<?x?x?xf16>`, and the onnx-loop outliner forwards those under-refined types straight into the `hip.loop` builder.

**The fix:**

* Declare `InferTypeOpInterface` on `Hip_LoopOp` and implement `LoopOp::inferReturnTypes` returning one `RankedTensorType` per `v_init` operand. Memref-mode `v_init` (post-bufferization) produces 0 result types.
* Existing callers that still pass explicit result types are unaffected — the interface is purely additive.
* New LIT pins the verifier rule the impl is engineered to preserve.

P.S. Migrating `OnnxLoopOutlinePass` to the InferType-aware builder is the natural fix for the verifier abort above, but it is coupled work — the outliner has to refine the body func's arg / yield / op types from `v_init` *and* re-run shape inference inside the body so cloned ops verify against the now-refined entry-block args. That coupled change ships in a follow-up PR.
