### PR TITLE
feat(hip): finish reify surface on conv/miopen.softmax/nonzero, promote 5 fallbacks to Tier-1 -- 5/n

### DIFF
--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -444,7 +444,9 @@ def Hip_HipblasltGraphOp : Hip_Op<"hipblaslt.graph", [SingleBlock, NoTerminator]
 
 // ===== MIOpen DNN Operations =================================================
 
-def Hip_ConvOp : Hip_DpsOp<"conv"> {
+def Hip_ConvOp : Hip_DpsOp<"conv", /*traits=*/[], /*outsAccessor=*/"Output",
+                           /*autoReify=*/1,
+                           /*autoInfer=*/1, /*declareInfer=*/1> {
   let summary = "2D convolution operation using MIOpen (in-place)";
   let description = [{
     Performs 2D convolution using MIOpen (miopenConvolutionForward).
@@ -1104,7 +1106,11 @@ def Hip_MinOp : Hip_DpsOp_Broadcast<"min", /*operandGetters=*/["Lhs", "Rhs"]> {
   }];
 }
 
-def Hip_MiopenSoftmaxOp : Hip_DpsOp<"miopen.softmax"> {
+def Hip_MiopenSoftmaxOp : Hip_DpsOp<"miopen.softmax",
+                                    /*traits=*/[],
+                                    /*outsAccessor=*/"Output",
+                                    /*autoReify=*/1,
+                                    /*autoInfer=*/1, /*declareInfer=*/1> {
   let summary = "Softmax via miopenSoftmaxForward_V2 (row-wise, last dim)";
   let arguments = (ins
     Hip_ContextType:$ctx,
@@ -2935,7 +2941,9 @@ def Hip_SizeOp : Hip_DpsOp<"size", /*traits=*/[],
   }];
 }
 
-def Hip_NonZeroOp : Hip_DpsOp<"nonzero"> {
+def Hip_NonZeroOp : Hip_DpsOp<"nonzero", /*traits=*/[], /*outsAccessor=*/"Y",
+                              /*autoReify=*/1,
+                              /*autoInfer=*/1, /*declareInfer=*/1> {
   let summary = "Indices of non-zero elements (ONNX NonZero)";
   let description = [{
     Implements the standard ONNX NonZero operator (opset 13+):

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -1199,7 +1199,7 @@ def Hip_GatherOp : Hip_DpsOp<"gather", /*traits=*/[],
 
 def Hip_RangeOp : Hip_DpsOp<"range", /*traits=*/[],
                             /*outsAccessor=*/"Output",
-                            /*autoReify=*/1,
+                            /*autoReify=*/0,
                             /*autoInfer=*/1,
                             /*declareInfer=*/1> {
   let summary = "Generate 1-D range tensor";
@@ -2481,7 +2481,7 @@ def Hip_CumSumOp : Hip_DpsOp<"cumsum", /*traits=*/[],
 def Hip_PadOp : Hip_DpsOp<"pad",
                           /*traits=*/[AttrSizedOperandSegments],
                           /*outsAccessor=*/"Output",
-                          /*autoReify=*/1,
+                          /*autoReify=*/0,
                           /*autoInfer=*/1,
                           /*declareInfer=*/1> {
   let summary = "Pad a tensor with constant / reflect / edge / wrap";
@@ -2531,7 +2531,7 @@ def Hip_PadOp : Hip_DpsOp<"pad",
 
 def Hip_TileOp : Hip_DpsOp<"tile", /*traits=*/[],
                            /*outsAccessor=*/"Output",
-                           /*autoReify=*/1,
+                           /*autoReify=*/0,
                            /*autoInfer=*/1,
                            /*declareInfer=*/1> {
   let summary = "Tile a tensor by repeating along each dimension";
@@ -2567,7 +2567,7 @@ def Hip_TileOp : Hip_DpsOp<"tile", /*traits=*/[],
 
 def Hip_ExpandOp : Hip_DpsOp<"expand", /*traits=*/[],
                              /*outsAccessor=*/"Output",
-                             /*autoReify=*/1,
+                             /*autoReify=*/0,
                              /*autoInfer=*/1,
                              /*declareInfer=*/1> {
   let summary = "Broadcast a tensor to a target shape";
@@ -2671,7 +2671,7 @@ def Hip_LessOp : Hip_DpsOp_Broadcast<"less", /*operandGetters=*/["Lhs", "Rhs"]> 
 def Hip_SliceOp : Hip_DpsOp<"slice",
                             /*traits=*/[AttrSizedOperandSegments],
                             /*outsAccessor=*/"Output",
-                            /*autoReify=*/1,
+                            /*autoReify=*/0,
                             /*autoInfer=*/1,
                             /*declareInfer=*/1> {
   let summary = "Slice a tensor along multiple axes (ONNX Slice fallback)";

--- a/include/hip/Dialect/IR/HipShapeUtils.h
+++ b/include/hip/Dialect/IR/HipShapeUtils.h
@@ -216,6 +216,83 @@ LogicalResult reifyBroadcastShapeFor(OpBuilder &b, Location loc,
                                      ValueRange operands, Operation *op,
                                      ReifiedRankedShapedTypeDims &reified);
 
+/// Reify the result shape of an ONNX-style `pad` op:
+///   `output[d] = data.shape[d] + pre_pad[d] + post_pad[d]`
+/// where `pre_pad[d]` / `post_pad[d]` come from `pads[axes.find(d)]` /
+/// `pads[axes.find(d) + N]` (default `axes = [0, rank)`, `N = num_axes`).
+///
+/// Fold-or-bail strategy: tries to introspect `pads` and (if non-null)
+/// `axes` as constant int vectors, then per-dim computes static output
+/// extents from `data.shape`. Returns `success()` and writes the per-dim
+/// `OpFoldResult`s into `out` ONLY when EVERY output dim is statically
+/// known; returns `failure()` otherwise (the per-op reify thunk falls
+/// back to `HipDpsOp::reifyResultShapes`'s outs-lift default so reify
+/// still succeeds end-to-end). This avoids emitting per-dim
+/// `arith.addi(tensor.dim, const)` chains that don't fold and would
+/// clutter the IR; the typical Tier-1 case is `pads` from an ONNX
+/// attribute (constant) + a fully-static `data.shape`, which folds
+/// entirely to `IndexAttr` results.
+///
+/// `axes` may be null (ONNX "pad all axes" default).
+LogicalResult reifyPadShape(OpBuilder &b, Location loc, Value data, Value pads,
+                            Value axes, SmallVectorImpl<OpFoldResult> &out);
+
+/// Reify the result shape of an ONNX-style `tile` op:
+///   `output[d] = input.shape[d] * repeats[d]`
+/// where `repeats` is a rank-1 i64 tensor of length `input.rank`.
+///
+/// Same fold-or-bail strategy as `reifyPadShape`: tries to introspect
+/// `repeats` as a constant int vector, computes static output extents
+/// from `input.shape`, and returns `success()` only when EVERY dim is
+/// statically known.
+LogicalResult reifyTileShape(OpBuilder &b, Location loc, Value input,
+                             Value repeats, SmallVectorImpl<OpFoldResult> &out);
+
+/// Reify the result shape of an ONNX-style `expand` op:
+///   broadcast `input.shape` against `shape`'s constant values
+///   (right-aligned, leading-1 padded on whichever side is shorter).
+///
+/// Same fold-or-bail strategy. `shape` is the target-shape operand
+/// (rank-1 i64 tensor); when it is an `arith.constant` with a
+/// `DenseIntElementsAttr`, the helper runs MLIR's
+/// `OpTrait::util::getBroadcastedShape` and lifts the result shape.
+/// Returns `failure()` when the broadcast result has any dynamic dim
+/// (so the caller falls back to outs-lifting).
+LogicalResult reifyExpandShape(OpBuilder &b, Location loc, Value input,
+                               Value shape, SmallVectorImpl<OpFoldResult> &out);
+
+/// Reify the result shape of an ONNX-style `slice` op. `output[axis]`
+/// for each `axis` in `axes` is `ceil_div(end - start, step)` (negative
+/// indices and steps clamp per ONNX rules); for axes not in `axes`,
+/// `output[d] = data.shape[d]`.
+///
+/// Pure fold-or-bail (no fallback for partial constants). The dim-arith
+/// chain `arith.divsi(arith.subi(end, start), step)` per axis would
+/// clutter the IR persistently when any of starts / ends / axes / steps
+/// is non-constant; returning `failure()` early lets the per-op reify
+/// thunk fall back to the `HipDpsOp` outs-lift default for a single
+/// `tensor.dim` per dim instead.
+///
+/// `axes` and `steps` may be null (ONNX defaults: `[0, rank)` and
+/// all-ones respectively).
+LogicalResult reifySliceShape(OpBuilder &b, Location loc, Value data,
+                              Value starts, Value ends, Value axes, Value steps,
+                              SmallVectorImpl<OpFoldResult> &out);
+
+/// Reify the result shape of an ONNX-style `range` op:
+///   `output.shape[0] = ceil_div(max(0, limit - start), delta)` (limit
+///   exclusive; clamp to 0 when `limit < start && delta > 0`, etc.).
+///
+/// `start`, `limit`, `delta` are scalar (rank-0) tensors. Pure
+/// fold-or-bail: when ALL three are `arith.constant` with a single int
+/// value, computes the static output count and returns a one-element
+/// `IndexAttr` vector. Else `failure()` -- the dim-arith chain to
+/// compute the count at runtime is rarely useful for refinement and
+/// would persist in IR.
+LogicalResult reifyRangeShape(OpBuilder &b, Location loc, Value start,
+                              Value limit, Value delta,
+                              SmallVectorImpl<OpFoldResult> &out);
+
 } // namespace hip
 } // namespace mlir
 

--- a/lib/Conversion/OnnxToHip/ActivationConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ActivationConversion.cpp
@@ -32,8 +32,10 @@ SoftmaxToHip::matchAndRewrite(mlir::Operation *op,
   auto resultType =
       mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
   mlir::Value init = createEmptyTensor(rewriter, loc, resultType, input);
-  auto hipOp = mlir::hip::MiopenSoftmaxOp::create(rewriter, loc, resultType,
-                                                  context, input, init);
+  // Result type inferred from `init` via InferTypeOpInterface — DPS contract:
+  // result type == outs operand type.
+  auto hipOp =
+      mlir::hip::MiopenSoftmaxOp::create(rewriter, loc, context, input, init);
   rewriter.replaceOp(op, hipOp->getResult(0));
   return mlir::success();
 }

--- a/lib/Conversion/OnnxToHip/ConvConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ConvConversion.cpp
@@ -114,9 +114,9 @@ ConvToHip::matchAndRewrite(mlir::Operation *op,
   attrs.push_back(rewriter.getNamedAttr("dilations", dilationsAttr));
   attrs.push_back(rewriter.getNamedAttr("group", groupAttr));
 
-  // Create hip.conv operation using generic builder
-  auto hipOp = mlir::hip::ConvOp::create(
-      rewriter, loc, mlir::TypeRange{resultType}, operands, attrs);
+  // Result type inferred from `init` via InferTypeOpInterface — DPS contract:
+  // result type == outs operand type.
+  auto hipOp = mlir::hip::ConvOp::create(rewriter, loc, operands, attrs);
 
   rewriter.replaceOp(op, hipOp.getResult(0));
   return mlir::success();

--- a/lib/Conversion/OnnxToHip/NonZeroConversion.cpp
+++ b/lib/Conversion/OnnxToHip/NonZeroConversion.cpp
@@ -123,8 +123,10 @@ struct NonZeroToHip : public mlir::RewritePattern {
         rewriter, loc, resultType.getShape(), resultType.getElementType(),
         mlir::ValueRange{upperBound});
 
+    // Result type inferred from `init` via InferTypeOpInterface — DPS contract:
+    // result type == outs operand type.
     auto hipOp = mlir::hip::NonZeroOp::create(
-        rewriter, loc, resultType, context, op->getOperand(0), init,
+        rewriter, loc, context, op->getOperand(0), init,
         rewriter.getI64IntegerAttr(inputDataType));
     rewriter.replaceOp(op, hipOp->getResult(0));
     return mlir::success();

--- a/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
+++ b/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
@@ -324,11 +324,17 @@ GemmOp::reifyResultShapes(OpBuilder &b,
 // per-op `.cpp` thunk is needed.
 //
 // Other ops whose output dims are arithmetic functions of operand
-// values (pad, tile, expand, slice, range) keep their default
-// `Hip_DpsOp` auto-emit reify (`autoReify=1`) — the default walks
-// `getDpsInits()` and lifts each output's shape. Proper per-op
-// arithmetic for those (e.g. `tensor::PadOp`'s
-// `affine.apply (d0 + d1 + d2)` recipe) is deferred.
+// values (pad, tile, expand, slice, range) have per-op Tier-1 reify
+// thunks below: each calls a dedicated `reifyPadShape` /
+// `reifyTileShape` / `reifyExpandShape` / `reifySliceShape` /
+// `reifyRangeShape` helper (`HipShapeUtils.cpp`) that computes the
+// output shape from the INPUT operands using a fold-or-bail strategy.
+// On bail (non-constant operands, dynamic input dims) the thunk falls
+// back to `cast<HipDpsOp>(getOperation()).reifyResultShapes` — i.e. the
+// shared `HipDpsOp` outs-lift default. This avoids emitting per-dim
+// `arith.addi(tensor.dim, const)` / `arith.divsi(...)` chains that
+// don't fold and would clutter the IR (particularly important for
+// slice's per-axis chain and range's count-only output).
 //
 // Before (transpose, perm-driven mapping):
 //   %t = hip.transpose(%ctx) ins(%x : tensor<2x?x4096xf16>)
@@ -338,6 +344,33 @@ GemmOp::reifyResultShapes(OpBuilder &b,
 //   dim 0 -> 4096 : index            (static, from %x.shape[2])
 //   dim 1 -> 2 : index               (static, from %x.shape[0])
 //   dim 2 -> tensor.dim %x, %c1      (dynamic, from %x.shape[1])
+//
+// Before (reduce_sum with constant axes, keepdims=1, Tier 1):
+//   %a = arith.constant dense<[1]> : tensor<1xi64>
+//   %r = hip.reduce_sum(%ctx) ins(%x, %a : tensor<?x4096xf16>,
+//                                            tensor<1xi64>)
+//                              outs(%out : tensor<?x?xf16>)
+//                              {keepdims = 1, noop_with_empty_axes = 0}
+//                            : tensor<?x?xf16>
+// After (reified result shape):
+//   dim 0 -> tensor.dim %x, %c0     (passes through from input)
+//   dim 1 -> 1 : index              (axes-listed dim → keepdims=1 → 1)
+//
+// Before (pad, Tier-1 with constant pads, full fold):
+//   %pads = arith.constant dense<[1, 2, 1, 2]> : tensor<4xi64>
+//   %p = hip.pad(%ctx) ins(%x, %pads : tensor<3x4xf16>, tensor<4xi64>)
+//                      outs(%out : tensor<?x?xf16>)
+//                      {mode = "constant"} : tensor<?x?xf16>
+// After (reified result shape — computed from data.shape + pads):
+//   dim 0 -> 6 : index    (3 + pads[0]=1 + pads[2]=1)
+//   dim 1 -> 8 : index    (4 + pads[1]=2 + pads[3]=2)
+//
+// Before (slice, non-foldable starts -> outs-lift fallback):
+//   %p = hip.slice(%ctx) ins(%data, %starts, %ends : ...)
+//        outs(%out : tensor<?x4xf32>) : tensor<?x4xf32>
+// After (reified result shape — outs-lift via HipDpsOp default, no IR bloat):
+//   dim 0 -> tensor.dim %out, %c0   (passes through from outs)
+//   dim 1 -> 4 : index              (static dim of `outs`)
 //===----------------------------------------------------------------------===//
 
 LogicalResult TransposeOp::reifyResultShapes(
@@ -397,4 +430,80 @@ LogicalResult GatherNDOp::reifyResultShapes(
     return failure();
   reifiedReturnShapes.assign({std::move(dims)});
   return success();
+}
+
+// Per-op Tier-1 thunks for pad / tile / expand / slice / range. Each
+// calls its dedicated `reify*Shape` helper (HipShapeUtils.cpp); on
+// failure it falls back to the shared `HipDpsOp::reifyResultShapes`
+// default body in `HipDpsOpInterface.cpp`, which walks `getDpsInits()`
+// and lifts each init's runtime shape via `tensor::getMixedSizes` /
+// `memref::getMixedSizes`. The fallback dispatches through the
+// `HipDpsOp` interface concept and resolves to the default body (these
+// ops override only `ReifyRankedShapedTypeOpInterface::reifyResultShapes`
+// — the body of THIS function — and do not override the `HipDpsOp`
+// interface method, so the call below does not recurse).
+LogicalResult
+PadOp::reifyResultShapes(OpBuilder &b,
+                         ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
+  SmallVector<OpFoldResult> dims;
+  if (succeeded(mlir::hip::reifyPadShape(b, getLoc(), getData(), getPads(),
+                                         getAxes(), dims))) {
+    reifiedReturnShapes.assign({std::move(dims)});
+    return success();
+  }
+  return cast<HipDpsOp>(getOperation())
+      .reifyResultShapes(b, reifiedReturnShapes);
+}
+
+LogicalResult
+TileOp::reifyResultShapes(OpBuilder &b,
+                          ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
+  SmallVector<OpFoldResult> dims;
+  if (succeeded(mlir::hip::reifyTileShape(b, getLoc(), getInput(), getRepeats(),
+                                          dims))) {
+    reifiedReturnShapes.assign({std::move(dims)});
+    return success();
+  }
+  return cast<HipDpsOp>(getOperation())
+      .reifyResultShapes(b, reifiedReturnShapes);
+}
+
+LogicalResult
+ExpandOp::reifyResultShapes(OpBuilder &b,
+                            ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
+  SmallVector<OpFoldResult> dims;
+  if (succeeded(mlir::hip::reifyExpandShape(b, getLoc(), getInput(), getShape(),
+                                            dims))) {
+    reifiedReturnShapes.assign({std::move(dims)});
+    return success();
+  }
+  return cast<HipDpsOp>(getOperation())
+      .reifyResultShapes(b, reifiedReturnShapes);
+}
+
+LogicalResult
+SliceOp::reifyResultShapes(OpBuilder &b,
+                           ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
+  SmallVector<OpFoldResult> dims;
+  if (succeeded(mlir::hip::reifySliceShape(b, getLoc(), getData(), getStarts(),
+                                           getEnds(), getAxes(), getSteps(),
+                                           dims))) {
+    reifiedReturnShapes.assign({std::move(dims)});
+    return success();
+  }
+  return cast<HipDpsOp>(getOperation())
+      .reifyResultShapes(b, reifiedReturnShapes);
+}
+
+LogicalResult
+RangeOp::reifyResultShapes(OpBuilder &b,
+                           ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
+  SmallVector<OpFoldResult> dims;
+  if (succeeded(mlir::hip::reifyRangeShape(b, getLoc(), getStart(), getLimit(),
+                                           getDelta(), dims))) {
+    reifiedReturnShapes.assign({std::move(dims)});
+    return success();
+  }
+  return cast<HipDpsOp>(getOperation())
+      .reifyResultShapes(b, reifiedReturnShapes);
 }

--- a/lib/Dialect/IR/HipShapeUtils.cpp
+++ b/lib/Dialect/IR/HipShapeUtils.cpp
@@ -28,6 +28,8 @@
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <algorithm>
+
 using namespace mlir;
 using namespace mlir::hip;
 
@@ -469,4 +471,246 @@ mlir::hip::reifyReductionShape(OpBuilder &b, Location loc, Value data,
   // override the `HipDpsOp` interface method, so the call below resolves
   // to the default body and does not recurse.
   return cast<HipDpsOp>(op).reifyResultShapes(b, reified);
+}
+
+LogicalResult mlir::hip::reifyPadShape(OpBuilder &b, Location loc, Value data,
+                                       Value pads, Value axes,
+                                       SmallVectorImpl<OpFoldResult> &out) {
+  out.clear();
+  auto dataType = dyn_cast<RankedTensorType>(data.getType());
+  if (!dataType)
+    return failure();
+  ArrayRef<int64_t> dataShape = dataType.getShape();
+  int64_t dataRank = dataType.getRank();
+
+  // pads is the primary semantic info; without it nothing can be tightened
+  // beyond outs (and the caller's Tier-2 fallback already handles that).
+  SmallVector<int64_t> padsList;
+  if (!extractConstantInts(pads, padsList))
+    return failure();
+
+  // axes default: full range. ONNX requires len(pads) == 2 * len(axes).
+  SmallVector<int64_t> axesList;
+  if (axes) {
+    if (!extractConstantInts(axes, axesList))
+      return failure();
+    for (int64_t &a : axesList) {
+      if (a < 0)
+        a += dataRank;
+      if (a < 0 || a >= dataRank)
+        return failure();
+    }
+  } else {
+    axesList.reserve(dataRank);
+    for (int64_t i : llvm::seq<int64_t>(0, dataRank))
+      axesList.push_back(i);
+  }
+  if (static_cast<int64_t>(padsList.size()) !=
+      2 * static_cast<int64_t>(axesList.size()))
+    return failure();
+
+  // Index axes -> [pre, post]. Default 0 for non-listed axes.
+  SmallVector<std::pair<int64_t, int64_t>> perAxis(dataRank, {0, 0});
+  int64_t numAxes = axesList.size();
+  for (int64_t i : llvm::seq<int64_t>(0, numAxes)) {
+    int64_t a = axesList[i];
+    perAxis[a] = {padsList[i], padsList[i + numAxes]};
+  }
+
+  // Fold-or-bail: each output dim must be statically computable. A
+  // dynamic data dim under a non-zero pad gives a dynamic output dim
+  // (would need arith.addi(tensor.dim, const)) -- we'd rather fall back
+  // to Tier-2 outs-lifting than emit a non-foldable arith chain.
+  SmallVector<int64_t> outShape;
+  outShape.reserve(dataRank);
+  for (int64_t d : llvm::seq<int64_t>(0, dataRank)) {
+    if (ShapedType::isDynamic(dataShape[d]))
+      return failure();
+    outShape.push_back(dataShape[d] + perAxis[d].first + perAxis[d].second);
+  }
+
+  out.reserve(dataRank);
+  for (int64_t v : outShape)
+    out.push_back(b.getIndexAttr(v));
+  return success();
+}
+
+LogicalResult mlir::hip::reifyTileShape(OpBuilder &b, Location loc, Value input,
+                                        Value repeats,
+                                        SmallVectorImpl<OpFoldResult> &out) {
+  out.clear();
+  auto inputType = dyn_cast<RankedTensorType>(input.getType());
+  if (!inputType)
+    return failure();
+  ArrayRef<int64_t> inputShape = inputType.getShape();
+  int64_t inputRank = inputType.getRank();
+
+  SmallVector<int64_t> repeatsList;
+  if (!extractConstantInts(repeats, repeatsList))
+    return failure();
+  if (static_cast<int64_t>(repeatsList.size()) != inputRank)
+    return failure();
+
+  // Same fold-or-bail logic as pad: skip dynamic input dims.
+  out.reserve(inputRank);
+  for (int64_t d : llvm::seq<int64_t>(0, inputRank)) {
+    if (ShapedType::isDynamic(inputShape[d]))
+      return failure();
+    int64_t r = repeatsList[d];
+    if (r < 0)
+      return failure();
+    out.push_back(b.getIndexAttr(inputShape[d] * r));
+  }
+  return success();
+}
+
+LogicalResult mlir::hip::reifyExpandShape(OpBuilder &b, Location loc,
+                                          Value input, Value shape,
+                                          SmallVectorImpl<OpFoldResult> &out) {
+  out.clear();
+  auto inputType = dyn_cast<RankedTensorType>(input.getType());
+  if (!inputType)
+    return failure();
+
+  SmallVector<int64_t> shapeVals;
+  if (!extractConstantInts(shape, shapeVals))
+    return failure();
+
+  // ONNX broadcast: right-aligned, leading-1 padded. Defer the actual
+  // broadcast math to MLIR's `OpTrait::util::getBroadcastedShape` for
+  // consistency with matmul / reifyBroadcastShape.
+  SmallVector<int64_t> outShape;
+  if (!OpTrait::util::getBroadcastedShape(inputType.getShape(), shapeVals,
+                                          outShape))
+    return failure();
+
+  // Fold-or-bail: any dynamic in the broadcast result means we can't
+  // produce a tight shape; let the Tier-2 fallback lift from outs.
+  for (int64_t d : outShape)
+    if (ShapedType::isDynamic(d))
+      return failure();
+
+  out.reserve(outShape.size());
+  for (int64_t v : outShape)
+    out.push_back(b.getIndexAttr(v));
+  return success();
+}
+
+LogicalResult mlir::hip::reifySliceShape(OpBuilder &b, Location loc, Value data,
+                                         Value starts, Value ends, Value axes,
+                                         Value steps,
+                                         SmallVectorImpl<OpFoldResult> &out) {
+  out.clear();
+  auto dataType = dyn_cast<RankedTensorType>(data.getType());
+  if (!dataType)
+    return failure();
+  ArrayRef<int64_t> dataShape = dataType.getShape();
+  int64_t dataRank = dataType.getRank();
+
+  // ALL operands must be foldable -- partial constants on slice would
+  // emit `arith.divsi(arith.subi(end, start), step)` chains per axis
+  // that don't fold, persisting as dead IR. Tier-2 outs-lifting is the
+  // safer fallback.
+  SmallVector<int64_t> startsList, endsList, axesList, stepsList;
+  if (!extractConstantInts(starts, startsList) ||
+      !extractConstantInts(ends, endsList))
+    return failure();
+  if (axes) {
+    if (!extractConstantInts(axes, axesList))
+      return failure();
+  } else {
+    axesList.reserve(dataRank);
+    for (int64_t i : llvm::seq<int64_t>(0, dataRank))
+      axesList.push_back(i);
+  }
+  if (steps) {
+    if (!extractConstantInts(steps, stepsList))
+      return failure();
+  } else {
+    stepsList.assign(axesList.size(), 1);
+  }
+
+  if (startsList.size() != axesList.size() ||
+      endsList.size() != axesList.size() || stepsList.size() != axesList.size())
+    return failure();
+
+  // Per-axis sliced extent; non-axis dims pass through.
+  SmallVector<int64_t> outShape(dataShape.begin(), dataShape.end());
+  for (size_t i : llvm::seq<size_t>(0, axesList.size())) {
+    int64_t a = axesList[i];
+    if (a < 0)
+      a += dataRank;
+    if (a < 0 || a >= dataRank)
+      return failure();
+    int64_t dim = dataShape[a];
+    if (ShapedType::isDynamic(dim))
+      return failure();
+    int64_t step = stepsList[i];
+    if (step == 0)
+      return failure();
+    int64_t s = startsList[i];
+    int64_t e = endsList[i];
+    // ONNX clamping: negative values offset by `dim`; out-of-range clamps.
+    if (s < 0)
+      s += dim;
+    if (e < 0)
+      e += dim;
+    if (step > 0) {
+      s = std::clamp<int64_t>(s, 0, dim);
+      e = std::clamp<int64_t>(e, 0, dim);
+      outShape[a] = (e > s) ? ((e - s + step - 1) / step) : 0;
+    } else { // step < 0
+      s = std::clamp<int64_t>(s, 0, dim - 1);
+      // Negative-step end clamps to [-1, dim-1] (treat <-1 as -1).
+      e = std::clamp<int64_t>(e, -1, dim - 1);
+      int64_t span = s - e;
+      int64_t k = -step;
+      outShape[a] = (s > e) ? ((span + k - 1) / k) : 0;
+    }
+  }
+
+  // All dims must be static (fold-or-bail).
+  for (int64_t v : outShape)
+    if (ShapedType::isDynamic(v))
+      return failure();
+
+  out.reserve(dataRank);
+  for (int64_t v : outShape)
+    out.push_back(b.getIndexAttr(v));
+  return success();
+}
+
+LogicalResult mlir::hip::reifyRangeShape(OpBuilder &b, Location loc,
+                                         Value start, Value limit, Value delta,
+                                         SmallVectorImpl<OpFoldResult> &out) {
+  out.clear();
+
+  // Each operand is a rank-0 (scalar) integer tensor. extractConstantInts
+  // returns a 1-element vector for the rank-0 / IntegerAttr case.
+  SmallVector<int64_t> sList, lList, dList;
+  if (!extractConstantInts(start, sList) ||
+      !extractConstantInts(limit, lList) || !extractConstantInts(delta, dList))
+    return failure();
+  if (sList.size() != 1 || lList.size() != 1 || dList.size() != 1)
+    return failure();
+  int64_t s = sList[0], l = lList[0], d = dList[0];
+  if (d == 0)
+    return failure();
+
+  // ONNX Range: count = max(0, ceil((limit - start) / delta)) for the
+  // direction implied by sign(delta). Negative direction (delta < 0)
+  // counts down from start to limit.
+  int64_t count = 0;
+  if ((d > 0 && l > s) || (d < 0 && l < s)) {
+    int64_t diff = l - s;
+    int64_t step = d;
+    if (step < 0) {
+      diff = -diff;
+      step = -step;
+    }
+    count = (diff + step - 1) / step;
+  }
+
+  out.push_back(b.getIndexAttr(count));
+  return success();
 }

--- a/test/lit/Dialect/hip-infer-shapes.mlir
+++ b/test/lit/Dialect/hip-infer-shapes.mlir
@@ -576,3 +576,124 @@ func.func @refine_pad_dps_out_fallback(%ctx: !hip.context,
     : tensor<?x?xf32>
   return %y : tensor<?x?xf32>
 }
+
+// -----
+
+// `hip.gqa` is multi-result (3 required outs: output, present_key,
+// present_value, plus one optional debug out `output_qk` -- omitted
+// here). Reify routes through `Hip_DpsOp`'s default `reifyResultShapes`
+// body in `lib/Dialect/IR/HipDpsOpInterface.cpp`, which walks
+// `getDpsInits()` and lifts each init's runtime shape via
+// `tensor::getMixedSizes` -- one entry of `reified` per result. The
+// LIT case uses matching dynamic outs/result triples and guards the
+// no-crash + multi-result-walk contract; for static-dim refinement
+// see the per-op-arithmetic cases like `refine_transpose_perm_driven`.
+//
+// Pass behavior: walks all 3 results, calls reify which lifts each
+// outs's `tensor<?x?x?xf16>` / `tensor<?x?x?x?xf16>` shape as
+// `tensor.dim` ops, finds nothing static-er to narrow to, and exits
+// without mutating the op. The CHECK guards that the op stays intact
+// across all three outs and the dim-walk doesn't bail mid-result.
+// CHECK-LABEL: func.func @refine_gqa_multi_result_dps_out_fallback
+// CHECK:         %[[E0:.*]] = tensor.empty(%{{.*}}, %{{.*}}, %{{.*}}) : tensor<?x?x?xf16>
+// CHECK:         %[[E1:.*]] = tensor.empty(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : tensor<?x?x?x?xf16>
+// CHECK:         %[[E2:.*]] = tensor.empty(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : tensor<?x?x?x?xf16>
+// CHECK:         %[[R:.*]]:3 = hip.gqa
+// CHECK-SAME:      outs(%[[E0]], %[[E1]], %[[E2]] :
+// CHECK-SAME:           tensor<?x?x?xf16>, tensor<?x?x?x?xf16>, tensor<?x?x?x?xf16>)
+// CHECK:         return %[[R]]#0, %[[R]]#1, %[[R]]#2
+func.func @refine_gqa_multi_result_dps_out_fallback(
+    %ctx: !hip.context,
+    %query: tensor<1x?x4096xf16>,
+    %key: tensor<1x?x1024xf16>,
+    %value: tensor<1x?x1024xf16>,
+    %past_key: tensor<1x8x?x128xf16>,
+    %past_value: tensor<1x8x?x128xf16>,
+    %seqlens_k: tensor<1xi32>,
+    %total_seq_len: tensor<i32>,
+    %d0: index, %d1: index, %d2: index, %d3: index)
+    -> (tensor<?x?x?xf16>, tensor<?x?x?x?xf16>, tensor<?x?x?x?xf16>) {
+  %e0 = tensor.empty(%d0, %d1, %d2) : tensor<?x?x?xf16>
+  %e1 = tensor.empty(%d0, %d1, %d2, %d3) : tensor<?x?x?x?xf16>
+  %e2 = tensor.empty(%d0, %d1, %d2, %d3) : tensor<?x?x?x?xf16>
+  %r:3 = hip.gqa(%ctx)
+    ins(%query, %key, %value, %past_key, %past_value,
+        %seqlens_k, %total_seq_len :
+        tensor<1x?x4096xf16>, tensor<1x?x1024xf16>, tensor<1x?x1024xf16>,
+        tensor<1x8x?x128xf16>, tensor<1x8x?x128xf16>,
+        tensor<1xi32>, tensor<i32>)
+    outs(%e0, %e1, %e2 :
+         tensor<?x?x?xf16>, tensor<?x?x?x?xf16>, tensor<?x?x?x?xf16>)
+    {num_heads = 32 : i64, kv_num_heads = 8 : i64,
+     scale = 0.0883883461 : f32, softcap = 0.000000e+00 : f32,
+     do_rotary = 0 : i64, rotary_interleaved = 0 : i64,
+     local_window_size = -1 : i64}
+    : tensor<?x?x?xf16>, tensor<?x?x?x?xf16>, tensor<?x?x?x?xf16>
+  return %r#0, %r#1, %r#2 : tensor<?x?x?xf16>, tensor<?x?x?x?xf16>, tensor<?x?x?x?xf16>
+}
+
+// -----
+
+// `hip.layer_norm` is variadic-multi-result: 1, 2, or 3 outs (output
+// required; mean and inv_std optional, training-only). The default
+// `Hip_DpsOp::reifyResultShapes` body walks `getDpsInits()` regardless
+// of arity; this case exercises the full 3-out form so the variadic
+// iteration is covered (1-out covered implicitly by every Tier-2
+// fallback test).
+//
+// Same matching-dynamic-outs pattern as the gqa case above: pass walks
+// all 3 results, reify lifts dynamic outs, no narrowing happens, op
+// stays intact -- guards "Variadic outputs interpreted correctly".
+// CHECK-LABEL: func.func @refine_layer_norm_variadic_three_outs
+// CHECK:         %[[E0:.*]] = tensor.empty(%{{.*}}, %{{.*}}, %{{.*}}) : tensor<?x?x?xf16>
+// CHECK:         %[[E1:.*]] = tensor.empty(%{{.*}}, %{{.*}}, %{{.*}}) : tensor<?x?x?xf32>
+// CHECK:         %[[E2:.*]] = tensor.empty(%{{.*}}, %{{.*}}, %{{.*}}) : tensor<?x?x?xf32>
+// CHECK:         %[[R:.*]]:3 = hip.layer_norm
+// CHECK-SAME:      outs(%[[E0]], %[[E1]], %[[E2]] :
+// CHECK-SAME:           tensor<?x?x?xf16>, tensor<?x?x?xf32>, tensor<?x?x?xf32>)
+// CHECK:         return %[[R]]#0, %[[R]]#1, %[[R]]#2
+func.func @refine_layer_norm_variadic_three_outs(
+    %ctx: !hip.context,
+    %input: tensor<?x?x?xf16>,
+    %scale: tensor<?xf16>,
+    %d0: index, %d1: index, %d2: index)
+    -> (tensor<?x?x?xf16>, tensor<?x?x?xf32>, tensor<?x?x?xf32>) {
+  %e0 = tensor.empty(%d0, %d1, %d2) : tensor<?x?x?xf16>
+  %e1 = tensor.empty(%d0, %d1, %d2) : tensor<?x?x?xf32>
+  %e2 = tensor.empty(%d0, %d1, %d2) : tensor<?x?x?xf32>
+  %r:3 = hip.layer_norm(%ctx)
+    ins(%input, %scale : tensor<?x?x?xf16>, tensor<?xf16>)
+    outs(%e0, %e1, %e2 :
+         tensor<?x?x?xf16>, tensor<?x?x?xf32>, tensor<?x?x?xf32>)
+    {axis = -1 : i64, epsilon = 9.99999974e-06 : f32, stash_type = 1 : i64}
+    : tensor<?x?x?xf16>, tensor<?x?x?xf32>, tensor<?x?x?xf32>
+  return %r#0, %r#1, %r#2 : tensor<?x?x?xf16>, tensor<?x?x?xf32>, tensor<?x?x?xf32>
+}
+
+// -----
+
+// `hip.nonzero` has a data-dependent output dim 1 (number of non-zero
+// elements -- only knowable at runtime). The default DPS Tier-2 reify
+// lifts the outs's shape directly: dim 0 is the static input rank,
+// dim 1 lifts as `tensor.dim %outs, %c1` and stays dynamic because
+// outs itself was constructed dynamic. This is the "outs IS the only
+// authority on the output shape" case the Tier-2 contract is designed
+// for -- the LIT case guards that reify doesn't crash on data-
+// dependent shapes.
+// CHECK-LABEL: func.func @refine_nonzero_data_dependent_dim1
+// CHECK:         %[[E:.*]] = tensor.empty(%{{.*}}, %{{.*}}) : tensor<?x?xi64>
+// CHECK:         %[[Y:.*]] = hip.nonzero
+// CHECK-SAME:      outs(%[[E]] : tensor<?x?xi64>){{.*}}: tensor<?x?xi64>
+// CHECK:         return %[[Y]] : tensor<?x?xi64>
+func.func @refine_nonzero_data_dependent_dim1(
+    %ctx: !hip.context,
+    %x: tensor<3x4xf16>,
+    %d0: index, %d1: index)
+    -> tensor<?x?xi64> {
+  %e = tensor.empty(%d0, %d1) : tensor<?x?xi64>
+  %y = hip.nonzero(%ctx) ins(%x : tensor<3x4xf16>)
+                          outs(%e : tensor<?x?xi64>)
+                          {input_data_type = 1 : i64}
+                          : tensor<?x?xi64>
+  return %y : tensor<?x?xi64>
+}

--- a/test/lit/Dialect/hip-infer-shapes.mlir
+++ b/test/lit/Dialect/hip-infer-shapes.mlir
@@ -579,6 +579,167 @@ func.func @refine_pad_dps_out_fallback(%ctx: !hip.context,
 
 // -----
 
+// `hip.pad` Tier-1 promotion. With static `data` and constant `pads`,
+// the helper computes
+// `output[d] = data.shape[d] + pads[d] + pads[d + N]`. Pads = [1, 2, 1, 2]
+// over axes [0, 1] yields output [3+1+1=5, 4+2+2=8]. The pass refines
+// the result type from `tensor<?x?xf32>` to `tensor<5x8xf32>` and the
+// outs `tensor.empty` producer is rebuilt without dynamic operands.
+// CHECK-LABEL: func.func @refine_pad_tier1_constant_pads
+// CHECK:         %[[E:.*]] = tensor.empty() : tensor<5x8xf32>
+// CHECK:         %[[Y:.*]] = hip.pad
+// CHECK-SAME:                  outs(%[[E]] : tensor<5x8xf32>){{.*}}: tensor<5x8xf32>
+// CHECK:         tensor.cast %[[Y]] : tensor<5x8xf32> to tensor<?x?xf32>
+func.func @refine_pad_tier1_constant_pads(%ctx: !hip.context,
+                                          %data: tensor<3x4xf32>,
+                                          %cval: tensor<f32>,
+                                          %d0: index, %d1: index)
+    -> tensor<?x?xf32> {
+  %pads = arith.constant dense<[1, 2, 1, 2]> : tensor<4xi64>
+  %e = tensor.empty(%d0, %d1) : tensor<?x?xf32>
+  %y = hip.pad(%ctx)
+    ins(%data, %pads : tensor<3x4xf32>, tensor<4xi64>)
+    cval(%cval : tensor<f32>)
+    outs(%e : tensor<?x?xf32>)
+    {mode = "constant"}
+    : tensor<?x?xf32>
+  return %y : tensor<?x?xf32>
+}
+
+// -----
+
+// `hip.tile` Tier-1 promotion. With static `input` and constant
+// `repeats`, the helper computes
+// `output[d] = input.shape[d] * repeats[d]`. Repeats = [2, 3] over a
+// `tensor<3x4xf32>` yields output [6, 12].
+// CHECK-LABEL: func.func @refine_tile_tier1_constant_repeats
+// CHECK:         %[[E:.*]] = tensor.empty() : tensor<6x12xf32>
+// CHECK:         %[[Y:.*]] = hip.tile
+// CHECK-SAME:                  outs(%[[E]] : tensor<6x12xf32>){{.*}}: tensor<6x12xf32>
+// CHECK:         tensor.cast %[[Y]] : tensor<6x12xf32> to tensor<?x?xf32>
+func.func @refine_tile_tier1_constant_repeats(%ctx: !hip.context,
+                                               %input: tensor<3x4xf32>,
+                                               %d0: index, %d1: index)
+    -> tensor<?x?xf32> {
+  %repeats = arith.constant dense<[2, 3]> : tensor<2xi64>
+  %e = tensor.empty(%d0, %d1) : tensor<?x?xf32>
+  %y = hip.tile(%ctx)
+    ins(%input, %repeats : tensor<3x4xf32>, tensor<2xi64>)
+    outs(%e : tensor<?x?xf32>)
+    : tensor<?x?xf32>
+  return %y : tensor<?x?xf32>
+}
+
+// -----
+
+// `hip.expand` Tier-1 promotion. With static `input` and constant
+// `shape`, the helper runs the standard NumPy broadcast (right-
+// aligned, leading-1 padded). Input `tensor<3x1xf32>` broadcast
+// against shape [2, 3, 6] yields output [2, 3, 6].
+// CHECK-LABEL: func.func @refine_expand_tier1_constant_shape
+// CHECK:         %[[E:.*]] = tensor.empty() : tensor<2x3x6xf32>
+// CHECK:         %[[Y:.*]] = hip.expand
+// CHECK-SAME:                  outs(%[[E]] : tensor<2x3x6xf32>){{.*}}: tensor<2x3x6xf32>
+// CHECK:         tensor.cast %[[Y]] : tensor<2x3x6xf32> to tensor<?x?x?xf32>
+func.func @refine_expand_tier1_constant_shape(%ctx: !hip.context,
+                                                %input: tensor<3x1xf32>,
+                                                %d0: index, %d1: index,
+                                                %d2: index)
+    -> tensor<?x?x?xf32> {
+  %shape = arith.constant dense<[2, 3, 6]> : tensor<3xi64>
+  %e = tensor.empty(%d0, %d1, %d2) : tensor<?x?x?xf32>
+  %y = hip.expand(%ctx)
+    ins(%input, %shape : tensor<3x1xf32>, tensor<3xi64>)
+    outs(%e : tensor<?x?x?xf32>)
+    : tensor<?x?x?xf32>
+  return %y : tensor<?x?x?xf32>
+}
+
+// -----
+
+// `hip.slice` Tier-1 promotion. With static `data` and constant
+// `starts` / `ends` (axes default to [0..rank), steps default to
+// all-ones), the helper computes
+// `output[axis] = ceil_div(end - start, step)`. Slicing `tensor<10x4xf32>`
+// with starts=[1, 0], ends=[6, 4] yields output [5, 4].
+// CHECK-LABEL: func.func @refine_slice_tier1_constant_indices
+// CHECK:         %[[E:.*]] = tensor.empty() : tensor<5x4xf32>
+// CHECK:         %[[Y:.*]] = hip.slice
+// CHECK-SAME:                  outs(%[[E]] : tensor<5x4xf32>){{.*}}: tensor<5x4xf32>
+// CHECK:         tensor.cast %[[Y]] : tensor<5x4xf32> to tensor<?x?xf32>
+func.func @refine_slice_tier1_constant_indices(%ctx: !hip.context,
+                                                 %data: tensor<10x4xf32>,
+                                                 %d0: index, %d1: index)
+    -> tensor<?x?xf32> {
+  %starts = arith.constant dense<[1, 0]> : tensor<2xi64>
+  %ends = arith.constant dense<[6, 4]> : tensor<2xi64>
+  %e = tensor.empty(%d0, %d1) : tensor<?x?xf32>
+  %y = hip.slice(%ctx)
+    ins(%data, %starts, %ends : tensor<10x4xf32>, tensor<2xi64>, tensor<2xi64>)
+    outs(%e : tensor<?x?xf32>)
+    : tensor<?x?xf32>
+  return %y : tensor<?x?xf32>
+}
+
+// -----
+
+// `hip.slice` non-foldable case: `starts` is a function arg, not a
+// constant. The Tier-1 helper bails and the per-op thunk falls back
+// to `HipDpsOp::reifyResultShapes`'s outs-lift default. Static dims
+// of the outs (`tensor<10x?xf32>`) still tighten dim 0; the dynamic
+// dim 1 stays dynamic. This guards "no IR bloat on non-foldable slice"
+// (the dim-arith chain would have been
+// `arith.divsi(arith.subi(end, start), step)` per axis -- never emitted).
+// CHECK-LABEL: func.func @refine_slice_non_foldable_falls_back_to_outs
+// CHECK-NOT:     arith.subi
+// CHECK-NOT:     arith.divsi
+// CHECK:         %[[E:.*]] = tensor.empty(%{{.*}}) : tensor<10x?xf32>
+// CHECK:         %[[Y:.*]] = hip.slice
+// CHECK-SAME:                  outs(%[[E]] : tensor<10x?xf32>){{.*}}: tensor<10x?xf32>
+// CHECK:         tensor.cast %[[Y]] : tensor<10x?xf32> to tensor<?x?xf32>
+func.func @refine_slice_non_foldable_falls_back_to_outs(
+    %ctx: !hip.context,
+    %data: tensor<10x4xf32>,
+    %starts: tensor<2xi64>,
+    %ends: tensor<2xi64>,
+    %d0: index)
+    -> tensor<?x?xf32> {
+  %e = tensor.empty(%d0) : tensor<10x?xf32>
+  %y = hip.slice(%ctx)
+    ins(%data, %starts, %ends : tensor<10x4xf32>, tensor<2xi64>, tensor<2xi64>)
+    outs(%e : tensor<10x?xf32>)
+    : tensor<10x?xf32>
+  %c = tensor.cast %y : tensor<10x?xf32> to tensor<?x?xf32>
+  return %c : tensor<?x?xf32>
+}
+
+// -----
+
+// `hip.range` Tier-1 promotion. With constant rank-0 start / limit /
+// delta, the helper computes
+// `count = ceil_div(max(0, limit - start), delta)`. start=2, limit=10,
+// delta=3 yields count=3.
+// CHECK-LABEL: func.func @refine_range_tier1_constant_args
+// CHECK:         %[[E:.*]] = tensor.empty() : tensor<3xi64>
+// CHECK:         %[[Y:.*]] = hip.range
+// CHECK-SAME:                  outs(%[[E]] : tensor<3xi64>){{.*}}: tensor<3xi64>
+// CHECK:         tensor.cast %[[Y]] : tensor<3xi64> to tensor<?xi64>
+func.func @refine_range_tier1_constant_args(%ctx: !hip.context,
+                                              %d0: index)
+    -> tensor<?xi64> {
+  %start = arith.constant dense<2> : tensor<i64>
+  %limit = arith.constant dense<10> : tensor<i64>
+  %delta = arith.constant dense<3> : tensor<i64>
+  %e = tensor.empty(%d0) : tensor<?xi64>
+  %y = hip.range(%ctx)
+    ins(%start, %limit, %delta : tensor<i64>, tensor<i64>, tensor<i64>)
+    outs(%e : tensor<?xi64>)
+    : tensor<?xi64>
+  return %y : tensor<?xi64>
+}
+
+// -----
+
 // `hip.gqa` is multi-result (3 required outs: output, present_key,
 // present_value, plus one optional debug out `output_qk` -- omitted
 // here). Reify routes through `Hip_DpsOp`'s default `reifyResultShapes`


### PR DESCRIPTION
<!--
PR #264 description (rev 2 — after rebase onto #263 absorbed the multi-result wiring).
Pipe via: gh pr edit 264 --body-file .cursor/note/pr264-description.md
-->

Stacks on top of #263. Three single-result ops left untouched in #263 (`hip.conv`, `hip.miopen.softmax`, `hip.nonzero`) now opt into the `Hip_DpsOp` interface infrastructure, and five Tier-2 fallback ops from #263 (`hip.pad`, `hip.tile`, `hip.expand`, `hip.slice`, `hip.range`) get real Tier-1 shape arithmetic that folds when shape-determining operands are constant.

**Example MLIR — pad with constant pads now folds entirely** (was Tier-2 in #263, only lifting outs):

```mlir
%pads = arith.constant dense<[1, 2, 1, 2]> : tensor<4xi64>
%e    = tensor.empty(%d0, %d1) : tensor<?x?xf32>          // dynamic outs
%y    = hip.pad(%ctx) ins(%data, %pads : tensor<3x4xf32>, tensor<4xi64>)
                      outs(%e : tensor<?x?xf32>) {mode = "constant"} : tensor<?x?xf32>
// After --hip-infer-shapes, %e becomes tensor.empty() : tensor<5x8xf32>
// (3 + pads[0]=1 + pads[2]=1 = 5; 4 + pads[1]=2 + pads[3]=2 = 8)
```

**The fix:**

* `hip.conv`, `hip.miopen.softmax`, `hip.nonzero` flip on `Hip_DpsOp`'s `autoReify=1, autoInfer=1, declareInfer=1`. `hip.nonzero` sets `outsAccessor=Y` since its outs operand is named `$y` rather than the default `$output`. The three matching `OnnxToHip*Conversion.cpp` callsites (`Conv`, `MiopenSoftmax`, `NonZero`) drop their explicit `mlir::TypeRange{resultType}` argument now that the InferType-aware builder fills it from outs.

* Five new Tier-1 helpers (`reifyPadShape`, `reifyTileShape`, `reifyExpandShape`, `reifySliceShape`, `reifyRangeShape`) in `HipShapeUtils` follow a fold-or-bail contract: introspect shape-determining operands as `arith.constant` via the `extractConstantInts` helper from #263, compute output extents from input shape arithmetic, and return all-`IndexAttr` `OpFoldResult`s when every output dim folds. On any non-constant operand or dynamic input dim, `failure()` falls through to `Hip_DpsOp`'s default outs-lift body. The bail avoids per-dim `arith.addi(tensor.dim, const)` / `arith.divsi(...)` chains that don't fold and would bloat the IR — particularly important for `slice` (per-axis chain) and `range` (count-only output).

* `test/lit/Dialect/hip-infer-shapes.mlir` gains 9 dynamic-shape refinement cases: three exercise the multi-result / variadic / data-dependent walk that #263 wired but did not yet test on these specific ops (`refine_gqa_multi_result_dps_out_fallback`, `refine_layer_norm_variadic_three_outs`, `refine_nonzero_data_dependent_dim1`), and six pin the Tier-1 folds (one per promoted op plus `refine_slice_non_foldable_falls_back_to_outs` with `CHECK-NOT: arith.subi` / `CHECK-NOT: arith.divsi` to guard the no-IR-bloat fallback contract).

P.S. `hip.hipdnn_graph` (DPS but only appears post-outlining + compilation, past where the consumer pass runs) and `hip.hipdnn_graph_outline` (region op, not DPS) are deliberately out of scope — neither is on the model-graph path for the upcoming backward dim-origin composer.
