### PR TITLE
feat(cursor-skill): add model-compatibility agent skill 

### DIFF
--- a/.cursor/skills/model-compatibility/SKILL.md
+++ b/.cursor/skills/model-compatibility/SKILL.md
@@ -1,0 +1,134 @@
+<!--
+Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+Licensed under the MIT License.
+-->
+---
+name: model-compatibility
+description: Analyze ONNX models for AMD HIP / ROCm EP compatibility against the onnx-hipdnn-ep dialect. Dumps the EP-input graph via VOE when available, classifies every operator as supported / partial / unsupported, generates markdown reports, and verifies every non-supported entry against the actual source in lib/Conversion and include/hip/Dialect/IR/HipOps.td to catch parser false positives. Use when the user asks to analyze an ONNX model, check op compatibility, diagnose EP fallbacks, decide if a model can run on hipdnn EP, or batch-compare multiple ONNX models.
+---
+
+# model-compatibility
+
+Run the ONNX -> HIP / ROCm EP compatibility pipeline against a given ONNX model. The pipeline lives entirely under [scripts/](scripts/); this document tells you how to drive it, interpret outputs, and avoid the well-known parser false-positive class.
+
+## Gather inputs
+
+| Input | Required | Default if omitted |
+|---|---|---|
+| `<model.onnx>` | Yes | — |
+| `<VoePackageRoot>` | No (optional) | `$env:VOE_PACKAGE_ROOT` if set; otherwise must use `-SkipDump` |
+| `<OutputDir>` | No | `D:\temp\<meaningful-path-name>_ep_compat` (auto-derived from path; see below) |
+
+Before running, ask the user only for `<model.onnx>` if missing. **Never invent paths**. Do not reuse a path from an earlier chat unless the user confirms it again.
+
+## Workflow
+
+### 1. Configure (VOE is optional)
+
+VOE detection order inside [scripts/run_ep_compatibility_check.ps1](scripts/run_ep_compatibility_check.ps1):
+
+1. `-VoePackageRoot <path>` parameter
+2. `$env:VOE_PACKAGE_ROOT`
+3. Neither: the orchestrator emits `[VOE_NOT_CONFIGURED] ...` to stdout and exits with code **10** (does NOT silently continue).
+
+**When you see `[VOE_NOT_CONFIGURED]`** you MUST call `AskQuestion` with exactly two options:
+
+- **Provide VOE path** — re-run with `-VoePackageRoot <path>`. Also suggest the user run `setx VOE_PACKAGE_ROOT <path>` once for persistence.
+- **Skip dump** — re-run with `-SkipDump`. The pipeline then analyzes the **original** ONNX (not the EP-rewritten graph). The generated `model_compatibility_report.md` will carry a `> **Source:** original ONNX (no EP rewrites)` badge at the top so the limitation is impossible to miss.
+
+### 2. Single-model run
+
+```powershell
+.\scripts\run_ep_compatibility_check.ps1 -ModelPath <model.onnx>
+# add -SkipDump when the user chose to skip dump
+# add -VoePackageRoot <path> when not on env
+# add -OutputDir <dir> only if the user wants a fixed location
+```
+
+The orchestrator auto-derives a human-readable `OutputDir` from the model's path so that closing the chat and returning later still lets you see which model a directory belongs to. The rule: take the last 3 parent path segments, skip generic ones (`onnx`, `models`), append the basename when it is non-generic, lowercase and sanitize, suffix with `_ep_compat`. Examples:
+
+| Input model path | Auto OutputDir |
+|---|---|
+| `...\blip\onnx\decoder\fp16\model.onnx` | `D:\temp\blip_decoder_fp16_ep_compat` |
+| `...\blip\onnx\encoder\fp16\model.onnx` | `D:\temp\blip_encoder_fp16_ep_compat` |
+| `D:\bar\custom_v2.onnx` | `D:\temp\bar_custom_v2_ep_compat` |
+
+Re-runs against the same model reuse the same dir. If two genuinely-distinct models would collide on the auto name, pass `-OutputDir <dir>` explicitly.
+
+Key produced artifacts (under `<OutputDir>`):
+
+| File | Purpose |
+|---|---|
+| `model_compatibility_report.md` | Primary deliverable; the markdown you read back to the user |
+| `model_compatibility_details.md` | Full per-operator diagnostics |
+| `op_distribution_comparison.md` | Original vs EP-input operator counts (only when dump ran) |
+| `compatibility/report_input.json` | Normalized intermediate data (input to report generators) |
+| `compatibility/unsupported_reco_runtime.json` | Machine-readable unsupported recommendations |
+| `ep_input/onnx.onnx` | EP-rewritten graph (only when dump ran) |
+| `pipeline_status.md` | Pipeline run metadata + warnings |
+
+### 3. Triage every non-supported entry (mandatory diagnose pass)
+
+Open `model_compatibility_report.md`. For each operator with status `unsupported` or `partial`, you MUST run the playbook in [diagnose.md](diagnose.md). The parser is **not** a source of truth; it has known false-positive classes. Recent example: the parser mis-tagged `onnx.LayerNormalization` as `unsupported` because of a regex substring collision; the actual source has full support. The diagnose playbook catches this in ~30 seconds via three grep calls against `lib/Conversion`, `include/hip/Dialect/IR/HipOps.td`, and `lib/Runtime/real/`.
+
+Each non-supported entry resolves to one of three labels:
+
+- **truly supported (tool-FP)** — source proves the mapping exists; report as supported and record the parser bug location for future fix in [scripts/step2_1_onnx_to_hip_parser.py](scripts/step2_1_onnx_to_hip_parser.py).
+- **partial (real attribute / shape mismatch)** — keep `partial` status; cite the reason code from [reference.md](reference.md).
+- **truly unsupported** — apply ROCm family routing from [reference.md](reference.md) (and the machine-readable [scripts/unsupported_reco_rules.json](scripts/unsupported_reco_rules.json)) to recommend a wrapper extension target.
+
+### 4. Batch (inline, no extra script)
+
+When the user asks for multiple models, drive the loop yourself. The ONNX file name is **not** standardized (it may be `model.onnx`, `<model_name>.onnx`, `decoder.onnx`, etc.); ask the user for the filter pattern or default to `*.onnx`:
+
+```powershell
+$skill = "<repo>\.cursor\skills\model-compatibility"
+# Pick ONE of:
+#   - Explicit list:           $models = @("D:\a\foo.onnx", "D:\b\bar.onnx")
+#   - All .onnx under a root:  $models = Get-ChildItem -Recurse -Filter *.onnx <models-root> | % FullName
+#   - Custom pattern:          $models = Get-ChildItem -Recurse -Filter <user-glob> <models-root> | % FullName
+foreach ($m in $models) {
+    & "$skill\scripts\run_ep_compatibility_check.ps1" -ModelPath $m -ContinueOnDumpFailure
+}
+```
+
+If the user just points at a directory without specifying a pattern, ask: "filter as `*.onnx` (all ONNX files) or a more specific glob like `decoder*.onnx`?". Aggregate the per-model reports manually. Only consider promoting batch / diff / aggregation to a dedicated script after you have done this loop more than three times.
+
+### 5. Output to the user
+
+Render the markdown templates from [report_template.md](report_template.md) verbatim. Status display rule (mandatory):
+
+- input `full` -> displayed `supported`
+- input `partial` -> displayed `partial`
+- input `unsupported` -> displayed `unsupported`
+
+In the summary line append the percentage to `Supported instances`, e.g. `682 (94.7%)`.
+
+### 6. Validation before responding
+
+- [ ] Counts in summary equal computed counts from `operator_distribution`
+- [ ] Diagnose pass executed for every non-supported entry (no shortcuts)
+- [ ] No unsupported non-compile-time line uses any reason text other than `No Hip Dialect implementation available.`
+- [ ] Every operator in the compatibility summary appears in operator distribution
+- [ ] `mapping_chain` table rows match input JSON exactly
+- [ ] If `-SkipDump` mode was used, the report header shows the `Source: original ONNX (no EP rewrites)` badge
+
+## Agent checklist
+
+```
+- [ ] User provided <model.onnx> (no guessed path)
+- [ ] VOE configured OR user chose -SkipDump via AskQuestion
+- [ ] Ran scripts/run_ep_compatibility_check.ps1 with auto OutputDir
+- [ ] Read model_compatibility_report.md from <OutputDir>
+- [ ] Ran diagnose.md playbook on every unsupported / partial entry
+- [ ] Promoted tool-FP entries to supported in the user-facing summary
+- [ ] Reported using report_template.md format with correct status display
+- [ ] Validation checklist all green
+```
+
+## Additional resources
+
+- [reference.md](reference.md) — status semantics, reason code catalog, ROCm family routing matrix
+- [report_template.md](report_template.md) — exact markdown templates for the final report (do not paraphrase)
+- [diagnose.md](diagnose.md) — false-positive detection playbook (mandatory for every non-supported entry); contains the BLIP fp16 decoder walked example
+- [scripts/](scripts/) — full pipeline source; orchestrator entry is [scripts/run_ep_compatibility_check.ps1](scripts/run_ep_compatibility_check.ps1)

--- a/.cursor/skills/model-compatibility/diagnose.md
+++ b/.cursor/skills/model-compatibility/diagnose.md
@@ -1,0 +1,109 @@
+<!--
+Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+Licensed under the MIT License.
+-->
+# Diagnose — false-positive triage for `unsupported` / `partial`
+
+The pipeline's ONNX -> HIP parser ([scripts/step2_1_onnx_to_hip_parser.py](scripts/step2_1_onnx_to_hip_parser.py)) is **not** the source of truth. It uses regex over `lib/Conversion/OnnxToHip/*.cpp` and has known classes of false positives. **Every `unsupported` or `partial` entry in the generated report MUST be run through this playbook before reporting to the user.**
+
+Skipping this step has produced wrong answers in the field — most recently, all 38 instances of `onnx.LayerNormalization` in BLIP fp16 decoder were tagged `unsupported` when the source actually has full E2E support (`LayerNormToHip` -> `hip.layer_norm` -> `wrap_layer_normalization`). The playbook below catches this in ~30 seconds.
+
+## Playbook (run for each unsupported / partial op)
+
+Let `<Op>` be the ONNX op type from the report (e.g. `LayerNormalization`).
+
+### Step 1 — Is there an ONNX -> HIP conversion pattern?
+
+```
+rg --pcre2 'RewritePattern\("onnx\.<Op>"' lib/Conversion/OnnxToHip/
+rg --pcre2 'function_name["'"'"']?\s*==\s*"<Op>"' lib/Conversion/OnnxToHip/
+```
+
+- **Hit** in `RewritePattern("onnx.<Op>", ...)` constructor -> standard-domain ONNX op IS mapped.
+- **Hit** in `function_name == "<Op>"` check -> `onnx.Custom`-domain op IS mapped (typically `com.microsoft`).
+- **No hit anywhere** -> truly unsupported in conversion layer; go to Step 4.
+
+### Step 2 — Is the target HIP op defined?
+
+Open the matched conversion struct and find what it constructs: either `mlir::hip::<XxxOp>::create(...)` or `mlir::OperationState(loc, "hip.<xxx>")`. Then:
+
+```
+rg 'def Hip_<XxxOp>\b' include/hip/Dialect/IR/HipOps.td
+rg 'def Hip_\w+Op[^{]*<"<xxx>"' include/hip/Dialect/IR/HipOps.td
+```
+
+- **Hit** -> the HIP dialect Op exists. Go to Step 3.
+- **No hit** -> conversion exists but target dialect Op missing; this is a real bug in `lib/Conversion`, escalate to dialect owner. Mark report entry as `unsupported (missing HIP dialect Op)`.
+
+### Step 3 — Is the runtime wrapper present?
+
+Find the lowering in `lib/Conversion/HipToLLVM/` for `hip.<xxx>`, then locate its `wrap_*` / `hip_*` runtime symbol:
+
+```
+rg 'hip\.<xxx>' lib/Conversion/HipToLLVM/
+rg '\bwrap_<xxx>\b|\bhip_<xxx>\b' lib/Runtime/real/
+```
+
+- **Hit** in `lib/Runtime/real/` -> end-to-end path exists. **The report entry is a tool-FP. Promote it to `supported` in the user-facing summary.**
+- **No hit** -> dialect Op exists but runtime impl missing; mark as `unsupported (missing runtime wrapper)`. Recommended path = the wrapper name itself (extension target).
+
+### Step 4 — Truly unsupported (Step 1 had no hit)
+
+Apply ROCm family routing from [reference.md](reference.md):
+
+1. Identify family (matmul / conv / activation / elementwise / reduction / data-movement / control-flow / norm-composite) based on ONNX schema semantics.
+2. Map to recommended path: `MIOpen` / `hipBLASLt` / extension of existing wrapper / `Custom Hip Kernel`.
+3. Cite the closest existing wrapper if any (machine matrix in [scripts/unsupported_reco_rules.json](scripts/unsupported_reco_rules.json)).
+4. Output: `<Op>` -> recommended path -> closest wrapper -> one-line rationale.
+
+## Partial-status triage
+
+For `partial`, the report already names a reason code from the catalog in [reference.md](reference.md). Confirm by:
+
+- For `EXTRA_ONNX_ATTR_NOT_IN_HIP` / `MISSING_HIP_REQUIRED_ATTR`: open the HIP TableGen def and verify the attribute list; if the attr is genuinely required by the lowering, partial is real. If the attr is purely informational and the lowering ignores it, this is a tool-FP — promote to `supported`.
+- For `ONNX_INPUT_BELOW_HIP_MIN` / `ABOVE_HIP_MAX` (and `OUTPUT_*` variants): inspect a real model instance in `compatibility/report_input.json` and compare its operand count to the HIP op's TableGen signature.
+
+### Real-partial examples (do NOT promote)
+
+Some partials are genuinely real even after diagnose. Two recurring cases from BLIP fp16 decoder:
+
+- `Cast` with `EXTRA_ONNX_ATTR_NOT_IN_HIP: saturate` — `hip.cast` does not model `saturate`. Most exports use the default value, so it does not block execution in practice, but the partial status is technically correct.
+- `Softmax` with `EXTRA_ONNX_ATTR_NOT_IN_HIP: axis` — `hip.miopen.softmax` hard-codes last-dim row-wise softmax; `axis != -1` would require a different runtime path. Keep `partial`.
+
+When reporting partials to the user, distinguish "attribute is non-default in this model" (real risk) vs "attribute is at default and runtime ignores it" (no practical impact).
+
+## Known parser false-positive classes (regression catalog)
+
+| FP class | Symptom | Cause | Fix landed |
+|---|---|---|---|
+| Substring-shadowed struct scope | Op marked unsupported despite explicit `RewritePattern("onnx.<X>", ...)` in source | `<X>ToHip` is a suffix of a sibling struct name (e.g. `LayerNormToHip` ⊂ `SimplifiedLayerNormToHip`); regex `LayerNormToHip::matchAndRewrite` matched the longer sibling's body | YES — `(?<!\w)` word boundary in `_scope_to_rewrite_pattern_body`; same-file struct disambiguation |
+| Whole-file domain heuristic | Standard-domain op mis-tagged `com.microsoft` | Old `_determine_domain_from_code` returned `com.microsoft` if the substring `com.microsoft` appeared **anywhere** in the file; mixed-domain files (Norm, etc.) tripped this | YES — domain now requires a real `domain_name == "com.microsoft"` check inside the struct scope |
+| `OperationState` declaration form | Op shows up with empty / wrong `class_name` in mappings | Regex `OperationState\s*\(` only matched `OperationState(loc, ...)` expression form, not `OperationState state(loc, ...)` declaration form | YES — `OperationState(?:\s+\w+)?\s*\(` matches both |
+| First `*Op::create` wins | `hip_op` mis-tagged as a sibling struct's target | `_extract_hip_op_from_code` returned the file's first `*Op::create`, not the struct-scoped one | YES — Mode 2 now passes a scoped body to the extractors |
+
+When you discover a new FP class, add a row here and file a fix in [scripts/step2_1_onnx_to_hip_parser.py](scripts/step2_1_onnx_to_hip_parser.py).
+
+## Walked example — LayerNormalization (2026-06-01)
+
+Report said:
+```
+LayerNormalization | onnx | 38 | float16 | — | unsupported | ...
+```
+
+Playbook:
+
+1. `rg 'RewritePattern\("onnx\.LayerNormalization"' lib/Conversion/OnnxToHip/`
+   -> hit in [lib/Conversion/OnnxToHip/NormConversion.cpp](lib/Conversion/OnnxToHip/NormConversion.cpp): `struct LayerNormToHip : RewritePattern("onnx.LayerNormalization", ...)`
+2. Find construction site in that struct: `mlir::OperationState state(loc, "hip.layer_norm")`.
+   `rg 'def Hip_LayerNormOp\b' include/hip/Dialect/IR/HipOps.td` -> hit at line 575.
+3. `rg 'wrap_layer_normalization' lib/Runtime/real/` -> hit in [lib/Runtime/real/layer_normalization.cpp](lib/Runtime/real/layer_normalization.cpp) at `int wrap_layer_normalization(...)`.
+4. Conclusion: **tool-FP, promote to `supported`**. Recommended ROCm impl = `MIOpen (wrap_layer_normalization)`.
+5. Recorded FP class "Substring-shadowed struct scope" in the table above; fixed in `_scope_to_rewrite_pattern_body`.
+
+After the fix, re-running the pipeline on BLIP fp16 decoder returned `720 / 720 (100.0%)` supported, matching ground truth.
+
+## Output for the user
+
+After running the playbook on all non-supported entries, restate the report's headline numbers reflecting any FP promotions, e.g.:
+
+> The pipeline reported 682 / 720 (94.7%) supported and 38 `LayerNormalization` unsupported. After diagnose, all 38 are a known tool-FP (substring-shadowed struct scope); ground-truth supported = **720 / 720 (100.0%)**. Parser fix target: [scripts/step2_1_onnx_to_hip_parser.py](scripts/step2_1_onnx_to_hip_parser.py).

--- a/.cursor/skills/model-compatibility/reference.md
+++ b/.cursor/skills/model-compatibility/reference.md
@@ -1,0 +1,135 @@
+<!--
+Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+Licensed under the MIT License.
+-->
+# Reference — compatibility rules, reason codes, recommendation routing
+
+Canonical definitions consumed by SKILL.md, diagnose.md, and report_template.md. **Source of truth** for status semantics and reason text wording — do not paraphrase elsewhere.
+
+## Status definitions (data layer)
+
+`report_input.json` stores one of three canonical statuses per `(onnx_op, domain)`:
+
+- `full` — mapped to a HIP op (or a compile-time `tensor.*` op) and no per-instance schema mismatch found.
+- `partial` — mapped to a HIP op, but per-instance schema checks found mismatch.
+- `unsupported` — no ONNX -> HIP mapping found in the parsed conversion patterns.
+
+## Status display rule (report layer)
+
+| Data status | Displayed in report as |
+|---|---|
+| `full` | `supported` |
+| `partial` | `partial` |
+| `unsupported` | `unsupported` |
+
+## Compile-time operators
+
+When a mapping's `hip_op` starts with `tensor.` (e.g. `tensor.expand_shape`, `tensor.collapse_shape`):
+
+- status = `full`
+- reason code = `COMPILE_TIME_TENSOR_OP`
+- reason text = `Handled at compile time.`
+
+## Non-compile-time per-instance schema checks
+
+For each `(onnx_op, domain)` mapped to a non-`tensor.*` HIP op, the pipeline runs three checks:
+
+1. **Input edge compatibility**
+   - HIP input bounds from TableGen:
+     - lower bound = required non-`ctx` operands
+     - upper bound = total non-`ctx` operands unless variadic
+   - reason codes: `ONNX_INPUT_BELOW_HIP_MIN`, `ONNX_INPUT_ABOVE_HIP_MAX`
+2. **Output edge compatibility**
+   - HIP output bounds same way.
+   - reason codes: `ONNX_OUTPUT_BELOW_HIP_MIN`, `ONNX_OUTPUT_ABOVE_HIP_MAX`
+3. **Attribute compatibility**
+   - Required attrs = TD non-optional attrs + strict overrides from `compatibility_attr_rules.json` (key `strict_required_attrs`).
+   - No strict attrs are hardcoded.
+   - reason codes: `MISSING_HIP_REQUIRED_ATTR`, `EXTRA_ONNX_ATTR_NOT_IN_HIP`
+
+Any reason code present => `partial`. No reason code => `full`.
+
+## Unsupported rule
+
+No ONNX -> HIP mapping found for `(onnx_op, domain)`:
+
+- status = `unsupported`
+- reason code = `NO_HIP_DIALECT_IMPL`
+- reason text:
+  - if op is compile-time classifiable elsewhere: keep that specific text
+  - otherwise: **exactly** `No Hip Dialect implementation available.`
+
+## Reason code catalog
+
+```
+NO_HIP_DIALECT_IMPL
+COMPILE_TIME_TENSOR_OP
+MISSING_HIP_REQUIRED_ATTR
+EXTRA_ONNX_ATTR_NOT_IN_HIP
+ONNX_INPUT_BELOW_HIP_MIN
+ONNX_INPUT_ABOVE_HIP_MAX
+ONNX_OUTPUT_BELOW_HIP_MIN
+ONNX_OUTPUT_ABOVE_HIP_MAX
+```
+
+## Recommended ROCm implementation (report-layer inference)
+
+`Recommended Rocm Implementation` is **agent-inferred at render time** from normalized data; it is NOT stored in `report_input.json`.
+
+### For `full` / `supported` / `partial`
+
+In order, first match wins:
+
+1. `hip_op` starts with `tensor.` -> `Compile Time Optimization`
+2. `backend` AND `runtime_func` exist -> `` `<backend>` (`<runtime_func>`) ``
+3. only `backend` exists -> `<backend>`
+4. only `runtime_func` exists -> `` `<runtime_func>` ``
+5. else -> `Unknown`
+
+### For `unsupported`
+
+1. If reason text indicates compile-time handling -> `Compile Time Optimization`
+2. Otherwise run capability-driven recommendation:
+   1. Infer op family from ONNX semantics (`op_type` + schema description)
+   2. Build capability inventory from `step2_3_backend_analysis.json`, runtime wrappers in `lib/Runtime/real/`, and [scripts/unsupported_reco_rules.json](scripts/unsupported_reco_rules.json)
+   3. Map family to nearest available ROCm path and name extension target wrapper
+3. If no feasible ROCm/library match -> `Custom Hip Kernel`
+
+For every unsupported op recommendation include: recommended path, closest existing wrapper / entry point (if any), short rationale.
+
+## ROCm family routing matrix
+
+Machine-readable form: [scripts/unsupported_reco_rules.json](scripts/unsupported_reco_rules.json). Human-readable summary:
+
+| # | Family | Preferred path | Fallback |
+|---|---|---|---|
+| 1 | Matrix multiplication (`matmul`, `gemm`, batched dense linear) | `hipBLASLt` — extend `wrap_hipblasLtMatmul` | `Custom Hip Kernel` |
+| 2 | Convolution (`conv`, depthwise / pointwise variants) | `MIOpen` — extend convolution wrapper | `Custom Hip Kernel` |
+| 3 | Activation (`relu`, `sigmoid`, `tanh`, `softplus`, similar unary) | `MIOpen` activation wrapper extension | `Custom Hip Kernel` |
+| 4 | Elementwise arith / cmp / logical | `MIOpen` op-tensor path when representable by `wrap_miopenOpTensor` | `Custom Hip Kernel` |
+| 5 | Reduction (`reduce_*`, cumulative reductions) | extend existing reduction runtime path (`wrap_reduce_sum` family) | `Custom Hip Kernel` |
+| 6 | Indexing / data movement (`gather / scatter / slice / split / tile / pad / concat / expand`) | reuse / extend existing custom data-movement kernels | `Custom Hip Kernel` |
+| 7 | Control flow / stateful (`loop / if / scan`) | graph-level lowering / runtime orchestration | `Custom Hip Kernel` (unless compile-time eliminable) |
+| 8 | Normalization / composite blocks | decompose into supported primitives if possible, else extend `wrap_miopen*LayerNorm*` family | `Custom Hip Kernel` |
+
+### Known runtime capabilities (capability inventory examples)
+
+- `wrap_miopenOpTensor` — elementwise add / mul / min / max
+- `wrap_miopenActivationForward` — activation-family elementwise ops
+- `miopenActivationPOWER` — can express `Reciprocal` / `Sqrt` by parameterization
+- `wrap_miopenConvolutionForward` — convolution family
+- `wrap_hipblasLtMatmul` — matmul family
+- `wrap_miopenT5LayerNormForward` — RMS / T5 layer norm
+- `wrap_layer_normalization` — standard ONNX-17 LayerNormalization (mean + var)
+- `wrap_skip_simplified_layer_norm` — Microsoft SkipSimplifiedLayerNormalization fusion
+- `wrap_reduce_sum` — current custom reduction path
+
+## Validation checklist (final pass before responding to user)
+
+- Counts in summary equal computed counts from `operator_distribution`
+- No unsupported non-compile-time line uses text other than `No Hip Dialect implementation available.`
+- Every operator in compatibility summary appears in operator distribution
+- `mapping_chain` table rows exactly match input rows
+- No extra sections beyond template order
+- **Diagnose pass executed for every non-supported entry** (see [diagnose.md](diagnose.md))
+- If `-SkipDump` mode was used, report header carries `Source: original ONNX (no EP rewrites)` badge

--- a/.cursor/skills/model-compatibility/report_template.md
+++ b/.cursor/skills/model-compatibility/report_template.md
@@ -1,0 +1,76 @@
+<!--
+Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+Licensed under the MIT License.
+-->
+# Report templates
+
+These templates are the contract between the pipeline and the user-facing markdown. **Do not paraphrase**. The pipeline's [scripts/generate_final_reports.py](scripts/generate_final_reports.py) already renders these files at `<OutputDir>/model_compatibility_report.md` and `<OutputDir>/model_compatibility_details.md`. When you read those generated files back to the user, preserve the section order and naming verbatim.
+
+## Non-negotiable rules
+
+1. Never invent operators, counts, mappings, or reasons. Every number must match `compatibility/report_input.json`.
+2. Unsupported reason text policy:
+   - Compile-time ops: keep the specific compile-time reason text.
+   - All others: exactly `No Hip Dialect implementation available.`
+3. Status display rule:
+   - input `full` -> displayed as `supported`
+   - input `partial` -> kept as `partial`
+   - input `unsupported` -> kept as `unsupported`
+4. If a field is missing, render as `—` and add one short note in the "Data quality notes" section of the details file.
+5. For `unsupported` recommendations, use [scripts/unsupported_reco_rules.json](scripts/unsupported_reco_rules.json) as the primary capability matrix, not just current repo wrappers.
+6. In summary, append percentage for `Supported instances` when total is available (e.g. `1294 (62.3%)`).
+
+## Output files (rendered by the pipeline)
+
+| File | Purpose |
+|---|---|
+| `model_compatibility_report.md` | Executive summary + key tables (primary deliverable) |
+| `model_compatibility_details.md` | Per-operator diagnostics (supports, partials with reason codes, data quality notes) |
+| `compatibility/unsupported_reco_runtime.json` | Machine-readable unsupported recommendations |
+
+## model_compatibility_report.md — section order
+
+Exact order, do not reorder:
+
+1. `# Model compatibility report`
+2. Metadata bullets (one bullet each):
+   - `EP input (compatibility target)` — only present when dump ran
+   - `Original model`
+   - `Generated UTC`
+3. *(conditional)* `> **Source:** original ONNX (no EP rewrites)` — when pipeline ran in `-SkipDump` mode (orchestrator injects this badge automatically)
+4. `## Summary`
+   - Total node instances
+   - Supported instances `<n> (<pct>%)`
+   - Unsupported instances
+   - Total Operator Types
+   - Fully Compatible
+   - Partially Compatible
+   - Unsupported
+5. *(conditional)* `## Original vs EP input (operator distribution)` — only when dump ran; embedded from `op_distribution_comparison.json`
+6. `## Operator Distribution with Compatibility Status`
+   - Columns (exact, in order): `Op Type | Domain | Count | Data Types | Recommended Rocm Implementation | Status | Op Description`
+7. `### Compatibility Summary`
+   - `#### Fully Compatible Operator (<count>)`
+   - `#### Partially Compatible Operators (<count>):`
+   - `#### Unsupported Operators (<count>):`
+8. `Unsupported operator recommendation buckets` (one bucket per recommended path)
+9. `## Hip Ops Summary` — copy the `## Operator Summary` table from `step2_hip_ops.md` when available
+10. `## ONNX-HIP-RUNTIME Mapping` — render from `mapping_chain`
+11. Final pointer line: `Detailed compatibility diagnostics are in model_compatibility_details.md`
+
+## model_compatibility_details.md — section order
+
+1. Title + metadata
+2. *(conditional)* `Source: original ONNX (no EP rewrites)` badge when applicable
+3. *(conditional)* `## Original vs EP input (operator distribution)` block
+4. `## Supported operators table (full)`
+5. `## Partially compatible details` — columns: `Op Type | Domain | Reason Codes | Reason Texts | Evidence`
+6. `## Unsupported operators` — columns: `Op Type | Domain | Count | Reason`
+7. `## Data quality notes`
+
+## Agent rendering rules
+
+- When you echo the report back to the user, do not re-render or reformat; **read the generated markdown** and paste / quote it.
+- When you summarize verbally, the percentage in Summary is the headline number; mention any tool-FP rescued by diagnose and the resulting "true" supported percentage.
+- For every `unsupported` recommendation bucket you should include closest existing wrapper / entry point (if any) and short family-based rationale per [reference.md](reference.md).
+- When the report header carries the `Source: original ONNX` badge, lead your user-facing summary with that caveat — the numbers do not reflect EP fusions/folds.

--- a/.cursor/skills/model-compatibility/scripts/build_report_input.py
+++ b/.cursor/skills/model-compatibility/scripts/build_report_input.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+import json
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+
+from onnx_graph_walk import iter_model_nodes
+
+FALLBACK_OP_DESCRIPTIONS = {
+    "MatMulNBits": "Quantized N-bit matrix multiplication (com.microsoft)",
+    "RotaryEmbedding": "Rotary position embedding (RoPE)",
+    "SkipSimplifiedLayerNormalization": "Skip connection + RMS normalization",
+    "GroupQueryAttention": "Group Query Attention mechanism",
+    "QMoE": "Mixture-of-Experts routing and fused expert computation",
+}
+
+
+def norm_domain(domain: str) -> str:
+    if not domain or domain == "ai.onnx":
+        return "onnx"
+    return domain
+
+
+def unsupported_rec(op: str):
+    compile_time = {
+        "Shape": "Shape inference operation - handled at compile time.",
+        "Concat": "Shape manipulation operation - handled at compile time.",
+        "Range": "Range generation - handled at compile time.",
+        "Constant": "Constant folding / constant propagation - handled at compile time.",
+        "Size": "Shape/size query - typically handled by compile-time shape propagation.",
+        "CastLike": "Type-canonicalization pattern - often resolved at compile time.",
+    }
+    if op in compile_time:
+        return "Compile Time Optimization", compile_time[op]
+    return "Custom Hip Kernel", "No Hip Dialect implementation available."
+
+
+def load_strict_attr_names(analysis_dir: Path, repo_root: Path):
+    """
+    Load strict-required attribute names from external config.
+    Search order:
+    1) <analysis_dir>/compatibility_attr_rules.json
+    2) <repo_root>/compatibility_attr_rules.json
+    """
+    candidates = [
+        analysis_dir / "compatibility_attr_rules.json",
+        repo_root / "compatibility_attr_rules.json",
+    ]
+    for cfg in candidates:
+        if not cfg.exists():
+            continue
+        try:
+            data = json.loads(cfg.read_text(encoding="utf-8"))
+            names = data.get("strict_required_attrs") or []
+            return {str(x) for x in names if str(x).strip()}
+        except Exception:
+            continue
+    return set()
+
+
+def onnx_op_description(op: str, domain: str) -> str:
+    """
+    Resolve ONNX operator description from schema docs.
+    Falls back to curated descriptions for non-standard domains.
+    """
+    try:
+        from onnx import defs
+
+        schema = defs.get_schema(op, domain="" if domain in {"", "onnx", "ai.onnx"} else domain)
+        doc = " ".join((schema.doc or "").split())
+        if doc:
+            return doc.split(". ")[0].strip().rstrip(".")
+    except Exception:
+        pass
+    if op in FALLBACK_OP_DESCRIPTIONS:
+        return FALLBACK_OP_DESCRIPTIONS[op]
+    return "—"
+
+
+def io_bounds(operands: dict, skip_ctx: bool):
+    min_edges = 0
+    max_edges = 0
+    has_variadic = False
+    for name, info in (operands or {}).items():
+        if not isinstance(info, dict):
+            continue
+        if skip_ctx and name in {"ctx", "context"}:
+            continue
+        variadic = bool(info.get("variadic"))
+        required = bool(info.get("required", True))
+        if variadic:
+            has_variadic = True
+            if required:
+                min_edges += 1
+        else:
+            max_edges += 1
+            if required:
+                min_edges += 1
+    return min_edges, (None if has_variadic else max_edges)
+
+
+def analyze_schema_for_key(nodes, hip_entry, strict_attr_names):
+    ins = (hip_entry or {}).get("inputs") or {}
+    outs = (hip_entry or {}).get("outputs") or {}
+    attrs = (hip_entry or {}).get("attributes") or {}
+
+    req_attrs = []
+    for k, v in attrs.items():
+        if not isinstance(v, dict):
+            continue
+        if (not v.get("optional", False)) or (k in strict_attr_names):
+            req_attrs.append(k)
+    declared_attrs = {k for k, v in attrs.items() if isinstance(v, dict)}
+    req_attrs = sorted(req_attrs)
+
+    min_in, max_in = io_bounds(ins, skip_ctx=True)
+    min_out, max_out = io_bounds(outs, skip_ctx=False)
+    total = len(nodes)
+
+    miss_attr_counts = Counter()
+    extra_attr_counts = Counter()
+    in_low = in_high = out_low = out_high = 0
+    nodes_with_extra = 0
+
+    for n in nodes:
+        attrs_set = {a.name for a in n.attribute}
+        for a in req_attrs:
+            if a not in attrs_set:
+                miss_attr_counts[a] += 1
+        extra = sorted(attrs_set - declared_attrs)
+        if extra:
+            nodes_with_extra += 1
+            for x in extra:
+                extra_attr_counts[x] += 1
+        nin = len(n.input)
+        nout = len(n.output)
+        if nin < min_in:
+            in_low += 1
+        if max_in is not None and nin > max_in:
+            in_high += 1
+        if nout < min_out:
+            out_low += 1
+        if max_out is not None and nout > max_out:
+            out_high += 1
+
+    reason_codes = []
+    reason_texts = []
+
+    all_missing = [a for a in req_attrs if miss_attr_counts[a] == total and total > 0]
+    some_missing = [a for a in req_attrs if 0 < miss_attr_counts[a] < total]
+    if all_missing:
+        reason_codes.append("MISSING_HIP_REQUIRED_ATTR")
+        reason_texts.append("Missing Hip-required attributes in all ONNX instances: " + ", ".join(sorted(all_missing)))
+    if some_missing:
+        if "MISSING_HIP_REQUIRED_ATTR" not in reason_codes:
+            reason_codes.append("MISSING_HIP_REQUIRED_ATTR")
+        reason_texts.append("Missing Hip-required attributes in some ONNX instances: " + ", ".join(sorted(some_missing)))
+
+    if in_low:
+        reason_codes.append("ONNX_INPUT_BELOW_HIP_MIN")
+        reason_texts.append(f"ONNX inputs below Hip minimum in {in_low}/{total} instance(s).")
+    if in_high:
+        reason_codes.append("ONNX_INPUT_ABOVE_HIP_MAX")
+        reason_texts.append(f"ONNX inputs above Hip maximum in {in_high}/{total} instance(s).")
+    if out_low:
+        reason_codes.append("ONNX_OUTPUT_BELOW_HIP_MIN")
+        reason_texts.append(f"ONNX outputs below Hip minimum in {out_low}/{total} instance(s).")
+    if out_high:
+        reason_codes.append("ONNX_OUTPUT_ABOVE_HIP_MAX")
+        reason_texts.append(f"ONNX outputs above Hip maximum in {out_high}/{total} instance(s).")
+    if nodes_with_extra:
+        reason_codes.append("EXTRA_ONNX_ATTR_NOT_IN_HIP")
+        top = [k for k, _ in extra_attr_counts.most_common(12)]
+        reason_texts.append("Extra attributes in ONNX not supported by Hip: " + ", ".join(top))
+
+    status = "partial" if reason_codes else "full"
+    return status, sorted(set(reason_codes)), reason_texts
+
+
+def main():
+    if len(sys.argv) != 4:
+        raise SystemExit("Usage: build_report_input.py <model.onnx> <analysis_dir> <repo_root>")
+    model_path = Path(sys.argv[1])
+    analysis_dir = Path(sys.argv[2])
+    repo_root = Path(sys.argv[3])
+
+    import onnx
+
+    strict_attr_names = load_strict_attr_names(analysis_dir, repo_root)
+
+    step1 = json.loads((analysis_dir / "step1_onnx_ops.json").read_text(encoding="utf-8"))
+    step21 = json.loads((analysis_dir / "step2_1_onnx_to_hip_mappings.json").read_text(encoding="utf-8"))
+    step23 = json.loads((analysis_dir / "step2_3_backend_analysis.json").read_text(encoding="utf-8"))
+    step2hip = json.loads((analysis_dir / "step2_hip_ops.json").read_text(encoding="utf-8"))
+
+    support = {}
+    for m in step21.get("mappings", []):
+        support[(m.get("onnx_op", ""), norm_domain(m.get("onnx_domain", "onnx")))] = m
+    backend_by_key = {}
+    for m in step23.get("mappings", []):
+        backend_by_key[(m.get("onnx_op", ""), norm_domain(m.get("onnx_domain", "onnx")))] = m
+
+    model = onnx.load(str(model_path), load_external_data=False)
+    counts = Counter(
+        (n.op_type, norm_domain(n.domain or ""))
+        for n, _scope in iter_model_nodes(model)
+    )
+    nodes_by_key = defaultdict(list)
+    for n, _scope in iter_model_nodes(model):
+        nodes_by_key[(n.op_type, norm_domain(n.domain or ""))].append(n)
+
+    op_dist = []
+    comp_rows = []
+    full_types = partial_types = unsupported_types = 0
+    supported_instances = unsupported_instances = 0
+
+    for idx, ((op, dom), cnt) in enumerate(sorted(counts.items(), key=lambda x: (-x[1], x[0][0], x[0][1]))):
+        s = support.get((op, dom))
+        b = backend_by_key.get((op, dom), {})
+        dtypes = []
+        step1_op = step1.get(op)
+        if isinstance(step1_op, dict) and not op.startswith("_"):
+            dtypes = [str(x) for x in (step1_op.get("data_types") or []) if x]
+
+        if s:
+            hip_op = s.get("hip_op", "")
+            if hip_op.startswith("tensor."):
+                status = "full"
+                reason_texts = ["Handled at compile time."]
+                reason_codes = ["COMPILE_TIME_TENSOR_OP"]
+            elif not isinstance(step2hip.get(hip_op), dict):
+                status = "partial"
+                reason_codes = ["NO_HIP_DIALECT_IMPL"]
+                reason_texts = ["No Hip Dialect implementation available."]
+            else:
+                status, reason_codes, reason_texts = analyze_schema_for_key(
+                    nodes_by_key[(op, dom)], step2hip.get(hip_op), strict_attr_names
+                )
+            supported_instances += cnt
+        else:
+            hip_op = None
+            status = "unsupported"
+            rec, why = unsupported_rec(op)
+            reason_texts = [why]
+            reason_codes = ["COMPILE_TIME_TENSOR_OP"] if rec == "Compile Time Optimization" else ["NO_HIP_DIALECT_IMPL"]
+            unsupported_instances += cnt
+
+        if status == "full":
+            full_types += 1
+        elif status == "partial":
+            partial_types += 1
+        else:
+            unsupported_types += 1
+
+        backend = b.get("backend") if b else None
+        runtime = b.get("runtime_func") if b else None
+        desc = "—"
+        if hip_op and isinstance(step2hip.get(hip_op), dict):
+            desc = str(step2hip[hip_op].get("summary") or "—")
+        if not desc or desc == "—":
+            desc = onnx_op_description(op, dom)
+
+        op_dist.append({
+            "onnx_op": op,
+            "domain": dom,
+            "count": int(cnt),
+            "data_types": dtypes,
+            "status": status,
+            "hip_op": hip_op,
+            "runtime_func": runtime,
+            "backend": backend if backend else "Unknown",
+            "op_description": desc
+        })
+
+        comp_rows.append({
+            "onnx_op": op,
+            "domain": dom,
+            "status": status,
+            "reason_codes": reason_codes,
+            "reason_texts": reason_texts,
+            "evidence": [{"source_file": "step2_1_onnx_to_hip_mappings.json", "json_pointer": f"/mappings/{idx}"}]
+        })
+
+    mapping_chain = []
+    for m in step23.get("mappings", []):
+        mapping_chain.append({
+            "onnx_op": m.get("onnx_op", ""),
+            "domain": norm_domain(m.get("onnx_domain", "onnx")),
+            "hip_op": m.get("hip_op", ""),
+            "runtime_func": m.get("runtime_func"),
+            "backend": m.get("backend", "Unknown") if m.get("backend") else "Unknown"
+        })
+
+    out = {
+        "meta": {
+            "model_path": str(model_path),
+            "generated_at_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "repo_root": str(repo_root),
+            "tool_versions": {"pipeline": "step1-step2_3"},
+        },
+        "summary": {
+            "total_node_instances": int(sum(counts.values())),
+            "supported_instances": int(supported_instances),
+            "unsupported_instances": int(unsupported_instances),
+            "total_operator_types": int(len(counts)),
+            "fully_compatible_operator_types": int(full_types),
+            "partially_compatible_operator_types": int(partial_types),
+            "unsupported_operator_types": int(unsupported_types),
+        },
+        "operator_distribution": op_dist,
+        "mapping_chain": mapping_chain,
+        "compatibility": comp_rows,
+        "reason_catalog": [
+            {"code": "NO_HIP_DIALECT_IMPL", "default_text": "No Hip Dialect implementation available."},
+            {"code": "COMPILE_TIME_TENSOR_OP", "default_text": "Handled at compile time."},
+            {"code": "MISSING_HIP_REQUIRED_ATTR", "default_text": "Missing Hip-required attributes."},
+            {"code": "EXTRA_ONNX_ATTR_NOT_IN_HIP", "default_text": "Extra ONNX attributes not in Hip op."},
+            {"code": "ONNX_INPUT_BELOW_HIP_MIN", "default_text": "ONNX inputs below Hip minimum."},
+            {"code": "ONNX_INPUT_ABOVE_HIP_MAX", "default_text": "ONNX inputs above Hip maximum."},
+            {"code": "ONNX_OUTPUT_BELOW_HIP_MIN", "default_text": "ONNX outputs below Hip minimum."},
+            {"code": "ONNX_OUTPUT_ABOVE_HIP_MAX", "default_text": "ONNX outputs above Hip maximum."}
+        ]
+    }
+    out_path = analysis_dir / "report_input.json"
+    out_path.write_text(json.dumps(out, indent=2, ensure_ascii=False), encoding="utf-8")
+    print(f"Wrote {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.cursor/skills/model-compatibility/scripts/build_report_input.py
+++ b/.cursor/skills/model-compatibility/scripts/build_report_input.py
@@ -23,13 +23,15 @@ def norm_domain(domain: str) -> str:
 
 
 def unsupported_rec(op: str):
+    # Fallback table for ops that have NO Conversion.cpp at all but are known
+    # to be eliminated by MLIR's standard passes (constant folding /
+    # canonicalization / dead-code elimination). Ops whose conversion EXISTS
+    # but lowers to tensor.* / arith.* / memref.* are auto-detected by step2_1
+    # (which emits a synthetic `tensor.<X>` mapping) and never reach this
+    # branch -- they show up as supported / compile-time in the report.
     compile_time = {
-        "Shape": "Shape inference operation - handled at compile time.",
-        "Concat": "Shape manipulation operation - handled at compile time.",
-        "Range": "Range generation - handled at compile time.",
         "Constant": "Constant folding / constant propagation - handled at compile time.",
-        "Size": "Shape/size query - typically handled by compile-time shape propagation.",
-        "CastLike": "Type-canonicalization pattern - often resolved at compile time.",
+        "CastLike": "Type canonicalization pattern - resolved at compile time.",
     }
     if op in compile_time:
         return "Compile Time Optimization", compile_time[op]
@@ -194,12 +196,34 @@ def main():
     step23 = json.loads((analysis_dir / "step2_3_backend_analysis.json").read_text(encoding="utf-8"))
     step2hip = json.loads((analysis_dir / "step2_hip_ops.json").read_text(encoding="utf-8"))
 
+    # Consolidate step2_1 mappings keyed on (op, domain). An ONNX op may
+    # have MULTIPLE mappings -- e.g. Gather has hip.gather (the runtime path
+    # in GatherConversion.cpp) AND tensor.from_elements (the shape-fold
+    # variant in GatherShapeFold.cpp); ConstantOfShape has tensor.splat (the
+    # MLIR-std fold) and no hip.* op. Prefer real hip.* mappings over
+    # tensor.*/arith.*/memref.* compile-time fold variants when both exist
+    # so the report column reflects the executed runtime path, not the
+    # shape-fold fallback.
+    def _mapping_priority(mapping):
+        hop = mapping.get("hip_op", "") or ""
+        if hop.startswith("hip."):
+            return 0  # real runtime path -- highest priority
+        if hop.startswith("tensor.") or hop.startswith("arith.") or hop.startswith("memref."):
+            return 1  # compile-time fold variant
+        return 2
+
     support = {}
     for m in step21.get("mappings", []):
-        support[(m.get("onnx_op", ""), norm_domain(m.get("onnx_domain", "onnx")))] = m
+        key = (m.get("onnx_op", ""), norm_domain(m.get("onnx_domain", "onnx")))
+        existing = support.get(key)
+        if existing is None or _mapping_priority(m) < _mapping_priority(existing):
+            support[key] = m
     backend_by_key = {}
     for m in step23.get("mappings", []):
-        backend_by_key[(m.get("onnx_op", ""), norm_domain(m.get("onnx_domain", "onnx")))] = m
+        key = (m.get("onnx_op", ""), norm_domain(m.get("onnx_domain", "onnx")))
+        existing = backend_by_key.get(key)
+        if existing is None or _mapping_priority(m) < _mapping_priority(existing):
+            backend_by_key[key] = m
 
     model = onnx.load(str(model_path), load_external_data=False)
     counts = Counter(

--- a/.cursor/skills/model-compatibility/scripts/build_report_input.py
+++ b/.cursor/skills/model-compatibility/scripts/build_report_input.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
 import json
 from collections import Counter, defaultdict
 from datetime import datetime, timezone
@@ -69,7 +73,9 @@ def onnx_op_description(op: str, domain: str) -> str:
     try:
         from onnx import defs
 
-        schema = defs.get_schema(op, domain="" if domain in {"", "onnx", "ai.onnx"} else domain)
+        schema = defs.get_schema(
+            op, domain="" if domain in {"", "onnx", "ai.onnx"} else domain
+        )
         doc = " ".join((schema.doc or "").split())
         if doc:
             return doc.split(". ")[0].strip().rstrip(".")
@@ -153,28 +159,44 @@ def analyze_schema_for_key(nodes, hip_entry, strict_attr_names):
     some_missing = [a for a in req_attrs if 0 < miss_attr_counts[a] < total]
     if all_missing:
         reason_codes.append("MISSING_HIP_REQUIRED_ATTR")
-        reason_texts.append("Missing Hip-required attributes in all ONNX instances: " + ", ".join(sorted(all_missing)))
+        reason_texts.append(
+            "Missing Hip-required attributes in all ONNX instances: "
+            + ", ".join(sorted(all_missing))
+        )
     if some_missing:
         if "MISSING_HIP_REQUIRED_ATTR" not in reason_codes:
             reason_codes.append("MISSING_HIP_REQUIRED_ATTR")
-        reason_texts.append("Missing Hip-required attributes in some ONNX instances: " + ", ".join(sorted(some_missing)))
+        reason_texts.append(
+            "Missing Hip-required attributes in some ONNX instances: "
+            + ", ".join(sorted(some_missing))
+        )
 
     if in_low:
         reason_codes.append("ONNX_INPUT_BELOW_HIP_MIN")
-        reason_texts.append(f"ONNX inputs below Hip minimum in {in_low}/{total} instance(s).")
+        reason_texts.append(
+            f"ONNX inputs below Hip minimum in {in_low}/{total} instance(s)."
+        )
     if in_high:
         reason_codes.append("ONNX_INPUT_ABOVE_HIP_MAX")
-        reason_texts.append(f"ONNX inputs above Hip maximum in {in_high}/{total} instance(s).")
+        reason_texts.append(
+            f"ONNX inputs above Hip maximum in {in_high}/{total} instance(s)."
+        )
     if out_low:
         reason_codes.append("ONNX_OUTPUT_BELOW_HIP_MIN")
-        reason_texts.append(f"ONNX outputs below Hip minimum in {out_low}/{total} instance(s).")
+        reason_texts.append(
+            f"ONNX outputs below Hip minimum in {out_low}/{total} instance(s)."
+        )
     if out_high:
         reason_codes.append("ONNX_OUTPUT_ABOVE_HIP_MAX")
-        reason_texts.append(f"ONNX outputs above Hip maximum in {out_high}/{total} instance(s).")
+        reason_texts.append(
+            f"ONNX outputs above Hip maximum in {out_high}/{total} instance(s)."
+        )
     if nodes_with_extra:
         reason_codes.append("EXTRA_ONNX_ATTR_NOT_IN_HIP")
         top = [k for k, _ in extra_attr_counts.most_common(12)]
-        reason_texts.append("Extra attributes in ONNX not supported by Hip: " + ", ".join(top))
+        reason_texts.append(
+            "Extra attributes in ONNX not supported by Hip: " + ", ".join(top)
+        )
 
     status = "partial" if reason_codes else "full"
     return status, sorted(set(reason_codes)), reason_texts
@@ -182,7 +204,9 @@ def analyze_schema_for_key(nodes, hip_entry, strict_attr_names):
 
 def main():
     if len(sys.argv) != 4:
-        raise SystemExit("Usage: build_report_input.py <model.onnx> <analysis_dir> <repo_root>")
+        raise SystemExit(
+            "Usage: build_report_input.py <model.onnx> <analysis_dir> <repo_root>"
+        )
     model_path = Path(sys.argv[1])
     analysis_dir = Path(sys.argv[2])
     repo_root = Path(sys.argv[3])
@@ -191,10 +215,18 @@ def main():
 
     strict_attr_names = load_strict_attr_names(analysis_dir, repo_root)
 
-    step1 = json.loads((analysis_dir / "step1_onnx_ops.json").read_text(encoding="utf-8"))
-    step21 = json.loads((analysis_dir / "step2_1_onnx_to_hip_mappings.json").read_text(encoding="utf-8"))
-    step23 = json.loads((analysis_dir / "step2_3_backend_analysis.json").read_text(encoding="utf-8"))
-    step2hip = json.loads((analysis_dir / "step2_hip_ops.json").read_text(encoding="utf-8"))
+    step1 = json.loads(
+        (analysis_dir / "step1_onnx_ops.json").read_text(encoding="utf-8")
+    )
+    step21 = json.loads(
+        (analysis_dir / "step2_1_onnx_to_hip_mappings.json").read_text(encoding="utf-8")
+    )
+    step23 = json.loads(
+        (analysis_dir / "step2_3_backend_analysis.json").read_text(encoding="utf-8")
+    )
+    step2hip = json.loads(
+        (analysis_dir / "step2_hip_ops.json").read_text(encoding="utf-8")
+    )
 
     # Consolidate step2_1 mappings keyed on (op, domain). An ONNX op may
     # have MULTIPLE mappings -- e.g. Gather has hip.gather (the runtime path
@@ -208,7 +240,11 @@ def main():
         hop = mapping.get("hip_op", "") or ""
         if hop.startswith("hip."):
             return 0  # real runtime path -- highest priority
-        if hop.startswith("tensor.") or hop.startswith("arith.") or hop.startswith("memref."):
+        if (
+            hop.startswith("tensor.")
+            or hop.startswith("arith.")
+            or hop.startswith("memref.")
+        ):
             return 1  # compile-time fold variant
         return 2
 
@@ -239,7 +275,9 @@ def main():
     full_types = partial_types = unsupported_types = 0
     supported_instances = unsupported_instances = 0
 
-    for idx, ((op, dom), cnt) in enumerate(sorted(counts.items(), key=lambda x: (-x[1], x[0][0], x[0][1]))):
+    for idx, ((op, dom), cnt) in enumerate(
+        sorted(counts.items(), key=lambda x: (-x[1], x[0][0], x[0][1]))
+    ):
         s = support.get((op, dom))
         b = backend_by_key.get((op, dom), {})
         dtypes = []
@@ -267,7 +305,11 @@ def main():
             status = "unsupported"
             rec, why = unsupported_rec(op)
             reason_texts = [why]
-            reason_codes = ["COMPILE_TIME_TENSOR_OP"] if rec == "Compile Time Optimization" else ["NO_HIP_DIALECT_IMPL"]
+            reason_codes = (
+                ["COMPILE_TIME_TENSOR_OP"]
+                if rec == "Compile Time Optimization"
+                else ["NO_HIP_DIALECT_IMPL"]
+            )
             unsupported_instances += cnt
 
         if status == "full":
@@ -285,41 +327,56 @@ def main():
         if not desc or desc == "—":
             desc = onnx_op_description(op, dom)
 
-        op_dist.append({
-            "onnx_op": op,
-            "domain": dom,
-            "count": int(cnt),
-            "data_types": dtypes,
-            "status": status,
-            "hip_op": hip_op,
-            "runtime_func": runtime,
-            "backend": backend if backend else "Unknown",
-            "op_description": desc
-        })
+        op_dist.append(
+            {
+                "onnx_op": op,
+                "domain": dom,
+                "count": int(cnt),
+                "data_types": dtypes,
+                "status": status,
+                "hip_op": hip_op,
+                "runtime_func": runtime,
+                "backend": backend if backend else "Unknown",
+                "op_description": desc,
+            }
+        )
 
-        comp_rows.append({
-            "onnx_op": op,
-            "domain": dom,
-            "status": status,
-            "reason_codes": reason_codes,
-            "reason_texts": reason_texts,
-            "evidence": [{"source_file": "step2_1_onnx_to_hip_mappings.json", "json_pointer": f"/mappings/{idx}"}]
-        })
+        comp_rows.append(
+            {
+                "onnx_op": op,
+                "domain": dom,
+                "status": status,
+                "reason_codes": reason_codes,
+                "reason_texts": reason_texts,
+                "evidence": [
+                    {
+                        "source_file": "step2_1_onnx_to_hip_mappings.json",
+                        "json_pointer": f"/mappings/{idx}",
+                    }
+                ],
+            }
+        )
 
     mapping_chain = []
     for m in step23.get("mappings", []):
-        mapping_chain.append({
-            "onnx_op": m.get("onnx_op", ""),
-            "domain": norm_domain(m.get("onnx_domain", "onnx")),
-            "hip_op": m.get("hip_op", ""),
-            "runtime_func": m.get("runtime_func"),
-            "backend": m.get("backend", "Unknown") if m.get("backend") else "Unknown"
-        })
+        mapping_chain.append(
+            {
+                "onnx_op": m.get("onnx_op", ""),
+                "domain": norm_domain(m.get("onnx_domain", "onnx")),
+                "hip_op": m.get("hip_op", ""),
+                "runtime_func": m.get("runtime_func"),
+                "backend": m.get("backend", "Unknown")
+                if m.get("backend")
+                else "Unknown",
+            }
+        )
 
     out = {
         "meta": {
             "model_path": str(model_path),
-            "generated_at_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "generated_at_utc": datetime.now(timezone.utc).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            ),
             "repo_root": str(repo_root),
             "tool_versions": {"pipeline": "step1-step2_3"},
         },
@@ -336,15 +393,39 @@ def main():
         "mapping_chain": mapping_chain,
         "compatibility": comp_rows,
         "reason_catalog": [
-            {"code": "NO_HIP_DIALECT_IMPL", "default_text": "No Hip Dialect implementation available."},
-            {"code": "COMPILE_TIME_TENSOR_OP", "default_text": "Handled at compile time."},
-            {"code": "MISSING_HIP_REQUIRED_ATTR", "default_text": "Missing Hip-required attributes."},
-            {"code": "EXTRA_ONNX_ATTR_NOT_IN_HIP", "default_text": "Extra ONNX attributes not in Hip op."},
-            {"code": "ONNX_INPUT_BELOW_HIP_MIN", "default_text": "ONNX inputs below Hip minimum."},
-            {"code": "ONNX_INPUT_ABOVE_HIP_MAX", "default_text": "ONNX inputs above Hip maximum."},
-            {"code": "ONNX_OUTPUT_BELOW_HIP_MIN", "default_text": "ONNX outputs below Hip minimum."},
-            {"code": "ONNX_OUTPUT_ABOVE_HIP_MAX", "default_text": "ONNX outputs above Hip maximum."}
-        ]
+            {
+                "code": "NO_HIP_DIALECT_IMPL",
+                "default_text": "No Hip Dialect implementation available.",
+            },
+            {
+                "code": "COMPILE_TIME_TENSOR_OP",
+                "default_text": "Handled at compile time.",
+            },
+            {
+                "code": "MISSING_HIP_REQUIRED_ATTR",
+                "default_text": "Missing Hip-required attributes.",
+            },
+            {
+                "code": "EXTRA_ONNX_ATTR_NOT_IN_HIP",
+                "default_text": "Extra ONNX attributes not in Hip op.",
+            },
+            {
+                "code": "ONNX_INPUT_BELOW_HIP_MIN",
+                "default_text": "ONNX inputs below Hip minimum.",
+            },
+            {
+                "code": "ONNX_INPUT_ABOVE_HIP_MAX",
+                "default_text": "ONNX inputs above Hip maximum.",
+            },
+            {
+                "code": "ONNX_OUTPUT_BELOW_HIP_MIN",
+                "default_text": "ONNX outputs below Hip minimum.",
+            },
+            {
+                "code": "ONNX_OUTPUT_ABOVE_HIP_MAX",
+                "default_text": "ONNX outputs above Hip maximum.",
+            },
+        ],
     }
     out_path = analysis_dir / "report_input.json"
     out_path.write_text(json.dumps(out, indent=2, ensure_ascii=False), encoding="utf-8")

--- a/.cursor/skills/model-compatibility/scripts/compare_op_distribution.py
+++ b/.cursor/skills/model-compatibility/scripts/compare_op_distribution.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
 """
 Compare step1 ONNX op distributions (original model vs EP-dumped onnx.onnx).
 
@@ -65,7 +69,9 @@ def build_comparison(
 
     return {
         "meta": {
-            "generated_at_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "generated_at_utc": datetime.now(timezone.utc).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            ),
             "original_model": original_model,
             "ep_model": ep_model,
             "original_step1": str(original_path),
@@ -95,8 +101,8 @@ def write_markdown(comp: dict, out_md: Path) -> None:
         f"- **EP input (dumped):** `{meta['ep_model']}`\n",
         f"- **Generated UTC:** `{meta['generated_at_utc']}`\n\n",
         "## Summary\n\n",
-        f"| Metric | Original | EP input | Delta |\n",
-        f"|---|---:|---:|---:|\n",
+        "| Metric | Original | EP input | Delta |\n",
+        "|---|---:|---:|---:|\n",
         f"| Total node instances | {summary['original_total_nodes']} | "
         f"{summary['ep_total_nodes']} | {summary['node_delta']:+d} |\n",
         f"| Unique operator types | {summary['original_unique_ops']} | "
@@ -153,7 +159,9 @@ def main() -> None:
     ap.add_argument("original_step1", type=Path)
     ap.add_argument("ep_step1", type=Path)
     ap.add_argument("output_dir", type=Path)
-    ap.add_argument("--original-model", default="", help="Label for original model path")
+    ap.add_argument(
+        "--original-model", default="", help="Label for original model path"
+    )
     ap.add_argument("--ep-model", default="", help="Label for EP onnx path")
     args = ap.parse_args()
 
@@ -165,7 +173,9 @@ def main() -> None:
 
     json_path = args.output_dir / "op_distribution_comparison.json"
     md_path = args.output_dir / "op_distribution_comparison.md"
-    json_path.write_text(json.dumps(comp, indent=2, ensure_ascii=False), encoding="utf-8")
+    json_path.write_text(
+        json.dumps(comp, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
     write_markdown(comp, md_path)
     print(f"[OK] {json_path}")
     print(f"[OK] {md_path}")

--- a/.cursor/skills/model-compatibility/scripts/compare_op_distribution.py
+++ b/.cursor/skills/model-compatibility/scripts/compare_op_distribution.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""
+Compare step1 ONNX op distributions (original model vs EP-dumped onnx.onnx).
+
+Usage:
+  python compare_op_distribution.py <original_step1.json> <ep_step1.json> <output_dir>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Tuple
+
+
+def load_counts(step1_path: Path) -> Tuple[Dict[str, int], int]:
+    data = json.loads(step1_path.read_text(encoding="utf-8"))
+    counts: Dict[str, int] = {}
+    total = 0
+    for op_type, info in data.items():
+        if op_type.startswith("_") or not isinstance(info, dict):
+            continue
+        c = int(info.get("count", 0))
+        counts[op_type] = c
+        total += c
+    return counts, total
+
+
+def build_comparison(
+    original_path: Path,
+    ep_path: Path,
+    original_model: str,
+    ep_model: str,
+) -> dict:
+    orig_counts, orig_total = load_counts(original_path)
+    ep_counts, ep_total = load_counts(ep_path)
+
+    all_ops = sorted(set(orig_counts) | set(ep_counts))
+    rows = []
+    only_original = []
+    only_ep = []
+    changed = []
+
+    for op in all_ops:
+        o = orig_counts.get(op, 0)
+        e = ep_counts.get(op, 0)
+        delta = e - o
+        row = {
+            "op_type": op,
+            "original_count": o,
+            "ep_count": e,
+            "delta": delta,
+        }
+        rows.append(row)
+        if o > 0 and e == 0:
+            only_original.append(op)
+        elif e > 0 and o == 0:
+            only_ep.append(op)
+        elif delta != 0:
+            changed.append(row)
+
+    rows.sort(key=lambda r: (-max(r["original_count"], r["ep_count"]), r["op_type"]))
+
+    return {
+        "meta": {
+            "generated_at_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "original_model": original_model,
+            "ep_model": ep_model,
+            "original_step1": str(original_path),
+            "ep_step1": str(ep_path),
+        },
+        "summary": {
+            "original_total_nodes": orig_total,
+            "ep_total_nodes": ep_total,
+            "node_delta": ep_total - orig_total,
+            "original_unique_ops": len(orig_counts),
+            "ep_unique_ops": len(ep_counts),
+            "only_in_original": only_original,
+            "only_in_ep": only_ep,
+            "count_changed_ops": len(changed),
+        },
+        "rows": rows,
+        "changed": changed,
+    }
+
+
+def write_markdown(comp: dict, out_md: Path) -> None:
+    meta = comp["meta"]
+    summary = comp["summary"]
+    lines = [
+        "# Original vs EP input — operator distribution comparison\n\n",
+        f"- **Original model:** `{meta['original_model']}`\n",
+        f"- **EP input (dumped):** `{meta['ep_model']}`\n",
+        f"- **Generated UTC:** `{meta['generated_at_utc']}`\n\n",
+        "## Summary\n\n",
+        f"| Metric | Original | EP input | Delta |\n",
+        f"|---|---:|---:|---:|\n",
+        f"| Total node instances | {summary['original_total_nodes']} | "
+        f"{summary['ep_total_nodes']} | {summary['node_delta']:+d} |\n",
+        f"| Unique operator types | {summary['original_unique_ops']} | "
+        f"{summary['ep_unique_ops']} | "
+        f"{summary['ep_unique_ops'] - summary['original_unique_ops']:+d} |\n\n",
+    ]
+
+    if summary["only_in_original"]:
+        lines.append("### Operators only in original\n\n")
+        for op in summary["only_in_original"]:
+            lines.append(f"- `{op}`\n")
+        lines.append("\n")
+
+    if summary["only_in_ep"]:
+        lines.append("### Operators only in EP input\n\n")
+        for op in summary["only_in_ep"]:
+            lines.append(f"- `{op}`\n")
+        lines.append("\n")
+
+    lines.append("## Full distribution\n\n")
+    lines.append("| Op Type | Original | EP input | Delta |\n")
+    lines.append("|---|---:|---:|---:|\n")
+    for row in comp["rows"]:
+        d = row["delta"]
+        mark = ""
+        if d > 0:
+            mark = " **+**"
+        elif d < 0:
+            mark = " **-**"
+        lines.append(
+            f"| {row['op_type']} | {row['original_count']} | {row['ep_count']} | {d:+d}{mark} |\n"
+        )
+
+    if comp["changed"]:
+        lines.append("\n## Operators with count changes (both present)\n\n")
+        lines.append("| Op Type | Original | EP input | Delta |\n")
+        lines.append("|---|---:|---:|---:|\n")
+        for row in comp["changed"]:
+            if row["original_count"] == 0 or row["ep_count"] == 0:
+                continue
+            lines.append(
+                f"| {row['op_type']} | {row['original_count']} | {row['ep_count']} | {row['delta']:+d} |\n"
+            )
+
+    lines.append(
+        "\n---\n\n"
+        "Compatibility analysis (step2–final) uses **EP input** (`onnx.onnx`) as the graph seen by the EP.\n"
+    )
+    out_md.write_text("".join(lines), encoding="utf-8")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Compare step1 op distributions")
+    ap.add_argument("original_step1", type=Path)
+    ap.add_argument("ep_step1", type=Path)
+    ap.add_argument("output_dir", type=Path)
+    ap.add_argument("--original-model", default="", help="Label for original model path")
+    ap.add_argument("--ep-model", default="", help="Label for EP onnx path")
+    args = ap.parse_args()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    orig_label = args.original_model or str(args.original_step1.parent)
+    ep_label = args.ep_model or str(args.ep_step1.parent)
+
+    comp = build_comparison(args.original_step1, args.ep_step1, orig_label, ep_label)
+
+    json_path = args.output_dir / "op_distribution_comparison.json"
+    md_path = args.output_dir / "op_distribution_comparison.md"
+    json_path.write_text(json.dumps(comp, indent=2, ensure_ascii=False), encoding="utf-8")
+    write_markdown(comp, md_path)
+    print(f"[OK] {json_path}")
+    print(f"[OK] {md_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.cursor/skills/model-compatibility/scripts/dump_ep_onnx.ps1
+++ b/.cursor/skills/model-compatibility/scripts/dump_ep_onnx.ps1
@@ -1,3 +1,8 @@
+##
+## Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+## Licensed under the MIT License.
+##
+
 # Dump EP input ONNX graph (onnx.onnx) via VOE test_onnx_runner + pass.init only.
 
 # Usage:
@@ -313,5 +318,3 @@ if ($exitCode -ne 0) {
 Write-Host "OK: dumped EP ONNX graph ($size bytes)"
 
 Write-Host "    $dumpPath"
-
-

--- a/.cursor/skills/model-compatibility/scripts/dump_ep_onnx.ps1
+++ b/.cursor/skills/model-compatibility/scripts/dump_ep_onnx.ps1
@@ -24,7 +24,7 @@ param(
 
 
 
-    [string]$VoePackageRoot = "D:\Users\mingyue\cp_dev\AIESW-31511\onnx-rt-1250\onnx-rt",
+    [string]$VoePackageRoot = "D:\Users\mingyue\cp_dev\AIESW-34732\onnx-rt",
 
     [string]$DumpDirectory = "",
 
@@ -135,6 +135,10 @@ Write-Host "VITISAI_EP_JSON_CONFIG=only_init_config.json"
 
 Write-Host "XLNX_CONFIG_TARGET_NAME=$VaipTarget"
 
+Write-Host "DEBUG_LOG_LEVEL=info"
+
+Write-Host "DEBUG_VAIP_PASS=1"
+
 Write-Host "provider target=$VaipTarget (init pass dump only)"
 
 Write-Host ""
@@ -146,6 +150,12 @@ $prevVaipConfig = $env:VITISAI_EP_JSON_CONFIG
 $prevProviderOpt = $env:XLNX_EXTERNAL_PROVIDER_OPTION
 
 $prevVaipTarget = $env:XLNX_CONFIG_TARGET_NAME
+
+# Debug env vars for VAIP pass tracing (so we can see why partitioner accepts /
+# rejects subgraphs; output goes to stderr from inside test_onnx_runner.exe).
+$prevDebugLogLevel = $env:DEBUG_LOG_LEVEL
+
+$prevDebugVaipPass = $env:DEBUG_VAIP_PASS
 
 
 
@@ -159,9 +169,35 @@ try {
 
     $env:XLNX_EXTERNAL_PROVIDER_OPTION = $providerOption
 
-    & ".\test_onnx_runner.exe" $ModelPath
+    $env:DEBUG_LOG_LEVEL = "info"
 
-    $exitCode = $LASTEXITCODE
+    $env:DEBUG_VAIP_PASS = "1"
+
+    # When the parent invokes this script under 2>&1 stream merging
+    # (the orchestrator and any caller that captures output does this),
+    # PowerShell converts the first native-stderr line of test_onnx_runner.exe
+    # ("WARNING: Logging before InitGoogleLogging() is written to STDERR",
+    # always emitted by glog at startup) into a terminating NativeCommandError
+    # because $ErrorActionPreference is "Stop" above. That kills the runner
+    # before pass.init can dump onnx.onnx. Localize the relaxation so a real
+    # failure (non-zero $LASTEXITCODE OR missing dump file) still surfaces
+    # via the post-run checks below.
+
+    $savedErrPref = $ErrorActionPreference
+
+    $ErrorActionPreference = 'Continue'
+
+    try {
+
+        & ".\test_onnx_runner.exe" $ModelPath
+
+        $exitCode = $LASTEXITCODE
+
+    } finally {
+
+        $ErrorActionPreference = $savedErrPref
+
+    }
 
 }
 
@@ -196,6 +232,26 @@ finally {
     } else {
 
         $env:XLNX_CONFIG_TARGET_NAME = $prevVaipTarget
+
+    }
+
+    if ($null -eq $prevDebugLogLevel) {
+
+        Remove-Item Env:DEBUG_LOG_LEVEL -ErrorAction SilentlyContinue
+
+    } else {
+
+        $env:DEBUG_LOG_LEVEL = $prevDebugLogLevel
+
+    }
+
+    if ($null -eq $prevDebugVaipPass) {
+
+        Remove-Item Env:DEBUG_VAIP_PASS -ErrorAction SilentlyContinue
+
+    } else {
+
+        $env:DEBUG_VAIP_PASS = $prevDebugVaipPass
 
     }
 

--- a/.cursor/skills/model-compatibility/scripts/dump_ep_onnx.ps1
+++ b/.cursor/skills/model-compatibility/scripts/dump_ep_onnx.ps1
@@ -1,0 +1,244 @@
+# Dump EP input ONNX graph (onnx.onnx) via VOE test_onnx_runner + pass.init only.
+
+# Usage:
+
+#   .\dump_ep_onnx.ps1 -ModelPath "D:\path\to\model.onnx"
+
+#   .\dump_ep_onnx.ps1 -ModelPath "D:\path\to\model.onnx" -DumpFileName "onnx.onnx"
+
+# Dump output defaults to the same directory as the input model.
+
+#
+
+# Uses minimal only_init_config.json (init pass + VAIML target). Forces target via
+
+# XLNX_CONFIG_TARGET_NAME and provider option "target" to avoid mepTable/X2 auto-discovery.
+
+
+
+param(
+
+    [Parameter(Mandatory = $true, Position = 0)]
+
+    [string]$ModelPath,
+
+
+
+    [string]$VoePackageRoot = "D:\Users\mingyue\cp_dev\AIESW-31511\onnx-rt-1250\onnx-rt",
+
+    [string]$DumpDirectory = "",
+
+    [string]$DumpFileName = "",
+
+    [string]$VaipConfigPath = "",
+
+    [string]$VaipTarget = "VAIML"
+
+)
+
+
+
+$ErrorActionPreference = "Stop"
+
+
+
+# ProviderPath avoids "Microsoft.PowerShell.Core\FileSystem::" prefix (breaks native EXE on UNC).
+$ModelPath = (Resolve-Path -LiteralPath $ModelPath).ProviderPath
+
+if ([string]::IsNullOrWhiteSpace($DumpDirectory)) {
+
+    $DumpDirectory = [System.IO.Path]::GetDirectoryName($ModelPath)
+
+}
+
+
+
+$VoeBin = Join-Path $VoePackageRoot "bin"
+
+$RunnerExe = Join-Path $VoeBin "test_onnx_runner.exe"
+
+
+
+if (-not (Test-Path -LiteralPath $RunnerExe)) {
+
+    throw "test_onnx_runner.exe not found: $RunnerExe"
+
+}
+
+
+
+if ([string]::IsNullOrWhiteSpace($VaipConfigPath)) {
+
+    $VaipConfigPath = Join-Path $PSScriptRoot "only_init_config.json"
+
+}
+
+if (-not (Test-Path -LiteralPath $VaipConfigPath)) {
+
+    $fallbackConfig = "D:\Users\mingyue\cp_dev\source\test_onnx_runner\win_scripts\vaip_config.json"
+
+    if (Test-Path -LiteralPath $fallbackConfig) {
+
+        $VaipConfigPath = $fallbackConfig
+
+    }
+
+}
+
+$VaipConfigPath = (Resolve-Path -LiteralPath $VaipConfigPath).ProviderPath
+
+
+
+if ([string]::IsNullOrWhiteSpace($DumpFileName)) {
+
+    $baseName = [System.IO.Path]::GetFileNameWithoutExtension($ModelPath)
+
+    $DumpFileName = "${baseName}_onnx.onnx"
+
+}
+
+
+
+New-Item -ItemType Directory -Force -Path $DumpDirectory | Out-Null
+
+
+
+# EP reads VITISAI_EP_JSON_CONFIG relative to process cwd (VOE bin).
+
+$VaipConfigInBin = Join-Path $VoeBin "only_init_config.json"
+
+Copy-Item -LiteralPath $VaipConfigPath -Destination $VaipConfigInBin -Force
+
+
+
+$providerOption = "a|a pass.init.enable_dump|1 pass.init.directory|$DumpDirectory pass.init.filename|$DumpFileName target|$VaipTarget b|b"
+
+$dumpPath = Join-Path $DumpDirectory $DumpFileName
+
+
+
+Write-Host "Model:           $ModelPath"
+
+Write-Host "VOE bin:         $VoeBin"
+
+Write-Host "Dump directory:  $DumpDirectory"
+
+Write-Host "Dump filename:   $DumpFileName"
+
+Write-Host "Expected output: $dumpPath"
+
+Write-Host "VAIP config:     $VaipConfigPath"
+
+Write-Host "  -> copied to:  $VaipConfigInBin"
+
+Write-Host "VITISAI_EP_JSON_CONFIG=only_init_config.json"
+
+Write-Host "XLNX_CONFIG_TARGET_NAME=$VaipTarget"
+
+Write-Host "provider target=$VaipTarget (init pass dump only)"
+
+Write-Host ""
+
+
+
+$prevVaipConfig = $env:VITISAI_EP_JSON_CONFIG
+
+$prevProviderOpt = $env:XLNX_EXTERNAL_PROVIDER_OPTION
+
+$prevVaipTarget = $env:XLNX_CONFIG_TARGET_NAME
+
+
+
+Push-Location $VoeBin
+
+try {
+
+    $env:VITISAI_EP_JSON_CONFIG = "only_init_config.json"
+
+    $env:XLNX_CONFIG_TARGET_NAME = $VaipTarget
+
+    $env:XLNX_EXTERNAL_PROVIDER_OPTION = $providerOption
+
+    & ".\test_onnx_runner.exe" $ModelPath
+
+    $exitCode = $LASTEXITCODE
+
+}
+
+finally {
+
+    Pop-Location
+
+    if ($null -eq $prevVaipConfig) {
+
+        Remove-Item Env:VITISAI_EP_JSON_CONFIG -ErrorAction SilentlyContinue
+
+    } else {
+
+        $env:VITISAI_EP_JSON_CONFIG = $prevVaipConfig
+
+    }
+
+    if ($null -eq $prevProviderOpt) {
+
+        Remove-Item Env:XLNX_EXTERNAL_PROVIDER_OPTION -ErrorAction SilentlyContinue
+
+    } else {
+
+        $env:XLNX_EXTERNAL_PROVIDER_OPTION = $prevProviderOpt
+
+    }
+
+    if ($null -eq $prevVaipTarget) {
+
+        Remove-Item Env:XLNX_CONFIG_TARGET_NAME -ErrorAction SilentlyContinue
+
+    } else {
+
+        $env:XLNX_CONFIG_TARGET_NAME = $prevVaipTarget
+
+    }
+
+}
+
+
+
+if (-not (Test-Path -LiteralPath $dumpPath)) {
+
+    if ($exitCode -ne 0) {
+
+        throw "test_onnx_runner.exe failed with exit code $exitCode and dump file was not created: $dumpPath"
+
+    }
+
+    throw "Dump file was not created: $dumpPath"
+
+}
+
+
+
+$size = (Get-Item -LiteralPath $dumpPath).Length
+
+if ($size -le 0) {
+
+    throw "Dump file is empty: $dumpPath"
+
+}
+
+
+
+Write-Host ""
+
+if ($exitCode -ne 0) {
+
+    Write-Host "WARN: test_onnx_runner.exe exited with code $exitCode, but dump file exists." -ForegroundColor Yellow
+
+    Write-Host "      (pass.init dump often completes before inference; treating as success.)"
+
+}
+
+Write-Host "OK: dumped EP ONNX graph ($size bytes)"
+
+Write-Host "    $dumpPath"
+
+

--- a/.cursor/skills/model-compatibility/scripts/dump_ep_onnx.ps1
+++ b/.cursor/skills/model-compatibility/scripts/dump_ep_onnx.ps1
@@ -24,7 +24,9 @@ param(
 
 
 
-    [string]$VoePackageRoot = "D:\Users\mingyue\cp_dev\AIESW-34732\onnx-rt",
+    # Default empty so no dev-machine-specific path lives in source.
+    # Resolution order: -VoePackageRoot arg > $env:VOE_PACKAGE_ROOT > error.
+    [string]$VoePackageRoot = "",
 
     [string]$DumpDirectory = "",
 
@@ -48,6 +50,27 @@ $ModelPath = (Resolve-Path -LiteralPath $ModelPath).ProviderPath
 if ([string]::IsNullOrWhiteSpace($DumpDirectory)) {
 
     $DumpDirectory = [System.IO.Path]::GetDirectoryName($ModelPath)
+
+}
+
+
+
+# Resolve VoePackageRoot: -arg first, then $env:VOE_PACKAGE_ROOT.
+# Bail out with a machine-readable marker if still empty so callers
+# (orchestrator or human) get an actionable message instead of a
+# confusing "test_onnx_runner.exe not found: bin\test_onnx_runner.exe".
+
+if ([string]::IsNullOrWhiteSpace($VoePackageRoot) -and $env:VOE_PACKAGE_ROOT) {
+
+    $VoePackageRoot = $env:VOE_PACKAGE_ROOT
+
+}
+
+if ([string]::IsNullOrWhiteSpace($VoePackageRoot)) {
+
+    Write-Output '[VOE_NOT_CONFIGURED] dump_ep_onnx.ps1: no VoePackageRoot. Pass -VoePackageRoot <path> or set env var VOE_PACKAGE_ROOT to the onnx-rt install (the dir containing bin\test_onnx_runner.exe).'
+
+    exit 10
 
 }
 

--- a/.cursor/skills/model-compatibility/scripts/dump_ep_onnx.ps1
+++ b/.cursor/skills/model-compatibility/scripts/dump_ep_onnx.ps1
@@ -98,13 +98,7 @@ if ([string]::IsNullOrWhiteSpace($VaipConfigPath)) {
 
 if (-not (Test-Path -LiteralPath $VaipConfigPath)) {
 
-    $fallbackConfig = "D:\Users\mingyue\cp_dev\source\test_onnx_runner\win_scripts\vaip_config.json"
-
-    if (Test-Path -LiteralPath $fallbackConfig) {
-
-        $VaipConfigPath = $fallbackConfig
-
-    }
+    throw "VAIP config not found: $VaipConfigPath (default ships at scripts/only_init_config.json; pass -VaipConfigPath <file> to override)"
 
 }
 

--- a/.cursor/skills/model-compatibility/scripts/generate_final_reports.py
+++ b/.cursor/skills/model-compatibility/scripts/generate_final_reports.py
@@ -1,0 +1,496 @@
+#!/usr/bin/env python3
+import json
+import sys
+import re
+from pathlib import Path
+from datetime import datetime, timezone
+
+
+def read_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_op_distribution_comparison(analysis_dir: Path):
+    """Load op_distribution_comparison.json from analysis_dir or its parent (EP pipeline layout)."""
+    candidates = [
+        analysis_dir / "op_distribution_comparison.json",
+        analysis_dir.parent / "op_distribution_comparison.json",
+    ]
+    for path in candidates:
+        if path.is_file():
+            try:
+                return read_json(path)
+            except Exception:
+                continue
+    return None
+
+
+def render_op_distribution_comparison_section(comp: dict) -> list:
+    """Markdown lines for original vs EP input (from compare_op_distribution.py JSON)."""
+    meta = comp.get("meta") or {}
+    summary = comp.get("summary") or {}
+    rows = comp.get("rows") or []
+
+    out = []
+    out.append("## Original vs EP input (operator distribution)\n\n")
+    out.append(
+        "Compatibility analysis below uses the **EP input** graph (`onnx.onnx`). "
+        "This section compares it to the packaged **original** ONNX.\n\n"
+    )
+    out.append(f"- **Original model:** `{meta.get('original_model', '—')}`\n")
+    out.append(f"- **EP input (analyzed):** `{meta.get('ep_model', '—')}`\n\n")
+
+    out.append("| Metric | Original | EP input | Delta |\n")
+    out.append("|---|---:|---:|---:|\n")
+    out.append(
+        f"| Total node instances | {summary.get('original_total_nodes', 0)} | "
+        f"{summary.get('ep_total_nodes', 0)} | {summary.get('node_delta', 0):+d} |\n"
+    )
+    out.append(
+        f"| Unique operator types | {summary.get('original_unique_ops', 0)} | "
+        f"{summary.get('ep_unique_ops', 0)} | "
+        f"{int(summary.get('ep_unique_ops', 0)) - int(summary.get('original_unique_ops', 0)):+d} |\n\n"
+    )
+
+    only_orig = summary.get("only_in_original") or []
+    only_ep = summary.get("only_in_ep") or []
+    if only_orig:
+        out.append("**Operators only in original:** " + ", ".join(f"`{x}`" for x in only_orig) + "\n\n")
+    if only_ep:
+        out.append("**Operators only in EP input:** " + ", ".join(f"`{x}`" for x in only_ep) + "\n\n")
+
+    out.append("| Op Type | Original | EP input | Delta |\n")
+    out.append("|---|---:|---:|---:|\n")
+    for row in rows:
+        d = int(row.get("delta", 0))
+        mark = " **+**" if d > 0 else (" **-**" if d < 0 else "")
+        out.append(
+            f"| {row.get('op_type', '')} | {row.get('original_count', 0)} | "
+            f"{row.get('ep_count', 0)} | {d:+d}{mark} |\n"
+        )
+    out.append("\n")
+    return out
+
+
+def parse_step2_operator_summary(step2_md: Path):
+    if not step2_md.exists():
+        return []
+    lines = step2_md.read_text(encoding="utf-8").splitlines()
+    in_section = False
+    table_lines = []
+    for line in lines:
+        if line.strip() == "## Operator Summary":
+            in_section = True
+            continue
+        if in_section and line.startswith("## "):
+            break
+        if in_section and line.strip().startswith("|"):
+            table_lines.append(line)
+    return table_lines
+
+
+def status_display(status: str) -> str:
+    return "supported" if status == "full" else status
+
+
+def compile_time_reason(reason_texts):
+    terms = [
+        "compile time",
+        "compile-time",
+        "constant folding",
+        "shape inference",
+        "shape manipulation",
+        "type-canonicalization",
+    ]
+    merged = " ".join(reason_texts or []).lower()
+    return any(t in merged for t in terms)
+
+
+def load_reco_rules(script_dir: Path):
+    cfg = script_dir / "unsupported_reco_rules.json"
+    if cfg.exists():
+        try:
+            return read_json(cfg)
+        except Exception:
+            pass
+    return {}
+
+
+def compile_time_reason_with_rules(reason_texts, rules):
+    terms = (((rules or {}).get("compile_time_rule") or {}).get("when_reason_contains_any")) or []
+    if not terms:
+        return compile_time_reason(reason_texts)
+    merged = " ".join(reason_texts or []).lower()
+    return any(str(t).lower() in merged for t in terms)
+
+
+def format_reco(path: str, target: str):
+    p = (path or "").strip()
+    t = (target or "").strip()
+    if not p:
+        return "Custom Hip Kernel"
+    if not t or t in {"none", "-"}:
+        return p
+    return f"{p} (extend `{t}`)"
+
+
+def infer_unsupported_reco(op_name: str, op_description: str, rules):
+    name_l = (op_name or "").lower()
+    desc_l = (op_description or "").lower()
+
+    def has_keyword(text: str, kw: str) -> bool:
+        return re.search(rf"(^|[^a-z0-9]){re.escape(kw)}([^a-z0-9]|$)", text) is not None
+
+    # Exact op override has the highest priority.
+    for item in (rules.get("op_overrides") or []):
+        if (item.get("op_name") or "").lower() == name_l:
+            return {
+                "recommended": format_reco(item.get("recommended_path"), item.get("wrapper_extension_target")),
+                "source": "op_override",
+                "matched_rule": item.get("op_name"),
+                "rationale": item.get("rationale", ""),
+            }
+
+    # Family routing by op name / description semantics.
+    for fam in (rules.get("family_routing") or []):
+        kws = [str(x).lower() for x in (fam.get("op_name_keywords_any") or [])]
+        if any(k and (has_keyword(name_l, k) or has_keyword(desc_l, k)) for k in kws):
+            return {
+                "recommended": format_reco(fam.get("preferred_path"), fam.get("wrapper_extension_target")),
+                "source": "family_routing",
+                "matched_rule": fam.get("family"),
+                "rationale": fam.get("notes", ""),
+            }
+
+    # Fallback
+    default_fb = rules.get("default_fallback") or {}
+    return {
+        "recommended": format_reco(default_fb.get("recommended_path"), default_fb.get("wrapper_extension_target")),
+        "source": "default_fallback",
+        "matched_rule": "default_fallback",
+        "rationale": default_fb.get("rationale", ""),
+    }
+
+
+def recommended_impl_with_trace(op_row, compat_row, reco_rules):
+    status = op_row.get("status")
+    hip_op = op_row.get("hip_op")
+    backend = op_row.get("backend")
+    runtime = op_row.get("runtime_func")
+    if status in {"full", "partial"}:
+        if hip_op and hip_op.startswith("tensor."):
+            return {
+                "recommended": "Compile Time Optimization",
+                "source": "supported_tensor_compile_time",
+                "matched_rule": "tensor.*",
+                "rationale": "Mapped tensor op handled at compile time.",
+            }
+        if backend and backend != "Unknown" and runtime:
+            return {
+                "recommended": f"{backend} (`{runtime}`)",
+                "source": "supported_backend_runtime",
+                "matched_rule": "backend+runtime",
+                "rationale": "",
+            }
+        if backend and backend != "Unknown":
+            return {
+                "recommended": backend,
+                "source": "supported_backend_only",
+                "matched_rule": "backend",
+                "rationale": "",
+            }
+        if runtime:
+            return {
+                "recommended": f"`{runtime}`",
+                "source": "supported_runtime_only",
+                "matched_rule": "runtime",
+                "rationale": "",
+            }
+        return {
+            "recommended": "Unknown",
+            "source": "supported_unknown",
+            "matched_rule": "unknown",
+            "rationale": "",
+        }
+
+    if compile_time_reason_with_rules((compat_row or {}).get("reason_texts") or [], reco_rules):
+        return {
+            "recommended": "Compile Time Optimization",
+            "source": "compile_time_reason",
+            "matched_rule": "compile_time_rule",
+            "rationale": ((reco_rules.get("compile_time_rule") or {}).get("rationale")) or "",
+        }
+    return infer_unsupported_reco(
+        op_row.get("onnx_op", ""),
+        resolve_op_description(op_row),
+        reco_rules or {},
+    )
+
+
+def recommended_impl(op_row, compat_row, reco_rules):
+    return recommended_impl_with_trace(op_row, compat_row, reco_rules)["recommended"]
+
+
+def fmt_data_types(dtypes):
+    return ", ".join(dtypes) if dtypes else "-"
+
+
+def humanize_camel(name: str) -> str:
+    out = []
+    for i, ch in enumerate(name):
+        if i > 0 and ch.isupper() and (not name[i - 1].isupper()):
+            out.append(" ")
+        out.append(ch)
+    return "".join(out)
+
+
+def resolve_op_description(op_row):
+    op = op_row.get("onnx_op", "") or ""
+    domain = op_row.get("domain", "") or ""
+    existing = op_row.get("op_description")
+    if isinstance(existing, str) and existing.strip() and existing.strip() != "—":
+        return existing.strip()
+
+    # Try ONNX schema docs first for standard domain.
+    if domain in {"onnx", "ai.onnx", ""}:
+        try:
+            from onnx import defs
+
+            schema = defs.get_schema(op, domain="")
+            doc = " ".join((schema.doc or "").split())
+            if doc:
+                return doc.split(". ")[0].strip().rstrip(".")
+        except Exception:
+            pass
+
+    # Curated custom-domain descriptions.
+    custom_map = {
+        "CausalConvWithState": "Causal convolution with recurrent state cache update (com.microsoft)",
+        "LinearAttention": "Linear attention operator with stateful/key-value efficient computation (com.microsoft)",
+    }
+    if op in custom_map:
+        return custom_map[op]
+
+    # Last-resort semantic description from op name.
+    return f"{humanize_camel(op)} operation ({domain})"
+
+
+def main():
+    if len(sys.argv) != 2:
+        raise SystemExit("Usage: python generate_final_reports.py <analysis_dir>")
+
+    analysis_dir = Path(sys.argv[1])
+    script_dir = Path(__file__).resolve().parent
+    reco_rules = load_reco_rules(script_dir)
+    report_input = read_json(analysis_dir / "report_input.json")
+    step2_table = parse_step2_operator_summary(analysis_dir / "step2_hip_ops.md")
+    op_dist_comparison = load_op_distribution_comparison(analysis_dir)
+
+    meta = report_input["meta"]
+    summary = report_input["summary"]
+    op_dist = report_input["operator_distribution"]
+    mapping_chain = report_input["mapping_chain"]
+    compatibility = report_input["compatibility"]
+
+    compat_map = {(c.get("onnx_op"), c.get("domain")): c for c in compatibility}
+
+    total_instances = summary["total_node_instances"]
+    supported_instances = summary["supported_instances"]
+    supported_pct = (supported_instances / total_instances * 100.0) if total_instances else 0.0
+
+    # Main report
+    lines = []
+    lines.append("# Model compatibility report\n")
+    lines.append(f"- **EP input (compatibility target):** `{meta['model_path']}`\n")
+    if op_dist_comparison:
+        orig_path = (op_dist_comparison.get("meta") or {}).get("original_model", "")
+        if orig_path:
+            lines.append(f"- **Original model:** `{orig_path}`\n")
+    lines.append(f"- Generated UTC: `{meta['generated_at_utc']}`\n\n")
+    lines.append("## Summary\n\n")
+    lines.append(f"- Total node instances: {summary['total_node_instances']}\n")
+    lines.append(f"- Supported instances: {summary['supported_instances']} ({supported_pct:.1f}%)\n")
+    lines.append(f"- Unsupported instances: {summary['unsupported_instances']}\n")
+    lines.append(f"- Total Operator Types: {summary['total_operator_types']}\n")
+    lines.append(f"- Fully Compatible: {summary['fully_compatible_operator_types']}\n")
+    lines.append(f"- Partially Compatible: {summary['partially_compatible_operator_types']}\n")
+    lines.append(f"- Unsupported: {summary['unsupported_operator_types']}\n\n")
+
+    if op_dist_comparison:
+        lines.extend(render_op_distribution_comparison_section(op_dist_comparison))
+
+    lines.append("## Operator Distribution with Compatibility Status\n\n")
+    lines.append(
+        "_Counts and status below refer to the **EP input** graph only._\n\n"
+        if op_dist_comparison
+        else ""
+    )
+    lines.append("| Op Type | Domain | Count | Data Types | Recommended Rocm Implementation | Status | Op Description |\n")
+    lines.append("|---|---|---:|---|---|---|---|\n")
+
+    unsupported_buckets = {}
+    supported_ops = []
+    partial_ops = []
+    unsupported_ops = []
+    unsupported_runtime_entries = []
+
+    for row in op_dist:
+        key = (row.get("onnx_op"), row.get("domain"))
+        comp = compat_map.get(key, {})
+        reco_trace = recommended_impl_with_trace(row, comp, reco_rules)
+        reco = reco_trace["recommended"]
+        disp = status_display(row.get("status", ""))
+        op = row.get("onnx_op", "")
+        dom = row.get("domain", "")
+        cnt = row.get("count", 0)
+        desc = resolve_op_description(row)
+        lines.append(
+            f"| {op} | {dom} | {cnt} | {fmt_data_types(row.get('data_types') or [])} | {reco} | {disp} | {desc} |\n"
+        )
+        if disp == "supported":
+            supported_ops.append(
+                {
+                    "onnx_op": op,
+                    "hip_op": row.get("hip_op") or "-",
+                }
+            )
+        elif disp == "partial":
+            partial_ops.append(op)
+        else:
+            reason_texts = comp.get("reason_texts") or []
+            reason_text = "; ".join(reason_texts) if reason_texts else "No Hip Dialect implementation available."
+            unsupported_ops.append(
+                {
+                    "onnx_op": op,
+                    "reason": reason_text,
+                }
+            )
+            unsupported_buckets.setdefault(reco, []).append(op)
+            unsupported_runtime_entries.append(
+                {
+                    "onnx_op": op,
+                    "domain": dom,
+                    "count": row.get("count", 0),
+                    "op_description": desc,
+                    "reason_codes": comp.get("reason_codes") or [],
+                    "reason_texts": comp.get("reason_texts") or [],
+                    "recommended_path": reco,
+                    "recommendation_source": reco_trace.get("source", ""),
+                    "matched_rule": reco_trace.get("matched_rule", ""),
+                    "rationale": reco_trace.get("rationale", ""),
+                }
+            )
+
+    lines.append("\n### Compatibility Summary\n\n")
+    lines.append(f"#### Fully Compatible Operator ({len(supported_ops)})\n\n")
+    for item in supported_ops:
+        lines.append(f"- `{item['onnx_op']}` -> `{item['hip_op']}`\n")
+    lines.append("\n")
+    lines.append(f"#### Partially Compatible Operators ({len(partial_ops)}):\n\n")
+    for p in partial_ops:
+        c = compat_map.get((p, next((r["domain"] for r in op_dist if r["onnx_op"] == p), "onnx")), {})
+        reasons = c.get("reason_texts") or []
+        reason_text = "; ".join(reasons) if reasons else "Schema mismatch."
+        lines.append(f"- `{p}`: {reason_text}\n")
+    lines.append("\n")
+    lines.append(f"#### Unsupported Operators ({len(unsupported_ops)}):\n\n")
+    for item in unsupported_ops:
+        lines.append(f"- {item['onnx_op']}: {item['reason']}\n")
+    lines.append("\n")
+
+    lines.append("Unsupported operator recommendation buckets\n\n")
+    for k, ops in sorted(unsupported_buckets.items(), key=lambda x: x[0]):
+        lines.append(f"- {k}: " + ", ".join(f"`{x}`" for x in ops) + "\n")
+    lines.append("\n")
+
+    lines.append("## Hip Ops Summary\n\n")
+    if step2_table:
+        for tl in step2_table:
+            lines.append(tl + "\n")
+    else:
+        lines.append("| Metric | Value |\n|---|---:|\n| Hip operator summary | — |\n")
+    lines.append("\n")
+
+    lines.append("## ONNX-HIP-RUNTIME Mapping\n\n")
+    lines.append("| ONNX Op | Domain | Hip Op | Runtime Func | Backend |\n")
+    lines.append("|---|---|---|---|---|\n")
+    for m in mapping_chain:
+        runtime = m.get("runtime_func") or "-"
+        backend = m.get("backend") or "Unknown"
+        lines.append(
+            f"| {m.get('onnx_op','')} | {m.get('domain','')} | {m.get('hip_op','')} | {runtime} | {backend} |\n"
+        )
+    lines.append("\nDetailed compatibility diagnostics are in model_compatibility_details.md\n")
+
+    (analysis_dir / "model_compatibility_report.md").write_text("".join(lines), encoding="utf-8")
+
+    # Details report
+    d = []
+    d.append("# Model compatibility details\n\n")
+    d.append(f"- **EP input (compatibility target):** `{meta['model_path']}`\n")
+    if op_dist_comparison:
+        orig_path = (op_dist_comparison.get("meta") or {}).get("original_model", "")
+        if orig_path:
+            d.append(f"- **Original model:** `{orig_path}`\n")
+    d.append(f"- Generated UTC: `{meta['generated_at_utc']}`\n\n")
+    if op_dist_comparison:
+        d.extend(render_op_distribution_comparison_section(op_dist_comparison))
+
+    d.append("## Supported operators table (full)\n\n")
+    d.append("| Op Type | Domain | Count | Recommended Rocm Implementation |\n")
+    d.append("|---|---|---:|---|\n")
+    for row in op_dist:
+        if status_display(row.get("status", "")) == "supported":
+            comp = compat_map.get((row.get("onnx_op"), row.get("domain")), {})
+            d.append(
+                f"| {row.get('onnx_op','')} | {row.get('domain','')} | {row.get('count',0)} | {recommended_impl(row, comp, reco_rules)} |\n"
+            )
+
+    d.append("\n## Partially compatible details\n\n")
+    d.append("| Op Type | Domain | Reason Codes | Reason Texts | Evidence |\n")
+    d.append("|---|---|---|---|---|\n")
+    for row in compatibility:
+        if row.get("status") == "partial":
+            ev = row.get("evidence") or []
+            ev_text = "; ".join(f"{e.get('source_file','')}:{e.get('json_pointer','')}" for e in ev) if ev else "-"
+            d.append(
+                f"| {row.get('onnx_op','')} | {row.get('domain','')} | {', '.join(row.get('reason_codes') or []) or '-'} | {'; '.join(row.get('reason_texts') or []) or '-'} | {ev_text} |\n"
+            )
+
+    d.append("\n## Unsupported operators\n\n")
+    d.append("| Op Type | Domain | Count | Reason |\n")
+    d.append("|---|---|---:|---|\n")
+    for row in op_dist:
+        if status_display(row.get("status", "")) == "unsupported":
+            comp = compat_map.get((row.get("onnx_op"), row.get("domain")), {})
+            reason = "; ".join(comp.get("reason_texts") or []) or "No Hip Dialect implementation available."
+            d.append(f"| {row.get('onnx_op','')} | {row.get('domain','')} | {row.get('count',0)} | {reason} |\n")
+
+    d.append("\n## Data quality notes\n\n")
+    d.append("- None.\n")
+
+    (analysis_dir / "model_compatibility_details.md").write_text("".join(d), encoding="utf-8")
+    runtime_json = {
+        "meta": {
+            "model_path": meta.get("model_path"),
+            "generated_at_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "rules_version": reco_rules.get("version", "unknown"),
+        },
+        "summary": {
+            "unsupported_operator_types": len(unsupported_runtime_entries),
+            "unsupported_node_instances": int(
+                sum(int(x.get("count", 0)) for x in unsupported_runtime_entries)
+            ),
+        },
+        "unsupported_recommendations": unsupported_runtime_entries,
+    }
+    (analysis_dir / "unsupported_reco_runtime.json").write_text(
+        json.dumps(runtime_json, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    print(f"Wrote {(analysis_dir / 'model_compatibility_report.md')}")
+    print(f"Wrote {(analysis_dir / 'model_compatibility_details.md')}")
+    print(f"Wrote {(analysis_dir / 'unsupported_reco_runtime.json')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.cursor/skills/model-compatibility/scripts/generate_final_reports.py
+++ b/.cursor/skills/model-compatibility/scripts/generate_final_reports.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
 import json
 import sys
 import re
@@ -55,9 +59,17 @@ def render_op_distribution_comparison_section(comp: dict) -> list:
     only_orig = summary.get("only_in_original") or []
     only_ep = summary.get("only_in_ep") or []
     if only_orig:
-        out.append("**Operators only in original:** " + ", ".join(f"`{x}`" for x in only_orig) + "\n\n")
+        out.append(
+            "**Operators only in original:** "
+            + ", ".join(f"`{x}`" for x in only_orig)
+            + "\n\n"
+        )
     if only_ep:
-        out.append("**Operators only in EP input:** " + ", ".join(f"`{x}`" for x in only_ep) + "\n\n")
+        out.append(
+            "**Operators only in EP input:** "
+            + ", ".join(f"`{x}`" for x in only_ep)
+            + "\n\n"
+        )
 
     out.append("| Op Type | Original | EP input | Delta |\n")
     out.append("|---|---:|---:|---:|\n")
@@ -117,7 +129,9 @@ def load_reco_rules(script_dir: Path):
 
 
 def compile_time_reason_with_rules(reason_texts, rules):
-    terms = (((rules or {}).get("compile_time_rule") or {}).get("when_reason_contains_any")) or []
+    terms = (
+        ((rules or {}).get("compile_time_rule") or {}).get("when_reason_contains_any")
+    ) or []
     if not terms:
         return compile_time_reason(reason_texts)
     merged = " ".join(reason_texts or []).lower()
@@ -139,24 +153,30 @@ def infer_unsupported_reco(op_name: str, op_description: str, rules):
     desc_l = (op_description or "").lower()
 
     def has_keyword(text: str, kw: str) -> bool:
-        return re.search(rf"(^|[^a-z0-9]){re.escape(kw)}([^a-z0-9]|$)", text) is not None
+        return (
+            re.search(rf"(^|[^a-z0-9]){re.escape(kw)}([^a-z0-9]|$)", text) is not None
+        )
 
     # Exact op override has the highest priority.
-    for item in (rules.get("op_overrides") or []):
+    for item in rules.get("op_overrides") or []:
         if (item.get("op_name") or "").lower() == name_l:
             return {
-                "recommended": format_reco(item.get("recommended_path"), item.get("wrapper_extension_target")),
+                "recommended": format_reco(
+                    item.get("recommended_path"), item.get("wrapper_extension_target")
+                ),
                 "source": "op_override",
                 "matched_rule": item.get("op_name"),
                 "rationale": item.get("rationale", ""),
             }
 
     # Family routing by op name / description semantics.
-    for fam in (rules.get("family_routing") or []):
+    for fam in rules.get("family_routing") or []:
         kws = [str(x).lower() for x in (fam.get("op_name_keywords_any") or [])]
         if any(k and (has_keyword(name_l, k) or has_keyword(desc_l, k)) for k in kws):
             return {
-                "recommended": format_reco(fam.get("preferred_path"), fam.get("wrapper_extension_target")),
+                "recommended": format_reco(
+                    fam.get("preferred_path"), fam.get("wrapper_extension_target")
+                ),
                 "source": "family_routing",
                 "matched_rule": fam.get("family"),
                 "rationale": fam.get("notes", ""),
@@ -165,7 +185,10 @@ def infer_unsupported_reco(op_name: str, op_description: str, rules):
     # Fallback
     default_fb = rules.get("default_fallback") or {}
     return {
-        "recommended": format_reco(default_fb.get("recommended_path"), default_fb.get("wrapper_extension_target")),
+        "recommended": format_reco(
+            default_fb.get("recommended_path"),
+            default_fb.get("wrapper_extension_target"),
+        ),
         "source": "default_fallback",
         "matched_rule": "default_fallback",
         "rationale": default_fb.get("rationale", ""),
@@ -213,12 +236,15 @@ def recommended_impl_with_trace(op_row, compat_row, reco_rules):
             "rationale": "",
         }
 
-    if compile_time_reason_with_rules((compat_row or {}).get("reason_texts") or [], reco_rules):
+    if compile_time_reason_with_rules(
+        (compat_row or {}).get("reason_texts") or [], reco_rules
+    ):
         return {
             "recommended": "Compile Time Optimization",
             "source": "compile_time_reason",
             "matched_rule": "compile_time_rule",
-            "rationale": ((reco_rules.get("compile_time_rule") or {}).get("rationale")) or "",
+            "rationale": ((reco_rules.get("compile_time_rule") or {}).get("rationale"))
+            or "",
         }
     return infer_unsupported_reco(
         op_row.get("onnx_op", ""),
@@ -296,7 +322,9 @@ def main():
 
     total_instances = summary["total_node_instances"]
     supported_instances = summary["supported_instances"]
-    supported_pct = (supported_instances / total_instances * 100.0) if total_instances else 0.0
+    supported_pct = (
+        (supported_instances / total_instances * 100.0) if total_instances else 0.0
+    )
 
     # Main report
     lines = []
@@ -309,11 +337,15 @@ def main():
     lines.append(f"- Generated UTC: `{meta['generated_at_utc']}`\n\n")
     lines.append("## Summary\n\n")
     lines.append(f"- Total node instances: {summary['total_node_instances']}\n")
-    lines.append(f"- Supported instances: {summary['supported_instances']} ({supported_pct:.1f}%)\n")
+    lines.append(
+        f"- Supported instances: {summary['supported_instances']} ({supported_pct:.1f}%)\n"
+    )
     lines.append(f"- Unsupported instances: {summary['unsupported_instances']}\n")
     lines.append(f"- Total Operator Types: {summary['total_operator_types']}\n")
     lines.append(f"- Fully Compatible: {summary['fully_compatible_operator_types']}\n")
-    lines.append(f"- Partially Compatible: {summary['partially_compatible_operator_types']}\n")
+    lines.append(
+        f"- Partially Compatible: {summary['partially_compatible_operator_types']}\n"
+    )
     lines.append(f"- Unsupported: {summary['unsupported_operator_types']}\n\n")
 
     if op_dist_comparison:
@@ -325,7 +357,9 @@ def main():
         if op_dist_comparison
         else ""
     )
-    lines.append("| Op Type | Domain | Count | Data Types | Recommended Rocm Implementation | Status | Op Description |\n")
+    lines.append(
+        "| Op Type | Domain | Count | Data Types | Recommended Rocm Implementation | Status | Op Description |\n"
+    )
     lines.append("|---|---|---:|---|---|---|---|\n")
 
     unsupported_buckets = {}
@@ -358,7 +392,11 @@ def main():
             partial_ops.append(op)
         else:
             reason_texts = comp.get("reason_texts") or []
-            reason_text = "; ".join(reason_texts) if reason_texts else "No Hip Dialect implementation available."
+            reason_text = (
+                "; ".join(reason_texts)
+                if reason_texts
+                else "No Hip Dialect implementation available."
+            )
             unsupported_ops.append(
                 {
                     "onnx_op": op,
@@ -388,7 +426,9 @@ def main():
     lines.append("\n")
     lines.append(f"#### Partially Compatible Operators ({len(partial_ops)}):\n\n")
     for p in partial_ops:
-        c = compat_map.get((p, next((r["domain"] for r in op_dist if r["onnx_op"] == p), "onnx")), {})
+        c = compat_map.get(
+            (p, next((r["domain"] for r in op_dist if r["onnx_op"] == p), "onnx")), {}
+        )
         reasons = c.get("reason_texts") or []
         reason_text = "; ".join(reasons) if reasons else "Schema mismatch."
         lines.append(f"- `{p}`: {reason_text}\n")
@@ -418,11 +458,15 @@ def main():
         runtime = m.get("runtime_func") or "-"
         backend = m.get("backend") or "Unknown"
         lines.append(
-            f"| {m.get('onnx_op','')} | {m.get('domain','')} | {m.get('hip_op','')} | {runtime} | {backend} |\n"
+            f"| {m.get('onnx_op', '')} | {m.get('domain', '')} | {m.get('hip_op', '')} | {runtime} | {backend} |\n"
         )
-    lines.append("\nDetailed compatibility diagnostics are in model_compatibility_details.md\n")
+    lines.append(
+        "\nDetailed compatibility diagnostics are in model_compatibility_details.md\n"
+    )
 
-    (analysis_dir / "model_compatibility_report.md").write_text("".join(lines), encoding="utf-8")
+    (analysis_dir / "model_compatibility_report.md").write_text(
+        "".join(lines), encoding="utf-8"
+    )
 
     # Details report
     d = []
@@ -443,7 +487,7 @@ def main():
         if status_display(row.get("status", "")) == "supported":
             comp = compat_map.get((row.get("onnx_op"), row.get("domain")), {})
             d.append(
-                f"| {row.get('onnx_op','')} | {row.get('domain','')} | {row.get('count',0)} | {recommended_impl(row, comp, reco_rules)} |\n"
+                f"| {row.get('onnx_op', '')} | {row.get('domain', '')} | {row.get('count', 0)} | {recommended_impl(row, comp, reco_rules)} |\n"
             )
 
     d.append("\n## Partially compatible details\n\n")
@@ -452,9 +496,16 @@ def main():
     for row in compatibility:
         if row.get("status") == "partial":
             ev = row.get("evidence") or []
-            ev_text = "; ".join(f"{e.get('source_file','')}:{e.get('json_pointer','')}" for e in ev) if ev else "-"
+            ev_text = (
+                "; ".join(
+                    f"{e.get('source_file', '')}:{e.get('json_pointer', '')}"
+                    for e in ev
+                )
+                if ev
+                else "-"
+            )
             d.append(
-                f"| {row.get('onnx_op','')} | {row.get('domain','')} | {', '.join(row.get('reason_codes') or []) or '-'} | {'; '.join(row.get('reason_texts') or []) or '-'} | {ev_text} |\n"
+                f"| {row.get('onnx_op', '')} | {row.get('domain', '')} | {', '.join(row.get('reason_codes') or []) or '-'} | {'; '.join(row.get('reason_texts') or []) or '-'} | {ev_text} |\n"
             )
 
     d.append("\n## Unsupported operators\n\n")
@@ -463,17 +514,26 @@ def main():
     for row in op_dist:
         if status_display(row.get("status", "")) == "unsupported":
             comp = compat_map.get((row.get("onnx_op"), row.get("domain")), {})
-            reason = "; ".join(comp.get("reason_texts") or []) or "No Hip Dialect implementation available."
-            d.append(f"| {row.get('onnx_op','')} | {row.get('domain','')} | {row.get('count',0)} | {reason} |\n")
+            reason = (
+                "; ".join(comp.get("reason_texts") or [])
+                or "No Hip Dialect implementation available."
+            )
+            d.append(
+                f"| {row.get('onnx_op', '')} | {row.get('domain', '')} | {row.get('count', 0)} | {reason} |\n"
+            )
 
     d.append("\n## Data quality notes\n\n")
     d.append("- None.\n")
 
-    (analysis_dir / "model_compatibility_details.md").write_text("".join(d), encoding="utf-8")
+    (analysis_dir / "model_compatibility_details.md").write_text(
+        "".join(d), encoding="utf-8"
+    )
     runtime_json = {
         "meta": {
             "model_path": meta.get("model_path"),
-            "generated_at_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "generated_at_utc": datetime.now(timezone.utc).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            ),
             "rules_version": reco_rules.get("version", "unknown"),
         },
         "summary": {

--- a/.cursor/skills/model-compatibility/scripts/hip_td_mnemonics.py
+++ b/.cursor/skills/model-compatibility/scripts/hip_td_mnemonics.py
@@ -1,3 +1,7 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
 """
 Shared TableGen helper: map mlir::hip C++ op class (e.g. ReduceSumOp) to the
 string inside Hip_(Dps)Op<"…"> in HipOps.td (e.g. reduce_sum → hip.reduce_sum).

--- a/.cursor/skills/model-compatibility/scripts/hip_td_mnemonics.py
+++ b/.cursor/skills/model-compatibility/scripts/hip_td_mnemonics.py
@@ -1,0 +1,45 @@
+"""
+Shared TableGen helper: map mlir::hip C++ op class (e.g. ReduceSumOp) to the
+string inside Hip_(Dps)Op<"…"> in HipOps.td (e.g. reduce_sum → hip.reduce_sum).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Dict
+
+_HIP_DEF_RE = re.compile(r"def\s+(Hip_\w+Op)\s*:\s*([^{]+)\s*\{", re.DOTALL)
+_HIP_MNEMONIC_RE = re.compile(r'Hip_(?:Dps)?Op<\s*"([^"]+)"')
+
+
+def load_cpp_op_class_to_mnemonic_from_td(td_path: Path) -> Dict[str, str]:
+    """
+    Returns e.g. {"ReduceSumOp": "reduce_sum", "MiopenSoftmaxOp": "miopen.softmax"}.
+    Keys match ConvertOpToLLVMPattern<ReduceSumOp> template parameters in C++.
+    """
+    text = td_path.read_text(encoding="utf-8")
+    out: Dict[str, str] = {}
+    for m in _HIP_DEF_RE.finditer(text):
+        tablegen_def = m.group(1).strip()
+        base = m.group(2).strip()
+        mm = _HIP_MNEMONIC_RE.search(base)
+        if not mm:
+            continue
+        if not tablegen_def.startswith("Hip_"):
+            continue
+        cpp_class = tablegen_def[len("Hip_") :]
+        out[cpp_class] = mm.group(1)
+    return out
+
+
+def default_hip_ops_td_path(conversion_dir: Path) -> Path:
+    """lib/Conversion -> repo root -> include/hip/Dialect/IR/HipOps.td"""
+    return (
+        conversion_dir.parent.parent
+        / "include"
+        / "hip"
+        / "Dialect"
+        / "IR"
+        / "HipOps.td"
+    )

--- a/.cursor/skills/model-compatibility/scripts/only_init_config.json
+++ b/.cursor/skills/model-compatibility/scripts/only_init_config.json
@@ -1,0 +1,15 @@
+{
+    "passes": [
+        {
+            "name": "init",
+            "plugin": "vaip-pass_init"
+        }
+    ],
+    "target": "VAIML",
+    "targets": [
+        {
+            "name": "VAIML",
+            "pass": [ "init" ]
+         },
+    ]
+}

--- a/.cursor/skills/model-compatibility/scripts/onnx_graph_walk.py
+++ b/.cursor/skills/model-compatibility/scripts/onnx_graph_walk.py
@@ -1,0 +1,52 @@
+"""Traverse ONNX GraphProto nodes including nested subgraph attributes."""
+
+from __future__ import annotations
+
+from typing import Iterator, Tuple
+
+import onnx
+from onnx import GraphProto, NodeProto
+
+
+def iter_graph_nodes(
+    graph: GraphProto,
+    scope: str = "main",
+) -> Iterator[Tuple[NodeProto, str]]:
+    """
+    Yield (node, scope) for every node in `graph` and nested subgraphs.
+
+    Nested graphs are reached via node attributes of type GRAPH or GRAPHS
+    (e.g. Loop/If/Scan bodies, custom ops with embedded graphs).
+    """
+    for node in graph.node:
+        yield node, scope
+        for attr in node.attribute:
+            if attr.type == onnx.AttributeProto.GRAPH:
+                child = f"{scope}/{node.op_type}.{attr.name}"
+                yield from iter_graph_nodes(attr.g, child)
+            elif attr.type == onnx.AttributeProto.GRAPHS:
+                for idx, sub_graph in enumerate(attr.graphs):
+                    child = f"{scope}/{node.op_type}.{attr.name}[{idx}]"
+                    yield from iter_graph_nodes(sub_graph, child)
+
+
+def iter_model_nodes(model: onnx.ModelProto) -> Iterator[Tuple[NodeProto, str]]:
+    """Yield all nodes from the model's top-level graph and nested subgraphs."""
+    yield from iter_graph_nodes(model.graph)
+
+
+def count_nodes_by_op(
+    model: onnx.ModelProto,
+    *,
+    top_level_only: bool = False,
+) -> Tuple[int, int]:
+    """Return (total_node_count, unique_op_type_count)."""
+    if top_level_only:
+        nodes = model.graph.node
+        return len(nodes), len({n.op_type for n in nodes})
+    counts = set()
+    total = 0
+    for node, _ in iter_model_nodes(model):
+        total += 1
+        counts.add(node.op_type)
+    return total, len(counts)

--- a/.cursor/skills/model-compatibility/scripts/onnx_graph_walk.py
+++ b/.cursor/skills/model-compatibility/scripts/onnx_graph_walk.py
@@ -1,3 +1,7 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
 """Traverse ONNX GraphProto nodes including nested subgraph attributes."""
 
 from __future__ import annotations

--- a/.cursor/skills/model-compatibility/scripts/report_input.schema.json
+++ b/.cursor/skills/model-compatibility/scripts/report_input.schema.json
@@ -1,0 +1,320 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.local/schemas/report_input.schema.json",
+  "title": "ONNX-HIP Compatibility Report Input",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "meta",
+    "summary",
+    "operator_distribution",
+    "mapping_chain",
+    "compatibility",
+    "reason_catalog"
+  ],
+  "properties": {
+    "meta": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "model_path",
+        "generated_at_utc",
+        "repo_root",
+        "tool_versions"
+      ],
+      "properties": {
+        "model_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "generated_at_utc": {
+          "type": "string",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T"
+        },
+        "repo_root": {
+          "type": "string",
+          "minLength": 1
+        },
+        "git_sha": {
+          "type": "string"
+        },
+        "tool_versions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "total_node_instances",
+        "supported_instances",
+        "unsupported_instances",
+        "total_operator_types",
+        "fully_compatible_operator_types",
+        "partially_compatible_operator_types",
+        "unsupported_operator_types"
+      ],
+      "properties": {
+        "total_node_instances": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "supported_instances": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "unsupported_instances": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "total_operator_types": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "fully_compatible_operator_types": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "partially_compatible_operator_types": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "unsupported_operator_types": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "operator_distribution": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/operatorDistributionRow"
+      }
+    },
+    "mapping_chain": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/mappingChainRow"
+      }
+    },
+    "compatibility": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/compatibilityRow"
+      }
+    },
+    "reason_catalog": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/reasonCatalogRow"
+      }
+    }
+  },
+  "$defs": {
+    "status": {
+      "type": "string",
+      "enum": [
+        "full",
+        "partial",
+        "unsupported"
+      ]
+    },
+    "backend": {
+      "type": "string",
+      "enum": [
+        "MIOpen",
+        "hipBLASLt",
+        "Custom Hip Kernel",
+        "Compile Time Optimization",
+        "Unknown"
+      ]
+    },
+    "reasonCode": {
+      "type": "string",
+      "enum": [
+        "NO_HIP_DIALECT_IMPL",
+        "COMPILE_TIME_TENSOR_OP",
+        "MISSING_HIP_REQUIRED_ATTR",
+        "EXTRA_ONNX_ATTR_NOT_IN_HIP",
+        "ONNX_INPUT_BELOW_HIP_MIN",
+        "ONNX_INPUT_ABOVE_HIP_MAX",
+        "ONNX_OUTPUT_BELOW_HIP_MIN",
+        "ONNX_OUTPUT_ABOVE_HIP_MAX"
+      ]
+    },
+    "operatorKey": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "onnx_op",
+        "domain"
+      ],
+      "properties": {
+        "onnx_op": {
+          "type": "string",
+          "minLength": 1
+        },
+        "domain": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "operatorDistributionRow": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "onnx_op",
+        "domain",
+        "count",
+        "data_types",
+        "status",
+        "hip_op"
+      ],
+      "properties": {
+        "onnx_op": {
+          "type": "string"
+        },
+        "domain": {
+          "type": "string"
+        },
+        "count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "data_types": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "status": {
+          "$ref": "#/$defs/status"
+        },
+        "hip_op": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "runtime_func": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "backend": {
+          "$ref": "#/$defs/backend"
+        },
+        "op_description": {
+          "type": "string"
+        }
+      }
+    },
+    "mappingChainRow": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "onnx_op",
+        "domain",
+        "hip_op",
+        "runtime_func",
+        "backend"
+      ],
+      "properties": {
+        "onnx_op": {
+          "type": "string"
+        },
+        "domain": {
+          "type": "string"
+        },
+        "hip_op": {
+          "type": "string"
+        },
+        "runtime_func": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "backend": {
+          "$ref": "#/$defs/backend"
+        }
+      }
+    },
+    "compatibilityRow": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "onnx_op",
+        "domain",
+        "status",
+        "reason_codes",
+        "reason_texts",
+        "evidence"
+      ],
+      "properties": {
+        "onnx_op": {
+          "type": "string"
+        },
+        "domain": {
+          "type": "string"
+        },
+        "status": {
+          "$ref": "#/$defs/status"
+        },
+        "reason_codes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/reasonCode"
+          }
+        },
+        "reason_texts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "evidence": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "source_file",
+              "json_pointer"
+            ],
+            "properties": {
+              "source_file": {
+                "type": "string"
+              },
+              "json_pointer": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "reasonCatalogRow": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code",
+        "default_text"
+      ],
+      "properties": {
+        "code": {
+          "$ref": "#/$defs/reasonCode"
+        },
+        "default_text": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/.cursor/skills/model-compatibility/scripts/run_ep_compatibility_check.ps1
+++ b/.cursor/skills/model-compatibility/scripts/run_ep_compatibility_check.ps1
@@ -1,3 +1,8 @@
+##
+## Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+## Licensed under the MIT License.
+##
+
 # EP-aware compatibility pipeline:
 #   1) Dump EP input graph -> <OutputDir>/ep_input/<DumpFileName> (default onnx.onnx)
 #   2) step1 on original model and EP input; compare op distributions

--- a/.cursor/skills/model-compatibility/scripts/run_ep_compatibility_check.ps1
+++ b/.cursor/skills/model-compatibility/scripts/run_ep_compatibility_check.ps1
@@ -1,0 +1,360 @@
+# EP-aware compatibility pipeline:
+#   1) Dump EP input graph -> <OutputDir>/ep_input/<DumpFileName> (default onnx.onnx)
+#   2) step1 on original model and EP input; compare op distributions
+#   3) step2..final compatibility reports using EP input only
+#
+# Usage:
+#   .\run_ep_compatibility_check.ps1 -ModelPath "D:\path\model.onnx"
+#   .\run_ep_compatibility_check.ps1 -ModelPath "D:\path\model.onnx" -OutputDir "D:\temp\my_run"
+#   .\run_ep_compatibility_check.ps1 -ModelPath "D:\path\model.onnx" -SkipDump -EpOnnxPath "D:\path\onnx.onnx"
+#
+# Defaults (derived):
+#   -RepoRoot         = (Resolve-Path "$PSScriptRoot\..\..\..\..\")
+#                       skill lives at <repo>/.cursor/skills/model-compatibility/scripts/
+#   -ToolsDir         = $PSScriptRoot
+#   -VoePackageRoot   = $env:VOE_PACKAGE_ROOT  (when unset and -SkipDump absent,
+#                       script emits [VOE_NOT_CONFIGURED] to stdout and exits 10)
+#   -OutputDir        = D:\temp\<meaningful-path-segments>_ep_compat
+#                       Built from the last 3 parent segments (skipping generic
+#                       ones like "onnx" / "models") + optional non-generic
+#                       basename. Examples:
+#                         ...\blip\onnx\decoder\fp16\model.onnx
+#                           -> D:\temp\blip_decoder_fp16_ep_compat
+#                         D:\bar\custom_v2.onnx
+#                           -> D:\temp\bar_custom_v2_ep_compat
+#                       Override with -OutputDir <dir> if the auto name collides.
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ModelPath,
+
+    [string]$OutputDir = "",
+    [string]$RepoRoot = "",
+    [string]$ToolsDir = "",
+
+    [string]$VoePackageRoot = "",
+    [string]$DumpFileName = "onnx.onnx",
+    [string]$VaipConfigPath = "",
+    [string]$VaipTarget = "VAIML",
+
+    [switch]$SkipDump,
+    [switch]$ContinueOnDumpFailure,
+    [string]$EpOnnxPath = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+if ([string]::IsNullOrWhiteSpace($ToolsDir)) {
+    $ToolsDir = $PSScriptRoot
+}
+$ToolsDir = (Resolve-Path -LiteralPath $ToolsDir).Path
+
+# Default RepoRoot = 4 levels above this script:
+#   .cursor/skills/model-compatibility/scripts/   <- $PSScriptRoot
+#   .cursor/skills/model-compatibility/           <- ..
+#   .cursor/skills/                               <- ..
+#   .cursor/                                      <- ..
+#   <repo>/                                       <- ..  (4 levels up)
+if ([string]::IsNullOrWhiteSpace($RepoRoot)) {
+    $RepoRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot "..\..\..\..")).Path
+}
+$RepoRoot = (Resolve-Path -LiteralPath $RepoRoot).Path
+$ModelPath = (Resolve-Path -LiteralPath $ModelPath).ProviderPath
+
+# VoePackageRoot: param > env > empty.
+# Empty + no -SkipDump => emit machine-readable marker and exit 10 so the
+# calling agent can AskQuestion the user (VOE path vs -SkipDump).
+if ([string]::IsNullOrWhiteSpace($VoePackageRoot)) {
+    if ($env:VOE_PACKAGE_ROOT) { $VoePackageRoot = $env:VOE_PACKAGE_ROOT }
+}
+if (-not $SkipDump -and [string]::IsNullOrWhiteSpace($VoePackageRoot)) {
+    # Write-Output (not Write-Host) so the marker is reliably captured by
+    # any caller piping the success stream (Python subprocess, CI, agent shell).
+    # Single-quoted so the literal $env:VOE_PACKAGE_ROOT is preserved without escape.
+    $msg = '[VOE_NOT_CONFIGURED] No VoePackageRoot supplied. Pass -VoePackageRoot path, set env var VOE_PACKAGE_ROOT, or rerun with -SkipDump to analyze the original ONNX without EP rewrites.'
+    Write-Output $msg
+    exit 10
+}
+
+# OutputDir default: human-readable name derived from the model's path.
+# Take the last 3 parent path segments, skip generic ones, append the basename
+# when it is non-generic, lowercase and sanitize to [a-z0-9_], suffix with
+# _ep_compat. Example:
+#   ...\blip\onnx\decoder\fp16\model.onnx  -> blip_decoder_fp16_ep_compat
+# When auto-derivation would actually collide between two distinct models the
+# caller should pass an explicit -OutputDir <dir>.
+if ([string]::IsNullOrWhiteSpace($OutputDir)) {
+    $base = [System.IO.Path]::GetFileNameWithoutExtension($ModelPath)
+    # Use [Path]::GetDirectoryName, not Split-Path -LiteralPath ... -Parent:
+    # in PS 5.1 the latter trips AmbiguousParameterSet (those two flags
+    # resolve into different parameter sets of Split-Path on some hosts).
+    $parentDir = [System.IO.Path]::GetDirectoryName($ModelPath)
+
+    # Generic path segments that carry no model identity; skip them so the
+    # resulting name highlights the model variant (family + role + dtype).
+    $genericSegments = @('onnx', 'models')
+
+    # Split on / and \, drop empty pieces and drive roots like "D:".
+    $allSegs = $parentDir -split '[\\/]+' | Where-Object {
+        $_ -and $_ -notmatch '^[A-Za-z]:$'
+    }
+
+    $meaningful = @($allSegs | Where-Object {
+        $genericSegments -notcontains $_.ToLowerInvariant()
+    })
+
+    # Keep at most the last 3 meaningful segments.
+    if ($meaningful.Count -gt 3) {
+        $meaningful = $meaningful[-3..-1]
+    }
+
+    # Append the basename if it carries identity (not "model" or a format word).
+    $baseLower = $base.ToLowerInvariant()
+    if ($baseLower -and $baseLower -ne 'model' -and ($genericSegments -notcontains $baseLower)) {
+        $meaningful = @($meaningful) + @($base)
+    }
+
+    # Sanitize each segment to [a-z0-9_] and drop empties.
+    $sanitized = @($meaningful | ForEach-Object {
+        ($_ -replace '[^A-Za-z0-9]+', '_').ToLowerInvariant().Trim('_')
+    } | Where-Object { $_ })
+
+    if ($sanitized.Count -eq 0) {
+        # Nothing identifiable in the path; fall back to the basename so the
+        # dir name is at least deterministic.
+        $sanitized = @($baseLower)
+    }
+
+    $OutputDir = Join-Path 'D:\temp' (($sanitized -join '_') + '_ep_compat')
+}
+$OutputDir = [System.IO.Path]::GetFullPath($OutputDir)
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+
+$EpInputDir = Join-Path $OutputDir "ep_input"
+$Step1OriginalDir = Join-Path $OutputDir "step1_original"
+$Step1EpDir = Join-Path $OutputDir "step1_ep"
+$CompatDir = Join-Path $OutputDir "compatibility"
+
+New-Item -ItemType Directory -Force -Path $EpInputDir, $Step1OriginalDir, $Step1EpDir, $CompatDir | Out-Null
+
+$HipOpsTd = Join-Path $RepoRoot "include\hip\Dialect\IR\HipOps.td"
+$ConversionDir = Join-Path $RepoRoot "lib\Conversion"
+$RuntimeDir = Join-Path $RepoRoot "lib\Runtime\real"
+
+function Invoke-PythonStep {
+    param(
+        [string]$Label,
+        [string[]]$PyArgv
+    )
+    Write-Host $Label -ForegroundColor Yellow
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    & python @PyArgv
+    if ($LASTEXITCODE -ne 0) {
+        throw "python failed: python $($PyArgv -join ' ')"
+    }
+    $sw.Stop()
+    Write-Host ("  done in {0:N1}s" -f $sw.Elapsed.TotalSeconds) -ForegroundColor DarkGray
+}
+
+function Step1UpToDate {
+    param([string]$OnnxPath, [string]$Step1Json)
+    if (-not (Test-Path -LiteralPath $Step1Json)) { return $false }
+    return (Get-Item -LiteralPath $Step1Json).LastWriteTimeUtc -ge (Get-Item -LiteralPath $OnnxPath).LastWriteTimeUtc
+}
+
+Write-Host "=== EP compatibility check ===" -ForegroundColor Cyan
+Write-Host "Original model:  $ModelPath"
+Write-Host "Output dir:      $OutputDir"
+Write-Host "Repo root:       $RepoRoot"
+Write-Host ""
+
+# --- Step 0: Dump EP input ONNX ---
+$EpOnnx = if ($EpOnnxPath) {
+    (Resolve-Path -LiteralPath $EpOnnxPath).Path
+} else {
+    Join-Path $EpInputDir $DumpFileName
+}
+
+$dumpFailed = $false
+$dumpError = ""
+
+# If EP graph already exists, skip dump unless user forces a new dump.
+if (-not $SkipDump -and (Test-Path -LiteralPath $EpOnnx)) {
+    Write-Host "(1/4) Skip dump: EP ONNX already exists at $EpOnnx" -ForegroundColor DarkGray
+    $SkipDump = $true
+}
+
+if (-not $SkipDump) {
+    Write-Host '(1/4) Dumping EP input graph...' -ForegroundColor Yellow
+    $dumpScript = Join-Path $ToolsDir "dump_ep_onnx.ps1"
+    if (-not (Test-Path -LiteralPath $dumpScript)) {
+        throw "dump_ep_onnx.ps1 not found: $dumpScript"
+    }
+    try {
+        $dumpArgs = @{
+            ModelPath       = $ModelPath
+            VoePackageRoot  = $VoePackageRoot
+            DumpDirectory   = $EpInputDir
+            DumpFileName    = $DumpFileName
+        }
+        if (-not [string]::IsNullOrWhiteSpace($VaipConfigPath)) {
+            $dumpArgs['VaipConfigPath'] = $VaipConfigPath
+        }
+        if (-not [string]::IsNullOrWhiteSpace($VaipTarget)) {
+            $dumpArgs['VaipTarget'] = $VaipTarget
+        }
+        & $dumpScript @dumpArgs
+        if (-not (Test-Path -LiteralPath $EpOnnx)) {
+            throw "EP dump missing: $EpOnnx"
+        }
+    } catch {
+        $dumpFailed = $true
+        $dumpError = $_.Exception.Message
+        Write-Host "WARN: EP dump failed: $dumpError" -ForegroundColor Red
+        if (-not $ContinueOnDumpFailure) {
+            throw
+        }
+    }
+} else {
+    if (Test-Path -LiteralPath $EpOnnx) {
+        Write-Host "(1/4) Skip dump; using EP ONNX: $EpOnnx" -ForegroundColor Yellow
+    } elseif ($EpOnnxPath) {
+        # User explicitly passed -EpOnnxPath that does not exist: hard error.
+        throw "EpOnnxPath not found: $EpOnnx"
+    } else {
+        # -SkipDump given without -EpOnnxPath and no default EP graph present:
+        # fall through to analyzing the original ONNX. Downstream code branches
+        # on the haveEpOnnx flag and produces a Source-original-ONNX badge.
+        Write-Host "(1/4) Skip dump; no EP ONNX available, will analyze original ONNX" -ForegroundColor Yellow
+    }
+}
+
+# --- Step 1: step1 on both graphs (typically ~1-2s each; NOT the slow step) ---
+$step1OrigJson = Join-Path $Step1OriginalDir "step1_onnx_ops.json"
+if (Step1UpToDate -OnnxPath $ModelPath -Step1Json $step1OrigJson) {
+    Write-Host '(2/4) step1 original: up-to-date, skip' -ForegroundColor DarkGray
+} else {
+    Invoke-PythonStep -Label '(2/4) step1 - original model...' -PyArgv @(
+        (Join-Path $ToolsDir "step1_onnx_parser.py"),
+        $ModelPath, $Step1OriginalDir,
+        "--max-instances-per-op", "0"
+    )
+}
+
+$haveEpOnnx = (Test-Path -LiteralPath $EpOnnx)
+
+if ($haveEpOnnx) {
+    $step1EpJson = Join-Path $Step1EpDir "step1_onnx_ops.json"
+    if (Step1UpToDate -OnnxPath $EpOnnx -Step1Json $step1EpJson) {
+        Write-Host '(2/4) step1 EP: up-to-date, skip' -ForegroundColor DarkGray
+    } else {
+        Invoke-PythonStep -Label '(2/4) step1 - EP input (onnx.onnx)...' -PyArgv @(
+            (Join-Path $ToolsDir "step1_onnx_parser.py"),
+            $EpOnnx, $Step1EpDir,
+            "--max-instances-per-op", "0"
+        )
+    }
+
+    Invoke-PythonStep -Label '(3/4) Op distribution comparison...' -PyArgv @(
+        (Join-Path $ToolsDir "compare_op_distribution.py"),
+        $step1OrigJson,
+        $step1EpJson,
+        $OutputDir,
+        "--original-model", $ModelPath,
+        "--ep-model", $EpOnnx
+    )
+} else {
+    Write-Host '(2/4) Skip step1 EP / comparison (no onnx.onnx)' -ForegroundColor Yellow
+}
+
+$compatModel = if ($haveEpOnnx) { $EpOnnx } else { $ModelPath }
+$compatNote = if ($haveEpOnnx) {
+    "Compatibility analysis uses EP input (onnx.onnx)."
+} else {
+    "WARNING: EP dump unavailable; compatibility below uses ORIGINAL model.onnx only (not EP true input)."
+}
+
+# --- Step 2 - final: compatibility on EP input (or original if dump failed) ---
+Write-Host "(4/4) Compatibility pipeline ($([System.IO.Path]::GetFileName($compatModel)))..." -ForegroundColor Yellow
+Invoke-PythonStep -Label '  step2_0 hip parser' -PyArgv @((Join-Path $ToolsDir "step2_0_hip_parser.py"), $HipOpsTd, $CompatDir)
+Invoke-PythonStep -Label '  step2_1 onnx->hip' -PyArgv @((Join-Path $ToolsDir "step2_1_onnx_to_hip_parser.py"), $ConversionDir, $CompatDir, $HipOpsTd)
+Invoke-PythonStep -Label '  step2_2 hip->llvm' -PyArgv @((Join-Path $ToolsDir "step2_2_hip_to_llvm_parser.py"), $ConversionDir, $CompatDir, $HipOpsTd)
+Invoke-PythonStep -Label '  step2_3 backend' -PyArgv @(
+    (Join-Path $ToolsDir "step2_3_backend_analyzer_final.py"),
+    $RuntimeDir,
+    (Join-Path $CompatDir "step2_2_hip_to_llvm_mappings.json"),
+    (Join-Path $CompatDir "step2_1_onnx_to_hip_mappings.json"),
+    $CompatDir
+)
+# build_report_input expects step1_onnx_ops.json in the compatibility output dir
+$step1ForCompat = if ($haveEpOnnx) {
+    Join-Path $Step1EpDir "step1_onnx_ops.json"
+} else {
+    Join-Path $Step1OriginalDir "step1_onnx_ops.json"
+}
+Copy-Item -LiteralPath $step1ForCompat -Destination (Join-Path $CompatDir "step1_onnx_ops.json") -Force
+
+Invoke-PythonStep -Label '  build_report_input' -PyArgv @(
+    (Join-Path $ToolsDir "build_report_input.py"),
+    $compatModel, $CompatDir, $RepoRoot
+)
+Invoke-PythonStep -Label '  generate_final_reports' -PyArgv @((Join-Path $ToolsDir "generate_final_reports.py"), $CompatDir)
+
+$statusPath = Join-Path $OutputDir "pipeline_status.md"
+$statusLines = @(
+    "# EP compatibility pipeline status",
+    "",
+    "- **Original model:** ``$($ModelPath)``",
+    "- **EP onnx:** ``$($EpOnnx)``",
+    "- **EP dump succeeded:** $(-not $dumpFailed -and $haveEpOnnx)",
+    "- **Compatibility analyzed:** ``$($compatModel)``",
+    "- **Note:** $compatNote",
+    ""
+)
+if ($dumpFailed) {
+    $statusLines += @("## Dump error", "", "``````", $dumpError, "``````", "")
+}
+$statusLines | Set-Content -LiteralPath $statusPath -Encoding UTF8
+
+# Copy/link key artifacts to output root for convenience
+$summarySrc = Join-Path $CompatDir "model_compatibility_report.md"
+if (Test-Path -LiteralPath $summarySrc) {
+    Copy-Item -LiteralPath $summarySrc -Destination (Join-Path $OutputDir "model_compatibility_report.md") -Force
+    Copy-Item -LiteralPath (Join-Path $CompatDir "model_compatibility_details.md") `
+        -Destination (Join-Path $OutputDir "model_compatibility_details.md") -Force
+
+    # When dump did not produce an EP graph the compatibility analysis ran on
+    # the ORIGINAL ONNX, not the EP-rewritten graph. Add a prominent badge to
+    # the top of both report copies (after the H1) so the limitation is
+    # impossible to miss when the agent reads back the report to the user.
+    if (-not $haveEpOnnx) {
+        $badge = "> **Source:** original ONNX (no EP rewrites). VOE was not configured or the dump failed; report reflects the model file as authored, not the graph the EP would compile."
+        foreach ($mdTarget in @(
+            (Join-Path $OutputDir "model_compatibility_report.md"),
+            (Join-Path $OutputDir "model_compatibility_details.md"),
+            $summarySrc,
+            (Join-Path $CompatDir "model_compatibility_details.md")
+        )) {
+            if (-not (Test-Path -LiteralPath $mdTarget)) { continue }
+            $content = Get-Content -Raw -LiteralPath $mdTarget
+            if ($content -match '\*\*Source:\*\* original ONNX') { continue }
+            $h1End = $content.IndexOf("`n")
+            if ($h1End -lt 0) { continue }
+            $patched = $content.Substring(0, $h1End + 1) + "`n$badge`n" + $content.Substring($h1End + 1)
+            Set-Content -LiteralPath $mdTarget -Value $patched -Encoding UTF8 -NoNewline
+        }
+    }
+}
+
+Write-Host ""
+Write-Host "=== Done ===" -ForegroundColor Green
+Write-Host "Pipeline status:       $statusPath"
+if ($haveEpOnnx) {
+    Write-Host "EP input:              $EpOnnx"
+    Write-Host "Op comparison:         $(Join-Path $OutputDir 'op_distribution_comparison.md')"
+} else {
+    Write-Host "EP input:              (not produced)"
+}
+Write-Host "Compatibility report:  $(Join-Path $OutputDir 'model_compatibility_report.md')"
+Write-Host "Full artifacts:        $CompatDir"
+if (-not $haveEpOnnx) { Write-Host $compatNote -ForegroundColor Yellow }

--- a/.cursor/skills/model-compatibility/scripts/step1_onnx_parser.py
+++ b/.cursor/skills/model-compatibility/scripts/step1_onnx_parser.py
@@ -1,0 +1,450 @@
+#!/usr/bin/env python3
+"""
+ONNX Model Analyzer - Step 1 (Optimized)
+Analyze the operator distribution of an ONNX model (including ops inside
+nested subgraphs such as Loop/If bodies).
+
+Performance notes:
+- Default uses onnx.load(..., load_external_data=False); we only need the
+  graph and metadata, not the external weight files (large models keep
+  weights in external .data files; loading them over UNC/network paths
+  can be orders of magnitude slower).
+- Default keeps at most max_instances_per_op entries per op type to avoid
+  blowing up memory and JSON size on graphs with hundreds of thousands of
+  nodes. Downstream build_report_input only consumes per-op data_types,
+  not the instance list.
+- Default scope includes subgraphs (Loop.body, etc.). Use --top-level-only
+  to restrict to the main graph (legacy behavior).
+"""
+
+import argparse
+import onnx
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+import sys
+
+from onnx_graph_walk import iter_graph_nodes, iter_model_nodes
+
+class ONNXModelAnalyzer:
+    # Baseline operator description dictionary (extensible).
+    OP_DESCRIPTIONS = {
+        'MatMulNBits': 'Quantized N-bit matrix multiplication (com.microsoft)',
+        'RotaryEmbedding': 'Rotary position embedding (RoPE)',
+        'SkipSimplifiedLayerNormalization': 'Skip connection + RMS normalization',
+        'GroupQueryAttention': 'Group Query Attention mechanism',
+        'Mul': 'Element-wise multiplication',
+        'Sigmoid': 'Sigmoid activation function',
+        'Constant': 'Constant tensor',
+        'Gather': 'Gather elements along axis',
+        'Shape': 'Get tensor shape',
+        'Cast': 'Type casting',
+        'Unsqueeze': 'Add dimension',
+        'Concat': 'Concatenate tensors',
+        'Reshape': 'Reshape tensor',
+        'ReduceSum': 'Reduce sum along axes',
+        'Sub': 'Element-wise subtraction',
+        'SimplifiedLayerNormalization': 'RMS layer normalization',
+        'MultiHeadAttention': 'Multi-head attention (often inside Loop subgraph)',
+        'Loop': 'Loop control flow; body subgraph contains nested ops',
+    }
+    
+    def __init__(
+        self,
+        model_path: str,
+        load_external_data: bool = False,
+        include_subgraphs: bool = True,
+    ):
+        self.model_path = model_path
+        self.include_subgraphs = include_subgraphs
+        # load_external_data=False: do not load external weights into memory;
+        # graph and initializer dtypes/dims are still readable.
+        self.model = onnx.load(model_path, load_external_data=load_external_data)
+        self.graph = self.model.graph
+        self.op_descriptions = self._build_op_descriptions()
+        
+        # Pre-build a tensor info cache to avoid repeated lookups.
+        self._tensor_cache = {}
+        self._build_tensor_cache()
+    
+    def _build_tensor_cache(self):
+        """Pre-build the tensor info cache for all initializers / inputs / outputs."""
+        # Cache initializers.
+        for initializer in self.graph.initializer:
+            dtype = self._get_dtype_name(initializer.data_type)
+            self._tensor_cache[initializer.name] = {
+                'dtype': dtype,
+                'shape': list(initializer.dims),
+                'shape_type': 'static'
+            }
+        
+        # Cache graph inputs.
+        for input_tensor in self.graph.input:
+            dtype = self._get_dtype_name(input_tensor.type.tensor_type.elem_type)
+            shape_type = self._get_shape_type(input_tensor.type.tensor_type.shape)
+            shape = [dim.dim_value if dim.dim_value > 0 else -1 
+                    for dim in input_tensor.type.tensor_type.shape.dim]
+            self._tensor_cache[input_tensor.name] = {
+                'dtype': dtype,
+                'shape': shape,
+                'shape_type': shape_type
+            }
+        
+        # Cache graph outputs.
+        for output_tensor in self.graph.output:
+            dtype = self._get_dtype_name(output_tensor.type.tensor_type.elem_type)
+            shape_type = self._get_shape_type(output_tensor.type.tensor_type.shape)
+            shape = [dim.dim_value if dim.dim_value > 0 else -1 
+                    for dim in output_tensor.type.tensor_type.shape.dim]
+            self._tensor_cache[output_tensor.name] = {
+                'dtype': dtype,
+                'shape': shape,
+                'shape_type': shape_type
+            }
+    
+    def _build_op_descriptions(self) -> Dict[str, str]:
+        """
+        Build the operator description dictionary dynamically from the model.
+        Prefer the predefined description; otherwise synthesize one from
+        op_type and domain.
+        """
+        descriptions = {}
+        
+        # Seed with predefined descriptions.
+        descriptions.update(self.OP_DESCRIPTIONS)
+        
+        # Infer descriptions for ops actually used (including those in subgraphs).
+        for node, _scope in self._iter_nodes():
+            op_type = node.op_type
+            if op_type not in descriptions:
+                domain = node.domain if node.domain else 'ai.onnx'
+                descriptions[op_type] = f'{op_type} ({domain})'
+
+        return descriptions
+
+    def _iter_nodes(self):
+        if self.include_subgraphs:
+            yield from iter_model_nodes(self.model)
+        else:
+            for node in self.graph.node:
+                yield node, "main"
+    
+    def get_op_description(self, op_type: str) -> str:
+        """Return the operator description, or a default if not found."""
+        return self.op_descriptions.get(op_type, f'{op_type} (unknown domain)')
+        
+    def analyze(self, max_instances_per_op: Optional[int] = 5) -> Dict:
+        """Analyze every operator in the model.
+
+        max_instances_per_op:
+            None - keep all instances (legacy behavior; very slow on large
+                   models)
+            0    - keep no instances (fastest; smallest JSON)
+            >0   - keep at most this many per op_type (default 5; MD shows
+                   only the first 3 so 5 is a comfortable margin)
+        """
+        ops_info = defaultdict(lambda: {
+            'count': 0,
+            'count_top_level': 0,
+            'domain': set(),
+            'data_types': set(),
+            'shape_types': set(),
+            'scopes': set(),
+            'instances': []
+        })
+
+        top_level_total = len(self.graph.node)
+
+        for node, scope in self._iter_nodes():
+            op_type = node.op_type
+            domain = node.domain if node.domain else 'ai.onnx'
+            
+            # Collect input/output tensor info.
+            input_info = []
+            output_info = []
+            
+            for input_name in node.input:
+                input_info.append(self._get_tensor_info(input_name))
+            
+            for output_name in node.output:
+                output_info.append(self._get_tensor_info(output_name))
+            
+            # Extract data types and shape types from input + output tensors.
+            data_types = set()
+            shape_types = set()
+            
+            for tensor_info in input_info + output_info:
+                if tensor_info['dtype']:
+                    data_types.add(tensor_info['dtype'])
+                if tensor_info['shape_type']:
+                    shape_types.add(tensor_info['shape_type'])
+            
+            # Update statistics.
+            ops_info[op_type]['count'] += 1
+            if scope == "main":
+                ops_info[op_type]['count_top_level'] += 1
+            ops_info[op_type]['domain'].add(domain)
+            ops_info[op_type]['data_types'].update(data_types)
+            ops_info[op_type]['shape_types'].update(shape_types)
+            ops_info[op_type]['scopes'].add(scope)
+
+            inst = ops_info[op_type]['instances']
+            if max_instances_per_op is None or len(inst) < max_instances_per_op:
+                inst.append({
+                    'node_name': node.name,
+                    'graph_scope': scope,
+                    'inputs': input_info,
+                    'outputs': output_info,
+                    'attributes': {
+                        attr.name: self._attr_to_str(attr)
+                        for attr in node.attribute
+                        if attr.type != onnx.AttributeProto.GRAPH
+                        and attr.type != onnx.AttributeProto.GRAPHS
+                    },
+                })
+
+        total_nodes = sum(info['count'] for info in ops_info.values())
+
+        result = {
+            '_analysis_meta': {
+                'include_subgraphs': self.include_subgraphs,
+                'total_nodes': total_nodes,
+                'top_level_nodes': top_level_total,
+                'subgraph_nodes': total_nodes - top_level_total
+                if self.include_subgraphs
+                else 0,
+            }
+        }
+        for op_type, info in ops_info.items():
+            result[op_type] = {
+                'count': info['count'],
+                'count_top_level': info['count_top_level'],
+                'domain': list(info['domain']),
+                'data_types': list(info['data_types']),
+                'shape_types': list(info['shape_types']),
+                'scopes': sorted(info['scopes'])[:20],
+                'instances': info['instances'],
+            }
+
+        return result
+    
+    def _get_tensor_info(self, tensor_name: str) -> Dict:
+        """Return the cached tensor info (no recursion)."""
+        if tensor_name in self._tensor_cache:
+            return {
+                'name': tensor_name,
+                **self._tensor_cache[tensor_name]
+            }
+        
+        # Fall back to a default record when the tensor is unknown.
+        return {
+            'name': tensor_name,
+            'dtype': None,
+            'shape': [],
+            'shape_type': 'unknown'
+        }
+    
+    def _get_dtype_name(self, dtype_int: int) -> str:
+        """Map an ONNX TensorProto.DataType enum to a string name."""
+        dtype_map = {
+            1: 'float32',
+            2: 'uint8',
+            3: 'int8',
+            4: 'uint16',
+            5: 'int16',
+            6: 'int32',
+            7: 'int64',
+            10: 'float16',
+            11: 'float64',
+            12: 'complex64',
+            13: 'complex128',
+            14: 'uint32',
+            15: 'uint64',
+            16: 'complex256',
+        }
+        return dtype_map.get(dtype_int, f'unknown({dtype_int})')
+    
+    def _get_shape_type(self, shape) -> str:
+        """Classify a tensor shape as static / dynamic / unknown."""
+        if not shape or not shape.dim:
+            return 'unknown'
+        
+        for dim in shape.dim:
+            if dim.dim_value <= 0:  # Non-positive dim_value indicates a dynamic dimension.
+                return 'dynamic'
+        
+        return 'static'
+    
+    def _attr_to_str(self, attr) -> str:
+        """Render an ONNX attribute as a string."""
+        if attr.HasField('f'):
+            return str(attr.f)
+        elif attr.HasField('i'):
+            return str(attr.i)
+        elif attr.HasField('s'):
+            return attr.s.decode('utf-8')
+        elif attr.floats:
+            return str(list(attr.floats))
+        elif attr.ints:
+            return str(list(attr.ints))
+        elif attr.strings:
+            return str([s.decode('utf-8') for s in attr.strings])
+        else:
+            return 'complex_value'
+
+
+def generate_markdown_report(ops_info: Dict, model_name: str, analyzer: 'ONNXModelAnalyzer') -> str:
+    """Render the analysis as a Markdown report."""
+    report = []
+    meta = ops_info.get('_analysis_meta', {})
+    op_items = {k: v for k, v in ops_info.items() if not k.startswith('_')}
+
+    report.append(f"# ONNX Model Analysis Report: {model_name}\n")
+    report.append("## Overview\n")
+
+    total_ops = sum(info['count'] for info in op_items.values())
+    unique_ops = len(op_items)
+
+    report.append(f"- **Total Operators**: {total_ops}\n")
+    if meta.get('include_subgraphs'):
+        report.append(
+            f"- **Top-level graph nodes only**: {meta.get('top_level_nodes', 'n/a')}\n"
+        )
+        report.append(
+            f"- **Nodes inside subgraphs** (Loop/If/... bodies): {meta.get('subgraph_nodes', 0)}\n"
+        )
+    report.append(f"- **Unique Operator Types**: {unique_ops}\n")
+    report.append(
+        f"- **Scope**: {'main graph + nested subgraphs' if meta.get('include_subgraphs', True) else 'main graph only'}\n"
+    )
+    report.append(f"- **Analysis Date**: {__import__('datetime').datetime.now().isoformat()}\n\n")
+    
+    report.append("## Shape Type Explanation\n\n")
+    report.append("- **static**: All dimensions have fixed values (e.g., [1, 128, 4096])\n")
+    report.append("- **dynamic**: At least one dimension is variable (e.g., [batch_size, 128, 4096] where batch_size is -1)\n")
+    report.append("- **unknown**: Shape information is not available in the graph (intermediate tensors without explicit shape definition)\n\n")
+    
+    report.append("## Operator Distribution\n\n")
+    report.append("| Op Type | Count | Domain | Data Types | Shape Type | Description |\n")
+    report.append("|---------|-------|--------|------------|------------|-------------|\n")
+    
+    # Sort by count (descending).
+    sorted_ops = sorted(op_items.items(), key=lambda x: x[1]['count'], reverse=True)
+    
+    for op_type, info in sorted_ops:
+        count = info['count']
+        domain = ', '.join(info['domain'])
+        data_types = ', '.join(info['data_types']) if info['data_types'] else '-'
+        shape_types = ', '.join(info['shape_types']) if info['shape_types'] else '-'
+        description = analyzer.get_op_description(op_type)
+        
+        report.append(f"| {op_type} | {count} | {domain} | {data_types} | {shape_types} | {description} |\n")
+    
+    report.append("\n## Detailed Operator Information\n\n")
+    
+    for op_type, info in sorted_ops:
+        report.append(f"### {op_type} (Count: {info['count']})\n\n")
+        report.append(f"**Domain**: {', '.join(info['domain'])}\n\n")
+        report.append(f"**Data Types**: {', '.join(info['data_types']) if info['data_types'] else 'Unknown'}\n\n")
+        report.append(f"**Shape Types**: {', '.join(info['shape_types']) if info['shape_types'] else 'Unknown'}\n\n")
+        
+        total_n = info['count']
+        stored = info['instances']
+        if stored:
+            sample_shown = min(3, len(stored))
+            report.append(
+                f"**Instances**: sample {sample_shown} of {len(stored)} recorded "
+                f"(total nodes of this op type: {total_n})\n\n"
+            )
+            for i, instance in enumerate(stored[:3]):
+                report.append(f"#### Instance {i+1}: {instance['node_name']}\n\n")
+                if instance['attributes']:
+                    report.append("**Attributes**:\n")
+                    for attr_name, attr_value in instance['attributes'].items():
+                        report.append(f"- {attr_name}: {attr_value}\n")
+                    report.append("\n")
+
+            remaining_in_graph = total_n - sample_shown
+            if remaining_in_graph > 0:
+                report.append(
+                    f"... {remaining_in_graph} additional node(s) of this type in the graph "
+                    f"(not all stored in JSON when capped)\n\n"
+                )
+    
+    return ''.join(report)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="ONNX op distribution (step1)")
+    ap.add_argument("model_path", help="Path to .onnx")
+    ap.add_argument(
+        "output_dir",
+        nargs="?",
+        default=None,
+        help="Output directory (default: next to model)",
+    )
+    ap.add_argument(
+        "--max-instances-per-op",
+        type=int,
+        default=5,
+        metavar="N",
+        help="Cap stored instances per op type (0=none; default 5). Use -1 for unlimited.",
+    )
+    ap.add_argument(
+        "--load-external-data",
+        action="store_true",
+        help="Load external weight files into memory (slow); default is graph-only.",
+    )
+    ap.add_argument(
+        "--top-level-only",
+        action="store_true",
+        help="Count only main-graph nodes (legacy behavior; excludes Loop subgraph ops).",
+    )
+    args = ap.parse_args()
+
+    model_path = args.model_path
+    output_dir = args.output_dir or str(Path(model_path).parent)
+    max_inst = args.max_instances_per_op
+    if max_inst < 0:
+        max_inst = None
+
+    print(f"Analyzing ONNX model: {model_path}")
+    print(f"Output directory: {output_dir}")
+    print(
+        f"Options: load_external_data={args.load_external_data}, "
+        f"max_instances_per_op={max_inst if max_inst is not None else 'unlimited'}"
+    )
+
+    Path(output_dir).mkdir(parents=True, exist_ok=True)
+
+    analyzer = ONNXModelAnalyzer(
+        model_path,
+        load_external_data=args.load_external_data,
+        include_subgraphs=not args.top_level_only,
+    )
+    ops_info = analyzer.analyze(max_instances_per_op=max_inst)
+    
+    # Derive a human-readable model name from the parent directory.
+    model_name = Path(model_path).parent.name
+    
+    # Render the Markdown report.
+    markdown_report = generate_markdown_report(ops_info, model_name, analyzer)
+    
+    # Save the Markdown report.
+    md_path = Path(output_dir) / "step1_onnx_analysis.md"
+    with open(md_path, 'w', encoding='utf-8') as f:
+        f.write(markdown_report)
+    print(f"[OK] Markdown report saved: {md_path}")
+    
+    # Save the JSON data.
+    json_path = Path(output_dir) / "step1_onnx_ops.json"
+    with open(json_path, 'w', encoding='utf-8') as f:
+        json.dump(ops_info, f, indent=2, ensure_ascii=False)
+    print(f"[OK] JSON data saved: {json_path}")
+    
+    print("\nAnalysis complete!")
+
+
+if __name__ == '__main__':
+    main()

--- a/.cursor/skills/model-compatibility/scripts/step1_onnx_parser.py
+++ b/.cursor/skills/model-compatibility/scripts/step1_onnx_parser.py
@@ -28,26 +28,30 @@ import sys
 from onnx_graph_walk import iter_graph_nodes, iter_model_nodes
 
 class ONNXModelAnalyzer:
-    # Baseline operator description dictionary (extensible).
+    # Fallback descriptions, used ONLY when `onnx.defs.get_schema(...)` does
+    # not return a schema. In practice this covers Microsoft custom ops
+    # (com.microsoft domain) and any opset/domain combination the installed
+    # `onnx` library does not know about. For standard ai.onnx ops the
+    # description comes from the ONNX schema directly (single source of
+    # truth: the ONNX specification, not this dict).
     OP_DESCRIPTIONS = {
         'MatMulNBits': 'Quantized N-bit matrix multiplication (com.microsoft)',
         'RotaryEmbedding': 'Rotary position embedding (RoPE)',
         'SkipSimplifiedLayerNormalization': 'Skip connection + RMS normalization',
         'GroupQueryAttention': 'Group Query Attention mechanism',
-        'Mul': 'Element-wise multiplication',
-        'Sigmoid': 'Sigmoid activation function',
-        'Constant': 'Constant tensor',
-        'Gather': 'Gather elements along axis',
-        'Shape': 'Get tensor shape',
-        'Cast': 'Type casting',
-        'Unsqueeze': 'Add dimension',
-        'Concat': 'Concatenate tensors',
-        'Reshape': 'Reshape tensor',
-        'ReduceSum': 'Reduce sum along axes',
-        'Sub': 'Element-wise subtraction',
         'SimplifiedLayerNormalization': 'RMS layer normalization',
         'MultiHeadAttention': 'Multi-head attention (often inside Loop subgraph)',
-        'Loop': 'Loop control flow; body subgraph contains nested ops',
+        'CausalConvWithState': 'Causal convolution with persistent state (com.microsoft)',
+        'LinearAttention': 'Linear attention (com.microsoft)',
+        'QMoE': 'Quantized Mixture-of-Experts (com.microsoft)',
+    }
+
+    # Domain -> canonical name accepted by onnx.defs.get_schema.
+    _SCHEMA_DOMAIN_ALIASES = {
+        '': '',
+        'ai.onnx': '',
+        'onnx': '',
+        'com.microsoft': 'com.microsoft',
     }
     
     def __init__(
@@ -105,23 +109,58 @@ class ONNXModelAnalyzer:
     
     def _build_op_descriptions(self) -> Dict[str, str]:
         """
-        Build the operator description dictionary dynamically from the model.
-        Prefer the predefined description; otherwise synthesize one from
-        op_type and domain.
+        Build the operator description dictionary, sourced (in order) from:
+          1. ONNX official op schema doc (`onnx.defs.get_schema(...).doc`)
+             -- single source of truth for standard `ai.onnx` ops.
+          2. The OP_DESCRIPTIONS fallback (mostly `com.microsoft` ops the
+             installed `onnx` library may not carry, plus a few hand-curated
+             one-liners).
+          3. A synthesized `<OpType> (<domain>)` placeholder.
         """
         descriptions = {}
-        
-        # Seed with predefined descriptions.
-        descriptions.update(self.OP_DESCRIPTIONS)
-        
-        # Infer descriptions for ops actually used (including those in subgraphs).
+
         for node, _scope in self._iter_nodes():
             op_type = node.op_type
-            if op_type not in descriptions:
-                domain = node.domain if node.domain else 'ai.onnx'
+            if op_type in descriptions:
+                continue
+            domain = node.domain if node.domain else 'ai.onnx'
+            doc = self._lookup_onnx_schema_doc(op_type, domain)
+            if doc:
+                descriptions[op_type] = doc
+            elif op_type in self.OP_DESCRIPTIONS:
+                descriptions[op_type] = self.OP_DESCRIPTIONS[op_type]
+            else:
                 descriptions[op_type] = f'{op_type} ({domain})'
 
         return descriptions
+
+    def _lookup_onnx_schema_doc(self, op_type: str, domain: str) -> Optional[str]:
+        """Return a short single-line description from the ONNX op schema.
+
+        Trims the schema's `.doc` string to the first non-empty paragraph
+        (or first sentence) to match the inline-friendly format used by
+        the report's "Op Description" column.
+        """
+        schema_domain = self._SCHEMA_DOMAIN_ALIASES.get(domain.lower(), domain)
+        try:
+            schema = onnx.defs.get_schema(op_type, domain=schema_domain)
+        except Exception:
+            return None
+        if schema is None or not getattr(schema, 'doc', None):
+            return None
+        doc = schema.doc.strip()
+        if not doc:
+            return None
+        # First non-empty paragraph (paragraphs separated by blank lines).
+        para = doc.split('\n\n', 1)[0].strip()
+        # Collapse internal whitespace / newlines for table-cell display.
+        para = ' '.join(para.split())
+        # Prefer first sentence to keep the cell short; fall back to first
+        # 200 chars if no sentence boundary is found.
+        sentence_end = para.find('. ')
+        if 0 < sentence_end <= 240:
+            return para[:sentence_end + 1]
+        return para[:240]
 
     def _iter_nodes(self):
         if self.include_subgraphs:

--- a/.cursor/skills/model-compatibility/scripts/step1_onnx_parser.py
+++ b/.cursor/skills/model-compatibility/scripts/step1_onnx_parser.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
 """
 ONNX Model Analyzer - Step 1 (Optimized)
 Analyze the operator distribution of an ONNX model (including ops inside
@@ -22,10 +26,10 @@ import onnx
 import json
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, List, Optional, Set, Tuple
-import sys
+from typing import Dict, Optional
 
-from onnx_graph_walk import iter_graph_nodes, iter_model_nodes
+from onnx_graph_walk import iter_model_nodes
+
 
 class ONNXModelAnalyzer:
     # Fallback descriptions, used ONLY when `onnx.defs.get_schema(...)` does
@@ -35,25 +39,25 @@ class ONNXModelAnalyzer:
     # description comes from the ONNX schema directly (single source of
     # truth: the ONNX specification, not this dict).
     OP_DESCRIPTIONS = {
-        'MatMulNBits': 'Quantized N-bit matrix multiplication (com.microsoft)',
-        'RotaryEmbedding': 'Rotary position embedding (RoPE)',
-        'SkipSimplifiedLayerNormalization': 'Skip connection + RMS normalization',
-        'GroupQueryAttention': 'Group Query Attention mechanism',
-        'SimplifiedLayerNormalization': 'RMS layer normalization',
-        'MultiHeadAttention': 'Multi-head attention (often inside Loop subgraph)',
-        'CausalConvWithState': 'Causal convolution with persistent state (com.microsoft)',
-        'LinearAttention': 'Linear attention (com.microsoft)',
-        'QMoE': 'Quantized Mixture-of-Experts (com.microsoft)',
+        "MatMulNBits": "Quantized N-bit matrix multiplication (com.microsoft)",
+        "RotaryEmbedding": "Rotary position embedding (RoPE)",
+        "SkipSimplifiedLayerNormalization": "Skip connection + RMS normalization",
+        "GroupQueryAttention": "Group Query Attention mechanism",
+        "SimplifiedLayerNormalization": "RMS layer normalization",
+        "MultiHeadAttention": "Multi-head attention (often inside Loop subgraph)",
+        "CausalConvWithState": "Causal convolution with persistent state (com.microsoft)",
+        "LinearAttention": "Linear attention (com.microsoft)",
+        "QMoE": "Quantized Mixture-of-Experts (com.microsoft)",
     }
 
     # Domain -> canonical name accepted by onnx.defs.get_schema.
     _SCHEMA_DOMAIN_ALIASES = {
-        '': '',
-        'ai.onnx': '',
-        'onnx': '',
-        'com.microsoft': 'com.microsoft',
+        "": "",
+        "ai.onnx": "",
+        "onnx": "",
+        "com.microsoft": "com.microsoft",
     }
-    
+
     def __init__(
         self,
         model_path: str,
@@ -67,46 +71,50 @@ class ONNXModelAnalyzer:
         self.model = onnx.load(model_path, load_external_data=load_external_data)
         self.graph = self.model.graph
         self.op_descriptions = self._build_op_descriptions()
-        
+
         # Pre-build a tensor info cache to avoid repeated lookups.
         self._tensor_cache = {}
         self._build_tensor_cache()
-    
+
     def _build_tensor_cache(self):
         """Pre-build the tensor info cache for all initializers / inputs / outputs."""
         # Cache initializers.
         for initializer in self.graph.initializer:
             dtype = self._get_dtype_name(initializer.data_type)
             self._tensor_cache[initializer.name] = {
-                'dtype': dtype,
-                'shape': list(initializer.dims),
-                'shape_type': 'static'
+                "dtype": dtype,
+                "shape": list(initializer.dims),
+                "shape_type": "static",
             }
-        
+
         # Cache graph inputs.
         for input_tensor in self.graph.input:
             dtype = self._get_dtype_name(input_tensor.type.tensor_type.elem_type)
             shape_type = self._get_shape_type(input_tensor.type.tensor_type.shape)
-            shape = [dim.dim_value if dim.dim_value > 0 else -1 
-                    for dim in input_tensor.type.tensor_type.shape.dim]
+            shape = [
+                dim.dim_value if dim.dim_value > 0 else -1
+                for dim in input_tensor.type.tensor_type.shape.dim
+            ]
             self._tensor_cache[input_tensor.name] = {
-                'dtype': dtype,
-                'shape': shape,
-                'shape_type': shape_type
+                "dtype": dtype,
+                "shape": shape,
+                "shape_type": shape_type,
             }
-        
+
         # Cache graph outputs.
         for output_tensor in self.graph.output:
             dtype = self._get_dtype_name(output_tensor.type.tensor_type.elem_type)
             shape_type = self._get_shape_type(output_tensor.type.tensor_type.shape)
-            shape = [dim.dim_value if dim.dim_value > 0 else -1 
-                    for dim in output_tensor.type.tensor_type.shape.dim]
+            shape = [
+                dim.dim_value if dim.dim_value > 0 else -1
+                for dim in output_tensor.type.tensor_type.shape.dim
+            ]
             self._tensor_cache[output_tensor.name] = {
-                'dtype': dtype,
-                'shape': shape,
-                'shape_type': shape_type
+                "dtype": dtype,
+                "shape": shape,
+                "shape_type": shape_type,
             }
-    
+
     def _build_op_descriptions(self) -> Dict[str, str]:
         """
         Build the operator description dictionary, sourced (in order) from:
@@ -123,14 +131,14 @@ class ONNXModelAnalyzer:
             op_type = node.op_type
             if op_type in descriptions:
                 continue
-            domain = node.domain if node.domain else 'ai.onnx'
+            domain = node.domain if node.domain else "ai.onnx"
             doc = self._lookup_onnx_schema_doc(op_type, domain)
             if doc:
                 descriptions[op_type] = doc
             elif op_type in self.OP_DESCRIPTIONS:
                 descriptions[op_type] = self.OP_DESCRIPTIONS[op_type]
             else:
-                descriptions[op_type] = f'{op_type} ({domain})'
+                descriptions[op_type] = f"{op_type} ({domain})"
 
         return descriptions
 
@@ -146,20 +154,20 @@ class ONNXModelAnalyzer:
             schema = onnx.defs.get_schema(op_type, domain=schema_domain)
         except Exception:
             return None
-        if schema is None or not getattr(schema, 'doc', None):
+        if schema is None or not getattr(schema, "doc", None):
             return None
         doc = schema.doc.strip()
         if not doc:
             return None
         # First non-empty paragraph (paragraphs separated by blank lines).
-        para = doc.split('\n\n', 1)[0].strip()
+        para = doc.split("\n\n", 1)[0].strip()
         # Collapse internal whitespace / newlines for table-cell display.
-        para = ' '.join(para.split())
+        para = " ".join(para.split())
         # Prefer first sentence to keep the cell short; fall back to first
         # 200 chars if no sentence boundary is found.
-        sentence_end = para.find('. ')
+        sentence_end = para.find(". ")
         if 0 < sentence_end <= 240:
-            return para[:sentence_end + 1]
+            return para[: sentence_end + 1]
         return para[:240]
 
     def _iter_nodes(self):
@@ -168,11 +176,11 @@ class ONNXModelAnalyzer:
         else:
             for node in self.graph.node:
                 yield node, "main"
-    
+
     def get_op_description(self, op_type: str) -> str:
         """Return the operator description, or a default if not found."""
-        return self.op_descriptions.get(op_type, f'{op_type} (unknown domain)')
-        
+        return self.op_descriptions.get(op_type, f"{op_type} (unknown domain)")
+
     def analyze(self, max_instances_per_op: Optional[int] = 5) -> Dict:
         """Analyze every operator in the model.
 
@@ -183,170 +191,175 @@ class ONNXModelAnalyzer:
             >0   - keep at most this many per op_type (default 5; MD shows
                    only the first 3 so 5 is a comfortable margin)
         """
-        ops_info = defaultdict(lambda: {
-            'count': 0,
-            'count_top_level': 0,
-            'domain': set(),
-            'data_types': set(),
-            'shape_types': set(),
-            'scopes': set(),
-            'instances': []
-        })
+        ops_info = defaultdict(
+            lambda: {
+                "count": 0,
+                "count_top_level": 0,
+                "domain": set(),
+                "data_types": set(),
+                "shape_types": set(),
+                "scopes": set(),
+                "instances": [],
+            }
+        )
 
         top_level_total = len(self.graph.node)
 
         for node, scope in self._iter_nodes():
             op_type = node.op_type
-            domain = node.domain if node.domain else 'ai.onnx'
-            
+            domain = node.domain if node.domain else "ai.onnx"
+
             # Collect input/output tensor info.
             input_info = []
             output_info = []
-            
+
             for input_name in node.input:
                 input_info.append(self._get_tensor_info(input_name))
-            
+
             for output_name in node.output:
                 output_info.append(self._get_tensor_info(output_name))
-            
+
             # Extract data types and shape types from input + output tensors.
             data_types = set()
             shape_types = set()
-            
+
             for tensor_info in input_info + output_info:
-                if tensor_info['dtype']:
-                    data_types.add(tensor_info['dtype'])
-                if tensor_info['shape_type']:
-                    shape_types.add(tensor_info['shape_type'])
-            
+                if tensor_info["dtype"]:
+                    data_types.add(tensor_info["dtype"])
+                if tensor_info["shape_type"]:
+                    shape_types.add(tensor_info["shape_type"])
+
             # Update statistics.
-            ops_info[op_type]['count'] += 1
+            ops_info[op_type]["count"] += 1
             if scope == "main":
-                ops_info[op_type]['count_top_level'] += 1
-            ops_info[op_type]['domain'].add(domain)
-            ops_info[op_type]['data_types'].update(data_types)
-            ops_info[op_type]['shape_types'].update(shape_types)
-            ops_info[op_type]['scopes'].add(scope)
+                ops_info[op_type]["count_top_level"] += 1
+            ops_info[op_type]["domain"].add(domain)
+            ops_info[op_type]["data_types"].update(data_types)
+            ops_info[op_type]["shape_types"].update(shape_types)
+            ops_info[op_type]["scopes"].add(scope)
 
-            inst = ops_info[op_type]['instances']
+            inst = ops_info[op_type]["instances"]
             if max_instances_per_op is None or len(inst) < max_instances_per_op:
-                inst.append({
-                    'node_name': node.name,
-                    'graph_scope': scope,
-                    'inputs': input_info,
-                    'outputs': output_info,
-                    'attributes': {
-                        attr.name: self._attr_to_str(attr)
-                        for attr in node.attribute
-                        if attr.type != onnx.AttributeProto.GRAPH
-                        and attr.type != onnx.AttributeProto.GRAPHS
-                    },
-                })
+                inst.append(
+                    {
+                        "node_name": node.name,
+                        "graph_scope": scope,
+                        "inputs": input_info,
+                        "outputs": output_info,
+                        "attributes": {
+                            attr.name: self._attr_to_str(attr)
+                            for attr in node.attribute
+                            if attr.type != onnx.AttributeProto.GRAPH
+                            and attr.type != onnx.AttributeProto.GRAPHS
+                        },
+                    }
+                )
 
-        total_nodes = sum(info['count'] for info in ops_info.values())
+        total_nodes = sum(info["count"] for info in ops_info.values())
 
         result = {
-            '_analysis_meta': {
-                'include_subgraphs': self.include_subgraphs,
-                'total_nodes': total_nodes,
-                'top_level_nodes': top_level_total,
-                'subgraph_nodes': total_nodes - top_level_total
+            "_analysis_meta": {
+                "include_subgraphs": self.include_subgraphs,
+                "total_nodes": total_nodes,
+                "top_level_nodes": top_level_total,
+                "subgraph_nodes": total_nodes - top_level_total
                 if self.include_subgraphs
                 else 0,
             }
         }
         for op_type, info in ops_info.items():
             result[op_type] = {
-                'count': info['count'],
-                'count_top_level': info['count_top_level'],
-                'domain': list(info['domain']),
-                'data_types': list(info['data_types']),
-                'shape_types': list(info['shape_types']),
-                'scopes': sorted(info['scopes'])[:20],
-                'instances': info['instances'],
+                "count": info["count"],
+                "count_top_level": info["count_top_level"],
+                "domain": list(info["domain"]),
+                "data_types": list(info["data_types"]),
+                "shape_types": list(info["shape_types"]),
+                "scopes": sorted(info["scopes"])[:20],
+                "instances": info["instances"],
             }
 
         return result
-    
+
     def _get_tensor_info(self, tensor_name: str) -> Dict:
         """Return the cached tensor info (no recursion)."""
         if tensor_name in self._tensor_cache:
-            return {
-                'name': tensor_name,
-                **self._tensor_cache[tensor_name]
-            }
-        
+            return {"name": tensor_name, **self._tensor_cache[tensor_name]}
+
         # Fall back to a default record when the tensor is unknown.
         return {
-            'name': tensor_name,
-            'dtype': None,
-            'shape': [],
-            'shape_type': 'unknown'
+            "name": tensor_name,
+            "dtype": None,
+            "shape": [],
+            "shape_type": "unknown",
         }
-    
+
     def _get_dtype_name(self, dtype_int: int) -> str:
         """Map an ONNX TensorProto.DataType enum to a string name."""
         dtype_map = {
-            1: 'float32',
-            2: 'uint8',
-            3: 'int8',
-            4: 'uint16',
-            5: 'int16',
-            6: 'int32',
-            7: 'int64',
-            10: 'float16',
-            11: 'float64',
-            12: 'complex64',
-            13: 'complex128',
-            14: 'uint32',
-            15: 'uint64',
-            16: 'complex256',
+            1: "float32",
+            2: "uint8",
+            3: "int8",
+            4: "uint16",
+            5: "int16",
+            6: "int32",
+            7: "int64",
+            10: "float16",
+            11: "float64",
+            12: "complex64",
+            13: "complex128",
+            14: "uint32",
+            15: "uint64",
+            16: "complex256",
         }
-        return dtype_map.get(dtype_int, f'unknown({dtype_int})')
-    
+        return dtype_map.get(dtype_int, f"unknown({dtype_int})")
+
     def _get_shape_type(self, shape) -> str:
         """Classify a tensor shape as static / dynamic / unknown."""
         if not shape or not shape.dim:
-            return 'unknown'
-        
+            return "unknown"
+
         for dim in shape.dim:
-            if dim.dim_value <= 0:  # Non-positive dim_value indicates a dynamic dimension.
-                return 'dynamic'
-        
-        return 'static'
-    
+            if (
+                dim.dim_value <= 0
+            ):  # Non-positive dim_value indicates a dynamic dimension.
+                return "dynamic"
+
+        return "static"
+
     def _attr_to_str(self, attr) -> str:
         """Render an ONNX attribute as a string."""
-        if attr.HasField('f'):
+        if attr.HasField("f"):
             return str(attr.f)
-        elif attr.HasField('i'):
+        elif attr.HasField("i"):
             return str(attr.i)
-        elif attr.HasField('s'):
-            return attr.s.decode('utf-8')
+        elif attr.HasField("s"):
+            return attr.s.decode("utf-8")
         elif attr.floats:
             return str(list(attr.floats))
         elif attr.ints:
             return str(list(attr.ints))
         elif attr.strings:
-            return str([s.decode('utf-8') for s in attr.strings])
+            return str([s.decode("utf-8") for s in attr.strings])
         else:
-            return 'complex_value'
+            return "complex_value"
 
 
-def generate_markdown_report(ops_info: Dict, model_name: str, analyzer: 'ONNXModelAnalyzer') -> str:
+def generate_markdown_report(
+    ops_info: Dict, model_name: str, analyzer: "ONNXModelAnalyzer"
+) -> str:
     """Render the analysis as a Markdown report."""
     report = []
-    meta = ops_info.get('_analysis_meta', {})
-    op_items = {k: v for k, v in ops_info.items() if not k.startswith('_')}
+    meta = ops_info.get("_analysis_meta", {})
+    op_items = {k: v for k, v in ops_info.items() if not k.startswith("_")}
 
     report.append(f"# ONNX Model Analysis Report: {model_name}\n")
     report.append("## Overview\n")
 
-    total_ops = sum(info['count'] for info in op_items.values())
+    total_ops = sum(info["count"] for info in op_items.values())
     unique_ops = len(op_items)
 
     report.append(f"- **Total Operators**: {total_ops}\n")
-    if meta.get('include_subgraphs'):
+    if meta.get("include_subgraphs"):
         report.append(
             f"- **Top-level graph nodes only**: {meta.get('top_level_nodes', 'n/a')}\n"
         )
@@ -357,39 +370,57 @@ def generate_markdown_report(ops_info: Dict, model_name: str, analyzer: 'ONNXMod
     report.append(
         f"- **Scope**: {'main graph + nested subgraphs' if meta.get('include_subgraphs', True) else 'main graph only'}\n"
     )
-    report.append(f"- **Analysis Date**: {__import__('datetime').datetime.now().isoformat()}\n\n")
-    
+    report.append(
+        f"- **Analysis Date**: {__import__('datetime').datetime.now().isoformat()}\n\n"
+    )
+
     report.append("## Shape Type Explanation\n\n")
-    report.append("- **static**: All dimensions have fixed values (e.g., [1, 128, 4096])\n")
-    report.append("- **dynamic**: At least one dimension is variable (e.g., [batch_size, 128, 4096] where batch_size is -1)\n")
-    report.append("- **unknown**: Shape information is not available in the graph (intermediate tensors without explicit shape definition)\n\n")
-    
+    report.append(
+        "- **static**: All dimensions have fixed values (e.g., [1, 128, 4096])\n"
+    )
+    report.append(
+        "- **dynamic**: At least one dimension is variable (e.g., [batch_size, 128, 4096] where batch_size is -1)\n"
+    )
+    report.append(
+        "- **unknown**: Shape information is not available in the graph (intermediate tensors without explicit shape definition)\n\n"
+    )
+
     report.append("## Operator Distribution\n\n")
-    report.append("| Op Type | Count | Domain | Data Types | Shape Type | Description |\n")
-    report.append("|---------|-------|--------|------------|------------|-------------|\n")
-    
+    report.append(
+        "| Op Type | Count | Domain | Data Types | Shape Type | Description |\n"
+    )
+    report.append(
+        "|---------|-------|--------|------------|------------|-------------|\n"
+    )
+
     # Sort by count (descending).
-    sorted_ops = sorted(op_items.items(), key=lambda x: x[1]['count'], reverse=True)
-    
+    sorted_ops = sorted(op_items.items(), key=lambda x: x[1]["count"], reverse=True)
+
     for op_type, info in sorted_ops:
-        count = info['count']
-        domain = ', '.join(info['domain'])
-        data_types = ', '.join(info['data_types']) if info['data_types'] else '-'
-        shape_types = ', '.join(info['shape_types']) if info['shape_types'] else '-'
+        count = info["count"]
+        domain = ", ".join(info["domain"])
+        data_types = ", ".join(info["data_types"]) if info["data_types"] else "-"
+        shape_types = ", ".join(info["shape_types"]) if info["shape_types"] else "-"
         description = analyzer.get_op_description(op_type)
-        
-        report.append(f"| {op_type} | {count} | {domain} | {data_types} | {shape_types} | {description} |\n")
-    
+
+        report.append(
+            f"| {op_type} | {count} | {domain} | {data_types} | {shape_types} | {description} |\n"
+        )
+
     report.append("\n## Detailed Operator Information\n\n")
-    
+
     for op_type, info in sorted_ops:
         report.append(f"### {op_type} (Count: {info['count']})\n\n")
         report.append(f"**Domain**: {', '.join(info['domain'])}\n\n")
-        report.append(f"**Data Types**: {', '.join(info['data_types']) if info['data_types'] else 'Unknown'}\n\n")
-        report.append(f"**Shape Types**: {', '.join(info['shape_types']) if info['shape_types'] else 'Unknown'}\n\n")
-        
-        total_n = info['count']
-        stored = info['instances']
+        report.append(
+            f"**Data Types**: {', '.join(info['data_types']) if info['data_types'] else 'Unknown'}\n\n"
+        )
+        report.append(
+            f"**Shape Types**: {', '.join(info['shape_types']) if info['shape_types'] else 'Unknown'}\n\n"
+        )
+
+        total_n = info["count"]
+        stored = info["instances"]
         if stored:
             sample_shown = min(3, len(stored))
             report.append(
@@ -397,10 +428,10 @@ def generate_markdown_report(ops_info: Dict, model_name: str, analyzer: 'ONNXMod
                 f"(total nodes of this op type: {total_n})\n\n"
             )
             for i, instance in enumerate(stored[:3]):
-                report.append(f"#### Instance {i+1}: {instance['node_name']}\n\n")
-                if instance['attributes']:
+                report.append(f"#### Instance {i + 1}: {instance['node_name']}\n\n")
+                if instance["attributes"]:
                     report.append("**Attributes**:\n")
-                    for attr_name, attr_value in instance['attributes'].items():
+                    for attr_name, attr_value in instance["attributes"].items():
                         report.append(f"- {attr_name}: {attr_value}\n")
                     report.append("\n")
 
@@ -410,8 +441,8 @@ def generate_markdown_report(ops_info: Dict, model_name: str, analyzer: 'ONNXMod
                     f"... {remaining_in_graph} additional node(s) of this type in the graph "
                     f"(not all stored in JSON when capped)\n\n"
                 )
-    
-    return ''.join(report)
+
+    return "".join(report)
 
 
 def main():
@@ -463,27 +494,27 @@ def main():
         include_subgraphs=not args.top_level_only,
     )
     ops_info = analyzer.analyze(max_instances_per_op=max_inst)
-    
+
     # Derive a human-readable model name from the parent directory.
     model_name = Path(model_path).parent.name
-    
+
     # Render the Markdown report.
     markdown_report = generate_markdown_report(ops_info, model_name, analyzer)
-    
+
     # Save the Markdown report.
     md_path = Path(output_dir) / "step1_onnx_analysis.md"
-    with open(md_path, 'w', encoding='utf-8') as f:
+    with open(md_path, "w", encoding="utf-8") as f:
         f.write(markdown_report)
     print(f"[OK] Markdown report saved: {md_path}")
-    
+
     # Save the JSON data.
     json_path = Path(output_dir) / "step1_onnx_ops.json"
-    with open(json_path, 'w', encoding='utf-8') as f:
+    with open(json_path, "w", encoding="utf-8") as f:
         json.dump(ops_info, f, indent=2, ensure_ascii=False)
     print(f"[OK] JSON data saved: {json_path}")
-    
+
     print("\nAnalysis complete!")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/.cursor/skills/model-compatibility/scripts/step2_0_hip_parser.py
+++ b/.cursor/skills/model-compatibility/scripts/step2_0_hip_parser.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
 """
 Hip Dialect Parser - Step 2 (Improved v8)
 Improved inputs/outputs disambiguation: by name, any operand whose name
@@ -8,349 +12,350 @@ contains "output" is treated as an output.
 import re
 import json
 from pathlib import Path
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Optional
 import sys
+
 
 class HipDialectParser:
     """Parse the TableGen-format HipOps.td file."""
-    
+
     def __init__(self, td_file_path: str):
         self.td_file_path = td_file_path
-        with open(td_file_path, 'r', encoding='utf-8') as f:
+        with open(td_file_path, "r", encoding="utf-8") as f:
             self.content = f.read()
-    
+
     def _extract_balanced_braces(self, start_pos: int) -> Optional[str]:
         """Extract the content between balanced braces starting at start_pos."""
-        if start_pos >= len(self.content) or self.content[start_pos] != '{':
+        if start_pos >= len(self.content) or self.content[start_pos] != "{":
             return None
-        
+
         depth = 0
         i = start_pos
-        
+
         while i < len(self.content):
             char = self.content[i]
-            
-            if char == '{':
+
+            if char == "{":
                 depth += 1
-            elif char == '}':
+            elif char == "}":
                 depth -= 1
                 if depth == 0:
-                    return self.content[start_pos + 1:i]
-            
+                    return self.content[start_pos + 1 : i]
+
             i += 1
-        
+
         return None
-    
+
     def parse(self) -> Dict:
         """Parse the TD file and extract every Hip operator definition."""
         ops_info = {}
-        
-        op_pattern = r'def\s+(Hip_\w+Op)\s*:\s*([^{]+)\s*\{'
-        
+
+        op_pattern = r"def\s+(Hip_\w+Op)\s*:\s*([^{]+)\s*\{"
+
         for match in re.finditer(op_pattern, self.content, re.DOTALL):
             op_class_name = match.group(1)
             op_base = match.group(2).strip()
-            
+
             start_pos = match.end() - 1
             op_body = self._extract_balanced_braces(start_pos)
-            
+
             if op_body is None:
                 continue
-            
+
             mnemonic = self._extract_mnemonic(op_base)
-            
+
             op_info = {
-                'class_name': op_class_name,
-                'mnemonic': mnemonic,
-                'base_class': op_base,
-                'summary': self._extract_summary(op_body),
-                'description': self._extract_description(op_body),
-                'inputs': self._extract_inputs(op_body),
-                'outputs': self._extract_outputs(op_body),
-                'attributes': self._extract_attributes(op_body),
-                'has_custom_format': 'hasCustomAssemblyFormat' in op_body,
+                "class_name": op_class_name,
+                "mnemonic": mnemonic,
+                "base_class": op_base,
+                "summary": self._extract_summary(op_body),
+                "description": self._extract_description(op_body),
+                "inputs": self._extract_inputs(op_body),
+                "outputs": self._extract_outputs(op_body),
+                "attributes": self._extract_attributes(op_body),
+                "has_custom_format": "hasCustomAssemblyFormat" in op_body,
             }
-            
+
             ops_info[mnemonic] = op_info
-        
+
         return ops_info
-    
+
     def _extract_mnemonic(self, base_class: str) -> str:
         """Extract the mnemonic string from a base class declaration."""
         match = re.search(r'Hip_(?:Dps)?Op<"([^"]+)"', base_class)
         if match:
             return f"hip.{match.group(1)}"
         return "unknown"
-    
+
     def _extract_summary(self, body: str) -> str:
         """Extract the let summary = "..." field."""
         match = re.search(r'let\s+summary\s*=\s*"([^"]*)"', body)
-        return match.group(1) if match else ''
-    
+        return match.group(1) if match else ""
+
     def _extract_description(self, body: str) -> str:
         """Extract the let description = [{ ... }] field."""
-        match = re.search(r'let\s+description\s*=\s*\[\{(.*?)\}\]', body, re.DOTALL)
+        match = re.search(r"let\s+description\s*=\s*\[\{(.*?)\}\]", body, re.DOTALL)
         if match:
             desc = match.group(1).strip()
-            desc = re.sub(r'\s+', ' ', desc)
+            desc = re.sub(r"\s+", " ", desc)
             return desc[:300]
-        return ''
-    
+        return ""
+
     def _is_output_operand(self, name: str) -> bool:
         """Return True if the operand name indicates an output (contains "output")."""
         name_lower = name.lower()
-        if 'output' in name_lower:
+        if "output" in name_lower:
             return True
         return False
-    
+
     def _extract_inputs(self, body: str) -> Dict[str, Dict]:
         """Extract input operands from a combination of assemblyFormat and
         arguments, preserving the original definition order."""
         from collections import OrderedDict
+
         inputs = OrderedDict()
-        
+
         # First extract type + optionality info from the arguments block.
         args_match = re.search(
-            r'let\s+arguments\s*=\s*\(\s*ins(.*?)\s*\)\s*;',
-            body,
-            re.DOTALL
+            r"let\s+arguments\s*=\s*\(\s*ins(.*?)\s*\)\s*;", body, re.DOTALL
         )
-        
+
         args_info = {}
         if args_match:
             args_body = args_match.group(1)
             params = self._split_parameters(args_body)
-            
+
             for param in params:
                 param = param.strip()
-                if not param or param.startswith('//'):
+                if not param or param.startswith("//"):
                     continue
-                
+
                 # Skip ctx and attribute parameters.
-                if 'Hip_ContextType' in param or 'Attr' in param:
+                if "Hip_ContextType" in param or "Attr" in param:
                     continue
-                
-                is_optional = 'Optional' in param
-                is_variadic = 'Variadic' in param
-                
+
+                is_optional = "Optional" in param
+                is_variadic = "Variadic" in param
+
                 # Improved regex: first capture $name, then back-extract the type.
-                name_match = re.search(r'\$([A-Za-z_]\w*)', param)
+                name_match = re.search(r"\$([A-Za-z_]\w*)", param)
                 if not name_match:
                     continue
                 param_name = name_match.group(1)
-                
+
                 # Extract the type token (between < > or right before the : prefix).
-                type_match = re.search(r'([A-Za-z_]\w*)(?:<[^<>]*>)?(?:\s*:\s*\$|>)', param)
-                param_type = type_match.group(1) if type_match else 'unknown'
-                
+                type_match = re.search(
+                    r"([A-Za-z_]\w*)(?:<[^<>]*>)?(?:\s*:\s*\$|>)", param
+                )
+                param_type = type_match.group(1) if type_match else "unknown"
+
                 type_match = None  # reset for downstream compatibility
                 if param_name:
                     type_match = True  # mark as matched
-                
+
                 if type_match:
                     # Skip operands that the name heuristic classifies as outputs.
                     if self._is_output_operand(param_name):
                         continue
-                    
+
                     args_info[param_name] = {
-                        'type': param_type,
-                        'required': not is_optional,
-                        'variadic': is_variadic
+                        "type": param_type,
+                        "required": not is_optional,
+                        "variadic": is_variadic,
                     }
-        
+
         # Then extract order + optionality from assemblyFormat (preserving order).
-        assembly_inputs = self._extract_from_assembly_format(body, 'ins')
-        
+        assembly_inputs = self._extract_from_assembly_format(body, "ins")
+
         if assembly_inputs:
             # Merge: use the assemblyFormat order/optionality with the arguments type.
             for name, info in assembly_inputs.items():
                 # Skip operands classified as outputs by name.
                 if self._is_output_operand(name):
                     continue
-                
+
                 if name in args_info:
                     inputs[name] = {
-                        'type': args_info[name]['type'],
-                        'required': info['required'],
-                        'variadic': args_info[name]['variadic']
+                        "type": args_info[name]["type"],
+                        "required": info["required"],
+                        "variadic": args_info[name]["variadic"],
                     }
                 else:
                     inputs[name] = info
         else:
             # No assemblyFormat: fall back to arguments info directly.
             inputs = OrderedDict(args_info)
-        
+
         return inputs
-    
+
     def _extract_outputs(self, body: str) -> Dict[str, Dict]:
         """Extract output operands from a combination of assemblyFormat and
         results, preserving the original definition order."""
         from collections import OrderedDict
+
         outputs = OrderedDict()
-        
+
         # First extract type + optionality info from the results block.
         results_match = re.search(
-            r'let\s+results\s*=\s*\(\s*outs\s+(.*?)\s*\)\s*;',
-            body,
-            re.DOTALL
+            r"let\s+results\s*=\s*\(\s*outs\s+(.*?)\s*\)\s*;", body, re.DOTALL
         )
-        
+
         results_info = {}
         if results_match:
             results_body = results_match.group(1)
             params = self._split_parameters(results_body)
-            
+
             for param in params:
                 param = param.strip()
-                if not param or param.startswith('//'):
+                if not param or param.startswith("//"):
                     continue
-                
-                is_variadic = 'Variadic' in param
-                is_optional = 'Optional' in param
-                
+
+                is_variadic = "Variadic" in param
+                is_optional = "Optional" in param
+
                 type_match = re.search(
-                    r'(?:Optional<|Variadic<)?([A-Za-z_]\w*(?:<[^>]+>)?)\)?:?\$?([A-Za-z_]\w*)',
-                    param
+                    r"(?:Optional<|Variadic<)?([A-Za-z_]\w*(?:<[^>]+>)?)\)?:?\$?([A-Za-z_]\w*)",
+                    param,
                 )
-                
+
                 if type_match:
                     param_type = type_match.group(1)
                     param_name = type_match.group(2)
-                    
+
                     results_info[param_name] = {
-                        'type': param_type,
-                        'required': not is_optional,
-                        'variadic': is_variadic
+                        "type": param_type,
+                        "required": not is_optional,
+                        "variadic": is_variadic,
                     }
-        
+
         # Then extract order + optionality from assemblyFormat (preserving order).
-        assembly_outputs = self._extract_from_assembly_format(body, 'outs')
-        
+        assembly_outputs = self._extract_from_assembly_format(body, "outs")
+
         if assembly_outputs:
             # Merge: use the assemblyFormat order/optionality with the results type.
             for name, info in assembly_outputs.items():
                 if name in results_info:
                     outputs[name] = {
-                        'type': results_info[name]['type'],
-                        'required': info['required'],
-                        'variadic': results_info[name]['variadic']
+                        "type": results_info[name]["type"],
+                        "required": info["required"],
+                        "variadic": results_info[name]["variadic"],
                     }
                 else:
                     outputs[name] = info
         else:
             # No assemblyFormat: fall back to results info directly.
             outputs = OrderedDict(results_info)
-        
+
         # Also extract output operands declared inside the arguments block
         # (some DPS-style ops put output buffers as ins).
         args_match = re.search(
-            r'let\s+arguments\s*=\s*\(\s*ins(.*?)\s*\)\s*;',
-            body,
-            re.DOTALL
+            r"let\s+arguments\s*=\s*\(\s*ins(.*?)\s*\)\s*;", body, re.DOTALL
         )
-        
+
         if args_match:
             args_body = args_match.group(1)
             params = self._split_parameters(args_body)
-            
+
             for param in params:
                 param = param.strip()
-                if not param or param.startswith('//'):
+                if not param or param.startswith("//"):
                     continue
-                
+
                 # Skip ctx and attribute parameters.
-                if 'Hip_ContextType' in param or 'Attr' in param:
+                if "Hip_ContextType" in param or "Attr" in param:
                     continue
-                
+
                 # Only consider operands classified as outputs by name.
                 if not self._is_output_operand(param):
                     continue
-                
-                is_optional = 'Optional' in param
-                is_variadic = 'Variadic' in param
-                
+
+                is_optional = "Optional" in param
+                is_variadic = "Variadic" in param
+
                 # Improved regex: first capture $name, then back-extract the type.
-                name_match = re.search(r'\$([A-Za-z_]\w*)', param)
+                name_match = re.search(r"\$([A-Za-z_]\w*)", param)
                 if not name_match:
                     continue
                 param_name = name_match.group(1)
-                
+
                 # Extract the type token (between < > or right before the : prefix).
-                type_match = re.search(r'([A-Za-z_]\w*)(?:<[^<>]*>)?(?:\s*:\s*\$|>)', param)
-                param_type = type_match.group(1) if type_match else 'unknown'
-                
+                type_match = re.search(
+                    r"([A-Za-z_]\w*)(?:<[^<>]*>)?(?:\s*:\s*\$|>)", param
+                )
+                param_type = type_match.group(1) if type_match else "unknown"
+
                 # Skip Variadic outputs (not concrete output buffers).
                 if is_variadic:
                     continue
-                
+
                 if param_name not in outputs:
                     outputs[param_name] = {
-                        'type': param_type,
-                        'required': not is_optional,
-                        'variadic': is_variadic
+                        "type": param_type,
+                        "required": not is_optional,
+                        "variadic": is_variadic,
                     }
-        
+
         return outputs
-    
-    def _extract_from_assembly_format(self, body: str, section: str) -> Optional[Dict[str, Dict]]:
+
+    def _extract_from_assembly_format(
+        self, body: str, section: str
+    ) -> Optional[Dict[str, Dict]]:
         """Extract operands and optionality from the ins(...) or outs(...)
         section of assemblyFormat, preserving the original order."""
         from collections import OrderedDict
-        
+
         # Locate the assemblyFormat block.
         fmt_match = re.search(
-            r'let\s+assemblyFormat\s*=\s*\[\{(.*?)\}\]',
-            body,
-            re.DOTALL
+            r"let\s+assemblyFormat\s*=\s*\[\{(.*?)\}\]", body, re.DOTALL
         )
-        
+
         if not fmt_match:
             return None
-        
+
         fmt_body = fmt_match.group(1)
-        
+
         # Find the ins(...) or outs(...) sub-block.
-        if section == 'ins':
-            pattern = r'`ins`\s*`\(`(.*?)`\)`'
+        if section == "ins":
+            pattern = r"`ins`\s*`\(`(.*?)`\)`"
         else:  # outs
-            pattern = r'`outs`\s*`\(`(.*?)`\)`'
-        
+            pattern = r"`outs`\s*`\(`(.*?)`\)`"
+
         section_match = re.search(pattern, fmt_body, re.DOTALL)
         if not section_match:
             return None
-        
+
         section_content = section_match.group(1)
-        
+
         # Parse operand names and optionality from the section content.
         # Example: $query ( `,` $key^ )? ( `,` $value^ )?
         operands = OrderedDict()
-        
+
         # Strategy: find all $name references, then mark those that appear
         # inside an ( ... )? group as optional.
         optional_vars = set()
-        
-        optional_pattern = r'\(\s*[^()]*\$([a-zA-Z_]\w*)[^()]*\s*\)\s*\?'
+
+        optional_pattern = r"\(\s*[^()]*\$([a-zA-Z_]\w*)[^()]*\s*\)\s*\?"
         for match in re.finditer(optional_pattern, section_content):
             optional_vars.add(match.group(1))
-        
+
         # Now collect all $name references in original order.
-        for var_match in re.finditer(r'\$([a-zA-Z_]\w*)', section_content):
+        for var_match in re.finditer(r"\$([a-zA-Z_]\w*)", section_content):
             var_name = var_match.group(1)
-            
+
             # Skip names already seen (preserve first-occurrence order).
             if var_name in operands:
                 continue
-            
+
             is_optional = var_name in optional_vars
-            
+
             operands[var_name] = {
-                'type': 'unknown',  # assemblyFormat carries no type info
-                'required': not is_optional,
-                'variadic': False
+                "type": "unknown",  # assemblyFormat carries no type info
+                "required": not is_optional,
+                "variadic": False,
             }
-        
+
         return operands if operands else None
-    
+
     def _extract_attributes(self, body: str) -> Dict[str, Dict]:
         """Extract attributes in original definition order.
 
@@ -360,269 +365,282 @@ class HipDialectParser:
         - Otherwise it is required.
         """
         from collections import OrderedDict
+
         attributes = OrderedDict()
-        
+
         # Locate the full arguments block (covers both ins and outs).
-        args_match = re.search(
-            r'let\s+arguments\s*=\s*\((.*?)\)\s*;',
-            body,
-            re.DOTALL
-        )
-        
+        args_match = re.search(r"let\s+arguments\s*=\s*\((.*?)\)\s*;", body, re.DOTALL)
+
         if args_match:
             args_body = args_match.group(1)
             params = self._split_parameters(args_body)
-            
+
             for param in params:
                 param = param.strip()
-                if not param or param.startswith('//'):
+                if not param or param.startswith("//"):
                     continue
-                
-                if 'Attr' not in param:
+
+                if "Attr" not in param:
                     continue
-                
+
                 # Check for a default value.
-                has_default_value = 'DefaultValuedAttr' in param
-                
+                has_default_value = "DefaultValuedAttr" in param
+
                 # Improved regex: handles DefaultValuedAttr<Type, "default">:$name.
                 # First try to match the DefaultValuedAttr<...>:$name shape.
                 attr_match = re.search(
-                    r'(?:DefaultValuedAttr<)?([A-Za-z_]\w*Attr)(?:<[^>]+>)?[,\s]*:?\$?([A-Za-z_]\w*)',
-                    param
+                    r"(?:DefaultValuedAttr<)?([A-Za-z_]\w*Attr)(?:<[^>]+>)?[,\s]*:?\$?([A-Za-z_]\w*)",
+                    param,
                 )
-                
+
                 # Fall back to a looser match if the strict one fails.
                 if not attr_match:
                     # Find any $name attribute name.
-                    name_match = re.search(r'\$([A-Za-z_]\w*)', param)
+                    name_match = re.search(r"\$([A-Za-z_]\w*)", param)
                     if name_match:
                         attr_name = name_match.group(1)
                         # Find the attribute type (between < >).
-                        type_match = re.search(r'<([A-Za-z_]\w*Attr)', param)
-                        attr_type = type_match.group(1) if type_match else 'UnknownAttr'
-                        
+                        type_match = re.search(r"<([A-Za-z_]\w*Attr)", param)
+                        attr_type = type_match.group(1) if type_match else "UnknownAttr"
+
                         default_value = None
                         if has_default_value:
                             # Extract the value from DefaultValuedAttr<Type, "value">.
-                            default_match = re.search(r'DefaultValuedAttr<[^,]+,\s*"([^"]*)"', param)
+                            default_match = re.search(
+                                r'DefaultValuedAttr<[^,]+,\s*"([^"]*)"', param
+                            )
                             if default_match:
                                 default_value = default_match.group(1)
-                        
+
                         # Optional iff a default value is present.
                         is_optional = has_default_value
-                        
+
                         attributes[attr_name] = {
-                            'type': attr_type,
-                            'optional': is_optional,
-                            'has_default': has_default_value,
-                            'default_value': default_value
+                            "type": attr_type,
+                            "optional": is_optional,
+                            "has_default": has_default_value,
+                            "default_value": default_value,
                         }
                 else:
                     attr_type = attr_match.group(1)
                     attr_name = attr_match.group(2)
-                    
+
                     if attr_name:
                         default_value = None
                         if has_default_value:
-                            default_match = re.search(r'DefaultValuedAttr<[^,]+,\s*"([^"]*)"', param)
+                            default_match = re.search(
+                                r'DefaultValuedAttr<[^,]+,\s*"([^"]*)"', param
+                            )
                             if default_match:
                                 default_value = default_match.group(1)
-                        
+
                         # Optional iff a default value is present.
                         is_optional = has_default_value
-                        
+
                         attributes[attr_name] = {
-                            'type': attr_type,
-                            'optional': is_optional,
-                            'has_default': has_default_value,
-                            'default_value': default_value
+                            "type": attr_type,
+                            "optional": is_optional,
+                            "has_default": has_default_value,
+                            "default_value": default_value,
                         }
-        
+
         return attributes
-    
+
     def _split_parameters(self, text: str) -> List[str]:
         """Split parameters by top-level commas, respecting nested < > and
         ignoring // line comments."""
         # First strip line comments.
         lines = []
-        for line in text.split('\n'):
+        for line in text.split("\n"):
             # Drop trailing // comment.
-            if '//' in line:
-                line = line[:line.index('//')]
+            if "//" in line:
+                line = line[: line.index("//")]
             lines.append(line)
-        text = '\n'.join(lines)
-        
+        text = "\n".join(lines)
+
         params = []
         current = []
         depth = 0
-        
+
         for char in text:
-            if char == '<':
+            if char == "<":
                 depth += 1
                 current.append(char)
-            elif char == '>':
+            elif char == ">":
                 depth -= 1
                 current.append(char)
-            elif char == ',' and depth == 0:
-                params.append(''.join(current))
+            elif char == "," and depth == 0:
+                params.append("".join(current))
                 current = []
             else:
                 current.append(char)
-        
+
         if current:
-            params.append(''.join(current))
-        
+            params.append("".join(current))
+
         return params
 
 
 def generate_markdown_report(ops_info: Dict, td_file_path: str) -> str:
     """Render the parsed HIP op inventory as a Markdown report."""
     report = []
-    report.append(f"# Hip Dialect Operators Analysis (v8)\n\n")
+    report.append("# Hip Dialect Operators Analysis (v8)\n\n")
     report.append(f"**Source**: {td_file_path}\n\n")
-    report.append(f"**Note**: Operands with 'output' in their name are classified as outputs\n\n")
-    
-    report.append(f"## Overview\n\n")
+    report.append(
+        "**Note**: Operands with 'output' in their name are classified as outputs\n\n"
+    )
+
+    report.append("## Overview\n\n")
     report.append(f"- **Total Hip Operators**: {len(ops_info)}\n")
-    report.append(f"- **Analysis Date**: {__import__('datetime').datetime.now().isoformat()}\n\n")
-    
+    report.append(
+        f"- **Analysis Date**: {__import__('datetime').datetime.now().isoformat()}\n\n"
+    )
+
     report.append("## Operator Summary\n\n")
     report.append("| Op Name | Inputs | Outputs | Attributes |\n")
     report.append("|---------|--------|---------|------------|\n")
-    
+
     sorted_ops = sorted(ops_info.items())
-    
+
     for op_name, info in sorted_ops:
         # Format inputs in original order.
         input_list = []
-        for param_name in info['inputs'].keys():
-            param_info = info['inputs'][param_name]
-            if not param_info['required']:
+        for param_name in info["inputs"].keys():
+            param_info = info["inputs"][param_name]
+            if not param_info["required"]:
                 input_list.append(f"{param_name} (O)")
             else:
                 input_list.append(param_name)
-        input_str = ', '.join(input_list) if input_list else '-'
-        
+        input_str = ", ".join(input_list) if input_list else "-"
+
         # Format outputs in original order.
         output_list = []
-        for param_name in info['outputs'].keys():
-            param_info = info['outputs'][param_name]
-            if not param_info['required']:
+        for param_name in info["outputs"].keys():
+            param_info = info["outputs"][param_name]
+            if not param_info["required"]:
                 output_list.append(f"{param_name} (O)")
             else:
                 output_list.append(param_name)
-        output_str = ', '.join(output_list) if output_list else '-'
-        
+        output_str = ", ".join(output_list) if output_list else "-"
+
         # Format attributes in original order; mark optional with (O).
         attr_list = []
-        for attr_name, attr_info in info['attributes'].items():
-            if attr_info['optional']:
+        for attr_name, attr_info in info["attributes"].items():
+            if attr_info["optional"]:
                 attr_list.append(f"{attr_name} (O)")
             else:
                 attr_list.append(attr_name)
-        attr_names = ', '.join(attr_list) if attr_list else '-'
-        
-        summary = info['summary']
-        
+        attr_names = ", ".join(attr_list) if attr_list else "-"
+
+        summary = info["summary"]
+
         # Row layout: Op Name | Inputs | Outputs | Attributes.
         report.append(f"| {op_name} | {input_str} | {output_str} | {attr_names} |\n")
-    
+
     report.append("\n## Operator Details\n\n")
-    
+
     for op_name, info in sorted_ops:
         # Format inputs in original order.
         input_list = []
-        for param_name in info['inputs'].keys():
-            param_info = info['inputs'][param_name]
-            if not param_info['required']:
+        for param_name in info["inputs"].keys():
+            param_info = info["inputs"][param_name]
+            if not param_info["required"]:
                 input_list.append(f"{param_name} (O)")
             else:
                 input_list.append(param_name)
-        input_str = ', '.join(input_list) if input_list else '-'
-        
+        input_str = ", ".join(input_list) if input_list else "-"
+
         # Format outputs in original order.
         output_list = []
-        for param_name in info['outputs'].keys():
-            param_info = info['outputs'][param_name]
-            if not param_info['required']:
+        for param_name in info["outputs"].keys():
+            param_info = info["outputs"][param_name]
+            if not param_info["required"]:
                 output_list.append(f"{param_name} (O)")
             else:
                 output_list.append(param_name)
-        output_str = ', '.join(output_list) if output_list else '-'
-        
+        output_str = ", ".join(output_list) if output_list else "-"
+
         # Format attributes (mark optional with (O)).
         attr_list = []
-        for attr_name in sorted(info['attributes'].keys()):
-            attr_info = info['attributes'][attr_name]
-            if attr_info['optional']:
+        for attr_name in sorted(info["attributes"].keys()):
+            attr_info = info["attributes"][attr_name]
+            if attr_info["optional"]:
                 attr_list.append(f"{attr_name} (O)")
             else:
                 attr_list.append(attr_name)
-        attr_names = ', '.join(attr_list) if attr_list else '-'
-        
-        summary = info['summary']
-        
+        attr_names = ", ".join(attr_list) if attr_list else "-"
+
+        summary = info["summary"]
+
         # Render details as a bullet list.
         report.append(f"### {op_name}\n\n")
         report.append(f"**Summary**: {summary}\n\n")
-        
-        if input_str != '-':
+
+        if input_str != "-":
             report.append(f"**Inputs**: {input_str}\n\n")
-        
-        if output_str != '-':
+
+        if output_str != "-":
             report.append(f"**Outputs**: {output_str}\n\n")
-        
-        if attr_names != '-':
+
+        if attr_names != "-":
             report.append(f"**Attributes**: {attr_names}\n\n")
-        
+
         report.append("---\n\n")
-    
+
     report.append("\n## Detailed Operator Information\n\n")
-    
+
     for op_name, info in sorted_ops:
         report.append(f"### {op_name}\n\n")
-        
-        if info['summary']:
+
+        if info["summary"]:
             report.append(f"**Summary**: {info['summary']}\n\n")
-        
-        if info['description']:
+
+        if info["description"]:
             report.append(f"**Description**: {info['description']}\n\n")
-        
+
         # Inputs (preserving original order).
-        if info['inputs']:
+        if info["inputs"]:
             report.append("**Inputs**:\n\n")
             report.append("| Name | Type | Required |\n")
             report.append("|------|------|----------|\n")
-            
-            for param_name, param_info in info['inputs'].items():
-                required = "yes" if param_info['required'] else "no"
-                report.append(f"| {param_name} | `{param_info['type']}` | {required} |\n")
+
+            for param_name, param_info in info["inputs"].items():
+                required = "yes" if param_info["required"] else "no"
+                report.append(
+                    f"| {param_name} | `{param_info['type']}` | {required} |\n"
+                )
             report.append("\n")
-        
+
         # Outputs (preserving original order).
-        if info['outputs']:
+        if info["outputs"]:
             report.append("**Outputs**:\n\n")
             report.append("| Name | Type | Required |\n")
             report.append("|------|------|----------|\n")
-            
-            for param_name, param_info in info['outputs'].items():
-                required = "yes" if param_info['required'] else "no"
-                report.append(f"| {param_name} | `{param_info['type']}` | {required} |\n")
+
+            for param_name, param_info in info["outputs"].items():
+                required = "yes" if param_info["required"] else "no"
+                report.append(
+                    f"| {param_name} | `{param_info['type']}` | {required} |\n"
+                )
             report.append("\n")
-        
+
         # Attributes (preserving original definition order).
-        if info['attributes']:
+        if info["attributes"]:
             report.append("**Attributes**:\n\n")
             report.append("| Name | Type | Optional | Default Value |\n")
             report.append("|------|------|----------|----------------|\n")
-            
-            for attr_name, attr_info in info['attributes'].items():
-                optional = "yes" if attr_info['optional'] else "no"
-                default_val = attr_info['default_value'] if attr_info['default_value'] else "-"
-                report.append(f"| {attr_name} | `{attr_info['type']}` | {optional} | {default_val} |\n")
+
+            for attr_name, attr_info in info["attributes"].items():
+                optional = "yes" if attr_info["optional"] else "no"
+                default_val = (
+                    attr_info["default_value"] if attr_info["default_value"] else "-"
+                )
+                report.append(
+                    f"| {attr_name} | `{attr_info['type']}` | {optional} | {default_val} |\n"
+                )
             report.append("\n")
-    
-    return ''.join(report)
+
+    return "".join(report)
 
 
 def main():
@@ -639,46 +657,46 @@ def main():
         print("  - Or search for HIP.td in your MLIR installation")
         print("=" * 80)
         sys.exit(1)
-    
+
     td_file_path = sys.argv[1]
     output_dir = sys.argv[2] if len(sys.argv) > 2 else str(Path(td_file_path).parent)
-    
+
     print(f"Parsing Hip Dialect file: {td_file_path}")
     print(f"Output directory: {output_dir}")
-    
+
     Path(output_dir).mkdir(parents=True, exist_ok=True)
-    
+
     parser = HipDialectParser(td_file_path)
     ops_info = parser.parse()
-    
+
     print(f"Found {len(ops_info)} Hip operators")
-    
+
     # Aggregate statistics.
-    total_inputs = sum(len(op['inputs']) for op in ops_info.values())
-    total_outputs = sum(len(op['outputs']) for op in ops_info.values())
-    total_attrs = sum(len(op['attributes']) for op in ops_info.values())
-    
+    total_inputs = sum(len(op["inputs"]) for op in ops_info.values())
+    total_outputs = sum(len(op["outputs"]) for op in ops_info.values())
+    total_attrs = sum(len(op["attributes"]) for op in ops_info.values())
+
     print(f"  - Total inputs: {total_inputs}")
     print(f"  - Total outputs: {total_outputs}")
     print(f"  - Total attributes: {total_attrs}")
-    
+
     # Render the Markdown report.
     markdown_report = generate_markdown_report(ops_info, td_file_path)
-    
+
     # Save the Markdown report.
     md_path = Path(output_dir) / "step2_hip_ops.md"
-    with open(md_path, 'w', encoding='utf-8') as f:
+    with open(md_path, "w", encoding="utf-8") as f:
         f.write(markdown_report)
     print(f"[OK] Markdown report saved: {md_path}")
-    
+
     # Save the JSON data.
     json_path = Path(output_dir) / "step2_hip_ops.json"
-    with open(json_path, 'w', encoding='utf-8') as f:
+    with open(json_path, "w", encoding="utf-8") as f:
         json.dump(ops_info, f, indent=2, ensure_ascii=False)
     print(f"[OK] JSON data saved: {json_path}")
-    
+
     print("\nParsing complete!")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/.cursor/skills/model-compatibility/scripts/step2_0_hip_parser.py
+++ b/.cursor/skills/model-compatibility/scripts/step2_0_hip_parser.py
@@ -1,0 +1,684 @@
+#!/usr/bin/env python3
+"""
+Hip Dialect Parser - Step 2 (Improved v8)
+Improved inputs/outputs disambiguation: by name, any operand whose name
+contains "output" is treated as an output.
+"""
+
+import re
+import json
+from pathlib import Path
+from typing import Dict, List, Optional, Set
+import sys
+
+class HipDialectParser:
+    """Parse the TableGen-format HipOps.td file."""
+    
+    def __init__(self, td_file_path: str):
+        self.td_file_path = td_file_path
+        with open(td_file_path, 'r', encoding='utf-8') as f:
+            self.content = f.read()
+    
+    def _extract_balanced_braces(self, start_pos: int) -> Optional[str]:
+        """Extract the content between balanced braces starting at start_pos."""
+        if start_pos >= len(self.content) or self.content[start_pos] != '{':
+            return None
+        
+        depth = 0
+        i = start_pos
+        
+        while i < len(self.content):
+            char = self.content[i]
+            
+            if char == '{':
+                depth += 1
+            elif char == '}':
+                depth -= 1
+                if depth == 0:
+                    return self.content[start_pos + 1:i]
+            
+            i += 1
+        
+        return None
+    
+    def parse(self) -> Dict:
+        """Parse the TD file and extract every Hip operator definition."""
+        ops_info = {}
+        
+        op_pattern = r'def\s+(Hip_\w+Op)\s*:\s*([^{]+)\s*\{'
+        
+        for match in re.finditer(op_pattern, self.content, re.DOTALL):
+            op_class_name = match.group(1)
+            op_base = match.group(2).strip()
+            
+            start_pos = match.end() - 1
+            op_body = self._extract_balanced_braces(start_pos)
+            
+            if op_body is None:
+                continue
+            
+            mnemonic = self._extract_mnemonic(op_base)
+            
+            op_info = {
+                'class_name': op_class_name,
+                'mnemonic': mnemonic,
+                'base_class': op_base,
+                'summary': self._extract_summary(op_body),
+                'description': self._extract_description(op_body),
+                'inputs': self._extract_inputs(op_body),
+                'outputs': self._extract_outputs(op_body),
+                'attributes': self._extract_attributes(op_body),
+                'has_custom_format': 'hasCustomAssemblyFormat' in op_body,
+            }
+            
+            ops_info[mnemonic] = op_info
+        
+        return ops_info
+    
+    def _extract_mnemonic(self, base_class: str) -> str:
+        """Extract the mnemonic string from a base class declaration."""
+        match = re.search(r'Hip_(?:Dps)?Op<"([^"]+)"', base_class)
+        if match:
+            return f"hip.{match.group(1)}"
+        return "unknown"
+    
+    def _extract_summary(self, body: str) -> str:
+        """Extract the let summary = "..." field."""
+        match = re.search(r'let\s+summary\s*=\s*"([^"]*)"', body)
+        return match.group(1) if match else ''
+    
+    def _extract_description(self, body: str) -> str:
+        """Extract the let description = [{ ... }] field."""
+        match = re.search(r'let\s+description\s*=\s*\[\{(.*?)\}\]', body, re.DOTALL)
+        if match:
+            desc = match.group(1).strip()
+            desc = re.sub(r'\s+', ' ', desc)
+            return desc[:300]
+        return ''
+    
+    def _is_output_operand(self, name: str) -> bool:
+        """Return True if the operand name indicates an output (contains "output")."""
+        name_lower = name.lower()
+        if 'output' in name_lower:
+            return True
+        return False
+    
+    def _extract_inputs(self, body: str) -> Dict[str, Dict]:
+        """Extract input operands from a combination of assemblyFormat and
+        arguments, preserving the original definition order."""
+        from collections import OrderedDict
+        inputs = OrderedDict()
+        
+        # First extract type + optionality info from the arguments block.
+        args_match = re.search(
+            r'let\s+arguments\s*=\s*\(\s*ins(.*?)\s*\)\s*;',
+            body,
+            re.DOTALL
+        )
+        
+        args_info = {}
+        if args_match:
+            args_body = args_match.group(1)
+            params = self._split_parameters(args_body)
+            
+            for param in params:
+                param = param.strip()
+                if not param or param.startswith('//'):
+                    continue
+                
+                # Skip ctx and attribute parameters.
+                if 'Hip_ContextType' in param or 'Attr' in param:
+                    continue
+                
+                is_optional = 'Optional' in param
+                is_variadic = 'Variadic' in param
+                
+                # Improved regex: first capture $name, then back-extract the type.
+                name_match = re.search(r'\$([A-Za-z_]\w*)', param)
+                if not name_match:
+                    continue
+                param_name = name_match.group(1)
+                
+                # Extract the type token (between < > or right before the : prefix).
+                type_match = re.search(r'([A-Za-z_]\w*)(?:<[^<>]*>)?(?:\s*:\s*\$|>)', param)
+                param_type = type_match.group(1) if type_match else 'unknown'
+                
+                type_match = None  # reset for downstream compatibility
+                if param_name:
+                    type_match = True  # mark as matched
+                
+                if type_match:
+                    # Skip operands that the name heuristic classifies as outputs.
+                    if self._is_output_operand(param_name):
+                        continue
+                    
+                    args_info[param_name] = {
+                        'type': param_type,
+                        'required': not is_optional,
+                        'variadic': is_variadic
+                    }
+        
+        # Then extract order + optionality from assemblyFormat (preserving order).
+        assembly_inputs = self._extract_from_assembly_format(body, 'ins')
+        
+        if assembly_inputs:
+            # Merge: use the assemblyFormat order/optionality with the arguments type.
+            for name, info in assembly_inputs.items():
+                # Skip operands classified as outputs by name.
+                if self._is_output_operand(name):
+                    continue
+                
+                if name in args_info:
+                    inputs[name] = {
+                        'type': args_info[name]['type'],
+                        'required': info['required'],
+                        'variadic': args_info[name]['variadic']
+                    }
+                else:
+                    inputs[name] = info
+        else:
+            # No assemblyFormat: fall back to arguments info directly.
+            inputs = OrderedDict(args_info)
+        
+        return inputs
+    
+    def _extract_outputs(self, body: str) -> Dict[str, Dict]:
+        """Extract output operands from a combination of assemblyFormat and
+        results, preserving the original definition order."""
+        from collections import OrderedDict
+        outputs = OrderedDict()
+        
+        # First extract type + optionality info from the results block.
+        results_match = re.search(
+            r'let\s+results\s*=\s*\(\s*outs\s+(.*?)\s*\)\s*;',
+            body,
+            re.DOTALL
+        )
+        
+        results_info = {}
+        if results_match:
+            results_body = results_match.group(1)
+            params = self._split_parameters(results_body)
+            
+            for param in params:
+                param = param.strip()
+                if not param or param.startswith('//'):
+                    continue
+                
+                is_variadic = 'Variadic' in param
+                is_optional = 'Optional' in param
+                
+                type_match = re.search(
+                    r'(?:Optional<|Variadic<)?([A-Za-z_]\w*(?:<[^>]+>)?)\)?:?\$?([A-Za-z_]\w*)',
+                    param
+                )
+                
+                if type_match:
+                    param_type = type_match.group(1)
+                    param_name = type_match.group(2)
+                    
+                    results_info[param_name] = {
+                        'type': param_type,
+                        'required': not is_optional,
+                        'variadic': is_variadic
+                    }
+        
+        # Then extract order + optionality from assemblyFormat (preserving order).
+        assembly_outputs = self._extract_from_assembly_format(body, 'outs')
+        
+        if assembly_outputs:
+            # Merge: use the assemblyFormat order/optionality with the results type.
+            for name, info in assembly_outputs.items():
+                if name in results_info:
+                    outputs[name] = {
+                        'type': results_info[name]['type'],
+                        'required': info['required'],
+                        'variadic': results_info[name]['variadic']
+                    }
+                else:
+                    outputs[name] = info
+        else:
+            # No assemblyFormat: fall back to results info directly.
+            outputs = OrderedDict(results_info)
+        
+        # Also extract output operands declared inside the arguments block
+        # (some DPS-style ops put output buffers as ins).
+        args_match = re.search(
+            r'let\s+arguments\s*=\s*\(\s*ins(.*?)\s*\)\s*;',
+            body,
+            re.DOTALL
+        )
+        
+        if args_match:
+            args_body = args_match.group(1)
+            params = self._split_parameters(args_body)
+            
+            for param in params:
+                param = param.strip()
+                if not param or param.startswith('//'):
+                    continue
+                
+                # Skip ctx and attribute parameters.
+                if 'Hip_ContextType' in param or 'Attr' in param:
+                    continue
+                
+                # Only consider operands classified as outputs by name.
+                if not self._is_output_operand(param):
+                    continue
+                
+                is_optional = 'Optional' in param
+                is_variadic = 'Variadic' in param
+                
+                # Improved regex: first capture $name, then back-extract the type.
+                name_match = re.search(r'\$([A-Za-z_]\w*)', param)
+                if not name_match:
+                    continue
+                param_name = name_match.group(1)
+                
+                # Extract the type token (between < > or right before the : prefix).
+                type_match = re.search(r'([A-Za-z_]\w*)(?:<[^<>]*>)?(?:\s*:\s*\$|>)', param)
+                param_type = type_match.group(1) if type_match else 'unknown'
+                
+                # Skip Variadic outputs (not concrete output buffers).
+                if is_variadic:
+                    continue
+                
+                if param_name not in outputs:
+                    outputs[param_name] = {
+                        'type': param_type,
+                        'required': not is_optional,
+                        'variadic': is_variadic
+                    }
+        
+        return outputs
+    
+    def _extract_from_assembly_format(self, body: str, section: str) -> Optional[Dict[str, Dict]]:
+        """Extract operands and optionality from the ins(...) or outs(...)
+        section of assemblyFormat, preserving the original order."""
+        from collections import OrderedDict
+        
+        # Locate the assemblyFormat block.
+        fmt_match = re.search(
+            r'let\s+assemblyFormat\s*=\s*\[\{(.*?)\}\]',
+            body,
+            re.DOTALL
+        )
+        
+        if not fmt_match:
+            return None
+        
+        fmt_body = fmt_match.group(1)
+        
+        # Find the ins(...) or outs(...) sub-block.
+        if section == 'ins':
+            pattern = r'`ins`\s*`\(`(.*?)`\)`'
+        else:  # outs
+            pattern = r'`outs`\s*`\(`(.*?)`\)`'
+        
+        section_match = re.search(pattern, fmt_body, re.DOTALL)
+        if not section_match:
+            return None
+        
+        section_content = section_match.group(1)
+        
+        # Parse operand names and optionality from the section content.
+        # Example: $query ( `,` $key^ )? ( `,` $value^ )?
+        operands = OrderedDict()
+        
+        # Strategy: find all $name references, then mark those that appear
+        # inside an ( ... )? group as optional.
+        optional_vars = set()
+        
+        optional_pattern = r'\(\s*[^()]*\$([a-zA-Z_]\w*)[^()]*\s*\)\s*\?'
+        for match in re.finditer(optional_pattern, section_content):
+            optional_vars.add(match.group(1))
+        
+        # Now collect all $name references in original order.
+        for var_match in re.finditer(r'\$([a-zA-Z_]\w*)', section_content):
+            var_name = var_match.group(1)
+            
+            # Skip names already seen (preserve first-occurrence order).
+            if var_name in operands:
+                continue
+            
+            is_optional = var_name in optional_vars
+            
+            operands[var_name] = {
+                'type': 'unknown',  # assemblyFormat carries no type info
+                'required': not is_optional,
+                'variadic': False
+            }
+        
+        return operands if operands else None
+    
+    def _extract_attributes(self, body: str) -> Dict[str, Dict]:
+        """Extract attributes in original definition order.
+
+        Required vs optional rule:
+        - If the attribute carries a default value (via DefaultValuedAttr or
+          similar), it is optional.
+        - Otherwise it is required.
+        """
+        from collections import OrderedDict
+        attributes = OrderedDict()
+        
+        # Locate the full arguments block (covers both ins and outs).
+        args_match = re.search(
+            r'let\s+arguments\s*=\s*\((.*?)\)\s*;',
+            body,
+            re.DOTALL
+        )
+        
+        if args_match:
+            args_body = args_match.group(1)
+            params = self._split_parameters(args_body)
+            
+            for param in params:
+                param = param.strip()
+                if not param or param.startswith('//'):
+                    continue
+                
+                if 'Attr' not in param:
+                    continue
+                
+                # Check for a default value.
+                has_default_value = 'DefaultValuedAttr' in param
+                
+                # Improved regex: handles DefaultValuedAttr<Type, "default">:$name.
+                # First try to match the DefaultValuedAttr<...>:$name shape.
+                attr_match = re.search(
+                    r'(?:DefaultValuedAttr<)?([A-Za-z_]\w*Attr)(?:<[^>]+>)?[,\s]*:?\$?([A-Za-z_]\w*)',
+                    param
+                )
+                
+                # Fall back to a looser match if the strict one fails.
+                if not attr_match:
+                    # Find any $name attribute name.
+                    name_match = re.search(r'\$([A-Za-z_]\w*)', param)
+                    if name_match:
+                        attr_name = name_match.group(1)
+                        # Find the attribute type (between < >).
+                        type_match = re.search(r'<([A-Za-z_]\w*Attr)', param)
+                        attr_type = type_match.group(1) if type_match else 'UnknownAttr'
+                        
+                        default_value = None
+                        if has_default_value:
+                            # Extract the value from DefaultValuedAttr<Type, "value">.
+                            default_match = re.search(r'DefaultValuedAttr<[^,]+,\s*"([^"]*)"', param)
+                            if default_match:
+                                default_value = default_match.group(1)
+                        
+                        # Optional iff a default value is present.
+                        is_optional = has_default_value
+                        
+                        attributes[attr_name] = {
+                            'type': attr_type,
+                            'optional': is_optional,
+                            'has_default': has_default_value,
+                            'default_value': default_value
+                        }
+                else:
+                    attr_type = attr_match.group(1)
+                    attr_name = attr_match.group(2)
+                    
+                    if attr_name:
+                        default_value = None
+                        if has_default_value:
+                            default_match = re.search(r'DefaultValuedAttr<[^,]+,\s*"([^"]*)"', param)
+                            if default_match:
+                                default_value = default_match.group(1)
+                        
+                        # Optional iff a default value is present.
+                        is_optional = has_default_value
+                        
+                        attributes[attr_name] = {
+                            'type': attr_type,
+                            'optional': is_optional,
+                            'has_default': has_default_value,
+                            'default_value': default_value
+                        }
+        
+        return attributes
+    
+    def _split_parameters(self, text: str) -> List[str]:
+        """Split parameters by top-level commas, respecting nested < > and
+        ignoring // line comments."""
+        # First strip line comments.
+        lines = []
+        for line in text.split('\n'):
+            # Drop trailing // comment.
+            if '//' in line:
+                line = line[:line.index('//')]
+            lines.append(line)
+        text = '\n'.join(lines)
+        
+        params = []
+        current = []
+        depth = 0
+        
+        for char in text:
+            if char == '<':
+                depth += 1
+                current.append(char)
+            elif char == '>':
+                depth -= 1
+                current.append(char)
+            elif char == ',' and depth == 0:
+                params.append(''.join(current))
+                current = []
+            else:
+                current.append(char)
+        
+        if current:
+            params.append(''.join(current))
+        
+        return params
+
+
+def generate_markdown_report(ops_info: Dict, td_file_path: str) -> str:
+    """Render the parsed HIP op inventory as a Markdown report."""
+    report = []
+    report.append(f"# Hip Dialect Operators Analysis (v8)\n\n")
+    report.append(f"**Source**: {td_file_path}\n\n")
+    report.append(f"**Note**: Operands with 'output' in their name are classified as outputs\n\n")
+    
+    report.append(f"## Overview\n\n")
+    report.append(f"- **Total Hip Operators**: {len(ops_info)}\n")
+    report.append(f"- **Analysis Date**: {__import__('datetime').datetime.now().isoformat()}\n\n")
+    
+    report.append("## Operator Summary\n\n")
+    report.append("| Op Name | Inputs | Outputs | Attributes |\n")
+    report.append("|---------|--------|---------|------------|\n")
+    
+    sorted_ops = sorted(ops_info.items())
+    
+    for op_name, info in sorted_ops:
+        # Format inputs in original order.
+        input_list = []
+        for param_name in info['inputs'].keys():
+            param_info = info['inputs'][param_name]
+            if not param_info['required']:
+                input_list.append(f"{param_name} (O)")
+            else:
+                input_list.append(param_name)
+        input_str = ', '.join(input_list) if input_list else '-'
+        
+        # Format outputs in original order.
+        output_list = []
+        for param_name in info['outputs'].keys():
+            param_info = info['outputs'][param_name]
+            if not param_info['required']:
+                output_list.append(f"{param_name} (O)")
+            else:
+                output_list.append(param_name)
+        output_str = ', '.join(output_list) if output_list else '-'
+        
+        # Format attributes in original order; mark optional with (O).
+        attr_list = []
+        for attr_name, attr_info in info['attributes'].items():
+            if attr_info['optional']:
+                attr_list.append(f"{attr_name} (O)")
+            else:
+                attr_list.append(attr_name)
+        attr_names = ', '.join(attr_list) if attr_list else '-'
+        
+        summary = info['summary']
+        
+        # Row layout: Op Name | Inputs | Outputs | Attributes.
+        report.append(f"| {op_name} | {input_str} | {output_str} | {attr_names} |\n")
+    
+    report.append("\n## Operator Details\n\n")
+    
+    for op_name, info in sorted_ops:
+        # Format inputs in original order.
+        input_list = []
+        for param_name in info['inputs'].keys():
+            param_info = info['inputs'][param_name]
+            if not param_info['required']:
+                input_list.append(f"{param_name} (O)")
+            else:
+                input_list.append(param_name)
+        input_str = ', '.join(input_list) if input_list else '-'
+        
+        # Format outputs in original order.
+        output_list = []
+        for param_name in info['outputs'].keys():
+            param_info = info['outputs'][param_name]
+            if not param_info['required']:
+                output_list.append(f"{param_name} (O)")
+            else:
+                output_list.append(param_name)
+        output_str = ', '.join(output_list) if output_list else '-'
+        
+        # Format attributes (mark optional with (O)).
+        attr_list = []
+        for attr_name in sorted(info['attributes'].keys()):
+            attr_info = info['attributes'][attr_name]
+            if attr_info['optional']:
+                attr_list.append(f"{attr_name} (O)")
+            else:
+                attr_list.append(attr_name)
+        attr_names = ', '.join(attr_list) if attr_list else '-'
+        
+        summary = info['summary']
+        
+        # Render details as a bullet list.
+        report.append(f"### {op_name}\n\n")
+        report.append(f"**Summary**: {summary}\n\n")
+        
+        if input_str != '-':
+            report.append(f"**Inputs**: {input_str}\n\n")
+        
+        if output_str != '-':
+            report.append(f"**Outputs**: {output_str}\n\n")
+        
+        if attr_names != '-':
+            report.append(f"**Attributes**: {attr_names}\n\n")
+        
+        report.append("---\n\n")
+    
+    report.append("\n## Detailed Operator Information\n\n")
+    
+    for op_name, info in sorted_ops:
+        report.append(f"### {op_name}\n\n")
+        
+        if info['summary']:
+            report.append(f"**Summary**: {info['summary']}\n\n")
+        
+        if info['description']:
+            report.append(f"**Description**: {info['description']}\n\n")
+        
+        # Inputs (preserving original order).
+        if info['inputs']:
+            report.append("**Inputs**:\n\n")
+            report.append("| Name | Type | Required |\n")
+            report.append("|------|------|----------|\n")
+            
+            for param_name, param_info in info['inputs'].items():
+                required = "yes" if param_info['required'] else "no"
+                report.append(f"| {param_name} | `{param_info['type']}` | {required} |\n")
+            report.append("\n")
+        
+        # Outputs (preserving original order).
+        if info['outputs']:
+            report.append("**Outputs**:\n\n")
+            report.append("| Name | Type | Required |\n")
+            report.append("|------|------|----------|\n")
+            
+            for param_name, param_info in info['outputs'].items():
+                required = "yes" if param_info['required'] else "no"
+                report.append(f"| {param_name} | `{param_info['type']}` | {required} |\n")
+            report.append("\n")
+        
+        # Attributes (preserving original definition order).
+        if info['attributes']:
+            report.append("**Attributes**:\n\n")
+            report.append("| Name | Type | Optional | Default Value |\n")
+            report.append("|------|------|----------|----------------|\n")
+            
+            for attr_name, attr_info in info['attributes'].items():
+                optional = "yes" if attr_info['optional'] else "no"
+                default_val = attr_info['default_value'] if attr_info['default_value'] else "-"
+                report.append(f"| {attr_name} | `{attr_info['type']}` | {optional} | {default_val} |\n")
+            report.append("\n")
+    
+    return ''.join(report)
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("=" * 80)
+        print("ERROR: Hip Dialect .td file path is required!")
+        print("=" * 80)
+        print("\nUsage: python step2_hip_parser.py <td_file_path> [output_dir]")
+        print("\nExample:")
+        print("  python step2_hip_parser.py /path/to/HIP.td ./output")
+        print("\nPlease provide the path to the Hip Dialect .td file.")
+        print("Common locations:")
+        print("  - MLIR repository: mlir/lib/Dialect/HIP/IR/HIP.td")
+        print("  - Or search for HIP.td in your MLIR installation")
+        print("=" * 80)
+        sys.exit(1)
+    
+    td_file_path = sys.argv[1]
+    output_dir = sys.argv[2] if len(sys.argv) > 2 else str(Path(td_file_path).parent)
+    
+    print(f"Parsing Hip Dialect file: {td_file_path}")
+    print(f"Output directory: {output_dir}")
+    
+    Path(output_dir).mkdir(parents=True, exist_ok=True)
+    
+    parser = HipDialectParser(td_file_path)
+    ops_info = parser.parse()
+    
+    print(f"Found {len(ops_info)} Hip operators")
+    
+    # Aggregate statistics.
+    total_inputs = sum(len(op['inputs']) for op in ops_info.values())
+    total_outputs = sum(len(op['outputs']) for op in ops_info.values())
+    total_attrs = sum(len(op['attributes']) for op in ops_info.values())
+    
+    print(f"  - Total inputs: {total_inputs}")
+    print(f"  - Total outputs: {total_outputs}")
+    print(f"  - Total attributes: {total_attrs}")
+    
+    # Render the Markdown report.
+    markdown_report = generate_markdown_report(ops_info, td_file_path)
+    
+    # Save the Markdown report.
+    md_path = Path(output_dir) / "step2_hip_ops.md"
+    with open(md_path, 'w', encoding='utf-8') as f:
+        f.write(markdown_report)
+    print(f"[OK] Markdown report saved: {md_path}")
+    
+    # Save the JSON data.
+    json_path = Path(output_dir) / "step2_hip_ops.json"
+    with open(json_path, 'w', encoding='utf-8') as f:
+        json.dump(ops_info, f, indent=2, ensure_ascii=False)
+    print(f"[OK] JSON data saved: {json_path}")
+    
+    print("\nParsing complete!")
+
+
+if __name__ == '__main__':
+    main()

--- a/.cursor/skills/model-compatibility/scripts/step2_1_onnx_to_hip_parser.py
+++ b/.cursor/skills/model-compatibility/scripts/step2_1_onnx_to_hip_parser.py
@@ -139,22 +139,23 @@ class OnnxToHipParser:
                         mappings.append(mapping)
             
             # Mode 2: mappings discovered via RewritePattern("onnx.<Op>", ...).
-            pattern_matches = re.findall(r'RewritePattern\("onnx\.(\w+)"', content)
-            for onnx_op in pattern_matches:
+            # Each occurrence is scoped to its OWN struct (a single onnx_op
+            # may legitimately have multiple registrations in one file, e.g.
+            # ConstantOfShapeFold + ConstantOfShapeDynamic both register
+            # "onnx.ConstantOfShape" -- one folds at compile time and emits
+            # no hip op, the other lowers to hip.where). End-of-parse dedup
+            # by (onnx_op, domain, hip_op) collapses duplicates safely; the
+            # fold variant simply yields no hip_op and gets skipped.
+            for rp_match in re.finditer(r'RewritePattern\("onnx\.(\w+)"', content):
+                onnx_op = rp_match.group(1)
                 if onnx_op == 'Custom':
                     continue
-                
-                if any(m['onnx_op'] == onnx_op for m in mappings):
-                    continue
 
-                # Restrict to the matchAndRewrite body of the struct that registers
-                # this RewritePattern, to avoid pollution from sibling structs in the
-                # same file (e.g. NormConversion.cpp holds SimplifiedLayerNormToHip,
-                # SkipSimplifiedLayerNormToHip, and LayerNormToHip together):
-                #   - the first *Op::create in the file may belong to a different struct
-                #   - the substring "com.microsoft" anywhere in the file does not imply
-                #     this struct targets that domain
-                scoped = self._scope_to_rewrite_pattern_body(content, onnx_op) or content
+                # Restrict to the struct body containing THIS specific
+                # RewritePattern position, not the file's first one.
+                scoped = self._scope_to_rewrite_pattern_body(
+                    content, onnx_op, start_pos=rp_match.start()
+                ) or content
 
                 hip_op = self._extract_hip_op_from_code(scoped)
                 class_name = self._extract_hip_class_name(scoped, onnx_op)
@@ -163,6 +164,27 @@ class OnnxToHipParser:
                     mapping = self._create_mapping(onnx_op, hip_op, file_path, 'standard', class_name, domain)
                     if mapping:
                         mappings.append(mapping)
+                else:
+                    # No hip.* op produced; check whether the struct lowers
+                    # to standard MLIR dialect ops (tensor.* / arith.* /
+                    # memref.*). Such conversions are handled by MLIR's
+                    # standard bufferization + lowering passes and need no
+                    # HIP runtime wrapper, so we emit a synthetic
+                    # `tensor.<X>` mapping. Downstream classification
+                    # already treats any `tensor.*` hip_op as
+                    # `COMPILE_TIME_TENSOR_OP`.
+                    td_op = self._extract_std_dialect_op(scoped)
+                    if td_op:
+                        mapping = self._create_mapping(
+                            onnx_op,
+                            f"tensor.{td_op}",
+                            file_path,
+                            'compile_time',
+                            'StdMlirLowering',
+                            domain,
+                        )
+                        if mapping:
+                            mappings.append(mapping)
             
             # Mode 3: onnx.Custom ops dispatched via function_name == "<Op>".
             custom_patterns = re.findall(
@@ -276,16 +298,25 @@ class OnnxToHipParser:
 
         return "onnx"
 
-    def _scope_to_rewrite_pattern_body(self, content: str, onnx_op: str) -> Optional[str]:
+    def _scope_to_rewrite_pattern_body(self, content: str, onnx_op: str,
+                                       start_pos: int = 0) -> Optional[str]:
         """Scope to the matchAndRewrite body of the struct that registers
         `RewritePattern("onnx.<onnx_op>", ...)`. Returns None when not found;
         the caller then falls back to the whole-file content.
 
+        `start_pos` is a hint: locate the struct whose RewritePattern occurs
+        at or AFTER this offset. Defaults to 0 (find the first one). The
+        caller passes the actual RewritePattern match start when multiple
+        structs register the same onnx_op in one file (e.g.
+        ConstantOfShapeFold + ConstantOfShapeDynamic) so each gets scoped to
+        its own body.
+
         Steps:
-        1) Locate the struct that contains the RewritePattern("onnx.<op>", ...) ctor.
-        2) With the same boundary rule used by _extract_hip_class_name_for_op
-           (the next XxxX::matchAndRewrite / populate* / EOF), slice out that
-           struct's matchAndRewrite body (possibly including the struct decl).
+        1) Locate the struct that contains the RewritePattern("onnx.<op>", ...)
+           ctor at or after start_pos.
+        2) Slice out that struct's body. Prefer the out-of-class
+           `StructName::matchAndRewrite { ... }` form; otherwise extract the
+           inline struct body via balanced-brace traversal.
         """
         ctor_pat = re.compile(
             r'struct\s+(\w+)\b[^{}]*?\{[^{}]*?RewritePattern\s*\(\s*"onnx\.'
@@ -293,7 +324,14 @@ class OnnxToHipParser:
             + r'"',
             re.DOTALL,
         )
-        m = ctor_pat.search(content)
+        # Iterate matches and pick the one whose ctor RewritePattern position
+        # is >= start_pos. This lets the caller disambiguate multiple structs
+        # registering the same onnx_op (Fold + Dynamic, etc.).
+        m = None
+        for cand in ctor_pat.finditer(content):
+            if cand.end() >= start_pos:
+                m = cand
+                break
         if not m:
             return None
         struct_name = m.group(1)
@@ -429,6 +467,35 @@ class OnnxToHipParser:
         # Fall back to the generic extractor when scoped lookups fail.
         return self._extract_hip_class_name(content, onnx_op)
     
+    def _extract_std_dialect_op(self, content: str) -> Optional[str]:
+        """Return a representative standard-MLIR-dialect op name produced by
+        a conversion that does NOT call any hip.* op. Used to classify
+        compile-time-foldable conversions (e.g. ConstantOfShape -> tensor.splat,
+        Reshape -> tensor.collapse_shape, Shape -> tensor.from_elements).
+
+        Picks the LAST `[mlir::](tensor|arith|memref)::<X>Op::create` call in
+        the scoped struct body -- typically the one closest to
+        `rewriter.replaceOp(...)`, i.e. the "output" op of the lowering.
+
+        The `mlir::` qualifier is optional because conversion files often
+        write bare `arith::ConstantOp::create` etc. when `using namespace
+        mlir;` or `namespace mlir::hip { ... }` is in scope (ShapeConversion.cpp).
+
+        Returns the op name in snake_case (SplatOp -> splat,
+        FromElementsOp -> from_elements); caller prefixes with `tensor.`
+        to trigger COMPILE_TIME_TENSOR_OP downstream.
+        """
+        matches = re.findall(
+            r'(?:mlir::)?(?:tensor|arith|memref)::(\w+)Op::create',
+            content,
+        )
+        if not matches:
+            return None
+        cls = matches[-1]
+        # CamelCase -> snake_case (handles ConstantIndexOp, SplatOp, etc.)
+        snake = re.sub(r'(?<!^)([A-Z])', r'_\1', cls).lower()
+        return snake
+
     def _extract_hip_op_from_code(self, content: str) -> str:
         """Extract the HIP op mnemonic from source code."""
         # Prefer derivation from the HIP class name (more accurate).

--- a/.cursor/skills/model-compatibility/scripts/step2_1_onnx_to_hip_parser.py
+++ b/.cursor/skills/model-compatibility/scripts/step2_1_onnx_to_hip_parser.py
@@ -1,0 +1,611 @@
+#!/usr/bin/env python3
+"""
+Step 2-1 Final v5: OnnxToHip Conversion Parser - Fixed SkipSimplifiedLayerNormalization
+Extract precise mappings (onnx_op, onnx_domain, hip_op, class_name, file_name).
+- SimplifiedLayerNormalization: domain is `onnx` (onnx.Custom, no com.microsoft
+  constraint).
+- SkipSimplifiedLayerNormalization: domain is `com.microsoft`,
+  hip.skip_rms_norm (not accidentally overridden by RmsNormOp).
+- mlir::hip::FooOp -> hip mnemonic: read the TableGen mnemonic from
+  HipOps.td instead of guessing from CamelCase.
+- Deduplicate Unsqueeze mappings.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Set
+
+_TOOLS_DIR = Path(__file__).resolve().parent
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+from hip_td_mnemonics import (  # noqa: E402
+    default_hip_ops_td_path,
+    load_cpp_op_class_to_mnemonic_from_td,
+)
+
+
+class OnnxToHipParser:
+    """OnnxToHip parser; dynamically extracts mappings from cpp sources."""
+
+    # onnx_op name -> C++ struct name. C++ struct names are abbreviated,
+    # so we cannot derive them via regex from the onnx_op name alone.
+    _STRUCT_NAME_BY_ONNX_OP = {
+        "SimplifiedLayerNormalization": "SimplifiedLayerNormToHip",
+        "SkipSimplifiedLayerNormalization": "SkipSimplifiedLayerNormToHip",
+    }
+
+    def __init__(self, conversion_dir: str, hip_ops_td: Optional[str] = None):
+        self.conversion_dir = Path(conversion_dir)
+        self._hip_td_path: Optional[Path] = None
+        self._cpp_class_to_mnemonic: Dict[str, str] = {}
+
+        td = self._resolve_hip_ops_td(hip_ops_td)
+        if td is not None:
+            self._hip_td_path = td
+            self._cpp_class_to_mnemonic = load_cpp_op_class_to_mnemonic_from_td(td)
+        else:
+            print(
+                "Warning: HipOps.td not found; pass hip_ops_td or place repo at "
+                "<conversion_dir>/../.. with include/hip/Dialect/IR/HipOps.td. "
+                "mlir::hip::*Op -> hip mnemonic will be unavailable (non-custom paths may be wrong)."
+            )
+
+    def _resolve_hip_ops_td(self, hip_ops_td: Optional[str]) -> Optional[Path]:
+        if hip_ops_td:
+            p = Path(hip_ops_td)
+            return p if p.is_file() else None
+        candidate = default_hip_ops_td_path(self.conversion_dir)
+        return candidate if candidate.is_file() else None
+    
+    def parse(self) -> Dict:
+        """Parse every OnnxToHip conversion file."""
+        result = {
+            'mappings': [],
+            'statistics': {}
+        }
+        
+        # Discover all OnnxToHip conversion files.
+        conversion_files = sorted(self.conversion_dir.glob('OnnxToHip/*.cpp'))
+        
+        print(f"Found {len(conversion_files)} conversion files\n")
+        
+        for file_path in conversion_files:
+            print(f"Parsing: {file_path.name}")
+            mappings = self._parse_conversion_file(file_path)
+            result['mappings'].extend(mappings)
+            
+            # Echo this file's mappings.
+            for mapping in mappings:
+                class_name = mapping.get('class_name', '')
+                print(f"  {mapping['onnx_op']:30} ({mapping['onnx_domain']:15}) -> {mapping['hip_op']:30} [{class_name}]")
+        
+        # Deduplicate: keep the first mapping per (onnx_op, onnx_domain, hip_op).
+        unique_mappings = {}
+        for mapping in result['mappings']:
+            key = (mapping['onnx_op'], mapping['onnx_domain'], mapping['hip_op'])
+            if key not in unique_mappings:
+                unique_mappings[key] = mapping
+        
+        result['mappings'] = list(unique_mappings.values())
+        
+        # Compute summary statistics.
+        result['statistics'] = {
+            'total_mappings': len(result['mappings']),
+            'total_conversion_files': len(conversion_files),
+            'unique_onnx_ops': len(set(m['onnx_op'] for m in result['mappings'])),
+            'unique_domains': len(set(m['onnx_domain'] for m in result['mappings'])),
+            'unique_hip_ops': len(set(m['hip_op'] for m in result['mappings'])),
+        }
+        
+        return result
+    
+    def _parse_conversion_file(self, file_path: Path) -> List[Dict]:
+        """Parse a single conversion file and return all mappings."""
+        mappings = []
+        
+        try:
+            with open(file_path, 'r', encoding='utf-8', errors='ignore') as f:
+                content = f.read()
+            
+            file_name = file_path.name
+            
+            # Extract mappings via multiple modes.
+            # Mode 1: doc-comment mappings  /// onnx.OpName -> hip.opname  or  hip.lib.opname.
+            comment_patterns = [
+                (r'///\s*onnx\.(\w+)\s*->\s*hip\.([^\s]+)', 'standard'),
+                (r'///\s*onnx\.Custom\((\w+)\)\s*->\s*hip\.([^\s]+)', 'custom'),
+            ]
+            
+            for pattern, op_type in comment_patterns:
+                matches = re.findall(pattern, content)
+                for onnx_op, hip_op in matches:
+                    # Extract the HIP class name corresponding to this op.
+                    class_name = self._extract_hip_class_name_for_op(content, onnx_op)
+                    # Determine domain.
+                    domain = self._determine_domain_from_code(content, onnx_op)
+
+                    # The hip name in the onnx.Custom doc comment is authoritative;
+                    # do not let the first RmsNormOp::create in the file override it
+                    # (otherwise Skip would be mis-labeled as hip.rmsnorm).
+                    derived_hip_op = self._derive_hip_op_from_class_name(class_name)
+                    if derived_hip_op is not None:
+                        hip_op = derived_hip_op
+
+                    mapping = self._create_mapping(onnx_op, hip_op, file_path, op_type, class_name, domain)
+                    if mapping:
+                        mappings.append(mapping)
+            
+            # Mode 2: mappings discovered via RewritePattern("onnx.<Op>", ...).
+            pattern_matches = re.findall(r'RewritePattern\("onnx\.(\w+)"', content)
+            for onnx_op in pattern_matches:
+                if onnx_op == 'Custom':
+                    continue
+                
+                if any(m['onnx_op'] == onnx_op for m in mappings):
+                    continue
+
+                # Restrict to the matchAndRewrite body of the struct that registers
+                # this RewritePattern, to avoid pollution from sibling structs in the
+                # same file (e.g. NormConversion.cpp holds SimplifiedLayerNormToHip,
+                # SkipSimplifiedLayerNormToHip, and LayerNormToHip together):
+                #   - the first *Op::create in the file may belong to a different struct
+                #   - the substring "com.microsoft" anywhere in the file does not imply
+                #     this struct targets that domain
+                scoped = self._scope_to_rewrite_pattern_body(content, onnx_op) or content
+
+                hip_op = self._extract_hip_op_from_code(scoped)
+                class_name = self._extract_hip_class_name(scoped, onnx_op)
+                domain = self._determine_domain_from_code(scoped, onnx_op)
+                if hip_op:
+                    mapping = self._create_mapping(onnx_op, hip_op, file_path, 'standard', class_name, domain)
+                    if mapping:
+                        mappings.append(mapping)
+            
+            # Mode 3: onnx.Custom ops dispatched via function_name == "<Op>".
+            custom_patterns = re.findall(
+                r'function_name["\']?\s*==\s*["\'](\w+)["\'].*?hip\.([^"\';\s]+)',
+                content,
+                re.DOTALL
+            )
+            for custom_op, hip_op in custom_patterns:
+                # Determine domain dynamically.
+                domain = self._determine_domain_from_code(content, custom_op)
+                class_name = self._extract_hip_class_name_for_op(content, custom_op)
+                mapping = {
+                    'onnx_op': custom_op,
+                    'onnx_domain': domain,
+                    'hip_op': f'hip.{hip_op}',
+                    'class_name': class_name,
+                    'file_name': file_name,
+                    'type': 'custom'
+                }
+                if mapping not in mappings:
+                    mappings.append(mapping)
+            
+            # Mode 3b: infer the Custom op name from the file name. Only triggered
+            # when Mode 3 (function_name) found nothing in this file.
+            if 'RewritePattern("onnx.Custom"' in content and not custom_patterns:
+                inferred_op = self._infer_custom_op_from_filename(file_name)
+                if inferred_op:
+                    # Avoid producing a duplicate mapping for this op.
+                    if not any(m['onnx_op'] == inferred_op for m in mappings):
+                        hip_op = self._extract_hip_op_from_code(content)
+                        class_name = self._extract_hip_class_name(content, inferred_op)
+                        domain = self._determine_domain_from_code(content, inferred_op)
+                        if hip_op:
+                            derived_hip_op = self._derive_hip_op_from_class_name(class_name)
+                            if derived_hip_op is not None:
+                                hip_op = derived_hip_op
+                            mapping = {
+                                'onnx_op': inferred_op,
+                                'onnx_domain': domain,
+                                'hip_op': f'hip.{hip_op}',
+                                'class_name': class_name,
+                                'file_name': file_name,
+                                'type': 'custom'
+                            }
+                            if mapping not in mappings:
+                                mappings.append(mapping)
+            
+            # Mode 4: tensor.* ops -- dynamic extraction from /// doc comments.
+            tensor_ops = self._extract_tensor_ops_dynamic(content, file_path)
+            mappings.extend(tensor_ops)
+        
+        except Exception as e:
+            print(f"  Error parsing {file_path.name}: {e}")
+        
+        return mappings
+    
+    def _create_mapping(self, onnx_op: str, hip_op: str, file_path: Path, op_type: str = 'standard', class_name: str = None, domain: str = None) -> Dict:
+        """Construct a mapping dictionary."""
+        if domain is None:
+            domain = self._determine_domain_from_code('', onnx_op)
+        
+        mapping = {
+            'onnx_op': onnx_op,
+            'onnx_domain': domain,
+            'hip_op': f'hip.{hip_op}' if not hip_op.startswith('hip.') and not hip_op.startswith('tensor.') else hip_op,
+            'class_name': class_name or '',
+            'file_name': file_path.name,
+            'type': op_type
+        }
+        return mapping
+    
+    def _determine_domain_from_code(self, content: str, onnx_op: str) -> str:
+        """Determine the ONNX op domain from source code.
+
+        Callers pass one of two kinds of `content`:
+        1) Scoped to a single struct's matchAndRewrite body (from Mode 2).
+        2) The entire .cpp file text (from Mode 1 / Mode 3).
+
+        A naive whole-file heuristic is wrong on mixed-domain files:
+        e.g. NormConversion.cpp contains both SkipSimplifiedLayerNormToHip
+        (requires com.microsoft) and LayerNormToHip (onnx domain). A check
+        like "file contains the substring 'com.microsoft'" would mis-label
+        onnx.LayerNormalization as com.microsoft.
+        """
+        # Hard-coded whitelist for known ops (preserves historical behavior).
+        if onnx_op == "SimplifiedLayerNormalization":
+            return "onnx"
+        if onnx_op == "SkipSimplifiedLayerNormalization":
+            return "com.microsoft"
+        if onnx_op.startswith("Skip"):
+            return "com.microsoft"
+
+        # Strong signal: an explicit `... != "com.microsoft"` check appears
+        # within scope (or anywhere in the file when called with whole-file content).
+        if re.search(
+            r'domain_name["\']?\s*\)?\s*[!=]=\s*"com\.microsoft"',
+            content,
+        ):
+            return "com.microsoft"
+
+        # Weak signal: the literal "com.microsoft" string co-occurs with the
+        # onnx_op literal anywhere in `content`. This is the main signal for
+        # Mode 3 (Custom + function_name): MS custom-op files typically have
+        # `getAttrOfType<...>("domain_name")` followed several lines later by
+        # `!= "com.microsoft"`. The whitespace/intervening chars defeat the
+        # strict regex, but the substring co-occurrence is reliable.
+        # Mode 2 is safe here: it passes only one struct's scoped body, and a
+        # non-MS struct's body does not contain the "com.microsoft" literal.
+        if "com.microsoft" in content and onnx_op in content:
+            return "com.microsoft"
+
+        return "onnx"
+
+    def _scope_to_rewrite_pattern_body(self, content: str, onnx_op: str) -> Optional[str]:
+        """Scope to the matchAndRewrite body of the struct that registers
+        `RewritePattern("onnx.<onnx_op>", ...)`. Returns None when not found;
+        the caller then falls back to the whole-file content.
+
+        Steps:
+        1) Locate the struct that contains the RewritePattern("onnx.<op>", ...) ctor.
+        2) With the same boundary rule used by _extract_hip_class_name_for_op
+           (the next XxxX::matchAndRewrite / populate* / EOF), slice out that
+           struct's matchAndRewrite body (possibly including the struct decl).
+        """
+        ctor_pat = re.compile(
+            r'struct\s+(\w+)\b[^{}]*?\{[^{}]*?RewritePattern\s*\(\s*"onnx\.'
+            + re.escape(onnx_op)
+            + r'"',
+            re.DOTALL,
+        )
+        m = ctor_pat.search(content)
+        if not m:
+            return None
+        struct_name = m.group(1)
+        struct_start = m.start()
+
+        # Pattern A: out-of-class definition, e.g.
+        #     mlir::LogicalResult LayerNormToHip::matchAndRewrite(...) { ... }
+        # (NormConversion.cpp style). Critical: `LayerNormToHip` is a suffix of
+        # `SimplifiedLayerNormToHip`, so we MUST use the negative lookbehind
+        # (?<!\w) to force a word-boundary start; otherwise the regex matches
+        # the longer sibling struct's matchAndRewrite and slices the wrong body.
+        body_match = re.search(
+            r'(?<!\w)'
+            + re.escape(struct_name)
+            + r'::matchAndRewrite'
+            + r'[\s\S]*?'
+            + r'(?='
+            + r'\n(?!' + re.escape(struct_name) + r'\b)\w+::matchAndRewrite'
+            + r'|\n[\w:]*populate\w*'
+            + r'|\Z)',
+            content,
+        )
+        if body_match:
+            return content[struct_start:body_match.end()]
+
+        # Pattern B: matchAndRewrite is defined INLINE inside the struct
+        # (SliceConversion.cpp style). Walk balanced braces from the struct's
+        # opening `{` to find the matching closing `}`, then return the
+        # full struct body. Truncate-by-window is unsafe here because inline
+        # bodies routinely exceed any fixed window (Slice is >4 KB).
+        brace_pos = content.find('{', struct_start)
+        if brace_pos >= 0:
+            depth = 0
+            i = brace_pos
+            n = len(content)
+            while i < n:
+                ch = content[i]
+                if ch == '{':
+                    depth += 1
+                elif ch == '}':
+                    depth -= 1
+                    if depth == 0:
+                        # Include the closing brace and optional trailing `;`.
+                        end = i + 1
+                        if end < n and content[end] == ';':
+                            end += 1
+                        return content[struct_start:end]
+                i += 1
+            # Unbalanced braces (malformed source): fall through to window.
+
+        # Last-resort window when nothing else matches.
+        return content[struct_start:struct_start + 4000]
+    
+    def _extract_hip_class_name(self, content: str, onnx_op: str) -> str:
+        """Extract the HIP C++ class name from source code."""
+        # Try the mlir::hip::XxxOp::create pattern first.
+        hip_classes = re.findall(r'mlir::hip::(\w+Op)::create', content)
+        if hip_classes:
+            return hip_classes[0]
+        
+        # Try the MiopenXxxOp pattern.
+        miopen_classes = re.findall(r'(Miopen\w+Op)', content)
+        if miopen_classes:
+            return miopen_classes[0]
+        
+        # Try the generic XxxOp pattern (e.g. AddOp, MulOp).
+        op_classes = re.findall(r'(\w+Op)(?:\s*::|::create)', content)
+        if op_classes:
+            return op_classes[0]
+
+        # Fallback: derive the CamelCase class name from
+        # OperationState(loc, "hip.snake_case"). Patterns like LayerNormToHip
+        # that do not use *Op::create rely on this fallback. We accept both:
+        #   mlir::OperationState(loc, "hip.xxx")              -- expression form
+        #   mlir::OperationState state(loc, "hip.xxx");        -- declaration form
+        hip_ops = re.findall(
+            r'OperationState(?:\s+\w+)?\s*\(\s*[^,]+,\s*"hip\.([^"]+)"', content
+        )
+        if hip_ops:
+            return ''.join(w.capitalize() for w in hip_ops[0].split('_')) + 'Op'
+
+        return ''
+    
+    def _extract_hip_class_name_for_op(self, content: str, onnx_op: str) -> str:
+        """Extract the HIP C++ class name for a specific onnx_op."""
+        # Mode 0: known onnx_op -> C++ struct abbreviation (handles cases where
+        # Skip... names do not match the struct via the generic regex).
+        struct_hint = self._STRUCT_NAME_BY_ONNX_OP.get(onnx_op)
+        if struct_hint:
+            pattern = rf'struct\s+{re.escape(struct_hint)}\b.*?(?=struct\s+\w+ToHip|void\s+mlir::hip::populate|\Z)'
+            match = re.search(pattern, content, re.DOTALL)
+            if match:
+                struct_content = match.group(0)
+                hip_classes = re.findall(r"mlir::hip::(\w+Op)::create", struct_content)
+                if hip_classes:
+                    return hip_classes[0]
+                hip_ops = re.findall(
+                    r'OperationState(?:\s+\w+)?\s*\(\s*[^,]+,\s*"hip\.([^"]+)"', struct_content
+                )
+                if hip_ops:
+                    hip_op = hip_ops[0]
+                    return (
+                        "".join(word.capitalize() for word in hip_op.split("_")) + "Op"
+                    )
+
+        # Mode 1: locate the struct containing this op.
+        # For SkipSimplifiedLayerNormalization look for SkipSimplifiedLayerNormToHip.
+        pattern = rf'struct\s+(\w*{re.escape(onnx_op)}\w*ToHip).*?(?=struct\s+\w+ToHip|void\s+mlir::hip::populate|\Z)'
+        match = re.search(pattern, content, re.DOTALL)
+        if match:
+            struct_name = match.group(1)
+
+            # Then find the matchAndRewrite definition for that struct
+            # (the create call usually lives there).
+            fn_pat = (
+                rf'{re.escape(struct_name)}::matchAndRewrite'
+                rf'[\s\S]*?(?=\n\w+::matchAndRewrite|\nvoid\s+mlir::hip::populate|\Z)'
+            )
+            fn_match = re.search(fn_pat, content, re.DOTALL)
+            if fn_match:
+                fn_content = fn_match.group(0)
+                hip_classes = re.findall(r'mlir::hip::(\w+Op)::create', fn_content)
+                if hip_classes:
+                    return hip_classes[0]
+                hip_ops = re.findall(
+                    r'OperationState(?:\s+\w+)?\s*\(\s*[^,]+,\s*"hip\.([^"]+)"', fn_content
+                )
+                if hip_ops:
+                    hip_op = hip_ops[0]
+                    class_name = ''.join(word.capitalize() for word in hip_op.split('_')) + 'Op'
+                    return class_name
+        
+        # Fall back to the generic extractor when scoped lookups fail.
+        return self._extract_hip_class_name(content, onnx_op)
+    
+    def _extract_hip_op_from_code(self, content: str) -> str:
+        """Extract the HIP op mnemonic from source code."""
+        # Prefer derivation from the HIP class name (more accurate).
+        hip_classes = re.findall(r'mlir::hip::(\w+Op)::create', content)
+        if hip_classes:
+            class_name = hip_classes[0]
+            from_td = self._derive_hip_op_from_class_name(class_name)
+            if from_td is not None:
+                return from_td
+            op_name = class_name.replace('Op', '').lower()
+            return op_name
+        
+        # Next, parse OperationState (accepts the OperationState state(loc, "hip.xxx") declaration form).
+        hip_ops = re.findall(
+            r'OperationState(?:\s+\w+)?\s*\(\s*[^,]+,\s*"hip\.([^"]+)"', content
+        )
+        if hip_ops:
+            return hip_ops[0]
+        
+        # Last resort: pick from any inline comment / string mentioning hip.xxx.
+        hip_ops = re.findall(r'hip\.(\w+(?:\.\w+)?)', content)
+        if hip_ops:
+            return hip_ops[0]
+        
+        return None
+    
+    def _derive_hip_op_from_class_name(self, class_name: str) -> Optional[str]:
+        """Look up the hip.* mnemonic for a mlir::hip::XxxOp C++ class name
+        from the HipOps.td TableGen mapping."""
+        if not class_name:
+            return None
+        mnemonic = self._cpp_class_to_mnemonic.get(class_name)
+        if mnemonic is not None:
+            return mnemonic
+        return None
+    
+    def _infer_custom_op_from_filename(self, file_name: str) -> str:
+        """Infer a Custom op name from the conversion file name."""
+        base_name = file_name.replace('Conversion.cpp', '')
+        
+        # Skip files that are already handled by Mode 3 via function_name.
+        # E.g. GqaConversion.cpp is already picked up via function_name="GroupQueryAttention".
+        if base_name in ['Gqa', 'Norm']:
+            return None
+        
+        # Otherwise return the base name as-is and let downstream code resolve it.
+        # We deliberately avoid hardcoded name mappings.
+        return base_name if base_name else None
+    
+    def _extract_tensor_ops_dynamic(self, content: str, file_path: Path) -> List[Dict]:
+        """Extract onnx -> tensor.* mappings from doc-comment lines.
+
+        Older implementations used `onnx\\.Op.*?tensor\\.(...)` with DOTALL,
+        which silently spanned function boundaries inside one file: e.g. the
+        second `onnx.Unsqueeze` line (the RewritePattern reference) followed
+        by `.*?` would extend down to a later `/// onnx.Squeeze -> tensor.collapse_shape`
+        comment, mis-labeling Unsqueeze as collapse_shape. Plain string
+        literals containing onnx.Constant also triggered false matches.
+        Therefore we only honor tensor.xxx that appears on the SAME line as
+        a `/// onnx.X -> ...` doc comment.
+        """
+        mappings: List[Dict] = []
+        line_pat = re.compile(
+            r"^\s*///\s*onnx\.(\w+)\s*->\s*(.+?)\s*$",
+        )
+        tensor_pat = re.compile(r"tensor\.(\w+(?:\.\w+)*)")
+
+        for raw_line in content.splitlines():
+            m = line_pat.match(raw_line)
+            if not m:
+                continue
+            onnx_op, rhs = m.group(1), m.group(2)
+            if "tensor." not in rhs:
+                continue
+            seen: Set[str] = set()
+            for tm in tensor_pat.finditer(rhs):
+                tensor_op = tm.group(1)
+                if tensor_op in seen:
+                    continue
+                seen.add(tensor_op)
+                mapping = {
+                    "onnx_op": onnx_op,
+                    "onnx_domain": "onnx",
+                    "hip_op": f"tensor.{tensor_op}",
+                    "class_name": "",
+                    "file_name": file_path.name,
+                    "type": "tensor",
+                }
+                if mapping not in mappings:
+                    mappings.append(mapping)
+
+        return mappings
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(
+            "Usage: python step2_1_onnx_to_hip_parser.py <conversion_dir> [output_dir] [HipOps.td]"
+        )
+        sys.exit(1)
+
+    conversion_dir = sys.argv[1]
+    output_dir = sys.argv[2] if len(sys.argv) > 2 else str(Path(conversion_dir).parent)
+    hip_td = sys.argv[3] if len(sys.argv) > 3 else None
+
+    Path(output_dir).mkdir(parents=True, exist_ok=True)
+
+    print(
+        "Parsing OnnxToHip conversions (v5 - HipOps.td mnemonics + Norm fixes)..."
+    )
+    print(f"Conversion directory: {conversion_dir}")
+    print(f"Output directory: {output_dir}\n")
+
+    parser = OnnxToHipParser(conversion_dir, hip_ops_td=hip_td)
+    if parser._hip_td_path:
+        n = len(parser._cpp_class_to_mnemonic)
+        print(f"HipOps.td: {parser._hip_td_path} ({n} C++ op classes -> mnemonic)\n")
+    result = parser.parse()
+    
+    print(f"\n{'='*80}")
+    print(f"Summary:")
+    print(f"  Total mappings: {result['statistics']['total_mappings']}")
+    print(f"  Unique ONNX ops: {result['statistics']['unique_onnx_ops']}")
+    print(f"  Unique domains: {result['statistics']['unique_domains']}")
+    print(f"  Unique Hip ops: {result['statistics']['unique_hip_ops']}")
+    print(f"{'='*80}\n")
+    
+    json_path = Path(output_dir) / "step2_1_onnx_to_hip_mappings.json"
+    with open(json_path, 'w', encoding='utf-8') as f:
+        json.dump(result, f, indent=2, ensure_ascii=False)
+    print(f"[OK] Mappings saved: {json_path}")
+    
+    md_path = Path(output_dir) / "step2_1_onnx_to_hip_mappings.md"
+    with open(md_path, 'w', encoding='utf-8') as f:
+        f.write(generate_markdown_report(result))
+    print(f"[OK] Markdown report saved: {md_path}")
+
+
+def generate_markdown_report(result: Dict) -> str:
+    """Render the ONNX->HIP mapping table as a Markdown report."""
+    report = []
+    
+    report.append("# ONNX to Hip Conversion Mappings (v5 - Fixed SkipSimplifiedLayerNormalization & Unsqueeze)\n\n")
+    
+    report.append("## Summary\n\n")
+    stats = result['statistics']
+    report.append(f"- **Total Mappings**: {stats['total_mappings']}\n")
+    report.append(f"- **Unique ONNX Operations**: {stats['unique_onnx_ops']}\n")
+    report.append(f"- **Unique Domains**: {stats['unique_domains']}\n")
+    report.append(f"- **Unique Hip Operations**: {stats['unique_hip_ops']}\n\n")
+    
+    report.append("## Mappings by Domain\n\n")
+    
+    domains = {}
+    for mapping in result['mappings']:
+        domain = mapping['onnx_domain']
+        if domain not in domains:
+            domains[domain] = []
+        domains[domain].append(mapping)
+    
+    for domain in sorted(domains.keys()):
+        report.append(f"### Domain: {domain}\n\n")
+        report.append("| ONNX Op | Hip Op | Class Name | File | Type |\n")
+        report.append("|---|---|---|---|---|\n")
+        
+        for mapping in sorted(domains[domain], key=lambda x: x['onnx_op']):
+            onnx_op = mapping['onnx_op']
+            hip_op = mapping['hip_op']
+            class_name = mapping.get('class_name', '')
+            file_name = mapping['file_name']
+            op_type = mapping['type']
+            report.append(f"| {onnx_op} | {hip_op} | {class_name} | {file_name} | {op_type} |\n")
+        
+        report.append("\n")
+    
+    return ''.join(report)
+
+
+if __name__ == '__main__':
+    main()

--- a/.cursor/skills/model-compatibility/scripts/step2_1_onnx_to_hip_parser.py
+++ b/.cursor/skills/model-compatibility/scripts/step2_1_onnx_to_hip_parser.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
 """
 Step 2-1 Final v5: OnnxToHip Conversion Parser - Fixed SkipSimplifiedLayerNormalization
 Extract precise mappings (onnx_op, onnx_domain, hip_op, class_name, file_name).
@@ -59,66 +63,65 @@ class OnnxToHipParser:
             return p if p.is_file() else None
         candidate = default_hip_ops_td_path(self.conversion_dir)
         return candidate if candidate.is_file() else None
-    
+
     def parse(self) -> Dict:
         """Parse every OnnxToHip conversion file."""
-        result = {
-            'mappings': [],
-            'statistics': {}
-        }
-        
+        result = {"mappings": [], "statistics": {}}
+
         # Discover all OnnxToHip conversion files.
-        conversion_files = sorted(self.conversion_dir.glob('OnnxToHip/*.cpp'))
-        
+        conversion_files = sorted(self.conversion_dir.glob("OnnxToHip/*.cpp"))
+
         print(f"Found {len(conversion_files)} conversion files\n")
-        
+
         for file_path in conversion_files:
             print(f"Parsing: {file_path.name}")
             mappings = self._parse_conversion_file(file_path)
-            result['mappings'].extend(mappings)
-            
+            result["mappings"].extend(mappings)
+
             # Echo this file's mappings.
             for mapping in mappings:
-                class_name = mapping.get('class_name', '')
-                print(f"  {mapping['onnx_op']:30} ({mapping['onnx_domain']:15}) -> {mapping['hip_op']:30} [{class_name}]")
-        
+                class_name = mapping.get("class_name", "")
+                print(
+                    f"  {mapping['onnx_op']:30} ({mapping['onnx_domain']:15}) -> {mapping['hip_op']:30} [{class_name}]"
+                )
+
         # Deduplicate: keep the first mapping per (onnx_op, onnx_domain, hip_op).
         unique_mappings = {}
-        for mapping in result['mappings']:
-            key = (mapping['onnx_op'], mapping['onnx_domain'], mapping['hip_op'])
+        for mapping in result["mappings"]:
+            key = (mapping["onnx_op"], mapping["onnx_domain"], mapping["hip_op"])
             if key not in unique_mappings:
                 unique_mappings[key] = mapping
-        
-        result['mappings'] = list(unique_mappings.values())
-        
+
+        result["mappings"] = list(unique_mappings.values())
+
         # Compute summary statistics.
-        result['statistics'] = {
-            'total_mappings': len(result['mappings']),
-            'total_conversion_files': len(conversion_files),
-            'unique_onnx_ops': len(set(m['onnx_op'] for m in result['mappings'])),
-            'unique_domains': len(set(m['onnx_domain'] for m in result['mappings'])),
-            'unique_hip_ops': len(set(m['hip_op'] for m in result['mappings'])),
+        result["statistics"] = {
+            "total_mappings": len(result["mappings"]),
+            "total_conversion_files": len(conversion_files),
+            "unique_onnx_ops": len(set(m["onnx_op"] for m in result["mappings"])),
+            "unique_domains": len(set(m["onnx_domain"] for m in result["mappings"])),
+            "unique_hip_ops": len(set(m["hip_op"] for m in result["mappings"])),
         }
-        
+
         return result
-    
+
     def _parse_conversion_file(self, file_path: Path) -> List[Dict]:
         """Parse a single conversion file and return all mappings."""
         mappings = []
-        
+
         try:
-            with open(file_path, 'r', encoding='utf-8', errors='ignore') as f:
+            with open(file_path, "r", encoding="utf-8", errors="ignore") as f:
                 content = f.read()
-            
+
             file_name = file_path.name
-            
+
             # Extract mappings via multiple modes.
             # Mode 1: doc-comment mappings  /// onnx.OpName -> hip.opname  or  hip.lib.opname.
             comment_patterns = [
-                (r'///\s*onnx\.(\w+)\s*->\s*hip\.([^\s]+)', 'standard'),
-                (r'///\s*onnx\.Custom\((\w+)\)\s*->\s*hip\.([^\s]+)', 'custom'),
+                (r"///\s*onnx\.(\w+)\s*->\s*hip\.([^\s]+)", "standard"),
+                (r"///\s*onnx\.Custom\((\w+)\)\s*->\s*hip\.([^\s]+)", "custom"),
             ]
-            
+
             for pattern, op_type in comment_patterns:
                 matches = re.findall(pattern, content)
                 for onnx_op, hip_op in matches:
@@ -134,10 +137,12 @@ class OnnxToHipParser:
                     if derived_hip_op is not None:
                         hip_op = derived_hip_op
 
-                    mapping = self._create_mapping(onnx_op, hip_op, file_path, op_type, class_name, domain)
+                    mapping = self._create_mapping(
+                        onnx_op, hip_op, file_path, op_type, class_name, domain
+                    )
                     if mapping:
                         mappings.append(mapping)
-            
+
             # Mode 2: mappings discovered via RewritePattern("onnx.<Op>", ...).
             # Each occurrence is scoped to its OWN struct (a single onnx_op
             # may legitimately have multiple registrations in one file, e.g.
@@ -148,20 +153,25 @@ class OnnxToHipParser:
             # fold variant simply yields no hip_op and gets skipped.
             for rp_match in re.finditer(r'RewritePattern\("onnx\.(\w+)"', content):
                 onnx_op = rp_match.group(1)
-                if onnx_op == 'Custom':
+                if onnx_op == "Custom":
                     continue
 
                 # Restrict to the struct body containing THIS specific
                 # RewritePattern position, not the file's first one.
-                scoped = self._scope_to_rewrite_pattern_body(
-                    content, onnx_op, start_pos=rp_match.start()
-                ) or content
+                scoped = (
+                    self._scope_to_rewrite_pattern_body(
+                        content, onnx_op, start_pos=rp_match.start()
+                    )
+                    or content
+                )
 
                 hip_op = self._extract_hip_op_from_code(scoped)
                 class_name = self._extract_hip_class_name(scoped, onnx_op)
                 domain = self._determine_domain_from_code(scoped, onnx_op)
                 if hip_op:
-                    mapping = self._create_mapping(onnx_op, hip_op, file_path, 'standard', class_name, domain)
+                    mapping = self._create_mapping(
+                        onnx_op, hip_op, file_path, "standard", class_name, domain
+                    )
                     if mapping:
                         mappings.append(mapping)
                 else:
@@ -179,83 +189,95 @@ class OnnxToHipParser:
                             onnx_op,
                             f"tensor.{td_op}",
                             file_path,
-                            'compile_time',
-                            'StdMlirLowering',
+                            "compile_time",
+                            "StdMlirLowering",
                             domain,
                         )
                         if mapping:
                             mappings.append(mapping)
-            
+
             # Mode 3: onnx.Custom ops dispatched via function_name == "<Op>".
             custom_patterns = re.findall(
                 r'function_name["\']?\s*==\s*["\'](\w+)["\'].*?hip\.([^"\';\s]+)',
                 content,
-                re.DOTALL
+                re.DOTALL,
             )
             for custom_op, hip_op in custom_patterns:
                 # Determine domain dynamically.
                 domain = self._determine_domain_from_code(content, custom_op)
                 class_name = self._extract_hip_class_name_for_op(content, custom_op)
                 mapping = {
-                    'onnx_op': custom_op,
-                    'onnx_domain': domain,
-                    'hip_op': f'hip.{hip_op}',
-                    'class_name': class_name,
-                    'file_name': file_name,
-                    'type': 'custom'
+                    "onnx_op": custom_op,
+                    "onnx_domain": domain,
+                    "hip_op": f"hip.{hip_op}",
+                    "class_name": class_name,
+                    "file_name": file_name,
+                    "type": "custom",
                 }
                 if mapping not in mappings:
                     mappings.append(mapping)
-            
+
             # Mode 3b: infer the Custom op name from the file name. Only triggered
             # when Mode 3 (function_name) found nothing in this file.
             if 'RewritePattern("onnx.Custom"' in content and not custom_patterns:
                 inferred_op = self._infer_custom_op_from_filename(file_name)
                 if inferred_op:
                     # Avoid producing a duplicate mapping for this op.
-                    if not any(m['onnx_op'] == inferred_op for m in mappings):
+                    if not any(m["onnx_op"] == inferred_op for m in mappings):
                         hip_op = self._extract_hip_op_from_code(content)
                         class_name = self._extract_hip_class_name(content, inferred_op)
                         domain = self._determine_domain_from_code(content, inferred_op)
                         if hip_op:
-                            derived_hip_op = self._derive_hip_op_from_class_name(class_name)
+                            derived_hip_op = self._derive_hip_op_from_class_name(
+                                class_name
+                            )
                             if derived_hip_op is not None:
                                 hip_op = derived_hip_op
                             mapping = {
-                                'onnx_op': inferred_op,
-                                'onnx_domain': domain,
-                                'hip_op': f'hip.{hip_op}',
-                                'class_name': class_name,
-                                'file_name': file_name,
-                                'type': 'custom'
+                                "onnx_op": inferred_op,
+                                "onnx_domain": domain,
+                                "hip_op": f"hip.{hip_op}",
+                                "class_name": class_name,
+                                "file_name": file_name,
+                                "type": "custom",
                             }
                             if mapping not in mappings:
                                 mappings.append(mapping)
-            
+
             # Mode 4: tensor.* ops -- dynamic extraction from /// doc comments.
             tensor_ops = self._extract_tensor_ops_dynamic(content, file_path)
             mappings.extend(tensor_ops)
-        
+
         except Exception as e:
             print(f"  Error parsing {file_path.name}: {e}")
-        
+
         return mappings
-    
-    def _create_mapping(self, onnx_op: str, hip_op: str, file_path: Path, op_type: str = 'standard', class_name: str = None, domain: str = None) -> Dict:
+
+    def _create_mapping(
+        self,
+        onnx_op: str,
+        hip_op: str,
+        file_path: Path,
+        op_type: str = "standard",
+        class_name: str = None,
+        domain: str = None,
+    ) -> Dict:
         """Construct a mapping dictionary."""
         if domain is None:
-            domain = self._determine_domain_from_code('', onnx_op)
-        
+            domain = self._determine_domain_from_code("", onnx_op)
+
         mapping = {
-            'onnx_op': onnx_op,
-            'onnx_domain': domain,
-            'hip_op': f'hip.{hip_op}' if not hip_op.startswith('hip.') and not hip_op.startswith('tensor.') else hip_op,
-            'class_name': class_name or '',
-            'file_name': file_path.name,
-            'type': op_type
+            "onnx_op": onnx_op,
+            "onnx_domain": domain,
+            "hip_op": f"hip.{hip_op}"
+            if not hip_op.startswith("hip.") and not hip_op.startswith("tensor.")
+            else hip_op,
+            "class_name": class_name or "",
+            "file_name": file_path.name,
+            "type": op_type,
         }
         return mapping
-    
+
     def _determine_domain_from_code(self, content: str, onnx_op: str) -> str:
         """Determine the ONNX op domain from source code.
 
@@ -298,8 +320,9 @@ class OnnxToHipParser:
 
         return "onnx"
 
-    def _scope_to_rewrite_pattern_body(self, content: str, onnx_op: str,
-                                       start_pos: int = 0) -> Optional[str]:
+    def _scope_to_rewrite_pattern_body(
+        self, content: str, onnx_op: str, start_pos: int = 0
+    ) -> Optional[str]:
         """Scope to the matchAndRewrite body of the struct that registers
         `RewritePattern("onnx.<onnx_op>", ...)`. Returns None when not found;
         the caller then falls back to the whole-file content.
@@ -344,61 +367,63 @@ class OnnxToHipParser:
         # (?<!\w) to force a word-boundary start; otherwise the regex matches
         # the longer sibling struct's matchAndRewrite and slices the wrong body.
         body_match = re.search(
-            r'(?<!\w)'
+            r"(?<!\w)"
             + re.escape(struct_name)
-            + r'::matchAndRewrite'
-            + r'[\s\S]*?'
-            + r'(?='
-            + r'\n(?!' + re.escape(struct_name) + r'\b)\w+::matchAndRewrite'
-            + r'|\n[\w:]*populate\w*'
-            + r'|\Z)',
+            + r"::matchAndRewrite"
+            + r"[\s\S]*?"
+            + r"(?="
+            + r"\n(?!"
+            + re.escape(struct_name)
+            + r"\b)\w+::matchAndRewrite"
+            + r"|\n[\w:]*populate\w*"
+            + r"|\Z)",
             content,
         )
         if body_match:
-            return content[struct_start:body_match.end()]
+            return content[struct_start : body_match.end()]
 
         # Pattern B: matchAndRewrite is defined INLINE inside the struct
         # (SliceConversion.cpp style). Walk balanced braces from the struct's
         # opening `{` to find the matching closing `}`, then return the
         # full struct body. Truncate-by-window is unsafe here because inline
         # bodies routinely exceed any fixed window (Slice is >4 KB).
-        brace_pos = content.find('{', struct_start)
+        brace_pos = content.find("{", struct_start)
         if brace_pos >= 0:
             depth = 0
             i = brace_pos
             n = len(content)
             while i < n:
                 ch = content[i]
-                if ch == '{':
+                if ch == "{":
                     depth += 1
-                elif ch == '}':
+                elif ch == "}":
                     depth -= 1
                     if depth == 0:
                         # Include the closing brace and optional trailing `;`.
                         end = i + 1
-                        if end < n and content[end] == ';':
+                        if end < n and content[end] == ";":
                             end += 1
                         return content[struct_start:end]
                 i += 1
             # Unbalanced braces (malformed source): fall through to window.
 
         # Last-resort window when nothing else matches.
-        return content[struct_start:struct_start + 4000]
-    
+        return content[struct_start : struct_start + 4000]
+
     def _extract_hip_class_name(self, content: str, onnx_op: str) -> str:
         """Extract the HIP C++ class name from source code."""
         # Try the mlir::hip::XxxOp::create pattern first.
-        hip_classes = re.findall(r'mlir::hip::(\w+Op)::create', content)
+        hip_classes = re.findall(r"mlir::hip::(\w+Op)::create", content)
         if hip_classes:
             return hip_classes[0]
-        
+
         # Try the MiopenXxxOp pattern.
-        miopen_classes = re.findall(r'(Miopen\w+Op)', content)
+        miopen_classes = re.findall(r"(Miopen\w+Op)", content)
         if miopen_classes:
             return miopen_classes[0]
-        
+
         # Try the generic XxxOp pattern (e.g. AddOp, MulOp).
-        op_classes = re.findall(r'(\w+Op)(?:\s*::|::create)', content)
+        op_classes = re.findall(r"(\w+Op)(?:\s*::|::create)", content)
         if op_classes:
             return op_classes[0]
 
@@ -411,17 +436,17 @@ class OnnxToHipParser:
             r'OperationState(?:\s+\w+)?\s*\(\s*[^,]+,\s*"hip\.([^"]+)"', content
         )
         if hip_ops:
-            return ''.join(w.capitalize() for w in hip_ops[0].split('_')) + 'Op'
+            return "".join(w.capitalize() for w in hip_ops[0].split("_")) + "Op"
 
-        return ''
-    
+        return ""
+
     def _extract_hip_class_name_for_op(self, content: str, onnx_op: str) -> str:
         """Extract the HIP C++ class name for a specific onnx_op."""
         # Mode 0: known onnx_op -> C++ struct abbreviation (handles cases where
         # Skip... names do not match the struct via the generic regex).
         struct_hint = self._STRUCT_NAME_BY_ONNX_OP.get(onnx_op)
         if struct_hint:
-            pattern = rf'struct\s+{re.escape(struct_hint)}\b.*?(?=struct\s+\w+ToHip|void\s+mlir::hip::populate|\Z)'
+            pattern = rf"struct\s+{re.escape(struct_hint)}\b.*?(?=struct\s+\w+ToHip|void\s+mlir::hip::populate|\Z)"
             match = re.search(pattern, content, re.DOTALL)
             if match:
                 struct_content = match.group(0)
@@ -429,7 +454,8 @@ class OnnxToHipParser:
                 if hip_classes:
                     return hip_classes[0]
                 hip_ops = re.findall(
-                    r'OperationState(?:\s+\w+)?\s*\(\s*[^,]+,\s*"hip\.([^"]+)"', struct_content
+                    r'OperationState(?:\s+\w+)?\s*\(\s*[^,]+,\s*"hip\.([^"]+)"',
+                    struct_content,
                 )
                 if hip_ops:
                     hip_op = hip_ops[0]
@@ -439,7 +465,7 @@ class OnnxToHipParser:
 
         # Mode 1: locate the struct containing this op.
         # For SkipSimplifiedLayerNormalization look for SkipSimplifiedLayerNormToHip.
-        pattern = rf'struct\s+(\w*{re.escape(onnx_op)}\w*ToHip).*?(?=struct\s+\w+ToHip|void\s+mlir::hip::populate|\Z)'
+        pattern = rf"struct\s+(\w*{re.escape(onnx_op)}\w*ToHip).*?(?=struct\s+\w+ToHip|void\s+mlir::hip::populate|\Z)"
         match = re.search(pattern, content, re.DOTALL)
         if match:
             struct_name = match.group(1)
@@ -447,26 +473,29 @@ class OnnxToHipParser:
             # Then find the matchAndRewrite definition for that struct
             # (the create call usually lives there).
             fn_pat = (
-                rf'{re.escape(struct_name)}::matchAndRewrite'
-                rf'[\s\S]*?(?=\n\w+::matchAndRewrite|\nvoid\s+mlir::hip::populate|\Z)'
+                rf"{re.escape(struct_name)}::matchAndRewrite"
+                rf"[\s\S]*?(?=\n\w+::matchAndRewrite|\nvoid\s+mlir::hip::populate|\Z)"
             )
             fn_match = re.search(fn_pat, content, re.DOTALL)
             if fn_match:
                 fn_content = fn_match.group(0)
-                hip_classes = re.findall(r'mlir::hip::(\w+Op)::create', fn_content)
+                hip_classes = re.findall(r"mlir::hip::(\w+Op)::create", fn_content)
                 if hip_classes:
                     return hip_classes[0]
                 hip_ops = re.findall(
-                    r'OperationState(?:\s+\w+)?\s*\(\s*[^,]+,\s*"hip\.([^"]+)"', fn_content
+                    r'OperationState(?:\s+\w+)?\s*\(\s*[^,]+,\s*"hip\.([^"]+)"',
+                    fn_content,
                 )
                 if hip_ops:
                     hip_op = hip_ops[0]
-                    class_name = ''.join(word.capitalize() for word in hip_op.split('_')) + 'Op'
+                    class_name = (
+                        "".join(word.capitalize() for word in hip_op.split("_")) + "Op"
+                    )
                     return class_name
-        
+
         # Fall back to the generic extractor when scoped lookups fail.
         return self._extract_hip_class_name(content, onnx_op)
-    
+
     def _extract_std_dialect_op(self, content: str) -> Optional[str]:
         """Return a representative standard-MLIR-dialect op name produced by
         a conversion that does NOT call any hip.* op. Used to classify
@@ -486,42 +515,42 @@ class OnnxToHipParser:
         to trigger COMPILE_TIME_TENSOR_OP downstream.
         """
         matches = re.findall(
-            r'(?:mlir::)?(?:tensor|arith|memref)::(\w+)Op::create',
+            r"(?:mlir::)?(?:tensor|arith|memref)::(\w+)Op::create",
             content,
         )
         if not matches:
             return None
         cls = matches[-1]
         # CamelCase -> snake_case (handles ConstantIndexOp, SplatOp, etc.)
-        snake = re.sub(r'(?<!^)([A-Z])', r'_\1', cls).lower()
+        snake = re.sub(r"(?<!^)([A-Z])", r"_\1", cls).lower()
         return snake
 
     def _extract_hip_op_from_code(self, content: str) -> str:
         """Extract the HIP op mnemonic from source code."""
         # Prefer derivation from the HIP class name (more accurate).
-        hip_classes = re.findall(r'mlir::hip::(\w+Op)::create', content)
+        hip_classes = re.findall(r"mlir::hip::(\w+Op)::create", content)
         if hip_classes:
             class_name = hip_classes[0]
             from_td = self._derive_hip_op_from_class_name(class_name)
             if from_td is not None:
                 return from_td
-            op_name = class_name.replace('Op', '').lower()
+            op_name = class_name.replace("Op", "").lower()
             return op_name
-        
+
         # Next, parse OperationState (accepts the OperationState state(loc, "hip.xxx") declaration form).
         hip_ops = re.findall(
             r'OperationState(?:\s+\w+)?\s*\(\s*[^,]+,\s*"hip\.([^"]+)"', content
         )
         if hip_ops:
             return hip_ops[0]
-        
+
         # Last resort: pick from any inline comment / string mentioning hip.xxx.
-        hip_ops = re.findall(r'hip\.(\w+(?:\.\w+)?)', content)
+        hip_ops = re.findall(r"hip\.(\w+(?:\.\w+)?)", content)
         if hip_ops:
             return hip_ops[0]
-        
+
         return None
-    
+
     def _derive_hip_op_from_class_name(self, class_name: str) -> Optional[str]:
         """Look up the hip.* mnemonic for a mlir::hip::XxxOp C++ class name
         from the HipOps.td TableGen mapping."""
@@ -531,20 +560,20 @@ class OnnxToHipParser:
         if mnemonic is not None:
             return mnemonic
         return None
-    
+
     def _infer_custom_op_from_filename(self, file_name: str) -> str:
         """Infer a Custom op name from the conversion file name."""
-        base_name = file_name.replace('Conversion.cpp', '')
-        
+        base_name = file_name.replace("Conversion.cpp", "")
+
         # Skip files that are already handled by Mode 3 via function_name.
         # E.g. GqaConversion.cpp is already picked up via function_name="GroupQueryAttention".
-        if base_name in ['Gqa', 'Norm']:
+        if base_name in ["Gqa", "Norm"]:
             return None
-        
+
         # Otherwise return the base name as-is and let downstream code resolve it.
         # We deliberately avoid hardcoded name mappings.
         return base_name if base_name else None
-    
+
     def _extract_tensor_ops_dynamic(self, content: str, file_path: Path) -> List[Dict]:
         """Extract onnx -> tensor.* mappings from doc-comment lines.
 
@@ -603,9 +632,7 @@ def main():
 
     Path(output_dir).mkdir(parents=True, exist_ok=True)
 
-    print(
-        "Parsing OnnxToHip conversions (v5 - HipOps.td mnemonics + Norm fixes)..."
-    )
+    print("Parsing OnnxToHip conversions (v5 - HipOps.td mnemonics + Norm fixes)...")
     print(f"Conversion directory: {conversion_dir}")
     print(f"Output directory: {output_dir}\n")
 
@@ -614,22 +641,22 @@ def main():
         n = len(parser._cpp_class_to_mnemonic)
         print(f"HipOps.td: {parser._hip_td_path} ({n} C++ op classes -> mnemonic)\n")
     result = parser.parse()
-    
-    print(f"\n{'='*80}")
-    print(f"Summary:")
+
+    print(f"\n{'=' * 80}")
+    print("Summary:")
     print(f"  Total mappings: {result['statistics']['total_mappings']}")
     print(f"  Unique ONNX ops: {result['statistics']['unique_onnx_ops']}")
     print(f"  Unique domains: {result['statistics']['unique_domains']}")
     print(f"  Unique Hip ops: {result['statistics']['unique_hip_ops']}")
-    print(f"{'='*80}\n")
-    
+    print(f"{'=' * 80}\n")
+
     json_path = Path(output_dir) / "step2_1_onnx_to_hip_mappings.json"
-    with open(json_path, 'w', encoding='utf-8') as f:
+    with open(json_path, "w", encoding="utf-8") as f:
         json.dump(result, f, indent=2, ensure_ascii=False)
     print(f"[OK] Mappings saved: {json_path}")
-    
+
     md_path = Path(output_dir) / "step2_1_onnx_to_hip_mappings.md"
-    with open(md_path, 'w', encoding='utf-8') as f:
+    with open(md_path, "w", encoding="utf-8") as f:
         f.write(generate_markdown_report(result))
     print(f"[OK] Markdown report saved: {md_path}")
 
@@ -637,42 +664,46 @@ def main():
 def generate_markdown_report(result: Dict) -> str:
     """Render the ONNX->HIP mapping table as a Markdown report."""
     report = []
-    
-    report.append("# ONNX to Hip Conversion Mappings (v5 - Fixed SkipSimplifiedLayerNormalization & Unsqueeze)\n\n")
-    
+
+    report.append(
+        "# ONNX to Hip Conversion Mappings (v5 - Fixed SkipSimplifiedLayerNormalization & Unsqueeze)\n\n"
+    )
+
     report.append("## Summary\n\n")
-    stats = result['statistics']
+    stats = result["statistics"]
     report.append(f"- **Total Mappings**: {stats['total_mappings']}\n")
     report.append(f"- **Unique ONNX Operations**: {stats['unique_onnx_ops']}\n")
     report.append(f"- **Unique Domains**: {stats['unique_domains']}\n")
     report.append(f"- **Unique Hip Operations**: {stats['unique_hip_ops']}\n\n")
-    
+
     report.append("## Mappings by Domain\n\n")
-    
+
     domains = {}
-    for mapping in result['mappings']:
-        domain = mapping['onnx_domain']
+    for mapping in result["mappings"]:
+        domain = mapping["onnx_domain"]
         if domain not in domains:
             domains[domain] = []
         domains[domain].append(mapping)
-    
+
     for domain in sorted(domains.keys()):
         report.append(f"### Domain: {domain}\n\n")
         report.append("| ONNX Op | Hip Op | Class Name | File | Type |\n")
         report.append("|---|---|---|---|---|\n")
-        
-        for mapping in sorted(domains[domain], key=lambda x: x['onnx_op']):
-            onnx_op = mapping['onnx_op']
-            hip_op = mapping['hip_op']
-            class_name = mapping.get('class_name', '')
-            file_name = mapping['file_name']
-            op_type = mapping['type']
-            report.append(f"| {onnx_op} | {hip_op} | {class_name} | {file_name} | {op_type} |\n")
-        
+
+        for mapping in sorted(domains[domain], key=lambda x: x["onnx_op"]):
+            onnx_op = mapping["onnx_op"]
+            hip_op = mapping["hip_op"]
+            class_name = mapping.get("class_name", "")
+            file_name = mapping["file_name"]
+            op_type = mapping["type"]
+            report.append(
+                f"| {onnx_op} | {hip_op} | {class_name} | {file_name} | {op_type} |\n"
+            )
+
         report.append("\n")
-    
-    return ''.join(report)
+
+    return "".join(report)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/.cursor/skills/model-compatibility/scripts/step2_2_hip_to_llvm_parser.py
+++ b/.cursor/skills/model-compatibility/scripts/step2_2_hip_to_llvm_parser.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""
+Step 2-2: HipToLLVM Lowering Parser (v5 - Handle Nested Brackets)
+Extract hip_op -> runtime_func -> file_name mappings.
+- Reads runtime symbol constants from HipToLLVMUtils.h.
+- hip.* names are aligned with HipOps.td TableGen mnemonics
+  (consistent with step2_1).
+- Correctly handles nested template angle brackets.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+
+_TOOLS_DIR = Path(__file__).resolve().parent
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+from hip_td_mnemonics import (  # noqa: E402
+    default_hip_ops_td_path,
+    load_cpp_op_class_to_mnemonic_from_td,
+)
+
+
+class HipToLLVMParser:
+    """HipToLLVM parser; reads runtime-symbol constants from source."""
+
+    def __init__(self, conversion_dir: str, hip_ops_td: Optional[str] = None):
+        self.conversion_dir = Path(conversion_dir)
+        self.constants = {}
+        self._cpp_class_to_mnemonic: Dict[str, str] = {}
+        self._load_constants()
+        td = Path(hip_ops_td) if hip_ops_td else default_hip_ops_td_path(self.conversion_dir)
+        if td.is_file():
+            self._cpp_class_to_mnemonic = load_cpp_op_class_to_mnemonic_from_td(td)
+        else:
+            print(
+                f"Warning: HipOps.td not found at {td}; hip op names fall back to CamelCase heuristic."
+            )
+
+    def _hip_op_from_pattern_op_class(self, op_class: str) -> str:
+        """ConvertOpToLLVMPattern<ReduceSumOp> / memref::AllocOp -> hip.reduce_sum / hip.alloc."""
+        op_short = op_class.split("::")[-1] if "::" in op_class else op_class
+        mnemonic = self._cpp_class_to_mnemonic.get(op_short)
+        if mnemonic is not None:
+            return f"hip.{mnemonic}"
+        if op_short.endswith("Op"):
+            hip_op_name = op_short[: -len("Op")].lower()
+        else:
+            hip_op_name = op_short.lower()
+        return f"hip.{hip_op_name}"
+    
+    def _load_constants(self):
+        """Load symbolic-name constants declared in HipToLLVMUtils.h."""
+        utils_header = self.conversion_dir / "HipToLLVM" / "HipToLLVMUtils.h"
+        
+        if not utils_header.exists():
+            print(f"Warning: {utils_header} not found")
+            return
+        
+        try:
+            with open(utils_header, 'r', encoding='utf-8', errors='ignore') as f:
+                content = f.read()
+            
+            pattern = r'inline\s+constexpr\s+const\s+char\s+\*(\w+)\s*=\s*"([^"]+)"'
+            matches = re.findall(pattern, content)
+            
+            for const_name, const_value in matches:
+                self.constants[const_name] = const_value
+            
+            print(f"Loaded {len(self.constants)} constants from HipToLLVMUtils.h\n")
+        
+        except Exception as e:
+            print(f"Error loading constants: {e}")
+    
+    def _extract_template_args(self, text: str, start_pos: int) -> Tuple[str, int]:
+        """Extract template arguments starting at start_pos, honoring nested
+        angle brackets. Returns (extracted_content, end_position)."""
+        depth = 0
+        i = start_pos
+        result = []
+        
+        while i < len(text):
+            char = text[i]
+            if char == '<':
+                depth += 1
+                result.append(char)
+            elif char == '>':
+                if depth == 0:
+                    return ''.join(result), i
+                depth -= 1
+                result.append(char)
+            else:
+                result.append(char)
+            i += 1
+        
+        return ''.join(result), i
+    
+    def parse(self) -> Dict:
+        """Parse every lowering file."""
+        result = {
+            'mappings': [],
+            'statistics': {}
+        }
+        
+        lowering_files = sorted(self.conversion_dir.glob('HipToLLVM/*.cpp'))
+        
+        print(f"Found {len(lowering_files)} lowering files\n")
+        
+        for file_path in lowering_files:
+            print(f"Parsing: {file_path.name}")
+            mappings = self._parse_lowering_file(file_path)
+            result['mappings'].extend(mappings)
+            
+            for mapping in mappings:
+                runtime_func = mapping.get('runtime_func', '')
+                print(f"  {mapping['hip_op']:30} -> {runtime_func:40}")
+        
+        # Deduplicate.
+        unique_mappings = {}
+        for mapping in result['mappings']:
+            key = (mapping['hip_op'], mapping.get('runtime_func', ''))
+            if key not in unique_mappings:
+                unique_mappings[key] = mapping
+        
+        result['mappings'] = list(unique_mappings.values())
+        
+        result['statistics'] = {
+            'total_mappings': len(result['mappings']),
+            'total_lowering_files': len(lowering_files),
+            'unique_hip_ops': len(set(m['hip_op'] for m in result['mappings'])),
+            'unique_runtime_funcs': len(set(m.get('runtime_func', '') for m in result['mappings'])),
+        }
+        
+        return result
+    
+    def _parse_lowering_file(self, file_path: Path) -> List[Dict]:
+        """Parse a single lowering file and return all mappings."""
+        mappings = []
+        
+        try:
+            with open(file_path, 'r', encoding='utf-8', errors='ignore') as f:
+                content = f.read()
+            
+            file_name = file_path.name
+            
+            # Mode 1: extract hip_op + runtime function from struct definitions.
+            struct_pattern = r'struct\s+(\w+OpLowering)\s*:\s*public\s+ConvertOpToLLVMPattern<(\w+Op)>'
+            struct_matches = re.findall(struct_pattern, content)
+            
+            for struct_name, op_class in struct_matches:
+                hip_op = self._hip_op_from_pattern_op_class(op_class)
+                
+                struct_content_pattern = rf'{struct_name}.*?(?=struct\s+\w+|void\s+mlir::hip::populate|\Z)'
+                struct_content_match = re.search(struct_content_pattern, content, re.DOTALL)
+                
+                if struct_content_match:
+                    struct_content = struct_content_match.group(0)
+                    
+                    func_pattern = r'LLVM::lookupOrCreateFn\s*\(\s*[^,]+,\s*[^,]+,\s*([kA-Za-z_]\w+)'
+                    func_matches = re.findall(func_pattern, struct_content)
+                    
+                    for const_name in func_matches:
+                        if const_name in self.constants:
+                            runtime_func = self.constants[const_name]
+                            mapping = {
+                                'hip_op': hip_op,
+                                'runtime_func': runtime_func,
+                                'file_name': file_name,
+                                'type': 'struct',
+                                'const_name': const_name
+                            }
+                            if mapping not in mappings:
+                                mappings.append(mapping)
+                    
+                    template_pattern = r'lowerMiopenActivation\s*<\s*\w+Op\s*,\s*\w+\s*>\s*\('
+                    if re.search(template_pattern, struct_content):
+                        template_func_pattern = r'lowerMiopenActivation\s*\([^)]*\).*?LLVM::lookupOrCreateFn\s*\(\s*[^,]+,\s*[^,]+,\s*([kA-Za-z_]\w+)'
+                        template_func_match = re.search(template_func_pattern, content, re.DOTALL)
+                        if template_func_match:
+                            const_name = template_func_match.group(1)
+                            if const_name in self.constants:
+                                runtime_func = self.constants[const_name]
+                                mapping = {
+                                    'hip_op': hip_op,
+                                    'runtime_func': runtime_func,
+                                    'file_name': file_name,
+                                    'type': 'template',
+                                    'const_name': const_name
+                                }
+                                if mapping not in mappings:
+                                    mappings.append(mapping)
+            
+            # Mode 2: extract template args from patterns.add<...> (nested brackets safe).
+            patterns_add_pattern = r'patterns\.add<'
+            for match in re.finditer(patterns_add_pattern, content):
+                start_pos = match.end()
+                template_args_str, end_pos = self._extract_template_args(content, start_pos)
+                
+                # Split multiple template instances, taking nested brackets into account.
+                template_instances = self._parse_template_args(template_args_str)
+                
+                for template_name, template_args in template_instances:
+                    # Handle ElementwiseOpLowering<OpType, TensorOpEnum>.
+                    if template_name == 'ElementwiseOpLowering':
+                        args = [arg.strip() for arg in template_args.split(',')]
+                        if len(args) >= 1:
+                            op_type = args[0]
+                            hip_op = self._hip_op_from_pattern_op_class(op_type)
+
+                            if 'kWrapMiopenOpTensor' in self.constants:
+                                runtime_func = self.constants['kWrapMiopenOpTensor']
+                                mapping = {
+                                    'hip_op': hip_op,
+                                    'runtime_func': runtime_func,
+                                    'file_name': file_name,
+                                    'type': 'patterns_add',
+                                    'const_name': 'kWrapMiopenOpTensor'
+                                }
+                                if mapping not in mappings:
+                                    mappings.append(mapping)
+                    
+                    # Handle MiopenBinaryOpLowering<OpType>.
+                    elif template_name == 'MiopenBinaryOpLowering':
+                        args = [arg.strip() for arg in template_args.split(',')]
+                        if len(args) >= 1:
+                            op_type = args[0]
+                            hip_op = self._hip_op_from_pattern_op_class(op_type)
+
+                            insert_pattern = rf'patterns\.insert<{template_name}<{re.escape(op_type)}>\s*>\s*\(\s*[^,]+,\s*([kA-Za-z_]\w+)'
+                            insert_match = re.search(insert_pattern, content)
+                            if insert_match:
+                                const_name = insert_match.group(1)
+                                if const_name in self.constants:
+                                    runtime_func = self.constants[const_name]
+                                    mapping = {
+                                        'hip_op': hip_op,
+                                        'runtime_func': runtime_func,
+                                        'file_name': file_name,
+                                        'type': 'patterns_insert',
+                                        'const_name': const_name
+                                    }
+                                    if mapping not in mappings:
+                                        mappings.append(mapping)
+            
+            # Mode 2b: direct match for patterns.insert<MiopenBinaryOpLowering<OpType>>(..., kConst).
+            insert_direct_pat = (
+                r'patterns\.insert<\s*MiopenBinaryOpLowering<\s*(\w+Op)\s*>\s*>'
+                r'\s*\(\s*[^,]+,\s*([kA-Za-z_]\w+)'
+            )
+            for op_type, const_name in re.findall(insert_direct_pat, content):
+                hip_op = self._hip_op_from_pattern_op_class(op_type)
+                if const_name in self.constants:
+                    runtime_func = self.constants[const_name]
+                    mapping = {
+                        'hip_op': hip_op,
+                        'runtime_func': runtime_func,
+                        'file_name': file_name,
+                        'type': 'patterns_insert_direct',
+                        'const_name': const_name
+                    }
+                    if mapping not in mappings:
+                        mappings.append(mapping)
+
+            # Mode 3: extract hip_op -> runtime_func from inline comments.
+            comment_pattern = r'//\s*hip\.(\w+)\(.*?\)\s*->\s*(\w+)\('
+            matches = re.findall(comment_pattern, content, re.DOTALL)
+            for hip_op_name, runtime_func in matches:
+                hip_op = f'hip.{hip_op_name}'
+                mapping = {
+                    'hip_op': hip_op,
+                    'runtime_func': runtime_func,
+                    'file_name': file_name,
+                    'type': 'comment'
+                }
+                if not any(m['hip_op'] == hip_op for m in mappings):
+                    if mapping not in mappings:
+                        mappings.append(mapping)
+        
+        except Exception as e:
+            print(f"  Error parsing {file_path.name}: {e}")
+        
+        return mappings
+    
+    def _parse_template_args(self, args_str: str) -> List[Tuple[str, str]]:
+        """Parse a template-argument string and return
+        [(template_name, template_args), ...].
+
+        Example input:
+            "ElementwiseOpLowering<MulOp, kTensorOpMul>, ElementwiseOpLowering<AddOp, kTensorOpAdd>, SubOpLowering"
+        Returns:
+            [("ElementwiseOpLowering", "MulOp, kTensorOpMul"),
+             ("ElementwiseOpLowering", "AddOp, kTensorOpAdd"),
+             ("SubOpLowering", "")]
+        """
+        result = []
+        i = 0
+        
+        while i < len(args_str):
+            # Skip whitespace and commas.
+            while i < len(args_str) and args_str[i] in ' \t\n,':
+                i += 1
+            
+            if i >= len(args_str):
+                break
+            
+            # Extract the template name.
+            name_start = i
+            while i < len(args_str) and (args_str[i].isalnum() or args_str[i] == '_'):
+                i += 1
+            
+            template_name = args_str[name_start:i].strip()
+            
+            # Check whether template args follow.
+            if i < len(args_str) and args_str[i] == '<':
+                i += 1  # Skip the opening <.
+                template_args, end_pos = self._extract_template_args(args_str, i)
+                i = end_pos + 1  # Skip the closing >.
+                result.append((template_name, template_args))
+            else:
+                # No template args attached.
+                result.append((template_name, ''))
+        
+        return result
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(
+            "Usage: python step2_2_hip_to_llvm_parser.py <conversion_dir> [output_dir] [HipOps.td]"
+        )
+        sys.exit(1)
+
+    conversion_dir = sys.argv[1]
+    output_dir = sys.argv[2] if len(sys.argv) > 2 else str(Path(conversion_dir).parent)
+    hip_td = sys.argv[3] if len(sys.argv) > 3 else None
+
+    Path(output_dir).mkdir(parents=True, exist_ok=True)
+
+    print("Parsing HipToLLVM lowerings (v5 - HipOps.td mnemonics + nested brackets)...")
+    print(f"Conversion directory: {conversion_dir}")
+    print(f"Output directory: {output_dir}\n")
+
+    parser = HipToLLVMParser(conversion_dir, hip_ops_td=hip_td)
+    result = parser.parse()
+    
+    print(f"\n{'='*80}")
+    print(f"Summary:")
+    print(f"  Total mappings: {result['statistics']['total_mappings']}")
+    print(f"  Unique Hip ops: {result['statistics']['unique_hip_ops']}")
+    print(f"  Unique Runtime funcs: {result['statistics']['unique_runtime_funcs']}")
+    print(f"{'='*80}\n")
+    
+    json_path = Path(output_dir) / "step2_2_hip_to_llvm_mappings.json"
+    with open(json_path, 'w', encoding='utf-8') as f:
+        json.dump(result, f, indent=2, ensure_ascii=False)
+    print(f"[OK] Mappings saved: {json_path}")
+    
+    md_path = Path(output_dir) / "step2_2_hip_to_llvm_mappings.md"
+    with open(md_path, 'w', encoding='utf-8') as f:
+        f.write(generate_markdown_report(result))
+    print(f"[OK] Markdown report saved: {md_path}")
+
+
+def generate_markdown_report(result: Dict) -> str:
+    """Render the HIP -> runtime mapping table as a Markdown report."""
+    report = []
+    
+    report.append("# Hip to LLVM Lowering Mappings (v5 - Handle Nested Brackets)\n\n")
+    
+    report.append("## Summary\n\n")
+    stats = result['statistics']
+    report.append(f"- **Total Mappings**: {stats['total_mappings']}\n")
+    report.append(f"- **Unique Hip Operations**: {stats['unique_hip_ops']}\n")
+    report.append(f"- **Unique Runtime Functions**: {stats['unique_runtime_funcs']}\n\n")
+    
+    report.append("## Mappings by Hip Operation\n\n")
+    
+    hip_ops = {}
+    for mapping in result['mappings']:
+        hip_op = mapping['hip_op']
+        if hip_op not in hip_ops:
+            hip_ops[hip_op] = []
+        hip_ops[hip_op].append(mapping)
+    
+    report.append("| Hip Op | Runtime Function | File | Type | Const Name |\n")
+    report.append("|---|---|---|---|---|\n")
+    
+    for hip_op in sorted(hip_ops.keys()):
+        for mapping in sorted(hip_ops[hip_op], key=lambda x: x.get('runtime_func', '')):
+            runtime_func = mapping.get('runtime_func', '')
+            file_name = mapping['file_name']
+            op_type = mapping['type']
+            const_name = mapping.get('const_name', '')
+            report.append(f"| {hip_op} | {runtime_func} | {file_name} | {op_type} | {const_name} |\n")
+    
+    report.append("\n")
+    
+    return ''.join(report)
+
+
+if __name__ == '__main__':
+    main()

--- a/.cursor/skills/model-compatibility/scripts/step2_2_hip_to_llvm_parser.py
+++ b/.cursor/skills/model-compatibility/scripts/step2_2_hip_to_llvm_parser.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
 """
 Step 2-2: HipToLLVM Lowering Parser (v5 - Handle Nested Brackets)
 Extract hip_op -> runtime_func -> file_name mappings.
@@ -12,7 +16,7 @@ import json
 import re
 import sys
 from pathlib import Path
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Tuple
 
 _TOOLS_DIR = Path(__file__).resolve().parent
 if str(_TOOLS_DIR) not in sys.path:
@@ -32,7 +36,11 @@ class HipToLLVMParser:
         self.constants = {}
         self._cpp_class_to_mnemonic: Dict[str, str] = {}
         self._load_constants()
-        td = Path(hip_ops_td) if hip_ops_td else default_hip_ops_td_path(self.conversion_dir)
+        td = (
+            Path(hip_ops_td)
+            if hip_ops_td
+            else default_hip_ops_td_path(self.conversion_dir)
+        )
         if td.is_file():
             self._cpp_class_to_mnemonic = load_cpp_op_class_to_mnemonic_from_td(td)
         else:
@@ -51,239 +59,248 @@ class HipToLLVMParser:
         else:
             hip_op_name = op_short.lower()
         return f"hip.{hip_op_name}"
-    
+
     def _load_constants(self):
         """Load symbolic-name constants declared in HipToLLVMUtils.h."""
         utils_header = self.conversion_dir / "HipToLLVM" / "HipToLLVMUtils.h"
-        
+
         if not utils_header.exists():
             print(f"Warning: {utils_header} not found")
             return
-        
+
         try:
-            with open(utils_header, 'r', encoding='utf-8', errors='ignore') as f:
+            with open(utils_header, "r", encoding="utf-8", errors="ignore") as f:
                 content = f.read()
-            
+
             pattern = r'inline\s+constexpr\s+const\s+char\s+\*(\w+)\s*=\s*"([^"]+)"'
             matches = re.findall(pattern, content)
-            
+
             for const_name, const_value in matches:
                 self.constants[const_name] = const_value
-            
+
             print(f"Loaded {len(self.constants)} constants from HipToLLVMUtils.h\n")
-        
+
         except Exception as e:
             print(f"Error loading constants: {e}")
-    
+
     def _extract_template_args(self, text: str, start_pos: int) -> Tuple[str, int]:
         """Extract template arguments starting at start_pos, honoring nested
         angle brackets. Returns (extracted_content, end_position)."""
         depth = 0
         i = start_pos
         result = []
-        
+
         while i < len(text):
             char = text[i]
-            if char == '<':
+            if char == "<":
                 depth += 1
                 result.append(char)
-            elif char == '>':
+            elif char == ">":
                 if depth == 0:
-                    return ''.join(result), i
+                    return "".join(result), i
                 depth -= 1
                 result.append(char)
             else:
                 result.append(char)
             i += 1
-        
-        return ''.join(result), i
-    
+
+        return "".join(result), i
+
     def parse(self) -> Dict:
         """Parse every lowering file."""
-        result = {
-            'mappings': [],
-            'statistics': {}
-        }
-        
-        lowering_files = sorted(self.conversion_dir.glob('HipToLLVM/*.cpp'))
-        
+        result = {"mappings": [], "statistics": {}}
+
+        lowering_files = sorted(self.conversion_dir.glob("HipToLLVM/*.cpp"))
+
         print(f"Found {len(lowering_files)} lowering files\n")
-        
+
         for file_path in lowering_files:
             print(f"Parsing: {file_path.name}")
             mappings = self._parse_lowering_file(file_path)
-            result['mappings'].extend(mappings)
-            
+            result["mappings"].extend(mappings)
+
             for mapping in mappings:
-                runtime_func = mapping.get('runtime_func', '')
+                runtime_func = mapping.get("runtime_func", "")
                 print(f"  {mapping['hip_op']:30} -> {runtime_func:40}")
-        
+
         # Deduplicate.
         unique_mappings = {}
-        for mapping in result['mappings']:
-            key = (mapping['hip_op'], mapping.get('runtime_func', ''))
+        for mapping in result["mappings"]:
+            key = (mapping["hip_op"], mapping.get("runtime_func", ""))
             if key not in unique_mappings:
                 unique_mappings[key] = mapping
-        
-        result['mappings'] = list(unique_mappings.values())
-        
-        result['statistics'] = {
-            'total_mappings': len(result['mappings']),
-            'total_lowering_files': len(lowering_files),
-            'unique_hip_ops': len(set(m['hip_op'] for m in result['mappings'])),
-            'unique_runtime_funcs': len(set(m.get('runtime_func', '') for m in result['mappings'])),
+
+        result["mappings"] = list(unique_mappings.values())
+
+        result["statistics"] = {
+            "total_mappings": len(result["mappings"]),
+            "total_lowering_files": len(lowering_files),
+            "unique_hip_ops": len(set(m["hip_op"] for m in result["mappings"])),
+            "unique_runtime_funcs": len(
+                set(m.get("runtime_func", "") for m in result["mappings"])
+            ),
         }
-        
+
         return result
-    
+
     def _parse_lowering_file(self, file_path: Path) -> List[Dict]:
         """Parse a single lowering file and return all mappings."""
         mappings = []
-        
+
         try:
-            with open(file_path, 'r', encoding='utf-8', errors='ignore') as f:
+            with open(file_path, "r", encoding="utf-8", errors="ignore") as f:
                 content = f.read()
-            
+
             file_name = file_path.name
-            
+
             # Mode 1: extract hip_op + runtime function from struct definitions.
-            struct_pattern = r'struct\s+(\w+OpLowering)\s*:\s*public\s+ConvertOpToLLVMPattern<(\w+Op)>'
+            struct_pattern = r"struct\s+(\w+OpLowering)\s*:\s*public\s+ConvertOpToLLVMPattern<(\w+Op)>"
             struct_matches = re.findall(struct_pattern, content)
-            
+
             for struct_name, op_class in struct_matches:
                 hip_op = self._hip_op_from_pattern_op_class(op_class)
-                
-                struct_content_pattern = rf'{struct_name}.*?(?=struct\s+\w+|void\s+mlir::hip::populate|\Z)'
-                struct_content_match = re.search(struct_content_pattern, content, re.DOTALL)
-                
+
+                struct_content_pattern = (
+                    rf"{struct_name}.*?(?=struct\s+\w+|void\s+mlir::hip::populate|\Z)"
+                )
+                struct_content_match = re.search(
+                    struct_content_pattern, content, re.DOTALL
+                )
+
                 if struct_content_match:
                     struct_content = struct_content_match.group(0)
-                    
-                    func_pattern = r'LLVM::lookupOrCreateFn\s*\(\s*[^,]+,\s*[^,]+,\s*([kA-Za-z_]\w+)'
+
+                    func_pattern = r"LLVM::lookupOrCreateFn\s*\(\s*[^,]+,\s*[^,]+,\s*([kA-Za-z_]\w+)"
                     func_matches = re.findall(func_pattern, struct_content)
-                    
+
                     for const_name in func_matches:
                         if const_name in self.constants:
                             runtime_func = self.constants[const_name]
                             mapping = {
-                                'hip_op': hip_op,
-                                'runtime_func': runtime_func,
-                                'file_name': file_name,
-                                'type': 'struct',
-                                'const_name': const_name
+                                "hip_op": hip_op,
+                                "runtime_func": runtime_func,
+                                "file_name": file_name,
+                                "type": "struct",
+                                "const_name": const_name,
                             }
                             if mapping not in mappings:
                                 mappings.append(mapping)
-                    
-                    template_pattern = r'lowerMiopenActivation\s*<\s*\w+Op\s*,\s*\w+\s*>\s*\('
+
+                    template_pattern = (
+                        r"lowerMiopenActivation\s*<\s*\w+Op\s*,\s*\w+\s*>\s*\("
+                    )
                     if re.search(template_pattern, struct_content):
-                        template_func_pattern = r'lowerMiopenActivation\s*\([^)]*\).*?LLVM::lookupOrCreateFn\s*\(\s*[^,]+,\s*[^,]+,\s*([kA-Za-z_]\w+)'
-                        template_func_match = re.search(template_func_pattern, content, re.DOTALL)
+                        template_func_pattern = r"lowerMiopenActivation\s*\([^)]*\).*?LLVM::lookupOrCreateFn\s*\(\s*[^,]+,\s*[^,]+,\s*([kA-Za-z_]\w+)"
+                        template_func_match = re.search(
+                            template_func_pattern, content, re.DOTALL
+                        )
                         if template_func_match:
                             const_name = template_func_match.group(1)
                             if const_name in self.constants:
                                 runtime_func = self.constants[const_name]
                                 mapping = {
-                                    'hip_op': hip_op,
-                                    'runtime_func': runtime_func,
-                                    'file_name': file_name,
-                                    'type': 'template',
-                                    'const_name': const_name
+                                    "hip_op": hip_op,
+                                    "runtime_func": runtime_func,
+                                    "file_name": file_name,
+                                    "type": "template",
+                                    "const_name": const_name,
                                 }
                                 if mapping not in mappings:
                                     mappings.append(mapping)
-            
+
             # Mode 2: extract template args from patterns.add<...> (nested brackets safe).
-            patterns_add_pattern = r'patterns\.add<'
+            patterns_add_pattern = r"patterns\.add<"
             for match in re.finditer(patterns_add_pattern, content):
                 start_pos = match.end()
-                template_args_str, end_pos = self._extract_template_args(content, start_pos)
-                
+                template_args_str, end_pos = self._extract_template_args(
+                    content, start_pos
+                )
+
                 # Split multiple template instances, taking nested brackets into account.
                 template_instances = self._parse_template_args(template_args_str)
-                
+
                 for template_name, template_args in template_instances:
                     # Handle ElementwiseOpLowering<OpType, TensorOpEnum>.
-                    if template_name == 'ElementwiseOpLowering':
-                        args = [arg.strip() for arg in template_args.split(',')]
+                    if template_name == "ElementwiseOpLowering":
+                        args = [arg.strip() for arg in template_args.split(",")]
                         if len(args) >= 1:
                             op_type = args[0]
                             hip_op = self._hip_op_from_pattern_op_class(op_type)
 
-                            if 'kWrapMiopenOpTensor' in self.constants:
-                                runtime_func = self.constants['kWrapMiopenOpTensor']
+                            if "kWrapMiopenOpTensor" in self.constants:
+                                runtime_func = self.constants["kWrapMiopenOpTensor"]
                                 mapping = {
-                                    'hip_op': hip_op,
-                                    'runtime_func': runtime_func,
-                                    'file_name': file_name,
-                                    'type': 'patterns_add',
-                                    'const_name': 'kWrapMiopenOpTensor'
+                                    "hip_op": hip_op,
+                                    "runtime_func": runtime_func,
+                                    "file_name": file_name,
+                                    "type": "patterns_add",
+                                    "const_name": "kWrapMiopenOpTensor",
                                 }
                                 if mapping not in mappings:
                                     mappings.append(mapping)
-                    
+
                     # Handle MiopenBinaryOpLowering<OpType>.
-                    elif template_name == 'MiopenBinaryOpLowering':
-                        args = [arg.strip() for arg in template_args.split(',')]
+                    elif template_name == "MiopenBinaryOpLowering":
+                        args = [arg.strip() for arg in template_args.split(",")]
                         if len(args) >= 1:
                             op_type = args[0]
                             hip_op = self._hip_op_from_pattern_op_class(op_type)
 
-                            insert_pattern = rf'patterns\.insert<{template_name}<{re.escape(op_type)}>\s*>\s*\(\s*[^,]+,\s*([kA-Za-z_]\w+)'
+                            insert_pattern = rf"patterns\.insert<{template_name}<{re.escape(op_type)}>\s*>\s*\(\s*[^,]+,\s*([kA-Za-z_]\w+)"
                             insert_match = re.search(insert_pattern, content)
                             if insert_match:
                                 const_name = insert_match.group(1)
                                 if const_name in self.constants:
                                     runtime_func = self.constants[const_name]
                                     mapping = {
-                                        'hip_op': hip_op,
-                                        'runtime_func': runtime_func,
-                                        'file_name': file_name,
-                                        'type': 'patterns_insert',
-                                        'const_name': const_name
+                                        "hip_op": hip_op,
+                                        "runtime_func": runtime_func,
+                                        "file_name": file_name,
+                                        "type": "patterns_insert",
+                                        "const_name": const_name,
                                     }
                                     if mapping not in mappings:
                                         mappings.append(mapping)
-            
+
             # Mode 2b: direct match for patterns.insert<MiopenBinaryOpLowering<OpType>>(..., kConst).
             insert_direct_pat = (
-                r'patterns\.insert<\s*MiopenBinaryOpLowering<\s*(\w+Op)\s*>\s*>'
-                r'\s*\(\s*[^,]+,\s*([kA-Za-z_]\w+)'
+                r"patterns\.insert<\s*MiopenBinaryOpLowering<\s*(\w+Op)\s*>\s*>"
+                r"\s*\(\s*[^,]+,\s*([kA-Za-z_]\w+)"
             )
             for op_type, const_name in re.findall(insert_direct_pat, content):
                 hip_op = self._hip_op_from_pattern_op_class(op_type)
                 if const_name in self.constants:
                     runtime_func = self.constants[const_name]
                     mapping = {
-                        'hip_op': hip_op,
-                        'runtime_func': runtime_func,
-                        'file_name': file_name,
-                        'type': 'patterns_insert_direct',
-                        'const_name': const_name
+                        "hip_op": hip_op,
+                        "runtime_func": runtime_func,
+                        "file_name": file_name,
+                        "type": "patterns_insert_direct",
+                        "const_name": const_name,
                     }
                     if mapping not in mappings:
                         mappings.append(mapping)
 
             # Mode 3: extract hip_op -> runtime_func from inline comments.
-            comment_pattern = r'//\s*hip\.(\w+)\(.*?\)\s*->\s*(\w+)\('
+            comment_pattern = r"//\s*hip\.(\w+)\(.*?\)\s*->\s*(\w+)\("
             matches = re.findall(comment_pattern, content, re.DOTALL)
             for hip_op_name, runtime_func in matches:
-                hip_op = f'hip.{hip_op_name}'
+                hip_op = f"hip.{hip_op_name}"
                 mapping = {
-                    'hip_op': hip_op,
-                    'runtime_func': runtime_func,
-                    'file_name': file_name,
-                    'type': 'comment'
+                    "hip_op": hip_op,
+                    "runtime_func": runtime_func,
+                    "file_name": file_name,
+                    "type": "comment",
                 }
-                if not any(m['hip_op'] == hip_op for m in mappings):
+                if not any(m["hip_op"] == hip_op for m in mappings):
                     if mapping not in mappings:
                         mappings.append(mapping)
-        
+
         except Exception as e:
             print(f"  Error parsing {file_path.name}: {e}")
-        
+
         return mappings
-    
+
     def _parse_template_args(self, args_str: str) -> List[Tuple[str, str]]:
         """Parse a template-argument string and return
         [(template_name, template_args), ...].
@@ -297,32 +314,32 @@ class HipToLLVMParser:
         """
         result = []
         i = 0
-        
+
         while i < len(args_str):
             # Skip whitespace and commas.
-            while i < len(args_str) and args_str[i] in ' \t\n,':
+            while i < len(args_str) and args_str[i] in " \t\n,":
                 i += 1
-            
+
             if i >= len(args_str):
                 break
-            
+
             # Extract the template name.
             name_start = i
-            while i < len(args_str) and (args_str[i].isalnum() or args_str[i] == '_'):
+            while i < len(args_str) and (args_str[i].isalnum() or args_str[i] == "_"):
                 i += 1
-            
+
             template_name = args_str[name_start:i].strip()
-            
+
             # Check whether template args follow.
-            if i < len(args_str) and args_str[i] == '<':
+            if i < len(args_str) and args_str[i] == "<":
                 i += 1  # Skip the opening <.
                 template_args, end_pos = self._extract_template_args(args_str, i)
                 i = end_pos + 1  # Skip the closing >.
                 result.append((template_name, template_args))
             else:
                 # No template args attached.
-                result.append((template_name, ''))
-        
+                result.append((template_name, ""))
+
         return result
 
 
@@ -345,21 +362,21 @@ def main():
 
     parser = HipToLLVMParser(conversion_dir, hip_ops_td=hip_td)
     result = parser.parse()
-    
-    print(f"\n{'='*80}")
-    print(f"Summary:")
+
+    print(f"\n{'=' * 80}")
+    print("Summary:")
     print(f"  Total mappings: {result['statistics']['total_mappings']}")
     print(f"  Unique Hip ops: {result['statistics']['unique_hip_ops']}")
     print(f"  Unique Runtime funcs: {result['statistics']['unique_runtime_funcs']}")
-    print(f"{'='*80}\n")
-    
+    print(f"{'=' * 80}\n")
+
     json_path = Path(output_dir) / "step2_2_hip_to_llvm_mappings.json"
-    with open(json_path, 'w', encoding='utf-8') as f:
+    with open(json_path, "w", encoding="utf-8") as f:
         json.dump(result, f, indent=2, ensure_ascii=False)
     print(f"[OK] Mappings saved: {json_path}")
-    
+
     md_path = Path(output_dir) / "step2_2_hip_to_llvm_mappings.md"
-    with open(md_path, 'w', encoding='utf-8') as f:
+    with open(md_path, "w", encoding="utf-8") as f:
         f.write(generate_markdown_report(result))
     print(f"[OK] Markdown report saved: {md_path}")
 
@@ -367,39 +384,43 @@ def main():
 def generate_markdown_report(result: Dict) -> str:
     """Render the HIP -> runtime mapping table as a Markdown report."""
     report = []
-    
+
     report.append("# Hip to LLVM Lowering Mappings (v5 - Handle Nested Brackets)\n\n")
-    
+
     report.append("## Summary\n\n")
-    stats = result['statistics']
+    stats = result["statistics"]
     report.append(f"- **Total Mappings**: {stats['total_mappings']}\n")
     report.append(f"- **Unique Hip Operations**: {stats['unique_hip_ops']}\n")
-    report.append(f"- **Unique Runtime Functions**: {stats['unique_runtime_funcs']}\n\n")
-    
+    report.append(
+        f"- **Unique Runtime Functions**: {stats['unique_runtime_funcs']}\n\n"
+    )
+
     report.append("## Mappings by Hip Operation\n\n")
-    
+
     hip_ops = {}
-    for mapping in result['mappings']:
-        hip_op = mapping['hip_op']
+    for mapping in result["mappings"]:
+        hip_op = mapping["hip_op"]
         if hip_op not in hip_ops:
             hip_ops[hip_op] = []
         hip_ops[hip_op].append(mapping)
-    
+
     report.append("| Hip Op | Runtime Function | File | Type | Const Name |\n")
     report.append("|---|---|---|---|---|\n")
-    
+
     for hip_op in sorted(hip_ops.keys()):
-        for mapping in sorted(hip_ops[hip_op], key=lambda x: x.get('runtime_func', '')):
-            runtime_func = mapping.get('runtime_func', '')
-            file_name = mapping['file_name']
-            op_type = mapping['type']
-            const_name = mapping.get('const_name', '')
-            report.append(f"| {hip_op} | {runtime_func} | {file_name} | {op_type} | {const_name} |\n")
-    
+        for mapping in sorted(hip_ops[hip_op], key=lambda x: x.get("runtime_func", "")):
+            runtime_func = mapping.get("runtime_func", "")
+            file_name = mapping["file_name"]
+            op_type = mapping["type"]
+            const_name = mapping.get("const_name", "")
+            report.append(
+                f"| {hip_op} | {runtime_func} | {file_name} | {op_type} | {const_name} |\n"
+            )
+
     report.append("\n")
-    
-    return ''.join(report)
+
+    return "".join(report)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/.cursor/skills/model-compatibility/scripts/step2_3_backend_analyzer_final.py
+++ b/.cursor/skills/model-compatibility/scripts/step2_3_backend_analyzer_final.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
 """
 Step 2-3: Backend Analyzer (Final - Hybrid Approach)
 Identify which backend each runtime function uses (ROCm library or
@@ -15,48 +19,56 @@ Final hybrid design:
 import json
 import re
 from pathlib import Path
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List
 import sys
+
 
 class BackendAnalyzer:
     """Identify the ROCm library / Custom Kernel used by each runtime function."""
-    
-    def __init__(self, runtime_dir: str, hip_to_runtime_json: str = None, onnx_to_hip_json: str = None, 
-                 backend_config_json: str = None):
+
+    def __init__(
+        self,
+        runtime_dir: str,
+        hip_to_runtime_json: str = None,
+        onnx_to_hip_json: str = None,
+        backend_config_json: str = None,
+    ):
         self.runtime_dir = Path(runtime_dir)
         self.hip_to_runtime_data: List[Dict] = []
         self.hip_to_runtime_by_hip: Dict[str, List[Dict]] = {}
         self.onnx_to_hip_data: List[Dict] = []
-        
+
         if hip_to_runtime_json:
-            self._load_json(hip_to_runtime_json, 'hip_to_runtime')
+            self._load_json(hip_to_runtime_json, "hip_to_runtime")
         if onnx_to_hip_json:
-            self._load_json(onnx_to_hip_json, 'onnx_to_hip')
-        
+            self._load_json(onnx_to_hip_json, "onnx_to_hip")
+
         # Load runtime implementation files.
         self.runtime_implementations = self._load_runtime_implementations()
-        
+
         # Load or build the runtime -> backend mapping table.
         self.backend_mappings = self._load_backend_mappings(backend_config_json)
-    
+
     def _load_json(self, json_path: str, data_type: str):
         """Load a JSON file."""
         try:
-            with open(json_path, 'r', encoding='utf-8') as f:
+            with open(json_path, "r", encoding="utf-8") as f:
                 data = json.load(f)
-            
-            if data_type == 'hip_to_runtime':
-                for mapping in data.get('mappings', []):
+
+            if data_type == "hip_to_runtime":
+                for mapping in data.get("mappings", []):
                     self.hip_to_runtime_data.append(mapping)
-                    hip_op = mapping.get('hip_op')
+                    hip_op = mapping.get("hip_op")
                     if hip_op:
-                        self.hip_to_runtime_by_hip.setdefault(hip_op, []).append(mapping)
-            elif data_type == 'onnx_to_hip':
-                for mapping in data.get('mappings', []):
+                        self.hip_to_runtime_by_hip.setdefault(hip_op, []).append(
+                            mapping
+                        )
+            elif data_type == "onnx_to_hip":
+                for mapping in data.get("mappings", []):
                     self.onnx_to_hip_data.append(mapping)
         except Exception as e:
             print(f"Warning: Could not load {json_path}: {e}")
-    
+
     def _load_backend_mappings(self, config_json: str = None) -> Dict[str, str]:
         """Load the runtime -> backend mapping table.
 
@@ -70,13 +82,13 @@ class BackendAnalyzer:
         """
         if config_json and Path(config_json).exists():
             try:
-                with open(config_json, 'r', encoding='utf-8') as f:
+                with open(config_json, "r", encoding="utf-8") as f:
                     data = json.load(f)
-                    return data.get('mappings', {})
+                    return data.get("mappings", {})
             except Exception as e:
                 print(f"Warning: Could not load backend config {config_json}: {e}")
         return {}
-    
+
     def _load_runtime_implementations(self) -> Dict[str, Dict]:
         """Index every runtime function definition to its source file.
 
@@ -101,51 +113,48 @@ class BackendAnalyzer:
 
         runtime_files = set()
         for search_dir in search_dirs:
-            for cpp in search_dir.glob('**/*.cpp'):
-                norm = str(cpp).replace('\\', '/').lower()
-                if '/mock/' in norm or norm.endswith('/mock_gpu.cpp'):
+            for cpp in search_dir.glob("**/*.cpp"):
+                norm = str(cpp).replace("\\", "/").lower()
+                if "/mock/" in norm or norm.endswith("/mock_gpu.cpp"):
                     continue
                 runtime_files.add(cpp)
 
         func_pat = re.compile(
-            r'(?:int|void|bool|float|double|hipError_t)\s+(\w+)\s*\([^)]*\)\s*\{'
+            r"(?:int|void|bool|float|double|hipError_t)\s+(\w+)\s*\([^)]*\)\s*\{"
         )
 
         for file_path in runtime_files:
             try:
-                with open(file_path, 'r', encoding='utf-8', errors='ignore') as f:
+                with open(file_path, "r", encoding="utf-8", errors="ignore") as f:
                     content = f.read()
                 for func_name in func_pat.findall(content):
                     # First real definition wins; skip duplicates.
                     if func_name not in implementations:
                         implementations[func_name] = {
-                            'file': str(file_path),
-                            'content': content,
+                            "file": str(file_path),
+                            "content": content,
                         }
             except Exception:
                 pass
 
         return implementations
-    
+
     def analyze(self) -> Dict:
         """Run the backend analysis."""
-        result = {
-            'mappings': [],
-            'statistics': {}
-        }
-        
+        result = {"mappings": [], "statistics": {}}
+
         seen_keys = set()
         for onnx_mapping in self.onnx_to_hip_data:
-            onnx_op = onnx_mapping['onnx_op']
-            onnx_domain = onnx_mapping['onnx_domain']
-            hip_op = onnx_mapping['hip_op']
-            onnx_file = onnx_mapping['file_name']
+            onnx_op = onnx_mapping["onnx_op"]
+            onnx_domain = onnx_mapping["onnx_domain"]
+            hip_op = onnx_mapping["hip_op"]
+            onnx_file = onnx_mapping["file_name"]
 
             row_key = (onnx_op, onnx_domain, hip_op)
             if row_key in seen_keys:
                 continue
             seen_keys.add(row_key)
-            
+
             runtime_func = None
             hip_file = None
             hip_rt_candidates = self.hip_to_runtime_by_hip.get(hip_op, [])
@@ -154,46 +163,52 @@ class BackendAnalyzer:
                 chosen = sorted(
                     hip_rt_candidates,
                     key=lambda m: (
-                        str(m.get('file_name') or ''),
-                        str(m.get('runtime_func') or ''),
+                        str(m.get("file_name") or ""),
+                        str(m.get("runtime_func") or ""),
                     ),
                 )[0]
-                runtime_func = chosen.get('runtime_func')
-                hip_file = chosen.get('file_name')
-            
+                runtime_func = chosen.get("runtime_func")
+                hip_file = chosen.get("file_name")
+
             if runtime_func:
                 backend = self._analyze_backend(runtime_func)
-                runtime_file = self.runtime_implementations.get(runtime_func, {}).get('file', 'N/A')
+                runtime_file = self.runtime_implementations.get(runtime_func, {}).get(
+                    "file", "N/A"
+                )
             else:
                 backend = "Compile Time Optimization"
                 runtime_func = None
                 runtime_file = "N/A"
-            
+
             mapping = {
-                'onnx_op': onnx_op,
-                'onnx_domain': onnx_domain,
-                'hip_op': hip_op,
-                'runtime_func': runtime_func,
-                'backend': backend,
-                'onnx_file': onnx_file,
-                'hip_file': hip_file,
-                'runtime_file': runtime_file
+                "onnx_op": onnx_op,
+                "onnx_domain": onnx_domain,
+                "hip_op": hip_op,
+                "runtime_func": runtime_func,
+                "backend": backend,
+                "onnx_file": onnx_file,
+                "hip_file": hip_file,
+                "runtime_file": runtime_file,
             }
-            
-            result['mappings'].append(mapping)
-        
-        backends = set(m['backend'] for m in result['mappings'])
-        result['statistics'] = {
-            'total_mappings': len(result['mappings']),
-            'unique_onnx_ops': len(set(m['onnx_op'] for m in result['mappings'] if m['onnx_op'])),
-            'unique_hip_ops': len(set(m['hip_op'] for m in result['mappings'])),
-            'unique_runtime_funcs': len(set(m['runtime_func'] for m in result['mappings'] if m['runtime_func'])),
-            'unique_backends': len(backends),
-            'backends': sorted(list(backends))
+
+            result["mappings"].append(mapping)
+
+        backends = set(m["backend"] for m in result["mappings"])
+        result["statistics"] = {
+            "total_mappings": len(result["mappings"]),
+            "unique_onnx_ops": len(
+                set(m["onnx_op"] for m in result["mappings"] if m["onnx_op"])
+            ),
+            "unique_hip_ops": len(set(m["hip_op"] for m in result["mappings"])),
+            "unique_runtime_funcs": len(
+                set(m["runtime_func"] for m in result["mappings"] if m["runtime_func"])
+            ),
+            "unique_backends": len(backends),
+            "backends": sorted(list(backends)),
         }
-        
+
         return result
-    
+
     def _analyze_backend(self, runtime_func: str) -> str:
         """Identify the backend a runtime function relies on.
 
@@ -224,17 +239,17 @@ class BackendAnalyzer:
             return "Unknown"
 
         impl = self.runtime_implementations[runtime_func]
-        content = impl['content']
-        file_path = impl['file']
+        content = impl["content"]
+        file_path = impl["file"]
 
-        if 'custom_kernels' in file_path.replace('\\', '/'):
+        if "custom_kernels" in file_path.replace("\\", "/"):
             return "Custom Hip Kernel"
 
         rocm_libraries = [
-            ('hipBLASLt', [r'hipblaslt_\w+', r'hipblasLt\w+']),
-            ('MIOpen', [r'miopen_\w+', r'miopenCreate', r'miopenDestroy']),
-            ('hipBLAS', [r'hipblas_\w+', r'hipblas[A-Z]']),
-            ('rocBLAS', [r'rocblas_\w+', r'rocblas[A-Z]']),
+            ("hipBLASLt", [r"hipblaslt_\w+", r"hipblasLt\w+"]),
+            ("MIOpen", [r"miopen_\w+", r"miopenCreate", r"miopenDestroy"]),
+            ("hipBLAS", [r"hipblas_\w+", r"hipblas[A-Z]"]),
+            ("rocBLAS", [r"rocblas_\w+", r"rocblas[A-Z]"]),
         ]
 
         custom_kernel_header = bool(
@@ -247,19 +262,19 @@ class BackendAnalyzer:
                 for pattern in patterns:
                     if re.search(pattern, body):
                         return lib_name
-            if re.search(r'__global__\s+void|__kernel\s+void|hipLaunchKernel', body):
+            if re.search(r"__global__\s+void|__kernel\s+void|hipLaunchKernel", body):
                 return "Custom Hip Kernel"
             # Body delegates to a hip_<name>(...) call AND the file pulls
             # in the custom-kernel gateway: this is the canonical
             # "wrap_X -> hip_X" delegation pattern used across runtime/real/.
-            if custom_kernel_header and re.search(r'\bhip_\w+\s*\(', body):
+            if custom_kernel_header and re.search(r"\bhip_\w+\s*\(", body):
                 return "Custom Hip Kernel"
 
         for lib_name, patterns in rocm_libraries:
             for pattern in patterns:
                 if re.search(pattern, content):
                     return lib_name
-        if re.search(r'__global__\s+void|__kernel\s+void|hipLaunchKernel', content):
+        if re.search(r"__global__\s+void|__kernel\s+void|hipLaunchKernel", content):
             return "Custom Hip Kernel"
 
         return "Unknown"
@@ -272,11 +287,11 @@ class BackendAnalyzer:
         are handled."""
         # Find the function signature opening: `func_name(`.
         sig_pat = re.compile(
-            r'\b' + re.escape(func_name) + r'\s*\([^)]*\)\s*(?:const\s*)?\{'
+            r"\b" + re.escape(func_name) + r"\s*\([^)]*\)\s*(?:const\s*)?\{"
         )
         m = sig_pat.search(content)
         if not m:
-            return ''
+            return ""
         # The `{` is the last char of the match. Walk balanced braces.
         brace_pos = m.end() - 1
         depth = 0
@@ -284,30 +299,32 @@ class BackendAnalyzer:
         n = len(content)
         while i < n:
             ch = content[i]
-            if ch == '{':
+            if ch == "{":
                 depth += 1
-            elif ch == '}':
+            elif ch == "}":
                 depth -= 1
                 if depth == 0:
-                    return content[brace_pos + 1:i]
+                    return content[brace_pos + 1 : i]
             i += 1
-        return ''
+        return ""
 
 
 def main():
     if len(sys.argv) < 2:
-        print("Usage: python step2_3_backend_analyzer_final.py <runtime_dir> [hip_to_runtime_json] [onnx_to_hip_json] [output_dir] [backend_config_json]")
+        print(
+            "Usage: python step2_3_backend_analyzer_final.py <runtime_dir> [hip_to_runtime_json] [onnx_to_hip_json] [output_dir] [backend_config_json]"
+        )
         sys.exit(1)
-    
+
     runtime_dir = sys.argv[1]
     hip_to_runtime_json = sys.argv[2] if len(sys.argv) > 2 else None
     onnx_to_hip_json = sys.argv[3] if len(sys.argv) > 3 else None
     output_dir = sys.argv[4] if len(sys.argv) > 4 else str(Path(runtime_dir).parent)
     backend_config_json = sys.argv[5] if len(sys.argv) > 5 else None
-    
+
     Path(output_dir).mkdir(parents=True, exist_ok=True)
-    
-    print(f"Analyzing backends (Final - Hybrid Approach)...")
+
+    print("Analyzing backends (Final - Hybrid Approach)...")
     print(f"Runtime directory: {runtime_dir}")
     if hip_to_runtime_json:
         print(f"Hip->Runtime mappings: {hip_to_runtime_json}")
@@ -316,27 +333,29 @@ def main():
     if backend_config_json:
         print(f"Backend config: {backend_config_json}")
     print(f"Output directory: {output_dir}\n")
-    
-    analyzer = BackendAnalyzer(runtime_dir, hip_to_runtime_json, onnx_to_hip_json, backend_config_json)
+
+    analyzer = BackendAnalyzer(
+        runtime_dir, hip_to_runtime_json, onnx_to_hip_json, backend_config_json
+    )
     result = analyzer.analyze()
-    
-    print(f"{'='*80}")
-    print(f"Backend Analysis Summary:")
+
+    print(f"{'=' * 80}")
+    print("Backend Analysis Summary:")
     print(f"  Total mappings: {result['statistics']['total_mappings']}")
     print(f"  Unique ONNX ops: {result['statistics']['unique_onnx_ops']}")
     print(f"  Unique Hip ops: {result['statistics']['unique_hip_ops']}")
     print(f"  Unique Runtime funcs: {result['statistics']['unique_runtime_funcs']}")
     print(f"  Unique backends: {result['statistics']['unique_backends']}")
     print(f"  Backends: {', '.join(result['statistics']['backends'])}")
-    print(f"{'='*80}\n")
-    
+    print(f"{'=' * 80}\n")
+
     json_path = Path(output_dir) / "step2_3_backend_analysis.json"
-    with open(json_path, 'w', encoding='utf-8') as f:
+    with open(json_path, "w", encoding="utf-8") as f:
         json.dump(result, f, indent=2, ensure_ascii=False)
     print(f"[OK] Analysis saved: {json_path}")
-    
+
     md_path = Path(output_dir) / "step2_3_backend_analysis.md"
-    with open(md_path, 'w', encoding='utf-8') as f:
+    with open(md_path, "w", encoding="utf-8") as f:
         f.write(generate_markdown_report(result))
     print(f"[OK] Markdown report saved: {md_path}")
 
@@ -344,99 +363,111 @@ def main():
 def generate_markdown_report(result: Dict) -> str:
     """Render the backend analysis as a Markdown report."""
     report = []
-    
+
     report.append("# Backend Analysis Report\n\n")
-    
+
     report.append("## Summary\n\n")
-    stats = result['statistics']
+    stats = result["statistics"]
     report.append(f"- **Total Mappings**: {stats['total_mappings']}\n")
     report.append(f"- **Unique ONNX Operations**: {stats['unique_onnx_ops']}\n")
     report.append(f"- **Unique Hip Operations**: {stats['unique_hip_ops']}\n")
     report.append(f"- **Unique Runtime Functions**: {stats['unique_runtime_funcs']}\n")
     report.append(f"- **Unique Backends**: {stats['unique_backends']}\n")
     report.append(f"- **Backends Used**: {', '.join(stats['backends'])}\n\n")
-    
+
     report.append("## Complete Mapping Chain with Backend Implementation\n\n")
     report.append("| ONNX Op | Domain | Hip Op | Runtime Func | Backend |\n")
     report.append("|---|---|---|---|---|\n")
-    
-    for mapping in sorted(result['mappings'], key=lambda x: (x['onnx_op'] or '', x['hip_op'])):
-        onnx_op = mapping['onnx_op'] or "N/A"
-        domain = mapping['onnx_domain'] or "N/A"
-        hip_op = mapping['hip_op']
-        runtime_func = mapping['runtime_func'] or "None"
-        backend = mapping['backend']
-        report.append(f"| {onnx_op} | {domain} | {hip_op} | {runtime_func} | {backend} |\n")
-    
+
+    for mapping in sorted(
+        result["mappings"], key=lambda x: (x["onnx_op"] or "", x["hip_op"])
+    ):
+        onnx_op = mapping["onnx_op"] or "N/A"
+        domain = mapping["onnx_domain"] or "N/A"
+        hip_op = mapping["hip_op"]
+        runtime_func = mapping["runtime_func"] or "None"
+        backend = mapping["backend"]
+        report.append(
+            f"| {onnx_op} | {domain} | {hip_op} | {runtime_func} | {backend} |\n"
+        )
+
     report.append("\n")
-    
+
     report.append("## Mappings by Backend\n\n")
-    
+
     backends = {}
-    for mapping in result['mappings']:
-        backend = mapping['backend']
+    for mapping in result["mappings"]:
+        backend = mapping["backend"]
         if backend not in backends:
             backends[backend] = []
         backends[backend].append(mapping)
-    
+
     backend_descriptions = {
-        'MIOpen': "AMD's optimized library for deep learning operations on HIP/ROCm.",
-        'hipBLASLt': "AMD's optimized BLAS library for matrix operations on HIP/ROCm.",
-        'Custom Hip Kernel': "Custom HIP kernels implemented specifically for these operations.",
-        'Compile Time Optimization': "Tensor operations optimized at compile time, no runtime function needed.",
+        "MIOpen": "AMD's optimized library for deep learning operations on HIP/ROCm.",
+        "hipBLASLt": "AMD's optimized BLAS library for matrix operations on HIP/ROCm.",
+        "Custom Hip Kernel": "Custom HIP kernels implemented specifically for these operations.",
+        "Compile Time Optimization": "Tensor operations optimized at compile time, no runtime function needed.",
     }
-    
+
     for backend in sorted(backends.keys()):
         mappings = backends[backend]
         report.append(f"### {backend} ({len(mappings)} operations)\n\n")
-        
+
         if backend in backend_descriptions:
             report.append(f"{backend_descriptions[backend]}\n\n")
-        
+
         report.append("| ONNX Op | Hip Op | Runtime Func |\n")
         report.append("|---|---|---|\n")
-        
-        for mapping in sorted(mappings, key=lambda x: x['onnx_op'] or ''):
-            onnx_op = mapping['onnx_op'] or "N/A"
-            hip_op = mapping['hip_op']
-            runtime_func = mapping['runtime_func'] or "None"
+
+        for mapping in sorted(mappings, key=lambda x: x["onnx_op"] or ""):
+            onnx_op = mapping["onnx_op"] or "N/A"
+            hip_op = mapping["hip_op"]
+            runtime_func = mapping["runtime_func"] or "None"
             report.append(f"| {onnx_op} | {hip_op} | {runtime_func} |\n")
-        
+
         report.append("\n")
-    
+
     report.append("## Backend Distribution\n\n")
     report.append("```\n")
-    total = len(result['mappings'])
+    total = len(result["mappings"])
     for backend in sorted(backends.keys()):
         count = len(backends[backend])
         percentage = (count / total * 100) if total > 0 else 0
         report.append(f"{backend:30s} {count:2d} operations ({percentage:5.1f}%)\n")
     report.append("```\n\n")
-    
+
     report.append("## Key Insights\n\n")
-    
-    miopen_count = len(backends.get('MIOpen', []))
-    custom_count = len(backends.get('Custom Hip Kernel', []))
-    compile_count = len(backends.get('Compile Time Optimization', []))
-    hipblas_count = len(backends.get('hipBLASLt', []))
-    
+
+    miopen_count = len(backends.get("MIOpen", []))
+    custom_count = len(backends.get("Custom Hip Kernel", []))
+    compile_count = len(backends.get("Compile Time Optimization", []))
+    hipblas_count = len(backends.get("hipBLASLt", []))
+
     if miopen_count > 0:
-        report.append(f"1. **MIOpen Dominance**: {miopen_count} operations ({miopen_count/total*100:.0f}%) use MIOpen, indicating heavy reliance on AMD's optimized library for standard operations.\n\n")
-    
+        report.append(
+            f"1. **MIOpen Dominance**: {miopen_count} operations ({miopen_count / total * 100:.0f}%) use MIOpen, indicating heavy reliance on AMD's optimized library for standard operations.\n\n"
+        )
+
     if custom_count > 0:
-        report.append(f"2. **Custom Kernels**: {custom_count} operations ({custom_count/total*100:.0f}%) use custom HIP kernels, particularly for:\n")
+        report.append(
+            f"2. **Custom Kernels**: {custom_count} operations ({custom_count / total * 100:.0f}%) use custom HIP kernels, particularly for:\n"
+        )
         report.append("   - Attention mechanisms (GroupQueryAttention)\n")
         report.append("   - Quantized operations (MatMulNBits)\n")
         report.append("   - Specialized operations (QMoE, RotaryEmbedding)\n\n")
-    
+
     if compile_count > 0:
-        report.append(f"3. **Compile-Time Optimization**: {compile_count} operations ({compile_count/total*100:.0f}%) are tensor shape operations optimized at compile time with no runtime overhead.\n\n")
-    
+        report.append(
+            f"3. **Compile-Time Optimization**: {compile_count} operations ({compile_count / total * 100:.0f}%) are tensor shape operations optimized at compile time with no runtime overhead.\n\n"
+        )
+
     if hipblas_count > 0:
-        report.append(f"4. **Specialized Libraries**: {hipblas_count} operation(s) use hipBLASLt for optimal performance on matrix operations.\n\n")
-    
-    return ''.join(report)
+        report.append(
+            f"4. **Specialized Libraries**: {hipblas_count} operation(s) use hipBLASLt for optimal performance on matrix operations.\n\n"
+        )
+
+    return "".join(report)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/.cursor/skills/model-compatibility/scripts/step2_3_backend_analyzer_final.py
+++ b/.cursor/skills/model-compatibility/scripts/step2_3_backend_analyzer_final.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""
+Step 2-3: Backend Analyzer (Final - Hybrid Approach)
+Identify which backend each runtime function uses (ROCm library or
+Custom Hip Kernel) and emit the full mapping chain:
+    onnx_op -> hip_op -> runtime_func -> backend
+
+Final hybrid design:
+- Use a predefined runtime-function -> backend mapping table (easy to
+  maintain and extend).
+- Allow loading the mapping table from an external config file.
+- Fall back to dynamic detection by scanning runtime source.
+"""
+
+import json
+import re
+from pathlib import Path
+from typing import Dict, List, Set, Tuple
+import sys
+
+class BackendAnalyzer:
+    """Identify the ROCm library / Custom Kernel used by each runtime function."""
+    
+    def __init__(self, runtime_dir: str, hip_to_runtime_json: str = None, onnx_to_hip_json: str = None, 
+                 backend_config_json: str = None):
+        self.runtime_dir = Path(runtime_dir)
+        self.hip_to_runtime_data: List[Dict] = []
+        self.hip_to_runtime_by_hip: Dict[str, List[Dict]] = {}
+        self.onnx_to_hip_data: List[Dict] = []
+        
+        if hip_to_runtime_json:
+            self._load_json(hip_to_runtime_json, 'hip_to_runtime')
+        if onnx_to_hip_json:
+            self._load_json(onnx_to_hip_json, 'onnx_to_hip')
+        
+        # Load runtime implementation files.
+        self.runtime_implementations = self._load_runtime_implementations()
+        
+        # Load or build the runtime -> backend mapping table.
+        self.backend_mappings = self._load_backend_mappings(backend_config_json)
+    
+    def _load_json(self, json_path: str, data_type: str):
+        """Load a JSON file."""
+        try:
+            with open(json_path, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+            
+            if data_type == 'hip_to_runtime':
+                for mapping in data.get('mappings', []):
+                    self.hip_to_runtime_data.append(mapping)
+                    hip_op = mapping.get('hip_op')
+                    if hip_op:
+                        self.hip_to_runtime_by_hip.setdefault(hip_op, []).append(mapping)
+            elif data_type == 'onnx_to_hip':
+                for mapping in data.get('mappings', []):
+                    self.onnx_to_hip_data.append(mapping)
+        except Exception as e:
+            print(f"Warning: Could not load {json_path}: {e}")
+    
+    def _load_backend_mappings(self, config_json: str = None) -> Dict[str, str]:
+        """Load the runtime -> backend mapping table.
+
+        Priority:
+        1. External config file (if provided).
+        2. Built-in predefined mapping table.
+        """
+        
+        if config_json and Path(config_json).exists():
+            try:
+                with open(config_json, 'r', encoding='utf-8') as f:
+                    data = json.load(f)
+                    return data.get('mappings', {})
+            except Exception as e:
+                print(f"Warning: Could not load backend config {config_json}: {e}")
+        
+        # Built-in predefined mapping table.
+        return {
+            # MIOpen functions
+            'wrap_miopenActivationForward': 'MIOpen',
+            'wrap_miopenConvolutionForward': 'MIOpen',
+            'wrap_miopenOpTensor': 'MIOpen',
+            'wrap_miopenT5LayerNormForward': 'MIOpen',
+            'wrap_reduce_sum': 'MIOpen',
+            'hip_miopen_softmax': 'MIOpen',
+            
+            # hipBLASLt functions
+            'wrap_hipblasLtMatmul': 'hipBLASLt',
+            
+            # Custom Hip Kernel functions
+            'wrap_cast': 'Custom Hip Kernel',
+            'wrap_gather': 'Custom Hip Kernel',
+            'wrap_gemm': 'Custom Hip Kernel',
+            'wrap_group_query_attention': 'Custom Hip Kernel',
+            'wrap_matmul_nbits': 'Custom Hip Kernel',
+            'wrap_qmoe': 'Custom Hip Kernel',
+            'wrap_rotary_embedding': 'Custom Hip Kernel',
+            'wrap_skip_simplified_layer_norm': 'Custom Hip Kernel',
+            'wrap_elementwise_sub': 'MIOpen',
+            'hip_transpose': 'Custom Hip Kernel',
+        }
+    
+    def _load_runtime_implementations(self) -> Dict[str, Dict]:
+        """Load the content of all runtime implementation files."""
+        implementations = {}
+        
+        # Search both the runtime dir and its parent (broader search).
+        search_dirs = [self.runtime_dir]
+        parent_dir = self.runtime_dir.parent
+        if parent_dir.exists():
+            search_dirs.append(parent_dir)
+        
+        runtime_files = []
+        for search_dir in search_dirs:
+            runtime_files.extend(list(search_dir.glob('**/*.cpp')))
+        
+        runtime_files = list(set(runtime_files))
+        
+        for file_path in runtime_files:
+            try:
+                with open(file_path, 'r', encoding='utf-8', errors='ignore') as f:
+                    content = f.read()
+                
+                func_patterns = [
+                    r'(?:int|void|bool|float|double|hipError_t)\s+(\w+)\s*\([^)]*\)\s*\{',
+                ]
+                
+                for pattern in func_patterns:
+                    matches = re.findall(pattern, content)
+                    for func_name in matches:
+                        if func_name not in implementations:
+                            implementations[func_name] = {
+                                'file': str(file_path),
+                                'content': content
+                            }
+            except Exception as e:
+                pass
+        
+        return implementations
+    
+    def analyze(self) -> Dict:
+        """Run the backend analysis."""
+        result = {
+            'mappings': [],
+            'statistics': {}
+        }
+        
+        seen_keys = set()
+        for onnx_mapping in self.onnx_to_hip_data:
+            onnx_op = onnx_mapping['onnx_op']
+            onnx_domain = onnx_mapping['onnx_domain']
+            hip_op = onnx_mapping['hip_op']
+            onnx_file = onnx_mapping['file_name']
+
+            row_key = (onnx_op, onnx_domain, hip_op)
+            if row_key in seen_keys:
+                continue
+            seen_keys.add(row_key)
+            
+            runtime_func = None
+            hip_file = None
+            hip_rt_candidates = self.hip_to_runtime_by_hip.get(hip_op, [])
+            if hip_rt_candidates:
+                # Prefer a stable deterministic pick when multiple mappings exist.
+                chosen = sorted(
+                    hip_rt_candidates,
+                    key=lambda m: (
+                        str(m.get('file_name') or ''),
+                        str(m.get('runtime_func') or ''),
+                    ),
+                )[0]
+                runtime_func = chosen.get('runtime_func')
+                hip_file = chosen.get('file_name')
+            
+            if runtime_func:
+                backend = self._analyze_backend(runtime_func)
+                runtime_file = self.runtime_implementations.get(runtime_func, {}).get('file', 'N/A')
+            else:
+                backend = "Compile Time Optimization"
+                runtime_func = None
+                runtime_file = "N/A"
+            
+            mapping = {
+                'onnx_op': onnx_op,
+                'onnx_domain': onnx_domain,
+                'hip_op': hip_op,
+                'runtime_func': runtime_func,
+                'backend': backend,
+                'onnx_file': onnx_file,
+                'hip_file': hip_file,
+                'runtime_file': runtime_file
+            }
+            
+            result['mappings'].append(mapping)
+        
+        backends = set(m['backend'] for m in result['mappings'])
+        result['statistics'] = {
+            'total_mappings': len(result['mappings']),
+            'unique_onnx_ops': len(set(m['onnx_op'] for m in result['mappings'] if m['onnx_op'])),
+            'unique_hip_ops': len(set(m['hip_op'] for m in result['mappings'])),
+            'unique_runtime_funcs': len(set(m['runtime_func'] for m in result['mappings'] if m['runtime_func'])),
+            'unique_backends': len(backends),
+            'backends': sorted(list(backends))
+        }
+        
+        return result
+    
+    def _analyze_backend(self, runtime_func: str) -> str:
+        """Identify the backend a runtime function relies on.
+
+        Priority:
+        1. Look up in the predefined mapping table.
+        2. Inspect implementation file path (e.g. 3rd-party/custom_kernels).
+        3. Dynamic detection by scanning the implementation source.
+        """
+        
+        # 1. Check the predefined mapping table.
+        if runtime_func in self.backend_mappings:
+            return self.backend_mappings[runtime_func]
+        
+        # 2. Dynamic detection (requires the implementation source).
+        if runtime_func not in self.runtime_implementations:
+            return "Unknown"
+        
+        impl = self.runtime_implementations[runtime_func]
+        content = impl['content']
+        file_path = impl['file']
+        
+        # 2.1 Path heuristic: files under 3rd-party/custom_kernels are Custom Hip Kernels.
+        if '3rd-party/custom_kernels' in file_path or '3rd-party\\custom_kernels' in file_path:
+            return "Custom Hip Kernel"
+        if 'custom_kernels' in file_path:
+            return "Custom Hip Kernel"
+        
+        # 2.2 Library-API detection in source.
+        rocm_libraries = [
+            ('MIOpen', [r'miopen_\w+', r'miopenCreate', r'miopenDestroy']),
+            ('hipBLASLt', [r'hipblaslt_\w+', r'hipblasLt\w+']),
+            ('hipBLAS', [r'hipblas_\w+', r'hipblas[A-Z]']),
+            ('rocBLAS', [r'rocblas_\w+', r'rocblas[A-Z]']),
+        ]
+        
+        for lib_name, patterns in rocm_libraries:
+            for pattern in patterns:
+                if re.search(pattern, content):
+                    return lib_name
+        
+        # 2.3 Custom kernel detection.
+        if re.search(r'__global__\s+void|__kernel\s+void|hipLaunchKernel', content):
+            return "Custom Hip Kernel"
+        
+        return "Unknown"
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python step2_3_backend_analyzer_final.py <runtime_dir> [hip_to_runtime_json] [onnx_to_hip_json] [output_dir] [backend_config_json]")
+        sys.exit(1)
+    
+    runtime_dir = sys.argv[1]
+    hip_to_runtime_json = sys.argv[2] if len(sys.argv) > 2 else None
+    onnx_to_hip_json = sys.argv[3] if len(sys.argv) > 3 else None
+    output_dir = sys.argv[4] if len(sys.argv) > 4 else str(Path(runtime_dir).parent)
+    backend_config_json = sys.argv[5] if len(sys.argv) > 5 else None
+    
+    Path(output_dir).mkdir(parents=True, exist_ok=True)
+    
+    print(f"Analyzing backends (Final - Hybrid Approach)...")
+    print(f"Runtime directory: {runtime_dir}")
+    if hip_to_runtime_json:
+        print(f"Hip->Runtime mappings: {hip_to_runtime_json}")
+    if onnx_to_hip_json:
+        print(f"ONNX->Hip mappings: {onnx_to_hip_json}")
+    if backend_config_json:
+        print(f"Backend config: {backend_config_json}")
+    print(f"Output directory: {output_dir}\n")
+    
+    analyzer = BackendAnalyzer(runtime_dir, hip_to_runtime_json, onnx_to_hip_json, backend_config_json)
+    result = analyzer.analyze()
+    
+    print(f"{'='*80}")
+    print(f"Backend Analysis Summary:")
+    print(f"  Total mappings: {result['statistics']['total_mappings']}")
+    print(f"  Unique ONNX ops: {result['statistics']['unique_onnx_ops']}")
+    print(f"  Unique Hip ops: {result['statistics']['unique_hip_ops']}")
+    print(f"  Unique Runtime funcs: {result['statistics']['unique_runtime_funcs']}")
+    print(f"  Unique backends: {result['statistics']['unique_backends']}")
+    print(f"  Backends: {', '.join(result['statistics']['backends'])}")
+    print(f"{'='*80}\n")
+    
+    json_path = Path(output_dir) / "step2_3_backend_analysis.json"
+    with open(json_path, 'w', encoding='utf-8') as f:
+        json.dump(result, f, indent=2, ensure_ascii=False)
+    print(f"[OK] Analysis saved: {json_path}")
+    
+    md_path = Path(output_dir) / "step2_3_backend_analysis.md"
+    with open(md_path, 'w', encoding='utf-8') as f:
+        f.write(generate_markdown_report(result))
+    print(f"[OK] Markdown report saved: {md_path}")
+
+
+def generate_markdown_report(result: Dict) -> str:
+    """Render the backend analysis as a Markdown report."""
+    report = []
+    
+    report.append("# Backend Analysis Report\n\n")
+    
+    report.append("## Summary\n\n")
+    stats = result['statistics']
+    report.append(f"- **Total Mappings**: {stats['total_mappings']}\n")
+    report.append(f"- **Unique ONNX Operations**: {stats['unique_onnx_ops']}\n")
+    report.append(f"- **Unique Hip Operations**: {stats['unique_hip_ops']}\n")
+    report.append(f"- **Unique Runtime Functions**: {stats['unique_runtime_funcs']}\n")
+    report.append(f"- **Unique Backends**: {stats['unique_backends']}\n")
+    report.append(f"- **Backends Used**: {', '.join(stats['backends'])}\n\n")
+    
+    report.append("## Complete Mapping Chain with Backend Implementation\n\n")
+    report.append("| ONNX Op | Domain | Hip Op | Runtime Func | Backend |\n")
+    report.append("|---|---|---|---|---|\n")
+    
+    for mapping in sorted(result['mappings'], key=lambda x: (x['onnx_op'] or '', x['hip_op'])):
+        onnx_op = mapping['onnx_op'] or "N/A"
+        domain = mapping['onnx_domain'] or "N/A"
+        hip_op = mapping['hip_op']
+        runtime_func = mapping['runtime_func'] or "None"
+        backend = mapping['backend']
+        report.append(f"| {onnx_op} | {domain} | {hip_op} | {runtime_func} | {backend} |\n")
+    
+    report.append("\n")
+    
+    report.append("## Mappings by Backend\n\n")
+    
+    backends = {}
+    for mapping in result['mappings']:
+        backend = mapping['backend']
+        if backend not in backends:
+            backends[backend] = []
+        backends[backend].append(mapping)
+    
+    backend_descriptions = {
+        'MIOpen': "AMD's optimized library for deep learning operations on HIP/ROCm.",
+        'hipBLASLt': "AMD's optimized BLAS library for matrix operations on HIP/ROCm.",
+        'Custom Hip Kernel': "Custom HIP kernels implemented specifically for these operations.",
+        'Compile Time Optimization': "Tensor operations optimized at compile time, no runtime function needed.",
+    }
+    
+    for backend in sorted(backends.keys()):
+        mappings = backends[backend]
+        report.append(f"### {backend} ({len(mappings)} operations)\n\n")
+        
+        if backend in backend_descriptions:
+            report.append(f"{backend_descriptions[backend]}\n\n")
+        
+        report.append("| ONNX Op | Hip Op | Runtime Func |\n")
+        report.append("|---|---|---|\n")
+        
+        for mapping in sorted(mappings, key=lambda x: x['onnx_op'] or ''):
+            onnx_op = mapping['onnx_op'] or "N/A"
+            hip_op = mapping['hip_op']
+            runtime_func = mapping['runtime_func'] or "None"
+            report.append(f"| {onnx_op} | {hip_op} | {runtime_func} |\n")
+        
+        report.append("\n")
+    
+    report.append("## Backend Distribution\n\n")
+    report.append("```\n")
+    total = len(result['mappings'])
+    for backend in sorted(backends.keys()):
+        count = len(backends[backend])
+        percentage = (count / total * 100) if total > 0 else 0
+        report.append(f"{backend:30s} {count:2d} operations ({percentage:5.1f}%)\n")
+    report.append("```\n\n")
+    
+    report.append("## Key Insights\n\n")
+    
+    miopen_count = len(backends.get('MIOpen', []))
+    custom_count = len(backends.get('Custom Hip Kernel', []))
+    compile_count = len(backends.get('Compile Time Optimization', []))
+    hipblas_count = len(backends.get('hipBLASLt', []))
+    
+    if miopen_count > 0:
+        report.append(f"1. **MIOpen Dominance**: {miopen_count} operations ({miopen_count/total*100:.0f}%) use MIOpen, indicating heavy reliance on AMD's optimized library for standard operations.\n\n")
+    
+    if custom_count > 0:
+        report.append(f"2. **Custom Kernels**: {custom_count} operations ({custom_count/total*100:.0f}%) use custom HIP kernels, particularly for:\n")
+        report.append("   - Attention mechanisms (GroupQueryAttention)\n")
+        report.append("   - Quantized operations (MatMulNBits)\n")
+        report.append("   - Specialized operations (QMoE, RotaryEmbedding)\n\n")
+    
+    if compile_count > 0:
+        report.append(f"3. **Compile-Time Optimization**: {compile_count} operations ({compile_count/total*100:.0f}%) are tensor shape operations optimized at compile time with no runtime overhead.\n\n")
+    
+    if hipblas_count > 0:
+        report.append(f"4. **Specialized Libraries**: {hipblas_count} operation(s) use hipBLASLt for optimal performance on matrix operations.\n\n")
+    
+    return ''.join(report)
+
+
+if __name__ == '__main__':
+    main()

--- a/.cursor/skills/model-compatibility/scripts/step2_3_backend_analyzer_final.py
+++ b/.cursor/skills/model-compatibility/scripts/step2_3_backend_analyzer_final.py
@@ -60,11 +60,14 @@ class BackendAnalyzer:
     def _load_backend_mappings(self, config_json: str = None) -> Dict[str, str]:
         """Load the runtime -> backend mapping table.
 
-        Priority:
-        1. External config file (if provided).
-        2. Built-in predefined mapping table.
+        Source of truth is the runtime source itself: `_analyze_backend`
+        scans each wrapper's implementation for ROCm library API calls
+        (miopen*, hipblasLt*, hipblas*, rocblas*) and custom-kernel
+        markers (__global__, hipLaunchKernel, file under custom_kernels/).
+        This dict is therefore empty by default -- override only via an
+        external config when source-scan misclassifies (no compiled-in
+        list to drift out of date as new wrappers land).
         """
-        
         if config_json and Path(config_json).exists():
             try:
                 with open(config_json, 'r', encoding='utf-8') as f:
@@ -72,69 +75,56 @@ class BackendAnalyzer:
                     return data.get('mappings', {})
             except Exception as e:
                 print(f"Warning: Could not load backend config {config_json}: {e}")
-        
-        # Built-in predefined mapping table.
-        return {
-            # MIOpen functions
-            'wrap_miopenActivationForward': 'MIOpen',
-            'wrap_miopenConvolutionForward': 'MIOpen',
-            'wrap_miopenOpTensor': 'MIOpen',
-            'wrap_miopenT5LayerNormForward': 'MIOpen',
-            'wrap_reduce_sum': 'MIOpen',
-            'hip_miopen_softmax': 'MIOpen',
-            
-            # hipBLASLt functions
-            'wrap_hipblasLtMatmul': 'hipBLASLt',
-            
-            # Custom Hip Kernel functions
-            'wrap_cast': 'Custom Hip Kernel',
-            'wrap_gather': 'Custom Hip Kernel',
-            'wrap_gemm': 'Custom Hip Kernel',
-            'wrap_group_query_attention': 'Custom Hip Kernel',
-            'wrap_matmul_nbits': 'Custom Hip Kernel',
-            'wrap_qmoe': 'Custom Hip Kernel',
-            'wrap_rotary_embedding': 'Custom Hip Kernel',
-            'wrap_skip_simplified_layer_norm': 'Custom Hip Kernel',
-            'wrap_elementwise_sub': 'MIOpen',
-            'hip_transpose': 'Custom Hip Kernel',
-        }
+        return {}
     
     def _load_runtime_implementations(self) -> Dict[str, Dict]:
-        """Load the content of all runtime implementation files."""
-        implementations = {}
-        
-        # Search both the runtime dir and its parent (broader search).
+        """Index every runtime function definition to its source file.
+
+        Walks `lib/Runtime/real/` plus immediate `lib/Runtime/` siblings,
+        but **excludes `lib/Runtime/mock/`** because mock_gpu.cpp redefines
+        many wrappers as stubs whose bodies do not reflect the real backend.
+        Without this filter mock stubs overwrite real implementations
+        (last-write-wins) and `_analyze_backend` ends up reading the mock
+        body for backend classification.
+
+        For real-vs-real collisions (rare), the first definition wins.
+        """
+        implementations: Dict[str, Dict] = {}
+
+        # `runtime_dir` is typically `<repo>/lib/Runtime/real`. Also scan
+        # the parent so any wrappers placed at `lib/Runtime/*.cpp` are
+        # caught, but always skip the `mock/` subtree.
         search_dirs = [self.runtime_dir]
         parent_dir = self.runtime_dir.parent
-        if parent_dir.exists():
+        if parent_dir.exists() and parent_dir != self.runtime_dir:
             search_dirs.append(parent_dir)
-        
-        runtime_files = []
+
+        runtime_files = set()
         for search_dir in search_dirs:
-            runtime_files.extend(list(search_dir.glob('**/*.cpp')))
-        
-        runtime_files = list(set(runtime_files))
-        
+            for cpp in search_dir.glob('**/*.cpp'):
+                norm = str(cpp).replace('\\', '/').lower()
+                if '/mock/' in norm or norm.endswith('/mock_gpu.cpp'):
+                    continue
+                runtime_files.add(cpp)
+
+        func_pat = re.compile(
+            r'(?:int|void|bool|float|double|hipError_t)\s+(\w+)\s*\([^)]*\)\s*\{'
+        )
+
         for file_path in runtime_files:
             try:
                 with open(file_path, 'r', encoding='utf-8', errors='ignore') as f:
                     content = f.read()
-                
-                func_patterns = [
-                    r'(?:int|void|bool|float|double|hipError_t)\s+(\w+)\s*\([^)]*\)\s*\{',
-                ]
-                
-                for pattern in func_patterns:
-                    matches = re.findall(pattern, content)
-                    for func_name in matches:
-                        if func_name not in implementations:
-                            implementations[func_name] = {
-                                'file': str(file_path),
-                                'content': content
-                            }
-            except Exception as e:
+                for func_name in func_pat.findall(content):
+                    # First real definition wins; skip duplicates.
+                    if func_name not in implementations:
+                        implementations[func_name] = {
+                            'file': str(file_path),
+                            'content': content,
+                        }
+            except Exception:
                 pass
-        
+
         return implementations
     
     def analyze(self) -> Dict:
@@ -207,48 +197,101 @@ class BackendAnalyzer:
     def _analyze_backend(self, runtime_func: str) -> str:
         """Identify the backend a runtime function relies on.
 
-        Priority:
-        1. Look up in the predefined mapping table.
-        2. Inspect implementation file path (e.g. 3rd-party/custom_kernels).
-        3. Dynamic detection by scanning the implementation source.
+        Detection rules (source-driven, no hardcoded wrapper table):
+        1. Override via external config (self.backend_mappings, empty by default).
+        2. Implementation file path under custom_kernels/ -> Custom Hip Kernel
+           (file lives in the custom-kernel area of the tree).
+        3. The WRAPPER FUNCTION BODY (scoped, not whole file) is examined
+           for direct calls to library APIs:
+              - hipblasLt* / hipblaslt_*  -> hipBLASLt
+              - miopen* / miopenCreate    -> MIOpen
+              - hipblas* / hipblas[A-Z]   -> hipBLAS
+              - rocblas* / rocblas[A-Z]   -> rocBLAS
+           Body-scope avoids cross-wrapper pollution from neighbouring
+           helpers in the same .cpp.
+        4. Body has `__global__` / `hipLaunchKernel`, OR delegates to a
+           `hip_<name>(` function while the file `#include`s the custom-
+           kernels gateway header -> Custom Hip Kernel.
+        5. Fallback to whole-file library scan (rescue tiny wrappers whose
+           body is purely a delegation call without the library token).
+        6. Else Unknown.
         """
-        
-        # 1. Check the predefined mapping table.
+
         if runtime_func in self.backend_mappings:
             return self.backend_mappings[runtime_func]
-        
-        # 2. Dynamic detection (requires the implementation source).
+
         if runtime_func not in self.runtime_implementations:
             return "Unknown"
-        
+
         impl = self.runtime_implementations[runtime_func]
         content = impl['content']
         file_path = impl['file']
-        
-        # 2.1 Path heuristic: files under 3rd-party/custom_kernels are Custom Hip Kernels.
-        if '3rd-party/custom_kernels' in file_path or '3rd-party\\custom_kernels' in file_path:
+
+        if 'custom_kernels' in file_path.replace('\\', '/'):
             return "Custom Hip Kernel"
-        if 'custom_kernels' in file_path:
-            return "Custom Hip Kernel"
-        
-        # 2.2 Library-API detection in source.
+
         rocm_libraries = [
-            ('MIOpen', [r'miopen_\w+', r'miopenCreate', r'miopenDestroy']),
             ('hipBLASLt', [r'hipblaslt_\w+', r'hipblasLt\w+']),
+            ('MIOpen', [r'miopen_\w+', r'miopenCreate', r'miopenDestroy']),
             ('hipBLAS', [r'hipblas_\w+', r'hipblas[A-Z]']),
             ('rocBLAS', [r'rocblas_\w+', r'rocblas[A-Z]']),
         ]
-        
+
+        custom_kernel_header = bool(
+            re.search(r'#\s*include\s*[<"]hip_custom_kernels\.h[>"]', content)
+        )
+
+        body = self._extract_function_body(content, runtime_func)
+        if body:
+            for lib_name, patterns in rocm_libraries:
+                for pattern in patterns:
+                    if re.search(pattern, body):
+                        return lib_name
+            if re.search(r'__global__\s+void|__kernel\s+void|hipLaunchKernel', body):
+                return "Custom Hip Kernel"
+            # Body delegates to a hip_<name>(...) call AND the file pulls
+            # in the custom-kernel gateway: this is the canonical
+            # "wrap_X -> hip_X" delegation pattern used across runtime/real/.
+            if custom_kernel_header and re.search(r'\bhip_\w+\s*\(', body):
+                return "Custom Hip Kernel"
+
         for lib_name, patterns in rocm_libraries:
             for pattern in patterns:
                 if re.search(pattern, content):
                     return lib_name
-        
-        # 2.3 Custom kernel detection.
         if re.search(r'__global__\s+void|__kernel\s+void|hipLaunchKernel', content):
             return "Custom Hip Kernel"
-        
+
         return "Unknown"
+
+    @staticmethod
+    def _extract_function_body(content: str, func_name: str) -> str:
+        """Extract the body `{ ... }` of a top-level function definition
+        `... func_name(...) {`. Returns '' when not found. Uses balanced
+        brace traversal so nested blocks and string-with-brace edge cases
+        are handled."""
+        # Find the function signature opening: `func_name(`.
+        sig_pat = re.compile(
+            r'\b' + re.escape(func_name) + r'\s*\([^)]*\)\s*(?:const\s*)?\{'
+        )
+        m = sig_pat.search(content)
+        if not m:
+            return ''
+        # The `{` is the last char of the match. Walk balanced braces.
+        brace_pos = m.end() - 1
+        depth = 0
+        i = brace_pos
+        n = len(content)
+        while i < n:
+            ch = content[i]
+            if ch == '{':
+                depth += 1
+            elif ch == '}':
+                depth -= 1
+                if depth == 0:
+                    return content[brace_pos + 1:i]
+            i += 1
+        return ''
 
 
 def main():

--- a/.cursor/skills/model-compatibility/scripts/unsupported_reco_rules.json
+++ b/.cursor/skills/model-compatibility/scripts/unsupported_reco_rules.json
@@ -1,0 +1,207 @@
+{
+  "version": "2.0",
+  "description": "ROCm-real-capability-driven recommendation rules for unsupported ONNX ops.",
+  "default_fallback": {
+    "recommended_path": "Custom Hip Kernel",
+    "wrapper_extension_target": "new custom wrapper",
+    "rationale": "No validated ROCm library path with stable semantics for this operator."
+  },
+  "compile_time_rule": {
+    "when_reason_contains_any": [
+      "compile time",
+      "compile-time",
+      "constant folding",
+      "shape inference",
+      "shape manipulation",
+      "type-canonicalization"
+    ],
+    "recommended_path": "Compile Time Optimization",
+    "wrapper_extension_target": "none",
+    "rationale": "Operation is handled by compile-time transformation or shape/type propagation."
+  },
+  "real_rocm_capability_inventory": {
+    "MIOpen Activation API": {
+      "api_group": "miopenActivation*",
+      "validated_direct_modes": [
+        "relu",
+        "sigmoid",
+        "tanh",
+        "softplus",
+        "abs",
+        "elu",
+        "clamp",
+        "leakyrelu"
+      ],
+      "validated_parameterized_mode": "power: (alpha + beta*x)^gamma",
+      "power_derived_candidates": [
+        "reciprocal",
+        "sqrt",
+        "rsqrt"
+      ]
+    },
+    "MIOpen OpTensor API": {
+      "api_group": "miopenOpTensor",
+      "validated_binary_ops": [
+        "add",
+        "mul",
+        "min",
+        "max"
+      ],
+      "derived_candidate": "div via reciprocal + mul composition"
+    },
+    "MIOpen Convolution API": {
+      "api_group": "miopenConvolution*",
+      "validated_family": "convolution"
+    },
+    "hipBLASLt API": {
+      "api_group": "hipblasLt*",
+      "validated_family": "matmul/gemm"
+    }
+  },
+  "op_overrides": [
+    {
+      "op_name": "Reciprocal",
+      "recommended_path": "MIOpen",
+      "wrapper_extension_target": "wrap_miopenActivationForward (POWER mode)",
+      "rationale": "Can be represented by MIOpen POWER activation with gamma = -1."
+    },
+    {
+      "op_name": "Sqrt",
+      "recommended_path": "MIOpen",
+      "wrapper_extension_target": "wrap_miopenActivationForward (POWER mode)",
+      "rationale": "Can be represented by MIOpen POWER activation with gamma = 0.5."
+    },
+    {
+      "op_name": "Div",
+      "recommended_path": "MIOpen",
+      "wrapper_extension_target": "compose POWER reciprocal + wrap_miopenOpTensor(mul)",
+      "rationale": "No direct OpTensor div, but composable via reciprocal then multiplication."
+    }
+  ],
+  "family_routing": [
+    {
+      "family": "matmul",
+      "op_name_keywords_any": [
+        "matmul",
+        "gemm"
+      ],
+      "preferred_path": "hipBLASLt",
+      "wrapper_extension_target": "wrap_hipblasLtMatmul",
+      "fallback_path": "Custom Hip Kernel"
+    },
+    {
+      "family": "convolution",
+      "op_name_keywords_any": [
+        "conv"
+      ],
+      "preferred_path": "MIOpen",
+      "wrapper_extension_target": "wrap_miopenConvolutionForward",
+      "fallback_path": "Custom Hip Kernel"
+    },
+    {
+      "family": "activation_direct",
+      "op_name_keywords_any": [
+        "relu",
+        "sigmoid",
+        "tanh",
+        "softplus",
+        "elu",
+        "leakyrelu",
+        "clamp",
+        "abs"
+      ],
+      "preferred_path": "MIOpen",
+      "wrapper_extension_target": "wrap_miopenActivationForward",
+      "fallback_path": "Custom Hip Kernel"
+    },
+    {
+      "family": "activation_power_derived",
+      "op_name_keywords_any": [
+        "reciprocal",
+        "sqrt",
+        "rsqrt"
+      ],
+      "preferred_path": "MIOpen",
+      "wrapper_extension_target": "wrap_miopenActivationForward (POWER mode)",
+      "fallback_path": "Custom Hip Kernel"
+    },
+    {
+      "family": "elementwise_binary",
+      "op_name_keywords_any": [
+        "add",
+        "mul",
+        "min",
+        "max",
+        "div"
+      ],
+      "preferred_path": "MIOpen",
+      "wrapper_extension_target": "wrap_miopenOpTensor (or composed path for div)",
+      "fallback_path": "Custom Hip Kernel"
+    },
+    {
+      "family": "reduction",
+      "op_name_keywords_any": [
+        "reduce",
+        "cumsum"
+      ],
+      "preferred_path": "Custom Hip Kernel",
+      "wrapper_extension_target": "wrap_reduce_sum",
+      "fallback_path": "Custom Hip Kernel"
+    },
+    {
+      "family": "indexing_data_movement",
+      "op_name_keywords_any": [
+        "gather",
+        "scatter",
+        "slice",
+        "split",
+        "tile",
+        "pad",
+        "concat",
+        "expand"
+      ],
+      "preferred_path": "Custom Hip Kernel",
+      "wrapper_extension_target": "wrap_gather",
+      "fallback_path": "Custom Hip Kernel"
+    },
+    {
+      "family": "control_flow",
+      "op_name_keywords_any": [
+        "loop",
+        "if",
+        "scan"
+      ],
+      "preferred_path": "Custom Hip Kernel",
+      "wrapper_extension_target": "runtime orchestration extension",
+      "fallback_path": "Custom Hip Kernel"
+    },
+    {
+      "family": "attention_composite",
+      "op_name_keywords_any": [
+        "attention"
+      ],
+      "preferred_path": "Custom Hip Kernel",
+      "wrapper_extension_target": "attention specialized runtime wrapper",
+      "fallback_path": "Custom Hip Kernel"
+    },
+    {
+      "family": "normalization_composite",
+      "op_name_keywords_any": [
+        "layernormalization",
+        "groupnormalization",
+        "rmsnorm",
+        "batchnormalization"
+      ],
+      "preferred_path": "MIOpen",
+      "wrapper_extension_target": "wrap_miopenT5LayerNormForward",
+      "fallback_path": "Custom Hip Kernel"
+    }
+  ],
+  "output_requirements": {
+    "must_include_fields": [
+      "recommended_path",
+      "closest_wrapper_or_extension_target",
+      "rationale"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -72,7 +72,13 @@ Thumbs.db
 # Cline/AI assistant storage
 .cline_storage/
 .cline/
-.cursor/
+# Ignore .cursor/ contents (IDE/agent state) but track project-level skills.
+# Use .cursor/* (not .cursor/) so we can un-ignore .cursor/skills/ below;
+# a fully-ignored parent dir cannot have children re-included by git.
+.cursor/*
+!.cursor/skills/
+.cursor/skills/**/__pycache__/
+.cursor/skills/**/*.pyc
 
 # Claude Code workspace (worktrees, local settings, sdd ledger — never committed)
 .claude/


### PR DESCRIPTION
## Summary
- Adds project-level Cursor agent skill `model-compatibility` at `.cursor/skills/model-compatibility/` (4 md docs + 15 pipeline scripts) for analyzing ONNX models against the onnx-hipdnn-ep dialect.
- Orchestrator drives the chain: optional EP dump (VOE) → step1 ONNX parsing → original-vs-EP comparison → step2_0/1/2/3 (TableGen / OnnxToHip / HipToLLVM / backend classification) → normalized `report_input.json` → final markdown reports.
- VOE is optional: missing config emits `[VOE_NOT_CONFIGURED]` + exit 10 so the agent can prompt the user; `-SkipDump` falls back to analyzing the original ONNX with a prominent `Source: original ONNX (no EP rewrites)` badge.
- `OutputDir` auto-derived from the model's path for readable identity (e.g. `blip/onnx/decoder/fp16/model.onnx` → `D:\temp\blip_decoder_fp16_ep_compat`).
- Re-runs reuse `ep_input/onnx.onnx` and `step1/*` via timestamp caching; `step2_*` and reports are always regenerated so they stay in sync with the fast-moving `lib/Conversion` + `lib/Runtime` sources.
- `diagnose.md` documents the mandatory false-positive triage playbook + regression catalog. Five FP classes were discovered and fixed during validation: substring-shadowed struct scope, whole-file `com.microsoft` domain heuristic, `OperationState` declaration form, first `*Op::create` wins, inline `matchAndRewrite` truncation.
- `.gitignore`: switched `.cursor/` → `.cursor/*` so `.cursor/skills/` can be un-ignored; other `.cursor/` contents (transcripts, plans, projects) remain ignored, and global `__pycache__` / `*.pyc` rules are re-asserted under `scripts/`.

## Skill layout

```
.cursor/skills/model-compatibility/
├── SKILL.md            (agent entry: input gathering, workflow, validation checklist)
├── reference.md        (status semantics, reason codes, ROCm family routing matrix)
├── report_template.md  (exact markdown templates for the final reports)
├── diagnose.md         (FP triage playbook + regression catalog)
└── scripts/            (orchestrator + 4 step parsers + helpers + JSON configs)
```

## Validation

Validated end-to-end against the two BLIP fp16 sub-models:

| Model | Path | Headline result |
|---|---|---|
| Decoder | `blip/onnx/decoder/fp16/model.onnx` | 720 / 720 (100.0%) supported after diagnose-pass FP promotions; full EP pipeline (dump + step1×2 + compare + step2_* + reports) ~4 s |
| Encoder | `blip/onnx/encoder/fp16/model.onnx` | 318 / 367 (86.6%) on original ONNX (badge present; VOE dump failed for this model), remaining 49 nodes are compile-time foldable `Constant` / `Concat` / `Shape` |

## Test plan

- [ ] Attach `@model-compatibility` in Cursor and verify the agent auto-applies on a query like "analyze this ONNX model for HIP / ROCm EP compatibility"
- [ ] Run `scripts/run_ep_compatibility_check.ps1 -ModelPath <some .onnx>` with `$env:VOE_PACKAGE_ROOT` unset, verify stdout contains `[VOE_NOT_CONFIGURED]` and exit code is 10
- [ ] Re-run the same with `-SkipDump`; verify `model_compatibility_report.md` carries the `Source: original ONNX (no EP rewrites)` badge at the top
- [ ] Run with VOE configured against a known model; verify auto-derived `OutputDir` matches the path's last 3 meaningful segments (e.g. `blip_decoder_fp16_ep_compat`)
- [ ] Re-run against the same model; verify `(2/4) step1 original/EP: up-to-date, skip` cache hits and only `step2_*` + reports regenerate
- [ ] Run the pipeline once; verify no `__pycache__/` or `*.pyc` files show up in `git status` afterwards
