### PR TITLE
ci(windows): package model_mm + benchmark_multimodal.py and build OGA examples under VS18

### DIFF
--- a/.github/workflows/windows-build-mock.yml
+++ b/.github/workflows/windows-build-mock.yml
@@ -21,7 +21,10 @@ permissions:
 
 jobs:
   build-windows-mock:
-    runs-on: windows-latest
+    # Pin to VS 2022: windows-latest now serves the VS 2026 image
+    # (actions/runner-images#14017), which the pinned LLVM/ORT/OGA deps were
+    # not validated against.
+    runs-on: windows-2022
 
     env:
       LLVM_TAG: llvm-22.1.0-release

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -379,11 +379,12 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ${{ runner.workspace }}/oga-artifacts
-          # Reuse PREBUILT_CACHE_VERSION as the OGA cache version too: when
-          # the OGA build outputs change shape (e.g. wheel added), bumping
-          # PREBUILT_CACHE_VERSION invalidates both ORT and OGA caches in
-          # one step instead of needing two separate version knobs.
-          key: oga-dml-v${{ env.PREBUILT_CACHE_VERSION }}-${{ env.OGA_REF }}-ort${{ env.ONNXRUNTIME_VERSION }}
+          # Keyed on PREBUILT_CACHE_VERSION (shared with the ORT cache) plus an
+          # OGA-local token. Bump the OGA token when only the OGA artifact set
+          # changes shape (e.g. model_mm / benchmark_multimodal.py added) so the
+          # OGA build reruns without forcing an ORT source rebuild; bump
+          # PREBUILT_CACHE_VERSION when the ORT side changes.
+          key: oga-dml-v${{ env.PREBUILT_CACHE_VERSION }}-mm1-${{ env.OGA_REF }}-ort${{ env.ONNXRUNTIME_VERSION }}
 
       - name: Checkout OGA
         if: steps.cache-oga.outputs.cache-hit != 'true'
@@ -400,7 +401,7 @@ jobs:
         if: steps.cache-oga.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          ORT_HOME="${{ runner.workspace }}/oga-ort-home"
+          ORT_HOME="${{ github.workspace }}/source-oga/ort"
           mkdir -p "$ORT_HOME/include" "$ORT_HOME/lib"
           PREBUILT="${{ runner.workspace }}/prebuilt-local"
           cp -r "$PREBUILT/include/onnxruntime/"* "$ORT_HOME/include/"
@@ -418,12 +419,13 @@ jobs:
             --cmake_generator Ninja \
             --use_dml \
             --ort_home "$ORT_HOME" \
-            --skip_tests --skip_examples \
+            --skip_tests \
             --parallel \
             --build_dir "${{ runner.workspace }}/build-oga" \
             --cmake_extra_defines \
               CMAKE_C_COMPILER_LAUNCHER=sccache \
-              CMAKE_CXX_COMPILER_LAUNCHER=sccache
+              CMAKE_CXX_COMPILER_LAUNCHER=sccache \
+              "CMAKE_CXX_FLAGS=-wd4875 -wd4530 -D_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS"
 
           mkdir -p "${{ runner.workspace }}/oga-artifacts"
           OGA_OUT="${{ runner.workspace }}/build-oga/Release"
@@ -439,6 +441,17 @@ jobs:
           fi
           cp "$OGA_WHEEL" "${{ runner.workspace }}/oga-artifacts/"
           echo "Cached OGA wheel: $(basename "$OGA_WHEEL")"
+
+          MODEL_MM=$(find "${{ github.workspace }}/source-oga/examples/c/build" \
+            -name model_mm.exe -type f | head -1)
+          if [ -z "$MODEL_MM" ]; then
+            echo "ERROR: model_mm.exe not found in examples build tree"
+            exit 1
+          fi
+          cp "$MODEL_MM" "${{ runner.workspace }}/oga-artifacts/"
+
+          cp "${{ github.workspace }}/source-oga/benchmark/python/benchmark_multimodal.py" \
+            "${{ runner.workspace }}/oga-artifacts/"
 
       # -----------------------------------------------------------------------
       # Stage GPU test package:
@@ -511,6 +524,8 @@ jobs:
           # ---------------------------------------------------------------
           cp "${{ runner.workspace }}/oga-artifacts/model_benchmark.exe" staging/bin/
           cp "${{ runner.workspace }}/oga-artifacts/onnxruntime-genai.dll" staging/bin/
+          cp "${{ runner.workspace }}/oga-artifacts/model_mm.exe" staging/bin/
+          cp "${{ runner.workspace }}/oga-artifacts/benchmark_multimodal.py" staging/bin/
 
           # ---------------------------------------------------------------
           # Python wheels (ORT + OGA cp314) — bundled into the same artifact

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -417,18 +417,12 @@ jobs:
         if: steps.cache-oga.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          # examples/c builds model_qa/chat/mm/whisper in parallel, all sharing
-          # common.cpp; without /FS the concurrent cl.exe runs collide on the
-          # compiler PDB (C1041). -FS (dash form to avoid MSYS path mangling)
-          # forces synchronous PDB writes; CMake picks up CXXFLAGS for both the
-          # OGA core and the examples configure.
-          export CXXFLAGS=-FS
           python "${{ github.workspace }}/source-oga/build.py" \
             --config Release \
             --cmake_generator Ninja \
             --use_dml \
             --ort_home "$ORT_HOME" \
-            --skip_tests \
+            --skip_tests --skip_examples \
             --parallel \
             --build_dir "${{ runner.workspace }}/build-oga" \
             --cmake_extra_defines \
@@ -450,13 +444,22 @@ jobs:
           cp "$OGA_WHEEL" "${{ runner.workspace }}/oga-artifacts/"
           echo "Cached OGA wheel: $(basename "$OGA_WHEEL")"
 
-          MODEL_MM=$(find "${{ github.workspace }}/source-oga/examples/c/build" \
-            -name model_mm.exe -type f | head -1)
-          if [ -z "$MODEL_MM" ]; then
-            echo "ERROR: model_mm.exe not found in examples build tree"
-            exit 1
-          fi
-          cp "$MODEL_MM" "${{ runner.workspace }}/oga-artifacts/"
+          # build.py --skip_examples leaves examples/c unbuilt. Configure it as
+          # a standalone project against the just-built OGA lib + ORT_HOME and
+          # build only model_mm. build.py's own build_examples ignores CXXFLAGS,
+          # so set -DCMAKE_CXX_FLAGS=-FS here directly to force synchronous
+          # compiler-PDB writes (the parallel model_mm.cpp / common.cpp compiles
+          # otherwise clash on vc140.pdb -> C1041).
+          cmake -S "${{ github.workspace }}/source-oga/examples/c" \
+            -B "${{ runner.workspace }}/build-oga-examples" -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release -DMODEL_MM=ON -DCMAKE_CXX_FLAGS=-FS \
+            -DORT_INCLUDE_DIR="$ORT_HOME/include" \
+            -DORT_LIB_DIR="$ORT_HOME/lib" \
+            -DOGA_INCLUDE_DIR="${{ github.workspace }}/source-oga/src" \
+            -DOGA_LIB_DIR="$OGA_OUT"
+          cmake --build "${{ runner.workspace }}/build-oga-examples" --target model_mm
+          cp "${{ runner.workspace }}/build-oga-examples/model_mm.exe" \
+            "${{ runner.workspace }}/oga-artifacts/"
 
           cp "${{ github.workspace }}/source-oga/benchmark/python/benchmark_multimodal.py" \
             "${{ runner.workspace }}/oga-artifacts/"

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -124,17 +124,6 @@ jobs:
           tar -xzf therock.tar.gz -C "$THEROCK_DIST" --strip-components=1
           rm therock.tar.gz
 
-      # TEMP DEBUG: enumerate installed Visual Studio toolchains on the runner.
-      - name: List installed Visual Studio (debug)
-        shell: cmd
-        run: |
-          echo === vswhere -all -prerelease (path + version) ===
-          "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -all -prerelease -property installationPath
-          "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -all -prerelease -property installationVersion
-          echo === dir of VS roots ===
-          dir "C:\Program Files\Microsoft Visual Studio" 2>nul
-          dir "C:\Program Files (x86)\Microsoft Visual Studio" 2>nul
-
       # -----------------------------------------------------------------------
       # The prebuilt LLVM package has C:\msvsn2022 hardcoded in LLVMExports.cmake
       # for the DIA SDK path (known LLVM issue: llvm/llvm-project#111829).
@@ -428,6 +417,12 @@ jobs:
         if: steps.cache-oga.outputs.cache-hit != 'true'
         shell: bash
         run: |
+          # examples/c builds model_qa/chat/mm/whisper in parallel, all sharing
+          # common.cpp; without /FS the concurrent cl.exe runs collide on the
+          # compiler PDB (C1041). -FS (dash form to avoid MSYS path mangling)
+          # forces synchronous PDB writes; CMake picks up CXXFLAGS for both the
+          # OGA core and the examples configure.
+          export CXXFLAGS=-FS
           python "${{ github.workspace }}/source-oga/build.py" \
             --config Release \
             --cmake_generator Ninja \

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -22,7 +22,10 @@ permissions:
 
 jobs:
   build-windows:
-    runs-on: windows-latest
+    # windows-latest now serves the VS 2026 (VS 18) image, which the pinned
+    # onnxruntime-genai / onnxruntime_extensions does not build under. Pin to
+    # the VS 2022 image per actions/runner-images#14017.
+    runs-on: windows-2022
     # Cancel the build job when a newer commit lands on the same PR ref to
     # save runner minutes. gpu-test deliberately does NOT inherit this rule
     # (see its own concurrency block below) so an in-progress GPU run keeps
@@ -435,8 +438,7 @@ jobs:
             --build_dir "${{ runner.workspace }}/build-oga" \
             --cmake_extra_defines \
               CMAKE_C_COMPILER_LAUNCHER=sccache \
-              CMAKE_CXX_COMPILER_LAUNCHER=sccache \
-              "CMAKE_CXX_FLAGS=-wd4875 -wd4530 -D_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS"
+              CMAKE_CXX_COMPILER_LAUNCHER=sccache
 
           mkdir -p "${{ runner.workspace }}/oga-artifacts"
           OGA_OUT="${{ runner.workspace }}/build-oga/Release"

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -121,6 +121,17 @@ jobs:
           tar -xzf therock.tar.gz -C "$THEROCK_DIST" --strip-components=1
           rm therock.tar.gz
 
+      # TEMP DEBUG: enumerate installed Visual Studio toolchains on the runner.
+      - name: List installed Visual Studio (debug)
+        shell: cmd
+        run: |
+          echo === vswhere -all -prerelease (path + version) ===
+          "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -all -prerelease -property installationPath
+          "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -all -prerelease -property installationVersion
+          echo === dir of VS roots ===
+          dir "C:\Program Files\Microsoft Visual Studio" 2>nul
+          dir "C:\Program Files (x86)\Microsoft Visual Studio" 2>nul
+
       # -----------------------------------------------------------------------
       # The prebuilt LLVM package has C:\msvsn2022 hardcoded in LLVMExports.cmake
       # for the DIA SDK path (known LLVM issue: llvm/llvm-project#111829).


### PR DESCRIPTION
## Summary

Package the multimodal (VL) runners into `gpu-test-package` and make the from-scratch OGA build succeed on the runner's Visual Studio 18 toolchain. Split out of `release/msbuild` so CI iteration happens here instead of on the shared branch.

## What

1. **Package `model_mm` + `benchmark_multimodal.py`** for VL model CI: drop `--skip_examples` from the OGA `build.py` call and stage ORT at `REPO_ROOT/ort` (where `build_examples` hardcodes its ORT lookup) so the same build also produces `examples/c/model_mm.exe`; copy it and `benchmark/python/benchmark_multimodal.py` into `oga-artifacts` and then `gpu-test-package/bin`. Bump the OGA cache token so the artifact set rebuilds.
2. **VS 18 OGA build workarounds**: the runner now provides Visual Studio 18 (MSVC 14.51, via `vswhere -latest`), and the pinned `onnxruntime-genai` / `onnxruntime_extensions` does not build under it. Pass `CMAKE_CXX_FLAGS=-wd4875 -wd4530 -D_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS` to the OGA build: `-wd4875` (GSL `[[gsl::suppress]]` C4875), `-wd4530` (`/EHsc` C4530 in the noexcep_operators target), and the `_SILENCE` define (the `<experimental/coroutine>` STL1011 hard error). Pinning the compiler to VS 2022 was attempted but the runner no longer ships it.

## Why

VS 2022 is no longer installed on the runner, so the toolchain cannot be pinned back; the build must tolerate VS 18. The affected code is all pinned third-party (GSL, `onnxruntime_extensions`) fetched during the OGA build, not first-party.

## Test plan

- [ ] build-windows green on a cold OGA cache (OGA builds from scratch under VS 18; `model_mm.exe` produced).
- [ ] `gpu-test-package` contains `model_mm.exe` and `benchmark_multimodal.py`.
- [ ] More VS 18 warnings-as-errors may surface from the pinned deps; iterate here until green.
