### PR TITLE
perf(profiling): Reduce HIPDNN_EP_PERF profiler self-overhead and add report formatter + bench harness

### DIFF
--- a/backend-mlir-compiler/custom-op-mlir/src/InferenceState.cpp
+++ b/backend-mlir-compiler/custom-op-mlir/src/InferenceState.cpp
@@ -57,19 +57,24 @@ void InferenceState::resolveEntryPoints(const LoadedArtifact &artifact) {
   set_output_allocator_fn_ =
       artifact.get_method<void, void *, const output_allocator_t *>(
           hipdnn::abi::kSetOutputAllocator);
+  flush_op_profile_fn_ =
+      artifact.get_method<void, void *>(hipdnn::abi::kRuntimeFlushOpProfile);
 }
 
 InferenceState::InferenceState(PrivateTag, void *state,
                                std::unique_ptr<LoadedArtifact> artifact)
     : state_(state), artifact_(std::move(artifact)), compute_fn_(nullptr),
       compute_alloc_fn_(nullptr), cleanup_fn_(nullptr),
-      begin_compute_fn_(nullptr), set_output_allocator_fn_(nullptr) {
+      begin_compute_fn_(nullptr), set_output_allocator_fn_(nullptr),
+      flush_op_profile_fn_(nullptr) {
   resolveEntryPoints(*artifact_);
 
   MY_LOG(2) << "begin_compute symbol "
             << (begin_compute_fn_ ? "resolved" : "not exported (no-op)");
   MY_LOG(2) << "set_output_allocator symbol "
             << (set_output_allocator_fn_ ? "resolved" : "not exported (no-op)");
+  MY_LOG(2) << "flush_op_profile symbol "
+            << (flush_op_profile_fn_ ? "resolved" : "not exported (no-op)");
 
   // Without begin_compute, the GQA seqlens_k cache survives across
   // forward passes and decode returns token-1 values for tokens 2..N
@@ -199,6 +204,12 @@ void InferenceState::set_output_allocator(
 void InferenceState::begin_compute() const {
   if (begin_compute_fn_ && state_) {
     begin_compute_fn_(state_);
+  }
+}
+
+void InferenceState::flush_op_profile() const {
+  if (flush_op_profile_fn_ && state_) {
+    flush_op_profile_fn_(state_);
   }
 }
 

--- a/backend-mlir-compiler/custom-op-mlir/src/InferenceState.h
+++ b/backend-mlir-compiler/custom-op-mlir/src/InferenceState.h
@@ -85,6 +85,14 @@ public:
   // warns when the symbol is absent.
   void begin_compute() const;
 
+  // Flush per-op profile (HIPDNN_EP_PERF). Called by the EP AFTER its
+  // wall_ms timing window closes, so the resolve + std::map + fprintf cost
+  // no longer pollutes Compute() latency. No-op when the model.dll predates
+  // the export (per-op PERF block is silently skipped for such DLLs;
+  // inference is unaffected). Symbol resolved once in create() so the call
+  // is a single cached indirect dispatch.
+  void flush_op_profile() const;
+
   // Diagnostic-only accessor: returns the hipStream_t used by
   // inference_compute, as a void*.  Relies on RuntimeState
   // (lib/Runtime/runtime_state_internal.h) keeping hipStream_t as its first
@@ -138,6 +146,13 @@ private:
   // DLLs); only used in output-allocator mode.
   using SetOutputAllocatorFn = void (*)(void *, const output_allocator_t *);
   SetOutputAllocatorFn set_output_allocator_fn_;
+
+  // Cached function pointer for hipdnn_ep_runtime_flush_op_profile. Same
+  // contract as begin_compute_fn_: resolved once at session creation, null
+  // when the symbol is absent (older DLLs), one cached indirect call when
+  // present.
+  using FlushOpProfileFn = void (*)(void *);
+  FlushOpProfileFn flush_op_profile_fn_;
 };
 
 } // namespace mlir_compilation::customop

--- a/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
+++ b/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
@@ -736,11 +736,15 @@ MlirCustomOp::~MlirCustomOp() {
   for (const HostOutputScratch &slot : host_out_scratch_)
     if (slot.ptr)
       (void)hipFree(slot.ptr);
-#endif
-#ifndef BUILD_MOCK_RUNTIME
+
   // Release the lazy-allocated HIPDNN_EP_PERF event pair. Created on first
-  // perf-enabled Compute() and reused for the session lifetime; nullptr
-  // here means perf was never enabled, so nothing to release.
+  // perf-enabled Compute() and reused for the session lifetime; nullptr here
+  // means perf was never enabled, so nothing to release. Guarded by
+  // HIPDNN_EP_LINK_HIP_HOST (not BUILD_MOCK_RUNTIME): hipEvent_t /
+  // hipEventDestroy are only declared when the HIP headers are linked, and
+  // ep_perf_ev_* are only ever assigned by EpPerfTimer, which is itself behind
+  // this same macro -- so in builds without it these handles are always null
+  // and need no cleanup.
   if (ep_perf_ev_start_) {
     (void)hipEventDestroy(static_cast<hipEvent_t>(ep_perf_ev_start_));
     ep_perf_ev_start_ = nullptr;

--- a/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
+++ b/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
@@ -26,6 +26,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <mutex>
+#include <optional>
 #include <vector>
 
 // Environment parameters (global scope, before namespace)
@@ -382,8 +383,14 @@ customop::ArtifactKind determine_artifact_kind(const std::string &format_str) {
 //                               attention, etc.)
 //
 // Overhead when disabled: ~0 (single branch on a cached bool).
-// Overhead when enabled:  ~25us/call (hipEventCreate+Record+Sync+Destroy +
-//   one hipDeviceSynchronize + one fprintf) - negligible vs decode cost.
+// Overhead when enabled:  small per-call cost dominated by the
+//   hipDeviceSynchronize fence at the end of the timing block and the
+//   per-Compute fprintf line. hipEventCreate/Destroy is now amortized
+//   (events are session-scoped, lazy-allocated on first perf-enabled
+//   Compute), and the events themselves are created with
+//   hipEventDisableSystemFence so record() does not issue a system-scope
+//   acquire/release fence -- both wasted work for events we only read
+//   after the device-wide sync.
 // ============================================================================
 namespace {
 
@@ -473,6 +480,85 @@ private:
 PerfCollector g_perf_collector;
 
 PerfCollector &perf_collector() { return g_perf_collector; }
+
+#ifdef HIPDNN_EP_LINK_HIP_HOST
+// Per-Compute() HIPDNN_EP_PERF timer, shared by the classic and
+// output-allocator dispatch paths so the event lifecycle and PerfSample
+// assembly live in one place. Brackets the GPU work with a session-lifetime
+// event pair (owned by MlirCustomOp, lazily created here, released in its
+// destructor) and times the host phases with steady_clock.
+//
+// Usage: construct after begin-of-Compute, record_start() right before the
+// inference dispatch, record_stop() right after it returns, then populate the
+// host-phase fields on a PerfSample (they differ per path) and call finish(),
+// which fences the device, reads GPU elapsed time, fills wall/gpu/
+// fence_residual, and records the sample. Only construct when perf is enabled
+// (the disabled path must stay allocation- and timing-free).
+class EpPerfTimer {
+public:
+  using clock = std::chrono::steady_clock;
+
+  static double ms(clock::time_point a, clock::time_point b) {
+    return std::chrono::duration<double, std::milli>(b - a).count();
+  }
+
+  // start_slot / stop_slot are MlirCustomOp's mutable void* event handles.
+  // They are created once (on the first perf-enabled Compute()) and reused;
+  // t_enter is captured after creation so the one-time cost is excluded.
+  EpPerfTimer(void *&start_slot, void *&stop_slot, hipStream_t stream)
+      : stream_(stream) {
+    if (!start_slot) {
+      // hipEventDisableSystemFence: see op_profile.cpp
+      // (op_profile_acquire_event_pair) for the canonical rationale and
+      // guardrail. Safe here -- elapsed time is read only after the
+      // hipDeviceSynchronize() in finish().
+      hipEvent_t a = nullptr, b = nullptr;
+      (void)hipEventCreateWithFlags(&a, hipEventDisableSystemFence);
+      (void)hipEventCreateWithFlags(&b, hipEventDisableSystemFence);
+      start_slot = static_cast<void *>(a);
+      stop_slot = static_cast<void *>(b);
+    }
+    start_ = static_cast<hipEvent_t>(start_slot);
+    stop_ = static_cast<hipEvent_t>(stop_slot);
+    t_enter_ = clock::now();
+  }
+
+  clock::time_point t_enter() const { return t_enter_; }
+  clock::time_point t_after_compute() const { return t_after_compute_; }
+
+  // HIP error codes are intentionally discarded: a failure here only corrupts
+  // diagnostic numbers, never the inference result (the (void) cast also
+  // silences MSVC C4834 on the [[nodiscard]] return).
+  void record_start() { (void)hipEventRecord(start_, stream_); }
+  void record_stop() {
+    t_after_compute_ = clock::now();
+    (void)hipEventRecord(stop_, stream_);
+  }
+
+  // Closes the timing window: fences the device (the residual measures async
+  // work still queued after the dispatch returned), reads GPU elapsed time,
+  // fills the device-side fields on the caller-populated sample, and records
+  // it. The caller must have set the marshal_*/compute_cpu fields first.
+  void finish(PerfSample &s) {
+    (void)hipDeviceSynchronize();
+    const auto t_after_fence = clock::now();
+    float gpu_ms = 0.0f;
+    (void)hipEventSynchronize(stop_);
+    (void)hipEventElapsedTime(&gpu_ms, start_, stop_);
+    s.wall_ms = ms(t_enter_, t_after_fence);
+    s.gpu_ms = static_cast<double>(gpu_ms);
+    s.fence_residual_ms = ms(t_after_compute_, t_after_fence);
+    perf_collector().record(s);
+  }
+
+private:
+  hipStream_t stream_ = nullptr;
+  hipEvent_t start_ = nullptr;
+  hipEvent_t stop_ = nullptr;
+  clock::time_point t_enter_;
+  clock::time_point t_after_compute_;
+};
+#endif // HIPDNN_EP_LINK_HIP_HOST
 
 // Dumps the summary at DLL unload.  See ordering note above.
 struct PerfSummaryPrinter {
@@ -651,6 +737,19 @@ MlirCustomOp::~MlirCustomOp() {
     if (slot.ptr)
       (void)hipFree(slot.ptr);
 #endif
+#ifndef BUILD_MOCK_RUNTIME
+  // Release the lazy-allocated HIPDNN_EP_PERF event pair. Created on first
+  // perf-enabled Compute() and reused for the session lifetime; nullptr
+  // here means perf was never enabled, so nothing to release.
+  if (ep_perf_ev_start_) {
+    (void)hipEventDestroy(static_cast<hipEvent_t>(ep_perf_ev_start_));
+    ep_perf_ev_start_ = nullptr;
+  }
+  if (ep_perf_ev_stop_) {
+    (void)hipEventDestroy(static_cast<hipEvent_t>(ep_perf_ev_stop_));
+    ep_perf_ev_stop_ = nullptr;
+  }
+#endif
 }
 
 // Output-allocator dispatch: 2-arg inference_compute with in-graph
@@ -661,7 +760,27 @@ void MlirCustomOp::compute_with_output_allocator(
     OrtKernelContext *context) const {
   MY_LOG(2) << "MlirCustomOp::compute_with_output_allocator()";
 
+#ifdef HIPDNN_EP_LINK_HIP_HOST
+  // Allocator mode is a separate dispatch that returns before the classic
+  // Compute() perf block, so it must emit its own PerfSample (§4 per-call
+  // distribution) and per-op flush (§3 GPU table) here. Without this an
+  // output-allocator session -- every KV-cache model, the default ABI --
+  // produces no EP-side [PERF]/[PERF SUMMARY] lines under HIPDNN_EP_PERF=1.
+  // Unlike the classic path there is no marshal-out pre-pass (outputs are
+  // allocated in-graph via output_allocate_cb), so marshal_out_ms is 0.
+  const bool perf = perf_enabled();
+  std::optional<EpPerfTimer> timer;
+  EpPerfTimer::clock::time_point t_after_in{};
+  if (perf)
+    timer.emplace(ep_perf_ev_start_, ep_perf_ev_stop_,
+                  static_cast<hipStream_t>(inference_state_->get_stream_raw()));
+#endif
+
   auto inputs = marshal_input_tensors(context, input_index_map_);
+#ifdef HIPDNN_EP_LINK_HIP_HOST
+  if (perf)
+    t_after_in = EpPerfTimer::clock::now();
+#endif
 
   Ort::KernelContext ort_ctx(context);
   OutputAllocatorCtx octx;
@@ -676,7 +795,17 @@ void MlirCustomOp::compute_with_output_allocator(
   alloc.allocate = &output_allocate_cb;
   inference_state_->set_output_allocator(&alloc);
 
+#ifdef HIPDNN_EP_LINK_HIP_HOST
+  if (perf)
+    timer->record_start();
+#endif
+
   int ret = inference_state_->compute_with_output_allocator(&inputs.span);
+
+#ifdef HIPDNN_EP_LINK_HIP_HOST
+  if (perf)
+    timer->record_stop();
+#endif
 
   // Clear before octx leaves scope so a stale self pointer can never be used by
   // a later call (e.g. the next Compute() before it reinstalls its own ctx).
@@ -713,6 +842,19 @@ void MlirCustomOp::compute_with_output_allocator(
                  << " bytes failed: " << hipGetErrorString(e);
     }
   }
+
+  if (perf) {
+    // finish() fences after the post-compute D2H copies, so wall_ms /
+    // fence_residual_ms capture host-visible completion.
+    PerfSample s;
+    s.marshal_in_ms = EpPerfTimer::ms(timer->t_enter(), t_after_in);
+    s.marshal_out_ms = 0.0; // allocator mode: outputs allocated in-graph
+    s.compute_cpu_ms = EpPerfTimer::ms(t_after_in, timer->t_after_compute());
+    timer->finish(s);
+    // Resolve the per-op table AFTER the timing window closes (see the
+    // flush_op_profile contract -- keeps the resolve cost out of wall_ms).
+    inference_state_->flush_op_profile();
+  }
 #endif
 
   MY_LOG(2) << "compute_with_output_allocator completed";
@@ -733,7 +875,9 @@ void MlirCustomOp::Compute(const OrtApi *api, OrtKernelContext *context) const {
 
   if (use_output_allocator_) {
     // Allocator mode owns its output staging (no pre-filled outputs span) and
-    // its own post-compute host D2H; it does not share the classic perf path.
+    // its own post-compute host D2H; it runs its OWN HIPDNN_EP_PERF timing +
+    // per-op flush internally (see compute_with_output_allocator) rather than
+    // the classic perf block below.
     compute_with_output_allocator(context);
     MY_LOG(2) << "Compute completed successfully (allocator mode)";
     return;
@@ -757,45 +901,21 @@ void MlirCustomOp::Compute(const OrtApi *api, OrtKernelContext *context) const {
 
 #ifdef HIPDNN_EP_LINK_HIP_HOST
   // --- HIPDNN_EP_PERF path: wall + per-phase + GPU timing. ---
-  using clock = std::chrono::steady_clock;
-  auto elapsed_ms = [](clock::time_point a, clock::time_point b) {
-    return std::chrono::duration<double, std::milli>(b - a).count();
-  };
+  // The stream may be the default stream (hipStream_t(0)); hipEvent APIs
+  // accept that fine.
+  EpPerfTimer timer(
+      ep_perf_ev_start_, ep_perf_ev_stop_,
+      static_cast<hipStream_t>(inference_state_->get_stream_raw()));
 
-  const auto t_enter = clock::now();
   auto inputs = marshal_input_tensors(context, input_index_map_);
-  const auto t_after_in = clock::now();
+  const auto t_after_in = EpPerfTimer::clock::now();
   auto outputs =
       marshal_output_tensors(context, metadata_.outputs(), output_index_map_);
-  const auto t_after_out = clock::now();
+  const auto t_after_out = EpPerfTimer::clock::now();
 
-  // Stream used by inference_compute (first field of RuntimeState).  May be
-  // the default stream (hipStream_t(0)) — hipEvent APIs accept that fine.
-  auto stream = static_cast<hipStream_t>(inference_state_->get_stream_raw());
-
-  // HIP error codes are intentionally discarded below: any failure here only
-  // corrupts diagnostic numbers, never the inference result.  Casting to void
-  // also suppresses C4834 ([[nodiscard]] discarded) under MSVC /W4.
-  hipEvent_t ev_start = nullptr, ev_stop = nullptr;
-  (void)hipEventCreate(&ev_start);
-  (void)hipEventCreate(&ev_stop);
-  (void)hipEventRecord(ev_start, stream);
-
+  timer.record_start();
   const int ret = inference_state_->compute(&inputs.span, &outputs.span);
-  const auto t_after_compute = clock::now();
-
-  (void)hipEventRecord(ev_stop, stream);
-  // hipDeviceSynchronize() is the fence: measures residual async work left
-  // on any stream after compute() returned.  For correctly-synchronous
-  // dispatch paths this should be ~0.
-  (void)hipDeviceSynchronize();
-  const auto t_after_fence = clock::now();
-
-  float gpu_ms_f = 0.0f;
-  (void)hipEventSynchronize(ev_stop);
-  (void)hipEventElapsedTime(&gpu_ms_f, ev_start, ev_stop);
-  (void)hipEventDestroy(ev_start);
-  (void)hipEventDestroy(ev_stop);
+  timer.record_stop();
 
   if (ret != 0) {
     LOG(ERROR) << "inference_compute() failed with code: " << ret;
@@ -803,13 +923,17 @@ void MlirCustomOp::Compute(const OrtApi *api, OrtKernelContext *context) const {
   }
 
   PerfSample s;
-  s.wall_ms = elapsed_ms(t_enter, t_after_fence);
-  s.marshal_in_ms = elapsed_ms(t_enter, t_after_in);
-  s.marshal_out_ms = elapsed_ms(t_after_in, t_after_out);
-  s.compute_cpu_ms = elapsed_ms(t_after_out, t_after_compute);
-  s.gpu_ms = static_cast<double>(gpu_ms_f);
-  s.fence_residual_ms = elapsed_ms(t_after_compute, t_after_fence);
-  perf_collector().record(s);
+  s.marshal_in_ms = EpPerfTimer::ms(timer.t_enter(), t_after_in);
+  s.marshal_out_ms = EpPerfTimer::ms(t_after_in, t_after_out);
+  s.compute_cpu_ms = EpPerfTimer::ms(t_after_out, timer.t_after_compute());
+  timer.finish(s);
+
+  // Resolve the per-op table AFTER the timing window closes. The resolve
+  // (one hipEventElapsedTime per recorded op + std::map aggregation + a
+  // per-row fprintf) costs ~1 ms/Compute on a typical decoder graph -- large
+  // enough that keeping it inside the window measurably inflated wall_ms.
+  // See the flush_op_profile() contract in InferenceState.h.
+  inference_state_->flush_op_profile();
 
   MY_LOG(2) << "Compute completed successfully";
 #endif // HIPDNN_EP_LINK_HIP_HOST

--- a/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.h
+++ b/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.h
@@ -35,8 +35,9 @@ public:
                onnxruntime::Model *model);
 
   // Defined out-of-line: frees the allocator-mode host-output GPU scratch and
-  // releases the lazy-allocated HIPDNN_EP_PERF event pair below (hipEventDestroy
-  // lives in the hip header, which we keep out of this header).
+  // releases the lazy-allocated HIPDNN_EP_PERF event pair below
+  // (hipEventDestroy lives in the hip header, which we keep out of this
+  // header).
   ~MlirCustomOp() override;
 
   // Execute inference using loaded artifact

--- a/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.h
+++ b/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.h
@@ -34,7 +34,9 @@ public:
                const std::shared_ptr<morphizen::MetaDefProto> &meta_def,
                onnxruntime::Model *model);
 
-  // Defined out-of-line: frees the allocator-mode host-output GPU scratch.
+  // Defined out-of-line: frees the allocator-mode host-output GPU scratch and
+  // releases the lazy-allocated HIPDNN_EP_PERF event pair below (hipEventDestroy
+  // lives in the hip header, which we keep out of this header).
   ~MlirCustomOp() override;
 
   // Execute inference using loaded artifact
@@ -78,6 +80,15 @@ private:
   // cache, not observable state. Left empty (no allocation) in classic mode and
   // in mock builds.
   mutable std::vector<HostOutputScratch> host_out_scratch_;
+
+  // HIPDNN_EP_PERF wall-clock event pair. Created lazily on the first
+  // Compute() that observes perf_enabled(), then reused for the lifetime of
+  // this MlirCustomOp instance and destroyed in the destructor. Stored as
+  // void* to keep hip headers out of this header; the actual hipEvent_t type
+  // is just a pointer typedef on amdhip64, so the round-trip is safe.
+  // Mutable because Compute() is const but lazy-init writes these once.
+  mutable void *ep_perf_ev_start_ = nullptr;
+  mutable void *ep_perf_ev_stop_ = nullptr;
 };
 
 } // namespace mlir_compilation

--- a/docs/design/per-op-profiling.md
+++ b/docs/design/per-op-profiling.md
@@ -37,7 +37,7 @@ GPU events are recorded but not synchronized per-operator. Instead:
 
 1. Each `OpProfileScope` records `hipEventRecord(start)` in its constructor and `hipEventRecord(stop)` in its destructor, both on the existing HIP stream.
 2. Pending entries (name, shape, event pool index, CPU time) are stored in a vector inside `OpProfileState`.
-3. After `hipStreamSynchronize` completes (in `hipdnn_ep_stream_sync`), all pending events are resolved in bulk via `hipEventElapsedTime` and accumulated into a two-level profile map (op → shapes).
+3. After `hipStreamSynchronize` completes, all pending events are resolved in bulk via `hipEventElapsedTime` and accumulated into a two-level profile map (op → shapes). Resolve+print is invoked by the EP through `hipdnn_ep_runtime_flush_op_profile()` AFTER the `MlirCustomOp::Compute` wall-clock window closes — see "Resolve placement" below.
 
 This avoids per-operator GPU synchronization overhead.
 
@@ -45,7 +45,21 @@ This avoids per-operator GPU synchronization overhead.
 
 HIP events are pre-allocated in `OpProfileState::eventPool` and reused across inferences. `op_profile_acquire_event_pair()` returns the next available index; if the pool is exhausted, a new pair is created and appended. The pool grows on demand but never shrinks — after the first inference, all subsequent inferences reuse existing events with zero `hipEventCreate`/`hipEventDestroy` calls.
 
-For Llama 8B (486 operator calls per inference), this eliminates 972 `hipEventCreate` + 972 `hipEventDestroy` per inference. Measured overhead dropped from +56 ms (93%) to +35 ms (60%) compared to profiling-off baseline.
+For Llama 8B (486 operator calls per inference), this eliminates 972 `hipEventCreate` + 972 `hipEventDestroy` per inference.
+
+### `hipEventDisableSystemFence` on every recorded event
+
+Every event in the pool — plus the four H2D/D2H phase events in `hipdnn_ep_runtime_tensor.cpp` and the two EP-side wall-clock events in `MlirCustomOp.cpp` — is created with `hipEventCreateWithFlags(..., hipEventDisableSystemFence)`. By default, each `hipEventRecord` issues a system-scope acquire/release fence (CPU-visible cache flush across all GPUs and the CPU). The fence is wasted work for events we only read via `hipEventElapsedTime` AFTER an explicit `hipStreamSynchronize` — that sync already establishes the required ordering. Dropping the per-record fence cuts ~1 ms / Compute / ~500 records on Llama-8B decode. The flag is set once at creation time and applies to every subsequent record on the same event, so the win compounds across the session.
+
+Do NOT use this flag on events whose results are observed without a subsequent stream sync (e.g., cross-stream synchronization, multi-GPU coordination, CPU-side polling via `hipEventQuery`). All HIPDNN_EP_PERF events are read after sync, so all of them use the flag.
+
+### Resolve placement (`hipdnn_ep_runtime_flush_op_profile`)
+
+The resolve+print step (N × `hipEventElapsedTime` + `std::map` aggregation + ~hundreds of `fprintf` lines per Compute) was historically called from `hipdnn_ep_stream_sync` — which runs inside the generated `main_graph` function, which the EP times as part of `compute_cpu_ms` / `wall_ms`. That inflated the per-Compute latency reported in `[PERF SUMMARY]` and conflated kernel+dispatch time with profile-printing time.
+
+The resolve is now exported as a separate runtime entry point — `hipdnn_ep_runtime_flush_op_profile(RuntimeState*)` — and called by the EP from `MlirCustomOp::Compute` AFTER the `hipDeviceSynchronize` fence and AFTER `perf_collector().record(s)`. Symbol resolution is cached at session creation (`InferenceState::create`) so the per-Compute dispatch is a single indirect call; older model.dlls without the export silently skip the flush (per-op `[PERF]` block missing, inference otherwise unaffected — same compatibility contract as `hipdnn_ep_runtime_begin_compute`).
+
+This does NOT reduce OGA's measured TPS (the flush still runs inside `MlirCustomOp::Compute`, just after the EP's wall window) — its purpose is to make the `wall_ms` / `compute_cpu_ms` / `gpu_ms` numbers in `[PERF SUMMARY]` honest kernel+dispatch time, NOT kernel+dispatch+resolve time.
 
 ### State ownership
 
@@ -58,7 +72,7 @@ RuntimeState
 
 - Created in `hipdnn_ep_state_init_with_fs()` (only when PERF enabled)
 - Reset at the start of each inference (`prepare_input` with index==0)
-- Resolved and printed in `hipdnn_ep_stream_sync()` after GPU sync
+- Resolved and printed by the EP via `hipdnn_ep_runtime_flush_op_profile()` AFTER the EP's wall-clock window closes (post-`hipDeviceSynchronize`, post-`perf_collector().record`) — see "Resolve placement" above
 - Destroyed in `hipdnn_ep_state_cleanup()`
 
 ### Output format
@@ -102,10 +116,14 @@ Use the CPU column as a diagnostic: if an op that should be fully async shows >1
 | File | Role |
 |------|------|
 | `lib/Runtime/op_profile.h` | RAII scope guards (`OpProfileScope`, `OpProfileCpuScope`), `OP_PROFILE`/`OP_PROFILE_CPU` macros |
-| `lib/Runtime/op_profile.cpp` | `OpProfileState` struct (event pool + two-level: OpEntry → ShapeEntry), create/destroy/reset/resolve/print |
+| `lib/Runtime/op_profile.cpp` | `OpProfileState` struct (event pool + two-level: OpEntry → ShapeEntry), create/destroy/reset/resolve/print. Pool events created with `hipEventDisableSystemFence`. |
 | `lib/Runtime/debug_log.h` | `hipdnn_ep_perf_enabled()` — env var check (uses Win32 API on Windows) |
 | `lib/Runtime/runtime_state_internal.h` | `void *op_profile` field in `RuntimeState` |
-| `lib/Runtime/hipdnn_ep_runtime.h` | `hipdnn_ep_state_get_op_profile()` accessor |
+| `lib/Runtime/hipdnn_ep_runtime.h` | `hipdnn_ep_state_get_op_profile()` accessor; declarations for `hipdnn_ep_runtime_begin_compute` and `hipdnn_ep_runtime_flush_op_profile` |
+| `lib/Runtime/hipdnn_ep_runtime_state.cpp` | Implementations of the two `__declspec(dllexport)` runtime hooks above |
+| `lib/Compiler/CompilerDriver.cpp` | `export_symbols` list — both hooks must appear here so lld-link emits them in the model.dll export table |
+| `backend-mlir-compiler/custom-op-mlir/src/InferenceState.{h,cpp}` | Cached symbol lookup for both hooks (`begin_compute_fn_`, `flush_op_profile_fn_`); null when the model.dll predates the export |
+| `backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.{h,cpp}` | EP-side wall-clock timing; session-scoped `ep_perf_ev_{start,stop}_` event pair (lazy-allocated with `hipEventDisableSystemFence`); calls `flush_op_profile()` after `t_after_fence` |
 | `lib/Runtime/real/*.cpp` | One `OP_PROFILE`/`OP_PROFILE_CPU` call per wrapper function |
 
 ## Adding profiling to a new operator
@@ -127,9 +145,20 @@ int wrap_new_op(RuntimeState *state, ..., int64_t M, int64_t N, ...) {
 
 Use `OP_PROFILE_CPU` instead for operations that don't launch GPU kernels (e.g., `stream_sync`). The shape lambda is only called when profiling is active, so there is no `snprintf` overhead on the hot path.
 
+## Measured overhead (Llama-3.1-8B AWQ INT4 g128, gfx1151, OGA `model_benchmark -l 128 -g 128 -r 3`)
+
+After Fix 1 (`hipEventDisableSystemFence`) + Fix 2 (`flush_op_profile` hook) + Fix 3 (session-scoped EP-side events):
+
+| Mode | decode tok/s | per-Compute median wall | gap vs `mode=none` |
+|---|---|---|---|
+| `HIPDNN_EP_PERF=0` (none) | 42.79 | n/a | baseline |
+| `HIPDNN_EP_PERF=1` (perf) | 38.68 / 39.70 (two runs) | 24.05–24.76 ms | ~8% |
+
+Before any of these fixes the same workload showed `HIPDNN_EP_PERF=1` decode = 37.85 tok/s and per-Compute median wall = 25.51 ms — a ~12.3% gap. Roughly a third of the original PERF overhead was driver-induced (per-record system fences); the rest is intrinsic to per-op profiling (the ~500 `hipEventRecord` calls themselves, the same number of `hipEventElapsedTime` queries during resolve, and the `fprintf` traffic for the per-op breakdown block). Closing more requires changes in the "Future optimization ideas" section below.
+
 ## Future optimization ideas
 
-Current profiling-on overhead is ~35 ms (+60%) on Llama 8B, from 972 `hipEventRecord` + 486 `hipEventElapsedTime` HIP driver calls. Three approaches to reduce this further:
+After the three fixes above, residual overhead on Llama 8B is ~8% of decode TPS, dominated by the bare cost of recording ~500 events per inference plus the `fprintf` traffic for the per-op block. Approaches to reduce this further:
 
 ### Two-tier profiling (recommended next step)
 

--- a/include/hip/artifact_abi.h
+++ b/include/hip/artifact_abi.h
@@ -29,6 +29,8 @@ inline constexpr const char *kRuntimeBeginCompute =
     "hipdnn_ep_runtime_begin_compute";
 inline constexpr const char *kSetOutputAllocator =
     "hipdnn_ep_set_output_allocator";
+inline constexpr const char *kRuntimeFlushOpProfile =
+    "hipdnn_ep_runtime_flush_op_profile";
 
 // Internal-linkage globals baked into the artifact by GenerateInterface.
 //   kMetadataBlobGlobal: FlatBuffers HipModelMetaInfo consumed by

--- a/lib/Compiler/CompilerDriver.cpp
+++ b/lib/Compiler/CompilerDriver.cpp
@@ -179,7 +179,8 @@ bool CompilerDriver::compileImpl(mlir::ModuleOp module,
     //   hipdnn_ep_runtime_flush_op_profile   — HIPDNN_EP_PERF per-op resolve +
     //                                          print hook (called by EP AFTER
     //                                          its wall_ms window closes so the
-    //                                          resolve cost doesn't pollute TPS)
+    //                                          resolve cost doesn't pollute
+    //                                          TPS)
     std::vector<std::string> export_symbols = {
         hipdnn::abi::kInferenceInit,
         hipdnn::abi::kInferenceCompute,

--- a/lib/Compiler/CompilerDriver.cpp
+++ b/lib/Compiler/CompilerDriver.cpp
@@ -176,6 +176,10 @@ bool CompilerDriver::compileImpl(mlir::ModuleOp module,
     //   hipdnn_ep_runtime_begin_compute      — per-Compute() cache invalidation
     //   hipdnn_ep_set_output_allocator       — EP installs the output allocator
     //                                          before inference_compute
+    //   hipdnn_ep_runtime_flush_op_profile   — HIPDNN_EP_PERF per-op resolve +
+    //                                          print hook (called by EP AFTER
+    //                                          its wall_ms window closes so the
+    //                                          resolve cost doesn't pollute TPS)
     std::vector<std::string> export_symbols = {
         hipdnn::abi::kInferenceInit,
         hipdnn::abi::kInferenceCompute,
@@ -183,7 +187,8 @@ bool CompilerDriver::compileImpl(mlir::ModuleOp module,
         hipdnn::abi::kInferenceGetMetadataJson,
         "test_hip_from_dll",
         hipdnn::abi::kRuntimeBeginCompute,
-        hipdnn::abi::kSetOutputAllocator};
+        hipdnn::abi::kSetOutputAllocator,
+        hipdnn::abi::kRuntimeFlushOpProfile};
     std::vector<std::string> libraries;
     std::vector<std::string> library_paths;
     discoverLibraries(libraries, library_paths);

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -400,13 +400,41 @@ void *hipdnn_ep_state_get_error_flag_device_ptr(RuntimeState *state);
 int hipdnn_ep_state_reset_error_flag(RuntimeState *state);
 int hipdnn_ep_state_read_and_clear_error_flag(RuntimeState *state);
 // Mark the start of a new Compute() call. Invalidates per-forward-pass
-// caches such as the GQA seqlens_k cache (see runtime_state_internal.h).
-// Called by the EP-side MlirCustomOp::Compute() entry once per inference;
-// safe to call unconditionally (cheap: writes a single bool). Required for
-// the GQA seqlens_k cache (default on, set HIPDNN_EP_GQA_CACHE_SEQLENS=0
-// to disable) to be correct -- without this hook the cache would persist
-// across forward passes and return stale values.
+// runtime caches -- today: the GQA seqlens_k cache (see
+// runtime_state_internal.h for the canonical list).
+//
+// Contract: the EP-side caller must invoke this exactly once at the top
+// of every MlirCustomOp::Compute(), before any input marshaling. The
+// pairing with Compute() is what defines "forward pass" for cache
+// invalidation purposes.
+//
+// Cost: writes a small number of fields on RuntimeState (no allocation,
+// no GPU work). Safe to call unconditionally on the hot path.
+//
+// Backwards compatibility: model.dlls predating this export are loaded
+// with a null cached function pointer on the EP side and the call is
+// silently skipped. Such DLLs MUST run with HIPDNN_EP_GQA_CACHE_SEQLENS=0;
+// otherwise stale seqlens_k values from the previous forward pass would
+// silently corrupt decode output from token 2 onward. The mismatch is
+// detected at session creation by InferenceState::create() and produces
+// a LOG(WARNING) containing the substring "GQA seqlens_k cache is
+// enabled ... but the loaded model.dll does not export
+// hipdnn_ep_runtime_begin_compute" -- greppable across logs and code.
 void hipdnn_ep_runtime_begin_compute(RuntimeState *state);
+
+// Resolve and print the per-op profile table (HIPDNN_EP_PERF).
+//
+// Contract: the EP must invoke this AFTER the Compute() wall-clock window
+// has closed. The resolve (one hipEventElapsedTime per profiled op + map
+// aggregation + fprintf) used to run inside hipdnn_ep_stream_sync on the
+// hot path, where its cost inflated the very [PERF SUMMARY] numbers the
+// table explains. A no-op (single null check) when perf is disabled, so it
+// is safe to call unconditionally.
+//
+// Backwards compatibility: same as hipdnn_ep_runtime_begin_compute -- a
+// model.dll predating this export resolves to a null pointer EP-side and the
+// call is skipped (inference unaffected; the per-op block just won't print).
+void hipdnn_ep_runtime_flush_op_profile(RuntimeState *state);
 
 // Initialize memory pool in runtime state
 // Called by generated inference_init after creating RuntimeState

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -864,6 +864,27 @@ extern "C"
   hipdnn_ep_set_current_stream(static_cast<void *>(state->stream));
 }
 
+// Per-op profile flush hook. Moved out of hipdnn_ep_stream_sync (which is on
+// the inference_compute hot path) so the resolve + map + fprintf cost lands
+// AFTER the EP closes its wall_ms timing window. Same dllexport contract as
+// begin_compute above so dlsym/GetProcAddress can find it; symbol is
+// optional from the EP's perspective (older DLLs no-op).
+//
+// Body intentionally minimal: op_profile_resolve_and_print itself is a no-op
+// when the pending queue is empty or the state pointer is null, so callers
+// don't need to gate on HIPDNN_EP_PERF.
+extern "C"
+#ifdef _WIN32
+    __declspec(dllexport)
+#endif
+        void hipdnn_ep_runtime_flush_op_profile(RuntimeState *state) {
+  if (!state) {
+    return;
+  }
+  op_profile_resolve_and_print(
+      static_cast<OpProfileState *>(state->op_profile));
+}
+
 //===----------------------------------------------------------------------===//
 // Memory Pooling Support
 //===----------------------------------------------------------------------===//

--- a/lib/Runtime/hipdnn_ep_runtime_tensor.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_tensor.cpp
@@ -48,11 +48,20 @@ static PerfState g_perf;
 static void perf_ensure_events() {
   if (g_perf.initialized)
     return;
-  if (hipEventCreate(&g_perf.h2d_start) != hipSuccess ||
-      hipEventCreate(&g_perf.h2d_end) != hipSuccess ||
-      hipEventCreate(&g_perf.d2h_start) != hipSuccess ||
-      hipEventCreate(&g_perf.d2h_end) != hipSuccess) {
-    fprintf(stderr, "[PERF] WARNING: hipEventCreate failed, disabling PERF\n");
+  // hipEventDisableSystemFence: see op_profile.cpp
+  // (op_profile_acquire_event_pair) for the canonical rationale and the
+  // "never set without a following sync" guardrail. Safe here -- these phase
+  // events are read via hipEventElapsedTime only after hipStreamSynchronize.
+  if (hipEventCreateWithFlags(&g_perf.h2d_start, hipEventDisableSystemFence) !=
+          hipSuccess ||
+      hipEventCreateWithFlags(&g_perf.h2d_end, hipEventDisableSystemFence) !=
+          hipSuccess ||
+      hipEventCreateWithFlags(&g_perf.d2h_start, hipEventDisableSystemFence) !=
+          hipSuccess ||
+      hipEventCreateWithFlags(&g_perf.d2h_end, hipEventDisableSystemFence) !=
+          hipSuccess) {
+    fprintf(stderr,
+            "[PERF] WARNING: hipEventCreateWithFlags failed, disabling PERF\n");
     if (g_perf.h2d_start) {
       (void)hipEventDestroy(g_perf.h2d_start);
       g_perf.h2d_start = nullptr;
@@ -700,8 +709,10 @@ int hipdnn_ep_stream_sync(RuntimeState *state) {
             total_ms > 0 ? (h2d_ms / total_ms * 100.0) : 0.0,
             total_ms > 0 ? (compute_ms / total_ms * 100.0) : 0.0,
             total_ms > 0 ? (d2h_ms / total_ms * 100.0) : 0.0);
-    auto *op_ps = static_cast<OpProfileState *>(state->op_profile);
-    op_profile_resolve_and_print(op_ps);
+    // Per-op resolve+print was moved out of the hot path -- the EP now
+    // calls hipdnn_ep_runtime_flush_op_profile() after its wall_ms window
+    // closes, so the N x hipEventElapsedTime + std::map + fprintf cost no
+    // longer inflates the Compute() latency that drives TPS measurements.
   }
 
   return HIPDNN_EP_SUCCESS;

--- a/lib/Runtime/mock/mock_types.h
+++ b/lib/Runtime/mock/mock_types.h
@@ -29,6 +29,10 @@ struct hipDeviceProp_t {
 #define hipHostMallocMapped 0
 #define hipHostMallocNonCoherent 0
 #define hipEventDisableTiming 0
+// Mock stub: the real flag drops hipEventRecord's system-scope fence (see
+// op_profile.cpp). The mock hipEventCreateWithFlags ignores flags, so the
+// value is irrelevant -- it only needs to be a declared identifier.
+#define hipEventDisableSystemFence 0
 
 // MIOpen tensor layout enum (subset used by the runtime)
 typedef int miopenTensorLayout_t;

--- a/lib/Runtime/op_profile.cpp
+++ b/lib/Runtime/op_profile.cpp
@@ -73,8 +73,23 @@ int op_profile_acquire_event_pair(OpProfileState *ps) {
   int idx = ps->nextEventIndex++;
   if (idx >= (int)ps->eventPool.size()) {
     OpProfileState::EventPair ep;
-    hipEventCreate(&ep.start);
-    hipEventCreate(&ep.stop);
+    // Canonical rationale for hipEventDisableSystemFence across the profiler
+    // (other call sites reference this comment): hipEventRecord issues a
+    // system-scope acquire/release fence by default, which is wasted work for
+    // events whose elapsed time we read only after a hipStreamSynchronize.
+    // Disabling it preserves elapsed-time accuracy and GPU completion ordering
+    // while removing a per-record fence that, at hundreds of records per
+    // inference, otherwise dominated the per-op table.
+    //
+    // Guardrail: do NOT set this flag on events observed without a following
+    // stream/device sync (cross-stream coordination, CPU polling via
+    // hipEventQuery, multi-device visibility) -- those rely on the default
+    // flush semantics. No profiler event falls into that category.
+    //
+    // Pool slots are created once and reused across inferences, so creation
+    // cost is paid during warmup and every later record is free.
+    hipEventCreateWithFlags(&ep.start, hipEventDisableSystemFence);
+    hipEventCreateWithFlags(&ep.stop, hipEventDisableSystemFence);
     ps->eventPool.push_back(ep);
   }
   return idx;

--- a/tools/perf-report/.gitignore
+++ b/tools/perf-report/.gitignore
@@ -1,0 +1,10 @@
+# Runtime artifacts produced by run_bench.sh. Scoped here (rather than the
+# top-level .gitignore) because they only exist when this directory's
+# scripts are exercised. gitignore patterns must be on their own lines --
+# trailing same-line comments are treated as part of the pattern.
+
+# bench stderr+stdout captures
+_perf_logs/
+
+# staged model dirs (symlinks + copy of genai_config_MorphiZenEP.json)
+oga_dynamic_dirs/

--- a/tools/perf-report/README.md
+++ b/tools/perf-report/README.md
@@ -4,17 +4,31 @@ Licensed under the MIT License.
 -->
 # HIPDNN EP Profiling Report Formatter
 
-`format_perf_report.py` parses a `HIPDNN_EP_PERF=1` log produced by
-`model_benchmark` driving the MorphiZen EP and renders a locked-down,
-section-stable profiling report.
+This directory holds three cooperating tools that turn a single
+`HIPDNN_EP_PERF=1` bench run into a structured, section-stable profiling
+report:
 
-> **Scope: Linux Docker build.** The example invocations below use the
+| File | Purpose | Portability |
+|---|---|---|
+| [`format_perf_report.py`](format_perf_report.py) | Parses a captured log and renders the four-section report. The value-add tool. | Pure Python 3, stdlib only — any platform with Python ≥ 3.10. |
+| [`run_bench.sh`](run_bench.sh) | Bench driver. Runs `onnxruntime_perf_test` (default) or `model_benchmark` (`--oga`) against a model under `$WORKSPACE/oga_models/<dir>` and captures the log under `tools/perf-report/_perf_logs/`. The `--oga` path additionally pipes the log through `format_perf_report.py`; the perftest path prints its own grep-based summary inline. | Linux + AMD GPU + the in-container build artefacts at `$WORKSPACE/install/{bin,lib}`. |
+| [`docker_run_bench.sh`](docker_run_bench.sh) | Thin host-side wrapper that runs `run_bench.sh` (or any other repo-relative bench script via `REL_BENCH=...`) inside the `hipdnn-ep-build` Docker image as a `docker run --rm` one-shot — no interactive shell needed. | Linux + Docker + an AMD GPU exposed via `/dev/kfd` and `/dev/dri/renderD*`. |
+
+> **Scope: Linux Docker build.** The bench-side examples below use the
 > Linux paths (`$ROOT/bin/`, `$ROOT/lib/libonnxruntime_morphizen_ep.so`)
 > from the Docker build layout documented in
 > [`docs/quick_start_linux.md`](../../docs/quick_start_linux.md).
-> The script itself is pure Python 3 (stdlib only) and will run on any
-> platform with Python ≥ 3.10, but the bench-side command shown under
-> [Usage](#usage) is specific to the Linux build.
+> `format_perf_report.py` itself has no Linux assumptions and can be run
+> against a log captured from any platform; `run_bench.sh` and
+> `docker_run_bench.sh` are Linux / Docker specific.
+
+> **Models are not downloaded.** `run_bench.sh` expects a model directory
+> to already exist at `$WORKSPACE/oga_models/<dir>/` with `model.onnx`,
+> `model.onnx.data`, `tokenizer.json`, `tokenizer_config.json`, and
+> `genai_config_MorphiZenEP.json`. Stage one with e.g.
+> `huggingface-cli download <repo> --local-dir $WORKSPACE/oga_models/<dir>`
+> before invoking. `$WORKSPACE` defaults to the parent of the repo root,
+> matching the `docker/run.sh` convention.
 
 ## Why
 
@@ -46,35 +60,87 @@ for the underlying instrumentation design.
 
 ## Usage
 
-The full `model_benchmark` invocation (including the `-ml` rules for
-fixed-shape pipelines, how `$ROOT` is set up by the Docker build, and
-the canonical bench env vars) is documented in
-[`docs/quick_start_linux.md`](../../docs/quick_start_linux.md). The
-bare-minimum two-step is:
+The three tools compose into three layers of increasing automation.
+Pick the entry point that matches your situation.
+
+### Layer 1: format only (any host with a captured log)
+
+If you already have a `HIPDNN_EP_PERF=1` log produced anywhere, just
+render it:
 
 ```bash
-# 1) Run model_benchmark with HIPDNN_EP_PERF=1, capturing stderr+stdout
-#    into a single log file (all three [PERF*] streams go to stderr).
-#    $ROOT and $WORKSPACE are set up by docs/quick_start_linux.md when
-#    you `source` the in-container shell helpers; don't hardcode them.
-HIPDNN_EP_PERF=1 $ROOT/bin/model_benchmark \
-    -i /path/to/oga-model-dir \
-    --ep_library MorphiZenEP $ROOT/lib/libonnxruntime_morphizen_ep.so \
-    -l 128 -g 128 -ml -1 -r 3 -w 1 \
-    > run.log 2>&1
-
-# 2) Format the report:
 python3 tools/perf-report/format_perf_report.py run.log
 ```
 
-The script file is marked executable (`100755` in git), so the shebang
-form also works:
+`format_perf_report.py` is marked executable (`100755` in git), so the
+shebang form also works:
 
 ```bash
 ./tools/perf-report/format_perf_report.py run.log
 ```
 
-Flags:
+### Layer 2: run the bench inside the container shell
+
+From inside the build container (`./docker/run.sh shell`), the bench
+driver wires up env (`LD_LIBRARY_PATH`, `THEROCK_DIST`, optional
+`HIPDNN_EP_PERF=1`) and captures the log under
+`tools/perf-report/_perf_logs/`. On the `--oga` path it additionally
+pipes the log through `format_perf_report.py` before exiting:
+
+```bash
+# OGA path -- model_benchmark, prompt=128 gen=128, three reps, one warmup,
+# in --mode perf (sets HIPDNN_EP_PERF=1 so all four report sections render):
+tools/perf-report/run_bench.sh --oga --prompt 128 --gen 128 --reps 3 --warmup 1 --mode perf
+
+# perftest path -- onnxruntime_perf_test, decode-only dynamic, 30s window:
+# (prints its own P50 / [PERF SUMMARY] / last-per-op-table grep summary;
+#  does NOT auto-invoke format_perf_report.py because perftest output has
+#  no model_benchmark stats block.)
+tools/perf-report/run_bench.sh --time 30 --mode perf
+
+# Different model (must already be staged at $WORKSPACE/oga_models/<dir>/):
+tools/perf-report/run_bench.sh --oga --model Mistral-7B-Instruct-v0.3-dml-int4-awq-block-128 --mode perf
+```
+
+`run_bench.sh --help` prints the full flag list. Logs land at
+`tools/perf-report/_perf_logs/<model>_<tool>_<...>_<ts>.log` — keep them
+for postmortem, re-render any of them later with
+`format_perf_report.py <log>`.
+
+The raw `model_benchmark` invocation (which `run_bench.sh --oga` builds
+internally — `-l`/`-g`/`-r`/`-w`/`-b`/`-v`, optional `-ml`, EP loaded
+via CWD discovery from `$ROOT/lib`) is fully documented in the
+[`docs/quick_start_linux.md`](../../docs/quick_start_linux.md) "Open a
+container shell" section if you need to invoke it directly.
+
+### Layer 3: run the bench from the host (no shell needed)
+
+For a clean one-shot from any host terminal (including Cursor's embedded
+terminal, where `docker exec -it` is unreliable), the wrapper spins a
+`docker run --rm` container, exec's the bench inside it as your host
+UID/GID with the GPU and bind mounts attached, and exits when it's done.
+See the script header for the failure modes it works around (Cursor TTY
+behaviour, the `docker/entrypoint.sh` `getent` crash, zombie-container
+reaping).
+
+```bash
+# Equivalent to Layer 2's first example, but runs from the host:
+tools/perf-report/docker_run_bench.sh --oga --prompt 128 --gen 128 --reps 3 --warmup 1 --mode perf
+```
+
+The wrapper is an unopinionated relay — it forwards all CLI args
+verbatim to `$REL_BENCH` (default `tools/perf-report/run_bench.sh`).
+Override `REL_BENCH` to invoke a different in-container bench:
+
+```bash
+REL_BENCH=oga/my_local_harness.sh \
+    tools/perf-report/docker_run_bench.sh --foo --bar
+```
+
+Other env knobs (`WORKSPACE`, `IMAGE`) are documented in the script
+header.
+
+### Flags (`format_perf_report.py`)
 
 | Flag | Effect |
 |---|---|
@@ -82,7 +148,7 @@ Flags:
 | `--no-banner` | Suppress the top/bottom banner lines (useful when embedding the report inside another report) |
 | `--indent N` | Indent every output line by N spaces |
 
-Exit codes:
+### Exit codes (`format_perf_report.py`)
 
 | Code | Meaning |
 |---|---|
@@ -153,4 +219,11 @@ intended for CI / regression-bot consumption.
 
 ## Dependencies
 
-Python ≥ 3.10, standard library only. No third-party packages.
+| Tool | Required by | Notes |
+|---|---|---|
+| Python ≥ 3.10 | `format_perf_report.py` | Standard library only; no third-party packages. |
+| Bash + `git` + `python3` | `run_bench.sh` | All present in the `hipdnn-ep-build` image. `git` is used only for the PR #212 reachability check, which silently no-ops if `git` is unavailable. |
+| `$WORKSPACE/install/{bin,lib}` populated | `run_bench.sh` | `libonnxruntime_morphizen_ep.so` + `model_benchmark` (for `--oga`) + `onnxruntime_perf_test` (for the default path). Produced by `./docker/run.sh build` ([`docs/quick_start_linux.md`](../../docs/quick_start_linux.md)). |
+| `$WORKSPACE/oga_models/<dir>/` staged | `run_bench.sh` | Model directory with `model.onnx`, `model.onnx.data`, `tokenizer.*`, `genai_config_MorphiZenEP.json`. `run_bench.sh` does NOT download — see the "Models are not downloaded" callout above. |
+| Bash + `docker` CLI | `docker_run_bench.sh` | Tested with Docker Engine on Linux. Rootless Docker works as long as the engine can mount `/dev/kfd` and `/dev/dri/renderD*`. |
+| AMDGPU driver + `hipdnn-ep-build` image | `docker_run_bench.sh` | The image is the one built by `./docker/run.sh image` ([`docs/quick_start_linux.md`](../../docs/quick_start_linux.md)); image tag is overridable via `IMAGE`. |

--- a/tools/perf-report/README.md
+++ b/tools/perf-report/README.md
@@ -11,7 +11,7 @@ report:
 | File | Purpose | Portability |
 |---|---|---|
 | [`format_perf_report.py`](format_perf_report.py) | Parses a captured log and renders the four-section report. The value-add tool. | Pure Python 3, stdlib only — any platform with Python ≥ 3.10. |
-| [`run_bench.sh`](run_bench.sh) | Bench driver. Runs `onnxruntime_perf_test` (default) or `model_benchmark` (`--oga`) against a model under `$WORKSPACE/oga_models/<dir>` and captures the log under `tools/perf-report/_perf_logs/`. The `--oga` path additionally pipes the log through `format_perf_report.py`; the perftest path prints its own grep-based summary inline. | Linux + AMD GPU + the in-container build artefacts at `$WORKSPACE/install/{bin,lib}`. |
+| [`run_bench.sh`](run_bench.sh) | Bench driver. Runs `onnxruntime_perf_test` (default), `model_benchmark` (`--oga`), or `model_mm` (`--mm`, multimodal/VLM) against a model under `$WORKSPACE/oga_models/<dir>` and captures the log under `tools/perf-report/_perf_logs/`. The `--oga` path pipes the log through `format_perf_report.py`; `--mm` surfaces `model_mm`'s headline timing line inline and (under `--mode perf`) renders the per-op breakdown via `perf_multimodal_report.py`; the perftest path prints its own grep-based summary inline. | Linux + AMD GPU + the in-container build artefacts at `$WORKSPACE/install/{bin,lib}`. |
 | [`docker_run_bench.sh`](docker_run_bench.sh) | Thin host-side wrapper that runs `run_bench.sh` (or any other repo-relative bench script via `REL_BENCH=...`) inside the `hipdnn-ep-build` Docker image as a `docker run --rm` one-shot — no interactive shell needed. | Linux + Docker + an AMD GPU exposed via `/dev/kfd` and `/dev/dri/renderD*`. |
 
 > **Scope: Linux Docker build.** The bench-side examples below use the
@@ -101,6 +101,32 @@ tools/perf-report/run_bench.sh --time 30 --mode perf
 # Different model (must already be staged at $WORKSPACE/oga_models/<dir>/):
 tools/perf-report/run_bench.sh --oga --model Mistral-7B-Instruct-v0.3-dml-int4-awq-block-128 --mode perf
 ```
+
+#### Multimodal / VLM models (`--mm`)
+
+`--mm` drives `install/bin/model_mm` (the OGA C++ multimodal example) with an
+image + prompt instead of `model_benchmark`. Unlike `--oga` there is no staged
+dynamic dir — `model_mm` reads `genai_config.json` from the model dir directly,
+so the dir's active config must already select MorphiZenEP (pass `--variant <v>`
+to swap `genai_config_<v>.json` into place for the run; it is restored on exit):
+
+```bash
+# profiler OFF (true throughput) and ON (per-op breakdown), via the host wrapper:
+tools/perf-report/docker_run_bench.sh --mm \
+    --model <vlm-dir> --image eiffel.jpg --prompt "What is in this image?" \
+    --mode none
+tools/perf-report/docker_run_bench.sh --mm \
+    --model <vlm-dir> --image eiffel.jpg --prompt "What is in this image?" \
+    --mode perf
+```
+
+> **`model_mm` ignores `-g`/`--max_new_tokens`** (that flag is honored only by
+> the `model_chat` example): generation runs until EOS, bounded only by
+> `search.max_length` in `genai_config.json`. A full VLM generation under
+> `--mode perf` dumps a per-op table after **every** token, which is slow and
+> produces a large log. To cap the token count for a `--mode perf` run, point
+> `--variant` at a config whose `search.max_length` is set to
+> `(prompt_len + desired_new_tokens)`.
 
 `run_bench.sh --help` prints the full flag list. Logs land at
 `tools/perf-report/_perf_logs/<model>_<tool>_<...>_<ts>.log` — keep them

--- a/tools/perf-report/README.md
+++ b/tools/perf-report/README.md
@@ -1,0 +1,156 @@
+<!--
+Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+Licensed under the MIT License.
+-->
+# HIPDNN EP Profiling Report Formatter
+
+`format_perf_report.py` parses a `HIPDNN_EP_PERF=1` log produced by
+`model_benchmark` driving the MorphiZen EP and renders a locked-down,
+section-stable profiling report.
+
+> **Scope: Linux Docker build.** The example invocations below use the
+> Linux paths (`$ROOT/bin/`, `$ROOT/lib/libonnxruntime_morphizen_ep.so`)
+> from the Docker build layout documented in
+> [`docs/quick_start_linux.md`](../../docs/quick_start_linux.md).
+> The script itself is pure Python 3 (stdlib only) and will run on any
+> platform with Python ≥ 3.10, but the bench-side command shown under
+> [Usage](#usage) is specific to the Linux build.
+
+## Why
+
+When `HIPDNN_EP_PERF=1` is set, the EP and runtime emit three independent
+measurement streams that are interleaved with `model_benchmark`'s own
+output:
+
+| Stream | Emitted by | Cadence |
+|---|---|---|
+| `[PERF SUMMARY]` per-Compute aggregates (n, min/median/p99/max) | `MlirCustomOp::PerfCollector::dump_summary` (`backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp`) | once at library unload |
+| `[PERF] === ... ===` per-op GPU/CPU tables | `op_profile_resolve_and_print` (`lib/Runtime/op_profile.cpp`) | once per `Compute()` call |
+| `model_benchmark` stats block (Prompt processing / Token generation / Token sampling / E2E) | `model_benchmark` | once per run |
+
+Skim-reading the raw log to correlate these three views is painful. This
+script does it for you: it locks the output into four sections with stable
+header markers (`§ 1 HEADLINE`, `§ 2 STEADY-STATE DECODE BREAKDOWN`,
+`§ 3 PER-OP GPU BREAKDOWN`, `§ 4 PER-CALL DISTRIBUTION`) and prints a
+single one-line banner at the top and bottom of the report so external
+tooling (CI checks, perf-regression bots) can grep for stable anchors.
+
+See [`docs/design/per-op-profiling.md`](../../docs/design/per-op-profiling.md)
+for the underlying instrumentation design.
+
+> **Tool coverage.** The script needs the `model_benchmark` stats block
+> (stream 3 above) to render any report — § 1 / § 2 / footer all depend
+> on it, and the CLI exits with code 2 if it's absent. Logs from
+> `onnxruntime_perf_test` or pytest contain streams 1 + 2 but no
+> compatible § 3 — they're not supported today.
+
+## Usage
+
+The full `model_benchmark` invocation (including the `-ml` rules for
+fixed-shape pipelines, how `$ROOT` is set up by the Docker build, and
+the canonical bench env vars) is documented in
+[`docs/quick_start_linux.md`](../../docs/quick_start_linux.md). The
+bare-minimum two-step is:
+
+```bash
+# 1) Run model_benchmark with HIPDNN_EP_PERF=1, capturing stderr+stdout
+#    into a single log file (all three [PERF*] streams go to stderr).
+#    $ROOT and $WORKSPACE are set up by docs/quick_start_linux.md when
+#    you `source` the in-container shell helpers; don't hardcode them.
+HIPDNN_EP_PERF=1 $ROOT/bin/model_benchmark \
+    -i /path/to/oga-model-dir \
+    --ep_library MorphiZenEP $ROOT/lib/libonnxruntime_morphizen_ep.so \
+    -l 128 -g 128 -ml -1 -r 3 -w 1 \
+    > run.log 2>&1
+
+# 2) Format the report:
+python3 tools/perf-report/format_perf_report.py run.log
+```
+
+The script file is marked executable (`100755` in git), so the shebang
+form also works:
+
+```bash
+./tools/perf-report/format_perf_report.py run.log
+```
+
+Flags:
+
+| Flag | Effect |
+|---|---|
+| `--ascii` | Use ASCII tree-drawing characters instead of Unicode (for terminals or pipelines that don't render box-drawing glyphs cleanly) |
+| `--no-banner` | Suppress the top/bottom banner lines (useful when embedding the report inside another report) |
+| `--indent N` | Indent every output line by N spaces |
+
+Exit codes:
+
+| Code | Meaning |
+|---|---|
+| `0` | Report rendered. Any subset of the four sections may be present (each self-gates on its source data) |
+| `1` | Log file not found |
+| `2` | Log lacks the `model_benchmark` stats block (no `Batch size:` line). Caller should fall back to `tail -n 100 <log>` or similar |
+
+## Output sketch
+
+Real output produced by the script — units and headers are reproduced
+verbatim from a live `-l 128 -g 128 -r 3 -w 1` run:
+
+```
+══════════════════════════════════════════════════════════════════════════
+  HIPDNN EP profile  ·  <model-name>  ·  prompt=128 gen=128  ·  inferences=639
+══════════════════════════════════════════════════════════════════════════
+
+  § 1  HEADLINE  —  model_benchmark (batch=1, prompt=128, gen=128)
+  ──────────────────────────────────────────────────────────────────────────
+                          throughput     p50 latency        stddev   samples
+    Prefill (TTFT)        770.66 t/s    166048.58 us    1888.95 us   3 * 128 token(s)
+    Decode                 39.68 t/s     25066.96 us    1486.80 us   381 * 1 token(s)
+    Sampling            14527.63 t/s        68.15 us       1.74 us   3 * 1 token(s)
+    E2E generation                 —      3368.69 ms      12.82 ms   3
+    Peak working set   1.52 GiB (1633189888 bytes)
+
+  § 2  STEADY-STATE DECODE BREAKDOWN  —  1 decode token, median across run
+  ──────────────────────────────────────────────────────────────────────────
+                                                  latency    share   source
+    OGA::GenerateNextToken                      25.067 ms   100.0 %   ◀ § 1 Decode p50
+    ├─ OGA + ORT framework overhead              1.028 ms     4.1 %
+    │  ├─ Token sampling                         0.069 ms     0.3 %   ◀ § 1 Sampling avg
+    │  └─ Other (IoBinding rebind, etc.)         0.959 ms     3.8 %
+    └─ EP MlirCustomOp::Compute()               24.039 ms    95.9 %   ◀ § 4 wall_ms
+       ├─ ...
+       └─ Trailing fence (hipStreamSync)         0.009 ms     0.0 %   ◀ § 4 fence_residual_ms
+
+  § 3  PER-OP GPU BREAKDOWN  —  last Compute() = steady-state decode token
+  ──────────────────────────────────────────────────────────────────────────
+    ===============================================================
+                                   calls  gpu (ms)  cpu (ms)  gpu %
+     matmul_nbits                    225      20.0       0.6  86.9%
+       m=1,n=14336,k=4096             64      10.0       0.2  43.3%
+       ...
+     TOTAL                                    23.0       1.8
+    ===============================================================
+
+  § 4  PER-CALL DISTRIBUTION  —  EP MlirCustomOp::Compute() over 639 invocations (all ms)
+  ──────────────────────────────────────────────────────────────────────────
+                              min     median        p99          max
+    wall_ms                23.703     24.039     42.869     8008.406
+    compute_cpu_ms         23.635     23.966     42.774     8003.431
+    gpu_ms                 23.593     23.919     42.729     8003.326
+    ...
+
+══════════════════════════════════════════════════════════════════════════
+  [OGA] prefill=770.66 tok/s  TTFT=166.09 ms  decode=39.68 tok/s  peak_WS=1.52 GiB (1633189888 bytes)
+══════════════════════════════════════════════════════════════════════════
+```
+
+Each section is self-gating: if its source data is absent from the log
+(e.g. `--mode none` runs without per-op tables, or older builds that
+predate `[PERF SUMMARY]`), the section is silently omitted instead of
+printing an empty header.
+
+The bottom banner is a single greppable line — `^\[OGA\] prefill=` —
+intended for CI / regression-bot consumption.
+
+## Dependencies
+
+Python ≥ 3.10, standard library only. No third-party packages.

--- a/tools/perf-report/docker_run_bench.sh
+++ b/tools/perf-report/docker_run_bench.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+##
+## Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+## Licensed under the MIT License.
+##
+
 # Wrapper that runs a bench script inside the hipdnn-ep build container
 # without needing an interactive shell. Use this from any host terminal that
 # doesn't deliver a clean TTY to `docker exec -it` -- e.g. Cursor's embedded

--- a/tools/perf-report/docker_run_bench.sh
+++ b/tools/perf-report/docker_run_bench.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Wrapper that runs a bench script inside the hipdnn-ep build container
+# without needing an interactive shell. Use this from any host terminal that
+# doesn't deliver a clean TTY to `docker exec -it` -- e.g. Cursor's embedded
+# terminal, where `./docker/run.sh shell` SIGKILLs the docker-exec step and
+# leaves zombie containers behind.
+#
+# This is the standalone copy that lives under tools/perf-report/. It is
+# location-independent: the repo root is found by walking up from the
+# script's directory looking for build.py (the canonical project build
+# script per CLAUDE.md), so the same script works whether it sits at
+# <repo>/oga/, <repo>/tools/perf-report/, or anywhere else inside the
+# repo.
+#
+# Differences from `./docker/run.sh shell`:
+#   - One-shot container: `docker run --rm` (no --name, no persistent state,
+#     no zombies on Ctrl+C or TTY drop)
+#   - No --interactive / --tty flags; streams stdout/stderr only
+#   - Bypasses docker/entrypoint.sh entirely. The entrypoint has a latent bug
+#     that surfaces when the host's render-device GID (gid of /dev/kfd, often
+#     993 = `render` group on the host) does not exist as a group inside the
+#     container image: `grp_name=$(getent group "$dev_gid" | cut -d: -f1)`
+#     fails under `set -euo pipefail` (getent exits 2 -> pipefail propagates
+#     -> errexit kills the script) and the container dies silently with exit
+#     2 before the bench ever runs. The wrapper avoids this with --user +
+#     --group-add: we run directly as the host UID/GID and add the device's
+#     GID as a supplemental group via docker, no useradd / usermod needed.
+#     Side benefit: anything the bench writes into the bind-mounted workspace
+#     (e.g. tools/perf-report/_perf_logs/*.log) is already owned by you on
+#     the host.
+#
+# Usage (all args forwarded to the in-container bench script):
+#   tools/perf-report/docker_run_bench.sh                              # defaults
+#   tools/perf-report/docker_run_bench.sh --oga --prompt 128 --gen 128 --reps 3 --warmup 1
+#   tools/perf-report/docker_run_bench.sh --shape dynamic --seq 1 --time 30
+#   tools/perf-report/docker_run_bench.sh --help                       # forwarded
+#
+# Env knobs (override on the command line):
+#   WORKSPACE   parent dir bind-mounted into the container (default: auto-detected
+#               as parent of the repo root, matching docker/run.sh's convention)
+#   IMAGE       docker image tag (default: hipdnn-ep-build:llvm22-noble)
+#   REL_BENCH   path of the bench script to exec inside the container, relative
+#               to the repo root (default: tools/perf-report/run_bench.sh).
+#               Override to invoke against a different bench entry point, e.g.
+#               REL_BENCH=oga/run_bench.sh tools/perf-report/docker_run_bench.sh ...
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Locate the repo root by walking upward from SCRIPT_DIR looking for
+# `build.py` -- the canonical project build script per CLAUDE.md. This
+# decouples the wrapper from any specific placement under the repo (it
+# works from oga/, tools/perf-report/, or anywhere else). We deliberately
+# don't shell out to `git rev-parse --show-toplevel` so the script remains
+# usable inside extracted source tarballs that have no .git/ directory.
+# `build.py` is preferred over `CMakeLists.txt` as a marker because every
+# sub-project under tools/ and 3rd-party/ has its own CMakeLists.txt, but
+# build.py exists only at the repo root.
+SOURCE_DIR="$SCRIPT_DIR"
+while [ "$SOURCE_DIR" != "/" ] && [ ! -f "$SOURCE_DIR/build.py" ]; do
+    SOURCE_DIR="$(dirname "$SOURCE_DIR")"
+done
+if [ "$SOURCE_DIR" = "/" ]; then
+    echo "ERROR: could not locate repo root from $SCRIPT_DIR" >&2
+    echo "       (walked up looking for build.py; none found)" >&2
+    exit 1
+fi
+
+: "${WORKSPACE:=$(cd "$SOURCE_DIR/.." && pwd)}"
+: "${IMAGE:=hipdnn-ep-build:llvm22-noble}"
+: "${REL_BENCH:=tools/perf-report/run_bench.sh}"   # path inside the repo to invoke
+
+# Fail fast if the bench script doesn't exist on disk. Without this check
+# the container would still start, bash would fail to open the path, and
+# the user would see only `bash: <REL_BENCH>: No such file or directory`
+# with no hint that REL_BENCH was misset (or that the default script was
+# deleted / moved). The default targets the tracked sibling bench
+# (tools/perf-report/run_bench.sh) so a fresh clone has a working
+# entry point without any local setup.
+if [ ! -f "$SOURCE_DIR/$REL_BENCH" ]; then
+    echo "ERROR: bench script not found at \$SOURCE_DIR/\$REL_BENCH" >&2
+    echo "       \$SOURCE_DIR = $SOURCE_DIR" >&2
+    echo "       \$REL_BENCH  = $REL_BENCH" >&2
+    echo "       Set REL_BENCH to a bench script that exists under the repo" >&2
+    echo "       (default: tools/perf-report/run_bench.sh)." >&2
+    exit 1
+fi
+
+# Reap any leftover named container from a failed `./docker/run.sh shell`
+# attempt. Idempotent + silent if no such container exists. Cursor's embedded
+# terminal regularly leaves the persistent "${USER}.hipdnn-ep.shell" container
+# in "Exited" state when the docker-exec gets SIGKILL'd; subsequent
+# `./docker/run.sh shell` then errors with "container is not running". This
+# wrapper doesn't use a named container (--rm), but reaping keeps the docker
+# state clean for when you do drop into a real terminal later.
+ZOMBIE_NAME="${USER}.hipdnn-ep.shell"
+if docker container inspect -f '{{.State.Status}}' "$ZOMBIE_NAME" >/dev/null 2>&1; then
+    state=$(docker container inspect -f '{{.State.Status}}' "$ZOMBIE_NAME")
+    if [ "$state" != "running" ]; then
+        echo "[reap] removing stale '$ZOMBIE_NAME' (status: $state)"
+        docker rm -f "$ZOMBIE_NAME" >/dev/null
+    fi
+fi
+
+if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+    echo "ERROR: docker image '$IMAGE' not found." >&2
+    echo "       Build it first: ./docker/run.sh image" >&2
+    exit 1
+fi
+
+# Resolve the render-device GIDs on the host so we can add them as docker
+# supplemental groups. Two GIDs matter: /dev/kfd (the AMDGPU compute
+# interface) and /dev/dri/renderD128 (the render-node DRM interface used
+# for buffer management). They usually agree (both belong to `render`),
+# but a misconfigured host can split them; we add both as supplemental
+# groups in that case so the in-container user can open either.
+GPU_MISSING=0
+if [ ! -e /dev/kfd ]; then
+    echo "ERROR: /dev/kfd not found on host" >&2
+    GPU_MISSING=1
+fi
+if [ ! -e /dev/dri/renderD128 ]; then
+    echo "ERROR: /dev/dri/renderD128 not found on host" >&2
+    GPU_MISSING=1
+fi
+if [ "$GPU_MISSING" = "1" ]; then
+    echo "       This wrapper requires an AMD GPU exposed via the AMDGPU driver." >&2
+    echo "       Check 'lsmod | grep amdgpu' and 'ls /dev/kfd /dev/dri/' on host." >&2
+    exit 1
+fi
+KFD_GID=$(stat -c '%g' /dev/kfd)
+DRI_GID=$(stat -c '%g' /dev/dri/renderD128)
+if [ "$KFD_GID" != "$DRI_GID" ]; then
+    echo "WARNING: /dev/kfd gid=$KFD_GID differs from /dev/dri/renderD128 gid=$DRI_GID" >&2
+    echo "         Adding both as supplemental groups."                                  >&2
+fi
+
+# Build the docker args incrementally so the --group-add list is clean.
+DOCKER_ARGS=(
+    --rm
+    --mount "type=bind,source=$WORKSPACE,target=$WORKSPACE,bind-propagation=shared"
+    -w "$SOURCE_DIR"
+    --user "$(id -u):$(id -g)"
+    --group-add "$KFD_GID"
+)
+if [ "$KFD_GID" != "$DRI_GID" ]; then
+    DOCKER_ARGS+=(--group-add "$DRI_GID")
+fi
+DOCKER_ARGS+=(
+    --device=/dev/kfd --device=/dev/dri/renderD128
+    --cap-add SYS_PTRACE
+    -v /dev/shm:/dev/shm
+    --network=host
+    # Override HOME so anything the bench writes via $HOME (sccache cfg,
+    # Python __pycache__) goes into a writable per-user dir under workspace
+    # instead of the image's /root or a non-existent /home/<host-user>.
+    -e "HOME=$WORKSPACE/.docker-home"
+    # Skip docker/entrypoint.sh: --entrypoint bash + script-as-arg avoids
+    # the broken getent pipeline (see header comment).
+    --entrypoint bash
+)
+
+exec docker run "${DOCKER_ARGS[@]}" "$IMAGE" "$REL_BENCH" "$@"

--- a/tools/perf-report/format_perf_report.py
+++ b/tools/perf-report/format_perf_report.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
+#
 # Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 # Licensed under the MIT License.
+#
 """Format a HIPDNN EP OGA model_benchmark log into a structured profiling report.
 
 The report is the locked-down rendering of three independent measurement streams

--- a/tools/perf-report/format_perf_report.py
+++ b/tools/perf-report/format_perf_report.py
@@ -1,0 +1,802 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+"""Format a HIPDNN EP OGA model_benchmark log into a structured profiling report.
+
+The report is the locked-down rendering of three independent measurement streams
+that the EP + OGA emit into a single log when ``HIPDNN_EP_PERF=1`` is set:
+
+    1. ``[PERF SUMMARY]`` — per-Compute aggregates (n samples, min/median/p99/max)
+       emitted by ``MlirCustomOp.cpp::PerfCollector::dump_summary`` at library
+       unload (the per-model compiled shared object: ``.so`` on Linux,
+       ``.dll`` on Windows).
+    2. model_benchmark stats block — OGA's own Prompt processing / Token generation
+       / Token sampling / E2E summary printed by ``model_benchmark``.
+    3. ``[PERF] === ... ===`` per-op tables — one per Compute(), emitted by
+       ``op_profile_resolve_and_print`` in ``lib/Runtime/op_profile.cpp``.
+
+The script REQUIRES model_benchmark output (stream 2) to render any report --
+when the log has no ``Batch size:`` line the renderer returns the empty string
+and the CLI exits with code 2 so the caller can fall back to a raw tail.
+Streams 1 and 3 are EP-side and would be present under any host tool that
+exercises the MorphiZen EP with ``HIPDNN_EP_PERF=1``, but § 1 / § 2 / footer
+rendering is gated on the model_benchmark stats block being present.
+
+Output layout (reading order is headline-first — most-skimmable numbers up top,
+forensic distribution at the bottom):
+
+    § 1  HEADLINE                       OGA's own throughput / latency table
+    § 2  STEADY-STATE DECODE BREAKDOWN  synthesized "where does the time go" tree
+    § 3  PER-OP GPU BREAKDOWN           op_profile.cpp's table verbatim
+    § 4  PER-CALL DISTRIBUTION          raw EP Compute() distribution
+
+Stability contract (treat as public API for downstream tooling):
+
+    - Section markers always start with ``  § N  TITLE`` where N is a single
+      digit. Tools may grep for ``^  § \\d  `` to find section boundaries.
+    - The bottom banner is a single greppable line: ``^\\[OGA\\] prefill=``.
+    - Section / banner widths are stable; the indent prefix is the only
+      whitespace the caller may modify (via ``--indent``).
+    - Each section silently no-ops when its source data is absent (running
+      against a ``--mode none`` log prints only § 1 + bottom banner); the
+      caller is responsible for raw-tail fallback when no
+      ``Batch size:`` line is present (this script then exits with code 2).
+
+USAGE
+-----
+    tools/perf-report/format_perf_report.py <log-file>
+    tools/perf-report/format_perf_report.py <log-file> --ascii      # no Unicode
+    tools/perf-report/format_perf_report.py <log-file> --no-banner  # CI embed
+    tools/perf-report/format_perf_report.py <log-file> --indent 2   # indent N
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import statistics
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+
+# ─── parsers ─────────────────────────────────────────────────────────────────
+
+# All five stats live on a single [PERF SUMMARY] row; parse via labeled tokens
+# so we are robust to: (a) column reordering, (b) future-added stats (e.g.
+# p95), (c) metric-name renames -- the renderer below addresses metrics by
+# name, not position, so a new column shows up in __dict__ and is ignored
+# unless the renderer is teaching about it.
+_STAT_RE = re.compile(r"\b(min|mean|median|p99|max)=([-+0-9.eE]+)")
+
+
+@dataclass
+class PerfSummary:
+    """Aggregated per-Compute metrics from the ``[PERF SUMMARY]`` block.
+
+    ``metrics[name]`` is a dict with keys min / mean / median / p99 / max, all ms.
+    Names are kept as written in the log (wall_ms, gpu_ms, etc.) so they
+    cross-reference 1:1 with the source code in ``MlirCustomOp.cpp``.
+    """
+
+    total_inferences: int = 0
+    metrics: dict[str, dict[str, float]] = field(default_factory=dict)
+
+    METRIC_ORDER = (
+        "wall_ms",
+        "compute_cpu_ms",
+        "gpu_ms",
+        "marshal_in_ms",
+        "marshal_out_ms",
+        "fence_residual_ms",
+    )
+
+    @classmethod
+    def parse(cls, lines: list[str]) -> "PerfSummary":
+        out = cls()
+        for line in lines:
+            if not line.startswith("[PERF SUMMARY]"):
+                continue
+            m = re.match(r"\[PERF SUMMARY\] total_inferences=(\d+)", line)
+            if m:
+                out.total_inferences = int(m.group(1))
+                continue
+            # Format: `[PERF SUMMARY] <name>  min=X  mean=X  median=X  p99=X  max=X`
+            name_m = re.match(r"\[PERF SUMMARY\]\s+(\S+)\s+", line)
+            if not name_m:
+                continue
+            stats = {k: float(v) for k, v in _STAT_RE.findall(line)}
+            if stats:
+                out.metrics[name_m.group(1)] = stats
+        return out
+
+    def __bool__(self) -> bool:
+        return bool(self.metrics)
+
+
+@dataclass
+class OgaHeadline:
+    """``model_benchmark`` stats block (Prompt processing, Token generation, etc.).
+
+    Each section is parsed into a dict with the raw labels as keys (e.g.
+    ``avg_us``, ``avg_tps``, ``p50_us``, ``stddev_us``, ``n``). Sections that
+    were absent in the log resolve to None so ``__bool__`` can gate rendering.
+    """
+
+    batch_size: int = 0
+    prompt_tokens: int = 0
+    tokens_to_generate: int = 0
+    prefill: Optional[dict] = None
+    decode: Optional[dict] = None
+    sampling: Optional[dict] = None
+    e2e: Optional[dict] = None
+    peak_ws_bytes: Optional[int] = None
+
+    # Block header → field name. Headers exactly match what model_benchmark prints.
+    _BLOCKS = {
+        "Prompt processing (time to first token):": "prefill",
+        "Token generation:": "decode",
+        "Token sampling:": "sampling",
+        "E2E generation (entire generation loop):": "e2e",
+    }
+
+    @classmethod
+    def parse(cls, lines: list[str]) -> "OgaHeadline":
+        out = cls()
+        cur_field: Optional[str] = None
+        cur_block: Optional[dict] = None
+
+        # Pre-compile per-row patterns. model_benchmark uses literal tabs
+        # before each row, but we strip leading whitespace before matching.
+        # The unit token (us/ms/tokens/s) is OPTIONAL because the `n` row
+        # has no unit annotation; the non-capturing `(?:...)?` wrapper
+        # lets the regex still match those rows and leaves group(2) as
+        # None, which the dispatch below interprets as the raw-value path.
+        row_re = re.compile(
+            r"^(avg|p50|stddev|n)\s*"
+            r"(?:\((us|ms|tokens/s)\))?"
+            r":\s*"
+            r"(.+?)\s*$"
+        )
+
+        for line in lines:
+            stripped = line.lstrip()
+
+            # Single-line headers and tail rows
+            m = re.match(r"Batch size:\s*(\d+),\s*prompt tokens:\s*(\d+),"
+                         r"\s*tokens to generate:\s*(\d+)", line)
+            if m:
+                out.batch_size = int(m.group(1))
+                out.prompt_tokens = int(m.group(2))
+                out.tokens_to_generate = int(m.group(3))
+                cur_field, cur_block = None, None
+                continue
+
+            m = re.match(r"Peak working set size \(bytes\):\s*(\d+)", line)
+            if m:
+                out.peak_ws_bytes = int(m.group(1))
+                cur_field, cur_block = None, None
+                continue
+
+            # Block-start headers — always unindented
+            if not line.startswith(("\t", " ")):
+                field_name = cls._BLOCKS.get(line.rstrip())
+                if field_name is not None:
+                    cur_field = field_name
+                    cur_block = {}
+                    setattr(out, field_name, cur_block)
+                    continue
+                # Any other unindented line ends the current block
+                cur_field, cur_block = None, None
+                continue
+
+            if cur_block is None:
+                continue
+            m = row_re.match(stripped)
+            if not m:
+                continue
+            label, unit, value = m.group(1), m.group(2), m.group(3)
+            # n is the only non-numeric value (e.g. "3 * 128 token(s)"); keep raw
+            if label == "n":
+                cur_block["n"] = value
+                continue
+            # Numeric — normalize the key (avg → avg_us / avg_tps / avg_ms,
+            # depending on the unit annotation). model_benchmark sometimes
+            # emits multiple `avg` rows in one block (us + tokens/s).
+            if unit == "us":
+                cur_block[f"{label}_us"] = float(value)
+            elif unit == "ms":
+                cur_block[f"{label}_ms"] = float(value)
+            elif unit == "tokens/s":
+                cur_block[f"{label}_tps"] = float(value)
+            else:
+                cur_block[label] = float(value)
+        return out
+
+    def __bool__(self) -> bool:
+        return self.batch_size > 0
+
+
+@dataclass
+class PerOpTable:
+    """Last ``[PERF] === ... ===`` block in the log + median GPU TOTAL across run.
+
+    The last block is what users see as "steady-state decode": for a typical
+    OGA run of (warmup × W) + (reps × R) × (1 prefill + N decodes), the last
+    Compute() bracketed by ``[PERF] ===`` borders is the last decode of the
+    last rep -- past warmup, past first-call kernel autotune, past
+    pool-grow. The TOTAL gpu (ms) MEDIAN across ALL Computes in the log
+    (typically several hundred samples for a transformer decoder run) is
+    computed from every TOTAL row and feeds the § 2 breakdown so cold-start
+    outliers don't poison the derived "GPU outside OP_PROFILE" residual.
+    """
+
+    last_block_lines: list[str] = field(default_factory=list)
+    total_gpu_ms_samples: list[float] = field(default_factory=list)
+
+    # TOTAL row format: `[PERF]  TOTAL                          <gpu>      <cpu>`
+    # Trailing two columns are intentionally locked: op_profile.cpp may grow
+    # or shrink intermediate columns (per-op counts, shape tags, ...) but the
+    # last two are always (gpu_ms, cpu_ms). Anchoring on that suffix is
+    # cheaper and more robust than chasing column widths or labels.
+    _TOTAL_RE = re.compile(r"^\[PERF\]\s+TOTAL\s+([\d.]+)\s+([\d.]+)\s*$")
+
+    @classmethod
+    def parse(cls, lines: list[str]) -> "PerOpTable":
+        out = cls()
+        # Find all border line indices, then slice between the last two.
+        border_idx = [i for i, ln in enumerate(lines) if ln.startswith("[PERF] ===")]
+        if len(border_idx) >= 2:
+            top, bot = border_idx[-2], border_idx[-1]
+            out.last_block_lines = lines[top : bot + 1]
+
+        for line in lines:
+            m = cls._TOTAL_RE.match(line)
+            if m:
+                out.total_gpu_ms_samples.append(float(m.group(1)))
+        return out
+
+    @property
+    def total_gpu_median_ms(self) -> Optional[float]:
+        if not self.total_gpu_ms_samples:
+            return None
+        return statistics.median(self.total_gpu_ms_samples)
+
+    def __bool__(self) -> bool:
+        return bool(self.last_block_lines)
+
+
+# ─── derived breakdown for § 2 ───────────────────────────────────────────────
+
+
+@dataclass
+class DecodeBreakdown:
+    """Row values for § 2 STEADY-STATE DECODE BREAKDOWN.
+
+    All inputs come from independent distributions (OGA self-reports n=381, EP
+    [PERF SUMMARY] medians from n~639 mixed prefill+decode, per-op TOTAL median
+    from the same n samples). Derived rows are therefore approximate at steady
+    state, NOT strict per-call subtractions — this is why every difference
+    clamps to >= 0 instead of letting negative residuals propagate.
+    """
+
+    oga_p50_ms: float
+    sampling_avg_ms: float
+    wall_ms: float
+    marshal_in_ms: float
+    marshal_out_ms: float
+    compute_cpu_ms: float
+    gpu_ms: float
+    fence_ms: float
+    perop_gpu_median_ms: float
+
+    @classmethod
+    def build(cls, head: OgaHeadline, perf: PerfSummary,
+              perop: PerOpTable) -> Optional["DecodeBreakdown"]:
+        if not (head.decode and perf and perop.total_gpu_median_ms is not None):
+            return None
+        oga_p50_us = head.decode.get("p50_us")
+        sample_avg_us = head.sampling.get("avg_us") if head.sampling else 0.0
+        if oga_p50_us is None:
+            return None
+
+        def med(name: str) -> Optional[float]:
+            row = perf.metrics.get(name)
+            return row.get("median") if row else None
+
+        wall = med("wall_ms")
+        cpu = med("compute_cpu_ms")
+        gpu = med("gpu_ms")
+        if wall is None or cpu is None or gpu is None:
+            return None
+
+        return cls(
+            oga_p50_ms=oga_p50_us / 1000.0,
+            sampling_avg_ms=(sample_avg_us or 0.0) / 1000.0,
+            wall_ms=wall,
+            marshal_in_ms=med("marshal_in_ms") or 0.0,
+            marshal_out_ms=med("marshal_out_ms") or 0.0,
+            compute_cpu_ms=cpu,
+            gpu_ms=gpu,
+            fence_ms=med("fence_residual_ms") or 0.0,
+            perop_gpu_median_ms=perop.total_gpu_median_ms,
+        )
+
+    # ── derived rows (clamp to >= 0 since these are between-distribution diffs)
+    @property
+    def oga_overhead_ms(self) -> float:
+        return max(0.0, self.oga_p50_ms - self.wall_ms)
+
+    @property
+    def other_oga_ms(self) -> float:
+        return max(0.0, self.oga_overhead_ms - self.sampling_avg_ms)
+
+    @property
+    def unprofiled_gpu_ms(self) -> float:
+        return max(0.0, self.gpu_ms - self.perop_gpu_median_ms)
+
+    @property
+    def cpu_overhead_ms(self) -> float:
+        return max(0.0, self.compute_cpu_ms - self.gpu_ms)
+
+
+# ─── utilities ───────────────────────────────────────────────────────────────
+
+
+def human_bytes(b: Optional[int]) -> str:
+    if b is None or b < 0:
+        return "?"
+    units = ["B", "KiB", "MiB", "GiB", "TiB"]
+    val = float(b)
+    i = 0
+    while val >= 1024 and i < len(units) - 1:
+        val /= 1024
+        i += 1
+    return f"{int(val)} {units[i]}" if i == 0 else f"{val:.2f} {units[i]}"
+
+
+def model_name_from_log_path(p: Path) -> str:
+    """`<model>_<tool>_<shape>_p<L>g<G>_<mode>_<ts>.log` -> `<model>`."""
+    stem = p.stem
+    for marker in ("_oga_", "_perftest_"):
+        idx = stem.find(marker)
+        if idx > 0:
+            return stem[:idx]
+    return stem
+
+
+def run_params_from_log_path(p: Path) -> dict:
+    """Extract tool / shape / prompt / gen / mode tags from the log filename.
+
+    Returns whatever it can decode; absent keys are simply missing. Used to
+    populate the identity banner since the bench-wrapper '===' header line is
+    NOT redirected into the log file itself.
+    """
+    out: dict = {}
+    stem = p.stem
+    for marker, key in (("_oga_", "tool"), ("_perftest_", "tool")):
+        if marker in stem:
+            out["tool"] = marker.strip("_")
+            tail = stem.split(marker, 1)[1]
+            parts = tail.split("_")
+            # parts: [shape, "p128g128", mode, date, time] (approx)
+            if parts:
+                out["shape"] = parts[0]
+            for part in parts[1:]:
+                m = re.match(r"p(\d+)g(\d+)", part)
+                if m:
+                    out["prompt"] = int(m.group(1))
+                    out["gen"] = int(m.group(2))
+                elif part in ("none", "perf", "debug"):
+                    out["mode"] = part
+            break
+    return out
+
+
+# ─── renderers ───────────────────────────────────────────────────────────────
+
+
+# Two character sets for the tree in § 2: Unicode box-drawing (default) and an
+# ASCII fallback (--ascii). The renderer references these by name so we never
+# embed raw glyphs inline — one place to swap if a third style is ever added.
+TREE_CHARS = {
+    "unicode": {"branch": "├─", "last": "└─", "pipe": "│ ", "blank": "  "},
+    "ascii":   {"branch": "+-", "last": "+-", "pipe": "| ", "blank": "  "},
+}
+
+SECTION_RULE = "─" * 74
+
+# Width of the left column in § 2 (label + tree prefix). Picked so the widest
+# label ("model.dll inference_compute()") plus deepest indent (4 levels =
+# "│   │   │ ") still fits without wrapping in a standard 100-col terminal.
+LABEL_WIDTH = 42
+
+
+def render_banner(model: str, run_params: dict, perf: PerfSummary, indent: str) -> list[str]:
+    bar = "═" * (74 + len(indent))
+    bits = [f"HIPDNN EP profile  ·  {model}"]
+    # Show shape only when it's worth flagging. "dynamic" is the default for
+    # every OGA log this script handles (run_bench.sh rejects --oga --shape
+    # static), and even if the formatter is later wired to perftest dynamic
+    # runs the token would still be redundant — readers assume dynamic. Any
+    # other value (static, future shape modes) IS noteworthy, so it stays.
+    if run_params.get("shape") and run_params["shape"] != "dynamic":
+        bits.append(run_params["shape"])
+    if "prompt" in run_params and "gen" in run_params:
+        bits.append(f"prompt={run_params['prompt']} gen={run_params['gen']}")
+    if perf.total_inferences:
+        # Match the source field name (`total_inferences=` in [PERF SUMMARY])
+        # so anyone who greps either the banner or the raw log finds the same
+        # token. "n=" was ambiguous against § 1's per-block "samples" column
+        # (3 reps, 381 decode tokens, etc.) — readers couldn't tell whether
+        # the banner counted timed-window or whole-run.
+        bits.append(f"inferences={perf.total_inferences}")
+    return [f"{indent}{bar}", f"{indent}  {'  ·  '.join(bits)}", f"{indent}{bar}"]
+
+
+def render_section_header(num: int, title: str, subtitle: str, indent: str) -> list[str]:
+    return [
+        f"{indent}  § {num}  {title}  —  {subtitle}",
+        f"{indent}  {SECTION_RULE}",
+    ]
+
+
+def render_section_1_headline(head: OgaHeadline, indent: str) -> list[str]:
+    """§ 1 HEADLINE — single five-row table consolidating model_benchmark's four
+    indented blocks (Prompt processing / Token generation / Token sampling /
+    E2E / Peak WS). Throughput in tok/s, p50 in ms, stddev in ms, samples raw.
+
+    Source:        ``OgaHeadline`` -> model_benchmark stats block.
+    Self-gates:    rendered unconditionally when ``head`` is truthy (caller
+                   already skipped the whole report on ``not head``); absent
+                   sub-blocks within head render the literal ``(absent)``.
+    """
+    lines = render_section_header(
+        1, "HEADLINE",
+        f"model_benchmark (batch={head.batch_size}, prompt={head.prompt_tokens}, "
+        f"gen={head.tokens_to_generate})",
+        indent,
+    )
+    # Column widths chosen so all five rows align with the header.
+    fmt = "    {label:<18} {tps:>13}   {p50:>13}   {std:>11}   {n}"
+    lines.append(indent + fmt.format(
+        label="", tps="throughput",
+        p50="p50 latency", std="stddev", n="samples"
+    ).rstrip())
+
+    def row(label: str, block: Optional[dict], lat_unit: str, *, has_tps: bool = True) -> str:
+        if block is None:
+            return indent + f"    {label:<18} (absent)"
+        tps = f"{block.get('avg_tps', 0):.2f} t/s" if has_tps and "avg_tps" in block else "—"
+        p50_key = f"p50_{lat_unit}"
+        p50 = f"{block.get(p50_key, 0):.2f} {lat_unit}" if p50_key in block else "—"
+        std_key = f"stddev_{lat_unit}"
+        std = f"{block.get(std_key, 0):.2f} {lat_unit}" if std_key in block else "—"
+        n = block.get("n", "—")
+        return indent + fmt.format(label=label, tps=tps, p50=p50, std=std, n=n).rstrip()
+
+    lines.append(row("Prefill (TTFT)", head.prefill,  "us"))
+    lines.append(row("Decode",         head.decode,   "us"))
+    lines.append(row("Sampling",       head.sampling, "us"))
+    lines.append(row("E2E generation", head.e2e,      "ms", has_tps=False))
+    lines.append(indent + f"    {'Peak working set':<18} "
+                          f"{human_bytes(head.peak_ws_bytes)} "
+                          f"({head.peak_ws_bytes or '?'} bytes)")
+    return lines
+
+
+def render_section_2_breakdown(bd: DecodeBreakdown, charset: str, indent: str) -> list[str]:
+    """§ 2 STEADY-STATE DECODE BREAKDOWN — drawn as an actual tree.
+
+    Source:        ``DecodeBreakdown`` -> joined OgaHeadline + PerfSummary +
+                   PerOpTable medians. Each row carries a ``◀ § N`` arrow
+                   pointing to the section that owns its raw number, so a
+                   skeptical reader can always trace a value back one hop.
+    Self-gates:    caller ensures ``bd`` is not None (build() returns None
+                   when any of the three upstream feeds is missing); this
+                   renderer assumes all medians are present.
+
+    Indentation in the tree matches visual depth so readers skimming
+    top-to-bottom never have to count whitespace.
+    """
+    tc = TREE_CHARS[charset]
+    arrow = "<-" if charset == "ascii" else "◀"
+    lines = render_section_header(
+        2, "STEADY-STATE DECODE BREAKDOWN",
+        "1 decode token, median across run",
+        indent,
+    )
+    lines.append(indent + f"    {'':<{LABEL_WIDTH}} "
+                          f"{'latency':>10}   {'share':>6}   {'source':<20}")
+
+    def row(prefix: str, label: str, ms: float, share: float,
+            src: str = "") -> str:
+        pad = LABEL_WIDTH - len(prefix) - len(label)
+        if pad < 1:
+            pad = 1
+        return (f"{indent}    {prefix}{label}{' ' * pad} "
+                f"{ms:>7.3f} ms   {share:>5.1f} %   {src}").rstrip()
+
+    total = bd.oga_p50_ms
+
+    def pct(x: float) -> float:
+        return 100.0 * x / total if total else 0.0
+
+    # ── Tree row prefixes (hard-coded because the tree shape is fixed).
+    # Each prefix encodes both this row's hook (├─ vs └─) and whether each
+    # ancestor at every level above had more siblings (│  ) or was the last
+    # one (3-space blank). Compare against the visual layout below:
+    #
+    #   OGA::GenerateNextToken                       <- root, no prefix
+    #   ├─ OGA + ORT framework overhead              <- L1 not-last
+    #   │  ├─ Token sampling                         <- L2 under L1-not-last
+    #   │  └─ Other (last L2 under L1-not-last)
+    #   └─ EP MlirCustomOp::Compute()                <- L1 LAST (no pipe below)
+    #      ├─ Marshal in                             <- L2 under L1-LAST
+    #      ├─ Marshal out
+    #      ├─ model.dll inference_compute()
+    #      │  ├─ GPU: OP_PROFILE kernels (sum)       <- L3 under L1-LAST + L2-not-last
+    #      │  ├─ GPU: unwrapped + glue kernels
+    #      │  └─ CPU: host dispatch + sync poll      <- last L3
+    #      └─ Trailing fence (hipStreamSync)         <- last L2 under L1-LAST
+    PIPE   = f"{tc['pipe']} "    # "│  " — parent has more siblings below
+    BLANK  = "   "               # parent was last — no pipe through this column
+    BRANCH = f"{tc['branch']} "  # "├─ " — this row has siblings below
+    LAST   = f"{tc['last']} "    # "└─ " — last sibling at this level
+
+    lines.append(row("", "OGA::GenerateNextToken", bd.oga_p50_ms, 100.0,
+                     f"{arrow} § 1 Decode p50"))
+    lines.append(row(BRANCH, "OGA + ORT framework overhead",
+                     bd.oga_overhead_ms, pct(bd.oga_overhead_ms)))
+    lines.append(row(PIPE + BRANCH, "Token sampling",
+                     bd.sampling_avg_ms, pct(bd.sampling_avg_ms),
+                     f"{arrow} § 1 Sampling avg"))
+    lines.append(row(PIPE + LAST, "Other (IoBinding rebind, etc.)",
+                     bd.other_oga_ms, pct(bd.other_oga_ms)))
+    lines.append(row(LAST, "EP MlirCustomOp::Compute()",
+                     bd.wall_ms, pct(bd.wall_ms),
+                     f"{arrow} § 4 wall_ms"))
+    lines.append(row(BLANK + BRANCH, "Marshal in (input descriptors)",
+                     bd.marshal_in_ms, pct(bd.marshal_in_ms),
+                     f"{arrow} § 4 marshal_in_ms"))
+    lines.append(row(BLANK + BRANCH, "Marshal out (output desc.)",
+                     bd.marshal_out_ms, pct(bd.marshal_out_ms),
+                     f"{arrow} § 4 marshal_out_ms"))
+    lines.append(row(BLANK + BRANCH, "model.dll inference_compute()",
+                     bd.compute_cpu_ms, pct(bd.compute_cpu_ms),
+                     f"{arrow} § 4 compute_cpu_ms"))
+    lines.append(row(BLANK + PIPE + BRANCH, "GPU: OP_PROFILE kernels (sum)",
+                     bd.perop_gpu_median_ms, pct(bd.perop_gpu_median_ms),
+                     f"{arrow} § 3 TOTAL"))
+    lines.append(row(BLANK + PIPE + BRANCH, "GPU: outside § 3 scopes",
+                     bd.unprofiled_gpu_ms, pct(bd.unprofiled_gpu_ms)))
+    lines.append(row(BLANK + PIPE + LAST, "CPU: host dispatch + sync poll",
+                     bd.cpu_overhead_ms, pct(bd.cpu_overhead_ms)))
+    lines.append(row(BLANK + LAST, "Trailing fence (hipStreamSync)",
+                     bd.fence_ms, pct(bd.fence_ms),
+                     f"{arrow} § 4 fence_residual_ms"))
+
+    # Notes for the two "residual" rows that don't have a direct § N cross-ref
+    # (they are subtractive — what's left after the named rows are accounted
+    # for). Without these notes, first-time readers ask "what's in there?" for
+    # both rows. We deliberately do NOT annotate every row — the named ones
+    # speak for themselves once you've followed their § N arrow.
+    lines.append("")
+    lines.append(indent + "    notes:")
+    lines.append(indent + "      - \"GPU: outside § 3 scopes\" = § 4 gpu_ms − § 3 "
+                          "TOTAL: GPU work not bracketed by any")
+    lines.append(indent + "        OP_PROFILE wrapper. Typical sources: MIOpen / "
+                          "hipBLASLt internal helper")
+    lines.append(indent + "        launches, ops lacking an OP_PROFILE scope, "
+                          "hipMemset / glue between ops. If")
+    lines.append(indent + "        this row grows after a runtime change, "
+                          "OP_PROFILE coverage has regressed.")
+    lines.append(indent + "      - \"Other (IoBinding rebind, etc.)\" = § 1 Decode "
+                          "p50 − sampling − EP wall: OGA")
+    lines.append(indent + "        framework overhead between Generator steps. "
+                          "Dominated by IoBinding's per-token")
+    lines.append(indent + "        rebind of all input/output tensors (scales "
+                          "with KV buffer size, not seq len).")
+    return lines
+
+
+def render_section_3_perop(perop: PerOpTable, indent: str) -> list[str]:
+    """§ 3 PER-OP GPU BREAKDOWN — passes the runtime's own [PERF] table through
+    verbatim.
+
+    Source:        ``PerOpTable.last_block_lines`` -> the last
+                   ``[PERF] === ... ===`` block emitted by
+                   ``op_profile_resolve_and_print`` in
+                   ``lib/Runtime/op_profile.cpp``.
+    Self-gates:    returns ``[]`` when ``perop`` is empty (the log was run
+                   with ``HIPDNN_EP_PERF`` unset or no per-op table was
+                   ever printed).
+
+    The op_profile.cpp formatter already aligns columns nicely, so we only
+    strip the ``[PERF] `` prefix (the section header tells the reader which
+    subsystem these rows came from) and add the section frame.
+    """
+    if not perop:
+        return []
+    lines = render_section_header(
+        3, "PER-OP GPU BREAKDOWN",
+        "last Compute() = steady-state decode token",
+        indent,
+    )
+    for line in perop.last_block_lines:
+        # Drop the leading `[PERF] ` tag; the section header tells the reader
+        # which subsystem these rows came from.
+        body = line.removeprefix("[PERF] ")
+        lines.append(f"{indent}    {body}")
+    return lines
+
+
+def render_section_4_distribution(perf: PerfSummary, indent: str) -> list[str]:
+    """§ 4 PER-CALL DISTRIBUTION — six metrics × five stats, column-aligned.
+
+    Source:        ``PerfSummary.metrics`` -> the ``[PERF SUMMARY]`` block
+                   emitted by ``PerfCollector::dump_summary`` at DLL unload
+                   (see ``backend-mlir-compiler/.../MlirCustomOp.cpp``).
+    Self-gates:    returns ``[]`` when ``perf`` is empty (no [PERF SUMMARY]
+                   block in the log -- typically a ``--mode none`` run).
+
+    The cold-start note at the bottom is intentional: § 4's ``max`` column
+    almost always shows a multi-second outlier (the very first Compute()
+    that does kernel autotune + GPU pool first-grow) and this surprises
+    readers who haven't seen the report before. Documenting it in-band
+    pre-empts the predictable "why is max 1000x the median?" question.
+    """
+    if not perf:
+        return []
+    lines = render_section_header(
+        4, "PER-CALL DISTRIBUTION",
+        f"EP MlirCustomOp::Compute() over {perf.total_inferences} invocations (all ms)",
+        indent,
+    )
+    lines.append(indent + f"    {'':<18} {'min':>10} {'median':>10}"
+                          f" {'p99':>10} {'max':>12}")
+    for name in PerfSummary.METRIC_ORDER:
+        stats = perf.metrics.get(name)
+        if not stats:
+            continue
+        lines.append(
+            indent + f"    {name:<18} "
+                     f"{stats['min']:>10.3f} {stats['median']:>10.3f}"
+                     f" {stats['p99']:>10.3f} {stats['max']:>12.3f}"
+        )
+    # The two-line note below catches the two most-common "wait, what?" moments
+    # readers have when first comparing § 4 against § 1:
+    #   (a) why is `max` 1000× the median? -> cold start; see also § 2 caveat
+    #   (b) why doesn't this count match § 1's "samples" column? -> different
+    #       windows: § 1 reports only OGA's timed iterations, § 4 reports every
+    #       EP call including warmup + verbose-mode display generation.
+    lines.append(indent + "    notes:")
+    lines.append(indent + "      - `max` includes first-Compute cold start "
+                          "(kernel autotune + pool grow);")
+    lines.append(indent + "        § 2 uses median to skip those outliers.")
+    lines.append(indent + "      - this count covers ALL EP calls (warmup + "
+                          "verbose-display + timed reps);")
+    lines.append(indent + "        § 1's per-block `samples` column is the "
+                          "OGA-timed subset only.")
+    return lines
+
+
+def render_footer(head: OgaHeadline, indent: str) -> list[str]:
+    """Single greppable tail line — public contract; keep stable across runs.
+
+    Output format (treat as public API for downstream tooling):
+
+        [OGA] prefill=<P> tok/s  TTFT=<T> ms  decode=<D> tok/s  \\
+              peak_WS=<H> (<B> bytes)
+
+    Where <P>/<D> are floats in tokens/s, <T> is a float in ms, <H> is the
+    human-readable peak working-set (e.g. "1.34 GiB"), and <B> is the raw
+    byte count. Tools may grep for ``^\\[OGA\\] prefill=`` to locate the
+    line and parse the named fields. Peak working-set bytes are kept in
+    parens for greppability even though the GiB form is shown first.
+    """
+    if not head:
+        return []
+    bar = "═" * (74 + len(indent))
+    prefill_tps = head.prefill.get("avg_tps") if head.prefill else None
+    decode_tps = head.decode.get("avg_tps") if head.decode else None
+    # TTFT is the raw prompt-processing wall time -- `prefill=... tok/s` is
+    # derived from it (prompt_tokens / TTFT_seconds) but the time itself is
+    # the more directly meaningful number when comparing across prompt
+    # lengths or against external baselines. Use `avg_us` (matching what
+    # `prefill tok/s` is derived from) for internal consistency.
+    ttft_us = head.prefill.get("avg_us") if head.prefill else None
+    ttft_str = f"{ttft_us / 1000.0:.2f} ms" if ttft_us else "?"
+    peak_bytes = head.peak_ws_bytes if head.peak_ws_bytes is not None else "?"
+    return [
+        f"{indent}{bar}",
+        f"{indent}  [OGA] prefill={prefill_tps or '?'} tok/s  "
+        f"TTFT={ttft_str}  "
+        f"decode={decode_tps or '?'} tok/s  "
+        f"peak_WS={human_bytes(head.peak_ws_bytes)} ({peak_bytes} bytes)",
+        f"{indent}{bar}",
+    ]
+
+
+# ─── main ────────────────────────────────────────────────────────────────────
+
+
+def render_report(log_path: Path, *, charset: str = "unicode",
+                  show_banner: bool = True, indent: str = "") -> str:
+    lines = log_path.read_text(errors="replace").splitlines()
+
+    perf = PerfSummary.parse(lines)
+    head = OgaHeadline.parse(lines)
+    perop = PerOpTable.parse(lines)
+
+    if not head:
+        # No model_benchmark stats — likely a failed run. Caller prints a raw
+        # tail instead of this report; signal absence by returning empty.
+        return ""
+
+    breakdown = DecodeBreakdown.build(head, perf, perop)
+
+    out: list[str] = []
+    model = model_name_from_log_path(log_path)
+    run_params = run_params_from_log_path(log_path)
+
+    if show_banner:
+        out += render_banner(model, run_params, perf, indent)
+        out.append("")
+
+    out += render_section_1_headline(head, indent)
+    out.append("")
+
+    if breakdown is not None:
+        out += render_section_2_breakdown(breakdown, charset, indent)
+        out.append("")
+    if perop:
+        out += render_section_3_perop(perop, indent)
+        out.append("")
+    if perf:
+        out += render_section_4_distribution(perf, indent)
+        out.append("")
+
+    if show_banner:
+        out += render_footer(head, indent)
+
+    # Trim trailing blank line for cleaner embedding in bash output.
+    while out and out[-1] == "":
+        out.pop()
+    return "\n".join(out)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("log", type=Path, help="Path to a HIPDNN EP / OGA bench log")
+    p.add_argument("--ascii", action="store_true",
+                   help="Use ASCII tree chars instead of Unicode box-drawing")
+    p.add_argument("--no-banner", action="store_true",
+                   help="Omit the top/bottom identity banner")
+    p.add_argument("--indent", type=int, default=0,
+                   help="Indent every output line by N spaces (default: 0)")
+    args = p.parse_args(argv)
+
+    if not args.log.is_file():
+        print(f"error: log not found: {args.log}", file=sys.stderr)
+        return 1
+
+    report = render_report(
+        args.log,
+        charset="ascii" if args.ascii else "unicode",
+        show_banner=not args.no_banner,
+        indent=" " * args.indent,
+    )
+    if not report:
+        print(f"warning: log has no model_benchmark stats block: {args.log}",
+              file=sys.stderr)
+        return 2
+    print(report)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/perf-report/format_perf_report.py
+++ b/tools/perf-report/format_perf_report.py
@@ -49,6 +49,7 @@ USAGE
     tools/perf-report/format_perf_report.py <log-file> --no-banner  # CI embed
     tools/perf-report/format_perf_report.py <log-file> --indent 2   # indent N
 """
+
 from __future__ import annotations
 
 import argparse
@@ -143,7 +144,6 @@ class OgaHeadline:
     @classmethod
     def parse(cls, lines: list[str]) -> "OgaHeadline":
         out = cls()
-        cur_field: Optional[str] = None
         cur_block: Optional[dict] = None
 
         # Pre-compile per-row patterns. model_benchmark uses literal tabs
@@ -163,31 +163,33 @@ class OgaHeadline:
             stripped = line.lstrip()
 
             # Single-line headers and tail rows
-            m = re.match(r"Batch size:\s*(\d+),\s*prompt tokens:\s*(\d+),"
-                         r"\s*tokens to generate:\s*(\d+)", line)
+            m = re.match(
+                r"Batch size:\s*(\d+),\s*prompt tokens:\s*(\d+),"
+                r"\s*tokens to generate:\s*(\d+)",
+                line,
+            )
             if m:
                 out.batch_size = int(m.group(1))
                 out.prompt_tokens = int(m.group(2))
                 out.tokens_to_generate = int(m.group(3))
-                cur_field, cur_block = None, None
+                cur_block = None
                 continue
 
             m = re.match(r"Peak working set size \(bytes\):\s*(\d+)", line)
             if m:
                 out.peak_ws_bytes = int(m.group(1))
-                cur_field, cur_block = None, None
+                cur_block = None
                 continue
 
             # Block-start headers — always unindented
             if not line.startswith(("\t", " ")):
                 field_name = cls._BLOCKS.get(line.rstrip())
                 if field_name is not None:
-                    cur_field = field_name
                     cur_block = {}
                     setattr(out, field_name, cur_block)
                     continue
                 # Any other unindented line ends the current block
-                cur_field, cur_block = None, None
+                cur_block = None
                 continue
 
             if cur_block is None:
@@ -291,8 +293,9 @@ class DecodeBreakdown:
     perop_gpu_median_ms: float
 
     @classmethod
-    def build(cls, head: OgaHeadline, perf: PerfSummary,
-              perop: PerOpTable) -> Optional["DecodeBreakdown"]:
+    def build(
+        cls, head: OgaHeadline, perf: PerfSummary, perop: PerOpTable
+    ) -> Optional["DecodeBreakdown"]:
         if not (head.decode and perf and perop.total_gpu_median_ms is not None):
             return None
         oga_p50_us = head.decode.get("p50_us")
@@ -401,7 +404,7 @@ def run_params_from_log_path(p: Path) -> dict:
 # embed raw glyphs inline — one place to swap if a third style is ever added.
 TREE_CHARS = {
     "unicode": {"branch": "├─", "last": "└─", "pipe": "│ ", "blank": "  "},
-    "ascii":   {"branch": "+-", "last": "+-", "pipe": "| ", "blank": "  "},
+    "ascii": {"branch": "+-", "last": "+-", "pipe": "| ", "blank": "  "},
 }
 
 SECTION_RULE = "─" * 74
@@ -412,7 +415,9 @@ SECTION_RULE = "─" * 74
 LABEL_WIDTH = 42
 
 
-def render_banner(model: str, run_params: dict, perf: PerfSummary, indent: str) -> list[str]:
+def render_banner(
+    model: str, run_params: dict, perf: PerfSummary, indent: str
+) -> list[str]:
     bar = "═" * (74 + len(indent))
     bits = [f"HIPDNN EP profile  ·  {model}"]
     # Show shape only when it's worth flagging. "dynamic" is the default for
@@ -434,7 +439,9 @@ def render_banner(model: str, run_params: dict, perf: PerfSummary, indent: str) 
     return [f"{indent}{bar}", f"{indent}  {'  ·  '.join(bits)}", f"{indent}{bar}"]
 
 
-def render_section_header(num: int, title: str, subtitle: str, indent: str) -> list[str]:
+def render_section_header(
+    num: int, title: str, subtitle: str, indent: str
+) -> list[str]:
     return [
         f"{indent}  § {num}  {title}  —  {subtitle}",
         f"{indent}  {SECTION_RULE}",
@@ -452,22 +459,31 @@ def render_section_1_headline(head: OgaHeadline, indent: str) -> list[str]:
                    sub-blocks within head render the literal ``(absent)``.
     """
     lines = render_section_header(
-        1, "HEADLINE",
+        1,
+        "HEADLINE",
         f"model_benchmark (batch={head.batch_size}, prompt={head.prompt_tokens}, "
         f"gen={head.tokens_to_generate})",
         indent,
     )
     # Column widths chosen so all five rows align with the header.
     fmt = "    {label:<18} {tps:>13}   {p50:>13}   {std:>11}   {n}"
-    lines.append(indent + fmt.format(
-        label="", tps="throughput",
-        p50="p50 latency", std="stddev", n="samples"
-    ).rstrip())
+    lines.append(
+        indent
+        + fmt.format(
+            label="", tps="throughput", p50="p50 latency", std="stddev", n="samples"
+        ).rstrip()
+    )
 
-    def row(label: str, block: Optional[dict], lat_unit: str, *, has_tps: bool = True) -> str:
+    def row(
+        label: str, block: Optional[dict], lat_unit: str, *, has_tps: bool = True
+    ) -> str:
         if block is None:
             return indent + f"    {label:<18} (absent)"
-        tps = f"{block.get('avg_tps', 0):.2f} t/s" if has_tps and "avg_tps" in block else "—"
+        tps = (
+            f"{block.get('avg_tps', 0):.2f} t/s"
+            if has_tps and "avg_tps" in block
+            else "—"
+        )
         p50_key = f"p50_{lat_unit}"
         p50 = f"{block.get(p50_key, 0):.2f} {lat_unit}" if p50_key in block else "—"
         std_key = f"stddev_{lat_unit}"
@@ -475,17 +491,21 @@ def render_section_1_headline(head: OgaHeadline, indent: str) -> list[str]:
         n = block.get("n", "—")
         return indent + fmt.format(label=label, tps=tps, p50=p50, std=std, n=n).rstrip()
 
-    lines.append(row("Prefill (TTFT)", head.prefill,  "us"))
-    lines.append(row("Decode",         head.decode,   "us"))
-    lines.append(row("Sampling",       head.sampling, "us"))
-    lines.append(row("E2E generation", head.e2e,      "ms", has_tps=False))
-    lines.append(indent + f"    {'Peak working set':<18} "
-                          f"{human_bytes(head.peak_ws_bytes)} "
-                          f"({head.peak_ws_bytes or '?'} bytes)")
+    lines.append(row("Prefill (TTFT)", head.prefill, "us"))
+    lines.append(row("Decode", head.decode, "us"))
+    lines.append(row("Sampling", head.sampling, "us"))
+    lines.append(row("E2E generation", head.e2e, "ms", has_tps=False))
+    lines.append(
+        indent + f"    {'Peak working set':<18} "
+        f"{human_bytes(head.peak_ws_bytes)} "
+        f"({head.peak_ws_bytes or '?'} bytes)"
+    )
     return lines
 
 
-def render_section_2_breakdown(bd: DecodeBreakdown, charset: str, indent: str) -> list[str]:
+def render_section_2_breakdown(
+    bd: DecodeBreakdown, charset: str, indent: str
+) -> list[str]:
     """§ 2 STEADY-STATE DECODE BREAKDOWN — drawn as an actual tree.
 
     Source:        ``DecodeBreakdown`` -> joined OgaHeadline + PerfSummary +
@@ -502,20 +522,24 @@ def render_section_2_breakdown(bd: DecodeBreakdown, charset: str, indent: str) -
     tc = TREE_CHARS[charset]
     arrow = "<-" if charset == "ascii" else "◀"
     lines = render_section_header(
-        2, "STEADY-STATE DECODE BREAKDOWN",
+        2,
+        "STEADY-STATE DECODE BREAKDOWN",
         "1 decode token, median across run",
         indent,
     )
-    lines.append(indent + f"    {'':<{LABEL_WIDTH}} "
-                          f"{'latency':>10}   {'share':>6}   {'source':<20}")
+    lines.append(
+        indent + f"    {'':<{LABEL_WIDTH}} "
+        f"{'latency':>10}   {'share':>6}   {'source':<20}"
+    )
 
-    def row(prefix: str, label: str, ms: float, share: float,
-            src: str = "") -> str:
+    def row(prefix: str, label: str, ms: float, share: float, src: str = "") -> str:
         pad = LABEL_WIDTH - len(prefix) - len(label)
         if pad < 1:
             pad = 1
-        return (f"{indent}    {prefix}{label}{' ' * pad} "
-                f"{ms:>7.3f} ms   {share:>5.1f} %   {src}").rstrip()
+        return (
+            f"{indent}    {prefix}{label}{' ' * pad} "
+            f"{ms:>7.3f} ms   {share:>5.1f} %   {src}"
+        ).rstrip()
 
     total = bd.oga_p50_ms
 
@@ -539,42 +563,115 @@ def render_section_2_breakdown(bd: DecodeBreakdown, charset: str, indent: str) -
     #      │  ├─ GPU: unwrapped + glue kernels
     #      │  └─ CPU: host dispatch + sync poll      <- last L3
     #      └─ Trailing fence (hipStreamSync)         <- last L2 under L1-LAST
-    PIPE   = f"{tc['pipe']} "    # "│  " — parent has more siblings below
-    BLANK  = "   "               # parent was last — no pipe through this column
+    PIPE = f"{tc['pipe']} "  # "│  " — parent has more siblings below
+    BLANK = "   "  # parent was last — no pipe through this column
     BRANCH = f"{tc['branch']} "  # "├─ " — this row has siblings below
-    LAST   = f"{tc['last']} "    # "└─ " — last sibling at this level
+    LAST = f"{tc['last']} "  # "└─ " — last sibling at this level
 
-    lines.append(row("", "OGA::GenerateNextToken", bd.oga_p50_ms, 100.0,
-                     f"{arrow} § 1 Decode p50"))
-    lines.append(row(BRANCH, "OGA + ORT framework overhead",
-                     bd.oga_overhead_ms, pct(bd.oga_overhead_ms)))
-    lines.append(row(PIPE + BRANCH, "Token sampling",
-                     bd.sampling_avg_ms, pct(bd.sampling_avg_ms),
-                     f"{arrow} § 1 Sampling avg"))
-    lines.append(row(PIPE + LAST, "Other (IoBinding rebind, etc.)",
-                     bd.other_oga_ms, pct(bd.other_oga_ms)))
-    lines.append(row(LAST, "EP MlirCustomOp::Compute()",
-                     bd.wall_ms, pct(bd.wall_ms),
-                     f"{arrow} § 4 wall_ms"))
-    lines.append(row(BLANK + BRANCH, "Marshal in (input descriptors)",
-                     bd.marshal_in_ms, pct(bd.marshal_in_ms),
-                     f"{arrow} § 4 marshal_in_ms"))
-    lines.append(row(BLANK + BRANCH, "Marshal out (output desc.)",
-                     bd.marshal_out_ms, pct(bd.marshal_out_ms),
-                     f"{arrow} § 4 marshal_out_ms"))
-    lines.append(row(BLANK + BRANCH, "model.dll inference_compute()",
-                     bd.compute_cpu_ms, pct(bd.compute_cpu_ms),
-                     f"{arrow} § 4 compute_cpu_ms"))
-    lines.append(row(BLANK + PIPE + BRANCH, "GPU: OP_PROFILE kernels (sum)",
-                     bd.perop_gpu_median_ms, pct(bd.perop_gpu_median_ms),
-                     f"{arrow} § 3 TOTAL"))
-    lines.append(row(BLANK + PIPE + BRANCH, "GPU: outside § 3 scopes",
-                     bd.unprofiled_gpu_ms, pct(bd.unprofiled_gpu_ms)))
-    lines.append(row(BLANK + PIPE + LAST, "CPU: host dispatch + sync poll",
-                     bd.cpu_overhead_ms, pct(bd.cpu_overhead_ms)))
-    lines.append(row(BLANK + LAST, "Trailing fence (hipStreamSync)",
-                     bd.fence_ms, pct(bd.fence_ms),
-                     f"{arrow} § 4 fence_residual_ms"))
+    lines.append(
+        row(
+            "",
+            "OGA::GenerateNextToken",
+            bd.oga_p50_ms,
+            100.0,
+            f"{arrow} § 1 Decode p50",
+        )
+    )
+    lines.append(
+        row(
+            BRANCH,
+            "OGA + ORT framework overhead",
+            bd.oga_overhead_ms,
+            pct(bd.oga_overhead_ms),
+        )
+    )
+    lines.append(
+        row(
+            PIPE + BRANCH,
+            "Token sampling",
+            bd.sampling_avg_ms,
+            pct(bd.sampling_avg_ms),
+            f"{arrow} § 1 Sampling avg",
+        )
+    )
+    lines.append(
+        row(
+            PIPE + LAST,
+            "Other (IoBinding rebind, etc.)",
+            bd.other_oga_ms,
+            pct(bd.other_oga_ms),
+        )
+    )
+    lines.append(
+        row(
+            LAST,
+            "EP MlirCustomOp::Compute()",
+            bd.wall_ms,
+            pct(bd.wall_ms),
+            f"{arrow} § 4 wall_ms",
+        )
+    )
+    lines.append(
+        row(
+            BLANK + BRANCH,
+            "Marshal in (input descriptors)",
+            bd.marshal_in_ms,
+            pct(bd.marshal_in_ms),
+            f"{arrow} § 4 marshal_in_ms",
+        )
+    )
+    lines.append(
+        row(
+            BLANK + BRANCH,
+            "Marshal out (output desc.)",
+            bd.marshal_out_ms,
+            pct(bd.marshal_out_ms),
+            f"{arrow} § 4 marshal_out_ms",
+        )
+    )
+    lines.append(
+        row(
+            BLANK + BRANCH,
+            "model.dll inference_compute()",
+            bd.compute_cpu_ms,
+            pct(bd.compute_cpu_ms),
+            f"{arrow} § 4 compute_cpu_ms",
+        )
+    )
+    lines.append(
+        row(
+            BLANK + PIPE + BRANCH,
+            "GPU: OP_PROFILE kernels (sum)",
+            bd.perop_gpu_median_ms,
+            pct(bd.perop_gpu_median_ms),
+            f"{arrow} § 3 TOTAL",
+        )
+    )
+    lines.append(
+        row(
+            BLANK + PIPE + BRANCH,
+            "GPU: outside § 3 scopes",
+            bd.unprofiled_gpu_ms,
+            pct(bd.unprofiled_gpu_ms),
+        )
+    )
+    lines.append(
+        row(
+            BLANK + PIPE + LAST,
+            "CPU: host dispatch + sync poll",
+            bd.cpu_overhead_ms,
+            pct(bd.cpu_overhead_ms),
+        )
+    )
+    lines.append(
+        row(
+            BLANK + LAST,
+            "Trailing fence (hipStreamSync)",
+            bd.fence_ms,
+            pct(bd.fence_ms),
+            f"{arrow} § 4 fence_residual_ms",
+        )
+    )
 
     # Notes for the two "residual" rows that don't have a direct § N cross-ref
     # (they are subtractive — what's left after the named rows are accounted
@@ -583,20 +680,34 @@ def render_section_2_breakdown(bd: DecodeBreakdown, charset: str, indent: str) -
     # speak for themselves once you've followed their § N arrow.
     lines.append("")
     lines.append(indent + "    notes:")
-    lines.append(indent + "      - \"GPU: outside § 3 scopes\" = § 4 gpu_ms − § 3 "
-                          "TOTAL: GPU work not bracketed by any")
-    lines.append(indent + "        OP_PROFILE wrapper. Typical sources: MIOpen / "
-                          "hipBLASLt internal helper")
-    lines.append(indent + "        launches, ops lacking an OP_PROFILE scope, "
-                          "hipMemset / glue between ops. If")
-    lines.append(indent + "        this row grows after a runtime change, "
-                          "OP_PROFILE coverage has regressed.")
-    lines.append(indent + "      - \"Other (IoBinding rebind, etc.)\" = § 1 Decode "
-                          "p50 − sampling − EP wall: OGA")
-    lines.append(indent + "        framework overhead between Generator steps. "
-                          "Dominated by IoBinding's per-token")
-    lines.append(indent + "        rebind of all input/output tensors (scales "
-                          "with KV buffer size, not seq len).")
+    lines.append(
+        indent + '      - "GPU: outside § 3 scopes" = § 4 gpu_ms − § 3 '
+        "TOTAL: GPU work not bracketed by any"
+    )
+    lines.append(
+        indent + "        OP_PROFILE wrapper. Typical sources: MIOpen / "
+        "hipBLASLt internal helper"
+    )
+    lines.append(
+        indent + "        launches, ops lacking an OP_PROFILE scope, "
+        "hipMemset / glue between ops. If"
+    )
+    lines.append(
+        indent + "        this row grows after a runtime change, "
+        "OP_PROFILE coverage has regressed."
+    )
+    lines.append(
+        indent + '      - "Other (IoBinding rebind, etc.)" = § 1 Decode '
+        "p50 − sampling − EP wall: OGA"
+    )
+    lines.append(
+        indent + "        framework overhead between Generator steps. "
+        "Dominated by IoBinding's per-token"
+    )
+    lines.append(
+        indent + "        rebind of all input/output tensors (scales "
+        "with KV buffer size, not seq len)."
+    )
     return lines
 
 
@@ -619,7 +730,8 @@ def render_section_3_perop(perop: PerOpTable, indent: str) -> list[str]:
     if not perop:
         return []
     lines = render_section_header(
-        3, "PER-OP GPU BREAKDOWN",
+        3,
+        "PER-OP GPU BREAKDOWN",
         "last Compute() = steady-state decode token",
         indent,
     )
@@ -649,20 +761,22 @@ def render_section_4_distribution(perf: PerfSummary, indent: str) -> list[str]:
     if not perf:
         return []
     lines = render_section_header(
-        4, "PER-CALL DISTRIBUTION",
+        4,
+        "PER-CALL DISTRIBUTION",
         f"EP MlirCustomOp::Compute() over {perf.total_inferences} invocations (all ms)",
         indent,
     )
-    lines.append(indent + f"    {'':<18} {'min':>10} {'median':>10}"
-                          f" {'p99':>10} {'max':>12}")
+    lines.append(
+        indent + f"    {'':<18} {'min':>10} {'median':>10} {'p99':>10} {'max':>12}"
+    )
     for name in PerfSummary.METRIC_ORDER:
         stats = perf.metrics.get(name)
         if not stats:
             continue
         lines.append(
             indent + f"    {name:<18} "
-                     f"{stats['min']:>10.3f} {stats['median']:>10.3f}"
-                     f" {stats['p99']:>10.3f} {stats['max']:>12.3f}"
+            f"{stats['min']:>10.3f} {stats['median']:>10.3f}"
+            f" {stats['p99']:>10.3f} {stats['max']:>12.3f}"
         )
     # The two-line note below catches the two most-common "wait, what?" moments
     # readers have when first comparing § 4 against § 1:
@@ -671,13 +785,19 @@ def render_section_4_distribution(perf: PerfSummary, indent: str) -> list[str]:
     #       windows: § 1 reports only OGA's timed iterations, § 4 reports every
     #       EP call including warmup + verbose-mode display generation.
     lines.append(indent + "    notes:")
-    lines.append(indent + "      - `max` includes first-Compute cold start "
-                          "(kernel autotune + pool grow);")
+    lines.append(
+        indent + "      - `max` includes first-Compute cold start "
+        "(kernel autotune + pool grow);"
+    )
     lines.append(indent + "        § 2 uses median to skip those outliers.")
-    lines.append(indent + "      - this count covers ALL EP calls (warmup + "
-                          "verbose-display + timed reps);")
-    lines.append(indent + "        § 1's per-block `samples` column is the "
-                          "OGA-timed subset only.")
+    lines.append(
+        indent + "      - this count covers ALL EP calls (warmup + "
+        "verbose-display + timed reps);"
+    )
+    lines.append(
+        indent + "        § 1's per-block `samples` column is the "
+        "OGA-timed subset only."
+    )
     return lines
 
 
@@ -721,8 +841,13 @@ def render_footer(head: OgaHeadline, indent: str) -> list[str]:
 # ─── main ────────────────────────────────────────────────────────────────────
 
 
-def render_report(log_path: Path, *, charset: str = "unicode",
-                  show_banner: bool = True, indent: str = "") -> str:
+def render_report(
+    log_path: Path,
+    *,
+    charset: str = "unicode",
+    show_banner: bool = True,
+    indent: str = "",
+) -> str:
     lines = log_path.read_text(errors="replace").splitlines()
 
     perf = PerfSummary.parse(lines)
@@ -772,12 +897,20 @@ def main(argv: Optional[list[str]] = None) -> int:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     p.add_argument("log", type=Path, help="Path to a HIPDNN EP / OGA bench log")
-    p.add_argument("--ascii", action="store_true",
-                   help="Use ASCII tree chars instead of Unicode box-drawing")
-    p.add_argument("--no-banner", action="store_true",
-                   help="Omit the top/bottom identity banner")
-    p.add_argument("--indent", type=int, default=0,
-                   help="Indent every output line by N spaces (default: 0)")
+    p.add_argument(
+        "--ascii",
+        action="store_true",
+        help="Use ASCII tree chars instead of Unicode box-drawing",
+    )
+    p.add_argument(
+        "--no-banner", action="store_true", help="Omit the top/bottom identity banner"
+    )
+    p.add_argument(
+        "--indent",
+        type=int,
+        default=0,
+        help="Indent every output line by N spaces (default: 0)",
+    )
     args = p.parse_args(argv)
 
     if not args.log.is_file():
@@ -791,8 +924,10 @@ def main(argv: Optional[list[str]] = None) -> int:
         indent=" " * args.indent,
     )
     if not report:
-        print(f"warning: log has no model_benchmark stats block: {args.log}",
-              file=sys.stderr)
+        print(
+            f"warning: log has no model_benchmark stats block: {args.log}",
+            file=sys.stderr,
+        )
         return 2
     print(report)
     return 0

--- a/tools/perf-report/perf_multimodal_report.py
+++ b/tools/perf-report/perf_multimodal_report.py
@@ -1,0 +1,1321 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+"""Format a HIPDNN EP OGA model_benchmark log into a structured profiling report.
+
+The report is the locked-down rendering of three independent measurement streams
+that the EP + OGA emit into a single log when ``HIPDNN_EP_PERF=1`` is set:
+
+    1. ``[PERF SUMMARY]`` - per-Compute aggregates (n samples, min/median/p99/max)
+       emitted by ``MlirCustomOp.cpp::PerfCollector::dump_summary`` at library
+       unload (the per-model compiled shared object: ``.so`` on Linux,
+       ``.dll`` on Windows).
+    2. model_benchmark stats block - OGA's own Prompt processing / Token generation
+       / Token sampling / E2E summary printed by ``model_benchmark``.
+    3. ``[PERF] === ... ===`` per-op tables - one per Compute(), emitted by
+       ``op_profile_resolve_and_print`` in ``lib/Runtime/op_profile.cpp``.
+
+The script REQUIRES model_benchmark output (stream 2) to render any report --
+when the log has no ``Batch size:`` line the renderer returns the empty string
+and the CLI exits with code 2 so the caller can fall back to a raw tail.
+Streams 1 and 3 are EP-side and would be present under any host tool that
+exercises the MorphiZen EP with ``HIPDNN_EP_PERF=1``, but # 1 / # 2 / footer
+rendering is gated on the model_benchmark stats block being present.
+
+Output layout (reading order is headline-first - most-skimmable numbers up top,
+forensic distribution at the bottom):
+
+    # 1  HEADLINE                       OGA's own throughput / latency table
+    # 2  STEADY-STATE DECODE BREAKDOWN  synthesized "where does the time go" tree
+    # 3  PER-OP GPU BREAKDOWN           op_profile.cpp's table verbatim
+    # 4  PER-CALL DISTRIBUTION          raw EP Compute() distribution
+
+Stability contract (treat as public API for downstream tooling):
+
+    - Section markers always start with ``  # N  TITLE`` where N is a single
+      digit. Tools may grep for ``^  # \\d  `` to find section boundaries.
+    - The bottom banner is a single greppable line: ``^\\[OGA\\] prefill=``.
+    - Section / banner widths are stable; the indent prefix is the only
+      whitespace the caller may modify (via ``--indent``).
+    - Each section silently no-ops when its source data is absent (running
+      against a ``--mode none`` log prints only # 1 + bottom banner); the
+      caller is responsible for raw-tail fallback when no
+      ``Batch size:`` line is present (this script then exits with code 2).
+
+USAGE
+-----
+    perf_multimodal_report.py <log-file>
+    perf_multimodal_report.py <log-file> <csv-file> --reps N   # multimodal CSV headline
+    perf_multimodal_report.py <log-file> --no-banner           # CI embed
+    perf_multimodal_report.py <log-file> --indent 2            # indent N
+"""
+from __future__ import annotations
+
+import argparse
+import csv as _csv
+import re
+import statistics
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+
+# --- parsers -----------------------------------------------------------------
+
+# All five stats live on a single [PERF SUMMARY] row; parse via labeled tokens
+# so we are robust to: (a) column reordering, (b) future-added stats (e.g.
+# p95), (c) metric-name renames -- the renderer below addresses metrics by
+# name, not position, so a new column shows up in __dict__ and is ignored
+# unless the renderer is teaching about it.
+_STAT_RE = re.compile(r"\b(min|mean|median|p99|max)=([-+0-9.eE]+)")
+
+
+@dataclass
+class PerfSummary:
+    """Aggregated per-Compute metrics from the ``[PERF SUMMARY]`` block.
+
+    ``metrics[name]`` is a dict with keys min / mean / median / p99 / max, all ms.
+    Names are kept as written in the log (wall_ms, gpu_ms, etc.) so they
+    cross-reference 1:1 with the source code in ``MlirCustomOp.cpp``.
+    """
+
+    total_inferences: int = 0
+    metrics: dict[str, dict[str, float]] = field(default_factory=dict)
+
+    METRIC_ORDER = (
+        "wall_ms",
+        "compute_cpu_ms",
+        "gpu_ms",
+        "marshal_in_ms",
+        "marshal_out_ms",
+        "fence_residual_ms",
+    )
+
+    @classmethod
+    def parse(cls, lines: list[str]) -> "PerfSummary":
+        out = cls()
+        for line in lines:
+            if not line.startswith("[PERF SUMMARY]"):
+                continue
+            m = re.match(r"\[PERF SUMMARY\] total_inferences=(\d+)", line)
+            if m:
+                out.total_inferences = int(m.group(1))
+                continue
+            # Format: `[PERF SUMMARY] <name>  min=X  mean=X  median=X  p99=X  max=X`
+            name_m = re.match(r"\[PERF SUMMARY\]\s+(\S+)\s+", line)
+            if not name_m:
+                continue
+            stats = {k: float(v) for k, v in _STAT_RE.findall(line)}
+            if stats:
+                out.metrics[name_m.group(1)] = stats
+        return out
+
+    def __bool__(self) -> bool:
+        return bool(self.metrics)
+
+
+@dataclass
+class OgaHeadline:
+    """``model_benchmark`` stats block (Prompt processing, Token generation, etc.).
+
+    Each section is parsed into a dict with the raw labels as keys (e.g.
+    ``avg_us``, ``avg_tps``, ``p50_us``, ``stddev_us``, ``n``). Sections that
+    were absent in the log resolve to None so ``__bool__`` can gate rendering.
+    """
+
+    batch_size: int = 0
+    prompt_tokens: int = 0
+    tokens_to_generate: int = 0
+    prefill: Optional[dict] = None
+    decode: Optional[dict] = None
+    sampling: Optional[dict] = None
+    e2e: Optional[dict] = None
+    peak_ws_bytes: Optional[int] = None
+
+    # Block header > field name. Headers exactly match what model_benchmark prints.
+    _BLOCKS = {
+        "Prompt processing (time to first token):": "prefill",
+        "Token generation:": "decode",
+        "Token sampling:": "sampling",
+        "E2E generation (entire generation loop):": "e2e",
+    }
+
+    @classmethod
+    def parse(cls, lines: list[str]) -> "OgaHeadline":
+        out = cls()
+        cur_field: Optional[str] = None
+        cur_block: Optional[dict] = None
+
+        # Pre-compile per-row patterns. model_benchmark uses literal tabs
+        # before each row, but we strip leading whitespace before matching.
+        # The unit token (us/ms/tokens/s) is OPTIONAL because the `n` row
+        # has no unit annotation; the non-capturing `(?:...)?` wrapper
+        # lets the regex still match those rows and leaves group(2) as
+        # None, which the dispatch below interprets as the raw-value path.
+        row_re = re.compile(
+            r"^(avg|p50|stddev|n)\s*"
+            r"(?:\((us|ms|tokens/s)\))?"
+            r":\s*"
+            r"(.+?)\s*$"
+        )
+
+        for line in lines:
+            stripped = line.lstrip()
+
+            # Single-line headers and tail rows
+            m = re.match(r"Batch size:\s*(\d+),\s*prompt tokens:\s*(\d+),"
+                         r"\s*tokens to generate:\s*(\d+)", line)
+            if m:
+                out.batch_size = int(m.group(1))
+                out.prompt_tokens = int(m.group(2))
+                out.tokens_to_generate = int(m.group(3))
+                cur_field, cur_block = None, None
+                continue
+
+            m = re.match(r"Peak working set size \(bytes\):\s*(\d+)", line)
+            if m:
+                out.peak_ws_bytes = int(m.group(1))
+                cur_field, cur_block = None, None
+                continue
+
+            # Block-start headers - always unindented
+            if not line.startswith(("\t", " ")):
+                field_name = cls._BLOCKS.get(line.rstrip())
+                if field_name is not None:
+                    cur_field = field_name
+                    cur_block = {}
+                    setattr(out, field_name, cur_block)
+                    continue
+                # Any other unindented line ends the current block
+                cur_field, cur_block = None, None
+                continue
+
+            if cur_block is None:
+                continue
+            m = row_re.match(stripped)
+            if not m:
+                continue
+            label, unit, value = m.group(1), m.group(2), m.group(3)
+            # n is the only non-numeric value (e.g. "3 * 128 token(s)"); keep raw
+            if label == "n":
+                cur_block["n"] = value
+                continue
+            # Numeric - normalize the key (avg > avg_us / avg_tps / avg_ms,
+            # depending on the unit annotation). model_benchmark sometimes
+            # emits multiple `avg` rows in one block (us + tokens/s).
+            if unit == "us":
+                cur_block[f"{label}_us"] = float(value)
+            elif unit == "ms":
+                cur_block[f"{label}_ms"] = float(value)
+            elif unit == "tokens/s":
+                cur_block[f"{label}_tps"] = float(value)
+            else:
+                cur_block[label] = float(value)
+        return out
+
+    @classmethod
+    def from_multimodal_csv(cls, csv_path: Path, reps: int = 1) -> "OgaHeadline":
+        """Synthesize a headline from benchmark_multimodal.py's CSV output.
+
+        benchmark_multimodal.py (the Python OGA bench used for vision/audio
+        models) emits a CSV instead of model_benchmark's stats block, so its
+        logs have no ``Batch size:`` line and ## 1/2/footer would be skipped.
+        This maps the CSV's averaged columns onto the same dict shape
+        ``parse()`` produces, letting the rest of the renderer run unchanged.
+
+        Limitations (the CSV captures averages only, not per-iter dists):
+          * ``p50`` is filled with the average and ``stddev`` with 0.0 -- the
+            real per-call distribution lives in # 4 ([PERF SUMMARY]).
+          * batch_size is hard-coded to 1 (benchmark_multimodal.py is batch-1).
+          * # 2's "OGA + ORT framework overhead" row subtracts the EP wall
+            *median* (mixed across vision/embedding/text Computes for a
+            multimodal run) from this CSV decode latency, so that row is
+            approximate -- see the # 2 notes.
+        """
+        with csv_path.open(newline="") as f:
+            rows = list(_csv.DictReader(f))
+        if not rows:
+            raise ValueError(f"{csv_path} has no data rows")
+        row = rows[-1]
+
+        def num(col: str) -> float:
+            # Tolerant column lookup: exact, else first header containing col.
+            if col in row:
+                return float(row[col])
+            for k, v in row.items():
+                if col.lower() in k.lower():
+                    return float(v)
+            raise KeyError(f"column matching {col!r} not found in {csv_path}")
+
+        out = cls()
+        out.batch_size = 1
+        out.prompt_tokens = int(num("Prompt Length"))
+        out.tokens_to_generate = int(num("Tokens Generated"))
+        # benchmark_multimodal.py times i in [1 .. gen-1] decode tokens.
+        decode_calls = max(out.tokens_to_generate - 1, 1)
+
+        prompt_us = num("Prompt Latency") * 1000.0
+        decode_us = num("Token Generation Latency") * 1000.0
+        sample_us = num("Sampling Latency") * 1000.0
+        wall_ms = num("Wall Clock Time") * 1000.0
+        prefill_tps = (out.prompt_tokens / (prompt_us / 1e6)) if prompt_us else 0.0
+
+        out.prefill = {
+            "avg_us": prompt_us, "p50_us": prompt_us, "stddev_us": 0.0,
+            "n": f"{reps} * {out.prompt_tokens} token(s)", "avg_tps": prefill_tps,
+        }
+        out.decode = {
+            "avg_us": decode_us, "p50_us": decode_us, "stddev_us": 0.0,
+            "n": f"{reps} * {decode_calls} token(s)",
+            "avg_tps": num("Token Generation Throughput"),
+        }
+        out.sampling = {
+            "avg_us": sample_us, "p50_us": sample_us, "stddev_us": 0.0,
+            "n": f"{reps} * 1 token(s)",
+            "avg_tps": num("Sampling Throughput"),
+        }
+        out.e2e = {
+            "avg_ms": wall_ms, "p50_ms": wall_ms, "stddev_ms": 0.0, "n": f"{reps}",
+        }
+        out.peak_ws_bytes = int(num("Memory Usage") * 1024 ** 3)
+        return out
+
+    def __bool__(self) -> bool:
+        return self.batch_size > 0
+
+
+@dataclass
+class PerOpTable:
+    """Last ``[PERF] === ... ===`` block in the log + median GPU TOTAL across run.
+
+    The last block is what users see as "steady-state decode": for a typical
+    OGA run of (warmup x W) + (reps x R) x (1 prefill + N decodes), the last
+    Compute() bracketed by ``[PERF] ===`` borders is the last decode of the
+    last rep -- past warmup, past first-call kernel autotune, past
+    pool-grow. The TOTAL gpu (ms) MEDIAN across ALL Computes in the log
+    (typically several hundred samples for a transformer decoder run) is
+    computed from every TOTAL row and feeds the # 2 breakdown so cold-start
+    outliers don't poison the derived "GPU outside OP_PROFILE" residual.
+    """
+
+    last_block_lines: list[str] = field(default_factory=list)
+    total_gpu_ms_samples: list[float] = field(default_factory=list)
+    # Every [PERF] === block (one per Compute), so --all-ops can render the
+    # vision / embedding / text sub-model tables, not just the last (decode) one.
+    all_blocks: list[list[str]] = field(default_factory=list)
+
+    # TOTAL row format: `[PERF]  TOTAL                          <gpu>      <cpu>`
+    # Trailing two columns are intentionally locked: op_profile.cpp may grow
+    # or shrink intermediate columns (per-op counts, shape tags, ...) but the
+    # last two are always (gpu_ms, cpu_ms). Anchoring on that suffix is
+    # cheaper and more robust than chasing column widths or labels.
+    _TOTAL_RE = re.compile(r"^\[PERF\]\s+TOTAL\s+([\d.]+)\s+([\d.]+)\s*$")
+
+    @classmethod
+    def parse(cls, lines: list[str]) -> "PerOpTable":
+        out = cls()
+        # Find all border line indices, then slice between the last two.
+        border_idx = [i for i, ln in enumerate(lines) if ln.startswith("[PERF] ===")]
+        if len(border_idx) >= 2:
+            top, bot = border_idx[-2], border_idx[-1]
+            out.last_block_lines = lines[top : bot + 1]
+
+        # Blocks come in border pairs (open/close); slice each one out so
+        # --all-ops can show every Compute (vision / embedding / text).
+        for i in range(0, len(border_idx) - 1, 2):
+            out.all_blocks.append(lines[border_idx[i] : border_idx[i + 1] + 1])
+
+        for line in lines:
+            m = cls._TOTAL_RE.match(line)
+            if m:
+                out.total_gpu_ms_samples.append(float(m.group(1)))
+        return out
+
+    @property
+    def total_gpu_median_ms(self) -> Optional[float]:
+        if not self.total_gpu_ms_samples:
+            return None
+        return statistics.median(self.total_gpu_ms_samples)
+
+    def __bool__(self) -> bool:
+        return bool(self.last_block_lines)
+
+
+# --- derived breakdown for # 2 -----------------------------------------------
+
+
+@dataclass
+class DecodeBreakdown:
+    """Row values for # 2 STEADY-STATE DECODE BREAKDOWN.
+
+    All inputs come from independent distributions (OGA self-reports n=381, EP
+    [PERF SUMMARY] medians from n~639 mixed prefill+decode, per-op TOTAL median
+    from the same n samples). Derived rows are therefore approximate at steady
+    state, NOT strict per-call subtractions - this is why every difference
+    clamps to >= 0 instead of letting negative residuals propagate.
+    """
+
+    oga_p50_ms: float
+    sampling_avg_ms: float
+    wall_ms: float
+    marshal_in_ms: float
+    marshal_out_ms: float
+    compute_cpu_ms: float
+    gpu_ms: float
+    fence_ms: float
+    perop_gpu_median_ms: float
+
+    @classmethod
+    def build(cls, head: OgaHeadline, perf: PerfSummary,
+              perop: PerOpTable) -> Optional["DecodeBreakdown"]:
+        if not (head.decode and perf and perop.total_gpu_median_ms is not None):
+            return None
+        oga_p50_us = head.decode.get("p50_us")
+        sample_avg_us = head.sampling.get("avg_us") if head.sampling else 0.0
+        if oga_p50_us is None:
+            return None
+
+        def med(name: str) -> Optional[float]:
+            row = perf.metrics.get(name)
+            return row.get("median") if row else None
+
+        wall = med("wall_ms")
+        cpu = med("compute_cpu_ms")
+        gpu = med("gpu_ms")
+        if wall is None or cpu is None or gpu is None:
+            return None
+
+        return cls(
+            oga_p50_ms=oga_p50_us / 1000.0,
+            sampling_avg_ms=(sample_avg_us or 0.0) / 1000.0,
+            wall_ms=wall,
+            marshal_in_ms=med("marshal_in_ms") or 0.0,
+            marshal_out_ms=med("marshal_out_ms") or 0.0,
+            compute_cpu_ms=cpu,
+            gpu_ms=gpu,
+            fence_ms=med("fence_residual_ms") or 0.0,
+            # Use the SAME (last decode token) block that # 7 prints, so the
+            # # 2 row "GPU: OP_PROFILE kernels < # 7 TOTAL" reconciles exactly
+            # with # 7's TOTAL instead of being a median across all decode
+            # Computes (which differed slightly from the displayed last token).
+            perop_gpu_median_ms=_block_total_gpu(perop.last_block_lines),
+        )
+
+    # -- derived rows (clamp to >= 0 since these are between-distribution diffs)
+    @property
+    def oga_overhead_ms(self) -> float:
+        return max(0.0, self.oga_p50_ms - self.wall_ms)
+
+    @property
+    def other_oga_ms(self) -> float:
+        return max(0.0, self.oga_overhead_ms - self.sampling_avg_ms)
+
+    @property
+    def unprofiled_gpu_ms(self) -> float:
+        return max(0.0, self.gpu_ms - self.perop_gpu_median_ms)
+
+    @property
+    def cpu_overhead_ms(self) -> float:
+        return max(0.0, self.compute_cpu_ms - self.gpu_ms)
+
+
+# --- utilities ---------------------------------------------------------------
+
+
+def human_bytes(b: Optional[int]) -> str:
+    if b is None or b < 0:
+        return "?"
+    units = ["B", "KiB", "MiB", "GiB", "TiB"]
+    val = float(b)
+    i = 0
+    while val >= 1024 and i < len(units) - 1:
+        val /= 1024
+        i += 1
+    return f"{int(val)} {units[i]}" if i == 0 else f"{val:.2f} {units[i]}"
+
+
+def model_name_from_log_path(p: Path) -> str:
+    """`<model>_<tool>_<shape>_p<L>g<G>_<mode>_<ts>.log` -> `<model>`."""
+    stem = p.stem
+    for marker in ("_oga_", "_perftest_"):
+        idx = stem.find(marker)
+        if idx > 0:
+            return stem[:idx]
+    return stem
+
+
+def run_params_from_log_path(p: Path) -> dict:
+    """Extract tool / shape / prompt / gen / mode tags from the log filename.
+
+    Returns whatever it can decode; absent keys are simply missing. Used to
+    populate the identity banner since the bench-wrapper '===' header line is
+    NOT redirected into the log file itself.
+    """
+    out: dict = {}
+    stem = p.stem
+    for marker, key in (("_oga_", "tool"), ("_perftest_", "tool")):
+        if marker in stem:
+            out["tool"] = marker.strip("_")
+            tail = stem.split(marker, 1)[1]
+            parts = tail.split("_")
+            # parts: [shape, "p128g128", mode, date, time] (approx)
+            if parts:
+                out["shape"] = parts[0]
+            for part in parts[1:]:
+                m = re.match(r"p(\d+)g(\d+)", part)
+                if m:
+                    out["prompt"] = int(m.group(1))
+                    out["gen"] = int(m.group(2))
+                elif part in ("none", "perf", "debug"):
+                    out["mode"] = part
+            break
+    return out
+
+
+# --- renderers ---------------------------------------------------------------
+
+
+# ASCII tree glyphs for the # 2 / # 3 call stacks (one place to tweak).
+TREE = {"branch": "+-", "last": "+-", "pipe": "| ", "blank": "  "}
+
+SECTION_RULE = "-" * 74
+
+# Width of the left column in # 2 (label + tree prefix). Picked so the widest
+# label ("model.dll inference_compute()") plus deepest indent (4 levels =
+# "|   |   | ") still fits without wrapping in a standard 100-col terminal.
+LABEL_WIDTH = 42
+
+
+def render_banner(model: str, run_params: dict, perf: PerfSummary, indent: str) -> list[str]:
+    bar = "=" * (74 + len(indent))
+    bits = [f"HIPDNN EP profile  *  {model}"]
+    # Show shape only when it's worth flagging. "dynamic" is the default for
+    # every OGA log this script handles (run_bench.sh rejects --oga --shape
+    # static), and even if the formatter is later wired to perftest dynamic
+    # runs the token would still be redundant - readers assume dynamic. Any
+    # other value (static, future shape modes) IS noteworthy, so it stays.
+    if run_params.get("shape") and run_params["shape"] != "dynamic":
+        bits.append(run_params["shape"])
+    if "prompt" in run_params and "gen" in run_params:
+        bits.append(f"prompt={run_params['prompt']} gen={run_params['gen']}")
+    if perf.total_inferences:
+        # Match the source field name (`total_inferences=` in [PERF SUMMARY])
+        # so anyone who greps either the banner or the raw log finds the same
+        # token. "n=" was ambiguous against # 1's per-block "samples" column
+        # (3 reps, 381 decode tokens, etc.) - readers couldn't tell whether
+        # the banner counted timed-window or whole-run.
+        bits.append(f"inferences={perf.total_inferences}")
+    return [f"{indent}{bar}", f"{indent}  {'  *  '.join(bits)}", f"{indent}{bar}"]
+
+
+def render_section_header(num: int, title: str, subtitle: str, indent: str) -> list[str]:
+    return [
+        f"{indent}  # {num}  {title}  -  {subtitle}",
+        f"{indent}  {SECTION_RULE}",
+    ]
+
+
+def render_section_1_headline(head: OgaHeadline, indent: str) -> list[str]:
+    """# 1 HEADLINE - single five-row table consolidating model_benchmark's four
+    indented blocks (Prompt processing / Token generation / Token sampling /
+    E2E / Peak WS). Throughput in tok/s, p50 in ms, stddev in ms, samples raw.
+
+    Source:        ``OgaHeadline`` -> model_benchmark stats block.
+    Self-gates:    rendered unconditionally when ``head`` is truthy (caller
+                   already skipped the whole report on ``not head``); absent
+                   sub-blocks within head render the literal ``(absent)``.
+    """
+    lines = render_section_header(
+        1, "HEADLINE",
+        f"model_benchmark (batch={head.batch_size}, prompt={head.prompt_tokens}, "
+        f"gen={head.tokens_to_generate})",
+        indent,
+    )
+    # Column widths chosen so all five rows align with the header.
+    fmt = "    {label:<18} {tps:>13}   {p50:>13}   {std:>11}   {n}"
+    lines.append(indent + fmt.format(
+        label="", tps="throughput",
+        p50="p50 latency", std="stddev", n="samples"
+    ).rstrip())
+
+    def row(label: str, block: Optional[dict], lat_unit: str, *, has_tps: bool = True) -> str:
+        if block is None:
+            return indent + f"    {label:<18} (absent)"
+        tps = f"{block.get('avg_tps', 0):.2f} t/s" if has_tps and "avg_tps" in block else "-"
+        p50_key = f"p50_{lat_unit}"
+        p50 = f"{block.get(p50_key, 0):.2f} {lat_unit}" if p50_key in block else "-"
+        std_key = f"stddev_{lat_unit}"
+        std = f"{block.get(std_key, 0):.2f} {lat_unit}" if std_key in block else "-"
+        n = block.get("n", "-")
+        return indent + fmt.format(label=label, tps=tps, p50=p50, std=std, n=n).rstrip()
+
+    lines.append(row("Prefill (TTFT)", head.prefill,  "us"))
+    lines.append(row("Decode",         head.decode,   "us"))
+    lines.append(row("Sampling",       head.sampling, "us"))
+    lines.append(row("E2E generation", head.e2e,      "ms", has_tps=False))
+    lines.append(indent + f"    {'Peak working set':<18} "
+                          f"{human_bytes(head.peak_ws_bytes)} "
+                          f"({head.peak_ws_bytes or '?'} bytes)")
+    return lines
+
+
+def render_section_2_breakdown(bd: DecodeBreakdown, indent: str) -> list[str]:
+    """# 2 STEADY-STATE DECODE BREAKDOWN - drawn as an actual tree.
+
+    Source:        ``DecodeBreakdown`` -> joined OgaHeadline + PerfSummary +
+                   PerOpTable medians. Each row carries a ``< # N`` arrow
+                   pointing to the section that owns its raw number, so a
+                   skeptical reader can always trace a value back one hop.
+    Self-gates:    caller ensures ``bd`` is not None (build() returns None
+                   when any of the three upstream feeds is missing); this
+                   renderer assumes all medians are present.
+
+    Indentation in the tree matches visual depth so readers skimming
+    top-to-bottom never have to count whitespace.
+    """
+    tc = TREE
+    arrow = "<-"
+    lines = render_section_header(
+        3, "STEADY-STATE DECODE BREAKDOWN",
+        "1 decode token, median across run",
+        indent,
+    )
+    lines.append(indent + f"    {'':<{LABEL_WIDTH}} "
+                          f"{'latency':>10}   {'share':>6}   {'source':<20}")
+
+    def row(prefix: str, label: str, ms: float, share: float,
+            src: str = "") -> str:
+        pad = LABEL_WIDTH - len(prefix) - len(label)
+        if pad < 1:
+            pad = 1
+        return (f"{indent}    {prefix}{label}{' ' * pad} "
+                f"{ms:>7.3f} ms   {share:>5.1f} %   {src}").rstrip()
+
+    total = bd.oga_p50_ms
+
+    def pct(x: float) -> float:
+        return 100.0 * x / total if total else 0.0
+
+    # -- Tree row prefixes (hard-coded because the tree shape is fixed).
+    # Each prefix encodes both this row's hook (+- vs +-) and whether each
+    # ancestor at every level above had more siblings (|  ) or was the last
+    # one (3-space blank). Compare against the visual layout below:
+    #
+    #   OGA::GenerateNextToken                       <- root, no prefix
+    #   +- OGA + ORT framework overhead              <- L1 not-last
+    #   |  +- Token sampling                         <- L2 under L1-not-last
+    #   |  +- Other (last L2 under L1-not-last)
+    #   +- EP MlirCustomOp::Compute()                <- L1 LAST (no pipe below)
+    #      +- Marshal in                             <- L2 under L1-LAST
+    #      +- Marshal out
+    #      +- model.dll inference_compute()
+    #      |  +- GPU: OP_PROFILE kernels (sum)       <- L3 under L1-LAST + L2-not-last
+    #      |  +- GPU: unwrapped + glue kernels
+    #      |  +- CPU: host dispatch + sync poll      <- last L3
+    #      +- Trailing fence (hipStreamSync)         <- last L2 under L1-LAST
+    PIPE   = f"{tc['pipe']} "    # "|  " - parent has more siblings below
+    BLANK  = "   "               # parent was last - no pipe through this column
+    BRANCH = f"{tc['branch']} "  # "+- " - this row has siblings below
+    LAST   = f"{tc['last']} "    # "+- " - last sibling at this level
+
+    lines.append(row("", "OGA::GenerateNextToken", bd.oga_p50_ms, 100.0,
+                     f"{arrow} # 1 Decode p50"))
+    lines.append(row(BRANCH, "OGA + ORT framework overhead",
+                     bd.oga_overhead_ms, pct(bd.oga_overhead_ms)))
+    lines.append(row(PIPE + BRANCH, "Token sampling",
+                     bd.sampling_avg_ms, pct(bd.sampling_avg_ms),
+                     f"{arrow} # 1 Sampling avg"))
+    lines.append(row(PIPE + LAST, "Other (IoBinding rebind, etc.)",
+                     bd.other_oga_ms, pct(bd.other_oga_ms)))
+    lines.append(row(LAST, "EP MlirCustomOp::Compute()",
+                     bd.wall_ms, pct(bd.wall_ms),
+                     f"{arrow} # 6 wall_ms"))
+    lines.append(row(BLANK + BRANCH, "Marshal in (input descriptors)",
+                     bd.marshal_in_ms, pct(bd.marshal_in_ms),
+                     f"{arrow} # 6 marshal_in_ms"))
+    lines.append(row(BLANK + BRANCH, "Marshal out (output desc.)",
+                     bd.marshal_out_ms, pct(bd.marshal_out_ms),
+                     f"{arrow} # 6 marshal_out_ms"))
+    lines.append(row(BLANK + BRANCH, "model.dll inference_compute()",
+                     bd.compute_cpu_ms, pct(bd.compute_cpu_ms),
+                     f"{arrow} # 6 compute_cpu_ms"))
+    lines.append(row(BLANK + PIPE + BRANCH, "GPU: OP_PROFILE kernels (sum)",
+                     bd.perop_gpu_median_ms, pct(bd.perop_gpu_median_ms),
+                     f"{arrow} # 7 TOTAL"))
+    lines.append(row(BLANK + PIPE + BRANCH, "GPU: outside # 7 scopes",
+                     bd.unprofiled_gpu_ms, pct(bd.unprofiled_gpu_ms)))
+    lines.append(row(BLANK + PIPE + LAST, "CPU: host dispatch + sync poll",
+                     bd.cpu_overhead_ms, pct(bd.cpu_overhead_ms)))
+    lines.append(row(BLANK + LAST, "Trailing fence (hipStreamSync)",
+                     bd.fence_ms, pct(bd.fence_ms),
+                     f"{arrow} # 6 fence_residual_ms"))
+
+    # Notes for the two "residual" rows that don't have a direct # N cross-ref
+    # (they are subtractive - what's left after the named rows are accounted
+    # for). Without these notes, first-time readers ask "what's in there?" for
+    # both rows. We deliberately do NOT annotate every row - the named ones
+    # speak for themselves once you've followed their # N arrow.
+    lines.append("")
+    lines.append(indent + "    notes:")
+    lines.append(indent + "      - \"GPU: outside # 7 scopes\" = # 6 gpu_ms - # 7 "
+                          "TOTAL: GPU work not bracketed by any")
+    lines.append(indent + "        OP_PROFILE wrapper. Typical sources: MIOpen / "
+                          "hipBLASLt internal helper")
+    lines.append(indent + "        launches, ops lacking an OP_PROFILE scope, "
+                          "hipMemset / glue between ops. If")
+    lines.append(indent + "        this row grows after a runtime change, "
+                          "OP_PROFILE coverage has regressed.")
+    lines.append(indent + "      - \"Other (IoBinding rebind, etc.)\" = # 1 Decode "
+                          "p50 - sampling - EP wall: OGA")
+    lines.append(indent + "        framework overhead between Generator steps. "
+                          "Dominated by IoBinding's per-token")
+    lines.append(indent + "        rebind of all input/output tensors (scales "
+                          "with KV buffer size, not seq len).")
+    return lines
+
+
+# --- per-Compute samples + prefill/decode classification ---------------------
+
+# One line per Compute(), emitted by PerfCollector::record (MlirCustomOp.cpp).
+# Carries all six metrics for a SINGLE call -- unlike [PERF SUMMARY], which is
+# pre-aggregated across every Compute (prefill + decode + vision + ...) and so
+# cannot be re-split by stage. We re-derive per-stage distributions from these.
+_PERCALL_RE = re.compile(
+    r"\[PERF\] #(\d+) wall=([\d.]+) marshal_in=([\d.]+) marshal_out=([\d.]+) "
+    r"compute_cpu=([\d.]+) gpu=([\d.]+) fence_residual=([\d.]+)"
+)
+
+
+@dataclass
+class ComputeSample:
+    """One Compute() call: its six metrics + its [PERF] === op block + stage."""
+
+    wall_ms: float
+    marshal_in_ms: float
+    marshal_out_ms: float
+    compute_cpu_ms: float
+    gpu_ms: float
+    fence_residual_ms: float
+    block: list[str] = field(default_factory=list)
+    stage: str = "prefill"  # "prefill" | "decode"
+
+
+def _classify_stage(block: list[str]) -> str:
+    """prefill vs decode from the op block's sequence length.
+
+    Decode processes exactly one new token, so its attention / matmul shapes
+    carry ``sq=1,`` (gqa) or ``m=1,`` (matmul_nbits). Everything else --
+    text prefill (``sq=301,``), the vision encoder (``sq=1196,`` MHA), and
+    the embedding/glue Computes -- is the one-time TTFT work, bucketed as
+    prefill. This is the standard autoregressive single-token tell; the
+    ``sq=1,``/``m=1,`` trailing comma avoids matching ``sq=1196`` / ``m=1196``.
+    """
+    text = "\n".join(block)
+    return "decode" if ("sq=1," in text or "m=1," in text) else "prefill"
+
+
+# Prefill sub-model buckets, by op signature (Qwen-VL-shaped; the text-prefill
+# / vision tells are fairly general, embedding/glue is a catch-all):
+#   vision       -> multi_head_attention (the ViT encoder)
+#   text_prefill -> matmul_nbits (the quantized LLM prefill)
+#   embedding    -> image-feature scatter (nonzero / scatter_nd)
+#   glue         -> everything else (tiny inter-op Computes)
+def _prefill_substage(block: list[str]) -> str:
+    text = "\n".join(block)
+    if "multi_head_attention" in text:
+        return "vision"
+    if "matmul_nbits" in text:
+        return "text_prefill"
+    if "nonzero" in text or "scatter_nd" in text:
+        return "embedding"
+    return "glue"
+
+
+def parse_compute_samples(lines: list[str]) -> list[ComputeSample]:
+    """Pair each ``[PERF] #N`` metric line with its following ``[PERF] ===``
+    block (same Compute, printed in order) and classify the stage.
+
+    Pairing is by LINE POSITION -- each metric takes the next op-block that
+    *opens after* it -- NOT by sequential index. This matters when a metric
+    line is dropped: e.g. a console-wrapped ``[PERF] #1 wall=...`` line whose
+    ``fence_residual=`` spilled onto the next physical line no longer matches
+    ``_PERCALL_RE``, so it's missing from the metric list. With index pairing
+    that single drop shifts EVERY subsequent metric onto the previous Compute's
+    block, misclassifying a cold multi-second prefill Compute as a "decode"
+    token (and blowing up the # 2 decode share to thousands of percent).
+    Positional pairing instead just skips the one orphaned Compute.
+    """
+    metric_pos = [(i, m) for i, ln in enumerate(lines)
+                  if (m := _PERCALL_RE.search(ln))]
+    border_idx = [i for i, ln in enumerate(lines) if ln.startswith("[PERF] ===")]
+    pairs = [(border_idx[j], border_idx[j + 1])
+             for j in range(0, len(border_idx) - 1, 2)]
+    out: list[ComputeSample] = []
+    pi = 0
+    for pos, m in metric_pos:
+        # Advance past any op-block that opened before this metric line (e.g.
+        # the very first Compute's block, when its own metric line was dropped).
+        while pi < len(pairs) and pairs[pi][0] < pos:
+            pi += 1
+        blk = lines[pairs[pi][0]: pairs[pi][1] + 1] if pi < len(pairs) else []
+        if pi < len(pairs):
+            pi += 1
+        s = ComputeSample(
+            wall_ms=float(m.group(2)), marshal_in_ms=float(m.group(3)),
+            marshal_out_ms=float(m.group(4)), compute_cpu_ms=float(m.group(5)),
+            gpu_ms=float(m.group(6)), fence_residual_ms=float(m.group(7)),
+            block=blk,
+        )
+        s.stage = _classify_stage(blk)
+        out.append(s)
+    return out
+
+
+def stage_perf(samples: list[ComputeSample]) -> PerfSummary:
+    """Build a PerfSummary (min/mean/median/p99/max per metric) from a list of
+    Computes -- the per-stage analog of the EP's all-Computes [PERF SUMMARY]."""
+    ps = PerfSummary()
+    ps.total_inferences = len(samples)
+    for name in PerfSummary.METRIC_ORDER:
+        vals = sorted(getattr(s, name) for s in samples)
+        if not vals:
+            continue
+        n = len(vals)
+        ps.metrics[name] = {
+            "min": vals[0], "max": vals[-1],
+            "mean": sum(vals) / n,
+            "median": statistics.median(vals),
+            "p99": vals[max(0, int(round(0.99 * (n - 1))))],
+        }
+    return ps
+
+
+# Op rows in a [PERF] === block. Parent rows are indented 2 spaces after the
+# tag, shape sub-rows 4 spaces; both end in (calls, gpu, cpu[, gpu%]). The
+# label is captured lazily because shape labels can contain spaces (e.g.
+# "n=8192 rank=3"). TOTAL/header rows don't match (no integer `calls` column).
+_OP_PARENT_RE = re.compile(
+    r"^\[PERF\]  (\S.*?)\s+(\d+)\s+(\S+)\s+(\S+)(?:\s+\S+)?\s*$")
+_OP_SHAPE_RE = re.compile(
+    r"^\[PERF\]    (\S.*?)\s+(\d+)\s+(\S+)\s+(\S+)(?:\s+\S+)?\s*$")
+
+
+def _accum(slot: list, gpu_tok: str, cpu_tok: str) -> None:
+    for idx, tok in ((1, gpu_tok), (2, cpu_tok)):
+        if tok != "n/a":
+            try:
+                slot[idx] += float(tok)
+            except ValueError:
+                pass
+
+
+_PREFILL_SUBS = ("vision", "embedding", "text_prefill", "glue")
+_PREFILL_METRICS = ("wall", "mi", "mo", "cpu", "gpu", "fence", "optot")
+
+
+def _segment_prefill_generations(samples: list[ComputeSample]) -> list[dict]:
+    """Segment prefill Computes into generations -- a new generation begins at
+    each vision-substage Compute (the ViT runs once per rep) -- summing each
+    sub-stage's metrics per generation.
+
+    Shared by the # 3 waterfall and the # 5 per-generation normalization so
+    their generation counts can NEVER disagree. (They previously could: when a
+    first metric line is dropped/wrapped, the first parsed prefill Compute may
+    be non-vision, which opens a leading generation that a naive vision-count
+    would miss -- off-by-one against # 3.)
+    """
+    def blank() -> dict:
+        return {sub: {m: 0.0 for m in _PREFILL_METRICS}
+                for sub in _PREFILL_SUBS}
+
+    gens: list[dict] = []
+    cur: Optional[dict] = None
+    for s in samples:
+        sub = _prefill_substage(s.block) if s.stage == "prefill" else None
+        if sub == "vision":
+            if cur is not None:
+                gens.append(cur)
+            cur = blank()
+        if s.stage == "prefill":
+            if cur is None:
+                cur = blank()
+            d = cur[sub]
+            d["wall"] += s.wall_ms
+            d["mi"] += s.marshal_in_ms
+            d["mo"] += s.marshal_out_ms
+            d["cpu"] += s.compute_cpu_ms
+            d["gpu"] += s.gpu_ms
+            d["fence"] += s.fence_residual_ms
+            d["optot"] += _block_total_gpu(s.block)
+    if cur is not None and any(d["wall"] for d in cur.values()):
+        gens.append(cur)
+    return gens
+
+
+def _count_prefill_generations(samples: list[ComputeSample]) -> int:
+    """Generation count from the shared segmentation (>= 1)."""
+    return len(_segment_prefill_generations(samples)) or 1
+
+
+def render_perop_aggregate(blocks: list[list[str]], indent: str, *,
+                           num: int, subtitle: str,
+                           generations: int = 1) -> list[str]:
+    """Sum each op's gpu/cpu/calls across every block in a stage, keeping the
+    op -> shape hierarchy so the discriminating shapes stay visible.
+
+    Used for the PREFILL per-op view: a stage's prefill work spans several
+    Computes (vision encoder + embedding + text prefill), so a single block is
+    not representative -- the sum is the true "where did TTFT go". The shape
+    sub-rows are preserved (e.g. matmul_nbits -> m=301,... for text prefill)
+    so the stage is identifiable. Cold-start/autotune is part of prefill and
+    intentionally included.
+    """
+    # name -> [calls, gpu, cpu, {shape: [calls, gpu, cpu]}]
+    agg: dict[str, list] = {}
+    for blk in blocks:
+        cur: Optional[list] = None
+        for ln in blk:
+            mp = _OP_PARENT_RE.match(ln)
+            if mp and mp.group(1).strip() != "TOTAL":
+                cur = agg.setdefault(mp.group(1).strip(), [0, 0.0, 0.0, {}])
+                cur[0] += int(mp.group(2))
+                _accum(cur, mp.group(3), mp.group(4))
+                continue
+            ms = _OP_SHAPE_RE.match(ln)
+            if ms and cur is not None:
+                e = cur[3].setdefault(ms.group(1).strip(), [0, 0.0, 0.0])
+                e[0] += int(ms.group(2))
+                _accum(e, ms.group(3), ms.group(4))
+    if not agg:
+        return []
+    # Normalize GPU/CPU ms to PER GENERATION so this table's TOTAL reconciles
+    # with the per-generation # 3 waterfall that references it (# 3 is one
+    # generation; the raw sum here spans every rep). `calls` stays a run total
+    # (the exact launch count); only the time columns are divided.
+    div = generations if generations and generations > 0 else 1
+    title = ("PER-OP GPU BREAKDOWN (per generation)" if div > 1
+             else "PER-OP GPU BREAKDOWN (stage total)")
+    lines = render_section_header(num, title, subtitle, indent)
+    tot_gpu = sum(v[1] for v in agg.values())
+    tot_cpu = sum(v[2] for v in agg.values())
+    lines.append(indent + f"    {'op / shape':<40}{'calls':>7}{'gpu (ms)':>10}"
+                          f"{'cpu (ms)':>10}{'gpu %':>7}")
+    for name, (calls, gpu, cpu, shapes) in sorted(
+            agg.items(), key=lambda kv: kv[1][1], reverse=True):
+        pct = (100.0 * gpu / tot_gpu) if tot_gpu else 0.0
+        lines.append(indent + f"    {name:<40}{calls:>7}{gpu / div:>10.1f}"
+                              f"{cpu / div:>10.1f}{pct:>6.1f}%")
+        for shp, (scalls, sgpu, scpu) in sorted(
+                shapes.items(), key=lambda kv: kv[1][1], reverse=True):
+            spct = (100.0 * sgpu / tot_gpu) if tot_gpu else 0.0
+            lines.append(indent + f"      {shp:<38}{scalls:>7}{sgpu / div:>10.1f}"
+                                  f"{scpu / div:>10.1f}{spct:>6.1f}%")
+    lines.append(indent + f"    {'TOTAL':<40}{'':>7}"
+                          f"{tot_gpu / div:>10.1f}{tot_cpu / div:>10.1f}")
+    return lines
+
+
+def stage_perop(samples: list[ComputeSample]) -> PerOpTable:
+    """Build a PerOpTable for a stage: representative (last) block + the
+    stage's TOTAL gpu samples (feeds # 2's GPU-median residual)."""
+    pop = PerOpTable()
+    blocks = [s.block for s in samples if s.block]
+    if blocks:
+        pop.last_block_lines = blocks[-1]
+        pop.all_blocks = blocks
+    for blk in blocks:
+        for ln in blk:
+            m = PerOpTable._TOTAL_RE.match(ln)
+            if m:
+                pop.total_gpu_ms_samples.append(float(m.group(1)))
+    return pop
+
+
+def _block_total_gpu(block: list[str]) -> float:
+    """The op_profile TOTAL gpu (ms) for one [PERF] === block, else 0."""
+    for ln in block:
+        m = PerOpTable._TOTAL_RE.match(ln)
+        if m:
+            return float(m.group(1))
+    return 0.0
+
+
+def render_prefill_breakdown(samples: list[ComputeSample], head: OgaHeadline,
+                             indent: str, *, num: int) -> list[str]:
+    """Prefill waterfall: split TTFT's EP work into vision / embedding /
+    text-prefill / glue, and give the two big sub-models (vision, text-prefill)
+    a # 2-style call stack (marshal -> model.dll compute [GPU op_profile / GPU
+    outside / CPU dispatch] -> fence).
+
+    All values are the MEDIAN across generations so the one cold warmup
+    generation drops out (needs several reps -- e.g. -r 10 -- to be meaningful).
+    Generations are segmented at each vision Compute (every rep re-runs the
+    full vision->embedding->text-prefill->decode pipeline); per generation we
+    sum each sub-stage's metrics, then take the median generation.
+
+    Rows sum to the median per-generation EP prefill wall, NOT to TTFT:
+    benchmark_multimodal.py books text prefill under its own "sampling" phase,
+    so its phase boundaries don't map 1:1 onto these EP sub-stages. TTFT is a
+    reference line only.
+    """
+    prefill = [s for s in samples if s.stage == "prefill"]
+    if not prefill:
+        return []
+
+    subs = _PREFILL_SUBS
+    metrics = _PREFILL_METRICS
+    gens = _segment_prefill_generations(samples)
+    if not gens:
+        return []
+
+    med = {sub: {m: statistics.median([g[sub][m] for g in gens]) for m in metrics}
+           for sub in subs}
+    total = sum(med[sub]["wall"] for sub in subs)
+    if total <= 0:
+        return []
+
+    tc = TREE
+    arrow = "<-"
+    PIPE, BLANK, BRANCH, LAST = (f"{tc['pipe']} ", "   ",
+                                 f"{tc['branch']} ", f"{tc['last']} ")
+    lines = render_section_header(
+        num, "PREFILL STAGE BREAKDOWN",
+        f"median of {len(gens)} generation(s); EP wall per sub-model + call stack",
+        indent)
+    lines.append(indent + f"    {'':<{LABEL_WIDTH}} {'latency':>10}   {'share':>6}"
+                          f"   source")
+
+    def row(prefix: str, label: str, ms: float, src: str = "") -> str:
+        pad = max(1, LABEL_WIDTH - len(prefix) - len(label))
+        share = 100.0 * ms / total if total else 0.0
+        return (f"{indent}    {prefix}{label}{' ' * pad} "
+                f"{ms:>7.3f} ms   {share:>5.1f} %   {src}").rstrip()
+
+    def callstack(sub: str, is_last: bool) -> list[str]:
+        d = med[sub]
+        hook = LAST if is_last else BRANCH
+        cont = BLANK if is_last else PIPE
+        gpu_outside = max(0.0, d["gpu"] - d["optot"])
+        cpu_dispatch = max(0.0, d["cpu"] - d["gpu"])
+        return [
+            row(hook, _SUBLABEL[sub], d["wall"]),
+            row(cont + BRANCH, "Marshal in + out", d["mi"] + d["mo"]),
+            row(cont + BRANCH, "model.dll compute()", d["cpu"]),
+            row(cont + PIPE + BRANCH, "GPU: OP_PROFILE kernels", d["optot"],
+                f"{arrow} # 5 per-op"),
+            row(cont + PIPE + BRANCH, "GPU: outside scopes", gpu_outside),
+            row(cont + PIPE + LAST, "CPU: host dispatch", cpu_dispatch),
+            row(cont + LAST, "Trailing fence", d["fence"]),
+        ]
+
+    lines.append(row("", "EP prefill wall (per generation)", total))
+    # Two big sub-models get a call stack (largest wall first); embedding+glue
+    # are tiny -> one combined leaf, always last.
+    big = sorted(("vision", "text_prefill"), key=lambda s: med[s]["wall"],
+                 reverse=True)
+    for sub in big:
+        lines += callstack(sub, is_last=False)
+    eg = med["embedding"]["wall"] + med["glue"]["wall"]
+    lines.append(row(LAST, "Embedding + glue (image-feature scatter, etc.)", eg))
+
+    ttft_us = head.prefill.get("avg_us") if (head and head.prefill) else None
+    if ttft_us:
+        lines.append("")
+        lines.append(indent + f"    reference: CSV TTFT = {ttft_us / 1000.0:.1f} ms "
+                              "(OGA end-to-end prompt latency).")
+        lines.append(indent + "    NOTE: rows sum to EP prefill wall, not TTFT --"
+                              " benchmark_multimodal.py books text")
+        lines.append(indent + "    prefill under its 'sampling' phase, so TTFT's"
+                              " phase split differs from these EP sub-stages.")
+    return lines
+
+
+_SUBLABEL = {
+    "vision": "Vision encoder (ViT)",
+    "text_prefill": "Text prefill (LLM prompt)",
+}
+
+
+def render_section_3_perop(perop: PerOpTable, indent: str, *,
+                           num: int = 3,
+                           subtitle: str = "last Compute() = steady-state "
+                                           "decode token") -> list[str]:
+    """PER-OP GPU BREAKDOWN - passes the runtime's own [PERF] table through
+    verbatim.
+
+    Source:        ``PerOpTable.last_block_lines`` -> the last
+                   ``[PERF] === ... ===`` block emitted by
+                   ``op_profile_resolve_and_print`` in
+                   ``lib/Runtime/op_profile.cpp``.
+    Self-gates:    returns ``[]`` when ``perop`` is empty (the log was run
+                   with ``HIPDNN_EP_PERF`` unset or no per-op table was
+                   ever printed).
+
+    ``num`` / ``subtitle`` let the caller render one of these per stage
+    (prefill / decode) with a stage-specific header.
+
+    The op_profile.cpp formatter already aligns columns nicely, so we only
+    strip the ``[PERF] `` prefix (the section header tells the reader which
+    subsystem these rows came from) and add the section frame.
+    """
+    if not perop:
+        return []
+    lines = render_section_header(num, "PER-OP GPU BREAKDOWN", subtitle, indent)
+    blocks = [perop.last_block_lines]
+    for block in blocks:
+        for line in block:
+            # Drop the leading `[PERF] ` tag; the section header tells the reader
+            # which subsystem these rows came from.
+            body = line.removeprefix("[PERF] ")
+            lines.append(f"{indent}    {body}")
+    return lines
+
+
+def render_section_4_distribution(perf: PerfSummary, indent: str, *,
+                                  num: int = 4,
+                                  subtitle: Optional[str] = None) -> list[str]:
+    """# 4 PER-CALL DISTRIBUTION - six metrics x five stats, column-aligned.
+
+    Source:        ``PerfSummary.metrics`` -> the ``[PERF SUMMARY]`` block
+                   emitted by ``PerfCollector::dump_summary`` at DLL unload
+                   (see ``backend-mlir-compiler/.../MlirCustomOp.cpp``).
+    Self-gates:    returns ``[]`` when ``perf`` is empty (no [PERF SUMMARY]
+                   block in the log -- typically a ``--mode none`` run).
+
+    The cold-start note at the bottom is intentional: # 4's ``max`` column
+    almost always shows a multi-second outlier (the very first Compute()
+    that does kernel autotune + GPU pool first-grow) and this surprises
+    readers who haven't seen the report before. Documenting it in-band
+    pre-empts the predictable "why is max 1000x the median?" question.
+    """
+    if not perf:
+        return []
+    lines = render_section_header(
+        num, "PER-CALL DISTRIBUTION",
+        subtitle if subtitle is not None else
+        f"EP MlirCustomOp::Compute() over {perf.total_inferences} invocations (all ms)",
+        indent,
+    )
+    lines.append(indent + f"    {'':<18} {'min':>10} {'median':>10}"
+                          f" {'p99':>10} {'max':>12}")
+    for name in PerfSummary.METRIC_ORDER:
+        stats = perf.metrics.get(name)
+        if not stats:
+            continue
+        lines.append(
+            indent + f"    {name:<18} "
+                     f"{stats['min']:>10.3f} {stats['median']:>10.3f}"
+                     f" {stats['p99']:>10.3f} {stats['max']:>12.3f}"
+        )
+    # The two-line note below catches the two most-common "wait, what?" moments
+    # readers have when first comparing # 4 against # 1:
+    #   (a) why is `max` 1000x the median? -> cold start; see also # 2 caveat
+    #   (b) why doesn't this count match # 1's "samples" column? -> different
+    #       windows: # 1 reports only OGA's timed iterations, # 4 reports every
+    #       EP call including warmup + verbose-mode display generation.
+    lines.append(indent + "    notes:")
+    lines.append(indent + "      - `max` includes first-Compute cold start "
+                          "(kernel autotune + pool grow);")
+    lines.append(indent + "        # 2 uses median to skip those outliers.")
+    lines.append(indent + "      - this count covers ALL EP calls (warmup + "
+                          "verbose-display + timed reps);")
+    lines.append(indent + "        # 1's per-block `samples` column is the "
+                          "OGA-timed subset only.")
+    return lines
+
+
+def render_footer(head: OgaHeadline, indent: str) -> list[str]:
+    """Single greppable tail line - public contract; keep stable across runs.
+
+    Output format (treat as public API for downstream tooling):
+
+        [OGA] prefill=<P> tok/s  TTFT=<T> ms  decode=<D> tok/s  \\
+              peak_WS=<H> (<B> bytes)
+
+    Where <P>/<D> are floats in tokens/s, <T> is a float in ms, <H> is the
+    human-readable peak working-set (e.g. "1.34 GiB"), and <B> is the raw
+    byte count. Tools may grep for ``^\\[OGA\\] prefill=`` to locate the
+    line and parse the named fields. Peak working-set bytes are kept in
+    parens for greppability even though the GiB form is shown first.
+    """
+    if not head:
+        return []
+    bar = "=" * (74 + len(indent))
+    prefill_tps = head.prefill.get("avg_tps") if head.prefill else None
+    decode_tps = head.decode.get("avg_tps") if head.decode else None
+    # TTFT is the raw prompt-processing wall time -- `prefill=... tok/s` is
+    # derived from it (prompt_tokens / TTFT_seconds) but the time itself is
+    # the more directly meaningful number when comparing across prompt
+    # lengths or against external baselines. Use `avg_us` (matching what
+    # `prefill tok/s` is derived from) for internal consistency.
+    ttft_us = head.prefill.get("avg_us") if head.prefill else None
+    ttft_str = f"{ttft_us / 1000.0:.2f} ms" if ttft_us else "?"
+    peak_bytes = head.peak_ws_bytes if head.peak_ws_bytes is not None else "?"
+    return [
+        f"{indent}{bar}",
+        f"{indent}  [OGA] prefill={prefill_tps or '?'} tok/s  "
+        f"TTFT={ttft_str}  "
+        f"decode={decode_tps or '?'} tok/s  "
+        f"peak_WS={human_bytes(head.peak_ws_bytes)} ({peak_bytes} bytes)",
+        f"{indent}{bar}",
+    ]
+
+
+# --- main --------------------------------------------------------------------
+
+
+def _read_log_text(log_path: Path) -> str:
+    """Decode a log robustly. PowerShell `Tee-Object` writes UTF-16LE (with
+    BOM); plain redirects/our runner write UTF-8. Detect the BOM (or a high
+    NUL ratio for BOM-less UTF-16) so we never silently produce garbage."""
+    raw = log_path.read_bytes()
+    if raw[:2] in (b"\xff\xfe", b"\xfe\xff"):
+        return raw.decode("utf-16")
+    if raw[:3] == b"\xef\xbb\xbf":
+        return raw.decode("utf-8-sig")
+    if raw.count(b"\x00") > len(raw) // 4:
+        return raw.decode("utf-16", errors="replace")
+    return raw.decode("utf-8", errors="replace")
+
+
+def render_report(log_path: Path, *, show_banner: bool = True, indent: str = "",
+                  csv_path: Optional[Path] = None, reps: int = 1) -> str:
+    lines = _read_log_text(log_path).splitlines()
+
+    head = OgaHeadline.parse(lines)
+
+    # When a benchmark_multimodal.py CSV is supplied and the log itself has no
+    # model_benchmark stats block, synthesize the headline from the CSV so
+    # ## 1/2/footer (TTFT/TPS + OGA/ORT flow overhead) render. A real
+    # model_benchmark block in the log always wins.
+    if csv_path is not None and not head:
+        head = OgaHeadline.from_multimodal_csv(csv_path, reps=reps)
+
+    # Split every Compute() into prefill vs decode, then recompute the per-call
+    # distribution + per-op table PER STAGE. This is the fix for mixing: the
+    # EP's single [PERF SUMMARY] pools prefill (huge, with JIT/vision) and
+    # decode (small) into one median, so # 2's "EP wall" was wrong. Re-deriving
+    # decode-only medians from the raw [PERF] #N lines makes the OGA/ORT
+    # overhead (# 2) honest.
+    samples = parse_compute_samples(lines)
+    prefill = [s for s in samples if s.stage == "prefill"]
+    decode = [s for s in samples if s.stage == "decode"]
+
+    if not (head or samples):
+        # Nothing parseable - likely a failed run. Caller prints a raw tail.
+        return ""
+
+    # # 2 uses the DECODE-stage wall median (not the all-Compute mix).
+    dec_perf = stage_perf(decode)
+    dec_perop = stage_perop(decode)
+    breakdown = DecodeBreakdown.build(head, dec_perf, dec_perop) if decode else None
+
+    out: list[str] = []
+    model = model_name_from_log_path(log_path)
+    run_params = run_params_from_log_path(log_path)
+
+    if show_banner:
+        out += render_banner(model, run_params, stage_perf(samples), indent)
+        out.append("")
+
+    if head:
+        out += render_section_1_headline(head, indent)
+        out.append("")
+
+    # # 2 PREFILL breakdown -- chronologically first (prefill precedes decode).
+    if prefill:
+        wf = render_prefill_breakdown(samples, head, indent, num=2)
+        if wf:
+            out += wf
+            out.append("")
+
+    # # 3 DECODE breakdown.
+    if breakdown is not None:
+        out += render_section_2_breakdown(breakdown, indent)
+        out.append("")
+
+    # # 4/5 PREFILL dist + per-op, # 6/7 DECODE dist + per-op -- each stage
+    # from its own Computes only.
+    if prefill:
+        out += render_section_4_distribution(
+            stage_perf(prefill), indent, num=4,
+            subtitle=f"PREFILL stage -- {len(prefill)} Compute(s) "
+                     "(vision + embedding + text prefill), all ms")
+        out.append("")
+        # Prefill spans multiple Computes per generation -> sum per-op across
+        # them, then normalize to per-generation so the TOTAL matches # 2.
+        n_gen = _count_prefill_generations(samples)
+        out += render_perop_aggregate(
+            [s.block for s in prefill if s.block], indent, num=5,
+            generations=n_gen,
+            subtitle=f"gpu/cpu per generation (avg over {n_gen} gen(s)); "
+                     f"calls = run total over {len(prefill)} prefill Compute(s)")
+        out.append("")
+    if decode:
+        out += render_section_4_distribution(
+            dec_perf, indent, num=6,
+            subtitle=f"DECODE stage -- {len(decode)} Compute(s) "
+                     "(steady-state tokens), all ms")
+        out.append("")
+        # Decode is per-token steady state -> show the last (clean) token, not
+        # a sum (which would fold in the cold first-token LM-head autotune).
+        out += render_section_3_perop(
+            dec_perop, indent, num=7,
+            subtitle="representative = last decode token (steady state)")
+        out.append("")
+
+    if show_banner:
+        out += render_footer(head, indent)
+
+    # Trim trailing blank line for cleaner embedding in bash output.
+    while out and out[-1] == "":
+        out.pop()
+    return "\n".join(out)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("log", type=Path, help="Path to a HIPDNN EP / OGA bench log")
+    p.add_argument("csv", type=Path, nargs="?", default=None,
+                   help="Optional benchmark_multimodal.py CSV. When the log has "
+                        "no model_benchmark stats block (e.g. multimodal Python "
+                        "runs), the headline (# 1 TTFT/TPS), # 2 OGA/ORT flow "
+                        "overhead, and footer are synthesized from this CSV.")
+    p.add_argument("--reps", type=int, default=1,
+                   help="Repetitions used in the bench (matches "
+                        "benchmark_multimodal.py -r); only labels the CSV-derived "
+                        "`samples` column (default: 1)")
+    p.add_argument("--no-banner", action="store_true",
+                   help="Omit the top/bottom identity banner")
+    p.add_argument("--indent", type=int, default=0,
+                   help="Indent every output line by N spaces (default: 0)")
+    args = p.parse_args(argv)
+
+    if not args.log.is_file():
+        print(f"error: log not found: {args.log}", file=sys.stderr)
+        return 1
+    if args.csv is not None and not args.csv.is_file():
+        print(f"error: csv not found: {args.csv}", file=sys.stderr)
+        return 1
+
+    report = render_report(
+        args.log,
+        show_banner=not args.no_banner,
+        indent=" " * args.indent,
+        csv_path=args.csv,
+        reps=args.reps,
+    )
+    if not report:
+        print(f"warning: log has no parseable EP perf streams: {args.log}",
+              file=sys.stderr)
+        return 2
+    print(report)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/perf-report/perf_multimodal_report.py
+++ b/tools/perf-report/perf_multimodal_report.py
@@ -49,6 +49,7 @@ USAGE
     perf_multimodal_report.py <log-file> --no-banner           # CI embed
     perf_multimodal_report.py <log-file> --indent 2            # indent N
 """
+
 from __future__ import annotations
 
 import argparse
@@ -144,7 +145,6 @@ class OgaHeadline:
     @classmethod
     def parse(cls, lines: list[str]) -> "OgaHeadline":
         out = cls()
-        cur_field: Optional[str] = None
         cur_block: Optional[dict] = None
 
         # Pre-compile per-row patterns. model_benchmark uses literal tabs
@@ -164,31 +164,33 @@ class OgaHeadline:
             stripped = line.lstrip()
 
             # Single-line headers and tail rows
-            m = re.match(r"Batch size:\s*(\d+),\s*prompt tokens:\s*(\d+),"
-                         r"\s*tokens to generate:\s*(\d+)", line)
+            m = re.match(
+                r"Batch size:\s*(\d+),\s*prompt tokens:\s*(\d+),"
+                r"\s*tokens to generate:\s*(\d+)",
+                line,
+            )
             if m:
                 out.batch_size = int(m.group(1))
                 out.prompt_tokens = int(m.group(2))
                 out.tokens_to_generate = int(m.group(3))
-                cur_field, cur_block = None, None
+                cur_block = None
                 continue
 
             m = re.match(r"Peak working set size \(bytes\):\s*(\d+)", line)
             if m:
                 out.peak_ws_bytes = int(m.group(1))
-                cur_field, cur_block = None, None
+                cur_block = None
                 continue
 
             # Block-start headers - always unindented
             if not line.startswith(("\t", " ")):
                 field_name = cls._BLOCKS.get(line.rstrip())
                 if field_name is not None:
-                    cur_field = field_name
                     cur_block = {}
                     setattr(out, field_name, cur_block)
                     continue
                 # Any other unindented line ends the current block
-                cur_field, cur_block = None, None
+                cur_block = None
                 continue
 
             if cur_block is None:
@@ -262,23 +264,33 @@ class OgaHeadline:
         prefill_tps = (out.prompt_tokens / (prompt_us / 1e6)) if prompt_us else 0.0
 
         out.prefill = {
-            "avg_us": prompt_us, "p50_us": prompt_us, "stddev_us": 0.0,
-            "n": f"{reps} * {out.prompt_tokens} token(s)", "avg_tps": prefill_tps,
+            "avg_us": prompt_us,
+            "p50_us": prompt_us,
+            "stddev_us": 0.0,
+            "n": f"{reps} * {out.prompt_tokens} token(s)",
+            "avg_tps": prefill_tps,
         }
         out.decode = {
-            "avg_us": decode_us, "p50_us": decode_us, "stddev_us": 0.0,
+            "avg_us": decode_us,
+            "p50_us": decode_us,
+            "stddev_us": 0.0,
             "n": f"{reps} * {decode_calls} token(s)",
             "avg_tps": num("Token Generation Throughput"),
         }
         out.sampling = {
-            "avg_us": sample_us, "p50_us": sample_us, "stddev_us": 0.0,
+            "avg_us": sample_us,
+            "p50_us": sample_us,
+            "stddev_us": 0.0,
             "n": f"{reps} * 1 token(s)",
             "avg_tps": num("Sampling Throughput"),
         }
         out.e2e = {
-            "avg_ms": wall_ms, "p50_ms": wall_ms, "stddev_ms": 0.0, "n": f"{reps}",
+            "avg_ms": wall_ms,
+            "p50_ms": wall_ms,
+            "stddev_ms": 0.0,
+            "n": f"{reps}",
         }
-        out.peak_ws_bytes = int(num("Memory Usage") * 1024 ** 3)
+        out.peak_ws_bytes = int(num("Memory Usage") * 1024**3)
         return out
 
     def __bool__(self) -> bool:
@@ -367,8 +379,9 @@ class DecodeBreakdown:
     perop_gpu_median_ms: float
 
     @classmethod
-    def build(cls, head: OgaHeadline, perf: PerfSummary,
-              perop: PerOpTable) -> Optional["DecodeBreakdown"]:
+    def build(
+        cls, head: OgaHeadline, perf: PerfSummary, perop: PerOpTable
+    ) -> Optional["DecodeBreakdown"]:
         if not (head.decode and perf and perop.total_gpu_median_ms is not None):
             return None
         oga_p50_us = head.decode.get("p50_us")
@@ -487,7 +500,9 @@ SECTION_RULE = "-" * 74
 LABEL_WIDTH = 42
 
 
-def render_banner(model: str, run_params: dict, perf: PerfSummary, indent: str) -> list[str]:
+def render_banner(
+    model: str, run_params: dict, perf: PerfSummary, indent: str
+) -> list[str]:
     bar = "=" * (74 + len(indent))
     bits = [f"HIPDNN EP profile  *  {model}"]
     # Show shape only when it's worth flagging. "dynamic" is the default for
@@ -509,7 +524,9 @@ def render_banner(model: str, run_params: dict, perf: PerfSummary, indent: str) 
     return [f"{indent}{bar}", f"{indent}  {'  *  '.join(bits)}", f"{indent}{bar}"]
 
 
-def render_section_header(num: int, title: str, subtitle: str, indent: str) -> list[str]:
+def render_section_header(
+    num: int, title: str, subtitle: str, indent: str
+) -> list[str]:
     return [
         f"{indent}  # {num}  {title}  -  {subtitle}",
         f"{indent}  {SECTION_RULE}",
@@ -527,22 +544,31 @@ def render_section_1_headline(head: OgaHeadline, indent: str) -> list[str]:
                    sub-blocks within head render the literal ``(absent)``.
     """
     lines = render_section_header(
-        1, "HEADLINE",
+        1,
+        "HEADLINE",
         f"model_benchmark (batch={head.batch_size}, prompt={head.prompt_tokens}, "
         f"gen={head.tokens_to_generate})",
         indent,
     )
     # Column widths chosen so all five rows align with the header.
     fmt = "    {label:<18} {tps:>13}   {p50:>13}   {std:>11}   {n}"
-    lines.append(indent + fmt.format(
-        label="", tps="throughput",
-        p50="p50 latency", std="stddev", n="samples"
-    ).rstrip())
+    lines.append(
+        indent
+        + fmt.format(
+            label="", tps="throughput", p50="p50 latency", std="stddev", n="samples"
+        ).rstrip()
+    )
 
-    def row(label: str, block: Optional[dict], lat_unit: str, *, has_tps: bool = True) -> str:
+    def row(
+        label: str, block: Optional[dict], lat_unit: str, *, has_tps: bool = True
+    ) -> str:
         if block is None:
             return indent + f"    {label:<18} (absent)"
-        tps = f"{block.get('avg_tps', 0):.2f} t/s" if has_tps and "avg_tps" in block else "-"
+        tps = (
+            f"{block.get('avg_tps', 0):.2f} t/s"
+            if has_tps and "avg_tps" in block
+            else "-"
+        )
         p50_key = f"p50_{lat_unit}"
         p50 = f"{block.get(p50_key, 0):.2f} {lat_unit}" if p50_key in block else "-"
         std_key = f"stddev_{lat_unit}"
@@ -550,13 +576,15 @@ def render_section_1_headline(head: OgaHeadline, indent: str) -> list[str]:
         n = block.get("n", "-")
         return indent + fmt.format(label=label, tps=tps, p50=p50, std=std, n=n).rstrip()
 
-    lines.append(row("Prefill (TTFT)", head.prefill,  "us"))
-    lines.append(row("Decode",         head.decode,   "us"))
-    lines.append(row("Sampling",       head.sampling, "us"))
-    lines.append(row("E2E generation", head.e2e,      "ms", has_tps=False))
-    lines.append(indent + f"    {'Peak working set':<18} "
-                          f"{human_bytes(head.peak_ws_bytes)} "
-                          f"({head.peak_ws_bytes or '?'} bytes)")
+    lines.append(row("Prefill (TTFT)", head.prefill, "us"))
+    lines.append(row("Decode", head.decode, "us"))
+    lines.append(row("Sampling", head.sampling, "us"))
+    lines.append(row("E2E generation", head.e2e, "ms", has_tps=False))
+    lines.append(
+        indent + f"    {'Peak working set':<18} "
+        f"{human_bytes(head.peak_ws_bytes)} "
+        f"({head.peak_ws_bytes or '?'} bytes)"
+    )
     return lines
 
 
@@ -577,20 +605,24 @@ def render_section_2_breakdown(bd: DecodeBreakdown, indent: str) -> list[str]:
     tc = TREE
     arrow = "<-"
     lines = render_section_header(
-        3, "STEADY-STATE DECODE BREAKDOWN",
+        3,
+        "STEADY-STATE DECODE BREAKDOWN",
         "1 decode token, median across run",
         indent,
     )
-    lines.append(indent + f"    {'':<{LABEL_WIDTH}} "
-                          f"{'latency':>10}   {'share':>6}   {'source':<20}")
+    lines.append(
+        indent + f"    {'':<{LABEL_WIDTH}} "
+        f"{'latency':>10}   {'share':>6}   {'source':<20}"
+    )
 
-    def row(prefix: str, label: str, ms: float, share: float,
-            src: str = "") -> str:
+    def row(prefix: str, label: str, ms: float, share: float, src: str = "") -> str:
         pad = LABEL_WIDTH - len(prefix) - len(label)
         if pad < 1:
             pad = 1
-        return (f"{indent}    {prefix}{label}{' ' * pad} "
-                f"{ms:>7.3f} ms   {share:>5.1f} %   {src}").rstrip()
+        return (
+            f"{indent}    {prefix}{label}{' ' * pad} "
+            f"{ms:>7.3f} ms   {share:>5.1f} %   {src}"
+        ).rstrip()
 
     total = bd.oga_p50_ms
 
@@ -614,42 +646,115 @@ def render_section_2_breakdown(bd: DecodeBreakdown, indent: str) -> list[str]:
     #      |  +- GPU: unwrapped + glue kernels
     #      |  +- CPU: host dispatch + sync poll      <- last L3
     #      +- Trailing fence (hipStreamSync)         <- last L2 under L1-LAST
-    PIPE   = f"{tc['pipe']} "    # "|  " - parent has more siblings below
-    BLANK  = "   "               # parent was last - no pipe through this column
+    PIPE = f"{tc['pipe']} "  # "|  " - parent has more siblings below
+    BLANK = "   "  # parent was last - no pipe through this column
     BRANCH = f"{tc['branch']} "  # "+- " - this row has siblings below
-    LAST   = f"{tc['last']} "    # "+- " - last sibling at this level
+    LAST = f"{tc['last']} "  # "+- " - last sibling at this level
 
-    lines.append(row("", "OGA::GenerateNextToken", bd.oga_p50_ms, 100.0,
-                     f"{arrow} # 1 Decode p50"))
-    lines.append(row(BRANCH, "OGA + ORT framework overhead",
-                     bd.oga_overhead_ms, pct(bd.oga_overhead_ms)))
-    lines.append(row(PIPE + BRANCH, "Token sampling",
-                     bd.sampling_avg_ms, pct(bd.sampling_avg_ms),
-                     f"{arrow} # 1 Sampling avg"))
-    lines.append(row(PIPE + LAST, "Other (IoBinding rebind, etc.)",
-                     bd.other_oga_ms, pct(bd.other_oga_ms)))
-    lines.append(row(LAST, "EP MlirCustomOp::Compute()",
-                     bd.wall_ms, pct(bd.wall_ms),
-                     f"{arrow} # 6 wall_ms"))
-    lines.append(row(BLANK + BRANCH, "Marshal in (input descriptors)",
-                     bd.marshal_in_ms, pct(bd.marshal_in_ms),
-                     f"{arrow} # 6 marshal_in_ms"))
-    lines.append(row(BLANK + BRANCH, "Marshal out (output desc.)",
-                     bd.marshal_out_ms, pct(bd.marshal_out_ms),
-                     f"{arrow} # 6 marshal_out_ms"))
-    lines.append(row(BLANK + BRANCH, "model.dll inference_compute()",
-                     bd.compute_cpu_ms, pct(bd.compute_cpu_ms),
-                     f"{arrow} # 6 compute_cpu_ms"))
-    lines.append(row(BLANK + PIPE + BRANCH, "GPU: OP_PROFILE kernels (sum)",
-                     bd.perop_gpu_median_ms, pct(bd.perop_gpu_median_ms),
-                     f"{arrow} # 7 TOTAL"))
-    lines.append(row(BLANK + PIPE + BRANCH, "GPU: outside # 7 scopes",
-                     bd.unprofiled_gpu_ms, pct(bd.unprofiled_gpu_ms)))
-    lines.append(row(BLANK + PIPE + LAST, "CPU: host dispatch + sync poll",
-                     bd.cpu_overhead_ms, pct(bd.cpu_overhead_ms)))
-    lines.append(row(BLANK + LAST, "Trailing fence (hipStreamSync)",
-                     bd.fence_ms, pct(bd.fence_ms),
-                     f"{arrow} # 6 fence_residual_ms"))
+    lines.append(
+        row(
+            "",
+            "OGA::GenerateNextToken",
+            bd.oga_p50_ms,
+            100.0,
+            f"{arrow} # 1 Decode p50",
+        )
+    )
+    lines.append(
+        row(
+            BRANCH,
+            "OGA + ORT framework overhead",
+            bd.oga_overhead_ms,
+            pct(bd.oga_overhead_ms),
+        )
+    )
+    lines.append(
+        row(
+            PIPE + BRANCH,
+            "Token sampling",
+            bd.sampling_avg_ms,
+            pct(bd.sampling_avg_ms),
+            f"{arrow} # 1 Sampling avg",
+        )
+    )
+    lines.append(
+        row(
+            PIPE + LAST,
+            "Other (IoBinding rebind, etc.)",
+            bd.other_oga_ms,
+            pct(bd.other_oga_ms),
+        )
+    )
+    lines.append(
+        row(
+            LAST,
+            "EP MlirCustomOp::Compute()",
+            bd.wall_ms,
+            pct(bd.wall_ms),
+            f"{arrow} # 6 wall_ms",
+        )
+    )
+    lines.append(
+        row(
+            BLANK + BRANCH,
+            "Marshal in (input descriptors)",
+            bd.marshal_in_ms,
+            pct(bd.marshal_in_ms),
+            f"{arrow} # 6 marshal_in_ms",
+        )
+    )
+    lines.append(
+        row(
+            BLANK + BRANCH,
+            "Marshal out (output desc.)",
+            bd.marshal_out_ms,
+            pct(bd.marshal_out_ms),
+            f"{arrow} # 6 marshal_out_ms",
+        )
+    )
+    lines.append(
+        row(
+            BLANK + BRANCH,
+            "model.dll inference_compute()",
+            bd.compute_cpu_ms,
+            pct(bd.compute_cpu_ms),
+            f"{arrow} # 6 compute_cpu_ms",
+        )
+    )
+    lines.append(
+        row(
+            BLANK + PIPE + BRANCH,
+            "GPU: OP_PROFILE kernels (sum)",
+            bd.perop_gpu_median_ms,
+            pct(bd.perop_gpu_median_ms),
+            f"{arrow} # 7 TOTAL",
+        )
+    )
+    lines.append(
+        row(
+            BLANK + PIPE + BRANCH,
+            "GPU: outside # 7 scopes",
+            bd.unprofiled_gpu_ms,
+            pct(bd.unprofiled_gpu_ms),
+        )
+    )
+    lines.append(
+        row(
+            BLANK + PIPE + LAST,
+            "CPU: host dispatch + sync poll",
+            bd.cpu_overhead_ms,
+            pct(bd.cpu_overhead_ms),
+        )
+    )
+    lines.append(
+        row(
+            BLANK + LAST,
+            "Trailing fence (hipStreamSync)",
+            bd.fence_ms,
+            pct(bd.fence_ms),
+            f"{arrow} # 6 fence_residual_ms",
+        )
+    )
 
     # Notes for the two "residual" rows that don't have a direct # N cross-ref
     # (they are subtractive - what's left after the named rows are accounted
@@ -658,20 +763,34 @@ def render_section_2_breakdown(bd: DecodeBreakdown, indent: str) -> list[str]:
     # speak for themselves once you've followed their # N arrow.
     lines.append("")
     lines.append(indent + "    notes:")
-    lines.append(indent + "      - \"GPU: outside # 7 scopes\" = # 6 gpu_ms - # 7 "
-                          "TOTAL: GPU work not bracketed by any")
-    lines.append(indent + "        OP_PROFILE wrapper. Typical sources: MIOpen / "
-                          "hipBLASLt internal helper")
-    lines.append(indent + "        launches, ops lacking an OP_PROFILE scope, "
-                          "hipMemset / glue between ops. If")
-    lines.append(indent + "        this row grows after a runtime change, "
-                          "OP_PROFILE coverage has regressed.")
-    lines.append(indent + "      - \"Other (IoBinding rebind, etc.)\" = # 1 Decode "
-                          "p50 - sampling - EP wall: OGA")
-    lines.append(indent + "        framework overhead between Generator steps. "
-                          "Dominated by IoBinding's per-token")
-    lines.append(indent + "        rebind of all input/output tensors (scales "
-                          "with KV buffer size, not seq len).")
+    lines.append(
+        indent + '      - "GPU: outside # 7 scopes" = # 6 gpu_ms - # 7 '
+        "TOTAL: GPU work not bracketed by any"
+    )
+    lines.append(
+        indent + "        OP_PROFILE wrapper. Typical sources: MIOpen / "
+        "hipBLASLt internal helper"
+    )
+    lines.append(
+        indent + "        launches, ops lacking an OP_PROFILE scope, "
+        "hipMemset / glue between ops. If"
+    )
+    lines.append(
+        indent + "        this row grows after a runtime change, "
+        "OP_PROFILE coverage has regressed."
+    )
+    lines.append(
+        indent + '      - "Other (IoBinding rebind, etc.)" = # 1 Decode '
+        "p50 - sampling - EP wall: OGA"
+    )
+    lines.append(
+        indent + "        framework overhead between Generator steps. "
+        "Dominated by IoBinding's per-token"
+    )
+    lines.append(
+        indent + "        rebind of all input/output tensors (scales "
+        "with KV buffer size, not seq len)."
+    )
     return lines
 
 
@@ -746,11 +865,11 @@ def parse_compute_samples(lines: list[str]) -> list[ComputeSample]:
     token (and blowing up the # 2 decode share to thousands of percent).
     Positional pairing instead just skips the one orphaned Compute.
     """
-    metric_pos = [(i, m) for i, ln in enumerate(lines)
-                  if (m := _PERCALL_RE.search(ln))]
+    metric_pos = [(i, m) for i, ln in enumerate(lines) if (m := _PERCALL_RE.search(ln))]
     border_idx = [i for i, ln in enumerate(lines) if ln.startswith("[PERF] ===")]
-    pairs = [(border_idx[j], border_idx[j + 1])
-             for j in range(0, len(border_idx) - 1, 2)]
+    pairs = [
+        (border_idx[j], border_idx[j + 1]) for j in range(0, len(border_idx) - 1, 2)
+    ]
     out: list[ComputeSample] = []
     pi = 0
     for pos, m in metric_pos:
@@ -758,13 +877,16 @@ def parse_compute_samples(lines: list[str]) -> list[ComputeSample]:
         # the very first Compute's block, when its own metric line was dropped).
         while pi < len(pairs) and pairs[pi][0] < pos:
             pi += 1
-        blk = lines[pairs[pi][0]: pairs[pi][1] + 1] if pi < len(pairs) else []
+        blk = lines[pairs[pi][0] : pairs[pi][1] + 1] if pi < len(pairs) else []
         if pi < len(pairs):
             pi += 1
         s = ComputeSample(
-            wall_ms=float(m.group(2)), marshal_in_ms=float(m.group(3)),
-            marshal_out_ms=float(m.group(4)), compute_cpu_ms=float(m.group(5)),
-            gpu_ms=float(m.group(6)), fence_residual_ms=float(m.group(7)),
+            wall_ms=float(m.group(2)),
+            marshal_in_ms=float(m.group(3)),
+            marshal_out_ms=float(m.group(4)),
+            compute_cpu_ms=float(m.group(5)),
+            gpu_ms=float(m.group(6)),
+            fence_residual_ms=float(m.group(7)),
             block=blk,
         )
         s.stage = _classify_stage(blk)
@@ -783,7 +905,8 @@ def stage_perf(samples: list[ComputeSample]) -> PerfSummary:
             continue
         n = len(vals)
         ps.metrics[name] = {
-            "min": vals[0], "max": vals[-1],
+            "min": vals[0],
+            "max": vals[-1],
             "mean": sum(vals) / n,
             "median": statistics.median(vals),
             "p99": vals[max(0, int(round(0.99 * (n - 1))))],
@@ -795,10 +918,10 @@ def stage_perf(samples: list[ComputeSample]) -> PerfSummary:
 # tag, shape sub-rows 4 spaces; both end in (calls, gpu, cpu[, gpu%]). The
 # label is captured lazily because shape labels can contain spaces (e.g.
 # "n=8192 rank=3"). TOTAL/header rows don't match (no integer `calls` column).
-_OP_PARENT_RE = re.compile(
-    r"^\[PERF\]  (\S.*?)\s+(\d+)\s+(\S+)\s+(\S+)(?:\s+\S+)?\s*$")
+_OP_PARENT_RE = re.compile(r"^\[PERF\]  (\S.*?)\s+(\d+)\s+(\S+)\s+(\S+)(?:\s+\S+)?\s*$")
 _OP_SHAPE_RE = re.compile(
-    r"^\[PERF\]    (\S.*?)\s+(\d+)\s+(\S+)\s+(\S+)(?:\s+\S+)?\s*$")
+    r"^\[PERF\]    (\S.*?)\s+(\d+)\s+(\S+)\s+(\S+)(?:\s+\S+)?\s*$"
+)
 
 
 def _accum(slot: list, gpu_tok: str, cpu_tok: str) -> None:
@@ -825,9 +948,9 @@ def _segment_prefill_generations(samples: list[ComputeSample]) -> list[dict]:
     be non-vision, which opens a leading generation that a naive vision-count
     would miss -- off-by-one against # 3.)
     """
+
     def blank() -> dict:
-        return {sub: {m: 0.0 for m in _PREFILL_METRICS}
-                for sub in _PREFILL_SUBS}
+        return {sub: {m: 0.0 for m in _PREFILL_METRICS} for sub in _PREFILL_SUBS}
 
     gens: list[dict] = []
     cur: Optional[dict] = None
@@ -858,9 +981,14 @@ def _count_prefill_generations(samples: list[ComputeSample]) -> int:
     return len(_segment_prefill_generations(samples)) or 1
 
 
-def render_perop_aggregate(blocks: list[list[str]], indent: str, *,
-                           num: int, subtitle: str,
-                           generations: int = 1) -> list[str]:
+def render_perop_aggregate(
+    blocks: list[list[str]],
+    indent: str,
+    *,
+    num: int,
+    subtitle: str,
+    generations: int = 1,
+) -> list[str]:
     """Sum each op's gpu/cpu/calls across every block in a stage, keeping the
     op -> shape hierarchy so the discriminating shapes stay visible.
 
@@ -894,25 +1022,37 @@ def render_perop_aggregate(blocks: list[list[str]], indent: str, *,
     # generation; the raw sum here spans every rep). `calls` stays a run total
     # (the exact launch count); only the time columns are divided.
     div = generations if generations and generations > 0 else 1
-    title = ("PER-OP GPU BREAKDOWN (per generation)" if div > 1
-             else "PER-OP GPU BREAKDOWN (stage total)")
+    title = (
+        "PER-OP GPU BREAKDOWN (per generation)"
+        if div > 1
+        else "PER-OP GPU BREAKDOWN (stage total)"
+    )
     lines = render_section_header(num, title, subtitle, indent)
     tot_gpu = sum(v[1] for v in agg.values())
     tot_cpu = sum(v[2] for v in agg.values())
-    lines.append(indent + f"    {'op / shape':<40}{'calls':>7}{'gpu (ms)':>10}"
-                          f"{'cpu (ms)':>10}{'gpu %':>7}")
+    lines.append(
+        indent + f"    {'op / shape':<40}{'calls':>7}{'gpu (ms)':>10}"
+        f"{'cpu (ms)':>10}{'gpu %':>7}"
+    )
     for name, (calls, gpu, cpu, shapes) in sorted(
-            agg.items(), key=lambda kv: kv[1][1], reverse=True):
+        agg.items(), key=lambda kv: kv[1][1], reverse=True
+    ):
         pct = (100.0 * gpu / tot_gpu) if tot_gpu else 0.0
-        lines.append(indent + f"    {name:<40}{calls:>7}{gpu / div:>10.1f}"
-                              f"{cpu / div:>10.1f}{pct:>6.1f}%")
+        lines.append(
+            indent + f"    {name:<40}{calls:>7}{gpu / div:>10.1f}"
+            f"{cpu / div:>10.1f}{pct:>6.1f}%"
+        )
         for shp, (scalls, sgpu, scpu) in sorted(
-                shapes.items(), key=lambda kv: kv[1][1], reverse=True):
+            shapes.items(), key=lambda kv: kv[1][1], reverse=True
+        ):
             spct = (100.0 * sgpu / tot_gpu) if tot_gpu else 0.0
-            lines.append(indent + f"      {shp:<38}{scalls:>7}{sgpu / div:>10.1f}"
-                                  f"{scpu / div:>10.1f}{spct:>6.1f}%")
-    lines.append(indent + f"    {'TOTAL':<40}{'':>7}"
-                          f"{tot_gpu / div:>10.1f}{tot_cpu / div:>10.1f}")
+            lines.append(
+                indent + f"      {shp:<38}{scalls:>7}{sgpu / div:>10.1f}"
+                f"{scpu / div:>10.1f}{spct:>6.1f}%"
+            )
+    lines.append(
+        indent + f"    {'TOTAL':<40}{'':>7}{tot_gpu / div:>10.1f}{tot_cpu / div:>10.1f}"
+    )
     return lines
 
 
@@ -941,8 +1081,9 @@ def _block_total_gpu(block: list[str]) -> float:
     return 0.0
 
 
-def render_prefill_breakdown(samples: list[ComputeSample], head: OgaHeadline,
-                             indent: str, *, num: int) -> list[str]:
+def render_prefill_breakdown(
+    samples: list[ComputeSample], head: OgaHeadline, indent: str, *, num: int
+) -> list[str]:
     """Prefill waterfall: split TTFT's EP work into vision / embedding /
     text-prefill / glue, and give the two big sub-models (vision, text-prefill)
     a # 2-style call stack (marshal -> model.dll compute [GPU op_profile / GPU
@@ -969,28 +1110,39 @@ def render_prefill_breakdown(samples: list[ComputeSample], head: OgaHeadline,
     if not gens:
         return []
 
-    med = {sub: {m: statistics.median([g[sub][m] for g in gens]) for m in metrics}
-           for sub in subs}
+    med = {
+        sub: {m: statistics.median([g[sub][m] for g in gens]) for m in metrics}
+        for sub in subs
+    }
     total = sum(med[sub]["wall"] for sub in subs)
     if total <= 0:
         return []
 
     tc = TREE
     arrow = "<-"
-    PIPE, BLANK, BRANCH, LAST = (f"{tc['pipe']} ", "   ",
-                                 f"{tc['branch']} ", f"{tc['last']} ")
+    PIPE, BLANK, BRANCH, LAST = (
+        f"{tc['pipe']} ",
+        "   ",
+        f"{tc['branch']} ",
+        f"{tc['last']} ",
+    )
     lines = render_section_header(
-        num, "PREFILL STAGE BREAKDOWN",
+        num,
+        "PREFILL STAGE BREAKDOWN",
         f"median of {len(gens)} generation(s); EP wall per sub-model + call stack",
-        indent)
-    lines.append(indent + f"    {'':<{LABEL_WIDTH}} {'latency':>10}   {'share':>6}"
-                          f"   source")
+        indent,
+    )
+    lines.append(
+        indent + f"    {'':<{LABEL_WIDTH}} {'latency':>10}   {'share':>6}   source"
+    )
 
     def row(prefix: str, label: str, ms: float, src: str = "") -> str:
         pad = max(1, LABEL_WIDTH - len(prefix) - len(label))
         share = 100.0 * ms / total if total else 0.0
-        return (f"{indent}    {prefix}{label}{' ' * pad} "
-                f"{ms:>7.3f} ms   {share:>5.1f} %   {src}").rstrip()
+        return (
+            f"{indent}    {prefix}{label}{' ' * pad} "
+            f"{ms:>7.3f} ms   {share:>5.1f} %   {src}"
+        ).rstrip()
 
     def callstack(sub: str, is_last: bool) -> list[str]:
         d = med[sub]
@@ -1002,8 +1154,12 @@ def render_prefill_breakdown(samples: list[ComputeSample], head: OgaHeadline,
             row(hook, _SUBLABEL[sub], d["wall"]),
             row(cont + BRANCH, "Marshal in + out", d["mi"] + d["mo"]),
             row(cont + BRANCH, "model.dll compute()", d["cpu"]),
-            row(cont + PIPE + BRANCH, "GPU: OP_PROFILE kernels", d["optot"],
-                f"{arrow} # 5 per-op"),
+            row(
+                cont + PIPE + BRANCH,
+                "GPU: OP_PROFILE kernels",
+                d["optot"],
+                f"{arrow} # 5 per-op",
+            ),
             row(cont + PIPE + BRANCH, "GPU: outside scopes", gpu_outside),
             row(cont + PIPE + LAST, "CPU: host dispatch", cpu_dispatch),
             row(cont + LAST, "Trailing fence", d["fence"]),
@@ -1012,8 +1168,7 @@ def render_prefill_breakdown(samples: list[ComputeSample], head: OgaHeadline,
     lines.append(row("", "EP prefill wall (per generation)", total))
     # Two big sub-models get a call stack (largest wall first); embedding+glue
     # are tiny -> one combined leaf, always last.
-    big = sorted(("vision", "text_prefill"), key=lambda s: med[s]["wall"],
-                 reverse=True)
+    big = sorted(("vision", "text_prefill"), key=lambda s: med[s]["wall"], reverse=True)
     for sub in big:
         lines += callstack(sub, is_last=False)
     eg = med["embedding"]["wall"] + med["glue"]["wall"]
@@ -1022,12 +1177,18 @@ def render_prefill_breakdown(samples: list[ComputeSample], head: OgaHeadline,
     ttft_us = head.prefill.get("avg_us") if (head and head.prefill) else None
     if ttft_us:
         lines.append("")
-        lines.append(indent + f"    reference: CSV TTFT = {ttft_us / 1000.0:.1f} ms "
-                              "(OGA end-to-end prompt latency).")
-        lines.append(indent + "    NOTE: rows sum to EP prefill wall, not TTFT --"
-                              " benchmark_multimodal.py books text")
-        lines.append(indent + "    prefill under its 'sampling' phase, so TTFT's"
-                              " phase split differs from these EP sub-stages.")
+        lines.append(
+            indent + f"    reference: CSV TTFT = {ttft_us / 1000.0:.1f} ms "
+            "(OGA end-to-end prompt latency)."
+        )
+        lines.append(
+            indent + "    NOTE: rows sum to EP prefill wall, not TTFT --"
+            " benchmark_multimodal.py books text"
+        )
+        lines.append(
+            indent + "    prefill under its 'sampling' phase, so TTFT's"
+            " phase split differs from these EP sub-stages."
+        )
     return lines
 
 
@@ -1037,10 +1198,13 @@ _SUBLABEL = {
 }
 
 
-def render_section_3_perop(perop: PerOpTable, indent: str, *,
-                           num: int = 3,
-                           subtitle: str = "last Compute() = steady-state "
-                                           "decode token") -> list[str]:
+def render_section_3_perop(
+    perop: PerOpTable,
+    indent: str,
+    *,
+    num: int = 3,
+    subtitle: str = "last Compute() = steady-state decode token",
+) -> list[str]:
     """PER-OP GPU BREAKDOWN - passes the runtime's own [PERF] table through
     verbatim.
 
@@ -1072,9 +1236,9 @@ def render_section_3_perop(perop: PerOpTable, indent: str, *,
     return lines
 
 
-def render_section_4_distribution(perf: PerfSummary, indent: str, *,
-                                  num: int = 4,
-                                  subtitle: Optional[str] = None) -> list[str]:
+def render_section_4_distribution(
+    perf: PerfSummary, indent: str, *, num: int = 4, subtitle: Optional[str] = None
+) -> list[str]:
     """# 4 PER-CALL DISTRIBUTION - six metrics x five stats, column-aligned.
 
     Source:        ``PerfSummary.metrics`` -> the ``[PERF SUMMARY]`` block
@@ -1092,21 +1256,24 @@ def render_section_4_distribution(perf: PerfSummary, indent: str, *,
     if not perf:
         return []
     lines = render_section_header(
-        num, "PER-CALL DISTRIBUTION",
-        subtitle if subtitle is not None else
-        f"EP MlirCustomOp::Compute() over {perf.total_inferences} invocations (all ms)",
+        num,
+        "PER-CALL DISTRIBUTION",
+        subtitle
+        if subtitle is not None
+        else f"EP MlirCustomOp::Compute() over {perf.total_inferences} invocations (all ms)",
         indent,
     )
-    lines.append(indent + f"    {'':<18} {'min':>10} {'median':>10}"
-                          f" {'p99':>10} {'max':>12}")
+    lines.append(
+        indent + f"    {'':<18} {'min':>10} {'median':>10} {'p99':>10} {'max':>12}"
+    )
     for name in PerfSummary.METRIC_ORDER:
         stats = perf.metrics.get(name)
         if not stats:
             continue
         lines.append(
             indent + f"    {name:<18} "
-                     f"{stats['min']:>10.3f} {stats['median']:>10.3f}"
-                     f" {stats['p99']:>10.3f} {stats['max']:>12.3f}"
+            f"{stats['min']:>10.3f} {stats['median']:>10.3f}"
+            f" {stats['p99']:>10.3f} {stats['max']:>12.3f}"
         )
     # The two-line note below catches the two most-common "wait, what?" moments
     # readers have when first comparing # 4 against # 1:
@@ -1115,13 +1282,19 @@ def render_section_4_distribution(perf: PerfSummary, indent: str, *,
     #       windows: # 1 reports only OGA's timed iterations, # 4 reports every
     #       EP call including warmup + verbose-mode display generation.
     lines.append(indent + "    notes:")
-    lines.append(indent + "      - `max` includes first-Compute cold start "
-                          "(kernel autotune + pool grow);")
+    lines.append(
+        indent + "      - `max` includes first-Compute cold start "
+        "(kernel autotune + pool grow);"
+    )
     lines.append(indent + "        # 2 uses median to skip those outliers.")
-    lines.append(indent + "      - this count covers ALL EP calls (warmup + "
-                          "verbose-display + timed reps);")
-    lines.append(indent + "        # 1's per-block `samples` column is the "
-                          "OGA-timed subset only.")
+    lines.append(
+        indent + "      - this count covers ALL EP calls (warmup + "
+        "verbose-display + timed reps);"
+    )
+    lines.append(
+        indent + "        # 1's per-block `samples` column is the "
+        "OGA-timed subset only."
+    )
     return lines
 
 
@@ -1179,8 +1352,14 @@ def _read_log_text(log_path: Path) -> str:
     return raw.decode("utf-8", errors="replace")
 
 
-def render_report(log_path: Path, *, show_banner: bool = True, indent: str = "",
-                  csv_path: Optional[Path] = None, reps: int = 1) -> str:
+def render_report(
+    log_path: Path,
+    *,
+    show_banner: bool = True,
+    indent: str = "",
+    csv_path: Optional[Path] = None,
+    reps: int = 1,
+) -> str:
     lines = _read_log_text(log_path).splitlines()
 
     head = OgaHeadline.parse(lines)
@@ -1239,30 +1418,42 @@ def render_report(log_path: Path, *, show_banner: bool = True, indent: str = "",
     # from its own Computes only.
     if prefill:
         out += render_section_4_distribution(
-            stage_perf(prefill), indent, num=4,
+            stage_perf(prefill),
+            indent,
+            num=4,
             subtitle=f"PREFILL stage -- {len(prefill)} Compute(s) "
-                     "(vision + embedding + text prefill), all ms")
+            "(vision + embedding + text prefill), all ms",
+        )
         out.append("")
         # Prefill spans multiple Computes per generation -> sum per-op across
         # them, then normalize to per-generation so the TOTAL matches # 2.
         n_gen = _count_prefill_generations(samples)
         out += render_perop_aggregate(
-            [s.block for s in prefill if s.block], indent, num=5,
+            [s.block for s in prefill if s.block],
+            indent,
+            num=5,
             generations=n_gen,
             subtitle=f"gpu/cpu per generation (avg over {n_gen} gen(s)); "
-                     f"calls = run total over {len(prefill)} prefill Compute(s)")
+            f"calls = run total over {len(prefill)} prefill Compute(s)",
+        )
         out.append("")
     if decode:
         out += render_section_4_distribution(
-            dec_perf, indent, num=6,
+            dec_perf,
+            indent,
+            num=6,
             subtitle=f"DECODE stage -- {len(decode)} Compute(s) "
-                     "(steady-state tokens), all ms")
+            "(steady-state tokens), all ms",
+        )
         out.append("")
         # Decode is per-token steady state -> show the last (clean) token, not
         # a sum (which would fold in the cold first-token LM-head autotune).
         out += render_section_3_perop(
-            dec_perop, indent, num=7,
-            subtitle="representative = last decode token (steady state)")
+            dec_perop,
+            indent,
+            num=7,
+            subtitle="representative = last decode token (steady state)",
+        )
         out.append("")
 
     if show_banner:
@@ -1280,19 +1471,33 @@ def main(argv: Optional[list[str]] = None) -> int:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     p.add_argument("log", type=Path, help="Path to a HIPDNN EP / OGA bench log")
-    p.add_argument("csv", type=Path, nargs="?", default=None,
-                   help="Optional benchmark_multimodal.py CSV. When the log has "
-                        "no model_benchmark stats block (e.g. multimodal Python "
-                        "runs), the headline (# 1 TTFT/TPS), # 2 OGA/ORT flow "
-                        "overhead, and footer are synthesized from this CSV.")
-    p.add_argument("--reps", type=int, default=1,
-                   help="Repetitions used in the bench (matches "
-                        "benchmark_multimodal.py -r); only labels the CSV-derived "
-                        "`samples` column (default: 1)")
-    p.add_argument("--no-banner", action="store_true",
-                   help="Omit the top/bottom identity banner")
-    p.add_argument("--indent", type=int, default=0,
-                   help="Indent every output line by N spaces (default: 0)")
+    p.add_argument(
+        "csv",
+        type=Path,
+        nargs="?",
+        default=None,
+        help="Optional benchmark_multimodal.py CSV. When the log has "
+        "no model_benchmark stats block (e.g. multimodal Python "
+        "runs), the headline (# 1 TTFT/TPS), # 2 OGA/ORT flow "
+        "overhead, and footer are synthesized from this CSV.",
+    )
+    p.add_argument(
+        "--reps",
+        type=int,
+        default=1,
+        help="Repetitions used in the bench (matches "
+        "benchmark_multimodal.py -r); only labels the CSV-derived "
+        "`samples` column (default: 1)",
+    )
+    p.add_argument(
+        "--no-banner", action="store_true", help="Omit the top/bottom identity banner"
+    )
+    p.add_argument(
+        "--indent",
+        type=int,
+        default=0,
+        help="Indent every output line by N spaces (default: 0)",
+    )
     args = p.parse_args(argv)
 
     if not args.log.is_file():
@@ -1310,8 +1515,10 @@ def main(argv: Optional[list[str]] = None) -> int:
         reps=args.reps,
     )
     if not report:
-        print(f"warning: log has no parseable EP perf streams: {args.log}",
-              file=sys.stderr)
+        print(
+            f"warning: log has no parseable EP perf streams: {args.log}",
+            file=sys.stderr,
+        )
         return 2
     print(report)
     return 0

--- a/tools/perf-report/perf_multimodal_report.py
+++ b/tools/perf-report/perf_multimodal_report.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
+#
 # Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 # Licensed under the MIT License.
+#
 """Format a HIPDNN EP OGA model_benchmark log into a structured profiling report.
 
 The report is the locked-down rendering of three independent measurement streams

--- a/tools/perf-report/run_bench.sh
+++ b/tools/perf-report/run_bench.sh
@@ -1,0 +1,448 @@
+#!/usr/bin/env bash
+# Linux bench driver for the MorphiZen EP. Benchmarks an ONNX model from
+# <workspace>/oga_models/<dir> using one of two host tools, captures the
+# full stderr+stdout to a log under <script-dir>/_perf_logs/, and pipes
+# the result through format_perf_report.py (sibling under this directory).
+#
+# Two tools, selected by flag:
+#   (default)  onnxruntime_perf_test       -- per-Run() latency loop (kernel-level)
+#   --oga      install/bin/model_benchmark -- TTFT + decode-TPS (production OGA path)
+#
+# Both default to the dynamic single-graph model.onnx (PR #212). The decoder-
+# pipeline fixed-shape sub-models are still reachable via --shape static (perftest
+# only; OGA fixed-pipeline isn't wired in this script -- invoke model_benchmark
+# directly if you need it). Dynamic is the canonical Linux path going forward.
+#
+# Decode-only on dynamic shape for the PERFTEST path -- important caveat:
+#   onnxruntime_perf_test silently rejects 3+ `-f` flags (parser quirk in the
+#   prebuilt 1.25.1 binary; reproduced with 3/4 of {batch_size, sequence_length,
+#   past_sequence_length, total_sequence_length}). We can only override 2 dims;
+#   the other 2 fall back to ORT's default-1. The only shape that's still
+#   internally consistent under that constraint is decode at past_len=1,
+#   total_seq=1, seq=1. For prefill-shape perftest, --shape static is required.
+#   OGA does NOT have this limitation -- it builds the input shapes correctly.
+#
+# Where to run this script:
+#   This is host-tool-agnostic but expects an AMD GPU + the in-container
+#   build artefacts ($WORKSPACE/install/{bin,lib}/...) to be reachable. The
+#   two supported entry points are:
+#     1. From inside the build container: `./docker/run.sh shell`, then run
+#        this script directly.
+#     2. From the host: forward via the sibling wrapper, which spins a
+#        one-shot container with the GPU + bind mounts:
+#          REL_BENCH=tools/perf-report/run_bench.sh \
+#              tools/perf-report/docker_run_bench.sh --oga --prompt 128 ...
+#
+# Usage:
+#   ./tools/perf-report/run_bench.sh                                  # perftest, dynamic seq=1, 60s
+#   ./tools/perf-report/run_bench.sh --time 30                       # perftest, 30s window
+#   ./tools/perf-report/run_bench.sh --oga                           # OGA, dynamic, prompt=128 gen=128 r=3 w=1
+#   ./tools/perf-report/run_bench.sh --oga --prompt 128 --gen 128 --reps 3
+#   ./tools/perf-report/run_bench.sh --oga --prompt 2048 --gen 128 --max-length 16384
+#   ./tools/perf-report/run_bench.sh --shape static --seq 128 --seq 2048   # perftest, fixed-shape opt-in
+#   ./tools/perf-report/run_bench.sh --model <other-dir>             # different model under oga_models/
+
+set -euo pipefail
+
+# ─── defaults ──────────────────────────────────────────────────────────────
+MODEL_REL="Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml"
+TOOL="perftest"             # perftest | oga
+SHAPE="dynamic"             # dynamic | static (static = perftest fixed-pipeline opt-in)
+SEQS=()                     # perftest: empty -> [1] for dynamic, [128 2048] for static
+TIME_S=60                   # perftest only
+MODE="none"                 # none | perf | debug -- toggles HIPDNN_EP_PERF / _DEBUG
+TAG=""
+# OGA defaults (match Windows model_benchmark.exe defaults from CLAUDE.md
+# "Verified perf snapshot" section: -l 128 -g 128 -r 3 -w 1 captures the L=128
+# row; user overrides -l to walk the L=2048 column etc.)
+OGA_PROMPT=128
+OGA_GEN=128
+OGA_REPS=3
+OGA_WARMUP=1
+OGA_MAX_LENGTH=""           # empty -> let model_benchmark default to prompt+gen
+                            # NOTE: CLAUDE.md "For dynamic-shape models, do NOT pass -ml"
+                            # -- inflates peak WS without changing TPS/TTFT.
+
+# ─── arg parse ────────────────────────────────────────────────────────────
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --model)        MODEL_REL="$2"; shift 2 ;;
+        --oga)          TOOL="oga"; shift ;;
+        --shape)        SHAPE="$2"; shift 2 ;;
+        --seq)          SEQS+=("$2"); shift 2 ;;
+        --time|-t)      TIME_S="$2"; shift 2 ;;
+        --mode)         MODE="$2"; shift 2 ;;
+        --tag)          TAG="$2"; shift 2 ;;
+        --prompt|-l)    OGA_PROMPT="$2"; shift 2 ;;
+        --gen|-g)       OGA_GEN="$2"; shift 2 ;;
+        --reps|-r)      OGA_REPS="$2"; shift 2 ;;
+        --warmup|-w)    OGA_WARMUP="$2"; shift 2 ;;
+        --max-length|-ml) OGA_MAX_LENGTH="$2"; shift 2 ;;
+        -h|--help)
+            sed -n '2,43p' "$0"; exit 0 ;;
+        *)  echo "unknown arg: $1" >&2; exit 1 ;;
+    esac
+done
+
+case "$TOOL"  in perftest|oga)    ;; *) echo "bad --tool (internal): $TOOL"  >&2; exit 1 ;; esac
+case "$SHAPE" in dynamic|static)  ;; *) echo "bad --shape: $SHAPE"            >&2; exit 1 ;; esac
+case "$MODE"  in none|perf|debug) ;; *) echo "bad --mode: $MODE"              >&2; exit 1 ;; esac
+
+# OGA currently only runs against the dynamic single-graph config. Static-
+# pipeline OGA needs a different staging path (per-row sub-models, sliding
+# window etc.) and isn't wired here; gate it explicitly so the user gets a
+# clear error instead of silently running the perftest fallback.
+if [ "$TOOL" = "oga" ] && [ "$SHAPE" = "static" ]; then
+    echo "ERROR: --oga only supports --shape dynamic in this script." >&2
+    echo "       For fixed-pipeline OGA runs, invoke model_benchmark directly with -i <model_dir>" >&2
+    echo "       and the appropriate genai_config_p<L>m16384.json swapped in as genai_config.json." >&2
+    exit 1
+fi
+
+# ─── locate repo root + workspace ─────────────────────────────────────────
+# Walk upward from SCRIPT_DIR looking for `build.py` (the canonical project
+# build script per CLAUDE.md). This decouples the script from its placement
+# under the repo -- same logic works whether it lives at <repo>/oga/,
+# <repo>/tools/perf-report/, or anywhere else. We deliberately don't shell
+# out to `git rev-parse --show-toplevel` so the script remains usable in
+# extracted source tarballs that have no .git/ directory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC_DIR="$SCRIPT_DIR"
+while [ "$SRC_DIR" != "/" ] && [ ! -f "$SRC_DIR/build.py" ]; do
+    SRC_DIR="$(dirname "$SRC_DIR")"
+done
+if [ "$SRC_DIR" = "/" ]; then
+    echo "ERROR: could not locate repo root from $SCRIPT_DIR" >&2
+    echo "       (walked up looking for build.py; none found)" >&2
+    exit 1
+fi
+
+# WORKSPACE defaults to the parent of the repo root, matching the convention
+# `docker/run.sh` uses to choose the bind-mount root. Setting WORKSPACE
+# explicitly on the command line overrides (e.g. when the build artefacts
+# live somewhere other than `<repo>/../install/`).
+: "${WORKSPACE:=$(cd "$SRC_DIR/.." && pwd)}"
+
+# ─── env (mirrors docs/quick_start_linux.md "Open a container shell") ─────
+ROOT="$WORKSPACE/install"
+THEROCK_DIST="$WORKSPACE/therock-dist"
+export LD_LIBRARY_PATH="$ROOT/lib:$THEROCK_DIST/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export LIBRARY_PATH="$ROOT/lib:$THEROCK_DIST/lib${LIBRARY_PATH:+:$LIBRARY_PATH}"
+export THEROCK_DIST
+
+case "$MODE" in
+    perf)  export HIPDNN_EP_PERF=1 HIPDNN_EP_DEBUG=0 ;;
+    debug) export HIPDNN_EP_PERF=1 HIPDNN_EP_DEBUG=1 ;;
+    none)  export HIPDNN_EP_PERF=0 HIPDNN_EP_DEBUG=0 ;;
+esac
+
+EP_DLL="$ROOT/lib/libonnxruntime_morphizen_ep.so"
+PERFTEST="$WORKSPACE/build/onnxruntime/Release/onnxruntime_perf_test"
+MODEL_BENCHMARK="$ROOT/bin/model_benchmark"
+[ -f "$EP_DLL" ] || { echo "missing: $EP_DLL"; exit 1; }
+if [ "$TOOL" = "perftest" ]; then
+    [ -x "$PERFTEST" ] || { echo "missing: $PERFTEST"; exit 1; }
+else
+    [ -x "$MODEL_BENCHMARK" ] \
+        || { echo "missing: $MODEL_BENCHMARK -- rebuild with BUILD_OGA=1 ./docker/run.sh build"; exit 1; }
+fi
+
+# ─── PR #212 check: dynamic-shape support is reachable from HEAD ──────────
+# `safe.directory='*'` disarms git's "dubious ownership" check that fires
+# when the bench is run under a docker entrypoint that doesn't re-exec as
+# the host UID. We treat any git failure (missing binary, unowned repo,
+# detached worktree, ...) as "unknown" -- not "absent" -- so the script
+# never falsely forces --shape static on a build that does have #212.
+DYNSEQ_COMMIT="6b5cf01"   # feat: dynamic sequence length -- compile once, run any shape (#212)
+GIT="git -c safe.directory=*"
+pr212_state="unknown"
+if $GIT -C "$SRC_DIR" rev-parse HEAD >/dev/null 2>&1; then
+    if $GIT -C "$SRC_DIR" merge-base --is-ancestor "$DYNSEQ_COMMIT" HEAD 2>/dev/null; then
+        pr212_state="present"
+    else
+        pr212_state="absent"
+    fi
+fi
+case "$pr212_state" in
+    present) echo "[pr212] dynamic-shape support present (commit $DYNSEQ_COMMIT reachable from HEAD)" ;;
+    absent)
+        if [ "$SHAPE" = "dynamic" ]; then
+            echo "WARN: PR #212 ($DYNSEQ_COMMIT) NOT reachable from HEAD; --shape dynamic will likely fail"
+            echo "      forcing --shape static (perftest path only)"
+            if [ "$TOOL" = "oga" ]; then
+                echo "ERROR: cannot fall back to static for --oga (see error above)." >&2
+                exit 1
+            fi
+            SHAPE="static"
+        fi ;;
+    unknown) echo "[pr212] git unavailable; skipping reachability check (trusting --shape=$SHAPE)" ;;
+esac
+
+# ─── resolve model dir ───────────────────────────────────────────────────
+# Models are NOT downloaded by this script. They must already exist at
+# $WORKSPACE/oga_models/<MODEL_REL>/ with model.onnx + model.onnx.data +
+# tokenizer.* + genai_config_MorphiZenEP.json. Typical staging step (one-
+# time, host-side): `huggingface-cli download <repo> --local-dir
+# $WORKSPACE/oga_models/<dir>`.
+MODEL_DIR="$WORKSPACE/oga_models/$MODEL_REL"
+[ -d "$MODEL_DIR" ] || { echo "missing model dir: $MODEL_DIR"; exit 1; }
+MODEL_TAG="$(echo "$MODEL_REL" | tr '/' '_')"
+
+# ─── helpers ─────────────────────────────────────────────────────────────
+# Print the most recent per-op [PERF] table from a bench log. The table is
+# emitted to stderr by op_profile_resolve_and_print (lib/Runtime/op_profile.cpp)
+# at the end of every Compute() call, so a long generation produces hundreds
+# of tables -- the existing tail -n N step strips them. We show only the LAST
+# one (steady-state decode shape) inline; full history stays in the .log file.
+#
+# Self-gating on log content: no per-op tables in the log (e.g. --mode none,
+# or a stale model.dll predating the flush_op_profile export) -> no output.
+# That keeps the helper safe to call unconditionally.
+print_last_op_profile_table() {
+    local log="$1"
+    [ -f "$log" ] || return 0
+    # Locate the last two `[PERF] ===` borders -- they delimit the most recent
+    # table. Done in two passes (grep for line numbers, sed for the slice)
+    # to avoid the tac|awk|tac pipeline that, under `set -o pipefail`, can
+    # propagate a SIGPIPE (exit 141) from an early awk exit and kill the
+    # whole bench script right after printing the table.
+    local borders top bot
+    # `|| true` neutralizes grep's exit-1-on-no-match: under `set -o pipefail`
+    # an empty match would otherwise make the substitution fail, and with
+    # `set -e` the function would die before the `[ -n "$borders" ]` test.
+    borders=$(grep -n '^\[PERF\] ===' "$log" | tail -2 | cut -d: -f1 || true)
+    [ -n "$borders" ] || return 0
+    top=$(printf '%s\n' "$borders" | head -1)
+    bot=$(printf '%s\n' "$borders" | tail -1)
+    # Need two DISTINCT borders for a complete block; a single border means
+    # the run was killed mid-table or the model.dll predates the flush hook
+    # and only the EP-side [PERF SUMMARY] block landed in the log.
+    [ "$top" != "$bot" ] || return 0
+    echo "  --- last per-op table ---"
+    sed -n "${top},${bot}p" "$log" | sed 's/^/  /'
+}
+
+# Resolve the path to the locked-down Python report formatter. Lives next
+# to this script under tools/perf-report/ (both files are tracked + ship
+# together). Kept as a function so callers can `if [ -f "$(format_perf_report)" ]`
+# to feature-detect, and so future relocation is a single edit.
+format_perf_report() {
+    echo "$SCRIPT_DIR/format_perf_report.py"
+}
+
+# Build (idempotently) a minimal model directory for OGA's dynamic single-
+# graph path:
+#   <dst>/model.onnx              -> symlink to <src>/model.onnx
+#   <dst>/model.onnx.data         -> symlink to <src>/model.onnx.data
+#   <dst>/tokenizer.json          -> symlink to <src>/tokenizer.json
+#   <dst>/tokenizer_config.json   -> symlink to <src>/tokenizer_config.json
+#   <dst>/genai_config.json       =  copy of <src>/genai_config_MorphiZenEP.json
+#
+# OGA picks up `genai_config.json` by name -- it has no flag to override the
+# config filename -- so we copy the MorphiZenEP variant into place under the
+# canonical name. Stays in <script-dir>/oga_dynamic_dirs/<tag> so it's
+# adjacent to bench logs, writable by the host user, and easy to wipe
+# (`rm -rf $SCRIPT_DIR/oga_dynamic_dirs/`).
+stage_oga_dynamic_dir() {
+    local src="$1" tag="$2"
+    local dst="$SCRIPT_DIR/oga_dynamic_dirs/$tag"
+    local cfg_src="$src/genai_config_MorphiZenEP.json"
+    [ -f "$cfg_src" ] || {
+        echo "ERROR: $cfg_src not found -- this model dir doesn't ship a dynamic OGA config." >&2
+        return 1
+    }
+    [ -f "$src/model.onnx" ] || {
+        echo "ERROR: $src/model.onnx not found -- this model dir doesn't ship a dynamic ONNX." >&2
+        return 1
+    }
+    mkdir -p "$dst"
+    local f
+    # Use absolute symlinks so the dir is self-describing under `ls -la`.
+    for f in model.onnx model.onnx.data tokenizer.json tokenizer_config.json; do
+        if [ -e "$src/$f" ]; then
+            ln -sfn "$src/$f" "$dst/$f"
+        fi
+    done
+    # Always copy (not symlink) the config so we can safely diverge from it
+    # (e.g. patch chunk_size) without mutating the user's pristine model dir.
+    cp -f "$cfg_src" "$dst/genai_config.json"
+    echo "$dst"
+}
+
+# ─── perftest path ────────────────────────────────────────────────────────
+run_perftest() {
+    local has_per_row has_single
+    has_per_row=$(ls "$MODEL_DIR"/genai_config_p*m16384.json 2>/dev/null | wc -l)
+    has_single=$([ -f "$MODEL_DIR/genai_config.json" ] && echo 1 || echo 0)
+    case "$SHAPE" in
+        static)
+            [ "$has_per_row" -gt 0 ] \
+                || { echo "--shape static but no genai_config_p*m16384.json"; exit 1; } ;;
+        dynamic)
+            [ "$has_single" = 1 ] \
+                || { echo "--shape dynamic but no genai_config.json"; exit 1; } ;;
+    esac
+
+    if [ "${#SEQS[@]}" -eq 0 ]; then
+        if [ "$SHAPE" = "static" ]; then SEQS=(128 2048); else SEQS=(1); fi
+    fi
+
+    # dynamic-shape sanity: warn loudly if user asked for seq>1 (perftest
+    # parser only accepts 2 -f flags; seq>1 dynamic page-faults inside GQA).
+    if [ "$SHAPE" = "dynamic" ]; then
+        local s
+        for s in "${SEQS[@]}"; do
+            if [ "$s" -gt 1 ]; then
+                echo "WARN: --shape dynamic with --seq $s will GPU page-fault (perftest 2-flag parser limit)"
+                echo "      use --shape static for prefill-shape perftest, or --oga for prefill TPS"
+            fi
+        done
+    fi
+
+    local log_dir ts tag_suffix
+    log_dir="$SCRIPT_DIR/_perf_logs"; mkdir -p "$log_dir"
+    ts=$(date +%Y%m%d_%H%M%S)
+    tag_suffix="${TAG:+_$TAG}"
+
+    echo
+    echo "=== $MODEL_TAG | perftest | shape=$SHAPE | seqs=${SEQS[*]} | mode=$MODE | t=${TIME_S}s ==="
+    echo "    model dir: $MODEL_DIR"
+    echo "    log dir  : $log_dir"
+    echo
+
+    local logs=()
+    local seq model_file f_args=() log rc
+    for seq in "${SEQS[@]}"; do
+        case "$SHAPE" in
+            static)
+                model_file="$MODEL_DIR/prefill_p${seq}m16384.onnx"
+                [ -f "$model_file" ] \
+                    || { echo "  SKIP seq=$seq: $model_file not found"; continue; }
+                f_args=() ;;
+            dynamic)
+                model_file="$MODEL_DIR/model.onnx"
+                [ -f "$model_file" ] \
+                    || { echo "  SKIP seq=$seq: $model_file not found"; continue; }
+                f_args=(-f "batch_size:1" -f "sequence_length:$seq") ;;
+        esac
+
+        log="$log_dir/${MODEL_TAG}_perftest_${SHAPE}_seq${seq}_${MODE}${tag_suffix}_${ts}.log"
+        echo "──────────────────────────────────────────────────────"
+        echo " seq=$seq  $(basename "$model_file")  →  $(basename "$log")"
+        echo "──────────────────────────────────────────────────────"
+
+        SECONDS=0
+        "$PERFTEST" \
+            "${f_args[@]}" \
+            --plugin_ep_libs "MorphiZenEP|$EP_DLL" \
+            --plugin_eps     "MorphiZenEP" \
+            -C "session.disable_cpu_ep_fallback|1" \
+            -t "$TIME_S" -c 1 -s -I \
+            "$model_file" >"$log" 2>&1
+        rc=$?
+        printf "  wall: %ds   exit=%d\n" "$SECONDS" "$rc"
+        echo "  --- tail ---"
+        tail -n 18 "$log" | sed 's/^/  /'
+        echo "  ------------"
+        logs+=("$log")
+    done
+
+    if [ "$MODE" = "perf" ] || [ "$MODE" = "debug" ]; then
+        echo
+        echo "=== headline P50 latency per row ==="
+        local L
+        for L in "${logs[@]}"; do
+            [ -f "$L" ] || continue
+            printf '%-60s ' "$(basename "$L")"
+            grep -E "^P50 Latency:" "$L" | head -1 || echo "(no P50 line)"
+        done
+        echo
+        echo "=== [PERF SUMMARY] (per-Compute brackets) ==="
+        for L in "${logs[@]}"; do
+            [ -f "$L" ] || continue
+            if grep -q "^\[PERF SUMMARY\]" "$L"; then
+                echo "--- $(basename "$L") ---"
+                grep -E "^\[PERF SUMMARY\]" "$L" | tail -7
+            fi
+        done
+        echo
+        echo "=== last per-op [PERF] table per row ==="
+        for L in "${logs[@]}"; do
+            [ -f "$L" ] || continue
+            if grep -q "^\[PERF\] ===" "$L"; then
+                echo "--- $(basename "$L") ---"
+                print_last_op_profile_table "$L"
+            fi
+        done
+    fi
+}
+
+# ─── OGA path (model_benchmark on dynamic single-graph model.onnx) ────────
+run_oga() {
+    local oga_dir
+    oga_dir="$(stage_oga_dynamic_dir "$MODEL_DIR" "$MODEL_TAG")" || exit 1
+
+    local log_dir ts tag_suffix log
+    log_dir="$SCRIPT_DIR/_perf_logs"; mkdir -p "$log_dir"
+    ts=$(date +%Y%m%d_%H%M%S)
+    tag_suffix="${TAG:+_$TAG}"
+    log="$log_dir/${MODEL_TAG}_oga_dynamic_p${OGA_PROMPT}g${OGA_GEN}_${MODE}${tag_suffix}_${ts}.log"
+
+    echo
+    echo "=== $MODEL_TAG | OGA model_benchmark | dynamic | l=$OGA_PROMPT g=$OGA_GEN r=$OGA_REPS w=$OGA_WARMUP ==="
+    echo "    model dir (staged): $oga_dir"
+    echo "    log               : $log"
+    echo "──────────────────────────────────────────────────────"
+
+    local -a mb_args=(
+        -i "$oga_dir"
+        -l "$OGA_PROMPT" -g "$OGA_GEN"
+        -r "$OGA_REPS"   -w "$OGA_WARMUP"
+        -b 1
+        -v
+    )
+    if [ -n "$OGA_MAX_LENGTH" ]; then
+        mb_args+=(-ml "$OGA_MAX_LENGTH")
+    fi
+
+    # OGA's EP discovery looks for libonnxruntime_morphizen_ep.so in CWD on
+    # Linux (the Windows equivalent of "next to onnxruntime-genai.dll"). cd
+    # into install/lib so the load succeeds without --ep_library, which
+    # CLAUDE.md flags as a double-registration crash on Windows.
+    SECONDS=0
+    ( cd "$ROOT/lib" && "$MODEL_BENCHMARK" "${mb_args[@]}" ) >"$log" 2>&1
+    local rc=$?
+    printf "  wall: %ds   exit=%d\n" "$SECONDS" "$rc"
+    echo
+
+    if [ "$rc" -ne 0 ]; then
+        # Run failed -- format_perf_report.py would just print "no Batch size:"
+        # warning, so dump the raw tail instead so the error / stack trace is
+        # visible in the terminal (full log still on disk for forensics).
+        echo "  --- raw tail (run failed) ---"
+        tail -n 25 "$log" | sed 's/^/  /'
+        echo "  ------------"
+        return 0
+    fi
+
+    # Happy path: hand off to the locked-down formatter. format_perf_report.py
+    # owns the entire report layout (banner + § 1 HEADLINE + § 2 BREAKDOWN +
+    # § 3 PER-OP + § 4 DISTRIBUTION + [OGA] tail line). It self-gates on log
+    # content -- missing [PERF SUMMARY] / per-op tables under --mode none, or
+    # under an older model.dll predating the flush_op_profile export, will
+    # silently render only the sections that have data.
+    #
+    # --indent 2 keeps the report flush with the rest of the bench output;
+    # exit 2 (no model_benchmark stats) is treated as success here because
+    # the `rc` check above already covered the actual failure path.
+    python3 "$(format_perf_report)" "$log" --indent 2 || true
+}
+
+# ─── dispatch ─────────────────────────────────────────────────────────────
+case "$TOOL" in
+    perftest) run_perftest ;;
+    oga)      run_oga      ;;
+esac
+
+echo
+echo "done. logs in $SCRIPT_DIR/_perf_logs"

--- a/tools/perf-report/run_bench.sh
+++ b/tools/perf-report/run_bench.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+##
+## Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+## Licensed under the MIT License.
+##
+
 # Linux bench driver for the MorphiZen EP. Benchmarks an ONNX model from
 # <workspace>/oga_models/<dir> using one of two host tools, captures the
 # full stderr+stdout to a log under <script-dir>/_perf_logs/, and pipes

--- a/tools/perf-report/run_bench.sh
+++ b/tools/perf-report/run_bench.sh
@@ -5,13 +5,14 @@
 ##
 
 # Linux bench driver for the MorphiZen EP. Benchmarks an ONNX model from
-# <workspace>/oga_models/<dir> using one of two host tools, captures the
+# <workspace>/oga_models/<dir> using one of three host tools, captures the
 # full stderr+stdout to a log under <script-dir>/_perf_logs/, and pipes
 # the result through format_perf_report.py (sibling under this directory).
 #
-# Two tools, selected by flag:
+# Three tools, selected by flag:
 #   (default)  onnxruntime_perf_test       -- per-Run() latency loop (kernel-level)
 #   --oga      install/bin/model_benchmark -- TTFT + decode-TPS (production OGA path)
+#   --mm       install/bin/model_mm        -- multimodal/VLM (image + prompt) TTFT + decode-TPS
 #
 # Both default to the dynamic single-graph model.onnx (PR #212). The decoder-
 # pipeline fixed-shape sub-models are still reachable via --shape static (perftest
@@ -46,6 +47,8 @@
 #   ./tools/perf-report/run_bench.sh --oga --prompt 2048 --gen 128 --max-length 16384
 #   ./tools/perf-report/run_bench.sh --shape static --seq 128 --seq 2048   # perftest, fixed-shape opt-in
 #   ./tools/perf-report/run_bench.sh --model <other-dir>             # different model under oga_models/
+#   ./tools/perf-report/run_bench.sh --mm --model <vlm-dir> --image eiffel.jpg \
+#       --prompt "What is in this image?" --gen 128 --mode none      # multimodal/VLM via model_mm
 
 set -euo pipefail
 
@@ -67,29 +70,45 @@ OGA_WARMUP=1
 OGA_MAX_LENGTH=""           # empty -> let model_benchmark default to prompt+gen
                             # NOTE: CLAUDE.md "For dynamic-shape models, do NOT pass -ml"
                             # -- inflates peak WS without changing TPS/TTFT.
+# Multimodal (--mm) defaults: drives install/bin/model_mm (the OGA C++ VLM
+# example, built only with the OGA examples target) instead of model_benchmark.
+# model_mm reads genai_config.json from the model dir directly, so unlike the
+# --oga path there is no staged dynamic dir.
+MM_IMAGE=""                 # --image: path to the test image (required for --mm)
+MM_PROMPT_TEXT="What is in this image?"   # --prompt text in --mm mode
+MM_SYSTEM="You are a helpful AI assistant."
+MM_VARIANT=""               # optional --variant: swap genai_config_<v>.json into
+                            # genai_config.json for this run (restored on exit)
 
 # ─── arg parse ────────────────────────────────────────────────────────────
 while [ $# -gt 0 ]; do
     case "$1" in
         --model)        MODEL_REL="$2"; shift 2 ;;
         --oga)          TOOL="oga"; shift ;;
+        --mm)           TOOL="mm"; shift ;;
         --shape)        SHAPE="$2"; shift 2 ;;
         --seq)          SEQS+=("$2"); shift 2 ;;
         --time|-t)      TIME_S="$2"; shift 2 ;;
         --mode)         MODE="$2"; shift 2 ;;
         --tag)          TAG="$2"; shift 2 ;;
-        --prompt|-l)    OGA_PROMPT="$2"; shift 2 ;;
+        --image)        MM_IMAGE="$2"; shift 2 ;;
+        --system)       MM_SYSTEM="$2"; shift 2 ;;
+        --variant)      MM_VARIANT="$2"; shift 2 ;;
+        # --prompt is overloaded by tool: an int prompt length for perftest/oga
+        # (-l), the user prompt TEXT for --mm. We store both; each path reads the
+        # one it needs, so a single invocation only ever uses the valid reading.
+        --prompt|-l)    OGA_PROMPT="$2"; MM_PROMPT_TEXT="$2"; shift 2 ;;
         --gen|-g)       OGA_GEN="$2"; shift 2 ;;
         --reps|-r)      OGA_REPS="$2"; shift 2 ;;
         --warmup|-w)    OGA_WARMUP="$2"; shift 2 ;;
         --max-length|-ml) OGA_MAX_LENGTH="$2"; shift 2 ;;
         -h|--help)
-            sed -n '2,43p' "$0"; exit 0 ;;
+            sed -n '2,51p' "$0"; exit 0 ;;
         *)  echo "unknown arg: $1" >&2; exit 1 ;;
     esac
 done
 
-case "$TOOL"  in perftest|oga)    ;; *) echo "bad --tool (internal): $TOOL"  >&2; exit 1 ;; esac
+case "$TOOL"  in perftest|oga|mm) ;; *) echo "bad --tool (internal): $TOOL"  >&2; exit 1 ;; esac
 case "$SHAPE" in dynamic|static)  ;; *) echo "bad --shape: $SHAPE"            >&2; exit 1 ;; esac
 case "$MODE"  in none|perf|debug) ;; *) echo "bad --mode: $MODE"              >&2; exit 1 ;; esac
 
@@ -144,13 +163,21 @@ esac
 EP_DLL="$ROOT/lib/libonnxruntime_morphizen_ep.so"
 PERFTEST="$WORKSPACE/build/onnxruntime/Release/onnxruntime_perf_test"
 MODEL_BENCHMARK="$ROOT/bin/model_benchmark"
+MODEL_MM="$ROOT/bin/model_mm"
 [ -f "$EP_DLL" ] || { echo "missing: $EP_DLL"; exit 1; }
-if [ "$TOOL" = "perftest" ]; then
-    [ -x "$PERFTEST" ] || { echo "missing: $PERFTEST"; exit 1; }
-else
-    [ -x "$MODEL_BENCHMARK" ] \
-        || { echo "missing: $MODEL_BENCHMARK -- rebuild with BUILD_OGA=1 ./docker/run.sh build"; exit 1; }
-fi
+case "$TOOL" in
+    perftest)
+        [ -x "$PERFTEST" ] || { echo "missing: $PERFTEST"; exit 1; } ;;
+    oga)
+        [ -x "$MODEL_BENCHMARK" ] \
+            || { echo "missing: $MODEL_BENCHMARK -- rebuild with BUILD_OGA=1 ./docker/run.sh build"; exit 1; } ;;
+    mm)
+        # model_mm is the OGA C++ multimodal example; it is NOT built by the
+        # default OGA target. Build it with the OGA examples (MODEL_MM=ON) and
+        # stage it into install/bin -- see the model_mm build recipe in the repo.
+        [ -x "$MODEL_MM" ] \
+            || { echo "missing: $MODEL_MM -- build the OGA model_mm example (MODEL_MM=ON) and copy it into $ROOT/bin"; exit 1; } ;;
+esac
 
 # ─── PR #212 check: dynamic-shape support is reachable from HEAD ──────────
 # `safe.directory='*'` disarms git's "dubious ownership" check that fires
@@ -443,10 +470,122 @@ run_oga() {
     python3 "$(format_perf_report)" "$log" --indent 2 || true
 }
 
+# Restore the model dir's genai_config.json after a --variant swap. Defined at
+# script scope (not nested in run_mm) and driven off script-global state so the
+# EXIT/INT/TERM trap can still see the backup path after run_mm has returned.
+# Idempotent: guards on the backup still existing and disarms the trap, so the
+# EXIT firing after an INT/TERM is a clean no-op.
+MM_CFG_BACKUP=""
+MM_ACTIVE_CFG=""
+restore_mm_cfg() {
+    [ -n "$MM_CFG_BACKUP" ] && [ -f "$MM_CFG_BACKUP" ] || return 0
+    cp -f "$MM_CFG_BACKUP" "$MM_ACTIVE_CFG"
+    rm -f "$MM_CFG_BACKUP"
+    trap - EXIT INT TERM
+    echo "Restored original genai_config.json"
+}
+
+# ─── multimodal path (model_mm on the VLM model dir) ─────────────────────
+# Unlike --oga, model_mm reads genai_config.json straight from the model dir,
+# so there is no staged dynamic dir. The dir's active genai_config.json must
+# already select MorphiZenEP (the gpu/allgpu variant). Pass --variant <v> to
+# swap genai_config_<v>.json into place for the run (restored on exit).
+run_mm() {
+    [ -n "$MM_IMAGE" ] || { echo "ERROR: --mm requires --image <path>" >&2; exit 1; }
+
+    # Resolve the image: as given, then relative to the model dir, then under a
+    # sibling packaging dir's test_images/ (covers the bundled sample images).
+    local img="$MM_IMAGE"
+    if [ ! -f "$img" ]; then
+        if [ -f "$MODEL_DIR/$MM_IMAGE" ]; then
+            img="$MODEL_DIR/$MM_IMAGE"
+        else
+            local cand
+            cand=$(ls "$MODEL_DIR"/../*/test_images/"$MM_IMAGE" 2>/dev/null | head -1 || true)
+            [ -n "$cand" ] && img="$cand"
+        fi
+    fi
+    [ -f "$img" ] || { echo "ERROR: image not found: $MM_IMAGE" >&2; exit 1; }
+
+    # Optional provider-variant swap (e.g. --variant allgpu). Backed up and
+    # restored on any exit (success, error, Ctrl-C) so the user's pristine
+    # genai_config.json is never left clobbered. The backup path + active-config
+    # path are deliberately script-GLOBAL (not `local`): the EXIT trap fires
+    # after run_mm has returned, so a function-local would be out of scope and
+    # the restore would silently no-op (leaving the swapped-in config in place).
+    if [ -n "$MM_VARIANT" ]; then
+        local vcfg="$MODEL_DIR/genai_config_${MM_VARIANT}.json"
+        [ -f "$vcfg" ] || { echo "ERROR: variant config not found: $vcfg" >&2; exit 1; }
+        MM_ACTIVE_CFG="$MODEL_DIR/genai_config.json"
+        MM_CFG_BACKUP="$(mktemp)"
+        cp -f "$MM_ACTIVE_CFG" "$MM_CFG_BACKUP"
+        trap restore_mm_cfg EXIT INT TERM
+        echo "Switching active config (temporary): genai_config_${MM_VARIANT}.json -> genai_config.json"
+        cp -f "$vcfg" "$MM_ACTIVE_CFG"
+    fi
+
+    local log_dir ts tag_suffix log
+    log_dir="$SCRIPT_DIR/_perf_logs"; mkdir -p "$log_dir"
+    ts=$(date +%Y%m%d_%H%M%S)
+    tag_suffix="${TAG:+_$TAG}"
+    log="$log_dir/${MODEL_TAG}_mm_${MODE}${tag_suffix}_${ts}.log"
+
+    echo
+    echo "=== $MODEL_TAG | OGA model_mm | image | mode=$MODE ==="
+    echo "    model dir : $MODEL_DIR"
+    echo "    image     : $img"
+    echo "    prompt    : $MM_PROMPT_TEXT"
+    echo "    log       : $log"
+    echo "──────────────────────────────────────────────────────"
+    # NOTE: model_mm IGNORES -g/--max_new_tokens (that flag is honored only by
+    # the model_chat example). Generation runs until EOS, bounded only by
+    # search.max_length in genai_config.json. To cap the token count -- e.g. to
+    # keep a --mode perf run (which dumps a per-op table after EVERY token) from
+    # producing a multi-minute run and a huge log -- point --variant at a config
+    # whose search.max_length is set to (prompt_len + desired_new_tokens).
+
+    # cd into install/lib so OGA auto-discovers libonnxruntime_morphizen_ep.so
+    # from CWD (same EP-discovery trick as the --oga path; no --ep_library).
+    SECONDS=0
+    ( cd "$ROOT/lib" && "$MODEL_MM" \
+        -m "$MODEL_DIR" \
+        --image_paths "$img" \
+        --system_prompt "$MM_SYSTEM" \
+        --user_prompt "$MM_PROMPT_TEXT" \
+        --non_interactive \
+        -v ) >"$log" 2>&1
+    local rc=$?
+    printf "  wall: %ds   exit=%d\n" "$SECONDS" "$rc"
+    echo
+
+    # model_mm prints its own headline timing line (Prompt length / Time to
+    # first / New tokens per second) -- surface it inline regardless of rc.
+    echo "  --- model_mm timing ---"
+    grep -E "Prompt length:|tokens per second|Time to first" "$log" | sed 's/^/  /' || true
+    echo "  ------------------------"
+
+    if [ "$rc" -ne 0 ]; then
+        echo "  --- raw tail (run failed) ---"
+        tail -n 25 "$log" | sed 's/^/  /'
+        echo "  ------------"
+        return 0
+    fi
+
+    # Render the EP-side per-op / per-Compute sections when present (--mode perf).
+    # perf_multimodal_report.py self-gates: a model_mm log has no model_benchmark
+    # "Batch size:" block, so it exits 2 and prints nothing -- hence `|| true`
+    # and the explicit timing grep above carries the headline for --mm.
+    local mm_report="$SCRIPT_DIR/perf_multimodal_report.py"
+    if [ "$MODE" != "none" ] && [ -f "$mm_report" ]; then
+        python3 "$mm_report" "$log" --indent 2 || true
+    fi
+}
+
 # ─── dispatch ─────────────────────────────────────────────────────────────
 case "$TOOL" in
     perftest) run_perftest ;;
     oga)      run_oga      ;;
+    mm)       run_mm       ;;
 esac
 
 echo

--- a/tools/perf-report/run_multimodal_perf.py
+++ b/tools/perf-report/run_multimodal_perf.py
@@ -20,6 +20,7 @@ Workarounds folded in (4-way version skew): pre-load locally-built ORT 1.26
 onnxruntime.dll + DirectML.dll before importing onnxruntime_genai, and chdir to
 the EP bin dir so the plugin loader resolves the EP DLL.
 """
+
 import atexit
 import ctypes
 import os
@@ -29,24 +30,37 @@ import sys
 
 # ===================== EDIT THESE PATHS PER MACHINE =====================
 # Each may also be set via the env var in [brackets]; the env var wins.
-REPO_ROOT  = os.environ.get("HIPDNN_EP_ROOT",  r"C:\Users\Administrator\workspace\onnx-hipdnn-ep")  # onnx-hipdnn-ep checkout (contains install/)
-THEROCK    = os.environ.get("THEROCK_DIST",    r"C:\Users\Administrator\workspace\therock-7.11")    # TheRock ROCm SDK dir
-OGA_DIR    = os.environ.get("HIPDNN_EP_OGA",   r"C:\Python3\Python310\lib\site-packages\onnxruntime_genai")  # onnxruntime_genai package dir
-DML_DLL    = os.environ.get("HIPDNN_EP_DML",   r"C:\Users\Administrator\workspace\onnx-hipdnn-ep\install\oga-build\RelWithDebInfo\_deps\dmllib-src\bin\x64-win\DirectML.dll")  # x64 DirectML.dll
-MODEL_DIR  = os.environ.get("HIPDNN_EP_MODEL", r"")  # OGA model dir (or pass -i)
+REPO_ROOT = os.environ.get(
+    "HIPDNN_EP_ROOT", r"C:\Users\Administrator\workspace\onnx-hipdnn-ep"
+)  # onnx-hipdnn-ep checkout (contains install/)
+THEROCK = os.environ.get(
+    "THEROCK_DIST", r"C:\Users\Administrator\workspace\therock-7.11"
+)  # TheRock ROCm SDK dir
+OGA_DIR = os.environ.get(
+    "HIPDNN_EP_OGA", r"C:\Python3\Python310\lib\site-packages\onnxruntime_genai"
+)  # onnxruntime_genai package dir
+DML_DLL = os.environ.get(
+    "HIPDNN_EP_DML",
+    r"C:\Users\Administrator\workspace\onnx-hipdnn-ep\install\oga-build\RelWithDebInfo\_deps\dmllib-src\bin\x64-win\DirectML.dll",
+)  # x64 DirectML.dll
+MODEL_DIR = os.environ.get("HIPDNN_EP_MODEL", r"")  # OGA model dir (or pass -i)
 IMAGE_PATH = os.environ.get("HIPDNN_EP_IMAGE", r"")  # test image (or pass --image_path)
-OUT_DIR    = os.environ.get("HIPDNN_EP_OUT",   os.getcwd())  # where the CSV + log are written
+OUT_DIR = os.environ.get(
+    "HIPDNN_EP_OUT", os.getcwd()
+)  # where the CSV + log are written
 # ========================================================================
 
 # Install-tree paths (fixed layout under REPO_ROOT).
-ORT_126_DIR  = os.path.join(REPO_ROOT, "install", "onnxruntime", "lib")
+ORT_126_DIR = os.path.join(REPO_ROOT, "install", "onnxruntime", "lib")
 PREBUILT_BIN = os.path.join(REPO_ROOT, "install", "dist", "bin")
 PREBUILT_LIB = os.path.join(REPO_ROOT, "install", "dist", "lib")
-BENCHMARK    = os.path.join(REPO_ROOT, "install", "oga-source",
-                            "benchmark", "python", "benchmark_multimodal.py")
-THEROCK_BIN  = os.path.join(THEROCK, "bin")
-REPORT_SCRIPT = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                             "perf_multimodal_report.py")
+BENCHMARK = os.path.join(
+    REPO_ROOT, "install", "oga-source", "benchmark", "python", "benchmark_multimodal.py"
+)
+THEROCK_BIN = os.path.join(THEROCK, "bin")
+REPORT_SCRIPT = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "perf_multimodal_report.py"
+)
 
 
 # ---- Child mode: do the preloads + exec the benchmark in THIS process --------
@@ -56,8 +70,13 @@ REPORT_SCRIPT = os.path.join(os.path.dirname(os.path.abspath(__file__)),
 # pipe the parent is still draining*, so nothing is lost (unlike redirecting our
 # own fds, where the final flush would race the teardown).
 def _run_child(bench_argv):
-    for d in (THEROCK_BIN, PREBUILT_BIN, ORT_126_DIR, OGA_DIR,
-              os.path.dirname(DML_DLL) if DML_DLL else ""):
+    for d in (
+        THEROCK_BIN,
+        PREBUILT_BIN,
+        ORT_126_DIR,
+        OGA_DIR,
+        os.path.dirname(DML_DLL) if DML_DLL else "",
+    ):
         if d and os.path.isdir(d):
             os.add_dll_directory(d)
             os.environ["PATH"] = d + os.pathsep + os.environ["PATH"]
@@ -67,8 +86,10 @@ def _run_child(bench_argv):
     if os.path.isfile(shared):
         ctypes.CDLL(shared)
     ort = ctypes.CDLL(os.path.join(ORT_126_DIR, "onnxruntime.dll"))
-    print(f"[wrap] Pre-loaded ORT 1.26 onnxruntime.dll handle: {ort._handle:#x}",
-          flush=True)
+    print(
+        f"[wrap] Pre-loaded ORT 1.26 onnxruntime.dll handle: {ort._handle:#x}",
+        flush=True,
+    )
     os.chdir(PREBUILT_BIN)
     print(f"[wrap] cwd -> {os.getcwd()}", flush=True)
     sys.argv = [BENCHMARK] + list(bench_argv)
@@ -95,9 +116,9 @@ def _pop_value(argv, name, default=None):
         i = argv.index(name)
         if i + 1 < len(argv):
             val = argv[i + 1]
-            del argv[i:i + 2]
+            del argv[i : i + 2]
             return val
-        del argv[i:i + 1]
+        del argv[i : i + 1]
     return default
 
 
@@ -129,10 +150,16 @@ else:
     os.environ.setdefault("HIPDNN_EP_PERF", "1")
 os.environ.setdefault("PYTHONUTF8", "1")
 perf_on = os.environ["HIPDNN_EP_PERF"] != "0"
-print(f"[wrap] HIPDNN_EP_PERF={os.environ['HIPDNN_EP_PERF']}"
-      + ("  (per-op profiling ON; tok/s are instrumentation-bound -- "
-         "use --perf 0 for throughput)" if perf_on else "  (throughput mode)"),
-      flush=True)
+print(
+    f"[wrap] HIPDNN_EP_PERF={os.environ['HIPDNN_EP_PERF']}"
+    + (
+        "  (per-op profiling ON; tok/s are instrumentation-bound -- "
+        "use --perf 0 for throughput)"
+        if perf_on
+        else "  (throughput mode)"
+    ),
+    flush=True,
+)
 
 
 # ---- Auto-select the MorphiZenEP genai_config variant -----------------------
@@ -148,25 +175,33 @@ def maybe_swap_config(model_dir, keep):
     if "MorphiZenEP" in txt:
         return  # already MorphiZenEP
     if not os.path.isfile(variant):
-        print("[wrap] WARN: genai_config.json has no MorphiZenEP provider and "
-              "no genai_config_MorphiZenEP.json variant found; running as-is.",
-              flush=True)
+        print(
+            "[wrap] WARN: genai_config.json has no MorphiZenEP provider and "
+            "no genai_config_MorphiZenEP.json variant found; running as-is.",
+            flush=True,
+        )
         return
     backup = cfg + ".orig"
     if not os.path.exists(backup):
         shutil.copyfile(cfg, backup)
     shutil.copyfile(variant, cfg)
-    print(f"[wrap] swapped genai_config.json -> MorphiZenEP variant "
-          f"(original backed up to {os.path.basename(backup)})", flush=True)
+    print(
+        f"[wrap] swapped genai_config.json -> MorphiZenEP variant "
+        f"(original backed up to {os.path.basename(backup)})",
+        flush=True,
+    )
     if not keep:
+
         def _restore():
             try:
                 if os.path.exists(backup):
                     shutil.copyfile(backup, cfg)
-                    print(f"[wrap] restored original genai_config.json", flush=True)
+                    print("[wrap] restored original genai_config.json", flush=True)
             except Exception as e:
-                print(f"[wrap] WARN: failed to restore genai_config.json: {e}",
-                      flush=True)
+                print(
+                    f"[wrap] WARN: failed to restore genai_config.json: {e}", flush=True
+                )
+
         atexit.register(_restore)
 
 
@@ -174,8 +209,22 @@ if eff_model:
     maybe_swap_config(eff_model, opt_keep_config)
 
 # ---- Assemble the benchmark argv --------------------------------------------
-DEFAULT_ARGV = ["-g", "64", "-m", "2048", "-r", "10", "-w", "1",
-                "-k", "1", "-p", "1.0", "-v", "-mo"]
+DEFAULT_ARGV = [
+    "-g",
+    "64",
+    "-m",
+    "2048",
+    "-r",
+    "10",
+    "-w",
+    "1",
+    "-k",
+    "1",
+    "-p",
+    "1.0",
+    "-v",
+    "-mo",
+]
 argv = list(DEFAULT_ARGV) + list(user_args)
 # Inject model/image from CONFIG only if the user didn't pass them.
 if not _last_value(user_args, "-i", "--input_folder") and MODEL_DIR:
@@ -222,8 +271,11 @@ def run_and_tee(bench_argv, log_file_path):
     child_env["PYTHONUNBUFFERED"] = "1"
     proc = subprocess.Popen(
         [sys.executable, os.path.abspath(__file__)] + list(bench_argv),
-        env=child_env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-        bufsize=0)
+        env=child_env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        bufsize=0,
+    )
     out = sys.stdout.buffer
     with open(log_file_path, "wb") as logf:
         while True:

--- a/tools/perf-report/run_multimodal_perf.py
+++ b/tools/perf-report/run_multimodal_perf.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Portable smoke-test runner for benchmark_multimodal.py on a locally-built
+MorphiZen EP / OGA (ORT 1.26 / OGA 0.13 / MorphiZenEP plugin).
+
+To run on a new machine: set the paths at the top of this file (or the matching
+env vars). The install-tree paths derive from REPO_ROOT. Then:
+
+    python run_multimodal_perf.py -i <model_dir> --image_path <img> --perf 0 --report
+
+Our own flags (consumed here, NOT forwarded to the benchmark):
+  --perf {0,1}    set HIPDNN_EP_PERF (default 1). Use 0 for true throughput
+                  (PERF=1 adds profiling fences and is NOT a throughput number).
+  --log PATH      tee ALL output (incl. native EP [PERF] lines) to a UTF-8 file.
+                  Default: <OUT_DIR>/<image>_smoke.log
+  --report        after the run, render perf_multimodal_report.py on the log + CSV.
+  --keep-config   do not restore the model's genai_config.json after the run.
+Any other args are forwarded to benchmark_multimodal.py (e.g. -g -m -r -w -k).
+
+Workarounds folded in (4-way version skew): pre-load locally-built ORT 1.26
+onnxruntime.dll + DirectML.dll before importing onnxruntime_genai, and chdir to
+the EP bin dir so the plugin loader resolves the EP DLL.
+"""
+import atexit
+import ctypes
+import os
+import shutil
+import subprocess
+import sys
+
+# ===================== EDIT THESE PATHS PER MACHINE =====================
+# Each may also be set via the env var in [brackets]; the env var wins.
+REPO_ROOT  = os.environ.get("HIPDNN_EP_ROOT",  r"C:\Users\Administrator\workspace\onnx-hipdnn-ep")  # onnx-hipdnn-ep checkout (contains install/)
+THEROCK    = os.environ.get("THEROCK_DIST",    r"C:\Users\Administrator\workspace\therock-7.11")    # TheRock ROCm SDK dir
+OGA_DIR    = os.environ.get("HIPDNN_EP_OGA",   r"C:\Python3\Python310\lib\site-packages\onnxruntime_genai")  # onnxruntime_genai package dir
+DML_DLL    = os.environ.get("HIPDNN_EP_DML",   r"C:\Users\Administrator\workspace\onnx-hipdnn-ep\install\oga-build\RelWithDebInfo\_deps\dmllib-src\bin\x64-win\DirectML.dll")  # x64 DirectML.dll
+MODEL_DIR  = os.environ.get("HIPDNN_EP_MODEL", r"")  # OGA model dir (or pass -i)
+IMAGE_PATH = os.environ.get("HIPDNN_EP_IMAGE", r"")  # test image (or pass --image_path)
+OUT_DIR    = os.environ.get("HIPDNN_EP_OUT",   os.getcwd())  # where the CSV + log are written
+# ========================================================================
+
+# Install-tree paths (fixed layout under REPO_ROOT).
+ORT_126_DIR  = os.path.join(REPO_ROOT, "install", "onnxruntime", "lib")
+PREBUILT_BIN = os.path.join(REPO_ROOT, "install", "dist", "bin")
+PREBUILT_LIB = os.path.join(REPO_ROOT, "install", "dist", "lib")
+BENCHMARK    = os.path.join(REPO_ROOT, "install", "oga-source",
+                            "benchmark", "python", "benchmark_multimodal.py")
+THEROCK_BIN  = os.path.join(THEROCK, "bin")
+REPORT_SCRIPT = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                             "perf_multimodal_report.py")
+
+
+# ---- Child mode: do the preloads + exec the benchmark in THIS process --------
+# We re-exec ourselves as a child so the parent can capture the child's combined
+# stdout/stderr (including native EP fd-1/2 output) over a pipe and write a UTF-8
+# log. A child process flushes its C-runtime stdio buffers on exit *into the
+# pipe the parent is still draining*, so nothing is lost (unlike redirecting our
+# own fds, where the final flush would race the teardown).
+def _run_child(bench_argv):
+    for d in (THEROCK_BIN, PREBUILT_BIN, ORT_126_DIR, OGA_DIR,
+              os.path.dirname(DML_DLL) if DML_DLL else ""):
+        if d and os.path.isdir(d):
+            os.add_dll_directory(d)
+            os.environ["PATH"] = d + os.pathsep + os.environ["PATH"]
+    if DML_DLL and os.path.isfile(DML_DLL):
+        ctypes.CDLL(DML_DLL)
+    shared = os.path.join(ORT_126_DIR, "onnxruntime_providers_shared.dll")
+    if os.path.isfile(shared):
+        ctypes.CDLL(shared)
+    ort = ctypes.CDLL(os.path.join(ORT_126_DIR, "onnxruntime.dll"))
+    print(f"[wrap] Pre-loaded ORT 1.26 onnxruntime.dll handle: {ort._handle:#x}",
+          flush=True)
+    os.chdir(PREBUILT_BIN)
+    print(f"[wrap] cwd -> {os.getcwd()}", flush=True)
+    sys.argv = [BENCHMARK] + list(bench_argv)
+    with open(BENCHMARK) as f:
+        code = compile(f.read(), BENCHMARK, "exec")
+    exec(code, {"__name__": "__main__", "__file__": BENCHMARK})
+
+
+if os.environ.get("_OGA_SMOKE_CHILD") == "1":
+    _run_child(sys.argv[1:])
+    sys.exit(0)
+
+
+# ---- Parse OUR flags out of argv; the rest is forwarded to the benchmark -----
+def _pop_flag(argv, name):
+    if name in argv:
+        argv.remove(name)
+        return True
+    return False
+
+
+def _pop_value(argv, name, default=None):
+    if name in argv:
+        i = argv.index(name)
+        if i + 1 < len(argv):
+            val = argv[i + 1]
+            del argv[i:i + 2]
+            return val
+        del argv[i:i + 1]
+    return default
+
+
+user_args = sys.argv[1:]
+opt_perf = _pop_value(user_args, "--perf", None)
+opt_log = _pop_value(user_args, "--log", None)
+opt_report = _pop_flag(user_args, "--report")
+opt_keep_config = _pop_flag(user_args, "--keep-config")
+
+
+def _last_value(args, *flags):
+    found = None
+    for i, tok in enumerate(args):
+        if tok in flags and i + 1 < len(args):
+            found = args[i + 1]
+    return found
+
+
+# Effective model: CLI (-i) wins over the path block; used for the config swap.
+eff_model = _last_value(user_args, "-i", "--input_folder", "-im_dir") or MODEL_DIR
+
+
+# ---- Environment ------------------------------------------------------------
+os.environ["THEROCK_DIST"] = THEROCK
+os.environ["HIP_CUSTOM_KERNELS_DIR"] = PREBUILT_LIB
+if opt_perf is not None:
+    os.environ["HIPDNN_EP_PERF"] = opt_perf
+else:
+    os.environ.setdefault("HIPDNN_EP_PERF", "1")
+os.environ.setdefault("PYTHONUTF8", "1")
+perf_on = os.environ["HIPDNN_EP_PERF"] != "0"
+print(f"[wrap] HIPDNN_EP_PERF={os.environ['HIPDNN_EP_PERF']}"
+      + ("  (per-op profiling ON; tok/s are instrumentation-bound -- "
+         "use --perf 0 for throughput)" if perf_on else "  (throughput mode)"),
+      flush=True)
+
+
+# ---- Auto-select the MorphiZenEP genai_config variant -----------------------
+def maybe_swap_config(model_dir, keep):
+    cfg = os.path.join(model_dir, "genai_config.json")
+    variant = os.path.join(model_dir, "genai_config_MorphiZenEP.json")
+    if not os.path.isfile(cfg):
+        return
+    try:
+        txt = open(cfg, encoding="utf-8", errors="replace").read()
+    except Exception:
+        return
+    if "MorphiZenEP" in txt:
+        return  # already MorphiZenEP
+    if not os.path.isfile(variant):
+        print("[wrap] WARN: genai_config.json has no MorphiZenEP provider and "
+              "no genai_config_MorphiZenEP.json variant found; running as-is.",
+              flush=True)
+        return
+    backup = cfg + ".orig"
+    if not os.path.exists(backup):
+        shutil.copyfile(cfg, backup)
+    shutil.copyfile(variant, cfg)
+    print(f"[wrap] swapped genai_config.json -> MorphiZenEP variant "
+          f"(original backed up to {os.path.basename(backup)})", flush=True)
+    if not keep:
+        def _restore():
+            try:
+                if os.path.exists(backup):
+                    shutil.copyfile(backup, cfg)
+                    print(f"[wrap] restored original genai_config.json", flush=True)
+            except Exception as e:
+                print(f"[wrap] WARN: failed to restore genai_config.json: {e}",
+                      flush=True)
+        atexit.register(_restore)
+
+
+if eff_model:
+    maybe_swap_config(eff_model, opt_keep_config)
+
+# ---- Assemble the benchmark argv --------------------------------------------
+DEFAULT_ARGV = ["-g", "64", "-m", "2048", "-r", "10", "-w", "1",
+                "-k", "1", "-p", "1.0", "-v", "-mo"]
+argv = list(DEFAULT_ARGV) + list(user_args)
+# Inject model/image from CONFIG only if the user didn't pass them.
+if not _last_value(user_args, "-i", "--input_folder") and MODEL_DIR:
+    argv = ["-i", MODEL_DIR] + argv
+if not _last_value(user_args, "--image_path", "-im") and IMAGE_PATH:
+    argv = ["--image_path", IMAGE_PATH] + argv
+
+# CSV output (derived from image stem; into OUT_DIR) unless user gave -o.
+csv_out = _last_value(argv, "-o", "--output")
+if not csv_out:
+    img = _last_value(argv, "--image_path", "-im") or "run"
+    stem = os.path.splitext(os.path.basename(img))[0]
+    os.makedirs(OUT_DIR, exist_ok=True)
+    csv_out = os.path.join(OUT_DIR, f"{stem}_mm.csv")
+    argv += ["-o", csv_out]
+
+# Log path (UTF-8, written by us): default into OUT_DIR.
+if opt_log:
+    log_path = opt_log
+else:
+    img = _last_value(argv, "--image_path", "-im") or "run"
+    stem = os.path.splitext(os.path.basename(img))[0]
+    os.makedirs(OUT_DIR, exist_ok=True)
+    log_path = os.path.join(OUT_DIR, f"{stem}_smoke.log")
+
+reps = int(_last_value(argv, "-r", "--repetitions") or "10")
+print(f"[wrap] CSV  -> {csv_out}", flush=True)
+print(f"[wrap] log  -> {log_path}  (UTF-8)", flush=True)
+print(f"[wrap] argv -> {argv}", flush=True)
+
+
+# ---- Spawn the child (this script in --child mode) and tee to a UTF-8 log ----
+# Capturing a *child* process gives us its combined stdout+stderr (incl. the
+# native EP fd-1/2 output) and, crucially, the child's exit-time C-runtime flush
+# lands in the pipe we are still draining -- so the UTF-8 log is complete.
+def run_and_tee(bench_argv, log_file_path):
+    child_env = os.environ.copy()
+    child_env["_OGA_SMOKE_CHILD"] = "1"
+    child_env["THEROCK_DIST"] = THEROCK
+    child_env["HIP_CUSTOM_KERNELS_DIR"] = PREBUILT_LIB
+    child_env["HIPDNN_EP_PERF"] = os.environ["HIPDNN_EP_PERF"]
+    child_env["PYTHONUTF8"] = "1"
+    child_env["PYTHONIOENCODING"] = "utf-8"
+    child_env["PYTHONUNBUFFERED"] = "1"
+    proc = subprocess.Popen(
+        [sys.executable, os.path.abspath(__file__)] + list(bench_argv),
+        env=child_env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        bufsize=0)
+    out = sys.stdout.buffer
+    with open(log_file_path, "wb") as logf:
+        while True:
+            chunk = proc.stdout.readline()
+            if not chunk:
+                if proc.poll() is not None:
+                    break
+                continue
+            out.write(chunk)
+            out.flush()
+            logf.write(chunk)
+            logf.flush()
+    return proc.wait()
+
+
+rc = run_and_tee(argv, log_path)
+
+# atexit restore (config) runs at process exit.
+
+# ---- Optional: render the perf report on the captured UTF-8 log + CSV --------
+if opt_report:
+    if not os.path.isfile(REPORT_SCRIPT):
+        print(f"[wrap] --report: {REPORT_SCRIPT} not found; skipping.", flush=True)
+    else:
+        print("\n[wrap] ===== perf_multimodal_report =====", flush=True)
+        cmd = [sys.executable, REPORT_SCRIPT, log_path]
+        if os.path.isfile(csv_out):
+            cmd.append(csv_out)
+        cmd += ["--reps", str(reps)]
+        subprocess.run(cmd)
+
+sys.exit(rc)

--- a/tools/perf-report/run_multimodal_perf.py
+++ b/tools/perf-report/run_multimodal_perf.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
 """Portable smoke-test runner for benchmark_multimodal.py on a locally-built
 MorphiZen EP / OGA (ORT 1.26 / OGA 0.13 / MorphiZenEP plugin).
 


### PR DESCRIPTION
## What this PR does

When you turn the profiler on with `HIPDNN_EP_PERF=1`, it was skewing its own numbers. There were two problems:

1. The per-op timing work — recording the HIP events and printing the table — happened *inside* the same window we use to time each `Compute()` call. So the profiler was charging its own cost to the model and reporting throughput lower than the model actually runs at.
2. Every profiling event used a default system fence. That adds a little cost on every single record, and at the margins it could even make a slower kernel look faster than a quicker one.

This PR fixes both, and along the way it adds the same per-op profiling to the output-allocator path (the default for KV-cache models, which until now produced no per-op data at all). It also adds a few small tools that turn the raw `[PERF]` log into a readable report.

With the profiler **off** there is no overhead — none of this code runs. The numbers below are about the cost *when you ask for profiling*.

## Commits (please review in this order)

Only the first commit touches runtime/EP code — that's the one to look at closely. The other three are tooling and have no effect on the build or runtime.

* **`d42d5915` — the profiler fix.** Three things:
  * Create every profiling event with `hipEventDisableSystemFence`. This is safe because we only read the timing with `hipEventElapsedTime` *after* a `hipStreamSynchronize`, so the fence wasn't buying us anything. The reasoning is written out in one place (`op_profile.cpp`) and the other call sites point back to it.
  * Move the "resolve and print the per-op table" step *out* of the timed window. The EP now calls a new runtime hook, `hipdnn_ep_runtime_flush_op_profile`, right after the timing window closes. This is backwards compatible: an older `model.dll` that doesn't export the symbol simply skips the step (the cached function pointer is null), exactly like the existing `begin_compute` hook.
  * Allocate the EP's own timing event pair once per session and reuse it, instead of creating and destroying it on every `Compute()`.
  * Same commit also adds the timing to the output-allocator path and folds the shared event/timing logic into one small `EpPerfTimer` helper that both paths use, so there's no copy-pasted timing code.
* **`2d672ccf`** — `format_perf_report.py`: a standard-library-only Python script that turns a raw `[PERF]` log into a four-section report (headline, decode breakdown, per-op GPU table, per-call distribution).
* **`cfe7af00`** — `run_bench.sh` + `docker_run_bench.sh`: a one-command way to run a benchmark and format the result.
* **`4e4d61c5`** — a benchmark runner and report formatter for multimodal (VLM) models. Tooling only, no runtime impact.

<details><summary>Sample <code>--mode perf</code> report (Llama-3.1-8B)</summary>

```
$ tools/perf-report/docker_run_bench.sh --oga --prompt 128 --gen 128 --reps 3 --warmup 1 --mode perf
[pr212] dynamic-shape support present (commit 6b5cf01 reachable from HEAD)

=== Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml | OGA model_benchmark | dynamic | l=128 g=128 r=3 w=1 ===
    model dir (staged): tools/perf-report/oga_dynamic_dirs/Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml
    log               : tools/perf-report/_perf_logs/Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml_oga_dynamic_p128g128_perf_20260602_155310.log
──────────────────────────────────────────────────────
  wall: 29s   exit=0

  ════════════════════════════════════════════════════════════════════════════
    HIPDNN EP profile  ·  Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml  ·  prompt=128 gen=128  ·  inferences=639
  ════════════════════════════════════════════════════════════════════════════

    § 1  HEADLINE  —  model_benchmark (batch=1, prompt=128, gen=128)
    ──────────────────────────────────────────────────────────────────────────
                            throughput     p50 latency        stddev   samples
      Prefill (TTFT)        743.03 t/s    166367.06 us   13173.46 us   3 * 128 token(s)
      Decode                 39.82 t/s     25080.20 us     178.63 us   381 * 1 token(s)
      Sampling            15290.29 t/s        65.22 us       1.17 us   3 * 1 token(s)
      E2E generation                 —      3353.94 ms      16.99 ms   3
      Peak working set   1.52 GiB (1630154752 bytes)

    § 2  STEADY-STATE DECODE BREAKDOWN  —  1 decode token, median across run
    ──────────────────────────────────────────────────────────────────────────
                                                    latency    share   source
      OGA::GenerateNextToken                      25.080 ms   100.0 %   ◀ § 1 Decode p50
      ├─ OGA + ORT framework overhead              1.015 ms     4.0 %
      │  ├─ Token sampling                         0.065 ms     0.3 %   ◀ § 1 Sampling avg
      │  └─ Other (IoBinding rebind, etc.)         0.950 ms     3.8 %
      └─ EP MlirCustomOp::Compute()               24.065 ms    96.0 %   ◀ § 4 wall_ms
         ├─ Marshal in (input descriptors)         0.006 ms     0.0 %   ◀ § 4 marshal_in_ms
         ├─ Marshal out (output desc.)             0.054 ms     0.2 %   ◀ § 4 marshal_out_ms
         ├─ model.dll inference_compute()         23.995 ms    95.7 %   ◀ § 4 compute_cpu_ms
         │  ├─ GPU: OP_PROFILE kernels (sum)      22.900 ms    91.3 %   ◀ § 3 TOTAL
         │  ├─ GPU: outside § 3 scopes             1.051 ms     4.2 %
         │  └─ CPU: host dispatch + sync poll      0.044 ms     0.2 %
         └─ Trailing fence (hipStreamSync)         0.009 ms     0.0 %   ◀ § 4 fence_residual_ms

      notes:
        - "GPU: outside § 3 scopes" = § 4 gpu_ms − § 3 TOTAL: GPU work not bracketed by any
          OP_PROFILE wrapper. Typical sources: MIOpen / hipBLASLt internal helper
          launches, ops lacking an OP_PROFILE scope, hipMemset / glue between ops. If
          this row grows after a runtime change, OP_PROFILE coverage has regressed.
        - "Other (IoBinding rebind, etc.)" = § 1 Decode p50 − sampling − EP wall: OGA
          framework overhead between Generator steps. Dominated by IoBinding's per-token
          rebind of all input/output tensors (scales with KV buffer size, not seq len).

    § 3  PER-OP GPU BREAKDOWN  —  last Compute() = steady-state decode token
    ──────────────────────────────────────────────────────────────────────────
      ===============================================================
                                     calls  gpu (ms)  cpu (ms)  gpu %
       matmul_nbits                    225      20.1       0.6  87.3%
         m=1,n=14336,k=4096             64      10.0       0.2  43.3%
         m=1,n=4096,k=14336             32       4.5       0.1  19.6%
         m=1,n=4096,k=4096              64       3.2       0.2  14.0%
         m=1,n=128256,k=4096             1       1.3       0.0   5.4%
         m=1,n=1024,k=4096              64       1.1       0.2   4.9%
       skip_layernorm                   64       1.0       0.3   4.4%
         1x4096                         64       1.0       0.3   4.4%
       gqa                              32       1.0       0.3   4.2%
         b=1,sq=1,skv=256,h=32,d=128    32       1.0       0.3   4.2%
       rotary_emb                       64       0.4       0.2   1.5%
         h=32,hd=128,rd=128,bnsh=0      32       0.2       0.1   0.9%
         h=8,hd=128,rd=128,bnsh=0       32       0.1       0.1   0.6%
       elementwise                      64       0.3       0.2   1.2%
         1x1x1x14336                    64       0.3       0.2   1.2%
       activation                       32       0.3       0.1   1.2%
         n=14336                        32       0.3       0.1   1.2%
       layernorm                         1       0.0       0.0   0.0%
         1x4096                          1       0.0       0.0   0.0%
       cast                              2       0.0       0.0   0.0%
         n=1                             2       0.0       0.0   0.0%
       reduce_sum                        1       0.0       0.0   0.0%
         256->1                          1       0.0       0.0   0.0%
       gather                            1       0.0       0.0   0.0%
         n=4096                          1       0.0       0.0   0.0%
       sub                               1       0.0       0.0   0.0%
         n=1                             1       0.0       0.0   0.0%
       TOTAL                                    23.1       1.8
      ===============================================================

    § 4  PER-CALL DISTRIBUTION  —  EP MlirCustomOp::Compute() over 639 invocations (all ms)
    ──────────────────────────────────────────────────────────────────────────
                                min     median        p99          max
      wall_ms                23.738     24.065     25.185     8005.980
      compute_cpu_ms         23.672     23.995     25.038     8000.806
      gpu_ms                 23.632     23.951     24.994     8000.736
      marshal_in_ms           0.006      0.006      0.011        0.017
      marshal_out_ms          0.048      0.054      0.117        5.152
      fence_residual_ms       0.008      0.009      0.011        0.046
      notes:
        - `max` includes first-Compute cold start (kernel autotune + pool grow);
          § 2 uses median to skip those outliers.
        - this count covers ALL EP calls (warmup + verbose-display + timed reps);
          § 1's per-block `samples` column is the OGA-timed subset only.

  ════════════════════════════════════════════════════════════════════════════
    [OGA] prefill=743.03 tok/s  TTFT=172.27 ms  decode=39.82 tok/s  peak_WS=1.52 GiB (1630154752 bytes)
  ════════════════════════════════════════════════════════════════════════════

done. logs in tools/perf-report/_perf_logs
```

</details>

## How much overhead is left when profiling is on

Measured on gfx1151 (Strix Halo, 16 CUs), dynamic-shape single graph, OGA `model_benchmark`, L=128 / G=128, `-r 3 -w 1`. `--mode none` means the profiler is off — that's the real performance. `--mode perf` turns it on and adds the per-op `hipEventRecord` pair on every profiled op, plus the resolve/flush between calls. Quote the **off** numbers as the headline throughput; the **on** numbers are only useful for reading the per-op breakdown.

### Llama-3.1-8B-awq-g128-int4-asym

| Metric | profile OFF (`--mode none`) | profile ON (`--mode perf`) | Δ |
|---|---|---|---|
| Prefill | 702.85 t/s | 689.84 t/s | −1.9% |
| Decode  | 42.66 t/s  | 39.48 t/s  | −7.5% |
| TTFT    | 182.12 ms  | 185.55 ms  | +1.9% |
| Peak working set | 1.52 GiB | 1.52 GiB | ~0 |

### phi4-14B-int4-rtn-block-32

| Metric | profile OFF (`--mode none`) | profile ON (`--mode perf`) | Δ |
|---|---|---|---|
| Prefill | 763.57 t/s | 756.81 t/s | −0.9% |
| Decode  | 24.82 t/s  | 22.94 t/s  | −7.6% |
| TTFT    | 167.63 ms  | 169.13 ms  | +0.9% |
| Peak working set | 1.50 GiB | 1.50 GiB | ~0 |

Decode takes the bigger hit (~7.5%) because it pays the per-op record-and-flush cost on every single-token step, and there are hundreds of those per run (381 here). Prefill spreads the same fixed cost over a handful of large calls, so it's under 2%. Peak memory doesn't move — the event pool is tiny. The two fixes in `d42d5915` (disabling the system fence and moving the resolve/print out of the timed window) are what keep the leftover overhead this small.

### Multimodal / VLM (Qwen3.5-9B, `model_mm` via the new `--mm` path)

Same comparison via the new `--mm` mode (`model_mm`, image `eiffel.jpg` + prompt
"What is in this image?"). Fixed work: **130 new tokens** from an **894-token
prompt** (894 includes image patch tokens). The cap is set with a `--variant`
config (`search.max_length = 894 + 130`) because `model_mm` ignores `-g`.

| Metric | profile OFF (`--mode none`) | profile ON (`--mode perf`) | Δ |
|---|---|---|---|
| Decode | 18.40 t/s | 16.82 t/s | −8.6% |
| TTFT   | 12.29 s   | 12.25 s   | ~0 |
| New tokens generated | 130 | 130 | — |

Command (host wrapper; `--variant perfcap` is the capped-`max_length` config):

```bash
tools/perf-report/docker_run_bench.sh --mm --variant perfcap \
    --model <vlm-dir> --image eiffel.jpg --prompt "What is in this image?" \
    --mode none          # and --mode perf for the profiler-on run
```

P.S. `run_bench.sh --model` currently takes a directory name, not an absolute path — it looks for `$WORKSPACE/oga_models/<name>/`. Happy to extend it to absolute paths in a follow-up if reviewers would prefer.


