### PR TITLE
fix: integrate host-mapped scratch into MM for dynamic shapes

### DIFF
--- a/lib/MemoryManager/mm_hal.cpp
+++ b/lib/MemoryManager/mm_hal.cpp
@@ -36,8 +36,7 @@ public:
   Status free(void *ptr) override { return hip_error_to_status(hipFree(ptr)); }
 
   Status host_mapped_malloc(void **ptr, std::size_t size) override {
-    return hip_error_to_status(
-        hipHostMalloc(ptr, size, hipHostMallocMapped));
+    return hip_error_to_status(hipHostMalloc(ptr, size, hipHostMallocMapped));
   }
 
   Status host_mapped_free(void *ptr) override {


### PR DESCRIPTION
## Summary

- Fixes #274 — dynamic-shape models fail to link after PR #232 deleted `hipdnn_ep_get_host_scratch_base`
- Instead of restoring the old direct `hipHostMalloc` calls, integrates host-mapped allocation into the Memory Manager with a new `MemoryClass::HostMapped` class
- All host-mapped GPU memory now flows through `mm::alloc`/`mm::free`, keeping allocation tracking unified

## Changes

**Memory Manager (HAL + core):**
- `mm_hal.h/cpp`: Add `host_mapped_malloc`/`host_mapped_free` virtual methods wrapping `hipHostMalloc(hipHostMallocMapped)` / `hipHostFree`
- `mm_types.h`: Add `MemoryClass::HostMapped = 5`
- `mm_core.cpp`: Route HostMapped alloc through `hal->host_mapped_malloc`, free through `hal->host_mapped_free`, shutdown handles HostMapped correctly

**Runtime (fix for #274):**
- `runtime_state_internal.h`: Restore `host_scratch_base`, `host_scratch_size`, add `host_scratch_handle` for MM tracking
- `hipdnn_ep_runtime.h`: Restore `hipdnn_ep_get_host_scratch_base` declaration
- `hipdnn_ep_runtime_state.cpp`: Reimplement function using `mm::alloc(HostMapped)` / `mm::free` instead of direct `hipHostMalloc`/`hipHostFree`; init and cleanup via MM handle

**Tests + docs:**
- `mm_tests.cpp`: New `HostMappedAllocFree` test
- `memory-manager.md`: Updated HAL and call tree docs

## Why host-mapped?

The `hip-materialize-host-scalars` pass redirects tiny integer scalars that the host CPU writes (`memref.store`) and the GPU reads (`hip.*` ops). On targets where `hipMalloc` returns true device memory, host writes SEGV. `hipHostMalloc(hipHostMallocMapped)` creates a single VA accessible from both sides.

## Test plan

- [ ] CI `build-windows-mock` passes (MM not compiled in mock builds)
- [ ] CI `build-windows` + `linux-build` pass
- [ ] `mm_tests` pass including new `HostMappedAllocFree`
- [ ] Dynamic-shape model compiles without `undefined symbol` error
- [ ] Fixed-shape `gpu-test` passes (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)