### PR TITLE
feat(gqa): no_causal flag + fp32 decomposed attention path -- 2/n [Ready]

### DIFF
--- a/3rd-party/custom_kernels/hip/gqa_kernel.hip
+++ b/3rd-party/custom_kernels/hip/gqa_kernel.hip
@@ -15,6 +15,42 @@ static constexpr int GQA_THREADS = 256;
 static constexpr int WAVE_SIZE = 32;  // RDNA wave32; not portable to CDNA/wave64
 static constexpr float LOG2E = 1.4426950408889634f;
 
+// Element-size dispatch helper for the pure data-movement kernels (transpose,
+// kv-cache append/concat, kv-expand, split-qkv). These kernels only copy bytes
+// of the element type, so templating them on T and selecting __half (2 bytes)
+// vs float (4 bytes) is sufficient to fp32-enable the decomposed GQA path
+// (Whisper no_causal). 2 == fp16, 4 == fp32; anything else is an error.
+#define GQA_DISPATCH_BY_ELEM_SIZE(elem_size, FN, ...)                          \
+  do {                                                                         \
+    /* Clear any stale error so a launch failure is attributed to THIS         \
+     * kernel, not blamed on the next op that happens to call                  \
+     * hipGetLastError() (was misreported as "hip_layer_norm launch           \
+     * failed" on the Whisper path). */                                        \
+    (void)hipGetLastError();                                                   \
+    if ((elem_size) == 2) {                                                    \
+      FN<__half>(__VA_ARGS__);                                                 \
+    } else if ((elem_size) == 4) {                                            \
+      FN<float>(__VA_ARGS__);                                                  \
+    } else {                                                                   \
+      fprintf(stderr, "%s: unsupported element_size_bytes=%d (must be 2 or 4)\n", \
+              __func__, (int)(elem_size));                                     \
+      return -1;                                                               \
+    }                                                                          \
+  } while (0)
+
+// Report (and return) the launch status of the kernel issued just above.
+// hipGetLastError() returns + clears the most recent error, so pairing this
+// with the clear in GQA_DISPATCH_BY_ELEM_SIZE (or an explicit clear before a
+// raw <<<>>> launch) attributes errors to the correct kernel.
+#define GQA_RETURN_LAUNCH_STATUS()                                             \
+  do {                                                                         \
+    hipError_t _gqa_err = hipGetLastError();                                   \
+    if (_gqa_err != hipSuccess)                                                \
+      fprintf(stderr, "[custom_kernels] %s launch failed: %s\n", __func__,     \
+              hipGetErrorString(_gqa_err));                                     \
+    return _gqa_err;                                                           \
+  } while (0)
+
 //===----------------------------------------------------------------------===//
 // Algorithm: ONNX com.microsoft.GroupQueryAttention
 //===----------------------------------------------------------------------===//
@@ -185,11 +221,37 @@ static constexpr float LOG2E = 1.4426950408889634f;
 // Ref: onnxruntime/core/mlas/lib/rotary_embedding.cpp (MlasRotaryEmbedOneRow)
 // -------------------------------------------------------------------------
 
+// Scalar load/store helpers that promote the element type to float for math
+// and narrow back on store. Specialized for __half (HW convert) and float
+// (identity) so the data-movement / RoPE kernels can be templated on T.
+template <typename T>
+__device__ __forceinline__ float gqa_to_float(T v);
+template <>
+__device__ __forceinline__ float gqa_to_float<__half>(__half v) {
+  return __half2float(v);
+}
+template <>
+__device__ __forceinline__ float gqa_to_float<float>(float v) {
+  return v;
+}
+
+template <typename T>
+__device__ __forceinline__ T gqa_from_float(float v);
+template <>
+__device__ __forceinline__ __half gqa_from_float<__half>(float v) {
+  return __float2half(v);
+}
+template <>
+__device__ __forceinline__ float gqa_from_float<float>(float v) {
+  return v;
+}
+
+template <typename T>
 __global__ void rope_kernel(
-    const __half* __restrict__ input,
-    __half* __restrict__ output,
-    const __half* __restrict__ cos_cache,
-    const __half* __restrict__ sin_cache,
+    const T* __restrict__ input,
+    T* __restrict__ output,
+    const T* __restrict__ cos_cache,
+    const T* __restrict__ sin_cache,
     int seq_len, int num_heads, int head_dim,
     int half_rot, int past_len,
     const int* __restrict__ seqlens_k) {
@@ -211,13 +273,13 @@ __global__ void rope_kernel(
   int pos = eff_past_len + s;
   int base = ((batch_idx * seq_len + s) * num_heads + h) * head_dim;
 
-  float x1 = __half2float(input[base + d]);
-  float x2 = __half2float(input[base + d + half_rot]);
-  float c  = __half2float(cos_cache[pos * half_rot + d]);
-  float sn = __half2float(sin_cache[pos * half_rot + d]);
+  float x1 = gqa_to_float<T>(input[base + d]);
+  float x2 = gqa_to_float<T>(input[base + d + half_rot]);
+  float c  = gqa_to_float<T>(cos_cache[pos * half_rot + d]);
+  float sn = gqa_to_float<T>(sin_cache[pos * half_rot + d]);
 
-  output[base + d]            = __float2half(x1 * c - x2 * sn);
-  output[base + d + half_rot] = __float2half(x2 * c + x1 * sn);
+  output[base + d]            = gqa_from_float<T>(x1 * c - x2 * sn);
+  output[base + d + half_rot] = gqa_from_float<T>(x2 * c + x1 * sn);
 }
 
 // -------------------------------------------------------------------------
@@ -230,9 +292,10 @@ __global__ void rope_kernel(
 // Thread: one per element in dim1*dim2*D sub-tensor. blockIdx.y = batch.
 // -------------------------------------------------------------------------
 
+template <typename T>
 __global__ void transpose_mid_dims_kernel(
-    const __half* __restrict__ src,
-    __half* __restrict__ dst,
+    const T* __restrict__ src,
+    T* __restrict__ dst,
     int dim1, int dim2, int D) {
   const int batch_idx = __builtin_amdgcn_readfirstlane(blockIdx.y);
   int idx = blockIdx.x * blockDim.x + threadIdx.x;
@@ -267,9 +330,10 @@ __global__ void transpose_mid_dims_kernel(
 // Ref: onnxruntime/contrib_ops/cpu/bert/gqa_attention_base.h (ConcatStateChunkGQA)
 // -------------------------------------------------------------------------
 
+template <typename T>
 __global__ void kv_cache_append_kernel(
-    const __half* __restrict__ src,
-    __half* __restrict__ cache,
+    const T* __restrict__ src,
+    T* __restrict__ cache,
     int sq, int G, int d, int present_seq, int past_len,
     const int* __restrict__ seqlens_k) {
   const int batch_idx = __builtin_amdgcn_readfirstlane(blockIdx.y);
@@ -308,10 +372,11 @@ __global__ void kv_cache_append_kernel(
 // Thread: one per (b, s_present, g, d_i) element. blockIdx.y = batch.
 // -------------------------------------------------------------------------
 
+template <typename T>
 __global__ void kv_cache_concat_kernel(
-    const __half* __restrict__ past,
-    const __half* __restrict__ current,
-    __half* __restrict__ present,
+    const T* __restrict__ past,
+    const T* __restrict__ current,
+    T* __restrict__ present,
     int past_len, int sq, int G, int d,
     int past_seq, int present_seq) {
   const int batch_idx = __builtin_amdgcn_readfirstlane(blockIdx.y);
@@ -350,9 +415,10 @@ __global__ void kv_cache_concat_kernel(
 // Ref: onnxruntime/contrib_ops/cpu/bert/gqa_attention_base.h line 238
 // -------------------------------------------------------------------------
 
+template <typename T>
 __global__ void expand_kv_kernel(
-    const __half* __restrict__ src,
-    __half* __restrict__ dst,
+    const T* __restrict__ src,
+    T* __restrict__ dst,
     int heads_per_group,
     int src_stride,
     int dst_stride,
@@ -376,18 +442,19 @@ __global__ void expand_kv_kernel(
 // Thread: one per element in the packed tensor.
 // -------------------------------------------------------------------------
 
+template <typename T>
 __global__ void split_qkv_kernel(
-    const __half* __restrict__ packed,
-    __half* __restrict__ Q,
-    __half* __restrict__ K,
-    __half* __restrict__ V,
+    const T* __restrict__ packed,
+    T* __restrict__ Q,
+    T* __restrict__ K,
+    T* __restrict__ V,
     int BS, int D_total, int Q_dim, int K_dim) {
   int idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx >= BS * D_total) return;
 
   int row = idx / D_total;
   int col = idx % D_total;
-  __half val = packed[idx];
+  T val = packed[idx];
 
   if (col < Q_dim)
     Q[row * Q_dim + col] = val;
@@ -557,105 +624,157 @@ __global__ void softmax_inplace_kernel(
 // Extern "C" Launchers (thin wrappers, ordered by pipeline step)
 //===----------------------------------------------------------------------===//
 
+// Templated launch helpers (one per data-movement kernel). The extern "C"
+// launchers below dispatch to <__half> or <float> via element_size_bytes.
+
+template <typename T>
+static void launch_rope(
+    hipStream_t stream, const void* input, void* output,
+    const void* cos_cache, const void* sin_cache,
+    int batch_size, int seq_len, int num_heads,
+    int head_dim, int half_rot, int past_len, const void* seqlens_k) {
+  int elems = seq_len * num_heads * half_rot;
+  int blocks = (elems + GQA_THREADS - 1) / GQA_THREADS;
+  rope_kernel<T><<<dim3(blocks, batch_size), GQA_THREADS, 0, stream>>>(
+      static_cast<const T*>(input), static_cast<T*>(output),
+      static_cast<const T*>(cos_cache), static_cast<const T*>(sin_cache),
+      seq_len, num_heads, head_dim, half_rot, past_len,
+      static_cast<const int*>(seqlens_k));
+}
+
+template <typename T>
+static void launch_transpose_mid_dims(
+    hipStream_t stream, const void* src, void* dst,
+    int batch_size, int dim1, int dim2, int D) {
+  int per_batch = dim1 * dim2 * D;
+  int blocks = (per_batch + GQA_THREADS - 1) / GQA_THREADS;
+  transpose_mid_dims_kernel<T><<<dim3(blocks, batch_size), GQA_THREADS, 0,
+                                 stream>>>(
+      static_cast<const T*>(src), static_cast<T*>(dst), dim1, dim2, D);
+}
+
+template <typename T>
+static void launch_kv_cache_append(
+    hipStream_t stream, const void* src, void* cache,
+    int batch_size, int sq, int G, int d, int present_seq, int past_len,
+    const void* seqlens_k) {
+  int total = sq * G * d;
+  int blocks = (total + GQA_THREADS - 1) / GQA_THREADS;
+  kv_cache_append_kernel<T><<<dim3(blocks, batch_size), GQA_THREADS, 0,
+                              stream>>>(
+      static_cast<const T*>(src), static_cast<T*>(cache),
+      sq, G, d, present_seq, past_len, static_cast<const int*>(seqlens_k));
+}
+
+template <typename T>
+static void launch_kv_cache_concat(
+    hipStream_t stream, const void* past, const void* current, void* present,
+    int batch_size, int past_len, int sq, int G, int d,
+    int past_seq, int present_seq) {
+  int total_seq = past_len + sq;
+  int total = total_seq * G * d;
+  int blocks = (total + GQA_THREADS - 1) / GQA_THREADS;
+  kv_cache_concat_kernel<T><<<dim3(blocks, batch_size), GQA_THREADS, 0,
+                              stream>>>(
+      static_cast<const T*>(past), static_cast<const T*>(current),
+      static_cast<T*>(present), past_len, sq, G, d, past_seq, present_seq);
+}
+
+template <typename T>
+static void launch_expand_kv(
+    hipStream_t stream, const void* src, void* dst,
+    int total_heads, int heads_per_group,
+    int src_stride, int dst_stride, int copy_elems) {
+  int blocksY = (copy_elems + GQA_THREADS - 1) / GQA_THREADS;
+  expand_kv_kernel<T><<<dim3(total_heads, blocksY), GQA_THREADS, 0, stream>>>(
+      static_cast<const T*>(src), static_cast<T*>(dst),
+      heads_per_group, src_stride, dst_stride, copy_elems);
+}
+
+template <typename T>
+static void launch_split_qkv(
+    hipStream_t stream, const void* packed, void* Q, void* K, void* V,
+    int BS, int D_total, int Q_dim, int K_dim) {
+  int total_elems = BS * D_total;
+  int blocks = (total_elems + GQA_THREADS - 1) / GQA_THREADS;
+  split_qkv_kernel<T><<<blocks, GQA_THREADS, 0, stream>>>(
+      static_cast<const T*>(packed), static_cast<T*>(Q),
+      static_cast<T*>(K), static_cast<T*>(V), BS, D_total, Q_dim, K_dim);
+}
+
 // Step 1-2: RoPE
 extern "C" int hip_gqa_rope(
     void* stream_ptr, const void* input, void* output,
     const void* cos_cache, const void* sin_cache,
     int batch_size, int seq_len, int num_heads,
     int head_dim, int half_rot, int past_len,
-    const void* seqlens_k) {
+    const void* seqlens_k, int element_size_bytes) {
   hipStream_t stream = static_cast<hipStream_t>(stream_ptr);
-  int elems = seq_len * num_heads * half_rot;
-  int blocks = (elems + GQA_THREADS - 1) / GQA_THREADS;
-  rope_kernel<<<dim3(blocks, batch_size), GQA_THREADS, 0, stream>>>(
-      static_cast<const __half*>(input),
-      static_cast<__half*>(output),
-      static_cast<const __half*>(cos_cache),
-      static_cast<const __half*>(sin_cache),
-      seq_len, num_heads, head_dim, half_rot, past_len,
-      static_cast<const int*>(seqlens_k));
-  return hipSuccess;
+  GQA_DISPATCH_BY_ELEM_SIZE(element_size_bytes, launch_rope, stream, input,
+                            output, cos_cache, sin_cache, batch_size, seq_len,
+                            num_heads, head_dim, half_rot, past_len, seqlens_k);
+  GQA_RETURN_LAUNCH_STATUS();
 }
 
 // Step 3 / Step 11: Transpose middle dims
 extern "C" int hip_gqa_transpose_mid_dims(
     void* stream_ptr, const void* src, void* dst,
-    int batch_size, int dim1, int dim2, int D) {
+    int batch_size, int dim1, int dim2, int D, int element_size_bytes) {
   hipStream_t stream = static_cast<hipStream_t>(stream_ptr);
-  int per_batch = dim1 * dim2 * D;
-  int blocks = (per_batch + GQA_THREADS - 1) / GQA_THREADS;
-  transpose_mid_dims_kernel<<<dim3(blocks, batch_size), GQA_THREADS, 0, stream>>>(
-      static_cast<const __half*>(src),
-      static_cast<__half*>(dst),
-      dim1, dim2, D);
-  return hipSuccess;
+  GQA_DISPATCH_BY_ELEM_SIZE(element_size_bytes, launch_transpose_mid_dims,
+                            stream, src, dst, batch_size, dim1, dim2, D);
+  GQA_RETURN_LAUNCH_STATUS();
 }
 
 // Step 4-5: KV cache append (same-buffer)
 extern "C" int hip_gqa_kv_cache_append(
     void* stream_ptr, const void* src, void* cache,
     int batch_size, int sq, int G, int d, int present_seq, int past_len,
-    const void* seqlens_k) {
+    const void* seqlens_k, int element_size_bytes) {
   hipStream_t stream = static_cast<hipStream_t>(stream_ptr);
-  int total = sq * G * d;
-  int blocks = (total + GQA_THREADS - 1) / GQA_THREADS;
-  kv_cache_append_kernel<<<dim3(blocks, batch_size), GQA_THREADS, 0, stream>>>(
-      static_cast<const __half*>(src),
-      static_cast<__half*>(cache),
-      sq, G, d, present_seq, past_len,
-      static_cast<const int*>(seqlens_k));
-  return hipSuccess;
+  GQA_DISPATCH_BY_ELEM_SIZE(element_size_bytes, launch_kv_cache_append, stream,
+                            src, cache, batch_size, sq, G, d, present_seq,
+                            past_len, seqlens_k);
+  GQA_RETURN_LAUNCH_STATUS();
 }
 
 // Step 4-5: KV cache concat (separate-buffer)
 extern "C" int hip_gqa_kv_cache_concat(
     void* stream_ptr, const void* past, const void* current, void* present,
     int batch_size, int past_len, int sq, int G, int d,
-    int past_seq, int present_seq) {
+    int past_seq, int present_seq, int element_size_bytes) {
   hipStream_t stream = static_cast<hipStream_t>(stream_ptr);
-  int total_seq = past_len + sq;
-  int total = total_seq * G * d;
-  int blocks = (total + GQA_THREADS - 1) / GQA_THREADS;
-  kv_cache_concat_kernel<<<dim3(blocks, batch_size), GQA_THREADS, 0, stream>>>(
-      static_cast<const __half*>(past),
-      static_cast<const __half*>(current),
-      static_cast<__half*>(present),
-      past_len, sq, G, d, past_seq, present_seq);
-  return hipSuccess;
+  GQA_DISPATCH_BY_ELEM_SIZE(element_size_bytes, launch_kv_cache_concat, stream,
+                            past, current, present, batch_size, past_len, sq, G,
+                            d, past_seq, present_seq);
+  GQA_RETURN_LAUNCH_STATUS();
 }
 
 // Step 6-7: KV group expansion
 extern "C" int hip_gqa_expand_kv(
     void* stream_ptr, const void* src, void* dst,
     int total_heads, int heads_per_group,
-    int src_stride, int dst_stride, int copy_elems) {
+    int src_stride, int dst_stride, int copy_elems, int element_size_bytes) {
   hipStream_t stream = static_cast<hipStream_t>(stream_ptr);
-  int blocksY = (copy_elems + GQA_THREADS - 1) / GQA_THREADS;
-  expand_kv_kernel<<<dim3(total_heads, blocksY), GQA_THREADS, 0, stream>>>(
-      static_cast<const __half*>(src),
-      static_cast<__half*>(dst),
-      heads_per_group, src_stride, dst_stride, copy_elems);
-  return hipSuccess;
+  GQA_DISPATCH_BY_ELEM_SIZE(element_size_bytes, launch_expand_kv, stream, src,
+                            dst, total_heads, heads_per_group, src_stride,
+                            dst_stride, copy_elems);
+  GQA_RETURN_LAUNCH_STATUS();
 }
 
 // Step 0: Split packed QKV
 extern "C" int hip_gqa_split_qkv(
     void* stream_ptr, const void* packed, void* Q, void* K, void* V,
-    int batch_size, int seq_len, int num_heads, int kv_num_heads, int head_dim) {
+    int batch_size, int seq_len, int num_heads, int kv_num_heads, int head_dim,
+    int element_size_bytes) {
   hipStream_t stream = static_cast<hipStream_t>(stream_ptr);
   int BS = batch_size * seq_len;
   int Q_dim = num_heads * head_dim;
   int K_dim = kv_num_heads * head_dim;
   int D_total = Q_dim + 2 * K_dim;
-  int total_elems = BS * D_total;
-  int blocks = (total_elems + GQA_THREADS - 1) / GQA_THREADS;
-  split_qkv_kernel<<<blocks, GQA_THREADS, 0, stream>>>(
-      static_cast<const __half*>(packed),
-      static_cast<__half*>(Q),
-      static_cast<__half*>(K),
-      static_cast<__half*>(V),
-      BS, D_total, Q_dim, K_dim);
-  return hipSuccess;
+  GQA_DISPATCH_BY_ELEM_SIZE(element_size_bytes, launch_split_qkv, stream, packed,
+                            Q, K, V, BS, D_total, Q_dim, K_dim);
+  GQA_RETURN_LAUNCH_STATUS();
 }
 
 // Step 9a: Causal mask launchers (fp16 and fp32 instantiations)
@@ -667,10 +786,11 @@ extern "C" int hip_gqa_causal_mask(
   hipStream_t stream = static_cast<hipStream_t>(stream_ptr);
   int total = skv * sq;
   int blocksX = (total + GQA_THREADS - 1) / GQA_THREADS;
+  (void)hipGetLastError();  // clear stale error for correct attribution
   causal_mask_kernel_impl<__half><<<dim3(blocksX, total_heads), GQA_THREADS, 0, stream>>>(
       static_cast<__half*>(S),
       skv, sq, batch_stride, past_len, local_window_size);
-  return hipSuccess;
+  GQA_RETURN_LAUNCH_STATUS();
 }
 
 extern "C" int hip_gqa_causal_mask_f32(
@@ -680,24 +800,29 @@ extern "C" int hip_gqa_causal_mask_f32(
   hipStream_t stream = static_cast<hipStream_t>(stream_ptr);
   int total = skv * sq;
   int blocksX = (total + GQA_THREADS - 1) / GQA_THREADS;
+  (void)hipGetLastError();  // clear stale error for correct attribution
   causal_mask_kernel_impl<float><<<dim3(blocksX, total_heads), GQA_THREADS, 0, stream>>>(
       static_cast<float*>(S),
       skv, sq, batch_stride, past_len, local_window_size);
-  return hipSuccess;
+  GQA_RETURN_LAUNCH_STATUS();
 }
 
 // Step 9b (fp32->fp16 variant): Softmax reading fp32 scores, writing fp16 output
 // Avoids inf-inf=NaN by operating entirely in fp32 before the final fp16 store.
 
-__global__ void softmax_f32_to_f16_kernel(
-    const float* input, __half* output,
+// Output-type-templated: reads fp32 scores, writes TOut ∈ {__half, float}.
+// fp16 output (TOut=__half) feeds the fp16 Value GEMM; fp32 output (TOut=float)
+// feeds the fp32 Value GEMM on the Whisper no_causal fp32 decomposed path.
+template <typename TOut>
+__global__ void softmax_f32_to_out_kernel(
+    const float* input, TOut* output,
     int rows, int cols, int input_batch_stride, int output_batch_stride,
     const __half* head_sink, int num_heads, int use_smooth_softmax) {
   const int linear = __builtin_amdgcn_readfirstlane(blockIdx.x);
   const int head = __builtin_amdgcn_readfirstlane(linear / cols);
   const int col  = __builtin_amdgcn_readfirstlane(linear % cols);
   const float* in_col = input + (size_t)head * input_batch_stride + (size_t)col * rows;
-  __half* out_col = output + (size_t)head * output_batch_stride + (size_t)col * rows;
+  TOut* out_col = output + (size_t)head * output_batch_stride + (size_t)col * rows;
 
   const int tid = threadIdx.x;
   const int wave_id = tid / WAVE_SIZE;
@@ -749,12 +874,29 @@ __global__ void softmax_f32_to_f16_kernel(
     sum_val += expf(0.0f - max_val);
   }
 
-  // Pass 3: normalize and write fp16 output
+  // Pass 3: normalize and write output (fp16 or fp32 per TOut).
   float inv_sum = 1.0f / sum_val;
   for (int i = tid; i < rows; i += blockDim.x) {
     float e = exp2f((in_col[i] - max_val) * LOG2E);
-    out_col[i] = __float2half(e * inv_sum);
+    out_col[i] = gqa_from_float<TOut>(e * inv_sum);
   }
+}
+
+template <typename TOut>
+static void launch_softmax_f32_to_out(
+    hipStream_t stream, const void* input_f32, void* output,
+    int total_head_queries, int rows, int cols,
+    int input_batch_stride, int output_batch_stride,
+    const void* head_sink, int num_heads, int use_smooth_softmax) {
+  int threads = 32;
+  while (threads < std::min(rows, 256)) threads *= 2;
+  if (threads > 256) threads = 256;
+  int num_waves = threads / WAVE_SIZE;
+  softmax_f32_to_out_kernel<TOut><<<total_head_queries, threads,
+                                    num_waves * sizeof(float), stream>>>(
+      static_cast<const float*>(input_f32), static_cast<TOut*>(output),
+      rows, cols, input_batch_stride, output_batch_stride,
+      static_cast<const __half*>(head_sink), num_heads, use_smooth_softmax);
 }
 
 extern "C" int hip_gqa_softmax_f32_to_f16(
@@ -763,17 +905,29 @@ extern "C" int hip_gqa_softmax_f32_to_f16(
     int input_batch_stride, int output_batch_stride,
     const void* head_sink, int num_heads, int use_smooth_softmax) {
   hipStream_t stream = static_cast<hipStream_t>(stream_ptr);
-  int threads = 32;
-  while (threads < std::min(rows, 256)) threads *= 2;
-  if (threads > 256) threads = 256;
-  int num_waves = threads / WAVE_SIZE;
-  softmax_f32_to_f16_kernel<<<total_head_queries, threads,
-                              num_waves * sizeof(float), stream>>>(
-      static_cast<const float*>(input_f32),
-      static_cast<__half*>(output_f16),
-      rows, cols, input_batch_stride, output_batch_stride,
-      static_cast<const __half*>(head_sink), num_heads, use_smooth_softmax);
-  return hipSuccess;
+  (void)hipGetLastError();  // clear stale error for correct attribution
+  launch_softmax_f32_to_out<__half>(
+      stream, input_f32, output_f16, total_head_queries, rows, cols,
+      input_batch_stride, output_batch_stride, head_sink, num_heads,
+      use_smooth_softmax);
+  GQA_RETURN_LAUNCH_STATUS();
+}
+
+// fp32-output variant: fp32 scores -> fp32 probabilities, feeding the fp32
+// Value GEMM on the Whisper no_causal fp32 decomposed path. output_batch_stride
+// is in float elements (same units as the fp16 variant's half elements).
+extern "C" int hip_gqa_softmax_f32_to_f32(
+    void* stream_ptr, const void* input_f32, void* output_f32,
+    int total_head_queries, int rows, int cols,
+    int input_batch_stride, int output_batch_stride,
+    const void* head_sink, int num_heads, int use_smooth_softmax) {
+  hipStream_t stream = static_cast<hipStream_t>(stream_ptr);
+  (void)hipGetLastError();  // clear stale error for correct attribution
+  launch_softmax_f32_to_out<float>(
+      stream, input_f32, output_f32, total_head_queries, rows, cols,
+      input_batch_stride, output_batch_stride, head_sink, num_heads,
+      use_smooth_softmax);
+  GQA_RETURN_LAUNCH_STATUS();
 }
 
 // Step 9b: Softmax
@@ -787,12 +941,13 @@ extern "C" int hip_gqa_softmax_inplace(
   while (threads < std::min(rows, 256)) threads *= 2;
   if (threads > 256) threads = 256;
   int num_waves = threads / WAVE_SIZE;
+  (void)hipGetLastError();  // clear stale error for correct attribution
   softmax_inplace_kernel<<<total_head_queries, threads,
                            num_waves * sizeof(float), stream>>>(
       static_cast<__half*>(data),
       rows, cols, batch_stride,
       static_cast<const __half*>(head_sink), num_heads, use_smooth_softmax);
-  return hipSuccess;
+  GQA_RETURN_LAUNCH_STATUS();
 }
 
 //===----------------------------------------------------------------------===//
@@ -1196,6 +1351,7 @@ extern "C" int hip_gqa_fused_decode(
   const __half* hV = static_cast<const __half*>(Vcache);
   __half* hO = static_cast<__half*>(O);
   const int* iSeqlensK = static_cast<const int*>(seqlens_k);
+  (void)hipGetLastError();  // clear stale error for correct attribution
   switch (d) {
     case 64:
       fused_gqa_decode_kernel<64><<<grid, 64, 0, stream>>>(
@@ -1214,7 +1370,7 @@ extern "C" int hip_gqa_fused_decode(
               "(must be 64, 128, or 256)\n", d);
       return -1;
   }
-  return hipSuccess;
+  GQA_RETURN_LAUNCH_STATUS();
 }
 
 // Fused prefill launcher

--- a/3rd-party/custom_kernels/hip/layer_norm_kernel.hip
+++ b/3rd-party/custom_kernels/hip/layer_norm_kernel.hip
@@ -152,6 +152,12 @@ extern "C" int hip_layer_norm(void *stream, const void *input,
   dim3 grid(static_cast<unsigned int>(outer));
   dim3 block(kLayerNormBlockSize);
 
+  // Clear any error left sticky by a prior kernel whose launcher didn't check
+  // its own status, so the hipGetLastError() below attributes a failure to THIS
+  // launch only (otherwise an upstream error is misreported as
+  // "hip_layer_norm launch failed").
+  (void)hipGetLastError();
+
   CUSTOM_KERNELS_DEBUG_LOG(
       "[custom_kernels] hip_layer_norm: dtype=%d, mean_dtype=%d, "
       "outer=%lld, norm_size=%lld, epsilon=%f, "

--- a/3rd-party/custom_kernels/include/hip_custom_kernels.h
+++ b/3rd-party/custom_kernels/include/hip_custom_kernels.h
@@ -450,7 +450,11 @@ int hip_rope_forward(
  * =========================================================================
  *
  * Individual kernel launchers for the 12-step GQA pipeline (Step 0 + Steps 1-11).
- * All FP16 only. The orchestration (hipBLASLt GEMMs, workspace, temp
+ * The pure data-movement kernels (append / concat / rope / transpose / expand /
+ * split) take element_size_bytes (2 = fp16, 4 = fp32) and dispatch to the
+ * matching typed kernel -- this fp32-enables the decomposed GQA pipeline used
+ * by the Whisper no_causal path. The fused / flash decode kernels remain FP16
+ * only (Llama / gpt-oss). The orchestration (hipBLASLt GEMMs, workspace, temp
  * buffers) lives in the runtime wrapper (real/gqa.cpp).
  */
 
@@ -461,11 +465,12 @@ int hip_rope_forward(
  * Use when past and present share the same buffer (aliased / in-place).
  * seqlens_k: optional device pointer [B] int32. When non-null, past_len is
  * derived from seqlens_k[b]+1-sq (per-batch) and the host past_len is ignored.
- * Pass NULL for host-side past_len. */
+ * Pass NULL for host-side past_len.
+ * element_size_bytes: 2 = fp16, 4 = fp32. */
 int hip_gqa_kv_cache_append(
     void* stream, const void* src, void* cache,
     int batch_size, int sq, int G, int d, int present_seq, int past_len,
-    const void* seqlens_k);
+    const void* seqlens_k, int element_size_bytes);
 
 /* KV cache concat: concatenate past data and new tokens into a fresh present
  * buffer.  Fills present [B,G,present_seq,d] by copying past data from
@@ -473,42 +478,48 @@ int hip_gqa_kv_cache_append(
  * from current BSHD [B,sq,G,d] at [past_len,past_len+sq).
  * past_seq and present_seq are the actual sequence dimensions (strides) of the
  * respective buffers.  Handles the stride mismatch (past_seq != present_seq)
- * in a single kernel launch. */
+ * in a single kernel launch.
+ * element_size_bytes: 2 = fp16, 4 = fp32. */
 int hip_gqa_kv_cache_concat(
     void* stream, const void* past, const void* current, void* present,
     int batch_size, int past_len, int sq, int G, int d,
-    int past_seq, int present_seq);
+    int past_seq, int present_seq, int element_size_bytes);
 
-/* Internal GQA RoPE (half-rotated, FP16):
+/* Internal GQA RoPE (half-rotated):
  * out[d] = in[d]*cos - in[d+half]*sin
  * out[d+half] = in[d+half]*cos + in[d]*sin
  * seqlens_k: optional device pointer [B] int32. When non-null, past_len is
- * derived from seqlens_k[b]+1-seq_len and the host past_len is ignored. */
+ * derived from seqlens_k[b]+1-seq_len and the host past_len is ignored.
+ * element_size_bytes: 2 = fp16, 4 = fp32. */
 int hip_gqa_rope(
     void* stream, const void* input, void* output,
     const void* cos_cache, const void* sin_cache,
     int batch_size, int seq_len, int num_heads,
     int head_dim, int half_rot, int past_len,
-    const void* seqlens_k);
+    const void* seqlens_k, int element_size_bytes);
 
 /* Transpose middle two dims of 4D tensor:
- * [B, dim1, dim2, D] -> [B, dim2, dim1, D] */
+ * [B, dim1, dim2, D] -> [B, dim2, dim1, D]
+ * element_size_bytes: 2 = fp16, 4 = fp32. */
 int hip_gqa_transpose_mid_dims(
     void* stream, const void* src, void* dst,
-    int batch_size, int dim1, int dim2, int D);
+    int batch_size, int dim1, int dim2, int D, int element_size_bytes);
 
 /* KV group expansion: replicate G groups -> H heads.
- * For head h, copies from group g = h / heads_per_group. */
+ * For head h, copies from group g = h / heads_per_group.
+ * element_size_bytes: 2 = fp16, 4 = fp32. */
 int hip_gqa_expand_kv(
     void* stream, const void* src, void* dst,
     int total_heads, int heads_per_group,
-    int src_stride, int dst_stride, int copy_elems);
+    int src_stride, int dst_stride, int copy_elems, int element_size_bytes);
 
 /* Split packed QKV [B*S, (H+2*G)*d] into separate Q, K, V buffers.
- * Q: [B*S, H*d], K: [B*S, G*d], V: [B*S, G*d] */
+ * Q: [B*S, H*d], K: [B*S, G*d], V: [B*S, G*d]
+ * element_size_bytes: 2 = fp16, 4 = fp32. */
 int hip_gqa_split_qkv(
     void* stream, const void* packed, void* Q, void* K, void* V,
-    int batch_size, int seq_len, int num_heads, int kv_num_heads, int head_dim);
+    int batch_size, int seq_len, int num_heads, int kv_num_heads, int head_dim,
+    int element_size_bytes);
 
 /* Causal mask (prefill only): S[k,q] = -inf where k > past_len + q.
  * When local_window_size > 0, also masks k < past_len + q - local_window_size + 1. */
@@ -548,6 +559,16 @@ int hip_softmax_row_2d_inplace(void* stream, void* data, int rows, int cols);
  * input_batch_stride is in float elements, output_batch_stride in half elements. */
 int hip_gqa_softmax_f32_to_f16(
     void* stream, const void* input_f32, void* output_f16,
+    int total_head_queries, int rows, int cols,
+    int input_batch_stride, int output_batch_stride,
+    const void* head_sink, int num_heads, int use_smooth_softmax);
+
+/* Column-wise softmax: fp32 input -> fp32 output.
+ * Same as hip_gqa_softmax_f32_to_f16 but writes fp32 probabilities, feeding
+ * the fp32 Value GEMM on the Whisper no_causal fp32 decomposed path.
+ * input_batch_stride and output_batch_stride are both in float elements. */
+int hip_gqa_softmax_f32_to_f32(
+    void* stream, const void* input_f32, void* output_f32,
     int total_head_queries, int rows, int cols,
     int input_batch_stride, int output_batch_stride,
     const void* head_sink, int num_heads, int use_smooth_softmax);

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -2191,7 +2191,12 @@ def Hip_GqaOp : Hip_DpsOp<"gqa", [AttrSizedOperandSegments]> {
     // Quantization related attributes
     DefaultValuedAttr<StrAttr, "\"NONE\"">:$k_quant_type,  // "NONE"/"PER_TENSOR"/"PER_CHANNEL"
     DefaultValuedAttr<StrAttr, "\"NONE\"">:$v_quant_type,
-    DefaultValuedAttr<I64Attr, "8">:$kv_cache_bit_width  // 8 or 4
+    DefaultValuedAttr<I64Attr, "8">:$kv_cache_bit_width,  // 8 or 4
+
+    // Whisper / bidirectional-attention enabler: when true, the causal mask
+    // step in the runtime is skipped. Default false preserves all existing
+    // Llama / gpt-oss callers' behaviour.
+    DefaultValuedAttr<BoolAttr, "false">:$no_causal
   );
 
   let assemblyFormat = [{

--- a/lib/Conversion/HipToLLVM/GqaLowering.cpp
+++ b/lib/Conversion/HipToLLVM/GqaLowering.cpp
@@ -105,6 +105,11 @@ struct GqaOpLowering : public ConvertOpToLLVMPattern<GqaOp> {
     Value kQuantType = createI64Const(quantTypeToEnum(op.getKQuantType()));
     Value vQuantType = createI64Const(quantTypeToEnum(op.getVQuantType()));
 
+    // no_causal: emit as i32 (matches wrap_group_query_attention signature).
+    Value noCausal = LLVM::ConstantOp::create(
+        rewriter, loc, i32Type,
+        rewriter.getI32IntegerAttr(op.getNoCausal() ? 1 : 0));
+
     // Extract shape info from query memref: [batch, seq_q, num_heads *
     // head_dim]. Uses getMemRefDimSize() to handle both static and dynamic
     // dimensions — static dims become LLVM constants, dynamic dims are
@@ -180,7 +185,7 @@ struct GqaOpLowering : public ConvertOpToLLVMPattern<GqaOp> {
     Value elemSizeVal = createI64Const(elementSizeBytes);
 
     // Function signature matches wrap_group_query_attention() in gqa.cpp
-    SmallVector<Type, 38> paramTypes = {
+    SmallVector<Type, 39> paramTypes = {
         ptrType, // state
         // Inputs (14 pointers - some may be nullptr)
         ptrType, // query
@@ -215,6 +220,7 @@ struct GqaOpLowering : public ConvertOpToLLVMPattern<GqaOp> {
         i64Type, // k_quant_type
         i64Type, // v_quant_type
         i64Type, // kv_cache_bit_width
+        i32Type, // no_causal
         // Shape info (6 values)
         i64Type, // batch_size
         i64Type, // seq_len_q
@@ -229,7 +235,7 @@ struct GqaOpLowering : public ConvertOpToLLVMPattern<GqaOp> {
     if (failed(funcOp))
       return failure();
 
-    SmallVector<Value, 38> args = {
+    SmallVector<Value, 39> args = {
         statePtr,
         // Inputs (14 pointers)
         queryPtr, keyPtr, valuePtr, pastKeyPtr, pastValuePtr, seqlensKPtr,
@@ -237,10 +243,10 @@ struct GqaOpLowering : public ConvertOpToLLVMPattern<GqaOp> {
         attentionBiasPtr, headSinkPtr, kScalePtr, vScalePtr,
         // Outputs (4 pointers)
         outputPtr, presentKeyPtr, presentValuePtr, outputQkPtr,
-        // Attributes (12 values)
+        // Attributes (13 values)
         numHeads, kvNumHeads, scale, doRotary, rotaryInterleaved, softcap,
         localWindowSize, smoothSoftmax, qkOutput, kQuantType, vQuantType,
-        kvCacheBitWidth,
+        kvCacheBitWidth, noCausal,
         // Shape info (6 values)
         batchSizeVal, seqLenQVal, seqLenKVVal, pastBufSeqVal, headDimVal,
         elemSizeVal};

--- a/lib/Conversion/OnnxToHip/GqaConversion.cpp
+++ b/lib/Conversion/OnnxToHip/GqaConversion.cpp
@@ -255,6 +255,12 @@ mlir::LogicalResult GroupQueryAttentionToHip::matchAndRewrite(
   attrs.push_back(rewriter.getNamedAttr("v_quant_type", vQuantTypeAttr));
   attrs.push_back(
       rewriter.getNamedAttr("kv_cache_bit_width", kvCacheBitWidthAttr));
+  // Explicit no_causal=false: existing GroupQueryAttention ONNX op is always
+  // causal. The Whisper bidirectional paths (encoder self-attn and decoder
+  // cross-attn) construct hip.gqa via different conversions that set this to
+  // true explicitly.
+  attrs.push_back(
+      rewriter.getNamedAttr("no_causal", rewriter.getBoolAttr(false)));
 
   // Create operation using builder
   // We need to compute the operand_segment_sizes attribute for

--- a/lib/Dialect/IR/CMakeLists.txt
+++ b/lib/Dialect/IR/CMakeLists.txt
@@ -18,10 +18,9 @@ add_dependencies(HipDialectIR
 )
 
 # HipDialect.cpp pulls in the TableGen-generated op definitions for every Hip op
-# (each now carrying the DPS/reify/infer interface bodies). With the conv1d op
-# added on top of the shape-inference cascade, the single translation unit
-# exceeds MSVC's default COFF section limit (fatal error C1128). /bigobj raises
-# it. No-op on non-MSVC compilers.
+# (each now carrying the DPS/reify/infer interface bodies). On top of the
+# shape-inference cascade the single translation unit exceeds MSVC's default
+# COFF section limit (fatal error C1128). /bigobj raises it. No-op on non-MSVC.
 if(MSVC)
   target_compile_options(HipDialectIR PRIVATE /bigobj)
 endif()

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -769,11 +769,14 @@ int wrap_group_query_attention(
     void *attention_bias, void *head_sink, void *k_scale, void *v_scale,
     // Outputs
     void *output, void *present_key, void *present_value, void *output_qk,
-    // Attributes (12)
+    // Attributes (13)
     int64_t num_heads, int64_t kv_num_heads, float scale, int64_t do_rotary,
     int64_t rotary_interleaved, float softcap, int64_t local_window_size,
     int64_t smooth_softmax, int64_t qk_output, int64_t k_quant_type,
     int64_t v_quant_type, int64_t kv_cache_bit_width,
+    // Whisper bidirectional-attention flag: when non-zero, the causal mask
+    // step is skipped. Default 0 preserves Llama / gpt-oss behaviour.
+    int32_t no_causal,
     // Shape values (6)
     int64_t batch_size, int64_t seq_len_q, int64_t seq_len_kv,
     int64_t past_buf_seq, int64_t head_dim, int64_t element_size_bytes);

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -617,11 +617,13 @@ int wrap_group_query_attention(
     void *attention_bias, void *head_sink, void *k_scale, void *v_scale,
     // Outputs
     void *output, void *present_key, void *present_value, void *output_qk,
-    // Attributes (12)
+    // Attributes (13)
     int64_t num_heads, int64_t kv_num_heads, float scale, int64_t do_rotary,
     int64_t rotary_interleaved, float softcap, int64_t local_window_size,
     int64_t smooth_softmax, int64_t qk_output, int64_t k_quant_type,
     int64_t v_quant_type, int64_t kv_cache_bit_width,
+    // Whisper bidirectional-attention flag (mock stub ignores it).
+    int32_t no_causal,
     // Shape values (6)
     int64_t batch_size, int64_t seq_len_q, int64_t seq_len_kv,
     int64_t past_buf_seq, int64_t head_dim, int64_t element_size_bytes) {
@@ -642,6 +644,7 @@ int wrap_group_query_attention(
   (void)k_quant_type;
   (void)v_quant_type;
   (void)kv_cache_bit_width;
+  (void)no_causal;
   (void)past_buf_seq;
   (void)present_key;
   (void)present_value;

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -279,6 +279,10 @@ struct GqaGemmKey {
   int64_t m, n, k, batch;
   bool transA; // true for Score GEMM (K^T * Q), false for Value GEMM (V * S)
   bool outputFp32; // true to use HIP_R_32F for C/D layouts (Score GEMM)
+  // true to use HIP_R_32F for the A/B input layouts (fp32 GQA, e.g. Whisper
+  // no_causal). When false the inputs are HIP_R_16F (fp16 GQA -- Llama /
+  // gpt-oss, byte-identical to the pre-fp32 behaviour).
+  bool inputFp32;
   // Optional explicit per-operand batch strides (in elements). A value of 0
   // means "use the default dense stride" (m*k for A, n*k for B, n*m for C/D).
   // Non-zero values override the default and enable batch layouts that differ
@@ -291,7 +295,8 @@ struct GqaGemmKey {
   bool operator==(const GqaGemmKey &o) const {
     return m == o.m && n == o.n && k == o.k && batch == o.batch &&
            transA == o.transA && outputFp32 == o.outputFp32 &&
-           strideA == o.strideA && strideB == o.strideB && strideC == o.strideC;
+           inputFp32 == o.inputFp32 && strideA == o.strideA &&
+           strideB == o.strideB && strideC == o.strideC;
   }
 };
 
@@ -304,6 +309,7 @@ struct GqaGemmKeyHash {
     hash_combine_val(h, k.batch);
     hash_combine_val(h, k.transA);
     hash_combine_val(h, k.outputFp32);
+    hash_combine_val(h, k.inputFp32);
     hash_combine_val(h, k.strideA);
     hash_combine_val(h, k.strideB);
     hash_combine_val(h, k.strideC);
@@ -371,14 +377,16 @@ static const GqaGemmCacheEntry *queryOrCreateGemmState(RuntimeState *state,
     int64_t strideB = key.strideB != 0 ? key.strideB : n * k;
     int64_t strideC = key.strideC != 0 ? key.strideC : n * m;
 
+    // Input operand element type: HIP_R_16F (fp16 GQA) or HIP_R_32F (fp32
+    // GQA, e.g. Whisper no_causal). Compute is HIPBLAS_COMPUTE_32F either way.
+    hipDataType inType = key.inputFp32 ? HIP_R_32F : HIP_R_16F;
     int64_t a_rows = key.transA ? k : m;
     int64_t a_cols = key.transA ? m : k;
-    GQA_CACHE_CHECK(hipblasLtMatrixLayoutCreate(&entry.layA, HIP_R_16F, a_rows,
+    GQA_CACHE_CHECK(hipblasLtMatrixLayoutCreate(&entry.layA, inType, a_rows,
                                                 a_cols, a_rows));
     GQA_CACHE_CHECK(setLayoutBatch(entry.layA, batch, strideA));
 
-    GQA_CACHE_CHECK(
-        hipblasLtMatrixLayoutCreate(&entry.layB, HIP_R_16F, k, n, k));
+    GQA_CACHE_CHECK(hipblasLtMatrixLayoutCreate(&entry.layB, inType, k, n, k));
     GQA_CACHE_CHECK(setLayoutBatch(entry.layB, batch, strideB));
 
     hipDataType outType = key.outputFp32 ? HIP_R_32F : HIP_R_16F;
@@ -452,24 +460,62 @@ static int update_kv_cache(hipStream_t stream, const void *past_key,
                            const void *new_value, void *present_key,
                            void *present_value, int B, int past_len, int sq,
                            int G, int d, int past_buf_seq, int present_seq,
-                           const void *seqlens_k_ptr) {
+                           const void *seqlens_k_ptr, int elem_sz,
+                           bool no_causal = false, int skv = -1) {
+  // no_causal (Whisper encoder / cross-attn): bidirectional, no past KV.
+  // The KV to attend over is the FULL `new_key`/`new_value` (Skv tokens), not
+  // `sq` newly-appended tokens. Two sub-cases distinguished by sq vs Skv:
+  //   * Cross-attn (sq != Skv): `key`/`value` arrive as rank-4 BNSH
+  //     [B, G, Skv, d] -- already in the present_key layout. A straight
+  //     device-to-device copy of all Skv tokens populates present_*.
+  //   * Encoder self-attn (sq == Skv): `key`/`value` are BSHD [B, Skv, G, d];
+  //     fall through to the append kernel below with past_len forced to 0 and
+  //     seqlens_k=nullptr so it transposes all Skv tokens to offset 0 WITHOUT
+  //     the +1 PAST-token convention.
+  if (no_causal && skv >= 0 && skv != sq) {
+    // elem_sz is 2 (fp16) or 4 (fp32); the decomposed pipeline supports both.
+    size_t bytes = static_cast<size_t>(B) * G * static_cast<size_t>(skv) * d *
+                   static_cast<size_t>(elem_sz);
+    if (hipMemcpyAsync(present_key, new_key, bytes, hipMemcpyDeviceToDevice,
+                       stream) != hipSuccess)
+      return -1;
+    if (hipMemcpyAsync(present_value, new_value, bytes, hipMemcpyDeviceToDevice,
+                       stream) != hipSuccess)
+      return -1;
+    return 0;
+  }
+  if (no_causal) {
+    // Encoder self-attn: append all Skv (== sq) tokens at offset 0, bypassing
+    // the seqlens_k +1 convention (pass nullptr so the kernel uses past_len=0).
+    if (hip_gqa_kv_cache_append(stream, new_key, present_key, B, sq, G, d,
+                                present_seq, /*past_len=*/0,
+                                /*seqlens_k_ptr=*/nullptr, elem_sz) != 0)
+      return -1;
+    if (hip_gqa_kv_cache_append(stream, new_value, present_value, B, sq, G, d,
+                                present_seq, /*past_len=*/0,
+                                /*seqlens_k_ptr=*/nullptr, elem_sz) != 0)
+      return -1;
+    return 0;
+  }
   if (past_key && past_len > 0 && past_key != present_key) {
     // Separate-buffer concat: needs host-side past_len for stride computation
     if (hip_gqa_kv_cache_concat(stream, past_key, new_key, present_key, B,
-                                past_len, sq, G, d, past_buf_seq,
-                                present_seq) != 0)
+                                past_len, sq, G, d, past_buf_seq, present_seq,
+                                elem_sz) != 0)
       return -1;
     if (hip_gqa_kv_cache_concat(stream, past_value, new_value, present_value, B,
-                                past_len, sq, G, d, past_buf_seq,
-                                present_seq) != 0)
+                                past_len, sq, G, d, past_buf_seq, present_seq,
+                                elem_sz) != 0)
       return -1;
   } else {
     // In-place append: kernel can read past_len from device via seqlens_k_ptr
     if (hip_gqa_kv_cache_append(stream, new_key, present_key, B, sq, G, d,
-                                present_seq, past_len, seqlens_k_ptr) != 0)
+                                present_seq, past_len, seqlens_k_ptr,
+                                elem_sz) != 0)
       return -1;
     if (hip_gqa_kv_cache_append(stream, new_value, present_value, B, sq, G, d,
-                                present_seq, past_len, seqlens_k_ptr) != 0)
+                                present_seq, past_len, seqlens_k_ptr,
+                                elem_sz) != 0)
       return -1;
   }
   return 0;
@@ -495,13 +541,22 @@ static int gqa_forward_hipblaslt(
     void *present_key,       // BNSD [B, G, present_buf_seq, d]
     void *present_value, int64_t B, int64_t sq, int64_t skv,
     int64_t past_buf_seq, int64_t H, int64_t G, int64_t d, float scale,
-    int64_t do_rotary, int64_t local_window_size) {
+    int64_t do_rotary, int64_t local_window_size, bool no_causal,
+    int64_t element_size_bytes) {
 
   int64_t HPG = H / G;
   // present_seq is the buffer dimension of present_key (may be max_length
   // for pre-allocated caches, larger than the actual valid token count).
   int64_t present_seq = skv;
-  size_t elem_sz = 2; // FP16
+  // 2 = fp16 (Llama / gpt-oss), 4 = fp32 (Whisper no_causal). Drives scratch
+  // buffer sizing, the GEMM layout element type, the softmax output dtype, and
+  // the data-movement kernel dispatch below.
+  size_t elem_sz = static_cast<size_t>(element_size_bytes);
+  // hipBLASLt matrix layout element type for the fp16-in/fp16-out GEMMs
+  // (Value GEMM operands K/V/P/O). The Score GEMM accumulates to fp32 either
+  // way; only its input operands (K, Q) use this type. Compute stays
+  // HIPBLAS_COMPUTE_32F regardless.
+  bool gemm_fp32 = (elem_sz == 4);
 
   bool need_rope = do_rotary && cos_cache && sin_cache;
 
@@ -535,7 +590,14 @@ static int gqa_forward_hipblaslt(
   int32_t seqlens_k_pre =
       read_seqlens_k_for_dispatch(stream, seqlens_k_ptr, B, state);
   int64_t total_seq_pre = -1;
-  if (seqlens_k_pre != kSeqlensKNotRead) {
+  if (no_causal) {
+    // no_causal (Whisper encoder / cross-attn): seqlens_k = skv means "all skv
+    // keys valid", there is no past. total_seq is exactly skv -- do NOT apply
+    // the +1 decode convention (would over-count and trip the smart-dispatch
+    // size check / fused validation). See the matching exemption at the
+    // decomposed-path total_seq derivation below.
+    total_seq_pre = skv;
+  } else if (seqlens_k_pre != kSeqlensKNotRead) {
     // -1 is ORT's prefill sentinel: total_seq=sq, past_len=0. Real values
     // are 0..max_seq; total_seq = seqlens_k_val + 1.
     total_seq_pre =
@@ -591,10 +653,29 @@ static int gqa_forward_hipblaslt(
   // branch too.
   bool fused_packed_qkv = (!key && !value);
   bool kv_inputs_ok = (key && value) || fused_packed_qkv;
+  // The fused (hip_gqa_fused_decode) and flash (hip_gqa_flash_decode) decode
+  // kernels are __half-only (their Q/K/V/O pointers are `const __half*`). They
+  // are correct for the fp16 causal decode of Llama / gpt-oss (elem_size==2).
+  // The fp32 GQA path (Whisper decoder self-attn, elem_size==4) must NOT reach
+  // them: feeding fp32 buffers to a __half kernel reinterprets the bytes and
+  // produces garbage (observed: O == -4.28e37 sentinel leak → token 0 spam in
+  // greedy decode). The decomposed hipBLASLt pipeline below IS fp32-capable, so
+  // route fp32 decode there. This is the decode-side analogue of the no_causal
+  // exemption (the prefill sq>1 fp32 path already used decomposed). GATE-1
+  // (Llama / gpt-oss) is fp16 so `fused_fp16` stays true for them — byte
+  // identical.
+  bool fused_fp16 = (element_size_bytes == 2);
+  // no_causal (Whisper encoder / cross-attn) always takes the decomposed
+  // hipBLASLt path. The fused/flash decode kernels are decode-only (sq==1) and
+  // read seqlens_k with the +1 PAST-token convention, plus assume the KV cache
+  // is appended in BSHD->BNSD layout from `sq` new tokens. Neither holds for
+  // bidirectional no-past attention where `key` is the full Skv-length KV
+  // (cross-attn ships it as rank-4 BNSH with Skv != sq). Routing no_causal to
+  // the decomposed path keeps a single correct code path for these models.
   bool fused_predicate =
-      (!gqa_fused_decode_disabled() && fused_d && sq == 1 && kv_inputs_ok &&
-       present_key && present_value && sliding_ok_for_fused &&
-       sink_ok_for_fused && size_ok_for_fused);
+      (!gqa_fused_decode_disabled() && !no_causal && fused_fp16 && fused_d &&
+       sq == 1 && kv_inputs_ok && present_key && present_value &&
+       sliding_ok_for_fused && sink_ok_for_fused && size_ok_for_fused);
 
   if (fused_predicate) {
     const void *qSrc = query;
@@ -710,10 +791,10 @@ static int gqa_forward_hipblaslt(
       void *d_Qsplit = ws + off_split;
       void *d_Ksplit = ws + off_split + Q_full_bytes;
       void *d_Vsplit = ws + off_split + Q_full_bytes + K_full_bytes;
-      if (hip_gqa_split_qkv(stream, query, d_Qsplit, d_Ksplit, d_Vsplit,
-                            static_cast<int>(B), static_cast<int>(sq),
-                            static_cast<int>(H), static_cast<int>(G),
-                            static_cast<int>(d)) != 0)
+      if (hip_gqa_split_qkv(
+              stream, query, d_Qsplit, d_Ksplit, d_Vsplit, static_cast<int>(B),
+              static_cast<int>(sq), static_cast<int>(H), static_cast<int>(G),
+              static_cast<int>(d), static_cast<int>(elem_sz)) != 0)
         return -1;
       qSrc = d_Qsplit;
       kSrc = d_Ksplit;
@@ -729,12 +810,14 @@ static int gqa_forward_hipblaslt(
       if (hip_gqa_rope(stream, qSrc, d_Qroped, cos_cache, sin_cache,
                        static_cast<int>(B), static_cast<int>(sq),
                        static_cast<int>(H), static_cast<int>(d), half_rot,
-                       static_cast<int>(past_len), seqlens_k_ptr) != 0)
+                       static_cast<int>(past_len), seqlens_k_ptr,
+                       static_cast<int>(elem_sz)) != 0)
         return -1;
       if (hip_gqa_rope(stream, kSrc, d_Kroped, cos_cache, sin_cache,
                        static_cast<int>(B), static_cast<int>(sq),
                        static_cast<int>(G), static_cast<int>(d), half_rot,
-                       static_cast<int>(past_len), seqlens_k_ptr) != 0)
+                       static_cast<int>(past_len), seqlens_k_ptr,
+                       static_cast<int>(elem_sz)) != 0)
         return -1;
 
       qSrc = d_Qroped;
@@ -742,12 +825,12 @@ static int gqa_forward_hipblaslt(
       // vSrc is intentionally NOT updated: V is never RoPE'd.
     }
 
-    if (update_kv_cache(stream, past_key, past_value, kSrc, vSrc, present_key,
-                        present_value, static_cast<int>(B),
-                        static_cast<int>(past_len), static_cast<int>(sq),
-                        static_cast<int>(G), static_cast<int>(d),
-                        static_cast<int>(past_buf_seq),
-                        static_cast<int>(present_seq), seqlens_k_ptr) != 0)
+    if (update_kv_cache(
+            stream, past_key, past_value, kSrc, vSrc, present_key,
+            present_value, static_cast<int>(B), static_cast<int>(past_len),
+            static_cast<int>(sq), static_cast<int>(G), static_cast<int>(d),
+            static_cast<int>(past_buf_seq), static_cast<int>(present_seq),
+            seqlens_k_ptr, static_cast<int>(elem_sz)) != 0)
       return -1;
 
     if (use_flash_decode) {
@@ -822,7 +905,19 @@ static int gqa_forward_hipblaslt(
   // have no validated multi-batch decode workload yet.
   int64_t total_seq = skv;
   int64_t past_len = skv - sq;
-  if (seqlens_k_ptr) {
+  // no_causal (Whisper encoder self-attn + decoder cross-attn) is bidirectional
+  // with NO past KV: the converters emit a compile-time seqlens_k = skv meaning
+  // "all skv keys are valid". The ORT decode convention below (seqlens_k[b] =
+  // PAST tokens, total = past + current => total_seq = seqlens_k+1) does NOT
+  // apply here. Applying it would give total_seq = skv+1 > present_seq = skv ->
+  // rc=-1 -> zeroed output. Also, past_len = total_seq - sq is invalid when
+  // sq != skv (cross-attn has sq=1, skv=1500 => bogus past_len=1499). For
+  // no_causal there is no past, so total_seq = skv (== present_seq) and
+  // past_len = 0; skip the seqlens_k readback entirely.
+  if (no_causal) {
+    total_seq = skv;
+    past_len = 0;
+  } else if (seqlens_k_ptr) {
     int32_t seqlens_k_val = 0;
 
     if (seqlens_k_pre != kSeqlensKNotRead) {
@@ -951,6 +1046,7 @@ static int gqa_forward_hipblaslt(
                 /*batch=*/B * G,
                 /*transA=*/true,
                 /*outputFp32=*/true,
+                /*inputFp32=*/gemm_fp32,
                 /*strideA=*/present_seq * d,
                 /*strideB=*/HPG * sq * d,
                 /*strideC=*/HPG * sq * total_seq};
@@ -962,12 +1058,14 @@ static int gqa_forward_hipblaslt(
                 /*k=*/total_seq,
                 /*batch=*/B * G,
                 /*transA=*/false,
-                /*outputFp32=*/false,
+                /*outputFp32=*/gemm_fp32,
+                /*inputFp32=*/gemm_fp32,
                 /*strideA=*/present_seq * d,
                 /*strideB=*/HPG * sq * total_seq,
                 /*strideC=*/HPG * sq * d};
   } else {
-    scoreKey = {total_seq,     sq, d, B * H, true, true,
+    scoreKey = {total_seq,           sq,        d, B * H, true,
+                /*outputFp32=*/true, gemm_fp32,
                 /*strideA=*/0,
                 /*strideB=*/0,
                 /*strideC=*/0};
@@ -976,7 +1074,8 @@ static int gqa_forward_hipblaslt(
                 total_seq,
                 B * H,
                 false,
-                false,
+                /*outputFp32=*/gemm_fp32,
+                gemm_fp32,
                 /*strideA=*/0,
                 /*strideB=*/0,
                 /*strideC=*/0};
@@ -1086,10 +1185,10 @@ static int gqa_forward_hipblaslt(
       void *d_Qsplit = ws + off_Qsplit;
       void *d_Ksplit = ws + off_Ksplit;
       void *d_Vsplit = ws + off_Vsplit;
-      HIP_CHECK(hip_gqa_split_qkv(stream, query, d_Qsplit, d_Ksplit, d_Vsplit,
-                                  static_cast<int>(B), static_cast<int>(sq),
-                                  static_cast<int>(H), static_cast<int>(G),
-                                  static_cast<int>(d)));
+      HIP_CHECK(hip_gqa_split_qkv(
+          stream, query, d_Qsplit, d_Ksplit, d_Vsplit, static_cast<int>(B),
+          static_cast<int>(sq), static_cast<int>(H), static_cast<int>(G),
+          static_cast<int>(d), static_cast<int>(elem_sz)));
       qSrc = d_Qsplit;
       kSrc = d_Ksplit;
       vSrc = d_Vsplit;
@@ -1106,11 +1205,13 @@ static int gqa_forward_hipblaslt(
       HIP_CHECK(hip_gqa_rope(stream, qSrc, d_Qroped, cos_cache, sin_cache,
                              static_cast<int>(B), static_cast<int>(sq),
                              static_cast<int>(H), static_cast<int>(d), half_rot,
-                             static_cast<int>(past_len), nullptr));
+                             static_cast<int>(past_len), nullptr,
+                             static_cast<int>(elem_sz)));
       HIP_CHECK(hip_gqa_rope(stream, kSrc, d_Kroped, cos_cache, sin_cache,
                              static_cast<int>(B), static_cast<int>(sq),
                              static_cast<int>(G), static_cast<int>(d), half_rot,
-                             static_cast<int>(past_len), nullptr));
+                             static_cast<int>(past_len), nullptr,
+                             static_cast<int>(elem_sz)));
 
       qSrc = d_Qroped;
       kSrc = d_Kroped;
@@ -1123,7 +1224,7 @@ static int gqa_forward_hipblaslt(
     if (need_transpose) {
       HIP_CHECK(hip_gqa_transpose_mid_dims(
           stream, qSrc, d_Qtrans, static_cast<int>(B), static_cast<int>(sq),
-          static_cast<int>(H), static_cast<int>(d)));
+          static_cast<int>(H), static_cast<int>(d), static_cast<int>(elem_sz)));
     }
 
     // ---- Steps 4-5: KV Cache Update ----
@@ -1137,12 +1238,16 @@ static int gqa_forward_hipblaslt(
     // decode step. The expand path has already consumed total_seq host-side
     // above, so it passes nullptr to preserve the pre-refactor behaviour.
     if (present_key && present_value) {
+      // For no_causal, never hand seqlens_k to the append kernel (it would
+      // apply the +1 PAST-token convention); update_kv_cache routes no_causal
+      // through its bidirectional copy/append branch using skv directly.
       HIP_CHECK(update_kv_cache(
           stream, past_key, past_value, kSrc, vSrc, present_key, present_value,
           static_cast<int>(B), static_cast<int>(past_len), static_cast<int>(sq),
           static_cast<int>(G), static_cast<int>(d),
           static_cast<int>(past_buf_seq), static_cast<int>(present_seq),
-          use_no_expand ? seqlens_k_ptr : nullptr));
+          (use_no_expand && !no_causal) ? seqlens_k_ptr : nullptr,
+          static_cast<int>(elem_sz), no_causal, static_cast<int>(skv)));
     }
 
     // ---- Steps 6-7: KV Expand [B*G, present_seq, d] -> [B*H, total_seq, d]
@@ -1155,12 +1260,14 @@ static int gqa_forward_hipblaslt(
       int kvDstStride = static_cast<int>(total_seq * d);
       int expandCopy = static_cast<int>(total_seq * d);
 
-      HIP_CHECK(hip_gqa_expand_kv(
-          stream, kCache, d_Kexp, static_cast<int>(B * H),
-          static_cast<int>(HPG), kvSrcStride, kvDstStride, expandCopy));
-      HIP_CHECK(hip_gqa_expand_kv(
-          stream, vCache, d_Vexp, static_cast<int>(B * H),
-          static_cast<int>(HPG), kvSrcStride, kvDstStride, expandCopy));
+      HIP_CHECK(
+          hip_gqa_expand_kv(stream, kCache, d_Kexp, static_cast<int>(B * H),
+                            static_cast<int>(HPG), kvSrcStride, kvDstStride,
+                            expandCopy, static_cast<int>(elem_sz)));
+      HIP_CHECK(
+          hip_gqa_expand_kv(stream, vCache, d_Vexp, static_cast<int>(B * H),
+                            static_cast<int>(HPG), kvSrcStride, kvDstStride,
+                            expandCopy, static_cast<int>(elem_sz)));
     }
 
     // ---- Step 8: Score GEMM (fp16 in, fp32 out) ----
@@ -1185,17 +1292,30 @@ static int gqa_forward_hipblaslt(
     // (the no-expand strided-batched output lands in BNSD order too).
     int scoreF32BatchStride = static_cast<int>(sq * total_seq);
     int scoreFp16BatchStride = static_cast<int>(sq * total_seq);
-    if (sq > 1 || local_window_size > 0) {
+    if ((sq > 1 || local_window_size > 0) && !no_causal) {
       HIP_CHECK(hip_gqa_causal_mask_f32(
           stream, d_S_f32, static_cast<int>(B * H), static_cast<int>(total_seq),
           static_cast<int>(sq), scoreF32BatchStride, static_cast<int>(past_len),
           static_cast<int>(local_window_size)));
     }
-    HIP_CHECK(hip_gqa_softmax_f32_to_f16(
-        stream, d_S_f32, d_S_fp16, static_cast<int>(B * H * sq),
-        static_cast<int>(total_seq), static_cast<int>(sq), scoreF32BatchStride,
-        scoreFp16BatchStride, head_sink, static_cast<int>(H),
-        static_cast<int>(use_smooth_softmax)));
+    // fp16 GQA: softmax writes fp16 probabilities for the fp16 Value GEMM.
+    // fp32 GQA (Whisper no_causal): softmax writes fp32 probabilities for the
+    // fp32 Value GEMM. d_S_fp16 is the probabilities buffer either way (sized
+    // by elem_sz above), so the name is fp16-specific but the buffer holds
+    // fp32 when gemm_fp32.
+    if (gemm_fp32) {
+      HIP_CHECK(hip_gqa_softmax_f32_to_f32(
+          stream, d_S_f32, d_S_fp16, static_cast<int>(B * H * sq),
+          static_cast<int>(total_seq), static_cast<int>(sq),
+          scoreF32BatchStride, scoreFp16BatchStride, head_sink,
+          static_cast<int>(H), static_cast<int>(use_smooth_softmax)));
+    } else {
+      HIP_CHECK(hip_gqa_softmax_f32_to_f16(
+          stream, d_S_f32, d_S_fp16, static_cast<int>(B * H * sq),
+          static_cast<int>(total_seq), static_cast<int>(sq),
+          scoreF32BatchStride, scoreFp16BatchStride, head_sink,
+          static_cast<int>(H), static_cast<int>(use_smooth_softmax)));
+    }
 
     // ---- Step 10: Value GEMM (fp16 in, fp16 out) ----
     // A = V : no-expand reads present_value directly; expand reads d_Vexp.
@@ -1217,7 +1337,8 @@ static int gqa_forward_hipblaslt(
     if (need_transpose) {
       HIP_CHECK(hip_gqa_transpose_mid_dims(
           stream, d_O, output, static_cast<int>(B), static_cast<int>(H),
-          static_cast<int>(sq), static_cast<int>(d)));
+          static_cast<int>(sq), static_cast<int>(d),
+          static_cast<int>(elem_sz)));
     }
 
     RUNTIME_DEBUG_LOG(
@@ -1247,11 +1368,15 @@ int wrap_group_query_attention(
     void *attention_bias, void *head_sink, void *k_scale, void *v_scale,
     // Outputs
     void *output, void *present_key, void *present_value, void *output_qk,
-    // Attributes (12)
+    // Attributes (13)
     int64_t num_heads, int64_t kv_num_heads, float scale, int64_t do_rotary,
     int64_t rotary_interleaved, float softcap, int64_t local_window_size,
     int64_t smooth_softmax, int64_t qk_output, int64_t k_quant_type,
     int64_t v_quant_type, int64_t kv_cache_bit_width,
+    // Whisper bidirectional-attention flag: when non-zero, the causal mask
+    // step in gqa_forward_hipblaslt is skipped. Default 0 preserves Llama /
+    // gpt-oss behaviour.
+    int32_t no_causal,
     // Shape values (6): past_buf_seq is the buffer dimension of past_key
     // (may differ from actual past token count for pre-allocated caches)
     int64_t batch_size, int64_t seq_len_q, int64_t seq_len_kv,
@@ -1283,21 +1408,19 @@ int wrap_group_query_attention(
             (long long)num_heads, (long long)kv_num_heads);
     return -1;
   }
-  // The hipBLASLt GQA pipeline is currently FP16-only: all matrix layouts are
-  // created with HIP_R_16F and every custom HIP kernel (rope_kernel,
-  // kv_cache_append_kernel, softmax_inplace_kernel, etc.) operates on __half.
-  // This matches requirements where GQA runs in FP16.
-  //
-  // Future FP32 (or BF16) support would require:
-  //   1. Parameterizing all hipblasLtMatrixLayoutCreate() calls with the
-  //      runtime data type instead of hard-coded HIP_R_16F.
-  //   2. Templating the custom HIP kernels on the element type so they can
-  //      handle float / __hip_bfloat16 in addition to __half.
-  //   3. Adjusting workspace layout sizing for 4-byte (or other) elements.
-  if (element_size_bytes != 2) {
+  // The decomposed hipBLASLt GQA pipeline supports fp16 (elem_size=2) and
+  // fp32 (elem_size=4): GEMM matrix layouts are created with the runtime data
+  // type (gemm_fp32), the data-movement custom kernels (rope / append / concat
+  // / transpose / expand / split) dispatch on element_size_bytes, and softmax
+  // writes fp16 or fp32 probabilities to match. The fp32 path is used by
+  // Whisper's no_causal attention (encoder self-attn + decoder cross-attn),
+  // which is forced down the decomposed path. The fused / flash decode kernels
+  // (Llama / gpt-oss) remain FP16-only; no_causal never reaches them. BF16 is
+  // not yet supported.
+  if (element_size_bytes != 2 && element_size_bytes != 4) {
     fprintf(stderr,
             "wrap_group_query_attention: hipBLASLt pipeline requires "
-            "FP16 (elem_size=2), got %lld\n",
+            "FP16 (elem_size=2) or FP32 (elem_size=4), got %lld\n",
             (long long)element_size_bytes);
     return -1;
   }
@@ -1393,7 +1516,7 @@ int wrap_group_query_attention(
       seqlens_k, cos_cache, sin_cache, head_sink, has_smooth_softmax, output,
       present_key, present_value, batch_size, seq_len_q, seq_len_kv,
       past_buf_seq, num_heads, kv_num_heads, head_dim, scale, do_rotary,
-      local_window_size);
+      local_window_size, no_causal != 0, element_size_bytes);
 
   if (rc != 0) {
     fprintf(stderr, "wrap_group_query_attention: gqa_forward failed (rc=%d)\n",

--- a/lib/Runtime/real/multi_head_attention.cpp
+++ b/lib/Runtime/real/multi_head_attention.cpp
@@ -536,17 +536,18 @@ extern "C" int wrap_multi_head_attention(
   // as [batch_size, dim1, dim2, D]. For Q with dim1=Sq, dim2=N this produces
   // [B, N, Sq, H]; same shape with Skv for K and V.
   if (need_q_trans) {
+    // MHA path is fp16-only; element_size_bytes=2.
     HIP_CHECK(hip_gqa_transpose_mid_dims(
         stream, query, d_Qbnsh, static_cast<int>(B), static_cast<int>(Sq),
-        static_cast<int>(N), static_cast<int>(H)));
+        static_cast<int>(N), static_cast<int>(H), /*element_size_bytes=*/2));
   }
   if (need_kv_trans) {
     HIP_CHECK(hip_gqa_transpose_mid_dims(
         stream, key, d_Kbnsh, static_cast<int>(B), static_cast<int>(Skv),
-        static_cast<int>(N), static_cast<int>(H)));
+        static_cast<int>(N), static_cast<int>(H), /*element_size_bytes=*/2));
     HIP_CHECK(hip_gqa_transpose_mid_dims(
         stream, value, d_Vbnsh, static_cast<int>(B), static_cast<int>(Skv),
-        static_cast<int>(N), static_cast<int>(H)));
+        static_cast<int>(N), static_cast<int>(H), /*element_size_bytes=*/2));
   }
 
   // ---- Step 4: Score GEMM: S = Q @ K^T * scale, fp16->fp32 ---------------
@@ -647,7 +648,7 @@ extern "C" int wrap_multi_head_attention(
   if (need_o_trans) {
     HIP_CHECK(hip_gqa_transpose_mid_dims(
         stream, d_O_bnsh, output, static_cast<int>(B), static_cast<int>(N),
-        static_cast<int>(Sq), static_cast<int>(H)));
+        static_cast<int>(Sq), static_cast<int>(H), /*element_size_bytes=*/2));
   }
 
   RUNTIME_DEBUG_LOG(

--- a/test/lit/Conversion/hip-to-llvm/test_gqa.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_gqa.mlir
@@ -30,15 +30,16 @@ module {
 }
 
 // CHECK-LABEL: llvm.func @test_gqa_lowering
-// CHECK: llvm.call @wrap_group_query_attention({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, f32, i64, i64, f32, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
+// CHECK: llvm.call @wrap_group_query_attention({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, f32, i64, i64, f32, i64, i64, i64, i64, i64, i64, i32, i64, i64, i64, i64, i64, i64) -> i32
 
-// Verify 37 parameters (full MS GQA spec signature):
+// Verify 38 parameters (full MS GQA spec signature + no_causal):
 // - 19 pointers: state, query, key, value, past_key, past_value, seqlens_k, total_seq_len,
 //                cos_cache(NULL), sin_cache(NULL), position_ids(NULL), attention_bias(NULL),
 //                head_sink(NULL), k_scale(NULL), v_scale(NULL),
 //                output, present_key, present_value, output_qk(NULL)
-// - 12 attributes: num_heads=32, kv_num_heads=8, scale=0.0883883461, do_rotary=0, rotary_interleaved=0,
+// - 13 attributes: num_heads=32, kv_num_heads=8, scale=0.0883883461, do_rotary=0, rotary_interleaved=0,
 //                  softcap=0.0, local_window_size=-1, smooth_softmax=0, qk_output=0,
-//                  k_quant_type=0(NONE), v_quant_type=0(NONE), kv_cache_bit_width=8
+//                  k_quant_type=0(NONE), v_quant_type=0(NONE), kv_cache_bit_width=8,
+//                  no_causal=0(i32)
 // - 6 shape params: batch_size=1, seq_len_q=1, seq_len_kv=128, past_buf_seq=127, head_dim=128,
 //                   element_size_bytes=2

--- a/test/lit/gqa_no_causal_default_off.mlir
+++ b/test/lit/gqa_no_causal_default_off.mlir
@@ -1,0 +1,58 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Regression guard for the new `no_causal` attribute on hip.gqa:
+// the default lowering of com.microsoft.GroupQueryAttention MUST emit
+// `no_causal = false` (or no attribute, which is equivalent given the
+// DefaultValuedAttr<BoolAttr, "false"> definition).
+//
+// This protects every existing Llama / gpt-oss path against an accidental
+// flip to no_causal=true (which would skip the causal mask and silently
+// corrupt prefill / multi-token sliding-window decodes).
+// ============================================================================
+
+// RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip | FileCheck %s
+
+module {
+  func.func @main_graph(
+      %query: tensor<1x1x4096xf16>,
+      %key: tensor<1x1x1024xf16>,
+      %value: tensor<1x1x1024xf16>,
+      %past_key: tensor<1x8x127x128xf16>,
+      %past_value: tensor<1x8x127x128xf16>,
+      %seqlens_k: tensor<1x1xi32>,
+      %total_seq_len: tensor<i32>)
+      -> (tensor<1x1x4096xf16>, tensor<1x8x128x128xf16>, tensor<1x8x128x128xf16>) {
+
+    // CHECK-LABEL: func.func @main_graph
+    %none1 = "onnx.NoValue"() {value} : () -> none
+    %none2 = "onnx.NoValue"() {value} : () -> none
+
+    %out:3 = "onnx.Custom"(%query, %key, %value, %past_key, %past_value,
+                            %seqlens_k, %total_seq_len, %none1, %none2)
+        <{function_name = "GroupQueryAttention"}>
+        {domain_name = "com.microsoft",
+         num_heads = 32 : si64,
+         kv_num_heads = 8 : si64,
+         scale = 0.0883883461 : f32,
+         softcap = 0.000000e+00 : f32,
+         do_rotary = 0 : si64,
+         rotary_interleaved = 0 : si64}
+        : (tensor<1x1x4096xf16>, tensor<1x1x1024xf16>, tensor<1x1x1024xf16>,
+           tensor<1x8x127x128xf16>, tensor<1x8x127x128xf16>,
+           tensor<1x1xi32>, tensor<i32>, none, none)
+        -> (tensor<1x1x4096xf16>, tensor<1x8x128x128xf16>, tensor<1x8x128x128xf16>)
+
+    // hip.gqa with default no_causal must NOT emit no_causal=true. Note: MLIR
+    // omits DefaultValuedAttr<BoolAttr,"false"> entirely when at the default
+    // value, so the regression guard is the negative check below: any future
+    // accidental flip of the default to true would render `no_causal = true`
+    // explicitly in the assembly and the test would fail.
+    // CHECK: hip.gqa
+    // CHECK-NOT: no_causal = true
+
+    return %out#0, %out#1, %out#2 : tensor<1x1x4096xf16>, tensor<1x8x128x128xf16>, tensor<1x8x128x128xf16>
+  }
+}


### PR DESCRIPTION
Second of a **5-PR cascade** adding **Whisper-large-v3** support. Extends the existing `GroupQueryAttention` op + runtime to cover **bidirectional (no_causal) attention** and **fp32** — the kernel foundation Whisper needs, landed as a pure GQA capability extension (no Whisper graph yet). Independently shippable.

**Llama/gpt-oss are byte-identical:** `no_causal` defaults `false` and the fused/flash decode kernels stay fp16-only.

**LOC delta: 12 files, +591 / −194.**

## What's new

- **`no_causal` BoolAttr** on `Hip_GqaOp` (`HipOps.td`, default `false`).
- **`gqa.cpp`** — `no_causal` is exempt from the seqlens_k `+1` convention (encoder self / decoder cross are bidirectional: `total_seq = skv`, `past_len = 0`) and is forced down the **decomposed** hipBLASLt path. That path is now **fp32-capable** (`element_size_bytes ∈ {2,4}`, `GqaGemmKey.inputFp32`, fp32 softmax). The fused/flash decode kernels are untouched and remain `__half`-only.
- **`gqa_kernel.hip`** — data-movement kernels (rope / transpose / kv-append / kv-concat / expand / split-qkv) templated on dtype + an `hip_gqa_softmax_f32_to_f32` launcher. Every launcher now **clears + reports its own HIP launch status** (`GQA_DISPATCH_BY_ELEM_SIZE` clears before dispatch; `GQA_RETURN_LAUNCH_STATUS()` after) — previously a stale sticky error was misattributed to the next op that called `hipGetLastError()` (surfaced as a bogus `hip_layer_norm launch failed`).
- **`layer_norm_kernel.hip`** — clear-before-launch for correct error attribution.
- **`GqaConversion` / `GqaLowering`** — thread `no_causal` + `element_size_bytes`.
- **`multi_head_attention.cpp`** — pass `element_size_bytes=2` to the now-templated transpose launcher (fp16-only MHA path; kernel-signature sync, **required** so the existing MHA still compiles against the new launcher signature).

## Tests

- LIT `gqa_no_causal_default_off.mlir` (default is off) + `test_gqa.mlir` (lowering). ✅
- **Llama-3.2-1B regression** — 4/4 pass, confirming the causal path is byte-unchanged. ✅

## Stack overview

- **1/5 (#279):** conv1d op (encoder front-end).
- **2/5 (this PR):** GQA `no_causal` + fp32 decomposed path.
- **3/5:** `SkipLayerNormalization` → `hip.add` + `hip.layer_norm`.
- **4/5:** Whisper encoder/decoder attention → `hip.gqa` (depends on this PR).
- **5/5:** end-to-end Whisper (model setup + tests + CLI + docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
