### PR TITLE
feat(runtime): runtime + custom-kernel slice of PR #259 (mm preserved)

### DIFF
--- a/3rd-party/custom_kernels/CMakeLists.txt
+++ b/3rd-party/custom_kernels/CMakeLists.txt
@@ -32,6 +32,7 @@ hip_add_library(hip_custom_kernels STATIC
     hip/gqa_kernel.hip
     hip/gemm_wmma_kernel.hip
     hip/elementwise_sub_kernel.hip
+    hip/elementwise_mul_kernel.hip
     hip/elementwise_reciprocal_kernel.hip
     hip/elementwise_sqrt_kernel.hip
     hip/elementwise_gelu_kernel.hip
@@ -55,6 +56,8 @@ hip_add_library(hip_custom_kernels STATIC
     hip/causal_conv_step_kernel.hip
     hip/slice_kernel.hip
     hip/scatter_nd_kernel.hip
+    hip/softmax_kernel.hip
+    hip/nonzero_kernel.hip
     INCLUDE_DIRECTORIES
         ${CMAKE_CURRENT_SOURCE_DIR}/include
 )

--- a/3rd-party/custom_kernels/hip/cast_kernel.hip
+++ b/3rd-party/custom_kernels/hip/cast_kernel.hip
@@ -41,6 +41,131 @@ __global__ void cast_f16_to_f32_kernel(
   }
 }
 
+__global__ void cast_i64_to_f32_kernel(
+    const int64_t* __restrict__ input,
+    float* __restrict__ output,
+    int64_t num_elements) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < num_elements) {
+    output[idx] = static_cast<float>(input[idx]);
+  }
+}
+
+__global__ void cast_i32_to_f32_kernel(
+    const int32_t* __restrict__ input,
+    float* __restrict__ output,
+    int64_t num_elements) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < num_elements) {
+    output[idx] = static_cast<float>(input[idx]);
+  }
+}
+
+__global__ void cast_i64_to_f16_kernel(
+    const int64_t* __restrict__ input,
+    __half* __restrict__ output,
+    int64_t num_elements) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < num_elements) {
+    output[idx] = __float2half(static_cast<float>(input[idx]));
+  }
+}
+
+__global__ void cast_i32_to_f16_kernel(
+    const int32_t* __restrict__ input,
+    __half* __restrict__ output,
+    int64_t num_elements) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < num_elements) {
+    output[idx] = __float2half(static_cast<float>(input[idx]));
+  }
+}
+
+__global__ void cast_i32_to_i64_kernel(
+    const int32_t* __restrict__ input,
+    int64_t* __restrict__ output,
+    int64_t num_elements) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < num_elements) {
+    output[idx] = static_cast<int64_t>(input[idx]);
+  }
+}
+
+__global__ void cast_f32_to_i64_kernel(
+    const float* __restrict__ input,
+    int64_t* __restrict__ output,
+    int64_t num_elements) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < num_elements) {
+    output[idx] = static_cast<int64_t>(input[idx]);
+  }
+}
+
+__global__ void cast_f32_to_i32_kernel(
+    const float* __restrict__ input,
+    int32_t* __restrict__ output,
+    int64_t num_elements) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < num_elements) {
+    output[idx] = static_cast<int32_t>(input[idx]);
+  }
+}
+
+__global__ void cast_f16_to_i64_kernel(
+    const __half* __restrict__ input,
+    int64_t* __restrict__ output,
+    int64_t num_elements) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < num_elements) {
+    output[idx] = static_cast<int64_t>(__half2float(input[idx]));
+  }
+}
+
+__global__ void cast_f16_to_i32_kernel(
+    const __half* __restrict__ input,
+    int32_t* __restrict__ output,
+    int64_t num_elements) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < num_elements) {
+    output[idx] = static_cast<int32_t>(__half2float(input[idx]));
+  }
+}
+
+// Generic integer<->integer cast (used for the uint8 paths that the per-pair
+// kernels above don't cover). static_cast handles narrowing/widening per C++
+// rules; the kernels above stay as-is so existing FP paths keep their bespoke
+// __float2half / __half2float intrinsics.
+template <typename Src, typename Dst>
+__global__ void cast_int_to_int_kernel(
+    const Src* __restrict__ input,
+    Dst* __restrict__ output,
+    int64_t num_elements) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < num_elements) {
+    output[idx] = static_cast<Dst>(input[idx]);
+  }
+}
+
+__global__ void cast_ui8_to_f16_kernel(
+    const uint8_t* __restrict__ input,
+    __half* __restrict__ output,
+    int64_t num_elements) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < num_elements) {
+    output[idx] = __float2half(static_cast<float>(input[idx]));
+  }
+}
+
+__global__ void cast_f16_to_ui8_kernel(
+    const __half* __restrict__ input,
+    uint8_t* __restrict__ output,
+    int64_t num_elements) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < num_elements) {
+    output[idx] = static_cast<uint8_t>(__half2float(input[idx]));
+  }
+}
+
 extern "C" int hip_cast(
     void* stream,
     const void* input,
@@ -81,6 +206,82 @@ extern "C" int hip_cast(
                        static_cast<const __half*>(input),
                        static_cast<float*>(output),
                        num_elements);
+  } else if (input_dtype == HIP_DTYPE_INT64 && output_dtype == HIP_DTYPE_FLOAT32) {
+    CUSTOM_KERNELS_DEBUG_LOG("[custom_kernels] hip_cast: INT64->FLOAT32, num_elements=%lld\n", (long long)num_elements);
+    hipLaunchKernelGGL(cast_i64_to_f32_kernel,
+                       dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const int64_t*>(input),
+                       static_cast<float*>(output), num_elements);
+  } else if (input_dtype == HIP_DTYPE_INT32 && output_dtype == HIP_DTYPE_FLOAT32) {
+    hipLaunchKernelGGL(cast_i32_to_f32_kernel,
+                       dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const int32_t*>(input),
+                       static_cast<float*>(output), num_elements);
+  } else if (input_dtype == HIP_DTYPE_INT64 && output_dtype == HIP_DTYPE_FLOAT16) {
+    hipLaunchKernelGGL(cast_i64_to_f16_kernel,
+                       dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const int64_t*>(input),
+                       static_cast<__half*>(output), num_elements);
+  } else if (input_dtype == HIP_DTYPE_INT32 && output_dtype == HIP_DTYPE_FLOAT16) {
+    hipLaunchKernelGGL(cast_i32_to_f16_kernel,
+                       dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const int32_t*>(input),
+                       static_cast<__half*>(output), num_elements);
+  } else if (input_dtype == HIP_DTYPE_INT32 && output_dtype == HIP_DTYPE_INT64) {
+    hipLaunchKernelGGL(cast_i32_to_i64_kernel,
+                       dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const int32_t*>(input),
+                       static_cast<int64_t*>(output), num_elements);
+  } else if (input_dtype == HIP_DTYPE_FLOAT32 && output_dtype == HIP_DTYPE_INT64) {
+    hipLaunchKernelGGL(cast_f32_to_i64_kernel,
+                       dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const float*>(input),
+                       static_cast<int64_t*>(output), num_elements);
+  } else if (input_dtype == HIP_DTYPE_FLOAT32 && output_dtype == HIP_DTYPE_INT32) {
+    hipLaunchKernelGGL(cast_f32_to_i32_kernel,
+                       dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const float*>(input),
+                       static_cast<int32_t*>(output), num_elements);
+  } else if (input_dtype == HIP_DTYPE_FLOAT16 && output_dtype == HIP_DTYPE_INT64) {
+    hipLaunchKernelGGL(cast_f16_to_i64_kernel,
+                       dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const __half*>(input),
+                       static_cast<int64_t*>(output), num_elements);
+  } else if (input_dtype == HIP_DTYPE_FLOAT16 && output_dtype == HIP_DTYPE_INT32) {
+    hipLaunchKernelGGL(cast_f16_to_i32_kernel,
+                       dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const __half*>(input),
+                       static_cast<int32_t*>(output), num_elements);
+  } else if (input_dtype == HIP_DTYPE_INT64 && output_dtype == HIP_DTYPE_UINT8) {
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(cast_int_to_int_kernel<int64_t, uint8_t>),
+                       dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const int64_t*>(input),
+                       static_cast<uint8_t*>(output), num_elements);
+  } else if (input_dtype == HIP_DTYPE_UINT8 && output_dtype == HIP_DTYPE_INT64) {
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(cast_int_to_int_kernel<uint8_t, int64_t>),
+                       dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const uint8_t*>(input),
+                       static_cast<int64_t*>(output), num_elements);
+  } else if (input_dtype == HIP_DTYPE_INT32 && output_dtype == HIP_DTYPE_UINT8) {
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(cast_int_to_int_kernel<int32_t, uint8_t>),
+                       dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const int32_t*>(input),
+                       static_cast<uint8_t*>(output), num_elements);
+  } else if (input_dtype == HIP_DTYPE_UINT8 && output_dtype == HIP_DTYPE_INT32) {
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(cast_int_to_int_kernel<uint8_t, int32_t>),
+                       dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const uint8_t*>(input),
+                       static_cast<int32_t*>(output), num_elements);
+  } else if (input_dtype == HIP_DTYPE_UINT8 && output_dtype == HIP_DTYPE_FLOAT16) {
+    hipLaunchKernelGGL(cast_ui8_to_f16_kernel,
+                       dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const uint8_t*>(input),
+                       static_cast<__half*>(output), num_elements);
+  } else if (input_dtype == HIP_DTYPE_FLOAT16 && output_dtype == HIP_DTYPE_UINT8) {
+    hipLaunchKernelGGL(cast_f16_to_ui8_kernel,
+                       dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const __half*>(input),
+                       static_cast<uint8_t*>(output), num_elements);
   } else {
     fprintf(stderr,
             "[custom_kernels] hip_cast: unsupported conversion "

--- a/3rd-party/custom_kernels/hip/elementwise_binary_kernel.hip
+++ b/3rd-party/custom_kernels/hip/elementwise_binary_kernel.hip
@@ -67,82 +67,105 @@ __global__ void elementwise_div_kernel<__half>(const __half *__restrict__ lhs,
 // ORT: BINARY_OP_NAME_EXPR2(Equal, (a == b)) / (Less, (a < b))
 // =====================================================================
 
+// stride = (operand_num == 1) ? 0 : 1 -- scalar broadcast comes for free
+// by reading address 0 for every output index. We pass strides instead of
+// the per-input counts so the kernel can index without a branch.
+
 template <typename T>
 __global__ void elementwise_equal_kernel(const T *__restrict__ lhs,
                                          const T *__restrict__ rhs,
                                          uint8_t *__restrict__ output,
-                                         int64_t num_elements) {
+                                         int64_t num_elements,
+                                         int64_t lhs_stride,
+                                         int64_t rhs_stride) {
   int64_t idx =
       static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   if (idx < num_elements) {
-    output[idx] = static_cast<uint8_t>(lhs[idx] == rhs[idx]);
+    output[idx] = static_cast<uint8_t>(lhs[idx * lhs_stride] ==
+                                       rhs[idx * rhs_stride]);
   }
 }
 
 // FP16 path: promote to float to avoid relying on half operator==.
 __global__ void elementwise_equal_f16_kernel(
     const __half *__restrict__ lhs, const __half *__restrict__ rhs,
-    uint8_t *__restrict__ output, int64_t num_elements) {
+    uint8_t *__restrict__ output, int64_t num_elements,
+    int64_t lhs_stride, int64_t rhs_stride) {
   int64_t idx =
       static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   if (idx < num_elements) {
-    float a = __half2float(lhs[idx]);
-    float b = __half2float(rhs[idx]);
+    float a = __half2float(lhs[idx * lhs_stride]);
+    float b = __half2float(rhs[idx * rhs_stride]);
     output[idx] = static_cast<uint8_t>(a == b);
   }
 }
 
 extern "C" int hip_elementwise_equal(void *stream, const void *lhs,
                                      const void *rhs, void *output,
-                                     int64_t num_elements, int hip_dtype) {
-  if (num_elements <= 0)
+                                     int64_t lhs_num_elements,
+                                     int64_t rhs_num_elements,
+                                     int64_t out_num_elements, int hip_dtype) {
+  if (out_num_elements <= 0)
     return 0;
 
   hipStream_t hip_stream = static_cast<hipStream_t>(stream);
   constexpr int kBlockSize = 256;
   int grid_size =
-      static_cast<int>((num_elements + kBlockSize - 1) / kBlockSize);
+      static_cast<int>((out_num_elements + kBlockSize - 1) / kBlockSize);
+
+  // stride 0 = scalar broadcast (every idx reads the same single element);
+  // stride 1 = full-shape per-element read.
+  int64_t lhs_stride = (lhs_num_elements == 1) ? 0 : 1;
+  int64_t rhs_stride = (rhs_num_elements == 1) ? 0 : 1;
 
   switch (hip_dtype) {
   case HIP_DTYPE_FLOAT16:
     CUSTOM_KERNELS_DEBUG_LOG(
-        "[custom_kernels] hip_elementwise_equal: f16, num=%lld\n",
-        (long long)num_elements);
+        "[custom_kernels] hip_elementwise_equal: f16, out=%lld lhs_stride=%lld "
+        "rhs_stride=%lld\n",
+        (long long)out_num_elements, (long long)lhs_stride,
+        (long long)rhs_stride);
     hipLaunchKernelGGL(elementwise_equal_f16_kernel, dim3(grid_size),
                        dim3(kBlockSize), 0, hip_stream,
                        static_cast<const __half *>(lhs),
                        static_cast<const __half *>(rhs),
-                       static_cast<uint8_t *>(output), num_elements);
+                       static_cast<uint8_t *>(output), out_num_elements,
+                       lhs_stride, rhs_stride);
     break;
   case HIP_DTYPE_FLOAT32:
     CUSTOM_KERNELS_DEBUG_LOG(
-        "[custom_kernels] hip_elementwise_equal: f32, num=%lld\n",
-        (long long)num_elements);
+        "[custom_kernels] hip_elementwise_equal: f32, out=%lld\n",
+        (long long)out_num_elements);
     hipLaunchKernelGGL(elementwise_equal_kernel<float>, dim3(grid_size),
                        dim3(kBlockSize), 0, hip_stream,
                        static_cast<const float *>(lhs),
                        static_cast<const float *>(rhs),
-                       static_cast<uint8_t *>(output), num_elements);
+                       static_cast<uint8_t *>(output), out_num_elements,
+                       lhs_stride, rhs_stride);
     break;
   case HIP_DTYPE_INT32:
     CUSTOM_KERNELS_DEBUG_LOG(
-        "[custom_kernels] hip_elementwise_equal: i32, num=%lld\n",
-        (long long)num_elements);
+        "[custom_kernels] hip_elementwise_equal: i32, out=%lld\n",
+        (long long)out_num_elements);
     hipLaunchKernelGGL(elementwise_equal_kernel<int32_t>, dim3(grid_size),
                        dim3(kBlockSize), 0, hip_stream,
                        static_cast<const int32_t *>(lhs),
                        static_cast<const int32_t *>(rhs),
-                       static_cast<uint8_t *>(output), num_elements);
+                       static_cast<uint8_t *>(output), out_num_elements,
+                       lhs_stride, rhs_stride);
     break;
   case HIP_DTYPE_INT64:
     CUSTOM_KERNELS_DEBUG_LOG(
-        "[custom_kernels] hip_elementwise_equal: i64, num=%lld\n",
-        (long long)num_elements);
+        "[custom_kernels] hip_elementwise_equal: i64, out=%lld lhs_stride=%lld "
+        "rhs_stride=%lld\n",
+        (long long)out_num_elements, (long long)lhs_stride,
+        (long long)rhs_stride);
     hipLaunchKernelGGL(elementwise_equal_kernel<int64_t>, dim3(grid_size),
                        dim3(kBlockSize), 0, hip_stream,
                        static_cast<const int64_t *>(lhs),
                        static_cast<const int64_t *>(rhs),
-                       static_cast<uint8_t *>(output), num_elements);
+                       static_cast<uint8_t *>(output), out_num_elements,
+                       lhs_stride, rhs_stride);
     break;
   default:
     fprintf(stderr,
@@ -445,6 +468,319 @@ extern "C" int hip_elementwise_and(void *stream, const void *lhs,
             hipGetErrorString(err));
   }
   return static_cast<int>(err);
+}
+
+// =====================================================================
+// Mul / Add / Sub (typed). Dispatched from wrap_miopenOpTensor as the
+// integer-dtype fallback, because MIOpen's miopenOpTensor doesn't support
+// integer element types. Same-shape only -- broadcasting is materialised
+// upstream (see wrap_miopenOpTensor's 2-D broadcast fallback for the
+// general case; this kernel is only reached when shapes already match).
+// =====================================================================
+
+template <typename T>
+__global__ void elementwise_mul_kernel(const T *__restrict__ lhs,
+                                       const T *__restrict__ rhs,
+                                       T *__restrict__ output,
+                                       int64_t num_elements) {
+  int64_t idx =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < num_elements) {
+    output[idx] = lhs[idx] * rhs[idx];
+  }
+}
+
+template <>
+__global__ void elementwise_mul_kernel<__half>(const __half *__restrict__ lhs,
+                                               const __half *__restrict__ rhs,
+                                               __half *__restrict__ output,
+                                               int64_t num_elements) {
+  int64_t idx =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < num_elements) {
+    float a = __half2float(lhs[idx]);
+    float b = __half2float(rhs[idx]);
+    output[idx] = __float2half(a * b);
+  }
+}
+
+template <typename T>
+__global__ void elementwise_add_kernel(const T *__restrict__ lhs,
+                                       const T *__restrict__ rhs,
+                                       T *__restrict__ output,
+                                       int64_t num_elements) {
+  int64_t idx =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < num_elements) {
+    output[idx] = lhs[idx] + rhs[idx];
+  }
+}
+
+template <>
+__global__ void elementwise_add_kernel<__half>(const __half *__restrict__ lhs,
+                                               const __half *__restrict__ rhs,
+                                               __half *__restrict__ output,
+                                               int64_t num_elements) {
+  int64_t idx =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < num_elements) {
+    float a = __half2float(lhs[idx]);
+    float b = __half2float(rhs[idx]);
+    output[idx] = __float2half(a + b);
+  }
+}
+
+extern "C" int hip_elementwise_mul(void *stream, const void *lhs,
+                                   const void *rhs, void *output,
+                                   int64_t num_elements, int hip_dtype) {
+  if (num_elements <= 0)
+    return 0;
+  hipStream_t hip_stream = static_cast<hipStream_t>(stream);
+  constexpr int kBlockSize = 256;
+  int grid_size =
+      static_cast<int>((num_elements + kBlockSize - 1) / kBlockSize);
+  switch (hip_dtype) {
+  case HIP_DTYPE_INT64:
+    hipLaunchKernelGGL(elementwise_mul_kernel<int64_t>, dim3(grid_size),
+                       dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const int64_t *>(lhs),
+                       static_cast<const int64_t *>(rhs),
+                       static_cast<int64_t *>(output), num_elements);
+    break;
+  case HIP_DTYPE_INT32:
+    hipLaunchKernelGGL(elementwise_mul_kernel<int32_t>, dim3(grid_size),
+                       dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const int32_t *>(lhs),
+                       static_cast<const int32_t *>(rhs),
+                       static_cast<int32_t *>(output), num_elements);
+    break;
+  case HIP_DTYPE_FLOAT16:
+    hipLaunchKernelGGL(elementwise_mul_kernel<__half>, dim3(grid_size),
+                       dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const __half *>(lhs),
+                       static_cast<const __half *>(rhs),
+                       static_cast<__half *>(output), num_elements);
+    break;
+  case HIP_DTYPE_FLOAT32:
+    hipLaunchKernelGGL(elementwise_mul_kernel<float>, dim3(grid_size),
+                       dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const float *>(lhs),
+                       static_cast<const float *>(rhs),
+                       static_cast<float *>(output), num_elements);
+    break;
+  default:
+    fprintf(stderr, "[custom_kernels] hip_elementwise_mul: unsupported dtype=%d\n",
+            hip_dtype);
+    return -1;
+  }
+  return static_cast<int>(hipGetLastError());
+}
+
+extern "C" int hip_elementwise_add(void *stream, const void *lhs,
+                                   const void *rhs, void *output,
+                                   int64_t num_elements, int hip_dtype) {
+  if (num_elements <= 0)
+    return 0;
+  hipStream_t hip_stream = static_cast<hipStream_t>(stream);
+  constexpr int kBlockSize = 256;
+  int grid_size =
+      static_cast<int>((num_elements + kBlockSize - 1) / kBlockSize);
+  switch (hip_dtype) {
+  case HIP_DTYPE_INT64:
+    hipLaunchKernelGGL(elementwise_add_kernel<int64_t>, dim3(grid_size),
+                       dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const int64_t *>(lhs),
+                       static_cast<const int64_t *>(rhs),
+                       static_cast<int64_t *>(output), num_elements);
+    break;
+  case HIP_DTYPE_INT32:
+    hipLaunchKernelGGL(elementwise_add_kernel<int32_t>, dim3(grid_size),
+                       dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const int32_t *>(lhs),
+                       static_cast<const int32_t *>(rhs),
+                       static_cast<int32_t *>(output), num_elements);
+    break;
+  case HIP_DTYPE_FLOAT16:
+    hipLaunchKernelGGL(elementwise_add_kernel<__half>, dim3(grid_size),
+                       dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const __half *>(lhs),
+                       static_cast<const __half *>(rhs),
+                       static_cast<__half *>(output), num_elements);
+    break;
+  case HIP_DTYPE_FLOAT32:
+    hipLaunchKernelGGL(elementwise_add_kernel<float>, dim3(grid_size),
+                       dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const float *>(lhs),
+                       static_cast<const float *>(rhs),
+                       static_cast<float *>(output), num_elements);
+    break;
+  default:
+    fprintf(stderr, "[custom_kernels] hip_elementwise_add: unsupported dtype=%d\n",
+            hip_dtype);
+    return -1;
+  }
+  return static_cast<int>(hipGetLastError());
+}
+
+// =====================================================================
+// Min / Max (typed). Dispatched from wrap_miopenOpTensor as the
+// integer-dtype fallback for tensor_op = MIN / MAX, because MIOpen's
+// miopenOpTensor only supports floating-point element types. Same-shape
+// only -- broadcasting is materialised upstream by wrap_miopenOpTensor
+// via hip_expand, identical to the Mul/Add integer path above.
+//
+// Ternary form `(a < b) ? a : b` is used (rather than the HIP built-in
+// `min(a, b)`) so the integer specialisations don't accidentally pick up
+// a float overload, and so the FP16 path can promote to float without
+// special intrinsics.
+// =====================================================================
+
+template <typename T>
+__global__ void elementwise_min_kernel(const T *__restrict__ lhs,
+                                       const T *__restrict__ rhs,
+                                       T *__restrict__ output,
+                                       int64_t num_elements) {
+  int64_t idx =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < num_elements) {
+    T a = lhs[idx];
+    T b = rhs[idx];
+    output[idx] = (a < b) ? a : b;
+  }
+}
+
+template <>
+__global__ void elementwise_min_kernel<__half>(const __half *__restrict__ lhs,
+                                               const __half *__restrict__ rhs,
+                                               __half *__restrict__ output,
+                                               int64_t num_elements) {
+  int64_t idx =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < num_elements) {
+    float a = __half2float(lhs[idx]);
+    float b = __half2float(rhs[idx]);
+    output[idx] = __float2half((a < b) ? a : b);
+  }
+}
+
+template <typename T>
+__global__ void elementwise_max_kernel(const T *__restrict__ lhs,
+                                       const T *__restrict__ rhs,
+                                       T *__restrict__ output,
+                                       int64_t num_elements) {
+  int64_t idx =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < num_elements) {
+    T a = lhs[idx];
+    T b = rhs[idx];
+    output[idx] = (a > b) ? a : b;
+  }
+}
+
+template <>
+__global__ void elementwise_max_kernel<__half>(const __half *__restrict__ lhs,
+                                               const __half *__restrict__ rhs,
+                                               __half *__restrict__ output,
+                                               int64_t num_elements) {
+  int64_t idx =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < num_elements) {
+    float a = __half2float(lhs[idx]);
+    float b = __half2float(rhs[idx]);
+    output[idx] = __float2half((a > b) ? a : b);
+  }
+}
+
+extern "C" int hip_elementwise_min(void *stream, const void *lhs,
+                                   const void *rhs, void *output,
+                                   int64_t num_elements, int hip_dtype) {
+  if (num_elements <= 0)
+    return 0;
+  hipStream_t hip_stream = static_cast<hipStream_t>(stream);
+  constexpr int kBlockSize = 256;
+  int grid_size =
+      static_cast<int>((num_elements + kBlockSize - 1) / kBlockSize);
+  switch (hip_dtype) {
+  case HIP_DTYPE_INT64:
+    hipLaunchKernelGGL(elementwise_min_kernel<int64_t>, dim3(grid_size),
+                       dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const int64_t *>(lhs),
+                       static_cast<const int64_t *>(rhs),
+                       static_cast<int64_t *>(output), num_elements);
+    break;
+  case HIP_DTYPE_INT32:
+    hipLaunchKernelGGL(elementwise_min_kernel<int32_t>, dim3(grid_size),
+                       dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const int32_t *>(lhs),
+                       static_cast<const int32_t *>(rhs),
+                       static_cast<int32_t *>(output), num_elements);
+    break;
+  case HIP_DTYPE_FLOAT16:
+    hipLaunchKernelGGL(elementwise_min_kernel<__half>, dim3(grid_size),
+                       dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const __half *>(lhs),
+                       static_cast<const __half *>(rhs),
+                       static_cast<__half *>(output), num_elements);
+    break;
+  case HIP_DTYPE_FLOAT32:
+    hipLaunchKernelGGL(elementwise_min_kernel<float>, dim3(grid_size),
+                       dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const float *>(lhs),
+                       static_cast<const float *>(rhs),
+                       static_cast<float *>(output), num_elements);
+    break;
+  default:
+    fprintf(stderr, "[custom_kernels] hip_elementwise_min: unsupported dtype=%d\n",
+            hip_dtype);
+    return -1;
+  }
+  return static_cast<int>(hipGetLastError());
+}
+
+extern "C" int hip_elementwise_max(void *stream, const void *lhs,
+                                   const void *rhs, void *output,
+                                   int64_t num_elements, int hip_dtype) {
+  if (num_elements <= 0)
+    return 0;
+  hipStream_t hip_stream = static_cast<hipStream_t>(stream);
+  constexpr int kBlockSize = 256;
+  int grid_size =
+      static_cast<int>((num_elements + kBlockSize - 1) / kBlockSize);
+  switch (hip_dtype) {
+  case HIP_DTYPE_INT64:
+    hipLaunchKernelGGL(elementwise_max_kernel<int64_t>, dim3(grid_size),
+                       dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const int64_t *>(lhs),
+                       static_cast<const int64_t *>(rhs),
+                       static_cast<int64_t *>(output), num_elements);
+    break;
+  case HIP_DTYPE_INT32:
+    hipLaunchKernelGGL(elementwise_max_kernel<int32_t>, dim3(grid_size),
+                       dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const int32_t *>(lhs),
+                       static_cast<const int32_t *>(rhs),
+                       static_cast<int32_t *>(output), num_elements);
+    break;
+  case HIP_DTYPE_FLOAT16:
+    hipLaunchKernelGGL(elementwise_max_kernel<__half>, dim3(grid_size),
+                       dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const __half *>(lhs),
+                       static_cast<const __half *>(rhs),
+                       static_cast<__half *>(output), num_elements);
+    break;
+  case HIP_DTYPE_FLOAT32:
+    hipLaunchKernelGGL(elementwise_max_kernel<float>, dim3(grid_size),
+                       dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const float *>(lhs),
+                       static_cast<const float *>(rhs),
+                       static_cast<float *>(output), num_elements);
+    break;
+  default:
+    fprintf(stderr, "[custom_kernels] hip_elementwise_max: unsupported dtype=%d\n",
+            hip_dtype);
+    return -1;
+  }
+  return static_cast<int>(hipGetLastError());
 }
 
 extern "C" int hip_elementwise_div(void *stream, const void *lhs,

--- a/3rd-party/custom_kernels/hip/elementwise_mul_kernel.hip
+++ b/3rd-party/custom_kernels/hip/elementwise_mul_kernel.hip
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ *
+ * Elementwise INT64 multiplication kernel.
+ *
+ * Modeled after elementwise_sub_kernel.hip. Exists because MIOpen's
+ * miopenOpTensor (used by wrap_miopenOpTensor for fp16/fp32/bf16 mul)
+ * has no INT64 path; some models (Qwen3 mrope: total = batch * seq_len)
+ * produce scalar int64 multiplies that would otherwise silently no-op.
+ *
+ * No broadcasting: caller must ensure lhs/rhs/output all have the same
+ * element count. wrap_miopenOpTensor enforces this before dispatch.
+ */
+
+#include "hip_custom_kernels.h"
+#include "debug_log.h"
+
+#include <hip/hip_runtime.h>
+#include <cstdint>
+#include <cstdio>
+
+__global__ void elementwise_mul_i64_kernel(
+    const int64_t* __restrict__ lhs,
+    const int64_t* __restrict__ rhs,
+    int64_t* __restrict__ output,
+    int64_t num_elements) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < num_elements) {
+    output[idx] = lhs[idx] * rhs[idx];
+  }
+}
+
+extern "C" int hip_elementwise_mul(
+    void* stream,
+    const void* lhs,
+    const void* rhs,
+    void* output,
+    int64_t num_elements,
+    int hip_dtype) {
+  if (num_elements <= 0) return 0;
+
+  hipStream_t hip_stream = static_cast<hipStream_t>(stream);
+  constexpr int kBlockSize = 256;
+  int grid_size = static_cast<int>((num_elements + kBlockSize - 1) / kBlockSize);
+
+  switch (hip_dtype) {
+    case HIP_DTYPE_INT64: {
+      CUSTOM_KERNELS_DEBUG_LOG("[custom_kernels] hip_elementwise_mul: dtype=INT64, "
+              "num_elements=%lld, grid=%d, block=%d\n",
+              (long long)num_elements, grid_size, kBlockSize);
+
+      hipLaunchKernelGGL(elementwise_mul_i64_kernel,
+                         dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
+                         static_cast<const int64_t*>(lhs),
+                         static_cast<const int64_t*>(rhs),
+                         static_cast<int64_t*>(output),
+                         num_elements);
+      break;
+    }
+    default:
+      fprintf(stderr,
+              "[custom_kernels] hip_elementwise_mul: unsupported dtype=%d\n",
+              hip_dtype);
+      return -1;
+  }
+
+  hipError_t err = hipGetLastError();
+  if (err != hipSuccess) {
+    fprintf(stderr,
+            "[custom_kernels] hip_elementwise_mul launch failed: %s\n",
+            hipGetErrorString(err));
+  }
+  return static_cast<int>(err);
+}

--- a/3rd-party/custom_kernels/hip/elementwise_sub_kernel.hip
+++ b/3rd-party/custom_kernels/hip/elementwise_sub_kernel.hip
@@ -6,6 +6,7 @@
 #include "hip_custom_kernels.h"
 #include "debug_log.h"
 
+#include <hip/hip_fp16.h>
 #include <hip/hip_runtime.h>
 #include <cstdint>
 #include <cstdio>
@@ -18,6 +19,39 @@ __global__ void elementwise_sub_i64_kernel(
   int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   if (idx < num_elements) {
     output[idx] = lhs[idx] - rhs[idx];
+  }
+}
+
+__global__ void elementwise_sub_i32_kernel(
+    const int32_t* __restrict__ lhs,
+    const int32_t* __restrict__ rhs,
+    int32_t* __restrict__ output,
+    int64_t num_elements) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < num_elements) {
+    output[idx] = lhs[idx] - rhs[idx];
+  }
+}
+
+__global__ void elementwise_sub_f32_kernel(
+    const float* __restrict__ lhs,
+    const float* __restrict__ rhs,
+    float* __restrict__ output,
+    int64_t num_elements) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < num_elements) {
+    output[idx] = lhs[idx] - rhs[idx];
+  }
+}
+
+__global__ void elementwise_sub_f16_kernel(
+    const __half* __restrict__ lhs,
+    const __half* __restrict__ rhs,
+    __half* __restrict__ output,
+    int64_t num_elements) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < num_elements) {
+    output[idx] = __float2half(__half2float(lhs[idx]) - __half2float(rhs[idx]));
   }
 }
 
@@ -35,19 +69,34 @@ extern "C" int hip_elementwise_sub(
   int grid_size = static_cast<int>((num_elements + kBlockSize - 1) / kBlockSize);
 
   switch (hip_dtype) {
-    case HIP_DTYPE_INT64: {
-      CUSTOM_KERNELS_DEBUG_LOG("[custom_kernels] hip_elementwise_sub: dtype=INT64, "
-              "num_elements=%lld, grid=%d, block=%d\n",
-              (long long)num_elements, grid_size, kBlockSize);
-
+    case HIP_DTYPE_INT64:
       hipLaunchKernelGGL(elementwise_sub_i64_kernel,
                          dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
                          static_cast<const int64_t*>(lhs),
                          static_cast<const int64_t*>(rhs),
-                         static_cast<int64_t*>(output),
-                         num_elements);
+                         static_cast<int64_t*>(output), num_elements);
       break;
-    }
+    case HIP_DTYPE_INT32:
+      hipLaunchKernelGGL(elementwise_sub_i32_kernel,
+                         dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
+                         static_cast<const int32_t*>(lhs),
+                         static_cast<const int32_t*>(rhs),
+                         static_cast<int32_t*>(output), num_elements);
+      break;
+    case HIP_DTYPE_FLOAT32:
+      hipLaunchKernelGGL(elementwise_sub_f32_kernel,
+                         dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
+                         static_cast<const float*>(lhs),
+                         static_cast<const float*>(rhs),
+                         static_cast<float*>(output), num_elements);
+      break;
+    case HIP_DTYPE_FLOAT16:
+      hipLaunchKernelGGL(elementwise_sub_f16_kernel,
+                         dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
+                         static_cast<const __half*>(lhs),
+                         static_cast<const __half*>(rhs),
+                         static_cast<__half*>(output), num_elements);
+      break;
     default:
       fprintf(stderr,
               "[custom_kernels] hip_elementwise_sub: unsupported dtype=%d\n",

--- a/3rd-party/custom_kernels/hip/expand_kernel.hip
+++ b/3rd-party/custom_kernels/hip/expand_kernel.hip
@@ -160,6 +160,18 @@ extern "C" int hip_expand(void *stream, const void *input, void *output,
                        output_shape, aligned_in_strides, output_rank,
                        num_output_elements);
     break;
+  // Bitwise broadcast for 1-byte payloads (Equal/Mask outputs are uint8 or
+  // bool / int8). int8 instantiation covers both since the kernel only
+  // reads + writes 1-byte slots and never does arithmetic.
+  case HIP_DTYPE_INT8:
+  case HIP_DTYPE_UINT8:
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(hip_expand_kernel<int8_t>),
+                       dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const int8_t *>(input),
+                       static_cast<int8_t *>(output), aligned_in_shape,
+                       output_shape, aligned_in_strides, output_rank,
+                       num_output_elements);
+    break;
   default:
     fprintf(stderr, "[custom_kernels] hip_expand: unsupported dtype=%d\n",
             hip_dtype);

--- a/3rd-party/custom_kernels/hip/gather_kernel.hip
+++ b/3rd-party/custom_kernels/hip/gather_kernel.hip
@@ -10,30 +10,35 @@
 #include <cstdint>
 #include <cstdio>
 
-// Generic gather kernel for axis=0 with arbitrary number of indices.
+// Generic gather kernel for arbitrary axis.
+// data    has logical shape [outer, axis_size, inner]
+// indices has indices_num elements (flattened)
+// output  has logical shape [outer, indices_num, inner]
 // Each thread copies one element of the output tensor.
-// Thread tid maps to: index_idx = tid / slice_size, offset = tid % slice_size.
-// output[tid] = data[indices[index_idx] * slice_size + offset]
 template <typename T>
-__global__ void gather_axis0_kernel(
+__global__ void gather_kernel(
     const T* __restrict__ data,
     const int64_t* __restrict__ indices,
     T* __restrict__ output,
-    int64_t slice_size,
-    int64_t data_axis_size,
+    int64_t outer_size,
+    int64_t axis_size,
+    int64_t inner_size,
+    int64_t indices_num,
     int64_t total_elements) {
   int64_t tid = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-  if (tid < total_elements) {
-    int64_t index_idx = tid / slice_size;
-    int64_t offset = tid % slice_size;
-    int64_t index_val = indices[index_idx];
-    if (index_val < 0) index_val += data_axis_size;
-    if (index_val < 0 || index_val >= data_axis_size) {
-      output[tid] = T(0);
-      return;
-    }
-    output[tid] = data[index_val * slice_size + offset];
+  if (tid >= total_elements) return;
+  int64_t inner_off = tid % inner_size;
+  int64_t idx_off = (tid / inner_size) % indices_num;
+  int64_t outer_off = tid / (inner_size * indices_num);
+  int64_t index_val = indices[idx_off];
+  if (index_val < 0) index_val += axis_size;
+  if (index_val < 0 || index_val >= axis_size) {
+    output[tid] = T(0);
+    return;
   }
+  int64_t data_off =
+      (outer_off * axis_size + index_val) * inner_size + inner_off;
+  output[tid] = data[data_off];
 }
 
 extern "C" int hip_gather(
@@ -45,6 +50,8 @@ extern "C" int hip_gather(
     int64_t data_num_elements,
     int64_t indices_num_elements,
     int64_t output_num_elements,
+    int64_t axis_size,
+    int64_t inner_size,
     int element_size_bytes) {
   if (output_num_elements <= 0) return 0;
 
@@ -53,56 +60,56 @@ extern "C" int hip_gather(
   int grid_size = static_cast<int>(
       (output_num_elements + kBlockSize - 1) / kBlockSize);
 
-  if (axis != 0) {
+  // axis_size = data.shape[axis]; inner_size = product(data.shape[axis+1:])
+  // outer_size derived from data layout: data has outer*axis_size*inner elems.
+  int64_t outer_size = (axis_size > 0 && inner_size > 0)
+      ? data_num_elements / (axis_size * inner_size)
+      : 0;
+  if (outer_size <= 0) {
     fprintf(stderr,
-            "[custom_kernels] hip_gather: only axis=0 supported, got %lld\n",
-            (long long)axis);
+            "[custom_kernels] hip_gather: bad geometry axis=%lld data_num=%lld "
+            "axis_size=%lld inner_size=%lld\n",
+            (long long)axis, (long long)data_num_elements,
+            (long long)axis_size, (long long)inner_size);
     return -1;
   }
 
-  // For axis=0: output = [indices_shape..., data_shape[1:]]
-  // slice_size = product of data dimensions after axis 0
-  // data_axis_size = data_shape[0]
-  int64_t slice_size = (indices_num_elements > 0)
-      ? output_num_elements / indices_num_elements
-      : output_num_elements;
-  int64_t data_axis_size = (slice_size > 0)
-      ? data_num_elements / slice_size
-      : 0;
-
-  CUSTOM_KERNELS_DEBUG_LOG("[custom_kernels] hip_gather: axis=0, elem_size=%d, "
+  CUSTOM_KERNELS_DEBUG_LOG("[custom_kernels] hip_gather: axis=%lld, elem_size=%d, "
           "data_num=%lld, indices_num=%lld, output_num=%lld, "
-          "slice_size=%lld, data_axis_size=%lld, grid=%d, block=%d\n",
-          element_size_bytes,
+          "outer=%lld, axis_size=%lld, inner=%lld, grid=%d, block=%d\n",
+          (long long)axis, element_size_bytes,
           (long long)data_num_elements, (long long)indices_num_elements,
           (long long)output_num_elements,
-          (long long)slice_size, (long long)data_axis_size,
+          (long long)outer_size, (long long)axis_size, (long long)inner_size,
           grid_size, kBlockSize);
 
   switch (element_size_bytes) {
     case 2:
-      hipLaunchKernelGGL(gather_axis0_kernel<uint16_t>,
+      hipLaunchKernelGGL(gather_kernel<uint16_t>,
                          dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
                          static_cast<const uint16_t*>(data),
                          static_cast<const int64_t*>(indices),
                          static_cast<uint16_t*>(output),
-                         slice_size, data_axis_size, output_num_elements);
+                         outer_size, axis_size, inner_size,
+                         indices_num_elements, output_num_elements);
       break;
     case 4:
-      hipLaunchKernelGGL(gather_axis0_kernel<uint32_t>,
+      hipLaunchKernelGGL(gather_kernel<uint32_t>,
                          dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
                          static_cast<const uint32_t*>(data),
                          static_cast<const int64_t*>(indices),
                          static_cast<uint32_t*>(output),
-                         slice_size, data_axis_size, output_num_elements);
+                         outer_size, axis_size, inner_size,
+                         indices_num_elements, output_num_elements);
       break;
     case 8:
-      hipLaunchKernelGGL(gather_axis0_kernel<int64_t>,
+      hipLaunchKernelGGL(gather_kernel<int64_t>,
                          dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
                          static_cast<const int64_t*>(data),
                          static_cast<const int64_t*>(indices),
                          static_cast<int64_t*>(output),
-                         slice_size, data_axis_size, output_num_elements);
+                         outer_size, axis_size, inner_size,
+                         indices_num_elements, output_num_elements);
       break;
     default:
       fprintf(stderr,

--- a/3rd-party/custom_kernels/hip/matmul_nbits_kernel.hip
+++ b/3rd-party/custom_kernels/hip/matmul_nbits_kernel.hip
@@ -1256,8 +1256,10 @@ void GemmFp16U4Impl(
         FUSED_DQ ? (b_n_g * (K >> 1) + (b_k8 >> 1)) : 0;
     [[maybe_unused]] const int b_gid_base =
         FUSED_DQ ? (b_n_g * num_groups_k) : 0;
+    // cached_k_grp is the quant-group index currently loaded into cached_s/
+    // neg_zs; -1 forces a load on the first K-step. See the group derivation
+    // in issueLoads (keyed on the thread's actual k offset, not just t).
     [[maybe_unused]] int      cached_k_grp = -1;
-    [[maybe_unused]] int      next_grp_k = 0;
     [[maybe_unused]] _Float16 cached_s = 0;
     [[maybe_unused]] _Float16 neg_zs = 0;
 
@@ -1325,13 +1327,23 @@ void GemmFp16U4Impl(
             if constexpr (FUSED_DQ) {
                 pf_b4 = *reinterpret_cast<const uint32_t*>(
                     &B_packed[b_byte_base + (t >> 1)]);
-                if(__builtin_expect(t >= next_grp_k, 0))
+                // This thread dequants 8 contiguous nibbles at k=[t+b_k8 ..
+                // t+b_k8+7]. With block_size>=16 (kernel precondition) and b_k8
+                // a multiple of 8, those 8 weights lie entirely in ONE quant
+                // group: (t + b_k8) / group_size. Deriving the group from t
+                // ALONE is only valid when BK_T <= group_size; the 128x32
+                // WT2x1 tile has BK_T=64, so on a group_size<64 model (e.g. 32)
+                // a single K-step straddles two groups and the upper half would
+                // otherwise be dequantized with the previous group's scale.
+                // Cache keyed on the group index so the common BK_T<=group_size
+                // case still skips the reload across K-steps.
+                const int grp = (t + b_k8) / group_size;
+                if(__builtin_expect(grp != cached_k_grp, 0))
                 {
-                    cached_k_grp++;
-                    next_grp_k += group_size;
-                    cached_s   = scales[cached_k_grp + b_gid_base];
+                    cached_k_grp = grp;
+                    cached_s     = scales[grp + b_gid_base];
                     if constexpr(USE_ZEROS)
-                        neg_zs = -zeros[cached_k_grp + b_gid_base] * cached_s;
+                        neg_zs = -zeros[grp + b_gid_base] * cached_s;
                 }
             } else {
                 const _Float16* b_src = &B_fp16[b_n_g * K + t + b_k8];
@@ -2176,8 +2188,9 @@ void GemmFp16I8Impl(
     // Per-thread base offsets (constant across the K-loop).
     const int b_elem_base = b_n_g * K + b_k8;
     const int b_gid_base  = b_n_g * num_groups_k;
+    // -1 forces a scale load on the first K-step; the group index is derived
+    // from the thread's actual k offset (t+b_k8), see issueLoads below.
     int      cached_k_grp = -1;
-    int      next_grp_k   = 0;
     _Float16 cached_s     = 0;
     _Float16 neg_zs       = 0;
 
@@ -2230,16 +2243,20 @@ void GemmFp16I8Impl(
             // already includes b_k8, so the byte address is `b_elem_base + t`.
             pf_b8 = *reinterpret_cast<const uint2*>(&B[b_elem_base + t]);
 
-            // Group/scale stepping: K-step is `t` (in elements). When `t`
-            // crosses a group boundary, advance the cached scale and (if
-            // present) the cached -zp*scale precomputation.
-            if (__builtin_expect(t >= next_grp_k, 0)) {
-                cached_k_grp++;
-                next_grp_k += group_size;
-                cached_s = scales[cached_k_grp + b_gid_base];
+            // Group/scale stepping: this thread loads 8 contiguous weights at
+            // k=[t+b_k8 .. t+b_k8+7], which lie in one quant group
+            // (t+b_k8)/group_size (block_size>=16, b_k8 multiple of 8). Derive
+            // the group from the thread's actual k offset, NOT from t alone:
+            // when BK_T > group_size a single K-step straddles two groups and
+            // the upper half must use a later scale. Cache keyed on the group
+            // index so BK_T<=group_size still reuses the load across K-steps.
+            const int grp = (t + b_k8) / group_size;
+            if (__builtin_expect(grp != cached_k_grp, 0)) {
+                cached_k_grp = grp;
+                cached_s = scales[grp + b_gid_base];
                 if constexpr (USE_ZEROS) {
                     _Float16 zp_h = static_cast<_Float16>(
-                                        zeros[cached_k_grp + b_gid_base]);
+                                        zeros[grp + b_gid_base]);
                     neg_zs = -zp_h * cached_s;
                 } else {
                     // ONNX default zp = 2^(bits-1) = 128 for bits=8.

--- a/3rd-party/custom_kernels/hip/nonzero_kernel.hip
+++ b/3rd-party/custom_kernels/hip/nonzero_kernel.hip
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ *
+ * NonZero kernel: single-block cooperative ordered scan.
+ *
+ * Output layout: [rank, capacity] of i64. Valid columns are [0, *count_ptr),
+ * and ordering matches ONNX spec: row-major over the input.
+ *
+ * Ordered output is required so that downstream pipelines that read the
+ * indices in lockstep with a sequentially-derived companion tensor (e.g.
+ * `Slice(image_features, [0:M])` feeding ScatterND alongside these
+ * indices) write each update to the correct target position. The older
+ * atomicAdd-only design produced random ordering -- correct for cases
+ * where the update value is positional-independent, but silently wrong
+ * for the embedding-substitution pattern above.
+ *
+ * Algorithm (one block, BS threads):
+ *   1. Each thread sequentially counts nonzeros in its chunk [lo, hi).
+ *   2. Thread 0 does an exclusive prefix scan over the BS chunk counts
+ *      (BS is small -- 1024 -- so a single-thread scan is fastest).
+ *   3. Each thread re-walks its chunk and writes coords at
+ *      `chunk_offset[tid] + local_running`.
+ *   4. Thread 0 also writes the total count.
+ *
+ * Bounded to input rank <= 8.
+ */
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <stdint.h>
+
+#include "hip_custom_kernels.h"
+
+static constexpr int kMaxRank = 8;
+static constexpr int kNonZeroBlockSize = 1024;
+
+template <typename T>
+__global__ void nonzero_ordered_kernel(const T *__restrict__ input,
+                                       int64_t *__restrict__ output,
+                                       int *__restrict__ count_ptr,
+                                       int64_t capacity, int rank,
+                                       int64_t numel,
+                                       const int64_t *__restrict__ dims) {
+  __shared__ int s_chunk_count[kNonZeroBlockSize];
+  __shared__ int s_chunk_offset[kNonZeroBlockSize];
+
+  int tid = threadIdx.x;
+
+  // Even chunk size (round up); last thread may have a short chunk.
+  int64_t chunk = (numel + kNonZeroBlockSize - 1) / kNonZeroBlockSize;
+  int64_t lo = (int64_t)tid * chunk;
+  int64_t hi = lo + chunk;
+  if (hi > numel)
+    hi = numel;
+  if (lo > numel)
+    lo = numel;
+
+  // Phase 1: count nonzeros in [lo, hi).
+  int my_count = 0;
+  for (int64_t i = lo; i < hi; ++i) {
+    if (input[i] != (T)0)
+      ++my_count;
+  }
+  s_chunk_count[tid] = my_count;
+  __syncthreads();
+
+  // Phase 2: thread-0 exclusive scan over BS chunk counts. BS=1024 is
+  // small enough that single-thread shared-memory scan beats parallel
+  // Hillis-Steele in both latency and code complexity.
+  if (tid == 0) {
+    int sum = 0;
+    for (int t = 0; t < kNonZeroBlockSize; ++t) {
+      s_chunk_offset[t] = sum;
+      sum += s_chunk_count[t];
+    }
+    *count_ptr = sum;
+  }
+  __syncthreads();
+
+  // Phase 3: each thread re-walks its chunk and writes coords.
+  int local = 0;
+  int base = s_chunk_offset[tid];
+  for (int64_t i = lo; i < hi; ++i) {
+    if (input[i] != (T)0) {
+      int pos = base + local;
+      ++local;
+
+      // Decompose flat index -> multi-dim coordinates (row-major).
+      int64_t remaining = i;
+      for (int d = rank - 1; d >= 0; --d) {
+        int64_t dim_size = dims[d];
+        int64_t coord = remaining % dim_size;
+        remaining /= dim_size;
+        output[d * capacity + pos] = coord;
+      }
+    }
+  }
+}
+
+// Host-callable launcher
+extern "C" int hip_nonzero(void *stream, const void *input, void *output,
+                           int *count_ptr, int64_t input_num_elements,
+                           int64_t input_rank,
+                           const int64_t *input_dims_host,
+                           int64_t output_capacity, int hip_dtype) {
+  if (input_num_elements <= 0 || input_rank <= 0 || input_rank > kMaxRank)
+    return -1;
+
+  hipStream_t s = static_cast<hipStream_t>(stream);
+
+  // Zero the output buffer so padded slots (beyond actual count) contain
+  // index [0,...,0]. Important: ScatterND with valid_count gating only
+  // touches the first count slots, but defence-in-depth -- some passes
+  // may walk the full capacity (e.g. Transpose) and stale data could
+  // surface in indirect reads.
+  hipMemsetAsync(output, 0, input_rank * output_capacity * sizeof(int64_t), s);
+
+  // Copy dims to device (small fixed-size buffer, async)
+  int64_t *d_dims = nullptr;
+  hipMalloc(&d_dims, input_rank * sizeof(int64_t));
+  hipMemcpyAsync(d_dims, input_dims_host, input_rank * sizeof(int64_t),
+                 hipMemcpyHostToDevice, s);
+
+  // Single block, kNonZeroBlockSize threads -- cooperative ordered scan.
+  // Each thread handles ceil(numel / kNonZeroBlockSize) elements.
+  switch (hip_dtype) {
+  case HIP_DTYPE_FLOAT16:
+    nonzero_ordered_kernel<__half><<<1, kNonZeroBlockSize, 0, s>>>(
+        (const __half *)input, (int64_t *)output, count_ptr, output_capacity,
+        (int)input_rank, input_num_elements, d_dims);
+    break;
+  case HIP_DTYPE_FLOAT32:
+    nonzero_ordered_kernel<float><<<1, kNonZeroBlockSize, 0, s>>>(
+        (const float *)input, (int64_t *)output, count_ptr, output_capacity,
+        (int)input_rank, input_num_elements, d_dims);
+    break;
+  case HIP_DTYPE_INT32:
+    nonzero_ordered_kernel<int><<<1, kNonZeroBlockSize, 0, s>>>(
+        (const int *)input, (int64_t *)output, count_ptr, output_capacity,
+        (int)input_rank, input_num_elements, d_dims);
+    break;
+  case HIP_DTYPE_INT64:
+    nonzero_ordered_kernel<int64_t><<<1, kNonZeroBlockSize, 0, s>>>(
+        (const int64_t *)input, (int64_t *)output, count_ptr, output_capacity,
+        (int)input_rank, input_num_elements, d_dims);
+    break;
+  case HIP_DTYPE_INT8:
+    nonzero_ordered_kernel<int8_t><<<1, kNonZeroBlockSize, 0, s>>>(
+        (const int8_t *)input, (int64_t *)output, count_ptr, output_capacity,
+        (int)input_rank, input_num_elements, d_dims);
+    break;
+  case HIP_DTYPE_UINT8:
+    nonzero_ordered_kernel<uint8_t><<<1, kNonZeroBlockSize, 0, s>>>(
+        (const uint8_t *)input, (int64_t *)output, count_ptr, output_capacity,
+        (int)input_rank, input_num_elements, d_dims);
+    break;
+  default:
+    hipFree(d_dims);
+    return -1;
+  }
+
+  // Free device dims after kernel completes (enqueue on stream)
+  hipFreeAsync(d_dims, s);
+  return 0;
+}

--- a/3rd-party/custom_kernels/hip/scatter_nd_kernel.hip
+++ b/3rd-party/custom_kernels/hip/scatter_nd_kernel.hip
@@ -318,13 +318,19 @@ __global__ void hip_scatter_nd_kernel(const int64_t *__restrict__ indices,
                                       T *__restrict__ output,
                                       ScatterNDParams p,
                                       int64_t total_threads,
-                                      int reduction_id) {
+                                      int reduction_id,
+                                      const int32_t *valid_count) {
   int64_t tid =
       static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   if (tid >= total_threads)
     return;
 
   int64_t slice_id = tid / p.slice_size;
+
+  // When valid_count is set (NonZero upstream), skip padded rows
+  if (valid_count && slice_id >= *valid_count)
+    return;
+
   int64_t inner = tid % p.slice_size;
 
   // Walk the K-element index tuple for this slice.
@@ -363,7 +369,8 @@ __global__ void hip_scatter_nd_kernel(const int64_t *__restrict__ indices,
 
 extern "C" int hip_scatter_nd(void *stream, const void *data,
                               const void *indices, const void *updates,
-                              void *output, const int64_t *data_shape_host,
+                              void *output, const int32_t *count_ptr,
+                              const int64_t *data_shape_host,
                               int data_rank, const int64_t *indices_shape_host,
                               int indices_rank, int reduction_id,
                               int hip_dtype) {
@@ -482,7 +489,7 @@ extern "C" int hip_scatter_nd(void *stream, const void *data,
                        static_cast<const int64_t *>(indices),
                        static_cast<const __half *>(updates),
                        static_cast<__half *>(output), p, total_threads,
-                       reduction_id);
+                       reduction_id, count_ptr);
     break;
   case HIP_DTYPE_FLOAT32:
     hipLaunchKernelGGL(HIP_KERNEL_NAME(hip_scatter_nd_kernel<float>),
@@ -490,7 +497,7 @@ extern "C" int hip_scatter_nd(void *stream, const void *data,
                        static_cast<const int64_t *>(indices),
                        static_cast<const float *>(updates),
                        static_cast<float *>(output), p, total_threads,
-                       reduction_id);
+                       reduction_id, count_ptr);
     break;
   case HIP_DTYPE_INT32:
     hipLaunchKernelGGL(HIP_KERNEL_NAME(hip_scatter_nd_kernel<int32_t>),
@@ -498,7 +505,7 @@ extern "C" int hip_scatter_nd(void *stream, const void *data,
                        static_cast<const int64_t *>(indices),
                        static_cast<const int32_t *>(updates),
                        static_cast<int32_t *>(output), p, total_threads,
-                       reduction_id);
+                       reduction_id, count_ptr);
     break;
   case HIP_DTYPE_INT64:
     hipLaunchKernelGGL(HIP_KERNEL_NAME(hip_scatter_nd_kernel<int64_t>),
@@ -506,7 +513,7 @@ extern "C" int hip_scatter_nd(void *stream, const void *data,
                        static_cast<const int64_t *>(indices),
                        static_cast<const int64_t *>(updates),
                        static_cast<int64_t *>(output), p, total_threads,
-                       reduction_id);
+                       reduction_id, count_ptr);
     break;
   default:
     fprintf(stderr, "[custom_kernels] hip_scatter_nd: unsupported dtype=%d\n",

--- a/3rd-party/custom_kernels/hip/slice_kernel.hip
+++ b/3rd-party/custom_kernels/hip/slice_kernel.hip
@@ -43,6 +43,18 @@ static constexpr int kSliceMaxRank = 8;
 struct SliceParams {
   int64_t input_strides[kSliceMaxRank];
   int64_t output_strides[kSliceMaxRank];
+  // logical_extent[d] = the actual per-axis slice output extent. For
+  // axes not touched by `axes`, equals the data dim. For touched axes,
+  // equals `(end-start) / step` (positive step) clamped to >= 0. When
+  // logical_extent[d] < the physical output dim (i.e. the IR-supplied
+  // output_shape's d-th dim), the host has OVER-ALLOCATED the output
+  // buffer because `SliceToHip` could not constant-fold the per-axis
+  // extent at compile time (typical for slices whose starts/ends are
+  // runtime Gather outputs inside an outlined loop body). The kernel
+  // iterates physical positions and fills the over-allocated tail with
+  // zeros so downstream consumers operating on the full physical extent
+  // see clean deterministic data instead of pool garbage.
+  int64_t logical_extent[kSliceMaxRank];
   // start[d] and step[d] are signed; step may be negative when slicing
   // with a reverse stride.
   int64_t start_per_axis[kSliceMaxRank];
@@ -59,13 +71,31 @@ __global__ void hip_slice_kernel(const T *__restrict__ input,
   if (out_idx >= num_output_elements)
     return;
 
+  // Decode physical coord, then check whether every axis is within its
+  // logical extent. Any over-allocated tail position writes zero.
   int64_t remaining = out_idx;
-  int64_t in_offset = 0;
+  int64_t coord[kSliceMaxRank];
   for (int d = 0; d < p.rank; ++d) {
     int64_t out_stride = p.output_strides[d];
-    int64_t out_coord = remaining / out_stride;
-    remaining -= out_coord * out_stride;
-    int64_t in_coord = p.start_per_axis[d] + out_coord * p.step_per_axis[d];
+    coord[d] = remaining / out_stride;
+    remaining -= coord[d] * out_stride;
+  }
+
+  bool in_logical = true;
+  for (int d = 0; d < p.rank; ++d) {
+    if (coord[d] >= p.logical_extent[d]) {
+      in_logical = false;
+      break;
+    }
+  }
+  if (!in_logical) {
+    output[out_idx] = T(0);
+    return;
+  }
+
+  int64_t in_offset = 0;
+  for (int d = 0; d < p.rank; ++d) {
+    int64_t in_coord = p.start_per_axis[d] + coord[d] * p.step_per_axis[d];
     in_offset += in_coord * p.input_strides[d];
   }
 
@@ -84,6 +114,7 @@ static void compute_row_major_strides(const int64_t *shape, int rank,
 extern "C" int hip_slice(void *stream, const void *input, void *output,
                          const int64_t *input_shape_host,
                          const int64_t *output_shape_host,
+                         const int64_t *logical_extent_host,
                          const int64_t *starts_per_axis_host,
                          const int64_t *steps_per_axis_host, int rank,
                          int hip_dtype) {
@@ -101,6 +132,8 @@ extern "C" int hip_slice(void *stream, const void *input, void *output,
   for (int d = 0; d < rank; ++d) {
     p.start_per_axis[d] = starts_per_axis_host[d];
     p.step_per_axis[d] = steps_per_axis_host[d];
+    p.logical_extent[d] =
+        logical_extent_host ? logical_extent_host[d] : output_shape_host[d];
   }
 
   int64_t num_output_elements = 1;

--- a/3rd-party/custom_kernels/hip/softmax_kernel.hip
+++ b/3rd-party/custom_kernels/hip/softmax_kernel.hip
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- softmax_kernel.hip - Row-wise 2D softmax (fp16) --------------------===//
+//
+// Standalone Softmax over the last dim of a flattened [rows, cols] fp16
+// row-major buffer. One block per row, cooperative warp-shuffle reductions
+// for max + sum, then an inverse-multiply pass. Matches ONNX Softmax
+// semantics (`axis = -1` along the last dim).
+//
+// Used by the `hip_miopen_softmax` runtime entry point (lib/Runtime/real/
+// activation.cpp) for `onnx.Softmax` outside fused attention paths — most
+// notably the SigLIP / ViT self-attention scores in vision encoders. The
+// pre-existing `softmax_inplace_kernel` in `gqa_kernel.hip` is column-wise
+// over an internal layout convention specific to the GQA pipeline; using
+// it for the row-wise standalone case requires the caller to launch one
+// block per (head, col) pair which the existing `hip_gqa_softmax_inplace`
+// launcher does NOT do — hence this distinct kernel.
+//
+// Numerics: exp2f(x * LOG2E) instead of expf(x) for the native HW
+// instruction, fp32 accumulators, single max + single sum sweep per row.
+// LDS use: `num_waves * sizeof(float)` per block.
+//
+//===----------------------------------------------------------------------===//
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+#ifndef WAVE_SIZE
+#if defined(__GFX9__) || defined(__GFX9_NEXT__)
+#define WAVE_SIZE 64
+#else
+#define WAVE_SIZE 32
+#endif
+#endif
+
+#ifndef LOG2E
+#define LOG2E 1.44269504088896340736f
+#endif
+
+namespace {
+
+__device__ inline float warp_reduce_max_f(float v) {
+  for (int off = WAVE_SIZE / 2; off > 0; off /= 2)
+    v = fmaxf(v, __shfl_xor(v, off));
+  return v;
+}
+
+__device__ inline float warp_reduce_sum_f(float v) {
+  for (int off = WAVE_SIZE / 2; off > 0; off /= 2)
+    v += __shfl_xor(v, off);
+  return v;
+}
+
+__global__ void softmax_row_2d_inplace_kernel(__half* data, int rows,
+                                                int cols) {
+  const int row = blockIdx.x;
+  if (row >= rows)
+    return;
+  __half* row_ptr = data + (size_t)row * cols;
+
+  const int tid = threadIdx.x;
+  const int wave_id = tid / WAVE_SIZE;
+  const int num_waves = blockDim.x / WAVE_SIZE;
+
+  extern __shared__ float smem[];
+
+  // Pass 1: row max.
+  float local_max = -INFINITY;
+  for (int j = tid; j < cols; j += blockDim.x)
+    local_max = fmaxf(local_max, __half2float(row_ptr[j]));
+  local_max = warp_reduce_max_f(local_max);
+  if (tid % WAVE_SIZE == 0)
+    smem[wave_id] = local_max;
+  __syncthreads();
+  if (tid < WAVE_SIZE) {
+    float v = (tid < num_waves) ? smem[tid] : -INFINITY;
+    v = warp_reduce_max_f(v);
+    smem[0] = v;
+  }
+  __syncthreads();
+  float row_max = smem[0];
+
+  // Pass 2: exp2f + sum.
+  float local_sum = 0.0f;
+  for (int j = tid; j < cols; j += blockDim.x) {
+    float e = exp2f((__half2float(row_ptr[j]) - row_max) * LOG2E);
+    row_ptr[j] = __float2half(e);
+    local_sum += e;
+  }
+  local_sum = warp_reduce_sum_f(local_sum);
+  if (tid % WAVE_SIZE == 0)
+    smem[wave_id] = local_sum;
+  __syncthreads();
+  if (tid < WAVE_SIZE) {
+    float v = (tid < num_waves) ? smem[tid] : 0.0f;
+    v = warp_reduce_sum_f(v);
+    smem[0] = v;
+  }
+  __syncthreads();
+  float row_sum = smem[0];
+  float inv = 1.0f / row_sum;
+
+  // Pass 3: normalize.
+  for (int j = tid; j < cols; j += blockDim.x)
+    row_ptr[j] = __float2half(__half2float(row_ptr[j]) * inv);
+}
+
+} // namespace
+
+extern "C" int hip_softmax_row_2d_inplace(void* stream_ptr, void* data,
+                                            int rows, int cols) {
+  if (!data || rows <= 0 || cols <= 0)
+    return -1;
+  hipStream_t stream = static_cast<hipStream_t>(stream_ptr);
+  // Pick block size: power of two up to min(cols, 256). 32 minimum for one
+  // wave on RDNA / 64 on CDNA. SoftMax for vision attention has cols up to
+  // ~4096, well-served by 256 threads × 16 iters.
+  int threads = 32;
+  while (threads < cols && threads < 256)
+    threads *= 2;
+  if (threads > 256)
+    threads = 256;
+  int num_waves = (threads + WAVE_SIZE - 1) / WAVE_SIZE;
+  size_t smem_bytes = static_cast<size_t>(num_waves) * sizeof(float);
+  softmax_row_2d_inplace_kernel<<<rows, threads, smem_bytes, stream>>>(
+      static_cast<__half*>(data), rows, cols);
+  return hipSuccess;
+}

--- a/3rd-party/custom_kernels/include/hip_custom_kernels.h
+++ b/3rd-party/custom_kernels/include/hip_custom_kernels.h
@@ -44,6 +44,8 @@ typedef enum {
     HIP_DTYPE_FLOAT64  = 4,
     HIP_DTYPE_BFLOAT16 = 5,
     HIP_DTYPE_INT16    = 6,
+    HIP_DTYPE_UINT8    = 7,
+    HIP_DTYPE_INT8     = 8,
 } hip_dtype_t;
 
 /* =========================================================================
@@ -64,6 +66,28 @@ typedef enum {
  * Returns: 0 on success (hipSuccess), non-zero hipError_t on failure
  */
 int hip_elementwise_sub(
+    void* stream,
+    const void* lhs,
+    const void* rhs,
+    void* output,
+    int64_t num_elements,
+    int hip_dtype);
+
+/* =========================================================================
+ * Elementwise Multiplication (no broadcasting)
+ * =========================================================================
+ *
+ * Computes output[i] = lhs[i] * rhs[i] for num_elements elements.
+ * Caller must ensure lhs/rhs/output have identical layout (no broadcasting).
+ *
+ * Provided so wrap_miopenOpTensor (Add/Mul) can fall back to a custom kernel
+ * for dtypes MIOpen does not support (currently: INT64). Float dtypes still
+ * go through MIOpen for performance + autotuning.
+ *
+ * Currently supported types: HIP_DTYPE_INT64
+ * Returns: 0 on success (hipSuccess), non-zero hipError_t on failure
+ */
+int hip_elementwise_mul(
     void* stream,
     const void* lhs,
     const void* rhs,
@@ -187,6 +211,43 @@ int hip_elementwise_div(
     int64_t num_elements,
     int hip_dtype);
 
+// Element-wise Mul / Add / Min / Max, same-shape only (caller materialises
+// broadcast). Reached from wrap_miopenOpTensor for integer element types
+// that MIOpen rejects (e.g. INT64 scalar shape arithmetic like the
+// seqlens_k = Min(total_seq_len, max_seq_len) clamp in GQA). Supports
+// FP16, FP32, INT32, INT64.
+int hip_elementwise_mul(
+    void* stream,
+    const void* lhs,
+    const void* rhs,
+    void* output,
+    int64_t num_elements,
+    int hip_dtype);
+
+int hip_elementwise_add(
+    void* stream,
+    const void* lhs,
+    const void* rhs,
+    void* output,
+    int64_t num_elements,
+    int hip_dtype);
+
+int hip_elementwise_min(
+    void* stream,
+    const void* lhs,
+    const void* rhs,
+    void* output,
+    int64_t num_elements,
+    int hip_dtype);
+
+int hip_elementwise_max(
+    void* stream,
+    const void* lhs,
+    const void* rhs,
+    void* output,
+    int64_t num_elements,
+    int hip_dtype);
+
 int hip_elementwise_mod(
     void* stream,
     const void* lhs,
@@ -196,12 +257,23 @@ int hip_elementwise_mod(
     int hip_dtype,
     int fmod_flag);
 
+/*
+ * Element-wise Equal with optional scalar broadcast.
+ *
+ * `lhs_num_elements` / `rhs_num_elements` may each be 1 (scalar broadcast)
+ * or equal to `out_num_elements` (no broadcast). Other mismatches are
+ * rejected by the host wrapper.
+ *
+ * Output type is always uint8 (1-byte bool).
+ */
 int hip_elementwise_equal(
     void* stream,
     const void* lhs,
     const void* rhs,
     void* output,
-    int64_t num_elements,
+    int64_t lhs_num_elements,
+    int64_t rhs_num_elements,
+    int64_t out_num_elements,
     int hip_dtype);
 
 int hip_elementwise_less(
@@ -453,6 +525,13 @@ int hip_gqa_softmax_inplace(
     int batch_stride, const void* head_sink, int num_heads,
     int use_smooth_softmax);
 
+/* Row-wise softmax over a flattened [rows, cols] row-major fp16 buffer.
+ * One block per row, softmaxes the `cols` elements of each row in-place
+ * (data is overwritten with normalized probabilities). Matches ONNX
+ * Softmax semantics for axis = -1 on the flattened input. Used by the
+ * standalone `hip_miopen_softmax` runtime entry point. */
+int hip_softmax_row_2d_inplace(void* stream, void* data, int rows, int cols);
+
 /* Column-wise softmax: fp32 input -> fp16 output.
  * Reads fp32 Score matrix (no fp16 overflow/inf), writes fp16 probabilities.
  * input_batch_stride is in float elements, output_batch_stride in half elements. */
@@ -569,7 +648,10 @@ int hip_cast(
  *   output_num_elements  - total elements in output tensor
  *   element_size_bytes   - byte size per element (used for raw copy)
  *
- * Currently supports: axis=0
+ * Generic axis support. data has logical shape [outer, axis_size, inner];
+ * output has logical shape [outer, indices_num, inner]. The caller computes
+ * axis_size = data.shape[axis] and inner_size = product(data.shape[axis+1:]);
+ * outer_size is derived as data_num / (axis_size * inner_size).
  * Supported element sizes: 2 (f16/bf16), 4 (f32/i32), 8 (i64/f64)
  * Returns: 0 on success, non-zero on failure
  */
@@ -582,6 +664,8 @@ int hip_gather(
     int64_t data_num_elements,
     int64_t indices_num_elements,
     int64_t output_num_elements,
+    int64_t axis_size,
+    int64_t inner_size,
     int element_size_bytes);
 
 /* =========================================================================
@@ -736,7 +820,19 @@ int hip_slice(
     const void* input,
     void* output,
     const int64_t* input_shape_host,
-    const int64_t* output_shape_host,
+    const int64_t* output_shape_host,     /* physical alloc shape       */
+    const int64_t* logical_extent_host,   /* per-axis actual slice extent;
+                                             may be NULL, in which case the
+                                             kernel treats it as identical to
+                                             output_shape_host (i.e. no
+                                             over-alloc; entire physical
+                                             buffer is filled by the slice).
+                                             When set and logical[d] <
+                                             output_shape[d] for some d,
+                                             positions in the over-allocated
+                                             tail are filled with zero — the
+                                             host wrapper does not need to
+                                             pre-memset the buffer.        */
     const int64_t* starts_per_axis_host,  /* length = rank */
     const int64_t* steps_per_axis_host,   /* length = rank */
     int rank,
@@ -778,11 +874,41 @@ int hip_scatter_nd(
     const void* indices,
     const void* updates,
     void* output,
+    const int32_t* count_ptr,
     const int64_t* data_shape_host,
     int data_rank,
     const int64_t* indices_shape_host,
     int indices_rank,
     int reduction_id,
+    int hip_dtype);
+
+/* =========================================================================
+ * NonZero
+ * =========================================================================
+ *
+ * Single-pass atomic kernel: each thread checks one element. If nonzero,
+ * atomicAdd on count_ptr gives the write position, then coordinates are
+ * written into output[rank, capacity] at stride = capacity.
+ *
+ * count_ptr is zeroed by the launcher before the kernel. After completion,
+ * *count_ptr holds the actual number of nonzero elements (on GPU — no D2H
+ * needed; downstream ops read it directly).
+ *
+ * input_dims_host: host pointer to int64_t[rank] holding the input
+ * shape (copied to device internally before the kernel launch).
+ *
+ * Supported dtypes: f16, f32, i32, i64, i8, u8.
+ * Bounded to rank <= 8.
+ */
+int hip_nonzero(
+    void* stream,
+    const void* input,
+    void* output,
+    int* count_ptr,
+    int64_t input_num_elements,
+    int64_t input_rank,
+    const int64_t* input_dims_host,
+    int64_t output_capacity,
     int hip_dtype);
 
 /* =========================================================================

--- a/3rd-party/custom_kernels/include/msvc_hip_cmath_workaround.h
+++ b/3rd-party/custom_kernels/include/msvc_hip_cmath_workaround.h
@@ -34,46 +34,12 @@
 
 #if defined(_MSC_VER) && defined(__clang__) && defined(__HIP__)
 
-// Layer 1: predefine the MS STL's `_CLANG_BUILTIN*` macros to empty.
+// The MS STL's `_CLANG_BUILTIN1` / `_CLANG_BUILTIN2` / `_CLANG_BUILTIN2_TEMPLATED`
+// expansion in `<cmath>` is what produces the conflicting `inline` overloads.
+// Pre-define them as empty so the expansion produces no declarations.
 #define _CLANG_BUILTIN1(NAME)
 #define _CLANG_BUILTIN2(NAME)
 #define _CLANG_BUILTIN2_TEMPLATED(NAME)
-
-// Layer 2: rename the colliding function names before <cmath> pulls them in.
-// Comparison ops (`_CLANG_BUILTIN2` family).
-#define isgreater __msvc_hip_isgreater
-#define isgreaterequal __msvc_hip_isgreaterequal
-#define isless __msvc_hip_isless
-#define islessequal __msvc_hip_islessequal
-#define islessgreater __msvc_hip_islessgreater
-#define isunordered __msvc_hip_isunordered
-// Predicates (`_CLANG_BUILTIN1` family) — included defensively; the CI
-// failure surfaced only the BUILTIN2 conflicts but the same MS STL change
-// could expose BUILTIN1 conflicts on a future patch level.
-#define isfinite __msvc_hip_isfinite
-#define isinf __msvc_hip_isinf
-#define isnan __msvc_hip_isnan
-#define isnormal __msvc_hip_isnormal
-
-// Force-include <cmath> NOW so the MS STL emits the renamed declarations
-// while our `#define`s are still in scope. The header guard prevents the
-// auto-included `__clang_hip_runtime_wrapper.h` chain from reintroducing
-// the conflicting names later in the TU.
-#include <cmath>
-
-// Restore the original names so subsequent code (kernel device functions,
-// downstream includes like `<hip/hip_runtime.h>`) sees `isgreater` resolve
-// to clang-hip's `__device__` overloads.
-#undef isgreater
-#undef isgreaterequal
-#undef isless
-#undef islessequal
-#undef islessgreater
-#undef isunordered
-#undef isfinite
-#undef isinf
-#undef isnan
-#undef isnormal
 
 #endif // _MSC_VER && __clang__ && __HIP__
 

--- a/3rd-party/custom_kernels/include/msvc_hip_cmath_workaround.h
+++ b/3rd-party/custom_kernels/include/msvc_hip_cmath_workaround.h
@@ -34,12 +34,46 @@
 
 #if defined(_MSC_VER) && defined(__clang__) && defined(__HIP__)
 
-// The MS STL's `_CLANG_BUILTIN1` / `_CLANG_BUILTIN2` / `_CLANG_BUILTIN2_TEMPLATED`
-// expansion in `<cmath>` is what produces the conflicting `inline` overloads.
-// Pre-define them as empty so the expansion produces no declarations.
+// Layer 1: predefine the MS STL's `_CLANG_BUILTIN*` macros to empty.
 #define _CLANG_BUILTIN1(NAME)
 #define _CLANG_BUILTIN2(NAME)
 #define _CLANG_BUILTIN2_TEMPLATED(NAME)
+
+// Layer 2: rename the colliding function names before <cmath> pulls them in.
+// Comparison ops (`_CLANG_BUILTIN2` family).
+#define isgreater __msvc_hip_isgreater
+#define isgreaterequal __msvc_hip_isgreaterequal
+#define isless __msvc_hip_isless
+#define islessequal __msvc_hip_islessequal
+#define islessgreater __msvc_hip_islessgreater
+#define isunordered __msvc_hip_isunordered
+// Predicates (`_CLANG_BUILTIN1` family) — included defensively; the CI
+// failure surfaced only the BUILTIN2 conflicts but the same MS STL change
+// could expose BUILTIN1 conflicts on a future patch level.
+#define isfinite __msvc_hip_isfinite
+#define isinf __msvc_hip_isinf
+#define isnan __msvc_hip_isnan
+#define isnormal __msvc_hip_isnormal
+
+// Force-include <cmath> NOW so the MS STL emits the renamed declarations
+// while our `#define`s are still in scope. The header guard prevents the
+// auto-included `__clang_hip_runtime_wrapper.h` chain from reintroducing
+// the conflicting names later in the TU.
+#include <cmath>
+
+// Restore the original names so subsequent code (kernel device functions,
+// downstream includes like `<hip/hip_runtime.h>`) sees `isgreater` resolve
+// to clang-hip's `__device__` overloads.
+#undef isgreater
+#undef isgreaterequal
+#undef isless
+#undef islessequal
+#undef islessgreater
+#undef isunordered
+#undef isfinite
+#undef isinf
+#undef isnan
+#undef isnormal
 
 #endif // _MSC_VER && __clang__ && __HIP__
 

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -514,8 +514,13 @@ int wrap_hipMemcpy2DAsync(RuntimeState *state, void *dst_ptr, size_t dst_pitch,
 
 // MIOpen convolution forward operation
 // Full wrapper with descriptor creation, algorithm finding, workspace
-// management Follows opaque RuntimeState pattern - extracts handle/stream
-// internally Parameters match generated LLVM IR from HipToLLVM pass
+// management. Follows opaque RuntimeState pattern - extracts handle/stream
+// internally. Parameters match generated LLVM IR from HipToLLVM pass.
+//
+// `data_type` is a HIPDNN_EP_DATATYPE_* enum value applied uniformly to the
+// input / weights / output tensor descriptors — MIOpen requires all three to
+// share the same element type. The host-side lowering derives this from the
+// hip.conv result memref's element type.
 int wrap_miopenConvolutionForward(
     RuntimeState
         *state, // RuntimeState (opaque - extracts handle/stream internally)
@@ -540,7 +545,8 @@ int wrap_miopenConvolutionForward(
     int64_t pad_right,   // Padding right
     int64_t dilation_h,  // Dilation height
     int64_t dilation_w,  // Dilation width
-    int64_t group);      // Number of groups
+    int64_t group,       // Number of groups
+    int64_t data_type);  // HIPDNN_EP_DATATYPE_* for I/O and weights
 
 // hipBLASLt GEMM operation wrapper
 // Called by generated IR for matrix multiplication operations
@@ -558,16 +564,31 @@ int wrap_hipblasLtGemm(void *handle, // hipBLASLt handle
 // Computes output = A @ B for each batch
 // A: [batch_count x M x K], B: [K x N] (broadcast) or [batch_count x K x N]
 // output: [batch_count x M x N]
+//
+// `b_batch_stride` is hipBLASLt's STRIDED_BATCH_OFFSET on layA when
+// `batch_count > 1`: the per-batch advance in elements through B. It MUST be:
+//   * 0   when B is a broadcast weight — one matrix reused across all
+//         batches. Includes both rank-2 `[K, N]` and rank-N
+//         `[1, ..., 1, K, N]` (any leading-dim product == 1).
+//   * K*N when B is per-batch — leading-dim product > 1, so the buffer
+//         actually holds multiple `[K, N]` matrices laid out contiguously.
+// Mis-setting this to K*N for a broadcast B causes hipBLASLt to step K*N
+// elements past the end of the weight buffer on every batch beyond the
+// first, reading uninitialised memory into the GEMM and producing wrong
+// (often NaN) outputs for batch > 0. For batch_count == 1 the value is
+// ignored. Always pass an exact stride; the compiler computes 0 vs K*N
+// at compile time when B's leading dims are static, else at runtime.
 int wrap_hipblasLtMatmul(
     RuntimeState *state,
-    const void *A,       // Matrix A GPU pointer
-    const void *B,       // Matrix B GPU pointer
-    void *output,        // Output GPU pointer
-    int64_t M,           // Rows of A (per batch)
-    int64_t N,           // Columns of B
-    int64_t K,           // Columns of A / Rows of B
-    int64_t batch_count, // Number of batches
-    int64_t elem_size);  // Element size in bytes (2=f16, 4=f32)
+    const void *A,           // Matrix A GPU pointer
+    const void *B,           // Matrix B GPU pointer
+    void *output,            // Output GPU pointer
+    int64_t M,               // Rows of A (per batch)
+    int64_t N,               // Columns of B
+    int64_t K,               // Columns of A / Rows of B
+    int64_t batch_count,     // Number of batches
+    int64_t elem_size,       // Element size in bytes (2=f16, 4=f32)
+    int64_t b_batch_stride); // 0 = broadcast (any rank); K*N = per-batch
 
 // GroupQueryAttention operation wrapper (Full MS spec)
 // Called by generated IR for onnx.Custom(GroupQueryAttention) lowering
@@ -647,11 +668,16 @@ int wrap_miopenOpTensor(RuntimeState *state, void *lhs, void *rhs, void *output,
                         int64_t out_c, int64_t out_h, int64_t out_w,
                         int64_t data_type, int64_t tensor_op);
 
-// Element-wise subtraction wrapper
-// Computes output = lhs - rhs element-wise
+// Element-wise subtraction with 4D ONNX broadcast (rank <= 4).
+// Computes output = lhs - rhs; materialises broadcast via hip_expand when
+// an operand shape differs from the output shape. Sub is not commutative --
+// operands are never swapped.
 int wrap_elementwise_sub(RuntimeState *state, void *lhs, void *rhs,
-                         void *output, int64_t num_elements,
-                         int64_t element_size_bytes);
+                         void *output, int64_t lhs_n, int64_t lhs_c,
+                         int64_t lhs_h, int64_t lhs_w, int64_t rhs_n,
+                         int64_t rhs_c, int64_t rhs_h, int64_t rhs_w,
+                         int64_t out_n, int64_t out_c, int64_t out_h,
+                         int64_t out_w, int64_t data_type);
 
 // Element-wise Where wrapper (NumPy-style multidirectional broadcasting,
 // arbitrary rank). Computes output[i] = condition[i] ? x[i] : y[i] with
@@ -684,10 +710,14 @@ int wrap_power(RuntimeState *state, void *input, void *output,
                int64_t num_elements, int64_t data_type, double alpha,
                double beta, double gamma);
 
-// Gather operation wrapper
+// Gather operation wrapper.
+// `axis_size` = data.shape[axis]; `inner_size` = product of
+// data.shape[axis+1:]. outer_size is derived as data_num_elements / (axis_size
+// * inner_size).
 int wrap_gather(RuntimeState *state, void *data, void *indices, void *output,
                 int64_t axis, int64_t data_num_elements,
                 int64_t indices_num_elements, int64_t output_num_elements,
+                int64_t axis_size, int64_t inner_size,
                 int64_t element_size_bytes);
 
 // Range operation wrapper
@@ -914,8 +944,14 @@ int wrap_gemm(RuntimeState *state, const void *A, const void *B, const void *C,
               float beta, int64_t transA, int64_t transB, int64_t typeCode,
               int64_t cDim0, int64_t cDim1);
 
+// `out_num_elements` is the broadcast result count.  `a_num_elements` and
+// `b_num_elements` are the per-input element counts; either may be 1 to
+// indicate scalar broadcast.  Today only same-shape OR scalar-vs-tensor is
+// supported (the common case for embedding-style models like Qwen3.5 where
+// `Equal(input_ids[1,N], scalar)` lowers without an intervening `Expand`).
 int wrap_equal(RuntimeState *state, void *a, void *b, void *output,
-               int64_t num_elements, int64_t data_type);
+               int64_t a_num_elements, int64_t b_num_elements,
+               int64_t out_num_elements, int64_t data_type);
 
 // Element-wise logical AND wrapper. Inputs / output share the same data_type
 // (HIPDNN_EP_DATATYPE_*); ONNX `And` is defined on bool tensors, which the
@@ -945,7 +981,8 @@ int wrap_not(RuntimeState *state, void *input, void *output,
 // and throws std::runtime_error so an inference path that actually
 // reaches NonZero fails loudly instead of producing uninitialised output.
 int wrap_nonzero(RuntimeState *state, void *input, void *output,
-                 int64_t input_num_elements, int64_t input_rank,
+                 int32_t *count_ptr, int64_t input_num_elements,
+                 int64_t input_rank, const int64_t *input_dims,
                  int64_t output_capacity, int64_t input_data_type);
 
 // ONNX Size wrapper (dynamic-shape path only).
@@ -962,8 +999,14 @@ int wrap_cos(RuntimeState *state, void *input, void *output,
 int wrap_sin(RuntimeState *state, void *input, void *output,
              int64_t num_elements, int64_t data_type);
 
+// Element-wise division with 4D ONNX broadcast (rank <= 4, left-padded).
+// Computes output = lhs / rhs; materialises broadcast via hip_expand when
+// an operand shape differs from the output shape.
 int wrap_div(RuntimeState *state, void *lhs, void *rhs, void *output,
-             int64_t num_elements, int64_t data_type);
+             int64_t lhs_n, int64_t lhs_c, int64_t lhs_h, int64_t lhs_w,
+             int64_t rhs_n, int64_t rhs_c, int64_t rhs_h, int64_t rhs_w,
+             int64_t out_n, int64_t out_c, int64_t out_h, int64_t out_w,
+             int64_t data_type);
 
 // CumSum operation wrapper (cumulative sum along an axis).
 // `axis` is a rank-0 (scalar) GPU tensor whose i32/i64 value selects the
@@ -1065,12 +1108,12 @@ int wrap_slice(RuntimeState *state, void *data, void *starts, void *ends,
 // The runtime is responsible (when implemented) for both the initial
 // data -> output copy and the per-index scatter writes.
 int wrap_scatter_nd(RuntimeState *state, void *data, void *indices,
-                    void *updates, void *output, const int64_t *data_shape,
-                    int64_t data_rank, const int64_t *indices_shape,
-                    int64_t indices_rank, const int64_t *updates_shape,
-                    int64_t updates_rank, const int64_t *output_shape,
-                    int64_t output_rank, int64_t reduction_id,
-                    int64_t data_type);
+                    void *updates, void *output, const int32_t *count_ptr,
+                    const int64_t *data_shape, int64_t data_rank,
+                    const int64_t *indices_shape, int64_t indices_rank,
+                    const int64_t *updates_shape, int64_t updates_rank,
+                    const int64_t *output_shape, int64_t output_rank,
+                    int64_t reduction_id, int64_t data_type);
 
 //===----------------------------------------------------------------------===//
 // ONNX Loop Drivers

--- a/lib/Runtime/hipdnn_ep_runtime_tensor.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_tensor.cpp
@@ -120,8 +120,28 @@ static void check_gcnarch(const char *location) {
   }
 }
 
-// Helper: Calculate total size in bytes for a tensor
-// Returns 0 on error (overflow or invalid dimensions)
+// Helper: Calculate total size in bytes for a tensor.
+//
+// Return value semantics:
+//   * size_bytes > 0  -- regular non-empty tensor.
+//   * size_bytes == 0 -- legitimate zero-element tensor (any shape[i] == 0),
+//                        OR genuinely invalid input (rank>0 with null shape,
+//                        any shape[i] < 0, or overflow). Callers that need
+//                        to distinguish must inspect shape themselves.
+//
+// Zero-sized dims are legal under the ONNX spec and are produced routinely
+// in practice (e.g. KV-cache `past_key_values.*.key/value` with shape
+// [B, H, 0, D] on the first prefill step when past_sequence_length==0;
+// OGA VLM decode supplies image_features as [0, hidden_size] every step
+// after the prompt has been processed). The prepare_input / prepare_output
+// path treats size_bytes==0 as a successful empty pass-through; this helper
+// therefore must return 0 silently for zero-sized dims rather than logging
+// "Invalid dimension" to stderr, which (a) is misleading because the input
+// is correct, and (b) used to spam once per zero-dim tensor per inference
+// step on every VLM model.
+//
+// Strictly-negative dims still indicate corrupt metadata and remain a
+// reported error.
 static size_t calculateTensorSize(const int64_t *shape, size_t rank,
                                   size_t element_size) {
   if (rank == 0) {
@@ -131,23 +151,28 @@ static size_t calculateTensorSize(const int64_t *shape, size_t rank,
     return 0;
   }
 
-  // Validate all dimensions are positive
+  // Reject strictly-negative dims (corrupt metadata). Zero is allowed.
   for (size_t i = 0; i < rank; i++) {
-    if (shape[i] <= 0) {
+    if (shape[i] < 0) {
       fprintf(stderr, "Invalid dimension at index %zu: %lld\n", i,
               (long long)shape[i]);
       return 0;
     }
   }
 
-  // Calculate total number of elements with overflow check
+  // Multiply with overflow check. Skip the division guard when the current
+  // dim is zero -- a zero factor cannot overflow, and SIZE_MAX/0 would be
+  // undefined behavior. Once total_elements hits zero it stays there, which
+  // is the correct answer for any zero-element tensor regardless of the
+  // remaining dims.
   size_t total_elements = 1;
   for (size_t i = 0; i < rank; i++) {
-    if (total_elements > SIZE_MAX / static_cast<size_t>(shape[i])) {
+    size_t dim = static_cast<size_t>(shape[i]);
+    if (dim != 0 && total_elements > SIZE_MAX / dim) {
       fprintf(stderr, "Tensor size overflow at dimension %zu\n", i);
       return 0;
     }
-    total_elements *= static_cast<size_t>(shape[i]);
+    total_elements *= dim;
   }
 
   if (total_elements > SIZE_MAX / element_size) {
@@ -255,13 +280,7 @@ int hipdnn_ep_tensor_prepare_input(RuntimeState *state, span_t *inputs,
     return HIPDNN_EP_ERR_NULL_POINTER; // Use generic error code
   }
 
-  // Validate tensor pointers
-  if (!tensor->data) {
-    fprintf(stderr,
-            "hipdnn_ep_tensor_prepare_input: tensor[%zu].data is null\n",
-            index);
-    return HIPDNN_EP_ERR_NULL_POINTER;
-  }
+  // Shape must be present (or rank==0 for scalars).
   if (!tensor->shape && tensor->rank != 0) {
     fprintf(stderr,
             "hipdnn_ep_tensor_prepare_input: tensor[%zu].shape is null\n",
@@ -291,8 +310,34 @@ int hipdnn_ep_tensor_prepare_input(RuntimeState *state, span_t *inputs,
   // Calculate buffer size
   size_t size_bytes =
       calculateTensorSize(tensor->shape, tensor->rank, element_size);
+
+  // Empty tensors (any dim == 0 -> size_bytes == 0) are legitimate inputs --
+  // e.g. KV cache `past_key_values.*.key/value` with shape [B, H, 0, D] on
+  // the prefill step (past_sequence_length == 0).  ORT supplies these with
+  // `data == nullptr` because there is nothing to copy; we must accept that
+  // and let downstream compiled kernels see an empty dim and iterate zero
+  // times.  Skip the null-data check, skip pool_alloc + H2D, and return
+  // SUCCESS with a zero-size buffer (gpu_ptr=nullptr is fine because
+  // compiled MLIR kernels never dereference it when the corresponding dim
+  // is zero).
   if (size_bytes == 0) {
-    return HIPDNN_EP_ERR_INVALID_DIMENSION;
+    out_buffer->gpu_ptr = nullptr;
+    out_buffer->host_ptr = tensor->data;
+    out_buffer->shape_ptr = tensor->shape;
+    out_buffer->rank = tensor->rank;
+    out_buffer->size_bytes = 0;
+    out_buffer->is_pooled = false;
+    out_buffer->is_aliased = false;
+    return HIPDNN_EP_SUCCESS;
+  }
+
+  // Non-empty: data must be non-null now.
+  if (!tensor->data) {
+    fprintf(stderr,
+            "hipdnn_ep_tensor_prepare_input: tensor[%zu].data is null but "
+            "size_bytes=%zu (rank=%zu)\n",
+            index, size_bytes, tensor->rank);
+    return HIPDNN_EP_ERR_NULL_POINTER;
   }
 
   RUNTIME_DEBUG_LOG(
@@ -440,13 +485,7 @@ int hipdnn_ep_tensor_prepare_output(RuntimeState *state, span_t *outputs,
   // Extract tensor from span
   tensor_t *tensor = &outputs->data[index];
 
-  // Validate tensor pointers
-  if (!tensor->data) {
-    fprintf(stderr,
-            "hipdnn_ep_tensor_prepare_output: tensor[%zu].data is null\n",
-            index);
-    return HIPDNN_EP_ERR_NULL_POINTER;
-  }
+  // Shape must be present (or rank==0 for scalars).
   if (!tensor->shape && tensor->rank != 0) {
     fprintf(stderr,
             "hipdnn_ep_tensor_prepare_output: tensor[%zu].shape is null\n",
@@ -476,8 +515,30 @@ int hipdnn_ep_tensor_prepare_output(RuntimeState *state, span_t *outputs,
   // Calculate buffer size
   size_t size_bytes =
       calculateTensorSize(tensor->shape, tensor->rank, element_size);
+
+  // Empty output tensors (any dim == 0) are legitimate -- e.g. an op
+  // producing a slice with a zero-length dim.  Skip allocation and return
+  // success with a zero-size buffer.  Compiled kernels never dereference
+  // gpu_ptr when the corresponding dim is zero (the iteration range is
+  // empty).
   if (size_bytes == 0) {
-    return HIPDNN_EP_ERR_INVALID_DIMENSION;
+    out_buffer->gpu_ptr = nullptr;
+    out_buffer->host_ptr = tensor->data;
+    out_buffer->shape_ptr = tensor->shape;
+    out_buffer->rank = tensor->rank;
+    out_buffer->size_bytes = 0;
+    out_buffer->is_pooled = false;
+    out_buffer->is_aliased = false;
+    return HIPDNN_EP_SUCCESS;
+  }
+
+  // Non-empty: data must be non-null now.
+  if (!tensor->data) {
+    fprintf(stderr,
+            "hipdnn_ep_tensor_prepare_output: tensor[%zu].data is null but "
+            "size_bytes=%zu (rank=%zu)\n",
+            index, size_bytes, tensor->rank);
+    return HIPDNN_EP_ERR_NULL_POINTER;
   }
 
   RUNTIME_DEBUG_LOG(
@@ -535,6 +596,12 @@ int hipdnn_ep_tensor_finalize_output(RuntimeState *state,
     return HIPDNN_EP_ERR_NULL_POINTER;
   }
 
+  // Empty output (zero-sized dim): nothing to copy, nothing to release.
+  // prepare_output set gpu_ptr=nullptr and size_bytes=0 in this case.
+  if (buffer->size_bytes == 0) {
+    return HIPDNN_EP_SUCCESS;
+  }
+
   int result = HIPDNN_EP_SUCCESS;
 
   // PERF: record D2H start on first output finalize (after all compute).
@@ -590,6 +657,10 @@ int hipdnn_ep_tensor_finalize_output(RuntimeState *state,
 
 // Synchronize GPU stream once (called after all finalize_output calls).
 int hipdnn_ep_stream_sync(RuntimeState *state) {
+  // Per-Compute entry trace; gated on HIPDNN_EP_DEBUG to keep the hot path
+  // silent (fires once per Compute -> tens of thousands of lines on a
+  // multi-token decode).
+  RUNTIME_DEBUG_LOG("[stream_sync] enter state=%p\n", (void *)state);
   if (!state) {
     fprintf(stderr, "hipdnn_ep_stream_sync: null state\n");
     return HIPDNN_EP_ERR_NULL_POINTER;
@@ -641,6 +712,13 @@ void hipdnn_ep_tensor_free_input(RuntimeState *state, TensorBuffer *buffer) {
   (void)state;
   if (!buffer) {
     fprintf(stderr, "hipdnn_ep_tensor_free_input: null buffer\n");
+    return;
+  }
+
+  // Empty input (size_bytes == 0, e.g. KV cache with past_sequence_length==0
+  // on prefill): no pool allocation was made; nothing to release.
+  if (buffer->size_bytes == 0) {
+    buffer->gpu_ptr = nullptr;
     return;
   }
 

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -448,7 +448,8 @@ int wrap_miopenConvolutionForward(
     const void *bias, void *output, int64_t output_h, int64_t output_w,
     int64_t kernel_h, int64_t kernel_w, int64_t stride_h, int64_t stride_w,
     int64_t pad_top, int64_t pad_left, int64_t pad_bottom, int64_t pad_right,
-    int64_t dilation_h, int64_t dilation_w, int64_t group) {
+    int64_t dilation_h, int64_t dilation_w, int64_t group, int64_t data_type) {
+  (void)data_type;
   if (!state || !input || !weights || !output) {
     fprintf(stderr, "Invalid arguments to wrap_miopenConvolutionForward\n");
     return -1;
@@ -549,7 +550,9 @@ int wrap_hipblasLtGemm(void *handle, void *stream, int64_t m, int64_t n,
 
 int wrap_hipblasLtMatmul(RuntimeState *state, const void *A, const void *B,
                          void *output, int64_t M, int64_t N, int64_t K,
-                         int64_t batch_count, int64_t elem_size) {
+                         int64_t batch_count, int64_t elem_size,
+                         int64_t b_batch_stride) {
+  (void)b_batch_stride;
   if (!state) {
     fprintf(stderr, "Invalid state in wrap_hipblasLtMatmul\n");
     return -1;
@@ -748,16 +751,23 @@ int wrap_miopenOpTensor(RuntimeState *state, void *lhs, void *rhs, void *output,
 }
 
 int wrap_elementwise_sub(RuntimeState *state, void *lhs, void *rhs,
-                         void *output, int64_t num_elements,
-                         int64_t element_size_bytes) {
+                         void *output, int64_t lhs_n, int64_t lhs_c,
+                         int64_t lhs_h, int64_t lhs_w, int64_t rhs_n,
+                         int64_t rhs_c, int64_t rhs_h, int64_t rhs_w,
+                         int64_t out_n, int64_t out_c, int64_t out_h,
+                         int64_t out_w, int64_t data_type) {
   if (!state) {
     fprintf(stderr, "Invalid state in wrap_elementwise_sub\n");
     return -1;
   }
 
-  MOCK_PRINT("[MOCK] wrap_elementwise_sub(num_elements=%lld, "
-             "element_size=%lld)\n",
-             (long long)num_elements, (long long)element_size_bytes);
+  MOCK_PRINT("[MOCK] wrap_elementwise_sub lhs=[%lld,%lld,%lld,%lld] "
+             "rhs=[%lld,%lld,%lld,%lld] out=[%lld,%lld,%lld,%lld] dtype=%s\n",
+             (long long)lhs_n, (long long)lhs_c, (long long)lhs_h,
+             (long long)lhs_w, (long long)rhs_n, (long long)rhs_c,
+             (long long)rhs_h, (long long)rhs_w, (long long)out_n,
+             (long long)out_c, (long long)out_h, (long long)out_w,
+             hipdnn_ep_datatype_name(data_type));
 
   return 0;
 }
@@ -765,7 +775,13 @@ int wrap_elementwise_sub(RuntimeState *state, void *lhs, void *rhs,
 int wrap_gather(RuntimeState *state, void *data, void *indices, void *output,
                 int64_t axis, int64_t data_num_elements,
                 int64_t indices_num_elements, int64_t output_num_elements,
+                int64_t axis_size, int64_t inner_size,
                 int64_t element_size_bytes) {
+  (void)data;
+  (void)indices;
+  (void)output;
+  (void)axis_size;
+  (void)inner_size;
   if (!state) {
     fprintf(stderr, "Invalid state in wrap_gather\n");
     return -1;
@@ -773,9 +789,10 @@ int wrap_gather(RuntimeState *state, void *data, void *indices, void *output,
 
   MOCK_PRINT("[MOCK] wrap_gather(axis=%lld, data_num_elements=%lld, "
              "indices_num_elements=%lld, output_num_elements=%lld, "
-             "element_size=%lld)\n",
+             "axis_size=%lld, inner_size=%lld, element_size=%lld)\n",
              (long long)axis, (long long)data_num_elements,
              (long long)indices_num_elements, (long long)output_num_elements,
+             (long long)axis_size, (long long)inner_size,
              (long long)element_size_bytes);
 
   return 0;
@@ -1072,13 +1089,19 @@ int wrap_where(RuntimeState *state, void *condition, void *x, void *y,
 }
 
 int wrap_equal(RuntimeState *state, void *a, void *b, void *output,
-               int64_t num_elements, int64_t data_type) {
+               int64_t a_num_elements, int64_t b_num_elements,
+               int64_t out_num_elements, int64_t data_type) {
+  (void)a;
+  (void)b;
+  (void)output;
   if (!state) {
     fprintf(stderr, "Invalid state in wrap_equal\n");
     return -1;
   }
-  MOCK_PRINT("[MOCK] wrap_equal(num_elements=%lld, data_type=%s)\n",
-             (long long)num_elements, hipdnn_ep_datatype_name(data_type));
+  MOCK_PRINT("[MOCK] wrap_equal(a_num=%lld, b_num=%lld, out=%lld, "
+             "data_type=%s)\n",
+             (long long)a_num_elements, (long long)b_num_elements,
+             (long long)out_num_elements, hipdnn_ep_datatype_name(data_type));
   return 0;
 }
 
@@ -1097,13 +1120,21 @@ int wrap_and(RuntimeState *state, void *a, void *b, void *output,
 }
 
 int wrap_div(RuntimeState *state, void *lhs, void *rhs, void *output,
-             int64_t num_elements, int64_t data_type) {
+             int64_t lhs_n, int64_t lhs_c, int64_t lhs_h, int64_t lhs_w,
+             int64_t rhs_n, int64_t rhs_c, int64_t rhs_h, int64_t rhs_w,
+             int64_t out_n, int64_t out_c, int64_t out_h, int64_t out_w,
+             int64_t data_type) {
   if (!state) {
     fprintf(stderr, "Invalid state in wrap_div\n");
     return -1;
   }
-  MOCK_PRINT("[MOCK] wrap_div(num_elements=%lld, data_type=%s)\n",
-             (long long)num_elements, hipdnn_ep_datatype_name(data_type));
+  MOCK_PRINT("[MOCK] wrap_div lhs=[%lld,%lld,%lld,%lld] "
+             "rhs=[%lld,%lld,%lld,%lld] out=[%lld,%lld,%lld,%lld] dtype=%s\n",
+             (long long)lhs_n, (long long)lhs_c, (long long)lhs_h,
+             (long long)lhs_w, (long long)rhs_n, (long long)rhs_c,
+             (long long)rhs_h, (long long)rhs_w, (long long)out_n,
+             (long long)out_c, (long long)out_h, (long long)out_w,
+             hipdnn_ep_datatype_name(data_type));
   return 0;
 }
 
@@ -1131,7 +1162,8 @@ int wrap_not(RuntimeState *state, void *input, void *output,
 }
 
 int wrap_nonzero(RuntimeState *state, void *input, void *output,
-                 int64_t input_num_elements, int64_t input_rank,
+                 int32_t *count_ptr, int64_t input_num_elements,
+                 int64_t input_rank, const int64_t *input_dims,
                  int64_t output_capacity, int64_t input_data_type) {
   if (!state) {
     fprintf(stderr, "Invalid state in wrap_nonzero\n");
@@ -1139,6 +1171,10 @@ int wrap_nonzero(RuntimeState *state, void *input, void *output,
   }
   (void)input;
   (void)output;
+  (void)input_dims;
+  // Mock: set count to 0 (no nonzero elements)
+  if (count_ptr)
+    *count_ptr = 0;
   MOCK_PRINT("[MOCK] wrap_nonzero(input_num_elements=%lld, input_rank=%lld, "
              "output_capacity=%lld, input_data_type=%s(%lld))\n",
              (long long)input_num_elements, (long long)input_rank,
@@ -1317,12 +1353,12 @@ int wrap_slice(RuntimeState *state, void *data, void *starts, void *ends,
 }
 
 int wrap_scatter_nd(RuntimeState *state, void *data, void *indices,
-                    void *updates, void *output, const int64_t *data_shape,
-                    int64_t data_rank, const int64_t *indices_shape,
-                    int64_t indices_rank, const int64_t *updates_shape,
-                    int64_t updates_rank, const int64_t *output_shape,
-                    int64_t output_rank, int64_t reduction_id,
-                    int64_t data_type) {
+                    void *updates, void *output, const int32_t *count_ptr,
+                    const int64_t *data_shape, int64_t data_rank,
+                    const int64_t *indices_shape, int64_t indices_rank,
+                    const int64_t *updates_shape, int64_t updates_rank,
+                    const int64_t *output_shape, int64_t output_rank,
+                    int64_t reduction_id, int64_t data_type) {
   if (!state) {
     fprintf(stderr, "Invalid state in wrap_scatter_nd\n");
     return -1;
@@ -1331,17 +1367,18 @@ int wrap_scatter_nd(RuntimeState *state, void *data, void *indices,
   (void)indices;
   (void)updates;
   (void)output;
+  (void)count_ptr;
   (void)data_shape;
   (void)indices_shape;
   (void)updates_shape;
   (void)output_shape;
   MOCK_PRINT("[MOCK] wrap_scatter_nd(data_rank=%lld, indices_rank=%lld, "
              "updates_rank=%lld, output_rank=%lld, reduction_id=%lld, "
-             "data_type=%s(%lld))\n",
+             "data_type=%s(%lld), has_count=%d)\n",
              (long long)data_rank, (long long)indices_rank,
              (long long)updates_rank, (long long)output_rank,
              (long long)reduction_id, hipdnn_ep_datatype_name(data_type),
-             (long long)data_type);
+             (long long)data_type, count_ptr != nullptr);
   return 0;
 }
 

--- a/lib/Runtime/mock/mock_types.h
+++ b/lib/Runtime/mock/mock_types.h
@@ -27,6 +27,7 @@ struct hipDeviceProp_t {
 #define hipMemcpyDeviceToHost 1
 #define hipHostMallocDefault 0
 #define hipHostMallocMapped 0
+#define hipHostMallocNonCoherent 0
 #define hipEventDisableTiming 0
 
 // MIOpen tensor layout enum (subset used by the runtime)

--- a/lib/Runtime/real/activation.cpp
+++ b/lib/Runtime/real/activation.cpp
@@ -234,6 +234,69 @@ static int hipdnn_ep_to_hip_dtype_elementwise_unary(int64_t data_type) {
   }
 }
 
+// Standalone Softmax runtime entry point — called from
+// `ConvertHipToLLVM`'s `MiopenSoftmaxOpLowering` for `onnx.Softmax` paths
+// outside fused attention (vision encoder self-attention, primarily; text
+// decoders fuse softmax inside hip.gqa and don't reach this path).
+// Dispatches to `hip_softmax_row_2d_inplace` (custom HIP kernel) —
+// row-wise softmax over a contiguous row-major [rows, cols] fp16 buffer
+// with `cols` = the softmax axis size (ONNX Softmax axis = -1 over the
+// last dim of the flattened input).
+//
+// fp16-only today. The buffer element type is taken on faith from the
+// MemRef the lowering hands us; the runtime does not validate the dtype.
+// If a future model needs fp32 softmax, plumb an `elem_size` (or dtype
+// enum) through the lowering and dispatch in the kernel launcher.
+//
+// Symbol name is `hip_miopen_softmax` (not `hip_softmax`) to match the
+// lowering side's `kMiopenSoftmax` constant. The kernel-level dispatch
+// is unrelated to MIOpen.
+//
+// Reusing `hip_gqa_softmax_inplace` (from gqa_kernel.hip) would not work:
+// that kernel is column-wise over a GQA-specific layout AND its launcher
+// only spawns `total_head_queries` blocks, not `total_head_queries * cols`.
+// A standalone softmax wired to that path produces NaN downstream.
+extern "C" int hip_miopen_softmax(void *state, const void *input, void *output,
+                                  int64_t rows, int64_t cols) {
+  RuntimeState *st = static_cast<RuntimeState *>(state);
+  OP_PROFILE(
+      "softmax",
+      [&] {
+        char b[64];
+        snprintf(b, sizeof(b), "%lldx%lld", (long long)rows, (long long)cols);
+        return std::string(b);
+      },
+      st);
+  if (!state || !input || !output) {
+    fprintf(stderr, "[REAL] hip_miopen_softmax: null argument\n");
+    return -1;
+  }
+  if (rows <= 0 || cols <= 0) {
+    fprintf(stderr,
+            "[REAL] hip_miopen_softmax: invalid dims rows=%lld cols=%lld\n",
+            (long long)rows, (long long)cols);
+    return -1;
+  }
+
+  void *stream = hipdnn_ep_state_get_stream(st);
+
+  // Copy input -> output (kernel is in-place; both are fp16 contiguous
+  // buffers from `extractContiguousMemRefPtr`).
+  hipError_t err = hipMemcpyAsync(
+      output, input, static_cast<size_t>(rows) * cols * sizeof(uint16_t),
+      hipMemcpyDeviceToDevice, static_cast<hipStream_t>(stream));
+  if (err != hipSuccess) {
+    fprintf(stderr, "[REAL] hip_miopen_softmax: hipMemcpyAsync failed: %s\n",
+            hipGetErrorString(err));
+    return -1;
+  }
+
+  RUNTIME_DEBUG_LOG("[REAL] hip_miopen_softmax: rows=%lld cols=%lld\n",
+                    (long long)rows, (long long)cols);
+  return hip_softmax_row_2d_inplace(stream, output, static_cast<int>(rows),
+                                    static_cast<int>(cols));
+}
+
 int wrap_gelu(RuntimeState *state, void *input, void *output,
               int64_t num_elements, int64_t data_type, int64_t approximate) {
   OP_PROFILE(

--- a/lib/Runtime/real/cast.cpp
+++ b/lib/Runtime/real/cast.cpp
@@ -7,6 +7,8 @@
 #include "../op_profile.h"
 #include "hip_custom_kernels.h"
 
+#include <hip/hip_runtime.h>
+
 #include <cstdio>
 
 // Map HIPDNN_EP_DATATYPE_* → hip_dtype_t for custom kernels.
@@ -23,6 +25,10 @@ static int hipdnn_to_hip_dtype(int64_t hipdnn_type) {
     return HIP_DTYPE_INT32;
   case HIPDNN_EP_DATATYPE_INT64:
     return HIP_DTYPE_INT64;
+  case HIPDNN_EP_DATATYPE_UINT8:
+    return HIP_DTYPE_UINT8;
+  case HIPDNN_EP_DATATYPE_INT8:
+    return HIP_DTYPE_INT8;
   default:
     return -1;
   }
@@ -40,11 +46,58 @@ int wrap_cast(RuntimeState *state, void *input, void *output,
       },
       state);
   if (!state || !input || !output) {
-    RUNTIME_DEBUG_LOG("[REAL] wrap_cast: null argument\n");
+    RUNTIME_DEBUG_LOG(
+        "[REAL] wrap_cast: null argument (state=%p input=%p output=%p "
+        "n=%lld src=%lld dst=%lld)\n",
+        (void *)state, input, output, (long long)num_elements,
+        (long long)src_data_type, (long long)dst_data_type);
     return -1;
   }
 
   void *stream = hipdnn_ep_state_get_stream(state);
+
+  // Same-dtype fast-path: ONNX exporters (notably the Qwen3.5-VL vision
+  // encoder) sometimes emit redundant `Cast(x, to=src_dtype)` nodes that
+  // survive into the EP IR (e.g. fp32 LayerNorm scale/bias wrapped in
+  // `Cast(fp32_const, to=fp32)` on every transformer block). The custom kernel
+  // dispatch table only covers genuine type-changing casts and would return -1
+  // here for src==dst, which would silently leave `output` untouched (= the
+  // pool's zero-initialized contents) and propagate zeros through downstream
+  // ops (canonical symptom: LayerNorm sees a 0 scale/bias and emits a
+  // row-broadcast tensor). A device-to-device byte-copy is the correct identity
+  // semantics regardless of dtype, so handle this case before the kernel
+  // dispatch.
+  if (src_data_type == dst_data_type) {
+    int64_t elem_size = hipdnn_ep_datatype_size(src_data_type);
+    if (elem_size <= 0) {
+      fprintf(stderr,
+              "[REAL] wrap_cast same-dtype: unsupported data type %lld\n",
+              (long long)src_data_type);
+      return -1;
+    }
+    if (input == output) {
+      // Identity in-place: nothing to do.
+      return 0;
+    }
+    size_t bytes = static_cast<size_t>(num_elements) * elem_size;
+    hipError_t err =
+        hipMemcpyAsync(output, input, bytes, hipMemcpyDeviceToDevice,
+                       static_cast<hipStream_t>(stream));
+    if (err != hipSuccess) {
+      fprintf(stderr,
+              "[REAL] wrap_cast same-dtype hipMemcpyAsync failed: %s "
+              "(n=%lld dtype=%lld)\n",
+              hipGetErrorString(err), (long long)num_elements,
+              (long long)src_data_type);
+      return -1;
+    }
+    RUNTIME_DEBUG_LOG(
+        "[REAL] wrap_cast same-dtype D2D copy: n=%lld dtype=%s(%lld) "
+        "bytes=%zu\n",
+        (long long)num_elements, hipdnn_ep_datatype_name(src_data_type),
+        (long long)src_data_type, bytes);
+    return 0;
+  }
 
   int src_hip_dtype = hipdnn_to_hip_dtype(src_data_type);
   int dst_hip_dtype = hipdnn_to_hip_dtype(dst_data_type);

--- a/lib/Runtime/real/div.cpp
+++ b/lib/Runtime/real/div.cpp
@@ -3,15 +3,13 @@
  * Licensed under the MIT License.
  */
 
-// Div: y = a / b (element-wise, same-shape).
+// Div: y = lhs / rhs with ONNX multidirectional broadcast (rank <= 4).
 //
-// Source: onnxruntime/core/providers/cuda/math/binary_elementwise_ops_impl.cu
-//         @ v1.22.2 (BINARY_OP_NAME_EXPR(Div, (a / b)))
-//
-// Broadcasting is NOT supported here -- the HipToLLVM Div lowering passes
-// num_elements only (no per-input shapes). Any broadcasting must be
-// materialised upstream via Expand. This matches the
-// BinaryElementWiseNoBroadcastImpl fast-path in the CUDA EP.
+// Operand shapes are passed as 4D (N, C, H, W); the compiler left-pads
+// ranks 1-3 with 1. When lhs or rhs does not match the output shape,
+// hip_expand materialises the broadcast into the per-session workspace,
+// then hip_elementwise_div runs on same-shape buffers. Div is not
+// commutative -- operands are never swapped.
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
 #include "../op_profile.h"
@@ -35,13 +33,16 @@ static int div_hipdnn_to_hip_dtype(int64_t hipdnn_type) {
 }
 
 int wrap_div(RuntimeState *state, void *lhs, void *rhs, void *output,
-             int64_t num_elements, int64_t data_type) {
+             int64_t lhs_n, int64_t lhs_c, int64_t lhs_h, int64_t lhs_w,
+             int64_t rhs_n, int64_t rhs_c, int64_t rhs_h, int64_t rhs_w,
+             int64_t out_n, int64_t out_c, int64_t out_h, int64_t out_w,
+             int64_t data_type) {
   OP_PROFILE(
       "div",
       [&] {
-        char b[48];
-        snprintf(b, sizeof(b), "%lld:%s", (long long)num_elements,
-                 hipdnn_ep_datatype_name(data_type));
+        char b[64];
+        snprintf(b, sizeof(b), "%lldx%lldx%lldx%lld", (long long)out_n,
+                 (long long)out_c, (long long)out_h, (long long)out_w);
         return std::string(b);
       },
       state);
@@ -50,9 +51,10 @@ int wrap_div(RuntimeState *state, void *lhs, void *rhs, void *output,
     RUNTIME_DEBUG_LOG("[REAL] wrap_div: null argument\n");
     return -1;
   }
-  if (num_elements <= 0) {
+
+  const int64_t out_vol = out_n * out_c * out_h * out_w;
+  if (out_vol <= 0)
     return 0;
-  }
 
   int hip_dtype = div_hipdnn_to_hip_dtype(data_type);
   if (hip_dtype < 0) {
@@ -64,8 +66,63 @@ int wrap_div(RuntimeState *state, void *lhs, void *rhs, void *output,
   }
 
   void *stream = hipdnn_ep_state_get_stream(state);
-  RUNTIME_DEBUG_LOG(
-      "[REAL] wrap_div: num=%lld, data_type=%s -> hip_elementwise_div\n",
-      (long long)num_elements, hipdnn_ep_datatype_name(data_type));
-  return hip_elementwise_div(stream, lhs, rhs, output, num_elements, hip_dtype);
+
+  const bool lhs_eq_out =
+      (lhs_n == out_n && lhs_c == out_c && lhs_h == out_h && lhs_w == out_w);
+  const bool rhs_eq_out =
+      (rhs_n == out_n && rhs_c == out_c && rhs_h == out_h && rhs_w == out_w);
+
+  void *lhs_use = lhs;
+  void *rhs_use = rhs;
+
+  if (!lhs_eq_out || !rhs_eq_out) {
+    const int64_t elem_bytes = hipdnn_ep_datatype_size(data_type);
+    const size_t per_side = static_cast<size_t>(out_vol * elem_bytes);
+    const size_t needed = per_side * static_cast<size_t>((!lhs_eq_out ? 1 : 0) +
+                                                         (!rhs_eq_out ? 1 : 0));
+    if (hipdnn_ep_state_ensure_workspace(state, needed) != 0) {
+      fprintf(stderr, "[REAL] wrap_div: workspace ensure failed (%zu bytes)\n",
+              needed);
+      return -1;
+    }
+    void *ws = hipdnn_ep_state_get_workspace(state);
+    uint8_t *ws_byte = static_cast<uint8_t *>(ws);
+    const int64_t out_shape[4] = {out_n, out_c, out_h, out_w};
+
+    if (!lhs_eq_out) {
+      const int64_t in_lhs[4] = {lhs_n, lhs_c, lhs_h, lhs_w};
+      int rc =
+          hip_expand(stream, lhs, ws_byte, in_lhs, 4, out_shape, 4, hip_dtype);
+      if (rc != 0) {
+        fprintf(stderr, "[REAL] wrap_div: hip_expand(lhs) failed (%d)\n", rc);
+        return -1;
+      }
+      lhs_use = ws_byte;
+      ws_byte += per_side;
+    }
+    if (!rhs_eq_out) {
+      const int64_t in_rhs[4] = {rhs_n, rhs_c, rhs_h, rhs_w};
+      int rc =
+          hip_expand(stream, rhs, ws_byte, in_rhs, 4, out_shape, 4, hip_dtype);
+      if (rc != 0) {
+        fprintf(stderr, "[REAL] wrap_div: hip_expand(rhs) failed (%d)\n", rc);
+        return -1;
+      }
+      rhs_use = ws_byte;
+    }
+
+    RUNTIME_DEBUG_LOG(
+        "[REAL] wrap_div: broadcast expand lhs%s rhs%s -> out=[%lld,%lld,%lld,"
+        "%lld]\n",
+        lhs_eq_out ? "(ok)" : "(expanded)", rhs_eq_out ? "(ok)" : "(expanded)",
+        (long long)out_n, (long long)out_c, (long long)out_h, (long long)out_w);
+  } else {
+    RUNTIME_DEBUG_LOG(
+        "[REAL] wrap_div: same-shape out=[%lld,%lld,%lld,%lld], dtype=%s\n",
+        (long long)out_n, (long long)out_c, (long long)out_h, (long long)out_w,
+        hipdnn_ep_datatype_name(data_type));
+  }
+
+  return hip_elementwise_div(stream, lhs_use, rhs_use, output, out_vol,
+                             hip_dtype);
 }

--- a/lib/Runtime/real/elementwise.cpp
+++ b/lib/Runtime/real/elementwise.cpp
@@ -10,10 +10,38 @@
 #include "hip_custom_kernels.h"
 #include "runtime_types.h"
 
+#include <algorithm>
 #include <cstdio>
 #include <functional>
 #include <unordered_map>
 #include <utility>
+#include <vector>
+
+// Map HIPDNN_EP_DATATYPE_* -> hip_dtype_t for custom kernels (e.g. hip_expand
+// used as the broadcast-materialise fallback when MIOpen rejects double-side
+// broadcast).  The two enum systems use different orderings.  Local copy of
+// the helper in cast.cpp -- runtime files are bitcode TUs and cannot share
+// statics without extra plumbing.
+static int hipdnn_to_hip_dtype(int64_t hipdnn_type) {
+  switch (hipdnn_type) {
+  case HIPDNN_EP_DATATYPE_FLOAT:
+    return HIP_DTYPE_FLOAT32;
+  case HIPDNN_EP_DATATYPE_HALF:
+    return HIP_DTYPE_FLOAT16;
+  case HIPDNN_EP_DATATYPE_BFLOAT16:
+    return HIP_DTYPE_BFLOAT16;
+  case HIPDNN_EP_DATATYPE_INT32:
+    return HIP_DTYPE_INT32;
+  case HIPDNN_EP_DATATYPE_INT64:
+    return HIP_DTYPE_INT64;
+  case HIPDNN_EP_DATATYPE_UINT8:
+    return HIP_DTYPE_UINT8;
+  case HIPDNN_EP_DATATYPE_INT8:
+    return HIP_DTYPE_INT8;
+  default:
+    return -1;
+  }
+}
 
 // Explicit mapping from backend-independent HIPDNN_EP_DATATYPE_* enum to
 // MIOpen-specific miopenDataType_t. No static_cast -- our enum values are
@@ -193,12 +221,108 @@ int wrap_miopenOpTensor(RuntimeState *state, void *lhs, void *rhs, void *output,
       },
       state);
   if (!state || !lhs || !rhs || !output) {
-    fprintf(stderr, "wrap_miopenOpTensor: null argument\n");
+    fprintf(stderr,
+            "wrap_miopenOpTensor: null argument (state=%p lhs=%p rhs=%p "
+            "output=%p op=%lld dtype=%lld)\n",
+            (void *)state, lhs, rhs, output, (long long)tensor_op,
+            (long long)data_type);
     return -1;
   }
 
   const char *type_name = hipdnn_ep_datatype_name(data_type);
   const char *op_name = hipdnn_ep_tensor_op_name(tensor_op);
+
+  // Empty-operand identity-copy path.
+  //
+  // ONNX broadcast semantics are undefined when one operand has a dim
+  // that's 0 and the other has the same dim > 1. In practice, model
+  // exporters that emit "empty placeholder + Loop concat accumulator"
+  // patterns produce downstream Add/Sub/Mul/Div ops where the empty
+  // operand is meant as an additive/multiplicative identity (no
+  // contribution). Some exporters' shape inference then sizes the
+  // output OUT to MAX(LHS_dim, RHS_dim), which gives a non-empty OUT
+  // even when one operand is empty. The MIOpen tensor-op API rejects
+  // 0-dim descriptors, so we must handle this here.
+  //
+  // Treatment: if one operand is empty and the other has the same
+  // shape as OUT, copy the non-empty operand into OUT. If both
+  // operands are empty OR OUT itself is empty, the call is a no-op.
+  const bool out_empty = (out_n == 0 || out_c == 0 || out_h == 0 || out_w == 0);
+  const bool lhs_empty = (lhs_n == 0 || lhs_c == 0 || lhs_h == 0 || lhs_w == 0);
+  const bool rhs_empty = (rhs_n == 0 || rhs_c == 0 || rhs_h == 0 || rhs_w == 0);
+  if (out_empty || lhs_empty || rhs_empty) {
+    static int dbg_count = 0;
+    if (dbg_count++ < 4) {
+      fprintf(stderr,
+              "[elementwise-empty] op=%s dtype=%s "
+              "lhs=[%lld,%lld,%lld,%lld]%s "
+              "rhs=[%lld,%lld,%lld,%lld]%s "
+              "out=[%lld,%lld,%lld,%lld]%s\n",
+              op_name, type_name, (long long)lhs_n, (long long)lhs_c,
+              (long long)lhs_h, (long long)lhs_w, lhs_empty ? "(E)" : "",
+              (long long)rhs_n, (long long)rhs_c, (long long)rhs_h,
+              (long long)rhs_w, rhs_empty ? "(E)" : "", (long long)out_n,
+              (long long)out_c, (long long)out_h, (long long)out_w,
+              out_empty ? "(E)" : "");
+    }
+    if (out_empty)
+      return 0;
+    // Pick the non-empty operand whose shape matches OUT.
+    bool lhs_matches_out = !lhs_empty && lhs_n == out_n && lhs_c == out_c &&
+                           lhs_h == out_h && lhs_w == out_w;
+    bool rhs_matches_out = !rhs_empty && rhs_n == out_n && rhs_c == out_c &&
+                           rhs_h == out_h && rhs_w == out_w;
+    if (lhs_matches_out || rhs_matches_out) {
+      size_t elem_size = 0;
+      switch (data_type) {
+      case HIPDNN_EP_DATATYPE_HALF:
+        elem_size = 2;
+        break;
+      case HIPDNN_EP_DATATYPE_FLOAT:
+        elem_size = 4;
+        break;
+      case HIPDNN_EP_DATATYPE_INT32:
+        elem_size = 4;
+        break;
+      case HIPDNN_EP_DATATYPE_INT64:
+        elem_size = 8;
+        break;
+      default:
+        fprintf(
+            stderr,
+            "[elementwise-empty] unsupported dtype %lld for identity-copy\n",
+            (long long)data_type);
+        return -1;
+      }
+      size_t bytes =
+          static_cast<size_t>(out_n) * out_c * out_h * out_w * elem_size;
+      void *src = lhs_matches_out ? lhs : rhs;
+      hipStream_t stream =
+          static_cast<hipStream_t>(hipdnn_ep_state_get_stream(state));
+      hipError_t err =
+          hipMemcpyAsync(output, src, bytes, hipMemcpyDeviceToDevice, stream);
+      if (err != hipSuccess) {
+        fprintf(stderr, "[elementwise-empty] hipMemcpyAsync failed: %s\n",
+                hipGetErrorString(err));
+        return -1;
+      }
+      return 0;
+    }
+    // Neither operand matches OUT — undefined broadcast. Zero-fill OUT
+    // as a safe default (matches CPU treating empty as additive identity
+    // and the other operand contributing nothing meaningful).
+    fprintf(stderr, "[elementwise-empty] no operand matches OUT shape; "
+                    "zero-filling output as a safe default\n");
+    hipStream_t stream =
+        static_cast<hipStream_t>(hipdnn_ep_state_get_stream(state));
+    size_t elem_size = (data_type == HIPDNN_EP_DATATYPE_HALF) ? 2 : 4;
+    size_t bytes =
+        static_cast<size_t>(out_n) * out_c * out_h * out_w * elem_size;
+    hipError_t err = hipMemsetAsync(output, 0, bytes, stream);
+    if (err != hipSuccess)
+      return -1;
+    return 0;
+  }
   RUNTIME_DEBUG_LOG("[REAL] wrap_miopenOpTensor: op=%s, "
                     "lhs=[%lld,%lld,%lld,%lld], "
                     "rhs=[%lld,%lld,%lld,%lld], "
@@ -225,6 +349,115 @@ int wrap_miopenOpTensor(RuntimeState *state, void *lhs, void *rhs, void *output,
     return -1;
   }
 
+  // Integer dtypes (i32/i64/ui8) aren't supported by miopenOpTensor. Vision
+  // encoders run small i64 shape arithmetic via these ops (e.g. multiplying
+  // two i64 scalars to compute a downstream Reshape dim); attention chains
+  // run i32/i64 Min/Max for the seqlens_k = Min(total_seq_len, max_seq_len)
+  // clamp. Route those to a custom HIP kernel that handles same-shape
+  // mul/add/min/max. Broadcasting is materialised below by hip_expand into
+  // a per-state workspace before the flat kernel runs.
+  if (data_type == HIPDNN_EP_DATATYPE_INT64 ||
+      data_type == HIPDNN_EP_DATATYPE_INT32) {
+    if (tensor_op != HIPDNN_EP_TENSOR_OP_MUL &&
+        tensor_op != HIPDNN_EP_TENSOR_OP_ADD &&
+        tensor_op != HIPDNN_EP_TENSOR_OP_MIN &&
+        tensor_op != HIPDNN_EP_TENSOR_OP_MAX) {
+      fprintf(stderr,
+              "wrap_miopenOpTensor: integer fallback only supports "
+              "MUL/ADD/MIN/MAX (got tensor_op=%lld, data_type=%lld)\n",
+              (long long)tensor_op, (long long)data_type);
+      return -1;
+    }
+    void *stream = hipdnn_ep_state_get_stream(state);
+    int hip_dtype = hipdnn_to_hip_dtype(data_type);
+    if (hip_dtype < 0) {
+      fprintf(stderr,
+              "wrap_miopenOpTensor: integer fallback unsupported dtype %lld\n",
+              (long long)data_type);
+      return -1;
+    }
+    const int64_t elem_bytes = hipdnn_ep_datatype_size(data_type);
+    const int64_t out_vol = out_n * out_c * out_h * out_w;
+    const bool lhs_eq_out_ints =
+        (lhs_n == out_n && lhs_c == out_c && lhs_h == out_h && lhs_w == out_w);
+    const bool rhs_eq_out_ints =
+        (rhs_n == out_n && rhs_c == out_c && rhs_h == out_h && rhs_w == out_w);
+    // Materialise broadcasting via hip_expand into the per-state workspace,
+    // then call hip_elementwise on same-shape operands. hip_elementwise is a
+    // flat kernel and cannot broadcast on its own; vision-encoder shape
+    // arithmetic (e.g. multiplying [6,1,1,1] by [1,1,1,1] to drive a Range
+    // step) routinely produces broadcasting integer ops, so the integer path
+    // must mirror the float-side broadcast handling below.
+    void *lhs_use = lhs;
+    void *rhs_use = rhs;
+    void *ws = nullptr;
+    if (!lhs_eq_out_ints || !rhs_eq_out_ints) {
+      // We need workspace for any side(s) that need expansion. At most two
+      // (lhs to ws_a, rhs to ws_b) -- pack both back-to-back in the workspace.
+      const size_t per_side = static_cast<size_t>(out_vol * elem_bytes);
+      const size_t needed =
+          per_side * static_cast<size_t>((!lhs_eq_out_ints ? 1 : 0) +
+                                         (!rhs_eq_out_ints ? 1 : 0));
+      if (hipdnn_ep_state_ensure_workspace(state, needed) != 0) {
+        fprintf(stderr,
+                "wrap_miopenOpTensor: integer fallback workspace ensure failed "
+                "(%zu bytes)\n",
+                needed);
+        return -1;
+      }
+      ws = hipdnn_ep_state_get_workspace(state);
+      uint8_t *ws_byte = static_cast<uint8_t *>(ws);
+      const int64_t in_lhs[4] = {lhs_n, lhs_c, lhs_h, lhs_w};
+      const int64_t in_rhs[4] = {rhs_n, rhs_c, rhs_h, rhs_w};
+      const int64_t out_shape[4] = {out_n, out_c, out_h, out_w};
+      if (!lhs_eq_out_ints) {
+        int rc = hip_expand(stream, lhs, ws_byte, in_lhs, 4, out_shape, 4,
+                            hip_dtype);
+        if (rc != 0) {
+          fprintf(stderr,
+                  "wrap_miopenOpTensor: integer fallback hip_expand(lhs) "
+                  "failed (%d)\n",
+                  rc);
+          return -1;
+        }
+        lhs_use = ws_byte;
+        ws_byte += per_side;
+      }
+      if (!rhs_eq_out_ints) {
+        int rc = hip_expand(stream, rhs, ws_byte, in_rhs, 4, out_shape, 4,
+                            hip_dtype);
+        if (rc != 0) {
+          fprintf(stderr,
+                  "wrap_miopenOpTensor: integer fallback hip_expand(rhs) "
+                  "failed (%d)\n",
+                  rc);
+          return -1;
+        }
+        rhs_use = ws_byte;
+      }
+    }
+    int rc = -1;
+    switch (tensor_op) {
+    case HIPDNN_EP_TENSOR_OP_MUL:
+      rc = hip_elementwise_mul(stream, lhs_use, rhs_use, output, out_vol,
+                               hip_dtype);
+      break;
+    case HIPDNN_EP_TENSOR_OP_ADD:
+      rc = hip_elementwise_add(stream, lhs_use, rhs_use, output, out_vol,
+                               hip_dtype);
+      break;
+    case HIPDNN_EP_TENSOR_OP_MIN:
+      rc = hip_elementwise_min(stream, lhs_use, rhs_use, output, out_vol,
+                               hip_dtype);
+      break;
+    case HIPDNN_EP_TENSOR_OP_MAX:
+      rc = hip_elementwise_max(stream, lhs_use, rhs_use, output, out_vol,
+                               hip_dtype);
+      break;
+    }
+    return rc;
+  }
+
   // MIOpen's miopenOpTensor requires A.shape == C.shape; only B may broadcast
   // (dim==1) into A. Caller-provided lhs/rhs ordering is dictated by the
   // original ONNX graph and is not normalized by the lowering pass, so when
@@ -248,6 +481,83 @@ int wrap_miopenOpTensor(RuntimeState *state, void *lhs, void *rhs, void *output,
     std::swap(lhs_c, rhs_c);
     std::swap(lhs_h, rhs_h);
     std::swap(lhs_w, rhs_w);
+  }
+
+  // True 2-D broadcast: neither lhs nor rhs equals out. The canonical case
+  // is `lhs=[1,1,H,1] * rhs=[1,1,1,W] -> out=[1,1,H,W]` from vision-encoder
+  // mrope tables and similar position-encoding patterns. MIOpen accepts only
+  // single-side broadcast (B may broadcast into A; A must equal C). Expand
+  // the smaller-volume side into the runtime workspace, then call MIOpen
+  // with the expanded side as A. Workspace is single-use within this call
+  // (the next stream op runs after the MIOpen call returns, but the kernel
+  // is queued on the same stream and reads the workspace before any later
+  // user grows it).
+  if (!lhs_eq_out && !rhs_eq_out) {
+    const int64_t lhs_vol = lhs_n * lhs_c * lhs_h * lhs_w;
+    const int64_t rhs_vol = rhs_n * rhs_c * rhs_h * rhs_w;
+    const bool expand_lhs = (lhs_vol <= rhs_vol);
+    const int64_t elem_bytes = hipdnn_ep_datatype_size(data_type);
+    const int64_t out_vol = out_n * out_c * out_h * out_w;
+    const size_t needed = static_cast<size_t>(out_vol * elem_bytes);
+    if (hipdnn_ep_state_ensure_workspace(state, needed) != 0) {
+      fprintf(stderr,
+              "wrap_miopenOpTensor: failed to ensure workspace %zu bytes for "
+              "broadcast expand\n",
+              needed);
+      return -1;
+    }
+    void *ws = hipdnn_ep_state_get_workspace(state);
+    void *stream = hipdnn_ep_state_get_stream(state);
+
+    const int64_t in_shape[4] = {
+        expand_lhs ? lhs_n : rhs_n, expand_lhs ? lhs_c : rhs_c,
+        expand_lhs ? lhs_h : rhs_h, expand_lhs ? lhs_w : rhs_w};
+    const int64_t out_shape[4] = {out_n, out_c, out_h, out_w};
+    int hip_dtype = hipdnn_to_hip_dtype(data_type);
+    if (hip_dtype < 0) {
+      fprintf(stderr,
+              "wrap_miopenOpTensor: unsupported data_type %lld for expand\n",
+              (long long)data_type);
+      return -1;
+    }
+    RUNTIME_DEBUG_LOG(
+        "[REAL] wrap_miopenOpTensor: 2-D broadcast detected, expanding %s "
+        "side [%lld,%lld,%lld,%lld] to [%lld,%lld,%lld,%lld] into workspace\n",
+        expand_lhs ? "lhs" : "rhs", (long long)in_shape[0],
+        (long long)in_shape[1], (long long)in_shape[2], (long long)in_shape[3],
+        (long long)out_n, (long long)out_c, (long long)out_h, (long long)out_w);
+    int rc = hip_expand(stream, expand_lhs ? lhs : rhs, ws, in_shape, 4,
+                        out_shape, 4, hip_dtype);
+    if (rc != 0) {
+      fprintf(stderr, "wrap_miopenOpTensor: hip_expand failed (%d)\n", rc);
+      return -1;
+    }
+
+    if (expand_lhs) {
+      lhs = ws;
+      lhs_n = out_n;
+      lhs_c = out_c;
+      lhs_h = out_h;
+      lhs_w = out_w;
+    } else {
+      // After expanding rhs to out shape, swap so the expanded side lands on
+      // A (lhs); the original lhs becomes the broadcasting B side, which
+      // MIOpen handles natively for its 1-axes.
+      void *expanded = ws;
+      void *orig_lhs = lhs;
+      const int64_t orig_lhs_n = lhs_n, orig_lhs_c = lhs_c, orig_lhs_h = lhs_h,
+                    orig_lhs_w = lhs_w;
+      lhs = expanded;
+      lhs_n = out_n;
+      lhs_c = out_c;
+      lhs_h = out_h;
+      lhs_w = out_w;
+      rhs = orig_lhs;
+      rhs_n = orig_lhs_n;
+      rhs_c = orig_lhs_c;
+      rhs_h = orig_lhs_h;
+      rhs_w = orig_lhs_w;
+    }
   }
 
   OpTensorCacheKey key{lhs_n, lhs_c, lhs_h, lhs_w, rhs_n, rhs_c,    rhs_h,
@@ -280,19 +590,36 @@ int wrap_miopenOpTensor(RuntimeState *state, void *lhs, void *rhs, void *output,
 // Element-wise Subtraction via Custom HIP Kernel
 //===----------------------------------------------------------------------===//
 //
-// For types unsupported by MIOpen (e.g. int64), dispatches to
-// hip_elementwise_sub from the custom kernels library. The caller passes
-// element_size_bytes; we map it to the corresponding hip_dtype_t.
-//===----------------------------------------------------------------------===//
+// MIOpen has no subtract op; dispatches to hip_elementwise_sub after optional
+// hip_expand broadcast materialisation (4D shapes, rank <= 4).
+
+static int sub_hipdnn_to_hip_dtype(int64_t hipdnn_type) {
+  switch (hipdnn_type) {
+  case HIPDNN_EP_DATATYPE_HALF:
+    return HIP_DTYPE_FLOAT16;
+  case HIPDNN_EP_DATATYPE_FLOAT:
+    return HIP_DTYPE_FLOAT32;
+  case HIPDNN_EP_DATATYPE_INT32:
+    return HIP_DTYPE_INT32;
+  case HIPDNN_EP_DATATYPE_INT64:
+    return HIP_DTYPE_INT64;
+  default:
+    return -1;
+  }
+}
 
 int wrap_elementwise_sub(RuntimeState *state, void *lhs, void *rhs,
-                         void *output, int64_t num_elements,
-                         int64_t element_size_bytes) {
+                         void *output, int64_t lhs_n, int64_t lhs_c,
+                         int64_t lhs_h, int64_t lhs_w, int64_t rhs_n,
+                         int64_t rhs_c, int64_t rhs_h, int64_t rhs_w,
+                         int64_t out_n, int64_t out_c, int64_t out_h,
+                         int64_t out_w, int64_t data_type) {
   OP_PROFILE(
       "sub",
       [&] {
         char b[64];
-        snprintf(b, sizeof(b), "n=%lld", (long long)num_elements);
+        snprintf(b, sizeof(b), "%lldx%lldx%lldx%lld", (long long)out_n,
+                 (long long)out_c, (long long)out_h, (long long)out_w);
         return std::string(b);
       },
       state);
@@ -301,25 +628,80 @@ int wrap_elementwise_sub(RuntimeState *state, void *lhs, void *rhs,
     return -1;
   }
 
-  void *stream = hipdnn_ep_state_get_stream(state);
+  const int64_t out_vol = out_n * out_c * out_h * out_w;
+  if (out_vol <= 0)
+    return 0;
 
-  int hip_dtype;
-  switch (element_size_bytes) {
-  case 8:
-    hip_dtype = HIP_DTYPE_INT64;
-    break;
-  default:
-    RUNTIME_DEBUG_LOG(
-        "[REAL] wrap_elementwise_sub: unsupported element_size=%lld, "
-        "only int64 (8 bytes) is currently supported via custom kernel\n",
-        (long long)element_size_bytes);
+  int hip_dtype = sub_hipdnn_to_hip_dtype(data_type);
+  if (hip_dtype < 0) {
+    fprintf(stderr, "wrap_elementwise_sub: unsupported data_type=%s(%lld)\n",
+            hipdnn_ep_datatype_name(data_type), (long long)data_type);
     return -1;
   }
 
-  RUNTIME_DEBUG_LOG(
-      "[REAL] wrap_elementwise_sub: num_elements=%lld, "
-      "element_size=%lld, dtype=%d -> calling hip_elementwise_sub\n",
-      (long long)num_elements, (long long)element_size_bytes, hip_dtype);
+  void *stream = hipdnn_ep_state_get_stream(state);
 
-  return hip_elementwise_sub(stream, lhs, rhs, output, num_elements, hip_dtype);
+  const bool lhs_eq_out =
+      (lhs_n == out_n && lhs_c == out_c && lhs_h == out_h && lhs_w == out_w);
+  const bool rhs_eq_out =
+      (rhs_n == out_n && rhs_c == out_c && rhs_h == out_h && rhs_w == out_w);
+
+  void *lhs_use = lhs;
+  void *rhs_use = rhs;
+
+  if (!lhs_eq_out || !rhs_eq_out) {
+    const int64_t elem_bytes = hipdnn_ep_datatype_size(data_type);
+    const size_t per_side = static_cast<size_t>(out_vol * elem_bytes);
+    const size_t needed = per_side * static_cast<size_t>((!lhs_eq_out ? 1 : 0) +
+                                                         (!rhs_eq_out ? 1 : 0));
+    if (hipdnn_ep_state_ensure_workspace(state, needed) != 0) {
+      fprintf(stderr,
+              "wrap_elementwise_sub: workspace ensure failed (%zu bytes)\n",
+              needed);
+      return -1;
+    }
+    void *ws = hipdnn_ep_state_get_workspace(state);
+    uint8_t *ws_byte = static_cast<uint8_t *>(ws);
+    const int64_t out_shape[4] = {out_n, out_c, out_h, out_w};
+
+    if (!lhs_eq_out) {
+      const int64_t in_lhs[4] = {lhs_n, lhs_c, lhs_h, lhs_w};
+      int rc =
+          hip_expand(stream, lhs, ws_byte, in_lhs, 4, out_shape, 4, hip_dtype);
+      if (rc != 0) {
+        fprintf(stderr, "wrap_elementwise_sub: hip_expand(lhs) failed (%d)\n",
+                rc);
+        return -1;
+      }
+      lhs_use = ws_byte;
+      ws_byte += per_side;
+    }
+    if (!rhs_eq_out) {
+      const int64_t in_rhs[4] = {rhs_n, rhs_c, rhs_h, rhs_w};
+      int rc =
+          hip_expand(stream, rhs, ws_byte, in_rhs, 4, out_shape, 4, hip_dtype);
+      if (rc != 0) {
+        fprintf(stderr, "wrap_elementwise_sub: hip_expand(rhs) failed (%d)\n",
+                rc);
+        return -1;
+      }
+      rhs_use = ws_byte;
+    }
+
+    RUNTIME_DEBUG_LOG(
+        "[REAL] wrap_elementwise_sub: broadcast expand lhs%s rhs%s -> "
+        "out=[%lld,%lld,%lld,%lld], dtype=%s\n",
+        lhs_eq_out ? "(ok)" : "(expanded)", rhs_eq_out ? "(ok)" : "(expanded)",
+        (long long)out_n, (long long)out_c, (long long)out_h, (long long)out_w,
+        hipdnn_ep_datatype_name(data_type));
+  } else {
+    RUNTIME_DEBUG_LOG(
+        "[REAL] wrap_elementwise_sub: same-shape out=[%lld,%lld,%lld,%lld], "
+        "dtype=%s\n",
+        (long long)out_n, (long long)out_c, (long long)out_h, (long long)out_w,
+        hipdnn_ep_datatype_name(data_type));
+  }
+
+  return hip_elementwise_sub(stream, lhs_use, rhs_use, output, out_vol,
+                             hip_dtype);
 }

--- a/lib/Runtime/real/equal.cpp
+++ b/lib/Runtime/real/equal.cpp
@@ -33,12 +33,15 @@ static int equal_hipdnn_to_hip_dtype(int64_t hipdnn_type) {
 }
 
 int wrap_equal(RuntimeState *state, void *a, void *b, void *output,
-               int64_t num_elements, int64_t data_type) {
+               int64_t a_num_elements, int64_t b_num_elements,
+               int64_t out_num_elements, int64_t data_type) {
   OP_PROFILE(
       "equal",
       [&] {
-        char buf[48];
-        snprintf(buf, sizeof(buf), "%lld:%s", (long long)num_elements,
+        char buf[80];
+        snprintf(buf, sizeof(buf), "a=%lld:b=%lld:out=%lld:%s",
+                 (long long)a_num_elements, (long long)b_num_elements,
+                 (long long)out_num_elements,
                  hipdnn_ep_datatype_name(data_type));
         return std::string(buf);
       },
@@ -48,7 +51,7 @@ int wrap_equal(RuntimeState *state, void *a, void *b, void *output,
     RUNTIME_DEBUG_LOG("[REAL] wrap_equal: null argument\n");
     return -1;
   }
-  if (num_elements <= 0) {
+  if (out_num_elements <= 0) {
     return 0;
   }
 
@@ -61,9 +64,33 @@ int wrap_equal(RuntimeState *state, void *a, void *b, void *output,
     return -1;
   }
 
+  // Supported broadcast modes:
+  //   * same-shape: a_n == b_n == out_n
+  //   * scalar-rhs broadcast: b_n == 1, a_n == out_n
+  //   * scalar-lhs broadcast: a_n == 1, b_n == out_n
+  // Anything more general (rank-aware NumPy broadcast) must be materialised
+  // upstream via Expand and is rejected here so the kernel never reads OOB.
+  if (a_num_elements != out_num_elements && a_num_elements != 1) {
+    fprintf(stderr,
+            "[REAL] wrap_equal: unsupported broadcast: a_num=%lld out=%lld "
+            "(only scalar a (1) or full a (out) are supported)\n",
+            (long long)a_num_elements, (long long)out_num_elements);
+    return -1;
+  }
+  if (b_num_elements != out_num_elements && b_num_elements != 1) {
+    fprintf(stderr,
+            "[REAL] wrap_equal: unsupported broadcast: b_num=%lld out=%lld "
+            "(only scalar b (1) or full b (out) are supported)\n",
+            (long long)b_num_elements, (long long)out_num_elements);
+    return -1;
+  }
+
   void *stream = hipdnn_ep_state_get_stream(state);
   RUNTIME_DEBUG_LOG(
-      "[REAL] wrap_equal: num=%lld, input_type=%s -> hip_elementwise_equal\n",
-      (long long)num_elements, hipdnn_ep_datatype_name(data_type));
-  return hip_elementwise_equal(stream, a, b, output, num_elements, hip_dtype);
+      "[REAL] wrap_equal: a_num=%lld, b_num=%lld, out=%lld, input_type=%s "
+      "-> hip_elementwise_equal\n",
+      (long long)a_num_elements, (long long)b_num_elements,
+      (long long)out_num_elements, hipdnn_ep_datatype_name(data_type));
+  return hip_elementwise_equal(stream, a, b, output, a_num_elements,
+                               b_num_elements, out_num_elements, hip_dtype);
 }

--- a/lib/Runtime/real/expand.cpp
+++ b/lib/Runtime/real/expand.cpp
@@ -29,6 +29,10 @@ static int expand_hipdnn_to_hip_dtype(int64_t hipdnn_type) {
     return HIP_DTYPE_INT32;
   case HIPDNN_EP_DATATYPE_INT64:
     return HIP_DTYPE_INT64;
+  // Equal→Expand on embedding masks uses ui8; broadcast is bitwise-identical
+  // to i8 (no arithmetic), so reuse the int8 kernel instantiation.
+  case HIPDNN_EP_DATATYPE_UINT8:
+    return HIP_DTYPE_INT8;
   default:
     return -1;
   }

--- a/lib/Runtime/real/gather.cpp
+++ b/lib/Runtime/real/gather.cpp
@@ -13,6 +13,7 @@
 int wrap_gather(RuntimeState *state, void *data, void *indices, void *output,
                 int64_t axis, int64_t data_num_elements,
                 int64_t indices_num_elements, int64_t output_num_elements,
+                int64_t axis_size, int64_t inner_size,
                 int64_t element_size_bytes) {
   OP_PROFILE(
       "gather",
@@ -31,12 +32,14 @@ int wrap_gather(RuntimeState *state, void *data, void *indices, void *output,
 
   RUNTIME_DEBUG_LOG(
       "[REAL] wrap_gather: axis=%lld, data_num=%lld, indices_num=%lld, "
-      "output_num=%lld, elem_size=%lld -> calling hip_gather\n",
+      "output_num=%lld, axis_size=%lld, inner=%lld, elem_size=%lld -> "
+      "calling hip_gather\n",
       (long long)axis, (long long)data_num_elements,
       (long long)indices_num_elements, (long long)output_num_elements,
+      (long long)axis_size, (long long)inner_size,
       (long long)element_size_bytes);
 
   return hip_gather(stream, data, indices, output, axis, data_num_elements,
-                    indices_num_elements, output_num_elements,
-                    static_cast<int>(element_size_bytes));
+                    indices_num_elements, output_num_elements, axis_size,
+                    inner_size, static_cast<int>(element_size_bytes));
 }

--- a/lib/Runtime/real/hip.cpp
+++ b/lib/Runtime/real/hip.cpp
@@ -31,6 +31,36 @@ int wrap_hipFree(void *ptr) {
   return 0;
 }
 
+// MemoryLowering.cpp emits llvm.call @hip_device_malloc(size) -> ptr for
+// hip.alloc (and the fallback memref.alloc path).  Static-shape models pool
+// every alloc into the runtime byte pool so this entrypoint is never hit;
+// PR #254 first exercises it on dynamic-Range models (alloc(seq*batch) for
+// position_ids), and lld-link fails with "undefined symbol: hip_device_free"
+// at the EP fallback point if the runtime doesn't ship these symbols.
+//
+// Signature: (i64) -> ptr.  Returns nullptr on failure (callers check), no
+// HIP_CHECK that would terminate the host process from inside the model DLL.
+extern "C" void *hip_device_malloc(int64_t size) {
+  void *ptr = nullptr;
+  hipError_t err = hipMalloc(&ptr, size);
+  if (err != hipSuccess) {
+    fprintf(stderr, "hip_device_malloc(%lld) failed: %s\n", (long long)size,
+            hipGetErrorString(err));
+    return nullptr;
+  }
+  return ptr;
+}
+
+extern "C" void hip_device_free(void *ptr) {
+  if (!ptr)
+    return;
+  hipError_t err = hipFree(ptr);
+  if (err != hipSuccess) {
+    fprintf(stderr, "hip_device_free(%p) failed: %s\n", ptr,
+            hipGetErrorString(err));
+  }
+}
+
 int wrap_hipMemcpyH2D(void *dst, const void *src, int64_t size, void *stream) {
   HIP_CHECK(hipMemcpyAsync(dst, src, size, hipMemcpyHostToDevice,
                            static_cast<hipStream_t>(stream)));
@@ -46,4 +76,173 @@ int wrap_hipMemcpyD2H(void *dst, const void *src, int64_t size, void *stream) {
 int wrap_hipStreamSynchronize(void *stream) {
   HIP_CHECK(hipStreamSynchronize(static_cast<hipStream_t>(stream)));
   return 0;
+}
+
+// MLIR's standard memref dialect lowering for `memref.copy` calls a runtime
+// helper named `memrefCopy(elemSize, srcDescPtr, dstDescPtr)`. The MemRef
+// descriptors are ABI-stable structs: { allocPtr, alignedPtr, offset,
+// sizes[rank], strides[rank] }. For copying a rank-N strided memref, the
+// helper must walk the index space using src/dst strides — a flat
+// hipMemcpyAsync on `nelems * elemSize` bytes is only correct when both
+// the source and destination are row-major contiguous.
+//
+// The bufferized `tensor.insert_slice` chains that Concat / Slice / Tile
+// produce regularly emit `memref.copy` where the destination is a
+// strided `memref.subview` of an output buffer (e.g. Concat axis=-1 on
+// rank-2 produces a subview with strides `[stride_outer, 1]` and the
+// outer stride > the source's outer stride). A flat memcpy treats both
+// sides as packed and writes the wrong bytes — the second insert_slice's
+// 1024-byte source clobbers most of the first one's data and the
+// resulting layout is shifted by one element relative to what each
+// strided slice is supposed to cover. Symptom on Qwen 3.5 vision: a
+// Reshape→Unsqueeze→Concat(axis=-1)→Expand→Tile chain that should
+// interleave two index streams ends up returning only the second
+// stream's values, shifted by one.
+//
+// The strategy below has three tiers:
+//   1. Fast path (both sides fully contiguous): one hipMemcpyAsync.
+//   2. Single outer non-contiguous dim (the canonical Concat-on-last-axis
+//      pattern): one hipMemcpy2DAsync using GPU DMA, no kernel launch.
+//   3. General case (outer rank >= 2): walk the outer index space and
+//      issue one hipMemcpyAsync per row. Per-row copies are correct for
+//      any rank and stride pattern; if a future hotspot lands here we
+//      can replace this with a HIP kernel.
+struct UnrankedMemRefHeader {
+  int64_t rank;
+  void *descPtr;
+};
+struct StridedMemRefDescriptor {
+  void *allocPtr;
+  void *alignedPtr;
+  int64_t offset;
+  // sizesAndStrides[0..rank-1] are the sizes, sizesAndStrides[rank..2*rank-1]
+  // are the strides (in elements, not bytes). This layout matches MLIR's
+  // standard ranked memref descriptor lowering.
+  int64_t sizesAndStrides[];
+};
+extern "C" void memrefCopy(int64_t elemSize, UnrankedMemRefHeader *src,
+                           UnrankedMemRefHeader *dst) {
+  if (!src || !dst || !src->descPtr || !dst->descPtr)
+    return;
+  auto *sd = static_cast<StridedMemRefDescriptor *>(src->descPtr);
+  auto *dd = static_cast<StridedMemRefDescriptor *>(dst->descPtr);
+  int64_t rank = src->rank;
+
+  const int64_t *srcSizes = sd->sizesAndStrides;
+  const int64_t *srcStrides = sd->sizesAndStrides + rank;
+  const int64_t *dstSizes = dd->sizesAndStrides;
+  const int64_t *dstStrides = dd->sizesAndStrides + rank;
+
+  // Element-aligned base pointers (alignedPtr + offset * elemSize).
+  char *srcBase = static_cast<char *>(sd->alignedPtr) + sd->offset * elemSize;
+  char *dstBase = static_cast<char *>(dd->alignedPtr) + dd->offset * elemSize;
+
+  // Rank-0: a single element. No strides to honour.
+  if (rank == 0) {
+    hipError_t err =
+        hipMemcpyAsync(dstBase, srcBase, elemSize, hipMemcpyDeviceToDevice, 0);
+    if (err != hipSuccess) {
+      fprintf(stderr, "memrefCopy(rank-0) failed: %s\n",
+              hipGetErrorString(err));
+    }
+    return;
+  }
+
+  // Bail on any empty axis (memref of size 0) — nothing to copy.
+  for (int64_t i = 0; i < rank; ++i) {
+    if (srcSizes[i] == 0)
+      return;
+  }
+
+  // Find the longest contiguous suffix [rowStart..rank-1] where the strides
+  // of BOTH src and dst match the canonical row-major layout (i.e. the
+  // suffix can be flat-copied as one chunk per "row"). Iterate from the
+  // innermost dim outward, accumulating the expected stride as the running
+  // product of inner sizes. As soon as either side's stride disagrees with
+  // its expected value the suffix ends.
+  int64_t rowStart = rank;
+  int64_t expectedSrc = 1;
+  int64_t expectedDst = 1;
+  for (int64_t i = rank - 1; i >= 0; --i) {
+    if (srcStrides[i] != expectedSrc || dstStrides[i] != expectedDst)
+      break;
+    expectedSrc *= srcSizes[i];
+    expectedDst *= dstSizes[i];
+    rowStart = i;
+  }
+
+  // Bytes contained in one contiguous suffix "row".
+  int64_t rowElems = 1;
+  for (int64_t i = rowStart; i < rank; ++i)
+    rowElems *= srcSizes[i];
+  int64_t rowBytes = rowElems * elemSize;
+
+  // Tier 1: fully contiguous on both sides — one flat memcpy.
+  if (rowStart == 0) {
+    hipError_t err =
+        hipMemcpyAsync(dstBase, srcBase, rowBytes, hipMemcpyDeviceToDevice, 0);
+    if (err != hipSuccess) {
+      fprintf(stderr, "memrefCopy(%lld bytes contig) failed: %s\n",
+              static_cast<long long>(rowBytes), hipGetErrorString(err));
+    }
+    return;
+  }
+
+  // Tier 2: exactly one outer dim — hipMemcpy2DAsync handles strided
+  // destinations natively. This is the canonical Concat-axis-last on
+  // rank-2 (and on higher ranks when only the concat axis breaks
+  // contiguity) — the GPU DMA engine performs the strided copy with no
+  // kernel launch overhead.
+  if (rowStart == 1) {
+    int64_t height = srcSizes[0];
+    int64_t srcPitch = srcStrides[0] * elemSize;
+    int64_t dstPitch = dstStrides[0] * elemSize;
+    hipError_t err =
+        hipMemcpy2DAsync(dstBase, dstPitch, srcBase, srcPitch, rowBytes, height,
+                         hipMemcpyDeviceToDevice, 0);
+    if (err != hipSuccess) {
+      fprintf(stderr, "memrefCopy(rank-2 strided) failed: %s\n",
+              hipGetErrorString(err));
+    }
+    return;
+  }
+
+  // Tier 3: outer rank >= 2 — walk the outer index space and issue one
+  // hipMemcpyAsync per contiguous row. This is correct for any rank and
+  // stride pattern. Max rank is bounded by MLIR's descriptor layout; 12
+  // is comfortably above anything we currently generate.
+  constexpr int64_t kMaxRank = 12;
+  if (rank > kMaxRank) {
+    fprintf(stderr, "memrefCopy: rank %lld exceeds supported maximum %lld\n",
+            static_cast<long long>(rank), static_cast<long long>(kMaxRank));
+    return;
+  }
+
+  int64_t outerRank = rowStart;
+  int64_t idx[kMaxRank] = {};
+  int64_t outerTotal = 1;
+  for (int64_t i = 0; i < outerRank; ++i)
+    outerTotal *= srcSizes[i];
+
+  for (int64_t r = 0; r < outerTotal; ++r) {
+    int64_t srcByteOff = 0;
+    int64_t dstByteOff = 0;
+    for (int64_t i = 0; i < outerRank; ++i) {
+      srcByteOff += idx[i] * srcStrides[i] * elemSize;
+      dstByteOff += idx[i] * dstStrides[i] * elemSize;
+    }
+    hipError_t err = hipMemcpyAsync(dstBase + dstByteOff, srcBase + srcByteOff,
+                                    rowBytes, hipMemcpyDeviceToDevice, 0);
+    if (err != hipSuccess) {
+      fprintf(stderr, "memrefCopy(strided row) failed: %s\n",
+              hipGetErrorString(err));
+      return;
+    }
+    // Increment the outer multi-dim index (least-significant axis first).
+    for (int64_t i = outerRank - 1; i >= 0; --i) {
+      if (++idx[i] < srcSizes[i])
+        break;
+      idx[i] = 0;
+    }
+  }
 }

--- a/lib/Runtime/real/matmul.cpp
+++ b/lib/Runtime/real/matmul.cpp
@@ -43,9 +43,22 @@ static bool autotune_enabled() {
 
 struct MatmulCacheKey {
   int64_t M, N, K, batch_count, elem_size;
+  // hipBLASLt's STRIDED_BATCH_OFFSET on layA, in elements. Two distinct
+  // values reach this site at the same (M,N,K,batch,elem_size):
+  //   * 0   — B is a broadcast weight (rank-2 [K,N], or rank-N
+  //           [1,...,1,K,N] whose leading-dim product is 1).
+  //   * K*N — B is per-batch (leading-dim product > 1; the buffer holds
+  //           multiple [K,N] matrices laid out contiguously).
+  // Part of the cache key because the layout descriptor is parameterised
+  // by the stride: mixing the two would silently route one path through
+  // the other's stride and read past the end of a broadcast weight buffer.
+  // Keyed on the actual int stride (not a 0/1 bool) so any future site
+  // that legitimately uses a stride other than {0, K*N} also gets its
+  // own cache entry rather than aliasing one of these two.
+  int64_t b_batch_stride;
   bool operator==(const MatmulCacheKey &o) const {
     return M == o.M && N == o.N && K == o.K && batch_count == o.batch_count &&
-           elem_size == o.elem_size;
+           elem_size == o.elem_size && b_batch_stride == o.b_batch_stride;
   }
 };
 
@@ -57,6 +70,7 @@ struct MatmulCacheKeyHash {
     hash_combine_val(h, k.K);
     hash_combine_val(h, k.batch_count);
     hash_combine_val(h, k.elem_size);
+    hash_combine_val(h, k.b_batch_stride);
     return h;
   }
 };
@@ -126,7 +140,19 @@ static MatmulCacheEntry *queryOrCreateMatmul(hipblasLtHandle_t handle,
 
   if (key.batch_count > 1) {
     int64_t bc = key.batch_count;
-    int64_t sA = K * N, sB = M * K, sC = M * N;
+    // layA → user's B. The stride is whatever the compiler computed —
+    // 0 for broadcast B (rank-2 [K,N] or rank-N [1,...,1,K,N]), K*N for
+    // per-batch B (rank-N with leading-dim product > 1). Setting sA = K*N
+    // for a broadcast weight reads K*N elements PAST the end of the
+    // buffer on batch 1+ and feeds garbage into the GEMM — typical symptom
+    // on vision models is image-0 correct, image-1+ NaN (the OOB read
+    // often lands in a fp16-NaN pattern from adjacent pool slots /
+    // constants). Mis-setting sA = 0 for a per-batch B does the opposite:
+    // every batch reads matrix 0 instead of its own.
+    // layB → user's A and layC → output are always per-batch (the BATCH
+    // partition comes from A's leading dim by construction).
+    int64_t sA = key.b_batch_stride;
+    int64_t sB = M * K, sC = M * N;
     MATMUL_CACHE_CHECK(hipblasLtMatrixLayoutSetAttribute(
         entry.layA, HIPBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &bc, sizeof(bc)));
     MATMUL_CACHE_CHECK(hipblasLtMatrixLayoutSetAttribute(
@@ -350,7 +376,8 @@ static void autotuneMatmul(hipblasLtHandle_t handle, hipStream_t stream,
 
 int wrap_hipblasLtMatmul(RuntimeState *state, const void *A, const void *B,
                          void *output, int64_t M, int64_t N, int64_t K,
-                         int64_t batch_count, int64_t elem_size) {
+                         int64_t batch_count, int64_t elem_size,
+                         int64_t b_batch_stride) {
   OP_PROFILE(
       "matmul",
       [&] {
@@ -383,13 +410,14 @@ int wrap_hipblasLtMatmul(RuntimeState *state, const void *A, const void *B,
 
   const char *type_name = (elem_size == 2) ? "f16" : "f32";
   RUNTIME_DEBUG_LOG("[REAL] wrap_hipblasLtMatmul: M=%lld, N=%lld, K=%lld, "
-                    "batch=%lld, elem_size=%lld (%s), "
+                    "batch=%lld, b_batch_stride=%lld, elem_size=%lld (%s), "
                     "total_bytes=%lld\n",
                     (long long)M, (long long)N, (long long)K,
-                    (long long)batch_count, (long long)elem_size, type_name,
+                    (long long)batch_count, (long long)b_batch_stride,
+                    (long long)elem_size, type_name,
                     (long long)(batch_count * M * N * elem_size));
 
-  MatmulCacheKey key{M, N, K, batch_count, elem_size};
+  MatmulCacheKey key{M, N, K, batch_count, elem_size, b_batch_stride};
   MatmulCacheEntry *cached = queryOrCreateMatmul(handle, key);
   if (!cached) {
     fprintf(stderr,

--- a/lib/Runtime/real/miopen.cpp
+++ b/lib/Runtime/real/miopen.cpp
@@ -98,28 +98,74 @@
 //
 // BENEFIT: Eliminates malloc/free from hot path.
 
+// Map HIPDNN_EP_DATATYPE_* to miopenDataType_t for the conv tensor
+// descriptors. Mirrors hipdnn_ep_to_miopen_type in elementwise.cpp /
+// activation.cpp — copy kept local so this TU has no link-time dependency on
+// those siblings (each runtime .cpp is compiled to its own bitcode and the
+// shared bitcode link only resolves wrap_* entry points).
+static miopenDataType_t conv_to_miopen_type(int64_t data_type, bool &ok) {
+  ok = true;
+  switch (data_type) {
+  case HIPDNN_EP_DATATYPE_FLOAT:
+    return miopenFloat;
+  case HIPDNN_EP_DATATYPE_HALF:
+    return miopenHalf;
+  case HIPDNN_EP_DATATYPE_BFLOAT16:
+    return miopenBFloat16;
+  default:
+    ok = false;
+    return miopenFloat;
+  }
+}
+
 // MIOpen convolution forward implementation
-// Follows opaque RuntimeState pattern - extracts handle/stream from state
+// Follows opaque RuntimeState pattern - extracts handle/stream from state.
+//
+// `data_type` is a HIPDNN_EP_DATATYPE_* enum value applied uniformly to the
+// input, weights, and output tensor descriptors. All three buffers MUST share
+// the same element type — MIOpen's miopenConvolutionForward does not support
+// mixed-precision descriptors. This matches the host-side ConvConversion
+// invariant that all three operands use `resultType.getElementType()`.
+//
+// Historical note: prior to the data_type parameter the descriptors were
+// hardcoded to miopenFloat (fp32), which silently passed wrong strides to
+// MIOpen when the actual buffers were fp16 (e.g. SigLIP / ViT patch
+// embedding). MIOpen then read out-of-bounds bytes as the second-half stride
+// for every row, producing NaN/Inf at fp16-max in the output and cascading
+// NaN through the rest of the network.
 int wrap_miopenConvolutionForward(
     RuntimeState *state, const void *input, int64_t input_n, int64_t input_c,
     int64_t input_h, int64_t input_w, const void *weights, int64_t weights_k,
     const void *bias, void *output, int64_t output_h, int64_t output_w,
     int64_t kernel_h, int64_t kernel_w, int64_t stride_h, int64_t stride_w,
     int64_t pad_top, int64_t pad_left, int64_t pad_bottom, int64_t pad_right,
-    int64_t dilation_h, int64_t dilation_w, int64_t group) {
+    int64_t dilation_h, int64_t dilation_w, int64_t group, int64_t data_type) {
   OP_PROFILE(
       "conv",
       [&] {
-        char b[64];
-        snprintf(b, sizeof(b), "%lldx%lldx%lldx%lld,k=%lldx%lldx%lld",
+        char b[80];
+        const char *dt = (data_type == HIPDNN_EP_DATATYPE_HALF)       ? "f16"
+                         : (data_type == HIPDNN_EP_DATATYPE_BFLOAT16) ? "bf16"
+                                                                      : "f32";
+        snprintf(b, sizeof(b), "%lldx%lldx%lldx%lld,k=%lldx%lldx%lld,%s",
                  (long long)input_n, (long long)input_c, (long long)input_h,
                  (long long)input_w, (long long)weights_k, (long long)kernel_h,
-                 (long long)kernel_w);
+                 (long long)kernel_w, dt);
         return std::string(b);
       },
       state);
   if (!state || !input || !weights || !output) {
     fprintf(stderr, "Invalid arguments to wrap_miopenConvolutionForward\n");
+    return -1;
+  }
+
+  bool dt_ok;
+  miopenDataType_t miopen_dt = conv_to_miopen_type(data_type, dt_ok);
+  if (!dt_ok) {
+    fprintf(
+        stderr,
+        "[REAL] wrap_miopenConvolutionForward: unsupported data_type %lld\n",
+        (long long)data_type);
     return -1;
   }
 
@@ -151,22 +197,24 @@ int wrap_miopenConvolutionForward(
   MIOPEN_CHECK(miopenCreateTensorDescriptor(&weights_desc));
   MIOPEN_CHECK(miopenCreateTensorDescriptor(&output_desc));
 
-  // Set tensor descriptors with explicit NCHW layout (float32).
+  // Set tensor descriptors with explicit NCHW layout. The dtype is taken
+  // from the caller (data_type) — the previous hardcoded `miopenFloat`
+  // produced silent fp16-stride-as-fp32 corruption on fp16 models.
   // miopenSet4dTensorDescriptor leaves layout as UNKNOWN which triggers
   // warnings in MIOpen 7.12+.
   {
     int in_dims[] = {(int)input_n, (int)input_c, (int)input_h, (int)input_w};
     MIOPEN_CHECK(miopenSetNdTensorDescriptorWithLayout(
-        input_desc, miopenFloat, miopenTensorNCHW, in_dims, 4));
+        input_desc, miopen_dt, miopenTensorNCHW, in_dims, 4));
 
     int w_dims[] = {(int)weights_k, (int)input_c, (int)kernel_h, (int)kernel_w};
     MIOPEN_CHECK(miopenSetNdTensorDescriptorWithLayout(
-        weights_desc, miopenFloat, miopenTensorNCHW, w_dims, 4));
+        weights_desc, miopen_dt, miopenTensorNCHW, w_dims, 4));
 
     int out_dims[] = {(int)input_n, (int)weights_k, (int)output_h,
                       (int)output_w};
     MIOPEN_CHECK(miopenSetNdTensorDescriptorWithLayout(
-        output_desc, miopenFloat, miopenTensorNCHW, out_dims, 4));
+        output_desc, miopen_dt, miopenTensorNCHW, out_dims, 4));
   }
 
   // Create convolution descriptor
@@ -223,6 +271,55 @@ int wrap_miopenConvolutionForward(
   MIOPEN_CHECK(miopenConvolutionForward(
       miopen_handle, &alpha, input_desc, input, weights_desc, weights,
       conv_desc, algo, &beta, output_desc, output, workspace, workspace_size));
+
+  // Apply bias if provided. ONNX Conv carries an optional [K]-shaped bias
+  // term that gets broadcast-added to the [N,K,H,W] output. MIOpen's
+  // miopenConvolutionForward does NOT add bias and miopenConvolutionForwardBias
+  // restricts alpha/beta to alpha=1,beta=0 (i.e. it *overwrites* y with the
+  // bias, not the y+=bias you'd expect from the name). Use miopenOpTensor
+  // instead, which supports proper broadcast (bias desc shape [1,K,1,1]) AND
+  // accumulation (beta=0, alpha1=1, alpha2=1 → C = A + B, with A==C in-place
+  // satisfying MIOpen's "tensor A must equal tensor C" constraint).
+  //
+  // Skipping this silently produces conv-without-bias and typically passes
+  // downstream NaN/Inf checks because in practice the bias is small compared
+  // to dominant downstream additives (e.g. position embeddings), but the
+  // resulting feature map is wrong and any test comparing against a CPU
+  // reference will fail — both immediately (cosine < 1.0 on the conv
+  // output) and cumulatively (drift cascades through residual streams to
+  // produce NaN at the model output once values exceed fp16 range a few
+  // layers in).
+  if (bias) {
+    miopenTensorDescriptor_t bias_desc = nullptr;
+    MIOPEN_CHECK(miopenCreateTensorDescriptor(&bias_desc));
+    {
+      int bias_dims[] = {1, (int)weights_k, 1, 1};
+      miopenStatus_t bs = miopenSetNdTensorDescriptorWithLayout(
+          bias_desc, miopen_dt, miopenTensorNCHW, bias_dims, 4);
+      if (bs != miopenStatusSuccess) {
+        miopenDestroyTensorDescriptor(bias_desc);
+        fprintf(stderr,
+                "[REAL] wrap_miopenConvolutionForward: bias desc setup "
+                "failed (%d)\n",
+                bs);
+        result = -1;
+        goto cleanup;
+      }
+    }
+    float a1 = 1.0f, a2 = 1.0f, bz = 0.0f;
+    miopenStatus_t bs =
+        miopenOpTensor(miopen_handle, miopenTensorOpAdd, &a1, output_desc,
+                       output, &a2, bias_desc, bias, &bz, output_desc, output);
+    miopenDestroyTensorDescriptor(bias_desc);
+    if (bs != miopenStatusSuccess) {
+      fprintf(stderr,
+              "[REAL] wrap_miopenConvolutionForward: bias miopenOpTensor "
+              "failed (%d)\n",
+              bs);
+      result = -1;
+      goto cleanup;
+    }
+  }
 
 cleanup:
   // Best-effort cleanup: free all allocated resources

--- a/lib/Runtime/real/nonzero.cpp
+++ b/lib/Runtime/real/nonzero.cpp
@@ -2,39 +2,74 @@
  * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Licensed under the MIT License.
  */
+
+#include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../op_profile.h"
+#include "hip_custom_kernels.h"
 
 #include <cstdio>
-#include <stdexcept>
-#include <string>
 
-// Stub implementation of ONNX NonZero.
-//
-// NonZero returns the row-major indices of non-zero elements of `input`
-// as an int64 tensor of shape [R, N], where R is the input rank and N
-// is the (data-dependent) number of non-zero elements. There is no GPU
-// kernel for this op yet -- the compiler still emits a call into this
-// symbol so that models containing NonZero can compile end-to-end.
-//
-// Per the project convention for unimplemented runtime ops, this stub
-// logs its parameters and throws a std::runtime_error so any inference
-// path that actually executes the op fails loudly instead of silently
-// producing uninitialised output.
+static int nonzero_hipdnn_to_hip_dtype(int64_t hipdnn_type) {
+  switch (hipdnn_type) {
+  case HIPDNN_EP_DATATYPE_FLOAT:
+    return HIP_DTYPE_FLOAT32;
+  case HIPDNN_EP_DATATYPE_HALF:
+    return HIP_DTYPE_FLOAT16;
+  case HIPDNN_EP_DATATYPE_INT32:
+    return HIP_DTYPE_INT32;
+  case HIPDNN_EP_DATATYPE_INT64:
+    return HIP_DTYPE_INT64;
+  case HIPDNN_EP_DATATYPE_INT8:
+    return HIP_DTYPE_INT8;
+  case HIPDNN_EP_DATATYPE_UINT8:
+    return HIP_DTYPE_UINT8;
+  default:
+    return -1;
+  }
+}
+
 int wrap_nonzero(RuntimeState *state, void *input, void *output,
-                 int64_t input_num_elements, int64_t input_rank,
+                 int32_t *count_ptr, int64_t input_num_elements,
+                 int64_t input_rank, const int64_t *input_dims,
                  int64_t output_capacity, int64_t input_data_type) {
-  (void)state;
-  (void)input;
-  (void)output;
+  OP_PROFILE(
+      "nonzero",
+      [&] {
+        char b[64];
+        snprintf(b, sizeof(b), "numel=%lld:rank=%lld:%s",
+                 (long long)input_num_elements, (long long)input_rank,
+                 hipdnn_ep_datatype_name(input_data_type));
+        return std::string(b);
+      },
+      state);
 
-  std::fprintf(stderr,
-               "[STUB] wrap_nonzero(input=%p, output=%p, "
-               "input_num_elements=%lld, input_rank=%lld, "
-               "output_capacity=%lld, input_data_type=%s(%lld))\n",
-               input, output, (long long)input_num_elements,
-               (long long)input_rank, (long long)output_capacity,
-               hipdnn_ep_datatype_name(input_data_type),
-               (long long)input_data_type);
-  std::fflush(stderr);
-  return 0;
+  if (!state || !input || !output || !count_ptr || !input_dims) {
+    RUNTIME_DEBUG_LOG("[REAL] wrap_nonzero: null required argument\n");
+    return -1;
+  }
+  if (input_num_elements <= 0 || input_rank <= 0) {
+    RUNTIME_DEBUG_LOG("[REAL] wrap_nonzero: invalid dimensions "
+                      "(input_num_elements=%lld, input_rank=%lld)\n",
+                      (long long)input_num_elements, (long long)input_rank);
+    return -1;
+  }
+
+  int hip_dtype = nonzero_hipdnn_to_hip_dtype(input_data_type);
+  if (hip_dtype < 0) {
+    fprintf(stderr, "[REAL] wrap_nonzero: unsupported data_type=%s(%lld)\n",
+            hipdnn_ep_datatype_name(input_data_type),
+            (long long)input_data_type);
+    return -1;
+  }
+
+  void *stream = hipdnn_ep_state_get_stream(state);
+  RUNTIME_DEBUG_LOG(
+      "[REAL] wrap_nonzero: numel=%lld, rank=%lld, capacity=%lld, "
+      "dtype=%s -> hip_nonzero\n",
+      (long long)input_num_elements, (long long)input_rank,
+      (long long)output_capacity, hipdnn_ep_datatype_name(input_data_type));
+
+  return hip_nonzero(stream, input, output, count_ptr, input_num_elements,
+                     input_rank, input_dims, output_capacity, hip_dtype);
 }

--- a/lib/Runtime/real/range.cpp
+++ b/lib/Runtime/real/range.cpp
@@ -11,7 +11,11 @@
 int wrap_range(RuntimeState *state, void *start, void *limit, void *delta,
                void *output, int64_t output_num_elements, int64_t hip_dtype) {
   if (!state || !start || !limit || !delta || !output) {
-    RUNTIME_DEBUG_LOG("[REAL] wrap_range: null argument\n");
+    RUNTIME_DEBUG_LOG(
+        "[REAL] wrap_range: null argument (state=%p start=%p limit=%p "
+        "delta=%p output=%p output_num_elements=%lld hip_dtype=%lld)\n",
+        (void *)state, start, limit, delta, output,
+        (long long)output_num_elements, (long long)hip_dtype);
     return -1;
   }
 

--- a/lib/Runtime/real/scatter_nd.cpp
+++ b/lib/Runtime/real/scatter_nd.cpp
@@ -29,6 +29,7 @@
 #include "hip_custom_kernels.h"
 
 #include <cstdio>
+#include <hip/hip_runtime.h>
 
 static int scatter_nd_hipdnn_to_hip_dtype(int64_t hipdnn_type) {
   switch (hipdnn_type) {
@@ -63,12 +64,12 @@ static const char *reduction_name(int64_t id) {
 }
 
 int wrap_scatter_nd(RuntimeState *state, void *data, void *indices,
-                    void *updates, void *output, const int64_t *data_shape,
-                    int64_t data_rank, const int64_t *indices_shape,
-                    int64_t indices_rank, const int64_t *updates_shape,
-                    int64_t updates_rank, const int64_t *output_shape,
-                    int64_t output_rank, int64_t reduction_id,
-                    int64_t data_type) {
+                    void *updates, void *output, const int32_t *count_ptr,
+                    const int64_t *data_shape, int64_t data_rank,
+                    const int64_t *indices_shape, int64_t indices_rank,
+                    const int64_t *updates_shape, int64_t updates_rank,
+                    const int64_t *output_shape, int64_t output_rank,
+                    int64_t reduction_id, int64_t data_type) {
   OP_PROFILE(
       "scatter_nd",
       [&] {
@@ -85,8 +86,7 @@ int wrap_scatter_nd(RuntimeState *state, void *data, void *indices,
   (void)output_shape;
   (void)output_rank;
 
-  if (!state || !data || !indices || !updates || !output || !data_shape ||
-      !indices_shape) {
+  if (!state || !data || !output || !data_shape || !indices_shape) {
     RUNTIME_DEBUG_LOG("[REAL] wrap_scatter_nd: null required argument\n");
     return -1;
   }
@@ -113,14 +113,54 @@ int wrap_scatter_nd(RuntimeState *state, void *data, void *indices,
   }
 
   void *stream = hipdnn_ep_state_get_stream(state);
+
+  // Empty-updates fast path: ORT passes a null pointer for tensors with zero
+  // elements. The canonical trigger is the VLM embedding sub-model on a
+  // text-only call: `image_features` arrives with shape[0]==0, the upstream
+  // Slice produces an empty buffer (null pointer per ONNX zero-size
+  // convention), and the leading dim of `indices` is zero too. ScatterND
+  // semantics with zero slices to write is just `output := data` (copy
+  // through, no writes). The `none` / `add` / `mul` / `min` / `max`
+  // reductions all reduce to this same copy when the slice count is zero.
+  // Without this path the up-front null-check would fail the wrapper and
+  // leave `output` at its pool-init value (zeros), silently corrupting
+  // downstream consumers — the user-visible failure on Qwen 3.5 VLM was
+  // all-zero `inputs_embeds` for text-only inputs.
+  bool indices_empty = (indices_shape[0] == 0);
+  if (!updates || !indices || indices_empty) {
+    int64_t data_num_elements = 1;
+    for (int64_t d = 0; d < data_rank; ++d)
+      data_num_elements *= data_shape[d];
+    int64_t elem_size = hipdnn_ep_datatype_size(data_type);
+    if (data_num_elements > 0 && elem_size > 0) {
+      hipError_t err = hipMemcpyAsync(output, data,
+                                      static_cast<size_t>(data_num_elements) *
+                                          static_cast<size_t>(elem_size),
+                                      hipMemcpyDeviceToDevice,
+                                      static_cast<hipStream_t>(stream));
+      if (err != hipSuccess) {
+        fprintf(stderr,
+                "[REAL] wrap_scatter_nd: empty-updates D2D copy failed: %s\n",
+                hipGetErrorString(err));
+        return -1;
+      }
+    }
+    RUNTIME_DEBUG_LOG(
+        "[REAL] wrap_scatter_nd: empty updates (updates=%p indices=%p "
+        "indices_shape[0]=%lld) -- copied data -> output, no scatter\n",
+        updates, indices, (long long)indices_shape[0]);
+    return 0;
+  }
+
   RUNTIME_DEBUG_LOG(
       "[REAL] wrap_scatter_nd: data_rank=%lld, indices_rank=%lld, "
-      "reduction=%s, data_type=%s -> hip_scatter_nd\n",
+      "reduction=%s, data_type=%s, count_ptr=%p -> hip_scatter_nd\n",
       (long long)data_rank, (long long)indices_rank,
-      reduction_name(reduction_id), hipdnn_ep_datatype_name(data_type));
+      reduction_name(reduction_id), hipdnn_ep_datatype_name(data_type),
+      (const void *)count_ptr);
 
-  return hip_scatter_nd(stream, data, indices, updates, output, data_shape,
-                        static_cast<int>(data_rank), indices_shape,
+  return hip_scatter_nd(stream, data, indices, updates, output, count_ptr,
+                        data_shape, static_cast<int>(data_rank), indices_shape,
                         static_cast<int>(indices_rank),
                         static_cast<int>(reduction_id), hip_dtype);
 }

--- a/lib/Runtime/real/slice.cpp
+++ b/lib/Runtime/real/slice.cpp
@@ -67,6 +67,8 @@ int wrap_slice(RuntimeState *state, void *data, void *starts, void *ends,
                int64_t output_rank, int64_t starts_num_elements,
                int64_t axes_num_elements, int64_t steps_num_elements,
                int64_t data_type) {
+  // (Slice runtime entry trace removed; was used for the slice-empty-buffer
+  // root-cause investigation. Re-add with a HIPDNN_EP_DEBUG gate if needed.)
   OP_PROFILE(
       "slice",
       [&] {
@@ -78,8 +80,7 @@ int wrap_slice(RuntimeState *state, void *data, void *starts, void *ends,
       },
       state);
 
-  if (!state || !data || !starts || !ends || !output || !data_shape ||
-      !output_shape) {
+  if (!state || !starts || !ends || !output || !data_shape || !output_shape) {
     RUNTIME_DEBUG_LOG("[REAL] wrap_slice: null required argument\n");
     return -1;
   }
@@ -89,6 +90,51 @@ int wrap_slice(RuntimeState *state, void *data, void *starts, void *ends,
         "[REAL] wrap_slice: invalid ranks (data_rank=%lld, output_rank=%lld)\n",
         (long long)data_rank, (long long)output_rank);
     return -1;
+  }
+  // Empty input fast path: ORT passes a null `data` pointer for a tensor
+  // with zero elements (e.g. `image_features` with shape[0]==0 in the VLM
+  // embedding sub-model on a text-only call). Slicing an empty input
+  // necessarily produces an empty logical output; the physical output buffer
+  // is over-allocated by SliceToHip to the IR static dim and must be
+  // zero-filled so downstream consumers (e.g. ScatterND's updates buffer)
+  // see the zero tail the existing logical-extent==0 kernel path would have
+  // written. Returning -1 here would leave the buffer at its pool-init
+  // value and silently feed downstream ops garbage / zero, masking the
+  // missing-write as "EP produced zero output".
+  int64_t data_num_elements = 1;
+  for (int d = 0; d < data_rank; ++d)
+    data_num_elements *= data_shape[d];
+  if (!data || data_num_elements == 0) {
+    int64_t out_num_elements = 1;
+    for (int d = 0; d < output_rank; ++d)
+      out_num_elements *= output_shape[d];
+    int64_t elem_size = hipdnn_ep_datatype_size(data_type);
+    if (elem_size <= 0) {
+      fprintf(stderr,
+              "[REAL] wrap_slice: empty-input path -- unsupported "
+              "data_type=%s(%lld)\n",
+              hipdnn_ep_datatype_name(data_type), (long long)data_type);
+      return -1;
+    }
+    if (output && out_num_elements > 0) {
+      hipStream_t s =
+          static_cast<hipStream_t>(hipdnn_ep_state_get_stream(state));
+      hipError_t err = hipMemsetAsync(output, 0,
+                                      static_cast<size_t>(out_num_elements) *
+                                          static_cast<size_t>(elem_size),
+                                      s);
+      if (err != hipSuccess) {
+        fprintf(stderr,
+                "[REAL] wrap_slice: empty-input hipMemsetAsync failed: %s\n",
+                hipGetErrorString(err));
+        return -1;
+      }
+    }
+    RUNTIME_DEBUG_LOG(
+        "[REAL] wrap_slice: empty input (data=%p data_num_elements=%lld) "
+        "-- zeroed output and returning success\n",
+        data, (long long)data_num_elements);
+    return 0;
   }
   if (data_rank > kSliceRuntimeMaxRank) {
     fprintf(stderr, "[REAL] wrap_slice: data_rank=%lld exceeds max %d\n",
@@ -236,10 +282,14 @@ int wrap_slice(RuntimeState *state, void *data, void *starts, void *ends,
     step_per_axis[axis] = step;
   }
 
-  // Sanity check: derived output extents must match the IR-supplied
-  // output shape. Mismatches are programming bugs (lowering or upstream
-  // shape-inference disagreement) and would silently corrupt data, so
-  // fail loud rather than launch a broken kernel.
+  // Per-axis logical output extent (= actual ONNX-Slice output size,
+  // possibly < the physically allocated buffer dim when SliceToHip
+  // over-allocated due to runtime-only starts/ends). Initialised to
+  // output_shape; only sliced axes are recomputed in the loop below.
+  int64_t logical_extent[kSliceRuntimeMaxRank];
+  for (int d = 0; d < data_rank; ++d)
+    logical_extent[d] = output_shape[d];
+
   for (int d = 0; d < data_rank; ++d) {
     if (!axis_set[d])
       continue; // unmodified axis: output extent must == data extent.
@@ -272,14 +322,32 @@ int wrap_slice(RuntimeState *state, void *data, void *starts, void *ends,
       expected = (end - start + step + 1) / step;
     if (expected < 0)
       expected = 0;
-    if (expected != output_shape[d]) {
+    // Three cases:
+    //   (a) expected == output_shape[d]: normal, logical_extent[d] =
+    //       output_shape[d] (already initialised below).
+    //   (b) expected == 0 (empty slice). Set logical_extent[d] = 0 so the
+    //       kernel fills the entire physical extent with zeros — no
+    //       separate memset, single kernel call.
+    //   (c) expected > 0 && expected < output_shape[d]: compile-time
+    //       OVER-ALLOCATION. SliceToHip uses `tensor.dim(data, i)` as an
+    //       upper bound for dynamic output dims since the actual extent
+    //       depends on runtime starts/ends. Pass logical_extent[d] =
+    //       expected so the kernel slices the valid prefix and zeros the
+    //       over-allocated tail.
+    //   (d) expected > output_shape[d] is impossible (slice cannot widen
+    //       any axis) and remains a hard error.
+    if (expected > output_shape[d]) {
       fprintf(stderr,
               "[REAL] wrap_slice: derived output extent on axis %d "
-              "(%lld) != IR output_shape (%lld) -- aborting to avoid "
-              "writing out-of-bounds\n",
-              d, (long long)expected, (long long)output_shape[d]);
+              "(%lld) > IR output_shape (%lld) -- aborting "
+              "(start=%lld end=%lld step=%lld dim=%lld data_rank=%lld "
+              "K=%lld)\n",
+              d, (long long)expected, (long long)output_shape[d],
+              (long long)start, (long long)end, (long long)step, (long long)dim,
+              (long long)data_rank, (long long)K);
       return -1;
     }
+    logical_extent[d] = expected;
   }
 
   for (int d = 0; d < data_rank; ++d) {
@@ -295,6 +363,6 @@ int wrap_slice(RuntimeState *state, void *data, void *starts, void *ends,
                     hipdnn_ep_datatype_name(data_type));
 
   return hip_slice(hipdnn_ep_state_get_stream(state), data, output, data_shape,
-                   output_shape, start_per_axis, step_per_axis,
+                   output_shape, logical_extent, start_per_axis, step_per_axis,
                    static_cast<int>(data_rank), hip_dtype);
 }

--- a/lib/Runtime/real/transpose.cpp
+++ b/lib/Runtime/real/transpose.cpp
@@ -24,7 +24,27 @@ int wrap_transpose(RuntimeState *state, const void *input, void *output,
       },
       state);
   if (!state || !input || !output || !input_shape || !perm) {
-    RUNTIME_DEBUG_LOG("[REAL] wrap_transpose: null argument\n");
+    RUNTIME_DEBUG_LOG(
+        "[REAL] wrap_transpose: null argument (state=%p input=%p output=%p "
+        "input_shape=%p perm=%p rank=%lld num=%lld elem=%lld)\n",
+        (void *)state, input, output, (const void *)input_shape,
+        (const void *)perm, (long long)rank, (long long)num_elements,
+        (long long)element_size_bytes);
+    if (input_shape && rank > 0 && rank <= 8) {
+      fprintf(stderr, "  input_shape=[");
+      for (int64_t i = 0; i < rank; ++i)
+        fprintf(stderr, "%lld%s", (long long)input_shape[i],
+                i + 1 == rank ? "" : ",");
+      fprintf(stderr, "]");
+      if (perm) {
+        fprintf(stderr, "  perm=[");
+        for (int64_t i = 0; i < rank; ++i)
+          fprintf(stderr, "%lld%s", (long long)perm[i],
+                  i + 1 == rank ? "" : ",");
+        fprintf(stderr, "]");
+      }
+      fprintf(stderr, "\n");
+    }
     return -1;
   }
   if (rank <= 0) {


### PR DESCRIPTION
## Summary

This PR carves the **runtime + custom-kernel** portion out of the large `release/msbuild` branch (PR #259) so it can be reviewed on its own, rebased on top of current `main`.

Scope is two directories: `lib/Runtime/**` and `3rd-party/custom_kernels/**`. No compiler frontend (`lib/Conversion/OnnxToHip`), backend (`backend-mlir-compiler`), or build-system changes are included.

## MemoryManager (mm) is preserved — zero net change to mm/pool infra

PR #259 branched **before** the MemoryManager subsystem was merged to `main` (commit `6dc93b45`), so a naive `lib/Runtime` copy from `release/msbuild` would silently revert mm. This PR keeps `main`'s versions of the mm/pool infrastructure, introducing **zero net diff** to them:

- `hipdnn_ep_runtime_state.cpp`, `runtime_state_internal.h`, `hipdnn_ep_runtime_loop.cpp`, `lib/Runtime/CMakeLists.txt` — identical to `main` (mm `alloc` for constants/workspace/qmoe stays).
- `hipdnn_ep_runtime.h` — infra declarations reverted to `main` (`get_pool_base` 1-arg, no `push/pop_pool_depth`, no `get_host_scratch_base`, `begin_compute` without `dllexport`). Only per-op wrapper signatures changed.

The dynamic grow-on-demand pool, nested-pool, and host-scalar scratch infra are intentionally **out of scope** — they are compiler-coupled and will land with their MLIR passes.

## ⚠️ KNOWN ISSUE — 8 op-wrapper ABI changes (compiler-coupled)

8 runtime `wrap_*` functions changed signature. These are an **ABI contract with the HipToLLVM lowerings**, and `main` already ships those lowerings (emitting the *old* arg list). Until the matching lowering changes land on `main`, any model that reaches one of these ops will pass the **old** arg list into the **new** wrapper definition → reads extra/garbage args → wrong result (links fine; silently bypasses CPU-fallback accuracy tests). The matching `*Lowering.cpp` + `*Conversion.cpp` changes are deliberately **deferred to per-op feature PRs**.

| Op | `wrap_*` change | main impact |
|----|-----------------|-------------|
| **Gather** | `+axis_size, +inner_size` | **All LLMs** (embedding lookup) — always hit |
| **Div** | `num_elements` → 4D broadcast shape | Models using Div broadcast |
| **Sub / Elementwise** | `num_elements` → 4D broadcast shape | Models using Sub broadcast |
| **MatMul** (hipBLASLt) | `+b_batch_stride` | Batched non-quantized matmul paths |
| **Equal** | `num_elements` → `a/b/out_num_elements` | **VLM only** (embedding placeholder) |
| **NonZero** | `+count_ptr, +input_dims` | **VLM only** (embedding chain) |
| **ScatterND** | `+count_ptr` | **VLM only** (pairs with NonZero) |
| **Conv** | `+data_type` | **Vision only** (patch embedding / SigLIP / ViT) |

Impact summary:
- **Always affects main:** Gather.
- **Affects most models:** Div, Sub/Elementwise, MatMul.
- **Affects only if the regression set runs VLM/vision models:** Equal, NonZero, ScatterND, Conv.

This is tracked as a known issue; reviewers should land the per-op lowering+conversion before relying on these runtime paths.

## ABI-stable / additive (no main impact)

`hip.cpp` (stride-honouring `memrefCopy` Concat fix), `cast`, `slice`, `transpose`, `expand`, `range`, `activation`/softmax, `tensor.cpp`, `mock/*`, `matmul_nbits` kernel improvements, and the new `softmax`/`nonzero`/`elementwise_mul` kernels — `wrap_*` signatures unchanged, so they don't break `main`'s existing call sites.

## Test plan

- [ ] CI build.
- [ ] `pytest test/numeric` once built.
- [ ] Do not rely on the 8 ABI-changed ops until their lowering/conversion land on `main`.
