### PR TITLE
feat(hip): pre-bufferize tensor.dim resolution for reshape chains

### DIFF
--- a/include/hip/Dialect/Transforms/Passes.td
+++ b/include/hip/Dialect/Transforms/Passes.td
@@ -428,10 +428,13 @@ def ResolveTensorDimsPass
     `--one-shot-bufferize`, so refined dim values propagate into
     bufferize's allocation sizing. Idempotent.
   }];
+  // affine + arith are materialised by the upstream reify folds
+  // (`affine.apply` for collapse products, `arith.constant` for static
+  // slots); tensor is already loaded as the input dialect, so it is not
+  // listed here.
   let dependentDialects = [
     "mlir::affine::AffineDialect",
-    "mlir::arith::ArithDialect",
-    "mlir::tensor::TensorDialect"
+    "mlir::arith::ArithDialect"
   ];
 }
 

--- a/include/hip/Dialect/Transforms/Passes.td
+++ b/include/hip/Dialect/Transforms/Passes.td
@@ -402,6 +402,39 @@ def LowerAllocsPass : Pass<"hip-lower-allocs", "mlir::func::FuncOp"> {
   ];
 }
 
+def ResolveTensorDimsPass
+    : Pass<"hip-resolve-tensor-dims", "mlir::func::FuncOp"> {
+  let summary = "Fold `tensor.dim` queries via upstream reify patterns "
+                "(pre-bufferize)";
+  let description = [{
+    Per-`func.func` greedy rewrite that wraps upstream MLIR's
+    `populateResolveRankedShapedTypeResultDimsPatterns` (plus the
+    `InferShapedTypeOpInterface` companion populator and the tensor-
+    dialect canonicalisers) in a single fixed point. Folds `tensor.dim`
+    of any op carrying `ReifyRankedShapedTypeOpInterface` --
+    `tensor.expand_shape`, `tensor.collapse_shape`, `tensor.pad`, and
+    every HIP DPS op (which carries the interface via the dialect's
+    own external models registered in `InitAllPasses.h`).
+
+    Coverage assumes
+    `mlir::tensor::registerInferTypeOpInterfaceExternalModels` has
+    been wired into the dialect registry; without that registration
+    the upstream patterns are inert and reshape-dim queries silently
+    fall through to bufferize, where they get materialised as
+    `memref.dim` of a reshape op and explode the dominance domain
+    count of `--hip-pool-allocs`.
+
+    Pipeline placement: between `--hip-infer-shapes` and
+    `--one-shot-bufferize`, so refined dim values propagate into
+    bufferize's allocation sizing. Idempotent.
+  }];
+  let dependentDialects = [
+    "mlir::affine::AffineDialect",
+    "mlir::arith::ArithDialect",
+    "mlir::tensor::TensorDialect"
+  ];
+}
+
 def InferShapesPass : Pass<"hip-infer-shapes", "mlir::ModuleOp"> {
   let summary = "Refine dynamic dims in HIP DPS op result types via "
                 "`ReifyRankedShapedTypeOpInterface`";

--- a/include/hip/InitAllPasses.h
+++ b/include/hip/InitAllPasses.h
@@ -19,6 +19,7 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/MemRef/Transforms/AllocationOpInterfaceImpl.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Tensor/IR/TensorInferTypeOpInterfaceImpl.h"
 #include "mlir/Dialect/Tensor/Transforms/BufferizableOpInterfaceImpl.h"
 #include "mlir/IR/BuiltinDialect.h"
 #include "mlir/IR/MLIRContext.h"
@@ -60,6 +61,7 @@ inline void registerAllDialects(mlir::DialectRegistry &registry) {
   registry.insert<detail::OnnxStubDialect>();
   mlir::arith::registerBufferizableOpInterfaceExternalModels(registry);
   mlir::tensor::registerBufferizableOpInterfaceExternalModels(registry);
+  mlir::tensor::registerInferTypeOpInterfaceExternalModels(registry);
   mlir::bufferization::func_ext::registerBufferizableOpInterfaceExternalModels(
       registry);
   mlir::memref::registerAllocationOpInterfaceExternalModels(registry);

--- a/lib/Compiler/CMakeLists.txt
+++ b/lib/Compiler/CMakeLists.txt
@@ -26,6 +26,7 @@ target_link_libraries(LibHipCompiler PUBLIC
   MLIRLLVMDialect
   MLIRBufferizationDialect
   MLIRBufferizationTransforms
+  MLIRTensorInferTypeOpInterfaceImpl
   MLIRSCFDialect
   MLIRSCFToControlFlow
   MLIRParser

--- a/lib/Dialect/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Transforms/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(HipDialectTransforms STATIC
   PoolAllocs.cpp
   PromoteStridedHipOperands.cpp
   ResolveExternConstants.cpp
+  ResolveTensorDims.cpp
 )
 
 add_dependencies(HipDialectTransforms

--- a/lib/Dialect/Transforms/Pipelines.cpp
+++ b/lib/Dialect/Transforms/Pipelines.cpp
@@ -38,6 +38,19 @@ static void buildOnnxToHipPipelineTail(OpPassManager &pm) {
   //     the reference cases.
   pm.addPass(hip::createInferShapesPass());
 
+  // 1c. Fold `tensor.dim` queries on `tensor.expand_shape` /
+  //     `tensor.collapse_shape` chains into arithmetic on the chain
+  //     root's dims, in the tensor domain, before one-shot-bufferize.
+  //     The reshape ops' shape SSA (`output_shape` and reassociation
+  //     maps) is opaque to the post-bufferize `memref.dim` patterns,
+  //     so this is the last useful position.  Without it, downstream
+  //     `--hip-pool-allocs` sees scattered dim queries on each reshape
+  //     site and partitions them into separate dominance domains,
+  //     which blows past its cap on graphs with per-layer same-rank
+  //     dynamic `onnx.Reshape` (typical: norm / projection chains in
+  //     transformer decoders).  See `ResolveTensorDims.cpp`.
+  pm.addNestedPass<func::FuncOp>(hip::createResolveTensorDimsPass());
+
   // 2. Bufferize tensor IR to memref IR
   //
   // Use IdentityLayoutMap for function boundaries: all EP inputs/outputs come

--- a/lib/Dialect/Transforms/Pipelines.cpp
+++ b/lib/Dialect/Transforms/Pipelines.cpp
@@ -44,11 +44,12 @@ static void buildOnnxToHipPipelineTail(OpPassManager &pm) {
   //     The reshape ops' shape SSA (`output_shape` and reassociation
   //     maps) is opaque to the post-bufferize `memref.dim` patterns,
   //     so this is the last useful position.  Without it, downstream
-  //     `--hip-pool-allocs` sees scattered dim queries on each reshape
-  //     site and partitions them into separate dominance domains,
-  //     which blows past its cap on graphs with per-layer same-rank
-  //     dynamic `onnx.Reshape` (typical: norm / projection chains in
-  //     transformer decoders).  See `ResolveTensorDims.cpp`.
+  //     `--hip-pool-allocs` sees one scattered dim query per reshape
+  //     site and fragments them into many single-alloc dominance
+  //     domains -- a pooling-efficiency cost (one tiny pool each), not
+  //     a failure -- on graphs with per-layer same-rank dynamic
+  //     `onnx.Reshape` (typical: norm / projection chains).  See
+  //     `ResolveTensorDims.cpp`.
   pm.addNestedPass<func::FuncOp>(hip::createResolveTensorDimsPass());
 
   // 2. Bufferize tensor IR to memref IR

--- a/lib/Dialect/Transforms/ResolveTensorDims.cpp
+++ b/lib/Dialect/Transforms/ResolveTensorDims.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- ResolveTensorDims.cpp - Pre-bufferize `tensor.dim` resolver --------===//
+//
+// Per-`func.func` greedy rewrite that wraps upstream MLIR's
+// `populateResolveRankedShapedTypeResultDimsPatterns` (plus the
+// `InferShapedTypeOpInterface` companion populator and the tensor-dialect
+// canonicalisers) in a single fixed point.  Folds `tensor.dim` queries on
+// any op carrying `ReifyRankedShapedTypeOpInterface` -- including
+// `tensor.expand_shape`, `tensor.collapse_shape`, `tensor.pad`, and the
+// HIP DPS ops registered via this dialect's external models -- and
+// composes the upstream `Compose{Expand,Collapse}OfX` patterns so chains
+// like `dim(collapse(expand(arg)))` collapse end-to-end in one pass.
+//
+// Coverage assumes
+// `mlir::tensor::registerInferTypeOpInterfaceExternalModels` has been
+// wired into the dialect registry (see `InitAllPasses.h` and
+// `tools/hip-mlir-opt/hip-mlir-opt.cpp`).  Without that registration the
+// upstream `DimOf{,Reify}ShapedTypeOpInterface` patterns silently no-op
+// on `tensor.{expand,collapse}_shape`, the `tensor.dim` queries leak
+// through bufferize as `memref.dim` of a reshape op, and downstream
+// `--hip-pool-allocs` partitions them into separate dominance domains
+// (the canonical regression: Gemma-3 q_norm / k_norm pairs blow the
+// 8-domain cap).
+//
+// Pipeline placement: between `--hip-infer-shapes` and
+// `--one-shot-bufferize` so refined dim values propagate into
+// bufferize's allocation sizing.  Idempotent.
+//
+//===----------------------------------------------------------------------===//
+
+#include "hip/Dialect/Transforms/Passes.h"
+
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MemRef/Transforms/Transforms.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#define DEBUG_TYPE "hip-resolve-tensor-dims"
+
+namespace mlir::hip {
+
+#define GEN_PASS_DEF_RESOLVETENSORDIMSPASS
+#include "hip/Dialect/Transforms/Passes.h.inc"
+
+namespace {
+
+struct ResolveTensorDimsPass final
+    : public impl::ResolveTensorDimsPassBase<ResolveTensorDimsPass> {
+  using Base::Base;
+  void runOnOperation() override;
+};
+
+void ResolveTensorDimsPass::runOnOperation() {
+  func::FuncOp funcOp = getOperation();
+  if (funcOp.empty())
+    return;
+
+  MLIRContext *ctx = &getContext();
+  RewritePatternSet patterns(ctx);
+
+  // Upstream reify-driven dim folds.  `populateResolveRankedShapedType...`
+  // contributes
+  // `DimOfReifyRankedShapedTypeOpInterface<{memref,tensor}::DimOp>`, which
+  // dispatches through the op's `reifyDimOfResult` / `reifyShapeOfResult` /
+  // `reifyResultShapes` chain.  The companion populator covers ops on
+  // `InferShapedTypeOpInterface` (used for `tensor.dim` of HIP DPS results that
+  // go through `reifyReturnTypeShapes`).
+  memref::populateResolveRankedShapedTypeResultDimsPatterns(patterns);
+  memref::populateResolveShapedTypeResultDimsPatterns(patterns);
+
+  // Tensor canonicalisers needed to compose with the reify folds in a
+  // single fixed point: `ComposeExpandOfCollapseOp`, type-driven
+  // `tensor.dim` constant fold, dead reshape DCE.
+  tensor::DimOp::getCanonicalizationPatterns(patterns, ctx);
+  tensor::ExpandShapeOp::getCanonicalizationPatterns(patterns, ctx);
+  tensor::CollapseShapeOp::getCanonicalizationPatterns(patterns, ctx);
+
+  if (failed(applyPatternsGreedily(funcOp, std::move(patterns))))
+    return signalPassFailure();
+}
+
+} // namespace
+} // namespace mlir::hip

--- a/lib/Dialect/Transforms/ResolveTensorDims.cpp
+++ b/lib/Dialect/Transforms/ResolveTensorDims.cpp
@@ -14,16 +14,26 @@
 // composes the upstream `Compose{Expand,Collapse}OfX` patterns so chains
 // like `dim(collapse(expand(arg)))` collapse end-to-end in one pass.
 //
+// Before:  // %arg : tensor<?x?x4096xf16>
+//          %e  = tensor.expand_shape   %arg ... -> tensor<?x?x32x128xf16>
+//          %c  = tensor.collapse_shape %e   ... -> tensor<?x?x128xf16>
+//          %d  = tensor.dim %c, %c1                  // dim of a reshape result
+// After:   %d1 = tensor.dim %arg, %c1                // on the chain root
+//          %d  = affine.apply affine_map<()[s0] -> (s0 * 32)>()[%d1]
+//          // the expand/collapse ops are dead-code-eliminated
+//
 // Coverage assumes
 // `mlir::tensor::registerInferTypeOpInterfaceExternalModels` has been
 // wired into the dialect registry (see `InitAllPasses.h` and
 // `tools/hip-mlir-opt/hip-mlir-opt.cpp`).  Without that registration the
-// upstream `DimOf{,Reify}ShapedTypeOpInterface` patterns silently no-op
-// on `tensor.{expand,collapse}_shape`, the `tensor.dim` queries leak
+// upstream reify patterns silently no-op on
+// `tensor.{expand,collapse}_shape`, the `tensor.dim` queries leak
 // through bufferize as `memref.dim` of a reshape op, and downstream
-// `--hip-pool-allocs` partitions them into separate dominance domains
-// (the canonical regression: Gemma-3 q_norm / k_norm pairs blow the
-// 8-domain cap).
+// `--hip-pool-allocs` then sees one scattered dim query per reshape
+// site and fragments them into many single-alloc dominance domains --
+// a pooling-efficiency cost (one tiny pool each), not a hard failure.
+// The canonical trigger is per-layer same-rank dynamic `onnx.Reshape`
+// pairs (norm / projection chains).
 //
 // Pipeline placement: between `--hip-infer-shapes` and
 // `--one-shot-bufferize` so refined dim values propagate into
@@ -66,10 +76,10 @@ void ResolveTensorDimsPass::runOnOperation() {
   // Upstream reify-driven dim folds.  `populateResolveRankedShapedType...`
   // contributes
   // `DimOfReifyRankedShapedTypeOpInterface<{memref,tensor}::DimOp>`, which
-  // dispatches through the op's `reifyDimOfResult` / `reifyShapeOfResult` /
-  // `reifyResultShapes` chain.  The companion populator covers ops on
-  // `InferShapedTypeOpInterface` (used for `tensor.dim` of HIP DPS results that
-  // go through `reifyReturnTypeShapes`).
+  // dispatches through the op's `reifyResultShapes`
+  // (`ReifyRankedShapedTypeOpInterface`).  The companion populator covers ops
+  // on `InferShapedTypeOpInterface` (`tensor.dim` of HIP DPS results, via
+  // `reifyReturnTypeShapes`).
   memref::populateResolveRankedShapedTypeResultDimsPatterns(patterns);
   memref::populateResolveShapedTypeResultDimsPatterns(patterns);
 

--- a/test/lit/Dialect/hip-resolve-tensor-dims.mlir
+++ b/test/lit/Dialect/hip-resolve-tensor-dims.mlir
@@ -1,0 +1,176 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+// RUN: hip-mlir-opt %s --hip-resolve-tensor-dims | FileCheck %s
+//
+// Pins down the `tensor.dim` folds `--hip-resolve-tensor-dims` is
+// expected to handle.  The pass is a thin wrapper over upstream MLIR's
+// reify-driven patterns plus tensor canonicalisers, and depends on
+// `tensor::registerInferTypeOpInterfaceExternalModels` being wired
+// into the dialect registry (see InitAllPasses.h /
+// hip-mlir-opt.cpp).  Coverage:
+//
+//   * `tensor.dim` of `tensor.expand_shape` at a static result-dim
+//     slot                                          -> static constant
+//   * `tensor.dim` of `tensor.expand_shape` at a dynamic SSA slot
+//                                                   -> the matching
+//                                                      `output_shape`
+//                                                      operand
+//   * `tensor.dim` of `tensor.collapse_shape`       -> `affine.apply`
+//                                                      product over
+//                                                      reassociation
+//                                                      group dims
+//   * `tensor.dim` of a fully-static tensor          -> static constant
+//   * Chained `dim(collapse(expand(arg)))`           -> single
+//                                                      `affine.apply`
+//                                                      on chain-root
+//                                                      dims
+//   * Function with no `tensor.dim` of a reshape op  -> bit-identical
+//
+// The pass uses upstream reify which lowers static factors INTO the
+// affine map (e.g. group `(?, 32)` -> `affine_map<()[s0] -> (s0 * 32)>`)
+// rather than emitting a separate `arith.muli %dyn, %c32`.
+
+// -----
+
+// CHECK-LABEL: @dim_of_expand_static_slot
+func.func @dim_of_expand_static_slot(%arg0: tensor<?x4096xf16>) -> index {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x4096xf16>
+  %expand = tensor.expand_shape %arg0 [[0], [1, 2]] output_shape [%d0, 32, 128] : tensor<?x4096xf16> into tensor<?x32x128xf16>
+  %use = tensor.dim %expand, %c1 : tensor<?x32x128xf16>
+  return %use : index
+}
+// CHECK-NOT: tensor.expand_shape
+// CHECK: arith.constant 32 : index
+// CHECK: return
+
+// -----
+
+// CHECK-LABEL: @dim_of_expand_dynamic_slot
+func.func @dim_of_expand_dynamic_slot(%arg0: tensor<?x4096xf16>) -> index {
+  %c0 = arith.constant 0 : index
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x4096xf16>
+  %expand = tensor.expand_shape %arg0 [[0], [1, 2]] output_shape [%d0, 32, 128] : tensor<?x4096xf16> into tensor<?x32x128xf16>
+  %use = tensor.dim %expand, %c0 : tensor<?x32x128xf16>
+  return %use : index
+}
+// CHECK-NOT: tensor.expand_shape
+// CHECK-NOT: tensor.dim %{{.*expanded}}
+// CHECK: %[[D0:.+]] = tensor.dim %arg0, %{{.*}} : tensor<?x4096xf16>
+// CHECK: return %[[D0]]
+
+// -----
+
+// CHECK-LABEL: @dim_of_collapse_two_dyn
+func.func @dim_of_collapse_two_dyn(%arg0: tensor<?x?xf16>) -> index {
+  %c0 = arith.constant 0 : index
+  %collapse = tensor.collapse_shape %arg0 [[0, 1]] : tensor<?x?xf16> into tensor<?xf16>
+  %use = tensor.dim %collapse, %c0 : tensor<?xf16>
+  return %use : index
+}
+// CHECK-NOT: tensor.collapse_shape
+// CHECK-DAG: tensor.dim %arg0
+// CHECK: affine.apply
+// CHECK: return
+
+// -----
+
+// Mixed static / dynamic source: the static factor is folded INTO the
+// affine map by upstream reify -- no separate `arith.muli %dyn, %c32`.
+// CHECK-LABEL: @dim_of_collapse_static_and_dyn
+func.func @dim_of_collapse_static_and_dyn(%arg0: tensor<?x32xf16>) -> index {
+  %c0 = arith.constant 0 : index
+  %collapse = tensor.collapse_shape %arg0 [[0, 1]] : tensor<?x32xf16> into tensor<?xf16>
+  %use = tensor.dim %collapse, %c0 : tensor<?xf16>
+  return %use : index
+}
+// CHECK-NOT: tensor.collapse_shape
+// CHECK: tensor.dim %arg0
+// CHECK: affine.apply
+// CHECK: return
+
+// -----
+
+// 3-source group: chain length tracks `|group|`.
+// CHECK-LABEL: @dim_of_collapse_three_way
+func.func @dim_of_collapse_three_way(%arg0: tensor<?x?x?xf16>) -> index {
+  %c0 = arith.constant 0 : index
+  %collapse = tensor.collapse_shape %arg0 [[0, 1, 2]] : tensor<?x?x?xf16> into tensor<?xf16>
+  %use = tensor.dim %collapse, %c0 : tensor<?xf16>
+  return %use : index
+}
+// CHECK-NOT: tensor.collapse_shape
+// CHECK-COUNT-3: tensor.dim %arg0
+// CHECK: affine.apply
+// CHECK: return
+
+// -----
+
+// Same-rank dynamic Reshape decomposed to expand_shape + collapse_shape:
+// `dim(collapse, 1)` collapses end-to-end to `affine.apply [s0 * 32]` on
+// `tensor.dim %arg0, 1`.  Canonical pattern for transformer decoder
+// norm / projection chains.
+// CHECK-LABEL: @same_rank_reshape_chain_dim
+func.func @same_rank_reshape_chain_dim(%arg0: tensor<?x?x4096xf16>) -> index {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x?x4096xf16>
+  %d1 = tensor.dim %arg0, %c1 : tensor<?x?x4096xf16>
+  %expand = tensor.expand_shape %arg0 [[0], [1], [2, 3]] output_shape [%d0, %d1, 32, 128] : tensor<?x?x4096xf16> into tensor<?x?x32x128xf16>
+  %collapse = tensor.collapse_shape %expand [[0], [1, 2], [3]] : tensor<?x?x32x128xf16> into tensor<?x?x128xf16>
+  %use = tensor.dim %collapse, %c1 : tensor<?x?x128xf16>
+  return %use : index
+}
+// CHECK-NOT: tensor.collapse_shape
+// CHECK-NOT: tensor.expand_shape
+// CHECK-NOT: tensor.dim %{{.*expanded}}
+// CHECK-NOT: tensor.dim %{{.*collapsed}}
+// CHECK: tensor.dim %arg0
+// CHECK: affine.apply
+// CHECK: return
+
+// -----
+
+// `tensor.dim` of a fully-static tensor folds to a constant via the
+// `tensor.dim` canonicaliser (no reify needed).
+// CHECK-LABEL: @dim_of_static_const
+func.func @dim_of_static_const(%arg0: tensor<32x128xf16>) -> index {
+  %c0 = arith.constant 0 : index
+  %use = tensor.dim %arg0, %c0 : tensor<32x128xf16>
+  return %use : index
+}
+// CHECK-NOT: tensor.dim
+// CHECK: arith.constant 32 : index
+// CHECK: return
+
+// -----
+
+// No-op: function with no `tensor.dim` of a reshape op should produce
+// bit-identical IR.
+// CHECK-LABEL: @no_dim_on_reshape_noop
+func.func @no_dim_on_reshape_noop(%arg0: tensor<?x?xf16>) -> tensor<?x?xf16> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x?xf16>
+  %d1 = tensor.dim %arg0, %c1 : tensor<?x?xf16>
+  %empty = tensor.empty(%d0, %d1) : tensor<?x?xf16>
+  return %empty : tensor<?x?xf16>
+}
+// CHECK: tensor.dim %arg0, %c0
+// CHECK: tensor.dim %arg0, %c1
+// CHECK: tensor.empty
+// CHECK: return
+
+// -----
+
+// No-op: collapse_shape live but never `tensor.dim`-queried -- preserved
+// as an SSA value.
+// CHECK-LABEL: @no_dim_on_collapse_noop
+func.func @no_dim_on_collapse_noop(%arg0: tensor<?x?xf16>) -> tensor<?xf16> {
+  %collapse = tensor.collapse_shape %arg0 [[0, 1]] : tensor<?x?xf16> into tensor<?xf16>
+  return %collapse : tensor<?xf16>
+}
+// CHECK: tensor.collapse_shape
+// CHECK: return

--- a/tools/hip-mlir-opt/CMakeLists.txt
+++ b/tools/hip-mlir-opt/CMakeLists.txt
@@ -33,6 +33,7 @@ target_link_libraries(hip-mlir-opt PRIVATE
   MLIRMemRefTransforms
   MLIRSCFDialect
   MLIRTensorDialect
+  MLIRTensorInferTypeOpInterfaceImpl
   MLIRDestinationStyleOpInterface
   MLIRBufferizationDialect
   MLIRBufferizationTransforms

--- a/tools/hip-mlir-opt/hip-mlir-opt.cpp
+++ b/tools/hip-mlir-opt/hip-mlir-opt.cpp
@@ -26,6 +26,7 @@
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/SCF/Transforms/BufferizableOpInterfaceImpl.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Tensor/IR/TensorInferTypeOpInterfaceImpl.h"
 #include "mlir/Dialect/Tensor/Transforms/BufferizableOpInterfaceImpl.h"
 #include "mlir/IR/BuiltinDialect.h"
 #include "mlir/Tools/mlir-opt/MlirOptMain.h"
@@ -221,6 +222,7 @@ int main(int argc, char **argv) {
       registry);
   mlir::scf::registerBufferizableOpInterfaceExternalModels(registry);
   mlir::tensor::registerBufferizableOpInterfaceExternalModels(registry);
+  mlir::tensor::registerInferTypeOpInterfaceExternalModels(registry);
   mlir::memref::registerAllocationOpInterfaceExternalModels(registry);
   registerHipBufferizableOpInterfaceModels(registry);
 


### PR DESCRIPTION
## Summary
Stack PR **4/4** (base: #287). Final layer — keeps reshape-heavy dynamic decoders within the grow-on-demand multi-domain pool engine added in #287.

- New `--hip-resolve-tensor-dims` pass, run between `hip-infer-shapes` and `one-shot-bufferize`, folds `tensor.dim` on `tensor.expand_shape` / `tensor.collapse_shape` chains into arithmetic on the chain root's dims. Without it, same-rank dynamic `onnx.Reshape` decompositions (q_norm / k_norm / projection chains) leak scattered `memref.dim` ops past bufferize and force `hip-pool-allocs` to scatter the function across extra pool domains.
- Thin wrapper over upstream `populateResolveRankedShapedTypeResultDimsPatterns` + the `InferShapedTypeOpInterface` companion + tensor canonicalisers, in one fixed point. **No custom rewrite patterns** — `tensor.{expand,collapse}_shape` coverage comes from registering `mlir::tensor::registerInferTypeOpInterfaceExternalModels` on the registry (wired into `InitAllPasses.h` and `hip-mlir-opt.cpp`, with `MLIRTensorInferTypeOpInterfaceImpl` linked into both).
- Mixed static/dynamic collapse groups fold the static factor into an `affine.apply` map rather than a separate `arith.muli` — pure upstream canonical form.

## Stack
1. #286 — design doc (base: `main`)
2. #293 — `--hip-hoist-alloc-size-arith` pass (base: #286)
3. #287 — pool engine + runtime ABI (base: #293)
4. **#this** — reshape-dim resolution (base: #287)

Made with [Cursor](https://cursor.com)