### PR TITLE
feat(ep): resolve non-identity dynamic output dims via inference_infer_shapes

### DIFF
--- a/backend-mlir-compiler/custom-op-mlir/src/InferenceState.cpp
+++ b/backend-mlir-compiler/custom-op-mlir/src/InferenceState.cpp
@@ -54,15 +54,17 @@ InferenceState::InferenceState(PrivateTag, void *state,
     MY_LOG(2) << "begin_compute symbol "
               << (begin_compute_fn_ ? "resolved" : "not exported (no-op)");
 
-    // Cache the output-shape program (BuildShapeFunctionPass + GenerateInterface
-    // emit it only when the graph's outputs need it). Null on older model.dlls
+    // Cache the output-shape program (BuildShapeFunctionPass +
+    // GenerateInterface emit it only when the graph's outputs need it). Null on
+    // older model.dlls
     // -> infer_shapes() is a no-op and marshal_output_tensors falls back to the
     // DimSource path. Note inference_infer_shapes takes no state_ handle: it is
     // a pure data-independent shape program with no RuntimeState dependency.
     infer_shapes_fn_ =
-        plugin_->get_method<int, const int64_t *const *, const int64_t *,
-                            int64_t, int64_t *const *, const int64_t *,
-                            int64_t>("inference_infer_shapes");
+        plugin_
+            ->get_method<int, const int64_t *const *, const int64_t *, int64_t,
+                         int64_t *const *, const int64_t *, int64_t>(
+                "inference_infer_shapes");
     MY_LOG(2) << "infer_shapes symbol "
               << (infer_shapes_fn_ ? "resolved" : "not exported (no-op)");
   }
@@ -201,7 +203,8 @@ void InferenceState::begin_compute() const {
 }
 
 int InferenceState::infer_shapes(const int64_t *const *input_shapes,
-                                 const int64_t *input_ranks, int64_t input_count,
+                                 const int64_t *input_ranks,
+                                 int64_t input_count,
                                  int64_t *const *output_shapes,
                                  const int64_t *output_ranks,
                                  int64_t output_count) const {

--- a/backend-mlir-compiler/custom-op-mlir/src/InferenceState.cpp
+++ b/backend-mlir-compiler/custom-op-mlir/src/InferenceState.cpp
@@ -43,7 +43,7 @@ InferenceState::InferenceState(PrivateTag, void *state,
                                std::unique_ptr<morphizen::Plugin> plugin,
                                const std::string &temp_dll_path)
     : state_(state), plugin_(std::move(plugin)), temp_dll_path_(temp_dll_path),
-      begin_compute_fn_(nullptr) {
+      begin_compute_fn_(nullptr), infer_shapes_fn_(nullptr) {
   // Cache the begin_compute symbol so the per-Compute() invocation is a
   // single indirect call. Older model.dlls do not export this symbol; in
   // that case we leave begin_compute_fn_ null and begin_compute() becomes
@@ -53,6 +53,18 @@ InferenceState::InferenceState(PrivateTag, void *state,
         plugin_->get_method<void, void *>("hipdnn_ep_runtime_begin_compute");
     MY_LOG(2) << "begin_compute symbol "
               << (begin_compute_fn_ ? "resolved" : "not exported (no-op)");
+
+    // Cache the output-shape program (BuildShapeFunctionPass + GenerateInterface
+    // emit it only when the graph's outputs need it). Null on older model.dlls
+    // -> infer_shapes() is a no-op and marshal_output_tensors falls back to the
+    // DimSource path. Note inference_infer_shapes takes no state_ handle: it is
+    // a pure data-independent shape program with no RuntimeState dependency.
+    infer_shapes_fn_ =
+        plugin_->get_method<int, const int64_t *const *, const int64_t *,
+                            int64_t, int64_t *const *, const int64_t *,
+                            int64_t>("inference_infer_shapes");
+    MY_LOG(2) << "infer_shapes symbol "
+              << (infer_shapes_fn_ ? "resolved" : "not exported (no-op)");
   }
   // Safety net: warn loudly when the seqlens_k cache is effectively on
   // but the model.dll predates the begin_compute export. Without the
@@ -186,6 +198,19 @@ void InferenceState::begin_compute() const {
   if (begin_compute_fn_ && state_) {
     begin_compute_fn_(state_);
   }
+}
+
+int InferenceState::infer_shapes(const int64_t *const *input_shapes,
+                                 const int64_t *input_ranks, int64_t input_count,
+                                 int64_t *const *output_shapes,
+                                 const int64_t *output_ranks,
+                                 int64_t output_count) const {
+  // No-op on model.dlls that predate the export (see has_infer_shapes()).
+  if (!infer_shapes_fn_) {
+    return 0;
+  }
+  return infer_shapes_fn_(input_shapes, input_ranks, input_count, output_shapes,
+                          output_ranks, output_count);
 }
 
 // ----------------------------------------------------------------------------

--- a/backend-mlir-compiler/custom-op-mlir/src/InferenceState.h
+++ b/backend-mlir-compiler/custom-op-mlir/src/InferenceState.h
@@ -61,6 +61,29 @@ public:
   // Execute inference computation
   int compute(span_t *inputs, span_t *outputs) const;
 
+  // True when the model.dll exports inference_infer_shapes (resolved once in
+  // create()). False on older model.dlls that predate BuildShapeFunctionPass;
+  // callers fall back to the DimSource path in that case.
+  bool has_infer_shapes() const { return infer_shapes_fn_ != nullptr; }
+
+  // Run the data-independent output-shape program (inference_infer_shapes)
+  // emitted by BuildShapeFunctionPass. Maps every graph input's runtime dims
+  // to every graph output's dims via pure index arithmetic (no kernels, no
+  // device work). Used to resolve dynamic output dims that DimSource cannot
+  // express (non-identity functions of input dims, e.g. vision patch mergers).
+  //
+  //   input_shapes[k]  -> int64_t[input_ranks[k]]  (k in DLL/metadata order)
+  //   output_shapes[j] -> int64_t[output_ranks[j]] buffers the program fills
+  //
+  // Dims the program cannot resolve are written as a kDynamic sentinel
+  // (INT64_MIN); the caller treats negative results as "unresolved". Returns
+  // false (a no-op) when has_infer_shapes() is false. Returns the program's
+  // own status code otherwise (0 == success).
+  int infer_shapes(const int64_t *const *input_shapes,
+                   const int64_t *input_ranks, int64_t input_count,
+                   int64_t *const *output_shapes, const int64_t *output_ranks,
+                   int64_t output_count) const;
+
   // Mark the start of a new forward pass before inference_compute. If the
   // model.dll exports hipdnn_ep_runtime_begin_compute (resolved once in
   // create()) it is invoked to invalidate per-Compute() runtime caches
@@ -104,6 +127,15 @@ private:
   // predates the export.
   using BeginComputeFn = void (*)(void *);
   BeginComputeFn begin_compute_fn_;
+
+  // Cached function pointer for inference_infer_shapes. Resolved once in
+  // create() (same backward-compat contract as begin_compute_fn_): null when
+  // the model.dll predates the export, in which case infer_shapes() is a
+  // no-op and the EP resolves dynamic dims purely via DimSource.
+  using InferShapesFn = int (*)(const int64_t *const *, const int64_t *,
+                                int64_t, int64_t *const *, const int64_t *,
+                                int64_t);
+  InferShapesFn infer_shapes_fn_;
 };
 
 } // namespace mlir_compilation::customop

--- a/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
+++ b/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
@@ -243,15 +243,22 @@ static std::vector<int> build_present_to_past_input_idx(
 // output_index_map maps from metadata output index (= DLL output index) to
 // the ORT kernel context output index.
 // For dynamic shapes (dim == -1 in metadata), resolves the actual dimension
-// value from the corresponding input tensor using DimSource references.
+// value via the per-dim DimResolution strategy:
+//   - DIM_FROM_INPUT   -> copy input_idx.shape[dim_idx] (DimSource)
+//   - DIM_FROM_SHAPE_FN-> the model.dll's inference_infer_shapes program
+//                         (called once up-front for all outputs)
 // present_to_past_input_idx is precomputed at MlirCustomOp construction;
 // entry is -1 for outputs that are not `present.*` tensors.
+// `inputs` is the metadata input list (DLL/compiler order), used to build the
+// shape-program's input argument rows.
 TensorData marshal_output_tensors(
     OrtKernelContext *context,
     const google::protobuf::RepeatedPtrField<mlir_metadata::Output> &outputs,
+    const google::protobuf::RepeatedPtrField<mlir_metadata::Input> &inputs,
     const std::vector<int> &output_index_map,
     const std::vector<int> &input_index_map,
-    const std::vector<int> &present_to_past_input_idx) {
+    const std::vector<int> &present_to_past_input_idx,
+    const customop::InferenceState *inference_state) {
   if (outputs.size() == 0) {
     LOG(FATAL) << "No output shapes in metadata";
   }
@@ -263,10 +270,85 @@ TensorData marshal_output_tensors(
   data.tensors.resize(outputs.size());
   data.shapes.resize(outputs.size());
 
+  // ---- Shape-program (inference_infer_shapes) resolution ------------------
+  // Some dynamic output dims are non-identity functions of the input dims
+  // (e.g. a vision patch-merger seq collapse) that no single input dim
+  // expresses; build_metadata_json marks those DIM_FROM_SHAPE_FN. Resolve
+  // them by calling the model.dll's data-independent shape program once,
+  // feeding it every input's runtime shape and reading back every output's
+  // shape. Skipped entirely (zero cost) when no output needs it or the DLL
+  // predates the export.
+  bool need_shape_fn = false;
+  for (int i = 0; i < outputs.size() && !need_shape_fn; ++i) {
+    const auto &om = outputs[i];
+    for (int d = 0; d < om.dim_sources_size(); ++d) {
+      if (om.dim_sources(d).resolution() == mlir_metadata::DIM_FROM_SHAPE_FN) {
+        need_shape_fn = true;
+        break;
+      }
+    }
+  }
+
+  std::vector<std::vector<int64_t>> shape_fn_out; // [output][dim], empty if N/A
+  if (need_shape_fn && inference_state &&
+      inference_state->has_infer_shapes()) {
+    // Build input rows in DLL/metadata order from the actual runtime shapes.
+    const int input_count = inputs.size();
+    std::vector<std::vector<int64_t>> in_shapes(input_count);
+    std::vector<const int64_t *> in_ptrs(input_count);
+    std::vector<int64_t> in_ranks(input_count);
+    for (int k = 0; k < input_count; ++k) {
+      CHECK(k < static_cast<int>(input_index_map.size()))
+          << "Shape program: metadata input " << k
+          << " has no input_index_map entry (have "
+          << input_index_map.size() << ")";
+      auto src = ctx.GetInput(input_index_map[k]);
+      in_shapes[k] = src.GetTensorTypeAndShapeInfo().GetShape();
+      in_ptrs[k] = in_shapes[k].data();
+      in_ranks[k] = static_cast<int64_t>(in_shapes[k].size());
+    }
+
+    // Pre-size per-output buffers to each output's rank; the program fills
+    // every dim (unresolved dims come back as a negative kDynamic sentinel).
+    const int output_count = outputs.size();
+    shape_fn_out.resize(output_count);
+    std::vector<int64_t *> out_ptrs(output_count);
+    std::vector<int64_t> out_ranks(output_count);
+    for (int j = 0; j < output_count; ++j) {
+      shape_fn_out[j].assign(outputs[j].shape().size(), 0);
+      out_ptrs[j] = shape_fn_out[j].data();
+      out_ranks[j] = static_cast<int64_t>(shape_fn_out[j].size());
+    }
+
+    int rc = inference_state->infer_shapes(
+        in_ptrs.data(), in_ranks.data(), input_count, out_ptrs.data(),
+        out_ranks.data(), output_count);
+    CHECK(rc == 0) << "inference_infer_shapes failed with code " << rc;
+  }
+
   for (int i = 0; i < outputs.size(); ++i) {
     const auto &output_meta = outputs[i];
     data.shapes[i].assign(output_meta.shape().begin(),
                           output_meta.shape().end());
+
+    // First pass: fill DIM_FROM_SHAPE_FN dims from the shape-program result.
+    // A negative value means the program could not resolve the dim (kDynamic
+    // sentinel) -- leave it -1 so the DimSource fallback / past override below
+    // gets a chance, and the post-loop CHECK reports it if nothing resolves.
+    if (!shape_fn_out.empty()) {
+      for (int d = 0; d < static_cast<int>(data.shapes[i].size()); ++d) {
+        if (data.shapes[i][d] != -1)
+          continue;
+        if (d >= output_meta.dim_sources_size())
+          continue;
+        if (output_meta.dim_sources(d).resolution() !=
+            mlir_metadata::DIM_FROM_SHAPE_FN)
+          continue;
+        int64_t v = shape_fn_out[i][d];
+        if (v >= 0)
+          data.shapes[i][d] = v;
+      }
+    }
 
     // Resolve dynamic dims (-1) using DimSource entries from metadata.
     // Each DimSource with resolved=true says "this output dim equals
@@ -356,10 +438,13 @@ TensorData marshal_output_tensors(
     for (int d = 0; d < static_cast<int>(data.shapes[i].size()); ++d) {
       CHECK(data.shapes[i][d] >= 0)
           << "Output '" << output_meta.name() << "' dim " << d
-          << " is still dynamic (-1) after DimSource resolution. "
-          << "This means the compiler emitted no resolvable DimSource and "
-          << "no past-input override fired. Check that the dynamic dim has "
-          << "a dim_param shared with at least one input.";
+          << " is still dynamic (-1) after shape-program, DimSource, and "
+          << "past-input override resolution. Likely causes: (a) the dim is "
+          << "DIM_FROM_SHAPE_FN but inference_infer_shapes returned kDynamic "
+          << "(the shape program could not express it -- e.g. a data-dependent "
+          << "or hip.loop-carried dim), or (b) the loaded model.dll predates "
+          << "the inference_infer_shapes export (delete the cached "
+          << "morphizen_mlir_* DLL so it recompiles with the shape program).";
     }
 
     int ort_idx = output_index_map[i];
@@ -631,9 +716,9 @@ void MlirCustomOp::Compute(const OrtApi *api, OrtKernelContext *context) const {
   if (!perf_enabled()) {
     // --- Fast path: original behaviour, no timing overhead. ---
     auto inputs = marshal_input_tensors(context, input_index_map_);
-    auto outputs =
-        marshal_output_tensors(context, metadata_.outputs(), output_index_map_,
-                               input_index_map_, present_to_past_input_idx_);
+    auto outputs = marshal_output_tensors(
+        context, metadata_.outputs(), metadata_.inputs(), output_index_map_,
+        input_index_map_, present_to_past_input_idx_, inference_state_.get());
 
     int ret = inference_state_->compute(&inputs.span, &outputs.span);
     if (ret != 0) {
@@ -655,9 +740,9 @@ void MlirCustomOp::Compute(const OrtApi *api, OrtKernelContext *context) const {
   const auto t_enter = clock::now();
   auto inputs = marshal_input_tensors(context, input_index_map_);
   const auto t_after_in = clock::now();
-  auto outputs =
-      marshal_output_tensors(context, metadata_.outputs(), output_index_map_,
-                             input_index_map_, present_to_past_input_idx_);
+  auto outputs = marshal_output_tensors(
+      context, metadata_.outputs(), metadata_.inputs(), output_index_map_,
+      input_index_map_, present_to_past_input_idx_, inference_state_.get());
   const auto t_after_out = clock::now();
 
   // Stream used by inference_compute (first field of RuntimeState).  May be

--- a/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
+++ b/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
@@ -290,8 +290,7 @@ TensorData marshal_output_tensors(
   }
 
   std::vector<std::vector<int64_t>> shape_fn_out; // [output][dim], empty if N/A
-  if (need_shape_fn && inference_state &&
-      inference_state->has_infer_shapes()) {
+  if (need_shape_fn && inference_state && inference_state->has_infer_shapes()) {
     // Build input rows in DLL/metadata order from the actual runtime shapes.
     const int input_count = inputs.size();
     std::vector<std::vector<int64_t>> in_shapes(input_count);
@@ -300,8 +299,8 @@ TensorData marshal_output_tensors(
     for (int k = 0; k < input_count; ++k) {
       CHECK(k < static_cast<int>(input_index_map.size()))
           << "Shape program: metadata input " << k
-          << " has no input_index_map entry (have "
-          << input_index_map.size() << ")";
+          << " has no input_index_map entry (have " << input_index_map.size()
+          << ")";
       auto src = ctx.GetInput(input_index_map[k]);
       in_shapes[k] = src.GetTensorTypeAndShapeInfo().GetShape();
       in_ptrs[k] = in_shapes[k].data();
@@ -320,9 +319,9 @@ TensorData marshal_output_tensors(
       out_ranks[j] = static_cast<int64_t>(shape_fn_out[j].size());
     }
 
-    int rc = inference_state->infer_shapes(
-        in_ptrs.data(), in_ranks.data(), input_count, out_ptrs.data(),
-        out_ranks.data(), output_count);
+    int rc = inference_state->infer_shapes(in_ptrs.data(), in_ranks.data(),
+                                           input_count, out_ptrs.data(),
+                                           out_ranks.data(), output_count);
     CHECK(rc == 0) << "inference_infer_shapes failed with code " << rc;
   }
 

--- a/backend-mlir-compiler/level-1-pass/src/pass_main.cpp
+++ b/backend-mlir-compiler/level-1-pass/src/pass_main.cpp
@@ -264,36 +264,23 @@ static std::string build_metadata_json(const CompilationArtifact &artifact,
         int64_t dim_val = normalizeDim((*shape_ptr)[d]);
         output_proto->add_shape(dim_val);
 
-        // For dynamic dims, look up the symbolic name and resolve to the
-        // input tensor that defines it.  Static dims emit explicit sentinel
-        // values (input_idx=-1, dim_idx=-1, resolved=false) so the wire
-        // format is unambiguous: a `resolved=false` DimSource that carries
-        // -1 sentinels can never be confused with a real (input 0, dim 0)
-        // source by a future consumer that bug-skips the `resolved` check.
-        // marshal_output_tensors ignores unresolved entries and falls back
-        // to Output.shape regardless.
+        // Classify each output dim into one of three runtime-resolution
+        // strategies (see DimResolution in metadata.proto):
+        //   - static (dim_val >= 0)            -> DIM_STATIC
+        //   - dynamic, identity copy of an input dim (shares a dim_param with
+        //     a graph input)                   -> DIM_FROM_INPUT  (DimSource)
+        //   - dynamic, non-identity function of inputs (no shared dim_param;
+        //     e.g. a vision patch-merger seq collapse) -> DIM_FROM_SHAPE_FN
+        // The SHAPE_FN case is resolved at runtime by the model.dll's
+        // inference_infer_shapes program (emitted by BuildShapeFunctionPass).
+        // We intentionally do NOT hard-fail here for a missing dim_param: the
+        // shape function can express dims that no single input dim does, so a
+        // dim_param-less dynamic dim is delegated to it instead of aborting
+        // the compile. If the shape function ALSO cannot resolve it (returns
+        // the kDynamic sentinel at runtime), the EP raises a clear per-output
+        // CHECK at inference time.
         auto *ds = output_proto->add_dim_sources();
-        if (dim_val == -1) {
-          // Fail at compile time rather than at runtime so the user sees a
-          // clear error naming the output, dim index, and dim_param name
-          // instead of a generic "dim still -1" CHECK from the EP.
-          CHECK(dp && d < static_cast<int>(dp->size()) && !(*dp)[d].empty())
-              << "Output '" << output.name() << "' dim " << d
-              << " is dynamic but has no symbolic name in dim_params_map; "
-              << "cannot emit DimSource. Either fix the model to expose a "
-              << "dim_param for this dimension, or freeze it to a constant.";
-          const auto &param_name = (*dp)[d];
-          auto pit = dim_param_map.find(param_name);
-          CHECK(pit != dim_param_map.end())
-              << "Output '" << output.name() << "' dim " << d
-              << " has dim_param '" << param_name
-              << "' but no graph input declares this symbolic name; cannot "
-              << "resolve at runtime. Outputs can only carry symbolic dims "
-              << "that also appear on at least one input.";
-          ds->set_input_idx(pit->second.first);
-          ds->set_dim_idx(pit->second.second);
-          ds->set_resolved(true);
-        } else {
+        if (dim_val != -1) {
           // Static dim: emit explicit sentinels so the wire format
           // unambiguously distinguishes "not populated" from
           // "intentionally references (input 0, dim 0)" without relying
@@ -303,6 +290,28 @@ static std::string build_metadata_json(const CompilationArtifact &artifact,
           ds->set_input_idx(-1);
           ds->set_dim_idx(-1);
           ds->set_resolved(false);
+          ds->set_resolution(mlir_metadata::DIM_STATIC);
+        } else {
+          const bool has_param =
+              dp && d < static_cast<int>(dp->size()) && !(*dp)[d].empty();
+          auto pit = has_param ? dim_param_map.find((*dp)[d])
+                               : dim_param_map.end();
+          if (has_param && pit != dim_param_map.end()) {
+            // Identity dynamic dim: equals input[pit].shape[pit] at runtime.
+            ds->set_input_idx(pit->second.first);
+            ds->set_dim_idx(pit->second.second);
+            ds->set_resolved(true);
+            ds->set_resolution(mlir_metadata::DIM_FROM_INPUT);
+          } else {
+            // Non-identity dynamic dim: delegate to inference_infer_shapes.
+            ds->set_input_idx(-1);
+            ds->set_dim_idx(-1);
+            ds->set_resolved(false);
+            ds->set_resolution(mlir_metadata::DIM_FROM_SHAPE_FN);
+            MY_LOG(1) << "Output '" << output.name() << "' dim " << d
+                      << " has no input-shared dim_param; will be resolved by "
+                         "inference_infer_shapes at runtime.";
+          }
         }
       }
     } else {

--- a/backend-mlir-compiler/level-1-pass/src/pass_main.cpp
+++ b/backend-mlir-compiler/level-1-pass/src/pass_main.cpp
@@ -294,8 +294,8 @@ static std::string build_metadata_json(const CompilationArtifact &artifact,
         } else {
           const bool has_param =
               dp && d < static_cast<int>(dp->size()) && !(*dp)[d].empty();
-          auto pit = has_param ? dim_param_map.find((*dp)[d])
-                               : dim_param_map.end();
+          auto pit =
+              has_param ? dim_param_map.find((*dp)[d]) : dim_param_map.end();
           if (has_param && pit != dim_param_map.end()) {
             // Identity dynamic dim: equals input[pit].shape[pit] at runtime.
             ds->set_input_idx(pit->second.first);

--- a/backend-mlir-compiler/proto/metadata.proto
+++ b/backend-mlir-compiler/proto/metadata.proto
@@ -12,15 +12,36 @@ message Metadata {
   repeated Input inputs = 3;
 }
 
-// Tracks which input tensor dimension provides a dynamic output dimension's
-// runtime value. `resolved` disambiguates the {input_idx=0, dim_idx=0}
-// default — a real (input 0, dim 0) source has resolved=true; an
-// unresolved dim (or a static dim with no source needed) has resolved=false.
-// Consumers MUST treat resolved=false as "do not use input_idx/dim_idx".
+// How a single output dimension's runtime value is obtained by the EP.
+// Stored per-dim in DimSource.resolution (see below). Proto3 default is the
+// first enumerator (DIM_STATIC=0), so an old metadata blob that predates this
+// field decodes every dim as DIM_STATIC — which is only ever correct for a
+// dim whose shape[i] >= 0, exactly the legacy "no resolution needed" case.
+enum DimResolution {
+  // shape[i] >= 0: the compile-time-static dim is used verbatim, no runtime
+  // resolution needed.
+  DIM_STATIC = 0;
+  // shape[i] == -1 and the dim shares a dim_param with a graph input: the EP
+  // reads input_idx.shape[dim_idx] at runtime (the DimSource fast path).
+  DIM_FROM_INPUT = 1;
+  // shape[i] == -1 and the dim is a non-identity function of input dims (e.g.
+  // a vision patch-merger seq-length collapse) that no single input dim
+  // expresses: the EP calls the model.dll's inference_infer_shapes shape
+  // program to compute it. input_idx/dim_idx are sentinels (-1) and unused.
+  DIM_FROM_SHAPE_FN = 2;
+}
+
+// Tracks how a single output dimension's runtime value is resolved. `resolved`
+// disambiguates the {input_idx=0, dim_idx=0} default — a real (input 0, dim 0)
+// source has resolved=true; an unresolved dim (or a static dim with no source
+// needed) has resolved=false. Consumers MUST treat resolved=false as "do not
+// use input_idx/dim_idx". `resolution` is the authoritative selector for the
+// runtime strategy (resolved==true iff resolution==DIM_FROM_INPUT).
 message DimSource {
   int32 input_idx = 1;
   int32 dim_idx = 2;
   bool resolved = 3;
+  DimResolution resolution = 4;
 }
 
 message Input {

--- a/lib/Conversion/OnnxToHip/ConvConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ConvConversion.cpp
@@ -81,12 +81,71 @@ ConvToHip::matchAndRewrite(mlir::Operation *op,
   if (auto attr = op->getAttrOfType<mlir::IntegerAttr>("group"))
     group = attr.getValue().getSExtValue();
 
-  // Create output tensor
+  // Create the output (DPS destination) tensor. For each DYNAMIC output dim we
+  // must materialize its runtime extent. The naive "output dim == input dim"
+  // copy is only correct for the batch axis and for stride-1 same-padding
+  // convs; a strided / downsampling conv has spatial extents that are a
+  // non-identity floor-division of the input extent, so we emit that
+  // arithmetic here. This is what lets the downstream shape program
+  // (BuildShapeFunctionPass) fold the true output extent and the EP size the
+  // ORT output buffer correctly for dynamic-spatial vision-style models.
+  //
+  // ONNX Conv output spatial formula (explicit pads; auto_pad NOTSET — the
+  // SAME_*/VALID auto_pad modes are not handled here, matching the rest of
+  // this converter which reads only the explicit `pads` attribute):
+  //   out[s] = floor((in[s] + pad_begin[s] + pad_end[s]
+  //                   - dilation[s]*(kernel[s]-1) - 1) / stride[s]) + 1
+  // The pad/dilation/kernel/stride terms are all compile-time constants, so
+  // each spatial dim collapses to a single `addi/divsi/addi` chain over
+  // `tensor.dim(input, dimIdx)` (divsi == floor for the non-negative numerator
+  // any valid conv produces). divsi/addi are speculatable with the constant
+  // divisor and are hoistable by hip-hoist-alloc-size-arith / hip-pool-allocs.
+  //
+  // Before (strides=[2,2], pads=[1,1,1,1], k=3x3, input <1x3x?x?>):
+  //   %h = tensor.dim %in, 2
+  //   %w = tensor.dim %in, 3
+  //   %o = tensor.empty(%h, %w) : tensor<1x16x?x?xf32>   // WRONG: out==in
+  // After:
+  //   %h  = tensor.dim %in, 2
+  //   %h1 = arith.addi %h, -1                            // +
+  //   (pad_lo+pad_hi-dil*(k-1)-1) %h2 = arith.divsi %h1, 2 // / stride %ho =
+  //   arith.addi %h2, 1 (… same for W …) %o  = tensor.empty(%ho, %wo) :
+  //   tensor<1x16x?x?xf32>
+  const int64_t rank = resultType.getRank();
+  const int64_t numSpatial = static_cast<int64_t>(kernelShape.size());
+  // Leading (non-spatial) output dims: N (batch) and C (channels).
+  const int64_t numLeading = rank - numSpatial;
   llvm::SmallVector<mlir::Value> dynSizes;
-  for (int64_t dimIdx : llvm::seq<int64_t>(resultType.getRank())) {
-    if (resultType.isDynamicDim(dimIdx))
-      dynSizes.push_back(
-          mlir::tensor::DimOp::create(rewriter, loc, input, dimIdx));
+  for (int64_t dimIdx : llvm::seq<int64_t>(rank)) {
+    if (!resultType.isDynamicDim(dimIdx))
+      continue;
+    mlir::Value sz;
+    if (dimIdx < numLeading) {
+      // Batch (dim 0) passes through from the input; output channels (dim 1)
+      // equal the weight tensor's leading dim (M). Both are rarely dynamic
+      // (channels are a static architecture constant), handled for safety.
+      sz = (dimIdx == 0)
+               ? mlir::tensor::DimOp::create(rewriter, loc, input, 0)
+               : mlir::tensor::DimOp::create(rewriter, loc, weights, 0);
+    } else {
+      const int64_t s = dimIdx - numLeading;
+      const int64_t padLo = pads[s];
+      const int64_t padHi = pads[numSpatial + s];
+      const int64_t cConst =
+          padLo + padHi - dilations[s] * (kernelShape[s] - 1) - 1;
+      mlir::Value inDim =
+          mlir::tensor::DimOp::create(rewriter, loc, input, dimIdx);
+      mlir::Value cVal =
+          mlir::arith::ConstantIndexOp::create(rewriter, loc, cConst);
+      mlir::Value sum = mlir::arith::AddIOp::create(rewriter, loc, inDim, cVal);
+      mlir::Value strideVal =
+          mlir::arith::ConstantIndexOp::create(rewriter, loc, strides[s]);
+      mlir::Value div =
+          mlir::arith::DivSIOp::create(rewriter, loc, sum, strideVal);
+      mlir::Value one = mlir::arith::ConstantIndexOp::create(rewriter, loc, 1);
+      sz = mlir::arith::AddIOp::create(rewriter, loc, div, one);
+    }
+    dynSizes.push_back(sz);
   }
 
   mlir::Value init =

--- a/test/lit/Conversion/onnx-to-hip/test_conv.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_conv.mlir
@@ -126,4 +126,42 @@ module {
   // CHECK-SAME: !hip.context
   // CHECK: hip.conv({{.*}}) ins({{.*}}) outs({{.*}}) {dilations = [1, 1], group = 1 : i64, kernel_shape = [7, 3], pads = [3, 1, 3, 1], strides = [2, 3]}
   // CHECK-NOT: hip.alloc
+
+  // --------------------------------------------------------------------------
+  // 6. Dynamic spatial dims, downsampling (stride=2). The output spatial
+  //    extent is NOT an identity copy of the input extent; the converter must
+  //    emit the ONNX output-dim formula per dynamic spatial axis so the DPS
+  //    `tensor.empty` (and the downstream shape program) gets the true size:
+  //      out[s] = floor((in[s] + pad_lo + pad_hi - dil*(k-1) - 1) / stride) + 1
+  //    Here pad_lo+pad_hi-dil*(k-1)-1 = 1+1-1*(3-1)-1 = -1 and stride = 2.
+  // --------------------------------------------------------------------------
+  func.func @conv_dynamic_spatial(%input: tensor<1x3x?x?xf32>, %weights: tensor<16x3x3x3xf32>, %bias: tensor<16xf32>) -> tensor<1x16x?x?xf32> {
+    %output = "onnx.Conv"(%input, %weights, %bias) {
+      kernel_shape = [3, 3],
+      strides = [2, 2],
+      pads = [1, 1, 1, 1],
+      dilations = [1, 1],
+      group = 1 : i64
+    } : (tensor<1x3x?x?xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>) -> tensor<1x16x?x?xf32>
+    return %output : tensor<1x16x?x?xf32>
+  }
+
+  // CHECK-LABEL: func.func @conv_dynamic_spatial
+  // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[IN:.*]]: tensor<1x3x?x?xf32>, %[[W:.*]]: tensor<16x3x3x3xf32>, %[[B:.*]]: tensor<16xf32>) -> tensor<1x16x?x?xf32>
+  // The formula constant (-1) and the stride divisor (2) must both appear.
+  // CHECK-DAG: arith.constant -1 : index
+  // CHECK-DAG: arith.constant 2 : index
+  // H axis: floor((dim2 + (-1)) / 2) + 1
+  // CHECK: tensor.dim %[[IN]], %{{.*}} : tensor<1x3x?x?xf32>
+  // CHECK: arith.addi
+  // CHECK: arith.divsi
+  // CHECK: arith.addi
+  // W axis: floor((dim3 + (-1)) / 2) + 1
+  // CHECK: tensor.dim %[[IN]], %{{.*}} : tensor<1x3x?x?xf32>
+  // CHECK: arith.addi
+  // CHECK: arith.divsi
+  // CHECK: arith.addi
+  // CHECK: tensor.empty(%{{.*}}, %{{.*}}) : tensor<1x16x?x?xf32>
+  // CHECK: hip.conv(%[[CTX]]) ins(%[[IN]], %[[W]], %[[B]] : tensor<1x3x?x?xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>) outs({{.*}} : tensor<1x16x?x?xf32>) {dilations = [1, 1], group = 1 : i64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [2, 2]}
+  // CHECK-NOT: hip.alloc
 }

--- a/tools/hip-onnx-runner/hip-onnx-runner.cpp
+++ b/tools/hip-onnx-runner/hip-onnx-runner.cpp
@@ -827,6 +827,11 @@ int main(int argc, char *argv[]) {
       "p", "positive-only",
       "Generate positive-only random inputs (for Sqrt/Reciprocal testing)",
       "false", true);
+  mo.add_option("D", "dyn-dim",
+                "Concrete value for dynamic (-1) input dims other than batch "
+                "(dim 0 is always set to 1). Lets models with dynamic spatial "
+                "or sequence dims run",
+                "16");
 
   try {
     mo.parse(argc, argv);
@@ -850,6 +855,7 @@ int main(int argc, char *argv[]) {
   const bool use_input_files = !input_dir_str.empty();
   const int graph_optimization_level = mo.get<int>("graph-opt-level");
   const bool positive_only = mo.get<bool>("positive-only");
+  const int64_t dyn_dim_value = mo.get<int>("dyn-dim");
 
   if ((l2norm_arg.size() == 2) && !l2norm_arg[0].empty() &&
       !l2norm_arg[1].empty()) {
@@ -1025,9 +1031,17 @@ int main(int argc, char *argv[]) {
   std::vector<Ort::Value> input_tensors;
 
   for (size_t i = 0; i < input_count; ++i) {
+    // Resolve every dynamic (-1) dim to a concrete extent so ORT can allocate
+    // the tensor. Batch (dim 0) collapses to 1; any other dynamic dim (e.g.
+    // dynamic spatial H/W on a conv input, or a dynamic sequence length) uses
+    // --dyn-dim. Without this, non-leading dynamic dims stayed -1 and tensor
+    // creation failed with "negative value in shape".
     auto shape = input_shapes[i];
-    if (!shape.empty() && shape[0] == -1)
-      shape[0] = 1;
+    for (size_t d = 0; d < shape.size(); ++d) {
+      if (shape[d] != -1)
+        continue;
+      shape[d] = (d == 0) ? 1 : dyn_dim_value;
+    }
 
     size_t elem_size = element_byte_size(input_types[i]);
     int64_t n_elems = calculate_product(shape);


### PR DESCRIPTION
## Summary
Stack PR **2/3** (base: #289). EP side that consumes the `inference_infer_shapes` export from #289, making non-identity dynamic output dims live end-to-end. For dynamic output dims that no shared `dim_param` resolves, `pass_main` classifies them `DIM_FROM_SHAPE_FN`; at inference the custom op calls the shape program to size the output before `ctx.GetOutput()`.

**What's in this PR:**
- **EP wiring** (`InferenceState`, `MlirCustomOp`): resolve `inference_infer_shapes` from the model DLL, call it with the runtime input shapes, and feed the computed extents into output allocation; `metadata.proto` gains `DIM_FROM_SHAPE_FN`.
- **Conv dynamic spatial dims** (`ConvConversion.cpp`): compute dynamic conv output spatial extents so the shape program can resolve conv-bearing graphs.
- **Runner**: `hip-onnx-runner` fills all dynamic inputs so dynamic-shape models can be exercised directly.

## Stack
1. #289 — compiler: shape-function emission (base: #288)
2. **#290** — EP consumes the shape fn (+ conv/runner) (base: #289)
3. #291 — data-dependent outputs (base: #290)

## Test plan
- [x] LIT: `onnx-to-hip/test_conv.mlir` (dynamic spatial dims) green.
- [x] Existing `hip-build-shape-fn` / e2e shape-fn LIT still green on the stacked tree.

Made with [Cursor](https://cursor.com)