### PR TITLE
feat(hip,ep): data-dependent dynamic output shapes — closed-form shape fn + Range

### DIFF
--- a/backend-mlir-compiler/custom-op-mlir/src/InferenceState.cpp
+++ b/backend-mlir-compiler/custom-op-mlir/src/InferenceState.cpp
@@ -61,10 +61,9 @@ InferenceState::InferenceState(PrivateTag, void *state,
     // DimSource path. Note inference_infer_shapes takes no state_ handle: it is
     // a pure data-independent shape program with no RuntimeState dependency.
     infer_shapes_fn_ =
-        plugin_
-            ->get_method<int, const int64_t *const *, const int64_t *, int64_t,
-                         int64_t *const *, const int64_t *, int64_t>(
-                "inference_infer_shapes");
+        plugin_->get_method<int, const int64_t *const *, const int64_t *,
+                            int64_t, const void *const *, int64_t *const *,
+                            const int64_t *, int64_t>("inference_infer_shapes");
     MY_LOG(2) << "infer_shapes symbol "
               << (infer_shapes_fn_ ? "resolved" : "not exported (no-op)");
   }
@@ -205,6 +204,7 @@ void InferenceState::begin_compute() const {
 int InferenceState::infer_shapes(const int64_t *const *input_shapes,
                                  const int64_t *input_ranks,
                                  int64_t input_count,
+                                 const void *const *input_data,
                                  int64_t *const *output_shapes,
                                  const int64_t *output_ranks,
                                  int64_t output_count) const {
@@ -212,8 +212,8 @@ int InferenceState::infer_shapes(const int64_t *const *input_shapes,
   if (!infer_shapes_fn_) {
     return 0;
   }
-  return infer_shapes_fn_(input_shapes, input_ranks, input_count, output_shapes,
-                          output_ranks, output_count);
+  return infer_shapes_fn_(input_shapes, input_ranks, input_count, input_data,
+                          output_shapes, output_ranks, output_count);
 }
 
 // ----------------------------------------------------------------------------

--- a/backend-mlir-compiler/custom-op-mlir/src/InferenceState.h
+++ b/backend-mlir-compiler/custom-op-mlir/src/InferenceState.h
@@ -73,6 +73,11 @@ public:
   // express (non-identity functions of input dims, e.g. vision patch mergers).
   //
   //   input_shapes[k]  -> int64_t[input_ranks[k]]  (k in DLL/metadata order)
+  //   input_data[k]    -> raw host-readable bytes of input k (closed-form
+  //                       data-dependent shape fns, e.g. Range, read scalar
+  //                       VALUES out of these; only the inputs the program
+  //                       actually reads are dereferenced — the caller passes a
+  //                       pointer per input regardless, null when unavailable)
   //   output_shapes[j] -> int64_t[output_ranks[j]] buffers the program fills
   //
   // Dims the program cannot resolve are written as a kDynamic sentinel
@@ -81,8 +86,8 @@ public:
   // own status code otherwise (0 == success).
   int infer_shapes(const int64_t *const *input_shapes,
                    const int64_t *input_ranks, int64_t input_count,
-                   int64_t *const *output_shapes, const int64_t *output_ranks,
-                   int64_t output_count) const;
+                   const void *const *input_data, int64_t *const *output_shapes,
+                   const int64_t *output_ranks, int64_t output_count) const;
 
   // Mark the start of a new forward pass before inference_compute. If the
   // model.dll exports hipdnn_ep_runtime_begin_compute (resolved once in
@@ -133,8 +138,8 @@ private:
   // the model.dll predates the export, in which case infer_shapes() is a
   // no-op and the EP resolves dynamic dims purely via DimSource.
   using InferShapesFn = int (*)(const int64_t *const *, const int64_t *,
-                                int64_t, int64_t *const *, const int64_t *,
-                                int64_t);
+                                int64_t, const void *const *, int64_t *const *,
+                                const int64_t *, int64_t);
   InferShapesFn infer_shapes_fn_;
 };
 

--- a/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
+++ b/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
@@ -296,6 +296,14 @@ TensorData marshal_output_tensors(
     std::vector<std::vector<int64_t>> in_shapes(input_count);
     std::vector<const int64_t *> in_ptrs(input_count);
     std::vector<int64_t> in_ranks(input_count);
+    // Raw host-readable data pointer per input. Closed-form data-dependent
+    // shape fns (e.g. Range, whose 1-D length = ceildiv(limit-start, delta))
+    // read scalar VALUES out of these; the model.dll only dereferences the
+    // inputs its shape program actually reads (per hipdnn.shape_fn_data_args),
+    // so passing a pointer for every input is safe. The EP allocator maps GPU
+    // input buffers host-accessible (hipHostMallocMapped) and CPU inputs are
+    // natively host memory, so GetTensorRawData() is host-readable here.
+    std::vector<const void *> in_data(input_count);
     for (int k = 0; k < input_count; ++k) {
       CHECK(k < static_cast<int>(input_index_map.size()))
           << "Shape program: metadata input " << k
@@ -305,6 +313,7 @@ TensorData marshal_output_tensors(
       in_shapes[k] = src.GetTensorTypeAndShapeInfo().GetShape();
       in_ptrs[k] = in_shapes[k].data();
       in_ranks[k] = static_cast<int64_t>(in_shapes[k].size());
+      in_data[k] = src.GetTensorRawData();
     }
 
     // Pre-size per-output buffers to each output's rank; the program fills
@@ -319,9 +328,9 @@ TensorData marshal_output_tensors(
       out_ranks[j] = static_cast<int64_t>(shape_fn_out[j].size());
     }
 
-    int rc = inference_state->infer_shapes(in_ptrs.data(), in_ranks.data(),
-                                           input_count, out_ptrs.data(),
-                                           out_ranks.data(), output_count);
+    int rc = inference_state->infer_shapes(
+        in_ptrs.data(), in_ranks.data(), input_count, in_data.data(),
+        out_ptrs.data(), out_ranks.data(), output_count);
     CHECK(rc == 0) << "inference_infer_shapes failed with code " << rc;
   }
 

--- a/backend-mlir-compiler/level-1-pass/src/pass_main.cpp
+++ b/backend-mlir-compiler/level-1-pass/src/pass_main.cpp
@@ -260,6 +260,23 @@ static std::string build_metadata_json(const CompilationArtifact &artifact,
       const std::vector<std::string> *dp =
           (it != all_dim_params.end()) ? &it->second : nullptr;
 
+      // Data-dependent output detection (7b): an output whose extent depends on
+      // input *data values* (a reduction count), not on input shapes, has a
+      // dynamic dim that neither a shared dim_param nor the shape program can
+      // express — the shape program yields only the compile-time UPPER BOUND.
+      // The canonical case is ONNX NonZero (trailing dim = count of non-zero
+      // elements). We detect it by the producing node's op type (the EP-side
+      // metadata is built from the ONNX graph, so the MLIR DataDependentResult
+      // trait is not visible here; this op-type set is the ONNX-level mirror of
+      // that trait). Such dynamic dims are classified DIM_FROM_COUNT so the EP
+      // runs the bounded-scratch + count + trim path instead of trusting the
+      // shape program's upper bound as the final extent.
+      bool output_is_data_dependent = false;
+      if (auto producer = graphRef.find_node(output.name())) {
+        const std::string &op = producer->op_type();
+        output_is_data_dependent = (op == "NonZero");
+      }
+
       for (int d = 0; d < static_cast<int>(shape_ptr->size()); ++d) {
         int64_t dim_val = normalizeDim((*shape_ptr)[d]);
         output_proto->add_shape(dim_val);
@@ -302,6 +319,18 @@ static std::string build_metadata_json(const CompilationArtifact &artifact,
             ds->set_dim_idx(pit->second.second);
             ds->set_resolved(true);
             ds->set_resolution(mlir_metadata::DIM_FROM_INPUT);
+          } else if (output_is_data_dependent) {
+            // Reduction-count dynamic dim (e.g. NonZero): the shape program can
+            // only express the upper bound; the EP resolves the true extent
+            // post-compute from the count side-channel and trims. See
+            // DIM_FROM_COUNT in metadata.proto.
+            ds->set_input_idx(-1);
+            ds->set_dim_idx(-1);
+            ds->set_resolved(false);
+            ds->set_resolution(mlir_metadata::DIM_FROM_COUNT);
+            MY_LOG(1) << "Output '" << output.name() << "' dim " << d
+                      << " is data-dependent (producer is a reduction-count "
+                         "op); will be resolved by the EP count + trim path.";
           } else {
             // Non-identity dynamic dim: delegate to inference_infer_shapes.
             ds->set_input_idx(-1);

--- a/backend-mlir-compiler/proto/metadata.proto
+++ b/backend-mlir-compiler/proto/metadata.proto
@@ -29,6 +29,17 @@ enum DimResolution {
   // expresses: the EP calls the model.dll's inference_infer_shapes shape
   // program to compute it. input_idx/dim_idx are sentinels (-1) and unused.
   DIM_FROM_SHAPE_FN = 2;
+  // shape[i] == -1 and the extent depends on input *data values* (a reduction
+  // count), not on input shapes — canonically ONNX NonZero, whose trailing dim
+  // is the number of non-zero elements. The shape program can only bound this
+  // dim by its compile-time upper bound (the input element count), since the
+  // true value is knowable only after scanning the data. The EP therefore: runs
+  // the op into a scratch buffer sized at that upper bound; reads back the true
+  // count the kernel recorded in a per-RuntimeState side-channel keyed by the
+  // scratch pointer; binds the ORT output to [rank, count]; and copies the
+  // valid [:, :count] prefix in. input_idx/dim_idx are sentinels (-1) and
+  // unused. Set when the producing HIP op carries the DataDependentResult trait.
+  DIM_FROM_COUNT = 3;
 }
 
 // Tracks how a single output dimension's runtime value is resolved. `resolved`

--- a/include/hip/Dialect/IR/HipDialect.h
+++ b/include/hip/Dialect/IR/HipDialect.h
@@ -25,6 +25,24 @@
 // generated declaration references `HipDpsOp::Trait`.
 #include "hip/Dialect/IR/HipDpsOpInterface.h.inc"
 
+namespace mlir {
+namespace OpTrait {
+namespace hip {
+/// Op trait marking ops whose result EXTENT depends on input *data values*
+/// (not just input shapes) — e.g. ONNX NonZero, whose trailing output dim is
+/// the count of non-zero elements (knowable only after scanning the data).
+/// Generic passes and the EP-metadata builder query this with
+/// `op->hasTrait<mlir::OpTrait::hip::DataDependentResult>()` instead of
+/// name-matching, so adding a future data-dependent op (Unique, Compress,
+/// dynamic TopK, …) needs no edits to the generic resolution logic. Must be
+/// declared before HipOps.h.inc, whose generated op class lists the trait.
+template <typename ConcreteType>
+class DataDependentResult
+    : public TraitBase<ConcreteType, DataDependentResult> {};
+} // namespace hip
+} // namespace OpTrait
+} // namespace mlir
+
 #define GET_OP_CLASSES
 #include "hip/Dialect/IR/HipOps.h.inc"
 

--- a/include/hip/Dialect/IR/HipDialect.td
+++ b/include/hip/Dialect/IR/HipDialect.td
@@ -20,4 +20,13 @@ def Hip_Dialect : Dialect {
   let useDefaultTypePrinterParser = 1;
 }
 
+// Marks an op whose result EXTENT depends on input *data values* (not just
+// input shapes) — e.g. NonZero (trailing dim = count of non-zero elements).
+// The C++ trait class is declared in HipDialect.h. Generic passes / the EP
+// metadata builder gate data-dependent-output handling on this trait via
+// `op->hasTrait<mlir::OpTrait::hip::DataDependentResult>()`.
+def DataDependentResult : NativeOpTrait<"DataDependentResult"> {
+  let cppNamespace = "::mlir::OpTrait::hip";
+}
+
 #endif // HIP_DIALECT

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -2952,7 +2952,8 @@ def Hip_SizeOp : Hip_DpsOp<"size", /*traits=*/[],
   }];
 }
 
-def Hip_NonZeroOp : Hip_DpsOp<"nonzero", /*traits=*/[], /*outsAccessor=*/"Y",
+def Hip_NonZeroOp : Hip_DpsOp<"nonzero", /*traits=*/[DataDependentResult],
+                              /*outsAccessor=*/"Y",
                               /*autoReify=*/1,
                               /*autoInfer=*/1, /*declareInfer=*/1> {
   let summary = "Indices of non-zero elements (ONNX NonZero)";

--- a/lib/Conversion/HipToLLVM/HipToLLVM.cpp
+++ b/lib/Conversion/HipToLLVM/HipToLLVM.cpp
@@ -255,6 +255,16 @@ void ConvertHipToLLVMPass::runOnOperation() {
   // stages would require a reconcile-unrealized-casts cleanup pass.
   populateFuncToLLVMConversionPatterns(typeConverter, patterns);
   populateFinalizeMemRefToLLVMConversionPatterns(typeConverter, patterns);
+  // ceildivsi/floordivsi/ceildivui have no one-step LLVM form; each expands to
+  // primitive arith — e.g. ceildivsi(a,b) is a/b rounded toward +inf by adding
+  // 1 when the division has a nonzero remainder and the operands share a sign
+  // (cmp + select). The closed-form ONNX Range length is ceildiv(limit - start,
+  // delta), and that same expression is mirrored into the @infer_shapes shape
+  // program, so both the main graph and the shape function reach this pass
+  // carrying an arith.ceildivsi. Seeding the expand patterns into this single
+  // conversion lets the expanded primitives re-legalize through the arith→LLVM
+  // patterns below in the same fixpoint, avoiding a separate arith-expand pass.
+  arith::populateCeilFloorDivExpandOpsPatterns(patterns);
   arith::populateArithToLLVMConversionPatterns(typeConverter, patterns);
   cf::populateControlFlowToLLVMConversionPatterns(typeConverter, patterns);
 

--- a/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
+++ b/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
@@ -18,6 +18,7 @@
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 #include "mlir/Conversion/MemRefToLLVM/MemRefToLLVM.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Arith/Transforms/Passes.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/FunctionCallUtils.h"

--- a/lib/Dialect/Transforms/BuildShapeFunction.cpp
+++ b/lib/Dialect/Transforms/BuildShapeFunction.cpp
@@ -6,10 +6,11 @@
 //
 // Emits a pure, data-independent `@infer_shapes` function that computes every
 // `@main_graph` output dimension as index arithmetic over the input tensor
-// dimensions. The MorphiZen EP calls the exported `inference_infer_shapes`
-// wrapper (emitted later by GenerateInterface) before `ctx.GetOutput()` to
-// size output buffers whose dims are not a verbatim copy of an input dim —
-// flattens, reshapes, patch mergers — which `DimSource` cannot express.
+// dimensions (and, for closed-form data-dependent dims, input scalar values).
+// The MorphiZen EP calls the exported `inference_infer_shapes` wrapper
+// (emitted later by GenerateInterface) before `ctx.GetOutput()` to size output
+// buffers whose dims are not a verbatim copy of an input dim — flattens,
+// reshapes, patch mergers, strided convs — which `DimSource` cannot express.
 // `DimSource` stays the O(1) fast path; this pass is best-effort and never
 // hard-fails: any dim it cannot reduce to input arithmetic becomes the
 // kDynamic sentinel and the EP falls back to `DimSource`.
@@ -27,18 +28,36 @@
 //      folds. Each `tensor.dim` collapses to arithmetic over `tensor.dim %arg,
 //      c` leaves; the hip.* compute is not in that slice and folds away.
 //   4. For each resolved dim, walk its operand DAG post-order. The dim is
-//      RESOLVED iff every path bottoms out at a constant or a `tensor.dim
-//      %inputArg, c` (an input shape dim), joined only by side-effect-free,
-//      region-free arith/affine ops. Clone that slice into @infer_shapes,
-//      remapping each shape-dim leaf to its dim arg. Any other leaf (a hip.*
+//      RESOLVED iff every path bottoms out at one of
+//        * a constant,
+//        * `tensor.dim %inputArg, c`        — an input shape dim, or
+//        * `tensor.extract %inputArg[c...]` — an input scalar value,
+//      joined only by side-effect-free, region-free arith/affine ops. Clone
+//      that slice into @infer_shapes, remapping each shape-dim leaf to its dim
+//      arg and each scalar leaf to its value arg. Any other leaf (a hip.*
 //      result, a `tensor.dim` on a non-input value such as a hip.loop result,
 //      a non-arith op such as math.ceil) makes the dim unresolvable → kDynamic.
 //   5. Erase the scratch func.
 //
+// Closed-form data-dependent dims
+// -------------------------------
+// Some output extents are a function of input VALUES, not shapes — e.g. ONNX
+// Range, whose 1-D length is ceildiv(limit - start, delta). RangeConversion
+// already materializes that arithmetic in-IR: `tensor.extract` reads the
+// start/limit/delta scalars, arith computes the length, and the result feeds
+// the `tensor.empty` destination of hip.range, whose result dim reifies back
+// through that empty. So step 3 folds the dim query onto the same arith chain
+// and the only new leaf kind is a scalar `tensor.extract`. Each unique scalar
+// leaf becomes an extra @infer_shapes argument carrying that value; its
+// (input_idx, elem_offset, elem_bits) fetch descriptor is recorded in the
+// `hipdnn.shape_fn_data_args` module attribute so GenerateInterface can load
+// the scalar from the EP-provided input_data pointers.
+//
 // Signature contract (consumed by GenerateInterface):
-//   (!hip.context, index×totalInputDims) -> (index×outputDims)
+//   (!hip.context, index×totalInputDims, scalar×dataArgs) -> (index×outputDims)
 //   * arg 0 is an unused `!hip.context` (see below);
 //   * one `index` arg per (input tensor, dim), row-major over all inputs;
+//   * one arg per unique scalar leaf, in `hipdnn.shape_fn_data_args` order;
 //   * one `index` result per (output tensor, dim), row-major over all outputs.
 //   Non-tensor inputs and the context contribute no dims.
 //
@@ -127,17 +146,41 @@ static void runDimResolution(func::FuncOp f) {
   (void)applyPatternsGreedily(f, std::move(patterns));
 }
 
+/// Row-major linear element offset of a constant-index `tensor.extract` on a
+/// static-shape tensor. Rank-0 (scalar) → 0. Caller guarantees static shape +
+/// constant indices (gatherSlice's extract-leaf gate), so this never fails for
+/// an accepted leaf; std::nullopt only on a malformed (non-constant) index.
+static std::optional<int64_t> extractLinearOffset(tensor::ExtractOp ex) {
+  auto t = cast<RankedTensorType>(ex.getTensor().getType());
+  ArrayRef<int64_t> shape = t.getShape();
+  SmallVector<int64_t> strides(shape.size(), 1);
+  for (int64_t i = static_cast<int64_t>(shape.size()) - 2; i >= 0; --i)
+    strides[i] = strides[i + 1] * shape[i + 1];
+  int64_t offset = 0;
+  for (auto [i, idxVal] : llvm::enumerate(ex.getIndices())) {
+    std::optional<int64_t> c = getConstantIntValue(idxVal);
+    if (!c)
+      return std::nullopt;
+    offset += *c * strides[i];
+  }
+  return offset;
+}
+
 /// Post-order walk of `v`'s operand DAG. Returns true iff `v` is a pure
-/// function of constants and input-tensor dims. On success:
+/// function of constants, input-tensor dims, and input-tensor scalar values.
+/// On success:
 ///   - `orderedOps` accumulates the pure arith/affine ops to clone, operands
 ///     before uses (topo order);
 ///   - `leaves` records each `tensor.dim %arg, %c` leaf (NOT cloned — remapped
-///     to a scalar arg by the caller).
+///     to a dim arg by the caller);
+///   - `dataLeaves` records each `tensor.extract %arg[const]` leaf on an input
+///     scalar (NOT cloned — remapped to a data-value arg by the caller).
 /// `memo` dedups shared subexpressions (SSA is acyclic, so no cycle guard).
 static bool gatherSlice(Value v,
                         const DenseMap<BlockArgument, unsigned> &tensorArgPos,
                         llvm::SetVector<Operation *> &orderedOps,
                         SmallVectorImpl<tensor::DimOp> &leaves,
+                        SmallVectorImpl<tensor::ExtractOp> &dataLeaves,
                         DenseMap<Operation *, bool> &memo) {
   Operation *def = v.getDefiningOp();
   if (!def)
@@ -158,8 +201,27 @@ static bool gatherSlice(Value v,
     return ok;
   }
 
+  // Data leaf: `tensor.extract %inputArg[constIndices]` reads a scalar VALUE
+  // from an input tensor (closed-form data-dependent dims, e.g. Range length).
+  // Gated to a static-shape input-tensor block arg with all-constant indices
+  // so the element offset is statically known and the EP can read it host-side
+  // before GetOutput. The value becomes an extra @infer_shapes arg.
+  if (auto extractOp = dyn_cast<tensor::ExtractOp>(def)) {
+    auto blockArg = dyn_cast<BlockArgument>(extractOp.getTensor());
+    auto t = dyn_cast<RankedTensorType>(extractOp.getTensor().getType());
+    bool allConst = llvm::all_of(extractOp.getIndices(), [](Value idx) {
+      return getConstantIntValue(idx).has_value();
+    });
+    bool ok = blockArg && tensorArgPos.contains(blockArg) && t &&
+              t.hasStaticShape() && allConst;
+    memo[def] = ok;
+    if (ok)
+      dataLeaves.push_back(extractOp);
+    return ok;
+  }
+
   // Interior: any side-effect-free, region-free arith/affine op (covers
-  // arith.constant, muli/addi/divui/index_cast, affine.apply, …).
+  // arith.constant, muli/addi/divui/index_cast/cmpi/select, affine.apply, …).
   StringRef ns = def->getDialect() ? def->getDialect()->getNamespace() : "";
   bool pureArithAffine = isMemoryEffectFree(def) && def->getNumRegions() == 0 &&
                          (ns == "arith" || ns == "affine");
@@ -168,7 +230,8 @@ static bool gatherSlice(Value v,
     return false;
   }
   for (Value operand : def->getOperands()) {
-    if (!gatherSlice(operand, tensorArgPos, orderedOps, leaves, memo)) {
+    if (!gatherSlice(operand, tensorArgPos, orderedOps, leaves, dataLeaves,
+                     memo)) {
       memo[def] = false;
       return false;
     }
@@ -256,13 +319,59 @@ void BuildShapeFunctionPass::runOnOperation() {
     inPrefix[i + 1] = inPrefix[i] + inRanks[i];
   unsigned totalInDims = inPrefix.back();
 
-  // 5. Create @infer_shapes(!hip.context, index x totalInDims)
-  //                         -> (index x resolved.size()).
+  // 5. First pass: gather each resolved dim's pure slice and register the
+  //    unique data leaves (tensor.extract on input scalars). The data leaves
+  //    become extra @infer_shapes args carrying the scalar VALUES, so they
+  //    must be known before the signature is built. The SAME extract op is
+  //    shared across dims in @main_graph, so deduping by op pointer yields a
+  //    stable param slot per unique (input, element-offset).
+  struct DimSlice {
+    bool ok = false;
+    Value rv;
+    llvm::SetVector<Operation *> ordered;
+    SmallVector<tensor::DimOp> leaves;
+    SmallVector<tensor::ExtractOp> dataLeaves;
+  };
+  struct DataArg {
+    unsigned inputPos; // position among ranked-tensor inputs == model input idx
+    int64_t elemOffset; // row-major element offset into that input
+    Type elemTy;        // scalar element type (== the @infer_shapes data param)
+  };
+  SmallVector<DimSlice> slices(resolved.size());
+  SmallVector<DataArg> dataArgs;
+  DenseMap<Operation *, unsigned> extractSlot; // extract op -> data param slot
+  for (auto [i, rv] : llvm::enumerate(resolved)) {
+    DimSlice &s = slices[i];
+    s.rv = rv;
+    DenseMap<Operation *, bool> memo;
+    s.ok =
+        gatherSlice(rv, tensorArgPos, s.ordered, s.leaves, s.dataLeaves, memo);
+    if (!s.ok)
+      continue;
+    for (tensor::ExtractOp ex : s.dataLeaves) {
+      if (extractSlot.contains(ex.getOperation()))
+        continue;
+      std::optional<int64_t> off = extractLinearOffset(ex);
+      if (!off) { // non-constant index slipped through — treat dim as dynamic
+        s.ok = false;
+        break;
+      }
+      auto blockArg = cast<BlockArgument>(ex.getTensor());
+      extractSlot[ex.getOperation()] = dataArgs.size();
+      dataArgs.push_back({tensorArgPos[blockArg], *off, ex.getType()});
+    }
+  }
+
+  // 6. Create @infer_shapes(!hip.context, index x totalInDims, <dataTy> x
+  //    dataArgs.size()) -> (index x resolved.size()).
   //    arg 0 is the unused !hip.context (module-wide invariant; see header);
-  //    the scalar dim args follow it, hence the `1 +` offset in paramFor.
+  //    the dim args follow it (hence `1 +` in paramFor), then the data-value
+  //    args (hence `1 + totalInDims +` in dataParamFor).
   SmallVector<Type> argTypes;
   argTypes.push_back(ContextType::get(ctx));
   argTypes.append(totalInDims, idxTy);
+  for (const DataArg &da : dataArgs)
+    argTypes.push_back(da.elemTy);
   SmallVector<Type> resTypes(resolved.size(), idxTy);
   auto fn = func::FuncOp::create(loc, "infer_shapes",
                                  FunctionType::get(ctx, argTypes, resTypes));
@@ -273,32 +382,56 @@ void BuildShapeFunctionPass::runOnOperation() {
   auto paramFor = [&](unsigned tensorPos, int64_t dimIdx) -> Value {
     return fnBlock->getArgument(1 + inPrefix[tensorPos] + dimIdx);
   };
+  auto dataParamFor = [&](unsigned slot) -> Value {
+    return fnBlock->getArgument(1 + totalInDims + slot);
+  };
 
-  // 6. For each resolved dim, clone its pure slice into @infer_shapes (or emit
-  //    kDynamic on fallback).
+  // 7. For each resolved dim, clone its pure slice into @infer_shapes (or emit
+  //    kDynamic on fallback), remapping dim leaves to dim args and data leaves
+  //    to data-value args.
   SmallVector<Value> results;
   results.reserve(resolved.size());
-  for (Value rv : resolved) {
-    llvm::SetVector<Operation *> ordered;
-    SmallVector<tensor::DimOp> leaves;
-    DenseMap<Operation *, bool> memo;
-    if (!gatherSlice(rv, tensorArgPos, ordered, leaves, memo)) {
+  for (DimSlice &s : slices) {
+    if (!s.ok) {
       results.push_back(arith::ConstantIndexOp::create(fb, loc, kUnknownDim));
       continue;
     }
     IRMapping map;
-    for (tensor::DimOp dimOp : leaves) {
+    for (tensor::DimOp dimOp : s.leaves) {
       auto blockArg = cast<BlockArgument>(dimOp.getSource());
       int64_t dimIdx = *getConstantIntValue(dimOp.getIndex());
       map.map(dimOp.getResult(), paramFor(tensorArgPos[blockArg], dimIdx));
     }
-    for (Operation *op : ordered)
+    for (tensor::ExtractOp ex : s.dataLeaves)
+      map.map(ex.getResult(), dataParamFor(extractSlot[ex.getOperation()]));
+    for (Operation *op : s.ordered)
       fb.clone(*op, map);
-    results.push_back(map.lookupOrDefault(rv));
+    results.push_back(map.lookupOrDefault(s.rv));
   }
   func::ReturnOp::create(fb, loc, results);
 
-  // 7. Drop the scratch func.
+  // 8. Record the data-arg descriptors so GenerateInterface can emit the
+  //    matching input_data loads (one per appended data param, in slot order).
+  //    elem_bits is the scalar's bit width (int or float); the EP reads
+  //    input_data[input_idx] at byte offset elem_offset*(elem_bits/8).
+  if (!dataArgs.empty()) {
+    auto i64Ty = IntegerType::get(ctx, 64);
+    SmallVector<Attribute> dataArgAttrs;
+    for (const DataArg &da : dataArgs) {
+      int64_t bits = da.elemTy.getIntOrFloatBitWidth();
+      dataArgAttrs.push_back(DictionaryAttr::get(
+          ctx, {NamedAttribute(StringAttr::get(ctx, "input_idx"),
+                               IntegerAttr::get(i64Ty, da.inputPos)),
+                NamedAttribute(StringAttr::get(ctx, "elem_offset"),
+                               IntegerAttr::get(i64Ty, da.elemOffset)),
+                NamedAttribute(StringAttr::get(ctx, "elem_bits"),
+                               IntegerAttr::get(i64Ty, bits))}));
+    }
+    module->setAttr("hipdnn.shape_fn_data_args",
+                    ArrayAttr::get(ctx, dataArgAttrs));
+  }
+
+  // 9. Drop the scratch func.
   scratch.erase();
 }
 

--- a/lib/Dialect/Transforms/GenerateInterface.cpp
+++ b/lib/Dialect/Transforms/GenerateInterface.cpp
@@ -275,33 +275,42 @@ void generateInferenceGetMetadataJson(ModuleOp module) {
 ///   int inference_infer_shapes(
 ///       const int64_t* const* input_shapes,  const int64_t* input_ranks,
 ///       int64_t input_count,
+///       const void* const*    input_data,
 ///       int64_t* const*       output_shapes, const int64_t* output_ranks,
 ///       int64_t output_count);
 ///
 /// Body: load each input dim (flattened over inputs in (tensor, dim)
-/// row-major order) into the i64 args of the lowered `@infer_shapes`; call it;
-/// scatter the i64 results (same flattening over outputs) into the
-/// caller-allocated `output_shapes` rows. `input_ranks` / `*_count` /
-/// `output_ranks` are accepted for ABI stability but unused: the per-tensor
-/// ranks are compile-time constants from the module's shape metadata, the same
-/// iteration inference_compute uses. The flattening MUST match
-/// BuildShapeFunctionPass: @infer_shapes args = one i64 per (input tensor, dim)
-/// over `hipdnn.input_shapes`; results = one i64 per (output tensor, dim) over
-/// `hipdnn.output_shapes`.
+/// row-major order) into the leading args of the lowered `@infer_shapes`;
+/// then, for closed-form data-dependent shape fns (e.g. ONNX Range), load each
+/// recorded scalar VALUE out of `input_data` (per the `hipdnn.shape_fn_data_
+/// args` module attribute) into the trailing data args; call it; scatter the
+/// i64 results (same flattening over outputs) into the caller-allocated
+/// `output_shapes` rows. `input_ranks` / `*_count` / `output_ranks` are
+/// accepted for ABI stability but unused: the per-tensor ranks are
+/// compile-time constants from the module's shape metadata. `input_data` is
+/// only dereferenced for the inputs the shape program actually reads (the
+/// data-args descriptors); the EP passes a pointer per input regardless. The
+/// flattening MUST match BuildShapeFunctionPass: @infer_shapes args = one i64
+/// per (input tensor, dim) over `hipdnn.input_shapes`, then one per data arg
+/// over `hipdnn.shape_fn_data_args`; results = one i64 per (output tensor,
+/// dim) over `hipdnn.output_shapes`.
 ///
-/// Generated IR (input [B,S,4096] -> [B*S,4096]; @infer_shapes lowered to
-/// (i64,i64,i64) -> !llvm.struct<(i64,i64)>):
-///   llvm.func @inference_infer_shapes(%is, %ir, %ic, %os, %or, %oc) -> i32 {
-///     %p0 = llvm.load %is                  // input_shapes[0]
-///     %d0 = llvm.load %p0                   // [0]
-///     %g1 = llvm.getelementptr %p0[1]; %d1 = llvm.load %g1
-///     %g2 = llvm.getelementptr %p0[2]; %d2 = llvm.load %g2
+/// NOTE: adding `input_data` is an ABI break vs older model.dlls (6-arg). The
+/// EP and model.dll are versioned together; clear the cached `morphizen_mlir_*`
+/// DLLs after this change (same policy as any generated-interface change).
+///
+/// Generated IR (data-dependent Range(start,limit,delta) -> [count];
+/// @infer_shapes lowered to (ptr,i64,i64,i64) -> i64, three rank-0 i64 inputs
+/// so zero dim args + three data args from `hipdnn.shape_fn_data_args`):
+///   llvm.func @inference_infer_shapes(%is, %ir, %ic, %id, %os, %or, %oc) ->
+///   i32 {
 ///     %nil = llvm.mlir.zero : !llvm.ptr             // unused !hip.context
-///     %r  = llvm.call @infer_shapes(%nil, %d0, %d1, %d2)  // struct<(i64,i64)>
-///     %o0 = llvm.extractvalue %r[0]; %o1 = llvm.extractvalue %r[1]
-///     %q0 = llvm.load %os                  // output_shapes[0]
-///     llvm.store %o0, %q0
-///     %h1 = llvm.getelementptr %q0[1]; llvm.store %o1, %h1
+///     %r0 = llvm.load %id;        %s = llvm.load %r0   // input_data[0] ->
+///     start %g1 = llvm.getelementptr %id[1]; %r1 = llvm.load %g1; %l =
+///     llvm.load %r1 %g2 = llvm.getelementptr %id[2]; %r2 = llvm.load %g2; %dl
+///     = llvm.load %r2 %cnt = llvm.call @infer_shapes(%nil, %s, %l, %dl)   //
+///     i64 count %q0 = llvm.load %os                  // output_shapes[0]
+///     llvm.store %cnt, %q0
 ///     llvm.return %c0_i32
 ///   }
 void generateInferenceInferShapes(ModuleOp module) {
@@ -325,7 +334,10 @@ void generateInferenceInferShapes(ModuleOp module) {
   Type i32Type = builder.getI32Type();
   Type i64Type = builder.getI64Type();
 
-  SmallVector<Type> paramTypes = {ptrType, ptrType, i64Type,
+  // ABI: in_shapes, in_ranks, in_count, in_data, out_shapes, out_ranks,
+  // out_count. The in_data pointer array (arg 3) feeds the trailing data args
+  // for closed-form data-dependent shape fns; shifts out_* down by one.
+  SmallVector<Type> paramTypes = {ptrType, ptrType, i64Type, ptrType,
                                   ptrType, ptrType, i64Type};
   auto funcType = LLVM::LLVMFunctionType::get(i32Type, paramTypes);
   auto funcOp = LLVM::LLVMFuncOp::create(builder, loc, "inference_infer_shapes",
@@ -337,7 +349,8 @@ void generateInferenceInferShapes(ModuleOp module) {
   builder.setInsertionPointToStart(entry);
 
   Value inShapes = entry->getArgument(0);
-  Value outShapes = entry->getArgument(3);
+  Value inData = entry->getArgument(3);
+  Value outShapes = entry->getArgument(4);
 
   // @infer_shapes's arg 0 is the (unused) !hip.context, lowered to !llvm.ptr.
   // The shape program never dereferences it; pass null. The flattened input
@@ -357,6 +370,37 @@ void generateInferenceInferShapes(ModuleOp module) {
       Value elt = LLVM::GEPOp::create(builder, loc, ptrType, i64Type, row,
                                       ArrayRef<LLVM::GEPArg>{dIdx});
       callArgs.push_back(LLVM::LoadOp::create(builder, loc, i64Type, elt));
+    }
+  }
+
+  // Trailing data args (closed-form data-dependent shape fns, e.g. Range):
+  // for each descriptor in `hipdnn.shape_fn_data_args` (in slot order, the
+  // same order BuildShapeFunctionPass appended the @infer_shapes params), read
+  // input_data[input_idx], byte-offset to the scalar, and load it with the
+  // exact type the lowered @infer_shapes param expects.
+  auto dataArgs = module->getAttrOfType<ArrayAttr>("hipdnn.shape_fn_data_args");
+  if (dataArgs) {
+    ArrayRef<Type> inferParams = inferFn.getFunctionType().getParams();
+    Type i8Type = builder.getI8Type();
+    for (Attribute a : dataArgs) {
+      auto d = cast<DictionaryAttr>(a);
+      int64_t inputIdx = cast<IntegerAttr>(d.get("input_idx")).getInt();
+      int64_t elemOffset = cast<IntegerAttr>(d.get("elem_offset")).getInt();
+      int64_t elemBits = cast<IntegerAttr>(d.get("elem_bits")).getInt();
+      // Load type = the matching lowered @infer_shapes param (index->i64,
+      // i32->i32, f32->f32, …). callArgs.size() is the next param position.
+      Type loadTy = inferParams[callArgs.size()];
+      Value tIdx = LLVM::ConstantOp::create(
+          builder, loc, i64Type, builder.getI64IntegerAttr(inputIdx));
+      Value rowSlot = LLVM::GEPOp::create(builder, loc, ptrType, ptrType,
+                                          inData, ArrayRef<LLVM::GEPArg>{tIdx});
+      Value row = LLVM::LoadOp::create(builder, loc, ptrType, rowSlot);
+      int64_t byteOffset = elemOffset * (elemBits / 8);
+      Value bOff = LLVM::ConstantOp::create(
+          builder, loc, i64Type, builder.getI64IntegerAttr(byteOffset));
+      Value elt = LLVM::GEPOp::create(builder, loc, ptrType, i8Type, row,
+                                      ArrayRef<LLVM::GEPArg>{bOff});
+      callArgs.push_back(LLVM::LoadOp::create(builder, loc, loadTy, elt));
     }
   }
 

--- a/test/lit/Dialect/hip-build-shape-fn.mlir
+++ b/test/lit/Dialect/hip-build-shape-fn.mlir
@@ -13,8 +13,12 @@
 //   * non-identity B*S collapse  -> affine.apply product over input dims
 //                                   + static dim as a constant
 //   * identity output dim        -> the matching scalar arg, verbatim
-//   * data-dependent output dim  -> kDynamic (INT64_MIN) sentinel; the EP
-//                                   falls back to DimSource for that dim
+//   * closed-form data-dependent -> tensor.extract on an input scalar becomes
+//     output dim (Range-like)       an extra @infer_shapes VALUE arg, recorded
+//                                   in the hipdnn.shape_fn_data_args attr
+//   * non-resolvable data dim    -> kDynamic (INT64_MIN) sentinel (e.g. a
+//                                   tensor.extract with a non-constant index);
+//                                   the EP falls back to DimSource for that dim
 //   * @main_graph itself is never mutated by the pass
 
 // -----
@@ -52,12 +56,33 @@ func.func @main_graph(%a: tensor<?x4096xf16>) -> tensor<?x4096xf16> {
 
 // -----
 
-// Data-dependent: the output dim is read from tensor CONTENTS (tensor.extract),
-// not from any input shape. The slice cannot be rooted at input dims -> emit
-// the kDynamic sentinel so the EP falls back to DimSource for this dim.
+// Closed-form data-dependent (Range-like): the output dim is read from input
+// CONTENTS via tensor.extract on a static-shape input with a constant index.
+// The slice roots at the extract (a data leaf) -> @infer_shapes gains a VALUE
+// arg (i64, after the input's dim args) and emits hipdnn.shape_fn_data_args.
 func.func @main_graph(%a: tensor<4xi64>) -> tensor<?xf16> {
   %c0 = arith.constant 0 : index
   %v = tensor.extract %a[%c0] : tensor<4xi64>
+  %d = arith.index_cast %v : i64 to index
+  %e = tensor.empty(%d) : tensor<?xf16>
+  return %e : tensor<?xf16>
+}
+// CHECK: hipdnn.shape_fn_data_args = [{elem_bits = 64 : i64, elem_offset = 0 : i64, input_idx = 0 : i64}]
+// CHECK-LABEL: func.func @infer_shapes
+// CHECK-SAME: (%{{[^:]+}}: !hip.context, %{{[^:]+}}: index, %[[V:[^:]+]]: i64) -> index
+// CHECK: %[[D:.+]] = arith.index_cast %[[V]] : i64 to index
+// CHECK: return %[[D]] : index
+
+// -----
+
+// Non-resolvable data dim: tensor.extract with a NON-constant index (the index
+// itself comes from another input's value). The element offset is not
+// statically known -> the extract is rejected as a leaf -> kDynamic sentinel,
+// EP falls back to DimSource.
+func.func @main_graph(%a: tensor<4xi64>, %b: tensor<i64>) -> tensor<?xf16> {
+  %idx = tensor.extract %b[] : tensor<i64>
+  %i = arith.index_cast %idx : i64 to index
+  %v = tensor.extract %a[%i] : tensor<4xi64>
   %d = arith.index_cast %v : i64 to index
   %e = tensor.empty(%d) : tensor<?xf16>
   return %e : tensor<?xf16>


### PR DESCRIPTION
## Summary
Stack PR **3/3** (base: #290). Extends the shape program to output dims that depend on input *values*, not just input shapes. Covers the **closed-form** case end-to-end (ONNX Range, length `ceildiv(limit - start, delta)`) and lands the **scaffolding** for the reduction-count case (ONNX NonZero) without its runtime kernel.

**What's in this PR:**
- **Closed-form data args** (`BuildShapeFunction` + `GenerateInterface`): the slice walk now accepts `tensor.extract` on input scalars as leaves; each unique scalar becomes an extra `@infer_shapes` arg, recorded in the `hipdnn.shape_fn_data_args` module attribute. The export gains an `input_data` pointer array (6-arg → 7-arg ABI) so the EP can pass scalar values; Range resolves its length with no kernel-side readback.
- **ceildiv lowering fix** (`HipToLLVM.cpp`): seed `populateCeilFloorDivExpandOpsPatterns` so the `arith.ceildivsi` from the Range length expands and re-legalizes in the same fixpoint.
- **NonZero scaffolding** (trait + metadata, no kernel): `DataDependentResult` op trait, `DIM_FROM_COUNT` resolution kind, and `pass_main` detection so reduction-count outputs are classified. The runtime count side-channel + kernel are intentionally **not** in this PR.

ABI note: `input_data` is an ABI break vs older model.dlls — EP and model.dll are versioned together; clear cached `morphizen_mlir_*` DLLs after this lands.

## Stack
1. #289 — compiler: shape-function emission (base: #288)
2. #290 — EP consumes the shape fn (+ conv/runner) (base: #289)
3. **#this** — data-dependent outputs (base: #290)

## Test plan
- [x] LIT: `hip-build-shape-fn.mlir` data-arg cases green.
- [x] Range end-to-end (EP vs ORT CPU reference) — bit-exact, zero L2 diff.
- [ ] NonZero is scaffolding only (no kernel) — not exercised here.

Made with [Cursor](https://cursor.com)