### PR TITLE
ci(pr-policy): raise large-pr thresholds to 1000 LOC / 20 files

### DIFF
--- a/.github/workflows/pr-policy-reminder.yml
+++ b/.github/workflows/pr-policy-reminder.yml
@@ -66,8 +66,8 @@ jobs:
         with:
           script: |
             const pr = context.payload.pull_request;
-            const LOC_LIMIT = 500;
-            const FILE_LIMIT = 10;
+            const LOC_LIMIT = 1000;
+            const FILE_LIMIT = 20;
             const changedLoc = (pr.additions || 0) + (pr.deletions || 0);
             const changedFiles = pr.changed_files || 0;
             if (changedLoc > LOC_LIMIT || changedFiles > FILE_LIMIT) {


### PR DESCRIPTION
Bumps the large-pr auto-label thresholds from 500→1000 changed lines and 10→20 changed files. Label still fires when either limit is exceeded.