### PR TITLE
feat(conversion): NumPy-broadcast init + 4D-shape ABI for Div/Sub/Equal (#259 split 1/N)

### DIFF
--- a/lib/Conversion/HipToLLVM/DivLowering.cpp
+++ b/lib/Conversion/HipToLLVM/DivLowering.cpp
@@ -9,6 +9,15 @@ namespace mlir {
 namespace hip {
 namespace {
 
+// hip.div(ctx, lhs, rhs, output)
+//   -> wrap_div(state, lhs, rhs, output,
+//               lhs_n, lhs_c, lhs_h, lhs_w,
+//               rhs_n, rhs_c, rhs_h, rhs_w,
+//               out_n, out_c, out_h, out_w,
+//               data_type)
+//
+// Full 4D shapes enable runtime broadcast materialisation via hip_expand
+// before the flat hip_elementwise_div kernel (rank <= 4, left-padded with 1).
 struct DivOpLowering : public ConvertOpToLLVMPattern<DivOp> {
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
@@ -21,37 +30,49 @@ struct DivOpLowering : public ConvertOpToLLVMPattern<DivOp> {
     Type i32Type = rewriter.getI32Type();
     Type i64Type = rewriter.getI64Type();
 
-    Value statePtr = adaptor.getCtx();
-    Value lhsPtr = extractContiguousMemRefPtr(adaptor.getLhs(), rewriter, loc);
-    Value rhsPtr = extractContiguousMemRefPtr(adaptor.getRhs(), rewriter, loc);
-    Value outputPtr =
-        extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
-
-    auto outputType = cast<MemRefType>(op.getOutput().getType());
-    Value numElements =
-        computeNumElements(outputType, adaptor.getOutput(), rewriter, loc);
-
     auto lhsType = cast<MemRefType>(op.getLhs().getType());
-    int64_t dataType = getHipdnnDataType(lhsType.getElementType());
-    if (dataType < 0)
-      return rewriter.notifyMatchFailure(op, "unsupported input element type");
+    auto rhsType = cast<MemRefType>(op.getRhs().getType());
+    auto outputType = cast<MemRefType>(op.getOutput().getType());
 
-    auto createI64Const = [&](int64_t v) -> Value {
+    if (lhsType.getRank() > 4 || rhsType.getRank() > 4 ||
+        outputType.getRank() > 4)
+      return rewriter.notifyMatchFailure(
+          op, "rank > 4 unsupported by 4D broadcast descriptor API");
+
+    auto lhsDims =
+        extractShape4D(lhsType, adaptor.getLhs(), rewriter, loc, i64Type);
+    auto rhsDims =
+        extractShape4D(rhsType, adaptor.getRhs(), rewriter, loc, i64Type);
+    auto outDims =
+        extractShape4D(outputType, adaptor.getOutput(), rewriter, loc, i64Type);
+
+    int64_t dataType = getHipdnnDataType(outputType.getElementType());
+    if (dataType < 0)
+      return rewriter.notifyMatchFailure(op, "unsupported element type");
+
+    auto createI64Const = [&](int64_t v) {
       return LLVM::ConstantOp::create(rewriter, loc, i64Type,
                                       rewriter.getI64IntegerAttr(v));
     };
 
-    SmallVector<Type, 6> paramTypes = {ptrType, ptrType, ptrType,
-                                       ptrType, i64Type, i64Type};
+    // 17 params: state + 3 data ptrs + 12 shape dims + data_type
+    SmallVector<Type, 17> paramTypes(4, ptrType);
+    paramTypes.append(13, i64Type);
 
     FailureOr<LLVM::LLVMFuncOp> funcOp =
         LLVM::lookupOrCreateFn(rewriter, module, kWrapDiv, paramTypes, i32Type);
     if (failed(funcOp))
       return failure();
 
-    SmallVector<Value, 6> args = {statePtr,    lhsPtr,
-                                  rhsPtr,      outputPtr,
-                                  numElements, createI64Const(dataType)};
+    SmallVector<Value, 17> args = {
+        adaptor.getCtx(),
+        extractContiguousMemRefPtr(adaptor.getLhs(), rewriter, loc),
+        extractContiguousMemRefPtr(adaptor.getRhs(), rewriter, loc),
+        extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc)};
+    args.append(lhsDims.begin(), lhsDims.end());
+    args.append(rhsDims.begin(), rhsDims.end());
+    args.append(outDims.begin(), outDims.end());
+    args.push_back(createI64Const(dataType));
 
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
     rewriter.eraseOp(op);

--- a/lib/Conversion/HipToLLVM/ElementwiseLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ElementwiseLowering.cpp
@@ -150,11 +150,13 @@ struct ElementwiseOpLowering : public ConvertOpToLLVMPattern<OpTy> {
   }
 };
 
-// hip.sub(handle, lhs, rhs, output)
-//   -> wrap_miopenTensorOp(state, lhs, rhs, output, num_lhs, num_rhs,
-//                          data_type, tensor_op=0)
-// Supports both static and dynamic shapes (computes num_lhs, num_rhs at
-// runtime).
+// hip.sub(ctx, lhs, rhs, output)
+//   -> wrap_elementwise_sub(state, lhs, rhs, output,
+//                           lhs_n..lhs_w, rhs_n..rhs_w, out_n..out_w,
+//                           data_type)
+//
+// Full 4D shapes enable runtime broadcast materialisation via hip_expand
+// before the flat hip_elementwise_sub kernel (rank <= 4, left-padded with 1).
 struct SubOpLowering : public ConvertOpToLLVMPattern<SubOp> {
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
@@ -167,56 +169,51 @@ struct SubOpLowering : public ConvertOpToLLVMPattern<SubOp> {
     Type i32Type = rewriter.getI32Type();
     Type i64Type = rewriter.getI64Type();
 
-    // Helper to create i64 constants
-    auto createI64Const = [&](int64_t value) -> Value {
-      return LLVM::ConstantOp::create(rewriter, loc, i64Type,
-                                      rewriter.getI64IntegerAttr(value));
-    };
-
-    // Helper to compute num_elements for a memref (static or dynamic)
-    auto computeNumElements = [&](MemRefType type, Value descriptor) -> Value {
-      Value num = createI64Const(1);
-      MemRefDescriptor desc(descriptor);
-      for (auto dimIdx : llvm::seq<int64_t>(type.getRank())) {
-        Value dimSize;
-        if (type.isDynamicDim(dimIdx)) {
-          dimSize = desc.size(rewriter, loc, dimIdx);
-        } else {
-          dimSize = createI64Const(type.getDimSize(dimIdx));
-        }
-        num = LLVM::MulOp::create(rewriter, loc, num, dimSize);
-      }
-      return num;
-    };
-
-    Value statePtr = adaptor.getCtx();
-    Value lhsPtr = extractContiguousMemRefPtr(adaptor.getLhs(), rewriter, loc);
-    Value rhsPtr = extractContiguousMemRefPtr(adaptor.getRhs(), rewriter, loc);
-    Value outputPtr =
-        extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
-
+    auto lhsType = cast<MemRefType>(op.getLhs().getType());
+    auto rhsType = cast<MemRefType>(op.getRhs().getType());
     auto outputType = cast<MemRefType>(op.getOutput().getType());
 
-    // Compute num_elements (supports dynamic shapes)
-    Value numElementsVal = computeNumElements(outputType, adaptor.getOutput());
+    if (lhsType.getRank() > 4 || rhsType.getRank() > 4 ||
+        outputType.getRank() > 4)
+      return rewriter.notifyMatchFailure(
+          op, "rank > 4 unsupported by 4D broadcast descriptor API");
 
-    unsigned elementSizeBytes =
-        outputType.getElementType().getIntOrFloatBitWidth() / 8;
-    Value elemSizeVal = createI64Const(elementSizeBytes);
+    auto lhsDims =
+        extractShape4D(lhsType, adaptor.getLhs(), rewriter, loc, i64Type);
+    auto rhsDims =
+        extractShape4D(rhsType, adaptor.getRhs(), rewriter, loc, i64Type);
+    auto outDims =
+        extractShape4D(outputType, adaptor.getOutput(), rewriter, loc, i64Type);
 
-    SmallVector<Type, 6> paramTypes = {ptrType, ptrType, ptrType,
-                                       ptrType, i64Type, i64Type};
+    int64_t dataType = getHipdnnDataType(outputType.getElementType());
+    if (dataType < 0)
+      return rewriter.notifyMatchFailure(op, "unsupported element type");
+
+    auto createI64Const = [&](int64_t v) {
+      return LLVM::ConstantOp::create(rewriter, loc, i64Type,
+                                      rewriter.getI64IntegerAttr(v));
+    };
+
+    // 17 params: state + 3 data ptrs + 12 shape dims + data_type
+    SmallVector<Type, 17> paramTypes(4, ptrType);
+    paramTypes.append(13, i64Type);
 
     FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
         rewriter, module, kWrapElementwiseSub, paramTypes, i32Type);
     if (failed(funcOp))
       return failure();
 
-    SmallVector<Value, 6> args = {statePtr,  lhsPtr,         rhsPtr,
-                                  outputPtr, numElementsVal, elemSizeVal};
+    SmallVector<Value, 17> args = {
+        adaptor.getCtx(),
+        extractContiguousMemRefPtr(adaptor.getLhs(), rewriter, loc),
+        extractContiguousMemRefPtr(adaptor.getRhs(), rewriter, loc),
+        extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc)};
+    args.append(lhsDims.begin(), lhsDims.end());
+    args.append(rhsDims.begin(), rhsDims.end());
+    args.append(outDims.begin(), outDims.end());
+    args.push_back(createI64Const(dataType));
 
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
-
     rewriter.eraseOp(op);
     return success();
   }

--- a/lib/Conversion/HipToLLVM/EqualLowering.cpp
+++ b/lib/Conversion/HipToLLVM/EqualLowering.cpp
@@ -27,11 +27,21 @@ struct EqualOpLowering : public ConvertOpToLLVMPattern<EqualOp> {
     Value outputPtr =
         extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
 
+    auto lhsType = cast<MemRefType>(op.getLhs().getType());
+    auto rhsType = cast<MemRefType>(op.getRhs().getType());
     auto outputType = cast<MemRefType>(op.getOutput().getType());
-    Value numElements =
+
+    // ONNX Equal supports broadcasting; the kernel handles same-shape and
+    // scalar (lhs/rhs num_elements == 1) cases. Larger NumPy-style broadcasts
+    // must be materialised upstream via Expand (the runtime wrapper enforces
+    // this).
+    Value lhsNumElements =
+        computeNumElements(lhsType, adaptor.getLhs(), rewriter, loc);
+    Value rhsNumElements =
+        computeNumElements(rhsType, adaptor.getRhs(), rewriter, loc);
+    Value outNumElements =
         computeNumElements(outputType, adaptor.getOutput(), rewriter, loc);
 
-    auto lhsType = cast<MemRefType>(op.getLhs().getType());
     int64_t dataType = getHipdnnDataType(lhsType.getElementType());
     if (dataType < 0)
       return rewriter.notifyMatchFailure(op, "unsupported input element type");
@@ -41,17 +51,18 @@ struct EqualOpLowering : public ConvertOpToLLVMPattern<EqualOp> {
                                       rewriter.getI64IntegerAttr(v));
     };
 
-    SmallVector<Type, 6> paramTypes = {ptrType, ptrType, ptrType,
-                                       ptrType, i64Type, i64Type};
+    SmallVector<Type, 8> paramTypes = {ptrType, ptrType, ptrType, ptrType,
+                                       i64Type, i64Type, i64Type, i64Type};
 
     FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
         rewriter, module, kWrapEqual, paramTypes, i32Type);
     if (failed(funcOp))
       return failure();
 
-    SmallVector<Value, 6> args = {statePtr,    lhsPtr,
-                                  rhsPtr,      outputPtr,
-                                  numElements, createI64Const(dataType)};
+    SmallVector<Value, 8> args = {statePtr,       lhsPtr,
+                                  rhsPtr,         outputPtr,
+                                  lhsNumElements, rhsNumElements,
+                                  outNumElements, createI64Const(dataType)};
 
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
     rewriter.eraseOp(op);

--- a/lib/Conversion/OnnxToHip/AndConversion.cpp
+++ b/lib/Conversion/OnnxToHip/AndConversion.cpp
@@ -12,10 +12,9 @@ namespace {
 /// onnx.And -> hip.and
 ///
 /// Element-wise logical AND of two boolean tensors with NumPy-style
-/// broadcasting. Mirrors the EqualConversion pattern: pick whichever input
-/// already matches the broadcast output rank as the shape source for
-/// `createEmptyTensor`, so dynamic-shape models still get correct
-/// `tensor.dim` extractions for the DPS init.
+/// broadcasting. Dynamic output dims are resolved via
+/// `createBroadcastEmptyTensor` so each axis picks the non-broadcasting operand
+/// (e.g. `[?x1] & [1x?] -> [?x?]`).
 struct AndToHip : public mlir::RewritePattern {
   AndToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.And", /*benefit=*/1, ctx) {}
@@ -44,15 +43,14 @@ struct AndToHip : public mlir::RewritePattern {
     if (!aType || !bType)
       return rewriter.notifyMatchFailure(op, "expected ranked tensor inputs");
 
-    // Pick the side whose rank already matches the broadcast output so
-    // dynamic dims line up dim-by-dim for createEmptyTensor. When both
-    // operands have the same rank as the result this is just `a`; when
-    // one operand has a smaller rank (e.g. broadcasting a [N] mask against
-    // a [B, N] tensor) we prefer the larger-rank operand.
-    mlir::Value source = (aType.getRank() == resultType.getRank()) ? a : b;
-    mlir::Value init = createEmptyTensor(rewriter, loc, resultType, source);
+    mlir::FailureOr<mlir::Value> initOrFailure =
+        createBroadcastEmptyTensor(rewriter, loc, resultType, {a, b});
+    if (mlir::failed(initOrFailure))
+      return rewriter.notifyMatchFailure(
+          op, "And: no ranked operand spans dynamic result dim");
 
-    auto hipOp = mlir::hip::AndOp::create(rewriter, loc, context, a, b, init);
+    auto hipOp =
+        mlir::hip::AndOp::create(rewriter, loc, context, a, b, *initOrFailure);
     rewriter.replaceOp(op, hipOp->getResult(0));
     return mlir::success();
   }

--- a/lib/Conversion/OnnxToHip/DivConversion.cpp
+++ b/lib/Conversion/OnnxToHip/DivConversion.cpp
@@ -28,11 +28,14 @@ struct DivToHip : public mlir::RewritePattern {
     auto resultType =
         mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
 
-    auto aType = mlir::cast<mlir::RankedTensorType>(a.getType());
-    mlir::Value source = (aType.getRank() == resultType.getRank()) ? a : b;
-    mlir::Value init = createEmptyTensor(rewriter, loc, resultType, source);
+    mlir::FailureOr<mlir::Value> initOrFailure =
+        createBroadcastEmptyTensor(rewriter, loc, resultType, {a, b});
+    if (mlir::failed(initOrFailure))
+      return rewriter.notifyMatchFailure(
+          op, "Div: no ranked operand spans dynamic result dim");
 
-    auto hipOp = mlir::hip::DivOp::create(rewriter, loc, context, a, b, init);
+    auto hipOp =
+        mlir::hip::DivOp::create(rewriter, loc, context, a, b, *initOrFailure);
     rewriter.replaceOp(op, hipOp->getResult(0));
     return mlir::success();
   }

--- a/lib/Conversion/OnnxToHip/ElementwiseConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ElementwiseConversion.cpp
@@ -53,11 +53,14 @@ AddToHip::matchAndRewrite(mlir::Operation *op,
   auto resultType =
       mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
 
-  auto aType = mlir::cast<mlir::RankedTensorType>(a.getType());
-  mlir::Value source = (aType.getRank() == resultType.getRank()) ? a : b;
-  mlir::Value init = createEmptyTensor(rewriter, loc, resultType, source);
+  mlir::FailureOr<mlir::Value> initOrFailure =
+      createBroadcastEmptyTensor(rewriter, loc, resultType, {a, b});
+  if (mlir::failed(initOrFailure))
+    return rewriter.notifyMatchFailure(
+        op, "Add: no ranked operand spans dynamic result dim");
 
-  auto hipOp = mlir::hip::AddOp::create(rewriter, loc, context, a, b, init);
+  auto hipOp =
+      mlir::hip::AddOp::create(rewriter, loc, context, a, b, *initOrFailure);
   rewriter.replaceOp(op, hipOp->getResult(0));
   return mlir::success();
 }
@@ -76,13 +79,14 @@ MulToHip::matchAndRewrite(mlir::Operation *op,
   auto resultType =
       mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
 
-  // Use the operand whose rank matches the result for dim extraction
-  // (handles scalar * tensor broadcasting).
-  auto aType = mlir::cast<mlir::RankedTensorType>(a.getType());
-  mlir::Value source = (aType.getRank() == resultType.getRank()) ? a : b;
-  mlir::Value init = createEmptyTensor(rewriter, loc, resultType, source);
+  mlir::FailureOr<mlir::Value> initOrFailure =
+      createBroadcastEmptyTensor(rewriter, loc, resultType, {a, b});
+  if (mlir::failed(initOrFailure))
+    return rewriter.notifyMatchFailure(
+        op, "Mul: no ranked operand spans dynamic result dim");
 
-  auto hipOp = mlir::hip::MulOp::create(rewriter, loc, context, a, b, init);
+  auto hipOp =
+      mlir::hip::MulOp::create(rewriter, loc, context, a, b, *initOrFailure);
   rewriter.replaceOp(op, hipOp->getResult(0));
   return mlir::success();
 }
@@ -100,12 +104,13 @@ SubToHip::matchAndRewrite(mlir::Operation *op,
   mlir::Value rhs = op->getOperand(1);
   auto resultType =
       mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
-  // Use the operand whose rank matches the result for dynamic dim extraction
-  // (the other may be a broadcast scalar with fewer dims).
-  auto lhsType = mlir::cast<mlir::RankedTensorType>(lhs.getType());
-  mlir::Value source = (lhsType.getRank() == resultType.getRank()) ? lhs : rhs;
-  mlir::Value init = createEmptyTensor(rewriter, loc, resultType, source);
-  auto hipOp = mlir::hip::SubOp::create(rewriter, loc, context, lhs, rhs, init);
+  mlir::FailureOr<mlir::Value> initOrFailure =
+      createBroadcastEmptyTensor(rewriter, loc, resultType, {lhs, rhs});
+  if (mlir::failed(initOrFailure))
+    return rewriter.notifyMatchFailure(
+        op, "Sub: no ranked operand spans dynamic result dim");
+  auto hipOp = mlir::hip::SubOp::create(rewriter, loc, context, lhs, rhs,
+                                        *initOrFailure);
   rewriter.replaceOp(op, hipOp->getResult(0));
   return mlir::success();
 }

--- a/lib/Conversion/OnnxToHip/EqualConversion.cpp
+++ b/lib/Conversion/OnnxToHip/EqualConversion.cpp
@@ -28,11 +28,14 @@ struct EqualToHip : public mlir::RewritePattern {
     auto resultType =
         mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
 
-    auto aType = mlir::cast<mlir::RankedTensorType>(a.getType());
-    mlir::Value source = (aType.getRank() == resultType.getRank()) ? a : b;
-    mlir::Value init = createEmptyTensor(rewriter, loc, resultType, source);
+    mlir::FailureOr<mlir::Value> initOrFailure =
+        createBroadcastEmptyTensor(rewriter, loc, resultType, {a, b});
+    if (mlir::failed(initOrFailure))
+      return rewriter.notifyMatchFailure(
+          op, "Equal: no ranked operand spans dynamic result dim");
 
-    auto hipOp = mlir::hip::EqualOp::create(rewriter, loc, context, a, b, init);
+    auto hipOp = mlir::hip::EqualOp::create(rewriter, loc, context, a, b,
+                                            *initOrFailure);
     rewriter.replaceOp(op, hipOp->getResult(0));
     return mlir::success();
   }

--- a/lib/Conversion/OnnxToHip/LessConversion.cpp
+++ b/lib/Conversion/OnnxToHip/LessConversion.cpp
@@ -28,11 +28,14 @@ struct LessToHip : public mlir::RewritePattern {
     auto resultType =
         mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
 
-    auto aType = mlir::cast<mlir::RankedTensorType>(a.getType());
-    mlir::Value source = (aType.getRank() == resultType.getRank()) ? a : b;
-    mlir::Value init = createEmptyTensor(rewriter, loc, resultType, source);
+    mlir::FailureOr<mlir::Value> initOrFailure =
+        createBroadcastEmptyTensor(rewriter, loc, resultType, {a, b});
+    if (mlir::failed(initOrFailure))
+      return rewriter.notifyMatchFailure(
+          op, "Less: no ranked operand spans dynamic result dim");
 
-    auto hipOp = mlir::hip::LessOp::create(rewriter, loc, context, a, b, init);
+    auto hipOp =
+        mlir::hip::LessOp::create(rewriter, loc, context, a, b, *initOrFailure);
     rewriter.replaceOp(op, hipOp->getResult(0));
     return mlir::success();
   }

--- a/lib/Conversion/OnnxToHip/MinConversion.cpp
+++ b/lib/Conversion/OnnxToHip/MinConversion.cpp
@@ -53,11 +53,13 @@ MinToHip::matchAndRewrite(mlir::Operation *op,
     mlir::RankedTensorType stepResultType =
         (i == numInputs - 1) ? resultType : accType;
 
-    mlir::Value source =
-        (accType.getRank() == stepResultType.getRank()) ? accumulate : rhs;
-    mlir::Value init = createEmptyTensor(rewriter, loc, stepResultType, source);
-    auto minOp =
-        mlir::hip::MinOp::create(rewriter, loc, context, accumulate, rhs, init);
+    mlir::FailureOr<mlir::Value> initOrFailure = createBroadcastEmptyTensor(
+        rewriter, loc, stepResultType, {accumulate, rhs});
+    if (mlir::failed(initOrFailure))
+      return rewriter.notifyMatchFailure(
+          op, "Min: no ranked operand spans dynamic result dim");
+    auto minOp = mlir::hip::MinOp::create(rewriter, loc, context, accumulate,
+                                          rhs, *initOrFailure);
     accumulate = minOp->getResult(0);
   }
 

--- a/lib/Conversion/OnnxToHip/ModConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ModConversion.cpp
@@ -28,16 +28,19 @@ struct ModToHip : public mlir::RewritePattern {
     auto resultType =
         mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
 
-    auto aType = mlir::cast<mlir::RankedTensorType>(a.getType());
-    mlir::Value source = (aType.getRank() == resultType.getRank()) ? a : b;
-    mlir::Value init = createEmptyTensor(rewriter, loc, resultType, source);
+    mlir::FailureOr<mlir::Value> initOrFailure =
+        createBroadcastEmptyTensor(rewriter, loc, resultType, {a, b});
+    if (mlir::failed(initOrFailure))
+      return rewriter.notifyMatchFailure(
+          op, "Mod: no ranked operand spans dynamic result dim");
 
     int64_t fmod = 0;
     if (auto attr = op->getAttrOfType<mlir::IntegerAttr>("fmod"))
       fmod = attr.getValue().getSExtValue();
 
-    auto hipOp = mlir::hip::ModOp::create(rewriter, loc, context, a, b, init,
-                                          rewriter.getI64IntegerAttr(fmod));
+    auto hipOp =
+        mlir::hip::ModOp::create(rewriter, loc, context, a, b, *initOrFailure,
+                                 rewriter.getI64IntegerAttr(fmod));
     rewriter.replaceOp(op, hipOp->getResult(0));
     return mlir::success();
   }

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
@@ -94,6 +94,64 @@ inline mlir::Value createEmptyTensor(mlir::OpBuilder &builder,
                                        resultType.getElementType(), dynSizes);
 }
 
+/// Create a tensor.empty for a DPS init whose shape is the NumPy-style
+/// broadcast of \p operands. Operand shapes are right-aligned with the
+/// result. For each dynamic dimension of \p resultType, the size is taken
+/// from the first operand that truly contributes at that axis -- i.e. whose
+/// corresponding dim is not statically 1. Shorter-rank operands (left-padded
+/// with 1) and statically-1 dims are skipped. If every spanning operand is
+/// statically 1 at the axis, fall back to the first operand that spans it.
+///
+/// Use this for binary/multinary broadcast elementwise ops (Add, Mul, Where,
+/// ...). Do NOT use `createEmptyTensor(resultType, source)` when operands can
+/// disagree on which side supplies a dynamic extent (e.g. `[?x1] + [1x?] ->
+/// [?x?]` -- dim 0 from lhs, dim 1 from rhs).
+inline mlir::FailureOr<mlir::Value>
+createBroadcastEmptyTensor(mlir::OpBuilder &builder, mlir::Location loc,
+                           mlir::RankedTensorType resultType,
+                           mlir::ValueRange operands) {
+  int64_t resultRank = resultType.getRank();
+  llvm::SmallVector<mlir::Value> dynSizes;
+  for (int64_t dimIdx : llvm::seq<int64_t>(resultRank)) {
+    if (!resultType.isDynamicDim(dimIdx))
+      continue;
+
+    mlir::Value chosen;
+    int64_t chosenDim = -1;
+    mlir::Value fallback;
+    int64_t fallbackDim = -1;
+    for (mlir::Value operand : operands) {
+      auto t = mlir::dyn_cast<mlir::RankedTensorType>(operand.getType());
+      if (!t)
+        continue;
+      int64_t offset = resultRank - t.getRank();
+      if (dimIdx < offset)
+        continue;
+      int64_t operandDim = dimIdx - offset;
+      if (!fallback) {
+        fallback = operand;
+        fallbackDim = operandDim;
+      }
+      if (!t.isDynamicDim(operandDim) && t.getDimSize(operandDim) == 1)
+        continue;
+      chosen = operand;
+      chosenDim = operandDim;
+      break;
+    }
+    if (!chosen) {
+      chosen = fallback;
+      chosenDim = fallbackDim;
+    }
+    if (!chosen)
+      return mlir::failure();
+    dynSizes.push_back(
+        mlir::tensor::DimOp::create(builder, loc, chosen, chosenDim));
+  }
+  return mlir::Value(
+      mlir::tensor::EmptyOp::create(builder, loc, resultType.getShape(),
+                                    resultType.getElementType(), dynSizes));
+}
+
 /// Get !hip.context from function argument 0. Returns failure if the
 /// function has no arguments or the first argument is not !hip.context.
 inline mlir::FailureOr<mlir::Value>

--- a/lib/Conversion/OnnxToHip/ShapeConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ShapeConversion.cpp
@@ -69,12 +69,9 @@ namespace {
 // normalization) emit a 0-element constant tensor per ONNX spec rather than
 // failing the match -- preserving op semantics is the priority over
 // surfacing a "shouldn't happen" error.
-//
-// Benefit 2 (Expand is 1): onnx.Shape must lower before onnx.Expand so
-// ExpandConversion can traceback tensor.from_elements or onnx.Shape directly.
 struct ShapeToTensorDims : public mlir::RewritePattern {
   ShapeToTensorDims(mlir::MLIRContext *ctx)
-      : RewritePattern("onnx.Shape", /*benefit=*/2, ctx) {}
+      : RewritePattern("onnx.Shape", /*benefit=*/1, ctx) {}
 
   mlir::LogicalResult
   matchAndRewrite(mlir::Operation *op,

--- a/lib/Conversion/OnnxToHip/ShapeConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ShapeConversion.cpp
@@ -69,9 +69,12 @@ namespace {
 // normalization) emit a 0-element constant tensor per ONNX spec rather than
 // failing the match -- preserving op semantics is the priority over
 // surfacing a "shouldn't happen" error.
+//
+// Benefit 2 (Expand is 1): onnx.Shape must lower before onnx.Expand so
+// ExpandConversion can traceback tensor.from_elements or onnx.Shape directly.
 struct ShapeToTensorDims : public mlir::RewritePattern {
   ShapeToTensorDims(mlir::MLIRContext *ctx)
-      : RewritePattern("onnx.Shape", /*benefit=*/1, ctx) {}
+      : RewritePattern("onnx.Shape", /*benefit=*/2, ctx) {}
 
   mlir::LogicalResult
   matchAndRewrite(mlir::Operation *op,

--- a/test/lit/Conversion/hip-to-llvm/test_div.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_div.mlir
@@ -3,8 +3,9 @@
 
 // ============================================================================
 // TEST PURPOSE:
-// Verify hip.div lowers to llvm.call @wrap_div with signature
-//   (state, lhs, rhs, output, num_elements, data_type) -> i32.
+// Verify hip.div lowers to llvm.call @wrap_div with 4D shape-passing for
+// ONNX broadcast (same pattern as hip.min / hip.add). Both same-shape and
+// broadcasting cases are covered.
 // ============================================================================
 
 // RUN: hip-mlir-opt %s --convert-hip-to-llvm | FileCheck %s
@@ -20,7 +21,22 @@ module {
     hip.div(%ctx) ins(%a, %b : memref<128x64xf32, 1>, memref<128x64xf32, 1>)
                   outs(%c : memref<128x64xf32, 1>)
 
-    // CHECK: llvm.call @wrap_div({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64) -> i32
+    // CHECK: llvm.call @wrap_div({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
+    return
+  }
+
+  // Broadcasting: rhs is per-channel [32] padded to [1,1,1,32].
+  func.func @div_broadcast_f16(
+      %ctx: !hip.context,
+      %a: memref<1x128x32xf16, 1>,
+      %b: memref<1x1x32xf16, 1>,
+      %c: memref<1x128x32xf16, 1>) {
+    // CHECK-LABEL: llvm.func @div_broadcast_f16
+
+    hip.div(%ctx) ins(%a, %b : memref<1x128x32xf16, 1>, memref<1x1x32xf16, 1>)
+                  outs(%c : memref<1x128x32xf16, 1>)
+
+    // CHECK: llvm.call @wrap_div({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
     return
   }
 
@@ -34,10 +50,7 @@ module {
     hip.div(%ctx) ins(%a, %b : memref<?x?xf16, 1>, memref<?x?xf16, 1>)
                   outs(%c : memref<?x?xf16, 1>)
 
-    // CHECK: llvm.extractvalue %{{.*}}[3, 0]
-    // CHECK: llvm.extractvalue %{{.*}}[3, 1]
-    // CHECK: llvm.mul %{{.*}}, %{{.*}} : i64
-    // CHECK: llvm.call @wrap_div({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64) -> i32
+    // CHECK: llvm.call @wrap_div({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
     return
   }
 }

--- a/test/lit/Conversion/hip-to-llvm/test_equal.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_equal.mlir
@@ -4,8 +4,11 @@
 // ============================================================================
 // TEST PURPOSE:
 // Verify hip.equal lowers to llvm.call @wrap_equal with signature
-//   (state, lhs, rhs, output, num_elements, data_type) -> i32.
+//   (state, lhs, rhs, output,
+//    a_num_elements, b_num_elements, out_num_elements, data_type) -> i32.
 // Output is i1 (bool, 1 byte); data_type identifies the input element type.
+// Per-operand element counts let the kernel handle scalar (numel==1)
+// broadcast via zero stride without an upfront Expand of the scalar.
 // ============================================================================
 
 // RUN: hip-mlir-opt %s --convert-hip-to-llvm | FileCheck %s
@@ -22,7 +25,7 @@ module {
     hip.equal(%ctx) ins(%a, %b : memref<8xi64, 1>, memref<8xi64, 1>)
                     outs(%c : memref<8xi1, 1>)
 
-    // CHECK: llvm.call @wrap_equal({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64) -> i32
+    // CHECK: llvm.call @wrap_equal({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64) -> i32
     return
   }
 
@@ -38,7 +41,7 @@ module {
                     outs(%c : memref<?xi1, 1>)
 
     // CHECK: llvm.extractvalue %{{.*}}[3, 0]
-    // CHECK: llvm.call @wrap_equal({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64) -> i32
+    // CHECK: llvm.call @wrap_equal({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64) -> i32
     return
   }
 }

--- a/test/lit/Conversion/hip-to-llvm/test_sub.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_sub.mlir
@@ -3,24 +3,14 @@
 
 // ============================================================================
 // TEST PURPOSE:
-// Verify HIP sub operation is correctly lowered to LLVM call
-// to wrap_elementwise_sub runtime function with both static and dynamic shapes.
-//
-// This test validates:
-// - hip.sub → llvm.call @wrap_elementwise_sub
-// - Type conversion: !hip.context → !llvm.ptr
-// - Static shapes: num_elements and elem_size computed at compile time
-// - Dynamic shapes: num_elements computed at runtime via llvm.mul of dims
-// - Proper function signature for runtime API
-//
-// Expected: wrap_elementwise_sub(state, lhs_ptr, rhs_ptr, output_ptr,
-//                                 num_elements, elem_size)
+// Verify hip.sub lowers to llvm.call @wrap_elementwise_sub with 4D shape-
+// passing for ONNX broadcast (same pattern as hip.div). Both same-shape and
+// broadcasting cases are covered.
 // ============================================================================
 
 // RUN: hip-mlir-opt %s --convert-hip-to-llvm | FileCheck %s
 
 module {
-  // Test 1: Static shapes - num_elements = 128*512 = 65536, elem_size = 4 (f32)
   func.func @sub_static_test(
       %ctx: !hip.context,
       %lhs: memref<128x512xf32, 1>,
@@ -31,28 +21,25 @@ module {
     hip.sub(%ctx) ins(%lhs, %rhs : memref<128x512xf32, 1>, memref<128x512xf32, 1>)
                   outs(%output : memref<128x512xf32, 1>)
 
-    // CHECK: llvm.call @wrap_elementwise_sub({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64) -> i32
-
+    // CHECK: llvm.call @wrap_elementwise_sub({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
     return
   }
 
-  // Test 2: 1D tensor - num_elements = 1024, elem_size = 2 (f16)
-  func.func @sub_1d_test(
+  // Broadcasting: lhs scalar [1] padded to [1,1,1,1] over rhs [32].
+  func.func @sub_broadcast_i64(
       %ctx: !hip.context,
-      %lhs: memref<1024xf16, 1>,
-      %rhs: memref<1024xf16, 1>,
-      %output: memref<1024xf16, 1>) {
-    // CHECK-LABEL: llvm.func @sub_1d_test
+      %lhs: memref<1xi64, 1>,
+      %rhs: memref<32xi64, 1>,
+      %output: memref<32xi64, 1>) {
+    // CHECK-LABEL: llvm.func @sub_broadcast_i64
 
-    hip.sub(%ctx) ins(%lhs, %rhs : memref<1024xf16, 1>, memref<1024xf16, 1>)
-                  outs(%output : memref<1024xf16, 1>)
+    hip.sub(%ctx) ins(%lhs, %rhs : memref<1xi64, 1>, memref<32xi64, 1>)
+                  outs(%output : memref<32xi64, 1>)
 
-    // CHECK: llvm.call @wrap_elementwise_sub({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64) -> i32
-
+    // CHECK: llvm.call @wrap_elementwise_sub({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
     return
   }
 
-  // Test 3: Dynamic shapes - num_elements computed at runtime
   func.func @sub_dynamic_test(
       %ctx: !hip.context,
       %lhs: memref<?x512xf32, 1>,
@@ -63,9 +50,7 @@ module {
     hip.sub(%ctx) ins(%lhs, %rhs : memref<?x512xf32, 1>, memref<?x512xf32, 1>)
                   outs(%output : memref<?x512xf32, 1>)
 
-    // CHECK: llvm.mul {{.*}} : i64
-    // CHECK: llvm.call @wrap_elementwise_sub({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64) -> i32
-
+    // CHECK: llvm.call @wrap_elementwise_sub({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
     return
   }
 }

--- a/test/lit/Conversion/onnx-to-hip/test_div.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_div.mlir
@@ -39,4 +39,13 @@ module {
   // CHECK: tensor.dim
   // CHECK: tensor.empty({{.*}}) : tensor<?x?xf32>
   // CHECK: hip.div(%[[CTX3]]) ins(%[[A3]], %[[B3]] : tensor<?x?xf32>, tensor<?x?xf32>) outs({{.*}} : tensor<?x?xf32>)
+
+  func.func @div_broadcast_i64(%a: tensor<1xi64>, %b: tensor<32xi64>) -> tensor<32xi64> {
+    %result = "onnx.Div"(%a, %b) : (tensor<1xi64>, tensor<32xi64>) -> tensor<32xi64>
+    return %result : tensor<32xi64>
+  }
+
+  // CHECK-LABEL: func.func @div_broadcast_i64
+  // CHECK: tensor.empty() : tensor<32xi64>
+  // CHECK: hip.div(%{{.*}}) ins(%{{.*}}, %{{.*}} : tensor<1xi64>, tensor<32xi64>) outs({{.*}} : tensor<32xi64>)
 }

--- a/test/lit/Conversion/onnx-to-hip/test_sub.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_sub.mlir
@@ -46,10 +46,20 @@ module {
     %output = "onnx.Sub"(%lhs, %rhs) : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
     return %output : tensor<?x?xf32>
   }
-}
 
-// CHECK-LABEL: func.func @sub_dynamic
-// CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[LHS:.*]]: tensor<?x?xf32>, %[[RHS:.*]]: tensor<?x?xf32>) -> tensor<?x?xf32>
-// CHECK: %[[INIT:.*]] = tensor.empty(%{{.*}}, %{{.*}}) : tensor<?x?xf32>
-// CHECK: hip.sub(%[[CTX]]) ins(%[[LHS]], %[[RHS]] : tensor<?x?xf32>, tensor<?x?xf32>) outs(%[[INIT]] : tensor<?x?xf32>) : tensor<?x?xf32>
-// CHECK-NOT: hip.alloc
+  // CHECK-LABEL: func.func @sub_dynamic
+  // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[LHS:.*]]: tensor<?x?xf32>, %[[RHS:.*]]: tensor<?x?xf32>) -> tensor<?x?xf32>
+  // CHECK: %[[INIT:.*]] = tensor.empty(%{{.*}}, %{{.*}}) : tensor<?x?xf32>
+  // CHECK: hip.sub(%[[CTX]]) ins(%[[LHS]], %[[RHS]] : tensor<?x?xf32>, tensor<?x?xf32>) outs(%[[INIT]] : tensor<?x?xf32>) : tensor<?x?xf32>
+  // CHECK-NOT: hip.alloc
+
+  // Broadcast: lhs [1] subtracted from rhs [32] -> output [32]
+  func.func @sub_broadcast_i64(%lhs: tensor<1xi64>, %rhs: tensor<32xi64>) -> tensor<32xi64> {
+    %output = "onnx.Sub"(%lhs, %rhs) : (tensor<1xi64>, tensor<32xi64>) -> tensor<32xi64>
+    return %output : tensor<32xi64>
+  }
+
+  // CHECK-LABEL: func.func @sub_broadcast_i64
+  // CHECK: tensor.empty() : tensor<32xi64>
+  // CHECK: hip.sub(%{{.*}}) ins(%{{.*}}, %{{.*}} : tensor<1xi64>, tensor<32xi64>) outs({{.*}} : tensor<32xi64>)
+}


### PR DESCRIPTION
## Summary

First compiler-side slice of the #259 split, **stacked on PR284** (`feat/runtime-custom-kernels-split`).

- `OnnxToHipUtils`: add `createBroadcastEmptyTensor` -- per-axis selection of the non-broadcasting operand for a dynamic DPS init (e.g. `[?x1] + [1x?] -> [?x?]`, where dim 0 comes from lhs and dim 1 from rhs). The old `createEmptyTensor(resultType, single-source)` picks one operand for all axes and is wrong when the two sides disagree on which supplies a dynamic extent.
- Broadcast elementwise/util conversions use it: Add/Mul/Sub, Div, And, Min, Mod, Equal, Less. main's inferred-type `Op::create` is kept (no explicit result type).
- Lowerings `DivLowering` / `ElementwiseLowering` (Sub) / `EqualLowering` emit the new ABI that matches the runtime functions PR284 introduced: `wrap_div` / `wrap_elementwise_sub` (full 4D operand shapes for `hip_expand` broadcast materialisation) and `wrap_equal` (per-operand element counts). Uses the already-on-main `extractShape4D` / `computeNumElements` helpers.

## Background -- the defect `createBroadcastEmptyTensor` closes (from #259)

The original problem + solution is recorded in the #259 branch (`release/msbuild`), commit `1fca3099` -- *"Land Kokoro op coverage + dynamic-shape robustness"*:

> `BinaryElementwise`, `Elementwise`, `Tier3Compare` (`Where` / `Equal` / `Greater` / ...): replace the lhs-or-rhs source picker with `createBroadcastEmptyTensor`, which walks every candidate input per output dim and falls back for pure scalar broadcasts. **Avoids `tensor.dim` on rank-0 operands.**

Two distinct defects in the old single-source `createEmptyTensor` that this helper closes:

1. **Mixed-dynamic mis-sizing.** When different result dims take their dynamic extent from different operands -- `[?x1] + [1x?] -> [?x?]` (dim 0 from lhs, dim 1 from rhs) -- keying every `tensor.dim` on one operand sizes the wrong axis from a static-`1` extent, so the DPS init buffer is mis-sized. Our elementwise kernels do not broadcast internally (the runtime materialises broadcasts via `hip_expand` into a same-shape buffer before the kernel runs), so a mis-sized init buffer is a real correctness bug, not just slack.
2. **`tensor.dim` on rank-0 operands.** Pure scalar broadcasts (e.g. Kokoro's `scalar op tensor`) made the old picker call `tensor.dim` on a rank-0 value, which is invalid. The helper right-aligns each operand to the result and only considers operands that actually span the axis, so rank-0 / shorter-rank operands are skipped instead of being indexed.

The helper's selection rule per dynamic result axis: pick the first operand that genuinely spans the axis and is not statically `1` there; otherwise fall back to the first spanning operand; fail cleanly (no silent wrong size) if none spans it.

Broadcast-init LIT coverage for this helper landed in #259 (`4c4c33cd`, *"broadcast div/sub"*).

## Merge ordering (important)

PR284 changed the ABI of the **pre-existing** `wrap_div` / `wrap_elementwise_sub` / `wrap_equal`; these lowerings are their callers. **PR284 + this PR form an atomic merge train** -- this PR must merge together with / immediately after PR284, before model-compile CI gates main, otherwise Div/Sub/Equal model compilation breaks on a 6-arg-call vs new-ABI-runtime mismatch.

## Test plan

- [x] `hip-compiler.dll` + `hip-mlir-opt` rebuild clean (Release)
- [x] lit: `test_{div,equal,sub}` (hip-to-llvm) and `test_{div,sub}` (onnx-to-hip) pass
- [x] pre-commit (lintrunner + clang-format + license) clean
- [ ] CI on the stacked train
