### PR TITLE
perf(memrefCopy): parallel strided-copy kernel -- GPU vision prefill TTFT -63 to -68% (+ inter-op gap accounting)

### DIFF
--- a/3rd-party/custom_kernels/CMakeLists.txt
+++ b/3rd-party/custom_kernels/CMakeLists.txt
@@ -58,6 +58,7 @@ hip_add_library(hip_custom_kernels STATIC
     hip/scatter_nd_kernel.hip
     hip/softmax_kernel.hip
     hip/nonzero_kernel.hip
+    hip/strided_copy_kernel.hip
     INCLUDE_DIRECTORIES
         ${CMAKE_CURRENT_SOURCE_DIR}/include
 )

--- a/3rd-party/custom_kernels/hip/strided_copy_kernel.hip
+++ b/3rd-party/custom_kernels/hip/strided_copy_kernel.hip
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// Parallel strided device-to-device copy for MLIR `memref.copy` (memrefCopy)
+// when neither side is fully contiguous and the copy spans >1 outer dim.
+//
+// The runtime's memrefCopy previously walked the outer index space on the host
+// and issued one hipMemcpyAsync PER contiguous row. For the Qwen3.5 vision
+// encoder that is ~2 million 72-byte launches per prefill (Reshape/Concat/Tile
+// chains over ~19k rows x ~108 copies) and dominated GPU prefill time. This
+// kernel does the whole strided copy in ONE launch: one element per thread,
+// with the contiguous inner suffix mapped to consecutive threads (coalesced),
+// and the outer multi-index decomposed per thread to apply src/dst strides.
+
+#include <hip/hip_runtime.h>
+#include <cstdint>
+#include <cstdio>
+
+#include "hip_custom_kernels.h"
+
+namespace {
+constexpr int SC_MAX_RANK = HIPDNN_MAX_MEMREF_RANK;
+
+struct StridedCopyParams {
+  int64_t outerSizes[SC_MAX_RANK];      // sizes of the outer (non-contiguous) dims
+  int64_t srcOuterStride[SC_MAX_RANK];  // src strides (elements) of outer dims
+  int64_t dstOuterStride[SC_MAX_RANK];  // dst strides (elements) of outer dims
+  int outerRank;
+  int64_t rowElems;    // contiguous inner elements per outer row (stride 1)
+  int64_t outerTotal;  // product(outerSizes)
+};
+
+template <typename T>
+__global__ void strided_copy_kernel(T *__restrict__ dst,
+                                    const T *__restrict__ src,
+                                    StridedCopyParams p) {
+  const int64_t total = p.outerTotal * p.rowElems;
+  const int64_t gstride = (int64_t)gridDim.x * blockDim.x;
+  for (int64_t t = (int64_t)blockIdx.x * blockDim.x + threadIdx.x; t < total;
+       t += gstride) {
+    const int64_t row = t / p.rowElems;
+    const int64_t col = t - row * p.rowElems;  // contiguous within the row
+    int64_t srcOff = 0, dstOff = 0, r = row;
+    for (int i = p.outerRank - 1; i >= 0; --i) {
+      const int64_t idx = r % p.outerSizes[i];
+      r /= p.outerSizes[i];
+      srcOff += idx * p.srcOuterStride[i];
+      dstOff += idx * p.dstOuterStride[i];
+    }
+    dst[dstOff + col] = src[srcOff + col];
+  }
+}
+}  // namespace
+
+// One-launch strided D2D copy. Pointers are element-aligned bases (already
+// offset). outer_sizes/strides describe the OUTER dims [0..outer_rank-1];
+// row_elems is the contiguous inner suffix (stride 1 on both sides).
+// Returns 0 on success; -2 for an unsupported element size so the caller can
+// fall back to the host per-row path.
+extern "C" int hip_strided_copy(void *stream, void *dst, const void *src,
+                                int64_t elem_size, int outer_rank,
+                                const int64_t *outer_sizes,
+                                const int64_t *src_outer_strides,
+                                const int64_t *dst_outer_strides,
+                                int64_t row_elems, int64_t outer_total) {
+  if (outer_total <= 0 || row_elems <= 0)
+    return 0;
+  if (outer_rank < 0 || outer_rank > SC_MAX_RANK)
+    return -1;
+
+  StridedCopyParams p{};
+  p.outerRank = outer_rank;
+  p.rowElems = row_elems;
+  p.outerTotal = outer_total;
+  for (int i = 0; i < outer_rank; ++i) {
+    p.outerSizes[i] = outer_sizes[i];
+    p.srcOuterStride[i] = src_outer_strides[i];
+    p.dstOuterStride[i] = dst_outer_strides[i];
+  }
+
+  hipStream_t s = static_cast<hipStream_t>(stream);
+  const int64_t total = outer_total * row_elems;
+  const int block = 256;
+  int64_t grid64 = (total + block - 1) / block;
+  if (grid64 > 65535)
+    grid64 = 65535;  // grid-stride loop covers the remainder
+  dim3 grid((unsigned)grid64), blk(block);
+
+  // Clear any stale error left by a PRIOR unrelated launch so the post-launch
+  // check below reflects only this kernel. Without this a sticky error would
+  // make hipGetLastError() return non-zero here, the caller would treat the
+  // kernel as failed and re-run the host per-row loop -- double-copying the
+  // buffer. (A real launch-config failure IS synchronous and leaves nothing
+  // enqueued, so falling back to the host loop in that case is still correct.)
+  (void)hipGetLastError();
+
+  switch (elem_size) {
+  case 8:
+    hipLaunchKernelGGL(strided_copy_kernel<uint64_t>, grid, blk, 0, s,
+                       (uint64_t *)dst, (const uint64_t *)src, p);
+    break;
+  case 4:
+    hipLaunchKernelGGL(strided_copy_kernel<uint32_t>, grid, blk, 0, s,
+                       (uint32_t *)dst, (const uint32_t *)src, p);
+    break;
+  case 2:
+    hipLaunchKernelGGL(strided_copy_kernel<uint16_t>, grid, blk, 0, s,
+                       (uint16_t *)dst, (const uint16_t *)src, p);
+    break;
+  case 1:
+    hipLaunchKernelGGL(strided_copy_kernel<uint8_t>, grid, blk, 0, s,
+                       (uint8_t *)dst, (const uint8_t *)src, p);
+    break;
+  default:
+    return -2;  // odd element size -> host fallback
+  }
+
+  hipError_t err = hipGetLastError();
+  if (err != hipSuccess) {
+    fprintf(stderr, "[custom_kernels] hip_strided_copy launch failed: %s\n",
+            hipGetErrorString(err));
+  }
+  return (int)err;
+}

--- a/3rd-party/custom_kernels/include/hip_custom_kernels.h
+++ b/3rd-party/custom_kernels/include/hip_custom_kernels.h
@@ -1394,6 +1394,24 @@ int hip_linear_attention_decode(
     int64_t beta_per_head,
     int64_t type);
 
+// Max memref rank honoured by the strided memref.copy fast path
+// (hip_strided_copy) and the host per-row fallback in memrefCopy. Defined
+// once here so the kernel and the runtime helper cannot drift out of sync.
+#define HIPDNN_MAX_MEMREF_RANK 12
+
+// Parallel strided device-to-device copy (one launch) for MLIR memref.copy
+// where neither side is contiguous and the copy spans multiple outer dims.
+// Replaces the host per-row hipMemcpyAsync loop in memrefCopy. Pointers are
+// element-aligned bases; outer_sizes/strides cover the outer dims, row_elems
+// is the contiguous inner suffix. Returns 0 on success, -2 if elem_size is
+// unsupported (caller falls back to the host per-row path).
+int hip_strided_copy(void *stream, void *dst, const void *src,
+                     int64_t elem_size, int outer_rank,
+                     const int64_t *outer_sizes,
+                     const int64_t *src_outer_strides,
+                     const int64_t *dst_outer_strides, int64_t row_elems,
+                     int64_t outer_total);
+
 /* =========================================================================
  * Causal Depthwise 1D Conv -- single-step "decode" path
  * =========================================================================

--- a/backend-mlir-compiler/custom-op-mlir/src/InferenceState.cpp
+++ b/backend-mlir-compiler/custom-op-mlir/src/InferenceState.cpp
@@ -53,8 +53,8 @@ InferenceState::InferenceState(PrivateTag, void *state,
         plugin_->get_method<void, void *>("hipdnn_ep_runtime_begin_compute");
     MY_LOG(2) << "begin_compute symbol "
               << (begin_compute_fn_ ? "resolved" : "not exported (no-op)");
-    flush_op_profile_fn_ = plugin_->get_method<void, void *>(
-        "hipdnn_ep_runtime_flush_op_profile");
+    flush_op_profile_fn_ =
+        plugin_->get_method<void, void *>("hipdnn_ep_runtime_flush_op_profile");
     MY_LOG(2) << "flush_op_profile symbol "
               << (flush_op_profile_fn_ ? "resolved" : "not exported (no-op)");
   }

--- a/build.py
+++ b/build.py
@@ -102,11 +102,17 @@ def download(url, dest, *, max_retries=5):
             req = urllib.request.Request(url)
             if offset:
                 req.add_header("Range", f"bytes={offset}-")
-                log(f"  Resuming from {offset / 1048576:.1f} MB (attempt {attempt + 1})")
+                log(
+                    f"  Resuming from {offset / 1048576:.1f} MB (attempt {attempt + 1})"
+                )
             with urllib.request.urlopen(req) as resp:
                 total_from_header = int(resp.headers.get("Content-Length") or 0)
                 # For Range responses the Content-Length is the remaining bytes
-                total = (offset + total_from_header) if offset and resp.status == 206 else total_from_header
+                total = (
+                    (offset + total_from_header)
+                    if offset and resp.status == 206
+                    else total_from_header
+                )
                 done = offset
                 mode = "ab" if offset and resp.status == 206 else "wb"
                 if mode == "wb":
@@ -136,7 +142,9 @@ def download(url, dest, *, max_retries=5):
                 log(f"  Download error ({exc}), retrying in {wait}s ...")
                 time.sleep(wait)
             else:
-                raise RuntimeError(f"Download failed after {max_retries} attempts: {url}") from exc
+                raise RuntimeError(
+                    f"Download failed after {max_retries} attempts: {url}"
+                ) from exc
 
 
 def _tar_extract(archive, dest, *, strip=0):

--- a/lib/Conversion/HipToLLVM/MemoryLowering.cpp
+++ b/lib/Conversion/HipToLLVM/MemoryLowering.cpp
@@ -694,10 +694,10 @@ struct MemRefCopyOpLowering : public ConvertOpToLLVMPattern<memref::CopyOp> {
       // post-collapse inner extent; the two differ by the dropped dim's factor.
       // A single 2D copy with pitch = stride[splitDim-1] would then walk every
       // height row at that one (too-small) pitch and silently read the wrong
-      // source rows.  When we can STATICALLY PROVE the prefix does not collapse,
-      // bail so the generic strided @memrefCopy libcall (registered by the
-      // standard memref-to-llvm lowering at lower benefit) handles it correctly
-      // by walking the outer index space one row at a time.
+      // source rows.  When we can STATICALLY PROVE the prefix does not
+      // collapse, bail so the generic strided @memrefCopy libcall (registered
+      // by the standard memref-to-llvm lowering at lower benefit) handles it
+      // correctly by walking the outer index space one row at a time.
       //
       // Before:  memref.copy %sv, %tmp
       //   : memref<?x16x36xf16, strided<[3456, 72, 1], offset: ?>>
@@ -712,7 +712,8 @@ struct MemRefCopyOpLowering : public ConvertOpToLLVMPattern<memref::CopyOp> {
         if (ShapedType::isDynamic(typeStrides[i]) ||
             ShapedType::isDynamic(typeStrides[i + 1]) ||
             ShapedType::isDynamic(shape[i + 1]))
-          continue; // cannot disprove collapse; keep the runtime-correct 2D path
+          continue; // cannot disprove collapse; keep the runtime-correct 2D
+                    // path
         if (typeStrides[i] != typeStrides[i + 1] * shape[i + 1])
           return rewriter.notifyMatchFailure(
               op, "non-collapsible outer strides; defer to generic memrefCopy");

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -188,6 +188,15 @@ int hipdnn_ep_state_cleanup(RuntimeState *state);
 // Ownership: Caller does NOT own stream (destroyed in cleanup)
 void *hipdnn_ep_state_get_stream(RuntimeState *state);
 
+// Current inference session stream (hipStream_t as void*), set per Compute by
+// hipdnn_ep_runtime_begin_compute. Lets ABI-fixed runtime helpers that don't
+// receive `state` -- notably memrefCopy (MLIR memref.copy lowering) -- issue
+// their work on the session stream instead of the default/null stream (0).
+// Default-stream work serializes with the session stream (legacy implicit
+// sync) and shows up as GPU idle in the prefill profile. Returns NULL before
+// the first begin_compute on this thread (callers fall back to stream 0).
+void *hipdnn_ep_get_current_stream(void);
+
 // Get MIOpen handle from state (for MIOpen operations)
 // Returns: miopenHandle_t cast to void* (NULL on error)
 // Ownership: Caller does NOT own handle (destroyed in cleanup)

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -966,6 +966,14 @@ static int per_entry_load_constants(RuntimeState *state,
   return 0;
 }
 
+// Set per Compute in hipdnn_ep_runtime_begin_compute; read by memrefCopy and
+// any other ABI-fixed helper that lacks a `state` arg so it can run on the
+// session stream rather than the default/null stream. thread_local mirrors
+// g_pool_depth's rationale: one inference per thread, but parallel sessions on
+// separate threads each keep their own stream. Defined here (ahead of cleanup)
+// so cleanup can null it out when the owning stream is destroyed.
+static thread_local void *g_hipdnn_ep_current_stream = nullptr;
+
 int hipdnn_ep_state_cleanup(RuntimeState *state) {
   if (!state) {
     fprintf(stderr, "Invalid runtime state in cleanup\n");
@@ -1101,6 +1109,13 @@ int hipdnn_ep_state_cleanup(RuntimeState *state) {
 
   // Destroy HIP stream
   if (state->stream) {
+    // Stop ABI-fixed helpers (memrefCopy) from reading this stream after it is
+    // destroyed. begin_compute re-publishes the stream each forward pass, so
+    // this only matters for a stray call after teardown -- but it keeps the
+    // thread-local from dangling on a freed hipStream_t.
+    if (g_hipdnn_ep_current_stream == static_cast<void *>(state->stream)) {
+      g_hipdnn_ep_current_stream = nullptr;
+    }
     HIP_CLEANUP(hipStreamDestroy(state->stream));
   }
 
@@ -1122,6 +1137,8 @@ void *hipdnn_ep_constant_get(RuntimeState *state, int64_t index) {
 void *hipdnn_ep_state_get_stream(RuntimeState *state) {
   return state ? static_cast<void *>(state->stream) : nullptr;
 }
+
+void *hipdnn_ep_get_current_stream(void) { return g_hipdnn_ep_current_stream; }
 
 void *hipdnn_ep_state_get_miopen_handle(RuntimeState *state) {
   return state ? static_cast<void *>(state->miopen_handle) : nullptr;
@@ -1153,6 +1170,9 @@ extern "C"
   }
   state->seqlens_k_cached_valid = false;
   state->seqlens_k_cached_ptr = nullptr;
+  // Publish the session stream for ABI-fixed helpers (memrefCopy) that run
+  // before/within main_graph and otherwise default to stream 0.
+  g_hipdnn_ep_current_stream = static_cast<void *>(state->stream);
 }
 
 // Per-op profile flush hook. Moved out of hipdnn_ep_stream_sync (which is on

--- a/lib/Runtime/op_profile.h
+++ b/lib/Runtime/op_profile.h
@@ -17,6 +17,14 @@
 #include <optional>
 #include <string>
 
+// hipEventDisableSystemFence (skips the per-event system-scope fence -- a perf
+// win for events that are only read after a stream sync) is a newer-HIP macro.
+// Older toolchains (e.g. the mock CI build) lack it; fall back to default event
+// flags there. Defined here so every consumer of op_profile.h gets the guard.
+#ifndef hipEventDisableSystemFence
+#define hipEventDisableSystemFence 0x0
+#endif
+
 struct OpProfileState;
 
 OpProfileState *op_profile_create();

--- a/lib/Runtime/real/hip.cpp
+++ b/lib/Runtime/real/hip.cpp
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 #include "../hipdnn_ep_runtime.h"
+#include "hip_custom_kernels.h"
 #include "runtime_types.h"
 
 #include <cstdio>
@@ -137,10 +138,20 @@ extern "C" void memrefCopy(int64_t elemSize, UnrankedMemRefHeader *src,
   char *srcBase = static_cast<char *>(sd->alignedPtr) + sd->offset * elemSize;
   char *dstBase = static_cast<char *>(dd->alignedPtr) + dd->offset * elemSize;
 
+  // Issue copies on the inference session stream instead of the default/null
+  // stream 0. Default-stream work serializes with the session stream (legacy
+  // implicit sync) -- every strided memref.copy (vision Concat/Slice/Tile
+  // chains) would otherwise stall the GPU and show up as inter-op idle in the
+  // prefill profile. NULL (before the first begin_compute on this thread)
+  // falls back to stream 0 = previous behavior.
+  hipStream_t stream =
+      static_cast<hipStream_t>(hipdnn_ep_get_current_stream());
+
   // Rank-0: a single element. No strides to honour.
   if (rank == 0) {
     hipError_t err =
-        hipMemcpyAsync(dstBase, srcBase, elemSize, hipMemcpyDeviceToDevice, 0);
+        hipMemcpyAsync(dstBase, srcBase, elemSize, hipMemcpyDeviceToDevice,
+                       stream);
     if (err != hipSuccess) {
       fprintf(stderr, "memrefCopy(rank-0) failed: %s\n",
               hipGetErrorString(err));
@@ -180,7 +191,8 @@ extern "C" void memrefCopy(int64_t elemSize, UnrankedMemRefHeader *src,
   // Tier 1: fully contiguous on both sides — one flat memcpy.
   if (rowStart == 0) {
     hipError_t err =
-        hipMemcpyAsync(dstBase, srcBase, rowBytes, hipMemcpyDeviceToDevice, 0);
+        hipMemcpyAsync(dstBase, srcBase, rowBytes, hipMemcpyDeviceToDevice,
+                       stream);
     if (err != hipSuccess) {
       fprintf(stderr, "memrefCopy(%lld bytes contig) failed: %s\n",
               static_cast<long long>(rowBytes), hipGetErrorString(err));
@@ -199,7 +211,7 @@ extern "C" void memrefCopy(int64_t elemSize, UnrankedMemRefHeader *src,
     int64_t dstPitch = dstStrides[0] * elemSize;
     hipError_t err =
         hipMemcpy2DAsync(dstBase, dstPitch, srcBase, srcPitch, rowBytes, height,
-                         hipMemcpyDeviceToDevice, 0);
+                         hipMemcpyDeviceToDevice, stream);
     if (err != hipSuccess) {
       fprintf(stderr, "memrefCopy(rank-2 strided) failed: %s\n",
               hipGetErrorString(err));
@@ -211,7 +223,7 @@ extern "C" void memrefCopy(int64_t elemSize, UnrankedMemRefHeader *src,
   // hipMemcpyAsync per contiguous row. This is correct for any rank and
   // stride pattern. Max rank is bounded by MLIR's descriptor layout; 12
   // is comfortably above anything we currently generate.
-  constexpr int64_t kMaxRank = 12;
+  constexpr int64_t kMaxRank = HIPDNN_MAX_MEMREF_RANK;
   if (rank > kMaxRank) {
     fprintf(stderr, "memrefCopy: rank %lld exceeds supported maximum %lld\n",
             static_cast<long long>(rank), static_cast<long long>(kMaxRank));
@@ -224,6 +236,20 @@ extern "C" void memrefCopy(int64_t elemSize, UnrankedMemRefHeader *src,
   for (int64_t i = 0; i < outerRank; ++i)
     outerTotal *= srcSizes[i];
 
+  // Tier 3 fast path: a single parallel strided-copy kernel instead of
+  // `outerTotal` per-row hipMemcpyAsync launches (which dominate strided-copy
+  // heavy graphs -- e.g. ~2M tiny launches per Qwen3.5 vision prefill).
+  // `srcStrides`/`dstStrides` are the outer-dim element strides; `rowElems` is
+  // the contiguous inner suffix. The host per-row loop below is the fallback
+  // for element sizes the kernel does not handle (rc != 0).
+  {
+    int rc = hip_strided_copy(stream, dstBase, srcBase, elemSize,
+                              static_cast<int>(outerRank), srcSizes, srcStrides,
+                              dstStrides, rowElems, outerTotal);
+    if (rc == 0)
+      return;
+  }
+
   for (int64_t r = 0; r < outerTotal; ++r) {
     int64_t srcByteOff = 0;
     int64_t dstByteOff = 0;
@@ -232,7 +258,7 @@ extern "C" void memrefCopy(int64_t elemSize, UnrankedMemRefHeader *src,
       dstByteOff += idx[i] * dstStrides[i] * elemSize;
     }
     hipError_t err = hipMemcpyAsync(dstBase + dstByteOff, srcBase + srcByteOff,
-                                    rowBytes, hipMemcpyDeviceToDevice, 0);
+                                    rowBytes, hipMemcpyDeviceToDevice, stream);
     if (err != hipSuccess) {
       fprintf(stderr, "memrefCopy(strided row) failed: %s\n",
               hipGetErrorString(err));

--- a/lib/Runtime/real/hip.cpp
+++ b/lib/Runtime/real/hip.cpp
@@ -144,14 +144,12 @@ extern "C" void memrefCopy(int64_t elemSize, UnrankedMemRefHeader *src,
   // chains) would otherwise stall the GPU and show up as inter-op idle in the
   // prefill profile. NULL (before the first begin_compute on this thread)
   // falls back to stream 0 = previous behavior.
-  hipStream_t stream =
-      static_cast<hipStream_t>(hipdnn_ep_get_current_stream());
+  hipStream_t stream = static_cast<hipStream_t>(hipdnn_ep_get_current_stream());
 
   // Rank-0: a single element. No strides to honour.
   if (rank == 0) {
-    hipError_t err =
-        hipMemcpyAsync(dstBase, srcBase, elemSize, hipMemcpyDeviceToDevice,
-                       stream);
+    hipError_t err = hipMemcpyAsync(dstBase, srcBase, elemSize,
+                                    hipMemcpyDeviceToDevice, stream);
     if (err != hipSuccess) {
       fprintf(stderr, "memrefCopy(rank-0) failed: %s\n",
               hipGetErrorString(err));
@@ -190,9 +188,8 @@ extern "C" void memrefCopy(int64_t elemSize, UnrankedMemRefHeader *src,
 
   // Tier 1: fully contiguous on both sides — one flat memcpy.
   if (rowStart == 0) {
-    hipError_t err =
-        hipMemcpyAsync(dstBase, srcBase, rowBytes, hipMemcpyDeviceToDevice,
-                       stream);
+    hipError_t err = hipMemcpyAsync(dstBase, srcBase, rowBytes,
+                                    hipMemcpyDeviceToDevice, stream);
     if (err != hipSuccess) {
       fprintf(stderr, "memrefCopy(%lld bytes contig) failed: %s\n",
               static_cast<long long>(rowBytes), hipGetErrorString(err));

--- a/test/numeric/tests/test_shape_ops.py
+++ b/test/numeric/tests/test_shape_ops.py
@@ -125,10 +125,10 @@ class TestStridedCopyTier3:
         "dtype,shapes,axis",
         [
             # rank-3, last axis -> rowStart == 2 (outerRank == 2).
-            (np.float16, [[8, 16, 4], [8, 16, 4]], -1),   # 2-byte elems
-            (np.float32, [[8, 16, 5], [8, 16, 3]], -1),   # 4-byte elems
-            (np.int32, [[6, 9, 4], [6, 9, 7]], -1),       # 4-byte elems
-            (np.int64, [[5, 7, 3], [5, 7, 6]], -1),       # 8-byte elems
+            (np.float16, [[8, 16, 4], [8, 16, 4]], -1),  # 2-byte elems
+            (np.float32, [[8, 16, 5], [8, 16, 3]], -1),  # 4-byte elems
+            (np.int32, [[6, 9, 4], [6, 9, 7]], -1),  # 4-byte elems
+            (np.int64, [[5, 7, 3], [5, 7, 6]], -1),  # 8-byte elems
             # Large outer extent: 4096 rows forces grid clamp + grid-stride loop.
             (np.float16, [[64, 64, 2], [64, 64, 2]], -1),
             # rank-4, last axis -> rowStart == 3 (outerRank == 3).

--- a/test/numeric/tests/test_shape_ops.py
+++ b/test/numeric/tests/test_shape_ops.py
@@ -109,6 +109,48 @@ class TestConcat:
 
 
 # ---------------------------------------------------------------------------
+# Tier-3 strided memref.copy kernel (hip_strided_copy)
+# ---------------------------------------------------------------------------
+#
+# A last-axis Concat on rank >= 3 produces a destination `memref.subview`
+# whose contiguous suffix is only the innermost dim, so two or more outer
+# dims remain strided (rowStart >= 2 in memrefCopy). That is the generic
+# "Tier 3" regime, which the parallel `hip_strided_copy` kernel now handles
+# in a single launch instead of one hipMemcpyAsync per row. These cases pin
+# that path numerically against the ORT CPU reference, across the element
+# widths the kernel templates on (2/4/8 bytes) and with outer extents large
+# enough to span multiple thread blocks plus the grid-stride remainder.
+class TestStridedCopyTier3:
+    @pytest.mark.parametrize(
+        "dtype,shapes,axis",
+        [
+            # rank-3, last axis -> rowStart == 2 (outerRank == 2).
+            (np.float16, [[8, 16, 4], [8, 16, 4]], -1),   # 2-byte elems
+            (np.float32, [[8, 16, 5], [8, 16, 3]], -1),   # 4-byte elems
+            (np.int32, [[6, 9, 4], [6, 9, 7]], -1),       # 4-byte elems
+            (np.int64, [[5, 7, 3], [5, 7, 6]], -1),       # 8-byte elems
+            # Large outer extent: 4096 rows forces grid clamp + grid-stride loop.
+            (np.float16, [[64, 64, 2], [64, 64, 2]], -1),
+            # rank-4, last axis -> rowStart == 3 (outerRank == 3).
+            (np.float32, [[2, 3, 4, 5], [2, 3, 4, 6]], -1),
+            (np.int64, [[2, 2, 3, 4], [2, 2, 3, 4]], -1),
+        ],
+    )
+    def test_concat_last_axis_strided(self, model_runner, dtype, shapes, axis):
+        model = _make_concat_model(dtype, shapes, axis)
+        rng = np.random.default_rng(800 + sum(shapes[0]))
+        feeds = []
+        for s in shapes:
+            if np.issubdtype(dtype, np.integer):
+                feeds.append(rng.integers(-100, 100, s, dtype=dtype))
+            else:
+                feeds.append(rng.uniform(-2.0, 2.0, s).astype(dtype))
+        actual, expected = model_runner.run_sample(model, feeds)
+        # Pure data movement -- must be bit-exact, no tolerance.
+        compare_outputs(actual, expected, atol=0)
+
+
+# ---------------------------------------------------------------------------
 # Tile
 # ---------------------------------------------------------------------------
 def _make_tile_model(dtype, input_shape: list[int], repeats: list[int]):

--- a/test/python/test_qwen3_5_9b.py
+++ b/test/python/test_qwen3_5_9b.py
@@ -66,7 +66,9 @@ from conftest import (
 
 # Local model dir (vision.onnx + vision.onnx.data ~915 MB). Downloaded by
 # huggingface_hub from amd/Qwen3.5-9B-rtn-int4-int8-128gs-fp16-onnx-gpu.
-QWEN35_MODEL_DIR = REPO_ROOT / "models" / "Qwen3.5-9B-rtn-int4-int8-128gs-fp16-onnx-gpu-2"
+QWEN35_MODEL_DIR = (
+    REPO_ROOT / "models" / "Qwen3.5-9B-rtn-int4-int8-128gs-fp16-onnx-gpu-2"
+)
 
 
 def test_qwen_vision_patch_merger_dynshape():
@@ -783,9 +785,9 @@ class TestQwen3_5_9BMultimodal:
             "step failed silently."
         )
         assert not all(t == 0 for t in tokens), (
-            f"CPU produced all-zero token sequence — likely NaN/zero "
-            f"logits. ORT setup is broken; gate the rest of the suite "
-            f"on this before debugging EP-side issues."
+            "CPU produced all-zero token sequence — likely NaN/zero "
+            "logits. ORT setup is broken; gate the rest of the suite "
+            "on this before debugging EP-side issues."
         )
         assert "eiffel" in decoded.lower(), (
             "CPU baseline did not identify the Eiffel Tower in tower.jpg. "
@@ -796,7 +798,13 @@ class TestQwen3_5_9BMultimodal:
         )
 
     def _run_oga_in_provider_mode(
-        self, workspace, provider, *, with_image, max_new, max_length=None,
+        self,
+        workspace,
+        provider,
+        *,
+        with_image,
+        max_new,
+        max_length=None,
     ):
         """Spawn an OGA worker patched to use either CPU EP or MorphiZenEP,
         with or without the test image, and return the generated token list.

--- a/tools/perf-report/docker_run_bench.sh
+++ b/tools/perf-report/docker_run_bench.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+##
+## Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+## Licensed under the MIT License.
+##
+
 # Wrapper that runs a bench script inside the hipdnn-ep build container
 # without needing an interactive shell. Use this from any host terminal that
 # doesn't deliver a clean TTY to `docker exec -it` -- e.g. Cursor's embedded

--- a/tools/perf-report/format_perf_report.py
+++ b/tools/perf-report/format_perf_report.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
+#
 # Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 # Licensed under the MIT License.
+#
 """Format a HIPDNN EP OGA model_benchmark log into a structured profiling report.
 
 The report is the locked-down rendering of three independent measurement streams
@@ -49,6 +51,7 @@ USAGE
     tools/perf-report/format_perf_report.py <log-file> --no-banner  # CI embed
     tools/perf-report/format_perf_report.py <log-file> --indent 2   # indent N
 """
+
 from __future__ import annotations
 
 import argparse
@@ -144,7 +147,6 @@ class OgaHeadline:
     @classmethod
     def parse(cls, lines: list[str]) -> "OgaHeadline":
         out = cls()
-        cur_field: Optional[str] = None
         cur_block: Optional[dict] = None
 
         # Pre-compile per-row patterns. model_benchmark uses literal tabs
@@ -164,31 +166,33 @@ class OgaHeadline:
             stripped = line.lstrip()
 
             # Single-line headers and tail rows
-            m = re.match(r"Batch size:\s*(\d+),\s*prompt tokens:\s*(\d+),"
-                         r"\s*tokens to generate:\s*(\d+)", line)
+            m = re.match(
+                r"Batch size:\s*(\d+),\s*prompt tokens:\s*(\d+),"
+                r"\s*tokens to generate:\s*(\d+)",
+                line,
+            )
             if m:
                 out.batch_size = int(m.group(1))
                 out.prompt_tokens = int(m.group(2))
                 out.tokens_to_generate = int(m.group(3))
-                cur_field, cur_block = None, None
+                cur_block = None
                 continue
 
             m = re.match(r"Peak working set size \(bytes\):\s*(\d+)", line)
             if m:
                 out.peak_ws_bytes = int(m.group(1))
-                cur_field, cur_block = None, None
+                cur_block = None
                 continue
 
             # Block-start headers — always unindented
             if not line.startswith(("\t", " ")):
                 field_name = cls._BLOCKS.get(line.rstrip())
                 if field_name is not None:
-                    cur_field = field_name
                     cur_block = {}
                     setattr(out, field_name, cur_block)
                     continue
                 # Any other unindented line ends the current block
-                cur_field, cur_block = None, None
+                cur_block = None
                 continue
 
             if cur_block is None:
@@ -262,23 +266,33 @@ class OgaHeadline:
         prefill_tps = (out.prompt_tokens / (prompt_us / 1e6)) if prompt_us else 0.0
 
         out.prefill = {
-            "avg_us": prompt_us, "p50_us": prompt_us, "stddev_us": 0.0,
-            "n": f"{reps} * {out.prompt_tokens} token(s)", "avg_tps": prefill_tps,
+            "avg_us": prompt_us,
+            "p50_us": prompt_us,
+            "stddev_us": 0.0,
+            "n": f"{reps} * {out.prompt_tokens} token(s)",
+            "avg_tps": prefill_tps,
         }
         out.decode = {
-            "avg_us": decode_us, "p50_us": decode_us, "stddev_us": 0.0,
+            "avg_us": decode_us,
+            "p50_us": decode_us,
+            "stddev_us": 0.0,
             "n": f"{reps} * {decode_calls} token(s)",
             "avg_tps": num("Token Generation Throughput"),
         }
         out.sampling = {
-            "avg_us": sample_us, "p50_us": sample_us, "stddev_us": 0.0,
+            "avg_us": sample_us,
+            "p50_us": sample_us,
+            "stddev_us": 0.0,
             "n": f"{reps} * 1 token(s)",
             "avg_tps": num("Sampling Throughput"),
         }
         out.e2e = {
-            "avg_ms": wall_ms, "p50_ms": wall_ms, "stddev_ms": 0.0, "n": f"{reps}",
+            "avg_ms": wall_ms,
+            "p50_ms": wall_ms,
+            "stddev_ms": 0.0,
+            "n": f"{reps}",
         }
-        out.peak_ws_bytes = int(num("Memory Usage") * 1024 ** 3)
+        out.peak_ws_bytes = int(num("Memory Usage") * 1024**3)
         return out
 
     def __bool__(self) -> bool:
@@ -367,8 +381,9 @@ class DecodeBreakdown:
     perop_gpu_median_ms: float
 
     @classmethod
-    def build(cls, head: OgaHeadline, perf: PerfSummary,
-              perop: PerOpTable) -> Optional["DecodeBreakdown"]:
+    def build(
+        cls, head: OgaHeadline, perf: PerfSummary, perop: PerOpTable
+    ) -> Optional["DecodeBreakdown"]:
         if not (head.decode and perf and perop.total_gpu_median_ms is not None):
             return None
         oga_p50_us = head.decode.get("p50_us")
@@ -481,7 +496,7 @@ def run_params_from_log_path(p: Path) -> dict:
 # embed raw glyphs inline — one place to swap if a third style is ever added.
 TREE_CHARS = {
     "unicode": {"branch": "├─", "last": "└─", "pipe": "│ ", "blank": "  "},
-    "ascii":   {"branch": "+-", "last": "+-", "pipe": "| ", "blank": "  "},
+    "ascii": {"branch": "+-", "last": "+-", "pipe": "| ", "blank": "  "},
 }
 
 SECTION_RULE = "─" * 74
@@ -492,7 +507,9 @@ SECTION_RULE = "─" * 74
 LABEL_WIDTH = 42
 
 
-def render_banner(model: str, run_params: dict, perf: PerfSummary, indent: str) -> list[str]:
+def render_banner(
+    model: str, run_params: dict, perf: PerfSummary, indent: str
+) -> list[str]:
     bar = "═" * (74 + len(indent))
     bits = [f"HIPDNN EP profile  ·  {model}"]
     # Show shape only when it's worth flagging. "dynamic" is the default for
@@ -514,7 +531,9 @@ def render_banner(model: str, run_params: dict, perf: PerfSummary, indent: str) 
     return [f"{indent}{bar}", f"{indent}  {'  ·  '.join(bits)}", f"{indent}{bar}"]
 
 
-def render_section_header(num: int, title: str, subtitle: str, indent: str) -> list[str]:
+def render_section_header(
+    num: int, title: str, subtitle: str, indent: str
+) -> list[str]:
     return [
         f"{indent}  § {num}  {title}  —  {subtitle}",
         f"{indent}  {SECTION_RULE}",
@@ -532,22 +551,31 @@ def render_section_1_headline(head: OgaHeadline, indent: str) -> list[str]:
                    sub-blocks within head render the literal ``(absent)``.
     """
     lines = render_section_header(
-        1, "HEADLINE",
+        1,
+        "HEADLINE",
         f"model_benchmark (batch={head.batch_size}, prompt={head.prompt_tokens}, "
         f"gen={head.tokens_to_generate})",
         indent,
     )
     # Column widths chosen so all five rows align with the header.
     fmt = "    {label:<18} {tps:>13}   {p50:>13}   {std:>11}   {n}"
-    lines.append(indent + fmt.format(
-        label="", tps="throughput",
-        p50="p50 latency", std="stddev", n="samples"
-    ).rstrip())
+    lines.append(
+        indent
+        + fmt.format(
+            label="", tps="throughput", p50="p50 latency", std="stddev", n="samples"
+        ).rstrip()
+    )
 
-    def row(label: str, block: Optional[dict], lat_unit: str, *, has_tps: bool = True) -> str:
+    def row(
+        label: str, block: Optional[dict], lat_unit: str, *, has_tps: bool = True
+    ) -> str:
         if block is None:
             return indent + f"    {label:<18} (absent)"
-        tps = f"{block.get('avg_tps', 0):.2f} t/s" if has_tps and "avg_tps" in block else "—"
+        tps = (
+            f"{block.get('avg_tps', 0):.2f} t/s"
+            if has_tps and "avg_tps" in block
+            else "—"
+        )
         p50_key = f"p50_{lat_unit}"
         p50 = f"{block.get(p50_key, 0):.2f} {lat_unit}" if p50_key in block else "—"
         std_key = f"stddev_{lat_unit}"
@@ -555,17 +583,21 @@ def render_section_1_headline(head: OgaHeadline, indent: str) -> list[str]:
         n = block.get("n", "—")
         return indent + fmt.format(label=label, tps=tps, p50=p50, std=std, n=n).rstrip()
 
-    lines.append(row("Prefill (TTFT)", head.prefill,  "us"))
-    lines.append(row("Decode",         head.decode,   "us"))
-    lines.append(row("Sampling",       head.sampling, "us"))
-    lines.append(row("E2E generation", head.e2e,      "ms", has_tps=False))
-    lines.append(indent + f"    {'Peak working set':<18} "
-                          f"{human_bytes(head.peak_ws_bytes)} "
-                          f"({head.peak_ws_bytes or '?'} bytes)")
+    lines.append(row("Prefill (TTFT)", head.prefill, "us"))
+    lines.append(row("Decode", head.decode, "us"))
+    lines.append(row("Sampling", head.sampling, "us"))
+    lines.append(row("E2E generation", head.e2e, "ms", has_tps=False))
+    lines.append(
+        indent + f"    {'Peak working set':<18} "
+        f"{human_bytes(head.peak_ws_bytes)} "
+        f"({head.peak_ws_bytes or '?'} bytes)"
+    )
     return lines
 
 
-def render_section_2_breakdown(bd: DecodeBreakdown, charset: str, indent: str) -> list[str]:
+def render_section_2_breakdown(
+    bd: DecodeBreakdown, charset: str, indent: str
+) -> list[str]:
     """§ 2 STEADY-STATE DECODE BREAKDOWN — drawn as an actual tree.
 
     Source:        ``DecodeBreakdown`` -> joined OgaHeadline + PerfSummary +
@@ -582,20 +614,24 @@ def render_section_2_breakdown(bd: DecodeBreakdown, charset: str, indent: str) -
     tc = TREE_CHARS[charset]
     arrow = "<-" if charset == "ascii" else "◀"
     lines = render_section_header(
-        3, "STEADY-STATE DECODE BREAKDOWN",
+        3,
+        "STEADY-STATE DECODE BREAKDOWN",
         "1 decode token, median across run",
         indent,
     )
-    lines.append(indent + f"    {'':<{LABEL_WIDTH}} "
-                          f"{'latency':>10}   {'share':>6}   {'source':<20}")
+    lines.append(
+        indent + f"    {'':<{LABEL_WIDTH}} "
+        f"{'latency':>10}   {'share':>6}   {'source':<20}"
+    )
 
-    def row(prefix: str, label: str, ms: float, share: float,
-            src: str = "") -> str:
+    def row(prefix: str, label: str, ms: float, share: float, src: str = "") -> str:
         pad = LABEL_WIDTH - len(prefix) - len(label)
         if pad < 1:
             pad = 1
-        return (f"{indent}    {prefix}{label}{' ' * pad} "
-                f"{ms:>7.3f} ms   {share:>5.1f} %   {src}").rstrip()
+        return (
+            f"{indent}    {prefix}{label}{' ' * pad} "
+            f"{ms:>7.3f} ms   {share:>5.1f} %   {src}"
+        ).rstrip()
 
     total = bd.oga_p50_ms
 
@@ -619,42 +655,115 @@ def render_section_2_breakdown(bd: DecodeBreakdown, charset: str, indent: str) -
     #      │  ├─ GPU: unwrapped + glue kernels
     #      │  └─ CPU: host dispatch + sync poll      <- last L3
     #      └─ Trailing fence (hipStreamSync)         <- last L2 under L1-LAST
-    PIPE   = f"{tc['pipe']} "    # "│  " — parent has more siblings below
-    BLANK  = "   "               # parent was last — no pipe through this column
+    PIPE = f"{tc['pipe']} "  # "│  " — parent has more siblings below
+    BLANK = "   "  # parent was last — no pipe through this column
     BRANCH = f"{tc['branch']} "  # "├─ " — this row has siblings below
-    LAST   = f"{tc['last']} "    # "└─ " — last sibling at this level
+    LAST = f"{tc['last']} "  # "└─ " — last sibling at this level
 
-    lines.append(row("", "OGA::GenerateNextToken", bd.oga_p50_ms, 100.0,
-                     f"{arrow} § 1 Decode p50"))
-    lines.append(row(BRANCH, "OGA + ORT framework overhead",
-                     bd.oga_overhead_ms, pct(bd.oga_overhead_ms)))
-    lines.append(row(PIPE + BRANCH, "Token sampling",
-                     bd.sampling_avg_ms, pct(bd.sampling_avg_ms),
-                     f"{arrow} § 1 Sampling avg"))
-    lines.append(row(PIPE + LAST, "Other (IoBinding rebind, etc.)",
-                     bd.other_oga_ms, pct(bd.other_oga_ms)))
-    lines.append(row(LAST, "EP MlirCustomOp::Compute()",
-                     bd.wall_ms, pct(bd.wall_ms),
-                     f"{arrow} § 6 wall_ms"))
-    lines.append(row(BLANK + BRANCH, "Marshal in (input descriptors)",
-                     bd.marshal_in_ms, pct(bd.marshal_in_ms),
-                     f"{arrow} § 6 marshal_in_ms"))
-    lines.append(row(BLANK + BRANCH, "Marshal out (output desc.)",
-                     bd.marshal_out_ms, pct(bd.marshal_out_ms),
-                     f"{arrow} § 6 marshal_out_ms"))
-    lines.append(row(BLANK + BRANCH, "model.dll inference_compute()",
-                     bd.compute_cpu_ms, pct(bd.compute_cpu_ms),
-                     f"{arrow} § 6 compute_cpu_ms"))
-    lines.append(row(BLANK + PIPE + BRANCH, "GPU: OP_PROFILE kernels (sum)",
-                     bd.perop_gpu_median_ms, pct(bd.perop_gpu_median_ms),
-                     f"{arrow} § 7 TOTAL"))
-    lines.append(row(BLANK + PIPE + BRANCH, "GPU: outside § 7 scopes",
-                     bd.unprofiled_gpu_ms, pct(bd.unprofiled_gpu_ms)))
-    lines.append(row(BLANK + PIPE + LAST, "CPU: host dispatch + sync poll",
-                     bd.cpu_overhead_ms, pct(bd.cpu_overhead_ms)))
-    lines.append(row(BLANK + LAST, "Trailing fence (hipStreamSync)",
-                     bd.fence_ms, pct(bd.fence_ms),
-                     f"{arrow} § 6 fence_residual_ms"))
+    lines.append(
+        row(
+            "",
+            "OGA::GenerateNextToken",
+            bd.oga_p50_ms,
+            100.0,
+            f"{arrow} § 1 Decode p50",
+        )
+    )
+    lines.append(
+        row(
+            BRANCH,
+            "OGA + ORT framework overhead",
+            bd.oga_overhead_ms,
+            pct(bd.oga_overhead_ms),
+        )
+    )
+    lines.append(
+        row(
+            PIPE + BRANCH,
+            "Token sampling",
+            bd.sampling_avg_ms,
+            pct(bd.sampling_avg_ms),
+            f"{arrow} § 1 Sampling avg",
+        )
+    )
+    lines.append(
+        row(
+            PIPE + LAST,
+            "Other (IoBinding rebind, etc.)",
+            bd.other_oga_ms,
+            pct(bd.other_oga_ms),
+        )
+    )
+    lines.append(
+        row(
+            LAST,
+            "EP MlirCustomOp::Compute()",
+            bd.wall_ms,
+            pct(bd.wall_ms),
+            f"{arrow} § 6 wall_ms",
+        )
+    )
+    lines.append(
+        row(
+            BLANK + BRANCH,
+            "Marshal in (input descriptors)",
+            bd.marshal_in_ms,
+            pct(bd.marshal_in_ms),
+            f"{arrow} § 6 marshal_in_ms",
+        )
+    )
+    lines.append(
+        row(
+            BLANK + BRANCH,
+            "Marshal out (output desc.)",
+            bd.marshal_out_ms,
+            pct(bd.marshal_out_ms),
+            f"{arrow} § 6 marshal_out_ms",
+        )
+    )
+    lines.append(
+        row(
+            BLANK + BRANCH,
+            "model.dll inference_compute()",
+            bd.compute_cpu_ms,
+            pct(bd.compute_cpu_ms),
+            f"{arrow} § 6 compute_cpu_ms",
+        )
+    )
+    lines.append(
+        row(
+            BLANK + PIPE + BRANCH,
+            "GPU: OP_PROFILE kernels (sum)",
+            bd.perop_gpu_median_ms,
+            pct(bd.perop_gpu_median_ms),
+            f"{arrow} § 7 TOTAL",
+        )
+    )
+    lines.append(
+        row(
+            BLANK + PIPE + BRANCH,
+            "GPU: outside § 7 scopes",
+            bd.unprofiled_gpu_ms,
+            pct(bd.unprofiled_gpu_ms),
+        )
+    )
+    lines.append(
+        row(
+            BLANK + PIPE + LAST,
+            "CPU: host dispatch + sync poll",
+            bd.cpu_overhead_ms,
+            pct(bd.cpu_overhead_ms),
+        )
+    )
+    lines.append(
+        row(
+            BLANK + LAST,
+            "Trailing fence (hipStreamSync)",
+            bd.fence_ms,
+            pct(bd.fence_ms),
+            f"{arrow} § 6 fence_residual_ms",
+        )
+    )
 
     # Notes for the two "residual" rows that don't have a direct § N cross-ref
     # (they are subtractive — what's left after the named rows are accounted
@@ -663,20 +772,34 @@ def render_section_2_breakdown(bd: DecodeBreakdown, charset: str, indent: str) -
     # speak for themselves once you've followed their § N arrow.
     lines.append("")
     lines.append(indent + "    notes:")
-    lines.append(indent + "      - \"GPU: outside § 7 scopes\" = § 6 gpu_ms − § 7 "
-                          "TOTAL: GPU work not bracketed by any")
-    lines.append(indent + "        OP_PROFILE wrapper. Typical sources: MIOpen / "
-                          "hipBLASLt internal helper")
-    lines.append(indent + "        launches, ops lacking an OP_PROFILE scope, "
-                          "hipMemset / glue between ops. If")
-    lines.append(indent + "        this row grows after a runtime change, "
-                          "OP_PROFILE coverage has regressed.")
-    lines.append(indent + "      - \"Other (IoBinding rebind, etc.)\" = § 1 Decode "
-                          "p50 − sampling − EP wall: OGA")
-    lines.append(indent + "        framework overhead between Generator steps. "
-                          "Dominated by IoBinding's per-token")
-    lines.append(indent + "        rebind of all input/output tensors (scales "
-                          "with KV buffer size, not seq len).")
+    lines.append(
+        indent + '      - "GPU: outside § 7 scopes" = § 6 gpu_ms − § 7 '
+        "TOTAL: GPU work not bracketed by any"
+    )
+    lines.append(
+        indent + "        OP_PROFILE wrapper. Typical sources: MIOpen / "
+        "hipBLASLt internal helper"
+    )
+    lines.append(
+        indent + "        launches, ops lacking an OP_PROFILE scope, "
+        "hipMemset / glue between ops. If"
+    )
+    lines.append(
+        indent + "        this row grows after a runtime change, "
+        "OP_PROFILE coverage has regressed."
+    )
+    lines.append(
+        indent + '      - "Other (IoBinding rebind, etc.)" = § 1 Decode '
+        "p50 − sampling − EP wall: OGA"
+    )
+    lines.append(
+        indent + "        framework overhead between Generator steps. "
+        "Dominated by IoBinding's per-token"
+    )
+    lines.append(
+        indent + "        rebind of all input/output tensors (scales "
+        "with KV buffer size, not seq len)."
+    )
     return lines
 
 
@@ -751,11 +874,11 @@ def parse_compute_samples(lines: list[str]) -> list[ComputeSample]:
     token (and blowing up the § 2 decode share to thousands of percent).
     Positional pairing instead just skips the one orphaned Compute.
     """
-    metric_pos = [(i, m) for i, ln in enumerate(lines)
-                  if (m := _PERCALL_RE.search(ln))]
+    metric_pos = [(i, m) for i, ln in enumerate(lines) if (m := _PERCALL_RE.search(ln))]
     border_idx = [i for i, ln in enumerate(lines) if ln.startswith("[PERF] ===")]
-    pairs = [(border_idx[j], border_idx[j + 1])
-             for j in range(0, len(border_idx) - 1, 2)]
+    pairs = [
+        (border_idx[j], border_idx[j + 1]) for j in range(0, len(border_idx) - 1, 2)
+    ]
     out: list[ComputeSample] = []
     pi = 0
     for pos, m in metric_pos:
@@ -763,13 +886,16 @@ def parse_compute_samples(lines: list[str]) -> list[ComputeSample]:
         # the very first Compute's block, when its own metric line was dropped).
         while pi < len(pairs) and pairs[pi][0] < pos:
             pi += 1
-        blk = lines[pairs[pi][0]: pairs[pi][1] + 1] if pi < len(pairs) else []
+        blk = lines[pairs[pi][0] : pairs[pi][1] + 1] if pi < len(pairs) else []
         if pi < len(pairs):
             pi += 1
         s = ComputeSample(
-            wall_ms=float(m.group(2)), marshal_in_ms=float(m.group(3)),
-            marshal_out_ms=float(m.group(4)), compute_cpu_ms=float(m.group(5)),
-            gpu_ms=float(m.group(6)), fence_residual_ms=float(m.group(7)),
+            wall_ms=float(m.group(2)),
+            marshal_in_ms=float(m.group(3)),
+            marshal_out_ms=float(m.group(4)),
+            compute_cpu_ms=float(m.group(5)),
+            gpu_ms=float(m.group(6)),
+            fence_residual_ms=float(m.group(7)),
             block=blk,
         )
         s.stage = _classify_stage(blk)
@@ -788,7 +914,8 @@ def stage_perf(samples: list[ComputeSample]) -> PerfSummary:
             continue
         n = len(vals)
         ps.metrics[name] = {
-            "min": vals[0], "max": vals[-1],
+            "min": vals[0],
+            "max": vals[-1],
             "mean": sum(vals) / n,
             "median": statistics.median(vals),
             "p99": vals[max(0, int(round(0.99 * (n - 1))))],
@@ -800,10 +927,10 @@ def stage_perf(samples: list[ComputeSample]) -> PerfSummary:
 # tag, shape sub-rows 4 spaces; both end in (calls, gpu, cpu[, gpu%]). The
 # label is captured lazily because shape labels can contain spaces (e.g.
 # "n=8192 rank=3"). TOTAL/header rows don't match (no integer `calls` column).
-_OP_PARENT_RE = re.compile(
-    r"^\[PERF\]  (\S.*?)\s+(\d+)\s+(\S+)\s+(\S+)(?:\s+\S+)?\s*$")
+_OP_PARENT_RE = re.compile(r"^\[PERF\]  (\S.*?)\s+(\d+)\s+(\S+)\s+(\S+)(?:\s+\S+)?\s*$")
 _OP_SHAPE_RE = re.compile(
-    r"^\[PERF\]    (\S.*?)\s+(\d+)\s+(\S+)\s+(\S+)(?:\s+\S+)?\s*$")
+    r"^\[PERF\]    (\S.*?)\s+(\d+)\s+(\S+)\s+(\S+)(?:\s+\S+)?\s*$"
+)
 
 
 def _accum(slot: list, gpu_tok: str, cpu_tok: str) -> None:
@@ -830,9 +957,9 @@ def _segment_prefill_generations(samples: list[ComputeSample]) -> list[dict]:
     be non-vision, which opens a leading generation that a naive vision-count
     would miss -- off-by-one against § 3.)
     """
+
     def blank() -> dict:
-        return {sub: {m: 0.0 for m in _PREFILL_METRICS}
-                for sub in _PREFILL_SUBS}
+        return {sub: {m: 0.0 for m in _PREFILL_METRICS} for sub in _PREFILL_SUBS}
 
     gens: list[dict] = []
     cur: Optional[dict] = None
@@ -863,9 +990,14 @@ def _count_prefill_generations(samples: list[ComputeSample]) -> int:
     return len(_segment_prefill_generations(samples)) or 1
 
 
-def render_perop_aggregate(blocks: list[list[str]], indent: str, *,
-                           num: int, subtitle: str,
-                           generations: int = 1) -> list[str]:
+def render_perop_aggregate(
+    blocks: list[list[str]],
+    indent: str,
+    *,
+    num: int,
+    subtitle: str,
+    generations: int = 1,
+) -> list[str]:
     """Sum each op's gpu/cpu/calls across every block in a stage, keeping the
     op -> shape hierarchy so the discriminating shapes stay visible.
 
@@ -899,25 +1031,37 @@ def render_perop_aggregate(blocks: list[list[str]], indent: str, *,
     # generation; the raw sum here spans every rep). `calls` stays a run total
     # (the exact launch count); only the time columns are divided.
     div = generations if generations and generations > 0 else 1
-    title = ("PER-OP GPU BREAKDOWN (per generation)" if div > 1
-             else "PER-OP GPU BREAKDOWN (stage total)")
+    title = (
+        "PER-OP GPU BREAKDOWN (per generation)"
+        if div > 1
+        else "PER-OP GPU BREAKDOWN (stage total)"
+    )
     lines = render_section_header(num, title, subtitle, indent)
     tot_gpu = sum(v[1] for v in agg.values())
     tot_cpu = sum(v[2] for v in agg.values())
-    lines.append(indent + f"    {'op / shape':<40}{'calls':>7}{'gpu (ms)':>10}"
-                          f"{'cpu (ms)':>10}{'gpu %':>7}")
+    lines.append(
+        indent + f"    {'op / shape':<40}{'calls':>7}{'gpu (ms)':>10}"
+        f"{'cpu (ms)':>10}{'gpu %':>7}"
+    )
     for name, (calls, gpu, cpu, shapes) in sorted(
-            agg.items(), key=lambda kv: kv[1][1], reverse=True):
+        agg.items(), key=lambda kv: kv[1][1], reverse=True
+    ):
         pct = (100.0 * gpu / tot_gpu) if tot_gpu else 0.0
-        lines.append(indent + f"    {name:<40}{calls:>7}{gpu / div:>10.1f}"
-                              f"{cpu / div:>10.1f}{pct:>6.1f}%")
+        lines.append(
+            indent + f"    {name:<40}{calls:>7}{gpu / div:>10.1f}"
+            f"{cpu / div:>10.1f}{pct:>6.1f}%"
+        )
         for shp, (scalls, sgpu, scpu) in sorted(
-                shapes.items(), key=lambda kv: kv[1][1], reverse=True):
+            shapes.items(), key=lambda kv: kv[1][1], reverse=True
+        ):
             spct = (100.0 * sgpu / tot_gpu) if tot_gpu else 0.0
-            lines.append(indent + f"      {shp:<38}{scalls:>7}{sgpu / div:>10.1f}"
-                                  f"{scpu / div:>10.1f}{spct:>6.1f}%")
-    lines.append(indent + f"    {'TOTAL':<40}{'':>7}"
-                          f"{tot_gpu / div:>10.1f}{tot_cpu / div:>10.1f}")
+            lines.append(
+                indent + f"      {shp:<38}{scalls:>7}{sgpu / div:>10.1f}"
+                f"{scpu / div:>10.1f}{spct:>6.1f}%"
+            )
+    lines.append(
+        indent + f"    {'TOTAL':<40}{'':>7}{tot_gpu / div:>10.1f}{tot_cpu / div:>10.1f}"
+    )
     return lines
 
 
@@ -946,8 +1090,14 @@ def _block_total_gpu(block: list[str]) -> float:
     return 0.0
 
 
-def render_prefill_breakdown(samples: list[ComputeSample], head: OgaHeadline,
-                             charset: str, indent: str, *, num: int) -> list[str]:
+def render_prefill_breakdown(
+    samples: list[ComputeSample],
+    head: OgaHeadline,
+    charset: str,
+    indent: str,
+    *,
+    num: int,
+) -> list[str]:
     """Prefill waterfall: split TTFT's EP work into vision / embedding /
     text-prefill / glue, and give the two big sub-models (vision, text-prefill)
     a § 2-style call stack (marshal -> model.dll compute [GPU op_profile / GPU
@@ -974,28 +1124,39 @@ def render_prefill_breakdown(samples: list[ComputeSample], head: OgaHeadline,
     if not gens:
         return []
 
-    med = {sub: {m: statistics.median([g[sub][m] for g in gens]) for m in metrics}
-           for sub in subs}
+    med = {
+        sub: {m: statistics.median([g[sub][m] for g in gens]) for m in metrics}
+        for sub in subs
+    }
     total = sum(med[sub]["wall"] for sub in subs)
     if total <= 0:
         return []
 
     tc = TREE_CHARS[charset]
     arrow = "<-" if charset == "ascii" else "◀"
-    PIPE, BLANK, BRANCH, LAST = (f"{tc['pipe']} ", "   ",
-                                 f"{tc['branch']} ", f"{tc['last']} ")
+    PIPE, BLANK, BRANCH, LAST = (
+        f"{tc['pipe']} ",
+        "   ",
+        f"{tc['branch']} ",
+        f"{tc['last']} ",
+    )
     lines = render_section_header(
-        num, "PREFILL STAGE BREAKDOWN",
+        num,
+        "PREFILL STAGE BREAKDOWN",
         f"median of {len(gens)} generation(s); EP wall per sub-model + call stack",
-        indent)
-    lines.append(indent + f"    {'':<{LABEL_WIDTH}} {'latency':>10}   {'share':>6}"
-                          f"   source")
+        indent,
+    )
+    lines.append(
+        indent + f"    {'':<{LABEL_WIDTH}} {'latency':>10}   {'share':>6}   source"
+    )
 
     def row(prefix: str, label: str, ms: float, src: str = "") -> str:
         pad = max(1, LABEL_WIDTH - len(prefix) - len(label))
         share = 100.0 * ms / total if total else 0.0
-        return (f"{indent}    {prefix}{label}{' ' * pad} "
-                f"{ms:>7.3f} ms   {share:>5.1f} %   {src}").rstrip()
+        return (
+            f"{indent}    {prefix}{label}{' ' * pad} "
+            f"{ms:>7.3f} ms   {share:>5.1f} %   {src}"
+        ).rstrip()
 
     def callstack(sub: str, is_last: bool) -> list[str]:
         d = med[sub]
@@ -1007,8 +1168,12 @@ def render_prefill_breakdown(samples: list[ComputeSample], head: OgaHeadline,
             row(hook, _SUBLABEL[sub], d["wall"]),
             row(cont + BRANCH, "Marshal in + out", d["mi"] + d["mo"]),
             row(cont + BRANCH, "model.dll compute()", d["cpu"]),
-            row(cont + PIPE + BRANCH, "GPU: OP_PROFILE kernels", d["optot"],
-                f"{arrow} § 5 per-op"),
+            row(
+                cont + PIPE + BRANCH,
+                "GPU: OP_PROFILE kernels",
+                d["optot"],
+                f"{arrow} § 5 per-op",
+            ),
             row(cont + PIPE + BRANCH, "GPU: outside scopes", gpu_outside),
             row(cont + PIPE + LAST, "CPU: host dispatch", cpu_dispatch),
             row(cont + LAST, "Trailing fence", d["fence"]),
@@ -1017,8 +1182,7 @@ def render_prefill_breakdown(samples: list[ComputeSample], head: OgaHeadline,
     lines.append(row("", "EP prefill wall (per generation)", total))
     # Two big sub-models get a call stack (largest wall first); embedding+glue
     # are tiny -> one combined leaf, always last.
-    big = sorted(("vision", "text_prefill"), key=lambda s: med[s]["wall"],
-                 reverse=True)
+    big = sorted(("vision", "text_prefill"), key=lambda s: med[s]["wall"], reverse=True)
     for sub in big:
         lines += callstack(sub, is_last=False)
     eg = med["embedding"]["wall"] + med["glue"]["wall"]
@@ -1027,12 +1191,18 @@ def render_prefill_breakdown(samples: list[ComputeSample], head: OgaHeadline,
     ttft_us = head.prefill.get("avg_us") if (head and head.prefill) else None
     if ttft_us:
         lines.append("")
-        lines.append(indent + f"    reference: CSV TTFT = {ttft_us / 1000.0:.1f} ms "
-                              "(OGA end-to-end prompt latency).")
-        lines.append(indent + "    NOTE: rows sum to EP prefill wall, not TTFT --"
-                              " benchmark_multimodal.py books text")
-        lines.append(indent + "    prefill under its 'sampling' phase, so TTFT's"
-                              " phase split differs from these EP sub-stages.")
+        lines.append(
+            indent + f"    reference: CSV TTFT = {ttft_us / 1000.0:.1f} ms "
+            "(OGA end-to-end prompt latency)."
+        )
+        lines.append(
+            indent + "    NOTE: rows sum to EP prefill wall, not TTFT --"
+            " benchmark_multimodal.py books text"
+        )
+        lines.append(
+            indent + "    prefill under its 'sampling' phase, so TTFT's"
+            " phase split differs from these EP sub-stages."
+        )
     return lines
 
 
@@ -1042,10 +1212,13 @@ _SUBLABEL = {
 }
 
 
-def render_section_3_perop(perop: PerOpTable, indent: str, *,
-                           num: int = 3,
-                           subtitle: str = "last Compute() = steady-state "
-                                           "decode token") -> list[str]:
+def render_section_3_perop(
+    perop: PerOpTable,
+    indent: str,
+    *,
+    num: int = 3,
+    subtitle: str = "last Compute() = steady-state decode token",
+) -> list[str]:
     """PER-OP GPU BREAKDOWN — passes the runtime's own [PERF] table through
     verbatim.
 
@@ -1077,9 +1250,9 @@ def render_section_3_perop(perop: PerOpTable, indent: str, *,
     return lines
 
 
-def render_section_4_distribution(perf: PerfSummary, indent: str, *,
-                                  num: int = 4,
-                                  subtitle: Optional[str] = None) -> list[str]:
+def render_section_4_distribution(
+    perf: PerfSummary, indent: str, *, num: int = 4, subtitle: Optional[str] = None
+) -> list[str]:
     """§ 4 PER-CALL DISTRIBUTION — six metrics × five stats, column-aligned.
 
     Source:        ``PerfSummary.metrics`` -> the ``[PERF SUMMARY]`` block
@@ -1097,21 +1270,24 @@ def render_section_4_distribution(perf: PerfSummary, indent: str, *,
     if not perf:
         return []
     lines = render_section_header(
-        num, "PER-CALL DISTRIBUTION",
-        subtitle if subtitle is not None else
-        f"EP MlirCustomOp::Compute() over {perf.total_inferences} invocations (all ms)",
+        num,
+        "PER-CALL DISTRIBUTION",
+        subtitle
+        if subtitle is not None
+        else f"EP MlirCustomOp::Compute() over {perf.total_inferences} invocations (all ms)",
         indent,
     )
-    lines.append(indent + f"    {'':<18} {'min':>10} {'median':>10}"
-                          f" {'p99':>10} {'max':>12}")
+    lines.append(
+        indent + f"    {'':<18} {'min':>10} {'median':>10} {'p99':>10} {'max':>12}"
+    )
     for name in PerfSummary.METRIC_ORDER:
         stats = perf.metrics.get(name)
         if not stats:
             continue
         lines.append(
             indent + f"    {name:<18} "
-                     f"{stats['min']:>10.3f} {stats['median']:>10.3f}"
-                     f" {stats['p99']:>10.3f} {stats['max']:>12.3f}"
+            f"{stats['min']:>10.3f} {stats['median']:>10.3f}"
+            f" {stats['p99']:>10.3f} {stats['max']:>12.3f}"
         )
     # The two-line note below catches the two most-common "wait, what?" moments
     # readers have when first comparing § 4 against § 1:
@@ -1120,13 +1296,19 @@ def render_section_4_distribution(perf: PerfSummary, indent: str, *,
     #       windows: § 1 reports only OGA's timed iterations, § 4 reports every
     #       EP call including warmup + verbose-mode display generation.
     lines.append(indent + "    notes:")
-    lines.append(indent + "      - `max` includes first-Compute cold start "
-                          "(kernel autotune + pool grow);")
+    lines.append(
+        indent + "      - `max` includes first-Compute cold start "
+        "(kernel autotune + pool grow);"
+    )
     lines.append(indent + "        § 2 uses median to skip those outliers.")
-    lines.append(indent + "      - this count covers ALL EP calls (warmup + "
-                          "verbose-display + timed reps);")
-    lines.append(indent + "        § 1's per-block `samples` column is the "
-                          "OGA-timed subset only.")
+    lines.append(
+        indent + "      - this count covers ALL EP calls (warmup + "
+        "verbose-display + timed reps);"
+    )
+    lines.append(
+        indent + "        § 1's per-block `samples` column is the "
+        "OGA-timed subset only."
+    )
     return lines
 
 
@@ -1170,9 +1352,15 @@ def render_footer(head: OgaHeadline, indent: str) -> list[str]:
 # ─── main ────────────────────────────────────────────────────────────────────
 
 
-def render_report(log_path: Path, *, charset: str = "unicode",
-                  show_banner: bool = True, indent: str = "",
-                  csv_path: Optional[Path] = None, reps: int = 1) -> str:
+def render_report(
+    log_path: Path,
+    *,
+    charset: str = "unicode",
+    show_banner: bool = True,
+    indent: str = "",
+    csv_path: Optional[Path] = None,
+    reps: int = 1,
+) -> str:
     lines = log_path.read_text(errors="replace").splitlines()
 
     head = OgaHeadline.parse(lines)
@@ -1231,30 +1419,42 @@ def render_report(log_path: Path, *, charset: str = "unicode",
     # from its own Computes only.
     if prefill:
         out += render_section_4_distribution(
-            stage_perf(prefill), indent, num=4,
+            stage_perf(prefill),
+            indent,
+            num=4,
             subtitle=f"PREFILL stage -- {len(prefill)} Compute(s) "
-                     "(vision + embedding + text prefill), all ms")
+            "(vision + embedding + text prefill), all ms",
+        )
         out.append("")
         # Prefill spans multiple Computes per generation -> sum per-op across
         # them, then normalize to per-generation so the TOTAL matches § 2.
         n_gen = _count_prefill_generations(samples)
         out += render_perop_aggregate(
-            [s.block for s in prefill if s.block], indent, num=5,
+            [s.block for s in prefill if s.block],
+            indent,
+            num=5,
             generations=n_gen,
             subtitle=f"gpu/cpu per generation (avg over {n_gen} gen(s)); "
-                     f"calls = run total over {len(prefill)} prefill Compute(s)")
+            f"calls = run total over {len(prefill)} prefill Compute(s)",
+        )
         out.append("")
     if decode:
         out += render_section_4_distribution(
-            dec_perf, indent, num=6,
+            dec_perf,
+            indent,
+            num=6,
             subtitle=f"DECODE stage -- {len(decode)} Compute(s) "
-                     "(steady-state tokens), all ms")
+            "(steady-state tokens), all ms",
+        )
         out.append("")
         # Decode is per-token steady state -> show the last (clean) token, not
         # a sum (which would fold in the cold first-token LM-head autotune).
         out += render_section_3_perop(
-            dec_perop, indent, num=7,
-            subtitle="representative = last decode token (steady state)")
+            dec_perop,
+            indent,
+            num=7,
+            subtitle="representative = last decode token (steady state)",
+        )
         out.append("")
 
     if show_banner:
@@ -1272,21 +1472,38 @@ def main(argv: Optional[list[str]] = None) -> int:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     p.add_argument("log", type=Path, help="Path to a HIPDNN EP / OGA bench log")
-    p.add_argument("csv", type=Path, nargs="?", default=None,
-                   help="Optional benchmark_multimodal.py CSV. When the log has "
-                        "no model_benchmark stats block (e.g. multimodal Python "
-                        "runs), the headline (§ 1 TTFT/TPS), § 2 OGA/ORT flow "
-                        "overhead, and footer are synthesized from this CSV.")
-    p.add_argument("--reps", type=int, default=1,
-                   help="Repetitions used in the bench (matches "
-                        "benchmark_multimodal.py -r); only labels the CSV-derived "
-                        "`samples` column (default: 1)")
-    p.add_argument("--ascii", action="store_true",
-                   help="Use ASCII tree chars instead of Unicode box-drawing")
-    p.add_argument("--no-banner", action="store_true",
-                   help="Omit the top/bottom identity banner")
-    p.add_argument("--indent", type=int, default=0,
-                   help="Indent every output line by N spaces (default: 0)")
+    p.add_argument(
+        "csv",
+        type=Path,
+        nargs="?",
+        default=None,
+        help="Optional benchmark_multimodal.py CSV. When the log has "
+        "no model_benchmark stats block (e.g. multimodal Python "
+        "runs), the headline (§ 1 TTFT/TPS), § 2 OGA/ORT flow "
+        "overhead, and footer are synthesized from this CSV.",
+    )
+    p.add_argument(
+        "--reps",
+        type=int,
+        default=1,
+        help="Repetitions used in the bench (matches "
+        "benchmark_multimodal.py -r); only labels the CSV-derived "
+        "`samples` column (default: 1)",
+    )
+    p.add_argument(
+        "--ascii",
+        action="store_true",
+        help="Use ASCII tree chars instead of Unicode box-drawing",
+    )
+    p.add_argument(
+        "--no-banner", action="store_true", help="Omit the top/bottom identity banner"
+    )
+    p.add_argument(
+        "--indent",
+        type=int,
+        default=0,
+        help="Indent every output line by N spaces (default: 0)",
+    )
     args = p.parse_args(argv)
 
     if not args.log.is_file():
@@ -1305,8 +1522,10 @@ def main(argv: Optional[list[str]] = None) -> int:
         reps=args.reps,
     )
     if not report:
-        print(f"warning: log has no parseable EP perf streams: {args.log}",
-              file=sys.stderr)
+        print(
+            f"warning: log has no parseable EP perf streams: {args.log}",
+            file=sys.stderr,
+        )
         return 2
     print(report)
     return 0

--- a/tools/perf-report/mm_csv_stats.py
+++ b/tools/perf-report/mm_csv_stats.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
 """Compute TTFT / TPS (and profiling overhead) from benchmark_multimodal.py CSVs.
 
 The Python OGA multimodal bench writes a one-row CSV of averaged metrics.
@@ -14,6 +18,7 @@ Prefill TPS is derived (prompt_tokens / TTFT_seconds); everything else is read
 straight from the CSV columns. When two CSVs are given, the LAST is treated as
 the baseline and the deltas are reported relative to it.
 """
+
 import csv
 import sys
 from pathlib import Path
@@ -51,11 +56,19 @@ def load(path: Path) -> dict:
 def fmt(label: str, m: dict) -> None:
     print(f"== {label} ==")
     print(f"  prompt / gen tokens : {m['prompt_tokens']} / {m['gen_tokens']}")
-    print(f"  TTFT                : {m['ttft_ms']:.1f} ms  ({m['ttft_ms']/1000:.2f} s)")
-    print(f"  Prefill TPS         : {m['prefill_tps']:.2f} tok/s  (derived prompt/TTFT)")
-    print(f"  Decode  TPS         : {m['decode_tps']:.2f} tok/s  ({m['decode_ms']:.2f} ms/tok)")
+    print(
+        f"  TTFT                : {m['ttft_ms']:.1f} ms  ({m['ttft_ms'] / 1000:.2f} s)"
+    )
+    print(
+        f"  Prefill TPS         : {m['prefill_tps']:.2f} tok/s  (derived prompt/TTFT)"
+    )
+    print(
+        f"  Decode  TPS         : {m['decode_tps']:.2f} tok/s  ({m['decode_ms']:.2f} ms/tok)"
+    )
     print(f"  Sampling            : {m['sampling_ms']:.3f} ms/tok")
-    print(f"  Wall-clock TPS      : {m['wall_tps']:.2f} tok/s  (E2E {m['wall_s']:.2f} s)")
+    print(
+        f"  Wall-clock TPS      : {m['wall_tps']:.2f} tok/s  (E2E {m['wall_s']:.2f} s)"
+    )
     print(f"  Peak working set    : {m['peak_gib']:.2f} GiB")
 
 
@@ -68,11 +81,21 @@ def pct(new: float, base: float) -> str:
 def compare(prof_lbl, prof, base_lbl, base) -> None:
     print(f"== overhead: {prof_lbl} vs {base_lbl} (baseline) ==")
     rows = [
-        ("Decode latency (ms/tok)", prof["decode_ms"], base["decode_ms"], "lower=better"),
-        ("Decode TPS (tok/s)",      prof["decode_tps"], base["decode_tps"], "higher=better"),
-        ("TTFT (ms)",               prof["ttft_ms"],    base["ttft_ms"],    "lower=better"),
-        ("Prefill TPS (tok/s)",     prof["prefill_tps"],base["prefill_tps"],"higher=better"),
-        ("E2E wall (s)",            prof["wall_s"],     base["wall_s"],     "lower=better"),
+        (
+            "Decode latency (ms/tok)",
+            prof["decode_ms"],
+            base["decode_ms"],
+            "lower=better",
+        ),
+        ("Decode TPS (tok/s)", prof["decode_tps"], base["decode_tps"], "higher=better"),
+        ("TTFT (ms)", prof["ttft_ms"], base["ttft_ms"], "lower=better"),
+        (
+            "Prefill TPS (tok/s)",
+            prof["prefill_tps"],
+            base["prefill_tps"],
+            "higher=better",
+        ),
+        ("E2E wall (s)", prof["wall_s"], base["wall_s"], "lower=better"),
     ]
     w = max(len(r[0]) for r in rows)
     print(f"  {'metric':<{w}}  {prof_lbl:>12}  {base_lbl:>12}  {'delta':>10}  {'%':>8}")

--- a/tools/perf-report/oga_mm_smoketest.py
+++ b/tools/perf-report/oga_mm_smoketest.py
@@ -1,3 +1,7 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
 """Smoke-test wrapper for benchmark_multimodal.py against the user's locally
 built OGA (0.13.0.dev0 / ORT 1.26.0 / MorphiZenEP plugin).
 
@@ -53,6 +57,7 @@ Then:
 not benchmark_multimodal.py's output -- so manual grep is the path for
 multimodal until/unless the formatter is extended.)
 """
+
 import ctypes
 import os
 import sys
@@ -73,14 +78,22 @@ BENCHMARK = r"C:\Users\Administrator\workspace\onnx-hipdnn-ep\install\oga-source
 # Default benchmark args -- overridden by anything passed on the CLI
 # ---------------------------------------------------------------------------
 DEFAULT_ARGV = [
-    "-i", r"C:\Users\Administrator\Downloads\Qwen3.5-9B-rtn-int4-int8-128gs-fp16-onnx-gpu",
-    "--image_path", r"C:\Users\Administrator\workspace\onnx-hipdnn-ep\test\python\images\tower.jpg",
-    "-g", "64",
-    "-m", "2048",
-    "-r", "10",
-    "-w", "1",
-    "-k", "1",
-    "-p", "1.0",
+    "-i",
+    r"C:\Users\Administrator\Downloads\Qwen3.5-9B-rtn-int4-int8-128gs-fp16-onnx-gpu",
+    "--image_path",
+    r"C:\Users\Administrator\workspace\onnx-hipdnn-ep\test\python\images\tower.jpg",
+    "-g",
+    "64",
+    "-m",
+    "2048",
+    "-r",
+    "10",
+    "-w",
+    "1",
+    "-k",
+    "1",
+    "-p",
+    "1.0",
     "-v",
     "-mo",
 ]
@@ -91,8 +104,11 @@ DEFAULT_ARGV = [
 os.environ.setdefault("THEROCK_DIST", THEROCK_DIST)
 os.environ.setdefault("HIP_CUSTOM_KERNELS_DIR", PREBUILT_LIB)
 os.environ.setdefault("HIPDNN_EP_PERF", "1")
-print(f"[wrap] HIPDNN_EP_PERF={os.environ['HIPDNN_EP_PERF']}  "
-      f"THEROCK_DIST={os.environ['THEROCK_DIST']}", flush=True)
+print(
+    f"[wrap] HIPDNN_EP_PERF={os.environ['HIPDNN_EP_PERF']}  "
+    f"THEROCK_DIST={os.environ['THEROCK_DIST']}",
+    flush=True,
+)
 
 # ---------------------------------------------------------------------------
 # DLL search-path setup (+ PATH for any indirect lookups)
@@ -108,7 +124,9 @@ for d in (THEROCK_BIN, PREBUILT_BIN, ORT_126_DIR, OGA_DIR, os.path.dirname(DML_D
 ctypes.CDLL(DML_DLL)
 ctypes.CDLL(os.path.join(ORT_126_DIR, "onnxruntime_providers_shared.dll"))
 ort = ctypes.CDLL(os.path.join(ORT_126_DIR, "onnxruntime.dll"))
-print(f"[wrap] Pre-loaded ORT 1.26 onnxruntime.dll handle: {ort._handle:#x}", flush=True)
+print(
+    f"[wrap] Pre-loaded ORT 1.26 onnxruntime.dll handle: {ort._handle:#x}", flush=True
+)
 
 os.chdir(PREBUILT_BIN)
 print(f"[wrap] cwd -> {os.getcwd()}", flush=True)
@@ -137,8 +155,7 @@ def _last_value(args, *flags):
 if not any(a in ("-o", "--output") for a in user_args):
     img = _last_value(argv, "--image_path", "-im") or "run"
     stem = os.path.splitext(os.path.basename(img))[0]
-    csv_out = os.path.join(
-        r"C:\Users\Administrator\workspace\build", f"{stem}_mm.csv")
+    csv_out = os.path.join(r"C:\Users\Administrator\workspace\build", f"{stem}_mm.csv")
     argv += ["-o", csv_out]
     print(f"[wrap] CSV output -> {csv_out}", flush=True)
 
@@ -150,9 +167,12 @@ with open(BENCHMARK) as f:
 exec(code, {"__name__": "__main__", "__file__": BENCHMARK})
 
 print("", flush=True)
-print("[wrap] DONE. With HIPDNN_EP_PERF=1, look in your captured log for:",
-      flush=True)
-print("[wrap]   [PERF SUMMARY]        -- per-Compute aggregates (process exit)",
-      flush=True)
-print("[wrap]   [PERF] === ... ===    -- per-op GPU/CPU table (one per Compute())",
-      flush=True)
+print("[wrap] DONE. With HIPDNN_EP_PERF=1, look in your captured log for:", flush=True)
+print(
+    "[wrap]   [PERF SUMMARY]        -- per-Compute aggregates (process exit)",
+    flush=True,
+)
+print(
+    "[wrap]   [PERF] === ... ===    -- per-op GPU/CPU table (one per Compute())",
+    flush=True,
+)

--- a/tools/perf-report/run_bench.sh
+++ b/tools/perf-report/run_bench.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+##
+## Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+## Licensed under the MIT License.
+##
+
 # Linux bench driver for the MorphiZen EP. Benchmarks an ONNX model from
 # <workspace>/oga_models/<dir> using one of two host tools, captures the
 # full stderr+stdout to a log under <script-dir>/_perf_logs/, and pipes


### PR DESCRIPTION
## Summary

Fixes a **general** runtime bottleneck in `memrefCopy` (the helper for any MLIR `memref.copy` — emitted by Concat/Slice/Tile/insert_slice bufferization in any model). The non-contiguous, multi-outer-dim path was issuing **one `hipMemcpyAsync` per row** on the default stream, which for the Qwen3.5 vision encoder is ~2.07M tiny 72-byte launches per prefill and dominated GPU prefill time.

- **`hip_strided_copy`**: a single parallel strided-copy kernel replaces the host per-row loop. General — handles arbitrary rank/strides and element sizes 1/2/4/8 bytes; the host per-row loop remains only as a correctness fallback for other element sizes.
- `memrefCopy` is moved off the default stream (0) onto the session stream (a thread-local published per Compute in `hipdnn_ep_runtime_begin_compute`), removing default-stream serialization.

No new env vars, no model-specific code.

## Measured results (vision on MorphiZenEP)

| image | TTFT before | TTFT after | vision prefill span |
|-------|-------------|------------|---------------------|
| tower | 18,942 ms | **6,042 ms** (-68%) | 15,087 -> 2,217 ms (-85%) |
| dog   | 106,735 ms | **39,143 ms** (-63%) | 95,448 -> 28,542 ms (-70%) |

Honest env0 (profiling OFF) tower TTFT with GPU vision + fix: **5,822 ms**, on par with the 5.5s CPU-vision path (was ~18.9s). After the fix vision is compute-bound, and generated text is **bit-identical** before/after on both images (greedy decode unchanged).

## Files
6 files: `hip_strided_copy` kernel (`strided_copy_kernel.hip` + decl + CMake), `memrefCopy` stream routing + kernel call (`real/hip.cpp`), and the session-stream getter/publish (`hipdnn_ep_runtime.h` + `hipdnn_ep_runtime_state.cpp`).

## Test plan
- [ ] Build EP (RelWithDebInfo, gfx1151), clear `%TEMP%\morphizen_mlir_*`.
- [ ] `oga_mm_smoketest.py` on tower + dog, vision provider = MorphiZenEP; confirm TTFT drop via `format_perf_report.py` (`§ 2` wall).
- [ ] Verify generated text matches the CPU-vision baseline (numeric correctness of the strided copy).
- [ ] Sanity: decode + text-only path unaffected.
