### PR TITLE
perf(causal_conv): fused custom prefill kernel -- TTFT -43%, text-identical

### DIFF
--- a/3rd-party/custom_kernels/hip/causal_conv_step_kernel.hip
+++ b/3rd-party/custom_kernels/hip/causal_conv_step_kernel.hip
@@ -197,6 +197,145 @@ hipError_t launch_for_K(
 #undef DISPATCH_K_BIAS_ACT
 }
 
+// Prefill (seq_len > 1) fused causal depthwise 1D conv + bias + SiLU.
+// One thread per (b, c) plane slides a length-K window over the virtual
+// sequence [past_state[0..K-2], input[0..L-1]], writing L outputs and the
+// trailing K-1 present_state. fp32 accumulate -- numerically matches
+// causal_conv_step_kernel at L=1. Replaces the MIOpen prefill path (Find +
+// 3 pitched memcpys + conv + bias + activation + mul) with a single launch.
+// Layout matches wrap_causal_conv_with_state:
+//   input, output            flat [(b*C + c)*L + t]
+//   past_state, present_state flat [(b*C + c)*(K-1) + j]
+//   weight                    flat [c*K + j];   bias flat [c]
+template <typename T, int K, int HAS_BIAS, int ACT_SILU>
+__global__ void causal_conv_prefill_kernel(
+    const T* __restrict__ input,
+    const T* __restrict__ weight,
+    const T* __restrict__ bias,
+    const T* __restrict__ past_state,
+    T* __restrict__ output,
+    T* __restrict__ present_state,
+    int batch_size,
+    int channels,
+    int seq_len) {
+
+    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    const int total = batch_size * channels;
+    if (idx >= total)
+        return;
+
+    const int c = idx % channels;
+    constexpr int STATE_LEN = K - 1;
+
+    // Per-channel weights (K taps) and optional bias.
+    float w[K];
+    {
+        const T* wp = weight + static_cast<int64_t>(c) * K;
+        #pragma unroll
+        for (int j = 0; j < K; ++j)
+            w[j] = to_f32<T>(wp[j]);
+    }
+    const float bias_v = HAS_BIAS ? to_f32<T>(bias[c]) : 0.0f;
+
+    // window[0..K-1] holds virtual[t .. t+K-1] for the current output t.
+    // Init for t=0: [past_state[0..K-2], input[0]].
+    float window[K];
+    {
+        const T* ps = (STATE_LEN > 0 && past_state != nullptr)
+                          ? past_state + static_cast<int64_t>(idx) * STATE_LEN
+                          : nullptr;
+        #pragma unroll
+        for (int j = 0; j < STATE_LEN; ++j)
+            window[j] = ps ? to_f32<T>(ps[j]) : 0.0f;
+    }
+    const T* in_row = input + static_cast<int64_t>(idx) * seq_len;
+    T* out_row = output + static_cast<int64_t>(idx) * seq_len;
+    window[K - 1] = to_f32<T>(in_row[0]);
+
+    for (int t = 0; t < seq_len; ++t) {
+        if (t > 0) {
+            // Slide the window: drop oldest, append virtual[t+K-1] = input[t].
+            #pragma unroll
+            for (int j = 0; j < K - 1; ++j)
+                window[j] = window[j + 1];
+            window[K - 1] = to_f32<T>(in_row[t]);
+        }
+        float y = 0.0f;
+        #pragma unroll
+        for (int j = 0; j < K; ++j)
+            y += w[j] * window[j];
+        if (HAS_BIAS)
+            y += bias_v;
+        if (ACT_SILU) {
+            const float s = 1.0f / (1.0f + expf(-y));
+            y *= s;
+        }
+        out_row[t] = from_f32<T>(y);
+    }
+
+    // present_state = last K-1 of virtual = window[1..K-1] after the last step.
+    if (STATE_LEN > 0) {
+        T* nps = present_state + static_cast<int64_t>(idx) * STATE_LEN;
+        #pragma unroll
+        for (int j = 0; j < STATE_LEN; ++j)
+            nps[j] = from_f32<T>(window[j + 1]);
+    }
+}
+
+template <typename T>
+hipError_t launch_prefill_for_K(
+    int K, hipStream_t stream,
+    const T* input, const T* weight, const T* bias, const T* past_state,
+    T* output, T* present_state,
+    int batch_size, int channels, int seq_len, int has_bias, int act_silu) {
+
+    const int total = batch_size * channels;
+    const int block = 256;
+    const int grid = (total + block - 1) / block;
+
+    auto launch = [&](auto k_const, auto bias_const, auto act_const) {
+        constexpr int Kc = decltype(k_const)::value;
+        constexpr int Bc = decltype(bias_const)::value;
+        constexpr int Ac = decltype(act_const)::value;
+        hipLaunchKernelGGL(
+            (causal_conv_prefill_kernel<T, Kc, Bc, Ac>),
+            dim3(grid), dim3(block), 0, stream,
+            input, weight, bias, past_state, output, present_state,
+            batch_size, channels, seq_len);
+        return hipGetLastError();
+    };
+
+#define DISPATCH_PREFILL_K(KVAL)                                              \
+    case KVAL: {                                                              \
+        using K_t = std::integral_constant<int, KVAL>;                        \
+        if (has_bias && act_silu)                                             \
+            return launch(K_t{}, std::integral_constant<int, 1>{},            \
+                          std::integral_constant<int, 1>{});                  \
+        if (has_bias)                                                         \
+            return launch(K_t{}, std::integral_constant<int, 1>{},            \
+                          std::integral_constant<int, 0>{});                  \
+        if (act_silu)                                                         \
+            return launch(K_t{}, std::integral_constant<int, 0>{},            \
+                          std::integral_constant<int, 1>{});                  \
+        return launch(K_t{}, std::integral_constant<int, 0>{},                \
+                      std::integral_constant<int, 0>{});                      \
+    }
+
+    switch (K) {
+        DISPATCH_PREFILL_K(1)
+        DISPATCH_PREFILL_K(2)
+        DISPATCH_PREFILL_K(3)
+        DISPATCH_PREFILL_K(4)
+        DISPATCH_PREFILL_K(5)
+        DISPATCH_PREFILL_K(6)
+        DISPATCH_PREFILL_K(7)
+        DISPATCH_PREFILL_K(8)
+        default:
+            return hipErrorInvalidValue;
+    }
+#undef DISPATCH_PREFILL_K
+}
+
 } // namespace
 
 extern "C" int hip_causal_conv_step_decode(
@@ -282,6 +421,96 @@ extern "C" int hip_causal_conv_step_decode(
         fprintf(stderr,
                 "[custom_kernels] hip_causal_conv_step_decode: launch failed "
                 "(%s)\n",
+                hipGetErrorString(err));
+        return static_cast<int>(err);
+    }
+    return 0;
+}
+
+extern "C" int hip_causal_conv_prefill(
+    void* stream,
+    const void* input,
+    const void* weight,
+    const void* bias,
+    const void* past_state,
+    void* output,
+    void* present_state,
+    int64_t batch_size,
+    int64_t channels,
+    int64_t seq_len,
+    int64_t kernel_size,
+    int64_t activation,
+    int64_t element_size_bytes) {
+
+    if (!input || !weight || !output || !present_state) {
+        fprintf(stderr,
+                "[custom_kernels] hip_causal_conv_prefill: null required "
+                "pointer (input=%p weight=%p output=%p present_state=%p)\n",
+                input, weight, output, present_state);
+        return -1;
+    }
+    if (batch_size <= 0 || channels <= 0 || seq_len <= 0) {
+        fprintf(stderr,
+                "[custom_kernels] hip_causal_conv_prefill: invalid "
+                "batch=%lld channels=%lld seq_len=%lld\n",
+                (long long)batch_size, (long long)channels, (long long)seq_len);
+        return -1;
+    }
+    if (kernel_size < 1 || kernel_size > 8) {
+        fprintf(stderr,
+                "[custom_kernels] hip_causal_conv_prefill: kernel_size=%lld "
+                "outside supported range [1,8]\n",
+                (long long)kernel_size);
+        return -1;
+    }
+    if (activation != 0 && activation != 1) {
+        fprintf(stderr,
+                "[custom_kernels] hip_causal_conv_prefill: unsupported "
+                "activation=%lld (0=none, 1=SiLU)\n",
+                (long long)activation);
+        return -1;
+    }
+
+    hipStream_t s = static_cast<hipStream_t>(stream);
+    const int K = static_cast<int>(kernel_size);
+    const int B = static_cast<int>(batch_size);
+    const int C = static_cast<int>(channels);
+    const int L = static_cast<int>(seq_len);
+    const int has_bias = bias ? 1 : 0;
+    const int act_silu = (activation == 1) ? 1 : 0;
+
+    hipError_t err;
+    if (element_size_bytes == 4) {
+        err = launch_prefill_for_K<float>(
+            K, s,
+            static_cast<const float*>(input),
+            static_cast<const float*>(weight),
+            static_cast<const float*>(bias),
+            static_cast<const float*>(past_state),
+            static_cast<float*>(output),
+            static_cast<float*>(present_state),
+            B, C, L, has_bias, act_silu);
+    } else if (element_size_bytes == 2) {
+        err = launch_prefill_for_K<__half>(
+            K, s,
+            static_cast<const __half*>(input),
+            static_cast<const __half*>(weight),
+            static_cast<const __half*>(bias),
+            static_cast<const __half*>(past_state),
+            static_cast<__half*>(output),
+            static_cast<__half*>(present_state),
+            B, C, L, has_bias, act_silu);
+    } else {
+        fprintf(stderr,
+                "[custom_kernels] hip_causal_conv_prefill: unsupported "
+                "element_size_bytes=%lld (expect 2 or 4)\n",
+                (long long)element_size_bytes);
+        return -1;
+    }
+
+    if (err != hipSuccess) {
+        fprintf(stderr,
+                "[custom_kernels] hip_causal_conv_prefill: launch failed (%s)\n",
                 hipGetErrorString(err));
         return static_cast<int>(err);
     }

--- a/3rd-party/custom_kernels/include/hip_custom_kernels.h
+++ b/3rd-party/custom_kernels/include/hip_custom_kernels.h
@@ -1320,6 +1320,27 @@ int hip_causal_conv_step_decode(
     int64_t activation,
     int64_t element_size_bytes);
 
+// Prefill (seq_len > 1) fused causal depthwise 1D conv + bias + SiLU. One
+// launch replaces the MIOpen path (Find + 3 pitched memcpys + conv + bias +
+// activation + mul). fp32 accumulate; numerically matches the decode-step
+// kernel at seq_len==1. Same layout/contract as hip_causal_conv_step_decode
+// plus a seq_len argument. Supports kernel_size in [1,8], activation 0/1,
+// element_size 2/4; caller falls back to MIOpen for anything else.
+int hip_causal_conv_prefill(
+    void* stream,
+    const void* input,
+    const void* weight,
+    const void* bias,
+    const void* past_state,
+    void* output,
+    void* present_state,
+    int64_t batch_size,
+    int64_t channels,
+    int64_t seq_len,
+    int64_t kernel_size,
+    int64_t activation,
+    int64_t element_size_bytes);
+
 /* =========================================================================
  * WMMA GEMM (Small-M Matrix Multiply via Wave Matrix Multiply-Accumulate)
  * =========================================================================

--- a/lib/Runtime/real/causal_conv_with_state.cpp
+++ b/lib/Runtime/real/causal_conv_with_state.cpp
@@ -295,6 +295,31 @@ int wrap_causal_conv_with_state(
     return 0;
   }
 
+  // ---- Fast path: prefill (seq_len>1) via a single fused custom kernel ----
+  // Replaces the MIOpen path (Find + 3 pitched D2D memcpys to build the
+  // virtual buffer + conv + bias optensor + activation + mul) -- the single
+  // largest text-prefill op -- with one launch. Same supported envelope as
+  // the decode fast path (k in [1,8], activation none/SiLU, fp16/fp32);
+  // anything else falls through to MIOpen below.
+  if (seq_len > 1 && kernel_size >= 1 && kernel_size <= 8 &&
+      (activation == 0 || activation == 1) &&
+      (element_size_bytes == 2 || element_size_bytes == 4)) {
+    int rc =
+        hip_causal_conv_prefill(stream, input, weight, bias, past_state, output,
+                                present_state, batch_size, channels, seq_len,
+                                kernel_size, activation, element_size_bytes);
+    if (rc != 0) {
+      fprintf(stderr,
+              "wrap_causal_conv_with_state: hip_causal_conv_prefill failed "
+              "(%d)\n",
+              rc);
+      return -1;
+    }
+    RUNTIME_DEBUG_LOG(
+        "[REAL] wrap_causal_conv_with_state: completed via fast prefill\n");
+    return 0;
+  }
+
   const int64_t state_len = kernel_size - 1; // k-1
   const int64_t virtual_len = state_len + seq_len;
   const int64_t bc_rows = batch_size * channels;

--- a/test/numeric/tests/test_causal_conv_with_state.py
+++ b/test/numeric/tests/test_causal_conv_with_state.py
@@ -43,6 +43,12 @@ CHUNK_OPT_CHANNELS = 8192
 CHUNK_OPT_K = 4  # kernel size; carry state size = K - 1 = 3
 
 
+_NP_TO_TP = {
+    np.float16: TensorProto.FLOAT16,
+    np.float32: TensorProto.FLOAT,
+}
+
+
 def _make_causal_conv_with_state_model(
     batch: int,
     channels: int,
@@ -50,11 +56,15 @@ def _make_causal_conv_with_state_model(
     kernel_size: int,
     activation: str = "silu",
     with_bias: bool = True,
+    dtype: np.dtype = np.float16,
 ):
     """Build a 1D CausalConvWithState ONNX model with weight/bias as
     initializers and runtime inputs for the data tensor and carry state.
+
+    `dtype` defaults to fp16 (the chunk_opt footprint); pass np.float32 to
+    exercise the kernel's f32 path.
     """
-    tp = TensorProto.FLOAT16
+    tp = _NP_TO_TP[dtype]
     state_len = kernel_size - 1
 
     X = helper.make_tensor_value_info("input", tp, [batch, channels, seq_len])
@@ -69,11 +79,11 @@ def _make_causal_conv_with_state_model(
     # Weight / bias are realistic small magnitudes; keeping them tight
     # avoids fp16 overflow in long-S prefill cases when SiLU saturates.
     rng = np.random.default_rng(0xC0DE)
-    weight = (rng.standard_normal((channels, 1, kernel_size)) * 0.1).astype(np.float16)
+    weight = (rng.standard_normal((channels, 1, kernel_size)) * 0.1).astype(dtype)
     initializers = [numpy_helper.from_array(weight, name="weight")]
     inputs_w = ["input", "weight"]
     if with_bias:
-        bias = (rng.standard_normal((channels,)) * 0.05).astype(np.float16)
+        bias = (rng.standard_normal((channels,)) * 0.05).astype(dtype)
         initializers.append(numpy_helper.from_array(bias, name="bias"))
         inputs_w.append("bias")
     else:
@@ -147,6 +157,36 @@ class TestCausalConvWithState:
         actual, expected = model_runner.run_sample(model, [x, state])
         # Two outputs: depthwise fp16 conv; tight tolerance is fine.
         compare_outputs(actual, expected, atol=2e-3, rtol=1e-2)
+
+    @pytest.mark.parametrize("dtype", [np.float16, np.float32])
+    @pytest.mark.parametrize("with_bias", [True, False])
+    def test_ccws_prefill_dtype_bias(self, model_runner, dtype, with_bias):
+        """Prefill (seq_len>1) across the fused kernel's dtype and bias
+        branches: f32 in addition to fp16, and the no-bias (HAS_BIAS=0) path
+        that the chunk_opt footprint (always-bias) never exercises.
+        """
+        batch, channels, seq_len, kernel_size = 1, 32, 128, 4
+        model = _make_causal_conv_with_state_model(
+            batch,
+            channels,
+            seq_len,
+            kernel_size,
+            activation="silu",
+            with_bias=with_bias,
+            dtype=dtype,
+        )
+
+        rng = np.random.default_rng(3)
+        x = (rng.standard_normal((batch, channels, seq_len)) * 0.5).astype(dtype)
+        state = (rng.standard_normal((batch, channels, kernel_size - 1)) * 0.5).astype(
+            dtype
+        )
+
+        actual, expected = model_runner.run_sample(model, [x, state])
+        if dtype == np.float32:
+            compare_outputs(actual, expected, atol=1e-4, rtol=1e-4)
+        else:
+            compare_outputs(actual, expected, atol=2e-3, rtol=1e-2)
 
     @pytest.mark.parametrize("seq_len", SEQ_LENS)
     def test_ccws_chunk_opt_shape(self, model_runner, seq_len):


### PR DESCRIPTION
## Summary
Replaces the Mamba `causal_conv` **prefill** path (the single largest text-prefill op) with a single fused custom kernel `hip_causal_conv_prefill`.

The MIOpen path built a virtual buffer via 3 pitched D2D memcpys, ran a first-call `miopenFindConvolutionForwardAlgorithm`, then conv + bias optensor + activation + mul. The new kernel: one thread per (b,c) plane slides a length-K window over `virtual=[past_state, input]`, computing all `seq_len` outputs + `present_state` in **one launch**, fp32 accumulate. It is numerically identical to the existing decode-step kernel at `seq_len==1`. `wrap_causal_conv_with_state` routes `seq_len>1` (k in [1,8], act none/SiLU, fp16/fp32) to it; everything else falls back to MIOpen.

## Measured (tower gs128, vision on MorphiZen, PERF=1)
- Generated text **bit-identical** to the MIOpen baseline (full 64-token greedy output).
- `causal_conv` per block: **~1701 ms warm / ~9493 ms cold (MIOpen Find) -> ~7 ms**.
- **E2E TTFT: 5990 ms -> 3409 ms (-43%).**

## Test plan
- [ ] Build (RelWithDebInfo, gfx1151), clear `%TEMP%\morphizen_mlir_*`.
- [ ] tower + dog multimodal (vision on MorphiZen): generated text matches MIOpen baseline; TTFT drops; `causal_conv` op time collapses.
- [ ] Decode (seq_len==1) path unchanged (still uses the existing decode-step kernel).

Base: stacked on `perf/prefill-stall-removal` (memrefCopy PR #300); rebase onto `main`/`pr259_with_perf` once that merges.
