### PR TITLE
fix(gather): match wrap_gather 11-arg ABI (axis_size, inner_size)

### DIFF
--- a/lib/Conversion/HipToLLVM/GatherLowering.cpp
+++ b/lib/Conversion/HipToLLVM/GatherLowering.cpp
@@ -52,16 +52,34 @@ struct GatherOpLowering : public ConvertOpToLLVMPattern<GatherOp> {
         rewriter, loc, i64Type, rewriter.getI64IntegerAttr(elementSizeBytes));
 
     // axis attribute
+    int64_t axisAttr = op.getAxis();
     Value axisVal = LLVM::ConstantOp::create(
-        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getAxis()));
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(axisAttr));
+
+    // axis_size = data.shape[axis]; inner_size = product(data.shape[axis+1:]).
+    int64_t dataRank = dataType.getRank();
+    if (axisAttr < 0)
+      axisAttr += dataRank;
+    Value axisSizeVal =
+        getMemRefDimSize(dataType, static_cast<unsigned>(axisAttr),
+                         adaptor.getData(), rewriter, loc);
+    Value innerSizeVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(1));
+    for (int64_t d : llvm::seq<int64_t>(axisAttr + 1, dataRank)) {
+      Value ds = getMemRefDimSize(dataType, static_cast<unsigned>(d),
+                                  adaptor.getData(), rewriter, loc);
+      innerSizeVal = LLVM::MulOp::create(rewriter, loc, innerSizeVal, ds);
+    }
 
     // int wrap_gather(RuntimeState* state, void* data, void* indices,
     //                 void* output, int64_t axis, int64_t data_num_elements,
     //                 int64_t indices_num_elements,
-    //                 int64_t output_num_elements, int64_t element_size_bytes)
-    SmallVector<Type, 9> paramTypes = {ptrType, ptrType, ptrType,
-                                       ptrType, i64Type, i64Type,
-                                       i64Type, i64Type, i64Type};
+    //                 int64_t output_num_elements,
+    //                 int64_t axis_size, int64_t inner_size,
+    //                 int64_t element_size_bytes)
+    SmallVector<Type, 11> paramTypes = {ptrType, ptrType, ptrType, ptrType,
+                                        i64Type, i64Type, i64Type, i64Type,
+                                        i64Type, i64Type, i64Type};
 
     FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
         rewriter, module, kWrapGather, paramTypes, i32Type);
@@ -76,6 +94,8 @@ struct GatherOpLowering : public ConvertOpToLLVMPattern<GatherOp> {
                                dataNumElementsVal,
                                indicesNumElementsVal,
                                outputNumElementsVal,
+                               axisSizeVal,
+                               innerSizeVal,
                                elemSizeVal};
 
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);

--- a/test/lit/Conversion/hip-to-llvm/test_gather.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_gather.mlir
@@ -47,14 +47,15 @@ module {
   }
 }
 
-// All three variants lower to the same 9-parameter wrap_gather call:
-// 4 pointers (state, data, indices, output) + 5 i64 (axis, data_num, indices_num, output_num, elem_size)
+// All three variants lower to the same 11-parameter wrap_gather call:
+// 4 pointers (state, data, indices, output) + 7 i64 (axis, data_num,
+// indices_num, output_num, axis_size, inner_size, elem_size)
 
 // CHECK-LABEL: llvm.func @test_gather_multi_index
-// CHECK: llvm.call @wrap_gather({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64) -> i32
+// CHECK: llvm.call @wrap_gather({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64) -> i32
 
 // CHECK-LABEL: llvm.func @test_gather_scalar_index
-// CHECK: llvm.call @wrap_gather({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64) -> i32
+// CHECK: llvm.call @wrap_gather({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64) -> i32
 
 // CHECK-LABEL: llvm.func @test_gather_embedding
-// CHECK: llvm.call @wrap_gather({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64) -> i32
+// CHECK: llvm.call @wrap_gather({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64) -> i32


### PR DESCRIPTION
## Summary

Lowering-half of the #284 ABI train (**Gather slice**). #284's runtime ships `wrap_gather` with two new params -- `axis_size` (`data.shape[axis]`) and `inner_size` (`product(data.shape[axis+1:])`) -- so the gather kernel can map a flat index to the correct slice without re-deriving layout. main's `GatherLowering` still emitted the old **9-arg** call: a latent ABI mismatch that only manifests on Gather-heavy graphs (embedding lookups).

`GatherLowering` now computes both values from the `data` memref (static dims as constants, dynamic via the descriptor) and emits the **11-arg** call matching the runtime. No op-def or conversion change is needed -- both values derive from the existing `data` operand.

> Stacked on #284 (`feat/runtime-custom-kernels-split`). This is the Gather-only, self-contained slice of the original PR-3. NonZero / ScatterND (which need `count_buf` / `valid_count` op-def changes + reify-infra surgery) follow as a separate train PR.

## Test plan

- [x] Incremental rebuild + install (`build-hipdnn-ep.bat --rebuild-only`) -- green
- [x] `ctest -R MorphizenMLIRLitTests` -- 100% pass
- [x] `hip-to-llvm/test_gather.mlir` updated to the 11-param signature; FileCheck pass
- [x] pre-commit -- pass

## Dependencies

Base: **#284** (`feat/runtime-custom-kernels-split`). Part of the ABI train; merge after #284.

Made with [Cursor](https://cursor.com)