### PR TITLE
feat(nonzero,scatter_nd): thread GPU row-count via count_buf/valid_count to match #284 ABI

### DIFF
--- a/include/hip/Dialect/IR/HipInferTypeUtils.h
+++ b/include/hip/Dialect/IR/HipInferTypeUtils.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#ifndef HIP_DIALECT_IR_HIP_INFER_TYPE_UTILS_H
+#define HIP_DIALECT_IR_HIP_INFER_TYPE_UTILS_H
+
+#include "mlir/IR/TypeRange.h"
+#include "mlir/IR/Types.h"
+#include "mlir/Support/LogicalResult.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace mlir {
+namespace hip {
+
+/// Shared body for the hand-written `inferReturnTypes` of HIP DPS ops that
+/// need a specialization the auto-generated (`autoInfer=1`) one cannot
+/// produce -- e.g. ops with more than one DPS init operand, where the
+/// generated inference pushes only the single `outsAccessor` result.
+///
+/// Push one SSA result type per init operand, in DPS-init order, but only for
+/// the ranked-tensor-typed inits. In memref mode (post-bufferize) the inits
+/// are memrefs and produce no SSA results, so nothing is pushed -- which is
+/// exactly what callers want (the op has no results after bufferization).
+///
+/// `initTypes` MUST be supplied in DPS-init order so the resulting SSA result
+/// order matches what the op's converter builds (e.g. for NonZero:
+/// result[0] = y, result[1] = count_buf).
+///
+/// This lives in a dedicated utils file (rather than inline in HipDialect.cpp)
+/// so the set of `inferReturnTypes` specializations stays in one place as more
+/// multi-output ops are added.
+LogicalResult inferDpsInitReturnTypes(TypeRange initTypes,
+                                      SmallVectorImpl<Type> &results);
+
+} // namespace hip
+} // namespace mlir
+
+#endif // HIP_DIALECT_IR_HIP_INFER_TYPE_UTILS_H

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -2835,20 +2835,29 @@ def Hip_ScatterNDOp : Hip_DpsOp<"scatter_nd", /*traits=*/[],
       * `"min"` — minimum (`a = min(a, b)`)
       * `"max"` — maximum (`a = max(a, b)`)
 
+    `has_valid_count` indicates whether `valid_count` is meaningful. When
+    true, the `valid_count` buffer (`memref<1xi32>`) limits how many leading
+    index rows the runtime processes — the canonical case is a NonZero
+    upstream whose data-dependent row count was written into `count_buf`
+    (obtained here by backtracing the `indices` operand). When false,
+    `valid_count` is a dummy buffer that is never read and all `indices` rows
+    are processed.
+
     This is the inverse of GatherND.
 
     Uses destination-passing style: the `output` buffer is provided as an
     argument, and the runtime is responsible for both the initial
     `data → output` copy and the subsequent scatter writes.
 
-    Example:
+    Example (no valid_count — all rows processed):
     ```mlir
-    hip.scatter_nd(%ctx) ins(%data, %indices, %updates :
+    hip.scatter_nd(%ctx) ins(%data, %indices, %updates, %dummy_count :
                               memref<4x4x4xf32, 1>,
                               memref<2x1xi64, 1>,
-                              memref<2x4x4xf32, 1>)
+                              memref<2x4x4xf32, 1>,
+                              memref<1xi32, 1>)
                           outs(%out : memref<4x4x4xf32, 1>)
-                          {reduction = "none"}
+                          {reduction = "none", has_valid_count = false}
     ```
   }];
 
@@ -2857,13 +2866,16 @@ def Hip_ScatterNDOp : Hip_DpsOp<"scatter_nd", /*traits=*/[],
     Hip_TensorOrMemRef:$data,
     Hip_TensorOrMemRef:$indices,
     Hip_TensorOrMemRef:$updates,
+    Hip_TensorOrMemRef:$valid_count,
     Hip_TensorOrMemRef:$output,
-    DefaultValuedStrAttr<StrAttr, "none">:$reduction
+    DefaultValuedStrAttr<StrAttr, "none">:$reduction,
+    DefaultValuedAttr<BoolAttr, "false">:$has_valid_count
   );
 
   let assemblyFormat = [{
-    `(` $ctx `)` `ins` `(` $data `,` $indices `,` $updates `:`
-        type($data) `,` type($indices) `,` type($updates) `)`
+    `(` $ctx `)` `ins` `(` $data `,` $indices `,` $updates `,` $valid_count `:`
+        type($data) `,` type($indices) `,` type($updates) `,`
+        type($valid_count) `)`
     `outs` `(` $output `:` type($output) `)`
     attr-dict (`:` type($result_tensors)^)?
   }];
@@ -2984,9 +2996,16 @@ def Hip_SizeOp : Hip_DpsOp<"size", /*traits=*/[],
   }];
 }
 
+// autoInfer=0: NonZero is the only HIP DPS op with TWO outputs (`y` and
+// `count_buf`), and the auto-generated `inferReturnTypes` body only pushes the
+// single `outsAccessor` result. A hand-written `inferReturnTypes` in
+// HipDialect.cpp pushes both result types. autoReify still works for two
+// results: the shared HipDpsOp::reifyResultShapes walks every getDpsInits()
+// entry, so the two-init `getDpsInitsMutable()` (also in HipDialect.cpp) is
+// reified automatically.
 def Hip_NonZeroOp : Hip_DpsOp<"nonzero", /*traits=*/[], /*outsAccessor=*/"Y",
                               /*autoReify=*/1,
-                              /*autoInfer=*/1, /*declareInfer=*/1> {
+                              /*autoInfer=*/0, /*declareInfer=*/1> {
   let summary = "Indices of non-zero elements (ONNX NonZero)";
   let description = [{
     Implements the standard ONNX NonZero operator (opset 13+):
@@ -3000,13 +3019,19 @@ def Hip_NonZeroOp : Hip_DpsOp<"nonzero", /*traits=*/[], /*outsAccessor=*/"Y",
     over-allocates using `numel(x)` as the upper bound (since the input
     has fully static shape).
 
-    Uses destination-passing style: the output buffer is provided as
-    argument.
+    `count_buf` is a second output of shape `memref<1xi32>` that receives
+    the actual number of non-zero elements found at runtime (written by the
+    kernel via atomicAdd). Downstream ops (notably ScatterND, which obtains
+    `count_buf` by backtracing its `indices` operand to this op) read it to
+    bound the number of valid rows in `y` without any D2H synchronization.
+
+    Uses destination-passing style: both output buffers are provided as
+    arguments.
 
     Example:
     ```mlir
     hip.nonzero(%ctx) ins(%x : memref<3x4xf16, 1>)
-                      outs(%y : memref<2x?xi64, 1>)
+                      outs(%y, %count : memref<2x?xi64, 1>, memref<1xi32, 1>)
                       {input_data_type = 1 : i64}
     ```
   }];
@@ -3015,12 +3040,13 @@ def Hip_NonZeroOp : Hip_DpsOp<"nonzero", /*traits=*/[], /*outsAccessor=*/"Y",
     Hip_ContextType:$ctx,
     Hip_TensorOrMemRef:$x,
     Hip_TensorOrMemRef:$y,
+    Hip_TensorOrMemRef:$count_buf,
     I64Attr:$input_data_type
   );
 
   let assemblyFormat = [{
     `(` $ctx `)` `ins` `(` $x `:` type($x) `)`
-    `outs` `(` $y `:` type($y) `)`
+    `outs` `(` $y `,` $count_buf `:` type($y) `,` type($count_buf) `)`
     attr-dict (`:` type($result_tensors)^)?
   }];
 }

--- a/lib/Conversion/HipToLLVM/NonZeroLowering.cpp
+++ b/lib/Conversion/HipToLLVM/NonZeroLowering.cpp
@@ -5,24 +5,30 @@
 
 #include "HipToLLVMUtils.h"
 
+#include "llvm/ADT/Sequence.h"
+
 namespace mlir {
 namespace hip {
 namespace {
 
-// hip.nonzero(ctx, x, y) {input_data_type}
-//   -> wrap_nonzero(state, input_ptr, output_ptr,
+// hip.nonzero(ctx, x, y, count_buf) {input_data_type}
+//   -> wrap_nonzero(state, input_ptr, output_ptr, count_ptr,
 //                   input_num_elements, input_rank,
-//                   output_capacity, input_data_type)
+//                   input_dims_ptr, output_capacity, input_data_type)
 //
-// `input_num_elements` is the total count of input elements (product of
-// input dims, supports static + dynamic shapes via MemRefDescriptor).
-// `input_rank` is the static rank of the input (R), passed as a compile-
-// time i64 constant.
-// `output_capacity` is the size of the dynamic N dim of the output (i.e.,
-// the upper-bound number of nonzero entries materialised by the conversion
-// pass). For NonZero today this equals input_num_elements, but lowering
-// computes it directly from the output descriptor so the path is correct
-// even if the conversion ever uses a smaller upper bound.
+// `count_ptr` points to the single-i32 count_buf in the GPU pool. The kernel
+// writes the actual nonzero count there via atomicAdd; a downstream ScatterND
+// reads it directly on the GPU (no D2H) to bound the rows it processes.
+//
+// `input_dims_ptr` is a stack array of the input shape dims, used by the kernel
+// to decompose a flat non-zero index into multi-dim coordinates. Static dims
+// are compile-time constants; dynamic dims are read from the memref descriptor.
+//
+// `input_num_elements` is the product of input dims (static + dynamic via the
+// MemRefDescriptor). `input_rank` is the static rank R. `output_capacity` is
+// the N dim of the output (the upper-bound nonzero count the conversion pinned
+// to numel(X)), read from the output descriptor so the path stays correct even
+// if a future conversion uses a smaller upper bound.
 struct NonZeroOpLowering : public ConvertOpToLLVMPattern<NonZeroOp> {
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
@@ -42,7 +48,8 @@ struct NonZeroOpLowering : public ConvertOpToLLVMPattern<NonZeroOp> {
 
     auto inputType = dyn_cast<MemRefType>(op.getX().getType());
     auto outputType = dyn_cast<MemRefType>(op.getY().getType());
-    if (!inputType || !outputType)
+    auto countType = dyn_cast<MemRefType>(op.getCountBuf().getType());
+    if (!inputType || !outputType || !countType)
       return rewriter.notifyMatchFailure(
           op, "hip.nonzero lowering expects ranked memref operands");
     if (outputType.getRank() != 2)
@@ -52,35 +59,53 @@ struct NonZeroOpLowering : public ConvertOpToLLVMPattern<NonZeroOp> {
     Value statePtr = adaptor.getCtx();
     Value inputPtr = extractContiguousMemRefPtr(adaptor.getX(), rewriter, loc);
     Value outputPtr = extractContiguousMemRefPtr(adaptor.getY(), rewriter, loc);
+    Value countPtr =
+        extractContiguousMemRefPtr(adaptor.getCountBuf(), rewriter, loc);
 
     // Total input element count (handles static + dynamic dims).
     Value inputNumElements =
         computeNumElements(inputType, adaptor.getX(), rewriter, loc);
 
     // R is a static property of the input memref type.
-    Value inputRank = createI64Const(inputType.getRank());
+    int64_t rank = inputType.getRank();
+    Value inputRank = createI64Const(rank);
 
-    // Output capacity = N dim (data-dependent at the source level; the
-    // tensor.empty in OnnxToHip pins it to numel(X) upper-bound, but read
-    // from the descriptor here for correctness under any future re-size).
+    // Stack array of input dims for the kernel's flat->multi-dim decomposition.
+    Value one = createI64Const(1);
+    auto arrType =
+        LLVM::LLVMArrayType::get(i64Type, std::max(rank, (int64_t)1));
+    Value dimsArr =
+        LLVM::AllocaOp::create(rewriter, loc, ptrType, arrType, one, 8);
+    for (int64_t i : llvm::seq<int64_t>(0, rank)) {
+      Value dim = getMemRefDimSize(inputType, i, adaptor.getX(), rewriter, loc);
+      Value idx = LLVM::ConstantOp::create(rewriter, loc, i32Type,
+                                           rewriter.getI32IntegerAttr(i));
+      Value elemPtr =
+          LLVM::GEPOp::create(rewriter, loc, ptrType, i64Type, dimsArr, idx);
+      LLVM::StoreOp::create(rewriter, loc, dim, elemPtr);
+    }
+
+    // Output capacity = N dim of the output memref.
     Value outputCapacity = getMemRefDimSize(outputType, /*dimIdx=*/1,
                                             adaptor.getY(), rewriter, loc);
 
     Value inputDataTypeVal = createI64Const(op.getInputDataType());
 
     // int wrap_nonzero(RuntimeState* state, void* input, void* output,
-    //                  int64_t input_num_elements, int64_t input_rank,
+    //                  int32_t* count_ptr, int64_t input_num_elements,
+    //                  int64_t input_rank, const int64_t* input_dims,
     //                  int64_t output_capacity, int64_t input_data_type)
-    SmallVector<Type, 7> paramTypes = {ptrType, ptrType, ptrType, i64Type,
-                                       i64Type, i64Type, i64Type};
+    SmallVector<Type, 9> paramTypes = {ptrType, ptrType, ptrType,
+                                       ptrType, i64Type, i64Type,
+                                       ptrType, i64Type, i64Type};
     FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
         rewriter, module, kWrapNonZero, paramTypes, i32Type);
     if (failed(funcOp))
       return failure();
 
-    SmallVector<Value, 7> args = {statePtr,         inputPtr,  outputPtr,
-                                  inputNumElements, inputRank, outputCapacity,
-                                  inputDataTypeVal};
+    SmallVector<Value, 9> args = {statePtr, inputPtr,         outputPtr,
+                                  countPtr, inputNumElements, inputRank,
+                                  dimsArr,  outputCapacity,   inputDataTypeVal};
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
     rewriter.eraseOp(op);
     return success();

--- a/lib/Conversion/HipToLLVM/ScatterNDLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ScatterNDLowering.cpp
@@ -9,8 +9,10 @@ namespace mlir {
 namespace hip {
 namespace {
 
-// hip.scatter_nd(ctx, data, indices, updates, output) {reduction}
+// hip.scatter_nd(ctx, data, indices, updates, valid_count, output) {reduction,
+// has_valid_count}
 //   -> wrap_scatter_nd(state, data_ptr, indices_ptr, updates_ptr, out_ptr,
+//                      count_ptr,
 //                      data_shape_ptr, data_rank,
 //                      indices_shape_ptr, indices_rank,
 //                      updates_shape_ptr, updates_rank,
@@ -18,9 +20,11 @@ namespace {
 //                      reduction_id, data_type)
 //
 // `reduction_id` encodes the ONNX `reduction` string attribute as a small
-// integer enum (see ScatterNDOpLowering::reductionIdFromString below). The
-// runtime side is a stub today that only logs its parameters, but the
-// signature is shaped to match the future kernel implementation.
+// integer enum (see ScatterNDOpLowering::reductionIdFromString below).
+//
+// `count_ptr` is the GPU pointer to NonZero's count_buf (int32) when
+// `has_valid_count` is set, else a null pointer (all index rows are valid).
+// The runtime treats null as "process every row".
 struct ScatterNDOpLowering : public ConvertOpToLLVMPattern<ScatterNDOp> {
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
@@ -64,6 +68,15 @@ struct ScatterNDOpLowering : public ConvertOpToLLVMPattern<ScatterNDOp> {
     Value outPtr =
         extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
 
+    // count_ptr: GPU pointer from NonZero's count_buf, or null when no
+    // valid_count was wired (has_valid_count=false -> process all rows).
+    Value countPtr;
+    if (op.getHasValidCount())
+      countPtr =
+          extractContiguousMemRefPtr(adaptor.getValidCount(), rewriter, loc);
+    else
+      countPtr = LLVM::ZeroOp::create(rewriter, loc, ptrType);
+
     auto createI64Const = [&](int64_t v) {
       return LLVM::ConstantOp::create(rewriter, loc, i64Type,
                                       rewriter.getI64IntegerAttr(v));
@@ -99,9 +112,10 @@ struct ScatterNDOpLowering : public ConvertOpToLLVMPattern<ScatterNDOp> {
         createI64Const(reductionIdFromString(op.getReduction()));
     Value dataTypeVal = createI64Const(hipDtype);
 
-    SmallVector<Type, 16> paramTypes = {
+    SmallVector<Type, 17> paramTypes = {
         ptrType, ptrType, ptrType, ptrType, ptrType, // state, data, idx,
                                                      // updates, out
+        ptrType,                                     // count_ptr
         ptrType, i64Type,                            // data_shape, data_rank
         ptrType, i64Type,                            // idx_shape, idx_rank
         ptrType, i64Type,                            // upd_shape, upd_rank
@@ -113,10 +127,11 @@ struct ScatterNDOpLowering : public ConvertOpToLLVMPattern<ScatterNDOp> {
     if (failed(funcOp))
       return failure();
 
-    SmallVector<Value, 16> args = {
-        statePtr,    dataPtr,  indicesPtr,   updatesPtr,   outPtr,
-        dataShape,   dataRank, indicesShape, indicesRank,  updatesShape,
-        updatesRank, outShape, outRank,      reductionVal, dataTypeVal};
+    SmallVector<Value, 17> args = {
+        statePtr,     dataPtr,     indicesPtr,   updatesPtr,
+        outPtr,       countPtr,    dataShape,    dataRank,
+        indicesShape, indicesRank, updatesShape, updatesRank,
+        outShape,     outRank,     reductionVal, dataTypeVal};
 
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
     rewriter.eraseOp(op);

--- a/lib/Conversion/OnnxToHip/NonZeroConversion.cpp
+++ b/lib/Conversion/OnnxToHip/NonZeroConversion.cpp
@@ -45,9 +45,19 @@ static int64_t getHipdnnInputDataType(mlir::Type elemType) {
 //           and is materialised as the runtime `dynSize` of the
 //           `tensor.empty` init operand so the buffer is large enough to
 //           hold the worst case.
+// Output count_buf: tensor<1xi32>. Receives the actual non-zero count at
+//           runtime (written by the kernel via atomicAdd). The ONNX op has
+//           a single result (the indices), so count_buf has no ONNX-level
+//           consumer; downstream ScatterND backtraces its `indices` operand
+//           to this op and reads result[1] to bound the rows it processes
+//           (no D2H sync). Materialised as a second DPS init below.
+//
+// Benefit 2 (vs the default 1) so NonZero converts before ScatterND, letting
+// ScatterND's backtrace find a `hip.nonzero` rather than deferring on an
+// unconverted `onnx.NonZero`.
 struct NonZeroToHip : public mlir::RewritePattern {
   NonZeroToHip(mlir::MLIRContext *ctx)
-      : RewritePattern("onnx.NonZero", /*benefit=*/1, ctx) {}
+      : RewritePattern("onnx.NonZero", /*benefit=*/2, ctx) {}
 
   mlir::LogicalResult
   matchAndRewrite(mlir::Operation *op,
@@ -119,15 +129,24 @@ struct NonZeroToHip : public mlir::RewritePattern {
             mlir::arith::MulIOp::create(rewriter, loc, upperBound, dim);
       }
     }
-    mlir::Value init = mlir::tensor::EmptyOp::create(
+    mlir::Value indicesInit = mlir::tensor::EmptyOp::create(
         rewriter, loc, resultType.getShape(), resultType.getElementType(),
         mlir::ValueRange{upperBound});
 
-    // Result type inferred from `init` via InferTypeOpInterface — DPS contract:
-    // result type == outs operand type.
+    // Second DPS init: tensor<1xi32> count buffer (static, no dynsize).
+    auto countType = mlir::RankedTensorType::get({1}, rewriter.getI32Type());
+    mlir::Value countInit = mlir::tensor::EmptyOp::create(
+        rewriter, loc, countType.getShape(), countType.getElementType(),
+        mlir::ValueRange{});
+
+    // Two results: result[0] = indices (Y), result[1] = count_buf. Custom
+    // NonZeroOp::inferReturnTypes (HipDialect.cpp) pushes both in this order.
     auto hipOp = mlir::hip::NonZeroOp::create(
-        rewriter, loc, context, op->getOperand(0), init,
+        rewriter, loc, mlir::TypeRange{resultType, countType}, context,
+        op->getOperand(0), indicesInit, countInit,
         rewriter.getI64IntegerAttr(inputDataType));
+    // Replace the ONNX op (single result) with the indices result only;
+    // count_buf stays live via the downstream ScatterND backtrace.
     rewriter.replaceOp(op, hipOp->getResult(0));
     return mlir::success();
   }

--- a/lib/Conversion/OnnxToHip/ScatterNDConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ScatterNDConversion.cpp
@@ -9,6 +9,65 @@ namespace mlir {
 namespace hip {
 namespace {
 
+/// Backtrace the SSA chain from `indices` through ops that preserve element
+/// identity (Transpose/Reshape/Squeeze/Unsqueeze/Cast/Gather and their HIP /
+/// tensor equivalents) to find a `hip.nonzero`. If found, return its count_buf
+/// (result[1]) — the runtime row count to bound ScatterND's writes.
+///
+/// Returns {count_value, should_defer}:
+///   count_value : non-null if a converted `hip.nonzero` is found upstream.
+///   should_defer: true if an UNCONVERTED `onnx.NonZero` is found — the caller
+///                 returns failure() so the greedy rewriter retries this op
+///                 after NonZero converts (and exposes its count_buf result).
+static std::pair<mlir::Value, bool> traceToNonZeroCount(mlir::Value indices) {
+  mlir::Value current = indices;
+  // Bounded walk: the NonZero->ScatterND index chain in real exports is short
+  // (Transpose + a reshape or two); 16 hops is generous slack.
+  for (int depth = 0; depth < 16; ++depth) {
+    auto *defOp = current.getDefiningOp();
+    if (!defOp)
+      return {nullptr, false};
+
+    if (auto nonzeroOp = llvm::dyn_cast<mlir::hip::NonZeroOp>(defOp)) {
+      if (nonzeroOp->getNumResults() >= 2)
+        return {nonzeroOp->getResult(1), false};
+      return {nullptr, false};
+    }
+
+    // Unconverted onnx.NonZero: defer so the rewriter retries post-conversion.
+    if (defOp->getName().getStringRef() == "onnx.NonZero")
+      return {nullptr, true};
+
+    llvm::StringRef opName = defOp->getName().getStringRef();
+    // ONNX shape/identity ops carry the index data through operand 0.
+    if (opName == "onnx.Transpose" || opName == "onnx.Reshape" ||
+        opName == "onnx.Squeeze" || opName == "onnx.Unsqueeze" ||
+        opName == "onnx.Cast" || opName == "onnx.Gather") {
+      if (defOp->getNumOperands() >= 1) {
+        current = defOp->getOperand(0);
+        continue;
+      }
+    }
+    // HIP DPS equivalents take ctx as operand 0; the data input is operand 1.
+    if (opName == "hip.transpose" || opName == "hip.cast") {
+      if (defOp->getNumOperands() >= 2) {
+        current = defOp->getOperand(1);
+        continue;
+      }
+    }
+    // tensor reshape/cast descriptor ops carry data through operand 0.
+    if (opName == "tensor.cast" || opName == "tensor.collapse_shape" ||
+        opName == "tensor.expand_shape") {
+      if (defOp->getNumOperands() >= 1) {
+        current = defOp->getOperand(0);
+        continue;
+      }
+    }
+    return {nullptr, false};
+  }
+  return {nullptr, false};
+}
+
 /// onnx.ScatterND -> hip.scatter_nd
 ///
 /// Output shape matches `data` exactly (per ONNX spec), so the destination
@@ -27,6 +86,12 @@ namespace {
 /// `reduction` is forwarded as a string attribute (`"none"` by default).
 /// The runtime stub today only logs its parameters, so any reduction mode
 /// is accepted at compile time.
+///
+/// The conversion also backtraces `indices` (see traceToNonZeroCount): if it
+/// originates from a NonZero (possibly through Transpose/Reshape/...), that
+/// op's count_buf is passed as `valid_count` with `has_valid_count = true`, so
+/// the kernel processes only the runtime-valid rows. Otherwise a dummy 1xi32
+/// init is passed with `has_valid_count = false` (never read).
 struct ScatterNDToHip : public mlir::RewritePattern {
   ScatterNDToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.ScatterND", /*benefit=*/1, ctx) {}
@@ -81,8 +146,24 @@ struct ScatterNDToHip : public mlir::RewritePattern {
     else
       reductionAttr = rewriter.getStringAttr("none");
 
+    // Backtrace indices to an upstream NonZero count_buf. If an unconverted
+    // onnx.NonZero is found, defer so the rewriter retries after it converts.
+    auto [validCount, shouldDefer] = traceToNonZeroCount(indices);
+    if (shouldDefer)
+      return rewriter.notifyMatchFailure(
+          op, "deferring: upstream onnx.NonZero not yet converted");
+    bool hasValidCount = (validCount != nullptr);
+    if (!validCount) {
+      // No NonZero upstream — dummy 1xi32 init (has_valid_count=false; never
+      // read by the kernel, present only to satisfy the operand list).
+      auto countType = mlir::RankedTensorType::get({1}, rewriter.getI32Type());
+      validCount = mlir::tensor::EmptyOp::create(
+          rewriter, loc, countType.getShape(), countType.getElementType());
+    }
+
     auto hipOp = mlir::hip::ScatterNDOp::create(
-        rewriter, loc, context, data, indices, updates, init, reductionAttr);
+        rewriter, loc, resultType, context, data, indices, updates, validCount,
+        init, reductionAttr, rewriter.getBoolAttr(hasValidCount));
     rewriter.replaceOp(op, hipOp->getResult(0));
     return mlir::success();
   }

--- a/lib/Dialect/IR/CMakeLists.txt
+++ b/lib/Dialect/IR/CMakeLists.txt
@@ -6,6 +6,7 @@
 add_library(HipDialectIR STATIC
   HipDialect.cpp
   HipDpsOpInterface.cpp
+  HipInferTypeUtils.cpp
   HipReifyResultShapesImpl.cpp
   HipShapeUtils.cpp
 )

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -14,6 +14,7 @@
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/SymbolTable.h"
 
+#include "hip/Dialect/IR/HipInferTypeUtils.h"
 #include "hip/Dialect/IR/HipShapeUtils.h"
 
 using namespace mlir;
@@ -1452,21 +1453,19 @@ void NonZeroOp::getEffects(
 
 // Hand-written because NonZero is the only HIP DPS op with two outputs, and the
 // auto-generated inferReturnTypes (Hip_DpsOp autoInfer=1) pushes only the
-// single outsAccessor result. Push both `y` and `count_buf` in DPS-init order
-// so the SSA result order (result[0]=y, result[1]=count_buf) matches what
-// NonZeroConversion builds. Only ranked-tensor outs become SSA results; in
-// memref mode (post-bufferize) both are memrefs and nothing is pushed.
+// single outsAccessor result. The shared `inferDpsInitReturnTypes` helper
+// pushes both `y` and `count_buf` in DPS-init order, so the SSA result order
+// (result[0]=y, result[1]=count_buf) matches what NonZeroConversion builds.
+// Only the ranked-tensor inits become SSA results (memref mode pushes nothing).
+// The body lives in HipInferTypeUtils.cpp so future multi-output ops share it.
 LogicalResult
 NonZeroOp::inferReturnTypes(MLIRContext *, std::optional<Location>,
                             ValueRange operands, DictionaryAttr attrs,
                             OpaqueProperties props, RegionRange regions,
                             SmallVectorImpl<Type> &results) {
   NonZeroOp::Adaptor adaptor(operands, attrs, props, regions);
-  if (auto t = dyn_cast<RankedTensorType>(adaptor.getY().getType()))
-    results.push_back(t);
-  if (auto t = dyn_cast<RankedTensorType>(adaptor.getCountBuf().getType()))
-    results.push_back(t);
-  return success();
+  return inferDpsInitReturnTypes(
+      {adaptor.getY().getType(), adaptor.getCountBuf().getType()}, results);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -1432,15 +1432,41 @@ void ScatterNDOp::getEffects(
 }
 
 //===----------------------------------------------------------------------===//
-// NonZeroOp: ins(x), outs(y)
+// NonZeroOp: ins(x), outs(y, count_buf)
 //===----------------------------------------------------------------------===//
 
-MutableOperandRange NonZeroOp::getDpsInitsMutable() { return getYMutable(); }
+// Two DPS outputs. Operand order (attributes are not operands): ctx(0), x(1),
+// y(2), count_buf(3). Both y and count_buf are DPS inits, so the range spans
+// operands [2, 4). The shared HipDpsOp::reifyResultShapes iterates
+// getDpsInits() and reifies each, so returning both here is all that auto-reify
+// needs.
+MutableOperandRange NonZeroOp::getDpsInitsMutable() {
+  return MutableOperandRange(getOperation(), /*start=*/2, /*length=*/2);
+}
 
 void NonZeroOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
         &effects) {
   emitDpsMemoryEffects(getDpsInputOperands(), getDpsInitsMutable(), effects);
+}
+
+// Hand-written because NonZero is the only HIP DPS op with two outputs, and the
+// auto-generated inferReturnTypes (Hip_DpsOp autoInfer=1) pushes only the
+// single outsAccessor result. Push both `y` and `count_buf` in DPS-init order
+// so the SSA result order (result[0]=y, result[1]=count_buf) matches what
+// NonZeroConversion builds. Only ranked-tensor outs become SSA results; in
+// memref mode (post-bufferize) both are memrefs and nothing is pushed.
+LogicalResult
+NonZeroOp::inferReturnTypes(MLIRContext *, std::optional<Location>,
+                            ValueRange operands, DictionaryAttr attrs,
+                            OpaqueProperties props, RegionRange regions,
+                            SmallVectorImpl<Type> &results) {
+  NonZeroOp::Adaptor adaptor(operands, attrs, props, regions);
+  if (auto t = dyn_cast<RankedTensorType>(adaptor.getY().getType()))
+    results.push_back(t);
+  if (auto t = dyn_cast<RankedTensorType>(adaptor.getCountBuf().getType()))
+    results.push_back(t);
+  return success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/IR/HipInferTypeUtils.cpp
+++ b/lib/Dialect/IR/HipInferTypeUtils.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- HipInferTypeUtils.cpp - inferReturnTypes specialization helpers ----===//
+//
+// Implementation of the helpers declared in `HipInferTypeUtils.h`. These back
+// the hand-written `inferReturnTypes` of HIP DPS ops whose result set the
+// auto-generated inference cannot produce (currently the multi-output ops).
+// Keeping the bodies here -- instead of inline in HipDialect.cpp -- collects
+// every such specialization in one place as more are added.
+//
+//===----------------------------------------------------------------------===//
+
+#include "hip/Dialect/IR/HipInferTypeUtils.h"
+
+#include "mlir/IR/BuiltinTypes.h"
+
+using namespace mlir;
+using namespace mlir::hip;
+
+LogicalResult hip::inferDpsInitReturnTypes(TypeRange initTypes,
+                                           SmallVectorImpl<Type> &results) {
+  for (Type t : initTypes)
+    if (auto ranked = dyn_cast<RankedTensorType>(t))
+      results.push_back(ranked);
+  return success();
+}

--- a/test/lit/Conversion/hip-to-llvm/test_nonzero.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_nonzero.mlir
@@ -4,11 +4,13 @@
 // ============================================================================
 // TEST PURPOSE:
 // Verify hip.nonzero lowers to a single llvm.call into the wrap_nonzero
-// runtime stub, with the expected (state, in, out, num_elems, rank,
-// output_capacity, input_data_type) signature. Covers both fully static
-// inputs (num_elems computed at compile time) and partially dynamic
-// inputs (num_elems built from llvm.extractvalue + llvm.mul over the
-// MemRef descriptor sizes array).
+// runtime, with the expected 9-arg signature:
+//   (state, in, out, count_ptr, num_elems, rank, input_dims, output_capacity,
+//    input_data_type)
+// count_ptr is the second DPS out (count_buf); input_dims is a stack array of
+// the input shape dims. Covers both fully static inputs (num_elems computed at
+// compile time) and partially dynamic inputs (num_elems built from
+// llvm.extractvalue + llvm.mul over the MemRef descriptor sizes array).
 // ============================================================================
 
 // RUN: hip-mlir-opt %s --convert-hip-to-llvm | FileCheck %s
@@ -18,14 +20,15 @@ module {
   func.func @nonzero_static_bool(
       %ctx: !hip.context,
       %input: memref<3x4xi1, 1>,
-      %output: memref<2x?xi64, 1>) {
+      %output: memref<2x?xi64, 1>,
+      %count: memref<1xi32, 1>) {
     // CHECK-LABEL: llvm.func @nonzero_static_bool
 
     hip.nonzero(%ctx) ins(%input : memref<3x4xi1, 1>)
-                      outs(%output : memref<2x?xi64, 1>)
+                      outs(%output, %count : memref<2x?xi64, 1>, memref<1xi32, 1>)
                       {input_data_type = 5 : i64}
 
-    // CHECK: llvm.call @wrap_nonzero({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64) -> i32
+    // CHECK: llvm.call @wrap_nonzero({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, !llvm.ptr, i64, i64) -> i32
     return
   }
 
@@ -33,14 +36,15 @@ module {
   func.func @nonzero_static_f32(
       %ctx: !hip.context,
       %input: memref<2x3x4xf32, 1>,
-      %output: memref<3x?xi64, 1>) {
+      %output: memref<3x?xi64, 1>,
+      %count: memref<1xi32, 1>) {
     // CHECK-LABEL: llvm.func @nonzero_static_f32
 
     hip.nonzero(%ctx) ins(%input : memref<2x3x4xf32, 1>)
-                      outs(%output : memref<3x?xi64, 1>)
+                      outs(%output, %count : memref<3x?xi64, 1>, memref<1xi32, 1>)
                       {input_data_type = 0 : i64}
 
-    // CHECK: llvm.call @wrap_nonzero({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64) -> i32
+    // CHECK: llvm.call @wrap_nonzero({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, !llvm.ptr, i64, i64) -> i32
     return
   }
 
@@ -49,11 +53,12 @@ module {
   func.func @nonzero_dynamic_f16(
       %ctx: !hip.context,
       %input: memref<?x?xf16, 1>,
-      %output: memref<2x?xi64, 1>) {
+      %output: memref<2x?xi64, 1>,
+      %count: memref<1xi32, 1>) {
     // CHECK-LABEL: llvm.func @nonzero_dynamic_f16
 
     hip.nonzero(%ctx) ins(%input : memref<?x?xf16, 1>)
-                      outs(%output : memref<2x?xi64, 1>)
+                      outs(%output, %count : memref<2x?xi64, 1>, memref<1xi32, 1>)
                       {input_data_type = 1 : i64}
 
     // Verify dynamic shape computation: descriptor.sizes[0] * descriptor.sizes[1].
@@ -62,7 +67,7 @@ module {
     // CHECK-DAG: llvm.mul %{{.*}}, %{{.*}} : i64
     // CHECK-DAG: llvm.extractvalue %{{.*}}[3, 1]
 
-    // CHECK: llvm.call @wrap_nonzero({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64) -> i32
+    // CHECK: llvm.call @wrap_nonzero({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, !llvm.ptr, i64, i64) -> i32
     return
   }
 }

--- a/test/lit/Conversion/hip-to-llvm/test_scatter_nd.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_scatter_nd.mlir
@@ -4,20 +4,25 @@
 // RUN: hip-mlir-opt --convert-hip-to-llvm %s | FileCheck %s
 
 // Verify that hip.scatter_nd lowers to wrap_scatter_nd with the full
-// 15-parameter signature: 5 pointers + 4 shape pointers + 4 ranks +
-// reduction_id + data_type, regardless of the `reduction` attribute value.
+// 16-parameter signature: 6 pointers (state, data, indices, updates, output,
+// count_ptr) + 4 shape pointers + 4 ranks + reduction_id + data_type. When
+// has_valid_count=false the count_ptr arg is a null pointer (llvm.mlir.zero);
+// when true it is the valid_count buffer pointer.
 
 module {
+  // has_valid_count=false -> count_ptr is null.
   func.func @test_scatter_nd_default(%ctx: !hip.context,
                                       %data: memref<4x4x4xf32, 1>,
                                       %indices: memref<2x1xi64, 1>,
                                       %updates: memref<2x4x4xf32, 1>,
+                                      %count: memref<1xi32, 1>,
                                       %output: memref<4x4x4xf32, 1>) {
     hip.scatter_nd(%ctx)
-        ins(%data, %indices, %updates :
-            memref<4x4x4xf32, 1>, memref<2x1xi64, 1>, memref<2x4x4xf32, 1>)
+        ins(%data, %indices, %updates, %count :
+            memref<4x4x4xf32, 1>, memref<2x1xi64, 1>, memref<2x4x4xf32, 1>,
+            memref<1xi32, 1>)
         outs(%output : memref<4x4x4xf32, 1>)
-        {reduction = "none"}
+        {reduction = "none", has_valid_count = false}
     return
   }
 
@@ -25,18 +30,42 @@ module {
                                   %data: memref<8xf32, 1>,
                                   %indices: memref<4x1xi64, 1>,
                                   %updates: memref<4xf32, 1>,
+                                  %count: memref<1xi32, 1>,
                                   %output: memref<8xf32, 1>) {
     hip.scatter_nd(%ctx)
-        ins(%data, %indices, %updates :
-            memref<8xf32, 1>, memref<4x1xi64, 1>, memref<4xf32, 1>)
+        ins(%data, %indices, %updates, %count :
+            memref<8xf32, 1>, memref<4x1xi64, 1>, memref<4xf32, 1>,
+            memref<1xi32, 1>)
         outs(%output : memref<8xf32, 1>)
-        {reduction = "add"}
+        {reduction = "add", has_valid_count = false}
+    return
+  }
+
+  // has_valid_count=true -> count_ptr is the valid_count buffer pointer.
+  func.func @test_scatter_nd_valid_count(%ctx: !hip.context,
+                                          %data: memref<8xf32, 1>,
+                                          %indices: memref<4x1xi64, 1>,
+                                          %updates: memref<4xf32, 1>,
+                                          %count: memref<1xi32, 1>,
+                                          %output: memref<8xf32, 1>) {
+    hip.scatter_nd(%ctx)
+        ins(%data, %indices, %updates, %count :
+            memref<8xf32, 1>, memref<4x1xi64, 1>, memref<4xf32, 1>,
+            memref<1xi32, 1>)
+        outs(%output : memref<8xf32, 1>)
+        {reduction = "none", has_valid_count = true}
     return
   }
 }
 
 // CHECK-LABEL: llvm.func @test_scatter_nd_default
-// CHECK: llvm.call @wrap_scatter_nd({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, i64, i64) -> i32
+// has_valid_count=false materialises a null count pointer.
+// CHECK: llvm.mlir.zero : !llvm.ptr
+// CHECK: llvm.call @wrap_scatter_nd({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, i64, i64) -> i32
 
 // CHECK-LABEL: llvm.func @test_scatter_nd_add
-// CHECK: llvm.call @wrap_scatter_nd({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, i64, i64) -> i32
+// CHECK: llvm.mlir.zero : !llvm.ptr
+// CHECK: llvm.call @wrap_scatter_nd({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, i64, i64) -> i32
+
+// CHECK-LABEL: llvm.func @test_scatter_nd_valid_count
+// CHECK: llvm.call @wrap_scatter_nd({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, i64, i64) -> i32

--- a/test/lit/Conversion/onnx-to-hip/test_nonzero.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_nonzero.mlir
@@ -22,7 +22,8 @@ module {
   // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[IN:.*]]: tensor<3x4xi1>)
   // CHECK: %[[UB:.*]] = arith.constant 12 : index
   // CHECK: %[[INIT:.*]] = tensor.empty(%[[UB]]) : tensor<2x?xi64>
-  // CHECK: hip.nonzero(%[[CTX]]) ins(%[[IN]] : tensor<3x4xi1>) outs(%[[INIT]] : tensor<2x?xi64>) {input_data_type = 5 : i64}
+  // CHECK: %[[CNT:.*]] = tensor.empty() : tensor<1xi32>
+  // CHECK: hip.nonzero(%[[CTX]]) ins(%[[IN]] : tensor<3x4xi1>) outs(%[[INIT]], %[[CNT]] : tensor<2x?xi64>, tensor<1xi32>) {input_data_type = 5 : i64}
 
   // --- Case 2: f32 input, rank 3 ---
   func.func @nonzero_f32(%input: tensor<2x3x4xf32>) -> tensor<3x?xi64> {
@@ -34,7 +35,8 @@ module {
   // CHECK-SAME: (%[[CTX2:.*]]: !hip.context, %[[IN2:.*]]: tensor<2x3x4xf32>)
   // CHECK: %[[UB2:.*]] = arith.constant 24 : index
   // CHECK: %[[INIT2:.*]] = tensor.empty(%[[UB2]]) : tensor<3x?xi64>
-  // CHECK: hip.nonzero(%[[CTX2]]) ins(%[[IN2]] : tensor<2x3x4xf32>) outs(%[[INIT2]] : tensor<3x?xi64>) {input_data_type = 0 : i64}
+  // CHECK: %[[CNT2:.*]] = tensor.empty() : tensor<1xi32>
+  // CHECK: hip.nonzero(%[[CTX2]]) ins(%[[IN2]] : tensor<2x3x4xf32>) outs(%[[INIT2]], %[[CNT2]] : tensor<3x?xi64>, tensor<1xi32>) {input_data_type = 0 : i64}
 
   // --- Case 3: i64 input, rank 1 ---
   func.func @nonzero_i64(%input: tensor<8xi64>) -> tensor<1x?xi64> {
@@ -46,7 +48,8 @@ module {
   // CHECK-SAME: (%[[CTX3:.*]]: !hip.context, %[[IN3:.*]]: tensor<8xi64>)
   // CHECK: %[[UB3:.*]] = arith.constant 8 : index
   // CHECK: %[[INIT3:.*]] = tensor.empty(%[[UB3]]) : tensor<1x?xi64>
-  // CHECK: hip.nonzero(%[[CTX3]]) ins(%[[IN3]] : tensor<8xi64>) outs(%[[INIT3]] : tensor<1x?xi64>) {input_data_type = 4 : i64}
+  // CHECK: %[[CNT3:.*]] = tensor.empty() : tensor<1xi32>
+  // CHECK: hip.nonzero(%[[CTX3]]) ins(%[[IN3]] : tensor<8xi64>) outs(%[[INIT3]], %[[CNT3]] : tensor<1x?xi64>, tensor<1xi32>) {input_data_type = 4 : i64}
 
   // --- Case 4: dynamic input shape, rank 2 ---
   // Per-dim chain: upper bound = 1 * dim(input,0) * dim(input,1). The
@@ -71,7 +74,8 @@ module {
   // CHECK: tensor.dim %[[IN4]], %{{.*}} : tensor<?x?xf32>
   // CHECK: arith.muli %{{.*}}, %{{.*}} : index
   // CHECK: tensor.empty(%{{.*}}) : tensor<2x?xi64>
-  // CHECK: hip.nonzero(%[[CTX4]]) ins(%[[IN4]] : tensor<?x?xf32>) outs(%{{.*}} : tensor<2x?xi64>) {input_data_type = 0 : i64}
+  // CHECK: tensor.empty() : tensor<1xi32>
+  // CHECK: hip.nonzero(%[[CTX4]]) ins(%[[IN4]] : tensor<?x?xf32>) outs(%{{.*}}, %{{.*}} : tensor<2x?xi64>, tensor<1xi32>) {input_data_type = 0 : i64}
 
   // --- Case 5: partially dynamic input (mix of static + dynamic dims).
   // Static dims contribute a compile-time arith.constant; dynamic dims
@@ -109,8 +113,9 @@ module {
   // CHECK-SAME: (%[[CTX6:.*]]: !hip.context, %[[IN6:.*]]: tensor<2x4x8xui8>)
   // CHECK: %[[UB6:.*]] = arith.constant 64 : index
   // CHECK: %[[INIT6:.*]] = tensor.empty(%[[UB6]]) : tensor<3x?xi64>
+  // CHECK: %[[CNT6:.*]] = tensor.empty() : tensor<1xi32>
   // ui8 maps to the dedicated UINT8 slot (7), NOT INT8 (5) — the runtime
   // enum keeps signed/unsigned distinct so any future ordered-comparison
   // or arithmetic backend can dispatch correctly.
-  // CHECK: hip.nonzero(%[[CTX6]]) ins(%[[IN6]] : tensor<2x4x8xui8>) outs(%[[INIT6]] : tensor<3x?xi64>) {input_data_type = 7 : i64}
+  // CHECK: hip.nonzero(%[[CTX6]]) ins(%[[IN6]] : tensor<2x4x8xui8>) outs(%[[INIT6]], %[[CNT6]] : tensor<3x?xi64>, tensor<1xi32>) {input_data_type = 7 : i64}
 }

--- a/test/lit/Conversion/onnx-to-hip/test_scatter_nd.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_scatter_nd.mlir
@@ -25,12 +25,16 @@ module {
     %r = "onnx.ScatterND"(%data, %indices, %updates)
         : (tensor<8xf32>, tensor<4x1xi64>, tensor<4xf32>) -> tensor<8xf32>
 
+    // No NonZero upstream -> a dummy 1xi32 valid_count init is added as the
+    // 4th `ins` operand and has_valid_count stays false (default, elided).
     // CHECK-NOT: onnx.ScatterND
     // CHECK: tensor.empty() : tensor<8xf32>
+    // CHECK: tensor.empty() : tensor<1xi32>
     // CHECK: hip.scatter_nd({{.*}}) ins(
-    // CHECK-SAME: : tensor<8xf32>, tensor<4x1xi64>, tensor<4xf32>)
+    // CHECK-SAME: : tensor<8xf32>, tensor<4x1xi64>, tensor<4xf32>, tensor<1xi32>)
     // CHECK-SAME: outs({{.*}} : tensor<8xf32>)
     // CHECK-NOT: reduction
+    // CHECK-NOT: has_valid_count
 
     return %r : tensor<8xf32>
   }
@@ -48,7 +52,7 @@ module {
 
     // CHECK-NOT: onnx.ScatterND
     // CHECK: hip.scatter_nd({{.*}}) ins(
-    // CHECK-SAME: : tensor<4x4x4xf32>, tensor<2x1xi64>, tensor<2x4x4xf32>)
+    // CHECK-SAME: : tensor<4x4x4xf32>, tensor<2x1xi64>, tensor<2x4x4xf32>, tensor<1xi32>)
     // CHECK-SAME: outs({{.*}} : tensor<4x4x4xf32>)
     // CHECK-NOT: reduction
 
@@ -110,5 +114,28 @@ module {
   // CHECK-DAG: %[[A1:.*]] = arith.constant 1 : index
   // CHECK-DAG: %[[D1:.*]] = tensor.dim %[[D]], %[[A1]] : tensor<?x?xf32>
   // CHECK: tensor.empty(%[[D0]], %[[D1]]) : tensor<?x?xf32>
-  // CHECK: hip.scatter_nd({{.*}}) ins({{.*}}, {{.*}}, {{.*}} : tensor<?x?xf32>, tensor<2x2xi64>, tensor<2xf32>) outs({{.*}} : tensor<?x?xf32>)
+  // CHECK: hip.scatter_nd({{.*}}) ins({{.*}}, {{.*}}, {{.*}}, {{.*}} : tensor<?x?xf32>, tensor<2x2xi64>, tensor<2xf32>, tensor<1xi32>) outs({{.*}} : tensor<?x?xf32>)
+
+  // Backtrace: indices originate from NonZero (through a Transpose), so the
+  // ScatterND must reuse the NonZero's count_buf (result #1) as valid_count
+  // and set has_valid_count = true. This is the canonical VLM
+  // NonZero -> Transpose -> ScatterND placeholder-substitution chain.
+  func.func @test_scatter_nd_backtrace_nonzero(
+      %cond: tensor<4x4xi1>,
+      %data: tensor<4x4xf32>,
+      %updates: tensor<?xf32>) -> tensor<4x4xf32> {
+    %nz = "onnx.NonZero"(%cond) : (tensor<4x4xi1>) -> tensor<2x?xi64>
+    %t = "onnx.Transpose"(%nz) {perm = [1, 0]}
+        : (tensor<2x?xi64>) -> tensor<?x2xi64>
+    %r = "onnx.ScatterND"(%data, %t, %updates)
+        : (tensor<4x4xf32>, tensor<?x2xi64>, tensor<?xf32>) -> tensor<4x4xf32>
+    return %r : tensor<4x4xf32>
+  }
+
+  // CHECK-LABEL: func.func @test_scatter_nd_backtrace_nonzero
+  // The NonZero converts to a two-result hip.nonzero (indices + count_buf).
+  // CHECK: %[[NZ:.*]]:2 = hip.nonzero
+  // No dummy 1xi32 init is created here — valid_count is the NonZero count.
+  // CHECK: hip.scatter_nd
+  // CHECK-SAME: has_valid_count = true
 }

--- a/test/lit/Dialect/hip-infer-shapes.mlir
+++ b/test/lit/Dialect/hip-infer-shapes.mlir
@@ -856,20 +856,22 @@ func.func @refine_layer_norm_variadic_three_outs(
 // dependent shapes.
 // CHECK-LABEL: func.func @refine_nonzero_data_dependent_dim1
 // CHECK:         %[[E:.*]] = tensor.empty(%{{.*}}, %{{.*}}) : tensor<?x?xi64>
-// CHECK:         %[[Y:.*]] = hip.nonzero
-// CHECK-SAME:      outs(%[[E]] : tensor<?x?xi64>){{.*}}: tensor<?x?xi64>
-// CHECK:         return %[[Y]] : tensor<?x?xi64>
+// CHECK:         %[[C:.*]] = tensor.empty() : tensor<1xi32>
+// CHECK:         %[[Y:.*]]:2 = hip.nonzero
+// CHECK-SAME:      outs(%[[E]], %[[C]] : tensor<?x?xi64>, tensor<1xi32>)
+// CHECK:         return %[[Y]]#0 : tensor<?x?xi64>
 func.func @refine_nonzero_data_dependent_dim1(
     %ctx: !hip.context,
     %x: tensor<3x4xf16>,
     %d0: index, %d1: index)
     -> tensor<?x?xi64> {
   %e = tensor.empty(%d0, %d1) : tensor<?x?xi64>
-  %y = hip.nonzero(%ctx) ins(%x : tensor<3x4xf16>)
-                          outs(%e : tensor<?x?xi64>)
+  %c = tensor.empty() : tensor<1xi32>
+  %y:2 = hip.nonzero(%ctx) ins(%x : tensor<3x4xf16>)
+                          outs(%e, %c : tensor<?x?xi64>, tensor<1xi32>)
                           {input_data_type = 1 : i64}
-                          : tensor<?x?xi64>
-  return %y : tensor<?x?xi64>
+                          : tensor<?x?xi64>, tensor<1xi32>
+  return %y#0 : tensor<?x?xi64>
 }
 
 // -----


### PR DESCRIPTION
## Summary

Lowering-half of the #284 ABI train (**NonZero / ScatterND slice**, the GPU row-count dataflow). #284's runtime ships `wrap_nonzero` (9-arg, +`count_ptr`/`input_dims`) and `wrap_scatter_nd` (16-arg, +`count_ptr`), but the compiler half still emitted the old 7-/15-arg calls -- a latent ABI mismatch that only the VLM embedding `NonZero -> Transpose -> ScatterND` placeholder-substitution chain exercises. This brings the op defs, conversions and lowerings in line.

**NonZero** gains a second DPS output `count_buf` (`memref<1xi32>`) that receives the data-dependent non-zero count at runtime (kernel atomicAdd):
- `getDpsInitsMutable` now spans `{y, count_buf}` so the shared `HipDpsOp::reifyResultShapes` reifies both for free.
- `autoInfer=0` + a hand-written 2-result `inferReturnTypes` (the auto-generated body pushes only the single `outsAccessor` result).
- `NonZeroLowering` emits the 9-arg call (`count_ptr` + a stack `input_dims` array).

**ScatterND** gains a `valid_count` input operand + `has_valid_count` attr:
- `ScatterNDConversion` backtraces the `indices` operand (through Transpose/Reshape/Cast/... and their hip/tensor equivalents) to an upstream `hip.nonzero` and wires its `count_buf` as `valid_count` (`has_valid_count=true`); otherwise a dummy `1xi32` (`false`, never read). Defers when an unconverted `onnx.NonZero` is found so the greedy rewriter retries post-conversion.
- `ScatterNDLowering` emits the 16-arg call (`count_ptr` = the `valid_count` ptr, or null when `has_valid_count=false`). Operand-only change -> single-result auto-infer is untouched (low risk).

> This is the `count_buf`/reify-surgery half that PR-3 was split into. It is **independent of** and **parallel to** #304 (Gather slice) -- both branch directly off #284 and touch disjoint files, so they can merge in any order.

## Test plan

- [x] Full rebuild + install (tablegen regen) -- green
- [x] `ctest -R MorphizenMLIRLitTests` -- 100% pass
- [x] hip-to-llvm + onnx-to-hip `test_nonzero` / `test_scatter_nd` updated to the new assembly + sigs
- [x] Added `NonZero -> Transpose -> ScatterND` backtrace regression (asserts `has_valid_count = true` + 2-result `hip.nonzero`)
- [x] `hip-infer-shapes` nonzero case updated to the 2-out form
- [x] pre-commit (clang-format + license) -- pass

## Dependencies

Base: **#284** (the matching runtime). Parallel to #304; merge after #284.