### PR TITLE
fix(dialect): add /bigobj to HipDialectIR on MSVC

### DIFF
--- a/lib/Dialect/IR/CMakeLists.txt
+++ b/lib/Dialect/IR/CMakeLists.txt
@@ -17,6 +17,10 @@ add_dependencies(HipDialectIR
   HipOpsIncGen
 )
 
+if(MSVC)
+  target_compile_options(HipDialectIR PRIVATE /bigobj)
+endif()
+
 target_link_libraries(HipDialectIR PUBLIC
   MLIRIR
   MLIRSupport


### PR DESCRIPTION
## Summary

- `HipDialect.cpp` is a large TableGen-generated file that exceeds MSVC's default COFF object section limit (65535), causing fatal error `C1128: number of sections exceeded object file format limit`
- Add `target_compile_options(HipDialectIR PRIVATE /bigobj)` guarded by `if(MSVC)` so the extended section limit is applied on Windows only
- No behavioral change — `/bigobj` is a compiler bookkeeping format switch only

## Test plan

- [ ] Build passes on Windows with MSVC (verified locally: `python build.py` completes successfully targeting gfx1151)
- [ ] Linux/Mac builds are unaffected (`if(MSVC)` guard)