### PR TITLE
feat(onnx-to-hip): vision/projector compute ops + Conv/Matmul ABI (PR-9, ex #259)

### DIFF
--- a/lib/Conversion/HipToLLVM/ConvLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ConvLowering.cpp
@@ -17,7 +17,27 @@ namespace {
 //                                     output, output_h, output_w, kernel_h,
 //                                     kernel_w, stride_h, stride_w, pad_top,
 //                                     pad_left, pad_bottom, pad_right,
-//                                     dilation_h, dilation_w, group)
+//                                     dilation_h, dilation_w, group, data_type)
+//
+// Before:
+//   %out = hip.conv(%ctx) ins(%in, %w, %b :
+//                              memref<1x3x896x896xf16, 1>,
+//                              memref<1152x3x14x14xf16, 1>,
+//                              memref<1152xf16, 1>)
+//                          outs(%o : memref<1x1152x64x64xf16, 1>)
+//                          {kernel_shape=[14,14], strides=[14,14], ...}
+// After:
+//   llvm.call @wrap_miopenConvolutionForward(%ctx, %in, 1, 3, 896, 896,
+//                                              %w, 1152, %b, %o, 64, 64,
+//                                              14, 14, 14, 14, 0, 0, 0, 0,
+//                                              1, 1, 1,
+//                                              /*data_type=*/1 /* f16 */)
+//
+// The `data_type` value is derived from the OUTPUT memref's element type and
+// applied uniformly to all three MIOpen tensor descriptors. MIOpen requires
+// input / weights / output to share the same dtype; this is enforced by the
+// host-side typing rule in OnnxToHip (`init` tensor allocated with
+// `resultType.getElementType()`).
 struct ConvOpLowering : public ConvertOpToLLVMPattern<ConvOp> {
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
@@ -59,7 +79,8 @@ struct ConvOpLowering : public ConvertOpToLLVMPattern<ConvOp> {
     //     int64_t pad_right,      // Padding right
     //     int64_t dilation_h,     // Dilation height
     //     int64_t dilation_w,     // Dilation width
-    //     int64_t group           // Number of groups
+    //     int64_t group,          // Number of groups
+    //     int64_t data_type       // HIPDNN_EP_DATATYPE_* for I/O+weights
     // );
     //
     // Returns: 0 on success, non-zero on error
@@ -149,8 +170,19 @@ struct ConvOpLowering : public ConvertOpToLLVMPattern<ConvOp> {
     Value dilationW = createI64Const(getI64(dilations[1]));
     Value groupVal = createI64Const(group);
 
+    // dtype: derive from the output memref's element type. All three buffers
+    // (input, weights, output) must share this dtype — see the typing rule
+    // in OnnxToHip::ConvConversion which uses resultType.getElementType()
+    // for the allocated output. The runtime fails fast if the dtype is
+    // unsupported.
+    int64_t dataTypeEnum = getHipdnnDataType(outputType.getElementType());
+    if (dataTypeEnum < 0)
+      return op.emitError("hip.conv: unsupported output element type ")
+             << outputType.getElementType();
+    Value dataType = createI64Const(dataTypeEnum);
+
     // Build function signature
-    SmallVector<Type, 24> paramTypes = {
+    SmallVector<Type, 25> paramTypes = {
         ptrType, // state
         ptrType, // input
         i64Type, // input_n
@@ -173,7 +205,8 @@ struct ConvOpLowering : public ConvertOpToLLVMPattern<ConvOp> {
         i64Type, // pad_right
         i64Type, // dilation_h
         i64Type, // dilation_w
-        i64Type  // group
+        i64Type, // group
+        i64Type  // data_type
     };
 
     // Lookup or create the runtime function
@@ -183,11 +216,11 @@ struct ConvOpLowering : public ConvertOpToLLVMPattern<ConvOp> {
       return failure();
 
     // Build argument list matching the signature
-    SmallVector<Value, 24> args = {
-        statePtr,   inputPtr, inputN,    inputC,    inputH,  inputW,
-        weightsPtr, weightsK, biasPtr,   outputPtr, outputH, outputW,
-        kernelH,    kernelW,  strideH,   strideW,   padTop,  padLeft,
-        padBottom,  padRight, dilationH, dilationW, groupVal};
+    SmallVector<Value, 25> args = {
+        statePtr,   inputPtr, inputN,    inputC,    inputH,   inputW,
+        weightsPtr, weightsK, biasPtr,   outputPtr, outputH,  outputW,
+        kernelH,    kernelW,  strideH,   strideW,   padTop,   padLeft,
+        padBottom,  padRight, dilationH, dilationW, groupVal, dataType};
 
     // Call the runtime function
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);

--- a/lib/Conversion/HipToLLVM/MatmulLowering.cpp
+++ b/lib/Conversion/HipToLLVM/MatmulLowering.cpp
@@ -73,12 +73,74 @@ struct MatmulOpLowering : public ConvertOpToLLVMPattern<MatmulOp> {
     unsigned elemBits = AType.getElementType().getIntOrFloatBitWidth();
     Value elemSize = createI64Const(elemBits / 8);
 
+    // b_batch_stride: the per-batch stride (in elements) for hipBLASLt's
+    // STRIDED_BATCH_OFFSET on layA when batch_count > 1. Two distinct B
+    // memref shapes both reach this site with batch_count > 1 and need
+    // DIFFERENT strides:
+    //   * Rank-2 broadcast weight `[K, N]` → one matrix shared across all
+    //     batches → stride = 0.
+    //   * Rank-N per-batch weight `[d_0, ..., d_{N-3}, K, N]` whose leading
+    //     dims hold more than one matrix → stride = K * N.
+    //   * Rank-N weight whose leading dims multiply to 1 (e.g. `[1, K, N]`,
+    //     `[1, 1, K, N]`) → still ONE matrix; stride = 0.
+    // Previously encoded as a `b_batched` bool keyed on `BRank > 2`. That
+    // misclassified the `[1, K, N]` leading-one case as per-batch, causing
+    // OOB reads of `K*N` elements past the end of the weight on every batch
+    // beyond the first.
+    //
+    // Leading-dim product is computed at compile time when all leading dims
+    // are static (the common case for shipping models). When any leading dim
+    // is dynamic we emit a runtime `select` over the leading-product so the
+    // descriptor cache picks the right pre-built layout per call.
+    //
+    // Before:
+    //   hip.matmul ins(%A, %B : memref<2x128x4096xf16>,
+    //   memref<1x4096x1024xf16>)
+    // After:
+    //   %stride = llvm.mlir.constant(0 : i64) : i64   // leading product is 1
+    //   llvm.call @wrap_hipblasLtMatmul(..., %stride) : (...) -> i32
+    Value bBatchStride;
+    if (BRank == 2) {
+      bBatchStride = createI64Const(0);
+    } else {
+      bool allLeadingStatic = true;
+      int64_t staticLeadingProduct = 1;
+      for (int64_t i : llvm::seq<int64_t>(0, BRank - 2)) {
+        if (BType.isDynamicDim(i)) {
+          allLeadingStatic = false;
+          break;
+        }
+        staticLeadingProduct *= BType.getDimSize(i);
+      }
+      if (allLeadingStatic) {
+        bBatchStride = (staticLeadingProduct <= 1)
+                           ? createI64Const(0)
+                           : LLVM::MulOp::create(rewriter, loc, K, N).getRes();
+      } else {
+        Value one = createI64Const(1);
+        Value zero = createI64Const(0);
+        Value leadingProduct = one;
+        for (int64_t i : llvm::seq<int64_t>(0, BRank - 2)) {
+          Value dim = BDesc.size(rewriter, loc, i);
+          leadingProduct =
+              LLVM::MulOp::create(rewriter, loc, leadingProduct, dim).getRes();
+        }
+        Value isBroadcast = LLVM::ICmpOp::create(
+            rewriter, loc, LLVM::ICmpPredicate::sle, leadingProduct, one);
+        Value kn = LLVM::MulOp::create(rewriter, loc, K, N).getRes();
+        bBatchStride =
+            LLVM::SelectOp::create(rewriter, loc, isBroadcast, zero, kn)
+                .getRes();
+      }
+    }
+
     // Runtime signature:
     // int wrap_hipblasLtMatmul(RuntimeState* state,
     //                          const void* A, const void* B, void* output,
     //                          int64_t M, int64_t N, int64_t K,
-    //                          int64_t batch_count, int64_t elem_size)
-    SmallVector<Type, 9> paramTypes = {
+    //                          int64_t batch_count, int64_t elem_size,
+    //                          int64_t b_batch_stride)
+    SmallVector<Type, 10> paramTypes = {
         ptrType, // state
         ptrType, // A
         ptrType, // B
@@ -87,7 +149,8 @@ struct MatmulOpLowering : public ConvertOpToLLVMPattern<MatmulOp> {
         i64Type, // N
         i64Type, // K
         i64Type, // batch_count
-        i64Type  // elem_size
+        i64Type, // elem_size
+        i64Type  // b_batch_stride
     };
 
     FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
@@ -95,8 +158,9 @@ struct MatmulOpLowering : public ConvertOpToLLVMPattern<MatmulOp> {
     if (failed(funcOp))
       return failure();
 
-    SmallVector<Value, 9> args = {statePtr, APtr, BPtr,       outputPtr, M,
-                                  N,        K,    batchCount, elemSize};
+    SmallVector<Value, 10> args = {statePtr, APtr,        BPtr, outputPtr,
+                                   M,        N,           K,    batchCount,
+                                   elemSize, bBatchStride};
 
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
     rewriter.eraseOp(op);

--- a/lib/Conversion/OnnxToHip/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHip/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(OnnxToHip STATIC
   LinearAttentionConversion.cpp
   RangeConversion.cpp
   FastGeluFusion.cpp
+  ProjectorOpsRewrites.cpp
   EqualConversion.cpp
   DivConversion.cpp
   ReduceMaxConversion.cpp

--- a/lib/Conversion/OnnxToHip/FastGeluFusion.cpp
+++ b/lib/Conversion/OnnxToHip/FastGeluFusion.cpp
@@ -129,6 +129,25 @@ static std::optional<double> getScalarFloatConstant(mlir::Value v) {
     return std::sqrt(*inner);
   }
 
+  // Reciprocal of a constant. Exact-Gelu inlined chains in HF Qwen-VL-style
+  // exports encode 1/sqrt(2) as `Reciprocal(Sqrt(Constant(2)))` rather than
+  // a baked literal, so the chain to a constant goes through both Sqrt and
+  // Reciprocal before reaching the leaf onnx.Constant.
+  if (opName == "onnx.Reciprocal" && def->getNumOperands() >= 1) {
+    auto inner = getScalarFloatConstant(def->getOperand(0));
+    if (!inner || *inner == 0.0)
+      return std::nullopt;
+    return 1.0 / *inner;
+  }
+
+  // Div of two constants — sometimes 1/sqrt(2) ships as Div(1, Sqrt(2)).
+  if (opName == "onnx.Div" && def->getNumOperands() == 2) {
+    auto num = getScalarFloatConstant(def->getOperand(0));
+    auto den = getScalarFloatConstant(def->getOperand(1));
+    if (num && den && *den != 0.0)
+      return *num / *den;
+  }
+
   return std::nullopt;
 }
 
@@ -170,6 +189,196 @@ static bool isBinaryOpWithConst(mlir::Operation *op, llvm::StringRef opName,
   outOther = other;
   return true;
 }
+
+/// Vision variant: Gemma-3 SigLIP MLP inlines the FastGelu chain with three
+/// substitutions vs. the canonical pattern matched by `InlinedFastGeluToGelu`:
+///
+///   1. `Pow(x, 3)`              -> `Mul(x, Mul(x, x))`   (cube via repeated
+///   Mul)
+///   2. `Sum(a, b)`              -> `Add(a, b)`           (Add instead of Sum)
+///   3. `Mul(Mul(0.5, x), phi)`  -> `Mul(0.5, Mul(x, phi))` (constant on the
+///                                                          outer Mul)
+///
+/// Walk (all op names use `onnx.Add`/`onnx.Mul`, NOT `onnx.Sum`):
+///
+///   xx       = Mul(x, x)                 // x^2
+///   xxx      = Mul(x, xx)                // x^3 (operand order may vary)
+///   scaled   = Mul(0.044715, xxx)
+///   inner    = Add(x, scaled)
+///   tanh_in  = Mul(sqrt(2/π), inner)
+///   tanh     = Tanh(tanh_in)
+///   phi      = Add(1.0, tanh)
+///   x_phi    = Mul(x, phi)               // not yet * 0.5
+///   y        = Mul(0.5, x_phi)
+///
+/// Implemented separately rather than polymorphically with the canonical
+/// pattern so each match path stays readable and its diagnostics keep their
+/// per-step granularity (the `tanh.in.mul_sqrt2pi :: onnx.Mul` line documented
+/// in CLAUDE.md is the regression signal for that pattern; this pattern's
+/// failure histogram doesn't conflate the two).
+struct InlinedFastGeluVisionToGelu : public mlir::RewritePattern {
+  InlinedFastGeluVisionToGelu(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.Tanh", /*benefit=*/1, ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *tanhOp,
+                  mlir::PatternRewriter &rewriter) const override {
+    if (tanhOp->getNumOperands() != 1 || tanhOp->getNumResults() != 1)
+      return rewriter.notifyMatchFailure(tanhOp, "tanh.arity");
+
+    // tanh_in = Mul(sqrt(2/π), inner)
+    mlir::Operation *tanhInputMul = tanhOp->getOperand(0).getDefiningOp();
+    if (!tanhInputMul)
+      return rewriter.notifyMatchFailure(tanhOp, "tanh.in.defop_null");
+    mlir::Value c2pi, inner;
+    if (!isBinaryOpWithConst(tanhInputMul, "onnx.Mul",
+                             /*sqrt(2/π)*/ 0.7978845608, c2pi, inner))
+      return rewriter.notifyMatchFailure(tanhOp, [&](mlir::Diagnostic &d) {
+        d << "tanh.in.mul_sqrt2pi.vision (observed: " << tanhInputMul->getName()
+          << ")";
+      });
+
+    // inner = Add(x, scaled);  scaled = Mul(0.044715, xxx);  xxx = Mul(x,
+    // Mul(x, x))
+    mlir::Operation *innerOp = inner.getDefiningOp();
+    if (!innerOp || innerOp->getName().getStringRef() != "onnx.Add" ||
+        innerOp->getNumOperands() != 2)
+      return rewriter.notifyMatchFailure(tanhOp, [&](mlir::Diagnostic &d) {
+        d << "inner.add.vision (observed: "
+          << (innerOp ? innerOp->getName().getStringRef() : "<null>") << ")";
+      });
+
+    // Probe each Add operand: the non-`x` operand is `scaled = Mul(0.044715,
+    // xxx)`
+    mlir::Value scaled, x;
+    for (mlir::Value cand : innerOp->getOperands()) {
+      mlir::Operation *def = cand.getDefiningOp();
+      if (def && def->getName().getStringRef() == "onnx.Mul" &&
+          def->getNumOperands() == 2) {
+        auto [c, other] = matchCommutativeConst(def, 0.044715);
+        if (c) {
+          scaled = cand;
+          x = (cand == innerOp->getOperand(0)) ? innerOp->getOperand(1)
+                                               : innerOp->getOperand(0);
+          break;
+        }
+      }
+    }
+    if (!scaled || !x)
+      return rewriter.notifyMatchFailure(tanhOp, "scaled_pow.044715.vision");
+
+    mlir::Operation *scaledOp = scaled.getDefiningOp();
+    mlir::Value c044715, xxx;
+    if (!isBinaryOpWithConst(scaledOp, "onnx.Mul", 0.044715, c044715, xxx))
+      return rewriter.notifyMatchFailure(tanhOp, "scaled_pow.mul.vision");
+
+    // xxx = Mul(x, xx);  xx = Mul(x, x). The outer Mul is commutative — the
+    // canonical Gemma-3 export is Mul(x, xx) but accept either operand order.
+    mlir::Operation *xxxOp = xxx.getDefiningOp();
+    if (!xxxOp || xxxOp->getName().getStringRef() != "onnx.Mul" ||
+        xxxOp->getNumOperands() != 2)
+      return rewriter.notifyMatchFailure(tanhOp, "xxx.not_mul");
+    mlir::Value xx;
+    if (xxxOp->getOperand(0) == x)
+      xx = xxxOp->getOperand(1);
+    else if (xxxOp->getOperand(1) == x)
+      xx = xxxOp->getOperand(0);
+    else
+      return rewriter.notifyMatchFailure(tanhOp, "xxx.x_not_in_operands");
+    mlir::Operation *xxOp = xx.getDefiningOp();
+    if (!xxOp || xxOp->getName().getStringRef() != "onnx.Mul" ||
+        xxOp->getNumOperands() != 2)
+      return rewriter.notifyMatchFailure(tanhOp, "xx.not_mul");
+    if (xxOp->getOperand(0) != x || xxOp->getOperand(1) != x)
+      return rewriter.notifyMatchFailure(tanhOp, "xx.not_x_squared");
+
+    // Forward walk:
+    //   phi   = Add(1.0, tanh)        (Add not Sum)
+    //   x_phi = Mul(x, phi)
+    //   y     = Mul(0.5, x_phi)
+    mlir::Value tanhRes = tanhOp->getResult(0);
+    if (!tanhRes.hasOneUse())
+      return rewriter.notifyMatchFailure(tanhOp, "tanh.not_one_use");
+    mlir::Operation *phiOp = *tanhRes.getUsers().begin();
+    mlir::Value c1, tanhInPhi;
+    if (!isBinaryOpWithConst(phiOp, "onnx.Add", 1.0, c1, tanhInPhi))
+      return rewriter.notifyMatchFailure(tanhOp, [&](mlir::Diagnostic &d) {
+        d << "phi.add_one.vision (observed: " << phiOp->getName() << ")";
+      });
+    if (tanhInPhi != tanhRes)
+      return rewriter.notifyMatchFailure(tanhOp, "phi.tanh_mismatch.vision");
+
+    if (!phiOp->getResult(0).hasOneUse())
+      return rewriter.notifyMatchFailure(tanhOp, "phi.not_one_use");
+    mlir::Operation *xPhiOp = *phiOp->getResult(0).getUsers().begin();
+    if (xPhiOp->getName().getStringRef() != "onnx.Mul" ||
+        xPhiOp->getNumOperands() != 2)
+      return rewriter.notifyMatchFailure(tanhOp, "x_phi.not_mul.vision");
+    // The non-phi operand must be `x`.
+    mlir::Value xPhiOther;
+    for (mlir::Value cand : xPhiOp->getOperands()) {
+      if (cand != phiOp->getResult(0)) {
+        xPhiOther = cand;
+        break;
+      }
+    }
+    if (xPhiOther != x)
+      return rewriter.notifyMatchFailure(tanhOp, "x_phi.x_mismatch.vision");
+
+    if (!xPhiOp->getResult(0).hasOneUse())
+      return rewriter.notifyMatchFailure(tanhOp, "x_phi.not_one_use");
+    mlir::Operation *finalMulOp = *xPhiOp->getResult(0).getUsers().begin();
+    mlir::Value cHalf, xPhiInFinal;
+    if (!isBinaryOpWithConst(finalMulOp, "onnx.Mul", 0.5, cHalf, xPhiInFinal))
+      return rewriter.notifyMatchFailure(tanhOp, [&](mlir::Diagnostic &d) {
+        d << "final.mul_half.vision (observed: " << finalMulOp->getName()
+          << ")";
+      });
+    if (xPhiInFinal != xPhiOp->getResult(0))
+      return rewriter.notifyMatchFailure(tanhOp, "final.xphi_mismatch.vision");
+
+    // ── all matched; rewrite final Mul to onnx.Gelu(x, "tanh") ───────────
+    mlir::Location loc = finalMulOp->getLoc();
+    mlir::OperationState state(loc, "onnx.Gelu");
+    state.addOperands(x);
+    // Gelu output type == input type (same-shape unary). For an unranked
+    // input (rare on HF exports) the final Mul has the same shape as x by
+    // construction; any residual dynamic dims are resolved post-conversion
+    // by the HIP-dialect `--hip-infer-shapes` pass.
+    mlir::Type geluResultType = mlir::isa<mlir::RankedTensorType>(x.getType())
+                                    ? x.getType()
+                                    : finalMulOp->getResult(0).getType();
+    state.addTypes(geluResultType);
+    state.addAttribute("approximate", rewriter.getStringAttr("tanh"));
+    if (auto outputs =
+            finalMulOp->getAttrOfType<mlir::ArrayAttr>("node.outputs"))
+      state.addAttribute("node.outputs", outputs);
+    if (auto nodeName =
+            finalMulOp->getAttrOfType<mlir::StringAttr>("onnx_node_name"))
+      state.addAttribute("onnx_node_name", nodeName);
+    rewriter.setInsertionPoint(finalMulOp);
+    mlir::Operation *geluOp = rewriter.create(state);
+
+    rewriter.replaceOp(finalMulOp, geluOp->getResult(0));
+    auto eraseIfDead = [&rewriter](mlir::Operation *op) {
+      if (op && op->use_empty())
+        rewriter.eraseOp(op);
+    };
+    eraseIfDead(xPhiOp);
+    eraseIfDead(phiOp);
+    eraseIfDead(tanhOp);
+    eraseIfDead(tanhInputMul);
+    eraseIfDead(innerOp);
+    eraseIfDead(scaledOp);
+    eraseIfDead(xxxOp);
+    eraseIfDead(xxOp);
+
+    LLVM_DEBUG(llvm::dbgs() << "[" DEBUG_TYPE "] fused vision-variant chain at "
+                            << loc << "\n");
+    ++NumFastGeluFused;
+    return mlir::success();
+  }
+};
 
 struct InlinedFastGeluToGelu : public mlir::RewritePattern {
   InlinedFastGeluToGelu(mlir::MLIRContext *ctx)
@@ -294,7 +503,14 @@ struct InlinedFastGeluToGelu : public mlir::RewritePattern {
     mlir::Location loc = finalMulOp->getLoc();
     mlir::OperationState state(loc, "onnx.Gelu");
     state.addOperands(x);
-    state.addTypes(finalMulOp->getResult(0).getType());
+    // Gelu output type == input type (same-shape unary). For an unranked
+    // input (rare on HF exports) the final Mul has the same shape as x by
+    // construction; any residual dynamic dims are resolved post-conversion
+    // by the HIP-dialect `--hip-infer-shapes` pass.
+    mlir::Type geluResultType = mlir::isa<mlir::RankedTensorType>(x.getType())
+                                    ? x.getType()
+                                    : finalMulOp->getResult(0).getType();
+    state.addTypes(geluResultType);
     state.addAttribute("approximate", rewriter.getStringAttr("tanh"));
     // Preserve the original output name attribute so downstream IR dumps
     // and metadata stay readable.
@@ -340,11 +556,138 @@ struct InlinedFastGeluToGelu : public mlir::RewritePattern {
   }
 };
 
+/// Exact-Gelu (approximate="none") inlined chain — Erf-based.
+///
+/// Some ORT exports inline `Gelu(approximate="none")` instead of the Tanh
+/// approximation. Canonical inlined form:
+///
+///   scaled = Mul(x, 1/sqrt(2))      // 0.70710678...
+///   erf    = Erf(scaled)
+///   phi    = Sum(1.0, erf)          // or Add(1.0, erf); commutative
+///   half_x = Mul(0.5, x)            // or Mul(x, 0.5); commutative
+///   y      = Mul(half_x, phi)       // or Mul(phi, half_x); commutative
+///
+/// Rewritten to `onnx.Gelu(x) {approximate = "none"}` which is then handled
+/// by the existing `GeluToHip` converter (lowers to `hip.gelu` with the
+/// non-tanh runtime kernel).
+///
+/// Anchored on `onnx.Erf` to keep the matcher cheap — Erf is rare in non-
+/// Gelu graphs. The pattern walks forward from Erf to its Sum/Add consumer
+/// and then to the final Mul, checking the half-x branch resolves to the
+/// same SSA `x` as the `Mul(x, 1/sqrt(2))` operand. Multi-use Erf or Sum
+/// results break the pattern (we'd then duplicate the chain when rewriting
+/// to Gelu — fine for correctness but pessimises the IR; leave it for now).
+///
+/// Before:
+///   %scaled = onnx.Mul(%x, %const_invsqrt2)
+///   %erf    = onnx.Erf(%scaled)
+///   %phi    = onnx.Sum(%const_one, %erf)
+///   %hx     = onnx.Mul(%const_half, %x)
+///   %y      = onnx.Mul(%hx, %phi) : tensor<?xf16>
+///
+/// After:
+///   %y = onnx.Gelu(%x) {approximate = "none"} : tensor<?xf16>
+struct InlinedExactGeluToGelu : public mlir::RewritePattern {
+  InlinedExactGeluToGelu(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.Erf", /*benefit=*/2, ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *erfOp,
+                  mlir::PatternRewriter &rewriter) const override {
+    if (erfOp->getNumOperands() != 1 || erfOp->getNumResults() != 1)
+      return rewriter.notifyMatchFailure(erfOp, "erf.arity");
+
+    // scaled = Mul(x, 1/sqrt(2))
+    mlir::Operation *scaledOp = erfOp->getOperand(0).getDefiningOp();
+    mlir::Value invSqrt2, x;
+    if (!isBinaryOpWithConst(scaledOp, "onnx.Mul",
+                             /*1/sqrt(2)*/ 0.7071067811865, invSqrt2, x))
+      return rewriter.notifyMatchFailure(erfOp, "erf.in.mul_invsqrt2");
+
+    // erf has exactly one user, which must be the Sum/Add producing phi.
+    if (!erfOp->getResult(0).hasOneUse())
+      return rewriter.notifyMatchFailure(erfOp, "erf.multi_use");
+    mlir::Operation *phiOp = *erfOp->getResult(0).getUsers().begin();
+    if (!phiOp ||
+        (phiOp->getName().getStringRef() != "onnx.Sum" &&
+         phiOp->getName().getStringRef() != "onnx.Add") ||
+        phiOp->getNumOperands() != 2)
+      return rewriter.notifyMatchFailure(erfOp, [&](mlir::Diagnostic &d) {
+        d << "phi.sum_or_add (observed: "
+          << (phiOp ? phiOp->getName().getStringRef() : "<null>") << ")";
+      });
+    mlir::Value oneConst, erfVal;
+    // The non-erf operand must be the constant 1.0.
+    mlir::Value lhs = phiOp->getOperand(0), rhs = phiOp->getOperand(1);
+    if (lhs == erfOp->getResult(0) && isScalarFloatNear(rhs, 1.0)) {
+      erfVal = lhs;
+      oneConst = rhs;
+    } else if (rhs == erfOp->getResult(0) && isScalarFloatNear(lhs, 1.0)) {
+      erfVal = rhs;
+      oneConst = lhs;
+    } else {
+      return rewriter.notifyMatchFailure(erfOp, "phi.no_one_constant");
+    }
+
+    // phi has exactly one user, the final Mul.
+    if (!phiOp->getResult(0).hasOneUse())
+      return rewriter.notifyMatchFailure(erfOp, "phi.multi_use");
+    mlir::Operation *finalMul = *phiOp->getResult(0).getUsers().begin();
+    if (!finalMul || finalMul->getName().getStringRef() != "onnx.Mul" ||
+        finalMul->getNumOperands() != 2)
+      return rewriter.notifyMatchFailure(erfOp, "final_mul.shape");
+
+    // Other operand of finalMul must be a `Mul(0.5, x)` or `Mul(x, 0.5)`
+    // where x matches the scaled-input x.
+    mlir::Value otherOperand = (finalMul->getOperand(0) == phiOp->getResult(0))
+                                   ? finalMul->getOperand(1)
+                                   : finalMul->getOperand(0);
+    if (otherOperand == phiOp->getResult(0))
+      return rewriter.notifyMatchFailure(erfOp, "final_mul.no_phi_operand");
+    mlir::Operation *halfMulOp = otherOperand.getDefiningOp();
+    mlir::Value halfConst, halfX;
+    if (!isBinaryOpWithConst(halfMulOp, "onnx.Mul", /*0.5*/ 0.5, halfConst,
+                             halfX))
+      return rewriter.notifyMatchFailure(erfOp, "half_mul.no_half_constant");
+    if (halfX != x)
+      return rewriter.notifyMatchFailure(erfOp, "half_mul.x_mismatch_scaled_x");
+
+    // All checks passed — replace finalMul with onnx.Gelu(x, "none").
+    mlir::Type resultTy = finalMul->getResult(0).getType();
+    mlir::OperationState gelu(finalMul->getLoc(), "onnx.Gelu");
+    gelu.addOperands(x);
+    gelu.addTypes(resultTy);
+    gelu.addAttribute("approximate", rewriter.getStringAttr("none"));
+    mlir::Value y = rewriter.create(gelu)->getResult(0);
+    rewriter.replaceOp(finalMul, y);
+    // Erase the now-dead chain explicitly in reverse-topological order. The
+    // module-level DCE walk in OnnxToHip is a backstop but doesn't always
+    // catch arith subtrees emitted by other patterns once their consumers
+    // get rewritten — explicit erasure here mirrors the canonical FastGelu
+    // pattern's discipline and keeps the IR clean for the structural
+    // "no onnx.* should survive" check.
+    if (halfMulOp && halfMulOp->use_empty())
+      rewriter.eraseOp(halfMulOp);
+    if (phiOp && phiOp->use_empty())
+      rewriter.eraseOp(phiOp);
+    if (erfOp && erfOp->use_empty())
+      rewriter.eraseOp(erfOp);
+    if (scaledOp && scaledOp->use_empty())
+      rewriter.eraseOp(scaledOp);
+    ++NumFastGeluFused;
+    LLVM_DEBUG(llvm::dbgs()
+               << "[" DEBUG_TYPE "] fused exact (Erf-based) Gelu at "
+               << finalMul->getLoc() << "\n");
+    return mlir::success();
+  }
+};
+
 } // namespace
 
 void populateFastGeluFusionPatterns(mlir::RewritePatternSet &patterns,
                                     mlir::MLIRContext *ctx) {
-  patterns.add<InlinedFastGeluToGelu>(ctx);
+  patterns.add<InlinedFastGeluToGelu, InlinedFastGeluVisionToGelu,
+               InlinedExactGeluToGelu>(ctx);
 }
 
 } // namespace hip

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -704,26 +704,79 @@ void ConvertOnnxToHipPass::runOnOperation() {
     //   * Inlined FastGelu primitive chain (Pow/Mul/Sum/Tanh) ->
     //     onnx.Gelu(approximate="tanh"), restoring the MorphiZen-supported
     //     form for ORT paths that inline the Gelu function body.
-    // Both patterns are value-based and require the literal constants to
+    //   * Projector/vision decompositions (patch-embed Conv-ND -> Gemm,
+    //     AveragePool(kernel==stride) -> Reshape/Transpose/ReduceMean,
+    //     Pow(x,c) -> Mul chain, broadcasting Div -> Mul(Reciprocal)).
+    //     ProjectorOpsRewrites emits NEW `onnx.*` ops (Reshape, Gemm,
+    //     ReduceMean, ...) that a subsequent round must visit (e.g. the
+    //     AveragePool decomposition's emitted Reshape feeds the next
+    //     round's ReduceMean handling), so the set is applied in a
+    //     fixed-point loop until quiescence rather than a single pass.
+    // All patterns are value-based and require the literal constants to
     // still be inline in `onnx.Constant` `value` attributes — once the
     // constants are externalized to memref.get_global the matchers break.
-    // ExistingOps strictness is sufficient: no pattern produces an
-    // op another root-matches on (Gather rewrites to tensor.*; FastGelu
-    // rewrites to onnx.Gelu, never producing a fresh onnx.Tanh;
-    // ReshapeShapeFold roots on onnx.Reshape and only swaps its shape
-    // operand in place — the re-visit fails the "operand1 is onnx.Shape"
-    // guard, so it converges without looping).
+    // ExistingOps strictness is sufficient: the patterns either rewrite to
+    // tensor.* (Gather) or emit `onnx.*` ops. FastGelu (-> onnx.Gelu) and
+    // ReshapeShapeFold (roots on onnx.Reshape, only swaps its shape operand
+    // in place; the re-visit fails the "operand1 is onnx.Shape" guard) are
+    // convergent. ProjectorOpsRewrites emits NEW `onnx.*` ops (Reshape, Gemm,
+    // ReduceMean, ...) that a subsequent round must visit (e.g. the
+    // AveragePool decomposition's emitted Reshape feeds the next round's
+    // ReduceMean handling), so the set is applied in a fixed-point loop until
+    // quiescence rather than a single pass. Newly-emitted ops are given their
+    // result types in-place at emission (constructed explicitly from the dims
+    // the rewriter already knows), so no separate ONNX-level shape-inference
+    // pass is run between rounds — the HIP-dialect `--hip-infer-shapes` pass
+    // (pipeline tail, post-conversion) resolves any residual dynamic dims. A
+    // tiny RewriterBase::Listener flips a flag on any IR mutation; the loop
+    // breaks the first round that mutates nothing (capped at kMaxRounds as a
+    // safety net).
     {
-      mlir::RewritePatternSet preLoweringPatterns(ctx);
-      populateGatherShapeFoldPatterns(preLoweringPatterns, ctx);
-      populateReshapeShapeFoldPatterns(preLoweringPatterns, ctx);
-      populateFastGeluFusionPatterns(preLoweringPatterns, ctx);
-      mlir::GreedyRewriteConfig preLoweringConfig;
-      preLoweringConfig.setStrictness(
-          mlir::GreedyRewriteStrictness::ExistingOps);
-      if (mlir::failed(mlir::applyPatternsGreedily(
-              funcOp, std::move(preLoweringPatterns), preLoweringConfig)))
-        return signalPassFailure();
+      struct ChangeFlagListener final : public mlir::RewriterBase::Listener {
+        bool changed = false;
+        void notifyOperationInserted(mlir::Operation *,
+                                     mlir::OpBuilder::InsertPoint) override {
+          changed = true;
+        }
+        void notifyOperationModified(mlir::Operation *) override {
+          changed = true;
+        }
+        void notifyOperationReplaced(mlir::Operation *,
+                                     mlir::ValueRange) override {
+          changed = true;
+        }
+        void notifyOperationErased(mlir::Operation *) override {
+          changed = true;
+        }
+      };
+      constexpr int kMaxRounds = 4;
+      bool quiesced = false;
+      for (int round = 0; round < kMaxRounds; ++round) {
+        mlir::RewritePatternSet preLoweringPatterns(ctx);
+        populateGatherShapeFoldPatterns(preLoweringPatterns, ctx);
+        populateReshapeShapeFoldPatterns(preLoweringPatterns, ctx);
+        populateFastGeluFusionPatterns(preLoweringPatterns, ctx);
+        populateProjectorOpsRewritePatterns(preLoweringPatterns, ctx);
+        ChangeFlagListener listener;
+        mlir::GreedyRewriteConfig preLoweringConfig;
+        preLoweringConfig.setStrictness(
+            mlir::GreedyRewriteStrictness::ExistingOps);
+        preLoweringConfig.setListener(&listener);
+        if (mlir::failed(mlir::applyPatternsGreedily(
+                funcOp, std::move(preLoweringPatterns), preLoweringConfig)))
+          return signalPassFailure();
+        if (!listener.changed) {
+          quiesced = true;
+          break;
+        }
+      }
+      // If the loop never settles a future pattern set may rely on a
+      // rewrite the safety cap silently dropped — surface it so the next
+      // maintainer can raise the cap or find the bouncing pattern.
+      if (!quiesced)
+        funcOp.emitWarning()
+            << "convert-onnx-to-hip: pre-lowering round loop hit kMaxRounds="
+            << kMaxRounds << " without quiescence";
     }
     // Run ConstantOfShape folding BEFORE `lowerOnnxConstants` so it can
     // still see the original `onnx.Constant` (or `onnx.Shape`) as the

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
@@ -293,6 +293,19 @@ void populateReshapeShapeFoldPatterns(RewritePatternSet &patterns,
 void populateFastGeluFusionPatterns(RewritePatternSet &patterns,
                                     MLIRContext *ctx);
 
+/// Pre-lowering pattern set: decompose vision/projector ops that have no
+/// direct MorphiZen converter into supported primitives — patch-embed
+/// Conv-ND → Reshape/Gemm/Reshape, AveragePool(kernel==stride) →
+/// Reshape/Transpose/ReduceMean, Pow(x, c) → repeated Mul, ReduceMean →
+/// ReduceSum·(1/N), and broadcasting Div → Mul(x, Reciprocal). Emits
+/// `onnx.*` ops with result types built explicitly from the dims the
+/// rewriter already knows (no separate shape pass needed at emission;
+/// `--hip-infer-shapes` resolves any residual dynamic dims post-conversion).
+/// Runs in the same ExistingOps pre-lowering set as FastGeluFusion. See
+/// ProjectorOpsRewrites.cpp.
+void populateProjectorOpsRewritePatterns(RewritePatternSet &patterns,
+                                         MLIRContext *ctx);
+
 } // namespace hip
 } // namespace mlir
 

--- a/lib/Conversion/OnnxToHip/ProjectorOpsRewrites.cpp
+++ b/lib/Conversion/OnnxToHip/ProjectorOpsRewrites.cpp
@@ -1,0 +1,816 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- ProjectorOpsRewrites.cpp - Pre-lowering rewrites for projector ops --==//
+//
+// The Gemma-3 vision encoder's `multi_modal_projector` block uses three ops
+// that have no direct HIP converters: `onnx.Pow`, `onnx.ReduceMean`, and
+// `onnx.AveragePool`. Rather than introduce new HIP dialect ops + runtime
+// kernels for each, we rewrite them in pre-lowering to compositions of ops
+// that ALREADY have converters:
+//
+//   1. `Pow(x, c)` for small integer constants c -> chain of `Mul`s
+//      (c==2 -> Mul(x,x); c==3 -> Mul(x, Mul(x,x)); etc.). Sqrt special-cased
+//      for c==0.5.
+//   2. `ReduceMean(x, axes)` -> `ReduceSum(x, axes) / count` where `count`
+//      is the product of input dims along the reduce axes. Only fires when
+//      that count is compile-time-known (static along all reduce axes).
+//   3. `AveragePool(NCHW, kernel=K, stride=K, no pad)` -> Reshape ->
+//      Transpose -> ReduceMean. The 4-D NCHW input is first reshaped to
+//      6-D `[B, C, H/K, K, W/K, K]`, then transposed with perm
+//      `[0, 1, 2, 4, 3, 5]` to `[B, C, H/K, W/K, K, K]` so the K-K patch
+//      axes end up TRAILING, then ReduceMean over the two trailing K dims
+//      collapses them with `keepdims=0`. The transpose is required because
+//      `hip_reduce_sum` only handles reductions over a contiguous suffix
+//      of the input (it sums consecutive `reduce_size`-blocks); skipping
+//      it silently misroutes the reduction to dims [4,5] (the K-stride
+//      and innermost-K dims), producing wrong AvgPool output values that
+//      cascade into NaN downstream. This is mathematically equivalent to
+//      non-overlapping AveragePool with `K == stride`. Coverage is
+//      intentionally narrow — typical site is a Gemma-3-style projector
+//      (`kernel=4, stride=4` on a `[B, 1152, 64, 64]` tensor); overlap /
+//      padding cases would need a real pool kernel.
+//
+// All three rewrites run in the pre-lowering block of `ConvertOnnxToHipPass`,
+// alongside `FastGeluFusionPatterns` in a fixed-point round loop (an emitted
+// op from one round may be the root of a rewrite in the next). ONNX constant
+// `value` attrs must still be
+// inline (lowerOnnxConstants has not run yet) so the scalar exponent of
+// Pow and the axes value of ReduceMean are readable.
+//
+// Failure to rewrite is silent (returns notifyMatchFailure); the original
+// onnx.* op will then survive to OneShotBufferize and surface the canonical
+// "op was not bufferized" error. That is the right behavior — if the
+// projector morphology changes (e.g. K != stride, with padding, non-NCHW),
+// we want a loud failure with a clear pointer to the IR rather than a silent
+// wrong-answer.
+//
+//===----------------------------------------------------------------------===//
+
+#include "OnnxToHipUtils.h"
+
+#include "llvm/ADT/Statistic.h"
+#include "llvm/Support/Debug.h"
+
+#include <cmath>
+
+#define DEBUG_TYPE "projector-ops-rewrites"
+
+STATISTIC(NumPowRewrites, "onnx.Pow rewrites into Mul chains / Sqrt");
+STATISTIC(NumReduceMeanRewrites,
+          "onnx.ReduceMean rewrites into ReduceSum + Div");
+STATISTIC(NumAveragePoolRewrites,
+          "onnx.AveragePool rewrites into Reshape + ReduceMean");
+STATISTIC(NumBroadcastDivRewrites,
+          "onnx.Div rewrites into Mul(x, Reciprocal(y)) when broadcasting");
+
+namespace mlir {
+namespace hip {
+
+namespace {
+
+/// Read a single-element scalar from an onnx.Constant. Accepts f16/f32/f64
+/// and integer types.
+static std::optional<double> getOnnxConstantScalar(mlir::Operation *constOp) {
+  if (!constOp || constOp->getName().getStringRef() != "onnx.Constant")
+    return std::nullopt;
+  auto attr = mlir::dyn_cast_or_null<mlir::DenseElementsAttr>(
+      constOp->getAttr("value"));
+  if (!attr || attr.getNumElements() != 1)
+    return std::nullopt;
+  mlir::Type et = attr.getElementType();
+  if (et.isF32())
+    return static_cast<double>(*attr.getValues<float>().begin());
+  if (et.isF64())
+    return *attr.getValues<double>().begin();
+  if (et.isF16() || et.isBF16())
+    return (*attr.getValues<llvm::APFloat>().begin()).convertToDouble();
+  if (et.isIntOrIndex())
+    return static_cast<double>(
+        (*attr.getValues<llvm::APInt>().begin()).getSExtValue());
+  return std::nullopt;
+}
+
+//===----------------------------------------------------------------------===//
+// Pow(x, c) -> Mul chains (small integer exponents) or Sqrt (c=0.5)
+//===----------------------------------------------------------------------===//
+
+struct PowToMul : public mlir::RewritePattern {
+  PowToMul(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.Pow", /*benefit=*/2, ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override {
+    if (op->getNumOperands() != 2 || op->getNumResults() != 1)
+      return rewriter.notifyMatchFailure(op, "pow.arity");
+    mlir::Value x = op->getOperand(0);
+    auto expConst = getOnnxConstantScalar(op->getOperand(1).getDefiningOp());
+    if (!expConst)
+      return rewriter.notifyMatchFailure(op, "pow.exp_not_scalar_const");
+
+    auto outputType =
+        mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
+    if (!outputType)
+      return rewriter.notifyMatchFailure(op, "pow.output_not_ranked");
+
+    mlir::Location loc = op->getLoc();
+    double e = *expConst;
+
+    auto emitMul = [&](mlir::Value a, mlir::Value b) -> mlir::Value {
+      mlir::OperationState state(loc, "onnx.Mul");
+      state.addOperands({a, b});
+      state.addTypes(outputType);
+      return rewriter.create(state)->getResult(0);
+    };
+
+    // Small integer exponents: explicit Mul chain.
+    int64_t ie = static_cast<int64_t>(std::round(e));
+    if (std::abs(e - static_cast<double>(ie)) < 1e-6) {
+      if (ie == 0) {
+        // x^0 = 1 — emit a constant tensor of ones with the same shape.
+        // Skip: extremely rare in practice; bail out to surface the
+        // original op (and let the developer reconsider).
+        return rewriter.notifyMatchFailure(op, "pow.exp_zero");
+      }
+      if (ie == 1) {
+        rewriter.replaceOp(op, x);
+        ++NumPowRewrites;
+        return mlir::success();
+      }
+      if (ie >= 2 && ie <= 6) {
+        mlir::Value acc = x;
+        // x^N as repeated multiply (N-1 multiplies). For N=2: Mul(x, x).
+        // For N=3: Mul(x, Mul(x, x)). Etc. Simple and correct.
+        for (int64_t i = 1; i < ie; ++i)
+          acc = emitMul(x, acc);
+        rewriter.replaceOp(op, acc);
+        ++NumPowRewrites;
+        return mlir::success();
+      }
+    }
+
+    // Pow(x, 0.5) == Sqrt(x). Useful for RMSNorm's normalization step in
+    // some exports.
+    if (std::abs(e - 0.5) < 1e-6) {
+      mlir::OperationState state(loc, "onnx.Sqrt");
+      state.addOperands(x);
+      state.addTypes(outputType);
+      mlir::Value sqrt = rewriter.create(state)->getResult(0);
+      rewriter.replaceOp(op, sqrt);
+      ++NumPowRewrites;
+      return mlir::success();
+    }
+
+    return rewriter.notifyMatchFailure(op, "pow.exp_not_supported");
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// ReduceMean(x, axes) -> Div(ReduceSum(x, axes), N) where N = product of
+// input dims along the reduce axes.
+//===----------------------------------------------------------------------===//
+
+struct ReduceMeanToReduceSumDiv : public mlir::RewritePattern {
+  ReduceMeanToReduceSumDiv(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.ReduceMean", /*benefit=*/2, ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override {
+    if (op->getNumResults() != 1)
+      return rewriter.notifyMatchFailure(op, "reducemean.arity");
+    mlir::Value data = op->getOperand(0);
+    auto inputType = mlir::dyn_cast<mlir::RankedTensorType>(data.getType());
+    auto outputType =
+        mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
+    if (!inputType || !outputType)
+      return rewriter.notifyMatchFailure(op, "reducemean.not_ranked");
+    int64_t rank = inputType.getRank();
+
+    // Collect reduce axes. ONNX ReduceMean opset 18+: axes is an input
+    // tensor. Older opsets: axes is an attribute. Handle both.
+    llvm::SmallVector<int64_t> axes;
+    bool axesFound = false;
+    if (op->getNumOperands() >= 2) {
+      mlir::Operation *axesDef = op->getOperand(1).getDefiningOp();
+      if (axesDef && axesDef->getName().getStringRef() == "onnx.Constant") {
+        if (auto attr = mlir::dyn_cast_or_null<mlir::DenseElementsAttr>(
+                axesDef->getAttr("value"))) {
+          for (auto v : attr.getValues<llvm::APInt>())
+            axes.push_back(v.getSExtValue());
+          axesFound = true;
+        }
+      }
+    }
+    if (!axesFound) {
+      if (auto axesAttr = op->getAttrOfType<mlir::ArrayAttr>("axes")) {
+        for (mlir::Attribute a : axesAttr) {
+          auto ia = mlir::dyn_cast<mlir::IntegerAttr>(a);
+          if (!ia)
+            return rewriter.notifyMatchFailure(op, "reducemean.axes_attr_kind");
+          axes.push_back(ia.getSInt());
+        }
+        axesFound = true;
+      }
+    }
+    if (!axesFound || axes.empty())
+      return rewriter.notifyMatchFailure(op, "reducemean.axes_not_found");
+
+    // Normalize negative axes; require all reduce dims static.
+    int64_t reduceCount = 1;
+    for (int64_t a : axes) {
+      int64_t n = a < 0 ? a + rank : a;
+      if (n < 0 || n >= rank)
+        return rewriter.notifyMatchFailure(op, "reducemean.axis_oob");
+      if (inputType.isDynamicDim(n))
+        return rewriter.notifyMatchFailure(op, "reducemean.reduce_dim_dynamic");
+      reduceCount *= inputType.getDimSize(n);
+    }
+    if (reduceCount <= 0)
+      return rewriter.notifyMatchFailure(op, "reducemean.zero_count");
+
+    mlir::Location loc = op->getLoc();
+
+    // Step 1: emit onnx.ReduceSum with the same operands / attrs (will use
+    // the existing converter). To avoid the axes-attr-vs-input difference
+    // re-tripping the converter, preserve the original op's operand layout.
+    mlir::OperationState sumState(loc, "onnx.ReduceSum");
+    sumState.addOperands(op->getOperands());
+    sumState.addTypes(outputType);
+    // Copy keepdims and noop_with_empty_axes attrs verbatim.
+    if (auto a = op->getAttrOfType<mlir::IntegerAttr>("keepdims"))
+      sumState.addAttribute("keepdims", a);
+    if (auto a = op->getAttrOfType<mlir::IntegerAttr>("noop_with_empty_axes"))
+      sumState.addAttribute("noop_with_empty_axes", a);
+    if (auto a = op->getAttrOfType<mlir::ArrayAttr>("axes"))
+      sumState.addAttribute("axes", a);
+    mlir::Value sum = rewriter.create(sumState)->getResult(0);
+
+    // Step 2: scalar fp constant `1/count` with the same element type as
+    // the sum. Multiply (faster than Div for fp16 on GPU + commutative).
+    mlir::Type elemType = outputType.getElementType();
+    if (!elemType.isF16() && !elemType.isF32() && !elemType.isBF16() &&
+        !elemType.isF64())
+      return rewriter.notifyMatchFailure(op, "reducemean.unsupported_dtype");
+    auto scalarType = mlir::RankedTensorType::get({}, elemType);
+    double invCount = 1.0 / static_cast<double>(reduceCount);
+    mlir::DenseElementsAttr scaleAttr;
+    if (elemType.isF32()) {
+      scaleAttr = mlir::DenseElementsAttr::get(scalarType,
+                                               static_cast<float>(invCount));
+    } else if (elemType.isF64()) {
+      scaleAttr = mlir::DenseElementsAttr::get(scalarType, invCount);
+    } else { // f16 or bf16: convert through fp32 with proper rounding.
+      llvm::APFloat f(static_cast<float>(invCount));
+      bool losesInfo = false;
+      f.convert(elemType.isF16() ? llvm::APFloat::IEEEhalf()
+                                 : llvm::APFloat::BFloat(),
+                llvm::APFloat::rmNearestTiesToEven, &losesInfo);
+      scaleAttr = mlir::DenseElementsAttr::get(scalarType, f);
+    }
+    mlir::OperationState constState(loc, "onnx.Constant");
+    constState.addTypes(scalarType);
+    constState.addAttribute("value", scaleAttr);
+    mlir::Value scale = rewriter.create(constState)->getResult(0);
+
+    mlir::OperationState mulState(loc, "onnx.Mul");
+    mulState.addOperands({sum, scale});
+    mulState.addTypes(outputType);
+    mlir::Value mean = rewriter.create(mulState)->getResult(0);
+
+    rewriter.replaceOp(op, mean);
+    ++NumReduceMeanRewrites;
+    return mlir::success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// AveragePool(NCHW, kernel=K, stride=K, no pad) -> Reshape + ReduceMean
+//===----------------------------------------------------------------------===//
+
+struct AveragePoolToReshapeMean : public mlir::RewritePattern {
+  AveragePoolToReshapeMean(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.AveragePool", /*benefit=*/2, ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override {
+    if (op->getNumOperands() != 1 || op->getNumResults() != 1)
+      return rewriter.notifyMatchFailure(op, "avgpool.arity");
+    mlir::Value x = op->getOperand(0);
+    auto inputType = mlir::dyn_cast<mlir::RankedTensorType>(x.getType());
+    auto outputType =
+        mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
+    if (!inputType || !outputType)
+      return rewriter.notifyMatchFailure(op, "avgpool.not_ranked");
+    // NCHW only.
+    if (inputType.getRank() != 4)
+      return rewriter.notifyMatchFailure(op, "avgpool.rank_not_4");
+
+    auto getInt = [&](mlir::ArrayAttr a, int64_t i) -> int64_t {
+      auto ia = mlir::dyn_cast<mlir::IntegerAttr>(a.getValue()[i]);
+      return ia ? ia.getValue().getSExtValue() : -1;
+    };
+
+    auto kAttr = op->getAttrOfType<mlir::ArrayAttr>("kernel_shape");
+    auto sAttr = op->getAttrOfType<mlir::ArrayAttr>("strides");
+    auto pAttr = op->getAttrOfType<mlir::ArrayAttr>("pads");
+    if (!kAttr || kAttr.size() != 2)
+      return rewriter.notifyMatchFailure(op, "avgpool.no_kernel_2d");
+    int64_t kH = getInt(kAttr, 0), kW = getInt(kAttr, 1);
+    int64_t sH = kH, sW = kW;
+    if (sAttr) {
+      if (sAttr.size() != 2)
+        return rewriter.notifyMatchFailure(op, "avgpool.strides_not_2");
+      sH = getInt(sAttr, 0);
+      sW = getInt(sAttr, 1);
+    }
+    if (sH != kH || sW != kW)
+      return rewriter.notifyMatchFailure(op, "avgpool.kernel_neq_stride");
+    if (pAttr) {
+      for (mlir::Attribute a : pAttr) {
+        auto ia = mlir::dyn_cast<mlir::IntegerAttr>(a);
+        if (!ia || ia.getValue().getSExtValue() != 0)
+          return rewriter.notifyMatchFailure(op, "avgpool.has_padding");
+      }
+    }
+    // auto_pad must be NOTSET or VALID (no implicit padding).
+    if (auto ap = op->getAttrOfType<mlir::StringAttr>("auto_pad")) {
+      llvm::StringRef v = ap.getValue();
+      if (v != "NOTSET" && v != "VALID")
+        return rewriter.notifyMatchFailure(op, "avgpool.auto_pad_other");
+    }
+    // ceil_mode must be 0 (default).
+    if (auto a = op->getAttrOfType<mlir::IntegerAttr>("ceil_mode"))
+      if (a.getValue().getSExtValue() != 0)
+        return rewriter.notifyMatchFailure(op, "avgpool.ceil_mode");
+
+    // Spatial dims must be static and divisible by kernel size. (Vision
+    // encoder ships [B,1152,64,64] so this is comfortable.)
+    if (inputType.isDynamicDim(2) || inputType.isDynamicDim(3))
+      return rewriter.notifyMatchFailure(op, "avgpool.spatial_dynamic");
+    int64_t H = inputType.getDimSize(2);
+    int64_t W = inputType.getDimSize(3);
+    if (H % kH != 0 || W % kW != 0)
+      return rewriter.notifyMatchFailure(op, "avgpool.not_evenly_divisible");
+    int64_t outH = H / kH;
+    int64_t outW = W / kW;
+
+    int64_t B = inputType.getDimSize(0); // possibly dynamic
+    int64_t C = inputType.getDimSize(1); // expected static
+    if (inputType.isDynamicDim(1))
+      return rewriter.notifyMatchFailure(op, "avgpool.c_dynamic");
+
+    mlir::Location loc = op->getLoc();
+    mlir::Type elemType = inputType.getElementType();
+
+    // Step 1: Reshape [B, C, H, W] -> [B, C, outH, kH, outW, kW].
+    // Shape operand built as: Concat(Shape(x)[0:1], const[C, outH, kH,
+    // outW, kW]) when B is dynamic, or a single onnx.Constant when B is
+    // static.
+    auto i64Type = rewriter.getI64Type();
+    auto buildShapeConst = [&](mlir::ArrayRef<int64_t> dims) -> mlir::Value {
+      auto t = mlir::RankedTensorType::get({static_cast<int64_t>(dims.size())},
+                                           i64Type);
+      auto attr = mlir::DenseElementsAttr::get(t, dims);
+      mlir::OperationState s(loc, "onnx.Constant");
+      s.addTypes(t);
+      s.addAttribute("value", attr);
+      return rewriter.create(s)->getResult(0);
+    };
+
+    mlir::Value reshapeShape;
+    if (B != mlir::ShapedType::kDynamic) {
+      reshapeShape = buildShapeConst({B, C, outH, kH, outW, kW});
+    } else {
+      // Build Shape(x)[0:1] -> Concat with const tail.
+      // First emit Shape(x).
+      auto shapeRetType = mlir::RankedTensorType::get({4}, i64Type);
+      mlir::OperationState shapeState(loc, "onnx.Shape");
+      shapeState.addOperands(x);
+      shapeState.addTypes(shapeRetType);
+      mlir::Value shp = rewriter.create(shapeState)->getResult(0);
+      // Slice to [0:1].
+      mlir::Value zero = buildShapeConst({0});
+      mlir::Value one = buildShapeConst({1});
+      mlir::Value axes0 = buildShapeConst({0});
+      auto sliceRetType = mlir::RankedTensorType::get({1}, i64Type);
+      mlir::OperationState sliceState(loc, "onnx.Slice");
+      sliceState.addOperands({shp, zero, one, axes0});
+      sliceState.addTypes(sliceRetType);
+      mlir::Value sliceB = rewriter.create(sliceState)->getResult(0);
+      // Tail const.
+      mlir::Value tail = buildShapeConst({C, outH, kH, outW, kW});
+      auto concatType = mlir::RankedTensorType::get({6}, i64Type);
+      mlir::OperationState concatState(loc, "onnx.Concat");
+      concatState.addOperands({sliceB, tail});
+      concatState.addTypes(concatType);
+      concatState.addAttribute(
+          "axis", mlir::IntegerAttr::get(
+                      mlir::IntegerType::get(rewriter.getContext(), 64,
+                                             mlir::IntegerType::Signed),
+                      0));
+      reshapeShape = rewriter.create(concatState)->getResult(0);
+    }
+    // The result type is built explicitly from the dims we just computed
+    // ({B, C, outH, kH, outW, kW}) — the rewriter already knows every
+    // static dim, so there is no need to re-derive it by tracing the
+    // shape-operand SSA chain. B may be dynamic; any such dim is resolved
+    // post-conversion by the HIP-dialect `--hip-infer-shapes` pass.
+    auto reshapedType =
+        mlir::RankedTensorType::get({B, C, outH, kH, outW, kW}, elemType);
+    mlir::OperationState reshapeState(loc, "onnx.Reshape");
+    reshapeState.addOperands({x, reshapeShape});
+    reshapeState.addTypes(reshapedType);
+    reshapeState.addAttribute(
+        "allowzero", mlir::IntegerAttr::get(
+                         mlir::IntegerType::get(rewriter.getContext(), 64,
+                                                mlir::IntegerType::Signed),
+                         0));
+    mlir::Value reshaped = rewriter.create(reshapeState)->getResult(0);
+
+    // Step 2: Transpose [B, C, outH, kH, outW, kW] -> [B, C, outH, outW, kH,
+    // kW] (perm [0, 1, 2, 4, 3, 5]) so that the K-K patch axes end up trailing
+    // and contiguous in memory. Required because `hip_reduce_sum` only
+    // handles reductions over a contiguous suffix; without this transpose
+    // the subsequent ReduceMean over the K-sized dims would silently sum
+    // the wrong contiguous block (dims [4,5] instead of dims [3,5]) and
+    // produce wrong values that cascade into NaN downstream.
+    auto transposedType =
+        mlir::RankedTensorType::get({B, C, outH, outW, kH, kW}, elemType);
+    mlir::OperationState transposeState(loc, "onnx.Transpose");
+    transposeState.addOperands(reshaped);
+    transposeState.addTypes(transposedType);
+    transposeState.addAttribute(
+        "perm",
+        rewriter.getI64ArrayAttr(llvm::ArrayRef<int64_t>{0, 1, 2, 4, 3, 5}));
+    mlir::Value transposed = rewriter.create(transposeState)->getResult(0);
+
+    // Step 3: ReduceMean over dims 4 and 5 (the now-trailing K dims),
+    // keepdims=0. axes_const = [4, 5]
+    auto axesType = mlir::RankedTensorType::get({2}, i64Type);
+    auto axesAttr =
+        mlir::DenseElementsAttr::get(axesType, llvm::ArrayRef<int64_t>{4, 5});
+    mlir::OperationState axesState(loc, "onnx.Constant");
+    axesState.addTypes(axesType);
+    axesState.addAttribute("value", axesAttr);
+    mlir::Value axes = rewriter.create(axesState)->getResult(0);
+
+    // ReduceMean output type is built explicitly from the known dims,
+    // keeping the decomposition self-contained.
+    auto pooledType = mlir::RankedTensorType::get({B, C, outH, outW}, elemType);
+    mlir::OperationState meanState(loc, "onnx.ReduceMean");
+    meanState.addOperands({transposed, axes});
+    meanState.addTypes(pooledType);
+    meanState.addAttribute(
+        "keepdims", mlir::IntegerAttr::get(
+                        mlir::IntegerType::get(rewriter.getContext(), 64,
+                                               mlir::IntegerType::Signed),
+                        0));
+    meanState.addAttribute(
+        "noop_with_empty_axes",
+        mlir::IntegerAttr::get(
+            mlir::IntegerType::get(rewriter.getContext(), 64,
+                                   mlir::IntegerType::Signed),
+            0));
+    mlir::Value pooled = rewriter.create(meanState)->getResult(0);
+
+    rewriter.replaceOp(op, pooled);
+    ++NumAveragePoolRewrites;
+    LLVM_DEBUG(llvm::dbgs() << "[" DEBUG_TYPE "] decomposed AveragePool "
+                            << "K=" << kH << "x" << kW << " on " << inputType
+                            << " -> Reshape + ReduceMean\n");
+    return mlir::success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Broadcasting Div(x, y) -> Mul(x, Reciprocal(y))
+//
+// hip.div lowers to a plain element-wise kernel that does NOT broadcast:
+// it reads `num_elements` from the OUTPUT shape and indexes lhs/rhs with
+// the same linear index, which silently reads out-of-bounds (uninitialized
+// memory → NaN/Inf) when rhs is smaller than lhs. hip.mul (and other
+// ElementwiseOpLowering ops) DO broadcast via miopenOpTensor's 4D
+// descriptor API.
+//
+// The Gemma-3 multi-modal projector's RMSNorm shape divides
+// `x[1, 256, 1152]` by `sqrt(mean(x^2)+eps)[1, 256, 1]` — a textbook
+// broadcast. Without this rewrite the Div produces NaN for most output
+// rows and the projector's final MatMul cascades NaN to the output
+// `image_features`.
+//
+// Rewrite is conservative: only fires when lhs and rhs have different
+// shapes (i.e. the broadcast case). Same-shape Div continues to use the
+// existing element-wise path. Reciprocal is element-wise (no broadcast
+// concern) — it produces the same shape as rhs, then Mul broadcasts
+// rhs-shape against lhs.
+//
+// Before:
+//   %y = onnx.Div(%x, %d) : (tensor<?x256x1152xf16>, tensor<?x256x1xf16>)
+//                       -> tensor<?x256x1152xf16>
+// After:
+//   %r = onnx.Reciprocal(%d) : tensor<?x256x1xf16>
+//   %y = onnx.Mul(%x, %r)    : (tensor<?x256x1152xf16>, tensor<?x256x1xf16>)
+//                           -> tensor<?x256x1152xf16>
+//===----------------------------------------------------------------------===//
+
+struct BroadcastDivToMulReciprocal : public mlir::RewritePattern {
+  BroadcastDivToMulReciprocal(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.Div", /*benefit=*/2, ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override {
+    if (op->getNumOperands() != 2 || op->getNumResults() != 1)
+      return rewriter.notifyMatchFailure(op, "div.arity");
+    mlir::Value lhs = op->getOperand(0);
+    mlir::Value rhs = op->getOperand(1);
+    auto lhsType = mlir::dyn_cast<mlir::RankedTensorType>(lhs.getType());
+    auto rhsType = mlir::dyn_cast<mlir::RankedTensorType>(rhs.getType());
+    auto outType =
+        mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
+    if (!lhsType || !rhsType || !outType)
+      return rewriter.notifyMatchFailure(op, "div.not_ranked");
+    if (lhsType.getElementType() != rhsType.getElementType())
+      return rewriter.notifyMatchFailure(op, "div.mixed_types");
+
+    // Skip when shapes already match — the existing element-wise Div path
+    // is correct for that case.
+    if (lhsType.getShape() == rhsType.getShape())
+      return rewriter.notifyMatchFailure(op, "div.same_shape");
+
+    // Integer broadcast Div has no decomposition into Mul x Reciprocal:
+    // ONNX Reciprocal is fp-only, and hip.div in the runtime is a flat
+    // element-wise kernel that doesn't broadcast — on batch > 0 it
+    // reads past the end of the smaller operand and pulls garbage into
+    // the GEMM/RMSNorm chain downstream (NaN cascade visible only at
+    // model-output cosine, after the rewriter has long returned). Surface
+    // the unsupported case at compile time so it can't pass silently.
+    mlir::Type elemType = lhsType.getElementType();
+    if (elemType.isIntOrIndex()) {
+      op->emitWarning()
+          << "onnx.Div with mismatched integer-type operands has no "
+             "broadcasting decomposition; runtime hip.div will read OOB "
+             "on batch > 0. Extend BroadcastDivToMulReciprocal to integer "
+             "Div or add broadcast support to hip_elementwise_div.";
+      return rewriter.notifyMatchFailure(op,
+                                         "div.integer_broadcast_unsupported");
+    }
+
+    // Only fp16/fp32/bf16 — Reciprocal supports the same set.
+    if (!elemType.isF16() && !elemType.isF32() && !elemType.isBF16())
+      return rewriter.notifyMatchFailure(op, "div.unsupported_dtype");
+
+    mlir::Location loc = op->getLoc();
+
+    // 1) Reciprocal(rhs) — same shape as rhs.
+    mlir::OperationState recState(loc, "onnx.Reciprocal");
+    recState.addOperands(rhs);
+    recState.addTypes(rhsType);
+    mlir::Value rec = rewriter.create(recState)->getResult(0);
+
+    // 2) Mul(lhs, Reciprocal(rhs)) — broadcasts via existing Mul path.
+    mlir::OperationState mulState(loc, "onnx.Mul");
+    mulState.addOperands({lhs, rec});
+    mulState.addTypes(outType);
+    mlir::Value mul = rewriter.create(mulState)->getResult(0);
+
+    rewriter.replaceOp(op, mul);
+    ++NumBroadcastDivRewrites;
+    LLVM_DEBUG(llvm::dbgs() << "[" DEBUG_TYPE "] decomposed broadcasting "
+                            << "Div " << lhsType << " / " << rhsType
+                            << " into Mul(x, Reciprocal(y))\n");
+    return mlir::success();
+  }
+};
+
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// PatchEmbedConvToGemm — Conv with kernel covering entire spatial input.
+//
+// Vision-encoder "patch embedding" Convs have the unusual shape that the
+// kernel matches the input spatial dims exactly, so each output spatial dim
+// is 1: e.g. input `[N, 3, 2, 16, 16]`, weight `[1152, 3, 2, 16, 16]`,
+// strides `[2, 16, 16]`, output `[N, 1152, 1, 1, 1]`. Mathematically this is
+// a per-batch dot product of the flattened input row with each weight row:
+//
+//   out[n, m] = bias[m] + sum_{c, kd, kh, kw}
+//                 input[n, c, kd, kh, kw] * W[m, c, kd, kh, kw]
+//
+// which is exactly an `onnx.Gemm` with `transB=1`:
+//
+//   input_flat = Reshape(input, [-1, C*kD*kH*kW])
+//   weight_flat = Reshape(W, [M, C*kD*kH*kW])
+//   y_flat = Gemm(input_flat, weight_flat, bias, transA=0, transB=1)
+//   y = Reshape(y_flat, [-1, M, 1, 1, ..., 1])
+//
+// Rewriting at the ONNX level (before bufferization) avoids needing a new
+// 5D-Conv runtime / lowering path: the existing MatMul/Gemm path handles it
+// natively. Restricted to:
+//   - input rank >= 4 (covers 2D Conv with kernel == input spatial too)
+//   - rank-5 in practice today (3D Conv from typical ViT patch embeddings)
+//   - all output spatial dims static and equal to 1
+//   - all input spatial dims static (so the flatten K is compile-time known)
+//   - pads all zero
+//   - group = 1
+//   - weight has fully static shape (so we can flatten it with a Constant
+//     shape operand)
+//
+// Bias is optional. When absent we still emit Gemm with a zero C operand
+// because the converter requires three inputs; α=1 β=1.
+//
+// Before (ONNX dialect snippet, 3-D patch embed):
+//   %y = onnx.Conv(%x, %w, %b)
+//     {pads=[0,0,0,0,0,0], strides=[2,16,16], dilations=[1,1,1], group=1}
+//     : (tensor<?x3x2x16x16xf16>, tensor<1152x3x2x16x16xf16>,
+//        tensor<1152xf16>) -> tensor<?x1152x1x1x1xf16>
+//
+// After:
+//   %xf = onnx.Reshape(%x,  const [-1, 1536]) : -> tensor<?x1536xf16>
+//   %wf = onnx.Reshape(%w,  const [1152, 1536]) : -> tensor<1152x1536xf16>
+//   %y2 = onnx.Gemm(%xf, %wf, %b) {transA=0, transB=1, alpha=1.0, beta=1.0}
+//           : (tensor<?x1536xf16>, tensor<1152x1536xf16>, tensor<1152xf16>)
+//           -> tensor<?x1152xf16>
+//   %y  = onnx.Reshape(%y2, const [-1, 1152, 1, 1, 1])
+//           : -> tensor<?x1152x1x1x1xf16>
+struct PatchEmbedConvToGemm : public mlir::RewritePattern {
+  PatchEmbedConvToGemm(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.Conv", /*benefit=*/2, ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override {
+    if (op->getNumOperands() < 2 || op->getNumOperands() > 3 ||
+        op->getNumResults() != 1)
+      return rewriter.notifyMatchFailure(op, "conv.arity");
+    mlir::Value x = op->getOperand(0);
+    mlir::Value w = op->getOperand(1);
+    mlir::Value bias = op->getNumOperands() == 3 ? op->getOperand(2) : nullptr;
+
+    auto xType = mlir::dyn_cast<mlir::RankedTensorType>(x.getType());
+    auto wType = mlir::dyn_cast<mlir::RankedTensorType>(w.getType());
+    auto yType =
+        mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
+    if (!xType || !wType || !yType)
+      return rewriter.notifyMatchFailure(op, "conv.not_ranked");
+    int64_t rank = xType.getRank();
+    if (rank < 4 || rank != wType.getRank() || rank != yType.getRank())
+      return rewriter.notifyMatchFailure(op, "conv.rank_mismatch");
+
+    // group must be 1 (default).
+    if (auto g = op->getAttrOfType<mlir::IntegerAttr>("group"))
+      if (g.getValue().getSExtValue() != 1)
+        return rewriter.notifyMatchFailure(op, "conv.group_ne_1");
+
+    // pads all zero (any padding would make patch embed non-trivial).
+    if (auto pads = op->getAttrOfType<mlir::ArrayAttr>("pads"))
+      for (mlir::Attribute a : pads) {
+        auto ia = mlir::dyn_cast<mlir::IntegerAttr>(a);
+        if (!ia || ia.getValue().getSExtValue() != 0)
+          return rewriter.notifyMatchFailure(op, "conv.has_padding");
+      }
+
+    int64_t nSpatial = rank - 2;
+    // Input/weight spatial dims must be fully static AND equal to each other
+    // (kernel covers entire spatial), and output spatial dims must all be 1.
+    int64_t K = 1; // C * product(spatial)
+    int64_t Cin = xType.getDimSize(1);
+    if (Cin == mlir::ShapedType::kDynamic)
+      return rewriter.notifyMatchFailure(op, "conv.cin_dynamic");
+    K = Cin;
+    for (int64_t i : llvm::seq<int64_t>(0, nSpatial)) {
+      int64_t xs = xType.getDimSize(2 + i);
+      int64_t ws = wType.getDimSize(2 + i);
+      int64_t ys = yType.getDimSize(2 + i);
+      if (xs == mlir::ShapedType::kDynamic || ws == mlir::ShapedType::kDynamic)
+        return rewriter.notifyMatchFailure(op, "conv.spatial_dynamic");
+      if (xs != ws)
+        return rewriter.notifyMatchFailure(op, "conv.kernel_neq_input");
+      if (ys != 1)
+        return rewriter.notifyMatchFailure(op, "conv.out_spatial_ne_1");
+      K *= ws;
+    }
+    int64_t M = wType.getDimSize(0); // out_channels
+    if (M == mlir::ShapedType::kDynamic)
+      return rewriter.notifyMatchFailure(op, "conv.m_dynamic");
+
+    mlir::Location loc = op->getLoc();
+    mlir::Type elemType = xType.getElementType();
+    auto i64Type = rewriter.getI64Type();
+    auto buildShapeConst = [&](mlir::ArrayRef<int64_t> dims) -> mlir::Value {
+      auto t = mlir::RankedTensorType::get({static_cast<int64_t>(dims.size())},
+                                           i64Type);
+      auto attr = mlir::DenseElementsAttr::get(t, dims);
+      mlir::OperationState s(loc, "onnx.Constant");
+      s.addTypes(t);
+      s.addAttribute("value", attr);
+      return rewriter.create(s)->getResult(0);
+    };
+
+    // Reshape input to [N, K] using -1 for dynamic batch.
+    int64_t N = xType.getDimSize(0);
+    auto xFlatType = mlir::RankedTensorType::get({N, K}, elemType);
+    mlir::OperationState rIn(loc, "onnx.Reshape");
+    rIn.addOperands({x, buildShapeConst({-1, K})});
+    rIn.addTypes(xFlatType);
+    rIn.addAttribute("allowzero",
+                     mlir::IntegerAttr::get(
+                         mlir::IntegerType::get(rewriter.getContext(), 64,
+                                                mlir::IntegerType::Signed),
+                         0));
+    mlir::Value xFlat = rewriter.create(rIn)->getResult(0);
+
+    // Reshape weight to [M, K] (fully static).
+    auto wFlatType =
+        mlir::RankedTensorType::get({M, K}, wType.getElementType());
+    mlir::OperationState rW(loc, "onnx.Reshape");
+    rW.addOperands({w, buildShapeConst({M, K})});
+    rW.addTypes(wFlatType);
+    rW.addAttribute("allowzero",
+                    mlir::IntegerAttr::get(
+                        mlir::IntegerType::get(rewriter.getContext(), 64,
+                                               mlir::IntegerType::Signed),
+                        0));
+    mlir::Value wFlat = rewriter.create(rW)->getResult(0);
+
+    // Build Gemm. Bias is required by the GemmConversion (which calls
+    // ConvertOnnxGemm with 3 operands). When absent, synthesize a zero
+    // bias of shape [M]. The bias-add overhead is one element-wise
+    // op on a small tensor — negligible vs the GEMM itself.
+    mlir::Value cOp;
+    if (bias) {
+      cOp = bias;
+    } else {
+      // Zero bias constant. Use the input element type (Gemm expects all
+      // operands to share the dtype on this path).
+      auto bType = mlir::RankedTensorType::get({M}, elemType);
+      mlir::Attribute zeroAttr;
+      if (auto ft = mlir::dyn_cast<mlir::FloatType>(elemType)) {
+        llvm::SmallVector<llvm::APFloat> zeros(
+            M, llvm::APFloat::getZero(ft.getFloatSemantics()));
+        zeroAttr = mlir::DenseElementsAttr::get(bType, zeros);
+      } else {
+        return rewriter.notifyMatchFailure(op, "conv.bias_unsupported_dtype");
+      }
+      mlir::OperationState zState(loc, "onnx.Constant");
+      zState.addTypes(bType);
+      zState.addAttribute("value", zeroAttr);
+      cOp = rewriter.create(zState)->getResult(0);
+    }
+
+    auto gemmType = mlir::RankedTensorType::get({N, M}, elemType);
+    mlir::OperationState gemm(loc, "onnx.Gemm");
+    gemm.addOperands({xFlat, wFlat, cOp});
+    gemm.addTypes(gemmType);
+    gemm.addAttribute("transA",
+                      mlir::IntegerAttr::get(
+                          mlir::IntegerType::get(rewriter.getContext(), 64,
+                                                 mlir::IntegerType::Signed),
+                          0));
+    gemm.addAttribute("transB",
+                      mlir::IntegerAttr::get(
+                          mlir::IntegerType::get(rewriter.getContext(), 64,
+                                                 mlir::IntegerType::Signed),
+                          1));
+    gemm.addAttribute("alpha", rewriter.getF32FloatAttr(1.0f));
+    gemm.addAttribute("beta", rewriter.getF32FloatAttr(1.0f));
+    mlir::Value gemmOut = rewriter.create(gemm)->getResult(0);
+
+    // Reshape Gemm output [N, M] back to the Conv output shape (which has
+    // trailing 1s for every spatial dim).
+    llvm::SmallVector<int64_t> outShape;
+    outShape.push_back(-1); // batch
+    outShape.push_back(M);
+    for (int64_t i : llvm::seq<int64_t>(0, nSpatial))
+      (void)i, outShape.push_back(1);
+    mlir::OperationState rOut(loc, "onnx.Reshape");
+    rOut.addOperands({gemmOut, buildShapeConst(outShape)});
+    rOut.addTypes(yType);
+    rOut.addAttribute("allowzero",
+                      mlir::IntegerAttr::get(
+                          mlir::IntegerType::get(rewriter.getContext(), 64,
+                                                 mlir::IntegerType::Signed),
+                          0));
+    mlir::Value reshaped = rewriter.create(rOut)->getResult(0);
+
+    rewriter.replaceOp(op, reshaped);
+    LLVM_DEBUG(llvm::dbgs()
+               << "[" DEBUG_TYPE "] PatchEmbedConvToGemm: rank-" << rank
+               << " Conv " << xType << " * " << wType
+               << " -> Gemm + Reshape (K=" << K << ", M=" << M << ")\n");
+    return mlir::success();
+  }
+};
+
+void populateProjectorOpsRewritePatterns(mlir::RewritePatternSet &patterns,
+                                         mlir::MLIRContext *ctx) {
+  patterns.add<PowToMul, ReduceMeanToReduceSumDiv, AveragePoolToReshapeMean,
+               BroadcastDivToMulReciprocal, PatchEmbedConvToGemm>(ctx);
+}
+
+} // namespace hip
+} // namespace mlir

--- a/test/lit/Conversion/hip-to-llvm/test_matmul.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_matmul.mlir
@@ -3,11 +3,17 @@
 
 // RUN: hip-mlir-opt --convert-hip-to-llvm %s | FileCheck %s
 
+// ----- Rank-2 broadcast B [K, N] ---------------------------------------------
+// b_batch_stride MUST be a constant 0 (no leading dims to multiply).
+// `CHECK-NOT` between the label and the call asserts the compile-time
+// constant path was taken (no runtime `llvm.icmp` / `llvm.select` over a
+// leading-dim product).
+
 module {
-  func.func @test_matmul_lowering(%ctx: !hip.context,
-                                   %A: memref<1x128x4096xf16, 1>,
-                                   %B: memref<4096x1024xf16, 1>,
-                                   %output: memref<1x128x1024xf16, 1>) {
+  func.func @test_matmul_rank2_b(%ctx: !hip.context,
+                                  %A: memref<1x128x4096xf16, 1>,
+                                  %B: memref<4096x1024xf16, 1>,
+                                  %output: memref<1x128x1024xf16, 1>) {
     hip.matmul(%ctx)
         ins(%A, %B : memref<1x128x4096xf16, 1>, memref<4096x1024xf16, 1>)
         outs(%output : memref<1x128x1024xf16, 1>)
@@ -15,8 +21,36 @@ module {
   }
 }
 
-// CHECK-LABEL: llvm.func @test_matmul_lowering
-// CHECK: llvm.call @wrap_hipblasLtMatmul({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64) -> i32
-// Verify 9 parameters:
+// CHECK-LABEL: llvm.func @test_matmul_rank2_b
+// CHECK-NOT: llvm.icmp
+// CHECK-NOT: llvm.select
+// CHECK: llvm.call @wrap_hipblasLtMatmul({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64) -> i32
+// Verify 10 parameters:
 // - 4 pointers: state, A, B, output
-// - 5 i64: M=128, N=1024, K=4096, batch_count=1, elem_size=2
+// - 6 i64: M=128, N=1024, K=4096, batch_count=1, elem_size=2, b_batch_stride=0
+//   (B is rank-2 [K, N] = broadcast weight → stride = 0, compile-time const)
+
+// ----- Rank-3 leading-one B [1, K, N] ----------------------------------------
+// Leading dim is statically 1: still ONE [K, N] matrix in the buffer, so
+// b_batch_stride must be 0 (NOT K*N). The compiler folds this at compile
+// time when all leading dims are static — verified via CHECK-NOT for icmp /
+// select. Encoding this case as "rank > 2 ⇒ per-batch" (the prior `b_batched`
+// bool rule) caused hipBLASLt to step K*N elements past the end of the
+// weight buffer on batch > 0 and feed garbage into the GEMM.
+
+module {
+  func.func @test_matmul_rank3_leading_one_b(%ctx: !hip.context,
+                                              %A: memref<2x128x4096xf16, 1>,
+                                              %B: memref<1x4096x1024xf16, 1>,
+                                              %output: memref<2x128x1024xf16, 1>) {
+    hip.matmul(%ctx)
+        ins(%A, %B : memref<2x128x4096xf16, 1>, memref<1x4096x1024xf16, 1>)
+        outs(%output : memref<2x128x1024xf16, 1>)
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @test_matmul_rank3_leading_one_b
+// CHECK-NOT: llvm.icmp
+// CHECK-NOT: llvm.select
+// CHECK: llvm.call @wrap_hipblasLtMatmul({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64) -> i32

--- a/test/lit/Conversion/onnx-to-hip/test_projector_rewrites.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_projector_rewrites.mlir
@@ -1,0 +1,69 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// Pre-lowering rewrites that decompose ONNX ops into compositions the
+// existing converters already handle. Tests pin two invariants today:
+//
+//  1. AveragePoolToReshapeMean emits an `onnx.Transpose` with
+//     `perm = [0, 1, 2, 4, 3, 5]` between the 6-D Reshape and the
+//     ReduceMean. The transpose moves the K-K patch axes to the trailing
+//     position because `hip_reduce_sum` only reduces a contiguous
+//     suffix; without this transpose the subsequent reduce would
+//     silently sum the wrong contiguous block and produce garbage
+//     downstream (NaN cascade visible at model output).
+//
+//  2. BroadcastDivToMulReciprocal turns `onnx.Div(a, b)` with
+//     differing operand shapes into `Mul(a, Reciprocal(b))`, because
+//     `hip.div` is a flat element-wise kernel with no broadcast
+//     support. Reciprocal preserves rhs shape; the subsequent Mul
+//     broadcasts via the existing path (no kernel-level OOB read).
+
+// RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip | FileCheck %s
+
+module {
+  func.func @main_graph(%arg0: tensor<1xf32>) -> tensor<1xf32> {
+    return %arg0 : tensor<1xf32>
+  }
+
+  // AveragePool with kernel == stride (canonical patch-pooling shape).
+  // Trigger the AveragePoolToReshapeMean rewrite.
+  func.func @test_avgpool_to_reshape_mean(
+      %x: tensor<?x1152x16x16xf16>) -> tensor<?x1152x4x4xf16> {
+    %y = "onnx.AveragePool"(%x) {
+      kernel_shape = [4 : si64, 4 : si64],
+      strides = [4 : si64, 4 : si64],
+      auto_pad = "NOTSET",
+      pads = [0 : si64, 0 : si64, 0 : si64, 0 : si64]
+    } : (tensor<?x1152x16x16xf16>) -> tensor<?x1152x4x4xf16>
+    return %y : tensor<?x1152x4x4xf16>
+  }
+
+  // Broadcast Div with rhs lower-rank — trigger BroadcastDivToMulReciprocal.
+  // Shape pattern matches the canonical Gemma-3 projector RMSNorm divide.
+  func.func @test_broadcast_div_to_mul_reciprocal(
+      %x: tensor<?x256x1152xf16>, %y: tensor<?x256x1xf16>)
+      -> tensor<?x256x1152xf16> {
+    %z = "onnx.Div"(%x, %y)
+        : (tensor<?x256x1152xf16>, tensor<?x256x1xf16>)
+        -> tensor<?x256x1152xf16>
+    return %z : tensor<?x256x1152xf16>
+  }
+}
+
+// AvgPool decomp emits an onnx.Transpose with perm=[0,1,2,4,3,5] BEFORE
+// it lowers (the Transpose converter then turns it into the hip-dialect
+// equivalent). FileCheck on the perm attribute is the most reliable
+// signature — the surrounding Reshape / ReduceSum / Div forms are
+// implementation details that may move around.
+// CHECK-LABEL: func.func @test_avgpool_to_reshape_mean
+// CHECK-DAG: perm = [0, 1, 2, 4, 3, 5]
+// CHECK-NOT: onnx.AveragePool
+
+// Broadcast Div: onnx.Div is gone, replaced by Reciprocal + Mul which
+// then lower to hip.reciprocal + hip.mul. Either form (onnx.* mid-
+// pipeline or hip.* end-pipeline) proves the rewrite fired — check for
+// hip.reciprocal as the post-lowering signature.
+// CHECK-LABEL: func.func @test_broadcast_div_to_mul_reciprocal
+// CHECK-NOT: onnx.Div
+// CHECK-NOT: hip.div
+// CHECK: hip.reciprocal


### PR DESCRIPTION
## Summary (PR-9 of the #259 split — train tail, base #284)

Adds the vision/projector **compute-op** slice of #259 and finishes the Conv/Matmul **lowering ABI** whose runtime half already shipped in #284.

- **ProjectorOpsRewrites** (net-new): patch-embed Conv-ND -> Reshape/Gemm/Reshape, AveragePool(kernel==stride) -> Reshape/Transpose/ReduceMean, Pow(x,c) -> Mul chain, broadcasting Div -> Mul(Reciprocal).
- **FastGeluFusion**: exact-Gelu (Erf) + inlined-vision Gelu variants; peek-through Reciprocal/Div constants.
- **ConvLowering**: emit data_type (derived from output elem type) -> matches wrap_miopenConvolutionForward in #284.
- **MatmulLowering**: emit _batch_stride (compile-time-folded leading-dim product; rank-2 / leading-one B -> 0) -> matches wrap_hipblasLtMatmul in #284.
- **OnnxToHip pre-lowering**: FastGelu+Projector now run as a fixed-point quiescence loop (cap 4) so projector-emitted ops are re-visited next round. The upstream multi-round driver's `inferOnnxShapes` call is dropped — that ONNX-level forward inference was superseded on main by the HIP-dialect `--hip-infer-shapes` pass. Newly-emitted ops are typed **in-place at emission** (result types built explicitly from the dims the rewriter already knows); the `--hip-infer-shapes` pass (pipeline tail, post-conversion) resolves any residual dynamic dims.

> **Update — addressed review comment:** an earlier revision added an `OnnxResultTypeInference` helper (pure result-type rules for onnx.* ops) to type newly-emitted ops at emission. As noted in review, this is unnecessary now that shape inference + propagation (`--hip-infer-shapes`) covers it. The helper (`OnnxResultTypeInference.cpp/.h`) has been **removed** and its call sites inlined — each rewrite constructs its emitted ops' result types directly from the dims it already knows.

## Test plan

- [x] Full reconfigure + build + install clean (all new TUs compile).
- [x] LIT 208/208 pass — new `test_projector_rewrites.mlir`; `test_matmul.mlir` updated to 10-param + rank-3 leading-one B case.
- [ ] (post-merge of train) e2e vision-encoder accuracy on the dynamic-shape PR-1..#284 stack.
