### PR TITLE
feat(hip): add --hip-hoist-alloc-size-arith pass

### DIFF
--- a/include/hip/Dialect/Transforms/Passes.td
+++ b/include/hip/Dialect/Transforms/Passes.td
@@ -215,6 +215,132 @@ def PoolAllocsPass : Pass<"hip-pool-allocs", "mlir::func::FuncOp"> {
   ];
 }
 
+def HoistAllocSizeArithPass
+    : Pass<"hip-hoist-alloc-size-arith", "mlir::func::FuncOp"> {
+  let summary = "Hoist speculatable size arithmetic feeding memref.alloc dynamic "
+                "operands above the earliest dynamic memref.alloc in the entry "
+                "block";
+  let description = [{
+    Hoists speculatable producers of `memref.alloc` dynamic operands to a
+    point above the earliest dynamic `memref.alloc` in the function's
+    single entry block.  After this pass, every dynamic alloc's
+    dyn-operand SSA values dominate the earliest dynamic alloc — which is
+    exactly the precondition `--hip-pool-allocs` needs to anchor its
+    bucket-size arithmetic and `hip.get_pool` at a single-block-dominant
+    point.
+
+    Algorithm
+    ---------
+    Single-entry-block functions only (PoolAllocs already enforces this);
+    multi-block functions are skipped.  Only entry-block allocs are
+    considered — allocs nested inside region-carrying ops are untouched.
+
+    1. Collect every entry-block `memref.alloc` with at least one dynamic
+       operand.
+    2. Pick `earliestAlloc` = the one earliest in the block (per
+       `Operation::isBeforeInBlock`).
+    3. For each dynamic alloc, walk SSA backward from each of its dynamic
+       operands.  An op is hoistable when:
+         - it is in the entry block,
+         - it is below `earliestAlloc` (otherwise it already dominates),
+         - it is not a `memref.alloc` / `memref.alloca`,
+         - it satisfies `mlir::isSpeculatable(op)`,
+         - and every transitive operand is itself hoistable (or already
+           dominates `earliestAlloc`).
+    4. Topologically sorted (operands before uses), each hoistable op is
+       moved to immediately before `earliestAlloc`.  Forward iteration of
+       insertion order is operands-first, so each `moveBefore` pushes
+       prior moves up by one slot — final layout has the deepest operands
+       at the top of the hoist region.
+
+    Why "speculatable" is the right predicate
+    -----------------------------------------
+    `mlir::isSpeculatable` checks for both side effects AND undefined
+    behaviour.  Conditionally-speculatable ops (`arith.divsi`, `arith.divui`)
+    return false unless their divisor is a known-non-zero constant — so
+    hoisting them across a runtime guard cannot expose UB earlier.  This
+    is the same predicate upstream MLIR's LICM uses, and it admits new
+    arith ops automatically as the dialect evolves (vs. an explicit
+    allow-list that has to be maintained by hand).
+
+    Pipeline placement
+    ------------------
+    Wired into `buildOnnxToHipPipelineTail` between
+    `--hip-materialize-host-scalars` and `--hip-pool-allocs`.  Running
+    after host-scalar materialisation means rewrites that turn an alloc
+    into a `memref.view` over host scratch are visible (we will not try
+    to hoist their producers).  Running before pool-allocs means
+    pool-allocs sees IR where every dynamic alloc's operand chain has
+    already been pulled above the earliest dynamic alloc.
+
+    Why a separate pass (vs. an internal phase of pool-allocs)
+    ----------------------------------------------------------
+    `--hip-pool-allocs` deliberately does not move ops or fold shape
+    queries internally; it only places `hip.get_pool` + bucket-size
+    arithmetic at a single dominator point.  Keeping the hoist as a
+    standalone, separately-named pass — composed via the pipeline rather
+    than embedded in pool-allocs — keeps each pass single-purpose and is
+    idiomatic with MLIR convention (`--loop-invariant-code-motion`,
+    `--canonicalize`, IREE's `--iree-stream-emplace-transients`, etc.
+    are all standalone composable passes).
+
+    Caveat — does NOT pre-canonicalize
+    ----------------------------------
+    The pass moves existing ops; it does not duplicate, fold, or
+    simplify.  If an input IR has e.g. `arith.muli %x, %c0` (which would
+    fold to zero), this pass leaves it alone.  Canonicalisation runs
+    separately and earlier in the pipeline.
+
+    Idempotent: a second invocation finds no ops below `earliestAlloc`
+    that need moving, so it is a no-op.
+
+    Example IR (canonical case after bufferisation)
+    ------------------------------------------------------------
+
+    Before — `%6` and `%7` are speculatable but live below `%alloc`,
+    blocking single-block dominator-emit:
+
+    ```mlir
+    %dim   = memref.dim %arg, %c0 : memref<?x?xi64>
+    %dim_0 = memref.dim %arg, %c1 : memref<?x?xi64>
+    %alloc = memref.alloc(%dim, %dim_0) : memref<?x?xui8>
+    // ... unrelated ops ...
+    %6 = arith.muli %dim, %dim_0      : index
+    %7 = arith.muli %6,   %c4096      : index
+    %alloc_6 = memref.alloc(%7) : memref<3x?xi64>
+    ```
+
+    After — `%6` and `%7` hoisted to just before `%alloc`; original
+    locations now live above the earliest dynamic alloc:
+
+    ```mlir
+    %dim   = memref.dim %arg, %c0 : memref<?x?xi64>
+    %dim_0 = memref.dim %arg, %c1 : memref<?x?xi64>
+    %6 = arith.muli %dim, %dim_0      : index
+    %7 = arith.muli %6,   %c4096      : index
+    %alloc = memref.alloc(%dim, %dim_0) : memref<?x?xui8>
+    // ... unrelated ops ...
+    %alloc_6 = memref.alloc(%7) : memref<3x?xi64>
+    ```
+
+    Non-goals
+    ---------
+      - Multi-block functions: `--hip-pool-allocs` does not pool them
+        either, so they are silently skipped.  Allocs nested in
+        region-carrying ops within a single entry block are also left
+        untouched (only entry-block allocs are considered).
+      - Op duplication / cloning: an op with multiple uses is moved
+        once; hoisting follows existing SSA edges.  Cross-region cloning
+        à la IREE's `computeSizeSliceInRegion` is unnecessary for
+        single-block IR.
+      - Static-only allocs: no dynamic operands → nothing to hoist.
+  }];
+  let dependentDialects = [
+    "mlir::arith::ArithDialect",
+    "mlir::memref::MemRefDialect"
+  ];
+}
+
 def MaterializeHostScalarsPass
     : Pass<"hip-materialize-host-scalars", "mlir::func::FuncOp"> {
   let summary = "Redirect tiny host-fed memref.alloc ops to a host-mapped "

--- a/lib/Dialect/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Transforms/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(HipDialectTransforms STATIC
   AddHipContextArg.cpp
   BufferUtils.cpp
   GenerateInterface.cpp
+  HoistAllocSizeArith.cpp
   InferShapesPass.cpp
   LowerAllocs.cpp
   MaterializeHostScalars.cpp

--- a/lib/Dialect/Transforms/HoistAllocSizeArith.cpp
+++ b/lib/Dialect/Transforms/HoistAllocSizeArith.cpp
@@ -1,0 +1,259 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- HoistAllocSizeArith.cpp - Hoist alloc-size LICM for pool-allocs ----===//
+//
+// `--hip-hoist-alloc-size-arith` — hoists speculatable producers of
+// `memref.alloc` dynamic operands above the earliest dynamic
+// `memref.alloc` in the function's single entry block.  After this pass,
+// every dynamic alloc's dyn-operand SSA values dominate the earliest
+// dynamic alloc, which is exactly the precondition that
+// `--hip-pool-allocs`'s single-block dominator-emit phase needs.
+//
+// Why this pass exists
+// --------------------
+// `--hip-pool-allocs` is deliberately single-purpose: it anchors each
+// domain's `hip.get_pool` and bucket-size arithmetic at one block
+// position and does NOT move existing ops.  That position must dominate
+// every pooled alloc while being dominated by every alloc's dyn-operand
+// defs; if an alloc's dyn-operand def appears below the earliest pooled
+// alloc, pool-allocs splits a new domain rather than silently
+// mis-placing arithmetic.
+//
+// On bufferised graphs that condition is occasionally violated by
+// speculatable arithmetic that canonicalisation left interleaved with
+// allocs (e.g. `%6 = arith.muli %dim, %dim_0` after
+// `%alloc = memref.alloc(%dim, %dim_0)`).  This pass moves exactly that
+// arithmetic up — using MLIR's `mlir::isSpeculatable` predicate (the
+// same one upstream LICM uses) so safety is delegated to the standard
+// machinery, and ops that could trap (e.g. `arith.divsi` with a
+// runtime-zero divisor) stay where they are.
+//
+// Algorithm
+// ---------
+// Single-entry-block functions only (multi-block functions are skipped,
+// matching `--hip-pool-allocs`).  Only allocs that are direct children of
+// the entry block are considered; allocs nested inside region-carrying
+// ops are left untouched.
+//
+//   1. Collect every entry-block `memref.alloc` with at least one dynamic
+//      operand.
+//   2. Pick `earliestAlloc` = the one earliest in the block (per
+//      `Operation::isBeforeInBlock`).
+//   3. For each dynamic alloc, walk SSA backward from each dyn-operand.
+//      An op is hoistable when:
+//         - it lives in the entry block,
+//         - it is below `earliestAlloc` (otherwise it already dominates),
+//         - it is not a `memref.alloc` / `memref.alloca`,
+//         - it satisfies `mlir::isSpeculatable(op)`,
+//         - and every transitive operand is itself hoistable (or already
+//           dominates `earliestAlloc`).
+//      Hoistable ops are inserted into a SetVector.  Insertion order is
+//      operand-before-use because each op is inserted AFTER its operands
+//      have been recursed into.
+//   4. Forward iteration of the SetVector calls `op->moveBefore(
+//      earliestAlloc)` on each op.  Each `moveBefore` displaces prior
+//      moves up by one slot, so the deepest operands end up at the top
+//      of the hoist region and the closest-to-the-alloc ops at the
+//      bottom.  Final layout above the earliest alloc is a topological
+//      slice of the speculatable predecessor cone.
+//
+// Why not just mark hoistable=true unconditionally?
+// -------------------------------------------------
+// A chain `%loaded = memref.load ... ; %doubled = arith.muli %loaded,
+// %c2 ; %alloc(%doubled)` looks half-hoistable — `%doubled` IS
+// speculatable, but its operand `%loaded` is NOT.  Moving `%doubled`
+// above `%alloc` while `%loaded` stays below would break SSA dominance
+// at the new `%doubled` site.  The recursive check ensures we hoist
+// `%doubled` only when its entire transitive operand cone is also
+// hoistable (or already dominates `earliestAlloc`).
+//
+// Idempotence
+// -----------
+// A second invocation finds nothing below `earliestAlloc` that still
+// needs moving (everything in the cone now dominates), so the pass is a
+// no-op.  Verified by a LIT fixture.
+//
+// Example IR (the canonical case the regression tests pin down)
+// -------------------------------------------------------------
+//
+// Before:
+//
+//   %dim   = memref.dim %arg, %c0 : memref<?x?xi64>
+//   %dim_0 = memref.dim %arg, %c1 : memref<?x?xi64>
+//   %alloc = memref.alloc(%dim, %dim_0) : memref<?x?xui8>
+//   // ... unrelated ops ...
+//   %6 = arith.muli %dim, %dim_0      : index
+//   %7 = arith.muli %6,   %c4096      : index
+//   %alloc_6 = memref.alloc(%7) : memref<3x?xi64>
+//
+// After (`%6` and `%7` hoisted to just before `%alloc`):
+//
+//   %dim   = memref.dim %arg, %c0 : memref<?x?xi64>
+//   %dim_0 = memref.dim %arg, %c1 : memref<?x?xi64>
+//   %6 = arith.muli %dim, %dim_0      : index
+//   %7 = arith.muli %6,   %c4096      : index
+//   %alloc = memref.alloc(%dim, %dim_0) : memref<?x?xui8>
+//   // ... unrelated ops ...
+//   %alloc_6 = memref.alloc(%7) : memref<3x?xi64>
+//
+//===----------------------------------------------------------------------===//
+
+#include "hip/Dialect/Transforms/Passes.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/Statistic.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "hip-hoist-alloc-size-arith"
+
+STATISTIC(NumDynAllocsExamined,
+          "Number of memref.alloc ops with dynamic operands inspected");
+STATISTIC(NumOpsHoisted,
+          "Number of speculatable ops moved above the earliest dynamic alloc");
+
+namespace mlir {
+namespace hip {
+
+#define GEN_PASS_DEF_HOISTALLOCSIZEARITHPASS
+#include "hip/Dialect/Transforms/Passes.h.inc"
+
+namespace {
+
+/// Recursively determine whether \p value can be made to dominate
+/// \p earliestAlloc by hoisting speculatable predecessors that are
+/// currently below it.  Side-effect: every op on the path that needs to
+/// move is inserted into \p toMove (a SetVector — operand-before-use
+/// order is preserved by inserting after the recursion).
+///
+/// Return values:
+///   - `true`  — \p value already dominates `earliestAlloc`, OR is
+///               defined out-of-block, OR every op on the speculatable
+///               cone has been added to `toMove` (and will dominate
+///               after the move loop).
+///   - `false` — at least one op on the cone is non-speculatable
+///               (e.g. `memref.load`) or is itself an alloc; nothing on
+///               the cone of \p value can be safely hoisted.
+///
+/// `cache` memoises per-op verdicts so that ops shared across multiple
+/// dyn-operand chains are visited once.  Cycles cannot occur in pure
+/// SSA, but the optimistic-`true` insertion before the recursion
+/// defends against pathological IR without infinite recursion.
+static bool isReachableHoistable(Value value, Block *block,
+                                 Operation *earliestAlloc,
+                                 llvm::DenseMap<Operation *, bool> &cache,
+                                 llvm::SetVector<Operation *> &toMove) {
+  Operation *def = value.getDefiningOp();
+  if (!def)
+    return true;
+  if (def->getBlock() != block)
+    return true;
+  if (def->isBeforeInBlock(earliestAlloc))
+    return true;
+  if (isa<memref::AllocOp, memref::AllocaOp>(def))
+    return false;
+
+  auto it = cache.find(def);
+  if (it != cache.end())
+    return it->second;
+
+  if (!mlir::isSpeculatable(def)) {
+    cache[def] = false;
+    LLVM_DEBUG(llvm::dbgs()
+               << "  [non-speculatable] " << def->getName() << "\n");
+    return false;
+  }
+
+  cache[def] = true;
+  for (Value operand : def->getOperands()) {
+    if (!isReachableHoistable(operand, block, earliestAlloc, cache, toMove)) {
+      cache[def] = false;
+      return false;
+    }
+  }
+
+  toMove.insert(def);
+  LLVM_DEBUG(llvm::dbgs() << "  [hoist candidate] " << def->getName() << "\n");
+  return true;
+}
+
+struct HoistAllocSizeArithPass
+    : public impl::HoistAllocSizeArithPassBase<HoistAllocSizeArithPass> {
+
+  void runOnOperation() override;
+};
+
+void HoistAllocSizeArithPass::runOnOperation() {
+  func::FuncOp funcOp = getOperation();
+  if (funcOp.empty())
+    return;
+  if (!funcOp.getBody().hasOneBlock())
+    return;
+  Block &block = funcOp.getBody().front();
+
+  // Only entry-block allocs are candidates. getOps (vs. block.walk) is
+  // non-recursive on purpose: a recursive walk would also collect allocs
+  // nested inside region-carrying ops (scf.for/scf.if), whose results live
+  // in a different block — and the earliest-alloc selection and dominance
+  // checks below use Operation::isBeforeInBlock, which asserts same-block.
+  // An entry-block alloc's dynamic-size operands are themselves entry-block
+  // (or block args) by SSA dominance, so the operand walk also stays in-block.
+  SmallVector<memref::AllocOp> dynAllocs;
+  for (memref::AllocOp allocOp : block.getOps<memref::AllocOp>())
+    if (!allocOp.getDynamicSizes().empty())
+      dynAllocs.push_back(allocOp);
+  if (dynAllocs.empty())
+    return;
+  NumDynAllocsExamined += dynAllocs.size();
+
+  Operation *earliestAlloc =
+      *llvm::min_element(dynAllocs, [](memref::AllocOp a, memref::AllocOp b) {
+        return a->isBeforeInBlock(b);
+      });
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "[" DEBUG_TYPE "] @" << funcOp.getSymName() << ": "
+                 << dynAllocs.size()
+                 << " dynamic alloc(s); earliest = " << earliestAlloc->getName()
+                 << "\n";
+  });
+
+  llvm::DenseMap<Operation *, bool> cache;
+  llvm::SetVector<Operation *> toMove;
+  for (memref::AllocOp allocOp : dynAllocs) {
+    for (Value dynOp : allocOp.getDynamicSizes()) {
+      isReachableHoistable(dynOp, &block, earliestAlloc, cache, toMove);
+    }
+  }
+  if (toMove.empty()) {
+    LLVM_DEBUG(llvm::dbgs() << "[" DEBUG_TYPE "] no ops to hoist\n");
+    markAllAnalysesPreserved();
+    return;
+  }
+
+  // Forward iteration of toMove visits operands before uses (operands are
+  // inserted after the recursion descends into them).  Each moveBefore
+  // displaces the prior moves up by one slot, so the final layout above
+  // earliestAlloc is exactly the topologically-ordered hoist cone.
+  for (Operation *op : toMove)
+    op->moveBefore(earliestAlloc);
+  NumOpsHoisted += toMove.size();
+  LLVM_DEBUG(llvm::dbgs() << "[" DEBUG_TYPE "] hoisted " << toMove.size()
+                          << " op(s)\n");
+
+  // Hoisting within a single block does not change the CFG, only intra-block
+  // ordering.  No analyses depend on intra-block ordering, so everything is
+  // preserved.
+  markAllAnalysesPreserved();
+}
+
+} // namespace
+} // namespace hip
+} // namespace mlir

--- a/lib/Dialect/Transforms/Pipelines.cpp
+++ b/lib/Dialect/Transforms/Pipelines.cpp
@@ -102,6 +102,19 @@ static void buildOnnxToHipPipelineTail(OpPassManager &pm) {
   //     test/lit/Pipelines/ asserts this ordering does not regress.
   pm.addNestedPass<func::FuncOp>(hip::createMaterializeHostScalarsPass());
 
+  // 6c. Hoist speculatable size arithmetic feeding `memref.alloc` dynamic
+  //     operands above the earliest dynamic alloc in the entry block.
+  //     PoolAllocs's single-block dominator-emit phase requires every
+  //     dyn-operand SSA def to dominate the earliest pooled alloc; this
+  //     pass establishes that precondition for IR where canonicalize left
+  //     speculatable arith interleaved with allocs.  No-op for
+  //     already-feasible IR; PoolAllocs.cpp itself is unchanged.  Uses
+  //     `mlir::isSpeculatable` (the same predicate upstream LICM uses) so
+  //     traps (e.g. `arith.divsi` with a runtime-zero divisor) are not
+  //     speculated across the move.  See HoistAllocSizeArith.cpp for the
+  //     algorithm and rationale.
+  pm.addNestedPass<func::FuncOp>(hip::createHoistAllocSizeArithPass());
+
   pm.addNestedPass<func::FuncOp>(hip::createPoolAllocsPass());
 
   // 7. Lower remaining bufferization ops to memref

--- a/test/lit/Dialect/hip-hoist-alloc-size-arith.mlir
+++ b/test/lit/Dialect/hip-hoist-alloc-size-arith.mlir
@@ -165,3 +165,55 @@ func.func @do_not_hoist_through_load(%arg0: memref<?xi64>,
   memref.dealloc %alloc_1 : memref<?xf16>
   return
 }
+
+// --- 7. `arith.divsi` with a *runtime* (non-constant) divisor between two
+//        dynamic allocs.  `arith.divsi` is `ConditionallySpeculatable`:
+//        `mlir::isSpeculatable` returns true only when the divisor is a
+//        known-non-zero constant (case 2 above).  Here the divisor is a
+//        `memref.dim` result, which could be zero at runtime — the op may
+//        trap, so `isSpeculatable` returns false and the pass must NOT
+//        hoist `%div` (it stays below the first alloc).  The two
+//        speculatable `memref.dim` operands already dominate the alloc, so
+//        they are untouched.  This is the negative counterpart to case 2
+//        and guards the "div with runtime divisor stays put" invariant
+//        called out in the pass's header comment.
+// CHECK-LABEL: func.func @do_not_hoist_runtime_divisor_divsi
+// CHECK:         %[[DIM:.*]] = memref.dim
+// CHECK-NEXT:    %[[DIVISOR:.*]] = memref.dim
+// CHECK-NEXT:    %[[ALLOC0:.*]] = memref.alloc(%[[DIM]])
+// CHECK-NEXT:    %[[DIV:.*]] = arith.divsi %[[DIM]], %[[DIVISOR]]
+// CHECK-NEXT:    %[[ALLOC1:.*]] = memref.alloc(%[[DIV]])
+func.func @do_not_hoist_runtime_divisor_divsi(%arg0: memref<?xi64>,
+                                              %arg1: memref<?xi64>) {
+  %c0 = arith.constant 0 : index
+  %dim = memref.dim %arg0, %c0 : memref<?xi64>
+  %divisor = memref.dim %arg1, %c0 : memref<?xi64>
+  %alloc = memref.alloc(%dim) : memref<?xf16>
+  %div = arith.divsi %dim, %divisor : index
+  %alloc_1 = memref.alloc(%div) : memref<?xf16>
+  memref.dealloc %alloc : memref<?xf16>
+  memref.dealloc %alloc_1 : memref<?xf16>
+  return
+}
+
+// --- 8. Same as case 7 for `arith.divui`.  Both signed and unsigned
+//        integer division are `ConditionallySpeculatable` and both trap on
+//        a zero divisor, so a runtime divisor blocks the hoist identically.
+// CHECK-LABEL: func.func @do_not_hoist_runtime_divisor_divui
+// CHECK:         %[[DIM:.*]] = memref.dim
+// CHECK-NEXT:    %[[DIVISOR:.*]] = memref.dim
+// CHECK-NEXT:    %[[ALLOC0:.*]] = memref.alloc(%[[DIM]])
+// CHECK-NEXT:    %[[DIV:.*]] = arith.divui %[[DIM]], %[[DIVISOR]]
+// CHECK-NEXT:    %[[ALLOC1:.*]] = memref.alloc(%[[DIV]])
+func.func @do_not_hoist_runtime_divisor_divui(%arg0: memref<?xi64>,
+                                              %arg1: memref<?xi64>) {
+  %c0 = arith.constant 0 : index
+  %dim = memref.dim %arg0, %c0 : memref<?xi64>
+  %divisor = memref.dim %arg1, %c0 : memref<?xi64>
+  %alloc = memref.alloc(%dim) : memref<?xf16>
+  %div = arith.divui %dim, %divisor : index
+  %alloc_1 = memref.alloc(%div) : memref<?xf16>
+  memref.dealloc %alloc : memref<?xf16>
+  memref.dealloc %alloc_1 : memref<?xf16>
+  return
+}

--- a/test/lit/Dialect/hip-hoist-alloc-size-arith.mlir
+++ b/test/lit/Dialect/hip-hoist-alloc-size-arith.mlir
@@ -1,0 +1,167 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+//===----------------------------------------------------------------------===//
+// FileCheck tests for --hip-hoist-alloc-size-arith.
+//
+// The pass moves speculatable producers of `memref.alloc` dynamic operands
+// above the earliest dynamic `memref.alloc` in the function's single
+// entry block.  After the pass, every dyn-operand SSA def dominates the
+// earliest dynamic alloc — which is the precondition `--hip-pool-allocs`'s
+// single-block dominator-emit phase needs.
+//
+// These tests cover the pass in isolation (no PoolAllocs).  PoolAllocs's
+// own LIT remains unchanged — it consumes already-hoisted IR.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt --hip-hoist-alloc-size-arith %s 2>&1 | FileCheck %s
+
+// --- 1. Pure arith.muli between two dynamic allocs.  Both `%6` and
+//        `%7` are speculatable, both are below `%alloc`.  After the
+//        pass they appear above `%alloc` in operand-before-use order.
+// CHECK-LABEL: func.func @hoist_simple_chain
+// CHECK:         %[[DIM0:.*]] = memref.dim
+// CHECK:         %[[DIM1:.*]] = memref.dim
+// CHECK:         %[[MUL0:.*]] = arith.muli %[[DIM0]], %[[DIM1]]
+// CHECK:         %[[MUL1:.*]] = arith.muli %[[MUL0]], %{{.*}}
+// CHECK:         %[[ALLOC0:.*]] = memref.alloc(%[[DIM0]], %[[DIM1]])
+// CHECK:         %[[ALLOC1:.*]] = memref.alloc(%[[MUL1]])
+// CHECK:         memref.dealloc %[[ALLOC0]]
+// CHECK:         memref.dealloc %[[ALLOC1]]
+func.func @hoist_simple_chain(%arg0: memref<?x?xi64>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c4096 = arith.constant 4096 : index
+  %dim = memref.dim %arg0, %c0 : memref<?x?xi64>
+  %dim_0 = memref.dim %arg0, %c1 : memref<?x?xi64>
+  %alloc = memref.alloc(%dim, %dim_0) : memref<?x?xui8>
+  %6 = arith.muli %dim, %dim_0 : index
+  %7 = arith.muli %6, %c4096 : index
+  %alloc_6 = memref.alloc(%7) : memref<3x?xi64>
+  memref.dealloc %alloc : memref<?x?xui8>
+  memref.dealloc %alloc_6 : memref<3x?xi64>
+  return
+}
+
+// --- 2. Mixed-arith chain (addi / subi / divui / index_cast / select).
+//        Every op is speculatable when its operands are; the pass
+//        hoists the entire chain above the earliest dynamic alloc and
+//        preserves operand-before-use order.  `arith.divui` is
+//        `ConditionallySpeculatable` — `mlir::isSpeculatable` returns
+//        true here because the divisor is a known-non-zero constant.
+// CHECK-LABEL: func.func @hoist_mixed_arith_chain
+// CHECK:         %[[DIM:.*]] = memref.dim
+// CHECK:         %[[ADD:.*]] = arith.addi %[[DIM]], %{{.*}}
+// CHECK:         %[[SUB:.*]] = arith.subi %[[ADD]], %{{.*}}
+// CHECK:         %[[DIV:.*]] = arith.divui %[[SUB]], %{{.*}}
+// CHECK:         %[[CMP:.*]] = arith.cmpi sgt, %[[DIV]], %{{.*}}
+// CHECK:         %[[SEL:.*]] = arith.select %[[CMP]], %[[DIV]], %{{.*}}
+// CHECK:         %[[ALLOC0:.*]] = memref.alloc(%[[DIM]])
+// CHECK:         %[[ALLOC1:.*]] = memref.alloc(%[[SEL]])
+func.func @hoist_mixed_arith_chain(%arg0: memref<?xi64>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c8 = arith.constant 8 : index
+  %dim = memref.dim %arg0, %c0 : memref<?xi64>
+  %alloc = memref.alloc(%dim) : memref<?xf16>
+  %add = arith.addi %dim, %c8 : index
+  %sub = arith.subi %add, %c1 : index
+  %div = arith.divui %sub, %c2 : index
+  %cmp = arith.cmpi sgt, %div, %c1 : index
+  %sel = arith.select %cmp, %div, %c1 : index
+  %alloc_1 = memref.alloc(%sel) : memref<?xf16>
+  memref.dealloc %alloc : memref<?xf16>
+  memref.dealloc %alloc_1 : memref<?xf16>
+  return
+}
+
+// --- 3. `memref.load` between two dynamic allocs.  `memref.load` is
+//        NOT speculatable (read effect), so the pass must NOT hoist it.
+//        Verifies the side-effect filter.
+// CHECK-LABEL: func.func @do_not_hoist_load
+// CHECK:         %[[DIM:.*]] = memref.dim
+// CHECK-NEXT:    %[[ALLOC0:.*]] = memref.alloc(%[[DIM]])
+// CHECK-NEXT:    %[[LOAD:.*]] = memref.load
+// CHECK-NEXT:    %[[CAST:.*]] = arith.index_cast %[[LOAD]]
+// CHECK-NEXT:    %[[ALLOC1:.*]] = memref.alloc(%[[CAST]])
+func.func @do_not_hoist_load(%arg0: memref<?xi64>, %src: memref<1xi64>) {
+  %c0 = arith.constant 0 : index
+  %dim = memref.dim %arg0, %c0 : memref<?xi64>
+  %alloc = memref.alloc(%dim) : memref<?xf16>
+  %loaded = memref.load %src[%c0] : memref<1xi64>
+  %cast = arith.index_cast %loaded : i64 to index
+  %alloc_1 = memref.alloc(%cast) : memref<?xf16>
+  memref.dealloc %alloc : memref<?xf16>
+  memref.dealloc %alloc_1 : memref<?xf16>
+  return
+}
+
+// --- 4. `func.call` with no Pure trait between two dynamic allocs.
+//        Without `Pure` / `MemoryEffects::None` on the callee, the call
+//        is conservatively non-speculatable and must NOT be hoisted.
+//        Verifies the callable side-effect filter.
+// CHECK-LABEL: func.func @do_not_hoist_unmarked_call
+// CHECK:         %[[DIM:.*]] = memref.dim
+// CHECK-NEXT:    %[[ALLOC0:.*]] = memref.alloc(%[[DIM]])
+// CHECK-NEXT:    %[[CALL:.*]] = call @opaque_helper
+// CHECK-NEXT:    %[[ALLOC1:.*]] = memref.alloc(%[[CALL]])
+func.func private @opaque_helper(%x: index) -> index
+
+func.func @do_not_hoist_unmarked_call(%arg0: memref<?xi64>) {
+  %c0 = arith.constant 0 : index
+  %dim = memref.dim %arg0, %c0 : memref<?xi64>
+  %alloc = memref.alloc(%dim) : memref<?xf16>
+  %r = func.call @opaque_helper(%dim) : (index) -> index
+  %alloc_1 = memref.alloc(%r) : memref<?xf16>
+  memref.dealloc %alloc : memref<?xf16>
+  memref.dealloc %alloc_1 : memref<?xf16>
+  return
+}
+
+// --- 5. Already-hoisted IR.  Every dyn-operand def is above the
+//        earliest dynamic alloc — the pass is a no-op.  Verifies
+//        idempotence.
+// CHECK-LABEL: func.func @already_hoisted
+// CHECK:         %[[DIM:.*]] = memref.dim
+// CHECK-NEXT:    %[[MUL:.*]] = arith.muli %[[DIM]], %{{.*}}
+// CHECK-NEXT:    %[[ALLOC0:.*]] = memref.alloc(%[[DIM]])
+// CHECK-NEXT:    %[[ALLOC1:.*]] = memref.alloc(%[[MUL]])
+func.func @already_hoisted(%arg0: memref<?xi64>) {
+  %c0 = arith.constant 0 : index
+  %c2 = arith.constant 2 : index
+  %dim = memref.dim %arg0, %c0 : memref<?xi64>
+  %mul = arith.muli %dim, %c2 : index
+  %alloc = memref.alloc(%dim) : memref<?xf16>
+  %alloc_1 = memref.alloc(%mul) : memref<?xf16>
+  memref.dealloc %alloc : memref<?xf16>
+  memref.dealloc %alloc_1 : memref<?xf16>
+  return
+}
+
+// --- 6. Mixed chain: `arith.muli %loaded, %c2` is itself speculatable
+//        but its operand `%loaded` (memref.load) is NOT.  The pass
+//        must NOT hoist `%mul` either — the recursive operand check
+//        bails the whole chain out.  Verifies "stop-at-non-speculatable"
+//        propagates upward through the chain.
+// CHECK-LABEL: func.func @do_not_hoist_through_load
+// CHECK:         %[[DIM:.*]] = memref.dim
+// CHECK-NEXT:    %[[ALLOC0:.*]] = memref.alloc(%[[DIM]])
+// CHECK-NEXT:    %[[LOAD:.*]] = memref.load
+// CHECK-NEXT:    %[[CAST:.*]] = arith.index_cast %[[LOAD]]
+// CHECK-NEXT:    %[[MUL:.*]] = arith.muli %[[CAST]], %{{.*}}
+// CHECK-NEXT:    %[[ALLOC1:.*]] = memref.alloc(%[[MUL]])
+func.func @do_not_hoist_through_load(%arg0: memref<?xi64>,
+                                     %src: memref<1xi64>) {
+  %c0 = arith.constant 0 : index
+  %c2 = arith.constant 2 : index
+  %dim = memref.dim %arg0, %c0 : memref<?xi64>
+  %alloc = memref.alloc(%dim) : memref<?xf16>
+  %loaded = memref.load %src[%c0] : memref<1xi64>
+  %cast = arith.index_cast %loaded : i64 to index
+  %mul = arith.muli %cast, %c2 : index
+  %alloc_1 = memref.alloc(%mul) : memref<?xf16>
+  memref.dealloc %alloc : memref<?xf16>
+  memref.dealloc %alloc_1 : memref<?xf16>
+  return
+}


### PR DESCRIPTION
<!--
Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
Licensed under the MIT License.
-->

> **Note:** This supersedes #293, which was merged into `fhanuman.pool-design-doc` by mistake instead of `main`. Same two commits, now rebased onto and targeting `main`.

## Summary
Stack PR **2/4** (base: `main`, after #286). Adds `--hip-hoist-alloc-size-arith`, a standalone MLIR pass that moves the speculatable producers of `memref.alloc` dynamic operands above the earliest dynamic alloc in a function's single entry block. After it runs, every dynamic alloc's size operands dominate the earliest dynamic alloc — which is exactly the precondition the per-domain placement engine in #287 needs to anchor each bucket's size arithmetic and `hip.get_pool` at one block-dominant point. In practice it is what keeps the common case collapsed to a single pool domain. `lib/Dialect/Transforms/PoolAllocs.cpp` is untouched.

**Why a separate pass (not a phase inside `hip-pool-allocs`):** the #286 design deliberately keeps "make hoistable" and "place pool" as separate concerns. Folding the hoist into the placement pass would re-introduce exactly the internal-phase coupling that earlier stages removed. A standalone, separately-named pass is also the MLIR/LLVM/IREE convention (`--loop-invariant-code-motion`, `--canonicalize`, `--iree-stream-emplace-transients` are all standalone, composable passes) and lets the hoist and the placement be tested in isolation.

**What's in this PR (behavioural):**

* **New `--hip-hoist-alloc-size-arith` pass** (`lib/Dialect/Transforms/HoistAllocSizeArith.cpp`). For each `memref.alloc` with dynamic operands it walks the SSA producers of those operands and moves the speculatable ones to just above the earliest dynamic alloc in the entry block. It only *moves* existing ops — it never duplicates, folds, or canonicalises — and it is idempotent (a second run finds nothing below the earliest alloc to move).
* **Predicate is `mlir::isSpeculatable`** — the same one upstream LICM uses — rather than a hand-maintained allow-list. Conditionally-speculatable ops (`arith.divsi` / `arith.divui` with a runtime divisor) return `false`, so an op that could trap is never hoisted across a guard. Non-speculatable producers (`memref.load`, opaque `func.call`) stop the walk, and the transitive-operand check guarantees a dependent is never hoisted above an operand that stays put.
* **Single entry block only.** Multi-block / multi-region functions are skipped unchanged — `--hip-pool-allocs` does not pool them either. Candidate allocs are collected by direct entry-block iteration (not a recursive walk), matching `hip-pool-allocs` and keeping the `Operation::isBeforeInBlock` ordering checks same-block-safe.
* **Pipeline placement:** wired into `buildOnnxToHipPipelineTail` between `--hip-materialize-host-scalars` and `--hip-pool-allocs`, so host-scalar rewrites are already visible and pool-allocs sees IR whose dynamic-alloc operand chains are pre-hoisted.

## Stack
1. #286 — design doc (base: `main`, merged)
2. **this PR** — `--hip-hoist-alloc-size-arith` pass (base: `main`; supersedes #293) ← you are here
3. #287 — pool placement engine + runtime ABI
4. #288 — reshape-dim resolution
