### PR TITLE
feat(conversion): onnx.LpNormalization decomposition (#259 split 4/N)

### DIFF
--- a/lib/Conversion/OnnxToHip/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHip/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(OnnxToHip STATIC
   RangeConversion.cpp
   FastGeluFusion.cpp
   ProjectorOpsRewrites.cpp
+  LpNormalizationConversion.cpp
   EqualConversion.cpp
   DivConversion.cpp
   ReduceMaxConversion.cpp

--- a/lib/Conversion/OnnxToHip/LpNormalizationConversion.cpp
+++ b/lib/Conversion/OnnxToHip/LpNormalizationConversion.cpp
@@ -1,0 +1,225 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- LpNormalizationConversion.cpp - Decompose onnx.LpNormalization ----===//
+//
+// `onnx.LpNormalization` (opset 22) computes
+//
+//     output = input / Lp_norm(input, axis)
+//
+// where `Lp_norm` reduces along a single user-specified `axis` and `p` is
+// either 1 or 2. There is no MIOpen / hipBLASLt primitive that maps 1:1 to
+// this op; instead we rewrite it at the ONNX level as a small chain of ops
+// that already have HIP converters:
+//
+//   p == 2:
+//     %x_sq    = onnx.Mul(%x, %x)                        // same shape as %x
+//     %sum_sq  = onnx.ReduceSum(%x_sq, [axis], keepdims=1)
+//     %norm    = onnx.Sqrt(%sum_sq)
+//     %result  = onnx.Div(%x, %norm)                     // broadcasts on axis
+//
+//   p == 1:
+//     %x_sq    = onnx.Mul(%x, %x)
+//     %abs_x   = onnx.Sqrt(%x_sq)                        // |x| via sqrt(x^2)
+//     %norm    = onnx.ReduceSum(%abs_x, [axis], keepdims=1)
+//     %result  = onnx.Div(%x, %norm)
+//
+// The pattern runs in the convert-onnx-to-hip pre-lowering loop next to
+// FastGeluFusion / ProjectorOpsRewrites. Putting it there matters: the
+// pre-lowering loop rewrites with `GreedyRewriteStrictness::ExistingOps`
+// over MULTIPLE rounds, so the freshly-emitted onnx.Mul / onnx.Sqrt /
+// onnx.ReduceSum / onnx.Div ops become "existing" by the next round and
+// reach the main `convertComputeOps` driver below as ordinary onnx.* ops.
+// A pattern living inside `convertComputeOps` itself would not get the
+// same treatment — that driver is single-shot and would leave the
+// freshly-created onnx.* primitives unconverted, tripping the survival
+// check at the bottom of the pass.
+//
+// The broadcasting Div with a smaller-rank rhs is intentionally LEFT to
+// `BroadcastDivToMulReciprocal` (also in the pre-lowering loop) which
+// rewrites it into Mul(x, Reciprocal(norm)) — `hip.div`'s flat
+// element-wise kernel does not broadcast.
+//
+// Spec note: ONNX 22's text says "When the Lp norm is zero ... the output
+// is defined to be zero to avoid division by zero." The accompanying
+// example, however, computes `y = x / norm` directly, which produces
+// NaN/Inf when the norm is zero. Matching the canonical ORT CPU
+// behaviour (and the example) we do the simple division here. Adding
+// strict spec compliance would cost an Equal + Where pair around the
+// final Div; revisit if a downstream model trips the all-zero edge case.
+//
+// Before:
+//   %y = onnx.LpNormalization(%x) {axis = -1, p = 2}
+//        : (tensor<2x3xf32>) -> tensor<2x3xf32>
+//
+// After (p=2, conceptual — the pre-lowering loop's Div rewriter then
+// turns the broadcasting Div into Mul + Reciprocal before hip lowering):
+//   %x_sq   = onnx.Mul(%x, %x) : tensor<2x3xf32>
+//   %axes   = onnx.Constant {value = dense<[1]>}      : tensor<1xi64>
+//   %sum_sq = onnx.ReduceSum(%x_sq, %axes) {keepdims = 1, ...}
+//             : (tensor<2x3xf32>, tensor<1xi64>) -> tensor<2x1xf32>
+//   %norm   = onnx.Sqrt(%sum_sq) : tensor<2x1xf32>
+//   %y      = onnx.Div(%x, %norm)
+//             : (tensor<2x3xf32>, tensor<2x1xf32>) -> tensor<2x3xf32>
+//
+//===----------------------------------------------------------------------===//
+
+#include "OnnxToHipUtils.h"
+
+#include "llvm/ADT/Statistic.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "lpnormalization-decompose"
+
+STATISTIC(NumLpNormalizationRewrites,
+          "onnx.LpNormalization rewrites into Mul / ReduceSum / Sqrt / Div");
+
+namespace mlir {
+namespace hip {
+
+namespace {
+
+/// Decomposes `onnx.LpNormalization` into a chain of already-supported ONNX
+/// primitives. See file header for the rewrite shape and the rationale for
+/// living in the pre-lowering loop instead of `convertComputeOps`.
+struct LpNormalizationDecompose : public mlir::RewritePattern {
+  LpNormalizationDecompose(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.LpNormalization", /*benefit=*/2, ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override {
+    if (op->getNumOperands() != 1 || op->getNumResults() != 1)
+      return rewriter.notifyMatchFailure(op, "lpnorm.arity");
+
+    mlir::Value x = op->getOperand(0);
+    auto inputType = mlir::dyn_cast<mlir::RankedTensorType>(x.getType());
+    auto outputType =
+        mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
+    if (!inputType || !outputType)
+      return rewriter.notifyMatchFailure(op, "lpnorm.not_ranked");
+    if (inputType.getShape() != outputType.getShape() ||
+        inputType.getElementType() != outputType.getElementType())
+      return rewriter.notifyMatchFailure(op, "lpnorm.in_out_type_mismatch");
+
+    int64_t rank = inputType.getRank();
+    if (rank == 0)
+      return rewriter.notifyMatchFailure(op, "lpnorm.scalar_input");
+
+    // Read `axis` (default -1).
+    int64_t axis = -1;
+    if (auto axisAttr = op->getAttrOfType<mlir::IntegerAttr>("axis"))
+      axis = axisAttr.getSInt();
+    int64_t normAxis = axis < 0 ? axis + rank : axis;
+    if (normAxis < 0 || normAxis >= rank)
+      return rewriter.notifyMatchFailure(op, "lpnorm.axis_oob");
+
+    // Read `p` (default 2). Spec: only 1 and 2 are supported.
+    int64_t p = 2;
+    if (auto pAttr = op->getAttrOfType<mlir::IntegerAttr>("p"))
+      p = pAttr.getSInt();
+    if (p != 1 && p != 2)
+      return rewriter.notifyMatchFailure(op, "lpnorm.p_not_1_or_2");
+
+    // ONNX type-constraint T: bfloat16 / float16 / float / double. The
+    // decomposed primitives (Mul, ReduceSum, Sqrt, Div) must each see a
+    // floating-point element type — refuse anything else loudly so a
+    // future opset extension surfaces here instead of in some downstream
+    // converter.
+    auto elemType = inputType.getElementType();
+    if (!elemType.isF16() && !elemType.isF32() && !elemType.isBF16() &&
+        !elemType.isF64())
+      return rewriter.notifyMatchFailure(op, "lpnorm.elem_type_not_float");
+
+    mlir::Location loc = op->getLoc();
+    mlir::MLIRContext *ctx = rewriter.getContext();
+
+    // Reduced shape: same as input but with a `1` along the reduce axis
+    // (keepdims=1). Dynamic dims on other axes pass through unchanged.
+    llvm::SmallVector<int64_t> reducedShape(inputType.getShape().begin(),
+                                            inputType.getShape().end());
+    reducedShape[normAxis] = 1;
+    auto reducedType = mlir::RankedTensorType::get(reducedShape, elemType);
+
+    // Step 1: %x_sq = Mul(x, x). Element-wise, same shape/type as input.
+    mlir::OperationState mulState(loc, "onnx.Mul");
+    mulState.addOperands({x, x});
+    mulState.addTypes(inputType);
+    mlir::Value xSq = rewriter.create(mulState)->getResult(0);
+
+    // Step 2 (p=1 only): %abs_x = Sqrt(%x_sq) = |x|.  We avoid emitting an
+    // explicit `onnx.Abs` because there is no `onnx.Abs` converter in this
+    // pipeline and we don't want to add one just for this one decomposition.
+    mlir::Value reduceInput = xSq;
+    if (p == 1) {
+      mlir::OperationState sqrtState(loc, "onnx.Sqrt");
+      sqrtState.addOperands(xSq);
+      sqrtState.addTypes(inputType);
+      reduceInput = rewriter.create(sqrtState)->getResult(0);
+    }
+
+    // Step 3: %reduced = ReduceSum(reduceInput, axes=[normAxis], keepdims=1).
+    // Build the axes constant inline; the existing ReduceSum converter
+    // accepts axes either as an attribute or as an operand. We use the
+    // operand form so the reduction axis is visible to InferOnnxShapes.
+    auto i64Type = rewriter.getI64Type();
+    auto axesType = mlir::RankedTensorType::get({1}, i64Type);
+    auto axesValueAttr = mlir::DenseElementsAttr::get(
+        axesType, llvm::ArrayRef<int64_t>{normAxis});
+    mlir::OperationState axesState(loc, "onnx.Constant");
+    axesState.addTypes(axesType);
+    axesState.addAttribute("value", axesValueAttr);
+    mlir::Value axes = rewriter.create(axesState)->getResult(0);
+
+    // ONNX importers / hand-written IR alike normally encode `keepdims` and
+    // `noop_with_empty_axes` as `si64` IntegerAttr. Construct them
+    // explicitly so the existing ReduceSum converter reads the right value
+    // through `getSInt()`.
+    auto sintType = mlir::IntegerType::get(ctx, 64, mlir::IntegerType::Signed);
+    mlir::OperationState reduceState(loc, "onnx.ReduceSum");
+    reduceState.addOperands({reduceInput, axes});
+    reduceState.addTypes(reducedType);
+    reduceState.addAttribute("keepdims", mlir::IntegerAttr::get(sintType, 1));
+    reduceState.addAttribute("noop_with_empty_axes",
+                             mlir::IntegerAttr::get(sintType, 0));
+    mlir::Value reduced = rewriter.create(reduceState)->getResult(0);
+
+    // Step 4 (p=2 only): %norm = Sqrt(%reduced).  For p=1 the reduce result
+    // already IS the norm.
+    mlir::Value norm = reduced;
+    if (p == 2) {
+      mlir::OperationState sqrtState(loc, "onnx.Sqrt");
+      sqrtState.addOperands(reduced);
+      sqrtState.addTypes(reducedType);
+      norm = rewriter.create(sqrtState)->getResult(0);
+    }
+
+    // Step 5: %result = Div(%x, %norm).  `norm` has shape `[..., 1, ...]`
+    // (the reduce axis is 1, all others match `x`), so this Div broadcasts
+    // along the reduce axis. `BroadcastDivToMulReciprocal` (also in the
+    // pre-lowering loop) will rewrite this into Mul(x, Reciprocal(norm))
+    // before HIP lowering — `hip.div` itself is non-broadcasting.
+    mlir::OperationState divState(loc, "onnx.Div");
+    divState.addOperands({x, norm});
+    divState.addTypes(outputType);
+    mlir::Value result = rewriter.create(divState)->getResult(0);
+
+    rewriter.replaceOp(op, result);
+    ++NumLpNormalizationRewrites;
+    LLVM_DEBUG(llvm::dbgs()
+               << "[" DEBUG_TYPE "] decomposed LpNormalization " << inputType
+               << " axis=" << normAxis << " p=" << p << "\n");
+    return mlir::success();
+  }
+};
+
+} // namespace
+
+void populateLpNormalizationConversionPatterns(RewritePatternSet &patterns,
+                                               MLIRContext *ctx) {
+  patterns.add<LpNormalizationDecompose>(ctx);
+}
+
+} // namespace hip
+} // namespace mlir

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -757,6 +757,7 @@ void ConvertOnnxToHipPass::runOnOperation() {
         populateReshapeShapeFoldPatterns(preLoweringPatterns, ctx);
         populateFastGeluFusionPatterns(preLoweringPatterns, ctx);
         populateProjectorOpsRewritePatterns(preLoweringPatterns, ctx);
+        populateLpNormalizationConversionPatterns(preLoweringPatterns, ctx);
         ChangeFlagListener listener;
         mlir::GreedyRewriteConfig preLoweringConfig;
         preLoweringConfig.setStrictness(

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
@@ -306,6 +306,15 @@ void populateFastGeluFusionPatterns(RewritePatternSet &patterns,
 void populateProjectorOpsRewritePatterns(RewritePatternSet &patterns,
                                          MLIRContext *ctx);
 
+/// Pre-lowering pattern set: decompose `onnx.LpNormalization` into a small
+/// chain of already-supported ONNX primitives (Mul / Sqrt / ReduceSum /
+/// Div). Lives in the pre-lowering loop next to FastGeluFusion /
+/// ProjectorOpsRewrites so the freshly-emitted onnx.* primitives become
+/// "existing" ops by the next round and reach `convertComputeOps`'s
+/// converters as ordinary onnx.* ops. See LpNormalizationConversion.cpp.
+void populateLpNormalizationConversionPatterns(RewritePatternSet &patterns,
+                                               MLIRContext *ctx);
+
 } // namespace hip
 } // namespace mlir
 

--- a/test/lit/Conversion/onnx-to-hip/test_lpnormalization.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_lpnormalization.mlir
@@ -1,0 +1,72 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
+
+// LpNormalization decomposes in the convert-onnx-to-hip pre-lowering loop
+// into Mul(x,x) -> ReduceSum(axis, keepdims=1) -> Sqrt -> Div(x, norm). The
+// final Div broadcasts (rhs has 1 along the reduce axis), so
+// BroadcastDivToMulReciprocal -- also in the pre-lowering loop -- rewrites
+// it into Mul(x, Reciprocal(norm)). The expected hip.* op set is therefore:
+// hip.mul, hip.reduce_sum, hip.sqrt, hip.reciprocal, hip.mul. p=1 gets one
+// extra hip.sqrt for the Sqrt(x*x)=|x| step.
+
+module {
+  func.func @main_graph(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+    return %arg0 : tensor<4xf32>
+  }
+
+  // Default p=2, axis=-1 on a static rank-2 f32 input.
+  func.func @lp_norm_p2_default_f32(%x: tensor<2x3xf32>) -> tensor<2x3xf32> {
+    %r = "onnx.LpNormalization"(%x) {axis = -1 : si64, p = 2 : si64}
+        : (tensor<2x3xf32>) -> tensor<2x3xf32>
+    return %r : tensor<2x3xf32>
+  }
+  // CHECK-LABEL: func.func @lp_norm_p2_default_f32
+  // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[X:.*]]: tensor<2x3xf32>)
+  // CHECK-NOT: onnx.LpNormalization
+  // CHECK-NOT: onnx.Div
+  // CHECK: hip.mul(%[[CTX]]) ins(%[[X]], %[[X]]
+  // CHECK: hip.reduce_sum
+  // CHECK: hip.sqrt
+  // CHECK: hip.reciprocal
+  // CHECK: hip.mul
+
+  // p=1, explicit axis=1 on a rank-3 f16 input. p=1 path inserts an extra
+  // Sqrt(x*x) before the reduction to compute |x|.
+  func.func @lp_norm_p1_axis1_f16(%x: tensor<2x4x5xf16>) -> tensor<2x4x5xf16> {
+    %r = "onnx.LpNormalization"(%x) {axis = 1 : si64, p = 1 : si64}
+        : (tensor<2x4x5xf16>) -> tensor<2x4x5xf16>
+    return %r : tensor<2x4x5xf16>
+  }
+  // CHECK-LABEL: func.func @lp_norm_p1_axis1_f16
+  // CHECK-NOT: onnx.LpNormalization
+  // p=1 path: Mul(x,x) -> Sqrt(=abs) -> ReduceSum -> ... -> Reciprocal -> Mul
+  // CHECK: hip.mul
+  // CHECK: hip.sqrt
+  // CHECK: hip.reduce_sum
+  // CHECK: hip.reciprocal
+  // CHECK: hip.mul
+
+  // Dynamic batch + sequence dims; static feature dim along the reduce axis.
+  // Verifies the decomposition handles dynamic shapes through the
+  // tensor.dim + tensor.empty plumbing inherited from the primitive
+  // converters (Mul / ReduceSum / Sqrt / Reciprocal).
+  func.func @lp_norm_dynamic(%x: tensor<?x?x16xf32>) -> tensor<?x?x16xf32> {
+    %r = "onnx.LpNormalization"(%x) {axis = -1 : si64, p = 2 : si64}
+        : (tensor<?x?x16xf32>) -> tensor<?x?x16xf32>
+    return %r : tensor<?x?x16xf32>
+  }
+  // CHECK-LABEL: func.func @lp_norm_dynamic
+  // CHECK-SAME: (%[[CTX2:.*]]: !hip.context, %[[X2:.*]]: tensor<?x?x16xf32>)
+  // CHECK-NOT: onnx.LpNormalization
+  // CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+  // CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+  // CHECK: tensor.dim
+  // CHECK: tensor.dim
+  // CHECK: hip.mul
+  // CHECK: hip.reduce_sum
+  // CHECK: hip.sqrt
+  // CHECK: hip.reciprocal
+  // CHECK: hip.mul
+}

--- a/test/lit/e2e/test_lpnormalization_model.mlir
+++ b/test/lit/e2e/test_lpnormalization_model.mlir
@@ -1,0 +1,37 @@
+// RUN: hip-mlir-opt %s --hipdnn-pipeline | FileCheck %s
+
+// Test onnx.LpNormalization E2E full pipeline.
+// This IR represents an ONNX LpNormalization operation as it would be
+// imported via onnx-mlir / morphizen mlir-imp.
+//
+// Verifies the complete hipdnn-pipeline:
+// 1. convert-onnx-to-hip: onnx.LpNormalization decomposes into
+//    Mul / ReduceSum / Sqrt / Div, each handled by its own converter.
+//    The broadcasting Div is rewritten by BroadcastDivToMulReciprocal
+//    into Mul(x, Reciprocal(norm)). No new HIP op or runtime symbol is
+//    introduced — only existing primitives are exercised.
+// 2. canonicalize: simplify redundant operations
+// 3. memory-pooling: pool output buffer into single allocation
+// 4. convert-hip-to-llvm: HIP ops -> LLVM runtime calls
+//    (wrap_miopenOpTensor for Mul, wrap_reduce_sum for ReduceSum,
+//     wrap_power for Sqrt + Reciprocal)
+// 5. generate-interface: create inference_init/compute/cleanup/metadata
+
+// CHECK: module attributes {
+// CHECK-SAME: hipdnn.input_count = 1
+// CHECK-SAME: hipdnn.output_count = 1
+// CHECK-DAG: llvm.func @wrap_miopenOpTensor
+// CHECK-DAG: llvm.func @wrap_reduce_sum
+// CHECK-DAG: llvm.func @wrap_power
+// CHECK-DAG: llvm.func @inference_init
+// CHECK-DAG: llvm.func @inference_compute
+// CHECK-DAG: llvm.func @inference_cleanup
+// CHECK-DAG: llvm.func @inference_get_metadata_json
+// CHECK-NOT: onnx.LpNormalization
+module {
+  func.func @main_graph(%arg0: tensor<2x3xf32> {onnx.name = "input"}) -> (tensor<2x3xf32> {onnx.name = "output"}) {
+    %0 = "onnx.LpNormalization"(%arg0) {axis = -1 : si64, p = 2 : si64, onnx_node_name = "lpnorm_node"} : (tensor<2x3xf32>) -> tensor<2x3xf32>
+    "onnx.Return"(%0) : (tensor<2x3xf32>) -> ()
+  }
+  "onnx.EntryPoint"() {func = @main_graph} : () -> ()
+}


### PR DESCRIPTION
﻿Part 4 of the #259 mega-PR split. **Base = `pr259-split/09-vision-projector-compute` (PR #308)** — this PR stacks on PR-9 and should be reviewed/merged after it.

## What
Adds `onnx.LpNormalization` (opset 22) support by decomposing it at the ONNX level into a chain of ops that already have HIP converters. No new HIP dialect op or runtime kernel.

- `p == 2`: `x_sq = Mul(x,x)` -> `ReduceSum(x_sq, axis, keepdims=1)` -> `Sqrt` -> `Div(x, norm)`
- `p == 1`: `x_sq = Mul(x,x)` -> `Sqrt` (= `|x|`) -> `ReduceSum(.., axis, keepdims=1)` -> `Div(x, norm)`

## Why (rationale carried from #259)
- **No 1:1 primitive.** There is no MIOpen / hipBLASLt op that maps directly to LpNormalization, so we rewrite rather than add a bespoke kernel.
- **Why the pre-lowering loop, not `convertComputeOps`.** The pattern is registered next to `FastGeluFusion` / `ProjectorOpsRewrites` in the `convert-onnx-to-hip` `ExistingOps` fixed-point round loop. Freshly-emitted `onnx.*` primitives become "existing" by the next round and reach the `convertComputeOps` driver as ordinary ops. A pattern inside `convertComputeOps` (single-shot) would leave the new primitives unconverted and trip the survival check.
- **Why this depends on PR-9.** The final step emits a **broadcasting** `onnx.Div` (`norm` has shape `[...,1,...]`). `hip.div`'s flat element-wise kernel does **not** broadcast, so the broadcasting Div is intentionally left to `BroadcastDivToMulReciprocal` (introduced in PR-9) which rewrites it into `Mul(x, Reciprocal(norm))` before HIP lowering.
- **Spec edge case.** ONNX 22 defines zero-norm output as zero, but the accompanying example divides directly (NaN/Inf on zero norm). We match ORT CPU behaviour and the example with the plain division; strict compliance would cost an `Equal + Where` pair around the final Div. Revisit if a downstream model trips the all-zero edge case.

## Tests
- `test/lit/Conversion/onnx-to-hip/test_lpnormalization.mlir` (p=1, p=2, axis variants)
- `test/lit/e2e/test_lpnormalization_model.mlir`
- Full lit suite: **210/210 pass** (208 baseline + 2 new).
