### PR TITLE
feat(onnx-to-hip): fix dynamic-shape sizing for Expand/Tile/Range

### DIFF
--- a/lib/Conversion/OnnxToHip/ExpandConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ExpandConversion.cpp
@@ -5,16 +5,137 @@
 
 #include "OnnxToHipUtils.h"
 
+// Lowers `onnx.Expand` to `tensor.empty` + `hip.expand`.  For dynamic result
+// dims that come from the 1-D `shape` operand, we avoid `tensor.extract` on a
+// `tensor.from_elements` shape vector when each element traces to
+// `tensor.dim(source, k)` or a compile-time constant.  That keeps the
+// bufferized size chain in the `memref.dim` / `arith.*` form `hip-pool-allocs`
+// can hoist, instead of `memref.load` from a shared shape scratch buffer
+// (dominance failure when two Expands reuse one Shape result).
+//
+// Symmetric to `GatherShapeFold.cpp`, which collapses Gather(Shape, const) ->
+// tensor.dim.  Here the idiom is Shape(x) -> from_elements -> Expand, and we
+// read dims directly from x for `tensor.empty` sizing.
+//
+// ONNX Expand broadcast semantics (v8/v13 spec):
+//   per-axis output_dim[k] = max(input_dim[k'], shape_value[s']).
+// Critically: ONNX Expand is NOT numpy.broadcast_to.  When shape[s] == 1 but
+// input has input_dim > 1 at the corresponding axis, the spec says the output
+// dim is input_dim (identity broadcast), NOT 1.  This is rare in LLM-style
+// exports (which build shape from `Shape(x)` so SSA-traced values already
+// equal input_dim), but some HF vision-encoder exports emit literal
+// `Expand(x, [1, 1, ...])` with x rank > 0 -- a pure no-op at runtime, but
+// only if we honour max(input_dim, shape_value).  When the shape operand is an
+// opaque constant we cannot peek into, we emit
+// `arith.maxsi(tensor.dim(input, k), index_cast(extract(shape, k)))` instead
+// of just `index_cast(extract(shape, k))`.
+//
+// Before (broken on `Expand([3136,1152]xf16, dense<[1,1]>) -> [?, 1152]`):
+//   %v = tensor.extract %shape[%c0] : tensor<2xi64>      // = 1
+//   %d = arith.index_cast %v : i64 to index              // = 1
+//   %t = tensor.empty(%d) : tensor<?x1152xf16>           // = tensor<1x1152>
+//
+// After:
+//   %sv = tensor.extract %shape[%c0] : tensor<2xi64>     // = 1
+//   %sd = arith.index_cast %sv : i64 to index            // = 1
+//   %id = tensor.dim %input, %c0 : tensor<3136x1152xf16> // = 3136
+//   %d  = arith.maxsi %id, %sd : index                   // = 3136
+//   %t  = tensor.empty(%d) : tensor<?x1152xf16>          // = tensor<3136x1152>
+//
+// Compile-time fast paths (skip the `tensor.dim` + `maxsi` op pair):
+//   - input_idx < 0  (shape rank > input rank, leading output axis with no
+//                     input counterpart): output_dim = shape_value.
+//   - input_dim is statically 1: max(1, shape) == shape, so output_dim =
+//                                shape_value.  Preserves IR shape for the
+//                                canonical attention-mask Expand idiom (input
+//                                `[1, 1, S]`, shape via `from_elements`).
+
 namespace mlir {
 namespace hip {
 namespace {
 
-/// onnx.Expand -> hip.expand
+/// If \p value is `arith.index_cast` of an index-typed SSA value, return the
+/// operand; otherwise return \p value unchanged.
+static mlir::Value skipIndexCastToIndex(mlir::Value value) {
+  if (auto castOp = value.getDefiningOp<arith::IndexCastOp>()) {
+    if (castOp.getIn().getType().isIndex())
+      return castOp.getIn();
+  }
+  return value;
+}
+
+/// Try to resolve `shape[elemIdx]` to an index SSA value without
+/// `tensor.extract`, when `shape` is `tensor.from_elements(...)`.
 ///
-/// We trust the result type produced by ONNX shape inference. For dynamic
-/// dims in the result we extract the corresponding entry from the `shape`
-/// input tensor (right-aligned with the result rank, NumPy-style); leading
-/// dims that are absent from `shape` fall back to the matching input dim.
+/// Supported element producers (after optional `arith.index_cast` i64 <-
+/// index):
+///   - `tensor.dim %tensor, %k`
+///   - `arith.constant` i64 (static dim baked into Shape lowering)
+static std::optional<mlir::Value>
+tryResolveIndexFromShapeVector(mlir::Value shape, int64_t elemIdx,
+                               mlir::Location loc,
+                               mlir::PatternRewriter &rewriter) {
+  auto fromElts = shape.getDefiningOp<tensor::FromElementsOp>();
+  if (!fromElts)
+    return std::nullopt;
+  if (elemIdx < 0 || elemIdx >= static_cast<int64_t>(fromElts.getNumOperands()))
+    return std::nullopt;
+
+  mlir::Value elem = skipIndexCastToIndex(fromElts.getOperand(elemIdx));
+
+  if (auto dimOp = elem.getDefiningOp<tensor::DimOp>())
+    return dimOp.getResult();
+
+  if (auto cst = elem.getDefiningOp<arith::ConstantOp>()) {
+    if (auto intAttr = mlir::dyn_cast<mlir::IntegerAttr>(cst.getValue()))
+      return arith::ConstantIndexOp::create(rewriter, loc,
+                                            intAttr.getValue().getSExtValue());
+  }
+  return std::nullopt;
+}
+
+/// When `shape` is still `onnx.Shape(%tensor)` (Expand lowered before
+/// ShapeConversion in the same greedy pass), resolve entry \p elemIdx in the
+/// shape vector directly from \p tensor's dims (same start/end normalization
+/// as ShapeConversion / GatherShapeFold).
+static std::optional<mlir::Value>
+tryResolveIndexFromOnnxShape(mlir::Value shape, int64_t elemIdx,
+                             mlir::Location loc,
+                             mlir::PatternRewriter &rewriter) {
+  auto *shapeOp = shape.getDefiningOp();
+  if (!shapeOp || shapeOp->getName().getStringRef() != "onnx.Shape")
+    return std::nullopt;
+
+  mlir::Value shapeInput = shapeOp->getOperand(0);
+  auto inputType = mlir::dyn_cast<mlir::RankedTensorType>(shapeInput.getType());
+  if (!inputType)
+    return std::nullopt;
+
+  int64_t rank = inputType.getRank();
+  int64_t start = 0;
+  int64_t end = rank;
+  if (auto startAttr = shapeOp->getAttrOfType<mlir::IntegerAttr>("start"))
+    start = startAttr.getSInt();
+  if (auto endAttr = shapeOp->getAttrOfType<mlir::IntegerAttr>("end"))
+    end = endAttr.getSInt();
+  if (start < 0)
+    start += rank;
+  if (end < 0)
+    end += rank;
+  start = std::max(start, int64_t(0));
+  end = std::min(end, rank);
+  int64_t rangeLen = std::max(end - start, int64_t(0));
+  if (elemIdx < 0 || elemIdx >= rangeLen)
+    return std::nullopt;
+
+  int64_t absDim = start + elemIdx;
+  if (inputType.isDynamicDim(absDim))
+    return mlir::tensor::DimOp::create(rewriter, loc, shapeInput, absDim);
+  return arith::ConstantIndexOp::create(rewriter, loc,
+                                        inputType.getDimSize(absDim));
+}
+
+/// onnx.Expand -> hip.expand
 struct ExpandToHip : public mlir::RewritePattern {
   ExpandToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Expand", /*benefit=*/1, ctx) {}
@@ -47,21 +168,71 @@ struct ExpandToHip : public mlir::RewritePattern {
           op, "expand shape input must have static rank-1 type");
     int64_t shapeLen = shapeType.getDimSize(0);
 
+    mlir::Operation *shapeDef = shape.getDefiningOp();
+    const bool shapeIsFromElements =
+        shapeDef && isa<tensor::FromElementsOp>(shapeDef);
+    const bool shapeIsOnnxShape =
+        shapeDef && shapeDef->getName().getStringRef() == "onnx.Shape";
+
     llvm::SmallVector<mlir::Value> dynSizes;
     for (int64_t i = 0; i < resultRank; ++i) {
       if (!resultType.isDynamicDim(i))
         continue;
       int64_t shapeIdx = i - (resultRank - shapeLen);
+      // Right-aligned input axis matching this output axis (-1 if the output
+      // axis has no input counterpart -- leading dims when shape rank is
+      // larger than input rank).
+      int64_t inputIdx = i - (resultRank - inputRank);
       mlir::Value dim;
       if (shapeIdx >= 0) {
-        mlir::Value idx =
-            mlir::arith::ConstantIndexOp::create(rewriter, loc, shapeIdx);
-        mlir::Value extracted = mlir::tensor::ExtractOp::create(
-            rewriter, loc, shape, mlir::ValueRange{idx});
-        dim = mlir::arith::IndexCastOp::create(
-            rewriter, loc, rewriter.getIndexType(), extracted);
+        // Prefer tracing the shape entry back to a pure SSA size (tensor.dim
+        // or constant) so the bufferized size chain stays hoistable by
+        // hip-pool-allocs instead of becoming a memref.load on a shared
+        // shape buffer (dominance failure when two Expands reuse one Shape).
+        std::optional<mlir::Value> traced =
+            tryResolveIndexFromShapeVector(shape, shapeIdx, loc, rewriter);
+        if (!traced)
+          traced = tryResolveIndexFromOnnxShape(shape, shapeIdx, loc, rewriter);
+        if (traced) {
+          dim = *traced;
+        } else if (shapeIsFromElements || shapeIsOnnxShape) {
+          return rewriter.notifyMatchFailure(
+              op, "expand shape is Shape/from_elements but entry is not "
+                  "tensor.dim or constant; cannot size empty() without "
+                  "tensor.extract (breaks hip-pool-allocs dominance)");
+        } else {
+          // Opaque shape operand (initializer constant tensor or function
+          // argument). Honour the ONNX Expand spec rule that
+          //   output_dim[i] = max(input_dim[input_idx], shape_value[shape_idx])
+          // not just `shape_value`. The pre-fix code used shape_value
+          // directly, which silently shrank inputs when shape carries 1 at an
+          // axis where input has > 1 (identity-broadcast pattern). See file
+          // header for the IR diff.
+          mlir::Value idx =
+              mlir::arith::ConstantIndexOp::create(rewriter, loc, shapeIdx);
+          mlir::Value extracted = mlir::tensor::ExtractOp::create(
+              rewriter, loc, shape, mlir::ValueRange{idx});
+          mlir::Value shapeDim = mlir::arith::IndexCastOp::create(
+              rewriter, loc, rewriter.getIndexType(), extracted);
+          if (inputIdx < 0) {
+            // Leading output axis with no input dim: output = shape_value.
+            dim = shapeDim;
+          } else if (!inputType.isDynamicDim(inputIdx) &&
+                     inputType.getDimSize(inputIdx) == 1) {
+            // Static input dim is 1: max(1, x) == x, so output = shape_value.
+            dim = shapeDim;
+          } else {
+            // input_dim could be > 1 -- emit the runtime max so an
+            // identity-broadcast shape operand does not collapse the output.
+            mlir::Value inputDim =
+                mlir::tensor::DimOp::create(rewriter, loc, input, inputIdx);
+            dim =
+                mlir::arith::MaxSIOp::create(rewriter, loc, inputDim, shapeDim);
+          }
+        }
       } else {
-        int64_t inputIdx = i - (resultRank - inputRank);
+        // Output axis with no shape entry (shape rank < output rank): the
+        // missing leading dims come straight from the input.
         if (inputIdx < 0)
           return rewriter.notifyMatchFailure(
               op, "cannot resolve dynamic dim from input or shape");

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
@@ -23,6 +23,7 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Utils/ReshapeOpsUtils.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
@@ -109,6 +110,46 @@ getContextArg(mlir::Operation *op, mlir::PatternRewriter &rewriter) {
     return rewriter.notifyMatchFailure(op,
                                        "first argument is not !hip.context");
   return ctx;
+}
+
+/// If \p v is an inline `onnx.Constant` holding a single scalar element,
+/// return its `DenseElementsAttr`; otherwise return std::nullopt.  Relies
+/// on the hybrid two-phase externalisation in `ConvertOnnxToHipPass`:
+/// Phase 1 keeps small constants as inline `onnx.Constant`, Phase 2
+/// (post-convert) externalises whatever survived.  Without that ordering,
+/// the converter would see `bufferization.to_tensor(memref.get_global)`
+/// instead of `onnx.Constant` and this helper would return std::nullopt.
+inline std::optional<mlir::DenseElementsAttr>
+getInlineScalarFromOnnxConstant(mlir::Value v) {
+  mlir::Operation *def = v.getDefiningOp();
+  if (!def || def->getName().getStringRef() != "onnx.Constant")
+    return std::nullopt;
+  auto attr = mlir::dyn_cast_or_null<mlir::DenseElementsAttr>(
+      def->getAttrOfType<mlir::ElementsAttr>("value"));
+  if (!attr || attr.getNumElements() != 1)
+    return std::nullopt;
+  return attr;
+}
+
+/// Materialize a scalar SSA value (integer or float) from a 1-element
+/// DenseElementsAttr.  Element type of the resulting `arith.constant`
+/// matches the attr's stored element type, NOT the surrounding tensor type
+/// (which the caller wraps separately if needed).  Returns null Value if
+/// the attr is not int / float (e.g. complex, opaque).  Mirrors the
+/// `buildScalarFillValue` idiom in `ConstantOfShapeConversion.cpp`.
+inline mlir::Value
+materializeScalarFromDenseAttr(mlir::OpBuilder &builder, mlir::Location loc,
+                               mlir::DenseElementsAttr attr) {
+  mlir::Type elemTy = attr.getElementType();
+  if (auto intTy = mlir::dyn_cast<mlir::IntegerType>(elemTy)) {
+    llvm::APInt v = *attr.getValues<llvm::APInt>().begin();
+    return mlir::arith::ConstantIntOp::create(builder, loc, intTy, v);
+  }
+  if (auto floatTy = mlir::dyn_cast<mlir::FloatType>(elemTy)) {
+    llvm::APFloat v = *attr.getValues<llvm::APFloat>().begin();
+    return mlir::arith::ConstantFloatOp::create(builder, loc, floatTy, v);
+  }
+  return {};
 }
 
 // Pattern population functions (one per operator file)

--- a/lib/Conversion/OnnxToHip/RangeConversion.cpp
+++ b/lib/Conversion/OnnxToHip/RangeConversion.cpp
@@ -187,11 +187,18 @@ struct RangeToHip : public RewritePattern {
     if (!elemTy.isIntOrFloat())
       return rewriter.notifyMatchFailure(op, "unsupported element type");
 
+    // Check operands: ONNX Range takes scalar inputs, which can be either
+    // rank-0 tensors (tensor<i64>) or rank-1 tensors with shape [1]
+    // (tensor<1xi64>). Both representations are valid.
     for (Value v : op->getOperands()) {
       auto t = dyn_cast<RankedTensorType>(v.getType());
-      if (!t || t.getRank() != 0 || t.getElementType() != elemTy)
+      if (!t || t.getElementType() != elemTy)
         return rewriter.notifyMatchFailure(
-            op, "expected 0-D operands matching result element type");
+            op, "expected operands with matching result element type");
+      int64_t rank = t.getRank();
+      if (rank != 0 && (rank != 1 || t.getDimSize(0) != 1))
+        return rewriter.notifyMatchFailure(
+            op, "expected rank-0 or rank-1 size-1 scalar operands");
     }
 
     Location loc = op->getLoc();
@@ -199,12 +206,95 @@ struct RangeToHip : public RewritePattern {
     if (failed(verifyConstantDeltaNonZero(op, op->getOperand(2), elemTy)))
       return failure();
 
-    Value startE = tensor::ExtractOp::create(rewriter, loc, op->getOperand(0),
-                                             ValueRange{});
-    Value limitE = tensor::ExtractOp::create(rewriter, loc, op->getOperand(1),
-                                             ValueRange{});
-    Value deltaE = tensor::ExtractOp::create(rewriter, loc, op->getOperand(2),
-                                             ValueRange{});
+    // Extract scalar values for Range start/limit/delta operands.
+    //
+    // Naively emitting `tensor.extract %v[%c0]` on a rank-1 size-1 input
+    // bufferizes to `memref.load %buf[0]`, and `hip-pool-allocs` only hoists
+    // pure SSA shape arithmetic (memref.dim / arith.* / index_cast) -- not
+    // memref.load. If %v traces back to a `tensor.from_elements(%single)`
+    // (typical for Unsqueeze(scalar, [0])-style ONNX shape arithmetic), the
+    // resulting `memref.load` from a shared shape scratch buffer leaves the
+    // pool-size computation undefined w.r.t. block dominance and produces
+    // `operand #0 does not dominate this use` later in the pipeline.
+    //
+    // Same playbook as ExpandConversion: peek through value-preserving
+    // rank-changing ops (tensor.expand_shape / tensor.collapse_shape) and
+    // `tensor.from_elements` to reach the scalar producer; only fall back to
+    // `tensor.extract` when traceback is impossible (opaque function args
+    // etc.).
+    auto peekScalarProducer = [](Value v) -> Value {
+      while (true) {
+        Operation *defOp = v.getDefiningOp();
+        if (!defOp)
+          return v;
+        if (auto exp = dyn_cast<tensor::ExpandShapeOp>(defOp)) {
+          v = exp.getSrc();
+          continue;
+        }
+        if (auto col = dyn_cast<tensor::CollapseShapeOp>(defOp)) {
+          v = col.getSrc();
+          continue;
+        }
+        return v;
+      }
+    };
+
+    auto extractScalar = [&](Value v) -> Value {
+      // Case A (inline-constant path): producer is an inline `onnx.Constant`
+      // with a 1-element `value` attr that the hybrid Phase 1 left in place.
+      // Materialize a pure-SSA `arith.constant` of the stored scalar value.
+      // This keeps the Range count formula (sub/ceildivsi/clamp) free of
+      // `memref.load` for the common case where start/limit/delta are
+      // compile-time literals -- exactly what `hip-pool-allocs` needs in
+      // order to hoist the dynamic-size `memref.alloc` for the Range output.
+      // Peek both before and after rank-changing reshape views so we catch
+      // `Reshape(<1xi64>) -> <i64>`-style chains too.
+      if (auto attr = getInlineScalarFromOnnxConstant(v)) {
+        Value scalar = materializeScalarFromDenseAttr(rewriter, loc, *attr);
+        if (scalar && scalar.getType() == elemTy)
+          return scalar;
+      }
+
+      // Try traceback first: walk through rank-changing reshape views to the
+      // underlying scalar producer.
+      Value peek = peekScalarProducer(v);
+
+      if (auto attr = getInlineScalarFromOnnxConstant(peek)) {
+        Value scalar = materializeScalarFromDenseAttr(rewriter, loc, *attr);
+        if (scalar && scalar.getType() == elemTy)
+          return scalar;
+      }
+
+      // Case B: producer is a single-element tensor.from_elements.
+      if (auto fromElts = peek.getDefiningOp<tensor::FromElementsOp>()) {
+        if (fromElts.getNumOperands() == 1) {
+          Value elem = fromElts.getOperand(0);
+          if (elem.getType() == elemTy)
+            return elem;
+        }
+      }
+
+      // Case C: producer is itself a rank-0 tensor -- extract with empty
+      // indices. Bufferizes to a memref.load on a 0-D buffer, which is small
+      // enough that hip-materialize-host-scalars routes it through the
+      // runtime-owned host scratch buffer (not the GPU pool), so pool-allocs
+      // hoist still works.
+      if (auto peekTy = dyn_cast<RankedTensorType>(peek.getType())) {
+        if (peekTy.getRank() == 0)
+          return tensor::ExtractOp::create(rewriter, loc, peek, ValueRange{});
+      }
+
+      // Fallback: rank-0 = empty indices, rank-1 size-1 = [0].
+      auto t = cast<RankedTensorType>(v.getType());
+      if (t.getRank() == 0)
+        return tensor::ExtractOp::create(rewriter, loc, v, ValueRange{});
+      Value idx = arith::ConstantIndexOp::create(rewriter, loc, 0);
+      return tensor::ExtractOp::create(rewriter, loc, v, ValueRange{idx});
+    };
+
+    Value startE = extractScalar(op->getOperand(0));
+    Value limitE = extractScalar(op->getOperand(1));
+    Value deltaE = extractScalar(op->getOperand(2));
 
     Value len = llvm::TypeSwitch<Type, Value>(elemTy)
                     .Case<IntegerType>([&](IntegerType ity) {

--- a/lib/Conversion/OnnxToHip/ShapeConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ShapeConversion.cpp
@@ -69,9 +69,14 @@ namespace {
 // normalization) emit a 0-element constant tensor per ONNX spec rather than
 // failing the match -- preserving op semantics is the priority over
 // surfacing a "shouldn't happen" error.
+//
+// Benefit 2 (onnx.Expand is 1): onnx.Shape must lower before onnx.Expand so
+// ExpandConversion sees a `tensor.from_elements` shape vector it can trace
+// back to `tensor.dim` (pure SSA sizing), rather than racing the Expand
+// rewrite and falling back to `tensor.extract`.
 struct ShapeToTensorDims : public mlir::RewritePattern {
   ShapeToTensorDims(mlir::MLIRContext *ctx)
-      : RewritePattern("onnx.Shape", /*benefit=*/1, ctx) {}
+      : RewritePattern("onnx.Shape", /*benefit=*/2, ctx) {}
 
   mlir::LogicalResult
   matchAndRewrite(mlir::Operation *op,

--- a/lib/Conversion/OnnxToHip/TileConversion.cpp
+++ b/lib/Conversion/OnnxToHip/TileConversion.cpp
@@ -10,6 +10,30 @@ namespace hip {
 namespace {
 
 /// onnx.Tile -> hip.tile
+///
+/// For each dynamic output dim, the init alloc size must be
+/// `input.dim[i] * repeats[i]`, NOT `input.dim[i]` alone -- the latter is
+/// what `createEmptyTensor(resultType, input)` would do and it under-sizes
+/// the output buffer by the tile factor along every axis the model expects
+/// to grow. Under-size symptom downstream: the tiled-axis dim seen by
+/// consumers stays at the pre-tile value, and a subsequent broadcast Mul
+/// fails the MIOpen rank-broadcast check (`BTensor dim != 1 && BTensor dim
+/// != CTensor dim`).
+///
+/// Before:
+///   %0 = "onnx.Tile"(%in, %r) :
+///          (tensor<?x1152xf16>, tensor<2xi64>) -> tensor<?x1152xf16>
+///   // init alloc would size dim 0 from %in.dim[0] (pre-tile)
+///
+/// After:
+///   %c0 = arith.constant 0 : index
+///   %d0 = tensor.dim %in, %c0
+///   %r0_i64 = tensor.extract %r[%c0] : tensor<2xi64>
+///   %r0_idx = arith.index_cast %r0_i64 : i64 to index
+///   %d0_out = arith.muli %d0, %r0_idx
+///   %init   = tensor.empty(%d0_out) : tensor<?x1152xf16>
+///   %0 = hip.tile(%ctx) ins(%in, %r : ..., tensor<2xi64>)
+///                       outs(%init : tensor<?x1152xf16>)
 struct TileToHip : public mlir::RewritePattern {
   TileToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Tile", /*benefit=*/1, ctx) {}
@@ -28,10 +52,35 @@ struct TileToHip : public mlir::RewritePattern {
 
     auto resultType =
         mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
+    auto inputType = mlir::cast<mlir::RankedTensorType>(input.getType());
+    int64_t rank = resultType.getRank();
 
-    // Trust shape inference: output rank == input rank, dims may be dynamic.
-    // Use input as the source for any dynamic dim sizes.
-    mlir::Value init = createEmptyTensor(rewriter, loc, resultType, input);
+    // For each dynamic output dim, compute input.dim[i] * repeats[i].
+    llvm::SmallVector<mlir::Value> dynSizes;
+    for (int64_t i : llvm::seq<int64_t>(rank)) {
+      if (!resultType.isDynamicDim(i))
+        continue;
+      // input dim (static or runtime).
+      mlir::Value inDim;
+      if (inputType.isDynamicDim(i)) {
+        inDim = mlir::tensor::DimOp::create(rewriter, loc, input, i);
+      } else {
+        inDim = mlir::arith::ConstantIndexOp::create(rewriter, loc,
+                                                     inputType.getDimSize(i));
+      }
+      // repeats[i] is i64 in a 1-D tensor; extract and cast to index.
+      mlir::Value iIdx = mlir::arith::ConstantIndexOp::create(rewriter, loc, i);
+      mlir::Value rI64 = mlir::tensor::ExtractOp::create(
+          rewriter, loc, repeats, mlir::ValueRange{iIdx});
+      mlir::Value rIdx = mlir::arith::IndexCastOp::create(
+          rewriter, loc, rewriter.getIndexType(), rI64);
+      mlir::Value outDim =
+          mlir::arith::MulIOp::create(rewriter, loc, inDim, rIdx);
+      dynSizes.push_back(outDim);
+    }
+    mlir::Value init =
+        mlir::tensor::EmptyOp::create(rewriter, loc, resultType.getShape(),
+                                      resultType.getElementType(), dynSizes);
 
     auto hipOp =
         mlir::hip::TileOp::create(rewriter, loc, context, input, repeats, init);

--- a/test/lit/Conversion/onnx-to-hip/test_expand.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_expand.mlir
@@ -28,4 +28,18 @@ module {
   // CHECK: tensor.extract
   // CHECK: tensor.empty
   // CHECK: hip.expand({{.*}}) ins({{.*}}, {{.*}} : tensor<3x1xf32>, tensor<3xi64>) outs({{.*}} : tensor<?x3x?xf32>)
+
+  // Opaque shape operand with a possibly-> 1 input dim: honour ONNX Expand
+  // broadcast rule output_dim = max(input_dim, shape_value) so an
+  // identity-broadcast shape (e.g. [1, ...]) does not shrink the input.
+  func.func @expand_maxsi(%input: tensor<?x4xf32>, %shape: tensor<2xi64>) -> tensor<?x4xf32> {
+    %r = "onnx.Expand"(%input, %shape) : (tensor<?x4xf32>, tensor<2xi64>) -> tensor<?x4xf32>
+    return %r : tensor<?x4xf32>
+  }
+
+  // CHECK-LABEL: func.func @expand_maxsi
+  // CHECK: tensor.extract
+  // CHECK: tensor.dim
+  // CHECK: arith.maxsi
+  // CHECK: hip.expand({{.*}}) ins({{.*}}, {{.*}} : tensor<?x4xf32>, tensor<2xi64>) outs({{.*}} : tensor<?x4xf32>)
 }

--- a/test/lit/Conversion/onnx-to-hip/test_expand_shape_trace.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_expand_shape_trace.mlir
@@ -1,0 +1,47 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// Expand + Shape -> from_elements: resolve dynamic empty() sizes via
+// tensor.dim traceback (embedding-style), not tensor.extract on the shape
+// vector.  Avoids bufferized memref.load from a shared shape buffer that
+// breaks hip-pool-allocs dominance when multiple Expands share one Shape.
+// ============================================================================
+
+// RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip | FileCheck %s
+
+module {
+  func.func @main_graph(%arg0: tensor<?x?x4096xi8>) -> tensor<?x?x4096xi8> {
+    return %arg0 : tensor<?x?x4096xi8>
+  }
+
+  // Embedding-style: Shape(data) -> from_elements; two Expands share %shape.
+  func.func @expand_shape_trace_shared(
+      %mask: tensor<1x1xi8>, %data: tensor<?x?x4096xi8>)
+      -> (tensor<?x?x4096xi8>, tensor<?x?x4096xi8>) {
+    %shape = "onnx.Shape"(%data) : (tensor<?x?x4096xi8>) -> tensor<3xi64>
+    %e0 = "onnx.Expand"(%mask, %shape)
+        : (tensor<1x1xi8>, tensor<3xi64>) -> tensor<?x?x4096xi8>
+    %e1 = "onnx.Expand"(%mask, %shape)
+        : (tensor<1x1xi8>, tensor<3xi64>) -> tensor<?x?x4096xi8>
+    return %e0, %e1 : tensor<?x?x4096xi8>, tensor<?x?x4096xi8>
+  }
+
+  // CHECK-LABEL: func.func @expand_shape_trace_shared
+  // CHECK-NOT: tensor.extract
+  // Two Expands: each empty() sizes dynamic dims via tensor.dim on %data.
+  // CHECK-COUNT-4: tensor.dim %{{.*}} : tensor<?x?x4096xi8>
+  // CHECK-COUNT-2: hip.expand
+
+  // Opaque shape function argument: legacy tensor.extract path still allowed.
+  func.func @expand_opaque_shape(%mask: tensor<1x1xi8>, %shape: tensor<3xi64>)
+      -> tensor<?x?x4096xi8> {
+    %e = "onnx.Expand"(%mask, %shape)
+        : (tensor<1x1xi8>, tensor<3xi64>) -> tensor<?x?x4096xi8>
+    return %e : tensor<?x?x4096xi8>
+  }
+
+  // CHECK-LABEL: func.func @expand_opaque_shape
+  // CHECK: tensor.extract
+  // CHECK: hip.expand
+}

--- a/test/lit/Conversion/onnx-to-hip/test_range.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_range.mlir
@@ -84,4 +84,32 @@ module {
   // CHECK-LABEL: func.func @test_range_empty_neg_f32
   // CHECK: tensor.empty
   // CHECK: hip.range
+
+  // ONNX Range scalars may be rank-1 size-1 (tensor<1xi64>), not just rank-0.
+  // Such operands must still match and lower to hip.range.
+  func.func @test_range_rank1_dynamic(%s: tensor<1xi64>, %l: tensor<1xi64>, %d: tensor<1xi64>) -> tensor<?xi64> {
+    %r = "onnx.Range"(%s, %l, %d) : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<?xi64>
+    return %r : tensor<?xi64>
+  }
+  // CHECK-LABEL: func.func @test_range_rank1_dynamic
+  // CHECK: hip.range
+
+  // from_elements scalar producers are traced directly to their element, so
+  // the count formula stays free of tensor.extract (keeps the dynamic-size
+  // alloc hoistable by hip-pool-allocs). All three operands use runtime
+  // index args so the from_elements are not constant-folded to tensor
+  // constants (which would fall back to the tensor.extract path).
+  func.func @test_range_from_elements(%s: index, %l: index, %d: index) -> tensor<?xi64> {
+    %sc = arith.index_cast %s : index to i64
+    %lc = arith.index_cast %l : index to i64
+    %dc = arith.index_cast %d : index to i64
+    %start = tensor.from_elements %sc : tensor<1xi64>
+    %limit = tensor.from_elements %lc : tensor<1xi64>
+    %delta = tensor.from_elements %dc : tensor<1xi64>
+    %r = "onnx.Range"(%start, %limit, %delta) : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<?xi64>
+    return %r : tensor<?xi64>
+  }
+  // CHECK-LABEL: func.func @test_range_from_elements
+  // CHECK-NOT: tensor.extract
+  // CHECK: hip.range
 }

--- a/test/lit/Conversion/onnx-to-hip/test_tile.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_tile.mlir
@@ -23,6 +23,11 @@ module {
     return %r : tensor<?x?xf32>
   }
 
+  // Each dynamic output dim is sized as input.dim[i] * repeats[i] (NOT
+  // input.dim[i] alone), so the init alloc grows by the tile factor.
   // CHECK-LABEL: func.func @tile_dynamic
+  // CHECK: tensor.dim
+  // CHECK: tensor.extract
+  // CHECK: arith.muli
   // CHECK: hip.tile({{.*}}) ins({{.*}}, {{.*}} : tensor<?x?xf32>, tensor<2xi64>) outs({{.*}} : tensor<?x?xf32>)
 }


### PR DESCRIPTION
## Summary

Split from #259. Three independent dynamic-shape **sizing** correctness fixes
for the shape ops, ported onto main's `InferTypeOpInterface` `create()` (no
explicit result-type churn). Each fix only affects how the DPS `tensor.empty`
init buffer for a dynamic output dim is sized.

| Op | Bug (from #259) | Fix |
|----|-----------------|-----|
| Tile | dynamic dim sized as `input.dim[i]` (via `createEmptyTensor`), under-sizing the output by the tile factor | size as `input.dim[i] * repeats[i]` |
| Expand | (1) `shape_value` used directly, shrinking a `>1` input dim under an identity-broadcast shape `[1,1,...]`; (2) `tensor.extract` on a shared `Shape` vector breaks pool-allocs dominance | (1) `max(input_dim, shape_value)` via `arith.maxsi`; (2) trace shape entries back to `tensor.dim`/const |
| Range | (1) only rank-0 scalars accepted; (2) `tensor.extract` on rank-1 size-1 operand breaks pool-allocs dominance | (1) accept rank-1 size-1; (2) trace scalar producers to pure SSA |

## Details

### Tile -- tile-factor under-size
The init alloc for a dynamic output dim must be `input.dim[i] * repeats[i]`,
not `input.dim[i]` alone. Under-sizing leaves the tiled axis at its pre-tile
extent; a downstream broadcast `Mul` then fails the MIOpen rank-broadcast
check (`BTensor dim != 1 && BTensor dim != CTensor dim`) and the EP propagates
partial data, collapsing per-model cosine. Fix sizes each dynamic dim as
`input.dim[i] * extract(repeats, i)`.

### Expand -- broadcast max + pool-allocs traceback
1. **Shrink bug.** ONNX `Expand` is broadcast, not `numpy.broadcast_to`:
   `output_dim = max(input_dim, shape_value)`. Using `shape_value` directly
   collapsed a `>1` input dim when the shape carries `1` at that axis
   (identity-broadcast `Expand(x, [1, 1, ...])`). Fix emits
   `arith.maxsi(tensor.dim(input, k), shape_value)` for opaque shape operands,
   with compile-time fast paths when the input dim is statically `1` or absent.
2. **pool-allocs dominance.** `tensor.extract` on a `Shape` vector shared by
   two `Expand`s bufferizes to `memref.load` from one scratch buffer, which
   `hip-pool-allocs` cannot hoist -> `operand does not dominate this use`.
   Fix traces each shape entry back to `tensor.dim(source, k)` or a constant
   (handles both `tensor.from_elements` and `onnx.Shape` producers), keeping
   the size chain pure SSA.

`ShapeConversion` benefit is bumped `1 -> 2` so `onnx.Shape` lowers before
`onnx.Expand`, giving Expand a `tensor.from_elements` vector to trace instead
of racing the rewrite into the `tensor.extract` fallback.

### Range -- rank-1 scalars + pool-allocs traceback
1. Accept rank-1 size-1 scalar operands (`tensor<1xi64>`), not just rank-0 --
   both are valid ONNX scalar encodings.
2. `tensor.extract` on a rank-1 size-1 operand bufferizes to `memref.load`,
   which `hip-pool-allocs` only hoists for pure SSA shape arithmetic ->
   dominance failure on the dynamic-size Range output alloc. Fix traces scalar
   producers (inline `onnx.Constant`, `tensor.from_elements`, rank-0 tensors,
   through reshape views) to a pure-SSA scalar before falling back to
   `tensor.extract`.

Carries two shared helpers into `OnnxToHipUtils.h`:
`getInlineScalarFromOnnxConstant` and `materializeScalarFromDenseAttr`.

## Test plan

- [x] New `test_expand_shape_trace.mlir` (traceback + opaque fallback).
- [x] `test_tile.mlir` -- assert `arith.muli` sizing on the dynamic case.
- [x] `test_expand.mlir` -- assert `arith.maxsi` on the opaque-shape case.
- [x] `test_range.mlir` -- rank-1 size-1 scalar + `from_elements` traceback.
- [x] Full `hip-mlir-opt` lit suite: 212/212 pass.
- [x] Full reconfigure + build + install clean.
