### PR TITLE
feat(slice): size dynamic Slice output to exact logical extent (#259 split)

### DIFF
--- a/lib/Conversion/OnnxToHip/SliceConversion.cpp
+++ b/lib/Conversion/OnnxToHip/SliceConversion.cpp
@@ -10,6 +10,9 @@
 
 #include "llvm/ADT/APInt.h"
 
+#include <algorithm>
+#include <limits>
+
 namespace mlir {
 namespace hip {
 namespace {
@@ -32,11 +35,37 @@ namespace {
 //     at compile time.
 //
 //   * SliceToHip (benefit=1) — fallback for non-constant indices or negative
-//     steps. Produces a native `hip.slice` DPS op whose runtime function is
-//     a stub today (throws); models that hit this path are unsupported until
-//     the runtime is implemented, but the conversion / bufferization pipeline
-//     can still verify and link the IR. Dynamic output dims are sourced from
-//     `tensor.dim` on `data` (an upper bound — Slice cannot widen any axis).
+//     steps. Produces a native `hip.slice` DPS op. Dynamic output dims are
+//     sized as exactly as compile-time information allows (see below); only
+//     the irrecoverable case falls back to the `tensor.dim` upper bound.
+//
+// Dynamic-output-dim sizing in SliceToHip — three cases per dynamic axis:
+//
+//   (A) Touched axis, STATIC input dim  → IntegerAttr with the compile-time
+//       extent (ONNX neg-index + clamp evaluated at compile time).
+//   (B) Touched axis, DYNAMIC input dim, CONSTANT starts/ends/steps → host
+//       `index` arith on `tensor.dim` (descriptor-only, no GPU read), via
+//       `emitRuntimeExtent`. This is the headline fix: main previously sized
+//       these dims to `data.dim[i]` (an upper bound), so downstream reductions
+//       / matmuls folded the kernel's zero-padded tail into the result and the
+//       output cosine collapsed on dynamic-shape vision encoders. Sizing to
+//       the exact logical extent removes the padding from the live region.
+//   (C) Untouched axis, OR anything we cannot fold → `data.dim[i]` upper bound
+//       (the legacy contract; Slice can never widen an axis).
+//
+// Empty-slice (logical extent == 0) policy: the result dim is sized to the
+// data-dim upper bound, NOT 0. Two self-contained reasons: (1) ONNX Slice can
+// never widen an axis, so `data.dim(axis)` is always a sound over-allocation
+// and the runtime honours the real extent via `output_shape[i]`; (2) a true
+// dim-0 buffer is rejected by MIOpen broadcast tensor descriptors. (A
+// degenerate empty slice feeding a buffer-backed accumulator must likewise
+// stay at the upper bound rather than collapse to 0.)
+//
+// NOTE (deferred): a fourth case — RUNTIME starts/ends with constant axes (the
+// per-token attention slice inside an outlined `hip.loop` body) — is NOT
+// handled here. It requires following loop-body block-args back to the
+// enclosing loop's captures and a `hipdnn.fold_value` constant sidecar that is
+// not present on this branch; it lands with the dynamic-vision loop infra.
 
 /// Return the dense-elements attribute backing \p value if it can be
 /// determined at compile time. Matches the patterns produced by
@@ -97,6 +126,158 @@ static mlir::Value normaliseOptional(mlir::Value v) {
   if (defOp && defOp->getName().getStringRef() == "onnx.NoValue")
     return mlir::Value();
   return v;
+}
+
+/// (start, end, step) for one sliced axis, pre-normalisation.
+struct SliceParams {
+  int64_t start;
+  int64_t end;
+  int64_t step;
+};
+
+/// Compute the logical slice extent for one axis under ONNX semantics on a
+/// statically-known input dim. Mirrors `emitRuntimeExtent`'s runtime arith.
+static int64_t clampSlice(int64_t dim, SliceParams p) {
+  int64_t start = p.start, end = p.end, step = p.step;
+  if (start < 0)
+    start += dim;
+  if (end < 0)
+    end += dim;
+  start = std::clamp<int64_t>(start, 0, dim);
+  end = std::clamp<int64_t>(end, 0, dim);
+  if (end < start)
+    end = start;
+  int64_t sz = (end - start + step - 1) / step;
+  return sz < 0 ? 0 : sz;
+}
+
+/// Per-axis SliceToHip output-size hint. Priority order:
+///   * `staticSize >= 0`: exact compile-time extent (use IntegerAttr).
+///   * `runtimeFromDim = true` with `runtimeStart/runtimeEnd/step`: compute the
+///     extent at host runtime from `tensor.dim` (constant indices, dynamic
+///     input dim). Pure host-side `index` arith — no GPU read.
+///   * `useUpperBound = true`: fall back to `data.dim[i]`.
+struct SliceAxisInfo {
+  int64_t staticSize = -1;
+  bool runtimeFromDim = false;
+  bool useUpperBound = false;
+  int64_t runtimeStart = 0;
+  int64_t runtimeEnd = 0;
+  int64_t step = 1;
+};
+
+/// Resolve which input axes a Slice op touches and their (start, end, step).
+/// Returns `true` only when starts/ends/axes/steps ALL fold to compile-time
+/// constants and every touched axis maps to a unique in-range input axis.
+/// Untouched axes get `useUpperBound`; touched axes get `staticSize` (static
+/// input dim) or `runtimeFromDim` (dynamic input dim, constant indices).
+static bool resolveSliceExtents(mlir::Operation *op,
+                                mlir::RankedTensorType dataType,
+                                llvm::SmallVectorImpl<SliceAxisInfo> &info) {
+  if (op->getNumOperands() < 3)
+    return false;
+  llvm::SmallVector<int64_t> startsVec, endsVec, axesVec, stepsVec;
+  if (mlir::failed(extractIntVector(op->getOperand(1), startsVec)) ||
+      mlir::failed(extractIntVector(op->getOperand(2), endsVec)))
+    return false;
+  int64_t rank = dataType.getRank();
+  if (op->getNumOperands() >= 4) {
+    mlir::Value axes = normaliseOptional(op->getOperand(3));
+    if (axes)
+      if (mlir::failed(extractIntVector(axes, axesVec)))
+        return false;
+  }
+  if (axesVec.empty())
+    for (int64_t i : llvm::seq<int64_t>(rank))
+      axesVec.push_back(i);
+  if (op->getNumOperands() == 5) {
+    mlir::Value steps = normaliseOptional(op->getOperand(4));
+    if (steps)
+      if (mlir::failed(extractIntVector(steps, stepsVec)))
+        return false;
+  }
+  if (stepsVec.empty())
+    stepsVec.assign(axesVec.size(), 1);
+  if (axesVec.size() != startsVec.size() || axesVec.size() != endsVec.size() ||
+      axesVec.size() != stepsVec.size())
+    return false;
+
+  info.assign(rank, SliceAxisInfo{});
+  for (int64_t i : llvm::seq<int64_t>(rank))
+    info[i].useUpperBound = true;
+  llvm::SmallSet<int64_t, 8> seenAxes;
+  for (size_t k = 0; k < axesVec.size(); ++k) {
+    int64_t axis = axesVec[k];
+    if (axis < 0)
+      axis += rank;
+    if (axis < 0 || axis >= rank)
+      return false;
+    if (!seenAxes.insert(axis).second)
+      return false;
+    int64_t step = stepsVec[k];
+    // tensor extents are non-negative; negative/zero step (reverse slices)
+    // is unsupported by this sizing path — fall back to the upper bound.
+    if (step <= 0)
+      return false;
+    info[axis].useUpperBound = false;
+    info[axis].step = step;
+    if (dataType.isDynamicDim(axis)) {
+      info[axis].runtimeFromDim = true;
+      info[axis].runtimeStart = startsVec[k];
+      info[axis].runtimeEnd = endsVec[k];
+    } else {
+      int64_t dim = dataType.getDimSize(axis);
+      info[axis].staticSize =
+          clampSlice(dim, SliceParams{startsVec[k], endsVec[k], step});
+    }
+  }
+  return true;
+}
+
+/// Emit host-side `index` arithmetic computing the ONNX logical slice extent
+/// on a dynamic-input-dim axis given constant start/end/step. `dim` is the
+/// `tensor.dim` Value. INT64_MAX/MIN sentinels (ONNX "to end" / "from begin")
+/// resolve to `dim` / `0`.
+///
+/// Before:  axis i dynamic-output, data.dim(i) = %d (runtime), start=2,
+/// end=MAX, step=1 After:   %lo = max(2, 0); %s = min(%lo, %d)
+///          %e  = %d                       // end==MAX -> dim
+///          %eGeS = max(%e, %s); %diff = %eGeS - %s
+///          %extent = (%diff + step-1) / step
+static mlir::Value emitRuntimeExtent(mlir::OpBuilder &b, mlir::Location loc,
+                                     mlir::Value dim, int64_t startC,
+                                     int64_t endC, int64_t step) {
+  using mlir::arith::AddIOp;
+  using mlir::arith::ConstantIndexOp;
+  using mlir::arith::DivSIOp;
+  using mlir::arith::MaxSIOp;
+  using mlir::arith::MinSIOp;
+  using mlir::arith::SubIOp;
+  mlir::Value zero = ConstantIndexOp::create(b, loc, 0);
+
+  auto clampOnDim = [&](int64_t raw) -> mlir::Value {
+    if (raw == std::numeric_limits<int64_t>::max())
+      return dim;
+    if (raw == std::numeric_limits<int64_t>::min())
+      return zero;
+    if (raw >= 0) {
+      mlir::Value v = ConstantIndexOp::create(b, loc, raw);
+      return MinSIOp::create(b, loc, v, dim);
+    }
+    mlir::Value v = ConstantIndexOp::create(b, loc, raw);
+    mlir::Value sum = AddIOp::create(b, loc, dim, v);
+    mlir::Value lo = MaxSIOp::create(b, loc, sum, zero);
+    return MinSIOp::create(b, loc, lo, dim);
+  };
+
+  mlir::Value sIdx = clampOnDim(startC);
+  mlir::Value eIdx = clampOnDim(endC);
+  mlir::Value eGeS = MaxSIOp::create(b, loc, eIdx, sIdx);
+  mlir::Value diff = SubIOp::create(b, loc, eGeS, sIdx);
+  mlir::Value stepM1 = ConstantIndexOp::create(b, loc, step - 1);
+  mlir::Value stepC_ = ConstantIndexOp::create(b, loc, step);
+  mlir::Value diffPlusM = AddIOp::create(b, loc, diff, stepM1);
+  return DivSIOp::create(b, loc, diffPlusM, stepC_);
 }
 
 struct SliceDecompose : public mlir::RewritePattern {
@@ -292,11 +473,26 @@ struct SliceToHip : public mlir::RewritePattern {
 
     auto dataType = mlir::cast<mlir::RankedTensorType>(data.getType());
 
-    // For each dynamic output dim, source an upper bound from the data
-    // dim at the same position. This is sound because ONNX Slice can
-    // never widen any axis -- output dim i is at most data dim i. The
-    // runtime stub honours `output_shape[i]` as the actual extent so the
-    // over-allocation is benign.
+    // Size each dynamic output dim as exactly as compile-time information
+    // allows (see the per-axis cases in the file header). When the params do
+    // not all fold (`haveExtents == false`) or an axis is untouched, fall back
+    // to the data-dim upper bound: ONNX Slice can never widen an axis, so
+    // `data.dim[i]` is a sound over-bound and the runtime honours the actual
+    // logical extent via `output_shape[i]`.
+    llvm::SmallVector<SliceAxisInfo> sliceInfo;
+    bool haveExtents = resolveSliceExtents(op, dataType, sliceInfo);
+
+    // Empty-slice (logical extent == 0) is sized to the upper bound, not 0:
+    // Slice never widens an axis so `data.dim(axis)` is a sound over-bound, and
+    // MIOpen broadcast descriptors reject dim 0. `upper` = `data.dim(axis)`.
+    auto guardWithUpper = [&](mlir::Value extent, mlir::Value upper) {
+      mlir::Value zero = mlir::arith::ConstantIndexOp::create(rewriter, loc, 0);
+      mlir::Value isZero = mlir::arith::CmpIOp::create(
+          rewriter, loc, mlir::arith::CmpIPredicate::eq, extent, zero);
+      return mlir::arith::SelectOp::create(rewriter, loc, isZero, upper, extent)
+          .getResult();
+    };
+
     llvm::SmallVector<mlir::Value> dynSizes;
     for (int64_t i = 0; i < resultType.getRank(); ++i) {
       if (!resultType.isDynamicDim(i))
@@ -304,11 +500,36 @@ struct SliceToHip : public mlir::RewritePattern {
       if (i >= dataType.getRank())
         return rewriter.notifyMatchFailure(
             op, "result rank exceeds data rank — invalid Slice");
-      if (dataType.isDynamicDim(i))
-        dynSizes.push_back(mlir::tensor::DimOp::create(rewriter, loc, data, i));
-      else
-        dynSizes.push_back(mlir::arith::ConstantIndexOp::create(
-            rewriter, loc, dataType.getDimSize(i)));
+
+      mlir::Value upper =
+          dataType.isDynamicDim(i)
+              ? mlir::tensor::DimOp::create(rewriter, loc, data, i).getResult()
+              : mlir::arith::ConstantIndexOp::create(rewriter, loc,
+                                                     dataType.getDimSize(i))
+                    .getResult();
+
+      if (!haveExtents || sliceInfo[i].useUpperBound) {
+        dynSizes.push_back(upper); // case (C)
+        continue;
+      }
+      if (sliceInfo[i].staticSize >= 0) { // case (A)
+        if (sliceInfo[i].staticSize == 0)
+          dynSizes.push_back(upper); // empty -> upper bound
+        else
+          dynSizes.push_back(mlir::arith::ConstantIndexOp::create(
+              rewriter, loc, sliceInfo[i].staticSize));
+        continue;
+      }
+      if (sliceInfo[i].runtimeFromDim) { // case (B)
+        // `runtimeFromDim` is only set for a dynamic input dim, so `upper`
+        // (= `tensor.dim(data, i)`) is exactly the dim the extent arith needs.
+        mlir::Value extent =
+            emitRuntimeExtent(rewriter, loc, upper, sliceInfo[i].runtimeStart,
+                              sliceInfo[i].runtimeEnd, sliceInfo[i].step);
+        dynSizes.push_back(guardWithUpper(extent, upper));
+        continue;
+      }
+      dynSizes.push_back(upper);
     }
     mlir::Value init =
         mlir::tensor::EmptyOp::create(rewriter, loc, resultType.getShape(),

--- a/test/lit/Conversion/onnx-to-hip/test_slice.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_slice.mlir
@@ -4,10 +4,15 @@
 // Verify the two ONNX Slice lowering paths:
 //
 //   1. SliceDecompose (preferred) — all slice params are compile-time
-//      constants with positive unit stride, so onnx.Slice is rewritten to
-//      a zero-cost tensor.extract_slice.
-//   2. SliceToHip (fallback) — non-constant indices or negative steps fall
-//      through to a native hip.slice op whose runtime is a stub today.
+//      constants with positive unit stride AND every sliced axis has a static
+//      input dim, so onnx.Slice is rewritten to a zero-cost
+//      tensor.extract_slice.
+//   2. SliceToHip (fallback) — non-constant indices, negative steps, or a
+//      sliced axis with a dynamic input dim fall through to a native hip.slice
+//      op. For a dynamic output dim SliceToHip sizes the result buffer to the
+//      EXACT logical extent whenever the params fold (host `index` arith on
+//      `tensor.dim`), instead of the data-dim upper bound — so downstream
+//      consumers never fold the kernel's zero-padded tail into reductions.
 
 // RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
 
@@ -125,10 +130,12 @@ module {
     return %r : tensor<2x?xf32>
   }
 
-  // Test 7: SliceDecompose bails when a sliced axis has a dynamic
-  // input dim (ONNX clamping rules need the static dim size); falls
-  // through to hip.slice. The data dim is forwarded as an upper-bound
-  // tensor.dim for the dynamic output dim.
+  // Test 7: SliceDecompose bails when a sliced axis has a dynamic input dim
+  // (ONNX clamping rules need the static dim size); falls through to
+  // hip.slice. The slice params [1:3:1] DO fold, so SliceToHip sizes the
+  // dynamic output dim to the EXACT logical extent via host `index` arith on
+  // the runtime `tensor.dim` (min/max/sub/divsi), not the raw upper bound.
+  // A zero-extent guard sizes a genuinely-empty slice back to the upper bound.
   func.func @test_slice_native_dyn_axis(%input: tensor<?xf32>) -> tensor<?xf32> {
     // CHECK-LABEL: func.func @test_slice_native_dyn_axis
     %starts = arith.constant dense<[1]> : tensor<1xi64>
@@ -142,8 +149,41 @@ module {
     // CHECK-NOT: tensor.extract_slice
     // CHECK-DAG: %[[A0:.*]] = arith.constant 0 : index
     // CHECK-DAG: %[[DIM:.*]] = tensor.dim %{{.*}}, %[[A0]] : tensor<?xf32>
-    // CHECK: tensor.empty(%[[DIM]]) : tensor<?xf32>
+    // exact-extent arith (ONNX clamp on the runtime dim) replaces the raw
+    // upper bound:
+    // CHECK: arith.minsi
+    // CHECK: arith.maxsi
+    // CHECK: arith.subi
+    // CHECK: arith.divsi
+    // CHECK: %[[SEL:.*]] = arith.select
+    // CHECK: tensor.empty(%[[SEL]]) : tensor<?xf32>
     // CHECK: hip.slice({{.*}}) ins({{.*}}, {{.*}}, {{.*}} : tensor<?xf32>, tensor<1xi64>, tensor<1xi64>)
     return %r : tensor<?xf32>
+  }
+
+  // Test 8: multi-dim case (B) — a dynamic sliced axis (axis 1, [0:8:1])
+  // between a static batch dim and a static untouched trailing dim. The
+  // touched dynamic axis gets the exact extent (min(8, dim)); the untouched
+  // static trailing dim is not part of dynSizes (it stays in the result type).
+  func.func @test_slice_native_dyn_axis_mid(%input: tensor<1x?x4xf32>)
+      -> tensor<1x?x4xf32> {
+    // CHECK-LABEL: func.func @test_slice_native_dyn_axis_mid
+    %starts = arith.constant dense<[0]> : tensor<1xi64>
+    %ends   = arith.constant dense<[8]> : tensor<1xi64>
+    %axes   = arith.constant dense<[1]> : tensor<1xi64>
+    %steps  = arith.constant dense<[1]> : tensor<1xi64>
+    %r = "onnx.Slice"(%input, %starts, %ends, %axes, %steps)
+        : (tensor<1x?x4xf32>, tensor<1xi64>, tensor<1xi64>,
+           tensor<1xi64>, tensor<1xi64>) -> tensor<1x?x4xf32>
+
+    // CHECK-NOT: tensor.extract_slice
+    // CHECK-DAG: %[[A1:.*]] = arith.constant 1 : index
+    // CHECK-DAG: %[[DIM:.*]] = tensor.dim %{{.*}}, %[[A1]] : tensor<1x?x4xf32>
+    // CHECK: arith.minsi
+    // CHECK: arith.divsi
+    // CHECK: %[[SEL:.*]] = arith.select
+    // CHECK: tensor.empty(%[[SEL]]) : tensor<1x?x4xf32>
+    // CHECK: hip.slice
+    return %r : tensor<1x?x4xf32>
   }
 }


### PR DESCRIPTION
## Summary

Part of the #259 split (op-by-op). This PR ports the **dynamic `Slice`
exact-extent output sizing** from #259 onto current `main`, scoped to the
self-contained, non-regressing subset.

`SliceToHip` previously sized every dynamic output dim to the **data-dim upper
bound** (`tensor.dim`). When a sliced axis has a **dynamic input dim with
constant indices**, the `hip.slice` kernel writes only the logical prefix and
zero-pads the over-allocated tail. Downstream reductions / matmuls then fold
that zero-padded tail into the result, and the output cosine collapses on
dynamic-shape vision encoders.

## What this PR does

`SliceToHip` now sizes each dynamic output dim to the **exact logical extent**
whenever the params fold:

- **(A) touched axis + static input dim** → compile-time `clampSlice`
  `IntegerAttr`.
- **(B) touched axis + dynamic input dim + constant starts/ends/steps** →
  host-side `index` arith on `tensor.dim` (`emitRuntimeExtent`: ONNX neg-index
  + clamp + ceildiv). Descriptor-only, **no GPU read**. This is the headline
  fix.
- **(C) untouched axis / unfoldable params** → data-dim upper bound (the legacy
  contract; Slice can never widen an axis).

**Empty-slice (extent == 0)** is guarded back to the upper bound
(`guardWithUpper`) rather than sized to 0, for two self-contained reasons: ONNX
Slice can never widen an axis (so `data.dim(axis)` is always a sound
over-allocation and the runtime honours the real extent via `output_shape[i]`),
and a true dim-0 buffer is rejected by MIOpen broadcast descriptors.

## Scope decisions (vs #259)

- **Kept `main`'s `SliceDecompose`** (benefit=2): const-index + all-static-input
  slices still lower to a zero-copy `tensor.extract_slice` — the LLM
  static-prefix fast path. No regression; existing lit Tests 1–3/6 still assert
  `extract_slice`.
- **Deferred** #259's **runtime-operand case** (per-token attention slice with
  RUNTIME `starts`/`ends` inside an outlined `hip.loop` body). It needs
  `followCaptureToParent` + a `hipdnn.fold_value` constant sidecar that is **not
  present on `main`**; it lands with the dynamic-vision loop infra.

## Runtime gating

The empty-input / `logical_extent` partial-fill behaviour in
`lib/Runtime/real/slice.cpp` ships in **PR-9/#308**. On bare `main` this
conversion compiles and lit-passes (pure ONNX→HIP rewrite); the empty /
partial-fill **e2e** is exercised once #308's runtime lands.

## Test plan

- [x] `test_slice.mlir` **Test 7** updated (upper-bound → exact-extent arith);
      new **Test 8** (multi-dim case B).
- [x] Conversion + Dialect lit suite **211/211** (`ctest -R Lit`).
- [x] Full reconfigure + build + install clean.
- [x] `pre-commit` clean (clang-format / lintrunner / license).
- [ ] e2e empty/partial-fill: gated on PR-9/#308 runtime (see above).
