### PR TITLE
feat(flatten): add conversion of operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ These operations are handled through standard MLIR transformations without requi
 | Constant | arith.constant or externalized to .constants.bin | ONNX Constant nodes: small values inlined, large tensors externalized |
 | ConstantOfShape | arith.constant (compile-time fold) | Folds to a splat constant when the shape input is itself constant; honours optional `value` attribute |
 | Identity | SSA value forwarding | Pass-through op; the input value is wired directly to every user (equivalent to a full-range `memref.subview` view, but cheaper — no view op is materialised in the IR) |
+| Flatten | tensor.collapse_shape (+ tensor.expand_shape for axis = 0 / axis = r) | Reshapes rank-r input to rank-2; pure metadata reinterpretation. Dynamic dims supported. |
 
 ---
 

--- a/lib/Conversion/OnnxToHip/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHip/CMakeLists.txt
@@ -55,6 +55,7 @@ add_library(OnnxToHip STATIC
   SizeConversion.cpp
   NonZeroConversion.cpp
   ConcatConversion.cpp
+  FlattenConversion.cpp
   LoopOutline.cpp
 )
 

--- a/lib/Conversion/OnnxToHip/FlattenConversion.cpp
+++ b/lib/Conversion/OnnxToHip/FlattenConversion.cpp
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "OnnxToHipUtils.h"
+
+namespace mlir {
+namespace hip {
+namespace {
+
+//===----------------------------------------------------------------------===//
+// Flatten -> standard tensor ops (zero-cost metadata reinterpretation)
+//===----------------------------------------------------------------------===//
+//
+// `onnx.Flatten` reshapes a rank-r input into a 2D output:
+//   output[0] = d_0 * d_1 * ... * d_{axis-1}     (1 when axis == 0)
+//   output[1] = d_axis * d_{axis+1} * ... * d_n  (1 when axis == r)
+//
+// This is pure shape metadata reinterpretation — no data movement. We lower
+// to `tensor.collapse_shape` (and `tensor.expand_shape` for the corner cases
+// where one of the two output dims is 1 and not directly producible by a
+// single collapse). Bufferization later turns those into zero-copy
+// `memref.collapse_shape` / `memref.expand_shape` descriptor edits.
+//
+// Decomposition by case (a = normalised axis, r = input rank):
+//
+//   General case  (1 <= a <= r-1, r >= 2):
+//     Before:
+//       %y = "onnx.Flatten"(%x) {axis = a} : tensor<d0 x ... x dn>
+//                                          -> tensor<P0 x P1>
+//     After:
+//       %y = tensor.collapse_shape %x [[0..a-1], [a..r-1]]
+//              : tensor<d0 x ... x dn> into tensor<P0 x P1>
+//
+//   axis = 0, r = 1:
+//     Before:  tensor<d0> -> tensor<1 x d0>
+//     After:   tensor.expand_shape %x [[0, 1]] output_shape [1, d0]
+//
+//   axis = 0, r >= 2:
+//     Before:  tensor<d0 x ... x dn> -> tensor<1 x P>
+//     After:
+//       %t = tensor.collapse_shape %x [[0, 1, ..., r-1]] : ... into tensor<P>
+//       %y = tensor.expand_shape %t [[0, 1]] output_shape [1, P]
+//                                                : tensor<P> into tensor<1 x P>
+//
+//   axis = r, r = 1:
+//     Before:  tensor<d0> -> tensor<d0 x 1>
+//     After:   tensor.expand_shape %x [[0, 1]] output_shape [d0, 1]
+//
+//   axis = r, r >= 2:
+//     Before:  tensor<d0 x ... x dn> -> tensor<P x 1>
+//     After:
+//       %t = tensor.collapse_shape %x [[0, 1, ..., r-1]] : ... into tensor<P>
+//       %y = tensor.expand_shape %t [[0, 1]] output_shape [P, 1]
+//                                                : tensor<P> into tensor<P x 1>
+//
+// Dynamic shapes are supported. `tensor.collapse_shape` naturally preserves
+// dynamic dims (the collapsed extent becomes dynamic if any source dim is).
+// For the expand step, the output_shape uses the static `1` literal and
+// `tensor.dim` on the intermediate for the dynamic side.
+
+struct FlattenDecompose : public mlir::RewritePattern {
+  FlattenDecompose(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.Flatten", /*benefit=*/1, ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override {
+    if (op->getNumOperands() != 1 || op->getNumResults() != 1)
+      return rewriter.notifyMatchFailure(op, "expected 1 input and 1 output");
+
+    mlir::Value input = op->getOperand(0);
+    auto inputType = mlir::dyn_cast<mlir::RankedTensorType>(input.getType());
+    auto outputType =
+        mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
+    if (!inputType || !outputType)
+      return rewriter.notifyMatchFailure(op, "expected ranked tensor types");
+    if (inputType.getElementType() != outputType.getElementType())
+      return rewriter.notifyMatchFailure(op, "element type mismatch");
+    if (outputType.getRank() != 2)
+      return rewriter.notifyMatchFailure(op, "Flatten output must be rank-2");
+
+    int64_t r = inputType.getRank();
+    if (r < 1)
+      return rewriter.notifyMatchFailure(
+          op, "rank-0 input not supported by Flatten lowering");
+
+    // Normalise axis to [0, r]. ONNX allows axis in [-r, r]; default = 1.
+    // ONNX attributes are typically `si64` (signed) — use getSExtValue so
+    // we don't trip the signless-only assert inside IntegerAttr::getInt.
+    int64_t axis = 1;
+    if (auto attr = op->getAttrOfType<mlir::IntegerAttr>("axis"))
+      axis = attr.getValue().getSExtValue();
+    if (axis < 0)
+      axis += r;
+    if (axis < 0 || axis > r)
+      return rewriter.notifyMatchFailure(op, "axis out of range [-r, r]");
+
+    mlir::Location loc = op->getLoc();
+
+    // Helper: build a single-group reassociation [[0, 1, ..., n-1]] that
+    // collapses an entire rank-n tensor into rank-1.
+    auto buildFullCollapseReassoc = [](int64_t n) {
+      mlir::ReassociationIndices group;
+      group.reserve(n);
+      for (int64_t i : llvm::seq<int64_t>(n))
+        group.push_back(i);
+      return llvm::SmallVector<mlir::ReassociationIndices>{group};
+    };
+
+    // Helper: produce the 1D intermediate `tensor<P x elem>` (P may be
+    // dynamic) by collapsing the entire input. Only called for r >= 2.
+    auto buildFullCollapse1D = [&]() -> mlir::Value {
+      // Compute the single dim of the 1D result: static iff every input dim
+      // is static, otherwise dynamic.
+      int64_t flatDim = 1;
+      bool anyDyn = false;
+      for (int64_t i : llvm::seq<int64_t>(r)) {
+        if (inputType.isDynamicDim(i)) {
+          anyDyn = true;
+          break;
+        }
+        flatDim *= inputType.getDimSize(i);
+      }
+      int64_t flatExtent =
+          anyDyn ? mlir::ShapedType::kDynamic : flatDim;
+      auto flatType = mlir::RankedTensorType::get({flatExtent},
+                                                  inputType.getElementType());
+      auto reassoc = buildFullCollapseReassoc(r);
+      auto collapseOp = mlir::tensor::CollapseShapeOp::create(
+          rewriter, loc, flatType, input, reassoc);
+      return collapseOp.getResult();
+    };
+
+    // Case A: 1 <= axis <= r-1 (with r >= 2 implied). Pure collapse from
+    // rank-r to rank-2 with two contiguous groups.
+    if (axis >= 1 && axis <= r - 1) {
+      mlir::ReassociationIndices g0, g1;
+      for (int64_t i : llvm::seq<int64_t>(axis))
+        g0.push_back(i);
+      for (int64_t i = axis; i < r; ++i)
+        g1.push_back(i);
+      llvm::SmallVector<mlir::ReassociationIndices> reassoc{g0, g1};
+      auto collapseOp = mlir::tensor::CollapseShapeOp::create(
+          rewriter, loc, outputType, input, reassoc);
+      rewriter.replaceOp(op, collapseOp.getResult());
+      return mlir::success();
+    }
+
+    // Cases B/C: axis == 0 or axis == r. Both require an expand step to
+    // insert the size-1 dim.
+    //
+    // If r == 1, expand the rank-1 input directly into the rank-2 output.
+    // If r >= 2, first collapse the input into rank-1, then expand.
+
+    mlir::Value src;
+    mlir::RankedTensorType srcType;
+    if (r == 1) {
+      src = input;
+      srcType = inputType;
+    } else {
+      src = buildFullCollapse1D();
+      srcType = mlir::cast<mlir::RankedTensorType>(src.getType());
+    }
+
+    // The rank-1 -> rank-2 expand: single reassociation group [[0, 1]].
+    // The size-1 dim is whichever output dim equals 1 (axis == 0 -> dim 0,
+    // axis == r -> dim 1).
+    llvm::SmallVector<mlir::ReassociationIndices> expandReassoc{{0, 1}};
+
+    // Build output_shape as mixed (static 1 attr + runtime dim for the other).
+    llvm::SmallVector<mlir::OpFoldResult> outputShape;
+    outputShape.reserve(2);
+    for (int64_t i : llvm::seq<int64_t>(2)) {
+      if (!outputType.isDynamicDim(i)) {
+        outputShape.push_back(rewriter.getIndexAttr(outputType.getDimSize(i)));
+      } else {
+        // Dynamic side mirrors the rank-1 source's single dim.
+        mlir::Value dim =
+            mlir::tensor::DimOp::create(rewriter, loc, src, 0);
+        outputShape.push_back(dim);
+      }
+    }
+    (void)srcType; // type info embedded in the value
+
+    auto expandOp = mlir::tensor::ExpandShapeOp::create(
+        rewriter, loc, outputType, src, expandReassoc, outputShape);
+    rewriter.replaceOp(op, expandOp.getResult());
+    return mlir::success();
+  }
+};
+
+} // namespace
+
+void populateFlattenConversionPatterns(RewritePatternSet &patterns,
+                                       MLIRContext *ctx) {
+  patterns.add<FlattenDecompose>(ctx);
+}
+
+} // namespace hip
+} // namespace mlir

--- a/lib/Conversion/OnnxToHip/FlattenConversion.cpp
+++ b/lib/Conversion/OnnxToHip/FlattenConversion.cpp
@@ -123,10 +123,9 @@ struct FlattenDecompose : public mlir::RewritePattern {
         }
         flatDim *= inputType.getDimSize(i);
       }
-      int64_t flatExtent =
-          anyDyn ? mlir::ShapedType::kDynamic : flatDim;
-      auto flatType = mlir::RankedTensorType::get({flatExtent},
-                                                  inputType.getElementType());
+      int64_t flatExtent = anyDyn ? mlir::ShapedType::kDynamic : flatDim;
+      auto flatType =
+          mlir::RankedTensorType::get({flatExtent}, inputType.getElementType());
       auto reassoc = buildFullCollapseReassoc(r);
       auto collapseOp = mlir::tensor::CollapseShapeOp::create(
           rewriter, loc, flatType, input, reassoc);
@@ -177,8 +176,7 @@ struct FlattenDecompose : public mlir::RewritePattern {
         outputShape.push_back(rewriter.getIndexAttr(outputType.getDimSize(i)));
       } else {
         // Dynamic side mirrors the rank-1 source's single dim.
-        mlir::Value dim =
-            mlir::tensor::DimOp::create(rewriter, loc, src, 0);
+        mlir::Value dim = mlir::tensor::DimOp::create(rewriter, loc, src, 0);
         outputShape.push_back(dim);
       }
     }

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -512,6 +512,7 @@ static mlir::LogicalResult convertComputeOps(mlir::func::FuncOp funcOp,
   populateSizeConversionPatterns(patterns, ctx);
   populateNonZeroConversionPatterns(patterns, ctx);
   populateConcatConversionPatterns(patterns, ctx);
+  populateFlattenConversionPatterns(patterns, ctx);
 
   mlir::GreedyRewriteConfig config;
   config.setStrictness(mlir::GreedyRewriteStrictness::ExistingOps);

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
@@ -204,6 +204,8 @@ void populateNonZeroConversionPatterns(RewritePatternSet &patterns,
                                        MLIRContext *ctx);
 void populateConcatConversionPatterns(RewritePatternSet &patterns,
                                       MLIRContext *ctx);
+void populateFlattenConversionPatterns(RewritePatternSet &patterns,
+                                       MLIRContext *ctx);
 
 /// Pre-lowering pattern set: collapse the Gather(Shape(x), const_idx)
 /// idiom into tensor.from_elements over a tensor.dim of x. Must run

--- a/test/lit/Conversion/onnx-to-hip/test_flatten.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_flatten.mlir
@@ -1,0 +1,105 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// Verify the ONNX Flatten lowering: every onnx.Flatten is decomposed into
+// pure shape metadata ops (tensor.collapse_shape and/or tensor.expand_shape).
+// No `hip.*` op or runtime kernel is produced.
+
+// RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
+
+module {
+  func.func @main_graph(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+    return %arg0 : tensor<4xf32>
+  }
+
+  // Test 1: default axis = 1, rank-4 static input. Pure collapse, two groups
+  //         [[0], [1, 2, 3]] -> tensor<2x60xf32>.
+  func.func @test_flatten_axis1_static(%arg0: tensor<2x3x4x5xf32>) -> tensor<2x60xf32> {
+    // CHECK-LABEL: func.func @test_flatten_axis1_static
+    %r = "onnx.Flatten"(%arg0) {axis = 1 : si64}
+        : (tensor<2x3x4x5xf32>) -> tensor<2x60xf32>
+
+    // CHECK-NOT: onnx.Flatten
+    // CHECK-NOT: hip.flatten
+    // CHECK: tensor.collapse_shape %{{.*}} {{\[\[}}0{{\]}}, {{\[}}1, 2, 3{{\]\]}}
+    // CHECK-SAME: tensor<2x3x4x5xf32> into tensor<2x60xf32>
+
+    return %r : tensor<2x60xf32>
+  }
+
+  // Test 2: axis = 2 on a rank-4 static input. Reassoc [[0,1], [2,3]] -> 6x20.
+  func.func @test_flatten_axis2_static(%arg0: tensor<2x3x4x5xf32>) -> tensor<6x20xf32> {
+    // CHECK-LABEL: func.func @test_flatten_axis2_static
+    %r = "onnx.Flatten"(%arg0) {axis = 2 : si64}
+        : (tensor<2x3x4x5xf32>) -> tensor<6x20xf32>
+
+    // CHECK-NOT: onnx.Flatten
+    // CHECK: tensor.collapse_shape %{{.*}} {{\[\[}}0, 1{{\]}}, {{\[}}2, 3{{\]\]}}
+    // CHECK-SAME: tensor<2x3x4x5xf32> into tensor<6x20xf32>
+
+    return %r : tensor<6x20xf32>
+  }
+
+  // Test 3: axis = 0 corner case on a rank-3 static input. Requires
+  //         collapse-then-expand: tensor<2x3x4> -> tensor<24> -> tensor<1x24>.
+  func.func @test_flatten_axis0_static(%arg0: tensor<2x3x4xf32>) -> tensor<1x24xf32> {
+    // CHECK-LABEL: func.func @test_flatten_axis0_static
+    %r = "onnx.Flatten"(%arg0) {axis = 0 : si64}
+        : (tensor<2x3x4xf32>) -> tensor<1x24xf32>
+
+    // CHECK-NOT: onnx.Flatten
+    // CHECK: tensor.collapse_shape %{{.*}} {{\[\[}}0, 1, 2{{\]\]}}
+    // CHECK-SAME: tensor<2x3x4xf32> into tensor<24xf32>
+    // CHECK: tensor.expand_shape %{{.*}} {{\[\[}}0, 1{{\]\]}}
+    // CHECK-SAME: tensor<24xf32> into tensor<1x24xf32>
+
+    return %r : tensor<1x24xf32>
+  }
+
+  // Test 4: axis = r corner case (axis = 3 on rank-3 input). Trailing 1.
+  //         tensor<2x3x4> -> tensor<24> -> tensor<24x1>.
+  func.func @test_flatten_axis_eq_rank_static(%arg0: tensor<2x3x4xf32>) -> tensor<24x1xf32> {
+    // CHECK-LABEL: func.func @test_flatten_axis_eq_rank_static
+    %r = "onnx.Flatten"(%arg0) {axis = 3 : si64}
+        : (tensor<2x3x4xf32>) -> tensor<24x1xf32>
+
+    // CHECK-NOT: onnx.Flatten
+    // CHECK: tensor.collapse_shape %{{.*}} {{\[\[}}0, 1, 2{{\]\]}}
+    // CHECK-SAME: tensor<2x3x4xf32> into tensor<24xf32>
+    // CHECK: tensor.expand_shape %{{.*}} {{\[\[}}0, 1{{\]\]}}
+    // CHECK-SAME: tensor<24xf32> into tensor<24x1xf32>
+
+    return %r : tensor<24x1xf32>
+  }
+
+  // Test 5: dynamic batch dim with default axis = 1. The collapsed inner
+  //         group is fully static (3*4*5 = 60) so the output has shape
+  //         <?x60xf16>. tensor.collapse_shape naturally propagates the
+  //         dynamic outer dim.
+  func.func @test_flatten_dynamic_batch(%arg0: tensor<?x3x4x5xf16>) -> tensor<?x60xf16> {
+    // CHECK-LABEL: func.func @test_flatten_dynamic_batch
+    // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[ARG:.*]]: tensor<?x3x4x5xf16>)
+    %r = "onnx.Flatten"(%arg0) {axis = 1 : si64}
+        : (tensor<?x3x4x5xf16>) -> tensor<?x60xf16>
+
+    // CHECK-NOT: onnx.Flatten
+    // CHECK: tensor.collapse_shape %[[ARG]] {{\[\[}}0{{\]}}, {{\[}}1, 2, 3{{\]\]}}
+    // CHECK-SAME: tensor<?x3x4x5xf16> into tensor<?x60xf16>
+
+    return %r : tensor<?x60xf16>
+  }
+
+  // Test 6: negative axis = -1 normalises to r-1 = 3 on rank-4. Single
+  //         collapse with reassoc [[0,1,2], [3]] -> 24x5.
+  func.func @test_flatten_negative_axis(%arg0: tensor<2x3x4x5xf32>) -> tensor<24x5xf32> {
+    // CHECK-LABEL: func.func @test_flatten_negative_axis
+    %r = "onnx.Flatten"(%arg0) {axis = -1 : si64}
+        : (tensor<2x3x4x5xf32>) -> tensor<24x5xf32>
+
+    // CHECK-NOT: onnx.Flatten
+    // CHECK: tensor.collapse_shape %{{.*}} {{\[\[}}0, 1, 2{{\]}}, {{\[}}3{{\]\]}}
+    // CHECK-SAME: tensor<2x3x4x5xf32> into tensor<24x5xf32>
+
+    return %r : tensor<24x5xf32>
+  }
+}

--- a/test/lit/e2e/test_flatten_model.mlir
+++ b/test/lit/e2e/test_flatten_model.mlir
@@ -1,0 +1,29 @@
+// RUN: hip-mlir-opt %s --hipdnn-pipeline | FileCheck %s
+
+// Test Flatten E2E full pipeline.
+// onnx.Flatten decomposes to tensor.collapse_shape (and tensor.expand_shape
+// for axis = 0 / axis = r corner cases). Both bufferize to zero-cost
+// memref descriptor edits — no HIP kernel and no runtime symbol are emitted.
+//
+// Verifies the complete hipdnn-pipeline:
+// 1. convert-onnx-to-hip: onnx.Flatten -> tensor.collapse_shape
+// 2. one-shot-bufferize: tensor -> memref descriptor ops
+// 3. generate-interface: Create inference_init/compute/cleanup/metadata.
+
+// CHECK: module attributes {
+// CHECK-SAME: hipdnn.input_count = 1
+// CHECK-SAME: hipdnn.output_count = 1
+// CHECK-NOT: onnx.Flatten
+// CHECK: llvm.func @inference_init
+// CHECK: llvm.func @inference_compute
+// CHECK: llvm.func @inference_cleanup
+// CHECK: llvm.func @inference_get_metadata_json
+module {
+  func.func @main_graph(%arg0: tensor<2x3x4x5xf32> {onnx.name = "input"})
+      -> (tensor<2x60xf32> {onnx.name = "output"}) {
+    %0 = "onnx.Flatten"(%arg0) {axis = 1 : si64, onnx_node_name = "flatten_node"}
+        : (tensor<2x3x4x5xf32>) -> tensor<2x60xf32>
+    "onnx.Return"(%0) : (tensor<2x60xf32>) -> ()
+  }
+  "onnx.EntryPoint"() {func = @main_graph} : () -> ()
+}


### PR DESCRIPTION
<!--
Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
Licensed under the MIT License.
-->

<!--
Thanks for contributing! Please skim the two policies this repo
follows before requesting review (1-2 minutes each):

  Incremental development:
    https://llvm.org/docs/DeveloperPolicy.html#incremental-development
  AI tool use:
    https://llvm.org/docs/AIToolPolicy.html

A short summary lives in CONTRIBUTING.md at the repo root. Each
section below has an HTML comment explaining what to put in it; you
can delete the comment after filling the section in.
-->

## Summary

Part of the **#277 split** (op-by-op extraction from the Procyon model-support batch). This PR adds **`onnx.Flatten`** lowering so Procyon vision / multimodal graphs that reshape activations to rank-2 before Gemm/MatMul can compile through the MorphiZen pipeline instead of failing at ONNX→HIP conversion.
Previously, unsupported `onnx.Flatten` nodes blocked compilation (`error: op was not bufferized` / graph claim failure). This PR treats Flatten as a **zero-cost shape-metadata op** — same class as Reshape / Squeeze / Unsqueeze — with **no new `hip.*` dialect op and no runtime kernel**.
## What this PR does
- Add `FlattenConversion.cpp`: decompose `onnx.Flatten` into standard MLIR tensor shape ops:
  - **General case** (`1 <= axis <= r-1`): single `tensor.collapse_shape` with two reassociation groups.
  - **Corner cases** (`axis = 0` or `axis = r`): `tensor.collapse_shape` → `tensor.expand_shape` to insert the size-1 dim.
  - **Dynamic shapes**: supported; dynamic extents propagate via `tensor.collapse_shape` / `tensor.dim`.
  - **Negative axis**: normalised per ONNX spec (`axis += r`).
- Register `populateFlattenConversionPatterns` in `convert-onnx-to-hip`.
- Document the op in `README.md` operator table.
- Add LIT coverage:
  - `test/lit/Conversion/onnx-to-hip/test_flatten.mlir` — static/dynamic/negative-axis cases.
  - `test/lit/e2e/test_flatten_model.mlir` — full `hipdnn-pipeline` through `inference_init/compute/cleanup`.



## Test plan

- [x] Based on pr259 and this change, the results of procyon-related models are now consistent with cpuep.

## Notes for reviewers

<!--
- Known limitations and what they would take to fix.
- Follow-ups already planned (link the design issue / next PR).
- Anything load-bearing that isn't obvious from the diff (invariants,
  ABI assumptions, ordering constraints).
- "None" is a valid answer if the PR is small and self-contained.
-->

<!--
============================================================
Optional sections — include when applicable. Delete this whole
block if you don't need any of them.
============================================================

## Compiler IR walkthrough

<details>
<summary><b>Before</b> — short description</summary>

```mlir
// IR before this PR's pass / lowering
```

</details>

<details>
<summary><b>After</b> — short description</summary>

```mlir
// IR after this PR's pass / lowering
```

</details>

## Performance

<details>
<summary>Short headline result (e.g. "22x over DML EP on …")</summary>

| Metric | This PR | Baseline | Ratio |
|---|---:|---:|---:|
| Inferences/sec | … | … | … |
| Mean latency | … | … | … |

Hardware: gfxNNNN, model: <name>, build: <flags>.

</details>

============================================================
-->

## Checklist

- [ ] **Incremental.** This PR is either standalone, or a planned step
      in a documented series. If it exceeds ~500 LOC or ~10 files, the
      Summary / Why explains why it cannot be split, OR links the
      precursor PRs and the design issue. See:
      https://llvm.org/docs/DeveloperPolicy.html#incremental-development
- [ ] **AI policy.** If AI tools (Cursor, Claude, Copilot, etc.)
      generated substantial code or text, the Summary discloses it,
      the commit messages carry the trailers documented in
      [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md#commit-message-trailers),
      and you can answer questions about each design decision in
      review without delegating back to the tool. See:
      https://llvm.org/docs/AIToolPolicy.html
- [ ] **No `good first issue` automation.** This PR is not an AI-tool
      fix to an issue tagged `good first issue` (those are reserved as
      learning opportunities for new contributors).
- [ ] **Reviews resolved.** All review-comment threads from prior
      rounds are resolved (enforced by branch protection on `main`).
- [ ] **CODEOWNERS routing.** Reviewers were assigned automatically by
      [`CODEOWNERS`](../blob/main/.github/CODEOWNERS). If the change
      touches a path outside the current ownership map, the PR
      description names the operational owner.
