### PR TITLE
fix(deps): extract auto-downloaded TheRock without GNU-only --force-local

### DIFF
--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -94,11 +94,16 @@ if(_HIPDNN_NEED_TOOLCHAIN)
         file(MAKE_DIRECTORY "${_therock_root}")
         message(STATUS "Extracting TheRock SDK into ${_therock_root} ...")
         # tar (ships with Windows 10+/Linux) flattens the single top-level dir;
-        # file(ARCHIVE_EXTRACT) has no --strip-components. --force-local stops GNU
-        # tar from treating the Windows "D:\..." archive path as a remote host.
+        # file(ARCHIVE_EXTRACT) has no --strip-components. Pass the archive as a
+        # relative basename with WORKING_DIRECTORY so the path carries no
+        # drive-letter colon: GNU tar would otherwise read "D:\..." as a remote
+        # "host:path" (the reason --force-local was here), and Windows bsdtar
+        # rejects --force-local outright. The basename form needs neither and
+        # works for both. -C takes an absolute path unaffected by this parsing.
         execute_process(
-          COMMAND ${CMAKE_COMMAND} -E env tar --force-local -xzf "${_therock_tgz}"
+          COMMAND tar -xzf "${_therock_base}.tar.gz"
                   -C "${_therock_root}" --strip-components=1
+          WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
           RESULT_VARIABLE _therock_tar_rc)
         if(NOT _therock_tar_rc EQUAL 0)
           message(FATAL_ERROR "TheRock extraction failed (tar rc=${_therock_tar_rc}).")


### PR DESCRIPTION
## Problem

The from-source toolchain path in `cmake/deps.cmake` auto-downloads the TheRock SDK and unpacks it with:

```cmake
tar --force-local -xzf ${_therock_tgz} -C ${_therock_root} --strip-components=1
```

`--force-local` is a **GNU tar** extension. The `tar` that ships in Windows 10/11 (`C:\Windows\System32\tar.exe`) is **bsdtar** (libarchive), which rejects the flag outright:

```
tar: Option --force-local is not supported
CMake Error at cmake/deps.cmake:104 (message): TheRock extraction failed (tar rc=1).
```

So `cmake` configure aborts on any stock Windows host taking the from-source / auto-download path. It only happened to succeed where a GNU tar was earlier on `PATH`.

`--force-local` was added solely to stop GNU tar from interpreting the Windows archive path `D:\...` as a remote `host:path` (the drive-letter colon).

## Solution

Single-file change in `cmake/deps.cmake`: drop `--force-local` and pass the archive as a **relative basename** with `WORKING_DIRECTORY=${CMAKE_BINARY_DIR}`:

```cmake
execute_process(
  COMMAND tar -xzf ${_therock_base}.tar.gz
          -C ${_therock_root} --strip-components=1
  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
  RESULT_VARIABLE _therock_tar_rc)
```

- No drive-letter colon in the archive argument -> neither GNU tar nor bsdtar misparses it as remote, so the flag is unnecessary.
- The `-C` extraction dir stays an absolute path; the `host:path` parsing only applies to the `-f` archive argument, so `-C` is unaffected.
- Dropped the redundant `${CMAKE_COMMAND} -E env` wrapper.

## Results

Reproduced and verified on a stock Windows 11 host (bsdtar 3.8.4 / libarchive 3.8.4):

- Before: configure aborts at TheRock extraction (`tar rc=1`, `Option --force-local is not supported`).
- After: replicating the exact cmake invocation (relative basename + `WORKING_DIRECTORY` = build dir) extracts the 2.3 GB SDK with `tar rc=0` in ~18s; `_therock/bin/amdhip64_7.dll` and `_therock/bin/hipcc.exe` present.

### Diff scope

- `cmake/deps.cmake` only (the TheRock auto-download extraction step + its comment).