### PR TITLE
feat(hip-onnx-runner): free-dimension override (-f) for dynamic-shape models

### DIFF
--- a/tools/hip-onnx-runner/hip-onnx-runner.cpp
+++ b/tools/hip-onnx-runner/hip-onnx-runner.cpp
@@ -827,6 +827,15 @@ int main(int argc, char *argv[]) {
       "p", "positive-only",
       "Generate positive-only random inputs (for Sqrt/Reciprocal testing)",
       "false", true);
+  mo.add_option(
+      "f", "free-dim",
+      "Override a free/symbolic input dimension by name to a concrete value: "
+      "'name:value' (repeatable or comma-separated), e.g. "
+      "-f sequence_length:128. Mirrors onnxruntime_perf_test's -f option; "
+      "applied via AddFreeDimensionOverrideByName so ORT resolves the symbolic "
+      "dim consistently across the graph. Any free dim left unoverridden is "
+      "treated as 1.",
+      "");
 
   try {
     mo.parse(argc, argv);
@@ -952,6 +961,34 @@ int main(int argc, char *argv[]) {
     session_opts.AddConfigEntry("session.disable_cpu_ep_fallback", "1");
   }
 
+  // Free-dimension overrides (mirror onnxruntime_perf_test -f). Each entry is
+  // "name:value"; ORT substitutes the symbolic dim by name across the whole
+  // graph before shape inference, keeping shared dims consistent. Free dims
+  // left unoverridden are filled as 1 during input generation below.
+  for (const std::string &ov : mo.get_vector<std::string>("free-dim")) {
+    const auto colon = ov.find(':');
+    if (colon == std::string::npos || colon == 0 || colon + 1 >= ov.size()) {
+      std::cerr << "Error: --free-dim expects 'name:value', got: " << ov
+                << "\n";
+      return 1;
+    }
+    const std::string dim_name = trim_string(ov.substr(0, colon));
+    int64_t dim_value = 0;
+    try {
+      dim_value = std::stoll(trim_string(ov.substr(colon + 1)));
+    } catch (const std::exception &) {
+      std::cerr << "Error: --free-dim value is not an integer: " << ov << "\n";
+      return 1;
+    }
+    if (dim_value <= 0) {
+      std::cerr << "Error: --free-dim value must be > 0, got: " << ov << "\n";
+      return 1;
+    }
+    session_opts.AddFreeDimensionOverrideByName(dim_name.c_str(), dim_value);
+    std::cout << "Overriding free dimension '" << dim_name << "' -> "
+              << dim_value << "\n";
+  }
+
   // Create session
   auto model_path = std::filesystem::path(model_path_str);
   std::cout << "Loading model: " << model_path.string() << "\n";
@@ -1026,8 +1063,14 @@ int main(int argc, char *argv[]) {
 
   for (size_t i = 0; i < input_count; ++i) {
     auto shape = input_shapes[i];
-    if (!shape.empty() && shape[0] == -1)
-      shape[0] = 1;
+    // Any free dimension still unresolved here (i.e. not pinned via --free-dim)
+    // is treated as 1, matching onnxruntime_perf_test's default behavior
+    // (free dimensions are treated as 1 if not overridden). This keeps the
+    // buffer-size computation below from overflowing on symbolic dims.
+    for (auto &dim : shape) {
+      if (dim < 0)
+        dim = 1;
+    }
 
     size_t elem_size = element_byte_size(input_types[i]);
     int64_t n_elems = calculate_product(shape);

--- a/tools/hip-onnx-runner/hip-onnx-runner.cpp
+++ b/tools/hip-onnx-runner/hip-onnx-runner.cpp
@@ -829,12 +829,11 @@ int main(int argc, char *argv[]) {
       "false", true);
   mo.add_option(
       "f", "free-dim",
-      "Override a free/symbolic input dimension by name to a concrete value: "
-      "'name:value' (repeatable or comma-separated), e.g. "
-      "-f sequence_length:128. Mirrors onnxruntime_perf_test's -f option; "
-      "applied via AddFreeDimensionOverrideByName so ORT resolves the symbolic "
-      "dim consistently across the graph. Any free dim left unoverridden is "
-      "treated as 1.",
+      "Resolve a symbolic input dimension by name to a concrete value at RUN "
+      "time: 'name:value' (repeatable or comma-separated), e.g. "
+      "-f sequence_length:128. The EP still compiles the DYNAMIC (symbolic) "
+      "graph; the value only sizes the input tensors. Symbolic dims without a "
+      "matching override default to 1.",
       "");
 
   try {
@@ -961,10 +960,14 @@ int main(int argc, char *argv[]) {
     session_opts.AddConfigEntry("session.disable_cpu_ep_fallback", "1");
   }
 
-  // Free-dimension overrides (mirror onnxruntime_perf_test -f). Each entry is
-  // "name:value"; ORT substitutes the symbolic dim by name across the whole
-  // graph before shape inference, keeping shared dims consistent. Free dims
-  // left unoverridden are filled as 1 during input generation below.
+  // Free-dimension values for symbolic input dims. Each entry is "name:value".
+  // These are deliberately NOT applied via AddFreeDimensionOverrideByName: that
+  // would make ORT substitute the symbolic dims before the graph reaches the
+  // EP, so the EP would compile a *static* graph. We want the opposite -- the
+  // EP should compile the *dynamic* (symbolic) graph, and the concrete value is
+  // only used at run time to size the input tensors (see the input loop below).
+  // Symbolic input dims with no matching override fall back to 1.
+  std::unordered_map<std::string, int64_t> free_dim_values;
   for (const std::string &ov : mo.get_vector<std::string>("free-dim")) {
     const auto colon = ov.find(':');
     if (colon == std::string::npos || colon == 0 || colon + 1 >= ov.size()) {
@@ -984,9 +987,9 @@ int main(int argc, char *argv[]) {
       std::cerr << "Error: --free-dim value must be > 0, got: " << ov << "\n";
       return 1;
     }
-    session_opts.AddFreeDimensionOverrideByName(dim_name.c_str(), dim_value);
-    std::cout << "Overriding free dimension '" << dim_name << "' -> "
-              << dim_value << "\n";
+    free_dim_values[dim_name] = dim_value;
+    std::cout << "Free dimension '" << dim_name << "' -> " << dim_value
+              << " (runtime input shape; EP still compiles dynamic)\n";
   }
 
   // Create session
@@ -1019,6 +1022,7 @@ int main(int argc, char *argv[]) {
   std::vector<std::string> input_names_str;
   std::vector<const char *> input_names;
   std::vector<std::vector<int64_t>> input_shapes;
+  std::vector<std::vector<std::string>> input_symbolic_dims;
   std::vector<ONNXTensorElementDataType> input_types;
 
   for (size_t i = 0; i < input_count; ++i) {
@@ -1028,6 +1032,15 @@ int main(int argc, char *argv[]) {
     auto tensor_info = type_info.GetTensorTypeAndShapeInfo();
     input_shapes.push_back(tensor_info.GetShape());
     input_types.push_back(tensor_info.GetElementType());
+    // GetSymbolicDimensions returns ORT-owned const char* (one per dim; empty
+    // string for static dims). Copy to std::string while tensor_info is alive
+    // so we can resolve symbolic dims by name when sizing inputs below.
+    std::vector<const char *> sym = tensor_info.GetSymbolicDimensions();
+    std::vector<std::string> sym_copy;
+    sym_copy.reserve(sym.size());
+    for (const char *s : sym)
+      sym_copy.emplace_back(s ? s : "");
+    input_symbolic_dims.push_back(std::move(sym_copy));
   }
   for (auto &s : input_names_str)
     input_names.push_back(s.c_str());
@@ -1063,13 +1076,22 @@ int main(int argc, char *argv[]) {
 
   for (size_t i = 0; i < input_count; ++i) {
     auto shape = input_shapes[i];
-    // Any free dimension still unresolved here (i.e. not pinned via --free-dim)
-    // is treated as 1, matching onnxruntime_perf_test's default behavior
-    // (free dimensions are treated as 1 if not overridden). This keeps the
-    // buffer-size computation below from overflowing on symbolic dims.
-    for (auto &dim : shape) {
-      if (dim < 0)
-        dim = 1;
+    // Resolve free/symbolic dims (-1) for the *runtime* input tensor only; the
+    // graph the EP compiled stays dynamic. A dim is resolved by its symbolic
+    // name via --free-dim (e.g. sequence_length:128); any symbolic dim without
+    // a matching override falls back to 1 so the buffer-size computation below
+    // does not overflow.
+    const auto &sym = input_symbolic_dims[i];
+    for (size_t j = 0; j < shape.size(); ++j) {
+      if (shape[j] >= 0)
+        continue;
+      int64_t resolved = 1;
+      if (j < sym.size() && !sym[j].empty()) {
+        auto it = free_dim_values.find(sym[j]);
+        if (it != free_dim_values.end())
+          resolved = it->second;
+      }
+      shape[j] = resolved;
     }
 
     size_t elem_size = element_byte_size(input_types[i]);


### PR DESCRIPTION
## Summary

- Add dynamic-shape testing support to `hip-onnx-runner`: the EP compiles the **dynamic (symbolic) graph**, and `-f` only chooses the **concrete input shape used at run time**.
- New `-f` / `--free-dim` option (repeatable or comma-separated `name:value`) maps a symbolic dimension name to a value used when sizing the runtime input tensors. It deliberately does **not** call `AddFreeDimensionOverrideByName`, so ORT does not bake the dims and the EP still receives the `?`-shaped graph.
- Symbolic input dims without a matching `-f` override default to `1`. This also fixes a `std::length_error` crash on models with non-batch symbolic dims, where the old code only resolved the batch dim and `calculate_product` overflowed the input buffer size.

## Motivation

We want to exercise the EP's real dynamic-shape path: compile once with symbolic dims, then run at a concrete shape. Using `AddFreeDimensionOverrideByName` would specialize the graph to a fixed shape *before* it reaches the EP (the EP would only ever see static shapes). Instead, `-f` now affects only the runtime input tensors, leaving the compiled graph dynamic.

`single_op/Mul/Mul_dynamic.onnx` (inputs `[1, sequence_length, 14336]`) previously crashed the runner during random-input allocation because only the batch dim was resolved, leaving `sequence_length = -1`.

## How it works

For each input, the runner reads both `GetShape()` (with `-1` for symbolic dims) and `GetSymbolicDimensions()` (the dim names). When sizing the runtime tensor, each `-1` dim is resolved by looking up its symbolic name in the `-f` map; unmatched symbolic dims fall back to `1`. The session is created **without** any free-dimension override, so the EP compiles the dynamic graph.

## Usage

```bash
# Single dynamic dim — EP compiles tensor<1x?x14336xf16>, runs at seq=128
hip-onnx-runner -m Mul_dynamic.onnx -d 3 -s 42 -f sequence_length:128

# Multiple dynamic dims — repeat -f or comma-separate (equivalent)
hip-onnx-runner -m model.onnx -d 3 -s 42 -f seq_len:128 -f past_seq_len:64
hip-onnx-runner -m model.onnx -d 3 -s 42 -f "seq_len:128,past_seq_len:64"
```

Each override is `name:value` (`value > 0`). Matching is by symbolic name, so a name shared by several tensors is sized consistently.

> **Note — comparing EP vs CPU:** both runs must use the same `-f` values so the input shapes (and the seed-generated random inputs) match. `run_l2_test.ps1` does not forward `-f` yet; for dynamic models run the EP/CPU/compare steps manually with identical `-f` arguments.

> **Caveat — output-only symbolic dims:** if a symbolic dim appears *only* on an output (e.g. GroupQueryAttention's `present.*` carry `total_sequence_length`, declared on no input), the EP currently cannot resolve it when compiling the dynamic graph and session creation fails. This is an EP-side limitation independent of the runner.

## Test plan

- [x] Clean build + install (RelWithDebInfo, gfx1151).
- [x] `Mul_dynamic.onnx -f sequence_length:128`: IR dump confirms the EP compiles the **dynamic** graph (`func.func @main_graph(... tensor<1x?x14336xf16> ...)`), runtime runs at seq=128 (output 1,835,008 elems), EP vs CPU **L2 = 0**.
- [x] Without `-f`, symbolic dims default to 1 (no crash); `run_l2_test.ps1` on `single_op/Mul` (8 models) all PASS, **L2 = 0 / RMS = 0**.
- [x] Invalid `-f` inputs (missing `:`, non-integer, `<= 0`) are rejected with a clear error.
