### PR TITLE
docs(ep): add output-allocator call-tree (PR #298 r3382068035)

### DIFF
--- a/docs/design/output-allocator-design.md
+++ b/docs/design/output-allocator-design.md
@@ -323,6 +323,45 @@ sequenceDiagram
     Note over EP: clear allocator on RuntimeState (self must not dangle)<br/>then blocking hipMemcpy(host, scratch) per host output<br/>(GPU outputs: nothing — zero-copy)
 ```
 
+**Call tree (same flow, code-trace view).** The sequence diagram above shows the cross-component handshake; the tree below is the full nesting of actual functions for readers tracing the code. Function names only (no line numbers, which drift). Every output buffer comes from `GetOutput` with the graph's own in-graph shape — the callback never reshapes (KV cache included).
+
+```text
+MlirCustomOp::Compute(context)
+├─ inference_state_->begin_compute()            per-Compute cache reset (e.g. GQA seqlens_k)
+├─ if (use_output_allocator_)                   cached in ctor from metadata_.use_output_allocator()
+└─ compute_with_output_allocator(context)
+   ├─ marshal_input_tensors(context, ...)       EP-side: OrtValue -> inputs.span
+   ├─ build OutputAllocatorCtx octx{ctx, outputs, output_index_map, host_out_scratch, allocated[]}
+   ├─ output_allocator_t alloc{ self=&octx, allocate=&output_allocate_cb }
+   ├─ inference_state_->set_output_allocator(&alloc)
+   │     └─ hipdnn_ep_set_output_allocator(state, &alloc)   FATAL if the DLL lacks the export
+   ├─ inference_state_->compute_with_output_allocator(&inputs.span)
+   │  └─ inference_compute(state, inputs)        2-arg ABI, NO outputs span
+   │     ├─ hipdnn_ep_tensor_prepare_input(...) x N   -> input memref descriptors
+   │     ├─ hipdnn_ep_state_reset_error_flag(state)
+   │     ├─ main_graph(state, inputs)            thin wrapper: unpacks input descriptors,
+   │     │  └─ main_graph_internal(...)          calls body, DISCARDS its returned descriptor
+   │     │     ├─ hipdnn_ep_get_pool_base(state, domain_id, size)   grow-on-demand GPU pool
+   │     │     ├─ <compute ops> (e.g. wrap_hipblasLtMatmul, wrap_miopen*) -> pool slots
+   │     │     ├─ hipdnn_ep_alloc_output(state, out_idx, shape, rank, elem)   <-- OUTPUT ALLOC
+   │     │     │  └─ output_allocator.cpp: forwards to alloc.allocate(self, ...)
+   │     │     │     └─ output_allocate_cb(...)   noexcept
+   │     │     │        ├─ shape used verbatim (no override; present dim already = past capacity)
+   │     │     │        ├─ ctx.GetOutput(ort_idx, shape)   ORT returns pre-bound / fresh OrtValue
+   │     │     │        ├─ octx.allocated[out_idx] = true
+   │     │     │        └─ GPU output  -> return ORT ptr (zero-copy)
+   │     │     │           host output -> EP GPU scratch + queue pending_d2h
+   │     │     └─ <final op writes into that ptr>; returns output by-value memref (wrapper ignores it)
+   │     ├─ hipdnn_ep_stream_sync(state)         all GPU writes complete on return
+   │     ├─ hipdnn_ep_state_read_and_clear_error_flag(state)
+   │     └─ hipdnn_ep_tensor_free_input(state, ...) x N
+   ├─ inference_state_->set_output_allocator(nullptr)   clear before octx leaves scope
+   ├─ output-completeness guard: every allocated[i] true else LOG(FATAL)
+   └─ #ifndef BUILD_MOCK_RUNTIME: pending_d2h -> blocking hipMemcpy(host <- GPU scratch)
+```
+
+Note the `main_graph` / `main_graph_internal` split (from `convert-hip-to-llvm`): `main_graph` is a thin wrapper that bridges the runtime's `(ctx, inputs)` ABI to the exploded-descriptor ABI of the body, then **discards** the body's by-value return — the real output reaches the EP through the `hipdnn_ep_alloc_output` callback, not the return value.
+
 **Status: implemented.** The illustrative pseudocode above is realized by these files (the per-model auto-enable heuristic is deferred — allocator mode is an explicit, default-off `use_output_allocator` provider option):
 
 | Concern | Where |

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -173,6 +173,17 @@ typedef struct RuntimeState RuntimeState;
 // main_graph obtains each graph-output buffer from it at the point the output
 // shape is known (lowered from hip.alloc_output -> hipdnn_ep_alloc_output).
 //
+// Call flow (allocator mode):
+//   MlirCustomOp::Compute
+//     -> hipdnn_ep_set_output_allocator(state, &alloc)   (EP installs)
+//     -> inference_compute(state, inputs)                (2-arg, no out span)
+//        -> main_graph -> main_graph_internal -> ...
+//           -> hipdnn_ep_alloc_output(state, out_idx, shape, rank, elem)
+//                -> alloc.allocate(self, ...)            (= EP callback)
+//                     -> GetOutput(shape)               (GPU zero-copy /
+//                                                         host scratch + D2H)
+//     -> set_output_allocator(nullptr); completeness check; host D2H
+//
 // ABI: this struct crosses the model.dll <-> EP boundary. Its layout is a fixed
 // contract, locked by static_asserts and mirrored by an identical EP-side copy
 // -- same convention as tensor_t below. There is intentionally no size/version


### PR DESCRIPTION
## Summary

Documentation-only change addressing the PR #298 review request ([r3382068035](https://github.com/ROCm/onnx-hipdnn-ep/pull/298#discussion_r3382068035)) to add a call-tree clarifying the output-allocator flow.

- **`docs/design/output-allocator-design.md`** (+39): adds a function-name-anchored **call-tree** in the Phase 5 section, right after the existing sequence diagram. The sequence diagram shows the cross-component handshake; the call-tree shows the full code-trace nesting (`MlirCustomOp::Compute` → `compute_with_output_allocator` → `inference_compute` (2-arg) → `main_graph`/`main_graph_internal` → `hipdnn_ep_alloc_output` → `output_allocate_cb`), including the wrapper/body split and the host-output D2H tail. Function names only (no line numbers, which drift).
- **`lib/Runtime/hipdnn_ep_runtime.h`** (+11): adds a short, self-contained call-flow comment to the "Output Allocator Contract" block. Intentionally does **not** reference the design doc (headers should not depend on docs).

No code/behavior changes. Phase 5 itself merged via #306; this branch is rebased directly onto `main` so it carries only the single docs commit.

## Verification

Traced every node of the call-tree against the live code at the current commit; all match:

- `MlirCustomOp::Compute` / `compute_with_output_allocator` / `output_allocate_cb` (`backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp`)
- `InferenceState::compute_with_output_allocator` + `set_output_allocator` 2-arg ABI + FATAL-on-missing-export (`InferenceState.cpp`)
- 2-arg `inference_compute` body order: prepare_input → reset_error_flag → main_graph → stream_sync → read_and_clear_error_flag → free_input (`lib/Dialect/Transforms/GenerateInterface.cpp`)
- `main_graph` thin wrapper discards `main_graph_internal`'s by-value return; output reaches the EP via the callback (`lib/Conversion/HipToLLVM/HipToLLVM.cpp`)
- `hipdnn_ep_alloc_output` forwarding (`lib/Runtime/output_allocator.cpp`)

The `present.*` share-buffer override is correctly shown as living **only** in the classic `marshal_output_tensors` path, not in the allocator callback.

## Test plan

- [x] Docs-only diff confirmed (`git diff --stat`: 2 files, +50/-0)
- [x] Call-tree verified node-by-node against current source
- [ ] Reviewer confirms the call-tree resolves r3382068035
