### PR TITLE
feat(hip): add hip-infer-loop-body-shapes pass to rank outlined loop bodies

### DIFF
--- a/docs/design/hip-shape-inference.md
+++ b/docs/design/hip-shape-inference.md
@@ -432,6 +432,43 @@ HIP DPS ops (GQA, RmsNorm, SkipRmsNorm, Attention, RotaryEmbedding,
 …) gain reify impls, the wiring lets each new op participate without
 any change to `Pipelines.cpp`.
 
+### Pre-conversion sibling: `--hip-infer-loop-body-shapes`
+
+`--hip-infer-shapes` only *narrows* `?` dims within a known rank on
+HIP-dialect ops; it cannot *establish* rank on a `tensor<*xT>`, and it
+runs after conversion. That leaves a gap for outlined `hip.loop` body
+functions: the importer emits `tensor<*xT>` for values whose shape it
+cannot infer (canonically a loop-carried `onnx.Concat` accumulating
+along the sequence axis), and `convert-onnx-to-hip`'s converters require
+ranked results (`ConcatConversion` bails on unranked). An unranked body
+output therefore blocks conversion *and* leaves the body `func.return`
+operand type-incompatible with the func signature.
+
+`--hip-infer-loop-body-shapes`
+(`lib/Dialect/Transforms/InferLoopBodyShapesPass.cpp`) closes that gap
+**before** conversion, modeled on onnx-mlir's `ONNXLoopOp::inferShapes`
++ `inferFunctionReturnShapes`:
+
+```text
+simplify-onnx -> hip-add-context-arg -> onnx-loop-outline
+              -> hip-infer-loop-body-shapes      <-- pre-conversion
+              -> convert-onnx-to-hip
+              -> hip-infer-shapes                 <-- post-conversion (?-narrowing)
+              -> one-shot-bufferize -> ...
+```
+
+For each `hip.loop` body func it (1) seeds the loop-carried block args
+from `$v_init`, (2) forward-infers unranked `onnx.*` results from
+operand types (currently `onnx.Concat`; extensible dispatch), (3)
+applies a loop-contract backstop (any still-unranked loop-carried output
+is set to its `$v_init` type — the ONNX Loop spec guarantees
+body-output type == loop-carried-input type), and (4) reconciles the
+body func signature from the now-ranked terminator operands. Rank is
+only *established* here; all `?`-dim narrowing remains the job of the
+post-conversion `--hip-infer-shapes`. Wired into both
+`buildOnnxToHipPipeline` overloads. LIT:
+`test/lit/Dialect/hip-infer-loop-body-shapes.mlir`.
+
 ## How to add a new op
 
 For most new HIP DPS ops the recipe collapses to **two** edits:

--- a/include/hip/Dialect/Transforms/Passes.td
+++ b/include/hip/Dialect/Transforms/Passes.td
@@ -579,6 +579,63 @@ def InferShapesPass : Pass<"hip-infer-shapes", "mlir::ModuleOp"> {
   ];
 }
 
+def InferLoopBodyShapesPass
+    : Pass<"hip-infer-loop-body-shapes", "mlir::ModuleOp"> {
+  let summary = "Rank-establish unranked tensors inside outlined hip.loop "
+                "body functions before `convert-onnx-to-hip`";
+  let description = [{
+    Runs AFTER `onnx-loop-outline` and BEFORE `convert-onnx-to-hip`. The
+    importer (MorphiZen) emits `tensor<*xT>` (unranked) for values whose
+    shape it cannot infer -- most commonly an outlined `hip.loop` body's
+    loop-carried output (e.g. an `onnx.Concat` that accumulates along the
+    sequence axis). `convert-onnx-to-hip`'s op converters require ranked
+    result types (`ConcatConversion` bails on unranked), so an unranked
+    body output blocks conversion AND leaves the body `func.return`
+    operand type-incompatible with the func signature.
+
+    This pass closes that gap by, for every `hip.loop` body func:
+      1. Seeding the body's loop-carried block args from the loop op's
+         `$v_init` operand types (already ranked post-outline; done for
+         robustness / parity with onnx-mlir `ONNXLoopOp::inferShapes`).
+      2. Forward-inferring unranked `onnx.*` result types from operand
+         types (currently: `onnx.Concat`), iterated to a fixed point.
+      3. Loop-contract backstop: any loop-carried body output still
+         unranked is set to the matching `$v_init` type -- the ONNX Loop
+         spec guarantees body-output type == loop-carried-input type.
+      4. Reconciling the body func's declared result types from the (now
+         ranked) terminator operand types.
+
+    Post-conversion `--hip-infer-shapes` still handles all `?`-dim
+    narrowing on HIP-dialect ops; this pass only establishes rank so
+    conversion can proceed.
+
+    Example (one body func):
+    ```mlir
+    // before
+    func.func private @loop_body(%ctx, %i, %c, %acc: tensor<1x?x1152xf16>, ...)
+        -> tensor<*xf16> {
+      %a = hip.multi_head_attention ... : tensor<?x?x?xf16>
+      %r = "onnx.Concat"(%acc, %a) {axis = 1} :
+             (tensor<1x?x1152xf16>, tensor<?x?x?xf16>) -> tensor<*xf16>
+      return %r : tensor<*xf16>
+    }
+
+    // after
+    func.func private @loop_body(%ctx, %i, %c, %acc: tensor<1x?x1152xf16>, ...)
+        -> tensor<1x?x1152xf16> {
+      %a = hip.multi_head_attention ... : tensor<?x?x?xf16>
+      %r = "onnx.Concat"(%acc, %a) {axis = 1} :
+             (tensor<1x?x1152xf16>, tensor<?x?x?xf16>) -> tensor<1x?x1152xf16>
+      return %r : tensor<1x?x1152xf16>
+    }
+    ```
+  }];
+  let dependentDialects = [
+    "mlir::hip::HipDialect",
+    "mlir::func::FuncDialect"
+  ];
+}
+
 def ResolveExternConstantsPass
     : Pass<"hip-resolve-extern-constants", "mlir::ModuleOp"> {
   let summary = "Replace extern memref.global constants with "

--- a/lib/Dialect/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Transforms/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(HipDialectTransforms STATIC
   BufferUtils.cpp
   GenerateInterface.cpp
   HoistAllocSizeArith.cpp
+  InferLoopBodyShapesPass.cpp
   InferShapesPass.cpp
   LowerAllocs.cpp
   MaterializeHostScalars.cpp

--- a/lib/Dialect/Transforms/InferLoopBodyShapesPass.cpp
+++ b/lib/Dialect/Transforms/InferLoopBodyShapesPass.cpp
@@ -1,0 +1,301 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- InferLoopBodyShapesPass.cpp - Rank unranked tensors in loop bodies -===//
+//
+// Module pass that runs AFTER `onnx-loop-outline` and BEFORE
+// `convert-onnx-to-hip`.
+//
+// Problem. The importer emits `tensor<*xT>` (unranked) for values whose
+// shape it cannot infer. The canonical case is an outlined `hip.loop`
+// body's loop-carried output -- e.g. an `onnx.Concat` that accumulates a
+// KV-cache slice along the sequence axis. The ONNX-to-HIP converters
+// require ranked result types (`ConcatConversion` bails on unranked), so
+// an unranked body output (a) blocks conversion -- the op survives as
+// `onnx.*` and later fails bufferization -- and (b) leaves the body
+// `func.return` operand type-incompatible with the func signature.
+//
+// Fix. For every `hip.loop` body func, establish rank using two
+// complementary sources of truth, then reconcile the signature:
+//
+//   1. Seed  -- copy the loop op's `$v_init` operand types onto the body's
+//               loop-carried block args (already ranked post-outline; done
+//               for parity with onnx-mlir `ONNXLoopOp::inferShapes`, which
+//               likewise seeds body args from the loop inputs).
+//   2. Infer -- forward-propagate rank onto unranked `onnx.*` results from
+//               their (now ranked) operands, to a fixed point.
+//   3. Backstop -- any loop-carried body output still unranked is set to the
+//               matching `$v_init` type: the ONNX Loop spec mandates
+//               body-output type == loop-carried-input type, so this is
+//               authoritative even where no forward rule exists.
+//   4. Reconcile -- rebuild the body func signature from its (seeded) args
+//               and its (now ranked) terminator operands.
+//
+// Scope. This pass only ESTABLISHES rank so conversion can proceed; all
+// `?`-dim narrowing on the resulting HIP-dialect ops remains the job of the
+// post-conversion `--hip-infer-shapes`. See
+// `docs/design/hip-shape-inference.md`.
+//
+// Before:
+//   func.func private @loop_body(%ctx, %i, %c, %acc: tensor<1x?x1152xf16>, ...)
+//       -> tensor<*xf16> {
+//     %a = hip.multi_head_attention ... : tensor<?x?x?xf16>
+//     %r = "onnx.Concat"(%acc, %a) {axis = 1} :
+//            (tensor<1x?x1152xf16>, tensor<?x?x?xf16>) -> tensor<*xf16>
+//     return %r : tensor<*xf16>
+//   }
+// After:
+//   func.func private @loop_body(%ctx, %i, %c, %acc: tensor<1x?x1152xf16>, ...)
+//       -> tensor<1x?x1152xf16> {
+//     %a = hip.multi_head_attention ... : tensor<?x?x?xf16>
+//     %r = "onnx.Concat"(%acc, %a) {axis = 1} :
+//            (tensor<1x?x1152xf16>, tensor<?x?x?xf16>) -> tensor<1x?x1152xf16>
+//     return %r : tensor<1x?x1152xf16>
+//   }
+//
+//===----------------------------------------------------------------------===//
+
+#include "hip/Dialect/IR/HipDialect.h"
+#include "hip/Dialect/Transforms/Passes.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Operation.h"
+
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/Sequence.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/Statistic.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "hip-infer-loop-body-shapes"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "] ")
+
+STATISTIC(NumOnnxResultsRanked,
+          "Unranked onnx.* results rank-established by forward inference");
+STATISTIC(NumLoopContractRanked,
+          "Loop-carried body outputs rank-established from $v_init "
+          "(loop-contract backstop)");
+STATISTIC(NumBodyFuncsReconciled,
+          "Loop-body func signatures reconciled from terminator operand types");
+
+namespace mlir {
+namespace hip {
+
+#define GEN_PASS_DEF_INFERLOOPBODYSHAPESPASS
+#include "hip/Dialect/Transforms/Passes.h.inc"
+
+namespace {
+
+/// Forward shape rule for `onnx.Concat`: infer a ranked result type from the
+/// operand types, or return null when the rule cannot apply (some operand is
+/// unranked, ranks or element types disagree, or `axis` is missing / out of
+/// range).
+///
+/// Follows the ONNX Concat spec (and onnx-mlir `ONNXConcatOpShapeHelper`):
+/// every operand shares the result's rank and element type; a non-axis dim
+/// takes any operand's static extent if one exists (else stays dynamic), and
+/// the axis dim is the sum of operand extents (dynamic if any operand is
+/// dynamic there). Example: `Concat((1x?x1152, ?x?x?), axis=1)` -> `1x?x1152`.
+static Type inferConcatResult(Operation *op) {
+  if (op->getNumOperands() == 0 || op->getNumResults() != 1)
+    return {};
+  auto axisAttr = op->getAttrOfType<IntegerAttr>("axis");
+  if (!axisAttr)
+    return {};
+
+  // All operands must be ranked tensors of one common rank and element type.
+  SmallVector<RankedTensorType> operands;
+  operands.reserve(op->getNumOperands());
+  int64_t rank = -1;
+  Type elementType;
+  for (Value v : op->getOperands()) {
+    auto t = dyn_cast<RankedTensorType>(v.getType());
+    if (!t)
+      return {};
+    if (rank < 0) {
+      rank = t.getRank();
+      elementType = t.getElementType();
+    } else if (t.getRank() != rank || t.getElementType() != elementType) {
+      return {};
+    }
+    operands.push_back(t);
+  }
+  if (rank <= 0) // rank-0 tensors have no axis to concatenate.
+    return {};
+
+  // ONNX `axis` is signed (`si64`); getSInt sign-extends correctly. Negative
+  // axes count from the end.
+  int64_t axis = axisAttr.getSInt();
+  if (axis < 0)
+    axis += rank;
+  if (axis < 0 || axis >= rank)
+    return {};
+
+  SmallVector<int64_t> shape(rank, ShapedType::kDynamic);
+  for (int64_t d : llvm::seq<int64_t>(0, rank)) {
+    if (d != axis) {
+      // Non-axis dim: adopt the first static extent any operand provides.
+      for (RankedTensorType t : operands)
+        if (!t.isDynamicDim(d)) {
+          shape[d] = t.getDimSize(d);
+          break;
+        }
+      continue;
+    }
+    // Axis dim: sum of operand extents, dynamic if any contributor is.
+    int64_t sum = 0;
+    bool allStatic = true;
+    for (RankedTensorType t : operands) {
+      if (t.isDynamicDim(d)) {
+        allStatic = false;
+        break;
+      }
+      sum += t.getDimSize(d);
+    }
+    shape[d] = allStatic ? sum : ShapedType::kDynamic;
+  }
+  return RankedTensorType::get(shape, elementType);
+}
+
+/// Dispatch a forward shape rule for `op`, but only when its single result is
+/// currently unranked. Returns the inferred ranked type, or null if the
+/// result is already ranked or no rule covers the op. Register new op rules
+/// in the name switch below.
+///
+/// Why this is keyed on op name (and not the HIP dialect / an interface).
+/// Rank must be established BEFORE `convert-onnx-to-hip`: an unranked result
+/// blocks the converters (`ConcatConversion` bails on unranked), so the op
+/// never reaches the HIP dialect to be refined post-conversion by
+/// `--hip-infer-shapes`. At this stage the `onnx.*` ops are still
+/// unregistered operations carried by a stub `onnx` dialect (`OnnxStubDialect`
+/// in `InitAllPasses.h`, which `allowUnknownOperations` so unranked tensors
+/// round-trip) -- this repo matches ONNX by name via the generic `Operation`
+/// API rather than depending on onnx-mlir's registered op classes, so there is
+/// no op class and no `ShapeInferenceOpInterface` to dispatch on. A name
+/// switch is therefore the only handle available, and it mirrors how the
+/// converter layer itself is organized (`RewritePattern("onnx.Concat", ...)`). The
+/// op-agnostic loop-contract backstop in `inferLoopBodyShapes` is the general
+/// safety net for the failure mode (the loop-carried output); these forward
+/// rules are the enhancement tier that also ranks *interior* unranked values.
+///
+/// How to make this generic. Once the build takes a proper dependency on a
+/// registered ONNX dialect (onnx-mlir), every op implements
+/// `ShapeInferenceOpInterface::inferShapes()`, and this whole switch collapses
+/// into a single interface-driven walk -- the onnx-mlir `InferShapesPattern`
+/// (`OpInterfaceRewritePattern<ShapeInferenceOpInterface>`) calls each op's
+/// own `inferShapes`, so no per-op rule lives here anymore.
+static Type inferUnrankedOnnxResult(Operation *op) {
+  if (op->getNumResults() != 1 ||
+      !isa<UnrankedTensorType>(op->getResult(0).getType()))
+    return {};
+  if (op->getName().getStringRef() == "onnx.Concat")
+    return inferConcatResult(op);
+  return {};
+}
+
+/// Forward-propagate rank onto unranked `onnx.*` results within `body` until
+/// no further result can be ranked.
+///
+/// A single in-program-order walk suffices for a straight-line body (every
+/// operand is defined by an earlier op or a block arg, so a producer is
+/// always ranked before its consumer is visited). The bounded fixed point is
+/// a guard for any future shape in which a consumer precedes its producer in
+/// walk order; it is monotone (unranked -> ranked only) so it always
+/// terminates well within the cap.
+static void forwardInferUnrankedResults(func::FuncOp body) {
+  static constexpr unsigned kMaxIters = 8;
+  for (unsigned iter = 0; iter < kMaxIters; ++iter) {
+    bool changed = false;
+    body.walk([&](Operation *op) {
+      if (Type inferred = inferUnrankedOnnxResult(op)) {
+        LLVM_DEBUG(DBGS() << "rank " << op->getName() << ": "
+                          << op->getResult(0).getType() << " -> " << inferred
+                          << "\n");
+        op->getResult(0).setType(inferred);
+        ++NumOnnxResultsRanked;
+        changed = true;
+      }
+    });
+    if (!changed)
+      return;
+  }
+  LLVM_DEBUG(DBGS() << body.getSymName()
+                    << ": forward inference hit the iteration cap\n");
+}
+
+/// Establish rank inside one outlined `hip.loop` body func, then reconcile its
+/// signature. The body's argument and return layouts are fixed by
+/// `OnnxLoopOutlinePass`:
+///
+///   args:    [0] ctx, [1] iter, [2] cond, [3 .. 3+N) v_carry, [3+N ..]
+///   captures returns: v_carry occupies [0 .. N) when `cond_is_passthrough`,
+///   else
+///            [1 .. 1+N) with cond_out at slot 0.
+static void inferLoopBodyShapes(func::FuncOp body, hip::LoopOp loopOp) {
+  if (body.getBody().empty())
+    return;
+  Block &entry = body.getBody().front();
+  Operation::operand_range vInit = loopOp.getVInit();
+  static constexpr unsigned kArgVCarryStart = 3;
+
+  // 1. Seed loop-carried block args from the loop op's v_init types.
+  for (auto [i, v] : llvm::enumerate(vInit)) {
+    unsigned argSlot = kArgVCarryStart + i;
+    if (argSlot < entry.getNumArguments())
+      entry.getArgument(argSlot).setType(v.getType());
+  }
+
+  // 2. Forward-infer unranked onnx.* results from their (seeded) operands.
+  forwardInferUnrankedResults(body);
+
+  // 3. Loop-contract backstop: a still-unranked loop-carried output must equal
+  //    its v_init type per the ONNX Loop spec (covers ops with no forward
+  //    rule).
+  Operation *terminator = entry.getTerminator();
+  unsigned resultVCarryStart = loopOp.getCondIsPassthrough() ? 0u : 1u;
+  for (auto [i, v] : llvm::enumerate(vInit)) {
+    unsigned slot = resultVCarryStart + i;
+    if (slot >= terminator->getNumOperands())
+      break;
+    Value carried = terminator->getOperand(slot);
+    if (isa<UnrankedTensorType>(carried.getType())) {
+      LLVM_DEBUG(DBGS() << "backstop return slot " << slot << ": "
+                        << carried.getType() << " -> " << v.getType() << "\n");
+      carried.setType(v.getType());
+      ++NumLoopContractRanked;
+    }
+  }
+
+  // 4. Reconcile the signature so func.return matches the declared result
+  //    types. Inputs follow the (seeded) entry block args; results follow the
+  //    (now ranked) terminator operands.
+  FunctionType reconciled = body.getFunctionType().clone(
+      entry.getArgumentTypes(), terminator->getOperandTypes());
+  if (reconciled != body.getFunctionType()) {
+    body.setType(reconciled);
+    ++NumBodyFuncsReconciled;
+  }
+}
+
+struct InferLoopBodyShapesPass
+    : public impl::InferLoopBodyShapesPassBase<InferLoopBodyShapesPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<HipDialect, func::FuncDialect>();
+  }
+
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    module.walk([&](hip::LoopOp loopOp) {
+      if (auto body =
+              module.lookupSymbol<func::FuncOp>(loopOp.getBodyFuncAttr()))
+        inferLoopBodyShapes(body, loopOp);
+    });
+  }
+};
+
+} // namespace
+} // namespace hip
+} // namespace mlir

--- a/lib/Dialect/Transforms/InferLoopBodyShapesPass.cpp
+++ b/lib/Dialect/Transforms/InferLoopBodyShapesPass.cpp
@@ -176,10 +176,11 @@ static Type inferConcatResult(Operation *op) {
 /// API rather than depending on onnx-mlir's registered op classes, so there is
 /// no op class and no `ShapeInferenceOpInterface` to dispatch on. A name
 /// switch is therefore the only handle available, and it mirrors how the
-/// converter layer itself is organized (`RewritePattern("onnx.Concat", ...)`). The
-/// op-agnostic loop-contract backstop in `inferLoopBodyShapes` is the general
-/// safety net for the failure mode (the loop-carried output); these forward
-/// rules are the enhancement tier that also ranks *interior* unranked values.
+/// converter layer itself is organized (`RewritePattern("onnx.Concat", ...)`).
+/// The op-agnostic loop-contract backstop in `inferLoopBodyShapes` is the
+/// general safety net for the failure mode (the loop-carried output); these
+/// forward rules are the enhancement tier that also ranks *interior* unranked
+/// values.
 ///
 /// How to make this generic. Once the build takes a proper dependency on a
 /// registered ONNX dialect (onnx-mlir), every op implements

--- a/lib/Dialect/Transforms/Pipelines.cpp
+++ b/lib/Dialect/Transforms/Pipelines.cpp
@@ -222,6 +222,13 @@ void mlir::hip::buildOnnxToHipPipeline(OpPassManager &pm,
   // model end-to-end, then delete this TODO.
   pm.addPass(createOnnxLoopOutlinePass());
 
+  // Rank-establish unranked tensors inside outlined loop bodies (e.g. a
+  // loop-carried `onnx.Concat` output the importer left as `tensor<*xT>`)
+  // BEFORE conversion: `convert-onnx-to-hip` converters require ranked
+  // results and otherwise leave the op unconverted, breaking the body
+  // func signature and later bufferization.
+  pm.addPass(createInferLoopBodyShapesPass());
+
   if (fs) {
     pm.addPass(mlir::hip::createConvertOnnxToHipPass(
         fs, options.externalizeMinNumElements, options.skipConstantData));
@@ -244,6 +251,7 @@ void mlir::hip::buildOnnxToHipPipeline(OpPassManager &pm,
   pm.addPass(createSimplifyOnnxPass());
   pm.addPass(createHipAddContextArgPass());
   pm.addPass(createOnnxLoopOutlinePass());
+  pm.addPass(createInferLoopBodyShapesPass());
 
   if (handle) {
     pm.addPass(createOutlineOnnxToHipDNNPass());

--- a/test/lit/Dialect/hip-infer-loop-body-shapes.mlir
+++ b/test/lit/Dialect/hip-infer-loop-body-shapes.mlir
@@ -1,0 +1,128 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --hip-infer-loop-body-shapes %s | FileCheck %s
+
+// What this file tests
+// --------------------
+// The `--hip-infer-loop-body-shapes` pass (lib/Dialect/Transforms/
+// InferLoopBodyShapesPass.cpp), which rank-establishes `tensor<*xT>`
+// values inside outlined `hip.loop` body functions BEFORE
+// `convert-onnx-to-hip`:
+//
+//   - forward `onnx.Concat` shape rule ranks an unranked loop-carried
+//     output from its ranked operands (`forward_concat`),
+//   - loop-contract backstop ranks a returned value from $v_init when no
+//     forward rule applies (`backstop_no_rule`),
+//   - non-passthrough loops put cond_out at return slot 0 and v_carry at
+//     slot 1 (`non_passthrough`),
+//   - no-op when the body is already fully ranked (`already_ranked`).
+
+// -----------------------------------------------------------------------
+// Forward Concat rule: Concat((1x?x1152, ?x?x?), axis=1) -> 1x?x1152.
+// Non-axis dims prefer any operand's literal extent; axis dim is dynamic
+// because one operand is dynamic there.
+// -----------------------------------------------------------------------
+func.func @forward_concat(%ctx: !hip.context, %M: index, %cond: i1,
+                          %acc: tensor<1x?x1152xf16>,
+                          %other: tensor<?x?x?xf16>) -> tensor<1x?x1152xf16> {
+  %r = hip.loop(%ctx, %M, %cond)
+                 iter_args(%acc : tensor<1x?x1152xf16>)
+                 captures(%other : tensor<?x?x?xf16>)
+                 -> (tensor<1x?x1152xf16>)
+                 body @body_concat
+                 {num_loop_carried = 1 : i32, cond_is_passthrough}
+  return %r : tensor<1x?x1152xf16>
+}
+
+// CHECK-LABEL: func.func private @body_concat
+// CHECK-SAME:    -> tensor<1x?x1152xf16>
+// CHECK:         %[[R:.*]] = "onnx.Concat"
+// CHECK-SAME:      -> tensor<1x?x1152xf16>
+// CHECK:         return %[[R]] : tensor<1x?x1152xf16>
+func.func private @body_concat(%ctx: !hip.context, %iter: tensor<i64>,
+                               %cond_in: tensor<ui8>,
+                               %acc: tensor<1x?x1152xf16>,
+                               %other: tensor<?x?x?xf16>) -> tensor<*xf16> {
+  %r = "onnx.Concat"(%acc, %other) {axis = 1 : si64} :
+         (tensor<1x?x1152xf16>, tensor<?x?x?xf16>) -> tensor<*xf16>
+  return %r : tensor<*xf16>
+}
+
+// -----------------------------------------------------------------------
+// Loop-contract backstop: an op with no forward rule still gets its
+// returned (loop-carried) result ranked from $v_init.
+// -----------------------------------------------------------------------
+func.func @backstop_no_rule(%ctx: !hip.context, %M: index, %cond: i1,
+                            %acc: tensor<4x8xf32>) -> tensor<4x8xf32> {
+  %r = hip.loop(%ctx, %M, %cond)
+                 iter_args(%acc : tensor<4x8xf32>)
+                 -> (tensor<4x8xf32>)
+                 body @body_backstop
+                 {num_loop_carried = 1 : i32, cond_is_passthrough}
+  return %r : tensor<4x8xf32>
+}
+
+// CHECK-LABEL: func.func private @body_backstop
+// CHECK-SAME:    -> tensor<4x8xf32>
+// CHECK:         %[[R:.*]] = "onnx.NoRuleOp"
+// CHECK-SAME:      -> tensor<4x8xf32>
+// CHECK:         return %[[R]] : tensor<4x8xf32>
+func.func private @body_backstop(%ctx: !hip.context, %iter: tensor<i64>,
+                                 %cond_in: tensor<ui8>,
+                                 %acc: tensor<4x8xf32>) -> tensor<*xf32> {
+  %r = "onnx.NoRuleOp"(%acc) : (tensor<4x8xf32>) -> tensor<*xf32>
+  return %r : tensor<*xf32>
+}
+
+// -----------------------------------------------------------------------
+// Non-passthrough loop: return slot 0 is cond_out, v_carry is slot 1.
+// -----------------------------------------------------------------------
+func.func @non_passthrough(%ctx: !hip.context, %M: index, %cond: i1,
+                           %acc: tensor<1x?x1152xf16>,
+                           %other: tensor<?x?x?xf16>) -> tensor<1x?x1152xf16> {
+  %r = hip.loop(%ctx, %M, %cond)
+                 iter_args(%acc : tensor<1x?x1152xf16>)
+                 captures(%other : tensor<?x?x?xf16>)
+                 -> (tensor<1x?x1152xf16>)
+                 body @body_non_passthrough
+                 {num_loop_carried = 1 : i32}
+  return %r : tensor<1x?x1152xf16>
+}
+
+// CHECK-LABEL: func.func private @body_non_passthrough
+// CHECK-SAME:    -> (tensor<ui8>, tensor<1x?x1152xf16>)
+// CHECK:         %[[R:.*]] = "onnx.Concat"
+// CHECK-SAME:      -> tensor<1x?x1152xf16>
+// CHECK:         return %{{.*}}, %[[R]] : tensor<ui8>, tensor<1x?x1152xf16>
+func.func private @body_non_passthrough(%ctx: !hip.context, %iter: tensor<i64>,
+                                        %cond_in: tensor<ui8>,
+                                        %acc: tensor<1x?x1152xf16>,
+                                        %other: tensor<?x?x?xf16>)
+    -> (tensor<ui8>, tensor<*xf16>) {
+  %r = "onnx.Concat"(%acc, %other) {axis = 1 : si64} :
+         (tensor<1x?x1152xf16>, tensor<?x?x?xf16>) -> tensor<*xf16>
+  return %cond_in, %r : tensor<ui8>, tensor<*xf16>
+}
+
+// -----------------------------------------------------------------------
+// Already fully ranked: pass is a no-op (no type changes).
+// -----------------------------------------------------------------------
+func.func @already_ranked(%ctx: !hip.context, %M: index, %cond: i1,
+                          %acc: tensor<4x8xf32>) -> tensor<4x8xf32> {
+  %r = hip.loop(%ctx, %M, %cond)
+                 iter_args(%acc : tensor<4x8xf32>)
+                 -> (tensor<4x8xf32>)
+                 body @body_ranked
+                 {num_loop_carried = 1 : i32, cond_is_passthrough}
+  return %r : tensor<4x8xf32>
+}
+
+// CHECK-LABEL: func.func private @body_ranked
+// CHECK-SAME:    -> tensor<4x8xf32>
+// CHECK:         return %{{.*}} : tensor<4x8xf32>
+func.func private @body_ranked(%ctx: !hip.context, %iter: tensor<i64>,
+                               %cond_in: tensor<ui8>,
+                               %acc: tensor<4x8xf32>) -> tensor<4x8xf32> {
+  return %acc : tensor<4x8xf32>
+}


### PR DESCRIPTION
The MorphiZen importer emits unranked `tensor<*xT>` for values it can't infer, most often an outlined `hip.loop` body's loop-carried `onnx.Concat` output (e.g. a Concat accumulating along the sequence axis). `convert-onnx-to-hip`'s converters require ranked result types (`ConcatConversion` bails on unranked), so the op stays unconverted, the body `func.return` operand becomes type-incompatible with the func signature, and conversion/bufferization fail downstream. This blocks compiling models with data-dependent loops (hit on Qwen3.5-9B).

**Minimal example that demonstrates the issue (one outlined body func):**

```mlir
// `onnx.Concat` result is unranked, so ConcatConversion bails, the op stays
// unconverted, and the return operand no longer matches the func signature.
func.func private @loop_body(%ctx, %i, %c, %acc: tensor<1x?x1152xf16>, ...)
    -> tensor<*xf16> {
  %a = hip.multi_head_attention ... : tensor<?x?x?xf16>
  %r = "onnx.Concat"(%acc, %a) {axis = 1} :
         (tensor<1x?x1152xf16>, tensor<?x?x?xf16>) -> tensor<*xf16>  // unranked
  return %r : tensor<*xf16>
}
```

**The fix:**

A new pre-conversion pass `--hip-infer-loop-body-shapes`, run after `onnx-loop-outline` and before `convert-onnx-to-hip`. For every outlined `hip.loop` body func it:

* Seeds the loop-carried block args from the loop op's `$v_init` operand types (ranked post-outline).
* Forward-infers unranked `onnx.*` results from operand types (currently `onnx.Concat`), iterated to a fixed point.
* Loop-contract backstop: any loop-carried body output still unranked is set to the matching `$v_init` type (the ONNX Loop spec guarantees body-output type == loop-carried-input type).
* Reconciles the body func's declared result types from the now-ranked terminator operands.

Post-conversion `--hip-infer-shapes` is unchanged and still handles all `?`-dim narrowing on HIP-dialect ops; this pass only establishes *rank* so conversion can proceed.
