### PR TITLE
fix(hip): expand arith.ceildivsi/floordivsi in HIP->LLVM lowering

### DIFF
--- a/lib/Conversion/HipToLLVM/CMakeLists.txt
+++ b/lib/Conversion/HipToLLVM/CMakeLists.txt
@@ -59,4 +59,5 @@ target_link_libraries(HipToLLVM PUBLIC
   MLIRLLVMCommonConversion
   MLIRMemRefDialect
   MLIRTransforms
+  MLIRArithTransforms
 )

--- a/lib/Conversion/HipToLLVM/HipToLLVM.cpp
+++ b/lib/Conversion/HipToLLVM/HipToLLVM.cpp
@@ -344,6 +344,15 @@ void ConvertHipToLLVMPass::runOnOperation() {
   // stages would require a reconcile-unrealized-casts cleanup pass.
   populateFuncToLLVMConversionPatterns(typeConverter, patterns);
   populateFinalizeMemRefToLLVMConversionPatterns(typeConverter, patterns);
+  // ArithToLLVM has no direct lowering for arith.{ceil,floor}div{s,u}i; these
+  // must first be expanded into primitive arith ops (cmp/sub/add/div/select),
+  // so the expand patterns and the ToLLVM patterns form a pair that must be
+  // populated together. Upstream's -convert-arith-to-llvm pass does exactly
+  // this; because we hand-roll the pattern set, we replicate the pairing.
+  // Omitting the expand patterns lets a stray ceildivsi (e.g. from
+  // dynamic-shape index arithmetic) survive applyPartialConversion and abort
+  // MLIR->LLVM translation with "missing LLVMTranslationDialectInterface".
+  arith::populateCeilFloorDivExpandOpsPatterns(patterns);
   arith::populateArithToLLVMConversionPatterns(typeConverter, patterns);
   cf::populateControlFlowToLLVMConversionPatterns(typeConverter, patterns);
 

--- a/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
+++ b/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
@@ -18,6 +18,7 @@
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 #include "mlir/Conversion/MemRefToLLVM/MemRefToLLVM.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Arith/Transforms/Passes.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/FunctionCallUtils.h"

--- a/test/lit/Conversion/hip-to-llvm/test_ceildiv.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_ceildiv.mlir
@@ -1,0 +1,31 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify arith.ceildivsi / arith.floordivsi survive the HIP->LLVM partial
+// conversion by being EXPANDED into primitive arith ops (which the ArithToLLVM
+// patterns then lower), rather than being left untouched.
+//
+// ArithToLLVM has no direct pattern for ceildivsi / floordivsi / ceildivui;
+// without arith::populateCeilFloorDivExpandOpsPatterns in the conversion, a
+// stray ceildivsi (e.g. from dynamic-shape index arithmetic in an outlined
+// loop body) survives applyPartialConversion and aborts MLIR->LLVM translation
+// with "missing LLVMTranslationDialectInterface ... for op: arith.ceildivsi".
+//
+// Expected: the function lowers to llvm.func and NO arith.{ceildivsi,
+// floordivsi} op remains in the output.
+// ============================================================================
+
+// RUN: hip-mlir-opt %s --convert-hip-to-llvm | FileCheck %s
+
+module {
+  // CHECK-LABEL: llvm.func @ceildiv_floordiv_i64
+  // CHECK-NOT: arith.ceildivsi
+  // CHECK-NOT: arith.floordivsi
+  func.func @ceildiv_floordiv_i64(%a: i64, %b: i64) -> i64 {
+    %0 = arith.ceildivsi %a, %b : i64
+    %1 = arith.floordivsi %0, %b : i64
+    func.return %1 : i64
+  }
+}


### PR DESCRIPTION
`ConvertHipToLLVM` hand-rolls its conversion pattern set and called only `arith::populateArithToLLVMConversionPatterns`, which has no direct lowering for `arith.ceildivsi` / `floordivsi` / `ceildivui`. A stray `ceildivsi` (e.g. from dynamic-shape index arithmetic in an outlined loop body) then survives `applyPartialConversion` and aborts MLIR→LLVM translation with `missing LLVMTranslationDialectInterface ... for op: arith.ceildivsi` — which silently drops the graph to CPU. Hit on Qwen3.5-9B once the loop body started converting (stacked on #337).

**Minimal example that demonstrates the issue:**

```mlir
// Without the ceil/floor-div expand patterns, this arith.ceildivsi has no
// ToLLVM lowering, survives the partial conversion, and aborts translation:
//   "missing LLVMTranslationDialectInterface ... for op: arith.ceildivsi"
func.func @ceildiv(%a: i64, %b: i64) -> i64 {
  %0 = arith.ceildivsi %a, %b : i64
  return %0 : i64
}
```

**The fix:**

Upstream's `-convert-arith-to-llvm` pass populates `arith::populateCeilFloorDivExpandOpsPatterns` ahead of the ToLLVM patterns — the two are a pair. Because we hand-roll the pattern set, we replicate that pairing:

* Add `arith::populateCeilFloorDivExpandOpsPatterns(patterns)` before `arith::populateArithToLLVMConversionPatterns(...)`, so `ceil/floor div` expand into primitive arith ops (cmp/sub/add/div/select) that lower in the same `applyPartialConversion`.
* Link `MLIRArithTransforms`.
* New LIT test asserts no `arith.ceildivsi` / `floordivsi` survives `--convert-hip-to-llvm`.

P.S. Also bumps `3rd-party/morphizen` to pick up #228 ("preserve unranked tensors at the ORT boundary"), part of the same Qwen3.5-9B unranked-tensor enablement. Stacked on #337; base will retarget to `main` once that merges.
