### PR TITLE
fix(pass): emit unresolved DimSource sentinel under output-allocator ABI

### DIFF
--- a/backend-mlir-compiler/level-1-pass/src/dim_source_resolver.h
+++ b/backend-mlir-compiler/level-1-pass/src/dim_source_resolver.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+namespace hipdnn::level1pass {
+
+/// Outcome of resolving one dynamic (-1) output dimension to a DimSource entry.
+enum class DimSourceKind {
+  /// The dim's symbolic name maps to a graph-input dim. The EP resolves the
+  /// extent from that input before inference; carry (input_idx, dim_idx).
+  ResolvedToInput,
+  /// Output-allocator ABI with no input mapping. The DLL allocates the output
+  /// in-graph (sized from `hip.alloc_output`'s operands) and the EP never reads
+  /// this entry, so emit an unresolved sentinel (-1/-1/resolved=false).
+  UnresolvedSentinel,
+  /// Classic ABI with no input mapping. The EP pre-allocates the output and
+  /// cannot size this dim, so the caller must fail the compile.
+  Unresolvable,
+};
+
+/// A resolved DimSource: `input_idx`/`dim_idx` are meaningful only for
+/// `ResolvedToInput` and are sentinel (-1) otherwise.
+struct DimSourceResolution {
+  DimSourceKind kind;
+  int input_idx = -1;
+  int dim_idx = -1;
+};
+
+/// Decides how to emit the DimSource for one dynamic output dimension.
+///
+/// The dim is resolved by looking `paramName` (its symbolic name, or null if it
+/// has none) up in `dimParamMap`, which maps each symbolic name to the input
+/// (index, dim) that declares it. Two cases have no such input: the dim carries
+/// no symbolic name, or its name is declared on no input (e.g. a data-dependent
+/// extent computed inside the graph). These are fatal under the classic ABI
+/// (the EP pre-allocates outputs and has no other way to size the dim) but
+/// benign when `useOutputAllocator` is set (the DLL sizes the output in-graph),
+/// where they become a sentinel.
+inline DimSourceResolution resolveDynamicOutputDim(
+    const std::string *paramName,
+    const std::unordered_map<std::string, std::pair<int, int>> &dimParamMap,
+    bool useOutputAllocator) {
+  if (paramName) {
+    auto it = dimParamMap.find(*paramName);
+    if (it != dimParamMap.end())
+      return {DimSourceKind::ResolvedToInput, it->second.first,
+              it->second.second};
+  }
+  return useOutputAllocator
+             ? DimSourceResolution{DimSourceKind::UnresolvedSentinel}
+             : DimSourceResolution{DimSourceKind::Unresolvable};
+}
+
+} // namespace hipdnn::level1pass

--- a/backend-mlir-compiler/level-1-pass/src/pass_main.cpp
+++ b/backend-mlir-compiler/level-1-pass/src/pass_main.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "MlirCompiler.h"
+#include "dim_source_resolver.h"
 
 // Morphizen headers
 #include "hip/timing.h"
@@ -283,25 +284,46 @@ static std::string build_metadata_json(const CompilationArtifact &artifact,
         // to Output.shape regardless.
         auto *ds = output_proto->add_dim_sources();
         if (dim_val == -1) {
-          // Fail at compile time rather than at runtime so the user sees a
-          // clear error naming the output, dim index, and dim_param name
-          // instead of a generic "dim still -1" CHECK from the EP.
-          CHECK(dp && d < static_cast<int>(dp->size()) && !(*dp)[d].empty())
-              << "Output '" << output.name() << "' dim " << d
-              << " is dynamic but has no symbolic name in dim_params_map; "
-              << "cannot emit DimSource. Either fix the model to expose a "
-              << "dim_param for this dimension, or freeze it to a constant.";
-          const auto &param_name = (*dp)[d];
-          auto pit = dim_param_map.find(param_name);
-          CHECK(pit != dim_param_map.end())
-              << "Output '" << output.name() << "' dim " << d
-              << " has dim_param '" << param_name
-              << "' but no graph input declares this symbolic name; cannot "
-              << "resolve at runtime. Outputs can only carry symbolic dims "
-              << "that also appear on at least one input.";
-          ds->set_input_idx(pit->second.first);
-          ds->set_dim_idx(pit->second.second);
-          ds->set_resolved(true);
+          // Resolve the dynamic output dim to a graph-input dim via its
+          // symbolic name. resolveDynamicOutputDim decides among the three
+          // outcomes below (see dim_source_resolver.h for the rationale).
+          const std::string *param_name =
+              (dp && d < static_cast<int>(dp->size()) && !(*dp)[d].empty())
+                  ? &(*dp)[d]
+                  : nullptr;
+          auto res = resolveDynamicOutputDim(param_name, dim_param_map,
+                                             useOutputAllocator);
+          switch (res.kind) {
+          case DimSourceKind::ResolvedToInput:
+            ds->set_input_idx(res.input_idx);
+            ds->set_dim_idx(res.dim_idx);
+            ds->set_resolved(true);
+            break;
+          case DimSourceKind::UnresolvedSentinel:
+            // Output-allocator ABI: the DLL sizes this output in-graph, so the
+            // EP never consults this entry. Emit the same -1/-1/false sentinel
+            // as a static dim (it is unambiguous on the wire).
+            ds->set_input_idx(-1);
+            ds->set_dim_idx(-1);
+            ds->set_resolved(false);
+            break;
+          case DimSourceKind::Unresolvable:
+            // Classic ABI: fail at compile time rather than at runtime so the
+            // user sees a clear error naming the output, dim index, and
+            // dim_param instead of a generic "dim still -1" CHECK from the EP.
+            CHECK(param_name)
+                << "Output '" << output.name() << "' dim " << d
+                << " is dynamic but has no symbolic name in dim_params_map; "
+                << "cannot emit DimSource. Either fix the model to expose a "
+                << "dim_param for this dimension, or freeze it to a constant.";
+            CHECK(false)
+                << "Output '" << output.name() << "' dim " << d
+                << " has dim_param '" << *param_name
+                << "' but no graph input declares this symbolic name; cannot "
+                << "resolve at runtime. Outputs can only carry symbolic dims "
+                << "that also appear on at least one input.";
+            break;
+          }
         } else {
           // Static dim: emit explicit sentinels so the wire format
           // unambiguously distinguishes "not populated" from

--- a/backend-mlir-compiler/test/CMakeLists.txt
+++ b/backend-mlir-compiler/test/CMakeLists.txt
@@ -64,3 +64,19 @@ endif()
 add_test(NAME MlirE2ETest COMMAND test-e2e-mlir)
 
 set_target_properties(test-e2e-mlir PROPERTIES FOLDER "mlir-tests")
+
+# ----------------------------------------------------------------------------
+# Pure-logic unit test for the DimSource emission policy. No ORT / GPU / EP
+# dependency -- just the header under test and GTest -- so it builds and runs
+# anywhere the backend builds.
+# ----------------------------------------------------------------------------
+add_executable(test-dim-source-resolver test_dim_source_resolver.cpp)
+target_compile_features(test-dim-source-resolver PRIVATE cxx_std_17)
+target_include_directories(test-dim-source-resolver PRIVATE
+  "${CMAKE_CURRENT_SOURCE_DIR}/../level-1-pass/src")
+target_link_libraries(test-dim-source-resolver PRIVATE
+  GTest::gtest
+  GTest::gtest_main
+)
+add_test(NAME DimSourceResolverTest COMMAND test-dim-source-resolver)
+set_target_properties(test-dim-source-resolver PROPERTIES FOLDER "mlir-tests")

--- a/backend-mlir-compiler/test/test_dim_source_resolver.cpp
+++ b/backend-mlir-compiler/test/test_dim_source_resolver.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * @file test_dim_source_resolver.cpp
+ * @brief Unit tests for resolveDynamicOutputDim (DimSource emission policy).
+ *
+ * Pure-logic tests: no ORT, no GPU, no protobuf. Exercises every branch of the
+ * dynamic-output-dim resolution used by build_metadata_json.
+ */
+
+#include "dim_source_resolver.h"
+
+#include <gtest/gtest.h>
+
+using hipdnn::level1pass::DimSourceKind;
+using hipdnn::level1pass::resolveDynamicOutputDim;
+
+namespace {
+
+using DimParamMap = std::unordered_map<std::string, std::pair<int, int>>;
+
+// A symbolic name that maps to an input dim resolves to that input regardless
+// of ABI mode.
+TEST(DimSourceResolver, NameMappedToInputResolves) {
+  DimParamMap m{{"seq_len", {2, 1}}};
+  const std::string name = "seq_len";
+
+  for (bool allocator : {false, true}) {
+    auto r = resolveDynamicOutputDim(&name, m, allocator);
+    EXPECT_EQ(r.kind, DimSourceKind::ResolvedToInput);
+    EXPECT_EQ(r.input_idx, 2);
+    EXPECT_EQ(r.dim_idx, 1);
+  }
+}
+
+// No symbolic name + allocator ABI -> sentinel (DLL sizes the output in-graph).
+TEST(DimSourceResolver, NoNameAllocatorEmitsSentinel) {
+  DimParamMap m;
+  auto r = resolveDynamicOutputDim(/*paramName=*/nullptr, m,
+                                   /*useOutputAllocator=*/true);
+  EXPECT_EQ(r.kind, DimSourceKind::UnresolvedSentinel);
+  EXPECT_EQ(r.input_idx, -1);
+  EXPECT_EQ(r.dim_idx, -1);
+}
+
+// No symbolic name + classic ABI -> unresolvable (caller fails the compile).
+TEST(DimSourceResolver, NoNameClassicIsUnresolvable) {
+  DimParamMap m;
+  auto r = resolveDynamicOutputDim(/*paramName=*/nullptr, m,
+                                   /*useOutputAllocator=*/false);
+  EXPECT_EQ(r.kind, DimSourceKind::Unresolvable);
+}
+
+// Symbolic name present but on no input + allocator ABI -> sentinel. This is
+// the data-dependent-extent case (e.g. NonZero) that the relaxation unblocks.
+TEST(DimSourceResolver, UnmappedNameAllocatorEmitsSentinel) {
+  DimParamMap m{{"batch", {0, 0}}};
+  const std::string name = "num_nonzero"; // not declared by any input
+  auto r = resolveDynamicOutputDim(&name, m, /*useOutputAllocator=*/true);
+  EXPECT_EQ(r.kind, DimSourceKind::UnresolvedSentinel);
+}
+
+// Symbolic name present but on no input + classic ABI -> unresolvable.
+TEST(DimSourceResolver, UnmappedNameClassicIsUnresolvable) {
+  DimParamMap m{{"batch", {0, 0}}};
+  const std::string name = "num_nonzero";
+  auto r = resolveDynamicOutputDim(&name, m, /*useOutputAllocator=*/false);
+  EXPECT_EQ(r.kind, DimSourceKind::Unresolvable);
+}
+
+} // namespace


### PR DESCRIPTION
Compiling a vision-language model under the output-allocator ABI hits a hard `CHECK` failure in `build_metadata_json`: it fails any dynamic output dim whose symbolic name is declared on no input. Under the allocator ABI the EP never reads DimSource for outputs (the DLL sizes them in-graph), so the failure is spurious.

**Repro (Qwen3.5-9B vision sub-graph, `use_output_allocator=1`):**

```
F pass_main.cpp:300] Check failed: pit != dim_param_map.end()
  Output 'image_features' dim 0 has dim_param 'num_logical_patches' but no graph
  input declares this symbolic name; cannot resolve at runtime.
```

`num_logical_patches` is a data-dependent extent computed inside the graph, so it is correctly on no input.

**The fix:** on an unresolvable dynamic output dim, branch on the ABI instead of always failing:

* output-allocator ABI → emit an unresolved sentinel (`-1/-1/resolved=false`); the in-graph allocation sizes the output.
* classic ABI → keep the hard compile-time error (the EP pre-allocates outputs and can't size the dim otherwise).

Resolvable dims are unchanged. The decision moves to a pure helper (`resolveDynamicOutputDim`) with a unit test over both ABIs. `use_output_allocator` stays opt-in (default off).
