### PR TITLE
fix(nonzero): repair wrap_nonzero ABI mismatch causing kernel-launch SEGV

### DIFF
--- a/backend-mlir-compiler/level-1-pass/src/pass_main.cpp
+++ b/backend-mlir-compiler/level-1-pass/src/pass_main.cpp
@@ -204,10 +204,8 @@ parse_dim_params_map(const std::string &encoded) {
 }
 
 // Step 5: Build metadata JSON from graph inputs and outputs.
-// For dynamic shapes, records DimSource entries that map each dynamic output
-// dimension to the input tensor + dimension index that provides its runtime
-// value. Uses dim_params_map model metadata (populated by IR converter from
-// ORT's GetSymbolicDimensions) to match dimensions across tensors.
+// Classic ABI emits DimSource per dynamic output dim; allocator ABI skips it
+// (the DLL sizes outputs in-graph). See the useOutputAllocator branch below.
 static std::string build_metadata_json(const CompilationArtifact &artifact,
                                        Graph &graph, bool useOutputAllocator) {
   mlir_metadata::Metadata metadata;
@@ -265,53 +263,62 @@ static std::string build_metadata_json(const CompilationArtifact &artifact,
     if (shape_ptr && !output.is_unknown_shape()) {
       output_proto->set_rank(static_cast<int32_t>(shape_ptr->size()));
 
-      auto it = all_dim_params.find(output.name());
-      const std::vector<std::string> *dp =
-          (it != all_dim_params.end()) ? &it->second : nullptr;
+      if (useOutputAllocator) {
+        // DLL sizes outputs in-graph; emit shape only, no DimSource.
+        for (int d = 0; d < static_cast<int>(shape_ptr->size()); ++d) {
+          output_proto->add_shape(normalizeDim((*shape_ptr)[d]));
+        }
+      } else {
+        // TODO(output-allocator): delete this else branch once allocator mode
+        // is default-on (also drop the consumer in marshal_output_tensors).
+        auto it = all_dim_params.find(output.name());
+        const std::vector<std::string> *dp =
+            (it != all_dim_params.end()) ? &it->second : nullptr;
 
-      for (int d = 0; d < static_cast<int>(shape_ptr->size()); ++d) {
-        int64_t dim_val = normalizeDim((*shape_ptr)[d]);
-        output_proto->add_shape(dim_val);
+        for (int d = 0; d < static_cast<int>(shape_ptr->size()); ++d) {
+          int64_t dim_val = normalizeDim((*shape_ptr)[d]);
+          output_proto->add_shape(dim_val);
 
-        // For dynamic dims, look up the symbolic name and resolve to the
-        // input tensor that defines it.  Static dims emit explicit sentinel
-        // values (input_idx=-1, dim_idx=-1, resolved=false) so the wire
-        // format is unambiguous: a `resolved=false` DimSource that carries
-        // -1 sentinels can never be confused with a real (input 0, dim 0)
-        // source by a future consumer that bug-skips the `resolved` check.
-        // marshal_output_tensors ignores unresolved entries and falls back
-        // to Output.shape regardless.
-        auto *ds = output_proto->add_dim_sources();
-        if (dim_val == -1) {
-          // Fail at compile time rather than at runtime so the user sees a
-          // clear error naming the output, dim index, and dim_param name
-          // instead of a generic "dim still -1" CHECK from the EP.
-          CHECK(dp && d < static_cast<int>(dp->size()) && !(*dp)[d].empty())
-              << "Output '" << output.name() << "' dim " << d
-              << " is dynamic but has no symbolic name in dim_params_map; "
-              << "cannot emit DimSource. Either fix the model to expose a "
-              << "dim_param for this dimension, or freeze it to a constant.";
-          const auto &param_name = (*dp)[d];
-          auto pit = dim_param_map.find(param_name);
-          CHECK(pit != dim_param_map.end())
-              << "Output '" << output.name() << "' dim " << d
-              << " has dim_param '" << param_name
-              << "' but no graph input declares this symbolic name; cannot "
-              << "resolve at runtime. Outputs can only carry symbolic dims "
-              << "that also appear on at least one input.";
-          ds->set_input_idx(pit->second.first);
-          ds->set_dim_idx(pit->second.second);
-          ds->set_resolved(true);
-        } else {
-          // Static dim: emit explicit sentinels so the wire format
-          // unambiguously distinguishes "not populated" from
-          // "intentionally references (input 0, dim 0)" without relying
-          // on the proto-default-zero convention.  Consumers that read
-          // `resolved` first see the same behavior as before; consumers
-          // that don't see -1 instead of a misleading 0.
-          ds->set_input_idx(-1);
-          ds->set_dim_idx(-1);
-          ds->set_resolved(false);
+          // For dynamic dims, look up the symbolic name and resolve to the
+          // input tensor that defines it.  Static dims emit explicit sentinel
+          // values (input_idx=-1, dim_idx=-1, resolved=false) so the wire
+          // format is unambiguous: a `resolved=false` DimSource that carries
+          // -1 sentinels can never be confused with a real (input 0, dim 0)
+          // source by a future consumer that bug-skips the `resolved` check.
+          // marshal_output_tensors ignores unresolved entries and falls back
+          // to Output.shape regardless.
+          auto *ds = output_proto->add_dim_sources();
+          if (dim_val == -1) {
+            // Fail at compile time rather than at runtime so the user sees a
+            // clear error naming the output, dim index, and dim_param name
+            // instead of a generic "dim still -1" CHECK from the EP.
+            CHECK(dp && d < static_cast<int>(dp->size()) && !(*dp)[d].empty())
+                << "Output '" << output.name() << "' dim " << d
+                << " is dynamic but has no symbolic name in dim_params_map; "
+                << "cannot emit DimSource. Either fix the model to expose a "
+                << "dim_param for this dimension, or freeze it to a constant.";
+            const auto &param_name = (*dp)[d];
+            auto pit = dim_param_map.find(param_name);
+            CHECK(pit != dim_param_map.end())
+                << "Output '" << output.name() << "' dim " << d
+                << " has dim_param '" << param_name
+                << "' but no graph input declares this symbolic name; cannot "
+                << "resolve at runtime. Outputs can only carry symbolic dims "
+                << "that also appear on at least one input.";
+            ds->set_input_idx(pit->second.first);
+            ds->set_dim_idx(pit->second.second);
+            ds->set_resolved(true);
+          } else {
+            // Static dim: emit explicit sentinels so the wire format
+            // unambiguously distinguishes "not populated" from
+            // "intentionally references (input 0, dim 0)" without relying
+            // on the proto-default-zero convention.  Consumers that read
+            // `resolved` first see the same behavior as before; consumers
+            // that don't see -1 instead of a misleading 0.
+            ds->set_input_idx(-1);
+            ds->set_dim_idx(-1);
+            ds->set_resolved(false);
+          }
         }
       }
     } else {

--- a/lib/Conversion/HipToLLVM/NonZeroLowering.cpp
+++ b/lib/Conversion/HipToLLVM/NonZeroLowering.cpp
@@ -10,19 +10,28 @@ namespace hip {
 namespace {
 
 // hip.nonzero(ctx, x, y) {input_data_type}
-//   -> wrap_nonzero(state, input_ptr, output_ptr,
-//                   input_num_elements, input_rank,
+//   -> wrap_nonzero(state, input_ptr, output_ptr, /*count_ptr=*/null,
+//                   input_num_elements, input_rank, input_dims_ptr,
 //                   output_capacity, input_data_type)
 //
-// `input_num_elements` is the total count of input elements (product of
-// input dims, supports static + dynamic shapes via MemRefDescriptor).
-// `input_rank` is the static rank of the input (R), passed as a compile-
-// time i64 constant.
-// `output_capacity` is the size of the dynamic N dim of the output (i.e.,
-// the upper-bound number of nonzero entries materialised by the conversion
-// pass). For NonZero today this equals input_num_elements, but lowering
-// computes it directly from the output descriptor so the path is correct
-// even if the conversion ever uses a smaller upper bound.
+// `count_ptr` is passed as a null pointer: the runtime owns a per-state
+// single-int32 scratch for the data-dependent count (it is consumed GPU-side
+// and never needs to be an explicit IR value).
+// `input_dims_ptr` is a host-stack array (alloca) of the input shape dims; the
+// kernel uses it to decompose a flat index into multi-dim coordinates.
+// `input_num_elements` is the total input element count (product of input
+// dims; supports static + dynamic via the MemRef descriptor).
+// `input_rank` is the static input rank R (compile-time i64 constant).
+// `output_capacity` is the dynamic N dim of the output, read from its
+// descriptor (today == input_num_elements, but read directly so a smaller
+// future upper bound still lowers correctly).
+//
+// Before:
+//   hip.nonzero(%ctx) ins(%x : memref<3x4xi1,1>) outs(%y : memref<2x?xi64,1>)
+// After:
+//   %dims = llvm.alloca : !llvm.ptr           // [3, 4]
+//   llvm.call @wrap_nonzero(%state, %xp, %yp, %null, %numel, %rank, %dims,
+//                           %cap, %dtype)
 struct NonZeroOpLowering : public ConvertOpToLLVMPattern<NonZeroOp> {
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
@@ -53,12 +62,33 @@ struct NonZeroOpLowering : public ConvertOpToLLVMPattern<NonZeroOp> {
     Value inputPtr = extractContiguousMemRefPtr(adaptor.getX(), rewriter, loc);
     Value outputPtr = extractContiguousMemRefPtr(adaptor.getY(), rewriter, loc);
 
+    // count_ptr = null: the runtime owns the per-state count scratch.
+    Value countPtr = LLVM::ZeroOp::create(rewriter, loc, ptrType);
+
     // Total input element count (handles static + dynamic dims).
     Value inputNumElements =
         computeNumElements(inputType, adaptor.getX(), rewriter, loc);
 
     // R is a static property of the input memref type.
-    Value inputRank = createI64Const(inputType.getRank());
+    int64_t rank = inputType.getRank();
+    Value inputRank = createI64Const(rank);
+
+    // Host-stack array of the input dims (one i64 per dim), so the kernel can
+    // decompose a flat index into row-major multi-dim coordinates. Static dims
+    // fold to constants; dynamic dims are read from the descriptor.
+    Value one = createI64Const(1);
+    auto arrType =
+        LLVM::LLVMArrayType::get(i64Type, std::max(rank, (int64_t)1));
+    Value dimsArr = LLVM::AllocaOp::create(rewriter, loc, ptrType, arrType, one,
+                                           /*align=*/8);
+    for (int64_t i : llvm::seq<int64_t>(0, rank)) {
+      Value dim = getMemRefDimSize(inputType, i, adaptor.getX(), rewriter, loc);
+      Value idx = LLVM::ConstantOp::create(rewriter, loc, i32Type,
+                                           rewriter.getI32IntegerAttr(i));
+      Value elemPtr =
+          LLVM::GEPOp::create(rewriter, loc, ptrType, i64Type, dimsArr, idx);
+      LLVM::StoreOp::create(rewriter, loc, dim, elemPtr);
+    }
 
     // Output capacity = N dim (data-dependent at the source level; the
     // tensor.empty in OnnxToHip pins it to numel(X) upper-bound, but read
@@ -69,18 +99,20 @@ struct NonZeroOpLowering : public ConvertOpToLLVMPattern<NonZeroOp> {
     Value inputDataTypeVal = createI64Const(op.getInputDataType());
 
     // int wrap_nonzero(RuntimeState* state, void* input, void* output,
-    //                  int64_t input_num_elements, int64_t input_rank,
+    //                  int32_t* count_ptr, int64_t input_num_elements,
+    //                  int64_t input_rank, const int64_t* input_dims,
     //                  int64_t output_capacity, int64_t input_data_type)
-    SmallVector<Type, 7> paramTypes = {ptrType, ptrType, ptrType, i64Type,
-                                       i64Type, i64Type, i64Type};
+    SmallVector<Type, 9> paramTypes = {ptrType, ptrType, ptrType,
+                                       ptrType, i64Type, i64Type,
+                                       ptrType, i64Type, i64Type};
     FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
         rewriter, module, kWrapNonZero, paramTypes, i32Type);
     if (failed(funcOp))
       return failure();
 
-    SmallVector<Value, 7> args = {statePtr,         inputPtr,  outputPtr,
-                                  inputNumElements, inputRank, outputCapacity,
-                                  inputDataTypeVal};
+    SmallVector<Value, 9> args = {statePtr, inputPtr,         outputPtr,
+                                  countPtr, inputNumElements, inputRank,
+                                  dimsArr,  outputCapacity,   inputDataTypeVal};
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
     rewriter.eraseOp(op);
     return success();

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -322,6 +322,11 @@ void *hipdnn_ep_state_get_qmoe_host_scratch(RuntimeState *state);
 int hipdnn_ep_state_ensure_qmoe_host_scratch(RuntimeState *state,
                                              size_t needed_size);
 
+// Per-state single-int32 device buffer for the data-dependent NonZero count.
+// Lazily allocated on first call; never grows; freed in cleanup. wrap_nonzero
+// uses this when called with count_ptr == nullptr (the in-graph lowering path).
+int32_t *hipdnn_ep_state_get_nonzero_count_scratch(RuntimeState *state);
+
 // Device-side runtime error flag (set by kernels, observed by wrappers).
 // Intended for operators that detect runtime-invalid inputs on GPU (e.g. Range
 // delta==0) and need to propagate an error code back through main_graph.

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -237,6 +237,7 @@ static int initialize_state_handles(RuntimeState **out_state) {
   state->qmoe_scratch_size = 0;
   state->qmoe_host_scratch = nullptr;
   state->qmoe_host_scratch_size = 0;
+  state->nonzero_count_scratch = nullptr;
   state->gqa_gemm_cache = nullptr;
   state->mha_gemm_cache = nullptr;
   state->causal_conv_cache = nullptr;
@@ -985,6 +986,9 @@ int hipdnn_ep_state_cleanup(RuntimeState *state) {
   if (state->qmoe_host_scratch) {
     HIP_CLEANUP(hipHostFree(state->qmoe_host_scratch));
   }
+  if (state->nonzero_count_scratch) {
+    HIP_CLEANUP(hipFree(state->nonzero_count_scratch));
+  }
 
   // Free ONNX Loop driver host-mapped buffers + reusable sync event (if
   // allocated). The stream sync at the top of cleanup has already drained
@@ -1480,6 +1484,23 @@ int hipdnn_ep_state_ensure_workspace(RuntimeState *state, size_t needed_size) {
 // the old buffer when growing -- we sync the stream before hipFree+hipMalloc.
 void *hipdnn_ep_state_get_qmoe_scratch(RuntimeState *state) {
   return state ? state->qmoe_scratch : nullptr;
+}
+
+int32_t *hipdnn_ep_state_get_nonzero_count_scratch(RuntimeState *state) {
+  if (!state)
+    return nullptr;
+  // Lazily allocate the single-int32 count buffer on first NonZero. Fixed size,
+  // never grows -- the count is always one scalar regardless of input shape.
+  if (!state->nonzero_count_scratch) {
+    if (hipMalloc(&state->nonzero_count_scratch, sizeof(int32_t)) !=
+        hipSuccess) {
+      fprintf(stderr, "hipdnn_ep_state_get_nonzero_count_scratch: hipMalloc "
+                      "failed for 4 bytes\n");
+      state->nonzero_count_scratch = nullptr;
+      return nullptr;
+    }
+  }
+  return static_cast<int32_t *>(state->nonzero_count_scratch);
 }
 
 int hipdnn_ep_state_ensure_qmoe_scratch(RuntimeState *state,

--- a/lib/Runtime/real/nonzero.cpp
+++ b/lib/Runtime/real/nonzero.cpp
@@ -44,9 +44,21 @@ int wrap_nonzero(RuntimeState *state, void *input, void *output,
       },
       state);
 
-  if (!state || !input || !output || !count_ptr || !input_dims) {
+  if (!state || !input || !output || !input_dims) {
     RUNTIME_DEBUG_LOG("[REAL] wrap_nonzero: null required argument\n");
     return -1;
+  }
+
+  // The in-graph lowering passes count_ptr == nullptr: the count is consumed
+  // GPU-side and never needs to be an explicit IR value, so the runtime owns a
+  // per-state single-int32 scratch for it. A non-null count_ptr (e.g. a future
+  // caller that wires the count to a downstream op) is used as-is.
+  if (!count_ptr) {
+    count_ptr = hipdnn_ep_state_get_nonzero_count_scratch(state);
+    if (!count_ptr) {
+      RUNTIME_DEBUG_LOG("[REAL] wrap_nonzero: count scratch alloc failed\n");
+      return -1;
+    }
   }
   if (input_num_elements <= 0 || input_rank <= 0) {
     RUNTIME_DEBUG_LOG("[REAL] wrap_nonzero: invalid dimensions "

--- a/lib/Runtime/runtime_state_internal.h
+++ b/lib/Runtime/runtime_state_internal.h
@@ -120,6 +120,13 @@ struct RuntimeState {
   void *qmoe_host_scratch; // pinned host mirror for D2H of expert idx/weights
   size_t qmoe_host_scratch_size;
 
+  // Per-state device scratch holding the data-dependent NonZero count (a single
+  // int32). wrap_nonzero uses this when the caller passes count_ptr == nullptr
+  // (the in-graph lowering does, since the count is consumed GPU-side and never
+  // needs to be an explicit IR value). Allocated lazily on first NonZero call
+  // (fixed 4 bytes; never grows); hipFree'd in cleanup.
+  void *nonzero_count_scratch;
+
   // GQA GEMM descriptor cache (GqaGemmCache*) for the decomposed path.
   // Caches hipBLASLt descriptors + algorithms by GEMM shape.
   void *gqa_gemm_cache;

--- a/test/lit/Conversion/hip-to-llvm/test_nonzero.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_nonzero.mlir
@@ -4,11 +4,12 @@
 // ============================================================================
 // TEST PURPOSE:
 // Verify hip.nonzero lowers to a single llvm.call into the wrap_nonzero
-// runtime stub, with the expected (state, in, out, num_elems, rank,
-// output_capacity, input_data_type) signature. Covers both fully static
-// inputs (num_elems computed at compile time) and partially dynamic
-// inputs (num_elems built from llvm.extractvalue + llvm.mul over the
-// MemRef descriptor sizes array).
+// runtime function, with the (state, in, out, count_ptr, num_elems, rank,
+// dims_ptr, output_capacity, input_data_type) signature. count_ptr is a null
+// pointer (the runtime owns the count scratch) and dims_ptr is a host alloca.
+// Covers both fully static inputs (num_elems computed at compile time) and
+// partially dynamic inputs (num_elems built from llvm.extractvalue + llvm.mul
+// over the MemRef descriptor sizes array).
 // ============================================================================
 
 // RUN: hip-mlir-opt %s --convert-hip-to-llvm | FileCheck %s
@@ -25,7 +26,7 @@ module {
                       outs(%output : memref<2x?xi64, 1>)
                       {input_data_type = 5 : i64}
 
-    // CHECK: llvm.call @wrap_nonzero({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64) -> i32
+    // CHECK: llvm.call @wrap_nonzero({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, !llvm.ptr, i64, i64) -> i32
     return
   }
 
@@ -40,7 +41,7 @@ module {
                       outs(%output : memref<3x?xi64, 1>)
                       {input_data_type = 0 : i64}
 
-    // CHECK: llvm.call @wrap_nonzero({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64) -> i32
+    // CHECK: llvm.call @wrap_nonzero({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, !llvm.ptr, i64, i64) -> i32
     return
   }
 
@@ -62,7 +63,7 @@ module {
     // CHECK-DAG: llvm.mul %{{.*}}, %{{.*}} : i64
     // CHECK-DAG: llvm.extractvalue %{{.*}}[3, 1]
 
-    // CHECK: llvm.call @wrap_nonzero({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64) -> i32
+    // CHECK: llvm.call @wrap_nonzero({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, !llvm.ptr, i64, i64) -> i32
     return
   }
 }

--- a/test/python/test_output_allocator_unresolved_dim.py
+++ b/test/python/test_output_allocator_unresolved_dim.py
@@ -1,0 +1,160 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+
+"""Repro for PR #340: output-allocator compile must not hard-CHECK on a dynamic
+output dim whose symbolic name appears on no input.
+
+`build_metadata_json` (backend-mlir-compiler/level-1-pass/src/pass_main.cpp)
+builds a DimSource for every dynamic output dim by matching the dim's symbolic
+name to whichever *input* first declares it. For a data-dependent output extent
+computed *inside* the graph (e.g. a vision model's feature count), the symbol is
+correctly on no input, and the classic path aborts the whole compile. The
+output-allocator ABI never reads a DimSource (the DLL sizes outputs in-graph),
+so the fix skips DimSource emission in that ABI -- making such graphs compile.
+
+The fix surface is the compile-time metadata build, which runs during session
+creation. The worker only creates the session; it does NOT run inference --
+NonZero's GPU kernel has a separate, pre-existing execution segfault, so folding
+it in would conflate two bugs. Session creation is driven in a child process so
+a pre-fix glog CHECK abort doesn't take down the pytest runner.
+"""
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import onnx
+import pytest
+from onnx import TensorProto, helper
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+EP_DLL = REPO_ROOT / "install" / "dist" / "bin" / "onnxruntime_morphizen_ep.dll"
+
+# Symbolic name carried by the output's data-dependent dim. Intentionally on no
+# input -- that is the whole point of the repro.
+OUTPUT_SYMBOL = "num_logical_patches"
+
+# Signature of the spurious abort the fix removes.
+_UNRESOLVED_SIGNATURE = (
+    "no graph input declares this symbolic name",
+    "pit != dim_param_map.end()",
+)
+
+
+def _build_model(path: Path) -> None:
+    """Graph whose output symbol is on no input and reaches the output through a
+    downstream op (the realistic shape: a data-dependent extent propagated by a
+    normal op, not the data-dependent op's own result).
+
+    cond : bool[6]                              (static -> no input symbols)
+    NonZero(cond)  -> nz  : int64[1, N]         (data-dependent extent N)
+    Transpose(nz)  -> out : int64[N, 1]         (N carried to the output)
+    """
+    cond = helper.make_tensor_value_info("cond", TensorProto.BOOL, [6])
+    out = helper.make_tensor_value_info("out", TensorProto.INT64, [OUTPUT_SYMBOL, 1])
+    nz = helper.make_node("NonZero", ["cond"], ["nz"], name="nz")
+    tr = helper.make_node("Transpose", ["nz"], ["out"], name="tr", perm=[1, 0])
+    graph = helper.make_graph([nz, tr], "unresolved_output_symbol", [cond], [out])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+    model.ir_version = 10
+    onnx.save(model, str(path))
+
+
+# Child-process worker: register the EP, open a session in the requested ABI.
+# Session creation triggers the level-1 pass (build_metadata_json); reaching
+# "SESSION_CREATED_OK" proves the metadata build did not abort on the symbol.
+_WORKER = textwrap.dedent(
+    """
+    import sys
+    import onnxruntime as ort
+
+    model_path, use_alloc, ep_dll = sys.argv[1], sys.argv[2] == "1", sys.argv[3]
+
+    ort.register_execution_provider_library("MorphiZenExecutionProvider", ep_dll)
+    from onnxruntime.capi._pybind_state import get_ep_devices
+    devices = [d for d in get_ep_devices()
+               if d.ep_name == "MorphiZenExecutionProvider"]
+    if not devices:
+        print("NO_EP_DEVICES", file=sys.stderr)
+        sys.exit(3)
+
+    so = ort.SessionOptions()
+    so.add_provider_for_devices(
+        devices, {"use_output_allocator": "1"} if use_alloc else {})
+    sess = ort.InferenceSession(model_path, sess_options=so)
+    print("SESSION_CREATED_OK")
+    """
+)
+
+
+def _run_worker(model_path: Path, use_alloc: bool):
+    env = dict(os.environ)
+    # Leave strict off so a pre-fix soft CPU fallback is not turned into an
+    # abort -- the pass_main CHECK (if any) should be the only abort source.
+    env["HIPDNN_EP_STRICT"] = "0"
+    dist_bin = REPO_ROOT / "install" / "dist" / "bin"
+    therock_bin = REPO_ROOT / "install" / "therock" / "bin"
+    env["THEROCK_DIST"] = str(REPO_ROOT / "install" / "therock")
+    env["PATH"] = f"{dist_bin};{therock_bin};" + env.get("PATH", "")
+    return subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _WORKER,
+            str(model_path),
+            "1" if use_alloc else "0",
+            str(EP_DLL),
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=300,
+    )
+
+
+@pytest.fixture(scope="module")
+def model_path(tmp_path_factory):
+    p = tmp_path_factory.mktemp("unresolved_dim") / "nonzero_transpose.onnx"
+    _build_model(p)
+    return p
+
+
+@pytest.mark.skipif(not EP_DLL.exists(), reason="EP DLL not built — run build.py")
+def test_output_allocator_compiles_unresolved_symbol(model_path):
+    """Allocator ABI must compile a graph whose output symbol is on no input.
+
+    The PR #340 fix target. On pre-fix `main` the child aborts with the
+    pass_main.cpp CHECK and this test fails (reproducing the bug); post-fix
+    session creation completes cleanly.
+    """
+    proc = _run_worker(model_path, use_alloc=True)
+    combined = proc.stdout + "\n" + proc.stderr
+
+    if any(sig in combined for sig in _UNRESOLVED_SIGNATURE):
+        pytest.fail(
+            "PR #340 bug reproduced: output-allocator compile aborted on an "
+            f"output symbol that is on no input.\nrc={proc.returncode}\n{combined}"
+        )
+    assert "SESSION_CREATED_OK" in proc.stdout, (
+        "allocator-mode session creation did not complete (and not via the "
+        f"known unresolved-dim CHECK):\nrc={proc.returncode}\n{combined}"
+    )
+
+
+@pytest.mark.skipif(not EP_DLL.exists(), reason="EP DLL not built — run build.py")
+def test_classic_abi_still_errors_on_unresolved_symbol(model_path):
+    """Classic ABI: aborting on an unresolvable output symbol is correct (it
+    pre-allocates outputs and cannot size a symbol that is on no input). Asserts
+    the classic run does not silently succeed with a wrong shape.
+    """
+    proc = _run_worker(model_path, use_alloc=False)
+    combined = proc.stdout + "\n" + proc.stderr
+    if "SESSION_CREATED_OK" in proc.stdout and proc.returncode == 0:
+        return  # a future classic generalization handled it -- acceptable
+    assert (
+        any(sig in combined for sig in _UNRESOLVED_SIGNATURE) or proc.returncode != 0
+    ), f"classic ABI neither succeeded nor failed as expected:\n{combined}"


### PR DESCRIPTION
> Stacked on #342 (`fix/output-allocator-skip-dimsource`). Review/merge that first; this PR's diff is the single NonZero commit on top.

## Summary

Fixes a hard crash (`0xC0000005` in `hipModuleLaunchKernel`) on any model that actually executes a `NonZero` op.

**Root cause — ABI mismatch.** The runtime + HIP kernel were upgraded to a 9-arg `wrap_nonzero` (adding `int32_t* count_ptr` and `const int64_t* input_dims`), but the HipToLLVM lowering still emitted the old **7-arg** call. The runtime read the i64 `input_num_elements` as `count_ptr` (a pointer) with every later arg shifted by one → kernel launched with garbage pointers → SEGV. Session creation was unaffected, so the LIT compile tests and the unresolved-dim repro passed while real inference crashed.

## Fix — runtime-owned count scratch (not a 2nd DPS output)

- `NonZeroLowering.cpp` now emits the correct 9-arg call: builds a host-stack `input_dims` array (static dims fold to constants, dynamic read from the descriptor) and passes `count_ptr = null`.
- The runtime owns the data-dependent count: a per-`RuntimeState` single-`int32` `nonzero_count_scratch` (lazy-alloc, never grows, freed in cleanup) + accessor `hipdnn_ep_state_get_nonzero_count_scratch`. `wrap_nonzero` uses it when `count_ptr == nullptr`; a non-null `count_ptr` is still honored for a future caller that wires the count to a downstream op.
- `test_nonzero.mlir` CHECKs updated to the 9-arg signature.

This keeps `hip.nonzero` single-output — no op-arity change, no DPS/bufferize/pool-allocs ripple. (PR #259 instead makes `count_buf` a second DPS output; this is the smaller, lower-risk crash fix.)

## Test plan

- [x] `NonZero -> out` in classic mode returns `[[0, 2, 3, 5]]` for `cond=[1,0,1,1,0,1]` — matches numpy (crash gone, kernel correct).
- [x] `E2E_Execute_test_nonzero_model` — passed
- [x] `MorphizenMLIRLitTests` (incl. updated NonZero lowering CHECK) — passed
- [x] allocator ctest suite (`#36/#37/#66/#67`) — passed
- [x] `pre-commit run --files ...` — all hooks passed

## Known follow-up (separate, not this crash)

Allocator-mode end-to-end for data-dependent outputs still trips the output-completeness guard ("passthrough/aliased outputs not supported") because NonZero's buffer does not yet lower to `hip.alloc_output`. Tracked separately.
