### PR TITLE
fix(hip): register arith BufferDeallocationOpInterface external models

### DIFF
--- a/include/hip/InitAllPasses.h
+++ b/include/hip/InitAllPasses.h
@@ -11,6 +11,7 @@
 #include "hip/Dialect/Transforms/Passes.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Arith/Transforms/BufferDeallocationOpInterfaceImpl.h"
 #include "mlir/Dialect/Arith/Transforms/BufferizableOpInterfaceImpl.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Bufferization/Transforms/FuncBufferizableOpInterfaceImpl.h"
@@ -60,6 +61,11 @@ inline void registerAllDialects(mlir::DialectRegistry &registry) {
   registry.insert<mlir::hip::HipDialect>();
   registry.insert<detail::OnnxStubDialect>();
   mlir::arith::registerBufferizableOpInterfaceExternalModels(registry);
+  // The ownership-based buffer-deallocation pass walks arith ops (e.g.
+  // arith.select on buffers, present in hybrid/MoE graphs). Without this
+  // external model the pass fatal-errors: "interface BufferDeallocationOpInterface
+  // promised by dialect 'arith' but never implemented".
+  mlir::arith::registerBufferDeallocationOpInterfaceExternalModels(registry);
   mlir::tensor::registerBufferizableOpInterfaceExternalModels(registry);
   mlir::tensor::registerInferTypeOpInterfaceExternalModels(registry);
   mlir::bufferization::func_ext::registerBufferizableOpInterfaceExternalModels(

--- a/tools/hip-mlir-opt/hip-mlir-opt.cpp
+++ b/tools/hip-mlir-opt/hip-mlir-opt.cpp
@@ -10,6 +10,7 @@
 
 #include "mlir/Conversion/Passes.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Arith/Transforms/BufferDeallocationOpInterfaceImpl.h"
 #include "mlir/Dialect/Arith/Transforms/BufferizableOpInterfaceImpl.h"
 #include "mlir/Dialect/Bufferization/IR/BufferizableOpInterface.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
@@ -218,6 +219,7 @@ int main(int argc, char **argv) {
   registry.insert<hip::compiler::detail::OnnxStubDialect>();
 
   mlir::arith::registerBufferizableOpInterfaceExternalModels(registry);
+  mlir::arith::registerBufferDeallocationOpInterfaceExternalModels(registry);
   mlir::bufferization::func_ext::registerBufferizableOpInterfaceExternalModels(
       registry);
   mlir::scf::registerBufferizableOpInterfaceExternalModels(registry);


### PR DESCRIPTION
## Summary
- Register the `arith` `BufferDeallocationOpInterface` external model in `registerAllDialects` (and in `hip-mlir-opt` for consistency).
- The ownership-based buffer-deallocation pass walks `arith` ops (e.g. `arith.select` on buffers) present in hybrid / MoE graphs (e.g. Qwen3.5-35B-A3B). Without this external model the pass aborts with `LLVM ERROR: ... interface BufferDeallocationOpInterface ... promised by dialect 'arith' but never implemented`.
- Simple graphs (e.g. single-op Gather) never exercised this path, so the gap was latent until a graph with such `arith` ops was compiled.

## Test plan
- [ ] `check-hip-mlir-lit` passes (194/194)
- [ ] `ctest -R ^E2E_` passes (56/56)
- [ ] Compiling a graph that contains `arith` ops requiring buffer deallocation no longer aborts in `OwnershipBasedBufferDeallocationPass`.