### PR TITLE
feat(packaging): package MorphiZen EP as a Python wheel + CI wheel smoke

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -512,10 +512,8 @@ jobs:
           cp "$ORT_WHEEL" "$OGA_WHEEL" "$EP_WHEEL" wheelpkg/wheels/
           cp python/examples/run_onnx.py wheelpkg/
           cp "${{ runner.workspace }}/oga-artifacts/benchmark-python/"*.py wheelpkg/benchmark/
-          # Download EP dependency closure (ROCm) + ORT third-party deps for
-          # offline install. setuptools is a build dep for the rocm sdist.
+          # Download EP dependency closure (ROCm) for the wheel package.
           python -m pip download "$EP_WHEEL" \
-            flatbuffers numpy packaging protobuf coloredlogs setuptools \
             --extra-index-url https://repo.amd.com/rocm/whl/gfx1151/ \
             -d wheelpkg/wheels
           echo "=== Python wheel package layout ==="
@@ -811,11 +809,18 @@ jobs:
           python -m venv $venv
           $py = "$venv\Scripts\python.exe"
 
-          # Install project + ROCm wheels offline; benchmark deps from PyPI.
-          $whls = (Get-ChildItem "$pkg\wheels\onnxruntime_directml-*.whl", "$pkg\wheels\onnxruntime_morphizen_ep-*.whl", "$pkg\wheels\onnxruntime_genai_directml-*.whl").FullName
-          & $py -m pip install --quiet --no-index --find-links "$pkg\wheels" $whls
-          if ($LASTEXITCODE -ne 0) { Write-Host "[ERROR] wheel install failed"; exit 1 }
-          & $py -m pip install --quiet psutil tqdm pandas
+          # Install project + ROCm wheels from local dir; ORT deps from PyPI.
+          Push-Location "$pkg\wheels"
+          & $py -m pip install --quiet `
+            (Get-Item onnxruntime_directml-*.whl).Name `
+            (Get-Item onnxruntime_morphizen_ep-*.whl).Name `
+            (Get-Item onnxruntime_genai_directml-*.whl).Name `
+            (Get-Item rocm-*.tar.gz).Name `
+            (Get-Item rocm_sdk_core-*.whl).Name `
+            (Get-Item rocm_sdk_devel-*.whl).Name `
+            (Get-Item rocm_sdk_libraries_*.whl).Name `
+            psutil tqdm pandas
+          Pop-Location
           if ($LASTEXITCODE -ne 0) { Write-Host "[ERROR] wheel install failed"; exit 1 }
           & "$venv\Scripts\rocm-sdk.exe" init   # expand rocm[devel] import libs
           if ($LASTEXITCODE -ne 0) { Write-Host "[ERROR] rocm-sdk init failed"; exit 1 }

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -459,34 +459,23 @@ jobs:
           cp "${{ runner.workspace }}/oga-artifacts/onnxruntime-genai.dll" staging/bin/
 
           # ---------------------------------------------------------------
-          # Python wheels (ORT + OGA + MorphiZen EP) — bundled into the same
-          # artifact under staging/wheels/ so downstream consumers download a
-          # single zip. The ORT/OGA wheels are cached inside ort-install /
-          # oga-artifacts (cache hits restore them without rebuilding); the EP
-          # wheel is built fresh by build.py above (default target).
+          # Python wheels (ORT + OGA cp314) bundled into the artifact under
+          # staging/wheels/. Both are cached inside ort-install / oga-artifacts,
+          # so cache hits restore them without rebuilding ORT / OGA.
           # ---------------------------------------------------------------
           mkdir -p staging/wheels
           ORT_WHEEL=$(find "${{ runner.workspace }}/ort-install/wheels" \
             -name "onnxruntime_directml-*.whl" -type f | head -1)
           OGA_WHEEL=$(find "${{ runner.workspace }}/oga-artifacts" \
             -name "onnxruntime_genai_directml-*.whl" -type f | head -1)
-          EP_WHEEL=$(find "../build/$(basename "$PWD")/python/dist" \
-            -name "onnxruntime_morphizen_ep-*.whl" -type f | head -1)
-          if [ -z "$ORT_WHEEL" ] || [ -z "$OGA_WHEEL" ] || [ -z "$EP_WHEEL" ]; then
-            echo "ERROR: wheel(s) missing from build tree"
+          if [ -z "$ORT_WHEEL" ] || [ -z "$OGA_WHEEL" ]; then
+            echo "ERROR: cp314 wheel(s) missing from cache"
             echo "  ORT: $ORT_WHEEL"
             echo "  OGA: $OGA_WHEEL"
-            echo "  EP:  $EP_WHEEL"
             exit 1
           fi
           cp "$ORT_WHEEL" staging/wheels/
           cp "$OGA_WHEEL" staging/wheels/
-          cp "$EP_WHEEL" staging/wheels/
-
-          # OGA Python e2e benchmark scripts (benchmark_e2e.py + metrics.py) for
-          # the gpu-test wheel smoke.
-          mkdir -p staging/benchmark
-          cp "${{ runner.workspace }}/oga-artifacts/benchmark-python/"*.py staging/benchmark/
 
           echo "=== Staged package contents ==="
           find staging/ -type f | sort
@@ -496,6 +485,45 @@ jobs:
         with:
           name: gpu-test-package
           path: staging/
+          retention-days: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release_')) && 14 || 3 }}
+
+      # -----------------------------------------------------------------------
+      # Standalone, offline Python wheel package: the three project wheels + the
+      # full ROCm wheel closure (pip-downloaded from repo.amd.com) + run_onnx.py
+      # + OGA's benchmark scripts. Self-contained for ROCm (install offline via
+      # --find-links); only rocm-sdk init expands the devel libs afterwards.
+      # Uploaded as a separate artifact from gpu-test-package.
+      # -----------------------------------------------------------------------
+      - name: Stage Python wheel package
+        shell: bash
+        run: |
+          mkdir -p wheelpkg/wheels wheelpkg/benchmark
+          ORT_WHEEL=$(find "${{ runner.workspace }}/ort-install/wheels" \
+            -name "onnxruntime_directml-*.whl" -type f | head -1)
+          OGA_WHEEL=$(find "${{ runner.workspace }}/oga-artifacts" \
+            -name "onnxruntime_genai_directml-*.whl" -type f | head -1)
+          EP_WHEEL=$(find "../build/$(basename "$PWD")/python/dist" \
+            -name "onnxruntime_morphizen_ep-*.whl" -type f | head -1)
+          if [ -z "$ORT_WHEEL" ] || [ -z "$OGA_WHEEL" ] || [ -z "$EP_WHEEL" ]; then
+            echo "ERROR: wheel(s) missing"
+            echo "  ORT=$ORT_WHEEL OGA=$OGA_WHEEL EP=$EP_WHEEL"
+            exit 1
+          fi
+          cp "$ORT_WHEEL" "$OGA_WHEEL" "$EP_WHEEL" wheelpkg/wheels/
+          cp python/examples/run_onnx.py wheelpkg/
+          cp "${{ runner.workspace }}/oga-artifacts/benchmark-python/"*.py wheelpkg/benchmark/
+          # Download the EP wheel's dependency closure (ROCm) for offline install.
+          python -m pip download "$EP_WHEEL" \
+            --extra-index-url https://repo.amd.com/rocm/whl/gfx1151/ \
+            -d wheelpkg/wheels
+          echo "=== Python wheel package layout ==="
+          find wheelpkg/ -maxdepth 2 -mindepth 1 | sort
+
+      - name: Upload Python wheel package
+        uses: actions/upload-artifact@v4
+        with:
+          name: morphizen-python-package
+          path: wheelpkg/
           retention-days: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release_')) && 14 || 3 }}
 
   # ---------------------------------------------------------------------------
@@ -533,12 +561,19 @@ jobs:
           if exist oga-results rd /s /q oga-results
           if exist oga-smoke-venv rd /s /q oga-smoke-venv
           if exist oga-smoke-results rd /s /q oga-smoke-results
+          if exist wheelpkg rd /s /q wheelpkg
 
       - name: Download GPU test package
         uses: actions/download-artifact@v4
         with:
           name: gpu-test-package
           path: gpu-test-package
+
+      - name: Download Python wheel package
+        uses: actions/download-artifact@v4
+        with:
+          name: morphizen-python-package
+          path: wheelpkg
 
       # TheRock DLLs are required at runtime on the GPU machine.
       # Download is fast enough that caching is not needed on the self-hosted runner.
@@ -744,12 +779,10 @@ jobs:
           exit $failed
 
       # -----------------------------------------------------------------------
-      # OGA wheel smoke: install the packaged ORT + OGA + MorphiZen EP wheels and
-      # run OGA's own benchmark_e2e.py (packaged into gpu-test-package/benchmark)
-      # against a real model, following docs/quick_start.md "Install Python
-      # Wheels" verbatim (pip + rocm --extra-index-url, `rocm-sdk init`,
-      # THEROCK_DIST=_rocm_sdk_devel, LIB=capi, PATH=capi + rocm bins). Validates
-      # the documented end-user wheel flow end to end.
+      # OGA wheel smoke: install the wheels from the offline morphizen-python-
+      # package and run OGA's benchmark_e2e.py against a real model. ROCm comes
+      # from the package's bundled TheRock (THEROCK_DIST), so no pip ROCm /
+      # rocm-sdk init is needed. Validates the self-contained wheel package.
       # -----------------------------------------------------------------------
       # The cp314 ORT/OGA wheels need Python 3.14 to create the smoke venv (the
       # runner's default python may be a different version).
@@ -770,20 +803,22 @@ jobs:
           $model = "${{ runner.workspace }}\oga-models\Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml"
           if (-not (Test-Path $model)) { Write-Host "[SKIP] model not found: $model"; exit 0 }
 
-          # Fresh venv; install per quick_start (ROCm via --extra-index-url).
+          $pkg = "$PWD\wheelpkg"
           $venv = "$PWD\oga-smoke-venv"
           if (Test-Path $venv) { Remove-Item $venv -Recurse -Force }
           python -m venv $venv
           $py = "$venv\Scripts\python.exe"
-          $w = "$PWD\gpu-test-package\wheels"
-          $whls = (Get-ChildItem "$w\onnxruntime_directml-*.whl", "$w\onnxruntime_morphizen_ep-*.whl", "$w\onnxruntime_genai_directml-*.whl").FullName
-          & $py -m pip install --quiet $whls --extra-index-url https://repo.amd.com/rocm/whl/gfx1151/
+
+          # Install fully offline from the bundled wheel closure (ROCm + ORT/OGA
+          # deps + benchmark deps all present), then expand rocm[devel] libs.
+          $whls = (Get-ChildItem "$pkg\wheels\onnxruntime_directml-*.whl", "$pkg\wheels\onnxruntime_morphizen_ep-*.whl", "$pkg\wheels\onnxruntime_genai_directml-*.whl").FullName
+          & $py -m pip install --quiet --no-index --find-links "$pkg\wheels" $whls psutil tqdm pandas
           if ($LASTEXITCODE -ne 0) { Write-Host "[ERROR] wheel install failed"; exit 1 }
           & "$venv\Scripts\rocm-sdk.exe" init   # expand rocm[devel] import libs
           if ($LASTEXITCODE -ne 0) { Write-Host "[ERROR] rocm-sdk init failed"; exit 1 }
 
-          # THEROCK_DIST -> ROCm import libs; LIB -> capi (CRT + custom kernels);
-          # PATH -> capi (EP + hip-compiler) + rocm bins (runtime DLLs).
+          # THEROCK_DIST -> rocm[devel]; LIB -> capi (CRT + custom kernels);
+          # PATH -> capi (EP + hip-compiler) + rocm runtime bins.
           $sp = "$venv\Lib\site-packages"
           $capi = "$sp\onnxruntime\capi"
           $env:THEROCK_DIST = "$sp\_rocm_sdk_devel"
@@ -792,13 +827,11 @@ jobs:
             ForEach-Object { "$($_.FullName)\bin" } | Where-Object { Test-Path $_ }) -join ";"
           $env:PATH = "$capi;$rocmBins;$env:PATH"
 
-          & $py -m pip install --quiet psutil tqdm pandas   # benchmark_e2e.py deps
-
           # -e follow_config reads the provider from genai_config.json (populated
           # by the OGA benchmark step above from genai_config_128.json). Tee the
           # output so the publish step can extract throughput.
           New-Item -ItemType Directory -Force -Path oga-smoke-results | Out-Null
-          & $py "$PWD\gpu-test-package\benchmark\benchmark_e2e.py" `
+          & $py "$pkg\benchmark\benchmark_e2e.py" `
             -i $model -l 128 -g 128 -r 5 -w 1 -b 1 -m -1 -v `
             2>&1 | Tee-Object -FilePath "oga-smoke-results\Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml.txt"
           exit $LASTEXITCODE
@@ -1027,21 +1060,19 @@ jobs:
             $content = Get-Content $f.FullName -Raw
             $ppMatch = [regex]::Match($content, 'Average Prompt Processing Throughput \(per token\):\s+([\d.]+)')
             $tgMatch = [regex]::Match($content, 'Average Token Generation Throughput \(per token\):\s+([\d.]+)')
-            $wcMatch = [regex]::Match($content, 'Average Wall Clock Throughput:\s+([\d.]+)')
-            $pp = if ($ppMatch.Success) { "{0:F1}" -f [double]$ppMatch.Groups[1].Value } else { "-" }
-            $tg = if ($tgMatch.Success) { "{0:F1}" -f [double]$tgMatch.Groups[1].Value } else { "-" }
-            $wc = if ($wcMatch.Success) { "{0:F1}" -f [double]$wcMatch.Groups[1].Value } else { "-" }
+            $ttft = if ($ppMatch.Success) { "{0:F0}" -f (128.0 / [double]$ppMatch.Groups[1].Value * 1000) } else { "-" }
+            $tps  = if ($tgMatch.Success) { "{0:F1}" -f [double]$tgMatch.Groups[1].Value } else { "-" }
             if ($tgMatch.Success) {
-              $smokeRows += "| $model | $pp | $tg | $wc |`n"
+              $smokeRows += "| $model | $ttft | $tps |`n"
             } else {
-              $smokeRows += "| $model | failed | - | - |`n"
+              $smokeRows += "| $model | failed | - |`n"
             }
           }
           $smokeSection = ""
           if ($smokeRows) {
             $smokeSection = "`n## OGA Wheel Smoke (Python benchmark_e2e.py)`n`n" +
-                            "| Model | Prompt Proc (tps) | Token Gen (tps) | Wall Clock (tps) |`n" +
-                            "|-------|----:|----:|----:|`n" +
+                            "| Model | TTFT (ms) | TPS |`n" +
+                            "|-------|----:|----:|`n" +
                             $smokeRows
           }
 

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -792,7 +792,7 @@ jobs:
             ForEach-Object { "$($_.FullName)\bin" } | Where-Object { Test-Path $_ }) -join ";"
           $env:PATH = "$capi;$rocmBins;$env:PATH"
 
-          & $py -m pip install --quiet psutil tqdm   # benchmark_e2e.py deps
+          & $py -m pip install --quiet psutil tqdm pandas   # benchmark_e2e.py deps
 
           # -e follow_config reads the provider from genai_config.json (populated
           # by the OGA benchmark step above from genai_config_128.json). Tee the

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -809,10 +809,11 @@ jobs:
           python -m venv $venv
           $py = "$venv\Scripts\python.exe"
 
-          # Install fully offline from the bundled wheel closure (ROCm + ORT/OGA
-          # deps + benchmark deps all present), then expand rocm[devel] libs.
+          # Install project + ROCm wheels offline, then benchmark deps from PyPI.
           $whls = (Get-ChildItem "$pkg\wheels\onnxruntime_directml-*.whl", "$pkg\wheels\onnxruntime_morphizen_ep-*.whl", "$pkg\wheels\onnxruntime_genai_directml-*.whl").FullName
-          & $py -m pip install --quiet --no-index --find-links "$pkg\wheels" $whls psutil tqdm pandas
+          & $py -m pip install --quiet --no-index --find-links "$pkg\wheels" $whls
+          if ($LASTEXITCODE -ne 0) { Write-Host "[ERROR] wheel install failed"; exit 1 }
+          & $py -m pip install --quiet psutil tqdm pandas
           if ($LASTEXITCODE -ne 0) { Write-Host "[ERROR] wheel install failed"; exit 1 }
           & "$venv\Scripts\rocm-sdk.exe" init   # expand rocm[devel] import libs
           if ($LASTEXITCODE -ne 0) { Write-Host "[ERROR] rocm-sdk init failed"; exit 1 }

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -512,8 +512,10 @@ jobs:
           cp "$ORT_WHEEL" "$OGA_WHEEL" "$EP_WHEEL" wheelpkg/wheels/
           cp python/examples/run_onnx.py wheelpkg/
           cp "${{ runner.workspace }}/oga-artifacts/benchmark-python/"*.py wheelpkg/benchmark/
-          # Download the EP wheel's dependency closure (ROCm) for offline install.
+          # Download dependency closures for offline install: EP (-> ROCm),
+          # plus ORT/OGA third-party deps (flatbuffers etc.) and benchmark deps.
           python -m pip download "$EP_WHEEL" \
+            flatbuffers numpy packaging protobuf coloredlogs psutil tqdm pandas \
             --extra-index-url https://repo.amd.com/rocm/whl/gfx1151/ \
             -d wheelpkg/wheels
           echo "=== Python wheel package layout ==="
@@ -809,11 +811,9 @@ jobs:
           python -m venv $venv
           $py = "$venv\Scripts\python.exe"
 
-          # Install project + ROCm wheels offline, then benchmark deps from PyPI.
+          # Install fully offline from the bundled wheel closure.
           $whls = (Get-ChildItem "$pkg\wheels\onnxruntime_directml-*.whl", "$pkg\wheels\onnxruntime_morphizen_ep-*.whl", "$pkg\wheels\onnxruntime_genai_directml-*.whl").FullName
-          & $py -m pip install --quiet --no-index --find-links "$pkg\wheels" $whls
-          if ($LASTEXITCODE -ne 0) { Write-Host "[ERROR] wheel install failed"; exit 1 }
-          & $py -m pip install --quiet psutil tqdm pandas
+          & $py -m pip install --quiet --no-index --find-links "$pkg\wheels" $whls psutil tqdm pandas
           if ($LASTEXITCODE -ne 0) { Write-Host "[ERROR] wheel install failed"; exit 1 }
           & "$venv\Scripts\rocm-sdk.exe" init   # expand rocm[devel] import libs
           if ($LASTEXITCODE -ne 0) { Write-Host "[ERROR] rocm-sdk init failed"; exit 1 }

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -319,7 +319,7 @@ jobs:
           path: ${{ runner.workspace }}/oga-artifacts
           # Bump the v<N> token to invalidate the OGA cache when its output
           # set changes shape (e.g. a new artifact) without an OGA_REF/ORT bump.
-          key: oga-dml-v1-${{ env.OGA_REF }}-ort${{ env.ONNXRUNTIME_VERSION }}
+          key: oga-dml-v2-${{ env.OGA_REF }}-ort${{ env.ONNXRUNTIME_VERSION }}
 
       - name: Checkout OGA
         if: steps.cache-oga.outputs.cache-hit != 'true'
@@ -375,6 +375,14 @@ jobs:
           fi
           cp "$OGA_WHEEL" "${{ runner.workspace }}/oga-artifacts/"
           echo "Cached OGA wheel: $(basename "$OGA_WHEEL")"
+
+          # Cache the Python e2e benchmark scripts (benchmark_e2e.py + its metrics
+          # helper) so the gpu-test wheel smoke can run them without an OGA source
+          # checkout (which only happens on a cache miss).
+          mkdir -p "${{ runner.workspace }}/oga-artifacts/benchmark-python"
+          cp "${{ github.workspace }}/source-oga/benchmark/python/benchmark_e2e.py" \
+             "${{ github.workspace }}/source-oga/benchmark/python/metrics.py" \
+             "${{ runner.workspace }}/oga-artifacts/benchmark-python/"
 
       # -----------------------------------------------------------------------
       # Stage GPU test package:
@@ -451,25 +459,34 @@ jobs:
           cp "${{ runner.workspace }}/oga-artifacts/onnxruntime-genai.dll" staging/bin/
 
           # ---------------------------------------------------------------
-          # Python wheels (ORT + OGA cp314) — bundled into the same artifact
-          # under staging/wheels/ so downstream consumers download a single
-          # zip. Both wheels are cached inside ort-install / oga-artifacts
-          # respectively, so cache hits restore them without re-running ORT
-          # or OGA from source.
+          # Python wheels (ORT + OGA + MorphiZen EP) — bundled into the same
+          # artifact under staging/wheels/ so downstream consumers download a
+          # single zip. The ORT/OGA wheels are cached inside ort-install /
+          # oga-artifacts (cache hits restore them without rebuilding); the EP
+          # wheel is built fresh by build.py above (default target).
           # ---------------------------------------------------------------
           mkdir -p staging/wheels
           ORT_WHEEL=$(find "${{ runner.workspace }}/ort-install/wheels" \
             -name "onnxruntime_directml-*.whl" -type f | head -1)
           OGA_WHEEL=$(find "${{ runner.workspace }}/oga-artifacts" \
             -name "onnxruntime_genai_directml-*.whl" -type f | head -1)
-          if [ -z "$ORT_WHEEL" ] || [ -z "$OGA_WHEEL" ]; then
-            echo "ERROR: cp314 wheel(s) missing from cache"
+          EP_WHEEL=$(find "../build/$(basename "$PWD")/python/dist" \
+            -name "onnxruntime_morphizen_ep-*.whl" -type f | head -1)
+          if [ -z "$ORT_WHEEL" ] || [ -z "$OGA_WHEEL" ] || [ -z "$EP_WHEEL" ]; then
+            echo "ERROR: wheel(s) missing from build tree"
             echo "  ORT: $ORT_WHEEL"
             echo "  OGA: $OGA_WHEEL"
+            echo "  EP:  $EP_WHEEL"
             exit 1
           fi
           cp "$ORT_WHEEL" staging/wheels/
           cp "$OGA_WHEEL" staging/wheels/
+          cp "$EP_WHEEL" staging/wheels/
+
+          # OGA Python e2e benchmark scripts (benchmark_e2e.py + metrics.py) for
+          # the gpu-test wheel smoke.
+          mkdir -p staging/benchmark
+          cp "${{ runner.workspace }}/oga-artifacts/benchmark-python/"*.py staging/benchmark/
 
           echo "=== Staged package contents ==="
           find staging/ -type f | sort
@@ -514,6 +531,8 @@ jobs:
           if exist gpu-test-package rd /s /q gpu-test-package
           if exist l2-results rd /s /q l2-results
           if exist oga-results rd /s /q oga-results
+          if exist oga-smoke-venv rd /s /q oga-smoke-venv
+          if exist oga-smoke-results rd /s /q oga-smoke-results
 
       - name: Download GPU test package
         uses: actions/download-artifact@v4
@@ -723,6 +742,59 @@ jobs:
             if ($LASTEXITCODE -ne 0) { $failed = 1 }
           }
           exit $failed
+
+      # -----------------------------------------------------------------------
+      # OGA wheel smoke: install the packaged ORT + OGA + MorphiZen EP wheels and
+      # run OGA's own benchmark_e2e.py (packaged into gpu-test-package/benchmark)
+      # against a real model, following docs/quick_start.md "Install Python
+      # Wheels" verbatim (pip + rocm --extra-index-url, `rocm-sdk init`,
+      # THEROCK_DIST=_rocm_sdk_devel, LIB=capi, PATH=capi + rocm bins). Validates
+      # the documented end-user wheel flow end to end.
+      # -----------------------------------------------------------------------
+      - name: Run OGA wheel smoke (Python)
+        if: always()
+        timeout-minutes: 40
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          MODEL_W='${{ runner.workspace }}\oga-models\Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml'
+          if [ ! -d "$(cygpath -u "$MODEL_W")" ]; then echo "[SKIP] model not found: $MODEL_W"; exit 0; fi
+
+          # Fresh venv; install per quick_start (ROCm via --extra-index-url).
+          VENV="$PWD/oga-smoke-venv"
+          rm -rf "$VENV"
+          python -m venv "$VENV"
+          PY="$VENV/Scripts/python.exe"
+          cd "$PWD/gpu-test-package/wheels"
+          "$PY" -m pip install --quiet \
+            onnxruntime_directml-*.whl onnxruntime_morphizen_ep-*.whl onnxruntime_genai_directml-*.whl \
+            --extra-index-url https://repo.amd.com/rocm/whl/gfx1151/
+          cd -
+          "$VENV/Scripts/rocm-sdk.exe" init   # expand rocm[devel] import libs
+
+          # LIB/THEROCK_DIST feed the native JIT linker (MSYS does not convert
+          # them) -> Windows paths; PATH stays POSIX (MSYS converts it).
+          SP="$VENV/Lib/site-packages"
+          CAPI="$SP/onnxruntime/capi"
+          export THEROCK_DIST="$(cygpath -w "$SP/_rocm_sdk_devel")"
+          export LIB="$(cygpath -w "$CAPI")"
+          PATH="$CAPI:$PATH"
+          for d in "$SP"/_rocm_sdk_*/bin; do
+            [ -d "$d" ] && PATH="$d:$PATH"
+          done
+          export PATH
+
+          "$PY" -m pip install --quiet psutil tqdm   # benchmark_e2e.py deps
+
+          # -e follow_config reads the provider from genai_config.json (populated
+          # by the OGA benchmark step above from genai_config_128.json). tee the
+          # output so the publish step can extract throughput (pipefail keeps the
+          # benchmark's exit status).
+          mkdir -p oga-smoke-results
+          "$PY" "$PWD/gpu-test-package/benchmark/benchmark_e2e.py" \
+            -i "$MODEL_W" -l 128 -g 128 -r 5 -w 1 -b 1 -m -1 -v \
+            2>&1 | tee "oga-smoke-results/Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml.txt"
 
       # -----------------------------------------------------------------------
       # L2 accuracy test: compare MorphiZen EP vs CPU output for each model
@@ -941,8 +1013,33 @@ jobs:
                           $ogaRows
           }
 
+          # --- OGA Python wheel smoke (benchmark_e2e.py) results ---
+          $smokeRows = ""
+          foreach ($f in (Get-ChildItem "oga-smoke-results/*.txt" -ErrorAction SilentlyContinue)) {
+            $model = $f.BaseName
+            $content = Get-Content $f.FullName -Raw
+            $ppMatch = [regex]::Match($content, 'Average Prompt Processing Throughput \(per token\):\s+([\d.]+)')
+            $tgMatch = [regex]::Match($content, 'Average Token Generation Throughput \(per token\):\s+([\d.]+)')
+            $wcMatch = [regex]::Match($content, 'Average Wall Clock Throughput:\s+([\d.]+)')
+            $pp = if ($ppMatch.Success) { "{0:F1}" -f [double]$ppMatch.Groups[1].Value } else { "-" }
+            $tg = if ($tgMatch.Success) { "{0:F1}" -f [double]$tgMatch.Groups[1].Value } else { "-" }
+            $wc = if ($wcMatch.Success) { "{0:F1}" -f [double]$wcMatch.Groups[1].Value } else { "-" }
+            if ($tgMatch.Success) {
+              $smokeRows += "| $model | $pp | $tg | $wc |`n"
+            } else {
+              $smokeRows += "| $model | failed | - | - |`n"
+            }
+          }
+          $smokeSection = ""
+          if ($smokeRows) {
+            $smokeSection = "`n## OGA Wheel Smoke (Python benchmark_e2e.py)`n`n" +
+                            "| Model | Prompt Proc (tps) | Token Gen (tps) | Wall Clock (tps) |`n" +
+                            "|-------|----:|----:|----:|`n" +
+                            $smokeRows
+          }
+
           $footer = "`nRun: [${{ github.run_number }}]($runUrl) - Commit: ``$sha``"
-          $summary = $header + $tableRows + $epctxSection + $ogaSection + $footer
+          $summary = $header + $tableRows + $epctxSection + $ogaSection + $smokeSection + $footer
 
           # Always write to step summary and log
           Write-Host $summary

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -488,11 +488,10 @@ jobs:
           retention-days: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release_')) && 14 || 3 }}
 
       # -----------------------------------------------------------------------
-      # Standalone, offline Python wheel package: the three project wheels + the
-      # full ROCm wheel closure (pip-downloaded from repo.amd.com) + run_onnx.py
-      # + OGA's benchmark scripts. Self-contained for ROCm (install offline via
-      # --find-links); only rocm-sdk init expands the devel libs afterwards.
-      # Uploaded as a separate artifact from gpu-test-package.
+      # Python wheel package: the three project wheels + run_onnx.py + OGA
+      # benchmark scripts. ROCm wheels are NOT bundled — they are installed
+      # from repo.amd.com at runtime (CI smoke) or downloaded by the local
+      # package_release.ps1 script when building the offline distribution.
       # -----------------------------------------------------------------------
       - name: Stage Python wheel package
         shell: bash
@@ -512,10 +511,6 @@ jobs:
           cp "$ORT_WHEEL" "$OGA_WHEEL" "$EP_WHEEL" wheelpkg/wheels/
           cp python/examples/run_onnx.py wheelpkg/
           cp "${{ runner.workspace }}/oga-artifacts/benchmark-python/"*.py wheelpkg/
-          # Download EP dependency closure (ROCm) for the wheel package.
-          python -m pip download "$EP_WHEEL" \
-            --extra-index-url https://repo.amd.com/rocm/whl/gfx1151/ \
-            -d wheelpkg/wheels
           echo "=== Python wheel package layout ==="
           find wheelpkg/ -maxdepth 2 -mindepth 1 | sort
 
@@ -779,10 +774,9 @@ jobs:
           exit $failed
 
       # -----------------------------------------------------------------------
-      # OGA wheel smoke: install the wheels from the offline morphizen-python-
-      # package and run OGA's benchmark_e2e.py against a real model. ROCm comes
-      # from the package's bundled TheRock (THEROCK_DIST), so no pip ROCm /
-      # rocm-sdk init is needed. Validates the self-contained wheel package.
+      # OGA wheel smoke: install the project wheels from the morphizen-python-
+      # package artifact + ROCm wheels from repo.amd.com, then run OGA's
+      # benchmark_e2e.py against a real model.
       # -----------------------------------------------------------------------
       # The cp314 ORT/OGA wheels need Python 3.14 to create the smoke venv (the
       # runner's default python may be a different version).
@@ -809,16 +803,13 @@ jobs:
           python -m venv $venv
           $py = "$venv\Scripts\python.exe"
 
-          # Install project + ROCm wheels from local dir; ORT deps from PyPI.
+          # Install project wheels from local dir + ROCm wheels from repo.amd.com.
           Push-Location "$pkg\wheels"
           & $py -m pip install --quiet `
             (Get-Item onnxruntime_directml-*.whl).Name `
             (Get-Item onnxruntime_morphizen_ep-*.whl).Name `
             (Get-Item onnxruntime_genai_directml-*.whl).Name `
-            (Get-Item rocm-*.tar.gz).Name `
-            (Get-Item rocm_sdk_core-*.whl).Name `
-            (Get-Item rocm_sdk_devel-*.whl).Name `
-            (Get-Item rocm_sdk_libraries_*.whl).Name `
+            --extra-index-url https://repo.amd.com/rocm/whl/gfx1151/ `
             psutil tqdm pandas
           Pop-Location
           if ($LASTEXITCODE -ne 0) { Write-Host "[ERROR] wheel install failed"; exit 1 }

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -754,47 +754,46 @@ jobs:
       - name: Run OGA wheel smoke (Python)
         if: always()
         timeout-minutes: 40
-        shell: bash
+        shell: pwsh
         run: |
-          set -euo pipefail
+          $ErrorActionPreference = 'Continue'
+          $PSNativeCommandUseErrorActionPreference = $false
 
-          MODEL_W='${{ runner.workspace }}\oga-models\Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml'
-          if [ ! -d "$(cygpath -u "$MODEL_W")" ]; then echo "[SKIP] model not found: $MODEL_W"; exit 0; fi
+          $model = "${{ runner.workspace }}\oga-models\Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml"
+          if (-not (Test-Path $model)) { Write-Host "[SKIP] model not found: $model"; exit 0 }
 
           # Fresh venv; install per quick_start (ROCm via --extra-index-url).
-          VENV="$PWD/oga-smoke-venv"
-          rm -rf "$VENV"
-          python -m venv "$VENV"
-          PY="$VENV/Scripts/python.exe"
-          cd "$PWD/gpu-test-package/wheels"
-          "$PY" -m pip install --quiet \
-            onnxruntime_directml-*.whl onnxruntime_morphizen_ep-*.whl onnxruntime_genai_directml-*.whl \
-            --extra-index-url https://repo.amd.com/rocm/whl/gfx1151/
-          cd -
-          "$VENV/Scripts/rocm-sdk.exe" init   # expand rocm[devel] import libs
+          $venv = "$PWD\oga-smoke-venv"
+          if (Test-Path $venv) { Remove-Item $venv -Recurse -Force }
+          python -m venv $venv
+          $py = "$venv\Scripts\python.exe"
+          $w = "$PWD\gpu-test-package\wheels"
+          $whls = (Get-ChildItem "$w\onnxruntime_directml-*.whl", "$w\onnxruntime_morphizen_ep-*.whl", "$w\onnxruntime_genai_directml-*.whl").FullName
+          & $py -m pip install --quiet $whls --extra-index-url https://repo.amd.com/rocm/whl/gfx1151/
+          if ($LASTEXITCODE -ne 0) { Write-Host "[ERROR] wheel install failed"; exit 1 }
+          & "$venv\Scripts\rocm-sdk.exe" init   # expand rocm[devel] import libs
+          if ($LASTEXITCODE -ne 0) { Write-Host "[ERROR] rocm-sdk init failed"; exit 1 }
 
-          # LIB/THEROCK_DIST feed the native JIT linker (MSYS does not convert
-          # them) -> Windows paths; PATH stays POSIX (MSYS converts it).
-          SP="$VENV/Lib/site-packages"
-          CAPI="$SP/onnxruntime/capi"
-          export THEROCK_DIST="$(cygpath -w "$SP/_rocm_sdk_devel")"
-          export LIB="$(cygpath -w "$CAPI")"
-          PATH="$CAPI:$PATH"
-          for d in "$SP"/_rocm_sdk_*/bin; do
-            [ -d "$d" ] && PATH="$d:$PATH"
-          done
-          export PATH
+          # THEROCK_DIST -> ROCm import libs; LIB -> capi (CRT + custom kernels);
+          # PATH -> capi (EP + hip-compiler) + rocm bins (runtime DLLs).
+          $sp = "$venv\Lib\site-packages"
+          $capi = "$sp\onnxruntime\capi"
+          $env:THEROCK_DIST = "$sp\_rocm_sdk_devel"
+          $env:LIB = $capi
+          $rocmBins = (Get-ChildItem $sp -Directory -Filter "_rocm_sdk_*" |
+            ForEach-Object { "$($_.FullName)\bin" } | Where-Object { Test-Path $_ }) -join ";"
+          $env:PATH = "$capi;$rocmBins;$env:PATH"
 
-          "$PY" -m pip install --quiet psutil tqdm   # benchmark_e2e.py deps
+          & $py -m pip install --quiet psutil tqdm   # benchmark_e2e.py deps
 
           # -e follow_config reads the provider from genai_config.json (populated
-          # by the OGA benchmark step above from genai_config_128.json). tee the
-          # output so the publish step can extract throughput (pipefail keeps the
-          # benchmark's exit status).
-          mkdir -p oga-smoke-results
-          "$PY" "$PWD/gpu-test-package/benchmark/benchmark_e2e.py" \
-            -i "$MODEL_W" -l 128 -g 128 -r 5 -w 1 -b 1 -m -1 -v \
-            2>&1 | tee "oga-smoke-results/Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml.txt"
+          # by the OGA benchmark step above from genai_config_128.json). Tee the
+          # output so the publish step can extract throughput.
+          New-Item -ItemType Directory -Force -Path oga-smoke-results | Out-Null
+          & $py "$PWD\gpu-test-package\benchmark\benchmark_e2e.py" `
+            -i $model -l 128 -g 128 -r 5 -w 1 -b 1 -m -1 -v `
+            2>&1 | Tee-Object -FilePath "oga-smoke-results\Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml.txt"
+          exit $LASTEXITCODE
 
       # -----------------------------------------------------------------------
       # L2 accuracy test: compare MorphiZen EP vs CPU output for each model

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -512,12 +512,10 @@ jobs:
           cp "$ORT_WHEEL" "$OGA_WHEEL" "$EP_WHEEL" wheelpkg/wheels/
           cp python/examples/run_onnx.py wheelpkg/
           cp "${{ runner.workspace }}/oga-artifacts/benchmark-python/"*.py wheelpkg/benchmark/
-          # Download dependency closures for offline install: EP (-> ROCm),
-          # plus ORT/OGA third-party deps and benchmark deps. setuptools is
-          # needed as a build dep for the rocm sdist.
+          # Download EP dependency closure (ROCm) + ORT third-party deps for
+          # offline install. setuptools is a build dep for the rocm sdist.
           python -m pip download "$EP_WHEEL" \
-            flatbuffers numpy packaging protobuf coloredlogs \
-            psutil tqdm pandas setuptools \
+            flatbuffers numpy packaging protobuf coloredlogs setuptools \
             --extra-index-url https://repo.amd.com/rocm/whl/gfx1151/ \
             -d wheelpkg/wheels
           echo "=== Python wheel package layout ==="
@@ -813,9 +811,11 @@ jobs:
           python -m venv $venv
           $py = "$venv\Scripts\python.exe"
 
-          # Install fully offline from the bundled wheel closure.
+          # Install project + ROCm wheels offline; benchmark deps from PyPI.
           $whls = (Get-ChildItem "$pkg\wheels\onnxruntime_directml-*.whl", "$pkg\wheels\onnxruntime_morphizen_ep-*.whl", "$pkg\wheels\onnxruntime_genai_directml-*.whl").FullName
-          & $py -m pip install --quiet --no-index --find-links "$pkg\wheels" $whls psutil tqdm pandas
+          & $py -m pip install --quiet --no-index --find-links "$pkg\wheels" $whls
+          if ($LASTEXITCODE -ne 0) { Write-Host "[ERROR] wheel install failed"; exit 1 }
+          & $py -m pip install --quiet psutil tqdm pandas
           if ($LASTEXITCODE -ne 0) { Write-Host "[ERROR] wheel install failed"; exit 1 }
           & "$venv\Scripts\rocm-sdk.exe" init   # expand rocm[devel] import libs
           if ($LASTEXITCODE -ne 0) { Write-Host "[ERROR] rocm-sdk init failed"; exit 1 }

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -497,7 +497,7 @@ jobs:
       - name: Stage Python wheel package
         shell: bash
         run: |
-          mkdir -p wheelpkg/wheels wheelpkg/benchmark
+          mkdir -p wheelpkg/wheels
           ORT_WHEEL=$(find "${{ runner.workspace }}/ort-install/wheels" \
             -name "onnxruntime_directml-*.whl" -type f | head -1)
           OGA_WHEEL=$(find "${{ runner.workspace }}/oga-artifacts" \
@@ -511,7 +511,7 @@ jobs:
           fi
           cp "$ORT_WHEEL" "$OGA_WHEEL" "$EP_WHEEL" wheelpkg/wheels/
           cp python/examples/run_onnx.py wheelpkg/
-          cp "${{ runner.workspace }}/oga-artifacts/benchmark-python/"*.py wheelpkg/benchmark/
+          cp "${{ runner.workspace }}/oga-artifacts/benchmark-python/"*.py wheelpkg/
           # Download EP dependency closure (ROCm) for the wheel package.
           python -m pip download "$EP_WHEEL" \
             --extra-index-url https://repo.amd.com/rocm/whl/gfx1151/ \
@@ -825,21 +825,10 @@ jobs:
           & "$venv\Scripts\rocm-sdk.exe" init   # expand rocm[devel] import libs
           if ($LASTEXITCODE -ne 0) { Write-Host "[ERROR] rocm-sdk init failed"; exit 1 }
 
-          # THEROCK_DIST -> rocm[devel]; LIB -> capi (CRT + custom kernels);
-          # PATH -> capi (EP + hip-compiler) + rocm runtime bins.
-          $sp = "$venv\Lib\site-packages"
-          $capi = "$sp\onnxruntime\capi"
-          $env:THEROCK_DIST = "$sp\_rocm_sdk_devel"
-          $env:LIB = $capi
-          $rocmBins = (Get-ChildItem $sp -Directory -Filter "_rocm_sdk_*" |
-            ForEach-Object { "$($_.FullName)\bin" } | Where-Object { Test-Path $_ }) -join ";"
-          $env:PATH = "$capi;$rocmBins;$env:PATH"
-
-          # -e follow_config reads the provider from genai_config.json (populated
-          # by the OGA benchmark step above from genai_config_128.json). Tee the
-          # output so the publish step can extract throughput.
+          # run_onnx.py --benchmark sets up env (THEROCK_DIST/LIB/PATH) from the
+          # installed wheels, then delegates to benchmark_e2e.py.
           New-Item -ItemType Directory -Force -Path oga-smoke-results | Out-Null
-          & $py "$pkg\benchmark\benchmark_e2e.py" `
+          & $py "$pkg\run_onnx.py" --benchmark "$pkg\benchmark_e2e.py" `
             -i $model -l 128 -g 128 -r 5 -w 1 -b 1 -m -1 -v `
             2>&1 | Tee-Object -FilePath "oga-smoke-results\Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml.txt"
           exit $LASTEXITCODE

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -751,6 +751,14 @@ jobs:
       # THEROCK_DIST=_rocm_sdk_devel, LIB=capi, PATH=capi + rocm bins). Validates
       # the documented end-user wheel flow end to end.
       # -----------------------------------------------------------------------
+      # The cp314 ORT/OGA wheels need Python 3.14 to create the smoke venv (the
+      # runner's default python may be a different version).
+      - name: Setup Python 3.14 (wheel smoke)
+        if: always()
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        with:
+          python-version: "3.14"
+
       - name: Run OGA wheel smoke (Python)
         if: always()
         timeout-minutes: 40

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -513,9 +513,11 @@ jobs:
           cp python/examples/run_onnx.py wheelpkg/
           cp "${{ runner.workspace }}/oga-artifacts/benchmark-python/"*.py wheelpkg/benchmark/
           # Download dependency closures for offline install: EP (-> ROCm),
-          # plus ORT/OGA third-party deps (flatbuffers etc.) and benchmark deps.
+          # plus ORT/OGA third-party deps and benchmark deps. setuptools is
+          # needed as a build dep for the rocm sdist.
           python -m pip download "$EP_WHEEL" \
-            flatbuffers numpy packaging protobuf coloredlogs psutil tqdm pandas \
+            flatbuffers numpy packaging protobuf coloredlogs \
+            psutil tqdm pandas setuptools \
             --extra-index-url https://repo.amd.com/rocm/whl/gfx1151/ \
             -d wheelpkg/wheels
           echo "=== Python wheel package layout ==="

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ option(BUILD_EP "Build the ONNX HIP DNN Execution Provider" OFF)
 option(BUILD_HIP_TOOLS "Build HIP MLIR compiler tools (hip-mlir-opt, hip-compiler)" OFF)
 option(BUILD_MOCK_RUNTIME "Build mock runtime (no GPU required)" ON)
 option(BUILD_HIP_UNIT_TESTS "Build and register LIT and E2E tests with CTest" ON)
+option(BUILD_PYTHON_WHEEL "Configure the 'wheel' target that packages the EP as a Python wheel" OFF)
 
 # Centralized dependency resolution. Always included; internally partitions by
 # BUILD_EP / BUILD_HIP_TOOLS so a tools-only tree (BUILD_EP=OFF) still gets the
@@ -147,4 +148,11 @@ if(BUILD_HIP_TOOLS)
     # Runtime unit tests (GPU-free; native against mock types)
     add_subdirectory(test/runtime)
   endif()
+endif()
+
+# Python wheel packaging (opt-in; defines the 'wheel' target). Added last so
+# both the EP target (morphizen_CORE_DYNAMIC_UNIQUE_ID, from deps.cmake) and the
+# JIT compiler plugin target (hip-compiler-dll, from BUILD_HIP_TOOLS) exist.
+if(BUILD_EP AND BUILD_PYTHON_WHEEL)
+  add_subdirectory(python)
 endif()

--- a/build.py
+++ b/build.py
@@ -243,6 +243,10 @@ def generate_build_tree(args, build_dir, prefix_paths, hip_arch, mock):
         "-DBUILD_EP=ON",
         "-DBUILD_HIP_TOOLS=ON",
     ]
+    # Build the Python wheel by default for real builds; mock has no ROCm libs
+    # to bundle, and --skip_wheel opts out.
+    if not mock and not args.skip_wheel:
+        cmd.append("-DBUILD_PYTHON_WHEEL=ON")
     if prefix_paths:
         # CMAKE_PREFIX_PATH always uses ';' as the list separator.
         cmd.append("-DCMAKE_PREFIX_PATH=" + ";".join(prefix_paths))
@@ -390,6 +394,11 @@ def parse_arguments():
     )
     p.add_argument(
         "--skip_build", action="store_true", help="configure only; do not build/install"
+    )
+    p.add_argument(
+        "--skip_wheel",
+        action="store_true",
+        help="do not build the Python wheel (built by default for real builds)",
     )
     p.add_argument(
         "--skip_tests",

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -280,17 +280,57 @@ below. `onnxruntime_perf_test.exe` is staged separately in
 ### 4. Install Python Wheels (Optional)
 
 If you also want to drive ORT / OGA from Python (e.g. to write your own
-generation script instead of using `model_benchmark.exe`), install the two
-wheels produced by steps 1 and 3:
+generation script instead of using `model_benchmark.exe`), install the wheels.
+The MorphiZen EP wheel is built by default by `build.py` (pass `--skip_wheel` to
+opt out, or build just it with `cmake --build <build> --target wheel`) at
+`../build/onnx-hipdnn-ep/python/dist/`.
+
+**Install** -- give ORT / EP / OGA as local `.whl` files (so pip uses your custom
+builds, not the stock PyPI ones), and let `--extra-index-url` resolve ROCm:
 
 ```bash
 cd ../onnx-hipdnn-ep  # Back to the project root
 pip install \
   ../build/onnxruntime/Release/dist/onnxruntime_directml-*.whl \
-  ../build/onnxruntime-genai/Release/wheel/onnxruntime_genai_directml-*.whl
+  ../build/onnx-hipdnn-ep/python/dist/onnxruntime_morphizen_ep-*.whl \
+  ../build/onnxruntime-genai/Release/wheel/onnxruntime_genai_directml-*.whl \
+  --extra-index-url https://repo.amd.com/rocm/whl/gfx1151/
 ```
-> **Note**: the first whl file may be in  ../build/onnxruntime/Release/Release/dist/
->  Try this path if you meet error "the file does not exist"
+> **Note**: the ORT whl may be under `../build/onnxruntime/Release/Release/dist/`.
+> Replace `gfx1151` with your GPU arch. Install the EP wheel AFTER onnxruntime:
+> it ships its own native files (EP plugin, hip-compiler, custom kernels, CRT
+> import libs) straight into `onnxruntime/capi/` next to `onnxruntime.dll`. The
+> ROCm JIT import libs (amdhip64/MIOpen/hipBLASLt) come from the `rocm[devel]`
+> wheel (expanded next).
+
+**Expand ROCm devel** -- the EP's JIT linker needs the ROCm import libs, which
+`rocm[devel]` ships compressed. Expand them once:
+
+```bash
+rocm-sdk init   # populates site-packages/_rocm_sdk_devel/lib
+```
+
+**Lib search paths** -- the per-model JIT link step resolves import libs from two
+places, supplied via env vars before running:
+
+- `THEROCK_DIST` -> the ROCm lib root (`<site-packages>/_rocm_sdk_devel`, or a
+  TheRock SDK for dev builds); supplies `amdhip64`/`MIOpen`/`hipBLASLt`.
+- `LIB` (Windows) -> append `<onnxruntime/capi>`; supplies the colocated CRT and
+  `hip_custom_kernels` import libs.
+
+**Use** -- there is no Python API to import. For OGA, just set the decoder's
+provider to `MorphiZenEP` in `genai_config.json` (or `config.append_provider("MorphiZenEP")`)
+and run OGA's own scripts unchanged -- OGA discovers the colocated EP
+automatically. For plain ORT, register the colocated plugin via
+`ort.register_execution_provider_library("MorphiZenEP", <onnxruntime/capi>/onnxruntime_morphizen_ep.dll)`.
+
+**PATH** -- the ROCm runtime DLLs are not auto-loaded; add the EP dir and the
+ROCm bin dirs to `PATH` before running (rocm dirs come from the `rocm` wheels):
+
+```bash
+python -c "import onnxruntime, os; print(os.path.join(os.path.dirname(onnxruntime.__file__), 'capi'))"
+# add that capi dir + the rocm-sdk bin dirs to PATH
+```
 
 Verify:
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -318,26 +318,32 @@ places, supplied via env vars before running:
 - `LIB` (Windows) -> append `<onnxruntime/capi>`; supplies the colocated CRT and
   `hip_custom_kernels` import libs.
 
-**Use** -- there is no Python API to import. For OGA, just set the decoder's
-provider to `MorphiZenEP` in `genai_config.json` (or `config.append_provider("MorphiZenEP")`)
-and run OGA's own scripts unchanged -- OGA discovers the colocated EP
+**Use** -- there is no Python API to import; the native files are found by
+location. Set the env vars and run a model whose `genai_config.json` names the
+provider `MorphiZenEP`. This is exactly what the CI wheel smoke does (`Run OGA
+wheel smoke (Python)` in `.github/workflows/windows-build.yml`):
+
+```bash
+# site-packages root + the colocated capi dir
+SP=$(python -c "import onnxruntime, os; print(os.path.dirname(os.path.dirname(onnxruntime.__file__)))")
+CAPI="$SP/onnxruntime/capi"
+
+# JIT link: ROCm import libs from rocm[devel]; CRT + custom kernels from capi
+export THEROCK_DIST="$SP/_rocm_sdk_devel"
+export LIB="$CAPI"                      # Windows; ';'-separated if appending
+# Runtime DLLs: EP + hip-compiler (capi) and ROCm (rocm wheel bins) on PATH
+# (replace gfx1151 with your GPU arch)
+export PATH="$CAPI:$SP/_rocm_sdk_core/bin:$SP/_rocm_sdk_libraries_gfx1151/bin:$PATH"
+
+# Run OGA's own end-to-end benchmark from the OGA source cloned in step 3
+python onnxruntime-genai/benchmark/python/benchmark_e2e.py \
+  -i /path/to/model_dir -l 128 -g 128 -r 5 -w 1 -b 1 -m -1 -v
+```
+
+`benchmark_e2e.py` runs with the default `-e follow_config`, so the model's
+`genai_config.json` must list `MorphiZenEP`; OGA then discovers the colocated EP
 automatically. For plain ORT, register the colocated plugin via
-`ort.register_execution_provider_library("MorphiZenEP", <onnxruntime/capi>/onnxruntime_morphizen_ep.dll)`.
-
-**PATH** -- the ROCm runtime DLLs are not auto-loaded; add the EP dir and the
-ROCm bin dirs to `PATH` before running (rocm dirs come from the `rocm` wheels):
-
-```bash
-python -c "import onnxruntime, os; print(os.path.join(os.path.dirname(onnxruntime.__file__), 'capi'))"
-# add that capi dir + the rocm-sdk bin dirs to PATH
-```
-
-Verify:
-
-```bash
-python -c "import onnxruntime as ort; print(ort.__version__)"
-python -c "import onnxruntime_genai as og; print(og.__version__)"
-```
+`ort.register_execution_provider_library("MorphiZenEP", "$CAPI/onnxruntime_morphizen_ep.dll")`.
 
 ## Model Preparation
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,0 +1,107 @@
+##
+# ** Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# ** Licensed under the MIT License.
+##
+
+if(NOT BUILD_EP)
+  message(WARNING "BUILD_PYTHON_WHEEL requires BUILD_EP=ON; skipping wheel target")
+  return()
+endif()
+
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
+
+# Build out-of-source: never write into the source python/ tree. The package is
+# staged under the build dir, the wheel lands in <build>/python/dist.
+set(_pkg_src "${CMAKE_CURRENT_SOURCE_DIR}")
+set(_stage "${CMAKE_CURRENT_BINARY_DIR}/pkg")
+# Native artifacts are staged into the onnxruntime/capi namespace package so the
+# wheel ships them at onnxruntime/capi/ (platlib), installing next to
+# onnxruntime.dll cross-platform.
+set(_libs_dir "${_stage}/onnxruntime/capi")
+set(_dist_dir "${CMAKE_CURRENT_BINARY_DIR}/dist")
+
+# GPU arch this wheel targets, for the rocm --extra-index-url hint in
+# pyproject.toml. Take the first if HIP_ARCHITECTURES is a list; fall back to
+# gfx1151 when unset (e.g. mock builds).
+set(MORPHIZEN_HIP_ARCH "${HIP_ARCHITECTURES}")
+if(MORPHIZEN_HIP_ARCH MATCHES ";")
+  list(GET MORPHIZEN_HIP_ARCH 0 MORPHIZEN_HIP_ARCH)
+endif()
+if(NOT MORPHIZEN_HIP_ARCH)
+  set(MORPHIZEN_HIP_ARCH "gfx1151")
+endif()
+
+# Inject the project version + target arch into the staged pyproject.toml.
+configure_file(
+  "${_pkg_src}/pyproject.toml.in"
+  "${_stage}/pyproject.toml"
+  @ONLY)
+
+# The EP shared library target is created by morphizen via deps.cmake; its name
+# is the (git-versioned) unique id, output name onnxruntime_morphizen_ep.
+set(_ep_target "${morphizen_CORE_DYNAMIC_UNIQUE_ID}")
+if(NOT TARGET ${_ep_target})
+  message(FATAL_ERROR
+    "EP target '${_ep_target}' not found; cannot build the Python wheel.")
+endif()
+
+# The JIT compiler plugin (hip-compiler.dll) is loaded at runtime by the EP via
+# Plugin::get("hip-compiler"); it MUST ship in the wheel or model compilation
+# falls back to whatever (possibly stale) hip-compiler is on PATH.
+set(_dll_args "--dll" "$<TARGET_FILE:${_ep_target}>")
+set(_wheel_deps ${_ep_target})
+if(TARGET hip-compiler-dll)
+  list(APPEND _dll_args "--dll" "$<TARGET_FILE:hip-compiler-dll>")
+  list(APPEND _wheel_deps hip-compiler-dll)
+else()
+  message(WARNING
+    "hip-compiler-dll target not found (BUILD_HIP_TOOLS=OFF?); the wheel will "
+    "not be able to JIT-compile models. Build with BUILD_HIP_TOOLS=ON.")
+endif()
+
+if(WIN32)
+  set(_with_crt "--with-crt")
+else()
+  set(_with_crt "")
+endif()
+
+# Bundle the project's own custom-kernels import lib. ROCm import libs
+# (amdhip64/MIOpen/hipBLASLt) are supplied at runtime from the pip rocm[devel]
+# package (or THEROCK_DIST).
+set(_extra_lib_args "")
+if(TARGET hip_custom_kernels)
+  set(_extra_lib_args --extra-lib "$<TARGET_FILE:hip_custom_kernels>")
+  list(APPEND _wheel_deps hip_custom_kernels)
+endif()
+
+add_custom_target(wheel ALL
+  # 1. Stage the package sources into the build dir (keep source tree clean).
+  COMMAND ${CMAKE_COMMAND} -E copy_directory
+          "${_pkg_src}/onnxruntime_morphizen_ep"
+          "${_stage}/onnxruntime_morphizen_ep"
+  COMMAND ${CMAKE_COMMAND} -E copy
+          "${_pkg_src}/setup.py"
+          "${_stage}/"
+  # 2. Stage native artifacts (EP lib + hip-compiler + custom-kernels/CRT import
+  #    libs) into the onnxruntime/capi namespace package dir so the wheel ships
+  #    them at onnxruntime/capi/ (platlib).
+  COMMAND ${CMAKE_COMMAND} -E rm -rf "${_libs_dir}"
+  COMMAND ${Python3_EXECUTABLE} "${_pkg_src}/_pack_libs.py"
+          ${_dll_args}
+          --dest "${_libs_dir}"
+          ${_extra_lib_args}
+          ${_with_crt}
+  # 3. Build the wheel (PEP 517). Drop setuptools' build cache + egg-info first:
+  #    they linger across runs and would re-pack stale (e.g. removed) artifacts.
+  #    --no-deps: do not pull deps here.
+  COMMAND ${CMAKE_COMMAND} -E rm -rf
+          "${_stage}/build" "${_stage}/onnxruntime_morphizen_ep.egg-info"
+  COMMAND ${CMAKE_COMMAND} -E rm -rf "${_dist_dir}"
+  COMMAND ${Python3_EXECUTABLE} -m pip wheel "${_stage}"
+          --no-deps --wheel-dir "${_dist_dir}"
+  DEPENDS ${_wheel_deps}
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+  COMMENT "Building onnxruntime_morphizen_ep wheel -> ${_dist_dir}"
+  VERBATIM)
+
+message(STATUS "Python wheel target 'wheel' configured (out: ${_dist_dir})")

--- a/python/_pack_libs.py
+++ b/python/_pack_libs.py
@@ -1,0 +1,117 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""Build helper: stage native artifacts into the wheel's onnxruntime/capi.
+
+Invoked by python/CMakeLists.txt's `wheel` target (NOT shipped at runtime).
+Copies the prebuilt native libraries and, on Windows, the MSVC/WinSDK CRT import
+libraries the JIT linker (lld-link) resolves against. The CRT libs are located
+by scanning the `LIB` environment variable, which the VS dev environment / MSVC
+toolset populates with the MSVC and WinSDK lib directories.
+"""
+
+import argparse
+import os
+import shutil
+import sys
+from pathlib import Path
+
+# CRT/WinSDK import libraries the per-model lld-link step needs (the same set
+# the project's runtime lib setup stages for lld-link).
+CRT_LIBS = [
+    "msvcrt.lib",
+    "vcruntime.lib",
+    "oldnames.lib",
+    "libcpmt.lib",
+    "libcmt.lib",
+    "ucrt.lib",
+    "kernel32.lib",
+    "user32.lib",
+]
+
+
+def _find_in_lib_env(name: str):
+    for d in os.environ.get("LIB", "").split(os.pathsep):
+        if not d:
+            continue
+        cand = Path(d) / name
+        if cand.is_file():
+            return cand
+    return None
+
+
+def _copy_crt_libs(dest: Path) -> int:
+    missing = []
+    for name in CRT_LIBS:
+        src = _find_in_lib_env(name)
+        if src is None:
+            missing.append(name)
+            continue
+        shutil.copy2(src, dest / name)
+        print(f"  packaged CRT lib: {name} <- {src}")
+    if missing:
+        print(
+            "  WARNING: CRT import libs not found on %LIB%: "
+            + ", ".join(missing)
+            + "\n  Run the wheel build from a VS dev environment (LIB set), "
+            "or the JIT linker will fail at inference time."
+        )
+    return len(missing)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--dll",
+        action="append",
+        required=True,
+        metavar="PATH",
+        help="Path to a native library to bundle (repeatable). The EP plugin "
+        "library and its JIT compiler plugin (hip-compiler) are both required.",
+    )
+    ap.add_argument(
+        "--dest", required=True, help="Destination dir (the wheel's onnxruntime/capi)."
+    )
+    ap.add_argument(
+        "--extra-lib",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help="Additional import library to bundle (repeatable), e.g. "
+        "hip_custom_kernels.lib.",
+    )
+    ap.add_argument(
+        "--with-crt",
+        action="store_true",
+        help="Also copy MSVC/WinSDK CRT import libs (Windows).",
+    )
+    args = ap.parse_args()
+
+    dest = Path(args.dest)
+    dest.mkdir(parents=True, exist_ok=True)
+
+    for raw in args.dll:
+        lib = Path(raw)
+        if not lib.is_file():
+            print(f"ERROR: library not found: {lib}", file=sys.stderr)
+            return 1
+        shutil.copy2(lib, dest / lib.name)
+        print(f"  packaged library: {lib.name} <- {lib}")
+
+    for raw in args.extra_lib:
+        lib = Path(raw)
+        if lib.is_file():
+            shutil.copy2(lib, dest / lib.name)
+            print(f"  packaged import lib: {lib.name} <- {lib}")
+        else:
+            print(f"  WARNING: extra import lib not found: {lib}")
+
+    if args.with_crt:
+        _copy_crt_libs(dest)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/examples/run_onnx.py
+++ b/python/examples/run_onnx.py
@@ -2,12 +2,12 @@
 # Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 # Licensed under the MIT License.
 #
-"""Minimal standalone example: run an ONNX model on the MorphiZen EP.
+"""Run an ONNX model or OGA benchmark on the MorphiZen EP.
 
-Registers the wheel-colocated MorphiZen EP plugin, builds a session over the
-discovered AMD device, feeds random inputs, and prints the output shapes. All
-the JIT-link / runtime-DLL environment (THEROCK_DIST / LIB / DLL dirs) is wired
-up from the installed wheels by this script -- no manual env setup needed.
+Sets up the JIT-link / runtime-DLL environment (THEROCK_DIST / LIB / DLL dirs)
+from the installed wheels, then either:
+  - Runs a plain ONNX model with random inputs (default), or
+  - Delegates to benchmark_e2e.py for OGA benchmarks (--benchmark).
 
 Prerequisites (see docs/python_package_guide.md):
   - pip install the onnxruntime + onnxruntime_morphizen_ep wheels
@@ -15,10 +15,12 @@ Prerequisites (see docs/python_package_guide.md):
 
 Usage:
   python run_onnx.py path/to/model.onnx
+  python run_onnx.py --benchmark benchmark_e2e.py -i model_dir [args...]
 """
 
 import glob
 import os
+import subprocess
 import sys
 
 import numpy as np
@@ -26,7 +28,6 @@ import onnxruntime as ort
 
 EP_NAME = "MorphiZenEP"
 
-# ORT tensor type string -> numpy dtype (common cases).
 _NP_DTYPE = {
     "tensor(float)": np.float32,
     "tensor(float16)": np.float16,
@@ -40,19 +41,12 @@ _NP_DTYPE = {
 
 
 def _setup_env():
-    # Everything is derived from the installed onnxruntime location; no external
-    # env vars required. site-packages = .../onnxruntime/.. ; the EP native files
-    # live in onnxruntime/capi and pip rocm in _rocm_sdk_* siblings.
     sp = os.path.dirname(os.path.dirname(ort.__file__))
     capi = os.path.join(sp, "onnxruntime", "capi")
 
-    # JIT link inputs: ROCm import libs (rocm[devel]) + CRT/custom kernels (capi).
     os.environ["THEROCK_DIST"] = os.path.join(sp, "_rocm_sdk_devel")
     os.environ["LIB"] = os.pathsep.join(filter(None, [capi, os.environ.get("LIB", "")]))
 
-    # Runtime DLLs: EP + hip-compiler (capi) + ROCm runtime (rocm wheel bins).
-    # The EP loads hip-compiler.dll by name via PATH, so prepend these dirs to
-    # PATH (and register them as DLL dirs for ORT's own loader).
     dll_dirs = [
         d
         for d in [capi, *glob.glob(os.path.join(sp, "_rocm_sdk_*", "bin"))]
@@ -66,7 +60,6 @@ def _setup_env():
 
 def _random_input(spec):
     dtype = _NP_DTYPE.get(spec.type, np.float32)
-    # Replace dynamic / symbolic dims (None or str) with 1.
     shape = [d if isinstance(d, int) and d > 0 else 1 for d in spec.shape]
     if np.issubdtype(dtype, np.floating):
         return np.random.rand(*shape).astype(dtype)
@@ -75,14 +68,7 @@ def _random_input(spec):
     return np.random.randint(0, 2, size=shape).astype(dtype)
 
 
-def main():
-    if len(sys.argv) != 2:
-        print(f"usage: python {os.path.basename(__file__)} model.onnx", file=sys.stderr)
-        return 2
-    model_path = sys.argv[1]
-
-    capi = _setup_env()
-
+def _run_onnx(model_path, capi):
     ort.register_execution_provider_library(
         EP_NAME, os.path.join(capi, "onnxruntime_morphizen_ep.dll")
     )
@@ -106,6 +92,23 @@ def main():
     for spec, value in zip(sess.get_outputs(), outputs):
         print(f"output {spec.name}: shape={value.shape} dtype={value.dtype}")
     return 0
+
+
+def main():
+    if len(sys.argv) >= 3 and sys.argv[1] == "--benchmark":
+        _setup_env()
+        return subprocess.call([sys.executable, *sys.argv[2:]])
+
+    if len(sys.argv) != 2:
+        print(f"usage: python {os.path.basename(__file__)} model.onnx", file=sys.stderr)
+        print(
+            f"       python {os.path.basename(__file__)} --benchmark benchmark_e2e.py [args...]",
+            file=sys.stderr,
+        )
+        return 2
+
+    capi = _setup_env()
+    return _run_onnx(sys.argv[1], capi)
 
 
 if __name__ == "__main__":

--- a/python/examples/run_onnx.py
+++ b/python/examples/run_onnx.py
@@ -1,0 +1,112 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""Minimal standalone example: run an ONNX model on the MorphiZen EP.
+
+Registers the wheel-colocated MorphiZen EP plugin, builds a session over the
+discovered AMD device, feeds random inputs, and prints the output shapes. All
+the JIT-link / runtime-DLL environment (THEROCK_DIST / LIB / DLL dirs) is wired
+up from the installed wheels by this script -- no manual env setup needed.
+
+Prerequisites (see docs/python_package_guide.md):
+  - pip install the onnxruntime + onnxruntime_morphizen_ep wheels
+  - rocm-sdk init        (expands rocm[devel] import libs)
+
+Usage:
+  python run_onnx.py path/to/model.onnx
+"""
+
+import glob
+import os
+import sys
+
+import numpy as np
+import onnxruntime as ort
+
+EP_NAME = "MorphiZenEP"
+
+# ORT tensor type string -> numpy dtype (common cases).
+_NP_DTYPE = {
+    "tensor(float)": np.float32,
+    "tensor(float16)": np.float16,
+    "tensor(double)": np.float64,
+    "tensor(int64)": np.int64,
+    "tensor(int32)": np.int32,
+    "tensor(int8)": np.int8,
+    "tensor(uint8)": np.uint8,
+    "tensor(bool)": np.bool_,
+}
+
+
+def _setup_env():
+    # Everything is derived from the installed onnxruntime location; no external
+    # env vars required. site-packages = .../onnxruntime/.. ; the EP native files
+    # live in onnxruntime/capi and pip rocm in _rocm_sdk_* siblings.
+    sp = os.path.dirname(os.path.dirname(ort.__file__))
+    capi = os.path.join(sp, "onnxruntime", "capi")
+
+    # JIT link inputs: ROCm import libs (rocm[devel]) + CRT/custom kernels (capi).
+    os.environ["THEROCK_DIST"] = os.path.join(sp, "_rocm_sdk_devel")
+    os.environ["LIB"] = os.pathsep.join(filter(None, [capi, os.environ.get("LIB", "")]))
+
+    # Runtime DLLs: EP + hip-compiler (capi) + ROCm runtime (rocm wheel bins).
+    # The EP loads hip-compiler.dll by name via PATH, so prepend these dirs to
+    # PATH (and register them as DLL dirs for ORT's own loader).
+    dll_dirs = [
+        d
+        for d in [capi, *glob.glob(os.path.join(sp, "_rocm_sdk_*", "bin"))]
+        if os.path.isdir(d)
+    ]
+    os.environ["PATH"] = os.pathsep.join([*dll_dirs, os.environ.get("PATH", "")])
+    for d in dll_dirs:
+        os.add_dll_directory(d)
+    return capi
+
+
+def _random_input(spec):
+    dtype = _NP_DTYPE.get(spec.type, np.float32)
+    # Replace dynamic / symbolic dims (None or str) with 1.
+    shape = [d if isinstance(d, int) and d > 0 else 1 for d in spec.shape]
+    if np.issubdtype(dtype, np.floating):
+        return np.random.rand(*shape).astype(dtype)
+    if dtype == np.bool_:
+        return np.random.randint(0, 2, size=shape).astype(np.bool_)
+    return np.random.randint(0, 2, size=shape).astype(dtype)
+
+
+def main():
+    if len(sys.argv) != 2:
+        print(f"usage: python {os.path.basename(__file__)} model.onnx", file=sys.stderr)
+        return 2
+    model_path = sys.argv[1]
+
+    capi = _setup_env()
+
+    ort.register_execution_provider_library(
+        EP_NAME, os.path.join(capi, "onnxruntime_morphizen_ep.dll")
+    )
+
+    devices = [d for d in ort.get_ep_devices() if d.ep_name == EP_NAME]
+    if not devices:
+        print(f"ERROR: no {EP_NAME} device found", file=sys.stderr)
+        return 1
+    print(f"{EP_NAME} device(s): {len(devices)} ({[d.ep_vendor for d in devices]})")
+
+    so = ort.SessionOptions()
+    so.add_session_config_entry("session.disable_cpu_ep_fallback", "1")
+    so.add_provider_for_devices(devices, {})
+
+    sess = ort.InferenceSession(model_path, sess_options=so)
+    print(f"providers: {sess.get_providers()}")
+
+    feeds = {i.name: _random_input(i) for i in sess.get_inputs()}
+    outputs = sess.run(None, feeds)
+
+    for spec, value in zip(sess.get_outputs(), outputs):
+        print(f"output {spec.name}: shape={value.shape} dtype={value.dtype}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/onnxruntime_morphizen_ep/__init__.py
+++ b/python/onnxruntime_morphizen_ep/__init__.py
@@ -1,0 +1,26 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""MorphiZen Execution Provider for ONNX Runtime -- packaging marker.
+
+This distribution carries no Python API and no payload in this package. Its
+native artifacts (the EP plugin ``onnxruntime_morphizen_ep.dll``, its
+hip-compiler JIT plugin, and the custom-kernels + CRT import libraries the JIT
+linker resolves) are installed directly into ``onnxruntime/capi/`` -- next to
+``onnxruntime.dll`` -- by the wheel. The ROCm import libraries come from
+``rocm[devel]``.
+
+Install this wheel AFTER ``onnxruntime`` so ``onnxruntime/capi/`` exists. Then:
+
+- ONNX Runtime GenAI (OGA) discovers and registers the EP automatically (it
+  searches next to ``onnxruntime.dll``); reference it by the provider name
+  ``MorphiZenEP`` in genai_config.
+- ONNX Runtime: register the colocated plugin, e.g.
+  ``ort.register_execution_provider_library("MorphiZenEP",
+  <onnxruntime capi>/onnxruntime_morphizen_ep.dll)``.
+
+At inference the JIT linker needs the ROCm import libs (from ``rocm[devel]`` via
+``THEROCK_DIST``) and ``onnxruntime/capi`` on ``LIB``; ROCm runtime DLLs must be
+on ``PATH`` (e.g. from ``rocm[libraries]``).
+"""

--- a/python/pyproject.toml.in
+++ b/python/pyproject.toml.in
@@ -1,0 +1,45 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+# Template consumed by python/CMakeLists.txt via configure_file: @PROJECT_VERSION@
+# is substituted at configure time. Do not edit the generated pyproject.toml.
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "onnxruntime_morphizen_ep"
+version = "@PROJECT_VERSION@"
+description = "MorphiZen Execution Provider for ONNX Runtime (AMD GPU via HIP/ROCm)"
+requires-python = ">=3.8"
+license = { text = "MIT" }
+authors = [{ name = "Advanced Micro Devices, Inc." }]
+dependencies = [
+    # ROCm runtime (TheRock). Not on PyPI -- supply at install time via
+    # `--extra-index-url https://repo.amd.com/rocm/whl/@MORPHIZEN_HIP_ARCH@/`
+    # (@MORPHIZEN_HIP_ARCH@ = the GPU arch this wheel was built for). Pinned to
+    # the exact TheRock version the EP is built against to avoid runtime/JIT
+    # import ABI skew.
+    "rocm[libraries,devel]==7.11.0",
+]
+# NOTE: a custom ONNX Runtime build (the plugin-EP-patched onnxruntime-directml)
+# is required at runtime, but it is NOT declared as a dependency: this wheel
+# ships its native files into onnxruntime/capi (platlib), so onnxruntime must
+# already be installed (install this wheel AFTER it). Declaring it would also
+# risk pip pulling the stock PyPI build over the custom one.
+
+[tool.setuptools]
+# The EP's native artifacts ship directly under onnxruntime/capi/ (platlib),
+# the same layout ONNX Runtime itself uses -- so they install next to
+# onnxruntime.dll cross-platform (pip resolves platlib per OS, unlike a
+# hardcoded lib/site-packages data_files path). onnxruntime.capi is treated as
+# a PEP 420 namespace package (we ship NO __init__.py for onnxruntime/ or
+# onnxruntime/capi/, so we never clobber ONNX Runtime's own files).
+
+[tool.setuptools.packages.find]
+include = ["onnxruntime_morphizen_ep", "onnxruntime.capi"]
+namespaces = true
+
+[tool.setuptools.package-data]
+"onnxruntime.capi" = ["*.dll", "*.lib", "*.dll.a", "*.so"]

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,35 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""Setuptools shim.
+
+Metadata + packaging live in the generated pyproject.toml (the native artifacts
+ship as package-data of the ``onnxruntime.capi`` namespace package). This file
+only forces a platform-specific, Python-ABI-agnostic wheel tag (py3-none-<plat>),
+since the wheel ships prebuilt native libraries, not a Python extension.
+"""
+
+import sysconfig
+
+from setuptools import setup
+
+try:
+    from setuptools.command.bdist_wheel import bdist_wheel as _bdist_wheel
+except ImportError:  # older setuptools without the vendored command
+    from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+
+
+class bdist_wheel(_bdist_wheel):
+    # Keep the package content at the wheel root (Root-Is-Purelib: true) so it
+    # ships as onnxruntime/capi/... (like ONNX Runtime) rather than relocated
+    # under .data/purelib/. The bundled DLLs don't link libpython, so the tag is
+    # py3-none-<platform>: ABI-agnostic but platform-specific. We compute the
+    # platform tag ourselves because a "pure" wheel would otherwise report
+    # plat == "any".
+    def get_tag(self):
+        plat = sysconfig.get_platform().replace("-", "_").replace(".", "_")
+        return "py3", "none", plat
+
+
+setup(cmdclass={"bdist_wheel": bdist_wheel})


### PR DESCRIPTION
## Summary

Package the MorphiZen EP as a pip-installable wheel and validate it in CI. The wheel installs the EP's native files into `onnxruntime/capi` (so OGA/ORT auto-discover the colocated EP), is built by default from `build.py`, shipped in `gpu-test-package`, and exercised by a new gpu-test step running OGA's `benchmark_e2e.py` end to end.

## Why

OGA/ORT consumers want to `pip install` the EP, not hand-place DLLs. Installing into `onnxruntime/capi` (the layout ORT itself uses) puts the files next to `onnxruntime.dll` for zero-config discovery. The wheel bundles only our own artifacts (EP plugin, hip-compiler, custom-kernels, CRT import libs); ROCm import libs come from pip `rocm[devel]` at runtime (via `THEROCK_DIST` + `LIB`), so the bundle doesn't grow as ROCm evolves. `CompilerDriver` is intentionally unchanged.

## What

1. **`wheel` target** (`python/`): stages native libs into `onnxruntime/capi` and runs the PEP 517 build; metadata in `pyproject.toml.in` (namespace `onnxruntime.capi`, `rocm[libraries,devel]` dep) + `setup.py` (`py3-none-<platform>` tag) + `_pack_libs.py`.
2. **`build.py` / root `CMakeLists.txt`**: `-DBUILD_PYTHON_WHEEL` option, on by default for real builds (`--skip_wheel` to opt out; mock skips).
3. **CI** (`windows-build.yml`): ship the EP wheel in `staging/wheels/`; package OGA's `benchmark_e2e.py`; add a `Run OGA wheel smoke (Python)` gpu-test step (install three wheels + `rocm-sdk init` + run on Llama-3.1-8B) with throughput in the perf summary.
4. **Docs**: `docs/quick_start.md` updated for the wheel install + `rocm-sdk init` + env.

## Test plan

- [ ] Local clean-venv install of the three wheels + `rocm-sdk init`: ORT EP-device enumeration and OGA `benchmark_e2e.py` on Llama-3.1-8B pass (~28 tps).
- [ ] build-windows green: EP wheel present in `gpu-test-package/wheels/`.
- [ ] gpu-test green: OGA wheel smoke generates tokens; throughput in perf summary.

## Notes for reviewers

`benchmark_e2e.py` runs with `-e follow_config`, relying on the model's `genai_config.json` naming the provider `MorphiZenEP` (already populated by the OGA benchmark step). The smoke runs the full pip `rocm[devel]` + `rocm-sdk init` flow each gpu-test run by design, to exercise the published install path.

## Checklist

- [x] **Incremental** — 9 files, ~498 LOC (mostly new self-contained `python/` scaffolding).
- [x] **AI policy** — Cursor-assisted; disclosed via the commit `Co-authored-by: Cursor` trailer.
- [x] **No `good first issue` automation**.
- [ ] **Reviews resolved**.
- [x] **CODEOWNERS routing**.
