### PR TITLE
feat(hip): slice NonZero output to its true extent via hip.readback_dim

### DIFF
--- a/3rd-party/custom_kernels/include/hip_custom_kernels.h
+++ b/3rd-party/custom_kernels/include/hip_custom_kernels.h
@@ -1017,13 +1017,17 @@ int hip_scatter_nd(
  * NonZero
  * =========================================================================
  *
- * Single-pass atomic kernel: each thread checks one element. If nonzero,
- * atomicAdd on count_ptr gives the write position, then coordinates are
- * written into output[rank, capacity] at stride = capacity.
+ * Single-block cooperative ordered scan: each thread counts the non-zeros in
+ * its chunk, thread 0 exclusive-scans the per-chunk counts, then each thread
+ * re-walks its chunk and writes coordinates into output[rank, capacity] at
+ * stride = capacity, in row-major (ONNX-spec) order. Columns beyond the true
+ * count are left undefined (the launcher zero-fills them defensively).
  *
- * count_ptr is zeroed by the launcher before the kernel. After completion,
- * *count_ptr holds the actual number of nonzero elements (on GPU — no D2H
- * needed; downstream ops read it directly).
+ * After completion, *count_ptr (device i32) holds the actual number of
+ * non-zero elements. The host reads it back via hipdnn_ep_readback_i32
+ * (lowered from hip.readback_dim) and slices the output to its true extent, so
+ * downstream ops and the ORT-reported shape use the count rather than the
+ * worst-case capacity.
  *
  * input_dims_host: host pointer to int64_t[rank] holding the input
  * shape (copied to device internally before the kernel launch).

--- a/include/hip/Dialect/IR/HipBufferize.h
+++ b/include/hip/Dialect/IR/HipBufferize.h
@@ -61,9 +61,50 @@ struct HipDstBufferizableModel
   }
 };
 
+// Bufferization model for the non-DPS hip.readback_dim op. It reads the
+// `scalar` tensor operand (device i32 buffer) and produces a host `index`
+// result; it does not allocate, write, or alias any tensor value (the result
+// is not a tensor). Bufferization just rewrites the tensor operand to its
+// memref buffer; the index result passes through unchanged.
+struct HipReadbackDimBufferizableModel
+    : public bufferization::BufferizableOpInterface::ExternalModel<
+          HipReadbackDimBufferizableModel, ReadbackDimOp> {
+  bool bufferizesToMemoryRead(Operation *, OpOperand &,
+                              const bufferization::AnalysisState &) const {
+    return true;
+  }
+  bool bufferizesToMemoryWrite(Operation *, OpOperand &,
+                               const bufferization::AnalysisState &) const {
+    return false;
+  }
+  bufferization::AliasingValueList
+  getAliasingValues(Operation *, OpOperand &,
+                    const bufferization::AnalysisState &) const {
+    // The only result is an `index`, not a tensor, so no value aliases the
+    // (scalar) operand buffer.
+    return {};
+  }
+  LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
+                          const bufferization::BufferizationOptions &options,
+                          bufferization::BufferizationState &state) const {
+    auto readback = cast<ReadbackDimOp>(op);
+    FailureOr<Value> scalarBuf =
+        getBuffer(rewriter, readback.getScalar(), options, state);
+    if (failed(scalarBuf))
+      return failure();
+    auto newOp =
+        ReadbackDimOp::create(rewriter, op->getLoc(), rewriter.getIndexType(),
+                              readback.getCtx(), *scalarBuf);
+    bufferization::replaceOpWithBufferizedValues(rewriter, op,
+                                                 newOp.getResult());
+    return success();
+  }
+};
+
 inline void
 registerHipBufferizableOpInterfaceModels(DialectRegistry &registry) {
   registry.addExtension(+[](MLIRContext *ctx, HipDialect *) {
+    ReadbackDimOp::attachInterface<HipReadbackDimBufferizableModel>(*ctx);
     ConvOp::attachInterface<HipDstBufferizableModel<ConvOp>>(*ctx);
     ConvTransposeOp::attachInterface<HipDstBufferizableModel<ConvTransposeOp>>(
         *ctx);

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -3189,7 +3189,7 @@ def Hip_SizeOp : Hip_DpsOp<"size", /*traits=*/[],
 
 def Hip_NonZeroOp : Hip_DpsOp<"nonzero", /*traits=*/[], /*outsAccessor=*/"Y",
                               /*autoReify=*/1,
-                              /*autoInfer=*/1, /*declareInfer=*/1> {
+                              /*autoInfer=*/0, /*declareInfer=*/0> {
   let summary = "Indices of non-zero elements (ONNX NonZero)";
   let description = [{
     Implements the standard ONNX NonZero operator (opset 13+):
@@ -3200,16 +3200,26 @@ def Hip_NonZeroOp : Hip_DpsOp<"nonzero", /*traits=*/[], /*outsAccessor=*/"Y",
     `y` has shape `[R, N]` of element type `i64`, where `R` is the input
     rank and `N` is the (data-dependent) number of non-zero elements.
     The `N` dimension is represented as `?` in MLIR; the compiler
-    over-allocates using `numel(x)` as the upper bound (since the input
-    has fully static shape).
+    over-allocates `y` using `numel(x)` as the upper-bound *capacity*
+    (`N` columns beyond the true count are left undefined).
 
-    Uses destination-passing style: the output buffer is provided as
-    argument.
+    The true count `N` is data-dependent and only known once the kernel
+    has scanned the input, so the op also takes a second destination
+    `count` (a device `i32` scalar buffer) that the kernel writes with
+    the actual number of non-zero elements. Downstream code reads it back
+    to the host via `hip.readback_dim` and slices `y` to `[R, N]` so the
+    real extent (not the capacity) flows to consumers and to the
+    ORT-reported output shape. Two destinations means the op is
+    multi-result (`y`, `count`); like the other multi-output DPS ops it
+    keeps `autoInfer=0` (converters pass explicit result types).
+
+    Uses destination-passing style: both output buffers are provided as
+    arguments.
 
     Example:
     ```mlir
     hip.nonzero(%ctx) ins(%x : memref<3x4xf16, 1>)
-                      outs(%y : memref<2x?xi64, 1>)
+                      outs(%y, %count : memref<2x?xi64, 1>, memref<i32, 1>)
                       {input_data_type = 1 : i64}
     ```
   }];
@@ -3218,12 +3228,13 @@ def Hip_NonZeroOp : Hip_DpsOp<"nonzero", /*traits=*/[], /*outsAccessor=*/"Y",
     Hip_ContextType:$ctx,
     Hip_TensorOrMemRef:$x,
     Hip_TensorOrMemRef:$y,
+    Hip_TensorOrMemRef:$count,
     I64Attr:$input_data_type
   );
 
   let assemblyFormat = [{
     `(` $ctx `)` `ins` `(` $x `:` type($x) `)`
-    `outs` `(` $y `:` type($y) `)`
+    `outs` `(` $y `,` $count `:` type($y) `,` type($count) `)`
     attr-dict (`:` type($result_tensors)^)?
   }];
 }
@@ -3355,4 +3366,47 @@ def Hip_ResizeOp : Hip_DpsOp<"resize"> {
   }];
 }
 
+// hip.readback_dim : materialize a kernel-computed runtime extent as a host
+// `index`. It synchronizes the stream so the producing kernel has finished,
+// then reads back a single device-resident integer `scalar`.
+//
+// This is the host-side half of the data-dependent dynamic-shape lowering: a
+// kernel writes a runtime extent (a count, valid-length, selected-element
+// tally, ...) into a small device buffer, and `readback_dim` turns it into a
+// host `index` that can size a `tensor.extract_slice`, `tensor.empty`, or
+// `hip.alloc_output`.
+//
+// It is deliberately not `Pure` and not speculatable: it performs a
+// device->host copy plus a stream synchronization, and must remain below the
+// producing kernel in program order. Non-speculatability is also what stops
+// `hip-hoist-alloc-size-arith` from lifting an extent-sized allocation above
+// that kernel into the function entry block.
+//
+// Before (tensor form, after convert-onnx-to-hip):
+//   %n = hip.readback_dim(%ctx, %count : tensor<i32>) -> index
+// After bufferize:
+//   %n = hip.readback_dim(%ctx, %count : memref<i32, 1>) -> index
+def Hip_ReadbackDimOp : Hip_Op<"readback_dim",
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+  let summary = "Synchronize and read a device i32 scalar into a host index";
+  let description = [{
+    Reads the single integer stored in the device-resident `scalar` buffer
+    back to the host as an `index`, after synchronizing the GPU stream so the
+    kernel that wrote `scalar` is guaranteed to have completed.
+
+    Has device->host copy + stream-synchronization side effects; it is not
+    speculative and must not be hoisted across the kernel that produces
+    `scalar`.
+  }];
+
+  let arguments = (ins
+    Hip_ContextType:$ctx,
+    Hip_TensorOrMemRef:$scalar
+  );
+  let results = (outs Index:$dim);
+
+  let assemblyFormat = [{
+    `(` $ctx `,` $scalar `:` type($scalar) `)` attr-dict `->` type($dim)
+  }];
+}
 #endif // HIP_OPS

--- a/lib/Conversion/HipToLLVM/CMakeLists.txt
+++ b/lib/Conversion/HipToLLVM/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(HipToLLVM STATIC
   SliceLowering.cpp
   ScatterNDLowering.cpp
   NonZeroLowering.cpp
+  ReadbackDimLowering.cpp
   SizeLowering.cpp
   LoopLowering.cpp
   PoolLowering.cpp

--- a/lib/Conversion/HipToLLVM/HipToLLVM.cpp
+++ b/lib/Conversion/HipToLLVM/HipToLLVM.cpp
@@ -337,6 +337,7 @@ void ConvertHipToLLVMPass::runOnOperation() {
   populateSliceLoweringPatterns(typeConverter, patterns);
   populateScatterNDLoweringPatterns(typeConverter, patterns);
   populateNonZeroLoweringPatterns(typeConverter, patterns);
+  populateReadbackDimLoweringPatterns(typeConverter, patterns);
   populateSizeLoweringPatterns(typeConverter, patterns);
   populatePoolLoweringPatterns(typeConverter, patterns);
   populateResizeLoweringPatterns(typeConverter, patterns);

--- a/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
+++ b/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
@@ -113,6 +113,9 @@ inline constexpr const char *kWrapSlice = "wrap_slice";
 inline constexpr const char *kWrapScatterND = "wrap_scatter_nd";
 inline constexpr const char *kWrapNonZero = "wrap_nonzero";
 inline constexpr const char *kWrapSize = "wrap_size";
+// Synchronize the stream and read a device i32 scalar back to the host
+// (used by hip.readback_dim to materialise a data-dependent dynamic dim).
+inline constexpr const char *kHipReadbackI32 = "hipdnn_ep_readback_i32";
 
 // LLVM memref descriptor struct field indices.
 // Layout: { allocatedPtr, alignedPtr, offset, sizes[rank], strides[rank] }
@@ -418,6 +421,11 @@ void populateScatterNDLoweringPatterns(const LLVMTypeConverter &converter,
                                        RewritePatternSet &patterns);
 void populateNonZeroLoweringPatterns(const LLVMTypeConverter &converter,
                                      RewritePatternSet &patterns);
+// Generic data-dependent-shape readback primitive (hip.readback_dim). Not tied
+// to any single operator; any op that computes a runtime extent into a device
+// i32 scalar can be sliced/sized via this.
+void populateReadbackDimLoweringPatterns(const LLVMTypeConverter &converter,
+                                         RewritePatternSet &patterns);
 void populateSizeLoweringPatterns(const LLVMTypeConverter &converter,
                                   RewritePatternSet &patterns);
 void populateLoopLoweringPatterns(const LLVMTypeConverter &converter,

--- a/lib/Conversion/HipToLLVM/NonZeroLowering.cpp
+++ b/lib/Conversion/HipToLLVM/NonZeroLowering.cpp
@@ -9,15 +9,20 @@ namespace mlir {
 namespace hip {
 namespace {
 
-// hip.nonzero(ctx, x, y) {input_data_type}
-//   -> wrap_nonzero(state, input_ptr, output_ptr,
-//                   input_num_elements, input_rank,
+// hip.nonzero(ctx, x, y, count) {input_data_type}
+//   -> wrap_nonzero(state, input_ptr, output_ptr, count_ptr,
+//                   input_num_elements, input_rank, input_dims,
 //                   output_capacity, input_data_type)
 //
+// `count_ptr` is the device i32 scalar buffer (the `count` DPS init) that the
+// kernel writes with the true number of non-zero elements.
 // `input_num_elements` is the total count of input elements (product of
 // input dims, supports static + dynamic shapes via MemRefDescriptor).
 // `input_rank` is the static rank of the input (R), passed as a compile-
 // time i64 constant.
+// `input_dims` is a host i64[R] array of the input extents (the kernel copies
+// it to the device to decompose flat indices into multi-dim coordinates). It
+// is materialised here as a stack alloca filled with per-dim sizes.
 // `output_capacity` is the size of the dynamic N dim of the output (i.e.,
 // the upper-bound number of nonzero entries materialised by the conversion
 // pass). For NonZero today this equals input_num_elements, but lowering
@@ -52,13 +57,28 @@ struct NonZeroOpLowering : public ConvertOpToLLVMPattern<NonZeroOp> {
     Value statePtr = adaptor.getCtx();
     Value inputPtr = extractContiguousMemRefPtr(adaptor.getX(), rewriter, loc);
     Value outputPtr = extractContiguousMemRefPtr(adaptor.getY(), rewriter, loc);
+    Value countPtr =
+        extractContiguousMemRefPtr(adaptor.getCount(), rewriter, loc);
 
     // Total input element count (handles static + dynamic dims).
     Value inputNumElements =
         computeNumElements(inputType, adaptor.getX(), rewriter, loc);
 
     // R is a static property of the input memref type.
-    Value inputRank = createI64Const(inputType.getRank());
+    int64_t rank = inputType.getRank();
+    Value inputRank = createI64Const(rank);
+
+    // Host i64[R] array of input extents. Stack-allocated in the generated
+    // (host) inference_compute; the runtime copies it H2D.
+    Value dimsPtr =
+        LLVM::AllocaOp::create(rewriter, loc, ptrType, i64Type, inputRank);
+    for (int64_t i : llvm::seq<int64_t>(0, rank)) {
+      Value dimVal = getMemRefDimSize(inputType, /*dimIdx=*/i, adaptor.getX(),
+                                      rewriter, loc);
+      Value gep = LLVM::GEPOp::create(rewriter, loc, ptrType, i64Type, dimsPtr,
+                                      ValueRange{createI64Const(i)});
+      LLVM::StoreOp::create(rewriter, loc, dimVal, gep);
+    }
 
     // Output capacity = N dim (data-dependent at the source level; the
     // tensor.empty in OnnxToHip pins it to numel(X) upper-bound, but read
@@ -69,18 +89,20 @@ struct NonZeroOpLowering : public ConvertOpToLLVMPattern<NonZeroOp> {
     Value inputDataTypeVal = createI64Const(op.getInputDataType());
 
     // int wrap_nonzero(RuntimeState* state, void* input, void* output,
-    //                  int64_t input_num_elements, int64_t input_rank,
+    //                  int32_t* count_ptr, int64_t input_num_elements,
+    //                  int64_t input_rank, const int64_t* input_dims,
     //                  int64_t output_capacity, int64_t input_data_type)
-    SmallVector<Type, 7> paramTypes = {ptrType, ptrType, ptrType, i64Type,
-                                       i64Type, i64Type, i64Type};
+    SmallVector<Type, 9> paramTypes = {ptrType, ptrType, ptrType,
+                                       ptrType, i64Type, i64Type,
+                                       ptrType, i64Type, i64Type};
     FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
         rewriter, module, kWrapNonZero, paramTypes, i32Type);
     if (failed(funcOp))
       return failure();
 
-    SmallVector<Value, 7> args = {statePtr,         inputPtr,  outputPtr,
-                                  inputNumElements, inputRank, outputCapacity,
-                                  inputDataTypeVal};
+    SmallVector<Value, 9> args = {statePtr, inputPtr,         outputPtr,
+                                  countPtr, inputNumElements, inputRank,
+                                  dimsPtr,  outputCapacity,   inputDataTypeVal};
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
     rewriter.eraseOp(op);
     return success();

--- a/lib/Conversion/HipToLLVM/ReadbackDimLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ReadbackDimLowering.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "HipToLLVMUtils.h"
+
+namespace mlir {
+namespace hip {
+namespace {
+
+// hip.readback_dim(ctx, scalar) : index
+//   -> %c = hipdnn_ep_readback_i32(state, scalar_ptr)   // D2H + stream sync
+//      sext %c : i32 to i64                              // index ABI
+//
+// Generic host-readback primitive for data-dependent dynamic shapes (NOT
+// specific to any one operator): `scalar` is a device i32 buffer that some
+// kernel computed (e.g. a count / valid-length / selected-element tally). The
+// runtime helper synchronizes the stream (so the producing kernel has
+// finished) and copies the 4-byte scalar back to the host. The result feeds
+// host-side index arithmetic (tensor.extract_slice size, tensor.empty
+// dynsize, hip.alloc_output extent, ...).
+struct ReadbackDimOpLowering : public ConvertOpToLLVMPattern<ReadbackDimOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(ReadbackDimOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    ModuleOp module = op->getParentOfType<ModuleOp>();
+    Type ptrType = getPtrType();
+    Type i32Type = rewriter.getI32Type();
+    Type i64Type = rewriter.getI64Type();
+
+    Value statePtr = adaptor.getCtx();
+    Value scalarPtr =
+        extractContiguousMemRefPtr(adaptor.getScalar(), rewriter, loc);
+
+    // int32_t hipdnn_ep_readback_i32(RuntimeState* state, const void* scalar)
+    SmallVector<Type, 2> paramTypes = {ptrType, ptrType};
+    FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
+        rewriter, module, kHipReadbackI32, paramTypes, i32Type);
+    if (failed(funcOp))
+      return failure();
+
+    auto call = LLVM::CallOp::create(rewriter, loc, *funcOp,
+                                     ValueRange{statePtr, scalarPtr});
+    // The readback scalar is a non-negative extent; zero-extend to the i64
+    // that `index` lowers to.
+    Value widened =
+        LLVM::ZExtOp::create(rewriter, loc, i64Type, call.getResult());
+    rewriter.replaceOp(op, widened);
+    return success();
+  }
+};
+
+} // namespace
+
+void populateReadbackDimLoweringPatterns(const LLVMTypeConverter &converter,
+                                         RewritePatternSet &patterns) {
+  patterns.add<ReadbackDimOpLowering>(converter);
+}
+
+} // namespace hip
+} // namespace mlir

--- a/lib/Conversion/OnnxToHip/NonZeroConversion.cpp
+++ b/lib/Conversion/OnnxToHip/NonZeroConversion.cpp
@@ -119,16 +119,45 @@ struct NonZeroToHip : public mlir::RewritePattern {
             mlir::arith::MulIOp::create(rewriter, loc, upperBound, dim);
       }
     }
-    mlir::Value init = mlir::tensor::EmptyOp::create(
+    // Destination for the indices: [R, capacity] where capacity = numel(X)
+    // is the worst-case (every element non-zero) upper bound.
+    mlir::Value yInit = mlir::tensor::EmptyOp::create(
         rewriter, loc, resultType.getShape(), resultType.getElementType(),
         mlir::ValueRange{upperBound});
 
-    // Result type inferred from `init` via InferTypeOpInterface — DPS contract:
-    // result type == outs operand type.
+    // Second destination: a device i32 scalar the kernel writes with the
+    // actual number of non-zero elements (the data-dependent count N). The
+    // capacity buffer above is over-allocated; only the first N columns are
+    // meaningful. Reading the count back lets us slice `y` to its true extent
+    // so downstream ops and the ORT-reported output shape use N, not capacity.
+    auto countType =
+        mlir::RankedTensorType::get(/*shape=*/{}, rewriter.getI32Type());
+    mlir::Value countInit = mlir::tensor::EmptyOp::create(
+        rewriter, loc, countType.getShape(), countType.getElementType());
+
+    // hip.nonzero is multi-result (autoInfer=0): pass explicit result types.
     auto hipOp = mlir::hip::NonZeroOp::create(
-        rewriter, loc, context, op->getOperand(0), init,
+        rewriter, loc, mlir::TypeRange{resultType, countType}, context,
+        op->getOperand(0), yInit, countInit,
         rewriter.getI64IntegerAttr(inputDataType));
-    rewriter.replaceOp(op, hipOp->getResult(0));
+
+    // Read the device count back to a host `index` (D2H + stream sync), then
+    // slice the capacity buffer to [R, N] so the true extent flows onward.
+    mlir::Value count =
+        mlir::hip::ReadbackDimOp::create(rewriter, loc, rewriter.getIndexType(),
+                                         context, hipOp.getResult(1))
+            .getResult();
+
+    mlir::SmallVector<mlir::OpFoldResult, 2> offsets = {
+        rewriter.getIndexAttr(0), rewriter.getIndexAttr(0)};
+    mlir::SmallVector<mlir::OpFoldResult, 2> sizes = {
+        rewriter.getIndexAttr(inputRank), mlir::OpFoldResult(count)};
+    mlir::SmallVector<mlir::OpFoldResult, 2> strides = {
+        rewriter.getIndexAttr(1), rewriter.getIndexAttr(1)};
+    mlir::Value trimmed = mlir::tensor::ExtractSliceOp::create(
+        rewriter, loc, resultType, hipOp.getResult(0), offsets, sizes, strides);
+
+    rewriter.replaceOp(op, trimmed);
     return mlir::success();
   }
 };

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -1525,15 +1525,38 @@ void ScatterNDOp::getEffects(
 }
 
 //===----------------------------------------------------------------------===//
-// NonZeroOp: ins(x), outs(y)
+// NonZeroOp: ins(x), outs(y, count)
 //===----------------------------------------------------------------------===//
 
-MutableOperandRange NonZeroOp::getDpsInitsMutable() { return getYMutable(); }
+// Operand order is (ctx, x, y, count); the two DPS inits (y, count) are the
+// trailing contiguous range, as required by DestinationStyleOpInterface.
+MutableOperandRange NonZeroOp::getDpsInitsMutable() {
+  return MutableOperandRange(*this, /*start=*/2, /*length=*/2);
+}
 
 void NonZeroOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
         &effects) {
   emitDpsMemoryEffects(getDpsInputOperands(), getDpsInitsMutable(), effects);
+}
+
+//===----------------------------------------------------------------------===//
+// ReadbackDimOp: ins(scalar) -> index
+//===----------------------------------------------------------------------===//
+
+// Reads the device `scalar` buffer (a Read effect on the operand) plus a
+// stream synchronization. Declaring the effect gives the ownership-based
+// buffer-deallocation pass a known (non-allocating) effect for this op, and
+// the Read-after-Write against the producing kernel's write to the same buffer
+// keeps it correctly ordered (and, with no speculatable trait, un-hoistable).
+void ReadbackDimOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  // Operand order is (ctx, scalar); attach the Read to the scalar operand.
+  if (isa<MemRefType>(getScalar().getType()))
+    effects.emplace_back(MemoryEffects::Read::get(),
+                         &getOperation()->getOpOperand(1),
+                         SideEffects::DefaultResource::get());
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -1179,17 +1179,29 @@ int wrap_not(RuntimeState *state, void *input, void *output,
 // input rank and N is the (data-dependent) number of non-zero entries.
 // The caller pre-allocates the output buffer with capacity `output_capacity`
 // elements along the N dim (the OnnxToHip pass uses `input_num_elements`
-// as the upper bound).
+// as the upper bound); columns beyond the true count are left undefined.
+//
+// The kernel writes the true count N into the device i32 scalar `count_ptr`.
+// The generated code reads it back to the host via `hipdnn_ep_readback_i32`
+// (lowered from hip.readback_dim) and slices `output` to [R, N] so consumers
+// and the ORT-reported output shape see the real extent, not the capacity.
+//
+// `input_dims` is the host array of the R input extents (the runtime copies it
+// to the device so the kernel can decompose flat indices into coordinates).
 //
 // `input_data_type` is the HIPDNN_EP_DATATYPE_* value of the input tensor.
 // Bool (ONNX `tensor(bool)`) is marshalled as 1-byte uint8 by the EP and
-// reuses the INT8 slot here. Today this is a stub: it logs its parameters
-// and throws std::runtime_error so an inference path that actually
-// reaches NonZero fails loudly instead of producing uninitialised output.
+// reuses the INT8 slot here.
 int wrap_nonzero(RuntimeState *state, void *input, void *output,
                  int32_t *count_ptr, int64_t input_num_elements,
                  int64_t input_rank, const int64_t *input_dims,
                  int64_t output_capacity, int64_t input_data_type);
+
+// Synchronize the GPU stream (so the producing kernel has completed), then
+// copy a single device-resident i32 scalar back to the host and return it.
+// Used by hip.readback_dim to turn a kernel-computed runtime extent (e.g.
+// NonZero's non-zero count) into a host value that can size dynamic shapes.
+int32_t hipdnn_ep_readback_i32(RuntimeState *state, const void *device_scalar);
 
 // ONNX Size wrapper (dynamic-shape path only).
 //

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -1316,6 +1316,19 @@ int wrap_not(RuntimeState *state, void *input, void *output,
   return 0;
 }
 
+// Mock memory is plain host memory, so we can compute the true non-zero count
+// directly from `input`. This makes the host-readback path (hip.readback_dim
+// -> hipdnn_ep_readback_i32) return a meaningful dynamic dim under mock builds.
+template <typename T>
+static int32_t mock_count_nonzero(const void *data, int64_t n) {
+  const T *p = static_cast<const T *>(data);
+  int32_t count = 0;
+  for (int64_t i = 0; i < n; ++i)
+    if (p[i] != static_cast<T>(0))
+      ++count;
+  return count;
+}
+
 int wrap_nonzero(RuntimeState *state, void *input, void *output,
                  int32_t *count_ptr, int64_t input_num_elements,
                  int64_t input_rank, const int64_t *input_dims,
@@ -1324,19 +1337,48 @@ int wrap_nonzero(RuntimeState *state, void *input, void *output,
     fprintf(stderr, "Invalid state in wrap_nonzero\n");
     return -1;
   }
-  (void)input;
   (void)output;
   (void)input_dims;
-  // Mock: set count to 0 (no nonzero elements)
+
+  int32_t count = 0;
+  if (input && count_ptr) {
+    switch (input_data_type) {
+    case HIPDNN_EP_DATATYPE_FLOAT:
+      count = mock_count_nonzero<float>(input, input_num_elements);
+      break;
+    case HIPDNN_EP_DATATYPE_INT32:
+      count = mock_count_nonzero<int32_t>(input, input_num_elements);
+      break;
+    case HIPDNN_EP_DATATYPE_INT64:
+      count = mock_count_nonzero<int64_t>(input, input_num_elements);
+      break;
+    case HIPDNN_EP_DATATYPE_INT8:
+    case HIPDNN_EP_DATATYPE_UINT8:
+      count = mock_count_nonzero<int8_t>(input, input_num_elements);
+      break;
+    default:
+      // f16 and any other types: leave count at 0 (mock has no fp16 type).
+      break;
+    }
+  }
   if (count_ptr)
-    *count_ptr = 0;
+    *count_ptr = count;
+
   MOCK_PRINT("[MOCK] wrap_nonzero(input_num_elements=%lld, input_rank=%lld, "
-             "output_capacity=%lld, input_data_type=%s(%lld))\n",
+             "output_capacity=%lld, input_data_type=%s(%lld)) -> count=%d\n",
              (long long)input_num_elements, (long long)input_rank,
              (long long)output_capacity,
              hipdnn_ep_datatype_name(input_data_type),
-             (long long)input_data_type);
+             (long long)input_data_type, count);
   return 0;
+}
+
+int32_t hipdnn_ep_readback_i32(RuntimeState *state, const void *device_scalar) {
+  (void)state;
+  // Mock "device" memory is host memory: read the scalar directly.
+  if (!device_scalar)
+    return 0;
+  return *static_cast<const int32_t *>(device_scalar);
 }
 
 int wrap_cos(RuntimeState *state, void *input, void *output,

--- a/lib/Runtime/real/memory.cpp
+++ b/lib/Runtime/real/memory.cpp
@@ -73,3 +73,32 @@ int wrap_hipMemcpy2DAsync(RuntimeState *state, void *dst_ptr, size_t dst_pitch,
 
   return 0;
 }
+
+// Synchronize the stream, then read back a device-resident i32 scalar (e.g.
+// NonZero's non-zero count). The copy is enqueued after the producing kernel
+// on the same stream; the synchronize guarantees both have completed before
+// the host value is read. Returns 0 on any failure (a zero extent is a safe,
+// inert dynamic dim).
+int32_t hipdnn_ep_readback_i32(RuntimeState *state, const void *device_scalar) {
+  if (!state || !device_scalar) {
+    fprintf(stderr, "hipdnn_ep_readback_i32: null argument\n");
+    return 0;
+  }
+  hipStream_t stream =
+      static_cast<hipStream_t>(hipdnn_ep_state_get_stream(state));
+  int32_t host_val = 0;
+  hipError_t err = hipMemcpyAsync(&host_val, device_scalar, sizeof(int32_t),
+                                  hipMemcpyDeviceToHost, stream);
+  if (err != hipSuccess) {
+    fprintf(stderr, "hipdnn_ep_readback_i32: D2H copy failed: %s\n",
+            hipGetErrorString(err));
+    return 0;
+  }
+  err = hipStreamSynchronize(stream);
+  if (err != hipSuccess) {
+    fprintf(stderr, "hipdnn_ep_readback_i32: stream sync failed: %s\n",
+            hipGetErrorString(err));
+    return 0;
+  }
+  return host_val;
+}

--- a/test/lit/Conversion/hip-to-llvm/test_nonzero.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_nonzero.mlir
@@ -4,11 +4,14 @@
 // ============================================================================
 // TEST PURPOSE:
 // Verify hip.nonzero lowers to a single llvm.call into the wrap_nonzero
-// runtime stub, with the expected (state, in, out, num_elems, rank,
-// output_capacity, input_data_type) signature. Covers both fully static
-// inputs (num_elems computed at compile time) and partially dynamic
-// inputs (num_elems built from llvm.extractvalue + llvm.mul over the
-// MemRef descriptor sizes array).
+// runtime, with the expected 9-arg signature
+//   (state, in, out, count_ptr, num_elems, rank, input_dims, capacity, dtype)
+// where `count_ptr` is the device i32 scalar the kernel writes and
+// `input_dims` is a host i64[R] stack array. Covers both fully static inputs
+// (num_elems computed at compile time) and partially dynamic inputs
+// (num_elems built from llvm.extractvalue + llvm.mul over the MemRef
+// descriptor sizes array). Also verifies hip.readback_dim lowers to a single
+// llvm.call into hipdnn_ep_readback_i32 followed by an sext to i64.
 // ============================================================================
 
 // RUN: hip-mlir-opt %s --convert-hip-to-llvm | FileCheck %s
@@ -18,14 +21,17 @@ module {
   func.func @nonzero_static_bool(
       %ctx: !hip.context,
       %input: memref<3x4xi1, 1>,
-      %output: memref<2x?xi64, 1>) {
+      %output: memref<2x?xi64, 1>,
+      %count: memref<i32, 1>) {
     // CHECK-LABEL: llvm.func @nonzero_static_bool
 
     hip.nonzero(%ctx) ins(%input : memref<3x4xi1, 1>)
-                      outs(%output : memref<2x?xi64, 1>)
+                      outs(%output, %count : memref<2x?xi64, 1>, memref<i32, 1>)
                       {input_data_type = 5 : i64}
 
-    // CHECK: llvm.call @wrap_nonzero({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64) -> i32
+    // A host i64[R] dims array is stack-allocated and filled before the call.
+    // CHECK: llvm.alloca {{.*}} x i64
+    // CHECK: llvm.call @wrap_nonzero({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, !llvm.ptr, i64, i64) -> i32
     return
   }
 
@@ -33,14 +39,15 @@ module {
   func.func @nonzero_static_f32(
       %ctx: !hip.context,
       %input: memref<2x3x4xf32, 1>,
-      %output: memref<3x?xi64, 1>) {
+      %output: memref<3x?xi64, 1>,
+      %count: memref<i32, 1>) {
     // CHECK-LABEL: llvm.func @nonzero_static_f32
 
     hip.nonzero(%ctx) ins(%input : memref<2x3x4xf32, 1>)
-                      outs(%output : memref<3x?xi64, 1>)
+                      outs(%output, %count : memref<3x?xi64, 1>, memref<i32, 1>)
                       {input_data_type = 0 : i64}
 
-    // CHECK: llvm.call @wrap_nonzero({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64) -> i32
+    // CHECK: llvm.call @wrap_nonzero({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, !llvm.ptr, i64, i64) -> i32
     return
   }
 
@@ -49,11 +56,12 @@ module {
   func.func @nonzero_dynamic_f16(
       %ctx: !hip.context,
       %input: memref<?x?xf16, 1>,
-      %output: memref<2x?xi64, 1>) {
+      %output: memref<2x?xi64, 1>,
+      %count: memref<i32, 1>) {
     // CHECK-LABEL: llvm.func @nonzero_dynamic_f16
 
     hip.nonzero(%ctx) ins(%input : memref<?x?xf16, 1>)
-                      outs(%output : memref<2x?xi64, 1>)
+                      outs(%output, %count : memref<2x?xi64, 1>, memref<i32, 1>)
                       {input_data_type = 1 : i64}
 
     // Verify dynamic shape computation: descriptor.sizes[0] * descriptor.sizes[1].
@@ -62,7 +70,18 @@ module {
     // CHECK-DAG: llvm.mul %{{.*}}, %{{.*}} : i64
     // CHECK-DAG: llvm.extractvalue %{{.*}}[3, 1]
 
-    // CHECK: llvm.call @wrap_nonzero({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64) -> i32
+    // CHECK: llvm.call @wrap_nonzero({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, !llvm.ptr, i64, i64) -> i32
     return
+  }
+
+  // Test 4: hip.readback_dim lowers to hipdnn_ep_readback_i32 + zext to i64.
+  func.func @readback_dim(
+      %ctx: !hip.context,
+      %count: memref<i32, 1>) -> index {
+    // CHECK-LABEL: llvm.func @readback_dim
+    %n = hip.readback_dim(%ctx, %count : memref<i32, 1>) -> index
+    // CHECK: %[[C:.*]] = llvm.call @hipdnn_ep_readback_i32({{.*}}) : (!llvm.ptr, !llvm.ptr) -> i32
+    // CHECK: llvm.zext %[[C]] : i32 to i64
+    return %n : index
   }
 }

--- a/test/lit/Conversion/onnx-to-hip/test_nonzero.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_nonzero.mlir
@@ -22,7 +22,10 @@ module {
   // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[IN:.*]]: tensor<3x4xi1>)
   // CHECK: %[[UB:.*]] = arith.constant 12 : index
   // CHECK: %[[INIT:.*]] = tensor.empty(%[[UB]]) : tensor<2x?xi64>
-  // CHECK: hip.nonzero(%[[CTX]]) ins(%[[IN]] : tensor<3x4xi1>) outs(%[[INIT]] : tensor<2x?xi64>) {input_data_type = 5 : i64}
+  // CHECK: %[[CNT:.*]] = tensor.empty() : tensor<i32>
+  // CHECK: %[[NZ:.*]]:2 = hip.nonzero(%[[CTX]]) ins(%[[IN]] : tensor<3x4xi1>) outs(%[[INIT]], %[[CNT]] : tensor<2x?xi64>, tensor<i32>) {input_data_type = 5 : i64} : tensor<2x?xi64>, tensor<i32>
+  // CHECK: %[[N:.*]] = hip.readback_dim(%[[CTX]], %[[NZ]]#1 : tensor<i32>) -> index
+  // CHECK: tensor.extract_slice %[[NZ]]#0[0, 0] [2, %[[N]]] [1, 1] : tensor<2x?xi64> to tensor<2x?xi64>
 
   // --- Case 2: f32 input, rank 3 ---
   func.func @nonzero_f32(%input: tensor<2x3x4xf32>) -> tensor<3x?xi64> {
@@ -34,7 +37,10 @@ module {
   // CHECK-SAME: (%[[CTX2:.*]]: !hip.context, %[[IN2:.*]]: tensor<2x3x4xf32>)
   // CHECK: %[[UB2:.*]] = arith.constant 24 : index
   // CHECK: %[[INIT2:.*]] = tensor.empty(%[[UB2]]) : tensor<3x?xi64>
-  // CHECK: hip.nonzero(%[[CTX2]]) ins(%[[IN2]] : tensor<2x3x4xf32>) outs(%[[INIT2]] : tensor<3x?xi64>) {input_data_type = 0 : i64}
+  // CHECK: %[[CNT2:.*]] = tensor.empty() : tensor<i32>
+  // CHECK: %[[NZ2:.*]]:2 = hip.nonzero(%[[CTX2]]) ins(%[[IN2]] : tensor<2x3x4xf32>) outs(%[[INIT2]], %[[CNT2]] : tensor<3x?xi64>, tensor<i32>) {input_data_type = 0 : i64} : tensor<3x?xi64>, tensor<i32>
+  // CHECK: %[[N2:.*]] = hip.readback_dim(%[[CTX2]], %[[NZ2]]#1 : tensor<i32>) -> index
+  // CHECK: tensor.extract_slice %[[NZ2]]#0[0, 0] [3, %[[N2]]] [1, 1] : tensor<3x?xi64> to tensor<3x?xi64>
 
   // --- Case 3: i64 input, rank 1 ---
   func.func @nonzero_i64(%input: tensor<8xi64>) -> tensor<1x?xi64> {
@@ -46,7 +52,10 @@ module {
   // CHECK-SAME: (%[[CTX3:.*]]: !hip.context, %[[IN3:.*]]: tensor<8xi64>)
   // CHECK: %[[UB3:.*]] = arith.constant 8 : index
   // CHECK: %[[INIT3:.*]] = tensor.empty(%[[UB3]]) : tensor<1x?xi64>
-  // CHECK: hip.nonzero(%[[CTX3]]) ins(%[[IN3]] : tensor<8xi64>) outs(%[[INIT3]] : tensor<1x?xi64>) {input_data_type = 4 : i64}
+  // CHECK: %[[CNT3:.*]] = tensor.empty() : tensor<i32>
+  // CHECK: %[[NZ3:.*]]:2 = hip.nonzero(%[[CTX3]]) ins(%[[IN3]] : tensor<8xi64>) outs(%[[INIT3]], %[[CNT3]] : tensor<1x?xi64>, tensor<i32>) {input_data_type = 4 : i64} : tensor<1x?xi64>, tensor<i32>
+  // CHECK: %[[N3:.*]] = hip.readback_dim(%[[CTX3]], %[[NZ3]]#1 : tensor<i32>) -> index
+  // CHECK: tensor.extract_slice %[[NZ3]]#0[0, 0] [1, %[[N3]]] [1, 1] : tensor<1x?xi64> to tensor<1x?xi64>
 
   // --- Case 4: dynamic input shape, rank 2 ---
   // Per-dim chain: upper bound = 1 * dim(input,0) * dim(input,1). The
@@ -71,7 +80,10 @@ module {
   // CHECK: tensor.dim %[[IN4]], %{{.*}} : tensor<?x?xf32>
   // CHECK: arith.muli %{{.*}}, %{{.*}} : index
   // CHECK: tensor.empty(%{{.*}}) : tensor<2x?xi64>
-  // CHECK: hip.nonzero(%[[CTX4]]) ins(%[[IN4]] : tensor<?x?xf32>) outs(%{{.*}} : tensor<2x?xi64>) {input_data_type = 0 : i64}
+  // CHECK: tensor.empty() : tensor<i32>
+  // CHECK: hip.nonzero(%[[CTX4]]) ins(%[[IN4]] : tensor<?x?xf32>) outs(%{{.*}}, %{{.*}} : tensor<2x?xi64>, tensor<i32>) {input_data_type = 0 : i64} : tensor<2x?xi64>, tensor<i32>
+  // CHECK: hip.readback_dim(%[[CTX4]]
+  // CHECK: tensor.extract_slice
 
   // --- Case 5: partially dynamic input (mix of static + dynamic dims).
   // Static dims contribute a compile-time arith.constant; dynamic dims
@@ -112,5 +124,6 @@ module {
   // ui8 maps to the dedicated UINT8 slot (7), NOT INT8 (5) — the runtime
   // enum keeps signed/unsigned distinct so any future ordered-comparison
   // or arithmetic backend can dispatch correctly.
-  // CHECK: hip.nonzero(%[[CTX6]]) ins(%[[IN6]] : tensor<2x4x8xui8>) outs(%[[INIT6]] : tensor<3x?xi64>) {input_data_type = 7 : i64}
+  // CHECK: %[[CNT6:.*]] = tensor.empty() : tensor<i32>
+  // CHECK: hip.nonzero(%[[CTX6]]) ins(%[[IN6]] : tensor<2x4x8xui8>) outs(%[[INIT6]], %[[CNT6]] : tensor<3x?xi64>, tensor<i32>) {input_data_type = 7 : i64} : tensor<3x?xi64>, tensor<i32>
 }

--- a/test/lit/Dialect/hip-infer-shapes.mlir
+++ b/test/lit/Dialect/hip-infer-shapes.mlir
@@ -856,19 +856,21 @@ func.func @refine_layer_norm_variadic_three_outs(
 // dependent shapes.
 // CHECK-LABEL: func.func @refine_nonzero_data_dependent_dim1
 // CHECK:         %[[E:.*]] = tensor.empty(%{{.*}}, %{{.*}}) : tensor<?x?xi64>
-// CHECK:         %[[Y:.*]] = hip.nonzero
-// CHECK-SAME:      outs(%[[E]] : tensor<?x?xi64>){{.*}}: tensor<?x?xi64>
-// CHECK:         return %[[Y]] : tensor<?x?xi64>
+// CHECK:         %[[C:.*]] = tensor.empty() : tensor<i32>
+// CHECK:         %[[Y:.*]]:2 = hip.nonzero
+// CHECK-SAME:      outs(%[[E]], %[[C]] : tensor<?x?xi64>, tensor<i32>){{.*}}: tensor<?x?xi64>, tensor<i32>
+// CHECK:         return %[[Y]]#0 : tensor<?x?xi64>
 func.func @refine_nonzero_data_dependent_dim1(
     %ctx: !hip.context,
     %x: tensor<3x4xf16>,
     %d0: index, %d1: index)
     -> tensor<?x?xi64> {
   %e = tensor.empty(%d0, %d1) : tensor<?x?xi64>
-  %y = hip.nonzero(%ctx) ins(%x : tensor<3x4xf16>)
-                          outs(%e : tensor<?x?xi64>)
+  %c = tensor.empty() : tensor<i32>
+  %y, %cnt = hip.nonzero(%ctx) ins(%x : tensor<3x4xf16>)
+                          outs(%e, %c : tensor<?x?xi64>, tensor<i32>)
                           {input_data_type = 1 : i64}
-                          : tensor<?x?xi64>
+                          : tensor<?x?xi64>, tensor<i32>
   return %y : tensor<?x?xi64>
 }
 

--- a/tools/hip-mlir-opt/hip-mlir-opt.cpp
+++ b/tools/hip-mlir-opt/hip-mlir-opt.cpp
@@ -90,8 +90,49 @@ struct HipDstBufferizableModel
   }
 };
 
+// Bufferization model for the non-DPS hip.readback_dim op (mirror of the
+// canonical one in HipBufferize.h). Reads the scalar tensor operand to its
+// memref buffer; the `index` result passes through unchanged.
+struct HipReadbackDimBufferizableModel
+    : public mlir::bufferization::BufferizableOpInterface::ExternalModel<
+          HipReadbackDimBufferizableModel, mlir::hip::ReadbackDimOp> {
+  bool
+  bufferizesToMemoryRead(mlir::Operation *, mlir::OpOperand &,
+                         const mlir::bufferization::AnalysisState &) const {
+    return true;
+  }
+  bool
+  bufferizesToMemoryWrite(mlir::Operation *, mlir::OpOperand &,
+                          const mlir::bufferization::AnalysisState &) const {
+    return false;
+  }
+  mlir::bufferization::AliasingValueList
+  getAliasingValues(mlir::Operation *, mlir::OpOperand &,
+                    const mlir::bufferization::AnalysisState &) const {
+    return {};
+  }
+  mlir::LogicalResult
+  bufferize(mlir::Operation *op, mlir::RewriterBase &rewriter,
+            const mlir::bufferization::BufferizationOptions &options,
+            mlir::bufferization::BufferizationState &state) const {
+    auto readback = mlir::cast<mlir::hip::ReadbackDimOp>(op);
+    mlir::FailureOr<mlir::Value> scalarBuf =
+        getBuffer(rewriter, readback.getScalar(), options, state);
+    if (mlir::failed(scalarBuf))
+      return mlir::failure();
+    auto newOp = mlir::hip::ReadbackDimOp::create(
+        rewriter, op->getLoc(), rewriter.getIndexType(), readback.getCtx(),
+        *scalarBuf);
+    mlir::bufferization::replaceOpWithBufferizedValues(rewriter, op,
+                                                       newOp.getResult());
+    return mlir::success();
+  }
+};
+
 void registerHipBufferizableOpInterfaceModels(mlir::DialectRegistry &registry) {
   registry.addExtension(+[](mlir::MLIRContext *ctx, mlir::hip::HipDialect *) {
+    mlir::hip::ReadbackDimOp::attachInterface<HipReadbackDimBufferizableModel>(
+        *ctx);
     mlir::hip::ConvOp::attachInterface<
         HipDstBufferizableModel<mlir::hip::ConvOp>>(*ctx);
     mlir::hip::ConvTransposeOp::attachInterface<


### PR DESCRIPTION
NonZero's output column count `N` (the number of non-zero elements) is data-dependent, so `convert-onnx-to-hip` over-allocates the indices buffer to the worst-case capacity `numel(X)`. The problem: that *capacity* — not the true count — was flowing downstream as the dynamic dim, so consumers and the ORT-reported output shape saw `numel(X)` columns and read undefined data past the real count `N`.

**Minimal example that demonstrates the issue:**

```mlir
// X: int64[A, B]  (A, B dynamic)
%nz = "onnx.NonZero"(%X)   : (tensor<?x?xi64>) -> tensor<2x?xi64>  // 2nd dim = #nonzero, data-dependent
%y  = "onnx.Sub"(%nz, %nz) : (tensor<2x?xi64>, tensor<2x?xi64>) -> tensor<2x?xi64>  // consumes the ? dim
```

The `?` dim of `%nz` is only known after the kernel scans `X`. With the indices buffer sized to `numel(X)`, the `Sub` (and the graph output) inherited `numel(X)` as its extent instead of the true count, exposing the over-allocated tail.

**The fix:**

* `hip.nonzero` gains a second DPS destination `count` (a device `i32` scalar) that the kernel writes with the true non-zero count `N`.
* A new generic `hip.readback_dim` op synchronizes the stream and reads that device scalar back to a host `index`.
* The conversion slices the over-allocated indices buffer to `[R, N]` (`tensor.extract_slice`), so the true extent — not the capacity — flows to consumers and the output allocator.
* `hip.readback_dim` is non-speculatable (declares a `Read` effect on the scalar): buffer-deallocation sees a *known* (non-allocating) effect, and `hip-hoist-alloc-size-arith` cannot lift the extent-sized allocation above the producing kernel.

`hip.readback_dim` is deliberately operator-agnostic: any op that computes a runtime extent into a device scalar can size a dynamic shape through it. This change wires it up for NonZero, but it is not coupled to NonZero's lowering or kernel.

**IR walkthrough (`convert-onnx-to-hip`):**

<details>
<summary><b>Before</b> — ONNX input; the <code>?</code> dim of the NonZero result is data-dependent</summary>

```mlir
func.func @main_graph(%arg0: !hip.context, %arg1: tensor<?x?xi64> {onnx.name = "X"}) -> (tensor<2x?xi64> {onnx.name = "y1"}) {
  %0 = "onnx.NoValue"() {value} : () -> none
  %1 = "onnx.NonZero"(%arg1) {onnx_node_name = "nonzero1"} : (tensor<?x?xi64>) -> tensor<2x?xi64>
  %2 = "onnx.Sub"(%1, %1) {onnx_node_name = "sub1"} : (tensor<2x?xi64>, tensor<2x?xi64>) -> tensor<2x?xi64>
  "onnx.Return"(%2) : (tensor<2x?xi64>) -> ()
}
```

</details>

<details>
<summary><b>After</b> — <code>hip.nonzero</code> writes <code>count</code>; <code>hip.readback_dim</code> resolves it; <code>extract_slice</code> trims to the true extent</summary>

```mlir
func.func @main_graph(%arg0: !hip.context, %arg1: tensor<?x?xi64> {onnx.name = "X"}) -> tensor<2x?xi64> {
  %dim  = tensor.dim %arg1, %c0 : tensor<?x?xi64>
  %0    = arith.muli %c1, %dim : index
  %dim0 = tensor.dim %arg1, %c1 : tensor<?x?xi64>
  %1    = arith.muli %0, %dim0 : index                          // capacity = numel(X), worst-case upper bound
  %2    = tensor.empty(%1) : tensor<2x?xi64>                     // indices buffer (over-allocated)
  %3    = tensor.empty() : tensor<i32>                           // count buffer
  %4:2  = hip.nonzero(%arg0) ins(%arg1 : tensor<?x?xi64>)
            outs(%2, %3 : tensor<2x?xi64>, tensor<i32>) {input_data_type = 4 : i64} : tensor<2x?xi64>, tensor<i32>
  %5    = hip.readback_dim(%arg0, %4#1 : tensor<i32>) -> index   // true count N (D2H + stream sync)
  %slice = tensor.extract_slice %4#0[0, 0] [2, %5] [1, 1]        // trim [2, capacity] -> [2, N]
            : tensor<2x?xi64> to tensor<2x?xi64>
  %6    = tensor.empty(%dim1) : tensor<2x?xi64>
  %7    = hip.sub(%arg0) ins(%slice, %slice : ...) outs(%6 : tensor<2x?xi64>) : tensor<2x?xi64>
  return %7 : tensor<2x?xi64>
}
```

</details>