### PR TITLE
fix(hip): pass scatter_nd count_ptr and materialize host scalars reached through views

### DIFF
--- a/lib/Conversion/HipToLLVM/ScatterNDLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ScatterNDLowering.cpp
@@ -11,6 +11,7 @@ namespace {
 
 // hip.scatter_nd(ctx, data, indices, updates, output) {reduction}
 //   -> wrap_scatter_nd(state, data_ptr, indices_ptr, updates_ptr, out_ptr,
+//                      count_ptr,
 //                      data_shape_ptr, data_rank,
 //                      indices_shape_ptr, indices_rank,
 //                      updates_shape_ptr, updates_rank,
@@ -18,9 +19,21 @@ namespace {
 //                      reduction_id, data_type)
 //
 // `reduction_id` encodes the ONNX `reduction` string attribute as a small
-// integer enum (see ScatterNDOpLowering::reductionIdFromString below). The
-// runtime side is a stub today that only logs its parameters, but the
-// signature is shaped to match the future kernel implementation.
+// integer enum (see ScatterNDOpLowering::reductionIdFromString below).
+//
+// `count_ptr` is a device pointer to a dynamic "valid index-slice count" that
+// the NonZero->ScatterND path uses to skip padded rows. hip.scatter_nd has no
+// such operand: its `indices` buffer is already truncated to the valid extent
+// upstream (readback_dim -> subview -> transpose), so `indices_shape` already
+// equals the valid count and we pass null. The runtime treats a null count_ptr
+// as "process all num_slices rows".
+//
+// The argument is part of the ABI, not optional: wrap_scatter_nd is a 16-param
+// C function whose 6th parameter is count_ptr. Omitting it shifts every later
+// argument by one slot, so the callee reads the `indices_shape` pointer as
+// `data_rank` and dereferences a small-integer-as-pointer (SIGSEGV). Keep the
+// param list here in lockstep with the wrap_scatter_nd declaration in
+// hipdnn_ep_runtime.h.
 struct ScatterNDOpLowering : public ConvertOpToLLVMPattern<ScatterNDOp> {
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
@@ -99,9 +112,13 @@ struct ScatterNDOpLowering : public ConvertOpToLLVMPattern<ScatterNDOp> {
         createI64Const(reductionIdFromString(op.getReduction()));
     Value dataTypeVal = createI64Const(hipDtype);
 
+    // The op has no valid-count operand; pass null (see file header).
+    Value nullCountPtr = LLVM::ZeroOp::create(rewriter, loc, ptrType);
+
     SmallVector<Type, 16> paramTypes = {
         ptrType, ptrType, ptrType, ptrType, ptrType, // state, data, idx,
                                                      // updates, out
+        ptrType,                                     // count_ptr (nullable)
         ptrType, i64Type,                            // data_shape, data_rank
         ptrType, i64Type,                            // idx_shape, idx_rank
         ptrType, i64Type,                            // upd_shape, upd_rank
@@ -114,9 +131,10 @@ struct ScatterNDOpLowering : public ConvertOpToLLVMPattern<ScatterNDOp> {
       return failure();
 
     SmallVector<Value, 16> args = {
-        statePtr,    dataPtr,  indicesPtr,   updatesPtr,   outPtr,
-        dataShape,   dataRank, indicesShape, indicesRank,  updatesShape,
-        updatesRank, outShape, outRank,      reductionVal, dataTypeVal};
+        statePtr,     dataPtr,      indicesPtr,   updatesPtr,
+        outPtr,       nullCountPtr, dataShape,    dataRank,
+        indicesShape, indicesRank,  updatesShape, updatesRank,
+        outShape,     outRank,      reductionVal, dataTypeVal};
 
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
     rewriter.eraseOp(op);

--- a/lib/Dialect/Transforms/MaterializeHostScalars.cpp
+++ b/lib/Dialect/Transforms/MaterializeHostScalars.cpp
@@ -48,18 +48,37 @@
 // offset.  See test/lit/Dialect/hip-materialize-host-scalars.mlir for the
 // full set of accepted/rejected shapes.
 //
+// Peeking through view ops (host scalar reached via a descriptor edit)
+// --------------------------------------------------------------------
+// Bufferization + CSE often fuse two `tensor.from_elements` shape-arith
+// buffers into one alloc and `memref.reinterpret_cast` it for the second
+// (smaller) use, so the host store reaches its hip consumer through a view:
+//
+//   %alloc = memref.alloc() : memref<3xi64>          // <-- candidate
+//   memref.store %d0, %alloc[%c0] : memref<3xi64>    // host store (direct)
+//   hip.expand ins(%expand, %alloc) ...              // hip consumer (direct)
+//   %rc = memref.reinterpret_cast %alloc to          // view of the alloc
+//           offset: [0], sizes: [1], strides: [1]
+//           : memref<3xi64> to memref<1xi64>
+//   memref.store %n, %rc[%c0] : memref<1xi64>        // host store (via view)
+//   hip.slice ins(..., %rc) ...                      // hip consumer (via view)
+//
+// `classifyHostScalarUsers` recurses through the reinterpret_cast -- which
+// touches no memory of its own -- finds only host-I/O and hip users at the
+// leaves, and accepts the alloc.  Before this peek-through, the lone
+// reinterpret_cast user rejected the alloc, so it stayed in the GPU pool and
+// the host store SEGV'd on targets where the pool is real device memory.
+//
 // Hip-dialect users are accepted, not rejected
 // --------------------------------------------
 // `hipHostMalloc(hipHostMallocMapped)` returns a host pointer that is also
 // GPU-accessible at the same virtual address on UMA targets, so the bare-ptr
 // ABI used by `--convert-hip-to-llvm` consumes the same buffer regardless of
-// whether it was hipMalloc'd or hipHostMalloc'd.  This is the correctness fix
-// vs the early design that rejected hip consumers: the canonical
-// `tensor.from_elements -> reduce_sum + sub + cast -> seqlens_k` GQA
-// pattern produces exactly an alloc with a host `memref.store` followed
-// by a `hip.cast` reading it; rejecting it left the host store crashing
-// inside the GPU pool.  `isHostScalarCandidate` allows `hip.*` users for
-// this reason -- see the inline comment on the user-classification loop.
+// whether it was hipMalloc'd or hipHostMalloc'd.  The canonical
+// `tensor.from_elements -> reduce_sum + sub + cast -> seqlens_k` GQA pattern
+// produces exactly an alloc with a host `memref.store` followed by a
+// `hip.cast` that reads it; an earlier design rejected such hip consumers and
+// left the host store crashing inside the GPU pool.
 //
 // Non-goals
 // ---------
@@ -113,24 +132,43 @@ static int64_t roundUp(int64_t x, int64_t align) {
   return (x + align - 1) & ~(align - 1);
 }
 
-/// True if \p allocOp looks like a tiny host-fed scalar staging buffer:
-///   - static shape, small (<=16 elements)
-///   - integer or index element type (no float -> these are bigger and almost
-///     always GPU-consumed in flight)
-///   - has at least one host I/O user (memref.store or memref.load): this is
-///     the SEGV trigger on targets where the GPU pool is real device memory
-///     — host accessing a GPU-pool address
-///   - every user is in {memref.store, load, dim, dealloc} OR is a hip dialect
-///     op. Hip consumers are fine: hipHostMalloc(hipHostMallocMapped) returns
-///     a host pointer that is also GPU-accessible at the same VA on UMA
-///     targets, so the bare-ptr ABI used by --convert-hip-to-llvm works
-///     whether the backing memory is hipMalloc'd or hipHostMalloc'd.
+/// Classify every transitive user of \p memrefVal and decide whether they are
+/// all compatible with the backing buffer living in host-mapped scratch (see
+/// the file header for the rationale behind each category). Sets \p sawHostIO
+/// when a `memref.store`/`load` is found anywhere in the chain. Returns false
+/// at the first user we cannot vouch for -- an op of an unknown dialect, or a
+/// view whose own users escape.
 ///
-/// Critically, we DO accept allocs with hip op users (writers and readers).
-/// The original implementation rejected those — but the canonical
-/// `tensor.from_elements` -> `reduce_sum + sub + cast -> seqlens_k` pattern
-/// produces exactly such an alloc: `memref.store` from host then `hip.cast`
-/// reads it. Rejecting it left the host store crashing inside the GPU pool.
+/// Pure view/descriptor ops (reinterpret_cast, expand/collapse_shape, subview,
+/// view, cast) touch no memory themselves, so the backing buffer is still a
+/// host-staged scalar; we recurse into the view's result rather than bail.
+static bool classifyHostScalarUsers(Value memrefVal, bool &sawHostIO) {
+  for (Operation *user : memrefVal.getUsers()) {
+    if (isa<memref::StoreOp, memref::LoadOp>(user)) {
+      sawHostIO = true;
+      continue;
+    }
+    if (isa<memref::DimOp, memref::DeallocOp>(user))
+      continue;
+    if (user->getDialect() && user->getDialect()->getNamespace() == "hip")
+      continue;
+    if (isa<memref::ReinterpretCastOp, memref::ExpandShapeOp,
+            memref::CollapseShapeOp, memref::SubViewOp, memref::ViewOp,
+            memref::CastOp>(user)) {
+      if (!classifyHostScalarUsers(user->getResult(0), sawHostIO))
+        return false;
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
+/// True if \p allocOp is a tiny host-fed scalar staging buffer: a static,
+/// small (<= 16 elements), integer-or-index memref with at least one host-I/O
+/// user (possibly reached through view ops) whose entire transitive user set
+/// is host I/O, metadata, or hip consumers. See classifyHostScalarUsers and
+/// the file header for why each constraint exists.
 static bool isHostScalarCandidate(memref::AllocOp allocOp) {
   MemRefType type = allocOp.getType();
   if (!type.hasStaticShape())
@@ -142,21 +180,8 @@ static bool isHostScalarCandidate(memref::AllocOp allocOp) {
     return false;
 
   bool hasHostIO = false;
-  for (Operation *user : allocOp->getUsers()) {
-    if (isa<memref::StoreOp, memref::LoadOp>(user)) {
-      hasHostIO = true;
-      continue;
-    }
-    if (isa<memref::DimOp, memref::DeallocOp>(user))
-      continue;
-    // Hip dialect users (e.g. hip.cast that consumes a host-stored scalar to
-    // produce a GPU i32 for GQA) are fine — see comment above.
-    if (user->getDialect() && user->getDialect()->getNamespace() == "hip")
-      continue;
-    // Anything else (view-likes, casts that escape the function, unknown
-    // dialects) — bail out: we can't reason about its memory expectations.
+  if (!classifyHostScalarUsers(allocOp.getResult(), hasHostIO))
     return false;
-  }
   return hasHostIO;
 }
 

--- a/test/lit/Conversion/hip-to-llvm/test_scatter_nd.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_scatter_nd.mlir
@@ -4,8 +4,11 @@
 // RUN: hip-mlir-opt --convert-hip-to-llvm %s | FileCheck %s
 
 // Verify that hip.scatter_nd lowers to wrap_scatter_nd with the full
-// 15-parameter signature: 5 pointers + 4 shape pointers + 4 ranks +
-// reduction_id + data_type, regardless of the `reduction` attribute value.
+// 16-parameter signature: 5 buffer pointers + count_ptr (nullable, the 6th
+// pointer) + 4 shape pointers + 4 ranks + reduction_id + data_type, regardless
+// of the `reduction` attribute value. The count_ptr slot matters: dropping it
+// shifts every later argument by one and the runtime derefs a
+// shape-pointer-as-rank (SIGSEGV) -- see ScatterNDLowering.cpp header.
 
 module {
   func.func @test_scatter_nd_default(%ctx: !hip.context,
@@ -36,7 +39,7 @@ module {
 }
 
 // CHECK-LABEL: llvm.func @test_scatter_nd_default
-// CHECK: llvm.call @wrap_scatter_nd({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, i64, i64) -> i32
+// CHECK: llvm.call @wrap_scatter_nd({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, i64, i64) -> i32
 
 // CHECK-LABEL: llvm.func @test_scatter_nd_add
-// CHECK: llvm.call @wrap_scatter_nd({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, i64, i64) -> i32
+// CHECK: llvm.call @wrap_scatter_nd({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, i64, i64) -> i32

--- a/test/lit/Dialect/hip-materialize-host-scalars.mlir
+++ b/test/lit/Dialect/hip-materialize-host-scalars.mlir
@@ -123,6 +123,48 @@ func.func @host_store_then_hip_consumer(%ctx: !hip.context,
   return
 }
 
+// --- Host scalar reached through memref.reinterpret_cast: CSE fuses two
+//     from_elements shape-arith buffers into one alloc and reinterpret_casts
+//     it for the second (smaller) use, so the host store reaches its hip
+//     consumer through a view. The pass MUST peek through the view and still
+//     redirect the backing alloc to host scratch (otherwise the host store
+//     lands in the GPU pool and SEGVs on real-device-memory targets). This is
+//     the VLM-embedding regression pattern. ---
+// CHECK-LABEL: func.func @host_scalar_via_reinterpret_cast
+// CHECK-SAME:    (%[[CTX:.*]]: !hip.context
+// CHECK:         %[[SCRATCH:.*]] = hip.get_host_scratch(%[[CTX]],
+// CHECK-NOT:     memref.alloc() : memref<3xi64>
+// CHECK:         %[[V:.*]] = memref.view %[[SCRATCH]]{{.*}} : memref<?xi8> to memref<3xi64>
+// CHECK:         memref.reinterpret_cast %[[V]]
+func.func @host_scalar_via_reinterpret_cast(%ctx: !hip.context, %x: i64,
+                                            %o0: memref<3xi32>,
+                                            %o1: memref<1xi32>) {
+  %c0 = arith.constant 0 : index
+  %a = memref.alloc() : memref<3xi64>
+  memref.store %x, %a[%c0] : memref<3xi64>
+  hip.cast(%ctx) ins(%a : memref<3xi64>) outs(%o0 : memref<3xi32>) {to = 6 : i64}
+  %rc = memref.reinterpret_cast %a to offset: [0], sizes: [1], strides: [1] : memref<3xi64> to memref<1xi64>
+  memref.store %x, %rc[%c0] : memref<1xi64>
+  hip.cast(%ctx) ins(%rc : memref<1xi64>) outs(%o1 : memref<1xi32>) {to = 6 : i64}
+  memref.dealloc %a : memref<3xi64>
+  return
+}
+
+// --- Host scalar whose view escapes to a consumer we can't vouch for (here:
+//     returned from the function): the recursion must still REJECT it, since
+//     we can't reason about the escaped view's memory expectations. ---
+// CHECK-LABEL: func.func @host_scalar_view_escapes_left_alone
+// CHECK-NOT:   hip.get_host_scratch
+// CHECK:       memref.alloc() : memref<3xi64>
+func.func @host_scalar_view_escapes_left_alone(%ctx: !hip.context,
+                                               %x: i64) -> memref<1xi64> {
+  %c0 = arith.constant 0 : index
+  %a = memref.alloc() : memref<3xi64>
+  memref.store %x, %a[%c0] : memref<3xi64>
+  %rc = memref.reinterpret_cast %a to offset: [0], sizes: [1], strides: [1] : memref<3xi64> to memref<1xi64>
+  return %rc : memref<1xi64>
+}
+
 // --- Function whose arg 0 is NOT a !hip.context: the pass silently leaves
 //     it alone (best-effort mitigation; utility funcs without runtime
 //     access don't have a context to call hip.get_host_scratch on). The


### PR DESCRIPTION
Two pre-existing bugs that only the VLM `NonZero -> ScatterND` embedding path exercises, so no prior model surfaced them. #348 added that path (data-dependent NonZero extent), which is what first drove `hip.scatter_nd` and the merged host-scalar shape buffer end-to-end. Both reproduce as a hard SIGSEGV on a text-only prompt (zero image tokens, so the NonZero count `N` is 0).

**Bug 1 - `hip.scatter_nd` lowers to the wrong runtime ABI.**

`wrap_scatter_nd` is a 16-parameter C function whose 6th parameter is `count_ptr` (a nullable device pointer to a dynamic valid-slice count). The HIP->LLVM lowering built the call with only 15 arguments, omitting `count_ptr`:

```mlir
// hip.scatter_nd(%ctx) ins(%data, %indices, %updates) outs(%out) {reduction = "none"}
//   lowered call (BEFORE):  state, data, indices, updates, out,
//                           data_shape, data_rank, idx_shape, idx_rank, ...   // 15 args
//   callee expects:         state, data, indices, updates, out,
//                           count_ptr, data_shape, data_rank, idx_shape, ...  // 16 params
```

Every argument after `out` is shifted by one slot, so the callee reads the `data_shape` *pointer* as `count_ptr`, the `data_rank` *integer* as the `data_shape` pointer, and then dereferences a small integer as a pointer -> SIGSEGV.

**The fix:**

* Pass the missing `count_ptr` so the 16-arg call matches the C declaration in `hipdnn_ep_runtime.h`.
* The op carries no runtime valid-count operand and its `indices` buffer is already truncated to the valid extent upstream (`readback_dim -> extract_slice -> transpose`), so we pass `null`; the kernel then processes all `num_slices` rows, which is correct because the row count already equals the count.
* The hip-to-llvm LIT test encoded the buggy 15-arg signature; it now asserts the 16-arg ABI.

**Bug 2 - `MaterializeHostScalars` misses host scalars reached through a view op.**

The pass redirects tiny host-fed scalar `memref.alloc`s out of the GPU pool into host-mapped scratch (otherwise a host `memref.store` lands in real device memory and SEGVs). Its candidate filter bailed at the first user it could not classify - and after bufferization + CSE fuse two `tensor.from_elements` shape buffers into one alloc and `reinterpret_cast` it for the second use, the host store reaches its hip consumer *through* the cast:

```mlir
%alloc = memref.alloc() : memref<3xi64>          // candidate
memref.store %d0, %alloc[%c0] : memref<3xi64>    // host store (direct)
hip.expand ins(%e, %alloc) ...                   // hip consumer (direct)
%rc = memref.reinterpret_cast %alloc to offset: [0], sizes: [1], strides: [1]
        : memref<3xi64> to memref<1xi64>
memref.store %n, %rc[%c0] : memref<1xi64>        // host store (via view) -- filter bailed here
hip.slice ins(..., %rc) ...                      // hip consumer (via view)
```

The lone `reinterpret_cast` user made the filter reject `%alloc`, so it stayed in the GPU pool and the host store SEGV'd.

**The fix:**

* The user classifier recurses through pure descriptor/view ops (`reinterpret_cast`, `expand_shape`, `collapse_shape`, `subview`, `view`, `cast`) - they touch no memory, so the backing buffer is still a host-staged scalar - and accepts the alloc when every transitive leaf user is host I/O, metadata, or a hip consumer.
* A view chain that escapes to any other consumer still rejects the alloc (conservative, unchanged behaviour for the GPU-pool case).
* New LIT cases cover both the `reinterpret_cast` redirect and the view-escape rejection.

With both fixes the VLM OGA benchmark (text-only prompt, `--prompt 128 --gen 64`) runs to completion and produces coherent output instead of SIGSEGV. Full build + LIT + lint clean.

P.S. `MaterializeHostScalars` is a post-bufferization heuristic (size + element type + host-I/O users). The principled, upstream-aligned design is to carry a host memory space on these buffers as a typed `memref` attribute (assigned at bufferization via `defaultMemorySpaceFn`) and have `hip-pool-allocs` skip non-device spaces (IREE preserves `getMemorySpace()` when packing). That is a cross-cutting change (conversion + bufferization callback + pool filter + lowering + verifiers) and is intentionally out of scope here; I'll track it separately.
