### PR TITLE
feat(onnx-to-hip): Whisper encoder/decoder attention -> hip.gqa (re-land #282 onto main)

### DIFF
--- a/lib/Conversion/OnnxToHip/AttentionConversion.cpp
+++ b/lib/Conversion/OnnxToHip/AttentionConversion.cpp
@@ -1,0 +1,287 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "OnnxToHipUtils.h"
+
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+
+namespace mlir {
+namespace hip {
+namespace {
+
+/// onnx.Custom(com.microsoft.Attention) -> hip.gqa (bidirectional self-attn).
+///
+/// Whisper's encoder uses the legacy com.microsoft.Attention op with a single
+/// fused QKV projection weight + bias.  We rewrite each such node to:
+///
+///   1. One QKV projection over the fused weight (no transpose):
+///        qkv_proj  = onnx.MatMul(hidden, qkv_w)         : [B,S,H] @ [H,3H]
+///                                                            -> [B,S,3H]
+///        qkv_biased = onnx.Add(qkv_proj, qkv_b)         : broadcast on last
+///        dim
+///      The ORT com.microsoft.Attention spec stores the fused weight as
+///      [input_hidden, q_hidden+k_hidden+v_hidden] = [H, 3H] (what Whisper
+///      actually exports — `qkv_proj.weight` is [1280, 3840]).  This is the
+///      canonical layout, so the matmul consumes qkv_w directly — no transpose.
+///
+///   2. Three tensor.extract_slice ops splitting the last axis of qkv_biased
+///      into Q / K / V (`qkv_hidden_sizes`-driven offsets).
+///
+///   3. One hip.gqa with `no_causal = true` (encoder is bidirectional),
+///      `num_heads == kv_num_heads` (HPG=1, multi-head not group-query),
+///      and a compile-time `seqlens_k` / `total_sequence_length` constant
+///      equal to the static query sequence length S.  No past_key/past_value
+///      (encoder self-attn has no KV cache); the present_* outputs are
+///      DPS-style empty buffers that just satisfy the hip.gqa signature.
+///
+/// We keep the QKV projection fused (Option B) rather than splitting the
+/// weight into three independent MatMul/Add chains (Option A): the fused
+/// layout matches what the original ONNX graph already has and produces a
+/// single large GEMM (cleaner lowering, fewer hipBLASLt launches).
+struct AttentionToHip : public mlir::RewritePattern {
+  AttentionToHip(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.Custom", /*benefit=*/1, ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override;
+};
+
+mlir::LogicalResult
+AttentionToHip::matchAndRewrite(mlir::Operation *op,
+                                mlir::PatternRewriter &rewriter) const {
+  auto funcNameAttr = op->getAttrOfType<mlir::StringAttr>("function_name");
+  if (!funcNameAttr || funcNameAttr.getValue() != "Attention")
+    return rewriter.notifyMatchFailure(op, "not an Attention operation");
+
+  auto domainAttr = op->getAttrOfType<mlir::StringAttr>("domain_name");
+  if (!domainAttr || domainAttr.getValue() != "com.microsoft")
+    return rewriter.notifyMatchFailure(
+        op, "domain must be com.microsoft for Attention");
+
+  // === Operands (MS Attention spec) ===
+  // Required: input(hidden), weights(qkv_w), bias(qkv_b).
+  // Optional (5..8): mask_index, past, attention_bias, past_sequence_length.
+  // We only support the encoder-self-attn subset today: no past KV, no mask,
+  // no attention_bias.  Bail out (let it stay as onnx.Custom -> CPU fallback)
+  // if anything else is present.
+  if (op->getNumOperands() < 3)
+    return rewriter.notifyMatchFailure(
+        op, "Attention expects at least 3 operands (input, weights, bias)");
+
+  auto isLive = [](mlir::Value v) {
+    return v && !mlir::isa<mlir::NoneType>(v.getType());
+  };
+
+  for (size_t i = 3; i < op->getNumOperands(); ++i) {
+    if (isLive(op->getOperand(i)))
+      return rewriter.notifyMatchFailure(
+          op, "unsupported optional Attention operand (mask / past / bias / "
+              "past_seqlen) — only encoder-self-attn QKV-only is lowered");
+  }
+
+  mlir::Value hidden = op->getOperand(0);
+  mlir::Value qkvW = op->getOperand(1);
+  mlir::Value qkvB = op->getOperand(2);
+
+  // === Attributes ===
+
+  auto numHeadsAttrOnnx = op->getAttrOfType<mlir::IntegerAttr>("num_heads");
+  if (!numHeadsAttrOnnx)
+    return rewriter.notifyMatchFailure(op, "missing num_heads attribute");
+  const int64_t numHeads = numHeadsAttrOnnx.getValue().getSExtValue();
+  if (numHeads <= 0)
+    return rewriter.notifyMatchFailure(op, "num_heads must be > 0");
+
+  // Required for our path: do_rotary=0, unidirectional=0 (bidirectional),
+  // qkv_hidden_sizes.size() == 3 with equal entries.  Reject anything else
+  // — Whisper encoder always has equal sizes and we don't want to silently
+  // mis-lower a different model.
+  auto getI64 = [&](const char *name, int64_t defaultVal) {
+    auto a = op->getAttrOfType<mlir::IntegerAttr>(name);
+    return a ? a.getValue().getSExtValue() : defaultVal;
+  };
+  if (getI64("do_rotary", 0) != 0)
+    return rewriter.notifyMatchFailure(op, "do_rotary != 0 not supported");
+  if (getI64("unidirectional", 0) != 0)
+    return rewriter.notifyMatchFailure(
+        op,
+        "unidirectional != 0 (causal Attention) not supported on this path");
+  if (getI64("past_present_share_buffer", 0) != 0)
+    return rewriter.notifyMatchFailure(
+        op, "past_present_share_buffer != 0 not supported");
+
+  auto qkvSizesAttr = op->getAttrOfType<mlir::ArrayAttr>("qkv_hidden_sizes");
+  if (!qkvSizesAttr || qkvSizesAttr.size() != 3)
+    return rewriter.notifyMatchFailure(
+        op, "qkv_hidden_sizes must be a 3-element array");
+  llvm::SmallVector<int64_t, 3> qkvSizes;
+  for (mlir::Attribute a : qkvSizesAttr) {
+    auto ia = mlir::dyn_cast<mlir::IntegerAttr>(a);
+    if (!ia)
+      return rewriter.notifyMatchFailure(
+          op, "qkv_hidden_sizes entries must be integers");
+    qkvSizes.push_back(ia.getValue().getSExtValue());
+  }
+  if (qkvSizes[0] != qkvSizes[1] || qkvSizes[1] != qkvSizes[2])
+    return rewriter.notifyMatchFailure(
+        op, "qkv_hidden_sizes entries must be equal (multi-head, HPG=1)");
+  const int64_t qSize = qkvSizes[0]; // == kSize == vSize
+
+  // Scale: ONNX attr if present, else 1/sqrt(head_size).  We pass through to
+  // hip.gqa (which already honors `scale=0.0` as the auto-compute sentinel).
+  auto scaleAttrOnnx = op->getAttrOfType<mlir::FloatAttr>("scale");
+  const float scale =
+      scaleAttrOnnx ? scaleAttrOnnx.getValue().convertToFloat() : 0.0f;
+
+  // === Shape sanity (we need static shapes for the constant seqlens_k) ===
+
+  auto hiddenType = mlir::dyn_cast<mlir::RankedTensorType>(hidden.getType());
+  if (!hiddenType || hiddenType.getRank() != 3 || !hiddenType.hasStaticShape())
+    return rewriter.notifyMatchFailure(
+        op, "hidden must be a static rank-3 tensor [B, S, H]");
+  auto qkvWType = mlir::dyn_cast<mlir::RankedTensorType>(qkvW.getType());
+  if (!qkvWType || qkvWType.getRank() != 2 || !qkvWType.hasStaticShape())
+    return rewriter.notifyMatchFailure(
+        op, "qkv_w must be a static rank-2 tensor [H, 3H]");
+
+  const int64_t batch = hiddenType.getDimSize(0);
+  const int64_t seqLen = hiddenType.getDimSize(1);
+  const int64_t hiddenSize = hiddenType.getDimSize(2);
+  const int64_t qkvHidden = qSize * 3;
+
+  // ORT com.microsoft.Attention spec convention: qkv_w is [H, 3H], i.e.
+  // [input_hidden, q_hidden+k_hidden+v_hidden].  This is what Whisper actually
+  // exports (qkv_proj.weight = [1280, 3840]).  qkv_w.shape[0] must equal H and
+  // qkv_w.shape[1] must equal qkvHidden (3H) — the matmul consumes it directly.
+  if (qkvWType.getDimSize(0) != hiddenSize ||
+      qkvWType.getDimSize(1) != qkvHidden)
+    return rewriter.notifyMatchFailure(
+        op, "qkv_w shape must be [hidden, sum(qkv_hidden_sizes)]");
+
+  if (qSize % numHeads != 0)
+    return rewriter.notifyMatchFailure(
+        op, "qkv_hidden_sizes[0] must be divisible by num_heads");
+
+  // === Context arg ===
+
+  auto ctxOrFailure = getContextArg(op, rewriter);
+  if (mlir::failed(ctxOrFailure))
+    return rewriter.notifyMatchFailure(op, "missing context argument");
+  mlir::Value context = *ctxOrFailure;
+
+  mlir::Location loc = op->getLoc();
+  mlir::Type elemType = hiddenType.getElementType();
+
+  // === 1. Fused QKV projection: [B, S, H] @ [H, 3H] = [B, S, 3H] ==========
+  // The fused weight is already [H, 3H] (ORT Attention spec / Whisper export),
+  // so we feed qkv_w straight into hip.matmul — NO transpose needed.
+  auto projType =
+      mlir::RankedTensorType::get({batch, seqLen, qkvHidden}, elemType);
+  mlir::Value projInit = mlir::tensor::EmptyOp::create(
+      rewriter, loc, projType.getShape(), projType.getElementType());
+  mlir::Value qkvProj =
+      mlir::hip::MatmulOp::create(rewriter, loc, projType, context, hidden,
+                                  qkvW, projInit)
+          .getResult(0);
+
+  // === 2. Add bias (broadcasts on last dim): [B, S, 3H] + [3H] = [B,S,3H] ==
+  mlir::Value addInit = mlir::tensor::EmptyOp::create(
+      rewriter, loc, projType.getShape(), projType.getElementType());
+  mlir::Value qkvBiased =
+      mlir::hip::AddOp::create(rewriter, loc, projType, context, qkvProj, qkvB,
+                               addInit)
+          .getResult(0);
+
+  // === 3. Split qkv_biased along the last axis into Q / K / V =============
+  // Each slice has shape [B, S, qSize]; qSize == kSize == vSize per the
+  // equality check above.
+  auto sliceType =
+      mlir::RankedTensorType::get({batch, seqLen, qSize}, elemType);
+  auto buildSlice = [&](int64_t offsetOnLastAxis) -> mlir::Value {
+    llvm::SmallVector<mlir::OpFoldResult, 3> offsets = {
+        rewriter.getIndexAttr(0), rewriter.getIndexAttr(0),
+        rewriter.getIndexAttr(offsetOnLastAxis)};
+    llvm::SmallVector<mlir::OpFoldResult, 3> sizes = {
+        rewriter.getIndexAttr(batch), rewriter.getIndexAttr(seqLen),
+        rewriter.getIndexAttr(qSize)};
+    llvm::SmallVector<mlir::OpFoldResult, 3> strides(3,
+                                                     rewriter.getIndexAttr(1));
+    mlir::OperationState sliceState(
+        loc, mlir::tensor::ExtractSliceOp::getOperationName());
+    mlir::tensor::ExtractSliceOp::build(rewriter, sliceState, sliceType,
+                                        qkvBiased, offsets, sizes, strides);
+    mlir::Operation *sliceOp = rewriter.create(sliceState);
+    return sliceOp->getResult(0);
+  };
+  mlir::Value query = buildSlice(0);
+  mlir::Value key = buildSlice(qSize);
+  mlir::Value value = buildSlice(2 * qSize);
+
+  // === 4. Build seqlens_k = [S, S, ..., S]  and total_seq_len = S =========
+  //
+  // WHY a compile-time constant (not a runtime input): encoder self-attention
+  // has no padding mask — every token along the time dim S is a valid input
+  // (Whisper pads its mel-spectrogram up-front, before the encoder), so the
+  // valid-KV-length is exactly S for every batch element on every call.  No
+  // per-call runtime value is needed; we emit arith.constant tensors that
+  // const-fold downstream.
+  //
+  // hip.gqa derives the per-batch KV length from seqlens_k (1-D [B] i32)
+  // and the cache-buffer total length from total_sequence_length (scalar i32).
+  auto i32Ty = rewriter.getIntegerType(32);
+  auto seqlensKType = mlir::RankedTensorType::get({batch}, i32Ty);
+  llvm::SmallVector<llvm::APInt, 1> seqlensVals(
+      static_cast<size_t>(batch), llvm::APInt(32, seqLen, /*isSigned=*/true));
+  auto seqlensKAttr = mlir::DenseElementsAttr::get(
+      seqlensKType, llvm::ArrayRef<llvm::APInt>(seqlensVals));
+  mlir::Value seqlensK =
+      mlir::arith::ConstantOp::create(rewriter, loc, seqlensKAttr);
+
+  auto totalSeqLenType = mlir::RankedTensorType::get({}, i32Ty);
+  auto totalSeqLenAttr = mlir::DenseElementsAttr::get(
+      totalSeqLenType, llvm::APInt(32, seqLen, /*isSigned=*/true));
+  mlir::Value totalSeqLen =
+      mlir::arith::ConstantOp::create(rewriter, loc, totalSeqLenAttr);
+
+  // === 5. Build hip.gqa ====================================================
+  //
+  // Output 1 is the only ONNX-visible result (encoder self-attn has no KV
+  // cache exposed).  hip.gqa always emits present_key/present_value tensors
+  // (no_causal does NOT change the op signature), so we create DPS init
+  // buffers for them but discard their results.
+  //
+  // Cache buffer layout: [B, kv_num_heads, S, head_size] (BNSH).
+  auto outputType =
+      mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
+  if (outputType.getShape() != hiddenType.getShape())
+    return rewriter.notifyMatchFailure(
+        op, "Attention output shape must match input hidden shape");
+
+  auto presentType = mlir::RankedTensorType::get(
+      {batch, numHeads, seqLen, qSize / numHeads}, elemType);
+
+  // Delegate hip.gqa construction to the shared builder (see
+  // OnnxToHipUtils.h).  Encoder self-attn has no KV cache, so we pass
+  // pastKey/pastValue=nullptr and let the builder zero out those operand
+  // segments.  The op has a single ONNX-visible result (output); the builder
+  // positionally maps result[0]=output and drops the synthesized
+  // present_key/present_value on the floor.
+  return buildHipGqaCall(op, rewriter, context, query, key, value,
+                         /*pastKey=*/nullptr, /*pastValue=*/nullptr, seqlensK,
+                         totalSeqLen, numHeads, scale, /*noCausal=*/true,
+                         outputType, presentType, presentType);
+}
+
+} // namespace
+
+void populateAttentionConversionPatterns(RewritePatternSet &patterns,
+                                         MLIRContext *ctx) {
+  patterns.add<AttentionToHip>(ctx);
+}
+
+} // namespace hip
+} // namespace mlir

--- a/lib/Conversion/OnnxToHip/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHip/CMakeLists.txt
@@ -22,6 +22,8 @@ add_library(OnnxToHip STATIC
   RotaryEmbeddingConversion.cpp
   GqaConversion.cpp
   MultiHeadAttentionConversion.cpp
+  AttentionConversion.cpp
+  HipGqaBuilder.cpp
   GatherConversion.cpp
   GatherShapeFold.cpp
   ReshapeShapeFold.cpp

--- a/lib/Conversion/OnnxToHip/HipGqaBuilder.cpp
+++ b/lib/Conversion/OnnxToHip/HipGqaBuilder.cpp
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- HipGqaBuilder.cpp - Shared hip.gqa op builder ---------------------===//
+//
+// Builds a hip.gqa op with the AttrSizedOperandSegments layout used by the
+// Whisper attention lowering paths.  Used by both MultiHeadAttentionConversion
+// (Whisper decoder self-attn + cross-attn) and AttentionConversion (Whisper
+// encoder fused-QKV self-attn) so the 19-slot operand-segments table and
+// OperationState boilerplate live in exactly one place.
+//
+// The two callers map onto the same builder by passing nullptr for the
+// past_key / past_value operands when no KV cache is involved (encoder /
+// cross-attn).  See callers for the dispatch logic that decides which
+// no_causal / seqlens_k / total_seq_len values to feed in.
+//
+//===----------------------------------------------------------------------===//
+
+#include "OnnxToHipUtils.h"
+
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+
+namespace mlir {
+namespace hip {
+
+mlir::LogicalResult
+buildHipGqaCall(mlir::Operation *op, mlir::PatternRewriter &rewriter,
+                mlir::Value context, mlir::Value query, mlir::Value key,
+                mlir::Value value, mlir::Value pastKey, mlir::Value pastValue,
+                mlir::Value seqlensK, mlir::Value totalSeqLen, int64_t numHeads,
+                float scale, bool noCausal, mlir::RankedTensorType outputType,
+                mlir::RankedTensorType presentKeyType,
+                mlir::RankedTensorType presentValueType) {
+  mlir::Location loc = op->getLoc();
+
+  // DPS init buffers.  Derive dynamic dims of present_* from past_* when
+  // available (same buffer shape after concat), otherwise from query (size
+  // unused at compile time for the static-shape Whisper case).
+  mlir::Value outputInit = createEmptyTensor(rewriter, loc, outputType, query);
+  mlir::Value presentKeyInit = createEmptyTensor(rewriter, loc, presentKeyType,
+                                                 pastKey ? pastKey : query);
+  mlir::Value presentValueInit = createEmptyTensor(
+      rewriter, loc, presentValueType, pastValue ? pastValue : query);
+
+  llvm::SmallVector<mlir::Type> resultTypes = {outputType, presentKeyType,
+                                               presentValueType};
+
+  // Operand order matches Hip_GqaOp's AttrSizedOperandSegments layout.
+  llvm::SmallVector<mlir::Value> operands;
+  operands.push_back(context);
+  operands.push_back(query);
+  operands.push_back(key);
+  operands.push_back(value);
+  if (pastKey)
+    operands.push_back(pastKey);
+  if (pastValue)
+    operands.push_back(pastValue);
+  operands.push_back(seqlensK);
+  operands.push_back(totalSeqLen);
+  operands.push_back(outputInit);
+  operands.push_back(presentKeyInit);
+  operands.push_back(presentValueInit);
+
+  // segmentSizes order MUST match HipOps.td Hip_GqaOp argument order.
+  llvm::SmallVector<int32_t> segmentSizes;
+  segmentSizes.push_back(1);                 // ctx
+  segmentSizes.push_back(1);                 // query
+  segmentSizes.push_back(1);                 // key
+  segmentSizes.push_back(1);                 // value
+  segmentSizes.push_back(pastKey ? 1 : 0);   // past_key
+  segmentSizes.push_back(pastValue ? 1 : 0); // past_value
+  segmentSizes.push_back(1);                 // seqlens_k
+  segmentSizes.push_back(1);                 // total_seq_len
+  segmentSizes.push_back(0);                 // cos_cache
+  segmentSizes.push_back(0);                 // sin_cache
+  segmentSizes.push_back(0);                 // position_ids
+  segmentSizes.push_back(0);                 // attention_bias
+  segmentSizes.push_back(0);                 // head_sink
+  segmentSizes.push_back(0);                 // k_scale
+  segmentSizes.push_back(0);                 // v_scale
+  segmentSizes.push_back(1);                 // output
+  segmentSizes.push_back(1);                 // present_key
+  segmentSizes.push_back(1);                 // present_value
+  segmentSizes.push_back(0);                 // output_qk
+
+  llvm::SmallVector<mlir::NamedAttribute> attrs;
+  attrs.push_back(
+      rewriter.getNamedAttr("num_heads", rewriter.getI64IntegerAttr(numHeads)));
+  attrs.push_back(rewriter.getNamedAttr("kv_num_heads",
+                                        rewriter.getI64IntegerAttr(numHeads)));
+  attrs.push_back(
+      rewriter.getNamedAttr("scale", rewriter.getF32FloatAttr(scale)));
+  attrs.push_back(
+      rewriter.getNamedAttr("no_causal", rewriter.getBoolAttr(noCausal)));
+
+  mlir::OperationState gqaState(loc, "hip.gqa");
+  gqaState.addOperands(operands);
+  gqaState.addTypes(resultTypes);
+  gqaState.addAttributes(attrs);
+  gqaState.addAttribute("operand_segment_sizes",
+                        rewriter.getDenseI32ArrayAttr(segmentSizes));
+  mlir::Operation *gqaOp = rewriter.create(gqaState);
+
+  // Replace by positional mapping: the original op's results [0..N) become
+  // the hip.gqa's results [0..N).  Callers that don't expose present_* (e.g.
+  // encoder Attention with a single output, or cross-attn with one output)
+  // simply have fewer original results and the trailing hip.gqa results are
+  // dropped on the floor.
+  llvm::SmallVector<mlir::Value> replacements;
+  for (size_t i = 0; i < op->getNumResults(); ++i)
+    replacements.push_back(gqaOp->getResult(i));
+  rewriter.replaceOp(op, replacements);
+  return mlir::success();
+}
+
+} // namespace hip
+} // namespace mlir

--- a/lib/Conversion/OnnxToHip/MultiHeadAttentionConversion.cpp
+++ b/lib/Conversion/OnnxToHip/MultiHeadAttentionConversion.cpp
@@ -5,13 +5,42 @@
 
 #include "OnnxToHipUtils.h"
 
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+
 #include <cmath>
 
 namespace mlir {
 namespace hip {
 namespace {
 
-/// onnx.Custom(com.microsoft.MultiHeadAttention) -> hip.multi_head_attention
+/// onnx.Custom(com.microsoft.MultiHeadAttention) -> hip.{multi_head_attention,
+/// gqa}.
+///
+/// Dispatch (in order):
+///   1. 9-input MHA with past_key/past_value AND past_sequence_length, with
+///      `past_present_share_buffer = 1` — this is Whisper decoder self-attn
+///      AFTER the Task-9 ONNX surgery threads `past_sequence_length` into the
+///      graph.  Lower to `hip.gqa(no_causal=false)` with `seqlens_k =
+///      operands[8]` (runtime value).  Causal mask is kept (autoregressive).
+///
+///   2. 8-input MHA with EMPTY past_key/past_value slots — this is Whisper
+///      decoder cross-attn (K/V come from encoder output, not a KV cache).
+///      Lower to `hip.gqa(no_causal=true)` with `seqlens_k` as a constant
+///      tensor [Skv,…,Skv] equal to the K's static sequence length.  Cross-
+///      attention is bidirectional (Q can see all of K).
+///
+///   3. Everything else (8-input pre-surgery decoder self-attn, plain 3-input
+///      MHA, models with bias / mask / attention_bias, etc.) — keep the
+///      existing `hip.multi_head_attention` lowering.  This preserves Llama
+///      and gpt-oss behaviour and gives the unmodified Whisper self-attn form
+///      a working (if slower) CPU-fallback path.
+///
+/// The constant `seqlens_k` / `total_sequence_length` for the cross-attn case
+/// are emitted as `arith.constant` (not `onnx.Constant`): the greedy rewrite
+/// driver runs with `ExistingOps` strictness, so newly-emitted onnx.* ops
+/// would NOT be picked up by their lowering patterns in this pass.  See the
+/// same comment in `AttentionConversion.cpp`.
 struct MultiHeadAttentionToHip : public mlir::RewritePattern {
   MultiHeadAttentionToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Custom", /*benefit=*/1, ctx) {}
@@ -113,6 +142,140 @@ mlir::LogicalResult MultiHeadAttentionToHip::matchAndRewrite(
   auto maskFilterValueAttr = getFloatAttr("mask_filter_value", -10000.0f);
   auto scaleAttr = getFloatAttr("scale", 0.0f);
   auto unidirectionalAttr = getI64Attr("unidirectional", 0);
+
+  // === Whisper-style dispatch to hip.gqa ====================================
+  //
+  // Branch 2 (decoder self-attn after Task-9 surgery): 9-input form, both
+  // past_* present, AND the past_sequence_length operand (slot 8) present.
+  // Bias / mask / attention_bias / cache_indirection must all be absent —
+  // those signals would require additional hip.gqa wiring that this
+  // Whisper-targeted path doesn't model.
+  //
+  // The discriminator is the PRESENCE of the past_sequence_length operand, NOT
+  // a past_present_share_buffer attribute. ORT's
+  // com.microsoft.MultiHeadAttention schema rejects that attribute (it lives on
+  // GroupQueryAttention/Attention), so the Task-9 surgery threads only the
+  // input — and the input alone uniquely identifies the shared-buffer self-attn
+  // form (cross-attn has empty slot 8; plain self-attn without surgery has no
+  // slot 8 at all).
+  const bool noExtraInputs =
+      !bias && !keyPaddingMask && !attentionBias && !cacheIndirection;
+  const bool hasFullSelfAttnTrio =
+      key && value && pastKey && pastValue && pastSequenceLength;
+
+  if (noExtraInputs && hasFullSelfAttnTrio) {
+    // Decoder self-attn with past, post-surgery → hip.gqa(no_causal=false).
+    //
+    // seqlens_k: ONNX threads this as a [1]-i32 input named
+    // `past_sequence_length` (1-D, batch=1 today).  hip.gqa expects a 1-D
+    // [B]-i32 seqlens_k.  These match — we forward operand[8] directly.
+    //
+    // total_seq_len: the runtime infers `(past_seq_len + S)` itself from
+    // seqlens_k + the query's S dim, so we don't need to compute it on the
+    // MLIR side.  We pass `seqlens_k` again as a placeholder (any rank-0 or
+    // rank-1 i32 tensor works since the kernel reads seqlens_k for the actual
+    // KV length).  Actually hip.gqa REQUIRES a scalar total_seq_len, so we
+    // emit a constant tensor of `present_key.shape[2]` — the static buffer
+    // size from the IR (== `past_sequence_length_max + S`, baked in at compile
+    // time).
+    auto presentKType =
+        mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(1).getType());
+    if (!presentKType || presentKType.getRank() != 4 ||
+        presentKType.isDynamicDim(2))
+      return rewriter.notifyMatchFailure(
+          op, "post-surgery self-attn requires present_key with static dim 2");
+    const int64_t totalLen = presentKType.getDimSize(2);
+
+    auto i32Ty = rewriter.getIntegerType(32);
+    auto totalSeqLenType = mlir::RankedTensorType::get({}, i32Ty);
+    auto totalSeqLenAttr = mlir::DenseElementsAttr::get(
+        totalSeqLenType, llvm::APInt(32, totalLen, /*isSigned=*/true));
+    mlir::Value totalSeqLen =
+        mlir::arith::ConstantOp::create(rewriter, loc, totalSeqLenAttr);
+
+    auto outputType =
+        mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
+    auto presentValueType =
+        mlir::cast<mlir::RankedTensorType>(op->getResult(2).getType());
+
+    return buildHipGqaCall(
+        op, rewriter, context, query, key, value, pastKey, pastValue,
+        /*seqlensK=*/pastSequenceLength, totalSeqLen,
+        numHeadsAttr.getValue().getSExtValue(),
+        scaleAttr.getValue().convertToFloat(), /*noCausal=*/false, outputType,
+        presentKType, presentValueType);
+  }
+
+  // Branch 1 (decoder cross-attn): 8-input form, K/V supplied, past slots
+  // EMPTY (no KV cache — K/V come directly from encoder output), no
+  // bias/mask/attention_bias/cache_indirection.  The past_sequence_length
+  // slot (input 9) is also empty for this form.
+  //
+  // CRITICAL: gate on `numOps >= 8` so plain 3-input MHA (basic self-attn
+  // with just Q/K/V, no past slots even declared) keeps using the existing
+  // hip.multi_head_attention path.  The Whisper cross-attn pattern is
+  // recognisable specifically by the 8 (or more) operands with empty past
+  // slots — a graph author that built the op with only 3 operands didn't
+  // intend cross-attn semantics.
+  if (numOps >= 8 && noExtraInputs && key && value && !pastKey && !pastValue &&
+      !pastSequenceLength && !cacheIndirection) {
+    // Cross-attn: no_causal=true, seqlens_k = constant [Skv,…,Skv].
+    //
+    // Skv is K's sequence-length dim.  ONNX MHA's K can come in two layouts:
+    //   * 3-D [B, Skv, hidden]            (separate K activation)
+    //   * 4-D [B, num_heads, Skv, head]   (pre-split K cache — Whisper cross)
+    // Detect by rank.
+    auto keyType = mlir::dyn_cast<mlir::RankedTensorType>(key.getType());
+    if (!keyType || !keyType.hasStaticShape())
+      return rewriter.notifyMatchFailure(
+          op, "cross-attn dispatch requires static-shape key");
+    int64_t batch = keyType.getDimSize(0);
+    int64_t skv;
+    // We currently only support rank-4 BNSH cross-attention keys (the Whisper
+    // path). Rank-3 keys would require synthesizing BNSH layout via a reshape;
+    // no test exercises this path today, so reject loudly rather than ship
+    // silent dead code.
+    if (keyType.getRank() == 4)
+      skv = keyType.getDimSize(2);
+    else
+      return rewriter.notifyMatchFailure(
+          op, "cross-attn rank-3 key not yet supported; expected rank-4 BNSH");
+
+    auto i32Ty = rewriter.getIntegerType(32);
+    auto seqlensKType = mlir::RankedTensorType::get({batch}, i32Ty);
+    llvm::SmallVector<llvm::APInt, 1> seqlensVals(
+        static_cast<size_t>(batch), llvm::APInt(32, skv, /*isSigned=*/true));
+    auto seqlensKAttr = mlir::DenseElementsAttr::get(
+        seqlensKType, llvm::ArrayRef<llvm::APInt>(seqlensVals));
+    mlir::Value seqlensK =
+        mlir::arith::ConstantOp::create(rewriter, loc, seqlensKAttr);
+
+    auto totalSeqLenType = mlir::RankedTensorType::get({}, i32Ty);
+    auto totalSeqLenAttr = mlir::DenseElementsAttr::get(
+        totalSeqLenType, llvm::APInt(32, skv, /*isSigned=*/true));
+    mlir::Value totalSeqLen =
+        mlir::arith::ConstantOp::create(rewriter, loc, totalSeqLenAttr);
+
+    auto outputType =
+        mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
+
+    // hip.gqa always emits present_key / present_value buffers.  Cross-attn
+    // has no KV cache exposed at the ONNX boundary, so the present_* types
+    // just mirror K/V (they're discarded after the call).  K is guaranteed to
+    // be rank-4 BNSH here — the rank-3 case was rejected above.
+    auto valueType = mlir::cast<mlir::RankedTensorType>(value.getType());
+    mlir::RankedTensorType presentKType = keyType;
+    mlir::RankedTensorType presentVType = valueType;
+    const int64_t numHeads = numHeadsAttr.getValue().getSExtValue();
+
+    return buildHipGqaCall(
+        op, rewriter, context, query, key, value,
+        /*pastKey=*/nullptr, /*pastValue=*/nullptr, seqlensK, totalSeqLen,
+        numHeads, scaleAttr.getValue().convertToFloat(),
+        /*noCausal=*/true, outputType, presentKType, presentVType);
+  }
+
+  // === Default: existing hip.multi_head_attention lowering (unchanged) =====
 
   // === Check Outputs (1-4: output, [present_key, present_value, qk]) ===
 

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -481,6 +481,7 @@ static mlir::LogicalResult convertComputeOps(mlir::func::FuncOp funcOp,
   populateRotaryEmbeddingConversionPatterns(patterns, ctx);
   populateGqaConversionPatterns(patterns, ctx);
   populateMultiHeadAttentionConversionPatterns(patterns, ctx);
+  populateAttentionConversionPatterns(patterns, ctx);
   populateMatMulNBitsConversionPatterns(patterns, ctx);
   populateQMoEConversionPatterns(patterns, ctx);
   populateReshapeConversionPatterns(patterns, ctx);

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
@@ -169,6 +169,40 @@ getContextArg(mlir::Operation *op, mlir::PatternRewriter &rewriter) {
   return ctx;
 }
 
+/// Build a hip.gqa op for the Whisper-MHA / Whisper-encoder-Attention paths.
+///
+/// Emits one `hip.gqa` op with the 19-slot AttrSizedOperandSegments layout
+/// and replaces \p op's results positionally with the hip.gqa's results
+/// (callers with fewer than 3 results — e.g. cross-attn or fused-QKV
+/// Attention — simply drop the trailing present_* outputs on the floor).
+///
+/// Defined in HipGqaBuilder.cpp.  Shared between
+/// MultiHeadAttentionConversion.cpp and AttentionConversion.cpp.
+///
+/// \param numHeads        N (== kv_num_heads; HPG=1, multi-head, not GQA)
+/// \param scale           ONNX `scale` attr, or 0.0 sentinel for "auto-compute
+///                        1/sqrt(head_size) at runtime"
+/// \param noCausal        true for bidirectional (encoder / cross-attn);
+///                        false for causal (decoder self-attn)
+/// \param pastKey/pastValue  Past KV-cache buffers; nullptr when absent
+///                        (encoder / cross-attn).  When null the corresponding
+///                        operand_segment_size is 0.
+/// \param seqlensK        1-D [B] i32 (must already be in scope; either a
+///                        runtime arg or an arith.constant)
+/// \param totalSeqLen     scalar i32 (must already be in scope)
+/// \param outputType      hip.gqa output[0] type (== query type)
+/// \param presentKeyType  hip.gqa present_key type (BNSH); for cross-attn or
+///                        encoder paths an unused-but-required DPS init buffer
+/// \param presentValueType ditto for present_value
+mlir::LogicalResult
+buildHipGqaCall(mlir::Operation *op, mlir::PatternRewriter &rewriter,
+                mlir::Value context, mlir::Value query, mlir::Value key,
+                mlir::Value value, mlir::Value pastKey, mlir::Value pastValue,
+                mlir::Value seqlensK, mlir::Value totalSeqLen, int64_t numHeads,
+                float scale, bool noCausal, mlir::RankedTensorType outputType,
+                mlir::RankedTensorType presentKeyType,
+                mlir::RankedTensorType presentValueType);
+
 // Pattern population functions (one per operator file)
 void populateMatMulConversionPatterns(RewritePatternSet &patterns,
                                       MLIRContext *ctx);
@@ -200,6 +234,8 @@ void populateGqaConversionPatterns(RewritePatternSet &patterns,
                                    MLIRContext *ctx);
 void populateMultiHeadAttentionConversionPatterns(RewritePatternSet &patterns,
                                                   MLIRContext *ctx);
+void populateAttentionConversionPatterns(RewritePatternSet &patterns,
+                                         MLIRContext *ctx);
 void populateGatherConversionPatterns(RewritePatternSet &patterns,
                                       MLIRContext *ctx);
 void populateShapeConversionPatterns(RewritePatternSet &patterns,

--- a/test/lit/Conversion/onnx-to-hip/test_whisper_cross_mha.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_whisper_cross_mha.mlir
@@ -1,0 +1,102 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify com.microsoft.MultiHeadAttention (via onnx.Custom) — the 8-input form
+// used by Whisper's decoder cross-attention — lowers to hip.gqa with:
+//   * no_causal = true (cross-attn is bidirectional: Q can see all K),
+//   * num_heads == kv_num_heads (HPG=1; MHA, not group-query),
+//   * a compile-time arith.constant seqlens_k = [Skv,…,Skv] (every cross-attn
+//     batch element attends to the full encoder output, no padding),
+//   * a compile-time arith.constant total_seq_len = Skv.
+//
+// Dispatch signal: 8-input MHA with K/V present AND past_key/past_value slots
+// empty (operands[6,7] = NoValue) AND past_sequence_length empty
+// (operands[8] missing/empty).  K/V come from encoder output (not a cache).
+// ============================================================================
+
+// RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip | FileCheck %s
+
+module {
+  // Whisper-large-v3 decoder cross-attn: Q from decoder (1 token), K/V from
+  // encoder output already split into BNSH (B=1, N=20 heads, Skv=1500, d=64).
+  func.func @main_graph(
+      %q:  tensor<1x1x1280xf16>,
+      %k:  tensor<1x20x1500x64xf16>,
+      %v:  tensor<1x20x1500x64xf16>)
+      -> tensor<1x1x1280xf16> {
+
+    // CHECK-LABEL: func.func @main_graph
+    // CHECK-SAME: (%[[CTX:.*]]: !hip.context,
+
+    %none1 = "onnx.NoValue"() {value} : () -> none
+    %none2 = "onnx.NoValue"() {value} : () -> none
+    %none3 = "onnx.NoValue"() {value} : () -> none
+    %none4 = "onnx.NoValue"() {value} : () -> none
+    %none5 = "onnx.NoValue"() {value} : () -> none
+
+    %0 = "onnx.Custom"(%q, %k, %v, %none1, %none2, %none3, %none4, %none5)
+         <{function_name = "MultiHeadAttention"}>
+         {domain_name = "com.microsoft",
+          num_heads = 20 : si64,
+          scale = 1.250000e-01 : f32,
+          unidirectional = 0 : si64,
+          mask_filter_value = -1.000000e+04 : f32}
+         : (tensor<1x1x1280xf16>, tensor<1x20x1500x64xf16>, tensor<1x20x1500x64xf16>,
+            none, none, none, none, none) -> tensor<1x1x1280xf16>
+
+    // Constant seqlens_k = [1500] (1-element i32, batch=1) and
+    // total_seq_len = 1500 (scalar i32). DAG because MLIR may print the
+    // scalar before the 1-element tensor or vice versa.
+    // CHECK-DAG: arith.constant dense<1500> : tensor<1xi32>
+    // CHECK-DAG: arith.constant dense<1500> : tensor<i32>
+    // The MHA op lowers to hip.gqa with no_causal=true, HPG=1.
+    // CHECK: hip.gqa(%[[CTX]])
+    // CHECK-SAME: kv_num_heads = 20
+    // CHECK-SAME: no_causal = true
+    // CHECK-SAME: num_heads = 20
+    // CHECK-NOT: hip.multi_head_attention
+
+    return %0 : tensor<1x1x1280xf16>
+  }
+
+  // ===========================================================================
+  // Regression: pre-surgery decoder self-attn (8-input WITH past_key/past_value
+  // non-empty) MUST keep lowering to hip.multi_head_attention — Task 8 only
+  // changes the empty-past 8-input case.  The post-surgery 9-input form is
+  // covered by test_whisper_self_mha_with_past.mlir.
+  // ===========================================================================
+  func.func @decoder_self_pre_surgery(
+      %q:        tensor<1x1x1280xf16>,
+      %k:        tensor<1x1x1280xf16>,
+      %v:        tensor<1x1x1280xf16>,
+      %past_k:   tensor<1x20x447x64xf16>,
+      %past_v:   tensor<1x20x447x64xf16>)
+      -> (tensor<1x1x1280xf16>, tensor<1x20x448x64xf16>, tensor<1x20x448x64xf16>) {
+    // CHECK-LABEL: func.func @decoder_self_pre_surgery
+
+    %none1 = "onnx.NoValue"() {value} : () -> none
+    %none2 = "onnx.NoValue"() {value} : () -> none
+    %none3 = "onnx.NoValue"() {value} : () -> none
+
+    %out:3 = "onnx.Custom"(%q, %k, %v, %none1, %none2, %none3, %past_k, %past_v)
+        <{function_name = "MultiHeadAttention"}>
+        {domain_name = "com.microsoft",
+         num_heads = 20 : si64,
+         scale = 1.250000e-01 : f32,
+         unidirectional = 1 : si64,
+         mask_filter_value = -1.000000e+04 : f32}
+        : (tensor<1x1x1280xf16>, tensor<1x1x1280xf16>, tensor<1x1x1280xf16>,
+           none, none, none, tensor<1x20x447x64xf16>, tensor<1x20x447x64xf16>)
+        -> (tensor<1x1x1280xf16>, tensor<1x20x448x64xf16>, tensor<1x20x448x64xf16>)
+
+    // 8-input WITH past_key/past_value present and no past_sequence_length
+    // → existing hip.multi_head_attention lowering (NOT hip.gqa).
+    // CHECK: hip.multi_head_attention
+    // CHECK-NOT: hip.gqa
+
+    return %out#0, %out#1, %out#2
+      : tensor<1x1x1280xf16>, tensor<1x20x448x64xf16>, tensor<1x20x448x64xf16>
+  }
+}

--- a/test/lit/Conversion/onnx-to-hip/test_whisper_encoder_attention.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_whisper_encoder_attention.mlir
@@ -1,0 +1,98 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify com.microsoft.Attention (via onnx.Custom) — the fused-QKV
+// bidirectional-self-attention op used by Whisper's encoder — lowers to:
+//   * One QKV projection (MatMul + Add bias) over the fused weight.  The
+//     weight is [H, 3H] (ORT Attention spec / what Whisper exports:
+//     qkv_proj.weight = [1280, 3840]), so it feeds the MatMul DIRECTLY — there
+//     must be NO weight transpose.
+//   * Three tensor.extract_slice ops splitting the [B,S,3*H] activation
+//     into Q / K / V along the last axis (Option B: 1 fused MatMul + 3 slices,
+//     not 3 separate MatMul/Add).  The fused-weight layout matches what the
+//     original ONNX graph already has; we keep one large GEMM instead of
+//     splitting weights at compile time.
+//   * One hip.gqa with no_causal = true, num_heads == kv_num_heads (HPG=1),
+//     and a compile-time seqlens_k constant equal to the static Skv.
+//
+// Sources covered:
+//   - Whisper-large-v3 encoder Attention nodes (32 layers, identical shapes,
+//     d_model=1280, num_heads=20, head_dim=64, S=1500).
+// ============================================================================
+
+// RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip | FileCheck %s
+
+module {
+  func.func @main_graph(
+      %hidden: tensor<1x1500x1280xf16>,
+      %qkv_w:  tensor<1280x3840xf16>,
+      %qkv_b:  tensor<3840xf16>)
+      -> tensor<1x1500x1280xf16> {
+
+    // CHECK-LABEL: func.func @main_graph
+    // CHECK-SAME: (%[[CTX:.*]]: !hip.context,
+
+    %none1 = "onnx.NoValue"() {value} : () -> none
+    %none2 = "onnx.NoValue"() {value} : () -> none
+    %none3 = "onnx.NoValue"() {value} : () -> none
+    %none4 = "onnx.NoValue"() {value} : () -> none
+
+    // Real Whisper-large-v3 encoder weight layout: [H, 3H] = [1280, 3840]
+    // (ORT com.microsoft.Attention spec convention, output dims = q+k+v hidden).
+    %out = "onnx.Custom"(%hidden, %qkv_w, %qkv_b, %none1, %none2, %none3, %none4)
+        <{function_name = "Attention"}>
+        {domain_name = "com.microsoft",
+         num_heads = 20 : si64,
+         qkv_hidden_sizes = [1280, 1280, 1280],
+         unidirectional = 0 : si64,
+         do_rotary = 0 : si64,
+         past_present_share_buffer = 0 : si64,
+         rotary_embedding_dim = 0 : si64,
+         scale = 1.250000e-01 : f32,
+         mask_filter_value = -1.000000e+04 : f32}
+        : (tensor<1x1500x1280xf16>, tensor<1280x3840xf16>, tensor<3840xf16>,
+           none, none, none, none)
+        -> tensor<1x1500x1280xf16>
+
+    // The weight is already [H, 3H], so the fused QKV projection is just
+    // hip.matmul + hip.add — NO weight transpose must be emitted.
+    // CHECK-NOT: hip.transpose
+    // CHECK: hip.matmul
+    // CHECK: hip.add
+    // Three slices on the projected activation produce Q / K / V.
+    // CHECK-COUNT-3: tensor.extract_slice
+    // hip.gqa is bidirectional (no_causal=true) and uses HPG=1.
+    // CHECK: hip.gqa(%[[CTX]])
+    // CHECK-SAME: kv_num_heads = 20
+    // CHECK-SAME: no_causal = true
+    // CHECK-SAME: num_heads = 20
+
+    return %out : tensor<1x1500x1280xf16>
+  }
+
+  // CHECK-LABEL: func.func @encoder_attn_rejects_unidirectional
+  func.func @encoder_attn_rejects_unidirectional(%x: tensor<1x1500x1280xf16>,
+                                                  %qkv_w: tensor<1280x3840xf16>,
+                                                  %qkv_b: tensor<3840xf16>)
+      -> tensor<1x1500x1280xf16> {
+    // Pattern must REJECT this — encoder is bidirectional only.
+    %0 = "onnx.Custom"(%x, %qkv_w, %qkv_b) {function_name = "Attention",
+         domain_name = "com.microsoft", num_heads = 20 : i64,
+         qkv_hidden_sizes = [1280, 1280, 1280],
+         unidirectional = 1 : i64,
+         scale = 0.125 : f32, do_rotary = 0 : i64,
+         past_present_share_buffer = 0 : i64, rotary_embedding_dim = 0 : i64,
+         mask_filter_value = -10000.0 : f32}
+         : (tensor<1x1500x1280xf16>, tensor<1280x3840xf16>, tensor<3840xf16>)
+         -> tensor<1x1500x1280xf16>
+    return %0 : tensor<1x1500x1280xf16>
+  }
+  // Verify the pattern did NOT match — onnx.Custom must remain, hip.gqa must
+  // NOT appear in this function body.  CHECK-LABEL above scopes the
+  // CHECK-NOT to this function only (hip.gqa is expected in @main_graph).
+  // CHECK: onnx.Custom
+  // CHECK-NOT: hip.gqa
+  // CHECK: return
+}

--- a/test/lit/Conversion/onnx-to-hip/test_whisper_self_mha_with_past.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_whisper_self_mha_with_past.mlir
@@ -1,0 +1,120 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify com.microsoft.MultiHeadAttention (via onnx.Custom) — the 9-input form
+// produced by Task-9 ONNX surgery (past_sequence_length input injected into
+// slot 8) used by Whisper's decoder self-attention — lowers to hip.gqa with:
+//   * no_causal = false (decoder self-attn IS causal / autoregressive),
+//   * num_heads == kv_num_heads (HPG=1; MHA, not group-query),
+//   * seqlens_k = operands[8]  (the runtime past_sequence_length tensor),
+//   * total_seq_len = arith.constant <static cache buffer length>  (taken
+//     from the present_key BNSH shape's dim 2 — baked in at compile time).
+//
+// Dispatch signal: 9-input MHA with K/V present, past_key/past_value present,
+// the past_sequence_length operand (slot 8) present, AND no extra
+// bias/mask/attention_bias/cache_indirection inputs. The presence of the
+// past_sequence_length OPERAND is the discriminator — NOT a
+// past_present_share_buffer attribute (ORT's MHA schema rejects that
+// attribute, so the surgery threads only the input).
+// ============================================================================
+
+// RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip | FileCheck %s
+
+module {
+  // Whisper-large-v3 decoder self-attn after Task-9 surgery: Q/K/V from the
+  // current step, past KV (BNSH, B=1, N=20, max_kv=448, d=64), and an extra
+  // past_sequence_length (1-D i32) operand telling the runtime how many KV
+  // slots are already populated.
+  func.func @main_graph(
+      %q:        tensor<1x1x1280xf16>,
+      %k:        tensor<1x1x1280xf16>,
+      %v:        tensor<1x1x1280xf16>,
+      %past_k:   tensor<1x20x448x64xf16>,
+      %past_v:   tensor<1x20x448x64xf16>,
+      %past_seq: tensor<1xi32>)
+      -> (tensor<1x1x1280xf16>, tensor<1x20x448x64xf16>, tensor<1x20x448x64xf16>) {
+
+    // CHECK-LABEL: func.func @main_graph
+    // CHECK-SAME: (%[[CTX:.*]]: !hip.context,
+    // Capture the past_seq SSA name (last function argument here) so we can
+    // assert hip.gqa consumes it as seqlens_k.
+    // CHECK-SAME: %[[PAST_SEQ:[a-zA-Z0-9_]+]]: tensor<1xi32>
+
+    %none1 = "onnx.NoValue"() {value} : () -> none
+    %none2 = "onnx.NoValue"() {value} : () -> none
+    %none3 = "onnx.NoValue"() {value} : () -> none
+
+    %out:3 = "onnx.Custom"(%q, %k, %v, %none1, %none2, %none3, %past_k, %past_v, %past_seq)
+        <{function_name = "MultiHeadAttention"}>
+        {domain_name = "com.microsoft",
+         num_heads = 20 : si64,
+         scale = 1.250000e-01 : f32,
+         unidirectional = 1 : si64,
+         mask_filter_value = -1.000000e+04 : f32}
+        : (tensor<1x1x1280xf16>, tensor<1x1x1280xf16>, tensor<1x1x1280xf16>,
+           none, none, none, tensor<1x20x448x64xf16>, tensor<1x20x448x64xf16>,
+           tensor<1xi32>)
+        -> (tensor<1x1x1280xf16>, tensor<1x20x448x64xf16>, tensor<1x20x448x64xf16>)
+
+    // Compile-time total_seq_len constant = cache buffer length (448).
+    // CHECK: arith.constant dense<448> : tensor<i32>
+    // hip.gqa with no_causal=false (default → omitted by printer), HPG=1,
+    // consumes the runtime past_sequence_length as seqlens_k (asserted via
+    // %[[PAST_SEQ]] appearing in the ins() list).
+    // CHECK: hip.gqa(%[[CTX]])
+    // CHECK-SAME: %[[PAST_SEQ]]
+    // CHECK-SAME: kv_num_heads = 20
+    // CHECK-SAME: num_heads = 20
+    // CHECK-NOT: no_causal
+    // CHECK-NOT: hip.multi_head_attention
+
+    return %out#0, %out#1, %out#2
+      : tensor<1x1x1280xf16>, tensor<1x20x448x64xf16>, tensor<1x20x448x64xf16>
+  }
+
+  // ===========================================================================
+  // Regression: 9-input MHA with an EMPTY past_sequence_length slot (slot 8 is
+  // none) MUST keep falling through to hip.multi_head_attention.  The branch-2
+  // hip.gqa dispatch is gated on the PRESENCE of the past_sequence_length
+  // operand (Task-9 surgery wires a real [1]-i32 tensor there); a graph that
+  // declares the slot but leaves it empty is not the post-surgery shared-buffer
+  // form and must take the legacy path.
+  // ===========================================================================
+  func.func @main_graph_no_past_seqlen(
+      %q:        tensor<1x1x1280xf16>,
+      %k:        tensor<1x1x1280xf16>,
+      %v:        tensor<1x1x1280xf16>,
+      %past_k:   tensor<1x20x448x64xf16>,
+      %past_v:   tensor<1x20x448x64xf16>)
+      -> (tensor<1x1x1280xf16>, tensor<1x20x448x64xf16>, tensor<1x20x448x64xf16>) {
+
+    // CHECK-LABEL: func.func @main_graph_no_past_seqlen
+
+    %none1 = "onnx.NoValue"() {value} : () -> none
+    %none2 = "onnx.NoValue"() {value} : () -> none
+    %none3 = "onnx.NoValue"() {value} : () -> none
+    %none4 = "onnx.NoValue"() {value} : () -> none
+
+    // 9-input shape but slot 8 (past_sequence_length) is none.  Must NOT
+    // dispatch to branch-2 hip.gqa self-attn.
+    %out:3 = "onnx.Custom"(%q, %k, %v, %none1, %none2, %none3, %past_k, %past_v, %none4)
+        <{function_name = "MultiHeadAttention"}>
+        {domain_name = "com.microsoft",
+         num_heads = 20 : si64,
+         scale = 1.250000e-01 : f32,
+         unidirectional = 1 : si64,
+         mask_filter_value = -1.000000e+04 : f32}
+        : (tensor<1x1x1280xf16>, tensor<1x1x1280xf16>, tensor<1x1x1280xf16>,
+           none, none, none, tensor<1x20x448x64xf16>, tensor<1x20x448x64xf16>,
+           none)
+        -> (tensor<1x1x1280xf16>, tensor<1x20x448x64xf16>, tensor<1x20x448x64xf16>)
+
+    // CHECK: hip.multi_head_attention
+    // CHECK-NOT: hip.gqa
+
+    return %out#0, %out#1, %out#2
+      : tensor<1x1x1280xf16>, tensor<1x20x448x64xf16>, tensor<1x20x448x64xf16>
+  }
+}

--- a/test/numeric/tests/test_whisper_cross_attention.py
+++ b/test/numeric/tests/test_whisper_cross_attention.py
@@ -1,0 +1,147 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+
+"""Numeric tests for Whisper-large-v3 decoder CROSS-attention.
+
+Whisper's decoder cross-attn uses the 8-input ``com.microsoft.MultiHeadAttention``
+form: Q from the decoder (3-D ``[B, Sq, H*d]``) and K/V from the encoder output
+already split into BNSH (``[B, H, Skv, d]``), with the 5 trailing optional slots
+(bias / mask / attention_bias / past_key / past_value) empty and
+``unidirectional=0`` (cross-attn is bidirectional).  MorphiZen lowers this to
+``hip.gqa(no_causal=true)`` with HPG=1 and a compile-time constant
+``seqlens_k = [Skv]`` (see MultiHeadAttentionConversion.cpp, branch 1).
+
+Operand layout is taken from the Task-8 LIT fixture
+``test/lit/Conversion/onnx-to-hip/test_whisper_cross_mha.mlir``:
+K/V are rank-4 BNSH — the converter rejects rank-3 cross-attn keys.
+
+Reference: ORT CPU EP runs the SAME 8-input MHA model with bidirectional
+attention, so the standard run_sample CPU comparison applies directly (no
+weight-convention divergence, unlike the encoder Attention op).
+"""
+
+import numpy as np
+import pytest
+from onnx import TensorProto, helper
+
+from framework.comparator import compare_outputs
+from framework.onnx_utils import make_model_from_nodes
+
+# Whisper-large-v3 decoder geometry.
+NUM_HEADS = 20
+HEAD_DIM = 64
+HIDDEN = NUM_HEADS * HEAD_DIM  # 1280
+
+
+def _make_cross_mha_model(
+    batch, seq_q, seq_kv, num_heads, head_dim, np_dtype=np.float16
+):
+    """Build an 8-input com.microsoft.MultiHeadAttention cross-attn model.
+
+    Q is 3-D ``[B, Sq, H*d]``; K/V are rank-4 BNSH ``[B, H, Skv, d]`` (the
+    Whisper cross-attn layout the converter expects).  Output is ``[B, Sq, H*d]``.
+
+    ``np_dtype`` selects fp16 (default) or fp32; fp32 drives the fp32 decomposed
+    GQA path (element_size_bytes=4).
+    """
+    hidden = num_heads * head_dim
+    onnx_dtype = TensorProto.FLOAT if np_dtype == np.float32 else TensorProto.FLOAT16
+
+    query = helper.make_tensor_value_info("query", onnx_dtype, [batch, seq_q, hidden])
+    key = helper.make_tensor_value_info(
+        "key", onnx_dtype, [batch, num_heads, seq_kv, head_dim]
+    )
+    value = helper.make_tensor_value_info(
+        "value", onnx_dtype, [batch, num_heads, seq_kv, head_dim]
+    )
+    output = helper.make_tensor_value_info("output", onnx_dtype, [batch, seq_q, hidden])
+
+    scale = float(1.0 / np.sqrt(head_dim))
+    # 8-input form: Q, K, V, then 5 empty optional slots (bias, key_padding_mask,
+    # attention_bias, past_key, past_value).  This is the cross-attn dispatch
+    # signal for MultiHeadAttentionConversion branch 1.
+    node = helper.make_node(
+        "MultiHeadAttention",
+        ["query", "key", "value", "", "", "", "", ""],
+        ["output"],
+        domain="com.microsoft",
+        num_heads=num_heads,
+        scale=scale,
+        unidirectional=0,
+        mask_filter_value=-10000.0,
+    )
+    ms_opset = helper.make_opsetid("com.microsoft", 1)
+    return make_model_from_nodes(
+        [node],
+        [query, key, value],
+        [output],
+        extra_opsets=[ms_opset],
+    )
+
+
+def _cross_inputs(
+    batch, seq_q, seq_kv, num_heads, head_dim, seed=7, np_dtype=np.float16
+):
+    rng = np.random.default_rng(seed)
+    hidden = num_heads * head_dim
+    # Modest range keeps softmax inside fp16's safe band.
+    q = rng.uniform(-1.0, 1.0, [batch, seq_q, hidden]).astype(np_dtype)
+    k = rng.uniform(-1.0, 1.0, [batch, num_heads, seq_kv, head_dim]).astype(np_dtype)
+    v = rng.uniform(-1.0, 1.0, [batch, num_heads, seq_kv, head_dim]).astype(np_dtype)
+    return q, k, v
+
+
+# NOTE (was a bug, fixed in the no_causal seqlens_k exemption): same no_causal
+# GQA seqlens_k off-by-one as the encoder.  MultiHeadAttentionConversion.cpp
+# branch 1 emits a compile-time `seqlens_k = [Skv]` and `total_seq = Skv`, but
+# the runtime `gqa_forward_hipblaslt` used to apply `total_seq = seqlens_k[0] + 1`
+# -> over-counted by 1 (Skv+1 > present_seq=Skv) -> rc=-1 / zeroed output.
+# Cross-attn additionally has Skv != seq_q (K/V are the full rank-4 BNSH encoder
+# output, seq_q is the decoder query count), so the past_len = total_seq - sq
+# derivation was nonsense too.  The runtime now exempts no_causal: total_seq =
+# skv, past_len = 0, KV populated by a direct BNSH copy of all Skv keys (see
+# lib/Runtime/real/gqa.cpp update_kv_cache no_causal branch).  Cross-attn is
+# bidirectional with the full encoder output valid, so no_causal is correct.
+# This test is the executable repro that locks the fix in.
+
+
+class TestWhisperCrossAttention:
+    """8-input MultiHeadAttention cross-attn -> hip.gqa(no_causal=true)."""
+
+    @pytest.mark.parametrize("seq_q", [1, 4])
+    @pytest.mark.parametrize("seq_kv", [64, 256])
+    def test_cross_attention(self, model_runner, seq_q, seq_kv):
+        """Whisper decoder cross-attn: Q from decoder, K/V from encoder (BNSH).
+
+        Real Whisper Skv=1500; we test 64 / 256 for speed (kernel is
+        shape-agnostic).  Bidirectional, compared directly against ORT CPU.
+        """
+        batch = 1
+        model = _make_cross_mha_model(batch, seq_q, seq_kv, NUM_HEADS, HEAD_DIM)
+        q, k, v = _cross_inputs(batch, seq_q, seq_kv, NUM_HEADS, HEAD_DIM)
+
+        actual, expected = model_runner.run_sample(model, [q, k, v])
+        compare_outputs(actual, expected, atol=2e-2, rtol=2e-2, cos_threshold=0.999)
+
+    @pytest.mark.parametrize("seq_q", [1, 4])
+    @pytest.mark.parametrize("seq_kv", [64, 256])
+    def test_cross_attention_fp32(self, model_runner, seq_q, seq_kv):
+        """fp32 variant: drives the fp32 decomposed GQA path (elem_size=4).
+
+        seq_q=1 / seq_kv>1 exercises the no_causal D2D-copy KV population +
+        no-expand decode GEMM in fp32 (the decoder cross-attn decode shape).
+        Compared directly against ORT CPU fp32 MHA; tighter thresholds than the
+        fp16 test because both sides are fp32.
+        """
+        batch = 1
+        model = _make_cross_mha_model(
+            batch, seq_q, seq_kv, NUM_HEADS, HEAD_DIM, np_dtype=np.float32
+        )
+        q, k, v = _cross_inputs(
+            batch, seq_q, seq_kv, NUM_HEADS, HEAD_DIM, np_dtype=np.float32
+        )
+
+        actual, expected = model_runner.run_sample(model, [q, k, v])
+        compare_outputs(actual, expected, atol=2e-3, rtol=2e-3, cos_threshold=0.9999)

--- a/test/numeric/tests/test_whisper_encoder_attention.py
+++ b/test/numeric/tests/test_whisper_encoder_attention.py
@@ -1,0 +1,211 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+
+"""Numeric tests for Whisper-large-v3 ENCODER self-attention.
+
+Whisper's encoder uses the legacy fused-QKV ``com.microsoft.Attention`` op
+(unidirectional=0 -> bidirectional). MorphiZen lowers it to
+``hip.gqa(no_causal=true)`` with HPG=1 (num_heads == kv_num_heads) via a single
+fused QKV projection + 3 slices (see AttentionConversion.cpp).
+
+Reference strategy: a numpy fp32 bidirectional-MHA reference, NOT ORT CPU on the
+same model.  fp32 reference avoids the fp16 CPU softmax accumulation artefact
+seen elsewhere in this project (CPU fp16 attention can drift to cosine ~0.6).
+
+Weight layout: ``[hidden, 3*hidden]`` = ``[H, 3H]`` — the ORT
+com.microsoft.Attention spec convention (``[input_hidden,
+q_hidden+k_hidden+v_hidden]``) and what Whisper-large-v3 actually exports
+(``qkv_proj.weight`` is ``[1280, 3840]``).  MorphiZen's AttentionConversion
+consumes this layout directly in the fused QKV matmul (no transpose); the numpy
+reference projects with ``x @ qkv_w`` accordingly.
+
+Whisper-large-v3 encoder shapes: d_model=1280, num_heads=20, head_dim=64,
+S=1500.  We test small S (16, 64) for speed plus one S=256 case; the kernel is
+shape-agnostic so S=1500 is not needed to prove correctness.
+"""
+
+import numpy as np
+import pytest
+from onnx import TensorProto, helper, numpy_helper
+
+from framework.comparator import compare_outputs
+from framework.onnx_utils import make_model_from_nodes
+
+# Whisper-large-v3 encoder geometry.
+HIDDEN = 1280
+NUM_HEADS = 20
+HEAD_DIM = HIDDEN // NUM_HEADS  # 64
+
+
+def _make_encoder_attention_model(
+    batch, seq_len, hidden, num_heads, seed=0xA77, np_dtype=np.float16
+):
+    """Build a single-op com.microsoft.Attention model (fused QKV, bidirectional).
+
+    Weight layout is the real Whisper / ORT-spec convention that MorphiZen's
+    AttentionConversion expects: ``qkv_w`` is ``[hidden, 3*hidden]`` =
+    ``[H, 3H]`` (``[input_hidden, q+k+v hidden]``) and ``qkv_b`` is
+    ``[3*hidden]``.  Returns ``(model, qkv_w, qkv_b)`` so the test can feed the
+    same weights to the numpy reference.
+
+    ``np_dtype`` selects fp16 (default) or fp32; fp32 exercises the fp32
+    decomposed GQA path (element_size_bytes=4) that the Whisper greedy-correct
+    pipeline relies on.
+    """
+    qkv_hidden = 3 * hidden
+    onnx_dtype = TensorProto.FLOAT if np_dtype == np.float32 else TensorProto.FLOAT16
+
+    hidden_vi = helper.make_tensor_value_info(
+        "hidden", onnx_dtype, [batch, seq_len, hidden]
+    )
+    out_vi = helper.make_tensor_value_info(
+        "output", onnx_dtype, [batch, seq_len, hidden]
+    )
+
+    rng = np.random.default_rng(seed)
+    # Modest range keeps softmax inside fp16's safe band.
+    # [H, 3H] layout — the real Whisper qkv_proj.weight shape (= [1280, 3840]).
+    qkv_w = (rng.standard_normal((hidden, qkv_hidden)) * 0.05).astype(np_dtype)
+    qkv_b = (rng.standard_normal((qkv_hidden,)) * 0.05).astype(np_dtype)
+
+    initializers = [
+        numpy_helper.from_array(qkv_w, name="qkv_w"),
+        numpy_helper.from_array(qkv_b, name="qkv_b"),
+    ]
+
+    scale = float(1.0 / np.sqrt(HEAD_DIM))
+    # 7-input form (input, weights, bias, then 4 empty optional slots) matching
+    # the Whisper encoder node and the LIT test test_whisper_encoder_attention.
+    node = helper.make_node(
+        "Attention",
+        ["hidden", "qkv_w", "qkv_b", "", "", "", ""],
+        ["output"],
+        domain="com.microsoft",
+        num_heads=num_heads,
+        qkv_hidden_sizes=[hidden, hidden, hidden],
+        unidirectional=0,
+        do_rotary=0,
+        past_present_share_buffer=0,
+        rotary_embedding_dim=0,
+        scale=scale,
+        mask_filter_value=-10000.0,
+    )
+    ms_opset = helper.make_opsetid("com.microsoft", 1)
+    model = make_model_from_nodes(
+        [node],
+        [hidden_vi],
+        [out_vi],
+        initializers=initializers,
+        extra_opsets=[ms_opset],
+    )
+    return model, qkv_w, qkv_b
+
+
+def _bidirectional_mha_ref(x, qkv_w, qkv_b, num_heads):
+    """fp32 numpy bidirectional fused-QKV MHA reference.
+
+    ``qkv_w`` is ``[H, 3H]`` (the real Whisper / ORT-spec layout); the
+    projection is ``x @ qkv_w + qkv_b``.  Slices the projected ``[B, S, 3H]``
+    activation into Q/K/V along the last axis exactly like AttentionConversion's
+    three extract_slice ops, then runs standard softmax(QK^T / sqrt(d)) V with
+    NO causal mask.
+    """
+    x = x.astype(np.float64)
+    w = qkv_w.astype(np.float64)
+    b = qkv_b.astype(np.float64)
+    batch, seq_len, hidden = x.shape
+    head_dim = hidden // num_heads
+
+    qkv = x @ w + b  # [B, S, H] @ [H, 3H] -> [B, S, 3H]
+    q = qkv[..., :hidden]
+    k = qkv[..., hidden : 2 * hidden]
+    v = qkv[..., 2 * hidden :]
+
+    def to_heads(t):
+        return t.reshape(batch, seq_len, num_heads, head_dim).transpose(0, 2, 1, 3)
+
+    q, k, v = to_heads(q), to_heads(k), to_heads(v)
+    scale = 1.0 / np.sqrt(head_dim)
+    scores = (q @ k.transpose(0, 1, 3, 2)) * scale  # [B, nh, S, S]
+    scores = scores - scores.max(axis=-1, keepdims=True)
+    probs = np.exp(scores)
+    probs = probs / probs.sum(axis=-1, keepdims=True)
+    out = probs @ v  # [B, nh, S, d]
+    return out.transpose(0, 2, 1, 3).reshape(batch, seq_len, hidden)
+
+
+# NOTE (was a bug, fixed in the no_causal seqlens_k exemption): the no_causal
+# GQA path used to have a seqlens_k off-by-one.  AttentionConversion.cpp emits a
+# compile-time `seqlens_k = [S]` AND `total_seq = S`, but the runtime
+# `gqa_forward_hipblaslt` applied the ORT decode convention
+# `total_seq = seqlens_k[0] + 1` unconditionally.  For the encoder (S valid
+# tokens, no padding) that over-counted by 1: `total_seq = S+1 > present_seq = S`
+# -> the validation returned rc=-1, GQA left the output zero-initialised, and the
+# result was garbage (cosine ~0).  The no_causal path had NO end-to-end runtime
+# coverage before this test (LIT only checks IR), so the bug shipped unnoticed in
+# Tasks 7/8.  The runtime now exempts no_causal from the +1 (total_seq = skv,
+# past_len = 0) -- see lib/Runtime/real/gqa.cpp.  This test is the executable
+# repro that locks the fix in.
+
+
+class TestWhisperEncoderAttention:
+    """com.microsoft.Attention (fused QKV, bidirectional) -> hip.gqa(no_causal)."""
+
+    @pytest.mark.parametrize("seq_len", [16, 64, 256])
+    def test_encoder_self_attention(self, model_runner, seq_len):
+        """Whisper encoder self-attn at d_model=1280, num_heads=20.
+
+        Bidirectional (unidirectional=0).  Compared against an fp32 numpy
+        reference (see module docstring for why ORT CPU is unsuitable here).
+        """
+        batch = 1
+        model, qkv_w, qkv_b = _make_encoder_attention_model(
+            batch, seq_len, HIDDEN, NUM_HEADS
+        )
+
+        rng = np.random.default_rng(seq_len)
+        x = (rng.standard_normal((batch, seq_len, HIDDEN)) * 0.5).astype(np.float16)
+
+        # Drive MorphiZen directly; CPU-on-same-model would mis-interpret the
+        # weight layout (see module docstring).  session.disable_cpu_ep_fallback
+        # is set by the backend, so this run also proves GPU dispatch.
+        actual = model_runner.backend.run(_persist(model_runner, model), [x])
+        expected = [_bidirectional_mha_ref(x, qkv_w, qkv_b, NUM_HEADS)]
+
+        compare_outputs(actual, expected, atol=2e-2, rtol=2e-2, cos_threshold=0.999)
+
+    @pytest.mark.parametrize("seq_len", [16, 64, 256])
+    def test_encoder_self_attention_fp32(self, model_runner, seq_len):
+        """fp32 variant: drives the fp32 decomposed GQA path (elem_size=4).
+
+        Same geometry as the fp16 test but fp32 inputs/weights. The fp32 path
+        is what makes Whisper greedy transcription correct on GPU (fp16 is
+        argmax-lossy on the wide lm_head). Tighter thresholds than fp16 because
+        fp32 GEMM + fp32 softmax should track the fp64 numpy reference closely.
+        """
+        batch = 1
+        model, qkv_w, qkv_b = _make_encoder_attention_model(
+            batch, seq_len, HIDDEN, NUM_HEADS, np_dtype=np.float32
+        )
+
+        rng = np.random.default_rng(seq_len)
+        x = (rng.standard_normal((batch, seq_len, HIDDEN)) * 0.5).astype(np.float32)
+
+        actual = model_runner.backend.run(_persist(model_runner, model), [x])
+        expected = [_bidirectional_mha_ref(x, qkv_w, qkv_b, NUM_HEADS)]
+
+        compare_outputs(actual, expected, atol=2e-3, rtol=2e-3, cos_threshold=0.9999)
+
+
+def _persist(model_runner, model):
+    """Write *model* to a fresh per-test work subdir and return its path.
+
+    Mirrors what ModelRunner.run_sample does internally; needed because we
+    bypass run_sample to supply our own numpy reference instead of the CPU EP.
+    """
+    sub = model_runner._next_subdir()
+    path = sub / "model.onnx"
+    path.write_bytes(model.SerializeToString())
+    return str(path)

--- a/test/numeric/tests/test_whisper_self_attention.py
+++ b/test/numeric/tests/test_whisper_self_attention.py
@@ -1,0 +1,255 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+
+"""Numeric tests for Whisper-large-v3 decoder SELF-attention (with past KV).
+
+After the Task-9 ONNX surgery, Whisper's decoder self-attn is the 9-input
+``com.microsoft.MultiHeadAttention`` form: Q/K/V 3-D ``[B, Sq, H*d]``,
+past_key/past_value BNSH ``[B, H, 448, d]`` (pre-allocated shared buffer),
+and an injected ``past_sequence_length`` (1-D i32) operand, with
+``unidirectional=1`` (causal).  MorphiZen
+lowers this to ``hip.gqa(no_causal=false)`` with HPG=1, ``seqlens_k =
+operand[8]`` (the runtime past_sequence_length) and ``total_seq_len`` baked to
+the static cache buffer length (448) — see MultiHeadAttentionConversion.cpp
+branch 2 and the Task-8 LIT fixture test_whisper_self_mha_with_past.mlir.
+
+Reference strategy (FALLBACK OPTION 2 from the task brief): ORT CPU does NOT
+accept past_key/value of a DIFFERENT shape than present (the shared-buffer
+448-slot form with a partial valid prefix has no single-op ORT CPU equivalent).
+So we build a SEPARATE reference model: the standard 8-input MHA-with-past (no
+share-buffer) whose ``past_key/value`` carry exactly the ``past_seq_val`` valid
+prefix.  The
+two are mathematically equal for the decode output:
+  - MorphiZen 9-input: attends Q over KV slots [0, past_seq_val] of the 448
+    buffer (valid prefix + the freshly-appended token).
+  - CPU 8-input: attends Q over its [past_seq_val] past tokens + the new token.
+Both reduce over the identical KV content, so ``output`` matches.  (We compare
+``output`` only; the present-KV buffers have different shapes — 448-slot shared
+vs past_seq_val+1 concat — and the shared buffer's tail is intentionally
+garbage.)  Equivalence validated offline against a numpy causal-decode reference.
+"""
+
+import numpy as np
+import pytest
+from onnx import TensorProto, helper
+
+from framework.comparator import compare_outputs
+from framework.onnx_utils import make_model_from_nodes
+
+# Whisper-large-v3 decoder geometry.
+NUM_HEADS = 20
+HEAD_DIM = 64
+HIDDEN = NUM_HEADS * HEAD_DIM  # 1280
+CACHE = 448  # Whisper decoder max KV buffer (BNSH dim 2)
+
+
+def _make_self_mha_share_buffer_model(batch, seq_q, cache, num_heads, head_dim):
+    """9-input MHA, past_present_share_buffer=1 (post-Task-9-surgery form).
+
+    past_key/value are BNSH ``[B, H, cache, d]`` (shared buffer); present_key/
+    value mirror that shape; the 9th input is ``past_sequence_length`` (1-D i32).
+    """
+    hidden = num_heads * head_dim
+
+    query = helper.make_tensor_value_info(
+        "query", TensorProto.FLOAT16, [batch, seq_q, hidden]
+    )
+    key = helper.make_tensor_value_info(
+        "key", TensorProto.FLOAT16, [batch, seq_q, hidden]
+    )
+    value = helper.make_tensor_value_info(
+        "value", TensorProto.FLOAT16, [batch, seq_q, hidden]
+    )
+    past_key = helper.make_tensor_value_info(
+        "past_key", TensorProto.FLOAT16, [batch, num_heads, cache, head_dim]
+    )
+    past_value = helper.make_tensor_value_info(
+        "past_value", TensorProto.FLOAT16, [batch, num_heads, cache, head_dim]
+    )
+    past_seq = helper.make_tensor_value_info(
+        "past_sequence_length", TensorProto.INT32, [1]
+    )
+
+    output = helper.make_tensor_value_info(
+        "output", TensorProto.FLOAT16, [batch, seq_q, hidden]
+    )
+    present_key = helper.make_tensor_value_info(
+        "present_key", TensorProto.FLOAT16, [batch, num_heads, cache, head_dim]
+    )
+    present_value = helper.make_tensor_value_info(
+        "present_value", TensorProto.FLOAT16, [batch, num_heads, cache, head_dim]
+    )
+
+    scale = float(1.0 / np.sqrt(head_dim))
+    # NO past_present_share_buffer attribute: ORT's MHA schema rejects it (it
+    # lives on GroupQueryAttention/Attention). The 9-input form with the slot-8
+    # past_sequence_length operand is the post-surgery signal MorphiZen keys on
+    # (MultiHeadAttentionConversion.cpp branch 2), and it IS ORT-loadable.
+    node = helper.make_node(
+        "MultiHeadAttention",
+        [
+            "query",
+            "key",
+            "value",
+            "",
+            "",
+            "",
+            "past_key",
+            "past_value",
+            "past_sequence_length",
+        ],
+        ["output", "present_key", "present_value"],
+        domain="com.microsoft",
+        num_heads=num_heads,
+        scale=scale,
+        unidirectional=1,
+        mask_filter_value=-10000.0,
+    )
+    ms_opset = helper.make_opsetid("com.microsoft", 1)
+    return make_model_from_nodes(
+        [node],
+        [query, key, value, past_key, past_value, past_seq],
+        [output, present_key, present_value],
+        extra_opsets=[ms_opset],
+    )
+
+
+def _make_self_mha_plain_past_model(batch, seq_q, past, num_heads, head_dim):
+    """Standard 8-input MHA-with-past (no share-buffer) — the CPU reference.
+
+    past_key/value are BNSH ``[B, H, past, d]`` carrying exactly the valid
+    prefix; present_key/value are ``[B, H, past+seq_q, d]`` (concat).  ORT CPU
+    accepts this form; we compare only its ``output``.
+    """
+    hidden = num_heads * head_dim
+
+    query = helper.make_tensor_value_info(
+        "query", TensorProto.FLOAT16, [batch, seq_q, hidden]
+    )
+    key = helper.make_tensor_value_info(
+        "key", TensorProto.FLOAT16, [batch, seq_q, hidden]
+    )
+    value = helper.make_tensor_value_info(
+        "value", TensorProto.FLOAT16, [batch, seq_q, hidden]
+    )
+    past_key = helper.make_tensor_value_info(
+        "past_key", TensorProto.FLOAT16, [batch, num_heads, past, head_dim]
+    )
+    past_value = helper.make_tensor_value_info(
+        "past_value", TensorProto.FLOAT16, [batch, num_heads, past, head_dim]
+    )
+
+    output = helper.make_tensor_value_info(
+        "output", TensorProto.FLOAT16, [batch, seq_q, hidden]
+    )
+    present_key = helper.make_tensor_value_info(
+        "present_key",
+        TensorProto.FLOAT16,
+        [batch, num_heads, past + seq_q, head_dim],
+    )
+    present_value = helper.make_tensor_value_info(
+        "present_value",
+        TensorProto.FLOAT16,
+        [batch, num_heads, past + seq_q, head_dim],
+    )
+
+    scale = float(1.0 / np.sqrt(head_dim))
+    node = helper.make_node(
+        "MultiHeadAttention",
+        ["query", "key", "value", "", "", "", "past_key", "past_value"],
+        ["output", "present_key", "present_value"],
+        domain="com.microsoft",
+        num_heads=num_heads,
+        scale=scale,
+        unidirectional=1,
+        mask_filter_value=-10000.0,
+    )
+    ms_opset = helper.make_opsetid("com.microsoft", 1)
+    return make_model_from_nodes(
+        [node],
+        [query, key, value, past_key, past_value],
+        [output, present_key, present_value],
+        extra_opsets=[ms_opset],
+    )
+
+
+# HISTORICAL NOTE (Task 11 → resolved in Task 12): an earlier surgery emitted a
+# `past_present_share_buffer=1` ATTRIBUTE on the MHA node, which ORT's registered
+# `com.microsoft.MultiHeadAttention` schema does NOT define — ORT rejected the
+# model at graph-load with "Unrecognized attribute: past_present_share_buffer"
+# before any EP saw it, so this standalone numeric test had to be skipped.
+# Task 12 dropped that attribute: the 9-input form with the slot-8
+# `past_sequence_length` OPERAND is now the sole post-surgery signal (the operand
+# is schema-valid, so ORT loads it), and MultiHeadAttentionConversion.cpp branch
+# 2 keys on operand presence. The standalone model is therefore loadable now and
+# this test runs (CPU reference = standard 8-input MHA-with-past, fallback
+# option 2; equivalence validated offline against a numpy causal-decode
+# reference, max diff ~3e-4).
+
+
+class TestWhisperSelfAttention:
+    """9-input share-buffer MHA -> hip.gqa(no_causal=false), HPG=1, decode."""
+
+    @pytest.mark.parametrize("past_seq_val", [1, 64, 256, 447])
+    def test_self_attention_decode(self, model_runner, past_seq_val):
+        """Whisper decoder self-attn decode (Sq=1) at various valid past lengths.
+
+        MorphiZen runs the 9-input share-buffer form (448-slot buffer, valid
+        prefix = past_seq_val).  Reference = ORT CPU on the standard 8-input
+        MHA-with-past whose past tensor is exactly the valid prefix.
+        """
+        batch, seq_q = 1, 1
+
+        rng = np.random.default_rng(past_seq_val)
+        q = rng.uniform(-1.0, 1.0, [batch, seq_q, HIDDEN]).astype(np.float16)
+        k = rng.uniform(-1.0, 1.0, [batch, seq_q, HIDDEN]).astype(np.float16)
+        v = rng.uniform(-1.0, 1.0, [batch, seq_q, HIDDEN]).astype(np.float16)
+
+        # Valid KV prefix shared by both models.
+        pk_valid = rng.uniform(
+            -1.0, 1.0, [batch, NUM_HEADS, past_seq_val, HEAD_DIM]
+        ).astype(np.float16)
+        pv_valid = rng.uniform(
+            -1.0, 1.0, [batch, NUM_HEADS, past_seq_val, HEAD_DIM]
+        ).astype(np.float16)
+
+        # ---- MorphiZen: 9-input share-buffer form.  past_* is the 448-slot
+        # buffer with the valid prefix in [0, past_seq_val) and garbage tail
+        # (zeros) afterward; the kernel only reads [0, past_seq_val].
+        pk_buf = np.zeros([batch, NUM_HEADS, CACHE, HEAD_DIM], dtype=np.float16)
+        pv_buf = np.zeros([batch, NUM_HEADS, CACHE, HEAD_DIM], dtype=np.float16)
+        pk_buf[:, :, :past_seq_val, :] = pk_valid
+        pv_buf[:, :, :past_seq_val, :] = pv_valid
+        # past_sequence_length = number of valid past tokens (GQA seqlens_k
+        # convention: count of populated KV slots before the current token).
+        past_seq = np.array([past_seq_val], dtype=np.int32)
+
+        share_model = _make_self_mha_share_buffer_model(
+            batch, seq_q, CACHE, NUM_HEADS, HEAD_DIM
+        )
+        sub = model_runner._next_subdir("share_buffer")
+        share_path = str(sub / "model.onnx")
+        (sub / "model.onnx").write_bytes(share_model.SerializeToString())
+        ep_outputs = model_runner.backend.run(
+            share_path, [q, k, v, pk_buf, pv_buf, past_seq]
+        )
+        ep_output = ep_outputs[0]  # [B, 1, hidden]
+
+        # ---- CPU reference: standard 8-input MHA-with-past (no share-buffer),
+        # past tensor == the valid prefix only.  ORT CPU rejects the 9-input
+        # share-buffer form, so this equal-but-acceptable form is the reference.
+        ref_model = _make_self_mha_plain_past_model(
+            batch, seq_q, past_seq_val, NUM_HEADS, HEAD_DIM
+        )
+        _, ref_expected = model_runner.run_sample(
+            ref_model,
+            [q, k, v, pk_valid, pv_valid],
+            name="plain_past_ref",
+        )
+        cpu_output = ref_expected[0]  # [B, 1, hidden]
+
+        compare_outputs(
+            [ep_output], [cpu_output], atol=2e-2, rtol=2e-2, cos_threshold=0.999
+        )


### PR DESCRIPTION
Re-lands the Whisper encoder/decoder attention → `hip.gqa` conversion onto `main`.

## Why this PR exists

The original PR (#282) was approved and merged, but its base was the stacked branch `whisper-pr2-gqa` (the GQA `no_causal` PR, #280), **not** `main`. #280 was squash-merged into `main` *before* #282 merged into `whisper-pr2-gqa`, so #282's attention-conversion content landed only on the now-squashed stack branch and never reached `main`. This PR cherry-picks that exact content (`-x`) onto current `main`, where all of its dependencies (the `no_causal` GqaOp attr + fp32 decomposed GQA path) now live.

No code changes vs the approved #282 — clean cherry-pick, no conflicts.

## What it does

Routes all three Whisper attention forms through the `no_causal` / fp32 GQA path:

- **`AttentionConversion`** — encoder fused-QKV `com.microsoft.Attention` → `hip.gqa(no_causal=true)`, accepting the real `[H, 3H]` packed-QKV weight layout (no transpose).
- **`MultiHeadAttentionConversion`** — decoder cross-attn (8-input, empty past) → `hip.gqa(no_causal=true)`; decoder self-attn-with-past (9-input, slot-8 `past_sequence_length`) → `hip.gqa(no_causal=false)`, keyed on the operand trio rather than a `past_present_share_buffer` attribute (ORT's MHA schema rejects that attr).
- **`HipGqaBuilder`** — shared `buildHipGqaCall` helper (19-slot `AttrSizedOperandSegments` layout), used by both converters; declared in `OnnxToHipUtils.h`.
- `OnnxToHip.cpp` registers `populateAttentionConversionPatterns`.

## Tests

- LIT: `test_whisper_{encoder_attention,cross_mha,self_mha_with_past}.mlir`
- Numeric (op-level vs ORT CPU): `test_whisper_{encoder,cross,self}_attention.py` — 18 cases, fp16 + fp32, tight tolerances (fp32 cos ≥ 0.9999 / atol 2e-3, fp16 cos ≥ 0.999 / atol 2e-2).

Originally authored in #282 (approved by @fhanuman).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
