### PR TITLE
ci(windows): package model_mm + benchmark_multimodal.py for VL tests

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -322,8 +322,9 @@ jobs:
           path: ${{ runner.workspace }}/oga-artifacts
           # OGA is built against the patched ort-install, so the key folds in
           # both OGA's own PR list and ONNXRUNTIME_PR_PATCHES; editing either
-          # forces a rebuild.
-          key: oga-dml-${{ env.OGA_VERSION }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}
+          # forces a rebuild. The mm<N> token bumps when the OGA artifact set
+          # changes shape (e.g. model_mm / benchmark_multimodal.py added).
+          key: oga-dml-mm1-${{ env.OGA_VERSION }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}
 
       - name: Checkout OGA
         if: steps.cache-oga.outputs.cache-hit != 'true'
@@ -417,6 +418,27 @@ jobs:
              "${{ github.workspace }}/source-oga/benchmark/python/metrics.py" \
              "${{ runner.workspace }}/oga-artifacts/benchmark-python/"
 
+          # build.py --skip_examples leaves examples/c unbuilt. Build only
+          # model_mm (the multimodal example used by VL model CI) as a standalone
+          # cmake project against the just-built OGA lib + ORT_HOME. build.py's
+          # build_examples ignores CXXFLAGS, so set -DCMAKE_CXX_FLAGS=-FS here to
+          # force synchronous compiler-PDB writes (parallel model_mm.cpp /
+          # common.cpp otherwise clash on vc140.pdb -> C1041).
+          cmake -S "${{ github.workspace }}/source-oga/examples/c" \
+            -B "${{ runner.workspace }}/build-oga-examples" -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release -DMODEL_MM=ON -DCMAKE_CXX_FLAGS=-FS \
+            -DORT_INCLUDE_DIR="$ORT_HOME/include" \
+            -DORT_LIB_DIR="$ORT_HOME/lib" \
+            -DOGA_INCLUDE_DIR="${{ github.workspace }}/source-oga/src" \
+            -DOGA_LIB_DIR="$OGA_OUT"
+          cmake --build "${{ runner.workspace }}/build-oga-examples" --target model_mm
+          cp "${{ runner.workspace }}/build-oga-examples/model_mm.exe" \
+            "${{ runner.workspace }}/oga-artifacts/"
+
+          # benchmark_multimodal.py drives model_mm for the VL benchmark.
+          cp "${{ github.workspace }}/source-oga/benchmark/python/benchmark_multimodal.py" \
+            "${{ runner.workspace }}/oga-artifacts/"
+
       # -----------------------------------------------------------------------
       # Stage GPU test package:
       #   staging/bin/    – executables + DLLs needed at runtime on the GPU box
@@ -486,10 +508,13 @@ jobs:
           done
 
           # ---------------------------------------------------------------
-          # OGA artifacts: model_benchmark.exe + onnxruntime-genai.dll
+          # OGA artifacts: model_benchmark.exe + onnxruntime-genai.dll, plus
+          # model_mm.exe + benchmark_multimodal.py for the VL model tests.
           # ---------------------------------------------------------------
           cp "${{ runner.workspace }}/oga-artifacts/model_benchmark.exe" staging/bin/
           cp "${{ runner.workspace }}/oga-artifacts/onnxruntime-genai.dll" staging/bin/
+          cp "${{ runner.workspace }}/oga-artifacts/model_mm.exe" staging/bin/
+          cp "${{ runner.workspace }}/oga-artifacts/benchmark_multimodal.py" staging/bin/
 
           # ---------------------------------------------------------------
           # Python wheels (ORT + OGA cp314) bundled into the artifact under


### PR DESCRIPTION
## Summary

Restore packaging of `model_mm.exe` and `benchmark_multimodal.py` into the Windows GPU test package so the downstream VL (vision-language) model tests stop failing.

## Why

These two artifacts were added on the `release/msbuild` branch (PR #272) but never landed on `main`, and the subsequent switch to upstream onnxruntime-genai v0.14.0 (#353) did not carry them. The GPU test package therefore ships without `model_mm.exe` / `benchmark_multimodal.py`, and any VL test that consumes the package fails. Upstream OGA v0.14.0 already provides both (the `examples/c` `MODEL_MM` target and `benchmark/python/benchmark_multimodal.py`), so no fork or extra patch is needed. The example is built as a standalone cmake project because `build.py --skip_examples` leaves `examples/c` unbuilt; building only `model_mm` (rather than dropping `--skip_examples`) avoids the parallel multi-example PDB clash that motivated `-FS`.

## What

1. **Build OGA step** (`.github/workflows/windows-build.yml`): after the OGA core build, configure `source-oga/examples/c` standalone with `-DMODEL_MM=ON -DCMAKE_CXX_FLAGS=-FS`, pointing `ORT_*`/`OGA_*` dirs at ORT_HOME and the just-built OGA Release output; build the `model_mm` target and copy `model_mm.exe` plus `benchmark_multimodal.py` into `oga-artifacts/` (cached, so cache hits still stage them).
2. **OGA cache key**: add an `mm1` token so the artifact-set shape change forces a one-time OGA rebuild.
3. **Stage GPU test package step**: copy `model_mm.exe` + `benchmark_multimodal.py` from `oga-artifacts/` into `staging/bin/`.
4. **Intentional non-changes**: `linux-build.yml` is untouched (the VL package is Windows-only); the `-FS` flag and standalone-cmake approach mirror the previously validated PR #272.

## Test plan

- [ ] build-windows green on cold cache: `model_mm` configures (FetchContent pulls nlohmann_json + CLI11) and builds; `gpu-test-package/bin/` contains `model_mm.exe` and `benchmark_multimodal.py`.
- Local verification on gfx1151 host: the identical standalone cmake invocation against upstream OGA v0.14.0 + ORT_HOME + prebuilt OGA lib builds `model_mm` (exit 0, model_mm.exe 536,576 bytes), no link errors, no PDB C1041; `benchmark_multimodal.py` present in upstream `benchmark/python/`.

## Notes for reviewers

None.

## Checklist

- [x] **Incremental** — 1 file, ~28 LOC of YAML.
- [x] **AI policy** — workflow edit assisted by Cursor; disclosed via the commit `Co-authored-by` trailer.
- [x] **No `good first issue` automation**
- [ ] **Reviews resolved**
- [x] **CODEOWNERS routing** — CI workflow path.
