### PR TITLE
feat(ci): report OGA model_benchmark peak GPU memory

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1024,11 +1024,28 @@ jobs:
           $sha = $rawSha.Substring(0, 7)
           $prNumber = "${{ github.event.pull_request.number }}"
 
+          # Peak GPU memory (MB) from the EP's [PEAKMEM] lines (emitted in bytes;
+          # one set per process run, multiple if a step appends several runs into
+          # one file). Returns Dedicated / Shared (max of each segment).
+          function Get-GpuMem($content) {
+            $d = [regex]::Matches($content, '\[PEAKMEM\]\s*Dedicated GPU memory:\s+(\d+)\s+bytes')
+            $s = [regex]::Matches($content, '\[PEAKMEM\]\s*Shared GPU memory:\s+(\d+)\s+bytes')
+            if ($d.Count -eq 0 -and $s.Count -eq 0) {
+              return [pscustomobject]@{ Dedicated = "-"; Shared = "-" }
+            }
+            $dMax = if ($d.Count) { ($d | ForEach-Object { [long]$_.Groups[1].Value } | Measure-Object -Maximum).Maximum } else { 0 }
+            $sMax = if ($s.Count) { ($s | ForEach-Object { [long]$_.Groups[1].Value } | Measure-Object -Maximum).Maximum } else { 0 }
+            return [pscustomobject]@{
+              Dedicated = [long]($dMax / 1MB)
+              Shared    = [long]($sMax / 1MB)
+            }
+          }
+
           # Helper: build table rows from a results dir.
           # Each file: extract Number of inferences per second / Session
-          # creation / 1st infer / Avg CPU / Peak WS for the standard
-          # 6-column format (Model | QPS | Session (s) | 1st Infer (ms) |
-          # CPU% | Mem (MB)).
+          # creation / 1st infer / Avg CPU / Peak WS / peak GPU mem (dedicated,
+          # shared) for the 8-column format (Model | QPS | Session (s) |
+          # 1st Infer (ms) | CPU% | Mem (MB) | GPU Ded (MB) | GPU Shared (MB)).
           function Get-PerfRows($dir) {
             $rows = ""
             foreach ($f in (Get-ChildItem "$dir/*.txt" -ErrorAction SilentlyContinue)) {
@@ -1043,11 +1060,12 @@ jobs:
               $first = if ($firstMatch.Success) { $firstMatch.Groups[1].Value } else { "-" }
               $cpu = if ($cpuMatch.Success) { $cpuMatch.Groups[1].Value } else { "-" }
               $memMB = if ($memMatch.Success) { "{0:F0}" -f ([double]$memMatch.Groups[1].Value / 1MB) } else { "-" }
+              $gpu = Get-GpuMem $content
               if ($qpsMatch.Success) {
                 $qps = "{0:F2}" -f [double]$qpsMatch.Groups[1].Value
-                $rows += "| $model | $qps | $sess | $first | $cpu | $memMB |`n"
+                $rows += "| $model | $qps | $sess | $first | $cpu | $memMB | $($gpu.Dedicated) | $($gpu.Shared) |`n"
               } else {
-                $rows += "| $model | failed | $sess | $first | $cpu | $memMB |`n"
+                $rows += "| $model | failed | $sess | $first | $cpu | $memMB | $($gpu.Dedicated) | $($gpu.Shared) |`n"
               }
             }
             return $rows
@@ -1055,10 +1073,10 @@ jobs:
 
           # Build table rows from result files
           $tableRows = Get-PerfRows $resultsDir
-          if (-not $tableRows) { $tableRows = "| (no results) | - | - | - | - | - |`n" }
+          if (-not $tableRows) { $tableRows = "| (no results) | - | - | - | - | - | - | - |`n" }
 
-          $perfHeader = "| Model | QPS | Session (s) | 1st Infer (ms) | CPU% | Mem (MB) |`n" +
-                        "|-------|----:|----:|----:|----:|----:|`n"
+          $perfHeader = "| Model | QPS | Session (s) | 1st Infer (ms) | CPU% | Mem (MB) | GPU Ded (MB) | GPU Shared (MB) |`n" +
+                        "|-------|----:|----:|----:|----:|----:|----:|----:|`n"
           $header = "## MorphiZen EP Performance Results`n`n" + $perfHeader
 
           # EPContext export/import perf tables (full_model_seq128 only).
@@ -1083,13 +1101,16 @@ jobs:
             $ttft = if ($ttftMatch.Success) { "{0:F1}" -f ([double]$ttftMatch.Groups[1].Value / 1000) } else { "-" }
             $tps  = if ($tpsMatch.Success) { "{0:F1}" -f [double]$tpsMatch.Groups[2].Value } else { "-" }
             $mem  = if ($memMatch.Success) { "{0:F2}" -f ([double]$memMatch.Groups[1].Value / 1GB) } else { "-" }
-            $ogaRows += "| $model | 1 | 5 | 128 | 128 | $ttft | $tps | $mem |`n"
+            $gpu = Get-GpuMem $content
+            $gpuDedGB = if ($gpu.Dedicated -ne "-") { "{0:F2}" -f ([double]$gpu.Dedicated / 1024) } else { "-" }
+            $gpuShGB  = if ($gpu.Shared -ne "-") { "{0:F2}" -f ([double]$gpu.Shared / 1024) } else { "-" }
+            $ogaRows += "| $model | 1 | 5 | 128 | 128 | $ttft | $tps | $mem | $gpuDedGB | $gpuShGB |`n"
           }
           $ogaSection = ""
           if ($ogaRows) {
             $ogaSection = "`n## OGA Benchmark Results`n`n" +
-                          "| Model | Warmup | Reps | Prompt Len | Gen Tokens | TTFT (ms) | TPS | Peak Mem (GB) |`n" +
-                          "|-------|----:|----:|----:|----:|----:|----:|----:|`n" +
+                          "| Model | Warmup | Reps | Prompt Len | Gen Tokens | TTFT (ms) | TPS | Peak Mem (GB) | GPU Ded (GB) | GPU Shared (GB) |`n" +
+                          "|-------|----:|----:|----:|----:|----:|----:|----:|----:|----:|`n" +
                           $ogaRows
           }
 

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -816,12 +816,38 @@ jobs:
             # pass --ep_library: upstream model_benchmark rejects it, and where
             # supported it double-registers the EP and crashes on shutdown.
             Write-Host "=== OGA Benchmark: $($modelDir.Name) ==="
-            & $benchmark `
-              -i $modelDir.FullName `
-              -g 128 -r 5 -w 1 -b 1 -ml -1 `
-              @promptArgs `
-              -v 2>&1 | Tee-Object -FilePath $outFile
-            if ($LASTEXITCODE -ne 0) { $failed = 1 }
+            $bargs = @('-i', $modelDir.FullName, '-g', '128', '-r', '5', '-w', '1', '-b', '1', '-ml', '-1') + $promptArgs + @('-v')
+            $tmpOut = [System.IO.Path]::GetTempFileName()
+            $tmpErr = [System.IO.Path]::GetTempFileName()
+            # Launch model_benchmark and sample its per-process GPU memory via
+            # Windows perf counters while it runs (peak of dedicated + shared).
+            # External measurement keeps the EP/inference path untouched.
+            $proc = Start-Process -FilePath $benchmark -ArgumentList $bargs `
+              -NoNewWindow -PassThru `
+              -RedirectStandardOutput $tmpOut -RedirectStandardError $tmpErr
+            $peakDed = 0L
+            $peakShared = 0L
+            while (-not $proc.HasExited) {
+              Start-Sleep -Milliseconds 1500
+              try {
+                $d = (Get-Counter "\GPU Process Memory(pid_$($proc.Id)_*)\Dedicated Usage" -ErrorAction Stop).CounterSamples |
+                  Measure-Object -Property CookedValue -Sum
+                if ($d.Sum -gt $peakDed) { $peakDed = [long]$d.Sum }
+                $s = (Get-Counter "\GPU Process Memory(pid_$($proc.Id)_*)\Shared Usage" -ErrorAction Stop).CounterSamples |
+                  Measure-Object -Property CookedValue -Sum
+                if ($s.Sum -gt $peakShared) { $peakShared = [long]$s.Sum }
+              } catch { }
+            }
+            $proc.WaitForExit()
+            # Reassemble tool output into $outFile (so the publish-step parsers
+            # see model_benchmark's TTFT/TPS/Peak working set), echo to the log,
+            # then append the sampled GPU peaks for the publish step.
+            Get-Content $tmpOut, $tmpErr -ErrorAction SilentlyContinue | Set-Content $outFile
+            Add-Content $outFile "[GPUMEM] Dedicated GPU memory: $peakDed bytes"
+            Add-Content $outFile "[GPUMEM] Shared GPU memory: $peakShared bytes"
+            Get-Content $outFile | Write-Host
+            Remove-Item $tmpOut, $tmpErr -ErrorAction SilentlyContinue
+            if ($proc.ExitCode -ne 0) { $failed = 1 }
           }
           exit $failed
 
@@ -1024,29 +1050,11 @@ jobs:
           $sha = $rawSha.Substring(0, 7)
           $prNumber = "${{ github.event.pull_request.number }}"
 
-          # Peak GPU memory (MB) from the EP's [PEAKMEM] lines (emitted in bytes;
-          # one set per process run, multiple if a step appends several runs into
-          # one file). Returns Dedicated / Shared (max of each segment).
-          function Get-GpuMem($content) {
-            $d = [regex]::Matches($content, '\[PEAKMEM\]\s*Dedicated GPU memory:\s+(\d+)\s+bytes')
-            $s = [regex]::Matches($content, '\[PEAKMEM\]\s*Shared GPU memory:\s+(\d+)\s+bytes')
-            if ($d.Count -eq 0 -and $s.Count -eq 0) {
-              return [pscustomobject]@{ Dedicated = "-"; Shared = "-" }
-            }
-            $dMax = if ($d.Count) { ($d | ForEach-Object { [long]$_.Groups[1].Value } | Measure-Object -Maximum).Maximum } else { 0 }
-            $sMax = if ($s.Count) { ($s | ForEach-Object { [long]$_.Groups[1].Value } | Measure-Object -Maximum).Maximum } else { 0 }
-            return [pscustomobject]@{
-              Dedicated = [long]($dMax / 1MB)
-              Shared    = [long]($sMax / 1MB)
-            }
-          }
-
           # Helper: build table rows from a results dir.
           # Each file: extract Number of inferences per second / Session
-          # creation / 1st infer / Avg CPU / Peak WS / peak GPU mem (dedicated,
-          # shared) for the 8-column format (Model | QPS | Session (s) |
-          # 1st Infer (ms) | CPU% | Mem (MB) | GPU Dedicated (MB) |
-          # GPU Shared (MB)).
+          # creation / 1st infer / Avg CPU / Peak WS for the standard
+          # 6-column format (Model | QPS | Session (s) | 1st Infer (ms) |
+          # CPU% | Mem (MB)).
           function Get-PerfRows($dir) {
             $rows = ""
             foreach ($f in (Get-ChildItem "$dir/*.txt" -ErrorAction SilentlyContinue)) {
@@ -1061,12 +1069,11 @@ jobs:
               $first = if ($firstMatch.Success) { $firstMatch.Groups[1].Value } else { "-" }
               $cpu = if ($cpuMatch.Success) { $cpuMatch.Groups[1].Value } else { "-" }
               $memMB = if ($memMatch.Success) { "{0:F0}" -f ([double]$memMatch.Groups[1].Value / 1MB) } else { "-" }
-              $gpu = Get-GpuMem $content
               if ($qpsMatch.Success) {
                 $qps = "{0:F2}" -f [double]$qpsMatch.Groups[1].Value
-                $rows += "| $model | $qps | $sess | $first | $cpu | $memMB | $($gpu.Dedicated) | $($gpu.Shared) |`n"
+                $rows += "| $model | $qps | $sess | $first | $cpu | $memMB |`n"
               } else {
-                $rows += "| $model | failed | $sess | $first | $cpu | $memMB | $($gpu.Dedicated) | $($gpu.Shared) |`n"
+                $rows += "| $model | failed | $sess | $first | $cpu | $memMB |`n"
               }
             }
             return $rows
@@ -1074,10 +1081,10 @@ jobs:
 
           # Build table rows from result files
           $tableRows = Get-PerfRows $resultsDir
-          if (-not $tableRows) { $tableRows = "| (no results) | - | - | - | - | - | - | - |`n" }
+          if (-not $tableRows) { $tableRows = "| (no results) | - | - | - | - | - |`n" }
 
-          $perfHeader = "| Model | QPS | Session (s) | 1st Infer (ms) | CPU% | Mem (MB) | GPU Dedicated (MB) | GPU Shared (MB) |`n" +
-                        "|-------|----:|----:|----:|----:|----:|----:|----:|`n"
+          $perfHeader = "| Model | QPS | Session (s) | 1st Infer (ms) | CPU% | Mem (MB) |`n" +
+                        "|-------|----:|----:|----:|----:|----:|`n"
           $header = "## MorphiZen EP Performance Results`n`n" + $perfHeader
 
           # EPContext export/import perf tables (full_model_seq128 only).
@@ -1102,9 +1109,11 @@ jobs:
             $ttft = if ($ttftMatch.Success) { "{0:F1}" -f ([double]$ttftMatch.Groups[1].Value / 1000) } else { "-" }
             $tps  = if ($tpsMatch.Success) { "{0:F1}" -f [double]$tpsMatch.Groups[2].Value } else { "-" }
             $mem  = if ($memMatch.Success) { "{0:F2}" -f ([double]$memMatch.Groups[1].Value / 1GB) } else { "-" }
-            $gpu = Get-GpuMem $content
-            $gpuDedGB = if ($gpu.Dedicated -ne "-") { "{0:F2}" -f ([double]$gpu.Dedicated / 1024) } else { "-" }
-            $gpuShGB  = if ($gpu.Shared -ne "-") { "{0:F2}" -f ([double]$gpu.Shared / 1024) } else { "-" }
+            # GPU peaks sampled externally during the run (see OGA benchmark step).
+            $gpuDed = [regex]::Match($content, '\[GPUMEM\]\s*Dedicated GPU memory:\s+(\d+)\s+bytes')
+            $gpuSh  = [regex]::Match($content, '\[GPUMEM\]\s*Shared GPU memory:\s+(\d+)\s+bytes')
+            $gpuDedGB = if ($gpuDed.Success) { "{0:F2}" -f ([double]$gpuDed.Groups[1].Value / 1GB) } else { "-" }
+            $gpuShGB  = if ($gpuSh.Success) { "{0:F2}" -f ([double]$gpuSh.Groups[1].Value / 1GB) } else { "-" }
             $ogaRows += "| $model | 1 | 5 | 128 | 128 | $ttft | $tps | $mem | $gpuDedGB | $gpuShGB |`n"
           }
           $ogaSection = ""

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -825,6 +825,10 @@ jobs:
             $proc = Start-Process -FilePath $benchmark -ArgumentList $bargs `
               -NoNewWindow -PassThru `
               -RedirectStandardOutput $tmpOut -RedirectStandardError $tmpErr
+            # Cache the native handle so $proc.ExitCode is readable after exit;
+            # without this Start-Process -PassThru can leave ExitCode $null, and
+            # `$null -ne 0` is $true in PowerShell -> false failure.
+            $null = $proc.Handle
             $peakDed = 0L
             $peakShared = 0L
             while (-not $proc.HasExited) {
@@ -847,7 +851,8 @@ jobs:
             Add-Content $outFile "[GPUMEM] Shared GPU memory: $peakShared bytes"
             Get-Content $outFile | Write-Host
             Remove-Item $tmpOut, $tmpErr -ErrorAction SilentlyContinue
-            if ($proc.ExitCode -ne 0) { $failed = 1 }
+            $ec = $proc.ExitCode
+            if ($null -ne $ec -and $ec -ne 0) { $failed = 1 }
           }
           exit $failed
 
@@ -1109,18 +1114,25 @@ jobs:
             $ttft = if ($ttftMatch.Success) { "{0:F1}" -f ([double]$ttftMatch.Groups[1].Value / 1000) } else { "-" }
             $tps  = if ($tpsMatch.Success) { "{0:F1}" -f [double]$tpsMatch.Groups[2].Value } else { "-" }
             $mem  = if ($memMatch.Success) { "{0:F2}" -f ([double]$memMatch.Groups[1].Value / 1GB) } else { "-" }
-            # GPU peaks sampled externally during the run (see OGA benchmark step).
+            # GPU peak sampled externally during the run (see OGA benchmark
+            # step). Report the total (dedicated + shared): on the UMA APU the
+            # WDDM dedicated/shared split drifts with memory pressure run-to-run,
+            # but their sum -- the real footprint -- is stable.
             $gpuDed = [regex]::Match($content, '\[GPUMEM\]\s*Dedicated GPU memory:\s+(\d+)\s+bytes')
             $gpuSh  = [regex]::Match($content, '\[GPUMEM\]\s*Shared GPU memory:\s+(\d+)\s+bytes')
-            $gpuDedGB = if ($gpuDed.Success) { "{0:F2}" -f ([double]$gpuDed.Groups[1].Value / 1GB) } else { "-" }
-            $gpuShGB  = if ($gpuSh.Success) { "{0:F2}" -f ([double]$gpuSh.Groups[1].Value / 1GB) } else { "-" }
-            $ogaRows += "| $model | 1 | 5 | 128 | 128 | $ttft | $tps | $mem | $gpuDedGB | $gpuShGB |`n"
+            $gpuGB = if ($gpuDed.Success -or $gpuSh.Success) {
+              $tot = 0.0
+              if ($gpuDed.Success) { $tot += [double]$gpuDed.Groups[1].Value }
+              if ($gpuSh.Success) { $tot += [double]$gpuSh.Groups[1].Value }
+              "{0:F2}" -f ($tot / 1GB)
+            } else { "-" }
+            $ogaRows += "| $model | 1 | 5 | 128 | 128 | $ttft | $tps | $mem | $gpuGB |`n"
           }
           $ogaSection = ""
           if ($ogaRows) {
             $ogaSection = "`n## OGA Benchmark Results`n`n" +
-                          "| Model | Warmup | Reps | Prompt Len | Gen Tokens | TTFT (ms) | TPS | Peak Mem (GB) | GPU Dedicated (GB) | GPU Shared (GB) |`n" +
-                          "|-------|----:|----:|----:|----:|----:|----:|----:|----:|----:|`n" +
+                          "| Model | Warmup | Reps | Prompt Len | Gen Tokens | TTFT (ms) | TPS | Peak Mem (GB) | GPU Mem (GB) |`n" +
+                          "|-------|----:|----:|----:|----:|----:|----:|----:|----:|`n" +
                           $ogaRows
           }
 

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1045,7 +1045,8 @@ jobs:
           # Each file: extract Number of inferences per second / Session
           # creation / 1st infer / Avg CPU / Peak WS / peak GPU mem (dedicated,
           # shared) for the 8-column format (Model | QPS | Session (s) |
-          # 1st Infer (ms) | CPU% | Mem (MB) | GPU Ded (MB) | GPU Shared (MB)).
+          # 1st Infer (ms) | CPU% | Mem (MB) | GPU Dedicated (MB) |
+          # GPU Shared (MB)).
           function Get-PerfRows($dir) {
             $rows = ""
             foreach ($f in (Get-ChildItem "$dir/*.txt" -ErrorAction SilentlyContinue)) {
@@ -1075,7 +1076,7 @@ jobs:
           $tableRows = Get-PerfRows $resultsDir
           if (-not $tableRows) { $tableRows = "| (no results) | - | - | - | - | - | - | - |`n" }
 
-          $perfHeader = "| Model | QPS | Session (s) | 1st Infer (ms) | CPU% | Mem (MB) | GPU Ded (MB) | GPU Shared (MB) |`n" +
+          $perfHeader = "| Model | QPS | Session (s) | 1st Infer (ms) | CPU% | Mem (MB) | GPU Dedicated (MB) | GPU Shared (MB) |`n" +
                         "|-------|----:|----:|----:|----:|----:|----:|----:|`n"
           $header = "## MorphiZen EP Performance Results`n`n" + $perfHeader
 
@@ -1109,7 +1110,7 @@ jobs:
           $ogaSection = ""
           if ($ogaRows) {
             $ogaSection = "`n## OGA Benchmark Results`n`n" +
-                          "| Model | Warmup | Reps | Prompt Len | Gen Tokens | TTFT (ms) | TPS | Peak Mem (GB) | GPU Ded (GB) | GPU Shared (GB) |`n" +
+                          "| Model | Warmup | Reps | Prompt Len | Gen Tokens | TTFT (ms) | TPS | Peak Mem (GB) | GPU Dedicated (GB) | GPU Shared (GB) |`n" +
                           "|-------|----:|----:|----:|----:|----:|----:|----:|----:|----:|`n" +
                           $ogaRows
           }

--- a/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
+++ b/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
@@ -61,7 +61,8 @@ std::atomic<size_t> g_gpu_shared_peak{0};    // DXGI NON_LOCAL segment
 std::atomic<int> g_live_instances{0};
 
 #ifdef _WIN32
-// AMD adapter handle, resolved once on first sample. nullptr => sampling no-op.
+// AMD adapter handle, resolved once on first sample, released by the last
+// instance's destructor. nullptr => sampling no-op.
 IDXGIAdapter3 *g_dxgi_adapter = nullptr;
 std::once_flag g_dxgi_once;
 
@@ -91,6 +92,19 @@ void init_dxgi_adapter() {
   factory->Release();
 }
 #endif
+
+// Release the cached adapter. Called from the last instance's destructor -- a
+// normal execution point, deliberately NOT static/DLL-detach teardown, where
+// releasing a COM object under the loader lock is hazardous. After release,
+// sampling no-ops for any later session in the same process (fine: diagnostic).
+void release_dxgi_adapter() {
+#ifdef _WIN32
+  if (g_dxgi_adapter) {
+    g_dxgi_adapter->Release();
+    g_dxgi_adapter = nullptr;
+  }
+#endif
+}
 
 #ifdef _WIN32
 // CAS the running max into an atomic high-water mark.
@@ -754,6 +768,7 @@ MlirCustomOp::~MlirCustomOp() {
               << " bytes" << std::endl;
     std::cout << "[PEAKMEM] Shared GPU memory: " << g_gpu_shared_peak
               << " bytes" << std::endl;
+    release_dxgi_adapter();
   }
 }
 

--- a/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
+++ b/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
@@ -22,26 +22,11 @@
 #include <hip/hip_runtime_api.h>
 #endif
 #include <algorithm>
-#include <atomic>
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
-#include <iostream>
 #include <mutex>
 #include <vector>
-
-// Peak-memory diagnostics: per-process GPU memory via the Windows DXGI
-// video-memory budget API, plus the host peak working set.
-#ifdef _WIN32
-#define WIN32_LEAN_AND_MEAN
-#define NOMINMAX
-#include <windows.h>
-// dxgi1_4.h / psapi.h must follow windows.h.
-#include <dxgi1_4.h>
-#include <psapi.h>
-#pragma comment(lib, "dxgi.lib")
-#pragma comment(lib, "psapi.lib")
-#endif
 
 // Environment parameters (global scope, before namespace)
 DEF_ENV_PARAM(MORPHIZEN_DEBUG_MLIR_BACKEND, "0")
@@ -49,114 +34,6 @@ DEF_ENV_PARAM(MORPHIZEN_DEBUG_MLIR_BACKEND, "0")
 #define MY_LOG(n) LOG_IF(INFO, ENV_PARAM(MORPHIZEN_DEBUG_MLIR_BACKEND) >= n)
 
 namespace mlir_compilation {
-
-namespace {
-
-// High-water marks of this process's GPU memory (bytes), updated from the tail
-// of every Compute(). The two DXGI segment peaks are tracked independently.
-std::atomic<size_t> g_gpu_dedicated_peak{0}; // DXGI LOCAL segment
-std::atomic<size_t> g_gpu_shared_peak{0};    // DXGI NON_LOCAL segment
-// Live MlirCustomOp instances; the last destructor prints the [PEAKMEM] line so
-// multi-partition models emit it once.
-std::atomic<int> g_live_instances{0};
-
-#ifdef _WIN32
-// AMD adapter handle, resolved once on first sample, released by the last
-// instance's destructor. nullptr => sampling no-op.
-IDXGIAdapter3 *g_dxgi_adapter = nullptr;
-std::once_flag g_dxgi_once;
-
-void init_dxgi_adapter() {
-  IDXGIFactory1 *factory = nullptr;
-  if (FAILED(CreateDXGIFactory1(__uuidof(IDXGIFactory1),
-                                reinterpret_cast<void **>(&factory)))) {
-    return;
-  }
-  IDXGIAdapter1 *adapter = nullptr;
-  for (UINT i = 0; factory->EnumAdapters1(i, &adapter) != DXGI_ERROR_NOT_FOUND;
-       ++i) {
-    DXGI_ADAPTER_DESC1 desc{};
-    if (SUCCEEDED(adapter->GetDesc1(&desc)) &&
-        !(desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE) && desc.VendorId == 0x1002) {
-      IDXGIAdapter3 *a3 = nullptr;
-      if (SUCCEEDED(adapter->QueryInterface(__uuidof(IDXGIAdapter3),
-                                            reinterpret_cast<void **>(&a3)))) {
-        g_dxgi_adapter = a3;
-        adapter->Release();
-        break;
-      }
-    }
-    adapter->Release();
-    adapter = nullptr;
-  }
-  factory->Release();
-}
-#endif
-
-// Release the cached adapter. Called from the last instance's destructor -- a
-// normal execution point, deliberately NOT static/DLL-detach teardown, where
-// releasing a COM object under the loader lock is hazardous. After release,
-// sampling no-ops for any later session in the same process (fine: diagnostic).
-void release_dxgi_adapter() {
-#ifdef _WIN32
-  if (g_dxgi_adapter) {
-    g_dxgi_adapter->Release();
-    g_dxgi_adapter = nullptr;
-  }
-#endif
-}
-
-#ifdef _WIN32
-// CAS the running max into an atomic high-water mark.
-void update_peak(std::atomic<size_t> &peak, size_t v) {
-  size_t prev = peak.load(std::memory_order_relaxed);
-  while (v > prev &&
-         !peak.compare_exchange_weak(prev, v, std::memory_order_relaxed)) {
-  }
-}
-#endif
-
-// Sample this process's current GPU memory usage and update the high-water
-// marks. DXGI CurrentUsage is per-(calling-)process per-adapter: LOCAL is
-// dedicated VRAM (APU UMA carve-out), NON_LOCAL is shared system memory; their
-// sum is our total GPU footprint. All failures degrade silently -- this is
-// diagnostics, never inference-critical.
-void sample_gpu_peak() {
-#ifdef _WIN32
-  std::call_once(g_dxgi_once, init_dxgi_adapter);
-  if (g_dxgi_adapter == nullptr) {
-    return;
-  }
-  DXGI_QUERY_VIDEO_MEMORY_INFO local{};
-  DXGI_QUERY_VIDEO_MEMORY_INFO nonlocal{};
-  size_t dedicated = 0;
-  size_t shared = 0;
-  if (SUCCEEDED(g_dxgi_adapter->QueryVideoMemoryInfo(
-          0, DXGI_MEMORY_SEGMENT_GROUP_LOCAL, &local))) {
-    dedicated = local.CurrentUsage;
-  }
-  if (SUCCEEDED(g_dxgi_adapter->QueryVideoMemoryInfo(
-          0, DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL, &nonlocal))) {
-    shared = nonlocal.CurrentUsage;
-  }
-  update_peak(g_gpu_dedicated_peak, dedicated);
-  update_peak(g_gpu_shared_peak, shared);
-#endif
-}
-
-// Process peak working set in bytes (0 if unavailable). Windows-only; the
-// peak-memory diagnostics are not implemented on other platforms.
-size_t host_peak_working_set() {
-#ifdef _WIN32
-  PROCESS_MEMORY_COUNTERS pmc{};
-  if (GetProcessMemoryInfo(GetCurrentProcess(), &pmc, sizeof(pmc))) {
-    return pmc.PeakWorkingSetSize;
-  }
-#endif
-  return 0;
-}
-
-} // namespace
 
 // Tensor marshaling state - holds tensors, shapes, and span
 struct TensorData {
@@ -727,8 +604,6 @@ MlirCustomOp::MlirCustomOp(
 
   MY_LOG(1) << "MlirCustomOp constructor";
 
-  g_live_instances.fetch_add(1, std::memory_order_relaxed);
-
   // Parse metadata from JSON
   metadata_ = parse_metadata_from_metadef(context, meta_def);
   // Dispatch mode travels with the artifact's metadata (not a live provider
@@ -755,21 +630,6 @@ MlirCustomOp::~MlirCustomOp() {
     if (slot.ptr)
       (void)hipFree(slot.ptr);
 #endif
-
-  // Last live instance prints the peak-memory lines (once per process run) to
-  // stdout via std::cout, matching ORT perf_test's output style so CI captures
-  // them. Three lines, all in bytes: host working set uses ORT perf_test's
-  // exact wording; GPU uses the Windows Task Manager terms "Dedicated GPU
-  // memory" (DXGI LOCAL) and "Shared GPU memory" (DXGI NON_LOCAL).
-  if (g_live_instances.fetch_sub(1, std::memory_order_relaxed) == 1) {
-    std::cout << "[PEAKMEM] Peak working set size: " << host_peak_working_set()
-              << " bytes" << std::endl;
-    std::cout << "[PEAKMEM] Dedicated GPU memory: " << g_gpu_dedicated_peak
-              << " bytes" << std::endl;
-    std::cout << "[PEAKMEM] Shared GPU memory: " << g_gpu_shared_peak
-              << " bytes" << std::endl;
-    release_dxgi_adapter();
-  }
 }
 
 // Output-allocator dispatch: 2-arg inference_compute with in-graph
@@ -854,7 +714,6 @@ void MlirCustomOp::Compute(const OrtApi *api, OrtKernelContext *context) const {
     // Allocator mode owns its output staging (no pre-filled outputs span) and
     // its own post-compute host D2H; it does not share the classic perf path.
     compute_with_output_allocator(context);
-    sample_gpu_peak();
     MY_LOG(2) << "Compute completed successfully (allocator mode)";
     return;
   }
@@ -871,7 +730,6 @@ void MlirCustomOp::Compute(const OrtApi *api, OrtKernelContext *context) const {
       // TODO: Throw ORT exception
     }
 
-    sample_gpu_peak();
     MY_LOG(2) << "Compute completed successfully";
     return;
   }
@@ -932,7 +790,6 @@ void MlirCustomOp::Compute(const OrtApi *api, OrtKernelContext *context) const {
   s.fence_residual_ms = elapsed_ms(t_after_compute, t_after_fence);
   perf_collector().record(s);
 
-  sample_gpu_peak();
   MY_LOG(2) << "Compute completed successfully";
 #endif // BUILD_MOCK_RUNTIME
 }

--- a/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
+++ b/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
@@ -22,11 +22,26 @@
 #include <hip/hip_runtime_api.h>
 #endif
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
+#include <iostream>
 #include <mutex>
 #include <vector>
+
+// Peak-memory diagnostics: per-process GPU memory via the Windows DXGI
+// video-memory budget API, plus the host peak working set.
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+// dxgi1_4.h / psapi.h must follow windows.h.
+#include <dxgi1_4.h>
+#include <psapi.h>
+#pragma comment(lib, "dxgi.lib")
+#pragma comment(lib, "psapi.lib")
+#endif
 
 // Environment parameters (global scope, before namespace)
 DEF_ENV_PARAM(MORPHIZEN_DEBUG_MLIR_BACKEND, "0")
@@ -34,6 +49,100 @@ DEF_ENV_PARAM(MORPHIZEN_DEBUG_MLIR_BACKEND, "0")
 #define MY_LOG(n) LOG_IF(INFO, ENV_PARAM(MORPHIZEN_DEBUG_MLIR_BACKEND) >= n)
 
 namespace mlir_compilation {
+
+namespace {
+
+// High-water marks of this process's GPU memory (bytes), updated from the tail
+// of every Compute(). The two DXGI segment peaks are tracked independently.
+std::atomic<size_t> g_gpu_dedicated_peak{0}; // DXGI LOCAL segment
+std::atomic<size_t> g_gpu_shared_peak{0};    // DXGI NON_LOCAL segment
+// Live MlirCustomOp instances; the last destructor prints the [PEAKMEM] line so
+// multi-partition models emit it once.
+std::atomic<int> g_live_instances{0};
+
+#ifdef _WIN32
+// AMD adapter handle, resolved once on first sample. nullptr => sampling no-op.
+IDXGIAdapter3 *g_dxgi_adapter = nullptr;
+std::once_flag g_dxgi_once;
+
+void init_dxgi_adapter() {
+  IDXGIFactory1 *factory = nullptr;
+  if (FAILED(CreateDXGIFactory1(__uuidof(IDXGIFactory1),
+                                reinterpret_cast<void **>(&factory)))) {
+    return;
+  }
+  IDXGIAdapter1 *adapter = nullptr;
+  for (UINT i = 0; factory->EnumAdapters1(i, &adapter) != DXGI_ERROR_NOT_FOUND;
+       ++i) {
+    DXGI_ADAPTER_DESC1 desc{};
+    if (SUCCEEDED(adapter->GetDesc1(&desc)) &&
+        !(desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE) && desc.VendorId == 0x1002) {
+      IDXGIAdapter3 *a3 = nullptr;
+      if (SUCCEEDED(adapter->QueryInterface(__uuidof(IDXGIAdapter3),
+                                            reinterpret_cast<void **>(&a3)))) {
+        g_dxgi_adapter = a3;
+        adapter->Release();
+        break;
+      }
+    }
+    adapter->Release();
+    adapter = nullptr;
+  }
+  factory->Release();
+}
+#endif
+
+#ifdef _WIN32
+// CAS the running max into an atomic high-water mark.
+void update_peak(std::atomic<size_t> &peak, size_t v) {
+  size_t prev = peak.load(std::memory_order_relaxed);
+  while (v > prev &&
+         !peak.compare_exchange_weak(prev, v, std::memory_order_relaxed)) {
+  }
+}
+#endif
+
+// Sample this process's current GPU memory usage and update the high-water
+// marks. DXGI CurrentUsage is per-(calling-)process per-adapter: LOCAL is
+// dedicated VRAM (APU UMA carve-out), NON_LOCAL is shared system memory; their
+// sum is our total GPU footprint. All failures degrade silently -- this is
+// diagnostics, never inference-critical.
+void sample_gpu_peak() {
+#ifdef _WIN32
+  std::call_once(g_dxgi_once, init_dxgi_adapter);
+  if (g_dxgi_adapter == nullptr) {
+    return;
+  }
+  DXGI_QUERY_VIDEO_MEMORY_INFO local{};
+  DXGI_QUERY_VIDEO_MEMORY_INFO nonlocal{};
+  size_t dedicated = 0;
+  size_t shared = 0;
+  if (SUCCEEDED(g_dxgi_adapter->QueryVideoMemoryInfo(
+          0, DXGI_MEMORY_SEGMENT_GROUP_LOCAL, &local))) {
+    dedicated = local.CurrentUsage;
+  }
+  if (SUCCEEDED(g_dxgi_adapter->QueryVideoMemoryInfo(
+          0, DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL, &nonlocal))) {
+    shared = nonlocal.CurrentUsage;
+  }
+  update_peak(g_gpu_dedicated_peak, dedicated);
+  update_peak(g_gpu_shared_peak, shared);
+#endif
+}
+
+// Process peak working set in bytes (0 if unavailable). Windows-only; the
+// peak-memory diagnostics are not implemented on other platforms.
+size_t host_peak_working_set() {
+#ifdef _WIN32
+  PROCESS_MEMORY_COUNTERS pmc{};
+  if (GetProcessMemoryInfo(GetCurrentProcess(), &pmc, sizeof(pmc))) {
+    return pmc.PeakWorkingSetSize;
+  }
+#endif
+  return 0;
+}
+
+} // namespace
 
 // Tensor marshaling state - holds tensors, shapes, and span
 struct TensorData {
@@ -604,6 +713,8 @@ MlirCustomOp::MlirCustomOp(
 
   MY_LOG(1) << "MlirCustomOp constructor";
 
+  g_live_instances.fetch_add(1, std::memory_order_relaxed);
+
   // Parse metadata from JSON
   metadata_ = parse_metadata_from_metadef(context, meta_def);
   // Dispatch mode travels with the artifact's metadata (not a live provider
@@ -630,6 +741,20 @@ MlirCustomOp::~MlirCustomOp() {
     if (slot.ptr)
       (void)hipFree(slot.ptr);
 #endif
+
+  // Last live instance prints the peak-memory lines (once per process run) to
+  // stdout via std::cout, matching ORT perf_test's output style so CI captures
+  // them. Three lines, all in bytes: host working set uses ORT perf_test's
+  // exact wording; GPU uses the Windows Task Manager terms "Dedicated GPU
+  // memory" (DXGI LOCAL) and "Shared GPU memory" (DXGI NON_LOCAL).
+  if (g_live_instances.fetch_sub(1, std::memory_order_relaxed) == 1) {
+    std::cout << "[PEAKMEM] Peak working set size: " << host_peak_working_set()
+              << " bytes" << std::endl;
+    std::cout << "[PEAKMEM] Dedicated GPU memory: " << g_gpu_dedicated_peak
+              << " bytes" << std::endl;
+    std::cout << "[PEAKMEM] Shared GPU memory: " << g_gpu_shared_peak
+              << " bytes" << std::endl;
+  }
 }
 
 // Output-allocator dispatch: 2-arg inference_compute with in-graph
@@ -714,6 +839,7 @@ void MlirCustomOp::Compute(const OrtApi *api, OrtKernelContext *context) const {
     // Allocator mode owns its output staging (no pre-filled outputs span) and
     // its own post-compute host D2H; it does not share the classic perf path.
     compute_with_output_allocator(context);
+    sample_gpu_peak();
     MY_LOG(2) << "Compute completed successfully (allocator mode)";
     return;
   }
@@ -730,6 +856,7 @@ void MlirCustomOp::Compute(const OrtApi *api, OrtKernelContext *context) const {
       // TODO: Throw ORT exception
     }
 
+    sample_gpu_peak();
     MY_LOG(2) << "Compute completed successfully";
     return;
   }
@@ -790,6 +917,7 @@ void MlirCustomOp::Compute(const OrtApi *api, OrtKernelContext *context) const {
   s.fence_residual_ms = elapsed_ms(t_after_compute, t_after_fence);
   perf_collector().record(s);
 
+  sample_gpu_peak();
   MY_LOG(2) << "Compute completed successfully";
 #endif // BUILD_MOCK_RUNTIME
 }


### PR DESCRIPTION
﻿## Summary

Add a peak GPU memory column to the OGA model_benchmark CI results, sampled externally via Windows perf counters (no EP/inference changes).

## Why

CI had no GPU memory figure for the OGA benchmark, and TheRock's Windows distribution ships no `rocm-smi`/`amd-smi`. An earlier revision sampled inside the EP (DXGI in `MlirCustomOp`); per review that mixed diagnostics into the inference path and was fully reverted. Measurement now lives in CI: poll the `model_benchmark` PID's `\GPU Process Memory` counters. Host peak is already printed by `model_benchmark`, so only GPU is added; scope is the OGA suite only.

## What

1. **Sampling** in `Run OGA benchmark` of [.github/workflows/windows-build.yml](.github/workflows/windows-build.yml): start `model_benchmark.exe` via `Start-Process -PassThru`, poll `\GPU Process Memory(pid_*)\Dedicated Usage` + `\Shared Usage` for the peak, append as `[GPUMEM]` lines. `$proc.Handle` is cached so `ExitCode` is readable (else `Start-Process` may leave it `$null`, and `$null -ne 0` is `$true`, failing the step).
2. **Publish**: one `GPU Mem (GB)` column = dedicated + shared. The WDDM split drifts run-to-run on the UMA APU; the sum is stable, so report the total.
3. **No changes** to the EP, perf_test / EPContext / L2 tables, or dependencies (`Get-Counter` is built in).

## Test plan

- [x] Poller validated locally: captures PID, returns sane peaks.
- [x] OGA TTFT/TPS unchanged vs main within noise (Llama TPS 41.2 vs 41.6); external sampling does not perturb the benchmark.
- [x] Total GPU stable across runs (~13.8 GB gpt-oss, ~22.4 GB Llama) despite split drift.
- [ ] gpu-test on StrixHalo: OGA step green, `GPU Mem (GB)` populated.

## Notes for reviewers

PDH polled every ~1.5 s, peak only. PID polling requires `Start-Process` with separate stdout/stderr, so the EP's stderr lines group after stdout instead of interleaving (`2>&1`); metrics and parsing are unaffected.

- [ ] **Incremental** -- 1 file, ~50 LOC.
- [ ] **AI policy** -- Cursor-assisted; disclosed via commit `Co-authored-by` trailer.
- [ ] **Reviews resolved**
- [ ] **CODEOWNERS routing**
