### PR TITLE
feat(whisper): download models from AMD HF repos by default

### DIFF
--- a/docs/whisper_quick_start.md
+++ b/docs/whisper_quick_start.md
@@ -371,8 +371,9 @@ use (shared from `test/python/whisper/whisper_infer.py`). It auto-prepares the m
 (§3) on first run, so this one command works from a fresh checkout. Runs
 identically in PowerShell and Git Bash.
 
-If you've already run the tests (§4), the bundled **jfk.wav** sample is sitting
-in the data dir — transcribe it directly:
+Transcribe the bundled **jfk.wav** demo clip — if it isn't cached yet, the script
+**downloads it on demand**, so this works on a fresh checkout with nothing
+pre-fetched:
 
 ```
 python scripts/transcribe_whisper.py test/python/data/whisper/jfk.wav
@@ -381,7 +382,8 @@ python scripts/transcribe_whisper.py test/python/data/whisper/jfk.wav
 (Expected: *"And so my fellow Americans, ask not what your country can do for
 you..."*) The LibriSpeech clips fetched by §4 also work, e.g.
 `test/python/data/whisper/librispeech/sample_0.wav`. For your own audio, pass any
-16 kHz mono wav in place of the path above.
+16 kHz mono wav in place of the path above (only the bundled jfk.wav is
+auto-downloaded; other paths must exist).
 
 By default this prints the transcription **plus** the per-phase latency / RTF
 table (see below), running one discarded warmup pass first so the numbers are

--- a/docs/whisper_quick_start.md
+++ b/docs/whisper_quick_start.md
@@ -12,10 +12,12 @@ Whisper runs **fp16 by default** — it is both faster on GPU and bit-faithful: 
 fp16 build keeps the `lm_head` in fp32 while the body is fp16, so greedy decoding
 is argmax-lossless (verbatim transcription, prefill logit cosine 1.0 vs the
 fp16 CPU reference). An **fp32** variant is also available (`--fp32`). **Both
-precisions are built locally by one command** — `python scripts/build_whisper_models.py`
-(a pinned OGA DirectML model builder in an isolated venv) — so there is no separate
-opt-in build step. fp32 is selected at run time with `--fp32`; see §6 for
-fp16-vs-fp32 numbers.
+precisions are downloaded automatically from the AMD Hugging Face repos on first
+use** — [`amd/whisper-large-v3-onnx-fp16`](https://huggingface.co/amd/whisper-large-v3-onnx-fp16)
+and [`amd/whisper-large-v3-onnx-fp32`](https://huggingface.co/amd/whisper-large-v3-onnx-fp32) —
+so the tests and `transcribe_whisper.py` work from a fresh checkout with no
+separate model step. Building the models locally is the **backup** (§3b). fp32 is
+selected at run time with `--fp32`; see §6 for fp16-vs-fp32 numbers.
 
 > **Shell:** commands in this guide are written for **Git Bash** (the repo's
 > convention, same as the main [Quick Start](quick_start.md) — launch it from an
@@ -85,10 +87,11 @@ conda activate hipdnn-ep
 ```
 
 The test audio is fetched from public URLs at runtime (no `datasets` / `jiwer`
-dependency), and the model build (`python scripts/build_whisper_models.py`, §3)
-installs its pinned builder deps into a **dedicated isolated venv**
-(`install/whisper-builder-venv/`), so it never touches the `hipdnn-ep` env or
-shadows the OGA fork.
+dependency), and the Whisper models are **downloaded from Hugging Face** on first
+use (§3) via `huggingface_hub` (already in `environment.yml`). The optional local
+model build (`python scripts/build_whisper_models.py`, §3b) installs its pinned
+builder deps into a **dedicated isolated venv** (`install/whisper-builder-venv/`),
+so it never touches the `hipdnn-ep` env or shadows the OGA fork.
 
 The one pip package you **do** need at a specific version is `onnxruntime` —
 see §1b, which is mandatory before the EP will load.
@@ -221,30 +224,28 @@ $env:Path = "$env:THEROCK_DIST\bin;$ROOT\local\bin;$env:Path"
 
 ---
 
-## 3. Build + compile the model
+## 3. Get + compile the model
 
-Acquisition is **two steps**. First, **build the raw models** — `python
-scripts/build_whisper_models.py` builds BOTH the fp32 (`models/whisper-large-v3-onnx/`)
-and fp16 (`models/whisper-large-v3-onnx-fp16/`) bundles from
-`openai/whisper-large-v3` (pinned HF revision) via a pinned OGA DirectML model
-builder running in an isolated venv. No manual stock-OGA install is needed — the
-builder venv is self-contained. First run downloads HF weights + builds (~10 min);
-idempotent after.
-
-```
-python scripts/build_whisper_models.py
-```
-
-Then **prepare the model for the EP** — `setup_whisper_model.py` is consume-only:
-it applies the required ONNX surgery (`past_sequence_length` input + position-embed
-/ token-embed fixes for the static shared-buffer KV cache) and runs `fix_shapes`
-to lock the static shapes on the already-built raw bundle. It is idempotent and
-instant; if the raw model is absent it prints the build hint above and exits.
+**You normally don't run anything here** — the tests (§4) and
+`transcribe_whisper.py` (§5) prepare the model on demand: they download the raw
+OGA bundle from the AMD HF repo on first use, then apply the EP surgery +
+`fix_shapes` automatically. To do it ahead of time (or to verify the download),
+run the consume-only setup wrapper, which fetches the raw bundle if absent and
+prepares it for the EP:
 
 ```
-python scripts/setup_whisper_model.py          # fp16 (default)
-python scripts/setup_whisper_model.py --fp32   # fp32 model dir
+python scripts/setup_whisper_model.py          # fp16 (default) — amd/whisper-large-v3-onnx-fp16
+python scripts/setup_whisper_model.py --fp32   # fp32          — amd/whisper-large-v3-onnx-fp32
 ```
+
+This downloads `encoder.onnx`/`decoder.onnx` (+ `.data`) + tokenizer + config from
+Hugging Face (first run ~3–6 GB per precision), then applies the ONNX surgery
+(`past_sequence_length` input + position-/token-embed fixes for the static
+shared-buffer KV cache) and `fix_shapes`. Idempotent — instant once prepared.
+
+> **Gated / rate-limited?** If the download fails for auth reasons, run
+> `hf auth login` with a token that can read the repo and retry. If HF is
+> unreachable entirely, build the models locally instead (§3b).
 
 Verify the variants were produced (`ls` on Git Bash, `dir` on PowerShell) — the
 default fp16 bundle lives in `models/whisper-large-v3-onnx-fp16/`, the fp32 bundle
@@ -252,7 +253,7 @@ in `models/whisper-large-v3-onnx/`; both have the same file set:
 
 ```
 models/whisper-large-v3-onnx-fp16/   (default; fp32 dir mirrors this layout)
-  encoder.onnx (+.data), decoder.onnx (+.data), tokenizer.json, genai_config.json   (built raw bundle)
+  encoder.onnx (+.data), decoder.onnx (+.data), tokenizer.json, genai_config.json   (raw bundle from HF)
   encoder_fixed.onnx, decoder_surgery.onnx,
   decoder_fixed_prefill.onnx (S=4), decoder_fixed_decode.onnx (S=1)                  (compiled-shape variants)
 ```
@@ -267,20 +268,35 @@ models/whisper-large-v3-onnx-fp16/   (default; fp32 dir mirrors this layout)
 
 ---
 
-## 3b. Precisions (fp16 default, fp32 opt-out)
+## 3b. Build the models locally (backup)
+
+The §3 download is the normal path. Build locally only if HF is unreachable, or
+to **reproduce** the published models from source. `python
+scripts/build_whisper_models.py` builds BOTH the fp32 (`models/whisper-large-v3-onnx/`)
+and fp16 (`models/whisper-large-v3-onnx-fp16/`) bundles from
+`openai/whisper-large-v3` (pinned HF revision) via a pinned OGA DirectML model
+builder running in an isolated venv. This is exactly how the AMD HF repos were
+produced, so the output is byte-equivalent. First run downloads the HF *weights* +
+builds (~10 min); idempotent after.
+
+```
+python scripts/build_whisper_models.py            # both precisions
+python scripts/build_whisper_models.py --precision fp16   # one only
+```
+
+Because this writes the same `models/whisper-large-v3-onnx{,-fp16}/` dirs the §3
+download targets, a subsequent `setup_whisper_model.py` (or any test) sees the raw
+bundle already present and **skips the download** — the local build pre-populates
+the cache. No manual `onnxruntime-genai-directml` install is needed and the OGA
+fork is never shadowed — the builder runs in its own isolated venv (see §0).
+
+### Precisions (fp16 default, fp32 opt-out)
 
 fp16 is the **default** precision — faster on GPU and bit-faithful (fp32 `lm_head`
-keeps greedy argmax-lossless). Both bundles are produced **together** by the same
-`python scripts/build_whisper_models.py` in §3 — the pinned OGA DirectML model
-builder emits an fp16 body with an fp32 `lm_head` for the default model and an
-all-fp32 model for `--fp32`. `python scripts/setup_whisper_model.py` (default) and
-`--fp32` apply the SAME surgery + `fix_shapes`, writing
-`models/whisper-large-v3-onnx-fp16/` and `models/whisper-large-v3-onnx/`.
-
-No manual `onnxruntime-genai-directml` install is needed and the OGA fork is never
-shadowed — the builder runs in its own isolated venv (see §0). The default
-transcribe / test commands run fp16; add `--fp32` to use the fp32 model instead
-(§5, §6).
+keeps greedy argmax-lossless). The default transcribe / test commands run fp16;
+add `--fp32` to use the fp32 model instead (§5, §6). Both the HF download (§3) and
+the local build (above) provide the same two bundles; `setup_whisper_model.py`
+(default) and `--fp32` apply the SAME surgery + `fix_shapes` to each.
 
 ---
 
@@ -384,8 +400,8 @@ python scripts/transcribe_whisper.py test/python/data/whisper/jfk.wav --compare
 ```
 
 The default run uses the fp16 model. Add `--fp32` to run the fp32 model instead
-(build both precisions first with `python scripts/build_whisper_models.py`, §3).
-The metrics label shows the precision:
+(it auto-downloads on first use, same as fp16; see §3). The metrics label shows
+the precision:
 
 ```
 python scripts/transcribe_whisper.py test/python/data/whisper/jfk.wav --fp32
@@ -503,6 +519,7 @@ EP comparison.
 | Transcription is garbage / a "GPU" run is suspiciously slow | Silent CPU fallback. Set the env (§2), clear the model cache (PowerShell `Remove-Item "$env:TEMP\morphizen_mlir_*"` / Git Bash `rm -f "$TEMP"/morphizen_mlir_*`), and re-run. Confirm GPU dispatch with `HIPDNN_EP_DEBUG=1` (look for `[REAL] wrap_*` lines on stderr). |
 | Changed a runtime `.cpp` / kernel, behavior didn't change | Cached model DLLs embed the old bitcode. Clear the cache after rebuilding (PowerShell `Remove-Item "$env:TEMP\morphizen_mlir_*"` / Git Bash `rm -f "$TEMP"/morphizen_mlir_*`). |
 | A test `skip`s with "audio unavailable" | The network can't reach github/HF for the test clips. Connect and re-run; the audio caches locally after the first fetch. |
+| Model setup fails / `Could not obtain the Whisper raw model` | The raw bundle download from `amd/whisper-large-v3-onnx-{fp16,fp32}` failed. If it's an auth / rate-limit error, run `hf auth login` and retry. If HF is unreachable, build the models locally instead (§3b: `python scripts/build_whisper_models.py`). |
 | Every test `skip`s with "MorphiZen EP not found — run build.py first" | The tests can't locate the EP DLL. For an out-of-tree install (`$ROOT/local`), set `MORPHIZEN_EP_BIN` (§2). Verify the DLL exists at `$ROOT/local/bin/onnxruntime_morphizen_ep.dll`. |
 | EP registration fails (`requested API version [N] is not available`) / access violation on session create | The pip `onnxruntime` version ≠ the ORT the EP links (`cmake/deps.txt`). PyPI's `onnxruntime-directml` often lags the pinned tag, so `pip install` alone won't fix it — build a matching ORT wheel from source and install it (see §1b). |
 

--- a/scripts/setup_whisper_model.py
+++ b/scripts/setup_whisper_model.py
@@ -12,17 +12,17 @@ PowerShell). Runs identically in PowerShell and Git Bash:
     python scripts/setup_whisper_model.py          # fp16 (default)
     python scripts/setup_whisper_model.py --fp32   # fp32 model dir
 
-This script does NOT download or build the raw model — it only PREPARES one: it
-applies the ONNX surgery (past_sequence_length input + position-/token-embed
-fixes) and fix_shapes to produce the static-shape variants the EP compiles. The
-DEFAULT is the fp16 model; ``--fp32`` selects the fp32 model directory instead.
-The raw model must already exist; build it first with::
+This script PREPARES a model for the EP: it ensures the raw OGA bundle is present
+(auto-downloading it from the AMD HF repo on first use — backup is a local
+``python build.py --build-whisper-models``), then applies the ONNX surgery
+(past_sequence_length input + position-/token-embed fixes) and fix_shapes to
+produce the static-shape variants the EP compiles. The DEFAULT is the fp16 model
+(``amd/whisper-large-v3-onnx-fp16``); ``--fp32`` selects the fp32 model
+(``amd/whisper-large-v3-onnx-fp32``) instead.
 
-    python build.py --build-whisper-models
-
-If the raw model is absent, this script prints a build hint and exits non-zero.
-Idempotent: re-running is a no-op once the prepared files exist. Works from any
-current directory.
+If the raw model can be neither downloaded nor found locally, this script prints
+the HF + local-build hints and exits non-zero. Idempotent: re-running is a no-op
+once the prepared files exist. Works from any current directory.
 """
 
 import argparse
@@ -65,8 +65,6 @@ def main() -> int:
             setup_whisper_model_dir(model_dir)
     except FileNotFoundError as e:
         print(f"[whisper-setup] ERROR: {e}")
-        print("[whisper-setup] Build the raw models first:")
-        print("    python build.py --build-whisper-models")
         return 1
     expected = [
         "encoder_fixed.onnx",

--- a/scripts/transcribe_whisper.py
+++ b/scripts/transcribe_whisper.py
@@ -84,10 +84,11 @@ def main() -> int:
         "--fp32",
         action="store_true",
         help="use the fp32 model instead of the default fp16. The DEFAULT is the "
-        "fp16 model (built locally via the OGA DML builder; body fp16, lm_head "
-        "fp32 so greedy is argmax-lossless) — it is faster than fp32 on GPU. Both "
-        "precisions must be built first via 'python build.py "
-        "--build-whisper-models' (see docs/whisper_quick_start.md).",
+        "fp16 model (body fp16, lm_head fp32 so greedy is argmax-lossless) — it is "
+        "faster than fp32 on GPU. The raw model auto-downloads from "
+        "huggingface.co/amd/whisper-large-v3-onnx-{fp16,fp32} on first use; a local "
+        "'python build.py --build-whisper-models' is the backup "
+        "(see docs/whisper_quick_start.md).",
     )
     ap.add_argument(
         "--metrics",
@@ -120,8 +121,9 @@ def main() -> int:
     dtype = np.float16 if use_fp16 else np.float32
     model_dir = MODEL_DIR_FP16 if use_fp16 else MODEL_DIR
 
-    # The model must already be built (python build.py --build-whisper-models);
-    # the setup helpers are consume-only and raise FileNotFoundError if absent.
+    # The setup helpers auto-download the raw model from HF on first use (backup:
+    # python build.py --build-whisper-models) and raise FileNotFoundError if
+    # neither source is reachable.
     print(f"[transcribe] preparing {prec} model at {model_dir}")
     try:
         if use_fp16:
@@ -130,8 +132,6 @@ def main() -> int:
             setup_whisper_model_dir(model_dir)
     except FileNotFoundError as e:
         print(f"[transcribe] ERROR: {e}")
-        print("[transcribe] Build the model first:")
-        print("    python build.py --build-whisper-models")
         return 1
 
     print(f"[transcribe] loading audio features from {audio_path}")

--- a/scripts/transcribe_whisper.py
+++ b/scripts/transcribe_whisper.py
@@ -46,12 +46,19 @@ sys.path.insert(0, str(REPO_ROOT / "test" / "python" / "whisper"))
 
 import whisper_infer  # noqa: E402
 from conftest import (  # noqa: E402
+    setup_jfk_sample,
     setup_whisper_fp16_model_dir,
     setup_whisper_model_dir,
 )
 
 MODEL_DIR = REPO_ROOT / "models" / "whisper-large-v3-onnx"
 MODEL_DIR_FP16 = REPO_ROOT / "models" / "whisper-large-v3-onnx-fp16"
+
+# Canonical location of the bundled jfk.wav demo clip (the path shown in the
+# quick-start). It is gitignored and fetched on demand, so a fresh checkout that
+# runs the headline `transcribe_whisper.py test/python/data/whisper/jfk.wav`
+# command needs us to download it rather than error out.
+JFK_SAMPLE = REPO_ROOT / "test" / "python" / "data" / "whisper" / "jfk.wav"
 
 
 def main() -> int:
@@ -108,6 +115,15 @@ def main() -> int:
     args = ap.parse_args()
 
     audio_path = pathlib.Path(args.audio)
+    # The bundled jfk.wav demo clip is gitignored + fetched on demand. If the
+    # user passes that canonical path and it's not cached yet (fresh checkout),
+    # download it so the headline quick-start command works out of the box. Any
+    # OTHER missing path is a user error and still fails fast.
+    if not audio_path.exists() and audio_path.resolve() == JFK_SAMPLE.resolve():
+        print(f"[transcribe] fetching demo clip jfk.wav -> {audio_path}")
+        if not setup_jfk_sample(JFK_SAMPLE.parent):
+            print("[transcribe] ERROR: could not download jfk.wav (no network?)")
+            return 1
     if not audio_path.exists():
         print(f"[transcribe] ERROR: audio file not found: {audio_path}")
         return 1

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -560,25 +560,71 @@ class WhisperModelConfig:
     n_vocab: int = 51866
 
 
-def setup_whisper_model_dir(model_dir: pathlib.Path) -> None:
-    """Idempotent fp32 Whisper preparation — CONSUMES a locally-built raw model.
+# Canonical AMD-hosted raw OGA bundles (encoder/decoder + tokenizer + config).
+# These are the default model source: the setup helpers below download them on
+# first use; a local build (scripts/build_whisper_models.py) is the backup that
+# pre-populates the dir so the download is skipped. The fp32 LOCAL dir is
+# `models/whisper-large-v3-onnx` (no -fp32 suffix) but its HF repo carries the
+# -fp32 suffix — the download targets whatever model_dir the caller passes.
+WHISPER_HF_REPO_FP32 = "amd/whisper-large-v3-onnx-fp32"
+WHISPER_HF_REPO_FP16 = "amd/whisper-large-v3-onnx-fp16"
 
-    The raw fp32 ONNX is produced by ``scripts/build_whisper_models.py`` (pinned
-    OGA DirectML builder) into ``model_dir`` — there is NO download (the old
-    external prebuilt was non-reproducible). This function only runs the shared
-    surgery + fix_shapes on the already-present raw bundle.
 
-    Raises FileNotFoundError with a build hint if the raw model is absent, so
-    callers (pytest fixture / CLI) can skip/instruct cleanly.
+def _ensure_whisper_raw_downloaded(model_dir: pathlib.Path, hf_repo: str) -> None:
+    """Fetch the raw OGA bundle from ``hf_repo`` into ``model_dir`` if absent.
+
+    No-op when encoder.onnx + decoder.onnx are already present (a prior download,
+    or a local ``scripts/build_whisper_models.py`` build — the backup path). On
+    any failure (huggingface_hub missing, repo gated/unreachable) raises
+    FileNotFoundError pointing at BOTH the HF-auth and the local-build remedies,
+    so callers (pytest fixture / CLI) get one actionable message.
     """
+    if (model_dir / "encoder.onnx").exists() and (model_dir / "decoder.onnx").exists():
+        return
+
+    hint = (
+        f"Could not obtain the Whisper raw model for {model_dir}.\n"
+        f"  - Primary: it auto-downloads from https://huggingface.co/{hf_repo} "
+        "(run `hf auth login` if the repo needs auth / you are rate-limited).\n"
+        "  - Backup:  build it locally with `python build.py --build-whisper-models`."
+    )
+    try:
+        from huggingface_hub import snapshot_download
+    except ImportError as e:
+        raise FileNotFoundError(
+            f"{hint}\n  (huggingface_hub not installed: {e})"
+        ) from e
+
+    model_dir.mkdir(parents=True, exist_ok=True)
+    print(f"[whisper] downloading raw model from {hf_repo} -> {model_dir}")
+    # GatedRepo / RepositoryNotFound / network errors all map to the same hint.
+    try:
+        snapshot_download(repo_id=hf_repo, local_dir=str(model_dir))
+    except Exception as e:  # noqa: BLE001
+        raise FileNotFoundError(f"{hint}\n  (download failed: {e})") from e
+
+
+def setup_whisper_model_dir(model_dir: pathlib.Path) -> None:
+    """Idempotent fp32 Whisper preparation — downloads the raw model if needed.
+
+    The raw fp32 OGA bundle is fetched from ``amd/whisper-large-v3-onnx-fp32`` on
+    first use (the backup is a local ``scripts/build_whisper_models.py`` build via
+    the pinned OGA DirectML builder, which pre-populates ``model_dir``). This
+    function then runs the shared surgery + fix_shapes on the raw bundle.
+
+    Raises FileNotFoundError (with HF + local-build hints) if the raw model can
+    be neither downloaded nor found, so callers can skip/instruct cleanly.
+    """
+    _ensure_whisper_raw_downloaded(model_dir, WHISPER_HF_REPO_FP32)
     # Guard checks BOTH encoder + decoder: _apply_whisper_surgery_and_fix_shapes
     # reads encoder.onnx (fix_shapes) too, so a half-built dir with one but not
-    # the other must fail here with the build hint, not crash later raw.
+    # the other must fail here with the hint, not crash later raw.
     for fname in ("encoder.onnx", "decoder.onnx"):
         if not (model_dir / fname).exists():
             raise FileNotFoundError(
                 f"Whisper raw model incomplete at {model_dir} (missing {fname}). "
-                "Build it first: python build.py --build-whisper-models"
+                f"Download from https://huggingface.co/{WHISPER_HF_REPO_FP32} or "
+                "build it: python build.py --build-whisper-models"
             )
     _apply_whisper_surgery_and_fix_shapes(model_dir)
 
@@ -633,19 +679,22 @@ def _apply_whisper_surgery_and_fix_shapes(model_dir: pathlib.Path) -> None:
 
 
 def setup_whisper_fp16_model_dir(model_dir: pathlib.Path) -> None:
-    """Idempotent fp16 Whisper preparation — CONSUMES a locally-built raw model.
+    """Idempotent fp16 Whisper preparation — downloads the raw model if needed.
 
-    Identical to ``setup_whisper_model_dir`` but for the fp16 bundle (built by
-    ``scripts/build_whisper_models.py`` with -p fp16). The fp16 OGA graph has the
-    same layout as fp32, so ``_apply_whisper_surgery_and_fix_shapes`` applies
+    Identical to ``setup_whisper_model_dir`` but for the fp16 bundle (HF repo
+    ``amd/whisper-large-v3-onnx-fp16``; backup is a local
+    ``scripts/build_whisper_models.py`` build). The fp16 OGA graph has the same
+    layout as fp32, so ``_apply_whisper_surgery_and_fix_shapes`` applies
     unchanged. The fp16 lm_head stays fp32 (OGA convention) -> argmax-lossless.
     """
+    _ensure_whisper_raw_downloaded(model_dir, WHISPER_HF_REPO_FP16)
     # Guard checks BOTH encoder + decoder (see setup_whisper_model_dir).
     for fname in ("encoder.onnx", "decoder.onnx"):
         if not (model_dir / fname).exists():
             raise FileNotFoundError(
                 f"Whisper fp16 raw model incomplete at {model_dir} (missing {fname}). "
-                "Build it first: python build.py --build-whisper-models"
+                f"Download from https://huggingface.co/{WHISPER_HF_REPO_FP16} or "
+                "build it: python build.py --build-whisper-models"
             )
     _apply_whisper_surgery_and_fix_shapes(model_dir)
 

--- a/test/python/whisper/test_whisper.py
+++ b/test/python/whisper/test_whisper.py
@@ -160,13 +160,13 @@ def precision(request):
     """Parametrize a test across BOTH precisions — fp16 FIRST (the default path).
 
     Yields ``(model_dir, np_dtype, label)``:
-      * fp16 → the locally-built OGA DML bundle (body fp16 + fp32 lm_head).
-        Built ahead of time via ``python build.py --build-whisper-models``. If
-        absent/unbuilt, the fp16 parametrization SKIPS cleanly (the fp32 leg
-        still runs, so a machine without the OGA builder keeps full fp32
-        coverage).
-      * fp32 → the locally-built native-fp32 bundle (set up by the autouse
-        ``_setup`` fixture; always present).
+      * fp16 → the OGA DML bundle (body fp16 + fp32 lm_head), auto-downloaded
+        from ``amd/whisper-large-v3-onnx-fp16`` on first use (backup: ``python
+        build.py --build-whisper-models``). If it can be neither downloaded nor
+        found, the fp16 parametrization SKIPS cleanly (the fp32 leg still runs,
+        so an offline machine keeps full fp32 coverage).
+      * fp32 → the native-fp32 bundle (set up by the autouse ``_setup``
+        fixture; downloaded from ``amd/whisper-large-v3-onnx-fp32`` if absent).
 
     fp16 is listed first so it is the primary, default-precision leg.
     """
@@ -174,10 +174,11 @@ def precision(request):
     if label == "fp16":
         try:
             model_dir = _prepare_fp16_model_dir()
-        except Exception as e:  # noqa: BLE001 — unbuilt model / surgery error → skip
+        except Exception as e:  # noqa: BLE001 — download/build/surgery error → skip
             pytest.skip(
-                f"fp16 Whisper model unavailable: {e!r} "
-                "(build it: python build.py --build-whisper-models)"
+                f"fp16 Whisper model unavailable: {e!r} (auto-downloads from "
+                "huggingface.co/amd/whisper-large-v3-onnx-fp16; backup: "
+                "python build.py --build-whisper-models)"
             )
         return model_dir, np.float16, "fp16"
     return _MODEL_DIR, np.float32, "fp32"
@@ -1254,12 +1255,14 @@ def test_perf_decode_tps():
     # fp32 — always run (locally-built model is set up by the autouse fixture).
     _perf_one_precision(audio, "fp32", _MODEL_DIR, np.float32, results)
 
-    # fp16 — best-effort: build on demand; skip the precision entirely on failure.
+    # fp16 — best-effort: download/prepare on demand; skip the precision on failure.
     try:
         setup_whisper_fp16_model_dir(_MODEL_DIR_FP16)
         _perf_one_precision(audio, "fp16", _MODEL_DIR_FP16, np.float16, results)
     except Exception as e:  # noqa: BLE001
-        print(f"[perf] fp16 unavailable (build failed) — fp32-only table: {e!r}")
+        print(
+            f"[perf] fp16 unavailable (download/build failed) — fp32-only table: {e!r}"
+        )
 
     # ── Report ───────────────────────────────────────────────────────────────
     print("\n" + "=" * 86)


### PR DESCRIPTION
## Summary

Whisper tests and scripts now **download the model from the AMD-hosted Hugging Face repos by default**, so everything runs from a fresh checkout with no local model build. Building locally remains the **backup** path.

The two canonical repos (uploaded under the AMD org):
- [`amd/whisper-large-v3-onnx-fp16`](https://huggingface.co/amd/whisper-large-v3-onnx-fp16)
- [`amd/whisper-large-v3-onnx-fp32`](https://huggingface.co/amd/whisper-large-v3-onnx-fp32)

## What changed

- **`test/python/conftest.py`** — new `_ensure_whisper_raw_downloaded(model_dir, hf_repo)`: `snapshot_download`s the repo when `encoder.onnx`/`decoder.onnx` are absent, no-ops if they already exist (so a local build still pre-populates and skips the download). On failure it raises `FileNotFoundError` with both the `hf auth login` and local-build remedies. `setup_whisper_model_dir` / `setup_whisper_fp16_model_dir` call it before the existing surgery + `fix_shapes`. Every test fixture and script routes through these two helpers, so this single point flips the whole flow.
- **`test/python/whisper/test_whisper.py`** — fixture docstrings + skip messages updated to "auto-downloads from HF; backup: build".
- **`scripts/setup_whisper_model.py`**, **`scripts/transcribe_whisper.py`** — help text + error hints reworded; removed the old "build first or exit" messaging (they inherit auto-download via conftest).
- **`docs/whisper_quick_start.md`** — reworked to download-first: §3 is now "model auto-downloads on first use" (with an `hf auth login` note for gated/rate-limited), §3b retitled "Build the models locally (backup)", §7 gains a download-failure troubleshooting row.

Note: `snapshot_download` pulls the whole repo (raw bundle + the prepared `*_fixed*`/`*_surgery*` variants). That's harmless — setup is idempotent and gates on file existence.

## Test plan

- [ ] `pytest test/python/whisper/test_whisper.py::test_e2e_transcription_greedy -v -s` on a checkout with **no** local `models/whisper-large-v3-onnx*` dirs → downloads from HF, transcribes the JFK quote, passes.
- [ ] Re-run after a local `python scripts/build_whisper_models.py` → existence guard skips the download (no re-fetch).
- [ ] `python scripts/setup_whisper_model.py` and `--fp32` → fetch + prepare both precisions.
- [ ] Offline / no HF access → fails with the actionable FileNotFoundError pointing at `hf auth login` and the local-build backup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)