### PR TITLE
chore: bump morphizen and drop -ml flag from OGA benchmark

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -816,7 +816,7 @@ jobs:
             # pass --ep_library: upstream model_benchmark rejects it, and where
             # supported it double-registers the EP and crashes on shutdown.
             Write-Host "=== OGA Benchmark: $($modelDir.Name) ==="
-            $bargs = @('-i', $modelDir.FullName, '-g', '128', '-r', '5', '-w', '1', '-b', '1', '-ml', '-1') + $promptArgs + @('-v')
+            $bargs = @('-i', $modelDir.FullName, '-g', '128', '-r', '5', '-w', '1', '-b', '1') + $promptArgs + @('-v')
             $tmpOut = [System.IO.Path]::GetTempFileName()
             $tmpErr = [System.IO.Path]::GetTempFileName()
             # Launch model_benchmark and sample its per-process GPU memory via


### PR DESCRIPTION
## Summary

Bump the `morphizen` submodule to its latest `origin/main` (`302a969`, includes #232/#233/#227) and drop the `-ml -1` argument from the OGA `model_benchmark` invocation in the windows-build CI workflow.

## Why

The submodule pointer lagged behind `origin/main`; advancing it picks up the merged region-capture / const-initializer / DenseElementsAttr fixes. The `-ml -1` (max-length unbounded) flag on the OGA benchmark is removed so the benchmark uses the model's default generation length rather than forcing an unbounded run.

## What

1. **Submodule bump**: `3rd-party/morphizen` advanced from `e5d418f` to `302a969` (`origin/main` HEAD).
2. **CI argument change** at `.github/workflows/windows-build.yml`: removed `'-ml', '-1'` from the `model_benchmark` argument list.

## Test plan

- [ ] build-windows green: ORT + OGA + EP build successfully against bumped morphizen
- [ ] gpu-test green: OGA benchmark step runs without the `-ml -1` flag

## Notes for reviewers

None.

## Checklist

- [x] **Incremental.** Standalone, 2 files / 2 lines.
- [x] **AI policy.** Mechanical submodule bump + CI flag removal; no substantial generated code.
- [x] **No `good first issue` automation.**
- [ ] **Reviews resolved.**
- [x] **CODEOWNERS routing.** No new ownership paths touched.
