### PR TITLE
perf(slice): fold constant slices at compile time to drop runtime readback

### DIFF
--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -767,6 +767,7 @@ void ConvertOnnxToHipPass::runOnOperation() {
       for (int round = 0; round < kMaxRounds; ++round) {
         mlir::RewritePatternSet preLoweringPatterns(ctx);
         populateGatherShapeFoldPatterns(preLoweringPatterns, ctx);
+        populateSlicePreLoweringPatterns(preLoweringPatterns, ctx);
         populateReshapeShapeFoldPatterns(preLoweringPatterns, ctx);
         populatePadShapeFoldPatterns(preLoweringPatterns, ctx);
         populateFastGeluFusionPatterns(preLoweringPatterns, ctx);

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
@@ -364,6 +364,15 @@ void populateFlattenConversionPatterns(RewritePatternSet &patterns,
 void populateGatherShapeFoldPatterns(RewritePatternSet &patterns,
                                      MLIRContext *ctx);
 
+/// Pre-lowering pattern set: fold compile-time-constant, positive-step
+/// `onnx.Slice` to a zero-copy `tensor.extract_slice` (the `SliceDecompose`
+/// pattern). Must run BEFORE `lowerOnnxConstants` so the starts/ends/axes/steps
+/// are still inline in `onnx.Constant` -- after externalization the matcher
+/// cannot read them and the op falls back to the runtime `hip.slice` D2H
+/// readback. Folding here eliminates that readback at the compiler layer.
+void populateSlicePreLoweringPatterns(RewritePatternSet &patterns,
+                                      MLIRContext *ctx);
+
 /// Pre-lowering pattern set: rewrite the `Reshape(data, Shape(src))` idiom
 /// so the shape operand becomes an explicit
 /// `tensor.from_elements(tensor.dim(src, *))`. This lets ReshapeConversion's

--- a/lib/Conversion/OnnxToHip/SliceConversion.cpp
+++ b/lib/Conversion/OnnxToHip/SliceConversion.cpp
@@ -328,5 +328,19 @@ void populateSliceConversionPatterns(RewritePatternSet &patterns,
   patterns.add<SliceDecompose, SliceToHip>(ctx);
 }
 
+// Pre-lowering: only the constant-folding `SliceDecompose`. Registered in the
+// pre-`lowerOnnxConstants` phase so the matcher can read the inline
+// `onnx.Constant` starts/ends/axes/steps. Constant externalization
+// (externalize-min-num-elements=1) strips the inline value from even tiny
+// index tensors, so by the time `populateSliceConversionPatterns` runs in
+// `convertComputeOps` the fold fails and the slice falls back to the runtime
+// `hip.slice` D2H readback. Folding pre-externalization rewrites
+// constant + positive-step + static-dim slices to a zero-copy
+// `tensor.extract_slice` -- zero runtime readback, correct (compiler) layer.
+void populateSlicePreLoweringPatterns(RewritePatternSet &patterns,
+                                      MLIRContext *ctx) {
+  patterns.add<SliceDecompose>(ctx);
+}
+
 } // namespace hip
 } // namespace mlir

--- a/test/lit/Conversion/onnx-to-hip/test_slice_const_fold.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_slice_const_fold.mlir
@@ -1,0 +1,50 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify a compile-time-constant onnx.Slice folds to a zero-copy
+// tensor.extract_slice EVEN WHEN the slice's starts/ends/axes/steps come from
+// onnx.Constant ops that constant externalization would strip the inline value
+// from.
+//
+// SliceDecompose is registered in the PRE-lowering phase (before
+// lowerOnnxConstants) precisely so it reads the inline onnx.Constant values.
+// With externalize-min-num-elements=1 every constant -- including these tiny
+// index tensors -- is externalized to a memref.global with no inline value;
+// run AFTER externalization the fold could not read them and the slice would
+// fall back to the runtime hip.slice D2H readback. Folding pre-externalization
+// eliminates that readback at the compiler layer.
+//
+// Both RUN lines must produce the same extract_slice (no hip.slice / onnx.Slice):
+//   1. default options
+//   2. externalize-min-num-elements=1 (the case this fix targets; the dead
+//      externalized globals are harmless and DCE away)
+// ============================================================================
+
+// RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip | FileCheck %s
+// RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip=externalize-min-num-elements=1 | FileCheck %s
+
+module {
+  func.func @main_graph(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+    return %arg0 : tensor<4xf32>
+  }
+
+  // Constant slice via onnx.Constant operands (the externalizable form).
+  // Folds to tensor.extract_slice through the pre-lowering SliceDecompose.
+  func.func @test_slice_const_fold(%input: tensor<4x6xf32>) -> tensor<2x6xf32> {
+    // CHECK-LABEL: func.func @test_slice_const_fold
+    %starts = "onnx.Constant"() {value = dense<[1]> : tensor<1xi64>} : () -> tensor<1xi64>
+    %ends   = "onnx.Constant"() {value = dense<[3]> : tensor<1xi64>} : () -> tensor<1xi64>
+    %axes   = "onnx.Constant"() {value = dense<[0]> : tensor<1xi64>} : () -> tensor<1xi64>
+    %steps  = "onnx.Constant"() {value = dense<[1]> : tensor<1xi64>} : () -> tensor<1xi64>
+    %r = "onnx.Slice"(%input, %starts, %ends, %axes, %steps)
+        : (tensor<4x6xf32>, tensor<1xi64>, tensor<1xi64>,
+           tensor<1xi64>, tensor<1xi64>) -> tensor<2x6xf32>
+
+    // CHECK-NOT: onnx.Slice
+    // CHECK-NOT: hip.slice
+    // CHECK: tensor.extract_slice {{.*}}[1, 0] [2, 6] [1, 1]
+    return %r : tensor<2x6xf32>
+  }
+}


### PR DESCRIPTION
## Summary

Addresses the **slice half of PR #363 review comment # 2** ("const reads belong in the
compiler, not a runtime cache") at the correct layer.

Constant `onnx.Slice` ops were falling back to the runtime `hip.slice` path — a per-call
D2H readback of the `starts`/`ends`/`axes`/`steps` index tensors plus a `hipStreamSynchronize`
— even though the values are compile-time known. Root cause: `externalize-min-num-elements=1`
externalizes **every** constant (including these tiny index tensors) to the constants blob
*before* `convertComputeOps` runs, so the existing `SliceDecompose` fold there can no longer
read the inline value and bails to `SliceToHip`.

Fix: register the constant-folding `SliceDecompose` pattern in the **pre-`lowerOnnxConstants`**
phase (next to `GatherShapeFold`), where `onnx.Constant` is still inline. Constant +
positive-step + static-dim slices now fold to a zero-copy `tensor.extract_slice` (→
`memref.subview`) with **zero runtime readback** and zero first-inference overhead. Genuinely
dynamic slices (non-constant indices / negative step / dynamic sliced dim) are unchanged —
they still bail to the runtime `hip.slice`.

## Changes
- `lib/Conversion/OnnxToHip/SliceConversion.cpp` — new `populateSlicePreLoweringPatterns`
  (just `SliceDecompose`).
- `lib/Conversion/OnnxToHip/OnnxToHipUtils.h` — declaration.
- `lib/Conversion/OnnxToHip/OnnxToHip.cpp` — register it in the pre-lowering pattern set.
- `test/lit/Conversion/onnx-to-hip/test_slice_const_fold.mlir` — new LIT test.

## Test plan
- [x] LIT: `test_slice_const_fold.mlir` asserts the fold to `tensor.extract_slice` under BOTH
      default options AND `--convert-onnx-to-hip=externalize-min-num-elements=1` (the case
      this fix targets — proves the fold beats externalization). Existing `test_slice.mlir`
      unaffected.
- [x] Accuracy (7 ProcyonV2 models, real pre-recorded inputs for detr/esrgan/blip_decoder/
      sam_decoder): all cosine ≥ 0.99999 vs CPU fp32 — identical to baseline (behavior-
      preserving; detr output bit-identical).
- [x] Perf (Release, r=20, gfx1151): detr 61.4→59.4 ms, sam_decoder 27.4→25.9, sam_encoder
      108→104; others flat. Small (the readback sync is cheap on adequate-VRAM); the win is
      primarily architectural.
- [x] `lintrunner -a`

## Notes
Follow-ups for the rest of the review (separate PRs): Pad const-fold (on top of #357/#361,
which rewrite `PadConversion` + add `hip.readback_scalar`); conv Find cache (on top of #366
op-state-slot / WeakStore pattern).
