### PR TITLE
feat: add GreaterOrEqual, LessOrEqual, and Tanh ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This project demonstrates the integration of HIP (Heterogeneous-compute Interfac
 ## Features
 
 - **MLIR Compiler Pipeline**: ONNX dialect → HIP dialect → LLVM IR → native DLL
-- **MIOpen Integration**: Conv, ConvTranspose, Softmax, RMS Norm, Mul, Sigmoid, Softplus, CausalConvWithState via MIOpen library
+- **MIOpen Integration**: Conv, ConvTranspose, Softmax, RMS Norm, Mul, Sigmoid, Tanh, Softplus, CausalConvWithState via MIOpen library
 - **hipBLASLt MatMul**: High-performance matrix multiplication
 - **Custom HIP Kernels**: GQA, RoPE, Cast, Sub, Gather, ReduceSum, Reciprocal, Sqrt, GELU, Range, LinearAttention
 - **Memory Pool Optimization**: `hip-pool-allocs` pass packs allocations into a single grow-on-demand buffer
@@ -33,6 +33,7 @@ This project demonstrates the integration of HIP (Heterogeneous-compute Interfac
 | Mul | MIOpen |
 | Add | MIOpen |
 | Sigmoid | MIOpen |
+| Tanh | MIOpen |
 | Softplus | MIOpen |
 | Gelu | Custom HIP kernel |
 | Reciprocal | Custom HIP kernel |

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ This project demonstrates the integration of HIP (Heterogeneous-compute Interfac
 | Mod | Custom HIP Kernel |
 | Sign | Custom HIP Kernel |
 | Less | Custom HIP Kernel |
+| GreaterOrEqual | Decomposed (Not(Less(A, B))) |
 | Min | MIOpen |
 | ReduceSum | Custom HIP Kernel |
 | ReduceMax | Custom HIP Kernel |

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ This project demonstrates the integration of HIP (Heterogeneous-compute Interfac
 | Sign | Custom HIP Kernel |
 | Less | Custom HIP Kernel |
 | GreaterOrEqual | Decomposed (Not(Less(A, B))) |
+| LessOrEqual | Decomposed (Not(Less(B, A))) |
 | Min | MIOpen |
 | ReduceSum | Custom HIP Kernel |
 | ReduceMax | Custom HIP Kernel |

--- a/include/hip/Dialect/IR/HipBufferize.h
+++ b/include/hip/Dialect/IR/HipBufferize.h
@@ -129,6 +129,7 @@ registerHipBufferizableOpInterfaceModels(DialectRegistry &registry) {
     GqaOp::attachInterface<HipDstBufferizableModel<GqaOp>>(*ctx);
     CastOp::attachInterface<HipDstBufferizableModel<CastOp>>(*ctx);
     SigmoidOp::attachInterface<HipDstBufferizableModel<SigmoidOp>>(*ctx);
+    TanhOp::attachInterface<HipDstBufferizableModel<TanhOp>>(*ctx);
     SoftplusOp::attachInterface<HipDstBufferizableModel<SoftplusOp>>(*ctx);
     GeluOp::attachInterface<HipDstBufferizableModel<GeluOp>>(*ctx);
     LeakyReluOp::attachInterface<HipDstBufferizableModel<LeakyReluOp>>(*ctx);

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -1471,6 +1471,37 @@ def Hip_SigmoidOp : Hip_DpsOp<"sigmoid", /*traits=*/[],
   }];
 }
 
+def Hip_TanhOp : Hip_DpsOp<"tanh", /*traits=*/[],
+                           /*outsAccessor=*/"Y",
+                           /*autoReify=*/1,
+                           /*autoInfer=*/1,
+                           /*declareInfer=*/1> {
+  let summary = "Tanh activation";
+  let description = [{
+    Applies hyperbolic-tangent activation: y = tanh(x)
+
+    Uses destination-passing style: output buffer is provided as argument.
+
+    Example:
+    ```mlir
+    hip.tanh(%ctx) ins(%x : memref<1x128x512xf32, 1>)
+                   outs(%y : memref<1x128x512xf32, 1>)
+    ```
+  }];
+
+  let arguments = (ins
+    Hip_ContextType:$ctx,
+    Hip_TensorOrMemRef:$x,
+    Hip_TensorOrMemRef:$y
+  );
+
+  let assemblyFormat = [{
+    `(` $ctx `)` `ins` `(` $x `:` type($x) `)`
+    `outs` `(` $y `:` type($y) `)`
+    attr-dict (`:` type($result_tensors)^)?
+  }];
+}
+
 def Hip_SoftplusOp : Hip_DpsOp<"softplus", /*traits=*/[],
                                /*outsAccessor=*/"Y",
                                /*autoReify=*/1,

--- a/lib/Conversion/HipToLLVM/ActivationLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ActivationLowering.cpp
@@ -395,8 +395,7 @@ void populateActivationLoweringPatterns(const LLVMTypeConverter &converter,
                                         RewritePatternSet &patterns) {
   patterns.add<SigmoidOpLowering, TanhOpLowering, SoftplusOpLowering,
                GeluOpLowering, LeakyReluOpLowering, SiluOpLowering,
-               MiopenSoftmaxOpLowering>(
-      converter);
+               MiopenSoftmaxOpLowering>(converter);
 }
 
 } // namespace hip

--- a/lib/Conversion/HipToLLVM/ActivationLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ActivationLowering.cpp
@@ -117,6 +117,20 @@ struct SigmoidOpLowering : public ConvertOpToLLVMPattern<SigmoidOp> {
   }
 };
 
+// hip.tanh(ctx, x, y)
+//   -> wrap_miopenActivationForward(state, x, y, num_elements,
+//                                    data_type, activation_mode=TANH)
+struct TanhOpLowering : public ConvertOpToLLVMPattern<TanhOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(TanhOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    return lowerMiopenActivation<TanhOp, kActivationTanh>(op, adaptor,
+                                                          rewriter);
+  }
+};
+
 // hip.softplus(ctx, x, y)
 //   -> wrap_miopenActivationForward(state, x, y, num_elements,
 //                                    data_type, activation_mode=SOFTPLUS)
@@ -379,9 +393,9 @@ struct MiopenSoftmaxOpLowering
 
 void populateActivationLoweringPatterns(const LLVMTypeConverter &converter,
                                         RewritePatternSet &patterns) {
-  patterns.add<SigmoidOpLowering, SoftplusOpLowering, GeluOpLowering,
-               LeakyReluOpLowering, SiluOpLowering, MiopenSoftmaxOpLowering>(
-      converter);
+  patterns.add<SigmoidOpLowering, TanhOpLowering, SoftplusOpLowering,
+               GeluOpLowering, LeakyReluOpLowering, SiluOpLowering,
+               MiopenSoftmaxOpLowering>(converter);
 }
 
 } // namespace hip

--- a/lib/Conversion/HipToLLVM/ActivationLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ActivationLowering.cpp
@@ -395,7 +395,8 @@ void populateActivationLoweringPatterns(const LLVMTypeConverter &converter,
                                         RewritePatternSet &patterns) {
   patterns.add<SigmoidOpLowering, TanhOpLowering, SoftplusOpLowering,
                GeluOpLowering, LeakyReluOpLowering, SiluOpLowering,
-               MiopenSoftmaxOpLowering>(converter);
+               MiopenSoftmaxOpLowering>(
+      converter);
 }
 
 } // namespace hip

--- a/lib/Conversion/OnnxToHip/ActivationConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ActivationConversion.cpp
@@ -69,6 +69,34 @@ SigmoidToHip::matchAndRewrite(mlir::Operation *op,
   return mlir::success();
 }
 
+/// onnx.Tanh -> hip.tanh
+struct TanhToHip : public mlir::RewritePattern {
+  TanhToHip(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.Tanh", /*benefit=*/1, ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override;
+};
+
+mlir::LogicalResult
+TanhToHip::matchAndRewrite(mlir::Operation *op,
+                           mlir::PatternRewriter &rewriter) const {
+  auto ctxOrFailure = getContextArg(op, rewriter);
+  if (mlir::failed(ctxOrFailure))
+    return mlir::failure();
+  mlir::Value context = *ctxOrFailure;
+
+  mlir::Location loc = op->getLoc();
+  mlir::Value input = op->getOperand(0);
+  auto resultType =
+      mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
+  mlir::Value init = createEmptyTensor(rewriter, loc, resultType, input);
+  auto hipOp = mlir::hip::TanhOp::create(rewriter, loc, context, input, init);
+  rewriter.replaceOp(op, hipOp->getResult(0));
+  return mlir::success();
+}
+
 /// onnx.Softplus -> hip.softplus
 struct SoftplusToHip : public mlir::RewritePattern {
   SoftplusToHip(mlir::MLIRContext *ctx)
@@ -145,7 +173,8 @@ GeluToHip::matchAndRewrite(mlir::Operation *op,
 
 void populateActivationConversionPatterns(RewritePatternSet &patterns,
                                           MLIRContext *ctx) {
-  patterns.add<SoftmaxToHip, SigmoidToHip, SoftplusToHip, GeluToHip>(ctx);
+  patterns.add<SoftmaxToHip, SigmoidToHip, TanhToHip, SoftplusToHip, GeluToHip>(
+      ctx);
 }
 
 } // namespace hip

--- a/lib/Conversion/OnnxToHip/ActivationConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ActivationConversion.cpp
@@ -92,7 +92,8 @@ TanhToHip::matchAndRewrite(mlir::Operation *op,
   auto resultType =
       mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
   if (!resultType)
-    return rewriter.notifyMatchFailure(op, "Tanh expects a ranked tensor result");
+    return rewriter.notifyMatchFailure(op,
+                                       "Tanh expects a ranked tensor result");
   mlir::Value init = createEmptyTensor(rewriter, loc, resultType, input);
   auto hipOp = mlir::hip::TanhOp::create(rewriter, loc, context, input, init);
   rewriter.replaceOp(op, hipOp->getResult(0));

--- a/lib/Conversion/OnnxToHip/ActivationConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ActivationConversion.cpp
@@ -90,7 +90,9 @@ TanhToHip::matchAndRewrite(mlir::Operation *op,
   mlir::Location loc = op->getLoc();
   mlir::Value input = op->getOperand(0);
   auto resultType =
-      mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
+      mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
+  if (!resultType)
+    return rewriter.notifyMatchFailure(op, "Tanh expects a ranked tensor result");
   mlir::Value init = createEmptyTensor(rewriter, loc, resultType, input);
   auto hipOp = mlir::hip::TanhOp::create(rewriter, loc, context, input, init);
   rewriter.replaceOp(op, hipOp->getResult(0));

--- a/lib/Conversion/OnnxToHip/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHip/CMakeLists.txt
@@ -56,6 +56,7 @@ add_library(OnnxToHip STATIC
   ExpandConversion.cpp
   ReduceProdConversion.cpp
   LessConversion.cpp
+  GreaterOrEqualConversion.cpp
   GatherNDConversion.cpp
   SignConversion.cpp
   ModConversion.cpp

--- a/lib/Conversion/OnnxToHip/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHip/CMakeLists.txt
@@ -57,6 +57,7 @@ add_library(OnnxToHip STATIC
   ReduceProdConversion.cpp
   LessConversion.cpp
   GreaterOrEqualConversion.cpp
+  LessOrEqualConversion.cpp
   GatherNDConversion.cpp
   SignConversion.cpp
   ModConversion.cpp

--- a/lib/Conversion/OnnxToHip/GreaterOrEqualConversion.cpp
+++ b/lib/Conversion/OnnxToHip/GreaterOrEqualConversion.cpp
@@ -9,30 +9,29 @@ namespace mlir {
 namespace hip {
 namespace {
 
-/// onnx.GreaterOrEqual -> onnx.Not(onnx.Less(A, B))
+/// onnx.GreaterOrEqual -> hip.not(hip.less(A, B))
 ///
 /// GreaterOrEqual(A, B) is the elementwise complement of Less(A, B):
 ///   A >= B  <=>  !(A < B)
-/// Both onnx.Less and onnx.Not already have ONNX->HIP conversion patterns,
-/// so the emitted ops are picked up in the same greedy rewrite round. No new
-/// hip.* op, lowering or runtime implementation is required.
+/// The decomposition emits the hip.* ops directly (rather than onnx.Less /
+/// onnx.Not). convert-onnx-to-hip runs its greedy rewrite with
+/// GreedyRewriteStrictness::ExistingOps, so freshly created onnx.* ops would
+/// NOT be revisited by the onnx.Less / onnx.Not patterns and would survive to
+/// bufferization. Building hip.less / hip.not here keeps the lowering
+/// self-contained. No new hip.* op, lowering or runtime is required (hip.less
+/// and hip.not already exist).
 struct GreaterOrEqualDecompose : public mlir::RewritePattern {
   GreaterOrEqualDecompose(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.GreaterOrEqual", /*benefit=*/1, ctx) {}
 
-  static mlir::Value createOnnxOp(mlir::PatternRewriter &rewriter,
-                                  mlir::Location loc, llvm::StringRef opName,
-                                  llvm::ArrayRef<mlir::Value> operands,
-                                  mlir::Type resultType) {
-    mlir::OperationState state(loc, opName);
-    state.addOperands(operands);
-    state.addTypes(resultType);
-    return rewriter.create(state)->getResult(0);
-  }
-
   mlir::LogicalResult
   matchAndRewrite(mlir::Operation *op,
                   mlir::PatternRewriter &rewriter) const override {
+    auto ctxOrFailure = getContextArg(op, rewriter);
+    if (mlir::failed(ctxOrFailure))
+      return mlir::failure();
+    mlir::Value context = *ctxOrFailure;
+
     mlir::Location loc = op->getLoc();
     mlir::Value a = op->getOperand(0);
     mlir::Value b = op->getOperand(1);
@@ -43,12 +42,20 @@ struct GreaterOrEqualDecompose : public mlir::RewritePattern {
       return rewriter.notifyMatchFailure(
           op, "onnx.GreaterOrEqual decompose expects a ranked tensor result");
 
-    // %less has the same (boolean, broadcasted) type as the final result.
+    // less = (A < B); same (boolean, broadcasted) type as the final result.
+    mlir::FailureOr<mlir::Value> lessInit =
+        createBroadcastEmptyTensor(rewriter, loc, resultType, {a, b});
+    if (mlir::failed(lessInit))
+      return rewriter.notifyMatchFailure(
+          op, "GreaterOrEqual: no ranked operand spans dynamic result dim");
     mlir::Value less =
-        createOnnxOp(rewriter, loc, "onnx.Less", {a, b}, resultType);
-    mlir::Value result =
-        createOnnxOp(rewriter, loc, "onnx.Not", {less}, resultType);
-    rewriter.replaceOp(op, result);
+        mlir::hip::LessOp::create(rewriter, loc, context, a, b, *lessInit)
+            ->getResult(0);
+
+    // result = !less
+    mlir::Value notInit = createEmptyTensor(rewriter, loc, resultType, less);
+    auto notOp = mlir::hip::NotOp::create(rewriter, loc, context, less, notInit);
+    rewriter.replaceOp(op, notOp->getResult(0));
     return mlir::success();
   }
 };

--- a/lib/Conversion/OnnxToHip/GreaterOrEqualConversion.cpp
+++ b/lib/Conversion/OnnxToHip/GreaterOrEqualConversion.cpp
@@ -45,9 +45,10 @@ struct GreaterOrEqualDecompose : public mlir::RewritePattern {
     // less = (A < B); same (boolean, broadcasted) type as the final result.
     mlir::FailureOr<mlir::Value> lessInit =
         createBroadcastEmptyTensor(rewriter, loc, resultType, {a, b});
-    if (mlir::failed(lessInit))
-      return rewriter.notifyMatchFailure(
-          op, "GreaterOrEqual: no ranked operand spans dynamic result dim");
+  if (mlir::failed(lessInit))
+    return rewriter.notifyMatchFailure(
+        op, "GreaterOrEqual: cannot infer dynamic result dimensions from "
+            "operands (both inputs must be ranked tensors)");
     mlir::Value less =
         mlir::hip::LessOp::create(rewriter, loc, context, a, b, *lessInit)
             ->getResult(0);

--- a/lib/Conversion/OnnxToHip/GreaterOrEqualConversion.cpp
+++ b/lib/Conversion/OnnxToHip/GreaterOrEqualConversion.cpp
@@ -45,10 +45,10 @@ struct GreaterOrEqualDecompose : public mlir::RewritePattern {
     // less = (A < B); same (boolean, broadcasted) type as the final result.
     mlir::FailureOr<mlir::Value> lessInit =
         createBroadcastEmptyTensor(rewriter, loc, resultType, {a, b});
-  if (mlir::failed(lessInit))
-    return rewriter.notifyMatchFailure(
-        op, "GreaterOrEqual: cannot infer dynamic result dimensions from "
-            "operands (both inputs must be ranked tensors)");
+    if (mlir::failed(lessInit))
+      return rewriter.notifyMatchFailure(
+          op, "GreaterOrEqual: cannot infer dynamic result dimensions from "
+              "operands (both inputs must be ranked tensors)");
     mlir::Value less =
         mlir::hip::LessOp::create(rewriter, loc, context, a, b, *lessInit)
             ->getResult(0);

--- a/lib/Conversion/OnnxToHip/GreaterOrEqualConversion.cpp
+++ b/lib/Conversion/OnnxToHip/GreaterOrEqualConversion.cpp
@@ -54,7 +54,8 @@ struct GreaterOrEqualDecompose : public mlir::RewritePattern {
 
     // result = !less
     mlir::Value notInit = createEmptyTensor(rewriter, loc, resultType, less);
-    auto notOp = mlir::hip::NotOp::create(rewriter, loc, context, less, notInit);
+    auto notOp =
+        mlir::hip::NotOp::create(rewriter, loc, context, less, notInit);
     rewriter.replaceOp(op, notOp->getResult(0));
     return mlir::success();
   }

--- a/lib/Conversion/OnnxToHip/GreaterOrEqualConversion.cpp
+++ b/lib/Conversion/OnnxToHip/GreaterOrEqualConversion.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "OnnxToHipUtils.h"
+
+namespace mlir {
+namespace hip {
+namespace {
+
+/// onnx.GreaterOrEqual -> onnx.Not(onnx.Less(A, B))
+///
+/// GreaterOrEqual(A, B) is the elementwise complement of Less(A, B):
+///   A >= B  <=>  !(A < B)
+/// Both onnx.Less and onnx.Not already have ONNX->HIP conversion patterns,
+/// so the emitted ops are picked up in the same greedy rewrite round. No new
+/// hip.* op, lowering or runtime implementation is required.
+struct GreaterOrEqualDecompose : public mlir::RewritePattern {
+  GreaterOrEqualDecompose(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.GreaterOrEqual", /*benefit=*/1, ctx) {}
+
+  static mlir::Value createOnnxOp(mlir::PatternRewriter &rewriter,
+                                  mlir::Location loc, llvm::StringRef opName,
+                                  llvm::ArrayRef<mlir::Value> operands,
+                                  mlir::Type resultType) {
+    mlir::OperationState state(loc, opName);
+    state.addOperands(operands);
+    state.addTypes(resultType);
+    return rewriter.create(state)->getResult(0);
+  }
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override {
+    mlir::Location loc = op->getLoc();
+    mlir::Value a = op->getOperand(0);
+    mlir::Value b = op->getOperand(1);
+
+    auto resultType =
+        mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
+    if (!resultType)
+      return rewriter.notifyMatchFailure(
+          op, "onnx.GreaterOrEqual decompose expects a ranked tensor result");
+
+    // %less has the same (boolean, broadcasted) type as the final result.
+    mlir::Value less =
+        createOnnxOp(rewriter, loc, "onnx.Less", {a, b}, resultType);
+    mlir::Value result =
+        createOnnxOp(rewriter, loc, "onnx.Not", {less}, resultType);
+    rewriter.replaceOp(op, result);
+    return mlir::success();
+  }
+};
+
+} // namespace
+
+void populateGreaterOrEqualConversionPatterns(RewritePatternSet &patterns,
+                                              MLIRContext *ctx) {
+  patterns.add<GreaterOrEqualDecompose>(ctx);
+}
+
+} // namespace hip
+} // namespace mlir

--- a/lib/Conversion/OnnxToHip/GreaterOrEqualConversion.cpp
+++ b/lib/Conversion/OnnxToHip/GreaterOrEqualConversion.cpp
@@ -20,6 +20,15 @@ namespace {
 /// bufferization. Building hip.less / hip.not here keeps the lowering
 /// self-contained. No new hip.* op, lowering or runtime is required (hip.less
 /// and hip.not already exist).
+///
+/// KNOWN LIMITATION (NaN): the `A >= B  <=>  !(A < B)` identity holds only for
+/// a total order. With NaN operands it deviates from ONNX/IEEE-754: ONNX
+/// requires `NaN >= x` to be false, but `hip.less` (C++ `<`) returns false for
+/// any NaN comparison, so `!(A < B)` yields true. This is exact for integer
+/// inputs (the dominant index/mask use) and for NaN-free float models; float
+/// models that can produce NaN are not supported by this decomposition. A
+/// NaN-correct lowering would need e.g. `(B < A) || (A == B)` (extra ops) or a
+/// dedicated `>=` kernel.
 struct GreaterOrEqualDecompose : public mlir::RewritePattern {
   GreaterOrEqualDecompose(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.GreaterOrEqual", /*benefit=*/1, ctx) {}

--- a/lib/Conversion/OnnxToHip/LessOrEqualConversion.cpp
+++ b/lib/Conversion/OnnxToHip/LessOrEqualConversion.cpp
@@ -46,10 +46,10 @@ struct LessOrEqualDecompose : public mlir::RewritePattern {
     // less = (B < A); same (boolean, broadcasted) type as the final result.
     mlir::FailureOr<mlir::Value> lessInit =
         createBroadcastEmptyTensor(rewriter, loc, resultType, {b, a});
-  if (mlir::failed(lessInit))
-    return rewriter.notifyMatchFailure(
-        op, "LessOrEqual: cannot infer dynamic result dimensions from "
-            "operands (both inputs must be ranked tensors)");
+    if (mlir::failed(lessInit))
+      return rewriter.notifyMatchFailure(
+          op, "LessOrEqual: cannot infer dynamic result dimensions from "
+              "operands (both inputs must be ranked tensors)");
     mlir::Value less =
         mlir::hip::LessOp::create(rewriter, loc, context, b, a, *lessInit)
             ->getResult(0);

--- a/lib/Conversion/OnnxToHip/LessOrEqualConversion.cpp
+++ b/lib/Conversion/OnnxToHip/LessOrEqualConversion.cpp
@@ -55,7 +55,8 @@ struct LessOrEqualDecompose : public mlir::RewritePattern {
 
     // result = !less
     mlir::Value notInit = createEmptyTensor(rewriter, loc, resultType, less);
-    auto notOp = mlir::hip::NotOp::create(rewriter, loc, context, less, notInit);
+    auto notOp =
+        mlir::hip::NotOp::create(rewriter, loc, context, less, notInit);
     rewriter.replaceOp(op, notOp->getResult(0));
     return mlir::success();
   }

--- a/lib/Conversion/OnnxToHip/LessOrEqualConversion.cpp
+++ b/lib/Conversion/OnnxToHip/LessOrEqualConversion.cpp
@@ -9,31 +9,30 @@ namespace mlir {
 namespace hip {
 namespace {
 
-/// onnx.LessOrEqual -> onnx.Not(onnx.Less(B, A))
+/// onnx.LessOrEqual -> hip.not(hip.less(B, A))
 ///
 /// LessOrEqual(A, B) is the elementwise complement of Greater(A, B), and
 /// Greater(A, B) == Less(B, A):
 ///   A <= B  <=>  !(A > B)  <=>  !(B < A)
-/// Both onnx.Less and onnx.Not already have ONNX->HIP conversion patterns,
-/// so the emitted ops are picked up in the same greedy rewrite round. No new
-/// hip.* op, lowering or runtime implementation is required.
+/// The decomposition emits the hip.* ops directly (rather than onnx.Less /
+/// onnx.Not). convert-onnx-to-hip runs its greedy rewrite with
+/// GreedyRewriteStrictness::ExistingOps, so freshly created onnx.* ops would
+/// NOT be revisited by the onnx.Less / onnx.Not patterns and would survive to
+/// bufferization. Building hip.less / hip.not here keeps the lowering
+/// self-contained. No new hip.* op, lowering or runtime is required (hip.less
+/// and hip.not already exist).
 struct LessOrEqualDecompose : public mlir::RewritePattern {
   LessOrEqualDecompose(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.LessOrEqual", /*benefit=*/1, ctx) {}
 
-  static mlir::Value createOnnxOp(mlir::PatternRewriter &rewriter,
-                                  mlir::Location loc, llvm::StringRef opName,
-                                  llvm::ArrayRef<mlir::Value> operands,
-                                  mlir::Type resultType) {
-    mlir::OperationState state(loc, opName);
-    state.addOperands(operands);
-    state.addTypes(resultType);
-    return rewriter.create(state)->getResult(0);
-  }
-
   mlir::LogicalResult
   matchAndRewrite(mlir::Operation *op,
                   mlir::PatternRewriter &rewriter) const override {
+    auto ctxOrFailure = getContextArg(op, rewriter);
+    if (mlir::failed(ctxOrFailure))
+      return mlir::failure();
+    mlir::Value context = *ctxOrFailure;
+
     mlir::Location loc = op->getLoc();
     mlir::Value a = op->getOperand(0);
     mlir::Value b = op->getOperand(1);
@@ -44,12 +43,20 @@ struct LessOrEqualDecompose : public mlir::RewritePattern {
       return rewriter.notifyMatchFailure(
           op, "onnx.LessOrEqual decompose expects a ranked tensor result");
 
-    // Less(B, A) has the same (boolean, broadcasted) type as the final result.
+    // less = (B < A); same (boolean, broadcasted) type as the final result.
+    mlir::FailureOr<mlir::Value> lessInit =
+        createBroadcastEmptyTensor(rewriter, loc, resultType, {b, a});
+    if (mlir::failed(lessInit))
+      return rewriter.notifyMatchFailure(
+          op, "LessOrEqual: no ranked operand spans dynamic result dim");
     mlir::Value less =
-        createOnnxOp(rewriter, loc, "onnx.Less", {b, a}, resultType);
-    mlir::Value result =
-        createOnnxOp(rewriter, loc, "onnx.Not", {less}, resultType);
-    rewriter.replaceOp(op, result);
+        mlir::hip::LessOp::create(rewriter, loc, context, b, a, *lessInit)
+            ->getResult(0);
+
+    // result = !less
+    mlir::Value notInit = createEmptyTensor(rewriter, loc, resultType, less);
+    auto notOp = mlir::hip::NotOp::create(rewriter, loc, context, less, notInit);
+    rewriter.replaceOp(op, notOp->getResult(0));
     return mlir::success();
   }
 };

--- a/lib/Conversion/OnnxToHip/LessOrEqualConversion.cpp
+++ b/lib/Conversion/OnnxToHip/LessOrEqualConversion.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "OnnxToHipUtils.h"
+
+namespace mlir {
+namespace hip {
+namespace {
+
+/// onnx.LessOrEqual -> onnx.Not(onnx.Less(B, A))
+///
+/// LessOrEqual(A, B) is the elementwise complement of Greater(A, B), and
+/// Greater(A, B) == Less(B, A):
+///   A <= B  <=>  !(A > B)  <=>  !(B < A)
+/// Both onnx.Less and onnx.Not already have ONNX->HIP conversion patterns,
+/// so the emitted ops are picked up in the same greedy rewrite round. No new
+/// hip.* op, lowering or runtime implementation is required.
+struct LessOrEqualDecompose : public mlir::RewritePattern {
+  LessOrEqualDecompose(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.LessOrEqual", /*benefit=*/1, ctx) {}
+
+  static mlir::Value createOnnxOp(mlir::PatternRewriter &rewriter,
+                                  mlir::Location loc, llvm::StringRef opName,
+                                  llvm::ArrayRef<mlir::Value> operands,
+                                  mlir::Type resultType) {
+    mlir::OperationState state(loc, opName);
+    state.addOperands(operands);
+    state.addTypes(resultType);
+    return rewriter.create(state)->getResult(0);
+  }
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override {
+    mlir::Location loc = op->getLoc();
+    mlir::Value a = op->getOperand(0);
+    mlir::Value b = op->getOperand(1);
+
+    auto resultType =
+        mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
+    if (!resultType)
+      return rewriter.notifyMatchFailure(
+          op, "onnx.LessOrEqual decompose expects a ranked tensor result");
+
+    // Less(B, A) has the same (boolean, broadcasted) type as the final result.
+    mlir::Value less =
+        createOnnxOp(rewriter, loc, "onnx.Less", {b, a}, resultType);
+    mlir::Value result =
+        createOnnxOp(rewriter, loc, "onnx.Not", {less}, resultType);
+    rewriter.replaceOp(op, result);
+    return mlir::success();
+  }
+};
+
+} // namespace
+
+void populateLessOrEqualConversionPatterns(RewritePatternSet &patterns,
+                                           MLIRContext *ctx) {
+  patterns.add<LessOrEqualDecompose>(ctx);
+}
+
+} // namespace hip
+} // namespace mlir

--- a/lib/Conversion/OnnxToHip/LessOrEqualConversion.cpp
+++ b/lib/Conversion/OnnxToHip/LessOrEqualConversion.cpp
@@ -21,6 +21,15 @@ namespace {
 /// bufferization. Building hip.less / hip.not here keeps the lowering
 /// self-contained. No new hip.* op, lowering or runtime is required (hip.less
 /// and hip.not already exist).
+///
+/// KNOWN LIMITATION (NaN): the `A <= B  <=>  !(B < A)` identity holds only for
+/// a total order. With NaN operands it deviates from ONNX/IEEE-754: ONNX
+/// requires `x <= NaN` to be false, but `hip.less` (C++ `<`) returns false for
+/// any NaN comparison, so `!(B < A)` yields true. This is exact for integer
+/// inputs (the dominant index/mask use) and for NaN-free float models; float
+/// models that can produce NaN are not supported by this decomposition. A
+/// NaN-correct lowering would need e.g. `(A < B) || (A == B)` (extra ops) or a
+/// dedicated `<=` kernel.
 struct LessOrEqualDecompose : public mlir::RewritePattern {
   LessOrEqualDecompose(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.LessOrEqual", /*benefit=*/1, ctx) {}

--- a/lib/Conversion/OnnxToHip/LessOrEqualConversion.cpp
+++ b/lib/Conversion/OnnxToHip/LessOrEqualConversion.cpp
@@ -46,9 +46,10 @@ struct LessOrEqualDecompose : public mlir::RewritePattern {
     // less = (B < A); same (boolean, broadcasted) type as the final result.
     mlir::FailureOr<mlir::Value> lessInit =
         createBroadcastEmptyTensor(rewriter, loc, resultType, {b, a});
-    if (mlir::failed(lessInit))
-      return rewriter.notifyMatchFailure(
-          op, "LessOrEqual: no ranked operand spans dynamic result dim");
+  if (mlir::failed(lessInit))
+    return rewriter.notifyMatchFailure(
+        op, "LessOrEqual: cannot infer dynamic result dimensions from "
+            "operands (both inputs must be ranked tensors)");
     mlir::Value less =
         mlir::hip::LessOp::create(rewriter, loc, context, b, a, *lessInit)
             ->getResult(0);

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -508,6 +508,7 @@ static mlir::LogicalResult convertComputeOps(mlir::func::FuncOp funcOp,
   populateReduceProdConversionPatterns(patterns, ctx);
   populateLessConversionPatterns(patterns, ctx);
   populateGreaterOrEqualConversionPatterns(patterns, ctx);
+  populateLessOrEqualConversionPatterns(patterns, ctx);
   populateGatherNDConversionPatterns(patterns, ctx);
   populateSignConversionPatterns(patterns, ctx);
   populateModConversionPatterns(patterns, ctx);

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -507,6 +507,7 @@ static mlir::LogicalResult convertComputeOps(mlir::func::FuncOp funcOp,
   populateExpandConversionPatterns(patterns, ctx);
   populateReduceProdConversionPatterns(patterns, ctx);
   populateLessConversionPatterns(patterns, ctx);
+  populateGreaterOrEqualConversionPatterns(patterns, ctx);
   populateGatherNDConversionPatterns(patterns, ctx);
   populateSignConversionPatterns(patterns, ctx);
   populateModConversionPatterns(patterns, ctx);

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
@@ -323,6 +323,8 @@ void populateLessConversionPatterns(RewritePatternSet &patterns,
                                     MLIRContext *ctx);
 void populateGreaterOrEqualConversionPatterns(RewritePatternSet &patterns,
                                               MLIRContext *ctx);
+void populateLessOrEqualConversionPatterns(RewritePatternSet &patterns,
+                                           MLIRContext *ctx);
 void populateGatherNDConversionPatterns(RewritePatternSet &patterns,
                                         MLIRContext *ctx);
 void populateSignConversionPatterns(RewritePatternSet &patterns,

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
@@ -321,6 +321,8 @@ void populateReduceProdConversionPatterns(RewritePatternSet &patterns,
                                           MLIRContext *ctx);
 void populateLessConversionPatterns(RewritePatternSet &patterns,
                                     MLIRContext *ctx);
+void populateGreaterOrEqualConversionPatterns(RewritePatternSet &patterns,
+                                              MLIRContext *ctx);
 void populateGatherNDConversionPatterns(RewritePatternSet &patterns,
                                         MLIRContext *ctx);
 void populateSignConversionPatterns(RewritePatternSet &patterns,

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -807,6 +807,18 @@ void SigmoidOp::getEffects(
 }
 
 //===----------------------------------------------------------------------===//
+// TanhOp: ins(x), outs(y)
+//===----------------------------------------------------------------------===//
+
+MutableOperandRange TanhOp::getDpsInitsMutable() { return getYMutable(); }
+
+void TanhOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  emitDpsMemoryEffects(getDpsInputOperands(), getDpsInitsMutable(), effects);
+}
+
+//===----------------------------------------------------------------------===//
 // SoftplusOp: ins(x), outs(y)
 //===----------------------------------------------------------------------===//
 

--- a/lib/Runtime/real/activation.cpp
+++ b/lib/Runtime/real/activation.cpp
@@ -121,6 +121,12 @@ queryOrCreateActivation(const ActivationCacheKey &key) {
     // needs alpha = beta = 1. (LOGISTIC/SOFTRELU ignore alpha/beta, so the
     // 0,0,0 default is only correct for those modes -- with the default,
     // TANH would degenerate to 0 * tanh(0) = 0.)
+    //
+    // alpha/beta are a pure function of `act` here, and the descriptor cache is
+    // keyed by activation_mode (see ActivationCacheKey), so a TANH descriptor
+    // can never be reused for a different mode (no alpha/beta aliasing). If a
+    // future activation needs alpha/beta that vary independently of the mode,
+    // add those params to ActivationCacheKey as well.
     double alpha = 0.0, beta = 0.0;
     if (act == miopenActivationTANH) {
       alpha = 1.0;

--- a/lib/Runtime/real/activation.cpp
+++ b/lib/Runtime/real/activation.cpp
@@ -116,8 +116,20 @@ queryOrCreateActivation(const ActivationCacheKey &key) {
                       cache_fail);
   }
   MIOPEN_CHECK_GOTO(miopenCreateActivationDescriptor(&e.actDesc), cache_fail);
-  MIOPEN_CHECK_GOTO(
-      miopenSetActivationDescriptor(e.actDesc, act, 0.0, 0.0, 0.0), cache_fail);
+  {
+    // MIOpen's TANH mode computes y = alpha * tanh(beta * x); plain ONNX Tanh
+    // needs alpha = beta = 1. (LOGISTIC/SOFTRELU ignore alpha/beta, so the
+    // 0,0,0 default is only correct for those modes -- with the default,
+    // TANH would degenerate to 0 * tanh(0) = 0.)
+    double alpha = 0.0, beta = 0.0;
+    if (act == miopenActivationTANH) {
+      alpha = 1.0;
+      beta = 1.0;
+    }
+    MIOPEN_CHECK_GOTO(
+        miopenSetActivationDescriptor(e.actDesc, act, alpha, beta, 0.0),
+        cache_fail);
+  }
   goto cache_done;
 
 cache_fail:

--- a/test/lit/Conversion/hip-to-llvm/test_tanh.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_tanh.mlir
@@ -1,0 +1,74 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify HIP tanh operation is correctly lowered to LLVM call
+// to wrap_miopenActivationForward runtime function with both static and
+// dynamic shapes.
+//
+// This test validates:
+// - hip.tanh → llvm.call @wrap_miopenActivationForward
+// - Type conversion: !hip.context → !llvm.ptr
+// - Static shapes: num_elements computed at compile time
+// - Dynamic shapes: num_elements computed at runtime via extractvalue
+// - Proper function signature for runtime API
+//
+// Expected: wrap_miopenActivationForward(state, input_ptr, output_ptr,
+//                                         num_elements, data_type, activation_mode)
+// ============================================================================
+
+// RUN: hip-mlir-opt %s --convert-hip-to-llvm | FileCheck %s
+
+module {
+  // Test 1: Static 3D tensor
+  func.func @tanh_static_3d_test(
+      %ctx: !hip.context,
+      %input: memref<1x128x512xf32, 1>,
+      %output: memref<1x128x512xf32, 1>) {
+    // CHECK-LABEL: llvm.func @tanh_static_3d_test
+
+    hip.tanh(%ctx) ins(%input : memref<1x128x512xf32, 1>)
+                   outs(%output : memref<1x128x512xf32, 1>)
+
+    // CHECK: llvm.call @wrap_miopenActivationForward({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64) -> i32
+
+    return
+  }
+
+  // Test 2: Static 2D tensor
+  func.func @tanh_static_2d_test(
+      %ctx: !hip.context,
+      %input: memref<256x512xf32, 1>,
+      %output: memref<256x512xf32, 1>) {
+    // CHECK-LABEL: llvm.func @tanh_static_2d_test
+
+    hip.tanh(%ctx) ins(%input : memref<256x512xf32, 1>)
+                   outs(%output : memref<256x512xf32, 1>)
+
+    // CHECK: llvm.call @wrap_miopenActivationForward({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64) -> i32
+
+    return
+  }
+
+  // Test 3: Dynamic shapes
+  func.func @tanh_dynamic_test(
+      %ctx: !hip.context,
+      %input: memref<?x?x512xf32, 1>,
+      %output: memref<?x?x512xf32, 1>) {
+    // CHECK-LABEL: llvm.func @tanh_dynamic_test
+
+    hip.tanh(%ctx) ins(%input : memref<?x?x512xf32, 1>)
+                   outs(%output : memref<?x?x512xf32, 1>)
+
+    // CHECK-DAG: llvm.mlir.constant(1 : i64) : i64
+    // CHECK-DAG: llvm.extractvalue %{{.*}}[3, 0]
+    // CHECK-DAG: llvm.mul %{{.*}}, %{{.*}} : i64
+    // CHECK-DAG: llvm.extractvalue %{{.*}}[3, 1]
+    // CHECK-DAG: llvm.mlir.constant(512 : i64) : i64
+    // CHECK-DAG: llvm.mlir.constant(0 : i64) : i64
+    // CHECK: llvm.call @wrap_miopenActivationForward({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64) -> i32
+
+    return
+  }
+}

--- a/test/lit/Conversion/onnx-to-hip/test_greaterorequal.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_greaterorequal.mlir
@@ -1,0 +1,44 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
+
+module {
+  func.func @main_graph(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+    return %arg0 : tensor<4xf32>
+  }
+
+  // GreaterOrEqual(A, B) decomposes into Not(Less(A, B)), each lowered to its
+  // own hip.* op. The original onnx.GreaterOrEqual must disappear.
+  func.func @greaterorequal_f32(%a: tensor<3x4xf32>, %b: tensor<3x4xf32>) -> tensor<3x4xi1> {
+    %r = "onnx.GreaterOrEqual"(%a, %b) : (tensor<3x4xf32>, tensor<3x4xf32>) -> tensor<3x4xi1>
+    return %r : tensor<3x4xi1>
+  }
+
+  // CHECK-LABEL: func.func @greaterorequal_f32
+  // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[A:.*]]: tensor<3x4xf32>, %[[B:.*]]: tensor<3x4xf32>)
+  // CHECK-NOT: onnx.GreaterOrEqual
+  // CHECK: hip.less(%[[CTX]]) ins(%[[A]], %[[B]] : tensor<3x4xf32>, tensor<3x4xf32>) outs({{.*}} : tensor<3x4xi1>)
+  // CHECK: hip.not(%[[CTX]]) ins({{.*}} : tensor<3x4xi1>) outs({{.*}} : tensor<3x4xi1>)
+
+  func.func @greaterorequal_i32(%a: tensor<4xi32>, %b: tensor<4xi32>) -> tensor<4xi1> {
+    %r = "onnx.GreaterOrEqual"(%a, %b) : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
+    return %r : tensor<4xi1>
+  }
+
+  // CHECK-LABEL: func.func @greaterorequal_i32
+  // CHECK-NOT: onnx.GreaterOrEqual
+  // CHECK: hip.less({{.*}}) ins({{.*}}, {{.*}} : tensor<4xi32>, tensor<4xi32>) outs({{.*}} : tensor<4xi1>)
+  // CHECK: hip.not({{.*}}) ins({{.*}} : tensor<4xi1>) outs({{.*}} : tensor<4xi1>)
+
+  func.func @greaterorequal_dynamic(%a: tensor<?x?xf32>, %b: tensor<?x?xf32>) -> tensor<?x?xi1> {
+    %r = "onnx.GreaterOrEqual"(%a, %b) : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xi1>
+    return %r : tensor<?x?xi1>
+  }
+
+  // CHECK-LABEL: func.func @greaterorequal_dynamic
+  // CHECK-NOT: onnx.GreaterOrEqual
+  // CHECK: tensor.empty
+  // CHECK: hip.less({{.*}}) ins({{.*}}, {{.*}} : tensor<?x?xf32>, tensor<?x?xf32>) outs({{.*}} : tensor<?x?xi1>)
+  // CHECK: hip.not({{.*}}) ins({{.*}} : tensor<?x?xi1>) outs({{.*}} : tensor<?x?xi1>)
+}

--- a/test/lit/Conversion/onnx-to-hip/test_lessorequal.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_lessorequal.mlir
@@ -1,0 +1,45 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
+
+module {
+  func.func @main_graph(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+    return %arg0 : tensor<4xf32>
+  }
+
+  // LessOrEqual(A, B) decomposes into Not(Less(B, A)) (note swapped operands),
+  // each lowered to its own hip.* op. The original onnx.LessOrEqual must
+  // disappear.
+  func.func @lessorequal_f32(%a: tensor<3x4xf32>, %b: tensor<3x4xf32>) -> tensor<3x4xi1> {
+    %r = "onnx.LessOrEqual"(%a, %b) : (tensor<3x4xf32>, tensor<3x4xf32>) -> tensor<3x4xi1>
+    return %r : tensor<3x4xi1>
+  }
+
+  // CHECK-LABEL: func.func @lessorequal_f32
+  // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[A:.*]]: tensor<3x4xf32>, %[[B:.*]]: tensor<3x4xf32>)
+  // CHECK-NOT: onnx.LessOrEqual
+  // CHECK: hip.less(%[[CTX]]) ins(%[[B]], %[[A]] : tensor<3x4xf32>, tensor<3x4xf32>) outs({{.*}} : tensor<3x4xi1>)
+  // CHECK: hip.not(%[[CTX]]) ins({{.*}} : tensor<3x4xi1>) outs({{.*}} : tensor<3x4xi1>)
+
+  func.func @lessorequal_i32(%a: tensor<4xi32>, %b: tensor<4xi32>) -> tensor<4xi1> {
+    %r = "onnx.LessOrEqual"(%a, %b) : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
+    return %r : tensor<4xi1>
+  }
+
+  // CHECK-LABEL: func.func @lessorequal_i32
+  // CHECK-NOT: onnx.LessOrEqual
+  // CHECK: hip.less({{.*}}) ins({{.*}}, {{.*}} : tensor<4xi32>, tensor<4xi32>) outs({{.*}} : tensor<4xi1>)
+  // CHECK: hip.not({{.*}}) ins({{.*}} : tensor<4xi1>) outs({{.*}} : tensor<4xi1>)
+
+  func.func @lessorequal_dynamic(%a: tensor<?x?xf32>, %b: tensor<?x?xf32>) -> tensor<?x?xi1> {
+    %r = "onnx.LessOrEqual"(%a, %b) : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xi1>
+    return %r : tensor<?x?xi1>
+  }
+
+  // CHECK-LABEL: func.func @lessorequal_dynamic
+  // CHECK-NOT: onnx.LessOrEqual
+  // CHECK: tensor.empty
+  // CHECK: hip.less({{.*}}) ins({{.*}}, {{.*}} : tensor<?x?xf32>, tensor<?x?xf32>) outs({{.*}} : tensor<?x?xi1>)
+  // CHECK: hip.not({{.*}}) ins({{.*}} : tensor<?x?xi1>) outs({{.*}} : tensor<?x?xi1>)
+}

--- a/test/lit/Conversion/onnx-to-hip/test_tanh.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_tanh.mlir
@@ -20,6 +20,12 @@ module {
     return %output : tensor<1x128x14336xf16>
   }
 
+  // Static fp32 test (f16 covered by @main_graph; ensure fp32 lowers too).
+  func.func @tanh_fp32_static(%input: tensor<256x512xf32>) -> tensor<256x512xf32> {
+    %output = "onnx.Tanh"(%input) : (tensor<256x512xf32>) -> tensor<256x512xf32>
+    return %output : tensor<256x512xf32>
+  }
+
   // Dynamic shape test
   func.func @tanh_dynamic(%input: tensor<?x?x512xf32>) -> tensor<?x?x512xf32> {
     %output = "onnx.Tanh"(%input) : (tensor<?x?x512xf32>) -> tensor<?x?x512xf32>
@@ -33,6 +39,11 @@ module {
 // CHECK: tensor.empty() : tensor<1x128x14336xf16>
 // CHECK: hip.tanh(%[[CTX]]) ins(%[[INPUT]] : tensor<1x128x14336xf16>) outs({{.*}} : tensor<1x128x14336xf16>) : tensor<1x128x14336xf16>
 // CHECK-NOT: hip.alloc
+
+// CHECK-LABEL: func.func @tanh_fp32_static
+// CHECK-SAME: (%[[CTX2:.*]]: !hip.context, %[[IN2:.*]]: tensor<256x512xf32>) -> tensor<256x512xf32>
+// CHECK: tensor.empty() : tensor<256x512xf32>
+// CHECK: hip.tanh(%[[CTX2]]) ins(%[[IN2]] : tensor<256x512xf32>) outs({{.*}} : tensor<256x512xf32>) : tensor<256x512xf32>
 
 // CHECK-LABEL: func.func @tanh_dynamic
 // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[IN:.*]]: tensor<?x?x512xf32>) -> tensor<?x?x512xf32>

--- a/test/lit/Conversion/onnx-to-hip/test_tanh.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_tanh.mlir
@@ -1,0 +1,41 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify ONNX Tanh is correctly lowered to hip.tanh.
+//
+// Assertions:
+// - context argument prepended
+// - input and output tensor types preserved
+// - tensor.empty() used as output init (no hip.alloc)
+// - hip.tanh result type matches input type
+// ============================================================================
+
+// RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
+
+module {
+  func.func @main_graph(%input: tensor<1x128x14336xf16>) -> tensor<1x128x14336xf16> {
+    %output = "onnx.Tanh"(%input) : (tensor<1x128x14336xf16>) -> tensor<1x128x14336xf16>
+    return %output : tensor<1x128x14336xf16>
+  }
+
+  // Dynamic shape test
+  func.func @tanh_dynamic(%input: tensor<?x?x512xf32>) -> tensor<?x?x512xf32> {
+    %output = "onnx.Tanh"(%input) : (tensor<?x?x512xf32>) -> tensor<?x?x512xf32>
+    return %output : tensor<?x?x512xf32>
+  }
+}
+
+// CHECK-LABEL: func.func @main_graph
+// CHECK-SAME: (%[[CTX:.*]]: !hip.context,
+// CHECK-SAME: %[[INPUT:.*]]: tensor<1x128x14336xf16>) -> tensor<1x128x14336xf16>
+// CHECK: tensor.empty() : tensor<1x128x14336xf16>
+// CHECK: hip.tanh(%[[CTX]]) ins(%[[INPUT]] : tensor<1x128x14336xf16>) outs({{.*}} : tensor<1x128x14336xf16>) : tensor<1x128x14336xf16>
+// CHECK-NOT: hip.alloc
+
+// CHECK-LABEL: func.func @tanh_dynamic
+// CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[IN:.*]]: tensor<?x?x512xf32>) -> tensor<?x?x512xf32>
+// CHECK: %[[INIT:.*]] = tensor.empty(%{{.*}}, %{{.*}}) : tensor<?x?x512xf32>
+// CHECK: hip.tanh(%[[CTX]]) ins(%[[IN]] : tensor<?x?x512xf32>) outs(%[[INIT]] : tensor<?x?x512xf32>) : tensor<?x?x512xf32>
+// CHECK-NOT: hip.alloc

--- a/test/lit/e2e/test_greaterorequal_model.mlir
+++ b/test/lit/e2e/test_greaterorequal_model.mlir
@@ -1,0 +1,24 @@
+// RUN: hip-mlir-opt %s --hipdnn-pipeline | FileCheck %s
+
+// Test GreaterOrEqual E2E full pipeline.
+// onnx.GreaterOrEqual is decomposed into onnx.Not(onnx.Less(a, b)), so the
+// final LLVM IR contains the wrap_less + wrap_not runtime calls and the
+// original onnx.GreaterOrEqual must be gone.
+
+// CHECK: module attributes {
+// CHECK-SAME: hipdnn.input_count = 2
+// CHECK-SAME: hipdnn.output_count = 1
+// CHECK: llvm.func @wrap_less
+// CHECK: llvm.func @wrap_not
+// CHECK: llvm.func @inference_init
+// CHECK: llvm.func @inference_compute
+// CHECK: llvm.func @inference_cleanup
+// CHECK: llvm.func @inference_get_metadata_json
+// CHECK-NOT: onnx.GreaterOrEqual
+module {
+  func.func @main_graph(%arg0: tensor<3x4xf32> {onnx.name = "a"}, %arg1: tensor<3x4xf32> {onnx.name = "b"}) -> (tensor<3x4xi1> {onnx.name = "output"}) {
+    %0 = "onnx.GreaterOrEqual"(%arg0, %arg1) {onnx_node_name = "greaterorequal_node"} : (tensor<3x4xf32>, tensor<3x4xf32>) -> tensor<3x4xi1>
+    "onnx.Return"(%0) : (tensor<3x4xi1>) -> ()
+  }
+  "onnx.EntryPoint"() {func = @main_graph} : () -> ()
+}

--- a/test/lit/e2e/test_greaterorequal_model.mlir
+++ b/test/lit/e2e/test_greaterorequal_model.mlir
@@ -8,8 +8,8 @@
 // CHECK: module attributes {
 // CHECK-SAME: hipdnn.input_count = 2
 // CHECK-SAME: hipdnn.output_count = 1
-// CHECK: llvm.func @wrap_less
-// CHECK: llvm.func @wrap_not
+// CHECK-DAG: llvm.func @wrap_less
+// CHECK-DAG: llvm.func @wrap_not
 // CHECK: llvm.func @inference_init
 // CHECK: llvm.func @inference_compute
 // CHECK: llvm.func @inference_cleanup

--- a/test/lit/e2e/test_lessorequal_model.mlir
+++ b/test/lit/e2e/test_lessorequal_model.mlir
@@ -1,0 +1,24 @@
+// RUN: hip-mlir-opt %s --hipdnn-pipeline | FileCheck %s
+
+// Test LessOrEqual E2E full pipeline.
+// onnx.LessOrEqual is decomposed into onnx.Not(onnx.Less(b, a)), so the final
+// LLVM IR contains the wrap_less + wrap_not runtime calls and the original
+// onnx.LessOrEqual must be gone.
+
+// CHECK: module attributes {
+// CHECK-SAME: hipdnn.input_count = 2
+// CHECK-SAME: hipdnn.output_count = 1
+// CHECK: llvm.func @wrap_less
+// CHECK: llvm.func @wrap_not
+// CHECK: llvm.func @inference_init
+// CHECK: llvm.func @inference_compute
+// CHECK: llvm.func @inference_cleanup
+// CHECK: llvm.func @inference_get_metadata_json
+// CHECK-NOT: onnx.LessOrEqual
+module {
+  func.func @main_graph(%arg0: tensor<3x4xf32> {onnx.name = "a"}, %arg1: tensor<3x4xf32> {onnx.name = "b"}) -> (tensor<3x4xi1> {onnx.name = "output"}) {
+    %0 = "onnx.LessOrEqual"(%arg0, %arg1) {onnx_node_name = "lessorequal_node"} : (tensor<3x4xf32>, tensor<3x4xf32>) -> tensor<3x4xi1>
+    "onnx.Return"(%0) : (tensor<3x4xi1>) -> ()
+  }
+  "onnx.EntryPoint"() {func = @main_graph} : () -> ()
+}

--- a/test/lit/e2e/test_lessorequal_model.mlir
+++ b/test/lit/e2e/test_lessorequal_model.mlir
@@ -8,8 +8,8 @@
 // CHECK: module attributes {
 // CHECK-SAME: hipdnn.input_count = 2
 // CHECK-SAME: hipdnn.output_count = 1
-// CHECK: llvm.func @wrap_less
-// CHECK: llvm.func @wrap_not
+// CHECK-DAG: llvm.func @wrap_less
+// CHECK-DAG: llvm.func @wrap_not
 // CHECK: llvm.func @inference_init
 // CHECK: llvm.func @inference_compute
 // CHECK: llvm.func @inference_cleanup

--- a/test/lit/e2e/test_tanh_dynamic_model.mlir
+++ b/test/lit/e2e/test_tanh_dynamic_model.mlir
@@ -1,0 +1,28 @@
+// RUN: hip-mlir-opt %s --hipdnn-pipeline | FileCheck %s
+
+// Test Tanh E2E full pipeline -- DYNAMIC input shape.
+//
+// Companion to test_tanh_model.mlir (static path). With fully dynamic leading
+// dims the EP still compiles the dynamic graph: onnx.Tanh lowers to a hip.tanh
+// DPS op whose num_elements is computed at runtime, then to a
+// wrap_miopenActivationForward call. This verifies the full pipeline
+// (convert-onnx-to-hip + bufferize + memory-pooling + convert-hip-to-llvm +
+// generate-interface) handles the dynamic path end-to-end and leaves no
+// leftover onnx.Tanh.
+
+// CHECK: module attributes {
+// CHECK-SAME: hipdnn.input_count = 1
+// CHECK-SAME: hipdnn.output_count = 1
+// CHECK: llvm.func @wrap_miopenActivationForward
+// CHECK: llvm.func @inference_init
+// CHECK: llvm.func @inference_compute
+// CHECK: llvm.func @inference_cleanup
+// CHECK: llvm.func @inference_get_metadata_json
+// CHECK-NOT: onnx.Tanh
+module {
+  func.func @main_graph(%arg0: tensor<?x?x512xf16> {onnx.name = "input"}) -> (tensor<?x?x512xf16> {onnx.name = "output"}) {
+    %0 = "onnx.Tanh"(%arg0) {onnx_node_name = "tanh_node"} : (tensor<?x?x512xf16>) -> tensor<?x?x512xf16>
+    "onnx.Return"(%0) : (tensor<?x?x512xf16>) -> ()
+  }
+  "onnx.EntryPoint"() {func = @main_graph} : () -> ()
+}

--- a/test/lit/e2e/test_tanh_model.mlir
+++ b/test/lit/e2e/test_tanh_model.mlir
@@ -1,0 +1,29 @@
+// RUN: hip-mlir-opt %s --hipdnn-pipeline | FileCheck %s
+
+// Test Tanh E2E full pipeline.
+// The model has one onnx.Tanh with f16 tensors, mirroring the standalone
+// Tanh used by Gemma-2 logit soft-capping (logits = cap * tanh(logits/cap)).
+//
+// Verifies the complete hipdnn-pipeline:
+// 1. convert-onnx-to-hip: onnx.Tanh → hip.tanh
+// 2. canonicalize: Simplify redundant operations
+// 3. memory-pooling: Pool output buffer into single allocation
+// 4. convert-hip-to-llvm: HIP ops → LLVM runtime calls
+// 5. generate-interface: Create inference_init/compute/cleanup/metadata
+
+// CHECK: module attributes {
+// CHECK-SAME: hipdnn.input_count = 1
+// CHECK-SAME: hipdnn.output_count = 1
+// CHECK: llvm.func @wrap_miopenActivationForward
+// CHECK: llvm.func @inference_init
+// CHECK: llvm.func @inference_compute
+// CHECK: llvm.func @inference_cleanup
+// CHECK: llvm.func @inference_get_metadata_json
+// CHECK-NOT: onnx.Tanh
+module {
+  func.func @main_graph(%arg0: tensor<1x128x14336xf16> {onnx.name = "/lm_head/softcap/Div/output_0"}) -> (tensor<1x128x14336xf16> {onnx.name = "/lm_head/softcap/Tanh/output_0"}) {
+    %0 = "onnx.Tanh"(%arg0) {onnx_node_name = "/lm_head/softcap/Tanh"} : (tensor<1x128x14336xf16>) -> tensor<1x128x14336xf16>
+    "onnx.Return"(%0) : (tensor<1x128x14336xf16>) -> ()
+  }
+  "onnx.EntryPoint"() {func = @main_graph} : () -> ()
+}


### PR DESCRIPTION
<!--
Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
Licensed under the MIT License.
-->

## Summary
Adds three ONNX ops to the ONNX→HIP backend so models that use them stop
falling back to (the disabled) CPU EP:

- **GreaterOrEqual** and **LessOrEqual** (comparison)
- **Tanh** (activation)

## Details

### GreaterOrEqual / LessOrEqual
Implemented as rewrite-based decompositions on top of the existing `hip.less`
and `hip.not` ops — no new `hip.*` op, lowering, or runtime kernel needed:

- `GreaterOrEqual(A, B)` → `hip.not(hip.less(A, B))`   (`A >= B  <=>  !(A < B)`)
- `LessOrEqual(A, B)`    → `hip.not(hip.less(B, A))`   (`A <= B  <=>  !(B < A)`)

The decomposition builds the `hip.less` / `hip.not` ops **directly** rather than
emitting `onnx.Less` / `onnx.Not`. `convert-onnx-to-hip` runs its greedy rewrite
with `GreedyRewriteStrictness::ExistingOps`, so freshly created `onnx.*` ops are
never revisited by their own patterns — emitting them would leave the graph
un-bufferizable (`"op was not bufferized"`) and silently drop it to CPU.

### Tanh
New `hip.tanh` DPS op (mirrors `hip.sigmoid`), lowered to
`wrap_miopenActivationForward` with `miopenActivationTANH`. This unblocks any
model with a standalone `Tanh` outside the Gelu(tanh) fusion — e.g. Gemma-2
lm_head logit soft-capping (`cap * tanh(logits / cap)`), which previously
survived `convert-onnx-to-hip` unconverted and aborted one-shot-bufferize.

- `HipOps.td`: new `hip.tanh` op
- `HipDialect.cpp` / `HipBufferize.h`: DPS inits, effects, bufferization iface
- `ActivationConversion.cpp`: `onnx.Tanh` → `hip.tanh`
- `ActivationLowering.cpp`: `hip.tanh` → `wrap_miopenActivationForward(TANH)`
- Runtime `activation.cpp`: set `alpha = beta = 1` for `miopenActivationTANH`.
  MIOpen TANH computes `alpha * tanh(beta * x)`, so the previous `0,0,0` default
  degenerated to `0 * tanh(0) = 0` (LOGISTIC/SOFTRELU ignore alpha/beta). The
  descriptor cache is keyed by `activation_mode`, so the mode-derived alpha/beta
  never alias across modes.

The Gelu(tanh) fusion runs in the pre-lowering phase before `convertComputeOps`,
so the standalone `Tanh` pattern only claims the leftover `Tanh` and does not
interfere with Gelu fusion.

## Known limitations

**NaN semantics of GreaterOrEqual / LessOrEqual.** The identities
`A >= B  <=>  !(A < B)` and `A <= B  <=>  !(B < A)` hold only for a total order.
With NaN operands the decomposition deviates from ONNX/IEEE-754: ONNX requires a
comparison involving NaN to be `false`, but `hip.less` (C++ `<`) returns `false`
for any NaN comparison, so `!(A < B)` yields `true`. This is **exact for integer
inputs** (the dominant index/mask use) and for **NaN-free float models**; float
models that can produce NaN are not supported by this decomposition. This is a
deliberate trade-off (reuse `hip.less` + `hip.not` vs. a dedicated NaN-correct
`>=`/`<=` kernel) and is documented in the conversion sources.

## Tests
- LIT (conversion + hip-to-llvm + e2e), each with static **and dynamic-shape**
  cases for Tanh and GreaterOrEqual/LessOrEqual; Tanh covers fp16 and fp32.
- EP-vs-CPU accuracy validated exact (cosine = 1.0) for fp32/fp16/int32,
  equal-shape and dynamic-shape inputs.

> Note: a separate, unrelated compile-time crash in the existing reduce
> conversions (unranked result) and a test-harness input-range fix are tracked
> in their own PR, not here.
