### PR TITLE
fix(onnx-to-hip): infer ranked result type for reduce ops with unranked result

### DIFF
--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
@@ -97,6 +97,53 @@ inline mlir::Value createEmptyTensor(mlir::OpBuilder &builder,
                                        resultType.getElementType(), dynSizes);
 }
 
+/// Resolve the ranked result type of an ONNX reduction op (ReduceMax / Sum /
+/// Mean / Prod / ...).
+///
+/// Usually this is just the op's own result type. The ONNX importer can,
+/// however, leave a reduction result UNRANKED (`tensor<*xT>`) when the input
+/// carries dynamic symbolic dims and the axes are not explicit -- e.g. Phi's
+/// `ReduceMax(position_ids)` feeding `GreaterOrEqual`. A bare
+/// `mlir::cast<RankedTensorType>` on an unranked type is unchecked in release
+/// builds and dereferences garbage -> crash. In that case, infer the result
+/// type from the (ranked) input + statically-known reduced axes + keepdims,
+/// per ONNX reduction shape semantics:
+///   keepdims=1: reduced axes become size 1, other dims preserved.
+///   keepdims=0: reduced axes are dropped.
+///
+/// \p reducedAxes          reduced axis indices (may be negative; normalized
+///                         here). For the all-axes default the caller passes
+///                         every axis; for a noop (empty axes) it passes none.
+/// \p axesStaticallyKnown  false when axes are only known at runtime, in which
+///                         case an unranked result cannot be inferred.
+/// Returns failure only when the result is unranked AND cannot be inferred
+/// (unranked/absent input type, or runtime-only axes).
+inline mlir::FailureOr<mlir::RankedTensorType>
+inferReduceResultType(mlir::Operation *op, mlir::Value data,
+                      llvm::ArrayRef<int64_t> reducedAxes,
+                      bool axesStaticallyKnown, int64_t keepdims) {
+  if (auto ranked =
+          mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType()))
+    return ranked;
+  auto inputType = mlir::dyn_cast<mlir::RankedTensorType>(data.getType());
+  if (!inputType || !axesStaticallyKnown)
+    return mlir::failure();
+  int64_t rank = inputType.getRank();
+  llvm::SmallVector<bool> reduced(rank, false);
+  for (int64_t a : reducedAxes)
+    reduced[a < 0 ? a + rank : a] = true;
+  llvm::SmallVector<int64_t> outShape;
+  for (int64_t i = 0; i < rank; ++i) {
+    if (reduced[i]) {
+      if (keepdims)
+        outShape.push_back(1);
+    } else {
+      outShape.push_back(inputType.getDimSize(i));
+    }
+  }
+  return mlir::RankedTensorType::get(outShape, inputType.getElementType());
+}
+
 /// Create a tensor.empty for a DPS init whose shape is the NumPy-style
 /// broadcast of \p operands. Operand shapes are right-aligned with the
 /// result. For each dynamic dimension of \p resultType, the size is taken

--- a/lib/Conversion/OnnxToHip/ReduceMaxConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ReduceMaxConversion.cpp
@@ -30,9 +30,6 @@ ReduceMaxToHip::matchAndRewrite(mlir::Operation *op,
 
   mlir::Location loc = op->getLoc();
   mlir::Value data = op->getOperand(0);
-  auto resultType =
-      mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
-  mlir::Value init = createEmptyTensor(rewriter, loc, resultType, data);
 
   int64_t noopWithEmptyAxes = 0;
   if (auto noopAttr =
@@ -40,33 +37,51 @@ ReduceMaxToHip::matchAndRewrite(mlir::Operation *op,
     noopWithEmptyAxes = noopAttr.getSInt();
   }
 
-  mlir::Value axesOperand;
+  int64_t keepdims = 1;
+  if (auto keepdimsAttr = op->getAttrOfType<mlir::IntegerAttr>("keepdims")) {
+    keepdims = keepdimsAttr.getSInt();
+  }
 
-  if (op->getNumOperands() > 1) {
-    axesOperand = op->getOperand(1);
-  } else {
-    llvm::SmallVector<int64_t> axesVec;
+  // Statically-known reduced axes (only when axes is NOT a runtime operand).
+  // Used both to materialize the axes constant below and to infer the result
+  // type when the ONNX importer left the result unranked (see below).
+  bool axesStaticallyKnown = op->getNumOperands() <= 1;
+  llvm::SmallVector<int64_t> axesVec;
+  auto inputType = mlir::dyn_cast<mlir::RankedTensorType>(data.getType());
+  if (axesStaticallyKnown) {
     if (auto axesAttr = op->getAttrOfType<mlir::ArrayAttr>("axes")) {
       for (auto a : axesAttr)
         axesVec.push_back(
             mlir::cast<mlir::IntegerAttr>(a).getValue().getSExtValue());
-    } else if (noopWithEmptyAxes == 0) {
-      auto inputType = mlir::cast<mlir::RankedTensorType>(data.getType());
+    } else if (noopWithEmptyAxes == 0 && inputType) {
       for (int64_t i : llvm::seq<int64_t>(inputType.getRank()))
         axesVec.push_back(i);
     }
+  }
 
+  // The ONNX importer can leave the ReduceMax result unranked (e.g. Phi's
+  // pos_ids_reformat ReduceMax(position_ids) feeding GreaterOrEqual); infer a
+  // ranked result type in that case (see inferReduceResultType).
+  auto resultTypeOr =
+      inferReduceResultType(op, data, axesVec, axesStaticallyKnown, keepdims);
+  if (mlir::failed(resultTypeOr))
+    return rewriter.notifyMatchFailure(
+        op, "ReduceMax: cannot infer unranked result (need ranked input and "
+            "static axes)");
+  mlir::RankedTensorType resultType = *resultTypeOr;
+
+  mlir::Value init = createEmptyTensor(rewriter, loc, resultType, data);
+
+  mlir::Value axesOperand;
+  if (op->getNumOperands() > 1) {
+    axesOperand = op->getOperand(1);
+  } else {
     auto axesType = mlir::RankedTensorType::get(
         {static_cast<int64_t>(axesVec.size())}, rewriter.getI64Type());
     auto axesAttr =
         mlir::DenseIntElementsAttr::get(axesType, llvm::ArrayRef(axesVec));
     axesOperand =
         mlir::arith::ConstantOp::create(rewriter, loc, axesType, axesAttr);
-  }
-
-  int64_t keepdims = 1;
-  if (auto keepdimsAttr = op->getAttrOfType<mlir::IntegerAttr>("keepdims")) {
-    keepdims = keepdimsAttr.getSInt();
   }
 
   auto keepdimsAttr = rewriter.getI64IntegerAttr(keepdims);

--- a/lib/Conversion/OnnxToHip/ReduceMeanConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ReduceMeanConversion.cpp
@@ -48,9 +48,6 @@ ReduceMeanToHip::matchAndRewrite(mlir::Operation *op,
 
   mlir::Location loc = op->getLoc();
   mlir::Value data = op->getOperand(0);
-  auto resultType =
-      mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
-  mlir::Value init = createEmptyTensor(rewriter, loc, resultType, data);
 
   // Extract noop_with_empty_axes attribute (defaults to 0 in ONNX)
   int64_t noopWithEmptyAxes = 0;
@@ -59,31 +56,46 @@ ReduceMeanToHip::matchAndRewrite(mlir::Operation *op,
     noopWithEmptyAxes = noopAttr.getSInt();
   }
 
-  // Handle axes: can be operand (opset 18+) or attribute (opset < 18)
-  // axes is always required in HIP dialect; create empty tensor<0xi64> when not
-  // provided
-  mlir::Value axesOperand;
+  // Extract keepdims attribute (defaults to 1 in ONNX)
+  int64_t keepdims = 1;
+  if (auto keepdimsAttr = op->getAttrOfType<mlir::IntegerAttr>("keepdims")) {
+    keepdims = keepdimsAttr.getSInt();
+  }
 
-  if (op->getNumOperands() > 1) {
-    // Axes provided as operand (opset 18+)
-    axesOperand = op->getOperand(1);
-  } else {
-    // Axes provided as attribute - convert to constant tensor
-    llvm::SmallVector<int64_t> axesVec;
+  // Statically-known reduced axes (only when axes is NOT a runtime operand).
+  bool axesStaticallyKnown = op->getNumOperands() <= 1;
+  auto inputType = mlir::dyn_cast<mlir::RankedTensorType>(data.getType());
+  llvm::SmallVector<int64_t> axesVec;
+  if (axesStaticallyKnown) {
     if (auto axesAttr = op->getAttrOfType<mlir::ArrayAttr>("axes")) {
       for (auto a : axesAttr)
         axesVec.push_back(
             mlir::cast<mlir::IntegerAttr>(a).getValue().getSExtValue());
-    } else if (noopWithEmptyAxes == 0) {
+    } else if (noopWithEmptyAxes == 0 && inputType) {
       // Default: reduce all axes (when noop_with_empty_axes is 0)
-      auto inputType = mlir::cast<mlir::RankedTensorType>(data.getType());
       for (int64_t i : llvm::seq<int64_t>(inputType.getRank()))
         axesVec.push_back(i);
-    } else {
-      // noop_with_empty_axes is 1 and no axes provided, axesVec remains empty
-      // (will create empty tensor<0xi64>)
     }
+    // noop_with_empty_axes == 1 with no axes -> axesVec stays empty (identity).
+  }
 
+  // Resolve the result type (infer if the importer left it unranked).
+  auto resultTypeOr =
+      inferReduceResultType(op, data, axesVec, axesStaticallyKnown, keepdims);
+  if (mlir::failed(resultTypeOr))
+    return rewriter.notifyMatchFailure(
+        op, "ReduceMean: cannot infer unranked result (need ranked input and "
+            "static axes)");
+  mlir::RankedTensorType resultType = *resultTypeOr;
+  mlir::Value init = createEmptyTensor(rewriter, loc, resultType, data);
+
+  // axes is always required in HIP dialect; create empty tensor<0xi64> when not
+  // provided
+  mlir::Value axesOperand;
+  if (op->getNumOperands() > 1) {
+    // Axes provided as operand (opset 18+)
+    axesOperand = op->getOperand(1);
+  } else {
     // Create constant tensor for axes
     auto axesType = mlir::RankedTensorType::get(
         {static_cast<int64_t>(axesVec.size())}, rewriter.getI64Type());
@@ -91,12 +103,6 @@ ReduceMeanToHip::matchAndRewrite(mlir::Operation *op,
         mlir::DenseIntElementsAttr::get(axesType, llvm::ArrayRef(axesVec));
     axesOperand =
         mlir::arith::ConstantOp::create(rewriter, loc, axesType, axesAttr);
-  }
-
-  // Extract keepdims attribute (defaults to 1 in ONNX)
-  int64_t keepdims = 1;
-  if (auto keepdimsAttr = op->getAttrOfType<mlir::IntegerAttr>("keepdims")) {
-    keepdims = keepdimsAttr.getSInt();
   }
 
   // Create hip.reduce_mean operation (axes always provided, may be empty)

--- a/lib/Conversion/OnnxToHip/ReduceProdConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ReduceProdConversion.cpp
@@ -159,8 +159,6 @@ ReduceProdToHip::matchAndRewrite(mlir::Operation *op,
 
   mlir::Location loc = op->getLoc();
   mlir::Value data = op->getOperand(0);
-  auto resultType =
-      mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
 
   int64_t noopWithEmptyAxes = 0;
   if (auto noopAttr =
@@ -204,6 +202,16 @@ ReduceProdToHip::matchAndRewrite(mlir::Operation *op,
     axesOperand =
         mlir::arith::ConstantOp::create(rewriter, loc, axesType, axesAttr);
   }
+
+  // Resolve the result type (infer if the importer left it unranked). axesKnown
+  // also covers the compile-time-constant axes-operand case extracted above.
+  auto resultTypeOr =
+      inferReduceResultType(op, data, axesVec, axesKnown, keepdims);
+  if (mlir::failed(resultTypeOr))
+    return rewriter.notifyMatchFailure(
+        op, "ReduceProd: cannot infer unranked result (need ranked input and "
+            "static axes)");
+  mlir::RankedTensorType resultType = *resultTypeOr;
 
   mlir::Value init = buildReduceProdInit(rewriter, loc, resultType, data,
                                          axesVec, axesKnown, keepdims);

--- a/lib/Conversion/OnnxToHip/ReduceSumConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ReduceSumConversion.cpp
@@ -29,9 +29,6 @@ ReduceSumToHip::matchAndRewrite(mlir::Operation *op,
 
   mlir::Location loc = op->getLoc();
   mlir::Value data = op->getOperand(0);
-  auto resultType =
-      mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
-  mlir::Value init = createEmptyTensor(rewriter, loc, resultType, data);
 
   // Extract noop_with_empty_axes attribute (defaults to 0 in ONNX)
   int64_t noopWithEmptyAxes = 0;
@@ -40,31 +37,47 @@ ReduceSumToHip::matchAndRewrite(mlir::Operation *op,
     noopWithEmptyAxes = noopAttr.getSInt();
   }
 
-  // Handle axes: can be operand (opset 13+) or attribute (opset < 13)
-  // axes is always required in HIP dialect; create empty tensor<0xi64> when not
-  // provided
-  mlir::Value axesOperand;
+  // Extract keepdims attribute (defaults to 1 in ONNX)
+  int64_t keepdims = 1;
+  if (auto keepdimsAttr = op->getAttrOfType<mlir::IntegerAttr>("keepdims")) {
+    keepdims = keepdimsAttr.getSInt();
+  }
 
-  if (op->getNumOperands() > 1) {
-    // Axes provided as operand (opset 13+)
-    axesOperand = op->getOperand(1);
-  } else {
-    // Axes provided as attribute - convert to constant tensor
-    llvm::SmallVector<int64_t> axesVec;
+  // Statically-known reduced axes (only when axes is NOT a runtime operand).
+  // Used to materialize the axes constant and to infer an unranked result.
+  bool axesStaticallyKnown = op->getNumOperands() <= 1;
+  auto inputType = mlir::dyn_cast<mlir::RankedTensorType>(data.getType());
+  llvm::SmallVector<int64_t> axesVec;
+  if (axesStaticallyKnown) {
     if (auto axesAttr = op->getAttrOfType<mlir::ArrayAttr>("axes")) {
       for (auto a : axesAttr)
         axesVec.push_back(
             mlir::cast<mlir::IntegerAttr>(a).getValue().getSExtValue());
-    } else if (noopWithEmptyAxes == 0) {
+    } else if (noopWithEmptyAxes == 0 && inputType) {
       // Default: reduce all axes (when noop_with_empty_axes is 0)
-      auto inputType = mlir::cast<mlir::RankedTensorType>(data.getType());
       for (int64_t i : llvm::seq<int64_t>(inputType.getRank()))
         axesVec.push_back(i);
-    } else {
-      // noop_with_empty_axes is 1 and no axes provided, axesVec remains empty
-      // (will create empty tensor<0xi64>)
     }
+    // noop_with_empty_axes == 1 with no axes -> axesVec stays empty (identity).
+  }
 
+  // Resolve the result type (infer if the importer left it unranked).
+  auto resultTypeOr =
+      inferReduceResultType(op, data, axesVec, axesStaticallyKnown, keepdims);
+  if (mlir::failed(resultTypeOr))
+    return rewriter.notifyMatchFailure(
+        op, "ReduceSum: cannot infer unranked result (need ranked input and "
+            "static axes)");
+  mlir::RankedTensorType resultType = *resultTypeOr;
+  mlir::Value init = createEmptyTensor(rewriter, loc, resultType, data);
+
+  // axes is always required in HIP dialect; create empty tensor<0xi64> when not
+  // provided
+  mlir::Value axesOperand;
+  if (op->getNumOperands() > 1) {
+    // Axes provided as operand (opset 13+)
+    axesOperand = op->getOperand(1);
+  } else {
     // Create constant tensor for axes
     auto axesType = mlir::RankedTensorType::get(
         {static_cast<int64_t>(axesVec.size())}, rewriter.getI64Type());
@@ -72,12 +85,6 @@ ReduceSumToHip::matchAndRewrite(mlir::Operation *op,
         mlir::DenseIntElementsAttr::get(axesType, llvm::ArrayRef(axesVec));
     axesOperand =
         mlir::arith::ConstantOp::create(rewriter, loc, axesType, axesAttr);
-  }
-
-  // Extract keepdims attribute (defaults to 1 in ONNX)
-  int64_t keepdims = 1;
-  if (auto keepdimsAttr = op->getAttrOfType<mlir::IntegerAttr>("keepdims")) {
-    keepdims = keepdimsAttr.getSInt();
   }
 
   // Create hip.reduce_sum operation (axes always provided, may be empty)


### PR DESCRIPTION
<!--
Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
Licensed under the MIT License.
-->

## Summary
Fixes a compile-time crash in the ONNX→HIP reduce conversions when the importer
leaves a reduction result **unranked**, and makes the runner generate sane
random `int64` inputs. Both unblock the Phi-3/Phi-4 ONNX models.

## Details

### Reduce ops: unranked result crash (`access violation` at session init)
The ONNX importer can leave a reduction result UNRANKED (`tensor<*xT>`) when the
input has dynamic symbolic dims and the axes are not explicit — e.g. Phi's
`pos_ids_reformat` `ReduceMax(position_ids)` feeding `GreaterOrEqual`. The
conversions did:

```cpp
auto resultType = mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
```

`mlir::cast<>` is unchecked in release builds, so on an unranked type the
subsequent `getRank()/isDynamicDim()` dereferences garbage → access violation
(`0xC0000005`) during `GetCapability`, crashing the whole session for
Phi-3-mini-128k / Phi-3.5-mini / Phi-4-mini-instruct / Phi-4-mini-reasoning.

Fix: a shared helper `inferReduceResultType` (`OnnxToHipUtils.h`) that returns
the op's own result type when ranked, otherwise infers it from the (ranked)
input + statically-known reduced axes + keepdims per ONNX reduction shape
semantics (`keepdims=1` → reduced dims become 1; `keepdims=0` → reduced dims
dropped); it returns failure (graceful `notifyMatchFailure`, no crash) when it
cannot infer (non-ranked input or runtime-only axes). Applied in ReduceMax /
ReduceSum / ReduceMean / ReduceProd. Ranked-result behaviour is unchanged.

### Runner: small non-negative int64 random inputs
`hip-onnx-runner` filled random `int64` inputs with full-range `uint64` values.
In ONNX models int64 inputs are almost always indices / token-ids / masks, so
full-range values crash any model with an embedding `Gather` (index out of
bounds) and never exercise the real compute. Generate `int64` in `[0, 127]`
instead (mirroring how the harness already caps other index-like dtypes). EP and
CPU get identical bytes, so the EP-vs-CPU comparison stays valid.

## Result
- All four Phi-3/Phi-4 models now compile + run on the EP (previously crashed).
- LIT: 261/261 on this branch (no regressions).

> Independent of #374 (GreaterOrEqual/LessOrEqual/Tanh ops); branched from main.
