### PR TITLE
feat: update morphizen

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "3rd-party/morphizen"]
 	path = 3rd-party/morphizen
 	url = git@github.com:ROCm/MorphiZen.git
-	branch = genmingz/memorypoo
+	branch = genmingz/memorypool

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "3rd-party/morphizen"]
 	path = 3rd-party/morphizen
 	url = git@github.com:ROCm/MorphiZen.git
-	branch = genmingz/memorypool_debug
+	branch = genmingz/memorypool

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "3rd-party/morphizen"]
 	path = 3rd-party/morphizen
 	url = git@github.com:ROCm/MorphiZen.git
-	branch = genmingz/memorypool_debug
+	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "3rd-party/morphizen"]
 	path = 3rd-party/morphizen
 	url = git@github.com:ROCm/MorphiZen.git
-	branch = genmingz/memorypool_debug
+	branch = genmingz/memorypoo

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "3rd-party/morphizen"]
 	path = 3rd-party/morphizen
 	url = git@github.com:ROCm/MorphiZen.git
-	branch = genmingz/memorypool
+	branch = genmingz/memorypool_debug

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "3rd-party/morphizen"]
 	path = 3rd-party/morphizen
 	url = git@github.com:ROCm/MorphiZen.git
-	branch = main
+	branch = genmingz/memorypool


### PR DESCRIPTION
https://github.com/ROCm/MorphiZen/pull/236/
In some model runs, alloc can take up a significant amount of time; this change can resolve this issue.
<img width="1849" height="373" alt="image" src="https://github.com/user-attachments/assets/0a7f654d-52b2-44a9-b6cc-9624d6d7e05b" />
### Details
HipGpuAllocator now rounds each request up to a fixed size class
(4 KB / 64 KB / 1 MB / 16 MB) and allocates the full class capacity, so any
later request mapping to the same class reuses the buffer.
Requests larger than 16 MB are allocated at their exact size and recycled
best-fit (lower_bound): a freed 32 MB buffer can serve a later 31 MB
request.
Free never returns memory to the driver; all buffers (free or still
checked out) are released wholesale in the new destructor, matching the
per-session "grow-on-demand, never shrink, free at cleanup" contract.
Reuse needs no per-handout stream sync (ORT only calls Free after Run, and
allocator-mode inference_compute ends with a full hipdnn_ep_stream_sync).
Minor cleanup: drop the MORPHIZEN_EP_REGISTRATION_NAME compile-time
injection (CMake/Bazel) and hardcode the ep.morphizenexecutionprovider.
provider-option prefix in config_reader.cpp / morphizen-ep.cpp.