### PR TITLE
ci(windows): build and test across TheRock 7.11/7.12/7.13 matrix

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -24,8 +24,9 @@ jobs:
     runs-on: windows-2022
     # Build each TheRock ROCm SDK version in parallel. fail-fast: false so one
     # version's failure does not cancel the others. The version flows into the
-    # build (build.py --therock_dist), the packaged amdhip64_7.dll, and the
-    # per-version artifact names consumed by the matching gpu-test leg.
+    # build (-DTHEROCK_VERSION drives the deps.cmake auto-download + the rocm
+    # wheel pin), the packaged amdhip64_7.dll, and the per-version artifact names
+    # consumed by the matching gpu-test leg.
     strategy:
       fail-fast: false
       matrix:
@@ -352,29 +353,12 @@ jobs:
           "$CMAKE" --build "${{ runner.workspace }}/build-amdgpu" --target amdgpu-ep hipep-ep
 
       # -----------------------------------------------------------------------
-      # Download the matrix TheRock ROCm SDK so build.py uses this exact version
-      # (--therock_dist) instead of cmake/deps.cmake auto-downloading the pinned
-      # default. Same tarball layout the gpu-test job downloads at runtime; the
-      # packaged amdhip64_7.dll is taken from here too (staging step below).
-      # -----------------------------------------------------------------------
-      - name: Download & extract TheRock (build)
-        shell: pwsh
-        run: |
-          $dist = "${{ runner.workspace }}\therock-dist"
-          New-Item -ItemType Directory -Force -Path $dist | Out-Null
-          curl.exe -fsSL `
-            "https://repo.amd.com/rocm/tarball/therock-dist-windows-gfx1151-${{ matrix.therock }}.tar.gz" `
-            -o therock.tar.gz
-          tar -xzf therock.tar.gz -C $dist --strip-components=1
-          Remove-Item therock.tar.gz
-
-      # -----------------------------------------------------------------------
       # Build onnx-hipdnn-ep via the cross-platform build.py (same driver
       # as the Linux CI and docs/quick_start.md). Cached LLVM/ORT prefixes are
-      # injected; protobuf/flatbuffers build from source and TheRock comes from
-      # the matrix version downloaded above (--therock_dist). build.py's default
-      # build/install dirs resolve to ${{ runner.workspace }}/build/<repo> and
-      # ${{ runner.workspace }}/install (repo.parent), matching what the later
+      # injected; protobuf/flatbuffers build from source and TheRock auto-downloads
+      # via cmake/deps.cmake at the matrix version (-DTHEROCK_VERSION). build.py's
+      # default build/install dirs resolve to ${{ runner.workspace }}/build/<repo>
+      # and ${{ runner.workspace }}/install (repo.parent), matching what the later
       # staging step expects. The LIT tests run inside build.py after install.
       #
       # HIPEP_WHEEL_EXTRA_DLLS feeds the wheel target the amdgpu-ep.dll +
@@ -393,9 +377,9 @@ jobs:
             --config Release \
             --cmake_generator Ninja \
             --hip_arch gfx1151 \
-            --therock_dist "${{ runner.workspace }}/therock-dist" \
             --cmake_prefix_path "${{ runner.workspace }}/ort-install;${{ runner.workspace }}/llvm-install" \
             --cmake_extra_defines CMAKE_DISABLE_FIND_PACKAGE_OpenSSL=ON \
+            --cmake_extra_defines THEROCK_VERSION=${{ matrix.therock }} \
             --cmake_extra_defines "HIPEP_WHEEL_EXTRA_DLLS=$AMDGPU_EP;$HIPEP_BACKEND"
 
       # -----------------------------------------------------------------------
@@ -600,10 +584,10 @@ jobs:
           # without touching this workflow each time.
           cp "${{ runner.workspace }}/install/lib/"*.lib staging/lib/ 2>/dev/null || true
 
-          # amdhip64_7.dll – HIP runtime required at inference time. TheRock is
-          # the matrix version downloaded above and passed via build.py
-          # --therock_dist (so the build tree's _therock is not created).
-          THEROCK_DIR="${{ runner.workspace }}/therock-dist"
+          # amdhip64_7.dll – HIP runtime required at inference time. TheRock was
+          # auto-downloaded by cmake/deps.cmake (at THEROCK_VERSION) into the
+          # build tree's _therock.
+          THEROCK_DIR="../build/$(basename "$PWD")/_therock"
           cp "$THEROCK_DIR/bin/amdhip64_7.dll" staging/bin/
 
           # MorphiZen EP config

--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -18,6 +18,14 @@ foreach(_dep IN LISTS _HIPDNN_DEPS_LIST)
   set(DEP_HASH_${_dep_name} "${_dep}")  # remaining column = hash (may be empty)
 endforeach()
 
+# Single source of truth for the ROCm/TheRock SDK version: drives both the
+# auto-download tarball basename (below) and the rocm[...] wheel pin in
+# python/pyproject.toml.in. Defaults to the deps.txt therock pin; override with
+# -DTHEROCK_VERSION=<ver> (CI builds each matrix version) to keep the SDK and
+# the wheel dependency in lockstep.
+set(THEROCK_VERSION "${DEP_HASH_therock}" CACHE STRING
+    "ROCm/TheRock SDK version (auto-download tarball + rocm wheel pin)")
+
 # The shared toolchain (LLVM/MLIR/LLD, flatbuffers, cpptrace, TheRock) is needed
 # by both the EP and the standalone HIP tools, so it is resolved whenever either
 # is on. The EP-only deps (morphizen, ONNX Runtime, protobuf) stay gated on
@@ -59,9 +67,9 @@ if(_HIPDNN_NEED_TOOLCHAIN)
     else()
       # Auto-download: no SDK provided, so download the official tarball from the
       # public AMD host and extract it under the build tree, so a fresh real
-      # build needs no manual SDK setup. The pin lives in cmake/deps.txt
-      # (therock;<base-url>;<rocm-version>); the full tarball basename is derived
-      # from the host OS + the first HIP_ARCHITECTURES entry.
+      # build needs no manual SDK setup. The version is THEROCK_VERSION (default
+      # from the cmake/deps.txt therock row); the base URL is its url column. The
+      # full tarball basename is derived from the host OS + first HIP_ARCHITECTURES.
       set(_therock_root "${CMAKE_BINARY_DIR}/_therock")
       if(NOT EXISTS "${_therock_root}/bin")
         if(WIN32)
@@ -78,7 +86,7 @@ if(_HIPDNN_NEED_TOOLCHAIN)
             "Cannot derive the TheRock tarball: set -DHIP_ARCHITECTURES=<gfxNNNN> "
             "(GPU arch), or provide -DTHEROCK_DIST=/path/to/therock.")
         endif()
-        set(_therock_base "therock-dist-${_therock_os}-${_therock_arch}-${DEP_HASH_therock}")
+        set(_therock_base "therock-dist-${_therock_os}-${_therock_arch}-${THEROCK_VERSION}")
         set(_therock_url "${DEP_URL_therock}/${_therock_base}.tar.gz")
         set(_therock_tgz "${CMAKE_BINARY_DIR}/${_therock_base}.tar.gz")
         if(NOT EXISTS "${_therock_tgz}")

--- a/python/pyproject.toml.in
+++ b/python/pyproject.toml.in
@@ -19,9 +19,9 @@ dependencies = [
     # ROCm runtime (TheRock). Not on PyPI -- supply at install time via
     # `--extra-index-url https://repo.amd.com/rocm/whl/@MORPHIZEN_HIP_ARCH@/`
     # (@MORPHIZEN_HIP_ARCH@ = the GPU arch this wheel was built for). Pinned to
-    # the exact TheRock version the EP is built against to avoid runtime/JIT
-    # import ABI skew.
-    "rocm[libraries,devel]==7.11.0",
+    # the exact TheRock version the EP is built against (THEROCK_VERSION, default
+    # cmake/deps.txt) to avoid runtime/JIT import ABI skew.
+    "rocm[libraries,devel]==@THEROCK_VERSION@",
 ]
 # NOTE: a custom ONNX Runtime build (the plugin-EP-patched onnxruntime-directml)
 # is required at runtime, but it is NOT declared as a dependency: this wheel


### PR DESCRIPTION
## Summary

Build and GPU-test the EP against a matrix of TheRock ROCm SDK versions (7.11.0 / 7.12.0 / 7.13.0) in parallel, with `fail-fast: false` so one version failing does not abort the others. Closes the gap where CI only ever exercised the single pinned TheRock 7.11.0.

## Why

We need coverage on newer TheRock releases (7.12, 7.13) without dropping 7.11, and a failure on one version must not mask results for the rest. A job-level matrix on both `build-windows` and `gpu-test` is the minimal way to get per-version build + test legs that report independently. The version is threaded end-to-end (compile -> packaged `amdhip64_7.dll` -> per-version artifact -> matching runtime) so each leg is a true single-version build, not a runtime-only swap. Alternative considered and rejected: a separate manual `workflow_dispatch` workflow — duplicates the entire build/test pipeline and drifts from the real CI; matrixing the existing workflow keeps one source of truth.

## What

1. **`build-windows` matrix** at [.github/workflows/windows-build.yml](.github/workflows/windows-build.yml): `strategy.matrix.therock` = 7.11.0/7.12.0/7.13.0, `fail-fast: false`. Concurrency group now folds in `matrix.therock` so sibling legs of the same run do not cancel each other.
2. **New "Download & extract TheRock (build)" step**: downloads `therock-dist-windows-gfx1151-<ver>.tar.gz` to `runner.workspace/therock-dist`; `build.py` consumes it via `--therock_dist` instead of the `cmake/deps.cmake` auto-download. The staged `amdhip64_7.dll` is taken from this dir (the build tree's `_therock` is no longer created when `THEROCK_DIST` is set).
3. **Version-tagged artifacts**: `gpu-test-package-<ver>` and `hipep-python-package-<ver>`.
4. **`gpu-test` matrix**: same matrix + `fail-fast: false`, version-folded concurrency group, `THEROCK_VERSION` from `matrix.therock`, downloads the matching artifacts (download `path` unchanged so the rest of the job is untouched). L2 and perf PR-comment markers/headers include the version so the three legs post distinct comments instead of overwriting one.
5. **Intentional non-change**: `cmake/deps.txt` keeps its 7.11.0 fallback pin — CI always passes `--therock_dist`, so the fallback is never hit; leaving it avoids changing the local/default build behavior.

## Test plan

- [ ] build-windows shows 3 legs; each uploads `gpu-test-package-<ver>` and `hipep-python-package-<ver>`.
- [ ] gpu-test shows 3 legs; each downloads its matching package and the matching TheRock runtime, runs perf / native smoke / EPContext / L2 / OGA.
- [ ] A leg whose TheRock tarball is unavailable fails alone; the other legs complete (`fail-fast: false`).
- [ ] PR gets 3 distinct perf comments and 3 distinct L2 comments, one per version, none overwriting another.

Note: 7.12.0 / 7.13.0 Windows gfx1151 tarball availability on `repo.amd.com/rocm/tarball/` is confirmed by this run; an unavailable version surfaces as that leg's failure only.

## Notes for reviewers

This is a test PR to validate the matrix end-to-end and is not intended to merge as-is. Cold-cache first run rebuilds the shared LLVM/ORT/OGA caches up to 3x concurrently (same cache keys, TheRock-independent); warm runs only differ in the per-version EP build.
