### PR TITLE
Change morphizen url from https to ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "3rd-party/morphizen"]
 	path = 3rd-party/morphizen
-	url = https://github.com/ROCm/MorphiZen.git
+	url = git@github.com:ROCm/MorphiZen.git
 	branch = main


### PR DESCRIPTION
<!--
Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
Licensed under the MIT License.
-->

<!--
Thanks for contributing! Please skim the two policies this repo
follows before requesting review (1-2 minutes each):

  Incremental development:
    https://llvm.org/docs/DeveloperPolicy.html#incremental-development
  AI tool use:
    https://llvm.org/docs/AIToolPolicy.html

A short summary lives in CONTRIBUTING.md at the repo root. Each
section below has an HTML comment explaining what to put in it; you
can delete the comment after filling the section in.
-->

## Summary

<!--
1-3 sentences. What changed at a high level and what gap or bug it
closes.
-->

Given the Morphizen repo is private, with HTTPs url, git submodule update requires PAT or github app. Switch to SSH allows using SSH keys instead.
