### PR TITLE
refactor(op-state): simplify op-state API (create -> unique_ptr, plain-C++ set, get_op_state)

### DIFF
--- a/docs/design/op-state-slots-design.md
+++ b/docs/design/op-state-slots-design.md
@@ -98,7 +98,7 @@ ConvOp::generateOpStateInit(b, loc, statePtr, slot):
     ctor  = declare_extern("hipdnn_ep_op_state_construct_conv",
                            ret = i8, params = [ptr, i32, i64, i64])
     ok    = b.call(ctor, [ statePtr, const(slot), const(k), const(s) ])
-    return ok                                                # i8: store refused => 0
+    return ok                                                # i8: vestigial, always 0
 ```
 
 The runtime constructor takes those parameters, builds the state with `OpStateT::create` (which returns an owning `std::unique_ptr<T>` with `deletor` already wired), and hands the released pointer to `hipdnn_ep_op_state_set`, which stores it into the slot. `_set` is plain C++ internal to the runtime bitcode (never called by generated IR) and has no failure path: the compiler always supplies a valid slot into an already-allocated array, so the `RuntimeState` layout stays opaque without bounds-check ceremony:

--- a/docs/design/op-state-slots-design.md
+++ b/docs/design/op-state-slots-design.md
@@ -54,9 +54,9 @@ struct OpState {                 // base of every state struct
 
 template <class T> struct OpStateT : OpState {   // CRTP base each state derives from
   OpStateT() { deletor = [](OpState *p) { delete static_cast<T *>(p); }; }
-  static T   *get_slot(RuntimeState *, int slot);          // typed slot accessor
+  static T *get_op_state(RuntimeState *, int slot);        // typed slot accessor
   template <class... A>
-  static int8_t create(RuntimeState *, int32_t slot, A &&...);  // build + store into slot
+  static std::unique_ptr<T> create(A &&...);               // build an owning instance
 };
 
 struct RuntimeState {
@@ -101,7 +101,7 @@ ConvOp::generateOpStateInit(b, loc, statePtr, slot):
     return ok                                                # i8: store refused => 0
 ```
 
-The runtime constructor takes those parameters, builds the state, and stores it into its slot via `OpStateT::create` (which calls the bounds-checked `hipdnn_ep_op_state_set` and frees the object if the store is refused, so the `RuntimeState` layout stays opaque and nothing leaks):
+The runtime constructor takes those parameters, builds the state with `OpStateT::create` (which returns an owning `std::unique_ptr<T>` with `deletor` already wired), and hands the released pointer to `hipdnn_ep_op_state_set`, which stores it into the slot. `_set` is plain C++ internal to the runtime bitcode (never called by generated IR) and has no failure path: the compiler always supplies a valid slot into an already-allocated array, so the `RuntimeState` layout stays opaque without bounds-check ceremony:
 
 ```cpp
 struct ConvState : OpStateT<ConvState> {
@@ -112,7 +112,9 @@ struct ConvState : OpStateT<ConvState> {
 extern "C" int8_t
 hipdnn_ep_op_state_construct_conv(RuntimeState *s, int32_t slot,
                                   int64_t kernel, int64_t stride) {
-  return ConvState::create(s, slot, kernel, stride);   // build + wire deletor + store
+  hipdnn_ep_op_state_set(s, slot,
+                         ConvState::create(kernel, stride).release());  // build + store
+  return 0;
 }
 ```
 
@@ -122,10 +124,10 @@ A value that is unknown until inference (an input's dynamic shape, a data pointe
 
 ### Access
 
-Inside an operator's runtime entry, reaching the state is one indexed load through the typed `OpStateT::get_slot` accessor. `slot` is the second argument (right after `RuntimeState *`) the lowering threads into the operator's `wrap_*` call:
+Inside an operator's runtime entry, reaching the state is one indexed load through the typed `OpStateT::get_op_state` accessor. `slot` is the second argument (right after `RuntimeState *`) the lowering threads into the operator's `wrap_*` call:
 
 ```cpp
-ConvState *c = ConvState::get_slot(state, slot);   // == static_cast<ConvState*>(op_states[slot])
+ConvState *c = ConvState::get_op_state(state, slot);   // == static_cast<ConvState*>(op_states[slot])
 ```
 
 ### Sharing is opt-in
@@ -146,8 +148,8 @@ Expired entries are not pruned, so the residual is `O(#distinct keys)` — fine 
 graph TD
   ATTRS["op attributes (compile-time)"] --> GENM["op.generateOpStateInit(builder, slot)"]
   GENM -->|emit| CALL["call construct_op(state, slot, p1, ...)"]
-  CALL -->|"create() stores via op_state_set"| ARR["RuntimeState.op_states"]
-  WRAP["wrap_op(state, slot, ...) at inference"] -->|"State::get_slot(state, slot)"| ARR
+  CALL -->|"set(slot, create().release())"| ARR["RuntimeState.op_states"]
+  WRAP["wrap_op(state, slot, ...) at inference"] -->|"State::get_op_state(state, slot)"| ARR
 ```
 
 The slot-assignment pass stamps each op with its slot and records the slot count on the module. The interface generator, while building the `inference_init` entry, calls each op's `generateOpStateInit` to weave the per-slot construction in after core state and pool init. The lowerings thread the slot index in as the second `wrap_*` argument (right after `RuntimeState *`). This count-then-consume shape mirrors the memory pool, where a pass computes a count and offsets that generated init consumes; see [pool-allocs-memory-planning.md](pool-allocs-memory-planning.md).
@@ -176,7 +178,7 @@ Two `conv` instances in one fused function, with different compile-time attribut
 %ok1 = llvm.call @hipdnn_ep_op_state_construct_conv(%state, %sl1, %k1, %s1)
 ```
 
-**3. Session init (runs once)** — constructors run with the baked-in arguments, each building an object and storing it into its own slot (via `OpStateT::create` -> `hipdnn_ep_op_state_set`):
+**3. Session init (runs once)** — constructors run with the baked-in arguments, each building an object with `OpStateT::create` and storing it into its own slot via `hipdnn_ep_op_state_set`:
 
 ```cpp
 construct_conv(state, /*slot=*/0, /*kernel=*/3, /*stride=*/1);   // op_states[0] = ConvState{3,1}
@@ -186,8 +188,8 @@ construct_conv(state, /*slot=*/1, /*kernel=*/5, /*stride=*/2);   // op_states[1]
 **4. Inference (per call)** — each conv reads its own slot; the two never collide:
 
 ```cpp
-wrap_conv(state, /*slot=*/0, ...);   // ConvState::get_slot(state, 0) -> kernel 3
-wrap_conv(state, /*slot=*/1, ...);   // ConvState::get_slot(state, 1) -> kernel 5
+wrap_conv(state, /*slot=*/0, ...);   // ConvState::get_op_state(state, 0) -> kernel 3
+wrap_conv(state, /*slot=*/1, ...);   // ConvState::get_op_state(state, 1) -> kernel 5
 ```
 
 The input spatial size is unknown at step 2, so it is not a constructor argument; if `conv` needs a workspace sized by it, it grows that workspace inside `wrap_conv` from the runtime arguments, stored in the per-slot state.
@@ -196,8 +198,8 @@ The input spatial size is unknown at step 2, so it is not a constructor argument
 
 1. Define a state struct deriving from `OpStateT<MyState>` (the base wires `deletor` automatically).
 2. Implement `OpStateOpInterface::generateOpStateInit` — read the op's attributes and call `mlir::hip::emitOpStateConstruct(builder, loc, statePtr, slot, "construct_symbol", {i64 args})`, returning the i8 ok result.
-3. Provide the matching `extern "C" int8_t` constructor `(RuntimeState *, int32_t slot, params...)` that returns `MyState::create(state, slot, params...)`; optionally fetch a shared value from a `WeakStore` inside `MyState`'s constructor.
-4. Reach the state in the runtime entry with `MyState::get_slot(state, slot)`.
+3. Provide the matching `extern "C" int8_t` constructor `(RuntimeState *, int32_t slot, params...)` that calls `hipdnn_ep_op_state_set(state, slot, MyState::create(params...).release())` and returns `0`; optionally fetch a shared value from a `WeakStore` inside `MyState`'s constructor.
+4. Reach the state in the runtime entry with `MyState::get_op_state(state, slot)`.
 
 Stateless operators declare nothing.
 

--- a/include/hip/Dialect/IR/HipDialect.h
+++ b/include/hip/Dialect/IR/HipDialect.h
@@ -36,8 +36,8 @@ namespace hip {
 /// (or look up) the extern construct symbol `ctorSymbol` with signature
 /// `(RuntimeState*, i32 slot, i64 x N) -> i8`, emit the call passing
 /// `statePtr`, the `slot` constant, and `i64Args` as constants, and return the
-/// i8 ok result. The construct symbol stores the built state into
-/// op_states[slot] itself (via hipdnn_ep_op_state_set), so the caller
+/// i8 result (vestigial, always 0). The construct symbol stores the built state
+/// into op_states[slot] itself (via hipdnn_ep_op_state_set), so the caller
 /// (--generate-op-state-init) does not emit a separate store. Defined in
 /// lib/Dialect/IR/HipOpStateInterface.cpp.
 ::mlir::Value emitOpStateConstruct(::mlir::OpBuilder &builder,

--- a/include/hip/Dialect/IR/HipOpStateInterface.td
+++ b/include/hip/Dialect/IR/HipOpStateInterface.td
@@ -21,7 +21,9 @@ include "mlir/IR/OpBase.td"
 // construct symbol and slot). The emitted construct symbol stores the built
 // state into op_states[slot] itself (via hipdnn_ep_op_state_set, called inside
 // the runtime construct fn -- not the slot array directly), keeping the
-// RuntimeState layout opaque to generated IR. It returns an i8 ok flag.
+// RuntimeState layout opaque to generated IR. It returns an i8 that is
+// vestigial (always 0): hipdnn_ep_op_state_set has no failure path, so the
+// init pass keeps the result for a stable signature but does not branch on it.
 def OpStateOpInterface : OpInterface<"OpStateOpInterface"> {
   let description = [{
     Marker + code-gen interface for stateful HIP ops. Implementers emit the IR
@@ -38,7 +40,8 @@ def OpStateOpInterface : OpInterface<"OpStateOpInterface"> {
         the op's own attributes, declare the construct symbol with whatever
         parameter types are needed, and emit the call passing `slot`. The
         construct symbol stores the built state into op_states[slot] itself and
-        returns an i8 ok flag (0 at runtime means the store was refused).
+        returns an i8 that is vestigial (always 0): the store has no failure
+        path, so the init pass does not branch on it.
       }],
       /*retTy=*/"::mlir::Value",
       /*methodName=*/"generateOpStateInit",

--- a/lib/Dialect/IR/HipOpStateInterface.cpp
+++ b/lib/Dialect/IR/HipOpStateInterface.cpp
@@ -38,9 +38,10 @@ Value emitOpStateConstruct(OpBuilder &builder, Location loc, Value statePtr,
   Type i32Type = builder.getI32Type();
   Type i64Type = builder.getI64Type();
 
-  // Construct signature: (RuntimeState*, i32 slot, i64 x N) -> i8 (ok). The
-  // constructor stores the built state into op_states[slot] itself (via
-  // hipdnn_ep_op_state_set) and returns whether the store succeeded.
+  // Construct signature: (RuntimeState*, i32 slot, i64 x N) -> i8. The
+  // constructor builds its state and stores it into op_states[slot] itself (via
+  // hipdnn_ep_op_state_set). The i8 result is vestigial (always 0) -- it keeps
+  // a stable call signature but the init pass does not branch on it.
   SmallVector<Type> paramTypes;
   paramTypes.push_back(ptrType);
   paramTypes.push_back(i32Type);

--- a/lib/Dialect/Transforms/GenerateOpStateInit.cpp
+++ b/lib/Dialect/Transforms/GenerateOpStateInit.cpp
@@ -16,7 +16,7 @@
 //   ^construct:
 //     // per stateful op, in slot order. Each construct_<op> stores its built
 //     // state into op_states[slot] itself (via hipdnn_ep_op_state_set, called
-//     // inside the runtime fn) and returns an i8 ok flag:
+//     // inside the runtime fn) and returns a vestigial i8 (always 0):
 //     %ok = <op.generateOpStateInit emits: call construct_<op>(%state, slot,
 //     attrs)> llvm.return 0
 //   ^fail:

--- a/lib/Dialect/Transforms/GenerateOpStateInit.cpp
+++ b/lib/Dialect/Transforms/GenerateOpStateInit.cpp
@@ -133,11 +133,11 @@ struct GenerateOpStateInitPass
     Value oneI32 = LLVM::ConstantOp::create(builder, loc, i32Type,
                                             builder.getI32IntegerAttr(1));
 
-    // On alloc failure, return failure (1) WITHOUT running any construct_<op>:
-    // the slot array is null, so the store inside construct_<op> would refuse
-    // (see op_state.cpp / OpStateT::create) and free the state, but skipping
-    // construction entirely avoids the wasted device-resource churn.
-    // inference_init maps the returned 1 to a failed session.
+    // On alloc failure, return failure (1) WITHOUT running any construct_<op>.
+    // This skip is load-bearing: the slot array is null, and
+    // hipdnn_ep_op_state_set assumes a valid slot into an allocated array (it
+    // no longer bounds-checks), so a construct_<op> must never run when alloc
+    // failed. inference_init maps the returned 1 to a failed session.
     Block *constructBlock = initFn.addBlock();
     Block *allocFailBlock = initFn.addBlock();
     LLVM::CondBrOp::create(builder, loc, allocFailed, allocFailBlock,
@@ -148,10 +148,8 @@ struct GenerateOpStateInitPass
 
     // Success path: per stateful op (slot order), call its construct_<op>,
     // which builds the state and stores it into its own slot, then report
-    // success (0). The i8 ok result is not branched on here: a refused store
-    // can only come from a compiler-assigned out-of-range slot (a bug), and the
-    // construct fn already frees the state in that case, so there is nothing to
-    // unwind.
+    // success (0). The i8 result of each construct_<op> is vestigial (always 0)
+    // and intentionally not branched on.
     builder.setInsertionPointToStart(constructBlock);
     for (int64_t slot = 0; slot < numSlots; ++slot) {
       Operation *op = bySlot[slot];

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -395,13 +395,12 @@ int hipdnn_ep_state_ensure_conv_scratch(RuntimeState *state,
 
 // Per-op state slots (see docs/design/op-state-slots-design.md). The generated
 // @hipdnn_ep_op_states_init_fn (built by --generate-op-state-init) calls
-// _alloc once, then per stateful op calls its construct symbol and _set. _get
-// (declared in op_state.h) reaches a slot from an op's runtime entry. Cleanup
-// walks the array via each object's deletor. OpState is opaque here.
-struct OpState;
+// _alloc once, then per stateful op calls its construct symbol; each construct
+// stores its built state via hipdnn_ep_op_state_set (plain C++, declared in
+// op_state.h, since it is bitcode-internal -- never called by generated IR).
+// _get (also in op_state.h) reaches a slot from an op's runtime entry. Cleanup
+// walks the array via each object's deletor.
 bool hipdnn_ep_op_states_alloc(RuntimeState *state, int64_t n);
-bool hipdnn_ep_op_state_set(RuntimeState *state, int32_t slot,
-                            struct OpState *value);
 
 // Device-side runtime error flag (set by kernels, observed by wrappers).
 // Intended for operators that detect runtime-invalid inputs on GPU (e.g. Range

--- a/lib/Runtime/mock/op_state_stubs.cpp
+++ b/lib/Runtime/mock/op_state_stubs.cpp
@@ -25,7 +25,8 @@ struct MockOpState : OpStateT<MockOpState> {};
 // in real/matmul_nbits.cpp); the mock owns no device memory.
 extern "C" int8_t hipdnn_ep_op_state_construct_matmul_nbits(RuntimeState *state,
                                                             int32_t slot) {
-  return MockOpState::create(state, slot);
+  hipdnn_ep_op_state_set(state, slot, MockOpState::create().release());
+  return 0;
 }
 
 // MatMul: real runtime holds a shared_ptr to a device-wide hipBLASLt algo
@@ -33,7 +34,8 @@ extern "C" int8_t hipdnn_ep_op_state_construct_matmul_nbits(RuntimeState *state,
 // resources.
 extern "C" int8_t hipdnn_ep_op_state_construct_matmul(RuntimeState *state,
                                                       int32_t slot) {
-  return MockOpState::create(state, slot);
+  hipdnn_ep_op_state_set(state, slot, MockOpState::create().release());
+  return 0;
 }
 
 // CausalConvWithState: real runtime owns a per-shape MIOpen descriptor/algo
@@ -42,14 +44,16 @@ extern "C" int8_t hipdnn_ep_op_state_construct_matmul(RuntimeState *state,
 extern "C" int8_t
 hipdnn_ep_op_state_construct_causal_conv_with_state(RuntimeState *state,
                                                     int32_t slot) {
-  return MockOpState::create(state, slot);
+  hipdnn_ep_op_state_set(state, slot, MockOpState::create().release());
+  return 0;
 }
 
 // GQA: real runtime owns a per-GEMM-shape hipBLASLt descriptor/algo cache
 // (GqaState in real/gqa.cpp); the mock owns no device/hipBLASLt resources.
 extern "C" int8_t hipdnn_ep_op_state_construct_gqa(RuntimeState *state,
                                                    int32_t slot) {
-  return MockOpState::create(state, slot);
+  hipdnn_ep_op_state_set(state, slot, MockOpState::create().release());
+  return 0;
 }
 
 // MultiHeadAttention: real runtime owns a per-GEMM-shape hipBLASLt
@@ -58,7 +62,8 @@ extern "C" int8_t hipdnn_ep_op_state_construct_gqa(RuntimeState *state,
 extern "C" int8_t
 hipdnn_ep_op_state_construct_multi_head_attention(RuntimeState *state,
                                                   int32_t slot) {
-  return MockOpState::create(state, slot);
+  hipdnn_ep_op_state_set(state, slot, MockOpState::create().release());
+  return 0;
 }
 
 // Activation (sigmoid/tanh/softplus): real runtime holds a shared_ptr to a
@@ -66,7 +71,8 @@ hipdnn_ep_op_state_construct_multi_head_attention(RuntimeState *state,
 // the mock owns no device/MIOpen resources.
 extern "C" int8_t hipdnn_ep_op_state_construct_activation(RuntimeState *state,
                                                           int32_t slot) {
-  return MockOpState::create(state, slot);
+  hipdnn_ep_op_state_set(state, slot, MockOpState::create().release());
+  return 0;
 }
 
 // MIOpen OpTensor (miopen.add): real runtime holds a shared_ptr to a
@@ -74,7 +80,8 @@ extern "C" int8_t hipdnn_ep_op_state_construct_activation(RuntimeState *state,
 // the mock owns no device/MIOpen resources.
 extern "C" int8_t hipdnn_ep_op_state_construct_optensor(RuntimeState *state,
                                                         int32_t slot) {
-  return MockOpState::create(state, slot);
+  hipdnn_ep_op_state_set(state, slot, MockOpState::create().release());
+  return 0;
 }
 
 // SimplifiedLayerNorm (rms_norm): real runtime holds a shared_ptr to a
@@ -82,7 +89,8 @@ extern "C" int8_t hipdnn_ep_op_state_construct_optensor(RuntimeState *state,
 // real/simplified_layer_norm.cpp); the mock owns no device/MIOpen resources.
 extern "C" int8_t hipdnn_ep_op_state_construct_t5norm(RuntimeState *state,
                                                       int32_t slot) {
-  return MockOpState::create(state, slot);
+  hipdnn_ep_op_state_set(state, slot, MockOpState::create().release());
+  return 0;
 }
 
 // SkipSimplifiedLayerNorm (skip_rms_norm): real runtime holds a shared_ptr to a
@@ -91,12 +99,14 @@ extern "C" int8_t hipdnn_ep_op_state_construct_t5norm(RuntimeState *state,
 // resources.
 extern "C" int8_t hipdnn_ep_op_state_construct_skip_t5norm(RuntimeState *state,
                                                            int32_t slot) {
-  return MockOpState::create(state, slot);
+  hipdnn_ep_op_state_set(state, slot, MockOpState::create().release());
+  return 0;
 }
 
 // Gemm: real runtime holds a shared_ptr to a device-wide hipBLASLt algo table
 // (GemmState in real/gemm.cpp); the mock owns no device/hipBLASLt resources.
 extern "C" int8_t hipdnn_ep_op_state_construct_gemm(RuntimeState *state,
                                                     int32_t slot) {
-  return MockOpState::create(state, slot);
+  hipdnn_ep_op_state_set(state, slot, MockOpState::create().release());
+  return 0;
 }

--- a/lib/Runtime/op_state.cpp
+++ b/lib/Runtime/op_state.cpp
@@ -6,9 +6,10 @@
 //
 // Runtime side of the op-state-slots design (see
 // docs/design/op-state-slots-design.md):
-//   * hipdnn_ep_op_states_alloc / _set / _get manage the per-session
-//     RuntimeState::op_states array. They keep the RuntimeState layout opaque
-//     to generated IR, which only ever calls these by symbol.
+//   * hipdnn_ep_op_states_alloc / _get / _set manage the per-session
+//     RuntimeState::op_states array, keeping its layout opaque to the op TUs.
+//     Generated IR calls only _alloc (and the per-op construct_<op>); _get and
+//     _set are reached from within the runtime bitcode, so _set is plain C++.
 //
 // The per-op constructors (hipdnn_ep_op_state_construct_<class>) live in each
 // op's runtime TU (e.g. the reference op `conv` in real/miopen.cpp), since
@@ -22,6 +23,7 @@
 #include "hipdnn_ep_runtime.h"
 #include "runtime_state_internal.h"
 
+#include <cassert>
 #include <cstdlib>
 
 extern "C" {
@@ -43,20 +45,6 @@ bool hipdnn_ep_op_states_alloc(RuntimeState *state, int64_t n) {
   return true;
 }
 
-// Store a constructed state into its slot. Bounds- and null-checked so it is
-// memory-safe even if allocation failed (num_op_states == 0) or the compiler
-// emits a bad slot/value. Returns true on success, false (no write) otherwise.
-bool hipdnn_ep_op_state_set(RuntimeState *state, int32_t slot, OpState *value) {
-  if (!state->op_states)
-    return false;
-  if (slot < 0 || slot >= state->num_op_states)
-    return false;
-  if (!value)
-    return false;
-  state->op_states[slot] = value;
-  return true;
-}
-
 void *hipdnn_ep_op_state_get(RuntimeState *state, int slot) {
   if (!state || !state->op_states)
     return nullptr;
@@ -66,6 +54,16 @@ void *hipdnn_ep_op_state_get(RuntimeState *state, int slot) {
 }
 
 } // extern "C"
+
+// Store a constructed state into its slot. Plain C++ (not a C-ABI symbol): the
+// only callers are the per-op construct_<op> functions inside the runtime
+// bitcode, never generated IR. They run only on the alloc-success path and pass
+// a compiler-assigned slot in [0, num_op_states), so the store cannot fail; the
+// assert just documents that contract for debug builds.
+void hipdnn_ep_op_state_set(RuntimeState *state, int32_t slot, OpState *value) {
+  assert(state->op_states && slot >= 0 && slot < state->num_op_states && value);
+  state->op_states[slot] = value;
+}
 
 // NOTE: per-op constructors (hipdnn_ep_op_state_construct_<class>) live in each
 // op's own runtime translation unit, not here, because their state typically

--- a/lib/Runtime/op_state.h
+++ b/lib/Runtime/op_state.h
@@ -38,46 +38,40 @@ struct OpState {
   void (*deletor)(OpState *) = nullptr;
 };
 
-// Opaque slot accessors (defined in op_state.cpp where RuntimeState is
-// complete). `_get` returns nullptr for an out-of-range slot or an
-// unconstructed one; `_set` bounds- and null-checks the store and returns true
-// on success. Generated IR never touches the slot array directly -- every state
-// stores itself through `_set` (see OpStateT::create), keeping the RuntimeState
-// layout opaque to both generated IR and op translation units.
+// Slot accessors. `hipdnn_ep_op_state_get` stays `extern "C"`: it is the opaque
+// reader (defined in op_state.cpp where RuntimeState is complete) and returns
+// nullptr for an out-of-range or unconstructed slot. `hipdnn_ep_op_state_set`
+// is plain C++ -- it is only ever called from within the runtime bitcode (by
+// the per-op construct_<op> functions), never by generated IR, so it needs no
+// C ABI and no failure path: the compiler always hands it a valid slot into an
+// already-allocated array. Together they keep the RuntimeState layout opaque to
+// the op translation units that include this header.
 extern "C" void *hipdnn_ep_op_state_get(RuntimeState *state, int slot);
-extern "C" bool hipdnn_ep_op_state_set(RuntimeState *state, int32_t slot,
-                                       OpState *value);
+void hipdnn_ep_op_state_set(RuntimeState *state, int32_t slot, OpState *value);
 
 // CRTP base for per-op state structs: derive `struct FooState :
 // OpStateT<FooState>`. The constructor wires `deletor` to destroy the concrete
-// type, so a derived state can never forget to set it. `get_slot` reaches the
-// instance from an operator's runtime entry, and `create` builds the state and
-// stores it into its slot.
+// type, so a derived state can never forget to set it. `get_op_state` reaches
+// this op's instance from its runtime entry; `create` builds an owning instance
+// that the construct_<op> function then stores into its slot.
 template <class T> struct OpStateT : OpState {
   OpStateT() {
     this->deletor = [](OpState *p) { delete static_cast<T *>(p); };
   }
 
   // Reach this op's state inside its runtime entry.
-  static T *get_slot(RuntimeState *state, int slot) {
+  static T *get_op_state(RuntimeState *state, int slot) {
     return static_cast<T *>(hipdnn_ep_op_state_get(state, slot));
   }
 
-  // Construct T and store it into op_states[slot]; returns 1 on success, 0 if
-  // the store is refused (alloc failed / out-of-range slot), freeing the object
-  // via its deletor so nothing leaks. Uses a throwing `new` (as the rest of the
-  // runtime does): the nothrow placement form pulls in `operator new(size_t,
-  // nothrow_t)` / `std::nothrow`, which are not resolvable when the runtime
-  // bitcode is JIT-linked into the EP process, so every model's global_ctors
-  // would fail to materialize.
-  template <class... Args>
-  static int8_t create(RuntimeState *state, int32_t slot, Args &&...args) {
-    T *st = new T(std::forward<Args>(args)...);
-    if (!hipdnn_ep_op_state_set(state, slot, st)) {
-      st->deletor(st);
-      return 0;
-    }
-    return 1;
+  // Build an owning T. The caller (construct_<op>) hands the released pointer
+  // to hipdnn_ep_op_state_set. Uses a throwing `new` (as the rest of the
+  // runtime does): the nothrow form pulls in `operator new(size_t, nothrow_t)`
+  // / `std::nothrow`, which are not resolvable when the runtime bitcode is
+  // JIT-linked into the EP process, so every model's global_ctors would fail to
+  // materialize.
+  template <class... Args> static std::unique_ptr<T> create(Args &&...args) {
+    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
   }
 };
 

--- a/lib/Runtime/real/activation.cpp
+++ b/lib/Runtime/real/activation.cpp
@@ -126,7 +126,8 @@ struct ActivationState : OpStateT<ActivationState> {
 
 extern "C" int8_t hipdnn_ep_op_state_construct_activation(RuntimeState *state,
                                                           int32_t slot) {
-  return ActivationState::create(state, slot);
+  hipdnn_ep_op_state_set(state, slot, ActivationState::create().release());
+  return 0;
 }
 
 static const ActivationCacheEntry *
@@ -246,7 +247,7 @@ int wrap_miopenActivationForward(RuntimeState *state, int op_state_slot,
     return -1;
   }
 
-  ActivationState *as = ActivationState::get_slot(state, op_state_slot);
+  ActivationState *as = ActivationState::get_op_state(state, op_state_slot);
   if (!as || !as->table) {
     fprintf(stderr,
             "[REAL] wrap_miopenActivationForward: missing op-state for slot "

--- a/lib/Runtime/real/causal_conv_with_state.cpp
+++ b/lib/Runtime/real/causal_conv_with_state.cpp
@@ -193,7 +193,8 @@ struct CausalConvState : OpStateT<CausalConvState> {
 extern "C" int8_t
 hipdnn_ep_op_state_construct_causal_conv_with_state(RuntimeState *state,
                                                     int32_t slot) {
-  return CausalConvState::create(state, slot);
+  hipdnn_ep_op_state_set(state, slot, CausalConvState::create().release());
+  return 0;
 }
 
 // SiLU(x) = x * sigmoid(x) = x / (1 + exp(-x))
@@ -345,7 +346,7 @@ int wrap_causal_conv_with_state(RuntimeState *state, int op_state_slot,
                     bias ? 1 : 0,
                     activation};
 
-  CausalConvState *ccs = CausalConvState::get_slot(state, op_state_slot);
+  CausalConvState *ccs = CausalConvState::get_op_state(state, op_state_slot);
   if (!ccs) {
     fprintf(stderr,
             "wrap_causal_conv_with_state: no CausalConvState at slot %d\n",

--- a/lib/Runtime/real/elementwise.cpp
+++ b/lib/Runtime/real/elementwise.cpp
@@ -175,7 +175,8 @@ struct OpTensorState : OpStateT<OpTensorState> {
 
 extern "C" int8_t hipdnn_ep_op_state_construct_optensor(RuntimeState *state,
                                                         int32_t slot) {
-  return OpTensorState::create(state, slot);
+  hipdnn_ep_op_state_set(state, slot, OpTensorState::create().release());
+  return 0;
 }
 
 /// Look up or create cached MIOpen tensor descriptors for an OpTensor shape.
@@ -634,7 +635,7 @@ int wrap_miopenOpTensor(RuntimeState *state, int op_state_slot, void *lhs,
     }
   }
 
-  OpTensorState *os = OpTensorState::get_slot(state, op_state_slot);
+  OpTensorState *os = OpTensorState::get_op_state(state, op_state_slot);
   if (!os || !os->table) {
     fprintf(stderr, "wrap_miopenOpTensor: missing op-state for slot %d\n",
             op_state_slot);

--- a/lib/Runtime/real/gemm.cpp
+++ b/lib/Runtime/real/gemm.cpp
@@ -123,7 +123,8 @@ struct GemmState : OpStateT<GemmState> {
 
 extern "C" int8_t hipdnn_ep_op_state_construct_gemm(RuntimeState *state,
                                                     int32_t slot) {
-  return GemmState::create(state, slot);
+  hipdnn_ep_op_state_set(state, slot, GemmState::create().release());
+  return 0;
 }
 
 // =============================================================================
@@ -510,7 +511,7 @@ int wrap_gemm(RuntimeState *state, int op_state_slot, const void *A,
     return -1;
   }
 
-  GemmState *gs = GemmState::get_slot(state, op_state_slot);
+  GemmState *gs = GemmState::get_op_state(state, op_state_slot);
   if (!gs || !gs->table) {
     fprintf(stderr, "wrap_gemm: missing op-state for slot %d\n", op_state_slot);
     return -1;

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -348,7 +348,7 @@ struct GqaState : OpStateT<GqaState> {
 // nullptr when the slot is unconstructed (init failure) — callers propagate the
 // error rather than lazily allocating, since the slot is built at session init.
 static GqaGemmCache *get_gemm_cache(RuntimeState *state, int op_state_slot) {
-  GqaState *gs = GqaState::get_slot(state, op_state_slot);
+  GqaState *gs = GqaState::get_op_state(state, op_state_slot);
   return gs ? &gs->cache : nullptr;
 }
 
@@ -1572,5 +1572,6 @@ GqaGemmCache::~GqaGemmCache() {
 // construct fn stores the state into op_states[slot] itself.
 extern "C" int8_t hipdnn_ep_op_state_construct_gqa(RuntimeState *state,
                                                    int32_t slot) {
-  return GqaState::create(state, slot);
+  hipdnn_ep_op_state_set(state, slot, GqaState::create().release());
+  return 0;
 }

--- a/lib/Runtime/real/matmul.cpp
+++ b/lib/Runtime/real/matmul.cpp
@@ -145,7 +145,8 @@ struct MatmulState : OpStateT<MatmulState> {
 
 extern "C" int8_t hipdnn_ep_op_state_construct_matmul(RuntimeState *state,
                                                       int32_t slot) {
-  return MatmulState::create(state, slot);
+  hipdnn_ep_op_state_set(state, slot, MatmulState::create().release());
+  return 0;
 }
 
 static MatmulCacheEntry *queryOrCreateMatmul(MatmulAlgoTable &table,
@@ -474,7 +475,7 @@ int wrap_hipblasLtMatmul(RuntimeState *state, int op_state_slot, const void *A,
                     (long long)elem_size, type_name,
                     (long long)(batch_count * M * N * elem_size));
 
-  MatmulState *ms = MatmulState::get_slot(state, op_state_slot);
+  MatmulState *ms = MatmulState::get_op_state(state, op_state_slot);
   if (!ms || !ms->table) {
     fprintf(stderr, "wrap_hipblasLtMatmul: missing op-state for slot %d\n",
             op_state_slot);

--- a/lib/Runtime/real/matmul_nbits.cpp
+++ b/lib/Runtime/real/matmul_nbits.cpp
@@ -137,7 +137,8 @@ struct MatmulNbitsState : OpStateT<MatmulNbitsState> {
 
 extern "C" int8_t hipdnn_ep_op_state_construct_matmul_nbits(RuntimeState *state,
                                                             int32_t slot) {
-  return MatmulNbitsState::create(state, slot);
+  hipdnn_ep_op_state_set(state, slot, MatmulNbitsState::create().release());
+  return 0;
 }
 
 int wrap_matmul_nbits(RuntimeState *state, int op_state_slot, const void *A,
@@ -187,7 +188,8 @@ int wrap_matmul_nbits(RuntimeState *state, int op_state_slot, const void *A,
   const void *pre_zp_u8 = nullptr;
   const void *pre_zp_fp16 = nullptr;
   if (zero_points && zp_elem_size == 1 && bits == 4 && block_size > 0) {
-    MatmulNbitsState *mst = MatmulNbitsState::get_slot(state, op_state_slot);
+    MatmulNbitsState *mst =
+        MatmulNbitsState::get_op_state(state, op_state_slot);
     if (!mst) {
       fprintf(stderr, "wrap_matmul_nbits: no MatmulNbitsState at slot %d\n",
               op_state_slot);

--- a/lib/Runtime/real/multi_head_attention.cpp
+++ b/lib/Runtime/real/multi_head_attention.cpp
@@ -143,7 +143,7 @@ struct MhaState : OpStateT<MhaState> {
 // nullptr when the slot is unconstructed (init failure) — callers propagate the
 // error rather than lazily allocating, since the slot is built at session init.
 MhaGemmCache *get_mha_gemm_cache(RuntimeState *state, int op_state_slot) {
-  MhaState *ms = MhaState::get_slot(state, op_state_slot);
+  MhaState *ms = MhaState::get_op_state(state, op_state_slot);
   return ms ? &ms->cache : nullptr;
 }
 
@@ -303,7 +303,8 @@ MhaGemmCache::~MhaGemmCache() {
 extern "C" int8_t
 hipdnn_ep_op_state_construct_multi_head_attention(RuntimeState *state,
                                                   int32_t slot) {
-  return MhaState::create(state, slot);
+  hipdnn_ep_op_state_set(state, slot, MhaState::create().release());
+  return 0;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Runtime/real/simplified_layer_norm.cpp
+++ b/lib/Runtime/real/simplified_layer_norm.cpp
@@ -94,7 +94,8 @@ struct T5NormState : OpStateT<T5NormState> {
 
 extern "C" int8_t hipdnn_ep_op_state_construct_t5norm(RuntimeState *state,
                                                       int32_t slot) {
-  return T5NormState::create(state, slot);
+  hipdnn_ep_op_state_set(state, slot, T5NormState::create().release());
+  return 0;
 }
 
 static const T5NormCacheEntry *queryOrCreateT5Norm(T5NormTable &table,
@@ -236,7 +237,7 @@ int wrap_miopenT5LayerNormForward(RuntimeState *state, int op_state_slot,
     return -1;
   }
 
-  T5NormState *ns = T5NormState::get_slot(state, op_state_slot);
+  T5NormState *ns = T5NormState::get_op_state(state, op_state_slot);
   if (!ns || !ns->table) {
     fprintf(stderr,
             "wrap_miopenT5LayerNormForward: missing op-state for slot %d\n",

--- a/lib/Runtime/real/skip_simplified_layer_norm.cpp
+++ b/lib/Runtime/real/skip_simplified_layer_norm.cpp
@@ -100,7 +100,8 @@ struct SkipT5NormState : OpStateT<SkipT5NormState> {
 
 extern "C" int8_t hipdnn_ep_op_state_construct_skip_t5norm(RuntimeState *state,
                                                            int32_t slot) {
-  return SkipT5NormState::create(state, slot);
+  hipdnn_ep_op_state_set(state, slot, SkipT5NormState::create().release());
+  return 0;
 }
 
 static const SkipT5NormCacheEntry *
@@ -264,7 +265,7 @@ int wrap_skip_simplified_layer_norm(RuntimeState *state, int op_state_slot,
     return -1;
   }
 
-  SkipT5NormState *ns = SkipT5NormState::get_slot(state, op_state_slot);
+  SkipT5NormState *ns = SkipT5NormState::get_op_state(state, op_state_slot);
   if (!ns || !ns->table) {
     fprintf(stderr,
             "wrap_skip_simplified_layer_norm: missing op-state for slot %d\n",

--- a/test/lit/Transforms/GenerateOpStateInit/gen_init_activation.mlir
+++ b/test/lit/Transforms/GenerateOpStateInit/gen_init_activation.mlir
@@ -9,7 +9,7 @@
 // hip.sigmoid / hip.tanh / hip.softplus). The constructor takes no compile-time
 // args. The generated init must (1) allocate the slot array and (2) call
 // hipdnn_ep_op_state_construct_activation with slot 0, which stores the state
-// into op_states[0] itself and returns an i8 ok flag. See
+// into op_states[0] itself and returns an i8 status (vestigial, always 0). See
 // docs/design/op-state-slots-design.md.
 // ============================================================================
 

--- a/test/lit/Transforms/GenerateOpStateInit/gen_init_gemm.mlir
+++ b/test/lit/Transforms/GenerateOpStateInit/gen_init_gemm.mlir
@@ -9,7 +9,7 @@
 // compile-time args (the algo cache fills lazily per GEMM shape). The generated
 // init must allocate the slot array, then call hipdnn_ep_op_state_construct_gemm
 // with slot 0, which stores the state into op_states[0] itself and returns an
-// i8 ok flag. See docs/design/op-state-slots-design.md.
+// i8 status (vestigial, always 0). See docs/design/op-state-slots-design.md.
 // ============================================================================
 
 // RUN: hip-mlir-opt %s --assign-op-state-slots --generate-op-state-init | FileCheck %s

--- a/test/lit/Transforms/GenerateOpStateInit/gen_init_matmul_nbits.mlir
+++ b/test/lit/Transforms/GenerateOpStateInit/gen_init_matmul_nbits.mlir
@@ -8,7 +8,7 @@
 // fills lazily per call, so the constructor takes no compile-time args. The
 // generated init must (1) allocate the slot array and (2) call
 // hipdnn_ep_op_state_construct_matmul_nbits with slot 0, which stores the state
-// into op_states[0] itself and returns an i8 ok flag. See
+// into op_states[0] itself and returns an i8 status (vestigial, always 0). See
 // docs/design/op-state-slots-design.md.
 // ============================================================================
 

--- a/test/lit/Transforms/GenerateOpStateInit/gen_init_rms_norm.mlir
+++ b/test/lit/Transforms/GenerateOpStateInit/gen_init_rms_norm.mlir
@@ -8,7 +8,7 @@
 // descriptor table (shared across sessions via WeakStore). The constructor
 // takes no compile-time args. The generated init must allocate the slot array,
 // then call hipdnn_ep_op_state_construct_t5norm with slot 0, which stores the
-// state into op_states[0] itself and returns an i8 ok flag. See
+// state into op_states[0] itself and returns an i8 status (vestigial, always 0). See
 // docs/design/op-state-slots-design.md.
 // ============================================================================
 

--- a/test/lit/Transforms/GenerateOpStateInit/gen_init_skip_rms_norm.mlir
+++ b/test/lit/Transforms/GenerateOpStateInit/gen_init_skip_rms_norm.mlir
@@ -8,7 +8,7 @@
 // MIOpen descriptor table (shared across sessions via WeakStore). The
 // constructor takes no compile-time args. The generated init must allocate the
 // slot array, then call hipdnn_ep_op_state_construct_skip_t5norm with slot 0,
-// which stores the state into op_states[0] itself and returns an i8 ok flag.
+// which stores the state into op_states[0] itself and returns an i8 status (vestigial, always 0).
 // See docs/design/op-state-slots-design.md.
 // ============================================================================
 


### PR DESCRIPTION
## Summary

Implements the reviewer feedback on the op-state-slots API, tightening the boundary between the runtime bitcode and generated IR without changing the construct ABI or the emitted IR.

- `OpStateT::create()` now returns an owning `std::unique_ptr<T>` (with `deletor` already wired) instead of constructing-and-storing internally. Each `construct_<op>` hands the released pointer to the setter and returns `0`.
- `hipdnn_ep_op_state_set` is now plain C++ returning `void` (was `extern "C"` returning `bool`). It is only ever called from within the runtime bitcode by the `construct_<op>` functions, never by generated IR, so it needs no C ABI and no failure path; a debug `assert` documents the slot-validity contract.
- Renamed `OpStateT::get_slot` -> `get_op_state` for consistency with the setter/getter naming.
- Removed the redundant `hipdnn_ep_op_state_set` declaration in `hipdnn_ep_runtime.h` that conflicted with the `op_state.h` declaration (it was the source of the ambiguous-call build break).
- Updated all 10 real + 10 mock `construct_<op>` functions to the `set(state, slot, X::create().release())` form.
- Updated the MLIR-side comments (`HipOpStateInterface.td`/`.cpp`, `HipDialect.h`, `GenerateOpStateInit.cpp`), the design doc, and the `gen_init` lit test comments to reflect that the `construct_<op>` i8 result is now vestigial (always `0`) and that the store has no failure path.

No functional change: the `construct_<op>` ABI signature `(RuntimeState*, i32 slot, i64...) -> i8` and the generated IR are unchanged; the i8 is kept for a stable call signature and is not branched on.

## Test plan

- [x] `lintrunner` (clang-format / ruff): clean
- [x] Build under `vcvars64` (ninja, TheRock HIP SDK): clean
- [x] LIT suite: 277/277 pass
- [x] GPU numeric suite (EP DLL refreshed): 337 passed, 31 pre-existing failures unchanged vs `main` (no regressions)
- [ ] CI green on this PR
