### PR TITLE
docs(quick-start): align with hipep rename and dynamic-shape flow

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -187,21 +187,20 @@ python build.py --install_dir "$LOCAL_DIR" --cmake_prefix_path "$LOCAL_DIR"
 ```
 
 `--cmake_prefix_path "$LOCAL_DIR"` lets the build reuse an ONNX Runtime you
-installed in step 1; omit it and ORT is auto-downloaded. The MorphiZen EP, HIP
+installed in step 1; omit it and ORT is auto-downloaded. The hipep EP, HIP
 tools and LIT tests are built and installed into `../local/`.
 
 ### 3. Build OGA (onnxruntime-genai)
 
 OGA (ONNX Runtime GenAI) provides the generative-pipeline runtime used by
 `model_benchmark.exe` (and the Python `onnxruntime_genai` module) to drive
-prefill + decode token generation against models prepared via the [ONNX
-Model Splitter](../tools/onnx-model-splitter/README.md). Build it after
-step 1 (ORT) so it links against the same ORT version.
+prefill + decode token generation. Build it after step 1 (ORT) so it links
+against the same ORT version.
 
 **Prerequisites**: a local ORT install for `ORT_HOME` (build it in step 1, or
 stage the release zip). `--build_wheel` is only needed if you also want the ORT
 Python wheel (step 4); it is not required to build OGA's C++ artifacts. Step 2
-is only needed later to *run* `model_benchmark` against MorphiZen EP, not to
+is only needed later to *run* `model_benchmark` against hipep EP, not to
 build OGA itself.
 
 Run all commands below from the `onnx-hipdnn-ep/` project root.
@@ -224,15 +223,22 @@ cp "$LOCAL_DIR/bin/onnxruntime_providers_shared.dll" "$ORT_HOME/lib/"
 
 ```bash
 cd ..  # Go to workspace directory (sibling of onnx-hipdnn-ep)
-git clone -b feat/oga_hipdnn_experiment https://github.com/AMDmoore/onnxruntime-genai.git
+git clone -b v0.14.0 https://github.com/microsoft/onnxruntime-genai.git
 cd onnxruntime-genai
 git submodule update --init --recursive
+
+# Apply the AMDGPU integration PR on top of the upstream tag. pull/<n>.patch is
+# a format-patch series (it renames src/morphizen_ep -> src/amdgpu mid-series),
+# so apply it with `git am` -- `git apply` flattens the series and fails on the
+# rename whose pre-image only exists after an earlier commit.
+curl -fsSL https://github.com/microsoft/onnxruntime-genai/pull/2194.patch -o /tmp/oga-2194.patch
+git am --3way --whitespace=nowarn /tmp/oga-2194.patch
 ```
 
-> **Note**: CI pins a specific commit (see `OGA_REF` in
-> [`.github/workflows/windows-build.yml`](../.github/workflows/windows-build.yml)).
-> If you want byte-for-byte reproducibility, check out that commit instead of
-> the branch tip.
+> **Note**: the upstream tag + PR list are pinned in CI via `OGA_VERSION` and
+> `OGA_PR_PATCHES` in
+> [`.github/workflows/windows-build.yml`](../.github/workflows/windows-build.yml);
+> match those for byte-for-byte reproducibility.
 
 #### 3c. Build OGA
 
@@ -281,7 +287,7 @@ below. `onnxruntime_perf_test.exe` is staged separately in
 
 If you also want to drive ORT / OGA from Python (e.g. to write your own
 generation script instead of using `model_benchmark.exe`), install the wheels.
-The MorphiZen EP wheel is built by default by `build.py` (pass `--skip_wheel` to
+The hipep EP wheel is built by default by `build.py` (pass `--skip_wheel` to
 opt out, or build just it with `cmake --build <build> --target wheel`) at
 `../build/onnx-hipdnn-ep/python/dist/`.
 
@@ -292,16 +298,18 @@ builds, not the stock PyPI ones), and let `--extra-index-url` resolve ROCm:
 cd ../onnx-hipdnn-ep  # Back to the project root
 pip install \
   ../build/onnxruntime/Release/dist/onnxruntime_directml-*.whl \
-  ../build/onnx-hipdnn-ep/python/dist/onnxruntime_morphizen_ep-*.whl \
+  ../build/onnx-hipdnn-ep/python/dist/onnxruntime_ep_hipep-*.whl \
   ../build/onnxruntime-genai/Release/wheel/onnxruntime_genai_directml-*.whl \
   --extra-index-url https://repo.amd.com/rocm/whl/gfx1151/
 ```
 > **Note**: the ORT whl may be under `../build/onnxruntime/Release/Release/dist/`.
 > Replace `gfx1151` with your GPU arch. Install the EP wheel AFTER onnxruntime:
-> it ships its own native files (EP plugin, hip-compiler, custom kernels, CRT
-> import libs) straight into `onnxruntime/capi/` next to `onnxruntime.dll`. The
-> ROCm JIT import libs (amdhip64/MIOpen/hipBLASLt) come from the `rocm[devel]`
-> wheel (expanded next).
+> it ships its own native files (EP plugin `hipep.dll`, hip-compiler, custom
+> kernels) straight into `onnxruntime/capi/` next to `onnxruntime.dll`. The ROCm
+> runtime DLLs (amdhip64/MIOpen/hipBLASLt) come from the `rocm[devel]` wheel
+> (expanded next). The wheel does NOT bundle the AMD GPU umbrella
+> (`amdgpu-ep.dll` + `hipep-backend.dll`); driving OGA through the umbrella needs
+> those supplied separately (CI injects them via `HIPEP_WHEEL_EXTRA_DLLS`).
 
 **Expand ROCm devel** -- the EP's JIT linker needs the ROCm import libs, which
 `rocm[devel]` ships compressed. Expand them once:
@@ -310,29 +318,25 @@ pip install \
 rocm-sdk init   # populates site-packages/_rocm_sdk_devel/lib
 ```
 
-**Lib search paths** -- the per-model JIT link step resolves import libs from two
-places, supplied via env vars before running:
+**Runtime env** -- depends on the artifact mode:
 
-- `THEROCK_DIST` -> the ROCm lib root (`<site-packages>/_rocm_sdk_devel`, or a
-  TheRock SDK for dev builds); supplies `amdhip64`/`MIOpen`/`hipBLASLt`.
-- `LIB` (Windows) -> append `<onnxruntime/capi>`; supplies the colocated CRT and
-  `hip_custom_kernels` import libs.
+- Default (bitcode): the ROCm runtime DLLs on `PATH`.
+- NATIVE artifact (opt-in): the above plus `THEROCK_DIST` and `LIB`, used by the
+  lld-link step that builds the per-model `.dll`.
 
 **Use** -- there is no Python API to import; the native files are found by
-location. Set the env vars and run a model whose `genai_config.json` names the
-provider `MorphiZenEP`. This is exactly what the CI wheel smoke does (`Run OGA
-wheel smoke (Python)` in `.github/workflows/windows-build.yml`):
+location. Run a model whose `genai_config.json` selects the EP via
+`provider_options`; OGA discovers the colocated EP automatically. This is what
+the CI wheel smoke does (`Run OGA wheel smoke (Python)` in
+`.github/workflows/windows-build.yml`):
 
 ```bash
 # site-packages root + the colocated capi dir
 SP=$(python -c "import onnxruntime, os; print(os.path.dirname(os.path.dirname(onnxruntime.__file__)))")
 CAPI="$SP/onnxruntime/capi"
 
-# JIT link: ROCm import libs from rocm[devel]; CRT + custom kernels from capi
-export THEROCK_DIST="$SP/_rocm_sdk_devel"
-export LIB="$CAPI"                      # Windows; ';'-separated if appending
-# Runtime DLLs: EP + hip-compiler (capi) and ROCm (rocm wheel bins) on PATH
-# (replace gfx1151 with your GPU arch)
+# Default (bitcode): the ROCm runtime DLLs + colocated capi on PATH.
+# Replace gfx1151 with your GPU arch.
 export PATH="$CAPI:$SP/_rocm_sdk_core/bin:$SP/_rocm_sdk_libraries_gfx1151/bin:$PATH"
 
 # Run OGA's own end-to-end benchmark from the OGA source cloned in step 3
@@ -341,60 +345,27 @@ python onnxruntime-genai/benchmark/python/benchmark_e2e.py \
 ```
 
 `benchmark_e2e.py` runs with the default `-e follow_config`, so the model's
-`genai_config.json` must list `MorphiZenEP`; OGA then discovers the colocated EP
-automatically. For plain ORT, register the colocated plugin via
-`ort.register_execution_provider_library("MorphiZenEP", "$CAPI/onnxruntime_morphizen_ep.dll")`.
-
-## Model Preparation
-
-Please See
-[tools/onnx-model-splitter/README.md](../tools/onnx-model-splitter/README.md) for full details of this step.
-In this document, there is a step by step guide which use Llama-3.1-8B as example.
-
-Use `tools/onnx-model-splitter` to export prefill/decode ONNX models for
-benchmarking with ONNX Runtime GenAI. Install Python dependencies first:
-
-```bash
-pip install -r tools/onnx-model-splitter/requirements.txt
-```
-
-**Step 1 — Generate `genai_config_pipeline.json`:**
-
-```bash
-python tools/onnx-model-splitter/genai_config_pipeline_from_folder.py \
-  /path/to/model_folder \
-  --max-length 16384
-```
-
-This reads the model's config (e.g. `config.json`) and produces
-`genai_config_pipeline.json` in the model folder.
-
-**Step 2 — Export prefill/decode ONNX:**
-
-```bash
-python tools/onnx-model-splitter/export_chunk_model.py \
-  --model /path/to/model_folder/model.onnx \
-  --output /path/to/output \
-  -T /path/to/model_folder/genai_config_pipeline.json
-```
-
-This exports `prefill_p512m16384.onnx`, `decode_p512m16384.onnx`,
-`genai_config_p512m16384.json`, and shared external weights into the output
-directory.
+`genai_config.json` selects the EP via `provider_options`. With the upstream OGA
+(v0.14.0 + PR2194, DeviceType AMDGPU) this is the AMD GPU umbrella
+(`provider_options [{ "AMDGPU": {"profile": "llm"} }]`), which loads
+`amdgpu-ep.dll` and needs the umbrella DLLs colocated (see
+`.github/workflows/windows-build.yml`); the default wheel ships only the hipep
+chain. For plain ORT (direct hipep, no OGA), register the colocated plugin via
+`ort.register_execution_provider_library("hipep", "$CAPI/hipep.dll")`.
 
 ## Testing & Benchmarking
 
 ### Model Inference with hip-onnx-runner
 
-`hip-onnx-runner` runs a single ONNX model through MorphiZen EP and reports
+`hip-onnx-runner` runs a single ONNX model through hipep EP and reports
 timing. It is built automatically when `BUILD_HIP_TOOLS=ON`.
 
 ```bash
 # first cd to your onnx-hipdnn-ep directory
-# TheRock auto-downloaded by the build lives under the build dir; if you passed
-# your own -DTHEROCK_DIST, point at that path instead.
-export THEROCK_DIST=$(cd ../build/$(basename $PWD)/_therock && pwd)
-export PATH="$THEROCK_DIST/bin:$LOCAL_DIR/bin:$PATH"
+# Default (bitcode) needs the ROCm runtime DLLs on PATH; TheRock's bin is under
+# the build dir (or your own -DTHEROCK_DIST path). NATIVE artifacts additionally
+# use THEROCK_DIST + LIB for the lld-link step.
+export PATH="$(cd ../build/$(basename $PWD)/_therock/bin && pwd):$LOCAL_DIR/bin:$PATH"
 ```
 
 > **Note**: `hip-onnx-runner.exe` feeds the model random input by default. For an
@@ -406,14 +377,17 @@ export PATH="$THEROCK_DIST/bin:$LOCAL_DIR/bin:$PATH"
 > ```
 
 ```bash
-# Run with MorphiZen EP (default), using a fixed-shape model from Model Preparation
-$LOCAL_DIR/bin/hip-onnx-runner.exe -m /path/to/output/prefill_p512m16384.onnx -i gen_inputs
+# Run with hipep EP (default), on your model directly (dynamic shape)
+$LOCAL_DIR/bin/hip-onnx-runner.exe -m /path/to/model.onnx -i gen_inputs
+
+# Resolve symbolic input dims at runtime (the EP still compiles the dynamic graph)
+$LOCAL_DIR/bin/hip-onnx-runner.exe -m /path/to/model.onnx -i gen_inputs -f sequence_length:128
 
 # Run with CPU only (no EP)
-$LOCAL_DIR/bin/hip-onnx-runner.exe -m /path/to/output/prefill_p512m16384.onnx -n -i gen_inputs
+$LOCAL_DIR/bin/hip-onnx-runner.exe -m /path/to/model.onnx -n -i gen_inputs
 
 # Dump outputs for comparison
-$LOCAL_DIR/bin/hip-onnx-runner.exe -m /path/to/output/prefill_p512m16384.onnx -i gen_inputs -d 2
+$LOCAL_DIR/bin/hip-onnx-runner.exe -m /path/to/model.onnx -i gen_inputs -d 2
 
 # L2-norm compare EP vs CPU outputs
 $LOCAL_DIR/bin/hip-onnx-runner.exe -L ep_o_dump,cpu_o_dump
@@ -427,12 +401,13 @@ $LOCAL_DIR/bin/hip-onnx-runner.exe -L ep_o_dump,cpu_o_dump
 | `-n` | CPU only, skip EP registration |
 | `-d 0\|1\|2\|3` | Dump level: 0=off, 1=inputs, 2=outputs, 3=both |
 | `-i <dir>` | Load inputs from directory instead of random |
+| `-f <name>:<val>` | Resolve a symbolic input dim at runtime (repeatable/comma-separated); EP still compiles the dynamic graph, unmatched symbolic dims default to 1 |
 | `-L dir1,dir2` | L2-norm comparison of two output directories |
 
 ### Latency Benchmarking with onnxruntime_perf_test
 
 Use `onnxruntime_perf_test` to benchmark inference latency. The examples below
-compare MorphiZen EP (AMD GPU via HIP) against DML EP.
+compare hipep EP (AMD GPU via HIP) against DML EP.
 
 **Setup:**
 
@@ -442,22 +417,21 @@ default. Copy it into `../local/bin` before running:
 ```bash
 cp ../build/onnxruntime/Release/Release/onnxruntime_perf_test.exe $LOCAL_DIR/bin/
 
-# TheRock auto-downloaded by the build lives under the build dir; if you passed
-# your own -DTHEROCK_DIST, point at that path instead.
-export THEROCK_DIST=$(cd ../build/$(basename $PWD)/_therock && pwd)
-export PATH="$THEROCK_DIST/bin:$PATH"
+# Default (bitcode) needs the ROCm runtime DLLs on PATH; TheRock's bin is under
+# the build dir (or your own -DTHEROCK_DIST path). NATIVE artifacts additionally
+# use THEROCK_DIST + LIB for the lld-link step.
+export PATH="$(cd ../build/$(basename $PWD)/_therock/bin && pwd):$PATH"
 cd $LOCAL_DIR/bin
 ```
 
-**MorphiZen EP:**
+**hipep EP:**
 
 ```bash
 ./onnxruntime_perf_test.exe \
-  --plugin_ep_libs "MorphiZenEP|onnxruntime_morphizen_ep.dll" \
-  --plugin_eps "MorphiZenEP" \
-  --plugin_ep_options "config_file|morphizen_config.json" \
+  --plugin_ep_libs "hipep|hipep.dll" \
+  --plugin_eps "hipep" \
   -t 60 -c 1 -s -I \
-  /path/to/output/prefill_p512m16384.onnx
+  /path/to/model.onnx
 ```
 
 **DML EP:**
@@ -467,7 +441,7 @@ cd $LOCAL_DIR/bin
   -e dml \
   -C "ep.dml.disable_graph_fusion|1" \
   -t 60 -c 1 -s -I \
-  /path/to/output/prefill_p512m16384.onnx
+  /path/to/model.onnx
 ```
 
 **Key flags:**
@@ -483,21 +457,27 @@ cd $LOCAL_DIR/bin
 
 `model_benchmark` benchmarks the full generative pipeline (prefill + decode
 token generation). It was built and installed into `$LOCAL_DIR/bin/` in
-[step 3](#3-build-oga-onnxruntime-genai).  Before running, please copy the
-tokenizer related files from original model directory to /path/to/output
+[step 3](#3-build-oga-onnxruntime-genai). Point `-i` at an OGA model directory
+(the one containing `genai_config.json`); make sure its tokenizer files are
+present there too.
+
+The EP is selected by the model's `genai_config.json` `provider_options` and
+auto-discovered next to `onnxruntime-genai.dll` -- do NOT pass `--ep_library`
+(upstream `model_benchmark` rejects it). With the upstream OGA (v0.14.0 +
+PR2194) the EP is the AMD GPU umbrella (`provider_options [{ "AMDGPU":
+{"profile": "llm"} }]`), so `amdgpu-ep.dll` must sit next to the OGA DLLs (see
+`.github/workflows/windows-build.yml`).
 
 ```bash
 # Auto-generated prompt (512 tokens)
 ./model_benchmark.exe \
-  -i /path/to/output \
-  --ep_library MorphiZenEP onnxruntime_morphizen_ep.dll \
+  -i /path/to/oga_model_dir \
   -l 512 -g 128 \
   -r 5 -w 1
 
 # Prompt from file
 ./model_benchmark.exe \
-  -i /path/to/output \
-  --ep_library MorphiZenEP onnxruntime_morphizen_ep.dll \
+  -i /path/to/oga_model_dir \
   --prompt_file /path/to/prompt.txt -g 128 \
   -r 5 -w 1
 ```
@@ -507,7 +487,6 @@ tokenizer related files from original model directory to /path/to/output
 | Flag | Description |
 |------|-------------|
 | `-i <path>` | Path to OGA model directory (with `genai_config.json`) |
-| `--ep_library <name> <path>` | Register a custom EP library |
 | `-l <n>` | The number of auto-generated prompts (exclusive with `--prompt_file`) |
 | `--prompt_file <path>` | Load prompt text from a file (exclusive with `-l`) |
 | `-g <n>` | Max number of tokens to generate |

--- a/docs/quick_start_linux.md
+++ b/docs/quick_start_linux.md
@@ -81,7 +81,7 @@ python3 build.py
 The result tree under `<workspace>/install/`:
 
 - `bin/hip-onnx-runner`, `bin/hip-compiler`, `bin/hip-mlir-opt`, `bin/hip-test`
-- `lib/libhip-compiler.so`, `lib/libonnxruntime_morphizen_ep.so`
+- `lib/libhip-compiler.so`, `lib/libhipep.so`
 
 A locally-built `install/` is **not** fully self-contained: `libonnxruntime.so`
 lives in the ONNX Runtime prefix and the ROCm libs in TheRock, so run with
@@ -99,7 +99,7 @@ section once `install/bin/` is populated.
 ## Use the prebuilt package (testers, no compile)
 
 A ready-to-run package is published for each green build. It contains every
-`.so` / binary the host needs (`libonnxruntime_morphizen_ep`,
+`.so` / binary the host needs (`libhipep`,
 `hip-onnx-runner`, `onnxruntime_perf_test`, `model_benchmark`,
 `libonnxruntime`, `libonnxruntime-genai`) plus a `clang`/`lld` toolchain in
 `bin/` (next to the other tools). TheRock is **not** included — install ROCm on
@@ -169,7 +169,7 @@ export LIBRARY_PATH="$ROOT/lib:$THEROCK_DIST/lib"
 export PATH="$ROOT/bin:$PATH"
 
 # Sanity check
-ldd "$ROOT/lib/libonnxruntime_morphizen_ep.so" | grep "not found"   # expect empty
+ldd "$ROOT/lib/libhipep.so" | grep "not found"   # expect empty
 "$ROOT/bin/hip-onnx-runner" --help | head -5
 ```
 
@@ -178,17 +178,11 @@ ldd "$ROOT/lib/libonnxruntime_morphizen_ep.so" | grep "not found"   # expect emp
 host workspace path. Every command below uses `$ROOT/bin/<tool>`
 exclusively, so the snippets are identical regardless of entry path.
 
-## Model Preparation
-
-Same as the Windows guide — see
-[quick_start.md "Model Preparation"](quick_start.md#model-preparation).
-Run from the project root (inside the container if you used the Docker path).
-
 ## Testing & Benchmarking
 
 ### Model Inference with hip-onnx-runner
 
-`hip-onnx-runner` runs a single ONNX model through MorphiZen EP and reports
+`hip-onnx-runner` runs a single ONNX model through hipep EP and reports
 timing. It is built by `build.py` and also ships in the prebuilt
 package.
 
@@ -203,14 +197,17 @@ package.
 > ```
 
 ```bash
-# Run with MorphiZen EP (default), using a fixed-shape model from Model Preparation
-$ROOT/bin/hip-onnx-runner -m /path/to/output/prefill_p512m16384.onnx -i gen_inputs
+# Run with hipep EP (default), on your model directly (dynamic shape)
+$ROOT/bin/hip-onnx-runner -m /path/to/model.onnx -i gen_inputs
+
+# Resolve symbolic input dims at runtime (the EP still compiles the dynamic graph)
+$ROOT/bin/hip-onnx-runner -m /path/to/model.onnx -i gen_inputs -f sequence_length:128
 
 # Run with CPU only (no EP)
-$ROOT/bin/hip-onnx-runner -m /path/to/output/prefill_p512m16384.onnx -n -i gen_inputs
+$ROOT/bin/hip-onnx-runner -m /path/to/model.onnx -n -i gen_inputs
 
 # Dump outputs for comparison
-$ROOT/bin/hip-onnx-runner -m /path/to/output/prefill_p512m16384.onnx -i gen_inputs -d 2
+$ROOT/bin/hip-onnx-runner -m /path/to/model.onnx -i gen_inputs -d 2
 
 # L2-norm compare EP vs CPU outputs
 $ROOT/bin/hip-onnx-runner -L ep_o_dump,cpu_o_dump
@@ -224,22 +221,23 @@ $ROOT/bin/hip-onnx-runner -L ep_o_dump,cpu_o_dump
 | `-n` | CPU only, skip EP registration |
 | `-d 0\|1\|2\|3` | Dump level: 0=off, 1=inputs, 2=outputs, 3=both |
 | `-i <dir>` | Load inputs from directory instead of random |
+| `-f <name>:<val>` | Resolve a symbolic input dim at runtime (repeatable/comma-separated); EP still compiles the dynamic graph, unmatched symbolic dims default to 1 |
 | `-L dir1,dir2` | L2-norm comparison of two output directories |
 
 ### Latency Benchmarking with onnxruntime_perf_test
 
 `onnxruntime_perf_test` benchmarks inference latency. It ships in the prebuilt
-package; a local build may not include it. The examples below compare MorphiZen
+package; a local build may not include it. The examples below compare hipep
 EP against the CPU EP baseline (DML is Windows-only).
 
 ```bash
 # CPU baseline (no EP; useful to size the EP speedup)
 $ROOT/bin/onnxruntime_perf_test -e cpu -t 30 -c 1 -s /path/to/MODEL.onnx
 
-# MorphiZen EP
+# hipep EP
 $ROOT/bin/onnxruntime_perf_test \
-  --plugin_ep_libs "MorphiZenEP|$ROOT/lib/libonnxruntime_morphizen_ep.so" \
-  --plugin_eps     "MorphiZenEP" \
+  --plugin_ep_libs "hipep|$ROOT/lib/libhipep.so" \
+  --plugin_eps     "hipep" \
   -C "session.disable_cpu_ep_fallback|1" \
   -t 60 -c 1 -s -I \
   /path/to/MODEL.onnx
@@ -254,7 +252,7 @@ $ROOT/bin/onnxruntime_perf_test \
 | `-s` | Show per-iteration latency statistics |
 | `-I` | Use sequential inputs (do not randomize) |
 
-> The first iteration triggers MorphiZen's HIP kernel JIT compile
+> The first iteration triggers hipep's HIP kernel JIT compile
 > (multi-minute); bump `-t` so steady-state samples dominate the average.
 
 ### OGA End-to-End Benchmarking with model_benchmark
@@ -263,18 +261,22 @@ $ROOT/bin/onnxruntime_perf_test \
 decode token generation). It is not part of the local build, so use the
 prebuilt package to get it.
 
+The EP is selected by the model's `genai_config.json` `provider_options` and
+auto-discovered next to the OGA runtime lib -- do NOT pass `--ep_library`
+(upstream `model_benchmark` rejects it). With the upstream OGA (v0.14.0 + PR2194)
+the EP is the AMD GPU umbrella (`provider_options [{ "AMDGPU": {"profile": "llm"} }]`);
+the prebuilt package bundles the umbrella libs.
+
 ```bash
 # Auto-generated prompt (128 tokens, generate 32)
 $ROOT/bin/model_benchmark \
   -i /path/to/oga-model-dir \
-  --ep_library MorphiZenEP $ROOT/lib/libonnxruntime_morphizen_ep.so \
   -l 128 -g 32 -ml -1 \
   -r 5 -w 1
 
 # Prompt from file
 $ROOT/bin/model_benchmark \
   -i /path/to/oga-model-dir \
-  --ep_library MorphiZenEP $ROOT/lib/libonnxruntime_morphizen_ep.so \
   --prompt_file /path/to/prompt.txt -g 128 -ml -1 \
   -r 5 -w 1
 ```
@@ -291,7 +293,6 @@ $ROOT/bin/model_benchmark \
 | Flag | Description |
 |------|-------------|
 | `-i <path>` | Path to OGA model directory (with `genai_config.json`) |
-| `--ep_library <name> <path>` | Register a custom EP library |
 | `-l <n>` | Length of auto-generated prompt (exclusive with `--prompt_file`) |
 | `--prompt_file <path>` | Load prompt text from a file (exclusive with `-l`) |
 | `-g <n>` | Max number of tokens to generate |
@@ -345,13 +346,13 @@ Inside `./docker/run.sh shell` this is handled automatically — the
 container entrypoint reads the host GID off `/dev/kfd` and adds the
 in-container user to it, so you don't need host `render` membership.
 
-**`EP library not found: libonnxruntime_morphizen_ep.so` from `hip-onnx-runner`**
+**`EP library not found: libhipep.so` from `hip-onnx-runner`**
 
 The runner's search order is `$MORPHIZEN_EP_LIB` (full path) → cwd →
-`<exe-dir>/libonnxruntime_morphizen_ep.so` → `<exe-dir>/../lib/libonnxruntime_morphizen_ep.so`.
+`<exe-dir>/libhipep.so` → `<exe-dir>/../lib/libhipep.so`.
 If you're running out of `install/bin/`, no env vars are needed — the
 sibling `install/lib/` is auto-discovered. If you've copied the binary
-elsewhere, set `MORPHIZEN_EP_LIB=/full/path/to/libonnxruntime_morphizen_ep.so`.
+elsewhere, set `MORPHIZEN_EP_LIB=/full/path/to/libhipep.so`.
 
 **`clang++ not found on PATH and HIPDNN_CLANG_PATH is unset or stale` from `hip-compiler`**
 


### PR DESCRIPTION
## Summary

Bring the Windows and Linux quick-start guides in line with the EP rename merged in #376 and the dynamic-shape runner flow.

## Why

After #376 the EP artifact, registration name, and wheel were renamed (`onnxruntime_morphizen_ep` -> `hipep`), OGA is built from upstream `v0.14.0` + PR 2194 (AMD GPU umbrella, DeviceType AMDGPU), and models run dynamically without the fixed-shape splitter. The guides still referenced the old names, the old OGA fork, and a Model Preparation step that no longer applies, so a reader following them would hit broken commands.

## What

1. Rename across both guides: `MorphiZenEP`/`MorphiZenExecutionProvider` -> `hipep`, `onnxruntime_morphizen_ep.dll` -> `hipep.dll`, `libonnxruntime_morphizen_ep.so` -> `libhipep.so`, wheel `onnxruntime-ep-hipep`, and `register_execution_provider_library("hipep", ".../hipep.dll")`.
2. OGA build (`quick_start.md` step 3): clone upstream `microsoft/onnxruntime-genai v0.14.0` and `git am --3way` PR 2194 (replacing the old fork branch); the pin note now points at `OGA_VERSION` / `OGA_PR_PATCHES`.
3. `model_benchmark`: drop `--ep_library` (upstream rejects it); the EP is selected via the model's `genai_config.json` `provider_options` (AMD GPU umbrella, `profile=llm`) and auto-discovered next to the OGA runtime lib.
4. Remove the fixed-shape Model Preparation section; `hip-onnx-runner` / `onnxruntime_perf_test` now run the original `model.onnx` directly, and the new `-f/--free-dim` flag (resolve a symbolic input dim at runtime while the EP compiles the dynamic graph) is documented.
5. perf_test: drop the now-redundant `config_file|morphizen_config.json` option (the default config is embedded in the EP).
6. Runtime env stated per artifact mode: default bitcode needs only the ROCm runtime DLLs on `PATH`; NATIVE artifacts additionally use `THEROCK_DIST` + `LIB` for the lld-link step. The wheel note records that the default wheel ships the hipep chain only (the AMD GPU umbrella DLLs are injected separately, e.g. via `HIPEP_WHEEL_EXTRA_DLLS` in CI).

Intentional non-change: `quick_start_linux.md` keeps `THEROCK_DIST` in its runtime env, since on Linux `CompilerDriver::discoverLibraries()` reads it and `LD_LIBRARY_PATH`/`LIBRARY_PATH` depend on it.

## Test plan

- [ ] Docs-only change; rendered Markdown reviewed for the renamed commands, the upstream OGA + `git am` step, and the `-f/--free-dim` flag table entry.

## Notes for reviewers

None.

### Checklist

- [ ] **Incremental**: docs-only, 2 files.
- [ ] **AI policy**: AI-assisted; commit carries the `Co-authored-by: Cursor` trailer.
- [ ] **No `good first issue` automation**: N/A
- [ ] **Reviews resolved**
- [ ] **CODEOWNERS routing**: changes under `docs/`.
