### PR TITLE
ci(windows): relocate therock-dist next to gpu-test-package and clean at start

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -713,6 +713,7 @@ jobs:
           if exist oga-smoke-venv rd /s /q oga-smoke-venv
           if exist oga-smoke-results rd /s /q oga-smoke-results
           if exist wheelpkg rd /s /q wheelpkg
+          if exist therock-dist rd /s /q therock-dist
 
       - name: Download GPU test package
         uses: actions/download-artifact@v4
@@ -731,7 +732,7 @@ jobs:
       - name: Download & extract TheRock
         shell: pwsh
         run: |
-          $dist = "${{ runner.workspace }}\therock-dist"
+          $dist = "$PWD\therock-dist"
           New-Item -ItemType Directory -Force -Path $dist | Out-Null
           curl.exe -fsSL `
             "https://repo.amd.com/rocm/tarball/${{ env.THEROCK_VERSION }}.tar.gz" `
@@ -749,7 +750,7 @@ jobs:
       - name: Run onnxruntime_perf_test (GPU)
         shell: cmd
         run: |
-          set PATH=${{ runner.workspace }}\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
+          set PATH=%CD%\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
           set MODEL_DIR=${{ runner.workspace }}\model
           if not exist "%MODEL_DIR%" (
             echo [ERROR] MODEL_DIR not found: %MODEL_DIR%
@@ -791,9 +792,9 @@ jobs:
         if: always()
         shell: cmd
         run: |
-          set THEROCK_DIST=${{ runner.workspace }}\therock-dist
-          set PATH=${{ runner.workspace }}\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
-          set LIB=%CD%\gpu-test-package\lib;${{ runner.workspace }}\therock-dist\lib
+          set THEROCK_DIST=%CD%\therock-dist
+          set PATH=%CD%\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
+          set LIB=%CD%\gpu-test-package\lib;%CD%\therock-dist\lib
           set MODEL_DIR=${{ runner.workspace }}\model
           if not exist "%MODEL_DIR%" (
             echo [SKIP] MODEL_DIR not found: %MODEL_DIR%
@@ -837,9 +838,9 @@ jobs:
         if: always()
         shell: cmd
         run: |
-          set THEROCK_DIST=${{ runner.workspace }}\therock-dist
-          set PATH=${{ runner.workspace }}\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
-          set LIB=%CD%\gpu-test-package\lib;${{ runner.workspace }}\therock-dist\lib
+          set THEROCK_DIST=%CD%\therock-dist
+          set PATH=%CD%\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
+          set LIB=%CD%\gpu-test-package\lib;%CD%\therock-dist\lib
           set MODEL_DIR=${{ runner.workspace }}\model
           if not exist "%MODEL_DIR%" (
             echo [SKIP] MODEL_DIR not found: %MODEL_DIR%
@@ -880,7 +881,7 @@ jobs:
           $ErrorActionPreference = 'Continue'
           $PSNativeCommandUseErrorActionPreference = $false
           $pkgBin = Join-Path $PWD "gpu-test-package\bin"
-          $env:PATH = "${{ runner.workspace }}\therock-dist\bin;$pkgBin;$env:PATH"
+          $env:PATH = "$PWD\therock-dist\bin;$pkgBin;$env:PATH"
 
           $modelDir = "${{ runner.workspace }}\model"
           if (-not (Test-Path $modelDir)) {
@@ -956,7 +957,7 @@ jobs:
           $ErrorActionPreference = 'Continue'
           $PSNativeCommandUseErrorActionPreference = $false
           $pkgBin = Join-Path $PWD "gpu-test-package\bin"
-          $env:PATH = "${{ runner.workspace }}\therock-dist\bin;$pkgBin;$env:PATH"
+          $env:PATH = "$PWD\therock-dist\bin;$pkgBin;$env:PATH"
 
           # amdgpu-oga-models holds AMDGPU-profile genai_config copies; it was
           # generated once on the GPU runner and persists across runs, so just
@@ -1101,7 +1102,7 @@ jobs:
         shell: cmd
         run: |
           setlocal enabledelayedexpansion
-          set PATH=${{ runner.workspace }}\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
+          set PATH=%CD%\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
           rem The EP DLL is now hipep.dll; hip-onnx-runner's legacy default name
           rem is onnxruntime_morphizen_ep.dll, so point it at the new DLL.
           set MORPHIZEN_EP_LIB=%CD%\gpu-test-package\bin\hipep.dll


### PR DESCRIPTION
## Summary

Relocate the `gpu-test` job's `therock-dist` from `runner.workspace` to `github.workspace` (alongside `gpu-test-package`) and delete it in the opening `Clean workspace` step, so every run extracts TheRock fresh. This removes the in-place overwrite of the persistent runner's `therock-dist` that intermittently corrupted hipBLASLt's `TensileLibrary_lazy_gfx1151.dat`, which surfaced as flaky L2 accuracy results (notably GroupQueryAttention) that differed between a PR run and the same commit on `main`.

## Why

The StrixHalo `gpu-test` runner is persistent and the `Download & extract TheRock` step re-extracted into the same `therock-dist` every run with no prior cleanup, overwriting a 100+ MB Tensile kernel library in place. Overwriting that file while it is still mapped/locked from a prior run (or being scanned) can leave it truncated, after which hipBLASLt fails to load it and matmul-heavy ops (GQA) produce garbage. Because the failure depends on runner state, not source, the same commit could pass on a PR and fail on `main`.

This job has no `actions/checkout` step, so `github.workspace` is never auto-cleaned. Moving `therock-dist` there and deleting it in `Clean workspace` makes the start-of-job cleanup equivalent to delete-then-extract, with zero stale state carried across runs. The repo pins all third-party actions by SHA, so a marketplace cleanup action was rejected in favor of the existing in-workflow cleanup pattern.

## What

1. **`Clean workspace` step** in [.github/workflows/windows-build.yml](.github/workflows/windows-build.yml): add `if exist therock-dist rd /s /q therock-dist` next to the existing `gpu-test-package` / `wheelpkg` cleanup.
2. **`Download & extract TheRock` step**: extract to `$PWD\therock-dist` instead of `${{ runner.workspace }}\therock-dist`.
3. **Consumer steps**: repoint `THEROCK_DIST` / `PATH` / `LIB` references from `${{ runner.workspace }}\therock-dist` to `%CD%\therock-dist` (cmd) and `$PWD\therock-dist` (pwsh). Both resolve to `github.workspace`, matching the existing `%CD%\gpu-test-package` / `$pkgBin` usage on the same lines.
4. **Intentional non-changes**: pre-placed model dirs (`MODEL_DIR`, `l2-test-models`, `amdgpu-oga-models`) stay under `runner.workspace` since they are provisioned once and persist across runs; `THEROCK_VERSION` (tarball name) is untouched.

## Test plan

- [ ] `pre-commit run --all-files` green (ran locally: all hooks Passed).
- [ ] build-windows green; gpu-test job locates `therock-dist` in the new location across all steps (perf, native smoke, AMD GPU umbrella smoke, EPContext, OGA benchmark, L2).
- [ ] L2 GroupQueryAttention result stable between a PR run and the merged `main` commit (no more 238826 outlier).

## Notes for reviewers

None. This is a CI-only, self-contained change. It does not add download retry or post-extract integrity verification; the start-of-job cleanup alone removes the stale-file root cause.

## Checklist

- [x] **Incremental.** Standalone, ~12 lines in one file.
- [x] **AI policy.** Assisted by Cursor; commit carries the `Co-authored-by: Cursor` trailer.
- [x] **No `good first issue` automation.**
- [ ] **Reviews resolved.**
- [x] **CODEOWNERS routing.** CI workflow path; reviewers auto-assigned.
