### PR TITLE
ci(windows): bump ONNX Runtime to v1.27.0 and drop PR 28608 patch

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -27,10 +27,10 @@ env:
   # only invalidates the llvm-install cache.
   LLVM_TAG: llvmorg-22.1.0
   ONNXRUNTIME_VERSION: "1.27.0"
-  # Space-separated microsoft/onnxruntime PR numbers. Non-empty => build ORT
-  # from source and `git apply` each PR on top of the pinned tag; empty => use
-  # the official prebuilt release. Part of the ort-install cache key. Remove a
-  # PR once its fix lands in the pinned ONNX Runtime release.
+  # Space-separated microsoft/onnxruntime PR numbers `git apply`-ed on top of
+  # the pinned tag during the from-source build (an empty list applies nothing;
+  # ORT is still built from source either way). Part of the ort-install cache
+  # key. Remove a PR once its fix lands in the pinned ONNX Runtime release.
   ONNXRUNTIME_PR_PATCHES: ""
   OGA_VERSION: "0.14.0"
   # Space-separated microsoft/onnxruntime-genai PR numbers fetched from

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -305,6 +305,10 @@ jobs:
             echo "OGA_PR_PATCHES is empty; nothing to apply"
             exit 0
           fi
+          # pull/<n>.patch is a format-patch series; apply with `git am` so that
+          # intra-series file renames (morphizen_ep -> amdgpu) replay against the
+          # correct intermediate tree. `git apply` flattens the series and chokes
+          # on the rename whose pre-image only exists after an earlier commit.
           # git am needs a committer identity on a bare runner.
           git config user.email "ci@onnx-hipdnn-ep.local"
           git config user.name "onnx-hipdnn-ep CI"
@@ -316,7 +320,8 @@ jobs:
             curl -fsSL --retry 6 --retry-delay 10 --retry-all-errors \
               "$url" -o "/tmp/oga-pr-${pr}.patch"
             echo "Applying PR #${pr}"
-            git am --whitespace=nowarn "/tmp/oga-pr-${pr}.patch"
+            git am --3way --whitespace=nowarn "/tmp/oga-pr-${pr}.patch" \
+              || { git am --abort; echo "PR #${pr} failed to apply"; exit 1; }
           done
 
       - name: Build OGA

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -26,12 +26,12 @@ env:
   # LLVM/MLIR/LLD are built from source at this upstream release tag; bumping it
   # only invalidates the llvm-install cache.
   LLVM_TAG: llvmorg-22.1.0
-  ONNXRUNTIME_VERSION: "1.25.1"
+  ONNXRUNTIME_VERSION: "1.27.0"
   # Space-separated microsoft/onnxruntime PR numbers. Non-empty => build ORT
   # from source and `git apply` each PR on top of the pinned tag; empty => use
   # the official prebuilt release. Part of the ort-install cache key. Remove a
   # PR once its fix lands in the pinned ONNX Runtime release.
-  ONNXRUNTIME_PR_PATCHES: "28608"
+  ONNXRUNTIME_PR_PATCHES: ""
   OGA_VERSION: "0.14.0"
   # Space-separated microsoft/onnxruntime-genai PR numbers fetched from
   # pull/<n>.patch and `git apply` on top of v<OGA_VERSION>. Part of the OGA

--- a/.github/workflows/windows-build-mock.yml
+++ b/.github/workflows/windows-build-mock.yml
@@ -33,10 +33,10 @@ jobs:
       # windows-build.yml's, so identical cache keys resolve to identical
       # artifacts and each dep's expensive cold build runs once globally.
       LLVM_TAG: llvmorg-22.1.0
-      ONNXRUNTIME_VERSION: "1.25.1"
+      ONNXRUNTIME_VERSION: "1.27.0"
       # Must match windows-build.yml verbatim: it is part of the shared
       # ort-install cache key and drives the same patch set.
-      ONNXRUNTIME_PR_PATCHES: "28608"
+      ONNXRUNTIME_PR_PATCHES: ""
       SCCACHE_GHA_ENABLED: "true"
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
 

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -821,7 +821,7 @@ jobs:
       # ----------------------------------------------------------------------
       # AMD GPU umbrella NATIVE smoke test: same NATIVE compile/link/load path,
       # but driven through the amdgpu-ep umbrella instead of the hipgpu EP
-      # directly. profile=llm (an umbrella option, ep.amdgpuexecutionprovider.
+      # directly. profile=hip (an umbrella option, ep.amdgpuexecutionprovider.
       # prefix) selects the hipgpu backend; the umbrella forwards non-umbrella
       # session-config entries verbatim, so artifact_format is passed as a raw
       # ep.hipgpu.* entry to reach the backend. Real gate (no exit /b 0).
@@ -850,7 +850,7 @@ jobs:
           onnxruntime_perf_test.exe ^
             --plugin_ep_libs "AMDGPUExecutionProvider|amdgpu-ep.dll" ^
             --plugin_eps "AMDGPUExecutionProvider" ^
-            --plugin_ep_options "profile|llm" ^
+            --plugin_ep_options "profile|hip" ^
             -C "session.disable_cpu_ep_fallback|1" ^
             -C "ep.hipgpu.artifact_format|NATIVE" ^
             -r 1 -c 1 -s ^

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -296,14 +296,14 @@ jobs:
           # key folds in the pinned fork commit + ORT version/PR list; bumping
           # any of them forces a rebuild. On a hit the checkout + build below are
           # skipped and the staging step finds the cached DLLs in build-amdgpu.
-          key: dep-amdgpu-af39f35-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}
+          key: dep-amdgpu-b9460ee-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}
 
       - name: Checkout amdgpu-ep
         if: steps.cache-amdgpu.outputs.cache-hit != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: zz002/onnxruntime-ep-amdgpu
-          ref: af39f35fa832a0272904fb8606981c5b10bea974
+          ref: b9460eeed654a80d7bf2429c20a4397d940df180
           path: source-amdgpu
           fetch-depth: 1
           show-progress: false

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -296,14 +296,14 @@ jobs:
           # key folds in the pinned fork commit + ORT version/PR list; bumping
           # any of them forces a rebuild. On a hit the checkout + build below are
           # skipped and the staging step finds the cached DLLs in build-amdgpu.
-          key: dep-amdgpu-b9460ee-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}
+          key: dep-amdgpu-a1318ed-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}
 
       - name: Checkout amdgpu-ep
         if: steps.cache-amdgpu.outputs.cache-hit != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: zz002/onnxruntime-ep-amdgpu
-          ref: b9460eeed654a80d7bf2429c20a4397d940df180
+          ref: a1318edb3c5b87d539bd797eff3addaa7ba2ddda
           path: source-amdgpu
           fetch-depth: 1
           show-progress: false

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -37,14 +37,14 @@ jobs:
       # resolves LLVM via find_package against this build, so that fallback is
       # unused.
       LLVM_TAG: llvmorg-22.1.0
-      ONNXRUNTIME_VERSION: "1.25.1"
+      ONNXRUNTIME_VERSION: "1.27.0"
       # Space-separated list of microsoft/onnxruntime PR numbers to fetch
       # from github.com/microsoft/onnxruntime/pull/<n>.patch and `git apply`
       # on top of the pinned ONNXRUNTIME_VERSION tag during the source-build
       # step. The PR list is also part of the ort-install cache key, so
       # editing this list auto-invalidates the cached ORT install prefix.
       # Remove a PR number once its fix is in the pinned ONNXRUNTIME_VERSION.
-      ONNXRUNTIME_PR_PATCHES: "28608"
+      ONNXRUNTIME_PR_PATCHES: ""
       SCCACHE_GHA_ENABLED: "true"
       OGA_VERSION: "0.14.0"
       # Space-separated microsoft/onnxruntime-genai PR numbers fetched from
@@ -259,7 +259,7 @@ jobs:
           cp "$DML_DLL" "${{ runner.workspace }}/ort-install/bin/"
           # Cache the cp314 ORT Python wheel inside ort-install so it
           # rides the same cache key as the rest of the ORT artifacts.
-          # Output path: build-onnxruntime/Release/dist/onnxruntime_directml-1.25.1-cp314-cp314-win_amd64.whl
+          # Output path: build-onnxruntime/Release/dist/onnxruntime_directml-1.27.0-cp314-cp314-win_amd64.whl
           ORT_WHEEL=$(find "${{ runner.workspace }}/build-onnxruntime" \
             -name "onnxruntime_directml-*.whl" -type f | head -1)
           if [ -z "$ORT_WHEEL" ]; then

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -296,14 +296,14 @@ jobs:
           # key folds in the pinned fork commit + ORT version/PR list; bumping
           # any of them forces a rebuild. On a hit the checkout + build below are
           # skipped and the staging step finds the cached DLLs in build-amdgpu.
-          key: dep-amdgpu-daa120c-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}
+          key: dep-amdgpu-af39f35-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}
 
       - name: Checkout amdgpu-ep
         if: steps.cache-amdgpu.outputs.cache-hit != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: zz002/onnxruntime-ep-amdgpu
-          ref: daa120c415b00d52a59add8a7328221b4d25f4ff
+          ref: af39f35fa832a0272904fb8606981c5b10bea974
           path: source-amdgpu
           fetch-depth: 1
           show-progress: false

--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -18,7 +18,7 @@
 ## version. cmake/deps.cmake derives the per-OS archive basename
 ## (onnxruntime-win-x64-<ver>.zip / onnxruntime-linux-x64-<ver>.tgz). Resolved
 ## find_package-first; this is the download-only fallback.
-onnxruntime;https://github.com/microsoft/onnxruntime/releases/download;1.25.1
+onnxruntime;https://github.com/microsoft/onnxruntime/releases/download;1.27.0
 ##
 ## Source-built deps (hash = git tag/commit). Resolved find_package-first;
 ## these are the from-source fallbacks when no prefix is found.


### PR DESCRIPTION
## Summary

Upgrade the source-built ONNX Runtime to v1.27.0 (no PR patches needed) and pin the AMDGPU umbrella EP to a commit that carries the per-memory-type allocator fix plus the decouple/hipep build toggle.

## Why

v1.27.0 already contains the partitioning fix previously applied as PR-patch 28608, so no `git apply` patch is required; pinning to a released tag keeps CI aligned with upstream. The amdgpu-ep pin targets `build/decouple-dml-migraphx` rebased on ORT-1.27.0 upstream main, so it brings both the allocator fix (upstream `onnxruntime/onnxruntime-ep-amdgpu#46`) and the decouple build toggle needed to build hipep-only without a MIGraphX SDK.

## What

1. **ORT → 1.27.0**: `ONNXRUNTIME_VERSION` = `1.27.0` in `.github/workflows/windows-build.yml`, `windows-build-mock.yml`, `linux-build.yml`, and the onnxruntime row in `cmake/deps.txt` (kept in sync per the file header).
2. **`ONNXRUNTIME_PR_PATCHES` = `""`** in all three workflows (28608 is in the release). The empty value also rotates the `dep-ort` / `dep-amdgpu` / `oga-dml` cache keys.
3. **linux OGA patches via `git am --3way`** in `linux-build.yml` (matching `windows-build.yml`) so intra-series renames replay correctly.
4. **amdgpu-ep pin** in `windows-build.yml` (`dep-amdgpu-a1318ed` cache key + checkout `ref: a1318edb3c5b87d539bd797eff3addaa7ba2ddda`), containing the per-memory-type allocator fix + decouple toggle.
5. **Umbrella native smoke uses `--plugin_ep_options "profile|hip"`** (the amdgpu profile is `hip`).
6. **Unchanged**: `OGA_VERSION` / `OGA_PR_PATCHES` (PR 2194 still open upstream).

## Test plan

- [ ] build-windows green on cold cache: ORT v1.27.0 source-builds; OGA + EP + amdgpu-ep build against it.
- [ ] gpu-test green: umbrella native smoke (`profile|hip`) exits without `0xC0000005`; perf_test / runner smoke pass.

## Notes for reviewers

The OGA benchmark step reads a pre-placed `genai_config` on the GPU runner; if it specifies `profile=llm` it needs updating to `hip` for the new amdgpu-ep (out of this repo's scope).

## Checklist

- [x] **Incremental.** CI-only changes (workflows + `cmake/deps.txt`).
- [x] **AI policy.** Drafted with Cursor; commits carry the repo's standard trailer.
- [x] **No `good first issue` automation.**
- [ ] **Reviews resolved.**
- [x] **CODEOWNERS routing.** Touches `.github/workflows/` and `cmake/`.
