### PR TITLE
ci(windows): build per-arch matrix (gfx1151/1152/1150)

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -22,12 +22,22 @@ jobs:
     # (gsl/util C2220 warning-as-error). Pin to the VS 2022 image per
     # actions/runner-images#14017.
     runs-on: windows-2022
+    # Build once per GPU arch. Each leg auto-downloads its own per-arch TheRock
+    # SDK (cmake/deps.cmake derives the tarball from HIP_ARCHITECTURES) and
+    # builds custom_kernels_<arch>.dll. Only the gfx1151 leg feeds gpu-test;
+    # the others are compile/package coverage. fail-fast off so one arch's
+    # failure does not abort the rest.
+    strategy:
+      fail-fast: false
+      matrix:
+        hip_arch: [gfx1151, gfx1152, gfx1150]
     # Cancel the build job when a newer commit lands on the same PR ref to
     # save runner minutes. gpu-test deliberately does NOT inherit this rule
     # (see its own concurrency block below) so an in-progress GPU run keeps
-    # going to completion even if a newer build supersedes it.
+    # going to completion even if a newer build supersedes it. The group folds
+    # in matrix.hip_arch so the per-arch legs do not cancel each other.
     concurrency:
-      group: build-windows-${{ github.ref }}
+      group: build-windows-${{ github.ref }}-${{ matrix.hip_arch }}
       cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
     env:
@@ -365,7 +375,7 @@ jobs:
           python build.py \
             --config Release \
             --cmake_generator Ninja \
-            --hip_arch gfx1151 \
+            --hip_arch ${{ matrix.hip_arch }} \
             --cmake_prefix_path "${{ runner.workspace }}/ort-install;${{ runner.workspace }}/llvm-install" \
             --cmake_extra_defines CMAKE_DISABLE_FIND_PACKAGE_OpenSSL=ON \
             --cmake_extra_defines "HIPEP_WHEEL_EXTRA_DLLS=$AMDGPU_EP;$HIPEP_BACKEND"
@@ -559,9 +569,9 @@ jobs:
           # Smoke: the per-arch kernel DLL must be present in staging/bin/
           # for the gpu-test job to load it. Failure here means the install
           # rule in 3rd-party/custom_kernels/CMakeLists.txt regressed.
-          KERNEL_DLL="staging/bin/custom_kernels_gfx1151.dll"
+          KERNEL_DLL="staging/bin/custom_kernels_${{ matrix.hip_arch }}.dll"
           if [ ! -f "$KERNEL_DLL" ]; then
-            echo "ERROR: $KERNEL_DLL missing from install (HIP_ARCHITECTURES=gfx1151)"
+            echo "ERROR: $KERNEL_DLL missing from install (HIP_ARCHITECTURES=${{ matrix.hip_arch }})"
             ls -1 "${{ runner.workspace }}/install/bin/" || true
             exit 1
           fi
@@ -639,7 +649,7 @@ jobs:
       - name: Upload GPU test package
         uses: actions/upload-artifact@v4
         with:
-          name: gpu-test-package
+          name: gpu-test-package-${{ matrix.hip_arch }}
           path: staging/
           retention-days: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release_')) && 14 || 3 }}
 
@@ -673,7 +683,7 @@ jobs:
       - name: Upload Python wheel package
         uses: actions/upload-artifact@v4
         with:
-          name: hipep-python-package
+          name: hipep-python-package-${{ matrix.hip_arch }}
           path: wheelpkg/
           retention-days: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release_')) && 14 || 3 }}
 
@@ -718,13 +728,13 @@ jobs:
       - name: Download GPU test package
         uses: actions/download-artifact@v4
         with:
-          name: gpu-test-package
+          name: gpu-test-package-gfx1151
           path: gpu-test-package
 
       - name: Download Python wheel package
         uses: actions/download-artifact@v4
         with:
-          name: hipep-python-package
+          name: hipep-python-package-gfx1151
           path: wheelpkg
 
       # TheRock DLLs are required at runtime on the GPU machine.


### PR DESCRIPTION
## Summary

Build the Windows EP once per GPU arch via a `matrix.hip_arch` (gfx1151 / gfx1152 / gfx1150). Each leg auto-downloads its own per-arch TheRock SDK and builds `custom_kernels_<arch>.dll`; only the gfx1151 leg feeds the GPU test job.

## Why

We need compile/package coverage for gfx1152 and gfx1150 in addition to the existing gfx1151 path, but only the StrixHalo (gfx1151) self-hosted runner exists for GPU tests. A `matrix` over `hip_arch` keeps the build pipeline identical across arches (DRY) while `gpu-test` consumes only the gfx1151 artifact. Alternative considered: a separate compile-only job for the extra arches (cheaper, skips OGA/packaging) — rejected to keep one uniform build path and full per-arch packaging coverage.

## What

1. `build-windows` gains `strategy.matrix.hip_arch: [gfx1151, gfx1152, gfx1150]` with `fail-fast: false`, and the `concurrency` group folds in `matrix.hip_arch` so per-arch legs do not cancel each other.
2. `build.py --hip_arch` now takes `${{ matrix.hip_arch }}`; the per-arch TheRock tarball is derived from `HIP_ARCHITECTURES` in `cmake/deps.cmake` (verified gfx1151/1152/1150 7.11.0 tarballs all return HTTP 200 on repo.amd.com).
3. The kernel-presence smoke check and its error message use `custom_kernels_${{ matrix.hip_arch }}.dll`.
4. Upload artifacts are arch-namespaced: `gpu-test-package-<arch>` and `hipep-python-package-<arch>`.
5. `gpu-test` downloads the fixed `gpu-test-package-gfx1151` / `hipep-python-package-gfx1151`; `THEROCK_VERSION` and the gfx1151 wheel index stay gfx1151. Shared `ort-install` / `llvm-install` / `amdgpu` / `oga` caches keep identical keys so the arch-independent deps are built once and reused across legs.

## Test plan

- [ ] build-windows green for all three arches (gfx1151 / gfx1152 / gfx1150): EP + `custom_kernels_<arch>.dll` build and package successfully.
- [ ] gpu-test runs on StrixHalo against the gfx1151 artifact (perf / native smoke / EPContext / OGA / L2) as before.

## Notes for reviewers

`gpu-test` keeps `needs: build-windows`, so with the matrix it runs only after all three legs succeed; a gfx1152/gfx1150 build failure will block the gfx1151 GPU test. This is intentional for now (treat extra arches as required build gates).