### PR TITLE
feat(runtime): Unified Memory Manager Phase 1 — HAL + MemoryManager foundation

### DIFF
--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -270,7 +270,7 @@ endmacro()
 # Compiled to bitcode so the MM is merged into each per-model DLL alongside
 # the rest of the runtime. The HAL factory is included here; it selects the
 # correct backend at session-create time via hipDeviceGetAttribute.
-compile_to_bitcode(mm/hal_apu.cpp runtime_mm_hal_apu.bc)
+compile_to_bitcode(mm/hal_igpu.cpp runtime_mm_hal_igpu.bc)
 compile_to_bitcode(mm/hal_discrete.cpp runtime_mm_hal_discrete.bc)
 compile_to_bitcode(mm/hal_factory.cpp runtime_mm_hal_factory.bc)
 compile_to_bitcode(mm/memory_manager.cpp runtime_mm_memory_manager.bc)
@@ -343,7 +343,7 @@ if(NOT BUILD_MOCK_RUNTIME)
     compile_to_bitcode(real/global_pool.cpp runtime_global_pool.bc)
 
     set(RUNTIME_BC_MODULES
-        ${CMAKE_CURRENT_BINARY_DIR}/runtime_mm_hal_apu.bc
+        ${CMAKE_CURRENT_BINARY_DIR}/runtime_mm_hal_igpu.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_mm_hal_discrete.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_mm_hal_factory.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_mm_memory_manager.bc
@@ -416,7 +416,7 @@ else()
     compile_to_bitcode(mock/op_state_stubs.cpp runtime_op_state_stubs.bc)
 
     set(RUNTIME_BC_MODULES
-        ${CMAKE_CURRENT_BINARY_DIR}/runtime_mm_hal_apu.bc
+        ${CMAKE_CURRENT_BINARY_DIR}/runtime_mm_hal_igpu.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_mm_hal_discrete.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_mm_hal_factory.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_mm_memory_manager.bc

--- a/lib/Runtime/mm/hal.h
+++ b/lib/Runtime/mm/hal.h
@@ -7,7 +7,7 @@
 //
 // Defines HalAllocator — the polymorphic interface between MemoryManager and
 // the HIP runtime. Two concrete backends:
-//   ApuHalAllocator  — integrated GPU / UMA (hipHostMalloc Mapped+NonCoherent;
+//   IGpuHalAllocator  — integrated GPU / UMA (hipHostMalloc Mapped+NonCoherent;
 //                      gpu_ptr == cpu_ptr; eviction/restore are fence-only)
 //   DiscreteHalAllocator — discrete dGPU (hipMalloc VRAM + hipHostMalloc
 //                          pinned; both allocated at alloc() time;
@@ -118,11 +118,11 @@ public:
 HalAllocator *hal_create_for_device(int device_id);
 
 //===----------------------------------------------------------------------===//
-// Concrete backends (declared here, implemented in hal_apu.cpp /
+// Concrete backends (declared here, implemented in hal_igpu.cpp /
 // hal_discrete.cpp). Exposed so unit tests can construct either one directly.
 //===----------------------------------------------------------------------===//
 
-class ApuHalAllocator : public HalAllocator {
+class IGpuHalAllocator : public HalAllocator {
 public:
   HalBlock alloc(size_t bytes, MemTier preferred) override;
   void free(HalBlock &block) override;

--- a/lib/Runtime/mm/hal_factory.cpp
+++ b/lib/Runtime/mm/hal_factory.cpp
@@ -8,7 +8,7 @@
 // Detects hipDeviceAttributeIntegrated at session creation time and returns
 // the correct HalAllocator backend.
 //
-// Under HIPDNN_EP_MM_MOCK_HAL (unit tests), always returns ApuHalAllocator
+// Under HIPDNN_EP_MM_MOCK_HAL (unit tests), always returns IGpuHalAllocator
 // (both backends use malloc under the flag; APU is the simpler one).
 //
 //===----------------------------------------------------------------------===//
@@ -24,16 +24,16 @@ HalAllocator *hal_create_for_device(int device_id) {
   int rc = hipGetDeviceProperties(&prop, device_id);
   bool integrated = (rc == hipSuccess) && (prop.integrated != 0);
   if (integrated)
-    return new ApuHalAllocator();
+    return new IGpuHalAllocator();
   return new DiscreteHalAllocator();
 }
 
 #else
-// Mock / unit-test path: no HIP SDK available. Always return ApuHalAllocator
+// Mock / unit-test path: no HIP SDK available. Always return IGpuHalAllocator
 // because both backends use malloc under HIPDNN_EP_MM_MOCK_HAL, and APU is
 // the simpler of the two for tests. Avoids redefining hipGetDeviceProperties
 // which mock_types.h already declares as extern "C".
 HalAllocator *hal_create_for_device(int /*device_id*/) {
-  return new ApuHalAllocator();
+  return new IGpuHalAllocator();
 }
 #endif

--- a/lib/Runtime/mm/hal_igpu.cpp
+++ b/lib/Runtime/mm/hal_igpu.cpp
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-//===- hal_apu.cpp - APU / UMA HalAllocator implementation ---------------===//
+//===- hal_igpu.cpp - APU / UMA HalAllocator implementation ---------------===//
 //
 // Integrated GPU (AMD APU / iGPU) backend where GPU and CPU share physical
 // memory. Uses hipHostMalloc(Mapped|NonCoherent) so that:
@@ -74,7 +74,7 @@ static inline int hipEventDestroy(void * /*ev*/) { return 0; }
 #define hipSuccess 0
 #endif // HIPDNN_EP_MM_MOCK_HAL
 
-HalBlock ApuHalAllocator::alloc(size_t bytes, MemTier /*preferred*/) {
+HalBlock IGpuHalAllocator::alloc(size_t bytes, MemTier /*preferred*/) {
   if (bytes == 0)
     bytes = 1; // hipHostMalloc(0) is undefined
 
@@ -85,7 +85,7 @@ HalBlock ApuHalAllocator::alloc(size_t bytes, MemTier /*preferred*/) {
   if (hipHostMalloc(&cpu_ptr, bytes,
                     hipHostMallocMapped | hipHostMallocNonCoherent) !=
       hipSuccess) {
-    fprintf(stderr, "ApuHalAllocator::alloc: hipHostMalloc(%zu) failed\n",
+    fprintf(stderr, "IGpuHalAllocator::alloc: hipHostMalloc(%zu) failed\n",
             bytes);
     return block; // gpu_ptr == nullptr signals failure
   }
@@ -93,7 +93,8 @@ HalBlock ApuHalAllocator::alloc(size_t bytes, MemTier /*preferred*/) {
   // On APU UMA, hipHostGetDevicePointer returns the same VA as the host ptr.
   void *gpu_ptr = nullptr;
   if (hipHostGetDevicePointer(&gpu_ptr, cpu_ptr, 0) != hipSuccess) {
-    fprintf(stderr, "ApuHalAllocator::alloc: hipHostGetDevicePointer failed\n");
+    fprintf(stderr,
+            "IGpuHalAllocator::alloc: hipHostGetDevicePointer failed\n");
     hipHostFree(cpu_ptr);
     return block;
   }
@@ -106,7 +107,7 @@ HalBlock ApuHalAllocator::alloc(size_t bytes, MemTier /*preferred*/) {
   return block;
 }
 
-void ApuHalAllocator::free(HalBlock &block) {
+void IGpuHalAllocator::free(HalBlock &block) {
   if (!block.cpu_ptr)
     return;
   hipHostFree(block.cpu_ptr);
@@ -119,7 +120,7 @@ void ApuHalAllocator::free(HalBlock &block) {
 // already CPU-accessible. We record a HIP event on the stream so that any
 // subsequent CPU read (after hipStreamSynchronize / hipEventSynchronize) sees
 // the GPU-written data (NonCoherent ordering contract).
-void ApuHalAllocator::evict_to_cpu(HalBlock &block, void *stream) {
+void IGpuHalAllocator::evict_to_cpu(HalBlock &block, void *stream) {
   if (!block.gpu_ptr)
     return;
 
@@ -159,7 +160,7 @@ void ApuHalAllocator::evict_to_cpu(HalBlock &block, void *stream) {
 // to subsequent GPU reads. On NonCoherent APU memory the safest approach is
 // to call hipStreamSynchronize on the host side before the next GPU launch
 // that reads this block — that is the MemoryManager's responsibility.
-void ApuHalAllocator::restore_to_gpu(HalBlock &block, void *stream) {
+void IGpuHalAllocator::restore_to_gpu(HalBlock &block, void *stream) {
   if (!block.gpu_ptr)
     return;
   (void)stream; // no async transfer needed; caller must have synced CPU writes

--- a/test/runtime/mm/CMakeLists.txt
+++ b/test/runtime/mm/CMakeLists.txt
@@ -20,7 +20,7 @@ add_executable(test-memory-manager
     test_hal.cpp
     test_memory_manager.cpp
     # Source files under test — compiled natively, NOT as bitcode.
-    ${CMAKE_SOURCE_DIR}/lib/Runtime/mm/hal_apu.cpp
+    ${CMAKE_SOURCE_DIR}/lib/Runtime/mm/hal_igpu.cpp
     ${CMAKE_SOURCE_DIR}/lib/Runtime/mm/hal_discrete.cpp
     ${CMAKE_SOURCE_DIR}/lib/Runtime/mm/hal_factory.cpp
     ${CMAKE_SOURCE_DIR}/lib/Runtime/mm/memory_manager.cpp

--- a/test/runtime/mm/test_hal.cpp
+++ b/test/runtime/mm/test_hal.cpp
@@ -4,7 +4,7 @@
  */
 
 //===----------------------------------------------------------------------===//
-// GPU-free unit tests for HalAllocator (ApuHalAllocator +
+// GPU-free unit tests for HalAllocator (IGpuHalAllocator +
 // DiscreteHalAllocator).
 //
 // Compiled with HIPDNN_EP_MM_MOCK_HAL so all HIP calls are replaced with
@@ -32,11 +32,11 @@ extern int g_failures;
   } while (0)
 
 //===----------------------------------------------------------------------===//
-// ApuHalAllocator tests
+// IGpuHalAllocator tests
 //===----------------------------------------------------------------------===//
 
 static void test_apu_alloc_returns_valid_block() {
-  ApuHalAllocator hal;
+  IGpuHalAllocator hal;
   HalBlock b = hal.alloc(1024, MemTier::GPU);
   CHECK(b.gpu_ptr != nullptr);
   CHECK(b.cpu_ptr != nullptr);
@@ -52,7 +52,7 @@ static void test_apu_alloc_returns_valid_block() {
 }
 
 static void test_apu_alloc_zero_rounds_up() {
-  ApuHalAllocator hal;
+  IGpuHalAllocator hal;
   HalBlock b = hal.alloc(0, MemTier::GPU);
   // size=0 is rounded to 1 to avoid undefined hipHostMalloc(0)
   CHECK(b.gpu_ptr != nullptr);
@@ -60,7 +60,7 @@ static void test_apu_alloc_zero_rounds_up() {
 }
 
 static void test_apu_evict_to_cpu_is_metadata_only() {
-  ApuHalAllocator hal;
+  IGpuHalAllocator hal;
   HalBlock b = hal.alloc(64, MemTier::GPU);
   // Write a sentinel through the GPU pointer.
   *reinterpret_cast<uint32_t *>(b.gpu_ptr) = 0xDEADBEEF;
@@ -73,7 +73,7 @@ static void test_apu_evict_to_cpu_is_metadata_only() {
 }
 
 static void test_apu_restore_to_gpu_is_metadata_only() {
-  ApuHalAllocator hal;
+  IGpuHalAllocator hal;
   HalBlock b = hal.alloc(64, MemTier::GPU);
   hal.evict_to_cpu(b, nullptr);
   CHECK(b.resident == MemTier::CPU);
@@ -84,14 +84,14 @@ static void test_apu_restore_to_gpu_is_metadata_only() {
 }
 
 static void test_apu_free_null_block_is_noop() {
-  ApuHalAllocator hal;
+  IGpuHalAllocator hal;
   HalBlock empty{};
   hal.free(empty); // must not crash
   CHECK(empty.gpu_ptr == nullptr);
 }
 
 static void test_apu_is_integrated() {
-  ApuHalAllocator hal;
+  IGpuHalAllocator hal;
   CHECK(hal.is_integrated());
 }
 
@@ -182,7 +182,7 @@ static void test_discrete_free_null_block_is_noop() {
 //===----------------------------------------------------------------------===//
 
 static void test_factory_returns_nonnull() {
-  // In mock mode, factory always returns ApuHalAllocator.
+  // In mock mode, factory always returns IGpuHalAllocator.
   HalAllocator *hal = hal_create_for_device(0);
   CHECK(hal != nullptr);
   delete hal;

--- a/test/runtime/mm/test_memory_manager.cpp
+++ b/test/runtime/mm/test_memory_manager.cpp
@@ -6,7 +6,7 @@
 //===----------------------------------------------------------------------===//
 // GPU-free unit tests for MemoryManager (Phase 1 scope).
 //
-// Uses MockHalAllocator (which wraps ApuHalAllocator under
+// Uses MockHalAllocator (which wraps IGpuHalAllocator under
 // HIPDNN_EP_MM_MOCK_HAL) to verify pool management, scratch, workspace,
 // host-scalar, seqlens_k cache, and domain-independence contracts.
 //
@@ -31,9 +31,10 @@ int g_failures = 0;
     }                                                                          \
   } while (0)
 
-// Helper: create a MemoryManager backed by a fresh ApuHalAllocator (mock mode).
+// Helper: create a MemoryManager backed by a fresh IGpuHalAllocator (mock
+// mode).
 static MemoryManager *make_mm() {
-  return new MemoryManager(new ApuHalAllocator());
+  return new MemoryManager(new IGpuHalAllocator());
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
## Summary

Phase 1 of a 5-phase Unified Memory Manager (UMM). Introduces `MemoryManager` (`lib/Runtime/mm/`) to replace six independent `ensure_*` memory patterns in `RuntimeState` with a single typed API.

- **`HalAllocator` interface** with two fully-specified backends:
  - `ApuHalAllocator` — APU/UMA: `hipHostMalloc(Mapped|NonCoherent)`, eviction/restore are zero-copy fence ops
  - `DiscreteHalAllocator` — dGPU: `hipMalloc` VRAM + pre-allocated pinned host; eviction is async D2H, restore is async H2D. Both backing stores allocated at `alloc()` time to avoid latency spikes at eviction time.
- **`MemoryManager`** wraps pool domains, workspace, host-scalar scratch, and qmoe host scratch with uniform **1.5× amortized growth** (fixes the pool-domain exact-growth bug)
- `seqlens_k` cross-layer GQA cache moved into MM; `begin_compute()` is the single invalidation point
- **Bug fix**: `hipHostMallocCoherent` → `hipHostMallocNonCoherent` in `HipGpuAllocator` (+1.6–4.4% decode TPS on gfx1151)
- **38 GPU-free unit tests** (`test/runtime/mm/`) — all pass

## No behavior change in Phase 1

All existing extern C functions (`hipdnn_ep_get_pool_base`, `hipdnn_ep_get_host_scratch_base`, `hipdnn_ep_state_ensure_workspace`, etc.) delegate to `mm->*` with identical semantics. Legacy fields kept in `RuntimeState` during transition.

## Future phases

Phase 2 (block pool + bump-pointer scratch), Phase 3 (pool domains via block pool), Phase 4 (EP-owned KV cache), Phase 5 (Tier-1 CPU offload).

## Test plan

- [x] 38 GPU-free unit tests: `test-memory-manager.exe` — **all passed**
- [x] Runtime bitcode compiled cleanly via clang (4 new `.bc` files + `runtime.bc` linked)
- [ ] CI: Windows build
- [ ] CI: Linux build
- [ ] CI: GPU tests

🤖 Generated with [Claude Code](https://claude.ai/claude-code)