### PR TITLE
fix(jit): bind Windows JIT runtime stdio to ucrtbase (perf=1 heap corruption)

### DIFF
--- a/backend-mlir-compiler/custom-op-mlir/src/LlvmIrJit.cpp
+++ b/backend-mlir-compiler/custom-op-mlir/src/LlvmIrJit.cpp
@@ -297,6 +297,30 @@ bool installSearchGenerators(llvm::orc::LLJIT &jit) {
   }
 #endif // HIPDNN_EP_LOAD_KERNEL_DLLS
 
+#ifdef _WIN32
+  // Pin the C runtime to the shared UCRT before the process generator (ORC
+  // tries generators in add-order). Binds the runtime's stdio family to the
+  // same UCRT that owns the stderr/_iob FILE; otherwise the process search
+  // picks legacy msvcrt.dll's fputs over a ucrtbase FILE -> heap corruption
+  // under perf=1. Match this build's CRT: debug (/MTd, /MDd; _DEBUG) ships
+  // ucrtbased.dll, release ships ucrtbase.dll. operator new/delete and
+  // type_info stay pinned to the EP DLL via the absolute shims (which outrank
+  // generators), so the C++ heap is untouched.
+#ifdef _DEBUG
+  constexpr const char *kUcrtDll = "ucrtbased.dll";
+#else
+  constexpr const char *kUcrtDll = "ucrtbase.dll";
+#endif
+  if (auto ucrt = llvm::orc::DynamicLibrarySearchGenerator::Load(
+          kUcrtDll, global_prefix)) {
+    jd.addGenerator(std::move(*ucrt));
+  } else {
+    LOG(INFO) << "LlvmIrJit: Load(" << kUcrtDll
+              << ") failed: " << llvm::toString(ucrt.takeError())
+              << "; stdio may bind to a foreign CRT under perf=1.";
+  }
+#endif // _WIN32
+
   // Process image: EP DLL, amdhip64, the libs above, the CRT, ORT, ...
   auto gen = llvm::orc::DynamicLibrarySearchGenerator::GetForCurrentProcess(
       global_prefix);


### PR DESCRIPTION
## Summary
- Fixes the Windows `HIPDNN_EP_PERF=1` heap-corruption crash (`0xc0000374`) in **JIT / `LLVM_IR`** artifact mode.
- Root cause (captured at runtime, not inferred): the ORC process-symbol search bound the JIT'd runtime's `fputs` to the legacy **`msvcrt.dll`**, while `stderr` / `__acrt_iob_func` (the `FILE` state) came from **`ucrtbase.dll`**. `msvcrt`'s `fputs` then walked a `ucrtbase` `FILE` — different `__crt_stdio_stream_data` layout + a different heap — corrupting the heap during the per-op `[PERF]` `fprintf` flood.
- Fix: add a `ucrtbase.dll` (`ucrtbased.dll` under `_DEBUG`) search generator **before** the process generator in `installSearchGenerators`. ORC queries generators in add-order, so the runtime's stdio family now binds to the same UCRT that owns the `FILE`. `operator new/delete` and `type_info` remain pinned to the EP DLL by the existing absolute-symbol shims (which outrank generators), so the C++ heap is untouched.

## Why native mode was unaffected
Native mode links `runtime.bc` against one UCRT via `lld`, so all stdio symbols resolve into a single coherent CRT — it never had the split. This change brings JIT mode to the same coherence without requiring native compilation.

## Proof (Windows, gfx1151, Qwen3.5 decoder, `-g 4` `HIPDNN_EP_PERF=1`)
| | before | after |
|---|---|---|
| runtime `fputs` owner | `msvcrt.dll` | `ucrtbase.dll` (matches `FILE`) |
| process exit | `0xc0000374` (heap corruption) | `0` |
| per-op `[PERF]` tables | aborted mid-flush | fully printed |

## Test plan
- [x] JIT mode `-g 4` perf=1: exits 0, full `[PERF]` tables, runtime `fputs` → `ucrtbase.dll`.
- [x] Native mode unchanged: still exits 0.
- [ ] CI Windows build green.
