### PR TITLE
refactor(ep): rename hipep EP to hipgpu

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -365,7 +365,7 @@ jobs:
                 done
           }
           stage_pass \
-            "$INSTALL"/lib/libhipep.so \
+            "$INSTALL"/lib/libhipgpu.so \
             "$INSTALL"/lib/libhip-compiler.so \
             "$INSTALL"/bin/hip-compiler \
             "$INSTALL"/bin/hip-onnx-runner \
@@ -458,7 +458,7 @@ jobs:
 
           cp "${{ github.workspace }}/etc/morphizen_config.json" staging/etc/
 
-          # Smoke: per-arch kernel SO must sit next to libhipep.so (the EP, named
+          # Smoke: per-arch kernel SO must sit next to libhipgpu.so (the EP, named
           # via morphizen_OUTPUT_NAME); the EP anchors dlopen via dladdr() + RPATH=$ORIGIN.
           KERNEL_SO="staging/lib/libcustom_kernels_gfx1151.so"
           if [ ! -f "$KERNEL_SO" ]; then

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -292,14 +292,14 @@ jobs:
       # -----------------------------------------------------------------------
 
       # -----------------------------------------------------------------------
-      # Build the AMD GPU umbrella EP (onnxruntime-ep-amdgpu) + hipep-backend
+      # Build the AMD GPU umbrella EP (onnxruntime-ep-amdgpu) + hip-backend
       # shim from the fork's PR branch. USE_AMDGPU forces DML/MIGraphX off and
-      # HIPEP on (no MIGraphX SDK needed); the shim loads hipep.dll (the
+      # HIPGPU on (no MIGraphX SDK needed); the shim loads hipgpu.dll (the
       # morphizen EP, renamed via cmake/deps.cmake). Built against ort-install.
       # Commit is pinned; bump it (and the cache key below) when the fork moves.
       #
       # Built BEFORE onnx-hipdnn-ep so its wheel target can bundle amdgpu-ep.dll
-      # + hipep-backend.dll (HIPEP_WHEEL_EXTRA_DLLS below). amdgpu-ep only
+      # + hip-backend.dll (HIP_WHEEL_EXTRA_DLLS below). amdgpu-ep only
       # links ort-install, so it has no dependency on the onnx-hipdnn-ep build.
       # -----------------------------------------------------------------------
       - name: Cache amdgpu-ep build
@@ -307,18 +307,18 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ${{ runner.workspace }}/build-amdgpu
-          # amdgpu-ep/hipep-backend link against the patched ort-install, so the
+          # amdgpu-ep/hip-backend link against the patched ort-install, so the
           # key folds in the pinned fork commit + ORT version/PR list; bumping
           # any of them forces a rebuild. On a hit the checkout + build below are
           # skipped and the staging step finds the cached DLLs in build-amdgpu.
-          key: dep-amdgpu-19dc45a-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}
+          key: dep-amdgpu-daa120c-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}
 
       - name: Checkout amdgpu-ep
         if: steps.cache-amdgpu.outputs.cache-hit != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: zz002/onnxruntime-ep-amdgpu
-          ref: 19dc45af58bf3b2775d87fe80455a2543c7b24fb
+          ref: daa120c415b00d52a59add8a7328221b4d25f4ff
           path: source-amdgpu
           fetch-depth: 1
           show-progress: false
@@ -339,7 +339,7 @@ jobs:
             -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded \
             -DCMAKE_C_COMPILER_LAUNCHER=sccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
-          "$CMAKE" --build "${{ runner.workspace }}/build-amdgpu" --target amdgpu-ep hipep-ep
+          "$CMAKE" --build "${{ runner.workspace }}/build-amdgpu" --target amdgpu-ep hip-ep
 
       # -----------------------------------------------------------------------
       # Build onnx-hipdnn-ep via the cross-platform build.py (same driver
@@ -350,25 +350,25 @@ jobs:
       # (repo.parent), matching what the later staging step expects. The LIT tests
       # run inside build.py after install.
       #
-      # HIPEP_WHEEL_EXTRA_DLLS feeds the wheel target the amdgpu-ep.dll +
-      # hipep-backend.dll built above, so the morphizen wheel ships the whole
-      # AMD GPU umbrella chain in onnxruntime/capi/ next to hipep.dll.
+      # HIP_WHEEL_EXTRA_DLLS feeds the wheel target the amdgpu-ep.dll +
+      # hip-backend.dll built above, so the morphizen wheel ships the whole
+      # AMD GPU umbrella chain in onnxruntime/capi/ next to hipgpu.dll.
       # -----------------------------------------------------------------------
       - name: Build onnx-hipdnn-ep
         shell: bash
         run: |
           AMDGPU_BUILD="${{ runner.workspace }}/build-amdgpu"
           AMDGPU_EP=$(find "$AMDGPU_BUILD" -name "amdgpu-ep.dll" -type f | head -1)
-          HIPEP_BACKEND=$(find "$AMDGPU_BUILD" -name "hipep-backend.dll" -type f | head -1)
+          HIP_BACKEND=$(find "$AMDGPU_BUILD" -name "hip-backend.dll" -type f | head -1)
           echo "amdgpu-ep.dll:     $AMDGPU_EP"
-          echo "hipep-backend.dll: $HIPEP_BACKEND"
+          echo "hip-backend.dll: $HIP_BACKEND"
           python build.py \
             --config Release \
             --cmake_generator Ninja \
             --hip_arch gfx1151 \
             --cmake_prefix_path "${{ runner.workspace }}/ort-install;${{ runner.workspace }}/llvm-install" \
             --cmake_extra_defines CMAKE_DISABLE_FIND_PACKAGE_OpenSSL=ON \
-            --cmake_extra_defines "HIPEP_WHEEL_EXTRA_DLLS=$AMDGPU_EP;$HIPEP_BACKEND"
+            --cmake_extra_defines "HIP_WHEEL_EXTRA_DLLS=$AMDGPU_EP;$HIP_BACKEND"
 
       # -----------------------------------------------------------------------
       # Build OGA (onnxruntime-genai) for model_benchmark.exe
@@ -542,19 +542,19 @@ jobs:
           cp "${{ runner.workspace }}/install/bin/"*.dll staging/bin/ 2>/dev/null || true
           cp "${{ runner.workspace }}/install/bin/"*.exe staging/bin/ 2>/dev/null || true
 
-          # AMD GPU umbrella EP + hipep-backend shim (built from the fork PR
-          # above). The umbrella loads hipep-backend.dll, which loads hipep.dll
+          # AMD GPU umbrella EP + hip-backend shim (built from the fork PR
+          # above). The umbrella loads hip-backend.dll, which loads hipgpu.dll
           # (the morphizen EP, already copied from install/bin). All three sit
           # together in staging/bin so the load chain resolves.
           AMDGPU_BUILD="${{ runner.workspace }}/build-amdgpu"
           AMDGPU_EP=$(find "$AMDGPU_BUILD" -name "amdgpu-ep.dll" -type f | head -1)
-          HIPEP_BACKEND=$(find "$AMDGPU_BUILD" -name "hipep-backend.dll" -type f | head -1)
-          if [ -z "$AMDGPU_EP" ] || [ -z "$HIPEP_BACKEND" ]; then
-            echo "ERROR: amdgpu-ep.dll or hipep-backend.dll not found in $AMDGPU_BUILD"
+          HIP_BACKEND=$(find "$AMDGPU_BUILD" -name "hip-backend.dll" -type f | head -1)
+          if [ -z "$AMDGPU_EP" ] || [ -z "$HIP_BACKEND" ]; then
+            echo "ERROR: amdgpu-ep.dll or hip-backend.dll not found in $AMDGPU_BUILD"
             exit 1
           fi
           cp "$AMDGPU_EP" staging/bin/
-          cp "$HIPEP_BACKEND" staging/bin/
+          cp "$HIP_BACKEND" staging/bin/
 
           # Smoke: the per-arch kernel DLL must be present in staging/bin/
           # for the gpu-test job to load it. Failure here means the install
@@ -658,7 +658,7 @@ jobs:
           OGA_WHEEL=$(find "${{ runner.workspace }}/oga-artifacts" \
             -name "onnxruntime_genai_directml-*.whl" -type f | head -1)
           EP_WHEEL=$(find "../build/$(basename "$PWD")/python/dist" \
-            -name "onnxruntime_ep_hipep-*.whl" -type f | head -1)
+            -name "onnxruntime_ep_hip-*.whl" -type f | head -1)
           if [ -z "$ORT_WHEEL" ] || [ -z "$OGA_WHEEL" ] || [ -z "$EP_WHEEL" ]; then
             echo "ERROR: wheel(s) missing"
             echo "  ORT=$ORT_WHEEL OGA=$OGA_WHEEL EP=$EP_WHEEL"
@@ -673,7 +673,7 @@ jobs:
       - name: Upload Python wheel package
         uses: actions/upload-artifact@v4
         with:
-          name: hipep-python-package
+          name: hip-python-package
           path: wheelpkg/
           retention-days: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release_')) && 14 || 3 }}
 
@@ -724,7 +724,7 @@ jobs:
       - name: Download Python wheel package
         uses: actions/download-artifact@v4
         with:
-          name: hipep-python-package
+          name: hip-python-package
           path: wheelpkg
 
       # TheRock DLLs are required at runtime on the GPU machine.
@@ -768,8 +768,8 @@ jobs:
           for /r "%MODEL_DIR%" %%M in (*seq128.onnx) do (
             echo === Testing %%~nxM ===
             onnxruntime_perf_test.exe ^
-              --plugin_ep_libs "hipep|hipep.dll" ^
-              --plugin_eps "hipep" ^
+              --plugin_ep_libs "hipgpu|hipgpu.dll" ^
+              --plugin_eps "hipgpu" ^
               --plugin_ep_options "config_file|..\morphizen_config.json" ^
               -C "session.disable_cpu_ep_fallback|1" ^
               -t 30 -c 1 -s ^
@@ -780,7 +780,7 @@ jobs:
           exit /b %FAILED%
 
       # ----------------------------------------------------------------------
-      # Native artifact smoke test (artifact_format=NATIVE), direct hipep EP.
+      # Native artifact smoke test (artifact_format=NATIVE), direct hipgpu EP.
       # Exercises the dual-format path: CompilerDriver emits a per-model .dll
       # (lld-link in-process), InferenceState loads it via morphizen::Plugin
       # (LoadLibrary). LLVM IR stays the production default; native is opt-in.
@@ -814,8 +814,8 @@ jobs:
           )
           echo === Native smoke %SMOKE_MODEL% ===
           onnxruntime_perf_test.exe ^
-            --plugin_ep_libs "hipep|hipep.dll" ^
-            --plugin_eps "hipep" ^
+            --plugin_ep_libs "hipgpu|hipgpu.dll" ^
+            --plugin_eps "hipgpu" ^
             --plugin_ep_options "config_file|..\morphizen_config.json artifact_format|NATIVE" ^
             -C "session.disable_cpu_ep_fallback|1" ^
             -r 1 -c 1 -s ^
@@ -828,11 +828,11 @@ jobs:
 
       # ----------------------------------------------------------------------
       # AMD GPU umbrella NATIVE smoke test: same NATIVE compile/link/load path,
-      # but driven through the amdgpu-ep umbrella instead of the hipep EP
+      # but driven through the amdgpu-ep umbrella instead of the hipgpu EP
       # directly. profile=llm (an umbrella option, ep.amdgpuexecutionprovider.
-      # prefix) selects the hipep backend; the umbrella forwards non-umbrella
+      # prefix) selects the hipgpu backend; the umbrella forwards non-umbrella
       # session-config entries verbatim, so artifact_format is passed as a raw
-      # ep.hipep.* entry to reach the backend. Real gate (no exit /b 0).
+      # ep.hipgpu.* entry to reach the backend. Real gate (no exit /b 0).
       # ----------------------------------------------------------------------
       - name: Run AMD GPU umbrella native smoke test (GPU)
         if: always()
@@ -860,7 +860,7 @@ jobs:
             --plugin_eps "AMDGPUExecutionProvider" ^
             --plugin_ep_options "profile|llm" ^
             -C "session.disable_cpu_ep_fallback|1" ^
-            -C "ep.hipep.artifact_format|NATIVE" ^
+            -C "ep.hipgpu.artifact_format|NATIVE" ^
             -r 1 -c 1 -s ^
             "%SMOKE_MODEL%" > "..\results-amdgpu-native\smoke.txt" 2>&1
           set RC=%ERRORLEVEL%
@@ -909,8 +909,8 @@ jobs:
 
             Write-Host "=== EPContext export: $($m.Name) ==="
             & .\onnxruntime_perf_test.exe `
-              --plugin_ep_libs "hipep|hipep.dll" `
-              --plugin_eps "hipep" `
+              --plugin_ep_libs "hipgpu|hipgpu.dll" `
+              --plugin_eps "hipgpu" `
               --plugin_ep_options "config_file|..\morphizen_config.json" `
               -C "session.disable_cpu_ep_fallback|1 ep.context_enable|1 ep.context_embed_mode|0 ep.context_file_path|$ctxPath" `
               -t 5 -c 1 -s -I `
@@ -929,8 +929,8 @@ jobs:
 
             Write-Host "=== EPContext import: $($m.Name) ==="
             & .\onnxruntime_perf_test.exe `
-              --plugin_ep_libs "hipep|hipep.dll" `
-              --plugin_eps "hipep" `
+              --plugin_ep_libs "hipgpu|hipgpu.dll" `
+              --plugin_eps "hipgpu" `
               --plugin_ep_options "config_file|..\morphizen_config.json" `
               -C "session.disable_cpu_ep_fallback|1" `
               -t 30 -c 1 -s -I `
@@ -1061,7 +1061,7 @@ jobs:
           if (-not (Test-Path $model)) { Write-Host "[SKIP] model not found: $model"; exit 0 }
 
           # The morphizen wheel now bundles the whole AMD GPU umbrella chain
-          # (amdgpu-ep.dll + hipep-backend.dll + hipep.dll + hip-compiler +
+          # (amdgpu-ep.dll + hip-backend.dll + hipgpu.dll + hip-compiler +
           # custom_kernels) into onnxruntime/capi/, next to onnxruntime.dll where
           # OGA discovers the EP. No DLL injection needed — exercise the wheel
           # path end-to-end.
@@ -1075,7 +1075,7 @@ jobs:
           Push-Location "$pkg\wheels"
           & $py -m pip install --quiet `
             (Get-Item onnxruntime_directml-*.whl).Name `
-            (Get-Item onnxruntime_ep_hipep-*.whl).Name `
+            (Get-Item onnxruntime_ep_hip-*.whl).Name `
             (Get-Item onnxruntime_genai_directml-*.whl).Name `
             --extra-index-url https://repo.amd.com/rocm/whl/gfx1151/ `
             psutil tqdm pandas
@@ -1103,9 +1103,9 @@ jobs:
         run: |
           setlocal enabledelayedexpansion
           set PATH=%CD%\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
-          rem The EP DLL is now hipep.dll; hip-onnx-runner's legacy default name
+          rem The EP DLL is now hipgpu.dll; hip-onnx-runner's legacy default name
           rem is onnxruntime_morphizen_ep.dll, so point it at the new DLL.
-          set MORPHIZEN_EP_LIB=%CD%\gpu-test-package\bin\hipep.dll
+          set MORPHIZEN_EP_LIB=%CD%\gpu-test-package\bin\hipgpu.dll
           set L2_MODEL_DIR=${{ runner.workspace }}\l2-test-models
           if not exist "%L2_MODEL_DIR%" (
             echo [SKIP] L2 model directory not found: %L2_MODEL_DIR%

--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -335,8 +335,8 @@ if(BUILD_EP)
 
   # MorphiZen EP build settings, forced before add_subdirectory consumes them.
   set(morphizen_ENABLE_RYZENAI_BIN_METADATA OFF CACHE BOOL "Disable ryzenai_bin_metadata" FORCE)
-  set(morphizen_OUTPUT_NAME "hipep" CACHE STRING "Set output name" FORCE)
-  set(MORPHIZEN_EP_REGISTRATION_NAME "hipep" CACHE STRING "EP registration name for ORT" FORCE)
+  set(morphizen_OUTPUT_NAME "hipgpu" CACHE STRING "Set output name" FORCE)
+  set(MORPHIZEN_EP_REGISTRATION_NAME "hipgpu" CACHE STRING "EP registration name for ORT" FORCE)
   set(MORPHIZEN_JSON_CONFIG_FILE "${CMAKE_CURRENT_SOURCE_DIR}/etc/morphizen_config.json")
 
   # ONNX Runtime resolution (find_package first, official release zip fallback).

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -187,7 +187,7 @@ python build.py --install_dir "$LOCAL_DIR" --cmake_prefix_path "$LOCAL_DIR"
 ```
 
 `--cmake_prefix_path "$LOCAL_DIR"` lets the build reuse an ONNX Runtime you
-installed in step 1; omit it and ORT is auto-downloaded. The hipep EP, HIP
+installed in step 1; omit it and ORT is auto-downloaded. The hipgpu EP, HIP
 tools and LIT tests are built and installed into `../local/`.
 
 ### 3. Build OGA (onnxruntime-genai)
@@ -200,7 +200,7 @@ against the same ORT version.
 **Prerequisites**: a local ORT install for `ORT_HOME` (build it in step 1, or
 stage the release zip). `--build_wheel` is only needed if you also want the ORT
 Python wheel (step 4); it is not required to build OGA's C++ artifacts. Step 2
-is only needed later to *run* `model_benchmark` against hipep EP, not to
+is only needed later to *run* `model_benchmark` against hipgpu EP, not to
 build OGA itself.
 
 Run all commands below from the `onnx-hipdnn-ep/` project root.
@@ -287,7 +287,7 @@ below. `onnxruntime_perf_test.exe` is staged separately in
 
 If you also want to drive ORT / OGA from Python (e.g. to write your own
 generation script instead of using `model_benchmark.exe`), install the wheels.
-The hipep EP wheel is built by default by `build.py` (pass `--skip_wheel` to
+The hipgpu EP wheel is built by default by `build.py` (pass `--skip_wheel` to
 opt out, or build just it with `cmake --build <build> --target wheel`) at
 `../build/onnx-hipdnn-ep/python/dist/`.
 
@@ -298,18 +298,18 @@ builds, not the stock PyPI ones), and let `--extra-index-url` resolve ROCm:
 cd ../onnx-hipdnn-ep  # Back to the project root
 pip install \
   ../build/onnxruntime/Release/dist/onnxruntime_directml-*.whl \
-  ../build/onnx-hipdnn-ep/python/dist/onnxruntime_ep_hipep-*.whl \
+  ../build/onnx-hipdnn-ep/python/dist/onnxruntime_ep_hip-*.whl \
   ../build/onnxruntime-genai/Release/wheel/onnxruntime_genai_directml-*.whl \
   --extra-index-url https://repo.amd.com/rocm/whl/gfx1151/
 ```
 > **Note**: the ORT whl may be under `../build/onnxruntime/Release/Release/dist/`.
 > Replace `gfx1151` with your GPU arch. Install the EP wheel AFTER onnxruntime:
-> it ships its own native files (EP plugin `hipep.dll`, hip-compiler, custom
+> it ships its own native files (EP plugin `hipgpu.dll`, hip-compiler, custom
 > kernels) straight into `onnxruntime/capi/` next to `onnxruntime.dll`. The ROCm
 > runtime DLLs (amdhip64/MIOpen/hipBLASLt) come from the `rocm[devel]` wheel
 > (expanded next). The wheel does NOT bundle the AMD GPU umbrella
-> (`amdgpu-ep.dll` + `hipep-backend.dll`); driving OGA through the umbrella needs
-> those supplied separately (CI injects them via `HIPEP_WHEEL_EXTRA_DLLS`).
+> (`amdgpu-ep.dll` + `hip-backend.dll`); driving OGA through the umbrella needs
+> those supplied separately (CI injects them via `HIP_WHEEL_EXTRA_DLLS`).
 
 **Expand ROCm devel** -- the EP's JIT linker needs the ROCm import libs, which
 `rocm[devel]` ships compressed. Expand them once:
@@ -349,15 +349,15 @@ python onnxruntime-genai/benchmark/python/benchmark_e2e.py \
 (v0.14.0 + PR2194, DeviceType AMDGPU) this is the AMD GPU umbrella
 (`provider_options [{ "AMDGPU": {"profile": "llm"} }]`), which loads
 `amdgpu-ep.dll` and needs the umbrella DLLs colocated (see
-`.github/workflows/windows-build.yml`); the default wheel ships only the hipep
-chain. For plain ORT (direct hipep, no OGA), register the colocated plugin via
-`ort.register_execution_provider_library("hipep", "$CAPI/hipep.dll")`.
+`.github/workflows/windows-build.yml`); the default wheel ships only the hipgpu
+chain. For plain ORT (direct hipgpu, no OGA), register the colocated plugin via
+`ort.register_execution_provider_library("hipgpu", "$CAPI/hipgpu.dll")`.
 
 ## Testing & Benchmarking
 
 ### Model Inference with hip-onnx-runner
 
-`hip-onnx-runner` runs a single ONNX model through hipep EP and reports
+`hip-onnx-runner` runs a single ONNX model through hipgpu EP and reports
 timing. It is built automatically when `BUILD_HIP_TOOLS=ON`.
 
 ```bash
@@ -377,7 +377,7 @@ export PATH="$(cd ../build/$(basename $PWD)/_therock/bin && pwd):$LOCAL_DIR/bin:
 > ```
 
 ```bash
-# Run with hipep EP (default), on your model directly (dynamic shape)
+# Run with hipgpu EP (default), on your model directly (dynamic shape)
 $LOCAL_DIR/bin/hip-onnx-runner.exe -m /path/to/model.onnx -i gen_inputs
 
 # Resolve symbolic input dims at runtime (the EP still compiles the dynamic graph)
@@ -407,7 +407,7 @@ $LOCAL_DIR/bin/hip-onnx-runner.exe -L ep_o_dump,cpu_o_dump
 ### Latency Benchmarking with onnxruntime_perf_test
 
 Use `onnxruntime_perf_test` to benchmark inference latency. The examples below
-compare hipep EP (AMD GPU via HIP) against DML EP.
+compare hipgpu EP (AMD GPU via HIP) against DML EP.
 
 **Setup:**
 
@@ -424,12 +424,12 @@ export PATH="$(cd ../build/$(basename $PWD)/_therock/bin && pwd):$PATH"
 cd $LOCAL_DIR/bin
 ```
 
-**hipep EP:**
+**hipgpu EP:**
 
 ```bash
 ./onnxruntime_perf_test.exe \
-  --plugin_ep_libs "hipep|hipep.dll" \
-  --plugin_eps "hipep" \
+  --plugin_ep_libs "hipgpu|hipgpu.dll" \
+  --plugin_eps "hipgpu" \
   -t 60 -c 1 -s -I \
   /path/to/model.onnx
 ```

--- a/docs/quick_start_linux.md
+++ b/docs/quick_start_linux.md
@@ -81,7 +81,7 @@ python3 build.py
 The result tree under `<workspace>/install/`:
 
 - `bin/hip-onnx-runner`, `bin/hip-compiler`, `bin/hip-mlir-opt`, `bin/hip-test`
-- `lib/libhip-compiler.so`, `lib/libhipep.so`
+- `lib/libhip-compiler.so`, `lib/libhipgpu.so`
 
 A locally-built `install/` is **not** fully self-contained: `libonnxruntime.so`
 lives in the ONNX Runtime prefix and the ROCm libs in TheRock, so run with
@@ -99,7 +99,7 @@ section once `install/bin/` is populated.
 ## Use the prebuilt package (testers, no compile)
 
 A ready-to-run package is published for each green build. It contains every
-`.so` / binary the host needs (`libhipep`,
+`.so` / binary the host needs (`libhipgpu`,
 `hip-onnx-runner`, `onnxruntime_perf_test`, `model_benchmark`,
 `libonnxruntime`, `libonnxruntime-genai`) plus a `clang`/`lld` toolchain in
 `bin/` (next to the other tools). TheRock is **not** included — install ROCm on
@@ -169,7 +169,7 @@ export LIBRARY_PATH="$ROOT/lib:$THEROCK_DIST/lib"
 export PATH="$ROOT/bin:$PATH"
 
 # Sanity check
-ldd "$ROOT/lib/libhipep.so" | grep "not found"   # expect empty
+ldd "$ROOT/lib/libhipgpu.so" | grep "not found"   # expect empty
 "$ROOT/bin/hip-onnx-runner" --help | head -5
 ```
 
@@ -182,7 +182,7 @@ exclusively, so the snippets are identical regardless of entry path.
 
 ### Model Inference with hip-onnx-runner
 
-`hip-onnx-runner` runs a single ONNX model through hipep EP and reports
+`hip-onnx-runner` runs a single ONNX model through hipgpu EP and reports
 timing. It is built by `build.py` and also ships in the prebuilt
 package.
 
@@ -197,7 +197,7 @@ package.
 > ```
 
 ```bash
-# Run with hipep EP (default), on your model directly (dynamic shape)
+# Run with hipgpu EP (default), on your model directly (dynamic shape)
 $ROOT/bin/hip-onnx-runner -m /path/to/model.onnx -i gen_inputs
 
 # Resolve symbolic input dims at runtime (the EP still compiles the dynamic graph)
@@ -227,17 +227,17 @@ $ROOT/bin/hip-onnx-runner -L ep_o_dump,cpu_o_dump
 ### Latency Benchmarking with onnxruntime_perf_test
 
 `onnxruntime_perf_test` benchmarks inference latency. It ships in the prebuilt
-package; a local build may not include it. The examples below compare hipep
+package; a local build may not include it. The examples below compare hipgpu
 EP against the CPU EP baseline (DML is Windows-only).
 
 ```bash
 # CPU baseline (no EP; useful to size the EP speedup)
 $ROOT/bin/onnxruntime_perf_test -e cpu -t 30 -c 1 -s /path/to/MODEL.onnx
 
-# hipep EP
+# hipgpu EP
 $ROOT/bin/onnxruntime_perf_test \
-  --plugin_ep_libs "hipep|$ROOT/lib/libhipep.so" \
-  --plugin_eps     "hipep" \
+  --plugin_ep_libs "hipgpu|$ROOT/lib/libhipgpu.so" \
+  --plugin_eps     "hipgpu" \
   -C "session.disable_cpu_ep_fallback|1" \
   -t 60 -c 1 -s -I \
   /path/to/MODEL.onnx
@@ -252,7 +252,7 @@ $ROOT/bin/onnxruntime_perf_test \
 | `-s` | Show per-iteration latency statistics |
 | `-I` | Use sequential inputs (do not randomize) |
 
-> The first iteration triggers hipep's HIP kernel JIT compile
+> The first iteration triggers hipgpu's HIP kernel JIT compile
 > (multi-minute); bump `-t` so steady-state samples dominate the average.
 
 ### OGA End-to-End Benchmarking with model_benchmark
@@ -346,13 +346,13 @@ Inside `./docker/run.sh shell` this is handled automatically — the
 container entrypoint reads the host GID off `/dev/kfd` and adds the
 in-container user to it, so you don't need host `render` membership.
 
-**`EP library not found: libhipep.so` from `hip-onnx-runner`**
+**`EP library not found: libhipgpu.so` from `hip-onnx-runner`**
 
 The runner's search order is `$MORPHIZEN_EP_LIB` (full path) → cwd →
-`<exe-dir>/libhipep.so` → `<exe-dir>/../lib/libhipep.so`.
+`<exe-dir>/libhipgpu.so` → `<exe-dir>/../lib/libhipgpu.so`.
 If you're running out of `install/bin/`, no env vars are needed — the
 sibling `install/lib/` is auto-discovered. If you've copied the binary
-elsewhere, set `MORPHIZEN_EP_LIB=/full/path/to/libhipep.so`.
+elsewhere, set `MORPHIZEN_EP_LIB=/full/path/to/libhipgpu.so`.
 
 **`clang++ not found on PATH and HIPDNN_CLANG_PATH is unset or stale` from `hip-compiler`**
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -38,7 +38,7 @@ configure_file(
   @ONLY)
 
 # The EP shared library target is created by morphizen via deps.cmake; its name
-# is the (git-versioned) unique id, output name hipep (morphizen_OUTPUT_NAME).
+# is the (git-versioned) unique id, output name hipgpu (morphizen_OUTPUT_NAME).
 set(_ep_target "${morphizen_CORE_DYNAMIC_UNIQUE_ID}")
 if(NOT TARGET ${_ep_target})
   message(FATAL_ERROR
@@ -82,14 +82,14 @@ foreach(_arch IN LISTS HIP_ARCHITECTURES)
 endforeach()
 
 # Externally-built DLLs to also bundle next to the EP (absolute paths, ;-list).
-# Used to ship the AMD GPU umbrella chain (amdgpu-ep.dll + hipep-backend.dll),
+# Used to ship the AMD GPU umbrella chain (amdgpu-ep.dll + hip-backend.dll),
 # which is built in the separate onnxruntime-ep-amdgpu repo and has no target
 # here. Passed as --optional-dll so a plain EP-only wheel (var unset) is
 # unaffected and a missing path warns instead of failing. The caller (CI) is
 # responsible for building those DLLs before this wheel target runs.
-set(HIPEP_WHEEL_EXTRA_DLLS "" CACHE STRING
+set(HIP_WHEEL_EXTRA_DLLS "" CACHE STRING
   "Absolute paths (;-list) of externally-built DLLs to bundle into the wheel")
-foreach(_extra IN LISTS HIPEP_WHEEL_EXTRA_DLLS)
+foreach(_extra IN LISTS HIP_WHEEL_EXTRA_DLLS)
   if(_extra)
     list(APPEND _dll_args "--optional-dll" "${_extra}")
   endif()
@@ -98,8 +98,8 @@ endforeach()
 add_custom_target(wheel ALL
   # 1. Stage the package sources into the build dir (keep source tree clean).
   COMMAND ${CMAKE_COMMAND} -E copy_directory
-          "${_pkg_src}/onnxruntime_ep_hipep"
-          "${_stage}/onnxruntime_ep_hipep"
+          "${_pkg_src}/onnxruntime_ep_hip"
+          "${_stage}/onnxruntime_ep_hip"
   COMMAND ${CMAKE_COMMAND} -E copy
           "${_pkg_src}/setup.py"
           "${_stage}/"
@@ -115,13 +115,13 @@ add_custom_target(wheel ALL
   #    they linger across runs and would re-pack stale (e.g. removed) artifacts.
   #    --no-deps: do not pull deps here.
   COMMAND ${CMAKE_COMMAND} -E rm -rf
-          "${_stage}/build" "${_stage}/onnxruntime_ep_hipep.egg-info"
+          "${_stage}/build" "${_stage}/onnxruntime_ep_hip.egg-info"
   COMMAND ${CMAKE_COMMAND} -E rm -rf "${_dist_dir}"
   COMMAND ${Python3_EXECUTABLE} -m pip wheel "${_stage}"
           --no-deps --wheel-dir "${_dist_dir}"
   DEPENDS ${_wheel_deps}
   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
-  COMMENT "Building onnxruntime_ep_hipep wheel -> ${_dist_dir}"
+  COMMENT "Building onnxruntime_ep_hip wheel -> ${_dist_dir}"
   VERBATIM)
 
 message(STATUS "Python wheel target 'wheel' configured (out: ${_dist_dir})")

--- a/python/_pack_libs.py
+++ b/python/_pack_libs.py
@@ -87,7 +87,7 @@ def main():
         default=[],
         metavar="PATH",
         help="Externally-built runtime library to bundle if present (repeatable), "
-        "e.g. the amdgpu-ep/hipep-backend DLLs built in a separate repo. Missing "
+        "e.g. the amdgpu-ep/hip-backend DLLs built in a separate repo. Missing "
         "paths warn instead of failing, so a plain EP-only wheel build still works.",
     )
     ap.add_argument(

--- a/python/examples/run_onnx.py
+++ b/python/examples/run_onnx.py
@@ -10,7 +10,7 @@ from the installed wheels, then either:
   - Delegates to benchmark_e2e.py for OGA benchmarks (--benchmark).
 
 Prerequisites (see docs/python_package_guide.md):
-  - pip install the onnxruntime + onnxruntime_ep_hipep wheels
+  - pip install the onnxruntime + onnxruntime_ep_hip wheels
   - rocm-sdk init        (expands rocm[devel] import libs)
 
 Usage:
@@ -69,7 +69,7 @@ def _random_input(spec):
 
 
 def _run_onnx(model_path, capi):
-    ort.register_execution_provider_library(EP_NAME, os.path.join(capi, "hipep.dll"))
+    ort.register_execution_provider_library(EP_NAME, os.path.join(capi, "hipgpu.dll"))
 
     devices = [d for d in ort.get_ep_devices() if d.ep_name == EP_NAME]
     if not devices:

--- a/python/onnxruntime_ep_hip/__init__.py
+++ b/python/onnxruntime_ep_hip/__init__.py
@@ -2,12 +2,12 @@
 # Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 # Licensed under the MIT License.
 #
-"""hipep Execution Provider for ONNX Runtime -- packaging marker.
+"""hipgpu Execution Provider for ONNX Runtime -- packaging marker.
 
 This distribution carries no Python API and no payload in this package. Its
-native artifacts (the EP plugin ``hipep.dll``, its hip-compiler JIT plugin, the
+native artifacts (the EP plugin ``hipgpu.dll``, its hip-compiler JIT plugin, the
 per-arch custom-kernels, and the AMD GPU umbrella chain ``amdgpu-ep.dll`` +
-``hipep-backend.dll``) are installed directly into ``onnxruntime/capi/`` -- next
+``hip-backend.dll``) are installed directly into ``onnxruntime/capi/`` -- next
 to ``onnxruntime.dll`` -- by the wheel. The ROCm import libraries come from
 ``rocm[devel]``.
 
@@ -16,8 +16,8 @@ Install this wheel AFTER ``onnxruntime`` so ``onnxruntime/capi/`` exists. Then:
 - ONNX Runtime GenAI (OGA) discovers and registers the EP automatically (it
   searches next to ``onnxruntime.dll``).
 - ONNX Runtime: register the colocated plugin, e.g.
-  ``ort.register_execution_provider_library("hipep",
-  <onnxruntime capi>/hipep.dll)``.
+  ``ort.register_execution_provider_library("hipgpu",
+  <onnxruntime capi>/hipgpu.dll)``.
 
 ROCm runtime DLLs must be on ``PATH`` (e.g. from ``rocm[libraries]``).
 """

--- a/python/pyproject.toml.in
+++ b/python/pyproject.toml.in
@@ -9,9 +9,9 @@ requires = ["setuptools>=64", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "onnxruntime-ep-hipep"
+name = "onnxruntime-ep-hip"
 version = "@PROJECT_VERSION@"
-description = "hipep Execution Provider for ONNX Runtime (AMD GPU via HIP/ROCm)"
+description = "hipgpu Execution Provider for ONNX Runtime (AMD GPU via HIP/ROCm)"
 requires-python = ">=3.8"
 license = { text = "MIT" }
 authors = [{ name = "Advanced Micro Devices, Inc." }]
@@ -38,7 +38,7 @@ dependencies = [
 # onnxruntime/capi/, so we never clobber ONNX Runtime's own files).
 
 [tool.setuptools.packages.find]
-include = ["onnxruntime_ep_hipep", "onnxruntime.capi"]
+include = ["onnxruntime_ep_hip", "onnxruntime.capi"]
 namespaces = true
 
 [tool.setuptools.package-data]

--- a/tools/hip-onnx-runner/hip-onnx-runner.cpp
+++ b/tools/hip-onnx-runner/hip-onnx-runner.cpp
@@ -878,11 +878,11 @@ int main(int argc, char *argv[]) {
   // ORT environment
   Ort::Env env(ORT_LOGGING_LEVEL_ERROR, "hip-onnx-runner");
 
-  const std::string kEpName = "hipep";
+  const std::string kEpName = "hipgpu";
 #ifdef _WIN32
-  const std::string ep_lib_name = "hipep.dll";
+  const std::string ep_lib_name = "hipgpu.dll";
 #else
-  const std::string ep_lib_name = "libhipep.so";
+  const std::string ep_lib_name = "libhipgpu.so";
 #endif
 
   if (!no_ep) {


### PR DESCRIPTION
## Summary

Rename the morphizen execution provider from `hipep` to `hipgpu` (output/registration name, the `ep.hipgpu.*` provider-option prefix, `hip-onnx-runner`, docs, Windows CI), and name the Python wheel `onnxruntime-ep-hip` to match the `onnxruntime-ep-<backend>` convention used by the umbrella's sibling wheels. This addresses review feedback on the AMD GPU umbrella that the backend name must not expose that it is a standalone execution provider.

## Why

The EP shipped as `hipep` (i.e. "HIP EP"), which leaks that it is a standalone execution provider — exactly what the umbrella EP review asked us to avoid. The concrete EP plugin is renamed `hipgpu` (DLL/registration/provider-option prefix), while the distributable Python package is `onnxruntime-ep-hip`, mirroring the sibling `onnxruntime_ep_migraphx` / `onnxruntime_ep_directml` wheels (named after the backend family, not the plugin DLL). The umbrella backend shim (separate repo) is `hip-backend` / `hip-ep`; this PR aligns the morphizen EP it loads so the chain `amdgpu-ep.dll` -> `hip-backend.dll` -> `hipgpu.dll` is consistent.

## What

1. `cmake/deps.cmake`: `morphizen_OUTPUT_NAME` and `MORPHIZEN_EP_REGISTRATION_NAME` `hipep` -> `hipgpu` (drives the DLL/so name and the ORT registration name).
2. `tools/hip-onnx-runner/hip-onnx-runner.cpp`: default EP name and library (`hipgpu.dll` / `libhipgpu.so`).
3. Python packaging: wheel/distribution `onnxruntime-ep-hip`, package dir `python/onnxruntime_ep_hip/`, and the `HIP_WHEEL_EXTRA_DLLS` cmake cache var (`python/pyproject.toml.in`, `python/CMakeLists.txt`, `python/examples/run_onnx.py`, `python/_pack_libs.py`). The wheel still ships the `hipgpu` EP plugin DLL into `onnxruntime/capi/`.
4. `.github/workflows/windows-build.yml`: smoke tests use `--plugin_eps hipgpu` / `hipgpu.dll`, `ep.hipgpu.*`; the `hip-python-package` artifact and `onnxruntime_ep_hip-*.whl`; umbrella references updated to the renamed shim (`hip-backend` / `hip-ep`) with the pinned amdgpu-ep commit bumped.
5. `.github/workflows/linux-build.yml`: `libhipep.so` -> `libhipgpu.so`.
6. Docs (`docs/quick_start.md`, `docs/quick_start_linux.md`) updated to match.

## Test plan

- [ ] build-windows green: wheel builds as `onnxruntime_ep_hip-*.whl`; perf_test/native smoke tests load `hipgpu.dll` and the `ep.hipgpu.*` path resolves.
- [ ] build-linux green: `libhipgpu.so` ships and `hip-onnx-runner` resolves the EP.
- [ ] `git grep -i hipep` returns nothing in this repo.

## Notes for reviewers

Naming split is intentional: the Python distribution is `onnxruntime-ep-hip` (backend-family name, matching the sibling EP wheels), while the concrete EP plugin / ORT registration / provider-option prefix is `hipgpu` (`hipgpu.dll`, register as `hipgpu`, `ep.hipgpu.*`). The umbrella backend shim was renamed in the sibling `onnxruntime-ep-amdgpu` repo (`hip-backend` / `hip-ep`); the amdgpu-ep commit pinned in `windows-build.yml` is bumped to the matching revision. Any external caller using the old `ep.hipep.*` prefix or registering the EP as `hipep` must update to `hipgpu`.
