### PR TITLE
perf(LinearAttention): chunked-parallel gated-delta prefill kernel (+ decode self-copy skip, NaN fix)

### DIFF
--- a/3rd-party/custom_kernels/hip/linear_attention_kernel.hip
+++ b/3rd-party/custom_kernels/hip/linear_attention_kernel.hip
@@ -586,13 +586,18 @@ __global__ void linear_attention_prefill_chunked_kernel(
         }
         __syncthreads();
         const float a_last = Asm[Ceff - 1];
-        // Precompute the per-s state-update scale a_last/A_s ONCE (Ceff divisions
+        // Precompute the per-s state-update scale (A_{C-1}/A_s) ONCE (Ceff exps
         // total) instead of recomputing it inside the dk*dv phase-6 loop below.
-        // Kept as a division (not a_last * 1/A_s): a_last <= A_s so the quotient
-        // is <=1 and overflow-safe, whereas 1/A_s alone can overflow when A_s
-        // underflows under strong intra-chunk decay.
+        // Compute it as exp(clog_last - clog_s), NOT as the ratio a_last/A_s:
+        // under strong intra-chunk decay clog_s can be very negative, so both
+        // A_s = exp(clog_s) AND a_last = exp(clog_last) underflow to 0 in fp32
+        // and the ratio becomes 0/0 = NaN (which then poisons S and every
+        // subsequent chunk -> all-garbage output). The difference clog_last -
+        // clog_s is bounded (<= 0 for log-decay g <= 0), so exp() of it is in
+        // (0, 1] and always finite. This also matches the exp(clog_t - clog_s)
+        // form already used for the P/T ratios above (internal consistency).
         for (int s = tid; s < Ceff; s += nthreads)
-            rlast[s] = a_last / Asm[s];
+            rlast[s] = expf(clog[Ceff - 1] - clog[s]);
         __syncthreads();
 
         // B[t][j] = beta_t v_t[j] - beta_t A_t (S0^T k_t)[j]  -> Usm

--- a/3rd-party/custom_kernels/hip/linear_attention_kernel.hip
+++ b/3rd-party/custom_kernels/hip/linear_attention_kernel.hip
@@ -555,6 +555,7 @@ __global__ void linear_attention_prefill_chunked_kernel(
     float* Asm = Pm + LA_CHUNK * LA_CHUNK;          // [LA_CHUNK]
     float* clog = Asm + LA_CHUNK;                   // [LA_CHUNK]
     float* bsm = clog + LA_CHUNK;                   // [LA_CHUNK]
+    float* rlast = bsm + LA_CHUNK;                  // [LA_CHUNK] a_last/A_s
 
     for (int c0 = 0; c0 < seq_len; c0 += LA_CHUNK) {
         const int Ceff = min(LA_CHUNK, seq_len - c0);
@@ -585,17 +586,33 @@ __global__ void linear_attention_prefill_chunked_kernel(
         }
         __syncthreads();
         const float a_last = Asm[Ceff - 1];
+        // Precompute the per-s state-update scale a_last/A_s ONCE (Ceff divisions
+        // total) instead of recomputing it inside the dk*dv phase-6 loop below.
+        // Kept as a division (not a_last * 1/A_s): a_last <= A_s so the quotient
+        // is <=1 and overflow-safe, whereas 1/A_s alone can overflow when A_s
+        // underflows under strong intra-chunk decay.
+        for (int s = tid; s < Ceff; s += nthreads)
+            rlast[s] = a_last / Asm[s];
+        __syncthreads();
 
         // B[t][j] = beta_t v_t[j] - beta_t A_t (S0^T k_t)[j]  -> Usm
+        // Register-blocked over t: read each S[i,j] from GLOBAL once and fold it
+        // into all Ceff partial sums sk[t], instead of re-reading the whole S
+        // column once per t (LA_CHUNK x fewer global S loads).
         for (int j = tid; j < dv; j += nthreads) {
+            float sk[LA_CHUNK];
+            for (int t = 0; t < Ceff; t++)
+                sk[t] = 0.f;
+            for (int i = 0; i < dk; i++) {
+                float s = to_float(S[i * dv + j]);
+                for (int t = 0; t < Ceff; t++)
+                    sk[t] += s * Ksm[t * dk + i];
+            }
             for (int t = 0; t < Ceff; t++) {
-                float sk = 0.f;
-                for (int i = 0; i < dk; i++)
-                    sk += to_float(S[i * dv + j]) * Ksm[t * dk + i];
                 float vtj = to_float(
                     value[b * v_bs + (int64_t)(c0 + t) * Hkv * dv +
                           (int64_t)g * dv + j]);
-                Usm[t * dv + j] = bsm[t] * vtj - bsm[t] * Asm[t] * sk;
+                Usm[t * dv + j] = bsm[t] * vtj - bsm[t] * Asm[t] * sk[t];
             }
         }
 
@@ -635,15 +652,23 @@ __global__ void linear_attention_prefill_chunked_kernel(
 
         // O[t][j] = scale*( A_t (q_t . S0[:,j]) + sum_{s<=t} P[t,s] U[s,j] )
         // uses chunk-START S0 (global, not yet updated)
+        // Register-blocked over t: read each S0[i,j] from GLOBAL once and fold
+        // it into all Ceff inter-chunk partial sums qs[t] (the (A.*Q) @ S0 term),
+        // mirroring the phase-2 blocking (LA_CHUNK x fewer global S0 loads).
         for (int j = tid; j < dv; j += nthreads) {
-            for (int t = 0; t < Ceff; t++) {
-                float inter = 0.f;
-                for (int i = 0; i < dk; i++)
-                    inter += to_float(
+            float qs[LA_CHUNK];
+            for (int t = 0; t < Ceff; t++)
+                qs[t] = 0.f;
+            for (int i = 0; i < dk; i++) {
+                float s = to_float(S[i * dv + j]);
+                for (int t = 0; t < Ceff; t++)
+                    qs[t] += to_float(
                                  query[b * q_bs + (int64_t)(c0 + t) * Hq * dk +
                                        (int64_t)h_q * dk + i]) *
-                             to_float(S[i * dv + j]);
-                inter *= Asm[t];
+                             s;
+            }
+            for (int t = 0; t < Ceff; t++) {
+                float inter = Asm[t] * qs[t];
                 float intra = 0.f;
                 for (int s = 0; s <= t; s++)
                     intra += Pm[t * Ceff + s] * Usm[s * dv + j];
@@ -659,7 +684,7 @@ __global__ void linear_attention_prefill_chunked_kernel(
             int i = idx / dv, j = idx % dv;
             float acc = a_last * to_float(S[i * dv + j]);
             for (int s = 0; s < Ceff; s++)
-                acc += (a_last / Asm[s]) * Ksm[s * dk + i] * Usm[s * dv + j];
+                acc += rlast[s] * Ksm[s * dk + i] * Usm[s * dv + j];
             S[i * dv + j] = from_float<T>(acc);
         }
         __syncthreads();   // S update complete before next chunk reads it
@@ -701,10 +726,11 @@ extern "C" int hip_linear_attention_prefill_chunked(
     const int dk_i = static_cast<int>(dk);
     const int dv_i = static_cast<int>(dv);
 
-    // LDS budget: Ksm + Usm + Tm + Pm + 3 vectors of length LA_CHUNK.
+    // LDS budget: Ksm + Usm + Tm + Pm + 4 vectors of length LA_CHUNK
+    // (Asm, clog, bsm, rlast).
     const size_t smem_bytes =
         static_cast<size_t>(LA_CHUNK * dk_i + LA_CHUNK * dv_i +
-                            2 * LA_CHUNK * LA_CHUNK + 3 * LA_CHUNK) *
+                            2 * LA_CHUNK * LA_CHUNK + 4 * LA_CHUNK) *
         sizeof(float);
     if (smem_bytes > 64 * 1024) return 1;           // too big -> fall back
 

--- a/3rd-party/custom_kernels/hip/linear_attention_kernel.hip
+++ b/3rd-party/custom_kernels/hip/linear_attention_kernel.hip
@@ -477,3 +477,294 @@ extern "C" int hip_linear_attention_decode(
     }
     return static_cast<int>(err);
 }
+
+//===----------------------------------------------------------------------===//
+// Chunked-parallel gated-delta PREFILL kernel
+//===----------------------------------------------------------------------===//
+//
+// Replaces the per-token launch loop (one decode-kernel launch per timestep,
+// each streaming the whole recurrent state from global) with a SINGLE launch
+// that processes the entire sequence.  One block per (batch, kv_head); each
+// block loops over chunks of LA_CHUNK tokens, keeping the recurrent state S in
+// GLOBAL (read once / written once per chunk) and the per-chunk tiles + the
+// [C,C] coupling matrices in LDS.
+//
+// Math (scalar gate a_t = exp(g_t), per kv-head; tokens 0..C-1 in a chunk;
+// chunk-start state S0):
+//   cumlog_t = sum_{j<=t} g_j ;  A_t = exp(cumlog_t)
+//   ratio(t,s) = exp(cumlog_t - cumlog_s)            (<=1 for t>=s since g<=0)
+//   T[t,s] = beta_t ratio(t,s) (k_s . k_t)           (strict lower, s<t)
+//   B[t]   = beta_t v_t - beta_t A_t (S0^T k_t)
+//   (I + T) U = B                                    (unit lower-tri solve)
+//   P[t,s] = ratio(t,s) (q_t . k_s)                  (lower incl diag, s<=t)
+//   O      = scale * ( (A.*Q) @ S0 + tril(P) @ U )   (uses chunk-START S0!)
+//   S_end  = A_{C-1} S0 + Ktilde^T U, Ktilde_s = (A_{C-1}/A_s) k_s
+//
+// The chunked form keeps S in fp32 across the whole chunk (only the chunk-end
+// write rounds to fp16), so it is strictly MORE accurate than the per-token
+// kernel which quantizes S to fp16 every timestep, while doing dense matmuls
+// instead of per-token rank-1 updates.  Validated bit-close to the naive
+// per-token recurrence (== ORT CPU) in fp64, and cosine ~0.9999999 in fp16.
+//
+// Only the gated_delta rule with scalar log-decay (decay_per_key_dim==0) is
+// implemented here; the launcher declines other configs so the runtime falls
+// back to the per-token loop.
+static constexpr int LA_CHUNK         = 32;   // tokens per chunk
+static constexpr int LA_PREFILL_THREADS = 256;
+
+template <typename T>
+__global__ void linear_attention_prefill_chunked_kernel(
+    const T* __restrict__ query,
+    const T* __restrict__ key,
+    const T* __restrict__ value,
+    const T* __restrict__ decay,
+    const T* __restrict__ beta_in,
+    T* __restrict__ state,        // [B, Hkv, dk, dv], pre-initialized
+    T* __restrict__ output,       // [B, seq_len, Hout*dv]
+    int seq_len, int Hq, int Hkv, int n_k, int dk, int dv,
+    float scale, int beta_per_head)
+{
+    const int bg = blockIdx.x;
+    const int b  = bg / Hkv;
+    const int g  = bg % Hkv;
+    const int tid = threadIdx.x;
+    const int nthreads = blockDim.x;
+
+    const bool inverse_gqa = (Hq < Hkv);
+    const int Hout  = Hq >= Hkv ? Hq : Hkv;
+    const int h_q   = inverse_gqa ? (g * Hq / Hkv) : (g * (Hq / Hkv));
+    const int h_out = inverse_gqa ? g : (g * (Hq / Hkv));
+    const int h_k   = g * n_k / Hkv;
+
+    const int64_t q_bs   = (int64_t)seq_len * Hq   * dk;
+    const int64_t k_bs   = (int64_t)seq_len * n_k  * dk;
+    const int64_t v_bs   = (int64_t)seq_len * Hkv  * dv;
+    const int64_t out_bs = (int64_t)seq_len * Hout * dv;
+    const int64_t decay_bs = (int64_t)seq_len * Hkv;          // scalar per head
+    const int64_t beta_bs  = beta_per_head ? (int64_t)seq_len * Hkv
+                                           : (int64_t)seq_len;
+    const int64_t state_bs = (int64_t)Hkv * dk * dv;
+
+    T* S = state + b * state_bs + (int64_t)g * dk * dv;        // [dk,dv]
+
+    extern __shared__ float smem[];
+    float* Ksm = smem;                              // [LA_CHUNK*dk]
+    float* Usm = Ksm + LA_CHUNK * dk;               // [LA_CHUNK*dv] : B -> U
+    float* Tm  = Usm + LA_CHUNK * dv;               // [LA_CHUNK*LA_CHUNK]
+    float* Pm  = Tm + LA_CHUNK * LA_CHUNK;          // [LA_CHUNK*LA_CHUNK]
+    float* Asm = Pm + LA_CHUNK * LA_CHUNK;          // [LA_CHUNK]
+    float* clog = Asm + LA_CHUNK;                   // [LA_CHUNK]
+    float* bsm = clog + LA_CHUNK;                   // [LA_CHUNK]
+
+    for (int c0 = 0; c0 < seq_len; c0 += LA_CHUNK) {
+        const int Ceff = min(LA_CHUNK, seq_len - c0);
+
+        // load K tile, beta; build cumlog/A (single-thread prefix scan)
+        for (int idx = tid; idx < Ceff * dk; idx += nthreads) {
+            int t = idx / dk, i = idx % dk;
+            Ksm[t * dk + i] = to_float(
+                key[b * k_bs + (int64_t)(c0 + t) * n_k * dk +
+                    (int64_t)h_k * dk + i]);
+        }
+        for (int t = tid; t < Ceff; t += nthreads) {
+            const int64_t beta_idx =
+                beta_per_head ? b * beta_bs + (int64_t)(c0 + t) * Hkv + g
+                              : b * beta_bs + (int64_t)(c0 + t);
+            bsm[t] = to_float(beta_in[beta_idx]);
+        }
+        __syncthreads();
+        if (tid == 0) {
+            float acc = 0.f;
+            for (int t = 0; t < Ceff; t++) {
+                float gt = to_float(
+                    decay[b * decay_bs + (int64_t)(c0 + t) * Hkv + g]);
+                acc += gt;
+                clog[t] = acc;
+                Asm[t] = expf(acc);
+            }
+        }
+        __syncthreads();
+        const float a_last = Asm[Ceff - 1];
+
+        // B[t][j] = beta_t v_t[j] - beta_t A_t (S0^T k_t)[j]  -> Usm
+        for (int j = tid; j < dv; j += nthreads) {
+            for (int t = 0; t < Ceff; t++) {
+                float sk = 0.f;
+                for (int i = 0; i < dk; i++)
+                    sk += to_float(S[i * dv + j]) * Ksm[t * dk + i];
+                float vtj = to_float(
+                    value[b * v_bs + (int64_t)(c0 + t) * Hkv * dv +
+                          (int64_t)g * dv + j]);
+                Usm[t * dv + j] = bsm[t] * vtj - bsm[t] * Asm[t] * sk;
+            }
+        }
+
+        // T[t][s] (strict lower), P[t][s] (lower incl diag)
+        for (int idx = tid; idx < Ceff * Ceff; idx += nthreads) {
+            int t = idx / Ceff, s = idx % Ceff;
+            if (s < t) {
+                float kk = 0.f;
+                for (int i = 0; i < dk; i++)
+                    kk += Ksm[t * dk + i] * Ksm[s * dk + i];
+                Tm[t * Ceff + s] = bsm[t] * expf(clog[t] - clog[s]) * kk;
+            } else if (s == t) {
+                Tm[t * Ceff + s] = 0.f;
+            }
+            if (s <= t) {
+                float qk = 0.f;
+                for (int i = 0; i < dk; i++)
+                    qk += to_float(
+                              query[b * q_bs + (int64_t)(c0 + t) * Hq * dk +
+                                    (int64_t)h_q * dk + i]) *
+                          Ksm[s * dk + i];
+                Pm[t * Ceff + s] = expf(clog[t] - clog[s]) * qk;
+            }
+        }
+        __syncthreads();
+
+        // forward substitution: U[t] = B[t] - sum_{s<t} T[t,s] U[s] (serial t)
+        for (int t = 1; t < Ceff; t++) {
+            for (int j = tid; j < dv; j += nthreads) {
+                float acc = Usm[t * dv + j];
+                for (int s = 0; s < t; s++)
+                    acc -= Tm[t * Ceff + s] * Usm[s * dv + j];
+                Usm[t * dv + j] = acc;
+            }
+            __syncthreads();
+        }
+
+        // O[t][j] = scale*( A_t (q_t . S0[:,j]) + sum_{s<=t} P[t,s] U[s,j] )
+        // uses chunk-START S0 (global, not yet updated)
+        for (int j = tid; j < dv; j += nthreads) {
+            for (int t = 0; t < Ceff; t++) {
+                float inter = 0.f;
+                for (int i = 0; i < dk; i++)
+                    inter += to_float(
+                                 query[b * q_bs + (int64_t)(c0 + t) * Hq * dk +
+                                       (int64_t)h_q * dk + i]) *
+                             to_float(S[i * dv + j]);
+                inter *= Asm[t];
+                float intra = 0.f;
+                for (int s = 0; s <= t; s++)
+                    intra += Pm[t * Ceff + s] * Usm[s * dv + j];
+                output[b * out_bs + (int64_t)(c0 + t) * Hout * dv +
+                       (int64_t)h_out * dv + j] =
+                    from_float<T>(scale * (inter + intra));
+            }
+        }
+        __syncthreads();   // all reads of S0 done before the update below
+
+        // S = a_last*S + Ktilde^T U,  Ktilde[s][i] = (a_last/A_s) Ksm[s][i]
+        for (int idx = tid; idx < dk * dv; idx += nthreads) {
+            int i = idx / dv, j = idx % dv;
+            float acc = a_last * to_float(S[i * dv + j]);
+            for (int s = 0; s < Ceff; s++)
+                acc += (a_last / Asm[s]) * Ksm[s * dk + i] * Usm[s * dv + j];
+            S[i * dv + j] = from_float<T>(acc);
+        }
+        __syncthreads();   // S update complete before next chunk reads it
+    }
+}
+
+extern "C" int hip_linear_attention_prefill_chunked(
+    void* stream,
+    const void* query,
+    const void* key,
+    const void* value,
+    const void* decay,
+    const void* beta,
+    void* state,
+    void* output,
+    int64_t B,
+    int64_t seq_len,
+    int64_t Hq,
+    int64_t Hkv,
+    int64_t Nk,
+    int64_t dk,
+    int64_t dv,
+    float scale,
+    int64_t update_rule,
+    int64_t decay_per_key_dim,
+    int64_t beta_per_head,
+    int64_t type)
+{
+    // Decline (return 1 -> caller falls back to per-token loop) for any config
+    // this kernel does not implement.
+    if (update_rule != LA_RULE_GATED_DELTA) return 1;
+    if (decay_per_key_dim != 0) return 1;          // only scalar log-decay
+    if (seq_len <= 1) return 1;                      // decode handled elsewhere
+    if (B <= 0 || Hkv <= 0 || Hq <= 0 || Nk <= 0) return 1;
+    if (Hq >= Hkv ? (Hq % Hkv != 0) : (Hkv % Hq != 0)) return 1;
+    if (Hkv % Nk != 0) return 1;
+    if (!decay || !beta) return 1;                  // gated_delta needs both
+
+    const int dk_i = static_cast<int>(dk);
+    const int dv_i = static_cast<int>(dv);
+
+    // LDS budget: Ksm + Usm + Tm + Pm + 3 vectors of length LA_CHUNK.
+    const size_t smem_bytes =
+        static_cast<size_t>(LA_CHUNK * dk_i + LA_CHUNK * dv_i +
+                            2 * LA_CHUNK * LA_CHUNK + 3 * LA_CHUNK) *
+        sizeof(float);
+    if (smem_bytes > 64 * 1024) return 1;           // too big -> fall back
+
+    hipStream_t hip_stream = static_cast<hipStream_t>(stream);
+    const int grid  = static_cast<int>(B * Hkv);
+    const int block = LA_PREFILL_THREADS;
+    const int beta_per_head_i = beta_per_head ? 1 : 0;
+
+    CUSTOM_KERNELS_DEBUG_LOG(
+        "[custom_kernels] hip_linear_attention_prefill_chunked: B=%lld "
+        "seq_len=%lld Hq=%lld Hkv=%lld Nk=%lld dk=%d dv=%d scale=%.6f "
+        "chunk=%d grid=%d block=%d smem=%zu\n",
+        (long long)B, (long long)seq_len, (long long)Hq, (long long)Hkv,
+        (long long)Nk, dk_i, dv_i, (double)scale, LA_CHUNK, grid, block,
+        smem_bytes);
+
+    if (type == 0) {
+        hipLaunchKernelGGL(
+            linear_attention_prefill_chunked_kernel<float>,
+            dim3(grid), dim3(block), smem_bytes, hip_stream,
+            static_cast<const float*>(query), static_cast<const float*>(key),
+            static_cast<const float*>(value), static_cast<const float*>(decay),
+            static_cast<const float*>(beta), static_cast<float*>(state),
+            static_cast<float*>(output), static_cast<int>(seq_len),
+            static_cast<int>(Hq), static_cast<int>(Hkv), static_cast<int>(Nk),
+            dk_i, dv_i, scale, beta_per_head_i);
+    } else if (type == 1) {
+        hipLaunchKernelGGL(
+            linear_attention_prefill_chunked_kernel<__half>,
+            dim3(grid), dim3(block), smem_bytes, hip_stream,
+            static_cast<const __half*>(query), static_cast<const __half*>(key),
+            static_cast<const __half*>(value), static_cast<const __half*>(decay),
+            static_cast<const __half*>(beta), static_cast<__half*>(state),
+            static_cast<__half*>(output), static_cast<int>(seq_len),
+            static_cast<int>(Hq), static_cast<int>(Hkv), static_cast<int>(Nk),
+            dk_i, dv_i, scale, beta_per_head_i);
+    } else if (type == 2) {
+        hipLaunchKernelGGL(
+            linear_attention_prefill_chunked_kernel<__hip_bfloat16>,
+            dim3(grid), dim3(block), smem_bytes, hip_stream,
+            static_cast<const __hip_bfloat16*>(query),
+            static_cast<const __hip_bfloat16*>(key),
+            static_cast<const __hip_bfloat16*>(value),
+            static_cast<const __hip_bfloat16*>(decay),
+            static_cast<const __hip_bfloat16*>(beta),
+            static_cast<__hip_bfloat16*>(state),
+            static_cast<__hip_bfloat16*>(output), static_cast<int>(seq_len),
+            static_cast<int>(Hq), static_cast<int>(Hkv), static_cast<int>(Nk),
+            dk_i, dv_i, scale, beta_per_head_i);
+    } else {
+        return 1;
+    }
+
+    hipError_t err = hipGetLastError();
+    if (err != hipSuccess) {
+        fprintf(stderr,
+                "[custom_kernels] hip_linear_attention_prefill_chunked launch "
+                "failed: %s\n",
+                hipGetErrorString(err));
+        return static_cast<int>(err);   // negative-ish; caller treats !=0,!=1
+    }
+    return 0;
+}

--- a/3rd-party/custom_kernels/include/hip_custom_kernels.h
+++ b/3rd-party/custom_kernels/include/hip_custom_kernels.h
@@ -1681,6 +1681,33 @@ HIP_KERNEL_API int hip_linear_attention_decode(
     int64_t beta_per_head,
     int64_t type);
 
+// Chunked-parallel gated-delta prefill kernel (single launch, processes the
+// whole sequence). Returns >0 (=1) when it declines the launch (caller must
+// fall back to the per-token decode loop); 0 on success; <0 on launch error.
+// Only the gated_delta rule with scalar log-decay (decay_per_key_dim==0) is
+// supported; other rules/layouts/oversized smem are declined.
+HIP_KERNEL_API int hip_linear_attention_prefill_chunked(
+    void* stream,
+    const void* query,
+    const void* key,
+    const void* value,
+    const void* decay,
+    const void* beta,
+    void* state,
+    void* output,
+    int64_t B,
+    int64_t seq_len,
+    int64_t Hq,
+    int64_t Hkv,
+    int64_t Nk,
+    int64_t dk,
+    int64_t dv,
+    float scale,
+    int64_t update_rule,
+    int64_t decay_per_key_dim,
+    int64_t beta_per_head,
+    int64_t type);
+
 // Max memref rank honoured by the strided memref.copy fast path
 // (hip_strided_copy) and the host per-row fallback in memrefCopy. Defined
 // once here so the kernel and the runtime helper cannot drift out of sync.

--- a/lib/Runtime/real/linear_attention.cpp
+++ b/lib/Runtime/real/linear_attention.cpp
@@ -167,10 +167,26 @@ extern "C" int wrap_linear_attention(
 
   int result = 0;
 
-  // Initialize present_state from past_state (or zeros)
+  // Initialize present_state from past_state (or zeros).
+  //
+  // Skip the copy when the two buffers alias (past_state == present_state).
+  // Under a shared-buffer binding (OGA past_present_share_buffer / EP GPU
+  // aliasing) the recurrent state is one buffer used for both past input and
+  // present output, so present already holds past's data and the decode/prefill
+  // kernel updates it in place -- the copy is a semantic no-op. It is NOT free
+  // to issue, though: the buffer comes from the EP's host-mapped allocator
+  // (hipHostMallocMapped), and on that memory hipMemcpyAsync D2D degenerates to
+  // a synchronous host-staged copy, costing host (CPU) time per call. At
+  // decode this dominates the op (profiled ~54.6 ms CPU vs ~5.6 ms GPU across
+  // 30 single-token LA calls; ~1.8 ms CPU per layer per token), so skipping the
+  // self-copy removes the per-token recurrent-state staging overhead.
   if (past_state) {
-    HIP_CHECK(hipMemcpyAsync(present_state, past_state, total_state_bytes,
-                             hipMemcpyDeviceToDevice, (hipStream_t)hip_stream));
+    if (past_state != present_state) {
+      HIP_CHECK(hipMemcpyAsync(present_state, past_state, total_state_bytes,
+                               hipMemcpyDeviceToDevice,
+                               (hipStream_t)hip_stream));
+    }
+    // else: aliased shared buffer -> present already == past, copy is a no-op.
   } else {
     HIP_CHECK(hipMemsetAsync(present_state, 0, total_state_bytes,
                              (hipStream_t)hip_stream));

--- a/lib/Runtime/real/linear_attention.cpp
+++ b/lib/Runtime/real/linear_attention.cpp
@@ -176,6 +176,37 @@ extern "C" int wrap_linear_attention(
                              (hipStream_t)hip_stream));
   }
 
+  // Fast path: prefill (seq_len > 1) of the gated_delta rule is handled by a
+  // single chunked-parallel launch that processes the whole sequence (keeps
+  // the recurrent state fp32 across each chunk -> more accurate than the
+  // per-token kernel, and replaces ~seq_len launches with one). The launcher
+  // returns 1 when it declines an unsupported config; we then fall back to the
+  // per-token loop below.
+  if (update_rule == kUpdateRuleGatedDelta && seq_len > 1) {
+    int rc = hip_linear_attention_prefill_chunked(
+        hip_stream, query, key, value, decay, beta, present_state, output, B,
+        seq_len, Hq, Hkv, Nk, dk, dv, scale, update_rule, decay_per_key_dim,
+        beta_per_head, type);
+    if (rc == 0) {
+      RUNTIME_DEBUG_LOG(
+          "[linear_attention] prefill via chunked-parallel kernel (%lld "
+          "token(s))\n",
+          (long long)seq_len);
+      goto cleanup;
+    }
+    if (rc < 0) {
+      fprintf(stderr,
+              "[linear_attention] ERROR: chunked prefill kernel failed (%d)\n",
+              rc);
+      result = -1;
+      goto cleanup;
+    }
+    RUNTIME_DEBUG_LOG(
+        "[linear_attention] chunked prefill declined (rc=%d); falling back to "
+        "per-token loop\n",
+        rc);
+  }
+
   RUNTIME_DEBUG_LOG(
       "[linear_attention] dispatching %lld token(s) via per-step decode "
       "kernel\n",

--- a/lib/Runtime/real/memory.cpp
+++ b/lib/Runtime/real/memory.cpp
@@ -47,6 +47,14 @@ int wrap_hipMemcpyAsync(RuntimeState *state, void *dst_ptr, const void *src_ptr,
 int wrap_hipMemcpy2DAsync(RuntimeState *state, void *dst_ptr, size_t dst_pitch,
                           const void *src_ptr, size_t src_pitch, size_t width,
                           size_t height) {
+  OP_PROFILE(
+      "memcpy_2d",
+      [&] {
+        char b[64];
+        snprintf(b, sizeof(b), "w=%zu h=%zu", width, height);
+        return std::string(b);
+      },
+      state);
   if (!state) {
     fprintf(stderr, "wrap_hipMemcpy2DAsync: null state\n");
     return -1;
@@ -100,6 +108,15 @@ int wrap_strided_copy(RuntimeState *state, void *dst_ptr, const void *src_ptr,
                       int64_t elem_bytes, int64_t height,
                       int64_t src_pitch_elems, int64_t dst_pitch_elems,
                       int64_t row_elems) {
+  OP_PROFILE(
+      "strided_copy",
+      [&] {
+        char b[64];
+        snprintf(b, sizeof(b), "h=%lld row=%lld es=%lld", (long long)height,
+                 (long long)row_elems, (long long)elem_bytes);
+        return std::string(b);
+      },
+      state);
   if (!state) {
     fprintf(stderr, "wrap_strided_copy: null state\n");
     return -1;
@@ -158,6 +175,12 @@ int wrap_strided_copy(RuntimeState *state, void *dst_ptr, const void *src_ptr,
 // the host value is read. Returns 0 on any failure (a zero extent is a safe,
 // inert dynamic dim).
 int32_t hipdnn_ep_readback_i32(RuntimeState *state, const void *device_scalar) {
+  // CPU-only profiling: this call issues a hipStreamSynchronize, so its cost is
+  // host-side wait time (GPU drain), invisible to GPU per-op events. Surfacing
+  // it as a profiled row attributes the dynamic-shape readback sync overhead
+  // (Range / Reshape(-1) / readback_dim) that otherwise lands in "outside
+  // scopes".
+  OP_PROFILE_CPU("readback_i32", state);
   if (!state || !device_scalar) {
     fprintf(stderr, "hipdnn_ep_readback_i32: null argument\n");
     return 0;
@@ -197,6 +220,10 @@ int32_t hipdnn_ep_readback_i32(RuntimeState *state, const void *device_scalar) {
 // collapsed dynamic dimension.
 void hipdnn_ep_readback_scalar(RuntimeState *state, void *host_dst,
                                const void *device_scalar, int64_t num_bytes) {
+  // CPU-only profiling: like readback_i32 this issues a hipStreamSynchronize;
+  // its cost is host-side GPU-drain time. Profiling it attributes the
+  // Range/Expand/Pad/Loop shape-readback sync overhead.
+  OP_PROFILE_CPU("readback_scalar", state);
   if (!state || !host_dst || !device_scalar || num_bytes <= 0) {
     fprintf(stderr, "hipdnn_ep_readback_scalar: invalid argument\n");
     return;

--- a/tools/hip-onnx-runner/hip-onnx-runner.cpp
+++ b/tools/hip-onnx-runner/hip-onnx-runner.cpp
@@ -811,10 +811,6 @@ int main(int argc, char *argv[]) {
       "3=both",
       "0");
   mo.add_option("s", "seed", "RNG seed for random inputs", "42");
-  mo.add_option("r", "repeat",
-                "Number of timed inference runs (warm steady-state); reports "
-                "min/mean over runs. Default 1.",
-                "1");
   mo.add_option("i", "input-dir",
                 "Directory with input_<idx>_<name>_<type>.bin only; empty = "
                 "random inputs",
@@ -953,27 +949,14 @@ int main(int argc, char *argv[]) {
     }
     std::cout << "Found " << devices.size() << " EP device(s)\n";
 
-    // EP provider options. Optionally select the per-model artifact backend
-    // via $HIPDNN_EP_ARTIFACT_FORMAT (LLVM_IR | NATIVE). NATIVE compiles each
-    // subgraph to a per-OS .dll/.so loaded via LoadLibrary -- the EP's
-    // load_config reads the "artifact_format" provider option (see
-    // backend-mlir-compiler/level-1-pass/src/pass_main.cpp). Useful for dev /
-    // benchmarking; the LLVM-IR JIT path can crash when combined with
-    // HIPDNN_EP_PERF=1, so native is the stable choice for perf runs.
-    std::unordered_map<std::string, std::string> ep_options;
-    if (const char *fmt = std::getenv("HIPDNN_EP_ARTIFACT_FORMAT");
-        fmt && *fmt) {
-      ep_options["artifact_format"] = fmt;
-      std::cout << "EP provider option artifact_format=" << fmt << "\n";
-    }
-
     // ORT >=1.24 added an AppendExecutionProvider_V2 overload that accepts
     // Ort::KeyValuePairs alongside the legacy std::unordered_map<string,string>
     // version. Passing a brace-init `{}` is ambiguous against both candidates
     // on the prebuilt Linux ORT package we ship here. Spell out the map type
     // so we always bind to the original overload and stay compatible with the
     // older ORT version we still link against on Windows.
-    session_opts.AppendExecutionProvider_V2(env, devices, ep_options);
+    session_opts.AppendExecutionProvider_V2(
+        env, devices, std::unordered_map<std::string, std::string>{});
     session_opts.AddConfigEntry("session.disable_cpu_ep_fallback", "1");
   }
 
@@ -1156,44 +1139,22 @@ int main(int argc, char *argv[]) {
     }
   }
 
-  // Run inference. With -r N>1 the loop reuses one session so the GPU stays
-  // warm (steady-state clocks) -- the first run is reported separately as the
-  // cold sample, then min/mean over the remaining runs. The last run's outputs
-  // are kept for dumping.
-  const int repeat = std::max(1, mo.get<int>("repeat"));
-  std::cout << "Running inference (" << repeat << " run(s))...\n";
+  // Run inference
+  std::cout << "Running inference...\n";
   std::vector<Ort::Value> outputs;
   {
-    double cold_us = 0.0;
-    double min_us = 0.0;
-    double sum_us = 0.0;
-    int warm_count = 0;
-    for (int run = 0; run < repeat; ++run) {
-      auto t0 = std::chrono::steady_clock::now();
-      try {
-        outputs = session->Run(Ort::RunOptions{}, input_names.data(),
-                               input_tensors.data(), input_count,
-                               output_names.data(), output_count);
-      } catch (const Ort::Exception &e) {
-        std::cerr << "Inference failed: " << e.what() << "\n";
-        return 1;
-      }
-      const double us = elapsed_since(t0) * 1e6;
-      if (run == 0) {
-        cold_us = us;
-      } else {
-        sum_us += us;
-        min_us = (warm_count == 0) ? us : std::min(min_us, us);
-        ++warm_count;
-      }
+    auto t0 = std::chrono::steady_clock::now();
+    try {
+      outputs = session->Run(Ort::RunOptions{}, input_names.data(),
+                             input_tensors.data(), input_count,
+                             output_names.data(), output_count);
+      std::cout << "Inference: "
+                << static_cast<int64_t>(elapsed_since(t0) * 1e6) << " us\n";
+      std::cout << "OK - " << outputs.size() << " output tensor(s)\n";
+    } catch (const Ort::Exception &e) {
+      std::cerr << "Inference failed: " << e.what() << "\n";
+      return 1;
     }
-    std::cout << "Inference cold: " << static_cast<int64_t>(cold_us) << " us\n";
-    if (warm_count > 0) {
-      std::cout << "Inference warm: min=" << static_cast<int64_t>(min_us)
-                << " us  mean=" << static_cast<int64_t>(sum_us / warm_count)
-                << " us  (" << warm_count << " run(s))\n";
-    }
-    std::cout << "OK - " << outputs.size() << " output tensor(s)\n";
   }
 
   if (dump_level == 2 || dump_level == 3) {

--- a/tools/hip-onnx-runner/hip-onnx-runner.cpp
+++ b/tools/hip-onnx-runner/hip-onnx-runner.cpp
@@ -811,6 +811,10 @@ int main(int argc, char *argv[]) {
       "3=both",
       "0");
   mo.add_option("s", "seed", "RNG seed for random inputs", "42");
+  mo.add_option("r", "repeat",
+                "Number of timed inference runs (warm steady-state); reports "
+                "min/mean over runs. Default 1.",
+                "1");
   mo.add_option("i", "input-dir",
                 "Directory with input_<idx>_<name>_<type>.bin only; empty = "
                 "random inputs",
@@ -949,14 +953,27 @@ int main(int argc, char *argv[]) {
     }
     std::cout << "Found " << devices.size() << " EP device(s)\n";
 
+    // EP provider options. Optionally select the per-model artifact backend
+    // via $HIPDNN_EP_ARTIFACT_FORMAT (LLVM_IR | NATIVE). NATIVE compiles each
+    // subgraph to a per-OS .dll/.so loaded via LoadLibrary -- the EP's
+    // load_config reads the "artifact_format" provider option (see
+    // backend-mlir-compiler/level-1-pass/src/pass_main.cpp). Useful for dev /
+    // benchmarking; the LLVM-IR JIT path can crash when combined with
+    // HIPDNN_EP_PERF=1, so native is the stable choice for perf runs.
+    std::unordered_map<std::string, std::string> ep_options;
+    if (const char *fmt = std::getenv("HIPDNN_EP_ARTIFACT_FORMAT");
+        fmt && *fmt) {
+      ep_options["artifact_format"] = fmt;
+      std::cout << "EP provider option artifact_format=" << fmt << "\n";
+    }
+
     // ORT >=1.24 added an AppendExecutionProvider_V2 overload that accepts
     // Ort::KeyValuePairs alongside the legacy std::unordered_map<string,string>
     // version. Passing a brace-init `{}` is ambiguous against both candidates
     // on the prebuilt Linux ORT package we ship here. Spell out the map type
     // so we always bind to the original overload and stay compatible with the
     // older ORT version we still link against on Windows.
-    session_opts.AppendExecutionProvider_V2(
-        env, devices, std::unordered_map<std::string, std::string>{});
+    session_opts.AppendExecutionProvider_V2(env, devices, ep_options);
     session_opts.AddConfigEntry("session.disable_cpu_ep_fallback", "1");
   }
 
@@ -1139,22 +1156,44 @@ int main(int argc, char *argv[]) {
     }
   }
 
-  // Run inference
-  std::cout << "Running inference...\n";
+  // Run inference. With -r N>1 the loop reuses one session so the GPU stays
+  // warm (steady-state clocks) -- the first run is reported separately as the
+  // cold sample, then min/mean over the remaining runs. The last run's outputs
+  // are kept for dumping.
+  const int repeat = std::max(1, mo.get<int>("repeat"));
+  std::cout << "Running inference (" << repeat << " run(s))...\n";
   std::vector<Ort::Value> outputs;
   {
-    auto t0 = std::chrono::steady_clock::now();
-    try {
-      outputs = session->Run(Ort::RunOptions{}, input_names.data(),
-                             input_tensors.data(), input_count,
-                             output_names.data(), output_count);
-      std::cout << "Inference: "
-                << static_cast<int64_t>(elapsed_since(t0) * 1e6) << " us\n";
-      std::cout << "OK - " << outputs.size() << " output tensor(s)\n";
-    } catch (const Ort::Exception &e) {
-      std::cerr << "Inference failed: " << e.what() << "\n";
-      return 1;
+    double cold_us = 0.0;
+    double min_us = 0.0;
+    double sum_us = 0.0;
+    int warm_count = 0;
+    for (int run = 0; run < repeat; ++run) {
+      auto t0 = std::chrono::steady_clock::now();
+      try {
+        outputs = session->Run(Ort::RunOptions{}, input_names.data(),
+                               input_tensors.data(), input_count,
+                               output_names.data(), output_count);
+      } catch (const Ort::Exception &e) {
+        std::cerr << "Inference failed: " << e.what() << "\n";
+        return 1;
+      }
+      const double us = elapsed_since(t0) * 1e6;
+      if (run == 0) {
+        cold_us = us;
+      } else {
+        sum_us += us;
+        min_us = (warm_count == 0) ? us : std::min(min_us, us);
+        ++warm_count;
+      }
     }
+    std::cout << "Inference cold: " << static_cast<int64_t>(cold_us) << " us\n";
+    if (warm_count > 0) {
+      std::cout << "Inference warm: min=" << static_cast<int64_t>(min_us)
+                << " us  mean=" << static_cast<int64_t>(sum_us / warm_count)
+                << " us  (" << warm_count << " run(s))\n";
+    }
+    std::cout << "OK - " << outputs.size() << " output tensor(s)\n";
   }
 
   if (dump_level == 2 || dump_level == 3) {


### PR DESCRIPTION
## Summary

Speeds up the gated-delta **LinearAttention** path (Qwen3.5 / Qwen3.5-MoE family) by replacing the per-token prefill launch loop with a single chunked-parallel kernel, plus a few supporting runtime/profiling changes. Includes a correctness fix for an underflow-induced NaN found during VLM validation.

Commits in this PR (on top of `main` @ 2c6b93a9):

- **`feat(runtime)`: chunked-parallel gated-delta LinearAttention prefill kernel** — one launch processes the whole sequence in `LA_CHUNK=32` token chunks (one block per `(batch, kv_head)`), keeping the recurrent state `S` in **fp32** across the chunk and doing dense per-chunk matmuls (coupling matrices `T`/`P` in LDS) instead of per-token rank-1 updates. This is strictly *more* accurate than the per-token kernel (which rounds `S` to fp16 every step) — cosine ~0.9999999 in fp16 vs the naive recurrence / ORT CPU. Only `gated_delta` with scalar log-decay is implemented; the launcher declines other configs so the runtime falls back to the per-token loop.
- **`perf(runtime)`: skip recurrent-state self-copy on aliased buffers** — when `past_state` and `present_state` alias the same GPU buffer, the redundant device-to-device self-copy is skipped (decode hot path).
- **`perf(kernels)`: register-block S reads + hoist phase-6 scale** — each `S[i,j]` is read from global once and folded into all `Ceff` partial sums (≈`LA_CHUNK`× fewer global S loads in phases 2 and 5); the per-`s` state-update scale is precomputed once instead of inside the `dk*dv` loop.
- **`fix(kernels)`: avoid 0/0 NaN in the phase-6 state update** — see below.
- **`chore(profile)`: op-profile rows for memcpy/readback paths** — these copies/readbacks include GPU sync cost; profiling them attributes that time correctly in the timeline (gated on `HIPDNN_EP_PERF`).

## The NaN fix

The phase-6 state-update scale was computed as the ratio `a_last / Asm[s] = exp(clog_last) / exp(clog_s)`. Under strong intra-chunk decay (log-decay `g << 0`), `clog_s` becomes very negative, so **both** `exp(clog_s)` and `exp(clog_last)` underflow to `0` in fp32 and the ratio becomes `0/0 = NaN`. That NaN is folded into the recurrent state `S` and propagates to every subsequent chunk → all-garbage output (repeated `!` tokens) on long sequences.

Fix: compute the scale directly as `exp(clog_last - clog_s)`. The difference is bounded (`<= 0` for log-decay `g <= 0`), so `exp()` is always in `(0, 1]` and finite. This also matches the `exp(clog_t - clog_s)` form already used for the `P`/`T` coupling ratios in the same kernel. Math is unchanged in the well-conditioned case.

## Performance (gfx1151, Qwen3.5 VLM, 1842-token image prompt)

vs the pre-branch baseline (`main` @ 2c6b93a9), `vlm_benchmark.py`, `HIPDNN_EP_PERF=0`:

| Model | TTFT (ms) | TTFT speedup | Decode (tok/s) | Decode speedup |
|---|---|---|---|---|
| Qwen3.5-9B (dense) | 8646 → 5043 | **1.71×** | 29.5 → 34.0 | **1.15×** |
| Qwen3.5-35B-A3B (MoE) | 9886 → 5541 | **1.78×** | 35.0 → 46.1 | **1.32×** |

(TTFT lower is better; Decode higher is better. Both `speedup` columns are expressed so that >1× = faster.)

Notes:
- Prefill throughput is `prompt_tokens / TTFT`, so it mirrors the TTFT speedup (same 1.7–1.8×) — omitted here to avoid double-counting the same number.
- The decode gain comes from the recurrent-state self-copy skip; the decode kernel itself is unchanged by this PR. MoE (35B) decode tok/s is sensitive to WMMA-autotune cache warmth and varies run-to-run, so treat its multiplier as approximate.

## Correctness

- Qwen3.5-9B: greedy output is **token-identical** to the pre-optimization baseline (dense; the kernel's fp32-internal accumulation matches closely enough that argmax never flips).
- Qwen3.5-35B-A3B: greedy output is **semantically correct** (coherent, on-topic). It diverges token-by-token from baseline because the chunked kernel is numerically different by construction and MoE expert routing amplifies any legal fp delta — this is expected, not a regression.
- The garbage-output (`!!!!`) symptom that motivated the NaN fix is gone on both models.

## Test plan

- [ ] `ctest` LIT/unit suites green
- [ ] Qwen3.5-9B VLM end-to-end (image prompt) — coherent output, no `!` garbage
- [ ] Qwen3.5-35B-A3B VLM end-to-end (image prompt) — coherent output
- [ ] Confirm GPU dispatch (`HIPDNN_EP_DEBUG=1` → `[custom_kernels] hip_linear_attention_prefill_chunked` / decode rows)

## Note for reviewers

Branch is based on `main` @ 2c6b93a9; `main` has since refactored op-state handling (incl. `lib/Runtime/real/linear_attention.cpp`). A rebase onto current `main` may be needed before merge — `linear_attention.cpp` is the likely conflict point.
