### PR TITLE
testing silu fusion

### DIFF
--- a/3rd-party/custom_kernels/CMakeLists.txt
+++ b/3rd-party/custom_kernels/CMakeLists.txt
@@ -45,6 +45,7 @@ set(_kernel_sources
     hip/cumsum_kernel.hip
     hip/pad_kernel.hip
     hip/layer_norm_kernel.hip
+    hip/silu_kernel.hip
     hip/cast_kernel.hip
     hip/range_kernel.hip
     hip/gather_kernel.hip

--- a/3rd-party/custom_kernels/hip/silu_kernel.hip
+++ b/3rd-party/custom_kernels/hip/silu_kernel.hip
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ *
+ * SiLU / swish activation: y = x * sigmoid(x). fp32 math, fp16/fp32 I/O.
+ * Fused replacement for the exporter's separate onnx.Sigmoid + onnx.Mul.
+ */
+
+#include "hip_custom_kernels.h"
+
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+#include <cstdint>
+#include <cstdio>
+
+template <typename T>
+__global__ void hip_silu_kernel(const T *__restrict__ in, T *__restrict__ out,
+                                int64_t n) {
+  int64_t i = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (i >= n)
+    return;
+  float x = static_cast<float>(in[i]);
+  float y = x / (1.0f + __expf(-x));
+  out[i] = static_cast<T>(y);
+}
+
+template <>
+__global__ void hip_silu_kernel<__half>(const __half *__restrict__ in,
+                                        __half *__restrict__ out, int64_t n) {
+  int64_t i = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (i >= n)
+    return;
+  float x = __half2float(in[i]);
+  float y = x / (1.0f + __expf(-x));
+  out[i] = __float2half(y);
+}
+
+extern "C" int hip_silu(void *stream, const void *input, void *output,
+                        int64_t num_elements, int hip_dtype) {
+  if (num_elements <= 0)
+    return 0;
+  hipStream_t s = static_cast<hipStream_t>(stream);
+  constexpr int kBlock = 256;
+  int64_t grid = (num_elements + kBlock - 1) / kBlock;
+
+  if (hip_dtype == HIP_DTYPE_FLOAT16) {
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(hip_silu_kernel<__half>),
+                       dim3((unsigned)grid), dim3(kBlock), 0, s,
+                       static_cast<const __half *>(input),
+                       static_cast<__half *>(output), num_elements);
+  } else if (hip_dtype == HIP_DTYPE_FLOAT32) {
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(hip_silu_kernel<float>),
+                       dim3((unsigned)grid), dim3(kBlock), 0, s,
+                       static_cast<const float *>(input),
+                       static_cast<float *>(output), num_elements);
+  } else {
+    fprintf(stderr, "[custom_kernels] hip_silu: unsupported dtype=%d\n",
+            hip_dtype);
+    return -1;
+  }
+  hipError_t err = hipGetLastError();
+  if (err != hipSuccess)
+    fprintf(stderr, "[custom_kernels] hip_silu launch failed: %s\n",
+            hipGetErrorString(err));
+  return static_cast<int>(err);
+}

--- a/3rd-party/custom_kernels/include/hip_custom_kernels.h
+++ b/3rd-party/custom_kernels/include/hip_custom_kernels.h
@@ -1218,7 +1218,7 @@ HIP_KERNEL_API int hip_layer_norm(
     int mean_dtype);
 
 /* SiLU / swish: y = x * sigmoid(x). fp32 math; hip_dtype FLOAT16 or FLOAT32. */
-int hip_silu(
+HIP_KERNEL_API int hip_silu(
     void* stream,
     const void* input,
     void* output,

--- a/3rd-party/custom_kernels/include/hip_custom_kernels.h
+++ b/3rd-party/custom_kernels/include/hip_custom_kernels.h
@@ -1217,6 +1217,14 @@ HIP_KERNEL_API int hip_layer_norm(
     int hip_dtype,
     int mean_dtype);
 
+/* SiLU / swish: y = x * sigmoid(x). fp32 math; hip_dtype FLOAT16 or FLOAT32. */
+int hip_silu(
+    void* stream,
+    const void* input,
+    void* output,
+    int64_t num_elements,
+    int hip_dtype);
+
 /* =========================================================================
  * Range (1-D sequence generation)
  * =========================================================================

--- a/lib/Conversion/HipToLLVM/ActivationLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ActivationLowering.cpp
@@ -318,7 +318,10 @@ struct LeakyReluOpLowering : public ConvertOpToLLVMPattern<LeakyReluOp> {
   }
 };
 
-// hip.silu(handle, input, output)
+// hip.silu(ctx) ins(input) outs(output)
+//   -> wrap_silu(state, input, output, num_elements, element_size_bytes)
+// (Previously called a 3-arg "hip_silu" with no size/dtype -- never linkable;
+// hip.silu had no kernel until SiluFusion started emitting it.)
 struct SiluOpLowering : public ConvertOpToLLVMPattern<SiluOp> {
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
@@ -327,20 +330,44 @@ struct SiluOpLowering : public ConvertOpToLLVMPattern<SiluOp> {
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op.getLoc();
     ModuleOp module = op->getParentOfType<ModuleOp>();
-    Type voidType = getVoidType();
+    Type i32Type = rewriter.getI32Type();
+    Type i64Type = rewriter.getI64Type();
     Type ptrType = getPtrType();
 
-    SmallVector<Type> paramTypes(3, ptrType);
-    FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
-        rewriter, module, kHipSilu, paramTypes, voidType);
+    Value statePtr = adaptor.getCtx();
+    Value inputPtr =
+        extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc);
+    Value outputPtr =
+        extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
+
+    auto outputType = cast<MemRefType>(op.getOutput().getType());
+    Value numElements = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(1));
+    MemRefDescriptor outputDesc(adaptor.getOutput());
+    for (auto dimIdx : llvm::seq<int64_t>(outputType.getRank())) {
+      Value dimSize =
+          outputType.isDynamicDim(dimIdx)
+              ? outputDesc.size(rewriter, loc, dimIdx)
+              : LLVM::ConstantOp::create(
+                    rewriter, loc, i64Type,
+                    rewriter.getI64IntegerAttr(outputType.getDimSize(dimIdx)));
+      numElements = LLVM::MulOp::create(rewriter, loc, numElements, dimSize);
+    }
+
+    unsigned elemBytes =
+        outputType.getElementType().getIntOrFloatBitWidth() / 8;
+    Value elemSizeVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(elemBytes));
+
+    SmallVector<Type> paramTypes = {ptrType, ptrType, ptrType, i64Type,
+                                    i64Type};
+    FailureOr<LLVM::LLVMFuncOp> funcOp =
+        LLVM::lookupOrCreateFn(rewriter, module, kWrapSilu, paramTypes, i32Type);
     if (failed(funcOp))
       return failure();
 
-    SmallVector<Value> args = {
-        adaptor.getCtx(),
-        extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc),
-        extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc)};
-
+    SmallVector<Value> args = {statePtr, inputPtr, outputPtr, numElements,
+                               elemSizeVal};
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
     rewriter.eraseOp(op);
     return success();

--- a/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
+++ b/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
@@ -64,6 +64,7 @@ inline constexpr const char *kMiopenSoftmax = "hip_miopen_softmax";
 inline constexpr const char *kWrapTranspose = "wrap_transpose";
 inline constexpr const char *kWrapGather = "wrap_gather";
 inline constexpr const char *kHipSilu = "hip_silu";
+inline constexpr const char *kWrapSilu = "wrap_silu";
 inline constexpr const char *kWrapMiopenActivationForward =
     "wrap_miopenActivationForward";                   // hip.sigmoid
 inline constexpr const char *kWrapGelu = "wrap_gelu"; // hip.gelu

--- a/lib/Conversion/OnnxToHip/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHip/CMakeLists.txt
@@ -41,6 +41,7 @@ add_library(OnnxToHip STATIC
   ErfGeluFusion.cpp
   ProjectorOpsRewrites.cpp
   LpNormalizationConversion.cpp
+  SiluFusion.cpp
   EqualConversion.cpp
   DivConversion.cpp
   ReduceMaxConversion.cpp

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -776,6 +776,7 @@ void ConvertOnnxToHipPass::runOnOperation() {
         populateErfGeluFusionPatterns(preLoweringPatterns, ctx);
         populateProjectorOpsRewritePatterns(preLoweringPatterns, ctx);
         populateLpNormalizationConversionPatterns(preLoweringPatterns, ctx);
+        populateSiluFusionPatterns(preLoweringPatterns, ctx);
         populatePowDecompositionPatterns(preLoweringPatterns, ctx);
         ChangeFlagListener listener;
         mlir::GreedyRewriteConfig preLoweringConfig;

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
@@ -491,6 +491,9 @@ void populateProjectorOpsRewritePatterns(RewritePatternSet &patterns,
 void populateLpNormalizationConversionPatterns(RewritePatternSet &patterns,
                                                MLIRContext *ctx);
 
+/// Pre-lowering: fold Mul(x, Sigmoid(x)) into hip.silu. See SiluFusion.cpp.
+void populateSiluFusionPatterns(RewritePatternSet &patterns, MLIRContext *ctx);
+
 } // namespace hip
 } // namespace mlir
 

--- a/lib/Conversion/OnnxToHip/SiluFusion.cpp
+++ b/lib/Conversion/OnnxToHip/SiluFusion.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- SiluFusion.cpp - Fold Mul(x, Sigmoid(x)) into hip.silu ------------===//
+//
+// The Qwen3.5 SwiGLU MLP emits SiLU as a separate `onnx.Sigmoid` + `onnx.Mul`
+// (x * sigmoid(x)) rather than a fused activation. There is a `hip.silu` op
+// (output = input * sigmoid(input)) with a kernel + lowering, but no pass
+// creates it from the primitive pair, so each SiLU runs as two launch-bound
+// kernels (56 sites in text.onnx). This pass folds the pair into one
+// `hip.silu`, halving those launches. Output is bit-identical iff the silu
+// kernel computes x*sigmoid(x) the same way (validated by text match).
+//
+// Rooted on `onnx.Mul`; matches when one operand is `onnx.Sigmoid(s)` and the
+// OTHER operand is exactly `s` (true SiLU, not a gate `a*sigmoid(b)`).
+//
+//===----------------------------------------------------------------------===//
+
+#include "OnnxToHipUtils.h"
+
+#include "llvm/ADT/Statistic.h"
+#include "llvm/Support/Debug.h"
+
+#include <cstdlib>
+#include <string>
+
+#define DEBUG_TYPE "silu-fusion"
+
+STATISTIC(NumSiluFused, "Mul(x, Sigmoid(x)) pairs folded into hip.silu");
+
+namespace mlir {
+namespace hip {
+
+namespace {
+
+struct SiluFuse : public mlir::RewritePattern {
+  SiluFuse(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.Mul", /*benefit=*/2, ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *mulOp,
+                  mlir::PatternRewriter &rewriter) const override {
+    if (mulOp->getNumOperands() != 2 || mulOp->getNumResults() != 1)
+      return rewriter.notifyMatchFailure(mulOp, "mul.arity");
+
+    // One operand must be Sigmoid(s); the OTHER must be exactly s.
+    mlir::Value x;
+    mlir::Operation *sigOp = nullptr;
+    for (int i = 0; i < 2; ++i) {
+      mlir::Operation *def = mulOp->getOperand(i).getDefiningOp();
+      if (def && def->getName().getStringRef() == "onnx.Sigmoid" &&
+          def->getNumOperands() == 1 &&
+          def->getOperand(0) == mulOp->getOperand(1 - i)) {
+        sigOp = def;
+        x = mulOp->getOperand(1 - i);
+        break;
+      }
+    }
+    if (!sigOp)
+      return rewriter.notifyMatchFailure(mulOp, "not_silu");
+
+    auto xType = mlir::dyn_cast<mlir::RankedTensorType>(x.getType());
+    auto outType =
+        mlir::dyn_cast<mlir::RankedTensorType>(mulOp->getResult(0).getType());
+    if (!xType || !outType || outType.getShape() != xType.getShape() ||
+        outType.getElementType() != xType.getElementType())
+      return rewriter.notifyMatchFailure(mulOp, "type_mismatch");
+
+    auto ctxOrFailure = getContextArg(mulOp, rewriter);
+    if (mlir::failed(ctxOrFailure))
+      return rewriter.notifyMatchFailure(mulOp, "no_context_arg");
+    mlir::Value context = *ctxOrFailure;
+
+    mlir::Location loc = mulOp->getLoc();
+    rewriter.setInsertionPoint(mulOp);
+    mlir::Value init = createEmptyTensor(rewriter, loc, outType, x);
+    auto hipOp =
+        mlir::hip::SiluOp::create(rewriter, loc, outType, context, x, init);
+    rewriter.replaceOp(mulOp, hipOp->getResult(0));
+    if (sigOp->use_empty())
+      rewriter.eraseOp(sigOp);
+
+    LLVM_DEBUG(llvm::dbgs() << "[" DEBUG_TYPE "] fused SiLU at " << loc << "\n");
+    ++NumSiluFused;
+    return mlir::success();
+  }
+};
+
+} // namespace
+
+void populateSiluFusionPatterns(mlir::RewritePatternSet &patterns,
+                                mlir::MLIRContext *ctx) {
+  if (const char *env = std::getenv("HIPDNN_EP_SILU_FUSE"))
+    if (std::string(env) == "0")
+      return;
+  patterns.add<SiluFuse>(ctx);
+}
+
+} // namespace hip
+} // namespace mlir

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -272,6 +272,7 @@ if(NOT BUILD_MOCK_RUNTIME)
     compile_to_bitcode(real/power.cpp runtime_power.bc)
     compile_to_bitcode(real/matmul.cpp runtime_matmul.bc)
     compile_to_bitcode(real/activation.cpp runtime_activation.bc)
+    compile_to_bitcode(real/silu.cpp runtime_silu.bc)
     compile_to_bitcode(real/layer_normalization.cpp runtime_layer_normalization.bc)
     compile_to_bitcode(real/simplified_layer_norm.cpp runtime_simplified_layer_norm.bc)
     compile_to_bitcode(real/skip_simplified_layer_norm.cpp runtime_skip_simplified_layer_norm.bc)
@@ -333,6 +334,7 @@ if(NOT BUILD_MOCK_RUNTIME)
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_power.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_matmul.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_activation.bc
+        ${CMAKE_CURRENT_BINARY_DIR}/runtime_silu.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_layer_normalization.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_simplified_layer_norm.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_skip_simplified_layer_norm.bc

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -1111,6 +1111,10 @@ int wrap_layer_normalization(RuntimeState *state, void *input, void *scale,
                              int64_t element_size_bytes, int64_t axis,
                              float epsilon, int64_t stash_type);
 
+// SiLU / swish activation wrapper: output = input * sigmoid(input)
+int wrap_silu(RuntimeState *state, void *input, void *output,
+              int64_t num_elements, int64_t element_size_bytes);
+
 // SkipSimplifiedLayerNormalization operation wrapper (Full MS spec)
 // Computes: input_skip_bias_sum = input + skip [+ bias]
 //           output = RMSNorm(input_skip_bias_sum) * gamma

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -1098,6 +1098,17 @@ int wrap_rotary_embedding(RuntimeState *state, void *input, void *position_ids,
   return 0;
 }
 
+int wrap_silu(RuntimeState *state, void *input, void *output,
+              int64_t num_elements, int64_t element_size_bytes) {
+  if (!state) {
+    fprintf(stderr, "Invalid state in wrap_silu\n");
+    return -1;
+  }
+  MOCK_PRINT("[MOCK] wrap_silu(num_elements=%lld, element_size=%lld)\n",
+             (long long)num_elements, (long long)element_size_bytes);
+  return 0;
+}
+
 int wrap_miopenT5LayerNormForward(RuntimeState *state, int op_state_slot,
                                   void *input, void *scale, void *output,
                                   int64_t input_num_elements,

--- a/lib/Runtime/real/silu.cpp
+++ b/lib/Runtime/real/silu.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// SiLU / swish activation: y = x * sigmoid(x). Fused replacement for the
+// exporter's separate onnx.Sigmoid + onnx.Mul (see SiluFusion.cpp).
+
+#include "../debug_log.h"
+#include "../hipdnn_ep_runtime.h"
+#include "../op_profile.h"
+#include "hip_custom_kernels.h"
+#include "runtime_types.h"
+
+#include <cstdio>
+
+int wrap_silu(RuntimeState *state, void *input, void *output,
+              int64_t num_elements, int64_t element_size_bytes) {
+  OP_PROFILE(
+      "silu",
+      [&] {
+        char b[48];
+        snprintf(b, sizeof(b), "n=%lld:%s", (long long)num_elements,
+                 (element_size_bytes == 2) ? "f16" : "f32");
+        return std::string(b);
+      },
+      state);
+
+  if (!state || !input || !output) {
+    RUNTIME_DEBUG_LOG("[REAL] wrap_silu: null required arg\n");
+    return -1;
+  }
+
+  int hip_dtype;
+  if (element_size_bytes == 2)
+    hip_dtype = HIP_DTYPE_FLOAT16;
+  else if (element_size_bytes == 4)
+    hip_dtype = HIP_DTYPE_FLOAT32;
+  else {
+    fprintf(stderr, "[REAL] wrap_silu: unsupported element_size=%lld\n",
+            (long long)element_size_bytes);
+    return -1;
+  }
+
+  void *stream = hipdnn_ep_state_get_stream(state);
+  return hip_silu(stream, input, output, num_elements, hip_dtype);
+}


### PR DESCRIPTION
## Summary
- Rebased the SiLU fusion onto the latest `main` as a single self-contained commit (`885ba50e`).
- Adds a `SiluFusion` pre-lowering pass that folds `Mul(x, Sigmoid(x))` into `hip.silu`, plus the `silu` HIP kernel and the `wrap_silu` runtime wrapper (the `hip.silu` op already existed on `main` but had no working kernel).
- Gated by `HIPDNN_EP_SILU_FUSE` (default on).

## Local build verification
- Built with `build.py --cmake_generator Ninja --hip_arch gfx1151` on Windows (VS 2026 MSVC, sccache).
- `SiluFusion.cpp`, `silu_kernel.hip`, and `silu.cpp` compile; `hipep.dll` + `custom_kernels_gfx1151.dll` install cleanly.
- LIT suite: **277/277 passed**.

## Test plan
- [ ] CI build (Windows + Linux)
- [ ] GPU perf / accuracy run on a SwiGLU model (e.g. Llama/Qwen) to confirm `silu` fires and output is unchanged

Draft for testing.
