### PR TITLE
testing l2norm fusion

### DIFF
--- a/3rd-party/custom_kernels/CMakeLists.txt
+++ b/3rd-party/custom_kernels/CMakeLists.txt
@@ -45,6 +45,7 @@ set(_kernel_sources
     hip/cumsum_kernel.hip
     hip/pad_kernel.hip
     hip/layer_norm_kernel.hip
+    hip/l2_norm_kernel.hip
     hip/cast_kernel.hip
     hip/range_kernel.hip
     hip/gather_kernel.hip

--- a/3rd-party/custom_kernels/hip/l2_norm_kernel.hip
+++ b/3rd-party/custom_kernels/hip/l2_norm_kernel.hip
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ *
+ * L2 normalization over the last axis:
+ *   y = x * rsqrt(sum(x^2, last_axis) + epsilon)
+ *
+ * Fused replacement for the exporter-emitted q/k normalization chain in the
+ * Qwen3.5 linear-attention layers. One block per row, FP32 accumulation.
+ */
+
+#include "hip_custom_kernels.h"
+#include "debug_log.h"
+
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+#include <cstdint>
+#include <cstdio>
+
+static constexpr int kL2NormBlockSize = 256;
+
+template <typename T>
+__device__ inline float l2_load_as_float(const T *p) {
+  return static_cast<float>(*p);
+}
+template <>
+__device__ inline float l2_load_as_float<__half>(const __half *p) {
+  return __half2float(*p);
+}
+template <typename T>
+__device__ inline T l2_store_from_float(float v) {
+  return static_cast<T>(v);
+}
+template <>
+__device__ inline __half l2_store_from_float<__half>(float v) {
+  return __float2half(v);
+}
+
+template <typename T>
+__global__ void hip_l2_normalize_kernel(const T *__restrict__ input,
+                                        T *__restrict__ output, int64_t outer,
+                                        int64_t norm_size, float epsilon) {
+  int64_t row = blockIdx.x;
+  if (row >= outer)
+    return;
+
+  const T *x_row = input + row * norm_size;
+  T *y_row = output + row * norm_size;
+
+  __shared__ float s_inv;
+  __shared__ float s_reduce[kL2NormBlockSize];
+
+  float local_sumsq = 0.0f;
+  for (int64_t i = threadIdx.x; i < norm_size; i += blockDim.x) {
+    float v = l2_load_as_float<T>(x_row + i);
+    local_sumsq += v * v;
+  }
+
+  s_reduce[threadIdx.x] = local_sumsq;
+  __syncthreads();
+  for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+    if (threadIdx.x < stride)
+      s_reduce[threadIdx.x] += s_reduce[threadIdx.x + stride];
+    __syncthreads();
+  }
+  if (threadIdx.x == 0)
+    s_inv = rsqrtf(s_reduce[0] + epsilon);
+  __syncthreads();
+
+  float inv = s_inv;
+  for (int64_t i = threadIdx.x; i < norm_size; i += blockDim.x) {
+    float v = l2_load_as_float<T>(x_row + i);
+    y_row[i] = l2_store_from_float<T>(v * inv);
+  }
+}
+
+extern "C" int hip_l2_normalize(void *stream, const void *input, void *output,
+                                int64_t outer, int64_t norm_size, float epsilon,
+                                int hip_dtype) {
+  if (outer <= 0 || norm_size <= 0)
+    return 0;
+
+  hipStream_t hip_stream = static_cast<hipStream_t>(stream);
+  dim3 grid(static_cast<unsigned int>(outer));
+  dim3 block(kL2NormBlockSize);
+
+  if (hip_dtype == HIP_DTYPE_FLOAT16) {
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(hip_l2_normalize_kernel<__half>), grid,
+                       block, 0, hip_stream,
+                       static_cast<const __half *>(input),
+                       static_cast<__half *>(output), outer, norm_size,
+                       epsilon);
+  } else if (hip_dtype == HIP_DTYPE_FLOAT32) {
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(hip_l2_normalize_kernel<float>), grid,
+                       block, 0, hip_stream,
+                       static_cast<const float *>(input),
+                       static_cast<float *>(output), outer, norm_size, epsilon);
+  } else {
+    fprintf(stderr, "[custom_kernels] hip_l2_normalize: unsupported dtype=%d\n",
+            hip_dtype);
+    return -1;
+  }
+
+  hipError_t err = hipGetLastError();
+  if (err != hipSuccess) {
+    fprintf(stderr, "[custom_kernels] hip_l2_normalize launch failed: %s\n",
+            hipGetErrorString(err));
+  }
+  return static_cast<int>(err);
+}

--- a/3rd-party/custom_kernels/include/hip_custom_kernels.h
+++ b/3rd-party/custom_kernels/include/hip_custom_kernels.h
@@ -1217,6 +1217,18 @@ HIP_KERNEL_API int hip_layer_norm(
     int hip_dtype,
     int mean_dtype);
 
+/* L2 normalization over the last axis:
+ *   y = x * rsqrt(sum(x^2, last_axis) + epsilon)
+ * One block per row; FP32 accumulation. hip_dtype: FLOAT16 or FLOAT32. */
+int hip_l2_normalize(
+    void* stream,
+    const void* input,
+    void* output,
+    int64_t outer,
+    int64_t norm_size,
+    float epsilon,
+    int hip_dtype);
+
 /* =========================================================================
  * Range (1-D sequence generation)
  * =========================================================================

--- a/3rd-party/custom_kernels/include/hip_custom_kernels.h
+++ b/3rd-party/custom_kernels/include/hip_custom_kernels.h
@@ -1220,7 +1220,7 @@ HIP_KERNEL_API int hip_layer_norm(
 /* L2 normalization over the last axis:
  *   y = x * rsqrt(sum(x^2, last_axis) + epsilon)
  * One block per row; FP32 accumulation. hip_dtype: FLOAT16 or FLOAT32. */
-int hip_l2_normalize(
+HIP_KERNEL_API int hip_l2_normalize(
     void* stream,
     const void* input,
     void* output,

--- a/include/hip/Dialect/IR/HipBufferize.h
+++ b/include/hip/Dialect/IR/HipBufferize.h
@@ -156,6 +156,7 @@ registerHipBufferizableOpInterfaceModels(DialectRegistry &registry) {
     LinearAttentionOp::attachInterface<
         HipDstBufferizableModel<LinearAttentionOp>>(*ctx);
     LayerNormOp::attachInterface<HipDstBufferizableModel<LayerNormOp>>(*ctx);
+    L2NormOp::attachInterface<HipDstBufferizableModel<L2NormOp>>(*ctx);
     MinOp::attachInterface<HipDstBufferizableModel<MinOp>>(*ctx);
     MaxOp::attachInterface<HipDstBufferizableModel<MaxOp>>(*ctx);
     NegOp::attachInterface<HipDstBufferizableModel<NegOp>>(*ctx);

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -994,6 +994,43 @@ def Hip_RmsNormOp : Hip_DpsOp<"rms_norm", /*traits=*/[OpStateOpInterface],
   let hasVerifier = 1;
 }
 
+def Hip_L2NormOp : Hip_DpsOp<"l2_norm"> {
+  let summary = "L2 normalization over the last axis (q/k norm in linear attention)";
+  let description = [{
+    L2-normalizes `input` along its last axis:
+
+      output = input * rsqrt(sum(input^2, last_axis) + epsilon)
+
+    Fused form of the exporter-emitted decomposition
+    `Mul(x, Reciprocal(Sqrt(Add(ReduceSum(Mul(x,x)), eps))))` from the
+    Qwen3.5 linear-attention q/k normalization (24 layers x {q,k} = 48 sites).
+    Reduction is always over the LAST dimension; fp32 accumulation.
+
+    Example:
+    ```mlir
+    hip.l2_norm(%ctx)
+        ins(%input : memref<?x128xf16, 1>)
+        outs(%output : memref<?x128xf16, 1>)
+        {axis = -1 : i64, epsilon = 1.01327896e-06 : f32}
+    ```
+  }];
+
+  let arguments = (ins
+    Hip_ContextType:$ctx,
+    Hip_TensorOrMemRef:$input,
+    Hip_TensorOrMemRef:$output,
+    I64Attr:$axis,
+    F32Attr:$epsilon
+  );
+
+  let assemblyFormat = [{
+    `(` $ctx `)` `ins` `(` $input `:` type($input) `)`
+    `outs` `(` $output `:` type($output) `)`
+    attr-dict (`:` type($result_tensors)^)?
+  }];
+  let hasVerifier = 1;
+}
+
 def Hip_LayerNormOp : Hip_DpsOp<"layer_norm",
     [AttrSizedOperandSegments]> {
   let summary = "Standard layer normalization (ONNX LayerNormalization opset 17)";

--- a/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
+++ b/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
@@ -58,6 +58,7 @@ inline constexpr const char *kWrapSkipSimplifiedLayerNorm =
     "wrap_skip_simplified_layer_norm";
 inline constexpr const char *kWrapLayerNormalization =
     "wrap_layer_normalization";
+inline constexpr const char *kWrapL2Normalize = "wrap_l2_normalize";
 inline constexpr const char *kMiopenAdd = "hip_miopen_add";
 inline constexpr const char *kMiopenMul = "hip_miopen_mul";
 inline constexpr const char *kMiopenSoftmax = "hip_miopen_softmax";

--- a/lib/Conversion/HipToLLVM/NormLowering.cpp
+++ b/lib/Conversion/HipToLLVM/NormLowering.cpp
@@ -303,12 +303,73 @@ struct LayerNormOpLowering : public ConvertOpToLLVMPattern<LayerNormOp> {
   }
 };
 
+// hip.l2_norm(%ctx) ins(%input) outs(%output)
+//   -> wrap_l2_normalize(state, input, output,
+//        input_num_elements, norm_size, element_size_bytes, epsilon)
+struct L2NormOpLowering : public ConvertOpToLLVMPattern<L2NormOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(L2NormOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    ModuleOp module = op->getParentOfType<ModuleOp>();
+    Type ptrType = getPtrType();
+    Type i64Type = rewriter.getI64Type();
+    Type f32Type = rewriter.getF32Type();
+
+    Value statePtr = adaptor.getCtx();
+    Value inputPtr =
+        extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc);
+    Value outputPtr =
+        extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
+
+    auto inputType = cast<MemRefType>(op.getInput().getType());
+    Value inputNumElements =
+        computeNumElements(inputType, adaptor.getInput(), rewriter, loc);
+
+    int64_t rank = inputType.getRank();
+    if (rank == 0)
+      return rewriter.notifyMatchFailure(op, "l2_norm.scalar_input");
+    int64_t lastDim = inputType.getShape()[rank - 1];
+    if (ShapedType::isDynamic(lastDim))
+      return rewriter.notifyMatchFailure(op, "l2_norm.dynamic_last_dim");
+    Value normSize = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(lastDim));
+
+    Type elementType = inputType.getElementType();
+    unsigned elementSizeBytes = elementType.getIntOrFloatBitWidth() / 8;
+    Value elementSizeBytesVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(elementSizeBytes));
+
+    Value epsilonVal =
+        LLVM::ConstantOp::create(rewriter, loc, f32Type, op.getEpsilonAttr());
+
+    SmallVector<Type> paramTypes = {ptrType, ptrType, ptrType, i64Type,
+                                    i64Type, i64Type, f32Type};
+
+    FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
+        rewriter, module, kWrapL2Normalize, paramTypes, rewriter.getI32Type());
+    if (failed(funcOp))
+      return failure();
+
+    SmallVector<Value> args = {statePtr,  inputPtr,
+                               outputPtr, inputNumElements,
+                               normSize,  elementSizeBytesVal,
+                               epsilonVal};
+
+    LLVM::CallOp::create(rewriter, loc, *funcOp, args);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 } // namespace
 
 void populateNormLoweringPatterns(const LLVMTypeConverter &converter,
                                   RewritePatternSet &patterns) {
-  patterns.add<RmsNormOpLowering, SkipRmsNormOpLowering, LayerNormOpLowering>(
-      converter);
+  patterns.add<RmsNormOpLowering, SkipRmsNormOpLowering, LayerNormOpLowering,
+               L2NormOpLowering>(converter);
 }
 
 } // namespace hip

--- a/lib/Conversion/OnnxToHip/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHip/CMakeLists.txt
@@ -41,6 +41,7 @@ add_library(OnnxToHip STATIC
   ErfGeluFusion.cpp
   ProjectorOpsRewrites.cpp
   LpNormalizationConversion.cpp
+  L2NormFusion.cpp
   EqualConversion.cpp
   DivConversion.cpp
   ReduceMaxConversion.cpp

--- a/lib/Conversion/OnnxToHip/L2NormFusion.cpp
+++ b/lib/Conversion/OnnxToHip/L2NormFusion.cpp
@@ -1,0 +1,280 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- L2NormFusion.cpp - Fold the q/k L2-normalization chain into hip ---===//
+//
+// Collapses the exporter-emitted q/k L2-normalization decomposition in the
+// Qwen3.5 linear-attention layers:
+//
+//   sq   = onnx.Mul(x, x)                       // square (NOT Pow)
+//   ss   = onnx.ReduceSum(sq, axes=[-1], keepdims=1)
+//   den  = onnx.Add(ss, eps)
+//   r    = onnx.Reciprocal(onnx.Sqrt(den))
+//   out  = onnx.Mul(x, r)
+//
+// into a single `hip.l2_norm`. Rooted on the (rare) onnx.Reciprocal. Lives in
+// the pre-lowering loop (next to FastGeluFusion) so it matches the primitive
+// onnx.* ops before convertComputeOps and while the eps Constant is inline.
+//
+//===----------------------------------------------------------------------===//
+
+#include "OnnxToHipUtils.h"
+
+#include "llvm/ADT/Statistic.h"
+#include "llvm/Support/Debug.h"
+
+#include <cstdlib>
+#include <optional>
+#include <string>
+
+#define DEBUG_TYPE "l2-norm-fusion"
+
+STATISTIC(NumL2NormFused, "q/k L2-normalization chains folded into hip.l2_norm");
+
+namespace mlir {
+namespace hip {
+
+namespace {
+
+static std::optional<double> getScalarFloatConstant(mlir::Value v) {
+  mlir::Operation *def = v.getDefiningOp();
+  if (!def || def->getName().getStringRef() != "onnx.Constant")
+    return std::nullopt;
+  auto denseAttr =
+      mlir::dyn_cast_or_null<mlir::DenseElementsAttr>(def->getAttr("value"));
+  if (!denseAttr || denseAttr.getNumElements() != 1)
+    return std::nullopt;
+  mlir::Type et = denseAttr.getElementType();
+  if (et.isF32())
+    return static_cast<double>(*denseAttr.getValues<float>().begin());
+  if (et.isF64())
+    return *denseAttr.getValues<double>().begin();
+  if (et.isF16() || et.isBF16())
+    return (*denseAttr.getValues<llvm::APFloat>().begin()).convertToDouble();
+  // Pow exponent sometimes ships as an integer constant (e.g. 2 : i64).
+  if (et.isIntOrIndex())
+    return static_cast<double>(
+        (*denseAttr.getValues<llvm::APInt>().begin()).getSExtValue());
+  return std::nullopt;
+}
+
+static std::optional<int64_t> getSingleReduceAxis(mlir::Operation *reduceOp) {
+  if (reduceOp->getNumOperands() == 2) {
+    auto def = reduceOp->getOperand(1).getDefiningOp();
+    if (def && def->getName().getStringRef() == "onnx.Constant") {
+      auto dense = mlir::dyn_cast_or_null<mlir::DenseElementsAttr>(
+          def->getAttr("value"));
+      if (dense && dense.getElementType().isInteger(64) &&
+          dense.getNumElements() == 1)
+        return (*dense.getValues<llvm::APInt>().begin()).getSExtValue();
+    }
+    return std::nullopt;
+  }
+  if (auto axesAttr = reduceOp->getAttrOfType<mlir::ArrayAttr>("axes")) {
+    if (axesAttr.size() == 1)
+      if (auto ia = mlir::dyn_cast<mlir::IntegerAttr>(axesAttr[0]))
+        return ia.getValue().getSExtValue();
+  }
+  return std::nullopt;
+}
+
+struct L2NormChainToHip : public mlir::RewritePattern {
+  L2NormChainToHip(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.Reciprocal", /*benefit=*/2, ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *recipOp,
+                  mlir::PatternRewriter &rewriter) const override {
+    if (recipOp->getNumOperands() != 1 || recipOp->getNumResults() != 1)
+      return rewriter.notifyMatchFailure(recipOp, "recip.arity");
+
+    mlir::Operation *sqrtOp = recipOp->getOperand(0).getDefiningOp();
+    if (!sqrtOp || sqrtOp->getName().getStringRef() != "onnx.Sqrt" ||
+        sqrtOp->getNumOperands() != 1)
+      return rewriter.notifyMatchFailure(recipOp, "sqrt.in");
+
+    mlir::Operation *addOp = sqrtOp->getOperand(0).getDefiningOp();
+    if (!addOp || addOp->getName().getStringRef() != "onnx.Add" ||
+        addOp->getNumOperands() != 2)
+      return rewriter.notifyMatchFailure(recipOp, "add.in");
+
+    mlir::Operation *reduceOp = nullptr;
+    std::optional<double> eps;
+    for (int i = 0; i < 2; ++i) {
+      mlir::Value cand = addOp->getOperand(i);
+      mlir::Value other = addOp->getOperand(1 - i);
+      mlir::Operation *def = cand.getDefiningOp();
+      if (def && def->getName().getStringRef() == "onnx.ReduceSum") {
+        if (auto e = getScalarFloatConstant(other)) {
+          reduceOp = def;
+          eps = e;
+          break;
+        }
+      }
+    }
+    if (!reduceOp || !eps)
+      return rewriter.notifyMatchFailure(recipOp, "add.reducesum_eps");
+
+    std::optional<int64_t> axis = getSingleReduceAxis(reduceOp);
+    if (!axis)
+      return rewriter.notifyMatchFailure(recipOp, "reduce.axis_unknown");
+    auto sqType = mlir::dyn_cast<mlir::RankedTensorType>(
+        reduceOp->getOperand(0).getType());
+    if (!sqType)
+      return rewriter.notifyMatchFailure(recipOp, "reduce.in_not_ranked");
+    int64_t rank = sqType.getRank();
+    int64_t normAxis = *axis < 0 ? *axis + rank : *axis;
+    if (normAxis != rank - 1)
+      return rewriter.notifyMatchFailure(recipOp, "reduce.not_last_axis");
+    if (auto kd = reduceOp->getAttrOfType<mlir::IntegerAttr>("keepdims"))
+      if (kd.getValue().getSExtValue() != 1)
+        return rewriter.notifyMatchFailure(recipOp, "reduce.not_keepdims");
+
+    // Square is either Mul(x, x) (rtn export) or Pow(x, 2) (fp16-ve export).
+    mlir::Operation *sqOp = reduceOp->getOperand(0).getDefiningOp();
+    if (!sqOp || sqOp->getNumOperands() != 2)
+      return rewriter.notifyMatchFailure(recipOp, "square.arity");
+    llvm::StringRef sqName = sqOp->getName().getStringRef();
+    mlir::Value x;
+    if (sqName == "onnx.Mul") {
+      if (sqOp->getOperand(0) != sqOp->getOperand(1))
+        return rewriter.notifyMatchFailure(recipOp, "square.mul_operands_differ");
+      x = sqOp->getOperand(0);
+    } else if (sqName == "onnx.Pow") {
+      auto exp = getScalarFloatConstant(sqOp->getOperand(1));
+      if (!exp || *exp != 2.0)
+        return rewriter.notifyMatchFailure(recipOp, "square.pow_not_2");
+      x = sqOp->getOperand(0);
+    } else {
+      return rewriter.notifyMatchFailure(recipOp, "square.not_mul_or_pow");
+    }
+
+    mlir::Value recipRes = recipOp->getResult(0);
+    if (!recipRes.hasOneUse())
+      return rewriter.notifyMatchFailure(recipOp, "recip.not_one_use");
+    mlir::Operation *finalMul = *recipRes.getUsers().begin();
+    if (finalMul->getName().getStringRef() != "onnx.Mul" ||
+        finalMul->getNumOperands() != 2)
+      return rewriter.notifyMatchFailure(recipOp, "final.not_mul");
+    mlir::Value mulOther = (finalMul->getOperand(0) == recipRes)
+                               ? finalMul->getOperand(1)
+                               : finalMul->getOperand(0);
+    if (mulOther != x)
+      return rewriter.notifyMatchFailure(recipOp, "final.operand_neq_x");
+
+    auto xType = mlir::dyn_cast<mlir::RankedTensorType>(x.getType());
+    if (!xType)
+      return rewriter.notifyMatchFailure(recipOp, "x.not_ranked");
+    auto outType = mlir::dyn_cast<mlir::RankedTensorType>(
+        finalMul->getResult(0).getType());
+    if (!outType || outType.getShape() != xType.getShape() ||
+        outType.getElementType() != xType.getElementType())
+      return rewriter.notifyMatchFailure(recipOp, "out_type_mismatch");
+
+    auto ctxOrFailure = getContextArg(finalMul, rewriter);
+    if (mlir::failed(ctxOrFailure))
+      return rewriter.notifyMatchFailure(recipOp, "no_context_arg");
+    mlir::Value context = *ctxOrFailure;
+
+    mlir::Location loc = finalMul->getLoc();
+    rewriter.setInsertionPoint(finalMul);
+    mlir::Value init = createEmptyTensor(rewriter, loc, outType, x);
+    auto axisAttr = rewriter.getI64IntegerAttr(-1);
+    auto epsAttr = rewriter.getF32FloatAttr(static_cast<float>(*eps));
+
+    auto hipOp = mlir::hip::L2NormOp::create(rewriter, loc, outType, context, x,
+                                             init, axisAttr, epsAttr);
+    rewriter.replaceOp(finalMul, hipOp->getResult(0));
+
+    auto eraseIfDead = [&rewriter](mlir::Operation *op) {
+      if (op && op->use_empty())
+        rewriter.eraseOp(op);
+    };
+    eraseIfDead(recipOp);
+    eraseIfDead(sqrtOp);
+    eraseIfDead(addOp);
+    eraseIfDead(reduceOp);
+    eraseIfDead(sqOp);
+
+    LLVM_DEBUG(llvm::dbgs() << "[" DEBUG_TYPE "] fused L2-norm at " << loc
+                            << " (eps=" << *eps << ")\n");
+    ++NumL2NormFused;
+    return mlir::success();
+  }
+};
+
+/// Direct match of `onnx.LpNormalization` (p=2, last axis) -> hip.l2_norm.
+/// The fp16-ve Qwen3.5 export emits LpNormalization (48x) for q/k norm instead
+/// of the decomposed chain. LpNormalization has no epsilon (output = x /
+/// L2(x)), so eps=0 -- matching the LpNormalizationConversion decomposition's
+/// plain-division behaviour. Benefit 3 so this fires before
+/// LpNormalizationDecompose (benefit 2).
+struct LpNormalizationToHip : public mlir::RewritePattern {
+  LpNormalizationToHip(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.LpNormalization", /*benefit=*/3, ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override {
+    if (op->getNumOperands() != 1 || op->getNumResults() != 1)
+      return rewriter.notifyMatchFailure(op, "lpnorm.arity");
+
+    int64_t p = 2;
+    if (auto pAttr = op->getAttrOfType<mlir::IntegerAttr>("p"))
+      p = pAttr.getValue().getSExtValue();
+    if (p != 2)
+      return rewriter.notifyMatchFailure(op, "lpnorm.p_not_2");
+
+    mlir::Value x = op->getOperand(0);
+    auto xType = mlir::dyn_cast<mlir::RankedTensorType>(x.getType());
+    if (!xType)
+      return rewriter.notifyMatchFailure(op, "lpnorm.not_ranked");
+    int64_t rank = xType.getRank();
+    if (rank == 0)
+      return rewriter.notifyMatchFailure(op, "lpnorm.scalar");
+
+    int64_t axis = -1;
+    if (auto axisAttr = op->getAttrOfType<mlir::IntegerAttr>("axis"))
+      axis = axisAttr.getValue().getSExtValue();
+    int64_t normAxis = axis < 0 ? axis + rank : axis;
+    if (normAxis != rank - 1)
+      return rewriter.notifyMatchFailure(op, "lpnorm.not_last_axis");
+
+    auto outType =
+        mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
+    if (!outType || outType.getShape() != xType.getShape() ||
+        outType.getElementType() != xType.getElementType())
+      return rewriter.notifyMatchFailure(op, "lpnorm.out_type_mismatch");
+
+    auto ctxOrFailure = getContextArg(op, rewriter);
+    if (mlir::failed(ctxOrFailure))
+      return rewriter.notifyMatchFailure(op, "lpnorm.no_context_arg");
+    mlir::Value context = *ctxOrFailure;
+
+    mlir::Location loc = op->getLoc();
+    mlir::Value init = createEmptyTensor(rewriter, loc, outType, x);
+    auto axisAttr = rewriter.getI64IntegerAttr(-1);
+    auto epsAttr = rewriter.getF32FloatAttr(0.0f);
+    auto hipOp = mlir::hip::L2NormOp::create(rewriter, loc, outType, context, x,
+                                             init, axisAttr, epsAttr);
+    rewriter.replaceOp(op, hipOp->getResult(0));
+    LLVM_DEBUG(llvm::dbgs() << "[" DEBUG_TYPE "] fused LpNormalization at "
+                            << loc << "\n");
+    ++NumL2NormFused;
+    return mlir::success();
+  }
+};
+
+} // namespace
+
+void populateL2NormFusionPatterns(mlir::RewritePatternSet &patterns,
+                                  mlir::MLIRContext *ctx) {
+  if (const char *env = std::getenv("HIPDNN_EP_L2NORM_FUSE"))
+    if (std::string(env) == "0")
+      return;
+  patterns.add<L2NormChainToHip, LpNormalizationToHip>(ctx);
+}
+
+} // namespace hip
+} // namespace mlir

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -776,6 +776,7 @@ void ConvertOnnxToHipPass::runOnOperation() {
         populateErfGeluFusionPatterns(preLoweringPatterns, ctx);
         populateProjectorOpsRewritePatterns(preLoweringPatterns, ctx);
         populateLpNormalizationConversionPatterns(preLoweringPatterns, ctx);
+        populateL2NormFusionPatterns(preLoweringPatterns, ctx);
         populatePowDecompositionPatterns(preLoweringPatterns, ctx);
         ChangeFlagListener listener;
         mlir::GreedyRewriteConfig preLoweringConfig;

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
@@ -491,6 +491,12 @@ void populateProjectorOpsRewritePatterns(RewritePatternSet &patterns,
 void populateLpNormalizationConversionPatterns(RewritePatternSet &patterns,
                                                MLIRContext *ctx);
 
+/// Pre-lowering: collapse the q/k L2-normalization decomposition
+/// (Mul(x,x)->ReduceSum->Add(eps)->Sqrt->Reciprocal->Mul) into hip.l2_norm.
+/// See L2NormFusion.cpp.
+void populateL2NormFusionPatterns(RewritePatternSet &patterns,
+                                  MLIRContext *ctx);
+
 } // namespace hip
 } // namespace mlir
 

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -526,6 +526,25 @@ LogicalResult RmsNormOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// L2NormOp: ins(input), outs(output)
+//===----------------------------------------------------------------------===//
+
+MutableOperandRange L2NormOp::getDpsInitsMutable() {
+  return getOutputMutable();
+}
+
+void L2NormOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  emitDpsMemoryEffects(getDpsInputOperands(), getDpsInitsMutable(), effects);
+}
+
+LogicalResult L2NormOp::verify() {
+  return verifyDpsComputeOp(*this, {getInput(), getOutput()},
+                            /*numInits=*/1);
+}
+
+//===----------------------------------------------------------------------===//
 // SkipRmsNormOp: ins(input, skip, gamma, [bias])  outs(...variadic...)
 //===----------------------------------------------------------------------===//
 

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -273,6 +273,7 @@ if(NOT BUILD_MOCK_RUNTIME)
     compile_to_bitcode(real/matmul.cpp runtime_matmul.bc)
     compile_to_bitcode(real/activation.cpp runtime_activation.bc)
     compile_to_bitcode(real/layer_normalization.cpp runtime_layer_normalization.bc)
+    compile_to_bitcode(real/l2_norm.cpp runtime_l2_norm.bc)
     compile_to_bitcode(real/simplified_layer_norm.cpp runtime_simplified_layer_norm.bc)
     compile_to_bitcode(real/skip_simplified_layer_norm.cpp runtime_skip_simplified_layer_norm.bc)
     compile_to_bitcode(real/rotary_embedding.cpp runtime_rotary_embedding.bc)
@@ -334,6 +335,7 @@ if(NOT BUILD_MOCK_RUNTIME)
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_matmul.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_activation.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_layer_normalization.bc
+        ${CMAKE_CURRENT_BINARY_DIR}/runtime_l2_norm.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_simplified_layer_norm.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_skip_simplified_layer_norm.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_rotary_embedding.bc

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -1111,6 +1111,12 @@ int wrap_layer_normalization(RuntimeState *state, void *input, void *scale,
                              int64_t element_size_bytes, int64_t axis,
                              float epsilon, int64_t stash_type);
 
+// L2 normalization wrapper (q/k norm in linear attention).
+// output = input * rsqrt(sum(input^2, last_axis) + epsilon)
+int wrap_l2_normalize(RuntimeState *state, void *input, void *output,
+                      int64_t input_num_elements, int64_t norm_size,
+                      int64_t element_size_bytes, float epsilon);
+
 // SkipSimplifiedLayerNormalization operation wrapper (Full MS spec)
 // Computes: input_skip_bias_sum = input + skip [+ bias]
 //           output = RMSNorm(input_skip_bias_sum) * gamma

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -1098,6 +1098,20 @@ int wrap_rotary_embedding(RuntimeState *state, void *input, void *position_ids,
   return 0;
 }
 
+int wrap_l2_normalize(RuntimeState *state, void *input, void *output,
+                      int64_t input_num_elements, int64_t norm_size,
+                      int64_t element_size_bytes, float epsilon) {
+  if (!state) {
+    fprintf(stderr, "Invalid state in wrap_l2_normalize\n");
+    return -1;
+  }
+  MOCK_PRINT("[MOCK] wrap_l2_normalize(input_num_elements=%lld, norm_size=%lld, "
+             "element_size=%lld, epsilon=%f)\n",
+             (long long)input_num_elements, (long long)norm_size,
+             (long long)element_size_bytes, (double)epsilon);
+  return 0;
+}
+
 int wrap_miopenT5LayerNormForward(RuntimeState *state, int op_state_slot,
                                   void *input, void *scale, void *output,
                                   int64_t input_num_elements,

--- a/lib/Runtime/real/l2_norm.cpp
+++ b/lib/Runtime/real/l2_norm.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// L2 normalization over the last axis:
+//   y = x * rsqrt(sum(x^2, last_axis) + epsilon)
+// Fused replacement for the exporter q/k normalization chain (see
+// l2_norm_kernel.hip and L2NormFusion.cpp).
+
+#include "../debug_log.h"
+#include "../hipdnn_ep_runtime.h"
+#include "../op_profile.h"
+#include "hip_custom_kernels.h"
+#include "runtime_types.h"
+
+#include <cstdio>
+
+int wrap_l2_normalize(RuntimeState *state, void *input, void *output,
+                      int64_t input_num_elements, int64_t norm_size,
+                      int64_t element_size_bytes, float epsilon) {
+  OP_PROFILE(
+      "l2norm",
+      [&] {
+        char b[64];
+        int64_t outer = norm_size > 0 ? input_num_elements / norm_size : 0;
+        snprintf(b, sizeof(b), "%lldx%lld:%s", (long long)outer,
+                 (long long)norm_size,
+                 (element_size_bytes == 2) ? "f16" : "f32");
+        return std::string(b);
+      },
+      state);
+
+  if (!state || !input || !output) {
+    RUNTIME_DEBUG_LOG("[REAL] wrap_l2_normalize: null required arg\n");
+    return -1;
+  }
+  if (norm_size <= 0 || input_num_elements % norm_size != 0) {
+    fprintf(stderr,
+            "[REAL] wrap_l2_normalize: bad norm_size=%lld input_num=%lld\n",
+            (long long)norm_size, (long long)input_num_elements);
+    return -1;
+  }
+
+  int hip_dtype;
+  if (element_size_bytes == 2)
+    hip_dtype = HIP_DTYPE_FLOAT16;
+  else if (element_size_bytes == 4)
+    hip_dtype = HIP_DTYPE_FLOAT32;
+  else {
+    fprintf(stderr, "[REAL] wrap_l2_normalize: unsupported element_size=%lld\n",
+            (long long)element_size_bytes);
+    return -1;
+  }
+
+  int64_t outer = input_num_elements / norm_size;
+  void *stream = hipdnn_ep_state_get_stream(state);
+  return hip_l2_normalize(stream, input, output, outer, norm_size, epsilon,
+                          hip_dtype);
+}

--- a/test/lit/Conversion/onnx-to-hip/test_lpnormalization.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_lpnormalization.mlir
@@ -7,9 +7,13 @@
 // into Mul(x,x) -> ReduceSum(axis, keepdims=1) -> Sqrt -> Div(x, norm). The
 // final Div broadcasts (rhs has 1 along the reduce axis), so
 // BroadcastDivToMulReciprocal -- also in the pre-lowering loop -- rewrites
-// it into Mul(x, Reciprocal(norm)). The expected hip.* op set is therefore:
-// hip.mul, hip.reduce_sum, hip.sqrt, hip.reciprocal, hip.mul. p=1 gets one
-// extra hip.sqrt for the Sqrt(x*x)=|x| step.
+// it into Mul(x, Reciprocal(norm)).
+//
+// For p=2 the resulting Mul/ReduceSum/Sqrt/Reciprocal/Mul chain is exactly
+// the pattern L2NormFusion matches, so it is then folded into a single
+// hip.l2_norm (epsilon = 0, numerically identical: x / sqrt(sum(x^2))).
+// p=1 inserts an extra Sqrt(x*x)=|x| step, which does not match the L2
+// pattern, so it stays as the primitive decomposition.
 
 module {
   func.func @main_graph(%arg0: tensor<4xf32>) -> tensor<4xf32> {
@@ -26,11 +30,9 @@ module {
   // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[X:.*]]: tensor<2x3xf32>)
   // CHECK-NOT: onnx.LpNormalization
   // CHECK-NOT: onnx.Div
-  // CHECK: hip.mul(%[[CTX]]) ins(%[[X]], %[[X]]
-  // CHECK: hip.reduce_sum
-  // CHECK: hip.sqrt
-  // CHECK: hip.reciprocal
-  // CHECK: hip.mul
+  // p=2 chain is folded into a single hip.l2_norm by L2NormFusion.
+  // CHECK: hip.l2_norm(%[[CTX]]) ins(%[[X]]
+  // CHECK-NOT: hip.reduce_sum
 
   // p=1, explicit axis=1 on a rank-3 f16 input. p=1 path inserts an extra
   // Sqrt(x*x) before the reduction to compute |x|.
@@ -60,13 +62,7 @@ module {
   // CHECK-LABEL: func.func @lp_norm_dynamic
   // CHECK-SAME: (%[[CTX2:.*]]: !hip.context, %[[X2:.*]]: tensor<?x?x16xf32>)
   // CHECK-NOT: onnx.LpNormalization
-  // CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
-  // CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
-  // CHECK: tensor.dim
-  // CHECK: tensor.dim
-  // CHECK: hip.mul
-  // CHECK: hip.reduce_sum
-  // CHECK: hip.sqrt
-  // CHECK: hip.reciprocal
-  // CHECK: hip.mul
+  // p=2 dynamic-shape chain is likewise folded into hip.l2_norm.
+  // CHECK: hip.l2_norm(%[[CTX2]]) ins(%[[X2]]
+  // CHECK-NOT: hip.reduce_sum
 }

--- a/test/lit/e2e/test_lpnormalization_model.mlir
+++ b/test/lit/e2e/test_lpnormalization_model.mlir
@@ -5,24 +5,19 @@
 // imported via onnx-mlir / morphizen mlir-imp.
 //
 // Verifies the complete hipdnn-pipeline:
-// 1. convert-onnx-to-hip: onnx.LpNormalization decomposes into
-//    Mul / ReduceSum / Sqrt / Div, each handled by its own converter.
-//    The broadcasting Div is rewritten by BroadcastDivToMulReciprocal
-//    into Mul(x, Reciprocal(norm)). No new HIP op or runtime symbol is
-//    introduced — only existing primitives are exercised.
+// 1. convert-onnx-to-hip: onnx.LpNormalization (p=2) decomposes into
+//    Mul / ReduceSum / Sqrt / Div, the broadcasting Div is rewritten into
+//    Mul(x, Reciprocal(norm)), and L2NormFusion then folds that whole
+//    chain into a single hip.l2_norm (epsilon = 0, numerically identical).
 // 2. canonicalize: simplify redundant operations
 // 3. memory-pooling: pool output buffer into single allocation
-// 4. convert-hip-to-llvm: HIP ops -> LLVM runtime calls
-//    (wrap_miopenOpTensor for Mul, wrap_reduce_sum for ReduceSum,
-//     wrap_power for Sqrt + Reciprocal)
+// 4. convert-hip-to-llvm: hip.l2_norm -> wrap_l2_normalize runtime call
 // 5. generate-interface: create inference_init/compute/cleanup/metadata
 
 // CHECK: module attributes {
 // CHECK-SAME: hipdnn.input_count = 1
 // CHECK-SAME: hipdnn.output_count = 1
-// CHECK-DAG: llvm.func @wrap_miopenOpTensor
-// CHECK-DAG: llvm.func @wrap_reduce_sum
-// CHECK-DAG: llvm.func @wrap_power
+// CHECK-DAG: llvm.func @wrap_l2_normalize
 // CHECK-DAG: llvm.func @inference_init
 // CHECK-DAG: llvm.func @inference_compute
 // CHECK-DAG: llvm.func @inference_cleanup


### PR DESCRIPTION
## Summary
- Rebased the q/k L2-normalization fusion onto the latest `main`.
- `228afc1b` (cherry-pick): adds an `L2NormFusion` pre-lowering pass that folds the `Mul(x,x) -> ReduceSum -> Add(eps) -> Sqrt -> Reciprocal -> Mul` chain into a single `hip.l2_norm` op, plus the `l2_norm` HIP kernel, the `hip.l2_norm` op definition, and the `wrap_l2_normalize` runtime wrapper.
- `1e2197c5` (test adaptation): see note below.

## Note: interaction with main's `LpNormalization`
`main` gained `onnx.LpNormalization` support after this branch's original base. Its **p=2** decomposition is exactly the chain `L2NormFusion` matches, so the fusion now also folds `LpNormalization` p=2 into `hip.l2_norm` (epsilon = 0, numerically identical: `x / sqrt(sum(x^2))`). This is strictly fewer kernels and bit-equivalent. The two `LpNormalization` lit tests were updated to expect the fused op; the p=1 path is unchanged (its extra `Sqrt(|x|)` step does not match the L2 pattern).

## Local build verification
- Built with `build.py --cmake_generator Ninja --hip_arch gfx1151` on Windows (VS 2026 MSVC, sccache).
- `L2NormFusion.cpp`, `l2_norm_kernel.hip`, `l2_norm.cpp` compile; `hipep.dll` + `custom_kernels_gfx1151.dll` install cleanly.
- LIT suite: **277/277 passed** (after the test adaptation above).

## Test plan
- [ ] CI build (Windows + Linux)
- [ ] GPU accuracy run confirming q/k L2-norm and LpNormalization p=2 outputs are unchanged

Draft for testing.
