### PR TITLE
fix(hip): de-alias DPS init operands that CSE merged onto one tensor.empty

### DIFF
--- a/include/hip/Dialect/Transforms/Passes.td
+++ b/include/hip/Dialect/Transforms/Passes.td
@@ -765,4 +765,49 @@ def ResolveExternConstantsPass
   ];
 }
 
+def SplitDuplicateDpsInitsPass
+    : Pass<"hip-split-duplicate-dps-inits", "mlir::func::FuncOp"> {
+  let summary = "De-alias DPS init operands of an op that CSE merged onto one "
+                "tensor.empty";
+  let description = [{
+    `tensor.empty` is `Pure`, so CSE deduplicates same-typed empties. That is
+    harmless for single-use scratch, but WRONG when one merged empty feeds two
+    or more *init* (DPS-out) operands of the SAME op: bufferization then aliases
+    those results into one buffer, and an op whose kernel reads back its own
+    outputs -- e.g. `hip.gqa` reading K from `present_key` and V from
+    `present_value` -- consumes the same bytes for both and silently
+    miscompiles. One-Shot Bufferize separates such inits only when the tied
+    results are live; for dead scratch results it keeps them merged.
+
+    For each `DestinationStyleOpInterface` op, this pass re-points every init
+    operand after the first occurrence of a shared `tensor.empty` at its own
+    fresh `bufferization.alloc_tensor` (CSE-immune, documented to not alias any
+    other buffer). Only `tensor.empty` seeds are rewritten -- their contents are
+    undefined, so the substitution is value-preserving; non-empty inits, which
+    may carry contents the op reads, are left untouched. Single-use scratch
+    empties are unaffected and stay CSE-mergeable, so pool packing is preserved.
+
+    This is the surgical counterpart to running `empty-tensor-to-alloc-tensor`
+    over every empty (the upstream blanket approach), which also blocks benign
+    merges and inflates the buffer / pool-domain count on activation-heavy
+    graphs. Runs after CSE (which creates the duplication) and before
+    one-shot-bufferize (which would otherwise lock in the shared buffer).
+
+    Before (post-CSE; one %e feeds both present_* inits):
+
+        %e = tensor.empty() : tensor<AxBxCxDxf16>
+        hip.gqa(...) outs(%out, %e, %e : ...)   // present_key aliases present_value
+
+    After:
+
+        %e  = tensor.empty()               : tensor<AxBxCxDxf16>
+        %e2 = bufferization.alloc_tensor() : tensor<AxBxCxDxf16>
+        hip.gqa(...) outs(%out, %e, %e2 : ...)  // distinct buffers
+  }];
+  let dependentDialects = [
+    "mlir::bufferization::BufferizationDialect",
+    "mlir::tensor::TensorDialect"
+  ];
+}
+
 #endif // HIP_PASSES

--- a/lib/Dialect/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Transforms/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(HipDialectTransforms STATIC
   RelaxMultiDynExpandShape.cpp
   ResolveExternConstants.cpp
   ResolveTensorDims.cpp
+  SplitDuplicateDpsInits.cpp
   UseOutputAllocator.cpp
 )
 

--- a/lib/Dialect/Transforms/Pipelines.cpp
+++ b/lib/Dialect/Transforms/Pipelines.cpp
@@ -64,6 +64,18 @@ static void buildOnnxToHipPipelineTail(OpPassManager &pm,
   //      buffer reuse).
   pm.addPass(mlir::createCanonicalizerPass());
   pm.addPass(mlir::createCSEPass());
+  // 1b''. Repair the one unsafe consequence of the CSE above: when it merges
+  //       the seed `tensor.empty`s of two init operands of the SAME op, the
+  //       tied results bufferize into one buffer and an op that reads back its
+  //       own outputs (e.g. `hip.gqa` present_key/present_value) miscompiles.
+  //       This re-points each such duplicate at a fresh, non-aliasing
+  //       `bufferization.alloc_tensor`. It MUST run after the CSE that creates
+  //       the duplication and before `one-shot-bufferize` locks in the shared
+  //       buffer; it is the surgical alternative to a blanket
+  //       `empty-tensor-to-alloc-tensor` (which would also undo the benign
+  //       merges the CSE above is here to make). See
+  //       SplitDuplicateDpsInits.cpp.
+  pm.addNestedPass<func::FuncOp>(hip::createSplitDuplicateDpsInitsPass());
 
   // 1c. Fold `tensor.dim` queries on `tensor.expand_shape` /
   //     `tensor.collapse_shape` chains into arithmetic on the chain

--- a/lib/Dialect/Transforms/SplitDuplicateDpsInits.cpp
+++ b/lib/Dialect/Transforms/SplitDuplicateDpsInits.cpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- SplitDuplicateDpsInits.cpp - de-alias same-op DPS init operands ---===//
+//
+// Gives every init (DPS-out) operand of an op its own buffer when CSE has
+// collapsed several of their seed `tensor.empty` ops onto one value. Runs
+// AFTER CSE and BEFORE one-shot-bufferize.
+//
+// Why this pass exists
+// --------------------
+// `tensor.empty` is `Pure`, so CSE freely deduplicates same-typed empties.
+// That is harmless -- and desirable -- for single-use scratch: it keeps the
+// buffer count, and the downstream `--hip-pool-allocs` domain count, low.
+//
+// It is WRONG, however, when CSE collapses the distinct seeds of two *init*
+// operands of the SAME op onto one value. After bufferization both tied
+// results then share one buffer, and an op whose kernel reads back its own
+// outputs miscompiles. The canonical victim is `hip.gqa`: its kernel writes
+// then reads K from `present_key` and V from `present_value`, so aliasing the
+// two makes it read V as K and silently produce wrong attention output.
+//
+// One-Shot Bufferize does not save us here. Its analysis separates two writing
+// inits that alias only when it can find a read-after-write conflict on a tied
+// result -- i.e. when the results are LIVE. When the results are dead (e.g. a
+// present-KV output that no downstream op consumes), there is no such read, the
+// inits stay merged, and the kernel-internal read silently consumes the wrong
+// bytes.
+//
+// Relation to upstream
+// --------------------
+// Upstream handles the identical hazard structurally, by running
+// `bufferization::EmptyTensorToAllocTensor` over EVERY `tensor.empty` before
+// bufferize (see IREE `addIREEComprehensiveBufferizePasses` and the LLVM
+// sparsifier pipeline). `bufferization.alloc_tensor` is documented to not alias
+// any other buffer and is not `Pure`, so it survives CSE and forces a distinct
+// allocation. That blanket conversion is correct but also blocks every benign
+// empty merge, multiplying the buffer (and pool-domain) count on
+// activation-heavy graphs. This pass applies the same `alloc_tensor` mechanism
+// surgically -- only to the duplicated same-op inits that actually need it --
+// preserving the benign merges and their pool packing.
+//
+// Safety
+// ------
+// Only duplicates whose seed is a `tensor.empty` are rewritten. A
+// `tensor.empty` has undefined contents, so substituting a fresh uninitialized
+// `bufferization.alloc_tensor` is value-preserving. A non-empty duplicate
+// init may carry contents the op reads (a read-before-write / accumulate init),
+// so it is intentionally left untouched rather than risk dropping live data.
+//
+// Before (post-CSE; one %e feeds both present_* inits of one gqa):
+//
+//   %e = tensor.empty() : tensor<AxBxCxDxf16>
+//   hip.gqa(...) outs(%out, %e, %e : ...)   // present_key aliases
+//   present_value
+//
+// After:
+//
+//   %e  = tensor.empty()               : tensor<AxBxCxDxf16>
+//   %e2 = bufferization.alloc_tensor() : tensor<AxBxCxDxf16>
+//   hip.gqa(...) outs(%out, %e, %e2 : ...)  // distinct buffers
+//
+// Pipeline placement
+// ------------------
+// In `buildOnnxToHipPipelineTail`, immediately after the post-shape-inference
+// CSE (which produces the duplication this pass repairs) and before
+// `one-shot-bufferize` (which would otherwise lock in the shared buffer).
+//
+//===----------------------------------------------------------------------===//
+
+#include "hip/Dialect/Transforms/Passes.h"
+
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/Interfaces/DestinationStyleOpInterface.h"
+
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/Statistic.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "hip-split-duplicate-dps-inits"
+
+STATISTIC(NumInitsSplit,
+          "Number of duplicate same-op DPS init operands re-pointed at a fresh "
+          "bufferization.alloc_tensor");
+
+namespace mlir {
+namespace hip {
+
+#define GEN_PASS_DEF_SPLITDUPLICATEDPSINITSPASS
+#include "hip/Dialect/Transforms/Passes.h.inc"
+
+namespace {
+
+struct SplitDuplicateDpsInitsPass
+    : public impl::SplitDuplicateDpsInitsPassBase<SplitDuplicateDpsInitsPass> {
+
+  void runOnOperation() override {
+    getOperation().walk([](DestinationStyleOpInterface dpsOp) {
+      // Init values already seen on THIS op. The first occurrence keeps its
+      // original `tensor.empty`; later occurrences of the same value are each
+      // re-pointed at their own fresh allocation.
+      llvm::SmallPtrSet<Value, 4> seen;
+      for (OpOperand &init : dpsOp.getDpsInitsMutable()) {
+        // Only `tensor.empty` seeds are the CSE-merge hazard, and only they are
+        // safe to replace (undefined contents). Anything else is left intact.
+        auto emptyOp = init.get().getDefiningOp<tensor::EmptyOp>();
+        if (!emptyOp || seen.insert(init.get()).second)
+          continue;
+
+        OpBuilder b(dpsOp);
+        auto fresh = bufferization::AllocTensorOp::create(
+            b, emptyOp.getLoc(), emptyOp.getType(), emptyOp.getDynamicSizes());
+        init.set(fresh);
+        ++NumInitsSplit;
+        LLVM_DEBUG(llvm::dbgs()
+                   << "[" DEBUG_TYPE "] " << dpsOp->getName() << " init #"
+                   << init.getOperandNumber()
+                   << ": split shared tensor.empty -> fresh alloc_tensor\n");
+      }
+    });
+  }
+};
+
+} // namespace
+} // namespace hip
+} // namespace mlir

--- a/test/lit/Dialect/hip-split-duplicate-dps-inits.mlir
+++ b/test/lit/Dialect/hip-split-duplicate-dps-inits.mlir
@@ -1,0 +1,110 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --hip-split-duplicate-dps-inits %s | FileCheck %s
+
+// When CSE has merged the distinct seeds of two init (DPS-out) operands of the
+// SAME op onto one `tensor.empty`, the pass re-points every occurrence after
+// the first to a fresh `bufferization.alloc_tensor`, so bufferization gives
+// each tied result its own buffer (the GQA present_key/present_value clobber,
+// where the kernel would otherwise read V as K from the shared buffer).
+
+// CHECK-LABEL: func.func @gqa_duplicate_present_inits
+func.func @gqa_duplicate_present_inits(
+    %ctx: !hip.context,
+    %query: tensor<1x1x4096xf16>,
+    %key: tensor<1x1x1024xf16>,
+    %value: tensor<1x1x1024xf16>,
+    %past_key: tensor<1x8x127x128xf16>,
+    %past_value: tensor<1x8x127x128xf16>,
+    %seqlens_k: tensor<1xi32>,
+    %total_seq_len: tensor<i32>)
+    -> (tensor<1x1x4096xf16>, tensor<1x8x128x128xf16>, tensor<1x8x128x128xf16>) {
+  %eo  = tensor.empty() : tensor<1x1x4096xf16>
+  // One shared empty feeds BOTH present_key and present_value.
+  %ekv = tensor.empty() : tensor<1x8x128x128xf16>
+  // CHECK: %[[EO:.*]] = tensor.empty() : tensor<1x1x4096xf16>
+  // CHECK: %[[EKV:.*]] = tensor.empty() : tensor<1x8x128x128xf16>
+  // The second occurrence is rewritten to a distinct alloc_tensor:
+  // CHECK: %[[FRESH:.*]] = bufferization.alloc_tensor() : tensor<1x8x128x128xf16>
+  // CHECK: hip.gqa(%{{.*}}) ins(
+  // CHECK-SAME: outs(%[[EO]], %[[EKV]], %[[FRESH]] :
+  %r:3 = hip.gqa(%ctx)
+      ins(%query, %key, %value, %past_key, %past_value, %seqlens_k, %total_seq_len :
+          tensor<1x1x4096xf16>, tensor<1x1x1024xf16>, tensor<1x1x1024xf16>,
+          tensor<1x8x127x128xf16>, tensor<1x8x127x128xf16>,
+          tensor<1xi32>, tensor<i32>)
+      outs(%eo, %ekv, %ekv :
+           tensor<1x1x4096xf16>, tensor<1x8x128x128xf16>, tensor<1x8x128x128xf16>)
+      {num_heads = 32 : i64, kv_num_heads = 8 : i64,
+       scale = 0.0883883461 : f32, local_window_size = -1 : i64}
+      : tensor<1x1x4096xf16>, tensor<1x8x128x128xf16>, tensor<1x8x128x128xf16>
+  return %r#0, %r#1, %r#2 : tensor<1x1x4096xf16>, tensor<1x8x128x128xf16>, tensor<1x8x128x128xf16>
+}
+
+// -----
+
+// Single-use scratch empties (each feeding ONE init of ONE op) are left
+// untouched, so benign CSE merges -- and pool packing -- are unaffected.
+
+// CHECK-LABEL: func.func @no_duplicate_left_alone
+func.func @no_duplicate_left_alone(
+    %ctx: !hip.context,
+    %query: tensor<1x1x4096xf16>,
+    %key: tensor<1x1x1024xf16>,
+    %value: tensor<1x1x1024xf16>,
+    %past_key: tensor<1x8x127x128xf16>,
+    %past_value: tensor<1x8x127x128xf16>,
+    %seqlens_k: tensor<1xi32>,
+    %total_seq_len: tensor<i32>)
+    -> (tensor<1x1x4096xf16>, tensor<1x8x128x128xf16>, tensor<1x8x128x128xf16>) {
+  %eo = tensor.empty() : tensor<1x1x4096xf16>
+  %ek = tensor.empty() : tensor<1x8x128x128xf16>
+  %ev = tensor.empty() : tensor<1x8x128x128xf16>
+  // CHECK-NOT: bufferization.alloc_tensor
+  %r:3 = hip.gqa(%ctx)
+      ins(%query, %key, %value, %past_key, %past_value, %seqlens_k, %total_seq_len :
+          tensor<1x1x4096xf16>, tensor<1x1x1024xf16>, tensor<1x1x1024xf16>,
+          tensor<1x8x127x128xf16>, tensor<1x8x127x128xf16>,
+          tensor<1xi32>, tensor<i32>)
+      outs(%eo, %ek, %ev :
+           tensor<1x1x4096xf16>, tensor<1x8x128x128xf16>, tensor<1x8x128x128xf16>)
+      {num_heads = 32 : i64, kv_num_heads = 8 : i64,
+       scale = 0.0883883461 : f32, local_window_size = -1 : i64}
+      : tensor<1x1x4096xf16>, tensor<1x8x128x128xf16>, tensor<1x8x128x128xf16>
+  return %r#0, %r#1, %r#2 : tensor<1x1x4096xf16>, tensor<1x8x128x128xf16>, tensor<1x8x128x128xf16>
+}
+
+// -----
+
+// Safety restriction: a duplicate init whose seed is NOT a `tensor.empty`
+// (here a block argument, whose contents are defined) is left untouched --
+// substituting an uninitialized buffer could drop data the op reads. Only
+// undefined-content `tensor.empty` seeds are rewritten.
+
+// CHECK-LABEL: func.func @non_empty_duplicate_left_alone
+func.func @non_empty_duplicate_left_alone(
+    %ctx: !hip.context,
+    %query: tensor<1x1x4096xf16>,
+    %key: tensor<1x1x1024xf16>,
+    %value: tensor<1x1x1024xf16>,
+    %past_key: tensor<1x8x127x128xf16>,
+    %past_value: tensor<1x8x127x128xf16>,
+    %seqlens_k: tensor<1xi32>,
+    %total_seq_len: tensor<i32>,
+    %kv_buf: tensor<1x8x128x128xf16>)
+    -> (tensor<1x1x4096xf16>, tensor<1x8x128x128xf16>, tensor<1x8x128x128xf16>) {
+  %eo = tensor.empty() : tensor<1x1x4096xf16>
+  // CHECK-NOT: bufferization.alloc_tensor
+  %r:3 = hip.gqa(%ctx)
+      ins(%query, %key, %value, %past_key, %past_value, %seqlens_k, %total_seq_len :
+          tensor<1x1x4096xf16>, tensor<1x1x1024xf16>, tensor<1x1x1024xf16>,
+          tensor<1x8x127x128xf16>, tensor<1x8x127x128xf16>,
+          tensor<1xi32>, tensor<i32>)
+      outs(%eo, %kv_buf, %kv_buf :
+           tensor<1x1x4096xf16>, tensor<1x8x128x128xf16>, tensor<1x8x128x128xf16>)
+      {num_heads = 32 : i64, kv_num_heads = 8 : i64,
+       scale = 0.0883883461 : f32, local_window_size = -1 : i64}
+      : tensor<1x1x4096xf16>, tensor<1x8x128x128xf16>, tensor<1x8x128x128xf16>
+  return %r#0, %r#1, %r#2 : tensor<1x1x4096xf16>, tensor<1x8x128x128xf16>, tensor<1x8x128x128xf16>
+}


### PR DESCRIPTION
A model that lowers to a multi-result HIP DPS op whose kernel reads back its own outputs can silently miscompile. CSE deduplicates `tensor.empty` (it is `Pure`); when it collapses the seeds of two init (DPS-out) operands of the *same* op onto one value, bufferization aliases both tied results into one buffer, and the kernel then reads one output as the other.

**Minimal example (post-CSE):**

```mlir
%e = tensor.empty() : tensor<AxBxCxDxf16>
// present_key and present_value share %e -> after bufferize they share one
// buffer -> hip.gqa reads V (present_value) as K (present_key) -> wrong output
hip.gqa(...) outs(%out, %e, %e : ...)
```

This is fine for single-use scratch, but wrong here. One-Shot Bufferize only separates two aliased writing inits when it can find a read-after-write conflict on a tied result, i.e. when the results are live. When they are dead (e.g. a present-KV output nothing downstream consumes), it keeps them merged and the kernel-internal read consumes the wrong bytes.

**The fix:**

New pass `--hip-split-duplicate-dps-inits`, run after CSE and before one-shot-bufferize:

* For each DPS op, re-point every init operand after the first occurrence of a shared `tensor.empty` at its own fresh `bufferization.alloc_tensor` (CSE-immune, documented to not alias any other buffer).
* Only `tensor.empty` seeds are rewritten -- their contents are undefined, so the substitution is value-preserving. A non-empty init (which may carry contents the op reads) is left untouched.
* Single-use scratch empties are unaffected, so benign CSE merges -- and the downstream pool packing that depends on them -- are preserved.

This is the surgical counterpart to running `empty-tensor-to-alloc-tensor` over every empty (the upstream blanket approach), which also blocks the benign merges and inflates the buffer / pool-domain count on activation-heavy graphs.

Made with [Cursor](https://cursor.com)