### PR TITLE
ci(windows): try build on [windows, gfx1151] (do not merge)

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -21,7 +21,7 @@ jobs:
     # pinned onnxruntime-genai / onnxruntime_extensions fails to build
     # (gsl/util C2220 warning-as-error). Pin to the VS 2022 image per
     # actions/runner-images#14017.
-    runs-on: windows-2022
+    runs-on: [windows, gfx1151]
     # Cancel the build job when a newer commit lands on the same PR ref to
     # save runner minutes. gpu-test deliberately does NOT inherit this rule
     # (see its own concurrency block below) so an in-progress GPU run keeps


### PR DESCRIPTION
## Summary

**Experiment, do not merge.** Switches the `build-windows` job from the GitHub-hosted `windows-2022` image to the self-hosted `[windows, gfx1151]` runner to check whether that runner can compile the full build (ORT / LLVM / amdgpu-ep / onnx-hipdnn-ep / OGA).

## What

1. `runs-on: windows-2022` -> `runs-on: [windows, gfx1151]` for the `build-windows` job in `.github/workflows/windows-build.yml`.

## Test plan

- [ ] `build-windows` reaches a runner labelled `[windows, gfx1151]` and the build toolchain (MSVC, Python, sccache) is available there.

## Notes for reviewers

Not intended to merge.