### PR TITLE
fix(ci): apply OGA PR patches with git am + ship libamdgpu-ep.so

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -257,7 +257,7 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ${{ runner.workspace }}/oga-artifacts
-          key: linux-oga-${{ env.OGA_VERSION }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}
+          key: linux-oga-${{ env.OGA_VERSION }}-pr${{ env.OGA_PR_PATCHES }}-am-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}
 
       # Checkout + build are skipped on an OGA cache hit (step-level gate); the
       # install-copy below always runs so the
@@ -274,9 +274,12 @@ jobs:
           show-progress: false
 
       # Fetch and apply microsoft/onnxruntime-genai PR patches listed in
-      # OGA_PR_PATCHES (env), mirroring the ONNX Runtime PR patch step. Fresh
-      # checkout => patches apply directly; the OGA cache key includes the PR
-      # list, so editing it forces a rebuild.
+      # OGA_PR_PATCHES (env). pull/<n>.patch is a multi-commit mbox; `git am`
+      # replays each commit in order, so a PR that adds -> modifies -> renames
+      # the same path within its own series (e.g. #2194: morphizen_ep/* ->
+      # amdgpu/*) applies cleanly. `git apply` pre-checks every hunk against the
+      # base tree at once and self-conflicts on such a series. The OGA cache key
+      # includes the PR list, so editing it forces a rebuild.
       - name: Apply OGA PR patches
         if: steps.cache-oga.outputs.cache-hit != 'true'
         working-directory: onnxruntime-genai
@@ -289,12 +292,15 @@ jobs:
             echo "OGA_PR_PATCHES is empty; nothing to apply"
             exit 0
           fi
+          # git am needs a committer identity on a bare runner.
+          git config user.email "ci@onnx-hipdnn-ep.local"
+          git config user.name "onnx-hipdnn-ep CI"
           for pr in $prs; do
             url="https://github.com/microsoft/onnxruntime-genai/pull/${pr}.patch"
             echo "Fetching $url"
             curl -fsSL "$url" -o "/tmp/oga-pr-${pr}.patch"
             echo "Applying PR #${pr}"
-            git apply --whitespace=nowarn "/tmp/oga-pr-${pr}.patch"
+            git am --whitespace=nowarn "/tmp/oga-pr-${pr}.patch"
           done
 
       - name: Build OGA
@@ -351,6 +357,11 @@ jobs:
           INSTALL="${{ runner.workspace }}/install"
           ORT="${{ runner.workspace }}/ort-install"
           THEROCK="${{ runner.workspace }}/build/onnx-hipdnn-ep/_therock"
+          # The renamed AMDGPU OGA integration dlopen's libamdgpu-ep.so; the
+          # project still builds the EP as libhipgpu.so. Ship the expected
+          # filename so the genai auto-loader resolves it (deps + closure below
+          # then cover the copy too).
+          cp -a "$INSTALL/lib/libhipgpu.so" "$INSTALL/lib/libamdgpu-ep.so"
           stage_pass() {
             LD_LIBRARY_PATH="$THEROCK/lib:$ORT/lib:$INSTALL/lib" ldd "$@" 2>/dev/null \
               | awk -v p="$ORT" 'index($3, p) == 1 {print $3}' | sort -u \


### PR DESCRIPTION
## Background

`microsoft/onnxruntime-genai` PR #2194 first **adds** `src/morphizen_ep/*`, then **modifies** it, and finally **renames** it to `src/amdgpu/*` (renaming the EP library to `libamdgpu-ep.so` and the provider to `amdgpu`) — all within its own commit series.

CI currently applies it with `git apply pull/2194.patch`. `git apply` pre-checks every hunk in the mbox against the base tree at once, so modifying/renaming a file that the same series only just added self-conflicts. The `Apply OGA PR patches` step fails and the whole build dies. This is also why the current main package's OGA is still the pre-rename `MorphiZenEP` build.

## Changes

- **`git apply` → `git am`**: `pull/<n>.patch` is a multi-commit mbox; `git am` replays each commit in order, so any add → modify → rename sequence applies cleanly. Set a committer identity (a bare runner has no git identity, which `git am` requires).
- **Bump the OGA cache key (`-am`)**: invalidate the stale git-apply artifact so it is not served from cache.
- **Copy `libhipgpu.so` → `libamdgpu-ep.so` in the bundle step**: the renamed AMDGPU integration `dlopen`s `libamdgpu-ep.so` at runtime, while this project still builds the EP as `libhipgpu.so`. The copy is then picked up by the dependency-closure staging and packaging that follow.

## Validation

Reproduced locally the same way CI runs: `git am --whitespace=nowarn pull/2194.patch` applies all 5 commits (including `rename → AMDGPU`) cleanly on top of a clean `v0.14.0`, producing `src/amdgpu/`.

## Note

The genai_config provider name is uppercase `AMDGPU`, while the source uses `ep_name_ = "amdgpu"` (lowercase) — worth confirming whether the dispatch is case-sensitive.