### PR TITLE
perf(onnx-to-hip): fuse p=2 trailing-axis LpNormalization into hip.rms_norm

### DIFF
--- a/lib/Conversion/OnnxToHip/LpNormalizationConversion.cpp
+++ b/lib/Conversion/OnnxToHip/LpNormalizationConversion.cpp
@@ -70,6 +70,8 @@
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Support/Debug.h"
 
+#include <cmath>
+
 #define DEBUG_TYPE "lpnormalization-decompose"
 
 STATISTIC(NumLpNormalizationRewrites,
@@ -134,6 +136,79 @@ struct LpNormalizationDecompose : public mlir::RewritePattern {
 
     mlir::Location loc = op->getLoc();
     mlir::MLIRContext *ctx = rewriter.getContext();
+
+    // --- Fused fast path -------------------------------------------------
+    // For p==2 normalizing over the trailing axis with a static extent N
+    // (the q/k L2-norm shape in gated-delta-net / linear-attention decoders),
+    // emit ONE fused RMS-norm instead of the Mul + ReduceSum + Sqrt + Div
+    // chain (~5 element/reduce kernels). Identity:
+    //
+    //   L2Norm(x) = x / sqrt(sum(x^2))
+    //             = x / sqrt(mean(x^2) + 0) * (1/sqrt(N))
+    //             = SimplifiedLayerNorm(x, scale = 1/sqrt(N), epsilon = 0)
+    //
+    // SimplifiedLayerNormalization is lowered to `hip.rms_norm` (FP32-
+    // accumulated sum-of-squares) by NormConversion in the later
+    // convertComputeOps stage, so the whole normalization collapses to a
+    // single kernel launch. Other cases (p==1, non-trailing axis, or a
+    // dynamic trailing extent) fall through to the generic decomposition
+    // below.
+    //
+    // Before:
+    //   %y = onnx.LpNormalization(%x) {axis = -1, p = 2}
+    //        : (tensor<?x16x128xf16>) -> tensor<?x16x128xf16>
+    // After:
+    //   %s = onnx.Constant dense<0.0883883> : tensor<128xf16>   // 1/sqrt(128)
+    //   %y = onnx.Custom(%x, %s)
+    //          {function_name = "SimplifiedLayerNormalization",
+    //           epsilon = 0.0 : f32, axis = -1 : si64, stash_type = 1 : si64}
+    //          : (tensor<?x16x128xf16>, tensor<128xf16>) ->
+    //          tensor<?x16x128xf16>
+    if (p == 2 && normAxis == rank - 1) {
+      int64_t n = inputType.getShape()[normAxis];
+      if (n != mlir::ShapedType::kDynamic && n > 0) {
+        // scale = splat(1/sqrt(N)) in the input element type.
+        float invSqrtN = 1.0f / std::sqrt(static_cast<float>(n));
+        llvm::APFloat scaleVal(invSqrtN);
+        bool losesInfo = false;
+        scaleVal.convert(
+            mlir::cast<mlir::FloatType>(elemType).getFloatSemantics(),
+            llvm::APFloat::rmNearestTiesToEven, &losesInfo);
+        auto scaleType = mlir::RankedTensorType::get({n}, elemType);
+        llvm::SmallVector<llvm::APFloat> scaleData(static_cast<size_t>(n),
+                                                   scaleVal);
+        auto scaleAttr = mlir::DenseElementsAttr::get(scaleType, scaleData);
+        mlir::OperationState scaleState(loc, "onnx.Constant");
+        scaleState.addTypes(scaleType);
+        scaleState.addAttribute("value", scaleAttr);
+        mlir::Value scale = rewriter.create(scaleState)->getResult(0);
+
+        // NormConversion reads axis / stash_type via getSInt(), so they must be
+        // SIGNED i64 attrs; epsilon is an f32 FloatAttr.
+        auto sintType =
+            mlir::IntegerType::get(ctx, 64, mlir::IntegerType::Signed);
+        mlir::OperationState customState(loc, "onnx.Custom");
+        customState.addOperands({x, scale});
+        customState.addTypes(outputType);
+        customState.addAttribute(
+            "function_name",
+            rewriter.getStringAttr("SimplifiedLayerNormalization"));
+        customState.addAttribute("domain_name",
+                                 rewriter.getStringAttr("com.microsoft"));
+        customState.addAttribute("epsilon", rewriter.getF32FloatAttr(0.0f));
+        customState.addAttribute("axis", mlir::IntegerAttr::get(sintType, -1));
+        customState.addAttribute("stash_type",
+                                 mlir::IntegerAttr::get(sintType, 1));
+        mlir::Value result = rewriter.create(customState)->getResult(0);
+
+        rewriter.replaceOp(op, result);
+        ++NumLpNormalizationRewrites;
+        LLVM_DEBUG(llvm::dbgs()
+                   << "[" DEBUG_TYPE "] fused LpNormalization -> rms_norm "
+                   << inputType << " axis=" << normAxis << " N=" << n << "\n");
+        return mlir::success();
+      }
+    }
 
     // Reduced shape: same as input but with a `1` along the reduce axis
     // (keepdims=1). Dynamic dims on other axes pass through unchanged.

--- a/test/lit/Conversion/onnx-to-hip/test_lpnormalization.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_lpnormalization.mlir
@@ -3,20 +3,26 @@
 
 // RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
 
-// LpNormalization decomposes in the convert-onnx-to-hip pre-lowering loop
-// into Mul(x,x) -> ReduceSum(axis, keepdims=1) -> Sqrt -> Div(x, norm). The
-// final Div broadcasts (rhs has 1 along the reduce axis), so
-// BroadcastDivToMulReciprocal -- also in the pre-lowering loop -- rewrites
-// it into Mul(x, Reciprocal(norm)). The expected hip.* op set is therefore:
-// hip.mul, hip.reduce_sum, hip.sqrt, hip.reciprocal, hip.mul. p=1 gets one
-// extra hip.sqrt for the Sqrt(x*x)=|x| step.
+// LpNormalization has two lowering paths:
+//
+//   * Fused fast path (p=2, trailing normalize axis, STATIC trailing extent
+//     N): emits a single SimplifiedLayerNormalization with scale=1/sqrt(N),
+//     epsilon=0, which NormConversion lowers to one hip.rms_norm. This is the
+//     q/k L2-norm shape in linear-attention decoders.
+//
+//   * Generic decomposition (everything else): Mul(x,x) -> ReduceSum -> Sqrt
+//     -> Div(x, norm). The broadcasting Div is rewritten by
+//     BroadcastDivToMulReciprocal into Mul(x, Reciprocal(norm)), so the hip.*
+//     op set is hip.mul, hip.reduce_sum, hip.sqrt, hip.reciprocal, hip.mul.
+//     p=1 gets one extra hip.sqrt for the Sqrt(x*x)=|x| step.
 
 module {
   func.func @main_graph(%arg0: tensor<4xf32>) -> tensor<4xf32> {
     return %arg0 : tensor<4xf32>
   }
 
-  // Default p=2, axis=-1 on a static rank-2 f32 input.
+  // Default p=2, axis=-1 on a static rank-2 f32 input. Trailing extent is
+  // static (N=3) -> fused fast path -> a single hip.rms_norm.
   func.func @lp_norm_p2_default_f32(%x: tensor<2x3xf32>) -> tensor<2x3xf32> {
     %r = "onnx.LpNormalization"(%x) {axis = -1 : si64, p = 2 : si64}
         : (tensor<2x3xf32>) -> tensor<2x3xf32>
@@ -25,14 +31,11 @@ module {
   // CHECK-LABEL: func.func @lp_norm_p2_default_f32
   // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[X:.*]]: tensor<2x3xf32>)
   // CHECK-NOT: onnx.LpNormalization
-  // CHECK-NOT: onnx.Div
-  // CHECK: hip.mul(%[[CTX]]) ins(%[[X]], %[[X]]
-  // CHECK: hip.reduce_sum
-  // CHECK: hip.sqrt
-  // CHECK: hip.reciprocal
-  // CHECK: hip.mul
+  // CHECK-NOT: hip.reduce_sum
+  // CHECK: hip.rms_norm
 
-  // p=1, explicit axis=1 on a rank-3 f16 input. p=1 path inserts an extra
+  // p=1, explicit axis=1 on a rank-3 f16 input. p=1 never takes the fast path
+  // (only p=2 maps to L2/RMS), so it decomposes. The p=1 path inserts an extra
   // Sqrt(x*x) before the reduction to compute |x|.
   func.func @lp_norm_p1_axis1_f16(%x: tensor<2x4x5xf16>) -> tensor<2x4x5xf16> {
     %r = "onnx.LpNormalization"(%x) {axis = 1 : si64, p = 1 : si64}
@@ -41,6 +44,7 @@ module {
   }
   // CHECK-LABEL: func.func @lp_norm_p1_axis1_f16
   // CHECK-NOT: onnx.LpNormalization
+  // CHECK-NOT: hip.rms_norm
   // p=1 path: Mul(x,x) -> Sqrt(=abs) -> ReduceSum -> ... -> Reciprocal -> Mul
   // CHECK: hip.mul
   // CHECK: hip.sqrt
@@ -48,25 +52,34 @@ module {
   // CHECK: hip.reciprocal
   // CHECK: hip.mul
 
-  // Dynamic batch + sequence dims; static feature dim along the reduce axis.
-  // Verifies the decomposition handles dynamic shapes through the
-  // tensor.dim + tensor.empty plumbing inherited from the primitive
-  // converters (Mul / ReduceSum / Sqrt / Reciprocal).
-  func.func @lp_norm_dynamic(%x: tensor<?x?x16xf32>) -> tensor<?x?x16xf32> {
-    %r = "onnx.LpNormalization"(%x) {axis = -1 : si64, p = 2 : si64}
-        : (tensor<?x?x16xf32>) -> tensor<?x?x16xf32>
-    return %r : tensor<?x?x16xf32>
+  // p=2 over a NON-trailing axis (axis=1). The fast path requires the trailing
+  // axis, so this falls back to the generic decomposition.
+  func.func @lp_norm_p2_axis1_fallback(%x: tensor<2x3x4xf32>) -> tensor<2x3x4xf32> {
+    %r = "onnx.LpNormalization"(%x) {axis = 1 : si64, p = 2 : si64}
+        : (tensor<2x3x4xf32>) -> tensor<2x3x4xf32>
+    return %r : tensor<2x3x4xf32>
   }
-  // CHECK-LABEL: func.func @lp_norm_dynamic
-  // CHECK-SAME: (%[[CTX2:.*]]: !hip.context, %[[X2:.*]]: tensor<?x?x16xf32>)
+  // CHECK-LABEL: func.func @lp_norm_p2_axis1_fallback
   // CHECK-NOT: onnx.LpNormalization
-  // CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
-  // CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
-  // CHECK: tensor.dim
-  // CHECK: tensor.dim
+  // CHECK-NOT: hip.rms_norm
   // CHECK: hip.mul
   // CHECK: hip.reduce_sum
   // CHECK: hip.sqrt
   // CHECK: hip.reciprocal
   // CHECK: hip.mul
+
+  // Dynamic batch + sequence dims, STATIC trailing feature dim. p=2 over the
+  // trailing axis with a static extent (16) still fuses to a single
+  // hip.rms_norm — dynamic outer dims do not block the fast path. This is the
+  // canonical linear-attention q/k L2-norm shape.
+  func.func @lp_norm_p2_dynamic_outer(%x: tensor<?x?x16xf32>) -> tensor<?x?x16xf32> {
+    %r = "onnx.LpNormalization"(%x) {axis = -1 : si64, p = 2 : si64}
+        : (tensor<?x?x16xf32>) -> tensor<?x?x16xf32>
+    return %r : tensor<?x?x16xf32>
+  }
+  // CHECK-LABEL: func.func @lp_norm_p2_dynamic_outer
+  // CHECK-SAME: (%[[CTX2:.*]]: !hip.context, %[[X2:.*]]: tensor<?x?x16xf32>)
+  // CHECK-NOT: onnx.LpNormalization
+  // CHECK-NOT: hip.reduce_sum
+  // CHECK: hip.rms_norm
 }

--- a/test/lit/e2e/test_lpnormalization_model.mlir
+++ b/test/lit/e2e/test_lpnormalization_model.mlir
@@ -4,25 +4,23 @@
 // This IR represents an ONNX LpNormalization operation as it would be
 // imported via onnx-mlir / morphizen mlir-imp.
 //
+// The input has a static trailing extent (N=3) and p=2 over the trailing
+// axis, so it takes the fused fast path: LpNormalization -> one
+// SimplifiedLayerNormalization (scale=1/sqrt(N), epsilon=0) ->
+// hip.rms_norm -> wrap_miopenT5LayerNormForward. No Mul/ReduceSum/Sqrt
+// decomposition is emitted for this shape.
+//
 // Verifies the complete hipdnn-pipeline:
-// 1. convert-onnx-to-hip: onnx.LpNormalization decomposes into
-//    Mul / ReduceSum / Sqrt / Div, each handled by its own converter.
-//    The broadcasting Div is rewritten by BroadcastDivToMulReciprocal
-//    into Mul(x, Reciprocal(norm)). No new HIP op or runtime symbol is
-//    introduced — only existing primitives are exercised.
-// 2. canonicalize: simplify redundant operations
-// 3. memory-pooling: pool output buffer into single allocation
-// 4. convert-hip-to-llvm: HIP ops -> LLVM runtime calls
-//    (wrap_miopenOpTensor for Mul, wrap_reduce_sum for ReduceSum,
-//     wrap_power for Sqrt + Reciprocal)
-// 5. generate-interface: create inference_init/compute/cleanup/metadata
+// 1. convert-onnx-to-hip: onnx.LpNormalization (p=2, trailing, static N)
+//    fuses into a single hip.rms_norm.
+// 2. canonicalize / memory-pooling: pool output buffer into single allocation
+// 3. convert-hip-to-llvm: hip.rms_norm -> wrap_miopenT5LayerNormForward
+// 4. generate-interface: create inference_init/compute/cleanup/metadata
 
 // CHECK: module attributes {
 // CHECK-SAME: hipdnn.input_count = 1
 // CHECK-SAME: hipdnn.output_count = 1
-// CHECK-DAG: llvm.func @wrap_miopenOpTensor
-// CHECK-DAG: llvm.func @wrap_reduce_sum
-// CHECK-DAG: llvm.func @wrap_power
+// CHECK-DAG: llvm.func @wrap_miopenT5LayerNormForward
 // CHECK-DAG: llvm.func @inference_init
 // CHECK-DAG: llvm.func @inference_compute
 // CHECK-DAG: llvm.func @inference_cleanup


### PR DESCRIPTION
## Summary

`onnx.LpNormalization` (p=2) over the trailing axis was decomposed into `Mul + ReduceSum + Sqrt + Reciprocal + Mul` (~5 kernel launches per op). For the linear-attention q/k L2-norm this fires hundreds of times per decode token (**360x in the 35B hybrid decoder, 48x in the 9B variant**), and single-token decode is launch-bound.

This PR emits **one fused RMS-norm** instead, via the identity:

```
L2Norm(x) = x / sqrt(sum(x^2)) = SimplifiedLayerNorm(x, scale = 1/sqrt(N), epsilon = 0)
```

which `NormConversion` already lowers to `hip.rms_norm` (a single `miopenT5LayerNormForward`, FP32-accumulated).

The rewrite is restricted to:
- `p == 2`
- trailing normalize axis
- static trailing extent `N` (the q/k `head_dim` is an architecture constant)

All other `LpNormalization` shapes fall back to the existing decomposition. No new op / kernel / runtime code.

## Test plan / results

### 9B VLM (decode, earlier validation)
- decode: **21.73 -> 25.12 tok/s (+15.6%)**, generation output unchanged.

### 35B VLM local benchmark (gfx1151, MorphiZen EP, 5 iters, PERF off)
Model: `Qwen3.5-35B-A3B-fp16-ve-fp16-int4-text-gs32-dml`, image 1546x1213, 1842 prompt tokens, 64 gen tokens.

| Metric | Baseline (91e35b) | + LpNorm fusion | Delta |
|---|---|---|---|
| Decode TPS | 46.46 tok/s | **48.16 tok/s** | **+3.66%** |
| Decode ms/token | 21.52 | 20.76 | -0.76 ms |
| TTFT (avg) | 5484.49 ms | 5553.51 ms | +69 ms (~noise) |
| Prefill throughput | 335.86 tok/s | 331.68 tok/s | -1.2% (~noise) |

Decode is the consistent win (+3.66% on 35B, +15.6% on 9B); TTFT / prefill are within run-to-run variance. Generated text is unchanged between baseline and fused runs.
