### PR TITLE
feat(conv): cache MIOpen forward-conv Find results

### DIFF
--- a/lib/Runtime/real/miopen.cpp
+++ b/lib/Runtime/real/miopen.cpp
@@ -46,12 +46,13 @@
 //    the Find-selected algorithm + its actual workspace size are cached once
 //    per shape in RuntimeState::conv_fwd_cache (see ConvFwdCache below). On a
 //    cache hit the call skips miopenConvolutionForwardGetWorkSpaceSize AND
-//    miopenFindConvolutionForwardAlgorithm. MIOpen docs: "miopenFindConvolution*()
-//    is expensive in terms of run time and required workspace, so it's highly
-//    recommended to reserve the required algorithm and workspace to reuse them
-//    later." (PyTorch's torch.backends.cudnn.benchmark does the same.) For
-//    dynamic shapes the hit rate drops with shape variation, but the cache is
-//    never wrong: a new shape simply Finds + caches a new entry.
+//    miopenFindConvolutionForwardAlgorithm. MIOpen docs:
+//    "miopenFindConvolution*() is expensive in terms of run time and required
+//    workspace, so it's highly recommended to reserve the required algorithm
+//    and workspace to reuse them later." (PyTorch's
+//    torch.backends.cudnn.benchmark does the same.) For dynamic shapes the hit
+//    rate drops with shape variation, but the cache is never wrong: a new shape
+//    simply Finds + caches a new entry.
 //
 //    The MIOpen descriptors are deliberately NOT cached: Find/forward make
 //    MIOpen attach per-problem GPU-resident state (compiled solvers, pre-
@@ -67,7 +68,8 @@
 //    can be measured against the cached path. Default ON.
 //
 //    Sources:
-//    - https://rocm.docs.amd.com/projects/MIOpen/en/latest/how-to/find-and-immediate.html
+//    -
+//    https://rocm.docs.amd.com/projects/MIOpen/en/latest/how-to/find-and-immediate.html
 //    - https://docs.pytorch.org/docs/stable/notes/cuda.html
 //
 // 3. WORKSPACE POOLING (implemented)
@@ -292,26 +294,11 @@ int wrap_miopenConvolutionForward(
       state->conv_fwd_cache = new ConvFwdCache();
     conv_cache = static_cast<ConvFwdCache *>(state->conv_fwd_cache);
   }
-  ConvFwdKey conv_key{(int64_t)miopen_dt,
-                      input_n,
-                      input_c,
-                      input_h,
-                      input_w,
-                      weights_k,
-                      kernel_h,
-                      kernel_w,
-                      output_h,
-                      output_w,
-                      stride_h,
-                      stride_w,
-                      pad_top,
-                      pad_left,
-                      pad_bottom,
-                      pad_right,
-                      dilation_h,
-                      dilation_w,
-                      group,
-                      bias ? 1 : 0};
+  ConvFwdKey conv_key{
+      (int64_t)miopen_dt, input_n,    input_c,    input_h,  input_w,
+      weights_k,          kernel_h,   kernel_w,   output_h, output_w,
+      stride_h,           stride_w,   pad_top,    pad_left, pad_bottom,
+      pad_right,          dilation_h, dilation_w, group,    bias ? 1 : 0};
   // Copy the hit entry into a function-scope local so the hit branch below does
   // not deref a map iterator across the `goto cleanup` scope.
   bool cache_hit = false;
@@ -327,7 +314,8 @@ int wrap_miopenConvolutionForward(
   // Create + set the tensor descriptors with explicit NCHW layout. The dtype is
   // taken from the caller (data_type) — the previous hardcoded miopenFloat
   // produced silent fp16-stride-as-fp32 corruption on fp16 models.
-  // miopenSet4dTensorDescriptor leaves layout UNKNOWN which warns in MIOpen 7.12+.
+  // miopenSet4dTensorDescriptor leaves layout UNKNOWN which warns in
+  // MIOpen 7.12+.
   MIOPEN_CHECK(miopenCreateTensorDescriptor(&input_desc));
   MIOPEN_CHECK(miopenCreateTensorDescriptor(&weights_desc));
   MIOPEN_CHECK(miopenCreateTensorDescriptor(&output_desc));


### PR DESCRIPTION
## Motivation
`wrap_miopenConvolutionForward` re-ran the documented-expensive
`miopenFindConvolutionForwardAlgorithm` (which launches candidate kernels on the
GPU and synchronizes, and on a cold machine JIT-compiles + populates MIOpen's
disk PerfDb/FindDb) on every conv call. This made conv-heavy models' first
inference wildly variable machine-to-machine.

## Details
- Add a per-`RuntimeState` `conv_fwd_cache` (`ConvFwdCache`) keyed on the
  `(dtype, NCHW input, weights, output, stride/pad/dilation/group, has_bias)`
  tuple. On a hit, the call skips both `GetWorkSpaceSize` and Find, reusing the
  cached algorithm + its actual workspace size.
- Descriptors are deliberately NOT cached: keeping them alive per shape kept
  MIOpen's per-problem GPU-resident state coexisting all session, inflating peak
  GPU memory. They are rebuilt per call (cheap CPU structs) and destroyed at
  `cleanup`.
- A/B toggle `HIPDNN_EP_CONV_ALGO_CACHE=0` disables the cache entirely; latched
  once per process via `hipdnn_ep_conv_algo_cache_enabled()`.
- Cache is freed in `hipdnn_ep_state_cleanup` via
  `hipdnn_ep_conv_fwd_cache_destroy`. Add an unconditional `[CONV] conv_scratch
  grew to X MB` diagnostic on pool growth.

before:
http://xsjnts.xilinx.com/ROCm/hipdnn-detail?database=development&collection=daily_hipdnn_ep&id=6a438952403106e1ccae40f5
<img width="760" height="314" alt="image" src="https://github.com/user-attachments/assets/0944c56d-2812-4383-af02-08cdd1b5c185" />

after:
http://xsjnts.xilinx.com/ROCm/hipdnn-detail?database=development&collection=daily_hipdnn_ep&id=6a438a28d0d97a00a9f95313
<img width="764" height="312" alt="image" src="https://github.com/user-attachments/assets/ccf0f8d7-7d4c-4959-ab68-6922f8a1d88a" />
