### PR TITLE
perf(matmul-nbits): cold-cache autotune for decode GEMV + keep QMoE prefill offline

### DIFF
--- a/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
+++ b/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
@@ -897,6 +897,26 @@ static int tuneGemvConfig(
 static std::unordered_map<std::string, int> gemv_cache;
 static std::mutex gemv_tune_mutex;
 
+// QMoE-prefill mode selector for hip_matmul_nbits (see
+// hip_matmul_nbits_set_moe_mode in hip_custom_kernels.h). QMoE prefill calls
+// hip_matmul_nbits once per expert; the count==1 experts land in the small-M
+// GEMV path, which by default uses the ONLINE sampler (launchGemvOnline). The
+// online sampler blocks the host on hipEventSynchronize for every call until it
+// has locked a config (several sweeps); when that convergence window spills past
+// the harness warmup it leaks per-call syncs into the measured iterations and
+// makes prefill TTFT fluctuate. In MoE mode this path instead uses the OFFLINE
+// tuner, which tunes once on the first call for a shape and caches it, so a
+// single warmup prefill fully populates the cache and measured iterations are
+// pure cache hits (the pre-online baseline behaviour). Dense matmul (flag off)
+// keeps the online sampler, which is the better cold-cache choice for the
+// single-token decode it serves. thread_local so concurrent sessions on other
+// threads are unaffected; set only around the QMoE per-expert loop (wrap_qmoe).
+static thread_local bool g_matmul_nbits_moe_mode = false;
+
+extern "C" void hip_matmul_nbits_set_moe_mode(int on) {
+    g_matmul_nbits_moe_mode = (on != 0);
+}
+
 static std::string gemvCacheKey(int64_t M, int64_t N, int64_t K, int64_t bs,
                                 bool col_major, bool has_zp) {
     // has_zp must be in the key: the asym path executes one extra read_zp +
@@ -3216,6 +3236,29 @@ extern "C" int hip_matmul_nbits(
     const auto* z_u = static_cast<const uint8_t*>(zp_for_u8_paths);
     const auto* b_h = static_cast<const __half*>(bias);
     auto*       o_h = static_cast<__half*>(output);
+
+    // QMoE prefill: use the OFFLINE tuner (tune-once-then-cache). The online
+    // sampler's multi-sweep convergence window can leak per-call
+    // hipEventSynchronize into measured prefill iterations and make TTFT
+    // fluctuate; offline resolves fully during warmup. Only the QMoE
+    // per-expert count==1 shapes reach here in MoE mode. col_major=false
+    // (row-major M==1 path); getOrTuneGemvConfig treats M==1 as col-major
+    // agnostic. See g_matmul_nbits_moe_mode.
+    if (g_matmul_nbits_moe_mode) {
+      int cfg = getOrTuneGemvConfig(hip_stream, a_h, b_u, s_h, z_u, b_h, o_h,
+                                    M, N, K, batch_count, block_size,
+                                    /*col_major=*/false);
+      launchGemvConfig(cfg, hip_stream, a_h, b_u, s_h, z_u, b_h, o_h,
+                       M, N, K, batch_count, block_size, /*col_major=*/false);
+      hipError_t err = hipGetLastError();
+      if (err != hipSuccess) {
+        fprintf(stderr,
+                "[custom_kernels] hip_matmul_nbits GEMV(offline) launch "
+                "failed: %s\n",
+                hipGetErrorString(err));
+      }
+      return static_cast<int>(err);
+    }
 
     // Online (cold-cache) autotune: single-token decode reads each layer's
     // weights once, cold from DRAM, so we sample real launches instead of the

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -1384,6 +1384,22 @@ HIP_KERNEL_API int hip_matmul_nbits(
     const void* pre_unpacked_zp_u8,
     const void* pre_unpacked_zp_fp16);
 
+/* QMoE-prefill autotune-mode selector for hip_matmul_nbits (thread-local).
+ *
+ * QMoE prefill dispatches hip_matmul_nbits once per expert; experts routed a
+ * single token land in the small-M (M==1) GEMV path, which by default uses the
+ * ONLINE sampler. The online sampler blocks the host on hipEventSynchronize
+ * per call across several sweeps until it locks a config; if that convergence
+ * window outlasts the harness warmup it leaks per-call syncs into the measured
+ * prefill iterations and destabilises TTFT. With MoE mode ON, that path uses
+ * the OFFLINE tune-once-then-cache tuner instead, so one warmup prefill fully
+ * populates the cache and measured iterations are pure cache hits.
+ *
+ * Scope it tightly around the QMoE per-expert loop via the RAII guard in
+ * lib/Runtime/real/qmoe.cpp; dense matmul (flag off) keeps the online sampler,
+ * which is the better cold-cache choice for single-token decode. */
+HIP_KERNEL_API void hip_matmul_nbits_set_moe_mode(int on);
+
 /* Stand-alone launchers for the zero_points unpack/convert kernels, used by
  * the asym matmul_nbits cache in lib/Runtime/real/matmul_nbits.cpp.
  *

--- a/lib/Runtime/real/qmoe.cpp
+++ b/lib/Runtime/real/qmoe.cpp
@@ -23,6 +23,22 @@ struct TokenEntry {
   int32_t slot;
 };
 
+// RAII: put hip_matmul_nbits into QMoE offline-autotune mode for the scope's
+// lifetime, then restore. QMoE prefill issues one hip_matmul_nbits per expert;
+// the single-token experts hit the small-M GEMV path, which defaults to the
+// online sampler. The online sampler's multi-sweep convergence can leak
+// per-call hipEventSynchronize into measured prefill iterations (TTFT
+// instability). In MoE mode that path uses the offline tune-once-then-cache
+// tuner instead, so one warmup prefill fully populates the cache. The flag is
+// thread_local, so scoping it here leaves dense matmul (single-token decode,
+// which prefers the online sampler) on other code paths untouched.
+struct MoeMatmulModeGuard {
+  MoeMatmulModeGuard() { hip_matmul_nbits_set_moe_mode(1); }
+  ~MoeMatmulModeGuard() { hip_matmul_nbits_set_moe_mode(0); }
+  MoeMatmulModeGuard(const MoeMatmulModeGuard &) = delete;
+  MoeMatmulModeGuard &operator=(const MoeMatmulModeGuard &) = delete;
+};
+
 int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
               const void *router_weights, const void *fc1_weights,
               const void *fc1_scales, const void *fc1_bias,
@@ -198,6 +214,15 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
   }
 
   {
+    // Offline-autotune mode for the per-expert prefill matmul_nbits calls
+    // below (single-token experts otherwise sample the online tuner
+    // mid-measurement). Declared inside this block (not the function scope) so
+    // its scope ends before the `cleanup:` label: the earlier HIP_CHECK
+    // `goto cleanup`s (topk_routing / decode_fused, above) would otherwise
+    // jump past a live non-trivial-dtor local into its scope, which C++
+    // forbids. HIP_CHECKs within this block jump OUT of the guard's scope,
+    // which is legal (the destructor runs on the way out, restoring the mode).
+    MoeMatmulModeGuard moe_mode_guard;
     // Phase 2: GPU-side bucketing eliminates the per-expert host build +
     // 2 H2D round-trips per active expert per layer. Old flow was:
     //   D2H expert_indices + expert_weights -> sync -> host bucket loop ->


### PR DESCRIPTION
## Summary

matmul_nbits int4-GEMV autotune tuning for the decode + QMoE-prefill paths. Two parts:

1. **Online cold-cache autotune for single-token decode** (`M==1` row-major GEMV): sample the real decode launches instead of a hot tight loop, so the chosen `(BLOCK_SIZE, TILE_N)` matches the cold-cache memory pattern decode actually runs in. 9B VLM decode **24.29 -> 29.08 tok/s (+19.7%)**, generation output bit-unchanged.
2. **Keep QMoE per-expert prefill on the offline tuner** (new): QMoE prefill dispatches `hip_matmul_nbits` once per expert; the single-token experts hit the same `M==1` GEMV path and would otherwise inherit the online sampler, whose multi-sweep convergence leaks per-call `hipEventSynchronize` into measured prefill iterations and destabilises TTFT. A thread-local MoE-mode flag routes just that path back to the offline tune-once-then-cache tuner, scoped tightly around the QMoE per-expert loop.

> This branch previously carried an experimental device-side grouped-WMMA INT4 GEMM for MoE prefill; it was **dropped** in favour of the minimal, QMoE-scoped offline-autotune fix above, which keeps the original per-expert QMoE logic intact and avoids the grouped-WMMA regressions.

## Why (part 1 — online decode autotune)

Single-token decode `matmul_nbits` is a memory-bound GEMV: each layer's int4 weights are read exactly **once, cold from DRAM**, before the model moves to the next layer's different weights. The whole model is streamed once per token and the weights do not fit in last-level cache, so there is no reuse.

The existing `tuneGemvConfig` benchmarks every config in a **hot tight loop** — it launches the same weight buffer `ITERS` times back-to-back, so after the first launch the weights are resident in last-level cache and every timed iteration reads HOT weights. That measures a "weights are free" world decode never sees, and it mis-ranks `TILE_N`:

- **hot cache** (offline tuner): weight reads are free, so a large `TILE_N` (fewer, larger blocks, low launch overhead) looks fastest;
- **cold streaming** (decode): the bottleneck is DRAM latency/bandwidth, which wants a smaller `TILE_N` (more blocks → higher occupancy to hide load latency and saturate bandwidth).

So the offline tuner systematically picks too large a `TILE_N` for wide-N / short-K decode GEMVs.

## Why (part 2 — QMoE prefill stays offline)

The online sampler is the right cold-cache choice for single-token **decode**, but wrong for **QMoE prefill**: prefill runs many experts per layer, and the online sampler's per-call `hipEventSynchronize` convergence window can outlast the warmup and bleed into the measured iterations → TTFT jitter. The offline tuner resolves fully during warmup (one tune per shape, then pure cache hits), which restores the pre-online baseline TTFT behaviour for the MoE prefill path while leaving decode on the online sampler.

## What

- New online tuner in `lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip` for the `M==1` row-major GEMV path: a `gemvOnlinePick` / `gemvOnlineRecord` state machine plus a `launchGemvOnline` wrapper. Round-robin samples each applicable candidate on real decode calls, discards one warmup sweep, averages `kGemvSampleRounds` sweeps, then locks the min-mean config. Keyed by `(M,N,K,block_size,col_major,has_zp)`; dims are model-static, so one tuning window per shape then a pure cache lookup.
- Wide-GEMV live-range reduction to cut register pressure on the wide-N path.
- New thread-local `hip_matmul_nbits_set_moe_mode(int)` selector; `wrap_qmoe` (`lib/Runtime/real/qmoe.cpp`) sets it via an RAII guard around the per-expert prefill loop so the `M==1` GEMV path uses the offline tuner in MoE mode only. All candidate configs are numerically identical (same GEMV, different tiling), so output is correct throughout.
- Intentional non-changes: the general prefill (`M>1`, col-major) and int8 GEMV paths keep the offline `tuneGemvConfig`; dense single-token decode keeps the online sampler.

## Test plan

- [x] 9B VLM (VLM benchmark, `--max_tokens 64 --max_length 2048`): decode **24.29 -> 29.08 tok/s (+19.7%)**; TTFT within run-to-run noise; peak memory 15.0 -> 14.6 GB; generated text identical. QMoE-offline flag is a no-op for this dense (non-MoE) model — verified no TPS/TTFT regression.
- [x] 20B GPT-OSS MoE (prompt 128 + 2048): TTFT stabilised (no per-call sync leak into measured prefill) and decode TPS preserved/improved vs baseline `03fc68e8`; output reasonable.
- [x] Decode-only online change: the general prefill (TTFT) path is untouched and measured flat.

AI disclosure: developed with Cursor; the design and measurements above are explained and reproducible in review.
