### PR TITLE
refactor(compiler): emit only the output-allocator 2-arg ABI [Phase 1/2]

### DIFF
--- a/backend-mlir-compiler/level-1-pass/src/MlirCompiler.cpp
+++ b/backend-mlir-compiler/level-1-pass/src/MlirCompiler.cpp
@@ -48,8 +48,6 @@ std::string build_compiler_options_json(const CompilationConfig &config) {
   json << "\"opt_level\": " << config.optLevel;
   json << ", \"skip_constant_data\": "
        << (config.skipConstantData ? "true" : "false");
-  json << ", \"use_output_allocator\": "
-       << (config.useOutputAllocator ? "true" : "false");
   // output_mode maps to the flatbuffers OutputMode enum
   // (schemas/compilation_options.fbs). The flatbuffers JSON parser accepts
   // the enum value name.

--- a/docs/design/pool-allocs-memory-planning.md
+++ b/docs/design/pool-allocs-memory-planning.md
@@ -51,8 +51,8 @@ Several passes cooperate to produce the final pooled IR. The relevant stretch of
     → hip-infer-shapes                       (1b: refine `?` dims via ReifyRankedShapedTypeOpInterface)
     → hip-resolve-tensor-dims                (1c: fold `tensor.dim` via upstream reify patterns)
     → one-shot-bufferize                     (tensor → memref)
-    → buffer-results-to-out-params           (function results → out-param memrefs)
     → buildBufferDeallocationPipeline        (insert ownership-based deallocs)
+    → hip-use-output-allocator               (returned memref.alloc → hip.alloc_output)
     → CSE → canonicalize
     → hip-optimize-memrefs                   (HIP-specific buffer cleanup)
     → hip-promote-strided-hip-operands       (6a: contiguous temporaries for HIP-op operands)

--- a/docs/technical-pipeline-walkthrough.md
+++ b/docs/technical-pipeline-walkthrough.md
@@ -158,26 +158,28 @@ JITted code on every inference request:
 
 ```
 ORT calls MlirCustomOp::Compute()
-  │  marshal ORT tensors → span_t (pointer + shape + size)
+  │  marshal ORT input tensors → span_t (pointer + shape + size)
+  │  install EP output allocator (hipdnn_ep_set_output_allocator)
   ▼
-InferenceState::compute(inputs, outputs)
-  │  calls inference_compute(state, &inputs, &outputs) (JITted symbol)
+InferenceState::compute(inputs)
+  │  calls inference_compute(state, &inputs) (JITted symbol)
   ▼
 JITted in-memory module  (per-model bitcode + runtime.bc, single LLJIT JITDylib)
   │  inference_compute:
   │    ├── hipdnn_ep_tensor_prepare_input   → hipMemcpyH2D (host → GPU)
-  │    ├── hipdnn_ep_tensor_prepare_output  → allocate GPU output buffer
   │    ├── main_graph():
   │    │     ├── hip.get_pool        → get pre-allocated GPU scratch memory
   │    │     ├── hip.get_constant(0) → conv weights on GPU
   │    │     ├── hip.get_constant(1) → matmul weights on GPU
   │    │     ├── hipdnn_graph_execute        → Conv via hipDNN backend
   │    │     ├── wrap_hipblasLtMatmul        → MatMul via hipBLASLt
-  │    │     └── wrap_miopenActivationForward → Sigmoid via MIOpen
-  │    ├── hipdnn_ep_tensor_finalize_output  → hipMemcpyD2H (GPU → host)
+  │    │     ├── wrap_miopenActivationForward → Sigmoid via MIOpen
+  │    │     └── hipdnn_ep_alloc_output       → EP allocator callback (in-graph output)
+  │    ├── hipdnn_ep_stream_sync             → all GPU writes complete
   │    └── hipdnn_ep_tensor_free_input       → cleanup
   ▼
-Results back to ORT
+EP copies any CPU-memory outputs from device to host into ORT's buffers
+(GPU-memory outputs are already in ORT's buffers, zero-copy)
 ```
 
 **File:** `backend-mlir-compiler/custom-op-mlir/src/InferenceState.cpp`
@@ -187,17 +189,19 @@ auto jit = LlvmIrJit::create(bitcode_bytes, "model_compiled");
 auto init_fn = jit->get_method<int, void**, void*>("inference_init");
 int ret = init_fn(&state, static_cast<void*>(fs));
 
-// Per-run — call inference_compute (JITted symbol)
-int InferenceState::compute(span_t* inputs, span_t* outputs) const {
+// Per-run — call inference_compute (JITted symbol, 2-arg output-allocator ABI)
+int InferenceState::compute(span_t* inputs) const {
     auto compute_fn =
-        jit_->get_method<int, void*, span_t*, span_t*>("inference_compute");
-    return compute_fn(state_, inputs, outputs);
+        jit_->get_method<int, void*, span_t*>("inference_compute");
+    return compute_fn(state_, inputs);
 }
 ```
 
 **File:** `backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp`
-`marshal_input_tensors` / `marshal_output_tensors` convert ORT's `OrtKernelContext`
-tensors into `tensor_t` / `span_t` structs that the generated code expects.
+`marshal_input_tensors` converts ORT's `OrtKernelContext` input tensors into
+`tensor_t` / `span_t` structs that the generated code expects. Outputs are
+allocated in-graph via the EP's `output_allocate_cb` callback, which calls
+`ctx.GetOutput()` with the DLL's computed shape.
 
 ---
 
@@ -310,22 +314,26 @@ Key transformations:
 ### Stage 6: Bufferization (tensor → memref)
 
 `OneShotBufferize` converts tensor semantics to buffer (memref) semantics.
-Tensors become explicit memory allocations:
+Tensors become explicit memory allocations; the graph output stays a returned
+memref:
 
 ```mlir
-func.func @main_graph(%arg0: !hip.context, %arg1: memref<1x1x8x8xf32>,
-                       %arg2: memref<1x1x8x8xf32> {bufferize.result}) {
+func.func @main_graph(%arg0: !hip.context, %arg1: memref<1x1x8x8xf32>)
+    -> memref<1x1x8x8xf32> {
     %alloc = memref.alloc() : memref<1x1x8x8xf32>         // scratch for conv output
     hip.hipdnn_graph(%arg0) ... outs(%alloc)                // Conv writes to alloc
     %alloc_0 = memref.alloc() : memref<1x1x8x8xf32>       // scratch for matmul output
     hip.matmul(%arg0) ins(%alloc, %1) outs(%alloc_0)        // MatMul
-    hip.sigmoid(%arg0) ins(%alloc_0) outs(%arg2)            // Sigmoid writes to output param
-    return
+    %out = memref.alloc() : memref<1x1x8x8xf32>           // output buffer
+    hip.sigmoid(%arg0) ins(%alloc_0) outs(%out)             // Sigmoid writes to output
+    return %out
 }
 ```
 
-`BufferResultsToOutParams` converts the return value into an output parameter (`%arg2`).
-Buffer deallocation passes insert `memref.dealloc` for intermediate buffers.
+Buffer deallocation passes insert `memref.dealloc` for intermediate buffers
+(the returned `%out` is owned, so no clone). `hip-use-output-allocator` then
+rewrites the returned `memref.alloc` into `hip.alloc_output`, so the output is
+allocated in-graph via the EP callback rather than passed as an out-param.
 
 ### Stage 7: PoolAllocsPass (memory optimization)
 
@@ -386,11 +394,12 @@ Generates the three public entry points (`inference_init`, `inference_compute`,
   (creates HIP stream, MIOpen handle, hipBLASLt handle, loads constants to GPU)
 - Calls `hipdnn_ep_pool_init` to pre-allocate the GPU buffer pool (512 bytes here)
 
-**`inference_compute`:**
+**`inference_compute`** (2-arg output-allocator ABI):
 - Calls `hipdnn_ep_tensor_prepare_input` — copies host input to GPU (`hipMemcpyH2D`)
-- Calls `hipdnn_ep_tensor_prepare_output` — allocates GPU output buffer
-- Calls `main_graph(context, input_memref, output_memref)` — the compiled graph
-- Calls `hipdnn_ep_tensor_finalize_output` — copies GPU result to host (`hipMemcpyD2H`)
+- Calls `main_graph(context, input_memref)` — the compiled graph; each output is
+  allocated in-graph via `hip.alloc_output` → `hipdnn_ep_alloc_output` → the EP
+  allocator callback (zero-copy for GPU outputs)
+- Calls `hipdnn_ep_stream_sync` — ensures all GPU writes are complete on return
 - Calls `hipdnn_ep_tensor_free_input` — releases input staging buffer
 
 **`inference_cleanup`:**

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -393,7 +393,7 @@ def Hip_LoopOp : Hip_Op<"loop",
   );
 
   // v_final is non-empty only at the tensor level (DPS convention).
-  // After BufferResultsToOutParams / OneShotBufferize, the results are
+  // After bufferization + loop-body out-param promotion, the results are
   // eliminated and v_init carries the writes via its memref descriptors.
   let results = (outs Variadic<AnyRankedTensor>:$v_final);
 

--- a/include/hip/Dialect/Transforms/Passes.h
+++ b/include/hip/Dialect/Transforms/Passes.h
@@ -23,12 +23,10 @@ struct CompilationOptionsT;
 /// Creates a pass that generates the C interface for the compiled module.
 /// Transforms @main_graph to produce four C-ABI wrapper functions:
 /// inference_init, inference_compute, inference_cleanup,
-/// inference_get_metadata_json. The classic 3-arg (state, inputs, outputs) vs
-/// 2-arg allocator (state, inputs) ABI is selected from the module's
-/// `hipdnn.use_output_allocator` BoolAttr (set true by
-/// hip-use-output-allocator); in allocator mode graph outputs are allocated
-/// in-graph via hip.alloc_output (the hipdnn_ep_alloc_output runtime callback)
-/// rather than passed as out-params.
+/// inference_get_metadata_json. inference_compute has the 2-arg
+/// (state, inputs) ABI: graph outputs are allocated in-graph via
+/// hip.alloc_output (the hipdnn_ep_alloc_output runtime callback) rather than
+/// passed as out-params.
 std::unique_ptr<mlir::Pass>
 createGenerateInterfacePass(const CompilationOptionsT &options);
 

--- a/include/hip/Dialect/Transforms/Passes.td
+++ b/include/hip/Dialect/Transforms/Passes.td
@@ -532,8 +532,7 @@ def LoopBodyToOutParamsPass
     : Pass<"hip-loop-body-to-out-params", "mlir::ModuleOp"> {
   let summary = "Promote outlined hip.loop body returns to out-param ABI";
   let description = [{
-    Runs AFTER `one-shot-bufferize` and BEFORE `buffer-deallocation` in
-    both classic and allocator pipelines.
+    Runs AFTER `one-shot-bufferize` and BEFORE `buffer-deallocation`.
 
     `onnx-loop-outline` emits each `hip.loop` body as a private
     `func.func` named `*_loop_body_*`. After bufferization those helpers
@@ -541,12 +540,12 @@ def LoopBodyToOutParamsPass
     LoopLowering expects the out-param ABI (`v_in` + `v_out` per
     loop-carried value, with `{bufferize.result}` on each out-param).
 
-    Module-level `buffer-results-to-out-params` promotes `@main_graph` in
-    the classic pipeline but skips private functions; the allocator
-    pipeline skips module-level out-params on `@main_graph` entirely.
-    This pass closes the gap by calling MLIR's
-    `promoteBufferResultsToOutParams` with `modifyPublicFunctions = false`
-    and a filter on `*_loop_body_*` only.
+    This is the loop-body out-param ABI, which is INTERNAL to the DLL and
+    unrelated to the graph-entry output allocator ABI. `@main_graph`
+    outputs are handled by `hip-use-output-allocator` (`hip.alloc_output`
+    + EP callback); this pass only promotes the private `*_loop_body_*`
+    helpers by calling MLIR's `promoteBufferResultsToOutParams` with
+    `modifyPublicFunctions = false` and a filter on `*_loop_body_*` only.
 
     Example (one loop-carried memref):
       Before:  private @body(..., %v_in) -> memref<16xf32> { return %out }
@@ -574,14 +573,7 @@ def UseOutputAllocatorPass
     they are left unchanged.  Functions lacking !hip.context as argument 0 are
     likewise skipped.
 
-    The pass also stamps the `hipdnn.use_output_allocator` BoolAttr (value =
-    true) on the parent module -- the allocator-mode marker that downstream
-    convert-hip-to-llvm and generate-interface read to select the allocator ABI.
-    It is a typed bool, not a presence-only UnitAttr, so readers test the VALUE
-    (absence and `= false` both mean classic mode).  It is stamped even when no
-    alloc is rewritten, because the mode is decided by the pass being run, not by
-    the IR contents (a zero-output graph must still be marked).  Leaves the
-    function signature and func.return untouched.
+    Leaves the function signature and func.return untouched.
   }];
   let dependentDialects = [
     "mlir::hip::HipDialect",

--- a/include/hip/Dialect/Transforms/Pipelines.h
+++ b/include/hip/Dialect/Transforms/Pipelines.h
@@ -64,17 +64,6 @@ struct OnnxToHipPipelineOptions
       llvm::cl::desc("Skip writing constant data to constants.bin (metadata "
                      "only). Used for ORT EP live-compile path."),
       llvm::cl::init(false)};
-  Option<bool> useOutputAllocator{
-      *this, "use-output-allocator",
-      llvm::cl::desc(
-          "Allocator pipeline: replace buffer-results-to-out-params with "
-          "hip-use-output-allocator so graph outputs are allocated in-graph "
-          "via "
-          "hip.alloc_output (and the hipdnn.use_output_allocator module "
-          "attribute is "
-          "set for the LLVM half to read) (default: false = classic "
-          "out-params)"),
-      llvm::cl::init(false)};
 };
 
 /// Pipeline options for the HIP-to-LLVM lowering pipeline.
@@ -86,11 +75,6 @@ struct HipToLLVMPipelineOptions
       llvm::cl::desc(
           "Constants filename embedded in metadata (default: constants.bin)"),
       llvm::cl::init("constants.bin")};
-  // No use-output-allocator option here: convert-hip-to-llvm and
-  // generate-interface read the `hipdnn.use_output_allocator` module attribute
-  // set by hip-use-output-allocator in the ONNX-to-HIP half. When this pipeline
-  // is invoked standalone in allocator mode, the input IR must already carry
-  // that attribute.
 };
 
 /// Build the ONNX-to-HIP compilation pipeline.
@@ -145,16 +129,6 @@ struct HipdnnPipelineOptions
       llvm::cl::desc(
           "Minimum number of tensor elements to externalize (0 = disabled)"),
       llvm::cl::init(0)};
-  Option<bool> useOutputAllocator{
-      *this, "use-output-allocator",
-      llvm::cl::desc(
-          "Allocator pipeline: route the ONNX-to-HIP half through "
-          "hip-use-output-allocator, which sets the "
-          "hipdnn.use_output_allocator "
-          "module attribute; convert-hip-to-llvm + generate-interface then "
-          "read "
-          "that attribute (default: false = classic out-params)"),
-      llvm::cl::init(false)};
 };
 
 /// Build the complete HIPDNN pipeline: ONNX→HIP→LLVM→Interface.

--- a/lib/CInterface/CompilerAPI.cpp
+++ b/lib/CInterface/CompilerAPI.cpp
@@ -31,9 +31,6 @@ static const char *COMPILER_VERSION = "1.0.0";
 //   constants_file     — externalized weights filename (default
 //                        "constants.bin")
 //   skip_constant_data — skip writing constant bytes (default false)
-//   use_output_allocator — compile in output-allocator mode: 2-arg
-//                        inference_compute + in-graph hip.alloc_output (default
-//                        false)
 //   output_mode        — LLVM_IR (default; OS-portable LLVM IR as .bc,
 //   JIT-loaded
 //                        by the EP) or Native (per-OS .dll/.so linked here and

--- a/lib/Compiler/CompilerDriver.cpp
+++ b/lib/Compiler/CompilerDriver.cpp
@@ -225,13 +225,6 @@ bool CompilerDriver::runMLIRPasses(
   onnxToHipOpts.externalizeMinNumElements =
       mlir::hip::kDefaultExternalizeMinNumElements;
   onnxToHipOpts.skipConstantData = options.skip_constant_data;
-  // Allocator mode is selected once, here, on the OnnxToHip half: when set, the
-  // slot-4.5 pair (hip-use-output-allocator + hip-set-output-allocator-attr)
-  // runs in the OnnxToHip tail and stamps the `hipdnn.output_allocator` module
-  // attribute. The HipToLLVM half (convert-hip-to-llvm + generate-interface)
-  // reads that attribute off the IR, so it needs no separate flag -- the mode
-  // rides on the module, keeping the two halves from ever disagreeing.
-  onnxToHipOpts.useOutputAllocator = options.use_output_allocator;
 
   if (hipdnnHandle_) {
     compiledGraphs_ =

--- a/lib/Conversion/HipToLLVM/HipToLLVM.cpp
+++ b/lib/Conversion/HipToLLVM/HipToLLVM.cpp
@@ -64,38 +64,31 @@ private:
           loc, memrefStruct, ArrayRef<int64_t>{kStridesIdx, dim}));
   }
 
-  // Rewrite @main_graph from the convert-hip-to-llvm internal ABI into the
-  // runtime calling convention by splitting it into two functions:
+  // Split @main_graph into two functions so the runtime's simple (ctx, inputs)
+  // ABI can reach the graph body:
   //
-  //   main_graph_internal  the original graph body, keeping the MLIR memref
-  //     calling convention: a ranked-memref arg is NOT one struct parameter --
-  //     it is EXPLODED into its 3 + 2*rank descriptor fields
-  //     {allocatedPtr, alignedPtr, offset, sizes[rank], strides[rank]} as that
-  //     many separate scalar params. This flat form is what "unpacked memref
-  //     params" means throughout this file.
-  //   main_graph  a thin wrapper with the runtime's narrow ABI: the EP only
-  //     hands it (ctx, inputs[, outputs]) where inputs/outputs are C arrays of
-  //     pointers to memref descriptor structs. For each memref the wrapper
-  //     loads the descriptor and re-explodes it into scalars
-  //     (unpackMemRefStructWithAddrCast, which also addrspace-casts the two
-  //     ptrs back to addrspace(0)), then calls main_graph_internal with the
-  //     concatenated flat list. That re-explode is the "unpack" bridging the
-  //     two ABIs.
+  //   main_graph_internal  the graph body, unchanged. It keeps MLIR's memref
+  //     ABI: each memref arg is passed as its 3 + 2*rank scalar fields
+  //     {allocatedPtr, alignedPtr, offset, sizes[rank], strides[rank]}, not as
+  //     one struct. ("unpacked memref params" means this flat scalar form.)
+  //   main_graph  a thin wrapper (called by inference_compute, not the EP
+  //     directly) taking (ctx, inputs). Here `inputs` is a C array of pointers
+  //     to memref descriptor structs that inference_compute built from the
+  //     input tensors -- NOT the span_t the EP passes to inference_compute.
+  //     For each input it loads the descriptor and unpacks it back into the
+  //     scalar fields
+  //     (unpackMemRefStructWithAddrCast, which also casts the two ptrs to
+  //     addrspace(0)), then calls main_graph_internal. Outputs are NOT passed
+  //     in: the graph allocates them via hip.alloc_output (the EP callback) and
+  //     returns them by value, which the wrapper ignores.
   //
-  // Mode is read from the `hipdnn.use_output_allocator` module attribute (set
-  // by hip-use-output-allocator); the expected param count is then used only to
-  // verify @main_graph matches it. Classic main_graph has input AND output
-  // params; allocator main_graph has input params only and returns the
-  // in-graph-allocated output as a by-value memref result (which adds no
-  // param).
-  //
-  // Allocator mode, rank-1 input + in-graph-allocated output:
-  // Before (no output params; input already exploded into 5 = 3 + 2*1 scalars;
-  // main_graph returns the output descriptor):
+  // Example: 1 rank-1 input, 1 in-graph output.
+  // Before (input already flattened to 5 = 3 + 2*1 scalars; returns the output
+  // descriptor):
   //   llvm.func @main_graph(%ctx, %inAlloc, %inAligned, %inOff, %inSz, %inSt)
   //       -> !llvm.struct<(ptr,ptr,i64,array<1xi64>,array<1xi64>)> { ... }
-  // After (wrapper drops the outputs ptr and ignores the returned descriptor --
-  // the output reaches the EP via the hipdnn_ep_alloc_output callback):
+  // After (wrapper takes only (ctx, inputs); the returned descriptor is
+  // ignored, the output reaches the EP via the callback):
   //   llvm.func @main_graph_internal(<same 5 scalars>) -> !llvm.struct<...>
   //   llvm.func @main_graph(%ctx: ptr, %inputs: ptr) -> i32 {
   //     %sp = llvm.load (gep %inputs[0])       ; ptr to the descriptor
@@ -108,9 +101,6 @@ private:
   //     %_  = llvm.call @main_graph_internal(%ctx, %a, %al, %o, %s0, %t0)
   //     llvm.return %c0_i32
   //   }
-  // Classic mode is the same except the wrapper takes (%ctx, %inputs,
-  // %outputs), unpacks each output out-param the same way, and forwards the
-  // internal's i32/void result.
   LogicalResult transformMainFunction(ModuleOp module) {
     auto mainFunc = module.lookupSymbol<LLVM::LLVMFuncOp>("main_graph");
     if (!mainFunc)
@@ -140,18 +130,9 @@ private:
         (int64_t)outputShapesAttr.size() != outputCount)
       return module.emitError("Metadata mismatch: shapes array size != count");
 
-    // Mode comes from the attribute's VALUE, not its presence (see header):
-    // absent or `= false` => classic.
-    auto allocatorAttr =
-        module->getAttrOfType<BoolAttr>("hipdnn.use_output_allocator");
-    bool allocatorMode = allocatorAttr && allocatorAttr.getValue();
-
-    // Each memref unpacks to allocatedPtr + alignedPtr + offset + sizes[rank]
-    // + strides[rank] = 3 + 2*rank LLVM params. Both modes have the context +
-    // input params; only classic mode adds the output out-params (in allocator
-    // mode outputs are allocated in-graph and returned as a by-value struct,
-    // which adds no param) -- so the attr gates whether the output scope is
-    // counted.
+    // Each memref is 3 + 2*rank scalar params (allocatedPtr, alignedPtr,
+    // offset, sizes[rank], strides[rank]). @main_graph has context + inputs
+    // only; outputs are returned by value and add no param.
     constexpr unsigned kMemRefPtrs = 2;   // allocatedPtr + alignedPtr
     constexpr unsigned kMemRefOffset = 1; // offset scalar
     unsigned expectedParams = 1;          // context
@@ -159,44 +140,28 @@ private:
       int64_t rank = cast<DenseI64ArrayAttr>(shapeAttr).size();
       expectedParams += kMemRefPtrs + kMemRefOffset + rank + rank;
     }
-    if (!allocatorMode) {
-      for (auto shapeAttr : outputShapesAttr) {
-        int64_t rank = cast<DenseI64ArrayAttr>(shapeAttr).size();
-        expectedParams += kMemRefPtrs + kMemRefOffset + rank + rank;
-      }
-    }
 
     unsigned actualParams = mainFunc.getFunctionType().getNumParams();
     if (actualParams != expectedParams) {
       return module.emitError()
              << "[HipToLLVM] @main_graph parameter count mismatch: expected "
-             << expectedParams
-             << (allocatorMode ? " (allocator), got " : " (classic), got ")
-             << actualParams;
+             << expectedParams << ", got " << actualParams;
     }
 
     OpBuilder builder(module.getContext());
     Location loc = mainFunc.getLoc();
 
-    // Rename the original main_graph (with unpacked memref params) so we can
-    // create a new wrapper that takes the runtime calling convention --
-    // (ctx, inputs, outputs) in classic mode, or (ctx, inputs) in allocator
-    // mode (outputs are allocated in-graph) -- and unpacks the input (and, in
-    // classic mode, output) memref structs before forwarding the call.
+    // Rename the original main_graph so we can add a (ctx, inputs) wrapper that
+    // unpacks the input memref structs and forwards the call. No outputs arg.
     mainFunc.setName("main_graph_internal");
     mainFunc.setLinkage(LLVM::Linkage::Private);
 
     Type ptrType = LLVM::LLVMPointerType::get(builder.getContext(), 0);
     Type i32Type = builder.getI32Type();
-    // Allocator wrapper drops the trailing outputs pointer arg.
-    SmallVector<Type> newParamTypes =
-        allocatorMode ? SmallVector<Type>{ptrType, ptrType}
-                      : SmallVector<Type>{ptrType, ptrType, ptrType};
+    SmallVector<Type> newParamTypes{ptrType, ptrType}; // (ctx, inputs)
     auto newFuncType = LLVM::LLVMFunctionType::get(i32Type, newParamTypes);
 
-    // Create the new main_graph wrapper with the simplified runtime signature
-    // ((ctx, inputs, outputs) classic / (ctx, inputs) allocator) computed
-    // above.
+    // Create the (ctx, inputs) wrapper.
     builder.setInsertionPoint(mainFunc);
     auto newMainFunc =
         builder.create<LLVM::LLVMFuncOp>(loc, "main_graph", newFuncType);
@@ -230,56 +195,19 @@ private:
                                      mainInternalArgs);
     }
 
-    // Classic mode forwards each output out-param (unpacked memref struct) to
-    // the internal call. Allocator mode has no output args -- the internal
-    // main_graph allocates and returns the output via hip.alloc_output, so the
-    // outputs pointer is absent from the wrapper signature.
-    if (!allocatorMode) {
-      Value outputsArg = entryBlock->getArgument(2);
-      for (int64_t i : llvm::seq<int64_t>(0, outputCount)) {
-        int64_t rank = cast<DenseI64ArrayAttr>(outputShapesAttr[i]).size();
-        Value outputIdxVal = builder.create<LLVM::ConstantOp>(
-            loc, i32Type, builder.getI32IntegerAttr(i));
-        Value outputSlotPtr = builder.create<LLVM::GEPOp>(
-            loc, ptrType, ptrType, outputsArg, ValueRange{outputIdxVal});
-        Value outputStructPtr =
-            builder.create<LLVM::LoadOp>(loc, ptrType, outputSlotPtr);
-        Type memrefStructType = getMemRefStructType(builder, rank, 1);
-        Value outputMemref = builder.create<LLVM::LoadOp>(loc, memrefStructType,
-                                                          outputStructPtr);
-        unpackMemRefStructWithAddrCast(builder, loc, outputMemref, rank,
-                                       mainInternalArgs);
-      }
-    }
-
-    // Forward to the internal main_graph and return the i32 status:
-    //   - allocator mode: the internal returns a memref descriptor (by-value
-    //     struct) for the in-graph-allocated output. Call it, DISCARD the
-    //     struct result (the output reaches the EP through the
-    //     hipdnn_ep_alloc_output callback, not the return value), and return 0.
-    //   - classic void internal (real lowering): call, return 0.
-    //   - classic i32 internal (hand-written LIT shape): call, forward result.
-    auto internalRetTy = mainFunc.getFunctionType().getReturnType();
-    // The `allocatorMode` term is required: in allocator mode internalRetTy is
-    // the memref descriptor struct (neither void nor i32), so without it this
-    // would fall into the else branch and return that struct from the i32
-    // wrapper -- a type mismatch. The attr routes allocator mode to discard +
-    // return 0 instead.
-    if (allocatorMode || isa<LLVM::LLVMVoidType>(internalRetTy)) {
-      builder.create<LLVM::CallOp>(loc, mainFunc, mainInternalArgs);
-      Value zero = builder.create<LLVM::ConstantOp>(
-          loc, i32Type, builder.getI32IntegerAttr(0));
-      builder.create<LLVM::ReturnOp>(loc, zero);
-    } else {
-      auto callOp =
-          builder.create<LLVM::CallOp>(loc, mainFunc, mainInternalArgs);
-      builder.create<LLVM::ReturnOp>(loc, callOp.getResult());
-    }
+    // Call the internal graph and return 0. Outputs are not out-params: the
+    // graph allocates them via hip.alloc_output and returns them by value, so
+    // any returned descriptor is ignored (the output reaches the EP through the
+    // callback). A zero-output graph returns void, so there is nothing to
+    // ignore.
+    builder.create<LLVM::CallOp>(loc, mainFunc, mainInternalArgs);
+    Value zero = builder.create<LLVM::ConstantOp>(loc, i32Type,
+                                                  builder.getI32IntegerAttr(0));
+    builder.create<LLVM::ReturnOp>(loc, zero);
 
     COMPILER_DEBUG_LOG("[HipToLLVM] Transformed @main_graph signature: "
                        << actualParams << " params -> " << newParamTypes.size()
-                       << " params ("
-                       << (allocatorMode ? "allocator" : "classic") << ")\n");
+                       << " params\n");
     return success();
   }
 };

--- a/lib/Conversion/HipToLLVM/MemoryLowering.cpp
+++ b/lib/Conversion/HipToLLVM/MemoryLowering.cpp
@@ -261,7 +261,9 @@ struct AllocOutputOpLowering : public ConvertOpToLLVMPattern<AllocOutputOp> {
     Type elemType = memRefType.getElementType();
     if (!elemType.isIntOrFloat())
       return rewriter.notifyMatchFailure(op, "unsupported element type");
-    int64_t elemSizeBytes = elemType.getIntOrFloatBitWidth() / 8;
+    // Round bits up to whole bytes so sub-byte types report >= 1 byte: a
+    // bool (`i1`) output must be 1 byte, not 1/8 == 0.
+    int64_t elemSizeBytes = (elemType.getIntOrFloatBitWidth() + 7) / 8;
     if (elemSizeBytes <= 0)
       return rewriter.notifyMatchFailure(op, "unsupported element bit width");
 

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -874,11 +874,10 @@ void ConvertOnnxToHipPass::runOnOperation() {
   for (auto *op : toErase)
     op->erase();
 
-  // ONNX-MLIR attaches per-result attributes (e.g. "onnx_node_name") to
-  // func.func results. The downstream buffer-results-to-out-params pass
-  // skips any result that still carries attributes, leaving the function
-  // signature unconverted and causing later lowering failures. Clear all
-  // result attributes so every result is eligible for out-param conversion.
+  // ONNX-MLIR tags func.func results with attributes (e.g. "onnx_node_name").
+  // Downstream bufferization skips any result that still has attributes, which
+  // leaves the signature unconverted and breaks later lowering. Clear them so
+  // every result is handled.
   module.walk([&](mlir::func::FuncOp funcOp) {
     unsigned numResults = funcOp.getNumResults();
     if (numResults > 0) {

--- a/lib/Dialect/Transforms/GenerateInterface.cpp
+++ b/lib/Dialect/Transforms/GenerateInterface.cpp
@@ -9,7 +9,8 @@
 // This pass generates four C-ABI compatible functions that wrap the internal
 // @main_graph function:
 // - inference_init: Allocate context, create handles, upload constants
-// - inference_compute: Parse inputs/outputs, call @main_graph
+// - inference_compute: 2-arg (state, inputs) ABI -- stage inputs, call
+//   @main_graph (graph outputs are allocated in-graph via hip.alloc_output)
 // - inference_cleanup: Free resources
 // - inference_get_metadata_json: Return JSON metadata (input/output shapes)
 //===----------------------------------------------------------------------===//
@@ -345,11 +346,9 @@ static void emitErrorCheckedCall(OpBuilder &builder, Location loc,
 
 // Generates the four C-ABI interface functions (inference_init,
 // inference_compute, inference_cleanup, inference_get_metadata_json) for a
-// lowered module. Allocator vs classic mode is read from the
-// `hipdnn.use_output_allocator` module attribute (set by hip-use-output-
-// allocator) in place by verifyPrerequisites and generateInferenceCompute;
-// inference_init, inference_cleanup, runtime declarations and metadata are
-// identical in both modes.
+// lowered module. inference_compute has the (state, inputs) -> i32 signature;
+// graph outputs are allocated in-graph via hip.alloc_output, not passed as
+// out-params.
 class GenerateInterfacePass
     : public PassWrapper<GenerateInterfacePass, OperationPass<ModuleOp>> {
 public:
@@ -399,21 +398,14 @@ public:
 
     generateInferenceInit(module, blob.size());
     auto inputShapes = module->getAttrOfType<ArrayAttr>("hipdnn.input_shapes");
-    auto outputShapes =
-        module->getAttrOfType<ArrayAttr>("hipdnn.output_shapes");
-    generateInferenceCompute(module, inputShapes, outputShapes);
+    generateInferenceCompute(module, inputShapes);
     generateInferenceCleanup(module);
 
     std::string json = buildMetadataJson(module, constantsFile);
     generateMetadataGlobal(module, json);
     generateInferenceGetMetadataJson(module);
 
-    auto allocatorAttr =
-        module->getAttrOfType<BoolAttr>("hipdnn.use_output_allocator");
-    bool allocatorMode = allocatorAttr && allocatorAttr.getValue();
-    COMPILER_DEBUG_LOG("[GenerateInterface] Generated 4 interface functions ("
-                       << (allocatorMode ? "allocator" : "classic")
-                       << " mode)\n");
+    COMPILER_DEBUG_LOG("[GenerateInterface] Generated 4 interface functions\n");
   }
 
 private:
@@ -451,8 +443,6 @@ private:
         {"hipdnn_ep_pool_init", i32, {ptr, i64, ptr, i64}},
         {"hipdnn_ep_get_buffer_from_pool", ptr, {ptr, i64}},
         {"hipdnn_ep_tensor_prepare_input", i32, {ptr, ptr, i64, i64, ptr}},
-        {"hipdnn_ep_tensor_prepare_output", i32, {ptr, ptr, i64, i64, ptr}},
-        {"hipdnn_ep_tensor_finalize_output", i32, {ptr, ptr}},
         {"hipdnn_ep_tensor_free_input", vd, {ptr, ptr}},
         {"hipdnn_ep_tensor_buffer_get_gpu_ptr", ptr, {ptr}},
         {"hipdnn_ep_tensor_buffer_get_host_ptr", ptr, {ptr}},
@@ -482,9 +472,6 @@ private:
   }
 
   LogicalResult verifyPrerequisites(ModuleOp module) {
-    auto allocatorAttr =
-        module->getAttrOfType<BoolAttr>("hipdnn.use_output_allocator");
-    bool allocatorMode = allocatorAttr && allocatorAttr.getValue();
     MLIRContext *ctx = module.getContext();
     Type ptrType = LLVM::LLVMPointerType::get(ctx, 0);
     Type i32Type = IntegerType::get(ctx, 32);
@@ -513,23 +500,19 @@ private:
       return failure();
     }
 
-    // After convert-hip-to-llvm's transformMainFunction, @main_graph is the
-    // runtime-ABI wrapper: (ptr, ptr, ptr) -> i32 classic, (ptr, ptr) -> i32
-    // allocator (no outputs span). All params are opaque pointers; the result
-    // is the i32 status.
+    // After convert-hip-to-llvm, @main_graph is the (ctx, inputs) -> i32
+    // wrapper (no outputs param -- outputs are allocated in-graph). Both params
+    // are opaque pointers.
     auto mainType = mainFunc.getFunctionType();
-    unsigned expectedNumParams = allocatorMode ? 2 : 3;
-    bool sigOk = mainType.getNumParams() == expectedNumParams &&
+    constexpr unsigned kExpectedNumParams = 2; // (ctx, inputs)
+    bool sigOk = mainType.getNumParams() == kExpectedNumParams &&
                  mainType.getReturnType() == i32Type;
     if (sigOk)
-      for (unsigned p : llvm::seq<unsigned>(0, expectedNumParams))
+      for (unsigned p : llvm::seq<unsigned>(0, kExpectedNumParams))
         sigOk &= mainType.getParamType(p) == ptrType;
     if (!sigOk) {
       llvm::errs() << "[GenerateInterface] @main_graph has wrong signature.\n"
-                   << "Expected: "
-                   << (allocatorMode ? "(ptr, ptr) -> i32 (allocator)"
-                                     : "(ptr, ptr, ptr) -> i32 (classic)")
-                   << "\n";
+                   << "Expected: (ptr, ptr) -> i32\n";
       return failure();
     }
 
@@ -757,37 +740,21 @@ private:
     }
   }
 
-  /// Generated IR overview (1 input, 1 output of rank 1):
-  ///   llvm.func @inference_compute(%state: !llvm.ptr, %ins: !llvm.ptr,
-  ///                                %outs: !llvm.ptr) -> i32
+  /// Generated IR overview (1 input of rank 1; outputs allocated in-graph):
+  ///   llvm.func @inference_compute(%state: !llvm.ptr, %ins: !llvm.ptr) -> i32
   ///       attributes {llvm.emit_c_interface, sym_visibility = "public"} {
-  ///     // 1. Alloca TensorBuffer structs on the stack
+  ///     // 1. Alloca input TensorBuffer structs on the stack
   ///     // 2. For each input:  call hipdnn_ep_tensor_prepare_input,
   ///     error-check
-  ///     // 3. For each output: call hipdnn_ep_tensor_prepare_output,
-  ///     error-check
-  ///     // 4. Build LLVM memref descriptors from TensorBuffer GPU/shape ptrs
-  ///     // 5. Call @main_graph(%state, %input_memrefs, %output_memrefs)
-  ///     // 6. For each output: call hipdnn_ep_tensor_finalize_output,
-  ///     error-check
-  ///     // 7. Call hipdnn_ep_stream_sync (GPU sync + PERF profiling output)
-  ///     // 8. Read device-side error flag
-  ///     // 9. Free input TensorBuffers
+  ///     // 3. Build LLVM memref descriptors from TensorBuffer GPU/shape ptrs
+  ///     // 4. Call @main_graph(%state, %input_memrefs) -- outputs are
+  ///     //    allocated in-graph via hip.alloc_output and written directly
+  ///     // 5. Call hipdnn_ep_stream_sync (GPU sync + PERF profiling output)
+  ///     // 6. Read device-side error flag
+  ///     // 7. Free input TensorBuffers
   ///     // On error: store error code, free inputs, return error
   ///   }
-  ///
-  /// Allocator mode (module's `hipdnn.use_output_allocator` attr is true): the
-  /// wrapper takes (state, inputs) only; output-tensor handling
-  /// (prepare_output, the output-memref array, finalize_output) and the outputs
-  /// span are all skipped -- graph outputs are allocated in-graph by
-  /// hip.alloc_output (lowered to the hipdnn_ep_alloc_output callback) and
-  /// written directly, so
-  /// @main_graph is called as (state, input_memrefs).
-  void generateInferenceCompute(ModuleOp module, ArrayAttr inputShapes,
-                                ArrayAttr outputShapes) {
-    auto allocatorAttr =
-        module->getAttrOfType<BoolAttr>("hipdnn.use_output_allocator");
-    bool allocatorMode = allocatorAttr && allocatorAttr.getValue();
+  void generateInferenceCompute(ModuleOp module, ArrayAttr inputShapes) {
     OpBuilder builder(module.getContext());
     Location loc = module.getLoc();
     builder.setInsertionPointToEnd(module.getBody());
@@ -795,10 +762,7 @@ private:
     Type ptrType = LLVM::LLVMPointerType::get(builder.getContext(), 0);
     Type i32Type = builder.getI32Type();
     Type i64Type = builder.getI64Type();
-    // Allocator mode drops the trailing outputs span arg.
-    SmallVector<Type> paramTypes =
-        allocatorMode ? SmallVector<Type>{ptrType, ptrType}
-                      : SmallVector<Type>{ptrType, ptrType, ptrType};
+    SmallVector<Type> paramTypes{ptrType, ptrType}; // (state, inputs)
     auto funcType = LLVM::LLVMFunctionType::get(i32Type, paramTypes);
 
     auto funcOp = LLVM::LLVMFuncOp::create(
@@ -834,16 +798,8 @@ private:
       LLVM::CallOp::create(builder, loc, beginComputeFunc, ValueRange{state});
 
     Value inputsSpanPtr = entryBlock->getArgument(1);
-    // outputsSpanPtr is arg 2 in classic mode only; allocator mode has no
-    // outputs span (outputs are allocated in-graph).
-    Value outputsSpanPtr = allocatorMode ? Value() : entryBlock->getArgument(2);
 
     size_t numInputs = inputShapes ? inputShapes.size() : 0;
-    // True output count in both modes. Allocator mode skips the classic output
-    // staging below (prepare_output, output-memref build, finalize_output) via
-    // `if (!allocatorMode)` scopes, not by zeroing this count -- those outputs
-    // are instead allocated in-graph by the hip.alloc_output emitted earlier.
-    size_t numOutputs = outputShapes ? outputShapes.size() : 0;
 
     Value c0_i32 = LLVM::ConstantOp::create(builder, loc, i32Type,
                                             builder.getI32IntegerAttr(0));
@@ -852,10 +808,6 @@ private:
 
     auto prepareInputFunc =
         module.lookupSymbol<LLVM::LLVMFuncOp>("hipdnn_ep_tensor_prepare_input");
-    auto prepareOutputFunc = module.lookupSymbol<LLVM::LLVMFuncOp>(
-        "hipdnn_ep_tensor_prepare_output");
-    auto finalizeOutputFunc = module.lookupSymbol<LLVM::LLVMFuncOp>(
-        "hipdnn_ep_tensor_finalize_output");
     auto freeInputFunc =
         module.lookupSymbol<LLVM::LLVMFuncOp>("hipdnn_ep_tensor_free_input");
 
@@ -874,11 +826,6 @@ private:
         LLVM::AllocaOp::create(builder, loc, ptrType, i32Type, c1_i64, 0);
 
     SmallVector<Value> inputBuffers;
-    SmallVector<Value> outputBuffers;
-    // Hoisted: assigned inside the classic `if (!allocatorMode)` output-memref
-    // scope below, read by the @main_graph call. Stays null in allocator mode
-    // (where it is never pushed onto the call args).
-    Value outputMemrefArray;
 
     // sizeof(TensorBuffer) in the runtime (6 fields, 48 bytes on 64-bit).
     // TODO: Replace with sizeof(TensorBuffer) or a runtime query once the
@@ -895,17 +842,6 @@ private:
       Value bufferPtr = LLVM::AllocaOp::create(builder, loc, ptrType, i8Type,
                                                tensorBufferSize, 0);
       inputBuffers.push_back(bufferPtr);
-    }
-    // classic out-param staging - delete when classic is removed. Allocator
-    // mode allocates outputs in-graph via hip.alloc_output, so no per-output
-    // TensorBuffer is staged here.
-    if (!allocatorMode) {
-      for (auto i : llvm::seq<size_t>(0, numOutputs)) {
-        (void)i;
-        Value bufferPtr = LLVM::AllocaOp::create(builder, loc, ptrType, i8Type,
-                                                 tensorBufferSize, 0);
-        outputBuffers.push_back(bufferPtr);
-      }
     }
 
     Block *errorCleanupBlock = funcOp.addBlock();
@@ -925,26 +861,6 @@ private:
           builder, loc, prepareInputFunc,
           ValueRange{state, inputsSpanPtr, indexVal, rankVal, bufferPtr},
           errorCodePtr, errorCleanupBlock, funcOp);
-    }
-
-    // classic out-param staging - delete when classic is removed.
-    if (!allocatorMode) {
-      for (auto i : llvm::seq<size_t>(0, numOutputs)) {
-        Value bufferPtr = outputBuffers[i];
-
-        Value indexVal = LLVM::ConstantOp::create(builder, loc, i64Type,
-                                                  builder.getI64IntegerAttr(i));
-
-        Value rankVal = LLVM::ConstantOp::create(
-            builder, loc, i64Type,
-            builder.getI64IntegerAttr(
-                cast<DenseI64ArrayAttr>(outputShapes.getValue()[i]).size()));
-
-        emitErrorCheckedCall(
-            builder, loc, prepareOutputFunc,
-            ValueRange{state, outputsSpanPtr, indexVal, rankVal, bufferPtr},
-            errorCodePtr, errorCleanupBlock, funcOp);
-      }
     }
 
     // Build memref structs for @main call
@@ -979,43 +895,6 @@ private:
       LLVM::StoreOp::create(builder, loc, memrefPtr, arraySlot);
     }
 
-    // classic out-param staging - delete when classic is removed. The
-    // output-memref array is forwarded to @main_graph in classic mode only;
-    // allocator mode leaves outputMemrefArray null and never passes it.
-    if (!allocatorMode) {
-      Value numOutputsVal = LLVM::ConstantOp::create(
-          builder, loc, i64Type, builder.getI64IntegerAttr(numOutputs));
-      outputMemrefArray = LLVM::AllocaOp::create(builder, loc, ptrType, ptrType,
-                                                 numOutputsVal, 0);
-
-      for (auto i : llvm::seq<size_t>(0, numOutputs)) {
-        int64_t rank =
-            cast<DenseI64ArrayAttr>(outputShapes.getValue()[i]).size();
-
-        Value bufferPtr = outputBuffers[i];
-        Value gpuPtrRaw = LLVM::CallOp::create(builder, loc, getGpuPtrFunc,
-                                               ValueRange{bufferPtr})
-                              .getResult();
-        Value shapePtr = LLVM::CallOp::create(builder, loc, getShapePtrFunc,
-                                              ValueRange{bufferPtr})
-                             .getResult();
-
-        Value memref = buildMemrefDescriptor(builder, loc, gpuPtrRaw, shapePtr,
-                                             rank, ptrType, i64Type);
-
-        Value memrefPtr = LLVM::AllocaOp::create(builder, loc, ptrType,
-                                                 memref.getType(), c1_i64, 0);
-        LLVM::StoreOp::create(builder, loc, memref, memrefPtr);
-
-        Value indexVal = LLVM::ConstantOp::create(builder, loc, i64Type,
-                                                  builder.getI64IntegerAttr(i));
-        Value arraySlot = LLVM::GEPOp::create(builder, loc, ptrType, ptrType,
-                                              outputMemrefArray,
-                                              ArrayRef<LLVM::GEPArg>{indexVal});
-        LLVM::StoreOp::create(builder, loc, memrefPtr, arraySlot);
-      }
-    }
-
     // Reset kernel-side runtime error flag before graph execution.
     emitErrorCheckedCall(builder, loc, resetErrorFlagFunc, ValueRange{state},
                          errorCodePtr, errorCleanupBlock, funcOp);
@@ -1031,30 +910,15 @@ private:
       LLVM::BrOp::create(builder, loc, mainSuccessBlock);
     } else {
       mainSuccessBlock = funcOp.addBlock();
-      // Classic: @main_graph(state, in_memrefs, out_memrefs). Allocator:
-      // @main_graph(state, in_memrefs) -- outputs allocated in-graph.
+      // @main_graph(state, in_memrefs) -- outputs are allocated in-graph, so
+      // there is no outputs arg.
       SmallVector<Value> mainArgs = {state, inputMemrefArray};
-      if (!allocatorMode)
-        mainArgs.push_back(outputMemrefArray);
       emitErrorCheckedCall(builder, loc, mainFunc, mainArgs, errorCodePtr,
                            errorCleanupBlock, funcOp);
       LLVM::BrOp::create(builder, loc, mainSuccessBlock);
     }
 
-    // Finalize output tensors (D2H, sync, cleanup)
     builder.setInsertionPointToStart(mainSuccessBlock);
-
-    // classic out-param staging - delete when classic is removed. Allocator
-    // outputs are EP-owned (written in place by hip.alloc_output), so there is
-    // nothing to finalize back to a caller buffer here.
-    if (!allocatorMode) {
-      for (auto i : llvm::seq<size_t>(0, numOutputs)) {
-        Value bufferPtr = outputBuffers[i];
-        emitErrorCheckedCall(builder, loc, finalizeOutputFunc,
-                             ValueRange{state, bufferPtr}, errorCodePtr,
-                             errorCleanupBlock, funcOp);
-      }
-    }
 
     // Synchronize GPU stream after all D2H copies are queued. Also prints
     // PERF phase timing and per-op profile when HIPDNN_EP_PERF is enabled.

--- a/lib/Dialect/Transforms/LoopBodyToOutParams.cpp
+++ b/lib/Dialect/Transforms/LoopBodyToOutParams.cpp
@@ -13,15 +13,14 @@
 // LoopLowering expects the out-param ABI: one extra memref argument per
 // loop-carried value (`v_in` + `v_out`, tagged `{bufferize.result}`).
 //
-// The module-level `buffer-results-to-out-params` pass closes this gap for
-// `@main_graph` in the classic pipeline (`modifyPublicFunctions = true`) but
-// skips private helpers. The allocator pipeline skips module-level out-params
-// on `@main_graph` entirely (outputs are handled later by
-// `hip-use-output-allocator`). Neither path promotes outlined loop bodies.
+// `@main_graph`'s own outputs are handled by `hip-use-output-allocator`
+// (`hip.alloc_output` + the EP callback); that path never touches the private
+// outlined loop bodies. This loop-body out-param ABI is INTERNAL to the DLL
+// and unrelated to the graph-entry output allocator ABI.
 //
 // Fix. Invoke MLIR's `promoteBufferResultsToOutParams` with
 // `modifyPublicFunctions = false` and a name filter that selects only
-// `*_loop_body_*` functions. Runs in both classic and allocator pipelines.
+// `*_loop_body_*` functions.
 //
 // Before:
 //   func.func private @main_loop_body_n0(..., %v_in: memref<...>)

--- a/lib/Dialect/Transforms/Pipelines.cpp
+++ b/lib/Dialect/Transforms/Pipelines.cpp
@@ -26,14 +26,12 @@ using namespace mlir;
 
 /// Common tail of the ONNX-to-HIP pipeline after the OnnxToHip pass.
 ///
-/// \p useOutputAllocator selects the allocator pipeline. The classic pipeline
-/// runs `buffer-results-to-out-params` at slot 3 (each returned memref becomes
-/// a trailing out-param). The allocator pipeline SKIPS that pass and instead
-/// runs `hip-use-output-allocator` at slot 4.5, whose load-bearing placement
-/// (after buffer-deallocation, before pool-allocs) is explained at that slot.
-/// See docs/design/output-allocator-design.md.
-static void buildOnnxToHipPipelineTail(OpPassManager &pm,
-                                       bool useOutputAllocator) {
+/// Graph outputs use the output-allocator ABI: `hip-use-output-allocator` runs
+/// at slot 4.5, rewriting each returned `memref.alloc` into `hip.alloc_output`
+/// (allocated in-graph at runtime via the EP's output-allocator callback).
+/// Where it runs matters (after buffer-deallocation, before pool-allocs); the
+/// reason is at that slot. See docs/design/output-allocator-design.md.
+static void buildOnnxToHipPipelineTail(OpPassManager &pm) {
   // 1b. Refine `?` (kDynamic) dims on HIP DPS op result types using each
   //     op's `ReifyRankedShapedTypeOpInterface` impl. Placed here so the
   //     refinements propagate through bufferize and into pool / alloc
@@ -106,36 +104,21 @@ static void buildOnnxToHipPipelineTail(OpPassManager &pm,
       bufferization::LayoutMapOption::IdentityLayoutMap;
   pm.addPass(bufferization::createOneShotBufferizePass(bufferizeOpts));
 
-  // 3. Classic pipeline only: convert tensor function results to out-params
-  //    (memref). The allocator pipeline keeps results as returned memrefs here
-  //    and defers output handling to slot 4.5 (after buffer-deallocation) --
-  //    see that comment for the ownership/clone reason.
-  if (!useOutputAllocator) {
-    bufferization::BufferResultsToOutParamsPassOptions outParamsOpts;
-    outParamsOpts.hoistStaticAllocs = true;
-    outParamsOpts.hoistDynamicAllocs = true;
-    outParamsOpts.addResultAttribute = true;
-    outParamsOpts.modifyPublicFunctions = true;
-    pm.addPass(
-        bufferization::createBufferResultsToOutParamsPass(outParamsOpts));
-  }
-
-  // 3b. Promote outlined `*_loop_body_*` helpers to the out-param ABI
-  //     LoopLowering expects. Slot 3 above covers @main_graph only (classic);
-  //     allocator mode defers @main_graph to slot 4.5. Both pipelines need
-  //     this pass for private loop bodies before buffer-deallocation.
+  // 3. Promote outlined `*_loop_body_*` helpers to the out-param ABI
+  //    LoopLowering expects. @main_graph keeps its returned memrefs here and
+  //    defers output handling to slot 4.5 (hip-use-output-allocator). This pass
+  //    is scoped to the private loop bodies (modifyPublicFunctions = false) and
+  //    must run before buffer-deallocation.
   pm.addPass(hip::createLoopBodyToOutParamsPass());
 
   // 4. Insert ownership-based buffer deallocation
   bufferization::BufferDeallocationPipelineOptions deallocOpts;
   bufferization::buildBufferDeallocationPipeline(pm, deallocOpts);
 
-  // 4.5. Allocator pipeline only: hip-use-output-allocator (FuncOp) rewrites
-  //      each returned `memref.alloc` into `hip.alloc_output` (EP-owned,
-  //      allocated in-graph at runtime via the output-allocator callback) and
-  //      stamps the `hipdnn.use_output_allocator` module BoolAttr that
-  //      convert-hip-to-llvm + generate-interface read to select the allocator
-  //      ABI. Leaves the function signature + `return` intact.
+  // 4.5. hip-use-output-allocator (FuncOp) rewrites each returned
+  //      `memref.alloc` into `hip.alloc_output` (EP-owned, allocated in-graph
+  //      at runtime via the output-allocator callback). Leaves the function
+  //      signature + `return` intact.
   //
   //      Ordering is load-bearing -- the rewrite MUST run AFTER buffer-
   //      deallocation: `hip.alloc_output` has a Write effect but NO Allocate
@@ -148,8 +131,7 @@ static void buildOnnxToHipPipelineTail(OpPassManager &pm,
   //      pool-allocs (slot 6) so the EP-owned output never enters the GPU pool,
   //      which only absorbs `memref.alloc`. Verified by test/lit/Pipeline/
   //      output-allocator-dealloc.mlir (both orderings).
-  if (useOutputAllocator)
-    pm.addNestedPass<func::FuncOp>(hip::createUseOutputAllocatorPass());
+  pm.addNestedPass<func::FuncOp>(hip::createUseOutputAllocatorPass());
 
   // 4.6. Rewrite frozen Concat-accumulator offsets in outlined hip.loop bodies
   //      to iter-driven offsets (the loop trampoline aliases v_in/v_out onto
@@ -305,7 +287,7 @@ void mlir::hip::buildOnnxToHipPipeline(OpPassManager &pm,
     pm.addPass(createConvertOnnxToHipPass(std::move(onnxToHipOpts)));
   }
 
-  buildOnnxToHipPipelineTail(pm, options.useOutputAllocator);
+  buildOnnxToHipPipelineTail(pm);
 }
 
 void mlir::hip::buildOnnxToHipPipeline(OpPassManager &pm,
@@ -334,7 +316,7 @@ void mlir::hip::buildOnnxToHipPipeline(OpPassManager &pm,
     pm.addPass(createConvertOnnxToHipPass(std::move(onnxToHipOpts)));
   }
 
-  buildOnnxToHipPipelineTail(pm, options.useOutputAllocator);
+  buildOnnxToHipPipelineTail(pm);
 }
 
 void mlir::hip::buildHipToLLVMPipeline(
@@ -386,11 +368,10 @@ void mlir::hip::buildHipToLLVMPipeline(
 
   mlir::hip::CompilationOptionsT compOpts;
   compOpts.constants_file = options.constantsFile;
-  // Both convert-hip-to-llvm (above) and generate-interface read the
-  // `hipdnn.use_output_allocator` module attribute (set by
-  // hip-use-output-allocator in the ONNX-to-HIP half) to choose the 2-arg
-  // allocator vs 3-arg classic ABI. No pipeline option is needed here -- one
-  // generator handles both modes.
+  // convert-hip-to-llvm (above) rewrites @main_graph to the 2-arg
+  // (ctx, inputs) form; generate-interface emits the matching 2-arg
+  // inference_compute. Outputs are allocated inside the graph via
+  // hip.alloc_output. This is the only ABI.
   pm.addPass(createGenerateInterfacePass(compOpts));
 }
 
@@ -399,12 +380,6 @@ void mlir::hip::buildHipdnnPipeline(OpPassManager &pm,
   OnnxToHipPipelineOptions onnxOpts;
   onnxOpts.externalizeOutputDir = options.constantsDir;
   onnxOpts.externalizeMinNumElements = options.externalizeMinNumElements;
-  // Only the ONNX-to-HIP half consumes the flag: it picks slot-3
-  // buffer-results-to-out-params (classic) vs the slot-4.5
-  // hip-use-output-allocator pass, which stamps the
-  // `hipdnn.use_output_allocator` module attr. The HIP-to-LLVM half reads that
-  // attr, so it needs no option of its own.
-  onnxOpts.useOutputAllocator = options.useOutputAllocator;
   buildOnnxToHipPipeline(pm, onnxOpts);
 
   HipToLLVMPipelineOptions llvmOpts;

--- a/lib/Dialect/Transforms/UseOutputAllocator.cpp
+++ b/lib/Dialect/Transforms/UseOutputAllocator.cpp
@@ -26,17 +26,6 @@
 // `func.return` terminator are intentionally NOT modified -- `convert-hip-to-
 // llvm` synthesizes the `-> i32` entry wrapper in a later phase.
 //
-// The pass also stamps `hipdnn.use_output_allocator = true` on the parent
-// module -- the marker that later phases (`convert-hip-to-llvm`,
-// `generate-interface`) read to select the allocator ABI. It is a typed bool,
-// not a presence-only UnitAttr, so readers test the VALUE (absence and
-// `= false` both mean classic). The stamp is UNCONDITIONAL -- mode is decided
-// by this pass running (it is scheduled only in allocator mode), not by whether
-// a returned alloc was found, so a zero-output graph is still marked. A FuncOp
-// pass writing its parent module relaxes MLIR's pass-isolation contract; safe
-// here because it is an idempotent set of the same value (same precedent as
-// PoolAllocs stamping hipdnn.pool_size).
-//
 // Before:
 //   func.func @main_graph(%ctx: !hip.context, ...) -> memref<?x?xf16> {
 //     %out = memref.alloc(%M, %N) : memref<?x?xf16>      // returned output
@@ -45,13 +34,11 @@
 //   }
 //
 // After:
-//   module attributes {hipdnn.use_output_allocator = true} {
-//     func.func @main_graph(%ctx: !hip.context, ...) -> memref<?x?xf16> {
-//       %out = hip.alloc_output(%ctx, %M, %N) {out_idx = 0 : i64}
-//            : memref<?x?xf16>                            // EP-owned output
-//       hip.sigmoid(%ctx) ins(%t) outs(%out)
-//       return %out : memref<?x?xf16>
-//     }
+//   func.func @main_graph(%ctx: !hip.context, ...) -> memref<?x?xf16> {
+//     %out = hip.alloc_output(%ctx, %M, %N) {out_idx = 0 : i64}
+//          : memref<?x?xf16>                            // EP-owned output
+//     hip.sigmoid(%ctx) ins(%t) outs(%out)
+//     return %out : memref<?x?xf16>
 //   }
 //
 //===----------------------------------------------------------------------===//
@@ -157,14 +144,6 @@ struct UseOutputAllocatorPass
     patterns.add<ReplaceOutputAllocPattern>(&getContext());
     if (failed(applyPatternsGreedily(getOperation(), std::move(patterns))))
       signalPassFailure();
-
-    // Stamp the allocator-mode marker (typed bool, value = true) on the parent
-    // module. UNCONDITIONAL -- see the file header for why this must run even
-    // when nothing was rewritten. Readers test the value, so absence and
-    // `= false` both read as classic mode.
-    if (auto module = getOperation()->getParentOfType<ModuleOp>())
-      module->setAttr("hipdnn.use_output_allocator",
-                      BoolAttr::get(&getContext(), true));
   }
 };
 

--- a/schemas/compilation_options.fbs
+++ b/schemas/compilation_options.fbs
@@ -14,10 +14,6 @@ table CompilationOptions {
   verbose: bool = false;
   constants_file: string = "constants.bin";
   skip_constant_data: bool = false;
-  // When true, compile in output-allocator mode: graph outputs are allocated
-  // in-graph via hip.alloc_output and inference_compute takes (state, inputs)
-  // only (no out-param span). Default off keeps the classic 3-arg ABI.
-  use_output_allocator: bool = false;
 }
 
 root_type CompilationOptions;

--- a/test/lit/Conversion/hip-to-llvm/test_main_graph_param_mismatch.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_main_graph_param_mismatch.mlir
@@ -3,26 +3,19 @@
 //
 // ============================================================================
 // TEST: convert-hip-to-llvm's transformMainFunction rejects a @main_graph whose
-// post-lowering parameter count does not match the ABI selected by the
-// `hipdnn.use_output_allocator` module attribute.
+// post-lowering parameter count does not match the output-allocator ABI.
 //
-// Mode is chosen by the attribute's VALUE (set by hip-use-output-allocator),
-// NOT by param count. The expected count for the chosen mode is:
-//   expectedAllocator = 1 + sum_inputs(3 + 2*rank)            (context + inputs)
-//   expectedClassic   = expectedAllocator + sum_outputs(3 + 2*rank)
+// The expected count is context + inputs only (outputs are allocated in-graph):
+//   expected = 1 + sum_inputs(3 + 2*rank)
 //
-// Here: 1 input of rank 2 => expectedAllocator = 1 + (3 + 4) = 8;
-//       1 output of rank 2 => expectedClassic = 8 + (3 + 4) = 15.
-// @main_graph below has 5 params (neither), so the pass must emit a precise,
-// MODE-SPECIFIC mismatch diagnostic and fail rather than silently mis-wrapping.
-// Two modules (split-input-file) pin both diagnostics: classic (attr absent) and
-// allocator (attr = true).
+// Here: 1 input of rank 2 => expected = 1 + (3 + 4) = 8.
+// @main_graph below has 5 params, so the pass must emit a precise mismatch
+// diagnostic and fail rather than silently mis-wrapping.
 // ============================================================================
 
-// RUN: not hip-mlir-opt --convert-hip-to-llvm -split-input-file %s 2>&1 | FileCheck %s
+// RUN: not hip-mlir-opt --convert-hip-to-llvm %s 2>&1 | FileCheck %s
 
-// --- Classic (no hipdnn.use_output_allocator attr): expected = expectedClassic. ---
-// CHECK: @main_graph parameter count mismatch: expected 15 (classic), got 5
+// CHECK: @main_graph parameter count mismatch: expected 8, got 5
 module attributes {
   hipdnn.input_count = 1 : i64,
   hipdnn.input_shapes = [array<i64: 1, 4>],
@@ -30,43 +23,7 @@ module attributes {
   hipdnn.output_shapes = [array<i64: 1, 4>]
 } {
   // Already LLVM dialect: applyPartialConversion is a no-op, so transformMain
-  // sees this signature verbatim. 5 params != 15 (classic).
-  llvm.func @main_graph(%a: !llvm.ptr, %b: !llvm.ptr, %c: i64, %d: i64, %e: i64) -> i32 {
-    %0 = llvm.mlir.constant(0 : i32) : i32
-    llvm.return %0 : i32
-  }
-}
-
-// -----
-
-// --- Allocator (hipdnn.use_output_allocator = true): expected = expectedAllocator. ---
-// CHECK: @main_graph parameter count mismatch: expected 8 (allocator), got 5
-module attributes {
-  hipdnn.use_output_allocator = true,
-  hipdnn.input_count = 1 : i64,
-  hipdnn.input_shapes = [array<i64: 1, 4>],
-  hipdnn.output_count = 1 : i64,
-  hipdnn.output_shapes = [array<i64: 1, 4>]
-} {
-  // Same 5-param signature; allocator mode expects 8 (context + 1 rank-2 input).
-  llvm.func @main_graph(%a: !llvm.ptr, %b: !llvm.ptr, %c: i64, %d: i64, %e: i64) -> i32 {
-    %0 = llvm.mlir.constant(0 : i32) : i32
-    llvm.return %0 : i32
-  }
-}
-
-// -----
-
-// --- Attr PRESENT but = false: classic mode (proves readers test the value,
-//     not mere presence). expected = expectedClassic (15), same as attr-absent. ---
-// CHECK: @main_graph parameter count mismatch: expected 15 (classic), got 5
-module attributes {
-  hipdnn.use_output_allocator = false,
-  hipdnn.input_count = 1 : i64,
-  hipdnn.input_shapes = [array<i64: 1, 4>],
-  hipdnn.output_count = 1 : i64,
-  hipdnn.output_shapes = [array<i64: 1, 4>]
-} {
+  // sees this signature verbatim. 5 params != 8 (context + 1 rank-2 input).
   llvm.func @main_graph(%a: !llvm.ptr, %b: !llvm.ptr, %c: i64, %d: i64, %e: i64) -> i32 {
     %0 = llvm.mlir.constant(0 : i32) : i32
     llvm.return %0 : i32

--- a/test/lit/Dialect/hip-use-output-allocator.mlir
+++ b/test/lit/Dialect/hip-use-output-allocator.mlir
@@ -8,16 +8,9 @@
 // returned by func.return) into hip.alloc_output, reusing the alloc's dynamic
 // sizes and setting out_idx to the return position, while leaving intermediates,
 // passthrough outputs, private helpers, and context-less functions untouched.
-// The pass also stamps the hipdnn.use_output_allocator BoolAttr (= true) on the
-// enclosing module -- the allocator-mode marker that convert-hip-to-llvm and
-// generate-interface read by value.
 //===----------------------------------------------------------------------===//
 
 // RUN: hip-mlir-opt --hip-use-output-allocator %s 2>&1 | FileCheck %s
-
-// The module-level allocator-mode marker is stamped as a typed bool (= true),
-// not a presence-only unit attr, so downstream readers can test its value.
-// CHECK: module attributes {hipdnn.use_output_allocator = true}
 
 // --- Dynamic-shape output: replaced, reusing the alloc's %M, %N. ---
 // CHECK-LABEL: func.func @dynamic_output

--- a/test/lit/Transforms/GenerateInterface/test_basic_interface.mlir
+++ b/test/lit/Transforms/GenerateInterface/test_basic_interface.mlir
@@ -4,16 +4,19 @@
 // ============================================================================
 // TEST: GenerateInterface pass creates C-ABI wrapper functions.
 //
-// Input: HIP dialect IR with @main_graph using !hip.context and memref types.
+// Input: HIP dialect IR with an output-allocator @main_graph using
+// !hip.context and memref types. Outputs are allocated in-graph via
+// hip.alloc_output (2-arg ABI); there are no output out-params.
 // The hip-to-llvm-pipeline lowers this through:
 //   1. convert-hip-to-llvm (func/memref → LLVM, transformMainFunction wraps
-//      the expanded memref signature back to 3-pointer C ABI)
+//      the expanded memref signature to the 2-pointer (ctx, inputs) C ABI)
 //   2. generate-interface (creates inference_init/compute/cleanup wrappers)
 //
 // Verifies:
 //   1. Four wrapper functions are generated.
 //   2. inference_init calls hipdnn_ep_state_init_with_fs.
-//   3. inference_compute calls tensor prepare / main_graph / finalize.
+//   3. inference_compute stages inputs and calls main_graph (outputs
+//      allocated in-graph).
 //   4. inference_cleanup calls hipdnn_ep_state_cleanup.
 //   5. Metadata blob is embedded as a global constant.
 // ============================================================================
@@ -28,13 +31,11 @@
 // CHECK-SAME:  -> i32
 // CHECK:   llvm.call @hipdnn_ep_state_init_with_fs
 
-// --- inference_compute calls tensor helpers and main_graph ---
+// --- inference_compute stages inputs and calls main_graph (2-arg ABI) ---
 // CHECK-LABEL: llvm.func @inference_compute
 // CHECK-SAME:  -> i32
 // CHECK:   llvm.call @hipdnn_ep_tensor_prepare_input
-// CHECK:   llvm.call @hipdnn_ep_tensor_prepare_output
 // CHECK:   llvm.call @main_graph
-// CHECK:   llvm.call @hipdnn_ep_tensor_finalize_output
 // CHECK:   llvm.call @hipdnn_ep_stream_sync
 // CHECK:   llvm.call @hipdnn_ep_state_read_and_clear_error_flag
 
@@ -59,9 +60,8 @@ module attributes {
   hipdnn.buffer_count = 0 : i64
 } {
   func.func @main_graph(%ctx: !hip.context,
-                        %in: memref<8xf32>,
-                        %out: memref<8xf32>) -> i32 {
-    %zero = arith.constant 0 : i32
-    return %zero : i32
+                        %in: memref<8xf32>) -> memref<8xf32> {
+    %out = hip.alloc_output(%ctx) {out_idx = 0 : i64} : memref<8xf32>
+    return %out : memref<8xf32>
   }
 }

--- a/test/lit/e2e/test_gqa_model.mlir
+++ b/test/lit/e2e/test_gqa_model.mlir
@@ -13,7 +13,7 @@
 // CHECK-SAME: hipdnn.input_count = 7
 // CHECK-SAME: hipdnn.output_count = 3
 // CHECK: llvm.func @wrap_group_query_attention
-// CHECK: llvm.func private @main_graph(%{{.*}}: !llvm.ptr, %{{.*}}: !llvm.ptr, %{{.*}}: !llvm.ptr) -> i32
+// CHECK: llvm.func private @main_graph(%{{.*}}: !llvm.ptr, %{{.*}}: !llvm.ptr) -> i32
 // CHECK: llvm.call @wrap_group_query_attention
 // CHECK: llvm.func @inference_init
 // CHECK: llvm.func @inference_compute

--- a/test/lit/e2e/test_gqa_output_allocator_present_dim.mlir
+++ b/test/lit/e2e/test_gqa_output_allocator_present_dim.mlir
@@ -16,10 +16,8 @@
 // past_key_values input.
 //===----------------------------------------------------------------------===//
 
-// RUN: hip-mlir-opt %s --onnx-to-hip-pipeline=use-output-allocator=true 2>&1 | FileCheck %s
+// RUN: hip-mlir-opt %s --onnx-to-hip-pipeline 2>&1 | FileCheck %s
 
-// CHECK: module attributes {
-// CHECK-SAME: hipdnn.use_output_allocator = true
 // CHECK-LABEL: func.func @main_graph
 // CHECK-SAME:    %[[PK:[a-zA-Z0-9_]+]]: memref<1x8x?x128xf16> {onnx.name = "past_key_values.0.key"}
 // CHECK-SAME:    %[[PV:[a-zA-Z0-9_]+]]: memref<1x8x?x128xf16> {onnx.name = "past_key_values.0.value"}

--- a/test/lit/e2e/test_linear_attention_model.mlir
+++ b/test/lit/e2e/test_linear_attention_model.mlir
@@ -34,7 +34,7 @@
 // CHECK-SAME: hipdnn.input_count = 6
 // CHECK-SAME: hipdnn.output_count = 2
 // CHECK: llvm.func @wrap_linear_attention
-// CHECK: llvm.func private @main_graph(%{{.*}}: !llvm.ptr, %{{.*}}: !llvm.ptr, %{{.*}}: !llvm.ptr) -> i32
+// CHECK: llvm.func private @main_graph(%{{.*}}: !llvm.ptr, %{{.*}}: !llvm.ptr) -> i32
 // CHECK: llvm.call @wrap_linear_attention
 // CHECK: llvm.func @inference_init
 // CHECK: llvm.func @inference_compute

--- a/test/lit/e2e/test_multi_head_attention_model.mlir
+++ b/test/lit/e2e/test_multi_head_attention_model.mlir
@@ -12,7 +12,7 @@
 // CHECK-SAME: hipdnn.input_count = 3
 // CHECK-SAME: hipdnn.output_count = 1
 // CHECK: llvm.func @wrap_multi_head_attention
-// CHECK: llvm.func private @main_graph(%{{.*}}: !llvm.ptr, %{{.*}}: !llvm.ptr, %{{.*}}: !llvm.ptr) -> i32
+// CHECK: llvm.func private @main_graph(%{{.*}}: !llvm.ptr, %{{.*}}: !llvm.ptr) -> i32
 // CHECK: llvm.call @wrap_multi_head_attention
 // CHECK: llvm.func @inference_init
 // CHECK: llvm.func @inference_compute

--- a/test/lit/e2e/test_output_allocator_model.mlir
+++ b/test/lit/e2e/test_output_allocator_model.mlir
@@ -2,38 +2,21 @@
 // Licensed under the MIT License.
 //
 // ============================================================================
-// TEST: allocator vs classic output handling, end-to-end through
-// --hipdnn-pipeline on the same single-Sigmoid model.
+// TEST: output-allocator output handling, end-to-end through
+// --hipdnn-pipeline on a single-Sigmoid model.
 //
-// Allocator pipeline (use-output-allocator=true):
+// The output-allocator ABI is the only mode:
 //   - graph output is allocated in-graph: hip.alloc_output lowers to a
 //     llvm.call @hipdnn_ep_alloc_output (the EP output-allocator callback).
 //   - inference_compute has the 2-arg (state, inputs) ABI -- no outputs span.
-//   - NO output staging calls: prepare_output / finalize_output are skipped
-//     (the output buffer is EP-owned and written in place).
-//
-// Classic pipeline (default):
-//   - output is a caller-provided out-param: NO hipdnn_ep_alloc_output.
-//   - inference_compute has the 3-arg (state, inputs, outputs) ABI.
-//   - prepare_output + finalize_output calls stage the output buffer.
-//
-// The two modes are pinned against one input so the contrast cannot drift.
+//   - the output buffer is EP-owned and written in place (no output staging).
 // ============================================================================
 
-// RUN: hip-mlir-opt %s --hipdnn-pipeline='use-output-allocator=true' 2>&1 | FileCheck --check-prefix=ALLOC --implicit-check-not="llvm.call @hipdnn_ep_tensor_prepare_output" --implicit-check-not="llvm.call @hipdnn_ep_tensor_finalize_output" %s
-// RUN: hip-mlir-opt %s --hipdnn-pipeline 2>&1 | FileCheck --check-prefix=CLASSIC --implicit-check-not=hipdnn_ep_alloc_output --implicit-check-not=hipdnn.use_output_allocator %s
+// RUN: hip-mlir-opt %s --hipdnn-pipeline 2>&1 | FileCheck %s
 
-// --- Allocator: module attr (typed bool = true) is the single source of truth,
-//     then in-graph output allocation + 2-arg compute ABI. ---
-// ALLOC: hipdnn.use_output_allocator = true
-// ALLOC: llvm.call @hipdnn_ep_alloc_output
-// ALLOC: llvm.func @inference_compute(%{{[a-zA-Z0-9_]+}}: !llvm.ptr, %{{[a-zA-Z0-9_]+}}: !llvm.ptr) -> i32
-
-// --- Classic: NO module attr (implicit-check-not above), out-param 3-arg
-//     compute ABI + output staging calls. ---
-// CLASSIC: llvm.func @inference_compute(%{{[a-zA-Z0-9_]+}}: !llvm.ptr, %{{[a-zA-Z0-9_]+}}: !llvm.ptr, %{{[a-zA-Z0-9_]+}}: !llvm.ptr) -> i32
-// CLASSIC: llvm.call @hipdnn_ep_tensor_prepare_output
-// CLASSIC: llvm.call @hipdnn_ep_tensor_finalize_output
+// In-graph output allocation + 2-arg compute ABI.
+// CHECK: llvm.call @hipdnn_ep_alloc_output
+// CHECK: llvm.func @inference_compute(%{{[a-zA-Z0-9_]+}}: !llvm.ptr, %{{[a-zA-Z0-9_]+}}: !llvm.ptr) -> i32
 
 module {
   func.func @main_graph(%arg0: tensor<4x8xf16> {onnx.name = "input"}) -> (tensor<4x8xf16> {onnx.name = "output"}) {

--- a/test/lit/e2e/test_split_model.mlir
+++ b/test/lit/e2e/test_split_model.mlir
@@ -68,8 +68,7 @@ module {
 // CHECK: llvm.call @hipdnn_ep_state_init_with_fs
 // CHECK-LABEL: llvm.func @inference_compute
 // CHECK: llvm.call @hipdnn_ep_tensor_prepare_input
-// CHECK: llvm.call @hipdnn_ep_tensor_prepare_output
-// CHECK: llvm.call @hipdnn_ep_tensor_finalize_output
+// Outputs are allocated in-graph (2-arg ABI, no output staging).
 // CHECK-LABEL: llvm.func @inference_cleanup
 // CHECK: llvm.call @hipdnn_ep_state_cleanup
 // CHECK-LABEL: llvm.func @inference_get_metadata_json

--- a/tools/hip-test/CMakeLists.txt
+++ b/tools/hip-test/CMakeLists.txt
@@ -45,6 +45,10 @@ endif()
 if(NOT BUILD_MOCK_RUNTIME)
   find_package(hip CONFIG REQUIRED)
   target_link_libraries(hip-test PRIVATE hip::host)
+  # Signals the output-allocator callback to hand the model.dll real device
+  # memory (hipMalloc) and copy it back D2H for validation. Mock builds omit
+  # this and the callback returns host buffers the CPU stubs write directly.
+  target_compile_definitions(hip-test PRIVATE HIPDNN_EP_LINK_HIP_HOST=1)
 endif()
 
 target_include_directories(hip-test

--- a/tools/hip-test/hip-test.cpp
+++ b/tools/hip-test/hip-test.cpp
@@ -13,6 +13,13 @@
 #include "hip/Support/DiskFileSystem.h"
 #include "hip/artifact_abi.h" // hipdnn::abi symbol names
 #include <memory>
+// On real (GPU) builds we link hip::host so the output-allocator callback can
+// give the model a real device buffer and copy it back to host for validation
+// (same as the EP's callback). Mock builds use CPU stubs that write host memory
+// directly, so the callback just returns a host buffer -- no HIP needed.
+#ifdef HIPDNN_EP_LINK_HIP_HOST
+#include <hip/hip_runtime.h>
+#endif
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4244) // Conversion warnings in LLVM JSON.h
@@ -66,6 +73,81 @@ typedef struct {
   tensor_t *data; // Array of tensors
   size_t count;   // Number of tensors
 } span_t;
+
+// Local mirror of `hipdnn_output_allocator_t` (lib/Runtime/hipdnn_ep_runtime.h)
+// / `output_allocator_t` (custom_op_mlir.hpp). Layout MUST match: the runtime
+// setter does a plain struct copy across the model.dll <-> caller boundary. See
+// those headers for the ABI contract.
+typedef struct {
+  void *self; // opaque caller context (borrowed; runtime never owns/frees)
+  void *(*allocate)(void *self, int64_t out_idx, const int64_t *shape,
+                    int64_t rank, int64_t elem_size);
+} output_allocator_t;
+
+static_assert(offsetof(output_allocator_t, self) == 0,
+              "output_allocator_t.self must remain the first field");
+
+// One graph output produced in-graph via hip.alloc_output -> the callback
+// below. Owns the buffer the model.dll writes into (device memory in real
+// builds, host memory in mock builds) plus a host-side copy used for
+// validation.
+struct OutputSlot {
+  std::vector<int64_t> shape;
+  size_t elem_size = 0;
+  size_t nbytes = 0;
+  std::vector<uint8_t> host; // validation copy (== the write buffer in mock)
+#ifdef HIPDNN_EP_LINK_HIP_HOST
+  void *gpu = nullptr; // device buffer the model.dll writes into
+#endif
+};
+
+// Context threaded through output_allocator_t.self. In allocator mode the DLL
+// calls back once per graph output (indexed by out_idx) as each output's shape
+// becomes known in-graph; we allocate a write buffer here and return it.
+struct OutputAllocatorCtx {
+  std::vector<OutputSlot> outs; // indexed by compiler-order out_idx
+};
+
+// output_allocator_t.allocate: allocate the buffer for graph output `out_idx`
+// at the DLL's in-graph shape and return the pointer the DLL writes into. On a
+// real build that must be device memory (the GPU kernels target it); on a mock
+// build a host buffer suffices. Never returns null (the DLL builds a memref
+// from the pointer -- a null would segfault with no diagnostic).
+static void *hip_test_allocate(void *self, int64_t out_idx,
+                               const int64_t *shape, int64_t rank,
+                               int64_t elem_size) {
+  auto *ctx = static_cast<OutputAllocatorCtx *>(self);
+  if (out_idx < 0) {
+    std::cerr << "ERROR: output allocator got negative out_idx " << out_idx
+              << "\n";
+    std::abort();
+  }
+  if (static_cast<size_t>(out_idx) >= ctx->outs.size())
+    ctx->outs.resize(static_cast<size_t>(out_idx) + 1);
+  OutputSlot &slot = ctx->outs[static_cast<size_t>(out_idx)];
+  slot.shape.assign(shape, shape + rank);
+  slot.elem_size = static_cast<size_t>(elem_size);
+  size_t nelem = 1;
+  for (int64_t i = 0; i < rank; ++i)
+    nelem *= static_cast<size_t>(shape[i]);
+  slot.nbytes = nelem * static_cast<size_t>(elem_size);
+  slot.host.assign(slot.nbytes, 0);
+#ifdef HIPDNN_EP_LINK_HIP_HOST
+  if (slot.gpu) {
+    (void)hipFree(slot.gpu);
+    slot.gpu = nullptr;
+  }
+  hipError_t e = hipMalloc(&slot.gpu, slot.nbytes ? slot.nbytes : 1);
+  if (e != hipSuccess || !slot.gpu) {
+    std::cerr << "ERROR: hipMalloc(" << slot.nbytes << ") for output "
+              << out_idx << " failed: " << hipGetErrorString(e) << "\n";
+    std::abort();
+  }
+  return slot.gpu;
+#else
+  return slot.host.data();
+#endif
+}
 
 // Parse --input-shape arguments: "0=8,3,224,224;1=8,512"
 std::map<int, std::vector<int64_t>>
@@ -343,18 +425,27 @@ int main(int argc, char **argv) {
 
   auto init_func =
       artifact->get_method<int, void **, void *>(hipdnn::abi::kInferenceInit);
-  auto compute_func = artifact->get_method<int, void *, void *, void *>(
-      hipdnn::abi::kInferenceCompute);
+  // Output-allocator ABI: 2-arg inference_compute(state, inputs). Graph outputs
+  // are allocated in-graph via the callback installed through
+  // hipdnn_ep_set_output_allocator -- there is no outputs span.
+  auto compute_func =
+      artifact->get_method<int, void *, void *>(hipdnn::abi::kInferenceCompute);
+  auto set_alloc_func =
+      artifact->get_method<void, void *, const output_allocator_t *>(
+          hipdnn::abi::kSetOutputAllocator);
   auto cleanup_func =
       artifact->get_method<int, void *>(hipdnn::abi::kInferenceCleanup);
   auto get_metadata_func = artifact->get_method<const char *>(
       hipdnn::abi::kInferenceGetMetadataJson);
 
-  if (!init_func || !compute_func || !cleanup_func || !get_metadata_func) {
+  if (!init_func || !compute_func || !set_alloc_func || !cleanup_func ||
+      !get_metadata_func) {
     std::cerr << "ERROR: Missing required interface functions\n";
     std::cerr << "  inference_init: " << (init_func ? "OK" : "MISSING") << "\n";
     std::cerr << "  inference_compute: " << (compute_func ? "OK" : "MISSING")
               << "\n";
+    std::cerr << "  hipdnn_ep_set_output_allocator: "
+              << (set_alloc_func ? "OK" : "MISSING") << "\n";
     std::cerr << "  inference_cleanup: " << (cleanup_func ? "OK" : "MISSING")
               << "\n";
     std::cerr << "  inference_get_metadata_json: "
@@ -405,31 +496,16 @@ int main(int argc, char **argv) {
     }
   }
 
-  // Prepare output shapes
-  std::vector<std::vector<int64_t>> output_shapes;
-  for (size_t i = 0; i < num_outputs; i++) {
-    std::vector<int64_t> shape = output_metas[i].shape;
-    resolveShape(shape);
-    output_shapes.push_back(shape);
+  // Output shapes are NOT pre-computed here: in output-allocator mode the
+  // model.dll sizes each graph output in-graph and requests its buffer via the
+  // callback below (hip_test_allocate), passing the concrete shape at that
+  // point. `output_metas` is still parsed above for the output count / logging.
 
-    if (verbose) {
-      std::cout << "  Output " << i << " shape: [";
-      for (size_t j = 0; j < shape.size(); j++) {
-        std::cout << shape[j];
-        if (j + 1 < shape.size())
-          std::cout << ", ";
-      }
-      std::cout << "]\n";
-    }
-  }
-
-  // Element sizes from metadata
+  // Element sizes from metadata (inputs only; output element sizes arrive via
+  // the allocator callback's elem_size argument).
   std::vector<size_t> input_elem_sizes;
   for (size_t i = 0; i < num_inputs; i++)
     input_elem_sizes.push_back(input_metas[i].element_size);
-  std::vector<size_t> output_elem_sizes;
-  for (size_t i = 0; i < num_outputs; i++)
-    output_elem_sizes.push_back(output_metas[i].element_size);
 
   // Allocate input buffers and generate test data
   std::vector<std::vector<uint8_t>> input_buffers;
@@ -456,29 +532,15 @@ int main(int argc, char **argv) {
   inputs_span.data = input_tensors.data();
   inputs_span.count = input_tensors.size();
 
-  // Allocate output buffers
-  std::vector<std::vector<uint8_t>> output_buffers;
-  std::vector<std::vector<int64_t>> output_shape_storage;
-  std::vector<tensor_t> output_tensors;
-  for (size_t i = 0; i < output_shapes.size(); i++) {
-    size_t count = elementCount(output_shapes[i]);
-    size_t sizeBytes = count * output_elem_sizes[i];
-    std::vector<uint8_t> buffer(sizeBytes);
-    output_buffers.push_back(std::move(buffer));
-    output_shape_storage.push_back(output_shapes[i]);
-
-    tensor_t tensor;
-    tensor.data = output_buffers.back().data();
-    tensor.shape = output_shape_storage.back().data();
-    tensor.rank = output_shape_storage.back().size();
-    tensor.element_size = output_elem_sizes[i];
-    tensor.memory_type = TENSOR_MEMORY_CPU; // host buffers, runtime does D2H
-    output_tensors.push_back(tensor);
-  }
-
-  span_t outputs_span;
-  outputs_span.data = output_tensors.data();
-  outputs_span.count = output_tensors.size();
+  // Output-allocator context: the model.dll's in-graph hip.alloc_output calls
+  // back through this to obtain each graph-output buffer once its shape is
+  // known. Reserve num_outputs slots up front so a graph that produces them out
+  // of order still lands each at its compiler-order index.
+  OutputAllocatorCtx octx;
+  octx.outs.resize(num_outputs);
+  output_allocator_t alloc;
+  alloc.self = &octx;
+  alloc.allocate = &hip_test_allocate;
 
   // Initialize inference context
   if (verbose)
@@ -493,15 +555,20 @@ int main(int argc, char **argv) {
     return 1;
   }
 
+  // Install the output allocator so the model.dll can request output buffers
+  // in-graph. Cleared after the run so a stale `self` can never be used.
+  set_alloc_func(state, &alloc);
+
   // Run inference
   if (verbose)
     std::cout << "Running inference (" << iterations << " iteration(s))...\n";
 
   for (int iter = 0; iter < iterations; iter++) {
-    ret = compute_func(state, &inputs_span, &outputs_span);
+    ret = compute_func(state, &inputs_span);
     if (ret != 0) {
       std::cerr << "ERROR: inference_compute failed with code " << ret
                 << " at iteration " << iter << "\n";
+      set_alloc_func(state, nullptr);
       cleanup_func(state);
       return 1;
     }
@@ -510,16 +577,54 @@ int main(int argc, char **argv) {
       std::cout << "  Iteration " << (iter + 1) << "/" << iterations << "\n";
   }
 
+  set_alloc_func(state, nullptr);
+
+  if (verbose) {
+    for (size_t i = 0; i < octx.outs.size(); i++) {
+      std::cout << "  Output " << i << " shape: [";
+      for (size_t j = 0; j < octx.outs[i].shape.size(); j++) {
+        std::cout << octx.outs[i].shape[j];
+        if (j + 1 < octx.outs[i].shape.size())
+          std::cout << ", ";
+      }
+      std::cout << "]\n";
+    }
+  }
+
+#ifdef HIPDNN_EP_LINK_HIP_HOST
+  // Copy each device output back into its host validation buffer. The 2-arg
+  // inference_compute already stream-synced, so a blocking hipMemcpy is safe.
+  for (auto &slot : octx.outs) {
+    if (!slot.gpu || slot.nbytes == 0)
+      continue;
+    hipError_t e = hipMemcpy(slot.host.data(), slot.gpu, slot.nbytes,
+                             hipMemcpyDeviceToHost);
+    if (e != hipSuccess) {
+      std::cerr << "ERROR: D2H copy of output failed: " << hipGetErrorString(e)
+                << "\n";
+      cleanup_func(state);
+      return 1;
+    }
+  }
+#endif
+
   // Validate outputs
   if (validate) {
     if (verbose)
       std::cout << "\nValidating outputs...\n";
     bool all_valid = true;
-    for (size_t i = 0; i < output_buffers.size(); i++) {
+    for (size_t i = 0; i < octx.outs.size(); i++) {
       if (verbose)
         std::cout << "Output " << i << ":\n";
-      if (!validateOutput(output_buffers[i].data(), output_buffers[i].size(),
-                          output_elem_sizes[i], verbose)) {
+      const OutputSlot &slot = octx.outs[i];
+      if (slot.elem_size == 0) {
+        std::cerr << "VALIDATION FAILED: output " << i
+                  << " was never produced by the model\n";
+        all_valid = false;
+        continue;
+      }
+      if (!validateOutput(slot.host.data(), slot.host.size(), slot.elem_size,
+                          verbose)) {
         all_valid = false;
       }
     }
@@ -540,6 +645,12 @@ int main(int argc, char **argv) {
   if (ret != 0) {
     std::cerr << "WARNING: inference_cleanup failed with code " << ret << "\n";
   }
+
+#ifdef HIPDNN_EP_LINK_HIP_HOST
+  for (auto &slot : octx.outs)
+    if (slot.gpu)
+      (void)hipFree(slot.gpu);
+#endif
 
   std::cout << "SUCCESS: Model executed successfully\n";
   return 0;


### PR DESCRIPTION
## Summary
**PR 1 of 2** in the output-allocator-only migration stack. Makes the output-allocator ABI the only compiled path.

- Pipeline runs `hip-use-output-allocator` unconditionally; `convert-hip-to-llvm` / `generate-interface` emit only the 2-arg `inference_compute(state, inputs)`. Classic 3-arg out-param codegen removed.
- Removes the compile-time `use_output_allocator` flag consumer wire (flatbuffer field, JSON writer, `CompilerDriver` option, pipeline option). The metadata flag + runtime dispatch are retired in #441.
- `UseOutputAllocator` change here is removal-only: it drops the now-dead `hipdnn.use_output_allocator` module-attribute stamp (the codegen halves no longer read any allocator attribute; they are unconditional). The returned-alloc -> `hip.alloc_output` rewrite is unchanged from `main`.
- `MemoryLowering`: `alloc_output` element size for sub-byte types (`i1`) now uses ceil-div bytes.
- `hip-test` migrated to a host-buffer allocator callback; LIT/e2e tests updated to the 2-arg ABI.

## Docs (co-located so this PR is self-consistent)
- `docs/technical-pipeline-walkthrough.md` and `docs/design/pool-allocs-memory-planning.md` updated to the allocator-only pipeline.

## Stack
1. **this PR (#440)**   compiler
2. #441   ep/runtime (delete dead classic dispatch, retire proto fields)

## Test plan
- [ ] CI green
- [x] `pre-commit run` clean
