### PR TITLE
refactor(compiler): trace returned buffers via alias analysis in hip-use-output-allocator

### DIFF
--- a/docs/design/output-allocator-design.md
+++ b/docs/design/output-allocator-design.md
@@ -95,7 +95,7 @@ Introduce `hip.alloc_output` — an operation that allocates output buffers via 
 
 **Placement in pipeline:** *after* `buffer-deallocation`, *before* `hip-pool-allocs` (so pooling skips the EP-owned buffer). `hip-use-output-allocator` is FuncOp-scoped: it rewrites returned allocs (leaving each signature + `return` intact). The after-dealloc order is load-bearing — see [§2](#the-pipeline).
 
-The `hip-use-output-allocator` pass replaces the returned `memref.alloc` for each graph output with `hip.alloc_output`, reusing the alloc's dynamic-size operands.
+The `hip-use-output-allocator` pass replaces the returned `memref.alloc` for each graph output with `hip.alloc_output`, reusing the alloc's dynamic-size operands. An alloc counts as a graph output when `func.return` hands it back — either directly, or after it passes through view ops (`memref.cast`, `memref.collapse_shape`, `memref.expand_shape`, `memref.subview`, any number of them). The pass uses `BufferViewFlowAnalysis` to check this: an alloc is an output if any value made from it via those view ops is returned. This handles reshaped / cast / subview'd outputs without special-casing each op, and the view ops between the alloc and the return are left in place.
 
 **Example: Add → MatMul → Sigmoid**
 

--- a/include/hip/Dialect/Transforms/Passes.td
+++ b/include/hip/Dialect/Transforms/Passes.td
@@ -561,17 +561,23 @@ def UseOutputAllocatorPass
     : Pass<"hip-use-output-allocator", "mlir::func::FuncOp"> {
   let summary = "Rewrite returned memref.alloc outputs to hip.alloc_output";
   let description = [{
-    Replaces each graph-output memref.alloc (a value returned by func.return)
-    with hip.alloc_output, reusing the alloc's dynamic-size operands and setting
-    out_idx to the return operand position.  Output buffers are then obtained
-    from the EP output allocator (EP/runtime-owned) instead of being deallocated
-    or pooled.
+    Replaces each graph-output memref.alloc with hip.alloc_output, reusing the
+    alloc's dynamic-size operands and setting out_idx to its position in
+    func.return.  Output buffers then come from the EP output allocator (the EP
+    owns and frees them) instead of being deallocated or pooled.
 
-    Scope: only public (graph-entry) functions are rewritten.  Private helpers
-    (e.g. outlined onnx.Loop bodies) carry a !hip.context arg 0 and return
-    memref.allocs too, but their results are DLL-internal, never EP outputs, so
-    they are left unchanged.  Functions lacking !hip.context as argument 0 are
-    likewise skipped.
+    An alloc counts as a graph output when func.return hands it back -- either
+    directly, or after it passes through view ops (memref.cast,
+    memref.collapse_shape, memref.expand_shape, memref.subview, any number of
+    them).  The pass uses BufferViewFlowAnalysis to check this: an alloc is an
+    output if any value made from it via those view ops is returned.  This
+    handles reshaped / cast / subview'd outputs without special-casing each op.
+    The view ops between the alloc and the return are left in place.
+
+    Only public (graph-entry) functions are rewritten.  Private helpers (e.g.
+    outlined onnx.Loop bodies) also take a !hip.context arg and return allocs,
+    but those buffers stay inside the DLL and are not EP outputs, so they are
+    left unchanged.  Functions whose arg 0 is not !hip.context are skipped too.
 
     Leaves the function signature and func.return untouched.
   }];

--- a/lib/Dialect/Transforms/UseOutputAllocator.cpp
+++ b/lib/Dialect/Transforms/UseOutputAllocator.cpp
@@ -4,27 +4,36 @@
  */
 //===- UseOutputAllocator.cpp - returned allocs -> hip.alloc_output -------===//
 //
-// Rewrites each graph-output `memref.alloc` (a buffer returned by func.return,
-// directly or through a single shape-adjusting `memref.cast`) into a
-// `hip.alloc_output`, so output buffers are obtained from the EP output
-// allocator (EP/runtime-owned) instead of being deallocated / pooled like
-// intermediates. `out_idx` is the operand position in func.return (= graph
-// output index); the alloc's dynamic-size operands are reused verbatim. When
-// the buffer is returned through a `memref.cast` (the cast widens an
-// in-graph-static dim back to the ONNX-declared dynamic output dim), the cast
-// is left in place feeding the return; only the alloc becomes alloc_output.
+// Turns each graph-output `memref.alloc` into a `hip.alloc_output`. A graph
+// output is a buffer that func.return hands back -- either the alloc directly,
+// or the alloc after it goes through view ops like `memref.cast`,
+// `memref.collapse_shape`, `memref.expand_shape`, or `memref.subview` (any
+// number of them, in any order). `hip.alloc_output` gets its buffer from the
+// EP's output allocator, so the EP owns and frees it. Allocs that are NOT
+// returned are left alone and get freed / pooled later like normal temporaries.
 //
-// Scope: ONLY public (graph-entry) functions are rewritten. Private helpers --
-// e.g. outlined `onnx.Loop` bodies -- also carry a `!hip.context` arg 0 and
-// return `memref.alloc`s, but their results are DLL-internal, never EP outputs;
-// rewriting them would emit an `out_idx` colliding with the real graph outputs.
-// Functions lacking `!hip.context` as argument 0 are likewise skipped (no
-// runtime handle to build the new op). Intermediates (allocs NOT returned) and
-// true passthrough outputs (returns whose value traces to neither a
-// memref.alloc nor a memref.cast-of-alloc, e.g. block args / views) are left
-// untouched. The function signature and the
-// `func.return` terminator are intentionally NOT modified -- `convert-hip-to-
-// llvm` synthesizes the `-> i32` entry wrapper in a later phase.
+// For each matching alloc the rewrite:
+//   - sets `out_idx` to its position in func.return (the graph output index),
+//   - reuses the alloc's dynamic-size operands unchanged,
+//   - deletes any `memref.dealloc` of it (the EP frees it, not us),
+//   - leaves the view ops in place -- only the alloc op itself changes.
+//
+// How outputs are found. Rather than listing every view op by hand, the pass
+// asks `BufferViewFlowAnalysis` one question per alloc: does any value derived
+// from the alloc (through any chain of view ops) show up in func.return? That
+// covers every case with no per-op special-casing -- a direct return, a single
+// `memref.cast`, or a reshaped output such as a rank-4 conv result collapsed to
+// rank-2 before the return.
+//
+// Only public (graph-entry) functions are rewritten. Private helpers (e.g.
+// outlined `onnx.Loop` bodies) also take a `!hip.context` arg and return
+// allocs, but those buffers stay inside the DLL and are not EP outputs --
+// rewriting them would hand out an `out_idx` that clashes with the real
+// outputs. Functions whose arg 0 is not `!hip.context` are skipped too (no
+// runtime handle to pass to the new op). Pass-through outputs (a returned value
+// that comes from a block argument or a view of an input, not from an alloc)
+// are left alone. The function signature and the func.return are not touched
+// here -- `convert-hip-to-llvm` builds the `-> i32` entry wrapper later.
 //
 // Before:
 //   func.func @main_graph(%ctx: !hip.context, ...) -> memref<?x?xf16> {
@@ -46,12 +55,11 @@
 #include "hip/Dialect/IR/HipDialect.h"
 #include "hip/Dialect/Transforms/Passes.h"
 
+#include "mlir/Dialect/Bufferization/Transforms/BufferViewFlowAnalysis.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
-#include "mlir/IR/PatternMatch.h"
-#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #include "llvm/ADT/STLExtras.h"
 
@@ -65,85 +73,76 @@ namespace hip {
 
 namespace {
 
-// Rewrites a returned `memref.alloc` (in a public function with a
-// `!hip.context` arg 0) into a `hip.alloc_output`, dropping any dealloc of the
-// buffer (the EP owns it). An alloc returned at more than one operand position
-// (aliased multi-output) matches once and is rewritten with its FIRST return
-// index -- the one-match-per-alloc structure of the pattern is what dedupes it.
-struct ReplaceOutputAllocPattern : public OpRewritePattern<memref::AllocOp> {
-  using OpRewritePattern::OpRewritePattern;
+struct UseOutputAllocatorPass
+    : impl::UseOutputAllocatorPassBase<UseOutputAllocatorPass> {
 
-  LogicalResult matchAndRewrite(memref::AllocOp allocOp,
-                                PatternRewriter &rewriter) const override {
-    // Find if this alloc is returned (graph output) and at which index. The
-    // buffer may be returned DIRECTLY, or through a single `memref.cast` that
-    // adjusts the static/dynamic-ness of a dim to match the declared output
-    // type (e.g. a matmul whose middle dim is statically known by in-graph
-    // shape inference, `memref<?x256x2560>`, returned as the ONNX-declared
-    // `memref<?x?x2560>`). The cast is a pure descriptor reinterpretation, so
-    // the alloc is still the real graph-output buffer and must become a
-    // `hip.alloc_output`; otherwise the buffer is pooled/deallocated and the
-    // EP's allocator callback is never invoked for that output (runtime FATAL:
-    // "output ... was never allocated by the model.dll").
-    func::ReturnOp returnOp = nullptr;
-    int64_t outIdx = -1;
-    for (OpOperand &use : allocOp->getUses()) {
-      Operation *owner = use.getOwner();
-      if (auto ret = dyn_cast<func::ReturnOp>(owner)) {
-        returnOp = ret;
-        outIdx = use.getOperandNumber();
-        break; // first occurrence (aliased outputs share one rewrite)
-      }
-      if (auto castOp = dyn_cast<memref::CastOp>(owner)) {
-        for (OpOperand &castUse : castOp->getUses()) {
-          if (auto ret = dyn_cast<func::ReturnOp>(castUse.getOwner())) {
-            returnOp = ret;
-            outIdx = castUse.getOperandNumber();
-            break;
-          }
-        }
-        if (returnOp)
-          break;
-      }
-    }
-    if (!returnOp)
-      return failure(); // not a graph output
+  void getDependentDialects(DialectRegistry &registry) const override {
+    // The pass creates hip.alloc_output (HipDialect). BufferViewFlowAnalysis
+    // follows the memref view ops (cast, collapse_shape, expand_shape, subview)
+    // through their ViewLikeOpInterface, which MemRefDialect provides.
+    registry.insert<hip::HipDialect, memref::MemRefDialect>();
+  }
 
-    auto func = allocOp->getParentOfType<func::FuncOp>();
+  void runOnOperation() override {
+    func::FuncOp funcOp = getOperation();
+
     // Only public (graph-entry) functions own EP outputs. Private helpers (e.g.
     // outlined onnx.Loop bodies) also carry a !hip.context arg 0 and return
     // memref.allocs, but their outputs are DLL-internal -> skip non-public.
-    if (!func || !func.isPublic())
-      return failure();
+    if (!funcOp.isPublic() || funcOp.empty())
+      return;
 
     // Need !hip.context arg 0 to build hip.alloc_output.
-    if (func.getNumArguments() == 0 ||
-        !isa<ContextType>(func.getArgument(0).getType()))
-      return failure();
-    Value ctx = func.getArgument(0);
+    if (funcOp.getNumArguments() == 0 ||
+        !isa<ContextType>(funcOp.getArgument(0).getType()))
+      return;
+    Value ctx = funcOp.getArgument(0);
 
-    // EP owns the buffer now; drop any dealloc (it references the alloc
-    // result).
-    for (Operation *user : llvm::make_early_inc_range(allocOp->getUsers()))
-      if (auto dealloc = dyn_cast<memref::DeallocOp>(user))
-        rewriter.eraseOp(dealloc);
+    // Build the alias analysis once for the whole function.
+    BufferViewFlowAnalysis aliasAnalysis(funcOp);
 
-    auto allocOutput = AllocOutputOp::create(
-        rewriter, allocOp.getLoc(), allocOp.getType(), ctx,
-        allocOp.getDynamicSizes(), rewriter.getI64IntegerAttr(outIdx));
+    // Phase 1 -- classify (analysis only, no IR mutation). For each alloc that
+    // is a graph output, record (alloc, out_idx). resolve() gives back the
+    // alloc plus every value derived from it through view ops (cast / collapse
+    // / expand / subview / ...), so a returned alloc is found even when it was
+    // reshaped on the way to the return. getOperandNumber() on a func.return
+    // use of any alias IS the graph output index; if the buffer is returned in
+    // more than one slot (aliased multi-output), take the first (lowest).
+    // Keeping every analysis query here -- before any rewrite -- means the
+    // analysis (which caches Value handles) is never read after the IR it
+    // describes has been mutated. Walk order is program order, so out_idx
+    // values print in order in phase 2.
+    SmallVector<std::pair<memref::AllocOp, int64_t>> outputs;
+    funcOp.walk([&](memref::AllocOp allocOp) {
+      int64_t outIdx = -1;
+      for (Value aliased : aliasAnalysis.resolve(allocOp.getResult()))
+        for (OpOperand &use : aliased.getUses())
+          if (isa<func::ReturnOp>(use.getOwner())) {
+            int64_t idx = static_cast<int64_t>(use.getOperandNumber());
+            if (outIdx < 0 || idx < outIdx)
+              outIdx = idx;
+          }
+      if (outIdx >= 0)
+        outputs.emplace_back(allocOp, outIdx);
+    });
 
-    rewriter.replaceOp(allocOp, allocOutput.getResult());
-    return success();
-  }
-};
+    // Phase 2 -- rewrite (IR mutation only; the analysis is no longer queried).
+    OpBuilder builder(funcOp.getContext());
+    for (auto [allocOp, outIdx] : outputs) {
+      // The EP owns this buffer now, so drop any dealloc of it. A returned
+      // buffer normally has none, but remove one if present -- the EP-owned
+      // output must never be freed by the graph.
+      for (Operation *user : llvm::make_early_inc_range(allocOp->getUsers()))
+        if (auto dealloc = dyn_cast<memref::DeallocOp>(user))
+          dealloc.erase();
 
-struct UseOutputAllocatorPass
-    : impl::UseOutputAllocatorPassBase<UseOutputAllocatorPass> {
-  void runOnOperation() override {
-    RewritePatternSet patterns(&getContext());
-    patterns.add<ReplaceOutputAllocPattern>(&getContext());
-    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns))))
-      signalPassFailure();
+      builder.setInsertionPoint(allocOp);
+      auto allocOutput = AllocOutputOp::create(
+          builder, allocOp.getLoc(), allocOp.getType(), ctx,
+          allocOp.getDynamicSizes(), builder.getI64IntegerAttr(outIdx));
+      allocOp.getResult().replaceAllUsesWith(allocOutput.getResult());
+      allocOp.erase();
+    }
   }
 };
 

--- a/test/lit/Dialect/hip-use-output-allocator.mlir
+++ b/test/lit/Dialect/hip-use-output-allocator.mlir
@@ -238,6 +238,28 @@ func.func @chain_output(%ctx: !hip.context) -> memref<?xf32> {
   return %cast : memref<?xf32>
 }
 
+// --- A longer 3-op view chain (collapse_shape -> expand_shape -> cast), mixing
+//     all three view-op kinds before the return: the root alloc is still
+//     converted exactly once, and the whole chain is left in place. Proves the
+//     alias analysis follows arbitrary-length chains, not just one or two ops. ---
+// CHECK-LABEL: func.func @long_chain_output
+// CHECK-SAME:    (%[[CTX:.*]]: !hip.context)
+// CHECK-NOT:     memref.alloc
+// CHECK:         %[[OUT:.*]] = hip.alloc_output(%[[CTX]]) {out_idx = 0 : i64} : memref<2x4x8xf32>
+// CHECK:         %[[COL:.*]] = memref.collapse_shape %[[OUT]]
+// CHECK:         %[[EXP:.*]] = memref.expand_shape %[[COL]]
+// CHECK:         %[[CST:.*]] = memref.cast %[[EXP]]
+// CHECK:         return %[[CST]]
+func.func @long_chain_output(%ctx: !hip.context) -> memref<?x8xf32> {
+  %x = memref.alloc() : memref<2x4x8xf32>
+  %col = memref.collapse_shape %x [[0, 1, 2]]
+       : memref<2x4x8xf32> into memref<64xf32>
+  %exp = memref.expand_shape %col [[0, 1]] output_shape [8, 8]
+       : memref<64xf32> into memref<8x8xf32>
+  %cast = memref.cast %exp : memref<8x8xf32> to memref<?x8xf32>
+  return %cast : memref<?x8xf32>
+}
+
 // --- Output returned through memref.subview: the parent alloc becomes
 //     hip.alloc_output; the subview is left in place feeding the return. ---
 // CHECK-LABEL: func.func @subview_output

--- a/test/lit/Dialect/hip-use-output-allocator.mlir
+++ b/test/lit/Dialect/hip-use-output-allocator.mlir
@@ -186,3 +186,69 @@ func.func @return_order(%ctx: !hip.context, %M: index) -> (memref<4xf16>, memref
   %b = memref.alloc() : memref<4xf16>
   return %b, %a : memref<4xf16>, memref<?xf16>
 }
+
+// --- Output returned through memref.collapse_shape: the alloc still becomes
+//     hip.alloc_output, and the collapse_shape stays in place feeding the
+//     return. Models a reshaped output such as a rank-4 conv result flattened
+//     to rank-2 before the return, so the buffer is owned by the EP rather than
+//     pooled. ---
+// CHECK-LABEL: func.func @collapse_output
+// CHECK-SAME:    (%[[CTX:.*]]: !hip.context)
+// CHECK-NOT:     memref.alloc
+// CHECK:         %[[OUT:.*]] = hip.alloc_output(%[[CTX]]) {out_idx = 0 : i64} : memref<1x64x56x56xf32>
+// CHECK:         %[[C:.*]] = memref.collapse_shape %[[OUT]]
+// CHECK:         return %[[C]]
+func.func @collapse_output(%ctx: !hip.context) -> memref<1x200704xf32> {
+  %x = memref.alloc() : memref<1x64x56x56xf32>
+  %out = memref.collapse_shape %x [[0], [1, 2, 3]]
+       : memref<1x64x56x56xf32> into memref<1x200704xf32>
+  return %out : memref<1x200704xf32>
+}
+
+// --- Output returned through memref.expand_shape: handled the same way as
+//     collapse_shape (the analysis follows both). ---
+// CHECK-LABEL: func.func @expand_output
+// CHECK-SAME:    (%[[CTX:.*]]: !hip.context)
+// CHECK-NOT:     memref.alloc
+// CHECK:         %[[OUT:.*]] = hip.alloc_output(%[[CTX]]) {out_idx = 0 : i64} : memref<1x200704xf32>
+// CHECK:         %[[E:.*]] = memref.expand_shape %[[OUT]]
+// CHECK:         return %[[E]]
+func.func @expand_output(%ctx: !hip.context) -> memref<1x64x56x56xf32> {
+  %x = memref.alloc() : memref<1x200704xf32>
+  %out = memref.expand_shape %x [[0], [1, 2, 3]]
+       output_shape [1, 64, 56, 56]
+       : memref<1x200704xf32> into memref<1x64x56x56xf32>
+  return %out : memref<1x64x56x56xf32>
+}
+
+// --- A chain of view ops (collapse_shape -> cast) before the return: the alloc
+//     is still converted, exactly once. Shows that multi-op view chains are
+//     followed, not just a single view op. ---
+// CHECK-LABEL: func.func @chain_output
+// CHECK-NOT:     memref.alloc
+// CHECK:         %[[OUT:.*]] = hip.alloc_output(%{{.*}}) {out_idx = 0 : i64} : memref<2x4xf32>
+// CHECK:         %[[COL:.*]] = memref.collapse_shape %[[OUT]]
+// CHECK:         %[[CST:.*]] = memref.cast %[[COL]]
+// CHECK:         return %[[CST]]
+func.func @chain_output(%ctx: !hip.context) -> memref<?xf32> {
+  %x = memref.alloc() : memref<2x4xf32>
+  %col = memref.collapse_shape %x [[0, 1]]
+       : memref<2x4xf32> into memref<8xf32>
+  %cast = memref.cast %col : memref<8xf32> to memref<?xf32>
+  return %cast : memref<?xf32>
+}
+
+// --- Output returned through memref.subview: the parent alloc becomes
+//     hip.alloc_output; the subview is left in place feeding the return. ---
+// CHECK-LABEL: func.func @subview_output
+// CHECK-SAME:    (%[[CTX:.*]]: !hip.context)
+// CHECK-NOT:     memref.alloc
+// CHECK:         %[[OUT:.*]] = hip.alloc_output(%[[CTX]]) {out_idx = 0 : i64} : memref<4x8xf32>
+// CHECK:         %[[S:.*]] = memref.subview %[[OUT]]
+// CHECK:         return %[[S]]
+func.func @subview_output(%ctx: !hip.context) -> memref<2x4xf32, strided<[8, 1]>> {
+  %x = memref.alloc() : memref<4x8xf32>
+  %s = memref.subview %x[0, 0] [2, 4] [1, 1]
+     : memref<4x8xf32> to memref<2x4xf32, strided<[8, 1]>>
+  return %s : memref<2x4xf32, strided<[8, 1]>>
+}

--- a/test/lit/Dialect/hip-use-output-allocator.mlir
+++ b/test/lit/Dialect/hip-use-output-allocator.mlir
@@ -260,6 +260,36 @@ func.func @long_chain_output(%ctx: !hip.context) -> memref<?x8xf32> {
   return %cast : memref<?x8xf32>
 }
 
+// --- An even longer 5-op view chain exercising every view-op kind the analysis
+//     handles (collapse_shape -> collapse_shape -> expand_shape -> subview ->
+//     cast): the root alloc is still converted exactly once and the full chain
+//     is preserved. Stresses that the backward alias walk terminates correctly
+//     no matter how deep the view chain is. ---
+// CHECK-LABEL: func.func @longer_chain_output
+// CHECK-SAME:    (%[[CTX:.*]]: !hip.context)
+// CHECK-NOT:     memref.alloc
+// CHECK:         %[[OUT:.*]] = hip.alloc_output(%[[CTX]]) {out_idx = 0 : i64} : memref<2x4x8xf32>
+// CHECK:         %[[C1:.*]] = memref.collapse_shape %[[OUT]]
+// CHECK:         %[[C2:.*]] = memref.collapse_shape %[[C1]]
+// CHECK:         %[[E:.*]] = memref.expand_shape %[[C2]]
+// CHECK:         %[[S:.*]] = memref.subview %[[E]]
+// CHECK:         %[[CST:.*]] = memref.cast %[[S]]
+// CHECK:         return %[[CST]]
+func.func @longer_chain_output(%ctx: !hip.context) -> memref<?x8xf32, strided<[8, 1]>> {
+  %x = memref.alloc() : memref<2x4x8xf32>
+  %c1 = memref.collapse_shape %x [[0, 1], [2]]
+      : memref<2x4x8xf32> into memref<8x8xf32>
+  %c2 = memref.collapse_shape %c1 [[0, 1]]
+      : memref<8x8xf32> into memref<64xf32>
+  %e = memref.expand_shape %c2 [[0, 1]] output_shape [8, 8]
+     : memref<64xf32> into memref<8x8xf32>
+  %s = memref.subview %e[0, 0] [4, 8] [1, 1]
+     : memref<8x8xf32> to memref<4x8xf32, strided<[8, 1]>>
+  %cast = memref.cast %s
+        : memref<4x8xf32, strided<[8, 1]>> to memref<?x8xf32, strided<[8, 1]>>
+  return %cast : memref<?x8xf32, strided<[8, 1]>>
+}
+
 // --- Output returned through memref.subview: the parent alloc becomes
 //     hip.alloc_output; the subview is left in place feeding the return. ---
 // CHECK-LABEL: func.func @subview_output


### PR DESCRIPTION
## Summary

- Rework `hip-use-output-allocator` to decide whether each `memref.alloc` is a graph output using `BufferViewFlowAnalysis` instead of the previous cast-only `OpRewritePattern`. `resolve()` returns the alloc plus every value derived from it through **any** chain of view ops (`memref.cast` / `collapse_shape` / `expand_shape` / `subview`), so an alloc that is reshaped on the way to `func.return` — e.g. a rank-4 conv result collapsed to rank-2 — is now recognized and rewritten to `hip.alloc_output` with no per-op special-casing. The graph-output index comes from `getOperandNumber()` on the `func.return` use of any alias.
- Structure the pass as **analyze-then-transform**: phase 1 classifies allocs with the alias analysis (no IR mutation), phase 2 rewrites (no analysis queries), so the analysis (which caches `Value` handles) is never read after the IR it describes has been mutated.
- Declare `getDependentDialects` (`HipDialect` for the created `hip.alloc_output`, `MemRefDialect` for the view ops' `ViewLikeOpInterface`).
- Existing behavior is preserved: public-only functions, `!hip.context` arg-0 requirement, dealloc removal, first (lowest) `out_idx` for aliased multi-outputs, and program-order rewrite so `out_idx` values print in order.
- Extend the LIT test with `collapse_shape` / `expand_shape` / multi-op-chain / `subview` return cases; sync `Passes.td` and `docs/design/output-allocator-design.md`.

## Test plan

- [x] Incremental build via local build script (only `UseOutputAllocator.cpp` recompiled + relinked; clean).
- [x] `MorphizenMLIRLitTests` passes — covers direct / cast / collapse / expand / chain / subview / aliased / passthrough / no-context / private-helper cases plus the `output-allocator-dealloc.mlir` pipeline test.
- [x] `pre-commit run` clean (lintrunner/clang-format, license headers, whitespace).
