### PR TITLE
Extra guards for FFM upstream.

### DIFF
--- a/lib/Runtime/Kernels/hip/gemm_wmma_kernel.hip
+++ b/lib/Runtime/Kernels/hip/gemm_wmma_kernel.hip
@@ -11,6 +11,24 @@
 typedef _Float16 half16 __attribute__((ext_vector_type(16)));
 typedef float float8 __attribute__((ext_vector_type(8)));
 
+// The 16x16x16 fp16 WMMA builtin is an RDNA3-family (wave32) intrinsic. On GPU
+// targets that do not provide it, this file must still COMPILE (it is built for
+// every configured arch), but the WMMA path must never silently produce wrong
+// results. Guard on __has_builtin (arch-agnostic -- no hard-coded arch name):
+// where the intrinsic is missing, forward to a shim that traps, so a WMMA launch
+// on an unsupported target aborts loudly instead of returning a zeroed tile. A
+// target that needs WMMA on such an arch must add a real implementation here.
+#if !defined(__has_builtin) ||                                                  \
+    !__has_builtin(__builtin_amdgcn_wmma_f32_16x16x16_f16_w32)
+static __device__ __forceinline__ float8
+hipdnn_wmma_f32_16x16x16_f16_w32_unavailable(half16, half16, float8 c) {
+  __builtin_trap();
+  return c;
+}
+#define __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a, b, c)                     \
+  hipdnn_wmma_f32_16x16x16_f16_w32_unavailable((a), (b), (c))
+#endif
+
 static constexpr int kWmmaTile = 16;  // RDNA 3 WMMA tile dimension (16x16x16)
 
 //===----------------------------------------------------------------------===//

--- a/lib/Runtime/Kernels/hip/gemm_wmma_kernel.hip
+++ b/lib/Runtime/Kernels/hip/gemm_wmma_kernel.hip
@@ -11,13 +11,9 @@
 typedef _Float16 half16 __attribute__((ext_vector_type(16)));
 typedef float float8 __attribute__((ext_vector_type(8)));
 
-// The 16x16x16 fp16 WMMA builtin is an RDNA3-family (wave32) intrinsic. On GPU
-// targets that do not provide it, this file must still COMPILE (it is built for
-// every configured arch), but the WMMA path must never silently produce wrong
-// results. Guard on __has_builtin (arch-agnostic -- no hard-coded arch name):
-// where the intrinsic is missing, forward to a shim that traps, so a WMMA launch
-// on an unsupported target aborts loudly instead of returning a zeroed tile. A
-// target that needs WMMA on such an arch must add a real implementation here.
+// The WMMA builtin below is RDNA3-family (wave32) only. Where __has_builtin
+// reports it absent, trap instead so this file still compiles and a WMMA
+// launch on an unsupported arch aborts loudly rather than returning garbage.
 #if !defined(__has_builtin) ||                                                  \
     !__has_builtin(__builtin_amdgcn_wmma_f32_16x16x16_f16_w32)
 static __device__ __forceinline__ float8

--- a/lib/Runtime/Kernels/hip/gqa_kernel.hip
+++ b/lib/Runtime/Kernels/hip/gqa_kernel.hip
@@ -960,13 +960,9 @@ typedef _Float16 half16 __attribute__((ext_vector_type(16)));
 typedef float    float8 __attribute__((ext_vector_type(8)));
 #define HALF16(pointer) (reinterpret_cast<half16*>((void *)&(pointer))[0])
 
-// The 16x16x16 fp16 WMMA builtin is an RDNA3-family (wave32) intrinsic. On GPU
-// targets that do not provide it, this file must still COMPILE (it is built for
-// every configured arch), but the WMMA path must never silently produce wrong
-// results. Guard on __has_builtin (arch-agnostic -- no hard-coded arch name):
-// where the intrinsic is missing, forward to a shim that traps, so a WMMA launch
-// on an unsupported target aborts loudly instead of returning a zeroed tile. A
-// target that needs WMMA on such an arch must add a real implementation here.
+// The WMMA builtin below is RDNA3-family (wave32) only. Where __has_builtin
+// reports it absent, trap instead so this file still compiles and a WMMA
+// launch on an unsupported arch aborts loudly rather than returning garbage.
 #if !defined(__has_builtin) ||                                                  \
     !__has_builtin(__builtin_amdgcn_wmma_f32_16x16x16_f16_w32)
 static __device__ __forceinline__ float8

--- a/lib/Runtime/Kernels/hip/gqa_kernel.hip
+++ b/lib/Runtime/Kernels/hip/gqa_kernel.hip
@@ -960,6 +960,24 @@ typedef _Float16 half16 __attribute__((ext_vector_type(16)));
 typedef float    float8 __attribute__((ext_vector_type(8)));
 #define HALF16(pointer) (reinterpret_cast<half16*>((void *)&(pointer))[0])
 
+// The 16x16x16 fp16 WMMA builtin is an RDNA3-family (wave32) intrinsic. On GPU
+// targets that do not provide it, this file must still COMPILE (it is built for
+// every configured arch), but the WMMA path must never silently produce wrong
+// results. Guard on __has_builtin (arch-agnostic -- no hard-coded arch name):
+// where the intrinsic is missing, forward to a shim that traps, so a WMMA launch
+// on an unsupported target aborts loudly instead of returning a zeroed tile. A
+// target that needs WMMA on such an arch must add a real implementation here.
+#if !defined(__has_builtin) ||                                                  \
+    !__has_builtin(__builtin_amdgcn_wmma_f32_16x16x16_f16_w32)
+static __device__ __forceinline__ float8
+hipdnn_wmma_f32_16x16x16_f16_w32_unavailable(half16, half16, float8 c) {
+  __builtin_trap();
+  return c;
+}
+#define __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a, b, c)                     \
+  hipdnn_wmma_f32_16x16x16_f16_w32_unavailable((a), (b), (c))
+#endif
+
 //===----------------------------------------------------------------------===//
 // Fused GQA Decode Kernel (sq == 1, d in {64, 128, 256})
 //===----------------------------------------------------------------------===//

--- a/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
+++ b/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
@@ -1175,13 +1175,9 @@ __global__ void dequant_u4_to_fp16(
 typedef _Float16 half16 __attribute__((ext_vector_type(16)));
 typedef float    float8 __attribute__((ext_vector_type(8)));
 
-// The 16x16x16 fp16 WMMA builtin is an RDNA3-family (wave32) intrinsic. On GPU
-// targets that do not provide it, this file must still COMPILE (it is built for
-// every configured arch), but the WMMA path must never silently produce wrong
-// results. Guard on __has_builtin (arch-agnostic -- no hard-coded arch name):
-// where the intrinsic is missing, forward to a shim that traps, so a WMMA launch
-// on an unsupported target aborts loudly instead of returning a zeroed tile. A
-// target that needs WMMA on such an arch must add a real implementation here.
+// The WMMA builtin below is RDNA3-family (wave32) only. Where __has_builtin
+// reports it absent, trap instead so this file still compiles and a WMMA
+// launch on an unsupported arch aborts loudly rather than returning garbage.
 #if !defined(__has_builtin) ||                                                  \
     !__has_builtin(__builtin_amdgcn_wmma_f32_16x16x16_f16_w32)
 static __device__ __forceinline__ float8

--- a/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
+++ b/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
@@ -1175,6 +1175,24 @@ __global__ void dequant_u4_to_fp16(
 typedef _Float16 half16 __attribute__((ext_vector_type(16)));
 typedef float    float8 __attribute__((ext_vector_type(8)));
 
+// The 16x16x16 fp16 WMMA builtin is an RDNA3-family (wave32) intrinsic. On GPU
+// targets that do not provide it, this file must still COMPILE (it is built for
+// every configured arch), but the WMMA path must never silently produce wrong
+// results. Guard on __has_builtin (arch-agnostic -- no hard-coded arch name):
+// where the intrinsic is missing, forward to a shim that traps, so a WMMA launch
+// on an unsupported target aborts loudly instead of returning a zeroed tile. A
+// target that needs WMMA on such an arch must add a real implementation here.
+#if !defined(__has_builtin) ||                                                  \
+    !__has_builtin(__builtin_amdgcn_wmma_f32_16x16x16_f16_w32)
+static __device__ __forceinline__ float8
+hipdnn_wmma_f32_16x16x16_f16_w32_unavailable(half16, half16, float8 c) {
+  __builtin_trap();
+  return c;
+}
+#define __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a, b, c)                     \
+  hipdnn_wmma_f32_16x16x16_f16_w32_unavailable((a), (b), (c))
+#endif
+
 #define WMMA_TILE 16
 
 template <int BM_T, int BN_T, int WT_M, int WT_N, bool USE_ZEROS,

--- a/lib/Runtime/mock/mock_types.h
+++ b/lib/Runtime/mock/mock_types.h
@@ -5,6 +5,11 @@
 #ifndef HIPDNN_EP_RUNTIME_MOCK_TYPES_H
 #define HIPDNN_EP_RUNTIME_MOCK_TYPES_H
 
+// size_t is used in the hip* prototypes below. Most STL-carrying toolchains pull
+// it in transitively, but a freestanding bitcode compile (e.g. clang emitting
+// LLVM IR without the usual libstdc++ prelude) does not, so include it directly.
+#include <cstddef>
+
 // Mock type definitions for testing without GPU
 typedef void *hipStream_t;
 typedef void *hipEvent_t;

--- a/lib/Runtime/mock/mock_types.h
+++ b/lib/Runtime/mock/mock_types.h
@@ -5,9 +5,10 @@
 #ifndef HIPDNN_EP_RUNTIME_MOCK_TYPES_H
 #define HIPDNN_EP_RUNTIME_MOCK_TYPES_H
 
-// size_t is used in the hip* prototypes below. Most STL-carrying toolchains pull
-// it in transitively, but a freestanding bitcode compile (e.g. clang emitting
-// LLVM IR without the usual libstdc++ prelude) does not, so include it directly.
+// size_t is used in the hip* prototypes below. Most STL-carrying toolchains
+// pull it in transitively, but a freestanding bitcode compile (e.g. clang
+// emitting LLVM IR without the usual libstdc++ prelude) does not, so include it
+// directly.
 #include <cstddef>
 
 // Mock type definitions for testing without GPU

--- a/tools/hip-test/CMakeLists.txt
+++ b/tools/hip-test/CMakeLists.txt
@@ -59,15 +59,9 @@ if(NOT BUILD_MOCK_RUNTIME)
   # this and the callback returns host buffers the CPU stubs write directly.
   target_compile_definitions(hip-test PRIVATE HIPDNN_EP_LINK_HIP_HOST=1)
 
-  # hip-test statically links this build's LLVM, then at runtime loads the HIP
-  # runtime (libamdhip64 -> libamd_comgr), which on some ROCm distributions pulls
-  # in its OWN (different) shared libLLVM. With both LLVMs in one process, the
-  # executable's statically-linked LLVM symbols are exported and preempt the
-  # shared libLLVM's, so its static initializers run against mismatched globals
-  # and can SIGSEGV before main(). --exclude-libs,ALL localizes (hides) all
-  # static-archive symbols from the dynamic symbol table -- the correct default
-  # for an executable -- so the shared libLLVM resolves against itself. GNU ld /
-  # lld only (MSVC's linker has no equivalent and does not export by default).
+  # Hide static-archive symbols so hip-test's statically-linked LLVM can't clash
+  # with a different shared libLLVM the HIP runtime may pull in at load time
+  # (which can SIGSEGV before main). GNU ld / lld only.
   if(NOT WIN32)
     target_link_options(hip-test PRIVATE "LINKER:--exclude-libs,ALL")
   endif()

--- a/tools/hip-test/CMakeLists.txt
+++ b/tools/hip-test/CMakeLists.txt
@@ -58,6 +58,19 @@ if(NOT BUILD_MOCK_RUNTIME)
   # memory (hipMalloc) and copy it back D2H for validation. Mock builds omit
   # this and the callback returns host buffers the CPU stubs write directly.
   target_compile_definitions(hip-test PRIVATE HIPDNN_EP_LINK_HIP_HOST=1)
+
+  # hip-test statically links this build's LLVM, then at runtime loads the HIP
+  # runtime (libamdhip64 -> libamd_comgr), which on some ROCm distributions pulls
+  # in its OWN (different) shared libLLVM. With both LLVMs in one process, the
+  # executable's statically-linked LLVM symbols are exported and preempt the
+  # shared libLLVM's, so its static initializers run against mismatched globals
+  # and can SIGSEGV before main(). --exclude-libs,ALL localizes (hides) all
+  # static-archive symbols from the dynamic symbol table -- the correct default
+  # for an executable -- so the shared libLLVM resolves against itself. GNU ld /
+  # lld only (MSVC's linker has no equivalent and does not export by default).
+  if(NOT WIN32)
+    target_link_options(hip-test PRIVATE "LINKER:--exclude-libs,ALL")
+  endif()
 endif()
 
 target_include_directories(hip-test


### PR DESCRIPTION
### Summary

Three small, independent fixes so the compiler builds and runs on GPU targets
that differ from the RDNA3/gfx1151 assumptions in some kernels and tools. None
hard-codes a GPU name.

- mock_types.h: add a missing include for size_t, which a bitcode-only build
  doesn't get automatically.
- WMMA kernels (gemm_wmma, gqa, matmul_nbits): the fast matrix-multiply builtin
  only exists on RDNA3. On a GPU without it, the file now still compiles and, if
  that path is ever run, it stops with a clear crash instead of returning wrong
  numbers.
- hip-test: hide its own LLVM symbols at link time so they can't clash with a
  different LLVM the HIP runtime loads.