### PR TITLE
fix(ci): derive Linux _therock path from checkout dir (repo-rename fallout)

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -394,7 +394,14 @@ jobs:
           set -euo pipefail
           INSTALL="${{ runner.workspace }}/install"
           ORT="${{ runner.workspace }}/ort-install"
-          THEROCK="${{ runner.workspace }}/build/onnx-hipdnn-ep/_therock"
+          # build.py builds into <workspace>/build/<checkout-dir-name>/ (REPO.parent
+          # / build / REPO.name), so derive _therock from the checkout dir name
+          # instead of hardcoding it -- otherwise a repo rename (onnx-hipdnn-ep ->
+          # hip-ep) silently points this at an empty dir and the closure check below
+          # fails with "libamdhip64.so.7 => not found". This step runs in the default
+          # cwd (github.workspace = the checkout), matching windows-build.yml's
+          # `$(basename "$PWD")` idiom.
+          THEROCK="${{ runner.workspace }}/build/$(basename "$PWD")/_therock"
           # The renamed AMDGPU OGA integration dlopen's libamdgpu-ep.so; the
           # project still builds the EP as libhipgpu.so. Ship the expected
           # filename so the genai auto-loader resolves it (deps + closure below


### PR DESCRIPTION
## Summary

`build-linux` has been red on `main` (and every stacked PR based on it) since the repo was renamed **`onnx-hipdnn-ep` → `hip-ep`**.

The **"Bundle runtime .so + verify closure"** step hardcodes the TheRock SDK path as `build/onnx-hipdnn-ep/_therock`, but `build.py` builds into `<workspace>/build/<checkout-dir-name>/` (`REPO.parent / build / REPO.name`). After the rename the checkout dir is `hip-ep`, so TheRock is extracted into `build/hip-ep/_therock` while the verify step looks in the now-empty `build/onnx-hipdnn-ep/_therock`. The closure check then can't resolve the ROCm SONAMEs:

```
Extracting TheRock SDK into  .../build/hip-ep/_therock          ← where it actually is
ERROR: unresolved deps in .../install/bin/hip-test:  libamdhip64.so.7 => not found
ERROR: unresolved deps in .../install/lib/libhipgpu.so:         libamdhip64.so.7 => not found
ERROR: install/ is not self-contained
```

## Fix

Derive the build-dir name dynamically via `$(basename "$PWD")` (the step runs in `github.workspace`, i.e. the checkout dir), matching the idiom `windows-build.yml` already uses (`../build/$(basename "$PWD")/_therock`). Rename-proof — no hardcoded repo name.

One-line change to `.github/workflows/linux-build.yml` plus an explanatory comment.

## Test plan

- [ ] `build-linux` closure check passes (`libamdhip64.so.7` resolves from `_therock/lib`)
- [ ] `gpu-test` green

Made with [Cursor](https://cursor.com)