### PR TITLE
ci(windows): make GPU-test asset root configurable (repo-rename-proof)

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -747,11 +747,18 @@ jobs:
       # (those are NATIVE-only, set in the native smoke steps below).
       # Output is tee'd to results/ for QPS extraction. Non-zero exit code
       # sets FAILED but continues so all models are tested.
+      #
+      # GPU-test asset dirs (model/, amdgpu-oga-models/, l2-test-models/) resolve
+      # under ${{ vars.GPU_TEST_ASSET_ROOT || runner.workspace }}: set the repo/org
+      # Actions variable GPU_TEST_ASSET_ROOT to a stable path (and stage the dirs
+      # there) so persistent assets need not live under the repo-name-derived
+      # _work/<repo>/, which strands them on a repo rename. Unset => runner.workspace
+      # (unchanged from today).
       - name: Run onnxruntime_perf_test (GPU)
         shell: cmd
         run: |
           set PATH=%CD%\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
-          set MODEL_DIR=${{ runner.workspace }}\model
+          set MODEL_DIR=${{ vars.GPU_TEST_ASSET_ROOT || runner.workspace }}\model
           if not exist "%MODEL_DIR%" (
             echo [ERROR] MODEL_DIR not found: %MODEL_DIR%
             exit /b 1
@@ -795,7 +802,7 @@ jobs:
           set THEROCK_DIST=%CD%\therock-dist
           set PATH=%CD%\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
           set LIB=%CD%\gpu-test-package\lib;%CD%\therock-dist\lib
-          set MODEL_DIR=${{ runner.workspace }}\model
+          set MODEL_DIR=${{ vars.GPU_TEST_ASSET_ROOT || runner.workspace }}\model
           if not exist "%MODEL_DIR%" (
             echo [SKIP] MODEL_DIR not found: %MODEL_DIR%
             exit /b 0
@@ -841,7 +848,7 @@ jobs:
           set THEROCK_DIST=%CD%\therock-dist
           set PATH=%CD%\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
           set LIB=%CD%\gpu-test-package\lib;%CD%\therock-dist\lib
-          set MODEL_DIR=${{ runner.workspace }}\model
+          set MODEL_DIR=${{ vars.GPU_TEST_ASSET_ROOT || runner.workspace }}\model
           if not exist "%MODEL_DIR%" (
             echo [SKIP] MODEL_DIR not found: %MODEL_DIR%
             exit /b 0
@@ -883,7 +890,7 @@ jobs:
           $pkgBin = Join-Path $PWD "gpu-test-package\bin"
           $env:PATH = "$PWD\therock-dist\bin;$pkgBin;$env:PATH"
 
-          $modelDir = "${{ runner.workspace }}\model"
+          $modelDir = "${{ vars.GPU_TEST_ASSET_ROOT || runner.workspace }}\model"
           if (-not (Test-Path $modelDir)) {
             Write-Host "[SKIP] MODEL_DIR not found: $modelDir"
             exit 0
@@ -963,7 +970,7 @@ jobs:
           # generated once on the GPU runner and persists across runs, so just
           # consume it here (no re-copy / no config rewrite). It must be present
           # -- treat its absence as an error, not a skip.
-          $ogaModelRoot = "${{ runner.workspace }}\amdgpu-oga-models"
+          $ogaModelRoot = "${{ vars.GPU_TEST_ASSET_ROOT || runner.workspace }}\amdgpu-oga-models"
           if (-not (Test-Path $ogaModelRoot)) {
             Write-Host "[ERROR] AMDGPU OGA model directory not found: $ogaModelRoot"
             exit 1
@@ -1057,7 +1064,7 @@ jobs:
           $ErrorActionPreference = 'Continue'
           $PSNativeCommandUseErrorActionPreference = $false
 
-          $model = "${{ runner.workspace }}\amdgpu-oga-models\Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml"
+          $model = "${{ vars.GPU_TEST_ASSET_ROOT || runner.workspace }}\amdgpu-oga-models\Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml"
           if (-not (Test-Path $model)) { Write-Host "[SKIP] model not found: $model"; exit 0 }
 
           # The morphizen wheel now bundles the whole AMD GPU umbrella chain
@@ -1106,7 +1113,7 @@ jobs:
           rem The EP DLL is now hipgpu.dll; hip-onnx-runner's legacy default name
           rem is onnxruntime_morphizen_ep.dll, so point it at the new DLL.
           set MORPHIZEN_EP_LIB=%CD%\gpu-test-package\bin\hipgpu.dll
-          set L2_MODEL_DIR=${{ runner.workspace }}\l2-test-models
+          set L2_MODEL_DIR=${{ vars.GPU_TEST_ASSET_ROOT || runner.workspace }}\l2-test-models
           if not exist "%L2_MODEL_DIR%" (
             echo [SKIP] L2 model directory not found: %L2_MODEL_DIR%
             exit /b 0


### PR DESCRIPTION
## Summary

Companion to #452 (Linux `_therock` path) — same root cause on the **Windows self-hosted GPU runner**.

The `gpu-test` job resolves its **persistent** model dirs under `${{ runner.workspace }}` (= `C:\actions-runner\_work\<repo>`):

| Asset | Used by |
|---|---|
| `model/` | `onnxruntime_perf_test`, EPContext export/import |
| `amdgpu-oga-models/` | OGA benchmark + smoke |
| `l2-test-models/` | L2 accuracy |

Because `_work\<repo>` is named after the repo, the `onnx-hipdnn-ep → hip-ep` rename left the pre-staged assets stranded under the old `_work\onnx-hipdnn-ep\`, so every GPU sub-test reported *"not found" / "no results"*:

```
[SKIP] L2 model directory not found: C:\actions-runner\_work\hip-ep\l2-test-models
[ERROR] EPContext export failed
##[error] Process completed with exit code 1   (OGA benchmark)
| (no results) | - | - | - | - |
```

## Fix

Resolve the three asset dirs under `${{ vars.GPU_TEST_ASSET_ROOT || runner.workspace }}`. Set the repo/org **Actions variable** `GPU_TEST_ASSET_ROOT` to a stable path (and stage the dirs there) to decouple persistent test assets from the repo-name-derived work dir.

**Non-disruptive:** with `GPU_TEST_ASSET_ROOT` **unset**, the expression falls back to `runner.workspace` — identical to today. Nothing changes until the variable is opted into. Only the 7 asset-path sites are touched; `install`/`ort-install`/`llvm-install`/`build-*` refs are untouched.

## Rollout

1. On the self-hosted GPU runner, stage `model/`, `amdgpu-oga-models/`, `l2-test-models/` at a stable location (e.g. `C:\ci-gpu-assets`).
2. Set repo/org variable `GPU_TEST_ASSET_ROOT` to that path.
3. (Immediate unblock, independent of this PR: junction the three dirs from `_work\onnx-hipdnn-ep\` into `_work\hip-ep\`.)

## Test plan

- [ ] With `GPU_TEST_ASSET_ROOT` unset: `gpu-test` behaves exactly as before (no diff).
- [ ] With `GPU_TEST_ASSET_ROOT` set + assets staged: L2 / OGA / perf steps find their models.

Made with [Cursor](https://cursor.com)