### PR TITLE
Plugin interface: exercise the sample dialect + interface paths in CI

### DIFF
--- a/.github/workflows/windows-build-mock.yml
+++ b/.github/workflows/windows-build-mock.yml
@@ -222,13 +222,8 @@ jobs:
       # BUILD_MOCK_RUNTIME=ON (no ROCm/TheRock); ORT + LLVM come from the cached
       # prefixes and cmake/deps.cmake source-builds the rest. build.py runs the
       # GPU-free test suites (LIT + the plugin-registrar and output-allocator
-      # unit tests) after install.
-      #
-      # This is a validation-only build (no artifacts are shipped), so it is
-      # where we select the sample compiler plugin: with it linked, the plugin
-      # registrar unit test runs its HIP_EP_EXPECT_SAMPLE=1 assertions, which
-      # exercise the addDialectRegistration -> loadAllDialects path and the
-      # convert-hip-to-llvm hasPromisedInterface guard.
+      # unit tests) after install. No compiler plugin is selected here, so the
+      # LIT pipeline stays plugin-free (see the isolated step below for why).
       # -----------------------------------------------------------------------
       - name: Build onnx-hipdnn-ep (mock)
         shell: bash
@@ -237,5 +232,26 @@ jobs:
             --mock \
             --config Release \
             --cmake_generator Ninja \
-            --cmake_prefix_path "${{ runner.workspace }}/ort-install;${{ runner.workspace }}/llvm-install" \
-            --cmake_extra_defines HIPDNN_EP_COMPILER_PLUGINS=sample
+            --build_dir "${{ runner.workspace }}/build/mock" \
+            --cmake_prefix_path "${{ runner.workspace }}/ort-install;${{ runner.workspace }}/llvm-install"
+
+      # -----------------------------------------------------------------------
+      # Exercise the sample plugin's registrar unit test in ISOLATION. This is a
+      # validation-only build (no artifacts shipped), but the sample plugin
+      # cannot be selected in the build above: selecting a plugin injects its
+      # pipeline-slot pass into buildOnnxToHipPipeline, and the sample pass emits
+      # a remark per func.func, which pollutes the pipeline LIT tests that
+      # capture stderr. So reconfigure the just-built tree with the plugin and
+      # run ONLY the registrar ctest -- it checks the plugin registry (it does
+      # not run the pipeline), so it is unaffected. This covers the
+      # HIP_EP_EXPECT_SAMPLE=1 branch: the addDialectRegistration ->
+      # loadAllDialects path and the convert-hip-to-llvm hasPromisedInterface
+      # guard. LIT is not re-run here, so it stays plugin-free.
+      # -----------------------------------------------------------------------
+      - name: Plugin registrar unit test (sample plugin selected)
+        shell: bash
+        run: |
+          BUILD="${{ runner.workspace }}/build/mock"
+          cmake -B "$BUILD" -DHIPDNN_EP_COMPILER_PLUGINS=sample
+          cmake --build "$BUILD" --config Release --target test_static_plugins
+          ctest --test-dir "$BUILD" -C Release -R StaticPlugins --output-on-failure

--- a/.github/workflows/windows-build-mock.yml
+++ b/.github/workflows/windows-build-mock.yml
@@ -220,8 +220,15 @@ jobs:
       # -----------------------------------------------------------------------
       # Build (mock) via the cross-platform build.py. --mock sets
       # BUILD_MOCK_RUNTIME=ON (no ROCm/TheRock); ORT + LLVM come from the cached
-      # prefixes and cmake/deps.cmake source-builds the rest. The LIT tests run
-      # inside build.py after install.
+      # prefixes and cmake/deps.cmake source-builds the rest. build.py runs the
+      # GPU-free test suites (LIT + the plugin-registrar and output-allocator
+      # unit tests) after install.
+      #
+      # This is a validation-only build (no artifacts are shipped), so it is
+      # where we select the sample compiler plugin: with it linked, the plugin
+      # registrar unit test runs its HIP_EP_EXPECT_SAMPLE=1 assertions, which
+      # exercise the addDialectRegistration -> loadAllDialects path and the
+      # convert-hip-to-llvm hasPromisedInterface guard.
       # -----------------------------------------------------------------------
       - name: Build onnx-hipdnn-ep (mock)
         shell: bash
@@ -230,4 +237,5 @@ jobs:
             --mock \
             --config Release \
             --cmake_generator Ninja \
-            --cmake_prefix_path "${{ runner.workspace }}/ort-install;${{ runner.workspace }}/llvm-install"
+            --cmake_prefix_path "${{ runner.workspace }}/ort-install;${{ runner.workspace }}/llvm-install" \
+            --cmake_extra_defines HIPDNN_EP_COMPILER_PLUGINS=sample

--- a/build.py
+++ b/build.py
@@ -324,7 +324,9 @@ def build_targets(args, build_dir):
 
 
 def run_tests(args, build_dir):
-    """Run the LIT suite (MLIR pass verification; no GPU needed)."""
+    """Run the GPU-free test suites (no device needed, so they run on the build
+    machine in every CI job): the MLIR LIT pass-verification suite plus the
+    compiler-plugin registrar and output-allocator ctest unit tests."""
     step("Test (check-hip-mlir-lit)")
     run_subprocess(
         [
@@ -335,6 +337,24 @@ def run_tests(args, build_dir):
             args.config,
             "--target",
             "check-hip-mlir-lit",
+        ]
+    )
+
+    # GPU-free ctest unit suites (built as part of the default target above).
+    # -R limits the run to these two -- the plugin registrar (compiler-only) and
+    # the output-allocator test (links the mock runtime) -- so the GPU / hip-test
+    # e2e ctest suites, which need a real device, are not invoked here.
+    step("Test (plugin registrar + output-allocator unit tests)")
+    run_subprocess(
+        [
+            "ctest",
+            "--test-dir",
+            str(build_dir),
+            "-C",
+            args.config,
+            "-R",
+            "StaticPlugins|OutputAllocator",
+            "--output-on-failure",
         ]
     )
 

--- a/test/plugin/CMakeLists.txt
+++ b/test/plugin/CMakeLists.txt
@@ -21,8 +21,21 @@ add_executable(test_static_plugins test_static_plugins.cpp)
 
 target_compile_features(test_static_plugins PRIVATE cxx_std_17)
 
+# The test now includes mlir/ headers directly (MLIRContext, Dialect, the
+# ConvertToLLVM interface) to exercise loadAllDialects() + the sample dialect's
+# hasPromisedInterface state.
+target_include_directories(test_static_plugins PRIVATE
+  ${MLIR_INCLUDE_DIRS}
+  ${LLVM_INCLUDE_DIRS}
+)
+
 target_link_libraries(test_static_plugins PRIVATE
   LibHipCompiler
+  # Direct references from the dialect-path checks; the in-tree dialects that
+  # loadAllDialects() registers come transitively via LibHipCompiler.
+  MLIRIR
+  MLIRSupport
+  MLIRConvertToLLVMInterface
 )
 
 # Tell the test whether the sample plugin is linked into this build.

--- a/test/plugin/sample_plugin/CMakeLists.txt
+++ b/test/plugin/sample_plugin/CMakeLists.txt
@@ -77,6 +77,7 @@ set_target_properties(hip_ep_sample_lib PROPERTIES
 
 add_library(hip_ep_sample_plugin STATIC
   sample_plugin.cpp
+  sample_dialect.cpp
   ${SAMPLE_PLUGIN_BITCODE_SRC}
 )
 add_dependencies(hip_ep_sample_plugin hip_ep_sample_lib)
@@ -101,6 +102,12 @@ target_link_libraries(hip_ep_sample_plugin PUBLIC
   MLIRIR
   MLIRSupport
   MLIRFuncDialect
+  # For sample_dialect.cpp: the minimal dialect's HIP->LLVM lowering interface
+  # (ConvertToLLVMPatternInterface + LLVMTypeConverter + DialectConversion).
+  MLIRLLVMDialect
+  MLIRLLVMCommonConversion
+  MLIRConvertToLLVMInterface
+  MLIRTransformUtils
 )
 
 set_target_properties(hip_ep_sample_plugin PROPERTIES

--- a/test/plugin/sample_plugin/sample_dialect.cpp
+++ b/test/plugin/sample_plugin/sample_dialect.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// Minimal vendor-style dialect for the in-tree sample plugin, contributed via
+// addDialectRegistration. It exists only to give the host CI coverage of the
+// two plugin-dialect paths otherwise exercised only out-of-tree: the
+// loadAllDialects() plugin loop (InitAllPasses.h) and the hasPromisedInterface
+// guard in convert-hip-to-llvm (HipToLLVM.cpp). One nullary op whose
+// ConvertToLLVMPatternInterface lowering just erases it -- the smallest shape
+// touching both paths. A real vendor dialect would define its ops in ODS.
+
+#include "mlir/Conversion/ConvertToLLVM/ToLLVMInterface.h"
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/Dialect.h"
+#include "mlir/IR/DialectRegistry.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+#include "sample_dialect.h"
+
+using namespace mlir;
+
+namespace {
+
+/// Nullary op with no attributes -- enough to load the dialect and be walked by
+/// convert-hip-to-llvm.
+class SampleMarkerOp : public Op<SampleMarkerOp> {
+public:
+  using Op::Op;
+  static StringRef getOperationName() { return "hip_ep_sample.marker"; }
+  static ArrayRef<StringRef> getAttributeNames() { return {}; }
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SampleMarkerOp)
+};
+
+class SampleDialect : public Dialect {
+public:
+  explicit SampleDialect(MLIRContext *ctx)
+      : Dialect(getDialectNamespace(), ctx, TypeID::get<SampleDialect>()) {
+    addOperations<SampleMarkerOp>();
+  }
+  static StringRef getDialectNamespace() { return "hip_ep_sample"; }
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SampleDialect)
+};
+
+/// Stands in for a real op's lowering to a runtime call; only its dispatch
+/// through the interface matters here, so it just erases the marker.
+struct SampleMarkerLowering : public ConversionPattern {
+  SampleMarkerLowering(const LLVMTypeConverter &converter, MLIRContext *ctx)
+      : ConversionPattern(converter, SampleMarkerOp::getOperationName(),
+                          /*benefit=*/1, ctx) {}
+  LogicalResult
+  matchAndRewrite(Operation *op, ArrayRef<Value> /*operands*/,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+/// Implement the interface to lower hip_ep_sample to LLVM. Attaching it (below)
+/// -- not merely promising it -- is what makes the convert-hip-to-llvm guard
+/// admit the dialect (hasPromisedInterface == false).
+struct SampleConvertToLLVMInterface : public ConvertToLLVMPatternInterface {
+  using ConvertToLLVMPatternInterface::ConvertToLLVMPatternInterface;
+
+  void loadDependentDialects(MLIRContext *context) const final {
+    context->loadDialect<LLVM::LLVMDialect>();
+  }
+
+  void populateConvertToLLVMConversionPatterns(
+      ConversionTarget &target, LLVMTypeConverter &typeConverter,
+      RewritePatternSet &patterns) const final {
+    target.addIllegalDialect<SampleDialect>();
+    patterns.add<SampleMarkerLowering>(typeConverter, patterns.getContext());
+  }
+};
+
+} // namespace
+
+void registerHipEpSampleDialect(mlir::DialectRegistry &registry) {
+  registry.insert<SampleDialect>();
+  // Attach (not promise) the lowering interface when the dialect loads, so it
+  // is genuinely registered -- what the convert-hip-to-llvm guard expects.
+  registry.addExtension(+[](mlir::MLIRContext *, SampleDialect *dialect) {
+    dialect->addInterfaces<SampleConvertToLLVMInterface>();
+  });
+}

--- a/test/plugin/sample_plugin/sample_dialect.h
+++ b/test/plugin/sample_plugin/sample_dialect.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// Registration entry point for the sample plugin's minimal vendor dialect. In
+// its own TU so sample_plugin.cpp needs no MLIR dialect/conversion headers.
+
+#ifndef HIP_EP_TEST_SAMPLE_DIALECT_H
+#define HIP_EP_TEST_SAMPLE_DIALECT_H
+
+namespace mlir {
+class DialectRegistry;
+} // namespace mlir
+
+/// Insert the `hip_ep_sample` dialect and attach its
+/// ConvertToLLVMPatternInterface. Passed to
+/// HipEpPluginRegistry::addDialectRegistration (a plain function converts to
+/// the required pointer). See docs/design/plugin-interface.md.
+void registerHipEpSampleDialect(mlir::DialectRegistry &registry);
+
+#endif // HIP_EP_TEST_SAMPLE_DIALECT_H

--- a/test/plugin/sample_plugin/sample_plugin.cpp
+++ b/test/plugin/sample_plugin/sample_plugin.cpp
@@ -5,9 +5,10 @@
 
 // Sample static plugin for the plugin registrar + pipeline-slot tests.
 // Exercises the public plugin surface (PluginAPI.h / PluginRegistry.h) end to
-// end: registers a pass, requests a pipeline slot, and contributes runtime
-// bitcode + a link library. Statically linked into the host, so its
-// registrations land in the host's single MLIR/pass registry.
+// end: registers a pass, requests a pipeline slot, contributes a minimal vendor
+// dialect (via addDialectRegistration), and contributes runtime bitcode + a
+// link library. Statically linked into the host, so its registrations land in
+// the host's single MLIR/pass/dialect registry.
 
 #include "hip/Compiler/PluginAPI.h"
 #include "hip/Compiler/PluginRegistry.h"
@@ -17,6 +18,8 @@
 #include "mlir/Pass/Pass.h"
 
 #include "llvm/ADT/StringRef.h"
+
+#include "sample_dialect.h"
 
 #include <cstddef>
 
@@ -62,6 +65,12 @@ HIP_EP_DEFINE_PLUGIN(sample) {
   // <arg> matches getArgument() above.
   R.requestPipelineSlot(::hip::compiler::PipelineSlot::AfterConvertOnnxToHip,
                         "func.func(hip-ep-sample-print-functions)");
+
+  // Contribute a minimal vendor dialect (hip_ep_sample.marker + its
+  // ConvertToLLVMPatternInterface). This is the only in-tree exercise of the
+  // addDialectRegistration -> loadAllDialects path and the convert-hip-to-llvm
+  // hasPromisedInterface guard, so a refactor of either fails a host test.
+  R.addDialectRegistration(&registerHipEpSampleDialect);
 
   // Contribute the embedded bitcode (process-lifetime static, as
   // addRuntimeBitcode requires); skip the empty no-clang build.

--- a/test/plugin/test_static_plugins.cpp
+++ b/test/plugin/test_static_plugins.cpp
@@ -9,12 +9,17 @@
 // StaticPlugins.cpp) and checks the recorded registry state. CMake sets
 // HIP_EP_EXPECT_SAMPLE:
 //   * 1 (sample selected): the registry records the sample's slot request,
-//     library + search path, and bitcode buffer (empty => degraded no-clang
-//     build, skipped).
+//     library + search path, bitcode buffer (empty => degraded no-clang build,
+//     skipped), and dialect registration (loaded here via loadAllDialects).
 //   * 0 (no plugins): dispatch is a clean no-op; the registry stays empty.
 // Either way dispatch must be safe + idempotent. Plain main() (no GTest).
 
 #include "hip/Compiler/PluginRegistry.h"
+#include "hip/InitAllPasses.h"
+
+#include "mlir/Conversion/ConvertToLLVM/ToLLVMInterface.h"
+#include "mlir/IR/Dialect.h"
+#include "mlir/IR/MLIRContext.h"
 
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
@@ -62,6 +67,7 @@ int main() {
   auto libs = pluginLibraries();
   auto libPaths = pluginLibraryPaths();
   auto bitcode = pluginBitcodeBuffers();
+  auto dialectRegs = pluginDialectRegistrations();
 
 #if HIP_EP_EXPECT_SAMPLE
   llvm::outs() << "Mode: sample plugin EXPECTED (statically linked)\n";
@@ -84,6 +90,34 @@ int main() {
                    bytes[2] == 0xC0 && bytes[3] == 0xDE;
     check(magicOk, "plugin bitcode carries the LLVM bitcode magic");
   }
+
+  // Dialect-registration path. The sample plugin contributes a minimal vendor
+  // dialect (hip_ep_sample) with a ConvertToLLVMPatternInterface. This is the
+  // only in-tree coverage of loadAllDialects()'s plugin loop and the
+  // convert-hip-to-llvm hasPromisedInterface guard, so exercise both here.
+  check(!dialectRegs.empty(),
+        "pluginDialectRegistrations() records the sample dialect callback");
+
+  mlir::MLIRContext context;
+  hip::compiler::loadAllDialects(context);
+  mlir::Dialect *sampleDialect = context.getLoadedDialect("hip_ep_sample");
+  check(sampleDialect != nullptr,
+        "loadAllDialects() loaded the plugin's hip_ep_sample dialect");
+  if (sampleDialect) {
+    // Mirror the convert-hip-to-llvm guard: a genuinely-registered interface
+    // (attached via DialectExtension, not just promised) has
+    // hasPromisedInterface() false AND dyn_casts, so its patterns are used.
+    bool onlyPromised = sampleDialect->hasPromisedInterface(
+        sampleDialect->getTypeID(),
+        mlir::ConvertToLLVMPatternInterface::getInterfaceID());
+    check(!onlyPromised,
+          "hip_ep_sample's ConvertToLLVM interface is registered, not just "
+          "promised (hasPromisedInterface == false)");
+    check(mlir::dyn_cast<mlir::ConvertToLLVMPatternInterface>(sampleDialect) !=
+              nullptr,
+          "hip_ep_sample implements ConvertToLLVMPatternInterface "
+          "(convert-hip-to-llvm guard admits it)");
+  }
 #else
   llvm::outs() << "Mode: NO plugins selected (dispatch must be a no-op)\n";
 
@@ -91,6 +125,7 @@ int main() {
   check(libs.empty(), "no plugin libraries recorded");
   check(libPaths.empty(), "no plugin library paths recorded");
   check(bitcode.empty(), "no plugin bitcode recorded");
+  check(dialectRegs.empty(), "no plugin dialect registrations recorded");
 #endif
 
   if (g_failures == 0) {


### PR DESCRIPTION
> Follow-up to review feedback on #446.

## Problem

The in-tree sample plugin exercised the pass, pipeline-slot, runtime-bitcode, and link-library parts of the plugin API, but never `addDialectRegistration`. That left two code paths with no coverage in our own CI: the `loadAllDialects()` loop that applies plugin dialect registrations, and the `hasPromisedInterface` guard in `convert-hip-to-llvm` that lets a plugin dialect contribute its HIP-to-LLVM lowering. A refactor of either could break silently, since only the out-of-tree example plugin exercised them.

On top of that, the plugin unit test was built in CI but never run — CI ran only the LIT suite, not the ctest suites — so even the existing coverage did not execute on a PR.

## Change

Add a minimal `hip_ep_sample` dialect to the sample plugin: one marker op and a `ConvertToLLVMPatternInterface` that lowers it, contributed through `addDialectRegistration`. Extend the plugin unit test to check that the registration is recorded, that `loadAllDialects` loads the dialect, and that its interface resolves the way `convert-hip-to-llvm` expects (registered, not merely promised).

Then make these tests actually run in CI. `build.py` now runs the two GPU-free ctest suites — the plugin registrar and the output-allocator test — after the LIT suite, in every build. The mock build (which ships no artifacts) selects the sample plugin, so the plugin test runs its sample-plugin assertions and exercises the dialect-registration and interface paths on every PR. Real builds run the no-plugin branch, so no test plugin ends up in shipped artifacts.

Made with [Cursor](https://cursor.com)