### PR TITLE
Perf/ep chrome trace

### DIFF
--- a/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
+++ b/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
@@ -421,11 +421,16 @@ public:
     std::lock_guard<std::mutex> g(mu_);
     samples_.push_back(s);
     const size_t idx = samples_.size();
+    // launch_gap = wall - gpu: host-side dispatch/launch overhead + inter-kernel
+    // gaps NOT hidden behind GPU work. Large gap => decode is launch-bound
+    // (fusion/launch-reduction helps); ~0 => GPU-compute-bound.
+    const double launch_gap = s.wall_ms - s.gpu_ms;
     std::fprintf(stderr,
                  "[PERF] #%zu wall=%.3f marshal_in=%.3f marshal_out=%.3f "
-                 "compute_cpu=%.3f gpu=%.3f fence_residual=%.3f (ms)\n",
+                 "compute_cpu=%.3f gpu=%.3f fence_residual=%.3f "
+                 "launch_gap=%.3f (ms)\n",
                  idx, s.wall_ms, s.marshal_in_ms, s.marshal_out_ms,
-                 s.compute_cpu_ms, s.gpu_ms, s.fence_residual_ms);
+                 s.compute_cpu_ms, s.gpu_ms, s.fence_residual_ms, launch_gap);
     std::fflush(stderr);
   }
 

--- a/lib/Compiler/CompilerDriver.cpp
+++ b/lib/Compiler/CompilerDriver.cpp
@@ -316,6 +316,9 @@ bool CompilerDriver::runMLIRPasses(
     }
   }
 
+  const bool coldstartTimers = !hip_get_env("HIPDNN_EP_PERF").empty() ||
+                               !hip_get_env("HIPDNN_EP_COLDSTART").empty();
+  auto _csCompileStart = std::chrono::steady_clock::now();
   if (mlir::failed(pm.run(module))) {
     error_message = "MLIR pass pipeline failed";
     if (options.verbose) {
@@ -340,6 +343,13 @@ bool CompilerDriver::runMLIRPasses(
       std::abort();
     }
     return false;
+  }
+  if (coldstartTimers) {
+    double ms = std::chrono::duration<double, std::milli>(
+                    std::chrono::steady_clock::now() - _csCompileStart)
+                    .count();
+    llvm::errs() << "[COLDSTART] mlir_compile_pipeline=" << (ms / 1000.0)
+                 << " s\n";
   }
 
   if (options.verbose)

--- a/lib/Runtime/Kernels/CMakeLists.txt
+++ b/lib/Runtime/Kernels/CMakeLists.txt
@@ -39,6 +39,7 @@ set(_kernel_sources
     hip/rope_kernel.hip
     hip/gqa_kernel.hip
     hip/gemm_wmma_kernel.hip
+    hip/bw_probe_kernel.hip
     hip/elementwise_sub_kernel.hip
     hip/elementwise_reciprocal_kernel.hip
     hip/elementwise_sqrt_kernel.hip

--- a/lib/Runtime/Kernels/hip/bw_probe_kernel.hip
+++ b/lib/Runtime/Kernels/hip/bw_probe_kernel.hip
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+//===----------------------------------------------------------------------===//
+// Memory-bandwidth microbenchmark (STREAM-style) to CALIBRATE the roofline peak
+// instead of assuming a spec number. Measures:
+//   - copy  BW  = read+write (2 x bytes / time), the classic STREAM-copy metric
+//   - read  BW  = read-only grid-stride reduction (1 x bytes / time)
+// on a large device buffer. Used once at EP init when HIPDNN_EP_BW_PROBE=1.
+//===----------------------------------------------------------------------===//
+
+#include "hip_custom_kernels.h"
+
+#include <hip/hip_runtime.h>
+#include <cstdint>
+#include <cstdio>
+
+__global__ void bw_copy_kernel(const float4 *__restrict__ in,
+                               float4 *__restrict__ out, int64_t n4) {
+  int64_t i = (int64_t)blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t stride = (int64_t)gridDim.x * blockDim.x;
+  for (; i < n4; i += stride)
+    out[i] = in[i];
+}
+
+__global__ void bw_read_kernel(const float4 *__restrict__ in, int64_t n4,
+                               float *__restrict__ sink) {
+  int64_t i = (int64_t)blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t stride = (int64_t)gridDim.x * blockDim.x;
+  float acc = 0.0f;
+  for (; i < n4; i += stride) {
+    float4 v = in[i];
+    acc += v.x + v.y + v.z + v.w;
+  }
+  // Prevent the read loop from being optimized away.
+  if (acc == -1.0f && sink)
+    sink[0] = acc;
+}
+
+extern "C" int hip_bw_probe(void *stream, double *copy_gbps, double *read_gbps) {
+  hipStream_t s = static_cast<hipStream_t>(stream);
+  const int64_t bytes = 256LL * 1024 * 1024; // 256 MB
+  const int64_t n4 = bytes / (int64_t)sizeof(float4);
+  const int iters = 30;
+  const int warmup = 5;
+
+  float4 *in = nullptr, *out = nullptr;
+  float *sink = nullptr;
+  if (hipMalloc(&in, bytes) != hipSuccess ||
+      hipMalloc(&out, bytes) != hipSuccess ||
+      hipMalloc(&sink, sizeof(float)) != hipSuccess) {
+    fprintf(stderr, "[custom_kernels] hip_bw_probe: hipMalloc failed\n");
+    if (in) hipFree(in);
+    if (out) hipFree(out);
+    if (sink) hipFree(sink);
+    return -1;
+  }
+  hipMemsetAsync(in, 1, bytes, s);
+
+  const int block = 256;
+  int grid = (int)((n4 + block - 1) / block);
+  if (grid > 65535) grid = 65535;
+
+  hipEvent_t e0, e1;
+  hipEventCreate(&e0);
+  hipEventCreate(&e1);
+
+  auto timeKernel = [&](bool copy) -> double {
+    for (int i = 0; i < warmup; ++i) {
+      if (copy)
+        hipLaunchKernelGGL(bw_copy_kernel, dim3(grid), dim3(block), 0, s, in,
+                           out, n4);
+      else
+        hipLaunchKernelGGL(bw_read_kernel, dim3(grid), dim3(block), 0, s, in, n4,
+                           sink);
+    }
+    hipStreamSynchronize(s);
+    hipEventRecord(e0, s);
+    for (int i = 0; i < iters; ++i) {
+      if (copy)
+        hipLaunchKernelGGL(bw_copy_kernel, dim3(grid), dim3(block), 0, s, in,
+                           out, n4);
+      else
+        hipLaunchKernelGGL(bw_read_kernel, dim3(grid), dim3(block), 0, s, in, n4,
+                           sink);
+    }
+    hipEventRecord(e1, s);
+    hipEventSynchronize(e1);
+    float ms = 0.0f;
+    hipEventElapsedTime(&ms, e0, e1);
+    return ms / iters; // ms per iteration
+  };
+
+  double copyMs = timeKernel(true);
+  double readMs = timeKernel(false);
+  if (copy_gbps)
+    *copy_gbps = copyMs > 0 ? (2.0 * bytes / 1e9) / (copyMs / 1000.0) : 0.0;
+  if (read_gbps)
+    *read_gbps = readMs > 0 ? ((double)bytes / 1e9) / (readMs / 1000.0) : 0.0;
+
+  hipEventDestroy(e0);
+  hipEventDestroy(e1);
+  hipFree(in);
+  hipFree(out);
+  hipFree(sink);
+  return 0;
+}

--- a/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
+++ b/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
@@ -41,6 +41,7 @@
 #include <hip/hip_runtime.h>
 #include <hip/hip_fp16.h>
 #include <cstdint>
+#include <chrono>
 #include <cstdio>
 #include <mutex>
 #include <string>
@@ -930,8 +931,15 @@ static int getOrTuneGemvConfig(
     if (it != gemv_cache.end())
         return it->second;
 
+    auto _tuneStart = std::chrono::steady_clock::now();
     int best = tuneGemvConfig(stream, A, B, sc, zp, bi, out,
                                M, N, K, batch, bs, col_major);
+    double _tuneMs = std::chrono::duration<double, std::milli>(
+                         std::chrono::steady_clock::now() - _tuneStart)
+                         .count();
+    // Cold-start autotune cost (first time this shape is seen). Analyzer sums.
+    fprintf(stderr, "[COLDSTART] autotune=%.3f s (int4 M=%lld,N=%lld,K=%lld)\n",
+            _tuneMs / 1000.0, (long long)M, (long long)N, (long long)K);
     gemv_cache[key] = best;
 
     CUSTOM_KERNELS_DEBUG_LOG(

--- a/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
+++ b/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
@@ -43,6 +43,7 @@
 #include <cstdint>
 #include <chrono>
 #include <cstdio>
+#include <cstdlib>
 #include <mutex>
 #include <string>
 #include <unordered_map>
@@ -875,7 +876,16 @@ static void logGemvOccupancy(int config_id, int64_t M, int64_t N, int64_t K,
     hipDeviceProp_t prop{};
     hipGetDeviceProperties(&prop, 0);
     int maxThreadsCU = prop.maxThreadsPerMultiProcessor;
-    int cu = prop.multiProcessorCount;
+    // NOTE: prop.multiProcessorCount is UNRELIABLE on gfx1151 (reports 16, but
+    // the part has 40 physical CUs). Prefer HIPDNN_EP_CU_COUNT when set so the
+    // grid-vs-CU utilization figure reflects real hardware.
+    int hip_mp = prop.multiProcessorCount;
+    int cu = hip_mp;
+    if (const char *e = std::getenv("HIPDNN_EP_CU_COUNT")) {
+        int v = atoi(e);
+        if (v > 0)
+            cu = v;
+    }
     double occ = maxThreadsCU > 0
                      ? 100.0 * (double)maxBlocks * c.threads / maxThreadsCU
                      : 0.0;
@@ -883,10 +893,11 @@ static void logGemvOccupancy(int config_id, int64_t M, int64_t N, int64_t K,
         (long long)((N + c.tile_n - 1) / c.tile_n) * (M > 0 ? M : 1);
     fprintf(stderr,
             "[PERF-OCC] gemv M=%lld N=%lld K=%lld cfg[%d] thr=%d tile_n=%d: "
-            "occ~%.0f%% (%d blk/CU), grid=%lld blk over %d CUs, regs=%d "
+            "occ~%.0f%% (%d blk/CU), grid=%lld blk over %d CUs "
+            "(hip_mp=%d, set HIPDNN_EP_CU_COUNT to override), regs=%d "
             "lds=%zu B\n",
             (long long)M, (long long)N, (long long)K, config_id, c.threads,
-            c.tile_n, occ, maxBlocks, gridBlocks, cu, fa.numRegs,
+            c.tile_n, occ, maxBlocks, gridBlocks, cu, hip_mp, fa.numRegs,
             (size_t)fa.sharedSizeBytes);
 }
 

--- a/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
+++ b/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
@@ -834,6 +834,62 @@ static void launchGemvConfig(
 #undef GEMV_CASE
 }
 
+// Windows-friendly rocprof substitute for the occupancy dimension: query the
+// theoretical occupancy of a GEMV config via
+// hipOccupancyMaxActiveBlocksPerMultiprocessor (+ hipFuncGetAttributes for
+// registers/LDS). Logged once per shape ([PERF-OCC]) so we can tell whether a
+// GEMV shape is occupancy-limited vs launch/latency-limited (m=1 small-N is the
+// latter -- few-flops-per-launch -- which this makes explicit).
+static void logGemvOccupancy(int config_id, int64_t M, int64_t N, int64_t K,
+                             bool col_major) {
+    const auto &c = kGemvConfigs[config_id];
+    const void *fn = nullptr;
+#define OCC_CASE(ID, BS, TN)                                                    \
+    case ID:                                                                    \
+        fn = col_major ? reinterpret_cast<const void *>(                        \
+                             &matmul_nbits_gemv_kernel<BS, TN, true>)           \
+                       : reinterpret_cast<const void *>(                        \
+                             &matmul_nbits_gemv_kernel<BS, TN, false>);         \
+        break
+    switch (config_id) {
+        OCC_CASE(0,32,1); OCC_CASE(1,32,2); OCC_CASE(2,32,4); OCC_CASE(3,32,8);
+        OCC_CASE(4,64,1); OCC_CASE(5,64,2); OCC_CASE(6,64,4); OCC_CASE(7,64,8);
+        OCC_CASE(8,64,16); OCC_CASE(9,128,1); OCC_CASE(10,128,2);
+        OCC_CASE(11,128,4); OCC_CASE(12,128,8); OCC_CASE(13,128,16);
+        OCC_CASE(14,256,1); OCC_CASE(15,256,2); OCC_CASE(16,256,4);
+        OCC_CASE(17,256,8); OCC_CASE(18,256,16); OCC_CASE(19,512,1);
+        OCC_CASE(20,512,2); OCC_CASE(21,512,4); OCC_CASE(22,512,8);
+        OCC_CASE(23,512,16); OCC_CASE(24,1024,1); OCC_CASE(25,1024,2);
+        OCC_CASE(26,1024,4); OCC_CASE(27,1024,8); OCC_CASE(28,1024,16);
+        OCC_CASE(29,64,32); OCC_CASE(30,128,32); OCC_CASE(31,256,32);
+        OCC_CASE(32,64,64); OCC_CASE(33,128,64); OCC_CASE(34,256,64);
+        default: return;
+    }
+#undef OCC_CASE
+    int maxBlocks = 0;
+    if (hipOccupancyMaxActiveBlocksPerMultiprocessor(&maxBlocks, fn, c.threads,
+                                                     0) != hipSuccess)
+        return;
+    hipFuncAttributes fa{};
+    hipFuncGetAttributes(&fa, fn);
+    hipDeviceProp_t prop{};
+    hipGetDeviceProperties(&prop, 0);
+    int maxThreadsCU = prop.maxThreadsPerMultiProcessor;
+    int cu = prop.multiProcessorCount;
+    double occ = maxThreadsCU > 0
+                     ? 100.0 * (double)maxBlocks * c.threads / maxThreadsCU
+                     : 0.0;
+    long long gridBlocks =
+        (long long)((N + c.tile_n - 1) / c.tile_n) * (M > 0 ? M : 1);
+    fprintf(stderr,
+            "[PERF-OCC] gemv M=%lld N=%lld K=%lld cfg[%d] thr=%d tile_n=%d: "
+            "occ~%.0f%% (%d blk/CU), grid=%lld blk over %d CUs, regs=%d "
+            "lds=%zu B\n",
+            (long long)M, (long long)N, (long long)K, config_id, c.threads,
+            c.tile_n, occ, maxBlocks, gridBlocks, cu, fa.numRegs,
+            (size_t)fa.sharedSizeBytes);
+}
+
 static int tuneGemvConfig(
     hipStream_t stream,
     const __half* A, const uint8_t* B,
@@ -892,6 +948,7 @@ static int tuneGemvConfig(
         best_id, kGemvConfigs[best_id].threads,
         kGemvConfigs[best_id].tile_n, best_ms / ITERS);
 
+    logGemvOccupancy(best_id, M, N, K, col_major);
     return best_id;
 }
 

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -402,6 +402,15 @@ HIP_KERNEL_API int hip_elementwise_gelu(
     int64_t approximate);
 
 /* =========================================================================
+ * Memory-bandwidth microbenchmark (roofline calibration)
+ * =========================================================================
+ * Measures device copy (read+write) and read-only bandwidth on a large buffer.
+ * Returns GB/s via the out-params. Returns 0 on success.
+ */
+HIP_KERNEL_API int hip_bw_probe(void* stream, double* copy_gbps,
+                                double* read_gbps);
+
+/* =========================================================================
  * LeakyRelu Activation
  * =========================================================================
  *

--- a/lib/Runtime/debug_log.h
+++ b/lib/Runtime/debug_log.h
@@ -9,6 +9,7 @@
 // Set HIPDNN_EP_PERF=1 to enable only [PERF] timing breakdown per inference.
 #include <cstdio>
 #include <cstdlib>
+#include <string>
 
 #ifdef _WIN32
 // Static CRT (/MT) DLLs have their own CRT env — _dupenv_s can't see env vars
@@ -57,28 +58,73 @@ inline bool hipdnn_ep_perf_isolate_enabled() {
   return enabled;
 }
 
+// Low-distortion per-op profiling: instead of a start+stop hipEvent PAIR per
+// op (two system-fenced records that the comment in op_profile.cpp notes
+// "dominated the per-op table"), record a SINGLE fenceless marker event at the
+// end of each op and derive each op's GPU time by differencing consecutive
+// markers on the (in-order) stream. Halves the record count, drops the
+// per-record system fence, and never stream-syncs per op -- so the measurement
+// perturbs the run far less than the classic pair mode. Opt in with
+// HIPDNN_EP_PERF_TIMELINE=1 (implies HIPDNN_EP_PERF=1). Mutually exclusive with
+// ISOLATE (which deliberately serializes for standalone timings).
+inline bool hipdnn_ep_perf_timeline_enabled() {
+  static const bool enabled = [] {
+#ifdef _WIN32
+    return detail::check_env("HIPDNN_EP_PERF_TIMELINE");
+#else
+    const char *v = std::getenv("HIPDNN_EP_PERF_TIMELINE");
+    return v && v[0] >= '1';
+#endif
+  }();
+  return enabled;
+}
+
 inline bool hipdnn_ep_perf_enabled() {
   // PERF intentionally does NOT inherit from HIPDNN_EP_DEBUG: enabling PERF
   // forces a hipStreamSynchronize on every inference (so hipEventElapsedTime
   // can sample the H2D / Compute / D2H phases), which serializes the GPU
   // pipeline and skews measurements. Users who only want the per-call
   // [Runtime DEBUG] traces should not pay that cost.
-  // ISOLATE implies PERF.
+  // ISOLATE and TIMELINE both imply PERF.
   static const bool enabled = [] {
 #ifdef _WIN32
     if (detail::check_env("HIPDNN_EP_PERF"))
       return true;
-    return detail::check_env("HIPDNN_EP_PERF_ISOLATE");
+    if (detail::check_env("HIPDNN_EP_PERF_ISOLATE"))
+      return true;
+    return detail::check_env("HIPDNN_EP_PERF_TIMELINE");
 #else
     const char *v = std::getenv("HIPDNN_EP_PERF");
     if (v && v[0] >= '1')
       return true;
     const char *v2 = std::getenv("HIPDNN_EP_PERF_ISOLATE");
-    return v2 && v2[0] >= '1';
+    if (v2 && v2[0] >= '1')
+      return true;
+    const char *v3 = std::getenv("HIPDNN_EP_PERF_TIMELINE");
+    return v3 && v3[0] >= '1';
 #endif
   }();
   return enabled;
 }
+
+// Chrome-trace output path (HIPDNN_EP_TRACE_FILE). Empty => tracing disabled.
+// When set (and HIPDNN_EP_PERF/TIMELINE is on), op_profile emits a per-op
+// chrome://tracing JSON in addition to the aggregated [PERF] table.
+inline const std::string &hipdnn_ep_trace_path() {
+  static const std::string path = [] {
+#ifdef _WIN32
+    char buf[1024];
+    unsigned long n =
+        GetEnvironmentVariableA("HIPDNN_EP_TRACE_FILE", buf, sizeof(buf));
+    return (n > 0 && n < sizeof(buf)) ? std::string(buf, n) : std::string();
+#else
+    const char *v = std::getenv("HIPDNN_EP_TRACE_FILE");
+    return v ? std::string(v) : std::string();
+#endif
+  }();
+  return path;
+}
+inline bool hipdnn_ep_trace_enabled() { return !hipdnn_ep_trace_path().empty(); }
 
 #define RUNTIME_DEBUG_LOG(fmt, ...)                                            \
   do {                                                                         \

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -372,8 +372,12 @@ static int bulk_load_constants(RuntimeState *state, morphizen::FileSystem *fs,
     return 1;
   }
 
-  TIMING_LOG("[Session] hipMemcpy H2D bulk: %.3fs (%zu bytes)\n",
-             record_elapsed(t_prev), total_size);
+  double _uploadS = record_elapsed(t_prev);
+  TIMING_LOG("[Session] hipMemcpy H2D bulk: %.3fs (%zu bytes)\n", _uploadS,
+             total_size);
+  // Cold-start phase timer (emitted once per session, load-path only).
+  fprintf(stderr, "[COLDSTART] weight_upload=%.3f s (%zu bytes)\n", _uploadS,
+          total_size);
 
   free(cpu_buf); // no-op when mmap was used
   return 0;

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -12,6 +12,7 @@
 #include "model_metadata_generated.h"
 #include "morphizen-foundation/file_io.hpp"
 
+#include <chrono>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -329,6 +330,7 @@ static int hipmalloc_and_fixup(RuntimeState *state,
 static int bulk_load_constants(RuntimeState *state, morphizen::FileSystem *fs,
                                const char *constants_filename) {
   auto t_prev = timing_now();
+  auto _csUploadStart = std::chrono::steady_clock::now();
 
   auto reader = fs->create_reader_template(constants_filename);
   if (!reader) {
@@ -372,10 +374,12 @@ static int bulk_load_constants(RuntimeState *state, morphizen::FileSystem *fs,
     return 1;
   }
 
-  double _uploadS = record_elapsed(t_prev);
-  TIMING_LOG("[Session] hipMemcpy H2D bulk: %.3fs (%zu bytes)\n", _uploadS,
-             total_size);
-  // Cold-start phase timer (emitted once per session, load-path only).
+  TIMING_LOG("[Session] hipMemcpy H2D bulk: %.3fs (%zu bytes)\n",
+             record_elapsed(t_prev), total_size);
+  // Cold-start phase timer (bulk-blob path). Independent chrono timer.
+  double _uploadS = std::chrono::duration<double>(
+                        std::chrono::steady_clock::now() - _csUploadStart)
+                        .count();
   fprintf(stderr, "[COLDSTART] weight_upload=%.3f s (%zu bytes)\n", _uploadS,
           total_size);
 
@@ -551,6 +555,7 @@ static int per_entry_load_constants(RuntimeState *state,
                                     morphizen::FileSystem *fs,
                                     const char *constants_filename) {
   auto t_prev = timing_now();
+  auto _csUploadStart = std::chrono::steady_clock::now();
 
   auto *constants = meta->constants();
   int64_t count = constants ? (int64_t)constants->size() : 0;
@@ -669,6 +674,14 @@ static int per_entry_load_constants(RuntimeState *state,
 
   TIMING_LOG("[Session] per_entry upload: %.3fs (%lld constants)\n",
              record_elapsed(t_prev), (long long)count);
+  // Cold-start phase timer (streaming/per-entry constants path). Uses an
+  // independent chrono timer -- timing_now()/record_elapsed are no-ops unless
+  // the TIMING build flag is set.
+  double _uploadS = std::chrono::duration<double>(
+                        std::chrono::steady_clock::now() - _csUploadStart)
+                        .count();
+  fprintf(stderr, "[COLDSTART] weight_upload=%.3f s (%lld constants, streaming)\n",
+          _uploadS, (long long)count);
 
   free(staging);
   fref_cache_release(&fcache);

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -17,6 +17,9 @@
 #include <cstdlib>
 #include <cstring>
 
+// Roofline-calibration bandwidth probe (custom_kernels DLL, extern "C").
+extern "C" int hip_bw_probe(void *stream, double *copy_gbps, double *read_gbps);
+
 // Forward decl of static helpers defined later in this file.
 static int initialize_state_handles(RuntimeState **out_state);
 static int prepare_constants_array(RuntimeState *state,
@@ -203,6 +206,18 @@ static int initialize_state_handles(RuntimeState **out_state) {
   }
 
   TIMING_LOG("[Session] hipStreamCreate: %.3fs\n", record_elapsed(t_prev));
+
+  // Optional roofline calibration: measure real device bandwidth once instead
+  // of assuming a spec peak. Gated on HIPDNN_EP_BW_PROBE to keep init fast.
+  if (std::getenv("HIPDNN_EP_BW_PROBE")) {
+    double copy_gbps = 0, read_gbps = 0;
+    if (hip_bw_probe(state->stream, &copy_gbps, &read_gbps) == 0) {
+      fprintf(stderr,
+              "[BW-PROBE] device bandwidth: copy=%.0f GB/s (read+write), "
+              "read=%.0f GB/s\n",
+              copy_gbps, read_gbps);
+    }
+  }
 
   if (miopenCreate(&state->miopen_handle) != miopenStatusSuccess) {
     fprintf(stderr, "Failed to create MIOpen handle\n");

--- a/lib/Runtime/hipdnn_ep_runtime_tensor.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_tensor.cpp
@@ -423,6 +423,11 @@ int hipdnn_ep_tensor_prepare_input(RuntimeState *state, span_t *inputs,
                        g_perf.h2d_bytes / 1048576.0, h2d_ms, compute_ms,
                        g_perf.d2h_count, g_perf.d2h_bytes / 1048576.0, d2h_ms,
                        total_ms);
+      // Chrome trace: add the just-closed inference's pipeline phase spans
+      // (H2D / Compute / D2H) on their own tracks. No-op unless tracing is on.
+      op_profile_add_io_spans(static_cast<OpProfileState *>(state->op_profile),
+                              h2d_ms, (int64_t)g_perf.h2d_bytes, compute_ms,
+                              d2h_ms, (int64_t)g_perf.d2h_bytes);
     }
     g_perf.h2d_bytes = 0;
     g_perf.h2d_count = 0;

--- a/lib/Runtime/op_profile.cpp
+++ b/lib/Runtime/op_profile.cpp
@@ -6,6 +6,7 @@
 #include "op_profile.h"
 #include <algorithm>
 #include <cstdio>
+#include <cstdlib>
 #include <map>
 #include <string>
 #include <vector>
@@ -16,6 +17,7 @@ struct OpProfileState {
     double gpuMs = 0;
     double cpuMs = 0;
     int64_t count = 0;
+    int64_t bytes = 0; // total data footprint across calls (0 = unknown)
   };
   struct OpEntry {
     std::string name;
@@ -24,12 +26,14 @@ struct OpProfileState {
     double totalGpuMs = 0;
     double totalCpuMs = 0;
     int64_t totalCount = 0;
+    int64_t totalBytes = 0;
   };
   struct PendingEvent {
     std::string name;
     std::string shape;
     int eventIndex;
     double cpuMs;
+    int64_t bytes;
   };
 
   // Pre-allocated event pool: each pair is (start, stop).
@@ -105,10 +109,22 @@ hipEvent_t op_profile_get_stop_event(OpProfileState *ps, int index) {
 
 void op_profile_add_pending(OpProfileState *ps, const std::string &name,
                             const std::string &shape, int eventIndex,
-                            double cpuMs) {
+                            double cpuMs, int64_t bytes) {
   if (!ps)
     return;
-  ps->pending.push_back({name, shape, eventIndex, cpuMs});
+  ps->pending.push_back({name, shape, eventIndex, cpuMs, bytes});
+}
+
+double op_profile_roofline_gbps() {
+  static double gbps = [] {
+    if (const char *e = std::getenv("HIPDNN_EP_ROOFLINE_GBPS")) {
+      double v = atof(e);
+      if (v > 0)
+        return v;
+    }
+    return 256.0; // Strix Halo LPDDR5X default
+  }();
+  return gbps;
 }
 
 void op_profile_add_cpu(OpProfileState *ps, const std::string &name,
@@ -143,9 +159,11 @@ void op_profile_resolve_and_print(OpProfileState *ps) {
     sh.gpuMs += gpuMs;
     sh.cpuMs += ev.cpuMs;
     sh.count++;
+    sh.bytes += ev.bytes;
     op.totalGpuMs += gpuMs;
     op.totalCpuMs += ev.cpuMs;
     op.totalCount++;
+    op.totalBytes += ev.bytes;
   }
   ps->pending.clear();
 
@@ -158,6 +176,7 @@ void op_profile_resolve_and_print(OpProfileState *ps) {
     double totalGpuMs;
     double totalCpuMs;
     int64_t totalCount;
+    int64_t totalBytes;
     std::vector<OpProfileState::ShapeEntry> shapes;
   };
 
@@ -170,6 +189,7 @@ void op_profile_resolve_and_print(OpProfileState *ps) {
     row.totalGpuMs = op.totalGpuMs;
     row.totalCpuMs = op.totalCpuMs;
     row.totalCount = op.totalCount;
+    row.totalBytes = op.totalBytes;
     if ((int)row.name.size() > maxNameLen)
       maxNameLen = (int)row.name.size();
     for (auto &[_, sh] : op.shapes) {
@@ -200,21 +220,41 @@ void op_profile_resolve_and_print(OpProfileState *ps) {
     grandTotalCpuMs += r.totalCpuMs;
   }
 
-  int lineWidth = maxNameLen + 2 + 5 + 1 + 9 + 1 + 9 + 1 + 6;
+  const double peakGbps = op_profile_roofline_gbps();
+  // Achieved bandwidth (GB/s) and % of the memory roofline for a (bytes, ms)
+  // pair; empty strings when bytes are unknown (op not byte-instrumented).
+  auto fmtBw = [peakGbps](int64_t bytes, double ms, char *mbBuf, char *gbBuf,
+                          char *pkBuf, size_t n) {
+    if (bytes > 0 && ms > 0) {
+      double gbps = (double)bytes / 1e9 / (ms / 1000.0);
+      snprintf(mbBuf, n, "%.1f", (double)bytes / 1e6);
+      snprintf(gbBuf, n, "%.0f", gbps);
+      snprintf(pkBuf, n, "%.0f%%", 100.0 * gbps / peakGbps);
+    } else {
+      snprintf(mbBuf, n, "%s", "-");
+      snprintf(gbBuf, n, "%s", "-");
+      snprintf(pkBuf, n, "%s", "-");
+    }
+  };
+  char mbBuf[24], gbBuf[24], pkBuf[24];
+
+  int lineWidth = maxNameLen + 2 + 5 + 1 + 9 + 1 + 9 + 1 + 6 + 1 + 9 + 1 + 8 + 1 + 6;
   fprintf(stderr, "\n[PERF] ");
   for (int i = 0; i < lineWidth; ++i)
     fputc('=', stderr);
   fputc('\n', stderr);
-  fprintf(stderr, "[PERF]  %-*s %5s %9s %9s %6s\n", maxNameLen, "", "calls",
-          "gpu (ms)", "cpu (ms)", "gpu %");
+  fprintf(stderr, "[PERF]  %-*s %5s %9s %9s %6s %9s %8s %6s   (roofline %.0f GB/s)\n",
+          maxNameLen, "", "calls", "gpu (ms)", "cpu (ms)", "gpu %", "MB",
+          "GB/s", "%pk", peakGbps);
 
   for (auto &r : rows) {
     if (r.hasGpu) {
       double pct =
           grandTotalGpuMs > 0 ? r.totalGpuMs / grandTotalGpuMs * 100 : 0;
-      fprintf(stderr, "[PERF]  %-*s %5lld %9.1f %9.1f %5.1f%%\n", maxNameLen,
-              r.name.c_str(), (long long)r.totalCount, r.totalGpuMs,
-              r.totalCpuMs, pct);
+      fmtBw(r.totalBytes, r.totalGpuMs, mbBuf, gbBuf, pkBuf, sizeof(mbBuf));
+      fprintf(stderr, "[PERF]  %-*s %5lld %9.1f %9.1f %5.1f%% %9s %8s %6s\n",
+              maxNameLen, r.name.c_str(), (long long)r.totalCount, r.totalGpuMs,
+              r.totalCpuMs, pct, mbBuf, gbBuf, pkBuf);
     } else {
       fprintf(stderr, "[PERF]  %-*s %5lld %9s %9.1f %6s\n", maxNameLen,
               r.name.c_str(), (long long)r.totalCount, "n/a", r.totalCpuMs,
@@ -227,9 +267,10 @@ void op_profile_resolve_and_print(OpProfileState *ps) {
         if (sh.shape.empty())
           continue;
         double pct = grandTotalGpuMs > 0 ? sh.gpuMs / grandTotalGpuMs * 100 : 0;
-        fprintf(stderr, "[PERF]    %-*s %5lld %9.1f %9.1f %5.1f%%\n",
+        fmtBw(sh.bytes, sh.gpuMs, mbBuf, gbBuf, pkBuf, sizeof(mbBuf));
+        fprintf(stderr, "[PERF]    %-*s %5lld %9.1f %9.1f %5.1f%% %9s %8s %6s\n",
                 maxNameLen - 2, sh.shape.c_str(), (long long)sh.count, sh.gpuMs,
-                sh.cpuMs, pct);
+                sh.cpuMs, pct, mbBuf, gbBuf, pkBuf);
       }
     }
   }

--- a/lib/Runtime/op_profile.cpp
+++ b/lib/Runtime/op_profile.cpp
@@ -73,10 +73,34 @@ void op_profile_reset(OpProfileState *ps) {
 
 bool op_profile_is_active(OpProfileState *ps) { return ps && ps->active; }
 
+// One-time diagnostic sink for HIP-event failures on the profiling path.
+// Prints the first few failures with the hipError string + phase so we can
+// pinpoint the "invalid resource handle" root cause instead of guessing.
+static int g_opProfEventErrs = 0;
+void op_profile_note_event_error(const char *phase, int err) {
+  if (g_opProfEventErrs < 8) {
+    ++g_opProfEventErrs;
+    fprintf(stderr, "[PERF-DIAG] hipEvent %s failed: %s (%d)\n", phase,
+            hipGetErrorString(static_cast<hipError_t>(err)), err);
+  }
+}
+
+// Whether to create profiler events with hipEventDisableSystemFence. Defaults
+// to OFF (plain hipEventCreate) -- the disable-fence flag is the prime suspect
+// for the profiling-path "invalid resource handle". Opt back in with
+// HIPDNN_EP_PERF_FENCE_EVENTS=1 to A/B it.
+static bool op_profile_use_disable_fence() {
+  static bool v = [] {
+    const char *e = std::getenv("HIPDNN_EP_PERF_FENCE_EVENTS");
+    return e && (e[0] == '1' || e[0] == 'y' || e[0] == 'Y');
+  }();
+  return v;
+}
+
 int op_profile_acquire_event_pair(OpProfileState *ps) {
   int idx = ps->nextEventIndex++;
   if (idx >= (int)ps->eventPool.size()) {
-    OpProfileState::EventPair ep;
+    OpProfileState::EventPair ep{};
     // Canonical rationale for hipEventDisableSystemFence across the profiler
     // (other call sites reference this comment): hipEventRecord issues a
     // system-scope acquire/release fence by default, which is wasted work for
@@ -92,8 +116,18 @@ int op_profile_acquire_event_pair(OpProfileState *ps) {
     //
     // Pool slots are created once and reused across inferences, so creation
     // cost is paid during warmup and every later record is free.
-    hipEventCreateWithFlags(&ep.start, hipEventDisableSystemFence);
-    hipEventCreateWithFlags(&ep.stop, hipEventDisableSystemFence);
+    unsigned flags =
+        op_profile_use_disable_fence() ? hipEventDisableSystemFence : hipEventDefault;
+    hipError_t e1 = hipEventCreateWithFlags(&ep.start, flags);
+    hipError_t e2 = hipEventCreateWithFlags(&ep.stop, flags);
+    if (e1 != hipSuccess || e2 != hipSuccess) {
+      op_profile_note_event_error("create", e1 != hipSuccess ? e1 : e2);
+      // Fall back to plain default events.
+      if (e1 == hipSuccess) hipEventDestroy(ep.start);
+      if (e2 == hipSuccess) hipEventDestroy(ep.stop);
+      hipEventCreate(&ep.start);
+      hipEventCreate(&ep.stop);
+    }
     ps->eventPool.push_back(ep);
   }
   return idx;
@@ -147,8 +181,13 @@ void op_profile_resolve_and_print(OpProfileState *ps) {
 
   for (auto &ev : ps->pending) {
     float gpuMs = 0.0f;
-    hipEventElapsedTime(&gpuMs, ps->eventPool[ev.eventIndex].start,
-                        ps->eventPool[ev.eventIndex].stop);
+    hipError_t elErr = hipEventElapsedTime(
+        &gpuMs, ps->eventPool[ev.eventIndex].start,
+        ps->eventPool[ev.eventIndex].stop);
+    if (elErr != hipSuccess) {
+      op_profile_note_event_error("elapsed", elErr);
+      gpuMs = 0.0f;
+    }
     auto &op = ps->profile[ev.name];
     if (op.name.empty())
       op.name = ev.name;
@@ -166,6 +205,13 @@ void op_profile_resolve_and_print(OpProfileState *ps) {
     op.totalBytes += ev.bytes;
   }
   ps->pending.clear();
+
+  // Consume any sticky HIP error introduced by the profiler's own event calls
+  // (e.g. a hipEventElapsedTime on a not-fully-ready event). Otherwise the next
+  // Compute's first kernel wrapper that calls hipGetLastError() (hip_reduce_sum,
+  // the generic elementwise path) misattributes it as its own launch failure --
+  // the root cause of the "invalid resource handle" seen only under profiling.
+  (void)hipGetLastError();
 
   if (ps->profile.empty())
     return;

--- a/lib/Runtime/op_profile.cpp
+++ b/lib/Runtime/op_profile.cpp
@@ -31,8 +31,25 @@ struct OpProfileState {
   struct PendingEvent {
     std::string name;
     std::string shape;
-    int eventIndex;
+    int eventIndex; // pair index (classic) OR marker index (timeline)
     double cpuMs;
+    int64_t bytes;
+    bool timeline;    // true => eventIndex is a marker index into markerPool
+    double cpuStartUs; // op start, us since inference CPU epoch (chrome trace)
+  };
+
+  // Chrome-trace timeline point (retained only when HIPDNN_EP_TRACE_FILE set).
+  struct TimelineEvent {
+    std::string name, shape;
+    double tsUs, durUs; // GPU track (epoch-anchored)
+    double cpuTsUs, cpuDurUs; // CPU track (wrapper wall time)
+    int64_t bytes;
+  };
+  // H2D / Compute / D2H phase span for the pipeline track (own tids).
+  struct IoSpan {
+    std::string name;
+    int tid;
+    double tsUs, durUs;
     int64_t bytes;
   };
 
@@ -45,12 +62,42 @@ struct OpProfileState {
   std::vector<EventPair> eventPool;
   int nextEventIndex = 0;
 
+  // Timeline (low-distortion) mode: a single fenceless marker event per op plus
+  // one per-inference epoch event. Per-op GPU time is derived by differencing
+  // consecutive markers against the epoch on the (in-order) stream, so we pay
+  // one fenceless record per op instead of a fenced start+stop pair.
+  hipEvent_t epoch = nullptr;
+  bool epochRecorded = false;
+  std::vector<hipEvent_t> markerPool;
+  int nextMarker = 0;
+
   std::map<std::string, OpEntry> profile;
   std::vector<PendingEvent> pending;
   bool active = false;
+
+  // Chrome trace (HIPDNN_EP_TRACE_FILE): CPU epoch for this inference, all
+  // retained timeline points across inferences, and the running wall offset that
+  // lays consecutive inferences end-to-end on one timeline.
+  double gpuEpochAbsUs = 0.0; // ABSOLUTE us (since the process-wide trace epoch)
+                              // at which this inference's GPU epoch was recorded
+  std::vector<TimelineEvent> timeline;
+  std::vector<IoSpan> ioSpans;
+  int sessionId = 0;          // distinguishes concurrent EP sessions (own file)
 };
 
-OpProfileState *op_profile_create() { return new OpProfileState; }
+// One process-wide absolute time base for the chrome trace: every EP session
+// (embedding, decoder, ...) and every inference share this axis, so traces align
+// and merge without per-track/per-inference epoch guessing. Real gaps between
+// inferences (idle) show up naturally because absolute time keeps advancing.
+static std::chrono::steady_clock::time_point g_traceEpoch;
+static bool g_traceEpochSet = false;
+static int g_nextSessionId = 0;
+
+OpProfileState *op_profile_create() {
+  auto *ps = new OpProfileState;
+  ps->sessionId = g_nextSessionId++;
+  return ps;
+}
 
 void op_profile_destroy(OpProfileState *ps) {
   if (!ps)
@@ -59,6 +106,10 @@ void op_profile_destroy(OpProfileState *ps) {
     hipEventDestroy(ep.start);
     hipEventDestroy(ep.stop);
   }
+  for (auto &m : ps->markerPool)
+    hipEventDestroy(m);
+  if (ps->epoch)
+    hipEventDestroy(ps->epoch);
   delete ps;
 }
 
@@ -68,7 +119,22 @@ void op_profile_reset(OpProfileState *ps) {
   ps->profile.clear();
   ps->pending.clear();
   ps->nextEventIndex = 0;
+  ps->nextMarker = 0;
+  ps->epochRecorded = false; // re-anchor the timeline at the next op
   ps->active = true;
+  ps->gpuEpochAbsUs = 0.0;
+  if (hipdnn_ep_trace_enabled() && !g_traceEpochSet) {
+    g_traceEpoch = std::chrono::steady_clock::now();
+    g_traceEpochSet = true;
+  }
+}
+
+double op_profile_cpu_now_us(OpProfileState *ps) {
+  if (!ps || !hipdnn_ep_trace_enabled() || !g_traceEpochSet)
+    return 0.0;
+  return std::chrono::duration<double, std::micro>(
+             std::chrono::steady_clock::now() - g_traceEpoch)
+      .count();
 }
 
 bool op_profile_is_active(OpProfileState *ps) { return ps && ps->active; }
@@ -141,12 +207,75 @@ hipEvent_t op_profile_get_stop_event(OpProfileState *ps, int index) {
   return ps->eventPool[index].stop;
 }
 
+// Timeline mode: markers are fenceless (hipEventDisableSystemFence). Their
+// elapsed time is read only after the per-inference stream sync, so the default
+// system fence is pure overhead here -- and dropping it is the whole point of
+// this low-distortion path. See the fence rationale in op_profile_acquire_event_pair.
+static hipEvent_t op_profile_make_marker() {
+  hipEvent_t e = nullptr;
+  hipError_t err = hipEventCreateWithFlags(&e, hipEventDisableSystemFence);
+  if (err != hipSuccess || !e) {
+    op_profile_note_event_error("create_marker", err);
+    hipEventCreate(&e); // fall back to a plain event
+  }
+  return e;
+}
+
+void op_profile_ensure_epoch(OpProfileState *ps, hipStream_t stream) {
+  if (!ps || ps->epochRecorded)
+    return;
+  if (!ps->epoch)
+    ps->epoch = op_profile_make_marker();
+  hipError_t e = hipEventRecord(ps->epoch, stream);
+  if (e != hipSuccess)
+    op_profile_note_event_error("record_epoch", e);
+  (void)hipGetLastError(); // consume hipEventRecord sticky artifact (see scope)
+  ps->epochRecorded = true;
+  // Absolute time (on the shared trace axis) at which the GPU epoch was
+  // recorded. Adding this to each op's GPU-elapsed offset places the GPU track
+  // on the same absolute clock as the CPU track -> aligned, no epoch guessing.
+  ps->gpuEpochAbsUs = op_profile_cpu_now_us(ps);
+}
+
+int op_profile_acquire_marker(OpProfileState *ps) {
+  int idx = ps->nextMarker++;
+  if (idx >= (int)ps->markerPool.size())
+    ps->markerPool.push_back(op_profile_make_marker());
+  return idx;
+}
+
+hipEvent_t op_profile_get_marker_event(OpProfileState *ps, int index) {
+  return ps->markerPool[index];
+}
+
 void op_profile_add_pending(OpProfileState *ps, const std::string &name,
                             const std::string &shape, int eventIndex,
-                            double cpuMs, int64_t bytes) {
+                            double cpuMs, int64_t bytes, bool timeline,
+                            double cpuStartUs) {
   if (!ps)
     return;
-  ps->pending.push_back({name, shape, eventIndex, cpuMs, bytes});
+  ps->pending.push_back(
+      {name, shape, eventIndex, cpuMs, bytes, timeline, cpuStartUs});
+}
+
+static void write_chrome_trace(OpProfileState *ps);
+
+void op_profile_add_io_spans(OpProfileState *ps, double h2dMs, int64_t h2dBytes,
+                             double computeMs, double d2hMs, int64_t d2hBytes) {
+  // Called from the tensor runtime's per-inference flush for the inference that
+  // just resolved. Placed on dedicated pipeline tracks (H2D/Compute/D2H) within
+  // that inference's window (from its GPU epoch). Placement is approximate -- the
+  // phase events use a different epoch than the per-op GPU track -- so treat
+  // these as the pipeline breakdown, not perfectly aligned to the op spans.
+  if (!ps || !hipdnn_ep_trace_enabled())
+    return;
+  double t = ps->gpuEpochAbsUs; // absolute start of the just-resolved inference
+  ps->ioSpans.push_back({"H2D", 2, t, h2dMs * 1000.0, h2dBytes});
+  t += h2dMs * 1000.0;
+  ps->ioSpans.push_back({"Compute", 4, t, computeMs * 1000.0, 0});
+  t += computeMs * 1000.0;
+  ps->ioSpans.push_back({"D2H", 3, t, d2hMs * 1000.0, d2hBytes});
+  write_chrome_trace(ps);
 }
 
 double op_profile_roofline_gbps() {
@@ -175,18 +304,122 @@ void op_profile_add_cpu(OpProfileState *ps, const std::string &name,
   op.totalCount++;
 }
 
+// Chrome trace writer (chrome://tracing / Perfetto). Emits one GPU track
+// (epoch-anchored, faithful in timeline mode) and one CPU track (wrapper wall
+// time) with shape/bytes/GB-s args. Rewrites the whole file each inference so
+// the trace stays valid mid-run; events from all inferences sit at their real
+// absolute times on the shared axis. Gated by HIPDNN_EP_TRACE_FILE.
+static void write_chrome_trace(OpProfileState *ps) {
+  const std::string &base = hipdnn_ep_trace_path();
+  if (base.empty())
+    return;
+  // Per-session file: insert ".sN" before the extension so concurrent EP
+  // sessions (embedding, decoder, ...) don't clobber one shared file. They all
+  // share the absolute time axis, so merge_traces.py aligns them exactly.
+  size_t dot = base.find_last_of('.');
+  std::string path = (dot == std::string::npos)
+                         ? base + ".s" + std::to_string(ps->sessionId)
+                         : base.substr(0, dot) + ".s" +
+                               std::to_string(ps->sessionId) + base.substr(dot);
+  FILE *f = fopen(path.c_str(), "w");
+  if (!f)
+    return;
+  fputs("{\"displayTimeUnit\":\"ns\",\"traceEvents\":[\n", f);
+  fprintf(f, "{\"name\":\"process_name\",\"ph\":\"M\",\"pid\":0,\"tid\":0,"
+             "\"args\":{\"name\":\"hipdnn-ep session %d\"}},\n", ps->sessionId);
+  fputs("{\"name\":\"thread_name\",\"ph\":\"M\",\"pid\":0,\"tid\":0,"
+        "\"args\":{\"name\":\"CPU (wrapper)\"}},\n", f);
+  fputs("{\"name\":\"thread_name\",\"ph\":\"M\",\"pid\":0,\"tid\":1,"
+        "\"args\":{\"name\":\"GPU (stream)\"}},\n", f);
+  fputs("{\"name\":\"thread_name\",\"ph\":\"M\",\"pid\":0,\"tid\":2,"
+        "\"args\":{\"name\":\"H2D\"}},\n", f);
+  fputs("{\"name\":\"thread_name\",\"ph\":\"M\",\"pid\":0,\"tid\":3,"
+        "\"args\":{\"name\":\"D2H\"}},\n", f);
+  fputs("{\"name\":\"thread_name\",\"ph\":\"M\",\"pid\":0,\"tid\":4,"
+        "\"args\":{\"name\":\"Compute (phase)\"}}", f);
+  const double peak = op_profile_roofline_gbps();
+  for (auto &s : ps->ioSpans) {
+    fprintf(f,
+            ",\n{\"name\":\"%s\",\"cat\":\"io\",\"ph\":\"X\",\"pid\":0,"
+            "\"tid\":%d,\"ts\":%.3f,\"dur\":%.3f,\"args\":{\"bytes\":%lld}}",
+            s.name.c_str(), s.tid, s.tsUs, s.durUs, (long long)s.bytes);
+  }
+  for (auto &e : ps->timeline) {
+    double gbps = (e.bytes > 0 && e.durUs > 0)
+                      ? (double)e.bytes / 1e3 / e.durUs
+                      : 0.0; // bytes / us = GB/s * 1e-... : bytes/(us)/1e3
+    // GPU span
+    fprintf(f,
+            ",\n{\"name\":\"%s\",\"cat\":\"gpu\",\"ph\":\"X\",\"pid\":0,"
+            "\"tid\":1,\"ts\":%.3f,\"dur\":%.3f,\"args\":{\"shape\":\"%s\","
+            "\"bytes\":%lld,\"GB/s\":%.0f,\"%%peak\":%.0f}}",
+            e.name.c_str(), e.tsUs, e.durUs, e.shape.c_str(),
+            (long long)e.bytes, gbps, peak > 0 ? 100.0 * gbps / peak : 0.0);
+    // CPU span (host-side wrapper time: launch overhead + setup)
+    fprintf(f,
+            ",\n{\"name\":\"%s\",\"cat\":\"cpu\",\"ph\":\"X\",\"pid\":0,"
+            "\"tid\":0,\"ts\":%.3f,\"dur\":%.3f,\"args\":{\"shape\":\"%s\"}}",
+            e.name.c_str(), e.cpuTsUs, e.cpuDurUs, e.shape.c_str());
+  }
+  fputs("\n]}\n", f);
+  fclose(f);
+}
+
 void op_profile_resolve_and_print(OpProfileState *ps) {
   if (!ps)
     return;
 
+  // Timeline mode: each op's GPU time is the gap between its marker and the
+  // previous marker (or the epoch for the first op) on the in-order stream.
+  // pending is in enqueue order, so cumulative-from-epoch differencing yields
+  // per-op durations without any per-op start event.
+  const bool traceOn = hipdnn_ep_trace_enabled();
+  double tlPrevMs = 0.0;
   for (auto &ev : ps->pending) {
     float gpuMs = 0.0f;
-    hipError_t elErr = hipEventElapsedTime(
-        &gpuMs, ps->eventPool[ev.eventIndex].start,
-        ps->eventPool[ev.eventIndex].stop);
-    if (elErr != hipSuccess) {
-      op_profile_note_event_error("elapsed", elErr);
-      gpuMs = 0.0f;
+    double gpuStartMs = -1.0; // epoch-relative start (timeline mode only)
+    if (ev.timeline) {
+      if (ps->epoch) {
+        float cumMs = 0.0f;
+        hipError_t elErr = hipEventElapsedTime(
+            &cumMs, ps->epoch, ps->markerPool[ev.eventIndex]);
+        if (elErr != hipSuccess) {
+          op_profile_note_event_error("elapsed_marker", elErr);
+          cumMs = (float)tlPrevMs;
+        }
+        gpuMs = (float)(cumMs - tlPrevMs);
+        if (gpuMs < 0.0f)
+          gpuMs = 0.0f; // guard against event resolution jitter
+        gpuStartMs = tlPrevMs; // op ran from prev marker to this one
+        tlPrevMs = cumMs;
+      }
+    } else {
+      hipError_t elErr = hipEventElapsedTime(
+          &gpuMs, ps->eventPool[ev.eventIndex].start,
+          ps->eventPool[ev.eventIndex].stop);
+      if (elErr != hipSuccess) {
+        op_profile_note_event_error("elapsed", elErr);
+        gpuMs = 0.0f;
+      }
+      // Epoch-anchored start for classic mode (faithful chrome-trace placement).
+      if (traceOn && ps->epoch) {
+        float st = 0.0f;
+        if (hipEventElapsedTime(&st, ps->epoch,
+                                ps->eventPool[ev.eventIndex].start) ==
+            hipSuccess)
+          gpuStartMs = st;
+      }
+    }
+    if (traceOn) {
+      // Absolute timestamps on the shared axis. GPU start = inference's GPU
+      // epoch (absolute) + this op's GPU-elapsed offset; CPU start = absolute
+      // wrapper-entry time. Both already share the process trace epoch, so no
+      // per-track/per-inference re-basing is needed.
+      double gTsUs = (gpuStartMs >= 0.0)
+                         ? ps->gpuEpochAbsUs + gpuStartMs * 1000.0
+                         : ev.cpuStartUs;
+      ps->timeline.push_back({ev.name, ev.shape, gTsUs, gpuMs * 1000.0,
+                              ev.cpuStartUs, ev.cpuMs * 1000.0, ev.bytes});
     }
     auto &op = ps->profile[ev.name];
     if (op.name.empty())
@@ -205,6 +438,9 @@ void op_profile_resolve_and_print(OpProfileState *ps) {
     op.totalBytes += ev.bytes;
   }
   ps->pending.clear();
+
+  if (traceOn)
+    write_chrome_trace(ps); // absolute-axis; per-session file (own sessionId)
 
   // Consume any sticky HIP error introduced by the profiler's own event calls
   // (e.g. a hipEventElapsedTime on a not-fully-ready event). Otherwise the next

--- a/lib/Runtime/op_profile.h
+++ b/lib/Runtime/op_profile.h
@@ -25,7 +25,20 @@ void op_profile_reset(OpProfileState *ps);
 void op_profile_resolve_and_print(OpProfileState *ps);
 void op_profile_add_pending(OpProfileState *ps, const std::string &name,
                             const std::string &shape, int eventIndex,
-                            double cpuMs, int64_t bytes = 0);
+                            double cpuMs, int64_t bytes = 0,
+                            bool timeline = false, double cpuStartUs = 0.0);
+// Microseconds since this inference's CPU epoch (set in op_profile_reset). Used
+// to place ops on the CPU track of the chrome trace. 0 when tracing is off.
+double op_profile_cpu_now_us(OpProfileState *ps);
+// Add H2D/Compute/D2H pipeline spans (ms) for the most recently resolved
+// inference to the chrome trace's dedicated tracks. No-op unless tracing is on.
+void op_profile_add_io_spans(OpProfileState *ps, double h2dMs, int64_t h2dBytes,
+                             double computeMs, double d2hMs, int64_t d2hBytes);
+// Timeline (low-distortion) mode helpers: one epoch event per inference plus a
+// single fenceless marker per op. See hipdnn_ep_perf_timeline_enabled().
+void op_profile_ensure_epoch(OpProfileState *ps, hipStream_t stream);
+int op_profile_acquire_marker(OpProfileState *ps);
+hipEvent_t op_profile_get_marker_event(OpProfileState *ps, int index);
 // Roofline peak (GB/s) used for the [PERF] %peak column. Reads
 // HIPDNN_EP_ROOFLINE_GBPS once; defaults to 256 (Strix Halo LPDDR5X).
 double op_profile_roofline_gbps();
@@ -62,15 +75,25 @@ struct OpProfileScope {
   OpProfileState *ps;
   std::string name;
   std::string shape;
-  int eventIndex;
+  int eventIndex; // pair index (classic) OR marker index (timeline)
   hipStream_t stream;
   int64_t bytes;
+  bool timeline;
+  double cpuTsUs = 0.0; // op start, us since inference CPU epoch (chrome trace)
   std::chrono::steady_clock::time_point cpuStart;
 
   OpProfileScope(OpProfileState *p, std::string n, std::string sh,
-                 hipStream_t s, int evIdx, int64_t b = 0)
+                 hipStream_t s, int evIdx, int64_t b = 0, bool tl = false)
       : ps(p), name(std::move(n)), shape(std::move(sh)), eventIndex(evIdx),
-        stream(s), bytes(b) {
+        stream(s), bytes(b), timeline(tl) {
+    cpuStart = std::chrono::steady_clock::now();
+    cpuTsUs = op_profile_cpu_now_us(ps);
+    if (timeline)
+      // Low-distortion path: the epoch is recorded by the macro before this
+      // op's kernels are enqueued, and the op's GPU time is derived from the
+      // marker recorded in the destructor. Nothing to enqueue here -- no start
+      // event, no stream sync -- so the op runs essentially unperturbed.
+      return;
     // Sync-isolated diagnostic mode: drain the stream BEFORE we start timing,
     // so this op's reported GPU time excludes any work queued ahead of us.
     // Pairs with the post-stop sync in the destructor to give standalone
@@ -90,6 +113,22 @@ struct OpProfileScope {
   }
 
   ~OpProfileScope() {
+    if (timeline) {
+      // Single fenceless marker at the end of the op; no stream sync. Per-op
+      // duration = this marker minus the previous one (resolved at print time).
+      hipError_t _e =
+          hipEventRecord(op_profile_get_marker_event(ps, eventIndex), stream);
+      if (_e != hipSuccess)
+        op_profile_note_event_error("record_marker", _e);
+      (void)hipGetLastError(); // consume hipEventRecord sticky artifact
+      double ms = std::chrono::duration<double, std::milli>(
+                      std::chrono::steady_clock::now() - cpuStart)
+                      .count();
+      if (ps)
+        op_profile_add_pending(ps, name, shape, eventIndex, ms, bytes, true,
+                               cpuTsUs);
+      return;
+    }
     hipError_t _e = hipEventRecord(op_profile_get_stop_event(ps, eventIndex), stream);
     if (_e != hipSuccess)
       op_profile_note_event_error("record_stop", _e);
@@ -100,7 +139,8 @@ struct OpProfileScope {
                     std::chrono::steady_clock::now() - cpuStart)
                     .count();
     if (ps)
-      op_profile_add_pending(ps, name, shape, eventIndex, ms, bytes);
+      op_profile_add_pending(ps, name, shape, eventIndex, ms, bytes, false,
+                             cpuTsUs);
   }
 
   OpProfileScope(const OpProfileScope &) = delete;
@@ -121,9 +161,21 @@ struct OpProfileScope {
     auto *_stream =                                                            \
         static_cast<hipStream_t>(hipdnn_ep_state_get_stream(state_arg));       \
     if (_ps && _stream && op_profile_is_active(_ps)) {                         \
-      int _evIdx = op_profile_acquire_event_pair(_ps);                         \
-      _opProf.emplace(_ps, opname, (shape_fn)(), _stream, _evIdx,              \
-                      (int64_t)(bytes_fn)());                                   \
+      if (hipdnn_ep_perf_timeline_enabled()) {                                 \
+        op_profile_ensure_epoch(_ps, _stream);                                 \
+        int _mkIdx = op_profile_acquire_marker(_ps);                           \
+        _opProf.emplace(_ps, opname, (shape_fn)(), _stream, _mkIdx,            \
+                        (int64_t)(bytes_fn)(), true);                          \
+      } else {                                                                 \
+        /* Record a per-inference epoch so the chrome trace can place classic  \
+         * (pair-mode) ops on an epoch-anchored GPU timeline too, not just the \
+         * CPU-anchored fallback. Cheap: one fenceless event per inference. */ \
+        if (hipdnn_ep_trace_enabled())                                         \
+          op_profile_ensure_epoch(_ps, _stream);                               \
+        int _evIdx = op_profile_acquire_event_pair(_ps);                       \
+        _opProf.emplace(_ps, opname, (shape_fn)(), _stream, _evIdx,            \
+                        (int64_t)(bytes_fn)(), false);                         \
+      }                                                                        \
     }                                                                          \
   }
 

--- a/lib/Runtime/op_profile.h
+++ b/lib/Runtime/op_profile.h
@@ -25,7 +25,10 @@ void op_profile_reset(OpProfileState *ps);
 void op_profile_resolve_and_print(OpProfileState *ps);
 void op_profile_add_pending(OpProfileState *ps, const std::string &name,
                             const std::string &shape, int eventIndex,
-                            double cpuMs);
+                            double cpuMs, int64_t bytes = 0);
+// Roofline peak (GB/s) used for the [PERF] %peak column. Reads
+// HIPDNN_EP_ROOFLINE_GBPS once; defaults to 256 (Strix Halo LPDDR5X).
+double op_profile_roofline_gbps();
 void op_profile_add_cpu(OpProfileState *ps, const std::string &name,
                         double cpuMs);
 bool op_profile_is_active(OpProfileState *ps);
@@ -59,12 +62,13 @@ struct OpProfileScope {
   std::string shape;
   int eventIndex;
   hipStream_t stream;
+  int64_t bytes;
   std::chrono::steady_clock::time_point cpuStart;
 
   OpProfileScope(OpProfileState *p, std::string n, std::string sh,
-                 hipStream_t s, int evIdx)
+                 hipStream_t s, int evIdx, int64_t b = 0)
       : ps(p), name(std::move(n)), shape(std::move(sh)), eventIndex(evIdx),
-        stream(s) {
+        stream(s), bytes(b) {
     // Sync-isolated diagnostic mode: drain the stream BEFORE we start timing,
     // so this op's reported GPU time excludes any work queued ahead of us.
     // Pairs with the post-stop sync in the destructor to give standalone
@@ -83,7 +87,7 @@ struct OpProfileScope {
                     std::chrono::steady_clock::now() - cpuStart)
                     .count();
     if (ps)
-      op_profile_add_pending(ps, name, shape, eventIndex, ms);
+      op_profile_add_pending(ps, name, shape, eventIndex, ms, bytes);
   }
 
   OpProfileScope(const OpProfileScope &) = delete;
@@ -91,6 +95,12 @@ struct OpProfileScope {
 };
 
 #define OP_PROFILE(opname, shape_fn, state_arg)                                \
+  OP_PROFILE_BYTES(opname, shape_fn, [] { return (int64_t)0; }, state_arg)
+
+// Like OP_PROFILE but also records the op's data footprint (bytes moved) so the
+// [PERF] table can report achieved GB/s and % of the memory roofline. bytes_fn
+// is a callable returning int64_t, invoked only when profiling is active.
+#define OP_PROFILE_BYTES(opname, shape_fn, bytes_fn, state_arg)                 \
   std::optional<OpProfileScope> _opProf;                                       \
   if (hipdnn_ep_perf_enabled()) {                                              \
     auto *_ps = static_cast<OpProfileState *>(                                 \
@@ -99,7 +109,8 @@ struct OpProfileScope {
         static_cast<hipStream_t>(hipdnn_ep_state_get_stream(state_arg));       \
     if (_ps && _stream && op_profile_is_active(_ps)) {                         \
       int _evIdx = op_profile_acquire_event_pair(_ps);                         \
-      _opProf.emplace(_ps, opname, (shape_fn)(), _stream, _evIdx);             \
+      _opProf.emplace(_ps, opname, (shape_fn)(), _stream, _evIdx,              \
+                      (int64_t)(bytes_fn)());                                   \
     }                                                                          \
   }
 

--- a/lib/Runtime/op_profile.h
+++ b/lib/Runtime/op_profile.h
@@ -35,6 +35,8 @@ bool op_profile_is_active(OpProfileState *ps);
 int op_profile_acquire_event_pair(OpProfileState *ps);
 hipEvent_t op_profile_get_start_event(OpProfileState *ps, int index);
 hipEvent_t op_profile_get_stop_event(OpProfileState *ps, int index);
+// One-time diagnostic for HIP-event failures on the profiling path.
+void op_profile_note_event_error(const char *phase, int err);
 
 struct OpProfileCpuScope {
   OpProfileState *ps;
@@ -76,11 +78,22 @@ struct OpProfileScope {
     if (hipdnn_ep_perf_isolate_enabled())
       hipStreamSynchronize(stream);
     cpuStart = std::chrono::steady_clock::now();
-    hipEventRecord(op_profile_get_start_event(ps, eventIndex), stream);
+    hipError_t _e = hipEventRecord(op_profile_get_start_event(ps, eventIndex), stream);
+    if (_e != hipSuccess)
+      op_profile_note_event_error("record_start", _e);
+    // On this ROCm build hipEventRecord can leave sticky error state even when
+    // it returns hipSuccess; consume it so the next kernel wrapper that calls
+    // hipGetLastError() (hip_reduce_sum / elementwise) doesn't misreport it as
+    // its own "invalid resource handle" launch failure. The per-op timing is
+    // unaffected (events still record correctly).
+    (void)hipGetLastError();
   }
 
   ~OpProfileScope() {
-    hipEventRecord(op_profile_get_stop_event(ps, eventIndex), stream);
+    hipError_t _e = hipEventRecord(op_profile_get_stop_event(ps, eventIndex), stream);
+    if (_e != hipSuccess)
+      op_profile_note_event_error("record_stop", _e);
+    (void)hipGetLastError(); // consume hipEventRecord sticky artifact (see ctor)
     if (hipdnn_ep_perf_isolate_enabled())
       hipStreamSynchronize(stream);
     double ms = std::chrono::duration<double, std::milli>(

--- a/lib/Runtime/real/activation.cpp
+++ b/lib/Runtime/real/activation.cpp
@@ -217,13 +217,14 @@ int wrap_miopenActivationForward(RuntimeState *state, int op_state_slot,
                                  void *input, void *output,
                                  int64_t num_elements, int64_t data_type,
                                  int64_t activation_mode) {
-  OP_PROFILE(
+  OP_PROFILE_BYTES(
       "activation",
       [&] {
         char b[64];
         snprintf(b, sizeof(b), "n=%lld", (long long)num_elements);
         return std::string(b);
       },
+      [&] { return 2 * num_elements * hipdnn_ep_datatype_size(data_type); },
       state);
   if (!state || !input || !output) {
     fprintf(stderr, "wrap_miopenActivationForward: null argument\n");
@@ -373,13 +374,14 @@ extern "C" int hip_miopen_softmax(void *state, const void *input, void *output,
 
 int wrap_gelu(RuntimeState *state, void *input, void *output,
               int64_t num_elements, int64_t data_type, int64_t approximate) {
-  OP_PROFILE(
+  OP_PROFILE_BYTES(
       "gelu",
       [&] {
         char b[64];
         snprintf(b, sizeof(b), "n=%lld", (long long)num_elements);
         return std::string(b);
       },
+      [&] { return 2 * num_elements * hipdnn_ep_datatype_size(data_type); },
       state);
   if (!state || !input || !output) {
     fprintf(stderr, "[REAL] wrap_gelu: null argument\n");
@@ -420,13 +422,14 @@ int wrap_gelu(RuntimeState *state, void *input, void *output,
 
 int wrap_leaky_relu(RuntimeState *state, void *input, void *output,
                     int64_t num_elements, int64_t data_type, double alpha) {
-  OP_PROFILE(
+  OP_PROFILE_BYTES(
       "leaky_relu",
       [&] {
         char b[64];
         snprintf(b, sizeof(b), "n=%lld", (long long)num_elements);
         return std::string(b);
       },
+      [&] { return 2 * num_elements * hipdnn_ep_datatype_size(data_type); },
       state);
   if (!state || !input || !output) {
     fprintf(stderr, "[REAL] wrap_leaky_relu: null argument\n");

--- a/lib/Runtime/real/cast.cpp
+++ b/lib/Runtime/real/cast.cpp
@@ -37,12 +37,16 @@ static int hipdnn_to_hip_dtype(int64_t hipdnn_type) {
 int wrap_cast(RuntimeState *state, void *input, void *output,
               int64_t num_elements, int64_t src_data_type,
               int64_t dst_data_type) {
-  OP_PROFILE(
+  OP_PROFILE_BYTES(
       "cast",
       [&] {
         char b[64];
         snprintf(b, sizeof(b), "n=%lld", (long long)num_elements);
         return std::string(b);
+      },
+      [&] {
+        return num_elements * (hipdnn_ep_datatype_size(src_data_type) +
+                               hipdnn_ep_datatype_size(dst_data_type));
       },
       state);
   if (!state || !input || !output) {

--- a/lib/Runtime/real/elementwise.cpp
+++ b/lib/Runtime/real/elementwise.cpp
@@ -255,13 +255,17 @@ int wrap_miopenOpTensor(RuntimeState *state, int op_state_slot, void *lhs,
                         int64_t rhs_c, int64_t rhs_h, int64_t rhs_w,
                         int64_t out_n, int64_t out_c, int64_t out_h,
                         int64_t out_w, int64_t data_type, int64_t tensor_op) {
-  OP_PROFILE(
+  OP_PROFILE_BYTES(
       "elementwise",
       [&] {
         char b[64];
         snprintf(b, sizeof(b), "%lldx%lldx%lldx%lld", (long long)out_n,
                  (long long)out_c, (long long)out_h, (long long)out_w);
         return std::string(b);
+      },
+      [&] {
+        return 3 * out_n * out_c * out_h * out_w *
+               hipdnn_ep_datatype_size(data_type); // 2 reads + 1 write
       },
       state);
   if (!state || !lhs || !rhs || !output) {
@@ -696,13 +700,17 @@ int wrap_elementwise_sub(RuntimeState *state, void *lhs, void *rhs,
                          int64_t rhs_c, int64_t rhs_h, int64_t rhs_w,
                          int64_t out_n, int64_t out_c, int64_t out_h,
                          int64_t out_w, int64_t data_type) {
-  OP_PROFILE(
+  OP_PROFILE_BYTES(
       "sub",
       [&] {
         char b[64];
         snprintf(b, sizeof(b), "%lldx%lldx%lldx%lld", (long long)out_n,
                  (long long)out_c, (long long)out_h, (long long)out_w);
         return std::string(b);
+      },
+      [&] {
+        return 3 * out_n * out_c * out_h * out_w *
+               hipdnn_ep_datatype_size(data_type);
       },
       state);
   if (!state || !lhs || !rhs || !output) {

--- a/lib/Runtime/real/linear_attention.cpp
+++ b/lib/Runtime/real/linear_attention.cpp
@@ -33,7 +33,7 @@ extern "C" int wrap_linear_attention(
     int64_t decay_per_key_dim, int64_t beta_per_head, float scale,
     int64_t chunk_size, int64_t update_rule, int64_t B, int64_t seq_len,
     int64_t dk, int64_t dv, int64_t type) {
-  OP_PROFILE(
+  OP_PROFILE_BYTES(
       "linear_attention",
       [&] {
         char b[64];
@@ -42,6 +42,14 @@ extern "C" int wrap_linear_attention(
                  (long long)B, (long long)seq_len, (long long)Hq,
                  (long long)Hkv, (long long)dk, (long long)dv);
         return std::string(b);
+      },
+      [&] {
+        // q + k + v + o token traffic + recurrent state read/write (per kv head).
+        int64_t es = hipdnn_ep_datatype_size(type);
+        int64_t qkvo = B * seq_len *
+                       (Hq * dk + Nk * dk + Hkv * dv + Hq * dv) * es;
+        int64_t st = 2 * Hkv * dk * dv * es;
+        return qkvo + st;
       },
       state);
 

--- a/lib/Runtime/real/matmul_nbits.cpp
+++ b/lib/Runtime/real/matmul_nbits.cpp
@@ -148,13 +148,23 @@ int wrap_matmul_nbits(RuntimeState *state, int op_state_slot, const void *A,
                       int64_t K, int64_t batch_count, int64_t bits,
                       int64_t block_size, int64_t elem_size,
                       int64_t zp_elem_size) {
-  OP_PROFILE(
+  OP_PROFILE_BYTES(
       "matmul_nbits",
       [&] {
         char b[64];
         snprintf(b, sizeof(b), "m=%lld,n=%lld,k=%lld", (long long)M,
                  (long long)N, (long long)K);
         return std::string(b);
+      },
+      [&] {
+        // GEMV footprint: quantized weights + scales + activations + output.
+        int64_t es = elem_size > 0 ? elem_size : 2;
+        int64_t weights = N * K * bits / 8;
+        int64_t scales =
+            block_size > 0 ? N * ((K + block_size - 1) / block_size) * es : 0;
+        int64_t act = M * K * es;
+        int64_t out = M * N * es;
+        return (weights + scales + act + out) * (batch_count > 0 ? batch_count : 1);
       },
       state);
   if (!state || !A || !B || !scales || !output) {

--- a/lib/Runtime/real/power.cpp
+++ b/lib/Runtime/real/power.cpp
@@ -244,13 +244,14 @@ int launchSqrtHip(RuntimeState *state, void *input, void *output,
 int wrap_power(RuntimeState *state, void *input, void *output,
                int64_t num_elements, int64_t data_type, double alpha,
                double beta, double gamma) {
-  OP_PROFILE(
+  OP_PROFILE_BYTES(
       "power",
       [&] {
         char b[64];
         snprintf(b, sizeof(b), "n=%lld", (long long)num_elements);
         return std::string(b);
       },
+      [&] { return 2 * num_elements * hipdnn_ep_datatype_size(data_type); },
       state);
   if (!state || !input || !output) {
     fprintf(stderr, "wrap_power: null argument\n");

--- a/lib/Runtime/real/qmoe.cpp
+++ b/lib/Runtime/real/qmoe.cpp
@@ -11,6 +11,7 @@
 #include "zp_unpack_cache.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cstdio>
 #include <cstring>
 #include <utility>
@@ -121,6 +122,29 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
 
   hipStream_t hip_stream = static_cast<hipStream_t>(stream);
   int result = 0;
+
+  // Internal per-phase profiling (diagnostic; gated on HIPDNN_EP_PERF_ISOLATE
+  // since it stream-syncs after each phase to attribute GPU time). Reveals the
+  // gather / fc1 / swiglu / fc2 / scatter / bucket / host-sync split of the
+  // qmoe serial per-expert loop -- the TTFT driver. Sums across experts.
+  const bool qmoe_prof = hipdnn_ep_perf_isolate_enabled();
+  double qs_bucket = 0, qs_sync = 0, qs_gather = 0, qs_fc1 = 0, qs_swiglu = 0,
+         qs_fc2 = 0, qs_scatter = 0;
+  std::chrono::steady_clock::time_point _qt;
+#define QP_START()                                                             \
+  do {                                                                         \
+    if (qmoe_prof)                                                             \
+      _qt = std::chrono::steady_clock::now();                                  \
+  } while (0)
+#define QP_END(acc)                                                            \
+  do {                                                                         \
+    if (qmoe_prof) {                                                           \
+      hipStreamSynchronize(hip_stream);                                        \
+      (acc) += std::chrono::duration<double, std::milli>(                      \
+                   std::chrono::steady_clock::now() - _qt)                     \
+                   .count();                                                   \
+    }                                                                          \
+  } while (0)
 
   int64_t fusion_inter = 2 * inter_size;
   int64_t k_blocks_fc1 = (hidden_size + block_size - 1) / block_size;
@@ -245,18 +269,22 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
     // Bucket tokens on the device: count per expert (atomicAdd), exclusive
     // prefix sum into d_expert_offsets, scatter (token_id, weight) pairs
     // into d_sorted_token_ids / d_sorted_weights ordered by expert.
-    HIP_CHECK(hip_qmoe_bucket_tokens(stream, d_expert_indices, d_expert_weights,
-                                     d_expert_counts, d_expert_offsets,
-                                     d_sorted_token_ids, d_sorted_weights,
-                                     num_tokens, num_experts, k, elem_size));
+  QP_START();
+  HIP_CHECK(hip_qmoe_bucket_tokens(stream, d_expert_indices, d_expert_weights,
+                                   d_expert_counts, d_expert_offsets,
+                                   d_sorted_token_ids, d_sorted_weights,
+                                   num_tokens, num_experts, k, elem_size));
+  QP_END(qs_bucket);
 
     // Only readback the counts (num_experts * int32, e.g. 32*4 = 128 bytes)
     // to drive the host-side per-expert dispatch loop. Offsets are computed
     // on the host from the prefix sum of counts (cheap, avoids a second D2H).
+    QP_START();
     HIP_CHECK(hipMemcpyAsync(h_counts, d_expert_counts,
                              num_experts * sizeof(int32_t),
                              hipMemcpyDeviceToHost, hip_stream));
     HIP_CHECK(hipStreamSynchronize(hip_stream));
+    QP_END(qs_sync);
 
     // Recompute offsets on the host (mirrors the on-device prefix sum); used
     // for pointer arithmetic into the sorted device buffers below.
@@ -299,8 +327,10 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
 
       RUNTIME_DEBUG_LOG("[REAL] wrap_qmoe: expert %lld: %lld tokens - gather\n",
                         (long long)e, (long long)count);
+      QP_START();
       HIP_CHECK(hip_qmoe_gather_tokens(stream, input, d_gather_buf, d_ids_e,
                                        hidden_size, count, elem_size));
+      QP_END(qs_gather);
 
       const char *fc1_w_e = static_cast<const char *>(fc1_weights) +
                             e * fusion_inter * k_blocks_fc1 * blob_size_fc1;
@@ -356,19 +386,23 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
                         "[%lld x %lld] -> [%lld x %lld]\n",
                         (long long)e, (long long)count, (long long)hidden_size,
                         (long long)count, (long long)fusion_inter);
+      QP_START();
       HIP_CHECK(
           hip_matmul_nbits(stream, d_gather_buf, fc1_w_e, fc1_s_e, fc1_zp_e,
                            fc1_b_e, d_fc1_buf, count, fusion_inter, hidden_size,
                            1, expert_weight_bits, block_size, elem_size,
                            /*zp_elem_size=*/1, fc1_pre_zp_u8, fc1_pre_zp_fp16));
+      QP_END(qs_fc1);
 
       RUNTIME_DEBUG_LOG("[REAL] wrap_qmoe: expert %lld: swiglu(alpha=%.3f, "
                         "beta=%.3f, limit=%.1f)\n",
                         (long long)e, (double)activation_alpha,
                         (double)activation_beta, (double)swiglu_limit);
+      QP_START();
       HIP_CHECK(hip_qmoe_swiglu(stream, d_fc1_buf, d_act_buf, count, inter_size,
                                 activation_alpha, activation_beta, swiglu_limit,
                                 elem_size));
+      QP_END(qs_swiglu);
 
       const char *fc2_w_e = static_cast<const char *>(fc2_weights) +
                             e * hidden_size * k_blocks_fc2 * blob_size_fc2;
@@ -409,16 +443,29 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
                         "[%lld x %lld] -> [%lld x %lld]\n",
                         (long long)e, (long long)count, (long long)inter_size,
                         (long long)count, (long long)hidden_size);
+      QP_START();
       HIP_CHECK(hip_matmul_nbits(
           stream, d_act_buf, fc2_w_e, fc2_s_e, fc2_zp_e, fc2_b_e, d_fc2_buf,
           count, hidden_size, inter_size, 1, expert_weight_bits, block_size,
           elem_size, /*zp_elem_size=*/1, fc2_pre_zp_u8, fc2_pre_zp_fp16));
+      QP_END(qs_fc2);
 
       RUNTIME_DEBUG_LOG("[REAL] wrap_qmoe: expert %lld: scatter_add\n",
                         (long long)e);
+      QP_START();
       HIP_CHECK(hip_qmoe_scatter_add(stream, output, d_fc2_buf, d_ids_e,
                                      d_wts_e, hidden_size, count, elem_size));
+      QP_END(qs_scatter);
     }
+  }
+
+  if (qmoe_prof) {
+    fprintf(stderr,
+            "[QMOE-SPLIT] tokens=%lld experts=%lld: bucket=%.2f host_sync=%.2f "
+            "gather=%.2f fc1=%.2f swiglu=%.2f fc2=%.2f scatter=%.2f (ms; "
+            "fc1+fc2=%.2f)\n",
+            (long long)num_tokens, (long long)num_experts, qs_bucket, qs_sync,
+            qs_gather, qs_fc1, qs_swiglu, qs_fc2, qs_scatter, qs_fc1 + qs_fc2);
   }
 
 cleanup:

--- a/lib/Runtime/real/qmoe.cpp
+++ b/lib/Runtime/real/qmoe.cpp
@@ -36,7 +36,7 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
               int64_t swiglu_fusion, int64_t activation_type,
               float activation_alpha, float activation_beta, float swiglu_limit,
               int64_t normalize_routing_weights, int64_t elem_size) {
-  OP_PROFILE(
+  OP_PROFILE_BYTES(
       "qmoe",
       [&] {
         char b[64];
@@ -44,6 +44,24 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
                  (long long)hidden_size, (long long)inter_size,
                  (long long)num_experts);
         return std::string(b);
+      },
+      [&] {
+        // Footprint = (distinct activated experts) x per-expert weight+scale
+        // bytes + activation I/O. Decode (1 token, top-k) reads k experts;
+        // prefill saturates toward num_experts.
+        int64_t bits = expert_weight_bits > 0 ? expert_weight_bits : 4;
+        int64_t bs = block_size > 0 ? block_size : 32;
+        int64_t fc1_cols = 2 * inter_size; // swiglu-fused fc1
+        int64_t fc1_w = hidden_size * fc1_cols * bits / 8;
+        int64_t fc2_w = inter_size * hidden_size * bits / 8;
+        int64_t fc1_sc = fc1_cols * ((hidden_size + bs - 1) / bs) * 2;
+        int64_t fc2_sc = hidden_size * ((inter_size + bs - 1) / bs) * 2;
+        int64_t per_expert = fc1_w + fc2_w + fc1_sc + fc2_sc;
+        int64_t active = k * num_tokens;
+        if (num_experts > 0 && active > num_experts)
+          active = num_experts;
+        int64_t act_io = 2LL * num_tokens * hidden_size * 2;
+        return active * per_expert + act_io;
       },
       state);
   if (router_weights) {

--- a/lib/Runtime/real/reduce_sum.cpp
+++ b/lib/Runtime/real/reduce_sum.cpp
@@ -43,13 +43,17 @@ int wrap_reduce_sum(RuntimeState *state, void *data, void *axes, void *output,
                     int64_t axes_num_elements, int64_t data_type,
                     int64_t keepdims, int64_t noop_with_empty_axes,
                     int64_t inner_size) {
-  OP_PROFILE(
+  OP_PROFILE_BYTES(
       "reduce_sum",
       [&] {
         char b[64];
         snprintf(b, sizeof(b), "%lld->%lld", (long long)data_num_elements,
                  (long long)output_num_elements);
         return std::string(b);
+      },
+      [&] {
+        return (data_num_elements + output_num_elements) *
+               hipdnn_ep_datatype_size(data_type);
       },
       state);
   if (!state || !data || !output) {

--- a/lib/Runtime/real/simplified_layer_norm.cpp
+++ b/lib/Runtime/real/simplified_layer_norm.cpp
@@ -188,7 +188,7 @@ int wrap_miopenT5LayerNormForward(RuntimeState *state, int op_state_slot,
                                   int64_t scale_num_elements,
                                   int64_t element_size_bytes, int64_t axis,
                                   float epsilon, int64_t stash_type) {
-  OP_PROFILE(
+  OP_PROFILE_BYTES(
       "layernorm",
       [&] {
         char b[64];
@@ -198,6 +198,10 @@ int wrap_miopenT5LayerNormForward(RuntimeState *state, int op_state_slot,
                                  : 0),
                  (long long)scale_num_elements);
         return std::string(b);
+      },
+      [&] {
+        return (2 * input_num_elements + scale_num_elements) *
+               element_size_bytes;
       },
       state);
   if (!state || !input || !scale || !output) {

--- a/lib/Runtime/real/skip_simplified_layer_norm.cpp
+++ b/lib/Runtime/real/skip_simplified_layer_norm.cpp
@@ -215,7 +215,7 @@ int wrap_skip_simplified_layer_norm(RuntimeState *state, int op_state_slot,
                                     int64_t input_num_elements,
                                     int64_t gamma_num_elements,
                                     int64_t element_size_bytes, float epsilon) {
-  OP_PROFILE(
+  OP_PROFILE_BYTES(
       "skip_layernorm",
       [&] {
         char b[64];
@@ -225,6 +225,11 @@ int wrap_skip_simplified_layer_norm(RuntimeState *state, int op_state_slot,
                                  : 0),
                  (long long)gamma_num_elements);
         return std::string(b);
+      },
+      [&] {
+        // read input + skip, write output (+ skip-sum); gamma small.
+        return (3 * input_num_elements + gamma_num_elements) *
+               element_size_bytes;
       },
       state);
   if (!state || !input || !skip || !gamma || !output) {

--- a/lib/Runtime/real/transpose.cpp
+++ b/lib/Runtime/real/transpose.cpp
@@ -14,7 +14,7 @@ int wrap_transpose(RuntimeState *state, const void *input, void *output,
                    int64_t rank, const int64_t *input_shape,
                    const int64_t *perm, int64_t num_elements,
                    int64_t element_size_bytes) {
-  OP_PROFILE(
+  OP_PROFILE_BYTES(
       "transpose",
       [&] {
         char b[64];
@@ -22,6 +22,7 @@ int wrap_transpose(RuntimeState *state, const void *input, void *output,
                  (long long)rank);
         return std::string(b);
       },
+      [&] { return 2 * num_elements * element_size_bytes; },
       state);
   // Empty transpose is a no-op (NonZero count=0 → [3,0] indices in embedding).
   if (num_elements <= 0)

--- a/tools/perf-report/PERF_METHODOLOGY.md
+++ b/tools/perf-report/PERF_METHODOLOGY.md
@@ -1,0 +1,50 @@
+# Reliable perf measurement (HIPDNN/MorphiZen EP, gfx1151)
+
+Why this exists: decode TPS on this box has large run-to-run variance (GPU
+boost/thermal drift) and **no clock pinning is available** (no rocm-smi/amd-smi
+on Windows). Single runs and 2-sample A/Bs mislead — we previously mis-read a
+noise fluctuation as a "+5%" win. This harness makes results trustworthy.
+
+## Tool: `perf_measure.py`
+
+Each *sample* is a fresh **process** launch of `model_benchmark` (each reloads +
+re-autotunes, so process-level variance is the real noise). Within a process,
+`-r/-w` give a steady per-process number.
+
+- **Noise floor:** `python perf_measure.py noise --reps 20`
+  Reports mean/median/stddev/CoV/95%CI and the RESOLVABLE-WIN THRESHOLD (~2σ).
+- **Paired A/B:** `python perf_measure.py ab --pairs 12 --a-env "KEY=VAL,..."`
+  Runs K **interleaved** pairs (A,B,A,B,...); per-pair diffs cancel slow drift.
+  Reports the paired delta, its 95% CI, and a SIGNIFICANCE VERDICT.
+  A/B configs are env-var dicts, so you toggle ONE code path on the SAME build
+  (e.g. `--a-env HIPDNN_EP_MIOPEN_ACT=1` = baseline vs default custom kernel).
+
+## Measured baseline (2026-07-06, p128 g128)
+
+- **Noise floor: CoV ~4-5%.** Single-run resolvable threshold ~5%; a 10-pair
+  interleaved A/B resolves ~±1.7% (95% CI).
+- **=> optimizations under ~2% are unmeasurable here; under ~5% need the paired
+  harness to detect at all.**
+
+## Verdict on the shipped custom kernels (activation + fused skip-RMSNorm)
+
+10-pair interleaved A/B, A = MIOpen baseline, B = custom:
+`A=40.61±1.09  B=40.87±1.27  paired delta +0.6% ± 1.7% -> NOT significant.`
+Correct + harmless, but no measurable model-level decode gain. (The earlier
+"+5%" was a 2-sample noise artifact.)
+
+## Per-op profiler caveat (`HIPDNN_EP_PERF`)
+
+Sum of per-op `gpu(ms)` at steady decode (~52 ms) is ~2× the CLEAN wall
+(~25 ms/token): hipEvent-per-op bracketing inflates, worst for tiny ops. So the
+"~40% tiny-op tail" was substantially a profiling artifact; the clean tail is
+much smaller (decode is ~memory-bound: ~1.5 GB weights/token ÷ ~59 GB/s ≈ 25 ms).
+Treat `[PERF]` per-op **shares as rough/relative only**; use the roofline +
+paired A/B for decisions. TODO: low-distortion per-op profiler (batched events,
+single end-of-inference readback, no per-op sync).
+
+## Rules
+
+1. Establish the noise floor first.
+2. Only chase targets projected **above** it (>~5%).
+3. Validate with the paired harness — never single/2-sample runs.

--- a/tools/perf-report/bottleneck_probe.ps1
+++ b/tools/perf-report/bottleneck_probe.ps1
@@ -113,8 +113,10 @@ if (Test-Path $SingleOpDir) {
   Write-Host "[probe]   single_op dir not found: $SingleOpDir (skipping per-shape roofline)"
 }
 
-# --- Battery 5: coarse cold-start (minimal load-dominated run) ---
-$r = Invoke-Battery "coldstart" "$mb -i `"$Model`" -l 8 -g 1 -r 1 -w 0" "coldstart.log" -AllowKernelErr
+# --- Battery 5: coarse cold-start (minimal load-dominated run) + BW probe ---
+# HIPDNN_EP_BW_PROBE=1 runs a STREAM-style bandwidth microbench once at load to
+# CALIBRATE the roofline peak instead of assuming a spec number.
+$r = Invoke-Battery "coldstart+bw" "set HIPDNN_EP_BW_PROBE=1&& $mb -i `"$Model`" -l 8 -g 1 -r 1 -w 0" "coldstart.log" -AllowKernelErr
 $r.type = "coldstart"; $r.prompt = 8
 $manifest.runs += $r
 

--- a/tools/perf-report/bottleneck_probe.ps1
+++ b/tools/perf-report/bottleneck_probe.ps1
@@ -1,0 +1,124 @@
+<#
+  bottleneck_probe.ps1 - rigorous decode/prefill/cold-start bottleneck battery
+  for the HIPDNN (MorphiZen) EP on Windows.
+
+  Runs a fixed battery against ONE OGA model dir and captures raw logs plus a
+  manifest.json under perf-results/probe_<ts>/. The companion analyzer
+  (bottleneck_report.py) turns the logs into a single ranked, roofline-attributed
+  report. This script only orchestrates + captures -- it computes no metrics.
+
+  Batteries:
+    1. Headline    : model_benchmark at each prompt length (clean throughput).
+    2. Decode prof : model_benchmark p128 with HIPDNN_EP_PERF (per-op [PERF] tables).
+    3. Launch A/B  : p128 decode with vs without HIP_LAUNCH_BLOCKING=1.
+    4. Per-shape   : onnxruntime_perf_test -I over single_op seq1 graphs + HIPDNN_EP_PERF.
+    5. Cold start  : coarse process wall of a minimal (g=1) load-dominated run.
+
+  Transient "invalid resource handle" GPU-state failures are detected and the
+  affected run is retried up to -Retries times.
+#>
+[CmdletBinding()]
+param(
+  [string]$Model    = "D:\Qwen3.5-35B-A3B-fp16-ve-fp16-int4-text-gs32-dml",
+  [int[]] $Prompts  = @(128, 512, 2048),
+  [int]   $Gen      = 128,
+  [int]   $Reps     = 5,
+  [int]   $Warmup   = 2,
+  [string]$Workspace = "C:\Users\Administrator\workspace",
+  [string]$SingleOpDir = "D:\Qwen3.5-35B-A3B_int4_rtn_128gs_cuda_space\text\space_opt\single_op",
+  [int]   $Retries  = 2
+)
+
+$ErrorActionPreference = "Stop"
+$pkg     = Join-Path $Workspace "gpu-test-package\bin"
+$ibin    = Join-Path $Workspace "install\bin"
+$rock    = Join-Path $Workspace "therock-keep\bin"
+$cfg     = Join-Path $Workspace "onnx-hipdnn-ep\etc\morphizen_config.json"
+$ts      = Get-Date -Format "yyyyMMdd_HHmmss"
+$outDir  = Join-Path $Workspace "perf-results\probe_$ts"
+New-Item -ItemType Directory -Force $outDir | Out-Null
+$env:PATH = "$pkg;$ibin;$rock;" + $env:PATH
+
+$modelName = Split-Path $Model -Leaf
+Write-Host "[probe] model=$modelName out=$outDir"
+
+$manifest = [ordered]@{
+  model      = $Model
+  model_name = $modelName
+  timestamp  = $ts
+  gen        = $Gen
+  reps       = $Reps
+  warmup     = $Warmup
+  peak_gbps  = 256.0   # LPDDR5X roofline peak (Strix Halo) -- confirm exact spec
+  runs       = @()
+}
+
+function Test-KernelError($logPath) {
+  return [bool](Select-String -Path $logPath -Pattern 'invalid resource|launch failed|hipMalloc failed|Compilation failed' -Quiet)
+}
+
+# Run a command line (cmd /c) with env, capture to log, retry on transient GPU error.
+function Invoke-Battery($label, $cmdLine, $logName, [switch]$AllowKernelErr) {
+  $logPath = Join-Path $outDir $logName
+  for ($attempt = 1; $attempt -le ($Retries + 1); $attempt++) {
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    cmd /c "$cmdLine > `"$logPath`" 2>&1"
+    $sw.Stop()
+    $wallMs = [math]::Round($sw.Elapsed.TotalMilliseconds, 1)
+    $hasErr = Test-KernelError $logPath
+    if ($hasErr -and -not $AllowKernelErr -and $attempt -le $Retries) {
+      Write-Host "[probe]   $label attempt $attempt hit transient GPU error; retrying..."
+      Start-Sleep -Seconds 3
+      continue
+    }
+    Write-Host ("[probe]   {0} -> {1} (wall={2} ms, kernel_errors={3})" -f $label, $logName, $wallMs, $hasErr)
+    return @{ label = $label; log = $logName; wall_ms = $wallMs; kernel_errors = [bool]$hasErr }
+  }
+}
+
+$mb = "model_benchmark.exe"
+
+# --- Battery 1: headline throughput per prompt length ---
+foreach ($p in $Prompts) {
+  $r = Invoke-Battery "headline p$p" "$mb -i `"$Model`" -l $p -g $Gen -r $Reps -w $Warmup" "headline_p$p.log"
+  $r.type = "headline"; $r.prompt = $p
+  $manifest.runs += $r
+}
+
+# --- Battery 2: decode per-op profile (HIPDNN_EP_PERF) at p128 ---
+$r = Invoke-Battery "decode-profile p128" "set HIPDNN_EP_PERF=1&& $mb -i `"$Model`" -l 128 -g 64 -r 1 -w 1" "decode_perf_p128.log"
+$r.type = "decode_profile"; $r.prompt = 128
+$manifest.runs += $r
+
+# --- Battery 3: launch critical-path A/B (p128 decode) ---
+$r = Invoke-Battery "launch normal" "$mb -i `"$Model`" -l 128 -g 64 -r 3 -w 1" "launch_normal_p128.log"
+$r.type = "launch_normal"; $r.prompt = 128
+$manifest.runs += $r
+$r = Invoke-Battery "launch blocking" "set HIP_LAUNCH_BLOCKING=1&& $mb -i `"$Model`" -l 128 -g 64 -r 3 -w 1" "launch_blocking_p128.log"
+$r.type = "launch_blocking"; $r.prompt = 128
+$manifest.runs += $r
+
+# --- Battery 4: per-shape isolated roofline via single_op seq1 graphs ---
+if (Test-Path $SingleOpDir) {
+  $ops = Get-ChildItem $SingleOpDir -Directory | Where-Object { $_.Name -like "MatMulNBits_*" -or $_.Name -eq "QMoE" }
+  foreach ($op in $ops) {
+    $g = Join-Path $op.FullName ("{0}_seq1.onnx" -f $op.Name)
+    if (-not (Test-Path $g)) { continue }
+    $cmd = "set HIPDNN_EP_PERF=1&& onnxruntime_perf_test.exe --plugin_ep_libs `"hipgpu|$ibin\hipgpu.dll`" --plugin_eps `"hipgpu`" --plugin_ep_options `"config_file|$cfg`" -C `"session.disable_cpu_ep_fallback|1`" -t 4 -c 1 -s -I `"$g`""
+    $r = Invoke-Battery ("singleop {0}" -f $op.Name) $cmd ("singleop_{0}.log" -f $op.Name)
+    $r.type = "single_op"; $r.op = $op.Name
+    $manifest.runs += $r
+  }
+} else {
+  Write-Host "[probe]   single_op dir not found: $SingleOpDir (skipping per-shape roofline)"
+}
+
+# --- Battery 5: coarse cold-start (minimal load-dominated run) ---
+$r = Invoke-Battery "coldstart" "$mb -i `"$Model`" -l 8 -g 1 -r 1 -w 0" "coldstart.log" -AllowKernelErr
+$r.type = "coldstart"; $r.prompt = 8
+$manifest.runs += $r
+
+$manifestPath = Join-Path $outDir "manifest.json"
+$manifest | ConvertTo-Json -Depth 6 | Out-File $manifestPath -Encoding ascii
+Write-Host "[probe] done. manifest: $manifestPath"
+Write-Output $outDir

--- a/tools/perf-report/bottleneck_report.py
+++ b/tools/perf-report/bottleneck_report.py
@@ -50,6 +50,11 @@ def bits_for(n, k):
     return BITS_BY_NK.get((n, k), 4)
 
 
+def matmul_flops(m, n, k):
+    """MAC-based FLOPs for a GEMM/GEMV: 2*M*N*K."""
+    return 2.0 * m * n * k
+
+
 # ---------------------------------------------------------------------------
 # Parsers
 # ---------------------------------------------------------------------------
@@ -181,16 +186,28 @@ def load(probe_dir: Path):
     return manifest, runs, logtext, find
 
 
+_BW_PROBE = re.compile(r"\[BW-PROBE\].*?read=([\d.]+)\s*GB/s")
+
+
 def build_report(probe_dir: Path):
     manifest, runs, logtext, find = load(probe_dir)
     peak = float(manifest.get("peak_gbps", 256.0))
+    # Prefer a MEASURED peak (STREAM read BW from the [BW-PROBE] line) over the
+    # assumed spec number, so roofline % reflects real achievable bandwidth.
+    peak_measured = None
+    for r in runs:
+        for mm in _BW_PROBE.finditer(logtext(r["log"])):
+            peak_measured = max(peak_measured or 0.0, float(mm.group(1)))
+    if peak_measured:
+        peak = peak_measured
     L = []  # markdown lines
     csv_rows = []
     j = {"model": manifest["model_name"], "peak_gbps": peak, "sections": {}}
 
     L.append(f"# Bottleneck report -- {manifest['model_name']}")
     L.append("")
-    L.append(f"Probe dir: `{probe_dir.name}`  |  roofline peak: {peak:.0f} GB/s  |  "
+    L.append(f"Probe dir: `{probe_dir.name}`  |  roofline peak: {peak:.0f} GB/s "
+             f"({'measured (BW-probe read)' if peak_measured else 'assumed'})  |  "
              f"gen={manifest['gen']} reps={manifest['reps']} warmup={manifest['warmup']}")
     L.append("")
     L.append("> Phase 1 report: per-op GB/s and % peak are shape-model ESTIMATES (marked est). "
@@ -382,6 +399,34 @@ def build_report(probe_dir: Path):
             j["sections"]["prefill"] = {"total_gpu_ms": ptot,
                                         "ops": [{"op": n, "gpu": o["gpu"], "pct": o["pct"]}
                                                 for n, o in pref["ops"].items()]}
+            # Compute (FLOP) roofline for prefill -- matmul is compute-bound at
+            # M>1, so the BW roofline understates its ceiling. Achieved TFLOP/s
+            # is measured; %peak uses an ASSUMED peak (confirm for gfx1151).
+            peak_tf = float(manifest.get("peak_tflops", 59.0))
+            mm = pref["ops"].get("matmul_nbits")
+            # Use the CLEAN prefill time (TTFT) scaled by matmul's share of
+            # prefill GPU -- the profiled per-op gpu is inflated by profiling
+            # sync and would understate TFLOP/s badly.
+            pp = dp[0].get("prompt")
+            ttft_s = (headline.get(pp) or {}).get("ttft_s")
+            if mm and mm.get("shapes") and ttft_s and mm.get("pct", 0) > 0:
+                flops = 0.0
+                for label, rec in mm["shapes"].items():
+                    sm = _SHAPE_NK.search(label)
+                    if sm:
+                        flops += matmul_flops(int(sm.group(1)), int(sm.group(2)),
+                                              int(sm.group(3))) * rec["calls"]
+                mm_time_s = ttft_s * (mm["pct"] / 100.0)
+                if flops > 0 and mm_time_s > 0:
+                    tfs = (flops / 1e12) / mm_time_s
+                    L.append("")
+                    L.append(f"- Prefill matmul_nbits compute roofline (p{pp}): {flops/1e9:.1f} GFLOP "
+                             f"over ~{mm_time_s*1000:.0f} ms (TTFT {ttft_s:.2f}s x {mm['pct']:.0f}% matmul) "
+                             f"= ~{tfs:.1f} TFLOP/s = ~{100.0*tfs/peak_tf:.0f}% of ~{peak_tf:.0f} TFLOP/s peak "
+                             f"(peak ASSUMED -- confirm gfx1151 fp16 WMMA).")
+                    j["sections"]["prefill_compute"] = {
+                        "gflop": flops / 1e9, "achieved_tflops": tfs,
+                        "peak_tflops_assumed": peak_tf}
         else:
             L.append("- (No prefill Compute table found -- run needs a captured prompt-phase [PERF] table.)")
     L.append("")

--- a/tools/perf-report/bottleneck_report.py
+++ b/tools/perf-report/bottleneck_report.py
@@ -80,7 +80,7 @@ _PERF_ROW = re.compile(
     r"(?:\s+(\S+)\s+(\S+)\s+(\S+))?\s*$")
 _PERF_TOTAL = re.compile(r"^\[PERF\]\s+TOTAL\s+([\d.]+)\s+([\d.]+)")
 _PERF_WALL = re.compile(r"^\[PERF\]\s+#\d+\s+wall=([\d.]+).*?gpu=([\d.]+)(?:.*?launch_gap=([\d.]+))?")
-_COLDSTART = re.compile(r"^\[COLDSTART\]\s+(\S+)=([\d.]+)")
+_COLDSTART = re.compile(r"^\[COLDSTART\]\s+(\S+?)=([0-9.eE+-]+)")
 
 
 def parse_perf_tables(text):
@@ -149,6 +149,19 @@ def parse_singleop_gpu(text):
 
 
 _SHAPE_NK = re.compile(r"m=(\d+),n=(\d+),k=(\d+)")
+
+
+def _pick_prefill_table(tables):
+    """The prefill Compute is the one whose matmul_nbits shapes have m>1
+    (prompt tokens); decode Computes are all m=1. Fall back to the first table."""
+    for t in tables:
+        mm = t["ops"].get("matmul_nbits")
+        if mm:
+            for label in mm.get("shapes", {}):
+                sm = _SHAPE_NK.search(label)
+                if sm and int(sm.group(1)) > 1:
+                    return t
+    return tables[0] if tables else None
 
 
 # ---------------------------------------------------------------------------
@@ -278,13 +291,28 @@ def build_report(probe_dir: Path):
     lb = find(lambda r: r.get("type") == "launch_blocking")
     L.append("## E. Launch critical-path A/B (p128 decode)")
     L.append("")
-    # EP-measured per-Compute launch gap (wall - gpu) from the decode profile.
+    # EP-measured launch_gap (wall - gpu) distribution across decode Computes.
+    # This is the definitive GPU-bound vs launch-bound signal (median gap
+    # fraction): high => launch/dispatch on the critical path (fuse), low =>
+    # GPU-compute-bound (tune kernels).
     if dp:
         _t = parse_perf_tables(logtext(dp[0]["log"]))
-        if _t and _t[-1].get("launch_gap") is not None and _t[-1].get("wall"):
-            w = _t[-1]["wall"]; g = _t[-1]["launch_gap"]
-            L.append(f"- EP per-Compute (profiled): wall={w:.2f} ms, launch_gap (wall-gpu)={g:.2f} ms "
-                     f"({100.0*g/w:.0f}% of wall is host launch/dispatch not hidden by GPU).")
+        gaps = [(x["wall"], x["launch_gap"]) for x in _t
+                if x.get("launch_gap") is not None and x.get("wall")]
+        # decode-token gaps: drop the first (prefill) sample if present.
+        if len(gaps) > 1:
+            gaps = gaps[1:]
+        if gaps:
+            fracs = sorted(100.0 * g / w for w, g in gaps if w > 0)
+            med = fracs[len(fracs) // 2]
+            L.append(f"- EP launch_gap (wall-gpu) over {len(gaps)} decode Computes: "
+                     f"median {med:.0f}% of wall is host launch/dispatch not hidden by GPU "
+                     f"(range {fracs[0]:.0f}-{fracs[-1]:.0f}%).")
+            if med >= 25:
+                L.append("  => launch/dispatch IS on the critical path -> fusion / launch-reduction helps.")
+            else:
+                L.append("  => GPU-compute-bound -> prioritize kernel efficiency over fusion.")
+            j["sections"]["launch_gap_median_pct"] = med
             L.append("")
     if ln and lb:
         mn = parse_model_benchmark(logtext(ln[0]["log"]))
@@ -317,8 +345,25 @@ def build_report(probe_dir: Path):
     if headline:
         L.append("- TTFT vs prompt (from section A): "
                  + ", ".join(f"p{p}={headline[p].get('ttft_s', float('nan')):.2f}s" for p in sorted(headline)))
-        L.append("- Long-prompt TTFT is dominated by qmoe (most experts activated) + the huge-vocab lm_head. "
-                 "Per-op prefill attribution needs a prefill-phase [PERF] capture (Phase 2).")
+        L.append("")
+    # Prefill per-op attribution: the first Compute table (prompt tokens, m>1).
+    if dp:
+        ptables = parse_perf_tables(logtext(dp[0]["log"]))
+        pref = _pick_prefill_table(ptables)
+        if pref:
+            ptot = pref.get("total_gpu") or sum(o["gpu"] for o in pref["ops"].values())
+            L.append(f"- Prefill Compute per-op GPU breakdown (total {ptot:.1f} ms):")
+            L.append("")
+            L.append("| op | calls | gpu ms | % prefill |")
+            L.append("|---|---|---|---|")
+            for name, op in sorted(pref["ops"].items(), key=lambda kv: kv[1]["gpu"], reverse=True)[:8]:
+                L.append(f"| {name} | {op['calls']} | {op['gpu']:.1f} | {op['pct']:.1f}% |")
+                csv_rows.append(["prefill_op", "", name, op["calls"], op["gpu"], op["pct"], "", "", "", ""])
+            j["sections"]["prefill"] = {"total_gpu_ms": ptot,
+                                        "ops": [{"op": n, "gpu": o["gpu"], "pct": o["pct"]}
+                                                for n, o in pref["ops"].items()]}
+        else:
+            L.append("- (No prefill Compute table found -- run needs a captured prompt-phase [PERF] table.)")
     L.append("")
 
     # --- G. Cold start ---
@@ -329,14 +374,20 @@ def build_report(probe_dir: Path):
         L.append(f"- Minimal-run (l=8,g=1) process wall: {cs[0].get('wall_ms', 0)/1000.0:.1f} s "
                  "(model load + compile + weight upload + first-inference autotune, load-dominated).")
         # EP-measured [COLDSTART] phase timers (any log may carry them).
+        # Cold-start lines are emitted once per process load. Parse a SINGLE
+        # log (the coldstart run) to avoid multi-counting across battery runs.
         phases = {}
-        for r in runs:
-            for mm in _COLDSTART.finditer(logtext(r["log"])):
-                phases.setdefault(mm.group(1), float(mm.group(2)))
+        counts = {}
+        for line in logtext(cs[0]["log"]).splitlines():
+            mm = _COLDSTART.match(line)
+            if mm:
+                k = mm.group(1)
+                phases[k] = phases.get(k, 0.0) + float(mm.group(2))
+                counts[k] = counts.get(k, 0) + 1
         if phases:
-            L.append("- EP phase timers (measured):")
-            for k, v in phases.items():
-                L.append(f"  - {k}: {v:.3f} s")
+            L.append("- EP phase timers (measured, summed over cold-start events):")
+            for k, v in sorted(phases.items(), key=lambda kv: kv[1], reverse=True):
+                L.append(f"  - {k}: {v:.3f} s (n={counts[k]})")
             j["sections"]["coldstart_phases"] = phases
         else:
             L.append("- (No [COLDSTART] phase lines found -- rebuild with Phase 2 instrumentation.)")

--- a/tools/perf-report/bottleneck_report.py
+++ b/tools/perf-report/bottleneck_report.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+"""
+bottleneck_report.py -- turn a bottleneck_probe.ps1 run directory into ONE
+ranked, roofline-attributed bottleneck report (markdown + csv + json).
+
+Consumes: <probe_dir>/manifest.json plus the raw logs it references.
+Produces: <probe_dir>/bottleneck_report.{md,csv,json}
+
+Phase 1 note: per-op byte counts (hence achieved GB/s and % of roofline) are
+ESTIMATED from a shape-driven byte model here in the script. Phase 2 replaces
+these with values measured inside the EP (bytes reported directly in [PERF]).
+Sections that are estimates are labelled "(est)".
+
+Pure standard library; runs anywhere with Python >= 3.10.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Byte model
+# ---------------------------------------------------------------------------
+# int4/int8 GEMV weight quantization: bits per weight keyed on (n, k) for the
+# 35B model. Weights dominate; scales/act/out are secondary. Unknown shapes
+# default to 4 bits (int4). Confirmed from the decode IR (section 3 of results).
+BITS_BY_NK = {
+    (4096, 2048): 8, (32, 2048): 8, (8192, 2048): 8, (2048, 4096): 8,
+    (256, 2048): 4, (1, 2048): 4, (512, 2048): 4, (2048, 512): 4,
+    (248320, 2048): 4,
+}
+
+
+def matmul_nbits_bytes(m, n, k, bits, block, dt_bytes=2):
+    """Total bytes moved by an int-N GEMV: weights + scales + act + out."""
+    weights = n * k * bits / 8.0
+    scales = n * ((k + block - 1) // block) * dt_bytes
+    act = m * k * dt_bytes
+    out = m * n * dt_bytes
+    return weights + scales + act + out
+
+
+def bits_for(n, k):
+    return BITS_BY_NK.get((n, k), 4)
+
+
+# ---------------------------------------------------------------------------
+# Parsers
+# ---------------------------------------------------------------------------
+_MB_PROMPT = re.compile(r"Prompt processing.*?avg \(us\):\s*([\d.]+).*?avg \(tokens/s\):\s*([\d.]+)", re.S)
+_MB_GEN = re.compile(r"Token generation.*?avg \(us\):\s*([\d.]+).*?avg \(tokens/s\):\s*([\d.]+)", re.S)
+_MB_E2E = re.compile(r"E2E generation.*?avg \(ms\):\s*([\d.]+)", re.S)
+_MB_WS = re.compile(r"Peak working set size \(bytes\):\s*(\d+)")
+
+
+def parse_model_benchmark(text):
+    out = {}
+    if (mm := _MB_PROMPT.search(text)):
+        out["ttft_s"] = float(mm.group(1)) / 1e6  # prompt-processing avg is microseconds
+        out["prefill_tps"] = float(mm.group(2))
+    if (mm := _MB_GEN.search(text)):
+        out["decode_ms"] = float(mm.group(1)) / 1000.0
+        out["decode_tps"] = float(mm.group(2))
+    if (mm := _MB_E2E.search(text)):
+        out["e2e_ms"] = float(mm.group(1))
+    if (mm := _MB_WS.search(text)):
+        out["peak_ws_gb"] = int(mm.group(1)) / (1024 ** 3)
+    return out
+
+
+# Row now optionally carries EP-measured MB / GB/s / %pk columns after gpu%.
+_PERF_ROW = re.compile(
+    r"^\[PERF\](\s+)(\S.*?)\s+(\d+)\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)%"
+    r"(?:\s+(\S+)\s+(\S+)\s+(\S+))?\s*$")
+_PERF_TOTAL = re.compile(r"^\[PERF\]\s+TOTAL\s+([\d.]+)\s+([\d.]+)")
+_PERF_WALL = re.compile(r"^\[PERF\]\s+#\d+\s+wall=([\d.]+).*?gpu=([\d.]+)(?:.*?launch_gap=([\d.]+))?")
+_COLDSTART = re.compile(r"^\[COLDSTART\]\s+(\S+)=([\d.]+)")
+
+
+def parse_perf_tables(text):
+    """Return list of tables; each = {ops:{name:{calls,gpu,cpu,pct,shapes:{}}},
+    total_gpu, total_cpu, wall}. Ops accumulate until a TOTAL line closes one."""
+    tables = []
+    cur = None
+    last_op = None
+    pending_wall = None
+    pending_gap = None
+    for line in text.splitlines():
+        if (mw := _PERF_WALL.match(line)):
+            pending_wall = float(mw.group(1))
+            pending_gap = float(mw.group(3)) if mw.group(3) else None
+            continue
+        if (mt := _PERF_TOTAL.match(line)):
+            if cur is not None:
+                cur["total_gpu"] = float(mt.group(1))
+                cur["total_cpu"] = float(mt.group(2))
+                cur["wall"] = pending_wall
+                cur["launch_gap"] = pending_gap
+                tables.append(cur)
+                cur = None
+                last_op = None
+                pending_wall = None
+                pending_gap = None
+            continue
+        if (mr := _PERF_ROW.match(line)):
+            indent, name, calls, gpu, cpu, pct, mb, gbps, pk = mr.groups()
+            rec = {"calls": int(calls), "gpu": float(gpu), "cpu": float(cpu),
+                   "pct": float(pct)}
+            # EP-measured roofline columns (present only on byte-instrumented ops).
+            if mb and mb != "-":
+                rec["mb_meas"] = float(mb)
+                rec["gbps_meas"] = float(gbps) if gbps not in (None, "-") else None
+                rec["pk_meas"] = float(pk.rstrip("%")) if pk and pk != "-" else None
+            name = name.strip()
+            if name in ("", "calls"):
+                continue
+            if cur is None:
+                cur = {"ops": {}}
+            # op rows carry <=2 leading spaces; shape sub-rows are indented more.
+            if len(indent) <= 2:
+                rec["shapes"] = {}
+                cur["ops"][name] = rec
+                last_op = name
+            elif last_op is not None:
+                cur["ops"][last_op]["shapes"][name] = rec
+    return tables
+
+
+def parse_singleop_gpu(text):
+    """Isolated per-shape kernel time: last matmul_nbits (or qmoe) shape row."""
+    tables = parse_perf_tables(text)
+    if not tables:
+        return None
+    ops = tables[-1]["ops"]
+    for opname in ("matmul_nbits", "qmoe"):
+        if opname in ops:
+            op = ops[opname]
+            if op["shapes"]:
+                label, rec = list(op["shapes"].items())[-1]
+                return {"op": opname, "shape": label, "gpu": rec["gpu"], "calls": rec["calls"]}
+            return {"op": opname, "shape": "", "gpu": op["gpu"], "calls": op["calls"]}
+    return None
+
+
+_SHAPE_NK = re.compile(r"m=(\d+),n=(\d+),k=(\d+)")
+
+
+# ---------------------------------------------------------------------------
+# Report assembly
+# ---------------------------------------------------------------------------
+def load(probe_dir: Path):
+    manifest = json.loads((probe_dir / "manifest.json").read_text())
+    runs = manifest["runs"]
+
+    def logtext(name):
+        p = probe_dir / name
+        return p.read_text(errors="replace") if p.exists() else ""
+
+    def find(pred):
+        return [r for r in runs if pred(r)]
+
+    return manifest, runs, logtext, find
+
+
+def build_report(probe_dir: Path):
+    manifest, runs, logtext, find = load(probe_dir)
+    peak = float(manifest.get("peak_gbps", 256.0))
+    L = []  # markdown lines
+    csv_rows = []
+    j = {"model": manifest["model_name"], "peak_gbps": peak, "sections": {}}
+
+    L.append(f"# Bottleneck report -- {manifest['model_name']}")
+    L.append("")
+    L.append(f"Probe dir: `{probe_dir.name}`  |  roofline peak: {peak:.0f} GB/s  |  "
+             f"gen={manifest['gen']} reps={manifest['reps']} warmup={manifest['warmup']}")
+    L.append("")
+    L.append("> Phase 1 report: per-op GB/s and % peak are shape-model ESTIMATES (marked est). "
+             "Phase 2 replaces them with EP-measured bytes.")
+    L.append("")
+
+    # --- A. Headline ---
+    L.append("## A. Headline (model_benchmark)")
+    L.append("")
+    L.append("| prompt | TTFT (s) | prefill tok/s | decode tok/s | decode ms/tok | peak WS (GB) | kernel errors |")
+    L.append("|---|---|---|---|---|---|---|")
+    headline = {}
+    for r in sorted(find(lambda r: r.get("type") == "headline"), key=lambda r: r["prompt"]):
+        m = parse_model_benchmark(logtext(r["log"]))
+        headline[r["prompt"]] = m
+        L.append("| {p} | {ttft:.3f} | {pf:.0f} | {dc:.1f} | {dms:.2f} | {ws:.1f} | {ke} |".format(
+            p=r["prompt"], ttft=m.get("ttft_s", float("nan")), pf=m.get("prefill_tps", float("nan")),
+            dc=m.get("decode_tps", float("nan")), dms=m.get("decode_ms", float("nan")),
+            ws=m.get("peak_ws_gb", float("nan")), ke=r.get("kernel_errors")))
+        csv_rows.append(["headline", r["prompt"], "", m.get("prefill_tps"), m.get("decode_tps"),
+                         m.get("ttft_s"), m.get("peak_ws_gb"), "", "", ""])
+    j["sections"]["headline"] = {str(k): v for k, v in headline.items()}
+    L.append("")
+
+    # --- B/C. Decode per-op + per-shape roofline ---
+    dp = find(lambda r: r.get("type") == "decode_profile")
+    decode_rows = []
+    if dp:
+        tables = parse_perf_tables(logtext(dp[0]["log"]))
+        if tables:
+            t = tables[-1]  # steady-state decode Compute
+            total_gpu = t.get("total_gpu") or sum(o["gpu"] for o in t["ops"].values())
+            L.append(f"## B. Decode per-op roofline (steady token; total GPU {total_gpu:.1f} ms/Compute)")
+            L.append("")
+            L.append("| op | calls | gpu ms | % decode | bytes (MB, est) | GB/s (est) | % peak (est) |")
+            L.append("|---|---|---|---|---|---|---|")
+            ops_sorted = sorted(t["ops"].items(), key=lambda kv: kv[1]["gpu"], reverse=True)
+            for name, op in ops_sorted:
+                mb, gbps, pctpeak = _op_bytes(name, op, block=32, peak=peak)
+                mbs = f"{mb:.1f}" if mb else "-"
+                gs = f"{gbps:.0f}" if gbps else "-"
+                pp = f"{pctpeak:.0f}%" if pctpeak else "-"
+                L.append(f"| {name} | {op['calls']} | {op['gpu']:.1f} | {op['pct']:.1f}% | {mbs} | {gs} | {pp} |")
+                csv_rows.append(["decode_op", "", name, op["calls"], op["gpu"], op["pct"], mb, gbps, pctpeak, ""])
+                decode_rows.append({"op": name, "calls": op["calls"], "gpu": op["gpu"],
+                                    "pct": op["pct"], "mb": mb, "gbps": gbps, "pct_peak": pctpeak})
+            L.append("")
+            # C. matmul_nbits per-shape
+            if "matmul_nbits" in t["ops"] and t["ops"]["matmul_nbits"]["shapes"]:
+                L.append("## C. matmul_nbits per-shape roofline (est)")
+                L.append("")
+                L.append("| shape | calls | gpu ms | % decode | bits | bytes (MB) | GB/s | % peak | class |")
+                L.append("|---|---|---|---|---|---|---|---|---|")
+                shapes = t["ops"]["matmul_nbits"]["shapes"]
+                for label, rec in sorted(shapes.items(), key=lambda kv: kv[1]["gpu"], reverse=True):
+                    sm = _SHAPE_NK.search(label)
+                    row = f"| {label} | {rec['calls']} | {rec['gpu']:.1f} | {rec['pct']:.1f}% |"
+                    mbv = gbps = pk = None
+                    bits = ""
+                    if rec.get("mb_meas"):
+                        mbv = rec["mb_meas"]; gbps = rec.get("gbps_meas") or 0.0
+                        pk = rec.get("pk_meas") or 0.0
+                        if sm:
+                            bits = bits_for(int(sm.group(2)), int(sm.group(3)))
+                    elif sm:
+                        mI, nI, kI = int(sm.group(1)), int(sm.group(2)), int(sm.group(3))
+                        bits = bits_for(nI, kI)
+                        tot = matmul_nbits_bytes(mI, nI, kI, bits, 32) * rec["calls"]
+                        mbv = tot / 1e6
+                        gbps = (tot / 1e9) / (rec["gpu"] / 1000.0) if rec["gpu"] > 0 else 0
+                        pk = 100.0 * gbps / peak
+                    if mbv is not None:
+                        cls = "overhead-bound" if pk < 12 else ("headroom" if pk < 45 else "near-roofline")
+                        row += f" {bits} | {mbv:.1f} | {gbps:.0f} | {pk:.0f}% | {cls} |"
+                        csv_rows.append(["matmul_shape", "", label, rec["calls"], rec["gpu"], rec["pct"],
+                                         mbv, gbps, pk, cls])
+                    else:
+                        row += " - | - | - | - | - |"
+                    L.append(row)
+                L.append("")
+            # D. qmoe
+            if "qmoe" in t["ops"]:
+                q = t["ops"]["qmoe"]
+                L.append("## D. qmoe")
+                L.append("")
+                L.append(f"- decode: {q['calls']} calls, {q['gpu']:.1f} ms/Compute, {q['pct']:.1f}% of decode GPU time.")
+                L.append("- Sparsity realized (only k=8 active experts read); see prefill for the bigger qmoe cost.")
+                L.append("")
+            j["sections"]["decode"] = {"total_gpu_ms": total_gpu, "ops": decode_rows}
+    else:
+        L.append("## B. Decode per-op roofline")
+        L.append("")
+        L.append("_No decode profile log found._")
+        L.append("")
+
+    # --- E. Launch critical-path A/B ---
+    ln = find(lambda r: r.get("type") == "launch_normal")
+    lb = find(lambda r: r.get("type") == "launch_blocking")
+    L.append("## E. Launch critical-path A/B (p128 decode)")
+    L.append("")
+    # EP-measured per-Compute launch gap (wall - gpu) from the decode profile.
+    if dp:
+        _t = parse_perf_tables(logtext(dp[0]["log"]))
+        if _t and _t[-1].get("launch_gap") is not None and _t[-1].get("wall"):
+            w = _t[-1]["wall"]; g = _t[-1]["launch_gap"]
+            L.append(f"- EP per-Compute (profiled): wall={w:.2f} ms, launch_gap (wall-gpu)={g:.2f} ms "
+                     f"({100.0*g/w:.0f}% of wall is host launch/dispatch not hidden by GPU).")
+            L.append("")
+    if ln and lb:
+        mn = parse_model_benchmark(logtext(ln[0]["log"]))
+        mbk = parse_model_benchmark(logtext(lb[0]["log"]))
+        n_ms = mn.get("decode_ms"); b_ms = mbk.get("decode_ms")
+        L.append("| mode | decode tok/s | decode ms/tok |")
+        L.append("|---|---|---|")
+        L.append(f"| normal (async) | {mn.get('decode_tps', float('nan')):.1f} | {n_ms if n_ms else float('nan'):.2f} |")
+        L.append(f"| HIP_LAUNCH_BLOCKING=1 | {mbk.get('decode_tps', float('nan')):.1f} | {b_ms if b_ms else float('nan'):.2f} |")
+        L.append("")
+        if n_ms and b_ms and b_ms > 0:
+            ratio = b_ms / n_ms
+            hidden = b_ms - n_ms
+            L.append(f"- Serializing launches changes decode {n_ms:.2f} -> {b_ms:.2f} ms/tok "
+                     f"({ratio:.2f}x). ~{hidden:.2f} ms/tok of launch overhead is currently HIDDEN by overlap.")
+            if ratio < 1.15:
+                L.append("- Interpretation: launches are largely ON the critical path -> kernel-fusion / "
+                         "launch-reduction can help decode.")
+            else:
+                L.append("- Interpretation: launch overhead is mostly OVERLAPPED behind compute -> fusion "
+                         "yields little decode TPS; focus on the big compute kernels.")
+            j["sections"]["launch_ab"] = {"normal_ms": n_ms, "blocking_ms": b_ms, "ratio": ratio}
+    else:
+        L.append("_Launch A/B logs incomplete._")
+    L.append("")
+
+    # --- F. Prefill / TTFT ---
+    L.append("## F. Prefill / TTFT")
+    L.append("")
+    if headline:
+        L.append("- TTFT vs prompt (from section A): "
+                 + ", ".join(f"p{p}={headline[p].get('ttft_s', float('nan')):.2f}s" for p in sorted(headline)))
+        L.append("- Long-prompt TTFT is dominated by qmoe (most experts activated) + the huge-vocab lm_head. "
+                 "Per-op prefill attribution needs a prefill-phase [PERF] capture (Phase 2).")
+    L.append("")
+
+    # --- G. Cold start ---
+    cs = find(lambda r: r.get("type") == "coldstart")
+    L.append("## G. Cold start")
+    L.append("")
+    if cs:
+        L.append(f"- Minimal-run (l=8,g=1) process wall: {cs[0].get('wall_ms', 0)/1000.0:.1f} s "
+                 "(model load + compile + weight upload + first-inference autotune, load-dominated).")
+        # EP-measured [COLDSTART] phase timers (any log may carry them).
+        phases = {}
+        for r in runs:
+            for mm in _COLDSTART.finditer(logtext(r["log"])):
+                phases.setdefault(mm.group(1), float(mm.group(2)))
+        if phases:
+            L.append("- EP phase timers (measured):")
+            for k, v in phases.items():
+                L.append(f"  - {k}: {v:.3f} s")
+            j["sections"]["coldstart_phases"] = phases
+        else:
+            L.append("- (No [COLDSTART] phase lines found -- rebuild with Phase 2 instrumentation.)")
+    L.append("")
+
+    # --- Per-shape isolated roofline (single_op) ---
+    sops = find(lambda r: r.get("type") == "single_op")
+    if sops:
+        L.append("## (aux) Isolated per-shape kernel time (single_op seq1, gs128 graphs)")
+        L.append("")
+        L.append("| op graph | shape | calls | gpu ms |")
+        L.append("|---|---|---|---|")
+        for r in sops:
+            si = parse_singleop_gpu(logtext(r["log"]))
+            if si:
+                L.append(f"| {r['op']} | {si['shape']} | {si['calls']} | {si['gpu']:.3f} |")
+                csv_rows.append(["single_op", "", r["op"], si["calls"], si["gpu"], "", "", "", "", si["shape"]])
+        L.append("")
+
+    # --- H. Ranked bottleneck list ---
+    L.append("## H. Ranked decode bottlenecks (by GPU-time share)")
+    L.append("")
+    if decode_rows:
+        for i, d in enumerate(sorted(decode_rows, key=lambda x: x["pct"], reverse=True)[:6], 1):
+            lever = _lever_for(d["op"], d.get("pct_peak"))
+            pk = f"{d['pct_peak']:.0f}% peak" if d.get("pct_peak") else "n/a"
+            L.append(f"{i}. **{d['op']}** -- {d['pct']:.1f}% of decode ({pk}). {lever}")
+    L.append("")
+
+    (probe_dir / "bottleneck_report.md").write_text("\n".join(L), encoding="utf-8")
+    with (probe_dir / "bottleneck_report.csv").open("w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(["section", "prompt", "name", "calls", "gpu_or_tps", "pct_or_ttft",
+                    "mb_or_ws", "gbps", "pct_peak", "extra"])
+        w.writerows(csv_rows)
+    (probe_dir / "bottleneck_report.json").write_text(json.dumps(j, indent=2), encoding="utf-8")
+    return "\n".join(L)
+
+
+def _op_bytes(name, op, block, peak):
+    """Return (MB, GB/s, %peak). Prefer EP-measured columns when present;
+    otherwise fall back to the shape-driven estimate for matmul_nbits."""
+    if op.get("mb_meas"):
+        return op["mb_meas"], op.get("gbps_meas") or 0.0, op.get("pk_meas") or 0.0
+    if name == "matmul_nbits" and op.get("shapes"):
+        total = 0.0
+        for label, rec in op["shapes"].items():
+            sm = _SHAPE_NK.search(label)
+            if sm:
+                mI, nI, kI = int(sm.group(1)), int(sm.group(2)), int(sm.group(3))
+                total += matmul_nbits_bytes(mI, nI, kI, bits_for(nI, kI), block) * rec["calls"]
+        if total and op["gpu"] > 0:
+            gbps = (total / 1e9) / (op["gpu"] / 1000.0)
+            return total / 1e6, gbps, 100.0 * gbps / peak
+    return 0.0, 0.0, 0.0
+
+
+def _lever_for(op, pct_peak):
+    if op == "matmul_nbits":
+        return "Split into medium-N GEMV kernel efficiency (headroom) + small-N launch/batching (overhead-bound); see section C."
+    if op == "qmoe":
+        return "Grouped-expert GEMM (biggest prefill/TTFT lever); decode kernel BW tuning."
+    if op in ("skip_layernorm", "layernorm", "activation", "power", "silu", "reduce_sum", "transpose"):
+        return "Small-op tail -- fuse only if section E shows launches on the critical path."
+    if op == "gqa":
+        return "Full-attention decode kernel; check occupancy at m=1."
+    return "Investigate per section E (launch-bound?) and roofline % above."
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("probe_dir", help="perf-results/probe_<ts> directory")
+    args = ap.parse_args()
+    probe_dir = Path(args.probe_dir)
+    if not (probe_dir / "manifest.json").exists():
+        print(f"error: no manifest.json in {probe_dir}", file=sys.stderr)
+        return 1
+    build_report(probe_dir)
+    print(f"wrote {probe_dir/'bottleneck_report.md'}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/perf-report/bottleneck_report.py
+++ b/tools/perf-report/bottleneck_report.py
@@ -228,8 +228,10 @@ def build_report(probe_dir: Path):
             L.append("| op | calls | gpu ms | % decode | bytes (MB, est) | GB/s (est) | % peak (est) |")
             L.append("|---|---|---|---|---|---|---|")
             ops_sorted = sorted(t["ops"].items(), key=lambda kv: kv[1]["gpu"], reverse=True)
+            total_mb = 0.0
             for name, op in ops_sorted:
                 mb, gbps, pctpeak = _op_bytes(name, op, block=32, peak=peak)
+                total_mb += mb or 0.0
                 mbs = f"{mb:.1f}" if mb else "-"
                 gs = f"{gbps:.0f}" if gbps else "-"
                 pp = f"{pctpeak:.0f}%" if pctpeak else "-"
@@ -238,6 +240,24 @@ def build_report(probe_dir: Path):
                 decode_rows.append({"op": name, "calls": op["calls"], "gpu": op["gpu"],
                                     "pct": op["pct"], "mb": mb, "gbps": gbps, "pct_peak": pctpeak})
             L.append("")
+            # Top-down aggregate memory roofline -- PROFILER-INDEPENDENT: byte
+            # counts are correct even on degraded runs; multiply by the CLEAN
+            # decode tok/s to get achieved aggregate bandwidth vs peak. This is
+            # the roofline check that survives the profiling-path instability.
+            dtps = (headline.get(128) or headline.get(512) or {}).get("decode_tps")
+            if total_mb > 0 and dtps:
+                ach = (total_mb / 1000.0) * dtps  # GB/s = (GB/token) * tok/s
+                cov = 100.0 * sum(1 for d in decode_rows if d["mb"]) / max(1, len(decode_rows))
+                L.append(f"- Top-down aggregate memory roofline (profiler-independent): "
+                         f"~{total_mb/1000.0:.2f} GB/token (byte-model, ~{cov:.0f}% of ops covered) "
+                         f"x {dtps:.1f} tok/s = ~{ach:.0f} GB/s achieved = ~{100.0*ach/peak:.0f}% of {peak:.0f} GB/s peak.")
+                L.append(f"  Memory-roofline decode ceiling ~= {peak/(total_mb/1000.0):.0f} tok/s "
+                         f"(peak/bytes-per-token); measured {dtps:.1f} tok/s.")
+                L.append("")
+                j["sections"]["aggregate_roofline"] = {
+                    "gb_per_token": total_mb / 1000.0, "achieved_gbps": ach,
+                    "pct_peak": 100.0 * ach / peak, "ceiling_tps": peak / (total_mb / 1000.0),
+                    "ops_covered_pct": cov}
             # C. matmul_nbits per-shape
             if "matmul_nbits" in t["ops"] and t["ops"]["matmul_nbits"]["shapes"]:
                 L.append("## C. matmul_nbits per-shape roofline (est)")

--- a/tools/perf-report/merge_chrome_traces.py
+++ b/tools/perf-report/merge_chrome_traces.py
@@ -1,0 +1,56 @@
+"""Merge N Chrome-trace JSONs into ONE file (chrome://tracing / Perfetto load a
+single file only). Each input is placed in its own process (pid) block so they
+render as separate, stacked track groups.
+
+Usage:
+    python merge_traces.py out.json in1.json [in2.json ...] [--zero]
+
+- Same-clock inputs (e.g. EP per-session files sharing the absolute trace axis,
+  produced by op_profile.cpp) align automatically -- do NOT pass --zero.
+- Different-run/clock inputs (EP vs SQTT vs RGP golden) do not share a clock;
+  pass --zero to shift each to start at t=0 so they stack from a common origin
+  for shape comparison (they are NOT wall-clock aligned across runs).
+"""
+import json, sys, os
+
+def main(argv):
+    if len(argv) < 2:
+        print(__doc__); return 2
+    zero = "--zero" in argv
+    args = [a for a in argv if a != "--zero"]
+    out_path, inputs = args[0], args[1:]
+    if not inputs:
+        print(__doc__); return 2
+
+    merged = []
+    for i, path in enumerate(inputs):
+        d = json.load(open(path))
+        evs = d["traceEvents"] if isinstance(d, dict) else d
+        base_pid = 1000 * (i + 1)
+        label = os.path.basename(path)
+        # per-input time shift so inputs stack from a common origin if requested
+        shift = 0.0
+        if zero:
+            ts = [e["ts"] for e in evs if e.get("ph") == "X" and "ts" in e]
+            if ts:
+                shift = min(ts)
+        seen_pids = set()
+        for e in evs:
+            e = dict(e)
+            if "pid" in e:
+                e["pid"] = base_pid + int(e["pid"])
+                seen_pids.add(e["pid"])
+            if zero and e.get("ph") == "X" and "ts" in e:
+                e["ts"] = e["ts"] - shift
+            merged.append(e)
+        # a process_name so each input is clearly labeled in the merged view
+        for pid in (seen_pids or {base_pid}):
+            merged.append({"name": "process_name", "ph": "M", "pid": pid, "tid": 0,
+                           "args": {"name": f"[{i}] {label}"}})
+
+    json.dump({"displayTimeUnit": "ns", "traceEvents": merged}, open(out_path, "w"))
+    xs = sum(1 for e in merged if e.get("ph") == "X")
+    print(f"wrote {out_path}: {len(inputs)} inputs, {xs} span events, zero={zero}")
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]) or 0)

--- a/tools/perf-report/perf_measure.py
+++ b/tools/perf-report/perf_measure.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Reliable perf measurement harness for the HIPDNN/MorphiZen EP.
+
+Motivation: decode TPS on this box (gfx1151, no clock pinning available) has
+large run-to-run variance from GPU boost/thermal drift. Single runs and 2-sample
+A/Bs mislead. This harness makes results trustworthy by:
+
+  * NOISE-FLOOR mode: launch the model as N independent PROCESSES (each reloads +
+    re-autotunes, so process-level variance = the real noise), report
+    mean/median/stddev/CoV/95%CI, and the RESOLVABLE-WIN THRESHOLD (~2*stddev).
+    Any optimization smaller than that threshold is NOT measurable here.
+
+  * A/B mode: run K INTERLEAVED pairs (A,B,A,B,...). Paired per-pair differences
+    cancel slow common-mode drift (the dominant noise). Reports the mean paired
+    delta, its 95% CI, and a SIGNIFICANCE VERDICT (CI excludes 0 => real).
+
+Each "sample" is a fresh process (captures the real variance); within a process
+we use model_benchmark's own -r/-w to get a steady per-process number.
+
+Config A/B are environment-variable dicts (e.g. B={"HIPDNN_EP_MIOPEN_ACT":"1"}),
+so you can toggle a single code path on the SAME build for a clean paired A/B.
+
+Usage:
+  python perf_measure.py noise --reps 20
+  python perf_measure.py ab --pairs 12 --b-env HIPDNN_EP_MIOPEN_ACT=1
+  python perf_measure.py ab --pairs 12 --b-env HIPDNN_EP_MIOPEN_ACT=1,HIPDNN_EP_MIOPEN_NORM=1
+"""
+import argparse, os, re, statistics as st, subprocess, sys, time
+
+DEF_MODEL = r"D:\Qwen3.5-35B-A3B-fp16-ve-fp16-int4-text-gs32-dml"
+DEF_PKG = r"C:\Users\Administrator\workspace\gpu-test-package\bin"
+DEF_IBIN = r"C:\Users\Administrator\workspace\install\bin"
+DEF_ROCK = r"C:\Users\Administrator\workspace\therock-keep\bin"
+
+TPS_RE = re.compile(r"Token generation:.*?avg \(tokens/s\):\s*([\d.]+)", re.S)
+TTFT_RE = re.compile(r"Prompt processing.*?avg \(us\):\s*([\d.]+)", re.S)
+
+
+def run_once(exe, model, prompt, gen, reps, warmup, extra_env):
+    env = dict(os.environ)
+    env["PATH"] = f"{DEF_PKG};{DEF_IBIN};{DEF_ROCK};" + env.get("PATH", "")
+    # Clean perf/debug flags off unless the caller overrides.
+    for k in ("HIPDNN_EP_PERF", "HIPDNN_EP_PERF_ISOLATE", "HIPDNN_EP_QMOE_COARSE",
+              "HIPDNN_EP_QMOE_GROUPED", "HIPDNN_EP_QMOE_PARITY",
+              "HIPDNN_EP_NORM_PARITY", "HIPDNN_EP_CAST_DIAG",
+              "HIPDNN_EP_MIOPEN_ACT", "HIPDNN_EP_MIOPEN_NORM", "HIP_LAUNCH_BLOCKING"):
+        env.pop(k, None)
+    env.update(extra_env)
+    cmd = [exe, "-i", model, "-l", str(prompt), "-g", str(gen),
+           "-r", str(reps), "-w", str(warmup)]
+    p = subprocess.run(cmd, env=env, capture_output=True, text=True)
+    out = p.stdout + p.stderr
+    m = TPS_RE.search(out)
+    t = TTFT_RE.search(out)
+    tps = float(m.group(1)) if m else None
+    ttft = float(t.group(1)) / 1000.0 if t else None  # ms
+    return tps, ttft, out
+
+
+def stats(xs):
+    n = len(xs)
+    mean = st.mean(xs)
+    sd = st.stdev(xs) if n > 1 else 0.0
+    se = sd / (n ** 0.5) if n > 1 else 0.0
+    return dict(n=n, mean=mean, median=st.median(xs), sd=sd, se=se,
+                cov=100 * sd / mean if mean else 0, lo=min(xs), hi=max(xs),
+                ci95=1.96 * se)
+
+
+def parse_env(s):
+    d = {}
+    if not s:
+        return d
+    for kv in s.split(","):
+        kv = kv.strip()
+        if not kv:
+            continue
+        k, _, v = kv.partition("=")
+        d[k.strip()] = v.strip() if v else "1"
+    return d
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("mode", choices=["noise", "ab"])
+    ap.add_argument("--exe", default=os.path.join(DEF_PKG, "model_benchmark.exe"))
+    ap.add_argument("--model", default=DEF_MODEL)
+    ap.add_argument("--prompt", type=int, default=128)
+    ap.add_argument("--gen", type=int, default=128)
+    ap.add_argument("--reps", type=int, default=20, help="noise: #processes")
+    ap.add_argument("--pairs", type=int, default=12, help="ab: #interleaved pairs")
+    ap.add_argument("--inner-reps", type=int, default=3, help="model_benchmark -r")
+    ap.add_argument("--warmup", type=int, default=2, help="model_benchmark -w")
+    ap.add_argument("--drop", type=int, default=1, help="drop first N process samples (cold)")
+    ap.add_argument("--a-env", default="")
+    ap.add_argument("--b-env", default="")
+    ap.add_argument("--metric", choices=["tps", "ttft"], default="tps")
+    args = ap.parse_args()
+
+    def sample(extra_env):
+        tps, ttft, out = run_once(args.exe, args.model, args.prompt, args.gen,
+                                  args.inner_reps, args.warmup, extra_env)
+        val = tps if args.metric == "tps" else ttft
+        if val is None:
+            tail = "\n".join(out.strip().splitlines()[-3:])
+            print(f"  [FAIL] no {args.metric} parsed. tail: {tail}", flush=True)
+        return val
+
+    unit = "tok/s" if args.metric == "tps" else "ms"
+    if args.mode == "noise":
+        aenv = parse_env(args.a_env)
+        print(f"[noise] {args.reps} process reps, prompt={args.prompt} gen={args.gen} "
+              f"inner -r{args.inner_reps} -w{args.warmup}, env={aenv or 'clean'}")
+        xs = []
+        for i in range(args.reps):
+            v = sample(aenv)
+            if v is not None:
+                xs.append(v)
+                print(f"  rep {i+1:2d}: {v:.2f} {unit}", flush=True)
+        xs = xs[args.drop:]
+        s = stats(xs)
+        print(f"\n[noise floor] {args.metric} over n={s['n']} (dropped {args.drop} cold):")
+        print(f"  mean={s['mean']:.2f}  median={s['median']:.2f}  stddev={s['sd']:.2f}  "
+              f"CoV={s['cov']:.1f}%  min={s['lo']:.2f}  max={s['hi']:.2f}")
+        print(f"  95% CI of mean = +/-{s['ci95']:.2f} {unit}")
+        print(f"  RESOLVABLE-WIN THRESHOLD ~= 2*stddev = {2*s['sd']:.2f} {unit} "
+              f"({200*s['sd']/s['mean']:.1f}% of mean) -- smaller deltas are noise.")
+        return
+
+    # A/B interleaved paired
+    aenv, benv = parse_env(args.a_env), parse_env(args.b_env)
+    print(f"[ab] {args.pairs} interleaved pairs, prompt={args.prompt} gen={args.gen}, "
+          f"metric={args.metric}\n  A env={aenv or 'clean'}\n  B env={benv or 'clean'}")
+    a_vals, b_vals, diffs = [], [], []
+    for i in range(args.pairs):
+        a = sample(aenv)
+        b = sample(benv)
+        if a is None or b is None:
+            print(f"  pair {i+1:2d}: FAILED, skipping"); continue
+        d = b - a  # positive = B faster (tps) / B slower (ttft)
+        a_vals.append(a); b_vals.append(b); diffs.append(d)
+        print(f"  pair {i+1:2d}: A={a:.2f}  B={b:.2f}  B-A={d:+.2f}", flush=True)
+    if len(diffs) < 2:
+        print("not enough pairs"); return
+    sa, sb, sd = stats(a_vals), stats(b_vals), stats(diffs)
+    print(f"\n[A/B result] {args.metric} ({unit})")
+    print(f"  A: mean={sa['mean']:.2f} +/- {sa['ci95']:.2f} (CoV {sa['cov']:.1f}%)")
+    print(f"  B: mean={sb['mean']:.2f} +/- {sb['ci95']:.2f} (CoV {sb['cov']:.1f}%)")
+    pct = 100 * sd['mean'] / sa['mean'] if sa['mean'] else 0
+    print(f"  paired delta (B-A): mean={sd['mean']:+.2f}  95% CI=+/-{sd['ci95']:.2f}  "
+          f"({pct:+.1f}% vs A)")
+    sig = abs(sd['mean']) > sd['ci95'] and sd['ci95'] > 0
+    print(f"  VERDICT: {'SIGNIFICANT (CI excludes 0)' if sig else 'NOT significant (within noise)'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/perf-report/sample_bottleneck_report.md
+++ b/tools/perf-report/sample_bottleneck_report.md
@@ -1,6 +1,6 @@
 # Bottleneck report -- Qwen3.5-35B-A3B-fp16-ve-fp16-int4-text-gs32-dml
 
-Probe dir: `probe_20260705_220455`  |  roofline peak: 256 GB/s  |  gen=128 reps=5 warmup=2
+Probe dir: `probe_20260705_225537`  |  roofline peak: 242 GB/s (measured (BW-probe read))  |  gen=128 reps=5 warmup=2
 
 > Phase 1 report: per-op GB/s and % peak are shape-model ESTIMATES (marked est). Phase 2 replaces them with EP-measured bytes.
 
@@ -8,89 +8,91 @@ Probe dir: `probe_20260705_220455`  |  roofline peak: 256 GB/s  |  gen=128 reps=
 
 | prompt | TTFT (s) | prefill tok/s | decode tok/s | decode ms/tok | peak WS (GB) | kernel errors |
 |---|---|---|---|---|---|---|
-| 128 | 0.583 | 220 | 41.5 | 24.07 | 21.1 | False |
-| 512 | 1.521 | 337 | 42.0 | 23.78 | 22.4 | False |
-| 2048 | 6.823 | 300 | 37.2 | 26.84 | 27.7 | False |
+| 128 | 0.594 | 215 | 40.2 | 24.90 | 22.0 | False |
+| 512 | 1.531 | 334 | 41.2 | 24.28 | 23.4 | False |
+| 2048 | 4.722 | 434 | 39.2 | 25.51 | 27.8 | False |
 
-## B. Decode per-op roofline (steady token; total GPU 49.4 ms/Compute)
+## B. Decode per-op roofline (steady token; total GPU 47.4 ms/Compute)
 
 | op | calls | gpu ms | % decode | bytes (MB, est) | GB/s (est) | % peak (est) |
 |---|---|---|---|---|---|---|
-| matmul_nbits | 391 | 18.3 | 37.1% | 1094.0 | 60 | 23% |
-| qmoe | 40 | 5.5 | 11.2% | 566.6 | 102 | 40% |
-| elementwise | 440 | 5.1 | 10.3% | 6.3 | 1 | - |
-| linear_attention | 30 | 3.6 | 7.4% | - | - | - |
-| activation | 180 | 3.2 | 6.4% | 1.2 | - | - |
-| cast | 192 | 2.6 | 5.2% | 2.8 | 1 | - |
-| transpose | 100 | 2.2 | 4.5% | 2.3 | 1 | - |
-| skip_layernorm | 80 | 2.0 | 4.1% | 1.3 | 1 | - |
-| layernorm | 51 | 1.9 | 3.9% | 0.7 | - | - |
-| power | 120 | 1.9 | 3.8% | - | - | - |
-| gqa | 10 | 1.5 | 2.9% | - | - | - |
-| reduce_sum | 61 | 0.7 | 1.4% | 0.2 | - | - |
-| causal_conv | 30 | 0.4 | 0.8% | - | - | - |
-| rotary_emb | 20 | 0.3 | 0.5% | - | - | - |
-| gather | 9 | 0.2 | 0.4% | - | - | - |
-| sub | 1 | 0.0 | 0.1% | - | - | - |
+| matmul_nbits | 391 | 17.2 | 36.3% | 1094.0 | 64 | 25% |
+| qmoe | 40 | 5.3 | 11.1% | 566.6 | 108 | 42% |
+| elementwise | 440 | 5.1 | 10.7% | 6.3 | 1 | - |
+| linear_attention | 30 | 3.6 | 7.6% | 63.5 | 18 | 7% |
+| activation | 180 | 3.3 | 7.0% | 1.2 | - | - |
+| cast | 192 | 2.8 | 6.0% | 2.8 | 1 | - |
+| skip_layernorm | 80 | 2.4 | 5.0% | 1.3 | 1 | - |
+| transpose | 100 | 1.8 | 3.8% | 2.3 | 1 | 1% |
+| layernorm | 51 | 1.6 | 3.3% | 0.7 | - | - |
+| gqa | 10 | 1.5 | 3.2% | - | - | - |
+| power | 120 | 1.5 | 3.1% | - | - | - |
+| reduce_sum | 61 | 0.7 | 1.6% | 0.2 | - | - |
+| causal_conv | 30 | 0.3 | 0.7% | - | - | - |
+| rotary_emb | 20 | 0.2 | 0.4% | - | - | - |
+| gather | 9 | 0.2 | 0.3% | - | - | - |
+| sub | 1 | 0.0 | 0.0% | - | - | - |
 
-- Top-down aggregate memory roofline (profiler-independent): ~1.68 GB/token (byte-model, ~56% of ops covered) x 41.5 tok/s = ~70 GB/s achieved = ~27% of 256 GB/s peak.
-  Memory-roofline decode ceiling ~= 153 tok/s (peak/bytes-per-token); measured 41.5 tok/s.
+- Top-down aggregate memory roofline (profiler-independent): ~1.74 GB/token (byte-model, ~62% of ops covered) x 40.2 tok/s = ~70 GB/s achieved = ~29% of 242 GB/s peak.
+  Memory-roofline decode ceiling ~= 139 tok/s (peak/bytes-per-token); measured 40.2 tok/s.
 
 ## C. matmul_nbits per-shape roofline (est)
 
 | shape | calls | gpu ms | % decode | bits | bytes (MB) | GB/s | % peak | class |
 |---|---|---|---|---|---|---|---|---|
-| m=1,n=8192,k=2048 | 40 | 3.8 | 7.7% | 8 | 378.3 | 99 | 39% | headroom |
-| m=1,n=512,k=2048 | 100 | 3.1 | 6.2% | 4 | 59.5 | 19 | 8% | overhead-bound |
-| m=1,n=4096,k=2048 | 30 | 2.1 | 4.3% | 8 | 141.9 | 67 | 26% | headroom |
-| m=1,n=248320,k=2048 | 1 | 1.9 | 3.8% | 4 | 286.6 | 153 | 60% | near-roofline |
-| m=1,n=256,k=2048 | 40 | 1.8 | 3.6% | 4 | 12.0 | 7 | 3% | overhead-bound |
-| m=1,n=2048,k=4096 | 40 | 1.7 | 3.5% | 8 | 189.2 | 111 | 43% | headroom |
-| m=1,n=32,k=2048 | 60 | 1.5 | 3.1% | 8 | 2.5 | 2 | 1% | overhead-bound |
-| m=1,n=1,k=2048 | 40 | 1.2 | 2.5% | 4 | 0.2 | 0 | 0% | overhead-bound |
-| m=1,n=2048,k=512 | 40 | 1.2 | 2.4% | 4 | 23.8 | 20 | 8% | overhead-bound |
+| m=1,n=512,k=2048 | 100 | 3.9 | 8.3% | 4 | 59.5 | 15 | 6% | overhead-bound |
+| m=1,n=8192,k=2048 | 40 | 3.7 | 7.8% | 8 | 378.3 | 102 | 40% | headroom |
+| m=1,n=248320,k=2048 | 1 | 1.9 | 4.1% | 4 | 286.6 | 148 | 58% | near-roofline |
+| m=1,n=4096,k=2048 | 30 | 1.7 | 3.6% | 8 | 141.9 | 83 | 32% | headroom |
+| m=1,n=2048,k=4096 | 40 | 1.7 | 3.5% | 8 | 189.2 | 114 | 44% | headroom |
+| m=1,n=32,k=2048 | 60 | 1.3 | 2.7% | 8 | 2.5 | 2 | 1% | overhead-bound |
+| m=1,n=256,k=2048 | 40 | 1.1 | 2.3% | 4 | 12.0 | 11 | 4% | overhead-bound |
+| m=1,n=2048,k=512 | 40 | 1.0 | 2.1% | 4 | 23.8 | 24 | 9% | overhead-bound |
+| m=1,n=1,k=2048 | 40 | 0.9 | 1.9% | 4 | 0.2 | 0 | 0% | overhead-bound |
 
 ## D. qmoe
 
-- decode: 40 calls, 5.5 ms/Compute, 11.2% of decode GPU time.
+- decode: 40 calls, 5.3 ms/Compute, 11.1% of decode GPU time.
 - Sparsity realized (only k=8 active experts read); see prefill for the bigger qmoe cost.
 
 ## E. Launch critical-path A/B (p128 decode)
 
-- EP launch_gap (wall-gpu) over 505 decode Computes: median 1% of wall is host launch/dispatch not hidden by GPU (range 0-39%).
+- EP launch_gap (wall-gpu) over 505 decode Computes: median 0% of wall is host launch/dispatch not hidden by GPU (range 0-33%).
   => GPU-compute-bound -> prioritize kernel efficiency over fusion.
 
 | mode | decode tok/s | decode ms/tok |
 |---|---|---|
-| normal (async) | 38.8 | 25.79 |
-| HIP_LAUNCH_BLOCKING=1 | 10.7 | 93.54 |
+| normal (async) | 42.3 | 23.64 |
+| HIP_LAUNCH_BLOCKING=1 | 11.3 | 88.54 |
 
-- Serializing launches changes decode 25.79 -> 93.54 ms/tok (3.63x). ~67.75 ms/tok of launch overhead is currently HIDDEN by overlap.
+- Serializing launches changes decode 23.64 -> 88.54 ms/tok (3.75x). ~64.90 ms/tok of launch overhead is currently HIDDEN by overlap.
 - Interpretation: launch overhead is mostly OVERLAPPED behind compute -> fusion yields little decode TPS; focus on the big compute kernels.
 
 ## F. Prefill / TTFT
 
-- TTFT vs prompt (from section A): p128=0.58s, p512=1.52s, p2048=6.82s
+- TTFT vs prompt (from section A): p128=0.59s, p512=1.53s, p2048=4.72s
 
-- Prefill Compute per-op GPU breakdown (total 1707.2 ms):
+- Prefill Compute per-op GPU breakdown (total 1580.9 ms):
 
 | op | calls | gpu ms | % prefill |
 |---|---|---|---|
-| qmoe | 40 | 1409.6 | 82.6% |
-| gqa | 10 | 110.3 | 6.5% |
-| linear_attention | 30 | 72.3 | 4.2% |
-| matmul_nbits | 391 | 61.2 | 3.6% |
-| elementwise | 440 | 12.9 | 0.8% |
-| transpose | 100 | 8.9 | 0.5% |
-| activation | 180 | 6.1 | 0.4% |
+| qmoe | 40 | 1297.8 | 82.1% |
+| gqa | 10 | 98.9 | 6.3% |
+| linear_attention | 30 | 72.6 | 4.6% |
+| matmul_nbits | 391 | 59.9 | 3.8% |
+| elementwise | 440 | 11.8 | 0.7% |
+| transpose | 100 | 7.8 | 0.5% |
+| activation | 180 | 6.5 | 0.4% |
 | cast | 192 | 6.0 | 0.4% |
+
+- Prefill matmul_nbits compute roofline (p128): 500.2 GFLOP over ~23 ms (TTFT 0.59s x 4% matmul) = ~22.1 TFLOP/s = ~38% of ~59 TFLOP/s peak (peak ASSUMED -- confirm gfx1151 fp16 WMMA).
 
 ## G. Cold start
 
-- Minimal-run (l=8,g=1) process wall: 28.2 s (model load + compile + weight upload + first-inference autotune, load-dominated).
+- Minimal-run (l=8,g=1) process wall: 29.7 s (model load + compile + weight upload + first-inference autotune, load-dominated).
 - EP phase timers (measured, summed over cold-start events):
-  - autotune: 9.991 s (n=32)
-  - weight_upload: 3.632 s (n=3)
+  - autotune: 10.051 s (n=32)
+  - weight_upload: 3.608 s (n=3)
 
 ## (aux) Isolated per-shape kernel time (single_op seq1, gs128 graphs)
 
@@ -103,17 +105,17 @@ Probe dir: `probe_20260705_220455`  |  roofline peak: 256 GB/s  |  gen=128 reps=
 | MatMulNBits_in_proj_z | m=1,n=4096,k=2048 | 1 | 0.100 |
 | MatMulNBits_lm_head | m=1,n=248320,k=2048 | 1 | 1.800 |
 | MatMulNBits_out_proj | m=1,n=2048,k=4096 | 1 | 0.100 |
-| MatMulNBits_o_proj | m=1,n=2048,k=4096 | 1 | 0.000 |
-| MatMulNBits_q_proj | m=1,n=8192,k=2048 | 1 | 0.100 |
+| MatMulNBits_o_proj | m=1,n=2048,k=4096 | 1 | 0.100 |
+| MatMulNBits_q_proj | m=1,n=8192,k=2048 | 1 | 0.000 |
 | MatMulNBits_router | m=1,n=256,k=2048 | 1 | 0.000 |
 | MatMulNBits_shared_expert_gate | m=1,n=1,k=2048 | 1 | 0.000 |
 | QMoE | 1x2048x512,e=256 | 1 | 0.100 |
 
 ## H. Ranked decode bottlenecks (by GPU-time share)
 
-1. **matmul_nbits** -- 37.1% of decode (23% peak). Split into medium-N GEMV kernel efficiency (headroom) + small-N launch/batching (overhead-bound); see section C.
-2. **qmoe** -- 11.2% of decode (40% peak). Grouped-expert GEMM (biggest prefill/TTFT lever); decode kernel BW tuning.
-3. **elementwise** -- 10.3% of decode (n/a). Investigate per section E (launch-bound?) and roofline % above.
-4. **linear_attention** -- 7.4% of decode (n/a). Investigate per section E (launch-bound?) and roofline % above.
-5. **activation** -- 6.4% of decode (n/a). Small-op tail -- fuse only if section E shows launches on the critical path.
-6. **cast** -- 5.2% of decode (n/a). Investigate per section E (launch-bound?) and roofline % above.
+1. **matmul_nbits** -- 36.3% of decode (25% peak). Split into medium-N GEMV kernel efficiency (headroom) + small-N launch/batching (overhead-bound); see section C.
+2. **qmoe** -- 11.1% of decode (42% peak). Grouped-expert GEMM (biggest prefill/TTFT lever); decode kernel BW tuning.
+3. **elementwise** -- 10.7% of decode (n/a). Investigate per section E (launch-bound?) and roofline % above.
+4. **linear_attention** -- 7.6% of decode (7% peak). Investigate per section E (launch-bound?) and roofline % above.
+5. **activation** -- 7.0% of decode (n/a). Small-op tail -- fuse only if section E shows launches on the critical path.
+6. **cast** -- 6.0% of decode (n/a). Investigate per section E (launch-bound?) and roofline % above.

--- a/tools/perf-report/sample_bottleneck_report.md
+++ b/tools/perf-report/sample_bottleneck_report.md
@@ -1,6 +1,6 @@
 # Bottleneck report -- Qwen3.5-35B-A3B-fp16-ve-fp16-int4-text-gs32-dml
 
-Probe dir: `probe_20260705_095129`  |  roofline peak: 256 GB/s  |  gen=128 reps=5 warmup=2
+Probe dir: `probe_20260705_205931`  |  roofline peak: 256 GB/s  |  gen=128 reps=5 warmup=2
 
 > Phase 1 report: per-op GB/s and % peak are shape-model ESTIMATES (marked est). Phase 2 replaces them with EP-measured bytes.
 
@@ -8,69 +8,86 @@ Probe dir: `probe_20260705_095129`  |  roofline peak: 256 GB/s  |  gen=128 reps=
 
 | prompt | TTFT (s) | prefill tok/s | decode tok/s | decode ms/tok | peak WS (GB) | kernel errors |
 |---|---|---|---|---|---|---|
-| 128 | 0.653 | 196 | 36.9 | 27.12 | 21.0 | False |
-| 512 | 1.633 | 313 | 40.3 | 24.83 | 23.3 | False |
-| 2048 | 5.602 | 366 | 34.1 | 29.31 | 27.8 | False |
+| 128 | 0.571 | 224 | 39.5 | 25.31 | 22.0 | False |
+| 512 | 1.641 | 312 | 40.7 | 24.57 | 23.3 | False |
+| 2048 | 5.661 | 362 | 32.8 | 30.45 | 27.8 | False |
 
-## B. Decode per-op roofline (steady token; total GPU 48.7 ms/Compute)
+## B. Decode per-op roofline (steady token; total GPU 63.5 ms/Compute)
 
 | op | calls | gpu ms | % decode | bytes (MB, est) | GB/s (est) | % peak (est) |
 |---|---|---|---|---|---|---|
-| matmul_nbits | 391 | 18.0 | 36.9% | 1725.1 | 96 | 37% |
-| qmoe | 40 | 5.5 | 11.2% | - | - | - |
-| elementwise | 440 | 4.8 | 9.9% | - | - | - |
-| linear_attention | 30 | 3.6 | 7.4% | - | - | - |
-| activation | 180 | 3.2 | 6.6% | - | - | - |
-| cast | 192 | 2.7 | 5.6% | - | - | - |
-| skip_layernorm | 80 | 2.3 | 4.7% | - | - | - |
-| transpose | 100 | 2.2 | 4.6% | - | - | - |
-| layernorm | 51 | 1.8 | 3.7% | - | - | - |
-| power | 120 | 1.6 | 3.3% | - | - | - |
-| gqa | 10 | 1.4 | 2.9% | - | - | - |
-| reduce_sum | 61 | 0.6 | 1.3% | - | - | - |
-| causal_conv | 30 | 0.5 | 1.0% | - | - | - |
-| rotary_emb | 20 | 0.3 | 0.6% | - | - | - |
-| gather | 9 | 0.1 | 0.3% | - | - | - |
-| sub | 1 | 0.0 | 0.0% | - | - | - |
+| matmul_nbits | 391 | 20.2 | 31.9% | 1094.0 | 54 | 21% |
+| elementwise | 440 | 7.7 | 12.1% | 6.3 | 1 | - |
+| qmoe | 40 | 6.4 | 10.0% | 566.6 | 89 | 35% |
+| activation | 180 | 5.4 | 8.5% | 1.2 | - | - |
+| cast | 192 | 4.5 | 7.0% | 2.8 | 1 | - |
+| linear_attention | 30 | 4.2 | 6.7% | - | - | - |
+| transpose | 100 | 3.2 | 5.0% | 2.3 | 1 | - |
+| skip_layernorm | 80 | 3.1 | 4.9% | 1.3 | - | - |
+| layernorm | 51 | 2.6 | 4.0% | 0.7 | - | - |
+| power | 120 | 2.0 | 3.1% | - | - | - |
+| gqa | 10 | 1.9 | 3.0% | - | - | - |
+| causal_conv | 30 | 0.9 | 1.4% | - | - | - |
+| reduce_sum | 61 | 0.9 | 1.4% | 0.2 | - | - |
+| rotary_emb | 20 | 0.2 | 0.4% | - | - | - |
+| gather | 9 | 0.2 | 0.3% | - | - | - |
+| sub | 1 | 0.0 | 0.1% | - | - | - |
 
 ## C. matmul_nbits per-shape roofline (est)
 
 | shape | calls | gpu ms | % decode | bits | bytes (MB) | GB/s | % peak | class |
 |---|---|---|---|---|---|---|---|---|
-| m=1,n=8192,k=2048 | 40 | 3.8 | 7.8% | 8 | 713.9 | 188 | 73% | near-roofline |
-| m=1,n=512,k=2048 | 100 | 3.6 | 7.3% | 4 | 59.5 | 17 | 6% | overhead-bound |
-| m=1,n=2048,k=4096 | 40 | 2.8 | 5.7% | 8 | 357.0 | 128 | 50% | near-roofline |
-| m=1,n=4096,k=2048 | 30 | 2.1 | 4.4% | 8 | 267.8 | 128 | 50% | near-roofline |
-| m=1,n=248320,k=2048 | 1 | 2.0 | 4.2% | 4 | 286.6 | 143 | 56% | near-roofline |
-| m=1,n=32,k=2048 | 60 | 1.3 | 2.7% | 8 | 4.4 | 3 | 1% | overhead-bound |
-| m=1,n=256,k=2048 | 40 | 1.1 | 2.2% | 4 | 12.0 | 11 | 4% | overhead-bound |
-| m=1,n=1,k=2048 | 40 | 0.7 | 1.4% | 4 | 0.2 | 0 | 0% | overhead-bound |
-| m=1,n=2048,k=512 | 40 | 0.6 | 1.2% | 4 | 23.8 | 40 | 15% | headroom |
+| m=1,n=512,k=2048 | 100 | 4.3 | 6.8% | 4 | 59.5 | 14 | 5% | overhead-bound |
+| m=1,n=8192,k=2048 | 40 | 3.5 | 5.4% | 8 | 378.3 | 109 | 43% | headroom |
+| m=1,n=4096,k=2048 | 30 | 2.4 | 3.8% | 8 | 141.9 | 58 | 23% | headroom |
+| m=1,n=2048,k=4096 | 40 | 2.3 | 3.7% | 8 | 189.2 | 81 | 32% | headroom |
+| m=1,n=248320,k=2048 | 1 | 1.9 | 3.0% | 4 | 286.6 | 152 | 60% | near-roofline |
+| m=1,n=256,k=2048 | 40 | 1.6 | 2.6% | 4 | 12.0 | 7 | 3% | overhead-bound |
+| m=1,n=2048,k=512 | 40 | 1.6 | 2.5% | 4 | 23.8 | 15 | 6% | overhead-bound |
+| m=1,n=32,k=2048 | 60 | 1.3 | 2.1% | 8 | 2.5 | 2 | 1% | overhead-bound |
+| m=1,n=1,k=2048 | 40 | 1.3 | 2.0% | 4 | 0.2 | 0 | 0% | overhead-bound |
 
 ## D. qmoe
 
-- decode: 40 calls, 5.5 ms/Compute, 11.2% of decode GPU time.
+- decode: 40 calls, 6.4 ms/Compute, 10.0% of decode GPU time.
 - Sparsity realized (only k=8 active experts read); see prefill for the bigger qmoe cost.
 
 ## E. Launch critical-path A/B (p128 decode)
 
+- EP launch_gap (wall-gpu) over 505 decode Computes: median 0% of wall is host launch/dispatch not hidden by GPU (range 0-74%).
+  => GPU-compute-bound -> prioritize kernel efficiency over fusion.
+
 | mode | decode tok/s | decode ms/tok |
 |---|---|---|
-| normal (async) | 40.7 | 24.55 |
-| HIP_LAUNCH_BLOCKING=1 | 11.3 | 88.74 |
+| normal (async) | 32.0 | 31.20 |
+| HIP_LAUNCH_BLOCKING=1 | 10.9 | 92.04 |
 
-- Serializing launches changes decode 24.55 -> 88.74 ms/tok (3.61x). ~64.19 ms/tok of launch overhead is currently HIDDEN by overlap.
+- Serializing launches changes decode 31.20 -> 92.04 ms/tok (2.95x). ~60.84 ms/tok of launch overhead is currently HIDDEN by overlap.
 - Interpretation: launch overhead is mostly OVERLAPPED behind compute -> fusion yields little decode TPS; focus on the big compute kernels.
 
 ## F. Prefill / TTFT
 
-- TTFT vs prompt (from section A): p128=0.65s, p512=1.63s, p2048=5.60s
-- Long-prompt TTFT is dominated by qmoe (most experts activated) + the huge-vocab lm_head. Per-op prefill attribution needs a prefill-phase [PERF] capture (Phase 2).
+- TTFT vs prompt (from section A): p128=0.57s, p512=1.64s, p2048=5.66s
+
+- Prefill Compute per-op GPU breakdown (total 1826.2 ms):
+
+| op | calls | gpu ms | % prefill |
+|---|---|---|---|
+| qmoe | 40 | 1499.6 | 82.1% |
+| gqa | 10 | 123.9 | 6.8% |
+| linear_attention | 30 | 74.5 | 4.1% |
+| matmul_nbits | 391 | 66.3 | 3.6% |
+| elementwise | 440 | 15.6 | 0.9% |
+| transpose | 100 | 8.6 | 0.5% |
+| cast | 192 | 8.0 | 0.4% |
+| layernorm | 51 | 6.4 | 0.4% |
 
 ## G. Cold start
 
-- Minimal-run (l=8,g=1) process wall: 32.5 s (model load + compile + weight upload + first-inference autotune, load-dominated).
-- (No [COLDSTART] phase lines found -- rebuild with Phase 2 instrumentation.)
+- Minimal-run (l=8,g=1) process wall: 31.9 s (model load + compile + weight upload + first-inference autotune, load-dominated).
+- EP phase timers (measured, summed over cold-start events):
+  - autotune: 10.112 s (n=32)
+  - weight_upload: 4.995 s (n=3)
 
 ## (aux) Isolated per-shape kernel time (single_op seq1, gs128 graphs)
 
@@ -81,9 +98,9 @@ Probe dir: `probe_20260705_095129`  |  roofline peak: 256 GB/s  |  gen=128 reps=
 | MatMulNBits_in_proj_b | m=1,n=32,k=2048 | 1 | 0.000 |
 | MatMulNBits_in_proj_qkv | m=1,n=8192,k=2048 | 1 | 0.100 |
 | MatMulNBits_in_proj_z | m=1,n=4096,k=2048 | 1 | 0.100 |
-| MatMulNBits_lm_head | m=1,n=248320,k=2048 | 1 | 1.800 |
-| MatMulNBits_out_proj | m=1,n=2048,k=4096 | 1 | 0.000 |
-| MatMulNBits_o_proj | m=1,n=2048,k=4096 | 1 | 0.100 |
+| MatMulNBits_lm_head | m=1,n=248320,k=2048 | 1 | 2.100 |
+| MatMulNBits_out_proj | m=1,n=2048,k=4096 | 1 | 0.100 |
+| MatMulNBits_o_proj | m=1,n=2048,k=4096 | 1 | 0.000 |
 | MatMulNBits_q_proj | m=1,n=8192,k=2048 | 1 | 0.100 |
 | MatMulNBits_router | m=1,n=256,k=2048 | 1 | 0.000 |
 | MatMulNBits_shared_expert_gate | m=1,n=1,k=2048 | 1 | 0.000 |
@@ -91,9 +108,9 @@ Probe dir: `probe_20260705_095129`  |  roofline peak: 256 GB/s  |  gen=128 reps=
 
 ## H. Ranked decode bottlenecks (by GPU-time share)
 
-1. **matmul_nbits** -- 36.9% of decode (37% peak). Split into medium-N GEMV kernel efficiency (headroom) + small-N launch/batching (overhead-bound); see section C.
-2. **qmoe** -- 11.2% of decode (n/a). Grouped-expert GEMM (biggest prefill/TTFT lever); decode kernel BW tuning.
-3. **elementwise** -- 9.9% of decode (n/a). Investigate per section E (launch-bound?) and roofline % above.
-4. **linear_attention** -- 7.4% of decode (n/a). Investigate per section E (launch-bound?) and roofline % above.
-5. **activation** -- 6.6% of decode (n/a). Small-op tail -- fuse only if section E shows launches on the critical path.
-6. **cast** -- 5.6% of decode (n/a). Investigate per section E (launch-bound?) and roofline % above.
+1. **matmul_nbits** -- 31.9% of decode (21% peak). Split into medium-N GEMV kernel efficiency (headroom) + small-N launch/batching (overhead-bound); see section C.
+2. **elementwise** -- 12.1% of decode (n/a). Investigate per section E (launch-bound?) and roofline % above.
+3. **qmoe** -- 10.0% of decode (35% peak). Grouped-expert GEMM (biggest prefill/TTFT lever); decode kernel BW tuning.
+4. **activation** -- 8.5% of decode (n/a). Small-op tail -- fuse only if section E shows launches on the critical path.
+5. **cast** -- 7.0% of decode (n/a). Investigate per section E (launch-bound?) and roofline % above.
+6. **linear_attention** -- 6.7% of decode (n/a). Investigate per section E (launch-bound?) and roofline % above.

--- a/tools/perf-report/sample_bottleneck_report.md
+++ b/tools/perf-report/sample_bottleneck_report.md
@@ -33,6 +33,9 @@ Probe dir: `probe_20260705_212700`  |  roofline peak: 256 GB/s  |  gen=128 reps=
 | gather | 9 | 0.1 | 0.3% | - | - | - |
 | sub | 1 | 0.0 | 0.0% | - | - | - |
 
+- Top-down aggregate memory roofline (profiler-independent): ~1.68 GB/token (byte-model, ~56% of ops covered) x 37.8 tok/s = ~63 GB/s achieved = ~25% of 256 GB/s peak.
+  Memory-roofline decode ceiling ~= 153 tok/s (peak/bytes-per-token); measured 37.8 tok/s.
+
 ## C. matmul_nbits per-shape roofline (est)
 
 | shape | calls | gpu ms | % decode | bits | bytes (MB) | GB/s | % peak | class |

--- a/tools/perf-report/sample_bottleneck_report.md
+++ b/tools/perf-report/sample_bottleneck_report.md
@@ -1,0 +1,99 @@
+# Bottleneck report -- Qwen3.5-35B-A3B-fp16-ve-fp16-int4-text-gs32-dml
+
+Probe dir: `probe_20260705_095129`  |  roofline peak: 256 GB/s  |  gen=128 reps=5 warmup=2
+
+> Phase 1 report: per-op GB/s and % peak are shape-model ESTIMATES (marked est). Phase 2 replaces them with EP-measured bytes.
+
+## A. Headline (model_benchmark)
+
+| prompt | TTFT (s) | prefill tok/s | decode tok/s | decode ms/tok | peak WS (GB) | kernel errors |
+|---|---|---|---|---|---|---|
+| 128 | 0.653 | 196 | 36.9 | 27.12 | 21.0 | False |
+| 512 | 1.633 | 313 | 40.3 | 24.83 | 23.3 | False |
+| 2048 | 5.602 | 366 | 34.1 | 29.31 | 27.8 | False |
+
+## B. Decode per-op roofline (steady token; total GPU 48.7 ms/Compute)
+
+| op | calls | gpu ms | % decode | bytes (MB, est) | GB/s (est) | % peak (est) |
+|---|---|---|---|---|---|---|
+| matmul_nbits | 391 | 18.0 | 36.9% | 1725.1 | 96 | 37% |
+| qmoe | 40 | 5.5 | 11.2% | - | - | - |
+| elementwise | 440 | 4.8 | 9.9% | - | - | - |
+| linear_attention | 30 | 3.6 | 7.4% | - | - | - |
+| activation | 180 | 3.2 | 6.6% | - | - | - |
+| cast | 192 | 2.7 | 5.6% | - | - | - |
+| skip_layernorm | 80 | 2.3 | 4.7% | - | - | - |
+| transpose | 100 | 2.2 | 4.6% | - | - | - |
+| layernorm | 51 | 1.8 | 3.7% | - | - | - |
+| power | 120 | 1.6 | 3.3% | - | - | - |
+| gqa | 10 | 1.4 | 2.9% | - | - | - |
+| reduce_sum | 61 | 0.6 | 1.3% | - | - | - |
+| causal_conv | 30 | 0.5 | 1.0% | - | - | - |
+| rotary_emb | 20 | 0.3 | 0.6% | - | - | - |
+| gather | 9 | 0.1 | 0.3% | - | - | - |
+| sub | 1 | 0.0 | 0.0% | - | - | - |
+
+## C. matmul_nbits per-shape roofline (est)
+
+| shape | calls | gpu ms | % decode | bits | bytes (MB) | GB/s | % peak | class |
+|---|---|---|---|---|---|---|---|---|
+| m=1,n=8192,k=2048 | 40 | 3.8 | 7.8% | 8 | 713.9 | 188 | 73% | near-roofline |
+| m=1,n=512,k=2048 | 100 | 3.6 | 7.3% | 4 | 59.5 | 17 | 6% | overhead-bound |
+| m=1,n=2048,k=4096 | 40 | 2.8 | 5.7% | 8 | 357.0 | 128 | 50% | near-roofline |
+| m=1,n=4096,k=2048 | 30 | 2.1 | 4.4% | 8 | 267.8 | 128 | 50% | near-roofline |
+| m=1,n=248320,k=2048 | 1 | 2.0 | 4.2% | 4 | 286.6 | 143 | 56% | near-roofline |
+| m=1,n=32,k=2048 | 60 | 1.3 | 2.7% | 8 | 4.4 | 3 | 1% | overhead-bound |
+| m=1,n=256,k=2048 | 40 | 1.1 | 2.2% | 4 | 12.0 | 11 | 4% | overhead-bound |
+| m=1,n=1,k=2048 | 40 | 0.7 | 1.4% | 4 | 0.2 | 0 | 0% | overhead-bound |
+| m=1,n=2048,k=512 | 40 | 0.6 | 1.2% | 4 | 23.8 | 40 | 15% | headroom |
+
+## D. qmoe
+
+- decode: 40 calls, 5.5 ms/Compute, 11.2% of decode GPU time.
+- Sparsity realized (only k=8 active experts read); see prefill for the bigger qmoe cost.
+
+## E. Launch critical-path A/B (p128 decode)
+
+| mode | decode tok/s | decode ms/tok |
+|---|---|---|
+| normal (async) | 40.7 | 24.55 |
+| HIP_LAUNCH_BLOCKING=1 | 11.3 | 88.74 |
+
+- Serializing launches changes decode 24.55 -> 88.74 ms/tok (3.61x). ~64.19 ms/tok of launch overhead is currently HIDDEN by overlap.
+- Interpretation: launch overhead is mostly OVERLAPPED behind compute -> fusion yields little decode TPS; focus on the big compute kernels.
+
+## F. Prefill / TTFT
+
+- TTFT vs prompt (from section A): p128=0.65s, p512=1.63s, p2048=5.60s
+- Long-prompt TTFT is dominated by qmoe (most experts activated) + the huge-vocab lm_head. Per-op prefill attribution needs a prefill-phase [PERF] capture (Phase 2).
+
+## G. Cold start
+
+- Minimal-run (l=8,g=1) process wall: 32.5 s (model load + compile + weight upload + first-inference autotune, load-dominated).
+- (No [COLDSTART] phase lines found -- rebuild with Phase 2 instrumentation.)
+
+## (aux) Isolated per-shape kernel time (single_op seq1, gs128 graphs)
+
+| op graph | shape | calls | gpu ms |
+|---|---|---|---|
+| MatMulNBits_down_proj | m=1,n=2048,k=512 | 1 | 0.000 |
+| MatMulNBits_gate_proj | m=1,n=512,k=2048 | 1 | 0.000 |
+| MatMulNBits_in_proj_b | m=1,n=32,k=2048 | 1 | 0.000 |
+| MatMulNBits_in_proj_qkv | m=1,n=8192,k=2048 | 1 | 0.100 |
+| MatMulNBits_in_proj_z | m=1,n=4096,k=2048 | 1 | 0.100 |
+| MatMulNBits_lm_head | m=1,n=248320,k=2048 | 1 | 1.800 |
+| MatMulNBits_out_proj | m=1,n=2048,k=4096 | 1 | 0.000 |
+| MatMulNBits_o_proj | m=1,n=2048,k=4096 | 1 | 0.100 |
+| MatMulNBits_q_proj | m=1,n=8192,k=2048 | 1 | 0.100 |
+| MatMulNBits_router | m=1,n=256,k=2048 | 1 | 0.000 |
+| MatMulNBits_shared_expert_gate | m=1,n=1,k=2048 | 1 | 0.000 |
+| QMoE | 1x2048x512,e=256 | 1 | 0.000 |
+
+## H. Ranked decode bottlenecks (by GPU-time share)
+
+1. **matmul_nbits** -- 36.9% of decode (37% peak). Split into medium-N GEMV kernel efficiency (headroom) + small-N launch/batching (overhead-bound); see section C.
+2. **qmoe** -- 11.2% of decode (n/a). Grouped-expert GEMM (biggest prefill/TTFT lever); decode kernel BW tuning.
+3. **elementwise** -- 9.9% of decode (n/a). Investigate per section E (launch-bound?) and roofline % above.
+4. **linear_attention** -- 7.4% of decode (n/a). Investigate per section E (launch-bound?) and roofline % above.
+5. **activation** -- 6.6% of decode (n/a). Small-op tail -- fuse only if section E shows launches on the critical path.
+6. **cast** -- 5.6% of decode (n/a). Investigate per section E (launch-bound?) and roofline % above.

--- a/tools/perf-report/sample_bottleneck_report.md
+++ b/tools/perf-report/sample_bottleneck_report.md
@@ -1,6 +1,6 @@
 # Bottleneck report -- Qwen3.5-35B-A3B-fp16-ve-fp16-int4-text-gs32-dml
 
-Probe dir: `probe_20260705_212700`  |  roofline peak: 256 GB/s  |  gen=128 reps=5 warmup=2
+Probe dir: `probe_20260705_220455`  |  roofline peak: 256 GB/s  |  gen=128 reps=5 warmup=2
 
 > Phase 1 report: per-op GB/s and % peak are shape-model ESTIMATES (marked est). Phase 2 replaces them with EP-measured bytes.
 
@@ -8,89 +8,89 @@ Probe dir: `probe_20260705_212700`  |  roofline peak: 256 GB/s  |  gen=128 reps=
 
 | prompt | TTFT (s) | prefill tok/s | decode tok/s | decode ms/tok | peak WS (GB) | kernel errors |
 |---|---|---|---|---|---|---|
-| 128 | 0.654 | 196 | 37.8 | 26.44 | 21.0 | False |
-| 512 | 1.591 | 322 | 39.2 | 25.48 | 22.4 | False |
-| 2048 | 4.718 | 434 | 41.7 | 24.00 | 27.8 | False |
+| 128 | 0.583 | 220 | 41.5 | 24.07 | 21.1 | False |
+| 512 | 1.521 | 337 | 42.0 | 23.78 | 22.4 | False |
+| 2048 | 6.823 | 300 | 37.2 | 26.84 | 27.7 | False |
 
-## B. Decode per-op roofline (steady token; total GPU 45.1 ms/Compute)
+## B. Decode per-op roofline (steady token; total GPU 49.4 ms/Compute)
 
 | op | calls | gpu ms | % decode | bytes (MB, est) | GB/s (est) | % peak (est) |
 |---|---|---|---|---|---|---|
-| matmul_nbits | 391 | 15.5 | 34.4% | 1094.0 | 70 | 28% |
-| qmoe | 40 | 5.5 | 12.1% | 566.6 | 104 | 41% |
-| elementwise | 440 | 4.9 | 10.8% | 6.3 | 1 | 1% |
-| linear_attention | 30 | 3.5 | 7.7% | - | - | - |
-| activation | 180 | 3.2 | 7.2% | 1.2 | - | - |
-| cast | 192 | 2.8 | 6.2% | 2.8 | 1 | - |
-| skip_layernorm | 80 | 2.3 | 5.1% | 1.3 | 1 | - |
-| transpose | 100 | 1.9 | 4.3% | 2.3 | 1 | - |
-| layernorm | 51 | 1.8 | 4.0% | 0.7 | - | - |
-| gqa | 10 | 1.5 | 3.2% | - | - | - |
-| power | 120 | 1.1 | 2.5% | - | - | - |
-| reduce_sum | 61 | 0.5 | 1.1% | 0.2 | - | - |
-| causal_conv | 30 | 0.3 | 0.7% | - | - | - |
-| rotary_emb | 20 | 0.1 | 0.3% | - | - | - |
-| gather | 9 | 0.1 | 0.3% | - | - | - |
-| sub | 1 | 0.0 | 0.0% | - | - | - |
+| matmul_nbits | 391 | 18.3 | 37.1% | 1094.0 | 60 | 23% |
+| qmoe | 40 | 5.5 | 11.2% | 566.6 | 102 | 40% |
+| elementwise | 440 | 5.1 | 10.3% | 6.3 | 1 | - |
+| linear_attention | 30 | 3.6 | 7.4% | - | - | - |
+| activation | 180 | 3.2 | 6.4% | 1.2 | - | - |
+| cast | 192 | 2.6 | 5.2% | 2.8 | 1 | - |
+| transpose | 100 | 2.2 | 4.5% | 2.3 | 1 | - |
+| skip_layernorm | 80 | 2.0 | 4.1% | 1.3 | 1 | - |
+| layernorm | 51 | 1.9 | 3.9% | 0.7 | - | - |
+| power | 120 | 1.9 | 3.8% | - | - | - |
+| gqa | 10 | 1.5 | 2.9% | - | - | - |
+| reduce_sum | 61 | 0.7 | 1.4% | 0.2 | - | - |
+| causal_conv | 30 | 0.4 | 0.8% | - | - | - |
+| rotary_emb | 20 | 0.3 | 0.5% | - | - | - |
+| gather | 9 | 0.2 | 0.4% | - | - | - |
+| sub | 1 | 0.0 | 0.1% | - | - | - |
 
-- Top-down aggregate memory roofline (profiler-independent): ~1.68 GB/token (byte-model, ~56% of ops covered) x 37.8 tok/s = ~63 GB/s achieved = ~25% of 256 GB/s peak.
-  Memory-roofline decode ceiling ~= 153 tok/s (peak/bytes-per-token); measured 37.8 tok/s.
+- Top-down aggregate memory roofline (profiler-independent): ~1.68 GB/token (byte-model, ~56% of ops covered) x 41.5 tok/s = ~70 GB/s achieved = ~27% of 256 GB/s peak.
+  Memory-roofline decode ceiling ~= 153 tok/s (peak/bytes-per-token); measured 41.5 tok/s.
 
 ## C. matmul_nbits per-shape roofline (est)
 
 | shape | calls | gpu ms | % decode | bits | bytes (MB) | GB/s | % peak | class |
 |---|---|---|---|---|---|---|---|---|
-| m=1,n=512,k=2048 | 100 | 3.3 | 7.3% | 4 | 59.5 | 18 | 7% | overhead-bound |
-| m=1,n=8192,k=2048 | 40 | 2.8 | 6.3% | 8 | 378.3 | 133 | 52% | near-roofline |
-| m=1,n=2048,k=4096 | 40 | 2.0 | 4.4% | 8 | 189.2 | 96 | 37% | headroom |
-| m=1,n=4096,k=2048 | 30 | 1.9 | 4.3% | 8 | 141.9 | 73 | 29% | headroom |
-| m=1,n=248320,k=2048 | 1 | 1.9 | 4.3% | 4 | 286.6 | 148 | 58% | near-roofline |
-| m=1,n=256,k=2048 | 40 | 1.1 | 2.5% | 4 | 12.0 | 10 | 4% | overhead-bound |
-| m=1,n=32,k=2048 | 60 | 1.1 | 2.3% | 8 | 2.5 | 2 | 1% | overhead-bound |
-| m=1,n=2048,k=512 | 40 | 0.7 | 1.6% | 4 | 23.8 | 34 | 13% | headroom |
-| m=1,n=1,k=2048 | 40 | 0.6 | 1.4% | 4 | 0.2 | 0 | 0% | overhead-bound |
+| m=1,n=8192,k=2048 | 40 | 3.8 | 7.7% | 8 | 378.3 | 99 | 39% | headroom |
+| m=1,n=512,k=2048 | 100 | 3.1 | 6.2% | 4 | 59.5 | 19 | 8% | overhead-bound |
+| m=1,n=4096,k=2048 | 30 | 2.1 | 4.3% | 8 | 141.9 | 67 | 26% | headroom |
+| m=1,n=248320,k=2048 | 1 | 1.9 | 3.8% | 4 | 286.6 | 153 | 60% | near-roofline |
+| m=1,n=256,k=2048 | 40 | 1.8 | 3.6% | 4 | 12.0 | 7 | 3% | overhead-bound |
+| m=1,n=2048,k=4096 | 40 | 1.7 | 3.5% | 8 | 189.2 | 111 | 43% | headroom |
+| m=1,n=32,k=2048 | 60 | 1.5 | 3.1% | 8 | 2.5 | 2 | 1% | overhead-bound |
+| m=1,n=1,k=2048 | 40 | 1.2 | 2.5% | 4 | 0.2 | 0 | 0% | overhead-bound |
+| m=1,n=2048,k=512 | 40 | 1.2 | 2.4% | 4 | 23.8 | 20 | 8% | overhead-bound |
 
 ## D. qmoe
 
-- decode: 40 calls, 5.5 ms/Compute, 12.1% of decode GPU time.
+- decode: 40 calls, 5.5 ms/Compute, 11.2% of decode GPU time.
 - Sparsity realized (only k=8 active experts read); see prefill for the bigger qmoe cost.
 
 ## E. Launch critical-path A/B (p128 decode)
 
-- EP launch_gap (wall-gpu) over 505 decode Computes: median 0% of wall is host launch/dispatch not hidden by GPU (range 0-34%).
+- EP launch_gap (wall-gpu) over 505 decode Computes: median 1% of wall is host launch/dispatch not hidden by GPU (range 0-39%).
   => GPU-compute-bound -> prioritize kernel efficiency over fusion.
 
 | mode | decode tok/s | decode ms/tok |
 |---|---|---|
-| normal (async) | 41.9 | 23.86 |
-| HIP_LAUNCH_BLOCKING=1 | 11.1 | 90.06 |
+| normal (async) | 38.8 | 25.79 |
+| HIP_LAUNCH_BLOCKING=1 | 10.7 | 93.54 |
 
-- Serializing launches changes decode 23.86 -> 90.06 ms/tok (3.77x). ~66.20 ms/tok of launch overhead is currently HIDDEN by overlap.
+- Serializing launches changes decode 25.79 -> 93.54 ms/tok (3.63x). ~67.75 ms/tok of launch overhead is currently HIDDEN by overlap.
 - Interpretation: launch overhead is mostly OVERLAPPED behind compute -> fusion yields little decode TPS; focus on the big compute kernels.
 
 ## F. Prefill / TTFT
 
-- TTFT vs prompt (from section A): p128=0.65s, p512=1.59s, p2048=4.72s
+- TTFT vs prompt (from section A): p128=0.58s, p512=1.52s, p2048=6.82s
 
-- Prefill Compute per-op GPU breakdown (total 1564.8 ms):
+- Prefill Compute per-op GPU breakdown (total 1707.2 ms):
 
 | op | calls | gpu ms | % prefill |
 |---|---|---|---|
-| qmoe | 40 | 1285.9 | 82.2% |
-| gqa | 10 | 93.2 | 6.0% |
-| linear_attention | 30 | 73.4 | 4.7% |
-| matmul_nbits | 391 | 59.9 | 3.8% |
-| elementwise | 440 | 11.5 | 0.7% |
-| transpose | 100 | 7.7 | 0.5% |
-| layernorm | 51 | 7.3 | 0.5% |
-| cast | 192 | 5.8 | 0.4% |
+| qmoe | 40 | 1409.6 | 82.6% |
+| gqa | 10 | 110.3 | 6.5% |
+| linear_attention | 30 | 72.3 | 4.2% |
+| matmul_nbits | 391 | 61.2 | 3.6% |
+| elementwise | 440 | 12.9 | 0.8% |
+| transpose | 100 | 8.9 | 0.5% |
+| activation | 180 | 6.1 | 0.4% |
+| cast | 192 | 6.0 | 0.4% |
 
 ## G. Cold start
 
-- Minimal-run (l=8,g=1) process wall: 28.3 s (model load + compile + weight upload + first-inference autotune, load-dominated).
+- Minimal-run (l=8,g=1) process wall: 28.2 s (model load + compile + weight upload + first-inference autotune, load-dominated).
 - EP phase timers (measured, summed over cold-start events):
-  - autotune: 10.036 s (n=32)
-  - weight_upload: 3.568 s (n=3)
+  - autotune: 9.991 s (n=32)
+  - weight_upload: 3.632 s (n=3)
 
 ## (aux) Isolated per-shape kernel time (single_op seq1, gs128 graphs)
 
@@ -98,22 +98,22 @@ Probe dir: `probe_20260705_212700`  |  roofline peak: 256 GB/s  |  gen=128 reps=
 |---|---|---|---|
 | MatMulNBits_down_proj | m=1,n=2048,k=512 | 1 | 0.000 |
 | MatMulNBits_gate_proj | m=1,n=512,k=2048 | 1 | 0.000 |
-| MatMulNBits_in_proj_b | m=1,n=32,k=2048 | 1 | 0.100 |
+| MatMulNBits_in_proj_b | m=1,n=32,k=2048 | 1 | 0.000 |
 | MatMulNBits_in_proj_qkv | m=1,n=8192,k=2048 | 1 | 0.100 |
 | MatMulNBits_in_proj_z | m=1,n=4096,k=2048 | 1 | 0.100 |
-| MatMulNBits_lm_head | m=1,n=248320,k=2048 | 1 | 1.900 |
-| MatMulNBits_out_proj | m=1,n=2048,k=4096 | 1 | 0.000 |
-| MatMulNBits_o_proj | m=1,n=2048,k=4096 | 1 | 0.100 |
+| MatMulNBits_lm_head | m=1,n=248320,k=2048 | 1 | 1.800 |
+| MatMulNBits_out_proj | m=1,n=2048,k=4096 | 1 | 0.100 |
+| MatMulNBits_o_proj | m=1,n=2048,k=4096 | 1 | 0.000 |
 | MatMulNBits_q_proj | m=1,n=8192,k=2048 | 1 | 0.100 |
 | MatMulNBits_router | m=1,n=256,k=2048 | 1 | 0.000 |
 | MatMulNBits_shared_expert_gate | m=1,n=1,k=2048 | 1 | 0.000 |
-| QMoE | 1x2048x512,e=256 | 1 | 0.000 |
+| QMoE | 1x2048x512,e=256 | 1 | 0.100 |
 
 ## H. Ranked decode bottlenecks (by GPU-time share)
 
-1. **matmul_nbits** -- 34.4% of decode (28% peak). Split into medium-N GEMV kernel efficiency (headroom) + small-N launch/batching (overhead-bound); see section C.
-2. **qmoe** -- 12.1% of decode (41% peak). Grouped-expert GEMM (biggest prefill/TTFT lever); decode kernel BW tuning.
-3. **elementwise** -- 10.8% of decode (1% peak). Investigate per section E (launch-bound?) and roofline % above.
-4. **linear_attention** -- 7.7% of decode (n/a). Investigate per section E (launch-bound?) and roofline % above.
-5. **activation** -- 7.2% of decode (n/a). Small-op tail -- fuse only if section E shows launches on the critical path.
-6. **cast** -- 6.2% of decode (n/a). Investigate per section E (launch-bound?) and roofline % above.
+1. **matmul_nbits** -- 37.1% of decode (23% peak). Split into medium-N GEMV kernel efficiency (headroom) + small-N launch/batching (overhead-bound); see section C.
+2. **qmoe** -- 11.2% of decode (40% peak). Grouped-expert GEMM (biggest prefill/TTFT lever); decode kernel BW tuning.
+3. **elementwise** -- 10.3% of decode (n/a). Investigate per section E (launch-bound?) and roofline % above.
+4. **linear_attention** -- 7.4% of decode (n/a). Investigate per section E (launch-bound?) and roofline % above.
+5. **activation** -- 6.4% of decode (n/a). Small-op tail -- fuse only if section E shows launches on the critical path.
+6. **cast** -- 5.2% of decode (n/a). Investigate per section E (launch-bound?) and roofline % above.

--- a/tools/perf-report/sample_bottleneck_report.md
+++ b/tools/perf-report/sample_bottleneck_report.md
@@ -1,6 +1,6 @@
 # Bottleneck report -- Qwen3.5-35B-A3B-fp16-ve-fp16-int4-text-gs32-dml
 
-Probe dir: `probe_20260705_205931`  |  roofline peak: 256 GB/s  |  gen=128 reps=5 warmup=2
+Probe dir: `probe_20260705_212700`  |  roofline peak: 256 GB/s  |  gen=128 reps=5 warmup=2
 
 > Phase 1 report: per-op GB/s and % peak are shape-model ESTIMATES (marked est). Phase 2 replaces them with EP-measured bytes.
 
@@ -8,86 +8,86 @@ Probe dir: `probe_20260705_205931`  |  roofline peak: 256 GB/s  |  gen=128 reps=
 
 | prompt | TTFT (s) | prefill tok/s | decode tok/s | decode ms/tok | peak WS (GB) | kernel errors |
 |---|---|---|---|---|---|---|
-| 128 | 0.571 | 224 | 39.5 | 25.31 | 22.0 | False |
-| 512 | 1.641 | 312 | 40.7 | 24.57 | 23.3 | False |
-| 2048 | 5.661 | 362 | 32.8 | 30.45 | 27.8 | False |
+| 128 | 0.654 | 196 | 37.8 | 26.44 | 21.0 | False |
+| 512 | 1.591 | 322 | 39.2 | 25.48 | 22.4 | False |
+| 2048 | 4.718 | 434 | 41.7 | 24.00 | 27.8 | False |
 
-## B. Decode per-op roofline (steady token; total GPU 63.5 ms/Compute)
+## B. Decode per-op roofline (steady token; total GPU 45.1 ms/Compute)
 
 | op | calls | gpu ms | % decode | bytes (MB, est) | GB/s (est) | % peak (est) |
 |---|---|---|---|---|---|---|
-| matmul_nbits | 391 | 20.2 | 31.9% | 1094.0 | 54 | 21% |
-| elementwise | 440 | 7.7 | 12.1% | 6.3 | 1 | - |
-| qmoe | 40 | 6.4 | 10.0% | 566.6 | 89 | 35% |
-| activation | 180 | 5.4 | 8.5% | 1.2 | - | - |
-| cast | 192 | 4.5 | 7.0% | 2.8 | 1 | - |
-| linear_attention | 30 | 4.2 | 6.7% | - | - | - |
-| transpose | 100 | 3.2 | 5.0% | 2.3 | 1 | - |
-| skip_layernorm | 80 | 3.1 | 4.9% | 1.3 | - | - |
-| layernorm | 51 | 2.6 | 4.0% | 0.7 | - | - |
-| power | 120 | 2.0 | 3.1% | - | - | - |
-| gqa | 10 | 1.9 | 3.0% | - | - | - |
-| causal_conv | 30 | 0.9 | 1.4% | - | - | - |
-| reduce_sum | 61 | 0.9 | 1.4% | 0.2 | - | - |
-| rotary_emb | 20 | 0.2 | 0.4% | - | - | - |
-| gather | 9 | 0.2 | 0.3% | - | - | - |
-| sub | 1 | 0.0 | 0.1% | - | - | - |
+| matmul_nbits | 391 | 15.5 | 34.4% | 1094.0 | 70 | 28% |
+| qmoe | 40 | 5.5 | 12.1% | 566.6 | 104 | 41% |
+| elementwise | 440 | 4.9 | 10.8% | 6.3 | 1 | 1% |
+| linear_attention | 30 | 3.5 | 7.7% | - | - | - |
+| activation | 180 | 3.2 | 7.2% | 1.2 | - | - |
+| cast | 192 | 2.8 | 6.2% | 2.8 | 1 | - |
+| skip_layernorm | 80 | 2.3 | 5.1% | 1.3 | 1 | - |
+| transpose | 100 | 1.9 | 4.3% | 2.3 | 1 | - |
+| layernorm | 51 | 1.8 | 4.0% | 0.7 | - | - |
+| gqa | 10 | 1.5 | 3.2% | - | - | - |
+| power | 120 | 1.1 | 2.5% | - | - | - |
+| reduce_sum | 61 | 0.5 | 1.1% | 0.2 | - | - |
+| causal_conv | 30 | 0.3 | 0.7% | - | - | - |
+| rotary_emb | 20 | 0.1 | 0.3% | - | - | - |
+| gather | 9 | 0.1 | 0.3% | - | - | - |
+| sub | 1 | 0.0 | 0.0% | - | - | - |
 
 ## C. matmul_nbits per-shape roofline (est)
 
 | shape | calls | gpu ms | % decode | bits | bytes (MB) | GB/s | % peak | class |
 |---|---|---|---|---|---|---|---|---|
-| m=1,n=512,k=2048 | 100 | 4.3 | 6.8% | 4 | 59.5 | 14 | 5% | overhead-bound |
-| m=1,n=8192,k=2048 | 40 | 3.5 | 5.4% | 8 | 378.3 | 109 | 43% | headroom |
-| m=1,n=4096,k=2048 | 30 | 2.4 | 3.8% | 8 | 141.9 | 58 | 23% | headroom |
-| m=1,n=2048,k=4096 | 40 | 2.3 | 3.7% | 8 | 189.2 | 81 | 32% | headroom |
-| m=1,n=248320,k=2048 | 1 | 1.9 | 3.0% | 4 | 286.6 | 152 | 60% | near-roofline |
-| m=1,n=256,k=2048 | 40 | 1.6 | 2.6% | 4 | 12.0 | 7 | 3% | overhead-bound |
-| m=1,n=2048,k=512 | 40 | 1.6 | 2.5% | 4 | 23.8 | 15 | 6% | overhead-bound |
-| m=1,n=32,k=2048 | 60 | 1.3 | 2.1% | 8 | 2.5 | 2 | 1% | overhead-bound |
-| m=1,n=1,k=2048 | 40 | 1.3 | 2.0% | 4 | 0.2 | 0 | 0% | overhead-bound |
+| m=1,n=512,k=2048 | 100 | 3.3 | 7.3% | 4 | 59.5 | 18 | 7% | overhead-bound |
+| m=1,n=8192,k=2048 | 40 | 2.8 | 6.3% | 8 | 378.3 | 133 | 52% | near-roofline |
+| m=1,n=2048,k=4096 | 40 | 2.0 | 4.4% | 8 | 189.2 | 96 | 37% | headroom |
+| m=1,n=4096,k=2048 | 30 | 1.9 | 4.3% | 8 | 141.9 | 73 | 29% | headroom |
+| m=1,n=248320,k=2048 | 1 | 1.9 | 4.3% | 4 | 286.6 | 148 | 58% | near-roofline |
+| m=1,n=256,k=2048 | 40 | 1.1 | 2.5% | 4 | 12.0 | 10 | 4% | overhead-bound |
+| m=1,n=32,k=2048 | 60 | 1.1 | 2.3% | 8 | 2.5 | 2 | 1% | overhead-bound |
+| m=1,n=2048,k=512 | 40 | 0.7 | 1.6% | 4 | 23.8 | 34 | 13% | headroom |
+| m=1,n=1,k=2048 | 40 | 0.6 | 1.4% | 4 | 0.2 | 0 | 0% | overhead-bound |
 
 ## D. qmoe
 
-- decode: 40 calls, 6.4 ms/Compute, 10.0% of decode GPU time.
+- decode: 40 calls, 5.5 ms/Compute, 12.1% of decode GPU time.
 - Sparsity realized (only k=8 active experts read); see prefill for the bigger qmoe cost.
 
 ## E. Launch critical-path A/B (p128 decode)
 
-- EP launch_gap (wall-gpu) over 505 decode Computes: median 0% of wall is host launch/dispatch not hidden by GPU (range 0-74%).
+- EP launch_gap (wall-gpu) over 505 decode Computes: median 0% of wall is host launch/dispatch not hidden by GPU (range 0-34%).
   => GPU-compute-bound -> prioritize kernel efficiency over fusion.
 
 | mode | decode tok/s | decode ms/tok |
 |---|---|---|
-| normal (async) | 32.0 | 31.20 |
-| HIP_LAUNCH_BLOCKING=1 | 10.9 | 92.04 |
+| normal (async) | 41.9 | 23.86 |
+| HIP_LAUNCH_BLOCKING=1 | 11.1 | 90.06 |
 
-- Serializing launches changes decode 31.20 -> 92.04 ms/tok (2.95x). ~60.84 ms/tok of launch overhead is currently HIDDEN by overlap.
+- Serializing launches changes decode 23.86 -> 90.06 ms/tok (3.77x). ~66.20 ms/tok of launch overhead is currently HIDDEN by overlap.
 - Interpretation: launch overhead is mostly OVERLAPPED behind compute -> fusion yields little decode TPS; focus on the big compute kernels.
 
 ## F. Prefill / TTFT
 
-- TTFT vs prompt (from section A): p128=0.57s, p512=1.64s, p2048=5.66s
+- TTFT vs prompt (from section A): p128=0.65s, p512=1.59s, p2048=4.72s
 
-- Prefill Compute per-op GPU breakdown (total 1826.2 ms):
+- Prefill Compute per-op GPU breakdown (total 1564.8 ms):
 
 | op | calls | gpu ms | % prefill |
 |---|---|---|---|
-| qmoe | 40 | 1499.6 | 82.1% |
-| gqa | 10 | 123.9 | 6.8% |
-| linear_attention | 30 | 74.5 | 4.1% |
-| matmul_nbits | 391 | 66.3 | 3.6% |
-| elementwise | 440 | 15.6 | 0.9% |
-| transpose | 100 | 8.6 | 0.5% |
-| cast | 192 | 8.0 | 0.4% |
-| layernorm | 51 | 6.4 | 0.4% |
+| qmoe | 40 | 1285.9 | 82.2% |
+| gqa | 10 | 93.2 | 6.0% |
+| linear_attention | 30 | 73.4 | 4.7% |
+| matmul_nbits | 391 | 59.9 | 3.8% |
+| elementwise | 440 | 11.5 | 0.7% |
+| transpose | 100 | 7.7 | 0.5% |
+| layernorm | 51 | 7.3 | 0.5% |
+| cast | 192 | 5.8 | 0.4% |
 
 ## G. Cold start
 
-- Minimal-run (l=8,g=1) process wall: 31.9 s (model load + compile + weight upload + first-inference autotune, load-dominated).
+- Minimal-run (l=8,g=1) process wall: 28.3 s (model load + compile + weight upload + first-inference autotune, load-dominated).
 - EP phase timers (measured, summed over cold-start events):
-  - autotune: 10.112 s (n=32)
-  - weight_upload: 4.995 s (n=3)
+  - autotune: 10.036 s (n=32)
+  - weight_upload: 3.568 s (n=3)
 
 ## (aux) Isolated per-shape kernel time (single_op seq1, gs128 graphs)
 
@@ -95,12 +95,12 @@ Probe dir: `probe_20260705_205931`  |  roofline peak: 256 GB/s  |  gen=128 reps=
 |---|---|---|---|
 | MatMulNBits_down_proj | m=1,n=2048,k=512 | 1 | 0.000 |
 | MatMulNBits_gate_proj | m=1,n=512,k=2048 | 1 | 0.000 |
-| MatMulNBits_in_proj_b | m=1,n=32,k=2048 | 1 | 0.000 |
+| MatMulNBits_in_proj_b | m=1,n=32,k=2048 | 1 | 0.100 |
 | MatMulNBits_in_proj_qkv | m=1,n=8192,k=2048 | 1 | 0.100 |
 | MatMulNBits_in_proj_z | m=1,n=4096,k=2048 | 1 | 0.100 |
-| MatMulNBits_lm_head | m=1,n=248320,k=2048 | 1 | 2.100 |
-| MatMulNBits_out_proj | m=1,n=2048,k=4096 | 1 | 0.100 |
-| MatMulNBits_o_proj | m=1,n=2048,k=4096 | 1 | 0.000 |
+| MatMulNBits_lm_head | m=1,n=248320,k=2048 | 1 | 1.900 |
+| MatMulNBits_out_proj | m=1,n=2048,k=4096 | 1 | 0.000 |
+| MatMulNBits_o_proj | m=1,n=2048,k=4096 | 1 | 0.100 |
 | MatMulNBits_q_proj | m=1,n=8192,k=2048 | 1 | 0.100 |
 | MatMulNBits_router | m=1,n=256,k=2048 | 1 | 0.000 |
 | MatMulNBits_shared_expert_gate | m=1,n=1,k=2048 | 1 | 0.000 |
@@ -108,9 +108,9 @@ Probe dir: `probe_20260705_205931`  |  roofline peak: 256 GB/s  |  gen=128 reps=
 
 ## H. Ranked decode bottlenecks (by GPU-time share)
 
-1. **matmul_nbits** -- 31.9% of decode (21% peak). Split into medium-N GEMV kernel efficiency (headroom) + small-N launch/batching (overhead-bound); see section C.
-2. **elementwise** -- 12.1% of decode (n/a). Investigate per section E (launch-bound?) and roofline % above.
-3. **qmoe** -- 10.0% of decode (35% peak). Grouped-expert GEMM (biggest prefill/TTFT lever); decode kernel BW tuning.
-4. **activation** -- 8.5% of decode (n/a). Small-op tail -- fuse only if section E shows launches on the critical path.
-5. **cast** -- 7.0% of decode (n/a). Investigate per section E (launch-bound?) and roofline % above.
-6. **linear_attention** -- 6.7% of decode (n/a). Investigate per section E (launch-bound?) and roofline % above.
+1. **matmul_nbits** -- 34.4% of decode (28% peak). Split into medium-N GEMV kernel efficiency (headroom) + small-N launch/batching (overhead-bound); see section C.
+2. **qmoe** -- 12.1% of decode (41% peak). Grouped-expert GEMM (biggest prefill/TTFT lever); decode kernel BW tuning.
+3. **elementwise** -- 10.8% of decode (1% peak). Investigate per section E (launch-bound?) and roofline % above.
+4. **linear_attention** -- 7.7% of decode (n/a). Investigate per section E (launch-bound?) and roofline % above.
+5. **activation** -- 7.2% of decode (n/a). Small-op tail -- fuse only if section E shows launches on the critical path.
+6. **cast** -- 6.2% of decode (n/a). Investigate per section E (launch-bound?) and roofline % above.


### PR DESCRIPTION
<!--
Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
Licensed under the MIT License.
-->

<!--
Thanks for contributing! Please skim the two policies this repo
follows before requesting review (1-2 minutes each):

  Incremental development:
    https://llvm.org/docs/DeveloperPolicy.html#incremental-development
  AI tool use:
    https://llvm.org/docs/AIToolPolicy.html

A short summary lives in CONTRIBUTING.md at the repo root. Each
section below has an HTML comment explaining what to put in it; you
can delete the comment after filling the section in.
-->

## Summary

<!--
1-3 sentences. What changed at a high level and what gap or bug it
closes.
-->

## Why

<!--
Design rationale. What alternatives did you consider and why did you
pick this one? This section is what reviewers use to skip ahead and
agree with the design before reading the code. Even one paragraph is
fine if the choice is obvious; for non-trivial design decisions, be
explicit about the alternatives you rejected.
-->

## What

<!--
Numbered list of concrete changes, with file references. Useful
shapes:

1. **New pass / op / runtime helper** at `path/to/file.cpp`. <one
   sentence on the contract; one sentence on the predicate or scope>.
2. **Pipeline placement / call-site update**: <where it slots in and
   why that placement>.
3. **Helper rename / API change**: <one sentence>.
4. **Intentional non-changes**: <things the reader will expect to see
   touched that aren't, with the reason>.
-->

## Test plan

<!--
- Lit / pytest / runner commands you ran and the result (pass count,
  numerics delta vs reference, etc).
- Manual reproduction steps for behavioural changes (model name,
  hardware, command).
- For perf-sensitive changes, include a before/after table — see the
  optional Performance section below.
-->

## Notes for reviewers

<!--
- Known limitations and what they would take to fix.
- Follow-ups already planned (link the design issue / next PR).
- Anything load-bearing that isn't obvious from the diff (invariants,
  ABI assumptions, ordering constraints).
- "None" is a valid answer if the PR is small and self-contained.
-->

<!--
============================================================
Optional sections — include when applicable. Delete this whole
block if you don't need any of them.
============================================================

## Compiler IR walkthrough

<details>
<summary><b>Before</b> — short description</summary>

```mlir
// IR before this PR's pass / lowering
```

</details>

<details>
<summary><b>After</b> — short description</summary>

```mlir
// IR after this PR's pass / lowering
```

</details>

## Performance

<details>
<summary>Short headline result (e.g. "22x over DML EP on …")</summary>

| Metric | This PR | Baseline | Ratio |
|---|---:|---:|---:|
| Inferences/sec | … | … | … |
| Mean latency | … | … | … |

Hardware: gfxNNNN, model: <name>, build: <flags>.

</details>

============================================================
-->

## Checklist

- [ ] **Incremental.** This PR is either standalone, or a planned step
      in a documented series. If it exceeds ~500 LOC or ~10 files, the
      Summary / Why explains why it cannot be split, OR links the
      precursor PRs and the design issue. See:
      https://llvm.org/docs/DeveloperPolicy.html#incremental-development
- [ ] **AI policy.** If AI tools (Cursor, Claude, Copilot, etc.)
      generated substantial code or text, the Summary discloses it,
      the commit messages carry the trailers documented in
      [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md#commit-message-trailers),
      and you can answer questions about each design decision in
      review without delegating back to the tool. See:
      https://llvm.org/docs/AIToolPolicy.html
- [ ] **No `good first issue` automation.** This PR is not an AI-tool
      fix to an issue tagged `good first issue` (those are reserved as
      learning opportunities for new contributors).
- [ ] **Reviews resolved.** All review-comment threads from prior
      rounds are resolved (enforced by branch protection on `main`).
- [ ] **CODEOWNERS routing.** Reviewers were assigned automatically by
      [`CODEOWNERS`](../blob/main/.github/CODEOWNERS). If the change
      touches a path outside the current ownership map, the PR
      description names the operational owner.
