### PR TITLE
refactor(runtime/mm): remove legacy RuntimeState memory fields (Phase 2)

### DIFF
--- a/lib/HipDNNGraphRuntime/hipdnn_graph_runtime.cpp
+++ b/lib/HipDNNGraphRuntime/hipdnn_graph_runtime.cpp
@@ -38,6 +38,9 @@ enum GraphExecError {
 // vector types. All handle fields (hipStream_t, miopenHandle_t,
 // hipblasLtHandle_t) are pointer types, so void* is binary-compatible on the
 // same ABI.
+//
+// IMPORTANT: this must match the field order and sizes of RuntimeState exactly.
+// When RuntimeState's layout changes, update this mirror.
 struct RuntimeStateLayout {
   void *stream;
   void *miopen_handle;
@@ -45,12 +48,12 @@ struct RuntimeStateLayout {
   void *gpu_constants_blob;
   void **gpu_constants;
   size_t num_constants;
-  void *pool_base;
-  size_t pool_size;
-  size_t *buffer_offsets;
-  size_t num_buffers;
-  void *workspace;
-  size_t workspace_size;
+  void *mm;                // MemoryManager* (opaque here)
+  void *output_alloc_self; // hipdnn_output_allocator_t.self
+  void *output_alloc_fn;   // hipdnn_output_allocator_t.allocate
+  void *zp_unpack_cache;
+  void *op_profile;
+  void *device_error_flag; // int* (pointer-sized)
   void *hipdnn_handle;
   void *hipdnn_graph_registry;
 };

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -370,6 +370,8 @@ void *hipdnn_ep_get_host_scratch_base(RuntimeState *state, size_t needed_size);
 // a 64-byte-aligned GPU pointer; grows the workspace on demand. The bump
 // pointer is reset at the start of each Compute() (begin_compute).
 void *hipdnn_ep_scratch_alloc(RuntimeState *state, size_t size);
+size_t hipdnn_ep_scratch_save(RuntimeState *state);
+void hipdnn_ep_scratch_restore(RuntimeState *state, size_t saved);
 
 // Shared workspace management (lazily grown, reused across MatMul/GQA/Conv).
 // Prefer hipdnn_ep_scratch_alloc for new code; ensure_workspace is kept for

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -366,7 +366,14 @@ void *hipdnn_ep_get_pool_base(RuntimeState *state, int domain_id,
 // Returns: host-mapped base pointer (NULL on allocation failure)
 void *hipdnn_ep_get_host_scratch_base(RuntimeState *state, size_t needed_size);
 
-// Shared workspace management (lazily grown, reused across MatMul/GQA/Conv)
+// Bump-pointer scratch allocator over the shared workspace buffer. Returns
+// a 64-byte-aligned GPU pointer; grows the workspace on demand. The bump
+// pointer is reset at the start of each Compute() (begin_compute).
+void *hipdnn_ep_scratch_alloc(RuntimeState *state, size_t size);
+
+// Shared workspace management (lazily grown, reused across MatMul/GQA/Conv).
+// Prefer hipdnn_ep_scratch_alloc for new code; ensure_workspace is kept for
+// callers that need the raw buffer + its full size (e.g. hipBLASLt autotune).
 void *hipdnn_ep_state_get_workspace(RuntimeState *state);
 size_t hipdnn_ep_state_get_workspace_size(RuntimeState *state);
 int hipdnn_ep_state_ensure_workspace(RuntimeState *state, size_t needed_size);

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -370,6 +370,7 @@ void *hipdnn_ep_get_host_scratch_base(RuntimeState *state, size_t needed_size);
 // a 64-byte-aligned GPU pointer; grows the workspace on demand. The bump
 // pointer is reset at the start of each Compute() (begin_compute).
 void *hipdnn_ep_scratch_alloc(RuntimeState *state, size_t size);
+int hipdnn_ep_scratch_reserve(RuntimeState *state, size_t total);
 size_t hipdnn_ep_scratch_save(RuntimeState *state);
 void hipdnn_ep_scratch_restore(RuntimeState *state, size_t saved);
 

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -142,43 +142,20 @@ static int initialize_state_handles(RuntimeState **out_state) {
   state->gpu_constants_blob = nullptr;
   state->gpu_constants = nullptr;
   state->num_constants = 0;
-  // Unified Memory Manager — created before the pool/scratch fields so that
-  // the old extern C functions (hipdnn_ep_get_pool_base etc.) can delegate
-  // to it immediately. hal_create_for_device uses device 0 (set below).
-  // We create the MM with a temporary device_id=0; for multi-GPU support this
-  // would use the actual device. The stream is set after hipStreamCreate.
+  // Unified Memory Manager — owns all session-scoped GPU/host buffers.
+  // hal_create_for_device uses device 0 (set below); for multi-GPU support
+  // this would use the actual device. Stream is set after hipStreamCreate.
   state->mm = new MemoryManager(hal_create_for_device(0));
-  // Legacy transition fields — mm owns the actual data.
-  state->num_pool_domains = 0;
-  state->pool_base = nullptr;
-  state->pool_size = nullptr;
-  state->buffer_offsets = nullptr;
-  state->num_buffers = 0;
-  state->workspace = nullptr;
-  state->workspace_size = 0;
-  state->host_scratch_base = nullptr;
-  state->host_scratch_size = 0;
   // Start with no output allocator (null context + callback). The EP installs
   // one via hipdnn_ep_set_output_allocator before the first inference_compute,
   // and hipdnn_ep_alloc_output then forwards each graph-output request to it.
   state->output_allocator.self = nullptr;
   state->output_allocator.allocate = nullptr;
-  state->qmoe_scratch = nullptr;
-  state->qmoe_scratch_size = 0;
-  state->qmoe_host_scratch = nullptr;
-  state->qmoe_host_scratch_size = 0;
-  state->conv_scratch = nullptr;
-  state->conv_scratch_size = 0;
   state->zp_unpack_cache = nullptr;
   state->op_profile = hipdnn_ep_perf_enabled() ? op_profile_create() : nullptr;
   state->device_error_flag = nullptr;
   state->hipdnn_handle = nullptr;
   state->hipdnn_graph_registry = nullptr;
-  // seqlens_k cache lives in mm; legacy alias fields stay in sync via
-  // hipdnn_ep_runtime_begin_compute -> mm->begin_compute().
-  state->seqlens_k_cached_valid = false;
-  state->seqlens_k_cached_val = 0;
-  state->seqlens_k_cached_ptr = nullptr;
   state->loop_iter_cpu_buf = nullptr;
   state->loop_iter_capacity = 0;
   state->loop_iter_dev = nullptr;
@@ -704,29 +681,12 @@ int hipdnn_ep_state_cleanup(RuntimeState *state) {
     HIP_CLEANUP(hipStreamSynchronize(state->stream));
   }
 
-  // Destroy the Unified Memory Manager first (before stream teardown, because
-  // MM's destructor may need to sync the stream before freeing GPU pools).
-  // The MM destructor calls hip_free_gpu / hal_->free on all owned buffers.
+  // Destroy the Unified Memory Manager (frees all session-scoped GPU/host
+  // buffers: pool domains, shared workspace, host-scalar scratch, qmoe host
+  // scratch). Must happen before stream teardown because MM's destructor may
+  // need to sync the stream before freeing GPU pools.
   delete state->mm;
   state->mm = nullptr;
-
-  // Legacy fields were owned by mm in Phase 1; nothing to free here for them.
-  // qmoe_scratch / workspace / host_scratch_base are all null after mm delete.
-
-  // Free qmoe device scratch + pinned host mirror (if allocated directly,
-  // i.e. before MM was wired or for paths not yet migrated).
-  if (state->qmoe_scratch) {
-    HIP_CLEANUP(hipFree(state->qmoe_scratch));
-  }
-  if (state->qmoe_host_scratch) {
-    HIP_CLEANUP(hipHostFree(state->qmoe_host_scratch));
-  }
-
-  // Free the MIOpen convolution workspace pool (if allocated). The stream
-  // sync above has drained any in-flight conv that may still be reading it.
-  if (state->conv_scratch) {
-    HIP_CLEANUP(hipFree(state->conv_scratch));
-  }
 
   // Tear down per-op state slots. Each entry's deletor destroys its concrete
   // type; slots reference nothing in other slots, so order is irrelevant. The
@@ -761,30 +721,6 @@ int hipdnn_ep_state_cleanup(RuntimeState *state) {
 
   if (state->device_error_flag) {
     HIP_CLEANUP(hipFree(state->device_error_flag));
-  }
-
-  // host_scratch_base, workspace, pool_base/pool_size/buffer_offsets are now
-  // owned by RuntimeState::mm (deleted above). Nothing to free here for them.
-  // Legacy: if somehow mm was not created (allocation failure at init), fall
-  // back to direct cleanup for safety.
-  if (state->host_scratch_base) {
-    HIP_CLEANUP(hipHostFree(state->host_scratch_base));
-  }
-  if (state->pool_base) {
-    for (int i = 0; i < state->num_pool_domains; ++i) {
-      if (state->pool_base[i])
-        HIP_CLEANUP(hipFree(state->pool_base[i]));
-    }
-    free(state->pool_base);
-    state->pool_base = nullptr;
-  }
-  if (state->pool_size) {
-    free(state->pool_size);
-    state->pool_size = nullptr;
-  }
-  state->num_pool_domains = 0;
-  if (state->buffer_offsets) {
-    free(state->buffer_offsets);
   }
 
   // Free the single constants blob and the pointer array.
@@ -890,17 +826,8 @@ extern "C"
     return;
   }
   // Delegate cache invalidation to the MemoryManager (single authoritative
-  // location for all per-forward-pass caches). Keep the legacy RuntimeState
-  // alias fields in sync for GQA code that still reads them directly.
-  if (state->mm) {
-    state->mm->begin_compute();
-    // Sync legacy alias fields so gqa.cpp reads are still correct.
-    state->seqlens_k_cached_valid = state->mm->seqlens_k_valid_;
-    state->seqlens_k_cached_ptr = state->mm->seqlens_k_ptr_;
-  } else {
-    state->seqlens_k_cached_valid = false;
-    state->seqlens_k_cached_ptr = nullptr;
-  }
+  // location for all per-forward-pass caches).
+  state->mm->begin_compute();
   // Publish the session stream for ABI-fixed helpers (memrefCopy) that run
   // before/within main_graph and otherwise default to stream 0.
   hipdnn_ep_set_current_stream(static_cast<void *>(state->stream));
@@ -928,45 +855,8 @@ extern "C"
 }
 
 //===----------------------------------------------------------------------===//
-// Memory Pooling Support
+// Memory Management — all delegates to MemoryManager (mm)
 //===----------------------------------------------------------------------===//
-
-// Grow the per-domain pool arrays so that index [needed_count - 1] is valid.
-// New slots are zero-filled (null base, size 0) so they behave exactly like the
-// fresh inline entries the fixed-size array used to provide. Mirrors the
-// grow-on-demand contract of the individual pools: never shrinks, and at steady
-// state (every domain already seen) this is a no-op. Returns false on OOM,
-// leaving the existing arrays intact. realloc-move is safe — callers re-derive
-// pool_base[domain_id] from state on every access, never caching element ptrs.
-static bool ensure_pool_domains(RuntimeState *state, int needed_count) {
-  if (needed_count <= state->num_pool_domains) {
-    return true;
-  }
-  auto *new_base = static_cast<void **>(
-      realloc(state->pool_base, sizeof(void *) * needed_count));
-  if (!new_base) {
-    fprintf(stderr, "Failed to grow pool_base array to %d domains\n",
-            needed_count);
-    return false;
-  }
-  state->pool_base = new_base;
-  auto *new_size = static_cast<size_t *>(
-      realloc(state->pool_size, sizeof(size_t) * needed_count));
-  if (!new_size) {
-    // pool_base already grew; leaving it larger than num_pool_domains is safe
-    // because num_pool_domains (updated below) still bounds every loop.
-    fprintf(stderr, "Failed to grow pool_size array to %d domains\n",
-            needed_count);
-    return false;
-  }
-  state->pool_size = new_size;
-  for (int i = state->num_pool_domains; i < needed_count; ++i) {
-    state->pool_base[i] = nullptr;
-    state->pool_size[i] = 0;
-  }
-  state->num_pool_domains = needed_count;
-  return true;
-}
 
 extern "C" {
 
@@ -976,68 +866,12 @@ int hipdnn_ep_pool_init(RuntimeState *state, size_t pool_size,
     fprintf(stderr, "Invalid state parameter to hipdnn_ep_pool_init\n");
     return 1;
   }
-
-  if (state->mm) {
-    // Delegate to the MemoryManager. load_pool_plan records the static pool
-    // plan; the actual hipMalloc is deferred to the first get_pool_base call.
-    state->mm->load_pool_plan(pool_size, buffer_offsets, num_buffers);
-    // Update legacy alias fields so code that reads state->num_buffers etc.
-    // still sees consistent values.
-    state->num_buffers = num_buffers;
-    return 0;
-  }
-
-  // Fallback: original implementation (reached only if mm creation failed).
-  if (!ensure_pool_domains(state, 1)) {
-    return 1;
-  }
-  if (pool_size > 0) {
-    if (hipMalloc(&state->pool_base[0], pool_size) != hipSuccess) {
-      fprintf(stderr, "Failed to allocate memory pool of size %zu bytes\n",
-              pool_size);
-      return 2;
-    }
-  } else {
-    state->pool_base[0] = nullptr;
-  }
-  state->pool_size[0] = pool_size;
-  state->num_buffers = num_buffers;
-  if (num_buffers > 0 && buffer_offsets) {
-    state->buffer_offsets = (size_t *)malloc(sizeof(size_t) * num_buffers);
-    if (!state->buffer_offsets) {
-      if (state->pool_base[0]) {
-        HIP_CLEANUP(hipFree(state->pool_base[0]));
-        state->pool_base[0] = nullptr;
-      }
-      return 1;
-    }
-    memcpy(state->buffer_offsets, buffer_offsets, sizeof(size_t) * num_buffers);
-  } else {
-    state->buffer_offsets = nullptr;
-  }
+  state->mm->load_pool_plan(pool_size, buffer_offsets, num_buffers);
   return 0;
 }
 
 void *hipdnn_ep_get_buffer_from_pool(RuntimeState *state, size_t index) {
-  if (state && state->mm)
-    return state->mm->get_buffer_from_pool(index);
-
-  // Fallback: original implementation.
-  if (!state || !state->pool_base || state->num_pool_domains < 1 ||
-      !state->pool_base[0]) {
-    fprintf(stderr, "Invalid state or pool not initialized\n");
-    return nullptr;
-  }
-
-  if (index >= state->num_buffers) {
-    fprintf(stderr, "Buffer index %zu out of range (num_buffers = %zu)\n",
-            index, state->num_buffers);
-    return nullptr;
-  }
-
-  char *pool_ptr = static_cast<char *>(state->pool_base[0]);
-  size_t offset = state->buffer_offsets[index];
-  return pool_ptr + offset;
+  return state ? state->mm->get_buffer_from_pool(index) : nullptr;
 }
 
 void *hipdnn_ep_get_pool_base(RuntimeState *state, int domain_id,
@@ -1053,36 +887,7 @@ void *hipdnn_ep_get_pool_base(RuntimeState *state, int domain_id,
             domain_id);
     return nullptr;
   }
-  // Delegate to MemoryManager — provides 1.5× amortized growth.
-  if (state->mm)
-    return state->mm->get_pool_base(domain_id, needed_size);
-
-  // Fallback: original direct implementation (reached only if mm is null).
-  if (!ensure_pool_domains(state, domain_id + 1))
-    return nullptr;
-  if (needed_size == 0)
-    needed_size = 1;
-  if (needed_size > state->pool_size[domain_id]) {
-    if (state->pool_base[domain_id]) {
-      if (state->stream)
-        HIP_CLEANUP(hipStreamSynchronize(state->stream));
-      fprintf(stderr,
-              "hipdnn_ep_get_pool_base: growing pool[%d] %zu -> %zu bytes "
-              "(rare; first time this large input shape was seen)\n",
-              domain_id, state->pool_size[domain_id], needed_size);
-      fflush(stderr);
-      HIP_CLEANUP(hipFree(state->pool_base[domain_id]));
-    }
-    void *new_base = nullptr;
-    if (hipMalloc(&new_base, needed_size) != hipSuccess) {
-      state->pool_base[domain_id] = nullptr;
-      state->pool_size[domain_id] = 0;
-      return nullptr;
-    }
-    state->pool_base[domain_id] = new_base;
-    state->pool_size[domain_id] = needed_size;
-  }
-  return state->pool_base[domain_id];
+  return state->mm->get_pool_base(domain_id, needed_size);
 }
 
 void *hipdnn_ep_get_host_scratch_base(RuntimeState *state, size_t needed_size) {
@@ -1091,43 +896,15 @@ void *hipdnn_ep_get_host_scratch_base(RuntimeState *state, size_t needed_size) {
             "Invalid state parameter to hipdnn_ep_get_host_scratch_base\n");
     return nullptr;
   }
-  if (state->mm)
-    return state->mm->get_host_scratch(needed_size);
-
-  // Fallback: original implementation.
-  if (needed_size > state->host_scratch_size) {
-    if (state->host_scratch_base) {
-      if (state->stream)
-        HIP_CLEANUP(hipStreamSynchronize(state->stream));
-      HIP_CLEANUP(hipHostFree(state->host_scratch_base));
-    }
-    void *new_base = nullptr;
-    if (hipHostMalloc(&new_base, needed_size, hipHostMallocMapped) !=
-        hipSuccess) {
-      state->host_scratch_base = nullptr;
-      state->host_scratch_size = 0;
-      return nullptr;
-    }
-    state->host_scratch_base = new_base;
-    state->host_scratch_size = needed_size;
-  }
-  return state->host_scratch_base;
+  return state->mm->get_host_scratch(needed_size);
 }
 
-//===----------------------------------------------------------------------===//
-// Shared Workspace Support
-//===----------------------------------------------------------------------===//
-
 void *hipdnn_ep_state_get_workspace(RuntimeState *state) {
-  if (state && state->mm)
-    return state->mm->get_workspace();
-  return state ? state->workspace : nullptr;
+  return state ? state->mm->get_workspace() : nullptr;
 }
 
 size_t hipdnn_ep_state_get_workspace_size(RuntimeState *state) {
-  if (state && state->mm)
-    return state->mm->get_workspace_size();
-  return state ? state->workspace_size : 0;
+  return state ? state->mm->get_workspace_size() : 0;
 }
 
 int hipdnn_ep_state_ensure_workspace(RuntimeState *state, size_t needed_size) {
@@ -1135,74 +912,13 @@ int hipdnn_ep_state_ensure_workspace(RuntimeState *state, size_t needed_size) {
     return -1;
   if (needed_size == 0)
     return 0;
-  if (state->mm) {
-    return state->mm->ensure_workspace(needed_size) ? 0 : -1;
-  }
-  if (state->workspace_size >= needed_size)
-    return 0;
-
-  // Amortize growth: when enlarging an existing workspace, round the new
-  // size up to at least 1.5x the current buffer. Callers whose request
-  // size grows monotonically by a small increment per inference (e.g. the
-  // GQA decode path, which sizes S buffers to B*H*total_seq and adds B*H
-  // elements per token) would otherwise trigger a hipStreamSynchronize +
-  // hipFree + hipMalloc cycle on every decode step; with the 1.5x factor
-  // that drops to O(log N) reallocations over the whole generation.
-  // Cold-start (no existing workspace) keeps the exact requested size so
-  // warmup doesn't silently double large initial allocations.
-  size_t alloc_size = needed_size;
-  if (state->workspace_size > 0) {
-    size_t grown = state->workspace_size + state->workspace_size / 2; // 1.5x
-    if (grown > alloc_size)
-      alloc_size = grown;
-  }
-
-  // Grow: free old, allocate new.
-  // Sync the stream first to ensure no in-flight kernel is still using the
-  // old workspace buffer (prevents use-after-free on async GPU execution).
-  if (state->workspace) {
-    if (state->stream) {
-      HIP_CLEANUP(hipStreamSynchronize(state->stream));
-    }
-    HIP_CLEANUP(hipFree(state->workspace));
-    state->workspace = nullptr;
-    state->workspace_size = 0;
-  }
-
-  if (hipMalloc(&state->workspace, alloc_size) != hipSuccess) {
-    fprintf(
-        stderr,
-        "hipdnn_ep_state_ensure_workspace: hipMalloc failed for %zu bytes\n",
-        alloc_size);
-    std::abort();
-  }
-
-  state->workspace_size = alloc_size;
-  RUNTIME_DEBUG_LOG(
-      "[workspace] Allocated shared workspace: %zu bytes (requested %zu)\n",
-      alloc_size, needed_size);
-  return 0;
+  return state->mm->ensure_workspace(needed_size) ? 0 : -1;
 }
 
-//===----------------------------------------------------------------------===//
-// QMoE scratch helpers (device + pinned-host)
-//===----------------------------------------------------------------------===//
-//
-// Per-session grow-on-demand scratch shared by all qmoe instances. Single-
-// buffer reuse is safe because the HIP stream is serialised: the next qmoe
-// launches only after the previous one's kernels have consumed the buffer.
-// Both grow paths sync the stream BEFORE freeing the old buffer (hipFree on a
-// buffer with in-flight kernel reads is undefined behavior) and never shrink.
-//===----------------------------------------------------------------------===//
-
-// qmoe device scratch — now delegates to the shared MemoryManager workspace,
-// which provides the same grow-on-demand semantics with 1.5× amortization.
-// All qmoe instances share the same workspace slot because the HIP stream
-// serializes them (next qmoe only launches after previous kernels finish).
+// QMoE device scratch delegates to the shared MM workspace (all callers are
+// serialized on the same HIP stream so one buffer suffices).
 void *hipdnn_ep_state_get_qmoe_scratch(RuntimeState *state) {
-  if (state && state->mm)
-    return state->mm->get_workspace();
-  return state ? state->qmoe_scratch : nullptr;
+  return state ? state->mm->get_workspace() : nullptr;
 }
 
 int hipdnn_ep_state_ensure_qmoe_scratch(RuntimeState *state,
@@ -1211,37 +927,12 @@ int hipdnn_ep_state_ensure_qmoe_scratch(RuntimeState *state,
     return -1;
   if (needed_size == 0)
     return 0;
-  if (state->mm) {
-    return state->mm->ensure_workspace(needed_size) ? 0 : -1;
-  }
-  // Fallback: original implementation.
-  if (state->qmoe_scratch_size >= needed_size)
-    return 0;
-  size_t alloc_size = needed_size;
-  if (state->qmoe_scratch_size > 0) {
-    size_t grown = state->qmoe_scratch_size + state->qmoe_scratch_size / 2;
-    if (grown > alloc_size)
-      alloc_size = grown;
-  }
-  if (state->qmoe_scratch) {
-    if (state->stream)
-      HIP_CLEANUP(hipStreamSynchronize(state->stream));
-    HIP_CLEANUP(hipFree(state->qmoe_scratch));
-    state->qmoe_scratch = nullptr;
-    state->qmoe_scratch_size = 0;
-  }
-  if (hipMalloc(&state->qmoe_scratch, alloc_size) != hipSuccess) {
-    return -1;
-  }
-  state->qmoe_scratch_size = alloc_size;
-  return 0;
+  return state->mm->ensure_workspace(needed_size) ? 0 : -1;
 }
 
-// Pinned host mirror for qmoe D2H readback. Delegates to MM in Phase 1+.
+// QMoE pinned-host mirror for async D2H readback.
 void *hipdnn_ep_state_get_qmoe_host_scratch(RuntimeState *state) {
-  if (state && state->mm)
-    return state->mm->get_qmoe_host_scratch();
-  return state ? state->qmoe_host_scratch : nullptr;
+  return state ? state->mm->get_qmoe_host_scratch() : nullptr;
 }
 
 int hipdnn_ep_state_ensure_qmoe_host_scratch(RuntimeState *state,
@@ -1250,48 +941,12 @@ int hipdnn_ep_state_ensure_qmoe_host_scratch(RuntimeState *state,
     return -1;
   if (needed_size == 0)
     return 0;
-  if (state->mm) {
-    return state->mm->ensure_qmoe_host_scratch(needed_size) ? 0 : -1;
-  }
-  if (state->qmoe_host_scratch_size >= needed_size)
-    return 0;
-
-  size_t alloc_size = needed_size;
-  if (state->qmoe_host_scratch_size > 0) {
-    size_t grown =
-        state->qmoe_host_scratch_size + state->qmoe_host_scratch_size / 2;
-    if (grown > alloc_size)
-      alloc_size = grown;
-  }
-
-  if (state->qmoe_host_scratch) {
-    // Sync first: any in-flight hipMemcpyAsync(D2H) targeting this pinned
-    // buffer must complete before we free it. Cheap relative to alloc.
-    if (state->stream) {
-      HIP_CLEANUP(hipStreamSynchronize(state->stream));
-    }
-    HIP_CLEANUP(hipHostFree(state->qmoe_host_scratch));
-    state->qmoe_host_scratch = nullptr;
-    state->qmoe_host_scratch_size = 0;
-  }
-
-  if (hipHostMalloc(&state->qmoe_host_scratch, alloc_size,
-                    hipHostMallocDefault) != hipSuccess) {
-    fprintf(stderr,
-            "hipdnn_ep_state_ensure_qmoe_host_scratch: hipHostMalloc failed "
-            "for %zu bytes\n",
-            alloc_size);
-    return -1;
-  }
-  state->qmoe_host_scratch_size = alloc_size;
-  return 0;
+  return state->mm->ensure_qmoe_host_scratch(needed_size) ? 0 : -1;
 }
 
-// MIOpen conv workspace — now delegates to the shared MM workspace.
+// MIOpen conv workspace delegates to the shared MM workspace.
 void *hipdnn_ep_state_get_conv_scratch(RuntimeState *state) {
-  if (state && state->mm)
-    return state->mm->get_workspace();
-  return state ? state->conv_scratch : nullptr;
+  return state ? state->mm->get_workspace() : nullptr;
 }
 
 int hipdnn_ep_state_ensure_conv_scratch(RuntimeState *state,
@@ -1300,41 +955,7 @@ int hipdnn_ep_state_ensure_conv_scratch(RuntimeState *state,
     return -1;
   if (needed_size == 0)
     return 0;
-  if (state->mm) {
-    return state->mm->ensure_workspace(needed_size) ? 0 : -1;
-  }
-  if (state->conv_scratch_size >= needed_size)
-    return 0;
-
-  // 1.5x growth amortisation mirrors workspace / qmoe_scratch.
-  size_t alloc_size = needed_size;
-  if (state->conv_scratch_size > 0) {
-    size_t grown = state->conv_scratch_size + state->conv_scratch_size / 2;
-    if (grown > alloc_size)
-      alloc_size = grown;
-  }
-
-  if (state->conv_scratch) {
-    // Drain any in-flight conv that may still be reading the old workspace
-    // before we free it. Growth is rare (only on first call per new shape)
-    // so the sync cost is amortised away.
-    if (state->stream) {
-      hipStreamSynchronize(state->stream);
-    }
-    HIP_CLEANUP(hipFree(state->conv_scratch));
-    state->conv_scratch = nullptr;
-    state->conv_scratch_size = 0;
-  }
-
-  if (hipMalloc(&state->conv_scratch, alloc_size) != hipSuccess) {
-    fprintf(stderr,
-            "hipdnn_ep_state_ensure_conv_scratch: hipMalloc failed for %zu "
-            "bytes\n",
-            alloc_size);
-    return -1;
-  }
-  state->conv_scratch_size = alloc_size;
-  return 0;
+  return state->mm->ensure_workspace(needed_size) ? 0 : -1;
 }
 
 void *hipdnn_ep_state_get_error_flag_device_ptr(RuntimeState *state) {

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -903,6 +903,15 @@ void *hipdnn_ep_scratch_alloc(RuntimeState *state, size_t size) {
   return state ? state->mm->scratch_alloc(size) : nullptr;
 }
 
+size_t hipdnn_ep_scratch_save(RuntimeState *state) {
+  return state ? state->mm->scratch_save() : 0;
+}
+
+void hipdnn_ep_scratch_restore(RuntimeState *state, size_t saved) {
+  if (state)
+    state->mm->scratch_restore(saved);
+}
+
 void *hipdnn_ep_state_get_workspace(RuntimeState *state) {
   return state ? state->mm->get_workspace() : nullptr;
 }

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -903,6 +903,12 @@ void *hipdnn_ep_scratch_alloc(RuntimeState *state, size_t size) {
   return state ? state->mm->scratch_alloc(size) : nullptr;
 }
 
+int hipdnn_ep_scratch_reserve(RuntimeState *state, size_t total) {
+  if (!state)
+    return -1;
+  return state->mm->scratch_reserve(total) ? 0 : -1;
+}
+
 size_t hipdnn_ep_scratch_save(RuntimeState *state) {
   return state ? state->mm->scratch_save() : 0;
 }

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -899,6 +899,10 @@ void *hipdnn_ep_get_host_scratch_base(RuntimeState *state, size_t needed_size) {
   return state->mm->get_host_scratch(needed_size);
 }
 
+void *hipdnn_ep_scratch_alloc(RuntimeState *state, size_t size) {
+  return state ? state->mm->scratch_alloc(size) : nullptr;
+}
+
 void *hipdnn_ep_state_get_workspace(RuntimeState *state) {
   return state ? state->mm->get_workspace() : nullptr;
 }

--- a/lib/Runtime/mm/memory_manager.cpp
+++ b/lib/Runtime/mm/memory_manager.cpp
@@ -308,10 +308,36 @@ void *MemoryManager::get_host_scratch(size_t needed_size) {
 }
 
 //===----------------------------------------------------------------------===//
-// Shared GPU workspace
+// Scratch arena (bump-pointer allocator over the shared workspace)
+//===----------------------------------------------------------------------===//
+
+static constexpr size_t kScratchAlignment = 64;
+
+void *MemoryManager::scratch_alloc(size_t size) {
+  if (size == 0)
+    return workspace_ ? static_cast<char *>(workspace_) + scratch_offset_
+                      : nullptr;
+
+  size_t aligned = (size + kScratchAlignment - 1) & ~(kScratchAlignment - 1);
+  size_t needed = scratch_offset_ + aligned;
+  if (needed > workspace_size_) {
+    if (!grow_gpu_buffer(&workspace_, &workspace_size_, needed, "workspace"))
+      return nullptr;
+  }
+
+  void *ptr = static_cast<char *>(workspace_) + scratch_offset_;
+  scratch_offset_ += aligned;
+  return ptr;
+}
+
+void MemoryManager::scratch_reset() { scratch_offset_ = 0; }
+
+//===----------------------------------------------------------------------===//
+// Shared GPU workspace (low-level; prefer scratch_alloc for new code)
 //===----------------------------------------------------------------------===//
 
 void *MemoryManager::ensure_workspace(size_t needed_size) {
+  scratch_offset_ = 0;
   if (needed_size == 0)
     return workspace_;
   if (!grow_gpu_buffer(&workspace_, &workspace_size_, needed_size, "workspace"))
@@ -344,15 +370,13 @@ void *MemoryManager::get_qmoe_host_scratch() const {
 //===----------------------------------------------------------------------===//
 
 void MemoryManager::begin_compute() {
-  // Invalidate the seqlens_k cross-layer cache (same semantics as the old
-  // RuntimeState fields, just moved here so begin_compute() is the one
-  // authoritative place to invalidate all per-forward-pass caches).
+  scratch_reset();
   seqlens_k_valid_ = false;
   seqlens_k_ptr_ = nullptr;
 }
 
 void MemoryManager::end_compute() {
-  // No-op today. Phase 3 will reset the bump-pointer scratch arena here.
+  // Reserved for future phases that need end-of-inference cleanup.
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Runtime/mm/memory_manager.cpp
+++ b/lib/Runtime/mm/memory_manager.cpp
@@ -7,10 +7,9 @@
 //
 // See memory_manager.h for the design.
 //
-// Phase 1: wraps all six existing ensure_* patterns behind a typed API with
-// uniform 1.5× amortized growth. No behavior change — callers that used the
-// old direct RuntimeState fields now go through MM, which delegates to the
-// same underlying HIP calls (via HalAllocator or direct hipMalloc/hipFree).
+// Wraps all six existing ensure_* patterns behind a typed API with uniform
+// 1.5× amortized growth. All callers go through MM exclusively; the legacy
+// RuntimeState fields were removed in Phase 2.
 //
 //===----------------------------------------------------------------------===//
 
@@ -353,7 +352,7 @@ void MemoryManager::begin_compute() {
 }
 
 void MemoryManager::end_compute() {
-  // Phase 1: no-op. Phase 2 will reset the bump-pointer scratch arena here.
+  // No-op today. Phase 3 will reset the bump-pointer scratch arena here.
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Runtime/mm/memory_manager.cpp
+++ b/lib/Runtime/mm/memory_manager.cpp
@@ -337,7 +337,6 @@ void MemoryManager::scratch_reset() { scratch_offset_ = 0; }
 //===----------------------------------------------------------------------===//
 
 void *MemoryManager::ensure_workspace(size_t needed_size) {
-  scratch_offset_ = 0;
   if (needed_size == 0)
     return workspace_;
   if (!grow_gpu_buffer(&workspace_, &workspace_size_, needed_size, "workspace"))

--- a/lib/Runtime/mm/memory_manager.cpp
+++ b/lib/Runtime/mm/memory_manager.cpp
@@ -321,6 +321,10 @@ void *MemoryManager::scratch_alloc(size_t size) {
   size_t aligned = (size + kScratchAlignment - 1) & ~(kScratchAlignment - 1);
   size_t needed = scratch_offset_ + aligned;
   if (needed > workspace_size_) {
+    // Growth frees the old buffer and allocates a new one. Any pointers
+    // returned by prior scratch_alloc calls in this sequence become invalid.
+    // Callers must call scratch_reserve(total) up front to avoid mid-sequence
+    // growth, or re-derive all pointers after any alloc that might grow.
     if (!grow_gpu_buffer(&workspace_, &workspace_size_, needed, "workspace"))
       return nullptr;
   }
@@ -328,6 +332,12 @@ void *MemoryManager::scratch_alloc(size_t size) {
   void *ptr = static_cast<char *>(workspace_) + scratch_offset_;
   scratch_offset_ += aligned;
   return ptr;
+}
+
+bool MemoryManager::scratch_reserve(size_t total) {
+  if (total <= workspace_size_)
+    return true;
+  return grow_gpu_buffer(&workspace_, &workspace_size_, total, "workspace");
 }
 
 void MemoryManager::scratch_reset() { scratch_offset_ = 0; }

--- a/lib/Runtime/mm/memory_manager.h
+++ b/lib/Runtime/mm/memory_manager.h
@@ -19,8 +19,13 @@
 //   All callers now go through MemoryManager exclusively; fallback code paths
 //   deleted.
 //
-// Future phases add: BlockPool (Phase 3), KvCacheManager (Phase 4), Tier-1
-// CPU offload (Phase 5). The public API surface is kept stable across phases.
+// Phase 3: bump-pointer scratch arena backed by the shared workspace buffer.
+//   scratch_alloc(N) replaces manual offset arithmetic; begin_compute() resets
+//   the bump pointer. All callers migrated from ensure_workspace + manual
+//   offsets to scratch_alloc().
+//
+// Future phases add: KvCacheManager (Phase 4), Tier-1 CPU offload (Phase 5).
+// The public API surface is kept stable across phases.
 //
 //===----------------------------------------------------------------------===//
 
@@ -76,13 +81,29 @@ public:
   void *get_host_scratch(size_t needed_size);
 
   //-------------------------------------------------------------------
-  // Shared workspace (replaces hipdnn_ep_state_ensure_workspace,
-  //   hipdnn_ep_state_ensure_qmoe_scratch, hipdnn_ep_state_ensure_conv_scratch)
+  // Scratch arena (bump-pointer allocator over the shared workspace)
   //-------------------------------------------------------------------
 
-  // Single grow-on-demand GPU workspace shared by GQA, QMoE, conv, etc.
-  // All callers are serialized on the same HIP stream so one buffer suffices.
-  // Growth is 1.5× amortized. Returns nullptr on failure.
+  // Bump-allocate `size` bytes (64-byte aligned) from the scratch arena.
+  // Backed by the shared workspace buffer; grows it on demand (1.5×
+  // amortized). Returns nullptr on allocation failure. The bump pointer
+  // is reset by begin_compute() at the start of each Compute().
+  void *scratch_alloc(size_t size);
+
+  // Reset the bump pointer to 0 (called by begin_compute()).
+  void scratch_reset();
+
+  // Current bump pointer offset (for diagnostics and tests).
+  size_t scratch_offset() const { return scratch_offset_; }
+
+  //-------------------------------------------------------------------
+  // Shared workspace (low-level; prefer scratch_alloc for new code)
+  //-------------------------------------------------------------------
+
+  // Ensure the workspace buffer is at least `needed_size` bytes. Resets
+  // the scratch bump pointer (callers that use ensure_workspace want the
+  // whole buffer). Kept for gemm/matmul autotune which needs the raw
+  // buffer + its full size. Returns nullptr on failure.
   void *ensure_workspace(size_t needed_size);
   void *get_workspace() const;
   size_t get_workspace_size() const;
@@ -98,12 +119,12 @@ public:
   //-------------------------------------------------------------------
 
   // Called at the start of every Compute():
+  //   - Resets the scratch arena bump pointer.
   //   - Invalidates the seqlens_k cache.
-  //   - (Phase 3+) resets the bump-pointer scratch arena.
   void begin_compute();
 
-  // Called at the end of every Compute() (Phase 3+: releases scratch blocks).
-  // Currently a no-op for scratch until Phase 3.
+  // Called at the end of every Compute(). Currently a no-op; reserved for
+  // future phases that need end-of-inference cleanup.
   void end_compute();
 
   //-------------------------------------------------------------------
@@ -153,10 +174,11 @@ private:
   size_t num_buffers_ = 0;
 
   //-------------------------------------------------------------------
-  // Shared GPU workspace
+  // Shared GPU workspace + scratch arena bump pointer
   //-------------------------------------------------------------------
   void *workspace_ = nullptr;
   size_t workspace_size_ = 0;
+  size_t scratch_offset_ = 0; // bump pointer into workspace_
 
   //-------------------------------------------------------------------
   // Host-scalar scratch (hipHostMalloc Mapped+NonCoherent)

--- a/lib/Runtime/mm/memory_manager.h
+++ b/lib/Runtime/mm/memory_manager.h
@@ -10,15 +10,16 @@
 // across RuntimeState (workspace, host_scratch, qmoe_scratch,
 // qmoe_host_scratch, conv_scratch, and the per-domain pool arrays).
 //
-// Phase 1 scope:
-//   - Wraps all six existing patterns behind a uniform typed API.
-//   - Uniform 1.5× amortized growth for all GPU buffers (fixes the pool's
-//     exact-growth bug).
-//   - seqlens_k cache (moved here from RuntimeState).
-//   - begin_compute() / end_compute() lifecycle hooks.
-//   - APU + discrete GPU backends fully wired from day one.
+// Phase 1: wrapped all six existing patterns behind a uniform typed API with
+//   1.5× amortized growth, seqlens_k cache, begin_compute()/end_compute()
+//   lifecycle hooks, and APU + discrete GPU backends.
 //
-// Future phases add: BlockPool (Phase 2), KvCacheManager (Phase 4), Tier-1
+// Phase 2: removed legacy RuntimeState alias fields (pool_base, pool_size,
+//   workspace, host_scratch, qmoe_scratch, conv_scratch, seqlens_k_cached_*).
+//   All callers now go through MemoryManager exclusively; fallback code paths
+//   deleted.
+//
+// Future phases add: BlockPool (Phase 3), KvCacheManager (Phase 4), Tier-1
 // CPU offload (Phase 5). The public API surface is kept stable across phases.
 //
 //===----------------------------------------------------------------------===//
@@ -98,11 +99,11 @@ public:
 
   // Called at the start of every Compute():
   //   - Invalidates the seqlens_k cache.
-  //   - (Phase 2+) resets the bump-pointer scratch arena.
+  //   - (Phase 3+) resets the bump-pointer scratch arena.
   void begin_compute();
 
-  // Called at the end of every Compute() (Phase 2+: releases scratch blocks).
-  // Safe to call in Phase 1 — it is a no-op for scratch until Phase 2.
+  // Called at the end of every Compute() (Phase 3+: releases scratch blocks).
+  // Currently a no-op for scratch until Phase 3.
   void end_compute();
 
   //-------------------------------------------------------------------

--- a/lib/Runtime/mm/memory_manager.h
+++ b/lib/Runtime/mm/memory_manager.h
@@ -90,6 +90,11 @@ public:
   // is reset by begin_compute() at the start of each Compute().
   void *scratch_alloc(size_t size);
 
+  // Pre-grow the workspace to at least `total` bytes without bumping the
+  // offset. Call before a sequence of scratch_alloc() to avoid mid-sequence
+  // growth that would invalidate earlier pointers. Returns false on failure.
+  bool scratch_reserve(size_t total);
+
   // Reset the bump pointer to 0 (called by begin_compute()).
   void scratch_reset();
 

--- a/lib/Runtime/mm/memory_manager.h
+++ b/lib/Runtime/mm/memory_manager.h
@@ -96,6 +96,13 @@ public:
   // Current bump pointer offset (for diagnostics and tests).
   size_t scratch_offset() const { return scratch_offset_; }
 
+  // Save/restore the bump pointer for scoped reuse. Ops that run multiple
+  // times per Compute() (e.g. GQA × 32 layers, QMoE × 24 layers) save the
+  // offset on entry and restore on exit so consecutive calls reuse the same
+  // arena region instead of each bumping past the previous.
+  size_t scratch_save() const { return scratch_offset_; }
+  void scratch_restore(size_t saved) { scratch_offset_ = saved; }
+
   //-------------------------------------------------------------------
   // Shared workspace (low-level; prefer scratch_alloc for new code)
   //-------------------------------------------------------------------

--- a/lib/Runtime/mm/memory_manager.h
+++ b/lib/Runtime/mm/memory_manager.h
@@ -107,10 +107,10 @@ public:
   // Shared workspace (low-level; prefer scratch_alloc for new code)
   //-------------------------------------------------------------------
 
-  // Ensure the workspace buffer is at least `needed_size` bytes. Resets
-  // the scratch bump pointer (callers that use ensure_workspace want the
-  // whole buffer). Kept for gemm/matmul autotune which needs the raw
-  // buffer + its full size. Returns nullptr on failure.
+  // Ensure the workspace buffer is at least `needed_size` bytes. Does NOT
+  // reset the scratch bump pointer (other ops may have active scratch
+  // allocations in the same Compute). Kept for gemm/matmul autotune which
+  // needs the raw buffer + its full size. Returns nullptr on failure.
   void *ensure_workspace(size_t needed_size);
   void *get_workspace() const;
   size_t get_workspace_size() const;

--- a/lib/Runtime/real/causal_conv_with_state.cpp
+++ b/lib/Runtime/real/causal_conv_with_state.cpp
@@ -410,21 +410,18 @@ int wrap_causal_conv_with_state(RuntimeState *state, int op_state_slot,
     }
   }
 
-  const size_t total_ws = virtual_size + sigmoid_size + conv_workspace_size;
-  if (total_ws > 0 && hipdnn_ep_state_ensure_workspace(state, total_ws) != 0) {
+  void *virtual_buf = hipdnn_ep_scratch_alloc(state, virtual_size);
+  void *sigmoid_buf =
+      (activation == 1) ? hipdnn_ep_scratch_alloc(state, sigmoid_size) : nullptr;
+  void *conv_workspace =
+      (conv_workspace_size > 0) ? hipdnn_ep_scratch_alloc(state, conv_workspace_size)
+                                : nullptr;
+  if (!virtual_buf || (activation == 1 && !sigmoid_buf) ||
+      (conv_workspace_size > 0 && !conv_workspace)) {
     fprintf(stderr,
-            "wrap_causal_conv_with_state: ensure_workspace(%zu) failed\n",
-            total_ws);
+            "wrap_causal_conv_with_state: scratch_alloc failed\n");
     return -1;
   }
-  char *ws_base = static_cast<char *>(hipdnn_ep_state_get_workspace(state));
-  void *virtual_buf = ws_base;
-  void *sigmoid_buf =
-      (activation == 1) ? static_cast<void *>(ws_base + virtual_size) : nullptr;
-  void *conv_workspace =
-      (conv_workspace_size > 0)
-          ? static_cast<void *>(ws_base + virtual_size + sigmoid_size)
-          : nullptr;
 
   // ---- Build the virtual buffer using *pitched* 2D copies, replacing the
   // O(B*C) host launch loops. Each plane (b,c) occupies one row of the

--- a/lib/Runtime/real/causal_conv_with_state.cpp
+++ b/lib/Runtime/real/causal_conv_with_state.cpp
@@ -410,6 +410,7 @@ int wrap_causal_conv_with_state(RuntimeState *state, int op_state_slot,
     }
   }
 
+  hipdnn_ep_scratch_restore(state, 0);
   void *virtual_buf = hipdnn_ep_scratch_alloc(state, virtual_size);
   void *sigmoid_buf = (activation == 1)
                           ? hipdnn_ep_scratch_alloc(state, sigmoid_size)

--- a/lib/Runtime/real/causal_conv_with_state.cpp
+++ b/lib/Runtime/real/causal_conv_with_state.cpp
@@ -411,15 +411,16 @@ int wrap_causal_conv_with_state(RuntimeState *state, int op_state_slot,
   }
 
   void *virtual_buf = hipdnn_ep_scratch_alloc(state, virtual_size);
-  void *sigmoid_buf =
-      (activation == 1) ? hipdnn_ep_scratch_alloc(state, sigmoid_size) : nullptr;
+  void *sigmoid_buf = (activation == 1)
+                          ? hipdnn_ep_scratch_alloc(state, sigmoid_size)
+                          : nullptr;
   void *conv_workspace =
-      (conv_workspace_size > 0) ? hipdnn_ep_scratch_alloc(state, conv_workspace_size)
-                                : nullptr;
+      (conv_workspace_size > 0)
+          ? hipdnn_ep_scratch_alloc(state, conv_workspace_size)
+          : nullptr;
   if (!virtual_buf || (activation == 1 && !sigmoid_buf) ||
       (conv_workspace_size > 0 && !conv_workspace)) {
-    fprintf(stderr,
-            "wrap_causal_conv_with_state: scratch_alloc failed\n");
+    fprintf(stderr, "wrap_causal_conv_with_state: scratch_alloc failed\n");
     return -1;
   }
 

--- a/lib/Runtime/real/causal_conv_with_state.cpp
+++ b/lib/Runtime/real/causal_conv_with_state.cpp
@@ -411,6 +411,8 @@ int wrap_causal_conv_with_state(RuntimeState *state, int op_state_slot,
   }
 
   hipdnn_ep_scratch_restore(state, 0);
+  hipdnn_ep_scratch_reserve(state, virtual_size + sigmoid_size +
+                                       conv_workspace_size + 3 * 64);
   void *virtual_buf = hipdnn_ep_scratch_alloc(state, virtual_size);
   void *sigmoid_buf = (activation == 1)
                           ? hipdnn_ep_scratch_alloc(state, sigmoid_size)

--- a/lib/Runtime/real/div.cpp
+++ b/lib/Runtime/real/div.cpp
@@ -75,6 +75,7 @@ int wrap_div(RuntimeState *state, void *lhs, void *rhs, void *output,
   void *lhs_use = lhs;
   void *rhs_use = rhs;
 
+  hipdnn_ep_scratch_restore(state, 0);
   if (!lhs_eq_out || !rhs_eq_out) {
     const int64_t elem_bytes = hipdnn_ep_datatype_size(data_type);
     const size_t per_side = static_cast<size_t>(out_vol * elem_bytes);

--- a/lib/Runtime/real/div.cpp
+++ b/lib/Runtime/real/div.cpp
@@ -78,37 +78,39 @@ int wrap_div(RuntimeState *state, void *lhs, void *rhs, void *output,
   if (!lhs_eq_out || !rhs_eq_out) {
     const int64_t elem_bytes = hipdnn_ep_datatype_size(data_type);
     const size_t per_side = static_cast<size_t>(out_vol * elem_bytes);
-    const size_t needed = per_side * static_cast<size_t>((!lhs_eq_out ? 1 : 0) +
-                                                         (!rhs_eq_out ? 1 : 0));
-    if (hipdnn_ep_state_ensure_workspace(state, needed) != 0) {
-      fprintf(stderr, "[REAL] wrap_div: workspace ensure failed (%zu bytes)\n",
-              needed);
-      return -1;
-    }
-    void *ws = hipdnn_ep_state_get_workspace(state);
-    uint8_t *ws_byte = static_cast<uint8_t *>(ws);
     const int64_t out_shape[4] = {out_n, out_c, out_h, out_w};
 
     if (!lhs_eq_out) {
+      void *lhs_scratch = hipdnn_ep_scratch_alloc(state, per_side);
+      if (!lhs_scratch) {
+        fprintf(stderr, "[REAL] wrap_div: scratch_alloc failed (%zu bytes)\n",
+                per_side);
+        return -1;
+      }
       const int64_t in_lhs[4] = {lhs_n, lhs_c, lhs_h, lhs_w};
-      int rc =
-          hip_expand(stream, lhs, ws_byte, in_lhs, 4, out_shape, 4, hip_dtype);
+      int rc = hip_expand(stream, lhs, static_cast<uint8_t *>(lhs_scratch),
+                          in_lhs, 4, out_shape, 4, hip_dtype);
       if (rc != 0) {
         fprintf(stderr, "[REAL] wrap_div: hip_expand(lhs) failed (%d)\n", rc);
         return -1;
       }
-      lhs_use = ws_byte;
-      ws_byte += per_side;
+      lhs_use = lhs_scratch;
     }
     if (!rhs_eq_out) {
+      void *rhs_scratch = hipdnn_ep_scratch_alloc(state, per_side);
+      if (!rhs_scratch) {
+        fprintf(stderr, "[REAL] wrap_div: scratch_alloc failed (%zu bytes)\n",
+                per_side);
+        return -1;
+      }
       const int64_t in_rhs[4] = {rhs_n, rhs_c, rhs_h, rhs_w};
-      int rc =
-          hip_expand(stream, rhs, ws_byte, in_rhs, 4, out_shape, 4, hip_dtype);
+      int rc = hip_expand(stream, rhs, static_cast<uint8_t *>(rhs_scratch),
+                          in_rhs, 4, out_shape, 4, hip_dtype);
       if (rc != 0) {
         fprintf(stderr, "[REAL] wrap_div: hip_expand(rhs) failed (%d)\n", rc);
         return -1;
       }
-      rhs_use = ws_byte;
+      rhs_use = rhs_scratch;
     }
 
     RUNTIME_DEBUG_LOG(

--- a/lib/Runtime/real/elementwise.cpp
+++ b/lib/Runtime/real/elementwise.cpp
@@ -434,29 +434,22 @@ int wrap_miopenOpTensor(RuntimeState *state, int op_state_slot, void *lhs,
     // must mirror the float-side broadcast handling below.
     void *lhs_use = lhs;
     void *rhs_use = rhs;
-    void *ws = nullptr;
     if (!lhs_eq_out_ints || !rhs_eq_out_ints) {
-      // We need workspace for any side(s) that need expansion. At most two
-      // (lhs to ws_a, rhs to ws_b) -- pack both back-to-back in the workspace.
       const size_t per_side = static_cast<size_t>(out_vol * elem_bytes);
-      const size_t needed =
-          per_side * static_cast<size_t>((!lhs_eq_out_ints ? 1 : 0) +
-                                         (!rhs_eq_out_ints ? 1 : 0));
-      if (hipdnn_ep_state_ensure_workspace(state, needed) != 0) {
-        fprintf(stderr,
-                "wrap_miopenOpTensor: integer fallback workspace ensure failed "
-                "(%zu bytes)\n",
-                needed);
-        return -1;
-      }
-      ws = hipdnn_ep_state_get_workspace(state);
-      uint8_t *ws_byte = static_cast<uint8_t *>(ws);
       const int64_t in_lhs[4] = {lhs_n, lhs_c, lhs_h, lhs_w};
       const int64_t in_rhs[4] = {rhs_n, rhs_c, rhs_h, rhs_w};
       const int64_t out_shape[4] = {out_n, out_c, out_h, out_w};
       if (!lhs_eq_out_ints) {
-        int rc = hip_expand(stream, lhs, ws_byte, in_lhs, 4, out_shape, 4,
-                            hip_dtype);
+        void *lhs_scratch = hipdnn_ep_scratch_alloc(state, per_side);
+        if (!lhs_scratch) {
+          fprintf(stderr,
+                  "wrap_miopenOpTensor: integer fallback scratch_alloc "
+                  "failed (%zu bytes)\n",
+                  per_side);
+          return -1;
+        }
+        int rc = hip_expand(stream, lhs, static_cast<uint8_t *>(lhs_scratch),
+                            in_lhs, 4, out_shape, 4, hip_dtype);
         if (rc != 0) {
           fprintf(stderr,
                   "wrap_miopenOpTensor: integer fallback hip_expand(lhs) "
@@ -464,12 +457,19 @@ int wrap_miopenOpTensor(RuntimeState *state, int op_state_slot, void *lhs,
                   rc);
           return -1;
         }
-        lhs_use = ws_byte;
-        ws_byte += per_side;
+        lhs_use = lhs_scratch;
       }
       if (!rhs_eq_out_ints) {
-        int rc = hip_expand(stream, rhs, ws_byte, in_rhs, 4, out_shape, 4,
-                            hip_dtype);
+        void *rhs_scratch = hipdnn_ep_scratch_alloc(state, per_side);
+        if (!rhs_scratch) {
+          fprintf(stderr,
+                  "wrap_miopenOpTensor: integer fallback scratch_alloc "
+                  "failed (%zu bytes)\n",
+                  per_side);
+          return -1;
+        }
+        int rc = hip_expand(stream, rhs, static_cast<uint8_t *>(rhs_scratch),
+                            in_rhs, 4, out_shape, 4, hip_dtype);
         if (rc != 0) {
           fprintf(stderr,
                   "wrap_miopenOpTensor: integer fallback hip_expand(rhs) "
@@ -477,7 +477,7 @@ int wrap_miopenOpTensor(RuntimeState *state, int op_state_slot, void *lhs,
                   rc);
           return -1;
         }
-        rhs_use = ws_byte;
+        rhs_use = rhs_scratch;
       }
     }
     int rc = -1;
@@ -574,14 +574,14 @@ int wrap_miopenOpTensor(RuntimeState *state, int op_state_slot, void *lhs,
     const int64_t elem_bytes = hipdnn_ep_datatype_size(data_type);
     const int64_t out_vol = out_n * out_c * out_h * out_w;
     const size_t needed = static_cast<size_t>(out_vol * elem_bytes);
-    if (hipdnn_ep_state_ensure_workspace(state, needed) != 0) {
+    void *ws = hipdnn_ep_scratch_alloc(state, needed);
+    if (!ws) {
       fprintf(stderr,
-              "wrap_miopenOpTensor: failed to ensure workspace %zu bytes for "
+              "wrap_miopenOpTensor: scratch_alloc failed %zu bytes for "
               "broadcast expand\n",
               needed);
       return -1;
     }
-    void *ws = hipdnn_ep_state_get_workspace(state);
     void *stream = hipdnn_ep_state_get_stream(state);
 
     const int64_t in_shape[4] = {
@@ -734,40 +734,43 @@ int wrap_elementwise_sub(RuntimeState *state, void *lhs, void *rhs,
   if (!lhs_eq_out || !rhs_eq_out) {
     const int64_t elem_bytes = hipdnn_ep_datatype_size(data_type);
     const size_t per_side = static_cast<size_t>(out_vol * elem_bytes);
-    const size_t needed = per_side * static_cast<size_t>((!lhs_eq_out ? 1 : 0) +
-                                                         (!rhs_eq_out ? 1 : 0));
-    if (hipdnn_ep_state_ensure_workspace(state, needed) != 0) {
-      fprintf(stderr,
-              "wrap_elementwise_sub: workspace ensure failed (%zu bytes)\n",
-              needed);
-      return -1;
-    }
-    void *ws = hipdnn_ep_state_get_workspace(state);
-    uint8_t *ws_byte = static_cast<uint8_t *>(ws);
     const int64_t out_shape[4] = {out_n, out_c, out_h, out_w};
 
     if (!lhs_eq_out) {
+      void *lhs_scratch = hipdnn_ep_scratch_alloc(state, per_side);
+      if (!lhs_scratch) {
+        fprintf(stderr,
+                "wrap_elementwise_sub: scratch_alloc failed (%zu bytes)\n",
+                per_side);
+        return -1;
+      }
       const int64_t in_lhs[4] = {lhs_n, lhs_c, lhs_h, lhs_w};
-      int rc =
-          hip_expand(stream, lhs, ws_byte, in_lhs, 4, out_shape, 4, hip_dtype);
+      int rc = hip_expand(stream, lhs, static_cast<uint8_t *>(lhs_scratch),
+                          in_lhs, 4, out_shape, 4, hip_dtype);
       if (rc != 0) {
         fprintf(stderr, "wrap_elementwise_sub: hip_expand(lhs) failed (%d)\n",
                 rc);
         return -1;
       }
-      lhs_use = ws_byte;
-      ws_byte += per_side;
+      lhs_use = lhs_scratch;
     }
     if (!rhs_eq_out) {
+      void *rhs_scratch = hipdnn_ep_scratch_alloc(state, per_side);
+      if (!rhs_scratch) {
+        fprintf(stderr,
+                "wrap_elementwise_sub: scratch_alloc failed (%zu bytes)\n",
+                per_side);
+        return -1;
+      }
       const int64_t in_rhs[4] = {rhs_n, rhs_c, rhs_h, rhs_w};
-      int rc =
-          hip_expand(stream, rhs, ws_byte, in_rhs, 4, out_shape, 4, hip_dtype);
+      int rc = hip_expand(stream, rhs, static_cast<uint8_t *>(rhs_scratch),
+                          in_rhs, 4, out_shape, 4, hip_dtype);
       if (rc != 0) {
         fprintf(stderr, "wrap_elementwise_sub: hip_expand(rhs) failed (%d)\n",
                 rc);
         return -1;
       }
-      rhs_use = ws_byte;
+      rhs_use = rhs_scratch;
     }
 
     RUNTIME_DEBUG_LOG(

--- a/lib/Runtime/real/elementwise.cpp
+++ b/lib/Runtime/real/elementwise.cpp
@@ -273,6 +273,7 @@ int wrap_miopenOpTensor(RuntimeState *state, int op_state_slot, void *lhs,
     return -1;
   }
 
+  hipdnn_ep_scratch_restore(state, 0);
   const char *type_name = hipdnn_ep_datatype_name(data_type);
   const char *op_name = hipdnn_ep_tensor_op_name(tensor_op);
 
@@ -722,6 +723,7 @@ int wrap_elementwise_sub(RuntimeState *state, void *lhs, void *rhs,
   }
 
   void *stream = hipdnn_ep_state_get_stream(state);
+  hipdnn_ep_scratch_restore(state, 0);
 
   const bool lhs_eq_out =
       (lhs_n == out_n && lhs_c == out_c && lhs_h == out_h && lhs_w == out_w);

--- a/lib/Runtime/real/gemm.cpp
+++ b/lib/Runtime/real/gemm.cpp
@@ -693,18 +693,16 @@ int wrap_gemm(RuntimeState *state, int op_state_slot, const void *A,
   }
 
   {
-    if (cached.workspace_size > 0) {
-      if (hipdnn_ep_state_ensure_workspace(state, cached.workspace_size) != 0) {
+    void *ws_ptr = nullptr;
+    size_t ws_size = 0;
+    if (!cached.use_default_algo && cached.workspace_size > 0) {
+      ws_ptr = hipdnn_ep_scratch_alloc(state, cached.workspace_size);
+      if (!ws_ptr) {
         result = -1;
         goto cleanup;
       }
+      ws_size = cached.workspace_size;
     }
-
-    void *ws_ptr = cached.use_default_algo
-                       ? nullptr
-                       : hipdnn_ep_state_get_workspace(state);
-    size_t ws_size =
-        cached.use_default_algo ? 0 : hipdnn_ep_state_get_workspace_size(state);
     hipblasLtMatmulAlgo_t *algo_ptr =
         cached.use_default_algo
             ? nullptr

--- a/lib/Runtime/real/gemm.cpp
+++ b/lib/Runtime/real/gemm.cpp
@@ -693,6 +693,7 @@ int wrap_gemm(RuntimeState *state, int op_state_slot, const void *A,
   }
 
   {
+    hipdnn_ep_scratch_restore(state, 0);
     void *ws_ptr = nullptr;
     size_t ws_size = 0;
     if (!cached.use_default_algo && cached.workspace_size > 0) {

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -775,8 +775,7 @@ static int gqa_forward_hipblaslt(
                                (d + 2) * sizeof(float)
                          : 0;
 
-    // Scratch sub-allocations (bump-pointer; each returns a 64-byte-aligned
-    // region and the arena grows on demand).
+    hipdnn_ep_scratch_restore(state, 0);
     void *d_Qsplit = nullptr, *d_Ksplit = nullptr, *d_Vsplit = nullptr;
     void *d_Qroped = nullptr, *d_Kroped = nullptr;
     void *flash_partials = nullptr;
@@ -1121,6 +1120,7 @@ static int gqa_forward_hipblaslt(
   size_t gemm_ws_needed =
       std::max(scoreState->workspace_size, valueState->workspace_size);
 
+  hipdnn_ep_scratch_restore(state, 0);
   void *d_Qtrans =
       need_transpose ? hipdnn_ep_scratch_alloc(state, Qtrans_bytes) : nullptr;
   void *d_Kexp =

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -193,9 +193,9 @@ static int32_t read_seqlens_k_for_dispatch(hipStream_t stream,
     return kSeqlensKNotRead;
   }
 
-  if (gqa_cache_seqlens_enabled() && state && state->seqlens_k_cached_valid &&
-      state->seqlens_k_cached_ptr == seqlens_k_ptr) {
-    return state->seqlens_k_cached_val;
+  if (gqa_cache_seqlens_enabled() && state && state->mm &&
+      state->mm->seqlens_k_cache_valid(seqlens_k_ptr)) {
+    return state->mm->seqlens_k_cached_val();
   }
 
   int32_t seqlens_k_val = 0;
@@ -207,10 +207,8 @@ static int32_t read_seqlens_k_for_dispatch(hipStream_t stream,
     return kSeqlensKNotRead;
   }
 
-  if (gqa_cache_seqlens_enabled() && state) {
-    state->seqlens_k_cached_val = seqlens_k_val;
-    state->seqlens_k_cached_ptr = seqlens_k_ptr;
-    state->seqlens_k_cached_valid = true;
+  if (gqa_cache_seqlens_enabled() && state && state->mm) {
+    state->mm->seqlens_k_cache_set(seqlens_k_ptr, seqlens_k_val);
   }
 
   return seqlens_k_val;

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -1121,19 +1121,16 @@ static int gqa_forward_hipblaslt(
   size_t gemm_ws_needed =
       std::max(scoreState->workspace_size, valueState->workspace_size);
 
-  void *d_Qtrans = need_transpose
-                       ? hipdnn_ep_scratch_alloc(state, Qtrans_bytes)
-                       : nullptr;
-  void *d_Kexp = use_no_expand
-                     ? nullptr
-                     : hipdnn_ep_scratch_alloc(state, Kexp_bytes);
-  void *d_Vexp = use_no_expand
-                     ? nullptr
-                     : hipdnn_ep_scratch_alloc(state, Vexp_bytes);
+  void *d_Qtrans =
+      need_transpose ? hipdnn_ep_scratch_alloc(state, Qtrans_bytes) : nullptr;
+  void *d_Kexp =
+      use_no_expand ? nullptr : hipdnn_ep_scratch_alloc(state, Kexp_bytes);
+  void *d_Vexp =
+      use_no_expand ? nullptr : hipdnn_ep_scratch_alloc(state, Vexp_bytes);
   void *d_S_f32 = hipdnn_ep_scratch_alloc(state, S_f32_bytes);
   void *d_S_fp16 = hipdnn_ep_scratch_alloc(state, S_fp16_bytes);
-  void *d_O = need_transpose ? hipdnn_ep_scratch_alloc(state, O_bytes)
-                             : nullptr;
+  void *d_O =
+      need_transpose ? hipdnn_ep_scratch_alloc(state, O_bytes) : nullptr;
 
   void *d_Qroped_d = nullptr, *d_Kroped_d = nullptr;
   if (need_rope) {
@@ -1157,8 +1154,7 @@ static int gqa_forward_hipblaslt(
                           : nullptr;
   size_t gemm_ws_bytes = gemm_ws_needed;
 
-  if (!d_S_f32 || !d_S_fp16 ||
-      (need_transpose && (!d_Qtrans || !d_O)) ||
+  if (!d_S_f32 || !d_S_fp16 || (need_transpose && (!d_Qtrans || !d_O)) ||
       (!use_no_expand && (!d_Kexp || !d_Vexp)) ||
       (need_rope && (!d_Qroped_d || !d_Kroped_d)) ||
       (packed_qkv && (!d_Qsplit_d || !d_Ksplit_d || !d_Vsplit_d)) ||
@@ -1185,8 +1181,7 @@ static int gqa_forward_hipblaslt(
       HIP_CHECK(hip_gqa_split_qkv(
           stream, query, d_Qsplit_d, d_Ksplit_d, d_Vsplit_d,
           static_cast<int>(B), static_cast<int>(sq), static_cast<int>(H),
-          static_cast<int>(G), static_cast<int>(d),
-          static_cast<int>(elem_sz)));
+          static_cast<int>(G), static_cast<int>(d), static_cast<int>(elem_sz)));
       qSrc = d_Qsplit_d;
       kSrc = d_Ksplit_d;
       vSrc = d_Vsplit_d;

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -768,48 +768,39 @@ static int gqa_forward_hipblaslt(
                                   flash_decode_geometry_ok(H, G, d) &&
                                   skv >= gqa_flash_decode_min_skv();
 
-    // Sum split + rope-temp + flash-partials in a single ensure_workspace
-    // call. ensure_workspace does NOT preserve data on grow (free + malloc),
-    // so any data written earlier into the workspace would be lost if a
-    // later request triggered a regrowth. One combined request avoids that
-    // hazard, and the offsets below match the call order so each step's
-    // input region stays live while it is consumed.
     const size_t Q_full_bytes = static_cast<size_t>(B) * sq * H * d * elem_sz;
     const size_t K_full_bytes = static_cast<size_t>(B) * sq * G * d * elem_sz;
-    const size_t split_bytes =
-        fused_packed_qkv ? (Q_full_bytes + K_full_bytes + K_full_bytes) : 0;
-    const size_t rope_temp_bytes =
-        need_rope ? (Q_full_bytes + K_full_bytes) : 0;
     const size_t flash_partials_bytes =
         use_flash_decode ? static_cast<size_t>(B) * H * kFlashDecodeKSplits *
                                (d + 2) * sizeof(float)
                          : 0;
-    const size_t total_ws_bytes =
-        split_bytes + rope_temp_bytes + flash_partials_bytes;
 
-    if (total_ws_bytes > 0) {
-      if (hipdnn_ep_state_ensure_workspace(state, total_ws_bytes) != 0)
+    // Scratch sub-allocations (bump-pointer; each returns a 64-byte-aligned
+    // region and the arena grows on demand).
+    void *d_Qsplit = nullptr, *d_Ksplit = nullptr, *d_Vsplit = nullptr;
+    void *d_Qroped = nullptr, *d_Kroped = nullptr;
+    void *flash_partials = nullptr;
+
+    if (fused_packed_qkv) {
+      d_Qsplit = hipdnn_ep_scratch_alloc(state, Q_full_bytes);
+      d_Ksplit = hipdnn_ep_scratch_alloc(state, K_full_bytes);
+      d_Vsplit = hipdnn_ep_scratch_alloc(state, K_full_bytes);
+      if (!d_Qsplit || !d_Ksplit || !d_Vsplit)
+        return -1;
+    }
+    if (need_rope) {
+      d_Qroped = hipdnn_ep_scratch_alloc(state, Q_full_bytes);
+      d_Kroped = hipdnn_ep_scratch_alloc(state, K_full_bytes);
+      if (!d_Qroped || !d_Kroped)
+        return -1;
+    }
+    if (flash_partials_bytes > 0) {
+      flash_partials = hipdnn_ep_scratch_alloc(state, flash_partials_bytes);
+      if (!flash_partials)
         return -1;
     }
 
-    // Layout: [Qsplit?, Ksplit?, Vsplit? | Qroped?, Kroped? | flash_partials?]
-    const size_t off_split = 0;
-    const size_t off_rope = off_split + split_bytes;
-    const size_t off_partials = off_rope + rope_temp_bytes;
-
-    // ---- Step 0: Split packed QKV (if needed) ----
-    // For the fused / flash decode branch the split outputs become the new
-    // qSrc / kSrc / vSrc and persist in workspace until rope (Q,K) and
-    // update_kv_cache (V) consume them. After update_kv_cache returns V is
-    // committed to present_value, so the split V slot can be safely reused
-    // by downstream callers — but here we never overwrite it again because
-    // flash_partials is placed strictly after rope_temp, which is placed
-    // strictly after split.
     if (fused_packed_qkv) {
-      char *ws = static_cast<char *>(hipdnn_ep_state_get_workspace(state));
-      void *d_Qsplit = ws + off_split;
-      void *d_Ksplit = ws + off_split + Q_full_bytes;
-      void *d_Vsplit = ws + off_split + Q_full_bytes + K_full_bytes;
       if (hip_gqa_split_qkv(
               stream, query, d_Qsplit, d_Ksplit, d_Vsplit, static_cast<int>(B),
               static_cast<int>(sq), static_cast<int>(H), static_cast<int>(G),
@@ -821,10 +812,6 @@ static int gqa_forward_hipblaslt(
     }
 
     if (need_rope) {
-      char *ws = static_cast<char *>(hipdnn_ep_state_get_workspace(state));
-      void *d_Qroped = ws + off_rope;
-      void *d_Kroped = ws + off_rope + Q_full_bytes;
-
       int half_rot = static_cast<int>(d / 2);
       if (hip_gqa_rope(stream, qSrc, d_Qroped, cos_cache, sin_cache,
                        static_cast<int>(B), static_cast<int>(sq),
@@ -853,10 +840,8 @@ static int gqa_forward_hipblaslt(
       return -1;
 
     if (use_flash_decode) {
-      char *ws = static_cast<char *>(hipdnn_ep_state_get_workspace(state));
-      void *partials = ws + off_partials;
       if (hip_gqa_flash_decode(
-              stream, qSrc, present_key, present_value, output, partials,
+              stream, qSrc, present_key, present_value, output, flash_partials,
               static_cast<int>(B), static_cast<int>(H), static_cast<int>(G),
               static_cast<int>(d), static_cast<int>(present_seq),
               kFlashDecodeKSplits, scale, seqlens_k_ptr,
@@ -1133,61 +1118,57 @@ static int gqa_forward_hipblaslt(
   size_t O_bytes =
       need_transpose ? static_cast<size_t>(B) * H * sq * d * elem_sz : 0;
 
-  size_t off_Qtrans = 0;
-  size_t off_Kexp = off_Qtrans + Qtrans_bytes;
-  size_t off_Vexp = off_Kexp + Kexp_bytes;
-  size_t off_S_f32 = off_Vexp + Vexp_bytes;
-  size_t off_S_fp16 = off_S_f32 + S_f32_bytes;
-  size_t off_O = off_S_fp16 + S_fp16_bytes;
-  size_t temp_end = off_O + O_bytes;
+  size_t gemm_ws_needed =
+      std::max(scoreState->workspace_size, valueState->workspace_size);
 
-  // Optional RoPE buffers: allocated only when do_rotary is enabled.
-  size_t off_Qroped = 0, off_Kroped = 0;
+  void *d_Qtrans = need_transpose
+                       ? hipdnn_ep_scratch_alloc(state, Qtrans_bytes)
+                       : nullptr;
+  void *d_Kexp = use_no_expand
+                     ? nullptr
+                     : hipdnn_ep_scratch_alloc(state, Kexp_bytes);
+  void *d_Vexp = use_no_expand
+                     ? nullptr
+                     : hipdnn_ep_scratch_alloc(state, Vexp_bytes);
+  void *d_S_f32 = hipdnn_ep_scratch_alloc(state, S_f32_bytes);
+  void *d_S_fp16 = hipdnn_ep_scratch_alloc(state, S_fp16_bytes);
+  void *d_O = need_transpose ? hipdnn_ep_scratch_alloc(state, O_bytes)
+                             : nullptr;
+
+  void *d_Qroped_d = nullptr, *d_Kroped_d = nullptr;
   if (need_rope) {
     size_t Q_bytes = static_cast<size_t>(B) * sq * H * d * elem_sz;
     size_t K_bytes = static_cast<size_t>(B) * sq * G * d * elem_sz;
-    off_Qroped = temp_end;
-    off_Kroped = off_Qroped + Q_bytes;
-    temp_end = off_Kroped + K_bytes;
+    d_Qroped_d = hipdnn_ep_scratch_alloc(state, Q_bytes);
+    d_Kroped_d = hipdnn_ep_scratch_alloc(state, K_bytes);
   }
 
-  // Optional packed-QKV split buffers: allocated only when key/value are
-  // null (GPT-OSS style packed input).  These must be placed AFTER the RoPE
-  // buffers in the layout so that split outputs remain live while RoPE reads
-  // from them and writes to the RoPE region (no overlap).
-  size_t off_Qsplit = 0, off_Ksplit = 0, off_Vsplit = 0;
+  void *d_Qsplit_d = nullptr, *d_Ksplit_d = nullptr, *d_Vsplit_d = nullptr;
   if (packed_qkv) {
     size_t Q_bytes = static_cast<size_t>(B) * sq * H * d * elem_sz;
     size_t K_bytes = static_cast<size_t>(B) * sq * G * d * elem_sz;
-    off_Qsplit = temp_end;
-    off_Ksplit = off_Qsplit + Q_bytes;
-    off_Vsplit = off_Ksplit + K_bytes;
-    temp_end = off_Vsplit + K_bytes;
+    d_Qsplit_d = hipdnn_ep_scratch_alloc(state, Q_bytes);
+    d_Ksplit_d = hipdnn_ep_scratch_alloc(state, K_bytes);
+    d_Vsplit_d = hipdnn_ep_scratch_alloc(state, K_bytes);
+  }
+
+  void *gemm_ws_ptr = gemm_ws_needed > 0
+                          ? hipdnn_ep_scratch_alloc(state, gemm_ws_needed)
+                          : nullptr;
+  size_t gemm_ws_bytes = gemm_ws_needed;
+
+  if (!d_S_f32 || !d_S_fp16 ||
+      (need_transpose && (!d_Qtrans || !d_O)) ||
+      (!use_no_expand && (!d_Kexp || !d_Vexp)) ||
+      (need_rope && (!d_Qroped_d || !d_Kroped_d)) ||
+      (packed_qkv && (!d_Qsplit_d || !d_Ksplit_d || !d_Vsplit_d)) ||
+      (gemm_ws_needed > 0 && !gemm_ws_ptr)) {
+    return -1;
   }
 
   int result = 0;
 
-  // Single workspace allocation: temp buffers + GEMM workspace
   {
-    size_t gemm_ws =
-        std::max(scoreState->workspace_size, valueState->workspace_size);
-    size_t total_needed = temp_end + gemm_ws;
-    HIP_CHECK(hipdnn_ep_state_ensure_workspace(state, total_needed));
-  }
-
-  {
-    char *ws = static_cast<char *>(hipdnn_ep_state_get_workspace(state));
-    size_t ws_total = hipdnn_ep_state_get_workspace_size(state);
-
-    void *d_Qtrans = need_transpose ? (ws + off_Qtrans) : nullptr;
-    void *d_Kexp = use_no_expand ? nullptr : (ws + off_Kexp);
-    void *d_Vexp = use_no_expand ? nullptr : (ws + off_Vexp);
-    void *d_S_f32 = ws + off_S_f32;
-    void *d_S_fp16 = ws + off_S_fp16;
-    void *d_O = need_transpose ? (ws + off_O) : nullptr;
-
-    void *gemm_ws_ptr = ws + temp_end;
-    size_t gemm_ws_bytes = ws_total - temp_end;
 
     // Mutable source pointers: initially point to the raw inputs, but get
     // redirected to workspace buffers as pipeline steps (split, RoPE) produce
@@ -1201,40 +1182,32 @@ static int gqa_forward_hipblaslt(
     // When key/value are null, query is a packed [B, S, (H+2G)*d] tensor.
     // Split into separate Q [B*S, H*d], K [B*S, G*d], V [B*S, G*d].
     if (packed_qkv) {
-      void *d_Qsplit = ws + off_Qsplit;
-      void *d_Ksplit = ws + off_Ksplit;
-      void *d_Vsplit = ws + off_Vsplit;
       HIP_CHECK(hip_gqa_split_qkv(
-          stream, query, d_Qsplit, d_Ksplit, d_Vsplit, static_cast<int>(B),
-          static_cast<int>(sq), static_cast<int>(H), static_cast<int>(G),
-          static_cast<int>(d), static_cast<int>(elem_sz)));
-      qSrc = d_Qsplit;
-      kSrc = d_Ksplit;
-      vSrc = d_Vsplit;
+          stream, query, d_Qsplit_d, d_Ksplit_d, d_Vsplit_d,
+          static_cast<int>(B), static_cast<int>(sq), static_cast<int>(H),
+          static_cast<int>(G), static_cast<int>(d),
+          static_cast<int>(elem_sz)));
+      qSrc = d_Qsplit_d;
+      kSrc = d_Ksplit_d;
+      vSrc = d_Vsplit_d;
     }
 
-    // ---- Steps 1-2: RoPE (optional) ----
-    // Uses qSrc/kSrc (not raw query/key) so that packed-QKV split buffers
-    // are correctly fed into RoPE when both features are active.
     if (need_rope) {
       int half_rot = static_cast<int>(d / 2);
-      void *d_Qroped = ws + off_Qroped;
-      void *d_Kroped = ws + off_Kroped;
 
-      HIP_CHECK(hip_gqa_rope(stream, qSrc, d_Qroped, cos_cache, sin_cache,
+      HIP_CHECK(hip_gqa_rope(stream, qSrc, d_Qroped_d, cos_cache, sin_cache,
                              static_cast<int>(B), static_cast<int>(sq),
                              static_cast<int>(H), static_cast<int>(d), half_rot,
                              static_cast<int>(past_len), nullptr,
                              static_cast<int>(elem_sz)));
-      HIP_CHECK(hip_gqa_rope(stream, kSrc, d_Kroped, cos_cache, sin_cache,
+      HIP_CHECK(hip_gqa_rope(stream, kSrc, d_Kroped_d, cos_cache, sin_cache,
                              static_cast<int>(B), static_cast<int>(sq),
                              static_cast<int>(G), static_cast<int>(d), half_rot,
                              static_cast<int>(past_len), nullptr,
                              static_cast<int>(elem_sz)));
 
-      qSrc = d_Qroped;
-      kSrc = d_Kroped;
-      // vSrc is intentionally NOT updated: V is never RoPE'd.
+      qSrc = d_Qroped_d;
+      kSrc = d_Kroped_d;
     }
 
     // ---- Step 3: Q Transpose BSHD [B,S,H,d] -> BNSD [B,H,S,d] ----

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -776,6 +776,15 @@ static int gqa_forward_hipblaslt(
                          : 0;
 
     hipdnn_ep_scratch_restore(state, 0);
+    {
+      size_t total = 0;
+      if (fused_packed_qkv)
+        total += Q_full_bytes + K_full_bytes + K_full_bytes + 3 * 64;
+      if (need_rope)
+        total += Q_full_bytes + K_full_bytes + 2 * 64;
+      total += flash_partials_bytes + 64;
+      hipdnn_ep_scratch_reserve(state, total);
+    }
     void *d_Qsplit = nullptr, *d_Ksplit = nullptr, *d_Vsplit = nullptr;
     void *d_Qroped = nullptr, *d_Kroped = nullptr;
     void *flash_partials = nullptr;
@@ -1121,6 +1130,15 @@ static int gqa_forward_hipblaslt(
       std::max(scoreState->workspace_size, valueState->workspace_size);
 
   hipdnn_ep_scratch_restore(state, 0);
+  {
+    size_t Q_rope = static_cast<size_t>(B) * sq * H * d * elem_sz;
+    size_t K_rope = static_cast<size_t>(B) * sq * G * d * elem_sz;
+    size_t total = Qtrans_bytes + Kexp_bytes + Vexp_bytes + S_f32_bytes +
+                   S_fp16_bytes + O_bytes + gemm_ws_needed +
+                   (need_rope ? Q_rope + K_rope : 0) +
+                   (packed_qkv ? Q_rope + K_rope + K_rope : 0) + 15 * 64;
+    hipdnn_ep_scratch_reserve(state, total);
+  }
   void *d_Qtrans =
       need_transpose ? hipdnn_ep_scratch_alloc(state, Qtrans_bytes) : nullptr;
   void *d_Kexp =

--- a/lib/Runtime/real/matmul.cpp
+++ b/lib/Runtime/real/matmul.cpp
@@ -492,8 +492,9 @@ int wrap_hipblasLtMatmul(RuntimeState *state, int op_state_slot, const void *A,
     return -1;
   }
 
-  // Ensure workspace is large enough for auto-tune candidates (if pending)
-  // or the selected algorithm.
+  // Workspace for auto-tune candidates (first call) or the tuned algo.
+  // Uses ensure_workspace (not scratch_alloc) because the autotune loop
+  // needs the raw buffer + its full size for hipBLASLt benchmarking.
   size_t needed_ws =
       cached->tuned ? cached->workspace_size : cached->max_candidate_workspace;
   if (needed_ws > 0) {

--- a/lib/Runtime/real/miopen.cpp
+++ b/lib/Runtime/real/miopen.cpp
@@ -256,6 +256,7 @@ int wrap_miopenConvolutionForward(
       miopen_handle, weights_desc, input_desc, conv_desc, output_desc,
       &workspace_size));
 
+  hipdnn_ep_scratch_restore(state, 0);
   if (workspace_size > 0) {
     workspace = hipdnn_ep_scratch_alloc(state, workspace_size);
     if (!workspace) {

--- a/lib/Runtime/real/miopen.cpp
+++ b/lib/Runtime/real/miopen.cpp
@@ -257,15 +257,15 @@ int wrap_miopenConvolutionForward(
       &workspace_size));
 
   if (workspace_size > 0) {
-    if (hipdnn_ep_state_ensure_conv_scratch(state, workspace_size) != 0) {
+    workspace = hipdnn_ep_scratch_alloc(state, workspace_size);
+    if (!workspace) {
       fprintf(stderr,
-              "wrap_miopenConvolutionForward: failed to grow conv_scratch to "
+              "wrap_miopenConvolutionForward: scratch_alloc failed for "
               "%zu bytes\n",
               workspace_size);
       result = -1;
       goto cleanup;
     }
-    workspace = hipdnn_ep_state_get_conv_scratch(state);
   }
 
   // Find best algorithm

--- a/lib/Runtime/real/multi_head_attention.cpp
+++ b/lib/Runtime/real/multi_head_attention.cpp
@@ -496,6 +496,7 @@ extern "C" int wrap_multi_head_attention(
   const size_t sz_o_bnsh = need_o_trans ? B * N * Sq * H * 2 : 0;
   const size_t sz_gemm_ws = kMaxWorkspaceBytes;
 
+  hipdnn_ep_scratch_restore(state, 0);
   void *d_Qbnsh = sz_q_bnsh ? hipdnn_ep_scratch_alloc(state, sz_q_bnsh) : query;
   void *d_Kbnsh = sz_k_bnsh ? hipdnn_ep_scratch_alloc(state, sz_k_bnsh) : key;
   void *d_Vbnsh = sz_v_bnsh ? hipdnn_ep_scratch_alloc(state, sz_v_bnsh) : value;

--- a/lib/Runtime/real/multi_head_attention.cpp
+++ b/lib/Runtime/real/multi_head_attention.cpp
@@ -501,14 +501,14 @@ extern "C" int wrap_multi_head_attention(
   void *d_Vbnsh = sz_v_bnsh ? hipdnn_ep_scratch_alloc(state, sz_v_bnsh) : value;
   void *d_S_f32 = hipdnn_ep_scratch_alloc(state, sz_s_f32);
   void *d_P_f16 = hipdnn_ep_scratch_alloc(state, sz_p_f16);
-  void *d_O_bnsh = sz_o_bnsh ? hipdnn_ep_scratch_alloc(state, sz_o_bnsh) : output;
+  void *d_O_bnsh =
+      sz_o_bnsh ? hipdnn_ep_scratch_alloc(state, sz_o_bnsh) : output;
   void *gemm_ws = hipdnn_ep_scratch_alloc(state, sz_gemm_ws);
   const size_t gemm_ws_bytes = sz_gemm_ws;
-  if (!d_S_f32 || !d_P_f16 || !gemm_ws ||
-      (sz_q_bnsh && !d_Qbnsh) || (sz_k_bnsh && !d_Kbnsh) ||
-      (sz_v_bnsh && !d_Vbnsh) || (sz_o_bnsh && !d_O_bnsh)) {
-    fprintf(stderr,
-            "[multi_head_attention] ERROR: scratch_alloc failed\n");
+  if (!d_S_f32 || !d_P_f16 || !gemm_ws || (sz_q_bnsh && !d_Qbnsh) ||
+      (sz_k_bnsh && !d_Kbnsh) || (sz_v_bnsh && !d_Vbnsh) ||
+      (sz_o_bnsh && !d_O_bnsh)) {
+    fprintf(stderr, "[multi_head_attention] ERROR: scratch_alloc failed\n");
     return -1;
   }
 

--- a/lib/Runtime/real/multi_head_attention.cpp
+++ b/lib/Runtime/real/multi_head_attention.cpp
@@ -497,6 +497,9 @@ extern "C" int wrap_multi_head_attention(
   const size_t sz_gemm_ws = kMaxWorkspaceBytes;
 
   hipdnn_ep_scratch_restore(state, 0);
+  hipdnn_ep_scratch_reserve(state, sz_q_bnsh + sz_k_bnsh + sz_v_bnsh +
+                                       sz_s_f32 + sz_p_f16 + sz_o_bnsh +
+                                       sz_gemm_ws + 7 * 64);
   void *d_Qbnsh = sz_q_bnsh ? hipdnn_ep_scratch_alloc(state, sz_q_bnsh) : query;
   void *d_Kbnsh = sz_k_bnsh ? hipdnn_ep_scratch_alloc(state, sz_k_bnsh) : key;
   void *d_Vbnsh = sz_v_bnsh ? hipdnn_ep_scratch_alloc(state, sz_v_bnsh) : value;

--- a/lib/Runtime/real/multi_head_attention.cpp
+++ b/lib/Runtime/real/multi_head_attention.cpp
@@ -513,10 +513,10 @@ extern "C" int wrap_multi_head_attention(
   }
 
   RUNTIME_DEBUG_LOG(
-      "[multi_head_attention] workspace=%zu bytes (q=%zu k=%zu v=%zu "
+      "[multi_head_attention] scratch (q=%zu k=%zu v=%zu "
       "s=%zu p=%zu o=%zu gemm=%zu); need_q_trans=%d need_kv_trans=%d "
       "need_o_trans=%d\n",
-      total_ws, sz_q_bnsh, sz_k_bnsh, sz_v_bnsh, sz_s_f32, sz_p_f16, sz_o_bnsh,
+      sz_q_bnsh, sz_k_bnsh, sz_v_bnsh, sz_s_f32, sz_p_f16, sz_o_bnsh,
       sz_gemm_ws, (int)need_q_trans, (int)need_kv_trans, (int)need_o_trans);
 
   int result = 0;

--- a/lib/Runtime/real/multi_head_attention.cpp
+++ b/lib/Runtime/real/multi_head_attention.cpp
@@ -485,70 +485,32 @@ extern "C" int wrap_multi_head_attention(
   // When a transpose is skipped, the source memref is BSHD [B,1,N,H] which is
   // bit-identical to BNSH [B,N,1,H] (different logical reshape, same memory
   // order), so we can point straight at the input buffer instead of copying.
-  const size_t align = 64;
-  auto align_up = [&](size_t v) { return (v + align - 1) & ~(align - 1); };
   const bool need_q_trans = (Sq > 1);
   const bool need_kv_trans = (Skv > 1);
   const bool need_o_trans = (Sq > 1);
-  const size_t sz_q_bnsh = need_q_trans ? align_up(B * N * Sq * H * 2) : 0;
-  const size_t sz_k_bnsh = need_kv_trans ? align_up(B * N * Skv * H * 2) : 0;
-  const size_t sz_v_bnsh = need_kv_trans ? align_up(B * N * Skv * H * 2) : 0;
-  const size_t sz_s_f32 = align_up(B * N * Sq * Skv * 4);
-  const size_t sz_p_f16 = align_up(B * N * Sq * Skv * 2);
-  const size_t sz_o_bnsh = need_o_trans ? align_up(B * N * Sq * H * 2) : 0;
-  const size_t sz_gemm_ws = align_up(kMaxWorkspaceBytes);
-  const size_t total_ws = sz_q_bnsh + sz_k_bnsh + sz_v_bnsh + sz_s_f32 +
-                          sz_p_f16 + sz_o_bnsh + sz_gemm_ws;
+  const size_t sz_q_bnsh = need_q_trans ? B * N * Sq * H * 2 : 0;
+  const size_t sz_k_bnsh = need_kv_trans ? B * N * Skv * H * 2 : 0;
+  const size_t sz_v_bnsh = need_kv_trans ? B * N * Skv * H * 2 : 0;
+  const size_t sz_s_f32 = B * N * Sq * Skv * 4;
+  const size_t sz_p_f16 = B * N * Sq * Skv * 2;
+  const size_t sz_o_bnsh = need_o_trans ? B * N * Sq * H * 2 : 0;
+  const size_t sz_gemm_ws = kMaxWorkspaceBytes;
 
-  if (hipdnn_ep_state_ensure_workspace(state, total_ws) != 0) {
-    fprintf(stderr,
-            "[multi_head_attention] ERROR: failed to ensure workspace of "
-            "%zu bytes\n",
-            total_ws);
-    return -1;
-  }
-  char *ws = static_cast<char *>(hipdnn_ep_state_get_workspace(state));
-  if (!ws) {
-    fprintf(stderr,
-            "[multi_head_attention] ERROR: workspace pointer is null after "
-            "ensure_workspace\n");
-    return -1;
-  }
-  size_t off = 0;
-  void *d_Qbnsh = nullptr;
-  void *d_Kbnsh = nullptr;
-  void *d_Vbnsh = nullptr;
-  void *d_O_bnsh = nullptr;
-  if (sz_q_bnsh) {
-    d_Qbnsh = ws + off;
-    off += sz_q_bnsh;
-  } else {
-    d_Qbnsh = query;
-  }
-  if (sz_k_bnsh) {
-    d_Kbnsh = ws + off;
-    off += sz_k_bnsh;
-  } else {
-    d_Kbnsh = key;
-  }
-  if (sz_v_bnsh) {
-    d_Vbnsh = ws + off;
-    off += sz_v_bnsh;
-  } else {
-    d_Vbnsh = value;
-  }
-  void *d_S_f32 = ws + off;
-  off += sz_s_f32;
-  void *d_P_f16 = ws + off;
-  off += sz_p_f16;
-  if (sz_o_bnsh) {
-    d_O_bnsh = ws + off;
-    off += sz_o_bnsh;
-  } else {
-    d_O_bnsh = output;
-  }
-  void *gemm_ws = ws + off;
+  void *d_Qbnsh = sz_q_bnsh ? hipdnn_ep_scratch_alloc(state, sz_q_bnsh) : query;
+  void *d_Kbnsh = sz_k_bnsh ? hipdnn_ep_scratch_alloc(state, sz_k_bnsh) : key;
+  void *d_Vbnsh = sz_v_bnsh ? hipdnn_ep_scratch_alloc(state, sz_v_bnsh) : value;
+  void *d_S_f32 = hipdnn_ep_scratch_alloc(state, sz_s_f32);
+  void *d_P_f16 = hipdnn_ep_scratch_alloc(state, sz_p_f16);
+  void *d_O_bnsh = sz_o_bnsh ? hipdnn_ep_scratch_alloc(state, sz_o_bnsh) : output;
+  void *gemm_ws = hipdnn_ep_scratch_alloc(state, sz_gemm_ws);
   const size_t gemm_ws_bytes = sz_gemm_ws;
+  if (!d_S_f32 || !d_P_f16 || !gemm_ws ||
+      (sz_q_bnsh && !d_Qbnsh) || (sz_k_bnsh && !d_Kbnsh) ||
+      (sz_v_bnsh && !d_Vbnsh) || (sz_o_bnsh && !d_O_bnsh)) {
+    fprintf(stderr,
+            "[multi_head_attention] ERROR: scratch_alloc failed\n");
+    return -1;
+  }
 
   RUNTIME_DEBUG_LOG(
       "[multi_head_attention] workspace=%zu bytes (q=%zu k=%zu v=%zu "

--- a/lib/Runtime/real/qmoe.cpp
+++ b/lib/Runtime/real/qmoe.cpp
@@ -112,6 +112,7 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
 
   int64_t act_slots = std::max<int64_t>(num_tokens, k);
 
+  hipdnn_ep_scratch_restore(state, 0);
   void *d_expert_indices =
       hipdnn_ep_scratch_alloc(state, num_tokens * k * sizeof(int32_t));
   void *d_expert_weights =

--- a/lib/Runtime/real/qmoe.cpp
+++ b/lib/Runtime/real/qmoe.cpp
@@ -113,6 +113,24 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
   int64_t act_slots = std::max<int64_t>(num_tokens, k);
 
   hipdnn_ep_scratch_restore(state, 0);
+  {
+    size_t total = 0;
+    auto align64 = [](size_t s) { return (s + 63) & ~size_t(63); };
+    total += align64(num_tokens * k * sizeof(int32_t));
+    total += align64(num_tokens * k * elem_size);
+    total += align64(num_tokens * hidden_size * elem_size);
+    total += align64(num_tokens * fusion_inter * elem_size);
+    total += align64(act_slots * inter_size * elem_size);
+    total += align64(act_slots * hidden_size * elem_size);
+    total += align64(num_experts * sizeof(int32_t));
+    total += align64((num_experts + 1) * sizeof(int32_t));
+    total += align64(num_tokens * k * sizeof(int32_t));
+    total += align64(num_tokens * k * elem_size);
+    if (hipdnn_ep_scratch_reserve(state, total) != 0) {
+      fprintf(stderr, "wrap_qmoe: scratch_reserve(%zu) failed\n", total);
+      return -1;
+    }
+  }
   void *d_expert_indices =
       hipdnn_ep_scratch_alloc(state, num_tokens * k * sizeof(int32_t));
   void *d_expert_weights =

--- a/lib/Runtime/real/qmoe.cpp
+++ b/lib/Runtime/real/qmoe.cpp
@@ -110,65 +110,35 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
   int64_t k_blocks_fc2 = (inter_size + block_size - 1) / block_size;
   int64_t blob_size_fc2 = block_size / 2;
 
-  // Per-state grow-on-demand scratch in place of 8 hipMalloc/8 hipFree per
-  // call. Sub-buffers are 64-byte aligned (matches GPU pool alignment, gives
-  // each sub-buffer its own cache line). The buffer grows when num_tokens /
-  // sizes exceed the cached capacity, never shrinks; freed in state cleanup.
-  auto align_up_64 = [](size_t s) -> size_t { return (s + 63) & ~size_t(63); };
-  size_t sz_expert_indices = align_up_64(num_tokens * k * sizeof(int32_t));
-  size_t sz_expert_weights = align_up_64(num_tokens * k * elem_size);
-  size_t sz_gather_buf = align_up_64(num_tokens * hidden_size * elem_size);
-  size_t sz_fc1_buf = align_up_64(num_tokens * fusion_inter * elem_size);
-  // Fused decode (num_tokens == 1) reuses act_buf and fc2_buf as the [k,
-  // inter] activation slots and [k, hidden] per-expert output slots needed
-  // by hip_qmoe_decode_fused (gather/scatter happen inline inside the
-  // kernel, indexed by expert_indices). For num_tokens > 1 the multi-pass
-  // path uses [num_tokens, ...] sizing. Take the max so the per-state
-  // scratch is never under-sized regardless of which path runs.
   int64_t act_slots = std::max<int64_t>(num_tokens, k);
-  size_t sz_act_buf = align_up_64(act_slots * inter_size * elem_size);
-  size_t sz_fc2_buf = align_up_64(act_slots * hidden_size * elem_size);
-  // bucket_tokens outputs (Phase 2): per-expert counts + exclusive prefix sum
-  // offsets, plus tokens/weights re-grouped on-device into per-expert
-  // contiguous slices. Replaces the old per-expert host h_ids/h_wts_e build +
-  // H2D round-trip (2 hipMemcpyAsync per active expert per layer).
-  size_t sz_expert_counts = align_up_64(num_experts * sizeof(int32_t));
-  size_t sz_expert_offsets = align_up_64((num_experts + 1) * sizeof(int32_t));
-  size_t sz_sorted_token_ids = align_up_64(num_tokens * k * sizeof(int32_t));
-  size_t sz_sorted_weights = align_up_64(num_tokens * k * elem_size);
 
-  size_t off_expert_indices = 0;
-  size_t off_expert_weights = off_expert_indices + sz_expert_indices;
-  size_t off_gather_buf = off_expert_weights + sz_expert_weights;
-  size_t off_fc1_buf = off_gather_buf + sz_gather_buf;
-  size_t off_act_buf = off_fc1_buf + sz_fc1_buf;
-  size_t off_fc2_buf = off_act_buf + sz_act_buf;
-  size_t off_expert_counts = off_fc2_buf + sz_fc2_buf;
-  size_t off_expert_offsets = off_expert_counts + sz_expert_counts;
-  size_t off_sorted_token_ids = off_expert_offsets + sz_expert_offsets;
-  size_t off_sorted_weights = off_sorted_token_ids + sz_sorted_token_ids;
-  size_t total_scratch = off_sorted_weights + sz_sorted_weights;
+  void *d_expert_indices =
+      hipdnn_ep_scratch_alloc(state, num_tokens * k * sizeof(int32_t));
+  void *d_expert_weights =
+      hipdnn_ep_scratch_alloc(state, num_tokens * k * elem_size);
+  void *d_gather_buf =
+      hipdnn_ep_scratch_alloc(state, num_tokens * hidden_size * elem_size);
+  void *d_fc1_buf =
+      hipdnn_ep_scratch_alloc(state, num_tokens * fusion_inter * elem_size);
+  void *d_act_buf =
+      hipdnn_ep_scratch_alloc(state, act_slots * inter_size * elem_size);
+  void *d_fc2_buf =
+      hipdnn_ep_scratch_alloc(state, act_slots * hidden_size * elem_size);
+  int32_t *d_expert_counts = static_cast<int32_t *>(
+      hipdnn_ep_scratch_alloc(state, num_experts * sizeof(int32_t)));
+  int32_t *d_expert_offsets = static_cast<int32_t *>(
+      hipdnn_ep_scratch_alloc(state, (num_experts + 1) * sizeof(int32_t)));
+  int32_t *d_sorted_token_ids = static_cast<int32_t *>(
+      hipdnn_ep_scratch_alloc(state, num_tokens * k * sizeof(int32_t)));
+  char *d_sorted_weights = static_cast<char *>(
+      hipdnn_ep_scratch_alloc(state, num_tokens * k * elem_size));
 
-  if (hipdnn_ep_state_ensure_qmoe_scratch(state, total_scratch) != 0) {
-    fprintf(stderr, "wrap_qmoe: ensure_qmoe_scratch(%zu) failed\n",
-            total_scratch);
+  if (!d_expert_indices || !d_expert_weights || !d_gather_buf || !d_fc1_buf ||
+      !d_act_buf || !d_fc2_buf || !d_expert_counts || !d_expert_offsets ||
+      !d_sorted_token_ids || !d_sorted_weights) {
+    fprintf(stderr, "wrap_qmoe: scratch_alloc failed\n");
     return -1;
   }
-  char *scratch_base =
-      static_cast<char *>(hipdnn_ep_state_get_qmoe_scratch(state));
-  void *d_expert_indices = scratch_base + off_expert_indices;
-  void *d_expert_weights = scratch_base + off_expert_weights;
-  void *d_gather_buf = scratch_base + off_gather_buf;
-  void *d_fc1_buf = scratch_base + off_fc1_buf;
-  void *d_act_buf = scratch_base + off_act_buf;
-  void *d_fc2_buf = scratch_base + off_fc2_buf;
-  int32_t *d_expert_counts =
-      reinterpret_cast<int32_t *>(scratch_base + off_expert_counts);
-  int32_t *d_expert_offsets =
-      reinterpret_cast<int32_t *>(scratch_base + off_expert_offsets);
-  int32_t *d_sorted_token_ids =
-      reinterpret_cast<int32_t *>(scratch_base + off_sorted_token_ids);
-  char *d_sorted_weights = scratch_base + off_sorted_weights;
 
   RUNTIME_DEBUG_LOG("[REAL] wrap_qmoe: topk_routing(tokens=%lld, experts=%lld, "
                     "k=%lld, normalize=%lld)\n",

--- a/lib/Runtime/real/simplified_layer_norm.cpp
+++ b/lib/Runtime/real/simplified_layer_norm.cpp
@@ -255,14 +255,13 @@ int wrap_miopenT5LayerNormForward(RuntimeState *state, int op_state_slot,
     return -1;
   }
 
-  // Use shared workspace for rstd scratch buffer (always f32)
   size_t rstd_bytes = static_cast<size_t>(num_rows) * sizeof(float);
-  if (hipdnn_ep_state_ensure_workspace(state, rstd_bytes) != 0) {
+  void *rstd_buf = hipdnn_ep_scratch_alloc(state, rstd_bytes);
+  if (!rstd_buf) {
     fprintf(stderr,
-            "wrap_miopenT5LayerNormForward: workspace allocation failed\n");
+            "wrap_miopenT5LayerNormForward: scratch allocation failed\n");
     return -1;
   }
-  void *rstd_buf = hipdnn_ep_state_get_workspace(state);
 
   RUNTIME_DEBUG_LOG(
       "[REAL] wrap_miopenT5LayerNormForward: calling miopenT5LayerNormForward"

--- a/lib/Runtime/real/simplified_layer_norm.cpp
+++ b/lib/Runtime/real/simplified_layer_norm.cpp
@@ -255,6 +255,7 @@ int wrap_miopenT5LayerNormForward(RuntimeState *state, int op_state_slot,
     return -1;
   }
 
+  hipdnn_ep_scratch_restore(state, 0);
   size_t rstd_bytes = static_cast<size_t>(num_rows) * sizeof(float);
   void *rstd_buf = hipdnn_ep_scratch_alloc(state, rstd_bytes);
   if (!rstd_buf) {

--- a/lib/Runtime/real/skip_simplified_layer_norm.cpp
+++ b/lib/Runtime/real/skip_simplified_layer_norm.cpp
@@ -288,7 +288,8 @@ int wrap_skip_simplified_layer_norm(RuntimeState *state, int op_state_slot,
     skip_bytes = static_cast<size_t>(input_num_elements) * element_size_bytes;
   size_t rstd_bytes = static_cast<size_t>(num_rows) * sizeof(float);
 
-  void *skip_scratch = skip_bytes > 0 ? hipdnn_ep_scratch_alloc(state, skip_bytes) : nullptr;
+  void *skip_scratch =
+      skip_bytes > 0 ? hipdnn_ep_scratch_alloc(state, skip_bytes) : nullptr;
   void *rstd_buf = hipdnn_ep_scratch_alloc(state, rstd_bytes);
   if ((skip_bytes > 0 && !skip_scratch) || !rstd_buf) {
     fprintf(stderr,

--- a/lib/Runtime/real/skip_simplified_layer_norm.cpp
+++ b/lib/Runtime/real/skip_simplified_layer_norm.cpp
@@ -283,25 +283,20 @@ int wrap_skip_simplified_layer_norm(RuntimeState *state, int op_state_slot,
     return -1;
   }
 
-  // Shared workspace: pack [tmp_skip_buf (if needed) | rstd_buf]
-  // Align rstd_buf to 256 bytes for GPU memory access efficiency.
   size_t skip_bytes = 0;
   if (!input_skip_bias_sum)
     skip_bytes = static_cast<size_t>(input_num_elements) * element_size_bytes;
-  size_t skip_aligned =
-      (skip_bytes + kScratchAlignment - 1) & ~(kScratchAlignment - 1);
   size_t rstd_bytes = static_cast<size_t>(num_rows) * sizeof(float);
-  size_t total_ws = skip_aligned + rstd_bytes;
 
-  if (hipdnn_ep_state_ensure_workspace(state, total_ws) != 0) {
+  void *skip_scratch = skip_bytes > 0 ? hipdnn_ep_scratch_alloc(state, skip_bytes) : nullptr;
+  void *rstd_buf = hipdnn_ep_scratch_alloc(state, rstd_bytes);
+  if ((skip_bytes > 0 && !skip_scratch) || !rstd_buf) {
     fprintf(stderr,
-            "wrap_skip_simplified_layer_norm: workspace allocation failed\n");
+            "wrap_skip_simplified_layer_norm: scratch allocation failed\n");
     return -1;
   }
-  char *ws = static_cast<char *>(hipdnn_ep_state_get_workspace(state));
 
-  void *skip_buf = input_skip_bias_sum ? input_skip_bias_sum : ws;
-  void *rstd_buf = ws + skip_aligned;
+  void *skip_buf = input_skip_bias_sum ? input_skip_bias_sum : skip_scratch;
 
   int result = 0;
 

--- a/lib/Runtime/real/skip_simplified_layer_norm.cpp
+++ b/lib/Runtime/real/skip_simplified_layer_norm.cpp
@@ -283,6 +283,7 @@ int wrap_skip_simplified_layer_norm(RuntimeState *state, int op_state_slot,
     return -1;
   }
 
+  hipdnn_ep_scratch_restore(state, 0);
   size_t skip_bytes = 0;
   if (!input_skip_bias_sum)
     skip_bytes = static_cast<size_t>(input_num_elements) * element_size_bytes;

--- a/lib/Runtime/runtime_state_internal.h
+++ b/lib/Runtime/runtime_state_internal.h
@@ -26,10 +26,10 @@
 // layout-agnostic (it only forward-declares RuntimeState), so including it here
 // is acyclic.
 #include "op_state.h"
-// Unified Memory Manager (Phase 1). All session-scoped GPU/host buffers
-// (pool domains, workspace, host-scalar scratch, qmoe host scratch) are now
-// owned by MemoryManager and accessed through it. seqlens_k cache also lives
-// in MM so begin_compute() is the single invalidation point.
+// Unified Memory Manager. All session-scoped GPU/host buffers (pool domains,
+// workspace, host-scalar scratch, qmoe host scratch) are owned by
+// MemoryManager and accessed through it. seqlens_k cache also lives in MM
+// so begin_compute() is the single invalidation point.
 #include "mm/memory_manager.h"
 
 // Internal runtime state structure
@@ -48,36 +48,14 @@ struct RuntimeState {
   size_t num_constants;
 
   // -------------------------------------------------------------------------
-  // Unified Memory Manager (Phase 1+).
+  // Unified Memory Manager.
   //
   // All session-scoped memory — pool domains, shared workspace, host-scalar
-  // scratch, qmoe host scratch — is now owned by `mm`. The extern C API
-  // functions in hipdnn_ep_runtime.h remain unchanged; their implementations
-  // in hipdnn_ep_runtime_state.cpp delegate to mm->*.
-  //
-  // The legacy flat fields below (pool_base, pool_size, workspace, …) are kept
-  // during the Phase-1 transition period so that the EXISTING EXTERN C ABI
-  // surface compiles unchanged. They are effectively aliases — the actual data
-  // lives in mm, and these fields are unused once mm is created. They will be
-  // removed in Phase 2 once all callers are proven to go through mm.
+  // scratch, qmoe host scratch — is owned by `mm`. The extern C API functions
+  // in hipdnn_ep_runtime.h delegate to mm->*.
   // -------------------------------------------------------------------------
 
   MemoryManager *mm; // owns all session-scoped memory; created in init
-
-  // LEGACY: kept for ABI transition. Do not use directly — go through mm.
-  int num_pool_domains;   // mirrors mm->num_pool_domains()
-  void **pool_base;       // unused after Phase 1 (mm owns the pools)
-  size_t *pool_size;      // unused after Phase 1
-  size_t *buffer_offsets; // unused after Phase 1 (mm->buffer_offsets_)
-  size_t num_buffers;     // unused after Phase 1 (mm->num_buffers_)
-
-  // LEGACY: kept for ABI transition. Do not use directly — go through mm.
-  void *workspace;
-  size_t workspace_size;
-
-  // LEGACY: kept for ABI transition. Do not use directly — go through mm.
-  void *host_scratch_base;
-  size_t host_scratch_size;
 
   // Output allocator installed by the EP before inference_compute via
   // hipdnn_ep_set_output_allocator. hipdnn_ep_alloc_output forwards to
@@ -85,49 +63,6 @@ struct RuntimeState {
   // allocate == nullptr means no allocator has been installed yet;
   // zero-initialized in initialize_state_handles.
   hipdnn_output_allocator_t output_allocator;
-
-  // LEGACY: kept for ABI transition. Do not use directly — go through mm.
-  // Per-session scratch buffer for wrap_qmoe transient device buffers
-  // (expert_indices, expert_weights, gather_buf, fc1_buf, act_buf, fc2_buf,
-  // token_ids, token_wts -- 8 sub-buffers laid out at fixed offsets).
-  //
-  // Why this exists: pre-cache wrap_qmoe issued 8 hipMalloc + 8 hipFree per
-  // call, every layer, every inference. On 24-layer gpt-oss-20b that's 192
-  // mallocs + 192 frees per token; HIP's hipMalloc takes ~50 us each on
-  // Windows, so the storm cost ~10-12 ms/token and bottlenecked decode TPS to
-  // roughly half the Vulkan baseline on the same hardware.
-  //
-  // Layout policy: one contiguous buffer sized to fit ALL sub-buffers for the
-  // largest (num_tokens, hidden, inter, k, num_experts, elem) shape ever seen
-  // by this session. Sub-buffer offsets recomputed per-call (cheap arithmetic);
-  // the buffer itself grows on demand via hipdnn_ep_state_ensure_qmoe_scratch
-  // and never shrinks (mirrors the `workspace` field's policy). Shared by all
-  // qmoe instances in the session: safe because the HIP stream is serialised,
-  // so the next qmoe launches only after the previous one's kernels finish.
-  //
-  // Pinned host mirror is needed for the 24-bytes-per-layer D2H readback of
-  // expert routing decisions (still required at decode pre-Phase-2). hipHost-
-  // Malloc'd once with hipHostMallocDefault; reused across calls without sync.
-  void *qmoe_scratch;
-  size_t qmoe_scratch_size;
-  void *qmoe_host_scratch; // pinned host mirror for D2H of expert idx/weights
-  size_t qmoe_host_scratch_size;
-
-  // Per-session scratch buffer for the MIOpen convolution workspace
-  // (wrap_miopenConvolutionForward, both 2D and the H=1 1D conv path).
-  //
-  // The MIOpen forward-convolution Find API selects an algorithm whose
-  // workspace requirement is shape-dependent (winograd/gemm/etc). Whisper's
-  // encoder front-end runs the same two Conv shapes every inference
-  // (Cin=128/Cout=1280 K=3 s=1, Cin=1280/Cout=1280 K=3 s=2), so a per-call
-  // hipMalloc/hipFree of the workspace would be wasted work after the
-  // first call. Same grow-on-demand policy as qmoe_scratch above: lazily
-  // allocated on first use, never shrinks, freed in
-  // hipdnn_ep_state_cleanup. Single-buffer reuse is safe because the HIP
-  // stream is serialised -- the next conv launches only after the previous
-  // miopenConvolutionForward + bias add have consumed the workspace.
-  void *conv_scratch;
-  size_t conv_scratch_size;
 
   // NOTE: the GQA GEMM descriptor cache (GqaGemmCache) formerly lived here as
   // gqa_gemm_cache. It is now per-op-instance: each gqa instance owns one in
@@ -177,19 +112,6 @@ struct RuntimeState {
   // cleaned up here)
   void *hipdnn_handle;
   void *hipdnn_graph_registry;
-
-  // Per-Compute() seqlens_k cache — now lives in RuntimeState::mm.
-  //
-  // These three fields are kept here as ALIASES so that the existing code in
-  // gqa.cpp (which reads/writes state->seqlens_k_cached_*) continues to
-  // compile unchanged during Phase 1. They are populated from / flushed to
-  // mm->seqlens_k_* by hipdnn_ep_runtime_begin_compute(). In Phase 2 the
-  // gqa.cpp accessors will be redirected to mm directly and these removed.
-  //
-  // Invalidated by hipdnn_ep_runtime_begin_compute() via mm->begin_compute().
-  bool seqlens_k_cached_valid;
-  int32_t seqlens_k_cached_val;
-  const void *seqlens_k_cached_ptr;
 
   // ONNX Loop driver state. Lazily allocated by hipdnn_ep_run_counted_loop /
   // hipdnn_ep_run_loop on first call; freed in hipdnn_ep_state_cleanup.

--- a/test/runtime/mm/test_memory_manager.cpp
+++ b/test/runtime/mm/test_memory_manager.cpp
@@ -17,6 +17,7 @@
 #include "mm/memory_manager.h"
 
 #include <cassert>
+#include <cstdint>
 #include <cstdio>
 #include <cstring>
 
@@ -288,6 +289,84 @@ static void test_num_pool_domains_grows_on_demand() {
 }
 
 //===----------------------------------------------------------------------===//
+// Scratch arena
+//===----------------------------------------------------------------------===//
+
+static void test_scratch_alloc_returns_aligned_pointer() {
+  auto mm = make_mm();
+  void *p = mm->scratch_alloc(100);
+  CHECK(p != nullptr);
+  CHECK((reinterpret_cast<uintptr_t>(p) % 64) == 0);
+  void *p2 = mm->scratch_alloc(33);
+  CHECK(p2 != nullptr);
+  CHECK((reinterpret_cast<uintptr_t>(p2) % 64) == 0);
+  delete mm;
+}
+
+static void test_scratch_alloc_sequential_non_overlapping() {
+  auto mm = make_mm();
+  void *a = mm->scratch_alloc(128);
+  void *b = mm->scratch_alloc(256);
+  CHECK(a != nullptr);
+  CHECK(b != nullptr);
+  auto a_end = reinterpret_cast<uintptr_t>(a) + 128;
+  auto b_start = reinterpret_cast<uintptr_t>(b);
+  CHECK(b_start >= a_end);
+  delete mm;
+}
+
+static void test_scratch_reset_reuses_memory() {
+  auto mm = make_mm();
+  void *p1 = mm->scratch_alloc(512);
+  CHECK(p1 != nullptr);
+  CHECK(mm->scratch_offset() > 0);
+  mm->scratch_reset();
+  CHECK(mm->scratch_offset() == 0);
+  void *p2 = mm->scratch_alloc(512);
+  CHECK(p2 == p1);
+  delete mm;
+}
+
+static void test_scratch_alloc_grows_workspace() {
+  auto mm = make_mm();
+  mm->scratch_alloc(1000);
+  size_t ws1 = mm->get_workspace_size();
+  CHECK(ws1 >= 1000);
+  mm->scratch_alloc(2000);
+  size_t ws2 = mm->get_workspace_size();
+  CHECK(ws2 >= 1000 + 2000);
+  delete mm;
+}
+
+static void test_begin_compute_resets_scratch() {
+  auto mm = make_mm();
+  mm->scratch_alloc(256);
+  CHECK(mm->scratch_offset() > 0);
+  mm->begin_compute();
+  CHECK(mm->scratch_offset() == 0);
+  delete mm;
+}
+
+static void test_ensure_workspace_resets_scratch() {
+  auto mm = make_mm();
+  mm->scratch_alloc(128);
+  CHECK(mm->scratch_offset() > 0);
+  mm->ensure_workspace(4096);
+  CHECK(mm->scratch_offset() == 0);
+  delete mm;
+}
+
+static void test_scratch_alloc_zero_returns_valid_ptr() {
+  auto mm = make_mm();
+  mm->scratch_alloc(64);
+  size_t off_before = mm->scratch_offset();
+  void *p = mm->scratch_alloc(0);
+  CHECK(mm->scratch_offset() == off_before);
+  CHECK(p != nullptr);
+  delete mm;
+}
+
+//===----------------------------------------------------------------------===//
 // main — runs all MM unit tests (HAL + MemoryManager)
 //===----------------------------------------------------------------------===//
 
@@ -321,6 +400,14 @@ int main() {
   test_seqlens_k_cache_ptr_keyed();
   test_seqlens_k_cache_set_replaces();
   test_end_compute_is_noop_in_phase1();
+
+  test_scratch_alloc_returns_aligned_pointer();
+  test_scratch_alloc_sequential_non_overlapping();
+  test_scratch_reset_reuses_memory();
+  test_scratch_alloc_grows_workspace();
+  test_begin_compute_resets_scratch();
+  test_ensure_workspace_resets_scratch();
+  test_scratch_alloc_zero_returns_valid_ptr();
 
   test_gpu_bytes_used_accounts_for_pool_and_workspace();
   test_cpu_bytes_used_accounts_for_host_scratch();

--- a/test/runtime/mm/test_memory_manager.cpp
+++ b/test/runtime/mm/test_memory_manager.cpp
@@ -347,12 +347,13 @@ static void test_begin_compute_resets_scratch() {
   delete mm;
 }
 
-static void test_ensure_workspace_resets_scratch() {
+static void test_ensure_workspace_preserves_scratch() {
   auto mm = make_mm();
   mm->scratch_alloc(128);
-  CHECK(mm->scratch_offset() > 0);
+  size_t off = mm->scratch_offset();
+  CHECK(off > 0);
   mm->ensure_workspace(4096);
-  CHECK(mm->scratch_offset() == 0);
+  CHECK(mm->scratch_offset() == off);
   delete mm;
 }
 
@@ -406,7 +407,7 @@ int main() {
   test_scratch_reset_reuses_memory();
   test_scratch_alloc_grows_workspace();
   test_begin_compute_resets_scratch();
-  test_ensure_workspace_resets_scratch();
+  test_ensure_workspace_preserves_scratch();
   test_scratch_alloc_zero_returns_valid_ptr();
 
   test_gpu_bytes_used_accounts_for_pool_and_workspace();


### PR DESCRIPTION
## Summary
- Remove 17 legacy `RuntimeState` alias fields (`pool_base`, `pool_size`, `workspace`, `host_scratch_*`, `qmoe_scratch`, `conv_scratch`, `seqlens_k_cached_*`, etc.) that Phase 1 kept during the transition period
- Delete all `if (!state->mm)` fallback code paths and the `ensure_pool_domains()` helper — all 13 extern C memory functions are now one-liner delegates to `MemoryManager`
- Redirect `gqa.cpp` seqlens_k cache to use `state->mm->seqlens_k_cache_*()` directly, removing the alias sync in `begin_compute()`
- Update `RuntimeStateLayout` binary mirror in `hipdnn_graph_runtime.cpp` to match the new struct layout
- ~520 lines deleted, ~64 added

Stacked on #398 (Phase 1).

## Test plan
- [ ] `ctest -R MemoryManagerUnitTests` — all 38 GPU-free unit tests pass
- [ ] `ctest -R MorphizenMLIRLitTests` — no LIT regressions
- [ ] CI windows-build passes (full build + test)
- [ ] `grep -rn "state->pool_base\|state->workspace[^_]\|state->host_scratch\|state->qmoe_scratch\|state->conv_scratch\|state->seqlens_k_cached" lib/` returns zero matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)