### PR TITLE
AMDMLSS gfx1151: GQA is the only kernel candidate, and it gives zero porting value for decode

### DIFF
--- a/docs/amdmlss_gfx1151_assessment.md
+++ b/docs/amdmlss_gfx1151_assessment.md
@@ -1,0 +1,107 @@
+# AMDMLSS gfx1151 (Strix Halo) kernel port assessment
+
+Status: **assessed, not merged.** This document records which AMDMLSS kernels are
+portable to `onnx-hipdnn-ep` on gfx1151, what was actually validated, and why none
+of them is worth enabling for the target workload (LLM **decode**) right now.
+
+## TL;DR
+
+- The complete set of gfx1151-eligible AMDMLSS kernels is small: **MHA, GQA, MVN,
+  Conv1x1, Conv-dilated**. Everything else (RMSNorm, SiLU, GEMMGEMM, ConvMxN,
+  GEMM, QGEMM) is RDNA4-only (`gfx1200/1201`) or an empty scaffold.
+- All AMDMLSS attention kernels for gfx1151 are **CK WMMA throughput kernels**.
+  They are efficient only for large query tiles (prefill), and only for
+  `head_dim <= 80`. They are the wrong tool for **decode** (`q_seq = 1`).
+- Real target models are all **GQA with `head_dim = 128`** (or 256). That combination
+  falls on the **untuned fallback tile** and never hits the tuned kernels.
+- Net: **zero (or negative) value for decode, and ~zero for prefill on real models.**
+  Only the MHA decode shim was wired (behind an `m==1` gate) and its win is marginal.
+
+## Kernels available on gfx1151
+
+| Op | Available | Backend | Notes |
+|---|---|---|---|
+| MHA | Yes | CK WMMA fp16 | reuses gfx1150 blob |
+| GQA | Yes | CK WMMA fp16 (relocatable) | reuses gfx1150 blob |
+| MVN / InstanceNorm | Yes | HIP `mvn2` | vision/CNN op |
+| Conv 1x1 | Yes | HIP WMMA (Gemm2d) | vision/CNN op |
+| Conv dilated | Yes | HIP WMMA (grouped conv) | vision/CNN op |
+| Conv MxN Winograd | No | — | excludes gfx115x |
+| RMSNorm, SiLU, GEMMGEMM | No | — | `isGfx120x` only (RDNA4) |
+| GEMM, QGEMM | No | — | scaffold, no code objects |
+
+MVN / Conv1x1 / Conv-dilated are CNN/vision operators and do not appear in transformer
+decode graphs, so they contribute nothing to the LLM workload regardless of whether
+they are ported.
+
+## GQA ABI (now fully decoded)
+
+The blocker in prior rounds was the exact host ABI. It is recovered from
+`amd-mlss-tester` (`lib/include/common/misc.hpp::calcStrides` +
+`unit-tests/gqa_test.cpp`):
+
+- Physical tensor layout **BSHD**; stride arrays passed in **`[batch, head, seq, dim]`** order.
+- `Q`, `K`, `Out` use `make_query_strides(head, seq) = {seq*head*hd, hd, head*hd, 1}`.
+- **`V` uses `make_value_strides(kvhead, kvseq) = {kvseq*kvhead*hd, hd, 1, kvhead*hd}`**
+  i.e. `V` has **seq and dim strides swapped** vs `Q`. This single detail is what
+  earlier stride brute-forcing never tried (it reused the `K` stride array for `V`),
+  and is why validation failed for > 2 heads.
+- Kernel arg order (28 args): `Q**, K**, V**, Out**`, then `int` `M=q_seq, N=kv_seq,
+  K=head_dim, O=d_v, G0=batch, G1=q_heads, G1kv=kv_heads`, `float scale`, then
+  `q/k/v/out` strides (4 each). Grid/block come from the binary metadata.
+
+With this, standalone validation **passes bit-approximately (`maxAbsDiff ~6e-5`, fp16
+tolerance 5e-2)** across all real decode shapes, including `head_dim = 128`:
+
+```
+GQA B=1 QH=32 KVH=8 QS=1 KVS=128..4096 HD=128  -> PASS (maxAbsDiff ~6e-5)
+```
+
+So **correctness is no longer the blocker. Performance is.**
+
+## Why it is not worth enabling (measured on gfx1151)
+
+### Decode (`q_seq = 1`) is memory-bound; the WMMA kernel wastes the machine
+
+Peak: 59.4 TFLOPS fp16 (WMMA), 256 GB/s LPDDR5x. Decode attention is bandwidth-bound.
+
+| KVS | kernel | achieved BW | vs mem-floor |
+|---|---|---|---|
+| 512 | 49 us | 43 GB/s (17% peak) | 6.0x |
+| 4096 | 395 us | 43 GB/s (17% peak) | 6.0x |
+
+Root cause — the WMMA path always processes a 16-row query tile:
+
+| q_seq | kernel (KVS=1024, HD=128) | us / query |
+|---|---|---|
+| 1 | 100 us | 100 |
+| 16 | 103 us | 6.5 |
+| 64 | 172 us | 2.7 |
+
+`q_seq=1` and `q_seq=16` cost the same: decode uses 1 of 16 rows and throws away 15/16.
+Routing decode GQA here **regresses** vs any decode-tuned GEMV path.
+
+### Prefill is only OK for `head_dim <= 80`; real models (`head_dim = 128`) fall to the fallback tile
+
+| head_dim | q_seq | TFLOP/s | % of 59.4 peak | tile |
+|---|---|---|---|---|
+| 48 | 1024 | 12.4 | 21% | tuned |
+| 80 | 1024 | 13.6 | 23% | tuned |
+| 128 | 512 | 5.0 | 8% | fallback |
+| 128 | 1024 | 2.6 | 4% | fallback |
+
+The tuned GQA tiles only exist for `head_dim <= 80`. Every target model is
+`head_dim = 128` (Llama-3.1, Mistral, Qwen2.5/3, DeepSeek) or 256 (gemma3, Qwen3.5),
+so prefill hits the fallback at **4-8% of peak and degrades with prompt length**.
+Even the best tuned case (~20% of peak) is well under CK/hipBLASLt efficiency (~60%).
+
+## Recommendation
+
+- **Do not enable GQA (or the other ops) for decode or prefill on gfx1151.** No target
+  model benefits.
+- Keep the MHA decode shim gated behind `m==1` (already the case); its win is marginal
+  and no target model even emits plain MHA nodes, so it is effectively dormant.
+- The value delivered here is **enablement, not speed**: the GQA ABI is decoded and a
+  validator exists. If AMD ships (a) a decode-tuned (GEMV / flash-decode) attention
+  blob for gfx1151, or (b) `head_dim = 128` tuned tiles, wiring + validating it is now
+  a ~1-day task instead of weeks of ABI reverse-engineering.

--- a/lib/Runtime/Kernels/CMakeLists.txt
+++ b/lib/Runtime/Kernels/CMakeLists.txt
@@ -71,7 +71,33 @@ set(_kernel_sources
     hip/softmax_kernel.hip
     hip/nonzero_kernel.hip
     hip/strided_copy_kernel.hip
+    hip/mlss_mha_shim.cpp   # AMDMLSS MHA fast-path shim (host C++, links amdmlss)
 )
+
+# ----------------------------------------------------------------------------
+# AMDMLSS dependency (for the MHA fast-path shim). onnx-hipdnn-ep and
+# AMDMLSS-main are siblings in the workspace by default; override with
+# -DAMDMLSS_ROOT / -DAMDMLSS_BUILD as needed.
+# ----------------------------------------------------------------------------
+if(NOT AMDMLSS_ROOT)
+    set(AMDMLSS_ROOT "${CMAKE_SOURCE_DIR}/../AMDMLSS-main" CACHE PATH "AMDMLSS source root")
+endif()
+if(NOT AMDMLSS_BUILD)
+    set(AMDMLSS_BUILD "${AMDMLSS_ROOT}/build/ninja-release" CACHE PATH "AMDMLSS build dir")
+endif()
+find_library(AMDMLSS_LIB NAMES amdmlss PATHS "${AMDMLSS_BUILD}/modules/c_api" NO_DEFAULT_PATH)
+find_file(AMDMLSS_DLL NAMES amdmlss.dll PATHS "${AMDMLSS_BUILD}/modules/c_api" NO_DEFAULT_PATH)
+if(NOT AMDMLSS_LIB OR NOT AMDMLSS_DLL)
+    message(FATAL_ERROR
+        "[custom_kernels] AMDMLSS not found for the MHA shim.\n"
+        "  Looked in: ${AMDMLSS_BUILD}/modules/c_api\n"
+        "  Build it (workspace build_mlss.ps1) or pass -DAMDMLSS_BUILD=<dir>.")
+endif()
+set(AMDMLSS_INCLUDE_DIRS
+    "${AMDMLSS_ROOT}/modules/c_api/include"
+    "${AMDMLSS_ROOT}/modules/common/include"
+    "${AMDMLSS_BUILD}/modules/c_api/include")
+message(STATUS "[custom_kernels] AMDMLSS lib: ${AMDMLSS_LIB}")
 
 # One SHARED target per arch. Each builds a fatbin with that single slice;
 # OFFLOAD_ARCHS narrows the global list to one element so the resulting
@@ -81,6 +107,9 @@ foreach(_arch IN LISTS HIP_ARCHITECTURES)
     hip_add_library(${_target} SHARED ${_kernel_sources}
         INCLUDE_DIRECTORIES
             ${CMAKE_CURRENT_SOURCE_DIR}/include
+            ${AMDMLSS_INCLUDE_DIRS}
+        LINK_LIBRARIES
+            ${AMDMLSS_LIB}
         OFFLOAD_ARCHS
             ${_arch}
     )
@@ -93,6 +122,8 @@ foreach(_arch IN LISTS HIP_ARCHITECTURES)
         LIBRARY DESTINATION lib   # Linux .so co-located with EP .so
         ARCHIVE DESTINATION lib   # Windows import lib; unused by the EP but harmless
     )
+    # Co-locate amdmlss.dll (the shim's runtime dependency) with the EP DLLs.
+    install(FILES "${AMDMLSS_DLL}" DESTINATION bin)
     message(STATUS "[custom_kernels] Adding per-arch SHARED target: ${_target}")
 endforeach()
 

--- a/lib/Runtime/Kernels/hip/mlss_mha_shim.cpp
+++ b/lib/Runtime/Kernels/hip/mlss_mha_shim.cpp
@@ -1,0 +1,277 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ *
+ * AMDMLSS MHA fast-path shim.
+ *
+ * Bridges the EP's MultiHeadAttention runtime to a pre-tuned AMDMLSS gfx1151
+ * CK-WMMA attention code object for small sequences (see the seq-based
+ * dispatch in lib/Runtime/real/multi_head_attention.cpp and the crossover in
+ * AMDMLSS-main/docs/gfx1151_benchmark.md).
+ *
+ * It reuses the AMDMLSS C API to emit the code object, then loads and launches
+ * it with raw HIP on the caller's stream (the same technique validated by the
+ * standalone mlss-bench harness). Per-shape state (module, function, launch
+ * geometry, self-describing arg list, double-pointer slots) is cached.
+ */
+
+#include <hip/hip_runtime.h>
+
+#include <amdmlss/amdmlss_api.h>
+
+#include "hip_custom_kernels.h"
+
+#include <cstdio>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace {
+
+struct ArgDesc {
+  int32_t place;
+  MLSSenum type;
+  bool isPointer;
+  uint32_t indirection;
+  std::string name;
+};
+
+std::vector<ArgDesc> readArgs(const MLSSbinary &bin) {
+  MLSSvoid *raw = nullptr;
+  MLSSsize n = 0;
+  MLSSenum t = 0;
+  std::vector<ArgDesc> out;
+  if (mlssVectorRetrieveData(bin.m_argList, &raw, &n, &t) != MLSS_SUCCESS || !raw)
+    return out;
+  const MLSSarg *a = static_cast<const MLSSarg *>(raw);
+  for (MLSSsize i = 0; i < n; ++i)
+    out.push_back({a[i].m_place, a[i].m_type, static_cast<bool>(a[i].m_isPointer),
+                   a[i].m_indirectionLevel, a[i].m_name ? a[i].m_name : ""});
+  for (size_t i = 1; i < out.size(); ++i) { // insertion sort by place (tiny n)
+    ArgDesc key = out[i];
+    size_t j = i;
+    while (j > 0 && out[j - 1].place > key.place) { out[j] = out[j - 1]; --j; }
+    out[j] = key;
+  }
+  return out;
+}
+
+size_t typeSize(MLSSenum t) {
+  switch (t) {
+  case MLSS_BOOL: case MLSS_INT8: case MLSS_UINT8: return 1;
+  case MLSS_INT16: case MLSS_UINT16: case MLSS_FLOAT16: case MLSS_BFLOAT16: return 2;
+  case MLSS_INT32: case MLSS_UINT32: case MLSS_FLOAT32: case MLSS_ENUM: return 4;
+  case MLSS_INT64: case MLSS_UINT64: case MLSS_FLOAT64: case MLSS_ENUM64: return 8;
+  default: return 4;
+  }
+}
+
+struct PtrArg {
+  std::string name;   // "Q"/"K"/"V"/"output"
+  void *slot = nullptr;      // device slot holding the buffer pointer (indir>=2)
+  size_t kargOff = 0;        // byte offset in karg where this arg's value sits
+  bool indirect = false;     // indirection >= 2 (double pointer)
+  void *lastBuf = nullptr;   // last buffer pointer staged into slot
+};
+struct ScalarArg {
+  std::string name;
+  size_t kargOff = 0;
+  size_t size = 0;
+};
+
+struct Entry {
+  bool usable = false;
+  hipModule_t mod{};
+  hipFunction_t fn{};
+  MLSSdim3 grid{}, blocks{};
+  uint64_t lds = 0;
+  std::vector<uint8_t> karg;        // prebuilt kernarg buffer (layout fixed per shape)
+  std::vector<PtrArg> ptrArgs;      // pointer args + their slots/offsets
+  std::vector<ScalarArg> scalarArgs;
+};
+
+std::mutex g_mu;
+std::unordered_map<uint64_t, Entry> g_cache;
+
+uint64_t shapeKey(int64_t N, int64_t Sq, int64_t Skv, int64_t H) {
+  // pack into 64 bits: N(12) Sq(20) Skv(20) H(12)
+  return (uint64_t(N & 0xFFF) << 52) | (uint64_t(Sq & 0xFFFFF) << 32) |
+         (uint64_t(Skv & 0xFFFFF) << 12) | uint64_t(H & 0xFFF);
+}
+
+// Build/compile/load the AMDMLSS MHA code object for a shape. Caller holds g_mu.
+Entry buildEntry(int64_t B, int64_t N, int64_t Sq, int64_t Skv, int64_t H,
+                 float scale) {
+  Entry e;
+  MLSScontext ctx = 0;
+  MLSSstring op = const_cast<MLSSstring>(MLSS_MHA);
+  if (mlssCreateContext(&ctx, const_cast<MLSSstring>(MLSS_GFXAUTOFIND), op) != MLSS_SUCCESS)
+    return e;
+  uint32_t b = (uint32_t)B, h = (uint32_t)N, qs = (uint32_t)Sq, kvs = (uint32_t)Skv,
+           hd = (uint32_t)H, kv0 = 0, packing = MLSS_ATTR_CONFIG_MHA_PACKING_UNPACKED;
+  MLSSenum dt = MLSS_FLOAT16;
+  auto S = [&](MLSSenum a, const void *v) { mlssSetParameterByEnum(&ctx, op, a, v); };
+  S(MLSS_ATTR_MHA_BATCH, &b); S(MLSS_ATTR_MHA_QSEQ, &qs); S(MLSS_ATTR_MHA_KVSEQ, &kvs);
+  S(MLSS_ATTR_MHA_KDIM, &kv0); S(MLSS_ATTR_MHA_VDIM, &kv0); S(MLSS_ATTR_MHA_SIZEHEADS, &hd);
+  S(MLSS_ATTR_MHA_PACKING, &packing); S(MLSS_ATTR_MHA_HEADCOUNT, &h);
+  S(MLSS_ATTR_MHA_SCALE, &scale); S(MLSS_ATTR_MHA_DATATYPE, &dt);
+
+  MLSSstatus *st = nullptr; MLSSsize nst = 0;
+  if (mlssGetCaps(ctx, &st, &nst) != MLSS_SUCCESS) return e;
+  MLSSbinary *bins = nullptr; MLSSsize nb = 0;
+  if (mlssGetBinaries(ctx, &bins, &nb) != MLSS_SUCCESS || nb == 0) return e;
+
+  // Prefer non-relocatable with the fewest args (contiguous no-strides variant).
+  const MLSSbinary *bin = nullptr; size_t bestArgs = SIZE_MAX;
+  for (MLSSsize i = 0; i < nb; ++i) {
+    if (static_cast<bool>(bins[i].m_isRelocatable)) continue;
+    size_t na = readArgs(bins[i]).size();
+    if (na < bestArgs) { bestArgs = na; bin = &bins[i]; }
+  }
+  if (!bin) return e;
+
+  if (hipModuleLoadData(&e.mod, bin->m_binaries) != hipSuccess) return e;
+  if (hipModuleGetFunction(&e.fn, e.mod, bin->m_pKernelName) != hipSuccess) {
+    hipModuleUnload(e.mod); return e;
+  }
+  e.grid = bin->m_grid; e.blocks = bin->m_blocks; e.lds = bin->m_sharedMemInBytes;
+
+  // Prebuild the kernarg buffer once. Pointer args store the device *slot*
+  // address (stable); the buffer pointer is staged into the slot per-call
+  // (async, only when it changes). Scalar values are patched per-call (host).
+  auto align = [&](size_t a) { while (e.karg.size() % a) e.karg.push_back(0); };
+  for (auto &a : readArgs(*bin)) {
+    if (a.isPointer) {
+      void *slot = nullptr;
+      if (a.indirection >= 2) {
+        if (hipMalloc(&slot, sizeof(void *)) != hipSuccess) { hipModuleUnload(e.mod); return e; }
+      }
+      align(sizeof(void *));
+      PtrArg pa; pa.name = a.name; pa.slot = slot; pa.kargOff = e.karg.size();
+      pa.indirect = (a.indirection >= 2);
+      e.ptrArgs.push_back(pa);
+      e.karg.resize(e.karg.size() + sizeof(void *), 0);
+      // For indirect args the kernarg holds the (stable) slot address.
+      if (slot) std::memcpy(&e.karg[pa.kargOff], &slot, sizeof(void *));
+    } else {
+      size_t sz = typeSize(a.type);
+      align(sz);
+      ScalarArg sa; sa.name = a.name; sa.kargOff = e.karg.size(); sa.size = sz;
+      e.scalarArgs.push_back(sa);
+      e.karg.resize(e.karg.size() + sz, 0);
+    }
+  }
+  while (e.karg.size() % 8) e.karg.push_back(0);
+  e.usable = true;
+  return e;
+}
+
+} // namespace
+
+extern "C" HIP_KERNEL_API long long hipdnn_ep_amdmlss_max_seq(void) {
+  const char *env = std::getenv("HIPDNN_MLSS_MAX_SEQ");
+  if (env && *env) {
+    char *end = nullptr;
+    long long v = std::strtoll(env, &end, 10);
+    if (end != env && v >= 0) return v;
+  }
+  // Default OFF (0) for the PREFILL gate: in-EP the AMDMLSS "fallback" kernel is
+  // latency-bound for multi-token prefill (only B*H workgroups) and loses to the
+  // EP's sequence-tiled path. Opt in with HIPDNN_MLSS_MAX_SEQ=<n> to route
+  // prefill with Sq,Skv <= n. Decode (Sq==1) is gated separately below.
+  return 0;
+}
+
+namespace {
+// Decode gate: route single-query (Sq==1) attention when Skv >= this value.
+// Decode is where the compact per-head AMDMLSS kernel wins in-EP (the EP's
+// decode path scales worse with context). Default 512 (measured crossover on
+// gfx1151); set HIPDNN_MLSS_DECODE_MIN_KV=0 to disable decode routing.
+long long decodeMinKv() {
+  const char *env = std::getenv("HIPDNN_MLSS_DECODE_MIN_KV");
+  if (env && *env) {
+    char *end = nullptr;
+    long long v = std::strtoll(env, &end, 10);
+    if (end != env && v >= 0) return v;
+  }
+  return 512;
+}
+} // namespace
+
+extern "C" HIP_KERNEL_API int
+hipdnn_ep_amdmlss_mha(void *stream, const void *q, const void *k, const void *v,
+                      void *out, long long batch, long long num_heads,
+                      long long seq_q, long long seq_kv, long long head_dim,
+                      float scale) {
+  // Two independent gates: prefill (Sq,Skv <= max_seq; default off) and decode
+  // (Sq==1 && Skv >= decode_min_kv; default on for Skv>=512, the measured win).
+  const long long maxSeq = hipdnn_ep_amdmlss_max_seq();
+  const long long dmk = decodeMinKv();
+  const bool prefillOk = (maxSeq > 0 && seq_q <= maxSeq && seq_kv <= maxSeq);
+  const bool decodeOk = (dmk > 0 && seq_q == 1 && seq_kv >= dmk);
+  if (!prefillOk && !decodeOk) return 1; // let the EP handle it
+
+  std::lock_guard<std::mutex> lock(g_mu);
+  uint64_t key = shapeKey(num_heads, seq_q, seq_kv, head_dim);
+  auto it = g_cache.find(key);
+  if (it == g_cache.end()) {
+    Entry e = buildEntry(batch, num_heads, seq_q, seq_kv, head_dim, scale);
+    it = g_cache.emplace(key, std::move(e)).first;
+  }
+  Entry &e = it->second;
+  if (!e.usable) return 1;
+  hipStream_t hstream = reinterpret_cast<hipStream_t>(stream);
+
+  // Patch scalar values into the prebuilt kernarg (host-side, cheap). Values
+  // are fixed per shape, but re-patching keeps correctness if scale varies.
+  auto patchScalar = [&](const char *n, int32_t val) {
+    for (auto &s : e.scalarArgs) if (s.name == n) { std::memcpy(&e.karg[s.kargOff], &val, (s.size < 4 ? s.size : 4)); }
+  };
+  patchScalar("batch_size", (int32_t)batch);
+  patchScalar("q_sequence_length", (int32_t)seq_q);
+  patchScalar("kv_sequence_length", (int32_t)seq_kv);
+  patchScalar("sequence_length", (int32_t)seq_q);
+  patchScalar("head_num", (int32_t)num_heads);
+  patchScalar("head_dim", (int32_t)head_dim);
+  for (auto &s : e.scalarArgs) if (s.name == "scale") std::memcpy(&e.karg[s.kargOff], &scale, 4);
+
+  // Stage buffer pointers. For double-pointer args write the buffer ptr into
+  // the device slot (async, on the EP stream) only when it changed; for direct
+  // pointers patch the kernarg bytes. No synchronous copies on the hot path.
+  for (auto &pa : e.ptrArgs) {
+    void *buf = nullptr;
+    if (pa.name == "Q") buf = const_cast<void *>(q);
+    else if (pa.name == "K") buf = const_cast<void *>(k);
+    else if (pa.name == "V") buf = const_cast<void *>(v);
+    else if (pa.name == "output") buf = out;
+    else return 1;
+    if (pa.indirect) {
+      if (buf != pa.lastBuf) {
+        if (hipMemcpyAsync(pa.slot, &buf, sizeof(void *), hipMemcpyHostToDevice, hstream) != hipSuccess)
+          return 1;
+        pa.lastBuf = buf;
+      }
+      // kernarg already holds the stable slot address.
+    } else {
+      std::memcpy(&e.karg[pa.kargOff], &buf, sizeof(void *));
+    }
+  }
+
+  size_t kargSize = e.karg.size();
+  void *config[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER, e.karg.data(),
+                    HIP_LAUNCH_PARAM_BUFFER_SIZE, &kargSize,
+                    HIP_LAUNCH_PARAM_END};
+  hipError_t le = hipModuleLaunchKernel(
+      e.fn, e.grid.m_x, e.grid.m_y, e.grid.m_z, e.blocks.m_x, e.blocks.m_y,
+      e.blocks.m_z, (unsigned)e.lds, hstream,
+      nullptr, reinterpret_cast<void **>(&config));
+  if (le != hipSuccess) {
+    fprintf(stderr, "[mlss_mha_shim] launch failed: %s\n", hipGetErrorString(le));
+    return 1;
+  }
+  return 0;
+}

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -1826,6 +1826,28 @@ HIP_KERNEL_API int hip_causal_conv_prefill(
 HIP_KERNEL_API int hip_gemm_wmma_fp16(void* stream, const void* A, const void* B,
                        void* C, int M, int K, int N);
 
+/* =========================================================================
+ * AMDMLSS MHA fast path (sequence-length-based dispatch)
+ * =========================================================================
+ *
+ * Routes com.microsoft.MultiHeadAttention to a pre-tuned AMDMLSS gfx1151 CK
+ * WMMA attention kernel for small sequences, where it outperforms the EP's
+ * hipBLASLt pipeline (measured crossover ~seq 1024 on gfx1151; see
+ * AMDMLSS-main/docs/gfx1151_benchmark.md). Implemented in
+ * lib/Runtime/Kernels/hip/mlss_mha_shim.cpp; links the AMDMLSS C API and
+ * launches the emitted code object on the caller's stream.
+ *
+ * Q/K/V/out are fp16, contiguous [B, S, N*H] (== BSHD), unidirectional==0.
+ * Returns 0 on success (output written); non-zero => caller must fall back
+ * to the existing path (unsupported shape/config, threshold exceeded, or a
+ * launch error).
+ */
+HIP_KERNEL_API long long hipdnn_ep_amdmlss_max_seq(void);
+HIP_KERNEL_API int hipdnn_ep_amdmlss_mha(
+    void* stream, const void* q, const void* k, const void* v, void* out,
+    long long batch, long long num_heads, long long seq_q, long long seq_kv,
+    long long head_dim, float scale);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/Runtime/real/multi_head_attention.cpp
+++ b/lib/Runtime/real/multi_head_attention.cpp
@@ -464,6 +464,27 @@ extern "C" int wrap_multi_head_attention(
     fprintf(stderr, "[multi_head_attention] ERROR: failed to get HIP stream\n");
     return -1;
   }
+
+  // ---- AMDMLSS fast path ----
+  // The validation guards above already restrict execution to the fp16
+  // Q_K_V_BSNH subset the AMDMLSS gfx1151 attention kernel supports, and the
+  // query layout [B,Sq,N*H] is exactly the contiguous BSHD it expects (no
+  // transpose). Only non-causal attention is offered to the shim, which applies
+  // its own gates: decode (Sq==1 && Skv>=HIPDNN_MLSS_DECODE_MIN_KV, default on)
+  // -- where the compact per-head kernel beats the EP's decode path -- and an
+  // opt-in prefill gate (HIPDNN_MLSS_MAX_SEQ, default off). A non-zero return
+  // (not applicable / launch error) falls through to the hipBLASLt pipeline.
+  // See AMDMLSS-main/docs/gfx1151_benchmark.md.
+  if (unidirectional == 0) {
+    if (hipdnn_ep_amdmlss_mha(reinterpret_cast<void *>(stream), query, key, value,
+                              output, B, N, Sq, Skv, H, scale) == 0) {
+      RUNTIME_DEBUG_LOG("[multi_head_attention] served by AMDMLSS fast path "
+                        "(Sq=%lld Skv=%lld)\n",
+                        (long long)Sq, (long long)Skv);
+      return 0;
+    }
+  }
+
   hipblasLtHandle_t ltHandle = reinterpret_cast<hipblasLtHandle_t>(
       hipdnn_ep_state_get_hipblas_handle(state));
   if (!ltHandle) {


### PR DESCRIPTION
## 1. Candidates from MLSS (gfx1151)
- **GQA** (CK WMMA fp16) — the only real candidate; every target model uses it.
- **MHA** — dormant (our models export GroupQueryAttention, not MHA).
- MVN / Conv1x1 / Conv-dilated — vision ops, absent from transformer graphs.
- RMSNorm / SiLU / GEMMGEMM / ConvMxN / GEMM / QGEMM — not on gfx1151 (RDNA4-only or scaffold).

## 2. Where it beats onnx-hipdnn-ep
Only in the WMMA comfort zone: **prefill, head_dim ≤ 80** (~12–14 TFLOP/s), plus a marginal ~1.2–1.3× MHA decode microbench.

## 3. Why it's still zero porting value
Our models are **GQA decode, head_dim 128/256** — outside that zone:
- **Decode starves WMMA:** always a 16-row query tile, so q_seq=1 uses 1/16 (q_seq=1 ≈ q_seq=16 ≈ 100µs). ~17% of peak BW, 6× over the memory floor → **regresses** vs our decode path.
- **head_dim 128 misses the tuned tiles** (tuned only ≤80) → fallback at 4–8% of peak → prefill is a no-op too.

**Net: decode regresses, prefill no-op → zero value today.** Correctness isn't the blocker — GQA ABI is decoded and validates at ~6e-5 (see `docs/amdmlss_gfx1151_assessment.md`). Revisit only if AMD ships a decode-tuned or head_dim-128 blob for gfx1151.
