### PR TITLE
feat(dialect): add empty hipsr dialect

### DIFF
--- a/include/hip/Dialect/CMakeLists.txt
+++ b/include/hip/Dialect/CMakeLists.txt
@@ -5,3 +5,4 @@
 
 add_subdirectory(IR)
 add_subdirectory(Transforms)
+add_subdirectory(Hipsr)

--- a/include/hip/Dialect/Hipsr/CMakeLists.txt
+++ b/include/hip/Dialect/Hipsr/CMakeLists.txt
@@ -4,5 +4,3 @@
 ##
 
 add_subdirectory(IR)
-add_subdirectory(Transforms)
-add_subdirectory(Hipsr)

--- a/include/hip/Dialect/Hipsr/IR/CMakeLists.txt
+++ b/include/hip/Dialect/Hipsr/IR/CMakeLists.txt
@@ -1,0 +1,9 @@
+##
+# ** Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# ** Licensed under the MIT License.
+##
+
+set(LLVM_TARGET_DEFINITIONS HipsrDialect.td)
+mlir_tablegen(HipsrDialect.h.inc -gen-dialect-decls -dialect=hipsr)
+mlir_tablegen(HipsrDialect.cpp.inc -gen-dialect-defs -dialect=hipsr)
+add_public_tablegen_target(HipsrDialectIncGen)

--- a/include/hip/Dialect/Hipsr/IR/HipsrDialect.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrDialect.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#ifndef HIPSR_DIALECT_H
+#define HIPSR_DIALECT_H
+
+#include "mlir/IR/Dialect.h"
+
+#include "hip/Dialect/Hipsr/IR/HipsrDialect.h.inc"
+
+#endif // HIPSR_DIALECT_H

--- a/include/hip/Dialect/Hipsr/IR/HipsrDialect.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrDialect.td
@@ -6,7 +6,6 @@
 #ifndef HIPSR_DIALECT
 #define HIPSR_DIALECT
 
-include "mlir/IR/OpBase.td"
 include "mlir/IR/DialectBase.td"
 
 def Hipsr_Dialect : Dialect {

--- a/include/hip/Dialect/Hipsr/IR/HipsrDialect.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrDialect.td
@@ -1,0 +1,22 @@
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+
+#ifndef HIPSR_DIALECT
+#define HIPSR_DIALECT
+
+include "mlir/IR/OpBase.td"
+include "mlir/IR/DialectBase.td"
+
+def Hipsr_Dialect : Dialect {
+  let name = "hipsr";
+  let summary = "Declarative AMD GPU compute dialect with first-class shape regions";
+  let description = [{
+    An AMD GPU compute dialect that represents tensor computations
+    declaratively and models dynamic shapes as first-class shape regions.
+  }];
+  let cppNamespace = "::mlir::hipsr";
+}
+
+#endif // HIPSR_DIALECT

--- a/lib/Dialect/Hipsr/CMakeLists.txt
+++ b/lib/Dialect/Hipsr/CMakeLists.txt
@@ -4,5 +4,3 @@
 ##
 
 add_subdirectory(IR)
-add_subdirectory(Transforms)
-add_subdirectory(Hipsr)

--- a/lib/Dialect/Hipsr/IR/CMakeLists.txt
+++ b/lib/Dialect/Hipsr/IR/CMakeLists.txt
@@ -1,0 +1,17 @@
+##
+# ** Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# ** Licensed under the MIT License.
+##
+
+add_library(HipsrDialectIR STATIC
+  HipsrDialect.cpp
+)
+
+add_dependencies(HipsrDialectIR
+  HipsrDialectIncGen
+)
+
+target_link_libraries(HipsrDialectIR PUBLIC
+  MLIRIR
+  MLIRSupport
+)

--- a/lib/Dialect/Hipsr/IR/HipsrDialect.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrDialect.cpp
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "hip/Dialect/Hipsr/IR/HipsrDialect.h"
+
+using namespace mlir;
+using namespace mlir::hipsr;
+
+#include "hip/Dialect/Hipsr/IR/HipsrDialect.cpp.inc"
+
+void HipsrDialect::initialize() {}


### PR DESCRIPTION
## Summary

Add a new, empty MLIR dialect called `hipsr` ("hip shape region") and wire it into the build. No ops, types, attributes, or interfaces yet, and it isn't registered or used anywhere.

This is the first small step toward a dialect that handles tensor shapes (including dynamic shapes) as first-class regions. Later PRs add ops and types one at a time.

## Why

Starting a dedicated dialect for shape regions lets us build it up in small, reviewable pieces. Keeping this first PR empty makes it easy to review and sets up the folder and build structure for the ops that follow.

Folder layout follows the standard MLIR/IREE style (a per-dialect `IR/` subfolder; `Transforms/` and `Conversion/` to come later), so the dialect can grow without moving files around. Not registering it yet is deliberate — this PR changes no behavior.

## What

1. **Dialect** in `include/hip/Dialect/Hipsr/IR/HipsrDialect.td` — name `hipsr`, namespace `::mlir::hipsr`.
2. **Header + source**: `HipsrDialect.h` (pulls in the generated `.h.inc`) and an empty `HipsrDialect::initialize()` in `HipsrDialect.cpp`.
3. **Build files**: TableGen target `HipsrDialectIncGen` (include side) and static lib `HipsrDialectIR` linking `MLIRIR`/`MLIRSupport` (lib side), plus small wrappers adding the `IR` subfolder.
4. **Hook-up**: one `add_subdirectory(Hipsr)` line in `include/hip/Dialect/CMakeLists.txt` and `lib/Dialect/CMakeLists.txt`.

## Test plan

- Full clean build (Ninja + sccache) passes, including install and the LIT smoke test.
- Generated `HipsrDialect.h.inc` / `HipsrDialect.cpp.inc` and `HipsrDialectIR.lib` are produced.
- Generated header defines `class HipsrDialect : public ::mlir::Dialect` in `namespace mlir::hipsr`, name `"hipsr"`.

## Notes for reviewers

- Small and self-contained; no runtime or pass changes.
- Next PRs: register the dialect, then add shape ops/types incrementally.
- All new files carry the MIT license header.
