### PR TITLE
Extract constant externalization into a standalone `hip-externalize-constants` pass

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,7 +187,7 @@ ONNX (.onnx) → [onnx-to-hip-pipeline] → HIP dialect → [bufferize + optimiz
 
 Key passes in order:
 1. `hip-add-context-arg` — inject `!hip.context` argument
-2. `convert-onnx-to-hip` — ONNX ops to HIP dialect ops (externalizes large constants to `.constants.bin`)
+2. `convert-onnx-to-hip` — ONNX ops to HIP dialect ops; `onnx.Constant` → neutral `hip.constant` carriers (no externalization here). `hip-externalize-constants` runs immediately after (past the `AfterConvertOnnxToHip` plugin slot, so plugin-emitted `hip.constant` ops are serialized too): large → extern `memref.global` + `hip.external_data` → `.constants.bin`, small → inline `arith.constant`; stamps `hipdnn.constant_{sizes,offsets}`
 3. `one-shot-bufferize` — tensor semantics to memref (buffer) semantics
 4. `buffer-deallocation` + `hip-optimize-memrefs` — liveness-based buffer reuse
 5. `hip-pool-allocs` — pack all allocations into a single grow-on-demand GPU buffer

--- a/docs/design/constant-handling-design.md
+++ b/docs/design/constant-handling-design.md
@@ -95,7 +95,12 @@ Runtime  (hip-compiler.dll NOT loaded)                                          
                                                                               EP tar cache ◀┘
 ```
 
-**Compile time**: the `OnnxToHip` pass calls
+**Compile time**: `convert-onnx-to-hip` lowers each `onnx.Constant` to a
+neutral `hip.constant` carrier (holding either an inline dense `value` or an
+ORT external-data `location`/`offset`/`size` reference). The standalone
+`hip-externalize-constants` pass — scheduled just after the
+`AfterConvertOnnxToHip` plugin slot, so it also serializes any `hip.constant`
+a downstream plugin emitted for its own weights — then calls
 `fs->create_writer(constants_filename)` to stream raw constant bytes into
 storage. `constants_filename` is the configured constants file
 (default: `constants.bin`, see [compilation-options.md](compilation-options.md)).
@@ -138,7 +143,9 @@ the buffer after a single bulk read.
         │ globalIndex (0,1,2,…)
         ▼
   ┌─────────────────────────────────────────┐  compile time
-  │ Step 1: OnnxToHip                       │
+  │ Step 1a: convert-onnx-to-hip            │
+  │  → hip.constant carriers                │
+  │ Step 1b: hip-externalize-constants      │
   │  → constants file (via fs)              │
   │  → hipdnn.constant_sizes                │
   │  → hipdnn.constant_offsets              │
@@ -165,13 +172,24 @@ the buffer after a single bulk read.
 
 `model_metadata` schema: [compiler-runtime-contract.md](compiler-runtime-contract.md).
 
-### Step 1 — Discover constants and assign index
+### Step 1 — Lower to `hip.constant`, then externalize
 
-The `OnnxToHip` pass (`lib/Conversion/OnnxToHip/OnnxToHip.cpp`) walks the ONNX
-functions, assigns each `onnx.Constant` op a sequential `globalIndex`
-(0, 1, 2, …), and computes its byte size. Layout order in the constants file
-may differ from index order (see [constants.bin Format](#constants.bin-format)
-above), but `hipdnn.constant_offsets` preserves the mapping.
+`convert-onnx-to-hip` (`lib/Conversion/OnnxToHip/OnnxToHip.cpp`) lowers each
+`onnx.Constant` to a neutral `hip.constant` carrier op (defined in
+`include/hip/Dialect/IR/HipOps.td`). A carrier holds either an inline dense
+`value` or an ORT external-data reference (`location`/`offset`/`size`) and is
+dialect-agnostic, so a downstream plugin can emit `hip.constant` for its own
+weights and have them serialized on the same footing as in-tree constants.
+
+`hip-externalize-constants`
+(`lib/Dialect/Transforms/ExternalizeConstants.cpp`) — scheduled just after the
+`AfterConvertOnnxToHip` plugin slot — walks every `hip.constant`, assigns each
+a sequential `globalIndex` (0, 1, 2, …), and computes its byte size. Constants
+at or above `externalize-min-num-elements` become an extern `memref.global`
+carrying `hip.external_data` (index/offset/size); smaller constants are inlined
+as `arith.constant`. Layout order in the constants file may differ from index
+order (see [constants.bin Format](#constants.bin-format) above), but
+`hipdnn.constant_offsets` preserves the mapping.
 
 The pass then writes raw constant bytes to the configured constants file via
 `fs`, and emits two module attributes:
@@ -181,7 +199,8 @@ The pass then writes raw constant bytes to the configured constants file via
   constants file, indexed by `globalIndex`.
 
 The constant count is derived from `hipdnn.constant_sizes`; no separate count
-attribute is emitted.
+attribute is emitted. (`hip-resolve-extern-constants` later rewrites each
+extern `memref.global` into a `memref.view` over the runtime constants blob.)
 
 ### Step 2 — Code generation: `GenerateInterface` pass
 

--- a/docs/pipeline_pass_menu.md
+++ b/docs/pipeline_pass_menu.md
@@ -114,7 +114,8 @@ Options use MLIR's pipeline-option syntax:
 | `onnx-loop-outline` | module | Outline `onnx.Loop` bodies into separate `func.func` ops. |
 | `hip-infer-loop-body-shapes` | module | Rank-establish unranked tensors inside outlined loop bodies. |
 | `outline-onnx-to-hipdnn` | module | Outline subgraphs targeted at hipDNN graph compilation. |
-| `convert-onnx-to-hip` | module | Pattern-match ONNX ops by name → HIP dialect; externalize large constants. |
+| `convert-onnx-to-hip` | module | Pattern-match ONNX ops by name → HIP dialect; `onnx.Constant` → neutral `hip.constant` carrier (externalization deferred to `hip-externalize-constants`). |
+| `hip-externalize-constants` | module | Serialize `hip.constant` carriers (in-tree + plugin-emitted) to `constants.bin`: large → extern `memref.global` + `hip.external_data`, small → inline `arith.constant`; stamp `hipdnn.constant_{sizes,offsets}`. |
 | `hip-infer-shapes` | module | Refine `?` dims on HIP DPS result types via `ReifyRankedShapedTypeOpInterface`. |
 | `hip-split-duplicate-dps-inits` | func.func | De-alias DPS init operands that CSE merged onto one `tensor.empty`, so an op that reads back its own outputs (e.g. `hip.gqa` present K/V) does not share a buffer (pre-bufferize). |
 | `hip-resolve-tensor-dims` | func.func | Fold `tensor.dim` of reshape chains into root-dim arithmetic (pre-bufferize). |
@@ -181,6 +182,7 @@ ONNX → HIP  (buildOnnxToHipPipeline)
   [outline-onnx-to-hipdnn + compile-hipdnn-graphs]   (handle overload only)
   convert-onnx-to-hip
   «slot: AfterConvertOnnxToHip»
+  hip-externalize-constants
   hip-infer-shapes
   canonicalize ; cse
   func.func(hip-split-duplicate-dps-inits)

--- a/include/hip/Conversion/OnnxToHip/Passes.h
+++ b/include/hip/Conversion/OnnxToHip/Passes.h
@@ -16,17 +16,10 @@ class FileSystem;
 namespace mlir {
 namespace hip {
 
-/// Creates a pass that converts ONNX operations to HIP dialect.
-/// Uses default options (constants.bin, no externalization).
+/// Creates a pass that converts ONNX operations to HIP dialect. Constants are
+/// lowered to neutral hip.constant carriers; externalization to constants.bin
+/// is done by the standalone --hip-externalize-constants pass.
 std::unique_ptr<Pass> createConvertOnnxToHipPass();
-
-/// Creates a pass with an external FileSystem for constant storage.
-/// When \p fs is non-null, externalized constants are written via \p fs
-/// instead of a DiskFileSystem rooted at the output directory.
-std::unique_ptr<Pass> createConvertOnnxToHipPass(
-    morphizen::FileSystem *fs,
-    int64_t minNumElements = kDefaultExternalizeMinNumElements,
-    bool skipConstantData = false);
 
 /// Creates a pass that outlines each onnx.Loop body into a separate
 /// func.func and rewrites the loop into a hip.loop op that points at it.

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -464,6 +464,60 @@ def Hip_GetConstantOp : Hip_Op<"get_constant", [
   }];
 }
 
+def Hip_ConstantOp : Hip_Op<"constant", [Pure]> {
+  let summary = "Neutral large-constant carrier, externalized by "
+                "hip-externalize-constants";
+  let description = [{
+    Carries a constant that MAY be externalized to the constants.bin sidecar.
+    Emitted by convert-onnx-to-hip (from onnx.Constant) and by downstream
+    plugins for their own weight tensors, so a single standalone pass
+    (hip-externalize-constants) serializes every constant uniformly, regardless
+    of the producing dialect. Mirrors the constant-carrier duality of a
+    frontend constant op: it holds either an inline `value` (ElementsAttr) or an
+    external-data reference (`location`/`offset`/`size`).
+
+    No folder is defined on purpose: the op must survive canonicalize/cse
+    between convert-onnx-to-hip and the externalize pass so the latter can see
+    and serialize it.
+
+    Before (hip-externalize-constants input):
+      %w = hip.constant {value = dense<...> : tensor<64x64xf16>}
+             : tensor<64x64xf16>
+    After (large -> externalized):
+      memref.global "private" @hip_ext_constant_0 : memref<64x64xf16>
+        {hip.external_data = {index = 0, offset = 0, size = 8192}}
+      %g = memref.get_global @hip_ext_constant_0 : memref<64x64xf16>
+      %w = bufferization.to_tensor %g restrict
+             : memref<64x64xf16> to tensor<64x64xf16>
+    (small -> arith.constant)
+  }];
+
+  let arguments = (ins
+    OptionalAttr<ElementsAttr>:$value,
+    OptionalAttr<StrAttr>:$location,
+    OptionalAttr<I64Attr>:$offset,
+    OptionalAttr<I64Attr>:$size
+  );
+  let results = (outs AnyRankedTensor:$result);
+
+  let assemblyFormat = [{
+    attr-dict `:` type($result)
+  }];
+
+  let builders = [
+    // Result-type-only builder: producers create the carrier, then attach
+    // exactly one of `value` or `location` (+ offset/size) via setAttr.
+    OpBuilder<(ins "::mlir::Type":$result), [{
+      build($_builder, $_state, result, /*value=*/nullptr, /*location=*/nullptr,
+            /*offset=*/nullptr, /*size=*/nullptr);
+    }]>
+  ];
+
+  // Enforce the carrier duality: exactly one of the inline `value` or the
+  // external-data `location` must be present.
+  let hasVerifier = 1;
+}
+
 // ===== Region ops (structural grouping, no runtime) =========================
 
 def Hip_MiopenGraphOp : Hip_Op<"miopen.graph", [SingleBlock, NoTerminator]> {

--- a/include/hip/Dialect/Transforms/ConstantMetadata.h
+++ b/include/hip/Dialect/Transforms/ConstantMetadata.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+//===- ConstantMetadata.h - Externalized-constant metadata contract ------===//
+//
+// Single source of truth for the per-constant metadata that
+// hip-externalize-constants (producer) hands to generate-interface (consumer).
+//
+// The metadata rides the module as one attribute:
+//
+//   hipdnn.constants = [
+//     { offset = 0,  size = 64, kind = 0 },                       // full
+//     sidecar { offset = 64, size = 32, kind = 1, splat_value = ..,       //
+//     splat
+//       splat_elem_size = 4 },
+//     { offset = 0,  size = 16, kind = 2, file_path = "..",       // file-ref
+//       file_offset = 1048576 },
+//     { offset = 0,  size = 96, kind = 3, sidecar_offset = 128 }  // mem-addr
+//   ] : one DictionaryAttr per externalized constant, in constant-index order.
+//
+// This replaces the earlier set of index-synced parallel `DenseI64ArrayAttr`s
+// (constant_sizes/offsets/source_kinds/splat_*/file_*/sidecar_offset): each
+// constant's descriptor is now a single self-describing entry, so producer and
+// consumer cannot drift out of index lockstep and new fields are additive keys
+// rather than a new parallel array.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HIP_DIALECT_TRANSFORMS_CONSTANTMETADATA_H
+#define HIP_DIALECT_TRANSFORMS_CONSTANTMETADATA_H
+
+#include "llvm/ADT/StringRef.h"
+
+#include <cstdint>
+
+namespace mlir {
+namespace hip {
+
+/// How an externalized constant's bytes are obtained at model load. Shared by
+/// the producer (hip-externalize-constants) and the consumer
+/// (generate-interface). The integer values are ABI -- generate-interface maps
+/// them into the flatbuffer `ConstantInfo.source` union -- so do NOT renumber.
+enum class ConstantSourceKind : int32_t {
+  None = 0,    ///< bytes live in the full sidecar at `offset`
+  Splat = 1,   ///< tile the single element (`splat_value` / `splat_elem_size`)
+  FileRef = 2, ///< fread from (`file_path`, `file_offset`) at upload time
+  Sidecar = 3, ///< mem-addr bytes packed into the partial sidecar
+               ///< (`sidecar_offset`)
+};
+
+/// Attribute + dictionary-key names for the `hipdnn.constants` metadata.
+/// Sharing them keeps the encode (externalize) and decode (generate-interface)
+/// sides in lockstep. `offset`/`size`/`kind` are always present; the remaining
+/// keys appear only on entries of the matching kind.
+namespace constant_meta {
+inline constexpr llvm::StringLiteral kConstantsAttr = "hipdnn.constants";
+inline constexpr llvm::StringLiteral kConstantsFileAttr = "hip.constants_file";
+inline constexpr llvm::StringLiteral kOffset = "offset";
+inline constexpr llvm::StringLiteral kSize = "size";
+inline constexpr llvm::StringLiteral kKind = "kind";
+inline constexpr llvm::StringLiteral kSplatValue = "splat_value";
+inline constexpr llvm::StringLiteral kSplatElemSize = "splat_elem_size";
+inline constexpr llvm::StringLiteral kFilePath = "file_path";
+inline constexpr llvm::StringLiteral kFileOffset = "file_offset";
+inline constexpr llvm::StringLiteral kSidecarOffset = "sidecar_offset";
+} // namespace constant_meta
+
+} // namespace hip
+} // namespace mlir
+
+#endif // HIP_DIALECT_TRANSFORMS_CONSTANTMETADATA_H

--- a/include/hip/Dialect/Transforms/Passes.h
+++ b/include/hip/Dialect/Transforms/Passes.h
@@ -9,6 +9,10 @@
 #include <memory>
 #include <string>
 
+namespace morphizen {
+class FileSystem;
+} // namespace morphizen
+
 namespace mlir {
 namespace hip {
 
@@ -16,6 +20,15 @@ struct CompilationOptionsT;
 
 #define GEN_PASS_DECL
 #include "hip/Dialect/Transforms/Passes.h.inc"
+
+/// Create hip-externalize-constants with an EP-supplied FileSystem (writes the
+/// constants.bin into the EPContext tar) + the fs-mode threshold and
+/// skip-constant-data flag. The no-arg / options overloads (from GEN_PASS_DECL)
+/// use a DiskFileSystem rooted at externalize-output-dir.
+std::unique_ptr<mlir::Pass>
+createExternalizeConstantsPass(morphizen::FileSystem *fs,
+                               int64_t minNumElements,
+                               bool skipConstantData = false);
 
 #define GEN_PASS_REGISTRATION
 #include "hip/Dialect/Transforms/Passes.h.inc"

--- a/include/hip/Dialect/Transforms/Passes.td
+++ b/include/hip/Dialect/Transforms/Passes.td
@@ -93,14 +93,6 @@ def ConvertOnnxToHipPass : Pass<"convert-onnx-to-hip", "mlir::ModuleOp"> {
       pattern (krnl.global + omMMapBinaryFile) adapted to standard MLIR ops.
       Splat constants are always kept inline regardless of size.
   }];
-  let options = [
-    Option<"externalizeOutputDir", "externalize-output-dir", "std::string",
-           /*default=*/"\"\"",
-           "Directory for sidecar .constants.bin/.json files (empty = cwd)">,
-    Option<"externalizeMinNumElements", "externalize-min-num-elements",
-           "int64_t", /*default=*/"0",
-           "Minimum number of tensor elements to externalize (0 = disabled)">
-  ];
   let dependentDialects = [
     "mlir::hip::HipDialect",
     "mlir::arith::ArithDialect",
@@ -760,6 +752,55 @@ def ResolveExternConstantsPass
     "mlir::arith::ArithDialect",
     "mlir::func::FuncDialect",
     "mlir::memref::MemRefDialect"
+  ];
+}
+
+def ExternalizeConstantsPass
+    : Pass<"hip-externalize-constants", "mlir::ModuleOp"> {
+  let summary = "Externalize hip.constant carriers to the constants.bin sidecar";
+  let description = [{
+    Standalone, dialect-agnostic constant externalization. Walks every
+    `hip.constant` op -- whether emitted by `convert-onnx-to-hip` (from
+    `onnx.Constant`) or contributed by a downstream plugin for its own weights
+    -- and, at/above the element-count threshold, replaces it with an extern
+    `memref.global` + `hip.external_data` + `bufferization.to_tensor` bridge
+    (the exact contract `hip-resolve-extern-constants` consumes), stamping
+    `hip.constants_file` + `hipdnn.constant_{sizes,offsets}` on the module.
+    Constants below the threshold fold to `arith.constant`.
+
+    Before:
+      %w = hip.constant {value = dense<...> : tensor<64x64xf16>}
+             : tensor<64x64xf16>
+    After (>= threshold):
+      memref.global "private" @hip_ext_constant_0 : memref<64x64xf16>
+        {hip.external_data = {index = 0 : i64, offset = 0 : i64,
+                              size = 8192 : i64}}
+      %g = memref.get_global @hip_ext_constant_0 : memref<64x64xf16>
+      %w = bufferization.to_tensor %g restrict
+             : memref<64x64xf16> to tensor<64x64xf16>
+
+    Must run after the `AfterConvertOnnxToHip` plugin slot (so plugin-emitted
+    `hip.constant`s are included) and before `one-shot-bufferize` and
+    `generate-interface`.
+  }];
+  let options = [
+    Option<"externalizeMinNumElements", "externalize-min-num-elements",
+           "int64_t", /*default=*/"1",
+           "Minimum number of tensor elements to externalize (0 = disabled)">,
+    Option<"externalizeOutputDir", "externalize-output-dir", "std::string",
+           /*default=*/"\"\"",
+           "Directory for sidecar .constants.bin/.json files (empty = cwd)">,
+    Option<"skipConstantData", "skip-constant-data", "bool",
+           /*default=*/"false",
+           "Skip writing constant data to constants.bin (metadata only). Used "
+           "for the ORT EP live-compile path.">
+  ];
+  let dependentDialects = [
+    "mlir::hip::HipDialect",
+    "mlir::arith::ArithDialect",
+    "mlir::func::FuncDialect",
+    "mlir::memref::MemRefDialect",
+    "mlir::bufferization::BufferizationDialect"
   ];
 }
 

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -47,354 +47,27 @@ namespace hip {
 namespace {
 
 //===----------------------------------------------------------------------===//
-// Constant externalization helpers
+// Constant carrier lowering
 //===----------------------------------------------------------------------===//
+//
+// onnx.Constant is lowered to a neutral hip.constant carrier (below). The
+// externalization core (state, source-kind helpers, the constants.bin finalize
+// with its three emit modes) moved to the standalone
+// --hip-externalize-constants pass
+// (lib/Dialect/Transforms/ExternalizeConstants.cpp), which serializes both
+// these carriers and plugin-emitted hip.constant ops uniformly.
 
-static std::string elementTypeToString(mlir::Type elemType) {
-  if (elemType.isF16())
-    return "f16";
-  else if (elemType.isBF16())
-    return "bf16";
-  else if (elemType.isF32())
-    return "f32";
-  else if (elemType.isF64())
-    return "f64";
-  else if (elemType.isInteger(8))
-    return "i8";
-  else if (elemType.isInteger(16))
-    return "i16";
-  else if (elemType.isInteger(32))
-    return "i32";
-  else if (elemType.isInteger(64))
-    return "i64";
-  else if (elemType.isInteger(1))
-    return "i1";
-  std::string result;
-  llvm::raw_string_ostream os(result);
-  elemType.print(os);
-  return result;
-}
-
-static int64_t alignTo(int64_t value, int64_t alignment) {
-  return (value + alignment - 1) / alignment * alignment;
-}
-
-/// Mutable state shared across calls to lowerOnnxConstants when
-/// externalization is enabled. Constants are collected here during the
-/// walk; the finalize step in runOnOperation emits either constants.bin
-/// (skipDataWrite=false) via the shared ConstantsIO helper, or per-entry
-/// source descriptors as module attrs (skipDataWrite=true) that
-/// GenerateInterface bakes into __metadata_blob.ConstantInfo.source.
-struct ExternalizationState {
-  llvm::json::Array manifestEntries;
-  int64_t currentOffset = 0;
-  int64_t constantIndex = 0;
-  std::string binFileName;
-  llvm::SmallVector<int64_t> constantSizes;
-  llvm::SmallVector<int64_t> constantOffsets;
-  bool skipDataWrite = false;
-  llvm::SmallVector<std::string> constantNames;
-
-  // One descriptor per constant, in emission order. The descriptor encodes
-  // one of three sources:
-  //   * mem-addr / inline: `ptr` points at data owned elsewhere
-  //     (DenseElementsAttr rawData held by MLIRContext) and stays valid
-  //     through runOnOperation's end.
-  //   * splat: `splatElemSize > 0` and `ptr` points at the single element
-  //     bytes; the finalize emitter tile-expands on the fly.
-  //   * file-ref: `filePath` is non-empty; `fileOffset` is the byte offset
-  //     within that file. The runtime is expected to fread the data on
-  //     demand into a small staging buffer instead of mmap'ing the whole
-  //     external-data file. This is the path that avoids ORT mmap for
-  //     multi-GB models.
-  struct HostEntry {
-    const void *ptr = nullptr;
-    int64_t splatElemSize = 0;
-    std::string filePath; // empty unless file-ref
-    int64_t fileOffset = 0;
-  };
-  llvm::SmallVector<HostEntry> constantHostPtrs;
-};
-
-/// Advance `currentOffset` to the next aligned boundary. The actual
-/// padding bytes are emitted by the finalize step (writeConstantsBin*);
-/// in transfer-file mode padding is implicit in the recorded offsets.
-static int64_t writeAlignmentPadding(ExternalizationState *extState,
-                                     int64_t alignment = 64) {
-  int64_t aligned = llvm::alignTo(extState->currentOffset, alignment);
-  extState->currentOffset = aligned;
-  return aligned;
-}
-
-/// Shared bookkeeping after constant data has been written to constants.bin.
-/// Updates ExternalizationState counters, emits the JSON manifest entry,
-/// creates the extern memref.global with hip.external_data, and replaces
-/// the original op with memref.get_global + bufferization.to_tensor.
-static void finalizeExternalizedConstant(mlir::ModuleOp module,
-                                         mlir::Operation *constOp,
-                                         mlir::RankedTensorType tensorType,
-                                         int64_t byteSize, int64_t entryOffset,
-                                         ExternalizationState *extState) {
-  constexpr int64_t kAlignment = 64;
-  auto memrefType =
-      mlir::MemRefType::get(tensorType.getShape(), tensorType.getElementType());
-
-  std::string name = "hip_ext_constant_";
-  std::string onnxName;
-  if (auto nodeNameAttr =
-          constOp->getAttrOfType<mlir::StringAttr>("onnx_node_name")) {
-    onnxName = nodeNameAttr.getValue().str();
-    std::string fragment = sanitizeForMlirIdentifier(nodeNameAttr.getValue());
-    if (!fragment.empty())
-      name += fragment + "_";
-  }
-  // Initializers have their tensor name in "node.outputs" (the output NodeArg
-  // name), not in "onnx_node_name" (the NodeProto.name which may be empty).
-  if (onnxName.empty()) {
-    if (auto outputsAttr =
-            constOp->getAttrOfType<mlir::ArrayAttr>("node.outputs")) {
-      if (outputsAttr.size() > 0) {
-        if (auto strAttr =
-                mlir::dyn_cast<mlir::StringAttr>(outputsAttr.getValue()[0]))
-          onnxName = strAttr.getValue().str();
-      }
-    }
-  }
-  name += std::to_string(extState->constantIndex);
-
-  extState->constantSizes.push_back(byteSize);
-  extState->constantOffsets.push_back(entryOffset);
-  extState->constantNames.push_back(onnxName);
-
-  llvm::json::Array shapeArray;
-  for (int64_t dim : tensorType.getShape())
-    shapeArray.push_back(dim);
-  llvm::json::Object entry;
-  entry["name"] = name;
-  entry["shape"] = std::move(shapeArray);
-  entry["element_type"] = elementTypeToString(tensorType.getElementType());
-  entry["offset"] = entryOffset;
-  entry["size"] = byteSize;
-  entry["alignment"] = kAlignment;
-  extState->manifestEntries.push_back(std::move(entry));
-
-  mlir::OpBuilder moduleBuilder(module.getBody(), module.getBody()->begin());
-  auto externalDataAttr = moduleBuilder.getDictionaryAttr({
-      moduleBuilder.getNamedAttr(
-          "index", moduleBuilder.getI64IntegerAttr(extState->constantIndex)),
-      moduleBuilder.getNamedAttr("offset",
-                                 moduleBuilder.getI64IntegerAttr(entryOffset)),
-      moduleBuilder.getNamedAttr("size",
-                                 moduleBuilder.getI64IntegerAttr(byteSize)),
-  });
-  auto globalOp = mlir::memref::GlobalOp::create(
-      moduleBuilder, constOp->getLoc(), name,
-      /*sym_visibility=*/moduleBuilder.getStringAttr("private"),
-      /*type=*/memrefType,
-      /*initial_value=*/nullptr,
-      /*constant=*/false,
-      /*alignment=*/moduleBuilder.getI64IntegerAttr(kAlignment));
-  globalOp->setAttr("hip.external_data", externalDataAttr);
-
-  mlir::OpBuilder builder(constOp);
-  auto getGlobal = mlir::memref::GetGlobalOp::create(builder, constOp->getLoc(),
-                                                     memrefType, name);
-  auto toTensor = mlir::bufferization::ToTensorOp::create(
-      builder, constOp->getLoc(), tensorType, getGlobal.getResult(),
-      /*restrict=*/builder.getUnitAttr(),
-      /*writable=*/nullptr);
-  constOp->getResult(0).replaceAllUsesWith(toTensor.getResult());
-  constOp->erase();
-
-  ++extState->constantIndex;
-}
-
-/// Write one constant's raw data to constants.bin and replace the op with
-/// an extern memref.global + bufferization.to_tensor bridge.
-static void externalizeConstant(mlir::ModuleOp module, mlir::Operation *constOp,
-                                mlir::RankedTensorType tensorType,
-                                const void *rawPtr, int64_t byteSize,
-                                ExternalizationState *extState) {
-  int64_t entryOffset = writeAlignmentPadding(extState);
-  // Always collect layout + host pointer. The finalize step decides whether
-  // to emit constants.bin (skipDataWrite=false) or module attrs encoding
-  // the per-constant source (skipDataWrite=true). DenseElementsAttr raw
-  // data / ORT mmap addresses
-  // remain valid through runOnOperation, so recording the pointer here is
-  // safe for both consumers.
-  ExternalizationState::HostEntry entry;
-  entry.ptr = rawPtr;
-  extState->constantHostPtrs.push_back(std::move(entry));
-  extState->currentOffset += byteSize;
-  finalizeExternalizedConstant(module, constOp, tensorType, byteSize,
-                               entryOffset, extState);
-}
-
-/// Record a file-ref entry: data lives on disk at (filePath, fileOffset)
-/// and must be fread by the runtime into a staging buffer at upload time.
-/// Avoids holding any of the data in host memory during compilation.
-static void externalizeFileRefConstant(mlir::ModuleOp module,
-                                       mlir::Operation *constOp,
-                                       mlir::RankedTensorType tensorType,
-                                       const std::string &filePath,
-                                       int64_t fileOffset, int64_t byteSize,
-                                       ExternalizationState *extState) {
-  int64_t entryOffset = writeAlignmentPadding(extState);
-  ExternalizationState::HostEntry entry;
-  entry.filePath = filePath;
-  entry.fileOffset = fileOffset;
-  extState->constantHostPtrs.push_back(std::move(entry));
-  extState->currentOffset += byteSize;
-  finalizeExternalizedConstant(module, constOp, tensorType, byteSize,
-                               entryOffset, extState);
-}
-
-/// Replace an onnx.Constant op with an inline arith.constant.
-static void replaceWithArithConstant(mlir::Operation *constOp,
-                                     mlir::DenseElementsAttr valueAttr) {
-  mlir::OpBuilder builder(constOp);
-  auto arithConst =
-      mlir::arith::ConstantOp::create(builder, constOp->getLoc(), valueAttr);
-  constOp->getResult(0).replaceAllUsesWith(arithConst.getResult());
-  constOp->erase();
-}
-
-/// Externalize a splat constant: record only the single element bytes.
-/// The finalize step (constants.bin emit OR transfer-file emit) tiles the
-/// element value on the fly, so we never allocate a full-size buffer here.
-/// DenseElementsAttr's raw data is owned by the MLIRContext and stays
-/// valid through runOnOperation.
-static void externalizeSplatConstant(mlir::ModuleOp module,
-                                     mlir::Operation *constOp,
-                                     mlir::RankedTensorType tensorType,
-                                     mlir::DenseElementsAttr valueAttr,
-                                     int64_t byteSize,
-                                     ExternalizationState *extState) {
-  auto rawData = valueAttr.getRawData();
-  int64_t entryOffset = writeAlignmentPadding(extState);
-  ExternalizationState::HostEntry entry;
-  entry.ptr = rawData.data();
-  entry.splatElemSize = static_cast<int64_t>(rawData.size());
-  extState->constantHostPtrs.push_back(std::move(entry));
-  extState->currentOffset += byteSize;
-  finalizeExternalizedConstant(module, constOp, tensorType, byteSize,
-                               entryOffset, extState);
-}
-
-/// Resolve an onnx.Constant that carries a `location` attribute (zero-copy
-/// external data emitted by the ORT bridge). The `location` string selects
-/// one of two semantics:
+/// Lower onnx.Constant ops to neutral hip.constant carriers. The
+/// externalize-vs-inline decision and the constants.bin write are deferred to
+/// the standalone --hip-externalize-constants pass (which also serializes
+/// plugin-emitted hip.constant ops). A value constant carries its dense
+/// `value`; an ORT external-data constant carries `location`/`offset`/`size`.
+/// The onnx_node_name / node.outputs naming hints are carried through so the
+/// externalize pass reproduces identical externalized-global symbol names.
 ///
-///   * "*/_ORT_MEM_ADDR_/*"  -> `offset` is a raw memory address (ORT tensor
-///     pointer cast to i64) that the data lives at right now. Used for
-///     inline raw_data and (legacy) ORT mmap-resolved tensors.
-///   * <other string>        -> `offset` is a byte offset within the file
-///     at the given absolute path. Data is NOT in memory; the runtime is
-///     expected to fread it on demand. This is the path that avoids ORT
-///     mmap'ing multi-GB external-data files into the system page cache.
-///
-/// Input IR (produced by ir-converter-imp.cpp), mem-addr form:
-///
-///   %cst = "onnx.Constant"()
-///       {location = "*/_ORT_MEM_ADDR_/*",
-///        offset = 140695085056000 : i64,
-///        size = 32 : i64} : () -> tensor<2x4xf32>
-///
-/// File-ref form:
-///
-///   %cst = "onnx.Constant"()
-///       {location = "C:/.../weights.data",
-///        offset = 1048576 : i64,
-///        size = 33554432 : i64} : () -> tensor<...>
-///
-/// Output IR when externalization is enabled (extState != nullptr) is the
-/// same memref.global + bufferization.to_tensor bridge as in
-/// externalizeConstant; the only difference is what the transfer-file
-/// finalize step writes for this entry.
-///
-/// Output IR when externalization is disabled (extState == nullptr):
-///
-///   %cst = arith.constant dense<[[1.0, 2.0, 3.0, 4.0], ...]>
-///       : tensor<2x4xf32>
-static constexpr llvm::StringLiteral kOrtMemAddrTag = "*/_ORT_MEM_ADDR_/*";
-
-static mlir::LogicalResult
-resolveExternalLocationConstant(mlir::ModuleOp module, mlir::Operation *constOp,
-                                ExternalizationState *extState) {
-  auto locAttr = constOp->getAttrOfType<mlir::StringAttr>("location");
-  auto offsetAttr = constOp->getAttrOfType<mlir::IntegerAttr>("offset");
-  auto sizeAttr = constOp->getAttrOfType<mlir::IntegerAttr>("size");
-  if (!locAttr || !offsetAttr || !sizeAttr)
-    return constOp->emitError(
-        "onnx.Constant with location attribute missing location/offset/size");
-
-  int64_t offsetVal = offsetAttr.getInt();
-  int64_t dataSize = sizeAttr.getInt();
-  if (dataSize <= 0)
-    return constOp->emitError("onnx.Constant has invalid size");
-
-  auto tensorType =
-      mlir::dyn_cast<mlir::RankedTensorType>(constOp->getResult(0).getType());
-  if (!tensorType)
-    return constOp->emitError("external constant has non-ranked result type");
-
-  llvm::StringRef location = locAttr.getValue();
-  bool isMemAddr = (location == kOrtMemAddrTag);
-
-  if (isMemAddr) {
-    if (offsetVal == 0)
-      return constOp->emitError("onnx.Constant mem-addr has null address");
-    const void *dataPtr =
-        reinterpret_cast<const void *>(static_cast<uintptr_t>(offsetVal));
-
-    if (extState) {
-      externalizeConstant(module, constOp, tensorType, dataPtr, dataSize,
-                          extState);
-    } else {
-      auto rawData =
-          llvm::ArrayRef<char>(static_cast<const char *>(dataPtr), dataSize);
-      auto denseAttr =
-          mlir::DenseElementsAttr::getFromRawBuffer(tensorType, rawData);
-      replaceWithArithConstant(constOp, denseAttr);
-    }
-    return mlir::success();
-  }
-
-  // File-reference path: location is an absolute file path, offset is the
-  // byte offset within that file. Without externalization (offline / inline
-  // arith.constant test path) we still have to materialize the bytes; do a
-  // one-shot fread and feed them to DenseElementsAttr. The full streaming
-  // benefit only kicks in along the externalize path where a downstream
-  // consumer can stream tensor-by-tensor.
-  if (extState) {
-    externalizeFileRefConstant(module, constOp, tensorType, location.str(),
-                               offsetVal, dataSize, extState);
-    return mlir::success();
-  }
-
-  std::vector<char> buf(static_cast<size_t>(dataSize));
-  std::ifstream ifs(location.str(), std::ios::binary);
-  if (!ifs)
-    return constOp->emitError("failed to open external data file: ")
-           << location;
-  ifs.seekg(offsetVal);
-  ifs.read(buf.data(), dataSize);
-  if (!ifs)
-    return constOp->emitError("short read from external data file: ")
-           << location;
-  auto denseAttr = mlir::DenseElementsAttr::getFromRawBuffer(
-      tensorType, llvm::ArrayRef<char>(buf.data(), buf.size()));
-  replaceWithArithConstant(constOp, denseAttr);
-  return mlir::success();
-}
-
-/// Lower onnx.Constant ops to either externalized constants (constants.bin)
-/// or inline arith.constant ops.
-static mlir::LogicalResult lowerOnnxConstants(mlir::ModuleOp module,
-                                              mlir::func::FuncOp funcOp,
-                                              int64_t minNumElements,
-                                              ExternalizationState *extState) {
-
+/// Before: %c = "onnx.Constant"() {value = dense<...>} : () -> tensor<8xf32>
+/// After:  %c = hip.constant {value = dense<...>} : tensor<8xf32>
+static mlir::LogicalResult lowerOnnxConstants(mlir::func::FuncOp funcOp) {
   llvm::SmallVector<mlir::Operation *> constants;
   funcOp.walk([&](mlir::Operation *op) {
     if (op->getName().getStringRef() == "onnx.Constant")
@@ -402,39 +75,41 @@ static mlir::LogicalResult lowerOnnxConstants(mlir::ModuleOp module,
   });
 
   for (mlir::Operation *constOp : constants) {
-    auto valueAttr = mlir::dyn_cast_or_null<mlir::DenseElementsAttr>(
-        constOp->getAttrOfType<mlir::ElementsAttr>("value"));
+    auto tensorType =
+        mlir::dyn_cast<mlir::RankedTensorType>(constOp->getResult(0).getType());
+    if (!tensorType)
+      return constOp->emitError("onnx.Constant has non-ranked result type");
 
-    if (valueAttr) {
-      // Inline dense constant -- fall through to externalize-or-inline below.
-    } else if (constOp->hasAttr("location")) {
-      if (mlir::failed(
-              resolveExternalLocationConstant(module, constOp, extState)))
-        return mlir::failure();
-      continue;
-    } else {
+    bool hasValue = mlir::isa_and_present<mlir::DenseElementsAttr>(
+        constOp->getAttrOfType<mlir::ElementsAttr>("value"));
+    bool hasLocation = constOp->hasAttr("location");
+    if (!hasValue && !hasLocation)
       return constOp->emitError(
           "unsupported onnx.Constant form (expected dense value attribute "
           "or location attribute)");
-    }
 
-    if (extState && minNumElements > 0 &&
-        valueAttr.getNumElements() >= minNumElements) {
-      auto tensorType = mlir::cast<mlir::RankedTensorType>(valueAttr.getType());
-      int64_t elemBits = tensorType.getElementTypeBitWidth();
-      int64_t byteSize = valueAttr.getNumElements() * ((elemBits + 7) / 8);
-
-      if (valueAttr.isSplat()) {
-        externalizeSplatConstant(module, constOp, tensorType, valueAttr,
-                                 byteSize, extState);
-      } else {
-        externalizeConstant(module, constOp, tensorType,
-                            valueAttr.getRawData().data(), byteSize, extState);
-      }
-
+    mlir::OpBuilder builder(constOp);
+    auto hipConst =
+        mlir::hip::ConstantOp::create(builder, constOp->getLoc(), tensorType);
+    if (hasValue) {
+      hipConst->setAttr("value", constOp->getAttr("value"));
     } else {
-      replaceWithArithConstant(constOp, valueAttr);
+      // Carry the ORT external-data ref verbatim; offset/size may be absent on
+      // malformed input, in which case the externalize pass emits the
+      // diagnostic (guard avoids setting a null attribute here).
+      hipConst->setAttr("location", constOp->getAttr("location"));
+      if (auto o = constOp->getAttr("offset"))
+        hipConst->setAttr("offset", o);
+      if (auto s = constOp->getAttr("size"))
+        hipConst->setAttr("size", s);
     }
+    if (auto n = constOp->getAttr("onnx_node_name"))
+      hipConst->setAttr("onnx_node_name", n);
+    if (auto n = constOp->getAttr("node.outputs"))
+      hipConst->setAttr("node.outputs", n);
+
+    constOp->getResult(0).replaceAllUsesWith(hipConst.getResult());
+    constOp->erase();
   }
   return mlir::success();
 }
@@ -634,16 +309,7 @@ struct ConvertOnnxToHipPass
     : public impl::ConvertOnnxToHipPassBase<ConvertOnnxToHipPass> {
   using ConvertOnnxToHipPassBase::ConvertOnnxToHipPassBase;
 
-  ConvertOnnxToHipPass(morphizen::FileSystem *fs, int64_t minNumElements,
-                       bool skipConstantData = false)
-      : fileSystem_(fs), fsMinNumElements_(minNumElements),
-        skipConstantData_(skipConstantData) {}
-
   void runOnOperation() override;
-
-  morphizen::FileSystem *fileSystem_ = nullptr;
-  int64_t fsMinNumElements_ = 0;
-  bool skipConstantData_ = false;
 };
 
 void ConvertOnnxToHipPass::runOnOperation() {
@@ -665,37 +331,6 @@ void ConvertOnnxToHipPass::runOnOperation() {
       llvm::errs() << "[ConvertOnnxToHipPass] " << name << ": "
                    << llvm::format("%.3f", sec) << "s\n";
   };
-
-  // Set up externalization state if enabled.
-  // When fileSystem_ is provided (e.g. EPContext from ORT), use it directly.
-  // Otherwise fall back to DiskFileSystem rooted at externalizeOutputDir.
-  std::unique_ptr<ExternalizationState> extState;
-  std::unique_ptr<mlir::hip::DiskFileSystem> fallbackFs;
-  morphizen::FileSystem *fs = fileSystem_;
-
-  int64_t minElems =
-      fileSystem_ ? fsMinNumElements_ : externalizeMinNumElements.getValue();
-
-  if (!fs) {
-    llvm::StringRef dirRef = externalizeOutputDir.getValue();
-    std::string dir = dirRef.empty() ? "." : dirRef.str();
-    fallbackFs = std::make_unique<mlir::hip::DiskFileSystem>(dir.c_str());
-    fs = fallbackFs.get();
-  }
-
-  if (minElems > 0) {
-    extState = std::make_unique<ExternalizationState>();
-    extState->skipDataWrite = skipConstantData_;
-
-    std::string baseName = "model";
-    if (auto sym = module->getAttrOfType<mlir::StringAttr>(
-            mlir::SymbolTable::getSymbolAttrName()))
-      baseName = sym.getValue().str();
-    extState->binFileName = baseName + ".constants.bin";
-    // constants.bin is written in one streaming pass in finalize() via
-    // writeConstantsBinToFileSystem, after all offsets are known; no
-    // writer is opened here.
-  }
 
   // NOTE: onnx.CastLike -> onnx.Cast + dead-type-donor function-argument
   // drop is handled by the standalone simplify-onnx pass, which must run
@@ -815,8 +450,7 @@ void ConvertOnnxToHipPass::runOnOperation() {
               funcOp, std::move(preFoldPatterns), cfg)))
         return signalPassFailure();
     }
-    if (mlir::failed(
-            lowerOnnxConstants(module, funcOp, minElems, extState.get())))
+    if (mlir::failed(lowerOnnxConstants(funcOp)))
       return signalPassFailure();
     lowerOnnxReturns(funcOp);
     if (mlir::failed(convertComputeOps(funcOp, ctx)))
@@ -829,21 +463,11 @@ void ConvertOnnxToHipPass::runOnOperation() {
     // pass and one-shot-bufferize aborts with "op was not bufferized" (the EP
     // then silently falls back to CPU). Re-running externalizes / inlines them
     // exactly like every other constant.
-    if (mlir::failed(
-            lowerOnnxConstants(module, funcOp, minElems, extState.get())))
+    if (mlir::failed(lowerOnnxConstants(funcOp)))
       return signalPassFailure();
   }
 
-  if (timing && extState) {
-    std::string detail;
-    llvm::raw_string_ostream os(detail);
-    os << "(" << extState->constantIndex << " constants, "
-       << llvm::format("%.1f", extState->currentOffset / (1024.0 * 1024.0))
-       << " MB)";
-    logSubpass("constants + compute ops", detail.c_str());
-  } else {
-    logSubpass("constants + compute ops");
-  }
+  logSubpass("constants + compute ops");
 
   // Clean up onnx.NoValue and onnx.EntryPoint, plus any other unregistered
   // onnx.* op that ended up with no uses after conversion. The latter case
@@ -887,209 +511,6 @@ void ConvertOnnxToHipPass::runOnOperation() {
     }
   });
 
-  // Finalize externalization: emit the constants.bin sidecar or per-entry
-  // source descriptors (or both, in hybrid mode), write the JSON manifest
-  // when a full sidecar is produced, and stamp module attributes.
-  //
-  // Three emit modes:
-  //   * skipDataWrite=false  — full sidecar (Workflow A: EPContext export
-  //     + offline hip-compiler). All ConstantInfo.source remain NONE; the
-  //     runtime bulk-loads model.constants.bin and hipMemcpy's it once.
-  //   * skipDataWrite=true, no mem-addr entries — pure streaming. Per-entry
-  //     descriptors only (Splat / FileRef); no sidecar written.
-  //   * skipDataWrite=true, has mem-addr entries — hybrid. Mem-addr bytes
-  //     are packed into a *partial* sidecar at compact 64B-aligned offsets;
-  //     the descriptor for each mem-addr entry becomes SidecarSource with
-  //     its sidecar offset. file-ref / splat entries keep their streaming
-  //     descriptors. The runtime per-entry path uploads from a single
-  //     reusable staging buffer regardless of source mix, bounding host
-  //     peak to the largest single tensor instead of total constants size.
-  if (extState && extState->constantIndex > 0) {
-    // Module attributes shared across all emit modes.
-    module->setAttr("hip.constants_file",
-                    mlir::StringAttr::get(ctx, extState->binFileName));
-    module->setAttr("hipdnn.constant_sizes",
-                    mlir::DenseI64ArrayAttr::get(ctx, extState->constantSizes));
-    module->setAttr(
-        "hipdnn.constant_offsets",
-        mlir::DenseI64ArrayAttr::get(ctx, extState->constantOffsets));
-
-    if (!extState->skipDataWrite) {
-      // Stream constants.bin via the shared helper (preserves the 1 MB
-      // tile pattern for splats so peak host memory is bounded; file-ref
-      // entries stream from disk into the writer with no in-memory copy).
-      llvm::SmallVector<mlir::hip::ConstantEntry> entries;
-      entries.reserve(extState->constantHostPtrs.size());
-      for (size_t i = 0; i < extState->constantHostPtrs.size(); ++i) {
-        const auto &h = extState->constantHostPtrs[i];
-        mlir::hip::ConstantEntry e;
-        e.name = extState->constantNames[i];
-        e.offset = extState->constantOffsets[i];
-        e.size = extState->constantSizes[i];
-        e.data = h.ptr;
-        e.splat_elem_size = h.splatElemSize;
-        e.file_path = h.filePath;
-        e.file_offset = h.fileOffset;
-        entries.push_back(std::move(e));
-      }
-      if (!mlir::hip::writeConstantsBinToFileSystem(
-              fs, extState->binFileName,
-              std::vector<mlir::hip::ConstantEntry>(entries.begin(),
-                                                    entries.end()),
-              extState->currentOffset)) {
-        module.emitError(
-            "failed to write constants binary file via FileSystem: " +
-            extState->binFileName);
-        return signalPassFailure();
-      }
-
-      // JSON manifest (only meaningful when constants.bin is produced).
-      std::string baseName = "model";
-      if (auto sym = module->getAttrOfType<mlir::StringAttr>(
-              mlir::SymbolTable::getSymbolAttrName()))
-        baseName = sym.getValue().str();
-      std::string jsonPath = baseName + ".constants.json";
-
-      llvm::json::Object manifest;
-      manifest["version"] = 1;
-      manifest["binary_file"] = extState->binFileName;
-      manifest["num_constants"] = extState->constantIndex;
-      manifest["total_bytes"] = extState->currentOffset;
-      manifest["constants"] = std::move(extState->manifestEntries);
-
-      auto jsonWriter = fs->create_writer_template(jsonPath.c_str());
-      if (!jsonWriter) {
-        module.emitError("failed to open constants manifest via FileSystem: " +
-                         jsonPath);
-        return signalPassFailure();
-      }
-      std::string jsonStr;
-      llvm::raw_string_ostream jsonOs(jsonStr);
-      jsonOs << llvm::formatv("{0:2}", llvm::json::Value(std::move(manifest)));
-      jsonWriter->fwrite(jsonStr.data(), jsonStr.size());
-    } else if (!extState->constantHostPtrs.empty()) {
-      // skipDataWrite=true: per-entry descriptors with optional partial
-      // sidecar for mem-addr entries (hybrid).
-      //
-      // Six parallel arrays, all indexed by constantIndex:
-      //   constant_source_kinds:        0=NONE, 1=Splat, 2=FileRef, 3=Sidecar
-      //   constant_splat_elem_values:   elem bytes packed into i64 (0 unless
-      //   splat) constant_splat_elem_sizes:    elem byte count 1/2/4/8 (0
-      //   unless splat) constant_file_paths:          absolute OS path (empty
-      //   unless file-ref) constant_file_offsets:        byte offset within
-      //   file (0 unless file-ref) constant_sidecar_offsets:     byte offset
-      //   within partial sidecar
-      //                                 (0 unless mem-addr / Sidecar)
-      int64_t count = static_cast<int64_t>(extState->constantHostPtrs.size());
-      llvm::SmallVector<int32_t> kinds(count, 0);
-      llvm::SmallVector<int64_t> splatValues(count, 0);
-      llvm::SmallVector<int64_t> splatElemSizes(count, 0);
-      llvm::SmallVector<mlir::Attribute> filePaths;
-      filePaths.reserve(count);
-      llvm::SmallVector<int64_t> fileOffsets(count, 0);
-      llvm::SmallVector<int64_t> sidecarOffsets(count, 0);
-
-      // Pass 1: collect mem-addr entries into a compact partial sidecar
-      // layout. Each entry is 64B-aligned within the sidecar (matches the
-      // GPU blob alignment used elsewhere, so writeConstantsBinToFileSystem
-      // emits identical zero padding logic).
-      constexpr int64_t kSidecarAlign = 64;
-      llvm::SmallVector<mlir::hip::ConstantEntry> partialEntries;
-      int64_t sidecarPos = 0;
-      int64_t memAddrCount = 0, fileRefCount = 0, splatCount = 0;
-      for (int64_t i = 0; i < count; ++i) {
-        const auto &h = extState->constantHostPtrs[i];
-        if (!h.filePath.empty()) {
-          ++fileRefCount;
-        } else if (h.splatElemSize > 0) {
-          ++splatCount;
-        } else {
-          ++memAddrCount;
-          int64_t off = llvm::alignTo(sidecarPos, kSidecarAlign);
-          sidecarOffsets[i] = off;
-          mlir::hip::ConstantEntry e;
-          e.name = extState->constantNames[i];
-          e.offset = off;
-          e.size = extState->constantSizes[i];
-          e.data = h.ptr;
-          partialEntries.push_back(std::move(e));
-          sidecarPos = off + extState->constantSizes[i];
-        }
-      }
-
-      // Pass 2: write the partial sidecar (mem-addr bytes only). When
-      // there are no mem-addr entries the sidecar is omitted entirely
-      // (pure streaming model — runtime never opens constants_filename).
-      if (!partialEntries.empty()) {
-        if (!mlir::hip::writeConstantsBinToFileSystem(
-                fs, extState->binFileName,
-                std::vector<mlir::hip::ConstantEntry>(partialEntries.begin(),
-                                                      partialEntries.end()),
-                sidecarPos)) {
-          module.emitError(
-              "failed to write partial mem-addr sidecar via FileSystem: " +
-              extState->binFileName);
-          return signalPassFailure();
-        }
-        llvm::errs() << "[ConvertOnnxToHipPass] hybrid: " << memAddrCount
-                     << " mem-addr -> partial sidecar ("
-                     << llvm::format("%.1f", sidecarPos / (1024.0 * 1024.0))
-                     << " MB), " << fileRefCount << " file-ref + " << splatCount
-                     << " splat -> streaming\n";
-      } else {
-        llvm::errs() << "[ConvertOnnxToHipPass] streaming: " << fileRefCount
-                     << " file-ref + " << splatCount
-                     << " splat -> per-entry descriptors\n";
-      }
-
-      // Pass 3: stamp per-entry source descriptors. mem-addr entries get
-      // their sidecarOffsets[i] from pass 1; the rest stay at 0 in that
-      // slot which is fine because GenerateInterface only reads it for
-      // kind==3 (Sidecar).
-      for (int64_t i = 0; i < count; ++i) {
-        const auto &entry = extState->constantHostPtrs[i];
-        std::string path;
-        if (!entry.filePath.empty()) {
-          kinds[i] = 2; // FileRef
-          path = entry.filePath;
-          fileOffsets[i] = entry.fileOffset;
-        } else if (entry.splatElemSize > 0) {
-          kinds[i] = 1; // Splat
-          splatElemSizes[i] = entry.splatElemSize;
-          // Left-pack up to 8 bytes of element data into a uint64 carrier
-          // so we can ship it through a DenseI64ArrayAttr.
-          size_t n =
-              static_cast<size_t>(std::min<int64_t>(splatElemSizes[i], 8));
-          std::memcpy(&splatValues[i], entry.ptr, n);
-        } else {
-          kinds[i] = 3; // Sidecar (mem-addr packed into partial sidecar)
-        }
-        filePaths.push_back(mlir::StringAttr::get(ctx, path));
-      }
-
-      module->setAttr("hipdnn.constant_source_kinds",
-                      mlir::DenseI32ArrayAttr::get(ctx, kinds));
-      module->setAttr("hipdnn.constant_splat_elem_values",
-                      mlir::DenseI64ArrayAttr::get(ctx, splatValues));
-      module->setAttr("hipdnn.constant_splat_elem_sizes",
-                      mlir::DenseI64ArrayAttr::get(ctx, splatElemSizes));
-      module->setAttr("hipdnn.constant_file_paths",
-                      mlir::ArrayAttr::get(ctx, filePaths));
-      module->setAttr("hipdnn.constant_file_offsets",
-                      mlir::DenseI64ArrayAttr::get(ctx, fileOffsets));
-      module->setAttr("hipdnn.constant_sidecar_offsets",
-                      mlir::DenseI64ArrayAttr::get(ctx, sidecarOffsets));
-    }
-
-    LLVM_DEBUG(llvm::dbgs()
-               << "externalized " << extState->constantIndex << " constants ("
-               << extState->currentOffset << " bytes) to "
-               << extState->binFileName
-               << (extState->skipDataWrite ? " (per-entry descriptors)" : "")
-               << "\n");
-  }
-  logSubpass("finalize");
-
   if (timing) {
     llvm::errs() << "[ConvertOnnxToHipPass] total: "
                  << llvm::format("%.3f", elapsed_since(passStart)) << "s\n";
@@ -1097,13 +518,6 @@ void ConvertOnnxToHipPass::runOnOperation() {
 }
 
 } // namespace
-
-std::unique_ptr<mlir::Pass>
-createConvertOnnxToHipPass(morphizen::FileSystem *fs, int64_t minNumElements,
-                           bool skipConstantData) {
-  return std::make_unique<ConvertOnnxToHipPass>(fs, minNumElements,
-                                                skipConstantData);
-}
 
 } // namespace hip
 } // namespace mlir

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -113,6 +113,22 @@ LogicalResult AllocOutputOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// ConstantOp: neutral externalizable constant carrier
+//===----------------------------------------------------------------------===//
+
+LogicalResult ConstantOp::verify() {
+  // Carrier duality: exactly one of the inline `value` or the external-data
+  // `location` reference must be present. A producer (convert-onnx-to-hip or a
+  // plugin) chooses one representation; both-or-neither is malformed.
+  bool hasValue = getValueAttr() != nullptr;
+  bool hasLocation = getLocationAttr() != nullptr;
+  if (hasValue == hasLocation)
+    return emitOpError("must carry exactly one of `value` (inline) or "
+                       "`location` (external-data reference)");
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // LoopOp: outlined-body counted/conditional loop (DPS)
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Transforms/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(HipDialectTransforms STATIC
   AddHipContextArg.cpp
   AssignOpStateSlots.cpp
   BufferUtils.cpp
+  ExternalizeConstants.cpp
   FixLoopAccumulatorOffset.cpp
   GenerateInterface.cpp
   GenerateOpStateInit.cpp

--- a/lib/Dialect/Transforms/ExternalizeConstants.cpp
+++ b/lib/Dialect/Transforms/ExternalizeConstants.cpp
@@ -1,0 +1,641 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+//===- ExternalizeConstants.cpp - Externalize hip.constant carriers -------===//
+//
+// The --hip-externalize-constants pass is the compile-time, dialect-agnostic
+// half of constant handling (its runtime complement is the already-standalone
+// hip-resolve-extern-constants pass). It walks every `hip.constant` carrier --
+// whether lowered from onnx.Constant by convert-onnx-to-hip or emitted by a
+// downstream plugin for its own weights -- and serializes each one uniformly:
+//
+//   * value tensors at/above `externalize-min-num-elements` become an extern
+//     `memref.global` (+ a `hip.external_data` {index, offset, size} attr)
+//     whose bytes are appended to the `<model>.constants.bin` sidecar, then
+//     bridged back to tensor land via `memref.get_global` +
+//     `bufferization.to_tensor`;
+//   * smaller value tensors fold to `arith.constant` (kept inline in the DLL);
+//   * ORT external-data references (`location`/`offset`/`size`) are always
+//     externalized -- either a live host pointer (mem-addr) or an on-disk
+//     (path, offset) file range streamed by the runtime.
+//
+// Splitting this out of convert-onnx-to-hip is what lets plugins participate:
+// they only emit `hip.constant`, with no access to any private state here.
+//
+//   Before:  %w = hip.constant {value = dense<...> : tensor<8x8xf32>}
+//                    : tensor<8x8xf32>
+//   After (>= threshold):
+//     memref.global "private" @hip_ext_constant_0 : memref<8x8xf32>
+//         {alignment = 64, hip.external_data = {index = 0, offset = 0, size}}
+//     %g = memref.get_global @hip_ext_constant_0 : memref<8x8xf32>
+//     %w = bufferization.to_tensor %g restrict
+//            : memref<8x8xf32> to tensor<8x8xf32>
+//   After (< threshold):  %w = arith.constant dense<...> : tensor<8x8xf32>
+//
+//===----------------------------------------------------------------------===//
+
+#include "hip/Conversion/OnnxToHip/ConstantsIO.h"
+#include "hip/Dialect/IR/HipDialect.h"
+#include "hip/Dialect/Transforms/ConstantMetadata.h"
+#include "hip/Dialect/Transforms/Passes.h"
+#include "hip/Support/DiskFileSystem.h"
+#include "morphizen-foundation/file_io.hpp"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/SymbolTable.h"
+#include "mlir/Pass/Pass.h"
+
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/Sequence.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/FormatVariadic.h"
+#include "llvm/Support/JSON.h"
+#include "llvm/Support/MathExtras.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <cctype>
+#include <cstring>
+#include <fstream>
+#include <optional>
+#include <string>
+#include <vector>
+
+#define DEBUG_TYPE "hip-externalize-constants"
+
+namespace mlir {
+namespace hip {
+
+#define GEN_PASS_DEF_EXTERNALIZECONSTANTSPASS
+#include "hip/Dialect/Transforms/Passes.h.inc"
+
+namespace {
+
+/// GPU-blob alignment (bytes), shared by every externalized constant and the
+/// partial mem-addr sidecar; matches the runtime memory-pool alignment.
+constexpr int64_t kConstantAlignment = 64;
+
+/// Sentinel `location` meaning "`offset` is a live host pointer" (ORT zero-copy
+/// external data), as opposed to an absolute on-disk file path.
+constexpr llvm::StringLiteral kOrtMemAddrTag = "*/_ORT_MEM_ADDR_/*";
+
+/// Short element-type tag for the informational .constants.json manifest (the
+/// runtime keys off sizes/offsets, not this string). Signless integers map to
+/// `iN`; anything else falls back to the generic type printer.
+std::string elementTypeToString(Type elemType) {
+  return llvm::TypeSwitch<Type, std::string>(elemType)
+      .Case([](Float16Type) { return std::string("f16"); })
+      .Case([](BFloat16Type) { return std::string("bf16"); })
+      .Case([](Float32Type) { return std::string("f32"); })
+      .Case([](Float64Type) { return std::string("f64"); })
+      .Case([](IntegerType intTy) -> std::string {
+        if (intTy.isSignless())
+          return "i" + std::to_string(intTy.getWidth());
+        std::string s;
+        llvm::raw_string_ostream os(s);
+        Type(intTy).print(os);
+        return s;
+      })
+      .Default([](Type ty) {
+        std::string s;
+        llvm::raw_string_ostream os(s);
+        ty.print(os);
+        return s;
+      });
+}
+
+/// Sanitize an ONNX node name into a valid MLIR bare-identifier fragment.
+/// Mirrors OnnxToHipUtils::sanitizeForMlirIdentifier so externalized global
+/// symbol names are identical to the pre-split (in-convert) output.
+std::string sanitizeForMlirIdentifier(StringRef raw) {
+  std::string sanitized;
+  sanitized.reserve(raw.size());
+  for (char c : raw)
+    sanitized.push_back(
+        std::isalnum(static_cast<unsigned char>(c)) || c == '_' ? c : '_');
+  // Collapse runs of '_' and trim leading/trailing ones.
+  std::string result;
+  result.reserve(sanitized.size());
+  bool lastWasUnderscore = true;
+  for (char c : sanitized) {
+    if (c == '_') {
+      if (!lastWasUnderscore)
+        result.push_back(c);
+      lastWasUnderscore = true;
+    } else {
+      result.push_back(c);
+      lastWasUnderscore = false;
+    }
+  }
+  while (!result.empty() && result.back() == '_')
+    result.pop_back();
+  return result;
+}
+
+/// A validated ORT external-data reference read off a location-carrying
+/// hip.constant.
+struct ExternalRef {
+  StringRef location;
+  int64_t offset = 0;
+  int64_t size = 0;
+  bool isMemAddr = false; ///< location == kOrtMemAddrTag (offset is a host ptr)
+};
+
+/// Read + validate the `location`/`offset`/`size` attributes; emit a diagnostic
+/// and return failure on malformed input.
+FailureOr<ExternalRef> readExternalRef(hip::ConstantOp constOp) {
+  auto locAttr = constOp.getLocationAttr();
+  auto offsetAttr = constOp.getOffsetAttr();
+  auto sizeAttr = constOp.getSizeAttr();
+  if (!locAttr || !offsetAttr || !sizeAttr) {
+    constOp.emitError(
+        "hip.constant with location missing location/offset/size");
+    return failure();
+  }
+  ExternalRef ref;
+  ref.location = locAttr.getValue();
+  ref.offset = offsetAttr.getInt();
+  ref.size = sizeAttr.getInt();
+  ref.isMemAddr = (ref.location == kOrtMemAddrTag);
+  if (ref.size <= 0) {
+    constOp.emitError("hip.constant has invalid size");
+    return failure();
+  }
+  if (ref.isMemAddr && ref.offset == 0) {
+    constOp.emitError("hip.constant mem-addr has null address");
+    return failure();
+  }
+  return ref;
+}
+
+/// Replace a carrier with an inline `arith.constant` (below-threshold fold and
+/// the offline / no-externalize path).
+void replaceWithArithConstant(Operation *constOp, DenseElementsAttr valueAttr) {
+  OpBuilder builder(constOp);
+  auto arithConst =
+      arith::ConstantOp::create(builder, constOp->getLoc(), valueAttr);
+  constOp->getResult(0).replaceAllUsesWith(arithConst.getResult());
+  constOp->erase();
+}
+
+/// No-externalize path (threshold disabled): materialize a location-carrying
+/// carrier's bytes inline as an arith.constant. mem-addr reads the live host
+/// pointer; file-ref does a one-shot fread.
+LogicalResult materializeLocationInline(hip::ConstantOp constOp,
+                                        RankedTensorType tensorType) {
+  FailureOr<ExternalRef> ref = readExternalRef(constOp);
+  if (failed(ref))
+    return failure();
+
+  if (ref->isMemAddr) {
+    auto rawData = ArrayRef<char>(
+        reinterpret_cast<const char *>(static_cast<uintptr_t>(ref->offset)),
+        ref->size);
+    replaceWithArithConstant(
+        constOp, DenseElementsAttr::getFromRawBuffer(tensorType, rawData));
+    return success();
+  }
+
+  std::vector<char> buf(static_cast<size_t>(ref->size));
+  std::ifstream ifs(ref->location.str(), std::ios::binary);
+  if (!ifs)
+    return constOp.emitError("failed to open external data file: ")
+           << ref->location;
+  ifs.seekg(ref->offset);
+  ifs.read(buf.data(), ref->size);
+  if (!ifs)
+    return constOp.emitError("short read from external data file: ")
+           << ref->location;
+  replaceWithArithConstant(
+      constOp, DenseElementsAttr::getFromRawBuffer(
+                   tensorType, ArrayRef<char>(buf.data(), buf.size())));
+  return success();
+}
+
+/// Accumulates the constants-blob layout across the module walk and emits the
+/// extern globals, the `<model>.constants.bin` sidecar (or per-entry
+/// descriptors in skip-data mode), and the module-level metadata attributes.
+/// One instance per pass run; only created when externalization is enabled
+/// (threshold > 0).
+class ConstantExternalizer {
+public:
+  ConstantExternalizer(ModuleOp module, morphizen::FileSystem &fs,
+                       bool skipDataWrite)
+      : module_(module), ctx_(module.getContext()), fs_(fs),
+        skipDataWrite_(skipDataWrite),
+        binFileName_(moduleBaseName(module) + ".constants.bin") {}
+
+  /// Externalize an inline-`value` carrier already known to be at/above the
+  /// threshold. Splat values store only the single element (the sidecar writer
+  /// tiles it), so peak host memory stays bounded regardless of tensor size.
+  void externalizeValue(hip::ConstantOp constOp, RankedTensorType tensorType,
+                        DenseElementsAttr valueAttr) {
+    int64_t elemBytes = (tensorType.getElementTypeBitWidth() + 7) / 8;
+    int64_t byteSize = valueAttr.getNumElements() * elemBytes;
+    ArrayRef<char> raw = valueAttr.getRawData();
+    HostEntry entry;
+    entry.ptr = raw.data();
+    if (valueAttr.isSplat())
+      entry.splatElemSize = static_cast<int64_t>(raw.size());
+    recordEntry(constOp, tensorType, byteSize, std::move(entry));
+  }
+
+  /// Externalize a location-carrying carrier (ORT external data): mem-addr ->
+  /// the live host pointer, file-ref -> the on-disk (path, offset).
+  LogicalResult externalizeLocation(hip::ConstantOp constOp,
+                                    RankedTensorType tensorType) {
+    FailureOr<ExternalRef> ref = readExternalRef(constOp);
+    if (failed(ref))
+      return failure();
+    HostEntry entry;
+    if (ref->isMemAddr) {
+      entry.ptr =
+          reinterpret_cast<const void *>(static_cast<uintptr_t>(ref->offset));
+    } else {
+      entry.filePath = ref->location.str();
+      entry.fileOffset = ref->offset;
+    }
+    recordEntry(constOp, tensorType, ref->size, std::move(entry));
+    return success();
+  }
+
+  bool empty() const { return constantIndex_ == 0; }
+
+  /// Stamp `hip.constants_file`, write the bytes (full sidecar or partial
+  /// mem-addr sidecar), and emit the `hipdnn.constants` descriptor array. The
+  /// writers do the I/O and return the per-constant descriptors; this owns the
+  /// module attributes so both modes emit them the same way.
+  LogicalResult finalize() {
+    module_->setAttr(constant_meta::kConstantsFileAttr,
+                     StringAttr::get(ctx_, binFileName_));
+    FailureOr<SmallVector<Attribute>> descriptors =
+        skipDataWrite_ ? writePerEntryDescriptors() : writeFullSidecar();
+    if (failed(descriptors))
+      return failure();
+    module_->setAttr(constant_meta::kConstantsAttr,
+                     ArrayAttr::get(ctx_, *descriptors));
+    return success();
+  }
+
+private:
+  /// One record per externalized constant, in emission (index) order. The
+  /// active source is discriminated by the fields: splat if `splatElemSize >
+  /// 0`, file-ref if `filePath` is non-empty, otherwise mem-addr/dense (`ptr`).
+  struct HostEntry {
+    const void *ptr = nullptr;
+    int64_t splatElemSize = 0;
+    std::string filePath;
+    int64_t fileOffset = 0;
+  };
+
+  static std::string moduleBaseName(ModuleOp module) {
+    if (auto sym =
+            module->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName()))
+      return sym.getValue().str();
+    return "model";
+  }
+
+  /// Append one constant to the 64B-aligned running layout and rewrite it to
+  /// the extern `memref.global` + `get_global`/`to_tensor` bridge.
+  void recordEntry(Operation *constOp, RankedTensorType tensorType,
+                   int64_t byteSize, HostEntry entry) {
+    int64_t entryOffset = llvm::alignTo(currentOffset_, kConstantAlignment);
+    currentOffset_ = entryOffset + byteSize;
+
+    std::string name = makeGlobalName(constOp);
+    recordManifest(name, tensorType, entryOffset, byteSize);
+    sizes_.push_back(byteSize);
+    offsets_.push_back(entryOffset);
+    hostEntries_.push_back(std::move(entry));
+
+    emitExternGlobalBridge(constOp, tensorType, name, entryOffset, byteSize);
+    ++constantIndex_;
+  }
+
+  /// Reproduce the pre-split naming:
+  /// hip_ext_constant_<sanitized-onnx-name>_<idx> (falling back to
+  /// node.outputs[0], then a bare index). The raw ONNX name is stashed in
+  /// `names_` for the ConstantEntry.
+  std::string makeGlobalName(Operation *constOp) {
+    std::string name = "hip_ext_constant_";
+    std::string onnxName;
+    if (auto nodeName = constOp->getAttrOfType<StringAttr>("onnx_node_name")) {
+      onnxName = nodeName.getValue().str();
+      if (std::string frag = sanitizeForMlirIdentifier(nodeName.getValue());
+          !frag.empty())
+        name += frag + "_";
+    }
+    // Initializers carry their tensor name in node.outputs[0], not the
+    // (possibly empty) onnx_node_name.
+    if (onnxName.empty())
+      if (auto outputs = constOp->getAttrOfType<ArrayAttr>("node.outputs"))
+        if (!outputs.empty())
+          if (auto s = dyn_cast<StringAttr>(outputs.getValue().front()))
+            onnxName = s.getValue().str();
+    name += std::to_string(constantIndex_);
+    names_.push_back(onnxName);
+    return name;
+  }
+
+  void recordManifest(StringRef name, RankedTensorType tensorType,
+                      int64_t offset, int64_t byteSize) {
+    llvm::json::Array shape;
+    for (int64_t dim : tensorType.getShape())
+      shape.push_back(dim);
+    manifest_.push_back(llvm::json::Object{
+        {"name", name},
+        {"shape", std::move(shape)},
+        {"element_type", elementTypeToString(tensorType.getElementType())},
+        {"offset", offset},
+        {"size", byteSize},
+        {"alignment", kConstantAlignment},
+    });
+  }
+
+  void emitExternGlobalBridge(Operation *constOp, RankedTensorType tensorType,
+                              StringRef name, int64_t offset,
+                              int64_t byteSize) {
+    auto memrefType =
+        MemRefType::get(tensorType.getShape(), tensorType.getElementType());
+
+    OpBuilder moduleBuilder(module_.getBody(), module_.getBody()->begin());
+    auto externalData = moduleBuilder.getDictionaryAttr({
+        moduleBuilder.getNamedAttr(
+            "index", moduleBuilder.getI64IntegerAttr(constantIndex_)),
+        moduleBuilder.getNamedAttr("offset",
+                                   moduleBuilder.getI64IntegerAttr(offset)),
+        moduleBuilder.getNamedAttr("size",
+                                   moduleBuilder.getI64IntegerAttr(byteSize)),
+    });
+    auto globalOp = memref::GlobalOp::create(
+        moduleBuilder, constOp->getLoc(), name,
+        /*sym_visibility=*/moduleBuilder.getStringAttr("private"),
+        /*type=*/memrefType, /*initial_value=*/nullptr, /*constant=*/false,
+        /*alignment=*/moduleBuilder.getI64IntegerAttr(kConstantAlignment));
+    globalOp->setAttr("hip.external_data", externalData);
+
+    OpBuilder builder(constOp);
+    auto getGlobal = memref::GetGlobalOp::create(builder, constOp->getLoc(),
+                                                 memrefType, name);
+    auto toTensor = bufferization::ToTensorOp::create(
+        builder, constOp->getLoc(), tensorType, getGlobal.getResult(),
+        /*restrict=*/builder.getUnitAttr(), /*writable=*/nullptr);
+    constOp->getResult(0).replaceAllUsesWith(toTensor.getResult());
+    constOp->erase();
+  }
+
+  /// Build one `hipdnn.constants` descriptor dictionary for constant `i`.
+  /// offset/size/kind are always present; kind-specific keys are added only for
+  /// the matching kind, so each entry is self-describing.
+  DictionaryAttr
+  makeConstantDict(int64_t i, ConstantSourceKind kind, int64_t splatValue = 0,
+                   int64_t splatElemSize = 0, StringRef filePath = {},
+                   int64_t fileOffset = 0, int64_t sidecarOffset = 0) {
+    namespace cm = constant_meta;
+    Builder b(ctx_);
+    SmallVector<NamedAttribute> f;
+    f.emplace_back(b.getStringAttr(cm::kOffset),
+                   b.getI64IntegerAttr(offsets_[i]));
+    f.emplace_back(b.getStringAttr(cm::kSize), b.getI64IntegerAttr(sizes_[i]));
+    f.emplace_back(b.getStringAttr(cm::kKind),
+                   b.getI64IntegerAttr(static_cast<int64_t>(kind)));
+    switch (kind) {
+    case ConstantSourceKind::Splat:
+      f.emplace_back(b.getStringAttr(cm::kSplatValue),
+                     b.getI64IntegerAttr(splatValue));
+      f.emplace_back(b.getStringAttr(cm::kSplatElemSize),
+                     b.getI64IntegerAttr(splatElemSize));
+      break;
+    case ConstantSourceKind::FileRef:
+      f.emplace_back(b.getStringAttr(cm::kFilePath), b.getStringAttr(filePath));
+      f.emplace_back(b.getStringAttr(cm::kFileOffset),
+                     b.getI64IntegerAttr(fileOffset));
+      break;
+    case ConstantSourceKind::Sidecar:
+      f.emplace_back(b.getStringAttr(cm::kSidecarOffset),
+                     b.getI64IntegerAttr(sidecarOffset));
+      break;
+    case ConstantSourceKind::None:
+      break;
+    }
+    return b.getDictionaryAttr(f);
+  }
+
+  /// Full-sidecar mode: stream every constant's bytes into constants.bin and
+  /// write the JSON manifest; returns one `kind = None` descriptor per
+  /// constant.
+  FailureOr<SmallVector<Attribute>> writeFullSidecar() {
+    std::vector<mlir::hip::ConstantEntry> entries;
+    entries.reserve(hostEntries_.size());
+    for (auto [i, h] : llvm::enumerate(hostEntries_)) {
+      mlir::hip::ConstantEntry e;
+      e.name = names_[i];
+      e.offset = offsets_[i];
+      e.size = sizes_[i];
+      e.data = h.ptr;
+      e.splat_elem_size = h.splatElemSize;
+      e.file_path = h.filePath;
+      e.file_offset = h.fileOffset;
+      entries.push_back(std::move(e));
+    }
+    if (!mlir::hip::writeConstantsBinToFileSystem(&fs_, binFileName_, entries,
+                                                  currentOffset_)) {
+      module_.emitError("failed to write constants binary file: " +
+                        binFileName_);
+      return failure();
+    }
+
+    std::string jsonPath = moduleBaseName(module_) + ".constants.json";
+    llvm::json::Object manifest;
+    manifest["version"] = 1;
+    manifest["binary_file"] = binFileName_;
+    manifest["num_constants"] = constantIndex_;
+    manifest["total_bytes"] = currentOffset_;
+    manifest["constants"] = std::move(manifest_);
+    auto jsonWriter = fs_.create_writer_template(jsonPath.c_str());
+    if (!jsonWriter) {
+      module_.emitError("failed to open constants manifest: " + jsonPath);
+      return failure();
+    }
+    std::string jsonStr;
+    llvm::raw_string_ostream jsonOs(jsonStr);
+    jsonOs << llvm::formatv("{0:2}", llvm::json::Value(std::move(manifest)));
+    jsonWriter->fwrite(jsonStr.data(), jsonStr.size());
+
+    // Every constant's bytes live in the full sidecar at its offset, so all
+    // descriptors are kind = None.
+    SmallVector<Attribute> dicts;
+    dicts.reserve(sizes_.size());
+    for (size_t i : llvm::seq(sizes_.size()))
+      dicts.push_back(makeConstantDict(i, ConstantSourceKind::None));
+    return dicts;
+  }
+
+  /// Skip-data mode: pack mem-addr bytes into a partial sidecar and return one
+  /// self-describing descriptor per constant. mem-addr entries become Sidecar
+  /// (their bytes are only live during this compile); splat/file-ref entries
+  /// stream from their descriptor and carry no sidecar bytes.
+  FailureOr<SmallVector<Attribute>> writePerEntryDescriptors() {
+    // Pass 1: pack mem-addr bytes into a compact 64B-aligned partial sidecar.
+    SmallVector<int64_t> sidecarOffsets(hostEntries_.size(), 0);
+    std::vector<mlir::hip::ConstantEntry> partialEntries;
+    int64_t sidecarPos = 0;
+    for (auto [i, h] : llvm::enumerate(hostEntries_)) {
+      if (!h.filePath.empty() || h.splatElemSize > 0)
+        continue; // file-ref / splat stream from their descriptor
+      int64_t off = llvm::alignTo(sidecarPos, kConstantAlignment);
+      sidecarOffsets[i] = off;
+      mlir::hip::ConstantEntry e;
+      e.name = names_[i];
+      e.offset = off;
+      e.size = sizes_[i];
+      e.data = h.ptr;
+      partialEntries.push_back(std::move(e));
+      sidecarPos = off + sizes_[i];
+    }
+    if (!partialEntries.empty() &&
+        !mlir::hip::writeConstantsBinToFileSystem(&fs_, binFileName_,
+                                                  partialEntries, sidecarPos)) {
+      module_.emitError("failed to write partial mem-addr sidecar: " +
+                        binFileName_);
+      return failure();
+    }
+
+    // Pass 2: one self-describing descriptor per constant.
+    SmallVector<Attribute> dicts;
+    dicts.reserve(hostEntries_.size());
+    for (auto [i, h] : llvm::enumerate(hostEntries_)) {
+      if (!h.filePath.empty()) {
+        dicts.push_back(makeConstantDict(i, ConstantSourceKind::FileRef,
+                                         /*splatValue=*/0, /*splatElemSize=*/0,
+                                         h.filePath, h.fileOffset));
+      } else if (h.splatElemSize > 0) {
+        // Left-pack up to 8 element bytes into an i64 carrier.
+        int64_t splatValue = 0;
+        std::memcpy(&splatValue, h.ptr,
+                    static_cast<size_t>(std::min<int64_t>(h.splatElemSize, 8)));
+        dicts.push_back(makeConstantDict(i, ConstantSourceKind::Splat,
+                                         splatValue, h.splatElemSize));
+      } else {
+        dicts.push_back(makeConstantDict(i, ConstantSourceKind::Sidecar,
+                                         /*splatValue=*/0, /*splatElemSize=*/0,
+                                         /*filePath=*/{}, /*fileOffset=*/0,
+                                         sidecarOffsets[i]));
+      }
+    }
+    return dicts;
+  }
+
+  ModuleOp module_;
+  MLIRContext *ctx_;
+  morphizen::FileSystem &fs_;
+  bool skipDataWrite_;
+  std::string binFileName_;
+
+  int64_t currentOffset_ = 0;
+  int64_t constantIndex_ = 0;
+  llvm::SmallVector<int64_t> sizes_;
+  llvm::SmallVector<int64_t> offsets_;
+  llvm::SmallVector<std::string> names_;
+  llvm::SmallVector<HostEntry> hostEntries_;
+  llvm::json::Array manifest_;
+};
+
+struct ExternalizeConstantsPass
+    : public impl::ExternalizeConstantsPassBase<ExternalizeConstantsPass> {
+  using ExternalizeConstantsPassBase::ExternalizeConstantsPassBase;
+
+  ExternalizeConstantsPass(morphizen::FileSystem *fs, int64_t minNumElements,
+                           bool skipConstantData = false)
+      : fileSystem_(fs), fsMinNumElements_(minNumElements),
+        skipConstantData_(skipConstantData) {}
+
+  void runOnOperation() override;
+
+  morphizen::FileSystem *fileSystem_ = nullptr;
+  int64_t fsMinNumElements_ = 0;
+  bool skipConstantData_ = false;
+};
+
+void ExternalizeConstantsPass::runOnOperation() {
+  ModuleOp module = getOperation();
+
+  // FileSystem + threshold + skip-data come from the ctor (EP live-compile) or
+  // the CLI pass options (standalone hip-mlir-opt). CLI falls back to a
+  // DiskFileSystem rooted at externalize-output-dir.
+  std::unique_ptr<DiskFileSystem> fallbackFs;
+  morphizen::FileSystem *fs = fileSystem_;
+  int64_t minElems =
+      fileSystem_ ? fsMinNumElements_ : externalizeMinNumElements.getValue();
+  bool skipData = fileSystem_ ? skipConstantData_ : skipConstantData.getValue();
+  if (!fs) {
+    StringRef dir = externalizeOutputDir.getValue();
+    fallbackFs =
+        std::make_unique<DiskFileSystem>(dir.empty() ? "." : dir.str().c_str());
+    fs = fallbackFs.get();
+  }
+
+  const bool externalizing = minElems > 0;
+  std::optional<ConstantExternalizer> externalizer;
+  if (externalizing)
+    externalizer.emplace(module, *fs, skipData);
+
+  // Collect first: rewriting/erasing carriers during the walk would invalidate
+  // it.
+  SmallVector<hip::ConstantOp> constants;
+  module.walk([&](hip::ConstantOp c) { constants.push_back(c); });
+
+  for (hip::ConstantOp constOp : constants) {
+    auto tensorType = dyn_cast<RankedTensorType>(constOp.getResult().getType());
+    if (!tensorType) {
+      constOp.emitError("hip.constant has non-ranked result type");
+      return signalPassFailure();
+    }
+
+    if (auto valueAttr =
+            dyn_cast_if_present<DenseElementsAttr>(constOp.getValueAttr())) {
+      // Location constants are always externalized; value constants only at or
+      // above the element-count threshold, else they fold inline.
+      if (externalizing && valueAttr.getNumElements() >= minElems)
+        externalizer->externalizeValue(constOp, tensorType, valueAttr);
+      else
+        replaceWithArithConstant(constOp, valueAttr);
+      continue;
+    }
+    if (constOp.getLocationAttr()) {
+      LogicalResult r =
+          externalizing ? externalizer->externalizeLocation(constOp, tensorType)
+                        : materializeLocationInline(constOp, tensorType);
+      if (failed(r))
+        return signalPassFailure();
+      continue;
+    }
+    constOp.emitError("hip.constant missing value or location attribute");
+    return signalPassFailure();
+  }
+
+  if (externalizer && !externalizer->empty())
+    if (failed(externalizer->finalize()))
+      return signalPassFailure();
+}
+
+} // namespace
+
+std::unique_ptr<mlir::Pass>
+createExternalizeConstantsPass(morphizen::FileSystem *fs,
+                               int64_t minNumElements, bool skipConstantData) {
+  return std::make_unique<ExternalizeConstantsPass>(fs, minNumElements,
+                                                    skipConstantData);
+}
+
+} // namespace hip
+} // namespace mlir

--- a/lib/Dialect/Transforms/GenerateInterface.cpp
+++ b/lib/Dialect/Transforms/GenerateInterface.cpp
@@ -18,6 +18,7 @@
 #include "compilation_options_generated.h"
 #include "flatbuffers/flatbuffers.h"
 #include "hip/Dialect/IR/HipDialect.h"
+#include "hip/Dialect/Transforms/ConstantMetadata.h"
 #include "hip/Dialect/Transforms/Passes.h"
 #include "hip/artifact_abi.h"
 #include "hip/debug_log.h"
@@ -68,79 +69,61 @@ buildMetadataNative(ModuleOp module, const std::string &constantsFile) {
       module->getAttrOfType<IntegerAttr>("hipdnn.input_count");
   auto outputCountAttr =
       module->getAttrOfType<IntegerAttr>("hipdnn.output_count");
-  auto constantSizesAttr =
-      module->getAttrOfType<DenseI64ArrayAttr>("hipdnn.constant_sizes");
-  auto constantOffsetsAttr =
-      module->getAttrOfType<DenseI64ArrayAttr>("hipdnn.constant_offsets");
-
-  // Streaming-mode source descriptors. Present when OnnxToHip's finalize
-  // emitted per-constant source info (splat / file-ref / sidecar). Absent in
-  // full-sidecar mode (EPContext export), in which case every ConstantInfo
-  // keeps source = NONE and runtime falls back to the bulk constants_filename
-  // read. In hybrid mode (skipDataWrite=true with mem-addr entries) some
-  // constants carry SidecarSource pointing at a *partial* sidecar that holds
-  // only mem-addr bytes.
-  auto sourceKindsAttr =
-      module->getAttrOfType<DenseI32ArrayAttr>("hipdnn.constant_source_kinds");
-  auto splatValuesAttr = module->getAttrOfType<DenseI64ArrayAttr>(
-      "hipdnn.constant_splat_elem_values");
-  auto splatElemSizesAttr = module->getAttrOfType<DenseI64ArrayAttr>(
-      "hipdnn.constant_splat_elem_sizes");
-  auto filePathsAttr =
-      module->getAttrOfType<ArrayAttr>("hipdnn.constant_file_paths");
-  auto fileOffsetsAttr =
-      module->getAttrOfType<DenseI64ArrayAttr>("hipdnn.constant_file_offsets");
-  auto sidecarOffsetsAttr = module->getAttrOfType<DenseI64ArrayAttr>(
-      "hipdnn.constant_sidecar_offsets");
+  // Per-constant descriptors emitted by hip-externalize-constants: one
+  // self-describing DictionaryAttr per externalized constant, in index order.
+  // kind == None => bytes live in the bulk constants_filename at `offset`;
+  // the other kinds (splat / file-ref / sidecar) carry a source union. Absent
+  // entirely when nothing was externalized.
+  auto constantsAttr = module->getAttrOfType<ArrayAttr>(
+      mlir::hip::constant_meta::kConstantsAttr);
 
   mlir::hip::HipModelMetaInfoT meta;
   meta.version = 1;
   meta.constants_filename = constantsFile;
 
-  if (constantSizesAttr) {
-    auto sizes = constantSizesAttr.asArrayRef();
-    auto offsets = constantOffsetsAttr ? constantOffsetsAttr.asArrayRef()
-                                       : ArrayRef<int64_t>{};
-    auto kinds =
-        sourceKindsAttr ? sourceKindsAttr.asArrayRef() : ArrayRef<int32_t>{};
-    auto splatValues =
-        splatValuesAttr ? splatValuesAttr.asArrayRef() : ArrayRef<int64_t>{};
-    auto splatElemSizes = splatElemSizesAttr ? splatElemSizesAttr.asArrayRef()
-                                             : ArrayRef<int64_t>{};
-    auto fileOffsets =
-        fileOffsetsAttr ? fileOffsetsAttr.asArrayRef() : ArrayRef<int64_t>{};
-    auto sidecarOffsets = sidecarOffsetsAttr ? sidecarOffsetsAttr.asArrayRef()
-                                             : ArrayRef<int64_t>{};
-    for (auto i : llvm::seq<size_t>(0, sizes.size())) {
+  if (constantsAttr) {
+    namespace cm = mlir::hip::constant_meta;
+    for (Attribute entry : constantsAttr) {
+      auto dict = dyn_cast<DictionaryAttr>(entry);
+      if (!dict)
+        continue;
+      auto getI64 = [&](StringRef key) -> int64_t {
+        auto a = dict.getAs<IntegerAttr>(key);
+        return a ? a.getInt() : 0;
+      };
       auto ci = std::make_unique<mlir::hip::ConstantInfoT>();
-      ci->size = sizes[i];
-      ci->offset = (i < offsets.size()) ? offsets[i] : 0;
-      int32_t kind = (i < kinds.size()) ? kinds[i] : 0;
-      if (kind == 1) {
-        // Splat: extract the left-packed elem bytes out of the i64 carrier.
+      ci->size = getI64(cm::kSize);
+      ci->offset = getI64(cm::kOffset);
+      switch (static_cast<mlir::hip::ConstantSourceKind>(getI64(cm::kKind))) {
+      case mlir::hip::ConstantSourceKind::Splat: {
+        // Extract the left-packed elem bytes out of the i64 carrier.
         auto splat = std::make_unique<mlir::hip::SplatSourceT>();
-        int64_t elemSize = (i < splatElemSizes.size()) ? splatElemSizes[i] : 0;
-        size_t n = static_cast<size_t>(std::min<int64_t>(elemSize, 8));
-        const auto *base = reinterpret_cast<const uint8_t *>(&splatValues[i]);
+        int64_t packed = getI64(cm::kSplatValue);
+        size_t n = static_cast<size_t>(
+            std::min<int64_t>(getI64(cm::kSplatElemSize), 8));
+        const auto *base = reinterpret_cast<const uint8_t *>(&packed);
         splat->elem_bytes.assign(base, base + n);
         ci->source.Set(std::move(*splat));
-      } else if (kind == 2) {
+        break;
+      }
+      case mlir::hip::ConstantSourceKind::FileRef: {
         auto fref = std::make_unique<mlir::hip::FileRefSourceT>();
-        if (filePathsAttr && i < filePathsAttr.size()) {
-          if (auto s = dyn_cast<StringAttr>(filePathsAttr.getValue()[i]))
-            fref->path = s.getValue().str();
-        }
-        fref->file_offset = (i < fileOffsets.size()) ? fileOffsets[i] : 0;
+        if (auto p = dict.getAs<StringAttr>(cm::kFilePath))
+          fref->path = p.getValue().str();
+        fref->file_offset = getI64(cm::kFileOffset);
         ci->source.Set(std::move(*fref));
-      } else if (kind == 3) {
-        // Sidecar: mem-addr entry packed into
-        // HipModelMetaInfo.constants_filename at sidecar_offset by the
-        // OnnxToHip hybrid finalize. Runtime reads size bytes from that offset
-        // through the EP FileSystem.
+        break;
+      }
+      case mlir::hip::ConstantSourceKind::Sidecar: {
+        // mem-addr bytes packed into constants_filename at sidecar_offset by
+        // the hybrid finalize; the runtime reads `size` bytes from that offset.
         auto side = std::make_unique<mlir::hip::SidecarSourceT>();
-        side->sidecar_offset =
-            (i < sidecarOffsets.size()) ? sidecarOffsets[i] : 0;
+        side->sidecar_offset = getI64(cm::kSidecarOffset);
         ci->source.Set(std::move(*side));
+        break;
+      }
+      case mlir::hip::ConstantSourceKind::None:
+        break;
       }
       meta.constants.push_back(std::move(ci));
     }

--- a/lib/Dialect/Transforms/Pipelines.cpp
+++ b/lib/Dialect/Transforms/Pipelines.cpp
@@ -339,21 +339,31 @@ void mlir::hip::buildOnnxToHipPipeline(OpPassManager &pm,
   addPluginPassesForSlot(pm,
                          ::hip::compiler::PipelineSlot::AfterOnnxLoopOutline);
 
-  if (fs) {
-    pm.addPass(mlir::hip::createConvertOnnxToHipPass(
-        fs, options.externalizeMinNumElements, options.skipConstantData));
-  } else {
-    ConvertOnnxToHipPassOptions onnxToHipOpts;
-    onnxToHipOpts.externalizeOutputDir = options.externalizeOutputDir;
-    onnxToHipOpts.externalizeMinNumElements = options.externalizeMinNumElements;
-    pm.addPass(createConvertOnnxToHipPass(std::move(onnxToHipOpts)));
-  }
+  // convert-onnx-to-hip now emits neutral hip.constant carriers; the actual
+  // externalization runs in the standalone hip-externalize-constants pass
+  // below, so plugin-emitted hip.constant ops are serialized identically.
+  pm.addPass(createConvertOnnxToHipPass());
 
   // Plugin slot: AfterConvertOnnxToHip. The most common slot for
   // vendor lowerings of `onnx.Custom` ops or vendor-specific hip.*
-  // canonicalisations.
+  // canonicalisations. Vendor ops may emit hip.constant here for their
+  // weights; the externalize pass (next) serializes them.
   addPluginPassesForSlot(pm,
                          ::hip::compiler::PipelineSlot::AfterConvertOnnxToHip);
+
+  // Externalize hip.constant -> constants.bin. After the AfterConvertOnnxToHip
+  // slot (so plugin constants are included) and before bufferization (in the
+  // tail). The FileSystem overload writes into the EPContext tar.
+  if (fs) {
+    pm.addPass(mlir::hip::createExternalizeConstantsPass(
+        fs, options.externalizeMinNumElements, options.skipConstantData));
+  } else {
+    ExternalizeConstantsPassOptions extOpts;
+    extOpts.externalizeOutputDir = options.externalizeOutputDir;
+    extOpts.externalizeMinNumElements = options.externalizeMinNumElements;
+    extOpts.skipConstantData = options.skipConstantData;
+    pm.addPass(createExternalizeConstantsPass(std::move(extOpts)));
+  }
 
   buildOnnxToHipPipelineTail(pm);
 }
@@ -378,18 +388,22 @@ void mlir::hip::buildOnnxToHipPipeline(OpPassManager &pm,
     pm.addPass(createCompileHipDNNGraphsPass(handle, std::move(output_graphs)));
   }
 
-  if (fs) {
-    pm.addPass(mlir::hip::createConvertOnnxToHipPass(
-        fs, options.externalizeMinNumElements, options.skipConstantData));
-  } else {
-    ConvertOnnxToHipPassOptions onnxToHipOpts;
-    onnxToHipOpts.externalizeOutputDir = options.externalizeOutputDir;
-    onnxToHipOpts.externalizeMinNumElements = options.externalizeMinNumElements;
-    pm.addPass(createConvertOnnxToHipPass(std::move(onnxToHipOpts)));
-  }
+  pm.addPass(createConvertOnnxToHipPass());
 
   addPluginPassesForSlot(pm,
                          ::hip::compiler::PipelineSlot::AfterConvertOnnxToHip);
+
+  // Externalize hip.constant carriers (in-tree + plugin) to constants.bin.
+  if (fs) {
+    pm.addPass(mlir::hip::createExternalizeConstantsPass(
+        fs, options.externalizeMinNumElements, options.skipConstantData));
+  } else {
+    ExternalizeConstantsPassOptions extOpts;
+    extOpts.externalizeOutputDir = options.externalizeOutputDir;
+    extOpts.externalizeMinNumElements = options.externalizeMinNumElements;
+    extOpts.skipConstantData = options.skipConstantData;
+    pm.addPass(createExternalizeConstantsPass(std::move(extOpts)));
+  }
 
   buildOnnxToHipPipelineTail(pm);
 }

--- a/test/lit/Conversion/onnx-to-hip/test_constant_externalize_named.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_constant_externalize_named.mlir
@@ -10,7 +10,7 @@
 // underscores -- so "/model/MatMul_weights" becomes "model_MatMul_weights".
 //===----------------------------------------------------------------------===//
 
-// RUN: mkdir -p %t && hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip='externalize-min-num-elements=4 externalize-output-dir=%t' %s | FileCheck %s
+// RUN: mkdir -p %t && hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip --hip-externalize-constants='externalize-min-num-elements=4 externalize-output-dir=%t' %s | FileCheck %s
 
 // CHECK: memref.global "private" @hip_ext_constant_model_MatMul_weights_0 : memref<2x4xf32> {alignment = 64 : i64, hip.external_data = {index = 0 : i64, offset = 0 : i64, size = 32 : i64}}
 // CHECK: func.func @main_graph(%arg0: !hip.context) -> tensor<2x4xf32>

--- a/test/lit/Conversion/onnx-to-hip/test_constant_handling.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_constant_handling.mlir
@@ -2,24 +2,23 @@
 // Licensed under the MIT License.
 //
 //===----------------------------------------------------------------------===//
-// Test: constant externalization emits hipdnn.constant_sizes/offsets and
+// Test: constant externalization emits the hipdnn.constants descriptor array and
 // hip.external_data with index field.
 //
 // Verifies:
 // - Large constants (splat and non-splat) are externalized to memref.global
 //   with hip.external_data containing index, offset, and size
-// - hipdnn.constant_sizes and hipdnn.constant_offsets module attributes
-//   are emitted
+// - a hipdnn.constants module attribute (one offset/size/kind descriptor per
+//   externalized constant) is emitted
 // - Small constants (below threshold) remain inline as arith.constant
 //===----------------------------------------------------------------------===//
 
-// RUN: mkdir -p %t && hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip='externalize-min-num-elements=4 externalize-output-dir=%t' %s | FileCheck %s
+// RUN: mkdir -p %t && hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip --hip-externalize-constants='externalize-min-num-elements=4 externalize-output-dir=%t' %s | FileCheck %s
 
 // Module-level: constants file, sizes, and offsets attributes.
 // CHECK: module attributes {
 // CHECK-SAME: hip.constants_file = "model.constants.bin"
-// CHECK-SAME: hipdnn.constant_offsets = array<i64:
-// CHECK-SAME: hipdnn.constant_sizes = array<i64:
+// CHECK-SAME: hipdnn.constants = [{kind = 0 : i64, offset = 0 : i64, size = 64 : i64}, {kind = 0 : i64, offset = 64 : i64, size = 32 : i64}]
 
 // Extern memref.global with index in hip.external_data.
 // Splat constant (4x4, 16 elements >= threshold) externalized as index 0.

--- a/test/lit/Conversion/onnx-to-hip/test_constant_location_missing_attrs.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_constant_location_missing_attrs.mlir
@@ -9,11 +9,11 @@
 // are absent.
 //===----------------------------------------------------------------------===//
 
-// RUN: not hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s 2>&1 | FileCheck %s
+// RUN: not hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip --hip-externalize-constants %s 2>&1 | FileCheck %s
 
-// CHECK: error: onnx.Constant with location attribute missing location/offset/size
-// CHECK-NEXT: %0 = "onnx.Constant"() {location = "*/_ORT_MEM_ADDR_/*"} : () -> tensor<2x4xf32>
-// CHECK-NEXT: ^
+// convert-onnx-to-hip lowers the malformed constant to a hip.constant carrier;
+// hip-externalize-constants emits the diagnostic when offset/size are absent.
+// CHECK: error: hip.constant with location missing location/offset/size
 
 module {
   func.func @main_graph() -> tensor<2x4xf32> {

--- a/test/lit/Conversion/onnx-to-hip/test_constant_location_null_addr.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_constant_location_null_addr.mlir
@@ -8,11 +8,11 @@
 // Verify the pass rejects it with a clear diagnostic.
 //===----------------------------------------------------------------------===//
 
-// RUN: not hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s 2>&1 | FileCheck %s
+// RUN: not hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip --hip-externalize-constants %s 2>&1 | FileCheck %s
 
-// CHECK: error: onnx.Constant mem-addr has null address
-// CHECK-NEXT: %0 = "onnx.Constant"() {location = "*/_ORT_MEM_ADDR_/*", offset = 0 : i64, size = 32 : i64} : () -> tensor<2x4xf32>
-// CHECK-NEXT: ^
+// convert-onnx-to-hip lowers to a hip.constant carrier; hip-externalize-constants
+// rejects the null mem-addr.
+// CHECK: error: hip.constant mem-addr has null address
 
 module {
   func.func @main_graph() -> tensor<2x4xf32> {

--- a/test/lit/Conversion/onnx-to-hip/test_gqa_prefill_sentinel.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_gqa_prefill_sentinel.mlir
@@ -68,9 +68,10 @@ module {
         -> (tensor<1x128x4096xf16>, tensor<1x8x128x128xf16>, tensor<1x8x128x128xf16>)
 
     // The constant -1 must reach the conversion intact and the op must
-    // lower cleanly to hip.gqa. The onnx.Constant is folded to
-    // arith.constant; the value must be preserved verbatim.
-    // CHECK: arith.constant dense<-1> : tensor<1xi32>
+    // lower cleanly to hip.gqa. The onnx.Constant is lowered to a hip.constant
+    // carrier (externalization is deferred to hip-externalize-constants); the
+    // value must be preserved verbatim.
+    // CHECK: hip.constant {value = dense<-1> : tensor<1xi32>}
     // CHECK: hip.gqa(%[[CTX]])
     // CHECK-SAME: kv_num_heads = 8
     // CHECK-SAME: num_heads = 32

--- a/test/lit/Conversion/onnx-to-hip/test_pow.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_pow.mlir
@@ -29,8 +29,9 @@
 // ============================================================================
 
 // RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip | FileCheck %s
-// RUN: hip-mlir-opt %s --hip-add-context-arg \
-// RUN:   --convert-onnx-to-hip="externalize-min-num-elements=1" \
+// RUN: mkdir -p %t && hip-mlir-opt %s --hip-add-context-arg \
+// RUN:   --convert-onnx-to-hip \
+// RUN:   --hip-externalize-constants="externalize-min-num-elements=1 externalize-output-dir=%t" \
 // RUN:   | FileCheck %s --check-prefix=EXTERN
 
 module {

--- a/test/lit/Dialect/hip-externalize-constants.mlir
+++ b/test/lit/Dialect/hip-externalize-constants.mlir
@@ -1,0 +1,40 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: mkdir -p %t && hip-mlir-opt --hip-externalize-constants='externalize-min-num-elements=4 externalize-output-dir=%t' %s | FileCheck %s
+
+// Spike: prove the neutral hip.constant carrier + the standalone, dialect-
+// agnostic hip-externalize-constants pass. There is NO onnx op anywhere in this
+// file -- the pass keys only on hip.constant, so this also demonstrates that a
+// downstream plugin (which never touches the onnx dialect) can emit hip.constant
+// and get its weights externalized identically to in-tree ops.
+
+// Module-level externalization metadata is stamped (same contract that
+// convert-onnx-to-hip stamps today, so generate-interface + runtime are
+// unaffected by the split).
+// CHECK-DAG: hip.constants_file = "model.constants.bin"
+// CHECK-DAG: hipdnn.constants = [{kind = 0 : i64, offset = 0 : i64, size = 32 : i64}]
+
+// The large constant (8 elements >= threshold 4) becomes an extern
+// memref.global carrying hip.external_data (the exact form
+// hip-resolve-extern-constants consumes).
+// CHECK: memref.global "private" @hip_ext_constant_0
+// CHECK-SAME: hip.external_data = {index = 0 : i64, offset = 0 : i64, size = 32 : i64}
+
+// CHECK-LABEL: func.func @large_const
+// CHECK: %[[G:.*]] = memref.get_global @hip_ext_constant_0 : memref<2x4xf32>
+// CHECK: bufferization.to_tensor %[[G]] restrict : memref<2x4xf32> to tensor<2x4xf32>
+// CHECK-NOT: hip.constant
+func.func @large_const() -> tensor<2x4xf32> {
+  %0 = hip.constant {value = dense<[[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]]> : tensor<2x4xf32>} : tensor<2x4xf32>
+  return %0 : tensor<2x4xf32>
+}
+
+// The small constant (2 elements < threshold) folds to an inline arith.constant.
+// CHECK-LABEL: func.func @small_const
+// CHECK: arith.constant
+// CHECK-NOT: hip.constant
+func.func @small_const() -> tensor<2xf32> {
+  %0 = hip.constant {value = dense<[1.0, 2.0]> : tensor<2xf32>} : tensor<2xf32>
+  return %0 : tensor<2xf32>
+}

--- a/test/lit/Pipeline/externalize-constants.mlir
+++ b/test/lit/Pipeline/externalize-constants.mlir
@@ -11,20 +11,19 @@
 //
 // Also verifies module-level metadata:
 //   - hip.constants_file attribute
-//   - hipdnn.constant_sizes and hipdnn.constant_offsets arrays
+//   - hipdnn.constants (one per-constant descriptor: offset/size/kind)
 //   - hip.external_data includes index field
 //
 // All three constants are returned so they survive DCE in the greedy
 // pattern rewrite driver that runs as part of convertComputeOps.
 //===----------------------------------------------------------------------===//
 
-// RUN: mkdir -p %t && hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip='externalize-min-num-elements=4 externalize-output-dir=%t' %s | FileCheck %s
+// RUN: mkdir -p %t && hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip --hip-externalize-constants='externalize-min-num-elements=4 externalize-output-dir=%t' %s | FileCheck %s
 
 // Module-level: constants file attribute, sizes, and offsets.
 // CHECK: module attributes {
 // CHECK-SAME: hip.constants_file = "model.constants.bin"
-// CHECK-SAME: hipdnn.constant_offsets = array<i64:
-// CHECK-SAME: hipdnn.constant_sizes = array<i64:
+// CHECK-SAME: hipdnn.constants = [{kind = 0 : i64, offset = 0 : i64, size = 64 : i64}, {kind = 0 : i64, offset = 64 : i64, size = 32 : i64}]
 
 // Splat constant (4x4, 16 elements >= threshold) externalized as index 0.
 // CHECK-DAG: memref.global "private" @hip_ext_constant_0 : memref<4x4xf32>

--- a/test/lit/Pipeline/externalize-symbol-sanitize.mlir
+++ b/test/lit/Pipeline/externalize-symbol-sanitize.mlir
@@ -9,7 +9,7 @@
 // monotonic index suffix prevents collisions.
 //===----------------------------------------------------------------------===//
 
-// RUN: mkdir -p %t && hip-mlir-opt --convert-onnx-to-hip='externalize-min-num-elements=4 externalize-output-dir=%t' %s | FileCheck %s
+// RUN: mkdir -p %t && hip-mlir-opt --convert-onnx-to-hip --hip-externalize-constants='externalize-min-num-elements=4 externalize-output-dir=%t' %s | FileCheck %s
 
 // The node name "/model/layers.0/Constant" should become hip_ext_constant_model_layers_0_Constant_0
 // CHECK-DAG: memref.global "private" @hip_ext_constant_model_layers_0_Constant_0{{.*}}hip.external_data


### PR DESCRIPTION
## Problem

Constant externalization (large `onnx.Constant` → extern `memref.global` + a `.constants.bin` sidecar) lived entirely inside the monolithic `convert-onnx-to-hip` pass and matched only `onnx.Constant`. Downstream plugins that produce their own weight tensors had no way to get them serialized, and the resolve half was already a separate pass (`hip-resolve-extern-constants`), so the split was asymmetric.

## Change

Adds a neutral `hip.constant` carrier op and moves externalization into a standalone, dialect-agnostic `hip-externalize-constants` pass (symmetric to `hip-resolve-extern-constants`):

- `convert-onnx-to-hip` lowers `onnx.Constant` → `hip.constant` (inline `value`, or an ORT external-data `location`/`offset`/`size` reference).
- `hip-externalize-constants` runs after the `AfterConvertOnnxToHip` plugin slot and serializes **every** `hip.constant` — in-tree or plugin-emitted — uniformly: at/above the size threshold → extern `memref.global` + `.constants.bin`; below → inline `arith.constant`.

Plugins now participate in constant serialization simply by emitting `hip.constant`, with no access to any private pass state. Per-constant metadata is carried as a single self-describing `hipdnn.constants` descriptor array (offset/size/kind + kind-specific fields) rather than index-synced parallel module arrays.

## Verification

`model.constants.bin` is byte-identical to the pre-refactor output, the full LIT suite passes (280/280), and the Qwen 9B/35B VLM models generate correctly end-to-end on a clean build.

## Design

[docs/design/constant-handling-design.md](https://github.com/ROCm/onnx-hipdnn-ep/blob/refactor/hip-externalize-constants/docs/design/constant-handling-design.md)

Made with [Cursor](https://cursor.com)