### PR TITLE
perf(matmul_nbits): optional TILE_N cap for int4 GEMV decode autotune

### DIFF
--- a/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
+++ b/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
@@ -851,8 +851,24 @@ static int tuneGemvConfig(
     constexpr int WARMUP = 1;
     constexpr int ITERS  = 5;
 
+    // HIPDNN_EP_GEMV_MAX_TILEN: optionally cap TILE_N during autotune. This
+    // hot-cache microbenchmark ranks configs with weights resident in cache, so
+    // it favors large TILE_N (fewer blocks, more reuse). But on gfx1151 the int4
+    // GEMV kernel's VGPR use scales with TILE_N: TILE_N<=4 -> 16 waves/SIMD (full
+    // occupancy, no scratch), TILE_N=8/16 -> 12/9 waves, TILE_N=32/64 -> 8 waves
+    // AND register spill (356/1364 bytes/lane). In the real COLD-weight decode
+    // (M=1) the kernel is DRAM-latency-bound, where occupancy hides latency and
+    // spill adds traffic -- so the microbenchmark's large-TILE_N pick can be a
+    // net loss. Setting this env (e.g. 4 or 8) restricts the search to the
+    // higher-occupancy, non-spilling configs. Default 0 = unchanged (baseline).
+    static const int gemv_max_tilen = []{
+        const char* e = std::getenv("HIPDNN_EP_GEMV_MAX_TILEN");
+        return e ? atoi(e) : 0;
+    }();
+
     for (int cid = 0; cid < kNumGemvConfigs; cid++) {
         auto& cfg = kGemvConfigs[cid];
+        if (gemv_max_tilen > 0 && cfg.tile_n > gemv_max_tilen) continue;
         if (cfg.tile_n >= 64 && N < 2048) continue;
         if (cfg.tile_n >= 32 && cfg.tile_n < 64 && N < 1024) continue;
 


### PR DESCRIPTION
## Summary

The int4 GEMV decode kernel (`matmul_nbits_gemv_kernel`, M=1) is the dominant decode-time op and is DRAM-latency-bound. Its VGPR usage scales with `TILE_N`, and the autotuner (`tuneGemvConfig`) ranks configs with a **hot-cache** microbenchmark that favors large `TILE_N` (fewer blocks) — but those configs have **low occupancy and register spill**, which hurts the real **cold-weight** decode.

Compiler resource usage (gfx1151, `-Rpass-analysis=kernel-resource-usage`):

| TILE_N | VGPR | Occupancy (waves/SIMD) | Scratch (B/lane) |
|--------|------|------------------------|------------------|
| 1–4    | 38–77 | **16 (full)**         | 0 |
| 8      | 108  | 12                     | 0 |
| 16     | 157  | 9                      | 0 |
| 32     | 192  | 8                      | **356 (spill)** |
| 64     | 192  | 8                      | **1364 (spill)** |

An RGP/SQTT decode trace shows the autotuner selecting the spilling `TILE_N=32/64/16` configs for the large decode matmuls, running at ~10% occupancy / ~20% of memory bandwidth.

This PR adds an env-gated knob, **`HIPDNN_EP_GEMV_MAX_TILEN`**, that restricts the GEMV autotune search to `TILE_N <= N` (e.g. 4 or 8 = full/high occupancy, no spill). **Default `0` = unchanged (baseline).** The change only affects *which* config is chosen; per-column int4 math is independent of `TILE_N`, so decode output is **byte-identical**.

## Why this is a draft / what I need

I could **not** get a trustworthy decode-tps A/B on my local box:
- `model_benchmark` (deterministic) kernel-launch-fails against the CI-packaged model artifact (different commit than any I can build locally).
- The venv `benchmark_multimodal` path is coherent but nondeterministic (APU-clock bimodality ~17 vs ~130 tps, ±40% intra-condition scatter), which swamps the expected effect.

**Confidence: mechanism high, magnitude unproven.** Please perf remotely on a coherent build.

## Test plan

- [ ] Build EP; confirm baseline (env unset) is bit-for-bit unchanged.
- [ ] Decode tps A/B on a clock-pinned box: baseline vs `HIPDNN_EP_GEMV_MAX_TILEN=4` and `=8` (Qwen3.5-35B-A3B int4 decode).
- [ ] Correctness: greedy token / logits identity baseline vs capped (expected byte-identical).
- [ ] (Optional) SQTT/RGP: confirm chosen GEMV `TILE_N` drops to <=cap, occupancy rises (8→16), scratch→0, sustained GB/s up.
- [ ] If a clear winner, consider making the cap the default for M=1 decode shapes (fold into config selection) rather than env-gated.
