### PR TITLE
feat(dialect): scaffold hipsr op pipeline

### DIFF
--- a/include/hip/Dialect/Hipsr/IR/CMakeLists.txt
+++ b/include/hip/Dialect/Hipsr/IR/CMakeLists.txt
@@ -6,4 +6,9 @@
 set(LLVM_TARGET_DEFINITIONS HipsrDialect.td)
 mlir_tablegen(HipsrDialect.h.inc -gen-dialect-decls -dialect=hipsr)
 mlir_tablegen(HipsrDialect.cpp.inc -gen-dialect-defs -dialect=hipsr)
+
+set(LLVM_TARGET_DEFINITIONS HipsrOps.td)
+mlir_tablegen(HipsrOps.h.inc -gen-op-decls)
+mlir_tablegen(HipsrOps.cpp.inc -gen-op-defs)
+
 add_public_tablegen_target(HipsrDialectIncGen)

--- a/include/hip/Dialect/Hipsr/IR/HipsrOps.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrOps.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#ifndef HIPSR_OPS_H
+#define HIPSR_OPS_H
+
+#include "hip/Dialect/Hipsr/IR/HipsrDialect.h"
+
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/OpDefinition.h"
+
+#define GET_OP_CLASSES
+#include "hip/Dialect/Hipsr/IR/HipsrOps.h.inc"
+
+#endif // HIPSR_OPS_H

--- a/include/hip/Dialect/Hipsr/IR/HipsrOps.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrOps.td
@@ -1,0 +1,21 @@
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+
+#ifndef HIPSR_OPS
+#define HIPSR_OPS
+
+include "mlir/IR/OpBase.td"
+include "hip/Dialect/Hipsr/IR/HipsrDialect.td"
+
+//===----------------------------------------------------------------------===//
+// Base op class
+//===----------------------------------------------------------------------===//
+
+// Common base for all ops in the hipsr dialect. Downstream PRs define concrete
+// ops (shape-region terminators, shaped compute ops, ...) on top of this.
+class Hipsr_Op<string mnemonic, list<Trait> traits = []> :
+    Op<Hipsr_Dialect, mnemonic, traits>;
+
+#endif // HIPSR_OPS

--- a/lib/Dialect/Hipsr/IR/CMakeLists.txt
+++ b/lib/Dialect/Hipsr/IR/CMakeLists.txt
@@ -5,6 +5,7 @@
 
 add_library(HipsrDialectIR STATIC
   HipsrDialect.cpp
+  HipsrOps.cpp
 )
 
 add_dependencies(HipsrDialectIR

--- a/lib/Dialect/Hipsr/IR/HipsrOps.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrOps.cpp
@@ -3,18 +3,10 @@
  * Licensed under the MIT License.
  */
 
-#include "hip/Dialect/Hipsr/IR/HipsrDialect.h"
-
 #include "hip/Dialect/Hipsr/IR/HipsrOps.h"
 
 using namespace mlir;
 using namespace mlir::hipsr;
 
-#include "hip/Dialect/Hipsr/IR/HipsrDialect.cpp.inc"
-
-void HipsrDialect::initialize() {
-  addOperations<
-#define GET_OP_LIST
+#define GET_OP_CLASSES
 #include "hip/Dialect/Hipsr/IR/HipsrOps.cpp.inc"
-      >();
-}


### PR DESCRIPTION
Scaffold the op-generation pipeline for the `hipsr` dialect. No ops are defined yet — this only wires up the base class and TableGen op generation so later PRs can add ops one at a time.

- Add `HipsrOps.td` with the `Hipsr_Op` base class.
- Add op decls/defs generation (`-gen-op-decls` / `-gen-op-defs`) to `HipsrDialectIncGen`.
- Add `HipsrOps.h` / `HipsrOps.cpp`, link into `HipsrDialectIR`, and register the (empty) op list in `initialize()`.