### PR TITLE
feat(dialect): add hipsr memory-space attribute

### DIFF
--- a/include/hip/Dialect/Hipsr/IR/CMakeLists.txt
+++ b/include/hip/Dialect/Hipsr/IR/CMakeLists.txt
@@ -12,3 +12,10 @@ mlir_tablegen(HipsrOps.h.inc -gen-op-decls)
 mlir_tablegen(HipsrOps.cpp.inc -gen-op-defs)
 
 add_public_tablegen_target(HipsrDialectIncGen)
+
+set(LLVM_TARGET_DEFINITIONS HipsrAttributes.td)
+mlir_tablegen(HipsrEnums.h.inc -gen-enum-decls)
+mlir_tablegen(HipsrEnums.cpp.inc -gen-enum-defs)
+mlir_tablegen(HipsrAttributes.h.inc -gen-attrdef-decls -attrdefs-dialect=hipsr)
+mlir_tablegen(HipsrAttributes.cpp.inc -gen-attrdef-defs -attrdefs-dialect=hipsr)
+add_public_tablegen_target(HipsrAttributesIncGen)

--- a/include/hip/Dialect/Hipsr/IR/HipsrAttributes.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrAttributes.td
@@ -1,0 +1,45 @@
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+
+#ifndef HIPSR_ATTRIBUTES
+#define HIPSR_ATTRIBUTES
+
+include "hip/Dialect/Hipsr/IR/HipsrDialect.td"
+include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/EnumAttr.td"
+
+// Numeric values match the AMDGPU address spaces: host = 0 (flat),
+// device = 1 (global), pinned = 2, managed = 3.
+def Hipsr_Host    : I32EnumAttrCase<"Host",    0, "host">;
+def Hipsr_Device  : I32EnumAttrCase<"Device",  1, "device">;
+def Hipsr_Pinned  : I32EnumAttrCase<"Pinned",  2, "pinned">;
+def Hipsr_Managed : I32EnumAttrCase<"Managed", 3, "managed">;
+
+def Hipsr_MemorySpaceKind : I32EnumAttr<"MemorySpaceKind",
+    "hipsr memory space kind",
+    [Hipsr_Host, Hipsr_Device, Hipsr_Pinned, Hipsr_Managed]> {
+  let cppNamespace = "::mlir::hipsr";
+  // The enum is wrapped by MemorySpaceAttr below, so the syntax is
+  // `#hipsr.mem<device>`. Don't generate a separate attribute for the enum.
+  let genSpecializedAttr = 0;
+}
+
+def Hipsr_MemorySpaceAttr : AttrDef<Hipsr_Dialect, "MemorySpace"> {
+  let mnemonic = "mem";
+  let summary = "hipsr memory space attribute";
+  let description = [{
+    Says where a buffer lives, used as a `memref` memory space:
+    `device` (VRAM), `host` (pageable), `pinned` (page-locked host),
+    `managed` (unified). Example: `memref<4xf32, #hipsr.mem<device>>`.
+
+    Every hipsr `memref` must have one of these memory spaces; a memref
+    with no memory space is not allowed. (A later PR adds the checks that
+    enforce this.)
+  }];
+  let parameters = (ins EnumParameter<Hipsr_MemorySpaceKind>:$kind);
+  let assemblyFormat = "`<` $kind `>`";
+}
+
+#endif // HIPSR_ATTRIBUTES

--- a/include/hip/Dialect/Hipsr/IR/HipsrDialect.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrDialect.h
@@ -7,7 +7,15 @@
 #define HIPSR_DIALECT_H
 
 #include "mlir/IR/Dialect.h"
+// Needed by the generated attribute parser/printer.
+#include "mlir/IR/OpImplementation.h"
 
 #include "hip/Dialect/Hipsr/IR/HipsrDialect.h.inc"
+
+// Enum header first: MemorySpaceAttr uses MemorySpaceKind.
+#include "hip/Dialect/Hipsr/IR/HipsrEnums.h.inc"
+
+#define GET_ATTRDEF_CLASSES
+#include "hip/Dialect/Hipsr/IR/HipsrAttributes.h.inc"
 
 #endif // HIPSR_DIALECT_H

--- a/include/hip/Dialect/Hipsr/IR/HipsrDialect.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrDialect.td
@@ -16,6 +16,9 @@ def Hipsr_Dialect : Dialect {
     declaratively and models dynamic shapes as first-class shape regions.
   }];
   let cppNamespace = "::mlir::hipsr";
+
+  // Lets the dialect parse/print `#hipsr.mem<...>`.
+  let useDefaultAttributePrinterParser = 1;
 }
 
 #endif // HIPSR_DIALECT

--- a/lib/Dialect/Hipsr/IR/CMakeLists.txt
+++ b/lib/Dialect/Hipsr/IR/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(HipsrDialectIR STATIC
 
 add_dependencies(HipsrDialectIR
   HipsrDialectIncGen
+  HipsrAttributesIncGen
 )
 
 target_link_libraries(HipsrDialectIR PUBLIC

--- a/lib/Dialect/Hipsr/IR/HipsrDialect.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrDialect.cpp
@@ -7,14 +7,30 @@
 
 #include "hip/Dialect/Hipsr/IR/HipsrOps.h"
 
+#include "llvm/ADT/TypeSwitch.h"
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/DialectImplementation.h"
+
 using namespace mlir;
 using namespace mlir::hipsr;
 
 #include "hip/Dialect/Hipsr/IR/HipsrDialect.cpp.inc"
 
+// Enum code first: the attribute's parser/printer below calls these
+// enum name<->value helpers.
+#include "hip/Dialect/Hipsr/IR/HipsrEnums.cpp.inc"
+
+#define GET_ATTRDEF_CLASSES
+#include "hip/Dialect/Hipsr/IR/HipsrAttributes.cpp.inc"
+
 void HipsrDialect::initialize() {
   addOperations<
 #define GET_OP_LIST
 #include "hip/Dialect/Hipsr/IR/HipsrOps.cpp.inc"
+      >();
+  addAttributes<
+#define GET_ATTRDEF_LIST
+#include "hip/Dialect/Hipsr/IR/HipsrAttributes.cpp.inc"
       >();
 }

--- a/test/lit/Dialect/Hipsr/memory-space-attr.mlir
+++ b/test/lit/Dialect/Hipsr/memory-space-attr.mlir
@@ -1,0 +1,38 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+//===----------------------------------------------------------------------===//
+// Tests that #hipsr.mem<...> parses and prints, and that a bad kind errors.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt --split-input-file --verify-diagnostics %s | FileCheck %s
+
+// -----
+// All four kinds print back unchanged as a memref memory space.
+// CHECK-LABEL: func.func @roundtrip_spaces
+// CHECK-SAME:    memref<4xf32, #hipsr.mem<device>>
+// CHECK-SAME:    memref<4xf32, #hipsr.mem<host>>
+// CHECK-SAME:    memref<4xf32, #hipsr.mem<pinned>>
+// CHECK-SAME:    memref<4xf32, #hipsr.mem<managed>>
+func.func @roundtrip_spaces(%d: memref<4xf32, #hipsr.mem<device>>,
+                            %h: memref<4xf32, #hipsr.mem<host>>,
+                            %p: memref<4xf32, #hipsr.mem<pinned>>,
+                            %m: memref<4xf32, #hipsr.mem<managed>>) {
+  return
+}
+
+// -----
+// Also works as a plain attribute on an op, not just as a memref space.
+// CHECK-LABEL: func.func @attr_on_op
+// CHECK-SAME:    hipsr.space = #hipsr.mem<pinned>
+func.func @attr_on_op() attributes {hipsr.space = #hipsr.mem<pinned>} {
+  return
+}
+
+// -----
+// An unknown kind fails to parse.
+// expected-error @+2 {{to be one of: host, device, pinned, managed}}
+// expected-error @+1 {{failed to parse Hipsr_MemorySpaceAttr parameter 'kind'}}
+func.func @bad_kind(%x: memref<4xf32, #hipsr.mem<bogus>>) {
+  return
+}


### PR DESCRIPTION
## Summary

Adds a self-contained `#hipsr.mem<...>` memory-space attribute to the `hipsr` dialect:

- A `MemorySpaceKind` enum with four kinds — `host`, `device`, `pinned`, `managed` (numeric values matching the AMDGPU address spaces).
- A `MemorySpaceAttr` (`#hipsr.mem<device>`) usable as a `memref` memory space, e.g. `memref<4xf32, #hipsr.mem<device>>`.

This is **definitions only** — no type constraints, ops, lowering, or runtime. Those are deferred to later stacked PRs to keep this one small and easy to review. Follows the same wiring pattern as the existing `hip` dialect (enum + attrdef tablegen, `useDefaultAttributePrinterParser`, `addAttributes` in `initialize()`).

## Design note

Every hipsr `memref` is intended to carry an explicit memory space; a memref with no memory space is not allowed. Unlike the `hip` dialect, hipsr has no lenient "accept unspecified space" toggle. This PR documents that invariant at the definition site and demonstrates it in the test (all memrefs carry a space); the checks that mechanically enforce it land with the future type-constraints PR.

## Test plan

- [x] `HipsrAttributes.td` builds (enum + attrdef `.inc` generated, `HipsrDialect.cpp` compiles and links).
- [x] New LIT test `test/lit/Dialect/Hipsr/memory-space-attr.mlir` passes:
  - all four kinds round-trip as a memref memory space,
  - the attribute round-trips as a plain attribute on an op,
  - an unknown kind fails to parse (diagnostic asserted).
- [x] Full `MorphizenMLIRLitTests` suite passes (100%).
