### PR TITLE
ci(windows): bump amdgpu-ep pin to rebased decouple commit

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -296,14 +296,14 @@ jobs:
           # key folds in the pinned fork commit + ORT version/PR list; bumping
           # any of them forces a rebuild. On a hit the checkout + build below are
           # skipped and the staging step finds the cached DLLs in build-amdgpu.
-          key: dep-amdgpu-daa120c-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}
+          key: dep-amdgpu-af39f35-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}
 
       - name: Checkout amdgpu-ep
         if: steps.cache-amdgpu.outputs.cache-hit != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: zz002/onnxruntime-ep-amdgpu
-          ref: daa120c415b00d52a59add8a7328221b4d25f4ff
+          ref: af39f35fa832a0272904fb8606981c5b10bea974
           path: source-amdgpu
           fetch-depth: 1
           show-progress: false


### PR DESCRIPTION
## Summary
Bump the pinned amdgpu-ep (umbrella EP) commit used by the Windows CI to the decouple patch rebased onto the current onnxruntime-ep-amdgpu `main` (picks up PR #23/#24/#34/#38/#39), keeping the `build without a MIGraphX SDK` decoupling as a fork-only patch.

## Why
The old pin (`daa120c`) was based on a stale amdgpu tree from before PR #23 merged. Upstream `main` now forces `USE_DML/USE_MIGRAPHX ON` + `USE_HIP OFF` under `USE_AMDGPU`, which the SDK-less CI runner cannot build and would not produce `hip-backend.dll`. The decouple patch (DML/MIGRAPHX OFF, HIP ON, plus `USE_*` guards in gpu_factory/gpu_ep) is re-applied on top of latest `main` so CI keeps building `amdgpu-ep.dll` + `hip-backend.dll` while inheriting main's fixes.

## What
1. `.github/workflows/windows-build.yml`: amdgpu-ep `ref` `daa120c` -> `af39f35` and cache key `dep-amdgpu-daa120c` -> `dep-amdgpu-af39f35` (forces a cold rebuild). Repository pin (`zz002` fork) unchanged.

## Test plan
- [ ] build-windows green on cold cache: amdgpu-ep + hip-ep build without a MIGraphX/DirectML SDK, staging finds amdgpu-ep.dll + hip-backend.dll, gpu-test passes.
- Local verification: `cmake -DUSE_AMDGPU=ON` built `amdgpu-ep.dll` + `hip-backend.dll` with no directml/migraphx backend produced.

## Notes for reviewers
The rebased commit lives on the `zz002/onnxruntime-ep-amdgpu` fork branch `build/decouple-dml-migraphx` (`af39f35`); it is a fork-only `[do not merge]` decouple patch on top of upstream `main`.

Made with [Cursor](https://cursor.com)