### PR TITLE
feat(dialect): add Hipsr_DpsOp shaped-op base class

### DIFF
--- a/include/hip/Dialect/Hipsr/IR/HipsrOps.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrOps.td
@@ -7,8 +7,10 @@
 #define HIPSR_OPS
 
 include "mlir/IR/OpBase.td"
+include "mlir/Interfaces/DestinationStyleOpInterface.td"
 include "hip/Dialect/Hipsr/IR/HipsrDialect.td"
 include "hip/Dialect/Hipsr/IR/HipsrTypes.td"
+include "hip/Dialect/Hipsr/IR/HipsrShapeRegionInterface.td"
 
 //===----------------------------------------------------------------------===//
 // Base op class
@@ -18,5 +20,32 @@ include "hip/Dialect/Hipsr/IR/HipsrTypes.td"
 // ops (shape-region terminators, shaped compute ops, ...) on top of this.
 class Hipsr_Op<string mnemonic, list<Trait> traits = []> :
     Op<Hipsr_Dialect, mnemonic, traits>;
+
+//===----------------------------------------------------------------------===//
+// Shaped DPS op base class
+//===----------------------------------------------------------------------===//
+
+// Base for shaped compute ops (MatMul, Add, ...). Every such op:
+//   - carries a shape region (region 0) that computes its output shape and is
+//     terminated by `hipsr.shape_yield`. The SingleBlockImplicitTerminator
+//     trait auto-inserts that terminator and structurally checks it;
+//   - implements ShapeRegionInterface, the single source of truth for shape
+//     computation (each op provides populateShapeRegion());
+//   - uses destination-passing style (DestinationStyleOpInterface): its output
+//     buffer(s) are passed as `outs` init operands (getDpsInitsMutable is
+//     op-defined).
+//
+// Regular and StartBarrier ops use exactly this one shape region; EndBarrier
+// ops (which also need a capacity shape region) extend it separately.
+class Hipsr_DpsOp<string mnemonic, list<Trait> traits = []> :
+    Hipsr_Op<mnemonic, !listconcat([
+        DeclareOpInterfaceMethods<ShapeRegionInterface, ["populateShapeRegion"]>,
+        DeclareOpInterfaceMethods<DestinationStyleOpInterface,
+                                  ["getDpsInitsMutable"]>,
+        SingleBlockImplicitTerminator<"ShapeYieldOp">
+      ], traits)> {
+  let regions = (region SizedRegion<1>:$shape_region);
+  let results = (outs Variadic<AnyRankedTensor>:$result_tensors);
+}
 
 #endif // HIPSR_OPS


### PR DESCRIPTION
Add `Hipsr_DpsOp`, the base class for shaped compute ops (MatMul, Add, ...). Each op built on it:

- carries a shape region (region 0) terminated by `hipsr.shape_yield`, via the `SingleBlockImplicitTerminator<"ShapeYieldOp">` trait;
- implements `ShapeRegionInterface` (single source of truth for shape computation; each op provides `populateShapeRegion()`);
- uses destination-passing style (`DestinationStyleOpInterface`, `getDpsInitsMutable` op-defined);
- yields `Variadic<AnyRankedTensor>` results.

Regular and StartBarrier ops use exactly this one shape region; EndBarrier ops (which also need a capacity shape region) will extend it separately.

No concrete op uses the base yet, so it generates no code — this is pure scaffolding. The first shaped op (`hipsr.matmul`) will exercise the shape-region / reify / DPS path end-to-end (and add lit coverage) in a follow-up.

## Test plan

- Build passes; TableGen resolves the base class's interface/trait/type references.
- LIT suite green (0 failures).