### PR TITLE
feat(dialect): add hipsr context type

### DIFF
--- a/include/hip/Dialect/Hipsr/IR/CMakeLists.txt
+++ b/include/hip/Dialect/Hipsr/IR/CMakeLists.txt
@@ -22,3 +22,8 @@ set(LLVM_TARGET_DEFINITIONS HipsrAttrs.td)
 mlir_tablegen(HipsrAttrs.h.inc -gen-attrdef-decls -attrdefs-dialect=hipsr)
 mlir_tablegen(HipsrAttrs.cpp.inc -gen-attrdef-defs -attrdefs-dialect=hipsr)
 add_public_tablegen_target(HipsrAttrsIncGen)
+
+set(LLVM_TARGET_DEFINITIONS HipsrTypes.td)
+mlir_tablegen(HipsrTypes.h.inc -gen-typedef-decls -typedefs-dialect=hipsr)
+mlir_tablegen(HipsrTypes.cpp.inc -gen-typedef-defs -typedefs-dialect=hipsr)
+add_public_tablegen_target(HipsrTypesIncGen)

--- a/include/hip/Dialect/Hipsr/IR/HipsrDialect.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrDialect.h
@@ -18,6 +18,10 @@
 #define GET_ATTRDEF_CLASSES
 #include "hip/Dialect/Hipsr/IR/HipsrAttrs.h.inc"
 
+// Type declarations (e.g. !hipsr.context).
+#define GET_TYPEDEF_CLASSES
+#include "hip/Dialect/Hipsr/IR/HipsrTypes.h.inc"
+
 // Predicates for the Hipsr_*MemRef type constraints (used by op verifiers once
 // ops adopt them).
 #include "hip/Dialect/Hipsr/IR/HipsrTypes.h"

--- a/include/hip/Dialect/Hipsr/IR/HipsrDialect.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrDialect.td
@@ -19,6 +19,9 @@ def Hipsr_Dialect : Dialect {
 
   // Lets the dialect parse/print `#hipsr.mem<...>`.
   let useDefaultAttributePrinterParser = 1;
+
+  // Lets the dialect parse/print `!hipsr.context`.
+  let useDefaultTypePrinterParser = 1;
 }
 
 #endif // HIPSR_DIALECT

--- a/include/hip/Dialect/Hipsr/IR/HipsrTypes.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrTypes.td
@@ -7,6 +7,8 @@
 #define HIPSR_TYPES
 
 include "mlir/IR/OpBase.td"
+include "mlir/IR/AttrTypeBase.td"
+include "hip/Dialect/Hipsr/IR/HipsrDialect.td"
 
 // Type constraints for ops that need a memref in a specific memory space.
 //
@@ -24,5 +26,18 @@ def Hipsr_TensorOrHostMemRef    : AnyTypeOf<[AnyRankedTensor, Hipsr_HostMemRef],
 def Hipsr_TensorOrDeviceMemRef  : AnyTypeOf<[AnyRankedTensor, Hipsr_DeviceMemRef],  "ranked tensor or device memref">;
 def Hipsr_TensorOrPinnedMemRef  : AnyTypeOf<[AnyRankedTensor, Hipsr_PinnedMemRef],  "ranked tensor or pinned memref">;
 def Hipsr_TensorOrManagedMemRef : AnyTypeOf<[AnyRankedTensor, Hipsr_ManagedMemRef], "ranked tensor or managed memref">;
+
+// Base class for hipsr types.
+class Hipsr_Type<string name, string typeMnemonic> : TypeDef<Hipsr_Dialect, name> {
+  let mnemonic = typeMnemonic;
+}
+
+def Hipsr_ContextType : Hipsr_Type<"Context", "context"> {
+  let summary = "Opaque hipsr execution context";
+  let description = [{
+    Opaque per-session context. hipsr ops take it as their first operand.
+    Lowers to `!llvm.ptr`.
+  }];
+}
 
 #endif // HIPSR_TYPES

--- a/lib/Dialect/Hipsr/IR/CMakeLists.txt
+++ b/lib/Dialect/Hipsr/IR/CMakeLists.txt
@@ -13,6 +13,7 @@ add_dependencies(HipsrDialectIR
   HipsrDialectIncGen
   HipsrEnumsIncGen
   HipsrAttrsIncGen
+  HipsrTypesIncGen
 )
 
 target_link_libraries(HipsrDialectIR PUBLIC

--- a/lib/Dialect/Hipsr/IR/HipsrDialect.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrDialect.cpp
@@ -24,6 +24,9 @@ using namespace mlir::hipsr;
 #define GET_ATTRDEF_CLASSES
 #include "hip/Dialect/Hipsr/IR/HipsrAttrs.cpp.inc"
 
+#define GET_TYPEDEF_CLASSES
+#include "hip/Dialect/Hipsr/IR/HipsrTypes.cpp.inc"
+
 void HipsrDialect::initialize() {
   addOperations<
 #define GET_OP_LIST
@@ -32,5 +35,9 @@ void HipsrDialect::initialize() {
   addAttributes<
 #define GET_ATTRDEF_LIST
 #include "hip/Dialect/Hipsr/IR/HipsrAttrs.cpp.inc"
+      >();
+  addTypes<
+#define GET_TYPEDEF_LIST
+#include "hip/Dialect/Hipsr/IR/HipsrTypes.cpp.inc"
       >();
 }


### PR DESCRIPTION
## Summary

Add the opaque `!hipsr.context` type to the `hipsr` dialect. It represents a per-session execution context that `hipsr` ops take as their first operand by convention, and is intended to lower to `!llvm.ptr`.

Wiring:

- `HipsrTypes.td` — a `Hipsr_Type` TableGen base class and the `Hipsr_ContextType` (`!hipsr.context`) definition.
- `HipsrDialect.td` — `useDefaultTypePrinterParser = 1` so the dialect parses/prints `!hipsr.context`.
- `HipsrDialect.{h,cpp}` — include the generated type classes and register them via `addTypes<>` in `initialize()`.
- `CMakeLists.txt` — a new `HipsrTypesIncGen` tablegen target, wired into `HipsrDialectIR`.

This is foundation-only: the type lands here but no op uses it yet.

## Test plan

- [x] Full build clean (`hip-mlir-opt`).
- [x] `!hipsr.context` round-trips through `hip-mlir-opt`; `hipsr` listed in `--show-dialects`.
- [x] `pre-commit` passes on all changed files.