### PR TITLE
feat(dialect): add hipsr.matmul, the first shaped op

### DIFF
--- a/include/hip/Dialect/Hipsr/IR/CMakeLists.txt
+++ b/include/hip/Dialect/Hipsr/IR/CMakeLists.txt
@@ -19,6 +19,10 @@ set(LLVM_TARGET_DEFINITIONS HipsrOps.td)
 mlir_tablegen(HipsrOps.h.inc -gen-op-decls)
 mlir_tablegen(HipsrOps.cpp.inc -gen-op-defs)
 
+set(LLVM_TARGET_DEFINITIONS HipsrMatMulOp.td)
+mlir_tablegen(HipsrMatMulOp.h.inc -gen-op-decls)
+mlir_tablegen(HipsrMatMulOp.cpp.inc -gen-op-defs)
+
 add_public_tablegen_target(HipsrDialectIncGen)
 
 set(LLVM_TARGET_DEFINITIONS HipsrEnums.td)

--- a/include/hip/Dialect/Hipsr/IR/HipsrMatMulOp.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrMatMulOp.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#ifndef HIPSR_MATMUL_OP_H
+#define HIPSR_MATMUL_OP_H
+
+#include "hip/Dialect/Hipsr/IR/HipsrDialect.h"
+#include "hip/Dialect/Hipsr/IR/HipsrShapeRegionInterface.h"
+#include "hip/Dialect/Hipsr/IR/HipsrShapeYieldOp.h"
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/Interfaces/DestinationStyleOpInterface.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+
+#define GET_OP_CLASSES
+#include "hip/Dialect/Hipsr/IR/HipsrMatMulOp.h.inc"
+
+#endif // HIPSR_MATMUL_OP_H

--- a/include/hip/Dialect/Hipsr/IR/HipsrMatMulOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrMatMulOp.td
@@ -1,0 +1,54 @@
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+// The hipsr.matmul op. Each compute op lives in its own file and builds on the
+// Hipsr_DpsOp base class from HipsrOps.td.
+//
+
+#ifndef HIPSR_MATMUL_OP
+#define HIPSR_MATMUL_OP
+
+include "hip/Dialect/Hipsr/IR/HipsrOps.td"
+
+//===----------------------------------------------------------------------===//
+// Hipsr_MatMulOp
+//===----------------------------------------------------------------------===//
+
+def Hipsr_MatMulOp : Hipsr_DpsOp<"matmul"> {
+  let summary = "Matrix multiply (row-major), destination-passing style";
+  let description = [{
+    Computes `result = lhs * rhs` for 2-D operands: `lhs : [M, K]`,
+    `rhs : [K, N]`, `result : [M, N]`. Destination-passing style: the result
+    buffer is passed as the `init` operand.
+
+    Regular op: carries a shape region (region 0) computing `[M, N]` from the
+    input shapes (M = dim(lhs, 0), N = dim(rhs, 1)).
+
+    Example:
+    ```mlir
+    %0 = hipsr.matmul ins(%lhs, %rhs : tensor<?x256xf16>, tensor<256x512xf16>)
+                      outs(%init : tensor<?x512xf16>) -> tensor<?x512xf16> shape_region {
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %m = tensor.dim %lhs, %c0 : tensor<?x256xf16>
+      %n = tensor.dim %rhs, %c1 : tensor<256x512xf16>
+      hipsr.shape_yield %m, %n
+    }
+    ```
+  }];
+
+  let arguments = (ins
+    Hipsr_TensorOrDeviceMemRef:$lhs,
+    Hipsr_TensorOrDeviceMemRef:$rhs,
+    Hipsr_TensorOrDeviceMemRef:$init
+  );
+
+  let assemblyFormat = [{
+    `ins` `(` $lhs `,` $rhs `:` type($lhs) `,` type($rhs) `)`
+    `outs` `(` $init `:` type($init) `)`
+    attr-dict `->` type($result_tensors) `shape_region` $shape_region
+  }];
+}
+
+#endif // HIPSR_MATMUL_OP

--- a/include/hip/Dialect/Hipsr/IR/HipsrShapeYieldOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrShapeYieldOp.td
@@ -35,6 +35,12 @@ def Hipsr_ShapeYieldOp : Hipsr_Op<"shape_yield", [Pure, Terminator]> {
 
   let arguments = (ins Variadic<Index>:$dims);
 
+  // Zero-operand builder so SingleBlockImplicitTerminator can auto-insert an
+  // (empty) shape_yield into a shaped op's region (cf. scf.yield).
+  let builders = [
+    OpBuilder<(ins), [{ /* no dims */ }]>
+  ];
+
   // Operands are always `index` (Variadic<Index>), so the types are redundant
   // and omitted from the assembly (cf. scf.yield / func.return practice).
   let assemblyFormat = "attr-dict ($dims^)?";

--- a/lib/Dialect/Hipsr/IR/CMakeLists.txt
+++ b/lib/Dialect/Hipsr/IR/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(HipsrDialectIR STATIC
   HipsrShapeRegionInterface.cpp
   HipsrShapeYieldOp.cpp
   HipsrOps.cpp
+  HipsrMatMulOp.cpp
   HipsrTypes.cpp
 )
 
@@ -21,4 +22,5 @@ add_dependencies(HipsrDialectIR
 target_link_libraries(HipsrDialectIR PUBLIC
   MLIRIR
   MLIRSupport
+  MLIRTensorDialect
 )

--- a/lib/Dialect/Hipsr/IR/HipsrDialect.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrDialect.cpp
@@ -5,6 +5,7 @@
 
 #include "hip/Dialect/Hipsr/IR/HipsrDialect.h"
 
+#include "hip/Dialect/Hipsr/IR/HipsrMatMulOp.h"
 #include "hip/Dialect/Hipsr/IR/HipsrOps.h"
 #include "hip/Dialect/Hipsr/IR/HipsrShapeYieldOp.h"
 
@@ -36,6 +37,10 @@ void HipsrDialect::initialize() {
   addOperations<
 #define GET_OP_LIST
 #include "hip/Dialect/Hipsr/IR/HipsrOps.cpp.inc"
+      >();
+  addOperations<
+#define GET_OP_LIST
+#include "hip/Dialect/Hipsr/IR/HipsrMatMulOp.cpp.inc"
       >();
   addAttributes<
 #define GET_ATTRDEF_LIST

--- a/lib/Dialect/Hipsr/IR/HipsrMatMulOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrMatMulOp.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "hip/Dialect/Hipsr/IR/HipsrMatMulOp.h"
+
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+
+using namespace mlir;
+using namespace mlir::hipsr;
+
+#define GET_OP_CLASSES
+#include "hip/Dialect/Hipsr/IR/HipsrMatMulOp.cpp.inc"
+
+// DestinationStyleOpInterface: the single init operand is the DPS out.
+MutableOperandRange MatMulOp::getDpsInitsMutable() { return getInitMutable(); }
+
+// Single source of truth for the output shape [M, N]:
+//   M = dim(lhs, 0), N = dim(rhs, 1).
+void MatMulOp::populateShapeRegion(OpBuilder &builder, Region &shapeRegion) {
+  OpBuilder::InsertionGuard guard(builder);
+  Block *body = builder.createBlock(&shapeRegion);
+  builder.setInsertionPointToStart(body);
+
+  Location loc = getLoc();
+  Value m = builder.create<tensor::DimOp>(loc, getLhs(), 0);
+  Value n = builder.create<tensor::DimOp>(loc, getRhs(), 1);
+  builder.create<ShapeYieldOp>(loc, ValueRange{m, n});
+}

--- a/test/lit/Dialect/Hipsr/matmul.mlir
+++ b/test/lit/Dialect/Hipsr/matmul.mlir
@@ -1,0 +1,26 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+//===----------------------------------------------------------------------===//
+// Round-trips hipsr.matmul: a Regular shaped DPS op carrying a shape region
+// that computes its output shape [M, N] from the input shapes.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt %s | hip-mlir-opt | FileCheck %s
+
+// CHECK-LABEL: func.func @matmul
+func.func @matmul(%lhs: tensor<?x256xf16>, %rhs: tensor<256x512xf16>,
+                  %init: tensor<?x512xf16>) -> tensor<?x512xf16> {
+  // CHECK: hipsr.matmul ins(%{{.+}}, %{{.+}} : tensor<?x256xf16>, tensor<256x512xf16>) outs(%{{.+}} : tensor<?x512xf16>) -> tensor<?x512xf16> shape_region {
+  %0 = hipsr.matmul ins(%lhs, %rhs : tensor<?x256xf16>, tensor<256x512xf16>)
+                    outs(%init : tensor<?x512xf16>) -> tensor<?x512xf16>
+                    shape_region {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %m = tensor.dim %lhs, %c0 : tensor<?x256xf16>
+    %n = tensor.dim %rhs, %c1 : tensor<256x512xf16>
+    // CHECK: hipsr.shape_yield %{{.+}}, %{{.+}}
+    hipsr.shape_yield %m, %n
+  }
+  return %0 : tensor<?x512xf16>
+}

--- a/test/lit/Dialect/Hipsr/matmul_shape_region_verify.mlir
+++ b/test/lit/Dialect/Hipsr/matmul_shape_region_verify.mlir
@@ -1,0 +1,82 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+//===----------------------------------------------------------------------===//
+// Exercises ShapeRegionInterface's scoping verifier (verifyShapeRegionScoping)
+// through hipsr.matmul, the first op implementing the interface. The verifier
+// only runs on interface-implementing ops, so a real op (not an unregistered
+// placeholder) is required to trigger it.
+//
+// verifyShapeRegionStructure is a defensive backstop for ops that forget the
+// SingleBlockImplicitTerminator<"ShapeYieldOp"> trait; on a real op that trait
+// (and SizedRegion<1>) verify structure first, so it is not separately
+// exercised here.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt %s -split-input-file -verify-diagnostics | FileCheck %s
+
+// A shape region may reference the op's own operands (%lhs, %rhs) and values
+// defined inside the region. This is the allowed baseline.
+
+// CHECK-LABEL: func.func @scoping_operands_ok
+func.func @scoping_operands_ok(%lhs: tensor<?x256xf16>, %rhs: tensor<256x512xf16>,
+                               %init: tensor<?x512xf16>) -> tensor<?x512xf16> {
+  // CHECK: hipsr.matmul
+  %0 = hipsr.matmul ins(%lhs, %rhs : tensor<?x256xf16>, tensor<256x512xf16>)
+                    outs(%init : tensor<?x512xf16>) -> tensor<?x512xf16>
+                    shape_region {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %m = tensor.dim %lhs, %c0 : tensor<?x256xf16>
+    %n = tensor.dim %rhs, %c1 : tensor<256x512xf16>
+    hipsr.shape_yield %m, %n
+  }
+  return %0 : tensor<?x512xf16>
+}
+
+// -----
+
+// Values defined in a region nested inside the shape region (here an scf.if)
+// are allowed: the shape region is an ancestor of the nested region.
+
+// CHECK-LABEL: func.func @scoping_nested_region_ok
+func.func @scoping_nested_region_ok(%lhs: tensor<?x256xf16>, %rhs: tensor<256x512xf16>,
+                                    %init: tensor<?x512xf16>) -> tensor<?x512xf16> {
+  // CHECK: hipsr.matmul
+  %0 = hipsr.matmul ins(%lhs, %rhs : tensor<?x256xf16>, tensor<256x512xf16>)
+                    outs(%init : tensor<?x512xf16>) -> tensor<?x512xf16>
+                    shape_region {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %pred = arith.constant true
+    %m = scf.if %pred -> index {
+      %d = tensor.dim %lhs, %c0 : tensor<?x256xf16>
+      scf.yield %d : index
+    } else {
+      scf.yield %c0 : index
+    }
+    %n = tensor.dim %rhs, %c1 : tensor<256x512xf16>
+    hipsr.shape_yield %m, %n
+  }
+  return %0 : tensor<?x512xf16>
+}
+
+// -----
+
+// A value defined in the enclosing function that is NOT one of the op's
+// operands is a disallowed outer capture: verifyShapeRegionScoping rejects it.
+
+func.func @scoping_disallowed_outer(%lhs: tensor<?x256xf16>, %rhs: tensor<256x512xf16>,
+                                    %init: tensor<?x512xf16>) -> tensor<?x512xf16> {
+  %outer = arith.constant 512 : index
+  // expected-error@+1 {{shape region references disallowed outer value}}
+  %0 = hipsr.matmul ins(%lhs, %rhs : tensor<?x256xf16>, tensor<256x512xf16>)
+                    outs(%init : tensor<?x512xf16>) -> tensor<?x512xf16>
+                    shape_region {
+    %c0 = arith.constant 0 : index
+    %m = tensor.dim %lhs, %c0 : tensor<?x256xf16>
+    // expected-note@+1 {{used here by 'hipsr.shape_yield'}}
+    hipsr.shape_yield %m, %outer
+  }
+  return %0 : tensor<?x512xf16>
+}


### PR DESCRIPTION
First concrete op built on `Hipsr_DpsOp` (#480), exercising the shape-region / DPS / `ShapeRegionInterface` path end-to-end.

## What

- Add `hipsr.matmul` (Regular): `ins(lhs, rhs) outs(init) -> result`, carrying a shape region that computes `[M, N] = [dim(lhs, 0), dim(rhs, 1)]`. Implements `populateShapeRegion` and `getDpsInitsMutable`.
- Lives in its own per-op file (`HipsrMatMulOp.*`), matching the `shape_yield` layout, so `HipsrOps.td` stays base-class only and `shape_yield`'s TableGen does not pull in compute ops.
- Give `hipsr.shape_yield` a zero-operand builder so `SingleBlockImplicitTerminator<"ShapeYieldOp">` can auto-insert the terminator (cf. `scf.yield`).
- Print the region behind a `shape_region` keyword for readability.

## Tests

- `matmul.mlir`: round-trip.
- `matmul_shape_region_verify.mlir`: proves `verifyShapeRegionScoping` runs on a real interface op — operands and nested-region (scf.if) values are allowed; a disallowed outer capture is rejected with a clear error + note. (Note: `verifyShapeRegionStructure` is a defensive backstop preempted by the trait/region verifiers on real ops, and interface verifiers do not run on unregistered placeholder ops, so it is not separately exercised.)

## Test plan

- Build + install pass; all Hipsr `.inc` generate.
- LIT suite green (0 failures).