### PR TITLE
feat(dialect): add hipsr IsolatedFromAboveButAllowOperands trait

### DIFF
--- a/include/hip/Dialect/Hipsr/IR/HipsrOps.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrOps.h
@@ -14,6 +14,9 @@
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
+// Must precede the .inc: generated op classes use the trait template.
+#include "hip/Dialect/Hipsr/IR/HipsrTraits.h"
+
 #define GET_OP_CLASSES
 #include "hip/Dialect/Hipsr/IR/HipsrOps.h.inc"
 

--- a/include/hip/Dialect/Hipsr/IR/HipsrOps.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrOps.td
@@ -10,6 +10,7 @@ include "mlir/IR/OpBase.td"
 include "mlir/Interfaces/DestinationStyleOpInterface.td"
 include "hip/Dialect/Hipsr/IR/HipsrDialect.td"
 include "hip/Dialect/Hipsr/IR/HipsrTypes.td"
+include "hip/Dialect/Hipsr/IR/HipsrTraits.td"
 include "hip/Dialect/Hipsr/IR/HipsrShapeRegionInterface.td"
 
 //===----------------------------------------------------------------------===//
@@ -31,6 +32,8 @@ class Hipsr_Op<string mnemonic, list<Trait> traits = []> :
 //     trait auto-inserts that terminator and structurally checks it;
 //   - implements ShapeRegionInterface, the single source of truth for shape
 //     computation (each op provides populateShapeRegion());
+//   - carries IsolatedFromAboveButAllowOperands, so the shape region may only
+//     use the op's operands and values defined inside the region;
 //   - uses destination-passing style (DestinationStyleOpInterface): its output
 //     buffer(s) are passed as `outs` init operands (getDpsInitsMutable is
 //     op-defined).
@@ -42,6 +45,7 @@ class Hipsr_DpsOp<string mnemonic, list<Trait> traits = []> :
         DeclareOpInterfaceMethods<ShapeRegionInterface, ["populateShapeRegion"]>,
         DeclareOpInterfaceMethods<DestinationStyleOpInterface,
                                   ["getDpsInitsMutable"]>,
+        IsolatedFromAboveButAllowOperands,
         SingleBlockImplicitTerminator<"ShapeYieldOp">
       ], traits)> {
   let regions = (region SizedRegion<1>:$shape_region);

--- a/include/hip/Dialect/Hipsr/IR/HipsrShapeRegionInterface.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrShapeRegionInterface.h
@@ -9,34 +9,18 @@
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/Support/LogicalResult.h"
 
+// The generated interface verifier (in the .h.inc below) references the
+// IsolatedFromAboveButAllowOperands trait type, so it must be declared first.
+#include "hip/Dialect/Hipsr/IR/HipsrTraits.h"
+
 namespace mlir {
 namespace hipsr {
 
-/// Verifies that the shape region (region 0) has exactly one block that ends
-/// with a `hipsr.shape_yield` terminator. This is a defensive check for the
-/// case where an op implements ShapeRegionInterface but forgets to add the
-/// `SingleBlockImplicitTerminator<"ShapeYieldOp">` trait: it produces a clear
-/// error instead of letting a wrong terminator crash downstream code that
-/// assumes shape_yield. Runs before verifyShapeRegionScoping.
+/// Verifies that the shape region (region 0) has exactly one block ending with
+/// a `hipsr.shape_yield` terminator. Gives a clear error if an op implements
+/// ShapeRegionInterface but forgets the
+/// `SingleBlockImplicitTerminator<"ShapeYieldOp">` trait.
 ::mlir::LogicalResult verifyShapeRegionStructure(::mlir::Operation *op);
-
-/// Verifies that every value used inside an op's shape region is either
-/// defined within the region, a block argument of the region, or one of the
-/// op's own operands. Referenced by ShapeRegionInterface's verifier.
-///
-/// Design note: we use custom scoping verification instead of the
-/// IsolatedFromAbove trait because shape regions need *selective* isolation:
-/// - IsolatedFromAbove: region cannot access ANY outer value (full isolation).
-/// - verifyShapeRegionScoping: region CAN access the op's operands, nothing
-///   else.
-///
-/// Shape regions must read the op's inputs to compute output shapes, e.g.
-/// `tensor.dim %input, %c0` where %input is the op's operand. Under
-/// IsolatedFromAbove that would require threading every such value through
-/// verbose region arguments. This design allows direct access to the op's
-/// operands for ergonomics while still preventing accidental capture of
-/// arbitrary outer-scope values.
-::mlir::LogicalResult verifyShapeRegionScoping(::mlir::Operation *op);
 
 } // namespace hipsr
 } // namespace mlir

--- a/include/hip/Dialect/Hipsr/IR/HipsrShapeRegionInterface.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrShapeRegionInterface.td
@@ -26,19 +26,20 @@ def ShapeRegionInterface : OpInterface<"ShapeRegionInterface"> {
     the op's output dimensions and ends with a `hipsr.shape_yield`. The
     populate* methods emit that region; the get* accessors retrieve it.
 
-    REQUIREMENT: an op implementing this interface MUST also add the
-    `SingleBlockImplicitTerminator<"ShapeYieldOp">` trait, e.g.
+    REQUIREMENT: an op implementing this interface MUST also add two traits
+    (MLIR interfaces cannot auto-attach traits), e.g.
 
       def Hipsr_MatMulOp : Hipsr_Op<"matmul", [
           ShapeRegionInterface,
+          IsolatedFromAboveButAllowOperands,
           SingleBlockImplicitTerminator<"ShapeYieldOp">
       ]> { ... }
 
-    The trait provides automatic terminator insertion; MLIR interfaces cannot
-    auto-attach traits, so the interface verifier defensively checks the shape
-    region's single-block/terminator structure (verifyShapeRegionStructure)
-    before enforcing the scoping rules (verifyShapeRegionScoping), giving a
-    clear error instead of a downstream crash if the trait is forgotten.
+    `SingleBlockImplicitTerminator<"ShapeYieldOp">` inserts the terminator;
+    `IsolatedFromAboveButAllowOperands` restricts what the shape region may use.
+    The interface verifier checks the region structure and that the trait is
+    present (so a missing trait gives a clear error); the trait's own verifier
+    does the scoping check.
 
     Operation categories (barrier markers are separate interfaces):
     - Regular (MatMul, Add): no block arguments, one shape, depends on input shapes.
@@ -92,7 +93,13 @@ def ShapeRegionInterface : OpInterface<"ShapeRegionInterface"> {
   let verify = [{
     if (::mlir::failed(::mlir::hipsr::verifyShapeRegionStructure($_op)))
       return ::mlir::failure();
-    return ::mlir::hipsr::verifyShapeRegionScoping($_op);
+    // The trait's verifier does the scoping check; just require it be present.
+    if (!$_op->hasTrait<
+            ::mlir::hipsr::OpTrait::IsolatedFromAboveButAllowOperands>())
+      return $_op->emitOpError(
+          "ShapeRegionInterface requires the "
+          "IsolatedFromAboveButAllowOperands trait");
+    return ::mlir::success();
   }];
 }
 

--- a/include/hip/Dialect/Hipsr/IR/HipsrTraits.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrTraits.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#ifndef HIPSR_TRAITS_H
+#define HIPSR_TRAITS_H
+
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir {
+namespace hipsr {
+namespace OpTrait {
+namespace impl {
+/// Verifier for the `IsolatedFromAboveButAllowOperands` trait: every value used
+/// in `op`'s regions must be defined inside those regions (block arguments
+/// included) or be one of `op`'s operands. `op` must carry the trait.
+/// See HipsrTraits.cpp.
+::mlir::LogicalResult
+verifyIsolatedFromAboveButAllowOperands(::mlir::Operation *op);
+} // namespace impl
+
+/// `IsolatedFromAboveButAllowOperands` op trait; forwards to the verifier
+/// above. Uses verifyRegionTrait (like IsIsolatedFromAbove) so it runs after
+/// the nested region ops are verified.
+template <typename ConcreteType>
+class IsolatedFromAboveButAllowOperands
+    : public ::mlir::OpTrait::TraitBase<ConcreteType,
+                                        IsolatedFromAboveButAllowOperands> {
+public:
+  static ::mlir::LogicalResult verifyRegionTrait(::mlir::Operation *op) {
+    return impl::verifyIsolatedFromAboveButAllowOperands(op);
+  }
+};
+
+} // namespace OpTrait
+} // namespace hipsr
+} // namespace mlir
+
+#endif // HIPSR_TRAITS_H

--- a/include/hip/Dialect/Hipsr/IR/HipsrTraits.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrTraits.td
@@ -1,0 +1,19 @@
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+
+#ifndef HIPSR_TRAITS
+#define HIPSR_TRAITS
+
+include "mlir/IR/OpBase.td"
+
+// Like IsolatedFromAbove, but a region may also use the op's own operands (not
+// just values defined inside the region). Used by shape regions that read the
+// op's inputs to compute output shapes. See HipsrTraits.h for the verifier.
+def IsolatedFromAboveButAllowOperands : NativeOpTrait<
+    "IsolatedFromAboveButAllowOperands"> {
+  let cppNamespace = "::mlir::hipsr::OpTrait";
+}
+
+#endif // HIPSR_TRAITS

--- a/lib/Dialect/Hipsr/IR/CMakeLists.txt
+++ b/lib/Dialect/Hipsr/IR/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(HipsrDialectIR STATIC
   HipsrShapeRegionInterface.cpp
   HipsrShapeYieldOp.cpp
   HipsrOps.cpp
+  HipsrTraits.cpp
   HipsrTypes.cpp
 )
 

--- a/lib/Dialect/Hipsr/IR/HipsrShapeRegionInterface.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrShapeRegionInterface.cpp
@@ -7,8 +7,6 @@
 
 #include "hip/Dialect/Hipsr/IR/HipsrShapeYieldOp.h"
 
-#include "llvm/ADT/DenseSet.h"
-
 using namespace mlir;
 using namespace mlir::hipsr;
 
@@ -21,7 +19,7 @@ LogicalResult mlir::hipsr::verifyShapeRegionStructure(Operation *op) {
     return op->emitOpError("shape region must have exactly one block");
 
   Block &block = shapeRegion.front();
-  if (block.empty() || !block.back().hasTrait<OpTrait::IsTerminator>())
+  if (block.empty() || !block.back().hasTrait<mlir::OpTrait::IsTerminator>())
     return op->emitOpError("shape region block must end with a terminator");
 
   if (!isa<ShapeYieldOp>(block.back()))
@@ -33,45 +31,6 @@ LogicalResult mlir::hipsr::verifyShapeRegionStructure(Operation *op) {
               "SingleBlockImplicitTerminator<\"ShapeYieldOp\"> trait?";
 
   return success();
-}
-
-LogicalResult mlir::hipsr::verifyShapeRegionScoping(Operation *op) {
-  Region &shapeRegion = op->getRegion(0);
-  if (shapeRegion.empty())
-    return success();
-
-  // Values the shape region is allowed to reference from outside itself: the
-  // op's own operands (%ctx, inputs, outs, ...).
-  DenseSet<Value> allowedValues;
-  for (Value operand : op->getOperands())
-    allowedValues.insert(operand);
-
-  auto walkResult = shapeRegion.walk([&](Operation *innerOp) -> WalkResult {
-    for (Value operand : innerOp->getOperands()) {
-      // Block arguments (EndBarrier ops receive their results): fine.
-      if (isa<BlockArgument>(operand))
-        continue;
-      // Values (op results or block arguments) defined inside the shape
-      // region, directly or in a nested region (e.g. an scf.for used to
-      // compute a dim), are always fine. This also covers the shape region's
-      // own block arguments, which EndBarrier ops receive their results
-      // through; block arguments captured from an enclosing region are not an
-      // ancestor of the shape region and fall through to the operand check.
-      Region *definingRegion = operand.getParentRegion();
-      if (definingRegion && shapeRegion.isAncestor(definingRegion))
-        continue;
-      // Otherwise the value must be one of the op's own operands.
-      if (!allowedValues.contains(operand)) {
-        op->emitOpError("shape region references disallowed outer value")
-                .attachNote(innerOp->getLoc())
-            << "used here by '" << innerOp->getName() << "'";
-        return WalkResult::interrupt();
-      }
-    }
-    return WalkResult::advance();
-  });
-
-  return failure(walkResult.wasInterrupted());
 }
 
 #include "hip/Dialect/Hipsr/IR/HipsrShapeRegionInterface.cpp.inc"

--- a/lib/Dialect/Hipsr/IR/HipsrTraits.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrTraits.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "hip/Dialect/Hipsr/IR/HipsrTraits.h"
+
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/Region.h"
+
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include <cassert>
+
+using namespace mlir;
+
+// Same structure as MLIR's OpTrait::impl::verifyIsIsolatedFromAbove
+// (mlir/lib/IR/Operation.cpp), with one added rule: a region may also use the
+// op's own operands, not just values defined inside its regions.
+LogicalResult
+mlir::hipsr::OpTrait::impl::verifyIsolatedFromAboveButAllowOperands(
+    Operation *isolatedOp) {
+  assert(isolatedOp->hasTrait<
+             mlir::hipsr::OpTrait::IsolatedFromAboveButAllowOperands>() &&
+         "Intended to check IsolatedFromAboveButAllowOperands ops");
+
+  llvm::DenseSet<Value> allowedOperands;
+  for (Value operand : isolatedOp->getOperands())
+    allowedOperands.insert(operand);
+
+  llvm::SmallVector<Region *, 8> pendingRegions;
+  for (Region &region : isolatedOp->getRegions()) {
+    pendingRegions.push_back(&region);
+
+    while (!pendingRegions.empty()) {
+      for (Operation &op : pendingRegions.pop_back_val()->getOps()) {
+        for (Value operand : op.getOperands()) {
+          Region *operandRegion = operand.getParentRegion();
+          if (!operandRegion)
+            return op.emitError("operation's operand is unlinked");
+
+          // OK if the value is defined in this region or a nested one
+          // (isAncestor covers block arguments too), or is an op operand.
+          if (!region.isAncestor(operandRegion) &&
+              !allowedOperands.contains(operand)) {
+            return op.emitOpError("using value defined outside the region")
+                       .attachNote(isolatedOp->getLoc())
+                   << "may only use values defined in its regions or the op's "
+                      "operands";
+          }
+        }
+
+        // Descend, but skip ops that isolate themselves -- they run their own
+        // check.
+        if (op.getNumRegions() &&
+            !op.hasTrait<mlir::OpTrait::IsIsolatedFromAbove>() &&
+            !op.hasTrait<
+                mlir::hipsr::OpTrait::IsolatedFromAboveButAllowOperands>()) {
+          for (Region &subRegion : op.getRegions())
+            pendingRegions.push_back(&subRegion);
+        }
+      }
+    }
+  }
+
+  return success();
+}


### PR DESCRIPTION
## Summary

Adds a native op trait `IsolatedFromAboveButAllowOperands` to the `hipsr` dialect and applies it to `Hipsr_DpsOp`.

It works like MLIR's `IsolatedFromAbove` (a region can't reference values from the enclosing scope), but also lets region ops reference **the op's own operands**. Shape regions need this: they read the op's inputs to compute output shapes (e.g. `tensor.dim %input, %c0`), so full isolation would force threading every input through region arguments.

## Notes for reviewers

- The verifier follows upstream `verifyIsIsolatedFromAbove` closely, adding just one rule: the op's operands are allowed.
- This replaces the ad-hoc `verifyShapeRegionScoping` that previously lived in the `ShapeRegionInterface` verifier. The interface now only requires the trait to be present and lets the trait do the scoping check.
- No concrete op carries the trait yet (`Hipsr_DpsOp` is a base class), so scoping is exercised by later PRs that add concrete ops.
