### PR TITLE
feat(dialect): add hipsr SingleBlockExplicitTerminator trait

### DIFF
--- a/include/hip/Dialect/Hipsr/IR/HipsrOps.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrOps.td
@@ -27,9 +27,10 @@ class Hipsr_Op<string mnemonic, list<Trait> traits = []> :
 //===----------------------------------------------------------------------===//
 
 // Base for shaped compute ops (MatMul, Add, ...). Every such op:
-//   - carries a shape region (region 0) that computes its output shape and is
-//     terminated by `hipsr.shape_yield`. The SingleBlockImplicitTerminator
-//     trait auto-inserts that terminator and structurally checks it;
+//   - carries a shape region (region 0) that computes its output shape and ends
+//     with a `hipsr.shape_yield` written by populateShapeRegion(). The
+//     SingleBlockExplicitTerminator trait checks that yield is present but never
+//     adds one, so a missing shape_yield is an error, not a silent default;
 //   - implements ShapeRegionInterface, the single source of truth for shape
 //     computation (each op provides populateShapeRegion());
 //   - carries IsolatedFromAboveButAllowOperands, so the shape region may only
@@ -46,7 +47,7 @@ class Hipsr_DpsOp<string mnemonic, list<Trait> traits = []> :
         DeclareOpInterfaceMethods<DestinationStyleOpInterface,
                                   ["getDpsInitsMutable"]>,
         IsolatedFromAboveButAllowOperands,
-        SingleBlockImplicitTerminator<"ShapeYieldOp">
+        SingleBlockExplicitTerminator<"ShapeYieldOp">
       ], traits)> {
   let regions = (region SizedRegion<1>:$shape_region);
   let results = (outs Variadic<AnyRankedTensor>:$result_tensors);

--- a/include/hip/Dialect/Hipsr/IR/HipsrShapeRegionInterface.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrShapeRegionInterface.h
@@ -9,21 +9,11 @@
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/Support/LogicalResult.h"
 
-// The generated interface verifier (in the .h.inc below) references the
-// IsolatedFromAboveButAllowOperands trait type, so it must be declared first.
+// The generated verifier below uses both traits, and names
+// SingleBlockExplicitTerminator with ShapeYieldOp, so the traits header and the
+// full ShapeYieldOp type must be included first.
+#include "hip/Dialect/Hipsr/IR/HipsrShapeYieldOp.h"
 #include "hip/Dialect/Hipsr/IR/HipsrTraits.h"
-
-namespace mlir {
-namespace hipsr {
-
-/// Verifies that the shape region (region 0) has exactly one block ending with
-/// a `hipsr.shape_yield` terminator. Gives a clear error if an op implements
-/// ShapeRegionInterface but forgets the
-/// `SingleBlockImplicitTerminator<"ShapeYieldOp">` trait.
-::mlir::LogicalResult verifyShapeRegionStructure(::mlir::Operation *op);
-
-} // namespace hipsr
-} // namespace mlir
 
 #include "hip/Dialect/Hipsr/IR/HipsrShapeRegionInterface.h.inc"
 

--- a/include/hip/Dialect/Hipsr/IR/HipsrShapeRegionInterface.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrShapeRegionInterface.td
@@ -32,14 +32,15 @@ def ShapeRegionInterface : OpInterface<"ShapeRegionInterface"> {
       def Hipsr_MatMulOp : Hipsr_Op<"matmul", [
           ShapeRegionInterface,
           IsolatedFromAboveButAllowOperands,
-          SingleBlockImplicitTerminator<"ShapeYieldOp">
+          SingleBlockExplicitTerminator<"ShapeYieldOp">
       ]> { ... }
 
-    `SingleBlockImplicitTerminator<"ShapeYieldOp">` inserts the terminator;
-    `IsolatedFromAboveButAllowOperands` restricts what the shape region may use.
-    The interface verifier checks the region structure and that the trait is
-    present (so a missing trait gives a clear error); the trait's own verifier
-    does the scoping check.
+    `SingleBlockExplicitTerminator<"ShapeYieldOp">` requires each region to end
+    with a `hipsr.shape_yield` (never added automatically, since it carries the
+    computed shape). `IsolatedFromAboveButAllowOperands` limits what the shape
+    region may read. The interface verifier only checks that both traits are
+    present so a missing one gives a clear error; each trait's own verifier does
+    the real check.
 
     Operation categories (barrier markers are separate interfaces):
     - Regular (MatMul, Add): no block arguments, one shape, depends on input shapes.
@@ -91,9 +92,14 @@ def ShapeRegionInterface : OpInterface<"ShapeRegionInterface"> {
   ];
 
   let verify = [{
-    if (::mlir::failed(::mlir::hipsr::verifyShapeRegionStructure($_op)))
-      return ::mlir::failure();
-    // The trait's verifier does the scoping check; just require it be present.
+    // Each trait's own verifier does the real check (explicit shape_yield,
+    // scoping); here we only require both traits so a missing one is a clear
+    // error instead of a silent skip.
+    if (!$_op->hasTrait<::mlir::hipsr::OpTrait::SingleBlockExplicitTerminator<
+            ::mlir::hipsr::ShapeYieldOp>::Impl>())
+      return $_op->emitOpError(
+          "ShapeRegionInterface requires the "
+          "SingleBlockExplicitTerminator<ShapeYieldOp> trait");
     if (!$_op->hasTrait<
             ::mlir::hipsr::OpTrait::IsolatedFromAboveButAllowOperands>())
       return $_op->emitOpError(

--- a/include/hip/Dialect/Hipsr/IR/HipsrTraits.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrTraits.h
@@ -7,6 +7,7 @@
 #define HIPSR_TRAITS_H
 
 #include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/Region.h"
 #include "mlir/Support/LogicalResult.h"
 
 namespace mlir {
@@ -32,6 +33,36 @@ public:
   static ::mlir::LogicalResult verifyRegionTrait(::mlir::Operation *op) {
     return impl::verifyIsolatedFromAboveButAllowOperands(op);
   }
+};
+
+/// `SingleBlockExplicitTerminator<Op>` op trait: like
+/// `mlir::OpTrait::SingleBlockImplicitTerminator<Op>`, but the terminator is
+/// never auto-inserted -- each non-empty region must already end with `Op`.
+/// hipsr shape regions use it because the terminator (`hipsr.shape_yield`)
+/// carries the computed shape, so a missing one is an error, not a default.
+/// The one-block-per-region check comes from `SingleBlock`, which the ODS
+/// `TraitList` adds alongside this trait. The nested `Impl` template matches
+/// upstream so ODS can name the trait as `SingleBlockExplicitTerminator<Op>`.
+template <typename TerminatorOpType> struct SingleBlockExplicitTerminator {
+  template <typename ConcreteType>
+  class Impl : public ::mlir::OpTrait::TraitBase<
+                   ConcreteType,
+                   SingleBlockExplicitTerminator<TerminatorOpType>::Impl> {
+  public:
+    static ::mlir::LogicalResult verifyRegionTrait(::mlir::Operation *op) {
+      for (::mlir::Region &region : op->getRegions()) {
+        // An empty region has nothing to terminate.
+        if (region.empty())
+          continue;
+        ::mlir::Block &block = region.front();
+        if (block.empty() || !::mlir::isa<TerminatorOpType>(block.back()))
+          return op->emitOpError("region must end with an explicit '")
+                 << TerminatorOpType::getOperationName()
+                 << "' terminator (it is not auto-inserted)";
+      }
+      return ::mlir::success();
+    }
+  };
 };
 
 } // namespace OpTrait

--- a/include/hip/Dialect/Hipsr/IR/HipsrTraits.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrTraits.td
@@ -16,4 +16,17 @@ def IsolatedFromAboveButAllowOperands : NativeOpTrait<
   let cppNamespace = "::mlir::hipsr::OpTrait";
 }
 
+// Like SingleBlockImplicitTerminator<op>, but the terminator must be written
+// explicitly -- it is never auto-inserted. Used for shape regions, where the
+// terminator (hipsr.shape_yield) carries the computed shape, so a missing one
+// is a real error, not something to fill in. See HipsrTraits.h for the check.
+class SingleBlockExplicitTerminatorImpl<string op>
+    : ParamNativeOpTrait<"SingleBlockExplicitTerminator", op, [SingleBlock]>,
+      StructuralOpTrait {
+  let cppNamespace = "::mlir::hipsr::OpTrait";
+}
+
+class SingleBlockExplicitTerminator<string op>
+    : TraitList<[SingleBlock, SingleBlockExplicitTerminatorImpl<op>]>;
+
 #endif // HIPSR_TRAITS

--- a/lib/Dialect/Hipsr/IR/HipsrShapeRegionInterface.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrShapeRegionInterface.cpp
@@ -5,32 +5,4 @@
 
 #include "hip/Dialect/Hipsr/IR/HipsrShapeRegionInterface.h"
 
-#include "hip/Dialect/Hipsr/IR/HipsrShapeYieldOp.h"
-
-using namespace mlir;
-using namespace mlir::hipsr;
-
-LogicalResult mlir::hipsr::verifyShapeRegionStructure(Operation *op) {
-  if (op->getNumRegions() == 0)
-    return op->emitOpError("expected a shape region (region 0)");
-
-  Region &shapeRegion = op->getRegion(0);
-  if (!shapeRegion.hasOneBlock())
-    return op->emitOpError("shape region must have exactly one block");
-
-  Block &block = shapeRegion.front();
-  if (block.empty() || !block.back().hasTrait<mlir::OpTrait::IsTerminator>())
-    return op->emitOpError("shape region block must end with a terminator");
-
-  if (!isa<ShapeYieldOp>(block.back()))
-    return op->emitOpError(
-               "shape region must terminate with hipsr.shape_yield, "
-               "got '")
-           << block.back().getName()
-           << "'; did you forget the "
-              "SingleBlockImplicitTerminator<\"ShapeYieldOp\"> trait?";
-
-  return success();
-}
-
 #include "hip/Dialect/Hipsr/IR/HipsrShapeRegionInterface.cpp.inc"


### PR DESCRIPTION
## Summary

Replaces the `verifyShapeRegionStructure` helper with a new op trait, `SingleBlockExplicitTerminator<"op">`.

- It works like upstream `SingleBlockImplicitTerminator<"op">`, but never adds the terminator for you: each non-empty region must already end with the named op, or verification fails.
- `Hipsr_DpsOp` uses it as `SingleBlockExplicitTerminator<"ShapeYieldOp">`. This fits shape regions because `hipsr.shape_yield` carries the computed shape, so a missing one should be an error, not a default that gets filled in.
- `ShapeRegionInterface` now just checks that both required traits are present (giving a clear error if one is missing); each trait's own verifier does the real check.

## Changes

- `HipsrTraits.td` / `HipsrTraits.h`: add the `SingleBlockExplicitTerminator` trait (composed with `SingleBlock`).
- `HipsrOps.td`: `Hipsr_DpsOp` uses the new trait instead of `SingleBlockImplicitTerminator`.
- `HipsrShapeRegionInterface.{td,h,cpp}`: drop `verifyShapeRegionStructure`; require both traits in the interface verifier.
