### PR TITLE
feat(dialect): redesign hipsr.shape_yield with VariadicOfVariadic operands

### DIFF
--- a/include/hip/Dialect/Hipsr/IR/HipsrShapeRegionInterface.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrShapeRegionInterface.h
@@ -6,8 +6,12 @@
 #ifndef HIPSR_SHAPE_REGION_INTERFACE_H
 #define HIPSR_SHAPE_REGION_INTERFACE_H
 
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/Region.h"
+#include "mlir/IR/Value.h"
 #include "mlir/Support/LogicalResult.h"
+#include "llvm/ADT/SmallVector.h"
 
 // The generated interface verifier (in the .h.inc below) references the
 // IsolatedFromAboveButAllowOperands trait type, so it must be declared first.
@@ -21,6 +25,18 @@ namespace hipsr {
 /// ShapeRegionInterface but forgets the
 /// `SingleBlockImplicitTerminator<"ShapeYieldOp">` trait.
 ::mlir::LogicalResult verifyShapeRegionStructure(::mlir::Operation *op);
+
+/// Read the `hipsr.shape_yield` at the end of `shapeRegion` and return each
+/// result's dim values, grouped per result. The region must be populated.
+::llvm::SmallVector<::llvm::SmallVector<::mlir::Value>>
+getShapeRegionResultShapes(::mlir::Region &shapeRegion);
+
+/// Read the `hipsr.shape_yield` at the end of `shapeRegion` and return each
+/// result's tensor type. Every extent is dynamic; constant dims fold back to
+/// static extents later via the tensor.empty canonicalizer. The region must be
+/// populated.
+::llvm::SmallVector<::mlir::RankedTensorType>
+getShapeRegionResultTypes(::mlir::Region &shapeRegion);
 
 } // namespace hipsr
 } // namespace mlir

--- a/include/hip/Dialect/Hipsr/IR/HipsrShapeRegionInterface.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrShapeRegionInterface.td
@@ -88,6 +88,52 @@ def ShapeRegionInterface : OpInterface<"ShapeRegionInterface"> {
         return $_op->getNumRegions() > 1 ? &$_op->getRegion(1) : nullptr;
       }]
     >,
+    InterfaceMethod<
+      [{Return each result's dim values, grouped per result (handy for building
+        `tensor.empty`). The shape region must be populated.}],
+      "::llvm::SmallVector<::llvm::SmallVector<::mlir::Value>>",
+      "getShapeRegionResultShapes", (ins),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        return ::mlir::hipsr::getShapeRegionResultShapes($_op.getShapeRegion());
+      }]
+    >,
+    InterfaceMethod<
+      [{Return each result's tensor type. Every extent is dynamic (an empty dim
+        group gives a rank-0 tensor); constant dims fold back to static extents
+        later via the tensor.empty canonicalizer. The shape region must be
+        populated.}],
+      "::llvm::SmallVector<::mlir::RankedTensorType>",
+      "getShapeRegionResultTypes", (ins),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        return ::mlir::hipsr::getShapeRegionResultTypes($_op.getShapeRegion());
+      }]
+    >,
+    InterfaceMethod<
+      [{Like getShapeRegionResultShapes, but for the capacity region (region 1).
+        Only valid on EndBarrier ops; the capacity region must be populated.}],
+      "::llvm::SmallVector<::llvm::SmallVector<::mlir::Value>>",
+      "getCapacityShapeRegionResultShapes", (ins),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        ::mlir::Region *region = $_op.getCapacityShapeRegion();
+        assert(region && "op has no capacity shape region (region 1)");
+        return ::mlir::hipsr::getShapeRegionResultShapes(*region);
+      }]
+    >,
+    InterfaceMethod<
+      [{Like getShapeRegionResultTypes, but for the capacity region (region 1).
+        Only valid on EndBarrier ops; the capacity region must be populated.}],
+      "::llvm::SmallVector<::mlir::RankedTensorType>",
+      "getCapacityShapeRegionResultTypes", (ins),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        ::mlir::Region *region = $_op.getCapacityShapeRegion();
+        assert(region && "op has no capacity shape region (region 1)");
+        return ::mlir::hipsr::getShapeRegionResultTypes(*region);
+      }]
+    >,
   ];
 
   let verify = [{

--- a/include/hip/Dialect/Hipsr/IR/HipsrShapeYieldOp.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrShapeYieldOp.h
@@ -8,6 +8,7 @@
 
 #include "hip/Dialect/Hipsr/IR/HipsrDialect.h"
 
+#include "mlir/Bytecode/BytecodeOpInterface.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/OpDefinition.h"

--- a/include/hip/Dialect/Hipsr/IR/HipsrShapeYieldOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrShapeYieldOp.td
@@ -17,27 +17,58 @@ include "hip/Dialect/Hipsr/IR/HipsrOps.td"
 //===----------------------------------------------------------------------===//
 
 def Hipsr_ShapeYieldOp : Hipsr_Op<"shape_yield", [Pure, Terminator]> {
-  let summary = "Terminator of a hipsr shape region";
+  let summary = "Yield the result shapes from a hipsr shape region";
   let description = [{
-    Terminates a shape region and yields the computed output dimensions as
-    `index` values. Every shape region ends with exactly one `shape_yield`.
+    Ends a shape region and yields the output shape of each of the enclosing
+    op's results. Every shape region ends with exactly one `shape_yield`.
 
-    In Phase 1 a shape region is attached to a shaped op and computes that
-    op's output shape; `shape_yield` hands the resulting per-dimension SSA
-    values back to the enclosing op. A zero-operand `shape_yield` denotes a
-    rank-0 (scalar) result.
+    A result is described by three lists that line up by index:
 
-    Example:
+    - `shapes[i]`        : result i's dimensions, as a group of `index` values.
+    - `ranks[i]`         : result i's rank (how many dims are in `shapes[i]`).
+    - `element_types[i]` : result i's element type.
+
+    An empty dim group means a rank-0 (scalar) result. Each dim group prints in
+    parentheses; the element types print as a bracketed list.
+
+    Examples:
     ```mlir
-    hipsr.shape_yield %d0, %d1
+    // one 2-D f16 result
+    hipsr.shape_yield (%m, %n) : [f16]
+    // a 2-D f16 result and a 2-D i64 result
+    hipsr.shape_yield (%d0, %d1), (%N, %cap) : [f16, i64]
+    // one scalar (rank-0) result
+    hipsr.shape_yield () : [f32]
     ```
   }];
 
-  let arguments = (ins Variadic<Index>:$dims);
+  // `shapes` is a list of dim groups, one per result. `ranks` holds each
+  // group's size; it must be declared because VariadicOfVariadic looks it up by
+  // name (ODS does not add it for us) and fills it in from the shape groups.
+  // `element_types` holds each result's element type.
+  let arguments = (ins
+    VariadicOfVariadic<Index, "ranks">:$shapes,
+    DenseI32ArrayAttr:$ranks,
+    TypeArrayAttr:$element_types
+  );
 
-  // Operands are always `index` (Variadic<Index>), so the types are redundant
-  // and omitted from the assembly (cf. scf.yield / func.return practice).
-  let assemblyFormat = "attr-dict ($dims^)?";
+  // Dim groups print in parens; the element-type list prints in brackets. Dims
+  // are always `index`, so their types are left out (like scf.yield).
+  let assemblyFormat = "$shapes `:` $element_types attr-dict";
+
+  let hasVerifier = 1;
+
+  let builders = [
+    // Take element types as a TypeRange and wrap them into the attribute. Both
+    // args default to empty, so this also builds an empty `shape_yield` for
+    // SingleBlockImplicitTerminator. Callers that already have a TypeArrayAttr
+    // can use the builder ODS generates.
+    OpBuilder<(ins CArg<"::llvm::ArrayRef<::mlir::ValueRange>", "{}">:$shapes,
+                   CArg<"::mlir::TypeRange", "{}">:$elementTypes), [{
+      build($_builder, $_state, shapes,
+            $_builder.getTypeArrayAttr(elementTypes));
+    }]>
+  ];
 }
 
 #endif // HIPSR_SHAPE_YIELD_OP

--- a/lib/Dialect/Hipsr/IR/HipsrShapeRegionInterface.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrShapeRegionInterface.cpp
@@ -7,8 +7,19 @@
 
 #include "hip/Dialect/Hipsr/IR/HipsrShapeYieldOp.h"
 
+#include "llvm/ADT/STLExtras.h"
+
 using namespace mlir;
 using namespace mlir::hipsr;
+
+namespace {
+// Get the `hipsr.shape_yield` at the end of a (populated) shape region.
+ShapeYieldOp getShapeYieldOp(Region &shapeRegion) {
+  assert(!shapeRegion.empty() &&
+         "shape region must be populated before reading its shape_yield");
+  return cast<ShapeYieldOp>(shapeRegion.front().getTerminator());
+}
+} // namespace
 
 LogicalResult mlir::hipsr::verifyShapeRegionStructure(Operation *op) {
   if (op->getNumRegions() == 0)
@@ -31,6 +42,31 @@ LogicalResult mlir::hipsr::verifyShapeRegionStructure(Operation *op) {
               "SingleBlockImplicitTerminator<\"ShapeYieldOp\"> trait?";
 
   return success();
+}
+
+SmallVector<SmallVector<Value>>
+mlir::hipsr::getShapeRegionResultShapes(Region &shapeRegion) {
+  ShapeYieldOp yieldOp = getShapeYieldOp(shapeRegion);
+  SmallVector<SmallVector<Value>> dims;
+  for (OperandRange group : yieldOp.getShapes())
+    dims.emplace_back(group.begin(), group.end());
+  return dims;
+}
+
+SmallVector<RankedTensorType>
+mlir::hipsr::getShapeRegionResultTypes(Region &shapeRegion) {
+  ShapeYieldOp yieldOp = getShapeYieldOp(shapeRegion);
+  SmallVector<RankedTensorType> types;
+  for (auto [group, elemType] :
+       llvm::zip_equal(yieldOp.getShapes(),
+                       yieldOp.getElementTypes().getAsValueRange<TypeAttr>())) {
+    // Mark every extent dynamic and keep only the rank and element type. When a
+    // dim value is a constant, the tensor.empty canonicalizer folds it back to
+    // a static extent later, so nothing is lost.
+    SmallVector<int64_t> shape(group.size(), ShapedType::kDynamic);
+    types.push_back(RankedTensorType::get(shape, elemType));
+  }
+  return types;
 }
 
 #include "hip/Dialect/Hipsr/IR/HipsrShapeRegionInterface.cpp.inc"

--- a/lib/Dialect/Hipsr/IR/HipsrShapeYieldOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrShapeYieldOp.cpp
@@ -8,5 +8,19 @@
 using namespace mlir;
 using namespace mlir::hipsr;
 
+LogicalResult ShapeYieldOp::verify() {
+  // ODS already checks that `ranks` sums to the operand count, and `shapes` is
+  // built by splitting the operands on `ranks`, so shapes.size() ==
+  // ranks.size() and each shapes[i].size() == ranks[i] hold by construction.
+  // The one thing ODS does not tie down is the element-type count, so check it
+  // here: there must be one element type per result.
+  size_t numResults = getRanks().size();
+  size_t numTypes = getElementTypes().size();
+  if (numTypes != numResults)
+    return emitOpError() << "has " << numResults << " result(s) but "
+                         << numTypes << " element type(s)";
+  return success();
+}
+
 #define GET_OP_CLASSES
 #include "hip/Dialect/Hipsr/IR/HipsrShapeYieldOp.cpp.inc"


### PR DESCRIPTION
## What

Redesign `hipsr.shape_yield` to describe each result's shape as its own group of dims, and add matching accessors to `ShapeRegionInterface`.

## Changes

- **Op:** `hipsr.shape_yield` now takes `VariadicOfVariadic<Index, "ranks">` shapes, a `DenseI32ArrayAttr` rank-segment attr, and a `TypeArrayAttr` of per-result element types. Assembly prints dim groups in parens and element types in brackets, e.g. `hipsr.shape_yield (%m, %n) : [f16]`.
- **Verifier:** only checks the element-type count (ODS already verifies the rank segmentation).
- **Interface accessors:** `getShapeRegionResultShapes` (per-result dim values) and `getShapeRegionResultTypes` (per-result `RankedTensorType`, all extents dynamic), plus capacity-region siblings. Logic lives in free functions in the `.cpp`; the interface methods just delegate, so the interface header stays op-agnostic.
