### PR TITLE
feat(runtime): add INT16 cast and integer elementwise support

### DIFF
--- a/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
+++ b/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
@@ -174,6 +174,8 @@ inline int64_t getHipdnnDataType(Type elemType) {
     return 5; // HIPDNN_EP_DATATYPE_INT8
   if (elemType.isF64())
     return 6; // HIPDNN_EP_DATATYPE_DOUBLE
+  if (elemType.isInteger(16))
+    return 8; // HIPDNN_EP_DATATYPE_INT16
   return -1;
 }
 

--- a/lib/Runtime/Kernels/hip/cast_kernel.hip
+++ b/lib/Runtime/Kernels/hip/cast_kernel.hip
@@ -282,6 +282,16 @@ extern "C" int hip_cast(
                        dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
                        static_cast<const __half*>(input),
                        static_cast<uint8_t*>(output), num_elements);
+  } else if (input_dtype == HIP_DTYPE_INT8 && output_dtype == HIP_DTYPE_INT16) {
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(cast_int_to_int_kernel<int8_t, int16_t>),
+                       dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const int8_t*>(input),
+                       static_cast<int16_t*>(output), num_elements);
+  } else if (input_dtype == HIP_DTYPE_INT16 && output_dtype == HIP_DTYPE_UINT8) {
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(cast_int_to_int_kernel<int16_t, uint8_t>),
+                       dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const int16_t*>(input),
+                       static_cast<uint8_t*>(output), num_elements);
   } else {
     fprintf(stderr,
             "[custom_kernels] hip_cast: unsupported conversion "

--- a/lib/Runtime/Kernels/hip/elementwise_binary_kernel.hip
+++ b/lib/Runtime/Kernels/hip/elementwise_binary_kernel.hip
@@ -554,6 +554,13 @@ extern "C" int hip_elementwise_mul(void *stream, const void *lhs,
                        static_cast<const int32_t *>(rhs),
                        static_cast<int32_t *>(output), num_elements);
     break;
+  case HIP_DTYPE_INT16:
+    hipLaunchKernelGGL(elementwise_mul_kernel<int16_t>, dim3(grid_size),
+                       dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const int16_t *>(lhs),
+                       static_cast<const int16_t *>(rhs),
+                       static_cast<int16_t *>(output), num_elements);
+    break;
   case HIP_DTYPE_FLOAT16:
     hipLaunchKernelGGL(elementwise_mul_kernel<__half>, dim3(grid_size),
                        dim3(kBlockSize), 0, hip_stream,
@@ -599,6 +606,13 @@ extern "C" int hip_elementwise_add(void *stream, const void *lhs,
                        static_cast<const int32_t *>(lhs),
                        static_cast<const int32_t *>(rhs),
                        static_cast<int32_t *>(output), num_elements);
+    break;
+  case HIP_DTYPE_INT16:
+    hipLaunchKernelGGL(elementwise_add_kernel<int16_t>, dim3(grid_size),
+                       dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const int16_t *>(lhs),
+                       static_cast<const int16_t *>(rhs),
+                       static_cast<int16_t *>(output), num_elements);
     break;
   case HIP_DTYPE_FLOAT16:
     hipLaunchKernelGGL(elementwise_add_kernel<__half>, dim3(grid_size),

--- a/lib/Runtime/Kernels/hip/expand_kernel.hip
+++ b/lib/Runtime/Kernels/hip/expand_kernel.hip
@@ -172,6 +172,14 @@ extern "C" int hip_expand(void *stream, const void *input, void *output,
                        output_shape, aligned_in_strides, output_rank,
                        num_output_elements);
     break;
+  case HIP_DTYPE_INT16:
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(hip_expand_kernel<int16_t>),
+                       dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const int16_t *>(input),
+                       static_cast<int16_t *>(output), aligned_in_shape,
+                       output_shape, aligned_in_strides, output_rank,
+                       num_output_elements);
+    break;
   default:
     fprintf(stderr, "[custom_kernels] hip_expand: unsupported dtype=%d\n",
             hip_dtype);

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -38,6 +38,7 @@ extern "C" {
 #define HIPDNN_EP_DATATYPE_INT8 5     // i8, 1 byte
 #define HIPDNN_EP_DATATYPE_DOUBLE 6   // f64, 8 bytes
 #define HIPDNN_EP_DATATYPE_UINT8 7    // ui8, 1 byte
+#define HIPDNN_EP_DATATYPE_INT16 8    // i16, 2 byte
 
 //===----------------------------------------------------------------------===//
 // Backend-Independent Tensor Operation Identifiers
@@ -85,6 +86,8 @@ static inline int64_t hipdnn_ep_datatype_size(int64_t data_type) {
     return 1;
   case HIPDNN_EP_DATATYPE_DOUBLE:
     return 8;
+  case HIPDNN_EP_DATATYPE_INT16:
+    return 2;
   default:
     return -1;
   }
@@ -108,6 +111,8 @@ static inline const char *hipdnn_ep_datatype_name(int64_t data_type) {
     return "ui8";
   case HIPDNN_EP_DATATYPE_DOUBLE:
     return "f64";
+  case HIPDNN_EP_DATATYPE_INT16:
+    return "i16";
   default:
     return "unknown";
   }

--- a/lib/Runtime/real/cast.cpp
+++ b/lib/Runtime/real/cast.cpp
@@ -29,6 +29,8 @@ static int hipdnn_to_hip_dtype(int64_t hipdnn_type) {
     return HIP_DTYPE_UINT8;
   case HIPDNN_EP_DATATYPE_INT8:
     return HIP_DTYPE_INT8;
+  case HIPDNN_EP_DATATYPE_INT16:
+    return HIP_DTYPE_INT16;
   default:
     return -1;
   }

--- a/lib/Runtime/real/elementwise.cpp
+++ b/lib/Runtime/real/elementwise.cpp
@@ -41,6 +41,8 @@ static int hipdnn_to_hip_dtype(int64_t hipdnn_type) {
     return HIP_DTYPE_UINT8;
   case HIPDNN_EP_DATATYPE_INT8:
     return HIP_DTYPE_INT8;
+  case HIPDNN_EP_DATATYPE_INT16:
+    return HIP_DTYPE_INT16;
   default:
     return -1;
   }
@@ -393,7 +395,7 @@ int wrap_miopenOpTensor(RuntimeState *state, int op_state_slot, void *lhs,
     return -1;
   }
 
-  // Integer dtypes (i32/i64/ui8) aren't supported by miopenOpTensor. Vision
+  // Integer dtypes (i32/i64/i16) aren't supported by miopenOpTensor. Vision
   // encoders run small i64 shape arithmetic via these ops (e.g. multiplying
   // two i64 scalars to compute a downstream Reshape dim); attention chains
   // run i32/i64 Min/Max for the seqlens_k = Min(total_seq_len, max_seq_len)
@@ -401,7 +403,8 @@ int wrap_miopenOpTensor(RuntimeState *state, int op_state_slot, void *lhs,
   // mul/add/min/max. Broadcasting is materialised below by hip_expand into
   // a per-state workspace before the flat kernel runs.
   if (data_type == HIPDNN_EP_DATATYPE_INT64 ||
-      data_type == HIPDNN_EP_DATATYPE_INT32) {
+      data_type == HIPDNN_EP_DATATYPE_INT32 ||
+      data_type == HIPDNN_EP_DATATYPE_INT16) {
     if (tensor_op != HIPDNN_EP_TENSOR_OP_MUL &&
         tensor_op != HIPDNN_EP_TENSOR_OP_ADD &&
         tensor_op != HIPDNN_EP_TENSOR_OP_MIN &&


### PR DESCRIPTION
## Summary

Add end-to-end **INT16** support for cast and integer elementwise runtime paths, enabling models with `Cast(i8→i16) → Add(+offset) → Cast(i16→u8)` weight-pack subgraphs (e.g. PSU MF LoRA `MatMulNBits`) to compile and run on MorphiZen EP.

## Why

`PSU_MF_LORA_merged.onnx` (and similar LoRA exports) preprocess runtime INT8 adapter weights in-graph before `MatMulNBits(bits=8)`:

```
INT8 weight input → Transpose → Cast(i8→i16) → Add(+128) → Cast(i16→u8) → Reshape → MatMulNBits
```

Previously:

1. **Compile**: `onnx.Cast → hip.cast` succeeded, but `convert-hip-to-llvm` failed because `getHipdnnDataType()` had no `i16` mapping → `failed to legalize operation 'hip.cast'`.
2. **Runtime** (after partial cast fix):
   - `Add(i16)` fell through to MIOpen → `unsupported data_type 8 for MIOpen`
   - `Cast(i16→u8)` missing in `hip_cast` → `unsupported conversion input_dtype=6 -> output_dtype=7`

INT16 sits **between** two casts in a hot path; cast-only changes are not sufficient.

## What

| Layer | Change |
|-------|--------|
| **Type system** | `HIPDNN_EP_DATATYPE_INT16 = 8` in `hipdnn_ep_runtime.h`; size/name helpers updated |
| **Compiler** | `getHipdnnDataType()` maps MLIR `i16` → enum 8 (`HipToLLVMUtils.h`) |
| **Cast runtime** | `hipdnn_to_hip_dtype` in `cast.cpp` |
| **Cast kernels** | `hip_cast` dispatch: `i8→i16`, `i16→u8` via `cast_int_to_int_kernel` (`cast_kernel.hip`) |
| **Elementwise routing** | `wrap_miopenOpTensor` routes `INT16` to integer custom-kernel fallback (same as i32/i64), not MIOpen (`elementwise.cpp`) |
| **Broadcast** | `hip_expand` adds `int16_t` instantiation (`expand_kernel.hip`) — needed for scalar `+128` broadcast |
| **Add/Mul kernels** | `hip_elementwise_add/mul` add `int16_t` path (`elementwise_binary_kernel.hip`) |

**Out of scope** (not changed):

- `CastConversion.cpp` — ONNX→HIP already lowers `onnx.Cast` to `hip.cast` for `i16`
- Graph fusion / export-side pre-packing of weights
- LIT tests (recommended follow-up)

## Test plan

CI checks (all passed on this PR):

- [ ] **Linux Build** / `build-linux` (pull_request)
- [ ] **PR policy reminder** / `remind` (pull_request_target)
- [ ] **pre-commit** / `pre-commit` (pull_request)
- [ ] **Windows Build (Mock)** / `build-windows-mock` (pull_request)
- [ ] **Windows Build** / `build-windows` (pull_request)
- [ ] **Windows Build** / `gpu-test` (pull_request)

## Notes for reviewers

1. **Why elementwise + expand, not just cast?** PSU's `Add(i16, scalar 128)` is ONNX `Add`, lowered to `hip.add` → `wrap_miopenOpTensor`. MIOpen only supports float dtypes; i16 must use the existing integer fallback (`hip_expand` + `hip_elementwise_add`), same pattern as i32/i64 vision/attention shape ops.

2. **Enum value `8`**: appended after existing `0–7` dtypes; no reordering of prior values.

3. **Two enum namespaces**: `HIPDNN_EP_DATATYPE_INT16 (8)` maps to `HIP_DTYPE_INT16 (6)` in `hip_custom_kernels.h` — intentional, same as other dtypes.

4. **`int16` mul** added for parity with the integer fallback switch (supports MUL/ADD/MIN/MAX); PSU only exercises **Add** today.

5. **Stale model DLL caveat**: runtime/kernel bitcode is embedded at compile time; cache key is ONNX hash — reproducers must wipe `%TEMP%\morphizen_mlir_*` after rebuilding.

6. **No perf work**: 392 weight-pack chains per inference remain (Transpose + 2×Cast + Add per LoRA `MatMulNBits`); fusion pass is a future optimization.