### PR TITLE
add kvcache reuse demo & test case

### DIFF
--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -2668,9 +2668,7 @@ class BaseOGATests:
             del generator
             gc.collect()
 
-    def test_oga_ep_context_cache_reusing_rewind_pending_token(
-        self, oga_default_model
-    ):
+    def test_oga_ep_context_cache_reusing_rewind_pending_token(self, oga_default_model):
         """
         context cache reusing feature test
         step 1: send Q1, get A1, send Q2, get A2
@@ -2684,7 +2682,7 @@ class BaseOGATests:
         consumed by the model yet. Rewind by one token before appending Q2 so
         the reused KV cache and the replayed full context describe the same
         effective sequence.
-        This is oga feature/bug caused by PR1814: 
+        This is oga feature/bug caused by PR1814:
         the last token in previous chat is not put in kvcache.
         """
         spec = self.spec
@@ -2710,7 +2708,7 @@ class BaseOGATests:
             params.set_search_options(
                 max_length=max_length,
                 min_length=0,
-                do_sample=False, # for exact compare of model output
+                do_sample=False,  # for exact compare of model output
                 repetition_penalty=1.15,
             )
             return og.Generator(model, params)
@@ -2783,9 +2781,7 @@ class BaseOGATests:
                 )
                 split_gen.rewind_to(rewind_len)
 
-            effective_context = (
-                turn1_tokens + effective_turn1_generated + turn2_tokens
-            )
+            effective_context = turn1_tokens + effective_turn1_generated + turn2_tokens
             if len(effective_context) + turn2_limit >= max_length:
                 pytest.skip("not enough max_length budget for fixed-count turn2")
 
@@ -2829,7 +2825,6 @@ class BaseOGATests:
             del split_gen
             del full_gen
             gc.collect()
-
 
     def test_oga_ep_chunked_prefill(self, dynamic_model_path, repo_root, golden_store):
         """Chunked prefill accuracy: OGA+EP with chunk_size=128 vs CPU golden.

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -1492,7 +1492,9 @@ def setup_oga_ep(repo_root):
 
     global _oga_ep_registered
     if not _oga_ep_registered:
-        og.register_execution_provider_library(EP_OGA_NAME, str(ep_dll))
+        # OGA genai_config uses the provider key `AMDGPU`, but the plugin registers
+        # devices under the lowercase `amdgpu` name. need fix later
+        og.register_execution_provider_library(EP_OGA_NAME.lower(), str(ep_dll))
         _oga_ep_registered = True
 
     return og, ep_dll
@@ -2665,6 +2667,169 @@ class BaseOGATests:
         finally:
             del generator
             gc.collect()
+
+    def test_oga_ep_context_cache_reusing_rewind_pending_token(
+        self, oga_default_model
+    ):
+        """
+        context cache reusing feature test
+        step 1: send Q1, get A1, send Q2, get A2
+        step 2: send full(Q1+A1+Q2), get A2_new
+        step 3: veryfy A2==A2_new
+
+        Fixed-count multi-turn reuse, rewinding away a pending token.
+
+        If the first turn stops because of a token-count limit rather than EOS,
+        the final generated token is present in OGA's sequence but has not been
+        consumed by the model yet. Rewind by one token before appending Q2 so
+        the reused KV cache and the replayed full context describe the same
+        effective sequence.
+        This is oga feature/bug caused by PR1814: 
+        the last token in previous chat is not put in kvcache.
+        """
+        spec = self.spec
+        og, model = oga_default_model
+        tokenizer = og.Tokenizer(model)
+
+        turn1_prompt = (
+            " User: My name is Alice. I live in Berlin.\n"
+            "Assistant: I will remember that.\n"
+        )
+        turn2_prompt = " User: Where do I live?\nAssistant:"
+        turn1_tokens = [int(t) for t in tokenizer.encode(turn1_prompt)]
+        turn2_tokens = [int(t) for t in tokenizer.encode(turn2_prompt)]
+        turn1_limit = 200
+        turn2_limit = 200
+        max_length = max(
+            spec.max_seq_len,
+            len(turn1_tokens) + turn1_limit + len(turn2_tokens) + turn2_limit + 16,
+        )
+
+        def make_generator():
+            params = og.GeneratorParams(model)
+            params.set_search_options(
+                max_length=max_length,
+                min_length=0,
+                do_sample=False, # for exact compare of model output
+                repetition_penalty=1.15,
+            )
+            return og.Generator(model, params)
+
+        def generate_up_to(generator, limit, label, ttft_start=None):
+            generated = []
+            pieces = []
+            stream = tokenizer.create_stream()
+            ttft_ms = None
+            print(f"  {label}=", end="", flush=True)
+            for step in range(limit):
+                generator.generate_next_token()
+                if step == 0 and ttft_start is not None:
+                    ttft_ms = (time.perf_counter() - ttft_start) * 1000
+                if generator.is_done():
+                    print("", flush=True)
+                    print(
+                        f"  {label}_debug stopped_by=eos step={step} "
+                        f"generated={len(generated)} ttft_ms={ttft_ms}",
+                        flush=True,
+                    )
+                    return generated, "".join(pieces), True, ttft_ms
+                token = int(generator.get_next_tokens()[0])
+                generated.append(token)
+                piece = stream.decode(token)
+                pieces.append(piece)
+                print(piece, end="", flush=True)
+            print("", flush=True)
+            print(
+                f"  {label}_debug stopped_by=limit limit={limit} "
+                f"generated={len(generated)} is_done={generator.is_done()} "
+                f"ttft_ms={ttft_ms}",
+                flush=True,
+            )
+            return generated, "".join(pieces), False, ttft_ms
+
+        split_gen = make_generator()
+        full_gen = make_generator()
+        try:
+            print(f"\n{'=' * 60}")
+            print("OGA EP context-cache fixed-count rewind vs full replay")
+            print(f"  Q1={turn1_prompt!r}")
+            print(f"  Q2={turn2_prompt!r}")
+            print(
+                f"  max_length={max_length} turn1_limit={turn1_limit} "
+                f"turn2_limit={turn2_limit} turn1_tokens={len(turn1_tokens)} "
+                f"turn2_tokens={len(turn2_tokens)}"
+            )
+
+            q1_ttft_start = time.perf_counter()
+            split_gen.append_tokens(np.array(turn1_tokens, dtype=np.int32))
+            turn1_generated, turn1_text, turn1_eos, q1_ttft_ms = generate_up_to(
+                split_gen, turn1_limit, "A1", q1_ttft_start
+            )
+
+            if turn1_eos:
+                effective_turn1_generated = turn1_generated
+                print("  split: A1 ended by EOS; no rewind needed", flush=True)
+            else:
+                if not turn1_generated:
+                    pytest.skip("first turn produced no token before limit")
+                effective_turn1_generated = turn1_generated[:-1]
+                rewind_len = len(turn1_tokens) + len(effective_turn1_generated)
+                print(
+                    f"  split: rewinding from len="
+                    f"{len(turn1_tokens) + len(turn1_generated)} to "
+                    f"rewind_len={rewind_len} to drop pending token "
+                    f"{turn1_generated[-1]}",
+                    flush=True,
+                )
+                split_gen.rewind_to(rewind_len)
+
+            effective_context = (
+                turn1_tokens + effective_turn1_generated + turn2_tokens
+            )
+            if len(effective_context) + turn2_limit >= max_length:
+                pytest.skip("not enough max_length budget for fixed-count turn2")
+
+            q2_ttft_start = time.perf_counter()
+            split_gen.append_tokens(np.array(turn2_tokens, dtype=np.int32))
+            split_generated, split_text, split_eos, q2_ttft_ms = generate_up_to(
+                split_gen, turn2_limit, "A2", q2_ttft_start
+            )
+
+            full_ttft_start = time.perf_counter()
+            full_gen.append_tokens(np.array(effective_context, dtype=np.int32))
+            full_generated, full_text, full_eos, full_ttft_ms = generate_up_to(
+                full_gen, turn2_limit, "A2_new", full_ttft_start
+            )
+
+            print(f"\n{'=' * 60}")
+            print("OGA EP context-cache fixed-count rewind vs full replay summary")
+            print(f"  Q1={turn1_prompt!r}")
+            print(f"  A1={turn1_text!r}")
+            print(f"  A1_tokens={turn1_generated}")
+            print(f"  A1_eos={turn1_eos}")
+            print(f"  effective_A1_tokens={effective_turn1_generated}")
+            print(f"  Q2={turn2_prompt!r}")
+            print(f"  A2={split_text!r}")
+            print(f"  A2_new={full_text!r}")
+            print(f"  A2_tokens={split_generated}")
+            print(f"  A2_new_tokens={full_generated}")
+            print(f"  A2_eos={split_eos} A2_new_eos={full_eos}")
+            print(
+                f"  ttft_ms: Q1={q1_ttft_ms:.1f} "
+                f"Q2={q2_ttft_ms:.1f} full={full_ttft_ms:.1f}"
+            )
+            print(f"  full_Q1A1Q2={tokenizer.decode(effective_context)!r}")
+            print(f"{'=' * 60}")
+
+            assert split_generated == full_generated, (
+                "Continuous OGA append with rewind(len-1) produced different "
+                "tokens than replaying the same effective Q1+A1+Q2 context"
+            )
+        finally:
+            del split_gen
+            del full_gen
+            gc.collect()
+
 
     def test_oga_ep_chunked_prefill(self, dynamic_model_path, repo_root, golden_store):
         """Chunked prefill accuracy: OGA+EP with chunk_size=128 vs CPU golden.

--- a/tools/oga-test/kvcache_reuse_demo.py
+++ b/tools/oga-test/kvcache_reuse_demo.py
@@ -1,0 +1,414 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+r"""
+Minimal OGA KV-cache reuse demo.
+
+This is a standalone multi-turn OGA append demo:
+1. Build each user turn with the model's chat template.
+2. Append only the newly required token suffix for that turn.
+3. Generate an assistant answer before moving to the next turn.
+
+run environment: use same environment in https://amdcloud.sharepoint.com/sites/AIG/ACAS/AIS/Shared%20Documents/Forms/AllItems.aspx?sortField=Modified&isAscending=false&viewid=a7467c25%2D045c%2D4cfa%2Db7d6%2D6087479176b2&FolderCTID=0x01200030E43EC46C7307458A426ABB9063F706&OR=Teams%2DHL&CT=1758686810028&TeamsCID=985c526a%2D11af%2D4578%2Db989%2D6ca2917610a4&ovuser=3dd8961f%2De488%2D4e60%2D8e11%2Da82d994e183d%2Cshili9%40amd%2Ecom&id=%2Fsites%2FAIG%2FACAS%2FAIS%2FShared%20Documents%2FROCm%20EP%2Fdemo%2Fhipep%20EP%20Python%20Package%20Download%20%20Install%20%20Run%2Epdf&parent=%2Fsites%2FAIG%2FACAS%2FAIS%2FShared%20Documents%2FROCm%20EP%2Fdemo
+
+run command example:  
+(.venv) PS C:\a-1\hipep-wheels-release_0_2_0>  python C:\a-1\hipep-wheels-release_0_2_0\examples\kvcache_reuse_demo.py -m    C:\a-1\Qwen3.5-35B-A3B-fp16-ve-fp16-int4-text-gs32-dml  --testAll   > c:\a-1\dump.txt
+this command run the full six group of prompts;
+or
+(.venv) PS C:\a-1\hipep-wheels-release_0_2_0>  python C:\a-1\hipep-wheels-release_0_2_0\examples\kvcache_reuse_demo.py -m    C:\a-1\Qwen3.5-35B-A3B-fp16-ve-fp16-int4-text-gs32-dml > c:\a-1\dump.txt
+this command run 1 group of prompts;
+
+for vlm model, you can provide picture by parameter of -i
+
+"""
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+import numpy as np
+import onnxruntime_genai as og
+
+
+prompts = [
+ 
+]
+
+default_questions = [
+  " My name is Alice. I live in Berlin.", 
+  " Where do I live?"
+]
+
+def build_prompt_chat_template(
+    model_path: str,
+    tokenizer: og.Tokenizer,
+    messages: list[dict],
+    add_generation_prompt: bool = True,
+) -> str:
+    """Build a text prompt using the model directory's chat template.
+
+    This mirrors vlm_benchmark.py, but emits text-only messages.
+    """
+    model_dir = Path(model_path)
+    tok_cfg_path = model_dir / "tokenizer_config.json"
+    jinja_path = model_dir / "chat_template.jinja"
+
+    template_str = None
+    bos = None
+
+    if tok_cfg_path.exists():
+        with open(tok_cfg_path, "r", encoding="utf-8") as f:
+            tok_cfg = json.load(f)
+        template_str = tok_cfg.get("chat_template")
+        bos = tok_cfg.get("bos_token")
+
+    if not template_str and jinja_path.exists():
+        with open(jinja_path, "r", encoding="utf-8") as f:
+            template_str = f.read()
+        # print(f"  Loaded chat template from: {jinja_path}")
+
+    if not template_str:
+        return "".join(str(message.get("content", "")) for message in messages)
+
+    if not bos:
+        template_str = template_str.replace("{{ bos_token }}", "")
+
+    message_json = json.dumps(messages)
+    return tokenizer.apply_chat_template(
+        message_json,
+        template_str=template_str,
+        add_generation_prompt=add_generation_prompt,
+    )
+
+
+def encode_chat_prompt(model_path: str, tokenizer: og.Tokenizer, messages: list[dict]):
+    prompt = build_prompt_chat_template(
+        model_path, tokenizer, messages, add_generation_prompt=True
+    )
+    return [int(t) for t in tokenizer.encode(prompt)], prompt
+
+
+def to_numpy(tensor):
+    if hasattr(tensor, "as_numpy"):
+        return tensor.as_numpy()
+    if hasattr(tensor, "numpy"):
+        return tensor.numpy()
+    return np.array(tensor)
+
+
+def encode_prompt_inputs(
+    model_path: str,
+    tokenizer: og.Tokenizer,
+    processor,
+    images,
+    messages: list[dict],
+):
+    prompt = build_prompt_chat_template(
+        model_path, tokenizer, messages, add_generation_prompt=True
+    )
+    text_tokens = [int(t) for t in tokenizer.encode(prompt)]
+    if processor is None:
+        token_debug = {
+            "text_tokens": len(text_tokens),
+            "prompt_tokens": len(text_tokens),
+            "image_tokens_est": 0,
+        }
+        return text_tokens, prompt, None, token_debug
+
+    inputs = processor(prompt, images=images)
+    print("shili inputs ", inputs)
+    input_ids = to_numpy(inputs["input_ids"]).reshape(-1)
+    prompt_tokens = [int(t) for t in input_ids]
+    token_debug = {
+        "text_tokens": len(text_tokens),
+        "prompt_tokens": len(prompt_tokens),
+        "image_tokens_est": max(0, len(prompt_tokens) - len(text_tokens)),
+    }
+    return prompt_tokens, prompt, inputs, token_debug
+
+
+def make_user_message(question: str, image_path: str | None = None) -> dict:
+    if not image_path:
+        return {"role": "user", "content": question}
+
+    return {
+        "role": "user",
+        "content": [
+            {"type": "image"},
+            {"type": "text", "text": question},
+        ],
+    }
+
+
+def make_generator(model: og.Model, max_length: int, repetition_penalty: float):
+    params = og.GeneratorParams(model)
+    params.set_search_options(
+        # max_length=max_length,
+        # min_length=0,
+        # do_sample=False,
+        # repetition_penalty=repetition_penalty,
+        max_length=max_length,
+        min_length=0,
+        do_sample=False,
+        temperature=0.0,
+        top_k=1,
+        top_p=1.0,
+        repetition_penalty=1.0,
+
+    )
+    return og.Generator(model, params)
+
+
+def generate_up_to(generator, tokenizer, limit: int, label: str, ttft_start: float):
+    generated = []
+    pieces = []
+    stream = tokenizer.create_stream()
+    ttft_ms = None
+
+    print(f"  {label}=", end="", flush=True)
+    for step in range(limit):
+        generator.generate_next_token()
+        if step == 0:
+            ttft_ms = (time.perf_counter() - ttft_start) * 1000
+        if generator.is_done():
+            # print("", flush=True)
+            # print(
+            #     f"  {label}_debug stopped_by=eos step={step} "
+            #     f"generated={len(generated)}",
+            #     flush=True,
+            # )
+            return generated, pieces, True, ttft_ms
+
+        token = int(generator.get_next_tokens()[0])
+        generated.append(token)
+        piece = stream.decode(token)
+        pieces.append(piece)
+        print(piece, end="", flush=True)
+
+    # print("", flush=True)
+    # print(
+    #     f"  {label}_debug stopped_by=limit limit={limit} "
+    #     f"generated={len(generated)} is_done={generator.is_done()}",
+    #     flush=True,
+    # )
+    return generated, pieces, False, ttft_ms
+
+
+def run_questions(
+    args: argparse.Namespace,
+    model: og.Model,
+    tokenizer: og.Tokenizer,
+    processor,
+    images,
+    questions: list[str],
+    group_label: str,
+) -> list[float]:
+    generator = make_generator(model, args.max_length, args.repetition_penalty)
+    messages: list[dict] = []
+    committed_tokens: list[int] = []
+    answers = []
+    ttft_values: list[float] = []
+    close_previous_assistant = False
+
+    try:
+        print("\n" + "=" * 60)
+        # print(f"OGA KV-cache reuse demo: {group_label}")
+        # print(
+        #     f"  max_length={args.max_length} answer_limit={args.answer_limit} "
+        #     f"turns={len(questions)}"
+        # )
+
+        for i, question in enumerate(questions, start=1):
+            image_path = args.image_path if i == 1 else None
+            messages.clear()
+            messages.append(make_user_message(question, image_path))
+            prompt_tokens, prompt, inputs, token_debug = encode_prompt_inputs(
+                args.model_path,
+                tokenizer,
+                processor if image_path else None,
+                images if image_path else None,
+                messages,
+            )
+            append_tokens = prompt_tokens
+            if close_previous_assistant:
+                close_tokens = [int(t) for t in tokenizer.encode("<|im_end|>\n")]
+                append_tokens = close_tokens + append_tokens
+                token_debug = {
+                    **token_debug,
+                    "text_tokens": token_debug["text_tokens"] + len(close_tokens),
+                    "prompt_tokens": token_debug["prompt_tokens"] + len(close_tokens),
+                }
+            if not append_tokens:
+                raise RuntimeError("No new input tokens to append for this turn.")
+            context_after_append = len(committed_tokens) + len(append_tokens)
+            if context_after_append + args.answer_limit >= args.max_length:
+                raise RuntimeError(
+                    "Not enough max_length budget for this turn: "
+                    f"context={context_after_append} limit={args.answer_limit} "
+                    f"max_length={args.max_length}"
+                )
+
+            print(f"\n\n  Q{i}={question!r}")
+            print(f"  templated_Q{i}={prompt!r}")
+            print(
+                f"  turn={i} committed_tokens={len(committed_tokens)} "
+                f"append_tokens={len(append_tokens)} "
+                f"context_after_append={context_after_append}"
+            )
+            print(
+                f"  token_lengths: text_only={token_debug['text_tokens']} "
+                f"processor_input_ids={token_debug['prompt_tokens']} "
+                f"image_est={token_debug['image_tokens_est']}"
+            )
+            print(f"  decoded_processor_prompt={tokenizer.decode(append_tokens)!r}")
+
+            ttft_start = time.perf_counter()
+            if inputs is not None and not committed_tokens:
+                generator.set_inputs(inputs)
+            else:
+                generator.append_tokens(np.array(append_tokens, dtype=np.int32))
+            committed_tokens.extend(append_tokens)
+
+            generated, pieces, eos, ttft_ms = generate_up_to(
+                generator, tokenizer, args.answer_limit, f"A{i}", ttft_start
+            )
+            ttft_values.append(ttft_ms)
+            if eos:
+                effective_generated = generated
+                effective_pieces = pieces
+            else:
+                # OGA keeps the last fixed-count token in the sequence before it
+                # has been consumed into KV cache. Drop it before appending Q{i+1}.
+                effective_generated = generated[:-1]
+                effective_pieces = pieces[:-1]
+                rewind_len = len(committed_tokens) + len(effective_generated)
+                generator.rewind_to(rewind_len)
+
+            text = "".join(effective_pieces)
+            committed_tokens.extend(effective_generated)
+            answers.append((effective_generated, text, eos))
+            close_previous_assistant = not eos
+
+        print("\n" + "=" * 60)
+        return ttft_values
+    finally:
+        del generator
+
+
+def run_demo(args: argparse.Namespace) -> int:
+    # print(f"Loading model: {args.model_path}")
+    if args.image_path and not Path(args.image_path).exists():
+        raise FileNotFoundError(f"Image file not found: {args.image_path}")
+
+    config = og.Config(args.model_path)
+    if args.execution_provider != "follow_config":
+        config.clear_providers()
+        if args.execution_provider != "cpu":
+            print(f"Setting execution provider to {args.execution_provider}...")
+            config.append_provider(args.execution_provider)
+
+    model = og.Model(config)
+    print(f"Model loaded: {model.type}")
+    print(f"Device: {model.device_type}")
+    tokenizer = og.Tokenizer(model)
+    processor = model.create_multimodal_processor() if args.image_path else None
+    images = og.Images.open(args.image_path) if args.image_path else None
+    ttft_matrix: list[list[float]] = []
+
+    try:
+        if args.testAll:
+            print(f"Running all prompt groups: {len(prompts)}")
+            for i, questions in enumerate(prompts, start=1):
+                print("\nrun ", i, "test === begin \n")
+                ttft_matrix.append(
+                    run_questions(
+                        args,
+                        model,
+                        tokenizer,
+                        processor,
+                        images,
+                        questions,
+                        f"prompt group {i}",
+                    )
+                )
+                print("\nrun ", i, "test === end \n")
+        else:
+            ttft_matrix.append(
+                run_questions(
+                    args,
+                    model,
+                    tokenizer,
+                    processor,
+                    images,
+                    args.questions,
+                    "custom questions",
+                )
+            )
+        print("ttft_matrix_ms=[")
+        for row in ttft_matrix:
+            print("  " + json.dumps(row) + ",")
+        print("]")
+        return 0
+    finally:
+        del model
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Minimal OGA KV-cache reuse demo")
+    parser.add_argument(
+        "-m",
+        "--model_path",
+        required=True,
+        help="Path to the OGA model directory",
+    )
+    parser.add_argument(
+        "-e",
+        "--execution_provider",
+        type=str,
+        default="follow_config",
+        choices=["cpu", "dml", "follow_config"],
+        help="Execution provider (default: follow_config)",
+    )
+    parser.add_argument(
+        "--questions",
+        nargs="+",
+        default=default_questions,
+        help="User questions, one item per conversation turn",
+    )
+    parser.add_argument(
+        "--testAll",
+        action="store_true",
+        help="Run every question group in the built-in prompts list",
+    )
+    parser.add_argument(
+        "--answer_limit",
+        type=int,
+        default=2000,
+        help="Maximum assistant tokens to generate per turn",
+    )
+    parser.add_argument(
+        "--max_length",
+        type=int,
+        default=20480,
+        help="OGA max_length search option",
+    )
+    parser.add_argument(
+        "--repetition_penalty",
+        type=float,
+        default=1.15,
+        help="OGA repetition_penalty search option",
+    )
+    parser.add_argument(
+        "-i",
+        "--image_path",
+        type=str,
+        default=None,
+        help="Optional image path to attach to the first prompt",
+    )
+    args = parser.parse_args()
+    return run_demo(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/oga-test/kvcache_reuse_demo.py
+++ b/tools/oga-test/kvcache_reuse_demo.py
@@ -1,5 +1,7 @@
-# Copyright (c) Microsoft Corporation. All rights reserved.
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 # Licensed under the MIT License.
+#
 
 r"""
 Minimal OGA KV-cache reuse demo.
@@ -9,20 +11,23 @@ This is a standalone multi-turn OGA append demo:
 2. Append only the newly required token suffix for that turn.
 3. Generate an assistant answer before moving to the next turn.
 
-run environment: use same environment in https://amdcloud.sharepoint.com/sites/AIG/ACAS/AIS/Shared%20Documents/Forms/AllItems.aspx?sortField=Modified&isAscending=false&viewid=a7467c25%2D045c%2D4cfa%2Db7d6%2D6087479176b2&FolderCTID=0x01200030E43EC46C7307458A426ABB9063F706&OR=Teams%2DHL&CT=1758686810028&TeamsCID=985c526a%2D11af%2D4578%2Db989%2D6ca2917610a4&ovuser=3dd8961f%2De488%2D4e60%2D8e11%2Da82d994e183d%2Cshili9%40amd%2Ecom&id=%2Fsites%2FAIG%2FACAS%2FAIS%2FShared%20Documents%2FROCm%20EP%2Fdemo%2Fhipep%20EP%20Python%20Package%20Download%20%20Install%20%20Run%2Epdf&parent=%2Fsites%2FAIG%2FACAS%2FAIS%2FShared%20Documents%2FROCm%20EP%2Fdemo
+run environment: use python env
 
-run command example:  
-(.venv) PS C:\a-1\hipep-wheels-release_0_2_0>  python C:\a-1\hipep-wheels-release_0_2_0\examples\kvcache_reuse_demo.py -m    C:\a-1\Qwen3.5-35B-A3B-fp16-ve-fp16-int4-text-gs32-dml  --testAll   > c:\a-1\dump.txt
+run command example:
+ python kvcache_reuse_demo.py -m model_path\Qwen3.5-35B-A3B-fp16-ve-fp16-int4-text-gs32-dml  --testAll   > dump.txt
 this command run the full six group of prompts;
 or
-(.venv) PS C:\a-1\hipep-wheels-release_0_2_0>  python C:\a-1\hipep-wheels-release_0_2_0\examples\kvcache_reuse_demo.py -m    C:\a-1\Qwen3.5-35B-A3B-fp16-ve-fp16-int4-text-gs32-dml > c:\a-1\dump.txt
+ python kvcache_reuse_demo.py -m model_path\Qwen3.5-35B-A3B-fp16-ve-fp16-int4-text-gs32-dml > dump.txt
 this command run 1 group of prompts;
 
 for vlm model, you can provide picture by parameter of -i
+python kvcache_reuse_demo.py -m model_path\Qwen3.5-35B-A3B-fp16-ve-fp16-int4-text-gs32-dml -i some_pic.jpg --testAll   > dump.txt
 
 """
 
 import argparse
+import ast
+import contextlib
 import json
 import time
 from pathlib import Path
@@ -32,13 +37,50 @@ import onnxruntime_genai as og
 
 
 prompts = [
- 
+    # 1
+    [
+        " My name is Alex, I work as a data scientist at Orbital AI.",
+        " I live in Berlin and enjoy playing the piano in my free time.",
+        " Where do I live and what do I enjoy doing?",
+        " What is my profession?",
+    ],
+    # 2
+    [
+        ' When I say "compact summary," respond with 3 bullet points only.',
+        ' Give me a compact summary of: Ancient Egypt (Egyptian: km.t) was a cradle of civilization concentrated along the lower reaches of the Nile River in Northeast Africa. It emerged from prehistoric Egypt around 3150 BC (according to conventional Egyptian chronology), when Upper and Lower Egypt were amalgamated by Menes, who is believed by the majority of Egyptologists to have been the same person as Narmer. The history of ancient Egypt unfolded as a series of stable kingdoms interspersed by the "Intermediate Periods" of relative instability. These stable kingdoms existed in one of three periods: the Old Kingdom of the Early Bronze Age; the Middle Kingdom of the Middle Bronze Age; or the New Kingdom of the Late Bronze Age.',
+        " Give me a compact summary of: stages of butterfly",
+    ],
+    # 3
+    [
+        " Sarah is a software engineer who leads the AI team. James is her manager.",
+        " Who is Sarah's manager?",
+        " What team does Sarah lead?",
+    ],
+    # 4
+    [
+        " Here is a list of items I need from the store: apples, bread, milk, eggs, tomatoes, pasta, and cheese.",
+        " What was the fourth item?",
+        " How many dairy items are in the list?",
+    ],
+    # 5
+    [
+        " Alice is a biologist who works at Genomix Lab. She reports to Dr. Patel, who is the head of the lab. Her colleague, Martin, specializes in data analysis.",
+        " Who is Alice's manager?",
+        " Who is the data analyst at Genomix Lab?",
+        " What is Dr. Patel's position?",
+        " What field does Alice work in?",
+    ],
+    # 6
+    [
+        " A farmer has 3 fields. Each field has 240 apple trees.",
+        " If each tree produces 120 apples, how many apples does one field produce?",
+        " How many apples in total across all fields?",
+        " If 10% of the apples are spoiled, how many are still good?",
+    ],
 ]
 
-default_questions = [
-  " My name is Alice. I live in Berlin.", 
-  " Where do I live?"
-]
+default_questions = [" My name is Alice. I live in Berlin.", " Where do I live?"]
+
 
 def build_prompt_chat_template(
     model_path: str,
@@ -117,7 +159,6 @@ def encode_prompt_inputs(
         return text_tokens, prompt, None, token_debug
 
     inputs = processor(prompt, images=images)
-    print("shili inputs ", inputs)
     input_ids = to_numpy(inputs["input_ids"]).reshape(-1)
     prompt_tokens = [int(t) for t in input_ids]
     token_debug = {
@@ -155,7 +196,6 @@ def make_generator(model: og.Model, max_length: int, repetition_penalty: float):
         top_k=1,
         top_p=1.0,
         repetition_penalty=1.0,
-
     )
     return og.Generator(model, params)
 
@@ -354,6 +394,62 @@ def run_demo(args: argparse.Namespace) -> int:
         del model
 
 
+def extract_bracketed_list(text: str, start: int) -> str:
+    list_start = text.find("[", start)
+    if list_start < 0:
+        raise ValueError("ttft_matrix_ms marker found, but '[' was not found")
+
+    depth = 0
+    for idx in range(list_start, len(text)):
+        char = text[idx]
+        if char == "[":
+            depth += 1
+        elif char == "]":
+            depth -= 1
+            if depth == 0:
+                return text[list_start : idx + 1]
+
+    raise ValueError("ttft_matrix_ms list is not closed")
+
+
+def read_text_auto(path: Path) -> str:
+    data = path.read_bytes()
+    if data.startswith(bytes([0xFF, 0xFE])) or data.startswith(bytes([0xFE, 0xFF])):
+        return data.decode("utf-16")
+
+    # Windows PowerShell redirection may create UTF-16LE without a visible BOM.
+    if len(data) >= 4 and data[1::2].count(0) > len(data) // 4:
+        return data.decode("utf-16-le")
+    return data.decode("utf-8", errors="replace")
+
+
+def check_kvcache_reuse_output(path: Path) -> tuple[bool, list[str]]:
+    text = read_text_auto(path)
+    reasons: list[str] = []
+
+    q2_pos = text.find("Q2")
+    if q2_pos < 0:
+        reasons.append("can't find Q2")
+
+    berlin_pos = text.find(" Berlin", q2_pos + len("Q2")) if q2_pos >= 0 else -1
+    if q2_pos >= 0 and berlin_pos < 0:
+        reasons.append("can't find Berlin")
+
+    ttft_pos = text.find("ttft_matrix_ms", berlin_pos if berlin_pos >= 0 else 0)
+    if ttft_pos < 0:
+        reasons.append("can't find ttft_matrix_ms")
+    else:
+        matrix_text = extract_bracketed_list(text, ttft_pos)
+        matrix = ast.literal_eval(matrix_text)
+        first_row = matrix[0]
+        if len(first_row) < 2:
+            reasons.append("can't find ttft1/ttft2")
+        elif first_row[1] >= first_row[0]:
+            reasons.append("ttft2 > ttft1")
+
+    return not reasons, reasons
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Minimal OGA KV-cache reuse demo")
     parser.add_argument(
@@ -406,8 +502,34 @@ def main() -> int:
         default=None,
         help="Optional image path to attach to the first prompt",
     )
+    parser.add_argument(
+        "-o",
+        "--output_file",
+        type=Path,
+        default=Path("dump.txt"),
+        help="Path to write demo output (default: dump.txt)",
+    )
     args = parser.parse_args()
-    return run_demo(args)
+
+    if args.output_file.parent != Path(""):
+        args.output_file.parent.mkdir(parents=True, exist_ok=True)
+
+    with args.output_file.open("w", encoding="utf-8") as out_file:
+        with contextlib.redirect_stdout(out_file):
+            exit_code = run_demo(args)
+
+    if not args.testAll:
+        try:
+            passed, reasons = check_kvcache_reuse_output(args.output_file)
+        except Exception as exc:
+            passed, reasons = False, [f"check failed: {exc}"]
+        if passed:
+            print("OK")
+        else:
+            print("Fail: " + "; ".join(reasons))
+            return 1
+
+    return exit_code
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
Licensed under the MIT License.
-->

add 2 test case:
case 1 is in test/python/conftest.json, this test case can check kvcache resuse feature,
first send Q1, get A1,  send Q2, get A2,
then create new generator, and send full(Q1+A1+Q2), get A2_new,
check A2=A2_new to indicate that kvcache is exact same in the 2 cases.

case 2 is in tools/oga/kvcache_reuse_demo.py, provide several groups of prompts to test multi-turn,
the test indicate that model memories the previous information by saving it in kvcache and use it in later question.

<!--
Thanks for contributing! Please skim the two policies this repo
follows before requesting review (1-2 minutes each):

  Incremental development:
    https://llvm.org/docs/DeveloperPolicy.html#incremental-development
  AI tool use:
    https://llvm.org/docs/AIToolPolicy.html

A short summary lives in CONTRIBUTING.md at the repo root. Each
section below has an HTML comment explaining what to put in it; you
can delete the comment after filling the section in.
-->

## Summary

<!--
1-3 sentences. What changed at a high level and what gap or bug it
closes.
-->

## Why

<!--
Design rationale. What alternatives did you consider and why did you
pick this one? This section is what reviewers use to skip ahead and
agree with the design before reading the code. Even one paragraph is
fine if the choice is obvious; for non-trivial design decisions, be
explicit about the alternatives you rejected.
-->

## What

<!--
Numbered list of concrete changes, with file references. Useful
shapes:

1. **New pass / op / runtime helper** at `path/to/file.cpp`. <one
   sentence on the contract; one sentence on the predicate or scope>.
2. **Pipeline placement / call-site update**: <where it slots in and
   why that placement>.
3. **Helper rename / API change**: <one sentence>.
4. **Intentional non-changes**: <things the reader will expect to see
   touched that aren't, with the reason>.
-->

## Test plan

<!--
- Lit / pytest / runner commands you ran and the result (pass count,
  numerics delta vs reference, etc).
- Manual reproduction steps for behavioural changes (model name,
  hardware, command).
- For perf-sensitive changes, include a before/after table — see the
  optional Performance section below.
-->

## Notes for reviewers

<!--
- Known limitations and what they would take to fix.
- Follow-ups already planned (link the design issue / next PR).
- Anything load-bearing that isn't obvious from the diff (invariants,
  ABI assumptions, ordering constraints).
- "None" is a valid answer if the PR is small and self-contained.
-->

<!--
============================================================
Optional sections — include when applicable. Delete this whole
block if you don't need any of them.
============================================================

## Compiler IR walkthrough

<details>
<summary><b>Before</b> — short description</summary>

```mlir
// IR before this PR's pass / lowering
```

</details>

<details>
<summary><b>After</b> — short description</summary>

```mlir
// IR after this PR's pass / lowering
```

</details>

## Performance

<details>
<summary>Short headline result (e.g. "22x over DML EP on …")</summary>

| Metric | This PR | Baseline | Ratio |
|---|---:|---:|---:|
| Inferences/sec | … | … | … |
| Mean latency | … | … | … |

Hardware: gfxNNNN, model: <name>, build: <flags>.

</details>

============================================================
-->

## Checklist

- [ ] **Incremental.** This PR is either standalone, or a planned step
      in a documented series. If it exceeds ~500 LOC or ~10 files, the
      Summary / Why explains why it cannot be split, OR links the
      precursor PRs and the design issue. See:
      https://llvm.org/docs/DeveloperPolicy.html#incremental-development
- [ ] **AI policy.** If AI tools (Cursor, Claude, Copilot, etc.)
      generated substantial code or text, the Summary discloses it,
      the commit messages carry the trailers documented in
      [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md#commit-message-trailers),
      and you can answer questions about each design decision in
      review without delegating back to the tool. See:
      https://llvm.org/docs/AIToolPolicy.html
- [ ] **No `good first issue` automation.** This PR is not an AI-tool
      fix to an issue tagged `good first issue` (those are reserved as
      learning opportunities for new contributors).
- [ ] **Reviews resolved.** All review-comment threads from prior
      rounds are resolved (enforced by branch protection on `main`).
- [ ] **CODEOWNERS routing.** Reviewers were assigned automatically by
      [`CODEOWNERS`](../blob/main/.github/CODEOWNERS). If the change
      touches a path outside the current ownership map, the PR
      description names the operational owner.
