### PR TITLE
feat(dialect): add hipsr.pool_domain op with pool_domain_yield terminator

### DIFF
--- a/include/hip/Dialect/Hipsr/IR/CMakeLists.txt
+++ b/include/hip/Dialect/Hipsr/IR/CMakeLists.txt
@@ -19,6 +19,14 @@ set(LLVM_TARGET_DEFINITIONS HipsrOps.td)
 mlir_tablegen(HipsrOps.h.inc -gen-op-decls)
 mlir_tablegen(HipsrOps.cpp.inc -gen-op-defs)
 
+set(LLVM_TARGET_DEFINITIONS HipsrPoolDomainYieldOp.td)
+mlir_tablegen(HipsrPoolDomainYieldOp.h.inc -gen-op-decls)
+mlir_tablegen(HipsrPoolDomainYieldOp.cpp.inc -gen-op-defs)
+
+set(LLVM_TARGET_DEFINITIONS HipsrPoolDomainOp.td)
+mlir_tablegen(HipsrPoolDomainOp.h.inc -gen-op-decls)
+mlir_tablegen(HipsrPoolDomainOp.cpp.inc -gen-op-defs)
+
 add_public_tablegen_target(HipsrDialectIncGen)
 
 set(LLVM_TARGET_DEFINITIONS HipsrEnums.td)

--- a/include/hip/Dialect/Hipsr/IR/HipsrPoolDomainOp.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrPoolDomainOp.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#ifndef HIPSR_POOL_DOMAIN_OP_H
+#define HIPSR_POOL_DOMAIN_OP_H
+
+#include "hip/Dialect/Hipsr/IR/HipsrDialect.h"
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+
+// Must precede the .inc: the generated op class uses the trait template.
+#include "hip/Dialect/Hipsr/IR/HipsrTraits.h"
+
+// The .inc references PoolDomainYieldOp (from the implicit-terminator trait)
+// only by name, so a forward declaration is enough. The full type is needed
+// only in the .cpp, which includes its header.
+namespace mlir {
+namespace hipsr {
+class PoolDomainYieldOp;
+} // namespace hipsr
+} // namespace mlir
+
+#define GET_OP_CLASSES
+#include "hip/Dialect/Hipsr/IR/HipsrPoolDomainOp.h.inc"
+
+#endif // HIPSR_POOL_DOMAIN_OP_H

--- a/include/hip/Dialect/Hipsr/IR/HipsrPoolDomainOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrPoolDomainOp.td
@@ -1,0 +1,60 @@
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+// The hipsr.pool_domain op: a region that groups the ops sharing one memory
+// pool. Its terminator, hipsr.pool_domain_yield, lives in
+// HipsrPoolDomainYieldOp.td.
+//
+
+#ifndef HIPSR_POOL_DOMAIN_OP
+#define HIPSR_POOL_DOMAIN_OP
+
+include "hip/Dialect/Hipsr/IR/HipsrOps.td"
+include "hip/Dialect/Hipsr/IR/HipsrTraits.td"
+
+//===----------------------------------------------------------------------===//
+// Hipsr_PoolDomainOp
+//===----------------------------------------------------------------------===//
+
+def Hipsr_PoolDomainOp : Hipsr_Op<"pool_domain", [
+    IsolatedFromAboveButAllowOperands,
+    SingleBlockImplicitTerminator<"PoolDomainYieldOp">
+  ]> {
+  let summary = "Group operations that share one memory pool";
+  let description = [{
+    Groups a sequence of operations so they can share one memory pool.
+
+    The body is a single block ending in `hipsr.pool_domain_yield`, whose
+    values become this op's results. `IsolatedFromAboveButAllowOperands` lets
+    the body read this op's operands but nothing else outside, so the block
+    takes no arguments. Operands and results are `AnyType`, so the op is
+    unchanged by bufferization (tensors just become memrefs).
+
+    Example:
+    ```mlir
+    %out:2 = hipsr.pool_domain(%ctx, %in : !hipsr.context, tensor<3x4xf32>) {
+      %c1 = arith.constant 1 : index
+      %n = tensor.dim %in, %c1 : tensor<3x4xf32>
+      %idx = tensor.empty(%n) : tensor<2x?xi64>
+      %cnt = tensor.empty() : tensor<i32>
+      hipsr.pool_domain_yield %idx, %cnt : tensor<2x?xi64>, tensor<i32>
+    } -> tensor<2x?xi64>, tensor<i32>
+    ```
+  }];
+
+  let arguments = (ins Variadic<AnyType>:$operands);
+  let results = (outs Variadic<AnyType>:$results);
+  let regions = (region SizedRegion<1>:$body);
+
+  // Operands in parens, results after `->`; both optional so an empty domain
+  // prints cleanly.
+  let assemblyFormat = [{
+    `(` ($operands^ `:` type($operands))? `)` $body
+    (`->` type($results)^)? attr-dict
+  }];
+
+  let hasVerifier = 1;
+}
+
+#endif // HIPSR_POOL_DOMAIN_OP

--- a/include/hip/Dialect/Hipsr/IR/HipsrPoolDomainYieldOp.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrPoolDomainYieldOp.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#ifndef HIPSR_POOL_DOMAIN_YIELD_OP_H
+#define HIPSR_POOL_DOMAIN_YIELD_OP_H
+
+#include "hip/Dialect/Hipsr/IR/HipsrDialect.h"
+
+#include "mlir/Bytecode/BytecodeOpInterface.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+
+// The .inc references PoolDomainOp (from the HasParent trait) only by name, so
+// a forward declaration is enough. The full type is needed only in the .cpp,
+// which includes its header.
+namespace mlir {
+namespace hipsr {
+class PoolDomainOp;
+} // namespace hipsr
+} // namespace mlir
+
+#define GET_OP_CLASSES
+#include "hip/Dialect/Hipsr/IR/HipsrPoolDomainYieldOp.h.inc"
+
+#endif // HIPSR_POOL_DOMAIN_YIELD_OP_H

--- a/include/hip/Dialect/Hipsr/IR/HipsrPoolDomainYieldOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrPoolDomainYieldOp.td
@@ -1,0 +1,47 @@
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+// The hipsr.pool_domain_yield op: the terminator of a hipsr.pool_domain
+// region. The hipsr.pool_domain op itself lives in HipsrPoolDomainOp.td.
+//
+
+#ifndef HIPSR_POOL_DOMAIN_YIELD_OP
+#define HIPSR_POOL_DOMAIN_YIELD_OP
+
+include "mlir/Interfaces/SideEffectInterfaces.td"
+include "hip/Dialect/Hipsr/IR/HipsrOps.td"
+
+//===----------------------------------------------------------------------===//
+// Hipsr_PoolDomainYieldOp
+//===----------------------------------------------------------------------===//
+
+def Hipsr_PoolDomainYieldOp : Hipsr_Op<"pool_domain_yield",
+    [Pure, Terminator, HasParent<"PoolDomainOp">]> {
+  let summary = "Yield values out of a hipsr.pool_domain region";
+  let description = [{
+    Ends the body of a `hipsr.pool_domain`. Its operands are passed out as the
+    parent op's results, matched by the parent's verifier. Operands are
+    `AnyType` to match the parent's results.
+
+    Example:
+    ```mlir
+    hipsr.pool_domain_yield %out, %count : tensor<2x?xi64>, tensor<i32>
+    ```
+  }];
+
+  let arguments = (ins Variadic<AnyType>:$operands);
+
+  // Operands are optional, so the empty implicit terminator prints as just the
+  // mnemonic.
+  let assemblyFormat = "($operands^ `:` type($operands))? attr-dict";
+
+  let builders = [
+    // No-arg build for the implicit terminator the parent auto-inserts.
+    OpBuilder<(ins), [{
+      build($_builder, $_state, ::mlir::ValueRange{});
+    }]>
+  ];
+}
+
+#endif // HIPSR_POOL_DOMAIN_YIELD_OP

--- a/lib/Dialect/Hipsr/IR/CMakeLists.txt
+++ b/lib/Dialect/Hipsr/IR/CMakeLists.txt
@@ -8,6 +8,8 @@ add_library(HipsrDialectIR STATIC
   HipsrShapeRegionInterface.cpp
   HipsrShapeYieldOp.cpp
   HipsrOps.cpp
+  HipsrPoolDomainYieldOp.cpp
+  HipsrPoolDomainOp.cpp
   HipsrTraits.cpp
   HipsrTypes.cpp
 )

--- a/lib/Dialect/Hipsr/IR/HipsrDialect.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrDialect.cpp
@@ -6,6 +6,8 @@
 #include "hip/Dialect/Hipsr/IR/HipsrDialect.h"
 
 #include "hip/Dialect/Hipsr/IR/HipsrOps.h"
+#include "hip/Dialect/Hipsr/IR/HipsrPoolDomainOp.h"
+#include "hip/Dialect/Hipsr/IR/HipsrPoolDomainYieldOp.h"
 #include "hip/Dialect/Hipsr/IR/HipsrShapeYieldOp.h"
 
 #include "llvm/ADT/TypeSwitch.h"
@@ -32,10 +34,12 @@ void HipsrDialect::initialize() {
   addOperations<
 #define GET_OP_LIST
 #include "hip/Dialect/Hipsr/IR/HipsrShapeYieldOp.cpp.inc"
-      >();
-  addOperations<
+      ,
 #define GET_OP_LIST
-#include "hip/Dialect/Hipsr/IR/HipsrOps.cpp.inc"
+#include "hip/Dialect/Hipsr/IR/HipsrPoolDomainYieldOp.cpp.inc"
+      ,
+#define GET_OP_LIST
+#include "hip/Dialect/Hipsr/IR/HipsrPoolDomainOp.cpp.inc"
       >();
   addAttributes<
 #define GET_ATTRDEF_LIST

--- a/lib/Dialect/Hipsr/IR/HipsrPoolDomainOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrPoolDomainOp.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "hip/Dialect/Hipsr/IR/HipsrPoolDomainOp.h"
+
+// Needs the full PoolDomainYieldOp type: the implicit-terminator trait's
+// generated methods and verify() below both use it.
+#include "hip/Dialect/Hipsr/IR/HipsrPoolDomainYieldOp.h"
+
+#include "llvm/ADT/Sequence.h"
+
+using namespace mlir;
+using namespace mlir::hipsr;
+
+LogicalResult PoolDomainOp::verify() {
+  // The trait already guarantees a single block ending in PoolDomainYieldOp.
+  // Its operands become this op's results, so just check count and types.
+  auto yieldOp = cast<PoolDomainYieldOp>(getBody().front().getTerminator());
+
+  if (yieldOp.getNumOperands() != getNumResults())
+    return emitOpError() << "has " << getNumResults()
+                         << " result(s) but its pool_domain_yield yields "
+                         << yieldOp.getNumOperands() << " value(s)";
+
+  for (unsigned idx : llvm::seq<unsigned>(0, getNumResults())) {
+    Type resultType = getResultTypes()[idx];
+    Type yieldType = yieldOp.getOperandTypes()[idx];
+    if (resultType != yieldType)
+      return emitOpError() << "result #" << idx << " type " << resultType
+                           << " does not match the yielded value type "
+                           << yieldType;
+  }
+
+  return success();
+}
+
+#define GET_OP_CLASSES
+#include "hip/Dialect/Hipsr/IR/HipsrPoolDomainOp.cpp.inc"

--- a/lib/Dialect/Hipsr/IR/HipsrPoolDomainYieldOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrPoolDomainYieldOp.cpp
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "hip/Dialect/Hipsr/IR/HipsrPoolDomainYieldOp.h"
+
+// Needs the full PoolDomainOp type for the HasParent trait's generated check.
+#include "hip/Dialect/Hipsr/IR/HipsrPoolDomainOp.h"
+
+using namespace mlir;
+using namespace mlir::hipsr;
+
+#define GET_OP_CLASSES
+#include "hip/Dialect/Hipsr/IR/HipsrPoolDomainYieldOp.cpp.inc"

--- a/test/lit/Dialect/Hipsr/pool-domain.mlir
+++ b/test/lit/Dialect/Hipsr/pool-domain.mlir
@@ -133,6 +133,46 @@ func.func @tensor_vs_memref_mismatch(%in: memref<3x4xf32>) -> tensor<3x4xf32> {
 }
 
 // -----
+// Verifier: same element type but different static dims is still a mismatch.
+func.func @shape_mismatch_static(%in: tensor<4x3xf32>) -> tensor<3x4xf32> {
+  // expected-error @+1 {{result #0 type 'tensor<3x4xf32>' does not match the yielded value type 'tensor<4x3xf32>'}}
+  %0 = hipsr.pool_domain(%in : tensor<4x3xf32>) {
+    hipsr.pool_domain_yield %in : tensor<4x3xf32>
+  } -> tensor<3x4xf32>
+  return %0 : tensor<3x4xf32>
+}
+
+// -----
+// Verifier: differing rank (same total element count) is a mismatch.
+func.func @shape_mismatch_rank(%in: tensor<12xf32>) -> tensor<3x4xf32> {
+  // expected-error @+1 {{result #0 type 'tensor<3x4xf32>' does not match the yielded value type 'tensor<12xf32>'}}
+  %0 = hipsr.pool_domain(%in : tensor<12xf32>) {
+    hipsr.pool_domain_yield %in : tensor<12xf32>
+  } -> tensor<3x4xf32>
+  return %0 : tensor<3x4xf32>
+}
+
+// -----
+// Verifier: a static dim does not match a dynamic dim.
+func.func @shape_mismatch_dynamic(%in: tensor<2x?xi64>) -> tensor<2x4xi64> {
+  // expected-error @+1 {{result #0 type 'tensor<2x4xi64>' does not match the yielded value type 'tensor<2x?xi64>'}}
+  %0 = hipsr.pool_domain(%in : tensor<2x?xi64>) {
+    hipsr.pool_domain_yield %in : tensor<2x?xi64>
+  } -> tensor<2x4xi64>
+  return %0 : tensor<2x4xi64>
+}
+
+// -----
+// Verifier: memref results follow the same shape-consistency rule.
+func.func @shape_mismatch_memref(%in: memref<2x?xi64>) -> memref<2x8xi64> {
+  // expected-error @+1 {{result #0 type 'memref<2x8xi64>' does not match the yielded value type 'memref<2x?xi64>'}}
+  %0 = hipsr.pool_domain(%in : memref<2x?xi64>) {
+    hipsr.pool_domain_yield %in : memref<2x?xi64>
+  } -> memref<2x8xi64>
+  return %0 : memref<2x8xi64>
+}
+
+// -----
 // Verifier (SizedRegion<1>): the body must be a single block. Two blocks, each
 // terminated by its own pool_domain_yield, is rejected.
 func.func @multi_block_body(%in: tensor<3x4xf32>) {

--- a/test/lit/Dialect/Hipsr/pool-domain.mlir
+++ b/test/lit/Dialect/Hipsr/pool-domain.mlir
@@ -1,0 +1,146 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+//===----------------------------------------------------------------------===//
+// Tests that hipsr.pool_domain / hipsr.pool_domain_yield parse, round-trip, and
+// that the verifiers reject malformed IR.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt --split-input-file --verify-diagnostics %s | FileCheck %s
+
+// -----
+// Round-trip: operands + results. The body reads an operand (allowed by
+// IsolatedFromAboveButAllowOperands) to compute a dynamic shape.
+// CHECK-LABEL: func.func @roundtrip
+// CHECK: %[[R:.*]]:2 = hipsr.pool_domain(%{{.*}} : tensor<3x4xf32>) {
+// CHECK:   %[[N:.*]] = tensor.dim
+// CHECK:   %[[IDX:.*]] = tensor.empty(%[[N]]) : tensor<2x?xi64>
+// CHECK:   %[[CNT:.*]] = tensor.empty() : tensor<i32>
+// CHECK:   hipsr.pool_domain_yield %[[IDX]], %[[CNT]] : tensor<2x?xi64>, tensor<i32>
+// CHECK: } -> tensor<2x?xi64>, tensor<i32>
+func.func @roundtrip(%in: tensor<3x4xf32>) -> (tensor<2x?xi64>, tensor<i32>) {
+  %0:2 = hipsr.pool_domain(%in : tensor<3x4xf32>) {
+    %c1 = arith.constant 1 : index
+    %n = tensor.dim %in, %c1 : tensor<3x4xf32>
+    %idx = tensor.empty(%n) : tensor<2x?xi64>
+    %cnt = tensor.empty() : tensor<i32>
+    hipsr.pool_domain_yield %idx, %cnt : tensor<2x?xi64>, tensor<i32>
+  } -> tensor<2x?xi64>, tensor<i32>
+  return %0#0, %0#1 : tensor<2x?xi64>, tensor<i32>
+}
+
+// -----
+// Post-bufferization form: memref operands/results (AnyType) plus a non-tensor
+// `index` result.
+// CHECK-LABEL: func.func @memref_form
+// CHECK: hipsr.pool_domain(%{{.*}} : memref<2x?xi64>)
+// CHECK: hipsr.pool_domain_yield %{{.*}}, %{{.*}} : memref<2x?xi64>, index
+// CHECK: -> memref<2x?xi64>, index
+func.func @memref_form(%in: memref<2x?xi64>) -> (memref<2x?xi64>, index) {
+  %0:2 = hipsr.pool_domain(%in : memref<2x?xi64>) {
+    %c1 = arith.constant 1 : index
+    %n = memref.dim %in, %c1 : memref<2x?xi64>
+    hipsr.pool_domain_yield %in, %n : memref<2x?xi64>, index
+  } -> memref<2x?xi64>, index
+  return %0#0, %0#1 : memref<2x?xi64>, index
+}
+
+// -----
+// No operands, no results: the empty implicit terminator has no operands, so
+// the assembly format elides it -- the region round-trips as just `{ }`.
+// CHECK-LABEL: func.func @empty_domain
+// CHECK: hipsr.pool_domain() {
+// CHECK-NEXT: }
+func.func @empty_domain() {
+  hipsr.pool_domain() {
+    hipsr.pool_domain_yield
+  }
+  return
+}
+
+// -----
+// Verifier: result count must match the yielded value count.
+func.func @result_count_mismatch(%in: tensor<3x4xf32>) -> tensor<3x4xf32> {
+  // expected-error @+1 {{has 1 result(s) but its pool_domain_yield yields 0 value(s)}}
+  %0 = hipsr.pool_domain(%in : tensor<3x4xf32>) {
+    hipsr.pool_domain_yield
+  } -> tensor<3x4xf32>
+  return %0 : tensor<3x4xf32>
+}
+
+// -----
+// Verifier: result type must match the yielded value type.
+func.func @result_type_mismatch(%in: tensor<3x4xf32>) -> tensor<3x4xi64> {
+  // expected-error @+1 {{result #0 type 'tensor<3x4xi64>' does not match the yielded value type 'tensor<3x4xf32>'}}
+  %0 = hipsr.pool_domain(%in : tensor<3x4xf32>) {
+    hipsr.pool_domain_yield %in : tensor<3x4xf32>
+  } -> tensor<3x4xi64>
+  return %0 : tensor<3x4xi64>
+}
+
+// -----
+// Verifier (IsolatedFromAboveButAllowOperands): the body may not use a value
+// from the enclosing scope that is not one of the op's operands.
+func.func @body_uses_outside_value(%in: tensor<3x4xf32>, %other: tensor<3x4xf32>) -> tensor<3x4xf32> {
+  // Error is on the inner op using the outside value; note on the pool_domain.
+  // expected-note @+1 {{may only use values defined in its regions or the op's operands}}
+  %0 = hipsr.pool_domain(%in : tensor<3x4xf32>) {
+    // expected-error @+1 {{using value defined outside the region}}
+    hipsr.pool_domain_yield %other : tensor<3x4xf32>
+  } -> tensor<3x4xf32>
+  return %0 : tensor<3x4xf32>
+}
+
+// -----
+// Verifier (HasParent): pool_domain_yield outside a pool_domain is rejected.
+func.func @yield_without_parent(%in: tensor<3x4xf32>) {
+  // expected-error @+1 {{expects parent op 'hipsr.pool_domain'}}
+  hipsr.pool_domain_yield %in : tensor<3x4xf32>
+}
+
+// -----
+// Verifier: the count check also rejects yielding more values than the op has
+// results (here 0 results but 1 yielded value).
+func.func @more_yields_than_results(%in: tensor<3x4xf32>) {
+  // expected-error @+1 {{has 0 result(s) but its pool_domain_yield yields 1 value(s)}}
+  hipsr.pool_domain(%in : tensor<3x4xf32>) {
+    hipsr.pool_domain_yield %in : tensor<3x4xf32>
+  }
+  return
+}
+
+// -----
+// Verifier: a mismatch on a later result is reported with that result's index
+// (result #0 matches, result #1 does not).
+func.func @later_result_type_mismatch(%in: tensor<3x4xf32>)
+    -> (tensor<3x4xf32>, tensor<3x4xi64>) {
+  // expected-error @+1 {{result #1 type 'tensor<3x4xi64>' does not match the yielded value type 'tensor<3x4xf32>'}}
+  %0:2 = hipsr.pool_domain(%in : tensor<3x4xf32>) {
+    hipsr.pool_domain_yield %in, %in : tensor<3x4xf32>, tensor<3x4xf32>
+  } -> tensor<3x4xf32>, tensor<3x4xi64>
+  return %0#0, %0#1 : tensor<3x4xf32>, tensor<3x4xi64>
+}
+
+// -----
+// Verifier: types must match exactly -- a tensor result does not match a memref
+// yielded value even with the same shape and element type.
+func.func @tensor_vs_memref_mismatch(%in: memref<3x4xf32>) -> tensor<3x4xf32> {
+  // expected-error @+1 {{result #0 type 'tensor<3x4xf32>' does not match the yielded value type 'memref<3x4xf32>'}}
+  %0 = hipsr.pool_domain(%in : memref<3x4xf32>) {
+    hipsr.pool_domain_yield %in : memref<3x4xf32>
+  } -> tensor<3x4xf32>
+  return %0 : tensor<3x4xf32>
+}
+
+// -----
+// Verifier (SizedRegion<1>): the body must be a single block. Two blocks, each
+// terminated by its own pool_domain_yield, is rejected.
+func.func @multi_block_body(%in: tensor<3x4xf32>) {
+  // expected-error @+1 {{expects region #0 to have 0 or 1 blocks}}
+  hipsr.pool_domain(%in : tensor<3x4xf32>) {
+    hipsr.pool_domain_yield
+  ^bb1:
+    hipsr.pool_domain_yield
+  }
+  return
+}


### PR DESCRIPTION
Add the `hipsr.pool_domain` region op and its `hipsr.pool_domain_yield` terminator, defined in separate TableGen files.

- `pool_domain` scopes a group of allocations that share a lifetime.
- `pool_domain_yield` returns the domain results and is inserted implicitly as the region terminator.
- `pool_domain` is `IsolatedFromAboveButAllowOperands` with a single-block region and a verifier that checks the yield operands match the domain results in count and type.
