### PR TITLE
feat(dialect): allow an empty (unpopulated) shape region on Hipsr_DpsOp

### DIFF
--- a/include/hip/Dialect/Hipsr/IR/HipsrOps.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrOps.td
@@ -27,9 +27,14 @@ class Hipsr_Op<string mnemonic, list<Trait> traits = []> :
 //===----------------------------------------------------------------------===//
 
 // Base for shaped compute ops (MatMul, Add, ...). Every such op:
-//   - carries a shape region (region 0) that computes its output shape and is
-//     terminated by `hipsr.shape_yield`. The SingleBlockImplicitTerminator
-//     trait auto-inserts that terminator and structurally checks it;
+//   - carries an optional shape region (region 0): it holds either zero blocks
+//     (no shape computation) or exactly one block that computes its output
+//     shape and is terminated by `hipsr.shape_yield`. MaxSizedRegion<1> allows
+//     the 0-or-1-block range; the SingleBlock trait keeps a non-empty region to
+//     a single block. Unlike SingleBlockImplicitTerminator, it neither
+//     auto-inserts nor elides the terminator, so an empty region stays empty
+//     (even across a textual round-trip); the ShapeRegionInterface verifier is
+//     what requires a non-empty region to end with `hipsr.shape_yield`;
 //   - implements ShapeRegionInterface, the single source of truth for shape
 //     computation (each op provides populateShapeRegion());
 //   - carries IsolatedFromAboveButAllowOperands, so the shape region may only
@@ -46,9 +51,9 @@ class Hipsr_DpsOp<string mnemonic, list<Trait> traits = []> :
         DeclareOpInterfaceMethods<DestinationStyleOpInterface,
                                   ["getDpsInitsMutable"]>,
         IsolatedFromAboveButAllowOperands,
-        SingleBlockImplicitTerminator<"ShapeYieldOp">
+        SingleBlock
       ], traits)> {
-  let regions = (region SizedRegion<1>:$shape_region);
+  let regions = (region MaxSizedRegion<1>:$shape_region);
   let results = (outs Variadic<AnyRankedTensor>:$result_tensors);
 }
 

--- a/include/hip/Dialect/Hipsr/IR/HipsrShapeRegionInterface.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrShapeRegionInterface.td
@@ -22,9 +22,10 @@ def ShapeRegionInterface : OpInterface<"ShapeRegionInterface"> {
     Base interface for shape computation.
     Provides populateShapeRegion() method - single source of truth.
 
-    An implementing op carries a shape region (region 0) whose body computes
-    the op's output dimensions and ends with a `hipsr.shape_yield`. The
-    populate* methods emit that region; the get* accessors retrieve it.
+    An implementing op carries an optional shape region (region 0): either
+    empty (zero blocks, no shape computation yet) or a single block whose body
+    computes the op's output dimensions and ends with a `hipsr.shape_yield`.
+    The populate* methods emit that region; the get* accessors retrieve it.
 
     REQUIREMENT: an op implementing this interface MUST also add two traits
     (MLIR interfaces cannot auto-attach traits), e.g.
@@ -32,14 +33,16 @@ def ShapeRegionInterface : OpInterface<"ShapeRegionInterface"> {
       def Hipsr_MatMulOp : Hipsr_Op<"matmul", [
           ShapeRegionInterface,
           IsolatedFromAboveButAllowOperands,
-          SingleBlockImplicitTerminator<"ShapeYieldOp">
+          SingleBlock
       ]> { ... }
 
-    `SingleBlockImplicitTerminator<"ShapeYieldOp">` inserts the terminator;
+    `SingleBlock` keeps a non-empty region to a single block without inserting
+    or eliding a terminator (so an empty region stays empty);
     `IsolatedFromAboveButAllowOperands` restricts what the shape region may use.
-    The interface verifier checks the region structure and that the trait is
-    present (so a missing trait gives a clear error); the trait's own verifier
-    does the scoping check.
+    The interface verifier checks the region structure -- including that a
+    non-empty region ends with `hipsr.shape_yield` -- and that the
+    IsolatedFromAboveButAllowOperands trait is present (whose own verifier does
+    the scoping check).
 
     Operation categories (barrier markers are separate interfaces):
     - Regular (MatMul, Add): no block arguments, one shape, depends on input shapes.

--- a/lib/Dialect/Hipsr/IR/HipsrShapeRegionInterface.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrShapeRegionInterface.cpp
@@ -26,6 +26,12 @@ LogicalResult mlir::hipsr::verifyShapeRegionStructure(Operation *op) {
     return op->emitOpError("expected a shape region (region 0)");
 
   Region &shapeRegion = op->getRegion(0);
+
+  // The shape region is optional: an empty region (0 blocks) means the op
+  // carries no shape computation. When present it must have exactly one block.
+  if (shapeRegion.empty())
+    return success();
+
   if (!shapeRegion.hasOneBlock())
     return op->emitOpError("shape region must have exactly one block");
 
@@ -38,8 +44,8 @@ LogicalResult mlir::hipsr::verifyShapeRegionStructure(Operation *op) {
                "shape region must terminate with hipsr.shape_yield, "
                "got '")
            << block.back().getName()
-           << "'; did you forget the "
-              "SingleBlockImplicitTerminator<\"ShapeYieldOp\"> trait?";
+           << "'; a non-empty shape region block must end with "
+              "hipsr.shape_yield";
 
   return success();
 }


### PR DESCRIPTION
﻿## Why

`hipsr` shaped ops (those built on `Hipsr_DpsOp`) are created **before** their output-shape computation exists. In the ONNX -> hipsr flow, the ops are emitted first, and a **separate, dedicated pass later populates every op's shape region uniformly** (keeping shape computation as a single source of truth, with consistent timing). For that to work, an op must be able to legally exist with **no shape computation yet** -- i.e. the shape region has to be **optional**.

The previous base (`SizedRegion<1>` + `SingleBlockImplicitTerminator<"ShapeYieldOp">`) forced the opposite:
- `SizedRegion<1>` requires **exactly one block**, so an unpopulated (empty) region is illegal.
- `SingleBlockImplicitTerminator` **auto-inserts** a `shape_yield` on parse and **elides** it on print. So a region left empty silently becomes one holding a bare `shape_yield`, and "absent" vs "present-but-empty" are indistinguishable in text and do **not** round-trip stably.

## What

- `Hipsr_DpsOp`: `SizedRegion<1>` -> `MaxSizedRegion<1>` (0 or 1 block), and `SingleBlockImplicitTerminator<"ShapeYieldOp">` -> `SingleBlock`.
  - `MaxSizedRegion<1>` allows the 0-block (unpopulated) state.
  - `SingleBlock` keeps a non-empty region to a single block but neither auto-inserts nor elides the terminator, so an empty region **stays empty** (and round-trips faithfully) while a populated region prints its `shape_yield` explicitly. "Absent" becomes a first-class, stable, distinguishable state.
- `verifyShapeRegionStructure`: accept an empty region; a **non-empty** region must still be a single block ending with `hipsr.shape_yield`.
- Update `ShapeRegionInterface` docs to match.

## Notes

- Infra-only. No concrete `Hipsr_DpsOp` op exists on `main` yet, so there is no functional test here; the consumer + tests land in #483 (stacked on this branch).

## Test plan

- [x] `hip-mlir-opt` builds locally on latest `main` + this change.
- [ ] CI green.
