### PR TITLE
Fix hip-onnx-runner to run on FFM

### DIFF
--- a/tools/hip-onnx-runner/hip-onnx-runner.cpp
+++ b/tools/hip-onnx-runner/hip-onnx-runner.cpp
@@ -955,8 +955,10 @@ int main(int argc, char *argv[]) {
     // on the prebuilt Linux ORT package we ship here. Spell out the map type
     // so we always bind to the original overload and stay compatible with the
     // older ORT version we still link against on Windows.
-    session_opts.AppendExecutionProvider_V2(
-        env, devices, std::unordered_map<std::string, std::string>{});
+    std::unordered_map<std::string, std::string> ep_opts;
+    if (const char *af = std::getenv("HIPDNN_EP_ARTIFACT_FORMAT"))
+      ep_opts["artifact_format"] = af;
+    session_opts.AppendExecutionProvider_V2(env, devices, ep_opts);
     session_opts.AddConfigEntry("session.disable_cpu_ep_fallback", "1");
   }
 


### PR DESCRIPTION
### Summary
`hip-onnx-runner` currently passes an empty options map to AppendExecutionProvider_V2, which means the EP always uses the default LLVM_IR artifact format. This works fine on real hardware but fails on FFM where the in-process JIT cannot resolve vendor-BLAS symbols that the shim stubs out.

This change reads `HIPDNN_EP_ARTIFACT_FORMAT` from the environment and forwards it as the artifact_format provider option. Setting it to NATIVE makes the EP pre-link a .so (the same path hip-test already uses successfully on FFM) instead of JIT-compiling LLVM IR in-process.

No behavior change for any existing workflow. If the env var is not set, the options map is empty and everything works exactly as before. The env var is only needed when running under a software shim that stubs vendor-BLAS.