### PR TITLE
feat(hipsr): broaden constant result type and add onnx.Constant conversion

### DIFF
--- a/include/hip/Conversion/OnnxToHipsr/OnnxToHipsr.h
+++ b/include/hip/Conversion/OnnxToHipsr/OnnxToHipsr.h
@@ -6,6 +6,7 @@
 #ifndef HIP_CONVERSION_ONNXTOHIPSR_ONNXTOHIPSR_H
 #define HIP_CONVERSION_ONNXTOHIPSR_ONNXTOHIPSR_H
 
+#include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 
 #include <memory>
@@ -20,6 +21,12 @@ namespace hipsr {
 // hip/Conversion/Passes.h.
 #define GEN_PASS_DECL_CONVERTONNXTOHIPSRPASS
 #include "hip/Conversion/Passes.h.inc"
+
+// Populates patterns that convert `onnx.Constant` into `hipsr.constant`
+// (rank>=1 inline / mem_source / file_source) or `arith.constant` (rank-0
+// scalar). Pure IR rewrite -- no file I/O and no size-threshold policy (that
+// is layered on in the externalization pass).
+void populateOnnxToHipsrConstantPatterns(::mlir::RewritePatternSet &patterns);
 
 } // namespace hipsr
 } // namespace mlir

--- a/include/hip/Dialect/Hipsr/IR/HipsrConstantOp.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrConstantOp.h
@@ -40,9 +40,10 @@ template <typename T>::llvm::ArrayRef<T> ConstantOp::getDataValues() {
   // (numElements * elemByteWidth), never splat-optimized.
   if (auto dense =
           ::llvm::dyn_cast_or_null<::mlir::DenseElementsAttr>(getValueAttr())) {
-    if (dense.isSplat())
+    if (dense.isSplat()) {
       llvm_unreachable("splat DenseElementsAttr not supported "
                        "(MorphiZen never emits splat-optimized constants)");
+    }
     ::llvm::ArrayRef<char> raw = dense.getRawData();
     return ::llvm::ArrayRef<T>(reinterpret_cast<const T *>(raw.data()),
                                raw.size() / sizeof(T));
@@ -50,9 +51,10 @@ template <typename T>::llvm::ArrayRef<T> ConstantOp::getDataValues() {
 
   // Resource-backed inline value: not emitted by MorphiZen.
   if (::llvm::isa_and_nonnull<::mlir::DenseResourceElementsAttr>(
-          getValueAttr()))
+          getValueAttr())) {
     llvm_unreachable("DenseResourceElementsAttr not supported "
                      "(MorphiZen never emits this)");
+  }
 
   // External source: raw pointer (mem) or memory-mapped file (cached).
   if (::mlir::Attribute src = getSourceAttr()) {

--- a/include/hip/Dialect/Hipsr/IR/HipsrConstantOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrConstantOp.td
@@ -37,8 +37,9 @@ def Hipsr_ConstantOp : Hipsr_Op<"constant", [Pure]> {
     `externalize` (default true) is an orthogonal opt-out flag; a downstream pass
     calls `disableExternalize()` to keep a constant inline (compile-time value).
 
-    The result must be a device `memref` (`#hipsr.mem<device>`); constants reside
-    in VRAM. The verifier enforces this.
+    The result is a ranked tensor (pre-bufferization) or a device `memref`
+    (`#hipsr.mem<device>`, post-bufferization); constants reside in VRAM. The
+    `Hipsr_TensorOrDeviceMemRef` ODS constraint enforces this.
 
     Example:
     ```mlir
@@ -55,7 +56,7 @@ def Hipsr_ConstantOp : Hipsr_Op<"constant", [Pure]> {
     OptionalAttr<BoolAttr>:$externalize
   );
 
-  let results = (outs AnyMemRef:$result);
+  let results = (outs Hipsr_TensorOrDeviceMemRef:$result);
 
   let assemblyFormat = "attr-dict `:` type($result)";
 

--- a/lib/Conversion/OnnxToHipsr/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHipsr/CMakeLists.txt
@@ -4,6 +4,7 @@
 ##
 
 add_library(OnnxToHipsr STATIC
+  ConstantConversion.cpp
   OnnxToHipsr.cpp
 )
 

--- a/lib/Conversion/OnnxToHipsr/ConstantConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/ConstantConversion.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- ConstantConversion.cpp - onnx.Constant -> hipsr.constant ----------===//
+//
+// Converts `onnx.Constant` into the hipsr constant forms. Matched by name via
+// the generic Operation API (no onnx-mlir headers), consistent with the rest
+// of convert-onnx-to-hipsr. Four branches, keyed only on the storage form of
+// the incoming onnx.Constant -- no size threshold (that policy is layered on
+// later, in externalization):
+//
+//   inline value + rank-0 scalar     -> arith.constant <scalar>
+//   inline value + rank>=1           -> hipsr.constant {value}      : tensor<>
+//   location == "*/_ORT_MEM_ADDR_/*" -> hipsr.constant {mem_source} : tensor<>
+//   location == <other path>         -> hipsr.constant {file_source}: tensor<>
+//
+// The result stays a ranked tensor (pre-bufferization); the broadened
+// hipsr.constant result type (Hipsr_TensorOrDeviceMemRef) means no
+// memref->tensor bridge is needed here.
+//
+//===----------------------------------------------------------------------===//
+
+#include "hip/Conversion/OnnxToHipsr/OnnxToHipsr.h"
+#include "hip/Dialect/Hipsr/IR/HipsrConstantOp.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+
+namespace mlir {
+namespace hipsr {
+
+namespace {
+
+// The ORT bridge tags in-memory (zero-copy) constants with this location; any
+// other location string is an absolute file path. Mirrors kOrtMemAddrTag in
+// OnnxToHip.cpp.
+constexpr ::llvm::StringLiteral kOrtMemAddrTag = "*/_ORT_MEM_ADDR_/*";
+
+struct ConstantOpLowering : public ::mlir::RewritePattern {
+  explicit ConstantOpLowering(::mlir::MLIRContext *ctx)
+      : ::mlir::RewritePattern("onnx.Constant", /*benefit=*/1, ctx) {}
+
+  ::mlir::LogicalResult
+  matchAndRewrite(::mlir::Operation *op,
+                  ::mlir::PatternRewriter &rewriter) const override {
+    auto tensorType =
+        ::llvm::dyn_cast<::mlir::RankedTensorType>(op->getResult(0).getType());
+    if (!tensorType) {
+      return rewriter.notifyMatchFailure(op, "non-ranked result type");
+    }
+
+    // Inline dense value.
+    if (auto valueAttr = op->getAttrOfType<::mlir::ElementsAttr>("value")) {
+      // Rank-0 scalar stays a compile-time arith.constant (keeps the tensor<>
+      // result type; the elements attr is TypedAttr-compatible).
+      if (tensorType.getRank() == 0) {
+        rewriter.replaceOpWithNewOp<::mlir::arith::ConstantOp>(
+            op, ::llvm::cast<::mlir::TypedAttr>(valueAttr));
+        return ::mlir::success();
+      }
+
+      // rank>=1 -> hipsr.constant {value}.
+      rewriter.replaceOpWithNewOp<ConstantOp>(
+          op, /*result=*/tensorType, /*value=*/valueAttr,
+          /*source=*/::mlir::Attribute(), /*offset=*/::mlir::IntegerAttr(),
+          /*size=*/::mlir::IntegerAttr(), /*externalize=*/::mlir::BoolAttr());
+      return ::mlir::success();
+    }
+
+    // External data: location + offset + size.
+    auto locAttr = op->getAttrOfType<::mlir::StringAttr>("location");
+    if (!locAttr) {
+      return rewriter.notifyMatchFailure(
+          op, "onnx.Constant has neither value nor location");
+    }
+    auto offsetAttr = op->getAttrOfType<::mlir::IntegerAttr>("offset");
+    auto sizeAttr = op->getAttrOfType<::mlir::IntegerAttr>("size");
+    if (!offsetAttr || !sizeAttr) {
+      return rewriter.notifyMatchFailure(
+          op, "onnx.Constant with location missing offset/size");
+    }
+    int64_t offset = offsetAttr.getInt();
+    int64_t size = sizeAttr.getInt();
+
+    ::mlir::Attribute source;
+    if (locAttr.getValue() == kOrtMemAddrTag) {
+      source = MemSourceAttr::get(op->getContext(), /*address=*/offset, size);
+    } else {
+      source = FileSourceAttr::get(op->getContext(), locAttr, offset, size);
+    }
+
+    rewriter.replaceOpWithNewOp<ConstantOp>(
+        op, /*result=*/tensorType, /*value=*/::mlir::ElementsAttr(), source,
+        /*offset=*/::mlir::IntegerAttr(), /*size=*/::mlir::IntegerAttr(),
+        /*externalize=*/::mlir::BoolAttr());
+    return ::mlir::success();
+  }
+};
+
+} // namespace
+
+void populateOnnxToHipsrConstantPatterns(::mlir::RewritePatternSet &patterns) {
+  patterns.add<ConstantOpLowering>(patterns.getContext());
+}
+
+} // namespace hipsr
+} // namespace mlir

--- a/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
+++ b/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
@@ -32,8 +32,7 @@ struct ConvertOnnxToHipsrPass
     : impl::ConvertOnnxToHipsrPassBase<ConvertOnnxToHipsrPass> {
   void runOnOperation() override {
     ::mlir::RewritePatternSet patterns(&getContext());
-    // Per-op ONNX -> hipsr conversion patterns are registered by follow-up
-    // layers (e.g. Cast) that add both the hipsr op and its pattern here.
+    populateOnnxToHipsrConstantPatterns(patterns);
 
     // Same driver/config as convert-onnx-to-hip (greedy, ExistingOps): ONNX ops
     // are matched by name and only the ops present on entry are rewritten, so

--- a/lib/Dialect/Hipsr/IR/HipsrConstantOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrConstantOp.cpp
@@ -26,13 +26,8 @@ LogicalResult ConstantOp::verify() {
   if (hasOffset != hasSize)
     return emitOpError("`offset` and `size` must be set together");
 
-  // Constants reside in VRAM: the result memref must be device memory.
-  MemRefType memrefType = getResult().getType();
-  auto deviceSpace =
-      llvm::dyn_cast_or_null<MemorySpaceAttr>(memrefType.getMemorySpace());
-  if (!deviceSpace || deviceSpace.getKind() != MemorySpaceKind::Device)
-    return emitOpError("result must have #hipsr.mem<device> memory space");
-
+  // The result type (ranked tensor or #hipsr.mem<device> memref) is enforced
+  // by the Hipsr_TensorOrDeviceMemRef ODS constraint.
   return success();
 }
 

--- a/test/lit/Conversion/onnx-to-hipsr/test_constant.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/test_constant.mlir
@@ -1,0 +1,47 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+// convert-onnx-to-hipsr: onnx.Constant -> hipsr.constant / arith.constant.
+// Four branches keyed on storage form (no size threshold here):
+//   rank-0 scalar          -> arith.constant (compile-time)
+//   rank>=1 inline value   -> hipsr.constant {value}
+//   "*/_ORT_MEM_ADDR_/*"   -> hipsr.constant {mem_source}
+//   other location path    -> hipsr.constant {file_source}
+// onnx.Constant is written in generic form so no onnx dialect is required.
+
+// RUN: hip-mlir-opt --convert-onnx-to-hipsr %s | FileCheck %s
+
+// CHECK-LABEL: func.func @scalar_const
+func.func @scalar_const() -> tensor<f32> {
+  // CHECK: arith.constant dense<3.000000e+00> : tensor<f32>
+  // CHECK-NOT: hipsr.constant
+  %0 = "onnx.Constant"() {value = dense<3.0> : tensor<f32>} : () -> tensor<f32>
+  return %0 : tensor<f32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @inline_const
+func.func @inline_const() -> tensor<4xf32> {
+  // CHECK: hipsr.constant {value = dense<[1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00]> : tensor<4xf32>} : tensor<4xf32>
+  %0 = "onnx.Constant"() {value = dense<[1.0, 2.0, 3.0, 4.0]> : tensor<4xf32>} : () -> tensor<4xf32>
+  return %0 : tensor<4xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @mem_source_const
+func.func @mem_source_const() -> tensor<2x4xf32> {
+  // CHECK: hipsr.constant {source = #hipsr.mem_source<140695085056000, 32>} : tensor<2x4xf32>
+  %0 = "onnx.Constant"() {location = "*/_ORT_MEM_ADDR_/*", offset = 140695085056000 : i64, size = 32 : i64} : () -> tensor<2x4xf32>
+  return %0 : tensor<2x4xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @file_source_const
+func.func @file_source_const() -> tensor<100xf32> {
+  // CHECK: hipsr.constant {source = #hipsr.file_source<"weights.bin", 1048576, 400>} : tensor<100xf32>
+  %0 = "onnx.Constant"() {location = "weights.bin", offset = 1048576 : i64, size = 400 : i64} : () -> tensor<100xf32>
+  return %0 : tensor<100xf32>
+}

--- a/test/lit/Dialect/Hipsr/constant.mlir
+++ b/test/lit/Dialect/Hipsr/constant.mlir
@@ -17,6 +17,18 @@ func.func @inline_const() -> memref<4xf16, #hipsr.mem<device>> {
 
 // -----
 
+// A ranked tensor result is allowed (pre-bufferization form, as produced by
+// the onnx->hipsr conversion before bufferization).
+// CHECK-LABEL: func.func @inline_const_tensor
+func.func @inline_const_tensor() -> tensor<4xf16> {
+  // CHECK: hipsr.constant {value = dense<{{.*}}> : tensor<4xf16>} : tensor<4xf16>
+  %c = hipsr.constant {value = dense<[1.0, 2.0, 3.0, 4.0]> : tensor<4xf16>}
+     : tensor<4xf16>
+  return %c : tensor<4xf16>
+}
+
+// -----
+
 // CHECK-LABEL: func.func @file_source_const
 func.func @file_source_const() -> memref<100xf32, #hipsr.mem<device>> {
   // CHECK: hipsr.constant {source = #hipsr.file_source<"w.bin", 0, 1000>} : memref<100xf32, #hipsr.mem<device>>
@@ -66,8 +78,10 @@ func.func @offset_without_size_rejected() -> memref<4xf16, #hipsr.mem<device>> {
 
 // -----
 
+// A memref with no memory space is rejected by the ODS type constraint
+// (Hipsr_TensorOrDeviceMemRef), not by the verifier.
 func.func @non_device_space_rejected() -> memref<4xf16> {
-  // expected-error @+1 {{result must have #hipsr.mem<device> memory space}}
+  // expected-error @+1 {{result #0 must be ranked tensor or device memref}}
   %c = hipsr.constant {value = dense<1.0> : tensor<4xf16>} : memref<4xf16>
   return %c : memref<4xf16>
 }


### PR DESCRIPTION
﻿## Summary

Broadens `hipsr.constant`'s result type to ranked-tensor-or-device-memref and adds the `onnx.Constant -> hipsr.constant` conversion pattern, the first producer of the constant op that landed in #495. Also picks up the two minor review items from #495.

## Why

#495 landed `hipsr.constant` with an `AnyMemRef` result and a hand-written verifier check forcing `#hipsr.mem<device>`. hipsr compute ops are tensor-DPS, so a memref-only constant would force a `memref->tensor` bridge at every consumer in the conversion pass. Broadening the result type to `Hipsr_TensorOrDeviceMemRef` (already defined in `HipsrTypes.td`) lets the pass produce `hipsr.constant : tensor<...>` directly (pre-bufferization) while still allowing device memref post-bufferization; the ODS type constraint subsumes the verifier's device check, so that check is removed (it also mis-fired on tensor results).

The conversion pattern deliberately keys only on storage form, not size. The "keep small constants inline vs externalize" threshold policy is left to a later externalization pass, keeping this stage pure-IR with no file I/O and no policy, per the three-phase constant-subsystem split.

Alternative considered for rank-0: emitting a scalar `arith.constant` (bare `f32`). Rejected because it breaks the types of existing users that expect `tensor<f32>`; instead we keep the tensor-typed `arith.constant` (compile-time constant, type-preserving), matching the existing `OnnxToHip` behaviour.

## What

1. **Result type** at `include/hip/Dialect/Hipsr/IR/HipsrConstantOp.td`: `AnyMemRef` -> `Hipsr_TensorOrDeviceMemRef`; description updated.
2. **Verifier** at `lib/Dialect/Hipsr/IR/HipsrConstantOp.cpp`: drop the hand-written device memory-space check (now enforced by ODS); keep value-XOR-source and paired offset/size.
3. **Formatting** at `include/hip/Dialect/Hipsr/IR/HipsrConstantOp.h`: brace the two single-statement `if` guards in `getDataValues` (review request from #495).
4. **New conversion pattern** `lib/Conversion/OnnxToHipsr/ConstantConversion.cpp`: `ConstantOpLowering` (a `RewritePattern` matching `onnx.Constant` by name, no onnx-mlir headers). Four branches: rank-0 scalar -> `arith.constant`; rank>=1 inline value -> `hipsr.constant {value}`; `location == "*/_ORT_MEM_ADDR_/*"` -> `mem_source`; other location -> `file_source`.
5. **Registration**: `populateOnnxToHipsrConstantPatterns` declared in `OnnxToHipsr.h`, called from `OnnxToHipsr.cpp::runOnOperation`; `ConstantConversion.cpp` added to the CMake target.
6. **Intentional non-changes**: no size threshold / inline policy here (deferred to the externalization pass); no externalization or LLVM lowering.

## Test plan

- [x] LIT green: `check-hip-mlir-lit` -> 289 discovered, 287 passed, 0 failed, 2 unsupported (pre-existing plugin-gated).
- [x] Updated `test/lit/Dialect/Hipsr/constant.mlir`: non-device result now rejected by the ODS constraint (`result #0 must be ranked tensor or device memref`); added a tensor-result positive round-trip.
- [x] New `test/lit/Conversion/onnx-to-hipsr/test_constant.mlir` covers all four branches.
- [x] `pre-commit run --all-files` clean, no auto-fixes.

## Notes for reviewers

None.

## Checklist

- [x] **Incremental** -- 9 files, ~190 LOC.
- [x] **AI policy** -- pattern and tests drafted with Cursor; every design decision above is human-owned and answerable in review.
- [x] **No `good first issue` automation**
- [x] **Reviews resolved**
- [x] **CODEOWNERS routing**
