### PR TITLE
feat(hipsr): add -hipsr-externalize-constants pass

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,6 +207,9 @@ if(BUILD_HIP_TOOLS)
     # Static compiler-plugin tests (sample plugin + unit test).
     # See docs/design/plugin-interface.md.
     add_subdirectory(test/plugin)
+
+    # MLIR dialect/pass unit tests (GTest; cover Phase 2 write paths LIT can't).
+    add_subdirectory(test/unit)
   endif()
 
   # Out-of-tree plugin dirs (HIPDNN_EP_COMPILER_PLUGIN_PATHS): add each so it can

--- a/include/hip/Dialect/Hipsr/IR/HipsrDialect.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrDialect.h
@@ -18,6 +18,13 @@
 #include <memory>
 #include <mutex>
 
+// The dialect holds a non-owning FileSystem* (constants sidecar sink). Forward
+// declaration only -- avoids pulling morphizen-foundation into every dialect
+// consumer.
+namespace morphizen {
+class FileSystem;
+} // namespace morphizen
+
 #include "hip/Dialect/Hipsr/IR/HipsrDialect.h.inc"
 
 // Enum header first: MemorySpaceAttr uses MemorySpaceKind.

--- a/include/hip/Dialect/Hipsr/IR/HipsrDialect.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrDialect.td
@@ -35,10 +35,6 @@ def Hipsr_Dialect : Dialect {
     /// Non-owning; the compile driver injects the same FileSystem it hands the
     /// hip.* pipeline. Null when nobody injected one (e.g. hip-mlir-opt), in
     /// which case the pass writes no sidecar (pure IR transform).
-    ///
-    /// Not synchronized: inject once before scheduling passes; passes only read
-    /// it. (Unlike the file-map cache above, this sink has no mutex, which is
-    /// safe only under that inject-before-run contract.)
     void setFileSystem(::morphizen::FileSystem *fs) { fileSystem = fs; }
     ::morphizen::FileSystem *getFileSystem() { return fileSystem; }
 

--- a/include/hip/Dialect/Hipsr/IR/HipsrDialect.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrDialect.td
@@ -31,9 +31,21 @@ def Hipsr_Dialect : Dialect {
     /// multi-threaded, so the cache is guarded by a mutex.
     ::llvm::MemoryBuffer *getOrLoadFileMap(::llvm::StringRef path);
 
+    /// Sink for the constants sidecar written by -hipsr-externalize-constants.
+    /// Non-owning; the compile driver injects the same FileSystem it hands the
+    /// hip.* pipeline. Null when nobody injected one (e.g. hip-mlir-opt), in
+    /// which case the pass writes no sidecar (pure IR transform).
+    ///
+    /// Not synchronized: inject once before scheduling passes; passes only read
+    /// it. (Unlike the file-map cache above, this sink has no mutex, which is
+    /// safe only under that inject-before-run contract.)
+    void setFileSystem(::morphizen::FileSystem *fs) { fileSystem = fs; }
+    ::morphizen::FileSystem *getFileSystem() { return fileSystem; }
+
   private:
     ::llvm::StringMap<std::unique_ptr<::llvm::MemoryBuffer>> fileMaps;
     std::mutex fileMapsMutex;
+    ::morphizen::FileSystem *fileSystem = nullptr;
   }];
 }
 

--- a/include/hip/Dialect/Hipsr/Transforms/Passes.td
+++ b/include/hip/Dialect/Hipsr/Transforms/Passes.td
@@ -39,4 +39,43 @@ def PopulateShapeRegionPass
   ];
 }
 
+def HipsrExternalizeConstantsPass
+    : Pass<"hipsr-externalize-constants", "mlir::ModuleOp"> {
+  let summary = "Write hipsr.constant data to a sidecar and mark offset/size";
+  let description = [{
+    Phase 2 of the hipsr constant subsystem. Runs in two stages:
+
+    Phase 1 (always): walk every `hipsr.constant` in the module (across all
+    functions) that opts in (`shouldExternalize()` is true) and is not already
+    externalized; assign a 64-byte aligned cumulative offset and stamp the op
+    with `offset`/`size`.
+
+    Module-scoped by design: offsets accumulate into a single sidecar shared by
+    the whole module, so the pass must see every constant at once. A per-function
+    pass would restart offsets at 0 per function (overlapping placements) and
+    write the shared file once per function (races / last-writer-wins).
+    Append-only -- `value`/`source` are kept, so `getDataValues()` still works
+    afterward. Builds one `hip::ConstantEntry` per constant (file_source keeps
+    its path/offset with no byte read; inline/mem_source keep a byte view).
+
+    Phase 2 (only when a FileSystem is injected on the HipsrDialect via
+    `setFileSystem`): write the entries through
+    `writeConstantsBinToFileSystem`, so file-ref weights stream on demand and
+    are never mmap'd. When no FileSystem is injected (e.g. hip-mlir-opt) the
+    pass is a pure IR transform (no file written).
+
+    Constants with `externalize = false` and ones already externalized are
+    skipped. This pass emits no module-level descriptor arrays; runtime
+    metadata generation is a separate follow-up.
+  }];
+  let options = [
+    Option<"constantsFile", "constants-file", "std::string",
+           /*default=*/"\"constants.bin\"",
+           "Sidecar file name written through the injected FileSystem">
+  ];
+  let dependentDialects = [
+    "::mlir::hipsr::HipsrDialect"
+  ];
+}
+
 #endif // HIPSR_TRANSFORMS_PASSES

--- a/include/hip/Dialect/Hipsr/Transforms/Passes.td
+++ b/include/hip/Dialect/Hipsr/Transforms/Passes.td
@@ -60,13 +60,12 @@ def HipsrExternalizeConstantsPass
 
     Phase 2 (only when a FileSystem is injected on the HipsrDialect via
     `setFileSystem`): write the entries through
-    `writeConstantsBinToFileSystem`, so file-ref weights stream on demand and
-    are never mmap'd. When no FileSystem is injected (e.g. hip-mlir-opt) the
-    pass is a pure IR transform (no file written).
+    `writeConstantsBinToFileSystem`. When no FileSystem is injected (e.g.
+    hip-mlir-opt) the pass is a pure IR transform (no file written).
 
     Constants with `externalize = false` and ones already externalized are
-    skipped. This pass emits no module-level descriptor arrays; runtime
-    metadata generation is a separate follow-up.
+    skipped. This pass emits no module attributes; runtime metadata generation
+    is a separate follow-up.
   }];
   let options = [
     Option<"constantsFile", "constants-file", "std::string",

--- a/include/hip/InitAllPasses.h
+++ b/include/hip/InitAllPasses.h
@@ -137,7 +137,8 @@ inline void registerAllPasses() {
   mlir::hip::registerHipPasses();
   mlir::hip::registerHipPipelines();
 
-  // hipsr dialect transform passes (TableGen GEN_PASS_REGISTRATION)
+  // hipsr dialect transform passes (TableGen GEN_PASS_REGISTRATION):
+  // hipsr-populate-shape-region, hipsr-externalize-constants, ...
   mlir::hipsr::registerHipsrPasses();
 
   // Conversion passes (convert-onnx-to-hip, outline-onnx-to-hipdnn,

--- a/include/hip/Support/ConstantsIO.h
+++ b/include/hip/Support/ConstantsIO.h
@@ -5,15 +5,11 @@
 
 // Shared emit logic for the constants.bin sidecar.
 //
-// Multiple constant-externalization producers write the same constants.bin
-// layout: the ONNX->HIP conversion pass (standalone hip-compiler offline
-// path), the MorphiZen EP level-1 pass (EPContext export path), and the
-// hipsr-externalize-constants pass. This header provides a single
-// implementation they call, preserving the streaming-with-1MB-tile pattern for
-// splat constants so no full-size expansion buffer is allocated during write.
-//
-// Lives under Support (not any one conversion) because it is shared
-// infrastructure independent of the hip.* / hipsr.* pipeline lifetimes.
+// Both the ONNX->HIP conversion pass (standalone hip-compiler offline path)
+// and the MorphiZen EP level-1 pass (EPContext export path) produce the same
+// constants.bin layout. This header provides a single implementation they
+// call, preserving the streaming-with-1MB-tile pattern for splat constants so
+// no full-size expansion buffer is allocated during write.
 
 #ifndef HIP_SUPPORT_CONSTANTSIO_H
 #define HIP_SUPPORT_CONSTANTSIO_H

--- a/include/hip/Support/ConstantsIO.h
+++ b/include/hip/Support/ConstantsIO.h
@@ -5,14 +5,18 @@
 
 // Shared emit logic for the constants.bin sidecar.
 //
-// Both the ONNX->HIP conversion pass (standalone hip-compiler offline path)
-// and the MorphiZen EP level-1 pass (EPContext export path) produce the same
-// constants.bin layout. This header provides a single implementation they
-// call, preserving the streaming-with-1MB-tile pattern for splat constants so
-// no full-size expansion buffer is allocated during write.
+// Multiple constant-externalization producers write the same constants.bin
+// layout: the ONNX->HIP conversion pass (standalone hip-compiler offline
+// path), the MorphiZen EP level-1 pass (EPContext export path), and the
+// hipsr-externalize-constants pass. This header provides a single
+// implementation they call, preserving the streaming-with-1MB-tile pattern for
+// splat constants so no full-size expansion buffer is allocated during write.
+//
+// Lives under Support (not any one conversion) because it is shared
+// infrastructure independent of the hip.* / hipsr.* pipeline lifetimes.
 
-#ifndef HIP_CONVERSION_ONNXTOHIP_CONSTANTSIO_H
-#define HIP_CONVERSION_ONNXTOHIP_CONSTANTSIO_H
+#ifndef HIP_SUPPORT_CONSTANTSIO_H
+#define HIP_SUPPORT_CONSTANTSIO_H
 
 #include <cstdint>
 #include <string>
@@ -68,4 +72,4 @@ bool writeConstantsBinToFileSystem(morphizen::FileSystem *fs,
 } // namespace hip
 } // namespace mlir
 
-#endif // HIP_CONVERSION_ONNXTOHIP_CONSTANTSIO_H
+#endif // HIP_SUPPORT_CONSTANTSIO_H

--- a/lib/Conversion/OnnxToHip/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHip/CMakeLists.txt
@@ -6,7 +6,6 @@
 add_library(OnnxToHip STATIC
   OnnxToHip.cpp
   SimplifyOnnx.cpp
-  ConstantsIO.cpp
   MatMulConversion.cpp
   TransposeConversion.cpp
   ElementwiseConversion.cpp
@@ -88,6 +87,7 @@ add_dependencies(OnnxToHip
 
 target_link_libraries(OnnxToHip PUBLIC
   HipDialectIR
+  HipConstantsIO
   MLIRPass
   MLIRFuncDialect
   MLIRArithDialect

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -13,7 +13,7 @@
 
 #include "OnnxToHipUtils.h"
 
-#include "hip/Conversion/OnnxToHip/ConstantsIO.h"
+#include "hip/Support/ConstantsIO.h"
 #include "hip/Support/DiskFileSystem.h"
 #include "hip/timing.h"
 #include "morphizen-foundation/file_io.hpp"

--- a/lib/Dialect/Hipsr/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Hipsr/Transforms/CMakeLists.txt
@@ -4,6 +4,7 @@
 ##
 
 add_library(HipsrDialectTransforms STATIC
+  ExternalizeConstants.cpp
   PopulateShapeRegionPass.cpp
 )
 
@@ -14,9 +15,12 @@ add_dependencies(HipsrDialectTransforms
 
 target_link_libraries(HipsrDialectTransforms PUBLIC
   HipsrDialectIR
-  MLIRIR
+  HipConstantsIO  # writeConstantsBinToFileSystem / ConstantEntry
   MLIRPass
+  MLIRTransforms
   MLIRFuncDialect
   MLIRArithDialect
   MLIRShapeDialect
+  MLIRIR
+  MLIRSupport
 )

--- a/lib/Dialect/Hipsr/Transforms/ExternalizeConstants.cpp
+++ b/lib/Dialect/Hipsr/Transforms/ExternalizeConstants.cpp
@@ -12,9 +12,9 @@
 //   Phase 2 (only when a FileSystem is injected on the dialect): write the
 //     entries to the sidecar via writeConstantsBinToFileSystem.
 //
-// file_source entries carry their file_path/offset only (data = nullptr); the
-// writer streams them on demand, so the weight file is never mmap'd here.
-// inline / mem_source entries carry a byte view (getDataValues). See Passes.td.
+// file_source entries carry their file_path/offset only (data = nullptr) so
+// this pass does not read the weight file; inline / mem_source entries carry a
+// byte view (getDataValues). See Passes.td.
 //
 //===----------------------------------------------------------------------===//
 
@@ -69,8 +69,8 @@ struct HipsrExternalizeConstantsPass
       int64_t size = 0;
       if (auto fileSrc =
               llvm::dyn_cast_or_null<FileSourceAttr>(c.getSourceAttr())) {
-        // File-ref: keep the on-disk reference; the writer streams it on
-        // demand, so we never mmap the (possibly multi-GB) weight file here.
+        // File-ref: keep the on-disk reference (path/offset); this pass does
+        // not read the (possibly multi-GB) weight file.
         entry.file_path = fileSrc.getPath().getValue().str();
         entry.file_offset = fileSrc.getOffset();
         size = fileSrc.getSize();

--- a/lib/Dialect/Hipsr/Transforms/ExternalizeConstants.cpp
+++ b/lib/Dialect/Hipsr/Transforms/ExternalizeConstants.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- ExternalizeConstants.cpp - hipsr.constant -> sidecar --------------===//
+//
+// Phase 2 of the hipsr constant subsystem. Two stages inside one pass:
+//
+//   Phase 1 (always): walk each opted-in hipsr.constant, assign a 64-byte
+//     aligned cumulative offset, and stamp offset/size on the op (append-only
+//     -- value/source are kept). Builds one hip::ConstantEntry per constant.
+//   Phase 2 (only when a FileSystem is injected on the dialect): write the
+//     entries to the sidecar via writeConstantsBinToFileSystem.
+//
+// file_source entries carry their file_path/offset only (data = nullptr); the
+// writer streams them on demand, so the weight file is never mmap'd here.
+// inline / mem_source entries carry a byte view (getDataValues). See Passes.td.
+//
+//===----------------------------------------------------------------------===//
+
+#include "hip/Dialect/Hipsr/Transforms/Passes.h"
+
+#include "hip/Dialect/Hipsr/IR/HipsrConstantOp.h"
+#include "hip/Dialect/Hipsr/IR/HipsrDialect.h"
+#include "hip/Support/ConstantsIO.h"
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+
+#include "llvm/Support/MathExtras.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace mlir {
+namespace hipsr {
+
+#define GEN_PASS_DEF_HIPSREXTERNALIZECONSTANTSPASS
+#include "hip/Dialect/Hipsr/Transforms/Passes.h.inc"
+
+namespace {
+
+// Sidecar alignment: every constant starts on a 64-byte boundary (GPU
+// alignment; matches the hip.* sidecar layout).
+constexpr int64_t kConstantAlignment = 64;
+
+struct HipsrExternalizeConstantsPass
+    : impl::HipsrExternalizeConstantsPassBase<HipsrExternalizeConstantsPass> {
+  using impl::HipsrExternalizeConstantsPassBase<
+      HipsrExternalizeConstantsPass>::HipsrExternalizeConstantsPassBase;
+
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    MLIRContext *ctx = &getContext();
+    Builder builder(ctx);
+
+    // Phase 1: collect entries and stamp offset/size across the whole module.
+    // Module-scoped so a single cumulative offset feeds one shared sidecar
+    // (see Passes.td). Independent of the FileSystem so the IR transform is
+    // deterministic with or without a sink.
+    std::vector<hip::ConstantEntry> entries;
+    int64_t filePos = 0;
+    module.walk([&](ConstantOp c) {
+      if (!c.shouldExternalize() || c.isExternalized()) {
+        return;
+      }
+
+      hip::ConstantEntry entry;
+      int64_t size = 0;
+      if (auto fileSrc =
+              llvm::dyn_cast_or_null<FileSourceAttr>(c.getSourceAttr())) {
+        // File-ref: keep the on-disk reference; the writer streams it on
+        // demand, so we never mmap the (possibly multi-GB) weight file here.
+        entry.file_path = fileSrc.getPath().getValue().str();
+        entry.file_offset = fileSrc.getOffset();
+        size = fileSrc.getSize();
+      } else {
+        // inline value or mem_source: a byte view. getDataValues does not read
+        // the bytes here (it only forms the pointer/size); the writer reads
+        // them in Phase 2.
+        llvm::ArrayRef<uint8_t> bytes = c.getDataValues<uint8_t>();
+        entry.data = bytes.data();
+        size = static_cast<int64_t>(bytes.size());
+      }
+
+      int64_t offset = llvm::alignTo(filePos, kConstantAlignment);
+      entry.offset = offset;
+      entry.size = size;
+      entry.splat_elem_size = 0; // MorphiZen never emits splat constants.
+
+      c.setOffsetAttr(builder.getI64IntegerAttr(offset));
+      c.setSizeAttr(builder.getI64IntegerAttr(size));
+      filePos = offset + size;
+
+      entries.push_back(std::move(entry));
+    });
+
+    // Phase 2: write the sidecar, only when a FileSystem was injected (e.g. by
+    // the compile driver). Standalone runs (hip-mlir-opt) inject none, so the
+    // pass is a pure IR transform there.
+    morphizen::FileSystem *fs = nullptr;
+    if (auto *dialect = ctx->getLoadedDialect<HipsrDialect>()) {
+      fs = dialect->getFileSystem();
+    }
+    if (fs && !entries.empty()) {
+      if (!hip::writeConstantsBinToFileSystem(
+              fs, constantsFile, entries,
+              llvm::alignTo(filePos, kConstantAlignment))) {
+        module.emitError("failed to write constants sidecar: ")
+            << constantsFile;
+        signalPassFailure();
+      }
+    }
+  }
+};
+
+} // namespace
+
+} // namespace hipsr
+} // namespace mlir

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -10,3 +10,12 @@ target_include_directories(HipSupport PUBLIC
 )
 
 target_link_libraries(HipSupport PUBLIC cpptrace::cpptrace)
+
+# Shared constants.bin sidecar I/O. Its own target (not folded into any
+# conversion) so producers -- OnnxToHip, the MorphiZen EP, hipsr-externalize-
+# constants -- depend on this rather than on each other's pipeline libs.
+add_library(HipConstantsIO STATIC ConstantsIO.cpp)
+
+target_include_directories(HipConstantsIO PRIVATE
+  ${CMAKE_SOURCE_DIR}/morphizen/morphizen-foundation/include  # file_io.hpp
+)

--- a/lib/Support/ConstantsIO.cpp
+++ b/lib/Support/ConstantsIO.cpp
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-#include "hip/Conversion/OnnxToHip/ConstantsIO.h"
+#include "hip/Support/ConstantsIO.h"
 #include "morphizen-foundation/file_io.hpp"
 
 #include <algorithm>

--- a/test/lit/Dialect/Hipsr/test_externalize_constants.mlir
+++ b/test/lit/Dialect/Hipsr/test_externalize_constants.mlir
@@ -1,0 +1,94 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+// Tests -hipsr-externalize-constants (Phase 2). The pass assigns each opted-in
+// hipsr.constant a 64-byte aligned cumulative sidecar offset and stamps
+// offset/size on the op, append-only (value/source are kept). No FileSystem is
+// injected in these runs, so the sidecar write (Phase 2) is skipped and the
+// pass is a pure IR transform -- which is what lets these cases be checked
+// without any on-disk file.
+//
+// One case per distinct behavior (no source-kind duplication: file_source and
+// mem_source produce the same observable IR, so only file_source is checked):
+//   1. inline value        -> offset/size added, value kept
+//   2. file_source         -> offset/size added, source kept (size from attr)
+//   3. two constants       -> offsets are cumulative and 64-byte aligned
+//   4. externalize = false -> opted out, untouched
+//   5. already externalized -> skipped, not re-stamped (idempotent)
+
+// RUN: hip-mlir-opt --hipsr-externalize-constants %s -split-input-file | FileCheck %s
+
+// -----
+// Inline value: byte size (4 x f32 = 16) recorded at offset 0, value retained.
+
+// CHECK-LABEL: func.func @inline_value
+// CHECK: hipsr.constant {offset = 0 : i64, size = 16 : i64, value = dense<[1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00]> : tensor<4xf32>} : tensor<4xf32>
+func.func @inline_value() -> tensor<4xf32> {
+  %0 = hipsr.constant {value = dense<[1.0, 2.0, 3.0, 4.0]> : tensor<4xf32>} : tensor<4xf32>
+  return %0 : tensor<4xf32>
+}
+
+// -----
+// File-backed source: size is taken from the attr (the file is never read),
+// and the source attr is preserved alongside the new offset/size.
+
+// CHECK-LABEL: func.func @file_source
+// CHECK: hipsr.constant {offset = 0 : i64, size = 1000 : i64, source = #hipsr.file_source<"w.bin", 100, 1000>} : tensor<100xf32>
+func.func @file_source() -> tensor<100xf32> {
+  %0 = hipsr.constant {source = #hipsr.file_source<"w.bin", 100, 1000>} : tensor<100xf32>
+  return %0 : tensor<100xf32>
+}
+
+// -----
+// Cumulative placement: the first constant occupies [0, 1000); the second is
+// padded up to the next 64-byte boundary (1024), proving alignment + running
+// offset across constants.
+
+// CHECK-LABEL: func.func @cumulative_alignment
+// CHECK: hipsr.constant {offset = 0 : i64, size = 1000 : i64, source = #hipsr.file_source<"w.bin", 0, 1000>} : tensor<250xf32>
+// CHECK: hipsr.constant {offset = 1024 : i64, size = 8 : i64, value = dense<[5.000000e+00, 6.000000e+00]> : tensor<2xf32>} : tensor<2xf32>
+func.func @cumulative_alignment() -> (tensor<250xf32>, tensor<2xf32>) {
+  %0 = hipsr.constant {source = #hipsr.file_source<"w.bin", 0, 1000>} : tensor<250xf32>
+  %1 = hipsr.constant {value = dense<[5.0, 6.0]> : tensor<2xf32>} : tensor<2xf32>
+  return %0, %1 : tensor<250xf32>, tensor<2xf32>
+}
+
+// -----
+// Module-scoped: the pass runs on the whole module, so offsets accumulate
+// across functions (the second func's constant lands after the first, aligned)
+// rather than restarting at 0 per function.
+
+// CHECK-LABEL: func.func @first
+// CHECK: hipsr.constant {offset = 0 : i64, size = 1000 : i64, source = #hipsr.file_source<"w.bin", 0, 1000>} : tensor<250xf32>
+// CHECK-LABEL: func.func @second
+// CHECK: hipsr.constant {offset = 1024 : i64, size = 8 : i64, value = dense<[7.000000e+00, 8.000000e+00]> : tensor<2xf32>} : tensor<2xf32>
+func.func @first() -> tensor<250xf32> {
+  %0 = hipsr.constant {source = #hipsr.file_source<"w.bin", 0, 1000>} : tensor<250xf32>
+  return %0 : tensor<250xf32>
+}
+func.func @second() -> tensor<2xf32> {
+  %0 = hipsr.constant {value = dense<[7.0, 8.0]> : tensor<2xf32>} : tensor<2xf32>
+  return %0 : tensor<2xf32>
+}
+
+// -----
+// Opt-out: externalize = false is left exactly as-is (no offset/size added).
+
+// CHECK-LABEL: func.func @opt_out
+// CHECK: hipsr.constant {externalize = false, value = dense<{{.*}}> : tensor<4xf32>} : tensor<4xf32>
+// CHECK-NOT: offset
+func.func @opt_out() -> tensor<4xf32> {
+  %0 = hipsr.constant {externalize = false, value = dense<[1.0, 2.0, 3.0, 4.0]> : tensor<4xf32>} : tensor<4xf32>
+  return %0 : tensor<4xf32>
+}
+
+// -----
+// Idempotent: an already-externalized constant (offset present) is skipped, so
+// its pre-existing offset survives instead of being recomputed to 0.
+
+// CHECK-LABEL: func.func @already_externalized
+// CHECK: hipsr.constant {offset = 999 : i64, size = 16 : i64, value = dense<{{.*}}> : tensor<4xf32>} : tensor<4xf32>
+func.func @already_externalized() -> tensor<4xf32> {
+  %0 = hipsr.constant {value = dense<[1.0, 2.0, 3.0, 4.0]> : tensor<4xf32>, offset = 999 : i64, size = 16 : i64} : tensor<4xf32>
+  return %0 : tensor<4xf32>
+}

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1,0 +1,43 @@
+##
+# ** Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# ** Licensed under the MIT License.
+##
+
+#=============================================================================
+# MLIR dialect/pass unit tests (GPU-free).
+#=============================================================================
+# Cover behavior that LIT cannot: here -hipsr-externalize-constants runs with an
+# injected in-memory FileSystem so the Phase 2 sidecar write (and the bytes it
+# emits) can be asserted, which hip-mlir-opt (no FileSystem) cannot exercise.
+# Plain main() (no GTest), matching the other MLIR-side unit tests.
+
+message(STATUS "Configuring MLIR dialect/pass unit tests")
+
+add_executable(test-hipsr-externalize-constants test_externalize_constants.cpp)
+
+target_compile_features(test-hipsr-externalize-constants PRIVATE cxx_std_17)
+
+target_include_directories(test-hipsr-externalize-constants PRIVATE
+  ${MLIR_INCLUDE_DIRS}
+  ${LLVM_INCLUDE_DIRS}
+  ${CMAKE_SOURCE_DIR}/morphizen/morphizen-foundation/include  # file_io.hpp
+)
+
+target_link_libraries(test-hipsr-externalize-constants PRIVATE
+  HipsrDialectTransforms
+  HipsrDialectIR
+  HipConstantsIO
+  MLIRIR
+  MLIRParser
+  MLIRPass
+  MLIRFuncDialect
+  MLIRSupport
+)
+
+add_test(NAME HipsrExternalizeConstantsUnit
+  COMMAND test-hipsr-externalize-constants
+)
+
+set_target_properties(test-hipsr-externalize-constants PROPERTIES
+  FOLDER "mlir/Test/Dialect/Hipsr"
+)

--- a/test/unit/test_externalize_constants.cpp
+++ b/test/unit/test_externalize_constants.cpp
@@ -262,8 +262,8 @@ void testMemSourceBytesWritten() {
         "mem_source: blob bytes copied from address");
 }
 
-// file_source: the writer streams the bytes from the referenced file at the
-// given offset (never mmap'd by the pass). Covers the file-ref branch.
+// file_source: the sidecar bytes come from the referenced file at the given
+// offset. Covers the file-ref branch.
 void testFileSourceBytesStreamed() {
   auto path = std::filesystem::temp_directory_path() /
               "hipsr_externalize_test_weights.bin";

--- a/test/unit/test_externalize_constants.cpp
+++ b/test/unit/test_externalize_constants.cpp
@@ -1,0 +1,531 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// Unit test for -hipsr-externalize-constants that exercises Phase 2 (the
+// sidecar write), which the LIT tests cannot: LIT runs hip-mlir-opt with no
+// injected FileSystem, so it only sees the Phase 1 IR mutation (offset/size).
+// Here we inject an in-memory FileSystem and assert the actual bytes written --
+// the only way to catch entry-field bugs (e.g. file_source vs inline routing)
+// that are invisible in the IR because they produce identical offset/size.
+//
+// Plain main() (no GTest): matches the other MLIR-side unit tests and avoids a
+// GTest dependency that is not present in the compiler build.
+
+#include "hip/Dialect/Hipsr/IR/HipsrConstantOp.h"
+#include "hip/Dialect/Hipsr/IR/HipsrDialect.h"
+#include "hip/Dialect/Hipsr/Transforms/Passes.h"
+#include "hip/Support/DiskFileSystem.h"
+
+#include "morphizen-foundation/file_io.hpp"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Parser/Parser.h"
+#include "mlir/Pass/PassManager.h"
+
+#include "llvm/Support/MathExtras.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool cond, llvm::StringRef what) {
+  if (cond) {
+    llvm::outs() << "[ OK ] " << what << "\n";
+  } else {
+    llvm::errs() << "[FAIL] " << what << "\n";
+    ++g_failures;
+  }
+}
+
+// Seeks to `offset` in `file` and reads `size` bytes back -- an fseek
+// round-trip used to verify that each constant's data really lives at the
+// offset stamped on its op. Returns empty on short read / seek failure.
+std::vector<char> readAt(const std::filesystem::path &file, int64_t offset,
+                         int64_t size) {
+  std::ifstream ifs(file, std::ios::binary);
+  ifs.seekg(offset);
+  std::vector<char> buf(static_cast<size_t>(size));
+  ifs.read(buf.data(), size);
+  if (!ifs || ifs.gcount() != size) {
+    return {};
+  }
+  return buf;
+}
+
+// Verifies an in-memory sidecar `blob` against the ops (in walk order) and
+// their expected bytes, driven by the offset/size stamped on each op: the data
+// at each stamped offset must be that constant's bytes, sizes must match,
+// offsets must be 64-aligned / monotonic / non-overlapping, gap and trailing
+// bytes zero, and the total length the aligned end of the last constant.
+void verifyLayout(const std::vector<char> &blob,
+                  const std::vector<mlir::hipsr::ConstantOp> &ops,
+                  const std::vector<std::vector<char>> &expected,
+                  const std::string &label) {
+  check(ops.size() == expected.size(), label + ": constant count");
+  if (ops.size() != expected.size()) {
+    return;
+  }
+
+  int64_t prevEnd = 0, lastOffset = 0, lastSize = 0;
+  bool layout = true, bytes = true, len = true, gaps = true;
+  for (size_t i = 0; i < ops.size(); ++i) {
+    mlir::hipsr::ConstantOp c = ops[i];
+    if (!c.getOffsetAttr() || !c.getSizeAttr()) {
+      layout = false;
+      break;
+    }
+    int64_t off = c.getOffsetAttr().getInt();
+    int64_t sz = c.getSizeAttr().getInt();
+
+    if (sz != static_cast<int64_t>(expected[i].size())) {
+      len = false;
+    }
+    if (off % 64 != 0 || off < prevEnd) {
+      layout = false;
+    }
+    for (int64_t g = prevEnd; g < off && g < static_cast<int64_t>(blob.size());
+         ++g) {
+      if (blob[g] != 0) {
+        gaps = false;
+      }
+    }
+    if (off + sz <= static_cast<int64_t>(blob.size())) {
+      std::vector<char> slice(blob.begin() + off, blob.begin() + off + sz);
+      if (slice != expected[i]) {
+        bytes = false;
+      }
+    } else {
+      bytes = false;
+    }
+    prevEnd = off + sz;
+    lastOffset = off;
+    lastSize = sz;
+  }
+  for (int64_t g = prevEnd; g < static_cast<int64_t>(blob.size()); ++g) {
+    if (blob[g] != 0) {
+      gaps = false;
+    }
+  }
+
+  check(len, label + ": each stamped size == data length");
+  check(layout, label + ": offsets 64-aligned, monotonic, non-overlapping");
+  check(bytes, label + ": data at each stamped offset matches");
+  check(gaps, label + ": gap and trailing bytes are zero");
+  check(static_cast<int64_t>(blob.size()) ==
+            llvm::alignTo(lastOffset + lastSize, 64),
+        label + ": blob length == aligned total");
+}
+
+// FileSystem that captures every write into an in-memory buffer per filename,
+// so a test can inspect the exact sidecar bytes. create_reader is unused --
+// writeConstantsBinToFileSystem reads file_source data via std::fopen on the
+// file path directly, not through the FileSystem.
+class CapturingFileSystem : public morphizen::FileSystem {
+public:
+  class Writer : public morphizen::FileWriter {
+  public:
+    explicit Writer(std::vector<char> *buf) : buf_(buf) {}
+    std::size_t fwrite(const void *data, std::size_t size) const override {
+      const char *p = static_cast<const char *>(data);
+      buf_->insert(buf_->end(), p, p + size);
+      return size;
+    }
+
+  private:
+    std::vector<char> *buf_;
+  };
+
+  morphizen::FileReader *create_reader(const char *) override {
+    return nullptr;
+  }
+  morphizen::FileWriter *create_writer(const char *path) override {
+    return new Writer(&files[path]);
+  }
+  void destroy_reader(morphizen::FileReader *r) override { delete r; }
+  void destroy_writer(morphizen::FileWriter *w) override { delete w; }
+
+  std::map<std::string, std::vector<char>> files;
+};
+
+// FileSystem whose writer can never be created, to drive the failure path.
+class FailingFileSystem : public morphizen::FileSystem {
+public:
+  morphizen::FileReader *create_reader(const char *) override {
+    return nullptr;
+  }
+  morphizen::FileWriter *create_writer(const char *) override {
+    return nullptr;
+  }
+  void destroy_reader(morphizen::FileReader *) override {}
+  void destroy_writer(morphizen::FileWriter *) override {}
+};
+
+// Loads the parsed dialects, injects `fs`, runs the pass. Returns the module
+// and sets `ok` to whether the pass succeeded.
+struct Harness {
+  mlir::MLIRContext ctx;
+
+  Harness() {
+    ctx.loadDialect<mlir::hipsr::HipsrDialect, mlir::func::FuncDialect>();
+  }
+
+  mlir::OwningOpRef<mlir::ModuleOp> run(const std::string &ir,
+                                        morphizen::FileSystem *fs, bool &ok) {
+    auto module = mlir::parseSourceString<mlir::ModuleOp>(ir, &ctx);
+    if (!module) {
+      llvm::errs() << "failed to parse IR\n";
+      ok = false;
+      return module;
+    }
+    ctx.getLoadedDialect<mlir::hipsr::HipsrDialect>()->setFileSystem(fs);
+
+    mlir::PassManager pm(&ctx);
+    pm.addPass(mlir::hipsr::createHipsrExternalizeConstantsPass());
+    ok = mlir::succeeded(pm.run(*module));
+    return module;
+  }
+};
+
+// Inline value: the raw dense bytes land in the sidecar at offset 0, and the op
+// is stamped with that offset/size.
+void testInlineValueBytesWritten() {
+  Harness h;
+  CapturingFileSystem fs;
+  bool ok = false;
+  auto module = h.run(R"mlir(
+    func.func @f() -> tensor<4xi8> {
+      %0 = hipsr.constant {value = dense<[10, 20, 30, 40]> : tensor<4xi8>} : tensor<4xi8>
+      return %0 : tensor<4xi8>
+    }
+  )mlir",
+                      &fs, ok);
+  check(ok, "inline: pass succeeds");
+  if (!ok || !module) {
+    return;
+  }
+
+  mlir::hipsr::ConstantOp c;
+  module->walk([&](mlir::hipsr::ConstantOp op) { c = op; });
+  check(c && c.getOffsetAttr() && c.getOffsetAttr().getInt() == 0,
+        "inline: offset == 0");
+  check(c && c.getSizeAttr() && c.getSizeAttr().getInt() == 4,
+        "inline: size == 4");
+
+  // The blob is padded up to the 64-byte aligned total, so 4 data bytes at the
+  // start followed by zeros.
+  const std::vector<char> &blob = fs.files["constants.bin"];
+  check(blob.size() == 64, "inline: blob padded to 64");
+  check(blob.size() == 64 && static_cast<uint8_t>(blob[0]) == 10 &&
+            static_cast<uint8_t>(blob[3]) == 40 &&
+            static_cast<uint8_t>(blob[4]) == 0,
+        "inline: blob bytes match dense value, rest zero");
+}
+
+// mem_source: the writer must copy the bytes at the raw address (entry.data),
+// not treat it as a file. Covers the getDataValues mem-pointer branch.
+void testMemSourceBytesWritten() {
+  std::vector<uint8_t> host = {50, 60, 70};
+  auto addr = reinterpret_cast<uintptr_t>(host.data());
+
+  Harness h;
+  CapturingFileSystem fs;
+  bool ok = false;
+  auto module = h.run("func.func @f() -> tensor<3xi8> {\n"
+                      "  %0 = hipsr.constant {source = #hipsr.mem_source<" +
+                          std::to_string(addr) +
+                          ", 3>} : tensor<3xi8>\n"
+                          "  return %0 : tensor<3xi8>\n"
+                          "}\n",
+                      &fs, ok);
+  check(ok, "mem_source: pass succeeds");
+  if (!ok) {
+    return;
+  }
+
+  const std::vector<char> &blob = fs.files["constants.bin"];
+  check(blob.size() == 64, "mem_source: blob padded to 64");
+  check(blob.size() == 64 && static_cast<uint8_t>(blob[0]) == 50 &&
+            static_cast<uint8_t>(blob[2]) == 70,
+        "mem_source: blob bytes copied from address");
+}
+
+// file_source: the writer streams the bytes from the referenced file at the
+// given offset (never mmap'd by the pass). Covers the file-ref branch.
+void testFileSourceBytesStreamed() {
+  auto path = std::filesystem::temp_directory_path() /
+              "hipsr_externalize_test_weights.bin";
+  {
+    std::ofstream ofs(path, std::ios::binary);
+    const char bytes[] = {1, 2, 3, 4, 5};
+    ofs.write(bytes, sizeof(bytes));
+  }
+
+  Harness h;
+  CapturingFileSystem fs;
+  bool ok = false;
+  auto module = h.run("func.func @f() -> tensor<5xi8> {\n"
+                      "  %0 = hipsr.constant {source = #hipsr.file_source<\"" +
+                          path.generic_string() +
+                          "\", 0, 5>} : tensor<5xi8>\n"
+                          "  return %0 : tensor<5xi8>\n"
+                          "}\n",
+                      &fs, ok);
+  check(ok, "file_source: pass succeeds");
+
+  const std::vector<char> &blob = fs.files["constants.bin"];
+  check(blob.size() == 64, "file_source: blob padded to 64");
+  check(blob.size() == 64 && static_cast<uint8_t>(blob[0]) == 1 &&
+            static_cast<uint8_t>(blob[4]) == 5,
+        "file_source: blob bytes streamed from file");
+
+  std::filesystem::remove(path);
+}
+
+// Two constants: the second is padded to the next 64-byte boundary, and the
+// blob is padded up to the aligned total. Checks alignment + gap/trailing
+// zeros.
+void testCumulativeAlignmentAndPadding() {
+  Harness h;
+  CapturingFileSystem fs;
+  bool ok = false;
+  // Non-splat values: getDataValues is a MorphiZen-only contract that does not
+  // support splat-optimized DenseElementsAttr, so use distinct bytes.
+  auto module = h.run(R"mlir(
+    func.func @f() -> (tensor<4xi8>, tensor<8xi8>) {
+      %0 = hipsr.constant {value = dense<[1, 2, 3, 4]> : tensor<4xi8>} : tensor<4xi8>
+      %1 = hipsr.constant {value = dense<[5, 6, 7, 8, 9, 10, 11, 12]> : tensor<8xi8>} : tensor<8xi8>
+      return %0, %1 : tensor<4xi8>, tensor<8xi8>
+    }
+  )mlir",
+                      &fs, ok);
+  check(ok, "cumulative: pass succeeds");
+  if (!ok || !module) {
+    return;
+  }
+
+  std::vector<mlir::hipsr::ConstantOp> ops;
+  module->walk([&](mlir::hipsr::ConstantOp c) { ops.push_back(c); });
+  std::vector<std::vector<char>> expected = {
+      {1, 2, 3, 4},
+      {5, 6, 7, 8, 9, 10, 11, 12},
+  };
+  // Offset-driven: verifies the data sits at the stamped offset (0 then aligned
+  // 64), gap/trailing zeros, and total length alignTo(72, 64) = 128.
+  verifyLayout(fs.files["constants.bin"], ops, expected, "cumulative");
+}
+
+// Multiple functions in one module share a single cumulative offset and a
+// single sidecar write. This is the module-scoped contract: a per-function pass
+// would restart offsets at 0 and overwrite the file per function.
+void testMultiFunctionSharesOneSidecar() {
+  Harness h;
+  CapturingFileSystem fs;
+  bool ok = false;
+  auto module = h.run(R"mlir(
+    func.func @a() -> tensor<4xi8> {
+      %0 = hipsr.constant {value = dense<[1, 2, 3, 4]> : tensor<4xi8>} : tensor<4xi8>
+      return %0 : tensor<4xi8>
+    }
+    func.func @b() -> tensor<8xi8> {
+      %0 = hipsr.constant {value = dense<[5, 6, 7, 8, 9, 10, 11, 12]> : tensor<8xi8>} : tensor<8xi8>
+      return %0 : tensor<8xi8>
+    }
+  )mlir",
+                      &fs, ok);
+  check(ok, "multi-func: pass succeeds");
+  if (!ok || !module) {
+    return;
+  }
+
+  // One shared file with both functions' constants, not one overwrite per
+  // function.
+  check(fs.files.size() == 1, "multi-func: exactly one sidecar written");
+
+  std::vector<mlir::hipsr::ConstantOp> ops;
+  module->walk([&](mlir::hipsr::ConstantOp c) { ops.push_back(c); });
+  std::vector<std::vector<char>> expected = {
+      {1, 2, 3, 4},
+      {5, 6, 7, 8, 9, 10, 11, 12},
+  };
+  // Offset-driven: @a's constant at 0, @b's at aligned 64 in the shared blob.
+  verifyLayout(fs.files["constants.bin"], ops, expected, "multi-func");
+}
+
+// The core round-trip: several constants of mixed kinds / dtypes / sizes chosen
+// so offsets need real (non-coincidental) padding. The sidecar is written to a
+// real file; each constant is read back by fseek-ing to the offset stamped on
+// its op and comparing the bytes and length. This is what catches an
+// offset/size stamped != data actually placed bug, which the per-byte hardcoded
+// checks cannot.
+void testOffsetDrivenReadBack() {
+  namespace fs = std::filesystem;
+  fs::path dir = fs::temp_directory_path() / "hipsr_ext_readback";
+  std::error_code ec;
+  fs::remove_all(dir, ec);
+  fs::create_directories(dir, ec);
+
+  // Source file for the file_source constant: 200 bytes, src[i] == i, so the
+  // window [50, 150) is bytes 50..149. A nonzero file_offset also checks that
+  // the writer reads from the right place in the source.
+  fs::path srcFile = dir / "weights.bin";
+  {
+    std::ofstream ofs(srcFile, std::ios::binary);
+    for (int i = 0; i < 200; ++i) {
+      char b = static_cast<char>(i);
+      ofs.write(&b, 1);
+    }
+  }
+
+  // Live host buffer for the mem_source constant.
+  std::vector<uint8_t> memHost(7);
+  for (int i = 0; i < 7; ++i) {
+    memHost[i] = static_cast<uint8_t>(200 + i);
+  }
+  auto addr = reinterpret_cast<uintptr_t>(memHost.data());
+
+  // Expected bytes, in declaration order (== module walk order).
+  std::vector<std::vector<char>> expected;
+  expected.push_back(
+      {1, 2, 3, 4, 5, 6, 7, 8}); // c0 i32 little-endian raw bytes
+  std::vector<char> e1;          // c1 file window [50, 150)
+  for (int i = 50; i < 150; ++i) {
+    e1.push_back(static_cast<char>(i));
+  }
+  expected.push_back(std::move(e1));
+  expected.push_back({91, 92, 93}); // c2
+  std::vector<char> e3;             // c3 mem buffer
+  for (int i = 0; i < 7; ++i) {
+    e3.push_back(static_cast<char>(memHost[i]));
+  }
+  expected.push_back(std::move(e3));
+
+  // c0's i32 values whose little-endian bytes are {1..4} and {5..8}.
+  std::string ir =
+      "func.func @f() -> (tensor<2xi32>, tensor<100xi8>, tensor<3xi8>, "
+      "tensor<7xi8>) {\n"
+      "  %0 = hipsr.constant {value = dense<[67305985, 134678021]> : "
+      "tensor<2xi32>} : tensor<2xi32>\n"
+      "  %1 = hipsr.constant {source = #hipsr.file_source<\"" +
+      srcFile.generic_string() +
+      "\", 50, 100>} : tensor<100xi8>\n"
+      "  %2 = hipsr.constant {value = dense<[91, 92, 93]> : tensor<3xi8>} : "
+      "tensor<3xi8>\n"
+      "  %3 = hipsr.constant {source = #hipsr.mem_source<" +
+      std::to_string(addr) +
+      ", 7>} : tensor<7xi8>\n"
+      "  return %0, %1, %2, %3 : tensor<2xi32>, tensor<100xi8>, tensor<3xi8>, "
+      "tensor<7xi8>\n"
+      "}\n";
+
+  Harness h;
+  mlir::hip::DiskFileSystem diskFs(dir.string().c_str());
+  bool ok = false;
+  auto module = h.run(ir, &diskFs, ok);
+  check(ok, "readback: pass succeeds");
+  if (!ok || !module) {
+    fs::remove_all(dir, ec);
+    return;
+  }
+
+  std::vector<mlir::hipsr::ConstantOp> ops;
+  module->walk([&](mlir::hipsr::ConstantOp c) { ops.push_back(c); });
+  check(ops.size() == expected.size(), "readback: 4 constants stamped");
+  if (ops.size() != expected.size()) {
+    fs::remove_all(dir, ec);
+    return;
+  }
+
+  fs::path sidecar = dir / "constants.bin";
+  int64_t prevEnd = 0;
+  int64_t lastOffset = 0, lastSize = 0;
+  bool layoutOk = true;
+  bool bytesOk = true;
+  bool lenOk = true;
+  for (size_t i = 0; i < ops.size(); ++i) {
+    mlir::hipsr::ConstantOp c = ops[i];
+    if (!c.getOffsetAttr() || !c.getSizeAttr()) {
+      layoutOk = false;
+      break;
+    }
+    int64_t off = c.getOffsetAttr().getInt();
+    int64_t sz = c.getSizeAttr().getInt();
+
+    // Stamped size must equal the true data length (not element count).
+    if (sz != static_cast<int64_t>(expected[i].size())) {
+      lenOk = false;
+    }
+    // 64-aligned, monotonic, non-overlapping.
+    if (off % 64 != 0 || off < prevEnd) {
+      layoutOk = false;
+    }
+    // The data at the stamped offset is this constant's bytes.
+    if (readAt(sidecar, off, sz) != expected[i]) {
+      bytesOk = false;
+    }
+    prevEnd = off + sz;
+    lastOffset = off;
+    lastSize = sz;
+  }
+  check(lenOk, "readback: each stamped size == true byte length");
+  check(layoutOk, "readback: offsets 64-aligned, monotonic, non-overlapping");
+  check(bytesOk, "readback: bytes at each stamped offset match source data");
+
+  // Total file length is the aligned end of the last constant (derived, not
+  // hardcoded).
+  auto fileLen = static_cast<int64_t>(fs::file_size(sidecar, ec));
+  check(!ec && fileLen == llvm::alignTo(lastOffset + lastSize, 64),
+        "readback: sidecar length == aligned total");
+
+  fs::remove_all(dir, ec);
+}
+
+// A write failure (writer cannot be created) surfaces as pass failure.
+void testWriteFailureFailsPass() {
+  Harness h;
+  // The pass emits an error diagnostic on write failure; swallow it so the
+  // expected failure does not clutter the test log.
+  mlir::ScopedDiagnosticHandler handler(
+      &h.ctx, [](mlir::Diagnostic &) { return mlir::success(); });
+  FailingFileSystem fs;
+  bool ok = true;
+  h.run(R"mlir(
+    func.func @f() -> tensor<4xi8> {
+      %0 = hipsr.constant {value = dense<[1, 2, 3, 4]> : tensor<4xi8>} : tensor<4xi8>
+      return %0 : tensor<4xi8>
+    }
+  )mlir",
+        &fs, ok);
+  check(!ok, "write failure: pass fails");
+}
+
+} // namespace
+
+int main() {
+  testInlineValueBytesWritten();
+  testMemSourceBytesWritten();
+  testFileSourceBytesStreamed();
+  testCumulativeAlignmentAndPadding();
+  testMultiFunctionSharesOneSidecar();
+  testOffsetDrivenReadBack();
+  testWriteFailureFailsPass();
+
+  if (g_failures == 0) {
+    llvm::outs() << "All hipsr-externalize-constants unit tests passed.\n";
+    return 0;
+  }
+  llvm::errs() << g_failures << " check(s) failed.\n";
+  return 1;
+}


### PR DESCRIPTION
﻿## Summary

Adds the `-hipsr-externalize-constants` pass (Phase 2 of the hipsr constant subsystem, aligned with the v6 constant design), the first consumer of the constant op's `getDataValues()` / `shouldExternalize()` API from #495. It walks every `hipsr.constant` in the module, stamps a 64-byte aligned cumulative `offset`/`size` on each opted-in one, and (when a FileSystem is injected) writes the bytes to a single shared sidecar. Also extracts the shared sidecar writer into its own library.

## Why

#495 landed `hipsr.constant` with an append-only externalization model (`offset`/`size` are added, `value`/`source` are kept so `getDataValues()` still works) and #500 added the ONNX producer. This pass assigns sidecar placement and writes it.

Design points:

1. **Module-scoped (`ModuleOp` pass).** Offsets accumulate into one sidecar shared by the whole module, so the pass must see every constant at once. A per-function pass would restart offsets at 0 per function (overlapping placements) and write the shared file once per function (races under MLIR's parallel function passes / last-writer-wins when serial).
2. **Reuse the hip.* sidecar writer.** Entries are built as `hip::ConstantEntry` and written through `writeConstantsBinToFileSystem` (`ConstantsIO`), the same layout/streaming logic the hip.* pipeline uses. file_source entries carry only their path/offset (`data = nullptr`) so the writer streams them on demand -- the multi-GB weight file is never mmap'd by this pass.
3. **FileSystem-gated write, no fallback.** Phase 1 (offset/size + entry collection) always runs, so the IR transform is deterministic. The write (Phase 2) happens only when a `morphizen::FileSystem` is injected on the `HipsrDialect` (new non-owning `set/getFileSystem`, mirroring `getOrLoadFileMap`). The sink is not synchronized -- it must be injected before passes are scheduled; the pass only reads it. Standalone runs (`hip-mlir-opt`) inject none and get a pure IR transform.

To avoid coupling the hipsr pass to the legacy `OnnxToHip` conversion lib (which shrinks as hipsr takes over), the shared `ConstantsIO` writer is extracted into its own `HipConstantsIO` library under `lib/Support`. Both `OnnxToHip` and the hipsr pass now depend on that small lib, not on each other.

Out of scope: no module-level descriptor arrays (runtime metadata generation is a separate follow-up); the hybrid / three-emit-mode differentiation is deferred until the hipsr pipeline runs end-to-end.

## What

1. **hipsr Transforms infrastructure** (new): `Passes.td` + `Passes.h` + `-name Hipsr` tablegen; `registerHipsrPasses()` wired into `InitAllPasses.h`. Lib linked into `hip-mlir-opt` and `LibHipCompiler`.
2. **Dialect FileSystem sink** at `HipsrDialect.td`/`.h`: non-owning `set/getFileSystem` + forward-declared `morphizen::FileSystem`.
3. **The pass** `lib/Dialect/Hipsr/Transforms/ExternalizeConstants.cpp`: `ModuleOp`-scoped. Phase 1 builds `ConstantEntry` (file_source -> path/offset, no read; inline/mem_source -> `getDataValues<uint8_t>()` byte view; `splat_elem_size = 0`) and stamps `offset`/`size`. Phase 2 calls `writeConstantsBinToFileSystem` once when a FileSystem is present. Option `constants-file`.
4. **ConstantsIO extraction**: moved `ConstantsIO.{h,cpp}` from `Conversion/OnnxToHip` to `Support` as a standalone `HipConstantsIO` target (namespace `mlir::hip` unchanged).
5. **Intentional non-changes**: no size threshold / inline policy; no module descriptor arrays; read side `getOrLoadFileMap` untouched.

## Test plan

- [x] **LIT** `test/lit/Dialect/Hipsr/test_externalize_constants.mlir` -- one case per distinct Phase 1 behavior: inline, file_source, cumulative 64-byte alignment, cross-function accumulation (two funcs in one module -> offsets 0/1024), opt-out, idempotent skip. CHECK directives grouped per case.
- [x] **Unit test** `test/unit/test_externalize_constants.cpp` (GPU-free, plain main) -- injects an in-memory FileSystem to cover Phase 2: exact bytes written for inline/mem/file sources, alignment + gap/trailing padding, the multi-function single-sidecar contract, and the write-failure path. 20/20 checks pass.
- [x] `check-hip-mlir-lit` -> 293 discovered, 291 passed, 0 failed, 2 unsupported (pre-existing plugin-gated).
- [x] Full build (`hip-compiler`, `hip-compiler.dll`, `hipgpu.dll`) links after the ConstantsIO extraction; OnnxToHip constant LIT still passes.
- [x] `pre-commit run --all-files` clean.

## Notes for reviewers

- Append-only keeps the (possibly large) inline `value` `DenseElementsAttr` in the IR after externalization -- required by the verifier (value XOR source is always present) and by `getDataValues()`. Known trade-off.
- Rebased onto latest main (picks up the new hipsr.cast / hipsr.placeholder ops); no conflicts.

## Checklist

- [x] **Incremental** -- the ConstantsIO move is a pure relocation (git tracks it as a rename); the rest is new hipsr scaffolding + tests.
- [x] **AI policy** -- pass and tests drafted with Cursor; every design decision above is human-owned and answerable in review.
- [x] **No `good first issue` automation**
- [x] **Reviews resolved**
- [x] **CODEOWNERS routing**
