### PR TITLE
feat(dialect): add hipsr.placeholder op for DPS init operands

### DIFF
--- a/include/hip/Dialect/Hipsr/IR/CMakeLists.txt
+++ b/include/hip/Dialect/Hipsr/IR/CMakeLists.txt
@@ -43,6 +43,10 @@ set(LLVM_TARGET_DEFINITIONS HipsrCastOp.td)
 mlir_tablegen(HipsrCastOp.h.inc -gen-op-decls)
 mlir_tablegen(HipsrCastOp.cpp.inc -gen-op-defs)
 
+set(LLVM_TARGET_DEFINITIONS HipsrPlaceholderOp.td)
+mlir_tablegen(HipsrPlaceholderOp.h.inc -gen-op-decls)
+mlir_tablegen(HipsrPlaceholderOp.cpp.inc -gen-op-defs)
+
 add_public_tablegen_target(HipsrDialectIncGen)
 
 set(LLVM_TARGET_DEFINITIONS HipsrEnums.td)

--- a/include/hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#ifndef HIPSR_PLACEHOLDER_OP_H
+#define HIPSR_PLACEHOLDER_OP_H
+
+#include "hip/Dialect/Hipsr/IR/HipsrDialect.h"
+
+#include "mlir/Bytecode/BytecodeOpInterface.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+
+#define GET_OP_CLASSES
+#include "hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.h.inc"
+
+#endif // HIPSR_PLACEHOLDER_OP_H

--- a/include/hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.td
@@ -1,0 +1,55 @@
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+// The hipsr.placeholder op: a typed stand-in that mirrors a hipsr DPS op's
+// result type(s) so the DPS op can be built without first computing its output
+// shape. The shaped DPS op base class lives in HipsrOps.td.
+//
+
+#ifndef HIPSR_PLACEHOLDER_OP
+#define HIPSR_PLACEHOLDER_OP
+
+include "mlir/Interfaces/SideEffectInterfaces.td"
+include "hip/Dialect/Hipsr/IR/HipsrOps.td"
+
+//===----------------------------------------------------------------------===//
+// Hipsr_PlaceholderOp
+//===----------------------------------------------------------------------===//
+
+def Hipsr_PlaceholderOp : Hipsr_Op<"placeholder", [Pure]> {
+  let summary = "Typed placeholder for a hipsr DPS op's init operand(s)";
+  let description = [{
+    Stands in for the `outs` init operand(s) of a hipsr DPS op. It takes the DPS
+    op's result type(s) and re-emits the same type(s) as its own results, which
+    are then passed as the DPS op's init operands. This lets a DPS op be built
+    without computing its output shape first: the shape region stays the source
+    of truth for output dimensions.
+
+    The DPS verifier requires each init type to equal the matching result type,
+    and mirroring the result types makes that hold by construction. The op is
+    variadic, so one placeholder can back a multi-output DPS op (one result per
+    output).
+
+    `hipsr.placeholder` is transient: it has no bufferization interface, so it
+    must be replaced before bufferization runs.
+
+    Example:
+    ```mlir
+    %inits:2 = hipsr.placeholder : tensor<?x?xf16>, tensor<?xi64>
+    ```
+  }];
+
+  let results = (outs Variadic<AnyRankedTensor>:$results);
+
+  let assemblyFormat = "attr-dict `:` type($results)";
+
+  let builders = [
+    // Pass the DPS op's result types so init and result types match.
+    OpBuilder<(ins "::mlir::TypeRange":$resultTypes), [{
+      $_state.addTypes(resultTypes);
+    }]>
+  ];
+}
+
+#endif // HIPSR_PLACEHOLDER_OP

--- a/lib/Conversion/OnnxToHipsr/CastConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/CastConversion.cpp
@@ -5,8 +5,8 @@
 
 #include "hip/Conversion/OnnxToHipsr/OnnxToHipsr.h"
 #include "hip/Dialect/Hipsr/IR/HipsrCastOp.h"
+#include "hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.h"
 
-#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/PatternMatch.h"
 
 namespace mlir {
@@ -40,15 +40,21 @@ struct CastToHipsr : public ::mlir::RewritePattern {
     if (!resultType)
       return rewriter.notifyMatchFailure(op, "expected ranked tensor result");
 
-    // DPS init: an empty tensor of the result type. Cast preserves the shape,
-    // so dynamic dims are taken from the input.
-    ::llvm::SmallVector<::mlir::Value> dynDims;
-    for (int64_t i = 0; i < resultType.getRank(); ++i)
-      if (resultType.isDynamicDim(i))
-        dynDims.push_back(
-            rewriter.create<::mlir::tensor::DimOp>(loc, input, i));
-    ::mlir::Value init = rewriter.create<::mlir::tensor::EmptyOp>(
-        loc, resultType.getShape(), resultType.getElementType(), dynDims);
+    // DPS init: a hipsr.placeholder with the cast result type. Its type matches
+    // the result, which is all the DPS verifier needs, and it saves computing
+    // the output shape here (no tensor.empty + tensor.dim). A later pass fills
+    // in the shape region.
+    //
+    // Old way (built the init from the input shape):
+    //   %d0   = tensor.dim %input, %c0 : tensor<?x8xf32>
+    //   %init = tensor.empty(%d0)      : tensor<?x8xf16>
+    //   %0    = hipsr.cast ins(%input) outs(%init) -> tensor<?x8xf16>
+    // New way (placeholder mirrors the result type):
+    //   %init = hipsr.placeholder      : tensor<?x8xf16>
+    //   %0    = hipsr.cast ins(%input) outs(%init) -> tensor<?x8xf16>
+    ::mlir::Value init =
+        rewriter.create<PlaceholderOp>(loc, ::mlir::TypeRange{resultType})
+            .getResult(0);
 
     auto castOp = rewriter.create<CastOp>(loc, ::mlir::TypeRange{resultType},
                                           input, init);

--- a/lib/Dialect/Hipsr/IR/CMakeLists.txt
+++ b/lib/Dialect/Hipsr/IR/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(HipsrDialectIR STATIC
   HipsrPoolDomainYieldOp.cpp
   HipsrPoolDomainOp.cpp
   HipsrConstantOp.cpp
+  HipsrPlaceholderOp.cpp
   HipsrTraits.cpp
   HipsrCastOp.cpp
   HipsrTypes.cpp

--- a/lib/Dialect/Hipsr/IR/HipsrDialect.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrDialect.cpp
@@ -8,6 +8,7 @@
 #include "hip/Dialect/Hipsr/IR/HipsrCastOp.h"
 #include "hip/Dialect/Hipsr/IR/HipsrConstantOp.h"
 #include "hip/Dialect/Hipsr/IR/HipsrOps.h"
+#include "hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.h"
 #include "hip/Dialect/Hipsr/IR/HipsrPoolDomainOp.h"
 #include "hip/Dialect/Hipsr/IR/HipsrPoolDomainYieldOp.h"
 #include "hip/Dialect/Hipsr/IR/HipsrShapeYieldOp.h"
@@ -45,10 +46,12 @@ void HipsrDialect::initialize() {
       ,
 #define GET_OP_LIST
 #include "hip/Dialect/Hipsr/IR/HipsrConstantOp.cpp.inc"
-      >();
-  addOperations<
+      ,
 #define GET_OP_LIST
 #include "hip/Dialect/Hipsr/IR/HipsrCastOp.cpp.inc"
+      ,
+#define GET_OP_LIST
+#include "hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.cpp.inc"
       >();
   addAttributes<
 #define GET_ATTRDEF_LIST

--- a/lib/Dialect/Hipsr/IR/HipsrPlaceholderOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrPlaceholderOp.cpp
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.h"
+
+using namespace mlir;
+using namespace mlir::hipsr;
+
+#define GET_OP_CLASSES
+#include "hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.cpp.inc"

--- a/test/lit/Conversion/onnx-to-hipsr/cast.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/cast.mlir
@@ -11,11 +11,14 @@
 
 // CHECK-LABEL: func.func @cast
 func.func @cast(%input: tensor<?x8xf32>) -> tensor<?x8xf16> {
-  // CHECK: %[[D0:.+]] = tensor.dim %[[IN:.+]], %{{.+}} : tensor<?x8xf32>
-  // CHECK: %[[INIT:.+]] = tensor.empty(%[[D0]]) : tensor<?x8xf16>
+  // The DPS init is a hipsr.placeholder that mirrors the result type, so no
+  // output-shape computation (tensor.empty / tensor.dim) is emitted here.
+  // CHECK: %[[INIT:.+]] = hipsr.placeholder : tensor<?x8xf16>
   // The shape region is left empty (zero blocks) here; a later pass populates
   // it. The optional region group prints nothing when the region is empty.
-  // CHECK: hipsr.cast ins(%[[IN]] : tensor<?x8xf32>) outs(%[[INIT]] : tensor<?x8xf16>) -> tensor<?x8xf16>
+  // CHECK: hipsr.cast ins(%[[IN:.+]] : tensor<?x8xf32>) outs(%[[INIT]] : tensor<?x8xf16>) -> tensor<?x8xf16>
+  // CHECK-NOT: tensor.empty
+  // CHECK-NOT: tensor.dim
   // CHECK-NOT: shape_region
   %0 = "onnx.Cast"(%input) : (tensor<?x8xf32>) -> tensor<?x8xf16>
   return %0 : tensor<?x8xf16>

--- a/test/lit/Dialect/Hipsr/placeholder.mlir
+++ b/test/lit/Dialect/Hipsr/placeholder.mlir
@@ -1,0 +1,54 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+//===----------------------------------------------------------------------===//
+// Tests for hipsr.placeholder:
+//   - round-trips single-result and multi-result forms
+//   - an unranked result is rejected by the AnyRankedTensor constraint
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt --split-input-file --verify-diagnostics %s | FileCheck %s
+
+// -----
+// Single result, dynamic dims.
+// CHECK-LABEL: func.func @single_dynamic
+// CHECK: %{{.*}} = hipsr.placeholder : tensor<?x?xf16>
+func.func @single_dynamic() -> tensor<?x?xf16> {
+  %0 = hipsr.placeholder : tensor<?x?xf16>
+  return %0 : tensor<?x?xf16>
+}
+
+// -----
+// Single result, static dims.
+// CHECK-LABEL: func.func @single_static
+// CHECK: %{{.*}} = hipsr.placeholder : tensor<4x8xi64>
+func.func @single_static() -> tensor<4x8xi64> {
+  %0 = hipsr.placeholder : tensor<4x8xi64>
+  return %0 : tensor<4x8xi64>
+}
+
+// -----
+// Rank-0 (scalar) result.
+// CHECK-LABEL: func.func @rank0
+// CHECK: %{{.*}} = hipsr.placeholder : tensor<f32>
+func.func @rank0() -> tensor<f32> {
+  %0 = hipsr.placeholder : tensor<f32>
+  return %0 : tensor<f32>
+}
+
+// -----
+// Multi-result (variadic), mirroring a multi-output DPS op.
+// CHECK-LABEL: func.func @multi_result
+// CHECK: %{{.*}}:2 = hipsr.placeholder : tensor<?x?xf16>, tensor<?xi64>
+func.func @multi_result() -> (tensor<?x?xf16>, tensor<?xi64>) {
+  %0:2 = hipsr.placeholder : tensor<?x?xf16>, tensor<?xi64>
+  return %0#0, %0#1 : tensor<?x?xf16>, tensor<?xi64>
+}
+
+// -----
+// An unranked result is rejected by the AnyRankedTensor constraint.
+func.func @unranked_rejected() {
+  // expected-error @+1 {{op result #0 must be variadic of ranked tensor of any type values}}
+  %0 = "hipsr.placeholder"() : () -> tensor<*xf16>
+  return
+}

--- a/test/lit/Dialect/Hipsr/shape_region_verify.mlir
+++ b/test/lit/Dialect/Hipsr/shape_region_verify.mlir
@@ -2,14 +2,34 @@
 // Licensed under the MIT License.
 //
 //===----------------------------------------------------------------------===//
-// Negative tests for the hipsr shape region, exercised through hipsr.cast.
-// Cover both the scoping rule (IsolatedFromAboveButAllowOperands trait) and the
-// structural rules (SingleBlock trait + ShapeRegionInterface verifier): the
-// region is optional, but when present it must be a single, non-empty block
-// terminated by hipsr.shape_yield.
+// Tests for the hipsr shape region, exercised through hipsr.cast. The region is
+// optional; when present it must be a single, non-empty block ending in
+// hipsr.shape_yield. Covered here:
+//   - positive: a cast with the region omitted round-trips
+//   - scoping: the region may only use the op's operands
+//     (IsolatedFromAboveButAllowOperands)
+//   - structure: 0-or-1 blocks, non-empty, hipsr.shape_yield terminator
+//     (SingleBlock trait + ShapeRegionInterface verifier)
 //===----------------------------------------------------------------------===//
 
-// RUN: hip-mlir-opt %s -split-input-file -verify-diagnostics
+// RUN: hip-mlir-opt %s -split-input-file -verify-diagnostics | FileCheck %s
+
+// Positive round-trip: a cast with the shape region OMITTED entirely parses,
+// verifies, and prints back with no `shape_region` keyword (the optional region
+// group prints nothing when the region has zero blocks). This is the exact form
+// the onnx->hipsr conversion emits, so IR without a shape region must read back
+// correctly.
+// CHECK-LABEL: func.func @cast_no_shape_region
+func.func @cast_no_shape_region(%input: tensor<?x8xf32>,
+                                %init: tensor<?x8xf16>) -> tensor<?x8xf16> {
+  // CHECK: hipsr.cast ins(%{{.+}} : tensor<?x8xf32>) outs(%{{.+}} : tensor<?x8xf16>) -> tensor<?x8xf16>
+  // CHECK-NOT: shape_region
+  %0 = hipsr.cast ins(%input : tensor<?x8xf32>)
+                  outs(%init : tensor<?x8xf16>) -> tensor<?x8xf16>
+  return %0 : tensor<?x8xf16>
+}
+
+// -----
 
 // A value defined in the enclosing function that is NOT one of the op's
 // operands is a disallowed outer capture: the trait verifier rejects it.


### PR DESCRIPTION
## Summary

- Add `hipsr.placeholder`, a typed stand-in that mirrors a hipsr DPS op's result type(s). It re-emits the given result type(s) as its own results, which are then passed as the DPS op's `outs` init operands. This lets a DPS op be built without computing its output shape first, and the init/result types always match so the DPS verifier is happy.
- The op is `Pure` and variadic (one result per DPS output). It has no bufferization interface, so it must be replaced before bufferization runs.
- Use it in the `onnx.Cast -> hipsr.cast` conversion: the init operand is now a placeholder mirroring the result type, dropping the manual `tensor.empty` + `tensor.dim` shape computation. The shape region stays the source of truth for output dimensions.
- Wire the op into tablegen, the build, and dialect registration, with LIT tests for placeholder round-trips, the updated cast conversion, and an omitted shape region.

## Why not just use `tensor.empty`

`tensor.empty` cannot express a dynamic dim from the type alone; it requires an `index` SSA value for every `?` in the result type. This is baked into the op:

- Its operands *are* the dynamic sizes: `let arguments = (ins Variadic<Index>:$dynamicSizes);` (`mlir/Dialect/Tensor/IR/TensorOps.td`).
- Its verifier rejects any mismatch between the operand count and the number of dynamic dims:

```cpp
// mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
LogicalResult EmptyOp::verify() {
  return verifyDynamicDimensionCount(getOperation(), getType(),
                                     getDynamicSizes());
}

// mlir/lib/Dialect/Utils/VerificationUtils.cpp
LogicalResult mlir::verifyDynamicDimensionCount(Operation *op, ShapedType type,
                                                ValueRange dynamicSizes) {
  int64_t expectedCount = type.getNumDynamicDims();
  int64_t actualCount = dynamicSizes.size();
  if (expectedCount != actualCount)
    return op->emitOpError("incorrect number of dynamic sizes, has ")
           << actualCount << ", expected " << expectedCount;
  return success();
}
```

So building a `tensor.empty` for a `tensor<?x8xf16>` init forces the caller to first produce each dynamic extent as an `index` value (e.g. `tensor.dim %input, %c0`) and thread it in. That is the exact shape computation we want to defer.

## Shape inference is not needed at conversion time

The conversion already knows the result type from the ONNX op's output, so there is nothing to infer when building the op. Computing the dynamic extents (the `tensor.dim` calls) was only busywork to satisfy `tensor.empty`, not information the conversion actually needed.

`hipsr.placeholder` takes no size operands: it just re-emits the result type. The concrete extents are described once, later, by the DPS op's shape region, so the conversion no longer infers or computes any shape up front.
