### PR TITLE
feat(dialect): add hipsr.matmul op and onnx.MatMul -> hipsr.matmul conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ CMakePresets.json
 *.pb.cc
 *.pb.h
 compile_commands.json
+# Build-generated version placeholder in the vendored morphizen subtree
+morphizen/morphizen-core/version.txt
 
 # Python
 __pycache__/

--- a/include/hip/Conversion/OnnxToHipsr/OnnxToHipsr.h
+++ b/include/hip/Conversion/OnnxToHipsr/OnnxToHipsr.h
@@ -31,6 +31,9 @@ void populateOnnxToHipsrConstantPatterns(::mlir::RewritePatternSet &patterns);
 void populateCastConversionPatterns(::mlir::RewritePatternSet &patterns,
                                     ::mlir::MLIRContext *ctx);
 
+void populateMatMulConversionPatterns(::mlir::RewritePatternSet &patterns,
+                                      ::mlir::MLIRContext *ctx);
+
 } // namespace hipsr
 } // namespace mlir
 

--- a/include/hip/Dialect/Hipsr/IR/CMakeLists.txt
+++ b/include/hip/Dialect/Hipsr/IR/CMakeLists.txt
@@ -43,6 +43,10 @@ set(LLVM_TARGET_DEFINITIONS HipsrCastOp.td)
 mlir_tablegen(HipsrCastOp.h.inc -gen-op-decls)
 mlir_tablegen(HipsrCastOp.cpp.inc -gen-op-defs)
 
+set(LLVM_TARGET_DEFINITIONS HipsrMatMulOp.td)
+mlir_tablegen(HipsrMatMulOp.h.inc -gen-op-decls)
+mlir_tablegen(HipsrMatMulOp.cpp.inc -gen-op-defs)
+
 set(LLVM_TARGET_DEFINITIONS HipsrPlaceholderOp.td)
 mlir_tablegen(HipsrPlaceholderOp.h.inc -gen-op-decls)
 mlir_tablegen(HipsrPlaceholderOp.cpp.inc -gen-op-defs)

--- a/include/hip/Dialect/Hipsr/IR/HipsrMatMulOp.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrMatMulOp.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#ifndef HIPSR_MATMUL_OP_H
+#define HIPSR_MATMUL_OP_H
+
+#include "hip/Dialect/Hipsr/IR/HipsrDialect.h"
+#include "hip/Dialect/Hipsr/IR/HipsrShapeRegionInterface.h"
+#include "hip/Dialect/Hipsr/IR/HipsrShapeYieldOp.h"
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/Interfaces/DestinationStyleOpInterface.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+
+#define GET_OP_CLASSES
+#include "hip/Dialect/Hipsr/IR/HipsrMatMulOp.h.inc"
+
+#endif // HIPSR_MATMUL_OP_H

--- a/include/hip/Dialect/Hipsr/IR/HipsrMatMulOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrMatMulOp.td
@@ -27,9 +27,7 @@ def Hipsr_MatMulOp : Hipsr_DpsOp<"matmul"> {
     operand.
 
     Carries an optional shape region (region 0). When populated it yields the
-    output shape and asserts the matmul shape constraints: A and B must share the
-    contraction dim K, and the batch dims must be broadcastable (equal, or one
-    side is 1).
+    output shape.
 
     Example (populated shape region, 2-D):
     ```mlir
@@ -40,10 +38,6 @@ def Hipsr_MatMulOp : Hipsr_DpsOp<"matmul"> {
       %shB = shape.shape_of %B : tensor<?x?xf16> -> tensor<2xindex>
       %c0 = arith.constant 0 : index
       %c1 = arith.constant 1 : index
-      %ka = shape.get_extent %shA, %c1 : tensor<2xindex>, index -> index
-      %kb = shape.get_extent %shB, %c0 : tensor<2xindex>, index -> index
-      %eq = arith.cmpi eq, %ka, %kb : index
-      cf.assert %eq, "hipsr.matmul: A and B contraction dim (K) must be equal"
       %m = shape.get_extent %shA, %c0 : tensor<2xindex>, index -> index
       %n = shape.get_extent %shB, %c1 : tensor<2xindex>, index -> index
       hipsr.shape_yield (%m, %n) : [f16]

--- a/include/hip/Dialect/Hipsr/IR/HipsrMatMulOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrMatMulOp.td
@@ -26,38 +26,59 @@ def Hipsr_MatMulOp : Hipsr_DpsOp<"matmul"> {
     scalar. Destination-passing style: the result buffer is passed as the `init`
     operand.
 
+    The `ctx` operand (`!hipsr.context`) is the per-session execution context.
+    Every hipsr op carries it as its first operand; it is added in the ONNX
+    phase and threaded through unchanged.
+
     Carries an optional shape region (region 0). When populated it yields the
-    output shape.
+    output shape. The contraction dim K is not in the output but must match on
+    both sides, so it is constrained with a `shape.cstr_eq` witness guarding a
+    `shape.assuming` region that produces the output dims (a static-equal K
+    folds the witness away).
 
     Example (populated shape region, 2-D):
     ```mlir
-    %0 = hipsr.matmul ins(%A, %B : tensor<?x?xf16>, tensor<?x?xf16>)
+    %0 = hipsr.matmul(%ctx) ins(%A, %B : tensor<?x?xf16>, tensor<?x?xf16>)
                       outs(%init : tensor<?x?xf16>)
-                      -> tensor<?x?xf16> shape_region {
+                      : tensor<?x?xf16> shape_region {
       %shA = shape.shape_of %A : tensor<?x?xf16> -> tensor<2xindex>
       %shB = shape.shape_of %B : tensor<?x?xf16> -> tensor<2xindex>
       %c0 = arith.constant 0 : index
       %c1 = arith.constant 1 : index
-      %m = shape.get_extent %shA, %c0 : tensor<2xindex>, index -> index
-      %n = shape.get_extent %shB, %c1 : tensor<2xindex>, index -> index
-      hipsr.shape_yield (%m, %n) : [f16]
+      // Contraction dim K (A dim 1 == B dim 0): constrained, not in the result.
+      %kA = shape.get_extent %shA, %c1 : tensor<2xindex>, index -> index
+      %kB = shape.get_extent %shB, %c0 : tensor<2xindex>, index -> index
+      %sa = shape.from_extents %kA : index
+      %sb = shape.from_extents %kB : index
+      %w = shape.cstr_eq %sa, %sb : !shape.shape, !shape.shape
+      %d:2 = shape.assuming %w -> (index, index) {
+        %m = shape.get_extent %shA, %c0 : tensor<2xindex>, index -> index
+        %n = shape.get_extent %shB, %c1 : tensor<2xindex>, index -> index
+        shape.assuming_yield %m, %n : index, index
+      }
+      hipsr.shape_yield (%d#0, %d#1) : [f16]
     }
     ```
   }];
 
   let arguments = (ins
+    Hipsr_ContextType:$ctx,
     Hipsr_TensorOrDeviceMemRef:$A,
     Hipsr_TensorOrDeviceMemRef:$B,
     Hipsr_TensorOrDeviceMemRef:$init
   );
 
-  // The shape region is optional: an empty (zero-block) region prints nothing
-  // and round-trips as empty. A non-empty region prints as
-  // `shape_region { ... }`.
+  // `ctx` prints as a leading `(%ctx)` with its type elided (Hipsr_ContextType
+  // is a single fixed type), matching the hip dialect DPS ops. Result type
+  // follows the same convention: `: type` after attr-dict (optional, so a
+  // future memref/no-result form prints nothing). The shape region is optional
+  // too: an empty (zero-block) region prints nothing and round-trips as empty;
+  // a non-empty region prints as `shape_region { ... }`.
   let assemblyFormat = [{
+    `(` $ctx `)`
     `ins` `(` $A `,` $B `:` type($A) `,` type($B) `)`
     `outs` `(` $init `:` type($init) `)`
-    attr-dict `->` type($result_tensors) (`shape_region` $shape_region^)?
+    attr-dict (`:` type($result_tensors)^)? (`shape_region` $shape_region^)?
   }];
 
   // Rejects rank-0 (scalar) A/B: matmul needs at least a contraction dim.

--- a/include/hip/Dialect/Hipsr/IR/HipsrMatMulOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrMatMulOp.td
@@ -1,0 +1,70 @@
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+// The hipsr.matmul op. Each compute op lives in its own file and builds on the
+// Hipsr_DpsOp base class from HipsrOps.td.
+//
+
+#ifndef HIPSR_MATMUL_OP
+#define HIPSR_MATMUL_OP
+
+include "hip/Dialect/Hipsr/IR/HipsrOps.td"
+
+//===----------------------------------------------------------------------===//
+// Hipsr_MatMulOp
+//===----------------------------------------------------------------------===//
+
+def Hipsr_MatMulOp : Hipsr_DpsOp<"matmul"> {
+  let summary = "Matrix multiply (batched N-D x N-D), destination-passing style";
+  let description = [{
+    Matrix multiplication with ONNX/NumPy `matmul` semantics. For operands that
+    are both >= 2-D: `result[..., M, N] = A[..., M, K] @ B[..., K, N]`, where the
+    leading (batch) dims broadcast NumPy-style. A 1-D operand is promoted for the
+    multiply and stripped from the result: A `(K)` acts as `(1,K)` (drops the
+    leading 1), B `(K)` acts as `(K,1)` (drops the trailing 1); `(K) @ (K)` is a
+    scalar. Destination-passing style: the result buffer is passed as the `init`
+    operand.
+
+    Carries an optional shape region (region 0). When populated it yields the
+    output shape and asserts the matmul shape constraints: A and B must share the
+    contraction dim K, and the batch dims must be broadcastable (equal, or one
+    side is 1).
+
+    Example (populated shape region, 2-D):
+    ```mlir
+    %0 = hipsr.matmul ins(%A, %B : tensor<?x?xf16>, tensor<?x?xf16>)
+                      outs(%init : tensor<?x?xf16>)
+                      -> tensor<?x?xf16> shape_region {
+      %shA = shape.shape_of %A : tensor<?x?xf16> -> tensor<2xindex>
+      %shB = shape.shape_of %B : tensor<?x?xf16> -> tensor<2xindex>
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %ka = shape.get_extent %shA, %c1 : tensor<2xindex>, index -> index
+      %kb = shape.get_extent %shB, %c0 : tensor<2xindex>, index -> index
+      %eq = arith.cmpi eq, %ka, %kb : index
+      cf.assert %eq, "hipsr.matmul: A and B contraction dim (K) must be equal"
+      %m = shape.get_extent %shA, %c0 : tensor<2xindex>, index -> index
+      %n = shape.get_extent %shB, %c1 : tensor<2xindex>, index -> index
+      hipsr.shape_yield (%m, %n) : [f16]
+    }
+    ```
+  }];
+
+  let arguments = (ins
+    Hipsr_TensorOrDeviceMemRef:$A,
+    Hipsr_TensorOrDeviceMemRef:$B,
+    Hipsr_TensorOrDeviceMemRef:$init
+  );
+
+  // The shape region is optional: an empty (zero-block) region prints nothing
+  // and round-trips as empty. A non-empty region prints as
+  // `shape_region { ... }`.
+  let assemblyFormat = [{
+    `ins` `(` $A `,` $B `:` type($A) `,` type($B) `)`
+    `outs` `(` $init `:` type($init) `)`
+    attr-dict `->` type($result_tensors) (`shape_region` $shape_region^)?
+  }];
+}
+
+#endif // HIPSR_MATMUL_OP

--- a/include/hip/Dialect/Hipsr/IR/HipsrMatMulOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrMatMulOp.td
@@ -68,12 +68,10 @@ def Hipsr_MatMulOp : Hipsr_DpsOp<"matmul"> {
     Hipsr_TensorOrDeviceMemRef:$init
   );
 
-  // `ctx` prints as a leading `(%ctx)` with its type elided (Hipsr_ContextType
-  // is a single fixed type), matching the hip dialect DPS ops. Result type
-  // follows the same convention: `: type` after attr-dict (optional, so a
-  // future memref/no-result form prints nothing). The shape region is optional
-  // too: an empty (zero-block) region prints nothing and round-trips as empty;
-  // a non-empty region prints as `shape_region { ... }`.
+  // Matches the hip dialect DPS ops: `ctx` prints as a leading `(%ctx)` with
+  // its type elided (it is a single fixed type). Result type and shape region
+  // are both optional groups so a memref/no-result form and the empty-region
+  // form (the one convert-onnx-to-hipsr emits) print nothing extra.
   let assemblyFormat = [{
     `(` $ctx `)`
     `ins` `(` $A `,` $B `:` type($A) `,` type($B) `)`

--- a/include/hip/Dialect/Hipsr/IR/HipsrMatMulOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrMatMulOp.td
@@ -65,6 +65,9 @@ def Hipsr_MatMulOp : Hipsr_DpsOp<"matmul"> {
     `outs` `(` $init `:` type($init) `)`
     attr-dict `->` type($result_tensors) (`shape_region` $shape_region^)?
   }];
+
+  // Rejects rank-0 (scalar) A/B: matmul needs at least a contraction dim.
+  let hasVerifier = 1;
 }
 
 #endif // HIPSR_MATMUL_OP

--- a/lib/Conversion/OnnxToHipsr/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHipsr/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(OnnxToHipsr STATIC
   ConstantConversion.cpp
   OnnxToHipsr.cpp
   CastConversion.cpp
+  MatMulConversion.cpp
 )
 
 add_dependencies(OnnxToHipsr

--- a/lib/Conversion/OnnxToHipsr/MatMulConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/MatMulConversion.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "hip/Conversion/OnnxToHipsr/OnnxToHipsr.h"
+#include "hip/Dialect/Hipsr/IR/HipsrMatMulOp.h"
+#include "hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.h"
+
+#include "mlir/IR/PatternMatch.h"
+
+namespace mlir {
+namespace hipsr {
+namespace {
+
+/// onnx.MatMul -> hipsr.matmul. The shape region is left empty here; a later
+/// pass populates every op's shape region uniformly (see populateShapeRegion,
+/// which also emits the K/batch checks).
+///
+/// Before:
+///   %0 = "onnx.MatMul"(%A, %B) : (tensor<?x?xf16>, tensor<?x?xf16>)
+///                                 -> tensor<?x?xf16>
+/// After:
+///   %init = hipsr.placeholder : tensor<?x?xf16>
+///   %0 = hipsr.matmul ins(%A, %B : tensor<?x?xf16>, tensor<?x?xf16>)
+///                     outs(%init : tensor<?x?xf16>) -> tensor<?x?xf16>
+struct MatMulToHipsr : public ::mlir::RewritePattern {
+  MatMulToHipsr(::mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.MatMul", /*benefit=*/1, ctx) {}
+
+  ::mlir::LogicalResult
+  matchAndRewrite(::mlir::Operation *op,
+                  ::mlir::PatternRewriter &rewriter) const override {
+    // Matching is by name on an (unregistered) ONNX op, so guard the shape:
+    // onnx.MatMul is two-input / single-result.
+    if (op->getNumOperands() != 2 || op->getNumResults() != 1)
+      return rewriter.notifyMatchFailure(
+          op, "expected two operands and a single result");
+
+    ::mlir::Location loc = op->getLoc();
+    ::mlir::Value a = op->getOperand(0);
+    ::mlir::Value b = op->getOperand(1);
+    auto resultType =
+        ::mlir::dyn_cast<::mlir::RankedTensorType>(op->getResult(0).getType());
+    if (!resultType)
+      return rewriter.notifyMatchFailure(op, "expected ranked tensor result");
+
+    // DPS init: a hipsr.placeholder mirroring the result type. That is all the
+    // DPS verifier needs, and it avoids computing the output shape here (no
+    // tensor.empty + tensor.dim).
+    ::mlir::Value init =
+        rewriter.create<PlaceholderOp>(loc, ::mlir::TypeRange{resultType})
+            .getResult(0);
+
+    // Shape region left empty (zero blocks); a later pass populates it.
+    auto matmulOp = rewriter.create<MatMulOp>(
+        loc, ::mlir::TypeRange{resultType}, a, b, init);
+
+    rewriter.replaceOp(op, matmulOp.getResult(0));
+    return ::mlir::success();
+  }
+};
+
+} // namespace
+
+void populateMatMulConversionPatterns(::mlir::RewritePatternSet &patterns,
+                                      ::mlir::MLIRContext *ctx) {
+  patterns.add<MatMulToHipsr>(ctx);
+}
+
+} // namespace hipsr
+} // namespace mlir

--- a/lib/Conversion/OnnxToHipsr/MatMulConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/MatMulConversion.cpp
@@ -8,23 +8,40 @@
 #include "hip/Dialect/Hipsr/IR/HipsrMatMulOp.h"
 #include "hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.h"
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/PatternMatch.h"
 
 namespace mlir {
 namespace hipsr {
 namespace {
 
+/// Gets the `!hipsr.context` from function argument 0. The ONNX phase adds it
+/// as the enclosing function's first argument, so every hipsr op can thread it
+/// as its own first operand. Returns failure (so the pattern bails) if the
+/// function has no arguments or arg 0 is not `!hipsr.context`.
+::mlir::FailureOr<::mlir::Value>
+getHipsrContextArg(::mlir::Operation *op, ::mlir::PatternRewriter &rewriter) {
+  auto funcOp = op->getParentOfType<::mlir::func::FuncOp>();
+  if (!funcOp || funcOp.getBody().empty())
+    return rewriter.notifyMatchFailure(op, "not inside a function body");
+  ::mlir::Block &entry = funcOp.getBody().front();
+  if (entry.getNumArguments() == 0)
+    return rewriter.notifyMatchFailure(op, "function has no arguments");
+  ::mlir::Value ctx = entry.getArgument(0);
+  if (!::mlir::isa<::mlir::hipsr::ContextType>(ctx.getType()))
+    return rewriter.notifyMatchFailure(op,
+                                       "first argument is not !hipsr.context");
+  return ctx;
+}
+
 /// onnx.MatMul -> hipsr.matmul. The shape region is left empty here; a later
 /// pass populates every op's shape region uniformly (see populateShapeRegion).
-///
-/// The ONNX phase prepends the per-session `!hipsr.context` as operand 0 of
-/// every onnx op, so the conversion reads it straight off this op's first
-/// operand (not from the enclosing function) and threads it onto hipsr.matmul.
+/// The `!hipsr.context` threaded onto the op comes from function arg 0 (added
+/// in the ONNX phase).
 ///
 /// Before:
-///   %0 = "onnx.MatMul"(%ctx, %A, %B)
-///          : (!hipsr.context, tensor<?x?xf16>, tensor<?x?xf16>)
-///          -> tensor<?x?xf16>
+///   %0 = "onnx.MatMul"(%A, %B) : (tensor<?x?xf16>, tensor<?x?xf16>)
+///                                 -> tensor<?x?xf16>
 /// After:
 ///   %init = hipsr.placeholder : tensor<?x?xf16>
 ///   %0 = hipsr.matmul(%ctx) ins(%A, %B : tensor<?x?xf16>, tensor<?x?xf16>)
@@ -36,21 +53,19 @@ struct MatMulToHipsr : public ::mlir::RewritePattern {
   ::mlir::LogicalResult
   matchAndRewrite(::mlir::Operation *op,
                   ::mlir::PatternRewriter &rewriter) const override {
-    // Matching is by name on an (unregistered) ONNX op, so guard the shape.
-    // With the ONNX phase's ctx-prepend, a threaded onnx.MatMul carries
-    // ctx + the two matrix inputs (three operands), single-result.
-    if (op->getNumOperands() != 3 || op->getNumResults() != 1)
+    // Matching is by name on an (unregistered) ONNX op, so guard the shape:
+    // onnx.MatMul is two-input / single-result.
+    if (op->getNumOperands() != 2 || op->getNumResults() != 1)
       return rewriter.notifyMatchFailure(
-          op, "expected a context operand, two matrix operands, one result");
+          op, "expected two operands and a single result");
 
-    // %ctx is the op's first operand (prepended in the ONNX phase).
-    ::mlir::Value ctx = op->getOperand(0);
-    if (!::mlir::isa<::mlir::hipsr::ContextType>(ctx.getType()))
-      return rewriter.notifyMatchFailure(op, "operand 0 is not !hipsr.context");
+    ::mlir::FailureOr<::mlir::Value> ctx = getHipsrContextArg(op, rewriter);
+    if (::mlir::failed(ctx))
+      return ::mlir::failure();
 
     ::mlir::Location loc = op->getLoc();
-    ::mlir::Value a = op->getOperand(1);
-    ::mlir::Value b = op->getOperand(2);
+    ::mlir::Value a = op->getOperand(0);
+    ::mlir::Value b = op->getOperand(1);
     auto resultType =
         ::mlir::dyn_cast<::mlir::RankedTensorType>(op->getResult(0).getType());
     if (!resultType)
@@ -65,7 +80,7 @@ struct MatMulToHipsr : public ::mlir::RewritePattern {
 
     // Shape region left empty (zero blocks); a later pass populates it.
     auto matmulOp = rewriter.create<MatMulOp>(
-        loc, ::mlir::TypeRange{resultType}, ctx, a, b, init);
+        loc, ::mlir::TypeRange{resultType}, *ctx, a, b, init);
 
     rewriter.replaceOp(op, matmulOp.getResult(0));
     return ::mlir::success();

--- a/lib/Conversion/OnnxToHipsr/MatMulConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/MatMulConversion.cpp
@@ -4,25 +4,48 @@
  */
 
 #include "hip/Conversion/OnnxToHipsr/OnnxToHipsr.h"
+#include "hip/Dialect/Hipsr/IR/HipsrDialect.h"
 #include "hip/Dialect/Hipsr/IR/HipsrMatMulOp.h"
 #include "hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.h"
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/PatternMatch.h"
 
 namespace mlir {
 namespace hipsr {
 namespace {
 
+/// Gets the `!hipsr.context` from function argument 0. The ONNX phase adds it
+/// as the enclosing function's first argument, so every hipsr op can thread it
+/// as its own first operand. Returns failure (so the pattern bails) if the
+/// function has no arguments or arg 0 is not `!hipsr.context`.
+::mlir::FailureOr<::mlir::Value>
+getHipsrContextArg(::mlir::Operation *op, ::mlir::PatternRewriter &rewriter) {
+  auto funcOp = op->getParentOfType<::mlir::func::FuncOp>();
+  if (!funcOp || funcOp.getBody().empty())
+    return rewriter.notifyMatchFailure(op, "not inside a function body");
+  ::mlir::Block &entry = funcOp.getBody().front();
+  if (entry.getNumArguments() == 0)
+    return rewriter.notifyMatchFailure(op, "function has no arguments");
+  ::mlir::Value ctx = entry.getArgument(0);
+  if (!::mlir::isa<::mlir::hipsr::ContextType>(ctx.getType()))
+    return rewriter.notifyMatchFailure(op,
+                                       "first argument is not !hipsr.context");
+  return ctx;
+}
+
 /// onnx.MatMul -> hipsr.matmul. The shape region is left empty here; a later
 /// pass populates every op's shape region uniformly (see populateShapeRegion).
+/// The `!hipsr.context` threaded onto the op comes from function arg 0 (added
+/// in the ONNX phase).
 ///
 /// Before:
 ///   %0 = "onnx.MatMul"(%A, %B) : (tensor<?x?xf16>, tensor<?x?xf16>)
 ///                                 -> tensor<?x?xf16>
 /// After:
 ///   %init = hipsr.placeholder : tensor<?x?xf16>
-///   %0 = hipsr.matmul ins(%A, %B : tensor<?x?xf16>, tensor<?x?xf16>)
-///                     outs(%init : tensor<?x?xf16>) -> tensor<?x?xf16>
+///   %0 = hipsr.matmul(%ctx) ins(%A, %B : tensor<?x?xf16>, tensor<?x?xf16>)
+///                           outs(%init : tensor<?x?xf16>) : tensor<?x?xf16>
 struct MatMulToHipsr : public ::mlir::RewritePattern {
   MatMulToHipsr(::mlir::MLIRContext *ctx)
       : RewritePattern("onnx.MatMul", /*benefit=*/1, ctx) {}
@@ -35,6 +58,10 @@ struct MatMulToHipsr : public ::mlir::RewritePattern {
     if (op->getNumOperands() != 2 || op->getNumResults() != 1)
       return rewriter.notifyMatchFailure(
           op, "expected two operands and a single result");
+
+    ::mlir::FailureOr<::mlir::Value> ctx = getHipsrContextArg(op, rewriter);
+    if (::mlir::failed(ctx))
+      return ::mlir::failure();
 
     ::mlir::Location loc = op->getLoc();
     ::mlir::Value a = op->getOperand(0);
@@ -53,7 +80,7 @@ struct MatMulToHipsr : public ::mlir::RewritePattern {
 
     // Shape region left empty (zero blocks); a later pass populates it.
     auto matmulOp = rewriter.create<MatMulOp>(
-        loc, ::mlir::TypeRange{resultType}, a, b, init);
+        loc, ::mlir::TypeRange{resultType}, *ctx, a, b, init);
 
     rewriter.replaceOp(op, matmulOp.getResult(0));
     return ::mlir::success();

--- a/lib/Conversion/OnnxToHipsr/MatMulConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/MatMulConversion.cpp
@@ -14,8 +14,7 @@ namespace hipsr {
 namespace {
 
 /// onnx.MatMul -> hipsr.matmul. The shape region is left empty here; a later
-/// pass populates every op's shape region uniformly (see populateShapeRegion,
-/// which also emits the K/batch checks).
+/// pass populates every op's shape region uniformly (see populateShapeRegion).
 ///
 /// Before:
 ///   %0 = "onnx.MatMul"(%A, %B) : (tensor<?x?xf16>, tensor<?x?xf16>)

--- a/lib/Conversion/OnnxToHipsr/MatMulConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/MatMulConversion.cpp
@@ -3,36 +3,18 @@
  * Licensed under the MIT License.
  */
 
+#include "OnnxToHipsrUtils.h"
+
 #include "hip/Conversion/OnnxToHipsr/OnnxToHipsr.h"
 #include "hip/Dialect/Hipsr/IR/HipsrDialect.h"
 #include "hip/Dialect/Hipsr/IR/HipsrMatMulOp.h"
 #include "hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.h"
 
-#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/PatternMatch.h"
 
 namespace mlir {
 namespace hipsr {
 namespace {
-
-/// Gets the `!hipsr.context` from function argument 0. The ONNX phase adds it
-/// as the enclosing function's first argument, so every hipsr op can thread it
-/// as its own first operand. Returns failure (so the pattern bails) if the
-/// function has no arguments or arg 0 is not `!hipsr.context`.
-::mlir::FailureOr<::mlir::Value>
-getHipsrContextArg(::mlir::Operation *op, ::mlir::PatternRewriter &rewriter) {
-  auto funcOp = op->getParentOfType<::mlir::func::FuncOp>();
-  if (!funcOp || funcOp.getBody().empty())
-    return rewriter.notifyMatchFailure(op, "not inside a function body");
-  ::mlir::Block &entry = funcOp.getBody().front();
-  if (entry.getNumArguments() == 0)
-    return rewriter.notifyMatchFailure(op, "function has no arguments");
-  ::mlir::Value ctx = entry.getArgument(0);
-  if (!::mlir::isa<::mlir::hipsr::ContextType>(ctx.getType()))
-    return rewriter.notifyMatchFailure(op,
-                                       "first argument is not !hipsr.context");
-  return ctx;
-}
 
 /// onnx.MatMul -> hipsr.matmul. The shape region is left empty here; a later
 /// pass populates every op's shape region uniformly (see populateShapeRegion).
@@ -55,30 +37,31 @@ struct MatMulToHipsr : public ::mlir::RewritePattern {
                   ::mlir::PatternRewriter &rewriter) const override {
     // Matching is by name on an (unregistered) ONNX op, so guard the shape:
     // onnx.MatMul is two-input / single-result.
-    if (op->getNumOperands() != 2 || op->getNumResults() != 1)
+    if (op->getNumOperands() != 2 || op->getNumResults() != 1) {
       return rewriter.notifyMatchFailure(
           op, "expected two operands and a single result");
+    }
 
     ::mlir::FailureOr<::mlir::Value> ctx = getHipsrContextArg(op, rewriter);
-    if (::mlir::failed(ctx))
+    if (::mlir::failed(ctx)) {
       return ::mlir::failure();
+    }
 
     ::mlir::Location loc = op->getLoc();
     ::mlir::Value a = op->getOperand(0);
     ::mlir::Value b = op->getOperand(1);
     auto resultType =
         ::mlir::dyn_cast<::mlir::RankedTensorType>(op->getResult(0).getType());
-    if (!resultType)
+    if (!resultType) {
       return rewriter.notifyMatchFailure(op, "expected ranked tensor result");
+    }
 
-    // DPS init: a hipsr.placeholder mirroring the result type. That is all the
-    // DPS verifier needs, and it avoids computing the output shape here (no
-    // tensor.empty + tensor.dim).
+    // A hipsr.placeholder mirroring the result type satisfies the DPS verifier
+    // without computing the output shape here; a later pass fills that in.
     ::mlir::Value init =
         rewriter.create<PlaceholderOp>(loc, ::mlir::TypeRange{resultType})
             .getResult(0);
 
-    // Shape region left empty (zero blocks); a later pass populates it.
     auto matmulOp = rewriter.create<MatMulOp>(
         loc, ::mlir::TypeRange{resultType}, *ctx, a, b, init);
 

--- a/lib/Conversion/OnnxToHipsr/MatMulConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/MatMulConversion.cpp
@@ -8,40 +8,23 @@
 #include "hip/Dialect/Hipsr/IR/HipsrMatMulOp.h"
 #include "hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.h"
 
-#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/PatternMatch.h"
 
 namespace mlir {
 namespace hipsr {
 namespace {
 
-/// Gets the `!hipsr.context` from function argument 0. The ONNX phase adds it
-/// as the enclosing function's first argument, so every hipsr op can thread it
-/// as its own first operand. Returns failure (so the pattern bails) if the
-/// function has no arguments or arg 0 is not `!hipsr.context`.
-::mlir::FailureOr<::mlir::Value>
-getHipsrContextArg(::mlir::Operation *op, ::mlir::PatternRewriter &rewriter) {
-  auto funcOp = op->getParentOfType<::mlir::func::FuncOp>();
-  if (!funcOp || funcOp.getBody().empty())
-    return rewriter.notifyMatchFailure(op, "not inside a function body");
-  ::mlir::Block &entry = funcOp.getBody().front();
-  if (entry.getNumArguments() == 0)
-    return rewriter.notifyMatchFailure(op, "function has no arguments");
-  ::mlir::Value ctx = entry.getArgument(0);
-  if (!::mlir::isa<::mlir::hipsr::ContextType>(ctx.getType()))
-    return rewriter.notifyMatchFailure(op,
-                                       "first argument is not !hipsr.context");
-  return ctx;
-}
-
 /// onnx.MatMul -> hipsr.matmul. The shape region is left empty here; a later
 /// pass populates every op's shape region uniformly (see populateShapeRegion).
-/// The `!hipsr.context` threaded onto the op comes from function arg 0 (added
-/// in the ONNX phase).
+///
+/// The ONNX phase prepends the per-session `!hipsr.context` as operand 0 of
+/// every onnx op, so the conversion reads it straight off this op's first
+/// operand (not from the enclosing function) and threads it onto hipsr.matmul.
 ///
 /// Before:
-///   %0 = "onnx.MatMul"(%A, %B) : (tensor<?x?xf16>, tensor<?x?xf16>)
-///                                 -> tensor<?x?xf16>
+///   %0 = "onnx.MatMul"(%ctx, %A, %B)
+///          : (!hipsr.context, tensor<?x?xf16>, tensor<?x?xf16>)
+///          -> tensor<?x?xf16>
 /// After:
 ///   %init = hipsr.placeholder : tensor<?x?xf16>
 ///   %0 = hipsr.matmul(%ctx) ins(%A, %B : tensor<?x?xf16>, tensor<?x?xf16>)
@@ -53,19 +36,21 @@ struct MatMulToHipsr : public ::mlir::RewritePattern {
   ::mlir::LogicalResult
   matchAndRewrite(::mlir::Operation *op,
                   ::mlir::PatternRewriter &rewriter) const override {
-    // Matching is by name on an (unregistered) ONNX op, so guard the shape:
-    // onnx.MatMul is two-input / single-result.
-    if (op->getNumOperands() != 2 || op->getNumResults() != 1)
+    // Matching is by name on an (unregistered) ONNX op, so guard the shape.
+    // With the ONNX phase's ctx-prepend, a threaded onnx.MatMul carries
+    // ctx + the two matrix inputs (three operands), single-result.
+    if (op->getNumOperands() != 3 || op->getNumResults() != 1)
       return rewriter.notifyMatchFailure(
-          op, "expected two operands and a single result");
+          op, "expected a context operand, two matrix operands, one result");
 
-    ::mlir::FailureOr<::mlir::Value> ctx = getHipsrContextArg(op, rewriter);
-    if (::mlir::failed(ctx))
-      return ::mlir::failure();
+    // %ctx is the op's first operand (prepended in the ONNX phase).
+    ::mlir::Value ctx = op->getOperand(0);
+    if (!::mlir::isa<::mlir::hipsr::ContextType>(ctx.getType()))
+      return rewriter.notifyMatchFailure(op, "operand 0 is not !hipsr.context");
 
     ::mlir::Location loc = op->getLoc();
-    ::mlir::Value a = op->getOperand(0);
-    ::mlir::Value b = op->getOperand(1);
+    ::mlir::Value a = op->getOperand(1);
+    ::mlir::Value b = op->getOperand(2);
     auto resultType =
         ::mlir::dyn_cast<::mlir::RankedTensorType>(op->getResult(0).getType());
     if (!resultType)
@@ -80,7 +65,7 @@ struct MatMulToHipsr : public ::mlir::RewritePattern {
 
     // Shape region left empty (zero blocks); a later pass populates it.
     auto matmulOp = rewriter.create<MatMulOp>(
-        loc, ::mlir::TypeRange{resultType}, *ctx, a, b, init);
+        loc, ::mlir::TypeRange{resultType}, ctx, a, b, init);
 
     rewriter.replaceOp(op, matmulOp.getResult(0));
     return ::mlir::success();

--- a/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
+++ b/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
@@ -34,6 +34,7 @@ struct ConvertOnnxToHipsrPass
     ::mlir::RewritePatternSet patterns(&getContext());
     populateOnnxToHipsrConstantPatterns(patterns);
     populateCastConversionPatterns(patterns, &getContext());
+    populateMatMulConversionPatterns(patterns, &getContext());
 
     // Same driver/config as convert-onnx-to-hip (greedy, ExistingOps): ONNX ops
     // are matched by name and only the ops present on entry are rewritten, so

--- a/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
+++ b/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
@@ -6,9 +6,8 @@
 //
 // Converts ONNX dialect IR into hipsr dialect IR (tensor DPS). ONNX ops are
 // matched by name via the generic MLIR Operation API, so no onnx-mlir headers
-// are required. Each shaped op fills its shape region through
-// ShapeRegionInterface::populateShapeRegion(), so this pass exercises that
-// single-source-of-truth path.
+// are required. Each pattern emits the hipsr op with its shape region left
+// empty; a later pass fills the region via ShapeRegionInterface.
 //
 //===----------------------------------------------------------------------===//
 

--- a/lib/Conversion/OnnxToHipsr/OnnxToHipsrUtils.h
+++ b/lib/Conversion/OnnxToHipsr/OnnxToHipsrUtils.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- OnnxToHipsrUtils.h - Shared helpers for ONNX-to-hipsr patterns ----===//
+//
+// Shared utility functions used by the per-operator ONNX-to-hipsr conversion
+// files. Private to lib/Conversion/OnnxToHipsr (not an installed public
+// header), mirroring lib/Conversion/OnnxToHip/OnnxToHipUtils.h.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HIP_CONVERSION_ONNXTOHIPSR_UTILS_H
+#define HIP_CONVERSION_ONNXTOHIPSR_UTILS_H
+
+#include "hip/Dialect/Hipsr/IR/HipsrDialect.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/PatternMatch.h"
+
+namespace mlir {
+namespace hipsr {
+
+/// Gets the `!hipsr.context` from function argument 0. The ONNX phase adds it
+/// as the enclosing function's first argument, so every hipsr op can thread it
+/// as its own first operand (mirrors hip's getContextArg). Returns failure (so
+/// the calling pattern bails) if the op is not inside a function body, the
+/// function has no arguments, or arg 0 is not `!hipsr.context`.
+inline ::mlir::FailureOr<::mlir::Value>
+getHipsrContextArg(::mlir::Operation *op, ::mlir::PatternRewriter &rewriter) {
+  auto funcOp = op->getParentOfType<::mlir::func::FuncOp>();
+  if (!funcOp || funcOp.getBody().empty()) {
+    return rewriter.notifyMatchFailure(op, "not inside a function body");
+  }
+  ::mlir::Block &entry = funcOp.getBody().front();
+  if (entry.getNumArguments() == 0) {
+    return rewriter.notifyMatchFailure(op, "function has no arguments");
+  }
+  ::mlir::Value ctx = entry.getArgument(0);
+  if (!::mlir::isa<::mlir::hipsr::ContextType>(ctx.getType())) {
+    return rewriter.notifyMatchFailure(op,
+                                       "first argument is not !hipsr.context");
+  }
+  return ctx;
+}
+
+} // namespace hipsr
+} // namespace mlir
+
+#endif // HIP_CONVERSION_ONNXTOHIPSR_UTILS_H

--- a/lib/Dialect/Hipsr/IR/CMakeLists.txt
+++ b/lib/Dialect/Hipsr/IR/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(HipsrDialectIR STATIC
   HipsrPlaceholderOp.cpp
   HipsrTraits.cpp
   HipsrCastOp.cpp
+  HipsrMatMulOp.cpp
   HipsrTypes.cpp
 )
 
@@ -30,5 +31,6 @@ target_link_libraries(HipsrDialectIR PUBLIC
   MLIRIR
   MLIRSupport
   MLIRArithDialect
+  MLIRControlFlowDialect
   MLIRShapeDialect
 )

--- a/lib/Dialect/Hipsr/IR/CMakeLists.txt
+++ b/lib/Dialect/Hipsr/IR/CMakeLists.txt
@@ -31,6 +31,5 @@ target_link_libraries(HipsrDialectIR PUBLIC
   MLIRIR
   MLIRSupport
   MLIRArithDialect
-  MLIRControlFlowDialect
   MLIRShapeDialect
 )

--- a/lib/Dialect/Hipsr/IR/HipsrDialect.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrDialect.cpp
@@ -73,13 +73,15 @@ llvm::MemoryBuffer *HipsrDialect::getOrLoadFileMap(llvm::StringRef path) {
   std::lock_guard<std::mutex> lock(fileMapsMutex);
 
   auto it = fileMaps.find(path);
-  if (it != fileMaps.end())
+  if (it != fileMaps.end()) {
     return it->second.get();
+  }
 
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> bufOr =
       llvm::MemoryBuffer::getFile(path, /*IsText=*/false);
-  if (!bufOr)
+  if (!bufOr) {
     return nullptr;
+  }
 
   llvm::MemoryBuffer *raw = bufOr->get();
   fileMaps[path] = std::move(*bufOr);

--- a/lib/Dialect/Hipsr/IR/HipsrDialect.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrDialect.cpp
@@ -7,6 +7,7 @@
 
 #include "hip/Dialect/Hipsr/IR/HipsrCastOp.h"
 #include "hip/Dialect/Hipsr/IR/HipsrConstantOp.h"
+#include "hip/Dialect/Hipsr/IR/HipsrMatMulOp.h"
 #include "hip/Dialect/Hipsr/IR/HipsrOps.h"
 #include "hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.h"
 #include "hip/Dialect/Hipsr/IR/HipsrPoolDomainOp.h"
@@ -49,6 +50,9 @@ void HipsrDialect::initialize() {
       ,
 #define GET_OP_LIST
 #include "hip/Dialect/Hipsr/IR/HipsrCastOp.cpp.inc"
+      ,
+#define GET_OP_LIST
+#include "hip/Dialect/Hipsr/IR/HipsrMatMulOp.cpp.inc"
       ,
 #define GET_OP_LIST
 #include "hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.cpp.inc"

--- a/lib/Dialect/Hipsr/IR/HipsrMatMulOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrMatMulOp.cpp
@@ -22,6 +22,18 @@ using namespace mlir::hipsr;
 // DestinationStyleOpInterface: the single init operand is the DPS out.
 MutableOperandRange MatMulOp::getDpsInitsMutable() { return getInitMutable(); }
 
+// A and B must be at least 1-D. matmul needs a contraction dim, and
+// populateShapeRegion below indexes the last one or two dims of each operand
+// (promoting a 1-D operand to 2-D). A rank-0 operand has no such dim and would
+// produce out-of-range shape.get_extent indices.
+LogicalResult MatMulOp::verify() {
+  if (cast<ShapedType>(getA().getType()).getRank() < 1)
+    return emitOpError("operand A must be at least 1-D");
+  if (cast<ShapedType>(getB().getType()).getRank() < 1)
+    return emitOpError("operand B must be at least 1-D");
+  return success();
+}
+
 // Fills the shape region with the ONNX/NumPy `matmul` output shape and its
 // constraint asserts. Uses the shape dialect so it works for both tensor and
 // memref inputs; static dims fold, so a fully static matmul canonicalizes the

--- a/lib/Dialect/Hipsr/IR/HipsrMatMulOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrMatMulOp.cpp
@@ -6,7 +6,6 @@
 #include "hip/Dialect/Hipsr/IR/HipsrMatMulOp.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
-#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Shape/IR/Shape.h"
 
 #include "llvm/ADT/Sequence.h"
@@ -33,31 +32,28 @@ LogicalResult MatMulOp::verify() {
   return success();
 }
 
-// Fills the shape region with the ONNX/NumPy `matmul` output shape and its
-// constraint asserts. Uses the shape dialect so it works for both tensor and
-// memref inputs; static dims fold, so a fully static matmul canonicalizes the
-// asserts/selects away.
+// Fills the shape region with the ONNX/NumPy `matmul` output shape. Uses the
+// shape dialect so it works for both tensor and memref inputs; static dims
+// fold, so a fully static matmul canonicalizes the dim arithmetic away.
 //
-// ONNX/NumPy matmul rules (each maps to a branch below):
-//   - both >= 2-D: last two dims are the matrix (M,K)x(K,N)->(M,N); leading
-//   dims
-//     are batch dims and broadcast (equal, or one is 1).
+// ONNX/NumPy matmul output shape (each maps to a branch below):
+//   - both >= 2-D: (M,K) x (K,N) -> (M,N); leading dims are batch dims and
+//     broadcast (a dim of 1 takes the other side).
 //   - 1-D A (K): acts as (1,K); the leading 1 is dropped from the result.
 //   - 1-D B (K): acts as (K,1); the trailing 1 is dropped from the result.
 //   - both 1-D: scalar result.
-// The 1-D promotions and batch-dim count come from the static ranks, so only
-// the K check and batch broadcast are runtime values.
+// The 1-D promotions and batch-dim count come from the static ranks. Only the
+// output shape is computed here; the validity checks (K equality, batch
+// broadcastability) are emitted by the shape-region populate pass, which is
+// where they belong with the shape dialect.
 //
 // Before (region omitted, as emitted by convert-onnx-to-hipsr):
 //   %0 = hipsr.matmul ins(%A, %B : tensor<?x?xf16>, tensor<?x?xf16>)
 //                     outs(%init : tensor<?x?xf16>) -> tensor<?x?xf16>
 //
-// After (2-D case; batched adds one arith.select per broadcast batch axis):
+// After (2-D case; batched adds one dim per broadcast batch axis):
 //   %0 = hipsr.matmul ins(%A, %B) outs(%init) -> tensor<?x?xf16> shape_region {
 //     %shA = shape.shape_of %A ; %shB = shape.shape_of %B
-//     %ka = shape.get_extent %shA, 1 ; %kb = shape.get_extent %shB, 0
-//     %eq = arith.cmpi eq, %ka, %kb
-//     cf.assert %eq, "hipsr.matmul: A and B contraction dim (K) must be equal"
 //     %m = shape.get_extent %shA, 0 ; %n = shape.get_extent %shB, 1
 //     hipsr.shape_yield (%m, %n) : [f16]
 //   }
@@ -77,23 +73,10 @@ void MatMulOp::populateShapeRegion(OpBuilder &builder, Region &shapeRegion) {
     return builder.create<shape::GetExtentOp>(loc, shape, c);
   };
   Value one = builder.create<arith::ConstantIndexOp>(loc, 1);
-  auto isOne = [&](Value v) -> Value {
-    return builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq, v, one);
-  };
-  auto assertTrue = [&](Value cond, StringRef msg) {
-    builder.create<cf::AssertOp>(loc, cond, builder.getStringAttr(msg));
-  };
-  // Broadcast two dims: if either is 1, take the other; otherwise assert equal.
+  // Broadcast two batch dims: a dim of 1 takes the other side.
   auto broadcastDim = [&](Value da, Value db) -> Value {
-    Value aIs1 = isOne(da);
-    Value bIs1 = isOne(db);
-    Value eq =
-        builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq, da, db);
-    Value compat = builder.create<arith::OrIOp>(loc, eq, aIs1);
-    compat = builder.create<arith::OrIOp>(loc, compat, bIs1);
-    assertTrue(compat,
-               "hipsr.matmul: batch dims of A and B must be broadcastable");
-    // Pick the non-1 side (if both are 1, either gives 1).
+    Value aIs1 =
+        builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq, da, one);
     return builder.create<arith::SelectOp>(loc, aIs1, db, da);
   };
 
@@ -103,13 +86,6 @@ void MatMulOp::populateShapeRegion(OpBuilder &builder, Region &shapeRegion) {
   bool bIs1D = bRank == 1;
   int64_t aEffRank = aIs1D ? 2 : aRank;
   int64_t bEffRank = bIs1D ? 2 : bRank;
-
-  // K: A's last dim == B's second-to-last dim. A 1-D operand's sole dim is K.
-  Value ka = aIs1D ? extent(shA, 0) : extent(shA, aRank - 1);
-  Value kb = bIs1D ? extent(shB, 0) : extent(shB, bRank - 2);
-  Value kEq =
-      builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq, ka, kb);
-  assertTrue(kEq, "hipsr.matmul: A and B contraction dim (K) must be equal");
 
   // M from A, N from B. A 1-D operand contributes neither (its promoted unit
   // dim is stripped from the result).

--- a/lib/Dialect/Hipsr/IR/HipsrMatMulOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrMatMulOp.cpp
@@ -22,10 +22,9 @@ using namespace mlir::hipsr;
 // DestinationStyleOpInterface: the single init operand is the DPS out.
 MutableOperandRange MatMulOp::getDpsInitsMutable() { return getInitMutable(); }
 
-// A and B must be at least 1-D. matmul needs a contraction dim, and
-// populateShapeRegion below indexes the last one or two dims of each operand
-// (promoting a 1-D operand to 2-D). A rank-0 operand has no such dim and would
-// produce out-of-range shape.get_extent indices.
+// A and B must be at least 1-D: matmul needs a contraction dim, and the shape
+// region below reads the last one or two dims of each operand. A rank-0
+// (scalar) operand has neither.
 LogicalResult MatMulOp::verify() {
   if (cast<ShapedType>(getA().getType()).getRank() < 1)
     return emitOpError("operand A must be at least 1-D");

--- a/lib/Dialect/Hipsr/IR/HipsrMatMulOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrMatMulOp.cpp
@@ -32,9 +32,11 @@ LogicalResult MatMulOp::verify() {
   return success();
 }
 
-// Fills the shape region with the ONNX/NumPy `matmul` output shape. Uses the
-// shape dialect so it works for both tensor and memref inputs; static dims
-// fold, so a fully static matmul canonicalizes the dim arithmetic away.
+// Fills the shape region with the ONNX/NumPy `matmul` output shape, guarded by
+// a contraction-dim (K) equality constraint. Uses the shape dialect so it works
+// for both tensor and memref inputs; static dims fold to constants, so a fully
+// static matmul keeps no dim arithmetic (and shape.cstr_eq folds its witness
+// away, leaving no constraint IR).
 //
 // ONNX/NumPy matmul output shape (each maps to a branch below):
 //   - both >= 2-D: (M,K) x (K,N) -> (M,N); leading dims are batch dims and
@@ -42,19 +44,32 @@ LogicalResult MatMulOp::verify() {
 //   - 1-D A (K): acts as (1,K); the leading 1 is dropped from the result.
 //   - 1-D B (K): acts as (K,1); the trailing 1 is dropped from the result.
 //   - both 1-D: scalar result.
-// The 1-D promotions and batch-dim count come from the static ranks. This
-// computes only the output shape; validity checks (K equality, batch
-// broadcastability) are intentionally omitted and can be added later.
+// The 1-D promotions and batch-dim count come from the static ranks.
+//
+// The contraction dim K (A's last dim; B's last dim when B is 1-D, else its
+// second-to-last) is not part of the output shape, but ONNX requires the two
+// sides to match. That is expressed as a shape.cstr_eq witness guarding a
+// shape.assuming region that yields the output dims, so a later
+// shape-constraint lowering can turn it into a runtime check while a static
+// match folds it away. Batch-dim broadcast compatibility is still left
+// unchecked and can be added the same way later.
 //
 // Before (region omitted, as emitted by convert-onnx-to-hipsr):
-//   %0 = hipsr.matmul ins(%A, %B : tensor<?x?xf16>, tensor<?x?xf16>)
-//                     outs(%init : tensor<?x?xf16>) -> tensor<?x?xf16>
+//   %0 = hipsr.matmul(%ctx) ins(%A, %B : tensor<?x?xf16>, tensor<?x?xf16>)
+//                           outs(%init : tensor<?x?xf16>) : tensor<?x?xf16>
 //
 // After (2-D case; batched adds one dim per broadcast batch axis):
-//   %0 = hipsr.matmul ins(%A, %B) outs(%init) -> tensor<?x?xf16> shape_region {
+//   %0 = hipsr.matmul(%ctx) ins(%A, %B) outs(%init) : tensor<?x?xf16>
+//   shape_region {
 //     %shA = shape.shape_of %A ; %shB = shape.shape_of %B
-//     %m = shape.get_extent %shA, 0 ; %n = shape.get_extent %shB, 1
-//     hipsr.shape_yield (%m, %n) : [f16]
+//     %kA = shape.get_extent %shA, 1 ; %kB = shape.get_extent %shB, 0
+//     %sa = shape.from_extents %kA ; %sb = shape.from_extents %kB
+//     %w  = shape.cstr_eq %sa, %sb
+//     %d:2 = shape.assuming %w -> (index, index) {
+//       %m = shape.get_extent %shA, 0 ; %n = shape.get_extent %shB, 1
+//       shape.assuming_yield %m, %n : index, index
+//     }
+//     hipsr.shape_yield (%d#0, %d#1) : [f16]
 //   }
 void MatMulOp::populateShapeRegion(OpBuilder &builder, Region &shapeRegion) {
   OpBuilder::InsertionGuard guard(builder);
@@ -62,62 +77,87 @@ void MatMulOp::populateShapeRegion(OpBuilder &builder, Region &shapeRegion) {
   builder.setInsertionPointToStart(body);
 
   Location loc = getLoc();
+  MLIRContext *ctx = builder.getContext();
   Value shA = builder.create<shape::ShapeOfOp>(loc, getA());
   Value shB = builder.create<shape::ShapeOfOp>(loc, getB());
   int64_t aRank = cast<ShapedType>(getA().getType()).getRank();
   int64_t bRank = cast<ShapedType>(getB().getType()).getRank();
-
-  auto extent = [&](Value shape, int64_t idx) -> Value {
-    Value c = builder.create<arith::ConstantIndexOp>(loc, idx);
-    return builder.create<shape::GetExtentOp>(loc, shape, c);
-  };
-  Value one = builder.create<arith::ConstantIndexOp>(loc, 1);
-  // Broadcast two batch dims: a dim of 1 takes the other side.
-  auto broadcastDim = [&](Value da, Value db) -> Value {
-    Value aIs1 =
-        builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq, da, one);
-    return builder.create<arith::SelectOp>(loc, aIs1, db, da);
-  };
-
-  // A 1-D operand acts as rank 2 for the multiply (A: (1,K), B: (K,1)); the
-  // effective rank drives the batch-dim count below.
   bool aIs1D = aRank == 1;
   bool bIs1D = bRank == 1;
-  int64_t aEffRank = aIs1D ? 2 : aRank;
-  int64_t bEffRank = bIs1D ? 2 : bRank;
 
-  // M from A, N from B. A 1-D operand contributes neither (its promoted unit
-  // dim is stripped from the result).
-  Value m = aIs1D ? Value() : extent(shA, aRank - 2);
-  Value n = bIs1D ? Value() : extent(shB, bRank - 1);
+  auto extent = [&](OpBuilder &b, Value shape, int64_t idx) -> Value {
+    Value c = b.create<arith::ConstantIndexOp>(loc, idx);
+    return b.create<shape::GetExtentOp>(loc, shape, c);
+  };
 
-  // Batch dims: the leading dims of each operand, right-aligned and broadcast.
-  // The result's batch rank is the larger of the two.
-  int64_t aBatch = aEffRank - 2;
-  int64_t bBatch = bEffRank - 2;
-  int64_t batchRank = std::max(aBatch, bBatch);
-  SmallVector<Value> dims;
-  dims.reserve(batchRank + 2);
-  for (int64_t i : llvm::seq<int64_t>(0, batchRank)) {
-    // Right-align: a shorter operand has an implicit 1 at its missing leading
-    // axes, so a negative index means "that side is 1, take the other".
-    int64_t aAxis = i - (batchRank - aBatch);
-    int64_t bAxis = i - (batchRank - bBatch);
-    if (aAxis < 0)
-      dims.push_back(extent(shB, bAxis));
-    else if (bAxis < 0)
-      dims.push_back(extent(shA, aAxis));
-    else
-      dims.push_back(broadcastDim(extent(shA, aAxis), extent(shB, bAxis)));
-  }
-  // Append M then N, skipping the promoted (later-stripped) unit dims.
-  if (m)
-    dims.push_back(m);
-  if (n)
-    dims.push_back(n);
+  // Constrain the contraction dim K (A's last dim == B's K dim) even though K
+  // never reaches the output: wrap each K extent in a rank-1 shape and require
+  // them equal. shape.cstr_eq folds to a passing witness when both are static
+  // and equal, so a static matmul carries no constraint.
+  int64_t kAIdx = aRank - 1;
+  int64_t kBIdx = bIs1D ? bRank - 1 : bRank - 2;
+  auto shapeTy = shape::ShapeType::get(ctx);
+  Value sa = builder.create<shape::FromExtentsOp>(
+      loc, shapeTy, ValueRange{extent(builder, shA, kAIdx)});
+  Value sb = builder.create<shape::FromExtentsOp>(
+      loc, shapeTy, ValueRange{extent(builder, shB, kBIdx)});
+  Value witness = builder.create<shape::CstrEqOp>(
+      loc, shape::WitnessType::get(ctx), ValueRange{sa, sb});
 
-  // Single result: one dim group and its (output) element type.
+  // The output dims are produced inside the shape.assuming region, so they are
+  // valid under the K-equal assumption.
+  auto assuming = builder.create<shape::AssumingOp>(
+      loc, witness, [&](OpBuilder &b, Location) -> SmallVector<Value, 2> {
+        Value one = b.create<arith::ConstantIndexOp>(loc, 1);
+        // Broadcast two batch dims: a dim of 1 takes the other side.
+        auto broadcastDim = [&](Value da, Value db) -> Value {
+          Value aIs1 =
+              b.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq, da, one);
+          return b.create<arith::SelectOp>(loc, aIs1, db, da);
+        };
+
+        // A 1-D operand acts as rank 2 for the multiply (A: (1,K), B: (K,1));
+        // the effective rank drives the batch-dim count below.
+        int64_t aEffRank = aIs1D ? 2 : aRank;
+        int64_t bEffRank = bIs1D ? 2 : bRank;
+
+        // M from A, N from B. A 1-D operand contributes neither (its promoted
+        // unit dim is stripped from the result).
+        Value m = aIs1D ? Value() : extent(b, shA, aRank - 2);
+        Value n = bIs1D ? Value() : extent(b, shB, bRank - 1);
+
+        // Batch dims: the leading dims of each operand, right-aligned and
+        // broadcast. The result's batch rank is the larger of the two.
+        int64_t aBatch = aEffRank - 2;
+        int64_t bBatch = bEffRank - 2;
+        int64_t batchRank = std::max(aBatch, bBatch);
+        SmallVector<Value, 2> dims;
+        dims.reserve(batchRank + 2);
+        for (int64_t i : llvm::seq<int64_t>(0, batchRank)) {
+          // Right-align: a shorter operand has an implicit 1 at its missing
+          // leading axes, so a negative index means "that side is 1, take the
+          // other".
+          int64_t aAxis = i - (batchRank - aBatch);
+          int64_t bAxis = i - (batchRank - bBatch);
+          if (aAxis < 0)
+            dims.push_back(extent(b, shB, bAxis));
+          else if (bAxis < 0)
+            dims.push_back(extent(b, shA, aAxis));
+          else
+            dims.push_back(
+                broadcastDim(extent(b, shA, aAxis), extent(b, shB, bAxis)));
+        }
+        // Append M then N, skipping the promoted (later-stripped) unit dims.
+        if (m)
+          dims.push_back(m);
+        if (n)
+          dims.push_back(n);
+        return dims;
+      });
+
+  // Single result: one dim group (the assuming results) and its (output)
+  // element type.
   Type elemTy = cast<ShapedType>(getResult(0).getType()).getElementType();
-  builder.create<ShapeYieldOp>(loc, ArrayRef<ValueRange>{ValueRange(dims)},
+  builder.create<ShapeYieldOp>(loc, ArrayRef<ValueRange>{assuming.getResults()},
                                TypeRange{elemTy});
 }

--- a/lib/Dialect/Hipsr/IR/HipsrMatMulOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrMatMulOp.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "hip/Dialect/Hipsr/IR/HipsrMatMulOp.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/Dialect/Shape/IR/Shape.h"
+
+#include "llvm/ADT/Sequence.h"
+
+#include <algorithm>
+
+using namespace mlir;
+using namespace mlir::hipsr;
+
+#define GET_OP_CLASSES
+#include "hip/Dialect/Hipsr/IR/HipsrMatMulOp.cpp.inc"
+
+// DestinationStyleOpInterface: the single init operand is the DPS out.
+MutableOperandRange MatMulOp::getDpsInitsMutable() { return getInitMutable(); }
+
+// Fills the shape region with the ONNX/NumPy `matmul` output shape and its
+// constraint asserts. Uses the shape dialect so it works for both tensor and
+// memref inputs; static dims fold, so a fully static matmul canonicalizes the
+// asserts/selects away.
+//
+// ONNX/NumPy matmul rules (each maps to a branch below):
+//   - both >= 2-D: last two dims are the matrix (M,K)x(K,N)->(M,N); leading
+//   dims
+//     are batch dims and broadcast (equal, or one is 1).
+//   - 1-D A (K): acts as (1,K); the leading 1 is dropped from the result.
+//   - 1-D B (K): acts as (K,1); the trailing 1 is dropped from the result.
+//   - both 1-D: scalar result.
+// The 1-D promotions and batch-dim count come from the static ranks, so only
+// the K check and batch broadcast are runtime values.
+//
+// Before (region omitted, as emitted by convert-onnx-to-hipsr):
+//   %0 = hipsr.matmul ins(%A, %B : tensor<?x?xf16>, tensor<?x?xf16>)
+//                     outs(%init : tensor<?x?xf16>) -> tensor<?x?xf16>
+//
+// After (2-D case; batched adds one arith.select per broadcast batch axis):
+//   %0 = hipsr.matmul ins(%A, %B) outs(%init) -> tensor<?x?xf16> shape_region {
+//     %shA = shape.shape_of %A ; %shB = shape.shape_of %B
+//     %ka = shape.get_extent %shA, 1 ; %kb = shape.get_extent %shB, 0
+//     %eq = arith.cmpi eq, %ka, %kb
+//     cf.assert %eq, "hipsr.matmul: A and B contraction dim (K) must be equal"
+//     %m = shape.get_extent %shA, 0 ; %n = shape.get_extent %shB, 1
+//     hipsr.shape_yield (%m, %n) : [f16]
+//   }
+void MatMulOp::populateShapeRegion(OpBuilder &builder, Region &shapeRegion) {
+  OpBuilder::InsertionGuard guard(builder);
+  Block *body = builder.createBlock(&shapeRegion);
+  builder.setInsertionPointToStart(body);
+
+  Location loc = getLoc();
+  Value shA = builder.create<shape::ShapeOfOp>(loc, getA());
+  Value shB = builder.create<shape::ShapeOfOp>(loc, getB());
+  int64_t aRank = cast<ShapedType>(getA().getType()).getRank();
+  int64_t bRank = cast<ShapedType>(getB().getType()).getRank();
+
+  auto extent = [&](Value shape, int64_t idx) -> Value {
+    Value c = builder.create<arith::ConstantIndexOp>(loc, idx);
+    return builder.create<shape::GetExtentOp>(loc, shape, c);
+  };
+  Value one = builder.create<arith::ConstantIndexOp>(loc, 1);
+  auto isOne = [&](Value v) -> Value {
+    return builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq, v, one);
+  };
+  auto assertTrue = [&](Value cond, StringRef msg) {
+    builder.create<cf::AssertOp>(loc, cond, builder.getStringAttr(msg));
+  };
+  // Broadcast two dims: if either is 1, take the other; otherwise assert equal.
+  auto broadcastDim = [&](Value da, Value db) -> Value {
+    Value aIs1 = isOne(da);
+    Value bIs1 = isOne(db);
+    Value eq =
+        builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq, da, db);
+    Value compat = builder.create<arith::OrIOp>(loc, eq, aIs1);
+    compat = builder.create<arith::OrIOp>(loc, compat, bIs1);
+    assertTrue(compat,
+               "hipsr.matmul: batch dims of A and B must be broadcastable");
+    // Pick the non-1 side (if both are 1, either gives 1).
+    return builder.create<arith::SelectOp>(loc, aIs1, db, da);
+  };
+
+  // A 1-D operand acts as rank 2 for the multiply (A: (1,K), B: (K,1)); the
+  // effective rank drives the batch-dim count below.
+  bool aIs1D = aRank == 1;
+  bool bIs1D = bRank == 1;
+  int64_t aEffRank = aIs1D ? 2 : aRank;
+  int64_t bEffRank = bIs1D ? 2 : bRank;
+
+  // K: A's last dim == B's second-to-last dim. A 1-D operand's sole dim is K.
+  Value ka = aIs1D ? extent(shA, 0) : extent(shA, aRank - 1);
+  Value kb = bIs1D ? extent(shB, 0) : extent(shB, bRank - 2);
+  Value kEq =
+      builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq, ka, kb);
+  assertTrue(kEq, "hipsr.matmul: A and B contraction dim (K) must be equal");
+
+  // M from A, N from B. A 1-D operand contributes neither (its promoted unit
+  // dim is stripped from the result).
+  Value m = aIs1D ? Value() : extent(shA, aRank - 2);
+  Value n = bIs1D ? Value() : extent(shB, bRank - 1);
+
+  // Batch dims: the leading dims of each operand, right-aligned and broadcast.
+  // The result's batch rank is the larger of the two.
+  int64_t aBatch = aEffRank - 2;
+  int64_t bBatch = bEffRank - 2;
+  int64_t batchRank = std::max(aBatch, bBatch);
+  SmallVector<Value> dims;
+  dims.reserve(batchRank + 2);
+  for (int64_t i : llvm::seq<int64_t>(0, batchRank)) {
+    // Right-align: a shorter operand has an implicit 1 at its missing leading
+    // axes, so a negative index means "that side is 1, take the other".
+    int64_t aAxis = i - (batchRank - aBatch);
+    int64_t bAxis = i - (batchRank - bBatch);
+    if (aAxis < 0)
+      dims.push_back(extent(shB, bAxis));
+    else if (bAxis < 0)
+      dims.push_back(extent(shA, aAxis));
+    else
+      dims.push_back(broadcastDim(extent(shA, aAxis), extent(shB, bAxis)));
+  }
+  // Append M then N, skipping the promoted (later-stripped) unit dims.
+  if (m)
+    dims.push_back(m);
+  if (n)
+    dims.push_back(n);
+
+  // Single result: one dim group and its (output) element type.
+  Type elemTy = cast<ShapedType>(getResult(0).getType()).getElementType();
+  builder.create<ShapeYieldOp>(loc, ArrayRef<ValueRange>{ValueRange(dims)},
+                               TypeRange{elemTy});
+}

--- a/lib/Dialect/Hipsr/IR/HipsrMatMulOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrMatMulOp.cpp
@@ -42,10 +42,9 @@ LogicalResult MatMulOp::verify() {
 //   - 1-D A (K): acts as (1,K); the leading 1 is dropped from the result.
 //   - 1-D B (K): acts as (K,1); the trailing 1 is dropped from the result.
 //   - both 1-D: scalar result.
-// The 1-D promotions and batch-dim count come from the static ranks. Only the
-// output shape is computed here; the validity checks (K equality, batch
-// broadcastability) are emitted by the shape-region populate pass, which is
-// where they belong with the shape dialect.
+// The 1-D promotions and batch-dim count come from the static ranks. This
+// computes only the output shape; validity checks (K equality, batch
+// broadcastability) are intentionally omitted and can be added later.
 //
 // Before (region omitted, as emitted by convert-onnx-to-hipsr):
 //   %0 = hipsr.matmul ins(%A, %B : tensor<?x?xf16>, tensor<?x?xf16>)

--- a/lib/Dialect/Hipsr/IR/HipsrMatMulOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrMatMulOp.cpp
@@ -25,34 +25,26 @@ MutableOperandRange MatMulOp::getDpsInitsMutable() { return getInitMutable(); }
 // region below reads the last one or two dims of each operand. A rank-0
 // (scalar) operand has neither.
 LogicalResult MatMulOp::verify() {
-  if (cast<ShapedType>(getA().getType()).getRank() < 1)
+  if (cast<ShapedType>(getA().getType()).getRank() < 1) {
     return emitOpError("operand A must be at least 1-D");
-  if (cast<ShapedType>(getB().getType()).getRank() < 1)
+  }
+  if (cast<ShapedType>(getB().getType()).getRank() < 1) {
     return emitOpError("operand B must be at least 1-D");
+  }
   return success();
 }
 
-// Fills the shape region with the ONNX/NumPy `matmul` output shape, guarded by
-// a contraction-dim (K) equality constraint. Uses the shape dialect so it works
-// for both tensor and memref inputs; static dims fold to constants, so a fully
-// static matmul keeps no dim arithmetic (and shape.cstr_eq folds its witness
-// away, leaving no constraint IR).
+// Fills the shape region with the ONNX/NumPy matmul output shape (semantics in
+// HipsrMatMulOp.td), guarded by a contraction-dim (K) equality constraint.
 //
-// ONNX/NumPy matmul output shape (each maps to a branch below):
-//   - both >= 2-D: (M,K) x (K,N) -> (M,N); leading dims are batch dims and
-//     broadcast (a dim of 1 takes the other side).
-//   - 1-D A (K): acts as (1,K); the leading 1 is dropped from the result.
-//   - 1-D B (K): acts as (K,1); the trailing 1 is dropped from the result.
-//   - both 1-D: scalar result.
-// The 1-D promotions and batch-dim count come from the static ranks.
-//
-// The contraction dim K (A's last dim; B's last dim when B is 1-D, else its
-// second-to-last) is not part of the output shape, but ONNX requires the two
-// sides to match. That is expressed as a shape.cstr_eq witness guarding a
-// shape.assuming region that yields the output dims, so a later
-// shape-constraint lowering can turn it into a runtime check while a static
-// match folds it away. Batch-dim broadcast compatibility is still left
-// unchecked and can be added the same way later.
+// The shape dialect is used (over tensor.dim / arith) so the same code covers
+// both tensor and memref inputs and static dims fold to constants -- a fully
+// static matmul then keeps no dim arithmetic and shape.cstr_eq folds its
+// witness away, leaving no constraint IR. K never reaches the output, but ONNX
+// requires both sides to match, so the equality is a shape.cstr_eq witness
+// guarding the shape.assuming region that yields the output dims; a later
+// shape-constraint lowering can turn it into a runtime check, and a static
+// match drops it. (Batch-dim broadcast compatibility is not yet checked.)
 //
 // Before (region omitted, as emitted by convert-onnx-to-hipsr):
 //   %0 = hipsr.matmul(%ctx) ins(%A, %B : tensor<?x?xf16>, tensor<?x?xf16>)
@@ -90,10 +82,7 @@ void MatMulOp::populateShapeRegion(OpBuilder &builder, Region &shapeRegion) {
     return b.create<shape::GetExtentOp>(loc, shape, c);
   };
 
-  // Constrain the contraction dim K (A's last dim == B's K dim) even though K
-  // never reaches the output: wrap each K extent in a rank-1 shape and require
-  // them equal. shape.cstr_eq folds to a passing witness when both are static
-  // and equal, so a static matmul carries no constraint.
+  // K is A's last dim; B's last dim when B is 1-D, else its second-to-last.
   int64_t kAIdx = aRank - 1;
   int64_t kBIdx = bIs1D ? bRank - 1 : bRank - 2;
   auto shapeTy = shape::ShapeType::get(ctx);
@@ -104,8 +93,7 @@ void MatMulOp::populateShapeRegion(OpBuilder &builder, Region &shapeRegion) {
   Value witness = builder.create<shape::CstrEqOp>(
       loc, shape::WitnessType::get(ctx), ValueRange{sa, sb});
 
-  // The output dims are produced inside the shape.assuming region, so they are
-  // valid under the K-equal assumption.
+  // Output dims go inside the region so they hold under the K-equal assumption.
   auto assuming = builder.create<shape::AssumingOp>(
       loc, witness, [&](OpBuilder &b, Location) -> SmallVector<Value, 2> {
         Value one = b.create<arith::ConstantIndexOp>(loc, 1);
@@ -139,24 +127,25 @@ void MatMulOp::populateShapeRegion(OpBuilder &builder, Region &shapeRegion) {
           // other".
           int64_t aAxis = i - (batchRank - aBatch);
           int64_t bAxis = i - (batchRank - bBatch);
-          if (aAxis < 0)
+          if (aAxis < 0) {
             dims.push_back(extent(b, shB, bAxis));
-          else if (bAxis < 0)
+          } else if (bAxis < 0) {
             dims.push_back(extent(b, shA, aAxis));
-          else
+          } else {
             dims.push_back(
                 broadcastDim(extent(b, shA, aAxis), extent(b, shB, bAxis)));
+          }
         }
         // Append M then N, skipping the promoted (later-stripped) unit dims.
-        if (m)
+        if (m) {
           dims.push_back(m);
-        if (n)
+        }
+        if (n) {
           dims.push_back(n);
+        }
         return dims;
       });
 
-  // Single result: one dim group (the assuming results) and its (output)
-  // element type.
   Type elemTy = cast<ShapedType>(getResult(0).getType()).getElementType();
   builder.create<ShapeYieldOp>(loc, ArrayRef<ValueRange>{assuming.getResults()},
                                TypeRange{elemTy});

--- a/test/lit/Conversion/onnx-to-hipsr/matmul.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/matmul.mlir
@@ -3,11 +3,10 @@
 //
 //===----------------------------------------------------------------------===//
 // Converts onnx.MatMul to hipsr.matmul. The conversion mirrors the result type
-// into a hipsr.placeholder init, threads the !hipsr.context taken from the onnx
-// op's own first operand (the ONNX phase prepends it) onto the op, and leaves
-// the shape region empty (a later pass fills it). It does not branch on
-// rank/shape, so two cases cover it: a plain 2-D matmul and a 1-D-operand
-// matmul (the rank-reducing ONNX case).
+// into a hipsr.placeholder init, threads the !hipsr.context from function arg 0
+// (added in the ONNX phase) onto the op, and leaves the shape region empty (a
+// later pass fills it). It does not branch on rank/shape, so two cases cover
+// it: a plain 2-D matmul and a 1-D-operand matmul (the rank-reducing ONNX case).
 //
 // Positive CHECKs were seeded with mlir/utils/generate-test-checks.py (piped
 // from the -convert-onnx-to-hipsr output) and then refined: captures renamed,
@@ -30,8 +29,7 @@
 // CHECK-NOT:     shape_region
 func.func @matmul_2d(%ctx: !hipsr.context, %a: tensor<?x4096xf16>,
                      %b: tensor<4096x1024xf16>) -> tensor<?x1024xf16> {
-  %0 = "onnx.MatMul"(%ctx, %a, %b)
-      : (!hipsr.context, tensor<?x4096xf16>, tensor<4096x1024xf16>)
+  %0 = "onnx.MatMul"(%a, %b) : (tensor<?x4096xf16>, tensor<4096x1024xf16>)
       -> tensor<?x1024xf16>
   return %0 : tensor<?x1024xf16>
 }
@@ -52,8 +50,7 @@ func.func @matmul_2d(%ctx: !hipsr.context, %a: tensor<?x4096xf16>,
 // CHECK-NOT:     shape_region
 func.func @matmul_1d_rhs(%ctx: !hipsr.context, %a: tensor<?x4096xf16>,
                          %b: tensor<4096xf16>) -> tensor<?xf16> {
-  %0 = "onnx.MatMul"(%ctx, %a, %b)
-      : (!hipsr.context, tensor<?x4096xf16>, tensor<4096xf16>)
+  %0 = "onnx.MatMul"(%a, %b) : (tensor<?x4096xf16>, tensor<4096xf16>)
       -> tensor<?xf16>
   return %0 : tensor<?xf16>
 }

--- a/test/lit/Conversion/onnx-to-hipsr/matmul.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/matmul.mlir
@@ -1,0 +1,106 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+//===----------------------------------------------------------------------===//
+// Converts onnx.MatMul to hipsr.matmul. The shape region is left empty (zero
+// blocks); a later dedicated pass fills in the shape computation (and the K /
+// batch shape checks), so this stage does not populate it.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt %s -allow-unregistered-dialect -convert-onnx-to-hipsr | FileCheck %s
+
+// 2-D x 2-D.
+// CHECK-LABEL: func.func @matmul_2d
+func.func @matmul_2d(%a: tensor<?x4096xf16>, %b: tensor<4096x1024xf16>)
+    -> tensor<?x1024xf16> {
+  // The DPS init is a hipsr.placeholder that mirrors the result type, so no
+  // output-shape computation (tensor.empty / tensor.dim) is emitted here.
+  // CHECK: %[[INIT:.+]] = hipsr.placeholder : tensor<?x1024xf16>
+  // The shape region is left empty (zero blocks) here; a later pass populates
+  // it. The optional region group prints nothing when the region is empty.
+  // CHECK: hipsr.matmul ins(%[[A:.+]], %[[B:.+]] : tensor<?x4096xf16>, tensor<4096x1024xf16>) outs(%[[INIT]] : tensor<?x1024xf16>) -> tensor<?x1024xf16>
+  // CHECK-NOT: tensor.empty
+  // CHECK-NOT: tensor.dim
+  // CHECK-NOT: shape_region
+  %0 = "onnx.MatMul"(%a, %b) : (tensor<?x4096xf16>, tensor<4096x1024xf16>)
+      -> tensor<?x1024xf16>
+  return %0 : tensor<?x1024xf16>
+}
+
+// -----
+
+// Batched 3-D x 2-D (broadcast weight): batch + M from A, N from B's last dim.
+// CHECK-LABEL: func.func @matmul_batched
+func.func @matmul_batched(%a: tensor<2x?x4096xf16>, %b: tensor<4096x1024xf16>)
+    -> tensor<2x?x1024xf16> {
+  // CHECK: %[[INIT:.+]] = hipsr.placeholder : tensor<2x?x1024xf16>
+  // CHECK: hipsr.matmul ins(%[[A:.+]], %[[B:.+]] : tensor<2x?x4096xf16>, tensor<4096x1024xf16>) outs(%[[INIT]] : tensor<2x?x1024xf16>) -> tensor<2x?x1024xf16>
+  // CHECK-NOT: shape_region
+  %0 = "onnx.MatMul"(%a, %b) : (tensor<2x?x4096xf16>, tensor<4096x1024xf16>)
+      -> tensor<2x?x1024xf16>
+  return %0 : tensor<2x?x1024xf16>
+}
+
+// -----
+
+// 4-D x 4-D equally-batched: the conversion just mirrors the result type into
+// the placeholder init and leaves the region empty, so rank does not matter.
+// CHECK-LABEL: func.func @matmul_4d
+func.func @matmul_4d(%a: tensor<2x3x?x4096xf16>, %b: tensor<2x3x4096x1024xf16>)
+    -> tensor<2x3x?x1024xf16> {
+  // CHECK: %[[INIT:.+]] = hipsr.placeholder : tensor<2x3x?x1024xf16>
+  // CHECK: hipsr.matmul ins(%[[A:.+]], %[[B:.+]] : tensor<2x3x?x4096xf16>, tensor<2x3x4096x1024xf16>) outs(%[[INIT]] : tensor<2x3x?x1024xf16>) -> tensor<2x3x?x1024xf16>
+  // CHECK-NOT: tensor.empty
+  // CHECK-NOT: tensor.dim
+  // CHECK-NOT: shape_region
+  %0 = "onnx.MatMul"(%a, %b) : (tensor<2x3x?x4096xf16>, tensor<2x3x4096x1024xf16>)
+      -> tensor<2x3x?x1024xf16>
+  return %0 : tensor<2x3x?x1024xf16>
+}
+
+// -----
+
+// 4-D x 2-D broadcast weight: leading batch dims + M from A, N from B's last
+// dim. Fully static A/B shapes -> fully static result placeholder.
+// CHECK-LABEL: func.func @matmul_4d_by_2d
+func.func @matmul_4d_by_2d(%a: tensor<2x3x64x4096xf16>, %b: tensor<4096x1024xf16>)
+    -> tensor<2x3x64x1024xf16> {
+  // CHECK: %[[INIT:.+]] = hipsr.placeholder : tensor<2x3x64x1024xf16>
+  // CHECK: hipsr.matmul ins(%[[A:.+]], %[[B:.+]] : tensor<2x3x64x4096xf16>, tensor<4096x1024xf16>) outs(%[[INIT]] : tensor<2x3x64x1024xf16>) -> tensor<2x3x64x1024xf16>
+  // CHECK-NOT: shape_region
+  %0 = "onnx.MatMul"(%a, %b) : (tensor<2x3x64x4096xf16>, tensor<4096x1024xf16>)
+      -> tensor<2x3x64x1024xf16>
+  return %0 : tensor<2x3x64x1024xf16>
+}
+
+// -----
+
+// 1-D B (ONNX/NumPy): (M,K) @ (K) -> (M). The conversion mirrors the 1-D ONNX
+// result type into the placeholder; populateShapeRegion later handles the
+// promote-and-strip.
+// CHECK-LABEL: func.func @matmul_1d_rhs
+func.func @matmul_1d_rhs(%a: tensor<?x4096xf16>, %b: tensor<4096xf16>)
+    -> tensor<?xf16> {
+  // CHECK: %[[INIT:.+]] = hipsr.placeholder : tensor<?xf16>
+  // CHECK: hipsr.matmul ins(%[[A:.+]], %[[B:.+]] : tensor<?x4096xf16>, tensor<4096xf16>) outs(%[[INIT]] : tensor<?xf16>) -> tensor<?xf16>
+  // CHECK-NOT: shape_region
+  %0 = "onnx.MatMul"(%a, %b) : (tensor<?x4096xf16>, tensor<4096xf16>)
+      -> tensor<?xf16>
+  return %0 : tensor<?xf16>
+}
+
+// -----
+
+// NumPy batch broadcast (A batch dim 1, B batch dim 8 -> 8). The conversion is
+// shape-agnostic; the broadcast is resolved in the result type it mirrors.
+// CHECK-LABEL: func.func @matmul_broadcast_batch
+func.func @matmul_broadcast_batch(%a: tensor<1x64x4096xf16>,
+                                  %b: tensor<8x4096x1024xf16>)
+    -> tensor<8x64x1024xf16> {
+  // CHECK: %[[INIT:.+]] = hipsr.placeholder : tensor<8x64x1024xf16>
+  // CHECK: hipsr.matmul ins(%[[A:.+]], %[[B:.+]] : tensor<1x64x4096xf16>, tensor<8x4096x1024xf16>) outs(%[[INIT]] : tensor<8x64x1024xf16>) -> tensor<8x64x1024xf16>
+  // CHECK-NOT: shape_region
+  %0 = "onnx.MatMul"(%a, %b) : (tensor<1x64x4096xf16>, tensor<8x4096x1024xf16>)
+      -> tensor<8x64x1024xf16>
+  return %0 : tensor<8x64x1024xf16>
+}

--- a/test/lit/Conversion/onnx-to-hipsr/matmul.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/matmul.mlir
@@ -6,6 +6,11 @@
 // blocks); a later dedicated pass fills in the shape computation, so this stage
 // does not populate it.
 //
+// The conversion is shape-agnostic: it mirrors the result type into a
+// hipsr.placeholder init and leaves the region empty, with no rank/shape
+// branching. So a few representative shapes suffice: a 2-D case, a 1-D-operand
+// (rank-reducing) case, and a batched case.
+//
 // The positive CHECK lines were seeded with mlir/utils/generate-test-checks.py
 // (full signature + named operand captures), then refined by hand: the
 // CHECK-NOT intent checks (no tensor.empty/tensor.dim/shape_region) were
@@ -19,9 +24,9 @@
 
 // -----
 
-// 2-D x 2-D: the DPS init is a hipsr.placeholder mirroring the result type, so
-// no output-shape computation (tensor.empty / tensor.dim) is emitted, and the
-// shape region is left empty (prints nothing).
+// 2-D x 2-D (dynamic M): the DPS init is a hipsr.placeholder mirroring the
+// result type, so no output-shape computation (tensor.empty / tensor.dim) is
+// emitted, and the shape region is left empty (prints nothing).
 // CHECK-LABEL: func.func @matmul_2d(
 // CHECK-SAME:    %[[A:.*]]: tensor<?x4096xf16>,
 // CHECK-SAME:    %[[B:.*]]: tensor<4096x1024xf16>) -> tensor<?x1024xf16> {
@@ -40,64 +45,8 @@ func.func @matmul_2d(%a: tensor<?x4096xf16>, %b: tensor<4096x1024xf16>)
 
 // -----
 
-// Batched 3-D x 2-D (broadcast weight): batch + M from A, N from B's last dim.
-// CHECK-LABEL: func.func @matmul_batched(
-// CHECK-SAME:    %[[A:.*]]: tensor<2x?x4096xf16>,
-// CHECK-SAME:    %[[B:.*]]: tensor<4096x1024xf16>) -> tensor<2x?x1024xf16> {
-// CHECK:         %[[INIT:.*]] = hipsr.placeholder : tensor<2x?x1024xf16>
-// CHECK:         hipsr.matmul ins(%[[A]], %[[B]] : tensor<2x?x4096xf16>, tensor<4096x1024xf16>)
-// CHECK-SAME:      outs(%[[INIT]] : tensor<2x?x1024xf16>) -> tensor<2x?x1024xf16>
-// CHECK-NOT:     shape_region
-func.func @matmul_batched(%a: tensor<2x?x4096xf16>, %b: tensor<4096x1024xf16>)
-    -> tensor<2x?x1024xf16> {
-  %0 = "onnx.MatMul"(%a, %b) : (tensor<2x?x4096xf16>, tensor<4096x1024xf16>)
-      -> tensor<2x?x1024xf16>
-  return %0 : tensor<2x?x1024xf16>
-}
-
-// -----
-
-// 4-D x 4-D equally-batched: the conversion mirrors the result type into the
-// placeholder init and leaves the region empty, so rank does not matter.
-// CHECK-LABEL: func.func @matmul_4d(
-// CHECK-SAME:    %[[A:.*]]: tensor<2x3x?x4096xf16>,
-// CHECK-SAME:    %[[B:.*]]: tensor<2x3x4096x1024xf16>) -> tensor<2x3x?x1024xf16> {
-// CHECK:         %[[INIT:.*]] = hipsr.placeholder : tensor<2x3x?x1024xf16>
-// CHECK:         hipsr.matmul ins(%[[A]], %[[B]] : tensor<2x3x?x4096xf16>, tensor<2x3x4096x1024xf16>)
-// CHECK-SAME:      outs(%[[INIT]] : tensor<2x3x?x1024xf16>) -> tensor<2x3x?x1024xf16>
-// CHECK-NOT:     tensor.empty
-// CHECK-NOT:     tensor.dim
-// CHECK-NOT:     shape_region
-func.func @matmul_4d(%a: tensor<2x3x?x4096xf16>, %b: tensor<2x3x4096x1024xf16>)
-    -> tensor<2x3x?x1024xf16> {
-  %0 = "onnx.MatMul"(%a, %b) : (tensor<2x3x?x4096xf16>, tensor<2x3x4096x1024xf16>)
-      -> tensor<2x3x?x1024xf16>
-  return %0 : tensor<2x3x?x1024xf16>
-}
-
-// -----
-
-// 4-D x 2-D broadcast weight: leading batch dims + M from A, N from B's last
-// dim. Fully static A/B shapes -> fully static result placeholder.
-// CHECK-LABEL: func.func @matmul_4d_by_2d(
-// CHECK-SAME:    %[[A:.*]]: tensor<2x3x64x4096xf16>,
-// CHECK-SAME:    %[[B:.*]]: tensor<4096x1024xf16>) -> tensor<2x3x64x1024xf16> {
-// CHECK:         %[[INIT:.*]] = hipsr.placeholder : tensor<2x3x64x1024xf16>
-// CHECK:         hipsr.matmul ins(%[[A]], %[[B]] : tensor<2x3x64x4096xf16>, tensor<4096x1024xf16>)
-// CHECK-SAME:      outs(%[[INIT]] : tensor<2x3x64x1024xf16>) -> tensor<2x3x64x1024xf16>
-// CHECK-NOT:     shape_region
-func.func @matmul_4d_by_2d(%a: tensor<2x3x64x4096xf16>, %b: tensor<4096x1024xf16>)
-    -> tensor<2x3x64x1024xf16> {
-  %0 = "onnx.MatMul"(%a, %b) : (tensor<2x3x64x4096xf16>, tensor<4096x1024xf16>)
-      -> tensor<2x3x64x1024xf16>
-  return %0 : tensor<2x3x64x1024xf16>
-}
-
-// -----
-
-// 1-D B (ONNX/NumPy): (M,K) @ (K) -> (M). The conversion mirrors the 1-D ONNX
-// result type into the placeholder; populateShapeRegion later handles the
-// promote-and-strip.
+// 1-D B (ONNX/NumPy): (M,K) @ (K) -> (M), a rank-reducing result. The
+// conversion still just mirrors the result type into the placeholder.
 // CHECK-LABEL: func.func @matmul_1d_rhs(
 // CHECK-SAME:    %[[A:.*]]: tensor<?x4096xf16>,
 // CHECK-SAME:    %[[B:.*]]: tensor<4096xf16>) -> tensor<?xf16> {
@@ -114,8 +63,8 @@ func.func @matmul_1d_rhs(%a: tensor<?x4096xf16>, %b: tensor<4096xf16>)
 
 // -----
 
-// NumPy batch broadcast (A batch dim 1, B batch dim 8 -> 8). The conversion is
-// shape-agnostic; the broadcast is resolved in the result type it mirrors.
+// Batched with NumPy batch broadcast (A batch dim 1, B batch dim 8 -> 8). The
+// broadcast is resolved in the result type the conversion mirrors.
 // CHECK-LABEL: func.func @matmul_broadcast_batch(
 // CHECK-SAME:    %[[A:.*]]: tensor<1x64x4096xf16>,
 // CHECK-SAME:    %[[B:.*]]: tensor<8x4096x1024xf16>) -> tensor<8x64x1024xf16> {

--- a/test/lit/Conversion/onnx-to-hipsr/matmul.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/matmul.mlir
@@ -6,6 +6,11 @@
 // blocks); a later dedicated pass fills in the shape computation, so this stage
 // does not populate it.
 //
+// The positive CHECK lines were seeded with mlir/utils/generate-test-checks.py
+// (full signature + named operand captures), then refined by hand: the
+// CHECK-NOT intent checks (no tensor.empty/tensor.dim/shape_region) were
+// re-added and the return/terminator boilerplate dropped.
+//
 // Each case is one module (split by `// -----`); all CHECK directives are
 // grouped in the header above the function, isolated by CHECK-LABEL.
 //===----------------------------------------------------------------------===//
@@ -17,13 +22,15 @@
 // 2-D x 2-D: the DPS init is a hipsr.placeholder mirroring the result type, so
 // no output-shape computation (tensor.empty / tensor.dim) is emitted, and the
 // shape region is left empty (prints nothing).
-// CHECK-LABEL: func.func @matmul_2d
-// CHECK: %[[INIT:.+]] = hipsr.placeholder : tensor<?x1024xf16>
-// CHECK: hipsr.matmul ins(%{{.+}}, %{{.+}} : tensor<?x4096xf16>, tensor<4096x1024xf16>)
-// CHECK-SAME: outs(%[[INIT]] : tensor<?x1024xf16>) -> tensor<?x1024xf16>
-// CHECK-NOT: tensor.empty
-// CHECK-NOT: tensor.dim
-// CHECK-NOT: shape_region
+// CHECK-LABEL: func.func @matmul_2d(
+// CHECK-SAME:    %[[A:.*]]: tensor<?x4096xf16>,
+// CHECK-SAME:    %[[B:.*]]: tensor<4096x1024xf16>) -> tensor<?x1024xf16> {
+// CHECK:         %[[INIT:.*]] = hipsr.placeholder : tensor<?x1024xf16>
+// CHECK:         hipsr.matmul ins(%[[A]], %[[B]] : tensor<?x4096xf16>, tensor<4096x1024xf16>)
+// CHECK-SAME:      outs(%[[INIT]] : tensor<?x1024xf16>) -> tensor<?x1024xf16>
+// CHECK-NOT:     tensor.empty
+// CHECK-NOT:     tensor.dim
+// CHECK-NOT:     shape_region
 func.func @matmul_2d(%a: tensor<?x4096xf16>, %b: tensor<4096x1024xf16>)
     -> tensor<?x1024xf16> {
   %0 = "onnx.MatMul"(%a, %b) : (tensor<?x4096xf16>, tensor<4096x1024xf16>)
@@ -34,11 +41,13 @@ func.func @matmul_2d(%a: tensor<?x4096xf16>, %b: tensor<4096x1024xf16>)
 // -----
 
 // Batched 3-D x 2-D (broadcast weight): batch + M from A, N from B's last dim.
-// CHECK-LABEL: func.func @matmul_batched
-// CHECK: %[[INIT:.+]] = hipsr.placeholder : tensor<2x?x1024xf16>
-// CHECK: hipsr.matmul ins(%{{.+}}, %{{.+}} : tensor<2x?x4096xf16>, tensor<4096x1024xf16>)
-// CHECK-SAME: outs(%[[INIT]] : tensor<2x?x1024xf16>) -> tensor<2x?x1024xf16>
-// CHECK-NOT: shape_region
+// CHECK-LABEL: func.func @matmul_batched(
+// CHECK-SAME:    %[[A:.*]]: tensor<2x?x4096xf16>,
+// CHECK-SAME:    %[[B:.*]]: tensor<4096x1024xf16>) -> tensor<2x?x1024xf16> {
+// CHECK:         %[[INIT:.*]] = hipsr.placeholder : tensor<2x?x1024xf16>
+// CHECK:         hipsr.matmul ins(%[[A]], %[[B]] : tensor<2x?x4096xf16>, tensor<4096x1024xf16>)
+// CHECK-SAME:      outs(%[[INIT]] : tensor<2x?x1024xf16>) -> tensor<2x?x1024xf16>
+// CHECK-NOT:     shape_region
 func.func @matmul_batched(%a: tensor<2x?x4096xf16>, %b: tensor<4096x1024xf16>)
     -> tensor<2x?x1024xf16> {
   %0 = "onnx.MatMul"(%a, %b) : (tensor<2x?x4096xf16>, tensor<4096x1024xf16>)
@@ -50,13 +59,15 @@ func.func @matmul_batched(%a: tensor<2x?x4096xf16>, %b: tensor<4096x1024xf16>)
 
 // 4-D x 4-D equally-batched: the conversion mirrors the result type into the
 // placeholder init and leaves the region empty, so rank does not matter.
-// CHECK-LABEL: func.func @matmul_4d
-// CHECK: %[[INIT:.+]] = hipsr.placeholder : tensor<2x3x?x1024xf16>
-// CHECK: hipsr.matmul ins(%{{.+}}, %{{.+}} : tensor<2x3x?x4096xf16>, tensor<2x3x4096x1024xf16>)
-// CHECK-SAME: outs(%[[INIT]] : tensor<2x3x?x1024xf16>) -> tensor<2x3x?x1024xf16>
-// CHECK-NOT: tensor.empty
-// CHECK-NOT: tensor.dim
-// CHECK-NOT: shape_region
+// CHECK-LABEL: func.func @matmul_4d(
+// CHECK-SAME:    %[[A:.*]]: tensor<2x3x?x4096xf16>,
+// CHECK-SAME:    %[[B:.*]]: tensor<2x3x4096x1024xf16>) -> tensor<2x3x?x1024xf16> {
+// CHECK:         %[[INIT:.*]] = hipsr.placeholder : tensor<2x3x?x1024xf16>
+// CHECK:         hipsr.matmul ins(%[[A]], %[[B]] : tensor<2x3x?x4096xf16>, tensor<2x3x4096x1024xf16>)
+// CHECK-SAME:      outs(%[[INIT]] : tensor<2x3x?x1024xf16>) -> tensor<2x3x?x1024xf16>
+// CHECK-NOT:     tensor.empty
+// CHECK-NOT:     tensor.dim
+// CHECK-NOT:     shape_region
 func.func @matmul_4d(%a: tensor<2x3x?x4096xf16>, %b: tensor<2x3x4096x1024xf16>)
     -> tensor<2x3x?x1024xf16> {
   %0 = "onnx.MatMul"(%a, %b) : (tensor<2x3x?x4096xf16>, tensor<2x3x4096x1024xf16>)
@@ -68,11 +79,13 @@ func.func @matmul_4d(%a: tensor<2x3x?x4096xf16>, %b: tensor<2x3x4096x1024xf16>)
 
 // 4-D x 2-D broadcast weight: leading batch dims + M from A, N from B's last
 // dim. Fully static A/B shapes -> fully static result placeholder.
-// CHECK-LABEL: func.func @matmul_4d_by_2d
-// CHECK: %[[INIT:.+]] = hipsr.placeholder : tensor<2x3x64x1024xf16>
-// CHECK: hipsr.matmul ins(%{{.+}}, %{{.+}} : tensor<2x3x64x4096xf16>, tensor<4096x1024xf16>)
-// CHECK-SAME: outs(%[[INIT]] : tensor<2x3x64x1024xf16>) -> tensor<2x3x64x1024xf16>
-// CHECK-NOT: shape_region
+// CHECK-LABEL: func.func @matmul_4d_by_2d(
+// CHECK-SAME:    %[[A:.*]]: tensor<2x3x64x4096xf16>,
+// CHECK-SAME:    %[[B:.*]]: tensor<4096x1024xf16>) -> tensor<2x3x64x1024xf16> {
+// CHECK:         %[[INIT:.*]] = hipsr.placeholder : tensor<2x3x64x1024xf16>
+// CHECK:         hipsr.matmul ins(%[[A]], %[[B]] : tensor<2x3x64x4096xf16>, tensor<4096x1024xf16>)
+// CHECK-SAME:      outs(%[[INIT]] : tensor<2x3x64x1024xf16>) -> tensor<2x3x64x1024xf16>
+// CHECK-NOT:     shape_region
 func.func @matmul_4d_by_2d(%a: tensor<2x3x64x4096xf16>, %b: tensor<4096x1024xf16>)
     -> tensor<2x3x64x1024xf16> {
   %0 = "onnx.MatMul"(%a, %b) : (tensor<2x3x64x4096xf16>, tensor<4096x1024xf16>)
@@ -85,11 +98,13 @@ func.func @matmul_4d_by_2d(%a: tensor<2x3x64x4096xf16>, %b: tensor<4096x1024xf16
 // 1-D B (ONNX/NumPy): (M,K) @ (K) -> (M). The conversion mirrors the 1-D ONNX
 // result type into the placeholder; populateShapeRegion later handles the
 // promote-and-strip.
-// CHECK-LABEL: func.func @matmul_1d_rhs
-// CHECK: %[[INIT:.+]] = hipsr.placeholder : tensor<?xf16>
-// CHECK: hipsr.matmul ins(%{{.+}}, %{{.+}} : tensor<?x4096xf16>, tensor<4096xf16>)
-// CHECK-SAME: outs(%[[INIT]] : tensor<?xf16>) -> tensor<?xf16>
-// CHECK-NOT: shape_region
+// CHECK-LABEL: func.func @matmul_1d_rhs(
+// CHECK-SAME:    %[[A:.*]]: tensor<?x4096xf16>,
+// CHECK-SAME:    %[[B:.*]]: tensor<4096xf16>) -> tensor<?xf16> {
+// CHECK:         %[[INIT:.*]] = hipsr.placeholder : tensor<?xf16>
+// CHECK:         hipsr.matmul ins(%[[A]], %[[B]] : tensor<?x4096xf16>, tensor<4096xf16>)
+// CHECK-SAME:      outs(%[[INIT]] : tensor<?xf16>) -> tensor<?xf16>
+// CHECK-NOT:     shape_region
 func.func @matmul_1d_rhs(%a: tensor<?x4096xf16>, %b: tensor<4096xf16>)
     -> tensor<?xf16> {
   %0 = "onnx.MatMul"(%a, %b) : (tensor<?x4096xf16>, tensor<4096xf16>)
@@ -101,11 +116,13 @@ func.func @matmul_1d_rhs(%a: tensor<?x4096xf16>, %b: tensor<4096xf16>)
 
 // NumPy batch broadcast (A batch dim 1, B batch dim 8 -> 8). The conversion is
 // shape-agnostic; the broadcast is resolved in the result type it mirrors.
-// CHECK-LABEL: func.func @matmul_broadcast_batch
-// CHECK: %[[INIT:.+]] = hipsr.placeholder : tensor<8x64x1024xf16>
-// CHECK: hipsr.matmul ins(%{{.+}}, %{{.+}} : tensor<1x64x4096xf16>, tensor<8x4096x1024xf16>)
-// CHECK-SAME: outs(%[[INIT]] : tensor<8x64x1024xf16>) -> tensor<8x64x1024xf16>
-// CHECK-NOT: shape_region
+// CHECK-LABEL: func.func @matmul_broadcast_batch(
+// CHECK-SAME:    %[[A:.*]]: tensor<1x64x4096xf16>,
+// CHECK-SAME:    %[[B:.*]]: tensor<8x4096x1024xf16>) -> tensor<8x64x1024xf16> {
+// CHECK:         %[[INIT:.*]] = hipsr.placeholder : tensor<8x64x1024xf16>
+// CHECK:         hipsr.matmul ins(%[[A]], %[[B]] : tensor<1x64x4096xf16>, tensor<8x4096x1024xf16>)
+// CHECK-SAME:      outs(%[[INIT]] : tensor<8x64x1024xf16>) -> tensor<8x64x1024xf16>
+// CHECK-NOT:     shape_region
 func.func @matmul_broadcast_batch(%a: tensor<1x64x4096xf16>,
                                   %b: tensor<8x4096x1024xf16>)
     -> tensor<8x64x1024xf16> {

--- a/test/lit/Conversion/onnx-to-hipsr/matmul.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/matmul.mlir
@@ -3,25 +3,29 @@
 //
 //===----------------------------------------------------------------------===//
 // Converts onnx.MatMul to hipsr.matmul. The shape region is left empty (zero
-// blocks); a later dedicated pass fills in the shape computation (and the K /
-// batch shape checks), so this stage does not populate it.
+// blocks); a later dedicated pass fills in the shape computation, so this stage
+// does not populate it.
+//
+// Each case is one module (split by `// -----`); all CHECK directives are
+// grouped in the header above the function, isolated by CHECK-LABEL.
 //===----------------------------------------------------------------------===//
 
 // RUN: hip-mlir-opt %s -allow-unregistered-dialect -convert-onnx-to-hipsr | FileCheck %s
 
-// 2-D x 2-D.
+// -----
+
+// 2-D x 2-D: the DPS init is a hipsr.placeholder mirroring the result type, so
+// no output-shape computation (tensor.empty / tensor.dim) is emitted, and the
+// shape region is left empty (prints nothing).
 // CHECK-LABEL: func.func @matmul_2d
+// CHECK: %[[INIT:.+]] = hipsr.placeholder : tensor<?x1024xf16>
+// CHECK: hipsr.matmul ins(%{{.+}}, %{{.+}} : tensor<?x4096xf16>, tensor<4096x1024xf16>)
+// CHECK-SAME: outs(%[[INIT]] : tensor<?x1024xf16>) -> tensor<?x1024xf16>
+// CHECK-NOT: tensor.empty
+// CHECK-NOT: tensor.dim
+// CHECK-NOT: shape_region
 func.func @matmul_2d(%a: tensor<?x4096xf16>, %b: tensor<4096x1024xf16>)
     -> tensor<?x1024xf16> {
-  // The DPS init is a hipsr.placeholder that mirrors the result type, so no
-  // output-shape computation (tensor.empty / tensor.dim) is emitted here.
-  // CHECK: %[[INIT:.+]] = hipsr.placeholder : tensor<?x1024xf16>
-  // The shape region is left empty (zero blocks) here; a later pass populates
-  // it. The optional region group prints nothing when the region is empty.
-  // CHECK: hipsr.matmul ins(%[[A:.+]], %[[B:.+]] : tensor<?x4096xf16>, tensor<4096x1024xf16>) outs(%[[INIT]] : tensor<?x1024xf16>) -> tensor<?x1024xf16>
-  // CHECK-NOT: tensor.empty
-  // CHECK-NOT: tensor.dim
-  // CHECK-NOT: shape_region
   %0 = "onnx.MatMul"(%a, %b) : (tensor<?x4096xf16>, tensor<4096x1024xf16>)
       -> tensor<?x1024xf16>
   return %0 : tensor<?x1024xf16>
@@ -31,11 +35,12 @@ func.func @matmul_2d(%a: tensor<?x4096xf16>, %b: tensor<4096x1024xf16>)
 
 // Batched 3-D x 2-D (broadcast weight): batch + M from A, N from B's last dim.
 // CHECK-LABEL: func.func @matmul_batched
+// CHECK: %[[INIT:.+]] = hipsr.placeholder : tensor<2x?x1024xf16>
+// CHECK: hipsr.matmul ins(%{{.+}}, %{{.+}} : tensor<2x?x4096xf16>, tensor<4096x1024xf16>)
+// CHECK-SAME: outs(%[[INIT]] : tensor<2x?x1024xf16>) -> tensor<2x?x1024xf16>
+// CHECK-NOT: shape_region
 func.func @matmul_batched(%a: tensor<2x?x4096xf16>, %b: tensor<4096x1024xf16>)
     -> tensor<2x?x1024xf16> {
-  // CHECK: %[[INIT:.+]] = hipsr.placeholder : tensor<2x?x1024xf16>
-  // CHECK: hipsr.matmul ins(%[[A:.+]], %[[B:.+]] : tensor<2x?x4096xf16>, tensor<4096x1024xf16>) outs(%[[INIT]] : tensor<2x?x1024xf16>) -> tensor<2x?x1024xf16>
-  // CHECK-NOT: shape_region
   %0 = "onnx.MatMul"(%a, %b) : (tensor<2x?x4096xf16>, tensor<4096x1024xf16>)
       -> tensor<2x?x1024xf16>
   return %0 : tensor<2x?x1024xf16>
@@ -43,16 +48,17 @@ func.func @matmul_batched(%a: tensor<2x?x4096xf16>, %b: tensor<4096x1024xf16>)
 
 // -----
 
-// 4-D x 4-D equally-batched: the conversion just mirrors the result type into
-// the placeholder init and leaves the region empty, so rank does not matter.
+// 4-D x 4-D equally-batched: the conversion mirrors the result type into the
+// placeholder init and leaves the region empty, so rank does not matter.
 // CHECK-LABEL: func.func @matmul_4d
+// CHECK: %[[INIT:.+]] = hipsr.placeholder : tensor<2x3x?x1024xf16>
+// CHECK: hipsr.matmul ins(%{{.+}}, %{{.+}} : tensor<2x3x?x4096xf16>, tensor<2x3x4096x1024xf16>)
+// CHECK-SAME: outs(%[[INIT]] : tensor<2x3x?x1024xf16>) -> tensor<2x3x?x1024xf16>
+// CHECK-NOT: tensor.empty
+// CHECK-NOT: tensor.dim
+// CHECK-NOT: shape_region
 func.func @matmul_4d(%a: tensor<2x3x?x4096xf16>, %b: tensor<2x3x4096x1024xf16>)
     -> tensor<2x3x?x1024xf16> {
-  // CHECK: %[[INIT:.+]] = hipsr.placeholder : tensor<2x3x?x1024xf16>
-  // CHECK: hipsr.matmul ins(%[[A:.+]], %[[B:.+]] : tensor<2x3x?x4096xf16>, tensor<2x3x4096x1024xf16>) outs(%[[INIT]] : tensor<2x3x?x1024xf16>) -> tensor<2x3x?x1024xf16>
-  // CHECK-NOT: tensor.empty
-  // CHECK-NOT: tensor.dim
-  // CHECK-NOT: shape_region
   %0 = "onnx.MatMul"(%a, %b) : (tensor<2x3x?x4096xf16>, tensor<2x3x4096x1024xf16>)
       -> tensor<2x3x?x1024xf16>
   return %0 : tensor<2x3x?x1024xf16>
@@ -63,11 +69,12 @@ func.func @matmul_4d(%a: tensor<2x3x?x4096xf16>, %b: tensor<2x3x4096x1024xf16>)
 // 4-D x 2-D broadcast weight: leading batch dims + M from A, N from B's last
 // dim. Fully static A/B shapes -> fully static result placeholder.
 // CHECK-LABEL: func.func @matmul_4d_by_2d
+// CHECK: %[[INIT:.+]] = hipsr.placeholder : tensor<2x3x64x1024xf16>
+// CHECK: hipsr.matmul ins(%{{.+}}, %{{.+}} : tensor<2x3x64x4096xf16>, tensor<4096x1024xf16>)
+// CHECK-SAME: outs(%[[INIT]] : tensor<2x3x64x1024xf16>) -> tensor<2x3x64x1024xf16>
+// CHECK-NOT: shape_region
 func.func @matmul_4d_by_2d(%a: tensor<2x3x64x4096xf16>, %b: tensor<4096x1024xf16>)
     -> tensor<2x3x64x1024xf16> {
-  // CHECK: %[[INIT:.+]] = hipsr.placeholder : tensor<2x3x64x1024xf16>
-  // CHECK: hipsr.matmul ins(%[[A:.+]], %[[B:.+]] : tensor<2x3x64x4096xf16>, tensor<4096x1024xf16>) outs(%[[INIT]] : tensor<2x3x64x1024xf16>) -> tensor<2x3x64x1024xf16>
-  // CHECK-NOT: shape_region
   %0 = "onnx.MatMul"(%a, %b) : (tensor<2x3x64x4096xf16>, tensor<4096x1024xf16>)
       -> tensor<2x3x64x1024xf16>
   return %0 : tensor<2x3x64x1024xf16>
@@ -79,11 +86,12 @@ func.func @matmul_4d_by_2d(%a: tensor<2x3x64x4096xf16>, %b: tensor<4096x1024xf16
 // result type into the placeholder; populateShapeRegion later handles the
 // promote-and-strip.
 // CHECK-LABEL: func.func @matmul_1d_rhs
+// CHECK: %[[INIT:.+]] = hipsr.placeholder : tensor<?xf16>
+// CHECK: hipsr.matmul ins(%{{.+}}, %{{.+}} : tensor<?x4096xf16>, tensor<4096xf16>)
+// CHECK-SAME: outs(%[[INIT]] : tensor<?xf16>) -> tensor<?xf16>
+// CHECK-NOT: shape_region
 func.func @matmul_1d_rhs(%a: tensor<?x4096xf16>, %b: tensor<4096xf16>)
     -> tensor<?xf16> {
-  // CHECK: %[[INIT:.+]] = hipsr.placeholder : tensor<?xf16>
-  // CHECK: hipsr.matmul ins(%[[A:.+]], %[[B:.+]] : tensor<?x4096xf16>, tensor<4096xf16>) outs(%[[INIT]] : tensor<?xf16>) -> tensor<?xf16>
-  // CHECK-NOT: shape_region
   %0 = "onnx.MatMul"(%a, %b) : (tensor<?x4096xf16>, tensor<4096xf16>)
       -> tensor<?xf16>
   return %0 : tensor<?xf16>
@@ -94,12 +102,13 @@ func.func @matmul_1d_rhs(%a: tensor<?x4096xf16>, %b: tensor<4096xf16>)
 // NumPy batch broadcast (A batch dim 1, B batch dim 8 -> 8). The conversion is
 // shape-agnostic; the broadcast is resolved in the result type it mirrors.
 // CHECK-LABEL: func.func @matmul_broadcast_batch
+// CHECK: %[[INIT:.+]] = hipsr.placeholder : tensor<8x64x1024xf16>
+// CHECK: hipsr.matmul ins(%{{.+}}, %{{.+}} : tensor<1x64x4096xf16>, tensor<8x4096x1024xf16>)
+// CHECK-SAME: outs(%[[INIT]] : tensor<8x64x1024xf16>) -> tensor<8x64x1024xf16>
+// CHECK-NOT: shape_region
 func.func @matmul_broadcast_batch(%a: tensor<1x64x4096xf16>,
                                   %b: tensor<8x4096x1024xf16>)
     -> tensor<8x64x1024xf16> {
-  // CHECK: %[[INIT:.+]] = hipsr.placeholder : tensor<8x64x1024xf16>
-  // CHECK: hipsr.matmul ins(%[[A:.+]], %[[B:.+]] : tensor<1x64x4096xf16>, tensor<8x4096x1024xf16>) outs(%[[INIT]] : tensor<8x64x1024xf16>) -> tensor<8x64x1024xf16>
-  // CHECK-NOT: shape_region
   %0 = "onnx.MatMul"(%a, %b) : (tensor<1x64x4096xf16>, tensor<8x4096x1024xf16>)
       -> tensor<8x64x1024xf16>
   return %0 : tensor<8x64x1024xf16>

--- a/test/lit/Conversion/onnx-to-hipsr/matmul.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/matmul.mlir
@@ -3,10 +3,11 @@
 //
 //===----------------------------------------------------------------------===//
 // Converts onnx.MatMul to hipsr.matmul. The conversion mirrors the result type
-// into a hipsr.placeholder init, threads the !hipsr.context from function arg 0
-// (added in the ONNX phase) onto the op, and leaves the shape region empty (a
-// later pass fills it). It does not branch on rank/shape, so two cases cover
-// it: a plain 2-D matmul and a 1-D-operand matmul (the rank-reducing ONNX case).
+// into a hipsr.placeholder init, threads the !hipsr.context taken from the onnx
+// op's own first operand (the ONNX phase prepends it) onto the op, and leaves
+// the shape region empty (a later pass fills it). It does not branch on
+// rank/shape, so two cases cover it: a plain 2-D matmul and a 1-D-operand
+// matmul (the rank-reducing ONNX case).
 //
 // Positive CHECKs were seeded with mlir/utils/generate-test-checks.py (piped
 // from the -convert-onnx-to-hipsr output) and then refined: captures renamed,
@@ -29,7 +30,8 @@
 // CHECK-NOT:     shape_region
 func.func @matmul_2d(%ctx: !hipsr.context, %a: tensor<?x4096xf16>,
                      %b: tensor<4096x1024xf16>) -> tensor<?x1024xf16> {
-  %0 = "onnx.MatMul"(%a, %b) : (tensor<?x4096xf16>, tensor<4096x1024xf16>)
+  %0 = "onnx.MatMul"(%ctx, %a, %b)
+      : (!hipsr.context, tensor<?x4096xf16>, tensor<4096x1024xf16>)
       -> tensor<?x1024xf16>
   return %0 : tensor<?x1024xf16>
 }
@@ -50,7 +52,8 @@ func.func @matmul_2d(%ctx: !hipsr.context, %a: tensor<?x4096xf16>,
 // CHECK-NOT:     shape_region
 func.func @matmul_1d_rhs(%ctx: !hipsr.context, %a: tensor<?x4096xf16>,
                          %b: tensor<4096xf16>) -> tensor<?xf16> {
-  %0 = "onnx.MatMul"(%a, %b) : (tensor<?x4096xf16>, tensor<4096xf16>)
+  %0 = "onnx.MatMul"(%ctx, %a, %b)
+      : (!hipsr.context, tensor<?x4096xf16>, tensor<4096xf16>)
       -> tensor<?xf16>
   return %0 : tensor<?xf16>
 }

--- a/test/lit/Conversion/onnx-to-hipsr/matmul.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/matmul.mlir
@@ -2,42 +2,33 @@
 // Licensed under the MIT License.
 //
 //===----------------------------------------------------------------------===//
-// Converts onnx.MatMul to hipsr.matmul. The shape region is left empty (zero
-// blocks); a later dedicated pass fills in the shape computation, so this stage
-// does not populate it.
+// Converts onnx.MatMul to hipsr.matmul. The conversion mirrors the result type
+// into a hipsr.placeholder init, threads the !hipsr.context from function arg 0
+// (added in the ONNX phase) onto the op, and leaves the shape region empty (a
+// later pass fills it). It does not branch on rank/shape, so two cases cover
+// it: a plain 2-D matmul and a 1-D-operand matmul (the rank-reducing ONNX case).
 //
-// The conversion is shape-agnostic: it mirrors the result type into a
-// hipsr.placeholder init and leaves the region empty, with no rank/shape
-// branching. So a few representative shapes suffice: a 2-D case, a 1-D-operand
-// (rank-reducing) case, and a batched case.
-//
-// The positive CHECK lines were seeded with mlir/utils/generate-test-checks.py
-// (full signature + named operand captures), then refined by hand: the
-// CHECK-NOT intent checks (no tensor.empty/tensor.dim/shape_region) were
-// re-added and the return/terminator boilerplate dropped.
-//
-// Each case is one module (split by `// -----`); all CHECK directives are
-// grouped in the header above the function, isolated by CHECK-LABEL.
+// Positive CHECKs were seeded with mlir/utils/generate-test-checks.py (piped
+// from the -convert-onnx-to-hipsr output) and then refined: captures renamed,
+// the matmul operands tied back to the function arguments, terminator
+// boilerplate dropped, and the CHECK-NOT intent checks added.
 //===----------------------------------------------------------------------===//
 
-// RUN: hip-mlir-opt %s -allow-unregistered-dialect -convert-onnx-to-hipsr | FileCheck %s
+// RUN: hip-mlir-opt %s --split-input-file -allow-unregistered-dialect -convert-onnx-to-hipsr | FileCheck %s
 
-// -----
-
-// 2-D x 2-D (dynamic M): the DPS init is a hipsr.placeholder mirroring the
-// result type, so no output-shape computation (tensor.empty / tensor.dim) is
-// emitted, and the shape region is left empty (prints nothing).
+// 2-D x 2-D (dynamic M).
 // CHECK-LABEL: func.func @matmul_2d(
+// CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:    %[[A:.*]]: tensor<?x4096xf16>,
 // CHECK-SAME:    %[[B:.*]]: tensor<4096x1024xf16>) -> tensor<?x1024xf16> {
 // CHECK:         %[[INIT:.*]] = hipsr.placeholder : tensor<?x1024xf16>
-// CHECK:         hipsr.matmul ins(%[[A]], %[[B]] : tensor<?x4096xf16>, tensor<4096x1024xf16>)
-// CHECK-SAME:      outs(%[[INIT]] : tensor<?x1024xf16>) -> tensor<?x1024xf16>
+// CHECK:         hipsr.matmul(%[[CTX]]) ins(%[[A]], %[[B]] : tensor<?x4096xf16>, tensor<4096x1024xf16>)
+// CHECK-SAME:      outs(%[[INIT]] : tensor<?x1024xf16>) : tensor<?x1024xf16>
 // CHECK-NOT:     tensor.empty
 // CHECK-NOT:     tensor.dim
 // CHECK-NOT:     shape_region
-func.func @matmul_2d(%a: tensor<?x4096xf16>, %b: tensor<4096x1024xf16>)
-    -> tensor<?x1024xf16> {
+func.func @matmul_2d(%ctx: !hipsr.context, %a: tensor<?x4096xf16>,
+                     %b: tensor<4096x1024xf16>) -> tensor<?x1024xf16> {
   %0 = "onnx.MatMul"(%a, %b) : (tensor<?x4096xf16>, tensor<4096x1024xf16>)
       -> tensor<?x1024xf16>
   return %0 : tensor<?x1024xf16>
@@ -45,37 +36,21 @@ func.func @matmul_2d(%a: tensor<?x4096xf16>, %b: tensor<4096x1024xf16>)
 
 // -----
 
-// 1-D B (ONNX/NumPy): (M,K) @ (K) -> (M), a rank-reducing result. The
-// conversion still just mirrors the result type into the placeholder.
+// 1-D B: (M,K) @ (K) -> (M), a rank-reducing result. The conversion mirrors the
+// result type as-is, so the placeholder and matmul still carry no shape math.
 // CHECK-LABEL: func.func @matmul_1d_rhs(
+// CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:    %[[A:.*]]: tensor<?x4096xf16>,
 // CHECK-SAME:    %[[B:.*]]: tensor<4096xf16>) -> tensor<?xf16> {
 // CHECK:         %[[INIT:.*]] = hipsr.placeholder : tensor<?xf16>
-// CHECK:         hipsr.matmul ins(%[[A]], %[[B]] : tensor<?x4096xf16>, tensor<4096xf16>)
-// CHECK-SAME:      outs(%[[INIT]] : tensor<?xf16>) -> tensor<?xf16>
+// CHECK:         hipsr.matmul(%[[CTX]]) ins(%[[A]], %[[B]] : tensor<?x4096xf16>, tensor<4096xf16>)
+// CHECK-SAME:      outs(%[[INIT]] : tensor<?xf16>) : tensor<?xf16>
+// CHECK-NOT:     tensor.empty
+// CHECK-NOT:     tensor.dim
 // CHECK-NOT:     shape_region
-func.func @matmul_1d_rhs(%a: tensor<?x4096xf16>, %b: tensor<4096xf16>)
-    -> tensor<?xf16> {
+func.func @matmul_1d_rhs(%ctx: !hipsr.context, %a: tensor<?x4096xf16>,
+                         %b: tensor<4096xf16>) -> tensor<?xf16> {
   %0 = "onnx.MatMul"(%a, %b) : (tensor<?x4096xf16>, tensor<4096xf16>)
       -> tensor<?xf16>
   return %0 : tensor<?xf16>
-}
-
-// -----
-
-// Batched with NumPy batch broadcast (A batch dim 1, B batch dim 8 -> 8). The
-// broadcast is resolved in the result type the conversion mirrors.
-// CHECK-LABEL: func.func @matmul_broadcast_batch(
-// CHECK-SAME:    %[[A:.*]]: tensor<1x64x4096xf16>,
-// CHECK-SAME:    %[[B:.*]]: tensor<8x4096x1024xf16>) -> tensor<8x64x1024xf16> {
-// CHECK:         %[[INIT:.*]] = hipsr.placeholder : tensor<8x64x1024xf16>
-// CHECK:         hipsr.matmul ins(%[[A]], %[[B]] : tensor<1x64x4096xf16>, tensor<8x4096x1024xf16>)
-// CHECK-SAME:      outs(%[[INIT]] : tensor<8x64x1024xf16>) -> tensor<8x64x1024xf16>
-// CHECK-NOT:     shape_region
-func.func @matmul_broadcast_batch(%a: tensor<1x64x4096xf16>,
-                                  %b: tensor<8x4096x1024xf16>)
-    -> tensor<8x64x1024xf16> {
-  %0 = "onnx.MatMul"(%a, %b) : (tensor<1x64x4096xf16>, tensor<8x4096x1024xf16>)
-      -> tensor<8x64x1024xf16>
-  return %0 : tensor<8x64x1024xf16>
 }

--- a/test/lit/Dialect/Hipsr/matmul.mlir
+++ b/test/lit/Dialect/Hipsr/matmul.mlir
@@ -2,17 +2,13 @@
 // Licensed under the MIT License.
 //
 //===----------------------------------------------------------------------===//
-// Tests for hipsr.matmul (ONNX/NumPy matmul semantics):
+// Tests for hipsr.matmul that exercise its own code:
 //   - round-trip with the shape region omitted (the form onnx->hipsr emits)
-//   - round-trip with populated shape regions covering the shapes
-//     populateShapeRegion handles: 2-D, batched N-D, NumPy batch broadcast, and
-//     1-D operand promotion. Regions are hand-written (no pass calls
-//     populateShapeRegion yet), so they mirror what it emits.
-//   - fail cases the parser/verifier catches: DPS init/result type mismatch,
-//     non-shaped operand, empty shape region
+//   - verifier / parser diagnostics: rank-0 operand, DPS init/result type
+//     mismatch, non-shaped operand, empty shape-region block
 //
-// The K / broadcast checks are cf.asserts that fire at run time, so their
-// failure is covered by the numeric/runtime tests, not here. Generic
+// The shape region is populated by a later pass (not this stage), so
+// populateShapeRegion is covered with that pass, not here. Generic
 // shape-region structural tests live in shape_region_verify.mlir.
 //===----------------------------------------------------------------------===//
 
@@ -22,11 +18,12 @@
 // `shape_region` keyword (the optional region group prints nothing when the
 // region has zero blocks). This is the exact form convert-onnx-to-hipsr emits.
 // CHECK-LABEL: func.func @matmul_no_shape_region
+// CHECK: hipsr.matmul ins(%{{.+}}, %{{.+}} : tensor<?x4096xf16>, tensor<4096x1024xf16>)
+// CHECK-SAME: outs(%{{.+}} : tensor<?x1024xf16>) -> tensor<?x1024xf16>
+// CHECK-NOT: shape_region
 func.func @matmul_no_shape_region(%a: tensor<?x4096xf16>,
                                   %b: tensor<4096x1024xf16>,
                                   %init: tensor<?x1024xf16>) -> tensor<?x1024xf16> {
-  // CHECK: hipsr.matmul ins(%{{.+}}, %{{.+}} : tensor<?x4096xf16>, tensor<4096x1024xf16>) outs(%{{.+}} : tensor<?x1024xf16>) -> tensor<?x1024xf16>
-  // CHECK-NOT: shape_region
   %0 = hipsr.matmul ins(%a, %b : tensor<?x4096xf16>, tensor<4096x1024xf16>)
                     outs(%init : tensor<?x1024xf16>) -> tensor<?x1024xf16>
   return %0 : tensor<?x1024xf16>
@@ -34,254 +31,39 @@ func.func @matmul_no_shape_region(%a: tensor<?x4096xf16>,
 
 // -----
 
-// Populated shape region (2-D): the contraction dim K is checked with
-// arith.cmpi eq + cf.assert before the shape is yielded. The assert message
-// text is checked so a regression that drops the K check fails.
-// CHECK-LABEL: func.func @matmul_shape_region_k_check
-func.func @matmul_shape_region_k_check(%a: tensor<?x?xf16>, %b: tensor<?x?xf16>,
-                                       %init: tensor<?x?xf16>) -> tensor<?x?xf16> {
-  // CHECK: hipsr.matmul ins(%{{.+}}, %{{.+}} : tensor<?x?xf16>, tensor<?x?xf16>) outs(%{{.+}} : tensor<?x?xf16>) -> tensor<?x?xf16> shape_region {
-  // CHECK:   %[[SHA:.+]] = shape.shape_of %{{.+}} : tensor<?x?xf16> -> tensor<2xindex>
-  // CHECK:   %[[SHB:.+]] = shape.shape_of %{{.+}} : tensor<?x?xf16> -> tensor<2xindex>
-  // CHECK:   %[[EQ:.+]] = arith.cmpi eq, %{{.+}}, %{{.+}} : index
-  // CHECK:   cf.assert %[[EQ]], "hipsr.matmul: A and B contraction dim (K) must be equal"
-  // CHECK:   hipsr.shape_yield (%{{.+}}, %{{.+}}) : [f16]
-  %0 = hipsr.matmul ins(%a, %b : tensor<?x?xf16>, tensor<?x?xf16>)
-                    outs(%init : tensor<?x?xf16>) -> tensor<?x?xf16> shape_region {
-    %shA = shape.shape_of %a : tensor<?x?xf16> -> tensor<2xindex>
-    %shB = shape.shape_of %b : tensor<?x?xf16> -> tensor<2xindex>
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-    %ka = shape.get_extent %shA, %c1 : tensor<2xindex>, index -> index
-    %kb = shape.get_extent %shB, %c0 : tensor<2xindex>, index -> index
-    %eq = arith.cmpi eq, %ka, %kb : index
-    cf.assert %eq, "hipsr.matmul: A and B contraction dim (K) must be equal"
-    %m = shape.get_extent %shA, %c0 : tensor<2xindex>, index -> index
-    %n = shape.get_extent %shB, %c1 : tensor<2xindex>, index -> index
-    hipsr.shape_yield (%m, %n) : [f16]
-  }
-  return %0 : tensor<?x?xf16>
-}
-
-// -----
-
-// Populated shape region (batched 3-D x 3-D), equal-batch case: K check plus an
-// equality batch-dim check. (When both batch dims are known non-1, broadcast
-// degenerates to equality; this hand-written region uses the plain equality
-// form.)
-// CHECK-LABEL: func.func @matmul_shape_region_batch_check
-func.func @matmul_shape_region_batch_check(%a: tensor<?x?x?xf16>,
-                                           %b: tensor<?x?x?xf16>,
-                                           %init: tensor<?x?x?xf16>) -> tensor<?x?x?xf16> {
-  // CHECK: cf.assert %{{.+}}, "hipsr.matmul: A and B contraction dim (K) must be equal"
-  // CHECK: cf.assert %{{.+}}, "hipsr.matmul: batch dims of A and B must be equal"
-  // CHECK: hipsr.shape_yield (%{{.+}}, %{{.+}}, %{{.+}}) : [f16]
-  %0 = hipsr.matmul ins(%a, %b : tensor<?x?x?xf16>, tensor<?x?x?xf16>)
-                    outs(%init : tensor<?x?x?xf16>) -> tensor<?x?x?xf16> shape_region {
-    %shA = shape.shape_of %a : tensor<?x?x?xf16> -> tensor<3xindex>
-    %shB = shape.shape_of %b : tensor<?x?x?xf16> -> tensor<3xindex>
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-    %c2 = arith.constant 2 : index
-    %ka = shape.get_extent %shA, %c2 : tensor<3xindex>, index -> index
-    %kb = shape.get_extent %shB, %c1 : tensor<3xindex>, index -> index
-    %eqk = arith.cmpi eq, %ka, %kb : index
-    cf.assert %eqk, "hipsr.matmul: A and B contraction dim (K) must be equal"
-    %ba = shape.get_extent %shA, %c0 : tensor<3xindex>, index -> index
-    %bb = shape.get_extent %shB, %c0 : tensor<3xindex>, index -> index
-    %eqb = arith.cmpi eq, %ba, %bb : index
-    cf.assert %eqb, "hipsr.matmul: batch dims of A and B must be equal"
-    %m = shape.get_extent %shA, %c1 : tensor<3xindex>, index -> index
-    %n = shape.get_extent %shB, %c2 : tensor<3xindex>, index -> index
-    hipsr.shape_yield (%ba, %m, %n) : [f16]
-  }
-  return %0 : tensor<?x?x?xf16>
-}
-
-// -----
-
 //===----------------------------------------------------------------------===//
-// Multi-dimensional PASS cases (parse + verify + round-trip).
+// FAIL cases (compile-time diagnostics a LIT run observes).
 //===----------------------------------------------------------------------===//
 
-// 3-D x 2-D broadcast weight: batch + M from A, N from B's last dim. Region
-// omitted, as the conversion emits it.
-// CHECK-LABEL: func.func @matmul_3d_by_2d_broadcast
-func.func @matmul_3d_by_2d_broadcast(%a: tensor<2x?x4096xf16>,
-                                     %b: tensor<4096x1024xf16>,
-                                     %init: tensor<2x?x1024xf16>)
-    -> tensor<2x?x1024xf16> {
-  // CHECK: hipsr.matmul ins(%{{.+}}, %{{.+}} : tensor<2x?x4096xf16>, tensor<4096x1024xf16>) outs(%{{.+}} : tensor<2x?x1024xf16>) -> tensor<2x?x1024xf16>
-  // CHECK-NOT: shape_region
-  %0 = hipsr.matmul ins(%a, %b : tensor<2x?x4096xf16>, tensor<4096x1024xf16>)
-                    outs(%init : tensor<2x?x1024xf16>) -> tensor<2x?x1024xf16>
-  return %0 : tensor<2x?x1024xf16>
+// Rank-0 (scalar) A: a scalar tensor is a valid ranked tensor, so the operand
+// type constraint accepts it, but matmul needs a contraction dim so the
+// verifier rejects it.
+func.func @matmul_rank0_a(%a: tensor<f16>, %b: tensor<4096x1024xf16>,
+                          %init: tensor<1024xf16>) -> tensor<1024xf16> {
+  // expected-error@+1 {{operand A must be at least 1-D}}
+  %0 = hipsr.matmul ins(%a, %b : tensor<f16>, tensor<4096x1024xf16>)
+                    outs(%init : tensor<1024xf16>) -> tensor<1024xf16>
+  return %0 : tensor<1024xf16>
 }
 
 // -----
 
-// 4-D x 4-D, equal-batch case: two batch dims, so the region checks K plus both
-// batch dims and yields (batch0, batch1, M, N). Uses the equality form (see
-// matmul_broadcast_batch for the general NumPy-broadcast form).
-// CHECK-LABEL: func.func @matmul_4d_batched
-func.func @matmul_4d_batched(%a: tensor<?x?x?x?xf16>, %b: tensor<?x?x?x?xf16>,
-                             %init: tensor<?x?x?x?xf16>) -> tensor<?x?x?x?xf16> {
-  // CHECK: hipsr.matmul ins(%{{.+}}, %{{.+}} : tensor<?x?x?x?xf16>, tensor<?x?x?x?xf16>) outs(%{{.+}} : tensor<?x?x?x?xf16>) -> tensor<?x?x?x?xf16> shape_region {
-  // CHECK:   cf.assert %{{.+}}, "hipsr.matmul: A and B contraction dim (K) must be equal"
-  // Two batch dims -> two batch-equality asserts.
-  // CHECK:   cf.assert %{{.+}}, "hipsr.matmul: batch dims of A and B must be equal"
-  // CHECK:   cf.assert %{{.+}}, "hipsr.matmul: batch dims of A and B must be equal"
-  // CHECK:   hipsr.shape_yield (%{{.+}}, %{{.+}}, %{{.+}}, %{{.+}}) : [f16]
-  %0 = hipsr.matmul ins(%a, %b : tensor<?x?x?x?xf16>, tensor<?x?x?x?xf16>)
-                    outs(%init : tensor<?x?x?x?xf16>) -> tensor<?x?x?x?xf16>
-                    shape_region {
-    %shA = shape.shape_of %a : tensor<?x?x?x?xf16> -> tensor<4xindex>
-    %shB = shape.shape_of %b : tensor<?x?x?x?xf16> -> tensor<4xindex>
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-    %c2 = arith.constant 2 : index
-    %c3 = arith.constant 3 : index
-    // K: A dim 3 == B dim 2.
-    %ka = shape.get_extent %shA, %c3 : tensor<4xindex>, index -> index
-    %kb = shape.get_extent %shB, %c2 : tensor<4xindex>, index -> index
-    %eqk = arith.cmpi eq, %ka, %kb : index
-    cf.assert %eqk, "hipsr.matmul: A and B contraction dim (K) must be equal"
-    // Batch dim 0.
-    %b0a = shape.get_extent %shA, %c0 : tensor<4xindex>, index -> index
-    %b0b = shape.get_extent %shB, %c0 : tensor<4xindex>, index -> index
-    %eqb0 = arith.cmpi eq, %b0a, %b0b : index
-    cf.assert %eqb0, "hipsr.matmul: batch dims of A and B must be equal"
-    // Batch dim 1.
-    %b1a = shape.get_extent %shA, %c1 : tensor<4xindex>, index -> index
-    %b1b = shape.get_extent %shB, %c1 : tensor<4xindex>, index -> index
-    %eqb1 = arith.cmpi eq, %b1a, %b1b : index
-    cf.assert %eqb1, "hipsr.matmul: batch dims of A and B must be equal"
-    // Output shape: (batch0, batch1, M, N).
-    %m = shape.get_extent %shA, %c2 : tensor<4xindex>, index -> index
-    %n = shape.get_extent %shB, %c3 : tensor<4xindex>, index -> index
-    hipsr.shape_yield (%b0a, %b1a, %m, %n) : [f16]
-  }
-  return %0 : tensor<?x?x?x?xf16>
+// Rank-0 (scalar) B: same contract as A, on the second operand.
+func.func @matmul_rank0_b(%a: tensor<64x4096xf16>, %b: tensor<f16>,
+                          %init: tensor<64xf16>) -> tensor<64xf16> {
+  // expected-error@+1 {{operand B must be at least 1-D}}
+  %0 = hipsr.matmul ins(%a, %b : tensor<64x4096xf16>, tensor<f16>)
+                    outs(%init : tensor<64xf16>) -> tensor<64xf16>
+  return %0 : tensor<64xf16>
 }
 
 // -----
 
-// NumPy-broadcast batch dim (ONNX/NumPy matmul): A batch dim is 1, B's is
-// dynamic, so the result takes B's. The region folds the batch dim with
-// arith.cmpi/arith.select and asserts it is broadcastable, matching what
-// populateShapeRegion emits.
-// CHECK-LABEL: func.func @matmul_broadcast_batch
-func.func @matmul_broadcast_batch(%a: tensor<1x?x?xf16>, %b: tensor<?x?x?xf16>,
-                                  %init: tensor<?x?x?xf16>) -> tensor<?x?x?xf16> {
-  // CHECK: cf.assert %{{.+}}, "hipsr.matmul: A and B contraction dim (K) must be equal"
-  // CHECK: cf.assert %{{.+}}, "hipsr.matmul: batch dims of A and B must be broadcastable"
-  // CHECK: %[[BC:.+]] = arith.select %{{.+}}, %{{.+}}, %{{.+}} : index
-  // CHECK: hipsr.shape_yield (%[[BC]], %{{.+}}, %{{.+}}) : [f16]
-  %0 = hipsr.matmul ins(%a, %b : tensor<1x?x?xf16>, tensor<?x?x?xf16>)
-                    outs(%init : tensor<?x?x?xf16>) -> tensor<?x?x?xf16>
-                    shape_region {
-    %shA = shape.shape_of %a : tensor<1x?x?xf16> -> tensor<3xindex>
-    %shB = shape.shape_of %b : tensor<?x?x?xf16> -> tensor<3xindex>
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-    %c2 = arith.constant 2 : index
-    %ka = shape.get_extent %shA, %c2 : tensor<3xindex>, index -> index
-    %kb = shape.get_extent %shB, %c1 : tensor<3xindex>, index -> index
-    %eqk = arith.cmpi eq, %ka, %kb : index
-    cf.assert %eqk, "hipsr.matmul: A and B contraction dim (K) must be equal"
-    // Broadcast batch dim 0: da==1 ? db : (db==1 ? da : (assert da==db; da)).
-    %da = shape.get_extent %shA, %c0 : tensor<3xindex>, index -> index
-    %db = shape.get_extent %shB, %c0 : tensor<3xindex>, index -> index
-    %one = arith.constant 1 : index
-    %aIs1 = arith.cmpi eq, %da, %one : index
-    %bIs1 = arith.cmpi eq, %db, %one : index
-    %eqd = arith.cmpi eq, %da, %db : index
-    %c01 = arith.ori %eqd, %aIs1 : i1
-    %compat = arith.ori %c01, %bIs1 : i1
-    cf.assert %compat, "hipsr.matmul: batch dims of A and B must be broadcastable"
-    %bc = arith.select %aIs1, %db, %da : index
-    %m = shape.get_extent %shA, %c1 : tensor<3xindex>, index -> index
-    %n = shape.get_extent %shB, %c2 : tensor<3xindex>, index -> index
-    hipsr.shape_yield (%bc, %m, %n) : [f16]
-  }
-  return %0 : tensor<?x?x?xf16>
-}
-
-// -----
-
-// 1-D B (ONNX/NumPy matmul): B (K) is promoted to (K,1) for the multiply and the
-// trailing 1 is stripped, so (M,K) @ (K) -> (M). K is A's last dim == B's sole
-// dim; the yielded shape is just (M).
-// CHECK-LABEL: func.func @matmul_1d_rhs
-func.func @matmul_1d_rhs(%a: tensor<?x4096xf16>, %b: tensor<4096xf16>,
-                         %init: tensor<?xf16>) -> tensor<?xf16> {
-  // CHECK: cf.assert %{{.+}}, "hipsr.matmul: A and B contraction dim (K) must be equal"
-  // CHECK: hipsr.shape_yield (%{{.+}}) : [f16]
-  %0 = hipsr.matmul ins(%a, %b : tensor<?x4096xf16>, tensor<4096xf16>)
-                    outs(%init : tensor<?xf16>) -> tensor<?xf16> shape_region {
-    %shA = shape.shape_of %a : tensor<?x4096xf16> -> tensor<2xindex>
-    %shB = shape.shape_of %b : tensor<4096xf16> -> tensor<1xindex>
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-    %ka = shape.get_extent %shA, %c1 : tensor<2xindex>, index -> index
-    %kb = shape.get_extent %shB, %c0 : tensor<1xindex>, index -> index
-    %eqk = arith.cmpi eq, %ka, %kb : index
-    cf.assert %eqk, "hipsr.matmul: A and B contraction dim (K) must be equal"
-    // Only M survives (N came from B's promoted, then stripped, unit dim).
-    %m = shape.get_extent %shA, %c0 : tensor<2xindex>, index -> index
-    hipsr.shape_yield (%m) : [f16]
-  }
-  return %0 : tensor<?xf16>
-}
-
-// -----
-
-// Fully static 3-D batched matmul with a populated region: parses, verifies,
-// and round-trips with the region intact.
-// CHECK-LABEL: func.func @matmul_static_batched
-func.func @matmul_static_batched(%a: tensor<8x64x4096xf16>,
-                                 %b: tensor<8x4096x1024xf16>,
-                                 %init: tensor<8x64x1024xf16>)
-    -> tensor<8x64x1024xf16> {
-  // CHECK: hipsr.matmul ins(%{{.+}}, %{{.+}} : tensor<8x64x4096xf16>, tensor<8x4096x1024xf16>) outs(%{{.+}} : tensor<8x64x1024xf16>) -> tensor<8x64x1024xf16> shape_region {
-  // CHECK:   cf.assert %{{.+}}, "hipsr.matmul: A and B contraction dim (K) must be equal"
-  // CHECK:   cf.assert %{{.+}}, "hipsr.matmul: batch dims of A and B must be equal"
-  // CHECK:   hipsr.shape_yield (%{{.+}}, %{{.+}}, %{{.+}}) : [f16]
-  %0 = hipsr.matmul ins(%a, %b : tensor<8x64x4096xf16>, tensor<8x4096x1024xf16>)
-                    outs(%init : tensor<8x64x1024xf16>) -> tensor<8x64x1024xf16>
-                    shape_region {
-    %shA = shape.shape_of %a : tensor<8x64x4096xf16> -> tensor<3xindex>
-    %shB = shape.shape_of %b : tensor<8x4096x1024xf16> -> tensor<3xindex>
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-    %c2 = arith.constant 2 : index
-    %ka = shape.get_extent %shA, %c2 : tensor<3xindex>, index -> index
-    %kb = shape.get_extent %shB, %c1 : tensor<3xindex>, index -> index
-    %eqk = arith.cmpi eq, %ka, %kb : index
-    cf.assert %eqk, "hipsr.matmul: A and B contraction dim (K) must be equal"
-    %ba = shape.get_extent %shA, %c0 : tensor<3xindex>, index -> index
-    %bb = shape.get_extent %shB, %c0 : tensor<3xindex>, index -> index
-    %eqb = arith.cmpi eq, %ba, %bb : index
-    cf.assert %eqb, "hipsr.matmul: batch dims of A and B must be equal"
-    %m = shape.get_extent %shA, %c1 : tensor<3xindex>, index -> index
-    %n = shape.get_extent %shB, %c2 : tensor<3xindex>, index -> index
-    hipsr.shape_yield (%ba, %m, %n) : [f16]
-  }
-  return %0 : tensor<8x64x1024xf16>
-}
-
-// -----
-
-//===----------------------------------------------------------------------===//
-// Multi-dimensional FAIL cases (compile-time diagnostics a LIT run observes).
-//===----------------------------------------------------------------------===//
-
-// DPS init/result type mismatch (4-D): the DPS verifier requires init and
-// result types to be equal. Here the result batch-0 dim (4) differs from the
-// init (2).
-func.func @matmul_4d_init_result_mismatch(%a: tensor<2x3x64x4096xf16>,
-                                          %b: tensor<2x3x4096x1024xf16>,
-                                          %init: tensor<2x3x64x1024xf16>)
+// DPS init/result type mismatch: the DPS verifier requires init and result
+// types to be equal. Here the result batch-0 dim (4) differs from the init (2).
+func.func @matmul_init_result_mismatch(%a: tensor<2x3x64x4096xf16>,
+                                       %b: tensor<2x3x4096x1024xf16>,
+                                       %init: tensor<2x3x64x1024xf16>)
     -> tensor<4x3x64x1024xf16> {
   // expected-error@+1 {{to match type of corresponding result}}
   %0 = hipsr.matmul ins(%a, %b : tensor<2x3x64x4096xf16>, tensor<2x3x4096x1024xf16>)
@@ -291,11 +73,11 @@ func.func @matmul_4d_init_result_mismatch(%a: tensor<2x3x64x4096xf16>,
 
 // -----
 
-// DPS init/result element-type mismatch (3-D): init is f16, result is f32.
-// Same DPS rule (the full type must match, not just the shape).
-func.func @matmul_3d_elem_type_mismatch(%a: tensor<2x64x4096xf16>,
-                                        %b: tensor<2x4096x1024xf16>,
-                                        %init: tensor<2x64x1024xf16>)
+// DPS init/result element-type mismatch: init is f16, result is f32. Same DPS
+// rule (the full type must match, not just the shape).
+func.func @matmul_elem_type_mismatch(%a: tensor<2x64x4096xf16>,
+                                     %b: tensor<2x4096x1024xf16>,
+                                     %init: tensor<2x64x1024xf16>)
     -> tensor<2x64x1024xf32> {
   // expected-error@+1 {{to match type of corresponding result}}
   %0 = hipsr.matmul ins(%a, %b : tensor<2x64x4096xf16>, tensor<2x4096x1024xf16>)
@@ -321,9 +103,9 @@ func.func @matmul_operand_not_shaped(%a: f16, %b: tensor<4096x1024xf16>,
 
 // A present shape region must not be a lone empty block (an absent region is
 // expressed by omitting the region entirely).
-func.func @matmul_4d_empty_shape_region(%a: tensor<2x3x64x4096xf16>,
-                                        %b: tensor<2x3x4096x1024xf16>,
-                                        %init: tensor<2x3x64x1024xf16>)
+func.func @matmul_empty_shape_region(%a: tensor<2x3x64x4096xf16>,
+                                     %b: tensor<2x3x4096x1024xf16>,
+                                     %init: tensor<2x3x64x1024xf16>)
     -> tensor<2x3x64x1024xf16> {
   // expected-error@+1 {{expects a non-empty block}}
   %0 = hipsr.matmul ins(%a, %b : tensor<2x3x64x4096xf16>, tensor<2x3x4096x1024xf16>)
@@ -331,17 +113,4 @@ func.func @matmul_4d_empty_shape_region(%a: tensor<2x3x64x4096xf16>,
                     shape_region {
   }
   return %0 : tensor<2x3x64x1024xf16>
-}
-
-// -----
-
-// Rank-0 (scalar) operand: a scalar tensor is a valid ranked tensor, so the
-// operand type constraint accepts it, but matmul needs a contraction dim so the
-// verifier rejects it.
-func.func @matmul_rank0_operand(%a: tensor<f16>, %b: tensor<4096x1024xf16>,
-                                %init: tensor<1024xf16>) -> tensor<1024xf16> {
-  // expected-error@+1 {{operand A must be at least 1-D}}
-  %0 = hipsr.matmul ins(%a, %b : tensor<f16>, tensor<4096x1024xf16>)
-                    outs(%init : tensor<1024xf16>) -> tensor<1024xf16>
-  return %0 : tensor<1024xf16>
 }

--- a/test/lit/Dialect/Hipsr/matmul.mlir
+++ b/test/lit/Dialect/Hipsr/matmul.mlir
@@ -1,0 +1,334 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+//===----------------------------------------------------------------------===//
+// Tests for hipsr.matmul (ONNX/NumPy matmul semantics):
+//   - round-trip with the shape region omitted (the form onnx->hipsr emits)
+//   - round-trip with populated shape regions covering the shapes
+//     populateShapeRegion handles: 2-D, batched N-D, NumPy batch broadcast, and
+//     1-D operand promotion. Regions are hand-written (no pass calls
+//     populateShapeRegion yet), so they mirror what it emits.
+//   - fail cases the parser/verifier catches: DPS init/result type mismatch,
+//     non-shaped operand, empty shape region
+//
+// The K / broadcast checks are cf.asserts that fire at run time, so their
+// failure is covered by the numeric/runtime tests, not here. Generic
+// shape-region structural tests live in shape_region_verify.mlir.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt --split-input-file --verify-diagnostics %s | FileCheck %s
+
+// Shape region omitted: parses, verifies, and prints back with no
+// `shape_region` keyword (the optional region group prints nothing when the
+// region has zero blocks). This is the exact form convert-onnx-to-hipsr emits.
+// CHECK-LABEL: func.func @matmul_no_shape_region
+func.func @matmul_no_shape_region(%a: tensor<?x4096xf16>,
+                                  %b: tensor<4096x1024xf16>,
+                                  %init: tensor<?x1024xf16>) -> tensor<?x1024xf16> {
+  // CHECK: hipsr.matmul ins(%{{.+}}, %{{.+}} : tensor<?x4096xf16>, tensor<4096x1024xf16>) outs(%{{.+}} : tensor<?x1024xf16>) -> tensor<?x1024xf16>
+  // CHECK-NOT: shape_region
+  %0 = hipsr.matmul ins(%a, %b : tensor<?x4096xf16>, tensor<4096x1024xf16>)
+                    outs(%init : tensor<?x1024xf16>) -> tensor<?x1024xf16>
+  return %0 : tensor<?x1024xf16>
+}
+
+// -----
+
+// Populated shape region (2-D): the contraction dim K is checked with
+// arith.cmpi eq + cf.assert before the shape is yielded. The assert message
+// text is checked so a regression that drops the K check fails.
+// CHECK-LABEL: func.func @matmul_shape_region_k_check
+func.func @matmul_shape_region_k_check(%a: tensor<?x?xf16>, %b: tensor<?x?xf16>,
+                                       %init: tensor<?x?xf16>) -> tensor<?x?xf16> {
+  // CHECK: hipsr.matmul ins(%{{.+}}, %{{.+}} : tensor<?x?xf16>, tensor<?x?xf16>) outs(%{{.+}} : tensor<?x?xf16>) -> tensor<?x?xf16> shape_region {
+  // CHECK:   %[[SHA:.+]] = shape.shape_of %{{.+}} : tensor<?x?xf16> -> tensor<2xindex>
+  // CHECK:   %[[SHB:.+]] = shape.shape_of %{{.+}} : tensor<?x?xf16> -> tensor<2xindex>
+  // CHECK:   %[[EQ:.+]] = arith.cmpi eq, %{{.+}}, %{{.+}} : index
+  // CHECK:   cf.assert %[[EQ]], "hipsr.matmul: A and B contraction dim (K) must be equal"
+  // CHECK:   hipsr.shape_yield (%{{.+}}, %{{.+}}) : [f16]
+  %0 = hipsr.matmul ins(%a, %b : tensor<?x?xf16>, tensor<?x?xf16>)
+                    outs(%init : tensor<?x?xf16>) -> tensor<?x?xf16> shape_region {
+    %shA = shape.shape_of %a : tensor<?x?xf16> -> tensor<2xindex>
+    %shB = shape.shape_of %b : tensor<?x?xf16> -> tensor<2xindex>
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %ka = shape.get_extent %shA, %c1 : tensor<2xindex>, index -> index
+    %kb = shape.get_extent %shB, %c0 : tensor<2xindex>, index -> index
+    %eq = arith.cmpi eq, %ka, %kb : index
+    cf.assert %eq, "hipsr.matmul: A and B contraction dim (K) must be equal"
+    %m = shape.get_extent %shA, %c0 : tensor<2xindex>, index -> index
+    %n = shape.get_extent %shB, %c1 : tensor<2xindex>, index -> index
+    hipsr.shape_yield (%m, %n) : [f16]
+  }
+  return %0 : tensor<?x?xf16>
+}
+
+// -----
+
+// Populated shape region (batched 3-D x 3-D), equal-batch case: K check plus an
+// equality batch-dim check. (When both batch dims are known non-1, broadcast
+// degenerates to equality; this hand-written region uses the plain equality
+// form.)
+// CHECK-LABEL: func.func @matmul_shape_region_batch_check
+func.func @matmul_shape_region_batch_check(%a: tensor<?x?x?xf16>,
+                                           %b: tensor<?x?x?xf16>,
+                                           %init: tensor<?x?x?xf16>) -> tensor<?x?x?xf16> {
+  // CHECK: cf.assert %{{.+}}, "hipsr.matmul: A and B contraction dim (K) must be equal"
+  // CHECK: cf.assert %{{.+}}, "hipsr.matmul: batch dims of A and B must be equal"
+  // CHECK: hipsr.shape_yield (%{{.+}}, %{{.+}}, %{{.+}}) : [f16]
+  %0 = hipsr.matmul ins(%a, %b : tensor<?x?x?xf16>, tensor<?x?x?xf16>)
+                    outs(%init : tensor<?x?x?xf16>) -> tensor<?x?x?xf16> shape_region {
+    %shA = shape.shape_of %a : tensor<?x?x?xf16> -> tensor<3xindex>
+    %shB = shape.shape_of %b : tensor<?x?x?xf16> -> tensor<3xindex>
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %ka = shape.get_extent %shA, %c2 : tensor<3xindex>, index -> index
+    %kb = shape.get_extent %shB, %c1 : tensor<3xindex>, index -> index
+    %eqk = arith.cmpi eq, %ka, %kb : index
+    cf.assert %eqk, "hipsr.matmul: A and B contraction dim (K) must be equal"
+    %ba = shape.get_extent %shA, %c0 : tensor<3xindex>, index -> index
+    %bb = shape.get_extent %shB, %c0 : tensor<3xindex>, index -> index
+    %eqb = arith.cmpi eq, %ba, %bb : index
+    cf.assert %eqb, "hipsr.matmul: batch dims of A and B must be equal"
+    %m = shape.get_extent %shA, %c1 : tensor<3xindex>, index -> index
+    %n = shape.get_extent %shB, %c2 : tensor<3xindex>, index -> index
+    hipsr.shape_yield (%ba, %m, %n) : [f16]
+  }
+  return %0 : tensor<?x?x?xf16>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Multi-dimensional PASS cases (parse + verify + round-trip).
+//===----------------------------------------------------------------------===//
+
+// 3-D x 2-D broadcast weight: batch + M from A, N from B's last dim. Region
+// omitted, as the conversion emits it.
+// CHECK-LABEL: func.func @matmul_3d_by_2d_broadcast
+func.func @matmul_3d_by_2d_broadcast(%a: tensor<2x?x4096xf16>,
+                                     %b: tensor<4096x1024xf16>,
+                                     %init: tensor<2x?x1024xf16>)
+    -> tensor<2x?x1024xf16> {
+  // CHECK: hipsr.matmul ins(%{{.+}}, %{{.+}} : tensor<2x?x4096xf16>, tensor<4096x1024xf16>) outs(%{{.+}} : tensor<2x?x1024xf16>) -> tensor<2x?x1024xf16>
+  // CHECK-NOT: shape_region
+  %0 = hipsr.matmul ins(%a, %b : tensor<2x?x4096xf16>, tensor<4096x1024xf16>)
+                    outs(%init : tensor<2x?x1024xf16>) -> tensor<2x?x1024xf16>
+  return %0 : tensor<2x?x1024xf16>
+}
+
+// -----
+
+// 4-D x 4-D, equal-batch case: two batch dims, so the region checks K plus both
+// batch dims and yields (batch0, batch1, M, N). Uses the equality form (see
+// matmul_broadcast_batch for the general NumPy-broadcast form).
+// CHECK-LABEL: func.func @matmul_4d_batched
+func.func @matmul_4d_batched(%a: tensor<?x?x?x?xf16>, %b: tensor<?x?x?x?xf16>,
+                             %init: tensor<?x?x?x?xf16>) -> tensor<?x?x?x?xf16> {
+  // CHECK: hipsr.matmul ins(%{{.+}}, %{{.+}} : tensor<?x?x?x?xf16>, tensor<?x?x?x?xf16>) outs(%{{.+}} : tensor<?x?x?x?xf16>) -> tensor<?x?x?x?xf16> shape_region {
+  // CHECK:   cf.assert %{{.+}}, "hipsr.matmul: A and B contraction dim (K) must be equal"
+  // Two batch dims -> two batch-equality asserts.
+  // CHECK:   cf.assert %{{.+}}, "hipsr.matmul: batch dims of A and B must be equal"
+  // CHECK:   cf.assert %{{.+}}, "hipsr.matmul: batch dims of A and B must be equal"
+  // CHECK:   hipsr.shape_yield (%{{.+}}, %{{.+}}, %{{.+}}, %{{.+}}) : [f16]
+  %0 = hipsr.matmul ins(%a, %b : tensor<?x?x?x?xf16>, tensor<?x?x?x?xf16>)
+                    outs(%init : tensor<?x?x?x?xf16>) -> tensor<?x?x?x?xf16>
+                    shape_region {
+    %shA = shape.shape_of %a : tensor<?x?x?x?xf16> -> tensor<4xindex>
+    %shB = shape.shape_of %b : tensor<?x?x?x?xf16> -> tensor<4xindex>
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    // K: A dim 3 == B dim 2.
+    %ka = shape.get_extent %shA, %c3 : tensor<4xindex>, index -> index
+    %kb = shape.get_extent %shB, %c2 : tensor<4xindex>, index -> index
+    %eqk = arith.cmpi eq, %ka, %kb : index
+    cf.assert %eqk, "hipsr.matmul: A and B contraction dim (K) must be equal"
+    // Batch dim 0.
+    %b0a = shape.get_extent %shA, %c0 : tensor<4xindex>, index -> index
+    %b0b = shape.get_extent %shB, %c0 : tensor<4xindex>, index -> index
+    %eqb0 = arith.cmpi eq, %b0a, %b0b : index
+    cf.assert %eqb0, "hipsr.matmul: batch dims of A and B must be equal"
+    // Batch dim 1.
+    %b1a = shape.get_extent %shA, %c1 : tensor<4xindex>, index -> index
+    %b1b = shape.get_extent %shB, %c1 : tensor<4xindex>, index -> index
+    %eqb1 = arith.cmpi eq, %b1a, %b1b : index
+    cf.assert %eqb1, "hipsr.matmul: batch dims of A and B must be equal"
+    // Output shape: (batch0, batch1, M, N).
+    %m = shape.get_extent %shA, %c2 : tensor<4xindex>, index -> index
+    %n = shape.get_extent %shB, %c3 : tensor<4xindex>, index -> index
+    hipsr.shape_yield (%b0a, %b1a, %m, %n) : [f16]
+  }
+  return %0 : tensor<?x?x?x?xf16>
+}
+
+// -----
+
+// NumPy-broadcast batch dim (ONNX/NumPy matmul): A batch dim is 1, B's is
+// dynamic, so the result takes B's. The region folds the batch dim with
+// arith.cmpi/arith.select and asserts it is broadcastable, matching what
+// populateShapeRegion emits.
+// CHECK-LABEL: func.func @matmul_broadcast_batch
+func.func @matmul_broadcast_batch(%a: tensor<1x?x?xf16>, %b: tensor<?x?x?xf16>,
+                                  %init: tensor<?x?x?xf16>) -> tensor<?x?x?xf16> {
+  // CHECK: cf.assert %{{.+}}, "hipsr.matmul: A and B contraction dim (K) must be equal"
+  // CHECK: cf.assert %{{.+}}, "hipsr.matmul: batch dims of A and B must be broadcastable"
+  // CHECK: %[[BC:.+]] = arith.select %{{.+}}, %{{.+}}, %{{.+}} : index
+  // CHECK: hipsr.shape_yield (%[[BC]], %{{.+}}, %{{.+}}) : [f16]
+  %0 = hipsr.matmul ins(%a, %b : tensor<1x?x?xf16>, tensor<?x?x?xf16>)
+                    outs(%init : tensor<?x?x?xf16>) -> tensor<?x?x?xf16>
+                    shape_region {
+    %shA = shape.shape_of %a : tensor<1x?x?xf16> -> tensor<3xindex>
+    %shB = shape.shape_of %b : tensor<?x?x?xf16> -> tensor<3xindex>
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %ka = shape.get_extent %shA, %c2 : tensor<3xindex>, index -> index
+    %kb = shape.get_extent %shB, %c1 : tensor<3xindex>, index -> index
+    %eqk = arith.cmpi eq, %ka, %kb : index
+    cf.assert %eqk, "hipsr.matmul: A and B contraction dim (K) must be equal"
+    // Broadcast batch dim 0: da==1 ? db : (db==1 ? da : (assert da==db; da)).
+    %da = shape.get_extent %shA, %c0 : tensor<3xindex>, index -> index
+    %db = shape.get_extent %shB, %c0 : tensor<3xindex>, index -> index
+    %one = arith.constant 1 : index
+    %aIs1 = arith.cmpi eq, %da, %one : index
+    %bIs1 = arith.cmpi eq, %db, %one : index
+    %eqd = arith.cmpi eq, %da, %db : index
+    %c01 = arith.ori %eqd, %aIs1 : i1
+    %compat = arith.ori %c01, %bIs1 : i1
+    cf.assert %compat, "hipsr.matmul: batch dims of A and B must be broadcastable"
+    %bc = arith.select %aIs1, %db, %da : index
+    %m = shape.get_extent %shA, %c1 : tensor<3xindex>, index -> index
+    %n = shape.get_extent %shB, %c2 : tensor<3xindex>, index -> index
+    hipsr.shape_yield (%bc, %m, %n) : [f16]
+  }
+  return %0 : tensor<?x?x?xf16>
+}
+
+// -----
+
+// 1-D B (ONNX/NumPy matmul): B (K) is promoted to (K,1) for the multiply and the
+// trailing 1 is stripped, so (M,K) @ (K) -> (M). K is A's last dim == B's sole
+// dim; the yielded shape is just (M).
+// CHECK-LABEL: func.func @matmul_1d_rhs
+func.func @matmul_1d_rhs(%a: tensor<?x4096xf16>, %b: tensor<4096xf16>,
+                         %init: tensor<?xf16>) -> tensor<?xf16> {
+  // CHECK: cf.assert %{{.+}}, "hipsr.matmul: A and B contraction dim (K) must be equal"
+  // CHECK: hipsr.shape_yield (%{{.+}}) : [f16]
+  %0 = hipsr.matmul ins(%a, %b : tensor<?x4096xf16>, tensor<4096xf16>)
+                    outs(%init : tensor<?xf16>) -> tensor<?xf16> shape_region {
+    %shA = shape.shape_of %a : tensor<?x4096xf16> -> tensor<2xindex>
+    %shB = shape.shape_of %b : tensor<4096xf16> -> tensor<1xindex>
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %ka = shape.get_extent %shA, %c1 : tensor<2xindex>, index -> index
+    %kb = shape.get_extent %shB, %c0 : tensor<1xindex>, index -> index
+    %eqk = arith.cmpi eq, %ka, %kb : index
+    cf.assert %eqk, "hipsr.matmul: A and B contraction dim (K) must be equal"
+    // Only M survives (N came from B's promoted, then stripped, unit dim).
+    %m = shape.get_extent %shA, %c0 : tensor<2xindex>, index -> index
+    hipsr.shape_yield (%m) : [f16]
+  }
+  return %0 : tensor<?xf16>
+}
+
+// -----
+
+// Fully static 3-D batched matmul with a populated region: parses, verifies,
+// and round-trips with the region intact.
+// CHECK-LABEL: func.func @matmul_static_batched
+func.func @matmul_static_batched(%a: tensor<8x64x4096xf16>,
+                                 %b: tensor<8x4096x1024xf16>,
+                                 %init: tensor<8x64x1024xf16>)
+    -> tensor<8x64x1024xf16> {
+  // CHECK: hipsr.matmul ins(%{{.+}}, %{{.+}} : tensor<8x64x4096xf16>, tensor<8x4096x1024xf16>) outs(%{{.+}} : tensor<8x64x1024xf16>) -> tensor<8x64x1024xf16> shape_region {
+  // CHECK:   cf.assert %{{.+}}, "hipsr.matmul: A and B contraction dim (K) must be equal"
+  // CHECK:   cf.assert %{{.+}}, "hipsr.matmul: batch dims of A and B must be equal"
+  // CHECK:   hipsr.shape_yield (%{{.+}}, %{{.+}}, %{{.+}}) : [f16]
+  %0 = hipsr.matmul ins(%a, %b : tensor<8x64x4096xf16>, tensor<8x4096x1024xf16>)
+                    outs(%init : tensor<8x64x1024xf16>) -> tensor<8x64x1024xf16>
+                    shape_region {
+    %shA = shape.shape_of %a : tensor<8x64x4096xf16> -> tensor<3xindex>
+    %shB = shape.shape_of %b : tensor<8x4096x1024xf16> -> tensor<3xindex>
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %ka = shape.get_extent %shA, %c2 : tensor<3xindex>, index -> index
+    %kb = shape.get_extent %shB, %c1 : tensor<3xindex>, index -> index
+    %eqk = arith.cmpi eq, %ka, %kb : index
+    cf.assert %eqk, "hipsr.matmul: A and B contraction dim (K) must be equal"
+    %ba = shape.get_extent %shA, %c0 : tensor<3xindex>, index -> index
+    %bb = shape.get_extent %shB, %c0 : tensor<3xindex>, index -> index
+    %eqb = arith.cmpi eq, %ba, %bb : index
+    cf.assert %eqb, "hipsr.matmul: batch dims of A and B must be equal"
+    %m = shape.get_extent %shA, %c1 : tensor<3xindex>, index -> index
+    %n = shape.get_extent %shB, %c2 : tensor<3xindex>, index -> index
+    hipsr.shape_yield (%ba, %m, %n) : [f16]
+  }
+  return %0 : tensor<8x64x1024xf16>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Multi-dimensional FAIL cases (compile-time diagnostics a LIT run observes).
+//===----------------------------------------------------------------------===//
+
+// DPS init/result type mismatch (4-D): the DPS verifier requires init and
+// result types to be equal. Here the result batch-0 dim (4) differs from the
+// init (2).
+func.func @matmul_4d_init_result_mismatch(%a: tensor<2x3x64x4096xf16>,
+                                          %b: tensor<2x3x4096x1024xf16>,
+                                          %init: tensor<2x3x64x1024xf16>)
+    -> tensor<4x3x64x1024xf16> {
+  // expected-error@+1 {{to match type of corresponding result}}
+  %0 = hipsr.matmul ins(%a, %b : tensor<2x3x64x4096xf16>, tensor<2x3x4096x1024xf16>)
+                    outs(%init : tensor<2x3x64x1024xf16>) -> tensor<4x3x64x1024xf16>
+  return %0 : tensor<4x3x64x1024xf16>
+}
+
+// -----
+
+// DPS init/result element-type mismatch (3-D): init is f16, result is f32.
+// Same DPS rule (the full type must match, not just the shape).
+func.func @matmul_3d_elem_type_mismatch(%a: tensor<2x64x4096xf16>,
+                                        %b: tensor<2x4096x1024xf16>,
+                                        %init: tensor<2x64x1024xf16>)
+    -> tensor<2x64x1024xf32> {
+  // expected-error@+1 {{to match type of corresponding result}}
+  %0 = hipsr.matmul ins(%a, %b : tensor<2x64x4096xf16>, tensor<2x4096x1024xf16>)
+                    outs(%init : tensor<2x64x1024xf16>) -> tensor<2x64x1024xf32>
+  return %0 : tensor<2x64x1024xf32>
+}
+
+// -----
+
+// Non-shaped operand: A is a scalar f16, which the operand type constraint
+// rejects. The generic form needs an empty region ({}) for the (optional) shape
+// region so the region-count check passes and the operand-type check fires.
+func.func @matmul_operand_not_shaped(%a: f16, %b: tensor<4096x1024xf16>,
+                                     %init: tensor<64x1024xf16>)
+    -> tensor<64x1024xf16> {
+  // expected-error@+1 {{operand #0 must be ranked tensor or device memref}}
+  %0 = "hipsr.matmul"(%a, %b, %init) ({}) : (f16, tensor<4096x1024xf16>, tensor<64x1024xf16>)
+      -> tensor<64x1024xf16>
+  return %0 : tensor<64x1024xf16>
+}
+
+// -----
+
+// A present shape region must not be a lone empty block (an absent region is
+// expressed by omitting the region entirely).
+func.func @matmul_4d_empty_shape_region(%a: tensor<2x3x64x4096xf16>,
+                                        %b: tensor<2x3x4096x1024xf16>,
+                                        %init: tensor<2x3x64x1024xf16>)
+    -> tensor<2x3x64x1024xf16> {
+  // expected-error@+1 {{expects a non-empty block}}
+  %0 = hipsr.matmul ins(%a, %b : tensor<2x3x64x4096xf16>, tensor<2x3x4096x1024xf16>)
+                    outs(%init : tensor<2x3x64x1024xf16>) -> tensor<2x3x64x1024xf16>
+                    shape_region {
+  }
+  return %0 : tensor<2x3x64x1024xf16>
+}

--- a/test/lit/Dialect/Hipsr/matmul.mlir
+++ b/test/lit/Dialect/Hipsr/matmul.mlir
@@ -2,19 +2,16 @@
 // Licensed under the MIT License.
 //
 //===----------------------------------------------------------------------===//
-// Tests for hipsr.matmul that exercise its own code:
-//   - round-trip with the shape region omitted (the form onnx->hipsr emits)
-//   - verifier / parser diagnostics: rank-0 operand, DPS init/result type
-//     mismatch, non-shaped operand
-//
-// This stage emits the op with an empty shape region, so these tests cover the
-// empty-region round-trip and the verifier. populateShapeRegion belongs with a
-// future populate pass and will be tested there. Generic shape-region
-// structural tests (empty / multi-block region rules) live in
+// Tests for hipsr.matmul. Two RUN lines share the file, kept apart by a
+// FileCheck --check-prefix so each ignores the other's chunks: the default
+// prefix covers the empty-region round-trip and verifier diagnostics; the
+// POPULATE-* prefix covers -hipsr-populate-shape-region (MatMulOp's
+// populateShapeRegion). Generic shape-region structural rules live in
 // shape_region_verify.mlir.
 //===----------------------------------------------------------------------===//
 
 // RUN: hip-mlir-opt --split-input-file --verify-diagnostics %s | FileCheck %s
+// RUN: hip-mlir-opt --split-input-file --verify-diagnostics -hipsr-populate-shape-region %s | FileCheck %s --check-prefix=POPULATE
 
 // Shape region omitted: parses, verifies, and prints back with no
 // `shape_region` keyword (the optional region group prints nothing when the
@@ -22,7 +19,9 @@
 // CHECK-LABEL: func.func @matmul_no_shape_region
 // CHECK: hipsr.matmul(%{{.+}}) ins(%{{.+}}, %{{.+}} : tensor<?x4096xf16>, tensor<4096x1024xf16>)
 // CHECK-SAME: outs(%{{.+}} : tensor<?x1024xf16>) : tensor<?x1024xf16>
-// CHECK-NOT: shape_region
+// CHECK-NEXT asserts return follows immediately: no region was printed (a
+// populated region would put its body on the next line instead).
+// CHECK-NEXT: return
 func.func @matmul_no_shape_region(%ctx: !hipsr.context,
                                   %a: tensor<?x4096xf16>,
                                   %b: tensor<4096x1024xf16>,
@@ -90,5 +89,136 @@ func.func @matmul_operand_not_shaped(%ctx: !hipsr.context, %a: f16,
   // expected-error@+1 {{operand #1 must be ranked tensor or device memref}}
   %0 = "hipsr.matmul"(%ctx, %a, %b, %init) ({}) : (!hipsr.context, f16, tensor<4096x1024xf16>, tensor<64x1024xf16>)
       -> tensor<64x1024xf16>
+  return %0 : tensor<64x1024xf16>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Shape-region population (POPULATE-* RUN line only). One case per ONNX/NumPy
+// matmul shape rule (semantics in HipsrMatMulOp.td). The 2-D case pins the full
+// dataflow; the rest only assert the structure that differs from it.
+//===----------------------------------------------------------------------===//
+
+// Canonical 2-D case, checked end-to-end: the K guard reads A's last dim and
+// B's second-to-last, and M/N are yielded under the assumption.
+// POPULATE-LABEL: func.func @matmul_2d
+// POPULATE: hipsr.matmul(%{{.+}}) ins(%[[A:.+]], %[[B:.+]] : tensor<?x4096xf16>, tensor<4096x1024xf16>)
+// POPULATE-SAME: shape_region {
+// POPULATE:   %[[SHA:.+]] = shape.shape_of %[[A]]
+// POPULATE:   %[[SHB:.+]] = shape.shape_of %[[B]]
+// POPULATE:   %[[KA:.+]] = shape.get_extent %[[SHA]]
+// POPULATE:   %[[SA:.+]] = shape.from_extents %[[KA]]
+// POPULATE:   %[[KB:.+]] = shape.get_extent %[[SHB]]
+// POPULATE:   %[[SB:.+]] = shape.from_extents %[[KB]]
+// POPULATE:   %[[W:.+]] = shape.cstr_eq %[[SA]], %[[SB]]
+// POPULATE:   %[[D:.+]]:2 = shape.assuming %[[W]] -> (index, index) {
+// POPULATE:     %[[M:.+]] = shape.get_extent %[[SHA]]
+// POPULATE:     %[[N:.+]] = shape.get_extent %[[SHB]]
+// POPULATE:     shape.assuming_yield %[[M]], %[[N]] : index, index
+// POPULATE:   }
+// POPULATE:   hipsr.shape_yield (%[[D]]#0, %[[D]]#1) : [f16]
+func.func @matmul_2d(%ctx: !hipsr.context, %a: tensor<?x4096xf16>,
+                     %b: tensor<4096x1024xf16>,
+                     %init: tensor<?x1024xf16>) -> tensor<?x1024xf16> {
+  %0 = hipsr.matmul(%ctx) ins(%a, %b : tensor<?x4096xf16>, tensor<4096x1024xf16>)
+                    outs(%init : tensor<?x1024xf16>) : tensor<?x1024xf16>
+  return %0 : tensor<?x1024xf16>
+}
+
+// -----
+
+// 1-D A acts as (1,K); the promoted leading 1 is stripped, so only N survives.
+// POPULATE-LABEL: func.func @matmul_1d_a
+// POPULATE: shape_region {
+// POPULATE:   shape.cstr_eq
+// POPULATE:   %[[D:.+]] = shape.assuming %{{.+}} -> (index) {
+// POPULATE:     %[[N:.+]] = shape.get_extent
+// POPULATE:     shape.assuming_yield %[[N]] : index
+// POPULATE:   }
+// POPULATE:   hipsr.shape_yield (%[[D]]) : [f16]
+func.func @matmul_1d_a(%ctx: !hipsr.context, %a: tensor<4096xf16>,
+                       %b: tensor<4096x1024xf16>,
+                       %init: tensor<1024xf16>) -> tensor<1024xf16> {
+  %0 = hipsr.matmul(%ctx) ins(%a, %b : tensor<4096xf16>, tensor<4096x1024xf16>)
+                    outs(%init : tensor<1024xf16>) : tensor<1024xf16>
+  return %0 : tensor<1024xf16>
+}
+
+// -----
+
+// 1-D B acts as (K,1); the promoted trailing 1 is stripped, so only M survives.
+// POPULATE-LABEL: func.func @matmul_1d_b
+// POPULATE: shape_region {
+// POPULATE:   shape.cstr_eq
+// POPULATE:   %[[D:.+]] = shape.assuming %{{.+}} -> (index) {
+// POPULATE:     %[[M:.+]] = shape.get_extent
+// POPULATE:     shape.assuming_yield %[[M]] : index
+// POPULATE:   }
+// POPULATE:   hipsr.shape_yield (%[[D]]) : [f16]
+func.func @matmul_1d_b(%ctx: !hipsr.context, %a: tensor<64x4096xf16>,
+                       %b: tensor<4096xf16>,
+                       %init: tensor<64xf16>) -> tensor<64xf16> {
+  %0 = hipsr.matmul(%ctx) ins(%a, %b : tensor<64x4096xf16>, tensor<4096xf16>)
+                    outs(%init : tensor<64xf16>) : tensor<64xf16>
+  return %0 : tensor<64xf16>
+}
+
+// -----
+
+// Both 1-D -> scalar: no M or N, so the K guard wraps an empty region and
+// shape_yield has no dims.
+// POPULATE-LABEL: func.func @matmul_both_1d
+// POPULATE: shape_region {
+// POPULATE:   shape.cstr_eq
+// POPULATE:   shape.assuming %{{.+}} {
+// POPULATE:   hipsr.shape_yield () : [f16]
+func.func @matmul_both_1d(%ctx: !hipsr.context, %a: tensor<4096xf16>,
+                          %b: tensor<4096xf16>,
+                          %init: tensor<f16>) -> tensor<f16> {
+  %0 = hipsr.matmul(%ctx) ins(%a, %b : tensor<4096xf16>, tensor<4096xf16>)
+                    outs(%init : tensor<f16>) : tensor<f16>
+  return %0 : tensor<f16>
+}
+
+// -----
+
+// Batched: leading dims broadcast (a dim of 1 takes the other side), so A's
+// dynamic batch-0 against B's static 1 emits an arith.select.
+// POPULATE-LABEL: func.func @matmul_batched
+// POPULATE: shape_region {
+// POPULATE:   shape.cstr_eq
+// POPULATE:   %[[D:.+]]:4 = shape.assuming %{{.+}} -> (index, index, index, index) {
+// POPULATE:     arith.select
+// POPULATE:     shape.assuming_yield
+// POPULATE:   }
+// POPULATE:   hipsr.shape_yield (%[[D]]#0, %[[D]]#1, %[[D]]#2, %[[D]]#3) : [f16]
+func.func @matmul_batched(%ctx: !hipsr.context, %a: tensor<?x8x64x4096xf16>,
+                          %b: tensor<1x8x4096x1024xf16>,
+                          %init: tensor<?x8x64x1024xf16>) -> tensor<?x8x64x1024xf16> {
+  %0 = hipsr.matmul(%ctx) ins(%a, %b : tensor<?x8x64x4096xf16>, tensor<1x8x4096x1024xf16>)
+                    outs(%init : tensor<?x8x64x1024xf16>) : tensor<?x8x64x1024xf16>
+  return %0 : tensor<?x8x64x1024xf16>
+}
+
+// -----
+
+// Idempotent: the pass only fills empty regions, so a hand-written region
+// survives untouched (no generated shape.shape_of over it).
+// POPULATE-LABEL: func.func @matmul_already_populated
+// POPULATE: shape_region {
+// POPULATE:   %[[C64:.+]] = arith.constant 64 : index
+// POPULATE:   %[[C1024:.+]] = arith.constant 1024 : index
+// POPULATE:   hipsr.shape_yield (%[[C64]], %[[C1024]]) : [f16]
+// POPULATE-NOT: shape.shape_of
+func.func @matmul_already_populated(%ctx: !hipsr.context, %a: tensor<64x4096xf16>,
+                                    %b: tensor<4096x1024xf16>,
+                                    %init: tensor<64x1024xf16>) -> tensor<64x1024xf16> {
+  %0 = hipsr.matmul(%ctx) ins(%a, %b : tensor<64x4096xf16>, tensor<4096x1024xf16>)
+                    outs(%init : tensor<64x1024xf16>) : tensor<64x1024xf16> shape_region {
+    %c64 = arith.constant 64 : index
+    %c1024 = arith.constant 1024 : index
+    hipsr.shape_yield (%c64, %c1024) : [f16]
+  }
   return %0 : tensor<64x1024xf16>
 }

--- a/test/lit/Dialect/Hipsr/matmul.mlir
+++ b/test/lit/Dialect/Hipsr/matmul.mlir
@@ -332,3 +332,16 @@ func.func @matmul_4d_empty_shape_region(%a: tensor<2x3x64x4096xf16>,
   }
   return %0 : tensor<2x3x64x1024xf16>
 }
+
+// -----
+
+// Rank-0 (scalar) operand: a scalar tensor is a valid ranked tensor, so the
+// operand type constraint accepts it, but matmul needs a contraction dim so the
+// verifier rejects it.
+func.func @matmul_rank0_operand(%a: tensor<f16>, %b: tensor<4096x1024xf16>,
+                                %init: tensor<1024xf16>) -> tensor<1024xf16> {
+  // expected-error@+1 {{operand A must be at least 1-D}}
+  %0 = hipsr.matmul ins(%a, %b : tensor<f16>, tensor<4096x1024xf16>)
+                    outs(%init : tensor<1024xf16>) -> tensor<1024xf16>
+  return %0 : tensor<1024xf16>
+}

--- a/test/lit/Dialect/Hipsr/matmul.mlir
+++ b/test/lit/Dialect/Hipsr/matmul.mlir
@@ -20,14 +20,15 @@
 // `shape_region` keyword (the optional region group prints nothing when the
 // region has zero blocks). This is the exact form convert-onnx-to-hipsr emits.
 // CHECK-LABEL: func.func @matmul_no_shape_region
-// CHECK: hipsr.matmul ins(%{{.+}}, %{{.+}} : tensor<?x4096xf16>, tensor<4096x1024xf16>)
-// CHECK-SAME: outs(%{{.+}} : tensor<?x1024xf16>) -> tensor<?x1024xf16>
+// CHECK: hipsr.matmul(%{{.+}}) ins(%{{.+}}, %{{.+}} : tensor<?x4096xf16>, tensor<4096x1024xf16>)
+// CHECK-SAME: outs(%{{.+}} : tensor<?x1024xf16>) : tensor<?x1024xf16>
 // CHECK-NOT: shape_region
-func.func @matmul_no_shape_region(%a: tensor<?x4096xf16>,
+func.func @matmul_no_shape_region(%ctx: !hipsr.context,
+                                  %a: tensor<?x4096xf16>,
                                   %b: tensor<4096x1024xf16>,
                                   %init: tensor<?x1024xf16>) -> tensor<?x1024xf16> {
-  %0 = hipsr.matmul ins(%a, %b : tensor<?x4096xf16>, tensor<4096x1024xf16>)
-                    outs(%init : tensor<?x1024xf16>) -> tensor<?x1024xf16>
+  %0 = hipsr.matmul(%ctx) ins(%a, %b : tensor<?x4096xf16>, tensor<4096x1024xf16>)
+                    outs(%init : tensor<?x1024xf16>) : tensor<?x1024xf16>
   return %0 : tensor<?x1024xf16>
 }
 
@@ -40,22 +41,24 @@ func.func @matmul_no_shape_region(%a: tensor<?x4096xf16>,
 // Rank-0 (scalar) A: a scalar tensor is a valid ranked tensor, so the operand
 // type constraint accepts it, but matmul needs a contraction dim so the
 // verifier rejects it.
-func.func @matmul_rank0_a(%a: tensor<f16>, %b: tensor<4096x1024xf16>,
+func.func @matmul_rank0_a(%ctx: !hipsr.context, %a: tensor<f16>,
+                          %b: tensor<4096x1024xf16>,
                           %init: tensor<1024xf16>) -> tensor<1024xf16> {
   // expected-error@+1 {{operand A must be at least 1-D}}
-  %0 = hipsr.matmul ins(%a, %b : tensor<f16>, tensor<4096x1024xf16>)
-                    outs(%init : tensor<1024xf16>) -> tensor<1024xf16>
+  %0 = hipsr.matmul(%ctx) ins(%a, %b : tensor<f16>, tensor<4096x1024xf16>)
+                    outs(%init : tensor<1024xf16>) : tensor<1024xf16>
   return %0 : tensor<1024xf16>
 }
 
 // -----
 
 // Rank-0 (scalar) B: same contract as A, on the second operand.
-func.func @matmul_rank0_b(%a: tensor<64x4096xf16>, %b: tensor<f16>,
+func.func @matmul_rank0_b(%ctx: !hipsr.context, %a: tensor<64x4096xf16>,
+                          %b: tensor<f16>,
                           %init: tensor<64xf16>) -> tensor<64xf16> {
   // expected-error@+1 {{operand B must be at least 1-D}}
-  %0 = hipsr.matmul ins(%a, %b : tensor<64x4096xf16>, tensor<f16>)
-                    outs(%init : tensor<64xf16>) -> tensor<64xf16>
+  %0 = hipsr.matmul(%ctx) ins(%a, %b : tensor<64x4096xf16>, tensor<f16>)
+                    outs(%init : tensor<64xf16>) : tensor<64xf16>
   return %0 : tensor<64xf16>
 }
 
@@ -63,40 +66,29 @@ func.func @matmul_rank0_b(%a: tensor<64x4096xf16>, %b: tensor<f16>,
 
 // DPS init/result type mismatch: the DPS verifier requires init and result
 // types to be equal. Here the result batch-0 dim (4) differs from the init (2).
-func.func @matmul_init_result_mismatch(%a: tensor<2x3x64x4096xf16>,
+func.func @matmul_init_result_mismatch(%ctx: !hipsr.context,
+                                       %a: tensor<2x3x64x4096xf16>,
                                        %b: tensor<2x3x4096x1024xf16>,
                                        %init: tensor<2x3x64x1024xf16>)
     -> tensor<4x3x64x1024xf16> {
   // expected-error@+1 {{to match type of corresponding result}}
-  %0 = hipsr.matmul ins(%a, %b : tensor<2x3x64x4096xf16>, tensor<2x3x4096x1024xf16>)
-                    outs(%init : tensor<2x3x64x1024xf16>) -> tensor<4x3x64x1024xf16>
+  %0 = hipsr.matmul(%ctx) ins(%a, %b : tensor<2x3x64x4096xf16>, tensor<2x3x4096x1024xf16>)
+                    outs(%init : tensor<2x3x64x1024xf16>) : tensor<4x3x64x1024xf16>
   return %0 : tensor<4x3x64x1024xf16>
 }
 
 // -----
 
-// DPS init/result element-type mismatch: init is f16, result is f32. Same DPS
-// rule (the full type must match, not just the shape).
-func.func @matmul_elem_type_mismatch(%a: tensor<2x64x4096xf16>,
-                                     %b: tensor<2x4096x1024xf16>,
-                                     %init: tensor<2x64x1024xf16>)
-    -> tensor<2x64x1024xf32> {
-  // expected-error@+1 {{to match type of corresponding result}}
-  %0 = hipsr.matmul ins(%a, %b : tensor<2x64x4096xf16>, tensor<2x4096x1024xf16>)
-                    outs(%init : tensor<2x64x1024xf16>) -> tensor<2x64x1024xf32>
-  return %0 : tensor<2x64x1024xf32>
-}
-
-// -----
-
 // Non-shaped operand: A is a scalar f16, which the operand type constraint
-// rejects. The generic form needs an empty region ({}) for the (optional) shape
-// region so the region-count check passes and the operand-type check fires.
-func.func @matmul_operand_not_shaped(%a: f16, %b: tensor<4096x1024xf16>,
+// rejects. With ctx as operand #0, A is operand #1. The generic form needs an
+// empty region ({}) for the (optional) shape region so the region-count check
+// passes and the operand-type check fires.
+func.func @matmul_operand_not_shaped(%ctx: !hipsr.context, %a: f16,
+                                     %b: tensor<4096x1024xf16>,
                                      %init: tensor<64x1024xf16>)
     -> tensor<64x1024xf16> {
-  // expected-error@+1 {{operand #0 must be ranked tensor or device memref}}
-  %0 = "hipsr.matmul"(%a, %b, %init) ({}) : (f16, tensor<4096x1024xf16>, tensor<64x1024xf16>)
+  // expected-error@+1 {{operand #1 must be ranked tensor or device memref}}
+  %0 = "hipsr.matmul"(%ctx, %a, %b, %init) ({}) : (!hipsr.context, f16, tensor<4096x1024xf16>, tensor<64x1024xf16>)
       -> tensor<64x1024xf16>
   return %0 : tensor<64x1024xf16>
 }

--- a/test/lit/Dialect/Hipsr/matmul.mlir
+++ b/test/lit/Dialect/Hipsr/matmul.mlir
@@ -5,11 +5,13 @@
 // Tests for hipsr.matmul that exercise its own code:
 //   - round-trip with the shape region omitted (the form onnx->hipsr emits)
 //   - verifier / parser diagnostics: rank-0 operand, DPS init/result type
-//     mismatch, non-shaped operand, empty shape-region block
+//     mismatch, non-shaped operand
 //
-// The shape region is populated by a later pass (not this stage), so
-// populateShapeRegion is covered with that pass, not here. Generic
-// shape-region structural tests live in shape_region_verify.mlir.
+// This stage emits the op with an empty shape region, so these tests cover the
+// empty-region round-trip and the verifier. populateShapeRegion belongs with a
+// future populate pass and will be tested there. Generic shape-region
+// structural tests (empty / multi-block region rules) live in
+// shape_region_verify.mlir.
 //===----------------------------------------------------------------------===//
 
 // RUN: hip-mlir-opt --split-input-file --verify-diagnostics %s | FileCheck %s
@@ -97,20 +99,4 @@ func.func @matmul_operand_not_shaped(%a: f16, %b: tensor<4096x1024xf16>,
   %0 = "hipsr.matmul"(%a, %b, %init) ({}) : (f16, tensor<4096x1024xf16>, tensor<64x1024xf16>)
       -> tensor<64x1024xf16>
   return %0 : tensor<64x1024xf16>
-}
-
-// -----
-
-// A present shape region must not be a lone empty block (an absent region is
-// expressed by omitting the region entirely).
-func.func @matmul_empty_shape_region(%a: tensor<2x3x64x4096xf16>,
-                                     %b: tensor<2x3x4096x1024xf16>,
-                                     %init: tensor<2x3x64x1024xf16>)
-    -> tensor<2x3x64x1024xf16> {
-  // expected-error@+1 {{expects a non-empty block}}
-  %0 = hipsr.matmul ins(%a, %b : tensor<2x3x64x4096xf16>, tensor<2x3x4096x1024xf16>)
-                    outs(%init : tensor<2x3x64x1024xf16>) -> tensor<2x3x64x1024xf16>
-                    shape_region {
-  }
-  return %0 : tensor<2x3x64x1024xf16>
 }

--- a/tools/hip-mlir-opt/hip-mlir-opt.cpp
+++ b/tools/hip-mlir-opt/hip-mlir-opt.cpp
@@ -30,6 +30,7 @@
 #include "mlir/Dialect/MemRef/Transforms/Passes.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/SCF/Transforms/BufferizableOpInterfaceImpl.h"
+#include "mlir/Dialect/Shape/IR/Shape.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Tensor/IR/TensorInferTypeOpInterfaceImpl.h"
 #include "mlir/Dialect/Tensor/Transforms/BufferizableOpInterfaceImpl.h"
@@ -52,6 +53,7 @@ int main(int argc, char **argv) {
   registry.insert<mlir::func::FuncDialect>();
   registry.insert<mlir::memref::MemRefDialect>();
   registry.insert<mlir::scf::SCFDialect>();
+  registry.insert<mlir::shape::ShapeDialect>();
   registry.insert<mlir::linalg::LinalgDialect>();
   registry.insert<mlir::tensor::TensorDialect>();
   registry.insert<mlir::LLVM::LLVMDialect>();


### PR DESCRIPTION
## Summary

- Add a DPS `hipsr.matmul` op. Its shape region computes the result shape and asserts the runtime checks for ONNX/NumPy matmul: K dims must match, 1-D operands are promoted then stripped from the result, and batch dims broadcast (equal, or one is 1).
- Add the `convert-onnx-to-hipsr` pattern that turns `onnx.MatMul` into `hipsr.matmul` with a placeholder `init` and an empty shape region (filled in by a later pass).
- Add LIT tests for the dialect round-trip and the conversion.
