### PR TITLE
fix(tests): update AMDGPU umbrella EP profile option llm -> hip for whisper tests

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -345,7 +345,7 @@ python onnxruntime-genai/benchmark/python/benchmark_e2e.py \
 `benchmark_e2e.py` runs with the default `-e follow_config`, so the model's
 `genai_config.json` selects the EP via `provider_options`. With the upstream OGA
 (v0.14.0 + PR2194, DeviceType AMDGPU) this is the AMD GPU umbrella
-(`provider_options [{ "AMDGPU": {"profile": "llm"} }]`), which loads
+(`provider_options [{ "AMDGPU": {"profile": "hip"} }]`), which loads
 `amdgpu-ep.dll` and needs the umbrella DLLs colocated (see
 `.github/workflows/windows-build.yml`); the default wheel ships only the hipgpu
 chain. For plain ORT (direct hipgpu, no OGA), register the colocated plugin via
@@ -463,7 +463,7 @@ The EP is selected by the model's `genai_config.json` `provider_options` and
 auto-discovered next to `onnxruntime-genai.dll` -- do NOT pass `--ep_library`
 (upstream `model_benchmark` rejects it). With the upstream OGA (v0.14.0 +
 PR2194) the EP is the AMD GPU umbrella (`provider_options [{ "AMDGPU":
-{"profile": "llm"} }]`), so `amdgpu-ep.dll` must sit next to the OGA DLLs (see
+{"profile": "hip"} }]`), so `amdgpu-ep.dll` must sit next to the OGA DLLs (see
 `.github/workflows/windows-build.yml`).
 
 ```bash

--- a/docs/quick_start_linux.md
+++ b/docs/quick_start_linux.md
@@ -263,7 +263,7 @@ prebuilt package to get it.
 The EP is selected by the model's `genai_config.json` `provider_options` and
 auto-discovered next to the OGA runtime lib -- do NOT pass `--ep_library`
 (upstream `model_benchmark` rejects it). With the upstream OGA (v0.14.0 + PR2194)
-the EP is the AMD GPU umbrella (`provider_options [{ "AMDGPU": {"profile": "llm"} }]`);
+the EP is the AMD GPU umbrella (`provider_options [{ "AMDGPU": {"profile": "hip"} }]`);
 the prebuilt package bundles the umbrella libs.
 
 ```bash

--- a/docs/whisper_quick_start.md
+++ b/docs/whisper_quick_start.md
@@ -149,7 +149,7 @@ After it finishes you should have `$ROOT/local/bin/hipgpu.dll`.
 > from the `onnxruntime-ep-amdgpu` fork (see `.github/workflows/windows-build.yml`
 > for the pinned commit + `cmake -DUSE_AMDGPU=ON` recipe) and must sit next to
 > `hipgpu.dll` in `$ROOT/local/bin/`. The umbrella selects the hipgpu backend via
-> the `profile=llm` provider option.
+> the `profile=hip` provider option.
 
 ---
 
@@ -428,13 +428,13 @@ pytest test/python/whisper/test_whisper.py -k "$SEL" -v -s
 
 Conv1d, attention, and LayerNorm — **fp16 + fp32 across every variant's shapes**
 (attention parametrizes d_model/num_heads per variant; conv1d covers each
-variant's encoder front-end). One line — note `profile=llm` is the ONLY provider
+variant's encoder front-end). One line — note `profile=hip` is the ONLY provider
 option the AMDGPU umbrella accepts (do NOT pass `config_file=`, the umbrella
 rejects unknown provider options). `THEROCK_DIST` must be set so the numeric
 backend can find the ROCm runtime DLLs:
 
 ```
-pytest test/numeric/tests/test_whisper_encoder_attention.py test/numeric/tests/test_whisper_cross_attention.py test/numeric/tests/test_whisper_self_attention.py test/numeric/tests/test_conv1d.py test/numeric/tests/test_layer_norm.py --backend ort_ep --ep-name AMDGPUExecutionProvider --ep-dll $ROOT/local/bin/amdgpu-ep.dll --ep-option profile=llm -v
+pytest test/numeric/tests/test_whisper_encoder_attention.py test/numeric/tests/test_whisper_cross_attention.py test/numeric/tests/test_whisper_self_attention.py test/numeric/tests/test_conv1d.py test/numeric/tests/test_layer_norm.py --backend ort_ep --ep-name AMDGPUExecutionProvider --ep-dll $ROOT/local/bin/amdgpu-ep.dll --ep-option profile=hip -v
 ```
 
 ### 4e. MLIR conversion (LIT)

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -44,7 +44,7 @@ EP_REGISTRATION_NAME = "AMDGPUExecutionProvider"
 # OGA registers the umbrella under its short name (genai_config key).
 EP_OGA_NAME = "AMDGPU"
 # Provider option the umbrella forwards to pick the hipgpu backend.
-EP_PROVIDER_OPTIONS = {"profile": "llm"}
+EP_PROVIDER_OPTIONS = {"profile": "hip"}
 
 # Optional artifact-format override (escape hatch). Production / CI use the
 # default in-process LLVM-IR (bitcode) JIT, so this is UNSET by default and the
@@ -1294,7 +1294,7 @@ def create_ep_session(model_path, repo_root, provider_options=None):
     """Create an AMDGPU-umbrella-EP InferenceSession.
 
     provider_options: optional dict forwarded to the EP. Defaults to
-    EP_PROVIDER_OPTIONS ({"profile": "llm"}) — the umbrella uses "profile" to
+    EP_PROVIDER_OPTIONS ({"profile": "hip"}) — the umbrella uses "profile" to
     select the hipgpu backend. The backend compiles every model in
     output-allocator mode (the 2-arg in-graph hip.alloc_output ABI) -- there is
     no provider option to select a mode.

--- a/test/python/test_output_allocator_unresolved_dim.py
+++ b/test/python/test_output_allocator_unresolved_dim.py
@@ -84,7 +84,7 @@ _WORKER = textwrap.dedent(
         sys.exit(3)
 
     so = ort.SessionOptions()
-    so.add_provider_for_devices(devices, {"profile": "llm"})
+    so.add_provider_for_devices(devices, {"profile": "hip"})
     sess = ort.InferenceSession(model_path, sess_options=so)
     print("SESSION_CREATED_OK")
     """

--- a/test/python/whisper/test_whisper.py
+++ b/test/python/whisper/test_whisper.py
@@ -273,7 +273,7 @@ def _morphizen_session(model_name, model_dir=_MODEL_DIR):
     # bitcode by default; HIPEP_ARTIFACT_FORMAT=NATIVE is an opt-in escape hatch
     # (per-model DLL) — normally unneeded. See apply_artifact_format in conftest.
     apply_artifact_format(so)
-    # profile=llm tells the AMDGPU umbrella to dispatch to the hipgpu backend.
+    # profile=hip tells the AMDGPU umbrella to dispatch to the hipgpu backend.
     so.add_provider_for_devices(devices, dict(EP_PROVIDER_OPTIONS))
     return ort.InferenceSession(str(model_dir / model_name), sess_options=so)
 

--- a/test/python/whisper/whisper_infer.py
+++ b/test/python/whisper/whisper_infer.py
@@ -125,7 +125,7 @@ def make_morphizen_session_factory(repo_root, model_dir):
         # bitcode by default; HIPEP_ARTIFACT_FORMAT=NATIVE is an opt-in escape
         # hatch (per-model DLL) — normally unneeded. See apply_artifact_format.
         apply_artifact_format(so)
-        # profile=llm tells the AMDGPU umbrella to dispatch to the hipgpu backend.
+        # profile=hip tells the AMDGPU umbrella to dispatch to the hipgpu backend.
         so.add_provider_for_devices(devices, dict(EP_PROVIDER_OPTIONS))
         return ort.InferenceSession(str(model_dir / model_name), sess_options=so)
 


### PR DESCRIPTION
## Problem

CI PR #391 bumped ORT 1.25.1 → 1.27.0, and upstream `onnxruntime-ep-amdgpu` (PR #44, pinned in CI at commit `a1318ed`) renamed the AMD GPU umbrella EP's `profile` provider-option value from `llm` → `hip` (`Profile::Llm` → `Profile::Hip`).

The CI smoke tests were already updated (`windows-build.yml` passes `profile|hip`), but the Python test framework and docs still passed `{"profile": "llm"}`. With the new EP DLL, an unrecognized `llm` profile is rejected (`unknown profile: 'llm'`), so the umbrella never dispatches to the hipgpu backend and session create/run aborts with a Windows access violation (`0xc0000005`) — the whisper e2e CI failure:

```
test/python/whisper/test_whisper.py::test_e2e_transcription_greedy[base-fp16]
Windows fatal exception: access violation
  File ".../conftest.py", line 522 in register_morphizen_ep
[NATIVE-CRASH] rc=3221225477 native EP crash (access violation) in GPU session.run
```

## Fix

The central change is `EP_PROVIDER_OPTIONS` in `conftest.py` (`llm` → `hip`). It flows to both:
- the direct-ORT whisper session path (`add_provider_for_devices`), and
- the OGA `genai_config` patch path (`patch_genai_config_for_morphizen`, which reads `dict(EP_PROVIDER_OPTIONS)`).

Also updates the one hardcoded occurrence in `test_output_allocator_unresolved_dim.py` and the `profile=` references in the quick-start / whisper docs. The `test/numeric` harness takes `--ep-option` from the CLI, so no code change was needed there (only the documented invocation).

## Verification

`whisper test_e2e_transcription_greedy[base-fp16]` passes on GPU against ORT 1.27.0 + amdgpu-ep @ `a1318ed` (verbatim JFK quote, identical to CPU reference):

```
[e2e/base-fp16] GPU : 'And so my fellow Americans, ask not what your country can do for you, ...'
PASSED
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)