### PR TITLE
refactor(constants): rename sidecar -> constants file / MemSource

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -860,9 +860,9 @@ jobs:
           exit /b %RC%
 
       # ----------------------------------------------------------------------
-      # EPContext export + import perf test (PR #132 sidecar-in-tar path).
+      # EPContext export + import perf test (PR #132 constants-file-in-tar path).
       # Limited to full_model_seq128 to bound runtime: each model triggers
-      # one export pass (~60 s + N GB sidecar write) plus one import perf
+      # one export pass (~60 s + N GB constants-file write) plus one import perf
       # pass (-t 30). The _ctx.onnx + _MORPHIZEN.bin are deleted right after
       # import to keep runner disk usage bounded.
       # ----------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This project demonstrates the integration of HIP (Heterogeneous-compute Interfac
 - **hipBLASLt MatMul**: High-performance matrix multiplication
 - **Custom HIP Kernels**: GQA, RoPE, Cast, Sub, Gather, ReduceSum, Reciprocal, Sqrt, GELU, Range, LinearAttention, Softmax, CausalConvWithState(fast path)
 - **Memory Pool Optimization**: `hip-pool-allocs` pass packs allocations into a single grow-on-demand buffer
-- **Constant Externalization**: Large model weights stored in sidecar `.constants.bin` files
+- **Constant Externalization**: Large model weights stored in `.constants.bin` constants files
 - **Mock Runtime**: GPU-free development and testing with `BUILD_MOCK_RUNTIME=ON`
 - **MorphiZen EP Integration**: Plugs into ONNX Runtime as the MorphiZen Execution Provider
 

--- a/backend-mlir-compiler/level-1-pass/src/MlirCompiler.h
+++ b/backend-mlir-compiler/level-1-pass/src/MlirCompiler.h
@@ -30,11 +30,12 @@ enum class ArtifactFormat { LLVM_IR, NATIVE };
 // `skipConstantData` selects the OnnxToHip finalize output:
 //   * true  -> per-entry source (descriptors baked into __metadata_blob;
 //              MlirCustomOp ctor streams constants into the GPU blob)
-//   * false -> sidecar  (model.constants.bin + .json; MlirCustomOp ctor
+//   * false -> constants file  (model.constants.bin + .json; MlirCustomOp ctor
 //              goes through inference_init -> init_with_fs bulk hipMemcpy)
 // The in-process EP path decides this inside pass_main::load_config based
-// on ep.context_enable; EPContext export forces sidecar. The struct default
-// (true / streaming) only applies to code paths that bypass load_config.
+// on ep.context_enable; EPContext export forces constants file. The struct
+// default (true / streaming) only applies to code paths that bypass
+// load_config.
 struct CompilationConfig {
   ArtifactFormat artifactFormat;
   int optLevel;

--- a/backend-mlir-compiler/level-1-pass/src/pass_main.cpp
+++ b/backend-mlir-compiler/level-1-pass/src/pass_main.cpp
@@ -81,7 +81,7 @@ static CompilationConfig load_config(PassContext *ctx) {
                                                                 : "LLVM_IR")
             << "; skipConstantData="
             << (config.skipConstantData ? "true" : "false")
-            << (epctxExport ? " (EPContext export -> sidecar)"
+            << (epctxExport ? " (EPContext export -> constants file)"
                             : " (streaming default)");
 
   return config;

--- a/docs/technical-pipeline-walkthrough.md
+++ b/docs/technical-pipeline-walkthrough.md
@@ -112,7 +112,7 @@ hip-compiler.dll
   │      ├── translateToLLVMIR      (LLVM dialect → LLVM IR)
   │      ├── optimizeLLVMIR         (target-independent PerModule O0-O3)
   │      ├── stripTargetMetadata    (clear triple + data layout for OS portability)
-  │      └── emit model.bc          (+ model.constants.bin sidecar)
+  │      └── emit model.bc          (+ model.constants.bin constants file)
   ▼
 Per-model LLVM bitcode  (written via MorphiZen FileSystem into the EPContext tar)
 ```

--- a/include/hip/Dialect/Hipsr/IR/HipsrConstantOp.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrConstantOp.h
@@ -33,8 +33,9 @@ namespace hipsr {
 //
 // CONTRACT: MorphiZen-generated constants only. Works both before and after
 // externalization (value/source are never removed -- offset/size only mark the
-// sidecar location). Fails fast on forms MorphiZen never emits (splat-optimized
-// DenseElementsAttr, DenseResourceElementsAttr); add real APIs if that changes.
+// constants-file location). Fails fast on forms MorphiZen never emits
+// (splat-optimized DenseElementsAttr, DenseResourceElementsAttr); add real APIs
+// if that changes.
 template <typename T>::llvm::ArrayRef<T> ConstantOp::getDataValues() {
   // Inline dense value. MorphiZen writes FULL tensor data
   // (numElements * elemByteWidth), never splat-optimized.

--- a/include/hip/Dialect/Hipsr/IR/HipsrConstantOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrConstantOp.td
@@ -30,7 +30,7 @@ def Hipsr_ConstantOp : Hipsr_Op<"constant", [Pure]> {
                    file) or `#hipsr.mem_source<...>` (a raw ORT pointer).
 
     Externalization only *adds* `offset` + `size` (the location in the
-    compiler-produced constants sidecar); it never removes `value` / `source`,
+    compiler-produced constants file); it never removes `value` / `source`,
     so `getDataValues()` keeps working afterwards. Valid states:
     `{value}`, `{source}`, `{value, offset, size}`, `{source, offset, size}`.
 
@@ -67,7 +67,7 @@ def Hipsr_ConstantOp : Hipsr_Op<"constant", [Pure]> {
     bool isInline() { return getValueAttr() != nullptr; }
     /// True if the constant references an external file/memory source.
     bool hasExternalSource() { return getSourceAttr() != nullptr; }
-    /// True if the constant has been externalized (offset/size into sidecar).
+    /// True if the constant has been externalized (offset/size into constants file).
     bool isExternalized() { return getOffsetAttr() != nullptr; }
     /// Whether this constant should be externalized (defaults to true).
     bool shouldExternalize() {

--- a/include/hip/Dialect/Hipsr/IR/HipsrDialect.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrDialect.h
@@ -18,7 +18,7 @@
 #include <memory>
 #include <mutex>
 
-// The dialect holds a non-owning FileSystem* (constants sidecar sink). Forward
+// The dialect holds a non-owning FileSystem* (constants file sink). Forward
 // declaration only -- avoids pulling morphizen-foundation into every dialect
 // consumer.
 namespace morphizen {

--- a/include/hip/Dialect/Hipsr/IR/HipsrDialect.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrDialect.td
@@ -31,10 +31,10 @@ def Hipsr_Dialect : Dialect {
     /// multi-threaded, so the cache is guarded by a mutex.
     ::llvm::MemoryBuffer *getOrLoadFileMap(::llvm::StringRef path);
 
-    /// Sink for the constants sidecar written by -hipsr-externalize-constants.
+    /// Sink for the constants file written by -hipsr-externalize-constants.
     /// Non-owning; the compile driver injects the same FileSystem it hands the
     /// hip.* pipeline. Null when nobody injected one (e.g. hip-mlir-opt), in
-    /// which case the pass writes no sidecar (pure IR transform).
+    /// which case the pass writes no constants file (pure IR transform).
     void setFileSystem(::morphizen::FileSystem *fs) { fileSystem = fs; }
     ::morphizen::FileSystem *getFileSystem() { return fileSystem; }
 

--- a/include/hip/Dialect/Hipsr/Transforms/Passes.td
+++ b/include/hip/Dialect/Hipsr/Transforms/Passes.td
@@ -41,7 +41,7 @@ def PopulateShapeRegionPass
 
 def HipsrExternalizeConstantsPass
     : Pass<"hipsr-externalize-constants", "mlir::ModuleOp"> {
-  let summary = "Write hipsr.constant data to a sidecar and mark offset/size";
+  let summary = "Write hipsr.constant data to a constants file and mark offset/size";
   let description = [{
     Phase 2 of the hipsr constant subsystem. Runs in two stages:
 
@@ -50,7 +50,7 @@ def HipsrExternalizeConstantsPass
     externalized; assign a 64-byte aligned cumulative offset and stamp the op
     with `offset`/`size`.
 
-    Module-scoped by design: offsets accumulate into a single sidecar shared by
+    Module-scoped by design: offsets accumulate into a single constants file shared by
     the whole module, so the pass must see every constant at once. A per-function
     pass would restart offsets at 0 per function (overlapping placements) and
     write the shared file once per function (races / last-writer-wins).
@@ -70,7 +70,7 @@ def HipsrExternalizeConstantsPass
   let options = [
     Option<"constantsFile", "constants-file", "std::string",
            /*default=*/"\"constants.bin\"",
-           "Sidecar file name written through the injected FileSystem">
+           "Constants-file name written through the injected FileSystem">
   ];
   let dependentDialects = [
     "::mlir::hipsr::HipsrDialect"

--- a/include/hip/Dialect/Transforms/Passes.td
+++ b/include/hip/Dialect/Transforms/Passes.td
@@ -78,7 +78,7 @@ def ConvertOnnxToHipPass : Pass<"convert-onnx-to-hip", "mlir::ModuleOp"> {
     Transformations:
       1. Constants: onnx.Constant -> arith.constant (small/inline) or
          memref.global extern + memref.get_global + bufferization.to_tensor
-         (large/externalized to sidecar .constants.bin + .constants.json)
+         (large/externalized to constants file .constants.bin + .constants.json)
       2. Op mapping: onnx.{MatMul,Transpose,Mul,Softmax} -> hip.* (tensor DPS)
       3. Cleanup: erase onnx.EntryPoint
 
@@ -86,7 +86,7 @@ def ConvertOnnxToHipPass : Pass<"convert-onnx-to-hip", "mlir::ModuleOp"> {
     available as function argument 0.
 
     Constant externalization (opt-in via --externalize-min-num-elements):
-      Large constants above the threshold are written to a binary sidecar file
+      Large constants above the threshold are written to a binary constants file
       and replaced with extern memref.global ops carrying a hip.external_data
       attribute (offset + size).  The filename is recorded as a
       hip.constants_file attribute on the module.  This follows the onnx-mlir
@@ -96,7 +96,7 @@ def ConvertOnnxToHipPass : Pass<"convert-onnx-to-hip", "mlir::ModuleOp"> {
   let options = [
     Option<"externalizeOutputDir", "externalize-output-dir", "std::string",
            /*default=*/"\"\"",
-           "Directory for sidecar .constants.bin/.json files (empty = cwd)">,
+           "Directory for constants-file .constants.bin/.json files (empty = cwd)">,
     Option<"externalizeMinNumElements", "externalize-min-num-elements",
            "int64_t", /*default=*/"0",
            "Minimum number of tensor elements to externalize (0 = disabled)">
@@ -779,7 +779,7 @@ def ResolveExternConstantsPass
     memref.global. The !hip.context is taken from function argument 0
     (inserted by --hip-add-context-arg).
 
-    The runtime is responsible for loading the sidecar constants.bin file
+    The runtime is responsible for loading the constants.bin file
     via morphizen::FileSystem, uploading constants to GPU memory, and
     returning GPU pointers via hipdnn_ep_constant_get(state, index).
 

--- a/include/hip/Dialect/Transforms/Pipelines.h
+++ b/include/hip/Dialect/Transforms/Pipelines.h
@@ -51,8 +51,8 @@ struct OnnxToHipPipelineOptions
     : public PassPipelineOptions<OnnxToHipPipelineOptions> {
   Option<std::string> externalizeOutputDir{
       *this, "externalize-output-dir",
-      llvm::cl::desc(
-          "Directory for sidecar .constants.bin/.json files (empty = cwd)"),
+      llvm::cl::desc("Directory for constants-file .constants.bin/.json files "
+                     "(empty = cwd)"),
       llvm::cl::init("")};
   Option<int64_t> externalizeMinNumElements{
       *this, "externalize-min-num-elements",

--- a/include/hip/Support/ConstantsIO.h
+++ b/include/hip/Support/ConstantsIO.h
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-// Shared emit logic for the constants.bin sidecar.
+// Shared emit logic for the constants.bin file.
 //
 // Both the ONNX->HIP conversion pass (standalone hip-compiler offline path)
 // and the MorphiZen EP level-1 pass (EPContext export path) produce the same

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -887,20 +887,20 @@ void ConvertOnnxToHipPass::runOnOperation() {
     }
   });
 
-  // Finalize externalization: emit the constants.bin sidecar or per-entry
+  // Finalize externalization: emit the constants.bin file or per-entry
   // source descriptors (or both, in hybrid mode), write the JSON manifest
-  // when a full sidecar is produced, and stamp module attributes.
+  // when a full constants file is produced, and stamp module attributes.
   //
   // Three emit modes:
-  //   * skipDataWrite=false  — full sidecar (Workflow A: EPContext export
-  //     + offline hip-compiler). All ConstantInfo.source remain NONE; the
-  //     runtime bulk-loads model.constants.bin and hipMemcpy's it once.
+  //   * skipDataWrite=false  — full constants file (Workflow A: EPContext
+  //     export + offline hip-compiler). All ConstantInfo.source remain NONE;
+  //     the runtime bulk-loads model.constants.bin and hipMemcpy's it once.
   //   * skipDataWrite=true, no mem-addr entries — pure streaming. Per-entry
-  //     descriptors only (Splat / FileRef); no sidecar written.
+  //     descriptors only (Splat / FileRef); no constants file written.
   //   * skipDataWrite=true, has mem-addr entries — hybrid. Mem-addr bytes
-  //     are packed into a *partial* sidecar at compact 64B-aligned offsets;
-  //     the descriptor for each mem-addr entry becomes SidecarSource with
-  //     its sidecar offset. file-ref / splat entries keep their streaming
+  //     are packed into a *partial* constants file at compact 64B-aligned
+  //     offsets; the descriptor for each mem-addr entry becomes MemSource with
+  //     its mem offset. file-ref / splat entries keep their streaming
   //     descriptors. The runtime per-entry path uploads from a single
   //     reusable staging buffer regardless of source mix, bounding host
   //     peak to the largest single tensor instead of total constants size.
@@ -969,17 +969,17 @@ void ConvertOnnxToHipPass::runOnOperation() {
       jsonWriter->fwrite(jsonStr.data(), jsonStr.size());
     } else if (!extState->constantHostPtrs.empty()) {
       // skipDataWrite=true: per-entry descriptors with optional partial
-      // sidecar for mem-addr entries (hybrid).
+      // constants file for mem-addr entries (hybrid).
       //
       // Six parallel arrays, all indexed by constantIndex:
-      //   constant_source_kinds:        0=NONE, 1=Splat, 2=FileRef, 3=Sidecar
+      //   constant_source_kinds:        0=NONE, 1=Splat, 2=FileRef, 3=Mem
       //   constant_splat_elem_values:   elem bytes packed into i64 (0 unless
       //   splat) constant_splat_elem_sizes:    elem byte count 1/2/4/8 (0
       //   unless splat) constant_file_paths:          absolute OS path (empty
       //   unless file-ref) constant_file_offsets:        byte offset within
-      //   file (0 unless file-ref) constant_sidecar_offsets:     byte offset
-      //   within partial sidecar
-      //                                 (0 unless mem-addr / Sidecar)
+      //   file (0 unless file-ref) constant_mem_offsets:         byte offset
+      //   within partial constants file
+      //                                 (0 unless mem-addr / Mem)
       int64_t count = static_cast<int64_t>(extState->constantHostPtrs.size());
       llvm::SmallVector<int32_t> kinds(count, 0);
       llvm::SmallVector<int64_t> splatValues(count, 0);
@@ -987,15 +987,15 @@ void ConvertOnnxToHipPass::runOnOperation() {
       llvm::SmallVector<mlir::Attribute> filePaths;
       filePaths.reserve(count);
       llvm::SmallVector<int64_t> fileOffsets(count, 0);
-      llvm::SmallVector<int64_t> sidecarOffsets(count, 0);
+      llvm::SmallVector<int64_t> memOffsets(count, 0);
 
-      // Pass 1: collect mem-addr entries into a compact partial sidecar
-      // layout. Each entry is 64B-aligned within the sidecar (matches the
+      // Pass 1: collect mem-addr entries into a compact partial constants
+      // file layout. Each entry is 64B-aligned within the file (matches the
       // GPU blob alignment used elsewhere, so writeConstantsBinToFileSystem
       // emits identical zero padding logic).
-      constexpr int64_t kSidecarAlign = 64;
+      constexpr int64_t kMemAlign = 64;
       llvm::SmallVector<mlir::hip::ConstantEntry> partialEntries;
-      int64_t sidecarPos = 0;
+      int64_t memPos = 0;
       int64_t memAddrCount = 0, fileRefCount = 0, splatCount = 0;
       for (int64_t i = 0; i < count; ++i) {
         const auto &h = extState->constantHostPtrs[i];
@@ -1005,35 +1005,35 @@ void ConvertOnnxToHipPass::runOnOperation() {
           ++splatCount;
         } else {
           ++memAddrCount;
-          int64_t off = llvm::alignTo(sidecarPos, kSidecarAlign);
-          sidecarOffsets[i] = off;
+          int64_t off = llvm::alignTo(memPos, kMemAlign);
+          memOffsets[i] = off;
           mlir::hip::ConstantEntry e;
           e.name = extState->constantNames[i];
           e.offset = off;
           e.size = extState->constantSizes[i];
           e.data = h.ptr;
           partialEntries.push_back(std::move(e));
-          sidecarPos = off + extState->constantSizes[i];
+          memPos = off + extState->constantSizes[i];
         }
       }
 
-      // Pass 2: write the partial sidecar (mem-addr bytes only). When
-      // there are no mem-addr entries the sidecar is omitted entirely
+      // Pass 2: write the partial constants file (mem-addr bytes only). When
+      // there are no mem-addr entries the constants file is omitted entirely
       // (pure streaming model — runtime never opens constants_filename).
       if (!partialEntries.empty()) {
         if (!mlir::hip::writeConstantsBinToFileSystem(
                 fs, extState->binFileName,
                 std::vector<mlir::hip::ConstantEntry>(partialEntries.begin(),
                                                       partialEntries.end()),
-                sidecarPos)) {
-          module.emitError(
-              "failed to write partial mem-addr sidecar via FileSystem: " +
-              extState->binFileName);
+                memPos)) {
+          module.emitError("failed to write partial mem-addr constants file "
+                           "via FileSystem: " +
+                           extState->binFileName);
           return signalPassFailure();
         }
         llvm::errs() << "[ConvertOnnxToHipPass] hybrid: " << memAddrCount
-                     << " mem-addr -> partial sidecar ("
-                     << llvm::format("%.1f", sidecarPos / (1024.0 * 1024.0))
+                     << " mem-addr -> partial constants file ("
+                     << llvm::format("%.1f", memPos / (1024.0 * 1024.0))
                      << " MB), " << fileRefCount << " file-ref + " << splatCount
                      << " splat -> streaming\n";
       } else {
@@ -1043,9 +1043,9 @@ void ConvertOnnxToHipPass::runOnOperation() {
       }
 
       // Pass 3: stamp per-entry source descriptors. mem-addr entries get
-      // their sidecarOffsets[i] from pass 1; the rest stay at 0 in that
+      // their memOffsets[i] from pass 1; the rest stay at 0 in that
       // slot which is fine because GenerateInterface only reads it for
-      // kind==3 (Sidecar).
+      // kind==3 (Mem).
       for (int64_t i = 0; i < count; ++i) {
         const auto &entry = extState->constantHostPtrs[i];
         std::string path;
@@ -1062,7 +1062,7 @@ void ConvertOnnxToHipPass::runOnOperation() {
               static_cast<size_t>(std::min<int64_t>(splatElemSizes[i], 8));
           std::memcpy(&splatValues[i], entry.ptr, n);
         } else {
-          kinds[i] = 3; // Sidecar (mem-addr packed into partial sidecar)
+          kinds[i] = 3; // Mem (mem-addr packed into partial constants file)
         }
         filePaths.push_back(mlir::StringAttr::get(ctx, path));
       }
@@ -1077,8 +1077,8 @@ void ConvertOnnxToHipPass::runOnOperation() {
                       mlir::ArrayAttr::get(ctx, filePaths));
       module->setAttr("hipdnn.constant_file_offsets",
                       mlir::DenseI64ArrayAttr::get(ctx, fileOffsets));
-      module->setAttr("hipdnn.constant_sidecar_offsets",
-                      mlir::DenseI64ArrayAttr::get(ctx, sidecarOffsets));
+      module->setAttr("hipdnn.constant_mem_offsets",
+                      mlir::DenseI64ArrayAttr::get(ctx, memOffsets));
     }
 
     LLVM_DEBUG(llvm::dbgs()

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
@@ -454,7 +454,7 @@ void populateFastGeluFusionPatterns(RewritePatternSet &patterns,
 /// through their own ONNX→HIP converters in `convertComputeOps`. Must run
 /// BEFORE `lowerOnnxConstants` because production builds externalize every
 /// `onnx.Constant` (incl. 1-element scalars) into a memref.global with the
-/// value moved to the constants sidecar — at that point the exponent is no
+/// value moved to the constants file — at that point the exponent is no
 /// longer recoverable from IR. See PowerConversion.cpp.
 void populatePowDecompositionPatterns(RewritePatternSet &patterns,
                                       MLIRContext *ctx);

--- a/lib/Conversion/OnnxToHip/PowerConversion.cpp
+++ b/lib/Conversion/OnnxToHip/PowerConversion.cpp
@@ -34,7 +34,7 @@ static constexpr int64_t kMaxPowUnroll = 16;
 /// Why this peek runs PRE-lowering: with externalization enabled, every
 /// `onnx.Constant` — including 1-element scalars — is replaced by
 /// `bufferization.to_tensor(memref.get_global)` whose value lives in the
-/// constants sidecar, NOT in IR. A post-lowering matcher cannot recover the
+/// constants file, NOT in IR. A post-lowering matcher cannot recover the
 /// scalar value from that form. Running before `lowerOnnxConstants` keeps the
 /// `onnx.Constant` (and any wrapping Cast) in IR, so the value is readable.
 static std::optional<double> getScalarConstantValue(mlir::Value v) {
@@ -189,7 +189,7 @@ struct NegToHip : public mlir::RewritePattern {
 /// one). With externalization enabled in production every `onnx.Constant`
 /// — including 1-element scalars — gets replaced by
 /// `bufferization.to_tensor(memref.get_global)` whose value is buried in the
-/// constants sidecar; matching post-lowering would silently miss every Pow.
+/// constants file; matching post-lowering would silently miss every Pow.
 ///
 /// In practice the exponent is always a constant scalar (variance
 /// `Pow(x, 2)` in RMS/LayerNorm and SAM's LayerNorm2d, `Pow(x, 3)` in the

--- a/lib/Dialect/Hipsr/Transforms/ExternalizeConstants.cpp
+++ b/lib/Dialect/Hipsr/Transforms/ExternalizeConstants.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Licensed under the MIT License.
  */
-//===- ExternalizeConstants.cpp - hipsr.constant -> sidecar --------------===//
+//===- ExternalizeConstants.cpp - hipsr.constant -> constants file -------===//
 //
 // Phase 2 of the hipsr constant subsystem. Two stages inside one pass:
 //
@@ -10,7 +10,7 @@
 //     aligned cumulative offset, and stamp offset/size on the op (append-only
 //     -- value/source are kept). Builds one hip::ConstantEntry per constant.
 //   Phase 2 (only when a FileSystem is injected on the dialect): write the
-//     entries to the sidecar via writeConstantsBinToFileSystem.
+//     entries to the constants file via writeConstantsBinToFileSystem.
 //
 // file_source entries carry their file_path/offset only (data = nullptr) so
 // this pass does not read the weight file; inline / mem_source entries carry a
@@ -40,8 +40,8 @@ namespace hipsr {
 
 namespace {
 
-// Sidecar alignment: every constant starts on a 64-byte boundary (GPU
-// alignment; matches the hip.* sidecar layout).
+// Constants-file alignment: every constant starts on a 64-byte boundary (GPU
+// alignment; matches the hip.* constants-file layout).
 constexpr int64_t kConstantAlignment = 64;
 
 struct HipsrExternalizeConstantsPass
@@ -55,9 +55,9 @@ struct HipsrExternalizeConstantsPass
     Builder builder(ctx);
 
     // Phase 1: collect entries and stamp offset/size across the whole module.
-    // Module-scoped so a single cumulative offset feeds one shared sidecar
-    // (see Passes.td). Independent of the FileSystem so the IR transform is
-    // deterministic with or without a sink.
+    // Module-scoped so a single cumulative offset feeds one shared constants
+    // file (see Passes.td). Independent of the FileSystem so the IR transform
+    // is deterministic with or without a sink.
     std::vector<hip::ConstantEntry> entries;
     int64_t filePos = 0;
     module.walk([&](ConstantOp c) {
@@ -95,9 +95,9 @@ struct HipsrExternalizeConstantsPass
       entries.push_back(std::move(entry));
     });
 
-    // Phase 2: write the sidecar, only when a FileSystem was injected (e.g. by
-    // the compile driver). Standalone runs (hip-mlir-opt) inject none, so the
-    // pass is a pure IR transform there.
+    // Phase 2: write the constants file, only when a FileSystem was injected
+    // (e.g. by the compile driver). Standalone runs (hip-mlir-opt) inject none,
+    // so the pass is a pure IR transform there.
     morphizen::FileSystem *fs = nullptr;
     if (auto *dialect = ctx->getLoadedDialect<HipsrDialect>()) {
       fs = dialect->getFileSystem();
@@ -106,8 +106,7 @@ struct HipsrExternalizeConstantsPass
       if (!hip::writeConstantsBinToFileSystem(
               fs, constantsFile, entries,
               llvm::alignTo(filePos, kConstantAlignment))) {
-        module.emitError("failed to write constants sidecar: ")
-            << constantsFile;
+        module.emitError("failed to write constants file: ") << constantsFile;
         signalPassFailure();
       }
     }

--- a/lib/Dialect/Transforms/GenerateInterface.cpp
+++ b/lib/Dialect/Transforms/GenerateInterface.cpp
@@ -74,12 +74,12 @@ buildMetadataNative(ModuleOp module, const std::string &constantsFile) {
       module->getAttrOfType<DenseI64ArrayAttr>("hipdnn.constant_offsets");
 
   // Streaming-mode source descriptors. Present when OnnxToHip's finalize
-  // emitted per-constant source info (splat / file-ref / sidecar). Absent in
-  // full-sidecar mode (EPContext export), in which case every ConstantInfo
-  // keeps source = NONE and runtime falls back to the bulk constants_filename
-  // read. In hybrid mode (skipDataWrite=true with mem-addr entries) some
-  // constants carry SidecarSource pointing at a *partial* sidecar that holds
-  // only mem-addr bytes.
+  // emitted per-constant source info (splat / file-ref / mem). Absent in
+  // full-constants-file mode (EPContext export), in which case every
+  // ConstantInfo keeps source = NONE and runtime falls back to the bulk
+  // constants_filename read. In hybrid mode (skipDataWrite=true with mem-addr
+  // entries) some constants carry MemSource pointing at a *partial* constants
+  // file that holds only mem-addr bytes.
   auto sourceKindsAttr =
       module->getAttrOfType<DenseI32ArrayAttr>("hipdnn.constant_source_kinds");
   auto splatValuesAttr = module->getAttrOfType<DenseI64ArrayAttr>(
@@ -90,8 +90,8 @@ buildMetadataNative(ModuleOp module, const std::string &constantsFile) {
       module->getAttrOfType<ArrayAttr>("hipdnn.constant_file_paths");
   auto fileOffsetsAttr =
       module->getAttrOfType<DenseI64ArrayAttr>("hipdnn.constant_file_offsets");
-  auto sidecarOffsetsAttr = module->getAttrOfType<DenseI64ArrayAttr>(
-      "hipdnn.constant_sidecar_offsets");
+  auto memOffsetsAttr =
+      module->getAttrOfType<DenseI64ArrayAttr>("hipdnn.constant_mem_offsets");
 
   mlir::hip::HipModelMetaInfoT meta;
   meta.version = 1;
@@ -109,8 +109,8 @@ buildMetadataNative(ModuleOp module, const std::string &constantsFile) {
                                              : ArrayRef<int64_t>{};
     auto fileOffsets =
         fileOffsetsAttr ? fileOffsetsAttr.asArrayRef() : ArrayRef<int64_t>{};
-    auto sidecarOffsets = sidecarOffsetsAttr ? sidecarOffsetsAttr.asArrayRef()
-                                             : ArrayRef<int64_t>{};
+    auto memOffsets =
+        memOffsetsAttr ? memOffsetsAttr.asArrayRef() : ArrayRef<int64_t>{};
     for (auto i : llvm::seq<size_t>(0, sizes.size())) {
       auto ci = std::make_unique<mlir::hip::ConstantInfoT>();
       ci->size = sizes[i];
@@ -133,14 +133,13 @@ buildMetadataNative(ModuleOp module, const std::string &constantsFile) {
         fref->file_offset = (i < fileOffsets.size()) ? fileOffsets[i] : 0;
         ci->source.Set(std::move(*fref));
       } else if (kind == 3) {
-        // Sidecar: mem-addr entry packed into
-        // HipModelMetaInfo.constants_filename at sidecar_offset by the
+        // Mem: mem-addr entry packed into
+        // HipModelMetaInfo.constants_filename at mem_offset by the
         // OnnxToHip hybrid finalize. Runtime reads size bytes from that offset
         // through the EP FileSystem.
-        auto side = std::make_unique<mlir::hip::SidecarSourceT>();
-        side->sidecar_offset =
-            (i < sidecarOffsets.size()) ? sidecarOffsets[i] : 0;
-        ci->source.Set(std::move(*side));
+        auto mem = std::make_unique<mlir::hip::MemSourceT>();
+        mem->mem_offset = (i < memOffsets.size()) ? memOffsets[i] : 0;
+        ci->source.Set(std::move(*mem));
       }
       meta.constants.push_back(std::move(ci));
     }

--- a/lib/Dialect/Transforms/ResolveExternConstants.cpp
+++ b/lib/Dialect/Transforms/ResolveExternConstants.cpp
@@ -147,7 +147,7 @@ void ResolveExternConstantsPass::runOnOperation() {
     info.globalOp.erase();
 
   // Keep hip.constants_file so GenerateInterface can embed the correct
-  // sidecar filename in the model metadata.
+  // constants-file name in the model metadata.
 }
 
 } // namespace

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -82,8 +82,8 @@ int hipdnn_ep_state_init_with_fs(RuntimeState **out_state, void *fs,
 
   // 3. Dispatch by metadata semantics: if any constant carries a per-entry
   //    source descriptor (Splat / FileRef), do per-tensor upload driven by
-  //    the source union. Otherwise fall back to the bulk sidecar path (used
-  //    by EPContext export / import and has_mem_addr downgrade).
+  //    the source union. Otherwise fall back to the bulk constants-file path
+  //    (used by EPContext export / import and has_mem_addr downgrade).
   bool anyPerEntry = false;
   for (int64_t i = 0; i < count; ++i) {
     if (constants->Get(i)->source_type() != mlir::hip::ConstantSource::NONE) {
@@ -96,7 +96,7 @@ int hipdnn_ep_state_init_with_fs(RuntimeState **out_state, void *fs,
     constants_filename = meta->constants_filename()->c_str();
   int rc;
   if (anyPerEntry) {
-    // Hybrid path also goes through per-entry; SidecarSource entries open
+    // Hybrid path also goes through per-entry; MemSource entries open
     // constants_filename through fs to fetch their slice on demand. Pure
     // streaming (only Splat / FileRef) ignores fs/constants_filename.
     rc = per_entry_load_constants(*out_state, meta, fileSystem,
@@ -330,7 +330,7 @@ static int hipmalloc_and_fixup(RuntimeState *state,
   return 0;
 }
 
-// Load the entire constants sidecar as one blob and hipMemcpy it into the
+// Load the entire constants file as one blob and hipMemcpy it into the
 // pre-allocated gpu_constants_blob. Used when OnnxToHip wrote
 // model.constants.bin (non-streaming path: hip-compiler CLI, EPContext
 // import, mem-addr downgrade).
@@ -345,7 +345,7 @@ static int bulk_load_constants(RuntimeState *state, morphizen::FileSystem *fs,
   }
   size_t total_size = reader->size();
 
-  TIMING_LOG("[Session] open sidecar %s: %.3fs (%zu bytes)\n",
+  TIMING_LOG("[Session] open constants file %s: %.3fs (%zu bytes)\n",
              constants_filename, record_elapsed(t_prev), total_size);
 
   const void *src = reader->mmap();
@@ -459,13 +459,13 @@ static int fref_fetch(FrefCache *c, int64_t file_offset, size_t size,
   return 0;
 }
 
-// Lazy reader for the partial mem-addr sidecar (hybrid mode). Opened
-// through the EP FileSystem on first SidecarSource entry; if the
-// FileSystem can mmap the sidecar we keep the base pointer so the case
+// Lazy reader for the partial mem-addr constants file (hybrid mode). Opened
+// through the EP FileSystem on first MemSource entry; if the
+// FileSystem can mmap the constants file we keep the base pointer so the case
 // becomes a memcpy + hipMemcpy (no extra fread). On non-mmap backends
 // we fall back to fread, which still wins because the per-entry staging
 // reuse keeps host peak bounded to the largest single tensor.
-struct SidecarReaderCache {
+struct ConstantsFileReaderCache {
   std::unique_ptr<morphizen::FileReader,
                   morphizen::FileSystem::Deleter<morphizen::FileReader>>
       reader; // default-init: null pointer, deleter unused
@@ -475,21 +475,21 @@ struct SidecarReaderCache {
 };
 
 // Returns true on success (or no-op if already open). On first call
-// opens the sidecar through fs and tries mmap.
-static bool sidecar_cache_open(SidecarReaderCache *c, morphizen::FileSystem *fs,
-                               const char *constants_filename) {
+// opens the constants file through fs and tries mmap.
+static bool constants_file_cache_open(ConstantsFileReaderCache *c,
+                                      morphizen::FileSystem *fs,
+                                      const char *constants_filename) {
   if (c->tried_open)
     return c->reader != nullptr;
   c->tried_open = true;
   if (!fs || !constants_filename) {
-    fprintf(stderr,
-            "per_entry: SidecarSource entry but fs / constants_filename "
-            "unavailable\n");
+    fprintf(stderr, "per_entry: MemSource entry but fs / constants_filename "
+                    "unavailable\n");
     return false;
   }
   c->reader = fs->create_reader_template(constants_filename);
   if (!c->reader) {
-    fprintf(stderr, "per_entry: failed to open partial sidecar %s\n",
+    fprintf(stderr, "per_entry: failed to open partial constants file %s\n",
             constants_filename);
     return false;
   }
@@ -498,14 +498,16 @@ static bool sidecar_cache_open(SidecarReaderCache *c, morphizen::FileSystem *fs,
   return true;
 }
 
-// Copy `size` bytes at `offset` from the partial sidecar into `staging`.
-static int sidecar_fetch(SidecarReaderCache *c, int64_t offset, size_t size,
-                         void *staging) {
+// Copy `size` bytes at `offset` from the partial constants file into
+// `staging`.
+static int constants_file_fetch(ConstantsFileReaderCache *c, int64_t offset,
+                                size_t size, void *staging) {
   if ((uint64_t)offset + size > (uint64_t)c->total_size) {
-    fprintf(stderr,
-            "per_entry: sidecar fetch out of range (offset=%lld size=%zu "
-            "total=%zu)\n",
-            (long long)offset, size, c->total_size);
+    fprintf(
+        stderr,
+        "per_entry: constants-file fetch out of range (offset=%lld size=%zu "
+        "total=%zu)\n",
+        (long long)offset, size, c->total_size);
     return 1;
   }
   if (c->mmap_base) {
@@ -514,8 +516,8 @@ static int sidecar_fetch(SidecarReaderCache *c, int64_t offset, size_t size,
   }
   // Non-mmap reader: rewind + skip + fread. morphizen::FileReader does
   // not expose a seek primitive, so we read-and-discard up to offset.
-  // Sidecar is touched once per entry in entry order, so this still
-  // streams linearly through the file.
+  // The constants file is touched once per entry in entry order, so this
+  // still streams linearly through the file.
   c->reader->rewind();
   static constexpr size_t kSkipChunk = 64 * 1024;
   uint8_t skip_buf[kSkipChunk];
@@ -524,7 +526,8 @@ static int sidecar_fetch(SidecarReaderCache *c, int64_t offset, size_t size,
     size_t toRead = (size_t)std::min<uint64_t>(remaining_skip, kSkipChunk);
     size_t got = c->reader->fread(skip_buf, toRead);
     if (got != toRead) {
-      fprintf(stderr, "per_entry: sidecar skip short read (got %zu of %zu)\n",
+      fprintf(stderr,
+              "per_entry: constants-file skip short read (got %zu of %zu)\n",
               got, toRead);
       return 1;
     }
@@ -532,7 +535,8 @@ static int sidecar_fetch(SidecarReaderCache *c, int64_t offset, size_t size,
   }
   size_t got = c->reader->fread(staging, size);
   if (got != size) {
-    fprintf(stderr, "per_entry: sidecar payload short read (got %zu of %zu)\n",
+    fprintf(stderr,
+            "per_entry: constants-file payload short read (got %zu of %zu)\n",
             got, size);
     return 1;
   }
@@ -547,9 +551,9 @@ static int sidecar_fetch(SidecarReaderCache *c, int64_t offset, size_t size,
 // through a single reusable staging buffer, bounding host memory to the
 // largest single tensor.
 //
-// `fs` and `constants_filename` are only consulted by SidecarSource
+// `fs` and `constants_filename` are only consulted by MemSource
 // entries (hybrid path). Pure streaming modules (only Splat / FileRef)
-// never open the sidecar.
+// never open the constants file.
 static int per_entry_load_constants(RuntimeState *state,
                                     const mlir::hip::HipModelMetaInfo *meta,
                                     morphizen::FileSystem *fs,
@@ -581,7 +585,7 @@ static int per_entry_load_constants(RuntimeState *state,
   FrefCache fcache;
   fref_cache_init(&fcache);
 
-  SidecarReaderCache scache; // RAII; default-initialized above
+  ConstantsFileReaderCache cfcache; // RAII; default-initialized above
 
   for (int64_t i = 0; i < count; ++i) {
     auto *c = constants->Get(i);
@@ -636,21 +640,21 @@ static int per_entry_load_constants(RuntimeState *state,
       }
       break;
     }
-    case mlir::hip::ConstantSource::SidecarSource: {
-      auto *side = c->source_as_SidecarSource();
-      int64_t side_offset = side->sidecar_offset();
-      if (!sidecar_cache_open(&scache, fs, constants_filename)) {
+    case mlir::hip::ConstantSource::MemSource: {
+      auto *mem = c->source_as_MemSource();
+      int64_t mem_offset = mem->mem_offset();
+      if (!constants_file_cache_open(&cfcache, fs, constants_filename)) {
         free(staging);
         fref_cache_release(&fcache);
         return 1;
       }
-      if (sidecar_fetch(&scache, side_offset, sz, staging) != 0) {
+      if (constants_file_fetch(&cfcache, mem_offset, sz, staging) != 0) {
         free(staging);
         fref_cache_release(&fcache);
         return 1;
       }
       if (hipMemcpy(dst, staging, sz, hipMemcpyHostToDevice) != hipSuccess) {
-        fprintf(stderr, "per_entry: hipMemcpy failed for sidecar entry %lld\n",
+        fprintf(stderr, "per_entry: hipMemcpy failed for mem entry %lld\n",
                 (long long)i);
         free(staging);
         fref_cache_release(&fcache);

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -11,7 +11,7 @@ target_include_directories(HipSupport PUBLIC
 
 target_link_libraries(HipSupport PUBLIC cpptrace::cpptrace)
 
-# Shared constants.bin sidecar I/O. Its own target (not folded into any
+# Shared constants.bin file I/O. Its own target (not folded into any
 # conversion) so producers -- OnnxToHip, the MorphiZen EP, hipsr-externalize-
 # constants -- depend on this rather than on each other's pipeline libs.
 add_library(HipConstantsIO STATIC ConstantsIO.cpp)

--- a/schemas/model_metadata.fbs
+++ b/schemas/model_metadata.fbs
@@ -10,7 +10,7 @@ table TensorInfo {
 
 // Per-constant source descriptor baked into __metadata_blob. When a
 // ConstantInfo.source is NONE, the runtime falls back to the bulk
-// sidecar read (constants_filename). Otherwise it uploads this
+// constants-file read (constants_filename). Otherwise it uploads this
 // constant tensor-by-tensor using the source-specific payload.
 table SplatSource {
   // Element bytes (1 / 2 / 4 / 8), tile-expanded to ConstantInfo.size
@@ -23,13 +23,13 @@ table FileRefSource {
 }
 // Hybrid path: a constant whose source could not be re-read on demand
 // (mem-addr alias of DenseAttr / OrtValue) was packed into the small
-// per-session sidecar. The runtime fetches `size` bytes at
-// `sidecar_offset` from HipModelMetaInfo.constants_filename through
+// per-session partial constants file. The runtime fetches `size` bytes at
+// `mem_offset` from HipModelMetaInfo.constants_filename through
 // the EP's FileSystem and uploads via the per-entry staging buffer.
-table SidecarSource {
-  sidecar_offset: int64; // byte offset within HipModelMetaInfo.constants_filename
+table MemSource {
+  mem_offset: int64; // byte offset within HipModelMetaInfo.constants_filename
 }
-union ConstantSource { SplatSource, FileRefSource, SidecarSource }
+union ConstantSource { SplatSource, FileRefSource, MemSource }
 
 table ConstantInfo {
   size:   int64;

--- a/test/lit/Conversion/onnx-to-hip/test_pow.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_pow.mlir
@@ -11,7 +11,7 @@
 // Running pre-lowering is required: with externalization enabled (production
 // default), every onnx.Constant — including 1-element scalars — is replaced
 // by bufferization.to_tensor(memref.get_global) whose value lives in the
-// constants sidecar, and a post-lowering matcher could not recover it.
+// constants file, and a post-lowering matcher could not recover it.
 //
 // Covered exponents (all forms):
 //   2    -> single hip.mul (x*x)        — dominant RMS/LayerNorm variance case
@@ -117,7 +117,7 @@ module {
   // onnx.Cast. Validates the actual SAM `output_upscaling.1/Pow` pattern.
   // Verified BOTH with externalization off (CHECK) AND on (EXTERN), to lock
   // in that the decomposition runs before lowerOnnxConstants moves the value
-  // into the sidecar.
+  // into the constants file.
   func.func @test_pow_onnx_const_cast(%arg0: tensor<1x64x128x128xf16>) -> tensor<1x64x128x128xf16> {
     %c = "onnx.Constant"() {value = dense<3.0> : tensor<f32>} : () -> tensor<f32>
     %ec = "onnx.Cast"(%c) {to = 10 : si64} : (tensor<f32>) -> tensor<f16>

--- a/test/lit/Dialect/Hipsr/test_externalize_constants.mlir
+++ b/test/lit/Dialect/Hipsr/test_externalize_constants.mlir
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 //
 // Tests -hipsr-externalize-constants (Phase 2). The pass assigns each opted-in
-// hipsr.constant a 64-byte aligned cumulative sidecar offset and stamps
+// hipsr.constant a 64-byte aligned cumulative constants-file offset and stamps
 // offset/size on the op, append-only (value/source are kept). No FileSystem is
-// injected in these runs, so the sidecar write (Phase 2) is skipped and the
+// injected in these runs, so the constants-file write (Phase 2) is skipped and the
 // pass is a pure IR transform -- which is what lets these cases be checked
 // without any on-disk file.
 //

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -7,7 +7,7 @@
 # MLIR dialect/pass unit tests (GPU-free).
 #=============================================================================
 # Cover behavior that LIT cannot: here -hipsr-externalize-constants runs with an
-# injected in-memory FileSystem so the Phase 2 sidecar write (and the bytes it
+# injected in-memory FileSystem so the Phase 2 constants-file write (and the bytes it
 # emits) can be asserted, which hip-mlir-opt (no FileSystem) cannot exercise.
 # Plain main() (no GTest), matching the other MLIR-side unit tests.
 

--- a/test/unit/test_externalize_constants.cpp
+++ b/test/unit/test_externalize_constants.cpp
@@ -4,11 +4,12 @@
  */
 
 // Unit test for -hipsr-externalize-constants that exercises Phase 2 (the
-// sidecar write), which the LIT tests cannot: LIT runs hip-mlir-opt with no
-// injected FileSystem, so it only sees the Phase 1 IR mutation (offset/size).
-// Here we inject an in-memory FileSystem and assert the actual bytes written --
-// the only way to catch entry-field bugs (e.g. file_source vs inline routing)
-// that are invisible in the IR because they produce identical offset/size.
+// constants-file write), which the LIT tests cannot: LIT runs hip-mlir-opt with
+// no injected FileSystem, so it only sees the Phase 1 IR mutation
+// (offset/size). Here we inject an in-memory FileSystem and assert the actual
+// bytes written -- the only way to catch entry-field bugs (e.g. file_source vs
+// inline routing) that are invisible in the IR because they produce identical
+// offset/size.
 //
 // Plain main() (no GTest): matches the other MLIR-side unit tests and avoids a
 // GTest dependency that is not present in the compiler build.
@@ -65,9 +66,9 @@ std::vector<char> readAt(const std::filesystem::path &file, int64_t offset,
   return buf;
 }
 
-// Verifies an in-memory sidecar `blob` against the ops (in walk order) and
-// their expected bytes, driven by the offset/size stamped on each op: the data
-// at each stamped offset must be that constant's bytes, sizes must match,
+// Verifies an in-memory constants file `blob` against the ops (in walk order)
+// and their expected bytes, driven by the offset/size stamped on each op: the
+// data at each stamped offset must be that constant's bytes, sizes must match,
 // offsets must be 64-aligned / monotonic / non-overlapping, gap and trailing
 // bytes zero, and the total length the aligned end of the last constant.
 void verifyLayout(const std::vector<char> &blob,
@@ -130,8 +131,8 @@ void verifyLayout(const std::vector<char> &blob,
 }
 
 // FileSystem that captures every write into an in-memory buffer per filename,
-// so a test can inspect the exact sidecar bytes. create_reader is unused --
-// writeConstantsBinToFileSystem reads file_source data via std::fopen on the
+// so a test can inspect the exact constants-file bytes. create_reader is unused
+// -- writeConstantsBinToFileSystem reads file_source data via std::fopen on the
 // file path directly, not through the FileSystem.
 class CapturingFileSystem : public morphizen::FileSystem {
 public:
@@ -199,8 +200,8 @@ struct Harness {
   }
 };
 
-// Inline value: the raw dense bytes land in the sidecar at offset 0, and the op
-// is stamped with that offset/size.
+// Inline value: the raw dense bytes land in the constants file at offset 0, and
+// the op is stamped with that offset/size.
 void testInlineValueBytesWritten() {
   Harness h;
   CapturingFileSystem fs;
@@ -262,8 +263,8 @@ void testMemSourceBytesWritten() {
         "mem_source: blob bytes copied from address");
 }
 
-// file_source: the sidecar bytes come from the referenced file at the given
-// offset. Covers the file-ref branch.
+// file_source: the constants-file bytes come from the referenced file at the
+// given offset. Covers the file-ref branch.
 void testFileSourceBytesStreamed() {
   auto path = std::filesystem::temp_directory_path() /
               "hipsr_externalize_test_weights.bin";
@@ -328,9 +329,10 @@ void testCumulativeAlignmentAndPadding() {
 }
 
 // Multiple functions in one module share a single cumulative offset and a
-// single sidecar write. This is the module-scoped contract: a per-function pass
-// would restart offsets at 0 and overwrite the file per function.
-void testMultiFunctionSharesOneSidecar() {
+// single constants-file write. This is the module-scoped contract: a
+// per-function pass would restart offsets at 0 and overwrite the file per
+// function.
+void testMultiFunctionSharesOneConstantsFile() {
   Harness h;
   CapturingFileSystem fs;
   bool ok = false;
@@ -352,7 +354,7 @@ void testMultiFunctionSharesOneSidecar() {
 
   // One shared file with both functions' constants, not one overwrite per
   // function.
-  check(fs.files.size() == 1, "multi-func: exactly one sidecar written");
+  check(fs.files.size() == 1, "multi-func: exactly one constants file written");
 
   std::vector<mlir::hipsr::ConstantOp> ops;
   module->walk([&](mlir::hipsr::ConstantOp c) { ops.push_back(c); });
@@ -365,9 +367,9 @@ void testMultiFunctionSharesOneSidecar() {
 }
 
 // The core round-trip: several constants of mixed kinds / dtypes / sizes chosen
-// so offsets need real (non-coincidental) padding. The sidecar is written to a
-// real file; each constant is read back by fseek-ing to the offset stamped on
-// its op and comparing the bytes and length. This is what catches an
+// so offsets need real (non-coincidental) padding. The constants file is
+// written to a real file; each constant is read back by fseek-ing to the offset
+// stamped on its op and comparing the bytes and length. This is what catches an
 // offset/size stamped != data actually placed bug, which the per-byte hardcoded
 // checks cannot.
 void testOffsetDrivenReadBack() {
@@ -448,7 +450,7 @@ void testOffsetDrivenReadBack() {
     return;
   }
 
-  fs::path sidecar = dir / "constants.bin";
+  fs::path constantsFile = dir / "constants.bin";
   int64_t prevEnd = 0;
   int64_t lastOffset = 0, lastSize = 0;
   bool layoutOk = true;
@@ -472,7 +474,7 @@ void testOffsetDrivenReadBack() {
       layoutOk = false;
     }
     // The data at the stamped offset is this constant's bytes.
-    if (readAt(sidecar, off, sz) != expected[i]) {
+    if (readAt(constantsFile, off, sz) != expected[i]) {
       bytesOk = false;
     }
     prevEnd = off + sz;
@@ -485,9 +487,9 @@ void testOffsetDrivenReadBack() {
 
   // Total file length is the aligned end of the last constant (derived, not
   // hardcoded).
-  auto fileLen = static_cast<int64_t>(fs::file_size(sidecar, ec));
+  auto fileLen = static_cast<int64_t>(fs::file_size(constantsFile, ec));
   check(!ec && fileLen == llvm::alignTo(lastOffset + lastSize, 64),
-        "readback: sidecar length == aligned total");
+        "readback: constants-file length == aligned total");
 
   fs::remove_all(dir, ec);
 }
@@ -518,7 +520,7 @@ int main() {
   testMemSourceBytesWritten();
   testFileSourceBytesStreamed();
   testCumulativeAlignmentAndPadding();
-  testMultiFunctionSharesOneSidecar();
+  testMultiFunctionSharesOneConstantsFile();
   testOffsetDrivenReadBack();
   testWriteFailureFailsPass();
 


### PR DESCRIPTION
## Summary

Mechanical naming cleanup for the constant-data subsystem: the legacy term `sidecar` is renamed to `constants file` everywhere it referred to the constant blob, and the FlatBuffer descriptor `SidecarSource`/`sidecar_offset` becomes `MemSource`/`mem_offset`. No behavior change. AI tool (Cursor) was used to perform the rename; every change is a rename I can account for in review.

## Why

`sidecar` was an imprecise legacy name: the runtime always reads the constant blob from `constants.bin` / `model.constants.bin`, and the descriptor formerly called `SidecarSource` specifically identifies a constant whose bytes were packed into that file from a memory address (mem-addr alias), as opposed to `SplatSource` / `FileRefSource`. `MemSource` names that origin directly, and `constants file` names the artifact by what it is. Doing this now, as a standalone rename, keeps the diff reviewable and unblocks upcoming constant-lowering work from inheriting the old vocabulary.

Alternative considered: leave the names as-is. Rejected because the `sidecar` term keeps generating confusion in reviews and the union member name (`MemSource`) is about to be referenced by new op-first metadata code.

## What

1. **FlatBuffer schema** (schemas/model_metadata.fbs): table `SidecarSource` -> `MemSource`, field `sidecar_offset` -> `mem_offset`. Union `ConstantSource` member order is unchanged (`SplatSource`, `FileRefSource`, `MemSource` = kinds 1/2/3), so previously serialized `__metadata_blob` payloads still parse. The generated accessor header is regenerated by flatc at build time (not checked in).
2. **Consumers updated** to the regenerated accessors: lib/Dialect/Transforms/GenerateInterface.cpp (`MemSourceT` / `mem_offset` / reads `hipdnn.constant_mem_offsets`), lib/Runtime/hipdnn_ep_runtime_state.cpp (`source_as_MemSource` / `mem_offset` / local reader helpers), lib/Conversion/OnnxToHip/OnnxToHip.cpp (stamps `hipdnn.constant_mem_offsets`).
3. **Module attribute rename**: `hipdnn.constant_sidecar_offsets` -> `hipdnn.constant_mem_offsets` (producer in OnnxToHip, consumer in GenerateInterface).
4. **Prose rename**: `sidecar` -> `constants file` across comments, docs (README, technical-pipeline-walkthrough), pass `.td` descriptions, and LIT test comments.
5. **Intentional non-changes**: real file names `constants.bin` / `model.constants.bin` / `.constants.bin` / `.constants.json` are untouched. Two Python spots keep the word `sidecar` because there it means an unrelated companion file, not the constant blob: `.data sidecars` in 	est/python/conftest.py (ONNX external-data files) and `_emit_genai_dml_sidecars` in 	ools/onnx-model-splitter/export_chunk_model.py (genai `*_dml.json` configs).

## Test plan

- `python build.py --install_dir D:/ROCm/local --build_dir D:/ROCm/build/hip-ep --cmake_generator Ninja`: build green, flatc regenerated the metadata accessors, LIT 294/296 passed (2 unsupported, unchanged from baseline).
- `ctest -R HipsrExternalizeConstantsUnit`: passed (this unit test contains the renamed test function `testMultiFunctionSharesOneConstantsFile`).
- `pre-commit run --all-files`: converged (clang-format reflowed a few now-longer comment lines; re-staged and re-ran to green).

## Notes for reviewers

Wire compatibility is the one load-bearing invariant: the union member order and the `ConstantInfo` field layout are unchanged, so this is a pure identifier/prose rename with no schema-format break. None otherwise.

## Checklist

- [x] **Incremental.** Standalone rename PR, self-contained, no functional change.
- [x] **AI policy.** Cursor performed the mechanical rename; disclosed here and via the commit trailer. Every change is a rename I can explain in review.
- [x] **No `good first issue` automation.**
- [x] **Reviews resolved.**
- [x] **CODEOWNERS routing.** Touches schemas / runtime / conversion / dialect under the existing ownership map.