### PR TITLE
test(ci): switch OGA build to cliu1003 sliding_window_support_amdgpu fork

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -32,11 +32,14 @@ env:
   # ORT is still built from source either way). Part of the ort-install cache
   # key. Remove a PR once its fix lands in the pinned ONNX Runtime release.
   ONNXRUNTIME_PR_PATCHES: ""
-  OGA_VERSION: "0.14.0"
-  # Space-separated microsoft/onnxruntime-genai PR numbers fetched from
-  # pull/<n>.patch and `git apply` on top of v<OGA_VERSION>. Part of the OGA
-  # cache key. Remove a PR once it lands in the pinned OGA release.
-  OGA_PR_PATCHES: "2194"
+  # Fork branch carrying AMDGPU MorphiZen integration (former PR 2194) plus
+  # sliding_window support.
+  OGA_REPO: "cliu1003/onnxruntime-genai"
+  OGA_REF: "sliding_window_support_amdgpu"
+  # Optional space-separated microsoft/onnxruntime-genai PR numbers applied
+  # on top of the fork checkout via pull/<n>.patch + git am. Empty when the
+  # fork branch already carries the needed integration.
+  OGA_PR_PATCHES: ""
   # The GPU arch the artifact targets. CI runners have no GPU, so it is passed
   # explicitly (build.py auto-detects from /sys on a real GPU host).
   HIP_ARCHITECTURES: gfx1151
@@ -289,17 +292,20 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ${{ runner.workspace }}/oga-artifacts
-          key: linux-oga-${{ env.OGA_VERSION }}-pr${{ env.OGA_PR_PATCHES }}-am-whl-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}
+          key: linux-oga-${{ env.OGA_REPO }}-${{ env.OGA_REF }}-pr${{ env.OGA_PR_PATCHES }}-am-whl-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}
 
       # Checkout + build are skipped on an OGA cache hit (step-level gate); the
       # install-copy below always runs so the
       # cached artifacts land in install/ either way.
+      # OGA is built from cliu1003/onnxruntime-genai sliding_window_support_amdgpu
+      # (AMDGPU MorphiZen integration + sliding_window). Optional OGA_PR_PATCHES
+      # apply extra upstream PRs on top of the fork checkout.
       - name: Checkout OGA
         if: steps.cache-oga.outputs.cache-hit != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: microsoft/onnxruntime-genai
-          ref: v${{ env.OGA_VERSION }}
+          repository: ${{ env.OGA_REPO }}
+          ref: ${{ env.OGA_REF }}
           submodules: recursive
           path: onnxruntime-genai
           fetch-depth: 1

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -46,11 +46,14 @@ jobs:
       # Remove a PR number once its fix is in the pinned ONNXRUNTIME_VERSION.
       ONNXRUNTIME_PR_PATCHES: ""
       SCCACHE_GHA_ENABLED: "true"
-      OGA_VERSION: "0.14.0"
-      # Space-separated microsoft/onnxruntime-genai PR numbers fetched from
-      # pull/<n>.patch and `git apply` on top of v<OGA_VERSION>. Part of the OGA
-      # cache key. Remove a PR once it lands in the pinned OGA release.
-      OGA_PR_PATCHES: "2194"
+      # Fork branch carrying AMDGPU MorphiZen integration (former PR 2194) plus
+      # sliding_window support.
+      OGA_REPO: "cliu1003/onnxruntime-genai"
+      OGA_REF: "sliding_window_support_amdgpu"
+      # Optional space-separated microsoft/onnxruntime-genai PR numbers applied
+      # on top of the fork checkout via pull/<n>.patch + git am. Empty when the
+      # fork branch already carries the needed integration.
+      OGA_PR_PATCHES: ""
       # ilammy/msvc-dev-cmd and mozilla-actions/sccache-action have no
       # Node.js 24 releases yet; allow Node.js 20 until they are updated.
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
@@ -366,22 +369,19 @@ jobs:
         with:
           path: ${{ runner.workspace }}/oga-artifacts
           # OGA is built against the patched ort-install, so the key folds in
-          # both OGA's own PR list and ONNXRUNTIME_PR_PATCHES; editing either
-          # forces a rebuild. The mm<N> token bumps when the OGA artifact set
-          # changes shape, or when a PR's branch content changes under the same
-          # number (mm2: PR 2194 now carries the AMDGPU OGA integration).
-          key: oga-dml-mm2-${{ env.OGA_VERSION }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}
+          # the fork ref, optional OGA_PR_PATCHES, and ONNXRUNTIME_PR_PATCHES.
+          # The mm<N> token bumps when the OGA artifact set changes shape.
+          key: oga-dml-mm3-${{ env.OGA_REPO }}-${{ env.OGA_REF }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}
 
-      # OGA is built from upstream microsoft/onnxruntime-genai + PR patches
-      # (OGA_PR_PATCHES). PR 2194 (the dynamic-shape-morphizen branch) now also
-      # carries the AMDGPU umbrella integration, so the patched upstream build
-      # is the AMDGPU-targeted OGA -- no fork checkout needed.
+      # OGA is built from cliu1003/onnxruntime-genai sliding_window_support_amdgpu
+      # (AMDGPU MorphiZen integration + sliding_window). Optional OGA_PR_PATCHES
+      # apply extra upstream PRs on top of the fork checkout.
       - name: Checkout OGA
         if: steps.cache-oga.outputs.cache-hit != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: microsoft/onnxruntime-genai
-          ref: v${{ env.OGA_VERSION }}
+          repository: ${{ env.OGA_REPO }}
+          ref: ${{ env.OGA_REF }}
           path: source-oga
           submodules: true
           fetch-depth: 1


### PR DESCRIPTION
Replace microsoft/onnxruntime-genai v0.14.0 + PR 2194 patch workflow with a direct checkout of cliu1003/onnxruntime-genai@sliding_window_support_amdgpu, which already carries the AMDGPU MorphiZen integration and sliding_window support. Update OGA cache keys on Windows and Linux to invalidate stale artifacts.