### PR TITLE
fix(dialect): add a ctx operand to hipsr.cast and make its result optional

### DIFF
--- a/include/hip/Dialect/Hipsr/IR/HipsrCastOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrCastOp.td
@@ -23,6 +23,10 @@ def Hipsr_CastOp : Hipsr_DpsOp<"cast"> {
     Destination-passing style: the result buffer is passed as the `init`
     operand.
 
+    The `ctx` operand (`!hipsr.context`) is the per-session execution context.
+    Every hipsr op carries it as its first operand; it is added in the ONNX
+    phase and threaded through unchanged.
+
     Regular op: carries an optional shape region (region 0). When populated it
     copies the input shape (via `populateShapeRegion`, which emits
     `shape.shape_of` + `shape.get_extent` so it works for both tensor and
@@ -30,8 +34,8 @@ def Hipsr_CastOp : Hipsr_DpsOp<"cast"> {
 
     Example (populated shape region):
     ```mlir
-    %0 = hipsr.cast ins(%input : tensor<?x8xf32>) outs(%init : tensor<?x8xf16>)
-                    -> tensor<?x8xf16> shape_region {
+    %0 = hipsr.cast(%ctx) ins(%input : tensor<?x8xf32>) outs(%init : tensor<?x8xf16>)
+                          : tensor<?x8xf16> shape_region {
       %shape = shape.shape_of %input : tensor<?x8xf32> -> tensor<2xindex>
       %c0 = arith.constant 0 : index
       %d0 = shape.get_extent %shape, %c0 : tensor<2xindex>, index -> index
@@ -43,17 +47,24 @@ def Hipsr_CastOp : Hipsr_DpsOp<"cast"> {
   }];
 
   let arguments = (ins
+    Hipsr_ContextType:$ctx,
     Hipsr_TensorOrDeviceMemRef:$input,
     Hipsr_TensorOrDeviceMemRef:$init
   );
 
+
+  // Result type is optional: Bufferization removes results from DPS ops (the
+  // memref form has no result), so trying to print a non-existent result type
+  // would crash without the optional clause.
+  //
   // The shape region is optional: an empty (zero-block) region prints nothing
   // and round-trips as empty. A non-empty region prints as
   // `shape_region { ... }`.
   let assemblyFormat = [{
+    `(` $ctx `)`
     `ins` `(` $input `:` type($input) `)`
     `outs` `(` $init `:` type($init) `)`
-    attr-dict `->` type($result_tensors) (`shape_region` $shape_region^)?
+    attr-dict (`:` type($result_tensors)^)? (`shape_region` $shape_region^)?
   }];
 }
 

--- a/include/hip/Dialect/Hipsr/IR/HipsrCastOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrCastOp.td
@@ -52,11 +52,6 @@ def Hipsr_CastOp : Hipsr_DpsOp<"cast"> {
     Hipsr_TensorOrDeviceMemRef:$init
   );
 
-
-  // Result type is optional: Bufferization removes results from DPS ops (the
-  // memref form has no result), so trying to print a non-existent result type
-  // would crash without the optional clause.
-  //
   // The shape region is optional: an empty (zero-block) region prints nothing
   // and round-trips as empty. A non-empty region prints as
   // `shape_region { ... }`.

--- a/lib/Conversion/OnnxToHipsr/CastConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/CastConversion.cpp
@@ -31,20 +31,23 @@ struct CastToHipsr : public ::mlir::RewritePattern {
                   ::mlir::PatternRewriter &rewriter) const override {
     // Matching is by name on an (unregistered) ONNX op, so guard the shape:
     // onnx.Cast is single-input / single-result.
-    if (op->getNumOperands() != 1 || op->getNumResults() != 1)
+    if (op->getNumOperands() != 1 || op->getNumResults() != 1) {
       return rewriter.notifyMatchFailure(
           op, "expected a single operand and result");
+    }
 
     ::mlir::FailureOr<::mlir::Value> ctx = getHipsrContextArg(op, rewriter);
-    if (::mlir::failed(ctx))
+    if (::mlir::failed(ctx)) {
       return ::mlir::failure();
+    }
 
     ::mlir::Location loc = op->getLoc();
     ::mlir::Value input = op->getOperand(0);
     auto resultType =
         ::mlir::dyn_cast<::mlir::RankedTensorType>(op->getResult(0).getType());
-    if (!resultType)
+    if (!resultType) {
       return rewriter.notifyMatchFailure(op, "expected ranked tensor result");
+    }
 
     // DPS init: a hipsr.placeholder with the cast result type. Its type matches
     // the result, which is all the DPS verifier needs, and it saves computing

--- a/lib/Conversion/OnnxToHipsr/CastConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/CastConversion.cpp
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+#include "OnnxToHipsrUtils.h"
+
 #include "hip/Conversion/OnnxToHipsr/OnnxToHipsr.h"
 #include "hip/Dialect/Hipsr/IR/HipsrCastOp.h"
 #include "hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.h"
@@ -33,6 +35,10 @@ struct CastToHipsr : public ::mlir::RewritePattern {
       return rewriter.notifyMatchFailure(
           op, "expected a single operand and result");
 
+    ::mlir::FailureOr<::mlir::Value> ctx = getHipsrContextArg(op, rewriter);
+    if (::mlir::failed(ctx))
+      return ::mlir::failure();
+
     ::mlir::Location loc = op->getLoc();
     ::mlir::Value input = op->getOperand(0);
     auto resultType =
@@ -48,16 +54,16 @@ struct CastToHipsr : public ::mlir::RewritePattern {
     // Old way (built the init from the input shape):
     //   %d0   = tensor.dim %input, %c0 : tensor<?x8xf32>
     //   %init = tensor.empty(%d0)      : tensor<?x8xf16>
-    //   %0    = hipsr.cast ins(%input) outs(%init) -> tensor<?x8xf16>
+    //   %0    = hipsr.cast(%ctx) ins(%input) outs(%init) : tensor<?x8xf16>
     // New way (placeholder mirrors the result type):
     //   %init = hipsr.placeholder      : tensor<?x8xf16>
-    //   %0    = hipsr.cast ins(%input) outs(%init) -> tensor<?x8xf16>
+    //   %0    = hipsr.cast(%ctx) ins(%input) outs(%init) : tensor<?x8xf16>
     ::mlir::Value init =
         rewriter.create<PlaceholderOp>(loc, ::mlir::TypeRange{resultType})
             .getResult(0);
 
     auto castOp = rewriter.create<CastOp>(loc, ::mlir::TypeRange{resultType},
-                                          input, init);
+                                          *ctx, input, init);
     // The shape region is optional: leave it empty (zero blocks) here. A later
     // dedicated pass populates the shape computation.
 

--- a/lib/Dialect/Hipsr/IR/HipsrCastOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrCastOp.cpp
@@ -34,8 +34,9 @@ void CastOp::populateShapeRegion(OpBuilder &builder, Region &shapeRegion) {
     Value idx = builder.create<arith::ConstantIndexOp>(loc, i);
     dims.push_back(builder.create<shape::GetExtentOp>(loc, shape, idx));
   }
-  // Single result: one dim group and its (output) element type.
-  Type elemTy = cast<ShapedType>(getResult(0).getType()).getElementType();
+  // Output element type from the `init` operand, not getResult(0): the
+  // bufferized (memref) form has no tensor result.
+  Type elemTy = cast<ShapedType>(getInit().getType()).getElementType();
   builder.create<ShapeYieldOp>(loc, ArrayRef<ValueRange>{ValueRange(dims)},
                                TypeRange{elemTy});
 }

--- a/lib/Dialect/Hipsr/IR/HipsrCastOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrCastOp.cpp
@@ -34,8 +34,6 @@ void CastOp::populateShapeRegion(OpBuilder &builder, Region &shapeRegion) {
     Value idx = builder.create<arith::ConstantIndexOp>(loc, i);
     dims.push_back(builder.create<shape::GetExtentOp>(loc, shape, idx));
   }
-  // Output element type from the `init` operand, not getResult(0): the
-  // bufferized (memref) form has no tensor result.
   Type elemTy = cast<ShapedType>(getInit().getType()).getElementType();
   builder.create<ShapeYieldOp>(loc, ArrayRef<ValueRange>{ValueRange(dims)},
                                TypeRange{elemTy});

--- a/test/lit/Conversion/onnx-to-hipsr/cast.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/cast.mlir
@@ -9,14 +9,17 @@
 
 // RUN: hip-mlir-opt %s -allow-unregistered-dialect -convert-onnx-to-hipsr | FileCheck %s
 
-// CHECK-LABEL: func.func @cast
-func.func @cast(%input: tensor<?x8xf32>) -> tensor<?x8xf16> {
+// CHECK-LABEL: func.func @cast(
+// CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
+// CHECK-SAME:    %[[IN:.*]]: tensor<?x8xf32>) -> tensor<?x8xf16> {
+func.func @cast(%ctx: !hipsr.context, %input: tensor<?x8xf32>) -> tensor<?x8xf16> {
   // The DPS init is a hipsr.placeholder that mirrors the result type, so no
   // output-shape computation (tensor.empty / tensor.dim) is emitted here.
   // CHECK: %[[INIT:.+]] = hipsr.placeholder : tensor<?x8xf16>
-  // The shape region is left empty (zero blocks) here; a later pass populates
-  // it. The optional region group prints nothing when the region is empty.
-  // CHECK: hipsr.cast ins(%[[IN:.+]] : tensor<?x8xf32>) outs(%[[INIT]] : tensor<?x8xf16>) -> tensor<?x8xf16>
+  // The !hipsr.context (function arg 0) is threaded onto the op, and the shape
+  // region is left empty (zero blocks) here; a later pass populates it. The
+  // optional region group prints nothing when the region is empty.
+  // CHECK: hipsr.cast(%[[CTX]]) ins(%[[IN]] : tensor<?x8xf32>) outs(%[[INIT]] : tensor<?x8xf16>) : tensor<?x8xf16>
   // CHECK-NOT: tensor.empty
   // CHECK-NOT: tensor.dim
   // CHECK-NOT: shape_region

--- a/test/lit/Dialect/Hipsr/cast.mlir
+++ b/test/lit/Dialect/Hipsr/cast.mlir
@@ -4,9 +4,8 @@
 //===----------------------------------------------------------------------===//
 // hipsr.cast shape region, exercised through -hipsr-populate-shape-region: the
 // op's ShapeRegionInterface::populateShapeRegion() emits the shape computation
-// end-to-end (generated, not hand-written). Covers the tensor form, the
-// bufferized (all-memref, no-result) form, idempotency, and the whole-function
-// walk (two chained casts populated in one run).
+// end-to-end (generated, not hand-written). Pass-level behavior (idempotency,
+// whole-function walk) lives in populate_shape_region.mlir.
 //===----------------------------------------------------------------------===//
 
 // RUN: hip-mlir-opt %s -split-input-file -hipsr-populate-shape-region | FileCheck %s
@@ -25,70 +24,4 @@ func.func @cast_tensor(%ctx: !hipsr.context, %input: tensor<?x8xf32>, %init: ten
   // CHECK: }
   %0 = hipsr.cast(%ctx) ins(%input : tensor<?x8xf32>) outs(%init : tensor<?x8xf16>) : tensor<?x8xf16>
   return %0 : tensor<?x8xf16>
-}
-
-// -----
-
-// Bufferized form: after bufferization a DPS op has memref operands and NO
-// tensor result. populateShapeRegion must still work (it reads the output
-// element type from the `init` operand, not getResult(0)), and the result
-// clause prints nothing.
-
-// CHECK-LABEL: func.func @cast_bufferized
-func.func @cast_bufferized(%ctx: !hipsr.context,
-                           %input: memref<?x8xf32, #hipsr.mem<device>>,
-                           %init: memref<?x8xf16, #hipsr.mem<device>>) {
-  // CHECK: hipsr.cast(%{{.+}}) ins(%[[IN:.+]] : memref<?x8xf32, #hipsr.mem<device>>) outs(%{{.+}} : memref<?x8xf16, #hipsr.mem<device>>) shape_region {
-  // CHECK:   %[[SHAPE:.+]] = shape.shape_of %[[IN]]
-  // CHECK:   %[[D0:.+]] = shape.get_extent %[[SHAPE]]
-  // CHECK:   %[[D1:.+]] = shape.get_extent %[[SHAPE]]
-  // CHECK:   hipsr.shape_yield (%[[D0]], %[[D1]]) : [f16]
-  // CHECK: }
-  hipsr.cast(%ctx) ins(%input : memref<?x8xf32, #hipsr.mem<device>>) outs(%init : memref<?x8xf16, #hipsr.mem<device>>)
-  return
-}
-
-// -----
-
-// Idempotent: an already-populated region is left untouched (the pass only
-// fills empty regions).
-
-// CHECK-LABEL: func.func @cast_already_populated
-func.func @cast_already_populated(%ctx: !hipsr.context, %input: tensor<4x8xf32>, %init: tensor<4x8xf16>) -> tensor<4x8xf16> {
-  // CHECK: hipsr.cast
-  // CHECK: shape_region {
-  // CHECK:   %[[C4:.+]] = arith.constant 4 : index
-  // CHECK:   %[[C8:.+]] = arith.constant 8 : index
-  // CHECK:   hipsr.shape_yield (%[[C4]], %[[C8]]) : [f16]
-  // The pass must not re-emit the generated `shape.shape_of` form over the
-  // hand-written region.
-  // CHECK-NOT: shape.shape_of
-  %0 = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>) outs(%init : tensor<4x8xf16>) : tensor<4x8xf16> shape_region {
-    %c4 = arith.constant 4 : index
-    %c8 = arith.constant 8 : index
-    hipsr.shape_yield (%c4, %c8) : [f16]
-  }
-  return %0 : tensor<4x8xf16>
-}
-
-// -----
-
-// The pass walks the whole function: every ShapeRegionInterface op gets its own
-// empty region filled in a single run. Here two chained casts (f32->f16->f32)
-// are both populated, each yielding its own output element type.
-
-// CHECK-LABEL: func.func @cast_chain
-func.func @cast_chain(%ctx: !hipsr.context, %input: tensor<?x8xf32>, %init0: tensor<?x8xf16>,
-                      %init1: tensor<?x8xf32>) -> tensor<?x8xf32> {
-  // CHECK: hipsr.cast(%{{.+}}) ins(%{{.+}} : tensor<?x8xf32>) outs(%{{.+}} : tensor<?x8xf16>) : tensor<?x8xf16> shape_region {
-  // CHECK:   shape.shape_of
-  // CHECK:   hipsr.shape_yield (%{{.+}}, %{{.+}}) : [f16]
-  // CHECK: }
-  // CHECK: hipsr.cast(%{{.+}}) ins(%{{.+}} : tensor<?x8xf16>) outs(%{{.+}} : tensor<?x8xf32>) : tensor<?x8xf32> shape_region {
-  // CHECK:   shape.shape_of
-  // CHECK:   hipsr.shape_yield (%{{.+}}, %{{.+}}) : [f32]
-  // CHECK: }
-  %0 = hipsr.cast(%ctx) ins(%input : tensor<?x8xf32>) outs(%init0 : tensor<?x8xf16>) : tensor<?x8xf16>
-  %1 = hipsr.cast(%ctx) ins(%0 : tensor<?x8xf16>) outs(%init1 : tensor<?x8xf32>) : tensor<?x8xf32>
-  return %1 : tensor<?x8xf32>
 }

--- a/test/lit/Dialect/Hipsr/cast.mlir
+++ b/test/lit/Dialect/Hipsr/cast.mlir
@@ -4,8 +4,9 @@
 //===----------------------------------------------------------------------===//
 // hipsr.cast shape region, exercised through -hipsr-populate-shape-region: the
 // op's ShapeRegionInterface::populateShapeRegion() emits the shape computation
-// end-to-end (generated, not hand-written). Also checks the pass leaves an
-// already-populated region untouched (idempotent).
+// end-to-end (generated, not hand-written). Covers the tensor form, the
+// bufferized (all-memref, no-result) form, idempotency, and the whole-function
+// walk (two chained casts populated in one run).
 //===----------------------------------------------------------------------===//
 
 // RUN: hip-mlir-opt %s -split-input-file -hipsr-populate-shape-region | FileCheck %s
@@ -15,15 +16,36 @@
 // group with the output element type.
 
 // CHECK-LABEL: func.func @cast_tensor
-func.func @cast_tensor(%input: tensor<?x8xf32>, %init: tensor<?x8xf16>) -> tensor<?x8xf16> {
-  // CHECK: hipsr.cast ins(%[[IN:.+]] : tensor<?x8xf32>) outs(%{{.+}} : tensor<?x8xf16>) -> tensor<?x8xf16> shape_region {
+func.func @cast_tensor(%ctx: !hipsr.context, %input: tensor<?x8xf32>, %init: tensor<?x8xf16>) -> tensor<?x8xf16> {
+  // CHECK: hipsr.cast(%{{.+}}) ins(%[[IN:.+]] : tensor<?x8xf32>) outs(%{{.+}} : tensor<?x8xf16>) : tensor<?x8xf16> shape_region {
   // CHECK:   %[[SHAPE:.+]] = shape.shape_of %[[IN]]
   // CHECK:   %[[D0:.+]] = shape.get_extent %[[SHAPE]]
   // CHECK:   %[[D1:.+]] = shape.get_extent %[[SHAPE]]
   // CHECK:   hipsr.shape_yield (%[[D0]], %[[D1]]) : [f16]
   // CHECK: }
-  %0 = hipsr.cast ins(%input : tensor<?x8xf32>) outs(%init : tensor<?x8xf16>) -> tensor<?x8xf16>
+  %0 = hipsr.cast(%ctx) ins(%input : tensor<?x8xf32>) outs(%init : tensor<?x8xf16>) : tensor<?x8xf16>
   return %0 : tensor<?x8xf16>
+}
+
+// -----
+
+// Bufferized form: after bufferization a DPS op has memref operands and NO
+// tensor result. populateShapeRegion must still work (it reads the output
+// element type from the `init` operand, not getResult(0)), and the result
+// clause prints nothing.
+
+// CHECK-LABEL: func.func @cast_bufferized
+func.func @cast_bufferized(%ctx: !hipsr.context,
+                           %input: memref<?x8xf32, #hipsr.mem<device>>,
+                           %init: memref<?x8xf16, #hipsr.mem<device>>) {
+  // CHECK: hipsr.cast(%{{.+}}) ins(%[[IN:.+]] : memref<?x8xf32, #hipsr.mem<device>>) outs(%{{.+}} : memref<?x8xf16, #hipsr.mem<device>>) shape_region {
+  // CHECK:   %[[SHAPE:.+]] = shape.shape_of %[[IN]]
+  // CHECK:   %[[D0:.+]] = shape.get_extent %[[SHAPE]]
+  // CHECK:   %[[D1:.+]] = shape.get_extent %[[SHAPE]]
+  // CHECK:   hipsr.shape_yield (%[[D0]], %[[D1]]) : [f16]
+  // CHECK: }
+  hipsr.cast(%ctx) ins(%input : memref<?x8xf32, #hipsr.mem<device>>) outs(%init : memref<?x8xf16, #hipsr.mem<device>>)
+  return
 }
 
 // -----
@@ -32,7 +54,7 @@ func.func @cast_tensor(%input: tensor<?x8xf32>, %init: tensor<?x8xf16>) -> tenso
 // fills empty regions).
 
 // CHECK-LABEL: func.func @cast_already_populated
-func.func @cast_already_populated(%input: tensor<4x8xf32>, %init: tensor<4x8xf16>) -> tensor<4x8xf16> {
+func.func @cast_already_populated(%ctx: !hipsr.context, %input: tensor<4x8xf32>, %init: tensor<4x8xf16>) -> tensor<4x8xf16> {
   // CHECK: hipsr.cast
   // CHECK: shape_region {
   // CHECK:   %[[C4:.+]] = arith.constant 4 : index
@@ -41,7 +63,7 @@ func.func @cast_already_populated(%input: tensor<4x8xf32>, %init: tensor<4x8xf16
   // The pass must not re-emit the generated `shape.shape_of` form over the
   // hand-written region.
   // CHECK-NOT: shape.shape_of
-  %0 = hipsr.cast ins(%input : tensor<4x8xf32>) outs(%init : tensor<4x8xf16>) -> tensor<4x8xf16> shape_region {
+  %0 = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>) outs(%init : tensor<4x8xf16>) : tensor<4x8xf16> shape_region {
     %c4 = arith.constant 4 : index
     %c8 = arith.constant 8 : index
     hipsr.shape_yield (%c4, %c8) : [f16]
@@ -56,17 +78,17 @@ func.func @cast_already_populated(%input: tensor<4x8xf32>, %init: tensor<4x8xf16
 // are both populated, each yielding its own output element type.
 
 // CHECK-LABEL: func.func @cast_chain
-func.func @cast_chain(%input: tensor<?x8xf32>, %init0: tensor<?x8xf16>,
+func.func @cast_chain(%ctx: !hipsr.context, %input: tensor<?x8xf32>, %init0: tensor<?x8xf16>,
                       %init1: tensor<?x8xf32>) -> tensor<?x8xf32> {
-  // CHECK: hipsr.cast ins(%{{.+}} : tensor<?x8xf32>) outs(%{{.+}} : tensor<?x8xf16>) -> tensor<?x8xf16> shape_region {
+  // CHECK: hipsr.cast(%{{.+}}) ins(%{{.+}} : tensor<?x8xf32>) outs(%{{.+}} : tensor<?x8xf16>) : tensor<?x8xf16> shape_region {
   // CHECK:   shape.shape_of
   // CHECK:   hipsr.shape_yield (%{{.+}}, %{{.+}}) : [f16]
   // CHECK: }
-  // CHECK: hipsr.cast ins(%{{.+}} : tensor<?x8xf16>) outs(%{{.+}} : tensor<?x8xf32>) -> tensor<?x8xf32> shape_region {
+  // CHECK: hipsr.cast(%{{.+}}) ins(%{{.+}} : tensor<?x8xf16>) outs(%{{.+}} : tensor<?x8xf32>) : tensor<?x8xf32> shape_region {
   // CHECK:   shape.shape_of
   // CHECK:   hipsr.shape_yield (%{{.+}}, %{{.+}}) : [f32]
   // CHECK: }
-  %0 = hipsr.cast ins(%input : tensor<?x8xf32>) outs(%init0 : tensor<?x8xf16>) -> tensor<?x8xf16>
-  %1 = hipsr.cast ins(%0 : tensor<?x8xf16>) outs(%init1 : tensor<?x8xf32>) -> tensor<?x8xf32>
+  %0 = hipsr.cast(%ctx) ins(%input : tensor<?x8xf32>) outs(%init0 : tensor<?x8xf16>) : tensor<?x8xf16>
+  %1 = hipsr.cast(%ctx) ins(%0 : tensor<?x8xf16>) outs(%init1 : tensor<?x8xf32>) : tensor<?x8xf32>
   return %1 : tensor<?x8xf32>
 }

--- a/test/lit/Dialect/Hipsr/populate_shape_region.mlir
+++ b/test/lit/Dialect/Hipsr/populate_shape_region.mlir
@@ -1,0 +1,57 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+//===----------------------------------------------------------------------===//
+// Pass-level behavior of -hipsr-populate-shape-region: what the pass does over a
+// function, independent of any single op's shape math (that is checked per op in
+// cast.mlir, matmul.mlir, ...). Two behaviors:
+//   - idempotency: a region that is already populated is left untouched;
+//   - whole-function walk: every empty ShapeRegionInterface region in the
+//     function, across op kinds, is filled in a single run.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt %s -split-input-file -hipsr-populate-shape-region | FileCheck %s
+
+// Idempotency: the pass fills only empty regions, so an op that already carries a
+// (here hand-written) shape region is left byte-for-byte untouched -- the
+// generated shape.shape_of form must never be emitted over it.
+
+// CHECK-LABEL: func.func @already_populated
+func.func @already_populated(%ctx: !hipsr.context, %input: tensor<4x8xf32>, %init: tensor<4x8xf16>) -> tensor<4x8xf16> {
+  // CHECK: hipsr.cast
+  // CHECK: shape_region {
+  // CHECK:   %[[C4:.+]] = arith.constant 4 : index
+  // CHECK:   %[[C8:.+]] = arith.constant 8 : index
+  // CHECK:   hipsr.shape_yield (%[[C4]], %[[C8]]) : [f16]
+  // CHECK-NOT: shape.shape_of
+  %0 = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>) outs(%init : tensor<4x8xf16>) : tensor<4x8xf16> shape_region {
+    %c4 = arith.constant 4 : index
+    %c8 = arith.constant 8 : index
+    hipsr.shape_yield (%c4, %c8) : [f16]
+  }
+  return %0 : tensor<4x8xf16>
+}
+
+// -----
+
+// Whole-function walk: the pass visits every ShapeRegionInterface op in the
+// function and fills each empty region in one run, regardless of op kind. Here a
+// cast feeds a matmul; both are populated, each emitting its own op-specific
+// shape computation (cast: shape_of + get_extent; matmul: the K-equality guard).
+
+// CHECK-LABEL: func.func @whole_function_walk
+func.func @whole_function_walk(%ctx: !hipsr.context, %input: tensor<?x8xf32>,
+                               %cinit: tensor<?x8xf16>, %b: tensor<8x16xf16>,
+                               %minit: tensor<?x16xf16>) -> tensor<?x16xf16> {
+  // CHECK: hipsr.cast(%{{.+}}) ins(%{{.+}} : tensor<?x8xf32>) outs(%{{.+}} : tensor<?x8xf16>) : tensor<?x8xf16> shape_region {
+  // CHECK:   shape.shape_of
+  // CHECK:   hipsr.shape_yield (%{{.+}}, %{{.+}}) : [f16]
+  // CHECK: }
+  // CHECK: hipsr.matmul(%{{.+}}) ins(%{{.+}}, %{{.+}} : tensor<?x8xf16>, tensor<8x16xf16>) outs(%{{.+}} : tensor<?x16xf16>) : tensor<?x16xf16> shape_region {
+  // CHECK:   shape.cstr_eq
+  // CHECK:   hipsr.shape_yield (%{{.+}}, %{{.+}}) : [f16]
+  // CHECK: }
+  %0 = hipsr.cast(%ctx) ins(%input : tensor<?x8xf32>) outs(%cinit : tensor<?x8xf16>) : tensor<?x8xf16>
+  %1 = hipsr.matmul(%ctx) ins(%0, %b : tensor<?x8xf16>, tensor<8x16xf16>) outs(%minit : tensor<?x16xf16>) : tensor<?x16xf16>
+  return %1 : tensor<?x16xf16>
+}

--- a/test/lit/Dialect/Hipsr/shape_region_verify.mlir
+++ b/test/lit/Dialect/Hipsr/shape_region_verify.mlir
@@ -20,12 +20,12 @@
 // the onnx->hipsr conversion emits, so IR without a shape region must read back
 // correctly.
 // CHECK-LABEL: func.func @cast_no_shape_region
-func.func @cast_no_shape_region(%input: tensor<?x8xf32>,
+func.func @cast_no_shape_region(%ctx: !hipsr.context, %input: tensor<?x8xf32>,
                                 %init: tensor<?x8xf16>) -> tensor<?x8xf16> {
-  // CHECK: hipsr.cast ins(%{{.+}} : tensor<?x8xf32>) outs(%{{.+}} : tensor<?x8xf16>) -> tensor<?x8xf16>
+  // CHECK: hipsr.cast(%{{.+}}) ins(%{{.+}} : tensor<?x8xf32>) outs(%{{.+}} : tensor<?x8xf16>) : tensor<?x8xf16>
   // CHECK-NOT: shape_region
-  %0 = hipsr.cast ins(%input : tensor<?x8xf32>)
-                  outs(%init : tensor<?x8xf16>) -> tensor<?x8xf16>
+  %0 = hipsr.cast(%ctx) ins(%input : tensor<?x8xf32>)
+                  outs(%init : tensor<?x8xf16>) : tensor<?x8xf16>
   return %0 : tensor<?x8xf16>
 }
 
@@ -33,12 +33,12 @@ func.func @cast_no_shape_region(%input: tensor<?x8xf32>,
 
 // A value defined in the enclosing function that is NOT one of the op's
 // operands is a disallowed outer capture: the trait verifier rejects it.
-func.func @cast_scoping_disallowed_outer(%input: tensor<?x8xf32>,
+func.func @cast_scoping_disallowed_outer(%ctx: !hipsr.context, %input: tensor<?x8xf32>,
                                          %init: tensor<?x8xf16>) -> tensor<?x8xf16> {
   %outer = arith.constant 8 : index
   // expected-note@+1 {{may only use values defined in its regions or the op's operands}}
-  %0 = hipsr.cast ins(%input : tensor<?x8xf32>)
-                  outs(%init : tensor<?x8xf16>) -> tensor<?x8xf16>
+  %0 = hipsr.cast(%ctx) ins(%input : tensor<?x8xf32>)
+                  outs(%init : tensor<?x8xf16>) : tensor<?x8xf16>
                   shape_region {
     %c0 = arith.constant 0 : index
     %d0 = tensor.dim %input, %c0 : tensor<?x8xf32>
@@ -52,11 +52,11 @@ func.func @cast_scoping_disallowed_outer(%input: tensor<?x8xf32>,
 
 // A present shape region must not be a lone empty block. (An absent shape
 // region is expressed by omitting the region entirely, not by an empty block.)
-func.func @cast_empty_block(%input: tensor<4x8xf32>,
+func.func @cast_empty_block(%ctx: !hipsr.context, %input: tensor<4x8xf32>,
                             %init: tensor<4x8xf16>) -> tensor<4x8xf16> {
   // expected-error@+1 {{expects a non-empty block}}
-  %0 = hipsr.cast ins(%input : tensor<4x8xf32>)
-                  outs(%init : tensor<4x8xf16>) -> tensor<4x8xf16> shape_region {
+  %0 = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
+                  outs(%init : tensor<4x8xf16>) : tensor<4x8xf16> shape_region {
   }
   return %0 : tensor<4x8xf16>
 }
@@ -64,11 +64,11 @@ func.func @cast_empty_block(%input: tensor<4x8xf32>,
 // -----
 
 // The shape region may hold at most one block.
-func.func @cast_two_blocks(%input: tensor<4x8xf32>,
+func.func @cast_two_blocks(%ctx: !hipsr.context, %input: tensor<4x8xf32>,
                            %init: tensor<4x8xf16>) -> tensor<4x8xf16> {
   // expected-error@+1 {{expects region #0 to have 0 or 1 blocks}}
-  %0 = hipsr.cast ins(%input : tensor<4x8xf32>)
-                  outs(%init : tensor<4x8xf16>) -> tensor<4x8xf16> shape_region {
+  %0 = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
+                  outs(%init : tensor<4x8xf16>) : tensor<4x8xf16> shape_region {
     hipsr.shape_yield () : [f16]
   ^bb1:
     hipsr.shape_yield () : [f16]
@@ -79,11 +79,11 @@ func.func @cast_two_blocks(%input: tensor<4x8xf32>,
 // -----
 
 // A non-empty shape region block must end with a terminator.
-func.func @cast_missing_terminator(%input: tensor<4x8xf32>,
+func.func @cast_missing_terminator(%ctx: !hipsr.context, %input: tensor<4x8xf32>,
                                    %init: tensor<4x8xf16>) -> tensor<4x8xf16> {
   // expected-error@+1 {{shape region block must end with a terminator}}
-  %0 = hipsr.cast ins(%input : tensor<4x8xf32>)
-                  outs(%init : tensor<4x8xf16>) -> tensor<4x8xf16> shape_region {
+  %0 = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
+                  outs(%init : tensor<4x8xf16>) : tensor<4x8xf16> shape_region {
     %c0 = arith.constant 0 : index
   }
   return %0 : tensor<4x8xf16>
@@ -93,11 +93,11 @@ func.func @cast_missing_terminator(%input: tensor<4x8xf32>,
 
 // A non-empty shape region must terminate with hipsr.shape_yield, not some
 // other terminator.
-func.func @cast_wrong_terminator(%input: tensor<4x8xf32>,
+func.func @cast_wrong_terminator(%ctx: !hipsr.context, %input: tensor<4x8xf32>,
                                  %init: tensor<4x8xf16>) -> tensor<4x8xf16> {
   // expected-error@+1 {{shape region must terminate with hipsr.shape_yield, got 'cf.br'}}
-  %0 = hipsr.cast ins(%input : tensor<4x8xf32>)
-                  outs(%init : tensor<4x8xf16>) -> tensor<4x8xf16> shape_region {
+  %0 = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
+                  outs(%init : tensor<4x8xf16>) : tensor<4x8xf16> shape_region {
   ^bb0:
     cf.br ^bb0
   }


### PR DESCRIPTION
Re-does the `hipsr.cast` bufferized-form fix dropped from #501, aligning `hipsr.cast` with the other hipsr DPS ops.

### Dialect fix
- Add the `!hipsr.context` operand (prints as a leading `(%ctx)`), threaded by `convert-onnx-to-hipsr` from function arg 0.
- Make the result type optional and switch `->` to `:` so the result-less (post-bufferization, memref) form round-trips.
- `populateShapeRegion` reads the output element type from `init` instead of `getResult(0)`, so it works on the no-result memref form.

Resolves the three #501 review comments (ctx threading, `:` vs `->`, why-comment).

### Test layout
Pass-level cases are split out of `cast.mlir` into their own file so per-op test files stay op-centric: each `ShapeRegionInterface` op checks only its own shape computation, and adding an op means adding a file rather than editing (and re-checking) a shared one. Idempotency and the whole-function walk are properties of the `-hipsr-populate-shape-region` pass, not of `hipsr.cast`, so keeping them in `cast.mlir` would misattribute them and force every future op file to duplicate the same cases.

- `cast.mlir` — op-centric: `cast_tensor`, `hipsr.cast`'s own tensor-form shape computation.
- `populate_shape_region.mlir` (new) — pass-level behavior of `-hipsr-populate-shape-region`: `already_populated` (idempotency) and `whole_function_walk` (every `ShapeRegionInterface` op filled in one run, across op kinds — a cast feeding a matmul).

LIT passes locally.
