### PR TITLE
feat(runtime): add fp32 tiled GEMM fallback for vendor-BLAS-disabled …

### DIFF
--- a/lib/Runtime/Kernels/CMakeLists.txt
+++ b/lib/Runtime/Kernels/CMakeLists.txt
@@ -40,6 +40,7 @@ set(_kernel_sources
     hip/gqa_kernel.hip
     hip/multi_head_attention_kernel.hip
     hip/gemm_wmma_kernel.hip
+    hip/gemm_fp32_kernel.hip
     hip/elementwise_sub_kernel.hip
     hip/elementwise_reciprocal_kernel.hip
     hip/elementwise_sqrt_kernel.hip

--- a/lib/Runtime/Kernels/hip/gemm_fp32_kernel.hip
+++ b/lib/Runtime/Kernels/hip/gemm_fp32_kernel.hip
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include <hip/hip_runtime.h>
+
+#include "hip_custom_kernels.h"
+
+//===----------------------------------------------------------------------===//
+// Tiled fp32 GEMM (row-major) — vendor-BLAS-disabled fallback for wrap_gemm
+//===----------------------------------------------------------------------===//
+//
+// Computes  out[M,N] = alpha * (A[M,K] @ B[K,N]) + beta * bias_broadcast
+//
+// Used when hipBLASLt is unavailable (e.g. the functional-model build sets
+// HIPDNN_EP_DISABLE_VENDOR_BLAS, so wrap_gemm gets a null hipBLASLt handle).
+// There is NO hardware WMMA instruction for fp32 inputs on this GPU family
+// (WMMA accepts fp16/bf16/int operands only), so this is a classic
+// shared-memory-tiled GEMM rather than a WMMA kernel: a 16x16 output tile per
+// block, reducing over 16-deep K tiles staged through LDS (one thread per
+// output element). Boundary threads pad with 0, so arbitrary M/N/K are correct
+// (no multiple-of-16 requirement, unlike the WMMA path).
+//
+// Layout matches wrap_gemm's untransposed (transA==transB==0) case: A, B and
+// out are all row-major ([M,K], [K,N], [M,N]). bias is broadcast per
+// (bias_dim0, bias_dim1) where a dim of 1 means "broadcast along that axis"
+// (e.g. a per-N bias is [1, N]); pass bias==nullptr for no bias.
+
+namespace {
+
+constexpr int kTile = 16;
+
+__global__ void __launch_bounds__(kTile *kTile) gemm_fp32_tiled_kernel(
+    const float *__restrict__ A, const float *__restrict__ B,
+    const float *__restrict__ bias, float *__restrict__ out, int M, int N,
+    int K, float alpha, float beta, int bias_dim0, int bias_dim1) {
+  __shared__ float As[kTile][kTile];
+  __shared__ float Bs[kTile][kTile];
+
+  const int ty = threadIdx.y; // row within the output tile
+  const int tx = threadIdx.x; // col within the output tile
+  const int row = blockIdx.y * kTile + ty; // output row index (m)
+  const int col = blockIdx.x * kTile + tx; // output col index (n)
+
+  float acc = 0.0f;
+
+  for (int k0 = 0; k0 < K; k0 += kTile) {
+    // Stage one 16x16 tile of A and B into LDS, zero-padding out-of-range
+    // elements so the inner product is correct for ragged M/N/K.
+    const int a_col = k0 + tx;
+    As[ty][tx] = (row < M && a_col < K) ? A[row * K + a_col] : 0.0f;
+    const int b_row = k0 + ty;
+    Bs[ty][tx] = (b_row < K && col < N) ? B[b_row * N + col] : 0.0f;
+    __syncthreads();
+
+#pragma unroll
+    for (int kk = 0; kk < kTile; ++kk)
+      acc += As[ty][kk] * Bs[kk][tx];
+    __syncthreads();
+  }
+
+  if (row < M && col < N) {
+    float v = alpha * acc;
+    if (bias) {
+      const int br = (bias_dim0 == 1) ? 0 : row;
+      const int bc = (bias_dim1 == 1) ? 0 : col;
+      v += beta * bias[br * bias_dim1 + bc];
+    }
+    out[row * N + col] = v;
+  }
+}
+
+} // namespace
+
+extern "C" int hip_gemm_fp32(void *stream, const void *A, const void *B,
+                             const void *bias, void *out, int M, int N, int K,
+                             float alpha, float beta, int bias_dim0,
+                             int bias_dim1) {
+  dim3 block(kTile, kTile);
+  dim3 grid((N + kTile - 1) / kTile, (M + kTile - 1) / kTile);
+  // Clear any stale sticky error so hipGetLastError() below reflects only this
+  // launch (a swallowed upstream error must not be misattributed here).
+  (void)hipGetLastError();
+  hipLaunchKernelGGL(gemm_fp32_tiled_kernel, grid, block, 0,
+                     (hipStream_t)stream, (const float *)A, (const float *)B,
+                     (const float *)bias, (float *)out, M, N, K, alpha, beta,
+                     bias_dim0, bias_dim1);
+  return hipGetLastError() == hipSuccess ? 0 : -1;
+}

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -1954,6 +1954,30 @@ HIP_KERNEL_API int hip_causal_conv_prefill(
 HIP_KERNEL_API int hip_gemm_wmma_fp16(void* stream, const void* A, const void* B,
                        void* C, int M, int K, int N);
 
+/*
+ * Tiled fp32 GEMM (row-major) — vendor-BLAS-disabled fallback for wrap_gemm.
+ *
+ * Computes out[M,N] = alpha * (A[M,K] @ B[K,N]) + beta * bias_broadcast.
+ * There is no fp32-input WMMA on this GPU family, so this is an LDS-tiled GEMM
+ * (16x16 output tile, 16-deep K tiles); arbitrary M/N/K (no multiple-of-16
+ * requirement). Untransposed only (matches wrap_gemm transA==transB==0).
+ *
+ * Parameters:
+ *   stream    - hipStream_t cast to void*
+ *   A         - GPU pointer to [M, K] row-major (fp32)
+ *   B         - GPU pointer to [K, N] row-major (fp32)
+ *   bias      - GPU pointer to [bias_dim0, bias_dim1] (fp32), or nullptr
+ *   out       - GPU pointer to [M, N] row-major (fp32)
+ *   alpha,beta- output = alpha*(A@B) + beta*bias
+ *   bias_dim0/1 - bias logical shape; a dim of 1 broadcasts along that axis
+ *                 (e.g. per-N bias is [1, N]). Ignored when bias == nullptr.
+ *
+ * Returns: 0 on success, non-zero on failure
+ */
+HIP_KERNEL_API int hip_gemm_fp32(void* stream, const void* A, const void* B,
+                       const void* bias, void* out, int M, int N, int K,
+                       float alpha, float beta, int bias_dim0, int bias_dim1);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/Runtime/real/gemm.cpp
+++ b/lib/Runtime/real/gemm.cpp
@@ -7,6 +7,7 @@
 #include "../op_profile.h"
 #include "../op_state.h"
 #include "error_check_macros.h"
+#include "hip_custom_kernels.h"
 #include "runtime_types.h"
 
 #include <hipblaslt/hipblaslt-ext.hpp>
@@ -507,6 +508,23 @@ int wrap_gemm(RuntimeState *state, int op_state_slot, const void *A,
       static_cast<hipStream_t>(hipdnn_ep_state_get_stream(state));
 
   if (!handle || !stream) {
+    // hipBLASLt is unavailable (e.g. the functional-model build sets
+    // HIPDNN_EP_DISABLE_VENDOR_BLAS, so no hipBLASLt handle is created). Fall
+    // back to the in-tree tiled GEMM kernel so f32 Gemm subgraphs still run.
+    // Only the untransposed f32 case is handled; other dtypes/transposes keep
+    // the original failure rather than silently miscomputing.
+    if (typeCode == kTypeFloat32 && !transA && !transB) {
+      // bias is [cDim0, cDim1] added as beta*C (per-N bias is [1, N]); a null C
+      // means no bias.
+      const int bias_dim0 = C ? static_cast<int>(cDim0) : 0;
+      const int bias_dim1 = C ? static_cast<int>(cDim1) : 0;
+      int rc = hip_gemm_fp32(stream, A, B, C, output, static_cast<int>(M),
+                             static_cast<int>(N), static_cast<int>(K), alpha,
+                             beta, bias_dim0, bias_dim1);
+      if (rc != 0)
+        fprintf(stderr, "wrap_gemm: fp32 fallback kernel launch failed\n");
+      return rc;
+    }
     fprintf(stderr, "wrap_gemm: null handle or stream\n");
     return -1;
   }


### PR DESCRIPTION
## Summary

Add an in-tree tiled fp32 GEMM kernel and route `wrap_gemm`'s untransposed f32 case to it when hipBLASLt is unavailable, so f32 `Gemm` subgraphs run on vendor-BLAS-disabled builds instead of failing with "null handle or stream".

## What

1. **New kernel** `lib/Runtime/Kernels/hip/gemm_fp32_kernel.hip`: `hip_gemm_fp32`    computes `out[M,N] = alpha * (A[M,K] @ B[K,N]) + beta * bias_broadcast` (row-major). Bias is broadcast per `(bias_dim0, bias_dim1)`; a dim of 1
   broadcasts along that axis; `bias == nullptr` means no bias. Clears the sticky    HIP error before launch and returns `hipGetLastError()`.
2. **Declaration** in `lib/Runtime/Kernels/include/hip_custom_kernels.h` with the parameter/broadcast contract documented.
3. **Dispatch** in `lib/Runtime/real/gemm.cpp`: in `wrap_gemm`, when the handle or stream is null and `typeCode == kTypeFloat32 && !transA && !transB`, fall back to `hip_gemm_fp32` (bias derived from `C`/`cDim0`/`cDim1`) instead of erroring.
4. **Build** `lib/Runtime/Kernels/CMakeLists.txt`: register the new kernel source.

## Test plan

Ran the f32 Gemm subgraph end-to-end on the functional model:

    setenv ONNX .../test/models/microbenchmark_qdq_reshape_gemm_reshape.onnx
    scripts/validate_subgraph_ffm.sh build   # rebuild tools
    rm -f /tmp/morphizen_mlir_*              # cache is keyed on ONNX hash
    scripts/validate_subgraph_ffm.sh run-onnx -d 2

Result: the `wrap_gemm: null handle or stream` line is gone and the Gemm now
computes via `hip_gemm_fp32`.  <!-- add numerics / cosine vs reference if available -->

## Notes for reviewers

- Untransposed f32 only, by design; all other dtype/transpose combinations keep the pre-existing null-handle failure (no silent miscompute).
- Runtime/kernel-only change — no compiler pass or dialect changes.
- AI-assisted; disclosed via the commit trailers (`Co-Authored-By` / `Made-with`).
