### PR TITLE
feat(rgp_parser): headless pure-Python RGP (.rgp) profiler with SQTT decode + bottleneck analysis

### DIFF
--- a/tools/rgp_parser/README.md
+++ b/tools/rgp_parser/README.md
@@ -1,0 +1,196 @@
+<!--
+Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+Licensed under the MIT License.
+-->
+# rgp_parser
+
+Turns a **Radeon GPU Profiler (RGP)** capture (`.rgp`) into analysis-friendly
+formats: a per-kernel summary, an operators CSV, a per-dispatch CSV, and a
+Chrome/Perfetto trace.
+
+## What it does
+
+RGP captures great GPU data but only exposes it through its **GUI** — there's no
+headless way to pull symbolized, per-dispatch timing out of a `.rgp`. This tool
+makes RGP captures programmable:
+
+- **Automation / CI + AI analysis** — decode a `.rgp` in one command into
+  structured JSON/CSV; diff perf across builds and feed the trace to an LLM/agent
+  for automated bottleneck analysis instead of clicking through the GUI.
+- **Low performance distortion** — SQTT is hardware thread-tracing, so it perturbs
+  the workload far less than the EP's internal instrumentation-based profiling;
+  measured timings stay close to real, uninstrumented behavior.
+- **Wave-accurate per-dispatch metrics** — kernel name, start/duration (busy time
+  from occupancy wave start/end), exact wavefront/thread counts (from RGP SQTT
+  event-marker grids), workgroup size, VGPR/SGPR/LDS allocation, cache
+  flush/invalidate flags, and driver barriers; plus queue attribution `(me, pipe)`
+  and a wall-clock timeline from the realtime counter.
+- **Symbolization** — deterministic CodeObject-hash ↔ load-base pairing maps every
+  dispatch PC back to its kernel name (falls back to coverage-based mapping).
+- **Kernel-name decoding + op-family rollup** — Tensile/hipBLASLt/HIP names are
+  parsed into `library/family/dtype/tile/mi/workgroup/arch/flags` (e.g.
+  `Cijk_..._HHS_..._MT64x16x32_MI16x16x1_..._WG64_2_1` → `hgemm 64x16x32
+  wmma16x16 wg64x2 +bias`), so GEMM tile variants and repeated ops collapse into
+  per-family aggregates.
+- **Bottleneck analysis** — idle-gap/launch-overhead detection, theoretical
+  occupancy with the binding resource (gfx1151 constants verified vs LLVM), and a
+  per-dispatch bound class; with SPM, per-kernel memory bandwidth (EA counter) and
+  memory/compute-bound calls. Numbers degrade honestly when SPM is absent.
+- **Multiple outputs** — one command emits an AI-friendly summary (JSON + Markdown),
+  operators/families/dispatches CSVs, and a Perfetto/`chrome://tracing` timeline.
+
+Scope: a post-capture **decoder**, not a profiler. You still capture the `.rgp`
+with RGP/RDP; this owns everything after.
+
+## Workload to capture
+
+For performance-optimization captures, drive the model onlu with:
+
+- **VLM models** → `vlm_benchmark.py`
+- **non-VLM models** → `model_benchmark`
+
+Capture one representative slice (a single prefill or decode step) at steady state.
+
+## Setup (Git Bash)
+
+RGP ships in the **Radeon Developer Tool Suite (RDTS)** — no installer, just unzip.
+Get the current Windows zip URL from <https://gpuopen.com/tools/> (filename is versioned).
+
+```bash
+cd /c/tools
+curl -L -O https://gpuopen.com/download/RadeonDeveloperToolSuite-2026-05-28-1806.zip
+unzip -q RadeonDeveloperToolSuite-2026-05-28-1806.zip   # extracts to a versioned subfolder
+
+# add that subfolder (contains RadeonGPUProfiler.exe) to the Windows user PATH,
+# permanently (survives reboots, all shells)
+RGP_DIR='C:\tools\RadeonDeveloperToolSuite-2026-05-28-1806'
+powershell -Command "[Environment]::SetEnvironmentVariable('PATH', [Environment]::GetEnvironmentVariable('PATH','User').TrimEnd(';') + ';$RGP_DIR', 'User')"
+
+# reopen your shell, then verify
+which RadeonGPUProfiler
+```
+
+> Currently installed: RGP **v2.7.0.32** at
+> `C:\tools\RadeonDeveloperToolSuite\RadeonDeveloperToolSuite-2026-05-28-1806`.
+
+## What an RGP capture is
+
+A `.rgp` is a **dispatch-mode SQTT snapshot** of a bounded slice of the workload,
+not continuous profiling. The capture is driven in-process:
+
+1. **Arm before the HIP context exists** — `RadeonDeveloperPanelCLI -m profiling
+   --rgp-capture-mode dispatch --rgp-render-op-count <N> --rgp-sqtt-buffer-size
+   <sz>` is launched first so the driver hooks the process on connect.
+2. **`trigger()`** starts recording; the hardware writes SQTT tokens for the
+   dispatches after the trigger into an **SQTT buffer allocated in GPU memory**.
+3. **`stop()`** dwells for the driver to dump the `.rgp`.
+
+```mermaid
+flowchart LR
+  arm["arm() before HIP ctx"] --> load["load model + warmup JIT"]
+  load --> trig["trigger()"]
+  trig --> region["dispatches in region -> SQTT buffer (GPU mem)"]
+  region --> stop["stop() dwell -> .rgp dump"]
+```
+
+The resulting `.rgp` is an RDF container of chunks; a **usable** capture has one or
+more `SqttData` chunks (the hardware token stream) plus `CodeObject`s and, if SPM
+is on, `SpmCounterData`. A capture with `CodeObject`s but **no `SqttData`**, or a
+**0-byte** file, is unusable.
+
+## Limitations
+
+RGP allocates the **SQTT buffer in GPU memory**. On a shared-memory APU (no
+discrete VRAM) that buffer, the SPM counter buffers, and the model's own
+activations all compete for the same physical memory. This shared-memory
+footprint, not just token overflow, is the real constraint.
+
+**Verified failure modes** (gfx1151, Qwen3.5-9B VLM prefill):
+
+- **`--rgp-sqtt-buffer-size maximum` wedges the workload → no `.rgp`.** The
+  oversized reservation drives `SQTT + SPM + activations` past physical memory; the
+  app's HIP path fails mid-run (`hipMalloc` failure /
+  `hipErrorLaunchFailure` (719), process aborts) and **no file is written**.
+  Reproduced every time on a full prefill.
+- **Trigger miss (no dispatches in the region) → empty capture.** If the trigger
+  fires but the profiled region runs zero dispatches (workload already finished, or
+  the trigger lands outside steady state), the panel reports `capture FAILED
+  (tiny/empty)` and produces a **0-byte / no usable `.rgp`**.
+- **Undersized buffer silently truncates.** Too small and you get only part of the
+  run with no hard error — verify the capture contains your kernels before trusting
+  totals.
+
+**Not a failure mode (tested, falsified):** an oversized **`--rgp-render-op-count`**
+does *not* empty the capture. With `--rgp-render-op-count 100000` (window never
+fills) the capture still finalized fully — 169 MB `.rgp`, `SqttData` present
+(33.6 MB), identical to the 3000-op control — because dispatch mode dumps whatever
+was recorded up to `stop()`. `render_ops` affects window size/timing, not
+usability.
+
+**Recommended recipe** (verified good): `--rgp-sqtt-buffer-size minimum` + a modest
+`--rgp-render-op-count` (e.g. 3000), triggered during steady state over one
+representative slice (a single prefill or decode step). Do **not** shrink the
+prompt/image to fit — that changes the operating point, so the numbers no longer
+represent real inference. Verified control capture: **169 MB `.rgp`, 2 `SqttData`
+chunks (33.6 MB), 20 `CodeObject`s, 533 `SpmCounterData`**.
+
+## Usage
+
+```bash
+pip install -r requirements.txt
+
+# one .rgp + one output base -> every analyzed file at once
+python main.py <capture>.rgp sample
+```
+
+Given output base `sample`, this emits:
+
+| file | purpose |
+|---|---|
+| `sample_summary.json` / `sample_summary.md` | compact, AI-primary overview: capture meta + bottleneck classes + top idle gaps + op-family rollup + top kernels |
+| `sample_operators.csv` | per-kernel aggregate (grouped by full signature; artifacts flagged) + decoded family/dtype/tile, occupancy, bound class |
+| `sample_families.csv` | per-**op-family** rollup (GEMM tile variants and every instance of an op collapsed by `family/dtype/tile`) |
+| `sample_dispatches.csv` | one row per dispatch (drill-down) + idle gaps, occupancy, bound class/reason |
+| `sample_trace.json` | Perfetto/`chrome://tracing` timeline (human) |
+
+The base may include a directory (`out/sample`); any extension is ignored.
+
+## How the non-obvious numbers work
+
+Everything below is derived from the SQTT stream + kernel names; nothing is
+fabricated when data is missing.
+
+**Bound class** (per dispatch): `overhead` (tiny kernel dominated by its idle
+gap) · `latency/low-occupancy` (low theoretical occupancy) · `memory-bound` /
+`compute-bound` (**only** with SPM samples in-window) · `compute-or-memory
+(undetermined)` (SPM absent or window too short — reported honestly, never
+guessed). Theoretical occupancy is a static *resource ceiling* (like rocprof's),
+not measured achieved occupancy.
+
+**SPM memory bandwidth** (when present): attributed per dispatch from the raw EA
+ev55 unified-memory request counter,
+`mem_gbps = (requests in window × bytes/req) / window-time`, needing ≥3 samples
+in-window. We **sum raw request counts** rather than average per-sample GB/s on
+purpose — EA samples are bursty arbiter *arrivals*, so a single-sample rate is
+meaningless (it can exceed the roofline); only the windowed total is physical.
+Without SPM, `mem_gbps` stays `0`/`-` and the class degrades gracefully.
+
+Honest caveats: (1) a short window can catch the *drain* of a prior kernel's
+queued requests, so a few very short dispatches read above roofline — treat
+per-kernel `mem_gbps` as order-of-magnitude. (2) `memory-bound` = ≥70% of the
+*theoretical* roofline (`mem_roofline_gbps`, default 256 GB/s for Strix Halo
+LPDDR5X); the `compute-bound` label means "not memory-BW-bound with occupancy
+headroom filled", not a proof of ALU saturation (no VALU/IPC counters).
+
+Cleanup after a capture session (kills the Radeon Developer Service/Panel
+listeners):
+
+```bash
+python cleanup.py
+```
+
+## References
+
+- [libamdrdf](https://github.com/GPUOpen-Drivers/libamdrdf) — RDF `.rgp` container format (parse chunks)
+- [rocprof-trace-decoder](https://github.com/ROCm/rocm-systems/tree/develop/projects/rocprof-trace-decoder) — SQTT token format (ported to pure Python in `struct/sqtt_decode.py`)
+- Mesa — RGP SQTT marker struct layouts (`ac_sqtt.h`), used to decode grid dims and barrier fields

--- a/tools/rgp_parser/cleanup.py
+++ b/tools/rgp_parser/cleanup.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""Entry point: stop the RGP capture listeners.
+
+python cleanup.py   # kill Radeon Developer Service/Panel
+"""
+
+from rgp_parser.cleanup import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/rgp_parser/main.py
+++ b/tools/rgp_parser/main.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""Entry point: decode a .rgp capture and emit all analyzed files at once.
+
+    python main.py <capture>.rgp <output-base>
+
+e.g. `python main.py sample.rgp sample` -> sample_summary.json/.md,
+sample_operators.csv, sample_dispatches.csv, sample_trace.json.
+
+The logic lives in the rgp_parser package (kept in a package so its `struct`
+subpackage never shadows the stdlib `struct` module).
+"""
+
+from rgp_parser.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/rgp_parser/requirements.txt
+++ b/tools/rgp_parser/requirements.txt
@@ -1,0 +1,2 @@
+pyelftools>=0.29
+zstandard>=0.21

--- a/tools/rgp_parser/rgp_parser/__init__.py
+++ b/tools/rgp_parser/rgp_parser/__init__.py
@@ -1,0 +1,12 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""rgp_parser: decode a Radeon GPU Profiler (RGP) .rgp capture into analysis-friendly
+formats (per-kernel summary, operators CSV, per-dispatch CSV, Chrome trace).
+
+The package is intentionally nested under this directory so the `struct` subpackage is
+imported as ``rgp_parser.struct`` and never shadows Python's stdlib ``struct`` module.
+"""
+
+__version__ = "0.1.0"

--- a/tools/rgp_parser/rgp_parser/build.py
+++ b/tools/rgp_parser/rgp_parser/build.py
@@ -1,0 +1,462 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""Assemble a normalized :class:`~rgp_parser.model.Trace` from a ``.rgp`` capture.
+
+Flow:  RDF -> (SQTT decode | records.json) -> symbolize -> markers/barriers ->
+       exact counts + refined durations -> SPM/occupancy curves -> Trace
+
+Full RGP-parity trace builder: deterministic CodeObject-hash symbolization, RGP
+SQTT marker barriers, Event-marker grid thread/wavefront counts, min(wave-span,
+next-launch gap) duration, wavefront-occupancy band, and SPM counter curves.
+"""
+
+from __future__ import annotations
+
+import bisect
+import struct
+
+from . import kernelinfo, symbolize
+from . import occupancy as occ_calc
+from .model import Barrier, CaptureMeta, Curve, Dispatch, Event, OccupancySample, Trace
+from .struct import coload, spm, sqtt
+from .struct.codeobject import load_code_objects, load_code_objects_hashed
+from .struct.rdf import RdfFile
+
+# ---- RGP SQTT markers (reassembled from USERDATA_2 + USERDATA_3) --------------
+# RGP streams markers 2 dwords/packet into USERDATA_2/3; the patched decoder surfaces
+# each as EVENT type 15, payload = the 32-bit regdata, seq = capture order.
+# Layouts from Mesa src/amd/common/ac_sqtt.h (rgp_sqtt_marker_*).
+MARKER_EVENT_TYPE = 15
+MARKER_BASE = {
+    0x0: 3,
+    0x1: 4,
+    0x2: 3,
+    0x3: 2,
+    0x4: 2,
+    0x5: 1,
+    0x6: 1,
+    0x7: 1,
+    0x8: 3,
+    0x9: 2,
+    0xA: 3,
+    0xC: 3,
+}
+
+
+def _decode_barrier_end(d01, d02):
+    caches, stalls = [], []
+    if (d02 >> 3) & 1:
+        caches.append("K")  # inval_sqK (scalar)
+    if (d02 >> 1) & 1:
+        caches.append("L0")  # inval_tcp (L0 vector)
+    if (d02 >> 2) & 1:
+        caches.append("I")  # inval_sqI (instruction)
+    if (d02 >> 26) & 1:
+        caches.append("L1")  # inval_gl1
+    if (d02 >> 5) & 1:
+        caches.append("L2")  # inval_tcc
+    if (d02 >> 4) & 1:
+        caches.append("L2flush")  # flush_tcc
+    if (d01 >> 30) & 1:
+        stalls.append("CS")  # cs_partial_flush
+    if (d01 >> 28) & 1:
+        stalls.append("VS")
+    if (d01 >> 29) & 1:
+        stalls.append("PS")
+    if (d01 >> 27) & 1:
+        stalls.append("waitEOP")
+    if (d01 >> 31) & 1:
+        stalls.append("pfpSyncMe")
+    return {
+        "caches_invalidated": ", ".join(caches) or "None",
+        "frontend_sync": ", ".join(stalls) or "None",
+        "cb_id": (d01 >> 7) & 0xFFFFF,
+    }
+
+
+def _parse_markers(raw_events, me, pipe):
+    """Walk the reassembled marker dword stream for one queue. Returns
+    (barriers, events) where events = [(ts, grid_workgroups)] for dispatches, or
+    (None, None) if no markers (unpatched decoder)."""
+    res = sorted(
+        [
+            e
+            for e in raw_events
+            if e.get("type") == MARKER_EVENT_TYPE
+            and e.get("me") == me
+            and e.get("pipe") == pipe
+        ],
+        key=lambda e: e.get("seq", 0),
+    )
+    if not res:
+        return None, None
+    dw = [(e["ts"], int(e["payload"]) & 0xFFFFFFFF) for e in res]
+    barriers, events = [], []
+    i = 0
+    pend_start = None
+    while i < len(dw):
+        ts, d01 = dw[i]
+        ident = d01 & 0xF
+        ext = (d01 >> 4) & 0x7
+        if ident == 0x0:  # event (per draw/dispatch)
+            has_dims = (d01 >> 31) & 1
+            size = 3 + (3 if has_dims else 0) + ext
+            if has_dims and i + 5 < len(dw):
+                gx, gy, gz = dw[i + 3][1], dw[i + 4][1], dw[i + 5][1]
+                events.append((ts, gx * gy * gz))
+            i += size
+        elif ident == 0x3:  # barrier start
+            pend_start = ts
+            i += 2 + ext
+        elif ident == 0x4:  # barrier end
+            d02 = dw[i + 1][1] if i + 1 < len(dw) else 0
+            f = _decode_barrier_end(d01, d02)
+            start = pend_start if pend_start is not None else ts - 0.5
+            span = max(ts - start, 0.0)
+            barriers.append(
+                {
+                    "me": me,
+                    "pipe": pipe,
+                    "ts": start,
+                    "dur": span,
+                    "args": {
+                        **f,
+                        "barrier_type": "DRIVER",
+                        "interval_us": round(span, 3),
+                        "source": "RGP SQTT markers: cache/stall exact; "
+                        "interval = BarrierEnd.ts - BarrierStart.ts",
+                    },
+                }
+            )
+            pend_start = None
+            i += 2 + ext
+        else:
+            i += MARKER_BASE.get(ident, 1) + ext
+    return barriers, events
+
+
+def _queue_context(rdf):
+    """Queue mapping from QueueInfo/QueueEvent chunks."""
+    qinfo, qevents = [], []
+    for c in rdf.by_id("QueueInfo"):
+        d = rdf.data(c)
+        if len(d) >= 32:
+            hw = struct.unpack_from("<I", d, 24)[0]
+            qinfo.append((hw & 0xFF, (hw >> 8) & 0xFF))
+    for c in rdf.by_id("QueueEvent"):
+        d = rdf.data(c)
+        if len(d) >= 72:
+            et, cbid, frame, qii, sub, api, cpu, g0, g1 = struct.unpack_from(
+                "<IIQIIQQQQ", d, 16
+            )
+            if et == 0:
+                qevents.append((qii, g0, g1))
+    return qinfo, qevents
+
+
+def build_trace(
+    rgp_path: str,
+    records_path: str | None = None,
+    *,
+    spm_enabled: bool = True,
+    occupancy_enabled: bool = True,
+    counters_xml: str | None = None,
+    mem_roofline_gbps: float = 256.0,
+    mem_bytes_per_req: int = 64,
+) -> Trace:
+    """Decode + symbolize a capture into a Trace with full RGP-parity features.
+
+    :param rgp_path: path to the ``.rgp`` capture.
+    :param records_path: optional records.json from the C++ decoder. If omitted,
+        the pure-Python token decoder is used (currently ``NotImplementedError``).
+    :param spm_enabled: attach SPM counter curves (memory/cache bandwidth).
+    :param occupancy_enabled: attach the wavefront-occupancy band.
+    """
+    rdf = RdfFile.from_path(rgp_path)
+
+    if records_path:
+        rec = sqtt.load_records(records_path)
+    else:
+        rec = sqtt.decode_tokens(sqtt.extract_blobs(rdf))
+
+    WAVE = rec.wave_size
+    raw_disp = rec.dispatches
+    raw_events = rec.events
+
+    # duration-weighted PCs for symbolization
+    pcw: dict[int, float] = {}
+    for d in raw_disp:
+        pc = int(d["pc"], 16) if isinstance(d["pc"], str) else int(d["pc"])
+        pcw[pc] = pcw.get(pc, 0.0) + max(0.0, d.get("dur", 0.0))
+
+    # --- symbolize: prefer deterministic CodeObject-hash <-> COLoadEvent-base pairing
+    sym_note = ""
+    hash2base = coload.load_hash_bases(rdf)
+    names: dict[int, str] = {}
+    if hash2base and pcw:
+        co_hash_funcs = load_code_objects_hashed(rdf)
+        names, stats = symbolize.name_map_exact(co_hash_funcs, hash2base, pcw)
+        sym_note = (
+            f"exact CO-hash pairing: {stats[2]}/{stats[3]} code objects, "
+            f"{stats[0]}/{stats[1]} PCs, {stats[4]:.0f}% of dispatch-duration"
+        )
+    if not names and pcw:  # fallback: coverage-based
+        co_funcs = load_code_objects(rdf)
+        bases = coload.load_bases(rdf)
+        names = symbolize.name_map(co_funcs, bases, pcw)
+        sym_note = "coverage-based CO<->base assignment (no COLoadEvent hashes)"
+
+    # --- per-queue: markers -> barriers + exact grids; refined durations
+    queues = sorted({(int(d.get("me", 0)), int(d.get("pipe", 0))) for d in raw_disp})
+    dispatches: list[Dispatch] = []
+    barriers: list[Barrier] = []
+    wave_sizes: set[int] = set()
+    for me, pipe in queues:
+        ds = sorted(
+            [
+                d
+                for d in raw_disp
+                if int(d.get("me", 0)) == me and int(d.get("pipe", 0)) == pipe
+            ],
+            key=lambda x: x.get("launch_ts", x.get("ts", 0.0)),
+        )
+        mbar, mevents = _parse_markers(raw_events, me, pipe)
+        grids = [g for _, g in mevents] if mevents else []
+        counts_exact = (mevents is not None) and (len(grids) == len(ds))
+        launches = sorted(x.get("launch_ts", x.get("ts", 0.0)) for x in ds)
+        for j, d in enumerate(ds):
+            pc = int(d["pc"], 16) if isinstance(d["pc"], str) else int(d["pc"])
+            occ_wf = int(d.get("wavefronts", 0))
+            span = (
+                max(0.0, d["dur"])
+                if d.get("dur") is not None and d["dur"] >= 0
+                else 0.0
+            )
+            lt = d.get("launch_ts", d.get("ts", 0.0))
+            li = bisect.bisect_right(launches, lt)
+            gap = max(0.0, (launches[li] - lt) if li < len(launches) else span)
+            dur = min(span, gap) if span > 0 else gap
+            if counts_exact:
+                threads = grids[j] * int(d.get("wg", 0))
+                # ceil: a partial workgroup still occupies a full wavefront, which
+                # is how RGP reports launched waves (e.g. 32 threads -> 1 wave).
+                wf = -(-threads // WAVE) if WAVE else 0
+                wave_sizes.add(WAVE)
+                csrc = "Event-marker grid (exact)"
+            else:
+                threads = occ_wf * WAVE
+                wf = occ_wf
+                csrc = "occupancy (approx; marker grid unavailable)"
+            dispatches.append(
+                Dispatch(
+                    pc=pc,
+                    name=names.get(pc, hex(pc)),
+                    me=me,
+                    pipe=pipe,
+                    ts_us=float(d.get("ts", 0.0)),
+                    launch_ts_us=float(lt),
+                    dur_us=float(dur),
+                    wavefronts=wf,
+                    exp_waves=int(d.get("exp_waves", 0)),
+                    threads=threads,
+                    workgroup=int(d.get("wg", 0)),
+                    vgpr=int(d.get("vgpr", 0)),
+                    sgpr=int(d.get("sgpr", 0)),
+                    lds=int(d.get("lds", 0)),
+                    flags=int(d.get("flags", 0)),
+                    wave_span_us=round(span, 3),
+                    occupancy_wavefronts=occ_wf,
+                    counts_source=csrc,
+                    duration_note="min(occupancy wave-span, next-launch gap); approx",
+                )
+            )
+        if mbar:
+            for b in mbar:
+                barriers.append(
+                    Barrier(
+                        name="CmdBarrier()",
+                        me=b["me"],
+                        pipe=b["pipe"],
+                        ts_us=b["ts"],
+                        dur_us=b["dur"],
+                        args=b["args"],
+                    )
+                )
+
+    events = [
+        Event(
+            me=int(e.get("me", 0)),
+            pipe=int(e.get("pipe", 0)),
+            ts_us=float(e.get("ts", 0.0)),
+            type=int(e.get("type", 0)),
+            payload=int(e.get("payload", 0)),
+        )
+        for e in raw_events
+    ]
+
+    occupancy = []
+    for o in rec.occupancy:
+        per_se = {int(k[2:]): v for k, v in o.items() if k.startswith("se")}
+        occupancy.append(OccupancySample(ts_us=float(o.get("ts", 0.0)), per_se=per_se))
+
+    # --- SPM counter curves (memory/cache bandwidth) ---------------------------
+    curves: list[Curve] = []
+    spm_note = ""
+    mem_xs: list[float] = []  # full-resolution EA sample times (us)
+    mem_req: list[float] = []  # EA ev55 request counts per sample (for attribution)
+    if spm_enabled:
+        try:
+            session = spm.parse_spm(rgp_path)
+        except Exception as e:  # noqa: BLE001 - decode is best-effort
+            session = None
+            spm_note = f"SPM decode skipped: {e}"
+        if session:
+            trace_t0 = min((float(d.get("ts", 0.0)) for d in raw_disp), default=0.0)
+            mem_xs, mem_req = spm.ea_request_series(session, anchor_us=trace_t0)
+            for cv in spm.spm_curves(
+                session,
+                rocprof_xml=counters_xml,
+                anchor_us=trace_t0,
+                mem_roofline_gbps=mem_roofline_gbps,
+                ea_bytes_per_req=mem_bytes_per_req,
+            ):
+                curves.append(
+                    Curve(
+                        display=f"{cv['group']}: {cv['name']} [{cv['unit']}]",
+                        key=cv["name"],
+                        series=cv["series"],
+                        group=cv["group"],
+                        unit=cv["unit"],
+                    )
+                )
+            ms = spm.mem_traffic_summary(
+                session,
+                ea_bytes_per_req=mem_bytes_per_req,
+                roofline_gbps=mem_roofline_gbps,
+            )
+            if ms:
+                spm_note = (
+                    f"unified-mem (EA ev55): ~{ms['avg_gbps']:.1f} GB/s avg over "
+                    f"{ms['window_ms']:.1f} ms (~{ms['pct_roofline']:.0f}% of "
+                    f"{mem_roofline_gbps:.0f} GB/s roofline @{ms['bytes_per_req']}B/req)"
+                )
+        elif not spm_note:
+            spm_note = "no SPM counters in capture"
+
+    # --- decode kernel identity + theoretical occupancy ------------------------
+    for d in dispatches:
+        ki = kernelinfo.parse_kernel_name(d.name)
+        d.library, d.family, d.dtype, d.tile, d.label = (
+            ki.library,
+            ki.family,
+            ki.dtype,
+            ki.tile,
+            ki.label,
+        )
+        occ_pct, limiter, waves_cu = occ_calc.theoretical_occupancy(
+            d.vgpr, d.sgpr, d.lds, d.workgroup, wave_size=WAVE
+        )
+        d.occ_pct, d.occ_limiter, d.occ_theoretical = occ_pct, limiter, waves_cu
+
+    # --- idle gaps per queue (execution-window based, real dispatches only) -----
+    for q in queues:
+        ds = sorted(
+            [d for d in dispatches if (d.me, d.pipe) == q and not d.is_artifact],
+            key=lambda x: x.ts_us,
+        )
+        for i, d in enumerate(ds):
+            end = d.ts_us + max(d.dur_us, 0.0)
+            if i + 1 < len(ds):
+                gap = max(0.0, ds[i + 1].ts_us - end)
+                d.idle_after_us = round(gap, 3)
+                ds[i + 1].gap_before_us = round(gap, 3)
+
+    # --- opportunistic per-kernel SPM memory attribution (no-op if SPM absent) --
+    # Sustained BW = (EA requests arriving in the dispatch window * bytes/req) / window
+    # time. Summing raw counts (not averaging per-sample GB/s) is the physically-sound
+    # estimate: over the window, arrivals ~= completions, so their time-average is the
+    # sustained bandwidth -- same argument that makes the whole-capture average valid.
+    # Requires >=3 samples in-window to be trustworthy; short kernels stay 0 -> undet.
+    spm_present = bool(mem_xs)
+    if mem_xs:
+        for d in dispatches:
+            if d.is_artifact or d.dur_us <= 0:
+                continue
+            lo = bisect.bisect_left(mem_xs, d.ts_us)
+            hi = bisect.bisect_right(mem_xs, d.ts_us + d.dur_us)
+            n = hi - lo
+            if n >= 3:
+                # span the samples actually cover (avoids bias from partial windows)
+                span_us = max(mem_xs[hi - 1] - mem_xs[lo], d.dur_us)
+                req = sum(mem_req[lo:hi])
+                bytes_moved = req * mem_bytes_per_req
+                d.mem_bytes = round(bytes_moved, 1)
+                d.mem_gbps = round(bytes_moved / (span_us * 1e3), 2) if span_us else 0.0
+
+    # --- bottleneck classification (degrades gracefully without SPM) ------------
+    for d in dispatches:
+        if d.is_artifact:
+            continue
+        bc, br = occ_calc.classify_bound(
+            d,
+            spm_present=spm_present,
+            mem_reliable=(d.mem_gbps > 0),
+            roofline_gbps=mem_roofline_gbps,
+        )
+        d.bound_class, d.bound_reason = bc, br
+
+    # --- queue mapping metadata ------------------------------------------------
+    qinfo, qevents = _queue_context(rdf)
+    disp_per_queue = {
+        q: sum(1 for d in dispatches if (d.me, d.pipe) == q) for q in queues
+    }
+    primary_queue = max(queues, key=lambda q: disp_per_queue[q]) if queues else None
+    rt_freq = rec.rt_freq or 100_000_000
+    submit_span_ms = (
+        (
+            (max(g1 for _, _, g1 in qevents) - min(g0 for _, g0, _ in qevents))
+            / rt_freq
+            * 1e3
+        )
+        if qevents
+        else 0.0
+    )
+    n_compute = sum(1 for _qt, et in qinfo if et in (2, 3))
+    queue_note = (
+        f"{len(qevents)} cmdbuf submits; {n_compute} compute HW queue(s); "
+        f"submit span {submit_span_ms:.1f} ms"
+        if qevents
+        else "no QueueEvent chunks"
+    )
+
+    meta = CaptureMeta(
+        source=rgp_path,
+        rt_freq_hz=rt_freq,
+        wave_size=WAVE,
+        shader_engines=len(rdf.by_id("SqttData")) or rec.shader_engines,
+        queues=queues,
+        extra={
+            "chunks": rdf.counts(),
+            "symbolization": sym_note,
+            "spm": spm_note,
+            "queue_mapping": queue_note,
+            "primary_queue": (
+                f"me{primary_queue[0]}/pipe{primary_queue[1]}"
+                if primary_queue
+                else None
+            ),
+            "wave_sizes": sorted(wave_sizes) or [WAVE],
+            "clock": f"GPU timestamp {rt_freq / 1e6:.0f} MHz",
+        },
+    )
+
+    return Trace(
+        meta=meta,
+        dispatches=dispatches,
+        barriers=barriers,
+        events=events,
+        occupancy=occupancy,
+        curves=curves,
+    )

--- a/tools/rgp_parser/rgp_parser/cleanup.py
+++ b/tools/rgp_parser/rgp_parser/cleanup.py
@@ -1,0 +1,35 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""cleanup.py: stop the RGP capture 'listeners'.
+
+The RGP capture path leaves the Radeon Developer Service / Panel running (the
+'listeners' that talk to the driver's DevDriver router). This kills them. It does
+not touch the environment/PATH and does not reboot.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+PROCESSES = [
+    "RadeonDeveloperPanelCLI.exe",
+    "RadeonDeveloperPanel.exe",
+    "RadeonDeveloperServiceCLI.exe",
+    "RadeonDeveloperService.exe",
+]
+
+
+def main(argv=None) -> int:
+    if sys.platform != "win32":
+        print("nothing to do: RGP listeners run only on Windows.", file=sys.stderr)
+        return 0
+    for name in PROCESSES:
+        r = subprocess.run(
+            ["taskkill", "/F", "/IM", name], capture_output=True, text=True
+        )
+        if r.returncode == 0:
+            print(f"killed {name}")
+    return 0

--- a/tools/rgp_parser/rgp_parser/cli.py
+++ b/tools/rgp_parser/rgp_parser/cli.py
@@ -1,0 +1,70 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""main.py CLI: decode a .rgp and emit all analyzed files at once.
+
+    python main.py <capture>.rgp <output-base>
+
+Given output base ``sample`` (a name or path, extension ignored), emits:
+    sample_summary.json, sample_summary.md, sample_operators.csv,
+    sample_dispatches.csv, sample_trace.json
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from .build import build_trace
+from .format import WRITERS
+
+
+def _strip_ext(base: str) -> str:
+    # allow the user to pass "sample", "sample.json", "out/sample" etc.
+    root, ext = os.path.splitext(base)
+    return root if ext else base
+
+
+def main(argv=None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    # minimal positional parsing: <rgp> <output-base> [--records PATH]
+    records = None
+    if "--records" in argv:
+        i = argv.index("--records")
+        try:
+            records = argv[i + 1]
+            del argv[i : i + 2]
+        except IndexError:
+            print("error: --records needs a path", file=sys.stderr)
+            return 2
+    if len(argv) != 2 or argv[0] in ("-h", "--help"):
+        print(
+            "usage: main.py <capture>.rgp <output-base> [--records records.json]\n"
+            "  emits <output-base>_{summary.json,summary.md,operators.csv,"
+            "dispatches.csv,trace.json}",
+            file=sys.stderr,
+        )
+        return 0 if argv and argv[0] in ("-h", "--help") else 2
+
+    rgp, out_base = argv
+    if not os.path.isfile(rgp):
+        print(f"error: no such file: {rgp}", file=sys.stderr)
+        return 2
+
+    base = _strip_ext(out_base)
+    outdir = os.path.dirname(base)
+    if outdir:
+        os.makedirs(outdir, exist_ok=True)
+
+    try:
+        trace = build_trace(rgp, records_path=records)
+    except NotImplementedError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 3
+
+    for _fmt, (writer, suffix) in WRITERS.items():
+        out = base + suffix
+        writer(trace, out)
+        print(f"wrote {out}")
+    return 0

--- a/tools/rgp_parser/rgp_parser/format/__init__.py
+++ b/tools/rgp_parser/rgp_parser/format/__init__.py
@@ -1,0 +1,24 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""Formatters: pure functions turning a normalized Trace into an output artifact.
+
+Each module exposes ``write(trace, path)``. ``WRITERS`` maps a format name to its
+writer and the filename suffix appended to the output base (e.g. base ``sample``
+-> ``sample_summary.json``). Every format is always emitted at once.
+"""
+
+from __future__ import annotations
+
+from . import chrome, dispatches, operators, summary
+
+WRITERS = {
+    "summary": (summary.write, "_summary.json"),  # also writes _summary.md
+    "operators": (operators.write, "_operators.csv"),
+    "families": (operators.write_families, "_families.csv"),
+    "dispatches": (dispatches.write, "_dispatches.csv"),
+    "trace": (chrome.write, "_trace.json"),
+}
+
+__all__ = ["WRITERS", "chrome", "dispatches", "operators", "summary"]

--- a/tools/rgp_parser/rgp_parser/format/chrome.py
+++ b/tools/rgp_parser/rgp_parser/format/chrome.py
@@ -1,0 +1,185 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""chrome_trace.json - Chrome/Perfetto timeline (human visual inspection).
+
+Per-queue dispatch tracks (greedy lane-packed) + a barriers overlay + a dedicated
+counters process carrying the wavefront-occupancy band and SPM memory/cache-bandwidth
+curves. Open in https://ui.perfetto.dev or chrome://tracing.
+"""
+
+from __future__ import annotations
+
+import json
+
+from ..model import Trace
+
+CTR_PID = 1  # dedicated process for counter ("C") tracks
+
+
+def _lane_pack(items):
+    lanes: list[float] = []
+    out = []
+    for it in items:
+        placed = -1
+        for L, last in enumerate(lanes):
+            if it["ts"] >= last:
+                placed = L
+                lanes[L] = it["ts"] + max(it["dur"], 0.0)
+                break
+        if placed < 0:
+            placed = len(lanes)
+            lanes.append(it["ts"] + max(it["dur"], 0.0))
+        out.append(placed)
+    return out
+
+
+def write(trace: Trace, path: str) -> None:
+    queues = trace.meta.queues or sorted({(d.me, d.pipe) for d in trace.dispatches})
+    qidx = {q: i for i, q in enumerate(queues)}
+    primary = trace.meta.extra.get("primary_queue")
+    events_out = []
+
+    def meta(tid, name):
+        events_out.append(
+            {
+                "name": "thread_name",
+                "ph": "M",
+                "pid": 0,
+                "tid": tid,
+                "args": {"name": name},
+            }
+        )
+
+    for me, pipe in queues:
+        qi = qidx[(me, pipe)]
+        ds = sorted(
+            [d for d in trace.dispatches if d.me == me and d.pipe == pipe],
+            key=lambda x: x.ts_us,
+        )
+        items = []
+        for d in ds:
+            args = {
+                "queue": f"me{me}/pipe{pipe}",
+                "pc": hex(d.pc),
+                "workgroup_size": d.workgroup,
+                "vgpr_alloc": d.vgpr,
+                "sgpr_alloc": d.sgpr,
+                "lds": d.lds,
+                "is_artifact": d.is_artifact,
+                "duration_us": round(max(d.dur_us, 0.0), 3),
+                "total_threads": d.threads,
+                "total_wavefronts": d.wavefronts,
+                "occupancy_wavefronts": d.occupancy_wavefronts,
+            }
+            if d.wave_span_us >= 0:
+                args["wave_span_us"] = d.wave_span_us
+            if d.counts_source:
+                args["counts_source"] = d.counts_source
+            if d.duration_note:
+                args["duration_note"] = d.duration_note
+            items.append(
+                {
+                    "name": d.name,
+                    "cat": "dispatch",
+                    "ts": d.ts_us,
+                    "dur": max(d.dur_us, 0.0),
+                    "args": args,
+                }
+            )
+        for b in trace.barriers:
+            if b.me == me and b.pipe == pipe:
+                items.append(
+                    {
+                        "name": b.name,
+                        "cat": "barrier",
+                        "ts": b.ts_us,
+                        "dur": max(b.dur_us, 0.0),
+                        "args": b.args,
+                    }
+                )
+        items.sort(key=lambda x: x["ts"])
+        lanes = _lane_pack(items)
+        base_tid = 100 + qi * 10
+        used = set()
+        for it, L in zip(items, lanes):
+            used.add(L)
+            events_out.append(
+                {
+                    "name": it["name"],
+                    "cat": it["cat"],
+                    "ph": "X",
+                    "pid": 0,
+                    "tid": base_tid + L,
+                    "ts": it["ts"],
+                    "dur": it["dur"],
+                    "args": it["args"],
+                }
+            )
+        rgp_note = " [RGP Queue 1]" if primary == f"me{me}/pipe{pipe}" else ""
+        for L in sorted(used):
+            meta(base_tid + L, f"Queue me{me}/pipe{pipe} (COMPUTE){rgp_note} - row {L}")
+
+    # process metadata (queue mapping / symbolization / clock)
+    ex = trace.meta.extra
+    events_out.append(
+        {
+            "name": "process_name",
+            "ph": "M",
+            "pid": 0,
+            "tid": 0,
+            "args": {
+                "name": "gfx1151 SQTT (rgp_parser, RGP-parity)",
+                "queue_mapping": ex.get("queue_mapping"),
+                "primary_queue": ex.get("primary_queue"),
+                "symbolization": ex.get("symbolization"),
+                "spm": ex.get("spm"),
+                "clock": ex.get("clock"),
+            },
+        }
+    )
+
+    # ---- counter tracks: occupancy band (SQTT) + SPM curves -------------------
+    ctr = [
+        {
+            "name": "process_name",
+            "ph": "M",
+            "pid": CTR_PID,
+            "tid": 0,
+            "args": {"name": "GPU counters (occupancy / SPM)"},
+        }
+    ]
+
+    def emit_counter(name, points, arg_fn):
+        for ts, val in points:
+            ctr.append(
+                {
+                    "name": name,
+                    "cat": "counter",
+                    "ph": "C",
+                    "pid": CTR_PID,
+                    "tid": 0,
+                    "ts": float(ts),
+                    "args": arg_fn(val),
+                }
+            )
+
+    ncurve = 0
+    if trace.occupancy:
+        pts = [(s.ts_us, s.per_se) for s in trace.occupancy]
+        emit_counter(
+            "Wavefront occupancy",
+            pts,
+            lambda se: {f"se{k}": int(v) for k, v in se.items()},
+        )
+        ncurve += 1
+    for cv in trace.curves:
+        emit_counter(
+            cv.display, cv.series, lambda v, key=cv.key: {key: round(float(v), 3)}
+        )
+        ncurve += 1
+    events_out.extend(ctr)
+
+    with open(path, "w") as f:
+        json.dump({"displayTimeUnit": "ns", "traceEvents": events_out}, f)

--- a/tools/rgp_parser/rgp_parser/format/dispatches.py
+++ b/tools/rgp_parser/rgp_parser/format/dispatches.py
@@ -1,0 +1,81 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""dispatches.csv - one row per GPU dispatch (flat, for drill-down / custom analysis)."""
+
+from __future__ import annotations
+
+import csv
+
+from ..model import Trace
+
+FIELDS = [
+    "idx",
+    "kernel",
+    "family",
+    "dtype",
+    "tile",
+    "label",
+    "pc",
+    "queue",
+    "me",
+    "pipe",
+    "ts_us",
+    "launch_ts_us",
+    "dur_us",
+    "gap_before_us",
+    "idle_after_us",
+    "is_artifact",
+    "wavefronts",
+    "exp_waves",
+    "threads",
+    "workgroup",
+    "vgpr",
+    "sgpr",
+    "lds",
+    "occ_pct",
+    "occ_limiter",
+    "bound_class",
+    "bound_reason",
+    "mem_gbps",
+]
+
+
+def write(trace: Trace, path: str) -> None:
+    with open(path, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=FIELDS)
+        w.writeheader()
+        for i, d in enumerate(sorted(trace.dispatches, key=lambda x: x.ts_us)):
+            w.writerow(
+                {
+                    "idx": i,
+                    "kernel": d.name,
+                    "family": d.family,
+                    "dtype": d.dtype,
+                    "tile": d.tile,
+                    "label": d.label,
+                    "pc": hex(d.pc),
+                    "queue": f"me{d.me}/pipe{d.pipe}",
+                    "me": d.me,
+                    "pipe": d.pipe,
+                    "ts_us": round(d.ts_us, 4),
+                    "launch_ts_us": round(d.launch_ts_us, 4),
+                    "dur_us": round(d.dur_us, 4),
+                    "gap_before_us": round(d.gap_before_us, 4),
+                    "idle_after_us": round(d.idle_after_us, 4),
+                    "is_artifact": int(d.is_artifact),
+                    "wavefronts": d.wavefronts,
+                    "exp_waves": d.exp_waves,
+                    "threads": d.threads,
+                    "workgroup": d.workgroup,
+                    "vgpr": d.vgpr,
+                    "sgpr": d.sgpr,
+                    "lds": d.lds,
+                    "occ_pct": d.occ_pct,
+                    "occ_limiter": d.occ_limiter,
+                    "bound_class": d.bound_class,
+                    "bound_reason": d.bound_reason,
+                    "mem_gbps": d.mem_gbps,
+                }
+            )

--- a/tools/rgp_parser/rgp_parser/format/operators.py
+++ b/tools/rgp_parser/rgp_parser/format/operators.py
@@ -1,0 +1,177 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""operators.csv - per-kernel aggregate ('where does GPU time go').
+
+Grouped by full kernel signature (template args kept distinct: ``foo<1024,1>`` and
+``foo<256,64>`` are separate rows). ``wave_span=0`` launch-gap artifacts are counted
+separately and flagged so real totals can exclude them.
+"""
+
+from __future__ import annotations
+
+import csv
+from statistics import median
+
+from ..model import Trace
+
+FIELDS = [
+    "kernel",
+    "library",
+    "family",
+    "dtype",
+    "tile",
+    "count",
+    "artifact_count",
+    "total_us",
+    "pct_gpu",
+    "mean_us",
+    "median_us",
+    "p90_us",
+    "max_us",
+    "avg_wavefronts",
+    "avg_threads",
+    "workgroup",
+    "vgpr",
+    "sgpr",
+    "lds",
+    "occ_pct",
+    "occ_limiter",
+    "bound_class",
+    "avg_mem_gbps",
+    "pc",
+]
+
+# _families.csv columns (rollup by op family / dtype / tile).
+FAMILY_FIELDS = [
+    "family",
+    "dtype",
+    "tile",
+    "library",
+    "label",
+    "count",
+    "total_us",
+    "pct_gpu",
+    "mean_us",
+    "occ_pct",
+    "occ_limiter",
+    "bound_class",
+    "avg_mem_gbps",
+]
+
+
+def _p90(xs):
+    if not xs:
+        return 0.0
+    s = sorted(xs)
+    return s[min(len(s) - 1, int(round(0.9 * (len(s) - 1))))]
+
+
+def _dominant(strs):
+    """Most common non-empty string in an iterable ("" if none)."""
+    counts: dict[str, int] = {}
+    for s in strs:
+        if s:
+            counts[s] = counts.get(s, 0) + 1
+    return max(counts, key=counts.get) if counts else ""
+
+
+def aggregate(trace: Trace):
+    groups: dict[str, list] = {}
+    for d in trace.dispatches:
+        groups.setdefault(d.name, []).append(d)
+    busy = trace.gpu_busy_us() or 1.0
+
+    rows = []
+    for name, ds in groups.items():
+        real = [d for d in ds if not d.is_artifact and d.dur_us > 0]
+        durs = [d.dur_us for d in real]
+        total = sum(durs)
+        mem = [d.mem_gbps for d in real if d.mem_gbps > 0]
+        rows.append(
+            {
+                "kernel": name,
+                "library": ds[0].library,
+                "family": ds[0].family,
+                "dtype": ds[0].dtype,
+                "tile": ds[0].tile,
+                "count": len(ds),
+                "artifact_count": sum(1 for d in ds if d.is_artifact),
+                "total_us": round(total, 3),
+                "pct_gpu": round(100.0 * total / busy, 2),
+                "mean_us": round(total / len(durs), 3) if durs else 0.0,
+                "median_us": round(median(durs), 3) if durs else 0.0,
+                "p90_us": round(_p90(durs), 3),
+                "max_us": round(max(durs), 3) if durs else 0.0,
+                "avg_wavefronts": round(sum(d.wavefronts for d in real) / len(real), 1)
+                if real
+                else 0,
+                "avg_threads": round(sum(d.threads for d in real) / len(real), 1)
+                if real
+                else 0,
+                "workgroup": ds[0].workgroup,
+                "vgpr": ds[0].vgpr,
+                "sgpr": ds[0].sgpr,
+                "lds": ds[0].lds,
+                "occ_pct": ds[0].occ_pct,
+                "occ_limiter": ds[0].occ_limiter,
+                "bound_class": _dominant(d.bound_class for d in real),
+                "avg_mem_gbps": round(sum(mem) / len(mem), 2) if mem else 0.0,
+                "pc": hex(ds[0].pc),
+            }
+        )
+    rows.sort(key=lambda r: r["total_us"], reverse=True)
+    return rows
+
+
+def aggregate_families(trace: Trace):
+    """Roll up dispatches by (family, dtype, tile) so GEMM tile variants and every
+    instance of an op collapse into one row -- 'where does GPU time go by op'."""
+    groups: dict[tuple, list] = {}
+    for d in trace.dispatches:
+        groups.setdefault((d.family, d.dtype, d.tile), []).append(d)
+    busy = trace.gpu_busy_us() or 1.0
+
+    rows = []
+    for (family, dtype, tile), ds in groups.items():
+        real = [d for d in ds if not d.is_artifact and d.dur_us > 0]
+        durs = [d.dur_us for d in real]
+        total = sum(durs)
+        mem = [d.mem_gbps for d in real if d.mem_gbps > 0]
+        occ = [d.occ_pct for d in real if d.occ_pct]
+        rows.append(
+            {
+                "family": family or "(unknown)",
+                "dtype": dtype,
+                "tile": tile,
+                "library": _dominant(d.library for d in ds),
+                "label": _dominant(d.label for d in ds),
+                "count": len(ds),
+                "total_us": round(total, 3),
+                "pct_gpu": round(100.0 * total / busy, 2),
+                "mean_us": round(total / len(durs), 3) if durs else 0.0,
+                "occ_pct": round(sum(occ) / len(occ), 1) if occ else 0.0,
+                "occ_limiter": _dominant(d.occ_limiter for d in real),
+                "bound_class": _dominant(d.bound_class for d in real),
+                "avg_mem_gbps": round(sum(mem) / len(mem), 2) if mem else 0.0,
+            }
+        )
+    rows.sort(key=lambda r: r["total_us"], reverse=True)
+    return rows
+
+
+def write(trace: Trace, path: str) -> None:
+    rows = aggregate(trace)
+    with open(path, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=FIELDS)
+        w.writeheader()
+        w.writerows(rows)
+
+
+def write_families(trace: Trace, path: str) -> None:
+    rows = aggregate_families(trace)
+    with open(path, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=FAMILY_FIELDS)
+        w.writeheader()
+        w.writerows(rows)

--- a/tools/rgp_parser/rgp_parser/format/summary.py
+++ b/tools/rgp_parser/rgp_parser/format/summary.py
@@ -1,0 +1,176 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""summary.{md,json} - compact, AI-primary overview of a capture.
+
+High signal-per-token: capture metadata + top-N kernels rolled up. Small enough to
+drop into a prompt, which is what 'analyze this trace' usually needs. ``write``
+emits Markdown and a companion ``.json`` beside it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+from ..model import Trace
+from . import operators
+
+TOP_N = 25
+
+
+def _bottleneck_rollup(trace: Trace) -> list:
+    """Time + count grouped by bound_class over real dispatches, descending."""
+    busy = trace.gpu_busy_us() or 1.0
+    agg: dict[str, list] = {}
+    for d in trace.dispatches:
+        if d.is_artifact or d.dur_us <= 0:
+            continue
+        cls = d.bound_class or "(unclassified)"
+        cur = agg.setdefault(cls, [0.0, 0])
+        cur[0] += d.dur_us
+        cur[1] += 1
+    rows = [
+        {
+            "class": cls,
+            "total_us": round(t, 3),
+            "count": n,
+            "pct_gpu": round(100.0 * t / busy, 1),
+        }
+        for cls, (t, n) in agg.items()
+    ]
+    rows.sort(key=lambda r: r["total_us"], reverse=True)
+    return rows
+
+
+def build(trace: Trace, top_n: int = TOP_N) -> dict:
+    ops = operators.aggregate(trace)
+    fams = operators.aggregate_families(trace)
+    busy = trace.gpu_busy_us()
+    wall = trace.wall_span_us()
+    n_art = sum(1 for d in trace.dispatches if d.is_artifact)
+    gaps = trace.idle_gaps(top_n)
+    total_idle = round(sum(d.idle_after_us for d in trace.dispatches), 3)
+    overhead_us = round(
+        sum(
+            d.dur_us
+            for d in trace.dispatches
+            if d.bound_class == "overhead" and not d.is_artifact
+        ),
+        3,
+    )
+    return {
+        "source": trace.meta.source,
+        "gpu": trace.meta.extra.get("asic", ""),
+        "shader_engines": trace.meta.shader_engines,
+        "wave_size": trace.meta.wave_size,
+        "queues": [f"me{m}/pipe{p}" for m, p in trace.meta.queues],
+        "spm": trace.meta.extra.get("spm", ""),
+        "dispatch_count": len(trace.dispatches),
+        "artifact_count": n_art,
+        "gpu_busy_us": round(busy, 3),
+        "wall_span_us": round(wall, 3),
+        # clamp to [0, 100]: busy can exceed wall when dispatches overlap across
+        # queues (or on bad decode data), which would otherwise give a nonsense %.
+        "gpu_idle_pct": round(min(100.0, max(0.0, 100.0 * (1 - busy / wall))), 1)
+        if wall > 0
+        else 0.0,
+        "total_idle_us": total_idle,
+        "overhead_us": overhead_us,
+        "distinct_kernels": len(ops),
+        "distinct_families": len(fams),
+        "bottleneck_classes": _bottleneck_rollup(trace),
+        "top_idle_gaps": gaps,
+        "top_families": fams[:top_n],
+        "top_kernels": ops[:top_n],
+    }
+
+
+def _md(s: dict) -> str:
+    lines = [
+        "# RGP capture summary",
+        "",
+        f"- **source**: `{s['source']}`",
+        f"- **shader engines**: {s['shader_engines']}  |  **wave size**: {s['wave_size']}",
+        f"- **queues**: {', '.join(s['queues']) or '-'}",
+        f"- **dispatches**: {s['dispatch_count']} ({s['artifact_count']} artifacts)",
+        f"- **GPU busy**: {s['gpu_busy_us']:.1f} us  |  **wall span**: {s['wall_span_us']:.1f} us"
+        f"  |  **idle**: {s['gpu_idle_pct']:.1f}% ({s['total_idle_us']:.1f} us)",
+        f"- **launch/overhead time**: {s['overhead_us']:.1f} us",
+        f"- **distinct kernels**: {s['distinct_kernels']}  |  **distinct families**: {s['distinct_families']}",
+        f"- **SPM**: {s['spm'] or 'n/a'}",
+    ]
+
+    # --- bottleneck classification -------------------------------------------
+    lines += [
+        "",
+        "## Bottleneck classification (by GPU time)",
+        "",
+        "| class | total us | % gpu | count |",
+        "|---|---:|---:|---:|",
+    ]
+    for b in s["bottleneck_classes"]:
+        lines.append(
+            f"| {b['class']} | {b['total_us']:.1f} | {b['pct_gpu']:.1f} | {b['count']} |"
+        )
+
+    # --- idle gaps ------------------------------------------------------------
+    lines += [
+        "",
+        f"## Top {len(s['top_idle_gaps'])} idle gaps (GPU bubbles)",
+        "",
+        "| start us | dur us | preceding -> following | queue |",
+        "|---:|---:|---|---|",
+    ]
+    for g in s["top_idle_gaps"]:
+        lines.append(
+            f"| {g['start_us']:.1f} | {g['dur_us']:.1f} | "
+            f"`{g['prev_label']}` -> `{g['next_label']}` | {g['queue']} |"
+        )
+
+    # --- family rollup --------------------------------------------------------
+    lines += [
+        "",
+        f"## Top {len(s['top_families'])} op families by GPU time",
+        "",
+        "| family | dtype | tile | count | total us | % gpu | mean us | occ % | limiter | bound | mem GB/s |",
+        "|---|---|---|---:|---:|---:|---:|---:|---|---|---:|",
+    ]
+    for k in s["top_families"]:
+        lines.append(
+            f"| {k['family']} | {k['dtype'] or '-'} | {k['tile'] or '-'} | "
+            f"{k['count']} | {k['total_us']:.1f} | {k['pct_gpu']:.1f} | "
+            f"{k['mean_us']:.2f} | {k['occ_pct']:.0f} | {k['occ_limiter'] or '-'} | "
+            f"{k['bound_class'] or '-'} | "
+            f"{k['avg_mem_gbps'] if k['avg_mem_gbps'] else '-'} |"
+        )
+
+    # --- per-kernel detail ----------------------------------------------------
+    lines += [
+        "",
+        f"## Top {len(s['top_kernels'])} kernels by GPU time",
+        "",
+        "| kernel | count | total us | % gpu | mean us | max us | avg wf | occ % | limiter | bound |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---|---|",
+    ]
+    for k in s["top_kernels"]:
+        lines.append(
+            f"| `{k['kernel']}` | {k['count']} | {k['total_us']:.1f} | "
+            f"{k['pct_gpu']:.1f} | {k['mean_us']:.2f} | {k['max_us']:.2f} | "
+            f"{k['avg_wavefronts']} | {k['occ_pct']:.0f} | {k['occ_limiter'] or '-'} | "
+            f"{k['bound_class'] or '-'} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def write(trace: Trace, path: str) -> None:
+    s = build(trace)
+    if path.endswith(".json"):
+        json_path, md_path = path, os.path.splitext(path)[0] + ".md"
+    else:
+        md_path, json_path = path, os.path.splitext(path)[0] + ".json"
+    with open(md_path, "w") as f:
+        f.write(_md(s))
+    with open(json_path, "w") as f:
+        json.dump(s, f, indent=2)

--- a/tools/rgp_parser/rgp_parser/kernelinfo.py
+++ b/tools/rgp_parser/rgp_parser/kernelinfo.py
@@ -1,0 +1,214 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""Decode a (already simplified/demangled) kernel name into structured fields.
+
+Two symbol shapes dominate a HIP LLM capture and both encode the tuning config in
+the name; :func:`parse_kernel_name` normalizes them (plus a generic fallback) into
+a :class:`KernelInfo` so formatters can group by op *family* / dtype / tile instead
+of the raw 200-char string:
+
+- Tensile / hipBLASLt GEMMs, e.g.
+  ``Cijk_Ailk_Bljk_HHS_BH_Bias_..._MT128x48x32_MI16x16x1_..._WG64_2_1_..._ISA1151``
+  -> library ``tensile``, family ``gemm``, dtype ``f16``, tile ``128x48x32``,
+  mi ``16x16x1``, workgroup ``64x2``, arch ``gfx1151``, label ``hgemm 128x48x32
+  wmma16x16 wg64x2 +bias``.
+- First-party HIP kernels (demangled), e.g. ``rope_kernel<__half>``,
+  ``gqa_flash_prefill_v5_kernel<1, 32, 64>``, ``matmul_nbits_gemv_dp4a_kernel<64, 8>``
+  -> library ``hip``, family from the base (``_kernel`` stripped), dtype from the
+  type template arg, config from the numeric template args.
+
+Pure string parsing (no capture / HIP needed), so it is unit-testable in isolation.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+
+@dataclass
+class KernelInfo:
+    library: str = "other"  # tensile | hip | other | unknown
+    family: str = ""  # normalized op family, e.g. gemm, rope, gqa_flash_prefill
+    dtype: str = ""  # f16 | bf16 | f32 | i8 | ... ("" if undetermined)
+    tile: str = ""  # macro tile "MxNxK" (tensile) or ""
+    mi: str = ""  # matrix-instruction "MxNxK" (tensile) or ""
+    workgroup: str = ""  # workgroup dims "XxY" (tensile) or ""
+    arch: str = ""  # e.g. gfx1151
+    gsu: str = ""  # split-K / global-split-U hint ("" if none)
+    flags: list = field(default_factory=list)  # e.g. ["bias"]
+    params: dict = field(default_factory=dict)  # raw extracted fields
+    label: str = ""  # short human-readable label
+
+
+# Tensile precision code -> input dtype (first char is the A/B operand type).
+_TENSILE_DTYPE = {
+    "H": "f16",
+    "S": "f32",
+    "B": "bf16",
+    "D": "f64",
+    "I": "i8",
+    "C": "c32",
+    "Z": "c64",
+}
+# GEMM label prefix by dtype.
+_GEMM_PREFIX = {
+    "f16": "hgemm",
+    "f32": "sgemm",
+    "f64": "dgemm",
+    "bf16": "bf16 gemm",
+    "i8": "i8 gemm",
+}
+# C++ type spellings (as they appear in demangled template args) -> dtype tag.
+_CPP_DTYPE = {
+    "__half": "f16",
+    "_Float16": "f16",
+    "half": "f16",
+    "__hip_bfloat16": "bf16",
+    "__bf16": "bf16",
+    "hip_bfloat16": "bf16",
+    "float": "f32",
+    "double": "f64",
+    "int8_t": "i8",
+    "signed char": "i8",
+    "char": "i8",
+    "uint8_t": "u8",
+    "unsigned char": "u8",
+    "short": "i16",
+    "int": "i32",
+    "unsigned int": "u32",
+    "long": "i64",
+    "long long": "i64",
+    "unsigned long": "u64",
+}
+
+
+def _parse_tensile(name: str) -> KernelInfo:
+    info = KernelInfo(library="tensile", family="gemm")
+    p: dict = {}
+
+    # precision code: the token right after the two contraction-index groups,
+    # e.g. Cijk_Ailk_Bljk_HHS_...  -> "HHS"
+    m = re.match(r"^Cijk_[A-Za-z]+_[A-Za-z]+_([A-Z0-9]{2,4})(?:_|$)", name)
+    code = m.group(1) if m else ""
+    if code:
+        p["type_code"] = code
+        info.dtype = _TENSILE_DTYPE.get(code[0], "")
+
+    def grab(pat, key):
+        mm = re.search(pat, name)
+        if mm:
+            p[key] = mm.group(1)
+        return mm
+
+    if grab(r"_MT(\d+x\d+x\d+)", "mt"):
+        info.tile = p["mt"]
+    if grab(r"_MI(\d+x\d+x\d+(?:x\d+)?)", "mi"):
+        info.mi = p["mi"]
+    mwg = re.search(r"_WG(\d+)_(\d+)_(\d+)", name)
+    if mwg:
+        info.workgroup = f"{mwg.group(1)}x{mwg.group(2)}"
+        p["wg"] = f"{mwg.group(1)}_{mwg.group(2)}_{mwg.group(3)}"
+    misa = re.search(r"_ISA(\d+)", name)
+    if misa:
+        info.arch = "gfx" + misa.group(1)
+        p["isa"] = misa.group(1)
+    # split-K / global-split-U: GSU token present and an explicit _SK<n> with n>0.
+    msk = re.search(r"_SK(\d+)", name)
+    if "GSU" in name and msk and msk.group(1) != "0":
+        info.gsu = msk.group(1)
+    if "_Bias" in name:
+        info.flags.append("bias")
+
+    info.params = p
+    # readable label
+    prefix = _GEMM_PREFIX.get(info.dtype, "gemm")
+    parts = [prefix]
+    if info.tile:
+        parts.append(info.tile)
+    if info.mi:
+        mm = info.mi.split("x")
+        parts.append(f"wmma{mm[0]}x{mm[1]}")
+    if info.workgroup:
+        parts.append("wg" + info.workgroup)
+    label = " ".join(parts)
+    if info.gsu:
+        label += f" gsu{info.gsu}"
+    if "bias" in info.flags:
+        label += " +bias"
+    info.label = label
+    return info
+
+
+def _split_targs(targs: str) -> list:
+    """Split top-level template args, respecting nested <>/()."""
+    out, depth, cur = [], 0, ""
+    for ch in targs:
+        if ch in "<(":
+            depth += 1
+        elif ch in ")>":
+            depth -= 1
+        if ch == "," and depth == 0:
+            out.append(cur.strip())
+            cur = ""
+        else:
+            cur += ch
+    if cur.strip():
+        out.append(cur.strip())
+    return out
+
+
+def _parse_hip(name: str) -> KernelInfo:
+    info = KernelInfo(library="hip")
+    m = re.match(r"^([A-Za-z_][\w:]*)(?:<(.*)>)?$", name.strip())
+    if not m:
+        info.family = name
+        info.label = name
+        return info
+    base = m.group(1).split("::")[-1]
+    targs = m.group(2) or ""
+
+    family = base
+    if family.endswith("_kernel"):
+        family = family[: -len("_kernel")]
+    if family.startswith("hip_"):
+        family = family[len("hip_") :]
+    info.family = family
+
+    args = _split_targs(targs) if targs else []
+    nums, dtype = [], ""
+    for a in args:
+        if a in _CPP_DTYPE:
+            dtype = dtype or _CPP_DTYPE[a]
+        elif re.fullmatch(r"-?\d+", a):
+            nums.append(a)
+        elif a.lstrip("(").rstrip(")").lstrip("Li").rstrip("E").isdigit():
+            # itanium-demangler may keep literal wrappers like (int)1 or Li1E
+            nums.append(re.sub(r"\D", "", a))
+    info.dtype = dtype
+    if nums:
+        info.params["config"] = ",".join(nums)
+
+    label = family
+    if dtype:
+        label += f" {dtype}"
+    if nums:
+        label += f" <{','.join(nums)}>"
+    info.label = label
+    return info
+
+
+def parse_kernel_name(name: str) -> KernelInfo:
+    """Decode ``name`` (a simplified/demangled symbol) into a :class:`KernelInfo`."""
+    if not name:
+        return KernelInfo(library="unknown", family="", label="")
+    if name.startswith("0x"):  # unresolved PC
+        return KernelInfo(library="unknown", family="unresolved", label=name)
+    if name.startswith("Cijk"):
+        return _parse_tensile(name)
+    # first-party HIP / generic C++ symbol
+    if re.match(r"^[A-Za-z_]", name):
+        return _parse_hip(name)
+    return KernelInfo(library="other", family=name, label=name)

--- a/tools/rgp_parser/rgp_parser/model.py
+++ b/tools/rgp_parser/rgp_parser/model.py
@@ -1,0 +1,172 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""Normalized in-memory model shared by every formatter.
+
+The parse/decode stages populate a single :class:`Trace`; each formatter in
+``rgp_parser.format`` is a pure function of that object. Keeping one canonical
+representation means a new output format never has to re-parse the ``.rgp``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Dispatch:
+    """One GPU compute dispatch (kernel launch)."""
+
+    pc: int  # entry-point GPU virtual address
+    name: str  # symbolized kernel name (or hex PC if unresolved)
+    me: int  # micro-engine id  (queue = (me, pipe))
+    pipe: int  # pipe id
+    ts_us: float  # first-wave start, microseconds from trace start
+    launch_ts_us: float  # dispatch-initiator time (may precede ts_us)
+    dur_us: float  # wave-span duration (last wave end - first start)
+    wavefronts: int  # attributed occupancy waves
+    exp_waves: int  # marker-derived expected wave count (cross-check)
+    threads: int  # wavefronts * wave_size
+    workgroup: int  # threads per workgroup (block size)
+    vgpr: int
+    sgpr: int
+    lds: int
+    flags: int = 0
+    wave_span_us: float = -1.0  # raw occupancy wave-span (pre duration refinement)
+    occupancy_wavefronts: int = 0  # occupancy-attributed waves (cross-check vs marker)
+    counts_source: str = ""  # "Event-marker grid (exact)" | "occupancy (approx...)"
+    duration_note: str = ""
+
+    # --- decoded kernel identity (see rgp_parser.kernelinfo) -------------------
+    library: str = ""  # tensile | hip | other | unknown
+    family: str = ""  # normalized op family, e.g. gemm, rope, matmul_nbits_gemv_dp4a
+    dtype: str = ""  # f16 | bf16 | f32 | i8 | ... ("" if undetermined)
+    tile: str = ""  # macro tile "MxNxK" for GEMMs ("" otherwise)
+    label: str = ""  # short human-readable label
+
+    # --- idle-gap analysis (per queue, execution windows) ---------------------
+    gap_before_us: float = 0.0  # GPU-idle before this dispatch on its queue
+    idle_after_us: float = 0.0  # GPU-idle after this dispatch until the next one
+
+    # --- occupancy + bottleneck classification (see rgp_parser.occupancy) ------
+    occ_theoretical: int = 0  # theoretical resident waves/CU allowed by regs/LDS/WG
+    occ_pct: float = 0.0  # theoretical occupancy: % of HW max waves/CU (0 if unknown)
+    occ_limiter: str = ""  # VGPR | LDS | workgroup | "" (resource that binds)
+    bound_class: str = ""  # overhead | memory-bound | compute-bound | latency/low-occupancy | compute-or-memory (undetermined)
+    bound_reason: str = ""  # short auditable reason string
+
+    # --- per-kernel SPM memory attribution (empty unless SPM present) ----------
+    mem_bytes: float = 0.0  # attributed bytes moved over the dispatch window
+    mem_gbps: float = 0.0  # attributed memory bandwidth (GB/s); 0.0 => unavailable
+
+    @property
+    def is_artifact(self) -> bool:
+        """True when no real occupancy waves were attributed to this dispatch, so
+        its duration is a launch-gap artifact rather than measured execution time.
+        Excluded from trustworthy totals. Keyed off occupancy so an exact
+        marker-grid wavefront
+        override does not flip the classification."""
+        occ = self.occupancy_wavefronts if self.counts_source else self.wavefronts
+        return occ <= 0 or self.dur_us < 0
+
+
+@dataclass
+class Barrier:
+    name: str
+    me: int
+    pipe: int
+    ts_us: float
+    dur_us: float
+    args: dict = field(default_factory=dict)
+
+
+@dataclass
+class Event:
+    me: int
+    pipe: int
+    ts_us: float
+    type: int
+    payload: int = 0
+
+
+@dataclass
+class OccupancySample:
+    ts_us: float
+    per_se: dict = field(default_factory=dict)  # {se_index: peak alive waves}
+
+
+@dataclass
+class Curve:
+    """A counter curve for the Chrome trace (SPM or occupancy)."""
+
+    display: str  # track label, e.g. "Memory (bytes): L2 write [GB/s]"
+    key: str  # per-point arg key (short counter name)
+    series: list = field(default_factory=list)  # [(ts_us, value), ...]
+    group: str = ""
+    unit: str = ""
+
+
+@dataclass
+class CaptureMeta:
+    source: str = ""  # .rgp path
+    rt_freq_hz: int = 0  # realtime/GPU-timestamp clock
+    wave_size: int = 32
+    shader_engines: int = 0
+    queues: list = field(default_factory=list)  # sorted [(me, pipe), ...]
+    extra: dict = field(default_factory=dict)  # AsicInfo/ApiInfo/etc.
+
+
+@dataclass
+class Trace:
+    meta: CaptureMeta = field(default_factory=CaptureMeta)
+    dispatches: list[Dispatch] = field(default_factory=list)
+    barriers: list[Barrier] = field(default_factory=list)
+    events: list[Event] = field(default_factory=list)
+    occupancy: list[OccupancySample] = field(default_factory=list)
+    curves: list[Curve] = field(default_factory=list)  # SPM counter curves
+
+    def wall_span_us(self) -> float:
+        ts = [d.ts_us for d in self.dispatches] + [
+            d.ts_us + max(d.dur_us, 0.0) for d in self.dispatches
+        ]
+        return (max(ts) - min(ts)) if ts else 0.0
+
+    def gpu_busy_us(self) -> float:
+        """Sum of real (non-artifact) dispatch durations."""
+        return sum(
+            d.dur_us for d in self.dispatches if not d.is_artifact and d.dur_us > 0
+        )
+
+    def idle_gaps(self, top_n: int = 15) -> list:
+        """Top idle bubbles between consecutive real dispatches on the same queue.
+
+        Uses ``idle_after_us`` computed in build.py (execution-window gap: the next
+        dispatch's start minus this one's end). Returns descending by duration:
+        ``[{start_us, dur_us, prev_kernel, next_kernel, queue, prev_label,
+        next_label}]``.
+        """
+        real = [d for d in self.dispatches if not d.is_artifact]
+        by_q: dict = {}
+        for d in real:
+            by_q.setdefault((d.me, d.pipe), []).append(d)
+        gaps = []
+        for (me, pipe), ds in by_q.items():
+            ds.sort(key=lambda x: x.ts_us)
+            for a, b in zip(ds, ds[1:]):
+                g = b.ts_us - (a.ts_us + max(a.dur_us, 0.0))
+                if g <= 0:
+                    continue
+                gaps.append(
+                    {
+                        "start_us": round(a.ts_us + max(a.dur_us, 0.0), 3),
+                        "dur_us": round(g, 3),
+                        "prev_kernel": a.name,
+                        "next_kernel": b.name,
+                        "prev_label": a.label or a.name,
+                        "next_label": b.label or b.name,
+                        "queue": f"me{me}/pipe{pipe}",
+                    }
+                )
+        gaps.sort(key=lambda x: x["dur_us"], reverse=True)
+        return gaps[:top_n]

--- a/tools/rgp_parser/rgp_parser/occupancy.py
+++ b/tools/rgp_parser/rgp_parser/occupancy.py
@@ -1,0 +1,136 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""Static (theoretical) occupancy + bottleneck classification.
+
+Occupancy here is the *theoretical* resident-wave ceiling a kernel's own resource
+usage (VGPRs / LDS / workgroup size) allows, expressed as a percentage of the
+hardware maximum -- the same idea rocprof reports as "theoretical occupancy". It is
+derived by hand from the per-dispatch resource counts (see AMD GPUOpen "Occupancy
+explained" and the ROCm occupancy-math blog), NOT measured; a low value means the
+kernel leaves latency-hiding headroom on the table and names which resource binds.
+
+We deliberately do not infer an *achieved* per-SIMD occupancy per dispatch (SQTT
+gives total wavefronts + a global occupancy band, not a clean per-dispatch per-SIMD
+number), so this stays a resource-ceiling metric.
+
+Constants are for gfx1151 (RDNA3.5), verified against LLVM's AMDGPU backend
+(the authoritative occupancy source), traced to the exact gfx1151 feature set:
+  - Feature1536VGPRs is in FeatureISAVersion11_5_1 (gfx1151), and FeatureGFX11
+    carries FeatureAddressableLocalMemorySize65536 + FeatureGFX10_3Insts.
+  - vgpr_file_per_simd 1536 / vgpr_gran 24  -> IsaInfo::getTotalNumVGPRs /
+    getVGPRAllocGranule (Feature1536VGPRs, wave32).
+  - max_waves_per_simd 16                   -> IsaInfo::getMaxWavesPerEU
+    (hasGFX10_3Insts ? 16 : 20).
+  - simds_per_cu 2                          -> IsaInfo::getEUsPerCU (CU mode).
+  - lds_per_cu 65536 / lds_gran 512         -> getAddressableLocalMemorySize
+    (=65536) and its 128 encoding blocks (65536/128 = 512 B).
+The VGPR ceiling below mirrors IsaInfo::getNumWavesPerEUWithNumVGPRs exactly, and
+SGPRs are intentionally omitted (isSGPROccupancyLimited is false on gfx10+).
+Occupancy is theoretical (a resource ceiling), not measured.
+"""
+
+from __future__ import annotations
+
+import math
+
+# gfx1151 / RDNA3.5 occupancy limits (wave32). Verified vs LLVM IsaInfo (see above).
+GFX1151 = {
+    "max_waves_per_simd": 16,  # getMaxWavesPerEU (GFX10_3Insts)
+    "simds_per_cu": 2,  # getEUsPerCU (CU mode)
+    "vgpr_file_per_simd": 1536,  # getTotalNumVGPRs, Feature1536VGPRs (wave32)
+    "vgpr_gran": 24,  # getVGPRAllocGranule, Feature1536VGPRs (wave32)
+    "lds_per_cu": 65536,  # getAddressableLocalMemorySize (64 KB)
+    "lds_gran": 512,  # 65536 / 128 LDS encoding blocks
+    # Concurrent workgroups/CU slot limit. Set to the wave ceiling (max_waves_per_simd
+    # * simds_per_cu) so single-wave workgroups can still reach full occupancy; the
+    # real HW value is higher than needed for wave32 and only matters as an upper bound.
+    "max_wg_per_cu": 32,
+}
+
+# Classification thresholds.
+OVERHEAD_DUR_US = 3.0  # dispatches this short are launch/overhead-sensitive
+LOW_OCC_PCT = 50.0  # below this theoretical occupancy => latency-hiding headroom
+MEM_ROOF_FRAC = 0.7  # mem_gbps >= this * roofline => memory-bound
+MEM_LOW_FRAC = 0.3  # mem_gbps below this * roofline supports latency-bound call
+
+
+def _roundup(x: int, g: int) -> int:
+    return int(math.ceil(x / g) * g) if x > 0 else 0
+
+
+def theoretical_occupancy(vgpr, sgpr, lds, workgroup, wave_size=32, hw=GFX1151):
+    """Return (occ_pct, limiter, waves_per_cu).
+
+    occ_pct: theoretical resident waves as % of the hardware max waves/CU.
+    limiter: 'VGPR' | 'LDS' | 'workgroup' | '' (empty at full occupancy).
+    waves_per_cu: the theoretical resident-wave count per CU.
+    """
+    max_waves_cu = hw["max_waves_per_simd"] * hw["simds_per_cu"]
+    waves_per_wg = max(1, math.ceil(workgroup / wave_size)) if workgroup > 0 else 1
+
+    # VGPR ceiling (per SIMD -> per CU).
+    if vgpr and vgpr > 0:
+        waves_simd_vgpr = min(
+            hw["max_waves_per_simd"],
+            hw["vgpr_file_per_simd"] // max(1, _roundup(vgpr, hw["vgpr_gran"])),
+        )
+    else:
+        waves_simd_vgpr = hw["max_waves_per_simd"]
+    wg_by_vgpr = (waves_simd_vgpr * hw["simds_per_cu"]) // waves_per_wg
+
+    # LDS ceiling (per CU, shared by both SIMDs).
+    if lds and lds > 0:
+        wg_by_lds = hw["lds_per_cu"] // max(1, _roundup(lds, hw["lds_gran"]))
+    else:
+        wg_by_lds = hw["max_wg_per_cu"]
+
+    wg_by_slots = hw["max_wg_per_cu"]
+
+    cands = {"VGPR": wg_by_vgpr, "LDS": wg_by_lds, "workgroup": wg_by_slots}
+    wg_cu = max(0, min(cands.values()))
+    waves_cu = min(max_waves_cu, wg_cu * waves_per_wg)
+    occ_pct = round(100.0 * waves_cu / max_waves_cu, 1) if max_waves_cu else 0.0
+
+    limiter = min(cands, key=lambda k: cands[k])
+    if occ_pct >= 99.9:
+        limiter = ""
+    return occ_pct, limiter, waves_cu
+
+
+def classify_bound(d, *, spm_present, mem_reliable, roofline_gbps=256.0):
+    """Return (bound_class, bound_reason) for a dispatch.
+
+    Degraded (no/unreliable SPM) value space: overhead | latency/low-occupancy |
+    'compute-or-memory (undetermined)'. Full (SPM present + reliable) adds real
+    memory-bound / compute-bound. We never fabricate a bandwidth to force the call.
+    """
+    dur = d.dur_us
+    # overhead-bound: tiny kernel dominated by the idle gap around it.
+    if 0 < dur < OVERHEAD_DUR_US and d.gap_before_us > dur:
+        return "overhead", f"dur {dur:.1f}us < gap {d.gap_before_us:.1f}us"
+
+    occ = d.occ_pct
+    occ_note = (
+        f"occ {occ:.0f}% {d.occ_limiter}-limited"
+        if d.occ_limiter
+        else f"occ {occ:.0f}%"
+    )
+
+    if spm_present and mem_reliable and d.mem_gbps > 0:
+        frac = d.mem_gbps / roofline_gbps if roofline_gbps else 0.0
+        if frac >= MEM_ROOF_FRAC:
+            return "memory-bound", f"mem {d.mem_gbps:.0f} GB/s ({frac * 100:.0f}% roof)"
+        if occ and occ < LOW_OCC_PCT and frac < MEM_LOW_FRAC:
+            return "latency/low-occupancy", f"{occ_note}, mem {d.mem_gbps:.0f} GB/s"
+        return (
+            "compute-bound",
+            f"mem {d.mem_gbps:.0f} GB/s ({frac * 100:.0f}% roof), {occ_note}",
+        )
+
+    # SPM absent or per-kernel BW not trustworthy: no memory-vs-compute call.
+    if occ and occ < LOW_OCC_PCT:
+        return "latency/low-occupancy", occ_note
+    reason = "no SPM" if not spm_present else "SPM window too short"
+    return "compute-or-memory (undetermined)", reason

--- a/tools/rgp_parser/rgp_parser/struct/__init__.py
+++ b/tools/rgp_parser/rgp_parser/struct/__init__.py
@@ -1,0 +1,9 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""Binary parsers for the RGP/RDF container and its chunks.
+
+Imported as ``rgp_parser.struct`` (never as top-level ``struct``), so it does not
+shadow the Python standard-library ``struct`` module that these parsers rely on.
+"""

--- a/tools/rgp_parser/rgp_parser/struct/codeobject.py
+++ b/tools/rgp_parser/rgp_parser/struct/codeobject.py
@@ -1,0 +1,66 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""CodeObject chunks: AMDGPU ELF code objects carrying kernel symbols.
+
+Each ``CodeObject`` chunk's data is an AMDGPU ELF. Its ``.symtab`` STT_FUNC symbols
+give kernel entry offsets; combined with a load base (see :mod:`coload`) they map a
+dispatch PC to a kernel name.
+"""
+
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass
+
+from .rdf import RdfFile
+
+
+@dataclass
+class Symbol:
+    value: int  # st_value (offset within the code object)
+    size: int  # st_size (0x100 fallback when the ELF reports 0)
+    name: str
+
+
+def parse_functions(elf_bytes: bytes) -> list[tuple[int, int, str]]:
+    """Return sorted (value, size, name) for STT_FUNC symbols in one CO ELF."""
+    from elftools.elf.elffile import ELFFile
+
+    fns: list[tuple[int, int, str]] = []
+    try:
+        ef = ELFFile(io.BytesIO(elf_bytes))
+        st = ef.get_section_by_name(".symtab") or ef.get_section_by_name(".dynsym")
+        if st is None:
+            return fns
+        for s in st.iter_symbols():
+            if s["st_info"]["type"] != "STT_FUNC":
+                continue
+            name = s.name
+            if not name or name.startswith("__hip_cuid"):
+                continue
+            fns.append((s["st_value"], s["st_size"] or 0x100, name))
+    except Exception:
+        return fns
+    return sorted(fns)
+
+
+def load_code_objects(rdf: RdfFile) -> list[list[tuple[int, int, str]]]:
+    """Per-CodeObject list of STT_FUNC (value, size, name) tuples, in chunk order."""
+    return [parse_functions(rdf.data(c)) for c in rdf.by_id("CodeObject")]
+
+
+def load_code_objects_hashed(
+    rdf: RdfFile,
+) -> list[tuple[bytes, list[tuple[int, int, str]]]]:
+    """Per-CodeObject (16-byte header hash, STT_FUNC tuples).
+
+    The CodeObject chunk header carries the same 16-byte hash as its COLoadEvent
+    record (at header offset +8), enabling deterministic hash->base pairing."""
+    out = []
+    for c in rdf.by_id("CodeObject"):
+        hdr = rdf.raw_header(c)
+        h = hdr[8:24] if len(hdr) >= 24 else b""
+        out.append((h, parse_functions(rdf.data(c))))
+    return out

--- a/tools/rgp_parser/rgp_parser/struct/coload.py
+++ b/tools/rgp_parser/rgp_parser/struct/coload.py
@@ -1,0 +1,70 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""COLoadEvent chunk: code-object load records (GPU-VA load bases).
+
+Layout reverse-engineered and verified on real captures (NOT in the libamdrdf
+spec, so this is the least stable parser): a chunk-header record count followed by
+N x 40-byte records::
+
+    [+0  u64 id = 0x00C40000]
+    [+8  u64 GPU_VA_base]        <- SQTT dispatch PCs are GPU virtual addresses
+    [+16 16B hash]
+    [+32 u64 host_loader_base]
+
+Only the GPU-VA base is needed to place a code object's symbols in the PC space.
+"""
+
+from __future__ import annotations
+
+import struct
+
+from .rdf import RdfFile
+
+_RECORD_SIZE = 40
+
+
+def parse_bases(header: bytes, data: bytes) -> list[int]:
+    """Distinct GPU-VA load bases, in record order (dedup preserves first-seen)."""
+    n = (
+        struct.unpack_from("<I", header, 0)[0]
+        if len(header) >= 4
+        else len(data) // _RECORD_SIZE
+    )
+    n = min(n, len(data) // _RECORD_SIZE)
+    bases = [struct.unpack_from("<Q", data, r * _RECORD_SIZE + 8)[0] for r in range(n)]
+    seen, out = set(), []
+    for b in bases:
+        if b not in seen:
+            seen.add(b)
+            out.append(b)
+    return out
+
+
+def load_bases(rdf: RdfFile) -> list[int]:
+    chunks = rdf.by_id("COLoadEvent")
+    if not chunks:
+        return []
+    c = chunks[0]
+    return parse_bases(rdf.raw_header(c), rdf.data(c))
+
+
+def parse_hash_bases(data: bytes) -> dict[bytes, int]:
+    """{16-byte code-object hash -> GPU-VA load base} from the COLoadEvent records.
+
+    Enables deterministic CodeObject<->base pairing (each CodeObject chunk header
+    carries the same 16-byte hash), avoiding the coverage/greedy heuristic."""
+    out: dict[bytes, int] = {}
+    for r in range(len(data) // _RECORD_SIZE):
+        o = r * _RECORD_SIZE
+        base = struct.unpack_from("<Q", data, o + 8)[0]
+        out[data[o + 16 : o + 32]] = base
+    return out
+
+
+def load_hash_bases(rdf: RdfFile) -> dict[bytes, int]:
+    chunks = rdf.by_id("COLoadEvent")
+    if not chunks:
+        return {}
+    return parse_hash_bases(rdf.data(chunks[0]))

--- a/tools/rgp_parser/rgp_parser/struct/rdf.py
+++ b/tools/rgp_parser/rgp_parser/struct/rdf.py
@@ -1,0 +1,100 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""AMD_RDF (Radeon Data File) container parser.
+
+A ``.rgp`` capture is an RDF container: a 32-byte header, chunk data blobs, and a
+64-byte-per-entry chunk index. Layout verified against the libamdrdf spec
+(GPUOpen-Drivers/libamdrdf, docs/specification.md).
+"""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass
+
+_HEADER = struct.Struct("<8sIIqq")  # magic, version, reserved, indexOff, indexSize
+_MAGIC = b"AMD_RDF "
+_ENTRY_SIZE = 64
+
+
+@dataclass
+class Chunk:
+    identifier: str
+    version: int
+    compression: int  # 0 = raw, 1 = Zstd
+    header_off: int
+    header_size: int
+    data_off: int
+    data_size: int
+    uncompressed_size: int
+
+
+class RdfFile:
+    """Parsed RDF container. Holds the whole blob in memory and lazily returns
+    chunk header/data (inflating Zstd on demand)."""
+
+    def __init__(self, blob: bytes):
+        magic, self.version, _reserved, ioff, isize = _HEADER.unpack_from(blob, 0)
+        if magic != _MAGIC:
+            raise ValueError(f"not an RDF file: bad magic {magic!r}")
+        self._blob = blob
+        self.chunks: list[Chunk] = []
+        for i in range(isize // _ENTRY_SIZE):
+            base = ioff + i * _ENTRY_SIZE
+            cid = struct.unpack_from("<16s", blob, base)[0].split(b"\x00", 1)[0]
+            compression = blob[base + 16]
+            cver = struct.unpack_from("<I", blob, base + 20)[0]
+            hoff, hsize, doff, dsize, usize = struct.unpack_from(
+                "<qqqqq", blob, base + 24
+            )
+            self.chunks.append(
+                Chunk(
+                    identifier=cid.decode("utf-8", "replace"),
+                    version=cver,
+                    compression=compression,
+                    header_off=hoff,
+                    header_size=hsize,
+                    data_off=doff,
+                    data_size=dsize,
+                    uncompressed_size=usize,
+                )
+            )
+
+    @classmethod
+    def from_path(cls, path: str) -> "RdfFile":
+        with open(path, "rb") as f:
+            return cls(f.read())
+
+    def raw_header(self, chunk: Chunk) -> bytes:
+        return self._blob[chunk.header_off : chunk.header_off + chunk.header_size]
+
+    def raw_data(self, chunk: Chunk) -> bytes:
+        return self._blob[chunk.data_off : chunk.data_off + chunk.data_size]
+
+    def data(self, chunk: Chunk) -> bytes:
+        """Chunk data, inflated if Zstd-compressed."""
+        raw = self.raw_data(chunk)
+        if chunk.compression == 0:
+            return raw
+        if chunk.compression == 1:
+            try:
+                import zstandard as zstd
+            except ImportError as e:
+                raise RuntimeError(
+                    "chunk is Zstd-compressed; `pip install zstandard`"
+                ) from e
+            return zstd.ZstdDecompressor().decompress(
+                raw, max_output_size=chunk.uncompressed_size or 0
+            )
+        raise ValueError(f"unknown compression {chunk.compression}")
+
+    def by_id(self, identifier: str) -> list[Chunk]:
+        return [c for c in self.chunks if c.identifier == identifier]
+
+    def counts(self) -> dict[str, int]:
+        out: dict[str, int] = {}
+        for c in self.chunks:
+            out[c.identifier] = out.get(c.identifier, 0) + 1
+        return out

--- a/tools/rgp_parser/rgp_parser/struct/spm.py
+++ b/tools/rgp_parser/rgp_parser/struct/spm.py
@@ -1,0 +1,416 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""Decode the SPM (streaming perf counter) chunks from an RGP .rgp capture.
+
+Self-contained SPM counter decode (no external dependency).
+
+The capture stores SPM in the RDF trace-source format:
+  - SpmSession chunk: header {pciId, flags, samplingInterval, numTimestamps,
+    numSpmCounters} in the RDF *header* region; data region = u64 timestamps[].
+  - SpmCounterData chunks (one per counter): header {pciId, gpuBlock, blockInstance,
+    eventIndex, dataSize} in the header region; data region = dataSize-byte samples[].
+
+Counters are raw hardware (block, instance, eventIndex). RGP selected its own raw
+hardware event selects, which only partially match rocprofiler's named XML - so we
+name what matches and additionally compute memory-bandwidth curves from the GL2C EA
+request counters (which DO match). See README "SPM counters" for the honest scope.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import struct
+
+# Pal::GpuBlock enum -> name. The SpmCounterData chunk stores the block as Pal::GpuBlock
+# (pal/inc/core/palPerfExperiment.h), which the SpmGpuBlock enum mirrors 1:1
+# (pal/shared/inc/sqtt_file_format.h). Verified against both.
+GPU_BLOCK = {
+    0: "CPF",
+    1: "IA",
+    2: "VGT",
+    3: "PA",
+    4: "SC",
+    5: "SPI",
+    6: "SQ",
+    7: "SX",
+    8: "TA",
+    9: "TD",
+    10: "TCP",
+    11: "TCC",
+    12: "TCA",
+    13: "DB",
+    14: "CB",
+    15: "GDS",
+    16: "SRBM",
+    17: "GRBM",
+    18: "GRBMSE",
+    19: "RLC",
+    20: "DMA",
+    21: "MC",
+    22: "CPG",
+    23: "CPC",
+    24: "WD",
+    25: "TCS",
+    26: "ATC",
+    27: "ATCL2",
+    28: "MCVML2",
+    29: "EA",
+    30: "RPB",
+    31: "RMI",
+    32: "UMCCH",
+    33: "GE",
+    34: "GL1A",
+    35: "GL1C",
+    36: "GL1CG",
+    37: "GL2A",
+    38: "GL2C",
+    39: "CHA",
+    40: "CHC",
+    41: "CHCG",
+    42: "GUS",
+    43: "GCR",
+    44: "PH",
+    45: "UTCL1",
+    46: "GEDIST",
+    47: "GESE",
+    48: "DFMALL",
+    49: "SQWGP",
+    50: "PC",
+}
+
+# RDF chunk versions this parser was verified against (pal gpuPerfExperimentTraceSource.h:
+# SpmSessionChunkVersion / SpmCounterDataChunkVersion). A different version may reorder
+# header fields, so we warn rather than silently misparse.
+SPM_SESSION_VER = 2
+SPM_COUNTER_VER = 2
+
+
+def _walk_chunks(blob):
+    # AMD_RDF: 32-byte file header, then 64-byte IndexEntry[] (libamdrdf spec).
+    # IndexEntry: chunkIdentifier[16], compression+reserved (4B), version@20 (u32),
+    # then chunkHeader/Data offset+size (5x i64) @24.
+    _, ver, _, ioff, isz = struct.unpack_from("<8sIIqq", blob, 0)
+    for i in range(isz // 64):
+        b = ioff + i * 64
+        cid = (
+            struct.unpack_from("<16s", blob, b)[0]
+            .split(b"\x00", 1)[0]
+            .decode("utf-8", "replace")
+        )
+        cver = struct.unpack_from("<I", blob, b + 20)[0]
+        ho, hs, do, ds, us = struct.unpack_from("<qqqqq", blob, b + 24)
+        yield cid, cver, blob[ho : ho + hs], blob[do : do + ds]
+
+
+def parse_spm(rgp_path):
+    """Return {interval, timestamps:[u64], counters:[{block,name,instance,event,samples}]}
+    or None if the capture has no SPM."""
+    blob = open(rgp_path, "rb").read()
+    session = None
+    counters = []
+    ts_freq_hz = None
+    for cid, cver, hdr, data in _walk_chunks(blob):
+        if cid == "AsicInfo" and len(data) >= 32:
+            # TraceChunk::AsicInfo (pal asicInfoTraceSource.h) lives in the chunk DATA
+            # region (its header is empty): u32 pciId + 4B pad, then u64 shaderCoreClock,
+            # u64 memoryClock, u64 gpuTimestampFrequency @24. Verified: @24 = 100 MHz.
+            f = struct.unpack_from("<Q", data, 24)[0]
+            if 1e6 <= f <= 1e10:
+                ts_freq_hz = f
+        if cid == "SpmSession" and len(hdr) >= 20:
+            if cver != SPM_SESSION_VER:
+                print(
+                    "WARNING: SpmSession chunk version %d != expected %d; header layout "
+                    "may differ (verified against v%d)."
+                    % (cver, SPM_SESSION_VER, SPM_SESSION_VER)
+                )
+            pci, flags, interval, nts, ncnt = struct.unpack_from("<IIIII", hdr, 0)
+            ts = (
+                list(struct.unpack_from("<%dQ" % nts, data, 0))
+                if len(data) >= nts * 8
+                else []
+            )
+            session = {"interval": interval, "timestamps": ts, "numCounters": ncnt}
+        elif cid == "SpmCounterData" and len(hdr) >= 20:
+            if cver != SPM_COUNTER_VER:
+                print(
+                    "WARNING: SpmCounterData chunk version %d != expected %d; header layout "
+                    "may differ (verified against v%d)."
+                    % (cver, SPM_COUNTER_VER, SPM_COUNTER_VER)
+                )
+            pci, block, inst, evt, dsz = struct.unpack_from("<IIIII", hdr, 0)
+            n = len(data) // max(dsz, 1)
+            fmt = {1: "B", 2: "H", 4: "I"}.get(dsz, "H")
+            samples = struct.unpack_from("<%d%s" % (n, fmt), data, 0)
+            counters.append(
+                {
+                    "block": block,
+                    "blockname": GPU_BLOCK.get(block, str(block)),
+                    "instance": inst,
+                    "event": evt,
+                    "samples": samples,
+                }
+            )
+    if session is None:
+        return None
+    session["counters"] = counters
+    session["ts_freq_hz"] = ts_freq_hz  # from AsicInfo; None if chunk absent
+    return session
+
+
+def mem_traffic_summary(spm, ea_bytes_per_req=64, roofline_gbps=256.0):
+    """Honest whole-capture average of the EA ev55 unified-memory traffic.
+
+    Returns None if EA ev55 absent. The AVERAGE is physically sane (unlike per-sample
+    peaks, which exceed the roofline - see spm_curves). Reported as an order-of-
+    magnitude estimate, not a calibrated bandwidth."""
+    if not spm or not spm.get("timestamps"):
+        return None
+    ts = spm["timestamps"]
+    freq = (
+        spm.get("ts_freq_hz") or 1e8
+    )  # AsicInfo gpuTimestampFrequency; 100 MHz fallback
+    dur_s = (ts[-1] - ts[0]) / freq
+    if dur_s <= 0:
+        return None
+    tot = 0
+    for c in spm["counters"]:
+        if c["blockname"] == "EA" and c["event"] == 55:
+            tot += sum(c["samples"])
+    if tot == 0:
+        return None
+    gbps = tot * ea_bytes_per_req / dur_s / 1e9
+    return {
+        "total_req": tot,
+        "window_ms": dur_s * 1e3,
+        "avg_gbps": gbps,
+        "pct_roofline": 100.0 * gbps / roofline_gbps if roofline_gbps else None,
+        "bytes_per_req": ea_bytes_per_req,
+    }
+
+
+def ea_request_series(spm, anchor_us=0.0):
+    """Full-resolution EA ev55 unified-memory *request counts* per sample, for
+    per-kernel attribution: returns (ts_us, req_counts) at the raw SPM cadence.
+
+    Returns raw request COUNTS (not per-sample GB/s) on purpose: the correct
+    per-kernel bandwidth is total requests-in-window * bytes / window-time (the same
+    conservation argument that makes the whole-capture average trustworthy). The
+    per-sample GB/s value is meaningless here -- EA samples are bursty arbiter
+    *arrivals* that queue and drain, so single samples routinely exceed the roofline.
+    Returns ([], []) if EA ev55 is absent.
+    """
+    if not spm or not spm.get("timestamps"):
+        return [], []
+    ts = spm["timestamps"]
+    freq = spm.get("ts_freq_hz")
+    ticks_per_us = freq / 1e6 if freq else 100.0
+    ts_us = [anchor_us + (t - ts[0]) / ticks_per_us for t in ts]
+    ea = None
+    for c in spm["counters"]:
+        if c["blockname"] == "EA" and c["event"] == 55:
+            s = c["samples"]
+            if ea is None:
+                ea = list(s)
+            else:
+                for i in range(min(len(ea), len(s))):
+                    ea[i] += s[i]
+    if ea is None:
+        return [], []
+    return ts_us, list(ea)
+
+
+def _load_xml_names(rocprof_xml):
+    """(blockName, eventId) -> counterName from basic_counters.xml <gfx11>."""
+    if not rocprof_xml or not os.path.exists(rocprof_xml):
+        return {}
+    txt = open(rocprof_xml, encoding="utf-8", errors="replace").read()
+    m = re.search(r"<gfx11>(.*?)</gfx11>", txt, re.S)
+    seg = m.group(1) if m else ""
+    out = {}
+    for mm in re.finditer(r'name="([^"]+)"\s+block=(\w+)\s+event=(\d+)', seg):
+        out[(mm.group(2), int(mm.group(3)))] = mm.group(1)
+    return out
+
+
+def _median(xs):
+    s = sorted(xs)
+    m = len(s)
+    return s[m // 2] if m else 0
+
+
+def _downsample(ts_us, values, nsamp, reduce="max"):
+    """Bucket a series into nsamp (ts_us, value) points.
+
+    reduce="max"  -> bucket PEAK: matches RGP's curve display and preserves bursty
+                     raw-counter activity (SPM counters are near-zero with spikes).
+    reduce="median" -> robust sustained value: use for derived bandwidth, where rare
+                     single-sample spikes are decode artifacts (a 90k-req sample would
+                     imply TB/s) that must not dominate the GB/s reading.
+    reduce="mean" -> bucket average.
+    """
+    if not ts_us:
+        return []
+    red = {"max": max, "median": _median, "mean": lambda xs: sum(xs) / len(xs)}[reduce]
+    n = len(ts_us)
+    if n <= nsamp:
+        return list(zip(ts_us, values))
+    out = []
+    for k in range(nsamp):
+        a = k * n // nsamp
+        b = max(a + 1, (k + 1) * n // nsamp)
+        out.append((ts_us[(a + b) // 2], red(values[a:b])))
+    return out
+
+
+def spm_curves(
+    spm,
+    rocprof_xml=None,
+    nsamp=2000,
+    anchor_us=0.0,
+    mem_roofline_gbps=256.0,
+    ea_bytes_per_req=64,
+):
+    """Turn parsed SPM into a list of curves for the Chrome trace.
+
+    Each curve: {name, group, unit, series:[(ts_us, value)]}. Time base: SPM
+    timestamps are in the GPU timestamp-clock domain (AsicInfo.gpuTimestampFrequency);
+    ts_us = (ts - ts[0]) / (freq/1e6) + anchor.
+    NOTE: SPM/SQTT co-start is assumed for the anchor (see README caveats).
+
+    mem_roofline_gbps: LPDDR5X unified-memory peak for the % roofline curve (Strix
+      Halo ~256 GB/s). ea_bytes_per_req: assumed bytes per EA memory request (see the
+      EA-block note below - the exact unit is NOT verifiable from open counter defs).
+    """
+    if not spm or not spm["timestamps"]:
+        return []
+    names = _load_xml_names(rocprof_xml)
+    ts = spm["timestamps"]
+    # SPM timestamps are in the GPU timestamp-clock domain. Read the real frequency from
+    # the capture's AsicInfo chunk (gpuTimestampFrequency, Hz) instead of assuming; fall
+    # back to 100 MHz only if AsicInfo is absent. (Sanity: 4096-sclk interval @~2.7 GHz
+    # = 1.52 us -> dtick ~152 ticks, i.e. ~100 ticks/us -> 100 MHz, which matches.)
+    freq = spm.get("ts_freq_hz")
+    if freq:
+        ticks_per_us = freq / 1e6
+    else:
+        ticks_per_us = 100.0
+        print(
+            "SPM: no AsicInfo gpuTimestampFrequency; assuming 100 MHz timestamp clock"
+        )
+    ts_us = [anchor_us + (t - ts[0]) / ticks_per_us for t in ts]
+    dt_us = (ts_us[-1] - ts_us[0]) / max(len(ts_us) - 1, 1)  # per-sample interval (us)
+
+    # aggregate counters by (blockname, event): sum across instances per sample
+    agg = {}
+    for c in spm["counters"]:
+        key = (c["blockname"], c["event"])
+        s = agg.get(key)
+        if s is None:
+            agg[key] = list(c["samples"])
+        else:
+            for i in range(min(len(s), len(c["samples"]))):
+                s[i] += c["samples"][i]
+
+    curves = []
+    # 1) named raw counters (whatever matches rocprofiler gfx11 XML)
+    for (bn, evt), series in sorted(agg.items()):
+        nm = names.get((bn, evt))
+        if nm:
+            curves.append(
+                {
+                    "name": nm,
+                    "group": "SPM raw (%s)" % bn,
+                    "unit": "count/sample",
+                    "series": _downsample(ts_us, series, nsamp),
+                }
+            )
+
+    def get(bn, evt):
+        return agg.get((bn, evt))
+
+    # 2) UNIFIED-MEMORY (LPDDR5X) bandwidth from the EA / GCEA block.
+    #    On this APU (gfx1151) there is no discrete VRAM: all traffic that misses the
+    #    GPU caches goes to shared LPDDR5X through the EA (Efficiency Arbiter / GCEA,
+    #    SPM block 29). Event 55 carries that memory-request activity - it is by far
+    #    the dominant memory counter in the capture (~184M req vs ~0.6 MB of GL2C EA
+    #    read requests, which almost all hit in L2 here).
+    #
+    #    WHAT'S SOLID vs ASSUMED:
+    #      * The whole-capture AVERAGE at 64 B/req ~= 65 GB/s (~26% of 256 GB/s) is a
+    #        legitimate sustained-bandwidth estimate: over the capture, requests arriving
+    #        at the arbiter must equal completions, so their time-average = sustained BW.
+    #      * Instantaneous peaks (single samples ~55x the mean -> >roofline) are arbiter
+    #        *arrival* bursts that queue and drain later, NOT sustained bandwidth. SPM
+    #        timestamps are uniform (~1.52 us) so this is not a dt artifact. Hence the
+    #        per-sample GB/s curve is median-downsampled and treated as relative intensity.
+    #      * The 64 B/req unit is an ASSUMPTION (standard DRAM burst): rocprofiler has no
+    #        gfx11 GCEA table and RGP's raw->name map is closed, so the exact byte size is
+    #        not provable from open sources. Cross-check the ~65 GB/s average against RGP's
+    #        own bandwidth readout to confirm; override via ea_bytes_per_req if calibrated.
+    ea = get("EA", 55)
+    if ea is not None:
+        curves.append(
+            {
+                "name": "Unified-mem traffic (EA ev55, relative)",
+                "group": "SPM raw (EA)",
+                "unit": "req/sample",
+                "series": _downsample(ts_us, ea, nsamp),
+            }
+        )
+        bw = [
+            (ea_bytes_per_req * ea[i]) / (dt_us * 1e3)
+            if dt_us > 0 and i < len(ea)
+            else 0.0
+            for i in range(len(ts_us))
+        ]
+        # median downsample: rare burst samples (arbiter arrivals, not sustained BW)
+        # must not dominate the reading.
+        curves.append(
+            {
+                "name": "Unified LPDDR5X BW (est @%dB/req; avg trustworthy)"
+                % ea_bytes_per_req,
+                "group": "Memory (bytes)",
+                "unit": "GB/s",
+                "series": _downsample(ts_us, bw, nsamp, reduce="median"),
+            }
+        )
+
+    # 3) L2->memory read/write from GL2C EA request counters (these DO match the XML).
+    #    On an iGPU these are the *cache-miss* path to LPDDR5X; here they are small
+    #    (the working set largely hits in L2), so they are a secondary detail, not the
+    #    headline bandwidth. RDREQ_{32,64,96,128}B = reads of that size; WRREQ_64B writes.
+    rd = {
+        sz: get("GL2C", ev) for sz, ev in ((32, 99), (64, 100), (96, 101), (128, 102))
+    }
+    if any(v is not None for v in rd.values()):
+        fetch = []
+        for i in range(len(ts_us)):
+            b = sum(sz * (rd[sz][i] if rd[sz] and i < len(rd[sz]) else 0) for sz in rd)
+            fetch.append(b / (dt_us * 1e3) if dt_us > 0 else 0.0)  # bytes/us/1e3 = GB/s
+        curves.append(
+            {
+                "name": "L2 miss read (GL2C->mem)",
+                "group": "Memory (bytes)",
+                "unit": "GB/s",
+                "series": _downsample(ts_us, fetch, nsamp),
+            }
+        )
+    wr64 = get("GL2C", 85)
+    if wr64 is not None:
+        wr = [
+            (64 * wr64[i]) / (dt_us * 1e3) if dt_us > 0 and i < len(wr64) else 0.0
+            for i in range(len(ts_us))
+        ]
+        curves.append(
+            {
+                "name": "L2 write (GL2C->mem)",
+                "group": "Memory (bytes)",
+                "unit": "GB/s",
+                "series": _downsample(ts_us, wr, nsamp),
+            }
+        )
+    return curves

--- a/tools/rgp_parser/rgp_parser/struct/sqtt.py
+++ b/tools/rgp_parser/rgp_parser/struct/sqtt.py
@@ -1,0 +1,84 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""SqttData chunks: raw SQ Thread Trace token streams (one per shader engine).
+
+Two responsibilities:
+
+1. :func:`extract_blobs` - pull the raw (Zstd-inflated) SQTT byte streams out of the
+   RDF container. This is straightforward and fully implemented.
+2. :func:`decode_tokens` - turn those raw hardware token streams into structured
+   dispatch / event / occupancy / realtime records. This is the pure-Python port
+   of AMD's ``rocprof-trace-decoder`` gfx1x token parser (see
+   :mod:`rgp_parser.struct.sqtt_decode`). :func:`load_records` can alternatively
+   ingest a pre-decoded ``records.json`` for the same downstream pipeline
+   (symbolize -> model -> formats).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+
+from .rdf import RdfFile
+
+
+@dataclass
+class DecodedRecords:
+    """Raw, pre-symbolization decode output (dispatches / events / occupancy)."""
+
+    rt_freq: int = 100_000_000
+    rt0: int = 0
+    wave_size: int = 32
+    shader_engines: int = 0
+    dispatches: list[dict] = field(default_factory=list)
+    events: list[dict] = field(default_factory=list)
+    occupancy: list[dict] = field(default_factory=list)
+
+
+def extract_blobs(rdf: RdfFile) -> list[bytes]:
+    """One raw SQTT byte stream per shader engine, in chunk order."""
+    return [rdf.data(c) for c in rdf.by_id("SqttData")]
+
+
+def load_records(path: str) -> DecodedRecords:
+    """Load a pre-decoded records.json (optional external decode)."""
+    with open(path, "r") as f:
+        r = json.load(f)
+    return DecodedRecords(
+        rt_freq=r.get("rt_freq", 100_000_000),
+        rt0=r.get("rt0", 0),
+        wave_size=r.get("wave_size", 32),
+        shader_engines=len({d.get("se", 0) for d in r.get("dispatches", [])}) or 0,
+        dispatches=r.get("dispatches", []),
+        events=r.get("events", []),
+        occupancy=r.get("occupancy", []),
+    )
+
+
+def decode_tokens(blobs: list[bytes], *, wave_size: int = 32) -> DecodedRecords:
+    """Pure-Python SQTT hardware-token decoder (gfx11 / RDNA3).
+
+    Faithful port of AMD's ``rocprof-trace-decoder`` token parser plus the
+    wave-attribution / wall-clock post-processing. See
+    :mod:`rgp_parser.struct.sqtt_decode` for the implementation and its
+    source-of-truth references. Produces the raw record set (dispatches / events /
+    occupancy) the rest of the pipeline consumes.
+
+    One raw SQTT byte stream per shader engine is expected (see
+    :func:`extract_blobs`); dispatches / events / realtime are read from SE0
+    (they are broadcast), occupancy from every SE.
+    """
+    from . import sqtt_decode
+
+    r = sqtt_decode.decode(blobs, wave_size=wave_size)
+    return DecodedRecords(
+        rt_freq=r["rt_freq"],
+        rt0=r["rt0"],
+        wave_size=r["wave_size"],
+        shader_engines=len(blobs),
+        dispatches=r["dispatches"],
+        events=r["events"],
+        occupancy=r["occupancy"],
+    )

--- a/tools/rgp_parser/rgp_parser/struct/sqtt_decode.py
+++ b/tools/rgp_parser/rgp_parser/struct/sqtt_decode.py
@@ -1,0 +1,761 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""Pure-Python SQTT hardware-token decoder for gfx11 (RDNA3 / Strix Halo).
+
+This is a faithful port of AMD's ``rocprof-trace-decoder`` (the C++
+``rocprof_trace_decoder_parse_data`` token parser), plus the post-processing this
+pipeline needs (wave-to-dispatch attribution + wall-clock mapping), so the whole
+pipeline runs in Python.
+
+Scope: it produces the record set the rest of the pipeline consumes -- DISPATCH,
+EVENT, OCCUPANCY (wave start/end) and REALTIME -- for gfx11
+(``header.version == 3``). The full instruction-level wave stitching
+(INST/VALU/NEW_PC/SHADER_DATA -> per-wave instruction timelines) is intentionally
+skipped: it is not needed for the dispatch / occupancy / event trace.
+
+Source of truth (all in-tree under rocm-systems/projects/rocprof-trace-decoder):
+  * source/gfx10/gfx10parser.h, gfx10token.cpp   -- bit reader + token table
+  * source/gfx11/gfx11token.{h,cpp}, gfx11parser.h -- gfx11 overrides
+  * source/gfx10/rdna_sqtt.cpp                    -- the parse loop
+  * source/trace_parser.hpp                       -- CSRegisterHandler.PopulateDispatch
+"""
+
+from __future__ import annotations
+
+MASK64 = (1 << 64) - 1
+MASK32 = 0xFFFFFFFF
+BITMASK48 = (1 << 48) - 1
+INF = float("inf")
+
+# --- RdnaType (token_types.h enum order) ------------------------------------
+(
+    UNKNOWN,
+    EVENT,
+    EVENT_SYNC,
+    REG,
+    REG_INIT,
+    VALU_INST,
+    IMM_ONE,
+    IMMEDIATE,
+    WAVE_READY,
+    NEW_PC_GFX10,
+    WAVE_END,
+    WAVE_START,
+    WAVE_START_EXT,
+    WAVE_ALLOC,
+    SHADER_DATA,
+    SHADER_DATA_SHORT,
+    UTIL_COUNTER_GFX10,
+    TIME,
+    NOP,
+    MISC_GFX10,
+    TIMESTAMP,
+    HEADER,
+    INST,
+    UTIL_COUNTER_GFX11,
+    EXEC_POPCOUNT1,
+    EXEC_POPCOUNT3,
+    NEW_PC_GFX12,
+    LDS_CONFIG,
+    MEDIUM_TIME,
+) = range(29)
+
+# tokens the parse loop explicitly cases but that we skip (no dispatch/occ/event
+# effect); everything not handled and not here falls to the packet-loss default.
+_SKIP = frozenset(
+    (
+        INST,
+        VALU_INST,
+        IMM_ONE,
+        IMMEDIATE,
+        NEW_PC_GFX10,
+        NEW_PC_GFX12,
+        WAVE_READY,
+        SHADER_DATA,
+        SHADER_DATA_SHORT,
+    )
+)
+
+# --- decoder event types (trace_decoder_types.h) ----------------------------
+EV_CS_PARTIAL_FLUSH = 1
+EV_BOTTOM_OF_PIPE_TS = 2
+EV_SAVE_CONTEXT = 3
+EV_CACHE_FLUSH = 5
+EV_PACKET_LOSS = 6
+EV_TT_STALL_BEGIN = 9
+EV_TT_STALL_END = 10
+EV_TT_FLUSH = 11
+EV_DIDT_STALL_BEGIN = 12
+EV_DIDT_STALL_END = 13
+EV_GC_RINSE = 16
+EV_SPM_SAMPLE = 17
+EV_RGP_MARKER = (
+    15  # RESERVED id; carries one USERDATA_2/3 marker dword (build._parse_markers)
+)
+
+# RGP streams its SQTT markers 2 dwords/packet into the SQ thread-trace user-data
+# registers (PAL palubercapturemgr -> CmdInsertRgpTraceMarker). Reassembling these
+# in capture order reproduces the Mesa ac_sqtt.h rgp_sqtt_marker_* stream, which
+# yields per-dispatch grid dims (exact wavefronts) and exact barrier cache/stall bits.
+USERDATA_2 = 0xC342  # even marker dwords
+USERDATA_3 = 0xC343  # odd  marker dwords (barrier_end cache bits live here)
+
+# hardware EVENT-token ids (sqtt_event_type_t) -> decoder event type
+_EVENT_ID_MAP = {
+    0x7: EV_CS_PARTIAL_FLUSH,
+    0x6: EV_CACHE_FLUSH,
+    0x4: EV_CACHE_FLUSH,
+    0x16: EV_CACHE_FLUSH,
+    0x14: EV_CACHE_FLUSH,
+    0x28: EV_BOTTOM_OF_PIPE_TS,
+    0x36: EV_TT_FLUSH,
+}
+
+
+def _build_lookup():
+    """256-entry (type, length, time_begin, time_end) table for gfx11."""
+    tbl = [(UNKNOWN, 4, 0, 0)] * 256
+
+    def add(typ, pattern, plen, length, tb, te):
+        info = (typ, length, tb, te)
+        step = 1 << plen
+        for i in range(pattern, 256, step):
+            tbl[i] = info
+
+    # gfx10 base encodings
+    add(INST, 0b010, 3, 20, 4, 7)
+    add(VALU_INST, 0b011, 3, 12, 3, 6)
+    add(IMM_ONE, 0b1101, 4, 12, 4, 7)
+    add(IMMEDIATE, 0b00100, 5, 24, 5, 8)
+    add(WAVE_READY, 0b10100, 5, 24, 5, 8)
+    add(NEW_PC_GFX10, 0b0100001, 7, 64, 8, 11)
+    add(WAVE_START, 0b01100, 5, 32, 5, 7)
+    add(WAVE_START_EXT, 0b11100, 5, 48, 5, 7)
+    add(WAVE_ALLOC, 0b00101, 5, 20, 5, 8)
+    add(WAVE_END, 0b10101, 5, 20, 5, 8)
+    add(SHADER_DATA, 0b00110, 5, 52, 5, 8)
+    add(SHADER_DATA_SHORT, 0b10110, 5, 28, 5, 8)
+    add(UTIL_COUNTER_GFX10, 0b0110001, 7, 64, 7, 9)
+    add(TIME, 0b1000, 4, 8, 4, 8)
+    add(NOP, 0b0000, 4, 4, 0, 0)
+    add(MISC_GFX10, 0b1010001, 7, 24, 7, 16)
+    add(EVENT, 0b01100001, 8, 24, 8, 11)
+    add(EVENT_SYNC, 0b11100001, 8, 32, 8, 11)
+    add(REG, 0b1001, 4, 64, 4, 7)
+    add(REG_INIT, 0b1110001, 7, 64, 7, 10)
+    add(TIMESTAMP, 0b0000001, 7, 64, 16, 64)
+    add(HEADER, 0b0010001, 7, 64, 0, 0)
+    # gfx11 overrides
+    add(MISC_GFX10, 0b1010001, 7, 24, 7, 16)
+    add(UTIL_COUNTER_GFX11, 0b0110001, 7, 48, 7, 9)
+    add(TIMESTAMP, 0b0000001, 7, 48, 12, 48)
+    return tbl
+
+
+_LOOKUP = _build_lookup()
+_TS36 = (1 << 36) - 1
+
+
+class TokenGen:
+    """gfx11 token generator: bit reader + lookahead time-reorder (rdna_sqtt).
+
+    A single 64-bit window ``current`` slides over the LSB-first bit stream.
+    Because every gfx1x token length is a multiple of 4 bits, the C++ nibble/byte
+    shifting is exactly equivalent to reloading ``current`` from the byte buffer
+    at the running consumed-bit position -- which is what ``_reload`` does.
+    """
+
+    __slots__ = (
+        "mv",
+        "nbits",
+        "bit_ptr",
+        "bits_toread",
+        "current",
+        "globaltime",
+        "lookahead",
+        "realtime",
+        "packetlost",
+        "lookup",
+    )
+
+    def __init__(self, blob):
+        self.mv = memoryview(bytes(blob) + b"\x00" * 16)
+        self.nbits = len(blob) * 8
+        self.bit_ptr = 0  # fill pointer; consumed pos == bit_ptr - 64
+        self.bits_toread = 64
+        self.current = 0
+        self.globaltime = 0
+        self.lookahead = __import__("collections").deque()
+        self.realtime = []  # (shader_clock, realtime_clock)
+        self.packetlost = False
+        self.lookup = _LOOKUP
+
+    def _reload(self):
+        # consume previous token, load window at new consumed position
+        self.bit_ptr += self.bits_toread
+        pos = self.bit_ptr - 64
+        idx = pos >> 3
+        val = int.from_bytes(self.mv[idx : idx + 9], "little")
+        self.current = (val >> (pos & 7)) & MASK64
+
+    def buffer_padded(self):
+        return self.bit_ptr + 64 < self.nbits
+
+    def buffer_valid_unsafe(self):
+        return self.bit_ptr < self.nbits or self.current != 0
+
+    def next_valid(self):
+        return self.buffer_padded() or self.lookahead or self.current != 0
+
+    def _time(self, info):
+        """Advance globaltime; return realtime value (0 if none)."""
+        c = self.current
+        typ = info[0]
+        if typ == TIMESTAMP:
+            pl = (c >> 8) & 1
+            rt = (c >> 9) & 1
+            tm = (c >> 12) & _TS36
+            if pl == 1 and rt == 0:
+                self.packetlost = True
+            if rt == 0:
+                self.globaltime += tm
+                return 0
+            if pl == 0:
+                return tm
+            return 0
+        tb = info[2]
+        te = info[3]
+        mask = (1 << (te - tb)) - 1
+        delta = ((c >> tb) & mask) + (4 if typ == TIME else 0)
+        self.globaltime += delta
+        return 0
+
+    def _add_realtime(self, real):
+        rl = self.realtime
+        if rl:
+            sh_back, rt_back = rl[-1]
+            if rt_back >= real or sh_back >= self.globaltime:
+                rl[-1] = ((sh_back + self.globaltime) // 2, (rt_back + real) // 2)
+                return
+        rl.append((self.globaltime, real))
+
+    def next(self):
+        la = self.lookahead
+        lookup = self.lookup
+        # Loop 1: padded region (direct realtime emplace).
+        while self.buffer_padded() or la:
+            if la:
+                if la[0][0] < la[-1][0] or not self.buffer_padded():
+                    return la.popleft()
+            self._reload()
+            info = lookup[self.current & 0xFF]
+            typ = info[0]
+            if typ == NOP:
+                self.bits_toread = 4
+                continue
+            self.bits_toread = info[1]
+            real = self._time(info)
+            if typ == TIMESTAMP or typ == TIME:
+                if real != 0:
+                    self.realtime.append((self.globaltime, real))
+                continue
+            t = self.globaltime - 1 if typ == WAVE_READY else self.globaltime
+            tok = (t, self.current, typ)
+            if la and t < la[-1][0]:
+                la.appendleft(tok)
+            else:
+                la.append(tok)
+        # Loop 2: tail region (deduped realtime).
+        while self.buffer_valid_unsafe() or la:
+            if la:
+                if la[0][0] < la[-1][0] or not self.buffer_valid_unsafe():
+                    return la.popleft()
+            self._reload()
+            info = lookup[self.current & 0xFF]
+            typ = info[0]
+            if typ == NOP:
+                self.bits_toread = 4
+                continue
+            self.bits_toread = info[1]
+            real = self._time(info)
+            if typ == TIMESTAMP or typ == TIME:
+                if real != 0:
+                    self._add_realtime(real)
+                continue
+            t = self.globaltime - 1 if typ == WAVE_READY else self.globaltime
+            tok = (t, self.current, typ)
+            if la and t < la[-1][0]:
+                la.appendleft(tok)
+            else:
+                la.append(tok)
+        return (0, 0, TIMESTAMP)  # sentinel
+
+
+class CSRegister:
+    """Compute-shader register state -> dispatch snapshot (PopulateDispatch)."""
+
+    __slots__ = (
+        "wave_start_addr",
+        "dispatch_pkt",
+        "num_x",
+        "num_y",
+        "num_z",
+        "rsrc1",
+        "rsrc2",
+        "rsrc3",
+        "tt_version",
+    )
+
+    def __init__(self):
+        self.wave_start_addr = [[0, 0, 0, 0], [0, 0, 0, 0]]
+        self.dispatch_pkt = [[0, 0, 0, 0], [0, 0, 0, 0]]
+        self.num_x = self.num_y = self.num_z = 0
+        self.rsrc1 = self.rsrc2 = self.rsrc3 = 0
+        self.tt_version = 0
+
+    def update_cs(self, regaddr, regdata, me, pipe):
+        rd = regdata & MASK32
+        m = me & 1
+        if regaddr == 0xC:  # COMPUTE_PGM_LO
+            e = self.wave_start_addr[m][pipe]
+            self.wave_start_addr[m][pipe] = (e & ~MASK32) | rd
+        elif regaddr == 0xD:  # COMPUTE_PGM_HI
+            e = self.wave_start_addr[m][pipe]
+            self.wave_start_addr[m][pipe] = (e & MASK32) | (rd << 32)
+        elif regaddr == 0x7:  # COMPUTE_NUM_THREAD_X
+            self.num_x = rd
+        elif regaddr == 0x8:
+            self.num_y = rd
+        elif regaddr == 0x9:
+            self.num_z = rd
+        elif regaddr == 0x12:  # COMPUTE_PGM_RSRC1
+            self.rsrc1 = rd
+        elif regaddr == 0x13:  # COMPUTE_PGM_RSRC2
+            self.rsrc2 = rd
+        elif regaddr == 0x2D:  # COMPUTE_PGM_RSRC3
+            self.rsrc3 = rd
+        elif regaddr == 0xE:  # COMPUTE_DISPATCH_PKT_LO
+            e = self.dispatch_pkt[m][pipe]
+            self.dispatch_pkt[m][pipe] = (e & ~MASK32) | rd
+        elif regaddr == 0xF:  # COMPUTE_DISPATCH_PKT_HI
+            e = self.dispatch_pkt[m][pipe]
+            self.dispatch_pkt[m][pipe] = (e & MASK32) | (rd << 32)
+
+    def wave_start_pc(self, me, pipe):
+        return (self.wave_start_addr[me & 1][pipe] << 8) & BITMASK48
+
+    def populate_dispatch(self, time, me, pipe, se):
+        r1 = self.rsrc1
+        r2 = self.rsrc2
+        pc = (self.wave_start_addr[me & 1][pipe] << 8) & BITMASK48
+        lds = ((r2 >> 15) & 0x1FF) * 512
+        vgpr = (r1 & 0x3F) * 8 + 8
+        sgpr = 128
+        # tt_version 3 (gfx11): no <=1 / ==1 / >=5 adjustments
+        flags = 0
+        if (r1 >> 10) & 1:
+            flags |= 0x1
+        if (r1 >> 11) & 1:
+            flags |= 0x2
+        if (r1 >> 14) & 1:
+            flags |= 0x4
+        if r2 & 1:
+            flags |= 0x8
+        return {
+            "se": se,
+            "me": me,
+            "pipe": pipe,
+            "t": time,
+            "pc": pc,
+            "vgpr": vgpr,
+            "sgpr": sgpr,
+            "lds": lds,
+            "wg": self.num_x * self.num_y * self.num_z,
+            "flags": flags,
+        }
+
+
+def parse_se(blob, se_index, collect_de):
+    """One shader-engine parse pass.
+
+    Returns (dispatches, events, realtime, occupancy). ``dispatches``/``events``/
+    ``realtime`` are only populated when ``collect_de`` is set (they are global
+    and read from SE0 only, mirroring the C++ parse loop). ``occupancy`` is always
+    collected: a list of [time, start, cu, simd, wid, me, pipe, pc] in the exact
+    delivery order (synthetic pre-capture starts pushed to the front).
+    """
+    gen = TokenGen(blob)
+    cs = CSRegister()
+    running = {}  # gpu_location -> start pc
+    saved = {}
+    occ = __import__("collections").deque()
+    disps = []
+    events = []
+    tt_version = 0
+
+    while gen.next_valid():
+        t, c, typ = gen.next()
+
+        if typ == MISC_GFX10:
+            fields = (c >> 16) & 0xFF
+            if collect_de:
+                # emission order matches rdna_sqtt.cpp
+                if (fields >> 3) & 1:
+                    events.append((EV_SAVE_CONTEXT, t, 0, 0, 0, 0))
+                if (fields >> 4) & 1:
+                    events.append((EV_TT_STALL_BEGIN, t, 0, 0, 0, 0))
+                if (fields >> 5) & 1:
+                    events.append((EV_TT_STALL_END, t, 0, 0, 0, 0))
+                if (fields >> 6) & 1:
+                    events.append((EV_DIDT_STALL_BEGIN, t, 0, 0, 0, 0))
+                if (fields >> 7) & 1:
+                    events.append((EV_DIDT_STALL_END, t, 0, 0, 0, 0))
+                if (fields >> 1) & 1:
+                    events.append((EV_GC_RINSE, t, 0, 0, 0, 0))
+                if fields & 1:
+                    events.append((EV_SPM_SAMPLE, t, 0, 0, 0, 0))
+
+        elif typ == HEADER:
+            tt_version = (c >> 7) & 0x3F
+            cs.tt_version = tt_version
+
+        elif typ == WAVE_START or typ == WAVE_START_EXT:
+            sa = (c >> 7) & 1
+            simd = (c >> 8) & 3
+            wgp = (c >> 10) & 7
+            wid = (c >> 13) & 0x1F
+            pipe = (c >> 21) & 3
+            me = (c >> 23) & 1
+            count = (c >> 25) & 0x7F
+            sacu = (sa << 7) + (wgp & 0x7F)
+            loc = (sacu << 7) | (simd << 5) | wid
+            if 66 <= count < 90:
+                is_save = (0b0000110011 >> (count - 66)) & 1
+                is_resr = (0b1111001100 >> (count - 66)) & 1
+                if is_save:
+                    if loc in running:
+                        occ.append([t, 0, sacu, simd, wid, me, pipe, running[loc]])
+                        saved[loc] = running[loc]
+                elif is_resr:
+                    addr = saved.pop(loc, 0)
+                    running[loc] = addr
+                    occ.append([t, 1, sacu, simd, wid, me, pipe, addr])
+                continue
+            if gen.packetlost and loc in running:
+                occ.append([t - 1, 0, sacu, simd, wid, 0, 0, 0])
+            wave_addr = cs.wave_start_pc(me, pipe)
+            running[loc] = wave_addr
+            occ.append([t, 1, sacu, simd, wid, me, pipe, wave_addr])
+
+        elif typ == WAVE_END:
+            sa = (c >> 8) & 1
+            simd = (c >> 9) & 3
+            wgp = (c >> 11) & 7
+            wid = (c >> 15) & 0x1F
+            sacu = (sa << 7) + (wgp & 0x7F)
+            loc = (sacu << 7) | (simd << 5) | wid
+            if loc in running:
+                startpc = running.pop(loc)
+            else:
+                startpc = 0
+                occ.appendleft([0, 1, sacu, simd, wid, 0, 0, 0])
+            occ.append([t, 0, sacu, simd, wid, 0, 0, startpc])
+
+        elif typ == REG:
+            regaddr = (c >> 16) & 0xFFFF
+            regdata = (c >> 32) & MASK32
+            me = (c >> 9) & 3
+            pipe = (c >> 7) & 3
+            cs_bit = (c >> 15) & 1
+            if cs_bit:
+                cs.update_cs(regaddr, regdata, me, pipe)
+            elif collect_de and (regaddr == USERDATA_2 or regaddr == USERDATA_3):
+                # RGP SQTT marker dword (see USERDATA_2/3 note above). Surface each
+                # write as EVENT type 15 (payload = regdata); bop tags USERDATA_3 so
+                # the reader can verify the 2/3 interleave. build._parse_markers walks
+                # the concatenated stream into per-dispatch grids + barrier fields.
+                bop = 1 if regaddr == USERDATA_3 else 0
+                events.append((EV_RGP_MARKER, t, me, pipe, regdata, bop))
+
+        elif typ == REG_INIT:
+            rtype = (c >> 18) & 3
+            data = (c >> 20) & MASK32
+            if rtype == 2 and (data & 1) == 1 and collect_de:
+                me = (c >> 16) & 3
+                pipe = (c >> 14) & 3
+                disps.append(cs.populate_dispatch(t, me, pipe, se_index))
+
+        elif typ == EVENT:
+            eid = (c >> 18) & 0x3F
+            ty = _EVENT_ID_MAP.get(eid)
+            if ty is not None and collect_de:
+                me = (c >> 16) & 3
+                pipe = (c >> 14) & 3
+                bop = (c >> 11) & 1
+                flags = 0x1 | (0x2 if bop else 0)  # per_pipe + bop
+                events.append((ty, t, me & 1, pipe, 0, flags))
+
+        elif typ in _SKIP:
+            pass
+
+        else:
+            if typ == TIMESTAMP and c == 0:
+                break  # sentinel
+            if gen.packetlost and collect_de:
+                events.append((EV_PACKET_LOSS, t, 0, 0, 0, 0))
+                gen.packetlost = False
+
+    return disps, events, gen.realtime, list(occ)
+
+
+def decode(blobs, wave_size=32):
+    """Decode one SQTT blob per shader engine into raw records.
+
+    Returns a dict of raw decode records:
+    ``rt_freq, rt0, wave_size, dispatches, events, occupancy``.
+    """
+    import bisect
+
+    disps, ev_raw, rts, occ0 = parse_se(blobs[0], 0, True)
+    occ_all = [occ0]
+    for i in range(1, len(blobs)):
+        _, _, _, occ_i = parse_se(blobs[i], i, False)
+        occ_all.append(occ_i)
+
+    rt_freq = 100_000_000  # RGP capture: decoder emits no RT_FREQUENCY -> fallback
+
+    disps.sort(key=lambda d: d["t"])
+    for d in disps:
+        d["exp_waves"] = 0
+        d["wf"] = 0
+        d["min_start"] = INF
+        d["max_end"] = 0
+
+    # --- phase 2: pair occupancy waves per hw slot + build per-SE band ------
+    slot_pend = {}
+    pipe_waves = {}
+    occ_ev = [[] for _ in blobs]
+    for se, occ in enumerate(occ_all):
+        oe = occ_ev[se]
+        for rec in occ:
+            time, start, cu, simd, wid, me, pipe, pc = rec
+            sk = (se << 24) | ((cu & 0x7F) << 16) | ((simd & 0xF) << 8) | (wid & 0xFF)
+            oe.append((time, 1 if start else -1))
+            if start:
+                slot_pend[sk] = (time, pc, me, pipe)
+            else:
+                p = slot_pend.pop(sk, None)
+                if p is None:
+                    continue
+                st, ppc, pme, ppipe = p
+                key = (ppc << 8) | (((pme & 7) << 4) | (ppipe & 0xF))
+                lst = pipe_waves.get(key)
+                if lst is None:
+                    pipe_waves[key] = [(st, time)]
+                else:
+                    lst.append((st, time))
+
+    # --- exp_waves from RGP markers (USERDATA_2/3), per (me,pipe) ------------
+    # Reassemble the type-15 marker dwords in capture
+    # order, walk EVENT markers (ident 0x0 w/ dims) for grid workgroups, and pair
+    # them 1:1 with dispatches in launch order on the pipe. exp_waves =
+    # grid_workgroups * ceil(wg/wave). This gates the wave-attribution cap below so
+    # a sparse same-PC dispatch cannot absorb waves from the idle gap before its
+    # next invocation and inflate its wave-span (the small-dispatch duration bug).
+    def _mkey(me, pipe):
+        return ((me & 7) << 4) | (pipe & 0xF)
+
+    pipe_marker_dw = {}
+    for e in ev_raw:  # ev_raw is already in capture (seq) order
+        if e[0] == EV_RGP_MARKER:
+            pipe_marker_dw.setdefault(_mkey(e[2], e[3]), []).append(e[4] & 0xFFFFFFFF)
+    pipe_grids = {}
+    for mk, dw in pipe_marker_dw.items():
+        grids = []
+        i, n = 0, len(dw)
+        while i < n:
+            d0 = dw[i]
+            ident = d0 & 0xF
+            ext = (d0 >> 4) & 0x7
+            if ident == 0x0:  # EVENT (per dispatch)
+                has = (d0 >> 31) & 1
+                grids.append(
+                    dw[i + 3] * dw[i + 4] * dw[i + 5] if (has and i + 5 < n) else 0
+                )
+                i += 3 + (3 if has else 0) + ext
+            elif ident == 0x1:  # CB_START
+                i += 4 + ext
+            elif ident == 0x2 or ident == 0xC:  # CB_END / BIND_PIPELINE
+                i += 3 + ext
+            elif ident == 0x3 or ident == 0x4 or ident == 0x9:  # BARRIER_*/LAYOUT
+                i += 2 + ext
+            else:
+                i += 1 + ext
+        pipe_grids[mk] = grids
+    pipe_disps = {}
+    for i, d in enumerate(disps):
+        pipe_disps.setdefault(_mkey(d["me"], d["pipe"]), []).append(i)
+    for mk, idxs in pipe_disps.items():
+        grids = pipe_grids.get(mk, [])
+        for k, di in enumerate(idxs):
+            d = disps[di]
+            wg = d["wg"] or 1
+            wpw = (wg + wave_size - 1) // wave_size
+            grid = grids[k] if k < len(grids) else 0
+            d["exp_waves"] = grid * wpw
+
+    # --- attribute waves to dispatches by (me,pipe,pc) + launch window ------
+    pc_disps = {}
+    for i, d in enumerate(disps):
+        key = (d["pc"] << 8) | (((d["me"] & 7) << 4) | (d["pipe"] & 0xF))
+        pc_disps.setdefault(key, []).append(i)
+    for key, idxs in pc_disps.items():
+        wv = pipe_waves.get(key)
+        if not wv:
+            continue
+        times = [disps[i]["t"] for i in idxs]
+        wv.sort(key=lambda w: w[0])
+        for ws, we in wv:
+            k = bisect.bisect_right(times, ws) - 1
+            if k < 0:
+                k = 0
+            d = disps[idxs[k]]
+            if d["exp_waves"] > 0 and d["wf"] >= d["exp_waves"]:
+                continue
+            d["wf"] += 1
+            if ws < d["min_start"]:
+                d["min_start"] = ws
+            if we > d["max_end"]:
+                d["max_end"] = we
+
+    # --- wall-clock mapping -------------------------------------------------
+    rts_sorted = sorted(rts, key=lambda r: r[0])
+    rt_sh = [r[0] for r in rts_sorted]
+
+    def sc_to_rt(sc):
+        if not rts_sorted:
+            return float(sc)
+        if sc <= rts_sorted[0][0]:
+            return float(rts_sorted[0][1])
+        if sc >= rts_sorted[-1][0]:
+            return float(rts_sorted[-1][1])
+        j = bisect.bisect_left(rt_sh, sc)
+        a = rts_sorted[j - 1]
+        b = rts_sorted[j]
+        f = (sc - a[0]) / max(1, b[0] - a[0])
+        return a[1] + f * (b[1] - a[1])
+
+    sc0 = INF
+    for d in disps:
+        if d["t"] < sc0:
+            sc0 = d["t"]
+    for e in ev_raw:
+        if e[1] < sc0:
+            sc0 = e[1]
+    if sc0 == INF:
+        sc0 = 0
+    rt0 = sc_to_rt(sc0)
+    US = 1e6 / rt_freq
+
+    def to_us(sc):
+        return (sc_to_rt(sc) - rt0) * US
+
+    out_disp = []
+    for d in disps:
+        has = d["wf"] > 0 and d["min_start"] != INF
+        ws = d["min_start"] if has else d["t"]
+        dur = round(to_us(d["max_end"]) - to_us(d["min_start"]), 4) if has else -1.0
+        out_disp.append(
+            {
+                "se": d["se"],
+                "me": d["me"],
+                "pipe": d["pipe"],
+                "ts": round(to_us(ws), 4),
+                "launch_ts": round(to_us(d["t"]), 4),
+                "dur": dur,
+                "wavefronts": d["wf"],
+                "exp_waves": d["exp_waves"],
+                "flags": d["flags"],
+                "vgpr": d["vgpr"],
+                "sgpr": d["sgpr"],
+                "lds": d["lds"],
+                "wg": d["wg"],
+                "pc": "0x%x" % d["pc"],
+            }
+        )
+
+    out_ev = []
+    for seq, e in enumerate(ev_raw):
+        ty, rawt, me, pipe, payload, flags = e
+        out_ev.append(
+            {
+                "me": me,
+                "pipe": pipe,
+                "ts": round(to_us(rawt), 4),
+                "rawt": rawt,
+                "type": ty,
+                "flags": flags,
+                "payload": payload,
+                "seq": seq,
+            }
+        )
+
+    out_occ = _occupancy_band(occ_ev, len(blobs), to_us)
+
+    return {
+        "rt_freq": rt_freq,
+        "rt0": int(rt0),
+        "wave_size": wave_size,
+        "dispatches": out_disp,
+        "events": out_ev,
+        "occupancy": out_occ,
+    }
+
+
+def _occupancy_band(occ_ev, n_se, to_us):
+    """Peak alive-wave count per ~2us bucket, per SE (wavefront-occupancy band)."""
+    ns = min(n_se, 8)
+    tmin = INF
+    tmax = -INF
+    for s in range(ns):
+        for time, _ in occ_ev[s]:
+            if time < tmin:
+                tmin = time
+            if time > tmax:
+                tmax = time
+    if not (tmax > tmin):
+        return []
+    span_us = to_us(tmax) - to_us(tmin)
+    nsamp = int(span_us / 2.0)
+    if nsamp < 4000:
+        nsamp = 4000
+    if nsamp > 120000:
+        nsamp = 120000
+    for s in range(ns):
+        occ_ev[s].sort()
+    cur = [0] * ns
+    idx = [0] * ns
+    span = tmax - tmin
+    band = []
+    for k in range(nsamp):
+        t1 = tmin + int(span * (k + 1) / nsamp)
+        tmid = tmin + int(span * (k + 0.5) / nsamp)
+        row = {"ts": round(to_us(tmid), 4)}
+        for s in range(ns):
+            E = occ_ev[s]
+            ci = cur[s]
+            peak = ci if ci > 0 else 0
+            i = idx[s]
+            ne = len(E)
+            while i < ne and E[i][0] < t1:
+                ci += E[i][1]
+                if ci > peak:
+                    peak = ci
+                i += 1
+            cur[s] = ci
+            idx[s] = i
+            row["se%d" % s] = peak
+        band.append(row)
+    return band

--- a/tools/rgp_parser/rgp_parser/symbolize.py
+++ b/tools/rgp_parser/rgp_parser/symbolize.py
@@ -1,0 +1,194 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""Map dispatch PCs to demangled kernel names.
+
+Coverage-based CodeObject<->load-base assignment: treat observed dispatch PCs as
+ground truth and, for each code object, pick the load base under which its symbols
+actually cover the observed PCs (weighted by dispatch duration). Then demangle and
+simplify to ``name<template args>``.
+"""
+
+from __future__ import annotations
+
+import bisect
+import re
+import shutil
+import subprocess
+
+
+def _coverage(base, fns, pcset, pcs, pcw):
+    exact = sum(1 for v, _sz, _n in fns if base + v in pcset)
+    contain = 0.0
+    if exact:
+        starts = [base + v for v, _sz, _n in fns]
+        for pc in pcs:
+            i = bisect.bisect_right(starts, pc) - 1
+            if 0 <= i < len(fns):
+                v, sz, _n = fns[i]
+                if base + v <= pc < base + v + sz:
+                    contain += pcw[pc]
+    return exact, contain
+
+
+def assign_bases(co_funcs, bases, pcw):
+    """Greedy one-to-one (code_object -> base) assignment maximizing PC coverage."""
+    pcs = sorted(pcw)
+    pcset = set(pcs)
+    pairs = []
+    for ci, fns in enumerate(co_funcs):
+        for base in bases:
+            ex, co = _coverage(base, fns, pcset, pcs, pcw)
+            if ex > 0:
+                pairs.append((ex, co, ci, base))
+    pairs.sort(reverse=True)
+    assigned, used_co, used_base = {}, set(), set()
+    for _ex, _co, ci, base in pairs:
+        if ci in used_co or base in used_base:
+            continue
+        assigned[ci] = base
+        used_co.add(ci)
+        used_base.add(base)
+    return assigned
+
+
+def resolve_names(co_funcs, bases, pcw):
+    """Return {pc: mangled_name} for as many observed PCs as possible."""
+    pcs = sorted(pcw)
+    pcset = set(pcs)
+    assigned = assign_bases(co_funcs, bases, pcw)
+
+    entry, syms = {}, []
+    for ci, base in assigned.items():
+        for v, sz, n in co_funcs[ci]:
+            syms.append((base + v, base + v + sz, n))
+            if base + v in pcset:
+                entry.setdefault(base + v, n)
+    syms.sort()
+    sstarts = [s[0] for s in syms]
+
+    def resolve(pc):
+        if pc in entry:
+            return entry[pc]
+        i = bisect.bisect_right(sstarts, pc) - 1
+        if 0 <= i < len(syms) and syms[i][0] <= pc < syms[i][1]:
+            return syms[i][2]
+        return None
+
+    resolved = {pc: resolve(pc) for pc in pcs if resolve(pc)}
+    # fallback: exact-entry across ALL (code_object, base) combinations
+    baseset = set(bases)
+    for pc in pcs:
+        if pc in resolved:
+            continue
+        for fns in co_funcs:
+            hit = next((n for v, _sz, n in fns if (pc - v) in baseset), None)
+            if hit:
+                resolved[pc] = hit
+                break
+    return resolved
+
+
+def resolve_names_exact(co_hash_funcs, hash2base, pcw):
+    """Deterministic {pc: mangled_name} via CodeObject-hash <-> COLoadEvent-base pairing.
+
+    Each CodeObject chunk header carries a 16-byte hash that also keys its
+    COLoadEvent load base, so no coverage heuristic is needed. Returns
+    (resolved, matched, n_code_objects)."""
+    pcs = sorted(pcw)
+    pcset = set(pcs)
+    entry, syms, matched = {}, [], 0
+    for h, fns in co_hash_funcs:
+        base = hash2base.get(h)
+        if base is None:
+            continue  # CO not in COLoadEvent (loaded pre-capture)
+        matched += 1
+        for v, sz, n in fns:
+            a = base + v
+            syms.append((a, a + sz, n))
+            if a in pcset:
+                entry.setdefault(a, n)
+    syms.sort()
+    sstarts = [s[0] for s in syms]
+
+    def resolve(pc):
+        if pc in entry:
+            return entry[pc]
+        i = bisect.bisect_right(sstarts, pc) - 1
+        if 0 <= i < len(syms) and syms[i][0] <= pc < syms[i][1]:
+            return syms[i][2]
+        return None
+
+    resolved = {pc: resolve(pc) for pc in pcs if resolve(pc)}
+    return resolved, matched, len(co_hash_funcs)
+
+
+def _cxxfilt():
+    return shutil.which("llvm-cxxfilt") or shutil.which("c++filt")
+
+
+def demangle_batch(names):
+    names = list(names)
+    tool = _cxxfilt()
+    if tool:
+        out = subprocess.run(
+            [tool], input="\n".join(names), capture_output=True, text=True
+        )
+        lines = out.stdout.splitlines()
+        return {n: (lines[i] if i < len(lines) else n) for i, n in enumerate(names)}
+    try:
+        from itanium_demangler import parse as _dm
+
+        def one(n):
+            try:
+                r = _dm(n)
+                return str(r) if r else n
+            except Exception:
+                return n
+
+        return {n: one(n) for n in names}
+    except ImportError:
+        return {n: n for n in names}
+
+
+def simplify(dem: str) -> str:
+    s = dem
+    if s.startswith("void "):
+        s = s[5:]
+    s = s.replace("(anonymous namespace)::", "")
+    depth = 0
+    for i, ch in enumerate(s):
+        if ch == "<":
+            depth += 1
+        elif ch == ">":
+            depth -= 1
+        elif ch == "(" and depth == 0:
+            s = s[:i]
+            break
+    m = re.match(r"(.*?)(<.*>)?$", s)
+    base = m.group(1).split("::")[-1]
+    targs = m.group(2) or ""
+    out = (base + targs).strip()
+    return out or dem
+
+
+def name_map(co_funcs, bases, pcw):
+    """{pc: simplified demangled name} for all resolvable observed PCs."""
+    resolved = resolve_names(co_funcs, bases, pcw)
+    dem = demangle_batch(sorted(set(resolved.values())))
+    return {pc: simplify(dem[n]) for pc, n in resolved.items()}
+
+
+def name_map_exact(co_hash_funcs, hash2base, pcw):
+    """{pc: simplified demangled name} via deterministic hash<->base pairing.
+
+    Returns (name_map, stats) where stats = (resolved_pcs, total_pcs, co_matched,
+    co_total, pct_duration)."""
+    resolved, matched, n_co = resolve_names_exact(co_hash_funcs, hash2base, pcw)
+    dem = demangle_batch(sorted(set(resolved.values())))
+    names = {pc: simplify(dem[n]) for pc, n in resolved.items()}
+    rtot = sum(pcw.values()) or 1.0
+    rres = sum(pcw.get(pc, 0.0) for pc in resolved)
+    stats = (len(resolved), len(pcw), matched, n_co, 100.0 * rres / rtot)
+    return names, stats


### PR DESCRIPTION
## Summary

Adds `tools/rgp_parser`, a headless, pure-Python toolchain that turns a **Radeon GPU Profiler (RGP)** capture (`.rgp`) into analysis-friendly outputs — per-kernel summary (JSON/MD), operators CSV, per-dispatch CSV, and a Chrome/Perfetto trace — so RGP data is programmable for CI and LLM/agent analysis instead of being locked behind the GUI.

## What it does

- **Pure-Python SQTT decoder** (`struct/sqtt_decode.py`): ports AMD's upstream `rocprof-trace-decoder` gfx11 token parser and adds the post-processing this pipeline needs — dispatch/event/occupancy/realtime records, wave-to-dispatch attribution, wall-clock mapping, and the wavefront-occupancy band. No native binary required; the whole pipeline runs in Python.
- **Exact per-dispatch wavefront/thread counts**: reassembles RGP `USERDATA_2/3` marker streams (grid dims + barriers) to derive authoritative wavefront/thread counts and cap wave attribution, matching RGP's ground truth.
- **Bottleneck analysis**: theoretical occupancy for gfx1151 (VGPR/SGPR/LDS limits) plus opportunistic SPM counter attribution (EA/GL2C bandwidth) to classify each dispatch (overhead / low-occupancy / memory-bound / compute-bound / undetermined), with honest caveats where a number is a heuristic.
- **Symbolization**: deterministic CodeObject-hash ↔ COLoadEvent-base pairing (coverage fallback), demangled to readable `name<args>`; Tensile/hipBLASLt/HIP kernel-name parsing into family/dtype/tile fields for rollups.
- **Per-dispatch model**: busy duration (occupancy wave start/end), `min(wave-span, next-launch gap)` duration, workgroup size, VGPR/SGPR/LDS, cache flush/invalidate flags, `(me, pipe)` queue attribution, idle-gap/launch-overhead accounting, and a Chrome/Perfetto timeline with counter/barrier overlays.

## Validation

- Byte-for-byte parity of the pure-Python decoder against a reference native C++ decode on a real gfx1151 (Strix Halo) capture: **211/211 dispatches, 55252/55252 events** (incl. `seq` order), **42768/42768 occupancy buckets**, plus `rt_freq`/`rt0`.
- Marker-derived wavefront counts match RGP GUI ground truth across dispatches at scale (e.g. 262,144 wavefronts for a matmul).
- End-to-end `build_trace(.rgp)` (pure-Python path) produces dispatches identical (ts, symbolized name, pc) to the pre-decoded `records.json` path.

## Test plan

- [ ] `pip install -r tools/rgp_parser/requirements.txt`
- [ ] `python tools/rgp_parser/main.py <capture>.rgp out/sample` produces the 4 output files
- [ ] Spot-check `out/sample_trace.json` in `chrome://tracing` / Perfetto
- [ ] Confirm decode works with no native decoder present

Scope note: the decoder targets gfx11 (`header.version == 3`); gfx9/10/12/mi400 and instruction-timeline records are intentionally not ported (unused by this pipeline).
