### PR TITLE
feat(hipsr): add hipsr.empty / hipsr.empty_yield ops

### DIFF
--- a/include/hip/Dialect/Hipsr/IR/HipsrEmptyOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrEmptyOp.td
@@ -15,12 +15,9 @@ include "hip/Dialect/Hipsr/IR/HipsrOps.td"
 // Hipsr_EmptyOp
 //===----------------------------------------------------------------------===//
 
-// NOTE (staged delivery): Stage 1 defines the op WITHOUT the
-// DestinationStyleOpInterface (added in Stage 2) and intentionally WITHOUT the
-// `Pure` trait -- hipsr.empty allocates an init tensor (it bufferizes to
-// memref.alloc), so marking it Pure would let CSE merge two distinct inits into
-// one buffer (the tensor.empty CSE aliasing trap). It is modelled like
-// bufferization.alloc_tensor (a fresh allocation), not like tensor.empty.
+// Each hipsr.empty is a fresh init-tensor allocation (like
+// bufferization.alloc_tensor), so it is not memory-effect-free: distinct ops
+// yield distinct buffers even when their shapes match.
 def Hipsr_EmptyOp : Hipsr_Op<"empty",
     [SingleBlockImplicitTerminator<"EmptyYieldOp">]> {
   let summary = "Create init tensor(s) with shape computation in a region";
@@ -34,8 +31,7 @@ def Hipsr_EmptyOp : Hipsr_Op<"empty",
     parent-scope values (e.g. `shape.shape_of %input`, where %input is a domain
     operand). It is variadic so one hipsr.empty can back a multi-output DPS op.
 
-    Bufferizes to one `memref.alloc()` per yielded tensor (bufferization
-    interface added separately, in a later stage).
+    Bufferizes to one `memref.alloc()` per yielded tensor.
 
     Example:
     ```mlir

--- a/lib/Dialect/Hipsr/IR/HipsrEmptyOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrEmptyOp.cpp
@@ -20,18 +20,20 @@ LogicalResult EmptyOp::verify() {
   // yielded tensors become this op's results, so just check count and types.
   auto yieldOp = cast<EmptyYieldOp>(getRegion().front().getTerminator());
 
-  if (yieldOp.getTensors().size() != getNumResults())
+  if (yieldOp.getTensors().size() != getNumResults()) {
     return emitOpError() << "has " << getNumResults()
                          << " result(s) but its empty_yield yields "
                          << yieldOp.getTensors().size() << " value(s)";
+  }
 
   for (unsigned idx : llvm::seq<unsigned>(0, getNumResults())) {
     Type resultType = getResultTypes()[idx];
     Type yieldType = yieldOp.getTensors()[idx].getType();
-    if (resultType != yieldType)
+    if (resultType != yieldType) {
       return emitOpError() << "result #" << idx << " type " << resultType
                            << " does not match the yielded value type "
                            << yieldType;
+    }
   }
 
   return success();


### PR DESCRIPTION
## Summary

Adds the `hipsr.empty` init-tensor carrier op and its `hipsr.empty_yield` terminator, mirroring the landed `hipsr.pool_domain` (#493) file layout.

- `hipsr.empty` wraps output-shape computation in a **non-isolated** `SizedRegion<1>` that builds one `tensor.empty` per result and yields them via `hipsr.empty_yield`; the yielded tensors become the op's results (checked by the verifier).
- Variadic `AnyRankedTensor` results so one `hipsr.empty` can back a multi-output DPS op.
- Convenience methods `getShapes()` (per-result dynamic dims from each yielded `tensor.empty`) and `getTensorTypes()`.

This is the **first stage** of the work tracked by [wcy123/onnx-hipdnn-ep#13](https://github.com/wcy123/onnx-hipdnn-ep/issues/13) / task B1 (Confluence "Materialize Init Tensors Pass", Appendix A/B):

- **This PR (Stage 1):** op + verifier + round-trip/verifier LIT only.
- **Follow-up:** `DestinationStyleOpInterface` (`getDpsInitsMutable` -> empty range), then `BufferizableOpInterface` (region flatten -> one `memref.alloc` per yielded tensor).

### Design note

`hipsr.empty` is intentionally **not** marked `Pure`: it allocates an init tensor (bufferizes to `memref.alloc`), so `Pure` would let CSE merge two distinct inits into one buffer (the `tensor.empty` CSE-aliasing trap). It is modelled like `bufferization.alloc_tensor` (a fresh allocation), not like `tensor.empty`.

## Test plan

- [x] `hip-mlir-opt` builds cleanly with the new ops (TableGen + compile + dialect registration).
- [x] `test/lit/Dialect/Hipsr/empty.mlir` passes `--split-input-file --verify-diagnostics` (negative cases: result-count mismatch, result-type mismatch, later-result-index mismatch, `HasParent`, two-block `SizedRegion<1>`).
- [x] FileCheck round-trips: single dynamic-dim, multi-result (`tensor<?x?xf16>, tensor<?xi64>`), rank-0 scalar (`tensor<f32>`).
