### PR TITLE
feat: add Cursor agent skills and hip-onnx-runner MLIR dump workflow

### DIFF
--- a/morphizen/unit-test/morphizen-e2e-test/cmake/proto.cmake
+++ b/morphizen/unit-test/morphizen-e2e-test/cmake/proto.cmake
@@ -8,7 +8,7 @@ set(MORPHIZEN_E2E_TESTS_PROTO_FILES
 set(MORPHIZEN_E2E_TESTS_PROTO_SRCS "")
 set(MORPHIZEN_E2E_TESTS_PROTO_HDRS "")
 set(Protobuf_USE_STATIC_LIBS ON)
-if(NOT TARGET protobuf::libprotobuf)
+if(NOT TARGET protobuf::libprotobuf OR NOT TARGET protobuf::protoc)
   find_package(Protobuf CONFIG REQUIRED)
 endif()
 if (NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/e2e_config_proto)


### PR DESCRIPTION
## Summary
- Add project Cursor skills and slash commands for ONNX→MLIR dump, Netron-friendly MLIR shrink/fixes, halo load checks, remote model copy, and related dev workflows.
- Extend `hip-onnx-runner` with `--dump-compiler-mlir` / `--mlir-dump-dir` to emit pre-compiler MLIR for debugging.
- Add workspace rules (`gpu-ep-dev-workflow`, `gpu-ep-project`) documenting build/LIT paths on Windows.

## Test plan
- [ ] `hip-onnx-runner --dump-compiler-mlir` on a small ONNX model; confirm `mlir_bytecode_dump.mlir` is written.
- [ ] Run `shrink_mlir_for_netron` pipeline on a large `model.mlir`; open resulting `*.netron.mlir` in Netron.
- [ ] No CI impact expected for `.cursor/` and docs-only paths; runner change should pass existing Windows build.

Made with [Cursor.](https://cursor.com/)