### PR TITLE
perf(transpose): coalesced LDS-tiled batched last-two-dim transpose

### DIFF
--- a/lib/Runtime/Kernels/hip/transpose_kernel.hip
+++ b/lib/Runtime/Kernels/hip/transpose_kernel.hip
@@ -52,7 +52,115 @@ __global__ void transpose_kernel(const T* __restrict__ input,
     output[tid] = input[in_idx];
 }
 
+// Tiled, fully-coalesced batched 2-D transpose. Transposing is pure data
+// movement, so a single kernel templated on an unsigned integer of the element
+// width (uint8/16/32/64_t for 1/2/4/8-byte dtypes such as int8, fp16/bf16,
+// fp32/int32, int64/fp64) is dtype-agnostic. Each grid.z slice transposes one
+// row-major [rows x cols] matrix into a row-major [cols x rows] matrix. Both the
+// load and the store go through a bank-conflict-padded LDS tile so every global
+// access is coalesced, unlike transpose_kernel above whose per-output-element
+// gather issues a strided (uncoalesced) read whenever the innermost dim changes
+// -- the case that dominates the linear-attention [1, S, F] <-> [1, F, S]
+// transposes and runs ~15-30x slower than memory bandwidth. Mirrors the proven
+// tiled transpose used for WMMA layout conversion in matmul_nbits_kernel.hip.
+template <typename T, int TILE>
+__global__ void transpose_tiled_kernel(const T* __restrict__ src,
+                                       T* __restrict__ dst,
+                                       int rows, int cols) {
+    __shared__ T tile[TILE][TILE + 1];
+
+    const int64_t slice = static_cast<int64_t>(blockIdx.z) * rows * cols;
+    const T* s = src + slice;
+    T* d = dst + slice;
+
+    // Load a [TILE(rows) x TILE(cols)] block of src, coalesced along cols.
+    int x = blockIdx.x * TILE + threadIdx.x; // src column
+    int y = blockIdx.y * TILE + threadIdx.y; // src row
+    for (int j = 0; j < TILE; j += blockDim.y) {
+        int yy = y + j;
+        if (x < cols && yy < rows)
+            tile[threadIdx.y + j][threadIdx.x] =
+                s[static_cast<int64_t>(yy) * cols + x];
+    }
+    __syncthreads();
+
+    // Store the transposed block, coalesced along rows (dst's innermost dim).
+    int xo = blockIdx.y * TILE + threadIdx.x; // dst column (= src row)
+    int yo = blockIdx.x * TILE + threadIdx.y; // dst row    (= src col)
+    for (int j = 0; j < TILE; j += blockDim.y) {
+        int yy = yo + j;
+        if (xo < rows && yy < cols)
+            d[static_cast<int64_t>(yy) * rows + xo] =
+                tile[threadIdx.x][threadIdx.y + j];
+    }
+}
+
 }  // namespace
+
+// Fast path for a batched last-two-dim transpose of 1/2/4/8-byte elements.
+// Returns 0 on success, 1 if it declines the config (caller must fall back to
+// the generic hip_transpose), or a hipError_t on launch failure. gridDim.z is
+// capped at 65535 by the HW, so batches larger than that decline; unsupported
+// element widths also decline.
+extern "C" int hip_transpose_2d_tiled(void* stream, const void* input,
+                                      void* output, int64_t batch,
+                                      int64_t rows, int64_t cols,
+                                      int element_size_bytes) {
+    if (!input || !output) {
+        fprintf(stderr,
+                "[custom_kernels] hip_transpose_2d_tiled: null pointer\n");
+        return -1;
+    }
+    if (batch <= 0 || rows <= 0 || cols <= 0)
+        return 0; // nothing to do
+    if (batch > 65535)
+        return 1; // decline: exceeds gridDim.z limit
+
+    constexpr int TILE = 32;
+    dim3 block(TILE, 8);
+    dim3 grid(static_cast<unsigned>((cols + TILE - 1) / TILE),
+              static_cast<unsigned>((rows + TILE - 1) / TILE),
+              static_cast<unsigned>(batch));
+    hipStream_t hip_stream = static_cast<hipStream_t>(stream);
+    const int r = static_cast<int>(rows);
+    const int c = static_cast<int>(cols);
+    switch (element_size_bytes) {
+        case 1:
+            hipLaunchKernelGGL(
+                (transpose_tiled_kernel<uint8_t, TILE>), grid, block, 0,
+                hip_stream, static_cast<const uint8_t*>(input),
+                static_cast<uint8_t*>(output), r, c);
+            break;
+        case 2:
+            hipLaunchKernelGGL(
+                (transpose_tiled_kernel<uint16_t, TILE>), grid, block, 0,
+                hip_stream, static_cast<const uint16_t*>(input),
+                static_cast<uint16_t*>(output), r, c);
+            break;
+        case 4:
+            hipLaunchKernelGGL(
+                (transpose_tiled_kernel<uint32_t, TILE>), grid, block, 0,
+                hip_stream, static_cast<const uint32_t*>(input),
+                static_cast<uint32_t*>(output), r, c);
+            break;
+        case 8:
+            hipLaunchKernelGGL(
+                (transpose_tiled_kernel<uint64_t, TILE>), grid, block, 0,
+                hip_stream, static_cast<const uint64_t*>(input),
+                static_cast<uint64_t*>(output), r, c);
+            break;
+        default:
+            return 1; // decline: unsupported element width -> generic fallback
+    }
+    hipError_t err = hipGetLastError();
+    if (err != hipSuccess) {
+        fprintf(stderr,
+                "[custom_kernels] hip_transpose_2d_tiled launch failed: %s\n",
+                hipGetErrorString(err));
+        return static_cast<int>(err);
+    }
+    return 0;
+}
 
 extern "C" int hip_transpose(void* stream,
                              const void* input,

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -1469,6 +1469,25 @@ HIP_KERNEL_API int hip_transpose(
     int64_t num_elements,
     int element_size_bytes);
 
+/*
+ * hip_transpose_2d_tiled: coalesced LDS-tiled fast path for a *batched
+ * last-two-dim* transpose of 1/2/4/8-byte elements (transpose is pure data
+ * movement, so it is dtype-agnostic given the element width). Each of `batch`
+ * slices transposes a row-major [rows x cols] matrix into [cols x rows].
+ *
+ * Returns 0 on success, 1 if the config is declined -- unsupported element
+ * width or batch > gridDim.z limit -- (caller falls back to the generic
+ * hip_transpose), or a hipError_t / -1 on failure.
+ */
+HIP_KERNEL_API int hip_transpose_2d_tiled(
+    void* stream,
+    const void* input,
+    void* output,
+    int64_t batch,
+    int64_t rows,
+    int64_t cols,
+    int element_size_bytes);
+
 /* =========================================================================
  * MatMulNBits (Fused Dequant + MatMul)
  * =========================================================================

--- a/lib/Runtime/real/transpose.cpp
+++ b/lib/Runtime/real/transpose.cpp
@@ -63,6 +63,40 @@ int wrap_transpose(RuntimeState *state, const void *input, void *output,
       "[REAL] wrap_transpose: rank=%lld, num_elements=%lld, elem_size=%lld\n",
       (long long)rank, (long long)num_elements, (long long)element_size_bytes);
 
+  // Fast path: a batched last-two-dim swap of 1/2/4/8-byte elements
+  // (perm = [0,1,...,r-3, r-1, r-2]) is the layout flip around
+  // linear_attention ([1, S, F] <-> [1, F, S]) that dominates transpose GPU
+  // time. The generic kernel below gathers per output element with an
+  // uncoalesced read there; the tiled kernel restores coalescing. Bit-exact
+  // data movement, so it cannot change any model's output. Falls through to the
+  // generic path if the tiled launcher declines (unsupported width or
+  // batch > gridDim.z limit).
+  if (rank >= 2 && (element_size_bytes == 1 || element_size_bytes == 2 ||
+                    element_size_bytes == 4 || element_size_bytes == 8)) {
+    bool last_two_swap =
+        perm[rank - 1] == rank - 2 && perm[rank - 2] == rank - 1;
+    for (int64_t i = 0; last_two_swap && i < rank - 2; ++i)
+      last_two_swap = perm[i] == i;
+    if (last_two_swap) {
+      int64_t rows = input_shape[rank - 2];
+      int64_t cols = input_shape[rank - 1];
+      int64_t batch = 1;
+      for (int64_t i = 0; i < rank - 2; ++i)
+        batch *= input_shape[i];
+      int rc = hip_transpose_2d_tiled(stream, input, output, batch, rows, cols,
+                                      static_cast<int>(element_size_bytes));
+      if (rc == 0) {
+        RUNTIME_DEBUG_LOG("[REAL] wrap_transpose: tiled 2D path "
+                          "(batch=%lld rows=%lld cols=%lld)\n",
+                          (long long)batch, (long long)rows, (long long)cols);
+        return 0;
+      }
+      if (rc < 0) // hard launch failure -> surface it
+        return rc;
+      // rc == 1: declined (e.g. batch > gridDim.z limit) -> generic fallback.
+    }
+  }
+
   return hip_transpose(stream, input, output, rank, input_shape, perm,
                        num_elements, static_cast<int>(element_size_bytes));
 }


### PR DESCRIPTION
## What

Coalesced LDS-tiled fast path for the EP `transpose` op.

The generic transpose kernel gathers per output element, so its global reads are **uncoalesced whenever the innermost dim changes**. That is exactly the layout flip around linear-attention (`[1, S, F] <-> [1, F, S]`), which dominates transpose GPU time and runs well below memory bandwidth.

`hip_transpose_2d_tiled` transposes each batched `[rows x cols]` slice through a bank-conflict-padded LDS tile, so both the load and the store are fully coalesced. It is templated on element width and handles **1/2/4/8-byte** dtypes (int8, fp16/bf16, fp32/int32, int64/fp64) -- transpose is pure data movement, so it is dtype-agnostic and **bit-exact** (cannot change any model output).

`wrap_transpose` routes a batched last-two-dim swap (`perm = [0..r-3, r-1, r-2]`) of a supported width to the tiled kernel, and falls back to the generic kernel otherwise (non-last-two perms, unsupported widths, or batch beyond the `gridDim.z` limit). Always on -- no env gate.

## Results (gfx1151)

- **RGP:** dominant rank-3 fp16 transpose `9364us -> 1439us` (**6.5x**) at 100% occupancy, VGPR `32 -> 8`.
- **35B VLM prefill:** TTFT P50 **-396 ms (-7.9%)**, prefill throughput **+7.7%**.
- **Decode TPS:** unchanged (transposes are prefill-only).
- **Correctness:** greedy output **bit-identical** with the fast path on vs off.

## Scope / non-goals

Only the batched **last-two-dim** swap is accelerated (the uncoalesced pathology). Other permutations (e.g. rank-4 `[0,2,1,3]`) keep the innermost dim contiguous, are already coalesced on the generic kernel, and intentionally stay on it.

## Test

- A/B on 35B (fast path on/off): output bit-identical; TTFT/throughput as above.
- RGP re-capture confirms the tiled kernel replaces the generic strided kernel for the covered class.
