### PR TITLE
feat(cursor-skill): add export-onnx skill for Olive ONNX export

### DIFF
--- a/.cursor/skills/export-onnx/SKILL.md
+++ b/.cursor/skills/export-onnx/SKILL.md
@@ -1,3 +1,7 @@
+<!--
+Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+Licensed under the MIT License.
+-->
 ---
 name: export-onnx
 description: >-


### PR DESCRIPTION
## Summary
Adds a Cursor **agent skill** (export-onnx) that guides an agent through exporting a vision/ML model into an optimized fp16 ONNX model by authoring and running an Olive recipe under `olive-recipes/`.

## What's included
- `.cursor/skills/export-onnx/SKILL.md` — end-to-end workflow:
  - Inputs (model link / input shape / dtype) and exportability scope (CNNs & standard transformers; excludes multi-view 3D-detection stacks).
  - One-time setup (shallow-clone Olive repos, `hipdnn-ep` env deps, `onnxruntime-directml` caveat).
  - Recipe layout (`user_script.py` / `config.json` / `run.py`), incl. the torchvision shortcut and the required run-from-`olive/` gotcha.
  - `model_type` auto-detection for `OrtTransformersOptimization` (CNN vs transformer).
  - The fp16 duplicate-node post-fix.
  - Verification steps and reference recipes to mirror.

## Notes
- Skill only; no code/runtime changes. Perf-report tooling changes are intentionally excluded.
- Paths are genericized (`%USERPROFILE%\workspace`); no user-specific IDs.