### PR TITLE
perf(pipeline): drop ownership-based buffer deallocation (superseded by pool-allocs)

### DIFF
--- a/docs/design/output-allocator-design.md
+++ b/docs/design/output-allocator-design.md
@@ -49,8 +49,7 @@ Dynamic output shapes are computed **inside** the graph (e.g. `M = memref.dim %i
 
 ```mermaid
 graph TD
-    A[one-shot-bufferize] --> B[buffer-deallocation]
-    B --> C[hip-use-output-allocator]
+    A[one-shot-bufferize] --> C[hip-use-output-allocator]
     C --> D[hip-pool-allocs]
     D --> E[convert-hip-to-llvm]
     E --> F[generate-interface]
@@ -61,8 +60,7 @@ graph TD
 
 ```
 one-shot-bufferize
-buffer-deallocation              ← output still memref.alloc (owned) → no clone
-hip-use-output-allocator         ← memref.alloc → hip.alloc_output (AFTER dealloc)
+hip-use-output-allocator         ← memref.alloc → hip.alloc_output
 hip-pool-allocs                  ← pools only intermediates; skips hip.alloc_output
 convert-hip-to-llvm              ← 2-arg main_graph wrapper
 generate-interface               ← 2-arg inference_compute ABI
@@ -70,7 +68,7 @@ generate-interface               ← 2-arg inference_compute ABI
 - `main_graph(state, inputs_array) -> i32`
 - Outputs allocated in-graph via `hip.alloc_output`, no `outputs_array`
 
-**Pipeline ordering is load-bearing.** `hip-use-output-allocator` runs *after* `buffer-deallocation` and *before* `hip-pool-allocs` (the "slot 4.5" placement). After dealloc, the output is still a plain `memref.alloc` (owned) and is returned with no clone; running before dealloc would make the deallocator clone the unowned `hip.alloc_output` result at the `return`, defeating zero-copy. Before pool-allocs keeps the EP-owned output out of the GPU pool. Pinned in [test/lit/Pipeline/output-allocator-dealloc.mlir](../../test/lit/Pipeline/output-allocator-dealloc.mlir).
+**Pipeline ordering is load-bearing.** `hip-use-output-allocator` runs *before* `hip-pool-allocs` (the "slot 4.5" placement) so the EP-owned output stays out of the GPU pool. Note this pipeline does **not** run ownership-based buffer deallocation at all — every transient is packed into session-owned pool(s) by `hip-pool-allocs` (as `memref.view` over `hip.get_pool`) rather than freed per-`memref.alloc`, so there is nothing to deallocate (see the pipeline-tail comment in `lib/Dialect/Transforms/Pipelines.cpp`). The historical constraint of running the output-allocator *after* deallocation (to stop the deallocator cloning the unowned `hip.alloc_output` at the `return`) is therefore moot.
 
 ---
 
@@ -91,9 +89,9 @@ Introduce `hip.alloc_output` — an operation that allocates output buffers via 
 - Attribute: `out_idx` identifying which graph output
 - Result type: memref with static dims from type, dynamic dims from operands
 
-**Key property:** Does not declare `Allocate` memory effect — the buffer is owned by the EP/runtime, not the graph, so buffer-deallocation never inserts a `hip.free` for it.
+**Key property:** Does not declare `Allocate` memory effect — the buffer is owned by the EP/runtime, not the graph, so `hip-pool-allocs` skips it and no `hip.free` is ever emitted for it.
 
-**Placement in pipeline:** *after* `buffer-deallocation`, *before* `hip-pool-allocs` (so pooling skips the EP-owned buffer). `hip-use-output-allocator` is FuncOp-scoped: it rewrites returned allocs (leaving each signature + `return` intact). The after-dealloc order is load-bearing — see [§2](#the-pipeline).
+**Placement in pipeline:** *before* `hip-pool-allocs` (so pooling skips the EP-owned buffer). `hip-use-output-allocator` is FuncOp-scoped: it rewrites returned allocs (leaving each signature + `return` intact). See [§2](#the-pipeline).
 
 The `hip-use-output-allocator` pass replaces the returned `memref.alloc` for each graph output with `hip.alloc_output`, reusing the alloc's dynamic-size operands. An alloc counts as a graph output when `func.return` hands it back — either directly, or after it passes through view ops (`memref.cast`, `memref.collapse_shape`, `memref.expand_shape`, `memref.subview`, any number of them). The pass uses `BufferViewFlowAnalysis` to check this: an alloc is an output if any value made from it via those view ops is returned. This handles reshaped / cast / subview'd outputs without special-casing each op, and the view ops between the alloc and the return are left in place.
 

--- a/lib/Dialect/Transforms/Pipelines.cpp
+++ b/lib/Dialect/Transforms/Pipelines.cpp
@@ -13,7 +13,6 @@
 #include "mlir/Conversion/BufferizationToMemRef/BufferizationToMemRef.h"
 #include "mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h"
 #include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
-#include "mlir/Dialect/Bufferization/Pipelines/Passes.h"
 #include "mlir/Dialect/Bufferization/Transforms/Passes.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/Passes.h"
@@ -68,8 +67,8 @@ void addPluginPassesForSlot(OpPassManager &pm,
 /// Graph outputs use the output-allocator ABI: `hip-use-output-allocator` runs
 /// at slot 4.5, rewriting each returned `memref.alloc` into `hip.alloc_output`
 /// (allocated in-graph at runtime via the EP's output-allocator callback).
-/// Where it runs matters (after buffer-deallocation, before pool-allocs); the
-/// reason is at that slot. See docs/design/output-allocator-design.md.
+/// It must run before pool-allocs (slot 6); the reason is at that slot. See
+/// docs/design/output-allocator-design.md.
 static void buildOnnxToHipPipelineTail(OpPassManager &pm) {
   // 1b. Refine `?` (kDynamic) dims on HIP DPS op result types using each
   //     op's `ReifyRankedShapedTypeOpInterface` impl. Placed here so the
@@ -153,39 +152,39 @@ static void buildOnnxToHipPipelineTail(OpPassManager &pm) {
   //    LoopLowering expects. @main_graph keeps its returned memrefs here and
   //    defers output handling to slot 4.5 (hip-use-output-allocator). This pass
   //    is scoped to the private loop bodies (modifyPublicFunctions = false) and
-  //    must run before buffer-deallocation.
+  //    must run before the pool/lowering passes that consume the out-param ABI.
   pm.addPass(mlir::hip::createLoopBodyToOutParamsPass());
 
-  // 4. Insert ownership-based buffer deallocation
-  bufferization::BufferDeallocationPipelineOptions deallocOpts;
-  bufferization::buildBufferDeallocationPipeline(pm, deallocOpts);
+  // 4. Ownership-based buffer deallocation is intentionally NOT run. One-Shot
+  //    Bufferize emits a `memref.alloc` per transient, but this pipeline never
+  //    frees them individually: `hip-pool-allocs` (slot 6) rewrites each into a
+  //    `memref.view` over one of the session-owned pools (`hip.get_pool`),
+  //    reusing slots across disjoint lifetimes and freeing the pools once at
+  //    session cleanup; graph outputs become runtime-owned `hip.alloc_output`
+  //    (slot 4.5). So no individually allocated buffer survives -- there is
+  //    nothing to deallocate. Running the pass is also a compile-time hazard:
+  //    buffer-deallocation-simplification's O(n^2) pairwise `isSameAllocation`
+  //    scan over the one giant `bufferization.dealloc` it emits per block hangs
+  //    large single-block functions. (Dropping the bundle also omits
+  //    expand-realloc, fine here: the pipeline emits no `memref.realloc`.)
 
   // 4.5. hip-use-output-allocator (FuncOp) rewrites each returned
   //      `memref.alloc` into `hip.alloc_output` (EP-owned, allocated in-graph
   //      at runtime via the output-allocator callback). Leaves the function
-  //      signature + `return` intact.
-  //
-  //      Ordering is load-bearing -- the rewrite MUST run AFTER buffer-
-  //      deallocation: `hip.alloc_output` has a Write effect but NO Allocate
-  //      effect, so the ownership-based deallocation pass would treat it as an
-  //      unowned value at the `func.return` and clone it (`%c =
-  //      bufferization.clone %out; return %c`), adding a per-inference alloc +
-  //      full-output copy. By running here the deallocation pass sees the
-  //      output as a plain `memref.alloc` (Allocate effect => owned), so it
-  //      returns it directly with no clone and no dealloc. Still runs BEFORE
-  //      pool-allocs (slot 6) so the EP-owned output never enters the GPU pool,
-  //      which only absorbs `memref.alloc`. Verified by test/lit/Pipeline/
-  //      output-allocator-dealloc.mlir (both orderings).
+  //      signature + `return` intact. Must run BEFORE pool-allocs (slot 6) so
+  //      the EP-owned output never enters the GPU pool, which only absorbs
+  //      `memref.alloc` (`hip.alloc_output` carries a Write but no Allocate
+  //      effect).
   pm.addNestedPass<func::FuncOp>(mlir::hip::createUseOutputAllocatorPass());
 
   // 4.6. Rewrite frozen Concat-accumulator offsets in outlined hip.loop bodies
   //      to iter-driven offsets (the loop trampoline aliases v_in/v_out onto
   //      one descriptor, freezing `memref.dim %v_in` so a growing accumulator
   //      keeps only its last chunk). Placement is load-bearing: AFTER
-  //      buffer-deallocation (the in-place-writer alias only exists
-  //      post-out-param-promotion) and BEFORE the pool/hoist passes (so the
-  //      synthesized readback + index_cast flow through them). No-op on
-  //      non-loop-body funcs. See FixLoopAccumulatorOffset.cpp.
+  //      out-param promotion (slot 3, which is what creates the in-place-writer
+  //      alias) and BEFORE the pool/hoist passes (so the synthesized readback +
+  //      index_cast flow through them). No-op on non-loop-body funcs. See
+  //      FixLoopAccumulatorOffset.cpp.
   pm.addNestedPass<func::FuncOp>(
       mlir::hip::createFixLoopAccumulatorOffsetPass());
 

--- a/test/lit/Pipeline/output-allocator-dealloc.mlir
+++ b/test/lit/Pipeline/output-allocator-dealloc.mlir
@@ -2,24 +2,22 @@
 // Licensed under the MIT License.
 //
 //===----------------------------------------------------------------------===//
-// R2 gate: pins the buffer-deallocation vs hip-use-output-allocator ordering.
+// Isolated pass-interaction record -- NOT the production pipeline.
 //
-// hip.alloc_output carries a Write effect but NO Allocate effect (so the
-// ownership-based deallocation pass never FREES the EP-owned output buffer).
-// But "not freed" is not the whole story: a value returned by func.return whose
-// defining op has no Allocate effect is treated as UNOWNED, so if
-// hip-use-output-allocator runs BEFORE buffer-deallocation the deallocation
-// pass inserts a `bufferization.clone` at the return (returning the clone, not
-// the EP buffer) -- an extra per-inference alloc + full-output copy that
-// defeats the allocator's zero-copy goal.
+// The onnx-to-hip pipeline no longer runs ownership-based buffer deallocation
+// at all: hip-pool-allocs owns every buffer lifetime, so there is nothing to
+// deallocate (see lib/Dialect/Transforms/Pipelines.cpp buildOnnxToHipPipelineTail).
+// This file is retained only to document the pass INTERACTION that motivated the
+// output-allocator's placement, should deallocation ever be reintroduced:
 //
-// Therefore the onnx-to-hip allocator pipeline runs hip-use-output-allocator
-// AFTER buffer-deallocation (slot 4.5), when the output is still a
-// memref.alloc (Allocate effect => owned, returned directly with no clone).
-// This file characterizes BOTH orderings against the same input so the choice
-// is a committed, regression-guarded decision record. See
-// lib/Dialect/Transforms/Pipelines.cpp (buildOnnxToHipPipelineTail) and
-// docs/design/output-allocator-design.md.
+// hip.alloc_output carries a Write effect but NO Allocate effect, so a value
+// returned by func.return whose defining op has no Allocate effect is treated
+// as UNOWNED. If hip-use-output-allocator ran BEFORE buffer-deallocation, the
+// deallocation pass would insert a `bufferization.clone` at the return
+// (returning the clone, not the EP buffer) -- an extra per-inference alloc +
+// full-output copy defeating zero-copy; running AFTER leaves the output a plain
+// memref.alloc (owned, returned directly, no clone). This file characterizes
+// BOTH orderings against the same input.
 //===----------------------------------------------------------------------===//
 
 // Chosen ordering (deallocation THEN allocator): clean, zero-copy.


### PR DESCRIPTION
## Issue

On very large models (a single graph with hundreds of thousands of ops), compilation hangs in the buffer-deallocation pass. It builds one huge `bufferization.dealloc`, and the deallocation-simplification step then compares every buffer against every other to decide if they alias — an O(n²) scan that can take hours.

## Fix

Stop running the buffer-deallocation pipeline. This EP doesn't need it: instead of allocating and freeing each temporary individually, `hip-pool-allocs` packs all temporaries into session-owned pool(s) that live for the whole session and are freed once at the end, and graph outputs are owned by the runtime allocator. So there are no per-buffer allocations to free — the pass was pure overhead, and its output was already being discarded later in the pipeline.

Verified that the final compiled code is unchanged (same pooling, no leaks) on qwen3.5-35B, qwen3.5-9B, and gemma3; broader CI validation to follow.