### PR TITLE
refactor(pipeline): group pool allocation preconditions

### DIFF
--- a/lib/Dialect/Transforms/Pipelines.cpp
+++ b/lib/Dialect/Transforms/Pipelines.cpp
@@ -61,6 +61,19 @@ void addPluginPassesForSlot(OpPassManager &pm,
   }
 }
 
+/// Add shape normalizations used only to improve hip-pool-allocs:
+///   - resolve-memref-dims folds `memref.dim` through view chains to the root
+///     buffer.
+///   - hoist-alloc-size-arith moves size computations above the first dynamic
+///     allocation.
+/// Omitting either preserves correctness but may split allocations into more
+/// dominance domains and increase peak memory. Run these after view creation
+/// and immediately before pooling.
+void addPoolAllocsShapePreconditionPasses(OpPassManager &pm) {
+  pm.addNestedPass<func::FuncOp>(mlir::hip::createResolveMemRefDimsPass());
+  pm.addNestedPass<func::FuncOp>(mlir::hip::createHoistAllocSizeArithPass());
+}
+
 } // namespace
 
 /// Common tail of the ONNX-to-HIP pipeline after the OnnxToHip pass.
@@ -215,58 +228,34 @@ static void buildOnnxToHipPipelineTail(OpPassManager &pm) {
   // 6. HIP-specific buffer optimizations
   pm.addNestedPass<func::FuncOp>(mlir::hip::createOptimizeMemRefsPass());
 
-  // 6a. Promote strided memref operands of hip.* ops to contiguous
-  //     temporaries.  Required because the HIP runtime call ABI (used by
-  //     --convert-hip-to-llvm) only forwards a bare alignedPtr per memref
-  //     operand and has no channel for offset / per-dim strides; without
-  //     this pass, hip.* ops that consume memref.subview results read the
-  //     base of the parent buffer rather than the slice.
-  //
-  //     Placement: after OptimizeMemRefs (so we don't fight its
-  //     subview-folding) and before PoolAllocs (so the new transient
-  //     memref.alloc / memref.dealloc pairs flow through pool views and do
-  //     not trigger extra hipMalloc calls per inference).
+  // The remaining pre-pooling passes have two distinct roles:
+  //   - Correctness/ABI passes that must introduce or redirect allocations
+  //     before pooling (6a and 6b).
+  //   - Shape preconditions used only to improve pool quality (grouped in 6c).
+
+  // 6a. Correctness/ABI: promote strided memref operands of hip.* ops to
+  //     contiguous temporaries. The HIP runtime ABI (--convert-hip-to-llvm)
+  //     forwards only a bare aligned pointer per memref, with no offset or
+  //     stride metadata; otherwise, a hip.* op fed a `memref.subview` would
+  //     read the parent buffer's base instead of the slice. Runs after
+  //     OptimizeMemRefs to avoid competing subview rewrites and before pooling
+  //     so the new temporaries become pool views rather than per-inference
+  //     allocations.
   pm.addNestedPass<func::FuncOp>(
       mlir::hip::createPromoteStridedHipOperandsPass());
 
-  // 6b. Redirect tiny host-fed memref.alloc ops (bufferized
-  //     `tensor.from_elements` for shape arithmetic — rank-0 / 1xi64) away
-  //     from the GPU pool to a runtime-owned host-mapped scratch buffer.
-  //
-  //     Placement is load-bearing: MUST run AFTER PromoteStridedHipOperands
-  //     (so any contiguous-temporary memref.alloc that pass introduces is
-  //     also visible to the candidate scan) and BEFORE PoolAllocs (so
-  //     candidates are removed from its input set).  If PoolAllocs runs
-  //     first, it absorbs the alloc into a memref.view over GPU pool memory
-  //     and the subsequent host store SEGVs on targets where the GPU pool is
-  //     real device memory (other targets silently worked because hipMalloc
-  //     returned UMA-mapped host memory there, masking the bug).  See
-  //     MaterializeHostScalars.cpp file header for the full pinned-mapped
-  //     story; the static-shape lockdown test under
-  //     test/lit/Pipelines/ asserts this ordering does not regress.
+  // 6b. Correctness/ABI: redirect tiny host-fed memref.alloc ops (bufferized
+  //     `tensor.from_elements` shape arithmetic) from the GPU pool to
+  //     runtime-owned host-mapped scratch. Must run after 6a so its candidate
+  //     analysis sees the final allocation set, and before pooling so
+  //     host-written buffers never become views into device memory. See
+  //     MaterializeHostScalars.cpp; pipeline-static-shape-lockdown.mlir locks
+  //     down this ordering.
   pm.addNestedPass<func::FuncOp>(mlir::hip::createMaterializeHostScalarsPass());
 
-  // 6b'. Post-bufferize twin of slot 1c: fold `memref.dim` of view ops
-  //      (created by bufferization + PromoteStridedHipOperands, i.e. after
-  //      resolve-tensor-dims ran) back to the root/func-arg dim. Placement is
-  //      load-bearing -- AFTER the view-creating passes (6a, 6b) and BEFORE
-  //      HoistAllocSizeArith (6c), so the re-rooted size cones hoist and
-  //      PoolAllocs shares one pool instead of one domain per alloc. See
-  //      ResolveMemRefDims.cpp.
-  pm.addNestedPass<func::FuncOp>(mlir::hip::createResolveMemRefDimsPass());
-
-  // 6c. Hoist speculatable size arithmetic feeding `memref.alloc` dynamic
-  //     operands above the earliest dynamic alloc in the entry block.
-  //     PoolAllocs's single-block dominator-emit phase requires every
-  //     dyn-operand SSA def to dominate the earliest pooled alloc; this
-  //     pass establishes that precondition for IR where canonicalize left
-  //     speculatable arith interleaved with allocs.  No-op for
-  //     already-feasible IR; PoolAllocs.cpp itself is unchanged.  Uses
-  //     `mlir::isSpeculatable` (the same predicate upstream LICM uses) so
-  //     traps (e.g. `arith.divsi` with a runtime-zero divisor) are not
-  //     speculated across the move.  See HoistAllocSizeArith.cpp for the
-  //     algorithm and rationale.
-  pm.addNestedPass<func::FuncOp>(mlir::hip::createHoistAllocSizeArithPass());
+  // 6c. Pool quality: normalize dynamic allocation sizes after all view and
+  //     allocation rewrites, immediately before hip-pool-allocs.
+  addPoolAllocsShapePreconditionPasses(pm);
 
   pm.addNestedPass<func::FuncOp>(mlir::hip::createPoolAllocsPass());
 


### PR DESCRIPTION
Groups the two shape-normalization passes used by `hip-pool-allocs` into a helper. Updates the surrounding comments to distinguish pool-quality preconditions from correctness and ABI passes.

No functional changes. The pass order is unchanged.

Made with [Cursor](https://cursor.com)