### PR TITLE
docs: streamline README and supported operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,258 +2,134 @@
 Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 Licensed under the MIT License.
 -->
-# ONNXRuntime HIP Execution Provider
+# ROCm hip-ep
 
-An implementation of HIP for ONNXRuntime.
+**hip-ep** is an ONNX Runtime Execution Provider for AMD GPUs. It compiles ONNX graphs through an MLIR pipeline—from ONNX dialect operations to a custom HIP dialect and LLVM IR—and executes them with hipDNN, MIOpen, hipBLASLt, and custom HIP kernels.
 
-This project demonstrates the integration of HIP (Heterogeneous-compute Interface for Portability) operations within the MorphiZen optimization framework for ONNX Runtime.
+The provider integrates with ONNX Runtime through the MorphiZen pass framework. By default, compiled models are emitted as OS-portable LLVM bitcode and JIT-loaded in-process when a session is created. Native per-model libraries remain available as an opt-in artifact format.
 
----
+## Highlights
 
-## Features
+- **MLIR compiler pipeline** — lowers ONNX graphs to HIP and LLVM IR.
+- **ROCm execution backends** — dispatches to hipDNN, MIOpen, hipBLASLt, and custom HIP kernels.
+- **Dynamic shapes** — supports runtime batch/sequence dimensions, shape refinement, and runtime-sized outputs.
+- **GPU memory planning** — packs transient allocations into one or more grow-on-demand pool domains and keeps host-written shape scalars in separate host-mapped scratch.
+- **In-graph output allocation** — allocates graph outputs through the Execution Provider callback once their runtime shapes are known.
+- **Externalized constants** — stores large model weights in a sidecar constants file instead of embedding them in the model artifact.
+- **Two artifact formats** — LLVM bitcode with in-process JIT by default, or a native `.dll`/`.so` when explicitly requested.
+- **Extensible compiler pipeline** — supports registered plugin slots and out-of-tree dialect/pass plugins.
+- **GPU-free development** — provides a mock runtime for compiler and LIT testing without ROCm hardware.
 
-- **MLIR Compiler Pipeline**: ONNX dialect → HIP dialect → LLVM IR → native DLL
-- **MIOpen Integration**: Conv, ConvTranspose, RMS Norm, Sigmoid, Tanh, Softplus; fp elementwise Mul/Add/Min/Max; CausalConvWithState uses MIOpen only on the general fallback path
-- **hipBLASLt MatMul**: High-performance matrix multiplication
-- **Custom HIP Kernels**: GQA, RoPE, Cast, Sub, Gather, ReduceSum, Reciprocal, Sqrt, GELU, Range, LinearAttention, Softmax, CausalConvWithState(fast path)
-- **Memory Pool Optimization**: `hip-pool-allocs` pass packs allocations into a single grow-on-demand buffer
-- **Constant Externalization**: Large model weights stored in `.constants.bin` constants files
-- **Mock Runtime**: GPU-free development and testing with `BUILD_MOCK_RUNTIME=ON`
-- **MorphiZen EP Integration**: Plugs into ONNX Runtime as the MorphiZen Execution Provider
+## Get started
 
----
+| Goal | Guide |
+|---|---|
+| Build and run on Windows | [Windows quick start](docs/quick_start.md) |
+| Build on Linux, use Docker, or download a prebuilt package | [Linux quick start](docs/quick_start_linux.md) |
+| Understand artifact formats | [LLVM IR vs native artifacts](docs/native-vs-ir-comparison.md) |
+| Extend the pipeline with a plugin | [Plugin authoring guide](docs/plugin_authoring.md) |
+| Contribute to the project | [Contributing guide](CONTRIBUTING.md) |
 
-## Supported Operations
+## How it works
 
-| Operation | Backend |
-|-----------|---------|
-| Conv | MIOpen |
-| ConvTranspose | MIOpen |
-| MatMul | hipBLASLt |
-| Gemm | hipBLASLt |
-| Transpose | Custom HIP Kernel |
-| Mul | MIOpen |
-| Add | MIOpen |
-| Softmax | Custom HIP Kernel |
-| Sigmoid | MIOpen |
-| Tanh | MIOpen |
-| Softplus | MIOpen |
-| Gelu | Custom HIP kernel |
-| BiasGelu (com.microsoft) | Custom HIP kernel |
-| FastGelu (com.microsoft) | Custom HIP kernel |
-| Reciprocal | Custom HIP kernel |
-| Sqrt | Custom HIP kernel |
-| Exp | Custom HIP Kernel |
-| Log | Custom HIP Kernel |
-| Pow | Decomposed → Mul / Sqrt / Reciprocal for constant scalar exponents |
-| Sub | Custom HIP Kernel |
-| Cast | Custom HIP Kernel |
-| CastLike | Decomposed → Cast |
-| Ceil | Custom HIP Kernel |
-| Neg | Custom HIP Kernel |
-| Equal | Custom HIP Kernel |
-| Not | Custom HIP Kernel |
-| And | Custom HIP Kernel |
-| Or | Custom HIP Kernel |
-| Abs | Custom HIP Kernel |
-| Cos | Custom HIP Kernel |
-| Sin | Custom HIP Kernel |
-| Div | Custom HIP Kernel |
-| Mod | Custom HIP Kernel |
-| Sign | Custom HIP Kernel |
-| Where | Custom HIP Kernel |
-| Less | Custom HIP Kernel |
-| Greater | Decomposed (Less(B, A)) |
-| GreaterOrEqual | Decomposed (Not(Less(A, B))) |
-| LessOrEqual | Decomposed (Not(Less(B, A))) |
-| Min | MIOpen |
-| Max | MIOpen |
-| ReduceSum | Custom HIP Kernel |
-| ReduceMax | Custom HIP Kernel |
-| ReduceMin | Custom HIP Kernel |
-| ReduceProd | Custom HIP Kernel |
-| ReduceMean | Custom HIP Kernel |
-| CumSum | Custom HIP Kernel |
-| Pad | Custom HIP Kernel |
-| Tile | Custom HIP Kernel |
-| Expand | Custom HIP Kernel |
-| GatherND | Custom HIP Kernel |
-| ScatterND | Custom HIP Kernel (reductions: none / add / mul / min / max) |
-| ScatterElements | Custom HIP Kernel (reductions: none / add / mul / min / max) |
-| Range | Custom HIP kernel |
-| Size | Custom HIP Kernel (folds to a constant for static shapes) |
-| NonZero | Custom HIP Kernel |
-| Gather | Custom HIP Kernel |
-| GatherElements | Custom HIP Kernel |
-| TopK | Custom HIP Kernel |
-| If | Runtime branch dispatch (outlined then/else) |
-| Compress | Custom HIP Kernel |
-| OneHot | Custom HIP Kernel |
-| LayerNormalization | Custom HIP Kernel |
-| SkipLayerNormalization (com.microsoft) | Decomposed → Add (MIOpen) + LayerNormalization (Custom HIP Kernel) |
-| RMSNormalization | MIOpen |
-| SimplifiedLayerNormalization | MIOpen |
-| SkipSimplifiedLayerNormalization (com.microsoft) | MIOpen |
-| LpNormalization | Decomposed → Mul / ReduceSum / Sqrt / Div |
-| RotaryEmbedding (com.microsoft) | Custom HIP Kernel |
-| GroupQueryAttention (com.microsoft) | Custom HIP Kernel |
-| MultiHeadAttention (com.microsoft) | hipBLASLt + Custom HIP Kernels (encoder–decoder attention also lowers to GroupQueryAttention) |
-| Attention (com.microsoft) | Custom HIP Kernel (fused QKV split, lowered to GroupQueryAttention) |
-| Attention (ai.onnx opset 23/24) | Lowered to GroupQueryAttention (rank-3/rank-4 Q/K/V; 1 or 3 outputs; causal and/or additive-mask, or bidirectional; optional KV cache) |
-| MatMulNBits (com.microsoft) | Custom HIP Kernel |
-| QMoE (com.microsoft) | Custom HIP Kernel |
-| GatherBlockQuantized (com.microsoft) | Custom HIP Kernel |
-| LinearAttention (com.microsoft) | Custom HIP Kernel |
-| CausalConvWithState (com.microsoft) | Custom HIP Kernel (decode / prefill fast paths) + MIOpen (general fallback) |
-| Relu | Decomposed → Max (MIOpen) |
-| LeakyRelu | Custom HIP Kernel |
-| Clip | Decomposed → Max + Min (MIOpen) |
-| MaxPool | Custom HIP Kernel |
-| AveragePool | Custom HIP Kernel |
-| LpPool | Custom HIP Kernel |
-| Resize | Custom HIP Kernel |
-| GlobalAveragePool | Custom HIP Kernel |
-| GlobalMaxPool | Custom HIP Kernel |
-| GlobalLpPool | Custom HIP Kernel |
-
-### Compiler-Optimized Operations
-
-These operations are handled through standard MLIR transformations without requiring GPU backend support:
-
-| Operation | Implementation | Notes |
-|-----------|----------------|-------|
-| Reshape | tensor.expand_shape / tensor.collapse_shape | Zero-cost metadata operation, no data movement |
-| Unsqueeze | tensor.expand_shape | Inserts size-1 axes; shape/stride reinterpretation only |
-| Squeeze | tensor.collapse_shape | Removes size-1 axes; shape/stride reinterpretation only |
-| Split | tensor.extract_slice | Zero-copy tensor partitioning; creates views without data movement |
-| Slice (constant params, positive stride) | tensor.extract_slice (compile-time decompose) | Most common case — constant starts/ends/axes/steps with positive unit/N stride. Lowers to zero-copy `memref.subview` after bufferization. Non-constant indices or negative steps fall through to a native `hip.slice` op backed by a runtime kernel (`hip_slice`); index tensors are assumed INT64. |
-| Concat | tensor.empty + tensor.insert_slice | Variadic-input concatenation along any axis. Rewritten to one `tensor.empty` plus N `tensor.insert_slice` ops; each insert bufferizes to a `memref.subview` + `memref.copy` against the pooled output buffer. Static, dynamic and mixed shapes are all handled via mixed `OpFoldResult` offsets/sizes; no Concat-specific runtime kernel. |
-| Shape | tensor.dim + tensor.from_elements | Fully static shapes fold to a compile-time constant (placed in the constants blob). Dynamic dims lower to `tensor.dim` queries assembled via `tensor.from_elements`; honours optional `start`/`end` sub-range attributes. |
-| Constant | arith.constant or externalized to .constants.bin | ONNX Constant nodes: small values inlined, large tensors externalized |
-| ConstantOfShape | arith.constant (compile-time fold) | Folds to a splat constant when the shape input is itself constant; honours optional `value` attribute |
-| Identity | SSA value forwarding | Pass-through op; the input value is wired directly to every user (equivalent to a full-range `memref.subview` view, but cheaper — no view op is materialised in the IR) |
-| Flatten | tensor.collapse_shape (+ tensor.expand_shape for axis = 0 / axis = r) | Reshapes rank-r input to rank-2; pure metadata reinterpretation. Dynamic dims supported. |
-
----
-
-## Project Design
-
-### Components
-
-- **HIP MLIR Dialect** (`lib/Dialect/`) — custom dialect: `hip.conv`, `hip.matmul`, `hip.gqa`, etc.
-- **ONNX → HIP Conversion** (`lib/Conversion/OnnxToHip/`) — pattern-based ONNX op lowering
-- **HIP → LLVM Lowering** (`lib/Conversion/HipToLLVM/`) — lowers HIP ops to runtime C API calls
-- **Compiler Driver** (`lib/Compiler/`) — orchestrates the full compilation pipeline
-- **Runtime** (`lib/Runtime/`) — real (GPU) and mock (CPU) backends
-- **Custom HIP Kernels** (`lib/Runtime/Kernels/`) — handwritten `.hip` kernels for GQA, RoPE, etc.
-- **Compiler DLL** (`dll/`) — `hip-compiler.dll` exposing the C API
-- **Schemas** (`schemas/`) — FlatBuffers definitions for model metadata and compilation options
-- **Tools** — `hip-mlir-opt`, `hip-compiler`, `hip-onnx-runner`, `hip-inspect`, `hip-test`
-- **Backend Integration** (`backend-mlir-compiler/`) — bridges to MorphiZen Execution Provider
-
-### Architecture
-
-```
-=== COMPILE-TIME ===
-
-ONNX Model (.onnx)
-  │
-  ▼
-onnx-to-hip-pipeline
-    simplify-onnx                  (CastLike → Cast, drop dead type-donor args)
-    hip-add-context-arg
-    onnx-loop-outline              (+ hip-infer-loop-body-shapes)
-    onnx-if-outline
-    convert-onnx-to-hip            constants → .constants.bin
-    hip-infer-shapes               (refine dynamic result dims)
-    hip-resolve-tensor-dims
-    one-shot-bufferize             (tensor → memref)
-    hip-loop-body-to-out-params    (outlined onnx.Loop bodies → out-param ABI)
-    buffer-deallocation            (ownership-based)
-    hip-use-output-allocator       (graph outputs allocated in-graph via the
-                                    EP's output-allocator callback)
-    hip-fix-loop-accumulator-offset (onnx.Loop growing-accumulator offsets)
-    convert-linalg-to-loops        (lower any residual linalg.* to scf + stores)
-    hip-optimize-memrefs           (liveness-based buffer reuse)
-    hip-promote-strided-operands
-    hip-materialize-host-scalars   (host-mapped scratch for shape scalars)
-    hip-hoist-alloc-size-arith
-    hip-pool-allocs                (single grow-on-demand GPU pool)
-    convert-bufferization-to-memref (lower residual bufferization.* ops)
-    hip-lower-allocs               (memref.alloc → hip.alloc/free)
-    hip-resolve-extern-constants
-  │  (canonicalize / CSE cleanup runs interleaved between stages)
-  ▼
-hip-to-llvm-pipeline
-    hip-relax-multi-dyn-expand-shape
-    expand-strided-metadata        (+ lower-affine)
-    scf-to-control-flow            (+ reconcile-unrealized-casts)
-    convert-hip-to-llvm            (HIP ops → runtime C API calls)
-    generate-interface             (inference_init / compute / cleanup)
-  │
-  ▼
-MLIR → LLVM IR → optimize
-  │
-  ▼
-artifact_format?
-  ├─ LLVM_IR (default): emit model.bc  (runtime.bc kept separate;
-  │                     OS-portable, no linker)
-  └─ NATIVE  (opt-in) : merge runtime.bc → link model.dll/.so
-  │
-  ▼
-model.bc | model.dll   +   constants.bin
-
-
-=== RUNTIME ===
-
-Load artifact + constants.bin   (loader = artifact_format)
-  ├─ LLVM_IR: LlvmIrJit JIT-links model.bc + the runtime.bc
-  │           embedded in the EP, in-process (LLVM ORC)
-  └─ NATIVE : LoadLibrary / dlopen model.dll/.so
-  │
-  ▼
-inference_init    → GPU handles, upload constants, alloc pool
-inference_compute → execute ops (MIOpen / hipBLASLt / kernels)
-inference_cleanup → free GPU resources
-
-Dependencies: amdhip64, MIOpen, hipblaslt, custom_kernels
-No OS toolchain at inference time (LLVM_IR JITs in-process;
-the LLVM ORC engine ships inside the EP)
+```text
+ONNX model
+    │
+    ▼
+ONNX Runtime + MorphiZen EP integration
+    │
+    ▼
+ONNX MLIR
+    │  ONNX-to-HIP lowering
+    ▼
+HIP MLIR
+    │  shape refinement, bufferization, and memory planning
+    ▼
+LLVM dialect
+    │  HIP-to-LLVM lowering + generated model interface
+    ▼
+Per-model artifact + constants file
+    ├── LLVM bitcode (default) ──► in-process ORC JIT
+    └── native .dll/.so (opt-in) ─► OS dynamic loader
+    │
+    ▼
+hipDNN / MIOpen / hipBLASLt / custom HIP kernels
+    │
+    ▼
+AMD GPU
 ```
 
-> **Output-allocator ABI.** The EP compiles every model to the
-> 2-arg `inference_compute(state, inputs)` form: graph outputs are allocated
-> *in-graph* at runtime via the EP's output-allocator callback (`hip.alloc_output`),
-> emitted by the `hip-use-output-allocator` pass, which runs unconditionally.
+The generated model interface initializes per-session runtime state, executes the compiled graph, and releases resources. Graph outputs are allocated in-graph through the provider's output-allocation callback; transient buffers use lifetime-aware GPU pool planning.
 
-> **Artifact format.** Selected by the single compile option `artifact_format`
-> (`LLVM_IR` default, `NATIVE` opt-in) and recorded in the EPContext metadata,
-> which the EP reads at load time. The default ships **OS-portable LLVM IR** (`.bc`,
-> JIT-loaded in-process); native `.dll`/`.so` stays a first-class opt-in for
-> benchmarking/parity — see
-> [docs/native-vs-ir-comparison.md](docs/native-vs-ir-comparison.md).
+For the exact registered pass names and ordering, see the [pipeline pass menu](docs/pipeline_pass_menu.md). For compiler/runtime ABI details, see the [compiler-runtime contract](docs/design/compiler-runtime-contract.md).
 
----
+## Supported operations
 
-## Building
+hip-ep supports common operation families used by transformer, vision, convolutional, quantized, and multimodal models:
 
-For prerequisites, environment setup, and step-by-step build instructions, see
-[docs/quick_start.md](docs/quick_start.md).
+- convolution, transposed convolution, and pooling;
+- MatMul, Gemm, quantized MatMul, and mixture-of-experts operations;
+- attention, grouped-query attention, rotary embeddings, and KV-cache updates;
+- normalization and activation functions;
+- elementwise, reduction, gather/scatter, padding, resize, and indexing operations;
+- tensor shape/view operations and selected ONNX control flow.
 
----
+See [Supported operations](docs/supported-operations.md) for per-operation domains, lowering paths, runtime backends, data types, dynamic-shape behavior, and known limitations.
+
+## Developer tools
+
+| Tool | Purpose |
+|---|---|
+| `hip-mlir-opt` | Run and inspect registered HIP/MLIR passes and pipelines. |
+| `hip-compiler` | Compile ONNX MLIR into LLVM-bitcode or native model artifacts. |
+| `hip-onnx-runner` | Run ONNX models through the installed Execution Provider. |
+| `hip-inspect` | Inspect metadata embedded in a compiled model artifact. |
+| `hip-test` | Load and execute compiled artifacts through the same runtime path used by the EP. |
+
+Tool availability depends on the build configuration; see the platform quick-start guide for the corresponding CMake options and install layout.
+
+## Documentation
+
+### Architecture and compiler
+
+- [Pipeline pass menu](docs/pipeline_pass_menu.md)
+- [Compiler-runtime contract](docs/design/compiler-runtime-contract.md)
+- [Shape inference design](docs/design/hip-shape-inference.md)
+- [GPU memory planning](docs/design/pool-allocs-memory-planning.md)
+- [Output allocator design](docs/design/output-allocator-design.md)
+- [Constant handling](docs/design/constant-handling-design.md)
+- [Compilation options](docs/design/compilation-options.md)
+- [LLVM IR vs native artifacts](docs/native-vs-ir-comparison.md)
+
+### Extending and operating
+
+- [Plugin authoring](docs/plugin_authoring.md)
+- [Plugin interface design](docs/design/plugin-interface.md)
+- [Custom kernel design](docs/design/custom_kernel_design.md)
+- [Per-operation profiling](docs/design/per-op-profiling.md)
+- [Remote development workflow](docs/remote-dev-workflow.md)
+
+## Developer entry points
+
+- ONNX frontend: `lib/Conversion/OnnxToHip/`
+- HIP dialect: `include/hip/Dialect/` and `lib/Dialect/`
+- HIP-to-LLVM lowering: `lib/Conversion/HipToLLVM/`
+- Compiler driver: `lib/Compiler/`
+- Runtime and custom kernels: `lib/Runtime/`
+- MorphiZen/ONNX Runtime integration: `backend-mlir-compiler/` and `morphizen/`
+- Command-line tools: `tools/`
+- Tests: `test/lit/`, `test/numeric/`, `test/python/`, and `test/e2e/`
+
+## Issues and feedback
+
+Report bugs and request features through [GitHub Issues](https://github.com/ROCm/hip-ep/issues).
 
 ## Contributing
 
-This repo follows the LLVM project's
-[Incremental Development](https://llvm.org/docs/DeveloperPolicy.html#incremental-development)
-and [AI Tool Use](https://llvm.org/docs/AIToolPolicy.html) policies. Before
-opening a PR, please read [CONTRIBUTING.md](CONTRIBUTING.md) for the local
-specifics: PR sizing, AI-assistance disclosure, CODEOWNERS routing, and
-commit message trailers.
-
----
+This project follows LLVM's [incremental development](https://llvm.org/docs/DeveloperPolicy.html#incremental-development) and [AI tool use](https://llvm.org/docs/AIToolPolicy.html) policies. See [CONTRIBUTING.md](CONTRIBUTING.md) for project-specific requirements.
 
 ## License
 
 Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
-Licensed under the MIT License.
+
+Licensed under the MIT License. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ The provider integrates with ONNX Runtime through the MorphiZen pass framework. 
 - **Externalized constants** — stores large model weights in a sidecar constants file instead of embedding them in the model artifact.
 - **Two artifact formats** — LLVM bitcode with in-process JIT by default, or a native `.dll`/`.so` when explicitly requested.
 - **Extensible compiler pipeline** — supports registered plugin slots and out-of-tree dialect/pass plugins.
-- **GPU-free development** — provides a mock runtime for compiler and LIT testing without ROCm hardware.
 
 ## Get started
 

--- a/docs/supported-operations.md
+++ b/docs/supported-operations.md
@@ -129,7 +129,3 @@ These operations are handled through standard MLIR transformations and generally
 ## Fusion and preprocessing
 
 The frontend also recognizes or simplifies selected patterns before operation conversion, including approximate/FastGelu chains, Erf-based Gelu chains, supported Pow forms, LpNormalization decompositions, CastLike simplification, and model-exporter cleanup patterns.
-
-## Experimental paths
-
-The Hipsr dialect and ONNX-to-Hipsr conversion are experimental compiler-development paths and are not part of the built-in production Execution Provider pipeline.

--- a/docs/supported-operations.md
+++ b/docs/supported-operations.md
@@ -1,0 +1,135 @@
+<!--
+Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+Licensed under the MIT License.
+-->
+# Supported operations
+
+This reference summarizes ONNX operations handled by the built-in ONNX-to-HIP pipeline. Support may be provided by a vendor library, a custom HIP kernel, decomposition into other operations, or standard MLIR tensor transformations.
+
+The conversion registrations in `lib/Conversion/OnnxToHip/OnnxToHip.cpp` and the corresponding LIT/numeric tests are the source of truth. Individual operations may have data-type, rank, attribute, or dynamic-shape restrictions that are documented in their conversion and test files.
+
+## Runtime-backed operations
+
+| Operation | Backend or lowering |
+|---|---|
+| Conv | MIOpen |
+| ConvTranspose | MIOpen |
+| MatMul | hipBLASLt |
+| Gemm | hipBLASLt |
+| Transpose | Custom HIP kernel |
+| Mul | MIOpen |
+| Add | MIOpen |
+| Softmax | Custom HIP kernel |
+| Sigmoid | MIOpen |
+| Tanh | MIOpen |
+| Softplus | MIOpen |
+| Gelu | Custom HIP kernel |
+| BiasGelu (`com.microsoft`) | Custom HIP kernel |
+| FastGelu (`com.microsoft`) | Custom HIP kernel |
+| Reciprocal | Custom HIP kernel |
+| Sqrt | Custom HIP kernel |
+| Exp | Custom HIP kernel |
+| Log | Custom HIP kernel |
+| Pow | Decomposed to Mul / Sqrt / Reciprocal for supported constant scalar exponents |
+| Sub | Custom HIP kernel |
+| Cast | Custom HIP kernel |
+| CastLike | Simplified to Cast |
+| Ceil | Custom HIP kernel |
+| Neg | Custom HIP kernel |
+| Equal | Custom HIP kernel |
+| Not | Custom HIP kernel |
+| And | Custom HIP kernel |
+| Or | Custom HIP kernel |
+| Abs | Custom HIP kernel |
+| Cos | Custom HIP kernel |
+| Sin | Custom HIP kernel |
+| Div | Custom HIP kernel |
+| Mod | Custom HIP kernel |
+| Sign | Custom HIP kernel |
+| Where | Custom HIP kernel |
+| Less | Custom HIP kernel |
+| Greater | Decomposed to `Less(B, A)` |
+| GreaterOrEqual | Decomposed to `Not(Less(A, B))` |
+| LessOrEqual | Decomposed to `Not(Less(B, A))` |
+| Min | MIOpen |
+| Max | MIOpen |
+| ReduceSum | Custom HIP kernel |
+| ReduceMax | Custom HIP kernel |
+| ReduceMin | Custom HIP kernel |
+| ReduceProd | Custom HIP kernel |
+| ReduceMean | Custom HIP kernel |
+| CumSum | Custom HIP kernel |
+| Pad | Custom HIP kernel |
+| Tile | Custom HIP kernel |
+| Expand | Custom HIP kernel |
+| GatherND | Custom HIP kernel |
+| ScatterND | Custom HIP kernel (reductions: none / add / mul / min / max) |
+| ScatterElements | Custom HIP kernel (reductions: none / add / mul / min / max) |
+| Range | Custom HIP kernel |
+| Size | Custom HIP kernel; folds to a constant for static shapes |
+| NonZero | Custom HIP kernel |
+| Gather | Custom HIP kernel |
+| GatherElements | Custom HIP kernel |
+| TopK | Custom HIP kernel |
+| Compress | Custom HIP kernel |
+| OneHot | Custom HIP kernel |
+| LayerNormalization | Custom HIP kernel |
+| SkipLayerNormalization (`com.microsoft`) | Decomposed to Add + LayerNormalization |
+| RMSNormalization | MIOpen |
+| SimplifiedLayerNormalization | MIOpen |
+| SkipSimplifiedLayerNormalization (`com.microsoft`) | MIOpen |
+| LpNormalization | Decomposed to Mul / ReduceSum / Sqrt / Div |
+| RotaryEmbedding (`com.microsoft`) | Custom HIP kernel |
+| RotaryEmbedding (`ai.onnx`) | Custom HIP kernel |
+| GroupQueryAttention (`com.microsoft`) | Custom HIP kernels and hipBLASLt |
+| MultiHeadAttention (`com.microsoft`) | Lowered to GroupQueryAttention or decomposed hipBLASLt/custom-kernel paths |
+| Attention (`com.microsoft`) | Fused QKV split and GroupQueryAttention path for supported forms |
+| Attention (`ai.onnx`, opset 23/24) | Lowered to GroupQueryAttention for supported rank-3/rank-4, causal/masked, output, and KV-cache forms |
+| MatMulNBits (`com.microsoft`) | Custom HIP kernel |
+| QMoE (`com.microsoft`) | Custom HIP kernel |
+| GatherBlockQuantized (`com.microsoft`) | Custom HIP kernel |
+| LinearAttention (`com.microsoft`) | Custom HIP kernel |
+| CausalConvWithState (`com.microsoft`) | Custom HIP kernel fast paths with MIOpen fallback |
+| Relu | Decomposed to Max |
+| LeakyRelu | Custom HIP kernel |
+| Clip | Decomposed to Max + Min |
+| MaxPool | Custom HIP kernel |
+| AveragePool | Custom HIP kernel |
+| LpPool | Custom HIP kernel |
+| Resize | Custom HIP kernel |
+| GlobalAveragePool | Custom HIP kernel |
+| GlobalMaxPool | Custom HIP kernel |
+| GlobalLpPool | Custom HIP kernel |
+
+## Control flow
+
+| Operation | Implementation |
+|---|---|
+| If | Outlined then/else functions with runtime branch dispatch |
+| Loop | Outlined loop body with runtime loop dispatch |
+
+## Compiler-optimized operations
+
+These operations are handled through standard MLIR transformations and generally do not require operation-specific runtime backend support.
+
+| Operation | Implementation | Notes |
+|---|---|---|
+| Reshape | `tensor.expand_shape` / `tensor.collapse_shape` | Metadata-only where representable; dynamic dimensions are supported |
+| Unsqueeze | `tensor.expand_shape` | Inserts size-one axes |
+| Squeeze | `tensor.collapse_shape` | Removes size-one axes |
+| Split | `tensor.extract_slice` | Produces tensor slices that bufferize to views |
+| Slice | `tensor.extract_slice` or `hip.slice` | Constant positive-stride forms decompose to tensor slices; runtime indices or negative steps use the runtime path |
+| Concat | `tensor.empty` + `tensor.insert_slice` | Bufferizes to destination subviews and copies |
+| Shape | `tensor.dim` + `tensor.from_elements` | Static shapes fold to constants; dynamic dimensions remain runtime SSA |
+| Constant | `arith.constant` or external constants file | Large values are externalized |
+| ConstantOfShape | `arith.constant` when foldable | Produces a splat constant for constant shape inputs |
+| Identity | SSA value forwarding | No runtime operation |
+| Flatten | `tensor.collapse_shape` and, where needed, `tensor.expand_shape` | Metadata-only where representable |
+
+## Fusion and preprocessing
+
+The frontend also recognizes or simplifies selected patterns before operation conversion, including approximate/FastGelu chains, Erf-based Gelu chains, supported Pow forms, LpNormalization decompositions, CastLike simplification, and model-exporter cleanup patterns.
+
+## Experimental paths
+
+The Hipsr dialect and ONNX-to-Hipsr conversion are experimental compiler-development paths and are not part of the built-in production Execution Provider pipeline.


### PR DESCRIPTION
## Summary

- Rewrite the README as a concise project overview with quick-start links, architecture, tools, and documentation entry points.
- Move detailed operation coverage into a dedicated supported-operations reference.

## Test plan

- [x] `pre-commit run --files README.md docs/supported-operations.md`
- [x] `git diff --check`

Made with [Cursor](https://cursor.com)