### PR TITLE
chore(deps): bump TheRock ROCm SDK to 7.13.0

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -697,7 +697,7 @@ jobs:
       pull-requests: write
 
     env:
-      THEROCK_VERSION: therock-dist-windows-gfx1151-7.11.0
+      THEROCK_VERSION: therock-dist-windows-gfx1151-7.13.0
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
 
     steps:

--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -32,4 +32,4 @@ cpptrace;https://github.com/jeremy-rifkin/cpptrace.git;v0.8.3
 ## TheRock ROCm SDK. url = tarball base host; hash = pinned ROCm release. The
 ## full tarball basename (therock-dist-<os>-<gfxArch>-<rocmVersion>) is derived
 ## in cmake/deps.cmake from the host OS + HIP_ARCHITECTURES. Real builds only.
-therock;https://repo.amd.com/rocm/tarball;7.11.0
+therock;https://repo.amd.com/rocm/tarball;7.13.0

--- a/python/pyproject.toml.in
+++ b/python/pyproject.toml.in
@@ -21,7 +21,7 @@ dependencies = [
     # (@MORPHIZEN_HIP_ARCH@ = the GPU arch this wheel was built for). Pinned to
     # the exact TheRock version the EP is built against to avoid runtime/JIT
     # import ABI skew.
-    "rocm[libraries,devel]==7.11.0",
+    "rocm[libraries,devel]==7.13.0",
 ]
 # NOTE: a custom ONNX Runtime build (the plugin-EP-patched onnxruntime-directml)
 # is required at runtime, but it is NOT declared as a dependency: this wheel


### PR DESCRIPTION
﻿## Summary

Bump the pinned TheRock ROCm SDK from 7.11.0 to 7.13.0 across all three places that pin it (build-time auto-download, gpu-test download, and the wheel's ROCm runtime dependency).

## Why

TheRock is pinned to one exact ROCm version so the build-time SDK, the gpu-test runtime SDK, and the wheel's `rocm` runtime dependency stay in lockstep and avoid runtime/JIT import ABI skew. Bumping requires updating all three pins together; leaving any one behind would mix ABIs at inference/JIT time.

## What

1. **`cmake/deps.txt`** ΓÇö `therock` pin `7.11.0` ΓåÆ `7.13.0`. Drives the auto-download path in `cmake/deps.cmake` for both Windows and Linux (tarball basename is derived per-OS/arch from this version).
2. **`.github/workflows/windows-build.yml`** ΓÇö `THEROCK_VERSION` `therock-dist-windows-gfx1151-7.11.0` ΓåÆ `7.13.0`, the explicit TheRock download in the gpu-test job.
3. **`python/pyproject.toml.in`** ΓÇö wheel runtime dependency `rocm[libraries,devel]==7.11.0` ΓåÆ `7.13.0`, kept exactly in sync with the SDK the EP is built against.

Intentional non-change: `tools/perf-report/run_multimodal_perf.py` keeps its hardcoded `therock-7.11` default; that is a per-machine fallback directory name, not a version pin to the SDK download.

## Test plan

- [ ] build-windows green on cold cache: cmake/deps.cmake auto-downloads `therock-dist-windows-gfx1151-7.13.0` and ORT + EP build successfully
- [ ] build-linux green on cold cache: auto-download of `therock-dist-linux-*-7.13.0`
- [ ] gpu-test green: explicit `THEROCK_VERSION` download resolves and inference passes
- [x] All three pinned URLs/packages confirmed to exist (windows/linux tarballs HTTP 200, `rocm-7.13.0` present on the AMD wheel index)

## Notes for reviewers

None.

## Checklist

- [x] **Incremental** ΓÇö 3 lines across 3 files
- [x] **AI policy** ΓÇö assisted by Cursor; disclosed via commit trailer
- [x] **No `good first issue` automation**
- [x] **Reviews resolved**
- [x] **CODEOWNERS routing**
