### PR TITLE
ci(linux): build amdgpu-ep umbrella EP and stage into test package

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -233,6 +233,48 @@ jobs:
       # (not cached).
 
       # -----------------------------------------------------------------------
+      # Build the AMD GPU umbrella EP (onnxruntime-ep-amdgpu) + hipep-backend
+      # shim from the fork's pinned commit. USE_AMDGPU forces DML/MIGraphX off
+      # and HIPEP on (no MIGraphX SDK needed); the shim loads libhipep.so (the
+      # morphizen EP). Built against ort-install only, so it has no dependency
+      # on the onnx-hipdnn-ep build below. Bump the commit + cache key together
+      # when the fork moves.
+      # -----------------------------------------------------------------------
+      - name: Cache amdgpu-ep build
+        id: cache-amdgpu
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: ${{ runner.workspace }}/build-amdgpu
+          key: linux-amdgpu-19dc45a-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}
+
+      - name: Checkout amdgpu-ep
+        if: steps.cache-amdgpu.outputs.cache-hit != 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: zz002/onnxruntime-ep-amdgpu
+          ref: 19dc45af58bf3b2775d87fe80455a2543c7b24fb
+          path: source-amdgpu
+          fetch-depth: 1
+          show-progress: false
+
+      - name: Build amdgpu-ep
+        if: steps.cache-amdgpu.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          # onnxruntime-ep-amdgpu requires CMake >= 4.2; pin a pip cmake for it.
+          python3 -m pip install -q "cmake>=4.2"
+          CMAKE="$(python3 -c "import cmake, os; print(os.path.join(cmake.CMAKE_BIN_DIR, 'cmake'))")"
+          echo "Using $("$CMAKE" --version | head -1)"
+          "$CMAKE" -G Ninja -S source-amdgpu -B "${{ runner.workspace }}/build-amdgpu" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DUSE_AMDGPU=ON \
+            -DCMAKE_PREFIX_PATH="${{ runner.workspace }}/ort-install" \
+            -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+          "$CMAKE" --build "${{ runner.workspace }}/build-amdgpu" \
+            --target amdgpu-ep hipep-ep
+
+      # -----------------------------------------------------------------------
       # Build this project natively via the plain build.py. Deps are
       # injected as prefixes (llvm-install + ort-install); protobuf/flatbuffers
       # are resolved from source and TheRock auto-downloaded by cmake/deps.cmake.
@@ -337,6 +379,24 @@ jobs:
           cp "$ART/model_benchmark" "${{ runner.workspace }}/install/bin/"
           cp -a "$ART"/libonnxruntime-genai.so* "${{ runner.workspace }}/install/lib/"
 
+      # AMD GPU umbrella EP (libamdgpu-ep.so) + hipep-backend shim
+      # (libhipep-backend.so) from the fork build above. Drop them into
+      # install/lib so the closure pass resolves their deps and the staging
+      # step ships them next to libhipep.so (the morphizen EP they load).
+      - name: Install amdgpu-ep artifacts into install/
+        run: |
+          set -euo pipefail
+          AMDGPU_BUILD="${{ runner.workspace }}/build-amdgpu"
+          AMDGPU_EP=$(find "$AMDGPU_BUILD" -name "libamdgpu-ep.so" -type f | head -1)
+          HIPEP_BACKEND=$(find "$AMDGPU_BUILD" -name "libhipep-backend.so" -type f | head -1)
+          if [ -z "$AMDGPU_EP" ] || [ -z "$HIPEP_BACKEND" ]; then
+            echo "ERROR: libamdgpu-ep.so or libhipep-backend.so not found in $AMDGPU_BUILD"
+            find "$AMDGPU_BUILD" -name '*.so' -type f || true
+            exit 1
+          fi
+          cp -a "$AMDGPU_EP" "$HIPEP_BACKEND" "${{ runner.workspace }}/install/lib/"
+          echo "Installed: $(basename "$AMDGPU_EP") $(basename "$HIPEP_BACKEND")"
+
       # -----------------------------------------------------------------------
       # Bundle the runtime .so into install/lib so the artifact is
       # self-contained with LD_LIBRARY_PATH=install/lib:$THEROCK/lib. scripts/
@@ -367,6 +427,8 @@ jobs:
           stage_pass \
             "$INSTALL"/lib/libhipep.so \
             "$INSTALL"/lib/libhip-compiler.so \
+            "$INSTALL"/lib/libamdgpu-ep.so \
+            "$INSTALL"/lib/libhipep-backend.so \
             "$INSTALL"/bin/hip-compiler \
             "$INSTALL"/bin/hip-onnx-runner \
             "$INSTALL"/bin/hip-test \
@@ -467,6 +529,17 @@ jobs:
             exit 1
           fi
           echo "OK: $(basename "$KERNEL_SO") present"
+
+          # Smoke: AMD GPU umbrella EP + hipep-backend shim must ship next to
+          # libhipep.so so the umbrella load chain resolves on the GPU host.
+          for so in libamdgpu-ep.so libhipep-backend.so; do
+            if [ ! -f "staging/lib/$so" ]; then
+              echo "ERROR: staging/lib/$so missing (amdgpu-ep build/stage regressed)"
+              ls -1 staging/lib/ | head -40
+              exit 1
+            fi
+            echo "OK: $so present"
+          done
 
           rm -f staging/lib/libHipCInterface.a \
                 staging/lib/libcpptrace.a \


### PR DESCRIPTION
﻿## Summary

Build the AMD GPU umbrella EP (`onnxruntime-ep-amdgpu`) in the Linux CI and ship its `.so` in the Linux GPU test package, closing the gap with the Windows CI which already builds and packages this EP.

## Why

The Windows build job builds `amdgpu-ep` + the `hipep-backend` shim from the pinned fork and stages `amdgpu-ep.dll` + `hipep-backend.dll` into the GPU test package, but the Linux job built neither, so the Linux artifact could not exercise the umbrella EP load chain. This PR adds the equivalent Linux steps. It mirrors the Windows recipe (`-DUSE_AMDGPU=ON`, build against `ort-install`, fork commit pinned + folded into the cache key) so both platforms move in lockstep when the fork bumps. The two umbrella `.so` are dropped into `install/lib` before the existing closure pass rather than copied straight into `staging/lib`, so they reuse the dependency-resolution + self-containment verification that already runs there.

## What

1. **amdgpu-ep build steps** in [`.github/workflows/linux-build.yml`](.github/workflows/linux-build.yml), inserted before `Build onnx-hipdnn-ep`: `Cache amdgpu-ep build` (keyed on fork commit + ORT version/PR), `Checkout amdgpu-ep` (`zz002/onnxruntime-ep-amdgpu` @ `19dc45a`), and `Build amdgpu-ep` (pip `cmake>=4.2`, `-G Ninja -DUSE_AMDGPU=ON -DCMAKE_PREFIX_PATH=ort-install` + sccache, targets `amdgpu-ep hipep-ep`). The Windows-only `-DCMAKE_MSVC_RUNTIME_LIBRARY` is omitted.
2. **`Install amdgpu-ep artifacts into install/`** step: locates `libamdgpu-ep.so` + `libhipep-backend.so` under `build-amdgpu` (hard error if absent) and copies them into `install/lib`.
3. **Closure coverage**: both `.so` added to the `stage_pass` seed list in `Bundle runtime .so + verify closure` so their runtime deps are resolved and verified self-contained.
4. **Staging smoke check**: `Stage Linux GPU test package` now hard-fails if either `.so` is missing from `staging/lib` (they flow in via the existing `cp -a install/lib/.`).
5. **Intentional non-changes**: no wheel work (ORT `--build_wheel`, OGA wheel, Python wheel package, `HIPEP_WHEEL_EXTRA_DLLS`), no GPU test job, no `model_mm`/e2e scripts, single `gfx1151` arch retained ΓÇö out of scope for this round.

## Test plan

- [ ] Linux Build green on cold cache: `amdgpu-ep` + `hipep-ep` build successfully against `ort-install`.
- [ ] `Install amdgpu-ep artifacts` finds both `.so`; closure pass stays green with them added.
- [ ] `linux-gpu-test-package` artifact contains `lib/libamdgpu-ep.so` + `lib/libhipep-backend.so`.

## Notes for reviewers

amdgpu-ep is built against `ort-install` only and `USE_AMDGPU=ON` forces DML/MIGraphX off + HIPEP on, so no MIGraphX/GPU SDK is needed at build time. First run will exercise the assumption that the fork configures + builds on `ubuntu-latest`; the repo has explicit Linux link rules (`version_script.lds`), so this is expected to pass.

## Checklist

- [x] **Incremental.** Standalone, ~73 LOC in one file.
- [x] **AI policy.** Authored with Cursor; commit carries the `Co-authored-by` trailer.
- [x] **No `good first issue` automation.**
- [ ] **Reviews resolved.**
- [x] **CODEOWNERS routing.** Touches only `.github/workflows/`.
