### PR TITLE
ci: pin OGA to v0.15.2 + microsoft/onnxruntime-genai#2165

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -30,11 +30,8 @@ env:
   # ORT is still built from source either way). Part of the ort-install cache
   # key. Remove a PR once its fix lands in the pinned ONNX Runtime release.
   ONNXRUNTIME_PR_PATCHES: ""
-  OGA_VERSION: "0.14.0"
-  # Space-separated microsoft/onnxruntime-genai PR numbers fetched from
-  # pull/<n>.patch and `git apply` on top of v<OGA_VERSION>. Part of the OGA
-  # cache key. Remove a PR once it lands in the pinned OGA release.
-  OGA_PR_PATCHES: "2194"
+  OGA_VERSION: "0.15.0"
+  OGA_PR_PATCHES: "2165"
   # The GPU arch the artifact targets. CI runners have no GPU, so it is passed
   # explicitly (build.py auto-detects from /sys on a real GPU host).
   HIP_ARCHITECTURES: gfx1151
@@ -293,12 +290,31 @@ jobs:
       # build.py (whose target is the project .so) because OGA is a
       # CI/artifact concern.
       # -----------------------------------------------------------------------
+      - name: Resolve OGA PR head SHAs
+        id: oga-shas
+        env:
+          GH_TOKEN: ${{ github.token }}
+          OGA_PRS: ${{ env.OGA_PR_PATCHES }}
+        run: |
+          set -euo pipefail
+          tokens=""
+          for pr in $(echo "$OGA_PRS" | xargs || true); do
+            sha="$(gh api "repos/microsoft/onnxruntime-genai/pulls/${pr}" --jq .head.sha)"
+            if [ -z "$sha" ]; then
+              echo "Cannot resolve the head of OGA PR #${pr}"
+              exit 1
+            fi
+            echo "OGA PR #${pr} -> ${sha}"
+            tokens="${tokens:+${tokens}_}${pr}-${sha:0:12}"
+          done
+          echo "shas=${tokens}" >> "$GITHUB_OUTPUT"
+
       - name: Cache OGA artifacts
         id: cache-oga
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
         with:
           path: ${{ runner.workspace }}/oga-artifacts
-          key: linux-oga-${{ env.OGA_VERSION }}-pr${{ env.OGA_PR_PATCHES }}-am-whl-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}
+          key: linux-oga-${{ env.OGA_VERSION }}-pr${{ steps.oga-shas.outputs.shas }}-am-whl-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}
 
       # Checkout + build are skipped on an OGA cache hit (step-level gate); the
       # install-copy below always runs so the
@@ -314,13 +330,6 @@ jobs:
           fetch-depth: 1
           show-progress: false
 
-      # Fetch and apply microsoft/onnxruntime-genai PR patches listed in
-      # OGA_PR_PATCHES (env). pull/<n>.patch is a multi-commit mbox; `git am`
-      # replays each commit in order, so a PR that adds -> modifies -> renames
-      # the same path within its own series (e.g. #2194: morphizen_ep/* ->
-      # amdgpu/*) applies cleanly. `git apply` pre-checks every hunk against the
-      # base tree at once and self-conflicts on such a series. The OGA cache key
-      # includes the PR list, so editing it forces a rebuild.
       - name: Apply OGA PR patches
         if: steps.cache-oga.outputs.cache-hit != 'true'
         working-directory: onnxruntime-genai
@@ -333,10 +342,6 @@ jobs:
             echo "OGA_PR_PATCHES is empty; nothing to apply"
             exit 0
           fi
-          # pull/<n>.patch is a format-patch series; apply with `git am` so that
-          # intra-series file renames (morphizen_ep -> amdgpu) replay against the
-          # correct intermediate tree. `git apply` flattens the series and chokes
-          # on the rename whose pre-image only exists after an earlier commit.
           # git am needs a committer identity on a bare runner.
           git config user.email "ci@onnx-hipdnn-ep.local"
           git config user.name "onnx-hipdnn-ep CI"
@@ -369,11 +374,10 @@ jobs:
           fi
           cp -a "$ORT_PREFIX"/lib/libonnxruntime.so* "$ORT_HOME/lib/" 2>/dev/null || true
           cp -a "$ORT_PREFIX"/lib/libonnxruntime_providers_shared.so* "$ORT_HOME/lib/" 2>/dev/null || true
-          # Build the OGA python wheel too: it pairs with the ORT python wheel
-          # (built above with --build_wheel) so the pair is pip-installable.
           python3 onnxruntime-genai/build.py \
             --config Release \
             --cmake_generator Ninja \
+            --no_telemetry \
             --ort_home "$ORT_HOME" \
             --skip_tests --skip_examples \
             --parallel \

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -30,7 +30,7 @@ env:
   # ORT is still built from source either way). Part of the ort-install cache
   # key. Remove a PR once its fix lands in the pinned ONNX Runtime release.
   ONNXRUNTIME_PR_PATCHES: ""
-  OGA_VERSION: "0.15.0"
+  OGA_VERSION: "0.15.2"
   OGA_PR_PATCHES: "2165"
   # The GPU arch the artifact targets. CI runners have no GPU, so it is passed
   # explicitly (build.py auto-detects from /sys on a real GPU host).
@@ -290,31 +290,12 @@ jobs:
       # build.py (whose target is the project .so) because OGA is a
       # CI/artifact concern.
       # -----------------------------------------------------------------------
-      - name: Resolve OGA PR head SHAs
-        id: oga-shas
-        env:
-          GH_TOKEN: ${{ github.token }}
-          OGA_PRS: ${{ env.OGA_PR_PATCHES }}
-        run: |
-          set -euo pipefail
-          tokens=""
-          for pr in $(echo "$OGA_PRS" | xargs || true); do
-            sha="$(gh api "repos/microsoft/onnxruntime-genai/pulls/${pr}" --jq .head.sha)"
-            if [ -z "$sha" ]; then
-              echo "Cannot resolve the head of OGA PR #${pr}"
-              exit 1
-            fi
-            echo "OGA PR #${pr} -> ${sha}"
-            tokens="${tokens:+${tokens}_}${pr}-${sha:0:12}"
-          done
-          echo "shas=${tokens}" >> "$GITHUB_OUTPUT"
-
       - name: Cache OGA artifacts
         id: cache-oga
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
         with:
           path: ${{ runner.workspace }}/oga-artifacts
-          key: linux-oga-${{ env.OGA_VERSION }}-pr${{ steps.oga-shas.outputs.shas }}-am-whl-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}
+          key: linux-oga-${{ env.OGA_VERSION }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}
 
       # Checkout + build are skipped on an OGA cache hit (step-level gate); the
       # install-copy below always runs so the

--- a/.github/workflows/windows-deps.yml
+++ b/.github/workflows/windows-deps.yml
@@ -466,6 +466,12 @@ jobs:
         with:
           python-version: "3.14"
 
+      # requests: OGA build.py's util.dependency_resolver imports it at
+      # module load (the pinned Python 3.14 has no preinstalled requests).
+      - name: Install pip dependencies
+        if: steps.cache-oga.outputs.cache-hit != 'true'
+        run: pip install requests
+
       - name: Setup MSVC environment
         if: steps.cache-oga.outputs.cache-hit != 'true'
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0

--- a/.github/workflows/windows-deps.yml
+++ b/.github/workflows/windows-deps.yml
@@ -30,8 +30,8 @@ env:
   LLVM_TAG: llvmorg-22.1.0
   ONNXRUNTIME_VERSION: "1.27.0"
   ONNXRUNTIME_PR_PATCHES: ""
-  OGA_VERSION: "0.14.0"
-  OGA_PR_PATCHES: "2194"
+  OGA_VERSION: "0.15.2"
+  OGA_PR_PATCHES: "2165"
   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
   AMDGPU_EP_REF: "05eaa2a938f71e98b49bd1be3fb03720167be5cc"
 
@@ -442,7 +442,7 @@ jobs:
       - name: Compute cache key
         id: key
         shell: bash
-        run: echo "value=oga-dml-mm2-${{ env.OGA_VERSION }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}" >> "$GITHUB_OUTPUT"
+        run: echo "value=windows-oga-${{ env.OGA_VERSION }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}" >> "$GITHUB_OUTPUT"
 
       - name: Probe oga-artifacts
         id: cache-oga
@@ -554,6 +554,7 @@ jobs:
             --config Release \
             --cmake_generator Ninja \
             --use_dml \
+            --no_telemetry \
             --ort_home "$ORT_HOME" \
             --skip_tests --skip_examples \
             --parallel \

--- a/.github/workflows/windows-gpu-test.yml
+++ b/.github/workflows/windows-gpu-test.yml
@@ -650,7 +650,7 @@ jobs:
             $content = Get-Content $f.FullName -Raw
             $ttftMatch = [regex]::Match($content, 'Prompt processing \(time to first token\):\s*\n\s*avg \(us\):\s+([\d.]+)')
             $tpsMatch  = [regex]::Match($content, 'Token generation:\s*\n\s*avg \(us\):\s+([\d.]+)\s*\n\s*avg \(tokens/s\):\s+([\d.]+)')
-            $memMatch  = [regex]::Match($content, 'Peak working set size \(bytes\):\s+(\d+)')
+            $memMatch  = [regex]::Match($content, 'Peak working set size:\s+(\d+)\s+bytes')
             $ttft = if ($ttftMatch.Success) { "{0:F1}" -f ([double]$ttftMatch.Groups[1].Value / 1000) } else { "-" }
             $tps  = if ($tpsMatch.Success) { "{0:F1}" -f [double]$tpsMatch.Groups[2].Value } else { "-" }
             $mem  = if ($memMatch.Success) { "{0:F2}" -f ([double]$memMatch.Groups[1].Value / 1GB) } else { "-" }

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -248,7 +248,7 @@ cp "$LOCAL_DIR/bin/onnxruntime_providers_shared.dll" "$ORT_HOME/lib/"
 
 ```bash
 cd ..  # Go to workspace directory (sibling of hip-ep)
-git clone -b v0.15.0 https://github.com/microsoft/onnxruntime-genai.git
+git clone -b v0.15.2 https://github.com/microsoft/onnxruntime-genai.git
 cd onnxruntime-genai
 git submodule update --init --recursive
 
@@ -361,7 +361,7 @@ python python/examples/run_onnx.py /path/to/model.onnx
 
 `benchmark_e2e.py` runs with the default `-e follow_config`, so the model's
 `genai_config.json` selects the EP via `provider_options`. With the upstream OGA
-(v0.15.0 + PR2165, DeviceType AMDGPU) this is the AMD GPU umbrella
+(v0.15.2 + PR2165, DeviceType AMDGPU) this is the AMD GPU umbrella
 (`provider_options [{ "AMDGPU": {"profile": "hip"} }]`), which loads
 `amdgpu-ep.dll` and needs the umbrella DLLs colocated (see
 `.github/workflows/windows-build-real.yml`); the default wheel ships only the hipgpu
@@ -478,8 +478,8 @@ present there too.
 
 The EP is selected by the model's `genai_config.json` `provider_options` and
 auto-discovered next to `onnxruntime-genai.dll` -- do NOT pass `--ep_library`
-(upstream `model_benchmark` rejects it). With the upstream OGA (v0.15.0 +
-PR2165) the EP is the AMD GPU umbrella (`provider_options [{ "AMDGPU":
+(upstream `model_benchmark` rejects it). With the upstream OGA (v0.15.2 +
+PR2165) the EP is the AMD GPU umbrella (`provider_options [{ "AMDGPU":)
 {"profile": "hip"} }]`), so `amdgpu-ep.dll` must sit next to the OGA DLLs (see
 `.github/workflows/windows-build-real.yml`).
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -248,16 +248,12 @@ cp "$LOCAL_DIR/bin/onnxruntime_providers_shared.dll" "$ORT_HOME/lib/"
 
 ```bash
 cd ..  # Go to workspace directory (sibling of hip-ep)
-git clone -b v0.14.0 https://github.com/microsoft/onnxruntime-genai.git
+git clone -b v0.15.0 https://github.com/microsoft/onnxruntime-genai.git
 cd onnxruntime-genai
 git submodule update --init --recursive
 
-# Apply the AMDGPU integration PR on top of the upstream tag. pull/<n>.patch is
-# a format-patch series (it renames src/morphizen_ep -> src/amdgpu mid-series),
-# so apply it with `git am` -- `git apply` flattens the series and fails on the
-# rename whose pre-image only exists after an earlier commit.
-curl -fsSL https://github.com/microsoft/onnxruntime-genai/pull/2194.patch -o /tmp/oga-2194.patch
-git am --3way --whitespace=nowarn /tmp/oga-2194.patch
+curl -fsSL https://github.com/microsoft/onnxruntime-genai/pull/2165.patch -o /tmp/oga-2165.patch
+git am --3way --whitespace=nowarn /tmp/oga-2165.patch
 ```
 
 > **Note**: the upstream tag + PR list are pinned in CI via `OGA_VERSION` and
@@ -279,6 +275,7 @@ python build.py \
   --config Release \
   --cmake_generator Ninja \
   --use_dml \
+  --no_telemetry \
   --ort_home "$ORT_HOME" \
   --skip_tests --skip_examples \
   --parallel \
@@ -364,7 +361,7 @@ python python/examples/run_onnx.py /path/to/model.onnx
 
 `benchmark_e2e.py` runs with the default `-e follow_config`, so the model's
 `genai_config.json` selects the EP via `provider_options`. With the upstream OGA
-(v0.14.0 + PR2194, DeviceType AMDGPU) this is the AMD GPU umbrella
+(v0.15.0 + PR2165, DeviceType AMDGPU) this is the AMD GPU umbrella
 (`provider_options [{ "AMDGPU": {"profile": "hip"} }]`), which loads
 `amdgpu-ep.dll` and needs the umbrella DLLs colocated (see
 `.github/workflows/windows-build-real.yml`); the default wheel ships only the hipgpu
@@ -481,8 +478,8 @@ present there too.
 
 The EP is selected by the model's `genai_config.json` `provider_options` and
 auto-discovered next to `onnxruntime-genai.dll` -- do NOT pass `--ep_library`
-(upstream `model_benchmark` rejects it). With the upstream OGA (v0.14.0 +
-PR2194) the EP is the AMD GPU umbrella (`provider_options [{ "AMDGPU":
+(upstream `model_benchmark` rejects it). With the upstream OGA (v0.15.0 +
+PR2165) the EP is the AMD GPU umbrella (`provider_options [{ "AMDGPU":
 {"profile": "hip"} }]`), so `amdgpu-ep.dll` must sit next to the OGA DLLs (see
 `.github/workflows/windows-build-real.yml`).
 

--- a/docs/quick_start_linux.md
+++ b/docs/quick_start_linux.md
@@ -264,7 +264,7 @@ prebuilt package to get it.
 
 The EP is selected by the model's `genai_config.json` `provider_options` and
 auto-discovered next to the OGA runtime lib -- do NOT pass `--ep_library`
-(upstream `model_benchmark` rejects it). With the upstream OGA (v0.14.0 + PR2194)
+(upstream `model_benchmark` rejects it). With the upstream OGA (v0.15.0 + PR2165)
 the EP is the AMD GPU umbrella (`provider_options [{ "AMDGPU": {"profile": "hip"} }]`);
 the prebuilt package bundles the umbrella libs.
 

--- a/docs/quick_start_linux.md
+++ b/docs/quick_start_linux.md
@@ -264,7 +264,7 @@ prebuilt package to get it.
 
 The EP is selected by the model's `genai_config.json` `provider_options` and
 auto-discovered next to the OGA runtime lib -- do NOT pass `--ep_library`
-(upstream `model_benchmark` rejects it). With the upstream OGA (v0.15.0 + PR2165)
+(upstream `model_benchmark` rejects it). With the upstream OGA (v0.15.2 + PR2165)
 the EP is the AMD GPU umbrella (`provider_options [{ "AMDGPU": {"profile": "hip"} }]`);
 the prebuilt package bundles the umbrella libs.
 

--- a/tools/perf-report/format_perf_report.py
+++ b/tools/perf-report/format_perf_report.py
@@ -176,7 +176,7 @@ class OgaHeadline:
                 cur_block = None
                 continue
 
-            m = re.match(r"Peak working set size \(bytes\):\s*(\d+)", line)
+            m = re.match(r"Peak working set size:\s*(\d+)\s*bytes", line)
             if m:
                 out.peak_ws_bytes = int(m.group(1))
                 cur_block = None

--- a/tools/perf-report/perf_multimodal_report.py
+++ b/tools/perf-report/perf_multimodal_report.py
@@ -178,7 +178,7 @@ class OgaHeadline:
                 cur_block = None
                 continue
 
-            m = re.match(r"Peak working set size \(bytes\):\s*(\d+)", line)
+            m = re.match(r"Peak working set size:\s*(\d+)\s*bytes", line)
             if m:
                 out.peak_ws_bytes = int(m.group(1))
                 cur_block = None


### PR DESCRIPTION
## Summary

Pin OGA to upstream `v0.15.2` + `microsoft/onnxruntime-genai#2165`, replacing `v0.14.0` + `#2194`. Build with `--no_telemetry`, and parse 0.15's `Peak working set size` format in the GPU-test OGA table and in `tools/perf-report/`. Windows and Linux OGA cache keys are `windows-oga-*` / `linux-oga-*` (no `mm2` / `am-whl`).

## Related issue or design

None.

## Why

`#2194` never landed. The AMDGPU OGA integration is `#2165`, which is cut against a base newer than 0.14 and merged to OGA main after the `v0.15.2` tag, so the tag still needs `git am` of that patch. 0.15 enables 1DS telemetry by default. The Windows OGA pin lives in `windows-deps.yml` after the workflow split; the umbrella EP job on main already builds from `onnxruntime/onnxruntime-ep-amdgpu` with MIGraphX and is not part of this PR.

## What

- `OGA_VERSION=0.15.2`, `OGA_PR_PATCHES=2165` in `linux-build.yml` and `windows-deps.yml`
- Cache keys: `windows-oga-0.15.2-pr2165-ort1.27.0-ortpr` and `linux-oga-0.15.2-pr2165-ort1.27.0-ortpr`
- `--no_telemetry` on both OGA builds
- GPU-test OGA peak-mem regex + `tools/perf-report/` parsers
- `docs/quick_start*.md` follow the new tag, PR number, and `--no_telemetry`

## Test plan

- [ ] `git am` of `pull/2165.patch` on `v0.15.2` succeeds in CI (Apply OGA PR patches)
- [ ] Windows `prebuild / oga` cold cache: key `windows-oga-0.15.2-pr2165-ort1.27.0-ortpr`, build with `--no_telemetry`
- [ ] Linux `Cache OGA artifacts` cold cache: key `linux-oga-0.15.2-pr2165-ort1.27.0-ortpr`
- [ ] GPU-test OGA summary reports a numeric Peak Mem, not `-`

## Notes for reviewers

None.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [x] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.
