### PR TITLE
perf(qmoe): single-launch grouped WMMA int4 MoE prefill (default-on)

### DIFF
--- a/include/hip/env.h
+++ b/include/hip/env.h
@@ -71,4 +71,26 @@ inline std::string env_string(const char *name) {
   return (n > 0 && n < sizeof(buf)) ? std::string(buf, n) : std::string();
 }
 
+// Env var as an int; `dflt` when unset/blank. Manual parse (no std::stoi) to
+// keep the runtime bitcode free of MSVC vectorized helpers the JIT can't
+// resolve.
+inline int env_int(const char *name, int dflt) {
+  char buf[16];
+  unsigned long n = read_env(name, buf, sizeof(buf));
+  if (n == 0)
+    return dflt;
+  int sign = 1, i = 0;
+  if (buf[0] == '-') {
+    sign = -1;
+    i = 1;
+  }
+  long v = 0;
+  bool any = false;
+  for (; buf[i] >= '0' && buf[i] <= '9'; ++i) {
+    v = v * 10 + (buf[i] - '0');
+    any = true;
+  }
+  return any ? (int)(sign * v) : dflt;
+}
+
 } // namespace hipdnn_ep

--- a/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
+++ b/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
@@ -6187,3 +6187,397 @@ extern "C" int hip_matmul_nbits(
   }
   return static_cast<int>(err);
 }
+
+/* =======================================================================
+ * Grouped int4 WMMA GEMM for the fused MoE prefill path.
+ *
+ * Adapted from GemmFp16U4Impl above: identical double-buffered,
+ * register-prefetch Matrix-Core pipeline, but:
+ *   (1) blockIdx.z selects an active expert, so one launch runs every
+ *       expert's GEMM (grid.z = num_active experts). Grid.y is sized to the
+ *       hottest expert (max_count); blocks past an expert's row count early
+ *       out. B (int4 weights) therefore streams from DRAM once per expert.
+ *   (2) zero_points are read inline from the packed uint8 nibble buffer
+ *       (ONNX MatMulNBits layout [N, ceil(ngk/2)]) -- no fp16 pre-convert
+ *       (which would need ~GBs for all experts), matching
+ *       unpack_zp_u8_to_fp16_kernel's nibble order (low = even group).
+ *   (3) two epilogues: QMOE_EPI_PLAIN writes C_all[(off+row)*N + col]
+ *       (FC1 -> [P, fusion_inter], then a separate SwiGLU pass), and
+ *       QMOE_EPI_SCATTER does the routing-weighted atomicAdd into an fp32
+ *       accumulator at each token's original row (FC2).
+ * No column swizzle: row0/col0 come straight from blockIdx.y/.x within the
+ * expert (memory-bound on B, so L2 swizzle gains are marginal here).
+ * ======================================================================= */
+
+enum {
+  QMOE_EPI_PLAIN = 0,         // C_all[(off+row)*N + col] = v            (FC1, unfused)
+  QMOE_EPI_SCATTER = 1,       // routing-weighted atomicAdd into accum    (FC2)
+  QMOE_EPI_PLAIN_SWIGLU = 2,  // fused SwiGLU: act_out[(off+row)*N/2 + col/2] (FC1)
+};
+
+template <int BM_T, int BN_T, int WT_M, int WT_N, int EPI, bool GATHER>
+__global__
+__attribute__((amdgpu_flat_work_group_size(
+    GEMM_WG_SZ(BM_T, BN_T, WT_M, WT_N),
+    GEMM_WG_SZ(BM_T, BN_T, WT_M, WT_N))))
+void QMoEGroupedWmmaKernel(
+    int N, int K,
+    const _Float16* __restrict__ A_all,           // [P, K] gathered, or null when GATHER
+    const int32_t*  __restrict__ expert_offsets,  // [E + 1] exclusive prefix
+    const int32_t*  __restrict__ active_eids,     // [num_active]
+    const unsigned char* __restrict__ B_base,     // [E, N, K/2] packed int4
+    const _Float16* __restrict__ S_base,          // [E, N, num_groups_k] fp16
+    const unsigned char* __restrict__ Z_base,     // [E, N, (ngk+1)/2] or null
+    const _Float16* __restrict__ bias_base,       // [E, N] or null
+    int num_groups_k, int group_size,
+    _Float16* __restrict__ C_all,                 // [P, N] (EPI_PLAIN)
+    const int32_t* __restrict__ scatter_ids,      // [P] (EPI_SCATTER)
+    const _Float16* __restrict__ scatter_wts,     // [P] (EPI_SCATTER)
+    float* __restrict__ accum, int accum_ldc,     // [num_tokens, N] (EPI_SCATTER)
+    const _Float16* __restrict__ gather_input,    // [num_tokens, K] source (GATHER)
+    const int32_t* __restrict__ gather_ids,       // [P] token id per routed row (GATHER)
+    float sw_alpha, float sw_beta, float sw_limit) // SwiGLU params (EPI_PLAIN_SWIGLU)
+{
+    constexpr int WM_L   = BM_T / (WT_M * 16);
+    constexpr int WN_L   = BN_T / (WT_N * 16);
+    constexpr int THR_L  = WM_L * WN_L * 32;
+    constexpr int BK_T   = BM_T / (WT_M * WT_N);
+    constexpr int PAD_K  = 2;
+    constexpr int K_STR  = BK_T + PAD_K;
+    constexpr int A_VL   = (BM_T * BK_T) / (THR_L * 4);
+    constexpr int A_GRP_K = BK_T / 2;
+    constexpr int K_STEPS = BK_T / WMMA_TILE;
+    static_assert(A_VL >= 1, "A_VL must be >= 1");
+    static_assert(THR_L * 8 == BN_T * BK_T, "B loading balance");
+
+    const int e_slot = blockIdx.z;
+    const int e      = active_eids[e_slot];
+    const int off    = expert_offsets[e];
+    const int M      = expert_offsets[e + 1] - off;
+    const int row0   = blockIdx.y * BM_T;
+    if (row0 >= M) return;
+    const int col0   = blockIdx.x * BN_T;
+
+    // Per-routed-row A source: for FC1 (GATHER) the row is gathered straight
+    // from gather_input via its routed token id (no separate gather kernel /
+    // a_all buffer); for FC2 it reads the pre-laid-out A_all. lda == K in both.
+    auto row_src = [&](int r) -> const _Float16* {
+      if constexpr (GATHER)
+        return gather_input + static_cast<size_t>(gather_ids[off + r]) * K;
+      else
+        return A_all + static_cast<size_t>(off + r) * K;
+    };
+    const unsigned char* B_packed =
+        B_base + static_cast<size_t>(e) * N * (K / 2);
+    const _Float16* scales = S_base + static_cast<size_t>(e) * N * num_groups_k;
+    const int packed_cols = (num_groups_k + 1) / 2;
+    const unsigned char* Zp =
+        Z_base ? Z_base + static_cast<size_t>(e) * N * packed_cols : nullptr;
+    const bool has_zp = (Zp != nullptr);
+    const _Float16* bias = bias_base ? bias_base + static_cast<size_t>(e) * N
+                                     : nullptr;
+
+    __shared__ _Float16 smA[2][BM_T][K_STR];
+    __shared__ _Float16 smB[2][BN_T][K_STR];
+
+    const int tid  = threadIdx.x;
+    const int wid  = tid / 32;
+    const int lid  = tid % 32;
+    const int lane = lid % 16;
+    const int sub  = lid / 16;
+    const int wrow = wid / WN_L;
+    const int wcol = wid % WN_L;
+
+    constexpr int B_COL_SHIFT = __builtin_ctz(BK_T / 8);
+    const int b_col     = tid >> B_COL_SHIFT;
+    const int b_sub     = tid & ((1 << B_COL_SHIFT) - 1);
+    const int b_k8      = b_sub << 3;
+    const int b_n_g_raw = col0 + b_col;
+    const bool b_valid  = (b_n_g_raw < N);
+    const int b_n_g     = b_valid ? b_n_g_raw : 0;
+
+    const int b_byte_base = b_n_g * (K >> 1) + (b_k8 >> 1);
+    const int b_gid_base  = b_n_g * num_groups_k;
+    int      cached_k_grp = -1;
+    _Float16 cached_s = 0;
+    _Float16 neg_zs = 0;
+
+    float8 acc[WT_M][WT_N];
+#pragma unroll
+    for (int i = 0; i < WT_M; i++)
+#pragma unroll
+        for (int j = 0; j < WT_N; j++)
+#pragma unroll
+            for (int ee = 0; ee < 8; ee++) acc[i][j][ee] = 0.0f;
+
+    uint32_t pf_a1[A_VL], pf_a2[A_VL];
+    int      pf_am[A_VL], pf_ak[A_VL];
+    const _Float16* a_row1[A_VL];
+    const _Float16* a_row2[A_VL];
+    uint32_t pf_b4 = 0;
+
+    // Each thread's A-load geometry (which two rows / which K offset) is fixed
+    // across the K loop, so resolve each routed row's source pointer once. For
+    // FC1 this is the fused gather (row_src reads gather_input via token id).
+#pragma unroll
+    for (int ld = 0; ld < A_VL; ld++) {
+        int vid   = tid + ld * THR_L;
+        pf_ak[ld] = (vid % A_GRP_K) * 2;
+        pf_am[ld] = (vid / A_GRP_K) * 2;
+        int row_a = row0 + pf_am[ld];
+        a_row1[ld] = (row_a     < M) ? row_src(row_a)     : nullptr;
+        a_row2[ld] = (row_a + 1 < M) ? row_src(row_a + 1) : nullptr;
+    }
+
+    auto issueLoads = [&](int t) __attribute__((always_inline)) {
+#pragma unroll
+        for (int ld = 0; ld < A_VL; ld++) {
+            pf_a1[ld] = a_row1[ld] ? *reinterpret_cast<const uint32_t*>(
+                            &a_row1[ld][t + pf_ak[ld]]) : 0u;
+            pf_a2[ld] = a_row2[ld] ? *reinterpret_cast<const uint32_t*>(
+                            &a_row2[ld][t + pf_ak[ld]]) : 0u;
+        }
+        if (b_valid) {
+            pf_b4 = *reinterpret_cast<const uint32_t*>(
+                &B_packed[b_byte_base + (t >> 1)]);
+            const int grp = (t + b_k8) / group_size;
+            if (__builtin_expect(grp != cached_k_grp, 0)) {
+                cached_k_grp = grp;
+                cached_s = scales[grp + b_gid_base];
+                if (has_zp) {
+                    unsigned char zb = Zp[b_n_g * packed_cols + (grp >> 1)];
+                    int znib = (grp & 1) ? (zb >> 4) : (zb & 0xF);
+                    neg_zs = -static_cast<_Float16>(znib) * cached_s;
+                } else {
+                    neg_zs = static_cast<_Float16>(-8) * cached_s;
+                }
+            }
+        }
+    };
+
+    auto storeToShared = [&](int buf) __attribute__((always_inline)) {
+        if (b_valid) {
+            _Float16 s16 = cached_s;
+            _Float16 nzs = neg_zs;
+            _Float16 bv[8];
+            bv[0] = static_cast<_Float16>((pf_b4      ) & 0xFu) * s16 + nzs;
+            bv[1] = static_cast<_Float16>((pf_b4 >>  4) & 0xFu) * s16 + nzs;
+            bv[2] = static_cast<_Float16>((pf_b4 >>  8) & 0xFu) * s16 + nzs;
+            bv[3] = static_cast<_Float16>((pf_b4 >> 12) & 0xFu) * s16 + nzs;
+            bv[4] = static_cast<_Float16>((pf_b4 >> 16) & 0xFu) * s16 + nzs;
+            bv[5] = static_cast<_Float16>((pf_b4 >> 20) & 0xFu) * s16 + nzs;
+            bv[6] = static_cast<_Float16>((pf_b4 >> 24) & 0xFu) * s16 + nzs;
+            bv[7] = static_cast<_Float16>((pf_b4 >> 28)       ) * s16 + nzs;
+            *reinterpret_cast<uint2*>(&smB[buf][b_col][b_k8])     =
+                *reinterpret_cast<uint2*>(&bv[0]);
+            *reinterpret_cast<uint2*>(&smB[buf][b_col][b_k8 + 4]) =
+                *reinterpret_cast<uint2*>(&bv[4]);
+        } else {
+            uint2 zero2 = {0, 0};
+            *reinterpret_cast<uint2*>(&smB[buf][b_col][b_k8])     = zero2;
+            *reinterpret_cast<uint2*>(&smB[buf][b_col][b_k8 + 4]) = zero2;
+        }
+#pragma unroll
+        for (int ld = 0; ld < A_VL; ld++) {
+            *reinterpret_cast<uint32_t*>(&smA[buf][pf_am[ld]  ][pf_ak[ld]]) =
+                pf_a1[ld];
+            *reinterpret_cast<uint32_t*>(&smA[buf][pf_am[ld]+1][pf_ak[ld]]) =
+                pf_a2[ld];
+        }
+    };
+
+    auto computeWMMA = [&](int buf) __attribute__((always_inline)) {
+#pragma unroll
+        for (int ks = 0; ks < K_STEPS; ks++) {
+            half16 b_frag[WT_N];
+#pragma unroll
+            for (int wn = 0; wn < WT_N; wn++) {
+                int noff            = (wcol * WT_N + wn) * WMMA_TILE;
+                uint32_t* dst       = reinterpret_cast<uint32_t*>(&b_frag[wn]);
+                const uint32_t* src = reinterpret_cast<const uint32_t*>(
+                    &smB[buf][noff + lane][ks * WMMA_TILE]);
+#pragma unroll
+                for (int i = 0; i < 8; i++) dst[i] = src[i];
+            }
+#pragma unroll
+            for (int wm = 0; wm < WT_M; wm++) {
+                int moff            = (wrow * WT_M + wm) * WMMA_TILE;
+                half16 a_frag;
+                uint32_t* dst       = reinterpret_cast<uint32_t*>(&a_frag);
+                const uint32_t* src = reinterpret_cast<const uint32_t*>(
+                    &smA[buf][moff + lane][ks * WMMA_TILE]);
+#pragma unroll
+                for (int i = 0; i < 8; i++) dst[i] = src[i];
+#pragma unroll
+                for (int wn = 0; wn < WT_N; wn++)
+                    acc[wm][wn] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(
+                        a_frag, b_frag[wn], acc[wm][wn]);
+            }
+        }
+    };
+
+    issueLoads(0);
+    storeToShared(0);
+    __syncthreads();
+
+    int buf = 0;
+    for (int t = BK_T; t < K; t += BK_T) {
+        int nxt = 1 - buf;
+        issueLoads(t);
+        computeWMMA(buf);
+        storeToShared(nxt);
+        __syncthreads();
+        buf = nxt;
+    }
+    computeWMMA(buf);
+
+#pragma unroll
+    for (int wm = 0; wm < WT_M; wm++) {
+        int mbase = row0 + (wrow * WT_M + wm) * WMMA_TILE;
+#pragma unroll
+        for (int wn = 0; wn < WT_N; wn++) {
+            int nbase = col0 + (wcol * WT_N + wn) * WMMA_TILE;
+#pragma unroll
+            for (int ee = 0; ee < 8; ee++) {
+                int mrow = mbase + ee * 2 + sub;
+                int ncol = nbase + lane;
+                if constexpr (EPI == QMOE_EPI_PLAIN_SWIGLU) {
+                    // Fused SwiGLU. FC1 output columns are interleaved
+                    // gate(even)/linear(odd); the WMMA layout puts adjacent
+                    // columns on adjacent lanes (same mrow), so a lane-pair
+                    // shuffle gives each even lane both halves. The shuffle
+                    // must run for all lanes (mrow is identical across a pair,
+                    // so no divergence), then only the even lane emits act_out.
+                    float v = acc[wm][wn][ee];
+                    if (bias) v += static_cast<float>(bias[ncol]);
+                    float partner = __shfl_xor(v, 1);
+                    if (mrow < M && ((ncol & 1) == 0)) {
+                        float G = fminf(v, sw_limit);
+                        float L = fmaxf(fminf(partner, sw_limit), -sw_limit);
+                        float sig = 1.0f / (1.0f + expf(-sw_alpha * G));
+                        _Float16* act_out = C_all;
+                        act_out[static_cast<size_t>(off + mrow) * (N >> 1) +
+                                (ncol >> 1)] =
+                            static_cast<_Float16>(G * sig * (L + sw_beta));
+                    }
+                } else if (mrow < M && ncol < N) {
+                    float v = acc[wm][wn][ee];
+                    if (bias) v += static_cast<float>(bias[ncol]);
+                    if constexpr (EPI == QMOE_EPI_PLAIN) {
+                        C_all[static_cast<size_t>(off + mrow) * N + ncol] =
+                            static_cast<_Float16>(v);
+                    } else {
+                        int tok = scatter_ids[off + mrow];
+                        float w = static_cast<float>(scatter_wts[off + mrow]);
+                        atomicAdd(
+                            &accum[static_cast<size_t>(tok) * accum_ldc + ncol],
+                            w * v);
+                    }
+                }
+            }
+        }
+    }
+}
+
+/* Host launcher for one grouped int4 WMMA GEMM (all active experts, one
+ * launch). Used twice per MoE layer by hip_qmoe_grouped_prefill_wmma: FC1
+ * (epilogue=QMOE_EPI_PLAIN) and FC2 (epilogue=QMOE_EPI_SCATTER). Tile is
+ * fixed at 64x64 (WT2x2, 128 threads); N must be a multiple of 64 and K a
+ * multiple of 16 (true for the MoE FC1/FC2 shapes). */
+extern "C" int hip_qmoe_wmma_gemm_grouped(
+    void* stream,
+    const void* A_all,
+    const void* expert_offsets,
+    const void* active_eids, int num_active, int max_count,
+    const void* B_base, const void* S_base, const void* Z_base,
+    const void* bias_base,
+    int N, int K, int num_groups_k, int group_size,
+    int epilogue,
+    void* C_all,
+    const void* scatter_ids, const void* scatter_wts,
+    void* accum_f32, int accum_ldc,
+    const void* gather_input, const void* gather_ids,
+    float sw_alpha, float sw_beta, float sw_limit)
+{
+    if (num_active <= 0 || max_count <= 0) return 0;
+    constexpr int BM = 64, BN = 64, WT_M = 2, WT_N = 2;
+    if ((N % BN) != 0 || (K % 16) != 0) {
+        fprintf(stderr,
+                "[custom_kernels] hip_qmoe_wmma_gemm_grouped: N=%d must be "
+                "%%%d==0 and K=%d must be %%16==0\n", N, BN, K);
+        return -1;
+    }
+    hipStream_t s = static_cast<hipStream_t>(stream);
+    constexpr int THR = GEMM_WG_SZ(BM, BN, WT_M, WT_N);
+    dim3 grid(static_cast<unsigned>(N / BN),
+              static_cast<unsigned>((max_count + BM - 1) / BM),
+              static_cast<unsigned>(num_active));
+    dim3 block(THR);
+
+    if (epilogue == QMOE_EPI_PLAIN_SWIGLU) {
+        // FC1 (default): gather rows from gather_input (GATHER=true) and apply
+        // SwiGLU in the epilogue, writing act_out ([P, N/2]) via C_all. No
+        // separate a_all / fc1_out buffer, no separate gather / swiglu kernel.
+        hipLaunchKernelGGL(
+            HIP_KERNEL_NAME(QMoEGroupedWmmaKernel<BM, BN, WT_M, WT_N,
+                                                  QMOE_EPI_PLAIN_SWIGLU, true>),
+            grid, block, 0, s, N, K,
+            static_cast<const _Float16*>(A_all),
+            static_cast<const int32_t*>(expert_offsets),
+            static_cast<const int32_t*>(active_eids),
+            static_cast<const unsigned char*>(B_base),
+            static_cast<const _Float16*>(S_base),
+            static_cast<const unsigned char*>(Z_base),
+            static_cast<const _Float16*>(bias_base),
+            num_groups_k, group_size,
+            static_cast<_Float16*>(C_all), nullptr, nullptr, nullptr, 0,
+            static_cast<const _Float16*>(gather_input),
+            static_cast<const int32_t*>(gather_ids),
+            sw_alpha, sw_beta, sw_limit);
+    } else if (epilogue == QMOE_EPI_PLAIN) {
+        // FC1 (unfused): gathered plain store to C_all [P, N].
+        hipLaunchKernelGGL(
+            HIP_KERNEL_NAME(QMoEGroupedWmmaKernel<BM, BN, WT_M, WT_N,
+                                                  QMOE_EPI_PLAIN, true>),
+            grid, block, 0, s, N, K,
+            static_cast<const _Float16*>(A_all),
+            static_cast<const int32_t*>(expert_offsets),
+            static_cast<const int32_t*>(active_eids),
+            static_cast<const unsigned char*>(B_base),
+            static_cast<const _Float16*>(S_base),
+            static_cast<const unsigned char*>(Z_base),
+            static_cast<const _Float16*>(bias_base),
+            num_groups_k, group_size,
+            static_cast<_Float16*>(C_all), nullptr, nullptr, nullptr, 0,
+            static_cast<const _Float16*>(gather_input),
+            static_cast<const int32_t*>(gather_ids),
+            0.0f, 0.0f, 0.0f);
+    } else {
+        // FC2: A is the pre-laid-out act_out (GATHER=false).
+        hipLaunchKernelGGL(
+            HIP_KERNEL_NAME(QMoEGroupedWmmaKernel<BM, BN, WT_M, WT_N,
+                                                  QMOE_EPI_SCATTER, false>),
+            grid, block, 0, s, N, K,
+            static_cast<const _Float16*>(A_all),
+            static_cast<const int32_t*>(expert_offsets),
+            static_cast<const int32_t*>(active_eids),
+            static_cast<const unsigned char*>(B_base),
+            static_cast<const _Float16*>(S_base),
+            static_cast<const unsigned char*>(Z_base),
+            static_cast<const _Float16*>(bias_base),
+            num_groups_k, group_size, nullptr,
+            static_cast<const int32_t*>(scatter_ids),
+            static_cast<const _Float16*>(scatter_wts),
+            static_cast<float*>(accum_f32), accum_ldc,
+            nullptr, nullptr, 0.0f, 0.0f, 0.0f);
+    }
+
+    hipError_t e = hipGetLastError();
+    if (e != hipSuccess) {
+        fprintf(stderr,
+                "[custom_kernels] hip_qmoe_wmma_gemm_grouped launch failed: "
+                "%s\n", hipGetErrorString(e));
+        return static_cast<int>(e);
+    }
+    return 0;
+}

--- a/lib/Runtime/Kernels/hip/qmoe_kernel.hip
+++ b/lib/Runtime/Kernels/hip/qmoe_kernel.hip
@@ -947,6 +947,733 @@ __global__ void qmoe_decode_reduce_kernel(
   output[n] = static_cast<__half>(acc);
 }
 
+// ===========================================================================
+// Grouped PREFILL QMoE (num_tokens > 1): the fully-fused, sync-free analogue
+// of the decode path. Operates over P = num_tokens * k (token, slot) pairs
+// that bucket_tokens has already grouped by expert, so same-expert blocks are
+// contiguous and share the expert weight via L2/MALL. Replaces the old
+// bucket -> D2H counts -> hipStreamSynchronize -> host per-expert loop
+// (gather/fc1/swiglu/fc2/scatter) with 4 launches and zero host sync.
+//
+// Pair p carries expert = sorted_expert_id[p], token = sorted_token_ids[p],
+// routing weight = sorted_weights[p]. FC1 gathers input row `token` on load;
+// FC2 pre-multiplies by the routing weight; scatter atomic-adds each pair's
+// [hidden] result into an fp32 accumulator indexed by `token`; a cast kernel
+// writes the fp16 output. The int4 GEMV + SwiGLU math is identical to the
+// decode fc1/fc2 kernels (same packed-int4 weight, fp16 scale, packed-nibble
+// zp layout), so numerics match the decode path.
+// ===========================================================================
+
+// Fill sorted_expert_id[offsets[e] .. offsets[e+1]) = e. One block, one
+// thread per expert (num_experts <= 1024). Cheap; avoids widening the
+// bucket_tokens signature just to carry the per-pair expert id.
+__global__ void build_sorted_expert_id_kernel(
+    const int32_t* __restrict__ expert_offsets,  // [num_experts + 1]
+    int32_t*       __restrict__ sorted_expert_id,  // [P]
+    int num_experts) {
+  const int e = static_cast<int>(threadIdx.x);
+  if (e >= num_experts) return;
+  const int s   = expert_offsets[e];
+  const int end = expert_offsets[e + 1];
+  for (int p = s; p < end; p++) sorted_expert_id[p] = e;
+}
+
+// FC1 + SwiGLU, grouped over pairs. Mirrors qmoe_decode_fc1_kernel but the
+// slot index runs over all P pairs, the expert comes from sorted_expert_id,
+// and the input row is gathered via sorted_token_ids (fuses gather_tokens).
+template <int BLOCK_SIZE, int TILE_N>
+__global__ void qmoe_prefill_fc1_kernel(
+    const __half*  __restrict__ input,             // [num_tokens, hidden]
+    const int32_t* __restrict__ sorted_token_ids,  // [P]
+    const int32_t* __restrict__ sorted_expert_id,  // [P]
+    const uint8_t* __restrict__ fc1_w,             // [E, fusion_inter, hidden/2]
+    const __half*  __restrict__ fc1_s,             // [E, fusion_inter, n_blk_in]
+    const uint8_t* __restrict__ fc1_zp_packed,     // [E, fusion_inter, ceil(n_blk_in/2)] or null
+    const __half*  __restrict__ fc1_b,             // [E, fusion_inter] or null
+    __half*        __restrict__ act_out,           // [P, inter]
+    int hidden,
+    int fusion_inter,
+    int n_blk_in,
+    int block_size,
+    float swiglu_alpha,
+    float swiglu_beta,
+    float swiglu_limit) {
+  const int n_base = blockIdx.x * TILE_N;
+  const int pair   = blockIdx.y;
+  const int tid    = threadIdx.x;
+  const int E      = sorted_expert_id[pair];
+  const int token  = sorted_token_ids[pair];
+  const __half* in_row = input + static_cast<size_t>(token) * hidden;
+
+  const size_t  W_row_bytes = static_cast<size_t>(hidden) / 2;
+  const uint8_t* W = fc1_w + static_cast<size_t>(E) * fusion_inter * W_row_bytes;
+  const __half*  S = fc1_s + static_cast<size_t>(E) * fusion_inter * n_blk_in;
+  const int      packed_zp_stride = (n_blk_in + 1) / 2;
+  const uint8_t* Z = fc1_zp_packed
+                       ? fc1_zp_packed + static_cast<size_t>(E) * fusion_inter * packed_zp_stride
+                       : nullptr;
+  const __half*  Bv = fc1_b ? fc1_b + static_cast<size_t>(E) * fusion_inter : nullptr;
+
+  const int bs_shift = __builtin_ctz(static_cast<unsigned>(block_size));
+
+  float partial[TILE_N];
+  #pragma unroll
+  for (int t = 0; t < TILE_N; t++) partial[t] = 0.0f;
+
+  const uint8_t* W_rows[TILE_N];
+  const __half*  S_rows[TILE_N];
+  const uint8_t* Z_rows[TILE_N];
+  #pragma unroll
+  for (int t = 0; t < TILE_N; t++) {
+    int n = n_base + t;
+    int sn = (n < fusion_inter) ? n : 0;
+    W_rows[t] = W + static_cast<size_t>(sn) * W_row_bytes;
+    S_rows[t] = S + static_cast<size_t>(sn) * n_blk_in;
+    Z_rows[t] = Z ? Z + static_cast<size_t>(sn) * packed_zp_stride : nullptr;
+  }
+  const bool has_zp = (Z != nullptr);
+
+  const int num_u128 = hidden / 32;
+  for (int idx = tid; idx < num_u128; idx += BLOCK_SIZE) {
+    const int k32 = idx * 32;
+    float a_vals[32];
+    float a_sum = 0.0f;
+    #pragma unroll
+    for (int i = 0; i < 32; i++) {
+      a_vals[i] = static_cast<float>(in_row[k32 + i]);
+      a_sum += a_vals[i];
+    }
+    const int   grp = k32 >> bs_shift;
+    const float a_sum_x_default_zp = a_sum * 8.0f;
+
+    uint4 b_pk[TILE_N];
+    float sv[TILE_N];
+    #pragma unroll
+    for (int t = 0; t < TILE_N; t++) {
+      b_pk[t] = *reinterpret_cast<const uint4*>(&W_rows[t][idx * 16]);
+      sv[t]   = static_cast<float>(S_rows[t][grp]);
+    }
+
+    #pragma unroll
+    for (int t = 0; t < TILE_N; t++) {
+      float dot = 0.0f;
+      #pragma unroll
+      for (int i = 0; i < 8; i++)
+        dot = __fmaf_rn(a_vals[i],
+                        static_cast<float>((b_pk[t].x >> (i * 4)) & 0xF), dot);
+      #pragma unroll
+      for (int i = 0; i < 8; i++)
+        dot = __fmaf_rn(a_vals[8 + i],
+                        static_cast<float>((b_pk[t].y >> (i * 4)) & 0xF), dot);
+      #pragma unroll
+      for (int i = 0; i < 8; i++)
+        dot = __fmaf_rn(a_vals[16 + i],
+                        static_cast<float>((b_pk[t].z >> (i * 4)) & 0xF), dot);
+      #pragma unroll
+      for (int i = 0; i < 8; i++)
+        dot = __fmaf_rn(a_vals[24 + i],
+                        static_cast<float>((b_pk[t].w >> (i * 4)) & 0xF), dot);
+
+      if (has_zp) {
+        uint8_t zp_byte = Z_rows[t][grp >> 1];
+        float   zp = static_cast<float>(
+                       (grp & 1) ? (zp_byte >> 4) : (zp_byte & 0x0F));
+        partial[t] += (dot - a_sum * zp) * sv[t];
+      } else {
+        partial[t] += (dot - a_sum_x_default_zp) * sv[t];
+      }
+    }
+  }
+
+  constexpr int WARP_SIZE = 32;
+  const int warp_id = tid / WARP_SIZE;
+  const int lane    = tid % WARP_SIZE;
+  constexpr int NUM_WARPS = BLOCK_SIZE / WARP_SIZE;
+  static_assert((TILE_N & 1) == 0, "TILE_N must be even for SwiGLU pairing");
+  constexpr int TILE_OUT = TILE_N / 2;
+  const int sw_base = n_base / 2;
+  const int inter   = fusion_inter / 2;
+
+  #pragma unroll
+  for (int t = 0; t < TILE_N; t++) {
+    for (int off = WARP_SIZE >> 1; off > 0; off >>= 1)
+      partial[t] += __shfl_down(partial[t], off);
+  }
+
+  if constexpr (BLOCK_SIZE <= WARP_SIZE) {
+    if (lane == 0) {
+      #pragma unroll
+      for (int p = 0; p < TILE_OUT; p++) {
+        int n_g = n_base + 2 * p;
+        int n_l = n_g + 1;
+        if (n_g < fusion_inter && n_l < fusion_inter) {
+          float g = partial[2 * p];
+          float l = partial[2 * p + 1];
+          if (Bv) { g += static_cast<float>(Bv[n_g]); l += static_cast<float>(Bv[n_l]); }
+          float G = fminf(g, swiglu_limit);
+          float L = fmaxf(fminf(l, swiglu_limit), -swiglu_limit);
+          float sig = 1.0f / (1.0f + expf(-swiglu_alpha * G));
+          act_out[static_cast<size_t>(pair) * inter + sw_base + p] =
+              static_cast<__half>(G * sig * (L + swiglu_beta));
+        }
+      }
+    }
+  } else {
+    __shared__ float warp_sums[TILE_N * NUM_WARPS];
+    if (lane == 0) {
+      #pragma unroll
+      for (int t = 0; t < TILE_N; t++)
+        warp_sums[t * NUM_WARPS + warp_id] = partial[t];
+    }
+    __syncthreads();
+    if (warp_id == 0) {
+      float reduced[TILE_N];
+      #pragma unroll
+      for (int t = 0; t < TILE_N; t++) {
+        float v = (lane < NUM_WARPS) ? warp_sums[t * NUM_WARPS + lane] : 0.0f;
+        for (int off = WARP_SIZE >> 1; off > 0; off >>= 1)
+          v += __shfl_down(v, off);
+        reduced[t] = v;
+      }
+      if (lane == 0) {
+        #pragma unroll
+        for (int p = 0; p < TILE_OUT; p++) {
+          int n_g = n_base + 2 * p;
+          int n_l = n_g + 1;
+          if (n_g < fusion_inter && n_l < fusion_inter) {
+            float g = reduced[2 * p];
+            float l = reduced[2 * p + 1];
+            if (Bv) { g += static_cast<float>(Bv[n_g]); l += static_cast<float>(Bv[n_l]); }
+            float G = fminf(g, swiglu_limit);
+            float L = fmaxf(fminf(l, swiglu_limit), -swiglu_limit);
+            float sig = 1.0f / (1.0f + expf(-swiglu_alpha * G));
+            act_out[static_cast<size_t>(pair) * inter + sw_base + p] =
+                static_cast<__half>(G * sig * (L + swiglu_beta));
+          }
+        }
+      }
+    }
+  }
+}
+
+// FC2, grouped over pairs. Mirrors qmoe_decode_fc2_kernel; expert from
+// sorted_expert_id, routing weight from sorted_weights, activation slice from
+// act_out[pair]. Writes the routing-weighted [hidden] result to slot_buf[pair].
+template <int BLOCK_SIZE, int TILE_N>
+__global__ void qmoe_prefill_fc2_kernel(
+    const __half*  __restrict__ act_out,           // [P, inter]
+    const int32_t* __restrict__ sorted_expert_id,  // [P]
+    const __half*  __restrict__ sorted_weights,    // [P]
+    const uint8_t* __restrict__ fc2_w,             // [E, hidden, inter/2]
+    const __half*  __restrict__ fc2_s,             // [E, hidden, n_blk_mid]
+    const uint8_t* __restrict__ fc2_zp_packed,     // [E, hidden, ceil(n_blk_mid/2)] or null
+    const __half*  __restrict__ fc2_b,             // [E, hidden] or null
+    __half*        __restrict__ slot_buf,          // [P, hidden]
+    int inter,
+    int hidden,
+    int n_blk_mid,
+    int block_size) {
+  const int n_base = blockIdx.x * TILE_N;
+  const int pair   = blockIdx.y;
+  const int tid    = threadIdx.x;
+  const int E      = sorted_expert_id[pair];
+  const float wt   = static_cast<float>(sorted_weights[pair]);
+  const __half* a_in = act_out + static_cast<size_t>(pair) * inter;
+
+  const size_t  W_row_bytes = static_cast<size_t>(inter) / 2;
+  const uint8_t* W = fc2_w + static_cast<size_t>(E) * hidden * W_row_bytes;
+  const __half*  S = fc2_s + static_cast<size_t>(E) * hidden * n_blk_mid;
+  const int      packed_zp_stride = (n_blk_mid + 1) / 2;
+  const uint8_t* Z = fc2_zp_packed
+                       ? fc2_zp_packed + static_cast<size_t>(E) * hidden * packed_zp_stride
+                       : nullptr;
+  const __half*  Bv = fc2_b ? fc2_b + static_cast<size_t>(E) * hidden : nullptr;
+
+  const int bs_shift = __builtin_ctz(static_cast<unsigned>(block_size));
+
+  float partial[TILE_N];
+  #pragma unroll
+  for (int t = 0; t < TILE_N; t++) partial[t] = 0.0f;
+
+  const uint8_t* W_rows[TILE_N];
+  const __half*  S_rows[TILE_N];
+  const uint8_t* Z_rows[TILE_N];
+  #pragma unroll
+  for (int t = 0; t < TILE_N; t++) {
+    int n = n_base + t;
+    int sn = (n < hidden) ? n : 0;
+    W_rows[t] = W + static_cast<size_t>(sn) * W_row_bytes;
+    S_rows[t] = S + static_cast<size_t>(sn) * n_blk_mid;
+    Z_rows[t] = Z ? Z + static_cast<size_t>(sn) * packed_zp_stride : nullptr;
+  }
+  const bool has_zp = (Z != nullptr);
+
+  const int num_u128 = inter / 32;
+  for (int idx = tid; idx < num_u128; idx += BLOCK_SIZE) {
+    const int k32 = idx * 32;
+    float a_vals[32];
+    float a_sum = 0.0f;
+    #pragma unroll
+    for (int i = 0; i < 32; i++) {
+      a_vals[i] = static_cast<float>(a_in[k32 + i]);
+      a_sum += a_vals[i];
+    }
+    const int   grp = k32 >> bs_shift;
+    const float a_sum_x_default_zp = a_sum * 8.0f;
+
+    uint4 b_pk[TILE_N];
+    float sv[TILE_N];
+    #pragma unroll
+    for (int t = 0; t < TILE_N; t++) {
+      b_pk[t] = *reinterpret_cast<const uint4*>(&W_rows[t][idx * 16]);
+      sv[t]   = static_cast<float>(S_rows[t][grp]);
+    }
+
+    #pragma unroll
+    for (int t = 0; t < TILE_N; t++) {
+      float dot = 0.0f;
+      #pragma unroll
+      for (int i = 0; i < 8; i++)
+        dot = __fmaf_rn(a_vals[i],
+                        static_cast<float>((b_pk[t].x >> (i * 4)) & 0xF), dot);
+      #pragma unroll
+      for (int i = 0; i < 8; i++)
+        dot = __fmaf_rn(a_vals[8 + i],
+                        static_cast<float>((b_pk[t].y >> (i * 4)) & 0xF), dot);
+      #pragma unroll
+      for (int i = 0; i < 8; i++)
+        dot = __fmaf_rn(a_vals[16 + i],
+                        static_cast<float>((b_pk[t].z >> (i * 4)) & 0xF), dot);
+      #pragma unroll
+      for (int i = 0; i < 8; i++)
+        dot = __fmaf_rn(a_vals[24 + i],
+                        static_cast<float>((b_pk[t].w >> (i * 4)) & 0xF), dot);
+
+      if (has_zp) {
+        uint8_t zp_byte = Z_rows[t][grp >> 1];
+        float   zp = static_cast<float>(
+                       (grp & 1) ? (zp_byte >> 4) : (zp_byte & 0x0F));
+        partial[t] += (dot - a_sum * zp) * sv[t];
+      } else {
+        partial[t] += (dot - a_sum_x_default_zp) * sv[t];
+      }
+    }
+  }
+
+  constexpr int WARP_SIZE = 32;
+  const int warp_id = tid / WARP_SIZE;
+  const int lane    = tid % WARP_SIZE;
+  constexpr int NUM_WARPS = BLOCK_SIZE / WARP_SIZE;
+
+  #pragma unroll
+  for (int t = 0; t < TILE_N; t++) {
+    for (int off = WARP_SIZE >> 1; off > 0; off >>= 1)
+      partial[t] += __shfl_down(partial[t], off);
+  }
+
+  if constexpr (BLOCK_SIZE <= WARP_SIZE) {
+    if (lane == 0) {
+      #pragma unroll
+      for (int t = 0; t < TILE_N; t++) {
+        int n = n_base + t;
+        if (n < hidden) {
+          float v = partial[t];
+          if (Bv) v += static_cast<float>(Bv[n]);
+          slot_buf[static_cast<size_t>(pair) * hidden + n] =
+              static_cast<__half>(wt * v);
+        }
+      }
+    }
+  } else {
+    __shared__ float warp_sums[TILE_N * NUM_WARPS];
+    if (lane == 0) {
+      #pragma unroll
+      for (int t = 0; t < TILE_N; t++)
+        warp_sums[t * NUM_WARPS + warp_id] = partial[t];
+    }
+    __syncthreads();
+    if (warp_id == 0) {
+      #pragma unroll
+      for (int t = 0; t < TILE_N; t++) {
+        float v = (lane < NUM_WARPS) ? warp_sums[t * NUM_WARPS + lane] : 0.0f;
+        for (int off = WARP_SIZE >> 1; off > 0; off >>= 1)
+          v += __shfl_down(v, off);
+        if (lane == 0) {
+          int n = n_base + t;
+          if (n < hidden) {
+            if (Bv) v += static_cast<float>(Bv[n]);
+            slot_buf[static_cast<size_t>(pair) * hidden + n] =
+                static_cast<__half>(wt * v);
+          }
+        }
+      }
+    }
+  }
+}
+
+// Scatter each pair's [hidden] result into an fp32 accumulator indexed by its
+// token. Concurrent pairs of the same token race, so use atomicAdd in fp32
+// (fp16 atomicAdd is unavailable / lossy on gfx11). The accumulator must be
+// zeroed before launch.
+__global__ void qmoe_prefill_scatter_kernel(
+    const __half*  __restrict__ slot_buf,          // [P, hidden]
+    const int32_t* __restrict__ sorted_token_ids,  // [P]
+    float*         __restrict__ accum,             // [num_tokens, hidden] fp32
+    int hidden,
+    int64_t total) {                               // P * hidden
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx >= total) return;
+  const int pair  = static_cast<int>(idx / hidden);
+  const int col   = static_cast<int>(idx % hidden);
+  const int token = sorted_token_ids[pair];
+  atomicAdd(&accum[static_cast<size_t>(token) * hidden + col],
+            static_cast<float>(slot_buf[idx]));
+}
+
+// Cast fp32 accumulator -> fp16 output.
+__global__ void qmoe_f32_to_f16_kernel(
+    const float* __restrict__ accum,
+    __half*      __restrict__ output,
+    int64_t n) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx >= n) return;
+  output[idx] = static_cast<__half>(accum[idx]);
+}
+
+// ===========================================================================
+// Grouped GEMM prefill MoE. Unlike the per-pair kernels above, the block owns
+// (expert e, N-tile) and loops that expert's M_e sorted rows INSIDE the block:
+//   grid = (N / TILE_N, num_experts), block = BLOCK_SIZE threads (K-parallel
+//   reduction, single warp so the reduction is pure warp-shuffle).
+// For each K-chunk the block loads the TILE_N int4 weight columns once and
+// applies them to a register tile of TILE_M rows, so the expert weight streams
+// from DRAM ~once for the whole expert (row-tile re-reads hit L2/MALL). This
+// restores the per-expert weight reuse the per-pair kernels threw away.
+// Weight/scale/packed-zp layout matches the decode kernels exactly.
+// ===========================================================================
+
+// FC1 + SwiGLU, grouped. act_out is indexed by the GLOBAL sorted row index
+// (off + m), so FC2 can read it back per row without a second gather.
+template <int BLOCK_SIZE, int TILE_N, int TILE_M>
+__global__ void qmoe_grouped_fc1_kernel(
+    const __half*  __restrict__ input,             // [num_tokens, hidden]
+    const int32_t* __restrict__ sorted_token_ids,  // [P]
+    const int32_t* __restrict__ expert_offsets,    // [num_experts + 1]
+    const uint8_t* __restrict__ fc1_w,             // [E, fusion_inter, hidden/2]
+    const __half*  __restrict__ fc1_s,             // [E, fusion_inter, n_blk_in]
+    const uint8_t* __restrict__ fc1_zp_packed,     // [E, fusion_inter, ceil/2] or null
+    const __half*  __restrict__ fc1_b,             // [E, fusion_inter] or null
+    __half*        __restrict__ act_out,           // [P, inter]
+    int hidden,
+    int fusion_inter,
+    int n_blk_in,
+    int block_size,
+    float swiglu_alpha,
+    float swiglu_beta,
+    float swiglu_limit) {
+  static_assert(BLOCK_SIZE <= 32, "grouped kernel assumes single-warp reduce");
+  static_assert((TILE_N & 1) == 0, "TILE_N must be even for SwiGLU pairing");
+  const int n_base = blockIdx.x * TILE_N;
+  const int e      = blockIdx.y;
+  const int lane   = threadIdx.x;
+  const int off    = expert_offsets[e];
+  const int M_e    = expert_offsets[e + 1] - off;
+  if (M_e <= 0) return;
+
+  const size_t   W_row_bytes = static_cast<size_t>(hidden) / 2;
+  const uint8_t* W = fc1_w + static_cast<size_t>(e) * fusion_inter * W_row_bytes;
+  const __half*  S = fc1_s + static_cast<size_t>(e) * fusion_inter * n_blk_in;
+  const int      packed_zp_stride = (n_blk_in + 1) / 2;
+  const uint8_t* Z = fc1_zp_packed
+                       ? fc1_zp_packed + static_cast<size_t>(e) * fusion_inter * packed_zp_stride
+                       : nullptr;
+  const __half*  Bv = fc1_b ? fc1_b + static_cast<size_t>(e) * fusion_inter : nullptr;
+  const int bs_shift = __builtin_ctz(static_cast<unsigned>(block_size));
+  const bool has_zp = (Z != nullptr);
+
+  const uint8_t* W_rows[TILE_N];
+  const __half*  S_rows[TILE_N];
+  const uint8_t* Z_rows[TILE_N];
+  #pragma unroll
+  for (int t = 0; t < TILE_N; t++) {
+    int n = n_base + t;
+    int sn = (n < fusion_inter) ? n : 0;
+    W_rows[t] = W + static_cast<size_t>(sn) * W_row_bytes;
+    S_rows[t] = S + static_cast<size_t>(sn) * n_blk_in;
+    Z_rows[t] = Z ? Z + static_cast<size_t>(sn) * packed_zp_stride : nullptr;
+  }
+
+  const int num_u128 = hidden / 32;
+  const int inter    = fusion_inter / 2;
+  const int sw_base  = n_base / 2;
+  constexpr int TILE_OUT = TILE_N / 2;
+
+  for (int m0 = 0; m0 < M_e; m0 += TILE_M) {
+    const int mcnt = (M_e - m0 < TILE_M) ? (M_e - m0) : TILE_M;
+    const __half* in_rows[TILE_M];
+    #pragma unroll
+    for (int m = 0; m < TILE_M; m++) {
+      in_rows[m] = (m < mcnt)
+          ? input + static_cast<size_t>(sorted_token_ids[off + m0 + m]) * hidden
+          : nullptr;
+    }
+
+    float partial[TILE_M][TILE_N];
+    #pragma unroll
+    for (int m = 0; m < TILE_M; m++)
+      #pragma unroll
+      for (int t = 0; t < TILE_N; t++) partial[m][t] = 0.0f;
+
+    for (int idx = lane; idx < num_u128; idx += BLOCK_SIZE) {
+      const int k32 = idx * 32;
+      const int grp = k32 >> bs_shift;
+
+      uint4 b_pk[TILE_N];
+      float sv[TILE_N];
+      float zpv[TILE_N];
+      #pragma unroll
+      for (int t = 0; t < TILE_N; t++) {
+        b_pk[t] = *reinterpret_cast<const uint4*>(&W_rows[t][idx * 16]);
+        sv[t]   = static_cast<float>(S_rows[t][grp]);
+        if (has_zp) {
+          uint8_t zb = Z_rows[t][grp >> 1];
+          zpv[t] = static_cast<float>((grp & 1) ? (zb >> 4) : (zb & 0x0F));
+        } else {
+          zpv[t] = 8.0f;
+        }
+      }
+
+      #pragma unroll
+      for (int m = 0; m < TILE_M; m++) {
+        if (m >= mcnt) break;
+        float a_vals[32];
+        float a_sum = 0.0f;
+        #pragma unroll
+        for (int i = 0; i < 32; i++) {
+          a_vals[i] = static_cast<float>(in_rows[m][k32 + i]);
+          a_sum += a_vals[i];
+        }
+        #pragma unroll
+        for (int t = 0; t < TILE_N; t++) {
+          float dot = 0.0f;
+          #pragma unroll
+          for (int i = 0; i < 8; i++)
+            dot = __fmaf_rn(a_vals[i],
+                            static_cast<float>((b_pk[t].x >> (i * 4)) & 0xF), dot);
+          #pragma unroll
+          for (int i = 0; i < 8; i++)
+            dot = __fmaf_rn(a_vals[8 + i],
+                            static_cast<float>((b_pk[t].y >> (i * 4)) & 0xF), dot);
+          #pragma unroll
+          for (int i = 0; i < 8; i++)
+            dot = __fmaf_rn(a_vals[16 + i],
+                            static_cast<float>((b_pk[t].z >> (i * 4)) & 0xF), dot);
+          #pragma unroll
+          for (int i = 0; i < 8; i++)
+            dot = __fmaf_rn(a_vals[24 + i],
+                            static_cast<float>((b_pk[t].w >> (i * 4)) & 0xF), dot);
+          partial[m][t] += (dot - a_sum * zpv[t]) * sv[t];
+        }
+      }
+    }
+
+    // Single-warp reduction across lanes, then lane 0 SwiGLU-pairs and writes.
+    #pragma unroll
+    for (int m = 0; m < TILE_M; m++) {
+      if (m >= mcnt) break;
+      #pragma unroll
+      for (int t = 0; t < TILE_N; t++) {
+        float v = partial[m][t];
+        for (int o = BLOCK_SIZE >> 1; o > 0; o >>= 1)
+          v += __shfl_down(v, o);
+        partial[m][t] = v;
+      }
+    }
+    if (lane == 0) {
+      #pragma unroll
+      for (int m = 0; m < TILE_M; m++) {
+        if (m >= mcnt) break;
+        const size_t out_row = static_cast<size_t>(off + m0 + m) * inter;
+        #pragma unroll
+        for (int p = 0; p < TILE_OUT; p++) {
+          int n_g = n_base + 2 * p;
+          int n_l = n_g + 1;
+          if (n_g < fusion_inter && n_l < fusion_inter) {
+            float g = partial[m][2 * p];
+            float l = partial[m][2 * p + 1];
+            if (Bv) { g += static_cast<float>(Bv[n_g]); l += static_cast<float>(Bv[n_l]); }
+            float G = fminf(g, swiglu_limit);
+            float L = fmaxf(fminf(l, swiglu_limit), -swiglu_limit);
+            float sig = 1.0f / (1.0f + expf(-swiglu_alpha * G));
+            act_out[out_row + sw_base + p] =
+                static_cast<__half>(G * sig * (L + swiglu_beta));
+          }
+        }
+      }
+    }
+  }
+}
+
+// FC2, grouped. Reads act_out[off+m], multiplies by the routing weight, and
+// atomic-adds the [hidden] result into the fp32 accumulator indexed by token.
+template <int BLOCK_SIZE, int TILE_N, int TILE_M>
+__global__ void qmoe_grouped_fc2_kernel(
+    const __half*  __restrict__ act_out,           // [P, inter]
+    const int32_t* __restrict__ sorted_token_ids,  // [P]
+    const __half*  __restrict__ sorted_weights,    // [P]
+    const int32_t* __restrict__ expert_offsets,    // [num_experts + 1]
+    const uint8_t* __restrict__ fc2_w,             // [E, hidden, inter/2]
+    const __half*  __restrict__ fc2_s,             // [E, hidden, n_blk_mid]
+    const uint8_t* __restrict__ fc2_zp_packed,     // [E, hidden, ceil/2] or null
+    const __half*  __restrict__ fc2_b,             // [E, hidden] or null
+    float*         __restrict__ accum,             // [num_tokens, hidden] fp32
+    int inter,
+    int hidden,
+    int n_blk_mid,
+    int block_size) {
+  static_assert(BLOCK_SIZE <= 32, "grouped kernel assumes single-warp reduce");
+  const int n_base = blockIdx.x * TILE_N;
+  const int e      = blockIdx.y;
+  const int lane   = threadIdx.x;
+  const int off    = expert_offsets[e];
+  const int M_e    = expert_offsets[e + 1] - off;
+  if (M_e <= 0) return;
+
+  const size_t   W_row_bytes = static_cast<size_t>(inter) / 2;
+  const uint8_t* W = fc2_w + static_cast<size_t>(e) * hidden * W_row_bytes;
+  const __half*  S = fc2_s + static_cast<size_t>(e) * hidden * n_blk_mid;
+  const int      packed_zp_stride = (n_blk_mid + 1) / 2;
+  const uint8_t* Z = fc2_zp_packed
+                       ? fc2_zp_packed + static_cast<size_t>(e) * hidden * packed_zp_stride
+                       : nullptr;
+  const __half*  Bv = fc2_b ? fc2_b + static_cast<size_t>(e) * hidden : nullptr;
+  const int bs_shift = __builtin_ctz(static_cast<unsigned>(block_size));
+  const bool has_zp = (Z != nullptr);
+
+  const uint8_t* W_rows[TILE_N];
+  const __half*  S_rows[TILE_N];
+  const uint8_t* Z_rows[TILE_N];
+  #pragma unroll
+  for (int t = 0; t < TILE_N; t++) {
+    int n = n_base + t;
+    int sn = (n < hidden) ? n : 0;
+    W_rows[t] = W + static_cast<size_t>(sn) * W_row_bytes;
+    S_rows[t] = S + static_cast<size_t>(sn) * n_blk_mid;
+    Z_rows[t] = Z ? Z + static_cast<size_t>(sn) * packed_zp_stride : nullptr;
+  }
+
+  const int num_u128 = inter / 32;
+
+  for (int m0 = 0; m0 < M_e; m0 += TILE_M) {
+    const int mcnt = (M_e - m0 < TILE_M) ? (M_e - m0) : TILE_M;
+    const __half* a_rows[TILE_M];
+    int   tok[TILE_M];
+    float wt[TILE_M];
+    #pragma unroll
+    for (int m = 0; m < TILE_M; m++) {
+      if (m < mcnt) {
+        a_rows[m] = act_out + static_cast<size_t>(off + m0 + m) * inter;
+        tok[m]    = sorted_token_ids[off + m0 + m];
+        wt[m]     = static_cast<float>(sorted_weights[off + m0 + m]);
+      } else {
+        a_rows[m] = nullptr; tok[m] = 0; wt[m] = 0.0f;
+      }
+    }
+
+    float partial[TILE_M][TILE_N];
+    #pragma unroll
+    for (int m = 0; m < TILE_M; m++)
+      #pragma unroll
+      for (int t = 0; t < TILE_N; t++) partial[m][t] = 0.0f;
+
+    for (int idx = lane; idx < num_u128; idx += BLOCK_SIZE) {
+      const int k32 = idx * 32;
+      const int grp = k32 >> bs_shift;
+
+      uint4 b_pk[TILE_N];
+      float sv[TILE_N];
+      float zpv[TILE_N];
+      #pragma unroll
+      for (int t = 0; t < TILE_N; t++) {
+        b_pk[t] = *reinterpret_cast<const uint4*>(&W_rows[t][idx * 16]);
+        sv[t]   = static_cast<float>(S_rows[t][grp]);
+        if (has_zp) {
+          uint8_t zb = Z_rows[t][grp >> 1];
+          zpv[t] = static_cast<float>((grp & 1) ? (zb >> 4) : (zb & 0x0F));
+        } else {
+          zpv[t] = 8.0f;
+        }
+      }
+
+      #pragma unroll
+      for (int m = 0; m < TILE_M; m++) {
+        if (m >= mcnt) break;
+        float a_vals[32];
+        float a_sum = 0.0f;
+        #pragma unroll
+        for (int i = 0; i < 32; i++) {
+          a_vals[i] = static_cast<float>(a_rows[m][k32 + i]);
+          a_sum += a_vals[i];
+        }
+        #pragma unroll
+        for (int t = 0; t < TILE_N; t++) {
+          float dot = 0.0f;
+          #pragma unroll
+          for (int i = 0; i < 8; i++)
+            dot = __fmaf_rn(a_vals[i],
+                            static_cast<float>((b_pk[t].x >> (i * 4)) & 0xF), dot);
+          #pragma unroll
+          for (int i = 0; i < 8; i++)
+            dot = __fmaf_rn(a_vals[8 + i],
+                            static_cast<float>((b_pk[t].y >> (i * 4)) & 0xF), dot);
+          #pragma unroll
+          for (int i = 0; i < 8; i++)
+            dot = __fmaf_rn(a_vals[16 + i],
+                            static_cast<float>((b_pk[t].z >> (i * 4)) & 0xF), dot);
+          #pragma unroll
+          for (int i = 0; i < 8; i++)
+            dot = __fmaf_rn(a_vals[24 + i],
+                            static_cast<float>((b_pk[t].w >> (i * 4)) & 0xF), dot);
+          partial[m][t] += (dot - a_sum * zpv[t]) * sv[t];
+        }
+      }
+    }
+
+    #pragma unroll
+    for (int m = 0; m < TILE_M; m++) {
+      if (m >= mcnt) break;
+      #pragma unroll
+      for (int t = 0; t < TILE_N; t++) {
+        float v = partial[m][t];
+        for (int o = BLOCK_SIZE >> 1; o > 0; o >>= 1)
+          v += __shfl_down(v, o);
+        partial[m][t] = v;
+      }
+    }
+    if (lane == 0) {
+      #pragma unroll
+      for (int m = 0; m < TILE_M; m++) {
+        if (m >= mcnt) break;
+        const size_t acc_row = static_cast<size_t>(tok[m]) * hidden;
+        #pragma unroll
+        for (int t = 0; t < TILE_N; t++) {
+          int n = n_base + t;
+          if (n < hidden) {
+            float v = partial[m][t];
+            if (Bv) v += static_cast<float>(Bv[n]);
+            // Round the per-expert contribution to fp16 BEFORE accumulating, to
+            // match the per-pair/baseline path (slot_buf is __half, then the
+            // scatter atomic-adds the fp16 value as fp32). Accumulating in raw
+            // fp32 here would diverge from the reference numerics.
+            atomicAdd(&accum[acc_row + n],
+                      static_cast<float>(static_cast<__half>(wt[m] * v)));
+          }
+        }
+      }
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Decode launchers. Hand-picked BLOCK_SIZE=256, TILE_N=8 (a strong default
 // for matmul_nbits autotune at gpt-oss-20b shapes; can later wrap in a
@@ -1288,6 +2015,425 @@ extern "C" int hip_qmoe_decode_fused(
     hipError_t e = hipGetLastError();
     if (e != hipSuccess) {
       fprintf(stderr, "[custom_kernels] qmoe_decode_reduce failed: %s\n",
+              hipGetErrorString(e));
+      return static_cast<int>(e);
+    }
+  }
+
+  return 0;
+}
+
+// ===========================================================================
+// Grouped prefill launcher (num_tokens > 1). Runs the whole MoE layer in
+// build_sorted_expert_id + fc1 + fc2 + scatter + cast = 5 launches, no D2H,
+// no hipStreamSynchronize, no host expert loop. Inputs sorted_* come from
+// hip_qmoe_bucket_tokens; expert_offsets drives the per-pair expert id.
+// Uses the fp int4 GEMV path (BS=64, TN=8); a dp4a variant can stack later.
+// ===========================================================================
+extern "C" int hip_qmoe_prefill_fused(
+    void* stream,
+    const void* input,             // [num_tokens, hidden] fp16
+    const void* sorted_token_ids,  // [P] int32 (bucket_tokens)
+    const void* sorted_weights,    // [P] fp16  (bucket_tokens)
+    const void* expert_offsets,    // [num_experts + 1] int32 (bucket_tokens)
+    void* sorted_expert_id,        // [P] int32 scratch (filled here)
+    const void* fc1_weights, const void* fc1_scales,
+    const void* fc1_zero_points, const void* fc1_bias,
+    const void* fc2_weights, const void* fc2_scales,
+    const void* fc2_zero_points, const void* fc2_bias,
+    void* act_out,    // [P, inter] fp16 scratch
+    void* slot_buf,   // [P, hidden] fp16 scratch
+    void* accum_f32,  // [num_tokens, hidden] fp32 scratch
+    void* output,     // [num_tokens, hidden] fp16
+    int64_t num_tokens, int64_t hidden_size, int64_t inter_size,
+    int64_t k, int64_t num_experts, int64_t block_size,
+    float swiglu_alpha, float swiglu_beta, float swiglu_limit,
+    int64_t element_size_bytes) {
+  if (element_size_bytes != 2) {
+    fprintf(stderr, "[custom_kernels] hip_qmoe_prefill_fused: only fp16 "
+                    "supported (got element_size %lld)\n",
+            (long long)element_size_bytes);
+    return -1;
+  }
+  if (block_size <= 0 || (block_size & 1) != 0) {
+    fprintf(stderr, "[custom_kernels] hip_qmoe_prefill_fused: invalid "
+                    "block_size=%lld\n", (long long)block_size);
+    return -1;
+  }
+  if (hidden_size <= 0 || inter_size <= 0 || k <= 0 || num_tokens <= 0 ||
+      num_experts <= 0 || (hidden_size % 32) != 0 || (inter_size % 32) != 0) {
+    fprintf(stderr, "[custom_kernels] hip_qmoe_prefill_fused: invalid sizes "
+                    "(tokens=%lld hidden=%lld inter=%lld experts=%lld) or "
+                    "hidden/inter not multiples of 32\n",
+            (long long)num_tokens, (long long)hidden_size,
+            (long long)inter_size, (long long)num_experts);
+    return -1;
+  }
+  if (num_experts > 1024) {
+    fprintf(stderr, "[custom_kernels] hip_qmoe_prefill_fused: num_experts=%lld "
+                    "> 1024 not supported\n", (long long)num_experts);
+    return -1;
+  }
+
+  hipStream_t s = static_cast<hipStream_t>(stream);
+  const int P = static_cast<int>(num_tokens * k);
+  const int fusion_inter = static_cast<int>(2 * inter_size);
+  const int n_blk_in  = static_cast<int>((hidden_size + block_size - 1) / block_size);
+  const int n_blk_mid = static_cast<int>((inter_size  + block_size - 1) / block_size);
+  constexpr int BS = 64, TN = 8;
+
+  // 1) Per-pair expert id from the exclusive prefix-sum offsets.
+  {
+    int block_dim = static_cast<int>(((num_experts + 31) / 32) * 32);
+    hipLaunchKernelGGL(build_sorted_expert_id_kernel, dim3(1), dim3(block_dim),
+                       0, s, static_cast<const int32_t*>(expert_offsets),
+                       static_cast<int32_t*>(sorted_expert_id),
+                       static_cast<int>(num_experts));
+    hipError_t e = hipGetLastError();
+    if (e != hipSuccess) {
+      fprintf(stderr, "[custom_kernels] build_sorted_expert_id failed: %s\n",
+              hipGetErrorString(e));
+      return static_cast<int>(e);
+    }
+  }
+
+  // 2) FC1 + SwiGLU (gathers input row per pair): grid (fusion_inter/TN, P).
+  {
+    dim3 grid(static_cast<unsigned>((fusion_inter + TN - 1) / TN),
+              static_cast<unsigned>(P));
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(qmoe_prefill_fc1_kernel<BS, TN>), grid,
+                       dim3(BS), 0, s, static_cast<const __half*>(input),
+                       static_cast<const int32_t*>(sorted_token_ids),
+                       static_cast<const int32_t*>(sorted_expert_id),
+                       static_cast<const uint8_t*>(fc1_weights),
+                       static_cast<const __half*>(fc1_scales),
+                       static_cast<const uint8_t*>(fc1_zero_points),
+                       static_cast<const __half*>(fc1_bias),
+                       static_cast<__half*>(act_out),
+                       static_cast<int>(hidden_size), fusion_inter, n_blk_in,
+                       static_cast<int>(block_size), swiglu_alpha, swiglu_beta,
+                       swiglu_limit);
+    hipError_t e = hipGetLastError();
+    if (e != hipSuccess) {
+      fprintf(stderr, "[custom_kernels] qmoe_prefill_fc1 failed: %s\n",
+              hipGetErrorString(e));
+      return static_cast<int>(e);
+    }
+  }
+
+  // 3) FC2 + routing-weighted write: grid (hidden/TN, P).
+  {
+    dim3 grid(static_cast<unsigned>((hidden_size + TN - 1) / TN),
+              static_cast<unsigned>(P));
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(qmoe_prefill_fc2_kernel<BS, TN>), grid,
+                       dim3(BS), 0, s, static_cast<const __half*>(act_out),
+                       static_cast<const int32_t*>(sorted_expert_id),
+                       static_cast<const __half*>(sorted_weights),
+                       static_cast<const uint8_t*>(fc2_weights),
+                       static_cast<const __half*>(fc2_scales),
+                       static_cast<const uint8_t*>(fc2_zero_points),
+                       static_cast<const __half*>(fc2_bias),
+                       static_cast<__half*>(slot_buf),
+                       static_cast<int>(inter_size),
+                       static_cast<int>(hidden_size), n_blk_mid,
+                       static_cast<int>(block_size));
+    hipError_t e = hipGetLastError();
+    if (e != hipSuccess) {
+      fprintf(stderr, "[custom_kernels] qmoe_prefill_fc2 failed: %s\n",
+              hipGetErrorString(e));
+      return static_cast<int>(e);
+    }
+  }
+
+  // 4) Zero the fp32 accumulator, then atomic-scatter pair results by token.
+  {
+    hipError_t em = hipMemsetAsync(
+        accum_f32, 0,
+        static_cast<size_t>(num_tokens) * hidden_size * sizeof(float), s);
+    if (em != hipSuccess) {
+      fprintf(stderr, "[custom_kernels] qmoe_prefill accum memset failed: %s\n",
+              hipGetErrorString(em));
+      return static_cast<int>(em);
+    }
+    const int64_t total = static_cast<int64_t>(P) * hidden_size;
+    int grid = static_cast<int>((total + kBlock - 1) / kBlock);
+    hipLaunchKernelGGL(qmoe_prefill_scatter_kernel, dim3(grid), dim3(kBlock), 0,
+                       s, static_cast<const __half*>(slot_buf),
+                       static_cast<const int32_t*>(sorted_token_ids),
+                       static_cast<float*>(accum_f32),
+                       static_cast<int>(hidden_size), total);
+    hipError_t e = hipGetLastError();
+    if (e != hipSuccess) {
+      fprintf(stderr, "[custom_kernels] qmoe_prefill_scatter failed: %s\n",
+              hipGetErrorString(e));
+      return static_cast<int>(e);
+    }
+  }
+
+  // 5) Cast the fp32 accumulator to the fp16 output.
+  {
+    const int64_t n = static_cast<int64_t>(num_tokens) * hidden_size;
+    int grid = static_cast<int>((n + kBlock - 1) / kBlock);
+    hipLaunchKernelGGL(qmoe_f32_to_f16_kernel, dim3(grid), dim3(kBlock), 0, s,
+                       static_cast<const float*>(accum_f32),
+                       static_cast<__half*>(output), n);
+    hipError_t e = hipGetLastError();
+    if (e != hipSuccess) {
+      fprintf(stderr, "[custom_kernels] qmoe_f32_to_f16 failed: %s\n",
+              hipGetErrorString(e));
+      return static_cast<int>(e);
+    }
+  }
+
+  return 0;
+}
+
+// ===========================================================================
+// Grouped GEMM prefill launcher (num_tokens > 1). Runs the whole MoE layer in
+// memset(accum) + grouped FC1 + grouped FC2(atomic) + cast = 4 launches, no
+// D2H / hipStreamSynchronize / host loop, with per-expert weight reuse. Inputs
+// sorted_* and expert_offsets come from hip_qmoe_bucket_tokens.
+// ===========================================================================
+extern "C" int hip_qmoe_grouped_prefill_fused(
+    void* stream,
+    const void* input,             // [num_tokens, hidden] fp16
+    const void* sorted_token_ids,  // [P] int32 (bucket_tokens)
+    const void* sorted_weights,    // [P] fp16  (bucket_tokens)
+    const void* expert_offsets,    // [num_experts + 1] int32 (bucket_tokens)
+    const void* fc1_weights, const void* fc1_scales,
+    const void* fc1_zero_points, const void* fc1_bias,
+    const void* fc2_weights, const void* fc2_scales,
+    const void* fc2_zero_points, const void* fc2_bias,
+    void* act_out,    // [P, inter] fp16 scratch
+    void* accum_f32,  // [num_tokens, hidden] fp32 scratch
+    void* output,     // [num_tokens, hidden] fp16
+    int64_t num_tokens, int64_t hidden_size, int64_t inter_size,
+    int64_t k, int64_t num_experts, int64_t block_size,
+    float swiglu_alpha, float swiglu_beta, float swiglu_limit,
+    int64_t element_size_bytes) {
+  if (element_size_bytes != 2) {
+    fprintf(stderr, "[custom_kernels] hip_qmoe_grouped_prefill_fused: only fp16 "
+                    "supported (got element_size %lld)\n",
+            (long long)element_size_bytes);
+    return -1;
+  }
+  if (block_size <= 0 || (block_size & 1) != 0) {
+    fprintf(stderr, "[custom_kernels] hip_qmoe_grouped_prefill_fused: invalid "
+                    "block_size=%lld\n", (long long)block_size);
+    return -1;
+  }
+  if (hidden_size <= 0 || inter_size <= 0 || k <= 0 || num_tokens <= 0 ||
+      num_experts <= 0 || (hidden_size % 32) != 0 || (inter_size % 32) != 0) {
+    fprintf(stderr, "[custom_kernels] hip_qmoe_grouped_prefill_fused: invalid "
+                    "sizes (tokens=%lld hidden=%lld inter=%lld experts=%lld) or "
+                    "hidden/inter not multiples of 32\n",
+            (long long)num_tokens, (long long)hidden_size,
+            (long long)inter_size, (long long)num_experts);
+    return -1;
+  }
+
+  hipStream_t s = static_cast<hipStream_t>(stream);
+  const int fusion_inter = static_cast<int>(2 * inter_size);
+  const int n_blk_in  = static_cast<int>((hidden_size + block_size - 1) / block_size);
+  const int n_blk_mid = static_cast<int>((inter_size  + block_size - 1) / block_size);
+  constexpr int BS = 32, TN = 8, TM = 8;
+
+  // 1) Zero the fp32 accumulator (FC2 atomic-adds into it).
+  {
+    hipError_t em = hipMemsetAsync(
+        accum_f32, 0,
+        static_cast<size_t>(num_tokens) * hidden_size * sizeof(float), s);
+    if (em != hipSuccess) {
+      fprintf(stderr, "[custom_kernels] grouped accum memset failed: %s\n",
+              hipGetErrorString(em));
+      return static_cast<int>(em);
+    }
+  }
+
+  // 2) Grouped FC1 + SwiGLU: grid (fusion_inter/TN, num_experts).
+  {
+    dim3 grid(static_cast<unsigned>((fusion_inter + TN - 1) / TN),
+              static_cast<unsigned>(num_experts));
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(qmoe_grouped_fc1_kernel<BS, TN, TM>), grid,
+                       dim3(BS), 0, s, static_cast<const __half*>(input),
+                       static_cast<const int32_t*>(sorted_token_ids),
+                       static_cast<const int32_t*>(expert_offsets),
+                       static_cast<const uint8_t*>(fc1_weights),
+                       static_cast<const __half*>(fc1_scales),
+                       static_cast<const uint8_t*>(fc1_zero_points),
+                       static_cast<const __half*>(fc1_bias),
+                       static_cast<__half*>(act_out),
+                       static_cast<int>(hidden_size), fusion_inter, n_blk_in,
+                       static_cast<int>(block_size), swiglu_alpha, swiglu_beta,
+                       swiglu_limit);
+    hipError_t e = hipGetLastError();
+    if (e != hipSuccess) {
+      fprintf(stderr, "[custom_kernels] qmoe_grouped_fc1 failed: %s\n",
+              hipGetErrorString(e));
+      return static_cast<int>(e);
+    }
+  }
+
+  // 3) Grouped FC2: grid (hidden/TN, num_experts), atomic-add to accum.
+  {
+    dim3 grid(static_cast<unsigned>((hidden_size + TN - 1) / TN),
+              static_cast<unsigned>(num_experts));
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(qmoe_grouped_fc2_kernel<BS, TN, TM>), grid,
+                       dim3(BS), 0, s, static_cast<const __half*>(act_out),
+                       static_cast<const int32_t*>(sorted_token_ids),
+                       static_cast<const __half*>(sorted_weights),
+                       static_cast<const int32_t*>(expert_offsets),
+                       static_cast<const uint8_t*>(fc2_weights),
+                       static_cast<const __half*>(fc2_scales),
+                       static_cast<const uint8_t*>(fc2_zero_points),
+                       static_cast<const __half*>(fc2_bias),
+                       static_cast<float*>(accum_f32),
+                       static_cast<int>(inter_size),
+                       static_cast<int>(hidden_size), n_blk_mid,
+                       static_cast<int>(block_size));
+    hipError_t e = hipGetLastError();
+    if (e != hipSuccess) {
+      fprintf(stderr, "[custom_kernels] qmoe_grouped_fc2 failed: %s\n",
+              hipGetErrorString(e));
+      return static_cast<int>(e);
+    }
+  }
+
+  // 4) Cast the fp32 accumulator to the fp16 output.
+  {
+    const int64_t n = static_cast<int64_t>(num_tokens) * hidden_size;
+    int grid = static_cast<int>((n + kBlock - 1) / kBlock);
+    hipLaunchKernelGGL(qmoe_f32_to_f16_kernel, dim3(grid), dim3(kBlock), 0, s,
+                       static_cast<const float*>(accum_f32),
+                       static_cast<__half*>(output), n);
+    hipError_t e = hipGetLastError();
+    if (e != hipSuccess) {
+      fprintf(stderr, "[custom_kernels] qmoe_f32_to_f16 (grouped) failed: %s\n",
+              hipGetErrorString(e));
+      return static_cast<int>(e);
+    }
+  }
+
+  return 0;
+}
+
+// ===========================================================================
+// Grouped int4 WMMA (Matrix-Core) fused prefill MoE.
+//
+// Orchestrates the whole MoE layer as: gather A_all -> FC1 WMMA (+bias) ->
+// SwiGLU -> FC2 WMMA (routing-weighted atomic scatter) -> cast. Each FC is a
+// single grouped WMMA launch (blockIdx.z = active expert), reusing the tuned
+// Matrix-Core int4 pipeline (QMoEGroupedWmmaKernel / hip_qmoe_wmma_gemm_grouped
+// in matmul_nbits_kernel.hip) so the int4 weights stream once per expert. The
+// caller passes the active-expert list (built from a one-shot D2H of the
+// bucket_tokens counts) so the launcher needs no D2H / sync of its own.
+// ===========================================================================
+extern "C" int hip_qmoe_grouped_prefill_wmma(
+    void* stream,
+    const void* input,
+    const void* sorted_token_ids,
+    const void* sorted_weights,
+    const void* expert_offsets,
+    const void* active_eids, int num_active, int max_count,
+    const void* fc1_weights, const void* fc1_scales,
+    const void* fc1_zero_points, const void* fc1_bias,
+    const void* fc2_weights, const void* fc2_scales,
+    const void* fc2_zero_points, const void* fc2_bias,
+    void* act_out,
+    void* accum_f32,
+    void* output,
+    int64_t num_tokens, int64_t hidden_size, int64_t inter_size,
+    int64_t k, int64_t num_experts, int64_t block_size,
+    float swiglu_alpha, float swiglu_beta, float swiglu_limit,
+    int64_t element_size_bytes) {
+  if (element_size_bytes != 2) {
+    fprintf(stderr, "[custom_kernels] hip_qmoe_grouped_prefill_wmma: only fp16 "
+                    "supported (got element_size %lld)\n",
+            (long long)element_size_bytes);
+    return -1;
+  }
+  if (block_size <= 0 || (block_size & 1) != 0) {
+    fprintf(stderr, "[custom_kernels] hip_qmoe_grouped_prefill_wmma: invalid "
+                    "block_size=%lld\n", (long long)block_size);
+    return -1;
+  }
+  if (hidden_size <= 0 || inter_size <= 0 || k <= 0 || num_tokens <= 0 ||
+      num_experts <= 0 || (hidden_size % 64) != 0 || (inter_size % 64) != 0) {
+    fprintf(stderr, "[custom_kernels] hip_qmoe_grouped_prefill_wmma: invalid "
+                    "sizes (tokens=%lld hidden=%lld inter=%lld experts=%lld) or "
+                    "hidden/inter not multiples of 64\n",
+            (long long)num_tokens, (long long)hidden_size,
+            (long long)inter_size, (long long)num_experts);
+    return -1;
+  }
+
+  hipStream_t s = static_cast<hipStream_t>(stream);
+
+  if (num_active <= 0) {
+    // Nothing routed this layer -- zero the output and return.
+    hipError_t em = hipMemsetAsync(
+        output, 0, static_cast<size_t>(num_tokens) * hidden_size * 2, s);
+    return em == hipSuccess ? 0 : static_cast<int>(em);
+  }
+
+  const int fusion_inter = static_cast<int>(2 * inter_size);
+  const int ngk_fc1 =
+      static_cast<int>((hidden_size + block_size - 1) / block_size);
+  const int ngk_fc2 =
+      static_cast<int>((inter_size + block_size - 1) / block_size);
+
+  // 1) Zero the fp32 accumulator (FC2 atomic-adds into it).
+  {
+    hipError_t em = hipMemsetAsync(
+        accum_f32, 0,
+        static_cast<size_t>(num_tokens) * hidden_size * sizeof(float), s);
+    if (em != hipSuccess) {
+      fprintf(stderr, "[custom_kernels] wmma grouped accum memset failed: %s\n",
+              hipGetErrorString(em));
+      return static_cast<int>(em);
+    }
+  }
+
+  // 2) FC1 + SwiGLU (fused): grouped WMMA int4 GEMM gathers each routed row
+  //    straight from input via sorted_token_ids and applies SwiGLU in the
+  //    epilogue, writing act_out [P, inter] directly. No a_all, no fc1_out, and
+  //    no separate gather / swiglu kernels.
+  {
+    int rc = hip_qmoe_wmma_gemm_grouped(
+        stream, /*A_all=*/nullptr, expert_offsets, active_eids, num_active,
+        max_count, fc1_weights, fc1_scales, fc1_zero_points, fc1_bias,
+        fusion_inter, static_cast<int>(hidden_size), ngk_fc1,
+        static_cast<int>(block_size),
+        /*epilogue=plain_swiglu*/ 2, act_out, nullptr, nullptr, nullptr, 0,
+        /*gather_input=*/input, /*gather_ids=*/sorted_token_ids,
+        swiglu_alpha, swiglu_beta, swiglu_limit);
+    if (rc != 0) return rc;
+  }
+
+  // 3) FC2: grouped WMMA int4 GEMM with routing-weighted atomic scatter-add
+  //    of each expert's output rows into accum_f32 at the token's row.
+  {
+    int rc = hip_qmoe_wmma_gemm_grouped(
+        stream, act_out, expert_offsets, active_eids, num_active, max_count,
+        fc2_weights, fc2_scales, fc2_zero_points, fc2_bias,
+        static_cast<int>(hidden_size), static_cast<int>(inter_size), ngk_fc2,
+        static_cast<int>(block_size), /*epilogue=scatter*/ 1, nullptr,
+        sorted_token_ids, sorted_weights, accum_f32,
+        static_cast<int>(hidden_size), /*gather_input=*/nullptr,
+        /*gather_ids=*/nullptr, 0.0f, 0.0f, 0.0f);
+    if (rc != 0) return rc;
+  }
+
+  // 4) Cast the fp32 accumulator to the fp16 output.
+  {
+    const int64_t n = static_cast<int64_t>(num_tokens) * hidden_size;
+    int grid = static_cast<int>((n + kBlock - 1) / kBlock);
+    hipLaunchKernelGGL(qmoe_f32_to_f16_kernel, dim3(grid), dim3(kBlock), 0, s,
+                       static_cast<const float*>(accum_f32),
+                       static_cast<__half*>(output), n);
+    hipError_t e = hipGetLastError();
+    if (e != hipSuccess) {
+      fprintf(stderr, "[custom_kernels] qmoe_f32_to_f16 (wmma) failed: %s\n",
               hipGetErrorString(e));
       return static_cast<int>(e);
     }
@@ -1675,6 +2821,323 @@ __global__ void qmoe_decode_fc2_dp4a_kernel(
   }
 }
 
+// ===========================================================================
+// Grouped GEMM prefill, dp4a (W4A8). Same block/row-tiling as the scalar
+// grouped kernels (block owns (expert, N-tile), loops M_e rows so the weight
+// streams ~once), but the inner product uses sudot4 on int8 activations, and
+// BLOCK_SIZE can exceed a warp (multi-warp reduction) for real occupancy.
+// Activations are pre-quantized to deinterleaved int8 by qmoe_quant_act_i8.
+// ===========================================================================
+template <int BLOCK_SIZE, int TILE_N, int TILE_M>
+__global__ void qmoe_grouped_fc1_dp4a_kernel(
+    const int8_t*  __restrict__ a_qb,              // [num_tokens, hidden] i8
+    const float*   __restrict__ a_scale,           // [num_tokens, n_blk_in]
+    const int32_t* __restrict__ sorted_token_ids,  // [P]
+    const int32_t* __restrict__ expert_offsets,    // [num_experts + 1]
+    const uint8_t* __restrict__ fc1_w,
+    const __half*  __restrict__ fc1_s,
+    const uint8_t* __restrict__ fc1_zp_packed,
+    const __half*  __restrict__ fc1_b,
+    __half*        __restrict__ act_out,           // [P, inter]
+    int hidden, int fusion_inter, int n_blk_in, int block_size,
+    float swiglu_alpha, float swiglu_beta, float swiglu_limit) {
+  static_assert((TILE_N & 1) == 0, "TILE_N must be even for SwiGLU pairing");
+  constexpr int WARP_SIZE = 32;
+  constexpr int NUM_WARPS = BLOCK_SIZE / WARP_SIZE;
+  const int n_base = blockIdx.x * TILE_N;
+  const int e      = blockIdx.y;
+  const int tid    = threadIdx.x;
+  const int warp_id = tid / WARP_SIZE;
+  const int lane    = tid % WARP_SIZE;
+  const int off  = expert_offsets[e];
+  const int M_e  = expert_offsets[e + 1] - off;
+  if (M_e <= 0) return;
+
+  const size_t   W_row_bytes = static_cast<size_t>(hidden) / 2;
+  const uint8_t* W = fc1_w + static_cast<size_t>(e) * fusion_inter * W_row_bytes;
+  const __half*  S = fc1_s + static_cast<size_t>(e) * fusion_inter * n_blk_in;
+  const int      packed_zp_stride = (n_blk_in + 1) / 2;
+  const uint8_t* Z = fc1_zp_packed
+                       ? fc1_zp_packed + static_cast<size_t>(e) * fusion_inter * packed_zp_stride
+                       : nullptr;
+  const __half*  Bv = fc1_b ? fc1_b + static_cast<size_t>(e) * fusion_inter : nullptr;
+  const int  bs_shift = __builtin_ctz(static_cast<unsigned>(block_size));
+  const bool has_zp = (Z != nullptr);
+
+  const uint8_t* W_rows[TILE_N];
+  const __half*  S_rows[TILE_N];
+  const uint8_t* Z_rows[TILE_N];
+  #pragma unroll
+  for (int t = 0; t < TILE_N; t++) {
+    int n = n_base + t;
+    int sn = (n < fusion_inter) ? n : 0;
+    W_rows[t] = W + static_cast<size_t>(sn) * W_row_bytes;
+    S_rows[t] = S + static_cast<size_t>(sn) * n_blk_in;
+    Z_rows[t] = Z ? Z + static_cast<size_t>(sn) * packed_zp_stride : nullptr;
+  }
+
+  const int num_u128 = hidden / 32;
+  const int inter    = fusion_inter / 2;
+  const int sw_base  = n_base / 2;
+  constexpr int TILE_OUT = TILE_N / 2;
+  __shared__ float red[TILE_M * TILE_N * NUM_WARPS];
+
+  for (int m0 = 0; m0 < M_e; m0 += TILE_M) {
+    const int mcnt = (M_e - m0 < TILE_M) ? (M_e - m0) : TILE_M;
+    const int8_t* aqr[TILE_M];
+    const float*  asr[TILE_M];
+    #pragma unroll
+    for (int m = 0; m < TILE_M; m++) {
+      if (m < mcnt) {
+        int tok = sorted_token_ids[off + m0 + m];
+        aqr[m] = a_qb + static_cast<size_t>(tok) * hidden;
+        asr[m] = a_scale + static_cast<size_t>(tok) * n_blk_in;
+      } else { aqr[m] = nullptr; asr[m] = nullptr; }
+    }
+
+    float partial[TILE_M][TILE_N];
+    #pragma unroll
+    for (int m = 0; m < TILE_M; m++)
+      #pragma unroll
+      for (int t = 0; t < TILE_N; t++) partial[m][t] = 0.0f;
+
+    for (int idx = tid; idx < num_u128; idx += BLOCK_SIZE) {
+      const int grp = (idx * 32) >> bs_shift;
+      uint4 b_pk[TILE_N];
+      float sv[TILE_N];
+      int   zv[TILE_N];
+      #pragma unroll
+      for (int t = 0; t < TILE_N; t++) {
+        b_pk[t] = *reinterpret_cast<const uint4*>(&W_rows[t][idx * 16]);
+        sv[t]   = static_cast<float>(S_rows[t][grp]);
+        if (has_zp) {
+          uint8_t zb = Z_rows[t][grp >> 1];
+          zv[t] = static_cast<int>((grp & 1) ? (zb >> 4) : (zb & 0x0F));
+        } else zv[t] = 8;
+      }
+      #pragma unroll
+      for (int m = 0; m < TILE_M; m++) {
+        if (m >= mcnt) break;
+        const int8_t* aq = aqr[m] + static_cast<size_t>(idx) * 32;
+        int a_lo[4], a_hi[4];
+        #pragma unroll
+        for (int j = 0; j < 4; j++) {
+          a_lo[j] = *reinterpret_cast<const int*>(aq + j * 8);
+          a_hi[j] = *reinterpret_cast<const int*>(aq + j * 8 + 4);
+        }
+        int a_sum_q = 0;
+        #pragma unroll
+        for (int j = 0; j < 4; j++) {
+          a_sum_q = __builtin_amdgcn_sudot4(true, a_lo[j], false, 0x01010101, a_sum_q, false);
+          a_sum_q = __builtin_amdgcn_sudot4(true, a_hi[j], false, 0x01010101, a_sum_q, false);
+        }
+        const float a_sc = asr[m][grp];
+        #pragma unroll
+        for (int t = 0; t < TILE_N; t++) {
+          const unsigned comp[4] = {b_pk[t].x, b_pk[t].y, b_pk[t].z, b_pk[t].w};
+          int dot = 0;
+          #pragma unroll
+          for (int j = 0; j < 4; j++) {
+            const int lo_w = static_cast<int>(comp[j] & 0x0F0F0F0Fu);
+            const int hi_w = static_cast<int>((comp[j] >> 4) & 0x0F0F0F0Fu);
+            dot = __builtin_amdgcn_sudot4(true, a_lo[j], false, lo_w, dot, false);
+            dot = __builtin_amdgcn_sudot4(true, a_hi[j], false, hi_w, dot, false);
+          }
+          partial[m][t] += a_sc * sv[t] * static_cast<float>(dot - a_sum_q * zv[t]);
+        }
+      }
+    }
+
+    #pragma unroll
+    for (int m = 0; m < TILE_M; m++) {
+      if (m >= mcnt) break;
+      #pragma unroll
+      for (int t = 0; t < TILE_N; t++) {
+        float v = partial[m][t];
+        for (int o = WARP_SIZE >> 1; o > 0; o >>= 1) v += __shfl_down(v, o);
+        if (lane == 0) red[(m * TILE_N + t) * NUM_WARPS + warp_id] = v;
+      }
+    }
+    __syncthreads();
+    if (tid == 0) {
+      for (int m = 0; m < mcnt; m++) {
+        const size_t out_row = static_cast<size_t>(off + m0 + m) * inter;
+        for (int p = 0; p < TILE_OUT; p++) {
+          int n_g = n_base + 2 * p;
+          int n_l = n_g + 1;
+          if (n_g < fusion_inter && n_l < fusion_inter) {
+            float g = 0.0f, l = 0.0f;
+            #pragma unroll
+            for (int w = 0; w < NUM_WARPS; w++) {
+              g += red[(m * TILE_N + 2 * p) * NUM_WARPS + w];
+              l += red[(m * TILE_N + 2 * p + 1) * NUM_WARPS + w];
+            }
+            if (Bv) { g += static_cast<float>(Bv[n_g]); l += static_cast<float>(Bv[n_l]); }
+            float G = fminf(g, swiglu_limit);
+            float L = fmaxf(fminf(l, swiglu_limit), -swiglu_limit);
+            float sig = 1.0f / (1.0f + expf(-swiglu_alpha * G));
+            act_out[out_row + sw_base + p] =
+                static_cast<__half>(G * sig * (L + swiglu_beta));
+          }
+        }
+      }
+    }
+    __syncthreads();
+  }
+}
+
+template <int BLOCK_SIZE, int TILE_N, int TILE_M>
+__global__ void qmoe_grouped_fc2_dp4a_kernel(
+    const int8_t*  __restrict__ a_qb,              // [P, inter] i8
+    const float*   __restrict__ a_scale,           // [P, n_blk_mid]
+    const int32_t* __restrict__ sorted_token_ids,  // [P]
+    const __half*  __restrict__ sorted_weights,    // [P]
+    const int32_t* __restrict__ expert_offsets,    // [num_experts + 1]
+    const uint8_t* __restrict__ fc2_w,
+    const __half*  __restrict__ fc2_s,
+    const uint8_t* __restrict__ fc2_zp_packed,
+    const __half*  __restrict__ fc2_b,
+    float*         __restrict__ accum,             // [num_tokens, hidden] fp32
+    int inter, int hidden, int n_blk_mid, int block_size) {
+  constexpr int WARP_SIZE = 32;
+  constexpr int NUM_WARPS = BLOCK_SIZE / WARP_SIZE;
+  const int n_base = blockIdx.x * TILE_N;
+  const int e      = blockIdx.y;
+  const int tid    = threadIdx.x;
+  const int warp_id = tid / WARP_SIZE;
+  const int lane    = tid % WARP_SIZE;
+  const int off  = expert_offsets[e];
+  const int M_e  = expert_offsets[e + 1] - off;
+  if (M_e <= 0) return;
+
+  const size_t   W_row_bytes = static_cast<size_t>(inter) / 2;
+  const uint8_t* W = fc2_w + static_cast<size_t>(e) * hidden * W_row_bytes;
+  const __half*  S = fc2_s + static_cast<size_t>(e) * hidden * n_blk_mid;
+  const int      packed_zp_stride = (n_blk_mid + 1) / 2;
+  const uint8_t* Z = fc2_zp_packed
+                       ? fc2_zp_packed + static_cast<size_t>(e) * hidden * packed_zp_stride
+                       : nullptr;
+  const __half*  Bv = fc2_b ? fc2_b + static_cast<size_t>(e) * hidden : nullptr;
+  const int  bs_shift = __builtin_ctz(static_cast<unsigned>(block_size));
+  const bool has_zp = (Z != nullptr);
+
+  const uint8_t* W_rows[TILE_N];
+  const __half*  S_rows[TILE_N];
+  const uint8_t* Z_rows[TILE_N];
+  #pragma unroll
+  for (int t = 0; t < TILE_N; t++) {
+    int n = n_base + t;
+    int sn = (n < hidden) ? n : 0;
+    W_rows[t] = W + static_cast<size_t>(sn) * W_row_bytes;
+    S_rows[t] = S + static_cast<size_t>(sn) * n_blk_mid;
+    Z_rows[t] = Z ? Z + static_cast<size_t>(sn) * packed_zp_stride : nullptr;
+  }
+
+  const int num_u128 = inter / 32;
+  __shared__ float red[TILE_M * TILE_N * NUM_WARPS];
+
+  for (int m0 = 0; m0 < M_e; m0 += TILE_M) {
+    const int mcnt = (M_e - m0 < TILE_M) ? (M_e - m0) : TILE_M;
+    const int8_t* aqr[TILE_M];
+    const float*  asr[TILE_M];
+    int   tok[TILE_M];
+    float wt[TILE_M];
+    #pragma unroll
+    for (int m = 0; m < TILE_M; m++) {
+      if (m < mcnt) {
+        int gr = off + m0 + m;
+        aqr[m] = a_qb + static_cast<size_t>(gr) * inter;
+        asr[m] = a_scale + static_cast<size_t>(gr) * n_blk_mid;
+        tok[m] = sorted_token_ids[gr];
+        wt[m]  = static_cast<float>(sorted_weights[gr]);
+      } else { aqr[m] = nullptr; asr[m] = nullptr; tok[m] = 0; wt[m] = 0.0f; }
+    }
+
+    float partial[TILE_M][TILE_N];
+    #pragma unroll
+    for (int m = 0; m < TILE_M; m++)
+      #pragma unroll
+      for (int t = 0; t < TILE_N; t++) partial[m][t] = 0.0f;
+
+    for (int idx = tid; idx < num_u128; idx += BLOCK_SIZE) {
+      const int grp = (idx * 32) >> bs_shift;
+      uint4 b_pk[TILE_N];
+      float sv[TILE_N];
+      int   zv[TILE_N];
+      #pragma unroll
+      for (int t = 0; t < TILE_N; t++) {
+        b_pk[t] = *reinterpret_cast<const uint4*>(&W_rows[t][idx * 16]);
+        sv[t]   = static_cast<float>(S_rows[t][grp]);
+        if (has_zp) {
+          uint8_t zb = Z_rows[t][grp >> 1];
+          zv[t] = static_cast<int>((grp & 1) ? (zb >> 4) : (zb & 0x0F));
+        } else zv[t] = 8;
+      }
+      #pragma unroll
+      for (int m = 0; m < TILE_M; m++) {
+        if (m >= mcnt) break;
+        const int8_t* aq = aqr[m] + static_cast<size_t>(idx) * 32;
+        int a_lo[4], a_hi[4];
+        #pragma unroll
+        for (int j = 0; j < 4; j++) {
+          a_lo[j] = *reinterpret_cast<const int*>(aq + j * 8);
+          a_hi[j] = *reinterpret_cast<const int*>(aq + j * 8 + 4);
+        }
+        int a_sum_q = 0;
+        #pragma unroll
+        for (int j = 0; j < 4; j++) {
+          a_sum_q = __builtin_amdgcn_sudot4(true, a_lo[j], false, 0x01010101, a_sum_q, false);
+          a_sum_q = __builtin_amdgcn_sudot4(true, a_hi[j], false, 0x01010101, a_sum_q, false);
+        }
+        const float a_sc = asr[m][grp];
+        #pragma unroll
+        for (int t = 0; t < TILE_N; t++) {
+          const unsigned comp[4] = {b_pk[t].x, b_pk[t].y, b_pk[t].z, b_pk[t].w};
+          int dot = 0;
+          #pragma unroll
+          for (int j = 0; j < 4; j++) {
+            const int lo_w = static_cast<int>(comp[j] & 0x0F0F0F0Fu);
+            const int hi_w = static_cast<int>((comp[j] >> 4) & 0x0F0F0F0Fu);
+            dot = __builtin_amdgcn_sudot4(true, a_lo[j], false, lo_w, dot, false);
+            dot = __builtin_amdgcn_sudot4(true, a_hi[j], false, hi_w, dot, false);
+          }
+          partial[m][t] += a_sc * sv[t] * static_cast<float>(dot - a_sum_q * zv[t]);
+        }
+      }
+    }
+
+    #pragma unroll
+    for (int m = 0; m < TILE_M; m++) {
+      if (m >= mcnt) break;
+      #pragma unroll
+      for (int t = 0; t < TILE_N; t++) {
+        float v = partial[m][t];
+        for (int o = WARP_SIZE >> 1; o > 0; o >>= 1) v += __shfl_down(v, o);
+        if (lane == 0) red[(m * TILE_N + t) * NUM_WARPS + warp_id] = v;
+      }
+    }
+    __syncthreads();
+    if (tid == 0) {
+      for (int m = 0; m < mcnt; m++) {
+        const size_t acc_row = static_cast<size_t>(tok[m]) * hidden;
+        for (int t = 0; t < TILE_N; t++) {
+          int n = n_base + t;
+          if (n < hidden) {
+            float v = 0.0f;
+            #pragma unroll
+            for (int w = 0; w < NUM_WARPS; w++)
+              v += red[(m * TILE_N + t) * NUM_WARPS + w];
+            if (Bv) v += static_cast<float>(Bv[n]);
+            atomicAdd(&accum[acc_row + n],
+                      static_cast<float>(static_cast<__half>(wt[m] * v)));
+          }
+        }
+      }
+    }
+    __syncthreads();
+  }
+}
+
 template <int BS, int TN>
 static hipError_t launch_qmoe_fc1_dp4a(
     hipStream_t s, int k, int fusion_inter, const void* a_qb,
@@ -1913,6 +3376,170 @@ extern "C" int hip_qmoe_decode_fused_dp4a(
     if (e != hipSuccess) {
       fprintf(stderr, "[custom_kernels] qmoe_decode_reduce(dp4a) failed: %s\n",
               hipGetErrorString(e));
+      return static_cast<int>(e);
+    }
+  }
+
+  return 0;
+}
+
+// ===========================================================================
+// Grouped GEMM prefill, dp4a (W4A8). memset accum + quant(input) + grouped FC1
+// + quant(act_out) + grouped FC2(atomic) + cast = 6 launches, no host sync,
+// int8 sudot4 inner product, multi-warp blocks for occupancy.
+// ===========================================================================
+extern "C" int hip_qmoe_grouped_prefill_fused_dp4a(
+    void* stream,
+    const void* input,
+    const void* sorted_token_ids,
+    const void* sorted_weights,
+    const void* expert_offsets,
+    const void* fc1_weights, const void* fc1_scales,
+    const void* fc1_zero_points, const void* fc1_bias,
+    const void* fc2_weights, const void* fc2_scales,
+    const void* fc2_zero_points, const void* fc2_bias,
+    void* a_qb_in, void* a_scale_in,    // scratch: quantized [num_tokens, hidden]
+    void* a_qb_mid, void* a_scale_mid,  // scratch: quantized [P, inter]
+    void* act_out,    // [P, inter] fp16 scratch
+    void* accum_f32,  // [num_tokens, hidden] fp32 scratch
+    void* output,     // [num_tokens, hidden] fp16
+    int64_t num_tokens, int64_t hidden_size, int64_t inter_size,
+    int64_t k, int64_t num_experts, int64_t block_size,
+    float swiglu_alpha, float swiglu_beta, float swiglu_limit,
+    int64_t element_size_bytes) {
+  if (element_size_bytes != 2) {
+    fprintf(stderr, "[custom_kernels] grouped_prefill_dp4a: only fp16\n");
+    return -1;
+  }
+  if (block_size <= 0 || (block_size & 31) != 0) {
+    fprintf(stderr, "[custom_kernels] grouped_prefill_dp4a: block_size must be "
+                    "a positive multiple of 32 (got %lld)\n",
+            (long long)block_size);
+    return -1;
+  }
+  if (hidden_size <= 0 || inter_size <= 0 || k <= 0 || num_tokens <= 0 ||
+      num_experts <= 0 || (hidden_size % 32) != 0 || (inter_size % 32) != 0) {
+    fprintf(stderr, "[custom_kernels] grouped_prefill_dp4a: invalid sizes\n");
+    return -1;
+  }
+
+  hipStream_t s = static_cast<hipStream_t>(stream);
+  const int64_t P = num_tokens * k;
+  const int fusion_inter = static_cast<int>(2 * inter_size);
+  const int n_blk_in  = static_cast<int>((hidden_size + block_size - 1) / block_size);
+  const int n_blk_mid = static_cast<int>((inter_size  + block_size - 1) / block_size);
+  constexpr int BS = 128, TN = 8, TM = 4;
+
+  // 1) Zero the fp32 accumulator (FC2 atomic-adds into it).
+  {
+    hipError_t em = hipMemsetAsync(
+        accum_f32, 0,
+        static_cast<size_t>(num_tokens) * hidden_size * sizeof(float), s);
+    if (em != hipSuccess) {
+      fprintf(stderr, "[custom_kernels] grouped dp4a accum memset failed: %s\n",
+              hipGetErrorString(em));
+      return static_cast<int>(em);
+    }
+  }
+
+  // 2) Quantize all input rows to deinterleaved int8 (grid = groups x tokens).
+  {
+    dim3 grid(static_cast<unsigned>(n_blk_in), static_cast<unsigned>(num_tokens));
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(qmoe_quant_act_i8_kernel<128>), grid,
+                       dim3(128), 0, s, static_cast<const __half*>(input),
+                       static_cast<int8_t*>(a_qb_in),
+                       static_cast<float*>(a_scale_in),
+                       static_cast<int>(hidden_size),
+                       static_cast<int>(block_size), n_blk_in);
+    hipError_t e = hipGetLastError();
+    if (e != hipSuccess) {
+      fprintf(stderr, "[custom_kernels] grouped dp4a quant(in) failed: %s\n",
+              hipGetErrorString(e));
+      return static_cast<int>(e);
+    }
+  }
+
+  // 3) Grouped FC1 + SwiGLU (dp4a).
+  {
+    dim3 grid(static_cast<unsigned>((fusion_inter + TN - 1) / TN),
+              static_cast<unsigned>(num_experts));
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(qmoe_grouped_fc1_dp4a_kernel<BS, TN, TM>),
+                       grid, dim3(BS), 0, s,
+                       static_cast<const int8_t*>(a_qb_in),
+                       static_cast<const float*>(a_scale_in),
+                       static_cast<const int32_t*>(sorted_token_ids),
+                       static_cast<const int32_t*>(expert_offsets),
+                       static_cast<const uint8_t*>(fc1_weights),
+                       static_cast<const __half*>(fc1_scales),
+                       static_cast<const uint8_t*>(fc1_zero_points),
+                       static_cast<const __half*>(fc1_bias),
+                       static_cast<__half*>(act_out),
+                       static_cast<int>(hidden_size), fusion_inter, n_blk_in,
+                       static_cast<int>(block_size), swiglu_alpha, swiglu_beta,
+                       swiglu_limit);
+    hipError_t e = hipGetLastError();
+    if (e != hipSuccess) {
+      fprintf(stderr, "[custom_kernels] qmoe_grouped_fc1_dp4a failed: %s\n",
+              hipGetErrorString(e));
+      return static_cast<int>(e);
+    }
+  }
+
+  // 4) Quantize act_out rows to deinterleaved int8 (grid = groups x P rows).
+  {
+    dim3 grid(static_cast<unsigned>(n_blk_mid), static_cast<unsigned>(P));
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(qmoe_quant_act_i8_kernel<128>), grid,
+                       dim3(128), 0, s, static_cast<const __half*>(act_out),
+                       static_cast<int8_t*>(a_qb_mid),
+                       static_cast<float*>(a_scale_mid),
+                       static_cast<int>(inter_size),
+                       static_cast<int>(block_size), n_blk_mid);
+    hipError_t e = hipGetLastError();
+    if (e != hipSuccess) {
+      fprintf(stderr, "[custom_kernels] grouped dp4a quant(mid) failed: %s\n",
+              hipGetErrorString(e));
+      return static_cast<int>(e);
+    }
+  }
+
+  // 5) Grouped FC2 (dp4a), atomic-add to accum.
+  {
+    dim3 grid(static_cast<unsigned>((hidden_size + TN - 1) / TN),
+              static_cast<unsigned>(num_experts));
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(qmoe_grouped_fc2_dp4a_kernel<BS, TN, TM>),
+                       grid, dim3(BS), 0, s,
+                       static_cast<const int8_t*>(a_qb_mid),
+                       static_cast<const float*>(a_scale_mid),
+                       static_cast<const int32_t*>(sorted_token_ids),
+                       static_cast<const __half*>(sorted_weights),
+                       static_cast<const int32_t*>(expert_offsets),
+                       static_cast<const uint8_t*>(fc2_weights),
+                       static_cast<const __half*>(fc2_scales),
+                       static_cast<const uint8_t*>(fc2_zero_points),
+                       static_cast<const __half*>(fc2_bias),
+                       static_cast<float*>(accum_f32),
+                       static_cast<int>(inter_size),
+                       static_cast<int>(hidden_size), n_blk_mid,
+                       static_cast<int>(block_size));
+    hipError_t e = hipGetLastError();
+    if (e != hipSuccess) {
+      fprintf(stderr, "[custom_kernels] qmoe_grouped_fc2_dp4a failed: %s\n",
+              hipGetErrorString(e));
+      return static_cast<int>(e);
+    }
+  }
+
+  // 6) Cast the fp32 accumulator to the fp16 output.
+  {
+    const int64_t n = static_cast<int64_t>(num_tokens) * hidden_size;
+    int grid = static_cast<int>((n + kBlock - 1) / kBlock);
+    hipLaunchKernelGGL(qmoe_f32_to_f16_kernel, dim3(grid), dim3(kBlock), 0, s,
+                       static_cast<const float*>(accum_f32),
+                       static_cast<__half*>(output), n);
+    hipError_t e = hipGetLastError();
+    if (e != hipSuccess) {
+      fprintf(stderr, "[custom_kernels] qmoe_f32_to_f16 (grouped dp4a) failed: "
+                      "%s\n", hipGetErrorString(e));
       return static_cast<int>(e);
     }
   }

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -1826,6 +1826,140 @@ HIP_KERNEL_API int hip_qmoe_decode_fused_dp4a(
     float swiglu_alpha, float swiglu_beta, float swiglu_limit,
     int64_t element_size_bytes);
 
+/* -------------------------------------------------------------------------
+ * Fully fused MoE prefill (num_tokens > 1).
+ *
+ * The prefill analogue of hip_qmoe_decode_fused: runs the whole MoE layer in
+ * build_sorted_expert_id + FC1(+SwiGLU,+gather) + FC2 + atomic scatter + cast
+ * = 5 launches, with no D2H, no hipStreamSynchronize, and no host per-expert
+ * loop. Caller first runs hip_qmoe_topk_routing then hip_qmoe_bucket_tokens
+ * (producing sorted_token_ids / sorted_weights / expert_offsets grouped by
+ * expert); this launcher fills sorted_expert_id from expert_offsets and
+ * processes all P = num_tokens * k (token, slot) pairs.
+ *
+ * Scratch: act_out [P, inter] fp16, slot_buf [P, hidden] fp16, accum_f32
+ * [num_tokens, hidden] fp32, sorted_expert_id [P] int32. Weight/scale/zp
+ * layout is identical to hip_qmoe_decode_fused (per-expert packed int4).
+ * fp16 only; hidden_size and inter_size multiples of 32; block_size > 0/even.
+ */
+HIP_KERNEL_API int hip_qmoe_prefill_fused(
+    void* stream,
+    const void* input,
+    const void* sorted_token_ids,
+    const void* sorted_weights,
+    const void* expert_offsets,
+    void* sorted_expert_id,
+    const void* fc1_weights, const void* fc1_scales,
+    const void* fc1_zero_points, const void* fc1_bias,
+    const void* fc2_weights, const void* fc2_scales,
+    const void* fc2_zero_points, const void* fc2_bias,
+    void* act_out,
+    void* slot_buf,
+    void* accum_f32,
+    void* output,
+    int64_t num_tokens, int64_t hidden_size, int64_t inter_size,
+    int64_t k, int64_t num_experts, int64_t block_size,
+    float swiglu_alpha, float swiglu_beta, float swiglu_limit,
+    int64_t element_size_bytes);
+
+/* Grouped-GEMM variant of the fused prefill MoE. Same routing inputs as
+ * hip_qmoe_prefill_fused (sorted_* + expert_offsets from bucket_tokens), but
+ * each block owns (expert, N-tile) and loops the expert's rows internally so
+ * the int4 weight streams from DRAM ~once per expert. No sorted_expert_id /
+ * slot_buf needed (FC2 atomic-scatters into accum_f32). */
+HIP_KERNEL_API int hip_qmoe_grouped_prefill_fused(
+    void* stream,
+    const void* input,
+    const void* sorted_token_ids,
+    const void* sorted_weights,
+    const void* expert_offsets,
+    const void* fc1_weights, const void* fc1_scales,
+    const void* fc1_zero_points, const void* fc1_bias,
+    const void* fc2_weights, const void* fc2_scales,
+    const void* fc2_zero_points, const void* fc2_bias,
+    void* act_out,
+    void* accum_f32,
+    void* output,
+    int64_t num_tokens, int64_t hidden_size, int64_t inter_size,
+    int64_t k, int64_t num_experts, int64_t block_size,
+    float swiglu_alpha, float swiglu_beta, float swiglu_limit,
+    int64_t element_size_bytes);
+
+/* dp4a (W4A8) variant of the grouped prefill MoE: pre-quantizes activations to
+ * int8 and uses sudot4 for the inner product, multi-warp blocks for occupancy.
+ * Needs four extra scratch buffers for the quantized activations + scales. */
+HIP_KERNEL_API int hip_qmoe_grouped_prefill_fused_dp4a(
+    void* stream,
+    const void* input,
+    const void* sorted_token_ids,
+    const void* sorted_weights,
+    const void* expert_offsets,
+    const void* fc1_weights, const void* fc1_scales,
+    const void* fc1_zero_points, const void* fc1_bias,
+    const void* fc2_weights, const void* fc2_scales,
+    const void* fc2_zero_points, const void* fc2_bias,
+    void* a_qb_in, void* a_scale_in,
+    void* a_qb_mid, void* a_scale_mid,
+    void* act_out,
+    void* accum_f32,
+    void* output,
+    int64_t num_tokens, int64_t hidden_size, int64_t inter_size,
+    int64_t k, int64_t num_experts, int64_t block_size,
+    float swiglu_alpha, float swiglu_beta, float swiglu_limit,
+    int64_t element_size_bytes);
+
+/* Grouped int4 WMMA (Matrix-Core) variant of the fused prefill MoE.
+ *
+ * One grouped WMMA GEMM launch per FC (blockIdx.z selects an active expert),
+ * so the int4 weights stream from DRAM once per expert and the tuned
+ * Matrix-Core pipeline is reused across every expert. Flow: gather A_all ->
+ * FC1 WMMA (+bias) -> SwiGLU -> FC2 WMMA (routing-weighted atomic scatter to
+ * an fp32 accumulator) -> cast to fp16. Zero-points are read inline from the
+ * packed nibble buffer (no fp16 pre-convert).
+ *
+ * Caller (wrap_qmoe) provides the active-expert list built from a one-shot
+ * D2H of the bucket_tokens counts: active_eids [num_active] int32 (device),
+ * num_active and max_count (host). Scratch: a_all [P, hidden] fp16, fc1_out
+ * [P, 2*inter] fp16, act_out [P, inter] fp16, accum_f32 [num_tokens, hidden].
+ * fp16 only; hidden/inter multiples of 64; block_size > 0/even. */
+HIP_KERNEL_API int hip_qmoe_grouped_prefill_wmma(
+    void* stream,
+    const void* input,
+    const void* sorted_token_ids,
+    const void* sorted_weights,
+    const void* expert_offsets,
+    const void* active_eids, int num_active, int max_count,
+    const void* fc1_weights, const void* fc1_scales,
+    const void* fc1_zero_points, const void* fc1_bias,
+    const void* fc2_weights, const void* fc2_scales,
+    const void* fc2_zero_points, const void* fc2_bias,
+    void* act_out,
+    void* accum_f32,
+    void* output,
+    int64_t num_tokens, int64_t hidden_size, int64_t inter_size,
+    int64_t k, int64_t num_experts, int64_t block_size,
+    float swiglu_alpha, float swiglu_beta, float swiglu_limit,
+    int64_t element_size_bytes);
+
+/* Single grouped int4 WMMA GEMM over all active experts (one launch).
+ * Implemented in matmul_nbits_kernel.hip; used by hip_qmoe_grouped_prefill_wmma
+ * for FC1 (epilogue=0, plain store to C_all) and FC2 (epilogue=1, weighted
+ * atomic scatter-add into accum_f32). Tile fixed 64x64; N%64==0, K%16==0. */
+HIP_KERNEL_API int hip_qmoe_wmma_gemm_grouped(
+    void* stream,
+    const void* A_all,
+    const void* expert_offsets,
+    const void* active_eids, int num_active, int max_count,
+    const void* B_base, const void* S_base, const void* Z_base,
+    const void* bias_base,
+    int N, int K, int num_groups_k, int group_size,
+    int epilogue,
+    void* C_all,
+    const void* scatter_ids, const void* scatter_wts,
+    void* accum_f32, int accum_ldc,
+    const void* gather_input, const void* gather_ids,
+    float sw_alpha, float sw_beta, float sw_limit);
+
 /* =========================================================================
  * Linear Attention Decode (Single-Token Recurrence, Prefill-Friendly)
  * =========================================================================

--- a/lib/Runtime/debug_log.h
+++ b/lib/Runtime/debug_log.h
@@ -30,6 +30,78 @@ inline bool hipdnn_ep_matmul_dp4a_enabled() {
   return enabled;
 }
 
+// Minimum expert count for the grouped WMMA MoE prefill to be worthwhile.
+// Grouped amortizes one launch across all experts; it only beats the per-expert
+// host loop when there are many experts with small per-expert GEMMs. Measured:
+// gpt-oss-20b (32 experts) is ~18% faster on the host loop at P128 and P2048,
+// so few-expert models fall back. Default 64 sits between gpt-oss (32) and the
+// many-expert models (120b=128, A3B=256). CI-tunable via
+// HIPDNN_EP_QMOE_GROUPED_MIN_EXPERTS to sweep the crossover.
+inline int hipdnn_ep_qmoe_grouped_min_experts() {
+  static const int v =
+      hipdnn_ep::env_int("HIPDNN_EP_QMOE_GROUPED_MIN_EXPERTS", 64);
+  return v;
+}
+
+// Fill-aware post-bucket gate for grouped WMMA MoE prefill.
+//
+// The num_experts gate above is a poor predictor: grouped WMMA only wins when
+// each active expert fills its 64-row GEMM tile. gpt-oss-120b has 128 experts
+// (passes the count gate) but with k=4 routing its per-expert fill is ~7.6 rows
+// (P128) so the 64-row tile is mostly padding and the launch is gated by the
+// heaviest expert (tail) -> +13-37% TTFT regression. Qwen3.6-35B-A3B (256
+// experts, k=8) fills the tile well and wins. The separating signal is the
+// actual per-expert row distribution (h_counts), known only after bucketing.
+//
+// Decision (all must hold, else fall back to the host loop = pre-existing main
+// behavior, so there is no regression vs main):
+//   num_active >= MIN_ACTIVE  AND  dense_row_fraction >= MIN_DENSE_FRAC
+// where an expert is "dense" if its routed row count >= TILE_ROWS, and
+//   dense_row_fraction = (rows in dense experts) / (num_tokens * k).
+
+// Per-expert row count at/above which an expert fills the WMMA GEMM tile.
+inline int hipdnn_ep_qmoe_grouped_tile_rows() {
+  static const int v =
+      hipdnn_ep::env_int("HIPDNN_EP_QMOE_GROUPED_TILE_ROWS", 64);
+  return v;
+}
+
+// Minimum number of active experts for grouped's single-launch amortization to
+// beat the host loop. Few-expert models (gpt-oss-20b, <=32 active) issue few,
+// large, efficient per-expert GEMMs and lose with grouped even when dense.
+inline int hipdnn_ep_qmoe_grouped_min_active() {
+  static const int v =
+      hipdnn_ep::env_int("HIPDNN_EP_QMOE_GROUPED_MIN_ACTIVE", 64);
+  return v;
+}
+
+// Minimum fraction (percent, 0-100) of routed rows that must land in dense
+// experts for grouped WMMA to be selected. Conservative default: when in doubt,
+// use the host loop. Percent (not float) to reuse the int env parser.
+inline int hipdnn_ep_qmoe_grouped_min_dense_pct() {
+  static const int v =
+      hipdnn_ep::env_int("HIPDNN_EP_QMOE_GROUPED_MIN_DENSE_PCT", 70);
+  return v;
+}
+
+// Minimum prefill length (num_tokens) for grouped WMMA MoE prefill to be
+// selected. The dense-fraction gate above is scale-free (a ratio), so it admits
+// grouped for layers whose *shape* fills the tile even when the *total* prefill
+// is too small to amortize grouped's per-expert launch overhead. Measured on
+// Qwen3.6-35B-A3B (VLM image+text prefill), grouped vs host-loop TTFT:
+//   1842 tok: +4.7%   1949 tok: +5.9%   (grouped LOSES)   <- default vlm CSV pt
+//   2224 tok: -3.3%   2540 tok: -5.7%   3227 tok: -4.8%   3952 tok: -18.9%
+// i.e. a clean crossover at ~2.0-2.1k tokens. Below it, fall back to the host
+// loop (= pre-existing main behavior, so no regression vs main); above it keep
+// grouped and its large long-context win. Default 2048 sits in the
+// verified-safe window (1949, 2224]. CI-tunable via
+// HIPDNN_EP_QMOE_GROUPED_MIN_TOKENS.
+inline int hipdnn_ep_qmoe_grouped_min_tokens() {
+  static const int v =
+      hipdnn_ep::env_int("HIPDNN_EP_QMOE_GROUPED_MIN_TOKENS", 2048);
+  return v;
+}
+
 inline bool hipdnn_ep_perf_enabled() {
   // PERF intentionally does NOT inherit from HIPDNN_EP_DEBUG: enabling PERF
   // forces a hipStreamSynchronize on every inference (so hipEventElapsedTime

--- a/lib/Runtime/real/qmoe.cpp
+++ b/lib/Runtime/real/qmoe.cpp
@@ -111,15 +111,34 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
   int64_t k_blocks_fc2 = (inter_size + block_size - 1) / block_size;
   int64_t blob_size_fc2 = block_size / 2;
 
-  // The grouped-vs-host-loop prefill decision is made AFTER bucket_tokens (it
-  // depends on the actual per-expert row distribution, not on num_experts), so
-  // the scratch pool must reserve BOTH prefill paths' buffers up front. The
-  // grouped adds (pf_act/pf_accum/active_eids) are tens of MB on top of the
-  // host-loop buffers, so the peak stays ~= the host-loop footprint (which is
-  // the pre-existing `main` behavior -> no memory regression). Decode buffers
-  // stay gated on is_decode. See the post-bucket gate near the dispatch below.
+  // The grouped-vs-host-loop prefill decision has two parts: a shape/scale test
+  // knowable up front (grouped_shape_ok && grouped_scale_ok) and a fill test
+  // that needs the post-bucket per-expert row distribution (fill_ok). Only the
+  // grouped path uses pf_act/pf_accum/active_eids, so we reserve those buffers
+  // ONLY when grouped could actually run (the pre-bucket predicate below).
+  // Below the token threshold (short prompts, VLM image prefills) and for
+  // non-WMMA shapes the grouped-only scratch is skipped entirely, so the pool
+  // high-water matches the host-loop/main footprint and -- since the pool never
+  // shrinks -- is not carried into the decode phase. This is realloc-safe: the
+  // predicate is computed before bucket_tokens writes into the pool, so the
+  // size is final before the single ensure() below (growing after bucketing
+  // would realloc and drop the bucketed data). If the shape/scale test passes
+  // but fill_ok later fails, pf_* stay reserved-but-unused (rare: tokens >=
+  // threshold yet experts don't fill the WMMA tile). Decode buffers stay gated
+  // on is_decode.
   const bool is_decode = (num_tokens == 1);
   const bool is_prefill = !is_decode;
+  // Pre-bucket portion of the grouped-WMMA prefill gate (see the post-bucket
+  // gate near the dispatch for fill_ok). Kept as the single source of truth for
+  // both the scratch reservation here and the dispatch decision below.
+  const bool grouped_shape_ok =
+      elem_size == 2 && expert_weight_bits == 4 && block_size > 0 &&
+      (hidden_size % 64 == 0) && (inter_size % 64 == 0) &&
+      (num_experts >= hipdnn_ep_qmoe_grouped_min_experts());
+  const bool grouped_scale_ok =
+      num_tokens >= hipdnn_ep_qmoe_grouped_min_tokens();
+  const bool grouped_possible =
+      is_prefill && grouped_shape_ok && grouped_scale_ok;
 
   // Per-state grow-on-demand scratch in place of 8 hipMalloc/8 hipFree per
   // call. Sub-buffers are 64-byte aligned (matches GPU pool alignment, gives
@@ -198,14 +217,15 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
   // intermediates are gone.
   int64_t pf_pairs = num_tokens * k;
   size_t sz_pf_act =
-      is_prefill ? align_up_64(pf_pairs * inter_size * elem_size) : 0;
+      grouped_possible ? align_up_64(pf_pairs * inter_size * elem_size) : 0;
   size_t sz_pf_accum =
-      is_prefill ? align_up_64(num_tokens * hidden_size * sizeof(float)) : 0;
+      grouped_possible ? align_up_64(num_tokens * hidden_size * sizeof(float))
+                       : 0;
   // FC1 gathers its rows straight from `input` and applies SwiGLU in-kernel,
   // writing act_out (pf_act) directly, so neither the [P, hidden] a_all nor the
   // [P, 2*inter] fc1_out buffer is materialized any more.
   size_t sz_active_eids =
-      is_prefill ? align_up_64(num_experts * sizeof(int32_t)) : 0;
+      grouped_possible ? align_up_64(num_experts * sizeof(int32_t)) : 0;
   size_t off_pf_act = off_a_scale_mid + sz_a_scale_mid;
   size_t off_pf_accum = off_pf_act + sz_pf_act;
   size_t off_active_eids = off_pf_accum + sz_pf_accum;
@@ -373,22 +393,23 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
     const int64_t total_rows = num_tokens * k; // routed (token,expert) pairs
     const int dense_pct =
         total_rows > 0 ? static_cast<int>((dense_rows * 100) / total_rows) : 0;
-    // Shape must be WMMA-serviceable (fp16 int4, hidden/inter multiples of the
-    // 64-row tile). num_experts >= MIN_EXPERTS is retained as a hard
-    // override/off-switch (set it very high to force the host loop for A/B).
-    const bool shape_ok = elem_size == 2 && expert_weight_bits == 4 &&
-                          block_size > 0 && (hidden_size % 64 == 0) &&
-                          (inter_size % 64 == 0) &&
-                          (num_experts >= hipdnn_ep_qmoe_grouped_min_experts());
+    // Shape/scale portion of the gate was computed up front (grouped_shape_ok,
+    // grouped_scale_ok) as the single source of truth used to size the
+    // grouped-only scratch (pf_*). Only the fill test needs h_counts. Reusing
+    // the pre-bucket predicates guarantees the scratch reservation and the
+    // dispatch decision can never disagree (pf_* are always sized when this can
+    // pick grouped). num_experts >= MIN_EXPERTS (inside grouped_shape_ok) is
+    // retained as a hard override/off-switch (set it very high to force the
+    // host loop for A/B).
     const bool fill_ok = num_active >= hipdnn_ep_qmoe_grouped_min_active() &&
                          dense_pct >= hipdnn_ep_qmoe_grouped_min_dense_pct();
-    // Absolute work-scale gate: the dense-fraction test above is scale-free, so
-    // it admits grouped on short prefills (e.g. VLM image prefill ~1.8k tokens)
-    // where grouped's per-expert launch overhead is not amortized and it loses
-    // to the host loop (+5-6% TTFT) with high run-to-run variance. Require a
-    // minimum prefill length; below it, fall back to the host loop (= main).
-    const bool scale_ok = num_tokens >= hipdnn_ep_qmoe_grouped_min_tokens();
-    const bool use_grouped_prefill = shape_ok && fill_ok && scale_ok;
+    // grouped_scale_ok (num_tokens >= MIN_TOKENS) is the absolute work-scale
+    // gate: the dense-fraction test is scale-free, so it would otherwise admit
+    // grouped on short prefills (e.g. VLM image prefill ~1.8k tokens) where the
+    // per-expert launch overhead is not amortized and grouped loses to the host
+    // loop; below the threshold we fall back to the host loop (= main).
+    const bool use_grouped_prefill =
+        grouped_shape_ok && grouped_scale_ok && fill_ok;
     RUNTIME_DEBUG_LOG(
         "[REAL] wrap_qmoe: prefill gate active=%d/%lld max_count=%d "
         "dense_pct=%d num_tokens=%lld (min_active=%d min_dense_pct=%d "

--- a/lib/Runtime/real/qmoe.cpp
+++ b/lib/Runtime/real/qmoe.cpp
@@ -12,6 +12,7 @@
 
 #include <algorithm>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <utility>
 #include <vector>
@@ -110,41 +111,69 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
   int64_t k_blocks_fc2 = (inter_size + block_size - 1) / block_size;
   int64_t blob_size_fc2 = block_size / 2;
 
+  // The grouped-vs-host-loop prefill decision is made AFTER bucket_tokens (it
+  // depends on the actual per-expert row distribution, not on num_experts), so
+  // the scratch pool must reserve BOTH prefill paths' buffers up front. The
+  // grouped adds (pf_act/pf_accum/active_eids) are tens of MB on top of the
+  // host-loop buffers, so the peak stays ~= the host-loop footprint (which is
+  // the pre-existing `main` behavior -> no memory regression). Decode buffers
+  // stay gated on is_decode. See the post-bucket gate near the dispatch below.
+  const bool is_decode = (num_tokens == 1);
+  const bool is_prefill = !is_decode;
+
   // Per-state grow-on-demand scratch in place of 8 hipMalloc/8 hipFree per
   // call. Sub-buffers are 64-byte aligned (matches GPU pool alignment, gives
   // each sub-buffer its own cache line). The buffer grows when num_tokens /
   // sizes exceed the cached capacity, never shrinks; freed in state cleanup.
+  // Buffers a path doesn't touch are sized 0 (their offset collapses onto the
+  // next buffer; the inactive-path pointers below are simply never
+  // dereferenced).
   auto align_up_64 = [](size_t s) -> size_t { return (s + 63) & ~size_t(63); };
+  // Routing outputs (topk_routing) are used by every path.
   size_t sz_expert_indices = align_up_64(num_tokens * k * sizeof(int32_t));
   size_t sz_expert_weights = align_up_64(num_tokens * k * elem_size);
-  size_t sz_gather_buf = align_up_64(num_tokens * hidden_size * elem_size);
-  size_t sz_fc1_buf = align_up_64(num_tokens * fusion_inter * elem_size);
+  // Host-loop fallback per-expert FFN buffers (sized to num_tokens, reused
+  // across experts). Reserved for every prefill because the host-loop path may
+  // be selected post-bucket; only the host-loop path dereferences them.
+  size_t sz_gather_buf =
+      is_prefill ? align_up_64(num_tokens * hidden_size * elem_size) : 0;
+  size_t sz_fc1_buf =
+      is_prefill ? align_up_64(num_tokens * fusion_inter * elem_size) : 0;
   // Fused decode (num_tokens == 1) reuses act_buf and fc2_buf as the [k,
   // inter] activation slots and [k, hidden] per-expert output slots needed
   // by hip_qmoe_decode_fused (gather/scatter happen inline inside the
-  // kernel, indexed by expert_indices). For num_tokens > 1 the multi-pass
+  // kernel, indexed by expert_indices). For num_tokens > 1 the host-loop
   // path uses [num_tokens, ...] sizing. Take the max so the per-state
-  // scratch is never under-sized regardless of which path runs.
+  // scratch is never under-sized regardless of which of those two paths runs.
+  // Always reserved: decode needs them, and the host-loop prefill path (which
+  // may be selected post-bucket) needs them too. The grouped-WMMA prefill path
+  // uses none of these (it has its own pf_*).
   int64_t act_slots = std::max<int64_t>(num_tokens, k);
   size_t sz_act_buf = align_up_64(act_slots * inter_size * elem_size);
   size_t sz_fc2_buf = align_up_64(act_slots * hidden_size * elem_size);
   // bucket_tokens outputs (Phase 2): per-expert counts + exclusive prefix sum
   // offsets, plus tokens/weights re-grouped on-device into per-expert
-  // contiguous slices. Replaces the old per-expert host h_ids/h_wts_e build +
-  // H2D round-trip (2 hipMemcpyAsync per active expert per layer).
-  size_t sz_expert_counts = align_up_64(num_experts * sizeof(int32_t));
-  size_t sz_expert_offsets = align_up_64((num_experts + 1) * sizeof(int32_t));
-  size_t sz_sorted_token_ids = align_up_64(num_tokens * k * sizeof(int32_t));
-  size_t sz_sorted_weights = align_up_64(num_tokens * k * elem_size);
+  // contiguous slices. Used by both prefill paths (grouped + host-loop), not
+  // by decode.
+  size_t sz_expert_counts =
+      is_decode ? 0 : align_up_64(num_experts * sizeof(int32_t));
+  size_t sz_expert_offsets =
+      is_decode ? 0 : align_up_64((num_experts + 1) * sizeof(int32_t));
+  size_t sz_sorted_token_ids =
+      is_decode ? 0 : align_up_64(num_tokens * k * sizeof(int32_t));
+  size_t sz_sorted_weights =
+      is_decode ? 0 : align_up_64(num_tokens * k * elem_size);
   // dp4a decode scratch (fused decode only, env-gated): int8-quantized
   // activations + per-group fp32 scales for the fc1 input ([hidden]) and the
-  // fc2 slot activations ([k, inter]). Sized unconditionally (a few KB) so the
-  // offset layout is identical whether or not dp4a runs; the fp path ignores
-  // them. k_blocks_fc1 == n_blk_in, k_blocks_fc2 == n_blk_mid.
-  size_t sz_a_qb_in = align_up_64(hidden_size * sizeof(int8_t));
-  size_t sz_a_scale_in = align_up_64(k_blocks_fc1 * sizeof(float));
-  size_t sz_a_qb_mid = align_up_64(k * inter_size * sizeof(int8_t));
-  size_t sz_a_scale_mid = align_up_64(k * k_blocks_fc2 * sizeof(float));
+  // fc2 slot activations ([k, inter]). Decode path only.
+  // k_blocks_fc1 == n_blk_in, k_blocks_fc2 == n_blk_mid.
+  size_t sz_a_qb_in = is_decode ? align_up_64(hidden_size * sizeof(int8_t)) : 0;
+  size_t sz_a_scale_in =
+      is_decode ? align_up_64(k_blocks_fc1 * sizeof(float)) : 0;
+  size_t sz_a_qb_mid =
+      is_decode ? align_up_64(k * inter_size * sizeof(int8_t)) : 0;
+  size_t sz_a_scale_mid =
+      is_decode ? align_up_64(k * k_blocks_fc2 * sizeof(float)) : 0;
 
   size_t off_expert_indices = 0;
   size_t off_expert_weights = off_expert_indices + sz_expert_indices;
@@ -160,7 +189,27 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
   size_t off_a_scale_in = off_a_qb_in + sz_a_qb_in;
   size_t off_a_qb_mid = off_a_scale_in + sz_a_scale_in;
   size_t off_a_scale_mid = off_a_qb_mid + sz_a_qb_mid;
-  size_t total_scratch = off_a_scale_mid + sz_a_scale_mid;
+  // Grouped-WMMA prefill scratch (num_tokens > 1 default path). P =
+  // num_tokens*k pairs. FC1 fuses gather + SwiGLU into the WMMA kernel and
+  // writes act_out directly, and FC2 scatter-adds into an fp32 accumulator, so
+  // the path only needs: [P, inter] SwiGLU activations (pf_act), the fp32
+  // [num_tokens, hidden] accumulator (pf_accum), and the active-expert id list
+  // (active_eids). The old a_all [P, hidden] and fc1_out [P, 2*inter]
+  // intermediates are gone.
+  int64_t pf_pairs = num_tokens * k;
+  size_t sz_pf_act =
+      is_prefill ? align_up_64(pf_pairs * inter_size * elem_size) : 0;
+  size_t sz_pf_accum =
+      is_prefill ? align_up_64(num_tokens * hidden_size * sizeof(float)) : 0;
+  // FC1 gathers its rows straight from `input` and applies SwiGLU in-kernel,
+  // writing act_out (pf_act) directly, so neither the [P, hidden] a_all nor the
+  // [P, 2*inter] fc1_out buffer is materialized any more.
+  size_t sz_active_eids =
+      is_prefill ? align_up_64(num_experts * sizeof(int32_t)) : 0;
+  size_t off_pf_act = off_a_scale_mid + sz_a_scale_mid;
+  size_t off_pf_accum = off_pf_act + sz_pf_act;
+  size_t off_active_eids = off_pf_accum + sz_pf_accum;
+  size_t total_scratch = off_active_eids + sz_active_eids;
 
   if (hipdnn_ep_state_ensure_qmoe_scratch(state, total_scratch) != 0) {
     fprintf(stderr, "wrap_qmoe: ensure_qmoe_scratch(%zu) failed\n",
@@ -186,6 +235,10 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
   void *d_a_scale_in = scratch_base + off_a_scale_in;
   void *d_a_qb_mid = scratch_base + off_a_qb_mid;
   void *d_a_scale_mid = scratch_base + off_a_scale_mid;
+  void *d_pf_act = scratch_base + off_pf_act;
+  void *d_pf_accum = scratch_base + off_pf_accum;
+  int32_t *d_active_eids =
+      reinterpret_cast<int32_t *>(scratch_base + off_active_eids);
 
   RUNTIME_DEBUG_LOG("[REAL] wrap_qmoe: topk_routing(tokens=%lld, experts=%lld, "
                     "k=%lld, normalize=%lld)\n",
@@ -250,7 +303,10 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
       return (s + 63) & ~size_t(63);
     };
     size_t hsz_counts = align_up_64h(num_experts * sizeof(int32_t));
-    size_t total_host = hsz_counts;
+    // Grouped-WMMA path builds an active-expert id list on the host from the
+    // D2H'd counts; reserve space for it alongside h_counts.
+    size_t hsz_active = align_up_64h(num_experts * sizeof(int32_t));
+    size_t total_host = hsz_counts + hsz_active;
 
     if (hipdnn_ep_state_ensure_qmoe_host_scratch(state, total_host) != 0) {
       fprintf(stderr, "wrap_qmoe: ensure_qmoe_host_scratch(%zu) failed\n",
@@ -260,6 +316,7 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
     char *host_base =
         static_cast<char *>(hipdnn_ep_state_get_qmoe_host_scratch(state));
     int32_t *h_counts = reinterpret_cast<int32_t *>(host_base);
+    int32_t *h_active = reinterpret_cast<int32_t *>(host_base + hsz_counts);
 
     // Bucket tokens on the device: count per expert (atomicAdd), exclusive
     // prefix sum into d_expert_offsets, scatter (token_id, weight) pairs
@@ -287,14 +344,88 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
     HIP_CHECK(hipMemsetAsync(output, 0, num_tokens * hidden_size * elem_size,
                              hip_stream));
 
-    int64_t active_experts = 0;
+    // Post-bucket fill-aware gate: choose grouped WMMA prefill vs the host loop
+    // from the ACTUAL per-expert row distribution (h_counts), not from
+    // num_experts (which mis-predicts: gpt-oss-120b has 128 experts but ~7.6
+    // rows/expert, so the 64-row WMMA tile is mostly padding and grouped
+    // regresses; Qwen3.6-35B-A3B fills the tile and wins). See debug_log.h.
+    // One pass over h_counts computes: num_active (for launch amortization),
+    // max_count (grouped launch is sized to the heaviest expert), and
+    // dense_rows (routed rows in experts that fill the tile). Grouped is chosen
+    // only when the shape is WMMA-serviceable, there are enough active experts,
+    // and most routed rows land in dense experts; otherwise the host loop runs
+    // (this is the pre-existing `main` behavior, so there is no regression vs
+    // main).
+    const int tile_rows = hipdnn_ep_qmoe_grouped_tile_rows();
+    int num_active = 0;
+    int max_count = 0;
+    int64_t dense_rows = 0;
     for (int64_t e = 0; e < num_experts; e++) {
-      if (h_counts[e] > 0) {
-        active_experts++;
+      int c = h_counts[e];
+      if (c > 0) {
+        num_active++;
+        if (c > max_count)
+          max_count = c;
+        if (c >= tile_rows)
+          dense_rows += c;
       }
     }
-    RUNTIME_DEBUG_LOG("[REAL] wrap_qmoe: %lld/%lld experts active\n",
-                      (long long)active_experts, (long long)num_experts);
+    const int64_t total_rows = num_tokens * k; // routed (token,expert) pairs
+    const int dense_pct =
+        total_rows > 0 ? static_cast<int>((dense_rows * 100) / total_rows) : 0;
+    // Shape must be WMMA-serviceable (fp16 int4, hidden/inter multiples of the
+    // 64-row tile). num_experts >= MIN_EXPERTS is retained as a hard
+    // override/off-switch (set it very high to force the host loop for A/B).
+    const bool shape_ok = elem_size == 2 && expert_weight_bits == 4 &&
+                          block_size > 0 && (hidden_size % 64 == 0) &&
+                          (inter_size % 64 == 0) &&
+                          (num_experts >= hipdnn_ep_qmoe_grouped_min_experts());
+    const bool fill_ok = num_active >= hipdnn_ep_qmoe_grouped_min_active() &&
+                         dense_pct >= hipdnn_ep_qmoe_grouped_min_dense_pct();
+    // Absolute work-scale gate: the dense-fraction test above is scale-free, so
+    // it admits grouped on short prefills (e.g. VLM image prefill ~1.8k tokens)
+    // where grouped's per-expert launch overhead is not amortized and it loses
+    // to the host loop (+5-6% TTFT) with high run-to-run variance. Require a
+    // minimum prefill length; below it, fall back to the host loop (= main).
+    const bool scale_ok = num_tokens >= hipdnn_ep_qmoe_grouped_min_tokens();
+    const bool use_grouped_prefill = shape_ok && fill_ok && scale_ok;
+    RUNTIME_DEBUG_LOG(
+        "[REAL] wrap_qmoe: prefill gate active=%d/%lld max_count=%d "
+        "dense_pct=%d num_tokens=%lld (min_active=%d min_dense_pct=%d "
+        "min_tokens=%d) -> %s\n",
+        num_active, (long long)num_experts, max_count, dense_pct,
+        (long long)num_tokens, hipdnn_ep_qmoe_grouped_min_active(),
+        hipdnn_ep_qmoe_grouped_min_dense_pct(),
+        hipdnn_ep_qmoe_grouped_min_tokens(),
+        use_grouped_prefill ? "grouped WMMA" : "host loop");
+    if (use_grouped_prefill) {
+      // Build the active-expert id list (grouped launches one block group per
+      // active expert, blockIdx.z = expert).
+      int na = 0;
+      for (int64_t e = 0; e < num_experts; e++) {
+        if (h_counts[e] > 0)
+          h_active[na++] = static_cast<int32_t>(e);
+      }
+      if (na > 0) {
+        HIP_CHECK(hipMemcpyAsync(d_active_eids, h_active, na * sizeof(int32_t),
+                                 hipMemcpyHostToDevice, hip_stream));
+      }
+      RUNTIME_DEBUG_LOG("[REAL] wrap_qmoe: grouped WMMA prefill "
+                        "(active=%d, max_count=%d)\n",
+                        na, max_count);
+      int rc = hip_qmoe_grouped_prefill_wmma(
+          stream, input, d_sorted_token_ids, d_sorted_weights, d_expert_offsets,
+          d_active_eids, na, max_count, fc1_weights, fc1_scales,
+          fc1_zero_points, fc1_bias, fc2_weights, fc2_scales, fc2_zero_points,
+          fc2_bias, d_pf_act, d_pf_accum, output, num_tokens, hidden_size,
+          inter_size, k, num_experts, block_size, activation_alpha,
+          activation_beta, swiglu_limit, elem_size);
+      if (rc != 0) {
+        fprintf(stderr, "wrap_qmoe: grouped WMMA prefill failed (%d)\n", rc);
+        result = -1;
+      }
+      goto cleanup;
+    }
 
     // Per-session pointer-keyed zero_points unpack cache (qmoe-owned, lives on
     // RuntimeState). Each expert's fc1/fc2 zp is a distinct pointer into the


### PR DESCRIPTION
## What

Adds a single-launch **grouped Matrix-Core (WMMA) int4 GEMM** fast path for the quantized MoE (`qmoe`) prefill, replacing the host per-expert loop, and makes the associated scratch reservation conditional so it doesn't inflate the memory-pool high-water mark.

## Why

The previous prefill ran a **host per-expert loop** — roughly `5 x active_experts` dispatches plus a D2H copy / sync per MoE layer. That serializes launches and stalls on host round-trips, dominating prefill GPU time on high-activation models.

## Changes

- **Grouped WMMA int4 MoE prefill (default-on).** Each FC now runs one grouped int4 GEMM over all active experts (`blockIdx.z = expert`), reusing the tuned double-buffered int4 pipeline (~6 launches/layer instead of ~5x per-expert dispatches + D2H/sync). A fill-aware post-bucket gate keeps tiny prefills on the host-loop path via a minimum-token threshold. No env vars required.
- **Conditional grouped scratch reservation.** The grouped-only scratch (`pf_act` / `pf_accum` / `active_eids`) was previously reserved for *every* prefill (including sub-threshold and VLM image prefills that always take the host loop); since the per-state pool never shrinks, that unused reservation also leaked into the decode phase. The reservation is now gated on the pre-bucket portion of the grouped gate (`grouped_shape_ok && grouped_scale_ok`), known before `bucket_tokens` writes into the pool (realloc-safe). Below the token threshold / for non-WMMA shapes the grouped scratch is skipped, so the pool high-water matches the host-loop footprint. The same predicates are reused at the post-bucket dispatch so the reservation and the grouped decision can never disagree.

## Results / validation

- Grouped path still engages above the token threshold (>2048 tokens) on Qwen3.6-35B-A3B (dense_pct 91–93).
- Memory-pool high-water for sub-threshold / VLM image prefills and decode no longer carries the unused grouped scratch.

## Scope

int4 quantized MoE prefill only; decode and non-WMMA/sub-threshold shapes retain the existing host-loop path.
