### PR TITLE
feat(hipsr): add hipsr.empty/hipsr.empty_yield ops

### DIFF
--- a/include/hip/Dialect/Hipsr/IR/CMakeLists.txt
+++ b/include/hip/Dialect/Hipsr/IR/CMakeLists.txt
@@ -35,6 +35,14 @@ set(LLVM_TARGET_DEFINITIONS HipsrPoolDomainOp.td)
 mlir_tablegen(HipsrPoolDomainOp.h.inc -gen-op-decls)
 mlir_tablegen(HipsrPoolDomainOp.cpp.inc -gen-op-defs)
 
+set(LLVM_TARGET_DEFINITIONS HipsrEmptyYieldOp.td)
+mlir_tablegen(HipsrEmptyYieldOp.h.inc -gen-op-decls)
+mlir_tablegen(HipsrEmptyYieldOp.cpp.inc -gen-op-defs)
+
+set(LLVM_TARGET_DEFINITIONS HipsrEmptyOp.td)
+mlir_tablegen(HipsrEmptyOp.h.inc -gen-op-decls)
+mlir_tablegen(HipsrEmptyOp.cpp.inc -gen-op-defs)
+
 set(LLVM_TARGET_DEFINITIONS HipsrConstantOp.td)
 mlir_tablegen(HipsrConstantOp.h.inc -gen-op-decls)
 mlir_tablegen(HipsrConstantOp.cpp.inc -gen-op-defs)

--- a/include/hip/Dialect/Hipsr/IR/HipsrEmptyOp.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrEmptyOp.h
@@ -14,9 +14,6 @@
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
-// The .inc references EmptyYieldOp (from the implicit-terminator trait) only by
-// name, so a forward declaration is enough. The full type is needed only in the
-// .cpp, which includes its header.
 namespace mlir {
 namespace hipsr {
 class EmptyYieldOp;

--- a/include/hip/Dialect/Hipsr/IR/HipsrEmptyOp.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrEmptyOp.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#ifndef HIPSR_EMPTY_OP_H
+#define HIPSR_EMPTY_OP_H
+
+#include "hip/Dialect/Hipsr/IR/HipsrDialect.h"
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+
+// The .inc references EmptyYieldOp (from the implicit-terminator trait) only by
+// name, so a forward declaration is enough. The full type is needed only in the
+// .cpp, which includes its header.
+namespace mlir {
+namespace hipsr {
+class EmptyYieldOp;
+} // namespace hipsr
+} // namespace mlir
+
+#define GET_OP_CLASSES
+#include "hip/Dialect/Hipsr/IR/HipsrEmptyOp.h.inc"
+
+#endif // HIPSR_EMPTY_OP_H

--- a/include/hip/Dialect/Hipsr/IR/HipsrEmptyOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrEmptyOp.td
@@ -9,6 +9,7 @@
 #ifndef HIPSR_EMPTY_OP
 #define HIPSR_EMPTY_OP
 
+include "mlir/Interfaces/SideEffectInterfaces.td"
 include "hip/Dialect/Hipsr/IR/HipsrOps.td"
 
 //===----------------------------------------------------------------------===//
@@ -16,7 +17,7 @@ include "hip/Dialect/Hipsr/IR/HipsrOps.td"
 //===----------------------------------------------------------------------===//
 
 def Hipsr_EmptyOp : Hipsr_Op<"empty",
-    [SingleBlockImplicitTerminator<"EmptyYieldOp">]> {
+    [Pure, SingleBlockImplicitTerminator<"EmptyYieldOp">]> {
   let summary = "Create init tensor(s) with shape computation in a region";
   let description = [{
     Creates an init tensor for destination-passing style operations.

--- a/include/hip/Dialect/Hipsr/IR/HipsrEmptyOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrEmptyOp.td
@@ -19,16 +19,13 @@ def Hipsr_EmptyOp : Hipsr_Op<"empty",
     [SingleBlockImplicitTerminator<"EmptyYieldOp">]> {
   let summary = "Create init tensor(s) with shape computation in a region";
   let description = [{
-    Produces the `outs` init tensor(s) for a DPS op. The attached region
-    computes each result's shape (typically `shape.shape_of` + `shape.get_extent`
-    for a regular op, or `hipsr.readback_scalar` for a data-dependent one),
-    builds a `tensor.empty()` per result, and yields them via `hipsr.empty_yield`.
+    Creates an init tensor for destination-passing style operations.
+    Shape computation is encapsulated in the attached region, which executes
+    to produce the init tensor.
 
-    Unlike pool_domain / DPS compute ops, the region is NOT isolated: it may read
-    parent-scope values (e.g. `shape.shape_of %input`, where %input is a domain
-    operand). It is variadic so one hipsr.empty can back a multi-output DPS op.
-
-    Bufferizes to one `memref.alloc()` per yielded tensor.
+    The region contains operations that compute the tensor shape (dimensions
+    and element type), then creates a tensor.empty() with those dimensions,
+    and yields it via hipsr.empty_yield.
 
     Example:
     ```mlir

--- a/include/hip/Dialect/Hipsr/IR/HipsrEmptyOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrEmptyOp.td
@@ -58,9 +58,11 @@ def Hipsr_EmptyOp : Hipsr_Op<"empty",
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
-    /// Runtime dim SSA values per result: [[dims for result 0], ...]. Region
-    /// must be populated.
-    ::llvm::SmallVector<::llvm::SmallVector<::mlir::Value>> getShapes();
+    /// Mixed static/dynamic sizes per result, preserving dimension position:
+    /// [[sizes for result 0], ...]. Each entry is an Attribute (static extent)
+    /// or a Value (runtime extent), mirroring tensor::EmptyOp::getMixedSizes().
+    ::llvm::SmallVector<::llvm::SmallVector<::mlir::OpFoldResult>>
+    getMixedSizes();
 
     ::llvm::SmallVector<::mlir::RankedTensorType> getTensorTypes();
   }];

--- a/include/hip/Dialect/Hipsr/IR/HipsrEmptyOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrEmptyOp.td
@@ -15,9 +15,6 @@ include "hip/Dialect/Hipsr/IR/HipsrOps.td"
 // Hipsr_EmptyOp
 //===----------------------------------------------------------------------===//
 
-// Each hipsr.empty is a fresh init-tensor allocation (like
-// bufferization.alloc_tensor), so it is not memory-effect-free: distinct ops
-// yield distinct buffers even when their shapes match.
 def Hipsr_EmptyOp : Hipsr_Op<"empty",
     [SingleBlockImplicitTerminator<"EmptyYieldOp">]> {
   let summary = "Create init tensor(s) with shape computation in a region";
@@ -49,17 +46,15 @@ def Hipsr_EmptyOp : Hipsr_Op<"empty",
   let results = (outs Variadic<AnyRankedTensor>:$results);
   let regions = (region SizedRegion<1>:$region);
 
-  // Result types after `:`, then the region. Matches the pool_domain layout.
   let assemblyFormat = "`(` `)` attr-dict `:` type($results) $region";
 
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
-    /// Runtime dim SSA values per result: [[dims for result 0], ...].
-    /// Reads each yielded tensor.empty's dynamic sizes. Region must be populated.
+    /// Runtime dim SSA values per result: [[dims for result 0], ...]. Region
+    /// must be populated.
     ::llvm::SmallVector<::llvm::SmallVector<::mlir::Value>> getShapes();
 
-    /// Compile-time tensor types of all results.
     ::llvm::SmallVector<::mlir::RankedTensorType> getTensorTypes();
   }];
 }

--- a/include/hip/Dialect/Hipsr/IR/HipsrEmptyOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrEmptyOp.td
@@ -20,15 +20,15 @@ def Hipsr_EmptyOp : Hipsr_Op<"empty",
     [Pure, SingleBlockImplicitTerminator<"EmptyYieldOp">]> {
   let summary = "Create init tensor(s) with shape computation in a region";
   let description = [{
-    Creates an init tensor for destination-passing style operations.
-    Shape computation is encapsulated in the attached region, which executes
-    to produce the init tensor.
+    Creates init tensor(s) for destination-passing style operations. Shape
+    computation is encapsulated in the attached region, which executes to
+    produce the init tensor(s).
 
-    The region contains operations that compute the tensor shape (dimensions
-    and element type), then creates a tensor.empty() with those dimensions,
-    and yields it via hipsr.empty_yield.
+    The region contains operations that compute each tensor's shape (dimensions
+    and element type), creates a tensor.empty() per result with those
+    dimensions, and yields them via hipsr.empty_yield.
 
-    Example:
+    Example (single-output):
     ```mlir
     %init = hipsr.empty() : tensor<?x8xf16> {
       %shape = shape.shape_of %input : tensor<?x8xf32> -> tensor<2xindex>
@@ -36,6 +36,15 @@ def Hipsr_EmptyOp : Hipsr_Op<"empty",
       %d0 = shape.get_extent %shape, %c0 : tensor<2xindex>, index -> index
       %t = tensor.empty(%d0) : tensor<?x8xf16>
       hipsr.empty_yield %t : tensor<?x8xf16>
+    }
+    ```
+
+    Example (multi-result):
+    ```mlir
+    %init:2 = hipsr.empty() : tensor<?x?xf16>, tensor<?xi64> {
+      %t0 = tensor.empty(%n, %m) : tensor<?x?xf16>
+      %t1 = tensor.empty(%n) : tensor<?xi64>
+      hipsr.empty_yield %t0, %t1 : tensor<?x?xf16>, tensor<?xi64>
     }
     ```
   }];

--- a/include/hip/Dialect/Hipsr/IR/HipsrEmptyOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrEmptyOp.td
@@ -1,0 +1,67 @@
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+// The hipsr.empty op: an init-tensor carrier whose region computes the output
+// shape. Its terminator, hipsr.empty_yield, lives in HipsrEmptyYieldOp.td.
+//
+
+#ifndef HIPSR_EMPTY_OP
+#define HIPSR_EMPTY_OP
+
+include "hip/Dialect/Hipsr/IR/HipsrOps.td"
+
+//===----------------------------------------------------------------------===//
+// Hipsr_EmptyOp
+//===----------------------------------------------------------------------===//
+
+// Each hipsr.empty is a fresh init-tensor allocation (like
+// bufferization.alloc_tensor), so it is not memory-effect-free: distinct ops
+// yield distinct buffers even when their shapes match.
+def Hipsr_EmptyOp : Hipsr_Op<"empty",
+    [SingleBlockImplicitTerminator<"EmptyYieldOp">]> {
+  let summary = "Create init tensor(s) with shape computation in a region";
+  let description = [{
+    Produces the `outs` init tensor(s) for a DPS op. The attached region
+    computes each result's shape (typically `shape.shape_of` + `shape.get_extent`
+    for a regular op, or `hipsr.readback_scalar` for a data-dependent one),
+    builds a `tensor.empty()` per result, and yields them via `hipsr.empty_yield`.
+
+    Unlike pool_domain / DPS compute ops, the region is NOT isolated: it may read
+    parent-scope values (e.g. `shape.shape_of %input`, where %input is a domain
+    operand). It is variadic so one hipsr.empty can back a multi-output DPS op.
+
+    Bufferizes to one `memref.alloc()` per yielded tensor.
+
+    Example:
+    ```mlir
+    %init = hipsr.empty() : tensor<?x8xf16> {
+      %shape = shape.shape_of %input : tensor<?x8xf32> -> tensor<2xindex>
+      %c0 = arith.constant 0 : index
+      %d0 = shape.get_extent %shape, %c0 : tensor<2xindex>, index -> index
+      %t = tensor.empty(%d0) : tensor<?x8xf16>
+      hipsr.empty_yield %t : tensor<?x8xf16>
+    }
+    ```
+  }];
+
+  let arguments = (ins);
+  let results = (outs Variadic<AnyRankedTensor>:$results);
+  let regions = (region SizedRegion<1>:$region);
+
+  // Result types after `:`, then the region. Matches the pool_domain layout.
+  let assemblyFormat = "`(` `)` attr-dict `:` type($results) $region";
+
+  let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    /// Runtime dim SSA values per result: [[dims for result 0], ...].
+    /// Reads each yielded tensor.empty's dynamic sizes. Region must be populated.
+    ::llvm::SmallVector<::llvm::SmallVector<::mlir::Value>> getShapes();
+
+    /// Compile-time tensor types of all results.
+    ::llvm::SmallVector<::mlir::RankedTensorType> getTensorTypes();
+  }];
+}
+
+#endif // HIPSR_EMPTY_OP

--- a/include/hip/Dialect/Hipsr/IR/HipsrEmptyYieldOp.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrEmptyYieldOp.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#ifndef HIPSR_EMPTY_YIELD_OP_H
+#define HIPSR_EMPTY_YIELD_OP_H
+
+#include "hip/Dialect/Hipsr/IR/HipsrDialect.h"
+
+#include "mlir/Bytecode/BytecodeOpInterface.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+
+// The .inc references EmptyOp (from the HasParent trait) only by name, so a
+// forward declaration is enough. The full type is needed only in the .cpp,
+// which includes its header.
+namespace mlir {
+namespace hipsr {
+class EmptyOp;
+} // namespace hipsr
+} // namespace mlir
+
+#define GET_OP_CLASSES
+#include "hip/Dialect/Hipsr/IR/HipsrEmptyYieldOp.h.inc"
+
+#endif // HIPSR_EMPTY_YIELD_OP_H

--- a/include/hip/Dialect/Hipsr/IR/HipsrEmptyYieldOp.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrEmptyYieldOp.h
@@ -15,9 +15,6 @@
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
-// The .inc references EmptyOp (from the HasParent trait) only by name, so a
-// forward declaration is enough. The full type is needed only in the .cpp,
-// which includes its header.
 namespace mlir {
 namespace hipsr {
 class EmptyOp;

--- a/include/hip/Dialect/Hipsr/IR/HipsrEmptyYieldOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrEmptyYieldOp.td
@@ -1,0 +1,48 @@
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+// The hipsr.empty_yield op: the terminator of a hipsr.empty region. The
+// hipsr.empty op itself lives in HipsrEmptyOp.td.
+//
+
+#ifndef HIPSR_EMPTY_YIELD_OP
+#define HIPSR_EMPTY_YIELD_OP
+
+include "mlir/Interfaces/SideEffectInterfaces.td"
+include "hip/Dialect/Hipsr/IR/HipsrOps.td"
+
+//===----------------------------------------------------------------------===//
+// Hipsr_EmptyYieldOp
+//===----------------------------------------------------------------------===//
+
+def Hipsr_EmptyYieldOp : Hipsr_Op<"empty_yield",
+    [Pure, Terminator, HasParent<"EmptyOp">]> {
+  let summary = "Yield the init tensor(s) from a hipsr.empty region";
+  let description = [{
+    Ends the body of a `hipsr.empty`. Its operands (each a `tensor.empty`
+    result) become the parent op's results, matched by the parent's verifier.
+    Operands are `AnyRankedTensor`: `hipsr.empty` is a tensor-stage op, so it
+    can only yield tensors before bufferization.
+
+    Example:
+    ```mlir
+    hipsr.empty_yield %t0, %t1 : tensor<?x?xf16>, tensor<?xi64>
+    ```
+  }];
+
+  let arguments = (ins Variadic<AnyRankedTensor>:$tensors);
+
+  // Operands are optional so the empty implicit terminator prints as just the
+  // mnemonic (matches pool_domain_yield).
+  let assemblyFormat = "($tensors^ `:` type($tensors))? attr-dict";
+
+  let builders = [
+    // No-arg build for the implicit terminator the parent auto-inserts.
+    OpBuilder<(ins), [{
+      build($_builder, $_state, ::mlir::ValueRange{});
+    }]>
+  ];
+}
+
+#endif // HIPSR_EMPTY_YIELD_OP

--- a/include/hip/Dialect/Hipsr/IR/HipsrEmptyYieldOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrEmptyYieldOp.td
@@ -39,6 +39,8 @@ def Hipsr_EmptyYieldOp : Hipsr_Op<"empty_yield",
 
   let assemblyFormat = "($tensors^ `:` type($tensors))? attr-dict";
 
+  let hasVerifier = 1;
+
   let builders = [
     // No-arg build for the implicit terminator the parent auto-inserts.
     OpBuilder<(ins), [{

--- a/include/hip/Dialect/Hipsr/IR/HipsrEmptyYieldOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrEmptyYieldOp.td
@@ -20,20 +20,23 @@ def Hipsr_EmptyYieldOp : Hipsr_Op<"empty_yield",
     [Pure, Terminator, HasParent<"EmptyOp">]> {
   let summary = "Yield the init tensor(s) from a hipsr.empty region";
   let description = [{
-    Ends the body of a `hipsr.empty`. Its operands (each a `tensor.empty`
-    result) become the parent op's results, matched by the parent's verifier.
-    Operands are `AnyRankedTensor`: `hipsr.empty` is a tensor-stage op, so it
-    can only yield tensors before bufferization.
+    Terminates a hipsr.empty region and yields the computed init tensors.
+    The yielded tensors become the results of the hipsr.empty operation.
+    Supports variadic operands for multi-result operations.
 
-    Example:
+    Example (single result):
     ```mlir
-    hipsr.empty_yield %t0, %t1 : tensor<?x?xf16>, tensor<?xi64>
+    hipsr.empty_yield %tensor : tensor<?x512xf16>
     ```
+    Example (multi-result):
+    ```mlir
+    hipsr.empty_yield %tensor0, %tensor1 : tensor<?x?xf16>, tensor<?x?xi64>
+    ```
+
   }];
 
   let arguments = (ins Variadic<AnyRankedTensor>:$tensors);
 
-  // Operands optional so the implicit terminator prints as just the mnemonic.
   let assemblyFormat = "($tensors^ `:` type($tensors))? attr-dict";
 
   let builders = [

--- a/include/hip/Dialect/Hipsr/IR/HipsrEmptyYieldOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrEmptyYieldOp.td
@@ -33,8 +33,7 @@ def Hipsr_EmptyYieldOp : Hipsr_Op<"empty_yield",
 
   let arguments = (ins Variadic<AnyRankedTensor>:$tensors);
 
-  // Operands are optional so the empty implicit terminator prints as just the
-  // mnemonic (matches pool_domain_yield).
+  // Operands optional so the implicit terminator prints as just the mnemonic.
   let assemblyFormat = "($tensors^ `:` type($tensors))? attr-dict";
 
   let builders = [

--- a/lib/Dialect/Hipsr/IR/CMakeLists.txt
+++ b/lib/Dialect/Hipsr/IR/CMakeLists.txt
@@ -12,6 +12,8 @@ add_library(HipsrDialectIR STATIC
   HipsrOps.cpp
   HipsrPoolDomainYieldOp.cpp
   HipsrPoolDomainOp.cpp
+  HipsrEmptyYieldOp.cpp
+  HipsrEmptyOp.cpp
   HipsrConstantOp.cpp
   HipsrPlaceholderOp.cpp
   HipsrTraits.cpp
@@ -36,4 +38,5 @@ target_link_libraries(HipsrDialectIR PUBLIC
   MLIRLLVMCommonConversion
   MLIRConvertToLLVMInterface
   MLIRTransforms
+  MLIRTensorDialect
 )

--- a/lib/Dialect/Hipsr/IR/HipsrDialect.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrDialect.cpp
@@ -7,6 +7,8 @@
 
 #include "hip/Dialect/Hipsr/IR/HipsrCastOp.h"
 #include "hip/Dialect/Hipsr/IR/HipsrConstantOp.h"
+#include "hip/Dialect/Hipsr/IR/HipsrEmptyOp.h"
+#include "hip/Dialect/Hipsr/IR/HipsrEmptyYieldOp.h"
 #include "hip/Dialect/Hipsr/IR/HipsrMatMulOp.h"
 #include "hip/Dialect/Hipsr/IR/HipsrOps.h"
 #include "hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.h"
@@ -49,6 +51,12 @@ void HipsrDialect::initialize() {
       ,
 #define GET_OP_LIST
 #include "hip/Dialect/Hipsr/IR/HipsrPoolDomainOp.cpp.inc"
+      ,
+#define GET_OP_LIST
+#include "hip/Dialect/Hipsr/IR/HipsrEmptyYieldOp.cpp.inc"
+      ,
+#define GET_OP_LIST
+#include "hip/Dialect/Hipsr/IR/HipsrEmptyOp.cpp.inc"
       ,
 #define GET_OP_LIST
 #include "hip/Dialect/Hipsr/IR/HipsrConstantOp.cpp.inc"

--- a/lib/Dialect/Hipsr/IR/HipsrEmptyOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrEmptyOp.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "hip/Dialect/Hipsr/IR/HipsrEmptyOp.h"
+
+// Needs the full EmptyYieldOp type: the implicit-terminator trait's generated
+// methods and verify() below both use it.
+#include "hip/Dialect/Hipsr/IR/HipsrEmptyYieldOp.h"
+
+#include "mlir/Dialect/Tensor/IR/Tensor.h" // tensor::EmptyOp
+#include "llvm/ADT/Sequence.h"
+
+using namespace mlir;
+using namespace mlir::hipsr;
+
+LogicalResult EmptyOp::verify() {
+  // The trait already guarantees a single block ending in EmptyYieldOp. Its
+  // yielded tensors become this op's results, so just check count and types.
+  auto yieldOp = cast<EmptyYieldOp>(getRegion().front().getTerminator());
+
+  if (yieldOp.getTensors().size() != getNumResults()) {
+    return emitOpError() << "has " << getNumResults()
+                         << " result(s) but its empty_yield yields "
+                         << yieldOp.getTensors().size() << " value(s)";
+  }
+
+  for (unsigned idx : llvm::seq<unsigned>(0, getNumResults())) {
+    Type resultType = getResultTypes()[idx];
+    Type yieldType = yieldOp.getTensors()[idx].getType();
+    if (resultType != yieldType) {
+      return emitOpError() << "result #" << idx << " type " << resultType
+                           << " does not match the yielded value type "
+                           << yieldType;
+    }
+  }
+
+  return success();
+}
+
+SmallVector<SmallVector<Value>> EmptyOp::getShapes() {
+  // Only valid once the region is populated with the tensor.empty producers.
+  assert(!getRegion().empty() &&
+         "region must be populated before calling getShapes");
+  auto yieldOp = cast<EmptyYieldOp>(getRegion().front().getTerminator());
+  SmallVector<SmallVector<Value>> dimsPerResult;
+  for (Value t : yieldOp.getTensors()) {
+    SmallVector<Value> dims;
+    if (auto emptyTensor = t.getDefiningOp<tensor::EmptyOp>())
+      dims = llvm::to_vector(emptyTensor.getDynamicSizes());
+    dimsPerResult.push_back(std::move(dims));
+  }
+  return dimsPerResult;
+}
+
+SmallVector<RankedTensorType> EmptyOp::getTensorTypes() {
+  SmallVector<RankedTensorType> types;
+  for (Value result : getResults())
+    types.push_back(cast<RankedTensorType>(result.getType()));
+  return types;
+}
+
+#define GET_OP_CLASSES
+#include "hip/Dialect/Hipsr/IR/HipsrEmptyOp.cpp.inc"

--- a/lib/Dialect/Hipsr/IR/HipsrEmptyOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrEmptyOp.cpp
@@ -5,7 +5,6 @@
 
 #include "hip/Dialect/Hipsr/IR/HipsrEmptyOp.h"
 
-// Needs the full EmptyYieldOp type for the implicit-terminator trait and verify().
 #include "hip/Dialect/Hipsr/IR/HipsrEmptyYieldOp.h"
 
 #include "mlir/Dialect/Tensor/IR/Tensor.h" // tensor::EmptyOp
@@ -45,8 +44,9 @@ SmallVector<SmallVector<Value>> EmptyOp::getShapes() {
   SmallVector<SmallVector<Value>> dimsPerResult;
   for (Value t : yieldOp.getTensors()) {
     SmallVector<Value> dims;
-    if (auto emptyTensor = t.getDefiningOp<tensor::EmptyOp>())
+    if (auto emptyTensor = t.getDefiningOp<tensor::EmptyOp>()) {
       dims = llvm::to_vector(emptyTensor.getDynamicSizes());
+    }
     dimsPerResult.push_back(std::move(dims));
   }
   return dimsPerResult;
@@ -54,8 +54,9 @@ SmallVector<SmallVector<Value>> EmptyOp::getShapes() {
 
 SmallVector<RankedTensorType> EmptyOp::getTensorTypes() {
   SmallVector<RankedTensorType> types;
-  for (Value result : getResults())
+  for (Value result : getResults()) {
     types.push_back(cast<RankedTensorType>(result.getType()));
+  }
   return types;
 }
 

--- a/lib/Dialect/Hipsr/IR/HipsrEmptyOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrEmptyOp.cpp
@@ -5,8 +5,7 @@
 
 #include "hip/Dialect/Hipsr/IR/HipsrEmptyOp.h"
 
-// Needs the full EmptyYieldOp type: the implicit-terminator trait's generated
-// methods and verify() below both use it.
+// Needs the full EmptyYieldOp type for the implicit-terminator trait and verify().
 #include "hip/Dialect/Hipsr/IR/HipsrEmptyYieldOp.h"
 
 #include "mlir/Dialect/Tensor/IR/Tensor.h" // tensor::EmptyOp
@@ -40,7 +39,6 @@ LogicalResult EmptyOp::verify() {
 }
 
 SmallVector<SmallVector<Value>> EmptyOp::getShapes() {
-  // Only valid once the region is populated with the tensor.empty producers.
   assert(!getRegion().empty() &&
          "region must be populated before calling getShapes");
   auto yieldOp = cast<EmptyYieldOp>(getRegion().front().getTerminator());

--- a/lib/Dialect/Hipsr/IR/HipsrEmptyOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrEmptyOp.cpp
@@ -37,19 +37,18 @@ LogicalResult EmptyOp::verify() {
   return success();
 }
 
-SmallVector<SmallVector<Value>> EmptyOp::getShapes() {
+SmallVector<SmallVector<OpFoldResult>> EmptyOp::getMixedSizes() {
   assert(!getRegion().empty() &&
-         "region must be populated before calling getShapes");
+         "region must be populated before calling getMixedSizes");
   auto yieldOp = cast<EmptyYieldOp>(getRegion().front().getTerminator());
-  SmallVector<SmallVector<Value>> dimsPerResult;
+  SmallVector<SmallVector<OpFoldResult>> sizesPerResult;
   for (Value t : yieldOp.getTensors()) {
-    SmallVector<Value> dims;
-    if (auto emptyTensor = t.getDefiningOp<tensor::EmptyOp>()) {
-      dims = llvm::to_vector(emptyTensor.getDynamicSizes());
-    }
-    dimsPerResult.push_back(std::move(dims));
+    auto emptyTensor = t.getDefiningOp<tensor::EmptyOp>();
+    assert(emptyTensor && "hipsr.empty_yield verifier should ensure operands "
+                          "are tensor.empty results");
+    sizesPerResult.push_back(emptyTensor.getMixedSizes());
   }
-  return dimsPerResult;
+  return sizesPerResult;
 }
 
 SmallVector<RankedTensorType> EmptyOp::getTensorTypes() {

--- a/lib/Dialect/Hipsr/IR/HipsrEmptyYieldOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrEmptyYieldOp.cpp
@@ -5,7 +5,6 @@
 
 #include "hip/Dialect/Hipsr/IR/HipsrEmptyYieldOp.h"
 
-// Needs the full EmptyOp type for the HasParent trait's generated check.
 #include "hip/Dialect/Hipsr/IR/HipsrEmptyOp.h"
 
 using namespace mlir;

--- a/lib/Dialect/Hipsr/IR/HipsrEmptyYieldOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrEmptyYieldOp.cpp
@@ -7,8 +7,21 @@
 
 #include "hip/Dialect/Hipsr/IR/HipsrEmptyOp.h"
 
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "llvm/ADT/STLExtras.h"
+
 using namespace mlir;
 using namespace mlir::hipsr;
+
+LogicalResult EmptyYieldOp::verify() {
+  for (auto [idx, tensor] : llvm::enumerate(getTensors())) {
+    if (!tensor.getDefiningOp<tensor::EmptyOp>()) {
+      return emitOpError("operand #")
+             << idx << " must be a tensor.empty result";
+    }
+  }
+  return success();
+}
 
 #define GET_OP_CLASSES
 #include "hip/Dialect/Hipsr/IR/HipsrEmptyYieldOp.cpp.inc"

--- a/lib/Dialect/Hipsr/IR/HipsrEmptyYieldOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrEmptyYieldOp.cpp
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "hip/Dialect/Hipsr/IR/HipsrEmptyYieldOp.h"
+
+// Needs the full EmptyOp type for the HasParent trait's generated check.
+#include "hip/Dialect/Hipsr/IR/HipsrEmptyOp.h"
+
+using namespace mlir;
+using namespace mlir::hipsr;
+
+#define GET_OP_CLASSES
+#include "hip/Dialect/Hipsr/IR/HipsrEmptyYieldOp.cpp.inc"

--- a/test/lit/Dialect/Hipsr/empty.mlir
+++ b/test/lit/Dialect/Hipsr/empty.mlir
@@ -1,0 +1,119 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+//===----------------------------------------------------------------------===//
+// Tests that hipsr.empty / hipsr.empty_yield parse, round-trip, and that the
+// verifiers reject malformed IR.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt --split-input-file --verify-diagnostics %s | FileCheck %s
+
+// -----
+// Round-trip: single result with a dynamic dim. The (non-isolated) region reads
+// a parent-scope value (%input) to compute the shape.
+// CHECK-LABEL: func.func @roundtrip_single
+// CHECK: %[[R:.*]] = hipsr.empty() : tensor<?x8xf16> {
+// CHECK:   %[[SH:.*]] = shape.shape_of
+// CHECK:   %[[D0:.*]] = shape.get_extent
+// CHECK:   %[[T:.*]] = tensor.empty(%[[D0]]) : tensor<?x8xf16>
+// CHECK:   hipsr.empty_yield %[[T]] : tensor<?x8xf16>
+// CHECK: }
+func.func @roundtrip_single(%input: tensor<?x8xf32>) -> tensor<?x8xf16> {
+  %0 = hipsr.empty() : tensor<?x8xf16> {
+    %shape = shape.shape_of %input : tensor<?x8xf32> -> tensor<2xindex>
+    %c0 = arith.constant 0 : index
+    %d0 = shape.get_extent %shape, %c0 : tensor<2xindex>, index -> index
+    %t = tensor.empty(%d0) : tensor<?x8xf16>
+    hipsr.empty_yield %t : tensor<?x8xf16>
+  }
+  return %0 : tensor<?x8xf16>
+}
+
+// -----
+// Round-trip: multiple results (a multi-output DPS op's inits).
+// CHECK-LABEL: func.func @roundtrip_multi
+// CHECK: %[[R:.*]]:2 = hipsr.empty() : tensor<?x?xf16>, tensor<?xi64> {
+// CHECK:   hipsr.empty_yield %{{.*}}, %{{.*}} : tensor<?x?xf16>, tensor<?xi64>
+// CHECK: }
+func.func @roundtrip_multi(%n: index, %m: index) -> (tensor<?x?xf16>, tensor<?xi64>) {
+  %0:2 = hipsr.empty() : tensor<?x?xf16>, tensor<?xi64> {
+    %t0 = tensor.empty(%n, %m) : tensor<?x?xf16>
+    %t1 = tensor.empty(%n) : tensor<?xi64>
+    hipsr.empty_yield %t0, %t1 : tensor<?x?xf16>, tensor<?xi64>
+  }
+  return %0#0, %0#1 : tensor<?x?xf16>, tensor<?xi64>
+}
+
+// -----
+// Round-trip: rank-0 (scalar) result, no dynamic dims.
+// CHECK-LABEL: func.func @roundtrip_scalar
+// CHECK: %[[R:.*]] = hipsr.empty() : tensor<f32> {
+// CHECK:   %[[T:.*]] = tensor.empty() : tensor<f32>
+// CHECK:   hipsr.empty_yield %[[T]] : tensor<f32>
+// CHECK: }
+func.func @roundtrip_scalar() -> tensor<f32> {
+  %0 = hipsr.empty() : tensor<f32> {
+    %t = tensor.empty() : tensor<f32>
+    hipsr.empty_yield %t : tensor<f32>
+  }
+  return %0 : tensor<f32>
+}
+
+// -----
+// Verifier: result count must match the yielded tensor count.
+func.func @result_count_mismatch() -> tensor<4xf16> {
+  // expected-error @+1 {{has 1 result(s) but its empty_yield yields 2 value(s)}}
+  %0 = hipsr.empty() : tensor<4xf16> {
+    %t0 = tensor.empty() : tensor<4xf16>
+    %t1 = tensor.empty() : tensor<4xf16>
+    hipsr.empty_yield %t0, %t1 : tensor<4xf16>, tensor<4xf16>
+  }
+  return %0 : tensor<4xf16>
+}
+
+// -----
+// Verifier: result type must match the yielded tensor type.
+func.func @result_type_mismatch() -> tensor<4xi64> {
+  // expected-error @+1 {{result #0 type 'tensor<4xi64>' does not match the yielded value type 'tensor<4xf16>'}}
+  %0 = hipsr.empty() : tensor<4xi64> {
+    %t = tensor.empty() : tensor<4xf16>
+    hipsr.empty_yield %t : tensor<4xf16>
+  }
+  return %0 : tensor<4xi64>
+}
+
+// -----
+// Verifier: a mismatch on a later result is reported with that result's index
+// (result #0 matches, result #1 does not).
+func.func @later_result_type_mismatch() -> (tensor<4xf16>, tensor<4xi64>) {
+  // expected-error @+1 {{result #1 type 'tensor<4xi64>' does not match the yielded value type 'tensor<4xf16>'}}
+  %0:2 = hipsr.empty() : tensor<4xf16>, tensor<4xi64> {
+    %t0 = tensor.empty() : tensor<4xf16>
+    %t1 = tensor.empty() : tensor<4xf16>
+    hipsr.empty_yield %t0, %t1 : tensor<4xf16>, tensor<4xf16>
+  }
+  return %0#0, %0#1 : tensor<4xf16>, tensor<4xi64>
+}
+
+// -----
+// Verifier (HasParent): empty_yield outside a hipsr.empty is rejected.
+func.func @yield_without_parent(%t: tensor<4xf16>) {
+  // expected-error @+1 {{expects parent op 'hipsr.empty'}}
+  hipsr.empty_yield %t : tensor<4xf16>
+  return
+}
+
+// -----
+// Verifier (SizedRegion<1>): the region must be a single block. Two blocks,
+// each terminated by its own empty_yield, is rejected.
+func.func @multi_block_body() -> tensor<4xf16> {
+  // expected-error @+1 {{expects region #0 to have 0 or 1 blocks}}
+  %0 = hipsr.empty() : tensor<4xf16> {
+    %t = tensor.empty() : tensor<4xf16>
+    hipsr.empty_yield %t : tensor<4xf16>
+  ^bb1:
+    %t2 = tensor.empty() : tensor<4xf16>
+    hipsr.empty_yield %t2 : tensor<4xf16>
+  }
+  return %0 : tensor<4xf16>
+}

--- a/test/lit/Dialect/Hipsr/empty.mlir
+++ b/test/lit/Dialect/Hipsr/empty.mlir
@@ -81,6 +81,17 @@ func.func @later_result_type_mismatch() -> (tensor<4xf16>, tensor<4xi64>) {
 }
 
 // -----
+// Verifier: each empty_yield operand must be a tensor.empty result. Here the
+// region yields a parent-scope value (%arg) instead of a tensor.empty.
+func.func @yield_non_tensor_empty(%arg: tensor<4xf16>) -> tensor<4xf16> {
+  %0 = hipsr.empty() : tensor<4xf16> {
+    // expected-error @+1 {{operand #0 must be a tensor.empty result}}
+    hipsr.empty_yield %arg : tensor<4xf16>
+  }
+  return %0 : tensor<4xf16>
+}
+
+// -----
 // Verifier (HasParent): empty_yield outside a hipsr.empty is rejected.
 func.func @yield_without_parent(%t: tensor<4xf16>) {
   // expected-error @+1 {{expects parent op 'hipsr.empty'}}

--- a/test/lit/Dialect/Hipsr/empty.mlir
+++ b/test/lit/Dialect/Hipsr/empty.mlir
@@ -45,21 +45,6 @@ func.func @roundtrip_multi(%n: index, %m: index) -> (tensor<?x?xf16>, tensor<?xi
 }
 
 // -----
-// Round-trip: rank-0 (scalar) result, no dynamic dims.
-// CHECK-LABEL: func.func @roundtrip_scalar
-// CHECK: %[[R:.*]] = hipsr.empty() : tensor<f32> {
-// CHECK:   %[[T:.*]] = tensor.empty() : tensor<f32>
-// CHECK:   hipsr.empty_yield %[[T]] : tensor<f32>
-// CHECK: }
-func.func @roundtrip_scalar() -> tensor<f32> {
-  %0 = hipsr.empty() : tensor<f32> {
-    %t = tensor.empty() : tensor<f32>
-    hipsr.empty_yield %t : tensor<f32>
-  }
-  return %0 : tensor<f32>
-}
-
-// -----
 // Verifier: result count must match the yielded tensor count.
 func.func @result_count_mismatch() -> tensor<4xf16> {
   // expected-error @+1 {{has 1 result(s) but its empty_yield yields 2 value(s)}}


### PR DESCRIPTION
## Summary

Adds `hipsr.empty` and its terminator `hipsr.empty_yield` (per the *Materialize Init Tensors Pass* design, Appendix A). `hipsr.empty` carries a DPS op's output-shape computation in a region, builds one `tensor.empty()` per result, and yields them; variadic results back multi-output DPS ops.

- **`hipsr.empty`** — no operands; variadic ranked-tensor results; single-block, non-isolated region (shape computation may read parent-scope values). Verifier checks yielded-tensor count and per-result type. Accessors `getShapes()` / `getTensorTypes()`.
- **`hipsr.empty_yield`** — variadic ranked-tensor terminator, `HasParent<"EmptyOp">`.
- **LIT** — round-trip (single / multi / rank-0) + verifier negatives (count, type, orphan yield, multi-block region).

## Scope

Op definitions only. Follow-up PRs: `BufferizableOpInterface` (Appendix B) and the `materialize-init-tensors` pass .


## Test plan

- [x] `hip-mlir-opt` builds; `MorphizenMLIRLitTests` passes (`empty.mlir` included).
