### PR TITLE
feat(hipsr): add hipsr.add op with shape region and LLVM lowering

### DIFF
--- a/include/hip/Dialect/Hipsr/IR/CMakeLists.txt
+++ b/include/hip/Dialect/Hipsr/IR/CMakeLists.txt
@@ -47,6 +47,10 @@ set(LLVM_TARGET_DEFINITIONS HipsrMatMulOp.td)
 mlir_tablegen(HipsrMatMulOp.h.inc -gen-op-decls)
 mlir_tablegen(HipsrMatMulOp.cpp.inc -gen-op-defs)
 
+set(LLVM_TARGET_DEFINITIONS HipsrAddOp.td)
+mlir_tablegen(HipsrAddOp.h.inc -gen-op-decls)
+mlir_tablegen(HipsrAddOp.cpp.inc -gen-op-defs)
+
 set(LLVM_TARGET_DEFINITIONS HipsrPlaceholderOp.td)
 mlir_tablegen(HipsrPlaceholderOp.h.inc -gen-op-decls)
 mlir_tablegen(HipsrPlaceholderOp.cpp.inc -gen-op-defs)

--- a/include/hip/Dialect/Hipsr/IR/HipsrAddOp.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrAddOp.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#ifndef HIPSR_ADD_OP_H
+#define HIPSR_ADD_OP_H
+
+#include "hip/Dialect/Hipsr/IR/HipsrDialect.h"
+#include "hip/Dialect/Hipsr/IR/HipsrShapeRegionInterface.h"
+#include "hip/Dialect/Hipsr/IR/HipsrShapeYieldOp.h"
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/Interfaces/DestinationStyleOpInterface.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+
+#define GET_OP_CLASSES
+#include "hip/Dialect/Hipsr/IR/HipsrAddOp.h.inc"
+
+namespace mlir {
+class LLVMTypeConverter;
+class RewritePatternSet;
+
+namespace hipsr {
+
+void populateHipsrAddLoweringPatterns(const LLVMTypeConverter &converter,
+                                      RewritePatternSet &patterns);
+
+} // namespace hipsr
+} // namespace mlir
+
+#endif // HIPSR_ADD_OP_H

--- a/include/hip/Dialect/Hipsr/IR/HipsrAddOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrAddOp.td
@@ -1,0 +1,32 @@
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+
+#ifndef HIPSR_ADD_OP
+#define HIPSR_ADD_OP
+
+include "hip/Dialect/Hipsr/IR/HipsrOps.td"
+
+def Hipsr_AddOp : Hipsr_DpsOp<"add"> {
+  let summary = "Elementwise add, destination-passing style";
+  let description = [{
+    Elementwise addition with ONNX/NumPy broadcasting: `init = lhs + rhs`.
+  }];
+
+  let arguments = (ins
+    Hipsr_ContextType:$ctx,
+    Hipsr_TensorOrDeviceMemRef:$lhs,
+    Hipsr_TensorOrDeviceMemRef:$rhs,
+    Hipsr_TensorOrDeviceMemRef:$init
+  );
+
+  let assemblyFormat = [{
+    `(` $ctx `)`
+    `ins` `(` $lhs `,` $rhs `:` type($lhs) `,` type($rhs) `)`
+    `outs` `(` $init `:` type($init) `)`
+    attr-dict (`:` type($result_tensors)^)? (`shape_region` $shape_region^)?
+  }];
+}
+
+#endif // HIPSR_ADD_OP

--- a/include/hip/Dialect/Hipsr/IR/HipsrLLVMLoweringUtils.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrLLVMLoweringUtils.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#ifndef HIPSR_LLVM_LOWERING_UTILS_H
+#define HIPSR_LLVM_LOWERING_UTILS_H
+
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/Types.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+#include "llvm/ADT/SmallVector.h"
+
+#include <cstdint>
+
+namespace mlir {
+namespace hipsr {
+
+enum HipdnnTensorOp : int64_t {
+  kTensorOpMul = 0,
+  kTensorOpAdd = 1,
+  kTensorOpMin = 2,
+  kTensorOpMax = 3,
+};
+
+int64_t getHipdnnDataType(Type elemType);
+
+Value extractContiguousMemRefPtr(Value memrefDesc,
+                                 ConversionPatternRewriter &rewriter,
+                                 Location loc);
+
+llvm::SmallVector<Value, 4> extractShape4D(MemRefType type, Value descriptor,
+                                           ConversionPatternRewriter &rewriter,
+                                           Location loc, Type i64Type);
+
+} // namespace hipsr
+} // namespace mlir
+
+#endif // HIPSR_LLVM_LOWERING_UTILS_H

--- a/lib/Dialect/Hipsr/IR/CMakeLists.txt
+++ b/lib/Dialect/Hipsr/IR/CMakeLists.txt
@@ -17,6 +17,8 @@ add_library(HipsrDialectIR STATIC
   HipsrTraits.cpp
   HipsrCastOp.cpp
   HipsrMatMulOp.cpp
+  HipsrAddOp.cpp
+  HipsrLLVMLoweringUtils.cpp
   HipsrTypes.cpp
 )
 

--- a/lib/Dialect/Hipsr/IR/HipsrAddOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrAddOp.cpp
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "hip/Dialect/Hipsr/IR/HipsrAddOp.h"
+
+#include "hip/Dialect/Hipsr/IR/HipsrLLVMLoweringUtils.h"
+#include "hip/Dialect/Hipsr/IR/HipsrShapeRegionInterface.h"
+
+#include "mlir/Conversion/LLVMCommon/Pattern.h"
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/LLVMIR/FunctionCallUtils.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
+#include "mlir/Dialect/Shape/IR/Shape.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+#include "llvm/ADT/Sequence.h"
+
+#include <algorithm>
+
+using namespace mlir;
+using namespace mlir::hipsr;
+
+#define GET_OP_CLASSES
+#include "hip/Dialect/Hipsr/IR/HipsrAddOp.cpp.inc"
+
+namespace {
+struct AddShapeArgs : ShapeRegionArgs<AddOp> {
+  using ShapeRegionArgs::ShapeRegionArgs;
+  Value getLhs() const { return in(0); }
+  Value getRhs() const { return in(1); }
+};
+} // namespace
+
+MutableOperandRange AddOp::getDpsInitsMutable() { return getInitMutable(); }
+
+void AddOp::populateShapeRegion(OpBuilder &builder, Block &shapeBlock) {
+  OpBuilder::InsertionGuard guard(builder);
+  builder.setInsertionPointToStart(&shapeBlock);
+
+  Location loc = getLoc();
+  AddShapeArgs args{shapeBlock};
+  Value shLhs = builder.create<shape::ShapeOfOp>(loc, args.getLhs());
+  Value shRhs = builder.create<shape::ShapeOfOp>(loc, args.getRhs());
+
+  auto extentTensorTy = RankedTensorType::get(
+      {ShapedType::kDynamic}, IndexType::get(builder.getContext()));
+  Value bcast = builder.create<shape::BroadcastOp>(
+      loc, extentTensorTy, ValueRange{shLhs, shRhs}, /*error=*/nullptr);
+
+  int64_t outRank = cast<ShapedType>(getInit().getType()).getRank();
+  SmallVector<Value> dims;
+  dims.reserve(outRank);
+  for (int64_t i : llvm::seq<int64_t>(0, outRank)) {
+    Value idx = builder.create<arith::ConstantIndexOp>(loc, i);
+    dims.push_back(builder.create<shape::GetExtentOp>(loc, bcast, idx));
+  }
+
+  Type elemTy = cast<ShapedType>(getInit().getType()).getElementType();
+  builder.create<ShapeYieldOp>(loc, ArrayRef<ValueRange>{ValueRange(dims)},
+                               TypeRange{elemTy});
+}
+
+namespace {
+
+constexpr const char *kWrapMiopenOpTensor = "wrap_miopenOpTensor";
+
+struct AddLowering : public ConvertOpToLLVMPattern<AddOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(AddOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    ModuleOp module = op->getParentOfType<ModuleOp>();
+    Type ptrType = getPtrType();
+    Type i32Type = rewriter.getI32Type();
+    Type i64Type = rewriter.getI64Type();
+
+    auto lhsType = dyn_cast<MemRefType>(op.getLhs().getType());
+    auto rhsType = dyn_cast<MemRefType>(op.getRhs().getType());
+    auto outType = dyn_cast<MemRefType>(op.getInit().getType());
+    if (!lhsType || !rhsType || !outType) {
+      return rewriter.notifyMatchFailure(
+          op, "operands must be memrefs (run bufferization first)");
+    }
+
+    if (lhsType.getRank() > 4 || rhsType.getRank() > 4 ||
+        outType.getRank() > 4) {
+      return rewriter.notifyMatchFailure(
+          op, "rank > 4 unsupported by MIOpen 4D descriptor API");
+    }
+
+    auto lhsDims =
+        extractShape4D(lhsType, adaptor.getLhs(), rewriter, loc, i64Type);
+    auto rhsDims =
+        extractShape4D(rhsType, adaptor.getRhs(), rewriter, loc, i64Type);
+    auto outDims =
+        extractShape4D(outType, adaptor.getInit(), rewriter, loc, i64Type);
+
+    int64_t dataType = getHipdnnDataType(outType.getElementType());
+    if (dataType < 0) {
+      return rewriter.notifyMatchFailure(op, "unsupported element type");
+    }
+
+    auto createI64Const = [&](int64_t v) {
+      return LLVM::ConstantOp::create(rewriter, loc, i64Type,
+                                      rewriter.getI64IntegerAttr(v));
+    };
+
+    SmallVector<Type, 19> paramTypes = {ptrType, i32Type, ptrType, ptrType,
+                                        ptrType};
+    paramTypes.append(14, i64Type);
+
+    FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
+        rewriter, module, kWrapMiopenOpTensor, paramTypes, i32Type);
+    if (failed(funcOp)) {
+      return failure();
+    }
+
+    Value opStateSlot = LLVM::ConstantOp::create(
+        rewriter, loc, i32Type, rewriter.getI32IntegerAttr(-1));
+
+    SmallVector<Value, 19> args = {
+        adaptor.getCtx(), opStateSlot,
+        extractContiguousMemRefPtr(adaptor.getLhs(), rewriter, loc),
+        extractContiguousMemRefPtr(adaptor.getRhs(), rewriter, loc),
+        extractContiguousMemRefPtr(adaptor.getInit(), rewriter, loc)};
+    args.append(lhsDims.begin(), lhsDims.end());
+    args.append(rhsDims.begin(), rhsDims.end());
+    args.append(outDims.begin(), outDims.end());
+    args.push_back(createI64Const(dataType));
+    args.push_back(createI64Const(kTensorOpAdd));
+
+    LLVM::CallOp::create(rewriter, loc, *funcOp, args);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+} // namespace
+
+void mlir::hipsr::populateHipsrAddLoweringPatterns(
+    const LLVMTypeConverter &converter, RewritePatternSet &patterns) {
+  patterns.add<AddLowering>(converter);
+}

--- a/lib/Dialect/Hipsr/IR/HipsrAddOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrAddOp.cpp
@@ -115,6 +115,7 @@ struct AddLowering : public ConvertOpToLLVMPattern<AddOp> {
                                         ptrType};
     paramTypes.append(14, i64Type);
 
+    // TODO: the runtime function should use !llvm.ptr<1> (GPU) pointers.
     FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
         rewriter, module, kWrapMiopenOpTensor, paramTypes, i32Type);
     if (failed(funcOp)) {

--- a/lib/Dialect/Hipsr/IR/HipsrDialect.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrDialect.cpp
@@ -5,6 +5,7 @@
 
 #include "hip/Dialect/Hipsr/IR/HipsrDialect.h"
 
+#include "hip/Dialect/Hipsr/IR/HipsrAddOp.h"
 #include "hip/Dialect/Hipsr/IR/HipsrCastOp.h"
 #include "hip/Dialect/Hipsr/IR/HipsrConstantOp.h"
 #include "hip/Dialect/Hipsr/IR/HipsrMatMulOp.h"
@@ -60,6 +61,9 @@ void HipsrDialect::initialize() {
 #include "hip/Dialect/Hipsr/IR/HipsrMatMulOp.cpp.inc"
       ,
 #define GET_OP_LIST
+#include "hip/Dialect/Hipsr/IR/HipsrAddOp.cpp.inc"
+      ,
+#define GET_OP_LIST
 #include "hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.cpp.inc"
       >();
   addAttributes<
@@ -98,6 +102,7 @@ namespace {
 void populateHipsrToLLVMPatterns(const LLVMTypeConverter &typeConverter,
                                  RewritePatternSet &patterns) {
   populateHipsrConstantLoweringPatterns(typeConverter, patterns);
+  populateHipsrAddLoweringPatterns(typeConverter, patterns);
 }
 
 struct HipsrConvertToLLVMInterface : public ConvertToLLVMPatternInterface {
@@ -119,6 +124,9 @@ struct HipsrConvertToLLVMInterface : public ConvertToLLVMPatternInterface {
           return IntegerAttr::get(IntegerType::get(space.getContext(), 64),
                                   static_cast<int64_t>(space.getKind()));
         });
+    typeConverter.addConversion([](ContextType type) -> Type {
+      return LLVM::LLVMPointerType::get(type.getContext(), 0);
+    });
     target.addIllegalDialect<HipsrDialect>();
     populateHipsrToLLVMPatterns(typeConverter, patterns);
   }

--- a/lib/Dialect/Hipsr/IR/HipsrLLVMLoweringUtils.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrLLVMLoweringUtils.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "hip/Dialect/Hipsr/IR/HipsrLLVMLoweringUtils.h"
+
+#include "mlir/Conversion/LLVMCommon/MemRefBuilder.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
+
+#include "llvm/ADT/Sequence.h"
+
+using namespace mlir;
+
+int64_t mlir::hipsr::getHipdnnDataType(Type elemType) {
+  if (elemType.isF32()) {
+    return 0;
+  }
+  if (elemType.isF16()) {
+    return 1;
+  }
+  if (elemType.isBF16()) {
+    return 2;
+  }
+  if (elemType.isInteger(32)) {
+    return 3;
+  }
+  if (elemType.isInteger(64)) {
+    return 4;
+  }
+  if (elemType.isUnsignedInteger(8)) {
+    return 7;
+  }
+  if (elemType.isSignedInteger(8) || elemType.isSignlessInteger(8)) {
+    return 5;
+  }
+  if (elemType.isF64()) {
+    return 6;
+  }
+  if (elemType.isInteger(16)) {
+    return 8;
+  }
+  return -1;
+}
+
+Value mlir::hipsr::extractContiguousMemRefPtr(
+    Value memrefDesc, ConversionPatternRewriter &rewriter, Location loc) {
+  Value ptr = MemRefDescriptor(memrefDesc).alignedPtr(rewriter, loc);
+  auto ptrTy = cast<LLVM::LLVMPointerType>(ptr.getType());
+  if (ptrTy.getAddressSpace() != 0) {
+    ptr = LLVM::AddrSpaceCastOp::create(
+        rewriter, loc, LLVM::LLVMPointerType::get(rewriter.getContext(), 0),
+        ptr);
+  }
+  return ptr;
+}
+
+llvm::SmallVector<Value, 4>
+mlir::hipsr::extractShape4D(MemRefType type, Value descriptor,
+                            ConversionPatternRewriter &rewriter, Location loc,
+                            Type i64Type) {
+  auto createConst = [&](int64_t v) {
+    return LLVM::ConstantOp::create(rewriter, loc, i64Type,
+                                    rewriter.getI64IntegerAttr(v));
+  };
+  MemRefDescriptor desc(descriptor);
+  int rank = type.getRank();
+  llvm::SmallVector<Value, 4> dims;
+  for (int i : llvm::seq(4 - rank)) {
+    dims.push_back(createConst(1));
+  }
+  for (int i : llvm::seq(rank)) {
+    if (type.isDynamicDim(i)) {
+      dims.push_back(desc.size(rewriter, loc, i));
+    } else {
+      dims.push_back(createConst(type.getDimSize(i)));
+    }
+  }
+  return dims;
+}

--- a/lib/Dialect/Hipsr/IR/HipsrLLVMLoweringUtils.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrLLVMLoweringUtils.cpp
@@ -48,6 +48,7 @@ Value mlir::hipsr::extractContiguousMemRefPtr(
     Value memrefDesc, ConversionPatternRewriter &rewriter, Location loc) {
   Value ptr = MemRefDescriptor(memrefDesc).alignedPtr(rewriter, loc);
   auto ptrTy = cast<LLVM::LLVMPointerType>(ptr.getType());
+  // TODO: we should not need AddrSpaceCastOp in the future.
   if (ptrTy.getAddressSpace() != 0) {
     ptr = LLVM::AddrSpaceCastOp::create(
         rewriter, loc, LLVM::LLVMPointerType::get(rewriter.getContext(), 0),

--- a/test/lit/Conversion/hipsr-to-llvm/test_add.mlir
+++ b/test/lit/Conversion/hipsr-to-llvm/test_add.mlir
@@ -1,0 +1,19 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt %s --convert-to-llvm | FileCheck %s
+
+// CHECK-LABEL: llvm.func @add
+// CHECK-SAME:  (%[[CTX:.*]]: !llvm.ptr,
+// CHECK-DAG:   %[[SLOT:.*]] = llvm.mlir.constant(-1 : i32) : i32
+// CHECK-DAG:   %[[TOP:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK:       llvm.call @wrap_miopenOpTensor(%[[CTX]], %[[SLOT]],
+// CHECK-SAME:    !llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
+func.func @add(%ctx: !hipsr.context,
+               %lhs: memref<4x1024xf16, #hipsr.mem<device>>,
+               %rhs: memref<1024xf16, #hipsr.mem<device>>,
+               %init: memref<4x1024xf16, #hipsr.mem<device>>) {
+  hipsr.add(%ctx) ins(%lhs, %rhs : memref<4x1024xf16, #hipsr.mem<device>>, memref<1024xf16, #hipsr.mem<device>>)
+             outs(%init : memref<4x1024xf16, #hipsr.mem<device>>)
+  return
+}

--- a/test/lit/Dialect/Hipsr/add.mlir
+++ b/test/lit/Dialect/Hipsr/add.mlir
@@ -34,14 +34,17 @@ func.func @add_memref(%ctx: !hipsr.context,
 
 // POPULATE-LABEL: func.func @add_broadcast
 // POPULATE: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} : tensor<?x1024xf16>, tensor<1024xf16>)
-// POPULATE-SAME: shape_region {
+// POPULATE-SAME: outs(%{{.+}} : tensor<?x1024xf16>) : tensor<?x1024xf16> shape_region {
 // POPULATE:   ^bb0(%[[LHS:.+]]: tensor<?x1024xf16>, %[[RHS:.+]]: tensor<1024xf16>):
-// POPULATE:   %[[SHL:.+]] = shape.shape_of %[[LHS]]
-// POPULATE:   %[[SHR:.+]] = shape.shape_of %[[RHS]]
-// POPULATE:   %[[BC:.+]] = shape.broadcast %[[SHL]], %[[SHR]]
-// POPULATE:   %[[D0:.+]] = shape.get_extent %[[BC]]
-// POPULATE:   %[[D1:.+]] = shape.get_extent %[[BC]]
-// POPULATE:   hipsr.shape_yield (%[[D0]], %[[D1]]) : [f16]
+// POPULATE:     %[[SHL:.+]] = shape.shape_of %[[LHS]] : tensor<?x1024xf16> -> tensor<2xindex>
+// POPULATE:     %[[SHR:.+]] = shape.shape_of %[[RHS]] : tensor<1024xf16> -> tensor<1xindex>
+// POPULATE:     %[[BC:.+]] = shape.broadcast %[[SHL]], %[[SHR]] : tensor<2xindex>, tensor<1xindex> -> tensor<?xindex>
+// POPULATE:     %[[C0:.+]] = arith.constant 0 : index
+// POPULATE:     %[[D0:.+]] = shape.get_extent %[[BC]], %[[C0]] : tensor<?xindex>, index -> index
+// POPULATE:     %[[C1:.+]] = arith.constant 1 : index
+// POPULATE:     %[[D1:.+]] = shape.get_extent %[[BC]], %[[C1]] : tensor<?xindex>, index -> index
+// POPULATE:     hipsr.shape_yield (%[[D0]], %[[D1]]) : [f16]
+// POPULATE:   }
 func.func @add_broadcast(%ctx: !hipsr.context, %lhs: tensor<?x1024xf16>,
                          %rhs: tensor<1024xf16>,
                          %init: tensor<?x1024xf16>) -> tensor<?x1024xf16> {

--- a/test/lit/Dialect/Hipsr/add.mlir
+++ b/test/lit/Dialect/Hipsr/add.mlir
@@ -1,0 +1,51 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --split-input-file %s | FileCheck %s
+// RUN: hip-mlir-opt --split-input-file -hipsr-populate-shape-region %s | FileCheck %s --check-prefix=POPULATE
+
+// CHECK-LABEL: func.func @add_tensor
+// CHECK:      hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} : tensor<?x1024xf16>, tensor<1024xf16>)
+// CHECK-SAME:   outs(%{{.+}} : tensor<?x1024xf16>) : tensor<?x1024xf16>
+// CHECK-NEXT: return
+func.func @add_tensor(%ctx: !hipsr.context, %lhs: tensor<?x1024xf16>,
+                      %rhs: tensor<1024xf16>,
+                      %init: tensor<?x1024xf16>) -> tensor<?x1024xf16> {
+  %0 = hipsr.add(%ctx) ins(%lhs, %rhs : tensor<?x1024xf16>, tensor<1024xf16>)
+                  outs(%init : tensor<?x1024xf16>) : tensor<?x1024xf16>
+  return %0 : tensor<?x1024xf16>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @add_memref
+// CHECK: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} : memref<4x1024xf16, #hipsr.mem<device>>, memref<1024xf16, #hipsr.mem<device>>)
+// CHECK-SAME: outs(%{{.+}} : memref<4x1024xf16, #hipsr.mem<device>>)
+func.func @add_memref(%ctx: !hipsr.context,
+                      %lhs: memref<4x1024xf16, #hipsr.mem<device>>,
+                      %rhs: memref<1024xf16, #hipsr.mem<device>>,
+                      %init: memref<4x1024xf16, #hipsr.mem<device>>) {
+  hipsr.add(%ctx) ins(%lhs, %rhs : memref<4x1024xf16, #hipsr.mem<device>>, memref<1024xf16, #hipsr.mem<device>>)
+             outs(%init : memref<4x1024xf16, #hipsr.mem<device>>)
+  return
+}
+
+// -----
+
+// POPULATE-LABEL: func.func @add_broadcast
+// POPULATE: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} : tensor<?x1024xf16>, tensor<1024xf16>)
+// POPULATE-SAME: shape_region {
+// POPULATE:   ^bb0(%[[LHS:.+]]: tensor<?x1024xf16>, %[[RHS:.+]]: tensor<1024xf16>):
+// POPULATE:   %[[SHL:.+]] = shape.shape_of %[[LHS]]
+// POPULATE:   %[[SHR:.+]] = shape.shape_of %[[RHS]]
+// POPULATE:   %[[BC:.+]] = shape.broadcast %[[SHL]], %[[SHR]]
+// POPULATE:   %[[D0:.+]] = shape.get_extent %[[BC]]
+// POPULATE:   %[[D1:.+]] = shape.get_extent %[[BC]]
+// POPULATE:   hipsr.shape_yield (%[[D0]], %[[D1]]) : [f16]
+func.func @add_broadcast(%ctx: !hipsr.context, %lhs: tensor<?x1024xf16>,
+                         %rhs: tensor<1024xf16>,
+                         %init: tensor<?x1024xf16>) -> tensor<?x1024xf16> {
+  %0 = hipsr.add(%ctx) ins(%lhs, %rhs : tensor<?x1024xf16>, tensor<1024xf16>)
+                  outs(%init : tensor<?x1024xf16>) : tensor<?x1024xf16>
+  return %0 : tensor<?x1024xf16>
+}


### PR DESCRIPTION
## Summary

Add the `hipsr.add` elementwise op (ONNX/NumPy broadcasting, destination-passing style) with its shape-region population and LLVM lowering, plus a shared hipsr LLVM-lowering utility so later compute-op lowerings do not each re-implement the boilerplate.

## Why

`hipsr.add` follows the existing `Hipsr_DpsOp` convention (matmul/cast). Its lowering targets the existing runtime entry `wrap_miopenOpTensor` through the dialect's `ConvertToLLVMPatternInterface` (same mechanism as `hipsr.constant`), so no dedicated `-convert-hipsr-to-llvm` pass is added. The three lowering helpers mirror the hip-side `HipToLLVMUtils` but are re-declared on the hipsr side rather than reused: the hip path is slated for removal, so hipsr must not depend on it.

## What

1. **New op** `hipsr.add` at `include/hip/Dialect/Hipsr/IR/HipsrAddOp.{td,h}` and `lib/Dialect/Hipsr/IR/HipsrAddOp.cpp`: DPS elementwise add; shape-region population broadcasts the operand shapes; LLVM lowering emits a `wrap_miopenOpTensor` call (op_state_slot = -1, per-operand 4D N/C/H/W dims, data_type, tensor_op).
2. **New shared utility** at `include/hip/Dialect/Hipsr/IR/HipsrLLVMLoweringUtils.h` + `lib/Dialect/Hipsr/IR/HipsrLLVMLoweringUtils.cpp`: `getHipdnnDataType`, `extractContiguousMemRefPtr`, `extractShape4D`, and the `HipdnnTensorOp` enum.
3. **Registration**: `HipsrDialect.cpp` adds `populateHipsrAddLoweringPatterns` to the ConvertToLLVM interface; CMake compiles the two new sources into `HipsrDialectIR`.
4. **Tests**: `test/lit/Dialect/Hipsr/add.mlir` (round-trip + shape-region) and `test/lit/Conversion/hipsr-to-llvm/test_add.mlir` (LLVM lowering).

## Test plan

- [x] LIT passes locally: `add.mlir` (default + POPULATE) and `test_add.mlir`.
- [x] `HipsrDialectIR` + `hip-mlir-opt` build clean.
- [ ] CI green.

## Notes for reviewers

- `extractShape4D` is shared in the util even though `hipsr.add` is its only consumer; an `ElementwiseOpLowering` template (like the hip side) is deferred until a second elementwise op (mul/min/max) lands.
- ABI contract: the `HipdnnTensorOp` enum values and `getHipdnnDataType` mapping must match `HIPDNN_EP_TENSOR_OP_*` / `HIPDNN_EP_DATATYPE_*` in `lib/Runtime/hipdnn_ep_runtime.h`.

## Checklist

- [x] **Incremental.** Standalone, < 500 LOC / 10 files.
- [x] **AI policy.** Cursor assisted; disclosed via the commit `Co-Authored-By` trailer.
- [x] **No good first issue automation.**
- [ ] **Reviews resolved.**
- [x] **CODEOWNERS routing.**
