### PR TITLE
feat(cursor-command): add /export-onnx command for Olive ONNX export

### DIFF
--- a/.cursor/commands/export-onnx.md
+++ b/.cursor/commands/export-onnx.md
@@ -1,0 +1,29 @@
+<!--
+Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+Licensed under the MIT License.
+-->
+# Export a model to ONNX
+
+Export the model I provide into an optimized ONNX model by authoring and running an
+Olive recipe, following the **export-onnx** skill end to end:
+@.cursor/skills/export-onnx/SKILL.md
+
+## Inputs (parse from the text after the command; ask only if genuinely ambiguous)
+- **Model link** (required): HuggingFace id/URL, GitHub repo/path, or a checkpoint URL.
+- **Input shape** (optional): e.g. `1x3x224x224`. Default to the model's documented inference size.
+- **dtype** (optional): `f16` (default) or `f32`.
+
+If no model link is present in my message, ask me for one before doing anything else.
+
+## What to do
+1. Confirm the source is in scope (single-image CNN or standard transformer per the skill).
+2. Do the one-time setup only if missing (Olive repos cloned, `hipdnn-ep` env deps).
+3. Author the recipe under `olive-recipes/<model-slug>/olive/` (`user_script.py`,
+   `config.json`, `run.py`), mirroring the canonical reference recipes.
+4. `cd` into the recipe's `olive/` dir and run `run.py` (background + wait on
+   `RUN_COMPLETE`); apply the fp16 duplicate-node post-fix for f16 exports.
+5. Verify the output `model.onnx` (checker, I/O names/shapes/dtypes, one ORT inference).
+6. Report: recipe path, output model path, detected `model_type`, and verified I/O.
+
+Follow the skill's exact pass/config names, environment conventions, and gotchas
+(especially running from the recipe's `olive/` dir).

--- a/.gitignore
+++ b/.gitignore
@@ -72,11 +72,12 @@ Thumbs.db
 # Cline/AI assistant storage
 .cline_storage/
 .cline/
-# Ignore .cursor/ contents (IDE/agent state) but track project-level skills.
-# Use .cursor/* (not .cursor/) so we can un-ignore .cursor/skills/ below;
-# a fully-ignored parent dir cannot have children re-included by git.
+# Ignore .cursor/ contents (IDE/agent state) but track project-level skills
+# and commands. Use .cursor/* (not .cursor/) so we can un-ignore the shared
+# subdirs below; a fully-ignored parent dir cannot have children re-included.
 .cursor/*
 !.cursor/skills/
+!.cursor/commands/
 .cursor/skills/**/__pycache__/
 .cursor/skills/**/*.pyc
 


### PR DESCRIPTION
## Summary
Adds a Cursor **custom command** (`/export-onnx`) that drives the `export-onnx` agent skill to export a vision/ML model into an optimized fp16 ONNX model via an Olive recipe.

## What's included
- `.cursor/commands/export-onnx.md` — typing `/export-onnx <model-link> [shape] [dtype]` loads this prompt, which `@`-references the `export-onnx` skill and runs its workflow (scope check -> setup -> author recipe -> run -> verify -> report). It parses the model link / input shape / dtype from the message and asks only if the model link is missing.
- `.gitignore` — un-ignore `.cursor/commands/` so project-level commands are tracked, mirroring the existing `!.cursor/skills/` convention.

## Notes
- Draft; thin by design — the command frames/triggers the skill rather than duplicating it, keeping the skill as the single source of truth.
- Includes the AMD license header to satisfy the `licenseheaders` pre-commit hook.
- Companion to the `export-onnx` skill PR.
- No runtime/code changes; perf-report tooling changes are intentionally excluded.