### PR TITLE
feat(cursor): add export-onnx & add-hip-ep-op skills/commands + fix embedded-LLVM CMake

### DIFF
--- a/.cursor/commands/add-hip-ep-op.md
+++ b/.cursor/commands/add-hip-ep-op.md
@@ -1,0 +1,32 @@
+<!--
+Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+Licensed under the MIT License.
+-->
+# Add hip-ep Op
+
+Add a new operator end-to-end across the hip-ep MLIR compiler stack by reading
+and following `.cursor/skills/add-hip-ep-op/SKILL.md`.
+
+Op to add: $ARGUMENTS
+
+Steps:
+
+1. Read `.cursor/skills/add-hip-ep-op/SKILL.md` and follow it exactly.
+2. If the op details are missing, first gather: op name, ONNX source (native
+   `onnx.<Op>` vs `com.microsoft` `onnx.Custom`), math formula, attributes
+   (name/type/default), and supported dtypes.
+3. Model each layer on the closest existing op (GELU for a unary custom-kernel
+   op, LeakyRelu for float-`alpha` plumbing, Gqa for `onnx.Custom` +
+   `com.microsoft` matching).
+4. Implement every layer: HIP dialect op, ONNX->HIP conversion (+ register in
+   `OnnxToHipUtils.h` / `OnnxToHip.cpp` / `CMakeLists.txt`), bufferization
+   registration, HIP->LLVM lowering (+ `kWrap<Name>`), runtime wrapper (real +
+   mock + decl), HIP device kernel (+ header decl + `Kernels/CMakeLists.txt`),
+   and tests (lit conversion + e2e, numeric).
+5. Run the recently-edited files through the linter and fix issues.
+6. Do NOT build unless asked — report the build/run notes from the skill
+   (rebuild `build/hip-ep`, rebuild `custom_kernels_gfx1151`, clear
+   `%TEMP%\morphizen_mlir_*`, run via the NATIVE artifact path).
+
+A missing layer causes silent CPU fallback; a missing bufferization
+registration specifically produces `error: op was not bufferized`.

--- a/.cursor/commands/export-onnx.md
+++ b/.cursor/commands/export-onnx.md
@@ -1,0 +1,29 @@
+<!--
+Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+Licensed under the MIT License.
+-->
+# Export a model to ONNX
+
+Export the model I provide into an optimized ONNX model by authoring and running an
+Olive recipe, following the **export-onnx** skill end to end:
+@.cursor/skills/export-onnx/SKILL.md
+
+## Inputs (parse from the text after the command; ask only if genuinely ambiguous)
+- **Model link** (required): HuggingFace id/URL, GitHub repo/path, or a checkpoint URL.
+- **Input shape** (optional): e.g. `1x3x224x224`. Default to the model's documented inference size.
+- **dtype** (optional): `f16` (default) or `f32`.
+
+If no model link is present in my message, ask me for one before doing anything else.
+
+## What to do
+1. Confirm the source is in scope (single-image CNN or standard transformer per the skill).
+2. Do the one-time setup only if missing (Olive repos cloned, `hipdnn-ep` env deps).
+3. Author the recipe under `olive-recipes/<model-slug>/olive/` (`user_script.py`,
+   `config.json`, `run.py`), mirroring the canonical reference recipes.
+4. `cd` into the recipe's `olive/` dir and run `run.py` (background + wait on
+   `RUN_COMPLETE`); apply the fp16 duplicate-node post-fix for f16 exports.
+5. Verify the output `model.onnx` (checker, I/O names/shapes/dtypes, one ORT inference).
+6. Report: recipe path, output model path, detected `model_type`, and verified I/O.
+
+Follow the skill's exact pass/config names, environment conventions, and gotchas
+(especially running from the recipe's `olive/` dir).

--- a/.cursor/skills/add-hip-ep-op/SKILL.md
+++ b/.cursor/skills/add-hip-ep-op/SKILL.md
@@ -1,0 +1,77 @@
+<!--
+Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+Licensed under the MIT License.
+-->
+---
+name: add-hip-ep-op
+description: Add a new operator end-to-end across the hip-ep MLIR compiler stack (HIP dialect, ONNX-to-HIP conversion, bufferization, HIP-to-LLVM lowering, runtime wrapper, HIP device kernel, tests). Use when adding, implementing, or wiring up support for an ONNX op (native onnx.<Op> or com.microsoft onnx.Custom) in the hip-ep / hipgpu execution provider, or when an op fails with "op was not bufferized" or falls back to CPU.
+---
+
+# Add hip-ep Op End-to-End
+
+Add a new op across the full hip-ep MLIR compiler stack. First gather the op
+details if not provided: op name, ONNX source (native `onnx.<Op>` or
+`com.microsoft` `onnx.Custom`), math formula, attributes (name/type/default),
+and supported dtypes.
+
+Model each layer on an existing similar op:
+- Unary custom-kernel op: GELU
+- Float `alpha` attribute plumbing: LeakyRelu
+- `onnx.Custom` + `com.microsoft` domain matching: Gqa
+
+Missing any layer causes silent CPU fallback; a missing bufferization
+registration specifically produces `error: op was not bufferized`.
+
+Implement every layer below, then stop for the user to build.
+
+## 1. HIP Dialect
+- `hip-ep/include/hip/Dialect/IR/HipOps.td`: `def Hip_<Name>Op : Hip_DpsOp<"snake_name">`
+  with `Hip_ContextType:$ctx`, `Hip_TensorOrMemRef:$input/$output`, plus any attrs
+  (e.g. `DefaultValuedAttr<F64Attr, "1.702">:$alpha`).
+- `hip-ep/lib/Dialect/IR/HipDialect.cpp`: define `getDpsInitsMutable` + `getEffects`.
+
+## 2. ONNX -> HIP conversion
+- New `hip-ep/lib/Conversion/OnnxToHip/<Name>Conversion.cpp` with
+  `populate<Name>ConversionPatterns`. For `com.microsoft` ops, match `"onnx.Custom"`
+  and check `function_name` + `domain_name`. Build the op with `createEmptyTensor`
+  init + `getContextArg`.
+- Declare the populate fn in `OnnxToHipUtils.h`, call it in `OnnxToHip.cpp`
+  `convertComputeOps`, add the source to `OnnxToHip/CMakeLists.txt`.
+
+## 3. HIP -> memref (bufferization)
+- `hip-ep/include/hip/Dialect/IR/HipBufferize.h`: add
+  `<Name>Op::attachInterface<HipDstBufferizableModel<<Name>Op>>(*ctx);` in
+  `registerHipBufferizableOpInterfaceModels`.
+
+## 4. HIP -> LLVM lowering
+- `hip-ep/lib/Conversion/HipToLLVM/HipToLLVMUtils.h`: add `kWrap<Name> = "wrap_<name>"`.
+- `ActivationLowering.cpp` (or the relevant lowering file): add `<Name>OpLowering`
+  emitting the `wrap_<name>` call; register it in the `populate*LoweringPatterns` list.
+
+## 5. LLVM wrapper / host runtime
+- Declare `wrap_<name>` in `hip-ep/lib/Runtime/hipdnn_ep_runtime.h`.
+- Implement it in `hip-ep/lib/Runtime/real/<area>.cpp` dispatching to the kernel.
+- Add a mock stub in `hip-ep/lib/Runtime/mock/mock_gpu.cpp`.
+
+## 6. HIP device kernel
+- New `hip-ep/lib/Runtime/Kernels/hip/<name>_kernel.hip` (traits for f32/f16/bf16/f64;
+  `extern "C" int hip_<name>(...)` with dtype switch).
+- Declare `HIP_KERNEL_API int hip_<name>(...)` in `Kernels/include/hip_custom_kernels.h`.
+- Add the `.hip` to `Kernels/CMakeLists.txt` `_kernel_sources`.
+
+## 7. Tests
+- Lit: `test/lit/Conversion/onnx-to-hip/test_<name>.mlir` + e2e in `test/lit/e2e/`.
+- Numeric: extend the matching `test/numeric/tests/test_*.py`.
+
+## Build & run notes (report these; do not build unless asked)
+Rebuild via `build/hip-ep`; the kernel needs `custom_kernels_gfx1151` rebuilt too.
+Run on gfx1151 with the NATIVE artifact path (avoids the LLVM_IR JIT crash), TheRock
+DLLs on PATH, and a cleared model cache:
+
+```powershell
+$env:THEROCK_DIST="C:\Users\anilm\workspace\repos\rocm\therock-dist-windows-gfx1151-7.11.0"
+$env:PATH="$env:THEROCK_DIST\bin;$env:PATH"
+del $env:TEMP\morphizen_mlir_*
+./onnxruntime_perf_test.exe --plugin_ep_libs "hipgpu|hipgpu.dll" --plugin_eps "hipgpu" `
+  --plugin_ep_options "artifact_format|NATIVE" -t 1 -c 1 -s -I <MODEL_PATH>
+```

--- a/.cursor/skills/export-onnx/SKILL.md
+++ b/.cursor/skills/export-onnx/SKILL.md
@@ -16,9 +16,10 @@ description: >-
 
 Create and run an **Olive recipe** that converts a model into an optimized ONNX
 model, then verify it. Recipes live under a local clone of `microsoft/olive-recipes`
-at `%USERPROFILE%\workspace\olive-recipes\<model-slug>\olive\`. Mirror the
-canonical `nvidia-resnet50v1.5/olive/` (GitHub CNN) recipe; for a non-square
-transformer, mirror `microsoft-swinv2-tiny-patch4-window16-256/olive/`.
+(cloned into your workspace root, referred to below as `<workspace>`), at
+`<workspace>/olive-recipes/<model-slug>/olive/`. Mirror the canonical
+`nvidia-resnet50v1.5/olive/` (GitHub CNN) recipe; for a non-square transformer,
+mirror `microsoft-swinv2-tiny-patch4-window16-256/olive/`.
 
 NOTE: the team's vision recipes (`nvidia-resnet50v1.5`, `google-mobilenet_v2_1.0_224`,
 `qfgaohao-mb1-ssd`, `facebook-detr-resnet-50`, `ultralytics-yolov5lu`,
@@ -41,19 +42,20 @@ or weights only available behind a Google-Drive folder).
 - ❌ **Multi-view 3D-detection stacks** (PETR, BEVFormer, DETR3D): need the `mmdet3d`/`mmcv` ecosystem, multi-input camera geometry, and custom deformable/DCN ops that don't fit this CPU env or standard ONNX. Explain why and stop (offer only a backbone-only CNN stand-in).
 
 ## One-time setup (do first if missing)
-- **Repos**: clone both into `%USERPROFILE%\workspace` (shallow, to avoid the
-  known hang on large assets during a full clone):
+- **Repos**: clone both into your workspace root `<workspace>` (shallow, to avoid
+  the known hang on large assets during a full clone):
   `git clone --depth 1 https://github.com/microsoft/Olive.git` and
   `git clone --depth 1 https://github.com/microsoft/olive-recipes.git`.
-- **Env deps**: the `hipdnn-ep` env ships `onnx`, `onnxruntime-directml`,
+- **Env deps**: the `hipdnn-ep` conda env ships `onnx`, `onnxruntime-directml`,
   `transformers`, `onnx_ir` but NOT torch/olive. Install the rest:
   - `python -m pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu`
   - `python -m pip install olive-ai onnxscript`
   - Do NOT `pip install onnxruntime` — it collides with the installed
     `onnxruntime-directml`, which already provides `CPUExecutionProvider` (all
     Olive passes here run on CPU). Installing `olive-ai` does NOT pull it in.
-  - Env python: `C:\ProgramData\miniforge3\envs\hipdnn-ep\python.exe`
-    (conda root: `C:\ProgramData\miniforge3`).
+  - Env python: the `hipdnn-ep` env's interpreter under your conda/miniforge
+    install (find it via `conda env list`; e.g.
+    `<miniforge-root>/envs/hipdnn-ep/python.exe` on Windows).
 - Verified against **olive-ai 0.13.0** (pass/config names below match this).
   `onnxoptimizer` is optional (peephole logs a benign warning without it).
 
@@ -62,7 +64,8 @@ or weights only available behind a Google-Drive folder).
   ultralytics), use: `conda run --no-capture-output -n hipdnn-ep python ...`
   and set `PYTHONUTF8=1` (avoids a Windows cp1252 `conda run` crash). Running the
   env python directly (path above) with `$env:PYTHONUTF8=1` also works.
-- Scratch downloads/scripts go in `%USERPROFILE%\workspace\repos\rocm\cursor_workspace`.
+- Scratch downloads/scripts go in a scratch dir under your workspace
+  (e.g. `<workspace>/cursor_workspace`), referred to below as `cursor_workspace/`.
 - Do NOT `git clone` the **model source** repos (e.g. NVIDIA DeepLearningExamples) —
   they hang on assets. `curl` only the needed model definition file(s) from
   `raw.githubusercontent.com`. (The two Olive repos above are the exception:

--- a/.cursor/skills/export-onnx/SKILL.md
+++ b/.cursor/skills/export-onnx/SKILL.md
@@ -1,3 +1,7 @@
+<!--
+Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+Licensed under the MIT License.
+-->
 ---
 name: export-onnx
 description: >-

--- a/.cursor/skills/export-onnx/SKILL.md
+++ b/.cursor/skills/export-onnx/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: export-onnx
+description: >-
+  Export a vision/ML model given by a link (HuggingFace repo/URL, GitHub source
+  repo, or a checkpoint URL) into an optimized fp16 ONNX model by creating and
+  running an Olive recipe under olive-recipes/. Use when the user asks to
+  export/convert a model to ONNX, mentions an Olive recipe for a model, or pastes
+  a model link with an input shape/dtype for ONNX export.
+---
+
+# Export a model to ONNX (Olive recipe)
+
+Create and run an **Olive recipe** that converts a model into an optimized ONNX
+model, then verify it. Recipes live under a local clone of `microsoft/olive-recipes`
+at `%USERPROFILE%\workspace\olive-recipes\<model-slug>\olive\`. Mirror the
+canonical `nvidia-resnet50v1.5/olive/` (GitHub CNN) recipe; for a non-square
+transformer, mirror `microsoft-swinv2-tiny-patch4-window16-256/olive/`.
+
+NOTE: the team's vision recipes (`nvidia-resnet50v1.5`, `google-mobilenet_v2_1.0_224`,
+`qfgaohao-mb1-ssd`, `facebook-detr-resnet-50`, `ultralytics-yolov5lu`,
+`microsoft-swinv2-...`) are NOT in the public `microsoft/olive-recipes` — they are
+authored locally under the clone. If a referenced recipe is absent, author it from
+scratch using this skill (the public repo's `microsoft-resnet-50` is a *different*
+HF ResNet-50, not the NVIDIA v1.5 model).
+
+## Inputs (from the user's message)
+- **Model link** (required): HuggingFace model id/URL, GitHub repo/path, or a checkpoint URL.
+- **Input shape** (optional): e.g. `1x3x224x224`. Default to the model's documented inference size.
+- **dtype** (optional): `f16` (default) or `f32`.
+
+Ask a short clarifying question only if the source, input shape, or dtype is
+ambiguous AND it materially changes the result (e.g. multiple pretrained variants,
+or weights only available behind a Google-Drive folder).
+
+## Scope — is it exportable?
+- ✅ Single-image **CNNs and standard transformers**: ResNet, MobileNet, ViT, Swin, CLIP, DETR, SSD, YOLO, etc.
+- ❌ **Multi-view 3D-detection stacks** (PETR, BEVFormer, DETR3D): need the `mmdet3d`/`mmcv` ecosystem, multi-input camera geometry, and custom deformable/DCN ops that don't fit this CPU env or standard ONNX. Explain why and stop (offer only a backbone-only CNN stand-in).
+
+## One-time setup (do first if missing)
+- **Repos**: clone both into `%USERPROFILE%\workspace` (shallow, to avoid the
+  known hang on large assets during a full clone):
+  `git clone --depth 1 https://github.com/microsoft/Olive.git` and
+  `git clone --depth 1 https://github.com/microsoft/olive-recipes.git`.
+- **Env deps**: the `hipdnn-ep` env ships `onnx`, `onnxruntime-directml`,
+  `transformers`, `onnx_ir` but NOT torch/olive. Install the rest:
+  - `python -m pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu`
+  - `python -m pip install olive-ai onnxscript`
+  - Do NOT `pip install onnxruntime` — it collides with the installed
+    `onnxruntime-directml`, which already provides `CPUExecutionProvider` (all
+    Olive passes here run on CPU). Installing `olive-ai` does NOT pull it in.
+  - Env python: `C:\ProgramData\miniforge3\envs\hipdnn-ep\python.exe`
+    (conda root: `C:\ProgramData\miniforge3`).
+- Verified against **olive-ai 0.13.0** (pass/config names below match this).
+  `onnxoptimizer` is optional (peephole logs a benign warning without it).
+
+## Environment & conventions (must follow)
+- Run in the `hipdnn-ep` conda env. For models with rich console output (e.g.
+  ultralytics), use: `conda run --no-capture-output -n hipdnn-ep python ...`
+  and set `PYTHONUTF8=1` (avoids a Windows cp1252 `conda run` crash). Running the
+  env python directly (path above) with `$env:PYTHONUTF8=1` also works.
+- Scratch downloads/scripts go in `%USERPROFILE%\workspace\repos\rocm\cursor_workspace`.
+- Do NOT `git clone` the **model source** repos (e.g. NVIDIA DeepLearningExamples) —
+  they hang on assets. `curl` only the needed model definition file(s) from
+  `raw.githubusercontent.com`. (The two Olive repos above are the exception:
+  clone them shallow, once.)
+- For slow steps (large weight downloads, big exports), run in the background
+  (`block_until_ms: 0`), append `&& echo RUN_COMPLETE`, and wait on the output
+  pattern (`RUN_COMPLETE`/`Traceback`/`Error`) instead of long fixed timeouts.
+
+## Recipe layout — `olive-recipes/<model-slug>/olive/`
+1. **`user_script.py`** — a `model_loader(model_path=None)` returning the `.eval()` PyTorch model with pretrained weights.
+   - HuggingFace: load via `transformers`/`diffusers`; wrap so `forward` returns plain tensors (e.g. `out.logits`).
+   - GitHub source: vendor the minimal model file(s) into the recipe (as a package if it uses relative imports); shim tiny deps (e.g. a `timm` shim for `to_2tuple`/`DropPath`/`trunc_normal_`); auto-download the checkpoint (torch.hub / URL) in the loader, falling back to random init if unavailable (fine for perf benchmarking — note it).
+   - **torchvision shortcut**: when the GitHub model is a standard arch that
+     torchvision implements identically (e.g. NVIDIA `resnet50v1.5` == `torchvision.models.resnet50`),
+     build from torchvision and load its public ImageNet weights
+     (`ResNet50_Weights.IMAGENET1K_V2`) instead of vendoring + fetching an
+     authenticated NGC checkpoint. Weights don't change the exported graph or its
+     perf; note in the loader which weights (or random init) were used. This is
+     what the `nvidia-resnet50v1.5` recipe does.
+   - Rebuild at the requested input shape when it differs from default (drop resolution/window-derived buffers, load with `strict=False`).
+2. **`config.json`** — input model + `io_config`, passes in order. Exact type
+   string is `"PyTorchModel"` (GitHub source) with `"model_script": "user_script.py"`
+   and `"model_loader": "model_loader"`, or `"HfModel"`. `io_config` =
+   `input_names`, static `input_shapes` = requested shape, `output_names`. Passes:
+   - `conversion`: `OnnxConversion` (`target_opset` 17)
+   - `peephole`: `OnnxPeepholeOptimizer` (`onnxscript_optimize: true`, `fuse_reshape_operations: true`)
+   - `optimize`: `OrtTransformersOptimization` (auto-tuned by `run.py`, see below)
+   - `surgery`: `GraphSurgeries` — `"surgeries": [ { "surgeon": "DeduplicateNodes" }, { "surgeon": "InferShapes" } ]`
+   - `fp16`: `OnnxFloatToFloat16` (`keep_io_types: false`) — include only for f16
+   Define a `systems.local_system` (`"type": "LocalSystem"`,
+   `accelerators: [{ "device": "cpu", "execution_providers": [ "CPUExecutionProvider" ] }]`),
+   set `"host"`/`"target"` to it, and set `output_dir`/`cache_dir`.
+3. **`run.py`** — copy from `nvidia-resnet50v1.5/olive/run.py`. It:
+   - resolves `config.json` via `Path(__file__).parent`, loads the source model,
+     classifies **CNN vs transformer**, and patches the `optimize` pass;
+   - writes `config.generated.json`, calls `olive.workflows.run`, then applies the
+     fp16 post-fix (below).
+   - **Must run from the recipe's `olive/` dir**: `config.json` paths
+     (`model_script`, `output_dir`, `cache_dir`) are relative to cwd. Outputs land at
+     `olive/models/<output_dir>/model.onnx`; `cache/` and `config.generated.json`
+     are written there too (git-ignore / clean up).
+
+## `model_type` auto-detection (in `run.py`, for `OrtTransformersOptimization`)
+Supported ORT set: `bart bert clip conformer gpt2 gpt_neox mmdit phi qwen3 sam2 swin t5 tnlr unet vae vit`.
+- **CNN** (Conv-dominant, no attention): `model_type: "bert"`, `opt_level: 1`, ALL `optimization_options` off → ORT basic graph opt only (Conv+BN fold, const fold, DCE).
+- **Transformer** (has attention): keep the matched family (`vit`/`swin`/`clip`/…) if set, else default `bert`. For families not in the ORT set (e.g. `detr`), author `opt_level: 1` with fusions off (safe graph opt, no risky mis-fusions).
+- HuggingFace source with a local `config.json`: map its `model_type` to the ORT set (see `cursor_workspace/detect_model_type.py` if present, else map by hand).
+
+## fp16 duplicate-node post-fix (required in `run.py`)
+fp16 conversion can emit redundant `*_cast_to_fp32` nodes that share a node name
+AND redefine the same output tensor, which ORT rejects. After `olive_run`, load each
+output `model.onnx` and: drop nodes whose output name is already produced, uniquify
+duplicate node names, then **topologically re-sort** the graph. Canonical
+implementation: `fix_fp16_model` in `nvidia-resnet50v1.5/olive/run.py` (also in
+`ultralytics-yolov5lu`). The fix is a harmless no-op when there are no duplicates,
+so include it unconditionally for f16 exports.
+
+## Steps
+1. Identify source (HF vs GitHub vs checkpoint URL) and resolve input shape + dtype.
+2. Fetch/vendor the model definition + checkpoint; write `user_script.py`.
+3. Write `config.json`; copy/adapt `run.py`.
+4. `cd` into the recipe's `olive/` dir, then run:
+   `conda run --no-capture-output -n hipdnn-ep python run.py 2>&1 && echo RUN_COMPLETE`
+   (background + wait on `RUN_COMPLETE`). The export itself is fast (~10-15s once
+   weights are cached); the first run also downloads model weights.
+5. Verify `olive/models/<output_dir>/model.onnx`: `onnx.checker.check_model`, print
+   input/output names/shapes/dtypes (elem_type 10 = float16), and run one
+   onnxruntime inference (`providers=['CPUExecutionProvider']`, fp16 input) on random
+   input to confirm it loads and yields finite output.
+6. Report: recipe path, output model path, detected `model_type`, verified I/O.
+
+## Reference recipes (patterns to mirror; author under the local clone if absent)
+- `nvidia-resnet50v1.5` (GitHub CNN) — canonical `run.py`; uses the torchvision
+  shortcut (torchvision `resnet50` == v1.5) + `IMAGENET1K_V2` weights, `model_type: bert`,
+  `opt_level: 1`, all FusionOptions off. Output `[1,1000]` (add a 1001-class head only
+  if parity with an NVIDIA-trained checkpoint is required).
+- `microsoft-swinv2-tiny-patch4-window16-256` (transformer, non-square 512x1024).
+- `google-mobilenet_v2_1.0_224` (HF CNN via transformers).
+- `qfgaohao-mb1-ssd` (vendored package, detector, random-init fallback).
+- `facebook-detr-resnet-50` (HF hybrid CNN+transformer; needs `timm`).
+- `ultralytics-yolov5lu` (ultralytics; UTF-8/no-capture + fp16 post-fix).

--- a/backend-mlir-compiler/custom-op-mlir/CMakeLists.txt
+++ b/backend-mlir-compiler/custom-op-mlir/CMakeLists.txt
@@ -17,11 +17,17 @@ if(HIPDNN_EP_LINK_HIP_HOST)
   find_package(hip CONFIG REQUIRED)
 endif()
 
-# Re-import LLVM into this scope (already resolved transitively via
-# morphizen) so llvm_map_components_to_libnames works here.
-find_package(LLVM REQUIRED CONFIG)
-list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
-include(AddLLVM)
+# Re-import LLVM only when it comes from an external prefix. In the embedded
+# (from-source FetchContent) build LLVM_DIR is unset, and a find_package here
+# would wrongly resolve TheRock's LLVM from CMAKE_PREFIX_PATH -- mixing two
+# LLVMs into the EP DLL and crashing LLJIT in detectHost/~TargetOptions.
+# In that mode the parent scope already provides LLVM_INCLUDE_DIRS, AddLLVM,
+# and the LLVM targets, so just reuse them (as lib/Compiler etc. do).
+if(NOT HIPDNN_LLVM_EMBEDDED)
+  find_package(LLVM REQUIRED CONFIG)
+  list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
+  include(AddLLVM)
+endif()
 
 # Both RuntimeDyld and JITLink are required: LLJIT auto-selects the object
 # linking layer by triple -- RuntimeDyld on Windows (x86_64 COFF), JITLink on


### PR DESCRIPTION
## Summary
Consolidated PR for the Cursor agent tooling + a build fix, all rebuilt onto the current `main` after the repo-wide history rewrite. Supersedes #528 and #548.

## Contents
**Cursor skills & commands**
- `export-onnx` skill + `/export-onnx` command — author/run an Olive recipe to export a model to optimized fp16 ONNX.
- `add-hip-ep-op` skill + `/add-hip-ep-op` command — add a new operator end-to-end across the hip-ep MLIR compiler stack.

**Build fix**
- `custom-op-mlir/CMakeLists.txt` — avoid mixing two LLVMs in the embedded (from-source) build.

## Notes
- Draft. All new markdown files include the AMD license header (satisfies the `licenseheaders` pre-commit hook).
- Command files are committed directly, so they remain tracked without a `.gitignore` change.
- Perf-report tooling changes remain excluded.