### PR TITLE
docs: simplify contribution workflow guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,135 +4,65 @@ Licensed under the MIT License.
 -->
 
 <!--
-Thanks for contributing! Please skim the two policies this repo
-follows before requesting review (1-2 minutes each):
-
-  Incremental development:
-    https://llvm.org/docs/DeveloperPolicy.html#incremental-development
-  AI tool use:
-    https://llvm.org/docs/AIToolPolicy.html
-
-A short summary lives in CONTRIBUTING.md at the repo root. Each
-section below has an HTML comment explaining what to put in it; you
-can delete the comment after filling the section in.
+Thank you for contributing. Keep the description proportional to the change
+and review it for accuracy before requesting review. See CONTRIBUTING.md for
+the full workflow and AI-assistance disclosure requirements.
 -->
 
 ## Summary
 
-<!--
-1-3 sentences. What changed at a high level and what gap or bug it
-closes.
--->
+<!-- What changed and what user- or developer-visible effect it has. -->
+
+## Related issue or design
+
+<!-- Link the issue/design discussion, use "Fixes #123", or write "None". -->
 
 ## Why
 
-<!--
-Design rationale. What alternatives did you consider and why did you
-pick this one? This section is what reviewers use to skip ahead and
-agree with the design before reading the code. Even one paragraph is
-fine if the choice is obvious; for non-trivial design decisions, be
-explicit about the alternatives you rejected.
--->
+<!-- Explain the problem and rationale when the design choice is not obvious. -->
 
 ## What
 
-<!--
-Numbered list of concrete changes, with file references. Useful
-shapes:
-
-1. **New pass / op / runtime helper** at `path/to/file.cpp`. <one
-   sentence on the contract; one sentence on the predicate or scope>.
-2. **Pipeline placement / call-site update**: <where it slots in and
-   why that placement>.
-3. **Helper rename / API change**: <one sentence>.
-4. **Intentional non-changes**: <things the reader will expect to see
-   touched that aren't, with the reason>.
--->
+<!-- Optional for small changes. List concrete implementation details. -->
 
 ## Test plan
 
-<!--
-- Lit / pytest / runner commands you ran and the result (pass count,
-  numerics delta vs reference, etc).
-- Manual reproduction steps for behavioural changes (model name,
-  hardware, command).
-- For perf-sensitive changes, include a before/after table — see the
-  optional Performance section below.
--->
+<!-- List commands run and results, or explain why testing was not needed. -->
 
 ## Notes for reviewers
 
-<!--
-- Known limitations and what they would take to fix.
-- Follow-ups already planned (link the design issue / next PR).
-- Anything load-bearing that isn't obvious from the diff (invariants,
-  ABI assumptions, ordering constraints).
-- "None" is a valid answer if the PR is small and self-contained.
--->
+<!-- Optional: limitations, follow-ups, important assumptions, or ordering constraints. -->
 
 <!--
-============================================================
-Optional sections — include when applicable. Delete this whole
-block if you don't need any of them.
-============================================================
+Optional sections: remove this comment and keep the sections that apply.
 
-## Compiler IR walkthrough
+## Compiler IR
 
 <details>
-<summary><b>Before</b> — short description</summary>
+<summary>Before / after</summary>
 
 ```mlir
-// IR before this PR's pass / lowering
+// Before
 ```
 
-</details>
-
-<details>
-<summary><b>After</b> — short description</summary>
-
 ```mlir
-// IR after this PR's pass / lowering
+// After
 ```
 
 </details>
 
 ## Performance
 
-<details>
-<summary>Short headline result (e.g. "22x over DML EP on …")</summary>
+| Metric | Before | After |
+|---|---:|---:|
+| | | |
 
-| Metric | This PR | Baseline | Ratio |
-|---|---:|---:|---:|
-| Inferences/sec | … | … | … |
-| Mean latency | … | … | … |
-
-Hardware: gfxNNNN, model: <name>, build: <flags>.
-
-</details>
-
-============================================================
+Hardware, workload, build configuration, and measurement method:
 -->
 
 ## Checklist
 
-- [ ] **Incremental.** This PR is either standalone, or a planned step
-      in a documented series. If it exceeds ~500 LOC or ~10 files, the
-      Summary / Why explains why it cannot be split, OR links the
-      precursor PRs and the design issue. See:
-      https://llvm.org/docs/DeveloperPolicy.html#incremental-development
-- [ ] **AI policy.** If AI tools (Cursor, Claude, Copilot, etc.)
-      generated substantial code or text, the Summary discloses it,
-      the commit messages carry the trailers documented in
-      [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md#commit-message-trailers),
-      and you can answer questions about each design decision in
-      review without delegating back to the tool. See:
-      https://llvm.org/docs/AIToolPolicy.html
-- [ ] **No `good first issue` automation.** This PR is not an AI-tool
-      fix to an issue tagged `good first issue` (those are reserved as
-      learning opportunities for new contributors).
-- [ ] **Reviews resolved.** All review-comment threads from prior
-      rounds are resolved (enforced by branch protection on `main`).
-- [ ] **CODEOWNERS routing.** Reviewers were assigned automatically by
-      [`CODEOWNERS`](../blob/main/.github/CODEOWNERS). If the change
-      touches a path outside the current ownership map, the PR
-      description names the operational owner.
+- [ ] The change is focused, or links a design/series explaining its scope.
+- [ ] Relevant tests were added or updated and the results are documented.
+- [ ] User-facing or design documentation was updated when needed.
+- [ ] Substantial AI assistance is disclosed, and I reviewed and understand the result.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,294 +2,124 @@
 Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 Licensed under the MIT License.
 -->
-
 # Contributing to hip-ep
 
-This repo follows two contribution policies adopted from the LLVM
-project, with small adaptations noted below. Every PR is expected to
-honour both. The list will grow over time; for now this is the minimum
-bar for opening a PR on `main`.
+Thank you for contributing to hip-ep. We welcome improvements to the compiler, runtime, tests, documentation, and developer tooling. This guide explains how to prepare a change that is easy to review and safe to merge.
 
-- [Incremental Development](https://llvm.org/docs/DeveloperPolicy.html#incremental-development)
-- [AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html)
+hip-ep follows the LLVM project's guidance on:
 
-If you have not contributed here before, please skim the two LLVM pages
-linked above before opening a PR. They are short. The rest of this
-document explains how those policies translate into concrete
-expectations for this repo.
+- [Incremental development](https://llvm.org/docs/DeveloperPolicy.html#incremental-development)
+- [AI tool use](https://llvm.org/docs/AIToolPolicy.html)
 
----
+The sections below describe the project-specific workflow.
 
-## TL;DR
+## Before you start
 
-1. **Keep PRs small.** Large feature work should be decomposed into a
-   series of independent PRs (precursors first, then the main change).
-   ~1000 LOC / ~20 files is the soft threshold; bigger PRs need the
-   Summary section to explain why they cannot be split.
-2. **Human in the loop for AI-generated content.** You can use Cursor,
-   Claude, Copilot, or whatever helps you write code, but you are the
-   author and are accountable for the change. You must be able to
-   answer review questions about the work without delegating back to
-   the tool.
-3. **Disclose substantial AI usage.** Note it in the PR description
-   and use the commit message trailers documented in
-   [Commit message trailers](#commit-message-trailers) below.
-4. **Don't let AI tools fix `good first issue`s.** Those are reserved
-   as learning opportunities for new contributors.
-5. **Address every review comment.** Branch protection on `main`
-   requires every review-comment thread to be resolved before merge.
+- Search [existing issues](https://github.com/ROCm/hip-ep/issues) before opening a new one.
+- For a bug, include a minimal reproduction, relevant logs, platform details, and expected versus actual behavior.
+- Coordinate substantial work in a GitHub issue or discussion before implementation. This helps contributors avoid duplicate work and gives maintainers a chance to provide early design feedback.
+- Changes to public compiler/runtime ABIs, dialect semantics, artifact formats, or pipeline architecture should have a documented design discussion before implementation begins.
+- Use the [Windows quick start](docs/quick_start.md) or [Linux quick start](docs/quick_start_linux.md) to prepare a development environment.
 
----
+## Develop and validate
 
-## Incremental development
+Keep each change focused on one purpose. Add or update tests at the layer where the behavior is implemented:
 
-The full LLVM rationale is at
-<https://llvm.org/docs/DeveloperPolicy.html#incremental-development>.
-The points that bite hardest in this repo:
+- LIT tests for MLIR transformations and lowerings;
+- runtime unit tests for GPU-independent ABI and contract logic;
+- numeric tests for per-operation GPU-versus-CPU correctness;
+- E2E or model tests for full compiler/runtime behavior.
 
-> - Each change should be kept as small as possible. This simplifies
->   your work (into a logical progression), simplifies code review and
->   reduces the chance that you will get negative feedback on the
->   change. ...
-> - Large/invasive changes usually have a number of secondary changes
->   that are required before the big change can be made (e.g. API
->   cleanup, etc). These sorts of changes can often be done before the
->   major change is done, independently of that work.
-> - Often, an independent precursor to a big change is to add a new API
->   and slowly migrate clients to use the new API. ...
+See [test/README.md](test/README.md) for test commands and suite-specific guides.
 
-### What "small" means here
+Update documentation in the same PR when behavior, interfaces, pass ordering, configuration, or architecture changes.
 
-- **~1000 changed LOC** or **~20 changed files** (whichever is hit
-  first) is the soft threshold. PRs above this get the `large-pr`
-  label automatically as a reviewer signal — not a hard block.
-- A `large-pr` PR is acceptable when the work genuinely cannot be
-  split. **Listing a category below is not a free pass** — the
-  Summary / Why section must explain *why this specific change*
-  couldn't be sliced further, naming the parts you considered
-  extracting (precursor refactors, build/CI bumps, isolated test
-  fixtures, separable increments) and why each one would not be
-  reviewable on its own. Categories that have carried justified
-  `large-pr` size on this repo:
-  - a feature with irreducible cross-layer coupling (compiler +
-    runtime + tests that are only meaningful together);
-  - a coordinated rename or signature change across many call sites
-    where splitting would leave the tree uncompilable between PRs;
-  - a single test that exercises many paths.
-  Reviewers retain the right to apply the `extractive` label even
-  when a category applies, if the slicing argument doesn't hold up.
-- **Hard ceiling.** PRs above 2,000 LOC or 30 files require a
-  pre-PR design discussion linked from the description — a GitHub
-  issue, a sync-meeting agenda item, or a Teams thread with the
-  affected reviewers. At that size, "explain why in the PR
-  description" stops being a useful review tool; the design needs
-  to be agreed on before code is written.
-- A `large-pr` PR that *could* have been split but wasn't may be
-  marked `extractive` and asked to land as a series. See the
-  [Extractive contributions](#extractive-contributions) section
-  below.
+Run the repository checks before requesting review:
 
-### How to split
+```bash
+pre-commit run --all-files
+```
 
-A typical decomposition for a feature that touches the compiler and
-the runtime (the most common shape in this repo):
+Do not skip existing pre-commit hooks unless a reviewer explicitly approves it.
 
-1. **Precursor PRs** — refactors that don't change behaviour but make
-   the main change reviewable: factor a helper, rename a symbol, add
-   a TableGen option, introduce a runtime export with an old-symbol
-   fallback. Each lands on its own. Tag them with the
-   `incremental-precursor` label.
-2. **First increment** — the smallest end-to-end change that does
-   something useful. Often "add the new pass / op behind a flag,
-   default off". Lands once tests cover it.
-3. **Subsequent increments** — flip the flag, migrate callers, remove
-   the old path. Each is a separate PR.
+## Keep changes focused
 
-If you are unsure how to slice a change, open a design issue first
-and tag a reviewer for input before writing code. This is much
-cheaper than discovering during PR review that the structure is
-wrong.
+Small, focused PRs are easier to review, test, revert, and backport.
 
----
+- PRs over **1,000 changed lines** or **20 files** are automatically labeled `large-pr`. This is a reviewer signal, not a merge block.
+- PRs over **2,000 changed lines** or **30 files** should link a design discussion established before implementation.
+- A larger PR should explain why the change cannot be split into independently useful and reviewable steps.
 
-## AI tool use
+A typical compiler/runtime feature can often be divided into:
 
-The full LLVM policy is at <https://llvm.org/docs/AIToolPolicy.html>.
-Five points are load-bearing for this repo:
+1. behavior-preserving helpers or API preparation;
+2. the smallest useful end-to-end implementation, optionally behind a flag;
+3. caller migration and enablement;
+4. cleanup of the old path after the new path is proven.
 
-### Human in the loop
+If you are unsure how to divide a change, ask in an issue before investing in the full implementation.
 
-> Contributors must read and review all LLM-generated code or text
-> before they ask other project members to review it. The contributor
-> is always the author and is fully accountable for their
-> contributions.
+Maintainers may ask for a PR to be reduced or split when its review cost is disproportionate to the benefit of merging it. This is feedback on the shape of the change, not on the contributor.
 
-You should be sufficiently confident in the change that asking a
-maintainer to review it is a good use of their time. Concretely:
-during review, you must be able to answer questions about each
-design decision without delegating back to the tool. If you cannot,
-the PR is not ready.
+## Pull requests
 
-### Disclose substantial AI assistance
+Target the repository's default branch and use a draft PR while the change is still under development. Mark it ready and request review when:
 
-PR-level disclosure goes in the Summary section: a short note on which
-parts of the change were AI-assisted and how the output was validated.
-Commit-level disclosure goes via the trailers in
-[Commit message trailers](#commit-message-trailers) below.
+- the implementation is complete for the stated scope;
+- relevant tests pass;
+- documentation is current;
+- the description accurately reflects the diff;
+- known limitations and follow-ups are documented.
 
-The threshold for "substantial" is judgment, but a useful rule of
-thumb: if a reviewer would reasonably want to know that an LLM
-produced this code in order to ask sharper questions about it,
-disclose it.
+Link the relevant issue or design discussion when the change required prior coordination.
 
-### Write your own PR description
+The [pull-request template](.github/pull_request_template.md) asks for:
 
-Write the PR description yourself. Tools for translation,
-spell-check, or copy-editing are fine, but letting an LLM generate
-the entire description usually produces a longer, less-grounded
-text that doesn't match the actual code.
+| Section | What to include |
+|---|---|
+| Summary | Always: what changed and its user- or developer-visible effect |
+| Why | The problem and design rationale when the choice is not obvious |
+| What | Concrete implementation details for non-trivial changes |
+| Test plan | What was run and the result, or why testing was not needed |
+| Notes for reviewers | Optional: known limitations, follow-ups, important assumptions, or ordering constraints |
 
-### No automated reviews
+Keep the description proportional to the change. A small documentation or mechanical fix may need only a Summary and Test plan. A compiler/runtime design change usually benefits from all sections. Write the title and description so they remain useful in the project history after the PR is merged.
 
-Following LLVM's stance, **automated review tools that publish
-comments without human approval are not allowed** in this repo. An
-opt-in tool that routes through a human reviewer is fine. Posting an
-LLM's review verdict directly on a PR is not.
+Compiler changes may include a concise before/after IR walkthrough. Performance-sensitive changes should state the hardware, workload, build configuration, and measurement method.
 
-### `good first issue` is off-limits for AI
+PR descriptions may be prepared with tooling, but the contributor must review them for accuracy and own every claim.
 
-Issues tagged `good first issue` are explicitly reserved as learning
-opportunities for new contributors. Per LLVM's policy, fully
-automating those PRs squanders the learning opportunity and adds
-little value to the project. **Do not use AI tools to fix issues
-labelled `good first issue`.**
+Reviewers are assigned through [CODEOWNERS](.github/CODEOWNERS) where ownership is configured. After addressing feedback, re-request review so the updated PR returns to reviewer queues.
 
----
+## AI-assisted contributions
 
-## Extractive contributions
+AI tools are welcome as development aids. The contributor remains the author and is accountable for the submitted code and text.
 
-LLVM defines an *extractive contribution* as one where the cost of
-reviewing it is greater than the project's benefit from merging it.
-In practice, the patterns we see most often:
+When using AI tools:
 
-- A 5,000+ LOC PR touching the compiler, runtime, tests, and docs,
-  where the reviewer must hold the whole change in their head.
-- A "fixes everything" PR that bundles unrelated cleanups with a
-  feature change.
-- A PR that lands the output of an AI tool without the contributor
-  understanding the design enough to defend it in review.
+- review and understand all generated content before requesting human review;
+- validate the result with appropriate tests;
+- be prepared to explain every design decision without delegating the discussion back to the tool;
+- disclose substantial AI assistance in the PR description, including what was assisted and how it was validated;
+- use the commit trailers below for AI-assisted commits.
 
-If a maintainer judges that a PR fits this pattern, they will:
-
-1. Apply the `extractive` label.
-2. Comment with the LLVM-standard request:
-
-   > This PR doesn't appear to comply with our policy on
-   > tool-generated content, and requires additional justification
-   > for why it is valuable enough to the project for us to review
-   > it. Please see our developer policy on AI-generated
-   > contributions: http://llvm.org/docs/AIToolPolicy.html
-
-3. Ask the contributor to either reduce the scope, split it into a
-   series, or document why review cost is justified.
-
-This is not a personal judgement on the contributor — it is a
-statement that *the shape of the patch* is not a good fit for the
-project's review capacity right now. The fix is almost always to
-split.
-
----
-
-## PR description template
-
-Every PR is auto-populated with
-[`.github/pull_request_template.md`](.github/pull_request_template.md).
-The expected sections are:
-
-| Section | Always required? | What goes here |
-|---|---|---|
-| **Summary** | Yes | 1-3 sentences: what changed and what gap it closes. |
-| **Why** | Yes | Design rationale. Alternatives considered and why this one wins. |
-| **What** | Yes for non-trivial PRs | Numbered list of concrete changes with file references. |
-| **Test plan** | Yes | What you ran and the result. Numerics / TPS deltas where relevant. |
-| **Notes for reviewers** | Yes (use "None" if truly nothing) | Known limits, follow-ups, load-bearing invariants. |
-| **Compiler IR walkthrough** | Optional | For compiler-side changes — wrap before/after IR in a `<details>` block to keep the description scannable. |
-| **Performance** | Optional | For perf-sensitive changes — table comparing this PR vs baseline; mention hardware (gfx target, model, build flags). |
-
-You don't need every section on every PR. Small, single-purpose fixes
-can keep the description tight (Summary / Why / What / Test plan /
-Notes) and skip the optional sections entirely.
-
----
+Automated review tools may be used privately, but comments or verdicts must be reviewed and approved by a human before they are posted.
 
 ## Commit message trailers
 
-Every commit you author should carry these trailers in the body,
-separated from the message body by a blank line:
+For an AI-assisted commit, add these trailers after a blank line:
 
-```
-Co-Authored-By: <Tool or Person> <email>
+```text
+Co-Authored-By: <tool or model> <email>
 Made-with: <tool name>
 ```
 
-Examples used today on this repo:
+Use the model or tool that actually contributed to the change, and preserve the capitalization `Co-Authored-By`. For human collaborators, use the standard `Co-Authored-By` trailer for each collaborator.
 
-```
-Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
-Made-with: Cursor
-```
+If a pushed commit is missing attribution, do not rewrite reviewed history solely to add it. Add correct attribution to subsequent commits and note the omission in the PR when appropriate.
 
-```
-Co-Authored-By: Cursor <cursoragent@cursor.com>
-```
+## Review process
 
-Rules:
+Work with reviewers to resolve correctness, design, testing, documentation, and maintainability concerns. Address each review thread or explain why no change is needed.
 
-- Capitalisation is exactly `Co-Authored-By` (not `Co-authored-by`)
-  for AI tool attribution. Both forms are accepted by GitHub for
-  display purposes, but match the existing convention for grep-ability.
-- The model name in the trailer should match the model that actually
-  did the work (e.g. `Claude Opus 4.7`, `Claude Sonnet 4.5`,
-  `GPT-5`, `Cursor`).
-- Add the trailer on **every** commit you author, including test,
-  perf-attribution, and revert commits.
-- For multi-author work between humans, use the standard
-  `Co-Authored-By:` form for each collaborator.
-
-If a commit you authored does not carry the trailer, you may amend
-locally before push; if it has already been pushed and reviewed, do
-not force-push to amend — leave it and add the trailer on the next
-commit.
-
----
-
-## Other repo conventions
-
-- **Branch protection on `main`:** PR + 1 CODEOWNER approval, all
-  threads resolved, no force-push, no delete. Admins can bypass for
-  emergencies.
-- **CODEOWNERS:** see [`.github/CODEOWNERS`](.github/CODEOWNERS).
-  Every path is co-owned by at least three reviewers, so a single
-  person being unreachable does not block routing.
-- **Code style:** clang-format / black / lit-test conventions are
-  enforced by pre-commit. Run `pre-commit install` once per clone.
-- **Pre-existing pre-commit hooks must not be skipped** (no
-  `--no-verify`) unless explicitly approved by a reviewer.
-
----
-
-## Labels
-
-Reviewers may apply these labels to give shared vocabulary:
-
-| Label | Meaning |
-|---|---|
-| `extractive` | Review cost > project benefit. Needs to be split or made smaller. |
-| `large-pr` | Auto-applied when a PR exceeds the soft size thresholds. Reviewer signal, not a block. |
-| `incremental-precursor` | Standalone refactor that unblocks a larger upcoming change. |
-| `ai-assisted` | Substantial AI-generated content disclosed in the PR. |
-| `breaking-change` | Potentially-breaking change to a public API or runtime ABI. Surface in release notes. |
-
-This list will grow as additional policies (release-notes discipline,
-breaking-change handling, RFC process) are added on top of the two
-starting policies above.
+Maintainers may request additional tests, documentation, a smaller scope, or a design discussion before approving a change. Keep the conversation focused on the code, its behavior, and the evidence needed to merge it safely.


### PR DESCRIPTION
## Summary

- Rewrite the contribution guide with clearer setup, testing, PR, review, and AI-assistance guidance.
- Simplify the pull request template and align it with the documented workflow.

## Test plan

- [x] `pre-commit run --files CONTRIBUTING.md .github/pull_request_template.md`
- [x] `git diff --check -- CONTRIBUTING.md .github/pull_request_template.md`

Made with [Cursor](https://cursor.com)