### PR TITLE
Streamline shape inference and pool planning design docs

### DIFF
--- a/docs/design/compiler-runtime-contract.md
+++ b/docs/design/compiler-runtime-contract.md
@@ -17,6 +17,7 @@ Licensed under the MIT License.
 - [Schema: Single Source of Truth](#schema-single-source-of-truth)
 - [Embedding Mechanism](#embedding-mechanism)
 - [Current Fields](#current-fields)
+- [Generated-Code Runtime Inputs](#generated-code-runtime-inputs)
 - [Consumers](#consumers)
 - [Design Principles](#design-principles)
 - [Related Documents](#related-documents)
@@ -25,10 +26,11 @@ Licensed under the MIT License.
 
 ## Overview
 
-`schemas/model_metadata.fbs` is the **single source of truth** for the contract
-between the compiler and the runtime. Every piece of information the compiler
-needs to communicate to the runtime at code-generation time is expressed as a
-field in this schema.
+`schemas/model_metadata.fbs` is the **single source of truth for serialized
+model metadata** shared with artifact loaders and external consumers. It does
+not contain every compile-time value passed to runtime functions by generated
+LLVM IR. Transient memory planning is the canonical generated-code-only
+contract; see [Generated-Code Runtime Inputs](#generated-code-runtime-inputs).
 
 ```
   Compiler (GenerateInterface pass)
@@ -157,6 +159,31 @@ Dynamic dimensions are encoded as `-1`.
 
 ---
 
+## Generated-Code Runtime Inputs
+
+Some compiler/runtime coupling is encoded directly in generated LLVM calls
+rather than serialized in `model_metadata.fbs`. These contracts are internal to
+the compiled model and are documented by the design that owns the lowering.
+
+Pool planning is the canonical example:
+
+- `hip-pool-allocs` writes `hipdnn.pool_size`,
+  `hipdnn.buffer_count`, `hipdnn.buffer_offsets`, and optional
+  multi-domain attributes on the MLIR module.
+- `generate-interface` consumes the legacy attributes at compile time and emits
+  `hipdnn_ep_pool_init` only when all three are present and
+  `hipdnn.pool_size > 0`.
+- Each `hip.get_pool` lowers directly to
+  `hipdnn_ep_get_pool_base(state, domain_id, needed_size)`.
+- None of the `hipdnn.pool_*` or `hipdnn.buffer_*` attributes are fields in the
+  FlatBuffers schema or the JSON mirror.
+
+The generated LLVM IR plus `RuntimeState` therefore carry pool behavior. See
+[pool-allocs-memory-planning.md](pool-allocs-memory-planning.md) for the
+attribute, lowering, and grow-on-demand runtime contract.
+
+---
+
 ## Consumers
 
 | Consumer | Fields used | How |
@@ -168,14 +195,18 @@ Dynamic dimensions are encoded as `-1`.
 
 ## Design Principles
 
-**All compiler–runtime coupling goes through this schema.** If the compiler
-needs to pass information to the runtime, it adds a field here — not through
-a separate file, environment variable, or hardcoded constant.
+**Durable serialized metadata goes through this schema.** Add a schema field
+when information must be inspected by the loader or external consumers, or
+must remain available independently of generated code. Compile-time values
+used only to form calls inside the generated model may remain an internal
+lowering contract, but must be documented by the owning design and must not be
+described as part of `__metadata_blob`.
 
 ---
 
 ## Related Documents
 
 - [constant-handling-design.md](constant-handling-design.md) — how `constants_filename`, `sizes`, and `offsets` fields are produced and consumed
+- [pool-allocs-memory-planning.md](pool-allocs-memory-planning.md) — generated-code-only pool attributes and runtime calls
 - [morphizen-ep-integration.md](morphizen-ep-integration.md) — JIT loader contract; `inference_init` public interface
 - [compilation-options.md](compilation-options.md) — `constants_file` compilation option

--- a/docs/design/hip-shape-inference.md
+++ b/docs/design/hip-shape-inference.md
@@ -4,686 +4,238 @@ Licensed under the MIT License.
 -->
 # HIP dialect shape inference
 
-How HIP DPS (destination-passing-style) ops express their shape
-contract — verifier, `ReifyRankedShapedTypeOpInterface` impl,
-`--hip-infer-shapes` pass — and how to wire a new op into the same
-machinery.
+**Date:** 2026-07-24
+**Document Type:** Design
+**Status:** Implemented
+**Related:** [unranked-tensor-handling.md](unranked-tensor-handling.md), [pool-allocs-memory-planning.md](pool-allocs-memory-planning.md), [output-allocator-design.md](output-allocator-design.md), [compiler-runtime-contract.md](compiler-runtime-contract.md), [pipeline_pass_menu.md](../pipeline_pass_menu.md)
 
-## Goals
+## Purpose
 
-1. **Result types tracked through the converter.** A HIP DPS op that
-   declares `InferTypeOpInterface` lets the converter construct it
-   without restating the result type at every callsite — the
-   auto-generated `Op::create` overload reads the result type(s) from
-   the `outs` operand types. This keeps the DPS contract
-   `result_type == outs_operand_type` closed by construction. `hip.matmul`
-   is the worked example on #260 (`autoInfer=1, declareInfer=1`); other
-   DPS ops migrate in #262 when the parameterized base flips its
-   defaults to opt every single-result op in.
-2. **Reify dynamic dims.** When a result dim is `?` (`kDynamic`) at the
-   type level but is computable in terms of operand dims, the op exposes
-   that knowledge through
-   `ReifyRankedShapedTypeOpInterface::reifyResultShapes`. Downstream
-   `--resolve-shaped-type-result-dims` then folds `tensor.dim` of the
-   result into either an `arith.constant` (static dims) or a
-   `tensor.dim` of the relevant input (dynamic dims). The shared default
-   on `HipDpsOpInterface` (lifts from `getDpsInits()`) covers every
-   `Hip_DpsOp` whose result shape == outs shape; ops with tighter
-   contracts opt out via `autoReify=0` and ship a hand-written body in
-   `HipReifyResultShapesImpl.cpp`.
-3. **Module-level refinement.** The `--hip-infer-shapes` pass walks the
-   module, calls `reifyResultShapes` on every HIP-dialect op carrying
-   the interface, and refines `?` dims in result types in place —
-   including the DPS `outs` operand's `tensor.empty` producer, which is
-   necessary to keep the IR well-formed. Wired into the production
-   pipeline immediately after `convert-onnx-to-hip` (see
-   [Pipeline placement](#pipeline-placement)).
-4. **Static verification where it pays rent.** Ops with a non-trivial
-   static shape contract (canonical: `hip.matmul`'s
-   `[..., M, K] @ [..., K, N] -> [..., M, N]`) carry `let hasVerifier = 1`
-   and a per-op `verify()` driving the same shape helper used by Reify.
-   The default for new DPS ops is no verifier — the InferType-driven
-   `outs` typing already closes the DPS contract, and a Reify impl that
-   returns the wrong shape is caught by LIT cases under
-   `--hip-infer-shapes`.
+HIP destination-passing-style (DPS) operations expose shape information through standard MLIR interfaces. The design has four layers:
 
-`hip.matmul` is the worked example that exercises all four layers.
-Other ops compose the layers from a small helper menu chosen by shape
-contract — `reifyElementwiseSameShape` (input-shape passthrough),
-`reifyBroadcastShape` (NumPy broadcast), and dedicated helpers for
-permutation / reduction / gather. The "result shape == outs shape"
-case is the shared default on `HipDpsOpInterface` and covers most ops
-(every same-shape unary op, every multi-init outs-lift op, and every
-op whose output dims are arithmetic functions of operand values
-where the converter already encodes the runtime extent in `outs`);
-no per-op helper is needed. See [How to add a new op](#how-to-add-a-new-op)
-for the full table.
+1. **Construction-time result typing.** `InferTypeOpInterface` can derive tensor result types from DPS init operand types.
+2. **Dynamic-dimension reification.** `ReifyRankedShapedTypeOpInterface` exposes each result dimension as an `OpFoldResult`.
+3. **Module-level refinement.** `--hip-infer-shapes` uses reification to narrow dynamic result dimensions before bufferization while preserving DPS type equality.
+4. **Static verification.** Operations with non-trivial static shape contracts may add targeted verifiers.
 
-## Design rationale
+The implementation prefers standard MLIR interfaces, helpers, and canonicalization patterns over dialect-specific shape infrastructure.
 
-### Why `InferTypeOpInterface` + `ReifyRankedShapedTypeOpInterface`?
+Shape ownership is intentionally split:
 
-Three MLIR interfaces are relevant here:
-
-| Interface | Static shape | Dynamic shape | We use? |
-|---|---|---|---|
-| `InferTypeOpInterface` | yes (`inferReturnTypes`) | no | **YES** |
-| `InferShapedTypeOpInterface` | yes (`inferReturnTypeComponents`) | partial | no |
-| `ReifyRankedShapedTypeOpInterface` | implicit (IntegerAttr) | yes (Value) | **YES** |
-
-For DPS ops the result type is **tautologically tied** to the `outs`
-operand type — the result type IS the outs type, so an interface has
-nothing to "infer" from the inputs in the classical sense. The job
-`InferTypeOpInterface` does for us is different and concrete: the
-**converter** still has to construct each op, and on the legacy
-`Op::create` builder path every callsite has to spell out the result
-type list explicitly even though it is just the (already typed)
-`outs` operand type echoed back. `inferReturnTypes` moves that
-boilerplate into the op once — the auto-generated `Op::create`
-overload reads the outs operand types from the operation state and
-produces the result types. The auto-emitted body reads the outs SSA
-value via the op's typed adaptor (named by `outsAccessor`, default
-`"Output"`); if the value is a `RankedTensorType` it is pushed as the
-single result type, otherwise (memref mode) zero result types are
-returned — matching the rule that memref-mode DPS ops have no SSA
-results because the destination operand carries the writes through
-its memref descriptor. Every `OnnxToHip*Conversion.cpp` callsite then
-drops its explicit type list and relies on the inference; the matmul
-converter is the worked example on #260 (see
-`lib/Conversion/OnnxToHip/MatMulConversion.cpp`).
-
-### `HipDpsOpInterface` (in-dialect marker + default reify)
-
-The two interfaces above describe **what** the op promises the rest
-of MLIR. To avoid 53× per-op restatements of the "reify-from-outs"
-body, the dialect adds an in-dialect marker interface,
-`HipDpsOpInterface` (declared in
-[include/hip/Dialect/IR/HipDpsOpInterface.td](../../include/hip/Dialect/IR/HipDpsOpInterface.td),
-body in [lib/Dialect/IR/HipDpsOpInterface.cpp](../../lib/Dialect/IR/HipDpsOpInterface.cpp)).
-It carries one shared default `reifyResultShapes` that walks
-`getDpsInits()` and lifts each init operand's shape via
-`tensor::getMixedSizes` / `memref::getMixedSizes` — the
-identity-on-DPS contract.
-
-`Hip_DpsOp` (the TableGen base class for every DPS op) auto-emits the
-per-op `ReifyRankedShapedTypeOpInterface::reifyResultShapes` dispatcher
-via `extraClassDefinition`, forwarding to that interface default. A
-3-bit parameter set on the base controls per-op opt-out:
-
-| Parameter | Default | Effect |
+| Job | Owner | Pipeline position |
 |---|---|---|
-| `autoReify` | `1` | Auto-emit a per-op `reifyResultShapes` that delegates to `HipDpsOp::reifyResultShapes`. Set `0` for ops with a tighter contract (matmul) that provide a hand-written body in `HipReifyResultShapesImpl.cpp`. |
-| `autoInfer` | `0` | Auto-emit a per-op `inferReturnTypes` that reads the result type from the outs operand. Set `1` per-op when the op wants the InferType-aware `Op::create` builder. Opted in: `hip.matmul` on #260; `hip.rope`, `hip.rms_norm`, `hip.qmoe`, `hip.matmul_nbits`, `hip.gemm` on #262. Multi-result Hip_DpsOps (`hip.gqa`, `hip.layer_norm`, `hip.skip_rms_norm`) keep `0` because the auto-emit body pushes a single result type. |
-| `declareInfer` | `0` | Declare `InferTypeOpInterface` on the op (so converters can use the inferred-type `Op::create` overload). Set `1` in lockstep with `autoInfer`. |
-| `outsAccessor` | `"Output"` (37 ops) | ODS accessor name read by the auto-emitted `inferReturnTypes` body. Pass `"Y"` for ops with `$y` outs (12 ops), `"C"` for `hip.miopen.add` (`$C`), etc. |
+| Establish rank on an unranked loop-carried value | Importer contract and `--hip-infer-loop-body-shapes` | Before ONNX-to-HIP conversion |
+| Narrow `?` dimensions within known rank | `--hip-infer-shapes` | After ONNX-to-HIP conversion |
+| Fold `tensor.dim` through reification and reshape chains | `--hip-resolve-tensor-dims` | After shape refinement, before bufferization |
 
-The shape: the interface owns the default body in a sibling `.cpp`
-file; per-op dispatchers are auto-emitted by TableGen from the
-dialect's DPS base class. The opt-out lever (`autoReify=0`) gives
-ops with a tighter shape contract — `[..., M, K] @ [..., K, N] ->
-[..., M, N]` for matmul, or per-input-dim mappings (transpose,
-gather, reductions) — a clean escape hatch with no boilerplate.
-Note that `autoReify` and `autoInfer` are orthogonal: `hip.matmul`
-keeps `autoReify=0` (runtime dim recovery from operand shapes) while
-taking `autoInfer=1, declareInfer=1` (construction-time result type
-comes verbatim from the typed outs operand). The same split applies
-to other ops with bespoke reify (`hip.gemm`, `hip.qmoe`,
-`hip.matmul_nbits`) plus the shape-preserving `hip.rope` /
-`hip.rms_norm`. Ops whose output dims are arithmetic functions of
-operand values (`hip.range`, `hip.pad`, `hip.tile`, `hip.expand`,
-`hip.slice`, `hip.nonzero`) keep the default `autoReify=1` and lift
-their shape from the typed `outs` operand — the converter sets
-`outs` to `tensor.empty(<runtime extent>)` so a downstream
-`tensor.dim` on the result folds back to the SSA extent.
+ONNX-level shape inference remains upstream's responsibility. `--hip-infer-shapes` does not convert `UnrankedTensorType` into a ranked type; see [unranked-tensor-handling.md](unranked-tensor-handling.md).
 
-`ReifyRankedShapedTypeOpInterface` covers the orthogonal *dynamic-shape*
-job: per-dim `OpFoldResult`s for `--hip-infer-shapes` and the test
-pass `--resolve-shaped-type-result-dims`. Static dims fall out as
-`IntegerAttr`, dynamic dims fall out as `tensor.dim` (or `memref.dim`)
-of the operand they depend on. The interface and the test pass are
-both shipped by MLIR — the dialect plugs into them rather than
-forking equivalent infrastructure.
+## DPS shape contract
 
-The two interfaces compose cleanly with no overlap: InferType makes
-converters terse at op-construction time, Reify makes refinement work
-at module-walk time (`--hip-infer-shapes` calls reify, narrows result
-types in place, rebuilds outs producers). Verifier checks slot in on
-top — for ops with a non-trivial shape contract — sharing the same
-static shape helper (`inferMatmulShape`) that Reify lifts into
-`OpFoldResult`s.
+In tensor mode, each HIP DPS tensor result must equal the corresponding `outs` operand type. In memref mode, the operation has no tensor result; it writes directly through the destination memref.
 
-An earlier draft added a custom `HipShapeInferenceOpInterface` with an
-`inferOutputShape(...) -> SmallVector<int64_t>` static method. Dropped:
-the two MLIR interfaces above already cover both jobs (static type
-inference, dynamic dim reify), doubling up adds maintenance with no
-payoff, and the test-pass machinery is the test surface for free.
+This gives two related but distinct jobs:
 
-### Why a dedicated `--hip-infer-shapes` pass?
+- **InferType** avoids restating result types at converter call sites when the result is already represented by a typed destination.
+- **Reify** makes static and dynamic result dimensions available to downstream transformations.
 
-Two related MLIR passes already exist:
+## MLIR interfaces
 
-* **`--reify-result-shapes`** (memref dialect, MLIR 22): only `tensor::Pad`
-  / `tensor::Concat`; skips DPS ops by design.
-* **`--infer-static-shapes`** (newer): handles all
-  `ReifyRankedShapedTypeOpInterface` ops, but is **not in the pinned
-  MLIR** and is not DPS-aware (it does not refine the `outs` operand's
-  producer to keep the type chain well-formed).
-
-`--hip-infer-shapes` extends the same module-walk pattern with the
-DPS-aware producer refinement: when the outs operand is a single-use
-`tensor.empty`, the pass rebuilds it with the new static shape and
-drops any dyn-dim operands that became static. Shared empties (more
-than one use) and producers we don't know how to refine today
-(function args, other DPS ops higher in the chain) are skipped — the
-pass then leaves that result index at `?`.
-
-The pass restricts itself to **HIP-dialect ops**. Non-HIP-dialect ops
-that also implement the reify interface (`tensor::EmptyOp`,
-`tensor::ExtractSliceOp`, `tensor::PadOp`, …) carry per-op invariants
-between operand SSA values and the result shape (e.g.
-`tensor.empty(%dyn)` requires the dynamic-size operand count to equal
-the number of `?` dims in the result). An in-place `result.setType()`
-narrow on those would desync those invariants, and we deliberately do
-not duplicate those ops' folder/canonicalizer surface here. The
-canonicalizer is the right tool for non-HIP-op refinement; this pass
-is for HIP DPS op result types only.
-
-### Why DPS-aware?
-
-In a non-DPS world the pass could simply rewrite the op's result type
-and call it a day. DPS ops require `result_type == outs_operand_type`,
-so refining the result without matching the outs producer triggers a
-verifier error.  The simplest DPS-aware refinement we can do safely is
-to refine `tensor.empty` producers: that op is a pure constructor with
-trivial type semantics and its dyn-dim operand list maps 1:1 to the
-result's dynamic dims.
-
-For other producers (function args, results of an op we don't refine),
-the pass bails out at that result index and leaves the type as written.
-
-### Per-op refinement, not whole-chain
-
-When refining op `A`'s result, the pass inserts a `tensor.cast` back to
-the original type for every non-DPS-init use of the new value. That
-cast is a propagation BARRIER: a downstream consumer `B` that reads `A`
-through a non-DPS edge sees the OLD type at its `ins`, so `B`'s own
-`reifyResultShapes` runs against the OLD operand type. `B` can still
-refine its result, but only through the static dims its own helper can
-deduce locally — it does **not** transitively inherit `A`'s narrowing.
-
-This is intentional: a transitive narrowing scheme would require either
-retyping the cast (cascading into every downstream signature) or
-trusting that consumers tolerate a more-static `ins` (false in
-general). Per-op refinement is the local, terminating, verifier-safe
-choice. See `refine_chained_matmul` in
-`test/lit/Dialect/hip-infer-shapes.mlir` for the canonical example.
-
-That said, the "barrier" is leaky in a *good* way: when the consumer's
-`reifyResultShapes` materialises `tensor.dim %cast, i` via
-`tensor::getMixedSize` (which uses `createOrFold`),
-`tensor::DimOp::fold` looks through the cast and resolves to the
-underlying static size. So a chained DPS op whose operand is a cast of
-an already-refined value will still recover the static dim via the dim
-op, **without** giving up the cast-as-barrier on the `ins` edge type.
-The chained-matmul test exercises exactly this case.
-
-### MLIR helpers we lean on
-
-Where the implementation could be expressed via either a bespoke helper
-or a library-provided one, it consistently picks the library helper:
-
-| Need | Helper |
+| Interface | Role in hip-ep |
 |---|---|
-| Constant-int extraction from `OpFoldResult` | `mlir::getConstantIntValue(OpFoldResult)` (`mlir/Dialect/Utils/StaticValueUtils.h`) |
-| Re-typing a `RankedTensorType` while preserving encoding | `RankedTensorType::clone(ArrayRef<int64_t>)` (`mlir/IR/BuiltinTypeInterfaces.td` shared decl) |
-| `tensor.dim` of a value at a static-or-dynamic dim | `tensor::getMixedSize(OpBuilder &, Location, Value, int64_t)` |
-| IR mutation through an observable rewriter | `mlir::IRRewriter` |
+| `InferTypeOpInterface` | Builds result types from DPS init operand types |
+| `ReifyRankedShapedTypeOpInterface` | Materializes static dimensions as attributes and dynamic dimensions as SSA values |
+| `InferShapedTypeOpInterface` | Not used as the primary HIP DPS contract |
+| `HipDpsOpInterface` | Dialect marker interface extending `DestinationStyleOpInterface`; owns the shared default reification body |
 
-This keeps the HIP pass aligned with the rest of the dialect surface:
-when a future MLIR release ships a more general successor pass (e.g.
-`--infer-static-shapes`), retiring `--hip-infer-shapes` should be
-mostly a matter of substituting the new pass into `Pipelines.cpp` and
-re-running the LIT suite.
+`HipDpsOpInterface` is a generated MLIR `OpInterface`, but it is not a replacement for the standard InferType/Reify contracts. It marks HIP DPS compute operations and provides their shared default reification behavior: walk `DestinationStyleOpInterface::getDpsInits()` and return each destination's mixed sizes through `tensor::getMixedSizes` or `memref::getMixedSizes`.
 
-## Component layout
+Operations whose shape contract is more specific than "result shape equals destination shape" opt out of the default and provide a dedicated reification implementation.
 
-```text
-include/hip/Dialect/IR/
-  HipShapeUtils.h          -- public API: inferMatmulShape, verifyHipOpShape,
-                              reifyDimOrConstant, reifyElementwiseSameShape
-                              (added on #262 for ops whose result has the
-                              same shape as one designated input).
-                              Per-shape helpers reifyBroadcastShape /
-                              reifyTransposeByPerm / reifyGatherWithAxis /
-                              reifyGatherND / reifyReductionWithKeepdims
-                              land with the broadcast-op cleanup in #263.
-                              The one-shot wrappers reifyBroadcastShapeFor
-                              and reifyReductionShape (used as the bodies
-                              of `Hip_DpsOp_Broadcast` and
-                              `Hip_DpsOp_Reduction`'s auto-emitted reify
-                              dispatchers) live alongside them. Ops with
-                              value-dependent output dims (range, pad,
-                              tile, expand, slice, nonzero) defer to the
-                              shared `Hip_DpsOp` outs-lift default and do
-                              not need their own helper.
-  HipDpsOpInterface.td     -- in-dialect `HipDpsOp` interface declaration;
-                              carries the shared default `reifyResultShapes`
-                              that all `Hip_DpsOp`s inherit unless they opt
-                              out via `autoReify=0`
-  HipOps.td                -- `Hip_DpsOp` base auto-emits per-op
-                              `ReifyRankedShapedTypeOpInterface` dispatchers
-                              via `extraClassDefinition`, and from #260
-                              onward also auto-emits per-op
-                              `InferTypeOpInterface::inferReturnTypes` for
-                              ops that pass `autoInfer=1, declareInfer=1`
-                              (matmul on #260; rope, rms_norm, qmoe,
-                              matmul_nbits, gemm on #262). Per-op defs
-                              only carry the `autoReify` / `autoInfer` /
-                              `declareInfer` flags they need to override
-                              and `outsAccessor` when the outs SSA name
-                              is not `$output`. `let hasVerifier = 1`
-                              only when the op has a non-trivial shape
-                              contract (matmul today).
+## TableGen wiring
 
-lib/Dialect/IR/
-  HipShapeUtils.cpp                -- implementations + diagnostics
-  HipDpsOpInterface.cpp            -- shared default `reifyResultShapes`
-                                      body (walks `getDpsInits()`, lifts each
-                                      via `tensor::getMixedSizes` /
-                                      `memref::getMixedSizes`)
-  HipDialect.cpp                   -- per-op `verify()` (matmul only as of
-                                      #260, plus `LoopOp::verify()` added in
-                                      #261), `getEffects()`,
-                                      `getDpsInitsMutable()`, custom builders
-                                      / printers / parsers; `LoopOp::inferReturnTypes`
-                                      lives here next to its peers (control-flow op,
-                                      not a DPS compute op)
-  HipReifyResultShapesImpl.cpp     -- per-op `reifyResultShapes()` for ops
-                                      that opt out (`autoReify=0`) AND do
-                                      not match a parameterized sub-base,
-                                      one `// <OpName>` section per op.
-                                      Matmul is the only op in this file
-                                      on #260; `hip.rope` / `hip.rms_norm`
-                                      / `hip.qmoe` / `hip.matmul_nbits` /
-                                      `hip.gemm` join on #262; the bespoke
-                                      shape-changing ops `hip.transpose` /
-                                      `hip.gather` / `hip.gather_nd` join
-                                      on #263. Ops covered by a
-                                      parameterized sub-base contribute
-                                      ZERO per-op `.cpp` boilerplate: the
-                                      broadcast-op cluster (`hip.miopen.add`
-                                      / `hip.add` / `hip.mul` / `hip.min` /
-                                      `hip.div` / `hip.equal` / `hip.and`
-                                      / `hip.sub` / `hip.where` /
-                                      `hip.less` / `hip.mod`) is wired via
-                                      `Hip_DpsOp_Broadcast` in `HipOps.td`,
-                                      and the reductions (`hip.reduce_sum`
-                                      / `hip.reduce_max` /
-                                      `hip.reduce_prod`) via
-                                      `Hip_DpsOp_Reduction`. Both
-                                      sub-bases auto-emit the reify
-                                      dispatcher in `extraClassDefinition`
-                                      and call free helpers in
-                                      `HipShapeUtils.{h,cpp}`. Ops whose
-                                      output dims are arithmetic
-                                      functions of operand values (range,
-                                      pad, tile, expand, slice, nonzero),
-                                      the same-shape unary ops (silu,
-                                      sigmoid, softplus, gelu, reciprocal,
-                                      sqrt, not, cos, sin, neg, cast,
-                                      sign, cumsum, scatter_nd, size),
-                                      and the multi-init outs-lift ops
-                                      (gqa, mha, layer_norm,
-                                      skip_rms_norm, hipdnn_graph,
-                                      linear_attention,
-                                      causal_conv_with_state, conv,
-                                      miopen.softmax) all stay on the
-                                      shared `Hip_DpsOp` default
-                                      (`autoReify=1`) and contribute zero
-                                      `.cpp` boilerplate.
+`Hip_DpsOp` centralizes the interface boilerplate used by HIP compute operations.
 
-  (No HipResultTypeInferenceImpl.cpp today: every op that declares
-   `InferTypeOpInterface` so far is single-result, and the auto-emitted
-   body — push the outs operand's tensor type — is correct for them.
-   When a future op needs a hand-written body — most likely a
-   variadic-out op like `layer_norm` / `skip_rms_norm` / `hipdnn_graph`
-   that wants to declare `InferTypeOpInterface` — add a new
-   `HipResultTypeInferenceImpl.cpp` next to `HipReifyResultShapesImpl.cpp`,
-   wire it into `lib/Dialect/IR/CMakeLists.txt`, and follow the same
-   one-`// <OpName>`-section-per-op layout.)
+| Parameter | Default | Purpose |
+|---|---|---|
+| `outsAccessor` | `"Output"` | ODS accessor used by generated result-type inference |
+| `autoReify` | `1` | Emit a dispatcher to the shared `HipDpsOpInterface` reification body |
+| `autoInfer` | `0` | Emit `inferReturnTypes` using the DPS init tensor type |
+| `declareInfer` | `0` | Add `InferTypeOpInterface`; `autoInfer=1` requires it, while `declareInfer=1, autoInfer=0` requires a hand-written `inferReturnTypes` implementation |
+| `customReifyBody` | empty | Provide an inline custom body for parameterized DPS sub-bases |
 
-include/hip/Dialect/Transforms/
-  Passes.td                -- `def InferShapesPass` registration
+`Hip_DpsOp_Broadcast` and `Hip_DpsOp_Reduction` use `customReifyBody` to share broadcast and reduction reification across operation families without per-op C++ implementations.
 
-lib/Dialect/Transforms/
-  InferShapesPass.cpp      -- module-level walk; DPS-aware refinement
+Multi-result and specialized operations may keep inferred result construction disabled when a single generated body cannot describe all results.
 
-test/lit/Dialect/
-  hip-matmul-shape-verifier.mlir   -- matmul shape-contract verifier
-                                       positive + negative cases
-  hip-matmul-reify-shapes.mlir     -- driven by the
-                                       `--resolve-shaped-type-result-dims`
-                                       test pass
-  hip-loop-verifier.mlir           -- `hip.loop` v_init / result type
-                                       contract (added by #261)
-  hip-infer-shapes.mlir            -- consolidated `--hip-infer-shapes`
-                                       LIT, one section per op rolled out
-                                       across #260 - #264
-```
+## Shape-contract mechanisms
 
-### Why the per-interface split
+Choose the smallest mechanism that matches the operation's semantics:
 
-`reifyResultShapes` lives in its own translation unit because it grows
-on a different schedule from the rest of an op's machinery. Verifiers,
-`getEffects`, `getDpsInitsMutable`, and op-local builders touch the op
-once and rarely need maintenance after that. Reify implementations are
-non-trivial shape arithmetic that benefits from being read alongside
-each other (every dynamic-shape op solves a small variant of the same
-"lift static dims to `IntegerAttr`, dynamic dims to `tensor.dim` of
-the right operand" problem). The file follows a one-`// <OpName>`-
-section-per-op convention.
+| Shape contract | Mechanism |
+|---|---|
+| Result shape equals DPS init shape, including most multi-result DPS ops | Shared `HipDpsOpInterface` default |
+| Result shape equals a named input | `reifyElementwiseSameShape` or a small dedicated thunk |
+| NumPy-style broadcast | `Hip_DpsOp_Broadcast` and broadcast helpers |
+| Reduction with constant axes/keepdims | `Hip_DpsOp_Reduction` and reduction helpers |
+| Permutation | `reifyTransposeByPerm` |
+| Gather/GatherND/GatherElements | Gather-specific helpers or thunks |
+| OneHot, Compress, TopK | Dedicated reification thunks |
+| Pad, Tile, Expand, Slice, Range | Fold-or-bail helpers with fallback to DPS-init shape |
+| MatMul/Gemm/MatMulNBits | Dedicated shape logic based on operand dimensions and attributes |
+| Attention or normalization with multiple destinations | One shape vector per DPS init unless an op supplies a dedicated thunk |
+| Convolution, pooling, or resize with converter-computed destinations | DPS-init shape, with semantic validity handled by conversion or verification |
+| Runtime-dependent count, such as NonZero | DPS-init shape; unresolved dimensions remain dynamic |
 
-`inferReturnTypes` does NOT have its own translation unit today: the
-auto-emitted body in `Hip_DpsOp::extraClassDefinition` covers every op
-that opts in (single-result, result type == outs operand type). When a
-future op (most likely a variadic-out one) needs a hand-written body,
-add `HipResultTypeInferenceImpl.cpp` next to `HipReifyResultShapesImpl.cpp`
-following the same per-op-section layout.
+Shared helpers live in `HipShapeUtils.{h,cpp}`. Operations that set `autoReify=0` and are not covered by a parameterized sub-base define their member functions in `HipReifyResultShapesImpl.cpp`.
 
-The interface impls are **member functions, not external models** —
-`attachInterface` / `ExternalModel<>` is only needed when implementing
-an interface from *outside* the op's owning dialect. Inside the HIP
-dialect we own both the op and the interface impl, so a normal
-class-member definition in `HipReifyResultShapesImpl.cpp` is the right
-shape (and the same shape applies to a future
-`HipResultTypeInferenceImpl.cpp` when it lands).
+Pure descriptor transformations such as Reshape, Squeeze, and Unsqueeze generally lower to standard tensor operations rather than HIP DPS compute operations. Their shape inference and dim folding use MLIR's standard tensor interfaces and external models, not a second HIP-specific contract.
 
-When a future interface accumulates enough impls to deserve the same
-treatment (e.g. a dialect-defined op interface, a tiling interface, or
-a bufferization interface), follow the same pattern: a new
-`Hip<InterfaceName>Impl.cpp` next to the existing files, sectioned by
-op name, listed in `lib/Dialect/IR/CMakeLists.txt`.
+## Static result typing
+
+For a single-result DPS operation with `declareInfer=1` and `autoInfer=1`, ODS provides an inferred-type `Op::create` overload. The generated `inferReturnTypes` reads the typed DPS init and emits:
+
+- one result type in tensor mode;
+- no result type in memref mode.
+
+Converters may use this overload instead of passing an explicit result-type list. Migration is per operation; explicit-type builders remain valid. Static type inference and dynamic-dimension reification are orthogonal: an operation may implement either interface without the other.
+
+`InferTypeOpInterface` does not replace semantic shape verification. An operation such as MatMul may still verify that static operand dimensions satisfy its contract.
+
+The generated InferType body intentionally covers the uniform single-result case. Multi-result operations and operations whose result types are not a one-to-one copy of DPS init types may retain explicit builders or provide custom `inferReturnTypes`.
+
+## Dynamic-dimension reification
+
+Reification returns one `OpFoldResult` for each result dimension:
+
+- static dimensions become `IntegerAttr`;
+- dynamic dimensions become existing SSA values or `tensor.dim`/`memref.dim` operations;
+- value-dependent helpers fold constants when possible and otherwise fall back to the DPS init's mixed sizes.
+
+Reification is allowed to create IR at the caller's insertion point. Helpers therefore reuse operand dimensions where possible, fold constant operands and attributes, and avoid pretending that a runtime-computed extent is static. For operations whose runtime extent cannot be represented before execution, the honest result remains dynamic.
+
+Reification is per result: `reifyResultShapes` returns one shape vector for every tensor result. The number and rank of those vectors must match the operation's tensor results even when the implementation derives them from DPS init operands.
+
+## `--hip-infer-shapes`
+
+`--hip-infer-shapes` is a module pass that runs after ONNX-to-HIP conversion and before One-Shot Bufferize. It is restricted to HIP dialect operations.
+
+### Phase 1: refine HIP DPS results
+
+The pass collects operations in post-order so producers inside nested regions are considered before enclosing users. An operation is eligible only when all of the following hold:
+
+- it is in the HIP dialect and implements `ReifyRankedShapedTypeOpInterface`;
+- it has at least one ranked tensor result;
+- reification succeeds and returns one shape vector per operation result.
+
+For each eligible operation:
+
+1. call `reifyResultShapes`;
+2. preserve existing static dimensions;
+3. replace a dynamic dimension when reification produces a constant;
+4. for a result paired with a DPS init, rebuild its single-use `tensor.empty` producer with the refined type;
+5. update the operation result type;
+6. insert `tensor.cast` barriers for non-DPS uses that still expect the original type.
+
+Non-tensor and unranked results are skipped individually. If a DPS destination cannot be safely rebuilt—such as a function argument, shared producer, or unsupported init-defining operation—that result remains unchanged. Reification failure or a result-count mismatch skips the operation. A per-result rank mismatch violates the reification interface contract and is treated as an implementation error.
+
+The pass inserts one cast per refined result when needed. Pre-existing non-DPS-init uses are redirected through it, except a `func.return` whose declared result type was already synchronized to the refined type. This preserves the old type at unrelated consumer boundaries while the refined result and rebuilt destination keep the DPS equality invariant. Standard tensor folding can still recover static dimensions through the compatible cast.
+
+### Phase 2: synchronize loop signatures
+
+When Phase 1 refines a value feeding `hip.loop`, the pass propagates types to a fixed point:
+
+- synchronize loop result types;
+- synchronize the outlined body function's loop-carried argument and result types;
+- rerun local body refinement when narrowed entry types expose additional static information.
+
+The synchronization copies each loop init type to the corresponding loop result, outlined-body carried argument, and outlined-body function result. When the body signature changes, the pass re-runs local HIP result refinement so the existing terminator operands catch up. Casts are inserted on non-DPS uses of narrowed loop results when consumers still require the old type. This keeps loop operations, body signatures, terminators, and carried values type-consistent without rewriting unrelated function signatures. Phase 2 iterates to a fixed point, with a hard cap guarding against non-monotone implementation bugs.
+
+## Tensor-dimension resolution
+
+`hip-resolve-tensor-dims` runs after shape refinement and the following canonicalize/CSE. It folds `tensor.dim` through reification interfaces and reshape/view chains, including standard `tensor.expand_shape`, `tensor.collapse_shape`, and `tensor.pad`, so allocation-size arithmetic sees root tensor dimensions rather than opaque descriptor edits.
+
+This pass is complementary to `hip-infer-shapes`: shape inference narrows result types; tensor-dim resolution simplifies queries that remain in SSA.
+
+Do not confuse the two dim-resolution surfaces:
+
+- MLIR's `--resolve-shaped-type-result-dims` is the focused LIT surface for testing an operation's reification contract.
+- Production compiles use `--hip-resolve-tensor-dims`, which applies upstream reify-driven dim folds and tensor canonicalization to a fixed point.
+
+**Registry contract:** `tensor::registerInferTypeOpInterfaceExternalModels` must be registered in the dialect registry. Without it, upstream patterns silently no-op on standard tensor reshape/pad operations and opaque dim queries survive into bufferization, increasing pool fragmentation.
 
 ## Pipeline placement
 
-`--hip-infer-shapes` runs on `mlir::ModuleOp`, immediately after
-`convert-onnx-to-hip` and before `one-shot-bufferize`:
+[pipeline_pass_menu.md](../pipeline_pass_menu.md) documents pass names and extension anchors. The order source of truth is `lib/Dialect/Transforms/Pipelines.cpp`; the relevant segment is:
 
 ```text
-simplify-onnx -> hip-add-context-arg -> convert-onnx-to-hip
-              -> hip-infer-shapes
-              -> one-shot-bufferize -> ...
+simplify-onnx
+→ hip-add-context-arg
+→ onnx-loop-outline
+→ onnx-if-outline
+→ hip-infer-loop-body-shapes
+→ convert-onnx-to-hip
+→ hip-infer-shapes
+→ canonicalize
+→ CSE
+→ func.func(hip-split-duplicate-dps-inits)
+→ func.func(hip-resolve-tensor-dims)
+→ one-shot-bufferize
 ```
 
-Wired in `lib/Dialect/Transforms/Pipelines.cpp` at the top of
-`buildOnnxToHipPipelineTail` (the shared post-conversion segment used
-by both `buildOnnxToHipPipeline` overloads), so every production
-compile path gets it.
+`--hip-infer-shapes` runs before bufferization so static refinements affect destination construction, memref allocation sizes, and downstream pool planning.
 
-Refining tensor result types BEFORE bufferize is what makes the pass
-pay rent: static dims then propagate through the alloc / pool sizing
-computations, and bufferize stops emitting `memref.dim` ops at the top
-of the function. The pass is idempotent (a second invocation that
-finds no further refinements is a no-op) and a no-op on functions
-whose ops either don't carry the interface or expose no further
-refinable dims — safe to run unconditionally regardless of how much
-HIP-op coverage the interface currently has. As more
-HIP DPS ops (GQA, RmsNorm, SkipRmsNorm, Attention, RotaryEmbedding,
-…) gain reify impls, the wiring lets each new op participate without
-any change to `Pipelines.cpp`.
+Canonicalization and CSE run immediately afterward to fold dimensions made static by refinement and to deduplicate independently emitted shape arithmetic. `hip-split-duplicate-dps-inits` then repairs same-op DPS init aliasing before bufferization.
 
-### Pre-conversion sibling: `--hip-infer-loop-body-shapes`
+Static refinements propagate into bufferization sizing and downstream pool planning. For graph outputs they may also simplify `hip.alloc_output` shape operands; extents that remain dynamic are represented as `-1` in model metadata and are sized in-graph at runtime. Runtime-dependent counts such as `hip.nonzero` remain dynamic at both levels.
 
-`--hip-infer-shapes` only *narrows* `?` dims within a known rank on
-HIP-dialect ops; it cannot *establish* rank on a `tensor<*xT>`, and it
-runs after conversion. That leaves a gap for outlined `hip.loop` body
-functions: the importer emits `tensor<*xT>` for values whose shape it
-cannot infer (canonically a loop-carried `onnx.Concat` accumulating
-along the sequence axis), and `convert-onnx-to-hip`'s converters require
-ranked results (`ConcatConversion` bails on unranked). An unranked body
-output therefore blocks conversion *and* leaves the body `func.return`
-operand type-incompatible with the func signature.
+## Pre-conversion loop-body rank inference
 
-`--hip-infer-loop-body-shapes`
-(`lib/Dialect/Transforms/InferLoopBodyShapesPass.cpp`) closes that gap
-**before** conversion, modeled on onnx-mlir's `ONNXLoopOp::inferShapes`
-+ `inferFunctionReturnShapes`:
+`--hip-infer-loop-body-shapes` is a narrow pre-conversion backstop. It runs after loop outlining and before ONNX-to-HIP conversion to establish rank for unranked loop-carried values that would otherwise block conversion; it is not the general HIP shape-inference mechanism.
 
-```text
-simplify-onnx -> hip-add-context-arg -> onnx-loop-outline
-              -> hip-infer-loop-body-shapes      <-- pre-conversion
-              -> convert-onnx-to-hip
-              -> hip-infer-shapes                 <-- post-conversion (?-narrowing)
-              -> one-shot-bufferize -> ...
-```
+For each outlined `hip.loop` body it:
 
-For each `hip.loop` body func it (1) seeds the loop-carried block args
-from `$v_init`, (2) forward-infers unranked `onnx.*` results from
-operand types (currently `onnx.Concat`; extensible dispatch), (3)
-applies a loop-contract backstop (any still-unranked loop-carried output
-is set to its `$v_init` type — the ONNX Loop spec guarantees
-body-output type == loop-carried-input type), and (4) reconciles the
-body func signature from the now-ranked terminator operands. Rank is
-only *established* here; all `?`-dim narrowing remains the job of the
-post-conversion `--hip-infer-shapes`. Wired into both
-`buildOnnxToHipPipeline` overloads. LIT:
-`test/lit/Dialect/hip-infer-loop-body-shapes.mlir`.
+1. seeds carried block arguments from `v_init`;
+2. forward-infers supported unranked ONNX results (currently Concat);
+3. applies the ONNX loop-carried type contract as a fallback;
+4. reconciles the body function signature with the terminator.
 
-## How to add a new op
+The loop-carried fallback is authoritative: if a carried body output is still unranked, the pass assigns the corresponding ranked `v_init` type as required by the ONNX Loop contract. Interior unranked values without a forward rule remain unchanged. Post-conversion `--hip-infer-shapes` performs static-dimension narrowing within the established rank.
 
-For most new HIP DPS ops the recipe collapses to **two** edits:
-(1) declare the op via `Hip_DpsOp` in TableGen and (2) add a LIT case.
-The `Hip_DpsOp` base auto-emits a working `reifyResultShapes` so the op
-participates in dynamic-shape refinement without per-op `.cpp`
-boilerplate. Construction-time `inferReturnTypes` is also auto-emitted
-when the op opts in via `autoInfer=1, declareInfer=1` (matmul on #260;
-five transformer-block ops on #262: `hip.rope`, `hip.rms_norm`,
-`hip.qmoe`, `hip.matmul_nbits`, `hip.gemm`). Verifier and per-op
-overrides remain optional escape hatches when the op has a shape
-contract tighter than "result_type == outs_operand_type".
+## Adding or changing a HIP DPS operation
 
-**Stack rollout context.** Infrastructure lands in #260: the in-dialect
-`HipDpsOpInterface`, the parameterized `Hip_DpsOp` base, and matmul as
-the dual worked example — opt out of the default reify
-(`autoReify=0`, with a hand-written `MatmulOp::reifyResultShapes` that
-recovers M/K/N from operand shapes) AND opt in to auto-emitted
-inferReturnTypes (`autoInfer=1, declareInfer=1`, with the converter
-callsite dropped to the inferred-type `Op::create` overload). #261
-adds `InferTypeOpInterface` to `hip.loop` (region op, not DPS). #262
-opts five transformer-block ops in to auto-emitted `inferReturnTypes`
-(`hip.rope`, `hip.rms_norm`, `hip.qmoe`, `hip.matmul_nbits`,
-`hip.gemm`) and gives them hand-written `reifyResultShapes`, so
-`--hip-infer-shapes` refines through a typical decoder block end-to-end.
-#263 introduces `Hip_DpsOp_Broadcast` and migrates 23 ops. #264 cleans
-up the remaining bespoke ops.
+1. **Choose the contract row** in [Shape-contract mechanisms](#shape-contract-mechanisms).
+2. **Set TableGen parameters** on `Hip_DpsOp` or use an existing DPS sub-base; use `declareInfer=1, autoInfer=0` only when supplying custom InferType logic.
+3. **Add a shared helper** in `HipShapeUtils` only when no existing category fits.
+4. **Add a member reification implementation** in `HipReifyResultShapesImpl.cpp` only for `autoReify=0` operations not covered by a sub-base.
+5. **Return one shape vector per tensor result** and preserve dynamic extents honestly when no pre-execution SSA value exists.
+6. **Use the inferred-type builder** in the converter when the generated or custom InferType contract supports it.
+7. **Add a verifier** only for non-trivial static contracts not already closed by DPS typing.
+8. **Add LIT coverage** for tensor and memref modes, static and dynamic shapes, fallback behavior, multi-result behavior, and negative cases as applicable.
 
-### 1. Declare the op in TableGen
+Do not create a new shape interface when the standard InferType/Reify interfaces can express the contract.
 
-In [HipOps.td](../../include/hip/Dialect/IR/HipOps.td):
+## Tests
 
-```tablegen
-def Hip_MyOp : Hip_DpsOp<"my_op"> {
-  // ... arguments, assemblyFormat ...
-}
-```
+Primary regression coverage:
 
-`Hip_DpsOp` declares `MemoryEffectsOpInterface`,
-`DestinationStyleOpInterface`, `HipDpsOpInterface`, and
-`ReifyRankedShapedTypeOpInterface` (with an auto-emitted body that
-forwards to the shared default), and emits the
-`Variadic<AnyRankedTensor>:$result_tensors` result for tensor mode.
-Pass `outsAccessor` when the DPS init operand SSA name is not
-`$output` (common for unary elementwise ops that use `$y`):
+| File | Contract |
+|---|---|
+| `test/lit/Dialect/hip-infer-shapes.mlir` | Module-level static-dimension refinement and cast barriers |
+| `test/lit/Dialect/hip-infer-loop-body-shapes.mlir` | Pre-conversion rank establishment |
+| `test/lit/Dialect/hip-dps-op-interface.mlir` | Shared `HipDpsOpInterface` reification |
+| `test/lit/Dialect/hip-matmul-reify-shapes.mlir` | Per-op reification through `--resolve-shaped-type-result-dims` |
+| `test/lit/Dialect/hip-matmul-shape-verifier.mlir` | Static MatMul shape validation |
+| `test/lit/Dialect/hip-loop-verifier.mlir` | Loop-carried type contract |
+| `test/lit/Dialect/hip-resolve-tensor-dims.mlir` | Production pre-bufferization dim folding |
 
-```tablegen
-def Hip_SigmoidOp : Hip_DpsOp<"sigmoid", /*traits=*/[],
-                              /*outsAccessor=*/"Y"> { /* ... */ }
-```
+Complex operations may use dedicated files; common shape categories should extend the consolidated infer-shapes coverage.
 
-Add `let hasVerifier = 1;` only if the op has a non-trivial static
-shape contract worth verifying (matmul-style; default for new ops is
-no verifier — see step 4).
+## Current limitations
 
-### 2. (Optional) Per-op `reifyResultShapes` override
-
-Skip this step unless the op has a shape contract tighter than
-"result_type == outs_operand_type". The `Hip_DpsOp` base's
-auto-emitted body forwards to `HipDpsOp::reifyResultShapes` (in
-[lib/Dialect/IR/HipDpsOpInterface.cpp](../../lib/Dialect/IR/HipDpsOpInterface.cpp)),
-which walks `getDpsInits()` and lifts each via
-`tensor::getMixedSizes` / `memref::getMixedSizes`. For most ops this
-is exactly the right behavior: result shape == outs shape by DPS
-contract, and `--hip-infer-shapes` will narrow `?` dims in the result
-type from any static dims the outs operand carries.
-
-If the op has a tighter contract — matmul-style
-`[..., M, K] @ [..., K, N] -> [..., M, N]`, or value-dependent
-contracts like `hip.range` — opt out via `autoReify=0` and add a
-`// MyOp` section banner at the bottom of
-[HipReifyResultShapesImpl.cpp](../../lib/Dialect/IR/HipReifyResultShapesImpl.cpp).
-Pick the reify helper that matches the op's shape contract:
-
-| Op shape contract | Helper | Lands in |
-|---|---|---|
-| Result shape == outs operand shape (default) | (no helper — interface default in `HipDpsOpInterface.cpp`) | #260 |
-| Result shape == named INPUT operand shape (e.g. rope, rms_norm, qmoe) | hand-written body calling `reifyElementwiseSameShape(b, loc, getInput())` | #262 |
-| NumPy broadcast (add, mul, where, ...) | `Hip_DpsOp_Broadcast<[...]>` sub-base + `reifyBroadcastShape` | #263 |
-| Permutation (`hip.transpose`) | `reifyTransposeByPerm` | #263 |
-| Reduction with `keepdims` (reduce_sum, reduce_mean, reduce_max, reduce_prod) | `Hip_DpsOp_Reduction` sub-base + `reifyReductionWithKeepdims` | #263 |
-| Gather along an axis (`hip.gather`, `hip.gather_nd`) | `reifyGatherWithAxis` / `reifyGatherND` | #263 |
-| Multi-init outs-lifting (gqa, mha, layer_norm, ...) | shared `Hip_DpsOp` default (walks every DPS init via `getDpsInits()`) | #260 |
-| Value-dependent output dims (pad, tile, slice, expand, range, nonzero) | shared `Hip_DpsOp` default; the converter sets `outs` to `tensor.empty(<runtime extent>)` so a downstream `tensor.dim` on the result folds to the SSA extent. Per-op fold-on-constant helpers (`reifyPadShape` / `reifyTileShape` / `reifySliceShape` / `reifyExpandShape` / `reifyRangeShape`) deferred to a follow-up | #263 (default), #264 (helpers) |
-| Matmul-shaped (`[..., M, K] @ [..., K, N] -> [..., M, N]`) | call `inferMatmulShape` to compute output extents, then `reifyDimOrConstant` per dim | #260 (matmul) |
-
-If your op's contract is not in the table, write a new helper in
-`HipShapeUtils.{h,cpp}` and add a row.
-
-`reifyDimOrConstant` (used by the matmul-shaped row) returns
-`IntegerAttr` when the dim is static and a `tensor.dim` / `memref.dim`
-otherwise.
-
-The interface declarations are already in TableGen (step 1), so no
-header / `attachInterface` changes are needed — the linker resolves
-each member function to whichever `.cpp` file defines it.
-
-### 3. Data-dependent shape contracts (`hip.range`, `hip.nonzero`, ...)
-
-Some ops have output dims that depend on operand **values** (not
-operand types). `hip.range(start, end, step)` produces a 1D result
-whose extent is `(end - start) / step`; `hip.nonzero(input)` produces
-a 2D result whose first dim is the runtime count of nonzero entries
-in the input.
-
-These ops keep the default `Hip_DpsOp` reify (`autoReify=1`), which
-walks `getDpsInits()` and lifts each output dim from the typed `outs`
-operand:
-
-1. **Constant value operands at converter time** — the OnnxToHip
-   converter folds `(end - start) / step` (or the equivalent
-   per-axis arithmetic for pad / tile / slice / expand) and
-   constructs `outs` as `tensor.empty()` with the static extent
-   baked into the type. The default reify lifts that static dim
-   straight off `outs.getType()` as an `IndexAttr`.
-2. **Non-foldable** — the converter constructs `outs` as
-   `tensor.empty(%dyn)` with the runtime extent as a dynamic-size
-   operand. The default reify emits `tensor.dim %outs, i` for the
-   `?` dim; downstream `tensor.dim` consumers fold through to the
-   original `%dyn` SSA value.
-
-Ops where the runtime extent has no SSA representation at all (e.g.
-`hip.nonzero` whose count cannot be expressed before running the
-kernel) leave the dim as `?` — the only honest answer.
-
-A future per-op fold-on-constant helper layer (`reifyRangeShape`,
-`reifyPadShape`, ...) would let reify recover a static extent from
-constant SSA operands even when the converter emitted a dynamic
-`tensor.empty` — a refinement on top of the outs-lift baseline,
-deferred to a follow-up PR.
-
-### 4. Converter callsites (inferred-type `Op::create`)
-
-For ops with `declareInfer=1, autoInfer=1` (matmul on #260; five
-transformer-block ops on #262: `hip.rope`, `hip.rms_norm`, `hip.qmoe`,
-`hip.matmul_nbits`, `hip.gemm`), drop the explicit `resultType`
-argument from the `Op::create` callsite in
-`lib/Conversion/OnnxToHip/<MyOp>Conversion.cpp`:
-
-```cpp
-// Before:
-hip::MyOp::create(b, loc, /*resultType=*/outsType, ctx, lhs, rhs, outs);
-// After (auto-emitted body reads outs.getType()):
-hip::MyOp::create(b, loc, ctx, lhs, rhs, outs);
-```
-
-The InferType-aware `Op::create` overload is auto-generated by ODS
-once `InferTypeOpInterface` is declared. Existing callers that still
-pass an explicit type list keep working — the migration is mechanical
-and per-op. See `lib/Conversion/OnnxToHip/MatMulConversion.cpp` for
-the worked example on #260.
-
-### 5. (Optional) Verifier in `HipDialect.cpp`
-
-Only for ops with a non-trivial static shape contract — `hip.matmul`
-is the only such op as of #264. Implement `verify()` under the
-`// MyOp` section banner alongside the existing
-`getDpsInitsMutable()` / `getEffects()`:
-
-```cpp
-LogicalResult MyOp::verify() {
-  // Cross-cutting DPS contract check first.
-  if (failed(verifyDpsComputeOp(*this, {getA(), getB(), getOutput()},
-                                /*numInits=*/1)))
-    return failure();
-
-  // Static shape check via the shared helper. Empty result vector means
-  // the helper already issued a diagnostic.
-  return mlir::hip::verifyHipOpShape(
-      *this, [&]() -> SmallVector<SmallVector<int64_t>> {
-        SmallVector<int64_t> outShape = mlir::hip::inferMatmulShape(
-            getShapeOf(getA()), getShapeOf(getB()),
-            [&]() { return this->emitOpError(); });
-        if (outShape.empty())
-          return {};
-        return {std::move(outShape)};
-      });
-}
-```
-
-Most new ops do **not** need this. The InferType-driven outs typing
-already closes the DPS contract by construction, and a Reify impl
-that returns the wrong shape is caught by LIT cases under
-`--hip-infer-shapes` (step 6).
-
-### 6. LIT coverage
-
-Append cases to
-[test/lit/Dialect/hip-infer-shapes.mlir](../../test/lit/Dialect/hip-infer-shapes.mlir),
-one per shape pattern your op exercises (typically one static, one
-dynamic; for ops whose output dims are arithmetic functions of operand
-values also one fully-dynamic outs case to pin that the default
-outs-lift survives the pass intact — see `refine_pad_dps_out_fallback`
-for the canonical example). Per-op verifier / reify files
-(`hip-<op>-shape-verifier.mlir`, `hip-<op>-reify-shapes.mlir`) are
-reserved for ops complex enough to deserve their own file (matmul has
-both today; `hip.loop` has its own `hip-loop-verifier.mlir` for the
-v_init / result-type contract added by #261).
-
-## Open extensions
-
-The recipe in [How to add a new op](#how-to-add-a-new-op) is the canonical
-guide for adding shape inference to additional HIP DPS ops. Per-op rollout,
-dialect generalisation, and backward dim-origin tracing across `func.return`
-are tracked outside this document.
-
-### `hip.matmul` rejects rank-1 operands
-
-The verifier requires both `A` and `B` to have rank >= 2. ONNX `MatMul`
-permits rank-1 operands (vector-matrix / matrix-vector) via implicit
-unit-dim promotion and result unit-dim stripping. None of the currently
-supported transformer models exercise this case. For future models that
-do, the fix belongs in `lib/Conversion/OnnxToHip/MatMulConversion.cpp`:
-insert a `tensor.expand_shape` to rank-2 before constructing `hip.matmul`,
-then `tensor.collapse_shape` the result. Lowering (`MatmulLowering.cpp`)
-and runtime assume rank >= 2 today (indexing `aShape[rank-2]` and
-`bShape[rank-1]`); the verifier turns what would have been a
-silently-wrong hipBLASLt call into an explicit diagnostic.
+- ONNX MatMul rank-1 operands require promotion to rank 2 before constructing `hip.matmul`; the runtime and current verifier require rank at least 2.
+- Converter migration to inferred-type builders is incremental; explicit result-type builders remain supported.
+- A future multi-result operation that needs custom `InferTypeOpInterface` logic may require a dedicated result-type inference implementation file.
+- Runtime-dependent extents without pre-execution SSA remain dynamic.
+- Phase 1 only rebuilds supported single-use destination producers; shared or externally supplied destinations are left unchanged.
+- The pre-conversion loop-body pass has intentionally narrow ONNX coverage and is not a whole-graph solver.

--- a/docs/design/pool-allocs-memory-planning.md
+++ b/docs/design/pool-allocs-memory-planning.md
@@ -2,874 +2,265 @@
 Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 Licensed under the MIT License.
 -->
-# Pool-Allocs Memory Planning
+# GPU memory planning and PoolAllocs
 
-**Date:** 2026-06-06
+**Date:** 2026-07-24
 **Document Type:** Design
 **Status:** Implemented
-**Related:** [compiler-runtime-contract.md](compiler-runtime-contract.md), [constant-handling-design.md](constant-handling-design.md)
+**Related:** [pipeline_pass_menu.md](../pipeline_pass_menu.md), [compiler-runtime-contract.md](compiler-runtime-contract.md), [output-allocator-design.md](output-allocator-design.md), [constant-handling-design.md](constant-handling-design.md)
 
----
+## Purpose
 
-## Table of Contents
+The compiler uses a session-owned GPU memory plan for transient intermediate tensors. It replaces function-local `memref.alloc` operations with views into one or more grow-on-demand byte pools, avoiding per-inference `hipMalloc`/`hipFree` traffic.
 
-- [Overview](#overview)
-- [Pipeline Position](#pipeline-position)
-- [Cooperating Passes](#cooperating-passes)
-- [The hip-pool-allocs Algorithm](#the-hip-pool-allocs-algorithm)
-- [Module-Attribute Contract](#module-attribute-contract)
-- [Compiler-Runtime ABI](#compiler-runtime-abi)
-- [Design Decisions](#design-decisions)
-- [Worked Example: Two-Domain Partition](#worked-example-two-domain-partition)
-- [Failure Modes & Diagnostics](#failure-modes--diagnostics)
-- [Future Work](#future-work)
+Three constraints shape the design:
 
----
+1. **Steady-state inference performs no transient allocator calls.** Pools are reused across invocations.
+2. **Memory grows to a high-water mark and does not shrink during the session.** A larger input shape may grow a pool after synchronizing the stream.
+3. **Pool size and offset SSA must obey dominance.** In the single-block functions PoolAllocs accepts, dominance is textual order: a pool acquisition must follow every in-block dynamic-size definition it consumes and precede every allocation it replaces.
 
-## Overview
+When all dynamic sizes can be computed before the earliest pooled allocation, the function uses one pool. When a size depends on a non-speculatable value produced later in the block, PoolAllocs creates another **dominance domain** with its own acquisition point and runtime buffer.
 
-The MLIR compiler converts ONNX models into a single-block `func.func @main_graph` whose body contains hundreds of `memref.alloc` ops — one per intermediate tensor materialised on the GPU. Three constraints shape the memory plan:
+## Ownership model
 
-1. **No per-inference allocator traffic.** Any `memref.alloc` left intact at lowering becomes a runtime allocate + free pair issued on *every* inference. Allocator calls are expensive and sit on the critical path; a function that materializes many transient buffers pays that cost multiplied by the buffer count on every invocation. The plan must keep allocation off the per-inference path.
+- Pool memory belongs to `RuntimeState`, not to an inference call.
+- `hip.get_pool(%ctx, %size) {domain_id = N}` obtains the backing buffer for a domain.
+- Pool buffers grow on demand and are freed during session cleanup.
+- Pooled `memref.alloc` operations become `memref.view` operations; matching per-allocation deallocations are removed.
+- Graph outputs are not pooled. `hip-use-output-allocator` rewrites them to `hip.alloc_output`.
+- Tiny host-written shape buffers are not pooled. `hip-materialize-host-scalars` redirects them to session-owned host-mapped scratch.
 
-2. **Bounded, monotonic memory growth.** Buffers are reused across inferences, not re-acquired. A stable workload performs no allocator calls after warm-up; a workload whose required sizes grow pays one resize per new high-water size and never shrinks. The footprint grows only when the working set genuinely grows, never per inference.
+The default domain ID is zero and is omitted from textual IR. Additional domains print an explicit `domain_id`.
 
-3. **SSA dominance.** Every value consumed inside the function body must be dominated by its definition. That includes the size operand of `hip.get_pool` and the offset operand of every `memref.view` derived from it. With dynamic shapes — where alloc sizes are runtime arithmetic over input dims — emitting `hip.get_pool` at function entry forces every dim-arith chain to also live at function entry, which does not always hold.
+## Pipeline relationship
 
-Pool-allocs replaces every `memref.alloc` in `@main_graph` with a `memref.view` into one or more grow-on-demand byte buffers (`memref<?xi8>`) acquired via `hip.get_pool(%ctx, %size) {domain_id = N : i64}`. The buffers live on `RuntimeState` for the session lifetime; they grow on shape change and are freed at session cleanup. No per-inference allocator activity in the steady state.
+[pipeline_pass_menu.md](../pipeline_pass_menu.md) documents pass names and extension anchors. The order source of truth is `lib/Dialect/Transforms/Pipelines.cpp`; the passes immediately surrounding memory planning have distinct roles:
 
-The dominance constraint is what makes the design non-trivial: a single function-wide pool requires all alloc sizes to be computable above the earliest pooled alloc, which does not always hold. The design partitions allocs into **dominance domains**, each with its own pool acquisition point and its own runtime backing buffer.
-
----
-
-## Pipeline Position
-
-Several passes cooperate to produce the final pooled IR. The relevant stretch of `lib/Dialect/Transforms/Pipelines.cpp::buildOnnxToHipPipelineTail` is:
-
-```
-... (onnx-to-hip conversion)
-    → hip-infer-shapes                       (1b: refine `?` dims via ReifyRankedShapedTypeOpInterface)
-    → hip-resolve-tensor-dims                (1c: fold `tensor.dim` via upstream reify patterns)
-    → one-shot-bufferize                     (tensor → memref)
-    → buildBufferDeallocationPipeline        (insert ownership-based deallocs)
-    → hip-use-output-allocator               (returned memref.alloc → hip.alloc_output)
-    → CSE → canonicalize
-    → hip-optimize-memrefs                   (HIP-specific buffer cleanup)
-    → hip-promote-strided-hip-operands       (6a: contiguous temporaries for HIP-op operands)
-    → hip-materialize-host-scalars           (6b: redirect tiny host-fed scalars to host scratch)
-    → hip-hoist-alloc-size-arith             (6c: pull speculatable size arith above earliest dyn-alloc)
-    → hip-pool-allocs                        (this doc's main subject)
-    → ConvertBufferizationToMemRef → CSE → canonicalize
-    → hip-lower-allocs                       (memref.alloc → hip.alloc/hip.free for what's left)
-    → ...
+```text
+... hip-infer-shapes
+→ canonicalize → CSE
+→ hip-split-duplicate-dps-inits
+→ hip-resolve-tensor-dims
+→ one-shot-bufferize
+→ hip-loop-body-to-out-params
+→ buffer-deallocation pipeline
+→ hip-use-output-allocator
+→ hip-fix-loop-accumulator-offset
+→ CSE → canonicalize
+→ convert-linalg-to-loops
+→ hip-optimize-memrefs
+→ hip-promote-strided-operands
+→ hip-materialize-host-scalars
+→ hip-resolve-memref-dims
+→ hip-hoist-alloc-size-arith
+→ hip-pool-allocs
+→ convert-bufferization-to-memref
+→ CSE → canonicalize
+→ hip-lower-allocs
 ```
 
-The 1c step (`--hip-resolve-tensor-dims`) is **pre-bufferize and load-bearing**. It operates on `tensor.dim` queries against `tensor.expand_shape` / `tensor.collapse_shape` — operations that bufferize lowers to `memref.expand_shape` / `memref.collapse_shape` whose shape SSA (`output_shape` operands and reassociation maps) is opaque to the post-bufferize `memref.dim` patterns. Pre-bufferize is the last useful position. Without it, downstream `hip-pool-allocs` sees one scattered `memref.dim` query per reshape site and partitions them into separate dominance domains — graphs with per-layer same-rank dynamic `onnx.Reshape` (typical: norm / projection chains in transformer decoders) fragment into one pool per reshape site, wasting pool-prefix overhead and defeating the point of pooling (the partition is unbounded, so this degrades efficiency rather than failing compilation). After 1c, the chain bottoms out at `tensor.dim %arg, %const` on a function argument and pool-allocs sees a single domain. See the dedicated subsection in Cooperating Passes below.
+### Correctness and ABI preparation
 
-The 6a/6b/6c ordering is load-bearing and **load-bearing in the order shown** — the Pipelines.cpp comments around each `addNestedPass` call spell out why:
+`hip-promote-strided-operands` materializes contiguous temporaries for HIP runtime calls whose ABI carries a bare pointer but no offset/stride metadata. It must run before pooling so those temporaries become pool views.
 
-- **`hip-promote-strided-hip-operands` runs FIRST (6a).** Some HIP-op operands arrive as `memref.subview` / strided memrefs; the runtime ABI for `hip.*` ops only forwards a bare `alignedPtr` per memref operand (no offset / per-dim strides channel), so this pass materialises a contiguous temporary `memref.alloc` + copy for any strided operand. Those new transient allocs then need to flow through the rest of the buffer pipeline.
+`hip-use-output-allocator` must run after buffer deallocation and before pooling so returned buffers are neither cloned nor absorbed into the transient pool. See [output-allocator-design.md](output-allocator-design.md).
 
-- **`hip-materialize-host-scalars` runs SECOND (6b), AFTER promote-strided.** Tiny static-shape integer-or-index allocs (≤16 elements) with at least one host I/O user (`memref.store` or `memref.load`) must live in host-mapped memory acquired via `hip.get_host_scratch` — not in the GPU pool, where on some targets a host store SEGVs (real device memory) while on others it silently works (UMA-mapped). The "AFTER promote-strided" placement is what the file header at `MaterializeHostScalars.cpp` specifically calls out: any contiguous-temporary `memref.alloc` introduced by 6a must also be visible to the host-scalar candidate scan, and 6b must run BEFORE pool-allocs so candidates are removed from its input set.
+`convert-linalg-to-loops` must run before host-scalar materialization: a rank-zero `linalg.fill` must become `memref.store` before the host-I/O candidate scan.
 
-- **`hip-hoist-alloc-size-arith` runs THIRD (6c), immediately before pool-allocs.** It moves speculatable size-arith ops above the earliest dynamic alloc, reducing the number of dominance domains pool-allocs sees.
+`hip-materialize-host-scalars` redirects small integer/index buffers with host accesses to host-mapped scratch. It runs after allocation-producing rewrites and before PoolAllocs so host-written memory never becomes a view into device-only pool storage.
 
-Each pass has a single, named purpose — no internal phases that quietly do work belonging to a sibling pass. When something breaks, bisect by reading `--debug-only=<pass>` traces independently instead of one tangled snapshot.
+### Pool-quality preconditions
 
----
+`hip-resolve-memref-dims` folds post-bufferization `memref.dim` queries through view chains to root-buffer dimensions. These views may be created by bufferization or operand promotion, so this pass runs after both.
 
-## Cooperating Passes
+`hip-hoist-alloc-size-arith` moves speculatable dynamic-size arithmetic above the earliest dynamic allocation when the complete operand cone can move safely.
 
-### `hip-resolve-tensor-dims`
+Both passes preserve correctness when omitted, but omission may create more dominance domains and increase peak memory.
 
-A single `func.func`-nested pass, run between `hip-infer-shapes` and `one-shot-bufferize`. Resolves `tensor.dim` queries that arise from same-rank dynamic `onnx.Reshape` decompositions (e.g. transformer-decoder `q_norm`/`k_norm`/projection chains lowered as `tensor.expand_shape + tensor.collapse_shape` pairs). Without it, the queries cross the bufferize boundary as scattered `memref.dim` ops on the resulting reshape ops; pool-allocs then partitions per reshape site, fragmenting the function into many single-alloc domains and degrading pooling efficiency (the partition is unbounded, so this is a perf cost, not a compile failure).
+Pre-bufferization `hip-resolve-tensor-dims` serves a related purpose for tensor reshape chains. It lets upstream reification and canonicalization reduce `tensor.dim` queries before they become memref-level size arithmetic. Coverage of standard tensor reshape operations requires `tensor::registerInferTypeOpInterfaceExternalModels` on the dialect registry.
 
-#### Implementation
+## PoolAllocs algorithm
 
-A thin wrapper over upstream MLIR's `populateResolveRankedShapedTypeResultDimsPatterns` (and the `InferShapedTypeOpInterface` companion populator) plus the tensor-dialect canonicalisers (`tensor::DimOp::getCanonicalizationPatterns`, `tensor::ExpandShapeOp::getCanonicalizationPatterns`, `tensor::CollapseShapeOp::getCanonicalizationPatterns`), run as a single greedy fixed point.
+PoolAllocs operates on a single-block `func.func` whose first argument is `!hip.context`.
 
-The wrapper carries **no new logic** — every fold is performed by an upstream pattern. The pass exists only because the same fixed point composes patterns that live in different upstream populators (`memref::populate*` on one side, `tensor::*::getCanonicalizationPatterns` on the other) and we want them to converge against each other in one pass invocation, so chains like `dim(collapse(expand(arg)))` bottom out at `tensor.dim %arg, %const` in a single greedy run.
+Input contract:
 
-The mental model: any op implementing `ReifyRankedShapedTypeOpInterface` exposes its result shape as either static type info or a chain of SSA values reachable from its operands; the upstream `DimOfReifyRankedShapedTypeOpInterface` pattern dispatches `tensor.dim` of such an op through `reifyDimOfResult` → `reifyShapeOfResult` → `reifyResultShapes`, returning the appropriate `OpFoldResult` (a static `IntegerAttr`, an existing SSA value, or a freshly-built `affine.apply` over upstream-extracted source dims).
+- only used `memref.alloc` operations that are direct children of the entry block are candidates;
+- unused allocations are ignored;
+- allocations nested inside region-bearing operations are not pooled by the enclosing function's pass;
+- a single used allocation remains a valid candidate.
 
-#### Required external-model registration
+### Phase 1: liveness
 
-Coverage of `tensor.{expand,collapse}_shape` and `tensor.pad` requires `mlir::tensor::registerInferTypeOpInterfaceExternalModels(registry)` to have been called on the dialect registry. Upstream attaches the `Reify{Expand,Collapse,Pad}ShapeOp` external models (in `mlir/lib/Dialect/Tensor/IR/TensorInferTypeOpInterfaceImpl.cpp`) only when this registration runs; without it, the upstream patterns silently no-op on these ops and the bufferize boundary leaks every reshape-dim query as a `memref.dim` of a reshape op.
+For each used `memref.alloc`, compute:
 
-The registration is wired into `hip::compiler::registerAllDialects` in `include/hip/InitAllPasses.h` (which `CompilerDriver.cpp` calls via `loadAllDialects`) and into the inline registry built by `tools/hip-mlir-opt/hip-mlir-opt.cpp::main` (which builds its own registry rather than going through `registerAllDialects`). Both sites are load-bearing: omitting either loses coverage in that tool and lets a regression slip past LIT or end-to-end compile.
+```text
+[definition index, last transitive aliased use]
+```
 
-If a future MLIR rebase moves the registration into a different translation unit, ensure that translation unit links the `MLIRTensorInferTypeOpInterfaceImpl` library (the fold logic is in a separate static library from `MLIRTensorDialect` and is not pulled in transitively).
+`BufferViewFlowAnalysis` follows view-like aliases, including `arith.select` through an externally registered view-flow model. Deallocation operations are not treated as data uses. Nested-region users are mapped to their enclosing entry-block operation; users that cannot be mapped are conservatively treated as live to block end.
 
-#### Worked example
+Two allocations may share an address range only when their intervals do not overlap.
 
-Same-rank dynamic Reshape pair (the canonical transformer-decoder norm / projection trigger):
+### Phase 1.5: dominance domains
 
-Before:
+Allocations are processed in textual order. An allocation joins the most recent domain for which one insertion point can:
+
+- follow every in-block dynamic-size definition used by the domain; and
+- precede every allocation in the domain.
+
+If no existing domain is feasible, a new domain is created. Domain count is unbounded; an unusually high count emits a performance advisory rather than failing compilation.
+
+Minimal two-domain example:
 
 ```mlir
-%d0 = tensor.dim %arg0, %c0 : tensor<?x?x4096xf16>
-%d1 = tensor.dim %arg0, %c1 : tensor<?x?x4096xf16>
-%expand   = tensor.expand_shape %arg0 [[0], [1], [2, 3]]
-              output_shape [%d0, %d1, 32, 128]
-              : tensor<?x?x4096xf16> into tensor<?x?x32x128xf16>
-%collapse = tensor.collapse_shape %expand [[0], [1, 2], [3]]
-              : tensor<?x?x32x128xf16> into tensor<?x?x128xf16>
-%use = tensor.dim %collapse, %c1 : tensor<?x?x128xf16>      // queries seq*32
+%n = memref.dim %arg, %c0
+%a = memref.alloc(%n) : memref<?xf16>       // domain 0
+// ...
+%late = memref.load %host_shape[%c0] : memref<1xindex>
+%b = memref.alloc(%late) : memref<?xf16>    // domain 1
 ```
 
-After:
+`%late` cannot move above `%a` because it reads mutable memory. No one insertion point can follow `%late` while preceding both allocations, so `%b` opens a second domain.
 
-```mlir
-#map = affine_map<()[s0] -> (s0 * 32)>
-%d1  = tensor.dim %arg0, %c1 : tensor<?x?x4096xf16>
-%use = affine.apply #map()[%d1]                             // (reshapes are
-                                                            //  DCE'd because
-                                                            //  the dim was
-                                                            //  their only use)
+### Phase 2: static and dynamic split
+
+Each domain is partitioned into:
+
+- fully static allocations, whose byte sizes are compile-time constants;
+- dynamic allocations, whose byte sizes depend on runtime SSA values.
+
+### Phase 3: static packing
+
+Static allocations use greedy best-fit gap packing in byte space. Allocations with disjoint lifetimes may reuse the same offset.
+
+### Phase 4: dynamic packing
+
+Dynamic allocation size is:
+
+```text
+staticFactor × product(dynamic dimension SSA values)
 ```
 
-The static factor is folded INTO the affine map by upstream reify rather than emitted as a separate `arith.muli %dyn, %c32`. Downstream `--lower-affine` (already in `buildHipToLLVMPipeline`) lowers `affine.apply` to arith ops in time for `--convert-hip-to-llvm`.
+where `staticFactor` is the element byte width multiplied by all static dimensions.
 
-#### Pattern correctness
+Dynamic allocations use two paths:
 
-Inherited from upstream — `DimOfReifyRankedShapedTypeOpInterface` carries `setHasBoundedRewriteRecursion()` and the `ReifyShapeOfResult` -> `reifyResultShapes` chain returns a finite SSA construction per call. Greedy non-convergence calls `signalPassFailure()`, mirroring upstream `ResolveShapedTypeResultDimsPass`.
+1. **Aligned groups.** When `staticFactor` is a multiple of the pool alignment, allocations sharing the same dynamic-dimension SSA values share a common runtime factor `F`. Their integer static factors are packed with the greedy best-fit algorithm, then offsets and span are multiplied by `F`.
+2. **Small buckets.** When `staticFactor` is not alignment-multiple, allocations are bucketed by `{staticFactor, dynamic operands}` and placed into first-fit lifetime bins in byte space. This avoids multiplying alignment padding by `F` for tiny allocations.
 
-#### Idempotence
+### Phase 5: IR emission
 
-The pass emits no new `tensor.dim` ops on reshape operands once it has converged. A second invocation has no work; the LIT fixture `test/lit/Dialect/hip-resolve-tensor-dims.mlir` pins this down across the canonical cases (collapse with two/three dyn sources, mixed static/dyn, expand at static and dynamic slots, chained collapse-of-expand, fully-static tensors, no-op on functions without reshape-dim queries).
+For each domain, the pass emits:
 
-#### What this pass cannot fix
+- dynamic size arithmetic;
+- one `hip.get_pool`;
+- offset arithmetic;
+- one `memref.view` per original allocation.
 
-Queries reaching values produced by `memref.load` of a host-scratch slot or other memory-mutating ops survive into bufferize. Those are exactly the chains `hip-pool-allocs`'s multi-domain partition is designed to handle (the `%alloc_11` case in the worked example below). This pass removes the structural noise from reshape chains; the partition handles the residue.
+The domain pool size is:
 
-#### Retirement
-
-This pass retires entirely (pipeline call + LIT fixture removed) when any of:
-
-1. Upstream MLIR's `tensor::DimOp::fold` learns `tensor.expand_shape` / `tensor.collapse_shape` chains directly (the LIT fixture becomes a regression catcher for the upstream fold and the pipeline entry is removed; the external-model registration stays as cheap insurance).
-2. The compiler migrates to an IREE-style `ShapeAwareOpInterface` that carries explicit shape SSA on HIP-dialect ops, eliminating `tensor.dim` queries from dynamic-shape IR entirely.
-3. The same-rank dynamic Reshape decomposition in `ReshapeConversion.cpp` is replaced by a single op that emits no `expand_shape` / `collapse_shape` pair (the canonical trigger disappears; the pass keeps doing useful work for any other reshape-pair-emitting path).
-
-#### History
-
-The pass originally shipped as this upstream-pattern wrapper plus a separate custom-pattern pass `--hip-resolve-reshape-dims` that explicitly rewrote `tensor.dim` of `collapse_shape` and the SSA-valued slot of `tensor.dim` of `expand_shape`. The custom patterns were necessary because the upstream `Reify{Expand,Collapse}ShapeOp` external models had never been registered in this project's dialect registry — without registration, the upstream `DimOfReifyRankedShapedTypeOpInterface` pattern silently failed on every reshape-dim query.
-
-Once the registration was added, every case the custom pass handled folds via upstream as cleanly or cleaner (e.g. mixed static/dyn collapse groups become `affine.apply [s0 * 32]` instead of `arith.muli %dyn, %c32`), so the custom pass was retired and the wrapper now stands alone. End-to-end compile of dynamic-shape models also improved on this transition: the cleaner reify-driven IR (static factors folded into `affine.apply` rather than scattered `arith.muli`) composes better with bufferize's allocation sizing.
-
-### `hip-hoist-alloc-size-arith`
-
-Before:
-
-```mlir
-%alloc_a = memref.alloc(%dim) : memref<?xf16>     // earliest dyn alloc
-... unrelated ops ...
-%size_b = arith.muli %dim, %dim_0 : index         // could have lived above %alloc_a
-%alloc_b = memref.alloc(%size_b) : memref<?xf16>
+```text
+static prefix
++ sum(aligned-group runtime factor × packed span)
++ sum(small-bucket aligned size × bin count)
 ```
 
-After:
+Each original allocation is replaced at its original position, preserving its dynamic dimensions and memref type.
 
-```mlir
-%size_b = arith.muli %dim, %dim_0 : index         // hoisted
-%alloc_a = memref.alloc(%dim) : memref<?xf16>
-... unrelated ops ...
-%alloc_b = memref.alloc(%size_b) : memref<?xf16>
-```
+A domain with no dynamic groups and a zero-byte static prefix emits no `hip.get_pool` because there is nothing to reserve. Multi-domain metadata still records a zero static prefix for that domain when present.
 
-#### Hoist-eligibility predicate
+`hipdnn.buffer_offsets` records `-1` when a view offset is runtime SSA; non-negative values are compile-time byte offsets within the allocation's domain.
 
-There is **no fixed allow-list of op kinds.** The pass uses MLIR's standard `mlir::isSpeculatable` predicate (the same one upstream LICM uses) — any speculatable op is potentially hoistable. The recursive descent in `isReachableHoistable` (`HoistAllocSizeArith.cpp`) accepts an op iff:
+## Empty and single-allocation functions
 
-1. It lives in the entry block (out-of-block defs already dominate any in-block insertion point).
-2. It is below `earliestAlloc` (in-block but already-above-earliest defs already dominate).
-3. It is **not** a `memref.alloc` / `memref.alloca` (those are the things we're trying to make feasible — moving one would alter buffer lifetimes).
-4. It satisfies `mlir::isSpeculatable(op)` (e.g. `memref.load`, `func.call` without `NoSideEffect`, `hip.host_sync`, `arith.divsi` — anything that could trap or read mutable memory — fail this).
-5. **Every transitive operand** also satisfies the same recursion (or already dominates `earliestAlloc`).
+- A function with no body blocks (`funcOp.empty()`) is left unchanged and emits no pool module attributes.
+- If the entry block has no used `memref.alloc` candidates—because it has no allocations or every allocation is unused—PoolAllocs emits zeroed legacy pool attributes and makes no IR replacement.
+- A single used allocation is still pooled. Leaving it to lower as an unsupported per-inference device allocation is not a valid fallback.
 
-Condition 5 is the non-obvious one. A chain like `%loaded = memref.load …; %doubled = arith.muli %loaded, %c2; %alloc(%doubled)` looks half-hoistable — `%doubled` IS speculatable, but its operand `%loaded` is NOT. Moving `%doubled` above `%alloc` while `%loaded` stays below would break SSA dominance at the new `%doubled` site. The recursive check ensures we only hoist `%doubled` when its entire transitive cone is also hoistable.
+## Compiler/runtime contract
 
-#### Move algorithm (and why the "displacement property" matters)
+PoolAllocs writes MLIR module attributes:
 
-The recursive descent inserts each accepted op into a `SetVector` AFTER recursing into its operands — so the SetVector ends up in operand-before-use order. The pass then **forward-iterates** the SetVector and calls `op->moveBefore(earliestAlloc)` on each op:
-
-```cpp
-for (Operation *op : toMove)
-  op->moveBefore(earliestAlloc);
-```
-
-The non-obvious correctness mechanic is that each `moveBefore(earliestAlloc)` displaces every previously-moved op up by one slot — so the deepest operands (inserted first into the SetVector, moved first by the loop) end up at the top of the hoist region, and the closest-to-the-alloc ops (inserted last, moved last) sit just above `earliestAlloc`. Final layout: a topologically-ordered slice of the speculatable predecessor cone, operands at the top, uses at the bottom.
-
-A naive "move each op directly to the slot above its consumer" would require recomputing slot positions after every move; relying on the displacement property keeps the loop one line.
-
-#### Why a separate pass
-
-Pool-allocs's downstream invariant — every alloc's dyn-operand defs precede the earliest pooled alloc — becomes feasible for many more inputs without entangling pool-allocs's placement logic with backward-slice analysis. Tests for the two passes stay independent. When something breaks at the boundary, bisect by reading `--debug-only=hip-hoist-alloc-size-arith` and `--debug-only=hip-pool-allocs` separately instead of one tangled trace.
-
-#### Idempotence
-
-A second invocation finds nothing below `earliestAlloc` that still needs moving (everything in the cone now dominates), so the pass is a no-op. A LIT fixture pins this down.
-
-#### What hoisting cannot fix
-
-Chains that reach a `memref.load` of a value computed mid-block (the canonical case is a host-scratch slot used to pass a runtime-dependent scalar from CPU to GPU). Those chains stay where they are; pool-allocs handles them by partitioning into domains.
-
-### `hip-pool-allocs`
-
-The subject of this doc. It partitions allocations into dominance domains and replaces each `memref.alloc` with a `memref.view` into one of N independent, grow-on-demand runtime pools, acquired per domain via `hip.get_pool`.
-
-### Briefly: `hip-materialize-host-scalars`
-
-Some allocs need to be host-writable AND device-readable: the canonical case is a single `int64` carrying `total_seq_len` written by CPU code from a `memref.dim` and read by the GPU as the `seqlens_k` argument of a `hip.gqa` op. Putting these in the GPU pool is incorrect on architectures where `hipMalloc` returns true device memory (the host store SEGVs); on others it silently works because `hipMalloc` returns UMA-mapped host memory there, masking the bug.
-
-#### Candidate filter
-
-`isHostScalarCandidate` (in `MaterializeHostScalars.cpp`) accepts a `memref.alloc` iff:
-
-- **Static shape**, **≤ 16 elements**.
-- **Integer or index** element type. Float allocs are excluded because they are almost always GPU-consumed in flight, where the GPU pool is the right home.
-- **At least one host I/O user**: `memref.store` OR `memref.load` directly on the alloc. Either flavour is enough — both are the SEGV trigger on real-device-memory targets.
-- **All other users are either `memref.dim` / `memref.dealloc` OR any `hip.*` op.** This is the load-bearing inclusion: the canonical regression is `memref.alloc<i64>` → `memref.store<HOST>` → `hip.cast<GPU>`, and `hipHostMalloc(hipHostMallocMapped)` memory is GPU-readable on UMA so the bare-ptr ABI used by `--convert-hip-to-llvm` consumes the same buffer regardless of whether it was `hipMalloc`'d or `hipHostMalloc`'d. An earlier "no-hip-users" filter rejected this exact pattern → pass was a no-op → SEGV persisted.
-
-#### Rewriting
-
-All candidates in a function share a single `hip.get_host_scratch(%ctx, %total) : memref<?xi8>` op emitted at the entry block. Each candidate is rewritten to `memref.view %scratch[%offset]` at its original alloc site. Offsets within the shared scratch are **64-byte aligned** (matches the GPU pool's alignment scale and gives every candidate its own cache line); element sizes derived from `getIntOrFloatBitWidth()` (index = 64 bits). Original `memref.dealloc`s are erased — the scratch buffer is runtime-owned.
-
-Pool-allocs and host-scalars are mutually exclusive: an alloc is either pool-eligible or host-scalar-eligible, never both.
-
----
-
-## The hip-pool-allocs Algorithm
-
-Input contract (assumed by the pass; violations either signal failure or get skipped):
-
-- Function has exactly one block (`funcOp.getBody().hasOneBlock()`).
-- Argument 0 is `!hip.context` (run `hip-add-context-arg` before).
-- Every alloc whose result has at least one use is a candidate; allocs with `result.use_empty()` are ignored.
-
-Output: every input `memref.alloc` is replaced by a `memref.view %pool[%offset]` into one of N grow-on-demand `memref<?xi8>` pools. Per-domain `hip.get_pool(%ctx, %pool_size) {domain_id = N : i64}` calls are emitted at points that dominate every pooled alloc in their domain.
-
-Algorithm (executed in `runOnOperation` of `lib/Dialect/Transforms/PoolAllocs.cpp`):
-
-```
-Phase 1   - Liveness.
-            Index every op in the block (sequential `defIndex`).
-            For each alloc, follow view-flow aliasing transitively to find
-            `lastUseIndex` (highest index of any aliased use).
-
-Phase 1.5 - Domain partition.
-            Greedy textual-order clustering by dominance feasibility.
-            Output: SmallVector<Domain>, each carrying a vector of allocs.
-
-Phases 2..5 (per domain):
-  Phase 2 - Static / dynamic split for this domain.
-  Phase 3 - Static packing: greedy best-fit gap-finding offset assignment.
-  Phase 4 - Dynamic packing: bucket by structural byte-size key, bin-pack
-            within bucket by lifetime.
-  Phase 5 - IR emission: per-bucket size arith, hip.get_pool, per-alloc
-            offset SSA, view replacements.
-
-Module metadata:
-  Always: legacy single-domain attrs (hipdnn.pool_size, hipdnn.buffer_count,
-          hipdnn.buffer_offsets).
-  When domain count > 1: also emit hipdnn.domain_count, hipdnn.pool_sizes,
-          hipdnn.buffer_domains (informational module metadata; NOT read by
-          GenerateInterface or the runtime -- see Module-Attribute Contract).
-```
-
-### Phase 1: Liveness Analysis
-
-For each alloc, compute `[defIndex, lastUseIndex]` using the helper `findLastAliasedUseIndex` in `BufferUtils.cpp`:
-
-- `defIndex` = sequential position of the alloc's `Operation*` in the block.
-- `lastUseIndex` = maximum `defIndex` over all uses of the alloc's result, **transitively through view-flow ops** (`memref.view`, `memref.subview`, `memref.cast`, `memref.expand_shape`, `memref.collapse_shape`, etc.) computed via MLIR's `BufferViewFlowAnalysis`.
-
-Two non-obvious behaviours of `findLastAliasedUseIndex`:
-
-- **Users in nested regions** (e.g. an `scf.for` body that consumes a view of the alloc) are mapped to their enclosing op's index in the entry block via `block.findAncestorOpInBlock`. Without this, a use inside a region would not be findable in `opIndex` and would be treated as "no users".
-- **Users unreachable from the entry block** conservatively return `blockSize - 1` (one past the last in-block op), making the alloc live to function exit. Strictly conservative — this branch is a defensive fallback, not a hot path.
-
-`PoolAllocs::getDependentDialects` registers `arith::registerBufferViewFlowOpInterfaceExternalModels` so view-flow tracking correctly follows `arith.select` of two memrefs (a value-flow case the upstream `BufferViewFlowAnalysis` would otherwise miss).
-
-Two allocs `A` and `B` have **overlapping lifetimes** iff their `[defIndex, lastUseIndex]` intervals overlap. Non-overlapping allocs may share offset slots in subsequent phases.
-
-`staticByteSize` is computed from the alloc's MemRefType (`getStaticByteSize` in `BufferUtils.cpp`): if the type is fully static, it is `elementBytes * product(shape)` rounded to a byte boundary. For dynamic shapes it is 0 (signalling the dynamic path).
-
-The single-block constraint is what makes sequential indices a valid liveness model. Multi-block / region-bearing functions would need MLIR's full `Liveness` analysis; today the upstream pipeline never produces multi-block `@main_graph` (control flow is collapsed into ops like `hip.if`, `hip.loop` whose regions are treated opaquely).
-
-### Phase 1.5: Dominance-Domain Partition
-
-The hardest and newest part of the design.
-
-A **domain** is a subset of pooled allocs whose `hip.get_pool` can share a single insertion point that
-
-- comes **strictly after** every dynamic-size operand definition reachable from any alloc in the domain, AND
-- comes **strictly before** every alloc in the domain.
-
-Such a position lets one `hip.get_pool` dominate every alloc in the domain, while every dyn-operand SSA value dominates the pool acquisition.
-
-The helper `findLatestLegalInsertionPoint(block, requiredAfter, requiredBefore)` returns the latest in-block iterator satisfying both constraints, or `std::nullopt` when no such point exists. (Implementation: take the latest op in `requiredAfter` as `lo` and the earliest in `requiredBefore` as `hi`; the answer is `std::next(lo)` iff `lo` is strictly before `hi`.)
-
-A domain is **feasible** iff `findLatestLegalInsertionPoint` over the union of (dyn-operand defs) and (allocs themselves) returns a value.
-
-#### Greedy clustering rule
-
-```
-domains = []
-for alloc in allocs sorted by defIndex:
-  for D in reversed(domains):              // most-recent first
-    speculatively add alloc to D
-    if D ∪ {alloc} is feasible: keep, break
-    else:                                   roll back
-  else:                                    // no D accepted
-    domains.append(Domain([alloc]))         // unbounded — one more pool
-return domains
-```
-
-Why most-recent-first: domains created later have later first-allocs, so their dominance window is the strictest. If alloc `A`'s dyn-operand chain lives above the latest-created domain `D_recent`, the merge into `D_recent` succeeds; if `A`'s dyn-defs are below `D_recent`'s earliest alloc, they are structurally below every earlier domain's earliest alloc too, and merging anywhere will fail. So the first feasible domain is always the most recent one. We still walk reverse order to remain robust against future reorderings.
-
-Why greedy textual-order: the ordering of allocs in the block IS the dataflow order. Processing in `defIndex` order means each alloc only ever joins a domain whose earlier members are already settled — no backtracking needed.
-
-#### Single-domain output
-
-In the common case (after `hip-hoist-alloc-size-arith` has run), every alloc's dyn-operand defs dominate every pooled alloc, so the first probe of `D[0]` always succeeds and the partition returns a single domain containing every alloc. Phases 2..5 then run on that single domain exactly as they would with no partitioning step at all — single-domain IR and metadata are identical whether or not a second domain is ever needed.
-
-#### Multi-domain output
-
-A second domain opens iff some alloc's dyn-operand chain comes from values defined **below** the earliest alloc of every existing domain. The canonical trigger is a `memref.load` from a host-scratch slot whose `memref.store` lives between two pooled allocs — the load cannot be hoisted (memory side effect) and the alloc that consumes it cannot share a domain with allocs above the load.
-
-**The domain count is unbounded — there is no compile-time cap.** The partition produces exactly as many domains as the dataflow requires (real graphs produce 1, canonical, or 2, one host-load chain), and the runtime backs them with per-domain pool arrays that grow on demand — `num_pool_domains` starts at 1 (domain 0) and the arrays realloc, zero-filling new slots, the first time a higher `domain_id` is seen (on the cold first inference). A fixed cap is not acceptable in production: it would turn a legitimate-but-unusual graph (e.g. several independent host-scratch chains) into a hard compile failure with no correct fallback. Soft-merging unrelated domains is never done — it would silently mis-place allocations — so the only correct behavior is to open another pool, which the dynamic backing makes free.
-
-A surprisingly high domain count still usually means upstream canonicalisation (`hip-resolve-tensor-dims`, `hip-hoist-alloc-size-arith`) left scattered size queries in place, which hurts pooling efficiency. That condition is surfaced as a non-fatal advisory (see Failure Modes), never as a compile error.
-
-### Phase 2: Static / Dynamic Split
-
-For each domain, partition allocs by `staticByteSize > 0`. Statics go to Phase 3 (constant-offset slot assignment); dynamics go to Phase 4 (runtime size + bin-shared offsets).
-
-Statics are sorted largest-first to give the gap-finder more room to work with.
-
-### Phase 3: Static Packing
-
-Greedy best-fit gap-finding in a 1-D byte address space.
-
-For each static alloc (largest first):
-
-1. Walk existing reservations sorted by offset.
-2. For each reservation whose lifetime overlaps the new alloc, check the gap before it.
-3. Place the alloc in the smallest gap that fits (best-fit).
-4. If no gap fits, append after the latest overlapping reservation.
-
-Two allocs whose lifetimes do not overlap can share the same address range — captured by ignoring non-overlapping reservations during the walk.
-
-Worst case grows as `O(n²)` in the number of static allocs per domain, but `n` is small (typically <16). Production graphs have ≤4 static allocs after upstream canonicalisation, so the constant factor dominates and this is effectively O(1).
-
-Why best-fit (not first-fit): `n` is small enough that the difference is one extra iteration of the inner loop, and best-fit produces tighter packings on the long tail of unbalanced gap distributions. The static prefix size feeds directly into `hip.get_pool`'s size operand, so tighter packings reduce pool footprint.
-
-### Phase 4: Dynamic Packing
-
-Two-level grouping: bucket by structural byte-size key, then bin-pack by lifetime within each bucket.
-
-#### Level 1: Bucket by `DynSizeKey`
-
-```
-DynSizeKey = { staticFactor: int64, dynOperands: SmallVector<Value> }
-staticFactor = elementBytes * product(static dims)
-dynOperands  = SSA values for the dynamic dims, in declaration order
-```
-
-Two allocs with the same key have identical runtime byte sizes:
-
-```
-byte_size = staticFactor * dynDim0 * dynDim1 * ...
-```
-
-This is a structural equivalence on the alloc's MemRefType + dynamic operand values, not a value-numbering or CSE pass. Two allocs of `memref<?x?x4096xf16>` whose `?` dims come from the same SSA values share a bucket. Two allocs of `memref<?x?x4096xf16>` whose `?` dims come from different SSA values do **not** share a bucket — even if those SSA values would be equal at runtime — because the type-level grouping is what guarantees correctness.
-
-Bucket creation order is insertion order (linear scan over a SmallVector), giving deterministic IR output across runs.
-
-#### Level 2: First-fit bin packing within bucket
-
-Within a bucket, allocs whose lifetimes do not overlap can share a single offset slot at runtime. First-fit packs each alloc into the first existing bin without conflicts; if none accepts, a new bin opens.
-
-Number of bins per bucket = number of simultaneously-live allocs of that size class. Each bin maps 1:1 to a runtime offset slot.
-
-Why first-fit (not best-fit): bins are unordered (no notion of "size left over"), so best-fit reduces to first-fit. The algorithmic distinction matters only for static packing where offsets are linear.
-
-### Phase 5: IR Emission
-
-Per-domain emission of size arithmetic, pool acquisition, offset SSA values, and view replacements. Each domain is processed independently; the emitted IR for domain N consumes only its own allocs' constraints, not the global function's.
-
-#### Per-bucket size arithmetic
-
-For each `DynBucket`, find the latest legal insertion point given:
-
-- `requiredAfter` = the bucket's `dynOperands` defs in this block,
-- `requiredBefore` = the bucket's allocs.
-
-Set the builder there and emit:
-
-```mlir
-%static  = arith.constant <staticFactor> : index
-%byte    = arith.muli %static, %dyn0 : index
-%byte    = arith.muli %byte,   %dyn1 : index    // for each dyn operand
-%aligned = align_up(%byte, alignment)           // skipped if staticFactor % align == 0
-```
-
-The skip condition is a small but real optimisation: when `staticFactor` is already a multiple of the alignment (very common for tensor types where `elementBytes * product(static dims)` is a cache-line multiple), the `align_up` is a semantic no-op and we save the `arith.divui + muli + addi` triple it would otherwise produce.
-
-#### Pool acquisition
-
-Find the latest legal insertion point given:
-
-- `requiredAfter` = every bucket's `alignedSize` def (forces pool acquisition after all bucket sizes are known),
-- `requiredBefore` = every alloc in this domain.
-
-Set the builder there and emit:
-
-```mlir
-%pool_size = arith.constant <static_prefix> : index
-%pool_size = arith.addi %pool_size, %bucket_0_aligned * %bucket_0_bin_count : index
-%pool_size = arith.addi %pool_size, %bucket_1_aligned * %bucket_1_bin_count : index
-...
-%pool = hip.get_pool(%ctx, %pool_size) {domain_id = N : i64} : memref<?xi8>
-```
-
-Domain `N == 0` omits the `domain_id` attribute — the operation definition declares it as `DefaultValuedAttr<I64Attr, "0">` so the printer elides it. A single-domain function therefore prints no `domain_id` anywhere, so its textual IR is unchanged by the existence of multi-domain support.
-
-#### Per-alloc offset assignment + view replacement
-
-Static allocs: each gets an `arith.constant` for its offset, emitted right below the pool acquisition.
-
-Dynamic allocs: offset = static prefix + cumulative bucket size + bin index × bucket aligned size. The `currentBase` cursor advances past each bucket's full footprint (`alignedSize × numBins`) to ensure distinct buckets never alias within this pool.
-
-For each alloc: `setInsertionPoint` to the alloc's original position, emit `memref.view %pool[%offset][%dyn_dims...]` of the alloc's original `MemRefType`, replace all uses of the alloc's result with the view, erase the original alloc.
-
-After all domains: walk the function once to find any `memref.dealloc` whose operand is now a `memref.view` and erase those — pools are runtime-owned, not function-scoped, so no per-alloc dealloc is appropriate.
-
----
-
-## Module-Attribute Contract
-
-Pool-allocs writes module-level attributes. The **legacy single-domain** attrs are read by downstream `GenerateInterface` to produce the FlatBuffers metadata blob baked into `model.dll` (and drive `hipdnn_ep_pool_init`). The **multi-domain** attrs are informational module metadata — emitted for inspection and debugging, but NOT consumed by `GenerateInterface` or the runtime today. Multi-domain wiring is carried entirely by the `hip.get_pool {domain_id}` ops themselves (see the Compiler-Runtime ABI section), not by these attributes. The contract is **additive**: legacy attributes are emitted on every run; multi-domain attributes are emitted only when `domain_count > 1`.
-
-### Always emitted (legacy contract)
-
-| Attribute | Type | Meaning |
-|---|---|---|
-| `hipdnn.pool_size` | `i64` | Domain 0's static prefix in bytes (the constant baked into `hip.get_pool(domain=0)`'s size). |
-| `hipdnn.buffer_count` | `i64` | Total pooled allocs across all domains. |
-| `hipdnn.buffer_offsets` | `array<i64>` | Per-buffer offset within its domain's pool. `-1` indicates a runtime-computed offset (dynamic allocs inside non-trivial buckets). Length = `buffer_count`. |
-
-A single-domain model produces only these three. A pre-multi-domain runtime that does not understand multi-domain attrs reads only these and behaves correctly.
-
-### Multi-domain attributes (emitted when `domain_count > 1`)
-
-| Attribute | Type | Meaning |
-|---|---|---|
-| `hipdnn.domain_count` | `i64` | Number of distinct pools (= number of `hip.get_pool` ops in the function). |
-| `hipdnn.pool_sizes` | `array<i64>` | Per-domain static prefix in bytes. Length = `domain_count`. |
-| `hipdnn.buffer_domains` | `array<i64>` | Per-buffer domain id (which pool a buffer lives in). Length = `buffer_count`. |
-
-These attrs are **not** read by `GenerateInterface` or the runtime — they are informational metadata for inspection tools and debugging. Multi-domain correctness does not depend on them: it is carried by the per-domain `hip.get_pool {domain_id}` ops, which lower (Compiler-Runtime ABI section) to `hipdnn_ep_get_pool_base(state, domain_id, size)` calls emitted directly into `main_graph`. The runtime keeps an independent grow-on-demand pool per `domain_id`. What would be unsafe is a runtime predating that ABI bump (no `domain_id` parameter on `get_pool_base`) — regardless of these attributes.
-
-### Trivial-input edge case
-
-When a function has fewer than two pooled allocs, the pass emits zeroed legacy attrs (`pool_size = 0`, `buffer_count = 0`, `buffer_offsets = []`) and returns without touching the IR. A missing attribute would crash the metadata reader; a zeroed one is a well-defined "no pool".
-
----
-
-## Compiler-Runtime ABI
-
-### `hip.get_pool` op
-
-`include/hip/Dialect/IR/HipOps.td`:
-
-```td
-def Hip_GetPoolOp : Hip_Op<"get_pool",
-    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
-  let arguments = (ins Hip_ContextType:$ctx, Index:$pool_size,
-                       DefaultValuedAttr<I64Attr, "0">:$domain_id);
-  let results = (outs AnyMemRef:$pool);
-  let assemblyFormat = "`(` $ctx `,` $pool_size `)` attr-dict `:` type($pool)";
-}
-```
-
-Textual IR:
-
-```mlir
-%pool0 = hip.get_pool(%ctx, %size0) : memref<?xi8>                             // domain_id elided
-%pool1 = hip.get_pool(%ctx, %size1) {domain_id = 1 : i64} : memref<?xi8>       // explicit
-```
-
-The default-valued attribute is what makes single-domain textual IR bit-identical to pre-multi-domain output: the printer omits attrs equal to their default, and the parser fills in `0` when the attr is absent. Existing LIT goldens that do not touch multi-domain cases continue to pass without edits. The `MemoryEffectsOpInterface` declaration lets canonicalize / CSE reason about the op (it has no read/write effects on its operands — the side-effect is the implicit runtime malloc, which we model out-of-band).
-
-### LLVM lowering
-
-`ConvertHipToLLVM` (`lib/Conversion/HipToLLVM/MemoryLowering.cpp::GetPoolOpLowering`) lowers `hip.get_pool` to a 3-arg C call:
-
-```mlir
-%domain_const = llvm.mlir.constant(N : i32) : i32
-%base = llvm.call @hipdnn_ep_get_pool_base(%state, %domain_const, %size)
-        : (!llvm.ptr, i32, i64) -> !llvm.ptr
-```
-
-The `domain_id` attribute is materialised as a small `i32` constant immediately above the call, then passed as the second argument. The runtime returns a generic AS-0 pointer; if the result memref is in a non-zero address space (e.g. AS-1 = AMDGPU global), an `llvm.addrspacecast` follows. The result is wrapped into a `memref<?xi8>` descriptor with stride 1 and the dynamic length equal to `%pool_size`.
-
-### Runtime state layout
-
-`lib/Runtime/runtime_state_internal.h`:
-
-```cpp
-struct RuntimeState {
-  // ... other fields (constants blob, stream, library handles, ...) ...
-  int     num_pool_domains;             // slots currently allocated; grows on demand
-  void  **pool_base;                    // [num_pool_domains] per-domain GPU pool base pointers
-  size_t *pool_size;                    // [num_pool_domains] per-domain pool size in bytes
-  size_t *buffer_offsets;               // offsets for static buffers in domain 0
-  size_t  num_buffers;                  // static buffer count in domain 0
-  // ... host scratch, qmoe scratch, descriptor caches, ... ...
-};
-```
-
-There is no compile-time domain cap. `pool_base` / `pool_size` are heap arrays of `num_pool_domains` entries that **grow on demand**: domain 0's slot is ensured at `inference_init`, and the arrays are reallocated (zero-filling the new slots) the first time a higher `domain_id` is observed — by `hipdnn_ep_get_pool_base`. Every `domain_id` is first seen on the cold first inference, so `num_pool_domains` stabilises after that and no further array realloc happens at steady state. `realloc`-move is safe because nothing caches `&pool_base[i]` across calls; `pool_base[domain_id]` is re-derived from `state` on every access. Freed in `hipdnn_ep_state_cleanup`.
-
-### Runtime entry points
-
-Three entry points consume this state. All declared in `lib/Runtime/hipdnn_ep_runtime.h`, all `extern "C"` so generated bitcode can call them.
-
-#### `hipdnn_ep_pool_init` — eager domain-0 allocation at session start
-
-```cpp
-int hipdnn_ep_pool_init(RuntimeState *state,
-                        size_t        pool_size,
-                        const size_t *buffer_offsets,
-                        size_t        num_buffers);
-```
-
-Called once from `inference_init` with values pulled from the FlatBuffers metadata blob. Maps to the legacy attribute set:
-
-- `pool_size` ← `hipdnn.pool_size` (= domain 0's static prefix in bytes)
-- `buffer_offsets` / `num_buffers` ← the constant entries of `hipdnn.buffer_offsets` (= the static-offset slots in domain 0)
-
-It ensures the per-domain arrays have a slot for domain 0 (`ensure_pool_domains(1)`) before touching `pool_base[0]`. The runtime does **not** read `hipdnn.domain_count` to pre-size the arrays — higher domains are grown lazily (below), so the compiled `domain_count` is informational metadata only. Then: if `pool_size > 0`, allocates `state->pool_base[0]` via `hipMalloc(pool_size)` — eagerly, so the first inference does not pay the malloc latency. If `pool_size == 0`, leaves `pool_base[0]` NULL and lets the dynamic grow path own the first allocation. `state->pool_size[0]` is set to `pool_size`. **Domains 1..N have no array slot yet; the first `hip.get_pool(domain=N)` call grows the arrays and lazily allocates that domain's pool.**
-
-The `buffer_offsets` array is `memcpy`'d into a `malloc`'d slot on `state` for use by `hipdnn_ep_get_buffer_from_pool` (next).
-
-#### `hipdnn_ep_get_buffer_from_pool` — legacy static-offset accessor
-
-```cpp
-void *hipdnn_ep_get_buffer_from_pool(RuntimeState *state, size_t index);
-```
-
-Returns `state->pool_base[0] + state->buffer_offsets[index]`. Used by code paths that consume the static-offset side of the pre-multi-domain ABI (the buffer-index entries in `hipdnn.buffer_offsets` that came out non-negative). All static buffers live in domain 0 by construction; multi-domain functions only use the dynamic `hip.get_pool` path.
-
-#### `hipdnn_ep_get_pool_base` — grow-on-demand pool acquisition
-
-```cpp
-void *hipdnn_ep_get_pool_base(RuntimeState *state,
-                              int           domain_id,
-                              size_t        needed_size);
-```
-
-Called by every `hip.get_pool` lowering. Behaviour:
-
-- Rejects `domain_id < 0` (returns NULL + stderr diagnostic flagging a compiler bug — `hip-pool-allocs` assigns domain ids starting at 0). There is no upper bound: `ensure_pool_domains(domain_id + 1)` grows the per-domain arrays (zero-filling new slots) the first time a higher `domain_id` is seen, a cold-path event on the first inference.
-- If `needed_size > state->pool_size[domain_id]`, grows: `hipStreamSynchronize(state->stream)` (so any in-flight kernel reading the old buffer finishes), `hipFree(old)`, `hipMalloc(needed_size)`, store new base + size. **Stream sync covers all domains** because they share a single compute stream, but the grow itself only touches the one domain — `pool_base[M]` for M ≠ domain_id are untouched.
-- If `needed_size <= state->pool_size[domain_id]`, just returns the existing base.
-- Pools never shrink. A session that hits a peak shape keeps that footprint until cleanup.
-- Cleanup (`hipdnn_ep_state_cleanup`): `hipFree` every non-NULL `pool_base[i]` for `i ∈ [0, num_pool_domains)`, then `free` the `pool_base` / `pool_size` arrays themselves.
-
----
-
-## Design Decisions
-
-### Single-block-only constraint
-
-`PoolAllocs::runOnOperation` requires `funcOp.getBody().hasOneBlock()` and signals failure otherwise. The diagnostic mentions that liveness analysis uses sequential op indices that do not generalise to control flow.
-
-Generalising to multi-block / region-bearing functions would require MLIR's full `Liveness` analysis (forward+backward dataflow) and dominator-tree-aware insertion points (instead of `Operation::isBeforeInBlock`). The codebase does not currently produce multi-block `@main_graph` — control flow is collapsed into single-result ops with regions (`hip.if`, `hip.loop`) whose bodies are opaque to pool-allocs.
-
-This is conservative-correct: the pass refuses to touch IR shapes it cannot reason about. Future work if multi-block bodies show up.
-
-### Greedy textual-order partition
-
-Alternatives considered:
-
-- **Tight (one domain per alloc):** trivially correct, defeats pooling.
-- **Loose (cluster by transitive equivalence):** more expressive, requires solving a graph-partition problem.
-
-The greedy approach picked here is correct for single-block functions because textual order = SSA dominance order, and the greedy rule is exactly "join the first domain whose existing constraints still admit a common dominator with this alloc's operands". Most-recent-first iteration is robust to future reorderings of the domain list without changing semantics.
-
-The partition is unbounded in the number of domains it can produce. An earlier design capped it at 8 and failed compilation past that, on the theory that a high count only ever indicated pathological IR. That is the wrong trade for production: a graph that *legitimately* needs many domains (several independent host-scratch chains) would fail to compile with no correct fallback, and the only alternative — soft-merging unrelated domains — is silently incorrect. Since the runtime backs domains with grow-on-demand arrays (reallocated the first time a higher `domain_id` is seen), opening another domain costs one more array slot on the cold first inference, so there is no reason to cap. A high count is now a perf advisory (it points at missing upstream canonicalisation), not an error.
-
-### Best-fit static packing, first-fit bin packing
-
-Static allocs have a 1-D byte-offset address space, so best-fit's "smallest gap that fits" produces tighter packings than first-fit. The cost is one extra inner iteration; on `n ≤ 16` allocs per domain the difference is invisible.
-
-Bin packing has no notion of "smallest gap" — bins are bags of non-overlapping lifetimes. First-fit is the natural choice and matches best-fit asymptotically.
-
-Cross-bucket lifetime sharing (e.g. a static slot freed by an alloc dying early reused by a dynamic alloc later) is **not** attempted: it would require resolving offsets at runtime for static allocs too, defeating the constant-offset advantage. The same restriction applies to cross-domain sharing — pools are independent buffers.
-
-### Default-elided `domain_id` attribute
-
-The `Hip_GetPoolOp` declaration uses `DefaultValuedAttr<I64Attr, "0">`. This produces three properties simultaneously:
-
-1. **Backwards-compat IR.** Pre-multi-domain textual IR (no `domain_id` attr) parses as `domain_id = 0`.
-2. **Bit-identical single-domain output.** The printer elides default-valued attrs, so single-domain output looks textually unchanged.
-3. **Explicit multi-domain output.** Domains 1..N print with `{domain_id = N : i64}`, which is grep-able from IR dumps and machine-checkable from LIT goldens.
-
-The alternative (a separate op kind like `hip.get_pool_n`) would have doubled the surface area for an additive feature. The default-attr approach kept the LIT golden churn tiny.
-
-### Per-domain lazy growth (domain 0 eager)
-
-Domain 0 is allocated eagerly at `pool_init` because:
-
-- The static prefix size is known at compile time and baked into the metadata.
-- For canonical single-domain models, domain 0 is the only domain and the eager allocation amortises the `hipMalloc` cost into session startup instead of the first inference.
-
-Domains 1..N start NULL and grow lazily because:
-
-- Their static prefix is often zero (the canonical case is a pure-dynamic late-bound alloc).
-- The shape that triggers them might not be hit on every shape combination a session sees. Lazy avoids unnecessary `hipMalloc`s.
-
-The grow path is identical across all domains: stream-sync-then-free-then-malloc. There is no shrink path; the pool keeps its peak footprint for the session.
-
-### 256-byte alignment
-
-The `--hip-pool-allocs` `alignment` option defaults to 256. Two reasons:
-
-1. **GPU coalesced-access requirement.** Most current AMD GPUs require 128-byte alignment for coalesced loads; 256 is the next power of two and matches the largest cache-line size that future GPUs in this family are likely to use. Going lower risks split-transaction penalties on memory-bound kernels.
-2. **No reserved-prefix mechanic.** When a domain has zero static allocs, `staticPoolSize == 0` and the first dynamic bin starts at offset 0 — there is no implicit 256-byte slot. The "static prefix" the IR shows in the worked example above is **emergent**: it is `staticPoolSize = max(end of each static reservation)` after the per-alloc end has been rounded up to alignment, and it happens to equal 256 in that example only because the only static there is one 4-byte alloc rounded up.
-
-Hardcoded today; a `ResourceConfig`-style configurable mechanism would be a much larger architectural change and the project is currently single-target.
-
-### Pool ownership: runtime-owned, no per-alloc dealloc
-
-After view replacement, the pass walks the function once and erases any orphaned `memref.dealloc` whose operand is now a `memref.view` of a pool. The pool itself has no `memref.dealloc` — its lifetime is the session, owned by `RuntimeState::pool_base[]`, freed in `hipdnn_ep_state_cleanup`.
-
-Alternative considered: a function-scoped "dealloc on exit" would let the pass ship without runtime-side state. Rejected because (a) ONNX models that get called repeatedly would re-allocate per-call, defeating reuse, and (b) the EP already owns runtime state for other reasons (constants, host scratch, KV cache aliasing) and adding pool slots is uniformly cheap.
-
----
-
-## Worked Example: Two-Domain Partition
-
-Hand-traced from a real production case — the `embedding.onnx` sub-model of an encoder-style multimodal pipeline whose `main_graph` has eight pooled allocs and triggers a two-domain split.
-
-### Input IR — alloc inventory
-
-Eight allocs in the entry block, classified by dyn-operand chain:
-
-| Alloc | Type | Element bytes | Dyn-operands | Origin of dyn-operands |
-|---|---|---|---|---|
-| `%alloc` | `memref<?x?xui8>` | 1 | `%dim, %dim_0` | `memref.dim %arg1, %c{0,1}` — function args, already at top |
-| `%alloc_1` | `memref<?x?x4096xf16>` | 2 | `%dim, %dim_0` | same |
-| `%alloc_3` | `memref<?x?x4096xui8>` | 1 | `%dim, %dim_0` | same |
-| `%alloc_4` | `memref<?x?x4096xui8>` | 1 | `%dim, %dim_0` | same |
-| `%alloc_6` | `memref<3x?xi64>` | 8 | `%7` | `%7 = arith.muli %6, %c4096`; `%6 = arith.muli %dim, %dim_0` — speculatable arith **interleaved with allocs** |
-| `%alloc_7` | `memref<1xi32>` | 4 | (static — none) | n/a (4-byte static) |
-| `%alloc_8` | `memref<?x3xi64>` | 8 | `%7` | same as `%alloc_6` |
-| `%alloc_11` | `memref<?xf16>` | 2 | `%26` | `%26 = arith.select %25, %dim_10, %24`; chain reaches `%11 = memref.load %expand_shape_9[%c0]` — **non-speculatable load through host-scratch** |
-
-All deallocs land at function tail; every alloc's lifetime overlaps every other's, so there are no intra-domain bin-sharing opportunities in this graph beyond same-key buckets.
-
-### Hoist analysis (runs before pool-allocs)
-
-`hip-hoist-alloc-size-arith` walks SSA backward from each pooled alloc's dyn-operands:
-
-| Chain root | Speculatable predecessors | Hoist action |
-|---|---|---|
-| `%dim, %dim_0` | already at top | no-op |
-| `%6 = arith.muli %dim, %dim_0` | speculatable; operands at top | **hoist to before earliest alloc** |
-| `%7 = arith.muli %6, %c4096` | speculatable; operand `%6` will be hoisted | **hoist to before earliest alloc** (after `%6`) |
-| `%26` chain | reaches `%11 = memref.load %expand_shape_9[%c0]` — NOT speculatable | hoist stops at the load; the chain stays where it was |
-
-Net hoist effect: moves exactly two ops (`%6`, `%7`) above the earliest pooled alloc. Allocs depending on `%7` (`%alloc_6`, `%alloc_8`) become feasible for a single-domain placement; `%alloc_11`'s chain is unchanged.
-
-### Phase 1.5 partition
-
-Probe each alloc against the most-recent domain in reverse order:
-
-| Step | Alloc | Probe | Feasible? | Action |
-|---|---|---|---|---|
-| 1 | `%alloc` | (none) | n/a | open `D0` |
-| 2..5 | `%alloc_1, %alloc_3, %alloc_4, %alloc_7` | `D0 ∪ {…}` | yes — all depend on `%dim, %dim_0` (already at top) or are static | merge into `D0` |
-| 6 | `%alloc_6` | `D0 ∪ {%alloc_6}` | yes — `%7` was hoisted above the earliest alloc | merge into `D0` |
-| 7 | `%alloc_8` | `D0 ∪ {%alloc_8}` | yes — same `%7` | merge into `D0` |
-| 8 | `%alloc_11` | `D0 ∪ {%alloc_11}` | NO — `%26`'s def is below `%alloc` (the earliest), no insertion point dominates `%alloc` while following `%26`'s def | roll back |
-| 8' | `%alloc_11` | (no other domain) | n/a | open `D1` |
-
-Result: `D0 = {%alloc, %alloc_1, %alloc_3, %alloc_4, %alloc_6, %alloc_7, %alloc_8}` (7 allocs, including the rank-0 i32 static), `D1 = {%alloc_11}` (1 dynamic alloc).
-
-### Phases 2..5 — Domain 0
-
-- **Phase 2 split:** 1 static (`%alloc_7`, 4 bytes), 6 dynamic.
-- **Phase 3 (statics):** `%alloc_7` placed at offset 0; `staticPoolSize = alignTo(4, 256) = 256` (one 4-byte alloc rounded to alignment 256). The "256-byte static prefix" the IR shows is **not** a reserved slot — it is exactly what falls out of `staticPoolSize = max(end of each static reservation)` when the only static is one tiny i32.
-- **Phase 4 buckets** (per `DynSizeKey = {staticFactor, dynOperands}`):
-
-| Bucket | Allocs | `staticFactor` | `dynOperands` | byte size SSA |
-|---|---|---|---|---|
-| B0 | `%alloc` | 1 | `{%dim, %dim_0}` | `dim * dim_0` |
-| B1 | `%alloc_1` | 8192 (= 4096 × 2) | `{%dim, %dim_0}` | `dim * dim_0 * 8192` |
-| B2 | `%alloc_3, %alloc_4` | 4096 | `{%dim, %dim_0}` | `dim * dim_0 * 4096`; two bins (lifetimes overlap) |
-| B3 | `%alloc_6, %alloc_8` | 24 (= 3 × 8) | `{%7}` | `%7 * 24`; two bins (lifetimes overlap) |
-
-`%alloc_3` and `%alloc_4` share key — same `(staticFactor, dynOperands)` — so they end up in one bucket with two bins. Same story for `%alloc_6` / `%alloc_8` (different memref types `<3x?xi64>` vs `<?x3xi64>` but identical key).
-
-- **Phase 5 anchor (D0):** just after `%7`'s hoisted def, just before `%alloc`. Pool acquisition + bucket size emission:
-
-```mlir
-%6 = arith.muli %dim, %dim_0 : index                              // hoisted
-%7 = arith.muli %6, %c4096 : index                                // hoisted
-
-%b0_size    = %6                                                  // dim * dim_0
-%b0_aligned = align_up(%b0_size, 256)
-%b1_size    = arith.muli ..., %c8192                              // staticFactor 8192 % 256 == 0 → align skipped
-%b1_aligned = %b1_size
-%b2_size    = arith.muli ..., %c4096                              // 4096 % 256 == 0 → align skipped
-%b2_aligned = %b2_size
-%b3_size    = arith.muli %7, %c24                                 // (3 cols × 8 bytes)
-%b3_aligned = align_up(%b3_size, 256)
-
-%dom0_total = arith.constant 256 : index                          // static prefix
-%dom0_total = arith.addi %dom0_total, %b0_aligned                 // 1 bin
-%dom0_total = arith.addi %dom0_total, %b1_aligned                 // 1 bin
-%dom0_total = arith.addi %dom0_total, arith.muli %b2_aligned, %c2 // 2 bins
-%dom0_total = arith.addi %dom0_total, arith.muli %b3_aligned, %c2 // 2 bins
-
-%pool_0 = hip.get_pool(%ctx, %dom0_total) : memref<?xi8>          // domain_id = 0 (elided)
-```
-
-Per-alloc views (offsets):
-
-| Alloc | Offset | Constant? | `bufferOffsets[i]` |
-|---|---|---|---|
-| `%alloc` (B0, bin 0) | 256 | yes (static prefix is constant) | `256` |
-| `%alloc_1` (B1) | 256 + b0_aligned | SSA | `-1` |
-| `%alloc_3` (B2 bin 0) | … + b1_aligned | SSA | `-1` |
-| `%alloc_4` (B2 bin 1) | … + b2_aligned | SSA | `-1` |
-| `%alloc_6` (B3 bin 0) | … | SSA | `-1` |
-| `%alloc_7` (static) | 0 | yes | `0` |
-| `%alloc_8` (B3 bin 1) | … | SSA | `-1` |
-
-Static (`%alloc_7`) and the first bin of the first bucket (`%alloc`) end up with constant offsets that survive `arith` folding — `bufferOffsets` records both. Every other alloc's offset depends on SSA chains threaded through the bucket arithmetic, so `bufferOffsets` records `-1`.
-
-### Phases 2..5 — Domain 1
-
-- **Phase 2 split:** 1 dynamic (`%alloc_11`), 0 static.
-- **Phase 4:** one bucket B5 = `{staticFactor=2, dynOperands={%26}}`, byte size `%26 * 2`.
-- **Phase 5 anchor (D1):** just after `%26`'s def, just before `%alloc_11`. The host-scratch path between Domain 0 and Domain 1 (`memref.store`s, `memref.load`, the `%26` chain) is left untouched.
-
-```mlir
-// ... %26 = arith.select %25, %dim_10, %24 : index ...
-
-%b5_size    = arith.muli %26, %c2 : index                         // f16 = 2 bytes
-%b5_aligned = align_up(%b5_size, 256)
-%dom1_total = %b5_aligned
-
-%pool_1 = hip.get_pool(%ctx, %dom1_total) {domain_id = 1 : i64} : memref<?xi8>
-
-%off_d1 = arith.constant 0 : index
-%view_alloc_11 = memref.view %pool_1[%off_d1][%26] : memref<?xi8> to memref<?xf16>
-```
-
-`%alloc_11` lives in `D1` at offset 0 (no static prefix in this domain → first dynamic bin starts at 0). Constant offset → `bufferOffsets` records `0`.
-
-### Module attributes (this example)
-
-```
-hipdnn.pool_size      = 256                                  : i64
-hipdnn.buffer_count   = 8                                    : i64
-hipdnn.buffer_offsets = [256, -1, -1, -1, -1, 0, -1, 0]      : array<i64>
-                        ↑    ↑ ↑ ↑ ↑    ↑   ↑ ↑
-                        |    | | | |    |   | └ %alloc_11 (D1, offset 0)
-                        |    | | | |    |   └── %alloc_8 (D0, dyn)
-                        |    | | | |    └────── %alloc_7 (D0, static, offset 0)
-                        |    | | | └─────────── %alloc_6 (D0, dyn)
-                        |    | | └───────────── %alloc_4 (D0, dyn)
-                        |    | └─────────────── %alloc_3 (D0, dyn)
-                        |    └───────────────── %alloc_1 (D0, dyn)
-                        └────────────────────── %alloc    (D0, offset 256)
-
-hipdnn.domain_count   = 2                                    : i64
-hipdnn.pool_sizes     = [256, 0]                             : array<i64>
-hipdnn.buffer_domains = [0, 0, 0, 0, 0, 0, 0, 1]             : array<i64>
-```
-
-`hipdnn.pool_size` (legacy attr) carries domain 0's static prefix = 256. `hipdnn.pool_sizes[0]` repeats this; `hipdnn.pool_sizes[1] = 0` because D1 has no static allocs.
-
-### Lowering output (LLVM dialect, sketched)
-
-```mlir
-%c0_i32 = llvm.mlir.constant(0 : i32) : i32
-%base0  = llvm.call @hipdnn_ep_get_pool_base(%state, %c0_i32, %dom0_total)
-          : (!llvm.ptr, i32, i64) -> !llvm.ptr
-
-%c1_i32 = llvm.mlir.constant(1 : i32) : i32
-%base1  = llvm.call @hipdnn_ep_get_pool_base(%state, %c1_i32, %dom1_total)
-          : (!llvm.ptr, i32, i64) -> !llvm.ptr
-```
-
-At runtime, `pool_base[0]` was eagerly malloc'd at session start to 256 bytes (the static prefix); the first inference's larger `%dom0_total` triggers the grow path on D0 only. the domain-1 array slot did not exist at session start; the first call to `hip.get_pool(%dom1_total) {domain_id = 1}` grows the per-domain arrays and allocates `pool_base[1]` lazily. Subsequent inferences with stable `%dim, %dim_0, %26` are zero-allocation; a shape that pushes `needed_size` beyond the current capacity triggers grow on the affected domain only — the other pool is untouched.
-
----
-
-## Failure Modes & Diagnostics
-
-### Hard failures (`signalPassFailure`)
-
-| Trigger | Diagnostic | Likely fix |
-|---|---|---|
-| `funcOp.getBody().hasOneBlock() == false` | "hip-pool-allocs requires single-block functions" | Run earlier passes that collapse control flow into region-bearing ops. |
-| `funcOp.getNumArguments() == 0 || arg0 not !hip.context` | "function missing !hip.context as arg 0 — run hip-add-context-arg before hip-pool-allocs" | Add `--hip-add-context-arg` to the pipeline. |
-| `alignment` not a positive power of 2 | "alignment must be a positive power of 2 (got N)" | Fix the pass option. |
-| `findLatestLegalInsertionPoint` returns `nullopt` for a bucket | "cannot place bucket size arithmetic at a legal point in the block (a dyn-operand def is at-or-after the earliest pooled alloc in its domain)" | Either the hoist pass is missing, or Phase 1.5 partition logic regressed (a dyn-operand below the earliest alloc was admitted into a domain whose anchor is above it). Verify the pipeline; if hoist is in place, this is a partition bug. |
-| `findLatestLegalInsertionPoint` returns `nullopt` for the pool itself | "cannot place hip.get_pool at a legal point dominating its domain's allocs" | Same root cause as the bucket-placement variant; surfaces in the second insertion-point query (per-domain pool acquisition rather than per-bucket size arith). |
-
-### Soft no-ops
-
-| Trigger | Behaviour |
+| Attribute | Meaning |
 |---|---|
-| Function is empty | Return without modification. |
-| Fewer than 2 pooled allocs (after dropping `result.use_empty()` allocs) | Emit zeroed legacy attrs and return. |
-| All allocs are static and lifetime-disjoint | Phase 4 produces no buckets; Phase 3 packs everything into the static prefix; pool acquisition uses a constant `pool_size`. |
-| Per-domain: domain has no dynamic buckets AND `staticPoolSize == 0` | Phase 5 skips emission of `hip.get_pool` and the offset arithmetic for that domain entirely (no work to do, no SSA values to thread). The domain still appears in `hipdnn.pool_sizes` as `0` so downstream metadata indexing stays consistent across domains. |
-| Domain count unexpectedly high (advisory threshold) | Non-fatal remark suggesting missing upstream canonicalisation; compilation continues with one pool per domain. Triage in this order: (1) `hip-resolve-tensor-dims` is in the pipeline AND `mlir::tensor::registerInferTypeOpInterfaceExternalModels` has been called on the dialect registry (without either, per-layer same-rank dynamic Reshape chains scatter `memref.dim` ops onto bufferized reshape ops and force one domain per reshape site); (2) `hip-hoist-alloc-size-arith` is in the pipeline; (3) any speculatable arithmetic that could be hoisted but is not (e.g. an `arith.divui` whose operands could not all be proven safe). The compiled model is still correct — each extra domain is a valid independent pool — but pooling efficiency suffers. |
+| `hipdnn.pool_size` | Domain 0 static prefix; dynamic contributions live only in SSA feeding `hip.get_pool` |
+| `hipdnn.buffer_count` | Total pooled allocation count |
+| `hipdnn.buffer_offsets` | Constant offset, or `-1` when offset is runtime SSA |
+| `hipdnn.domain_count` | Number of domains; emitted only for multi-domain functions |
+| `hipdnn.pool_sizes` | Per-domain static prefixes |
+| `hipdnn.buffer_domains` | Domain ID for each pooled allocation |
 
-### Statistics (collected via LLVM `STATISTIC` macros)
+The pool attributes are MLIR code-generation inputs, not fields in `schemas/model_metadata.fbs`. `generate-interface` emits `hipdnn_ep_pool_init` only when all three legacy attributes are present and `hipdnn.pool_size > 0`. Dynamic contributions are handled by the size operands on `hip.get_pool` during `inference_compute`.
 
+Pool behavior is therefore carried by generated LLVM IR plus `RuntimeState`, not by the FlatBuffers metadata blob. The optional multi-domain attributes are diagnostic/code-generation metadata; runtime domain selection comes from each lowered `hip.get_pool` call's `domain_id`.
+
+Each `hip.get_pool` lowers to:
+
+```c
+void *hipdnn_ep_get_pool_base(RuntimeState *state,
+                              int domain_id,
+                              size_t needed_size);
 ```
-hip-pool-allocs.NumAllocsPooled  = total allocs replaced by view
-hip-pool-allocs.NumStaticPacked  = static allocs that went through Phase 3
-hip-pool-allocs.NumDynBuckets    = number of dynamic buckets created
-```
 
-Visible via `hip-mlir-opt --stats` or `--debug-only=hip-pool-allocs`.
+The runtime maintains grow-on-demand arrays of pool bases and capacities. Domain 0 is initialized eagerly when it has a static prefix; higher domains allocate lazily on first use. A zero-byte request is promoted to one byte before calling HIP.
 
----
+When a domain grows, the runtime synchronizes the session stream, frees that domain's old buffer, allocates the new capacity, and leaves other domains untouched. Pools never shrink.
 
-## Future Work
+`hipdnn_ep_get_buffer_from_pool(state, index)` remains the legacy domain-zero accessor for compile-time offsets. Multi-domain dynamic paths use `hipdnn_ep_get_pool_base`.
 
-### Lifetime slot packing within bucket
+`hip.get_pool` carries an Allocate memory effect for the returned memref.
 
-Currently each bucket's bins map 1:1 to runtime offset slots. A bucket with 4 simultaneously-live allocs of `memref<?x?x4096xf16>` produces 4 distinct slots, each sized `dim*dim_0*8192` bytes. Lifetime-based slot packing could overlap two same-shape allocs whose lifetimes do not actually overlap into one slot — bounded by `max(simultaneously-live sizes)` rather than `sum(sizes)`.
+## Host scalar scratch
 
-Profiling on real models is needed first: if bin-sharing is rare in production, the algorithmic complexity is not worth it.
+`hip-materialize-host-scalars` selects static-shape integer/index allocations of at most 16 elements with host reads or writes, including accesses reachable through supported view/alias operations. Accepted descriptor-only and terminal users include memref dimension/deallocation operations, supported views, memref copies, reshape shape operands, and HIP operations.
 
-### Multi-block functions
+All selected allocations in a function share one `hip.get_host_scratch` buffer. Their offsets are aligned to 64 bytes, independently of PoolAllocs' default 256-byte alignment.
 
-If the upstream pipeline ever produces multi-block `@main_graph` (e.g. for early-exit inference or speculative-decoding sub-graphs that share a function), the sequential-index liveness model breaks. Replacement: MLIR's full `Liveness` analysis + dominator-tree-aware insertion points.
+Functions without `!hip.context` as argument zero are skipped.
 
-### Cross-domain bin sharing
+## Diagnostics and tests
 
-Allocs in different domains can never share offset slots today — pools are independent buffers. A future design where domains share an underlying allocation (with per-domain offset windows) could reclaim that footprint. Probably not worth it: the dominant pool footprint comes from one or two large dynamic buckets, not from prefix overhead.
+Hard failures include:
 
-### Alignment configurability
+- a multi-block function;
+- missing `!hip.context` argument zero;
+- invalid alignment;
+- inability to place dynamic size arithmetic or pool acquisition despite domain partitioning.
 
-The 256-byte alignment is hard-coded. Multi-target HIP support (or a future non-HIP backend) would benefit from a `ResourceConfig`-style mechanism. Out of scope until a second target lands.
+`hip-hoist-alloc-size-arith` silently skips multi-block functions, while PoolAllocs fails on them. Both passes consider only entry-block allocations.
 
----
+More than eight domains emits a non-fatal performance remark. Recommended triage, broader than the text of that remark:
 
-## Related Documents
+1. `hip-infer-shapes` and the following canonicalize/CSE;
+2. pre-bufferization `hip-resolve-tensor-dims` and tensor InferType external-model registration;
+3. post-bufferization `hip-resolve-memref-dims`;
+4. `hip-hoist-alloc-size-arith`;
+5. remaining non-speculatable runtime dependencies.
 
-- [compiler-runtime-contract.md](compiler-runtime-contract.md) — `model_metadata.fbs` schema; how pool attributes are baked into `__metadata_blob`.
-- [constant-handling-design.md](constant-handling-design.md) — sibling runtime allocation: model constants (read-only, session-lifetime) vs pool buffers (read-write, grow-on-demand).
-- [morphizen-ep-integration.md](morphizen-ep-integration.md) — `inference_init` / `inference_compute` / `inference_cleanup` lifecycle that owns `RuntimeState::pool_base[]`.
+LLVM statistics include pooled allocation count, static allocation count, aligned dynamic group plus small-bucket count, domain count, and static/dynamic fragmentation measures. `--hip-pool-allocs='emit-fragmentation-report=true'` emits per-domain remarks without changing IR.
+
+Primary regression coverage:
+
+- `test/lit/Dialect/hip-pool-allocs.mlir`
+- `test/lit/Dialect/hip-pool-allocs-multi-domain-metadata.mlir`
+- `test/lit/Dialect/hip-pool-allocs-many-domains.mlir`
+- `test/lit/Dialect/hip-pool-allocs-dynamic-binning.mlir`
+- `test/lit/Dialect/hip-pool-allocs-fragmentation-report.mlir`
+- `test/lit/Dialect/hip-resolve-tensor-dims.mlir`
+- `test/lit/Dialect/hip-resolve-memref-dims.mlir`
+- `test/lit/Dialect/hip-hoist-alloc-size-arith.mlir`
+- `test/lit/Dialect/hip-materialize-host-scalars.mlir`
+- `test/lit/Pipeline/output-allocator-dealloc.mlir`
+- `test/lit/Pipeline/pipeline-pool-lower.mlir`
+
+## Current limitations
+
+- PoolAllocs requires single-block functions.
+- Pools in separate domains cannot share storage.
+- Static-prefix and dynamic regions do not share offsets.
+- Distinct small buckets do not share offsets.
+- Small dynamic buckets retain per-key first-fit binning.
+- Pool alignment defaults to 256 bytes.
+
+These are performance or generality limits, not reasons to merge unrelated dominance domains or weaken correctness.

--- a/docs/design/unranked-tensor-handling.md
+++ b/docs/design/unranked-tensor-handling.md
@@ -95,12 +95,19 @@ ort-bridge): preserve unranked tensors at the ORT boundary`).
   operand types via the value's MLIR type, not from a separate
   declared field. Converters that genuinely require a ranked operand
   (e.g. those that index into a specific dim to size a `tensor.empty`)
-  bail on unranked input; the rank gap is closed by the next pass.
+  bail on unranked input.
+- **`--hip-infer-loop-body-shapes`**
+  (`lib/Dialect/Transforms/InferLoopBodyShapesPass.cpp`) runs before
+  ONNX-to-HIP conversion. It seeds outlined-loop carried arguments from
+  `v_init`, forward-infers supported unranked ONNX results (currently
+  `onnx.Concat`), and applies the ONNX loop-carried type contract as a
+  backstop. This is the EP's narrow rank-establishment stage.
 - **`--hip-infer-shapes`** (lib/Dialect/Transforms/InferShapesPass.cpp)
-  refines unranked / under-refined HIP DPS op result types from the
-  shapes reified by `ReifyRankedShapedTypeOpInterface` on each op,
-  and runs `refineLoopSignatures` (Phase 2) to sync `hip.loop` body
-  signatures with v_init types after HIP-dialect conversion. See
+  narrows dynamic dimensions (`?`) on already-ranked HIP DPS result
+  types from shapes reified by `ReifyRankedShapedTypeOpInterface`.
+  It does not convert `UnrankedTensorType` into a ranked type. Phase 2
+  synchronizes `hip.loop` body signatures with `v_init` types after
+  HIP-dialect conversion. See
   [`hip-shape-inference.md`](hip-shape-inference.md) for the full
   pass design.
 - **`--onnx-loop-outline`** (lib/Conversion/OnnxToHip/LoopOutline.cpp)
@@ -109,8 +116,9 @@ ort-bridge): preserve unranked tensors at the ORT boundary`).
   body block arg types — so `hip.loop`'s `result_type[i] ==
   v_init[i].type` invariant holds at outline-pass exit even when the
   body block arg is unranked. Cloned body ops keep their source-IR
-  result types (typically unranked); `--hip-infer-shapes` refines
-  them post-conversion.
+  result types (typically unranked);
+  `--hip-infer-loop-body-shapes` establishes the required rank before
+  conversion.
 
 ## Pipeline ordering
 
@@ -120,12 +128,20 @@ ONNX file → ort-bridge → mlir-imp → MLIR module → onnx-to-hip-pipeline
                                        (with        ├─ simplify-onnx
                                         tensor<*x>  ├─ hip-add-context-arg
                                         for unknown ├─ onnx-loop-outline
-                                        ranks)      ├─ convert-onnx-to-hip
+                                        ranks)      ├─ onnx-if-outline
+                                                    ├─ hip-infer-loop-body-shapes
+                                                    ├─ convert-onnx-to-hip
                                                     │  (tail:)
-                                                    ├─ hip-infer-shapes  ← single refinement
+                                                    ├─ hip-infer-shapes
+                                                    ├─ canonicalize ; CSE
+                                                    ├─ hip-split-duplicate-dps-inits
+                                                    ├─ hip-resolve-tensor-dims
                                                     ├─ one-shot-bufferize
                                                     ├─ buffer-deallocation
+                                                    ├─ hip-use-output-allocator
                                                     ├─ hip-optimize-memrefs
+                                                    ├─ hip-materialize-host-scalars
+                                                    ├─ hip-resolve-memref-dims
                                                     ├─ hip-pool-allocs
                                                     └─ ...
                                                   → hip-to-llvm-pipeline
@@ -135,10 +151,11 @@ ONNX file → ort-bridge → mlir-imp → MLIR module → onnx-to-hip-pipeline
                                                     └─ generate-interface
 ```
 
-The single refinement step on the EP side is `--hip-infer-shapes`,
-which runs once at the head of the ONNX-to-HIP pipeline tail
-(immediately after `--convert-onnx-to-hip`, before bufferize). There
-is no per-dialect ONNX-level inference pass.
+The EP uses two deliberately narrow stages: pre-conversion
+`--hip-infer-loop-body-shapes` establishes rank where outlined-loop
+conversion requires it; post-conversion `--hip-infer-shapes` narrows
+`?` dimensions within already-known ranks. There is no general
+ONNX-level inference pass in the EP.
 
 ## Why we don't run ONNX shape inference in the EP
 
@@ -161,15 +178,14 @@ deliberately do not:
    unregistered ONNX dialect that lacks the OpInterface scaffolding
    (`InferTypeOpInterface`, `ShapeInferenceOpInterface`) that
    upstream projects (onnx-mlir, torch-mlir, TOSA) rely on.
-3. **The HIP-side refinement already covers it.** Once
-   `--convert-onnx-to-hip` produces HIP ops, those ops carry
-   `ReifyRankedShapedTypeOpInterface` and `--hip-infer-shapes` walks
-   them to refine unranked → ranked result types. This works because
-   HIP DPS ops have ranked operands (the `outs` operand types come
-   from preceding ops or from `tensor.empty` with explicit shape),
-   and the result shape is a function of operand shapes via the
-   helpers in `lib/Dialect/IR/HipShapeUtils.cpp`. A single pass closes
-   the gap for every HIP op the converter emits.
+3. **The two HIP-side stages close the supported gap.**
+   `--hip-infer-loop-body-shapes` establishes rank before conversion
+   for the outlined-loop patterns that need it. Once
+   `--convert-onnx-to-hip` produces HIP ops,
+   `ReifyRankedShapedTypeOpInterface` and `--hip-infer-shapes` narrow
+   dynamic dimensions without inventing runtime-dependent extents.
+   Unsupported interior ONNX rank gaps remain explicit conversion
+   failures rather than being guessed post-conversion.
 
 The historical workaround `--onnx-infer-shapes`, with its op-name
 keyed rules library (`RefineOnnxResultType.{cpp,h}`), was deleted once
@@ -207,14 +223,17 @@ Two end-to-end signals tell you the contract is healthy:
    should be `tensor<*xT>` (unranked) or genuinely ranked, never
    rank-0 unless the ONNX source genuinely declared a scalar.
 
-2. **`--hip-infer-shapes` refines all unranked HIP ops.** After the
-   `--onnx-to-hip-pipeline` runs, every HIP-dialect op result type
-   should be `RankedTensorType` (with `?` dynamic dims allowed). If a
-   HIP op result type is `UnrankedTensorType` after pipeline exit,
-   either the converter that produced it doesn't propagate operand
-   shapes, or `ReifyRankedShapedTypeOpInterface` is missing on that
-   op kind. Both are `--hip-infer-shapes`-side bugs to fix; they are
-   never resolved by reintroducing ONNX-level inference.
+2. **Rank-required loop-body ops are ranked before conversion.** After
+   `--hip-infer-loop-body-shapes`, supported loop-carried ONNX results
+   should be `RankedTensorType` (with `?` dynamic dims allowed). An
+   unranked value that reaches a rank-requiring converter indicates a
+   missing pre-conversion rule or an importer contract gap.
+
+3. **`--hip-infer-shapes` only narrows ranked HIP results.** After the
+   ONNX-to-HIP pipeline, HIP DPS result types should remain ranked,
+   with any non-reifiable runtime extents represented by `?`.
+   `ReifyRankedShapedTypeOpInterface` bugs affect dimension refinement;
+   they are not repaired by reintroducing ONNX-level shape inference.
 
 The LIT case `test_loop_outline.mlir`'s `vision_encoder_loop` test
 pins the outline-time half of the contract (v_init drives the body

--- a/docs/pipeline_pass_menu.md
+++ b/docs/pipeline_pass_menu.md
@@ -112,6 +112,7 @@ Options use MLIR's pipeline-option syntax:
 | `simplify-onnx` | module | Pre-lowering ONNX cleanups (`CastLike`→`Cast`, drop dead type-donor args). |
 | `hip-add-context-arg` | module | Inject the `!hip.context` argument into functions. |
 | `onnx-loop-outline` | module | Outline `onnx.Loop` bodies into separate `func.func` ops. |
+| `onnx-if-outline` | module | Outline `onnx.If` branches before ONNX-to-HIP conversion. |
 | `hip-infer-loop-body-shapes` | module | Rank-establish unranked tensors inside outlined loop bodies. |
 | `outline-onnx-to-hipdnn` | module | Outline subgraphs targeted at hipDNN graph compilation. |
 | `convert-onnx-to-hip` | module | Pattern-match ONNX ops by name → HIP dialect; externalize large constants. |
@@ -124,8 +125,9 @@ Options use MLIR's pipeline-option syntax:
 | `hip-optimize-memrefs` | func.func | HIP-specific buffer reuse / subview folding. |
 | `hip-promote-strided-operands` | func.func | Materialize contiguous temporaries for strided memref operands of `hip.*` ops. |
 | `hip-materialize-host-scalars` | func.func | Redirect tiny host-fed scalar allocs to runtime-owned host-mapped scratch (away from the GPU pool). |
+| `hip-resolve-memref-dims` | func.func | Fold post-bufferization `memref.dim` through view/reshape chains before pool planning. |
 | `hip-hoist-alloc-size-arith` | func.func | Hoist speculatable size arithmetic above the earliest dynamic alloc (PoolAllocs precondition). |
-| `hip-pool-allocs` | func.func | Pack allocations into a single grow-on-demand GPU pool; stamp `hipdnn.pool_size`. |
+| `hip-pool-allocs` | func.func | Pack allocations into one or more grow-on-demand GPU pools; stamp pool-planning module attributes. |
 | `hip-lower-allocs` | func.func | Replace `memref.alloc`/`dealloc` with `hip.alloc`/`hip.free`. |
 | `hip-relax-multi-dyn-expand-shape` | func.func | Rewrite multi-dynamic-per-group `memref.expand_shape` → `reinterpret_cast` before strided-metadata expansion. |
 | `hip-resolve-extern-constants` | module | Resolve extern constants → `memref.view` into the constants-blob argument. |
@@ -176,6 +178,7 @@ ONNX → HIP  (buildOnnxToHipPipeline)
   «slot: AfterSimplifyOnnx»
   hip-add-context-arg
   onnx-loop-outline
+  onnx-if-outline
   hip-infer-loop-body-shapes
   «slot: AfterOnnxLoopOutline»
   [outline-onnx-to-hipdnn + compile-hipdnn-graphs]   (handle overload only)
@@ -196,6 +199,7 @@ ONNX → HIP  (buildOnnxToHipPipeline)
   func.func(hip-optimize-memrefs)
   func.func(hip-promote-strided-operands)
   func.func(hip-materialize-host-scalars)
+  func.func(hip-resolve-memref-dims)
   func.func(hip-hoist-alloc-size-arith)
   func.func(hip-pool-allocs)
   «slot: AfterPoolAllocs»
@@ -230,7 +234,7 @@ a fixed point without rewriting the order. Slots (see
 | Slot | Sits after / before | Typical use |
 |---|---|---|
 | `AfterSimplifyOnnx` | after `simplify-onnx` | Canonical ONNX dialect, no HIP context arg yet. |
-| `AfterOnnxLoopOutline` | after loop outlining + body shape inference | Operate on outlined ONNX loop bodies. |
+| `AfterOnnxLoopOutline` | after loop/if outlining + loop-body shape inference | Operate on outlined ONNX control-flow bodies. |
 | `AfterConvertOnnxToHip` | after `convert-onnx-to-hip` | Most common slot — lower `onnx.Custom`, vendor `hip.*` canonicalizations. |
 | `BeforeBufferization` | before `one-shot-bufferize` | Lower/canonicalize `hip.*` while still in tensor type-system. |
 | `AfterPoolAllocs` | after `hip-pool-allocs` | Analyze/transform pooled allocations (allocator tagging, etc.). |

--- a/lib/Dialect/Transforms/Pipelines.cpp
+++ b/lib/Dialect/Transforms/Pipelines.cpp
@@ -303,12 +303,12 @@ void mlir::hip::buildOnnxToHipPipeline(OpPassManager &pm,
   // mapping, etc.) -- the conversion pass already iterates all func.func
   // ops in the module.
   //
-  // ONNX-side shape refinement is intentionally NOT done here. The
-  // importer is responsible for emitting `tensor<*xT>` (unranked) for
-  // values whose shape it does not know, and `tensor<>` (rank-0) only
-  // for genuine scalars. Any unranked tensors that survive into the
-  // HIP dialect are refined post-conversion by `--hip-infer-shapes`
-  // via `ReifyRankedShapedTypeOpInterface`. See
+  // General ONNX-side shape refinement is intentionally NOT done here. The
+  // importer is responsible for emitting `tensor<*xT>` (unranked) for values
+  // whose shape it does not know, and `tensor<>` (rank-0) only for genuine
+  // scalars. The narrow pre-conversion pass below establishes rank where
+  // outlined-loop conversion requires it; post-conversion
+  // `--hip-infer-shapes` only narrows `?` dims on ranked HIP results. See
   // `docs/design/unranked-tensor-handling.md` for the full contract.
   //
   // TODO(unranked-import-contract): the unranked-import contract on

--- a/lib/Dialect/Transforms/PoolAllocs.cpp
+++ b/lib/Dialect/Transforms/PoolAllocs.cpp
@@ -1130,10 +1130,9 @@ void PoolAllocsPass::runOnOperation() {
   //     hipdnn.buffer_count   = i64           // total pooled allocs
   //     hipdnn.buffer_offsets = array<i64>    // -1 for dynamic offsets
   //
-  //   Emitted only when domain_count > 1 (consumed by the multi-domain
-  //   runtime — older runtimes predating the multi-domain ABI silently ignore
-  //   the extra attrs and would alias all domains onto a single pool, which is
-  //   incorrect; the compiler/runtime ABI bump fixes that):
+  //   Emitted only when domain_count > 1 (informational/code-generation
+  //   metadata; runtime domain selection is carried by each lowered
+  //   hip.get_pool call's domain_id and size operands):
   //     hipdnn.domain_count   = i64
   //     hipdnn.pool_sizes     = array<i64>    // per-domain static prefix
   //     hipdnn.buffer_domains = array<i64>    // per-buffer domain id


### PR DESCRIPTION
## Summary
- Replace stale shape-inference and PoolAllocs implementation histories with concise design contracts.
- Align pipeline ordering, unranked-tensor ownership, compiler/runtime metadata boundaries, and related source comments.
