### PR TITLE
fix(use-output-allocator): report graph-output rank for reshaped-view outputs

### DIFF
--- a/lib/Dialect/Transforms/UseOutputAllocator.cpp
+++ b/lib/Dialect/Transforms/UseOutputAllocator.cpp
@@ -14,9 +14,18 @@
 //
 // For each matching alloc the rewrite:
 //   - sets `out_idx` to its position in func.return (the graph output index),
-//   - reuses the alloc's dynamic-size operands unchanged,
-//   - deletes any `memref.dealloc` of it (the EP frees it, not us),
-//   - leaves the view ops in place -- only the alloc op itself changes.
+//   - allocates the EP-owned buffer at the GRAPH-OUTPUT type (the func.return
+//     operand type), not the producer alloc's type. These differ when the
+//     returned value is a reshaping view of the alloc (e.g. a rank-2 Gemm
+//     result expanded to rank-3 with no trailing op); allocating at the alloc's
+//     rank would make the EP report the wrong rank to ORT ("Invalid rank for
+//     output"). When they differ, the reshaping view chain (cast / expand_shape
+//     / collapse_shape, static output) is inverted so the producer keeps
+//     writing into the same EP-owned memory viewed as its original type. Other
+//     view ops (e.g. subview) or dynamic outputs fall back to allocating at the
+//     alloc's type (legacy behavior).
+//   - reuses the alloc's dynamic-size operands unchanged (fast/legacy path),
+//   - deletes any `memref.dealloc` of it (the EP frees it, not us).
 //
 // How outputs are found. Rather than listing every view op by hand, the pass
 // asks `BufferViewFlowAnalysis` one question per alloc: does any value derived
@@ -60,6 +69,7 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/Interfaces/ViewLikeInterface.h"
 
 #include "llvm/ADT/STLExtras.h"
 
@@ -126,6 +136,10 @@ struct UseOutputAllocatorPass
         outputs.emplace_back(allocOp, outIdx);
     });
 
+    // The single graph-entry return (graph functions have exactly one).
+    func::ReturnOp retOp;
+    funcOp.walk([&](func::ReturnOp r) { retOp = r; });
+
     // Phase 2 -- rewrite (IR mutation only; the analysis is no longer queried).
     OpBuilder builder(funcOp.getContext());
     for (auto [allocOp, outIdx] : outputs) {
@@ -136,11 +150,87 @@ struct UseOutputAllocatorPass
         if (auto dealloc = dyn_cast<memref::DeallocOp>(user))
           dealloc.erase();
 
+      // The buffer the EP allocates and reports to ORT must have the GRAPH
+      // OUTPUT shape (the func.return operand type), not the producer alloc's
+      // shape. They differ when the returned value is a reshaping view of the
+      // alloc (e.g. a rank-2 Gemm result expanded to rank-3 before the return,
+      // with no trailing op). Allocating at the alloc's rank would make the EP
+      // register the wrong rank with ORT -> "Invalid rank for output".
+      Value retVal = retOp ? retOp.getOperand(outIdx) : Value();
+      Type retTy = retVal ? retVal.getType() : allocOp.getType();
+
       builder.setInsertionPoint(allocOp);
+
+      // Fast path: producer alloc already has the graph-output type (direct
+      // return, or a shape-preserving view like memref.cast to same type).
+      if (retTy == allocOp.getType()) {
+        auto allocOutput = AllocOutputOp::create(
+            builder, allocOp.getLoc(), allocOp.getType(), ctx,
+            allocOp.getDynamicSizes(), builder.getI64IntegerAttr(outIdx));
+        allocOp.getResult().replaceAllUsesWith(allocOutput.getResult());
+        allocOp.erase();
+        continue;
+      }
+
+      // Shape-changing view chain. Collect the reshaping ops from the returned
+      // value down to the alloc. Only invertible metadata views (cast /
+      // expand_shape / collapse_shape) over a static output are handled; any
+      // other op (e.g. subview) or a dynamic output falls back to the legacy
+      // behavior so we never regress an existing case.
+      SmallVector<Operation *> chain;
+      Value cur = retVal;
+      bool invertible = mlir::cast<MemRefType>(retTy).hasStaticShape();
+      while (invertible && cur != allocOp.getResult()) {
+        Operation *def = cur.getDefiningOp();
+        if (isa_and_nonnull<memref::CastOp, memref::ExpandShapeOp,
+                            memref::CollapseShapeOp>(def)) {
+          chain.push_back(def);
+          cur = mlir::cast<ViewLikeOpInterface>(def).getViewSource();
+        } else {
+          invertible = false;
+        }
+      }
+
+      if (!invertible) {
+        // Legacy fallback: allocate at the producer alloc's type.
+        auto allocOutput = AllocOutputOp::create(
+            builder, allocOp.getLoc(), allocOp.getType(), ctx,
+            allocOp.getDynamicSizes(), builder.getI64IntegerAttr(outIdx));
+        allocOp.getResult().replaceAllUsesWith(allocOutput.getResult());
+        allocOp.erase();
+        continue;
+      }
+
+      // Allocate the EP-owned output at the graph-output (returned) type, then
+      // rebuild the inverse of the view chain so the producer keeps writing
+      // into the same memory viewed as its original (alloc) type.
       auto allocOutput = AllocOutputOp::create(
-          builder, allocOp.getLoc(), allocOp.getType(), ctx,
-          allocOp.getDynamicSizes(), builder.getI64IntegerAttr(outIdx));
-      allocOp.getResult().replaceAllUsesWith(allocOutput.getResult());
+          builder, allocOp.getLoc(), retTy, ctx, /*dynamicSizes=*/ValueRange{},
+          builder.getI64IntegerAttr(outIdx));
+
+      Value inv = allocOutput.getResult();
+      for (Operation *v : chain) { // outermost (produces retVal) -> innermost
+        Type srcTy = mlir::cast<ViewLikeOpInterface>(v).getViewSource().getType();
+        if (auto e = dyn_cast<memref::ExpandShapeOp>(v)) {
+          // forward src -> larger rank; inverse collapses back to src.
+          inv = memref::CollapseShapeOp::create(builder, v->getLoc(), srcTy, inv,
+                                                e.getReassociationIndices());
+        } else if (auto c = dyn_cast<memref::CollapseShapeOp>(v)) {
+          // forward src -> smaller rank; inverse expands back to src (static).
+          auto srcMr = mlir::cast<MemRefType>(srcTy);
+          SmallVector<OpFoldResult> outShape;
+          for (int64_t d : srcMr.getShape())
+            outShape.push_back(builder.getIndexAttr(d));
+          inv = memref::ExpandShapeOp::create(builder, v->getLoc(), srcTy, inv,
+                                              c.getReassociationIndices(),
+                                              outShape);
+        } else { // memref::CastOp
+          inv = memref::CastOp::create(builder, v->getLoc(), srcTy, inv);
+        }
+      }
+
+      // `inv` now has the alloc's type and aliases the EP-owned buffer.
+      allocOp.getResult().replaceAllUsesWith(inv);
       allocOp.erase();
     }
   }

--- a/lib/Dialect/Transforms/UseOutputAllocator.cpp
+++ b/lib/Dialect/Transforms/UseOutputAllocator.cpp
@@ -210,11 +210,12 @@ struct UseOutputAllocatorPass
 
       Value inv = allocOutput.getResult();
       for (Operation *v : chain) { // outermost (produces retVal) -> innermost
-        Type srcTy = mlir::cast<ViewLikeOpInterface>(v).getViewSource().getType();
+        Type srcTy =
+            mlir::cast<ViewLikeOpInterface>(v).getViewSource().getType();
         if (auto e = dyn_cast<memref::ExpandShapeOp>(v)) {
           // forward src -> larger rank; inverse collapses back to src.
-          inv = memref::CollapseShapeOp::create(builder, v->getLoc(), srcTy, inv,
-                                                e.getReassociationIndices());
+          inv = memref::CollapseShapeOp::create(
+              builder, v->getLoc(), srcTy, inv, e.getReassociationIndices());
         } else if (auto c = dyn_cast<memref::CollapseShapeOp>(v)) {
           // forward src -> smaller rank; inverse expands back to src (static).
           auto srcMr = mlir::cast<MemRefType>(srcTy);

--- a/test/lit/Dialect/hip-use-output-allocator.mlir
+++ b/test/lit/Dialect/hip-use-output-allocator.mlir
@@ -187,16 +187,18 @@ func.func @return_order(%ctx: !hip.context, %M: index) -> (memref<4xf16>, memref
   return %b, %a : memref<4xf16>, memref<?xf16>
 }
 
-// --- Output returned through memref.collapse_shape: the alloc still becomes
-//     hip.alloc_output, and the collapse_shape stays in place feeding the
-//     return. Models a reshaped output such as a rank-4 conv result flattened
-//     to rank-2 before the return, so the buffer is owned by the EP rather than
-//     pooled. ---
+// --- Output returned through memref.collapse_shape: hip.alloc_output is created
+//     at the GRAPH-OUTPUT (returned) type, and the view chain is inverted so the
+//     producer still writes into the EP-owned buffer viewed as its original
+//     type. Models a reshaped output such as a rank-4 conv result flattened to
+//     rank-2 before the return; the EP must report the returned (rank-2) shape
+//     to ORT, not the producer's rank-4 shape. ---
 // CHECK-LABEL: func.func @collapse_output
 // CHECK-SAME:    (%[[CTX:.*]]: !hip.context)
 // CHECK-NOT:     memref.alloc
-// CHECK:         %[[OUT:.*]] = hip.alloc_output(%[[CTX]]) {out_idx = 0 : i64} : memref<1x64x56x56xf32>
-// CHECK:         %[[C:.*]] = memref.collapse_shape %[[OUT]]
+// CHECK:         %[[OUT:.*]] = hip.alloc_output(%[[CTX]]) {out_idx = 0 : i64} : memref<1x200704xf32>
+// CHECK:         %[[E:.*]] = memref.expand_shape %[[OUT]]
+// CHECK:         %[[C:.*]] = memref.collapse_shape %[[E]]
 // CHECK:         return %[[C]]
 func.func @collapse_output(%ctx: !hip.context) -> memref<1x200704xf32> {
   %x = memref.alloc() : memref<1x64x56x56xf32>
@@ -205,13 +207,15 @@ func.func @collapse_output(%ctx: !hip.context) -> memref<1x200704xf32> {
   return %out : memref<1x200704xf32>
 }
 
-// --- Output returned through memref.expand_shape: handled the same way as
-//     collapse_shape (the analysis follows both). ---
+// --- Output returned through memref.expand_shape: hip.alloc_output is created at
+//     the returned (rank-4) type and the view chain is inverted (collapse) so
+//     the producer writes into the EP-owned buffer viewed as its rank-2 type. ---
 // CHECK-LABEL: func.func @expand_output
 // CHECK-SAME:    (%[[CTX:.*]]: !hip.context)
 // CHECK-NOT:     memref.alloc
-// CHECK:         %[[OUT:.*]] = hip.alloc_output(%[[CTX]]) {out_idx = 0 : i64} : memref<1x200704xf32>
-// CHECK:         %[[E:.*]] = memref.expand_shape %[[OUT]]
+// CHECK:         %[[OUT:.*]] = hip.alloc_output(%[[CTX]]) {out_idx = 0 : i64} : memref<1x64x56x56xf32>
+// CHECK:         %[[C:.*]] = memref.collapse_shape %[[OUT]]
+// CHECK:         %[[E:.*]] = memref.expand_shape %[[C]]
 // CHECK:         return %[[E]]
 func.func @expand_output(%ctx: !hip.context) -> memref<1x64x56x56xf32> {
   %x = memref.alloc() : memref<1x200704xf32>


### PR DESCRIPTION
## Summary

`UseOutputAllocator` rewrote a graph-output `memref.alloc` into `hip.alloc_output` using the **producer alloc's type**. When the returned value is a reshaping view of that alloc (e.g. a rank-2 Gemm result `expand_shape`'d to rank-3 with no trailing op — DETR's `class_labels_classifier` `logits` head), the EP registered the alloc's rank with ORT instead of the declared graph-output rank, so ORT rejected the output:

```
Invalid rank for output: logits Got: 2 Expected: 3
```

Outputs with a trailing op (e.g. `pred_boxes`' `sigmoid`, whose alloc is already at the output rank) were unaffected — which is why only `logits` failed.

## Fix

- Allocate `hip.alloc_output` at the `func.return` operand type (the graph-output shape).
- When it differs from the producer alloc's type, rebuild the **inverse** of the view chain (`cast` / `expand_shape` / `collapse_shape`, static output) so the producer keeps writing into the same EP-owned buffer viewed as its original type — no extra copy.
- Fast path (return type == alloc type) is unchanged; `subview` or dynamic-shaped outputs fall back to the legacy behavior, so no existing case regresses.

Applies to both the `LLVM_IR` and `NATIVE` artifact paths.

## Test plan

- [x] `facebook/detr-resnet-50` (fp16): `logits` now returns `{1,100,92}`; `onnxruntime_perf_test` runs clean.
- [ ] Re-run existing lit/numeric suites for regressions (esp. conv/reshape output models).
- [ ] Spot-check a model with a rank-4 conv output collapsed before return.
