### PR TITLE
fix(mock): Add missing zp_unpack_cache_destroy

### DIFF
--- a/lib/Runtime/mock/op_state_stubs.cpp
+++ b/lib/Runtime/mock/op_state_stubs.cpp
@@ -21,6 +21,12 @@ namespace {
 struct MockOpState : OpStateT<MockOpState> {};
 } // namespace
 
+// ZpUnpackCache teardown: real runtime deletes a ZpUnpackCache allocated
+// in real/matmul_nbits.cpp. The mock never creates one, so this is a no-op
+// (the cache pointer is always null under mock). Called from
+// hipdnn_ep_state_cleanup in the shared runtime_state TU.
+extern "C" void hipdnn_ep_zp_unpack_cache_destroy(void * /*cache_ptr*/) {}
+
 // MatMulNBits: real runtime owns a zero_points unpack cache (MatmulNbitsState
 // in real/matmul_nbits.cpp); the mock owns no device memory.
 extern "C" int8_t hipdnn_ep_op_state_construct_matmul_nbits(RuntimeState *state,


### PR DESCRIPTION
<!--
Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
Licensed under the MIT License.
-->

<!--
Thank you for contributing. Keep the description proportional to the change
and review it for accuracy before requesting review. See CONTRIBUTING.md for
the full workflow and AI-assistance disclosure requirements.
-->

## Summary

When running with mock runtime, it was crashing, because it was missing the hipdnn_ep_zp_unpack_cache_destroy function required. This PR adds the stub function in mock runtime.

## Test plan

**No tests are added, since it's mock runtime and we don't want to block due to failures due to mock runtime in the future.**
But I noticed there are no e2e tests that exercise the LLVM_IR path on mock runtime. It may be useful to test that.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [x] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.
