### PR TITLE
feat(hipsr): port get_pool op to hipsr dialect (#48)

### DIFF
--- a/include/hip/Dialect/Hipsr/IR/CMakeLists.txt
+++ b/include/hip/Dialect/Hipsr/IR/CMakeLists.txt
@@ -59,6 +59,10 @@ set(LLVM_TARGET_DEFINITIONS HipsrAddOp.td)
 mlir_tablegen(HipsrAddOp.h.inc -gen-op-decls)
 mlir_tablegen(HipsrAddOp.cpp.inc -gen-op-defs)
 
+set(LLVM_TARGET_DEFINITIONS HipsrGetPoolOp.td)
+mlir_tablegen(HipsrGetPoolOp.h.inc -gen-op-decls)
+mlir_tablegen(HipsrGetPoolOp.cpp.inc -gen-op-defs)
+
 set(LLVM_TARGET_DEFINITIONS HipsrPlaceholderOp.td)
 mlir_tablegen(HipsrPlaceholderOp.h.inc -gen-op-decls)
 mlir_tablegen(HipsrPlaceholderOp.cpp.inc -gen-op-defs)

--- a/include/hip/Dialect/Hipsr/IR/HipsrGetPoolOp.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrGetPoolOp.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#ifndef HIPSR_GET_POOL_OP_H
+#define HIPSR_GET_POOL_OP_H
+
+#include "hip/Dialect/Hipsr/IR/HipsrDialect.h"
+
+#include "mlir/Bytecode/BytecodeOpInterface.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+
+#define GET_OP_CLASSES
+#include "hip/Dialect/Hipsr/IR/HipsrGetPoolOp.h.inc"
+
+namespace mlir {
+class LLVMTypeConverter;
+class RewritePatternSet;
+
+namespace hipsr {
+
+void populateHipsrGetPoolLoweringPatterns(const LLVMTypeConverter &converter,
+                                          RewritePatternSet &patterns);
+
+} // namespace hipsr
+} // namespace mlir
+
+#endif // HIPSR_GET_POOL_OP_H

--- a/include/hip/Dialect/Hipsr/IR/HipsrGetPoolOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrGetPoolOp.td
@@ -23,7 +23,7 @@ def Hipsr_GetPoolOp : Hipsr_Op<"get_pool",
 
   let arguments = (ins Hipsr_ContextType:$ctx, Index:$pool_size,
                        DefaultValuedAttr<I64Attr, "0">:$domain_id);
-  let results = (outs AnyMemRef:$pool);
+  let results = (outs Hipsr_DeviceMemRef:$pool);
   let assemblyFormat = "`(` $ctx `,` $pool_size `)` attr-dict `:` type($pool)";
 }
 

--- a/include/hip/Dialect/Hipsr/IR/HipsrGetPoolOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrGetPoolOp.td
@@ -1,0 +1,30 @@
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+
+#ifndef HIPSR_GET_POOL_OP
+#define HIPSR_GET_POOL_OP
+
+include "mlir/IR/OpBase.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
+include "hip/Dialect/Hipsr/IR/HipsrOps.td"
+
+def Hipsr_GetPoolOp : Hipsr_Op<"get_pool",
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+  let summary = "Get a runtime-owned GPU memory pool";
+  let description = [{
+    Returns a runtime-managed GPU memory pool.
+
+    - `pool_size` : minimum size in bytes the returned buffer must hold.
+    - `domain_id` : selects an independent pool (default 0); pools with distinct
+                    domain_ids grow independently.
+  }];
+
+  let arguments = (ins Hipsr_ContextType:$ctx, Index:$pool_size,
+                       DefaultValuedAttr<I64Attr, "0">:$domain_id);
+  let results = (outs AnyMemRef:$pool);
+  let assemblyFormat = "`(` $ctx `,` $pool_size `)` attr-dict `:` type($pool)";
+}
+
+#endif // HIPSR_GET_POOL_OP

--- a/lib/Dialect/Hipsr/IR/CMakeLists.txt
+++ b/lib/Dialect/Hipsr/IR/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(HipsrDialectIR STATIC
   HipsrCastOp.cpp
   HipsrMatMulOp.cpp
   HipsrAddOp.cpp
+  HipsrGetPoolOp.cpp
   HipsrLLVMLoweringUtils.cpp
   HipsrTypes.cpp
 )

--- a/lib/Dialect/Hipsr/IR/HipsrDialect.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrDialect.cpp
@@ -10,6 +10,7 @@
 #include "hip/Dialect/Hipsr/IR/HipsrConstantOp.h"
 #include "hip/Dialect/Hipsr/IR/HipsrEmptyOp.h"
 #include "hip/Dialect/Hipsr/IR/HipsrEmptyYieldOp.h"
+#include "hip/Dialect/Hipsr/IR/HipsrGetPoolOp.h"
 #include "hip/Dialect/Hipsr/IR/HipsrMatMulOp.h"
 #include "hip/Dialect/Hipsr/IR/HipsrOps.h"
 #include "hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.h"
@@ -72,6 +73,9 @@ void HipsrDialect::initialize() {
 #include "hip/Dialect/Hipsr/IR/HipsrAddOp.cpp.inc"
       ,
 #define GET_OP_LIST
+#include "hip/Dialect/Hipsr/IR/HipsrGetPoolOp.cpp.inc"
+      ,
+#define GET_OP_LIST
 #include "hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.cpp.inc"
       >();
   addAttributes<
@@ -111,6 +115,7 @@ void populateHipsrToLLVMPatterns(const LLVMTypeConverter &typeConverter,
                                  RewritePatternSet &patterns) {
   populateHipsrConstantLoweringPatterns(typeConverter, patterns);
   populateHipsrAddLoweringPatterns(typeConverter, patterns);
+  populateHipsrGetPoolLoweringPatterns(typeConverter, patterns);
 }
 
 struct HipsrConvertToLLVMInterface : public ConvertToLLVMPatternInterface {

--- a/lib/Dialect/Hipsr/IR/HipsrGetPoolOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrGetPoolOp.cpp
@@ -39,14 +39,16 @@ struct GetPoolLowering : public ConvertOpToLLVMPattern<GetPoolOp> {
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op.getLoc();
     ModuleOp module = op->getParentOfType<ModuleOp>();
-    Type ptrType = getPtrType();
+    MLIRContext *ctx = rewriter.getContext();
+    Type hostPtrType = LLVM::LLVMPointerType::get(ctx, 0);
+    Type devicePtrType = LLVM::LLVMPointerType::get(ctx, 1);
     Type i32Type = rewriter.getI32Type();
     Type i64Type = rewriter.getI64Type();
     MemRefType memRefType = cast<MemRefType>(op.getPool().getType());
 
-    // TODO: the runtime function should use !llvm.ptr<1> (GPU) pointers.
-    FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
-        rewriter, module, kGetPoolBase, {ptrType, i32Type, i64Type}, ptrType);
+    FailureOr<LLVM::LLVMFuncOp> funcOp =
+        LLVM::lookupOrCreateFn(rewriter, module, kGetPoolBase,
+                               {hostPtrType, i32Type, i64Type}, devicePtrType);
     if (failed(funcOp)) {
       return failure();
     }
@@ -55,25 +57,10 @@ struct GetPoolLowering : public ConvertOpToLLVMPattern<GetPoolOp> {
     Value domainIdVal = LLVM::ConstantOp::create(
         rewriter, loc, i32Type,
         rewriter.getI32IntegerAttr(static_cast<int32_t>(op.getDomainId())));
-    Value rawPtr = LLVM::CallOp::create(
+    Value gpuPtr = LLVM::CallOp::create(
                        rewriter, loc, *funcOp,
                        ValueRange{adaptor.getCtx(), domainIdVal, poolSize})
                        .getResult();
-
-    FailureOr<unsigned> addrSpace =
-        getTypeConverter()->getMemRefAddressSpace(memRefType);
-    if (failed(addrSpace)) {
-      return failure();
-    }
-
-    Value gpuPtr = rawPtr;
-    if (cast<LLVM::LLVMPointerType>(rawPtr.getType()).getAddressSpace() !=
-        *addrSpace) {
-      gpuPtr = LLVM::AddrSpaceCastOp::create(
-          rewriter, loc,
-          LLVM::LLVMPointerType::get(rewriter.getContext(), *addrSpace),
-          rawPtr);
-    }
 
     Value stride1 = LLVM::ConstantOp::create(rewriter, loc, i64Type,
                                              rewriter.getI64IntegerAttr(1));

--- a/lib/Dialect/Hipsr/IR/HipsrGetPoolOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrGetPoolOp.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "hip/Dialect/Hipsr/IR/HipsrGetPoolOp.h"
+
+#include "mlir/Conversion/LLVMCommon/MemRefBuilder.h"
+#include "mlir/Conversion/LLVMCommon/Pattern.h"
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#include "mlir/Dialect/LLVMIR/FunctionCallUtils.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+using namespace mlir;
+using namespace mlir::hipsr;
+
+#define GET_OP_CLASSES
+#include "hip/Dialect/Hipsr/IR/HipsrGetPoolOp.cpp.inc"
+
+void GetPoolOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Allocate::get(),
+                       getOperation()->getResult(0),
+                       SideEffects::DefaultResource::get());
+}
+
+namespace {
+
+constexpr const char *kGetPoolBase = "hipdnn_ep_get_pool_base";
+
+struct GetPoolLowering : public ConvertOpToLLVMPattern<GetPoolOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(GetPoolOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    ModuleOp module = op->getParentOfType<ModuleOp>();
+    Type ptrType = getPtrType();
+    Type i32Type = rewriter.getI32Type();
+    Type i64Type = rewriter.getI64Type();
+    MemRefType memRefType = cast<MemRefType>(op.getPool().getType());
+
+    // TODO: the runtime function should use !llvm.ptr<1> (GPU) pointers.
+    FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
+        rewriter, module, kGetPoolBase, {ptrType, i32Type, i64Type}, ptrType);
+    if (failed(funcOp)) {
+      return failure();
+    }
+
+    Value poolSize = adaptor.getPoolSize();
+    Value domainIdVal = LLVM::ConstantOp::create(
+        rewriter, loc, i32Type,
+        rewriter.getI32IntegerAttr(static_cast<int32_t>(op.getDomainId())));
+    Value rawPtr = LLVM::CallOp::create(
+                       rewriter, loc, *funcOp,
+                       ValueRange{adaptor.getCtx(), domainIdVal, poolSize})
+                       .getResult();
+
+    FailureOr<unsigned> addrSpace =
+        getTypeConverter()->getMemRefAddressSpace(memRefType);
+    if (failed(addrSpace)) {
+      return failure();
+    }
+
+    Value gpuPtr = rawPtr;
+    if (cast<LLVM::LLVMPointerType>(rawPtr.getType()).getAddressSpace() !=
+        *addrSpace) {
+      gpuPtr = LLVM::AddrSpaceCastOp::create(
+          rewriter, loc,
+          LLVM::LLVMPointerType::get(rewriter.getContext(), *addrSpace),
+          rawPtr);
+    }
+
+    Value stride1 = LLVM::ConstantOp::create(rewriter, loc, i64Type,
+                                             rewriter.getI64IntegerAttr(1));
+
+    MemRefDescriptor desc = createMemRefDescriptor(
+        loc, memRefType, gpuPtr, gpuPtr, {poolSize}, {stride1}, rewriter);
+    rewriter.replaceOp(op, {desc});
+    return success();
+  }
+};
+
+} // namespace
+
+void mlir::hipsr::populateHipsrGetPoolLoweringPatterns(
+    const LLVMTypeConverter &converter, RewritePatternSet &patterns) {
+  patterns.add<GetPoolLowering>(converter);
+}

--- a/test/lit/Conversion/hipsr-to-llvm/get_pool.mlir
+++ b/test/lit/Conversion/hipsr-to-llvm/get_pool.mlir
@@ -3,10 +3,21 @@
 
 // RUN: hip-mlir-opt %s --convert-to-llvm | FileCheck %s
 
+// CHECK: llvm.func @hipdnn_ep_get_pool_base(!llvm.ptr, i32, i64) -> !llvm.ptr<1>
+
 // CHECK-LABEL: llvm.func @get_pool
-// CHECK-SAME:  (%[[CTX:.*]]: !llvm.ptr,
-// CHECK:       %[[DOMAIN:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK:       llvm.call @hipdnn_ep_get_pool_base(%[[CTX]], %[[DOMAIN]], %{{.*}}) : (!llvm.ptr, i32, i64) -> !llvm.ptr
+// CHECK-SAME:  (%[[CTX:.*]]: !llvm.ptr, %[[SIZE:.*]]: i64)
+// CHECK-NEXT:    %[[DOMAIN:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT:    %[[PTR:.*]] = llvm.call @hipdnn_ep_get_pool_base(%[[CTX]], %[[DOMAIN]], %[[SIZE]]) : (!llvm.ptr, i32, i64) -> !llvm.ptr<1>
+// CHECK-NEXT:    %[[STRIDE:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK-NEXT:    %[[D0:.*]] = llvm.mlir.poison : !llvm.struct<(ptr<1>, ptr<1>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK-NEXT:    %[[D1:.*]] = llvm.insertvalue %[[PTR]], %[[D0]][0]
+// CHECK-NEXT:    %[[D2:.*]] = llvm.insertvalue %[[PTR]], %[[D1]][1]
+// CHECK-NEXT:    %[[OFFSET:.*]] = llvm.mlir.constant(0 : index) : i64
+// CHECK-NEXT:    %[[D3:.*]] = llvm.insertvalue %[[OFFSET]], %[[D2]][2]
+// CHECK-NEXT:    %[[D4:.*]] = llvm.insertvalue %[[SIZE]], %[[D3]][3, 0]
+// CHECK-NEXT:    %[[D5:.*]] = llvm.insertvalue %[[STRIDE]], %[[D4]][4, 0]
+// CHECK-NEXT:    llvm.return %[[D5]]
 func.func @get_pool(%ctx: !hipsr.context, %size: index)
     -> memref<?xi8, #hipsr.mem<device>> {
   %pool = hipsr.get_pool(%ctx, %size) : memref<?xi8, #hipsr.mem<device>>
@@ -16,8 +27,9 @@ func.func @get_pool(%ctx: !hipsr.context, %size: index)
 // -----
 
 // CHECK-LABEL: llvm.func @get_pool_domain
-// CHECK:       %[[DOMAIN:.*]] = llvm.mlir.constant(2 : i32) : i32
-// CHECK:       llvm.call @hipdnn_ep_get_pool_base(%{{.*}}, %[[DOMAIN]], %{{.*}}) : (!llvm.ptr, i32, i64) -> !llvm.ptr
+// CHECK-SAME:  (%[[CTX:.*]]: !llvm.ptr, %[[SIZE:.*]]: i64)
+// CHECK-NEXT:    %[[DOMAIN:.*]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK-NEXT:    %[[PTR:.*]] = llvm.call @hipdnn_ep_get_pool_base(%[[CTX]], %[[DOMAIN]], %[[SIZE]]) : (!llvm.ptr, i32, i64) -> !llvm.ptr<1>
 func.func @get_pool_domain(%ctx: !hipsr.context, %size: index)
     -> memref<?xi8, #hipsr.mem<device>> {
   %pool = hipsr.get_pool(%ctx, %size) {domain_id = 2 : i64}

--- a/test/lit/Conversion/hipsr-to-llvm/get_pool.mlir
+++ b/test/lit/Conversion/hipsr-to-llvm/get_pool.mlir
@@ -1,0 +1,26 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt %s --convert-to-llvm | FileCheck %s
+
+// CHECK-LABEL: llvm.func @get_pool
+// CHECK-SAME:  (%[[CTX:.*]]: !llvm.ptr,
+// CHECK:       %[[DOMAIN:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK:       llvm.call @hipdnn_ep_get_pool_base(%[[CTX]], %[[DOMAIN]], %{{.*}}) : (!llvm.ptr, i32, i64) -> !llvm.ptr
+func.func @get_pool(%ctx: !hipsr.context, %size: index)
+    -> memref<?xi8, #hipsr.mem<device>> {
+  %pool = hipsr.get_pool(%ctx, %size) : memref<?xi8, #hipsr.mem<device>>
+  return %pool : memref<?xi8, #hipsr.mem<device>>
+}
+
+// -----
+
+// CHECK-LABEL: llvm.func @get_pool_domain
+// CHECK:       %[[DOMAIN:.*]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK:       llvm.call @hipdnn_ep_get_pool_base(%{{.*}}, %[[DOMAIN]], %{{.*}}) : (!llvm.ptr, i32, i64) -> !llvm.ptr
+func.func @get_pool_domain(%ctx: !hipsr.context, %size: index)
+    -> memref<?xi8, #hipsr.mem<device>> {
+  %pool = hipsr.get_pool(%ctx, %size) {domain_id = 2 : i64}
+      : memref<?xi8, #hipsr.mem<device>>
+  return %pool : memref<?xi8, #hipsr.mem<device>>
+}

--- a/test/lit/Dialect/Hipsr/get_pool.mlir
+++ b/test/lit/Dialect/Hipsr/get_pool.mlir
@@ -1,0 +1,24 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt %s -split-input-file | FileCheck %s
+
+// CHECK-LABEL: func.func @get_pool_default
+func.func @get_pool_default(%ctx: !hipsr.context, %size: index)
+    -> memref<?xi8, #hipsr.mem<device>> {
+  // CHECK: hipsr.get_pool(%{{.+}}, %{{.+}}) : memref<?xi8, #hipsr.mem<device>>
+  // CHECK-NOT: domain_id
+  %pool = hipsr.get_pool(%ctx, %size) : memref<?xi8, #hipsr.mem<device>>
+  return %pool : memref<?xi8, #hipsr.mem<device>>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @get_pool_domain
+func.func @get_pool_domain(%ctx: !hipsr.context, %size: index)
+    -> memref<?xi8, #hipsr.mem<device>> {
+  // CHECK: hipsr.get_pool(%{{.+}}, %{{.+}}) {domain_id = 1 : i64} : memref<?xi8, #hipsr.mem<device>>
+  %pool = hipsr.get_pool(%ctx, %size) {domain_id = 1 : i64}
+      : memref<?xi8, #hipsr.mem<device>>
+  return %pool : memref<?xi8, #hipsr.mem<device>>
+}


### PR DESCRIPTION
## Summary

Ports the `get_pool` operation from the `hip` dialect to `hipsr` (`hipsr.get_pool`): a runtime-owned GPU memory pool selected by an optional `domain_id`. Op definition and its LLVM lowering are co-located per the hipsr convention, registered through the dialect's `ConvertToLLVMPatternInterface`.

## Related issue or design

Fixes #48. Hard prerequisite for the PR9 pool-allocs series.

## Why

PR9 (pool allocation) needs `get_pool` in the hipsr dialect. hipsr has no `Conversion/HipsrToLLVM/` directory: each op's lowering pattern lives next to its definition and is registered in `HipsrDialect.cpp::populateHipsrToLLVMPatterns`. The op is non-DPS with explicit operands (ctx, pool_size), so it derives from the base `Hipsr_Op` and carries no shape region, unlike the `Hipsr_DpsOp` compute ops. The runtime ABI is unchanged: lowering reuses the existing `hipdnn_ep_get_pool_base(state, domain_id, size)` entry point.

## What

- `HipsrGetPoolOp.td`: `Hipsr_Op<"get_pool">` with `MemoryEffectsOpInterface`; operands `ctx` / `pool_size`, `domain_id` attr (default 0, elided when 0), `AnyMemRef` result.
- `HipsrGetPoolOp.h` / `.cpp`: `getEffects` (Allocate) + `GetPoolLowering` (materializes `domain_id` as an i32 constant, calls `hipdnn_ep_get_pool_base`, addrspace-casts to the memref's space, builds a 1-D memref descriptor) + `populateHipsrGetPoolLoweringPatterns`.
- `HipsrDialect.cpp` + both `CMakeLists.txt`: register the op, lowering, and tablegen/source entries.

## Test plan

- [x] build-windows green: hip-ep builds on incremental + reconfigure.
- [x] LIT green: 347 passed / 0 failed (2 pre-existing unsupported).
- [x] `test/lit/Dialect/Hipsr/get_pool.mlir`: round-trip; `domain_id = 0` elided, non-zero printed.
- [x] `test/lit/Conversion/hipsr-to-llvm/get_pool.mlir`: `--convert-to-llvm` emits `llvm.call @hipdnn_ep_get_pool_base(...) : (!llvm.ptr, i32, i64) -> !llvm.ptr` with `domain_id` materialized as an i32 constant.
- [x] `pre-commit run --all-files` converges clean.

## Notes for reviewers

The `addrspacecast` in the lowering exists only because `hipdnn_ep_get_pool_base` returns a generic (AS 0) pointer; a `TODO` marks that the runtime should return `!llvm.ptr<1>` directly (same debt as `hipsr.add`). Runtime side is untouched.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [ ] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.
