### PR TITLE
refactor(hipsr): use ReturnLike for empty_yield

### DIFF
--- a/include/hip/Dialect/Hipsr/IR/HipsrEmptyOp.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrEmptyOp.h
@@ -12,6 +12,7 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/OpImplementation.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
 namespace mlir {

--- a/include/hip/Dialect/Hipsr/IR/HipsrEmptyOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrEmptyOp.td
@@ -9,15 +9,17 @@
 #ifndef HIPSR_EMPTY_OP
 #define HIPSR_EMPTY_OP
 
-include "mlir/Interfaces/SideEffectInterfaces.td"
 include "hip/Dialect/Hipsr/IR/HipsrOps.td"
+include "mlir/Interfaces/ControlFlowInterfaces.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
 
 //===----------------------------------------------------------------------===//
 // Hipsr_EmptyOp
 //===----------------------------------------------------------------------===//
 
 def Hipsr_EmptyOp : Hipsr_Op<"empty",
-    [Pure, SingleBlockImplicitTerminator<"EmptyYieldOp">]> {
+    [Pure, DeclareOpInterfaceMethods<RegionBranchOpInterface>,
+     SingleBlockImplicitTerminator<"EmptyYieldOp">]> {
   let summary = "Create init tensor(s) with shape computation in a region";
   let description = [{
     Creates init tensor(s) for destination-passing style operations. Shape
@@ -27,6 +29,9 @@ def Hipsr_EmptyOp : Hipsr_Op<"empty",
     The region contains operations that compute each tensor's shape (dimensions
     and element type), creates a tensor.empty() per result with those
     dimensions, and yields them via hipsr.empty_yield.
+
+    `RegionBranchOpInterface` models the region's yielded values as this
+    operation's results and verifies their counts and types.
 
     Example (single-output):
     ```mlir

--- a/include/hip/Dialect/Hipsr/IR/HipsrEmptyYieldOp.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrEmptyYieldOp.h
@@ -13,6 +13,7 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/OpImplementation.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
 namespace mlir {

--- a/include/hip/Dialect/Hipsr/IR/HipsrEmptyYieldOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrEmptyYieldOp.td
@@ -9,20 +9,24 @@
 #ifndef HIPSR_EMPTY_YIELD_OP
 #define HIPSR_EMPTY_YIELD_OP
 
-include "mlir/Interfaces/SideEffectInterfaces.td"
 include "hip/Dialect/Hipsr/IR/HipsrOps.td"
+include "mlir/Interfaces/ControlFlowInterfaces.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
 
 //===----------------------------------------------------------------------===//
 // Hipsr_EmptyYieldOp
 //===----------------------------------------------------------------------===//
 
 def Hipsr_EmptyYieldOp : Hipsr_Op<"empty_yield",
-    [Pure, Terminator, HasParent<"EmptyOp">]> {
+    [Pure, ReturnLike, Terminator, HasParent<"EmptyOp">]> {
   let summary = "Yield the init tensor(s) from a hipsr.empty region";
   let description = [{
     Terminates a hipsr.empty region and yields the computed init tensors.
     The yielded tensors become the results of the hipsr.empty operation.
     Supports variadic operands for multi-result operations.
+
+    `ReturnLike` lets the parent's `RegionBranchOpInterface` verify that the
+    yielded values match the parent operation's results.
 
     Example (single result):
     ```mlir
@@ -38,8 +42,6 @@ def Hipsr_EmptyYieldOp : Hipsr_Op<"empty_yield",
   let arguments = (ins Variadic<AnyRankedTensor>:$tensors);
 
   let assemblyFormat = "($tensors^ `:` type($tensors))? attr-dict";
-
-  let hasVerifier = 1;
 
   let builders = [
     // No-arg build for the implicit terminator the parent auto-inserts.

--- a/lib/Dialect/Hipsr/IR/HipsrEmptyOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrEmptyOp.cpp
@@ -8,33 +8,39 @@
 #include "hip/Dialect/Hipsr/IR/HipsrEmptyYieldOp.h"
 
 #include "mlir/Dialect/Tensor/IR/Tensor.h" // tensor::EmptyOp
-#include "llvm/ADT/Sequence.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/ErrorHandling.h"
 
 using namespace mlir;
 using namespace mlir::hipsr;
 
 LogicalResult EmptyOp::verify() {
-  // The trait already guarantees a single block ending in EmptyYieldOp. Its
-  // yielded tensors become this op's results, so just check count and types.
+  // RegionBranchOpInterface checks that the yielded values match this op's
+  // results. This op additionally requires each value to be a tensor.empty so
+  // getMixedSizes() can recover its shape operands.
   auto yieldOp = cast<EmptyYieldOp>(getRegion().front().getTerminator());
 
-  if (yieldOp.getTensors().size() != getNumResults()) {
-    return emitOpError() << "has " << getNumResults()
-                         << " result(s) but its empty_yield yields "
-                         << yieldOp.getTensors().size() << " value(s)";
-  }
-
-  for (unsigned idx : llvm::seq<unsigned>(0, getNumResults())) {
-    Type resultType = getResultTypes()[idx];
-    Type yieldType = yieldOp.getTensors()[idx].getType();
-    if (resultType != yieldType) {
-      return emitOpError() << "result #" << idx << " type " << resultType
-                           << " does not match the yielded value type "
-                           << yieldType;
+  for (auto [idx, tensor] : llvm::enumerate(yieldOp.getTensors())) {
+    if (!tensor.getDefiningOp<tensor::EmptyOp>()) {
+      return yieldOp.emitOpError("operand #")
+             << idx << " must be a tensor.empty result";
     }
   }
-
   return success();
+}
+
+void EmptyOp::getSuccessorRegions(RegionBranchPoint point,
+                                  SmallVectorImpl<RegionSuccessor> &regions) {
+  if (point.isParent()) {
+    regions.emplace_back(&getRegion());
+    return;
+  }
+
+  Operation *terminator = point.getTerminatorPredecessorOrNull();
+  if (!terminator || terminator->getParentRegion() != &getRegion()) {
+    llvm::report_fatal_error("hipsr.empty received an unexpected branch point");
+  }
+  regions.emplace_back(getOperation(), getResults());
 }
 
 SmallVector<SmallVector<OpFoldResult>> EmptyOp::getMixedSizes() {
@@ -44,7 +50,7 @@ SmallVector<SmallVector<OpFoldResult>> EmptyOp::getMixedSizes() {
   SmallVector<SmallVector<OpFoldResult>> sizesPerResult;
   for (Value t : yieldOp.getTensors()) {
     auto emptyTensor = t.getDefiningOp<tensor::EmptyOp>();
-    assert(emptyTensor && "hipsr.empty_yield verifier should ensure operands "
+    assert(emptyTensor && "hipsr.empty verifier should ensure yielded values "
                           "are tensor.empty results");
     sizesPerResult.push_back(emptyTensor.getMixedSizes());
   }

--- a/lib/Dialect/Hipsr/IR/HipsrEmptyYieldOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrEmptyYieldOp.cpp
@@ -7,21 +7,5 @@
 
 #include "hip/Dialect/Hipsr/IR/HipsrEmptyOp.h"
 
-#include "mlir/Dialect/Tensor/IR/Tensor.h"
-#include "llvm/ADT/STLExtras.h"
-
-using namespace mlir;
-using namespace mlir::hipsr;
-
-LogicalResult EmptyYieldOp::verify() {
-  for (auto [idx, tensor] : llvm::enumerate(getTensors())) {
-    if (!tensor.getDefiningOp<tensor::EmptyOp>()) {
-      return emitOpError("operand #")
-             << idx << " must be a tensor.empty result";
-    }
-  }
-  return success();
-}
-
 #define GET_OP_CLASSES
 #include "hip/Dialect/Hipsr/IR/HipsrEmptyYieldOp.cpp.inc"

--- a/test/lit/Dialect/Hipsr/empty.mlir
+++ b/test/lit/Dialect/Hipsr/empty.mlir
@@ -45,36 +45,38 @@ func.func @roundtrip_multi(%n: index, %m: index) -> (tensor<?x?xf16>, tensor<?xi
 }
 
 // -----
-// Verifier: result count must match the yielded tensor count.
+// RegionBranchOpInterface: result count must match the yielded tensor count.
 func.func @result_count_mismatch() -> tensor<4xf16> {
-  // expected-error @+1 {{has 1 result(s) but its empty_yield yields 2 value(s)}}
+  // expected-error @+1 {{along control flow edge from Operation hipsr.empty_yield to parent: region branch point has 2 operands, but region successor needs 1 inputs}}
   %0 = hipsr.empty() : tensor<4xf16> {
     %t0 = tensor.empty() : tensor<4xf16>
     %t1 = tensor.empty() : tensor<4xf16>
+    // expected-note @+1 {{region branch point}}
     hipsr.empty_yield %t0, %t1 : tensor<4xf16>, tensor<4xf16>
   }
   return %0 : tensor<4xf16>
 }
 
 // -----
-// Verifier: result type must match the yielded tensor type.
+// RegionBranchOpInterface: result type must match the yielded tensor type.
 func.func @result_type_mismatch() -> tensor<4xi64> {
-  // expected-error @+1 {{result #0 type 'tensor<4xi64>' does not match the yielded value type 'tensor<4xf16>'}}
+  // expected-error @+1 {{along control flow edge from Operation hipsr.empty_yield to parent: successor operand type #0 'tensor<4xf16>' should match successor input type #0 'tensor<4xi64>'}}
   %0 = hipsr.empty() : tensor<4xi64> {
     %t = tensor.empty() : tensor<4xf16>
+    // expected-note @+1 {{region branch point}}
     hipsr.empty_yield %t : tensor<4xf16>
   }
   return %0 : tensor<4xi64>
 }
 
 // -----
-// Verifier: a mismatch on a later result is reported with that result's index
-// (result #0 matches, result #1 does not).
+// RegionBranchOpInterface reports the index of a later result mismatch.
 func.func @later_result_type_mismatch() -> (tensor<4xf16>, tensor<4xi64>) {
-  // expected-error @+1 {{result #1 type 'tensor<4xi64>' does not match the yielded value type 'tensor<4xf16>'}}
+  // expected-error @+1 {{along control flow edge from Operation hipsr.empty_yield to parent: successor operand type #1 'tensor<4xf16>' should match successor input type #1 'tensor<4xi64>'}}
   %0:2 = hipsr.empty() : tensor<4xf16>, tensor<4xi64> {
     %t0 = tensor.empty() : tensor<4xf16>
     %t1 = tensor.empty() : tensor<4xf16>
+    // expected-note @+1 {{region branch point}}
     hipsr.empty_yield %t0, %t1 : tensor<4xf16>, tensor<4xf16>
   }
   return %0#0, %0#1 : tensor<4xf16>, tensor<4xi64>


### PR DESCRIPTION
## Summary
- mark `hipsr.empty_yield` as `ReturnLike`
- model `hipsr.empty` region exits with `RegionBranchOpInterface`
- preserve the `tensor.empty` source invariant while using generic branch verification for result counts and types

## Test plan
- [x] Build `hip-mlir-opt` with the existing Ninja mock configuration
- [x] Run `Dialect/Hipsr/empty.mlir` with LLVM LIT
- [x] Run pre-commit checks on all modified files