### PR TITLE
docs: add security reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+<!--
+Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+Licensed under the MIT License.
+-->
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Do not open a public GitHub issue.** Report privately via one of:
+
+- **GitHub Private Vulnerability Reporting:** [Report a vulnerability](../../security/advisories/new)
+- **AMD Product Security portal:** https://www.amd.com/en/resources/product-security.html
+
+Please include: description and impact, steps to reproduce, and affected
+versions or commits.
+
+We aim to acknowledge reports within 1 business day.
+
+## Scope
+
+This policy covers code and configuration in this repository. For issues in
+third-party dependencies, report upstream. For AMD product issues unrelated to
+this repository, use the
+[AMD Product Security portal](https://www.amd.com/en/resources/product-security.html).


### PR DESCRIPTION
## Summary

Add `SECURITY.md` describing private GitHub and AMD Product Security reporting channels, requested report details, response expectations, and policy scope.
