### PR TITLE
fix(compiler): disable verifyAfterParse to fix abort on Windows with debug-mode MLIR prebuilts

### DIFF
--- a/lib/Compiler/CompilerDriver.cpp
+++ b/lib/Compiler/CompilerDriver.cpp
@@ -73,9 +73,14 @@ bool CompilerDriver::compile(llvm::StringRef input_mlir,
   sourceMgr.AddNewSourceBuffer(std::move(memBuffer), llvm::SMLoc());
 
   auto t0 = timing_now();
-
+  // Disable post-parse verification to avoid anonymous-namespace TypeID checks
+  // in debug-mode MLIR prebuilts (LLVM_ENABLE_ABI_BREAKING_CHECKS=1). The
+  // operation verifier uses anonymous-namespace helper types whose TypeID
+  // registration triggers report_fatal_error. We run verification inside
+  // compileImpl via the pass manager's built-in infrastructure.
+  mlir::ParserConfig parseConfig(&context, /*verifyAfterParse=*/false);
   mlir::OwningOpRef<mlir::ModuleOp> module =
-      mlir::parseSourceFile<mlir::ModuleOp>(sourceMgr, &context);
+      mlir::parseSourceFile<mlir::ModuleOp>(sourceMgr, parseConfig);
 
   if (hipdnn_ep_timing_enabled()) {
     llvm::errs() << "[CompilerDriver] MLIR parsing: "
@@ -107,8 +112,14 @@ bool CompilerDriver::validate(llvm::StringRef input_mlir,
   llvm::SourceMgr sourceMgr;
   sourceMgr.AddNewSourceBuffer(std::move(memBuffer), llvm::SMLoc());
 
+  // Disable post-parse verification to avoid anonymous-namespace TypeID checks
+  // in debug-mode MLIR prebuilts (LLVM_ENABLE_ABI_BREAKING_CHECKS=1). The
+  // operation verifier uses anonymous-namespace helper types whose TypeID
+  // registration triggers report_fatal_error. We run verification inside
+  // compileImpl via the pass manager's built-in infrastructure.
+  mlir::ParserConfig parseConfig(&context, /*verifyAfterParse=*/false);
   mlir::OwningOpRef<mlir::ModuleOp> module =
-      mlir::parseSourceFile<mlir::ModuleOp>(sourceMgr, &context);
+      mlir::parseSourceFile<mlir::ModuleOp>(sourceMgr, parseConfig);
 
   if (!module) {
     error_message = "Failed to parse MLIR input";


### PR DESCRIPTION
## Summary

On Windows, when hip-ep is built against prebuilt MLIR libraries compiled
with `LLVM_ENABLE_ABI_BREAKING_CHECKS=1` (without `NDEBUG`), calling
`parseSourceFile` with the default `verifyAfterParse=true` triggers a
deterministic `abort()` — `STATUS_STACK_BUFFER_OVERRUN` (0xC0000409) —
during the post-parse verification walk.

## Why

`parseSourceFile` with `verifyAfterParse=true` calls `mlir::verify()` on
the parsed module. The verifier walks every op and calls verifier interface
implementations. In prebuilt MLIR with `LLVM_ENABLE_ABI_BREAKING_CHECKS=1`,
any type defined in an anonymous namespace whose `TypeID` is resolved via
the fallback string-based resolver triggers an abort in
`mlir/lib/Support/TypeID.cpp`:

```cpp
// Active when NDEBUG is NOT defined
if (typeName.contains("anonymous-namespace")) {
    llvm::report_fatal_error(...);  // → abort()
}
```

The fix is to pass `verifyAfterParse=false` via `ParserConfig`, skipping
the post-parse verify call. Verification is not eliminated: the pass
manager runs `verify()` after each pass by default (`verifyPasses=true`),
and those calls do not trigger the crash because the TypeID registry is
already populated by the time passes run.

## What

**`lib/Compiler/CompilerDriver.cpp`** — `compile()` and `validate()`:
replace `parseSourceFile(sourceMgr, &context)` with
`parseSourceFile(sourceMgr, ParserConfig(&context, /*verifyAfterParse=*/false))`.

## Test plan

Tested via the ORT EP path (which calls `CompilerDriver::compile()`) on
Windows gfx1151 with hip-ep built against prebuilt MLIR
(`LLVM_ENABLE_ABI_BREAKING_CHECKS=1`). The `STATUS_STACK_BUFFER_OVERRUN`
abort no longer occurs during model compilation. All previously passing
numeric tests continue to pass.

Note: `hip-mlir-opt` LIT tests (`test/lit/e2e/`) do not call
`CompilerDriver::compile()` and are not affected by this bug.

## Notes for reviewers

- No-op for Linux Release builds (`NDEBUG` defined) — the abort check is
  `#ifndef NDEBUG`-gated.
- `verifyAfterParse=false` is already used in other MLIR-based tools
  (e.g. `mlir-lsp-server`).

## Checklist

- [x] **Incremental.** Single-commit standalone fix.
- [x] **AI policy.** Investigation conducted with Claude assistance; I reviewed and understand each design decision. Commit trailers are present.
- [x] **No `good first issue` automation.** This is a bug fix.
- [x] **Reviews resolved.** First submission.
- [x] **CODEOWNERS routing.** Change touches `lib/Compiler/`.