### PR TITLE
fix(typeid): add explicit TypeIDs to all anonymous-namespace RewritePattern subclasses

### DIFF
--- a/lib/Conversion/HipToLLVM/ActivationLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ActivationLowering.cpp
@@ -110,6 +110,7 @@ lowerMiopenActivation(OpType op, typename OpType::Adaptor adaptor,
 //   -> wrap_miopenActivationForward(state, x, y, num_elements,
 //                                    data_type, activation_mode=SIGMOID)
 struct SigmoidOpLowering : public ConvertOpToLLVMPattern<SigmoidOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SigmoidOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
@@ -124,6 +125,7 @@ struct SigmoidOpLowering : public ConvertOpToLLVMPattern<SigmoidOp> {
 //   -> wrap_miopenActivationForward(state, x, y, num_elements,
 //                                    data_type, activation_mode=TANH)
 struct TanhOpLowering : public ConvertOpToLLVMPattern<TanhOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TanhOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
@@ -139,6 +141,7 @@ struct TanhOpLowering : public ConvertOpToLLVMPattern<TanhOp> {
 //                                    data_type, activation_mode=SOFTPLUS)
 // Supports both static and dynamic shapes (computes num_elements at runtime).
 struct SoftplusOpLowering : public ConvertOpToLLVMPattern<SoftplusOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SoftplusOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
@@ -156,6 +159,7 @@ struct SoftplusOpLowering : public ConvertOpToLLVMPattern<SoftplusOp> {
 // Supports data types: f32, f16, bf16, f64 (per ONNX Gelu spec).
 // Supports approximate modes: "none" (erf) and "tanh".
 struct GeluOpLowering : public ConvertOpToLLVMPattern<GeluOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(GeluOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
@@ -242,6 +246,7 @@ struct GeluOpLowering : public ConvertOpToLLVMPattern<GeluOp> {
 // Supports static and dynamic shapes (computes num_elements at runtime).
 // Supports data types: f32, f16, f64.
 struct LeakyReluOpLowering : public ConvertOpToLLVMPattern<LeakyReluOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(LeakyReluOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
@@ -320,6 +325,7 @@ struct LeakyReluOpLowering : public ConvertOpToLLVMPattern<LeakyReluOp> {
 
 // hip.silu(handle, input, output)
 struct SiluOpLowering : public ConvertOpToLLVMPattern<SiluOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SiluOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
@@ -352,6 +358,7 @@ struct SiluOpLowering : public ConvertOpToLLVMPattern<SiluOp> {
 // Rank-generic: softmax over last dim. For 3D [B,S,D], rows = B*S, cols = D.
 struct MiopenSoftmaxOpLowering
     : public ConvertOpToLLVMPattern<MiopenSoftmaxOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(MiopenSoftmaxOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/AndLowering.cpp
+++ b/lib/Conversion/HipToLLVM/AndLowering.cpp
@@ -19,6 +19,7 @@ namespace {
 /// hip_elementwise_and kernel -- mirrors DivOpLowering. Inputs and output
 /// share the same element type for AND (no type promotion).
 struct AndOpLowering : public ConvertOpToLLVMPattern<AndOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(AndOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/CastLowering.cpp
+++ b/lib/Conversion/HipToLLVM/CastLowering.cpp
@@ -14,6 +14,7 @@ namespace {
 //                src_data_type, dst_data_type)
 // Supports both static and dynamic shapes (computes num_elements at runtime).
 struct CastOpLowering : public ConvertOpToLLVMPattern<CastOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(CastOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/CausalConvWithStateLowering.cpp
+++ b/lib/Conversion/HipToLLVM/CausalConvWithStateLowering.cpp
@@ -20,6 +20,7 @@ namespace {
 //                                 element_size_bytes)
 struct CausalConvWithStateOpLowering
     : public ConvertOpToLLVMPattern<CausalConvWithStateOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(CausalConvWithStateOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/ConvLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ConvLowering.cpp
@@ -39,6 +39,7 @@ namespace {
 // host-side typing rule in OnnxToHip (`init` tensor allocated with
 // `resultType.getElementType()`).
 struct ConvOpLowering : public ConvertOpToLLVMPattern<ConvOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ConvOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/ConvTransposeLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ConvTransposeLowering.cpp
@@ -26,6 +26,7 @@ namespace {
 // dtype (f16/bf16/f32).
 struct ConvTransposeOpLowering
     : public ConvertOpToLLVMPattern<ConvTransposeOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ConvTransposeOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/CumSumLowering.cpp
+++ b/lib/Conversion/HipToLLVM/CumSumLowering.cpp
@@ -20,6 +20,7 @@ namespace {
 // pointer plus the axis dtype enum so the runtime knows whether to treat
 // the byte buffer as int32 or int64.
 struct CumSumOpLowering : public ConvertOpToLLVMPattern<CumSumOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(CumSumOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/DivLowering.cpp
+++ b/lib/Conversion/HipToLLVM/DivLowering.cpp
@@ -19,6 +19,7 @@ namespace {
 // Full 4D shapes enable runtime broadcast materialisation via hip_expand
 // before the flat hip_elementwise_div kernel (rank <= 4, left-padded with 1).
 struct DivOpLowering : public ConvertOpToLLVMPattern<DivOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(DivOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/ElementwiseLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ElementwiseLowering.cpp
@@ -16,6 +16,7 @@ namespace {
 // over all elements of A.
 template <typename OpTy>
 struct MiopenBinaryOpLowering : public ConvertOpToLLVMPattern<OpTy> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(MiopenBinaryOpLowering)
   using ConvertOpToLLVMPattern<OpTy>::ConvertOpToLLVMPattern;
   const char *funcName;
 
@@ -88,6 +89,7 @@ struct MiopenBinaryOpLowering : public ConvertOpToLLVMPattern<OpTy> {
 // elementwise support is available.
 template <typename OpTy, HipdnnTensorOp tensorOpEnum>
 struct ElementwiseOpLowering : public ConvertOpToLLVMPattern<OpTy> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ElementwiseOpLowering)
   using ConvertOpToLLVMPattern<OpTy>::ConvertOpToLLVMPattern;
 
   LogicalResult
@@ -160,6 +162,7 @@ struct ElementwiseOpLowering : public ConvertOpToLLVMPattern<OpTy> {
 // Full 4D shapes enable runtime broadcast materialisation via hip_expand
 // before the flat hip_elementwise_sub kernel (rank <= 4, left-padded with 1).
 struct SubOpLowering : public ConvertOpToLLVMPattern<SubOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SubOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/EqualLowering.cpp
+++ b/lib/Conversion/HipToLLVM/EqualLowering.cpp
@@ -18,6 +18,7 @@ namespace {
 // the runtime handles same-shape / scalar directly and materialises any other
 // ONNX multidirectional broadcast via hip_expand -- mirrors DivOpLowering.
 struct EqualOpLowering : public ConvertOpToLLVMPattern<EqualOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(EqualOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/ExpandLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ExpandLowering.cpp
@@ -13,6 +13,7 @@ namespace {
 //   -> wrap_expand(state, in_ptr, shape_ptr, out_ptr,
 //                  in_shape_ptr, in_rank, out_shape_ptr, out_rank, data_type)
 struct ExpandOpLowering : public ConvertOpToLLVMPattern<ExpandOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ExpandOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/GatherBlockQuantizedLowering.cpp
+++ b/lib/Conversion/HipToLLVM/GatherBlockQuantizedLowering.cpp
@@ -45,6 +45,7 @@ namespace {
 
 struct GatherBlockQuantizedOpLowering
     : public ConvertOpToLLVMPattern<GatherBlockQuantizedOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(GatherBlockQuantizedOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/GatherLowering.cpp
+++ b/lib/Conversion/HipToLLVM/GatherLowering.cpp
@@ -11,6 +11,7 @@ namespace {
 
 // hip.gather(handle, indices, table, output)
 struct GatherOpLowering : public ConvertOpToLLVMPattern<GatherOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(GatherOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/GatherNDLowering.cpp
+++ b/lib/Conversion/HipToLLVM/GatherNDLowering.cpp
@@ -16,6 +16,7 @@ namespace {
 //                     output_shape_ptr, output_rank,
 //                     batch_dims, data_type)
 struct GatherNDOpLowering : public ConvertOpToLLVMPattern<GatherNDOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(GatherNDOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/GemmLowering.cpp
+++ b/lib/Conversion/HipToLLVM/GemmLowering.cpp
@@ -12,6 +12,7 @@ namespace {
 // hip.gemm(handle, input_A, input_B, input_C, output, alpha, beta, transA,
 // transB, typeCode)
 struct GemmOpLowering : public ConvertOpToLLVMPattern<GemmOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(GemmOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/GlobalPoolLowering.cpp
+++ b/lib/Conversion/HipToLLVM/GlobalPoolLowering.cpp
@@ -44,6 +44,7 @@ namespace {
 // rely on small positive values (>=1, validated upstream in OnnxToHip).
 
 struct GlobalPoolOpLowering : public ConvertOpToLLVMPattern<GlobalPoolOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(GlobalPoolOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/GqaLowering.cpp
+++ b/lib/Conversion/HipToLLVM/GqaLowering.cpp
@@ -13,6 +13,7 @@ namespace {
 // total_seq_len,
 //         output, present_key, present_value) {attributes...}
 struct GqaOpLowering : public ConvertOpToLLVMPattern<GqaOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(GqaOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/GraphLowering.cpp
+++ b/lib/Conversion/HipToLLVM/GraphLowering.cpp
@@ -13,6 +13,7 @@ namespace {
 
 template <typename OpTy>
 struct GraphRegionOpLowering : public ConvertOpToLLVMPattern<OpTy> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(GraphRegionOpLowering)
   using ConvertOpToLLVMPattern<OpTy>::ConvertOpToLLVMPattern;
 
   LogicalResult
@@ -31,6 +32,7 @@ using HipblasltGraphOpLowering = GraphRegionOpLowering<HipblasltGraphOp>;
 // --- HipDNNGraphOp: hip.hipdnn_graph -> hipdnn_graph_execute(state,
 //     graph_id, num_io, uids, ptrs)
 struct HipDNNGraphOpLowering : public ConvertOpToLLVMPattern<HipDNNGraphOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(HipDNNGraphOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/LessLowering.cpp
+++ b/lib/Conversion/HipToLLVM/LessLowering.cpp
@@ -19,6 +19,7 @@ namespace {
 // multidirectional broadcast via hip_expand before the flat
 // hip_elementwise_less kernel -- mirrors DivOpLowering.
 struct LessOpLowering : public ConvertOpToLLVMPattern<LessOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(LessOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/LinearAttentionLowering.cpp
+++ b/lib/Conversion/HipToLLVM/LinearAttentionLowering.cpp
@@ -11,6 +11,7 @@ namespace {
 
 struct LinearAttentionOpLowering
     : public ConvertOpToLLVMPattern<LinearAttentionOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(LinearAttentionOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/LoopLowering.cpp
+++ b/lib/Conversion/HipToLLVM/LoopLowering.cpp
@@ -259,6 +259,7 @@ createOrGetTrampoline(OpBuilder &b, ModuleOp module, Location loc, LoopOp op,
 //===----------------------------------------------------------------------===//
 
 struct LoopOpLowering : public ConvertOpToLLVMPattern<LoopOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(LoopOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/MatMulNBitsLowering.cpp
+++ b/lib/Conversion/HipToLLVM/MatMulNBitsLowering.cpp
@@ -14,6 +14,7 @@ namespace {
 //===----------------------------------------------------------------------===//
 
 struct MatMulNBitsOpLowering : public ConvertOpToLLVMPattern<MatMulNBitsOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(MatMulNBitsOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/MatmulLowering.cpp
+++ b/lib/Conversion/HipToLLVM/MatmulLowering.cpp
@@ -15,6 +15,7 @@ namespace {
 //   -> hip_hipblaslt_matmul(handle, A, B, C, rankA, rankB, batch, M, K, N)
 // Rank-generic: batch from A if 3D, B broadcast if rankB < rankA.
 struct MatmulOpLowering : public ConvertOpToLLVMPattern<MatmulOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(MatmulOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/MemoryLowering.cpp
+++ b/lib/Conversion/HipToLLVM/MemoryLowering.cpp
@@ -15,6 +15,7 @@ namespace {
 
 // --- AllocOp: hip.alloc(%ctx, %dyn...) -> hipMalloc(bytes) + memref descriptor
 struct AllocOpLowering : public ConvertOpToLLVMPattern<AllocOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(AllocOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
@@ -70,6 +71,7 @@ struct AllocOpLowering : public ConvertOpToLLVMPattern<AllocOp> {
 
 // --- FreeOp: hip.free(%ctx, %memref) -> llvm.call @hipFree(allocated_ptr)
 struct FreeOpLowering : public ConvertOpToLLVMPattern<FreeOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(FreeOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
@@ -109,6 +111,7 @@ struct FreeOpLowering : public ConvertOpToLLVMPattern<FreeOp> {
 // Single-domain models emit `domain_id = 0` and round-trip identically to
 // the pre-multi-domain IR (printer elides the default).
 struct GetPoolOpLowering : public ConvertOpToLLVMPattern<GetPoolOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(GetPoolOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
@@ -170,6 +173,7 @@ struct GetPoolOpLowering : public ConvertOpToLLVMPattern<GetPoolOp> {
 // memref.view see the same pointer.
 struct GetHostScratchOpLowering
     : public ConvertOpToLLVMPattern<GetHostScratchOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(GetHostScratchOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
@@ -242,6 +246,7 @@ struct GetHostScratchOpLowering
 //   // descriptor { alloc=%p, aligned=%p, offset=0, sizes=[%M,%N],
 //   //              strides=[%N,1] }
 struct AllocOutputOpLowering : public ConvertOpToLLVMPattern<AllocOutputOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(AllocOutputOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
@@ -343,6 +348,7 @@ struct AllocOutputOpLowering : public ConvertOpToLLVMPattern<AllocOutputOp> {
 //===----------------------------------------------------------------------===//
 
 struct GetConstantOpLowering : public ConvertOpToLLVMPattern<GetConstantOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(GetConstantOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
@@ -407,6 +413,7 @@ struct GetConstantOpLowering : public ConvertOpToLLVMPattern<GetConstantOp> {
 // --- memref.alloc -> hip_device_malloc (produced by bufferization for
 // tensor.empty)
 struct MemRefAllocOpLowering : public ConvertOpToLLVMPattern<memref::AllocOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(MemRefAllocOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
@@ -445,6 +452,7 @@ struct MemRefAllocOpLowering : public ConvertOpToLLVMPattern<memref::AllocOp> {
 // --- memref.dealloc -> hip_device_free (produced by bufferization)
 struct MemRefDeallocOpLowering
     : public ConvertOpToLLVMPattern<memref::DeallocOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(MemRefDeallocOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
@@ -544,6 +552,7 @@ static bool strideVectorsEqual(ArrayRef<int64_t> a, ArrayRef<int64_t> b) {
 /// wrap_hipMemcpy2DAsync when strides are statically known. Otherwise leaves
 /// conversion to the default MemRef→LLVM copy lowering (benefit 1).
 struct MemRefCopyOpLowering : public ConvertOpToLLVMPattern<memref::CopyOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(MemRefCopyOpLowering)
   MemRefCopyOpLowering(const LLVMTypeConverter &converter)
       : ConvertOpToLLVMPattern(converter, PatternBenefit(10)) {}
 

--- a/lib/Conversion/HipToLLVM/ModLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ModLowering.cpp
@@ -12,6 +12,7 @@ namespace {
 // hip.mod(ctx, a, b, output) {fmod}
 //   -> wrap_mod(state, a_ptr, b_ptr, out_ptr, num_elements, data_type, fmod)
 struct ModOpLowering : public ConvertOpToLLVMPattern<ModOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ModOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/MultiHeadAttentionLowering.cpp
+++ b/lib/Conversion/HipToLLVM/MultiHeadAttentionLowering.cpp
@@ -15,6 +15,7 @@ namespace {
 //     output, [present_key], [present_value], [qk]) {attributes...}
 struct MultiHeadAttentionOpLowering
     : public ConvertOpToLLVMPattern<MultiHeadAttentionOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(MultiHeadAttentionOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/NonZeroLowering.cpp
+++ b/lib/Conversion/HipToLLVM/NonZeroLowering.cpp
@@ -29,6 +29,7 @@ namespace {
 // computes it directly from the output descriptor so the path is correct
 // even if the conversion ever uses a smaller upper bound.
 struct NonZeroOpLowering : public ConvertOpToLLVMPattern<NonZeroOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(NonZeroOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/NormLowering.cpp
+++ b/lib/Conversion/HipToLLVM/NormLowering.cpp
@@ -36,6 +36,7 @@ inline Value getNullableMemRefPtr(Value memref,
 // Rank-generic: N = product of all dims except last, D = last dim.
 // For 3D [B,S,D]: N = B*S, D = D.
 struct RmsNormOpLowering : public ConvertOpToLLVMPattern<RmsNormOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(RmsNormOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
@@ -111,6 +112,7 @@ struct RmsNormOpLowering : public ConvertOpToLLVMPattern<RmsNormOp> {
 
 // hip.skip_rms_norm lowering with dynamic shape support
 struct SkipRmsNormOpLowering : public ConvertOpToLLVMPattern<SkipRmsNormOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SkipRmsNormOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult
@@ -213,6 +215,7 @@ struct SkipRmsNormOpLowering : public ConvertOpToLLVMPattern<SkipRmsNormOp> {
 // bias / mean / inv_std are optional — when absent, a null pointer (address
 // space 0) is forwarded so the runtime can early-out for that step.
 struct LayerNormOpLowering : public ConvertOpToLLVMPattern<LayerNormOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(LayerNormOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/PadLowering.cpp
+++ b/lib/Conversion/HipToLLVM/PadLowering.cpp
@@ -20,6 +20,7 @@ namespace {
 // `mode_id` encodes the string attribute as a small enum:
 //   0 = constant, 1 = reflect, 2 = edge, 3 = wrap.
 struct PadOpLowering : public ConvertOpToLLVMPattern<PadOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(PadOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   static int64_t modeIdFromString(StringRef m) {

--- a/lib/Conversion/HipToLLVM/PoolLowering.cpp
+++ b/lib/Conversion/HipToLLVM/PoolLowering.cpp
@@ -40,6 +40,7 @@ namespace {
 //   -> i32
 
 struct PoolOpLowering : public ConvertOpToLLVMPattern<PoolOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(PoolOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/PowerLowering.cpp
+++ b/lib/Conversion/HipToLLVM/PowerLowering.cpp
@@ -21,6 +21,7 @@ namespace {
 //   - Cube:       alpha=0, beta=1, gamma=3.0   → (0 + 1*x)^3 = x^3
 template <typename OpTy>
 struct PowerOpLowering : public ConvertOpToLLVMPattern<OpTy> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(PowerOpLowering)
   using ConvertOpToLLVMPattern<OpTy>::ConvertOpToLLVMPattern;
   double alpha, beta, gamma;
   const char *opName;

--- a/lib/Conversion/HipToLLVM/QMoELowering.cpp
+++ b/lib/Conversion/HipToLLVM/QMoELowering.cpp
@@ -14,6 +14,7 @@ namespace {
 //===----------------------------------------------------------------------===//
 
 struct QMoEOpLowering : public ConvertOpToLLVMPattern<QMoEOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(QMoEOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/RangeLowering.cpp
+++ b/lib/Conversion/HipToLLVM/RangeLowering.cpp
@@ -31,6 +31,7 @@ static int64_t getHipCustomKernelDType(Type elemType) {
 //   -> wrap_range(state, start, limit, delta, output, output_num_elements,
 //                 hip_dtype)
 struct RangeOpLowering : public ConvertOpToLLVMPattern<RangeOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(RangeOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/ReadbackDimLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ReadbackDimLowering.cpp
@@ -21,6 +21,7 @@ namespace {
 // host-side index arithmetic (tensor.extract_slice size, tensor.empty
 // dynsize, hip.alloc_output extent, ...).
 struct ReadbackDimOpLowering : public ConvertOpToLLVMPattern<ReadbackDimOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ReadbackDimOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/ReadbackScalarLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ReadbackScalarLowering.cpp
@@ -28,6 +28,7 @@ namespace {
 // operand's element type and sign.
 struct ReadbackScalarOpLowering
     : public ConvertOpToLLVMPattern<ReadbackScalarOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ReadbackScalarOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/ReduceLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ReduceLowering.cpp
@@ -26,6 +26,7 @@ namespace {
 // Supports both static and dynamic shapes (computes num_elements at runtime).
 template <typename OpTy>
 struct ReduceOpLowering : public ConvertOpToLLVMPattern<OpTy> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ReduceOpLowering)
   using ConvertOpToLLVMPattern<OpTy>::ConvertOpToLLVMPattern;
   const char *funcName;
   const char *opName;

--- a/lib/Conversion/HipToLLVM/ResizeLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ResizeLowering.cpp
@@ -30,6 +30,7 @@ namespace {
 //   -> i32
 
 struct ResizeOpLowering : public ConvertOpToLLVMPattern<ResizeOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ResizeOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/RopeLowering.cpp
+++ b/lib/Conversion/HipToLLVM/RopeLowering.cpp
@@ -11,6 +11,7 @@ namespace {
 
 // hip.miopen.rope(handle, q, k, cos_cache, sin_cache, start_pos)
 struct RopeOpLowering : public ConvertOpToLLVMPattern<RopeOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(RopeOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/ScatterNDLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ScatterNDLowering.cpp
@@ -35,6 +35,7 @@ namespace {
 // param list here in lockstep with the wrap_scatter_nd declaration in
 // hipdnn_ep_runtime.h.
 struct ScatterNDOpLowering : public ConvertOpToLLVMPattern<ScatterNDOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ScatterNDOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   static int64_t reductionIdFromString(StringRef r) {

--- a/lib/Conversion/HipToLLVM/SizeLowering.cpp
+++ b/lib/Conversion/HipToLLVM/SizeLowering.cpp
@@ -22,6 +22,7 @@ namespace {
 // input pointer also keeps the input memref live only as a shape source,
 // which buffer-deallocation can free aggressively.
 struct SizeOpLowering : public ConvertOpToLLVMPattern<SizeOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SizeOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/SliceLowering.cpp
+++ b/lib/Conversion/HipToLLVM/SliceLowering.cpp
@@ -23,6 +23,7 @@ namespace {
 // when a Slice cannot be folded to tensor.extract_slice by the OnnxToHip
 // decompose pattern.
 struct SliceOpLowering : public ConvertOpToLLVMPattern<SliceOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SliceOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/TileLowering.cpp
+++ b/lib/Conversion/HipToLLVM/TileLowering.cpp
@@ -13,6 +13,7 @@ namespace {
 //   -> wrap_tile(state, in_ptr, repeats_ptr, out_ptr,
 //                in_shape_ptr, in_rank, out_shape_ptr, out_rank, data_type)
 struct TileOpLowering : public ConvertOpToLLVMPattern<TileOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TileOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/TransposeLowering.cpp
+++ b/lib/Conversion/HipToLLVM/TransposeLowering.cpp
@@ -17,6 +17,7 @@ namespace {
 // the runtime treats them as host-side metadata and forwards them to the
 // transpose kernel after computing strides.
 struct TransposeOpLowering : public ConvertOpToLLVMPattern<TransposeOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TransposeOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/HipToLLVM/UnaryElementwiseLowering.cpp
+++ b/lib/Conversion/HipToLLVM/UnaryElementwiseLowering.cpp
@@ -16,6 +16,7 @@ namespace {
 // Ops lower to wrap_{op}(state, input, output, num_elements, data_type).
 template <typename OpTy>
 struct UnaryElementwiseOpLowering : public ConvertOpToLLVMPattern<OpTy> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(UnaryElementwiseOpLowering)
   using ConvertOpToLLVMPattern<OpTy>::ConvertOpToLLVMPattern;
   const char *funcName;
   const char *opName;

--- a/lib/Conversion/HipToLLVM/WhereLowering.cpp
+++ b/lib/Conversion/HipToLLVM/WhereLowering.cpp
@@ -50,6 +50,7 @@ namespace {
 // updated together; otherwise the kernel will read wrong offsets
 // silently. See the matching comment block at the top of that .hip file.
 struct WhereOpLowering : public ConvertOpToLLVMPattern<WhereOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(WhereOpLowering)
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   LogicalResult

--- a/lib/Conversion/OnnxToHip/ActivationConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ActivationConversion.cpp
@@ -11,6 +11,7 @@ namespace {
 
 /// onnx.Softmax -> hip.miopen.softmax
 struct SoftmaxToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SoftmaxToHip)
   SoftmaxToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Softmax", /*benefit=*/1, ctx) {}
 
@@ -42,6 +43,7 @@ SoftmaxToHip::matchAndRewrite(mlir::Operation *op,
 
 /// onnx.Sigmoid -> hip.sigmoid
 struct SigmoidToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SigmoidToHip)
   SigmoidToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Sigmoid", /*benefit=*/1, ctx) {}
 
@@ -71,6 +73,7 @@ SigmoidToHip::matchAndRewrite(mlir::Operation *op,
 
 /// onnx.Tanh -> hip.tanh
 struct TanhToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TanhToHip)
   TanhToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Tanh", /*benefit=*/1, ctx) {}
 
@@ -102,6 +105,7 @@ TanhToHip::matchAndRewrite(mlir::Operation *op,
 
 /// onnx.Softplus -> hip.softplus
 struct SoftplusToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SoftplusToHip)
   SoftplusToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Softplus", /*benefit=*/1, ctx) {}
 
@@ -131,6 +135,7 @@ SoftplusToHip::matchAndRewrite(mlir::Operation *op,
 
 /// onnx.Gelu -> hip.gelu
 struct GeluToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(GeluToHip)
   GeluToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Gelu", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/AndConversion.cpp
+++ b/lib/Conversion/OnnxToHip/AndConversion.cpp
@@ -16,6 +16,7 @@ namespace {
 /// `createBroadcastEmptyTensor` so each axis picks the non-broadcasting operand
 /// (e.g. `[?x1] & [1x?] -> [?x?]`).
 struct AndToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(AndToHip)
   AndToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.And", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/AttentionConversion.cpp
+++ b/lib/Conversion/OnnxToHip/AttentionConversion.cpp
@@ -42,6 +42,7 @@ namespace {
 /// layout matches what the original ONNX graph already has and produces a
 /// single large GEMM (cleaner lowering, fewer hipBLASLt launches).
 struct AttentionToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(AttentionToHip)
   AttentionToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Custom", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/CastConversion.cpp
+++ b/lib/Conversion/OnnxToHip/CastConversion.cpp
@@ -11,6 +11,7 @@ namespace {
 
 /// onnx.Cast -> hip.cast
 struct CastToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(CastToHip)
   CastToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Cast", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/CausalConvWithStateConversion.cpp
+++ b/lib/Conversion/OnnxToHip/CausalConvWithStateConversion.cpp
@@ -11,6 +11,7 @@ namespace {
 
 /// com.microsoft.CausalConvWithState -> hip.causal_conv_with_state
 struct CausalConvWithStateToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(CausalConvWithStateToHip)
   CausalConvWithStateToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Custom", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/ClipConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ClipConversion.cpp
@@ -48,6 +48,7 @@ static bool isNoValue(mlir::Value v) {
 }
 
 struct ClipToHipMinMax : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ClipToHipMinMax)
   ClipToHipMinMax(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Clip", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/ConcatConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ConcatConversion.cpp
@@ -64,6 +64,7 @@ namespace {
 //   %r    = tensor.insert_slice %b into %0  [%dim_a, 0] [3, 4] [1, 1]
 
 struct ConcatDecompose : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ConcatDecompose)
   ConcatDecompose(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Concat", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/ConstantOfShapeConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ConstantOfShapeConversion.cpp
@@ -211,6 +211,7 @@ static mlir::LogicalResult buildScalarFillValue(mlir::Operation *op,
 /// (host-writable AND GPU-readable at the same VA on UMA), so the where kernel
 /// reads a valid device-side address.
 struct ConstantOfShapeAsScalar : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ConstantOfShapeAsScalar)
   ConstantOfShapeAsScalar(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.ConstantOfShape", /*benefit=*/3, ctx) {}
 
@@ -259,6 +260,7 @@ struct ConstantOfShapeAsScalar : public mlir::RewritePattern {
 };
 
 struct ConstantOfShapeFold : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ConstantOfShapeFold)
   ConstantOfShapeFold(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.ConstantOfShape", /*benefit=*/2, ctx) {}
 
@@ -361,6 +363,7 @@ struct ConstantOfShapeFold : public mlir::RewritePattern {
 /// Handles either (a) a non-constant shape input or (b) a result type with
 /// at least one dynamic dim.
 struct ConstantOfShapeDynamic : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ConstantOfShapeDynamic)
   ConstantOfShapeDynamic(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.ConstantOfShape", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/ConvConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ConvConversion.cpp
@@ -19,6 +19,7 @@ namespace {
 /// convs), and dynamic result dims (batch, channels, and spatial extents) are
 /// sized at runtime from the conv input + attributes.
 struct ConvToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ConvToHip)
   ConvToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Conv", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/ConvTransposeConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ConvTransposeConversion.cpp
@@ -23,6 +23,7 @@ namespace {
 ///          {kernel_shape = [3, 3], strides = [2, 2], pads = [0, 0, 0, 0],
 ///           dilations = [1, 1], output_padding = [0, 0], group = 1}
 struct ConvTransposeToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ConvTransposeToHip)
   ConvTransposeToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.ConvTranspose", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/CosConversion.cpp
+++ b/lib/Conversion/OnnxToHip/CosConversion.cpp
@@ -12,6 +12,7 @@ namespace {
 /// onnx.Cos -> hip.cos
 /// Unary element-wise cosine: Y = cos(X). Float types.
 struct CosToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(CosToHip)
   CosToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Cos", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/CumSumConversion.cpp
+++ b/lib/Conversion/OnnxToHip/CumSumConversion.cpp
@@ -11,6 +11,7 @@ namespace {
 
 /// onnx.CumSum -> hip.cumsum
 struct CumSumToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(CumSumToHip)
   CumSumToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.CumSum", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/DivConversion.cpp
+++ b/lib/Conversion/OnnxToHip/DivConversion.cpp
@@ -11,6 +11,7 @@ namespace {
 
 /// onnx.Div -> hip.div
 struct DivToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(DivToHip)
   DivToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Div", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/ElementwiseConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ElementwiseConversion.cpp
@@ -11,6 +11,7 @@ namespace {
 
 /// onnx.Add -> hip.miopen.add
 struct AddToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(AddToHip)
   AddToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Add", /*benefit=*/1, ctx) {}
 
@@ -21,6 +22,7 @@ struct AddToHip : public mlir::RewritePattern {
 
 /// onnx.Mul -> hip.mul
 struct MulToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(MulToHip)
   MulToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Mul", /*benefit=*/1, ctx) {}
 
@@ -31,6 +33,7 @@ struct MulToHip : public mlir::RewritePattern {
 
 /// onnx.Sub -> hip.sub
 struct SubToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SubToHip)
   SubToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Sub", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/EqualConversion.cpp
+++ b/lib/Conversion/OnnxToHip/EqualConversion.cpp
@@ -11,6 +11,7 @@ namespace {
 
 /// onnx.Equal -> hip.equal
 struct EqualToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(EqualToHip)
   EqualToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Equal", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/ErfGeluFusion.cpp
+++ b/lib/Conversion/OnnxToHip/ErfGeluFusion.cpp
@@ -128,6 +128,7 @@ matchCommutativeConst(mlir::Operation *op, double expected) {
 }
 
 struct InlinedErfGeluToGelu : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(InlinedErfGeluToGelu)
   InlinedErfGeluToGelu(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Erf", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/ExpConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ExpConversion.cpp
@@ -21,6 +21,7 @@ namespace {
 //   %y = hip.exp(%ctx) ins(%x : tensor<1024x1x64x64xf16>)
 //                     outs(%init : tensor<1024x1x64x64xf16>)
 struct ExpToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ExpToHip)
   ExpToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Exp", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/ExpandConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ExpandConversion.cpp
@@ -29,6 +29,7 @@ static mlir::Value readShapeEntryToIndex(mlir::PatternRewriter &rewriter,
 /// input tensor (right-aligned with the result rank, NumPy-style); leading
 /// dims that are absent from `shape` fall back to the matching input dim.
 struct ExpandToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ExpandToHip)
   ExpandToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Expand", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/FastGeluFusion.cpp
+++ b/lib/Conversion/OnnxToHip/FastGeluFusion.cpp
@@ -217,6 +217,7 @@ static bool isBinaryOpWithConst(mlir::Operation *op, llvm::StringRef opName,
 /// in CLAUDE.md is the regression signal for that pattern; this pattern's
 /// failure histogram doesn't conflate the two).
 struct InlinedFastGeluVisionToGelu : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(InlinedFastGeluVisionToGelu)
   InlinedFastGeluVisionToGelu(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Tanh", /*benefit=*/1, ctx) {}
 
@@ -381,6 +382,7 @@ struct InlinedFastGeluVisionToGelu : public mlir::RewritePattern {
 };
 
 struct InlinedFastGeluToGelu : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(InlinedFastGeluToGelu)
   InlinedFastGeluToGelu(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Tanh", /*benefit=*/1, ctx) {}
 
@@ -588,6 +590,7 @@ struct InlinedFastGeluToGelu : public mlir::RewritePattern {
 /// After:
 ///   %y = onnx.Gelu(%x) {approximate = "none"} : tensor<?xf16>
 struct InlinedExactGeluToGelu : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(InlinedExactGeluToGelu)
   InlinedExactGeluToGelu(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Erf", /*benefit=*/2, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/FlattenConversion.cpp
+++ b/lib/Conversion/OnnxToHip/FlattenConversion.cpp
@@ -61,6 +61,7 @@ namespace {
 // `tensor.dim` on the intermediate for the dynamic side.
 
 struct FlattenDecompose : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(FlattenDecompose)
   FlattenDecompose(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Flatten", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/GatherBlockQuantizedConversion.cpp
+++ b/lib/Conversion/OnnxToHip/GatherBlockQuantizedConversion.cpp
@@ -41,6 +41,7 @@ namespace {
 // rows during the dequantize step.
 
 struct GatherBlockQuantizedToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(GatherBlockQuantizedToHip)
   GatherBlockQuantizedToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Custom", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/GatherConversion.cpp
+++ b/lib/Conversion/OnnxToHip/GatherConversion.cpp
@@ -14,6 +14,7 @@ namespace {
 //===----------------------------------------------------------------------===//
 
 struct GatherToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(GatherToHip)
   GatherToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Gather", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/GatherNDConversion.cpp
+++ b/lib/Conversion/OnnxToHip/GatherNDConversion.cpp
@@ -29,6 +29,7 @@ namespace {
 ///   * data-tail region (i >= q - 1): take from data at
 ///     `i - (q - 1) + batch_dims + indices.shape[-1]`.
 struct GatherNDToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(GatherNDToHip)
   GatherNDToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.GatherND", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/GatherShapeFold.cpp
+++ b/lib/Conversion/OnnxToHip/GatherShapeFold.cpp
@@ -97,6 +97,7 @@ static std::optional<int64_t> getInlineScalarIndex(mlir::Operation *constOp) {
 }
 
 struct GatherOfShapeToDim : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(GatherOfShapeToDim)
   GatherOfShapeToDim(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Gather", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/GemmConversion.cpp
+++ b/lib/Conversion/OnnxToHip/GemmConversion.cpp
@@ -13,6 +13,7 @@ namespace {
 // ONNX Gemm -> HIP Gemm
 //===----------------------------------------------------------------------===//
 struct GemmToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(GemmToHip)
   GemmToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Gemm", /*benefit=*/1, ctx) {}
   mlir::LogicalResult

--- a/lib/Conversion/OnnxToHip/GlobalPoolConversion.cpp
+++ b/lib/Conversion/OnnxToHip/GlobalPoolConversion.cpp
@@ -96,6 +96,7 @@ static mlir::LogicalResult buildHipGlobalPool(mlir::Operation *op,
 }
 
 struct GlobalAveragePoolToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(GlobalAveragePoolToHip)
   GlobalAveragePoolToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.GlobalAveragePool", /*benefit=*/1, ctx) {}
 
@@ -108,6 +109,7 @@ struct GlobalAveragePoolToHip : public mlir::RewritePattern {
 };
 
 struct GlobalMaxPoolToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(GlobalMaxPoolToHip)
   GlobalMaxPoolToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.GlobalMaxPool", /*benefit=*/1, ctx) {}
 
@@ -120,6 +122,7 @@ struct GlobalMaxPoolToHip : public mlir::RewritePattern {
 };
 
 struct GlobalLpPoolToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(GlobalLpPoolToHip)
   GlobalLpPoolToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.GlobalLpPool", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/GqaConversion.cpp
+++ b/lib/Conversion/OnnxToHip/GqaConversion.cpp
@@ -11,6 +11,7 @@ namespace {
 
 /// onnx.Custom(GroupQueryAttention) -> hip.gqa
 struct GroupQueryAttentionToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(GroupQueryAttentionToHip)
   GroupQueryAttentionToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Custom", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/GreaterOrEqualConversion.cpp
+++ b/lib/Conversion/OnnxToHip/GreaterOrEqualConversion.cpp
@@ -30,6 +30,7 @@ namespace {
 /// NaN-correct lowering would need e.g. `(B < A) || (A == B)` (extra ops) or a
 /// dedicated `>=` kernel.
 struct GreaterOrEqualDecompose : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(GreaterOrEqualDecompose)
   GreaterOrEqualDecompose(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.GreaterOrEqual", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/IdentityConversion.cpp
+++ b/lib/Conversion/OnnxToHip/IdentityConversion.cpp
@@ -29,6 +29,7 @@ namespace {
 // required.
 
 struct IdentityForward : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(IdentityForward)
   IdentityForward(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Identity", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/LeakyReluConversion.cpp
+++ b/lib/Conversion/OnnxToHip/LeakyReluConversion.cpp
@@ -28,6 +28,7 @@ namespace hip {
 namespace {
 
 struct LeakyReluToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(LeakyReluToHip)
   LeakyReluToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.LeakyRelu", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/LessConversion.cpp
+++ b/lib/Conversion/OnnxToHip/LessConversion.cpp
@@ -11,6 +11,7 @@ namespace {
 
 /// onnx.Less -> hip.less
 struct LessToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(LessToHip)
   LessToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Less", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/LessOrEqualConversion.cpp
+++ b/lib/Conversion/OnnxToHip/LessOrEqualConversion.cpp
@@ -31,6 +31,7 @@ namespace {
 /// NaN-correct lowering would need e.g. `(A < B) || (A == B)` (extra ops) or a
 /// dedicated `<=` kernel.
 struct LessOrEqualDecompose : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(LessOrEqualDecompose)
   LessOrEqualDecompose(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.LessOrEqual", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/LinearAttentionConversion.cpp
+++ b/lib/Conversion/OnnxToHip/LinearAttentionConversion.cpp
@@ -11,6 +11,7 @@ namespace {
 
 /// onnx.Custom(LinearAttention) -> hip.linear_attention
 struct LinearAttentionToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(LinearAttentionToHip)
   LinearAttentionToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Custom", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/LpNormalizationConversion.cpp
+++ b/lib/Conversion/OnnxToHip/LpNormalizationConversion.cpp
@@ -86,6 +86,7 @@ namespace {
 /// primitives. See file header for the rewrite shape and the rationale for
 /// living in the pre-lowering loop instead of `convertComputeOps`.
 struct LpNormalizationDecompose : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(LpNormalizationDecompose)
   LpNormalizationDecompose(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.LpNormalization", /*benefit=*/2, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/MatMulConversion.cpp
+++ b/lib/Conversion/OnnxToHip/MatMulConversion.cpp
@@ -11,6 +11,7 @@ namespace {
 
 /// onnx.MatMul -> hip.hipblaslt.matmul
 struct MatMulToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(MatMulToHip)
   MatMulToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.MatMul", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/MatMulNBitsConversion.cpp
+++ b/lib/Conversion/OnnxToHip/MatMulNBitsConversion.cpp
@@ -14,6 +14,7 @@ namespace {
 //===----------------------------------------------------------------------===//
 
 struct MatMulNBitsToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(MatMulNBitsToHip)
   MatMulNBitsToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Custom", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/MaxConversion.cpp
+++ b/lib/Conversion/OnnxToHip/MaxConversion.cpp
@@ -15,6 +15,7 @@ namespace {
 ///   max(a, b, c) = max(max(a, b), c)
 /// Single input is identity (pass through).
 struct MaxToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(MaxToHip)
   MaxToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Max", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/MinConversion.cpp
+++ b/lib/Conversion/OnnxToHip/MinConversion.cpp
@@ -15,6 +15,7 @@ namespace {
 ///   min(a, b, c) = min(min(a, b), c)
 /// Single input is identity (pass through).
 struct MinToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(MinToHip)
   MinToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Min", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/ModConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ModConversion.cpp
@@ -11,6 +11,7 @@ namespace {
 
 /// onnx.Mod -> hip.mod
 struct ModToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ModToHip)
   ModToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Mod", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/MultiHeadAttentionConversion.cpp
+++ b/lib/Conversion/OnnxToHip/MultiHeadAttentionConversion.cpp
@@ -42,6 +42,7 @@ namespace {
 /// would NOT be picked up by their lowering patterns in this pass.  See the
 /// same comment in `AttentionConversion.cpp`.
 struct MultiHeadAttentionToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(MultiHeadAttentionToHip)
   MultiHeadAttentionToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Custom", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/NonZeroConversion.cpp
+++ b/lib/Conversion/OnnxToHip/NonZeroConversion.cpp
@@ -46,6 +46,7 @@ static int64_t getHipdnnInputDataType(mlir::Type elemType) {
 //           `tensor.empty` init operand so the buffer is large enough to
 //           hold the worst case.
 struct NonZeroToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(NonZeroToHip)
   NonZeroToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.NonZero", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/NormConversion.cpp
+++ b/lib/Conversion/OnnxToHip/NormConversion.cpp
@@ -53,6 +53,7 @@ inline mlir::Value getOptionalResult(mlir::Operation *op, unsigned idx) {
 
 /// onnx.Custom(SimplifiedLayerNormalization) -> hip.rms_norm
 struct SimplifiedLayerNormToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SimplifiedLayerNormToHip)
   SimplifiedLayerNormToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Custom", /*benefit=*/1, ctx) {}
 
@@ -177,6 +178,7 @@ RMSNormalizationToHip::matchAndRewrite(mlir::Operation *op,
 
 /// onnx.Custom(SkipSimplifiedLayerNormalization) -> hip.skip_rms_norm
 struct SkipSimplifiedLayerNormToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SkipSimplifiedLayerNormToHip)
   SkipSimplifiedLayerNormToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Custom", /*benefit=*/1, ctx) {}
 
@@ -358,6 +360,7 @@ mlir::LogicalResult SkipSimplifiedLayerNormToHip::matchAndRewrite(
 /// not be revisited for lowering (see AttentionConversion.cpp:174-178 and
 /// MultiHeadAttentionConversion.cpp:40 for the same gotcha).
 struct SkipLayerNormToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SkipLayerNormToHip)
   SkipLayerNormToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Custom", /*benefit=*/1, ctx) {}
 
@@ -495,6 +498,7 @@ SkipLayerNormToHip::matchAndRewrite(mlir::Operation *op,
 /// runtime is allowed to skip computing them when the corresponding output
 /// tensor is omitted -- the lowering passes nullptr in that case.
 struct LayerNormToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(LayerNormToHip)
   LayerNormToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.LayerNormalization", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/NotConversion.cpp
+++ b/lib/Conversion/OnnxToHip/NotConversion.cpp
@@ -12,6 +12,7 @@ namespace {
 /// onnx.Not -> hip.not
 /// Unary logical NOT: Y = !X. Input/output are bool (i1).
 struct NotToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(NotToHip)
   NotToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Not", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/PadConversion.cpp
+++ b/lib/Conversion/OnnxToHip/PadConversion.cpp
@@ -202,6 +202,7 @@ static mlir::FailureOr<mlir::Value> buildPadOutputInit(
 /// Optional inputs may be present and typed `none` (onnx.NoValue) when omitted
 /// by the producer.
 struct PadToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(PadToHip)
   PadToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Pad", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/PadShapeFold.cpp
+++ b/lib/Conversion/OnnxToHip/PadShapeFold.cpp
@@ -113,6 +113,7 @@ getInlineIntVector(mlir::Value v) {
 }
 
 struct PadStampConstShape : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(PadStampConstShape)
   PadStampConstShape(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Pad", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/PoolConversion.cpp
+++ b/lib/Conversion/OnnxToHip/PoolConversion.cpp
@@ -68,6 +68,7 @@ constexpr int64_t kPoolMax = 1;
 constexpr int64_t kPoolLp = 2;
 
 struct PoolToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(PoolToHip)
   int64_t poolMode;
   PoolToHip(mlir::MLIRContext *ctx, llvm::StringRef onnxName, int64_t mode)
       : RewritePattern(onnxName, /*benefit=*/1, ctx), poolMode(mode) {}

--- a/lib/Conversion/OnnxToHip/PowerConversion.cpp
+++ b/lib/Conversion/OnnxToHip/PowerConversion.cpp
@@ -85,6 +85,7 @@ static std::optional<double> getScalarConstantValue(mlir::Value v) {
 /// Converts ONNX reciprocal (y = 1/x, full signed IEEE domain) to HIP.
 /// Runtime uses a HIP elementwise kernel (not MIOpen POWER activation).
 struct ReciprocalToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ReciprocalToHip)
   ReciprocalToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Reciprocal", /*benefit=*/1, ctx) {}
 
@@ -97,6 +98,7 @@ struct ReciprocalToHip : public mlir::RewritePattern {
 /// ONNX element-wise sqrt; lowered to @wrap_power(0, 1, 0.5) and executed
 /// with hip_elementwise_sqrt at runtime (not MIOpen POWER).
 struct SqrtToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SqrtToHip)
   SqrtToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Sqrt", /*benefit=*/1, ctx) {}
 
@@ -157,6 +159,7 @@ SqrtToHip::matchAndRewrite(mlir::Operation *op,
 /// onnx.Neg -> hip.neg
 /// Negation: y = -x. Lowered via wrap_power(alpha=0, beta=-1, gamma=1).
 struct NegToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(NegToHip)
   NegToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Neg", /*benefit=*/1, ctx) {}
 
@@ -222,6 +225,7 @@ struct NegToHip : public mlir::RewritePattern {
 ///        : (tensor<1x64x128x128xf16>, tensor<1x64x128x128xf16>)
 ///        -> tensor<1x64x128x128xf16>
 struct PowDecompose : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(PowDecompose)
   PowDecompose(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Pow", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/ProjectorOpsRewrites.cpp
+++ b/lib/Conversion/OnnxToHip/ProjectorOpsRewrites.cpp
@@ -103,6 +103,7 @@ static std::optional<double> getOnnxConstantScalar(mlir::Operation *constOp) {
 //===----------------------------------------------------------------------===//
 
 struct PowToMul : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(PowToMul)
   PowToMul(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Pow", /*benefit=*/2, ctx) {}
 
@@ -178,6 +179,7 @@ struct PowToMul : public mlir::RewritePattern {
 //===----------------------------------------------------------------------===//
 
 struct AveragePoolToReshapeMean : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(AveragePoolToReshapeMean)
   AveragePoolToReshapeMean(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.AveragePool", /*benefit=*/2, ctx) {}
 
@@ -405,6 +407,7 @@ struct AveragePoolToReshapeMean : public mlir::RewritePattern {
 //===----------------------------------------------------------------------===//
 
 struct BroadcastDivToMulReciprocal : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(BroadcastDivToMulReciprocal)
   BroadcastDivToMulReciprocal(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Div", /*benefit=*/2, ctx) {}
 
@@ -525,6 +528,7 @@ struct BroadcastDivToMulReciprocal : public mlir::RewritePattern {
 //   %y  = onnx.Reshape(%y2, const [-1, 1152, 1, 1, 1])
 //           : -> tensor<?x1152x1x1x1xf16>
 struct PatchEmbedConvToGemm : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(PatchEmbedConvToGemm)
   PatchEmbedConvToGemm(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Conv", /*benefit=*/2, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/QMoEConversion.cpp
+++ b/lib/Conversion/OnnxToHip/QMoEConversion.cpp
@@ -16,6 +16,7 @@ namespace {
 //===----------------------------------------------------------------------===//
 
 struct QMoEToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(QMoEToHip)
   QMoEToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Custom", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/RangeConversion.cpp
+++ b/lib/Conversion/OnnxToHip/RangeConversion.cpp
@@ -190,6 +190,7 @@ static Value collapseRangeBoundToScalar(PatternRewriter &rewriter, Location loc,
 }
 
 struct RangeToHip : public RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(RangeToHip)
   RangeToHip(MLIRContext *ctx) : RewritePattern("onnx.Range", 1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op,

--- a/lib/Conversion/OnnxToHip/ReduceMaxConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ReduceMaxConversion.cpp
@@ -12,6 +12,7 @@ namespace {
 /// onnx.ReduceMax -> hip.reduce_max
 /// Reuses the same axes/keepdims/noop_with_empty_axes handling as ReduceSum.
 struct ReduceMaxToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ReduceMaxToHip)
   ReduceMaxToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.ReduceMax", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/ReduceMeanConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ReduceMeanConversion.cpp
@@ -30,6 +30,7 @@ namespace {
 ///   %init = tensor.empty(%n) : tensor<?x1xf16>
 ///   %y    = hip.reduce_mean(%ctx) ins(%x, %axes) outs(%init) {keepdims = 1}
 struct ReduceMeanToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ReduceMeanToHip)
   ReduceMeanToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.ReduceMean", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/ReduceProdConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ReduceProdConversion.cpp
@@ -141,6 +141,7 @@ static mlir::Value buildReduceProdInit(mlir::PatternRewriter &rewriter,
 /// `keepdims` and `noop_with_empty_axes` through, and shares lowering with
 /// other reduction ops via the unified ReduceLowering template.
 struct ReduceProdToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ReduceProdToHip)
   ReduceProdToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.ReduceProd", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/ReduceSumConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ReduceSumConversion.cpp
@@ -11,6 +11,7 @@ namespace {
 
 /// onnx.ReduceSum -> hip.reduce_sum
 struct ReduceSumToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ReduceSumToHip)
   ReduceSumToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.ReduceSum", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/ReluConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ReluConversion.cpp
@@ -58,6 +58,7 @@ static mlir::Value buildZeroScalar(mlir::PatternRewriter &rewriter,
 }
 
 struct ReluToHipMax : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ReluToHipMax)
   ReluToHipMax(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Relu", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/ReshapeConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ReshapeConversion.cpp
@@ -111,6 +111,7 @@ llvm::SmallVector<mlir::OpFoldResult> buildExpandShapeOutputShape(
 /// alias) and then to LLVM struct manipulation (same data pointer, new
 /// sizes/strides).  No HIP kernel is needed.
 struct ReshapeToStdTensor : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ReshapeToStdTensor)
   ReshapeToStdTensor(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Reshape", /*benefit=*/1, ctx) {}
 
@@ -558,6 +559,7 @@ struct ReshapeToStdTensor : public mlir::RewritePattern {
 ///          output_shape [%b, %s, 128, 1]
 ///          : tensor<?x?x128xf16> into tensor<?x?x128x1xf16>
 struct UnsqueezeToStdTensor : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(UnsqueezeToStdTensor)
   UnsqueezeToStdTensor(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Unsqueeze", /*benefit=*/1, ctx) {}
 
@@ -593,6 +595,7 @@ struct UnsqueezeToStdTensor : public mlir::RewritePattern {
 
 /// onnx.Squeeze -> tensor.collapse_shape (zero-cost metadata operation).
 struct SqueezeToStdTensor : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SqueezeToStdTensor)
   SqueezeToStdTensor(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Squeeze", /*benefit=*/1, ctx) {}
 
@@ -672,6 +675,7 @@ struct SqueezeToStdTensor : public mlir::RewritePattern {
 /// which bufferize to memref.subview (zero-copy alias) and then to LLVM
 /// pointer arithmetic. No HIP kernel is needed.
 struct SplitToStdTensor : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SplitToStdTensor)
   SplitToStdTensor(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Split", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/ReshapeShapeFold.cpp
+++ b/lib/Conversion/OnnxToHip/ReshapeShapeFold.cpp
@@ -106,6 +106,7 @@ namespace hip {
 namespace {
 
 struct ReshapeOfShapeToFromElements : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ReshapeOfShapeToFromElements)
   ReshapeOfShapeToFromElements(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Reshape", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/ResizeConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ResizeConversion.cpp
@@ -55,6 +55,7 @@ namespace {
 //                         {mode = 1, coord_transform = 0, nearest_mode = 0}
 
 struct ResizeToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ResizeToHip)
   ResizeToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Resize", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/RotaryEmbeddingConversion.cpp
+++ b/lib/Conversion/OnnxToHip/RotaryEmbeddingConversion.cpp
@@ -11,6 +11,7 @@ namespace {
 
 /// onnx.Custom(RotaryEmbedding) -> hip.rope
 struct RotaryEmbeddingToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(RotaryEmbeddingToHip)
   RotaryEmbeddingToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Custom", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/ScatterNDConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ScatterNDConversion.cpp
@@ -28,6 +28,7 @@ namespace {
 /// The runtime stub today only logs its parameters, so any reduction mode
 /// is accepted at compile time.
 struct ScatterNDToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ScatterNDToHip)
   ScatterNDToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.ScatterND", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/ShapeConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ShapeConversion.cpp
@@ -70,6 +70,7 @@ namespace {
 // failing the match -- preserving op semantics is the priority over
 // surfacing a "shouldn't happen" error.
 struct ShapeToTensorDims : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ShapeToTensorDims)
   ShapeToTensorDims(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Shape", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/SignConversion.cpp
+++ b/lib/Conversion/OnnxToHip/SignConversion.cpp
@@ -13,6 +13,7 @@ namespace {
 /// Unary element-wise sign: Y = sign(X). Lowered through the unified unary
 /// elementwise template (wrap_sign).
 struct SignToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SignToHip)
   SignToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Sign", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/SinConversion.cpp
+++ b/lib/Conversion/OnnxToHip/SinConversion.cpp
@@ -12,6 +12,7 @@ namespace {
 /// onnx.Sin -> hip.sin
 /// Unary element-wise sine: Y = sin(X). Float types.
 struct SinToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SinToHip)
   SinToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Sin", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/SizeConversion.cpp
+++ b/lib/Conversion/OnnxToHip/SizeConversion.cpp
@@ -43,6 +43,7 @@ namespace {
 // because pre-existing models bake the constant into the DLL.
 
 struct SizeToConstantOrHipSize : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SizeToConstantOrHipSize)
   SizeToConstantOrHipSize(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Size", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/SliceConversion.cpp
+++ b/lib/Conversion/OnnxToHip/SliceConversion.cpp
@@ -100,6 +100,7 @@ static mlir::Value normaliseOptional(mlir::Value v) {
 }
 
 struct SliceDecompose : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SliceDecompose)
   SliceDecompose(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Slice", /*benefit=*/2, ctx) {}
 
@@ -259,6 +260,7 @@ struct SliceDecompose : public mlir::RewritePattern {
 };
 
 struct SliceToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SliceToHip)
   SliceToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Slice", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/TileConversion.cpp
+++ b/lib/Conversion/OnnxToHip/TileConversion.cpp
@@ -11,6 +11,7 @@ namespace {
 
 /// onnx.Tile -> hip.tile
 struct TileToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TileToHip)
   TileToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Tile", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/TransposeConversion.cpp
+++ b/lib/Conversion/OnnxToHip/TransposeConversion.cpp
@@ -16,6 +16,7 @@ namespace {
 /// [rank-1, ..., 0] is materialized so hip.transpose always carries an
 /// explicit perm attribute.
 struct TransposeToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TransposeToHip)
   TransposeToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Transpose", /*benefit=*/1, ctx) {}
 

--- a/lib/Conversion/OnnxToHip/WhereConversion.cpp
+++ b/lib/Conversion/OnnxToHip/WhereConversion.cpp
@@ -79,6 +79,7 @@ createBroadcastEmptyTensor(mlir::OpBuilder &builder, mlir::Location loc,
 /// X and Y. The condition tensor is bool (i1); X and Y share the result
 /// element type.
 struct WhereToHip : public mlir::RewritePattern {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(WhereToHip)
   WhereToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Where", /*benefit=*/1, ctx) {}
 

--- a/lib/Dialect/Transforms/RelaxMultiDynExpandShape.cpp
+++ b/lib/Dialect/Transforms/RelaxMultiDynExpandShape.cpp
@@ -108,6 +108,7 @@ namespace {
 /// file header for the rationale and the IR-snippet contract.
 struct RelaxMultiDynExpandShapePattern
     : public OpRewritePattern<memref::ExpandShapeOp> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(RelaxMultiDynExpandShapePattern)
   using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(memref::ExpandShapeOp op,


### PR DESCRIPTION
## Summary

All `RewritePattern`, `ConversionPattern`, and `ConvertToLLVMPattern`
subclasses defined in anonymous namespaces were missing
`MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID`. On Windows, when hip-ep
is built against prebuilt MLIR with `LLVM_ENABLE_ABI_BREAKING_CHECKS=1`
(the standard Windows prebuilt configuration), the missing macros cause a
deterministic crash — `STATUS_STACK_BUFFER_OVERRUN` (0xC0000409) — when
compiling ONNX models via `CompilerDriver::compile()`.

## Why

Without the macro, MLIR resolves TypeIDs for these classes via
`FallbackTypeIDResolver::registerImplicitTypeID`, which uses
`llvm::getTypeName<T>()` to derive a string name. On MSVC, that string
contains `` `anonymous-namespace' ``. The `#ifndef NDEBUG` check in
`mlir/lib/Support/TypeID.cpp` aborts when it sees this:

```cpp
if (typeName.contains("anonymous-namespace")) {
    llvm::report_fatal_error(...);  // → abort()
}
```

The abort fires during `pm.run()` when the pass pipeline is constructed
and the pattern types are registered for the first time.

`MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID` gives each class a unique
TypeID backed by a static variable — no string name involved, no abort.

## What

Add `MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ClassName)` as the
first line of the `public:` section of every affected anonymous-namespace
pattern class:

- **`lib/Conversion/HipToLLVM/`** — 45 files, covering all
  `ConvertToLLVMPattern` subclasses (e.g. `GemmOpLowering`,
  `MatmulLowering`, `ConcatLowering`, `LpNormLowering`)
- **`lib/Conversion/OnnxToHip/`** — 68 files, covering all
  `RewritePattern`/`ConversionPattern` subclasses (e.g. `GemmConversion`,
  `ConcatDecompose`, `LpNormalizationDecompose`)
- **`lib/Dialect/Transforms/RelaxMultiDynExpandShape.cpp`** — 1 pattern

158 one-line additions across 114 files. Zero logic changes.

## Test plan

A standalone reproducer `reproduce_typeid_crash.py` lives in the
gnpu-onnx-flow plugin repo (committed on branch `kirmatam/qwen-functional`).
It requires the MorphiZen EP DLL (`hipgpu.dll`) to exercise the
`CompilerDriver::compile()` path where the crash fires.

**Reproduce the crash:**

```powershell
# In gnpu-onnx-flow repo:

# 1. Get the reproducer script from the fixed branch (before checking out old commit)
git checkout kirmatam/qwen-functional -- reproduce_typeid_crash.py

# 2. Check out the commit before the TypeID fix and sync hip-ep
git checkout ea441db
git submodule update --init 3rd-party/hip-ep

# 3. Build
python build.py

# 4. Set up environment
$env:PATH = "install\dist\bin;install\therock\bin;" + $env:PATH
$env:THEROCK_DIST = "$PWD\install\therock"
$env:HIPDNN_EP_FORCE_H2D = "1"

# 5. Run — expect crash
python reproduce_typeid_crash.py
```

Expected crash output:
```
=== hip-compiler: abort() ===
#1  mlir::detail::FallbackTypeIDResolver::registerImplicitTypeID(llvm::StringRef)
#2  mlir::detail::FallbackTypeIDResolver::registerImplicitTypeID(llvm::StringRef)
#3  mlir::detail::FallbackTypeIDResolver::registerImplicitTypeID(llvm::StringRef)
```

**Verify the fix** (apply hip-ep PR #573, rebuild):

```powershell
# In gnpu-onnx-flow repo:
git checkout kirmatam/qwen-functional
git submodule update --init 3rd-party/hip-ep
python build.py
python reproduce_typeid_crash.py
# Expected: PASS: session created and inference is correct (crash is resolved).
```

Tested on Windows gfx1151, LLVM 22.1.0 prebuilts,
`LLVM_ABI_BREAKING_CHECKS=WITH_ASSERTS`.

## Notes for reviewers

- This is a pure annotation change — no logic, no API, no behaviour change.
- Linux Release builds (`NDEBUG` defined) are unaffected — the abort check
  is `#ifndef NDEBUG`-gated.
- The MLIR docs explicitly recommend `MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID`
  for anonymous-namespace classes (see `mlir/include/mlir/Support/TypeID.h`).

## Checklist

- [x] **Incremental.** Single-commit annotation-only change.
- [x] **AI policy.** Fix developed with Claude assistance; I reviewed and
      understand each change. Commit trailers are present.
- [x] **No `good first issue` automation.** This is a bug fix.
- [x] **Reviews resolved.** First submission.
- [x] **CODEOWNERS routing.** Touches `lib/Conversion/` broadly.