### PR TITLE
feat(tools): add onnx-merged-convert for split pipeline merging

### DIFF
--- a/tools/onnx-merged-convert/README.md
+++ b/tools/onnx-merged-convert/README.md
@@ -1,0 +1,166 @@
+<!--
+Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+Licensed under the MIT License.
+-->
+# Split-Pipeline to Merged ONNX Converter
+
+`run_merged_convert.py` is the CLI entry point. It converts a **split inference pipeline** (embedding, decoder prefill/decode, language-model head) into a **single merged ONNX model** suitable for ONNX Runtime GenAI.
+
+Implementation is split across the `merged_convert/` package (see [Code layout](#code-layout) below).
+
+## Requirements
+
+- Python 3.10+
+- Packages: `onnx`, `numpy`
+
+```bash
+pip install onnx numpy
+```
+
+## Usage
+
+```bash
+python run_merged_convert.py \
+  --input-dir  path/to/model-bundle \
+  --output-dir path/to/output
+```
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `--input-dir` | Yes | Directory containing the split ONNX files (see below). |
+| `--output-dir` | No | Output directory. Default: `<input-dir>/merged` |
+
+### Example
+
+```bash
+python run_merged_convert.py \
+  --input-dir ./my-model-bundle \
+  --output-dir ./my-model-bundle/merged
+```
+
+After conversion, copy tokenizer files into the output directory if you plan to run inference or benchmarks from that folder:
+
+```bash
+cp -r my-model-bundle/tokenizer/* my-model-bundle/merged/
+```
+
+## Input directory layout
+
+The converter expects **four ONNX files** in the same directory (or only the files listed below—extra ONNX files are ignored unless they form another valid decoder pair).
+
+### Required files
+
+| Role | Filename pattern | Notes |
+|------|------------------|-------|
+| Decoder (prefill) | `*_128.onnx` **or** `*_0.onnx` | Fixed prefill sequence length (typically 128). |
+| Decoder (decode) | Matching `*_1.onnx` | Single-token decode step; stem must match the prefill file (e.g. `model_128.onnx` + `model_1.onnx`). |
+| Embedding | `*_emb.onnx`, `*embedding*.onnx`, or `*embeddings*.onnx` | First match wins. |
+| Language-model head | `*_lm_head.onnx` or `*lm_head*.onnx` | First match wins. |
+
+**Example (minimal bundle):**
+
+```text
+model-bundle/
+├── model_128.onnx      # decoder prefill
+├── model_1.onnx        # decoder decode
+├── model_emb.onnx      # embedding
+├── model_lm_head.onnx  # lm head
+└── model.data          # external weights (if used)
+```
+
+### Optional files
+
+| File | Purpose |
+|------|---------|
+| `genai_config.json` | Source for model metadata and search settings. If missing, a default config is generated from the merged graph. |
+| `adapter.safetensors` | LoRA adapter weights; copied to the output when present. |
+| `tokenizer/` | Not read by the converter; copy manually for inference. |
+| `tokenizer/config.json` or `config.json` | Used to fill in `vocab_size` when the source genai config omits it. |
+
+### What happens if files are missing?
+
+The script validates the bundle **before** conversion:
+
+- No decoder prefill/decode pair → error.
+- Decoder pair present but embedding or lm head missing → error.
+- Input path does not exist → error.
+
+There is no partial conversion: all four components must be present.
+
+## Conversion pipeline
+
+The script runs five steps automatically:
+
+1. Remove activation QuantizeLinear / DequantizeLinear nodes.
+2. Promote activations to FP16.
+3. Rewrite lm_head to emit pruned logits (`Gather` last token + `Unsqueeze` → shape `[1, 1, vocab]`).
+4. Rebind prefill/decode seq_len axes to a dynamic `seq_len` parameter.
+5. Fuse embedding + dynamic decoder + lm_head into one merged ONNX.
+
+Pipeline **type** is inferred from the decoder prefill graph:
+
+| Detected pattern | Behavior |
+|------------------|----------|
+| Quantized linear (MatMulNBits) | Standard QDQ removal and merge. |
+| Many Gemm nodes, few MatMulNBits | Treats weights as folded Gemm (pure-Gemm / adapter path); may emit `lora_dequant.json`. |
+| GroupQueryAttention with 8-bit KV cache | Preserves int8 KV path. |
+| Many 2-bit MatMulNBits nodes | Low-bit decoder path. |
+
+## Output files
+
+| File | Description |
+|------|-------------|
+| `{decoder_stem}_merged.onnx` | Merged model (graph only or with inline weights). |
+| `{decoder_stem}_merged.data` | External weight blob (when weights are externalized). |
+| `genai_config.json` | GenAI runtime configuration (pipeline stages point at the merged file). |
+| `lora_dequant.json` | Present only for folded-Gemm / adapter bundles. |
+| `adapter.safetensors` | Copied from input when present and needed. |
+
+The merged `genai_config.json` is adjusted for a single merged graph:
+
+- Decoder inputs use `input_ids` (not precomputed embeddings).
+- Execution provider profile is set to `hip` for AMDGPU stages.
+- `vocab_size` is preserved from the source config or inferred from tokenizer metadata.
+
+## Code layout
+
+The five conversion steps map to modules under `merged_convert/`:
+
+| Step | Module | Role |
+|------|--------|------|
+| 1–2 | `step1_qdq_fp16.py` | Remove activation Q/DQ; promote activations to fp16 (decoder / emb / lm_head) |
+| 2 | `step2_fp16_cleanup.py` | FP16 activation cleanup helpers (also used as step 5 post-merge pass) |
+| 3 | `step3_lm_head.py` | lm_head Gather + Unsqueeze → pruned logits `[1, 1, vocab]` |
+| 4 | `step4_unfix_seq_len.py` | Rebind prefill/decode seq_len axes to a dynamic `seq_len` parameter (produces one dynamic decoder graph) |
+| 5 | `step5_merge.py` | Fuse embedding + decoder + lm_head into one ONNX |
+
+Supporting modules:
+
+| Module | Role |
+|--------|------|
+| `qdq_ext.py` | Alternate Q/DQ + fp16 path for low-bit models |
+| `int8kv.py` | Decoder conversion with int8 KV cache preserved |
+| `bundle.py` | Input bundle detection and `genai_config.json` generation |
+| `pipeline.py` | Wires the steps for each pipeline kind (`quantized_linear`, `int8_kv`, `low_bit`) |
+| `cli.py` | Argument parsing and `main()` |
+
+Run from this directory:
+
+```bash
+python run_merged_convert.py --input-dir ... --output-dir ...
+```
+
+Or as a module:
+
+```bash
+python -m merged_convert.cli --input-dir ... --output-dir ...
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|----------------|
+| `No decoder pair found` | Missing or misnamed `*_128.onnx` / `*_1.onnx` (or `*_0.onnx` / `*_1.onnx`) pair. |
+| `Missing embedding or lm_head` | Emb or head file missing or name does not match glob patterns. |
+| Runtime error on `vocab_size` | No vocab in source genai config and no `tokenizer/config.json`. Add one or fix paths. |
+| GenAI rejects `embeddings` input | Re-run with a current script build; merged configs must use `input_ids`. |

--- a/tools/onnx-merged-convert/merged_convert/__init__.py
+++ b/tools/onnx-merged-convert/merged_convert/__init__.py
@@ -1,0 +1,12 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+
+"""Split-pipeline to merged ONNX conversion."""
+
+from merged_convert.bundle import detect_bundle
+from merged_convert.cli import main
+from merged_convert.pipeline import convert_bundle
+
+__all__ = ["detect_bundle", "convert_bundle", "main"]

--- a/tools/onnx-merged-convert/merged_convert/bundle.py
+++ b/tools/onnx-merged-convert/merged_convert/bundle.py
@@ -1,0 +1,327 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+import onnx
+
+from .step1_qdq_fp16 import DEFAULT_MAX_SEQ_LEN
+
+DEFAULT_OUTPUT_DIR_NAME = "merged"
+
+_EMB_GLOBS = ("*_emb.onnx", "*embedding*.onnx", "*embeddings*.onnx")
+_HEAD_GLOBS = ("*_lm_head.onnx", "*lm_head*.onnx")
+
+
+class PipelineKind(str, Enum):
+    QUANTIZED_LINEAR = "quantized_linear"
+    INT8_KV = "int8_kv"
+    LOW_BIT = "low_bit"
+
+
+@dataclass(frozen=True)
+class ModelBundle:
+    input_dir: Path
+    pipeline: PipelineKind
+    decoder_stem: str
+    dec_prefill: Path
+    dec_decode: Path
+    emb: Path
+    head: Path
+    prefill_seq_len: int
+    merged_stem: str
+    chunk_size: int
+    fold_gemm_weights: bool = False
+
+
+def _load_graph_summary(path: Path) -> dict[str, int | bool]:
+    model = onnx.load(str(path), load_external_data=False)
+    nodes = model.graph.node
+    gemm = sum(1 for n in nodes if n.op_type == "Gemm")
+    mnb = sum(1 for n in nodes if n.op_type == "MatMulNBits")
+    two_bit_mnb = sum(
+        1
+        for n in nodes
+        if n.op_type == "MatMulNBits"
+        and any(a.name == "bits" and a.i == 2 for a in n.attribute)
+    )
+    int8_kv = any(
+        n.op_type == "GroupQueryAttention"
+        and any(a.name == "kv_cache_bit_width" and a.i == 8 for a in n.attribute)
+        for n in nodes
+    )
+    return {
+        "gemm": gemm,
+        "mnb": mnb,
+        "two_bit_mnb": two_bit_mnb,
+        "int8_kv": int8_kv,
+    }
+
+
+def _infer_prefill_seq_len(prefill: Path) -> int:
+    if prefill.stem.endswith("_128"):
+        return 128
+    model = onnx.load(str(prefill), load_external_data=False)
+    for vi in model.graph.input:
+        shape = vi.type.tensor_type.shape
+        for dim in shape.dim:
+            if dim.dim_value > 1:
+                return int(dim.dim_value)
+    for vi in model.graph.input:
+        shape = vi.type.tensor_type.shape
+        if len(shape.dim) >= 2 and shape.dim[1].dim_value > 0:
+            return int(shape.dim[1].dim_value)
+    return 128
+
+
+def _find_component(input_dir: Path, globs: tuple[str, ...]) -> Path | None:
+    seen: set[str] = set()
+    for pattern in globs:
+        for path in sorted(input_dir.glob(pattern)):
+            if path.name in seen:
+                continue
+            seen.add(path.name)
+            return path
+    return None
+
+
+def _find_decoder_pairs(input_dir: Path) -> list[tuple[Path, Path, str, int]]:
+    pairs: list[tuple[Path, Path, str, int]] = []
+    for prefill in sorted(input_dir.glob("*.onnx")):
+        stem = prefill.stem
+        if stem.endswith("_128"):
+            decoder_stem = stem[: -len("_128")]
+            decode = input_dir / f"{decoder_stem}_1.onnx"
+            if decode.is_file():
+                pairs.append((prefill, decode, decoder_stem, 128))
+        elif stem.endswith("_0"):
+            decoder_stem = stem[: -len("_0")]
+            decode = input_dir / f"{decoder_stem}_1.onnx"
+            if decode.is_file():
+                pairs.append(
+                    (prefill, decode, decoder_stem, _infer_prefill_seq_len(prefill))
+                )
+    return pairs
+
+
+def _select_pipeline(prefill: Path) -> tuple[PipelineKind, bool]:
+    summary = _load_graph_summary(prefill)
+    if summary["int8_kv"]:
+        return PipelineKind.INT8_KV, False
+    if summary["gemm"] >= 50 and summary["mnb"] < 20:
+        return PipelineKind.QUANTIZED_LINEAR, True
+    if summary["two_bit_mnb"] >= 50:
+        return PipelineKind.LOW_BIT, False
+    return PipelineKind.QUANTIZED_LINEAR, False
+
+
+def detect_bundle(input_dir: Path) -> ModelBundle:
+    input_dir = input_dir.resolve()
+    if not input_dir.is_dir():
+        raise FileNotFoundError(input_dir)
+
+    pairs = _find_decoder_pairs(input_dir)
+    if not pairs:
+        raise ValueError(
+            f"No decoder pair found under {input_dir} "
+            "(expected *_128.onnx + *_1.onnx or *_0.onnx + *_1.onnx)"
+        )
+
+    last_error: Exception | None = None
+    for dec_prefill, dec_decode, decoder_stem, prefill_seq_len in pairs:
+        emb = _find_component(input_dir, _EMB_GLOBS)
+        head = _find_component(input_dir, _HEAD_GLOBS)
+        if emb is None or head is None:
+            last_error = FileNotFoundError(
+                f"Missing embedding or lm_head ONNX next to decoder pair {dec_prefill.name}"
+            )
+            continue
+
+        pipeline, fold_gemm_weights = _select_pipeline(dec_prefill)
+        merged_stem = f"{decoder_stem}_merged"
+        return ModelBundle(
+            input_dir=input_dir,
+            pipeline=pipeline,
+            decoder_stem=decoder_stem,
+            dec_prefill=dec_prefill,
+            dec_decode=dec_decode,
+            emb=emb,
+            head=head,
+            prefill_seq_len=prefill_seq_len,
+            merged_stem=merged_stem,
+            chunk_size=prefill_seq_len,
+            fold_gemm_weights=fold_gemm_weights,
+        )
+
+    raise last_error or ValueError(f"Cannot classify model bundle: {input_dir}")
+
+
+def _find_genai_config_source(input_dir: Path) -> Path | None:
+    candidates = [
+        input_dir / "genai_config.json",
+        input_dir / "processed" / "genai_config.json",
+    ]
+    for pattern in (
+        "*_fp16_no_rewrite",
+        "*_fp16_pure_gemm",
+        "*_fp16",
+        "processed",
+        "merged",
+    ):
+        candidates.extend(sorted(input_dir.glob(f"{pattern}/genai_config.json")))
+    seen: set[Path] = set()
+    for path in candidates:
+        path = path.resolve()
+        if path in seen:
+            continue
+        seen.add(path)
+        if path.is_file():
+            return path
+    return None
+
+
+def introspect_merged_io(merged_path: Path) -> dict[str, int | list[str]]:
+    model = onnx.load(str(merged_path), load_external_data=False)
+    graph = model.graph
+
+    input_names = [vi.name for vi in graph.input]
+
+    num_layers = sum(1 for name in input_names if name.startswith("past_keys_"))
+
+    pipeline_inputs = ["input_ids", "past_seq_len", "total_seq_len"]
+    for i in range(num_layers):
+        pipeline_inputs.extend([f"past_keys_{i}", f"past_values_{i}"])
+
+    pipeline_outputs = ["logits"]
+    for i in range(num_layers):
+        pipeline_outputs.extend([f"present_keys_{i}", f"present_values_{i}"])
+
+    return {
+        "num_layers": num_layers,
+        "pipeline_inputs": pipeline_inputs,
+        "pipeline_outputs": pipeline_outputs,
+    }
+
+
+def _pipeline_stage(filename: str, io: dict) -> dict:
+    return {
+        "filename": filename,
+        "session_options": {
+            "provider_options": [{"AMDGPU": {"profile": "hip"}}],
+        },
+        "inputs": io["pipeline_inputs"],
+        "outputs": io["pipeline_outputs"],
+    }
+
+
+def build_genai_config(
+    bundle: ModelBundle,
+    merged_filename: str,
+    merged_path: Path,
+    *,
+    source: Path | None,
+) -> dict:
+    io = introspect_merged_io(merged_path)
+    prefill = _pipeline_stage(merged_filename, io)
+    prefill["run_on_prompt"] = True
+    prefill["run_on_token_gen"] = False
+    decode = _pipeline_stage(merged_filename, io)
+    decode["run_on_prompt"] = False
+    decode["run_on_token_gen"] = True
+
+    if source is not None and source.is_file():
+        cfg = json.loads(source.read_text(encoding="utf-8"))
+    else:
+        cfg = {
+            "model": {
+                "context_length": DEFAULT_MAX_SEQ_LEN,
+                "type": "decoder-pipeline",
+                "decoder": {
+                    "session_options": {
+                        "log_id": "onnxruntime-genai",
+                        "session.disable_cpu_ep_fallback": "1",
+                        "provider_options": [{"AMDGPU": {"profile": "hip"}}],
+                    },
+                    "head_size": 128,
+                    "hidden_size": 2048,
+                    "num_attention_heads": 24,
+                    "num_hidden_layers": int(io["num_layers"]),
+                    "num_key_value_heads": 8,
+                    "inputs": {
+                        "input_ids": "input_ids",
+                        "past_sequence_length": "past_seq_len",
+                        "total_sequence_length": "total_seq_len",
+                        "past_key_names": "past_keys_%d",
+                        "past_value_names": "past_values_%d",
+                    },
+                    "outputs": {
+                        "logits": "logits",
+                        "present_key_names": "present_keys_%d",
+                        "present_value_names": "present_values_%d",
+                    },
+                },
+            },
+            "search": {
+                "diversity_penalty": 0.0,
+                "do_sample": False,
+                "early_stopping": True,
+                "length_penalty": 1.0,
+                "max_length": DEFAULT_MAX_SEQ_LEN,
+                "min_length": 0,
+                "no_repeat_ngram_size": 0,
+                "num_beams": 1,
+                "num_return_sequences": 1,
+                "past_present_share_buffer": True,
+                "repetition_penalty": 1.0,
+                "temperature": 0.01,
+                "top_k": 5,
+                "top_p": 1.0,
+                "chunk_size": bundle.chunk_size,
+            },
+        }
+
+    model = cfg.setdefault("model", {})
+    decoder = model.setdefault("decoder", {})
+    decoder["num_hidden_layers"] = int(io["num_layers"])
+    decoder["pipeline"] = [{"prefill": prefill, "decode": decode}]
+
+    # Merged graph always takes token ids at the boundary, not precomputed embeddings.
+    inputs = decoder.setdefault("inputs", {})
+    inputs.pop("embeddings", None)
+    inputs["input_ids"] = "input_ids"
+    inputs.setdefault("past_sequence_length", "past_seq_len")
+    inputs.setdefault("total_sequence_length", "total_seq_len")
+    inputs.setdefault("past_key_names", "past_keys_%d")
+    inputs.setdefault("past_value_names", "past_values_%d")
+
+    session_opts = decoder.setdefault("session_options", {})
+    for opt in session_opts.get("provider_options", []):
+        if isinstance(opt, dict) and "AMDGPU" in opt:
+            opt["AMDGPU"]["profile"] = "hip"
+
+    if "vocab_size" not in model:
+        for tok_cfg in (
+            bundle.input_dir / "tokenizer" / "config.json",
+            bundle.input_dir / "config.json",
+        ):
+            if tok_cfg.is_file():
+                vocab = json.loads(tok_cfg.read_text(encoding="utf-8")).get(
+                    "vocab_size"
+                )
+                if isinstance(vocab, int) and vocab > 0:
+                    model["vocab_size"] = vocab
+                    break
+
+    search = cfg.setdefault("search", {})
+    search["chunk_size"] = bundle.chunk_size
+    if "max_length" not in search:
+        search["max_length"] = model.get("context_length", DEFAULT_MAX_SEQ_LEN)
+
+    return cfg

--- a/tools/onnx-merged-convert/merged_convert/bundle.py
+++ b/tools/onnx-merged-convert/merged_convert/bundle.py
@@ -9,6 +9,7 @@ import json
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
+from typing import Any
 
 import onnx
 
@@ -221,6 +222,112 @@ def _pipeline_stage(filename: str, io: dict) -> dict:
     }
 
 
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _token_content_to_id(content: str, added_decoder: dict[str, Any]) -> int | None:
+    for sid, info in added_decoder.items():
+        if info.get("content") == content:
+            return int(sid)
+    return None
+
+
+def _infer_vocab_size_from_merged(merged_path: Path) -> int | None:
+    model = onnx.load(str(merged_path), load_external_data=False)
+    for vi in model.graph.output:
+        if vi.name != "logits":
+            continue
+        dims = vi.type.tensor_type.shape.dim
+        if dims and dims[-1].dim_value > 0:
+            return int(dims[-1].dim_value)
+    return None
+
+
+_CANDIDATE_EOS_TOKEN_CONTENTS = ("<|endofprompt|>", "<|end|>")
+
+
+def _collect_eos_token_ids(
+    hf_cfg: dict[str, Any] | None, tok_cfg: dict[str, Any] | None
+) -> list[int]:
+    ids: list[int] = []
+    if hf_cfg is not None and hf_cfg.get("eos_token_id") is not None:
+        eos = hf_cfg["eos_token_id"]
+        ids.extend(eos if isinstance(eos, list) else [int(eos)])
+
+    added_decoder = (tok_cfg or {}).get("added_tokens_decoder") or {}
+    for content in _CANDIDATE_EOS_TOKEN_CONTENTS:
+        token_id = _token_content_to_id(content, added_decoder)
+        if token_id is not None and token_id not in ids:
+            ids.append(token_id)
+
+    if tok_cfg is not None:
+        eos_token = tok_cfg.get("eos_token")
+        if isinstance(eos_token, str):
+            token_id = _token_content_to_id(eos_token, added_decoder)
+            if token_id is not None and token_id not in ids:
+                ids.append(token_id)
+    return ids
+
+
+def _infer_model_metadata(bundle: ModelBundle, merged_path: Path) -> dict[str, Any]:
+    """Fill genai model fields when no source genai_config.json is available."""
+    input_dir = bundle.input_dir
+    hf_cfg = _read_json(input_dir / "tokenizer" / "config.json") or _read_json(
+        input_dir / "config.json"
+    )
+    tok_cfg = _read_json(input_dir / "tokenizer" / "tokenizer_config.json")
+    tok_json = _read_json(input_dir / "tokenizer" / "tokenizer.json")
+
+    meta: dict[str, Any] = {}
+
+    if hf_cfg:
+        for key in ("vocab_size", "bos_token_id", "pad_token_id"):
+            if key in hf_cfg and hf_cfg[key] is not None:
+                meta[key] = hf_cfg[key]
+        if hf_cfg.get("max_position_embeddings") is not None:
+            meta.setdefault("context_length", hf_cfg["max_position_embeddings"])
+
+    if "vocab_size" not in meta and tok_json:
+        added = tok_json.get("added_tokens") or []
+        if added:
+            meta["vocab_size"] = max(int(t["id"]) for t in added) + 1
+        else:
+            model_vocab = (tok_json.get("model") or {}).get("vocab_size")
+            if isinstance(model_vocab, int) and model_vocab > 0:
+                meta["vocab_size"] = model_vocab
+
+    if "vocab_size" not in meta:
+        vocab_size = _infer_vocab_size_from_merged(merged_path)
+        if vocab_size is not None:
+            meta["vocab_size"] = vocab_size
+
+    if "pad_token_id" not in meta and tok_cfg:
+        pad_token = tok_cfg.get("pad_token")
+        if isinstance(pad_token, str):
+            added_decoder = tok_cfg.get("added_tokens_decoder") or {}
+            pad_id = _token_content_to_id(pad_token, added_decoder)
+            if pad_id is not None:
+                meta["pad_token_id"] = pad_id
+
+    eos_ids = _collect_eos_token_ids(hf_cfg, tok_cfg)
+    if eos_ids:
+        meta["eos_token_id"] = eos_ids
+
+    return meta
+
+
+def _fill_missing_model_metadata(
+    model: dict[str, Any], bundle: ModelBundle, merged_path: Path
+) -> None:
+    inferred = _infer_model_metadata(bundle, merged_path)
+    for key, value in inferred.items():
+        if key not in model or model[key] in (None, "", []):
+            model[key] = value
+
+
 def build_genai_config(
     bundle: ModelBundle,
     merged_filename: str,
@@ -306,18 +413,7 @@ def build_genai_config(
         if isinstance(opt, dict) and "AMDGPU" in opt:
             opt["AMDGPU"]["profile"] = "hip"
 
-    if "vocab_size" not in model:
-        for tok_cfg in (
-            bundle.input_dir / "tokenizer" / "config.json",
-            bundle.input_dir / "config.json",
-        ):
-            if tok_cfg.is_file():
-                vocab = json.loads(tok_cfg.read_text(encoding="utf-8")).get(
-                    "vocab_size"
-                )
-                if isinstance(vocab, int) and vocab > 0:
-                    model["vocab_size"] = vocab
-                    break
+    _fill_missing_model_metadata(model, bundle, merged_path)
 
     search = cfg.setdefault("search", {})
     search["chunk_size"] = bundle.chunk_size

--- a/tools/onnx-merged-convert/merged_convert/cli.py
+++ b/tools/onnx-merged-convert/merged_convert/cli.py
@@ -1,0 +1,37 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .bundle import DEFAULT_OUTPUT_DIR_NAME, detect_bundle
+from .pipeline import _default_output_dir, convert_bundle
+
+__all__ = ["main"]
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Convert a split ONNX pipeline bundle into a single merged model."""
+    parser = argparse.ArgumentParser(description=main.__doc__)
+    parser.add_argument(
+        "--input-dir",
+        type=Path,
+        required=True,
+        help="Directory containing split embedding / decoder / lm_head ONNX files",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help=f"Output directory (default: <input-dir>/{DEFAULT_OUTPUT_DIR_NAME})",
+    )
+    args = parser.parse_args(argv)
+
+    bundle = detect_bundle(args.input_dir)
+    out = args.output_dir or _default_output_dir(bundle)
+    convert_bundle(bundle, out)
+    return 0

--- a/tools/onnx-merged-convert/merged_convert/int8kv.py
+++ b/tools/onnx-merged-convert/merged_convert/int8kv.py
@@ -1,0 +1,257 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import onnx
+from onnx import TensorProto, helper
+from onnx.compose import add_prefix, merge_graphs
+
+from .qdq_ext import (
+    CONVERT_PROFILE_LITE,
+    _align_model_ir_version_q,
+    _inline_initializer_names,
+    _pipeline_boundary_renames_q,
+    _rename_tensors_in_graph_q,
+    _topological_sort_graph_q,
+    apply_new_initializers_q,
+    assert_qdq_removed,
+    convert_matmul_int8_weight_dq,
+    fold_weight_dq_q,
+    fuse_conv_transpose_to_matmul_nbits_q,
+    infer_decoder_external_data_name_q,
+    prune_initializers_q,
+    promote_model_to_fp16_q,
+    rewrite_gqa_past_seq_len_to_seqlens_k_q,
+    save_decoder_model_q,
+    strip_activation_qdq_q,
+    unwrap_castfp32_before_quantize,
+)
+from .step2_fp16_cleanup import optimize_fp16_activations
+from .step3_lm_head import rewrite_lm_head_gather_unsqueeze
+
+FP16_q = TensorProto.FLOAT16
+FP32_q = TensorProto.FLOAT
+INT8 = TensorProto.INT8
+PIPELINE_PREFIXES = ("emb_", "dec_", "head_")
+KV_IO_PARTS = ("past_keys_", "past_values_", "present_keys_", "present_values_")
+
+
+def _count_fp32_casts(model: onnx.ModelProto) -> int:
+    return sum(
+        (
+            1
+            for n in model.graph.node
+            if n.op_type == "Cast"
+            and any((a.name == "to" and a.i == FP32_q for a in n.attribute))
+        )
+    )
+
+
+def assert_int8_kv_io(model: onnx.ModelProto, *, context: str = "") -> None:
+    """Ensure KV cache graph I/O remain int8."""
+    prefix = f"{context}: " if context else ""
+    for vi in list(model.graph.input) + list(model.graph.output):
+        if not any((part in vi.name for part in KV_IO_PARTS)):
+            continue
+        if vi.type.tensor_type.elem_type != INT8:
+            raise RuntimeError(
+                f"{prefix}{vi.name} must stay int8, got {vi.type.tensor_type.elem_type}"
+            )
+
+
+def assert_gqa_int8_quant(model: onnx.ModelProto, *, context: str = "") -> None:
+    prefix = f"{context}: " if context else ""
+    for node in model.graph.node:
+        if node.op_type != "GroupQueryAttention":
+            continue
+        attrs = {a.name: a for a in node.attribute}
+        kq = attrs.get("k_quant_type")
+        vq = attrs.get("v_quant_type")
+        bw = attrs.get("kv_cache_bit_width")
+        if kq is None or vq is None or bw is None:
+            raise RuntimeError(f"{prefix}GQA missing quant attributes on {node.name}")
+        if kq.s not in (b"PER_CHANNEL", b"PER_TENSOR"):
+            raise RuntimeError(f"{prefix}unexpected k_quant_type={kq.s!r}")
+        if vq.s not in (b"PER_CHANNEL", b"PER_TENSOR"):
+            raise RuntimeError(f"{prefix}unexpected v_quant_type={vq.s!r}")
+        if bw.i != 8:
+            raise RuntimeError(f"{prefix}expected kv_cache_bit_width=8, got {bw.i}")
+
+
+def wrap_gqa_fp32_query_for_int8_kv(model: onnx.ModelProto) -> int:
+    """ORT CPU GQA with int8 KV requires fp32 Q and matching float aux inputs."""
+    graph = model.graph
+    float_input_indices = (0, 7, 8)
+    new_nodes: list[onnx.NodeProto] = []
+    wrapped = 0
+    for node in graph.node:
+        if node.op_type != "GroupQueryAttention":
+            new_nodes.append(node)
+            continue
+        attrs = {a.name: a for a in node.attribute}
+        bw = attrs.get("kv_cache_bit_width")
+        kq = attrs.get("k_quant_type")
+        if bw is None or bw.i != 8 or kq is None or (kq.s == b"NONE"):
+            new_nodes.append(node)
+            continue
+        cast_nodes: list[onnx.NodeProto] = []
+        for idx in float_input_indices:
+            if idx >= len(node.input):
+                continue
+            src = node.input[idx]
+            if not src:
+                continue
+            fp32_name = f"{node.name}_in{idx}_fp32"
+            cast_nodes.append(
+                helper.make_node(
+                    "Cast",
+                    [src],
+                    [fp32_name],
+                    name=f"{node.name}_in{idx}_cast_fp32",
+                    to=FP32_q,
+                )
+            )
+            node.input[idx] = fp32_name
+        out_fp32 = f"{node.name}_out_fp32"
+        out_orig = node.output[0]
+        node.output[0] = out_fp32
+        new_nodes.extend(cast_nodes)
+        new_nodes.append(node)
+        new_nodes.append(
+            helper.make_node(
+                "Cast",
+                [out_fp32],
+                [out_orig],
+                name=f"{node.name}_out_cast_fp16",
+                to=FP16_q,
+            )
+        )
+        wrapped += 1
+    del graph.node[:]
+    graph.node.extend(new_nodes)
+    return wrapped
+
+
+def _cast_to_q(node: onnx.NodeProto) -> int | None:
+    if node.op_type != "Cast":
+        return None
+    for attr in node.attribute:
+        if attr.name == "to":
+            return int(attr.i)
+    return None
+
+
+def convert_decoder_int8kv(
+    src: Path, dst: Path, *, bundle_root: Path, gqa_seqlens_rewrite: bool = True
+) -> dict[str, int]:
+    """Q/DQ strip + Conv/MNB + fp16 activations; preserve int8 KV GQA."""
+    profile = CONVERT_PROFILE_LITE
+    model = onnx.load(str(src), load_external_data=True)
+    inline_at_load = _inline_initializer_names(model)
+    graph = model.graph
+    inits = {i.name: i for i in graph.initializer}
+    new_inits: dict[str, onnx.TensorProto] = {}
+    remove_inits: set[str] = set()
+    stats: dict[str, int] = {}
+    stats["unwrap_castfp32"] = unwrap_castfp32_before_quantize(graph)
+    stats["strip_qdq"] = strip_activation_qdq_q(
+        graph, inits, new_inits, pure_fp16=True, mode=profile.activation_qdq_mode
+    )
+    stats["conv_mnbits"] = fuse_conv_transpose_to_matmul_nbits_q(
+        graph, inits, new_inits, remove_inits
+    )
+    stats["matmul_int8_mnbits"] = convert_matmul_int8_weight_dq(
+        graph, inits, new_inits, remove_inits
+    )
+    stats["weight_dq_fold"] = fold_weight_dq_q(
+        graph, inits, new_inits, remove_inits, weight_dtype=__import__("numpy").float16
+    )
+    if new_inits or remove_inits:
+        apply_new_initializers_q(graph, new_inits)
+        prune_initializers_q(graph, remove_inits)
+    promote_model_to_fp16_q(
+        model,
+        skip_initializer_substrings=("_emu_scale", "_emu_zp", "k_scale_", "v_scale_"),
+    )
+    fp16_stats = optimize_fp16_activations(model)
+    stats["gqa_getitem_fp32_removed"] = fp16_stats["gqa_getitem_fp32_removed"]
+    stats["mnbits_fp16_casts_folded"] = fp16_stats["mnbits_fp16_casts_folded"]
+    stats["gqa_fp32_query_wrap"] = wrap_gqa_fp32_query_for_int8_kv(model)
+    stats["fp32_casts_remaining"] = _count_fp32_casts(model)
+    allowed_fp32_casts = 3 * stats["gqa_fp32_query_wrap"]
+    if stats["fp32_casts_remaining"] > allowed_fp32_casts:
+        raise RuntimeError(
+            f"{dst.name}: {stats['fp32_casts_remaining']} Cast->fp32 remain (allowed {allowed_fp32_casts} at GQA boundaries)"
+        )
+    stats["gqa_seqlens_rewrite"] = (
+        rewrite_gqa_past_seq_len_to_seqlens_k_q(model) if gqa_seqlens_rewrite else 0
+    )
+    assert_qdq_removed(graph, context=dst.name)
+    assert_int8_kv_io(model, context=dst.name)
+    assert_gqa_int8_quant(model, context=dst.name)
+    ext_name = infer_decoder_external_data_name_q(src, bundle_root)
+    save_decoder_model_q(
+        model, dst, external_data_name=ext_name, keep_inline=inline_at_load
+    )
+    return stats
+
+
+def merge_pipeline(
+    emb_path: Path,
+    decoder_path: Path,
+    head_path: Path,
+    dst_path: Path,
+    *,
+    external_data_name: str = "merged.data",
+) -> None:
+    emb = onnx.load(str(emb_path), load_external_data=True)
+    decoder = onnx.load(str(decoder_path), load_external_data=True)
+    head = onnx.load(str(head_path), load_external_data=True)
+    head = rewrite_lm_head_gather_unsqueeze(head)
+    target_ir = max(emb.ir_version, decoder.ir_version, head.ir_version)
+    _align_model_ir_version_q(emb, target_ir)
+    _align_model_ir_version_q(head, target_ir)
+    emb_p = add_prefix(emb, prefix=PIPELINE_PREFIXES[0])
+    dec_p = add_prefix(decoder, prefix=PIPELINE_PREFIXES[1])
+    head_p = add_prefix(head, prefix=PIPELINE_PREFIXES[2])
+    graph = merge_graphs(
+        emb_p.graph,
+        dec_p.graph,
+        [("emb_input_hidden_states", "dec_input_hidden_states")],
+    )
+    kv_outputs = [out.name for out in graph.output if "present_" in out.name]
+    graph = merge_graphs(
+        graph,
+        head_p.graph,
+        [("dec_output_hidden_states", "head_output_hidden_states")],
+        outputs=["head_logits", *kv_outputs],
+    )
+    _topological_sort_graph_q(graph)
+    _rename_tensors_in_graph_q(graph, _pipeline_boundary_renames_q(graph))
+    logits_out = next((vi for vi in graph.output if vi.name == "logits"), None)
+    if logits_out is not None:
+        other_outs = [vi for vi in graph.output if vi.name != "logits"]
+        del graph.output[:]
+        graph.output.extend([logits_out, *other_outs])
+    model = helper.make_model(graph, opset_imports=decoder.opset_import)
+    model.ir_version = target_ir
+    model.graph.name = f"{dst_path.stem}_graph"
+    dst_path.parent.mkdir(parents=True, exist_ok=True)
+    data_path = dst_path.parent / external_data_name
+    if dst_path.exists():
+        dst_path.unlink()
+    if data_path.exists():
+        data_path.unlink()
+    onnx.save_model(
+        model,
+        str(dst_path),
+        save_as_external_data=True,
+        all_tensors_to_one_file=True,
+        location=external_data_name,
+        size_threshold=65536,
+    )

--- a/tools/onnx-merged-convert/merged_convert/pipeline.py
+++ b/tools/onnx-merged-convert/merged_convert/pipeline.py
@@ -19,7 +19,6 @@ from .bundle import (
 )
 from .int8kv import convert_decoder_int8kv
 from .pipeline_aliases import (
-    CONVERT_PROFILE_LITE,
     CONVERT_PROFILE_LOW_BIT,
     convert_head_quantized,
     merge_split_pipeline,
@@ -28,6 +27,7 @@ from .pipeline_aliases import (
     patch_emb_quantized,
     process_one_onnx,
 )
+from .qdq_ext import CONVERT_PROFILE_LITE
 from .step1_qdq_fp16 import (
     ShapeFixConfig,
     convert_decoder_model,
@@ -345,12 +345,11 @@ def convert_bundle(bundle: ModelBundle, output_dir: Path) -> Path:
         meta_path = output_dir / "lora_dequant.json"
         meta_path.write_text(json.dumps(lora_dequant_meta, indent=2), encoding="utf-8")
         extras.append(f"lora_dequant.json ({len(lora_dequant_meta)} adapter ports)")
-        adapter_src = bundle.input_dir / "adapter.safetensors"
-        if adapter_src.exists():
-            adapter_dst = output_dir / "adapter.safetensors"
-            if not adapter_dst.exists():
-                shutil.copy2(adapter_src, adapter_dst)
-            extras.append("adapter.safetensors")
+
+    adapter_src = bundle.input_dir / "adapter.safetensors"
+    if adapter_src.is_file():
+        shutil.copy2(adapter_src, output_dir / "adapter.safetensors")
+        extras.append("adapter.safetensors")
 
     extra_msg = f" + {', '.join(extras)}" if extras else ""
     print(

--- a/tools/onnx-merged-convert/merged_convert/pipeline.py
+++ b/tools/onnx-merged-convert/merged_convert/pipeline.py
@@ -1,0 +1,363 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+from pathlib import Path
+
+from .bundle import (
+    DEFAULT_OUTPUT_DIR_NAME,
+    ModelBundle,
+    PipelineKind,
+    build_genai_config,
+    _find_genai_config_source,
+)
+from .int8kv import convert_decoder_int8kv
+from .pipeline_aliases import (
+    CONVERT_PROFILE_LITE,
+    CONVERT_PROFILE_LOW_BIT,
+    convert_head_quantized,
+    merge_split_pipeline,
+    merge_split_pipeline_lowbit,
+    merge_split_pipeline_quantized,
+    patch_emb_quantized,
+    process_one_onnx,
+)
+from .step1_qdq_fp16 import (
+    ShapeFixConfig,
+    convert_decoder_model,
+    convert_lm_head_model,
+    patch_emb_model,
+)
+from .step2_fp16_cleanup import patch_model_file
+from .step4_unfix_seq_len import unfix_seq_len
+
+DEFAULT_MAX_SEQ_LEN = 16384
+
+
+def _apply_pure_fp16(*paths: Path) -> None:
+    for path in paths:
+        patch_model_file(path, path)
+
+
+def _convert_quantized_linear(
+    bundle: ModelBundle, work: Path, merged_path: Path
+) -> dict[str, dict] | None:
+    shape_prefill = ShapeFixConfig(
+        enabled=True,
+        batch=1,
+        seq_len=bundle.prefill_seq_len,
+        max_seq_len=DEFAULT_MAX_SEQ_LEN,
+    )
+    shape_decode = ShapeFixConfig(
+        enabled=True, batch=1, seq_len=1, max_seq_len=DEFAULT_MAX_SEQ_LEN
+    )
+    shape_dyn = ShapeFixConfig(enabled=False)
+
+    dec_prefill = work / "dec_prefill.onnx"
+    dec_decode = work / "dec_decode.onnx"
+    emb_out = work / "emb.onnx"
+    head_out = work / "head.onnx"
+    dynamic = work / "decoder_dynamic.onnx"
+    lora_dequant_meta: dict[str, dict] = {}
+
+    decoder_mode = (
+        "folded Gemm weights + fp16 adapter inputs"
+        if bundle.fold_gemm_weights
+        else "quantized linear (MatMulNBits)"
+    )
+    print(f"  [1/5] QDQ removal + fp16 (decoder, {decoder_mode}) ...")
+    convert_decoder_model(
+        bundle.dec_prefill,
+        dec_prefill,
+        shape_fix=shape_prefill,
+        bundle_root=bundle.input_dir,
+        gqa_seqlens_rewrite=False,
+        pure_gemm=bundle.fold_gemm_weights,
+        lora_dequant_meta=lora_dequant_meta if bundle.fold_gemm_weights else None,
+    )
+    convert_decoder_model(
+        bundle.dec_decode,
+        dec_decode,
+        shape_fix=shape_decode,
+        bundle_root=bundle.input_dir,
+        gqa_seqlens_rewrite=False,
+        pure_gemm=bundle.fold_gemm_weights,
+        lora_dequant_meta=lora_dequant_meta if bundle.fold_gemm_weights else None,
+    )
+
+    print("  [2/5] QDQ removal + fp16 (emb / lm_head) + pruned logits ...")
+    patch_emb_model(
+        bundle.emb,
+        emb_out,
+        shape_fix=shape_dyn,
+        rewrite_head_data=True,
+        head_data_dir=work,
+    )
+    convert_lm_head_model(
+        bundle.head,
+        head_out,
+        shape_fix=shape_dyn,
+        rewrite_head_data=False,
+        head_data_dir=work,
+        gather_unsqueeze=True,
+    )
+
+    print(f"  [3/5] Unfix seq_len ({bundle.prefill_seq_len}/1 -> dynamic) ...")
+    unfix_seq_len(
+        dec_prefill,
+        dec_decode,
+        dec_prefill,
+        dynamic,
+        static_seq_lens=(1, bundle.prefill_seq_len),
+    )
+    _apply_pure_fp16(dec_decode, dec_prefill, dynamic)
+
+    print("  [4/5] Merge emb + dynamic decoder + lm_head ...")
+    data_name = f"{bundle.merged_stem}.data"
+    merge_split_pipeline(
+        emb_out,
+        dynamic,
+        head_out,
+        merged_path,
+        external_data_name=data_name,
+    )
+    print("  [5/5] Final fp16 activation cleanup on merged graph ...")
+    _apply_pure_fp16(merged_path)
+    return lora_dequant_meta if bundle.fold_gemm_weights and lora_dequant_meta else None
+
+
+def _convert_int8_kv(bundle: ModelBundle, work: Path, merged_path: Path) -> None:
+    shape_dyn = ShapeFixConfig(enabled=False)
+    profile = CONVERT_PROFILE_LITE
+
+    dec_prefill = work / "dec_prefill.onnx"
+    dec_decode = work / "dec_decode.onnx"
+    dynamic = work / "decoder_dynamic.onnx"
+    emb_out = work / "emb.onnx"
+    head_out = work / "head.onnx"
+
+    print("  [1/5] QDQ removal + fp16 decoder (int8 KV preserved, prefill/decode) ...")
+    convert_decoder_int8kv(
+        bundle.dec_prefill,
+        dec_prefill,
+        bundle_root=bundle.input_dir,
+        gqa_seqlens_rewrite=False,
+    )
+    convert_decoder_int8kv(
+        bundle.dec_decode,
+        dec_decode,
+        bundle_root=bundle.input_dir,
+        gqa_seqlens_rewrite=False,
+    )
+
+    print(f"  [2/5] Unfix seq_len ({bundle.prefill_seq_len}/1 -> dynamic) ...")
+    unfix_seq_len(
+        dec_prefill,
+        dec_decode,
+        dec_prefill,
+        dynamic,
+        static_seq_lens=(1, bundle.prefill_seq_len),
+    )
+    _apply_pure_fp16(dynamic)
+
+    print("  [3/5] QDQ removal + fp16 (emb / lm_head) ...")
+    patch_emb_quantized(
+        bundle.emb,
+        emb_out,
+        shape_fix=shape_dyn,
+        rewrite_head_data=False,
+        head_data_dir=work,
+        profile=profile,
+    )
+    convert_head_quantized(
+        bundle.head,
+        head_out,
+        shape_fix=shape_dyn,
+        rewrite_head_data=False,
+        head_data_dir=work,
+        gather_unsqueeze=False,
+        profile=profile,
+    )
+
+    print("  [4/5] Merge emb + dynamic decoder + lm_head (pruned logits at merge) ...")
+    data_name = f"{bundle.merged_stem}.data"
+    merge_split_pipeline_quantized(
+        emb_out,
+        dynamic,
+        head_out,
+        merged_path,
+        external_data_name=data_name,
+    )
+    print("  [5/5] Final fp16 activation cleanup on merged graph ...")
+    _apply_pure_fp16(merged_path)
+
+
+def _convert_low_bit(bundle: ModelBundle, work: Path, merged_path: Path) -> None:
+    shape_prefill = ShapeFixConfig(
+        enabled=True,
+        batch=1,
+        seq_len=bundle.prefill_seq_len,
+        max_seq_len=DEFAULT_MAX_SEQ_LEN,
+    )
+    shape_decode = ShapeFixConfig(
+        enabled=True, batch=1, seq_len=1, max_seq_len=DEFAULT_MAX_SEQ_LEN
+    )
+    shape_dyn = ShapeFixConfig(enabled=False)
+    profile = CONVERT_PROFILE_LOW_BIT
+
+    dec_prefill = work / "dec_prefill.onnx"
+    dec_decode = work / "dec_decode.onnx"
+    emb_out = work / "emb.onnx"
+    head_out = work / "head.onnx"
+    dynamic = work / "decoder_dynamic.onnx"
+
+    print("  [1/5] QDQ removal + fp16 (decoder prefill/decode) ...")
+    process_one_onnx(
+        bundle.dec_prefill,
+        dec_prefill,
+        kind="decoder",
+        shape_fix=shape_prefill,
+        bundle_root=bundle.input_dir,
+        head_data_dir=work,
+        rewrite_head_data=False,
+        profile=profile,
+    )
+    process_one_onnx(
+        bundle.dec_decode,
+        dec_decode,
+        kind="decoder",
+        shape_fix=shape_decode,
+        bundle_root=bundle.input_dir,
+        head_data_dir=work,
+        rewrite_head_data=False,
+        profile=profile,
+    )
+
+    print("  [2/5] QDQ removal + fp16 (emb / lm_head) ...")
+    process_one_onnx(
+        bundle.emb,
+        emb_out,
+        kind="emb",
+        shape_fix=shape_dyn,
+        bundle_root=bundle.input_dir,
+        head_data_dir=work,
+        rewrite_head_data=True,
+        profile=profile,
+    )
+    process_one_onnx(
+        bundle.head,
+        head_out,
+        kind="lm_head",
+        shape_fix=shape_dyn,
+        bundle_root=bundle.input_dir,
+        head_data_dir=work,
+        rewrite_head_data=False,
+        gather_unsqueeze=False,
+        profile=profile,
+    )
+
+    print(f"  [3/5] Unfix seq_len ({bundle.prefill_seq_len}/1 -> dynamic) ...")
+    unfix_seq_len(
+        dec_prefill,
+        dec_decode,
+        dec_prefill,
+        dynamic,
+        static_seq_lens=(1, bundle.prefill_seq_len),
+    )
+    _apply_pure_fp16(dec_decode, dec_prefill, dynamic)
+
+    print("  [4/5] Merge emb + dynamic decoder + lm_head (pruned logits) ...")
+    data_name = f"{bundle.merged_stem}.data"
+    merge_split_pipeline_lowbit(
+        emb_out,
+        dynamic,
+        head_out,
+        merged_path,
+        external_data_name=data_name,
+        gather_unsqueeze=True,
+    )
+    print("  [5/5] Final fp16 activation cleanup on merged graph ...")
+    _apply_pure_fp16(merged_path)
+
+
+def convert_bundle(bundle: ModelBundle, output_dir: Path) -> Path:
+    output_dir = output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    merged_path = output_dir / f"{bundle.merged_stem}.onnx"
+    merged_data = output_dir / f"{bundle.merged_stem}.data"
+    for path in (merged_path, merged_data):
+        if path.exists():
+            path.unlink()
+
+    flags = []
+    if bundle.fold_gemm_weights:
+        flags.append("folded-gemm")
+    flag_text = f", {', '.join(flags)}" if flags else ""
+    print(
+        f"\n=== {bundle.input_dir.name} ({bundle.pipeline.value}{flag_text}) "
+        f"-> {output_dir.name}/{bundle.merged_stem}.onnx ==="
+    )
+
+    lora_dequant_meta: dict[str, dict] | None = None
+    with tempfile.TemporaryDirectory(
+        prefix=f"merged_convert_{bundle.decoder_stem}_"
+    ) as tmp:
+        work = Path(tmp)
+        if bundle.pipeline is PipelineKind.QUANTIZED_LINEAR:
+            lora_dequant_meta = _convert_quantized_linear(bundle, work, merged_path)
+        elif bundle.pipeline is PipelineKind.INT8_KV:
+            _convert_int8_kv(bundle, work, merged_path)
+        elif bundle.pipeline is PipelineKind.LOW_BIT:
+            _convert_low_bit(bundle, work, merged_path)
+        else:
+            raise ValueError(f"Unsupported pipeline: {bundle.pipeline}")
+
+    if not merged_path.exists():
+        raise RuntimeError(
+            f"Conversion finished but merged model missing: {merged_path}"
+        )
+    if not merged_data.exists():
+        raise RuntimeError(
+            f"Conversion finished but external weights missing: {merged_data}"
+        )
+
+    source_cfg = _find_genai_config_source(bundle.input_dir)
+    cfg = build_genai_config(
+        bundle,
+        merged_path.name,
+        merged_path,
+        source=source_cfg,
+    )
+    cfg_path = output_dir / "genai_config.json"
+    cfg_path.write_text(
+        json.dumps(cfg, indent=4, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+
+    extras: list[str] = []
+    if lora_dequant_meta:
+        meta_path = output_dir / "lora_dequant.json"
+        meta_path.write_text(json.dumps(lora_dequant_meta, indent=2), encoding="utf-8")
+        extras.append(f"lora_dequant.json ({len(lora_dequant_meta)} adapter ports)")
+        adapter_src = bundle.input_dir / "adapter.safetensors"
+        if adapter_src.exists():
+            adapter_dst = output_dir / "adapter.safetensors"
+            if not adapter_dst.exists():
+                shutil.copy2(adapter_src, adapter_dst)
+            extras.append("adapter.safetensors")
+
+    extra_msg = f" + {', '.join(extras)}" if extras else ""
+    print(
+        f"  Wrote {merged_path.name} + {merged_data.name} + genai_config.json{extra_msg}"
+    )
+    return merged_path
+
+
+def _default_output_dir(bundle: ModelBundle) -> Path:
+    return bundle.input_dir / DEFAULT_OUTPUT_DIR_NAME

--- a/tools/onnx-merged-convert/merged_convert/pipeline_aliases.py
+++ b/tools/onnx-merged-convert/merged_convert/pipeline_aliases.py
@@ -1,0 +1,24 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+
+from __future__ import annotations
+
+from .int8kv import merge_pipeline
+from .qdq_ext import (
+    CONVERT_PROFILE_LOW_BIT_INTERNAL,
+    convert_lm_head_model_q,
+    merge_quantized_pipeline_models,
+    patch_emb_model_q,
+    process_one_onnx_q,
+)
+from .step5_merge import merge_split_pipeline_models
+
+CONVERT_PROFILE_LOW_BIT = CONVERT_PROFILE_LOW_BIT_INTERNAL
+merge_split_pipeline = merge_split_pipeline_models
+merge_split_pipeline_quantized = merge_pipeline
+merge_split_pipeline_lowbit = merge_quantized_pipeline_models
+patch_emb_quantized = patch_emb_model_q
+convert_head_quantized = convert_lm_head_model_q
+process_one_onnx = process_one_onnx_q

--- a/tools/onnx-merged-convert/merged_convert/qdq_ext.py
+++ b/tools/onnx-merged-convert/merged_convert/qdq_ext.py
@@ -1,0 +1,1629 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import onnx
+from onnx import TensorProto, helper, numpy_helper
+from onnx.compose import add_prefix, merge_graphs
+
+from .step2_fp16_cleanup import optimize_fp16_activations
+from .step3_lm_head import rewrite_lm_head_gather_unsqueeze
+
+FP32_q = TensorProto.FLOAT
+FP64_q = TensorProto.DOUBLE
+FP16_q = TensorProto.FLOAT16
+DEFAULT_BATCH_q = 1
+DEFAULT_SEQ_LEN_q = 128
+DEFAULT_MAX_SEQ_LEN_q = 16384
+_INT4_UNSIGNED_OFFSET_q = 8
+DEFAULT_ACCURACY_LEVEL_q = 1
+MATMUL_NBITS_ACCURACY_LEVEL_q = DEFAULT_ACCURACY_LEVEL_q
+_WEIGHT_DQ_CONSUMER_INPUTS: dict[str, tuple[int, ...]] = {
+    "Mul": (0, 1),
+    "Conv": (1,),
+    "Add": (0, 1),
+}
+DECODER_EXT_DATA = "decoder_4bit.data"
+
+
+def _dim_param_bindings_q(batch: int, seq_len: int, max_seq_len: int) -> dict[str, int]:
+    return {"batch": batch, "seq_len": seq_len, "max_seq_len": max_seq_len}
+
+
+def _fix_value_info_shapes_q(vi: onnx.ValueInfoProto, bindings: dict[str, int]) -> None:
+    for dim in vi.type.tensor_type.shape.dim:
+        if dim.dim_param and dim.dim_param in bindings:
+            dim.dim_value = bindings[dim.dim_param]
+            dim.ClearField("dim_param")
+
+
+@dataclass(frozen=True)
+class ShapeFixConfig_q:
+    """Optional static-shape binding for symbolic ONNX dimensions."""
+
+    enabled: bool = False
+    batch: int = DEFAULT_BATCH_q
+    seq_len: int = DEFAULT_SEQ_LEN_q
+    max_seq_len: int = DEFAULT_MAX_SEQ_LEN_q
+
+
+@dataclass(frozen=True)
+class ConvertProfile:
+    """Which conversion passes to run (``lite`` = QDQ + Conv/MNB + fp16 + merge only)."""
+
+    strip_qdq: bool = True
+    conv_mnbits: bool = True
+    weight_dq_fold: bool = True
+    fp16: bool = True
+    fp32_activations: bool = False
+    emb_bits4: bool = True
+    lm_head_gather: bool = True
+    gqa_fp16_no_quant: bool = True
+    gqa_seqlens_rewrite: bool = True
+    matmul_nbits_accuracy: bool = True
+    lpnorm_fp32: bool = True
+    gqa_pre_cast_fp32_remove: bool = True
+    activation_qdq_mode: str = "emu"
+
+
+CONVERT_PROFILE_FULL = ConvertProfile()
+CONVERT_PROFILE_LITE = ConvertProfile(
+    gqa_fp16_no_quant=False,
+    matmul_nbits_accuracy=False,
+    lpnorm_fp32=False,
+    activation_qdq_mode="bypass",
+)
+CONVERT_PROFILE_LOW_BIT_INTERNAL = ConvertProfile(
+    gqa_fp16_no_quant=False,
+    matmul_nbits_accuracy=False,
+    lpnorm_fp32=False,
+    gqa_seqlens_rewrite=False,
+    gqa_pre_cast_fp32_remove=False,
+    fp16=True,
+    fp32_activations=False,
+    activation_qdq_mode="bypass",
+)
+
+
+def maybe_fix_static_shapes_q(
+    model: onnx.ModelProto, shape_fix: ShapeFixConfig_q
+) -> None:
+    """Bind symbolic dims when ``shape_fix.enabled``."""
+    if not shape_fix.enabled:
+        return
+    bindings = _dim_param_bindings_q(
+        shape_fix.batch, shape_fix.seq_len, shape_fix.max_seq_len
+    )
+    graph = model.graph
+    for vi in list(graph.input) + list(graph.output) + list(graph.value_info):
+        _fix_value_info_shapes_q(vi, bindings)
+
+
+def fix_static_shapes_q(
+    model: onnx.ModelProto,
+    *,
+    batch: int = DEFAULT_BATCH_q,
+    seq_len: int = DEFAULT_SEQ_LEN_q,
+    max_seq_len: int = DEFAULT_MAX_SEQ_LEN_q,
+) -> None:
+    maybe_fix_static_shapes_q(
+        model,
+        ShapeFixConfig_q(
+            enabled=True, batch=batch, seq_len=seq_len, max_seq_len=max_seq_len
+        ),
+    )
+
+
+def _nibble_pack_int4_q(values: np.ndarray) -> np.ndarray:
+    nibbles = values.astype(np.int16) + _INT4_UNSIGNED_OFFSET_q & 15
+    return nibbles[0::2].astype(np.uint8) | nibbles[1::2].astype(np.uint8) << 4
+
+
+def choose_block_size_q(k: int) -> int:
+    """Pick a MatMulNBits-legal block_size (power of 2, >= 16) for a K dim.
+
+    Prefer the largest such block_size that divides K (no padding needed);
+    fall back to 32 with zero-padded trailing block when none divides.
+    """
+    for bs in (256, 128, 64, 32, 16):
+        if k % bs == 0:
+            return bs
+    return 32
+
+
+def pack_matmul_nbits_weight_q(
+    w_kn: np.ndarray, block_size: int
+) -> tuple[np.ndarray, int, int, int]:
+    k, n = w_kn.shape
+    if k % 2 != 0:
+        raise ValueError(f"K must be even for 4-bit packing, got K={k}")
+    n_blocks = (k + block_size - 1) // block_size
+    blob_size = block_size // 2
+    packed = np.zeros((n, n_blocks, blob_size), dtype=np.uint8)
+    for col in range(n):
+        col_bytes = _nibble_pack_int4_q(w_kn[:, col])
+        flat = np.zeros(n_blocks * blob_size, dtype=np.uint8)
+        flat[: col_bytes.size] = col_bytes
+        packed[col] = flat.reshape(n_blocks, blob_size)
+    return (packed, k, n, n_blocks)
+
+
+def pack_zero_points_q(z_n: np.ndarray, n: int, n_blocks: int) -> np.ndarray:
+    """Pack one (per-channel) 4-bit zero point, replicated across all blocks.
+
+    Layout matches MatMulNBits: per column, n_blocks nibbles packed two-per-byte
+    (even block -> low nibble, odd block -> high nibble).
+    """
+    zp_bytes = (n_blocks + 1) // 2
+    out = np.zeros((n, zp_bytes), dtype=np.uint8)
+    for col in range(n):
+        v = int(z_n[col]) + _INT4_UNSIGNED_OFFSET_q & 15
+        for b in range(n_blocks):
+            if b % 2 == 0:
+                out[col, b // 2] |= v
+            else:
+                out[col, b // 2] |= v << 4
+    return out
+
+
+_SIGNED_INT8_MNBITS_OFFSET = 128
+
+
+def pack_matmul_nbits_weight_int8(
+    w_kn: np.ndarray, block_size: int
+) -> tuple[np.ndarray, int, int, int]:
+    """Pack signed int8 weight [K, N] into MatMulNBits uint8 blocks [N, n_blocks, block_size]."""
+    k, n = w_kn.shape
+    n_blocks = (k + block_size - 1) // block_size
+    padded_k = n_blocks * block_size
+    packed = np.zeros((n, n_blocks, block_size), dtype=np.uint8)
+    for col in range(n):
+        col_w = w_kn[:, col].astype(np.int16)
+        if col_w.size < padded_k:
+            col_w = np.pad(col_w, (0, padded_k - col_w.size))
+        packed[col] = (
+            (col_w + _SIGNED_INT8_MNBITS_OFFSET)
+            .astype(np.uint8)
+            .reshape(n_blocks, block_size)
+        )
+    return (packed, k, n, n_blocks)
+
+
+def _int8_mnbits_zero_points(n: int, n_blocks: int) -> np.ndarray:
+    return np.full((n, n_blocks), _SIGNED_INT8_MNBITS_OFFSET, dtype=np.uint8)
+
+
+def convert_matmul_int8_weight_dq(
+    graph: onnx.GraphProto,
+    inits: dict[str, onnx.TensorProto],
+    new_inits: dict[str, onnx.TensorProto],
+    remove_inits: set[str],
+) -> int:
+    """Replace ``MatMul(int8 DQ weight)`` with ``MatMulNBits`` (bits=8)."""
+    dq_by_out = {d.output[0]: d for d in graph.node if d.op_type == "DequantizeLinear"}
+    replacements: dict[str, onnx.NodeProto] = {}
+    remove_nodes: set[str] = set()
+    converted = 0
+    for mm in graph.node:
+        if mm.op_type != "MatMul" or len(mm.input) < 2:
+            continue
+        dq = dq_by_out.get(mm.input[1])
+        if dq is None or dq.input[0] not in inits:
+            continue
+        w_init = inits[dq.input[0]]
+        if w_init.data_type != TensorProto.INT8:
+            continue
+        w = numpy_helper.to_array(w_init)
+        if w.ndim != 2:
+            continue
+        k, n = (int(w.shape[0]), int(w.shape[1]))
+        scale, zp = _expand_scale_zp_q(
+            numpy_helper.to_array(inits[dq.input[1]]),
+            numpy_helper.to_array(inits[dq.input[2]]),
+            n,
+        )
+        block_size = choose_block_size_q(k)
+        packed, k, n, n_blocks = pack_matmul_nbits_weight_int8(w, block_size)
+        base = w_init.name.removesuffix("_quantized")
+        q_name = f"{base}_mnbits_q8"
+        s_name = f"{base}_mnbits_scales"
+        z_name = f"{base}_mnbits_zp"
+        new_inits[q_name] = numpy_helper.from_array(packed, name=q_name)
+        new_inits[s_name] = numpy_helper.from_array(
+            np.repeat(scale.astype(np.float16).reshape(n, 1), n_blocks, axis=1),
+            name=s_name,
+        )
+        new_inits[z_name] = numpy_helper.from_array(
+            _int8_mnbits_zero_points(n, n_blocks), name=z_name
+        )
+        replacements[mm.name] = helper.make_node(
+            "MatMulNBits",
+            [mm.input[0], q_name, s_name, z_name],
+            list(mm.output),
+            name=f"{mm.name}_mnbits",
+            domain="com.microsoft",
+            K=k,
+            N=n,
+            bits=8,
+            block_size=block_size,
+            accuracy_level=MATMUL_NBITS_ACCURACY_LEVEL_q,
+        )
+        remove_nodes.update({mm.name, dq.name})
+        remove_inits.update({w_init.name, dq.input[1], dq.input[2]})
+        converted += 1
+    if converted:
+        kept: list[onnx.NodeProto] = []
+        for node in graph.node:
+            if node.name in replacements:
+                kept.append(replacements[node.name])
+            elif node.name not in remove_nodes:
+                kept.append(node)
+        del graph.node[:]
+        graph.node.extend(kept)
+    return converted
+
+
+def dequantize_initializer_q(
+    w: np.ndarray, scale: np.ndarray, zp: np.ndarray, *, out_dtype: type = np.float16
+) -> np.ndarray:
+    w_f = w.astype(np.float64)
+    s_f = np.asarray(scale, dtype=np.float64)
+    z_f = np.asarray(zp, dtype=np.float64)
+    return ((w_f - z_f) * s_f).astype(out_dtype)
+
+
+def _replace_tensor_name_q(
+    users: dict[str, list[tuple[onnx.NodeProto, int]]], old: str, new: str
+) -> None:
+    for node, idx in users.get(old, []):
+        if node.input[idx] == old:
+            node.input[idx] = new
+
+
+def _build_tensor_users_q(
+    graph: onnx.GraphProto,
+) -> dict[str, list[tuple[onnx.NodeProto, int]]]:
+    users: dict[str, list[tuple[onnx.NodeProto, int]]] = {}
+    for node in graph.node:
+        for idx, name in enumerate(node.input):
+            if name:
+                users.setdefault(name, []).append((node, idx))
+    return users
+
+
+def _referenced_initializer_names_q(graph: onnx.GraphProto) -> set[str]:
+    used: set[str] = set()
+    for node in graph.node:
+        for name in node.input:
+            if name:
+                used.add(name)
+    return used
+
+
+def _rename_value_tensor_q(
+    graph: onnx.GraphProto,
+    users: dict[str, list[tuple[onnx.NodeProto, int]]],
+    old: str,
+    new: str,
+) -> None:
+    if old == new:
+        return
+    for node in graph.node:
+        for idx, out_name in enumerate(node.output):
+            if out_name == old:
+                node.output[idx] = new
+    _replace_tensor_name_q(users, old, new)
+    for vi in graph.value_info:
+        if vi.name == old:
+            vi.name = new
+
+
+def _activation_qdq_source(graph: onnx.GraphProto, tensor: str) -> str:
+    """Prefer fp16 ``*_pre_cast`` over an upstream Cast(fp32) fake-quant input."""
+    producer: dict[str, onnx.NodeProto] = {}
+    for node in graph.node:
+        for out in node.output:
+            if out:
+                producer[out] = node
+    node = producer.get(tensor)
+    if node is None or node.op_type != "Cast" or (not node.input):
+        return tensor
+    if "pre_cast_castfp32" not in node.name:
+        return tensor
+    return node.input[0]
+
+
+def _cast_to_q(node: onnx.NodeProto) -> int | None:
+    if node.op_type != "Cast":
+        return None
+    for attr in node.attribute:
+        if attr.name == "to":
+            return int(attr.i)
+    return None
+
+
+def unwrap_castfp32_before_quantize(graph: onnx.GraphProto) -> int:
+    """Point QuantizeLinear at fp16 ``*_pre_cast`` instead of Cast(fp32) inputs."""
+    producer: dict[str, onnx.NodeProto] = {}
+    for node in graph.node:
+        for out in node.output:
+            if out:
+                producer[out] = node
+    remove: set[str] = set()
+    unwrapped = 0
+    for q in graph.node:
+        if q.op_type != "QuantizeLinear" or not q.input:
+            continue
+        cast = producer.get(q.input[0])
+        if cast is None or cast.op_type != "Cast" or _cast_to_q(cast) != FP32_q:
+            continue
+        if "pre_cast_castfp32" not in cast.name or not cast.input:
+            continue
+        if "GroupQueryAttention_output_" in cast.name:
+            continue
+        q.input[0] = cast.input[0]
+        remove.add(cast.name)
+        unwrapped += 1
+    if remove:
+        kept = [n for n in graph.node if n.name not in remove]
+        del graph.node[:]
+        graph.node.extend(kept)
+    return unwrapped
+
+
+def _fp16_zp_power_terms(zp: float) -> list[float]:
+    """Decompose integer zero-point into float16-exact power-of-two summands."""
+    remaining = int(round(zp))
+    if remaining == 0:
+        return [0.0]
+    terms: list[float] = []
+    sign = 1 if remaining >= 0 else -1
+    remaining = abs(remaining)
+    for bit in range(20):
+        mask = 1 << bit
+        if remaining & mask:
+            terms.append(float(np.float16(sign * mask)))
+            remaining -= mask
+    if remaining:
+        terms.append(float(np.float16(sign * remaining)))
+    return terms
+
+
+def _fp16_scale(scale: float) -> float:
+    """Return scale as float16 (Div/Mul emulation; avoid 1/scale which overflows fp16)."""
+    return float(np.float16(np.float32(scale)))
+
+
+def _fp16_zp(zp_init: onnx.TensorProto) -> float:
+    """Fold integer zero-point into one fp16 constant (convert-time power-sum)."""
+    zp = float(np.asarray(numpy_helper.to_array(zp_init)).reshape(-1)[0])
+    terms = _fp16_zp_power_terms(zp)
+    acc = np.float32(0.0)
+    for term in terms:
+        acc = np.float32(acc + np.float32(term))
+    return float(np.float16(acc))
+
+
+def _insert_pure_fp16_qdq_emulation(
+    *,
+    x: str,
+    y: str,
+    scale_init: onnx.TensorProto,
+    zp_init: onnx.TensorProto,
+    prefix: str,
+    new_inits: dict[str, onnx.TensorProto],
+) -> list[onnx.NodeProto]:
+    """Fake-quant in pure fp16: no Q/DQ ops, no fp32 activation tensors."""
+    scale = float(np.asarray(numpy_helper.to_array(scale_init)).reshape(-1)[0])
+    scale_f16 = _fp16_scale(scale)
+    zp_f16 = _fp16_zp(zp_init)
+    scale_name = f"{prefix}_emu_scale"
+    zp_name = f"{prefix}_emu_zp"
+    new_inits[scale_name] = numpy_helper.from_array(
+        np.array(scale_f16, dtype=np.float16), name=scale_name
+    )
+    new_inits[zp_name] = numpy_helper.from_array(
+        np.array(zp_f16, dtype=np.float16), name=zp_name
+    )
+    t_div = f"{prefix}_emu_div"
+    t_add = f"{prefix}_emu_add"
+    t_round = f"{prefix}_emu_round"
+    t_sub = f"{prefix}_emu_sub"
+    return [
+        helper.make_node("Div", [x, scale_name], [t_div], name=f"{prefix}_emu_div"),
+        helper.make_node("Add", [t_div, zp_name], [t_add], name=f"{prefix}_emu_add"),
+        helper.make_node("Round", [t_add], [t_round], name=f"{prefix}_emu_round"),
+        helper.make_node("Sub", [t_round, zp_name], [t_sub], name=f"{prefix}_emu_sub"),
+        helper.make_node("Mul", [t_sub, scale_name], [y], name=f"{prefix}_emu_mul_y"),
+    ]
+
+
+def _quantize_scale_zp(
+    scale_init: onnx.TensorProto,
+    zp_init: onnx.TensorProto,
+    *,
+    scale_name: str,
+    zp_name: str,
+) -> tuple[float, float, onnx.TensorProto, onnx.TensorProto]:
+    """Return scalar scale/zp and fp32 initializers for emulation."""
+    scale = float(np.asarray(numpy_helper.to_array(scale_init)).reshape(-1)[0])
+    zp = float(np.asarray(numpy_helper.to_array(zp_init)).reshape(-1)[0])
+    scale_t = numpy_helper.from_array(
+        np.array(scale, dtype=np.float32), name=scale_name
+    )
+    zp_t = numpy_helper.from_array(np.array(zp, dtype=np.float32), name=zp_name)
+    return (scale, zp, scale_t, zp_t)
+
+
+def _insert_qdq_emulation(
+    *,
+    x: str,
+    y: str,
+    scale_init: onnx.TensorProto,
+    zp_init: onnx.TensorProto,
+    prefix: str,
+    new_inits: dict[str, onnx.TensorProto],
+) -> list[onnx.NodeProto]:
+    """Match ORT QuantizeLinear+DequantizeLinear (fp32 math, fp16 activation output)."""
+    scale_name = f"{prefix}_emu_scale"
+    zp_name = f"{prefix}_emu_zp"
+    _, _, scale_t, zp_t = _quantize_scale_zp(
+        scale_init, zp_init, scale_name=scale_name, zp_name=zp_name
+    )
+    new_inits[scale_name] = scale_t
+    new_inits[zp_name] = zp_t
+    x_fp32 = f"{prefix}_emu_xf32"
+    t_div = f"{prefix}_emu_div"
+    t_add = f"{prefix}_emu_add"
+    t_round = f"{prefix}_emu_round"
+    t_sub = f"{prefix}_emu_sub"
+    return [
+        helper.make_node(
+            "Cast", [x], [x_fp32], name=f"{prefix}_emu_cast_in", to=FP32_q
+        ),
+        helper.make_node(
+            "Div", [x_fp32, scale_name], [t_div], name=f"{prefix}_emu_div"
+        ),
+        helper.make_node("Add", [t_div, zp_name], [t_add], name=f"{prefix}_emu_add"),
+        helper.make_node("Round", [t_add], [t_round], name=f"{prefix}_emu_round"),
+        helper.make_node("Sub", [t_round, zp_name], [t_sub], name=f"{prefix}_emu_sub"),
+        helper.make_node("Mul", [t_sub, scale_name], [y], name=f"{prefix}_emu_mul"),
+    ]
+
+
+def _rewire_tensor_uses(graph: onnx.GraphProto, old: str, new: str) -> None:
+    """Replace ``old`` tensor name with ``new`` on node inputs and graph outputs."""
+    for node in graph.node:
+        for idx, inp in enumerate(node.input):
+            if inp == old:
+                node.input[idx] = new
+    for out in graph.output:
+        if out.name == old:
+            out.name = new
+    for vi in graph.value_info:
+        if vi.name == old:
+            vi.name = new
+
+
+def strip_activation_qdq_q(
+    graph: onnx.GraphProto,
+    inits: dict[str, onnx.TensorProto],
+    new_inits: dict[str, onnx.TensorProto],
+    *,
+    pure_fp16: bool = True,
+    mode: str = "emu",
+) -> int:
+    """Remove activation Q/DQ pairs; bypass or emulate fake-quant without Q/DQ ops."""
+    init_names = set(inits)
+    dq_by_q_out = {
+        d.input[0]: d for d in graph.node if d.op_type == "DequantizeLinear" and d.input
+    }
+    remove_nodes: set[str] = set()
+    insert_nodes: list[onnx.NodeProto] = []
+    removed = 0
+    for q in graph.node:
+        if q.op_type != "QuantizeLinear" or not q.input or len(q.input) < 3:
+            continue
+        if q.input[0] in init_names:
+            continue
+        dq = dq_by_q_out.get(q.output[0])
+        if dq is None or not dq.output:
+            continue
+        scale_name, zp_name = (q.input[1], q.input[2])
+        if scale_name not in inits or zp_name not in inits:
+            continue
+        src = q.input[0]
+        dst = dq.output[0]
+        prefix = q.name.replace("/", "_").replace(".", "_")
+        if mode == "bypass":
+            if src != dst:
+                graph_outputs = {o.name for o in graph.output}
+                if dst in graph_outputs:
+                    insert_nodes.append(
+                        helper.make_node(
+                            "Identity", [src], [dst], name=f"{prefix}_qdq_bypass"
+                        )
+                    )
+                else:
+                    _rewire_tensor_uses(graph, dst, src)
+        elif pure_fp16:
+            insert_nodes.extend(
+                _insert_pure_fp16_qdq_emulation(
+                    x=src,
+                    y=dst,
+                    scale_init=inits[scale_name],
+                    zp_init=inits[zp_name],
+                    prefix=prefix,
+                    new_inits=new_inits,
+                )
+            )
+        else:
+            insert_nodes.extend(
+                _insert_qdq_emulation(
+                    x=src,
+                    y=dst,
+                    scale_init=inits[scale_name],
+                    zp_init=inits[zp_name],
+                    prefix=prefix,
+                    new_inits=new_inits,
+                )
+            )
+        remove_nodes.add(q.name)
+        remove_nodes.add(dq.name)
+        removed += 1
+    if insert_nodes:
+        graph.node.extend(insert_nodes)
+    if remove_nodes:
+        kept = [n for n in graph.node if n.name not in remove_nodes]
+        del graph.node[:]
+        graph.node.extend(kept)
+    return removed
+
+
+def _expand_scale_zp_q(
+    scale: np.ndarray, zp: np.ndarray, n: int
+) -> tuple[np.ndarray, np.ndarray]:
+    if scale.ndim == 0:
+        scale = np.full(n, float(scale), dtype=np.float32)
+    if zp.ndim == 0:
+        zp = np.full(n, int(zp), dtype=np.int8)
+    return (scale, zp)
+
+
+def fold_weight_dq_q(
+    graph: onnx.GraphProto,
+    inits: dict[str, onnx.TensorProto],
+    new_inits: dict[str, onnx.TensorProto],
+    remove_inits: set[str],
+    *,
+    weight_dtype: type = np.float16,
+) -> int:
+    """Fold weight/bias DQ into fp16/fp32 constants for Mul, Conv, and Add consumers."""
+    dq_by_out = {d.output[0]: d for d in graph.node if d.op_type == "DequantizeLinear"}
+    tensor_replace: dict[str, str] = {}
+    remove_dq: set[str] = set()
+    folded = 0
+    for node in graph.node:
+        input_indices = _WEIGHT_DQ_CONSUMER_INPUTS.get(node.op_type)
+        if input_indices is None:
+            continue
+        for idx in input_indices:
+            if idx >= len(node.input):
+                continue
+            dq = dq_by_out.get(node.input[idx])
+            if dq is None or dq.input[0] not in inits:
+                continue
+            w_name = dq.input[0]
+            w = numpy_helper.to_array(inits[w_name])
+            if w.dtype.name == "int4":
+                continue
+            scale = numpy_helper.to_array(inits[dq.input[1]])
+            zp = numpy_helper.to_array(inits[dq.input[2]])
+            const_name = f"{w_name}_fp{('32' if weight_dtype == np.float32 else '16')}"
+            new_inits[const_name] = numpy_helper.from_array(
+                dequantize_initializer_q(w, scale, zp, out_dtype=weight_dtype),
+                name=const_name,
+            )
+            tensor_replace[node.input[idx]] = const_name
+            remove_dq.add(dq.output[0])
+            remove_inits.update({w_name, dq.input[1], dq.input[2]})
+            folded += 1
+    if tensor_replace:
+        for node in graph.node:
+            for idx, inp in enumerate(node.input):
+                if inp in tensor_replace:
+                    node.input[idx] = tensor_replace[inp]
+        kept = [
+            n
+            for n in graph.node
+            if not (n.op_type == "DequantizeLinear" and n.output[0] in remove_dq)
+        ]
+        del graph.node[:]
+        graph.node.extend(kept)
+    return folded
+
+
+def fold_mul_weight_dq_q(
+    graph: onnx.GraphProto,
+    inits: dict[str, onnx.TensorProto],
+    new_inits: dict[str, onnx.TensorProto],
+    remove_inits: set[str],
+) -> int:
+    """Backward-compatible alias for norm-weight DQ folding (Mul only)."""
+    return fold_weight_dq_q(graph, inits, new_inits, remove_inits)
+
+
+def set_matmul_nbits_accuracy_level_q(
+    model: onnx.ModelProto, level: int | None = None
+) -> int:
+    """Force ``accuracy_level`` on every MatMulNBits node (incl. pre-existing ones).
+
+    The exported lm_head ships as MatMulNBits with ``accuracy_level=4`` (int8
+    activation), which degrades logits enough to pick wrong-but-adjacent tokens.
+    """
+    if level is None:
+        level = MATMUL_NBITS_ACCURACY_LEVEL_q
+    changed = 0
+    for node in model.graph.node:
+        if node.op_type != "MatMulNBits":
+            continue
+        attr = next((a for a in node.attribute if a.name == "accuracy_level"), None)
+        if attr is not None:
+            if attr.i != level:
+                attr.i = level
+                changed += 1
+        else:
+            node.attribute.extend([helper.make_attribute("accuracy_level", level)])
+            changed += 1
+    return changed
+
+
+def _promote_value_info_elem_type_q(vi: onnx.ValueInfoProto) -> None:
+    elem_type = vi.type.tensor_type.elem_type
+    if elem_type in (FP32_q, FP64_q):
+        vi.type.tensor_type.elem_type = FP16_q
+
+
+def _replace_node_inputs(
+    graph: onnx.GraphProto,
+    old: str,
+    new: str,
+    *,
+    skip_node_names: set[str] | None = None,
+) -> int:
+    skip = skip_node_names or set()
+    replaced = 0
+    for node in graph.node:
+        if node.name in skip:
+            continue
+        for idx, inp in enumerate(node.input):
+            if inp == old:
+                node.input[idx] = new
+                replaced += 1
+    return replaced
+
+
+def wrap_fp16_io_fp32_activations(model: onnx.ModelProto) -> dict[str, int]:
+    """Expose fp16 graph I/O while keeping the decoder body in fp32 (ORT QDQ parity)."""
+    graph = model.graph
+    stats = {"input_cast": 0, "output_cast": 0}
+    hidden_in = "input_hidden_states"
+    if any((vi.name == hidden_in for vi in graph.input)):
+        fp32_in = "input_hidden_states_compute_fp32"
+        cast_in_name = "input_hidden_states_cast_fp32"
+        for vi in graph.input:
+            if vi.name == hidden_in:
+                vi.type.tensor_type.elem_type = FP16_q
+        graph.node.insert(
+            0,
+            helper.make_node(
+                "Cast", [hidden_in], [fp32_in], name=cast_in_name, to=FP32_q
+            ),
+        )
+        stats["input_cast"] = _replace_node_inputs(
+            graph, hidden_in, fp32_in, skip_node_names={cast_in_name}
+        )
+    hidden_out = "output_hidden_states"
+    producer: dict[str, onnx.NodeProto] = {}
+    for node in graph.node:
+        for out in node.output:
+            if out:
+                producer[out] = node
+    prod = producer.get(hidden_out)
+    if prod is not None and prod.output and (prod.output[0] == hidden_out):
+        fp32_buf = "output_hidden_states_compute_fp32"
+        prod.output[0] = fp32_buf
+        graph.node.append(
+            helper.make_node(
+                "Cast",
+                [fp32_buf],
+                [hidden_out],
+                name="output_hidden_states_cast_fp16",
+                to=FP16_q,
+            )
+        )
+        stats["output_cast"] = 1
+        for vi in graph.output:
+            if vi.name == hidden_out:
+                vi.type.tensor_type.elem_type = FP16_q
+    return stats
+
+
+def promote_model_to_fp16_q(
+    model: onnx.ModelProto,
+    *,
+    skip_initializer_substrings: tuple[str, ...] = ("_emu_scale", "_emu_zp"),
+) -> None:
+    """Promote float32/float64 graph I/O and float initializers to float16."""
+    graph = model.graph
+    for vi in list(graph.input) + list(graph.output):
+        _promote_value_info_elem_type_q(vi)
+    for init in graph.initializer:
+        if any((part in init.name for part in skip_initializer_substrings)):
+            continue
+        if init.data_type == FP32_q:
+            arr = numpy_helper.to_array(init).astype(np.float16)
+            init.CopyFrom(numpy_helper.from_array(arr, name=init.name))
+        elif init.data_type == FP64_q:
+            arr = numpy_helper.to_array(init).astype(np.float16)
+            init.CopyFrom(numpy_helper.from_array(arr, name=init.name))
+    del graph.value_info[:]
+
+
+def stabilize_lpnorm_fp16_q(model: onnx.ModelProto) -> int:
+    """Force every LpNormalization to compute in fp32 via Cast wrappers.
+
+    The DirectML EP computes LpNormalization's internal sum-of-squares in the
+    tensor dtype (fp16); for large activations this overflows fp16 (>65504),
+    yielding a wrong norm that amplifies layer-over-layer into NaNs (the CPU EP
+    accumulates in fp32 and is unaffected). Wrapping each node with
+    ``Cast(fp32) -> LpNormalization -> Cast(fp16)`` makes both EPs agree.
+    """
+    graph = model.graph
+    if not any((n.op_type == "LpNormalization" for n in graph.node)):
+        return 0
+    new_nodes: list[onnx.NodeProto] = []
+    count = 0
+    for node in graph.node:
+        if node.op_type != "LpNormalization":
+            new_nodes.append(node)
+            continue
+        src = node.input[0]
+        dst = node.output[0]
+        pre = f"{node.name}_xf32"
+        post = f"{node.name}_yf32"
+        node.input[0] = pre
+        node.output[0] = post
+        new_nodes.append(
+            helper.make_node(
+                "Cast", [src], [pre], name=f"{node.name}_cast_in", to=FP32_q
+            )
+        )
+        new_nodes.append(node)
+        new_nodes.append(
+            helper.make_node(
+                "Cast", [post], [dst], name=f"{node.name}_cast_out", to=FP16_q
+            )
+        )
+        count += 1
+    del graph.node[:]
+    graph.node.extend(new_nodes)
+    return count
+
+
+def apply_new_initializers_q(
+    graph: onnx.GraphProto, new_inits: dict[str, onnx.TensorProto]
+) -> None:
+    existing = {i.name: idx for idx, i in enumerate(graph.initializer)}
+    for name, tensor in new_inits.items():
+        if name in existing:
+            graph.initializer[existing[name]] = tensor
+        else:
+            graph.initializer.append(tensor)
+
+
+def prune_initializers_q(graph: onnx.GraphProto, remove_inits: set[str]) -> None:
+    used = _referenced_initializer_names_q(graph)
+    kept = [
+        i for i in graph.initializer if i.name in used and i.name not in remove_inits
+    ]
+    del graph.initializer[:]
+    graph.initializer.extend(kept)
+
+
+def rewrite_gqa_past_seq_len_to_seqlens_k_q(model: onnx.ModelProto) -> int:
+    """Convert GQA input #5 from literal ``past_seq_len`` to ORT ``seqlens_k``.
+
+    BUNDLE / runtime pass the count of tokens already in the KV cache on graph input
+    ``past_seq_len``.  ORT GroupQueryAttention expects
+    ``seqlens_k = past_len + seq_q - 1``.  Insert a small subgraph once and
+    rewire every GQA node::
+
+        seqlens_k = Reshape(past_seq_len, [1]) + Shape(query)[1] - 1
+    """
+    graph = model.graph
+    gqa_nodes = [n for n in graph.node if n.op_type == "GroupQueryAttention"]
+    if not gqa_nodes:
+        return 0
+    past_input = "past_seq_len"
+    if not any((i.name == past_input for i in graph.input)):
+        return 0
+    if any((n.op_type == "Sub" and n.name == "gqa_seqlens_k_sub" for n in graph.node)):
+        return 0
+    if not all((len(n.input) > 5 and n.input[5] == past_input for n in gqa_nodes)):
+        return 0
+    query = gqa_nodes[0].input[0]
+    one_name = "gqa_seqlens_k_const_one"
+    past_reshape_shape = "gqa_past_reshape_shape"
+    graph.initializer.extend(
+        [
+            numpy_helper.from_array(np.array([1], dtype=np.int32), name=one_name),
+            numpy_helper.from_array(
+                np.array([1], dtype=np.int64), name=past_reshape_shape
+            ),
+            numpy_helper.from_array(
+                np.array(1, dtype=np.int64), name="gqa_gather_sq_idx"
+            ),
+        ]
+    )
+    new_nodes = [
+        helper.make_node("Shape", [query], ["gqa_query_shape"], name="gqa_query_shape"),
+        helper.make_node(
+            "Gather",
+            ["gqa_query_shape", "gqa_gather_sq_idx"],
+            ["gqa_sq_i64"],
+            name="gqa_gather_sq",
+            axis=0,
+        ),
+        helper.make_node(
+            "Cast",
+            ["gqa_sq_i64"],
+            ["gqa_sq_i32"],
+            name="gqa_cast_sq",
+            to=TensorProto.INT32,
+        ),
+        helper.make_node(
+            "Reshape",
+            [past_input, past_reshape_shape],
+            ["gqa_past_1d"],
+            name="gqa_past_reshape",
+        ),
+        helper.make_node(
+            "Add",
+            ["gqa_past_1d", "gqa_sq_i32"],
+            ["gqa_past_plus_sq"],
+            name="gqa_past_plus_sq",
+        ),
+        helper.make_node(
+            "Sub",
+            ["gqa_past_plus_sq", one_name],
+            ["gqa_seqlens_k"],
+            name="gqa_seqlens_k_sub",
+        ),
+    ]
+    insert_at = min(
+        (i for i, n in enumerate(graph.node) if n.op_type == "GroupQueryAttention")
+    )
+    for offset, node in enumerate(new_nodes):
+        graph.node.insert(insert_at + offset, node)
+    for node in gqa_nodes:
+        node.input[5] = "gqa_seqlens_k"
+    return len(gqa_nodes)
+
+
+def _external_data_location_q(init: onnx.TensorProto) -> str | None:
+    if init.data_location != TensorProto.EXTERNAL:
+        return None
+    for kv in init.external_data:
+        if kv.key == "location":
+            return kv.value
+    return None
+
+
+def save_model_with_external_data_q(
+    model: onnx.ModelProto,
+    dst: Path,
+    *,
+    rewrite_head_data: bool,
+    head_data_dir: Path | None = None,
+) -> None:
+    """Save emb/lm_head; rewrite external head blobs when present."""
+    from onnx.external_data_helper import set_external_data
+
+    if not model.graph.name:
+        model.graph.name = f"{dst.stem}_graph"
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    if dst.exists():
+        dst.unlink()
+    data_dir = head_data_dir or dst.parent
+    touched_locations: set[str] = set()
+    for init in model.graph.initializer:
+        location = _external_data_location_q(init)
+        if location is None:
+            continue
+        arr = numpy_helper.to_array(init)
+        out_path = data_dir / location
+        if rewrite_head_data or location not in touched_locations:
+            if rewrite_head_data and out_path.exists():
+                out_path.unlink()
+            if rewrite_head_data or not out_path.exists():
+                out_path.parent.mkdir(parents=True, exist_ok=True)
+                out_path.write_bytes(arr.tobytes())
+            touched_locations.add(location)
+        fresh = numpy_helper.from_array(arr, init.name)
+        set_external_data(fresh, location=location, offset=0, length=arr.nbytes)
+        init.CopyFrom(fresh)
+    onnx.save(model, str(dst))
+
+
+def patch_emb_model_q(
+    src: Path,
+    dst: Path,
+    *,
+    shape_fix: ShapeFixConfig_q,
+    rewrite_head_data: bool,
+    head_data_dir: Path | None = None,
+    profile: ConvertProfile = CONVERT_PROFILE_FULL,
+) -> None:
+    model = onnx.load(str(src), load_external_data=True)
+    if profile.emb_bits4:
+        for node in model.graph.node:
+            if node.op_type != "GatherBlockQuantized":
+                continue
+            if not any((a.name == "bits" for a in node.attribute)):
+                node.attribute.extend([helper.make_attribute("bits", 4)])
+    if profile.fp16 or profile.fp32_activations:
+        promote_model_to_fp16_q(model)
+    if profile.lpnorm_fp32:
+        stabilize_lpnorm_fp16_q(model)
+    maybe_fix_static_shapes_q(model, shape_fix)
+    save_model_with_external_data_q(
+        model, dst, rewrite_head_data=rewrite_head_data, head_data_dir=head_data_dir
+    )
+
+
+def convert_lm_head_model_q(
+    src: Path,
+    dst: Path,
+    *,
+    shape_fix: ShapeFixConfig_q,
+    rewrite_head_data: bool,
+    head_data_dir: Path | None = None,
+    gather_unsqueeze: bool = False,
+    profile: ConvertProfile = CONVERT_PROFILE_FULL,
+) -> None:
+    model = onnx.load(str(src), load_external_data=True)
+    if profile.fp16 or profile.fp32_activations:
+        promote_model_to_fp16_q(model)
+    if profile.matmul_nbits_accuracy:
+        set_matmul_nbits_accuracy_level_q(model)
+    if profile.lpnorm_fp32:
+        stabilize_lpnorm_fp16_q(model)
+    maybe_fix_static_shapes_q(model, shape_fix)
+    if gather_unsqueeze and profile.lm_head_gather:
+        model = rewrite_lm_head_gather_unsqueeze(model)
+    save_model_with_external_data_q(
+        model, dst, rewrite_head_data=rewrite_head_data, head_data_dir=head_data_dir
+    )
+
+
+def assert_pure_fp16_activations(model: onnx.ModelProto, *, context: str = "") -> None:
+    """Fail if any Cast->fp32 nodes remain (hard fp16 activation requirement)."""
+    fp32_casts = sum(
+        (
+            1
+            for n in model.graph.node
+            if n.op_type == "Cast"
+            and any((a.name == "to" and a.i == FP32_q for a in n.attribute))
+        )
+    )
+    if fp32_casts:
+        prefix = f"{context}: " if context else ""
+        raise RuntimeError(
+            f"{prefix}graph has {fp32_casts} Cast->fp32 node(s); pure fp16 activations required"
+        )
+
+
+def assert_qdq_removed(graph: onnx.GraphProto, *, context: str = "") -> None:
+    """Fail fast if any QuantizeLinear / DequantizeLinear nodes remain."""
+    q = sum((1 for n in graph.node if n.op_type == "QuantizeLinear"))
+    dq = sum((1 for n in graph.node if n.op_type == "DequantizeLinear"))
+    if q or dq:
+        prefix = f"{context}: " if context else ""
+        raise RuntimeError(
+            f"{prefix}QDQ not fully removed (QuantizeLinear={q}, DequantizeLinear={dq})"
+        )
+
+
+def prepare_gqa_fp16_no_quant(model: onnx.ModelProto) -> int:
+    """runtime GQA: fp16 KV cache, no quantization, no scale inputs.
+
+    - ``past_*`` / ``present_*`` KV graph I/O: int8 -> float16
+    - ``k_quant_type`` / ``v_quant_type``: ``NONE``
+    - ``kv_cache_bit_width``: keep 8 (``hip.gqa`` requires 4 or 8; do not set 0)
+    - Drop optional ``k_scale`` / ``v_scale`` inputs (truncate to 12) and remove
+      scale initializers (runtime errors on any non-null scale pointer).
+    """
+    graph = model.graph
+    remove_scales: set[str] = set()
+    changed = 0
+    for node in graph.node:
+        if node.op_type != "GroupQueryAttention":
+            continue
+        if len(node.input) > 12:
+            for idx in range(12, len(node.input)):
+                if node.input[idx]:
+                    remove_scales.add(node.input[idx])
+            del node.input[12:]
+        has_k_quant = has_v_quant = has_bit_width = False
+        bit_width = 8
+        for attr in node.attribute:
+            if attr.name == "kv_cache_bit_width" and attr.i in (4, 8):
+                bit_width = attr.i
+            elif attr.name == "k_quant_type":
+                attr.s = b"NONE"
+                has_k_quant = True
+            elif attr.name == "v_quant_type":
+                attr.s = b"NONE"
+                has_v_quant = True
+            elif attr.name == "kv_cache_bit_width":
+                has_bit_width = True
+        if not has_k_quant:
+            node.attribute.extend([helper.make_attribute("k_quant_type", "NONE")])
+        if not has_v_quant:
+            node.attribute.extend([helper.make_attribute("v_quant_type", "NONE")])
+        for attr in node.attribute:
+            if attr.name == "kv_cache_bit_width":
+                attr.i = bit_width
+                has_bit_width = True
+                break
+        if not has_bit_width:
+            node.attribute.extend(
+                [helper.make_attribute("kv_cache_bit_width", bit_width)]
+            )
+        changed += 1
+    kv_names = ("past_keys_", "past_values_", "present_keys_", "present_values_")
+    for vi in list(graph.input) + list(graph.output):
+        if not any((part in vi.name for part in kv_names)):
+            continue
+        if vi.type.tensor_type.elem_type == TensorProto.INT8:
+            vi.type.tensor_type.elem_type = FP16_q
+    if remove_scales:
+        kept = [i for i in graph.initializer if i.name not in remove_scales]
+        del graph.initializer[:]
+        graph.initializer.extend(kept)
+    return changed
+
+
+def _inline_initializer_names(model: onnx.ModelProto) -> set[str]:
+    return {
+        i.name
+        for i in model.graph.initializer
+        if i.data_location != TensorProto.EXTERNAL
+    }
+
+
+def _reembed_initializers(graph: onnx.GraphProto, names: set[str]) -> None:
+    """Force listed initializers back into the ONNX protobuf (not external data)."""
+    for init in graph.initializer:
+        if init.name not in names:
+            continue
+        arr = numpy_helper.to_array(init)
+        init.CopyFrom(numpy_helper.from_array(arr, name=init.name))
+
+
+def save_decoder_model_q(
+    model: onnx.ModelProto,
+    dst: Path,
+    *,
+    external_data_name: str = DECODER_EXT_DATA,
+    keep_inline: set[str] | None = None,
+) -> None:
+    if not model.graph.name:
+        model.graph.name = f"{dst.stem}_graph"
+    if keep_inline:
+        _reembed_initializers(model.graph, keep_inline)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    data_path = dst.parent / external_data_name
+    if dst.exists():
+        dst.unlink()
+    if data_path.exists():
+        data_path.unlink()
+    onnx.save_model(
+        model,
+        str(dst),
+        save_as_external_data=True,
+        all_tensors_to_one_file=True,
+        location=external_data_name,
+        size_threshold=65536,
+    )
+
+
+def infer_decoder_external_data_name_q(src: Path, bundle_root: Path) -> str:
+    model = onnx.load(str(src), load_external_data=False)
+    locations = {
+        loc
+        for init in model.graph.initializer
+        if (loc := _external_data_location_q(init)) is not None
+    }
+    if len(locations) == 1:
+        return locations.pop()
+    data_files = sorted(bundle_root.glob("*.data"))
+    if data_files:
+        return data_files[0].name
+    return DECODER_EXT_DATA
+
+
+DEFAULT_EMB_SEQ_LENS = (1, 512)
+DEFAULT_LM_HEAD_SEQ_LENS = (1, 512)
+DECODER_PREFILL_NAME = "SPLIT_0.onnx"
+DECODER_DECODE_NAME = "SPLIT_1.onnx"
+EMB_SRC_NAME = "embeddings_quant.quant.onnx"
+LM_HEAD_SRC_NAME = "lm_head_quant_w4a32.quant.onnx"
+INT4_q = TensorProto.INT4
+DECODER_EXTERNAL_DATA_q = DECODER_EXT_DATA
+DEFAULT_RUNTIME_EP = True
+MERGED_PIPELINE_DECODER_STEM = "decoder_lowbit"
+MERGED_PIPELINE_STEM = "decoder_lowbit_merged"
+MERGED_PIPELINE_OUTPUT_NAME = f"{MERGED_PIPELINE_STEM}.onnx"
+MERGED_PIPELINE_EXTERNAL_DATA = f"{MERGED_PIPELINE_STEM}.data"
+_PIPELINE_PREFIXES_q = ("emb_", "dec_", "head_")
+
+
+def _conv_kernel_shape_q(conv: onnx.NodeProto) -> list[int] | None:
+    for attr in conv.attribute:
+        if attr.name == "kernel_shape":
+            return list(attr.ints)
+    return None
+
+
+def _find_transpose_by_output_q(
+    graph: onnx.GraphProto, tensor: str
+) -> onnx.NodeProto | None:
+    return next(
+        (n for n in graph.node if n.op_type == "Transpose" and n.output[0] == tensor),
+        None,
+    )
+
+
+def _find_transpose_by_input_q(
+    graph: onnx.GraphProto, tensor: str
+) -> onnx.NodeProto | None:
+    return next(
+        (n for n in graph.node if n.op_type == "Transpose" and n.input[0] == tensor),
+        None,
+    )
+
+
+def fuse_conv_transpose_to_matmul_nbits_q(
+    graph: onnx.GraphProto,
+    inits: dict[str, onnx.TensorProto],
+    new_inits: dict[str, onnx.TensorProto],
+    remove_inits: set[str],
+) -> int:
+    """Replace Transpose -> Conv(int4/int8 DQ weight) -> Transpose with MatMulNBits."""
+    dq_by_out = {d.output[0]: d for d in graph.node if d.op_type == "DequantizeLinear"}
+    replacements: dict[str, list[onnx.NodeProto]] = {}
+    remove_nodes: set[str] = set()
+    converted = 0
+    for conv in graph.node:
+        if conv.op_type != "Conv" or len(conv.input) < 2:
+            continue
+        if _conv_kernel_shape_q(conv) != [1, 1]:
+            continue
+        w_dq = dq_by_out.get(conv.input[1])
+        if w_dq is None or w_dq.input[0] not in inits:
+            continue
+        w_init = inits[w_dq.input[0]]
+        if w_init.data_type == INT4_q:
+            weight_bits = 4
+        elif w_init.data_type == TensorProto.INT8:
+            weight_bits = 8
+        else:
+            continue
+        t0 = _find_transpose_by_output_q(graph, conv.input[0])
+        t1 = _find_transpose_by_input_q(graph, conv.output[0])
+        if t0 is None or t1 is None:
+            continue
+        block_input = t0.input[0]
+        block_output = t1.output[0]
+        w = numpy_helper.to_array(w_init)
+        if w.ndim != 4 or w.shape[2:] != (1, 1):
+            raise ValueError(
+                f"Expected 1x1 Conv weight [N,K,1,1], got {w.shape} for {w_init.name}"
+            )
+        n_out, k_in = (int(w.shape[0]), int(w.shape[1]))
+        w_kn = w[:, :, 0, 0].T
+        scale, zp = _expand_scale_zp_q(
+            numpy_helper.to_array(inits[w_dq.input[1]]),
+            numpy_helper.to_array(inits[w_dq.input[2]]),
+            n_out,
+        )
+        block_size = choose_block_size_q(k_in)
+        if weight_bits == 4:
+            packed, k, n, n_blocks = pack_matmul_nbits_weight_q(w_kn, block_size)
+        else:
+            packed, k, n, n_blocks = pack_matmul_nbits_weight_int8(w_kn, block_size)
+        base = w_init.name.removesuffix("_quantized")
+        q_name = f"{base}_mnbits_q{weight_bits}"
+        s_name = f"{base}_mnbits_scales"
+        z_name = f"{base}_mnbits_zp"
+        pre_shape_name = f"{base}_mnbits_pre_shape"
+        post_shape_name = f"{base}_mnbits_post_shape"
+        new_inits[q_name] = numpy_helper.from_array(packed, name=q_name)
+        new_inits[s_name] = numpy_helper.from_array(
+            np.repeat(scale.astype(np.float16).reshape(n, 1), n_blocks, axis=1),
+            name=s_name,
+        )
+        if weight_bits == 4:
+            new_inits[z_name] = numpy_helper.from_array(
+                pack_zero_points_q(zp, n, n_blocks), name=z_name
+            )
+        else:
+            new_inits[z_name] = numpy_helper.from_array(
+                _int8_mnbits_zero_points(n, n_blocks), name=z_name
+            )
+        new_inits[pre_shape_name] = numpy_helper.from_array(
+            np.array([-1, k], dtype=np.int64), name=pre_shape_name
+        )
+        new_inits[post_shape_name] = numpy_helper.from_array(
+            np.array([1, 1, -1, n], dtype=np.int64), name=post_shape_name
+        )
+        mm_in = f"{conv.name}_mnbits_in"
+        mm_out = f"{conv.name}_mnbits_out"
+        replacements[conv.name] = [
+            helper.make_node(
+                "Reshape",
+                [block_input, pre_shape_name],
+                [mm_in],
+                name=f"{conv.name}_mnbits_reshape_in",
+            ),
+            helper.make_node(
+                "MatMulNBits",
+                [mm_in, q_name, s_name, z_name],
+                [mm_out],
+                name=f"{conv.name}_mnbits",
+                domain="com.microsoft",
+                K=k,
+                N=n,
+                bits=weight_bits,
+                block_size=block_size,
+                accuracy_level=MATMUL_NBITS_ACCURACY_LEVEL_q,
+            ),
+            helper.make_node(
+                "Reshape",
+                [mm_out, post_shape_name],
+                [block_output],
+                name=f"{conv.name}_mnbits_reshape_out",
+            ),
+        ]
+        remove_nodes.update({t0.name, conv.name, t1.name, w_dq.name})
+        remove_inits.update({w_init.name, w_dq.input[1], w_dq.input[2]})
+        converted += 1
+    if converted:
+        kept: list[onnx.NodeProto] = []
+        for node in graph.node:
+            if node.name in replacements:
+                kept.extend(replacements[node.name])
+            elif node.name not in remove_nodes:
+                kept.append(node)
+        del graph.node[:]
+        graph.node.extend(kept)
+    return converted
+
+
+def convert_decoder_model_q(
+    src: Path,
+    dst: Path,
+    *,
+    shape_fix: ShapeFixConfig_q,
+    bundle_root: Path,
+    external_data_name: str | None = None,
+    runtime_ep: bool = DEFAULT_RUNTIME_EP,
+    profile: ConvertProfile = CONVERT_PROFILE_FULL,
+) -> dict[str, int]:
+    model = onnx.load(str(src), load_external_data=True)
+    inline_at_load = _inline_initializer_names(model)
+    graph = model.graph
+    inits = {i.name: i for i in graph.initializer}
+    new_inits: dict[str, onnx.TensorProto] = {}
+    remove_inits: set[str] = set()
+    stats: dict[str, int] = {}
+    stats["unwrap_castfp32"] = unwrap_castfp32_before_quantize(graph)
+    stats["strip_qdq"] = (
+        strip_activation_qdq_q(
+            graph,
+            inits,
+            new_inits,
+            pure_fp16=profile.fp16 and (not profile.fp32_activations),
+            mode=profile.activation_qdq_mode,
+        )
+        if profile.strip_qdq
+        else 0
+    )
+    stats["conv_mnbits"] = (
+        fuse_conv_transpose_to_matmul_nbits_q(graph, inits, new_inits, remove_inits)
+        if profile.conv_mnbits
+        else 0
+    )
+    stats["weight_dq_fold"] = (
+        fold_weight_dq_q(
+            graph,
+            inits,
+            new_inits,
+            remove_inits,
+            weight_dtype=np.float32 if profile.fp32_activations else np.float16,
+        )
+        if profile.weight_dq_fold
+        else 0
+    )
+    if new_inits or remove_inits:
+        apply_new_initializers_q(graph, new_inits)
+        prune_initializers_q(graph, remove_inits)
+    if profile.fp32_activations:
+        io_stats = wrap_fp16_io_fp32_activations(model)
+        stats["fp32_io_input_cast"] = io_stats["input_cast"]
+        stats["fp32_io_output_cast"] = io_stats["output_cast"]
+        stats["gqa_pre_cast_fp32_removed"] = 0
+        stats["mnbits_fp16_casts_folded"] = 0
+        stats["fp32_casts_remaining"] = sum(
+            (
+                1
+                for n in model.graph.node
+                if n.op_type == "Cast"
+                and any((a.name == "to" and a.i == FP32_q for a in n.attribute))
+            )
+        )
+    elif profile.fp16:
+        promote_model_to_fp16_q(model)
+        fp16_stats = optimize_fp16_activations(
+            model,
+            remove_gqa_fp32_casts=profile.gqa_pre_cast_fp32_remove,
+            rewrite_gqa_cast_fp32_to_fp16=not profile.gqa_pre_cast_fp32_remove,
+        )
+        stats["gqa_pre_cast_fp32_removed"] = fp16_stats["gqa_getitem_fp32_removed"]
+        stats["gqa_cast_fp32_to_fp16"] = fp16_stats["gqa_cast_fp32_to_fp16"]
+        stats["mnbits_fp16_casts_folded"] = fp16_stats["mnbits_fp16_casts_folded"]
+        stats["fp32_casts_remaining"] = fp16_stats["fp32_casts_remaining"]
+        if not profile.fp32_activations:
+            assert_pure_fp16_activations(model, context=dst.name)
+    if profile.matmul_nbits_accuracy:
+        set_matmul_nbits_accuracy_level_q(model)
+    if profile.gqa_fp16_no_quant and runtime_ep:
+        stats["lpnorm_fp32"] = 0
+        stats["gqa_fp16_no_quant"] = prepare_gqa_fp16_no_quant(model)
+    elif profile.lpnorm_fp32 and (not runtime_ep):
+        stats["lpnorm_fp32"] = stabilize_lpnorm_fp16_q(model)
+        stats["gqa_fp16_no_quant"] = 0
+    else:
+        stats["lpnorm_fp32"] = 0
+        stats["gqa_fp16_no_quant"] = 0
+    maybe_fix_static_shapes_q(model, shape_fix)
+    stats["gqa_seqlens_rewrite"] = (
+        rewrite_gqa_past_seq_len_to_seqlens_k_q(model)
+        if profile.gqa_seqlens_rewrite
+        else 0
+    )
+    if profile.strip_qdq:
+        assert_qdq_removed(graph, context=dst.name)
+    ext_name = external_data_name or infer_decoder_external_data_name_q(
+        src, bundle_root
+    )
+    save_decoder_model_q(
+        model,
+        dst,
+        external_data_name=ext_name or DECODER_EXTERNAL_DATA_q,
+        keep_inline=inline_at_load,
+    )
+    return stats
+
+
+def _emb_shape_fix_q(shape_fix: ShapeFixConfig_q, seq_len: int) -> ShapeFixConfig_q:
+    if not shape_fix.enabled:
+        return shape_fix
+    return ShapeFixConfig_q(
+        enabled=True,
+        batch=shape_fix.batch,
+        seq_len=seq_len,
+        max_seq_len=shape_fix.max_seq_len,
+    )
+
+
+def process_one_onnx_q(
+    src: Path,
+    dst: Path,
+    *,
+    kind: str,
+    shape_fix: ShapeFixConfig_q,
+    bundle_root: Path,
+    head_data_dir: Path,
+    rewrite_head_data: bool,
+    runtime_ep: bool = DEFAULT_RUNTIME_EP,
+    gather_unsqueeze: bool = False,
+    profile: ConvertProfile = CONVERT_PROFILE_FULL,
+) -> dict[str, int] | None:
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    if kind == "emb":
+        patch_emb_model_q(
+            src,
+            dst,
+            shape_fix=shape_fix,
+            rewrite_head_data=rewrite_head_data,
+            head_data_dir=head_data_dir,
+            profile=profile,
+        )
+        return None
+    if kind == "lm_head":
+        convert_lm_head_model_q(
+            src,
+            dst,
+            shape_fix=shape_fix,
+            rewrite_head_data=rewrite_head_data,
+            head_data_dir=head_data_dir,
+            gather_unsqueeze=gather_unsqueeze,
+            profile=profile,
+        )
+        return None
+    return convert_decoder_model_q(
+        src,
+        dst,
+        shape_fix=shape_fix,
+        bundle_root=bundle_root,
+        runtime_ep=runtime_ep,
+        profile=profile,
+    )
+
+
+def _align_model_ir_version_q(model: onnx.ModelProto, ir_version: int) -> None:
+    model.ir_version = ir_version
+
+
+def _topological_sort_graph_q(graph: onnx.GraphProto) -> None:
+    """Reorder ``graph.node`` so producers appear before consumers."""
+    nodes = list(graph.node)
+    if not nodes:
+        return
+    node_by_name = {n.name: n for n in nodes}
+    producers: dict[str, str] = {}
+    for node in nodes:
+        for out in node.output:
+            if out:
+                producers[out] = node.name
+    init_names = {init.name for init in graph.initializer}
+    input_names = {inp.name for inp in graph.input}
+    deps: dict[str, set[str]] = {}
+    for node in nodes:
+        dep: set[str] = set()
+        for inp in node.input:
+            if not inp or inp in input_names or inp in init_names:
+                continue
+            prod = producers.get(inp)
+            if prod and prod != node.name:
+                dep.add(prod)
+        deps[node.name] = dep
+    in_degree = {node.name: len(deps[node.name]) for node in nodes}
+    children: dict[str, set[str]] = {node.name: set() for node in nodes}
+    for node in nodes:
+        for dep in deps[node.name]:
+            children[dep].add(node.name)
+    queue = deque((node for node in nodes if in_degree[node.name] == 0))
+    sorted_nodes: list[onnx.NodeProto] = []
+    while queue:
+        node = queue.popleft()
+        sorted_nodes.append(node)
+        for child_name in children[node.name]:
+            in_degree[child_name] -= 1
+            if in_degree[child_name] == 0:
+                sorted_nodes.append(node_by_name[child_name])
+    if len(sorted_nodes) != len(nodes):
+        seen = {node.name for node in sorted_nodes}
+        sorted_nodes.extend((node for node in nodes if node.name not in seen))
+    del graph.node[:]
+    graph.node.extend(sorted_nodes)
+
+
+def _rename_tensors_in_graph_q(graph: onnx.GraphProto, mapping: dict[str, str]) -> None:
+    if not mapping:
+        return
+    for node in graph.node:
+        for idx, name in enumerate(node.input):
+            if name in mapping:
+                node.input[idx] = mapping[name]
+        for idx, name in enumerate(node.output):
+            if name in mapping:
+                node.output[idx] = mapping[name]
+    for vi in list(graph.input) + list(graph.output) + list(graph.value_info):
+        if vi.name in mapping:
+            vi.name = mapping[vi.name]
+    for init in graph.initializer:
+        if init.name in mapping:
+            init.name = mapping[init.name]
+
+
+def _pipeline_boundary_renames_q(graph: onnx.GraphProto) -> dict[str, str]:
+    """Map prefixed merge tensors back to the split-pipeline I/O names."""
+    mapping: dict[str, str] = {
+        "emb_input_ids": "input_ids",
+        "dec_past_seq_len": "past_seq_len",
+        "dec_total_seq_len": "total_seq_len",
+        "head_logits": "logits",
+    }
+    for vi in graph.input:
+        if vi.name.startswith("dec_past_keys_"):
+            mapping[vi.name] = vi.name.removeprefix("dec_")
+        elif vi.name.startswith("dec_past_values_"):
+            mapping[vi.name] = vi.name.removeprefix("dec_")
+    for vi in graph.output:
+        if vi.name.startswith("dec_present_keys_"):
+            mapping[vi.name] = vi.name.removeprefix("dec_")
+        elif vi.name.startswith("dec_present_values_"):
+            mapping[vi.name] = vi.name.removeprefix("dec_")
+    return mapping
+
+
+def merge_quantized_pipeline_models(
+    emb_path: Path,
+    decoder_path: Path,
+    head_path: Path,
+    dst_path: Path,
+    *,
+    external_data_name: str = MERGED_PIPELINE_EXTERNAL_DATA,
+    gather_unsqueeze: bool = True,
+) -> Path:
+    """Fuse emb -> decoder -> lm_head into one ONNX (dynamic ``seq_len``)."""
+    emb = onnx.load(str(emb_path), load_external_data=True)
+    decoder = onnx.load(str(decoder_path), load_external_data=True)
+    head = onnx.load(str(head_path), load_external_data=True)
+    if gather_unsqueeze:
+        head = rewrite_lm_head_gather_unsqueeze(head)
+    target_ir = max(emb.ir_version, decoder.ir_version, head.ir_version)
+    _align_model_ir_version_q(emb, target_ir)
+    _align_model_ir_version_q(head, target_ir)
+    emb_p = add_prefix(emb, prefix=_PIPELINE_PREFIXES_q[0])
+    dec_p = add_prefix(decoder, prefix=_PIPELINE_PREFIXES_q[1])
+    head_p = add_prefix(head, prefix=_PIPELINE_PREFIXES_q[2])
+    graph = merge_graphs(
+        emb_p.graph,
+        dec_p.graph,
+        [("emb_input_hidden_states", "dec_input_hidden_states")],
+    )
+    kv_outputs = [out.name for out in graph.output if "present_" in out.name]
+    graph = merge_graphs(
+        graph,
+        head_p.graph,
+        [("dec_output_hidden_states", "head_output_hidden_states")],
+        outputs=["head_logits", *kv_outputs],
+    )
+    _topological_sort_graph_q(graph)
+    _rename_tensors_in_graph_q(graph, _pipeline_boundary_renames_q(graph))
+    logits_out = next((vi for vi in graph.output if vi.name == "logits"), None)
+    if logits_out is not None:
+        other_outs = [vi for vi in graph.output if vi.name != "logits"]
+        del graph.output[:]
+        graph.output.extend([logits_out, *other_outs])
+    model = helper.make_model(graph, opset_imports=decoder.opset_import)
+    model.ir_version = target_ir
+    model.graph.name = f"{dst_path.stem}_graph"
+    dst_path.parent.mkdir(parents=True, exist_ok=True)
+    data_path = dst_path.parent / external_data_name
+    if dst_path.exists():
+        dst_path.unlink()
+    if data_path.exists():
+        data_path.unlink()
+    onnx.save_model(
+        model,
+        str(dst_path),
+        save_as_external_data=True,
+        all_tensors_to_one_file=True,
+        location=external_data_name,
+        size_threshold=65536,
+    )
+    return dst_path

--- a/tools/onnx-merged-convert/merged_convert/step1_qdq_fp16.py
+++ b/tools/onnx-merged-convert/merged_convert/step1_qdq_fp16.py
@@ -1,0 +1,1261 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import onnx
+from onnx import TensorProto, helper, numpy_helper
+
+from .step2_fp16_cleanup import optimize_fp16_activations
+from .step3_lm_head import rewrite_lm_head_gather_unsqueeze
+
+FP32__dup4 = TensorProto.FLOAT
+FP64 = TensorProto.DOUBLE
+FP16__dup4 = TensorProto.FLOAT16
+INT4 = TensorProto.INT4
+DECODER_EXTERNAL_DATA = "BUNDLE.data"
+HEAD_QWEIGHT_DATA = "BUNDLE_head_qweight.data"
+HEAD_SCALE_DATA = "BUNDLE_head_scale.data"
+DEFAULT_BATCH = 1
+DEFAULT_SEQ_LEN = 128
+DEFAULT_MAX_SEQ_LEN = 16384
+
+
+def _dim_param_bindings(batch: int, seq_len: int, max_seq_len: int) -> dict[str, int]:
+    return {"batch": batch, "seq_len": seq_len, "max_seq_len": max_seq_len}
+
+
+def _fix_value_info_shapes(vi: onnx.ValueInfoProto, bindings: dict[str, int]) -> None:
+    for dim in vi.type.tensor_type.shape.dim:
+        if dim.dim_param and dim.dim_param in bindings:
+            dim.dim_value = bindings[dim.dim_param]
+            dim.ClearField("dim_param")
+
+
+@dataclass(frozen=True)
+class ShapeFixConfig:
+    """Optional static-shape binding for symbolic ONNX dimensions."""
+
+    enabled: bool = False
+    batch: int = DEFAULT_BATCH
+    seq_len: int = DEFAULT_SEQ_LEN
+    max_seq_len: int = DEFAULT_MAX_SEQ_LEN
+
+
+def maybe_fix_static_shapes(model: onnx.ModelProto, shape_fix: ShapeFixConfig) -> None:
+    """Bind symbolic dims when ``shape_fix.enabled``."""
+    if not shape_fix.enabled:
+        return
+    bindings = _dim_param_bindings(
+        shape_fix.batch, shape_fix.seq_len, shape_fix.max_seq_len
+    )
+    graph = model.graph
+    for vi in list(graph.input) + list(graph.output) + list(graph.value_info):
+        _fix_value_info_shapes(vi, bindings)
+
+
+def fix_static_shapes(
+    model: onnx.ModelProto,
+    *,
+    batch: int = DEFAULT_BATCH,
+    seq_len: int = DEFAULT_SEQ_LEN,
+    max_seq_len: int = DEFAULT_MAX_SEQ_LEN,
+) -> None:
+    maybe_fix_static_shapes(
+        model,
+        ShapeFixConfig(
+            enabled=True, batch=batch, seq_len=seq_len, max_seq_len=max_seq_len
+        ),
+    )
+
+
+_INT4_UNSIGNED_OFFSET = 8
+DEFAULT_ACCURACY_LEVEL = 1
+MATMUL_NBITS_ACCURACY_LEVEL = DEFAULT_ACCURACY_LEVEL
+
+
+def _nibble_pack_int4(values: np.ndarray) -> np.ndarray:
+    nibbles = values.astype(np.int16) + _INT4_UNSIGNED_OFFSET & 15
+    return nibbles[0::2].astype(np.uint8) | nibbles[1::2].astype(np.uint8) << 4
+
+
+def choose_block_size(k: int) -> int:
+    """Pick a MatMulNBits-legal block_size (power of 2, >= 16) for a K dim.
+
+    Prefer the largest such block_size that divides K (no padding needed);
+    fall back to 32 with zero-padded trailing block when none divides.
+    """
+    for bs in (256, 128, 64, 32, 16):
+        if k % bs == 0:
+            return bs
+    return 32
+
+
+def pack_matmul_nbits_weight(
+    w_kn: np.ndarray, block_size: int
+) -> tuple[np.ndarray, int, int, int]:
+    k, n = w_kn.shape
+    if k % 2 != 0:
+        raise ValueError(f"K must be even for 4-bit packing, got K={k}")
+    n_blocks = (k + block_size - 1) // block_size
+    blob_size = block_size // 2
+    packed = np.zeros((n, n_blocks, blob_size), dtype=np.uint8)
+    for col in range(n):
+        col_bytes = _nibble_pack_int4(w_kn[:, col])
+        flat = np.zeros(n_blocks * blob_size, dtype=np.uint8)
+        flat[: col_bytes.size] = col_bytes
+        packed[col] = flat.reshape(n_blocks, blob_size)
+    return (packed, k, n, n_blocks)
+
+
+def pack_zero_points(z_n: np.ndarray, n: int, n_blocks: int) -> np.ndarray:
+    """Pack one (per-channel) 4-bit zero point, replicated across all blocks.
+
+    Layout matches MatMulNBits: per column, n_blocks nibbles packed two-per-byte
+    (even block -> low nibble, odd block -> high nibble).
+    """
+    zp_bytes = (n_blocks + 1) // 2
+    out = np.zeros((n, zp_bytes), dtype=np.uint8)
+    for col in range(n):
+        v = int(z_n[col]) + _INT4_UNSIGNED_OFFSET & 15
+        for b in range(n_blocks):
+            if b % 2 == 0:
+                out[col, b // 2] |= v
+            else:
+                out[col, b // 2] |= v << 4
+    return out
+
+
+def dequantize_initializer(
+    w: np.ndarray, scale: np.ndarray, zp: np.ndarray, *, out_dtype: type = np.float16
+) -> np.ndarray:
+    w_f = w.astype(np.float64)
+    s_f = np.asarray(scale, dtype=np.float64)
+    z_f = np.asarray(zp, dtype=np.float64)
+    return ((w_f - z_f) * s_f).astype(out_dtype)
+
+
+def dequantize_weight_array(
+    w: np.ndarray, scale: np.ndarray, zp: np.ndarray, *, out_dtype: type = np.float16
+) -> np.ndarray:
+    """Dequantize int4/int8 (or float) weights for offline Gemm weight folding."""
+    w_f = w.astype(np.float64)
+    s_f = np.asarray(scale, dtype=np.float64)
+    z_f = np.asarray(zp, dtype=np.float64)
+    if w.dtype.name == "int4" and s_f.ndim == 1 and (s_f.shape[0] == w.shape[0]):
+        return ((w_f - z_f.reshape(-1, 1)) * s_f.reshape(-1, 1)).astype(out_dtype)
+    if s_f.ndim == 1 and s_f.size == w.shape[0] and (w.ndim >= 2):
+        z_col = z_f.reshape(-1, 1) if z_f.ndim else z_f
+        s_col = s_f.reshape(-1, 1)
+        return ((w_f - z_col) * s_col).astype(out_dtype)
+    return dequantize_initializer(w, scale, zp, out_dtype=out_dtype)
+
+
+def _replace_tensor_name(
+    users: dict[str, list[tuple[onnx.NodeProto, int]]], old: str, new: str
+) -> None:
+    for node, idx in users.get(old, []):
+        if node.input[idx] == old:
+            node.input[idx] = new
+
+
+def _build_tensor_users(
+    graph: onnx.GraphProto,
+) -> dict[str, list[tuple[onnx.NodeProto, int]]]:
+    users: dict[str, list[tuple[onnx.NodeProto, int]]] = {}
+    for node in graph.node:
+        for idx, name in enumerate(node.input):
+            if name:
+                users.setdefault(name, []).append((node, idx))
+    return users
+
+
+def _referenced_initializer_names(graph: onnx.GraphProto) -> set[str]:
+    used: set[str] = set()
+    for node in graph.node:
+        for name in node.input:
+            if name:
+                used.add(name)
+    return used
+
+
+def _rename_value_tensor(
+    graph: onnx.GraphProto,
+    users: dict[str, list[tuple[onnx.NodeProto, int]]],
+    old: str,
+    new: str,
+) -> None:
+    if old == new:
+        return
+    for node in graph.node:
+        for idx, out_name in enumerate(node.output):
+            if out_name == old:
+                node.output[idx] = new
+    _replace_tensor_name(users, old, new)
+    for vi in graph.value_info:
+        if vi.name == old:
+            vi.name = new
+
+
+def strip_activation_qdq(graph: onnx.GraphProto) -> int:
+    users = _build_tensor_users(graph)
+    dq_by_q_out = {
+        d.input[0]: d for d in graph.node if d.op_type == "DequantizeLinear" and d.input
+    }
+    remove_nodes: set[str] = set()
+    dq_to_src: dict[str, str] = {}
+    removed = 0
+    for q in graph.node:
+        if q.op_type != "QuantizeLinear":
+            continue
+        dq = dq_by_q_out.get(q.output[0])
+        if dq is None:
+            continue
+        src, dst = (q.input[0], dq.output[0])
+        dq_to_src[dst] = src
+        _replace_tensor_name(users, dst, src)
+        remove_nodes.add(q.name)
+        remove_nodes.add(dq.name)
+        removed += 1
+    graph_outputs = {out.name for out in graph.output}
+    for dst, src in dq_to_src.items():
+        if dst in graph_outputs:
+            _rename_value_tensor(graph, users, src, dst)
+    if remove_nodes:
+        kept = [n for n in graph.node if n.name not in remove_nodes]
+        del graph.node[:]
+        graph.node.extend(kept)
+    return removed
+
+
+def _expand_scale_zp(
+    scale: np.ndarray, zp: np.ndarray, n: int
+) -> tuple[np.ndarray, np.ndarray]:
+    if scale.ndim == 0:
+        scale = np.full(n, float(scale), dtype=np.float32)
+    if zp.ndim == 0:
+        zp = np.full(n, int(zp), dtype=np.int8)
+    return (scale, zp)
+
+
+def convert_matmul_weight_dq(
+    graph: onnx.GraphProto,
+    inits: dict[str, onnx.TensorProto],
+    new_inits: dict[str, onnx.TensorProto],
+    remove_inits: set[str],
+) -> int:
+    dq_by_out = {d.output[0]: d for d in graph.node if d.op_type == "DequantizeLinear"}
+    replacements: dict[str, onnx.NodeProto] = {}
+    remove_nodes: set[str] = set()
+    converted = 0
+    for mm in graph.node:
+        if mm.op_type != "MatMul" or len(mm.input) < 2:
+            continue
+        dq = dq_by_out.get(mm.input[1])
+        if dq is None or dq.input[0] not in inits:
+            continue
+        w_name = dq.input[0]
+        w = numpy_helper.to_array(inits[w_name])
+        if w.dtype.name != "int4":
+            continue
+        scale, zp = _expand_scale_zp(
+            numpy_helper.to_array(inits[dq.input[1]]),
+            numpy_helper.to_array(inits[dq.input[2]]),
+            w.shape[1],
+        )
+        block_size = choose_block_size(w.shape[0])
+        packed, k, n, n_blocks = pack_matmul_nbits_weight(w, block_size)
+        base = w_name.removesuffix("_quantized")
+        q_name = f"{base}_mnbits_q4"
+        s_name = f"{base}_mnbits_scales"
+        z_name = f"{base}_mnbits_zp"
+        new_inits[q_name] = numpy_helper.from_array(packed, name=q_name)
+        new_inits[s_name] = numpy_helper.from_array(
+            np.repeat(scale.astype(np.float16).reshape(n, 1), n_blocks, axis=1),
+            name=s_name,
+        )
+        new_inits[z_name] = numpy_helper.from_array(
+            pack_zero_points(zp, n, n_blocks), name=z_name
+        )
+        replacements[mm.name] = helper.make_node(
+            "MatMulNBits",
+            [mm.input[0], q_name, s_name, z_name],
+            list(mm.output),
+            name=f"{mm.name}_mnbits",
+            domain="com.microsoft",
+            K=k,
+            N=n,
+            bits=4,
+            block_size=block_size,
+            accuracy_level=MATMUL_NBITS_ACCURACY_LEVEL,
+        )
+        remove_nodes.update({mm.name, dq.name})
+        remove_inits.update({w_name, dq.input[1], dq.input[2]})
+        converted += 1
+    if converted:
+        kept = []
+        for node in graph.node:
+            if node.name in replacements:
+                kept.append(replacements[node.name])
+            elif node.name in remove_nodes:
+                continue
+            else:
+                kept.append(node)
+        del graph.node[:]
+        graph.node.extend(kept)
+    return converted
+
+
+def _expand_scale_zp_blocks(
+    scale: np.ndarray, zp: np.ndarray, n: int, n_blocks: int
+) -> tuple[np.ndarray, np.ndarray | None]:
+    """Expand per-tensor (or per-channel) scale/zp to MatMulNBits block layout."""
+    scale_f = np.asarray(scale, dtype=np.float32)
+    if scale_f.ndim == 0:
+        scale_blocks = np.full((n, n_blocks), float(scale_f), dtype=np.float16)
+    elif scale_f.size == 1:
+        scale_blocks = np.full(
+            (n, n_blocks), float(scale_f.reshape(())), dtype=np.float16
+        )
+    elif scale_f.ndim == 1 and scale_f.shape[0] == n:
+        scale_blocks = np.repeat(
+            scale_f.astype(np.float16).reshape(n, 1), n_blocks, axis=1
+        )
+    else:
+        raise ValueError(f"unsupported scale shape {scale_f.shape} for N={n}")
+    zp_arr = np.asarray(zp)
+    if zp_arr.size == 1 and float(zp_arr.reshape(())) == 0.0:
+        return (scale_blocks, None)
+    if zp_arr.ndim == 0:
+        zp_blocks = np.full((n, n_blocks), int(zp_arr), dtype=np.uint8)
+    elif zp_arr.size == 1:
+        zp_blocks = np.full((n, n_blocks), int(zp_arr.reshape(())), dtype=np.uint8)
+    elif zp_arr.ndim == 1 and zp_arr.shape[0] == n:
+        zp_blocks = np.repeat(zp_arr.astype(np.uint8).reshape(n, 1), n_blocks, axis=1)
+    else:
+        raise ValueError(f"unsupported zero-point shape {zp_arr.shape} for N={n}")
+    return (scale_blocks, zp_blocks)
+
+
+def _matmul_nbits_block_size(k: int) -> int:
+    """Pick block_size for 8-bit MatMulNBits (power-of-2, divides K)."""
+    for bs in (256, 128, 64, 32, 16):
+        if k % bs == 0:
+            return bs
+    raise ValueError(f"K={k} has no power-of-2 block_size divisor >= 16")
+
+
+def has_graph_input_weight_quantized(graph: onnx.GraphProto) -> bool:
+    return any(("weight_quantized" in vi.name for vi in graph.input))
+
+
+def _expand_scale_zp_blocks_signed_int8(
+    scale: np.ndarray, zp: np.ndarray, n: int, n_blocks: int
+) -> tuple[np.ndarray, np.ndarray]:
+    """Block scale layout for signed int8 weights stored as uint8 with offset 128."""
+    scale_blocks, _ = _expand_scale_zp_blocks(scale, zp, n, n_blocks)
+    zp_blocks = np.full((n, n_blocks), 128, dtype=np.uint8)
+    return (scale_blocks, zp_blocks)
+
+
+def convert_matmul_graph_input_int8_dq(
+    graph: onnx.GraphProto,
+    inits: dict[str, onnx.TensorProto],
+    new_inits: dict[str, onnx.TensorProto],
+    remove_inits: set[str],
+) -> int:
+    """Fuse graph-input int8 ``weight_quantized -> DQ -> MatMul`` into MatMulNBits.
+
+    Keeps each ``weight_quantized`` port as a graph input (shape ``[K, N]``).
+    Inserts ``Transpose + Reshape`` so MatMulNBits receives ``[N, K/block, block]``.
+    """
+    graph_inputs = {vi.name: vi for vi in graph.input}
+    dq_by_out = {d.output[0]: d for d in graph.node if d.op_type == "DequantizeLinear"}
+    scale_cache: dict[tuple[str, str, int, int], str] = {}
+    insert_before: dict[str, list[onnx.NodeProto]] = {}
+    remove_nodes: set[str] = set()
+    converted = 0
+    for mm in graph.node:
+        if mm.op_type != "MatMul" or len(mm.input) < 2:
+            continue
+        dq = dq_by_out.get(mm.input[1])
+        if dq is None or len(dq.input) < 3:
+            continue
+        w_name = dq.input[0]
+        if w_name not in graph_inputs or w_name not in {vi.name for vi in graph.input}:
+            continue
+        if "weight_quantized" not in w_name:
+            continue
+        if dq.input[1] not in inits or dq.input[2] not in inits:
+            continue
+        vi = graph_inputs[w_name]
+        dims = [d.dim_value for d in vi.type.tensor_type.shape.dim]
+        if len(dims) != 2 or not all(dims):
+            continue
+        k, n = dims
+        block_size = _matmul_nbits_block_size(k)
+        n_blocks = k // block_size
+        packed_shape_name = f"{mm.name}_mnbits_pack_shape"
+        new_inits[packed_shape_name] = numpy_helper.from_array(
+            np.array([n, n_blocks, block_size], dtype=np.int64), name=packed_shape_name
+        )
+        offset_name = f"{mm.name}_mnbits_signed_offset"
+        new_inits[offset_name] = numpy_helper.from_array(
+            np.array(128, dtype=np.int16), name=offset_name
+        )
+        trans_out = f"{mm.name}_mnbits_w_t"
+        trans_i16 = f"{mm.name}_mnbits_w_t_i16"
+        shifted_i16 = f"{mm.name}_mnbits_w_shifted_i16"
+        trans_u8 = f"{mm.name}_mnbits_w_t_u8"
+        packed_u8 = f"{mm.name}_mnbits_w_uint8"
+        pack_nodes = [
+            helper.make_node(
+                "Transpose",
+                [w_name],
+                [trans_out],
+                name=f"{mm.name}_mnbits_transpose",
+                perm=[1, 0],
+            ),
+            helper.make_node(
+                "Cast",
+                [trans_out],
+                [trans_i16],
+                name=f"{mm.name}_mnbits_cast_i16",
+                to=TensorProto.INT16,
+            ),
+            helper.make_node(
+                "Add",
+                [trans_i16, offset_name],
+                [shifted_i16],
+                name=f"{mm.name}_mnbits_add_offset",
+            ),
+            helper.make_node(
+                "Cast",
+                [shifted_i16],
+                [trans_u8],
+                name=f"{mm.name}_mnbits_cast_u8",
+                to=TensorProto.UINT8,
+            ),
+            helper.make_node(
+                "Reshape",
+                [trans_u8, packed_shape_name],
+                [packed_u8],
+                name=f"{mm.name}_mnbits_pack",
+            ),
+        ]
+        scale_key = (dq.input[1], dq.input[2], n, n_blocks)
+        if scale_key not in scale_cache:
+            scale_blocks, zp_blocks = _expand_scale_zp_blocks_signed_int8(
+                numpy_helper.to_array(inits[dq.input[1]]),
+                numpy_helper.to_array(inits[dq.input[2]]),
+                n,
+                n_blocks,
+            )
+            s_name = f"{dq.input[1]}_blocks_{n}x{n_blocks}"
+            z_name = f"{dq.input[2]}_blocks_{n}x{n_blocks}_u8zp128"
+            new_inits[s_name] = numpy_helper.from_array(scale_blocks, name=s_name)
+            new_inits[z_name] = numpy_helper.from_array(zp_blocks, name=z_name)
+            scale_cache[scale_key] = s_name
+            scale_cache[dq.input[1], dq.input[2], n, n_blocks, "zp"] = z_name
+        s_name = scale_cache[scale_key]
+        z_name = scale_cache[dq.input[1], dq.input[2], n, n_blocks, "zp"]
+        mnbits_inputs = [mm.input[0], packed_u8, s_name, z_name]
+        mnbits = helper.make_node(
+            "MatMulNBits",
+            mnbits_inputs,
+            list(mm.output),
+            name=f"{mm.name}_mnbits",
+            domain="com.microsoft",
+            K=k,
+            N=n,
+            bits=8,
+            block_size=block_size,
+            accuracy_level=MATMUL_NBITS_ACCURACY_LEVEL,
+        )
+        insert_before[mm.name] = [*pack_nodes, mnbits]
+        remove_nodes.update({mm.name, dq.name})
+        converted += 1
+    if not converted:
+        return 0
+    kept: list[onnx.NodeProto] = []
+    for node in graph.node:
+        if node.name in insert_before:
+            kept.extend(insert_before[node.name])
+        elif node.name in remove_nodes:
+            continue
+        else:
+            kept.append(node)
+    del graph.node[:]
+    graph.node.extend(kept)
+    return converted
+
+
+def _conv_kernel_shape(conv: onnx.NodeProto) -> list[int] | None:
+    for attr in conv.attribute:
+        if attr.name == "kernel_shape":
+            return list(attr.ints)
+    return None
+
+
+def _find_transpose_by_output(
+    graph: onnx.GraphProto, tensor: str
+) -> onnx.NodeProto | None:
+    return next(
+        (n for n in graph.node if n.op_type == "Transpose" and n.output[0] == tensor),
+        None,
+    )
+
+
+def _find_transpose_by_input(
+    graph: onnx.GraphProto, tensor: str
+) -> onnx.NodeProto | None:
+    return next(
+        (n for n in graph.node if n.op_type == "Transpose" and n.input[0] == tensor),
+        None,
+    )
+
+
+def fuse_conv_transpose_to_matmul_nbits(
+    graph: onnx.GraphProto,
+    inits: dict[str, onnx.TensorProto],
+    new_inits: dict[str, onnx.TensorProto],
+    remove_inits: set[str],
+) -> int:
+    """Replace Transpose -> Conv(int4 DQ weight) -> Transpose with MatMulNBits."""
+    dq_by_out = {d.output[0]: d for d in graph.node if d.op_type == "DequantizeLinear"}
+    replacements: dict[str, list[onnx.NodeProto]] = {}
+    remove_nodes: set[str] = set()
+    converted = 0
+    for conv in graph.node:
+        if conv.op_type != "Conv" or len(conv.input) < 2:
+            continue
+        if _conv_kernel_shape(conv) != [1, 1]:
+            continue
+        w_dq = dq_by_out.get(conv.input[1])
+        if w_dq is None or w_dq.input[0] not in inits:
+            continue
+        w_init = inits[w_dq.input[0]]
+        if w_init.data_type != INT4:
+            continue
+        t0 = _find_transpose_by_output(graph, conv.input[0])
+        t1 = _find_transpose_by_input(graph, conv.output[0])
+        if t0 is None or t1 is None:
+            continue
+        block_input = t0.input[0]
+        block_output = t1.output[0]
+        w = numpy_helper.to_array(w_init)
+        if w.ndim != 4 or w.shape[2:] != (1, 1):
+            raise ValueError(
+                f"Expected 1x1 Conv weight [N,K,1,1], got {w.shape} for {w_init.name}"
+            )
+        n_out, k_in = (int(w.shape[0]), int(w.shape[1]))
+        w_kn = w[:, :, 0, 0].T
+        scale, zp = _expand_scale_zp(
+            numpy_helper.to_array(inits[w_dq.input[1]]),
+            numpy_helper.to_array(inits[w_dq.input[2]]),
+            n_out,
+        )
+        block_size = choose_block_size(k_in)
+        packed, k, n, n_blocks = pack_matmul_nbits_weight(w_kn, block_size)
+        base = w_init.name.removesuffix("_quantized")
+        q_name = f"{base}_mnbits_q4"
+        s_name = f"{base}_mnbits_scales"
+        z_name = f"{base}_mnbits_zp"
+        pre_shape_name = f"{base}_mnbits_pre_shape"
+        post_shape_name = f"{base}_mnbits_post_shape"
+        new_inits[q_name] = numpy_helper.from_array(packed, name=q_name)
+        new_inits[s_name] = numpy_helper.from_array(
+            np.repeat(scale.astype(np.float16).reshape(n, 1), n_blocks, axis=1),
+            name=s_name,
+        )
+        new_inits[z_name] = numpy_helper.from_array(
+            pack_zero_points(zp, n, n_blocks), name=z_name
+        )
+        new_inits[pre_shape_name] = numpy_helper.from_array(
+            np.array([-1, k], dtype=np.int64), name=pre_shape_name
+        )
+        new_inits[post_shape_name] = numpy_helper.from_array(
+            np.array([1, 1, -1, n], dtype=np.int64), name=post_shape_name
+        )
+        mm_in = f"{conv.name}_mnbits_in"
+        mm_out = f"{conv.name}_mnbits_out"
+        replacements[conv.name] = [
+            helper.make_node(
+                "Reshape",
+                [block_input, pre_shape_name],
+                [mm_in],
+                name=f"{conv.name}_mnbits_reshape_in",
+            ),
+            helper.make_node(
+                "MatMulNBits",
+                [mm_in, q_name, s_name, z_name],
+                [mm_out],
+                name=f"{conv.name}_mnbits",
+                domain="com.microsoft",
+                K=k,
+                N=n,
+                bits=4,
+                block_size=block_size,
+                accuracy_level=MATMUL_NBITS_ACCURACY_LEVEL,
+            ),
+            helper.make_node(
+                "Reshape",
+                [mm_out, post_shape_name],
+                [block_output],
+                name=f"{conv.name}_mnbits_reshape_out",
+            ),
+        ]
+        remove_nodes.update({t0.name, conv.name, t1.name, w_dq.name})
+        remove_inits.update({w_init.name, w_dq.input[1], w_dq.input[2]})
+        converted += 1
+    if converted:
+        kept: list[onnx.NodeProto] = []
+        for node in graph.node:
+            if node.name in replacements:
+                kept.extend(replacements[node.name])
+            elif node.name not in remove_nodes:
+                kept.append(node)
+        del graph.node[:]
+        graph.node.extend(kept)
+    return converted
+
+
+_WEIGHT_DQ_CONSUMER_INPUTS: dict[str, tuple[int, ...]] = {
+    "Mul": (0, 1),
+    "Conv": (1,),
+    "Gemm": (1,),
+    "Add": (0, 1),
+}
+
+
+def fold_weight_dq(
+    graph: onnx.GraphProto,
+    inits: dict[str, onnx.TensorProto],
+    new_inits: dict[str, onnx.TensorProto],
+    remove_inits: set[str],
+) -> int:
+    """Fold weight/bias DQ into fp16 constants for Mul, Conv, and Add consumers."""
+    dq_by_out = {d.output[0]: d for d in graph.node if d.op_type == "DequantizeLinear"}
+    tensor_replace: dict[str, str] = {}
+    remove_dq: set[str] = set()
+    folded = 0
+    for node in graph.node:
+        input_indices = _WEIGHT_DQ_CONSUMER_INPUTS.get(node.op_type)
+        if input_indices is None:
+            continue
+        for idx in input_indices:
+            if idx >= len(node.input):
+                continue
+            dq = dq_by_out.get(node.input[idx])
+            if dq is None or dq.input[0] not in inits:
+                continue
+            w_name = dq.input[0]
+            w = numpy_helper.to_array(inits[w_name])
+            if w.dtype.name == "int4":
+                continue
+            scale = numpy_helper.to_array(inits[dq.input[1]])
+            zp = numpy_helper.to_array(inits[dq.input[2]])
+            const_name = f"{w_name}_fp16"
+            new_inits[const_name] = numpy_helper.from_array(
+                dequantize_initializer(w, scale, zp), name=const_name
+            )
+            tensor_replace[node.input[idx]] = const_name
+            remove_dq.add(dq.output[0])
+            remove_inits.update({w_name, dq.input[1], dq.input[2]})
+            folded += 1
+    if tensor_replace:
+        for node in graph.node:
+            for idx, inp in enumerate(node.input):
+                if inp in tensor_replace:
+                    node.input[idx] = tensor_replace[inp]
+        kept = [
+            n
+            for n in graph.node
+            if not (n.op_type == "DequantizeLinear" and n.output[0] in remove_dq)
+        ]
+        del graph.node[:]
+        graph.node.extend(kept)
+    return folded
+
+
+def fold_mul_weight_dq(
+    graph: onnx.GraphProto,
+    inits: dict[str, onnx.TensorProto],
+    new_inits: dict[str, onnx.TensorProto],
+    remove_inits: set[str],
+) -> int:
+    """Backward-compatible alias for norm-weight DQ folding (Mul only)."""
+    return fold_weight_dq(graph, inits, new_inits, remove_inits)
+
+
+def fold_gemm_int4_backbone_dq(
+    graph: onnx.GraphProto,
+    inits: dict[str, onnx.TensorProto],
+    new_inits: dict[str, onnx.TensorProto],
+    remove_inits: set[str],
+) -> int:
+    """Fold int4 backbone ``DQ -> Gemm`` weights into fp16 initializers."""
+    dq_by_out = {d.output[0]: d for d in graph.node if d.op_type == "DequantizeLinear"}
+    tensor_replace: dict[str, str] = {}
+    remove_dq: set[str] = set()
+    folded = 0
+    for node in graph.node:
+        if node.op_type != "Gemm":
+            continue
+        for idx in (1,):
+            if idx >= len(node.input):
+                continue
+            dq = dq_by_out.get(node.input[idx])
+            if dq is None or dq.input[0] not in inits:
+                continue
+            w_name = dq.input[0]
+            if dq.input[1] not in inits or dq.input[2] not in inits:
+                continue
+            w = numpy_helper.to_array(inits[w_name])
+            if w.dtype.name != "int4":
+                continue
+            scale = numpy_helper.to_array(inits[dq.input[1]])
+            zp = numpy_helper.to_array(inits[dq.input[2]])
+            const_name = f"{w_name}_fp16"
+            new_inits[const_name] = numpy_helper.from_array(
+                dequantize_weight_array(w, scale, zp), name=const_name
+            )
+            tensor_replace[node.input[idx]] = const_name
+            remove_dq.add(dq.output[0])
+            remove_inits.update({w_name, dq.input[1], dq.input[2]})
+            folded += 1
+    if tensor_replace:
+        for node in graph.node:
+            for idx, inp in enumerate(node.input):
+                if inp in tensor_replace:
+                    node.input[idx] = tensor_replace[inp]
+        kept = [
+            n
+            for n in graph.node
+            if not (n.op_type == "DequantizeLinear" and n.output[0] in remove_dq)
+        ]
+        del graph.node[:]
+        graph.node.extend(kept)
+    return folded
+
+
+def convert_gemm_lora_input_dq_to_fp16(
+    graph: onnx.GraphProto,
+    inits: dict[str, onnx.TensorProto],
+    remove_inits: set[str],
+    lora_meta: dict[str, dict],
+) -> int:
+    """Replace LoRA ``graph_input int8 -> DQ -> Gemm`` with fp16 graph inputs."""
+    graph_inputs = {vi.name: vi for vi in graph.input}
+    dq_by_out = {d.output[0]: d for d in graph.node if d.op_type == "DequantizeLinear"}
+    remove_dq: set[str] = set()
+    converted = 0
+    for gemm in graph.node:
+        if gemm.op_type != "Gemm" or len(gemm.input) < 2:
+            continue
+        dq = dq_by_out.get(gemm.input[1])
+        if dq is None or len(dq.input) < 3:
+            continue
+        w_name = dq.input[0]
+        if w_name not in graph_inputs or "weight_quantized" not in w_name:
+            continue
+        if dq.input[1] not in inits or dq.input[2] not in inits:
+            continue
+        fp16_name = w_name.replace("weight_quantized", "weight_fp16")
+        scale = numpy_helper.to_array(inits[dq.input[1]])
+        zp = numpy_helper.to_array(inits[dq.input[2]])
+        lora_meta[w_name] = {
+            "onnx_input": fp16_name,
+            "scale": float(scale.reshape(())),
+            "zero_point": int(zp.reshape(())),
+        }
+        vi = graph_inputs[w_name]
+        vi.name = fp16_name
+        vi.type.tensor_type.elem_type = FP16__dup4
+        graph_inputs[fp16_name] = vi
+        del graph_inputs[w_name]
+        gemm.input[1] = fp16_name
+        remove_dq.add(dq.name)
+        remove_inits.update({dq.input[1], dq.input[2]})
+        converted += 1
+    if remove_dq:
+        kept = [n for n in graph.node if n.name not in remove_dq]
+        del graph.node[:]
+        graph.node.extend(kept)
+    return converted
+
+
+def set_matmul_nbits_accuracy_level(
+    model: onnx.ModelProto, level: int | None = None
+) -> int:
+    """Force ``accuracy_level`` on every MatMulNBits node (incl. pre-existing ones).
+
+    The exported lm_head ships as MatMulNBits with ``accuracy_level=4`` (int8
+    activation), which degrades logits enough to pick wrong-but-adjacent tokens.
+    """
+    if level is None:
+        level = MATMUL_NBITS_ACCURACY_LEVEL
+    changed = 0
+    for node in model.graph.node:
+        if node.op_type != "MatMulNBits":
+            continue
+        attr = next((a for a in node.attribute if a.name == "accuracy_level"), None)
+        if attr is not None:
+            if attr.i != level:
+                attr.i = level
+                changed += 1
+        else:
+            node.attribute.extend([helper.make_attribute("accuracy_level", level)])
+            changed += 1
+    return changed
+
+
+def _promote_value_info_elem_type(vi: onnx.ValueInfoProto) -> None:
+    elem_type = vi.type.tensor_type.elem_type
+    if elem_type in (FP32__dup4, FP64):
+        vi.type.tensor_type.elem_type = FP16__dup4
+
+
+def promote_model_to_fp16(model: onnx.ModelProto) -> None:
+    """Promote float32/float64 graph I/O and float initializers to float16."""
+    graph = model.graph
+    for vi in list(graph.input) + list(graph.output):
+        _promote_value_info_elem_type(vi)
+    for init in graph.initializer:
+        if init.data_type == FP32__dup4:
+            arr = numpy_helper.to_array(init).astype(np.float16)
+            init.CopyFrom(numpy_helper.from_array(arr, name=init.name))
+        elif init.data_type == FP64:
+            arr = numpy_helper.to_array(init).astype(np.float16)
+            init.CopyFrom(numpy_helper.from_array(arr, name=init.name))
+    del graph.value_info[:]
+
+
+def ensure_matmul_nbits_fp16_inputs__dup4(model: onnx.ModelProto) -> int:
+    """Cast MatMulNBits activations to fp16 so ORT does not mix float/float16 on T1."""
+    graph = model.graph
+    new_nodes: list[onnx.NodeProto] = []
+    count = 0
+    for node in graph.node:
+        if node.op_type != "MatMulNBits":
+            new_nodes.append(node)
+            continue
+        src = node.input[0]
+        cast_out = f"{node.name}_act_fp16"
+        node.input[0] = cast_out
+        new_nodes.append(
+            helper.make_node(
+                "Cast", [src], [cast_out], name=f"{node.name}_act_cast", to=FP16__dup4
+            )
+        )
+        new_nodes.append(node)
+        count += 1
+    del graph.node[:]
+    graph.node.extend(new_nodes)
+    return count
+
+
+def stabilize_lpnorm_fp16(model: onnx.ModelProto) -> int:
+    """Force every LpNormalization to compute in fp32 via Cast wrappers.
+
+    The DirectML EP computes LpNormalization's internal sum-of-squares in the
+    tensor dtype (fp16); for large activations this overflows fp16 (>65504),
+    yielding a wrong norm that amplifies layer-over-layer into NaNs (the CPU EP
+    accumulates in fp32 and is unaffected). Wrapping each node with
+    ``Cast(fp32) -> LpNormalization -> Cast(fp16)`` makes both EPs agree.
+    """
+    graph = model.graph
+    if not any((n.op_type == "LpNormalization" for n in graph.node)):
+        return 0
+    new_nodes: list[onnx.NodeProto] = []
+    count = 0
+    for node in graph.node:
+        if node.op_type != "LpNormalization":
+            new_nodes.append(node)
+            continue
+        src = node.input[0]
+        dst = node.output[0]
+        pre = f"{node.name}_xf32"
+        post = f"{node.name}_yf32"
+        node.input[0] = pre
+        node.output[0] = post
+        new_nodes.append(
+            helper.make_node(
+                "Cast", [src], [pre], name=f"{node.name}_cast_in", to=FP32__dup4
+            )
+        )
+        new_nodes.append(node)
+        new_nodes.append(
+            helper.make_node(
+                "Cast", [post], [dst], name=f"{node.name}_cast_out", to=FP16__dup4
+            )
+        )
+        count += 1
+    del graph.node[:]
+    graph.node.extend(new_nodes)
+    return count
+
+
+def apply_new_initializers(
+    graph: onnx.GraphProto, new_inits: dict[str, onnx.TensorProto]
+) -> None:
+    existing = {i.name: idx for idx, i in enumerate(graph.initializer)}
+    for name, tensor in new_inits.items():
+        if name in existing:
+            graph.initializer[existing[name]] = tensor
+        else:
+            graph.initializer.append(tensor)
+
+
+def prune_initializers(graph: onnx.GraphProto, remove_inits: set[str]) -> None:
+    used = _referenced_initializer_names(graph)
+    kept = [
+        i for i in graph.initializer if i.name in used and i.name not in remove_inits
+    ]
+    del graph.initializer[:]
+    graph.initializer.extend(kept)
+
+
+def rewrite_gqa_past_seq_len_to_seqlens_k(model: onnx.ModelProto) -> int:
+    """Convert GQA input #5 from literal ``past_seq_len`` to ORT ``seqlens_k``.
+
+    BUNDLE / runtime pass the count of tokens already in the KV cache on graph input
+    ``past_seq_len``.  ORT GroupQueryAttention expects
+    ``seqlens_k = past_len + seq_q - 1``.  Insert a small subgraph once and
+    rewire every GQA node::
+
+        seqlens_k = Reshape(past_seq_len, [1]) + Shape(query)[1] - 1
+    """
+    graph = model.graph
+    gqa_nodes = [n for n in graph.node if n.op_type == "GroupQueryAttention"]
+    if not gqa_nodes:
+        return 0
+    past_input = "past_seq_len"
+    if not any((i.name == past_input for i in graph.input)):
+        return 0
+    if any((n.op_type == "Sub" and n.name == "gqa_seqlens_k_sub" for n in graph.node)):
+        return 0
+    if not all((len(n.input) > 5 and n.input[5] == past_input for n in gqa_nodes)):
+        return 0
+    query = gqa_nodes[0].input[0]
+    one_name = "gqa_seqlens_k_const_one"
+    past_reshape_shape = "gqa_past_reshape_shape"
+    graph.initializer.extend(
+        [
+            numpy_helper.from_array(np.array([1], dtype=np.int32), name=one_name),
+            numpy_helper.from_array(
+                np.array([1], dtype=np.int64), name=past_reshape_shape
+            ),
+            numpy_helper.from_array(
+                np.array(1, dtype=np.int64), name="gqa_gather_sq_idx"
+            ),
+        ]
+    )
+    new_nodes = [
+        helper.make_node("Shape", [query], ["gqa_query_shape"], name="gqa_query_shape"),
+        helper.make_node(
+            "Gather",
+            ["gqa_query_shape", "gqa_gather_sq_idx"],
+            ["gqa_sq_i64"],
+            name="gqa_gather_sq",
+            axis=0,
+        ),
+        helper.make_node(
+            "Cast",
+            ["gqa_sq_i64"],
+            ["gqa_sq_i32"],
+            name="gqa_cast_sq",
+            to=TensorProto.INT32,
+        ),
+        helper.make_node(
+            "Reshape",
+            [past_input, past_reshape_shape],
+            ["gqa_past_1d"],
+            name="gqa_past_reshape",
+        ),
+        helper.make_node(
+            "Add",
+            ["gqa_past_1d", "gqa_sq_i32"],
+            ["gqa_past_plus_sq"],
+            name="gqa_past_plus_sq",
+        ),
+        helper.make_node(
+            "Sub",
+            ["gqa_past_plus_sq", one_name],
+            ["gqa_seqlens_k"],
+            name="gqa_seqlens_k_sub",
+        ),
+    ]
+    insert_at = min(
+        (i for i, n in enumerate(graph.node) if n.op_type == "GroupQueryAttention")
+    )
+    for offset, node in enumerate(new_nodes):
+        graph.node.insert(insert_at + offset, node)
+    for node in gqa_nodes:
+        node.input[5] = "gqa_seqlens_k"
+    return len(gqa_nodes)
+
+
+def save_decoder_model(
+    model: onnx.ModelProto,
+    dst: Path,
+    *,
+    external_data_name: str = DECODER_EXTERNAL_DATA,
+) -> None:
+    if not model.graph.name:
+        model.graph.name = f"{dst.stem}_graph"
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    data_path = dst.parent / external_data_name
+    if dst.exists():
+        dst.unlink()
+    if data_path.exists():
+        data_path.unlink()
+    onnx.save_model(
+        model,
+        str(dst),
+        save_as_external_data=True,
+        all_tensors_to_one_file=True,
+        location=external_data_name,
+        size_threshold=1024,
+    )
+    onnx_size = dst.stat().st_size
+    if onnx_size > 256 * 1024 * 1024:
+        raise RuntimeError(
+            f"{dst.name}: ONNX protobuf is {onnx_size} bytes; weights were not externalized to {external_data_name}"
+        )
+
+
+def _external_data_location__dup4(init: onnx.TensorProto) -> str | None:
+    if init.data_location != TensorProto.EXTERNAL:
+        return None
+    for kv in init.external_data:
+        if kv.key == "location":
+            return kv.value
+    return None
+
+
+def infer_decoder_external_data_name(src: Path, bundle_root: Path) -> str:
+    model = onnx.load(str(src), load_external_data=False)
+    locations = {
+        loc
+        for init in model.graph.initializer
+        if (loc := _external_data_location__dup4(init)) is not None
+    }
+    if len(locations) == 1:
+        return locations.pop()
+    data_files = sorted(bundle_root.glob("*.data"))
+    if data_files:
+        return data_files[0].name
+    return DECODER_EXTERNAL_DATA
+
+
+def save_model_with_external_data(
+    model: onnx.ModelProto,
+    dst: Path,
+    *,
+    rewrite_head_data: bool,
+    head_data_dir: Path | None = None,
+) -> None:
+    """Save emb/lm_head; rewrite external head blobs when present."""
+    from onnx.external_data_helper import set_external_data
+
+    if not model.graph.name:
+        model.graph.name = f"{dst.stem}_graph"
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    if dst.exists():
+        dst.unlink()
+    data_dir = head_data_dir or dst.parent
+    touched_locations: set[str] = set()
+    for init in model.graph.initializer:
+        location = _external_data_location__dup4(init)
+        if location is None:
+            continue
+        arr = numpy_helper.to_array(init)
+        out_path = data_dir / location
+        if rewrite_head_data or location not in touched_locations:
+            if rewrite_head_data and out_path.exists():
+                out_path.unlink()
+            if rewrite_head_data or not out_path.exists():
+                out_path.parent.mkdir(parents=True, exist_ok=True)
+                out_path.write_bytes(arr.tobytes())
+            touched_locations.add(location)
+        fresh = numpy_helper.from_array(arr, init.name)
+        set_external_data(fresh, location=location, offset=0, length=arr.nbytes)
+        init.CopyFrom(fresh)
+    onnx.save(model, str(dst))
+
+
+def convert_decoder_model(
+    src: Path,
+    dst: Path,
+    *,
+    shape_fix: ShapeFixConfig,
+    bundle_root: Path,
+    external_data_name: str | None = None,
+    lpnorm_fp32: bool = False,
+    gqa_seqlens_rewrite: bool = True,
+    pure_gemm: bool = False,
+    lora_dequant_meta: dict[str, dict] | None = None,
+) -> dict[str, int]:
+    model = onnx.load(str(src), load_external_data=True)
+    graph = model.graph
+    inits = {i.name: i for i in graph.initializer}
+    new_inits: dict[str, onnx.TensorProto] = {}
+    remove_inits: set[str] = set()
+    stats = {
+        "strip_qdq": strip_activation_qdq(graph),
+        "conv_mnbits": fuse_conv_transpose_to_matmul_nbits(
+            graph, inits, new_inits, remove_inits
+        ),
+        "matmul_mnbits": convert_matmul_weight_dq(
+            graph, inits, new_inits, remove_inits
+        ),
+        "matmul_mnbits_lora": 0,
+        "gemm_backbone_fold": 0,
+        "gemm_lora_fp16": 0,
+        "weight_dq_fold": 0,
+    }
+    if pure_gemm:
+        lora_meta = lora_dequant_meta if lora_dequant_meta is not None else {}
+        stats["gemm_backbone_fold"] = fold_gemm_int4_backbone_dq(
+            graph, inits, new_inits, remove_inits
+        )
+        stats["gemm_lora_fp16"] = convert_gemm_lora_input_dq_to_fp16(
+            graph, inits, remove_inits, lora_meta
+        )
+    elif has_graph_input_weight_quantized(graph):
+        stats["matmul_mnbits_lora"] = convert_matmul_graph_input_int8_dq(
+            graph, inits, new_inits, remove_inits
+        )
+    stats["weight_dq_fold"] = fold_weight_dq(graph, inits, new_inits, remove_inits)
+    apply_new_initializers(graph, new_inits)
+    prune_initializers(graph, remove_inits)
+    promote_model_to_fp16(model)
+    stats["mnbits_fp16_inputs"] = ensure_matmul_nbits_fp16_inputs__dup4(model)
+    set_matmul_nbits_accuracy_level(model)
+    if lpnorm_fp32:
+        stats["lpnorm_fp32"] = stabilize_lpnorm_fp16(model)
+        stats["gqa_getitem_fp32_removed"] = 0
+        stats["mnbits_fp16_casts_folded"] = 0
+        stats["fp32_casts_remaining"] = 0
+    else:
+        pure = optimize_fp16_activations(model)
+        stats["lpnorm_fp32"] = 0
+        stats.update(pure)
+    maybe_fix_static_shapes(model, shape_fix)
+    stats["gqa_seqlens_rewrite"] = (
+        rewrite_gqa_past_seq_len_to_seqlens_k(model) if gqa_seqlens_rewrite else 0
+    )
+    ext_name = external_data_name or infer_decoder_external_data_name(src, bundle_root)
+    save_decoder_model(model, dst, external_data_name=ext_name)
+    return stats
+
+
+def patch_emb_model(
+    src: Path,
+    dst: Path,
+    *,
+    shape_fix: ShapeFixConfig,
+    rewrite_head_data: bool,
+    head_data_dir: Path | None = None,
+    lpnorm_fp32: bool = False,
+) -> None:
+    model = onnx.load(str(src), load_external_data=True)
+    for node in model.graph.node:
+        if node.op_type != "GatherBlockQuantized":
+            continue
+        if not any((a.name == "bits" for a in node.attribute)):
+            node.attribute.extend([helper.make_attribute("bits", 4)])
+    promote_model_to_fp16(model)
+    if lpnorm_fp32:
+        stabilize_lpnorm_fp16(model)
+    maybe_fix_static_shapes(model, shape_fix)
+    save_model_with_external_data(
+        model, dst, rewrite_head_data=rewrite_head_data, head_data_dir=head_data_dir
+    )
+
+
+def convert_lm_head_model(
+    src: Path,
+    dst: Path,
+    *,
+    shape_fix: ShapeFixConfig,
+    rewrite_head_data: bool,
+    head_data_dir: Path | None = None,
+    gather_unsqueeze: bool = True,
+    lpnorm_fp32: bool = False,
+) -> None:
+    model = onnx.load(str(src), load_external_data=True)
+    promote_model_to_fp16(model)
+    set_matmul_nbits_accuracy_level(model)
+    if lpnorm_fp32:
+        stabilize_lpnorm_fp16(model)
+    maybe_fix_static_shapes(model, shape_fix)
+    if gather_unsqueeze:
+        model = rewrite_lm_head_gather_unsqueeze(model)
+    save_model_with_external_data(
+        model, dst, rewrite_head_data=rewrite_head_data, head_data_dir=head_data_dir
+    )
+
+
+def _emb_shape_fix(shape_fix: ShapeFixConfig, seq_len: int) -> ShapeFixConfig:
+    if not shape_fix.enabled:
+        return shape_fix
+    return ShapeFixConfig(
+        enabled=True,
+        batch=shape_fix.batch,
+        seq_len=seq_len,
+        max_seq_len=shape_fix.max_seq_len,
+    )
+
+
+def process_one_onnx(
+    src: Path,
+    dst: Path,
+    *,
+    kind: str,
+    shape_fix: ShapeFixConfig,
+    bundle_root: Path,
+    head_data_dir: Path,
+    rewrite_head_data: bool,
+    lm_head_gather_unsqueeze: bool = True,
+    lpnorm_fp32: bool = False,
+    gqa_seqlens_rewrite: bool = True,
+) -> dict[str, int] | None:
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    if kind == "emb":
+        patch_emb_model(
+            src,
+            dst,
+            shape_fix=shape_fix,
+            rewrite_head_data=rewrite_head_data,
+            head_data_dir=head_data_dir,
+            lpnorm_fp32=lpnorm_fp32,
+        )
+        return None
+    if kind == "lm_head":
+        convert_lm_head_model(
+            src,
+            dst,
+            shape_fix=shape_fix,
+            rewrite_head_data=rewrite_head_data,
+            head_data_dir=head_data_dir,
+            gather_unsqueeze=lm_head_gather_unsqueeze,
+            lpnorm_fp32=lpnorm_fp32,
+        )
+        return None
+    stats = convert_decoder_model(
+        src,
+        dst,
+        shape_fix=shape_fix,
+        bundle_root=bundle_root,
+        lpnorm_fp32=lpnorm_fp32,
+        gqa_seqlens_rewrite=gqa_seqlens_rewrite,
+    )
+    return stats

--- a/tools/onnx-merged-convert/merged_convert/step2_fp16_cleanup.py
+++ b/tools/onnx-merged-convert/merged_convert/step2_fp16_cleanup.py
@@ -1,0 +1,327 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import onnx
+from onnx import TensorProto, shape_inference
+
+FP32 = TensorProto.FLOAT
+FP16 = TensorProto.FLOAT16
+_PRE_CAST_CASTFP32_RE = re.compile(
+    "(?:^getitem(?:_\\d+)?_pre_cast_castfp32$|GroupQueryAttention_output_\\d+_pre_cast_castfp32$)"
+)
+
+
+def _cast_to(node: onnx.NodeProto) -> int | None:
+    if node.op_type != "Cast":
+        return None
+    for attr in node.attribute:
+        if attr.name == "to":
+            return int(attr.i)
+    return None
+
+
+def _replace_tensor_uses(graph: onnx.GraphProto, old: str, new: str) -> int:
+    if old == new:
+        return 0
+    replacements = 0
+    for node in graph.node:
+        for idx, name in enumerate(node.input):
+            if name == old:
+                node.input[idx] = new
+                replacements += 1
+    return replacements
+
+
+def _remove_nodes(graph: onnx.GraphProto, names: set[str]) -> int:
+    kept = [n for n in graph.node if n.name not in names]
+    removed = len(graph.node) - len(kept)
+    del graph.node[:]
+    graph.node.extend(kept)
+    return removed
+
+
+def unwrap_lpnorm_fp32_casts(model: onnx.ModelProto) -> int:
+    """Remove Cast(fp32)->LpNormalization->Cast(fp16) wrappers."""
+    graph = model.graph
+    remove: set[str] = set()
+    unwrapped = 0
+    for node in graph.node:
+        if node.op_type != "LpNormalization" or not node.input or (not node.output):
+            continue
+        lpnorm = node
+        pre = lpnorm.input[0]
+        post = lpnorm.output[0]
+        cast_in = next(
+            (
+                n
+                for n in graph.node
+                if n.op_type == "Cast"
+                and n.output
+                and (n.output[0] == pre)
+                and (_cast_to(n) == FP32)
+            ),
+            None,
+        )
+        cast_out = next(
+            (
+                n
+                for n in graph.node
+                if n.op_type == "Cast"
+                and n.input
+                and (n.input[0] == post)
+                and (_cast_to(n) == FP16)
+            ),
+            None,
+        )
+        if (
+            cast_in is None
+            or cast_out is None
+            or (not cast_in.input)
+            or (not cast_out.output)
+        ):
+            continue
+        fp16_src = cast_in.input[0]
+        fp16_dst = cast_out.output[0]
+        lpnorm.input[0] = fp16_src
+        lpnorm.output[0] = fp16_dst
+        remove.add(cast_in.name)
+        remove.add(cast_out.name)
+        unwrapped += 1
+    _remove_nodes(graph, remove)
+    return unwrapped
+
+
+def rewrite_gqa_pre_cast_castfp32_to_fp16(model: onnx.ModelProto) -> int:
+    """Runtime 3.2.0: keep ``pre_cast -> cast -> output_0`` wiring; use fp16 cast instead of fp32."""
+    graph = model.graph
+    changed = 0
+    for node in graph.node:
+        if node.op_type != "Cast" or _cast_to(node) != FP32:
+            continue
+        if not _PRE_CAST_CASTFP32_RE.search(node.name):
+            continue
+        for attr in node.attribute:
+            if attr.name == "to":
+                attr.i = int(FP16)
+                changed += 1
+    return changed
+
+
+def remove_gqa_getitem_fp32_casts(model: onnx.ModelProto) -> int:
+    """Bypass Cast(fp32) between GQA ``*_pre_cast`` and downstream users."""
+    graph = model.graph
+    remove: set[str] = set()
+    removed = 0
+    for node in graph.node:
+        if node.op_type != "Cast" or _cast_to(node) != FP32:
+            continue
+        if not _PRE_CAST_CASTFP32_RE.search(node.name):
+            continue
+        if not node.input or not node.output:
+            continue
+        fp16_src = node.input[0]
+        fp32_dst = node.output[0]
+        _replace_tensor_uses(graph, fp32_dst, fp16_src)
+        remove.add(node.name)
+        removed += 1
+    _remove_nodes(graph, remove)
+    return removed
+
+
+def count_fp32_activation_casts(model: onnx.ModelProto) -> int:
+    return sum(
+        (1 for n in model.graph.node if n.op_type == "Cast" and _cast_to(n) == FP32)
+    )
+
+
+def _tensor_consumer_count(graph: onnx.GraphProto, tensor: str) -> int:
+    return sum((1 for node in graph.node for inp in node.input if inp == tensor))
+
+
+def _emu_fp32_boundary_tensor(graph: onnx.GraphProto, tensor: str) -> bool:
+    """True when *tensor* is an fp32 fake-quant intermediate (must keep Cast->fp16)."""
+    if "_emu_" in tensor:
+        return True
+    producer: dict[str, onnx.NodeProto] = {}
+    for node in graph.node:
+        for out in node.output:
+            if out:
+                producer[out] = node
+    node = producer.get(tensor)
+    if node is None:
+        return False
+    if node.op_type == "Cast" and _cast_to(node) == FP32:
+        return True
+    if node.op_type in {"Div", "Add", "Round", "Sub", "Mul"} and "_emu_" in node.name:
+        return True
+    return _emu_fp32_boundary_tensor(graph, node.input[0]) if node.input else False
+
+
+def remove_redundant_mnbits_fp16_casts(model: onnx.ModelProto) -> int:
+    """Drop identity Cast(fp16) nodes that only feed MatMulNBits T1."""
+    graph = model.graph
+    producer: dict[str, onnx.NodeProto] = {}
+    for node in graph.node:
+        for out in node.output:
+            if out:
+                producer[out] = node
+    remove: set[str] = set()
+    folded = 0
+    for mmb in graph.node:
+        if mmb.op_type != "MatMulNBits" or not mmb.input:
+            continue
+        act = mmb.input[0]
+        cast = producer.get(act)
+        if cast is None or cast.op_type != "Cast" or _cast_to(cast) != FP16:
+            continue
+        if not cast.input or not cast.output:
+            continue
+        if _tensor_consumer_count(graph, act) != 1:
+            continue
+        if _emu_fp32_boundary_tensor(graph, cast.input[0]):
+            continue
+        src = cast.input[0]
+        act_out = cast.output[0]
+        if src.endswith("_pre_cast") and "GroupQueryAttention_output_" in act_out:
+            continue
+        mmb.input[0] = cast.input[0]
+        remove.add(cast.name)
+        folded += 1
+    _remove_nodes(graph, remove)
+    return folded
+
+
+def ensure_matmul_nbits_fp16_inputs(model: onnx.ModelProto) -> int:
+    """Cast MatMulNBits activations to fp16 so ORT does not mix float/float16 on T1."""
+    graph = model.graph
+    producer: dict[str, onnx.NodeProto] = {}
+    for node in graph.node:
+        for out in node.output:
+            if out:
+                producer[out] = node
+    new_nodes: list[onnx.NodeProto] = []
+    count = 0
+    for node in graph.node:
+        if node.op_type != "MatMulNBits":
+            new_nodes.append(node)
+            continue
+        src = node.input[0]
+        cast_node = producer.get(src)
+        if (
+            cast_node is not None
+            and cast_node.op_type == "Cast"
+            and (_cast_to(cast_node) == FP16)
+        ):
+            new_nodes.append(node)
+            continue
+        cast_out = f"{node.name}_act_fp16"
+        node.input[0] = cast_out
+        new_nodes.append(
+            onnx.helper.make_node(
+                "Cast", [src], [cast_out], name=f"{node.name}_act_cast", to=FP16
+            )
+        )
+        new_nodes.append(node)
+        count += 1
+    del graph.node[:]
+    graph.node.extend(new_nodes)
+    return count
+
+
+def optimize_fp16_activations(
+    model: onnx.ModelProto,
+    *,
+    clear_value_info: bool = True,
+    remove_gqa_fp32_casts: bool = True,
+    rewrite_gqa_cast_fp32_to_fp16: bool = False,
+) -> dict[str, int]:
+    """Apply all fp16 activation cleanup passes."""
+    stats = {
+        "lpnorm_unwrapped": unwrap_lpnorm_fp32_casts(model),
+        "gqa_getitem_fp32_removed": remove_gqa_getitem_fp32_casts(model)
+        if remove_gqa_fp32_casts
+        else 0,
+        "gqa_cast_fp32_to_fp16": rewrite_gqa_pre_cast_castfp32_to_fp16(model)
+        if rewrite_gqa_cast_fp32_to_fp16
+        else 0,
+        "mnbits_fp16_casts_folded": remove_redundant_mnbits_fp16_casts(model),
+        "mnbits_fp16_inputs": ensure_matmul_nbits_fp16_inputs(model),
+    }
+    if clear_value_info:
+        del model.graph.value_info[:]
+    stats["fp32_casts_remaining"] = count_fp32_activation_casts(model)
+    return stats
+
+
+def promote_pure_fp16_activations(
+    model: onnx.ModelProto, *, clear_value_info: bool = True
+) -> dict[str, int]:
+    """Strip fp32 activation casts; return rewrite stats."""
+    return optimize_fp16_activations(model, clear_value_info=clear_value_info)
+
+
+def _external_data_location__dup2(model: onnx.ModelProto) -> str | None:
+    locations = {
+        entry.value
+        for init in model.graph.initializer
+        for entry in init.external_data
+        if entry.key == "location"
+    }
+    if len(locations) == 1:
+        return locations.pop()
+    return None
+
+
+def _save_model_preserving_external_data(model: onnx.ModelProto, dst: Path) -> None:
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    if dst.exists():
+        dst.unlink()
+    ext_name = _external_data_location__dup2(model)
+    if ext_name is None:
+        data_candidates = sorted(
+            dst.parent.glob("*.data"), key=lambda p: p.stat().st_size, reverse=True
+        )
+        if data_candidates:
+            ext_name = data_candidates[0].name
+    if ext_name is not None:
+        data_path = dst.parent / ext_name
+        if not data_path.exists():
+            raise FileNotFoundError(
+                f"External weights not found for {dst.name}: {data_path}"
+            )
+        onnx.save_model(
+            model,
+            str(dst),
+            save_as_external_data=True,
+            all_tensors_to_one_file=True,
+            location=ext_name,
+            size_threshold=1024,
+        )
+        if dst.stat().st_size > 256 * 1024 * 1024:
+            raise RuntimeError(
+                f"{dst.name}: ONNX protobuf is {dst.stat().st_size} bytes after save; expected weights in {ext_name}"
+            )
+        return
+    onnx.save(model, str(dst))
+
+
+def patch_model_file(
+    src: Path, dst: Path, *, reinfer_shapes: bool = False
+) -> dict[str, int]:
+    model = onnx.load(str(src), load_external_data=True)
+    stats = optimize_fp16_activations(model)
+    if stats["fp32_casts_remaining"]:
+        raise RuntimeError(
+            f"{src.name}: {stats['fp32_casts_remaining']} Cast->fp32 node(s) remain after rewrite"
+        )
+    if reinfer_shapes:
+        model = shape_inference.infer_shapes(model)
+    _save_model_preserving_external_data(model, dst)
+    return stats

--- a/tools/onnx-merged-convert/merged_convert/step3_lm_head.py
+++ b/tools/onnx-merged-convert/merged_convert/step3_lm_head.py
@@ -1,0 +1,130 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import onnx
+from onnx import helper, numpy_helper
+
+_GATHER_NODE_NAME = "lm_head_gather"
+_GATHER_INDEX_NAME = "lm_head_gather_index"
+_UNSQUEEZE_NODE_NAME = "lm_head_unsqueeze"
+_UNSQUEEZE_AXES_NAME = "lm_head_unsqueeze_axes"
+
+
+def lm_head_has_gather_unsqueeze(model: onnx.ModelProto) -> bool:
+    return any((n.name == _GATHER_NODE_NAME for n in model.graph.node))
+
+
+def _gather_uses_const_last_index(graph: onnx.GraphProto) -> bool:
+    for node in graph.node:
+        if node.name != _GATHER_NODE_NAME or node.op_type != "Gather":
+            continue
+        if len(node.input) < 2 or node.input[1] != _GATHER_INDEX_NAME:
+            return False
+        for init in graph.initializer:
+            if init.name == _GATHER_INDEX_NAME:
+                return numpy_helper.to_array(init).item() == -1
+        return False
+    return False
+
+
+def _migrate_gather_index_input_to_const(graph: onnx.GraphProto) -> bool:
+    """Replace legacy ``head_token_index`` graph input with const ``-1`` initializer."""
+    gather = next((n for n in graph.node if n.name == _GATHER_NODE_NAME), None)
+    if gather is None or len(gather.input) < 2:
+        return False
+    index_name = gather.input[1]
+    legacy_names = {"head_token_index", "head_head_token_index"}
+    if index_name not in legacy_names and index_name != _GATHER_INDEX_NAME:
+        return False
+    if index_name == _GATHER_INDEX_NAME and _gather_uses_const_last_index(graph):
+        return False
+    gather.input[1] = _GATHER_INDEX_NAME
+    if not any((init.name == _GATHER_INDEX_NAME for init in graph.initializer)):
+        graph.initializer.append(
+            numpy_helper.from_array(
+                np.array(-1, dtype=np.int64), name=_GATHER_INDEX_NAME
+            )
+        )
+    graph.input[:] = [vi for vi in graph.input if vi.name not in legacy_names]
+    return True
+
+
+def rewrite_lm_head_gather_unsqueeze(model: onnx.ModelProto) -> onnx.ModelProto:
+    """Return *model* with Gather+Unsqueeze inserted before MatMulNBits."""
+    if lm_head_has_gather_unsqueeze(model):
+        if _migrate_gather_index_input_to_const(model.graph):
+            onnx.checker.check_model(model)
+        return model
+    graph = model.graph
+    mm_nodes = [n for n in graph.node if n.op_type == "MatMulNBits"]
+    if len(mm_nodes) != 1:
+        raise ValueError(
+            f"Expected exactly one MatMulNBits node in lm_head, found {len(mm_nodes)}"
+        )
+    mm_node = mm_nodes[0]
+    hidden_input = mm_node.input[0]
+    logits_output = mm_node.output[0]
+    gathered_name = "lm_head_gathered"
+    mm_input_name = "lm_head_mm_input"
+    graph.initializer.extend(
+        [
+            numpy_helper.from_array(
+                np.array(-1, dtype=np.int64), name=_GATHER_INDEX_NAME
+            ),
+            numpy_helper.from_array(
+                np.array([1], dtype=np.int64), name=_UNSQUEEZE_AXES_NAME
+            ),
+        ]
+    )
+    gather_node = helper.make_node(
+        "Gather",
+        [hidden_input, _GATHER_INDEX_NAME],
+        [gathered_name],
+        name=_GATHER_NODE_NAME,
+        axis=1,
+    )
+    unsqueeze_node = helper.make_node(
+        "Unsqueeze",
+        [gathered_name, _UNSQUEEZE_AXES_NAME],
+        [mm_input_name],
+        name=_UNSQUEEZE_NODE_NAME,
+    )
+    mm_idx = next((i for i, n in enumerate(graph.node) if n is mm_node))
+    graph.node.insert(mm_idx, gather_node)
+    graph.node.insert(mm_idx + 1, unsqueeze_node)
+    mm_node.input[0] = mm_input_name
+    for vi in graph.output:
+        if vi.name != logits_output:
+            continue
+        dims = vi.type.tensor_type.shape.dim
+        if len(dims) >= 2:
+            dims[1].ClearField("dim_param")
+            dims[1].dim_value = 1
+    onnx.checker.check_model(model)
+    return model
+
+
+def rewrite_lm_head_file(src: Path, dst: Path | None = None) -> Path:
+    """Rewrite *src* and save to *dst* (default: ``<stem>_gather.onnx``)."""
+    src = Path(src)
+    dst = (
+        Path(dst)
+        if dst is not None
+        else src.with_name(f"{src.stem}_gather{src.suffix}")
+    )
+    if dst.exists() and dst.stat().st_mtime >= src.stat().st_mtime:
+        return dst
+    model = onnx.load(str(src), load_external_data=True)
+    model = rewrite_lm_head_gather_unsqueeze(model)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    if dst.exists():
+        dst.unlink()
+    onnx.save(model, str(dst))
+    return dst

--- a/tools/onnx-merged-convert/merged_convert/step4_unfix_seq_len.py
+++ b/tools/onnx-merged-convert/merged_convert/step4_unfix_seq_len.py
@@ -1,0 +1,400 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+
+from __future__ import annotations
+
+import json
+import sys
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+import onnx
+from onnx import numpy_helper, shape_inference
+
+SEQ_LEN_PARAM = "seq_len"
+DEFAULT_STATIC_SEQ_LENS = (1, 128)
+
+
+def _dim_to_obj(dim) -> int | str | None:
+    if dim.dim_param:
+        return dim.dim_param
+    if dim.dim_value:
+        return int(dim.dim_value)
+    return None
+
+
+def _shape_tuple(vi: onnx.ValueInfoProto) -> tuple | None:
+    tt = vi.type.tensor_type
+    if not tt.HasField("shape"):
+        return None
+    return tuple((_dim_to_obj(d) for d in tt.shape.dim))
+
+
+def _load_model(path: Path, *, load_external: bool) -> onnx.ModelProto:
+    return onnx.load(str(path), load_external_data=load_external)
+
+
+def _maybe_infer_shapes(model: onnx.ModelProto) -> onnx.ModelProto:
+    try:
+        return shape_inference.infer_shapes(model)
+    except Exception as exc:
+        print(f"WARNING: shape inference failed: {exc}", file=sys.stderr)
+        return model
+
+
+def _collect_shapes(model: onnx.ModelProto) -> dict[str, tuple]:
+    shapes: dict[str, tuple] = {}
+    graph = model.graph
+    for vi in list(graph.input) + list(graph.output) + list(graph.value_info):
+        shape = _shape_tuple(vi)
+        if shape is not None:
+            shapes[vi.name] = shape
+    return shapes
+
+
+def _initializer_map(
+    model: onnx.ModelProto, *, load_values: bool
+) -> dict[str, np.ndarray | None]:
+    out: dict[str, np.ndarray | None] = {}
+    for init in model.graph.initializer:
+        if load_values:
+            out[init.name] = numpy_helper.to_array(init)
+        else:
+            out[init.name] = None
+    return out
+
+
+@dataclass
+class SeqLenAxis:
+    tensor: str
+    axis: int
+    value_a: int
+    value_b: int
+
+
+@dataclass
+class CompareReport:
+    model_a: str
+    model_b: str
+    node_count_a: int
+    node_count_b: int
+    graph_structure_match: bool
+    initializer_value_diffs: int
+    tensor_shape_diffs: list[tuple[str, tuple, tuple]] = field(default_factory=list)
+    seq_len_axes: list[SeqLenAxis] = field(default_factory=list)
+    node_io_diffs: list[dict] = field(default_factory=list)
+    axis_pattern_counts: dict[str, int] = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return {
+            "model_a": self.model_a,
+            "model_b": self.model_b,
+            "node_count_a": self.node_count_a,
+            "node_count_b": self.node_count_b,
+            "graph_structure_match": self.graph_structure_match,
+            "initializer_value_diffs": self.initializer_value_diffs,
+            "tensor_shape_diff_count": len(self.tensor_shape_diffs),
+            "tensor_shape_diffs": [
+                {"tensor": n, "shape_a": list(a), "shape_b": list(b)}
+                for n, a, b in self.tensor_shape_diffs
+            ],
+            "seq_len_axes": [
+                {
+                    "tensor": s.tensor,
+                    "axis": s.axis,
+                    "value_a": s.value_a,
+                    "value_b": s.value_b,
+                }
+                for s in self.seq_len_axes
+            ],
+            "node_io_diff_count": len(self.node_io_diffs),
+            "node_io_diffs": self.node_io_diffs,
+            "axis_pattern_counts": self.axis_pattern_counts,
+        }
+
+
+def _graph_structure_match(model_a: onnx.ModelProto, model_b: onnx.ModelProto) -> bool:
+    nodes_a = model_a.graph.node
+    nodes_b = model_b.graph.node
+    if len(nodes_a) != len(nodes_b):
+        return False
+    for na, nb in zip(nodes_a, nodes_b):
+        if (
+            na.op_type != nb.op_type
+            or na.name != nb.name
+            or na.input != nb.input
+            or (na.output != nb.output)
+        ):
+            return False
+    return True
+
+
+def _detect_seq_len_axes(
+    shape_a: tuple, shape_b: tuple, tensor_name: str, static_seq_lens: tuple[int, ...]
+) -> list[SeqLenAxis]:
+    hits: list[SeqLenAxis] = []
+    if len(shape_a) != len(shape_b):
+        return hits
+    values = set(static_seq_lens)
+    for axis, (va, vb) in enumerate(zip(shape_a, shape_b)):
+        if (
+            isinstance(va, int)
+            and isinstance(vb, int)
+            and (va in values)
+            and (vb in values)
+            and (va != vb)
+        ):
+            hits.append(
+                SeqLenAxis(tensor=tensor_name, axis=axis, value_a=va, value_b=vb)
+            )
+    return hits
+
+
+def compare_models(
+    path_a: Path,
+    path_b: Path,
+    *,
+    infer_shapes: bool = True,
+    static_seq_lens: tuple[int, ...] = DEFAULT_STATIC_SEQ_LENS,
+    load_external: bool = True,
+) -> CompareReport:
+    model_a = _load_model(path_a, load_external=load_external)
+    model_b = _load_model(path_b, load_external=load_external)
+    if infer_shapes:
+        model_a = _maybe_infer_shapes(model_a)
+        model_b = _maybe_infer_shapes(model_b)
+    shapes_a = _collect_shapes(model_a)
+    shapes_b = _collect_shapes(model_b)
+    tensor_diffs: list[tuple[str, tuple, tuple]] = []
+    seq_axes: list[SeqLenAxis] = []
+    axis_counter: Counter[tuple[int, int, int]] = Counter()
+    for name in sorted(set(shapes_a) | set(shapes_b)):
+        sa, sb = (shapes_a.get(name), shapes_b.get(name))
+        if sa == sb:
+            continue
+        if sa is None or sb is None:
+            tensor_diffs.append((name, sa or (), sb or ()))
+            continue
+        tensor_diffs.append((name, sa, sb))
+        for hit in _detect_seq_len_axes(sa, sb, name, static_seq_lens):
+            seq_axes.append(hit)
+            axis_counter[hit.axis, hit.value_a, hit.value_b] += 1
+    node_io_diffs: list[dict] = []
+    nodes_a = list(model_a.graph.node)
+    nodes_b = list(model_b.graph.node)
+    for idx, (na, nb) in enumerate(zip(nodes_a, nodes_b)):
+        if na.op_type != nb.op_type or na.name != nb.name:
+            node_io_diffs.append(
+                {
+                    "node_index": idx,
+                    "kind": "structure",
+                    "node_a": na.name,
+                    "node_b": nb.name,
+                    "op_a": na.op_type,
+                    "op_b": nb.op_type,
+                }
+            )
+            continue
+        for io_kind, names in (("input", na.input), ("output", na.output)):
+            for tensor in names:
+                if not tensor:
+                    continue
+                sa, sb = (shapes_a.get(tensor), shapes_b.get(tensor))
+                if sa != sb:
+                    node_io_diffs.append(
+                        {
+                            "node_index": idx,
+                            "kind": io_kind,
+                            "node": na.name,
+                            "op_type": na.op_type,
+                            "tensor": tensor,
+                            "shape_a": list(sa) if sa else None,
+                            "shape_b": list(sb) if sb else None,
+                        }
+                    )
+    init_a = _initializer_map(model_a, load_values=load_external)
+    init_b = _initializer_map(model_b, load_values=load_external)
+    init_diffs = 0
+    if load_external:
+        for name in sorted(set(init_a) & set(init_b)):
+            a, b = (init_a[name], init_b[name])
+            if a is None or b is None:
+                continue
+            if a.shape != b.shape or a.dtype != b.dtype or (not np.array_equal(a, b)):
+                init_diffs += 1
+    return CompareReport(
+        model_a=str(path_a),
+        model_b=str(path_b),
+        node_count_a=len(nodes_a),
+        node_count_b=len(nodes_b),
+        graph_structure_match=_graph_structure_match(model_a, model_b),
+        initializer_value_diffs=init_diffs,
+        tensor_shape_diffs=tensor_diffs,
+        seq_len_axes=seq_axes,
+        node_io_diffs=node_io_diffs,
+        axis_pattern_counts={
+            f"axis={axis} ({va} vs {vb})": count
+            for (axis, va, vb), count in axis_counter.most_common()
+        },
+    )
+
+
+def _set_dim_param(vi: onnx.ValueInfoProto, axis: int, param: str) -> None:
+    dim = vi.type.tensor_type.shape.dim[axis]
+    dim.ClearField("dim_value")
+    dim.dim_param = param
+
+
+def _apply_seq_len_bindings(
+    model: onnx.ModelProto,
+    bindings: dict[str, set[int]],
+    *,
+    seq_len_param: str,
+    clear_value_info: bool,
+) -> int:
+    """Replace marked axes with ``seq_len_param`` on graph inputs/outputs."""
+    changed = 0
+    graph = model.graph
+    if clear_value_info:
+        del graph.value_info[:]
+    for vi in list(graph.input) + list(graph.output):
+        shape = _shape_tuple(vi)
+        if shape is None:
+            continue
+        axes = bindings.get(vi.name)
+        if not axes:
+            continue
+        for axis in sorted(axes):
+            if axis >= len(shape):
+                continue
+            _set_dim_param(vi, axis, seq_len_param)
+            changed += 1
+    return changed
+
+
+def _external_data_location(model: onnx.ModelProto) -> str | None:
+    locations = {
+        entry.value
+        for init in model.graph.initializer
+        for entry in init.external_data
+        if entry.key == "location"
+    }
+    if len(locations) == 1:
+        return locations.pop()
+    return None
+
+
+def _save_unfixed_model(model: onnx.ModelProto, out_path: Path) -> None:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    if out_path.exists():
+        out_path.unlink()
+    ext_name = _external_data_location(model)
+    if ext_name is not None:
+        data_path = out_path.parent / ext_name
+        if not data_path.exists():
+            raise FileNotFoundError(
+                f"External weights not found for {out_path.name}: {data_path}"
+            )
+        onnx.save_model(
+            model,
+            str(out_path),
+            save_as_external_data=True,
+            all_tensors_to_one_file=True,
+            location=ext_name,
+            size_threshold=65536,
+        )
+        return
+    onnx.save(model, str(out_path))
+
+
+def unfix_seq_len(
+    src_path: Path,
+    ref_path_a: Path,
+    ref_path_b: Path,
+    out_path: Path,
+    *,
+    static_seq_lens: tuple[int, ...] = DEFAULT_STATIC_SEQ_LENS,
+    seq_len_param: str = SEQ_LEN_PARAM,
+    clear_value_info: bool = True,
+    reinfer_shapes: bool = False,
+) -> CompareReport:
+    report = compare_models(
+        ref_path_a,
+        ref_path_b,
+        infer_shapes=True,
+        static_seq_lens=static_seq_lens,
+        load_external=False,
+    )
+    if not report.graph_structure_match:
+        raise ValueError(
+            f"Graph structure mismatch between {ref_path_a.name} and {ref_path_b.name}"
+        )
+    if report.initializer_value_diffs:
+        raise ValueError(
+            f"Expected identical initializers, found {report.initializer_value_diffs} diffs"
+        )
+    if not report.seq_len_axes:
+        raise ValueError("No seq_len candidate axes detected between reference models")
+    bindings: dict[str, set[int]] = defaultdict(set)
+    for hit in report.seq_len_axes:
+        bindings[hit.tensor].add(hit.axis)
+    io_names = {
+        vi.name for vi in _load_model(src_path, load_external=False).graph.input
+    }
+    io_names.update(
+        (vi.name for vi in _load_model(src_path, load_external=False).graph.output)
+    )
+    io_bindings = {name: axes for name, axes in bindings.items() if name in io_names}
+    if not io_bindings:
+        raise ValueError(
+            "Seq_len axes were found only on intermediates; missing graph I/O bindings"
+        )
+    model = _load_model(src_path, load_external=False)
+    changed = _apply_seq_len_bindings(
+        model,
+        io_bindings,
+        seq_len_param=seq_len_param,
+        clear_value_info=clear_value_info,
+    )
+    if reinfer_shapes:
+        model = _maybe_infer_shapes(model)
+    _save_unfixed_model(model, out_path)
+    print(f"Wrote dynamic decoder: {out_path}")
+    print(f"  rebound {changed} input/output dimension(s) to '{seq_len_param}'")
+    for name in sorted(io_bindings):
+        axes = sorted(io_bindings[name])
+        print(f"  {name}: axis {axes} -> {seq_len_param}")
+    if clear_value_info:
+        print("  cleared stale graph.value_info")
+    return report
+
+
+def _print_compare_report(report: CompareReport, *, json_out: Path | None) -> None:
+    print(f"Model A: {report.model_a}")
+    print(f"Model B: {report.model_b}")
+    print(f"Nodes: {report.node_count_a} / {report.node_count_b}")
+    print(f"Graph structure match: {report.graph_structure_match}")
+    print(f"Initializer value diffs: {report.initializer_value_diffs}")
+    print(f"Tensor shape diffs: {len(report.tensor_shape_diffs)}")
+    print(f"Seq_len candidate axes: {len(report.seq_len_axes)}")
+    for hit in report.seq_len_axes:
+        print(
+            f"  {hit.tensor}[axis={hit.axis}]: {hit.value_a} vs {hit.value_b} -> {SEQ_LEN_PARAM}"
+        )
+    if report.axis_pattern_counts:
+        print("Axis patterns (1 vs 128):")
+        for key, count in report.axis_pattern_counts.items():
+            print(f"  {key}: {count} tensor(s)")
+    print(f"Node I/O shape diffs: {len(report.node_io_diffs)}")
+    for row in report.node_io_diffs[:40]:
+        print(f"  {row}")
+    if len(report.node_io_diffs) > 40:
+        print(f"  ... and {len(report.node_io_diffs) - 40} more")
+    if json_out is not None:
+        json_out.parent.mkdir(parents=True, exist_ok=True)
+        json_out.write_text(json.dumps(report.to_dict(), indent=2), encoding="utf-8")
+        print(f"JSON report: {json_out}")

--- a/tools/onnx-merged-convert/merged_convert/step5_merge.py
+++ b/tools/onnx-merged-convert/merged_convert/step5_merge.py
@@ -1,0 +1,193 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+
+from __future__ import annotations
+
+from collections import deque
+from pathlib import Path
+
+import onnx
+from onnx import TensorProto, helper, numpy_helper
+from onnx.compose import add_prefix, merge_graphs
+
+
+_PIPELINE_PREFIXES = ("emb_", "dec_", "head_")
+DEFAULT_EXTERNAL_DATA = "merged.data"
+
+
+def _align_model_ir_version(model: onnx.ModelProto, ir_version: int) -> None:
+    model.ir_version = ir_version
+
+
+def _topological_sort_graph(graph: onnx.GraphProto) -> None:
+    nodes = list(graph.node)
+    if not nodes:
+        return
+    node_by_name = {n.name: n for n in nodes}
+    producers: dict[str, str] = {}
+    for node in nodes:
+        for out in node.output:
+            if out:
+                producers[out] = node.name
+    init_names = {init.name for init in graph.initializer}
+    input_names = {inp.name for inp in graph.input}
+    deps: dict[str, set[str]] = {}
+    for node in nodes:
+        dep: set[str] = set()
+        for inp in node.input:
+            if not inp or inp in input_names or inp in init_names:
+                continue
+            prod = producers.get(inp)
+            if prod and prod != node.name:
+                dep.add(prod)
+        deps[node.name] = dep
+    in_degree = {node.name: len(deps[node.name]) for node in nodes}
+    children: dict[str, set[str]] = {node.name: set() for node in nodes}
+    for node in nodes:
+        for dep in deps[node.name]:
+            children[dep].add(node.name)
+    queue = deque((node for node in nodes if in_degree[node.name] == 0))
+    sorted_nodes: list[onnx.NodeProto] = []
+    while queue:
+        node = queue.popleft()
+        sorted_nodes.append(node)
+        for child_name in children[node.name]:
+            in_degree[child_name] -= 1
+            if in_degree[child_name] == 0:
+                sorted_nodes.append(node_by_name[child_name])
+    if len(sorted_nodes) != len(nodes):
+        seen = {node.name for node in sorted_nodes}
+        sorted_nodes.extend((node for node in nodes if node.name not in seen))
+    del graph.node[:]
+    graph.node.extend(sorted_nodes)
+
+
+def _rename_tensors_in_graph(graph: onnx.GraphProto, mapping: dict[str, str]) -> None:
+    if not mapping:
+        return
+    for node in graph.node:
+        for idx, name in enumerate(node.input):
+            if name in mapping:
+                node.input[idx] = mapping[name]
+        for idx, name in enumerate(node.output):
+            if name in mapping:
+                node.output[idx] = mapping[name]
+    for vi in list(graph.input) + list(graph.output) + list(graph.value_info):
+        if vi.name in mapping:
+            vi.name = mapping[vi.name]
+    for init in graph.initializer:
+        if init.name in mapping:
+            init.name = mapping[init.name]
+
+
+def _pipeline_boundary_renames(graph: onnx.GraphProto) -> dict[str, str]:
+    """Map prefixed merge tensors back to split-pipeline I/O names."""
+    mapping: dict[str, str] = {
+        "emb_input_ids": "input_ids",
+        "dec_past_seq_len": "past_seq_len",
+        "dec_total_seq_len": "total_seq_len",
+        "head_logits": "logits",
+    }
+    for vi in list(graph.input) + list(graph.output):
+        name = vi.name
+        if name.startswith("dec_past_keys_"):
+            mapping[name] = name.removeprefix("dec_")
+        elif name.startswith("dec_past_values_"):
+            mapping[name] = name.removeprefix("dec_")
+        elif name.startswith("dec_present_keys_"):
+            mapping[name] = name.removeprefix("dec_")
+        elif name.startswith("dec_present_values_"):
+            mapping[name] = name.removeprefix("dec_")
+        elif name.startswith("dec_model.") and name.endswith("weight_quantized"):
+            mapping[name] = name.removeprefix("dec_")
+        elif name.startswith("dec_model.") and name.endswith("weight_fp16"):
+            mapping[name] = name.removeprefix("dec_")
+    return mapping
+
+
+def _merged_opset_imports(*models: onnx.ModelProto) -> list[onnx.OperatorSetIdProto]:
+    versions: dict[str, int] = {}
+    for model in models:
+        for oi in model.opset_import:
+            versions[oi.domain] = max(versions.get(oi.domain, 0), int(oi.version))
+    return [
+        helper.make_opsetid(domain, ver) for domain, ver in sorted(versions.items())
+    ]
+
+
+def _inline_small_external_initializers(
+    model: onnx.ModelProto, *, max_bytes: int = 65536
+) -> int:
+    """ORT shape inference requires shape-like constants inline, not in .data."""
+    inlined = 0
+    for init in model.graph.initializer:
+        if init.data_location != TensorProto.EXTERNAL:
+            continue
+        arr = numpy_helper.to_array(init)
+        if arr.nbytes > max_bytes:
+            continue
+        init.CopyFrom(numpy_helper.from_array(arr, name=init.name))
+        inlined += 1
+    return inlined
+
+
+def merge_split_pipeline_models(
+    emb_path: Path,
+    decoder_path: Path,
+    head_path: Path,
+    dst_path: Path,
+    *,
+    external_data_name: str = DEFAULT_EXTERNAL_DATA,
+) -> Path:
+    """Fuse emb -> decoder -> lm_head into one ONNX."""
+    emb = onnx.load(str(emb_path), load_external_data=True)
+    decoder = onnx.load(str(decoder_path), load_external_data=True)
+    head = onnx.load(str(head_path), load_external_data=True)
+    target_ir = max(emb.ir_version, decoder.ir_version, head.ir_version)
+    _align_model_ir_version(emb, target_ir)
+    _align_model_ir_version(head, target_ir)
+    emb_p = add_prefix(emb, prefix=_PIPELINE_PREFIXES[0])
+    dec_p = add_prefix(decoder, prefix=_PIPELINE_PREFIXES[1])
+    head_p = add_prefix(head, prefix=_PIPELINE_PREFIXES[2])
+    graph = merge_graphs(
+        emb_p.graph,
+        dec_p.graph,
+        io_map=[("emb_input_hidden_states", "dec_input_hidden_states")],
+    )
+    kv_outputs = [out.name for out in graph.output if "present_" in out.name]
+    graph = merge_graphs(
+        graph,
+        head_p.graph,
+        io_map=[("dec_output_hidden_states", "head_output_hidden_states")],
+        outputs=["head_logits", *kv_outputs],
+    )
+    _topological_sort_graph(graph)
+    _rename_tensors_in_graph(graph, _pipeline_boundary_renames(graph))
+    logits_out = next((vi for vi in graph.output if vi.name == "logits"), None)
+    if logits_out is not None:
+        other_outs = [vi for vi in graph.output if vi.name != "logits"]
+        del graph.output[:]
+        graph.output.extend([logits_out, *other_outs])
+    model = helper.make_model(
+        graph, opset_imports=_merged_opset_imports(emb, decoder, head)
+    )
+    model.ir_version = target_ir
+    model.graph.name = f"{dst_path.stem}_graph"
+    _inline_small_external_initializers(model)
+    dst_path.parent.mkdir(parents=True, exist_ok=True)
+    data_path = dst_path.parent / external_data_name
+    if dst_path.exists():
+        dst_path.unlink()
+    if data_path.exists():
+        data_path.unlink()
+    onnx.save_model(
+        model,
+        str(dst_path),
+        save_as_external_data=True,
+        all_tensors_to_one_file=True,
+        location=external_data_name,
+        size_threshold=65536,
+    )
+    return dst_path

--- a/tools/onnx-merged-convert/run_merged_convert.py
+++ b/tools/onnx-merged-convert/run_merged_convert.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""Entry point for split-pipeline -> merged ONNX conversion.
+
+See README.md for usage.
+Implementation lives in the ``merged_convert`` package.
+"""
+
+from merged_convert.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
<!--
Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
Licensed under the MIT License.
-->

<!--
Thank you for contributing. Keep the description proportional to the change
and review it for accuracy before requesting review. See CONTRIBUTING.md for
the full workflow and AI-assistance disclosure requirements.
-->

## Summary

Add tools/onnx-merged-convert, a standalone Python tool that converts a split ORT GenAI inference bundle (embedding, decoder prefill/decode, lm_head) into a single merged ONNX model plus an updated genai_config.json.

Developers can point the tool at a model bundle directory and get a merged artifact suitable for single-graph GenAI inference on AMDGPU (profile: hip), without hand-editing ONNX graphs or config files.

## Related issue or design

None

## Why

Split-pipeline exports are useful for compilation and debugging, but GenAI deployment often needs one merged graph with dynamic seq_len, FP16 activations, pruned logits, and a config that uses input_ids at the model boundary.

This logic was previously only available as ad-hoc scripts. Checking it into tools/ makes the workflow reproducible and documents the expected bundle layout and conversion steps.

## What

+ Add tools/onnx-merged-convert/run_merged_convert.py as the CLI entry point.
+ Add tools/onnx-merged-convert/merged_convert/ with modular conversion steps:

  - step1_qdq_fp16.py — activation Q/DQ removal and FP16 promotion
  - step2_fp16_cleanup.py — FP16 activation cleanup (also post-merge)
  - step3_lm_head.py — lm_head Gather + Unsqueeze for pruned logits [1, 1, vocab]
  - step4_unfix_seq_len.py — rebind prefill/decode seq_len axes to dynamic seq_len
  - step5_merge.py — fuse embedding + decoder + lm_head
  - qdq_ext.py / int8kv.py — low-bit and int8-KV pipeline paths
  - bundle.py — bundle detection and genai_config.json generation
  - pipeline.py — orchestration for quantized_linear, int8_kv, and low_bit

+ Add tools/onnx-merged-convert/README.md with usage, input layout, pipeline behavior, and module map.

**Outputs**: {decoder_stem}_merged.onnx, {decoder_stem}_merged.data, genai_config.json (and optionally lora_dequant.json / adapter.safetensors for folded-Gemm bundles).

## Test plan

- [x] python tools/onnx-merged-convert/run_merged_convert.py --help — CLI loads successfully
- [x] Tested on multiple splitting models

## Notes for reviewers

- Pipeline kind is inferred from the decoder prefill graph (quantized_linear, int8_kv, or low_bit); there is no --pipeline override yet.
- Merge assumes split-export boundary tensor names (input_hidden_states, output_hidden_states, etc.); bundles must match the expected split layout documented in the README.
- Three merge code paths remain (step5_merge, int8kv.merge_pipeline, qdq_ext.merge_quantized_pipeline_models) for the three pipeline types; behavior is intentionally similar but not fully unified.
- No compiler/runtime/EP code is changed; this is a standalone offline tool under tools/.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [ ] Relevant tests were added or updated and the results are documented.
- [x] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.
