### PR TITLE
fix(pipeline): reconcile unrealized casts after convert-hip-to-llvm

### DIFF
--- a/lib/Dialect/Transforms/Pipelines.cpp
+++ b/lib/Dialect/Transforms/Pipelines.cpp
@@ -446,7 +446,7 @@ void mlir::hip::buildHipToLLVMPipeline(
   pm.addPass(createReconcileUnrealizedCastsPass());
 
   pm.addPass(createConvertHipToLLVMPass());
-  
+
   // convert-hip-to-llvm runs applyPartialConversion, which cleans up the
   // unrealized casts it materializes only when both the producer and every
   // consumer of a value get converted in that same run. The upstream

--- a/lib/Dialect/Transforms/Pipelines.cpp
+++ b/lib/Dialect/Transforms/Pipelines.cpp
@@ -446,7 +446,23 @@ void mlir::hip::buildHipToLLVMPipeline(
   pm.addPass(createReconcileUnrealizedCastsPass());
 
   pm.addPass(createConvertHipToLLVMPass());
-
+  
+  // convert-hip-to-llvm runs applyPartialConversion, which cleans up the
+  // unrealized casts it materializes only when both the producer and every
+  // consumer of a value get converted in that same run. The upstream
+  // memref->LLVM descriptor builders (populateFinalizeMemRefToLLVMConversion
+  // Patterns) can still leave a dead `i64 -> index -> index -> i64` round-trip
+  // when lowering a dynamic-shaped result descriptor: e.g. a memref.reshape
+  // feeding a hip.matmul_nbits output whose middle dim is data-dependent
+  // (dynamic sequence length in the Gemma qmoe vision encoder) loads each
+  // dynamic size as i64 and bounces it through `index` while assembling the
+  // descriptor's sizes[]/strides[]. Those casts have no LLVM translation, so
+  // MLIR->LLVM export aborts with "LLVM Translation failed for operation:
+  // builtin.unrealized_conversion_cast". The earlier reconcile (before
+  // convert-hip-to-llvm) cannot see them because they are introduced by this
+  // pass; reconcile again here to fold the round-trips away. No-op on graphs
+  // that leave no residual casts.
+  pm.addPass(createReconcileUnrealizedCastsPass());
   mlir::hip::CompilationOptionsT compOpts;
   compOpts.constants_file = options.constantsFile;
   // convert-hip-to-llvm (above) rewrites @main_graph to the 2-arg


### PR DESCRIPTION

## Summary

`reconcile-unrealized-casts` can only clean up the redundant type conversions that "already exist at the moment it runs"; it cannot touch ones produced later. So the conversions that `convert-hip-to-llvm` newly emits must be cleaned again **after** it.

1. A compile pipeline is a sequence of passes run **in order**; each pass only sees the result produced by all the passes before it.
2. `builtin.unrealized_conversion_cast` is a temporary "type adapter" in MLIR. It **cannot** be translated to LLVM IR; if it survives to the end, compilation fails with:
   `LLVM Translation failed for operation: builtin.unrealized_conversion_cast`.

### The two reconciles in the pipeline

```
line 445  SCFToControlFlow          // lowers scf.for/scf.if, leaves some casts
line 446  ReconcileUnrealizedCasts  // cleans up the casts above
line 448  ConvertHipToLLVM          // during conversion [newly emits] some casts
line 465  ReconcileUnrealizedCasts  // cleans up the casts from line 448  <- newly added
```
- Line 446 runs **before** `convert-hip-to-llvm` (line 448); it cleans up the casts left by the earlier `SCFToControlFlow`.
- `convert-hip-to-llvm` at line 448 **newly emits** a batch of redundant round-trip casts during conversion: `i64 → index → i64`.
- Those casts **do not exist yet** when line 446 runs, so that reconcile simply cannot clean them.
- Therefore line 465 is needed to reconcile once more **after** `convert-hip-to-llvm`; otherwise those casts survive to the translation stage and break the compile.

## Notes for reviewers

<!--
- Known limitations and what they would take to fix.
- Follow-ups already planned (link the design issue / next PR).
- Anything load-bearing that isn't obvious from the diff (invariants,
  ABI assumptions, ordering constraints).
- "None" is a valid answer if the PR is small and self-contained.
-->

<!--
============================================================
Optional sections — include when applicable. Delete this whole
block if you don't need any of them.
============================================================

## Compiler IR walkthrough

<details>
<summary><b>Before</b> — short description</summary>

```mlir
// IR before this PR's pass / lowering
```

</details>

<details>
<summary><b>After</b> — short description</summary>

```mlir
// IR after this PR's pass / lowering
```

</details>

## Performance

<details>
<summary>Short headline result (e.g. "22x over DML EP on …")</summary>

| Metric | This PR | Baseline | Ratio |
|---|---:|---:|---:|
| Inferences/sec | … | … | … |
| Mean latency | … | … | … |

Hardware: gfxNNNN, model: <name>, build: <flags>.

</details>

============================================================
-->

## Checklist

- [ ] **Incremental.** This PR is either standalone, or a planned step
      in a documented series. If it exceeds ~500 LOC or ~10 files, the
      Summary / Why explains why it cannot be split, OR links the
      precursor PRs and the design issue. See:
      https://llvm.org/docs/DeveloperPolicy.html#incremental-development
- [ ] **AI policy.** If AI tools (Cursor, Claude, Copilot, etc.)
      generated substantial code or text, the Summary discloses it,
      the commit messages carry the trailers documented in
      [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md#commit-message-trailers),
      and you can answer questions about each design decision in
      review without delegating back to the tool. See:
      https://llvm.org/docs/AIToolPolicy.html
- [ ] **No `good first issue` automation.** This PR is not an AI-tool
      fix to an issue tagged `good first issue` (those are reserved as
      learning opportunities for new contributors).
- [ ] **Reviews resolved.** All review-comment threads from prior
      rounds are resolved (enforced by branch protection on `main`).
- [ ] **CODEOWNERS routing.** Reviewers were assigned automatically by
      [`CODEOWNERS`](../blob/main/.github/CODEOWNERS). If the change
      touches a path outside the current ownership map, the PR
      description names the operational owner.
