### PR TITLE
fix(hipsr): preserve device address spaces in LLVM lowering

### DIFF
--- a/lib/Dialect/Hipsr/IR/HipsrAddOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrAddOp.cpp
@@ -74,7 +74,9 @@ struct AddLowering : public ConvertOpToLLVMPattern<AddOp> {
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op.getLoc();
     ModuleOp module = op->getParentOfType<ModuleOp>();
-    Type ptrType = getPtrType();
+    MLIRContext *ctx = rewriter.getContext();
+    Type hostPtrType = LLVM::LLVMPointerType::get(ctx, 0);
+    Type devicePtrType = LLVM::LLVMPointerType::get(ctx, 1);
     Type i32Type = rewriter.getI32Type();
     Type i64Type = rewriter.getI64Type();
 
@@ -109,11 +111,10 @@ struct AddLowering : public ConvertOpToLLVMPattern<AddOp> {
                                       rewriter.getI64IntegerAttr(v));
     };
 
-    SmallVector<Type, 19> paramTypes = {ptrType, i32Type, ptrType, ptrType,
-                                        ptrType};
+    SmallVector<Type, 19> paramTypes = {hostPtrType, i32Type, devicePtrType,
+                                        devicePtrType, devicePtrType};
     paramTypes.append(14, i64Type);
 
-    // TODO: the runtime function should use !llvm.ptr<1> (GPU) pointers.
     FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
         rewriter, module, kWrapMiopenOpTensor, paramTypes, i32Type);
     if (failed(funcOp)) {

--- a/lib/Dialect/Hipsr/IR/HipsrConstantOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrConstantOp.cpp
@@ -55,7 +55,8 @@ struct ConstantLowering : public ConvertOpToLLVMPattern<ConstantOp> {
     Location loc = op.getLoc();
     ModuleOp module = op->getParentOfType<ModuleOp>();
     MLIRContext *ctx = rewriter.getContext();
-    Type ptrType = LLVM::LLVMPointerType::get(ctx, 0);
+    Type hostPtrType = LLVM::LLVMPointerType::get(ctx, 0);
+    Type devicePtrType = LLVM::LLVMPointerType::get(ctx, 1);
     Type i64Type = IntegerType::get(ctx, 64);
 
     auto memRefType = dyn_cast<MemRefType>(op.getResult().getType());
@@ -80,9 +81,9 @@ struct ConstantLowering : public ConvertOpToLLVMPattern<ConstantOp> {
         rewriter, loc, i64Type,
         rewriter.getI64IntegerAttr(op.getIndexAttr().getInt()));
 
-    SmallVector<Type, 2> paramTypes = {ptrType, i64Type};
+    SmallVector<Type, 2> paramTypes = {hostPtrType, i64Type};
     FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
-        rewriter, module, kHipsrGetConstant, paramTypes, ptrType);
+        rewriter, module, kHipsrGetConstant, paramTypes, devicePtrType);
     if (failed(funcOp)) {
       return failure();
     }
@@ -90,19 +91,7 @@ struct ConstantLowering : public ConvertOpToLLVMPattern<ConstantOp> {
     SmallVector<Value, 2> args = {ctxArg, indexVal};
     auto callOp = LLVM::CallOp::create(rewriter, loc, *funcOp, args);
 
-    FailureOr<unsigned> addrSpace =
-        getTypeConverter()->getMemRefAddressSpace(memRefType);
-    if (failed(addrSpace)) {
-      return failure();
-    }
-
     Value dataPtr = callOp.getResult();
-    // TODO: hipdnn_ep_constant_get should return !llvm.ptr<1> so this cast is
-    // unnecessary.
-    if (*addrSpace != 0) {
-      dataPtr = LLVM::AddrSpaceCastOp::create(
-          rewriter, loc, LLVM::LLVMPointerType::get(ctx, *addrSpace), dataPtr);
-    }
 
     auto shape = memRefType.getShape();
     SmallVector<Value, 4> sizes;

--- a/lib/Dialect/Hipsr/IR/HipsrLLVMLoweringUtils.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrLLVMLoweringUtils.cpp
@@ -46,15 +46,7 @@ int64_t mlir::hipsr::getHipdnnDataType(Type elemType) {
 
 Value mlir::hipsr::extractContiguousMemRefPtr(
     Value memrefDesc, ConversionPatternRewriter &rewriter, Location loc) {
-  Value ptr = MemRefDescriptor(memrefDesc).alignedPtr(rewriter, loc);
-  auto ptrTy = cast<LLVM::LLVMPointerType>(ptr.getType());
-  // TODO: we should not need AddrSpaceCastOp in the future.
-  if (ptrTy.getAddressSpace() != 0) {
-    ptr = LLVM::AddrSpaceCastOp::create(
-        rewriter, loc, LLVM::LLVMPointerType::get(rewriter.getContext(), 0),
-        ptr);
-  }
-  return ptr;
+  return MemRefDescriptor(memrefDesc).alignedPtr(rewriter, loc);
 }
 
 llvm::SmallVector<Value, 4>

--- a/test/lit/Conversion/hipsr-to-llvm/test_add.mlir
+++ b/test/lit/Conversion/hipsr-to-llvm/test_add.mlir
@@ -8,7 +8,7 @@
 // CHECK-DAG:   %[[SLOT:.*]] = llvm.mlir.constant(-1 : i32) : i32
 // CHECK-DAG:   %[[TOP:.*]] = llvm.mlir.constant(1 : i64) : i64
 // CHECK:       llvm.call @wrap_miopenOpTensor(%[[CTX]], %[[SLOT]],
-// CHECK-SAME:    !llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
+// CHECK-SAME:    !llvm.ptr, i32, !llvm.ptr<1>, !llvm.ptr<1>, !llvm.ptr<1>, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
 func.func @add(%ctx: !hipsr.context,
                %lhs: memref<4x1024xf16, #hipsr.mem<device>>,
                %rhs: memref<1024xf16, #hipsr.mem<device>>,

--- a/test/lit/Conversion/hipsr-to-llvm/test_constant.mlir
+++ b/test/lit/Conversion/hipsr-to-llvm/test_constant.mlir
@@ -8,8 +8,7 @@
 func.func @single_constant(%ctx: !llvm.ptr)
     -> memref<3x4xf32, #hipsr.mem<device>> {
   // CHECK:   %[[IDX:.*]] = llvm.mlir.constant(0 : i64) : i64
-  // CHECK:   %[[PTR:.*]] = llvm.call @hipdnn_ep_constant_get(%[[CTX]], %[[IDX]]) : (!llvm.ptr, i64) -> !llvm.ptr
-  // CHECK:   llvm.addrspacecast %[[PTR]] : !llvm.ptr to !llvm.ptr<1>
+  // CHECK:   %[[PTR:.*]] = llvm.call @hipdnn_ep_constant_get(%[[CTX]], %[[IDX]]) : (!llvm.ptr, i64) -> !llvm.ptr<1>
   %c = hipsr.constant {value = dense<1.0> : tensor<3x4xf32>, offset = 0 : i64, size = 48 : i64, index = 0 : i64}
      : memref<3x4xf32, #hipsr.mem<device>>
   return %c : memref<3x4xf32, #hipsr.mem<device>>
@@ -20,14 +19,12 @@ func.func @single_constant(%ctx: !llvm.ptr)
 func.func @two_constants(%ctx: !llvm.ptr, %n: i64)
     -> (memref<64xf32, #hipsr.mem<device>>, memref<8xf32, #hipsr.mem<device>>) {
   // CHECK:   %[[IDX0:.*]] = llvm.mlir.constant(0 : i64) : i64
-  // CHECK:   %[[P0:.*]] = llvm.call @hipdnn_ep_constant_get(%[[CTX2]], %[[IDX0]]) : (!llvm.ptr, i64) -> !llvm.ptr
-  // CHECK:   llvm.addrspacecast %[[P0]] : !llvm.ptr to !llvm.ptr<1>
+  // CHECK:   %[[P0:.*]] = llvm.call @hipdnn_ep_constant_get(%[[CTX2]], %[[IDX0]]) : (!llvm.ptr, i64) -> !llvm.ptr<1>
   %w = hipsr.constant {value = dense<1.0> : tensor<64xf32>, offset = 0 : i64, size = 256 : i64, index = 0 : i64}
      : memref<64xf32, #hipsr.mem<device>>
   // CHECK:   llvm.insertvalue {{.*}}[4, 0]
   // CHECK:   %[[IDX1:.*]] = llvm.mlir.constant(1 : i64) : i64
-  // CHECK:   %[[P1:.*]] = llvm.call @hipdnn_ep_constant_get(%[[CTX2]], %[[IDX1]]) : (!llvm.ptr, i64) -> !llvm.ptr
-  // CHECK:   llvm.addrspacecast %[[P1]] : !llvm.ptr to !llvm.ptr<1>
+  // CHECK:   %[[P1:.*]] = llvm.call @hipdnn_ep_constant_get(%[[CTX2]], %[[IDX1]]) : (!llvm.ptr, i64) -> !llvm.ptr<1>
   %b = hipsr.constant {value = dense<2.0> : tensor<8xf32>, offset = 256 : i64, size = 32 : i64, index = 1 : i64}
      : memref<8xf32, #hipsr.mem<device>>
   return %w, %b : memref<64xf32, #hipsr.mem<device>>, memref<8xf32, #hipsr.mem<device>>


### PR DESCRIPTION
## Summary
- preserve the address space of pointers extracted from lowered Hipsr memref descriptors
- declare runtime state pointers in AS0 and device buffer pointers in AS1 for `hipsr.add` and `hipsr.constant`
- update focused LLVM lowering LIT checks for the corrected signatures

## Problem
Hipsr device memrefs lower to LLVM address space 1, but `extractContiguousMemRefPtr` converted non-AS0 pointers to AS0. The existing Add and Constant runtime declarations also described device buffers as AS0 pointers. This discarded the device-memory distinction and produced LLVM calls whose pointer types did not match the runtime ABI.

## Solution
Return the aligned memref pointer in its original address space and declare each runtime argument according to its role: host/runtime state remains AS0, while device buffers remain AS1. The generated call signatures now preserve the memory-space semantics without unnecessary `addrspacecast` operations.

## Test plan
- [x] Run the focused `hipsr.add` and `hipsr.constant` LLVM lowering LIT tests
- [x] Run the complete MorphizenMLIR LIT suite (353 passed, 2 unsupported)