### PR TITLE
feat(hipsr): add hipsr-pool-alloc pass skeleton

### DIFF
--- a/include/hip/Dialect/Hipsr/Transforms/Passes.td
+++ b/include/hip/Dialect/Hipsr/Transforms/Passes.td
@@ -161,4 +161,17 @@ def HipsrExternalizeConstantsPass
   ];
 }
 
+def HipsrPoolAllocPass : Pass<"hipsr-pool-alloc", "mlir::ModuleOp"> {
+  let summary = "Pool intermediate buffers per pool_domain by lifetime";
+  let description = [{
+    Pools each `hipsr.pool_domain`'s `memref.alloc`s by lifetime:
+    non-overlapping ones share one `hipsr.get_pool` buffer as `memref.view`s.
+  }];
+  let dependentDialects = [
+    "::mlir::hipsr::HipsrDialect",
+    "::mlir::memref::MemRefDialect",
+    "::mlir::arith::ArithDialect"
+  ];
+}
+
 #endif // HIPSR_TRANSFORMS_PASSES

--- a/lib/Dialect/Hipsr/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Hipsr/Transforms/CMakeLists.txt
@@ -5,6 +5,7 @@
 
 add_library(HipsrDialectTransforms STATIC
   ExternalizeConstants.cpp
+  HipsrPoolAllocPass.cpp
   PartitionPoolDomains.cpp
   PopulateShapeRegionPass.cpp
 )

--- a/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
+++ b/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "hip/Dialect/Hipsr/Transforms/Passes.h"
+
+#include "hip/Dialect/Hipsr/IR/HipsrDialect.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/BuiltinOps.h"
+
+namespace mlir {
+namespace hipsr {
+
+#define GEN_PASS_DEF_HIPSRPOOLALLOCPASS
+#include "hip/Dialect/Hipsr/Transforms/Passes.h.inc"
+
+namespace {
+
+struct HipsrPoolAllocPass : impl::HipsrPoolAllocPassBase<HipsrPoolAllocPass> {
+  using impl::HipsrPoolAllocPassBase<
+      HipsrPoolAllocPass>::HipsrPoolAllocPassBase;
+
+  void runOnOperation() override {}
+};
+
+} // namespace
+
+} // namespace hipsr
+} // namespace mlir

--- a/test/lit/Dialect/Hipsr/pool_alloc.mlir
+++ b/test/lit/Dialect/Hipsr/pool_alloc.mlir
@@ -1,0 +1,33 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt %s -split-input-file -verify-diagnostics -hipsr-pool-alloc | FileCheck %s
+
+// CHECK-LABEL: func.func @empty_domain
+// CHECK-NEXT: hipsr.pool_domain() {
+// CHECK-NEXT: }
+// CHECK-NOT: hipsr.get_pool
+func.func @empty_domain() {
+  hipsr.pool_domain() {
+    hipsr.pool_domain_yield
+  }
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @noalloc_noop
+// CHECK: hipsr.pool_domain
+// CHECK: %[[BUF:.+]] = tensor.empty() : tensor<2x4xi64>
+// CHECK-NEXT: hipsr.pool_domain_yield %[[BUF]] : tensor<2x4xi64>
+// CHECK-NOT: hipsr.get_pool
+// CHECK-NOT: memref.view
+func.func @noalloc_noop(%ctx: !hipsr.context,
+                        %in: tensor<3x4xf32>) -> tensor<2x4xi64> {
+  %0 = hipsr.pool_domain(%ctx, %in : !hipsr.context, tensor<3x4xf32>) {
+  ^bb0(%dctx: !hipsr.context, %din: tensor<3x4xf32>):
+    %buf = tensor.empty() : tensor<2x4xi64>
+    hipsr.pool_domain_yield %buf : tensor<2x4xi64>
+  } -> tensor<2x4xi64>
+  return %0 : tensor<2x4xi64>
+}


### PR DESCRIPTION
## Summary

Register `-hipsr-pool-alloc` as a no-op `ModuleOp` pass and add the lit file the rest of the series grows into. No IR changes yet.

## Related issue or design

Upstream [`wcy123/onnx-hipdnn-ep#108`](https://github.com/wcy123/onnx-hipdnn-ep/issues/108) (Phase 1, PR1 of `wcy123/onnx-hipdnn-ep#19`), which links the HIPSR Pool Allocation Pass design page.

## Why

Registration is zero extra code once the `def` exists — `Passes.h` pulls `GEN_PASS_REGISTRATION` and `InitAllPasses.h` already calls `registerHipsrPasses()`. Landing the skeleton on its own therefore gives each follow-up (liveness utility, single-group emit, multi-group offsets, opt-in report) a registered pass and a lit file to extend, so every one of them stays small and reviewable.

## What

- `Passes.td`: `def HipsrPoolAllocPass` over `mlir::ModuleOp`. The description states the target semantics and that this skeleton leaves the IR unchanged. `dependentDialects` already lists memref/arith so the follow-ups that emit views and size arithmetic do not have to revisit the def.
- `HipsrPoolAllocPass.cpp`: empty `runOnOperation()`.
- `test/lit/Dialect/Hipsr/pool_alloc.mlir`: `empty_domain` (a domain with only the implicit yield) and `noalloc_noop` (a tensor-mode domain). Both assert unchanged IR; the RUN line resolving `-hipsr-pool-alloc` is what proves the pass is registered.

## Test plan

- [x] `lit --filter pool_alloc` — `MorphizenMLIR :: Dialect/Hipsr/pool_alloc.mlir` PASS.
- [x] Full `check-hip-mlir-lit` — 351 passed, 0 failed.
- [x] `hip-mlir-opt --help` lists `--hipsr-pool-alloc`.
- [x] `pre-commit run --all-files` clean.

## Notes for reviewers

- The pass is not in any pipeline; it is reachable only through `hip-mlir-opt` until the rewrite lands.
- Follow-ups land in upstream order `wcy123/onnx-hipdnn-ep#109`-`#118`, each on top of the previous one.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [x] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.
