### PR TITLE
feat(hipsr): add expand LLVM lowering

### DIFF
--- a/include/hip/Conversion/HipsrToLLVM/HipsrToLLVM.h
+++ b/include/hip/Conversion/HipsrToLLVM/HipsrToLLVM.h
@@ -199,6 +199,8 @@ void populateHipsrGetPoolLoweringPatterns(const LLVMTypeConverter &converter,
                                           RewritePatternSet &patterns);
 void populateHipsrCastLoweringPatterns(const LLVMTypeConverter &converter,
                                        RewritePatternSet &patterns);
+void populateHipsrExpandLoweringPatterns(const LLVMTypeConverter &converter,
+                                         RewritePatternSet &patterns);
 
 } // namespace hipsr
 } // namespace mlir

--- a/lib/Dialect/Hipsr/IR/HipsrDialect.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrDialect.cpp
@@ -77,6 +77,7 @@ void populateHipsrToLLVMPatterns(const LLVMTypeConverter &typeConverter,
   populateHipsrAddLoweringPatterns(typeConverter, patterns);
   populateHipsrGetPoolLoweringPatterns(typeConverter, patterns);
   populateHipsrCastLoweringPatterns(typeConverter, patterns);
+  populateHipsrExpandLoweringPatterns(typeConverter, patterns);
 }
 
 struct HipsrConvertToLLVMInterface : public ConvertToLLVMPatternInterface {

--- a/lib/Dialect/Hipsr/IR/HipsrExpandOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrExpandOp.cpp
@@ -13,9 +13,7 @@
 #include "mlir/Conversion/LLVMCommon/Pattern.h"
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
-#include "mlir/Dialect/LLVMIR/FunctionCallUtils.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
-#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Shape/IR/Shape.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
@@ -204,9 +202,6 @@ struct ExpandLowering : ConvertOpToLLVMPattern<ExpandOp> {
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op.getLoc();
     ModuleOp module = op->getParentOfType<ModuleOp>();
-    MLIRContext *ctx = rewriter.getContext();
-    Type hostPtrType = LLVM::LLVMPointerType::get(ctx, 0);
-    Type devicePtrType = LLVM::LLVMPointerType::get(ctx, 1);
 
     auto inputType = dyn_cast<MemRefType>(op.getInput().getType());
     auto outputType = dyn_cast<MemRefType>(op.getInit().getType());
@@ -228,6 +223,7 @@ struct ExpandLowering : ConvertOpToLLVMPattern<ExpandOp> {
 
     Value one = createI64Const(1);
     Type i32Type = rewriter.getI32Type();
+    Type hostPtrType = LLVM::LLVMPointerType::get(rewriter.getContext(), 0);
     auto emitShapeArray = [&](MemRefType type, Value descriptor) -> Value {
       int64_t rank = type.getRank();
       auto arrayType =
@@ -247,44 +243,27 @@ struct ExpandLowering : ConvertOpToLLVMPattern<ExpandOp> {
       return array;
     };
 
-    Value inputPtr =
-        extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc);
     Value shapePtr =
         op.getShape()
             ? extractContiguousMemRefPtr(adaptor.getShape(), rewriter, loc)
             : LLVM::ZeroOp::create(rewriter, loc, hostPtrType).getResult();
-    Value outputPtr =
-        extractContiguousMemRefPtr(adaptor.getInit(), rewriter, loc);
     Value inputShape = emitShapeArray(inputType, adaptor.getInput());
     Value outputShape = emitShapeArray(outputType, adaptor.getInit());
 
-    SmallVector<Type, 9> paramTypes = {
-        hostPtrType,   // state
-        devicePtrType, // input
-        hostPtrType,   // requested shape
-        devicePtrType, // output
-        hostPtrType,   // input shape
-        i64Type,       // input rank
-        hostPtrType,   // output shape
-        i64Type,       // output rank
-        i64Type        // data type
-    };
-    FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
-        rewriter, module, kWrapExpand, paramTypes, i32Type);
-    if (failed(funcOp)) {
+    using ExpandCall = RuntimeFunc<i32, hostPtr, devicePtr, hostPtr, devicePtr,
+                                   hostPtr, i64, hostPtr, i64, i64>;
+    auto expandFunc =
+        ExpandCall::lookupOrCreateFn(rewriter, loc, module, kWrapExpand);
+    if (failed(expandFunc)) {
+      return failure();
+    }
+    if (failed(expandFunc->call(adaptor.getCtx(), adaptor.getInput(), shapePtr,
+                                adaptor.getInit(), inputShape,
+                                inputType.getRank(), outputShape,
+                                outputType.getRank(), dataType))) {
       return failure();
     }
 
-    SmallVector<Value, 9> args = {adaptor.getCtx(),
-                                  inputPtr,
-                                  shapePtr,
-                                  outputPtr,
-                                  inputShape,
-                                  createI64Const(inputType.getRank()),
-                                  outputShape,
-                                  createI64Const(outputType.getRank()),
-                                  createI64Const(dataType)};
-    LLVM::CallOp::create(rewriter, loc, *funcOp, args);
     rewriter.eraseOp(op);
     return success();
   }

--- a/lib/Dialect/Hipsr/IR/HipsrExpandOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrExpandOp.cpp
@@ -3,15 +3,24 @@
  * Licensed under the MIT License.
  */
 
+#include "hip/Conversion/HipsrToLLVM/HipsrToLLVM.h"
 #include "hip/Dialect/Hipsr/IR/HipsrOps.h"
 
+#include "hip/Dialect/Hipsr/IR/HipsrLLVMLoweringUtils.h"
 #include "hip/Dialect/Hipsr/IR/HipsrShapeRegionInterface.h"
 
+#include "mlir/Conversion/LLVMCommon/MemRefBuilder.h"
+#include "mlir/Conversion/LLVMCommon/Pattern.h"
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/LLVMIR/FunctionCallUtils.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Shape/IR/Shape.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Matchers.h"
+#include "mlir/Transforms/DialectConversion.h"
 
 #include "llvm/ADT/Sequence.h"
 
@@ -181,4 +190,109 @@ void ExpandOp::populateShapeRegion(OpBuilder &builder, Block &shapeBlock) {
   ShapeYieldOp::create(builder, loc,
                        ArrayRef<ValueRange>{assuming.getResults()},
                        TypeRange{inputType.getElementType()});
+}
+
+namespace {
+
+constexpr const char *kWrapExpand = "wrap_expand";
+
+struct ExpandLowering : ConvertOpToLLVMPattern<ExpandOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(ExpandOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    ModuleOp module = op->getParentOfType<ModuleOp>();
+    MLIRContext *ctx = rewriter.getContext();
+    Type hostPtrType = LLVM::LLVMPointerType::get(ctx, 0);
+    Type devicePtrType = LLVM::LLVMPointerType::get(ctx, 1);
+
+    auto inputType = dyn_cast<MemRefType>(op.getInput().getType());
+    auto outputType = dyn_cast<MemRefType>(op.getInit().getType());
+    if (!inputType || !outputType) {
+      return rewriter.notifyMatchFailure(
+          op, "operands must be memrefs (run bufferization first)");
+    }
+
+    int64_t dataType = getHipdnnDataType(inputType.getElementType());
+    if (dataType < 0) {
+      return rewriter.notifyMatchFailure(op, "unsupported element type");
+    }
+
+    Type i64Type = rewriter.getI64Type();
+    auto createI64Const = [&](int64_t v) {
+      return LLVM::ConstantOp::create(rewriter, loc, i64Type,
+                                      rewriter.getI64IntegerAttr(v));
+    };
+
+    Value one = createI64Const(1);
+    Type i32Type = rewriter.getI32Type();
+    auto emitShapeArray = [&](MemRefType type, Value descriptor) -> Value {
+      int64_t rank = type.getRank();
+      auto arrayType =
+          LLVM::LLVMArrayType::get(i64Type, std::max<int64_t>(rank, 1));
+      Value array = LLVM::AllocaOp::create(rewriter, loc, hostPtrType,
+                                           arrayType, one, /*alignment=*/8);
+      MemRefDescriptor desc(descriptor);
+      for (int64_t i : llvm::seq<int64_t>(0, rank)) {
+        Value dim = type.isDynamicDim(i) ? desc.size(rewriter, loc, i)
+                                         : createI64Const(type.getDimSize(i));
+        Value index = LLVM::ConstantOp::create(rewriter, loc, i32Type,
+                                               rewriter.getI32IntegerAttr(i));
+        Value elementPtr = LLVM::GEPOp::create(rewriter, loc, hostPtrType,
+                                               i64Type, array, index);
+        LLVM::StoreOp::create(rewriter, loc, dim, elementPtr);
+      }
+      return array;
+    };
+
+    Value inputPtr =
+        extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc);
+    Value shapePtr =
+        op.getShape()
+            ? extractContiguousMemRefPtr(adaptor.getShape(), rewriter, loc)
+            : LLVM::ZeroOp::create(rewriter, loc, hostPtrType).getResult();
+    Value outputPtr =
+        extractContiguousMemRefPtr(adaptor.getInit(), rewriter, loc);
+    Value inputShape = emitShapeArray(inputType, adaptor.getInput());
+    Value outputShape = emitShapeArray(outputType, adaptor.getInit());
+
+    SmallVector<Type, 9> paramTypes = {
+        hostPtrType,   // state
+        devicePtrType, // input
+        hostPtrType,   // requested shape
+        devicePtrType, // output
+        hostPtrType,   // input shape
+        i64Type,       // input rank
+        hostPtrType,   // output shape
+        i64Type,       // output rank
+        i64Type        // data type
+    };
+    FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
+        rewriter, module, kWrapExpand, paramTypes, i32Type);
+    if (failed(funcOp)) {
+      return failure();
+    }
+
+    SmallVector<Value, 9> args = {adaptor.getCtx(),
+                                  inputPtr,
+                                  shapePtr,
+                                  outputPtr,
+                                  inputShape,
+                                  createI64Const(inputType.getRank()),
+                                  outputShape,
+                                  createI64Const(outputType.getRank()),
+                                  createI64Const(dataType)};
+    LLVM::CallOp::create(rewriter, loc, *funcOp, args);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+} // namespace
+
+void mlir::hipsr::populateHipsrExpandLoweringPatterns(
+    const LLVMTypeConverter &converter, RewritePatternSet &patterns) {
+  patterns.add<ExpandLowering>(converter);
 }

--- a/test/lit/Conversion/hipsr-to-llvm/test_expand.mlir
+++ b/test/lit/Conversion/hipsr-to-llvm/test_expand.mlir
@@ -5,13 +5,15 @@
 
 // CHECK-LABEL: llvm.func @expand_host_shape
 // CHECK-SAME:  (%[[CTX:[^,]+]]: !llvm.ptr,
-// CHECK:       %[[INPUT_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
 // CHECK:       %[[SHAPE_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr,
-// CHECK:       %[[OUTPUT_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
-// CHECK:       llvm.alloca {{.*}} x !llvm.array<2 x i64>
-// CHECK:       llvm.alloca {{.*}} x !llvm.array<3 x i64>
-// CHECK:       llvm.call @wrap_expand(%[[CTX]], %[[INPUT_PTR]], %[[SHAPE_PTR]], %[[OUTPUT_PTR]],
-// CHECK-SAME:    (!llvm.ptr, !llvm.ptr<1>, !llvm.ptr, !llvm.ptr<1>, !llvm.ptr, i64, !llvm.ptr, i64, i64) -> i32
+// CHECK:       %[[INPUT_SHAPE:.*]] = llvm.alloca {{.*}} x !llvm.array<2 x i64>
+// CHECK:       %[[OUTPUT_SHAPE:.*]] = llvm.alloca {{.*}} x !llvm.array<3 x i64>
+// CHECK:       %[[INPUT_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
+// CHECK-NEXT:  %[[OUTPUT_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
+// CHECK-NEXT:  %[[INPUT_RANK:.*]] = llvm.mlir.constant(2 : i64) : i64
+// CHECK-NEXT:  %[[OUTPUT_RANK:.*]] = llvm.mlir.constant(3 : i64) : i64
+// CHECK-NEXT:  %[[DATA_TYPE:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-NEXT:  llvm.call @wrap_expand(%[[CTX]], %[[INPUT_PTR]], %[[SHAPE_PTR]], %[[OUTPUT_PTR]], %[[INPUT_SHAPE]], %[[INPUT_RANK]], %[[OUTPUT_SHAPE]], %[[OUTPUT_RANK]], %[[DATA_TYPE]]) : (!llvm.ptr, !llvm.ptr<1>, !llvm.ptr, !llvm.ptr<1>, !llvm.ptr, i64, !llvm.ptr, i64, i64) -> i32
 func.func @expand_host_shape(
     %ctx: !hipsr.context,
     %input: memref<3x1xf32, #hipsr.mem<device>>,
@@ -26,12 +28,16 @@ func.func @expand_host_shape(
 
 // CHECK-LABEL: llvm.func @expand_shape_attr
 // CHECK-SAME:  (%[[ATTR_CTX:[^,]+]]: !llvm.ptr,
-// CHECK:       %[[ATTR_INPUT_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
 // CHECK:       %[[NULL_SHAPE:.*]] = llvm.mlir.zero : !llvm.ptr
-// CHECK:       %[[ATTR_OUTPUT_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
+// CHECK:       %[[ATTR_INPUT_SHAPE:.*]] = llvm.alloca {{.*}} x !llvm.array<2 x i64>
+// CHECK:       %[[ATTR_OUTPUT_SHAPE:.*]] = llvm.alloca {{.*}} x !llvm.array<3 x i64>
 // CHECK:       llvm.extractvalue {{.*}}[3, 0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>,
-// CHECK:       llvm.call @wrap_expand(%[[ATTR_CTX]], %[[ATTR_INPUT_PTR]], %[[NULL_SHAPE]], %[[ATTR_OUTPUT_PTR]],
-// CHECK-SAME:    (!llvm.ptr, !llvm.ptr<1>, !llvm.ptr, !llvm.ptr<1>, !llvm.ptr, i64, !llvm.ptr, i64, i64) -> i32
+// CHECK:       %[[ATTR_INPUT_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
+// CHECK-NEXT:  %[[ATTR_OUTPUT_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
+// CHECK-NEXT:  %[[ATTR_INPUT_RANK:.*]] = llvm.mlir.constant(2 : i64) : i64
+// CHECK-NEXT:  %[[ATTR_OUTPUT_RANK:.*]] = llvm.mlir.constant(3 : i64) : i64
+// CHECK-NEXT:  %[[ATTR_DATA_TYPE:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK-NEXT:  llvm.call @wrap_expand(%[[ATTR_CTX]], %[[ATTR_INPUT_PTR]], %[[NULL_SHAPE]], %[[ATTR_OUTPUT_PTR]], %[[ATTR_INPUT_SHAPE]], %[[ATTR_INPUT_RANK]], %[[ATTR_OUTPUT_SHAPE]], %[[ATTR_OUTPUT_RANK]], %[[ATTR_DATA_TYPE]]) : (!llvm.ptr, !llvm.ptr<1>, !llvm.ptr, !llvm.ptr<1>, !llvm.ptr, i64, !llvm.ptr, i64, i64) -> i32
 func.func @expand_shape_attr(
     %ctx: !hipsr.context,
     %input: memref<?x1xf16, #hipsr.mem<device>>,

--- a/test/lit/Conversion/hipsr-to-llvm/test_expand.mlir
+++ b/test/lit/Conversion/hipsr-to-llvm/test_expand.mlir
@@ -1,0 +1,44 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt %s --convert-to-llvm | FileCheck %s
+
+// CHECK-LABEL: llvm.func @expand_host_shape
+// CHECK-SAME:  (%[[CTX:[^,]+]]: !llvm.ptr,
+// CHECK:       %[[INPUT_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
+// CHECK:       %[[SHAPE_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr,
+// CHECK:       %[[OUTPUT_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
+// CHECK:       llvm.alloca {{.*}} x !llvm.array<2 x i64>
+// CHECK:       llvm.alloca {{.*}} x !llvm.array<3 x i64>
+// CHECK:       llvm.call @wrap_expand(%[[CTX]], %[[INPUT_PTR]], %[[SHAPE_PTR]], %[[OUTPUT_PTR]],
+// CHECK-SAME:    (!llvm.ptr, !llvm.ptr<1>, !llvm.ptr, !llvm.ptr<1>, !llvm.ptr, i64, !llvm.ptr, i64, i64) -> i32
+func.func @expand_host_shape(
+    %ctx: !hipsr.context,
+    %input: memref<3x1xf32, #hipsr.mem<device>>,
+    %shape: memref<3xi64, #hipsr.mem<host>>,
+    %init: memref<2x3x6xf32, #hipsr.mem<device>>) {
+  hipsr.expand(%ctx)
+      ins(%input, %shape : memref<3x1xf32, #hipsr.mem<device>>,
+                            memref<3xi64, #hipsr.mem<host>>)
+      outs(%init : memref<2x3x6xf32, #hipsr.mem<device>>)
+  return
+}
+
+// CHECK-LABEL: llvm.func @expand_shape_attr
+// CHECK-SAME:  (%[[ATTR_CTX:[^,]+]]: !llvm.ptr,
+// CHECK:       %[[ATTR_INPUT_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
+// CHECK:       %[[NULL_SHAPE:.*]] = llvm.mlir.zero : !llvm.ptr
+// CHECK:       %[[ATTR_OUTPUT_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
+// CHECK:       llvm.extractvalue {{.*}}[3, 0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>,
+// CHECK:       llvm.call @wrap_expand(%[[ATTR_CTX]], %[[ATTR_INPUT_PTR]], %[[NULL_SHAPE]], %[[ATTR_OUTPUT_PTR]],
+// CHECK-SAME:    (!llvm.ptr, !llvm.ptr<1>, !llvm.ptr, !llvm.ptr<1>, !llvm.ptr, i64, !llvm.ptr, i64, i64) -> i32
+func.func @expand_shape_attr(
+    %ctx: !hipsr.context,
+    %input: memref<?x1xf16, #hipsr.mem<device>>,
+    %init: memref<?x3x?xf16, #hipsr.mem<device>>) {
+  hipsr.expand(%ctx)
+      ins(%input : memref<?x1xf16, #hipsr.mem<device>>)
+      outs(%init : memref<?x3x?xf16, #hipsr.mem<device>>)
+      {shape_attr = array<i64: 2, 3, 6>}
+  return
+}


### PR DESCRIPTION
## Summary
- lower `hipsr.expand` to the `wrap_expand` runtime call
- preserve AS1 input/output pointers while keeping requested shapes and generated shape arrays in AS0
- support both host shape operands and constant `shape_attr` forms
- register the lowering and add focused LIT coverage

## Test plan
- [x] Rebuild `hip-mlir-opt`
- [x] Run the complete MorphizenMLIR LIT suite (356 passed, 2 unsupported)

## AI assistance
Cursor assisted with isolating the existing Expand lowering changes, resolving registration conflicts against the latest main branch, and preparing tests and PR text. The changes were reviewed against the generated LLVM IR and validated by rebuilding `hip-mlir-opt` and running the complete LIT suite.