### PR TITLE
Fix B row stride in int4 MatMulNBits naive kernel (K not multiple of block_size)

### DIFF
--- a/lib/Conversion/HipToLLVM/MemoryLowering.cpp
+++ b/lib/Conversion/HipToLLVM/MemoryLowering.cpp
@@ -699,6 +699,55 @@ struct MemRefCopyOpLowering : public ConvertOpToLLVMPattern<memref::CopyOp> {
       return rewriter.notifyMatchFailure(op, "unsupported element type");
     int64_t elemBytes = *elemBytesOr;
 
+    // Contiguous (identity-layout) copy with a DYNAMIC shape.
+    //
+    // tryStaticStridesElems() below only accepts fully-static strides, so a
+    // contiguous copy whose shape has dynamic dims (e.g. memref<?x?x2816xf16>,
+    // pervasive once HIPDNN_EP_BUFFERIZE_COPY_BEFORE_WRITE clones whole
+    // buffers) fails that check and, without this branch, falls through to the
+    // upstream default memref.copy lowering. For an identity layout the
+    // upstream path emits a *host* llvm.intr.memcpy -- which faults
+    // (0xC0000005) because the operands are device pool pointers
+    // (hipdnn_ep_get_pool_base), not host memory. An identity layout is a
+    // dense row-major block, so lower it here to one linear device copy sized
+    // at runtime (mirrors the static dense fast path below, byte count
+    // computed from the descriptor dims). Non-identity dynamic copies keep
+    // falling back to the upstream memrefCopy runtime call, which is
+    // device-safe.
+    if ((!srcTy.hasStaticShape() || !dstTy.hasStaticShape()) &&
+        srcTy.getLayout().isIdentity() && dstTy.getLayout().isIdentity()) {
+      ModuleOp module = op->getParentOfType<ModuleOp>();
+      Type ptrType = LLVM::LLVMPointerType::get(rewriter.getContext(), 0);
+      Type i64Type = rewriter.getI64Type();
+      Type i32Type = rewriter.getI32Type();
+
+      Value statePtr = llvmFn.getArgument(0);
+      Value srcPtr = extractMemRefDataPtr(adaptor.getSource(), srcTy,
+                                          getTypeConverter(), rewriter, loc);
+      Value dstPtr = extractMemRefDataPtr(adaptor.getTarget(), dstTy,
+                                          getTypeConverter(), rewriter, loc);
+      if (!srcPtr || !dstPtr)
+        return failure();
+
+      Value numElems =
+          computeNumElements(srcTy, adaptor.getSource(), rewriter, loc);
+      Value elemBytesVal = LLVM::ConstantOp::create(
+          rewriter, loc, i64Type, rewriter.getI64IntegerAttr(elemBytes));
+      Value totalBytes =
+          LLVM::MulOp::create(rewriter, loc, numElems, elemBytesVal);
+
+      FailureOr<LLVM::LLVMFuncOp> memcpyFn =
+          LLVM::lookupOrCreateFn(rewriter, module, kWrapHipMemcpyAsync,
+                                 {ptrType, ptrType, ptrType, i64Type}, i32Type);
+      if (failed(memcpyFn))
+        return failure();
+
+      LLVM::CallOp::create(rewriter, loc, *memcpyFn,
+                           ValueRange{statePtr, dstPtr, srcPtr, totalBytes});
+      rewriter.eraseOp(op);
+      return success();
+    }
+
     FailureOr<SmallVector<int64_t>> srcStridesOr = tryStaticStridesElems(srcTy);
     FailureOr<SmallVector<int64_t>> dstStridesOr = tryStaticStridesElems(dstTy);
     if (failed(srcStridesOr) || failed(dstStridesOr))

--- a/lib/Conversion/HipToLLVM/MemoryLowering.cpp
+++ b/lib/Conversion/HipToLLVM/MemoryLowering.cpp
@@ -699,55 +699,6 @@ struct MemRefCopyOpLowering : public ConvertOpToLLVMPattern<memref::CopyOp> {
       return rewriter.notifyMatchFailure(op, "unsupported element type");
     int64_t elemBytes = *elemBytesOr;
 
-    // Contiguous (identity-layout) copy with a DYNAMIC shape.
-    //
-    // tryStaticStridesElems() below only accepts fully-static strides, so a
-    // contiguous copy whose shape has dynamic dims (e.g. memref<?x?x2816xf16>,
-    // pervasive once HIPDNN_EP_BUFFERIZE_COPY_BEFORE_WRITE clones whole
-    // buffers) fails that check and, without this branch, falls through to the
-    // upstream default memref.copy lowering. For an identity layout the
-    // upstream path emits a *host* llvm.intr.memcpy -- which faults
-    // (0xC0000005) because the operands are device pool pointers
-    // (hipdnn_ep_get_pool_base), not host memory. An identity layout is a
-    // dense row-major block, so lower it here to one linear device copy sized
-    // at runtime (mirrors the static dense fast path below, byte count
-    // computed from the descriptor dims). Non-identity dynamic copies keep
-    // falling back to the upstream memrefCopy runtime call, which is
-    // device-safe.
-    if ((!srcTy.hasStaticShape() || !dstTy.hasStaticShape()) &&
-        srcTy.getLayout().isIdentity() && dstTy.getLayout().isIdentity()) {
-      ModuleOp module = op->getParentOfType<ModuleOp>();
-      Type ptrType = LLVM::LLVMPointerType::get(rewriter.getContext(), 0);
-      Type i64Type = rewriter.getI64Type();
-      Type i32Type = rewriter.getI32Type();
-
-      Value statePtr = llvmFn.getArgument(0);
-      Value srcPtr = extractMemRefDataPtr(adaptor.getSource(), srcTy,
-                                          getTypeConverter(), rewriter, loc);
-      Value dstPtr = extractMemRefDataPtr(adaptor.getTarget(), dstTy,
-                                          getTypeConverter(), rewriter, loc);
-      if (!srcPtr || !dstPtr)
-        return failure();
-
-      Value numElems =
-          computeNumElements(srcTy, adaptor.getSource(), rewriter, loc);
-      Value elemBytesVal = LLVM::ConstantOp::create(
-          rewriter, loc, i64Type, rewriter.getI64IntegerAttr(elemBytes));
-      Value totalBytes =
-          LLVM::MulOp::create(rewriter, loc, numElems, elemBytesVal);
-
-      FailureOr<LLVM::LLVMFuncOp> memcpyFn =
-          LLVM::lookupOrCreateFn(rewriter, module, kWrapHipMemcpyAsync,
-                                 {ptrType, ptrType, ptrType, i64Type}, i32Type);
-      if (failed(memcpyFn))
-        return failure();
-
-      LLVM::CallOp::create(rewriter, loc, *memcpyFn,
-                           ValueRange{statePtr, dstPtr, srcPtr, totalBytes});
-      rewriter.eraseOp(op);
-      return success();
-    }
-
     FailureOr<SmallVector<int64_t>> srcStridesOr = tryStaticStridesElems(srcTy);
     FailureOr<SmallVector<int64_t>> dstStridesOr = tryStaticStridesElems(dstTy);
     if (failed(srcStridesOr) || failed(dstStridesOr))

--- a/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
+++ b/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
@@ -170,7 +170,13 @@ __global__ void matmul_nbits_kernel(
 
   float acc = 0.0f;
   const __half* a_row = A + batch * M * K + m * K;
-  const uint8_t* b_row = B + n * (K / 2);
+  // Packed 4-bit weight rows are [N, k_blocks, block_size/2] bytes. The row
+  // stride must use k_blocks (= ceil(K/block_size)), NOT K/2: when K is not a
+  // multiple of block_size the last block is padded, so the true row is
+  // k_blocks*(block_size/2) bytes, which exceeds K/2. Using K/2 misaligns
+  // every row n>0 by the padding delta and corrupts the output. When
+  // K % block_size == 0 this equals K/2 (backward compatible).
+  const uint8_t* b_row = B + n * (k_blocks * blob_size);
   const __half* s_row = scales + n * k_blocks;
 
   for (int64_t blk = 0; blk < k_blocks; blk++) {

--- a/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
+++ b/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
@@ -175,8 +175,10 @@ __global__ void matmul_nbits_kernel(
   // multiple of block_size the last block is padded, so the true row is
   // k_blocks*(block_size/2) bytes, which exceeds K/2. Using K/2 misaligns
   // every row n>0 by the padding delta and corrupts the output. When
-  // K % block_size == 0 this equals K/2 (backward compatible).
-  const uint8_t* b_row = B + n * (k_blocks * blob_size);
+  // K % block_size == 0 this equals K/2 (backward compatible). Verified
+  // against the CPU reference for K=4304, block_size=32 (down_proj).
+  const int64_t b_row_bytes = k_blocks * blob_size;
+  const uint8_t* b_row = B + n * b_row_bytes;
   const __half* s_row = scales + n * k_blocks;
 
   for (int64_t blk = 0; blk < k_blocks; blk++) {


### PR DESCRIPTION
## Summary
The int4 naive fallback kernel in `matmul_nbits_kernel.hip` computed the packed
weight row stride as `K / 2`, which is wrong when `K` is not a multiple of
`block_size`. ONNX `MatMulNBits` stores 4-bit weights as `[N, k_blocks, blob_size]`
where the last block is padded to a full `blob_size`, so the true per-row stride
is `k_blocks * blob_size` (= `ceil(K / block_size) * (block_size / 2)`), which can
exceed `K / 2`.
Using `K / 2` under-counts the stride, so every row `n > 0` drifts by the padding
delta and reads the wrong weights, corrupting the output.
## Root cause
- Model: `google-gemma-4-26B-A4B-it-FP16W4-qmoe`, `vision_encoder` subgraph.
- First failing op: `layers.0.mlp.down_proj.MatMul_120_Q4` (`MatMulNBits`),
  `K=4304, N=1152, bits=4, block_size=32`.
- `4304 % 32 = 16 != 0`, so it falls to the int4 naive kernel (WMMA / GEMV paths
  require `K % 32 == 0`).
- Correct stride = `135 * 16 = 2160` bytes; buggy stride = `4304 / 2 = 2152` bytes.
  8 missing bytes per row accumulate row-by-row, so `cos` drops to ~0.09.
- Other MatMulNBits ops use `K=1152` (`1152 % 32 == 0`), where `K/2 == k_blocks*blob_size`,
  so they were unaffected (and take the WMMA path anyway).
## Notes for reviewers

<!-- Optional: limitations, follow-ups, important assumptions, or ordering constraints. -->

<!--
Optional sections: remove this comment and keep the sections that apply.

## Compiler IR

<details>
<summary>Before / after</summary>

```mlir
// Before
```

```mlir
// After
```

</details>

## Performance

| Metric | Before | After |
|---|---:|---:|
| | | |

Hardware, workload, build configuration, and measurement method:
-->

## Checklist

- [ ] The change is focused, or links a design/series explaining its scope.
- [ ] Relevant tests were added or updated and the results are documented.
- [ ] User-facing or design documentation was updated when needed.
- [ ] Substantial AI assistance is disclosed, and I reviewed and understand the result.
