### PR TITLE
feat(hipsr): add pool-alloc liveness analysis

### DIFF
--- a/include/hip/Dialect/Hipsr/Transforms/Passes.td
+++ b/include/hip/Dialect/Hipsr/Transforms/Passes.td
@@ -167,6 +167,11 @@ def HipsrPoolAllocPass : Pass<"hipsr-pool-alloc", "mlir::ModuleOp"> {
     Pools each `hipsr.pool_domain`'s `memref.alloc`s by lifetime:
     non-overlapping ones share one `hipsr.get_pool` buffer as `memref.view`s.
   }];
+  let options = [
+    Option<"emitPoolReport", "emit-pool-report", "bool", /*default=*/"false",
+           "Debug-only: emit remarks describing the pooling decisions. "
+           "No effect on generated code.">
+  ];
   let dependentDialects = [
     "::mlir::hipsr::HipsrDialect",
     "::mlir::memref::MemRefDialect",

--- a/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
+++ b/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
@@ -6,10 +6,18 @@
 #include "hip/Dialect/Hipsr/Transforms/Passes.h"
 
 #include "hip/Dialect/Hipsr/IR/HipsrDialect.h"
+#include "hip/Dialect/Hipsr/IR/HipsrOps.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/Interfaces/DestinationStyleOpInterface.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/STLExtras.h"
+
+#include <cstddef>
+#include <optional>
 
 namespace mlir {
 namespace hipsr {
@@ -19,11 +27,76 @@ namespace hipsr {
 
 namespace {
 
+struct Lifetime {
+  size_t start;
+  size_t end;
+};
+
+llvm::DenseMap<Value, Lifetime> computeLiveness(Block &body) {
+  llvm::DenseMap<Operation *, size_t> opIndices;
+  size_t idx = 0;
+  for (Operation &op : body) {
+    opIndices[&op] = idx++;
+  }
+
+  llvm::DenseMap<Value, Lifetime> lifetimes;
+  for (Operation &op : body) {
+    auto allocOp = dyn_cast<memref::AllocOp>(&op);
+    if (!allocOp) {
+      continue;
+    }
+    Value buffer = allocOp.getResult();
+    std::optional<size_t> start;
+    std::optional<size_t> end;
+    for (Operation *user : buffer.getUsers()) {
+      Operation *blockLevelUser = body.findAncestorOpInBlock(*user);
+      assert(blockLevelUser && "alloc escapes its IsolatedFromAbove domain");
+      size_t userIdx = opIndices.lookup(blockLevelUser);
+      auto dpsUser = dyn_cast<DestinationStyleOpInterface>(user);
+      if (dpsUser && llvm::is_contained(dpsUser.getDpsInits(), buffer) &&
+          (!start || userIdx < *start)) {
+        start = userIdx;
+      }
+      if (!end || userIdx > *end) {
+        end = userIdx;
+      }
+    }
+    if (start) {
+      lifetimes[buffer] = Lifetime{*start, *end};
+    }
+  }
+  return lifetimes;
+}
+
+void emitPoolingReport(Block &body,
+                       const llvm::DenseMap<Value, Lifetime> &lifetimes) {
+  for (Operation &op : body) {
+    auto allocOp = dyn_cast<memref::AllocOp>(&op);
+    if (!allocOp) {
+      continue;
+    }
+    auto it = lifetimes.find(allocOp.getResult());
+    if (it == lifetimes.end()) {
+      continue;
+    }
+    allocOp.emitRemark() << "hipsr-pool-alloc: lifetime [" << it->second.start
+                         << "," << it->second.end << "]";
+  }
+}
+
 struct HipsrPoolAllocPass : impl::HipsrPoolAllocPassBase<HipsrPoolAllocPass> {
   using impl::HipsrPoolAllocPassBase<
       HipsrPoolAllocPass>::HipsrPoolAllocPassBase;
 
-  void runOnOperation() override {}
+  void runOnOperation() override {
+    getOperation().walk([&](PoolDomainOp domain) {
+      Block &body = domain.getBody().front();
+      llvm::DenseMap<Value, Lifetime> lifetimes = computeLiveness(body);
+      if (emitPoolReport) {
+        emitPoolingReport(body, lifetimes);
+      }
+    });
+  }
 };
 
 } // namespace

--- a/test/lit/Dialect/Hipsr/pool_alloc_report.mlir
+++ b/test/lit/Dialect/Hipsr/pool_alloc_report.mlir
@@ -1,0 +1,99 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt %s -split-input-file --verify-diagnostics \
+// RUN:   -hipsr-pool-alloc='emit-pool-report=true' \
+// RUN:   | FileCheck %s --implicit-check-not=hipsr.get_pool \
+// RUN:       --implicit-check-not=memref.view
+
+// CHECK-LABEL: func.func @interleaved_allocs
+func.func @interleaved_allocs(%ctx: !hipsr.context,
+                              %in: memref<4x1024xf16, #hipsr.mem<device>>) {
+  hipsr.pool_domain(%ctx, %in
+      : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
+  ^bb0(%dctx: !hipsr.context, %din: memref<4x1024xf16, #hipsr.mem<device>>):
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [1,3]}}
+    %a1 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+    hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>,
+                                      memref<4x1024xf16, #hipsr.mem<device>>)
+               outs(%a1 : memref<4x1024xf16, #hipsr.mem<device>>)
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [3,5]}}
+    %a2 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+    hipsr.add(%dctx) ins(%a1, %a1 : memref<4x1024xf16, #hipsr.mem<device>>,
+                                    memref<4x1024xf16, #hipsr.mem<device>>)
+               outs(%a2 : memref<4x1024xf16, #hipsr.mem<device>>)
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [5,7]}}
+    %a3 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+    hipsr.add(%dctx) ins(%a2, %a2 : memref<4x1024xf16, #hipsr.mem<device>>,
+                                    memref<4x1024xf16, #hipsr.mem<device>>)
+               outs(%a3 : memref<4x1024xf16, #hipsr.mem<device>>)
+    // No DPS write, so no live range: a remark here would be unexpected and
+    // fail the run.
+    %unwritten = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+    hipsr.add(%dctx) ins(%a3, %a3 : memref<4x1024xf16, #hipsr.mem<device>>,
+                                    memref<4x1024xf16, #hipsr.mem<device>>)
+               outs(%din : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.pool_domain_yield
+  }
+  return
+}
+
+// -----
+
+// Hoisted allocs are the form materialize-init-tensors produces. Ranges start
+// at the DPS write, so a1 and a3 stay disjoint; indexing the allocs themselves
+// would overlap all three and defeat reuse.
+// CHECK-LABEL: func.func @hoisted_allocs
+func.func @hoisted_allocs(%ctx: !hipsr.context,
+                          %in: memref<4x1024xf16, #hipsr.mem<device>>) {
+  hipsr.pool_domain(%ctx, %in
+      : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
+  ^bb0(%dctx: !hipsr.context, %din: memref<4x1024xf16, #hipsr.mem<device>>):
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [3,4]}}
+    %a1 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [4,5]}}
+    %a2 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [5,6]}}
+    %a3 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+    hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>,
+                                      memref<4x1024xf16, #hipsr.mem<device>>)
+               outs(%a1 : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a1, %a1 : memref<4x1024xf16, #hipsr.mem<device>>,
+                                    memref<4x1024xf16, #hipsr.mem<device>>)
+               outs(%a2 : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a2, %a2 : memref<4x1024xf16, #hipsr.mem<device>>,
+                                    memref<4x1024xf16, #hipsr.mem<device>>)
+               outs(%a3 : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a3, %a3 : memref<4x1024xf16, #hipsr.mem<device>>,
+                                    memref<4x1024xf16, #hipsr.mem<device>>)
+               outs(%din : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.pool_domain_yield
+  }
+  return
+}
+
+// -----
+
+// A user inside a nested region extends the range to the enclosing
+// block-level op (index 2), not to the nested op's own index.
+// CHECK-LABEL: func.func @nested_region_user
+func.func @nested_region_user(%ctx: !hipsr.context,
+                              %in: memref<4x1024xf16, #hipsr.mem<device>>) {
+  hipsr.pool_domain(%ctx, %in
+      : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
+  ^bb0(%dctx: !hipsr.context, %din: memref<4x1024xf16, #hipsr.mem<device>>):
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [1,2]}}
+    %a1 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+    hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>,
+                                      memref<4x1024xf16, #hipsr.mem<device>>)
+               outs(%a1 : memref<4x1024xf16, #hipsr.mem<device>>)
+    scf.execute_region {
+      hipsr.add(%dctx) ins(%a1, %a1 : memref<4x1024xf16, #hipsr.mem<device>>,
+                                      memref<4x1024xf16, #hipsr.mem<device>>)
+                 outs(%din : memref<4x1024xf16, #hipsr.mem<device>>)
+      scf.yield
+    }
+    hipsr.pool_domain_yield
+  }
+  return
+}


### PR DESCRIPTION
## Summary

`-hipsr-pool-alloc` now computes each pool domain's alloc live ranges. The pass still rewrites nothing; a new `emit-pool-report` option reports each range as a remark so lit can assert it.

## Related issue or design

Upstream [`wcy123/onnx-hipdnn-ep#109`](https://github.com/wcy123/onnx-hipdnn-ep/issues/109) (liveness analysis utility), a step of [`wcy123/onnx-hipdnn-ep#19`](https://github.com/wcy123/onnx-hipdnn-ep/issues/19), which links the HIPSR Pool Allocation Pass design page. Follows [#582](https://github.com/ROCm/hip-ep/pull/582) (`#108`, skeleton).

## Why

A live range starts at the first write, not at the alloc. After materialize-init-tensors the allocs sit together at the top of the domain, so ranges keyed on the alloc index all overlap and nothing can ever share pool space. Taking the first DPS `outs` write as the start keeps disjoint ranges disjoint, which is what makes the grouping in the follow-ups worth doing.

Indices are those of the domain block's own ops, so a user nested in a region has to fold to its enclosing block-level op — `Block::findAncestorOpInBlock`, as `PartitionPoolDomains.cpp` already does. Looking the nested op up directly returns index 0 and silently shortens the range, which would later let a live buffer be reused. `hipsr.pool_domain` is `IsolatedFromAbove`, so failing to find an ancestor means the IR broke that invariant: an assert, not a fallback branch.

`emit-pool-report` is the option name the whole series uses, not test scaffolding: `#110`-`#118` add group, size and reuse figures to the same report.

## What

- `Passes.td`: `emit-pool-report` bool option, default false, worded after the legacy `hip-pool-allocs` `emit-fragmentation-report`.
- `HipsrPoolAllocPass.cpp`: `Lifetime` plus `computeLiveness(Block &)` returning a `Value` -> `Lifetime` map, and `emitPoolingReport()` which walks the block so remark order is block order. An alloc with no DPS `outs` write has no range and is absent from the map; the warning for that case belongs to `#118`.
- `test/lit/Dialect/Hipsr/pool_alloc_report.mlir`: one RUN line, `--verify-diagnostics` for the ranges and `FileCheck --implicit-check-not` for the unchanged module.

Not done: alias-aware last use. The legacy `BufferUtils.h` tracks view-like aliases through `BufferViewFlowAnalysis` because `hip` domains contain them; hipsr domain bodies do not yet. This has to be revisited before `#117` wires the rewrite into a bufferized pipeline, otherwise an aliased use shortens the range.

## Test plan

- [x] `lit --filter pool_alloc` — `pool_alloc_report.mlir` and `pool_alloc.mlir` PASS.
- [x] Full `check-hip-mlir-lit` — 356 passed, 2 unsupported, 0 failed.
- [x] `hip-mlir-opt --help` lists `--emit-pool-report` under `--hipsr-pool-alloc`.
- [x] Mutation check: changing one expected range fails the run, and injecting a `hipsr.get_pool` into a domain trips `--implicit-check-not`, so neither half of the RUN line is vacuous.
- [x] `pre-commit run --all-files` clean.

## Notes for reviewers

- The default path is unchanged from the skeleton: the analysis runs, nothing is rewritten, nothing is printed. The lit RUN line asserts the module is byte-for-byte the input while the report is on.
- `Lifetime` carries only `start`/`end`. The endpoint ops are only needed by `#118`'s debug trace, so they land with it.
- Follow-ups land in upstream order `#110`-`#118`, each on top of the previous one.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [x] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.
