### PR TITLE
feat(hipsr): add matmul LLVM lowering

### DIFF
--- a/include/hip/Conversion/HipsrToLLVM/HipsrToLLVM.h
+++ b/include/hip/Conversion/HipsrToLLVM/HipsrToLLVM.h
@@ -199,6 +199,8 @@ void populateHipsrGetPoolLoweringPatterns(const LLVMTypeConverter &converter,
                                           RewritePatternSet &patterns);
 void populateHipsrCastLoweringPatterns(const LLVMTypeConverter &converter,
                                        RewritePatternSet &patterns);
+void populateHipsrMatMulLoweringPatterns(const LLVMTypeConverter &converter,
+                                         RewritePatternSet &patterns);
 
 } // namespace hipsr
 } // namespace mlir

--- a/lib/Dialect/Hipsr/IR/HipsrDialect.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrDialect.cpp
@@ -77,6 +77,7 @@ void populateHipsrToLLVMPatterns(const LLVMTypeConverter &typeConverter,
   populateHipsrAddLoweringPatterns(typeConverter, patterns);
   populateHipsrGetPoolLoweringPatterns(typeConverter, patterns);
   populateHipsrCastLoweringPatterns(typeConverter, patterns);
+  populateHipsrMatMulLoweringPatterns(typeConverter, patterns);
 }
 
 struct HipsrConvertToLLVMInterface : public ConvertToLLVMPatternInterface {

--- a/lib/Dialect/Hipsr/IR/HipsrMatMulOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrMatMulOp.cpp
@@ -3,12 +3,19 @@
  * Licensed under the MIT License.
  */
 
+#include "hip/Conversion/HipsrToLLVM/HipsrToLLVM.h"
 #include "hip/Dialect/Hipsr/IR/HipsrOps.h"
 
+#include "hip/Dialect/Hipsr/IR/HipsrLLVMLoweringUtils.h"
 #include "hip/Dialect/Hipsr/IR/HipsrShapeRegionInterface.h"
 
+#include "mlir/Conversion/LLVMCommon/MemRefBuilder.h"
+#include "mlir/Conversion/LLVMCommon/Pattern.h"
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Shape/IR/Shape.h"
+#include "mlir/Transforms/DialectConversion.h"
 
 #include "llvm/ADT/Sequence.h"
 
@@ -127,4 +134,109 @@ void MatMulOp::populateShapeRegion(OpBuilder &builder, Block &shapeBlock) {
   Type elemTy = cast<ShapedType>(getResult(0).getType()).getElementType();
   builder.create<ShapeYieldOp>(loc, ArrayRef<ValueRange>{assuming.getResults()},
                                TypeRange{elemTy});
+}
+
+namespace {
+
+constexpr const char *kWrapHipblasLtMatmul = "wrap_hipblasLtMatmul";
+
+struct MatMulLowering : ConvertOpToLLVMPattern<MatMulOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(MatMulOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    ModuleOp module = op->getParentOfType<ModuleOp>();
+
+    auto aType = dyn_cast<MemRefType>(op.getA().getType());
+    auto bType = dyn_cast<MemRefType>(op.getB().getType());
+    auto outputType = dyn_cast<MemRefType>(op.getInit().getType());
+    if (!aType || !bType || !outputType) {
+      return rewriter.notifyMatchFailure(
+          op, "operands must be memrefs (run bufferization first)");
+    }
+
+    Type i64Type = rewriter.getI64Type();
+    auto createI64Const = [&](int64_t value) {
+      return LLVM::ConstantOp::create(rewriter, loc, i64Type,
+                                      rewriter.getI64IntegerAttr(value));
+    };
+
+    MemRefDescriptor aDesc(adaptor.getA());
+    MemRefDescriptor bDesc(adaptor.getB());
+    int64_t aRank = aType.getRank();
+    int64_t bRank = bType.getRank();
+
+    Value m =
+        aRank == 1 ? createI64Const(1) : aDesc.size(rewriter, loc, aRank - 2);
+    Value k = aDesc.size(rewriter, loc, aRank - 1);
+    Value n =
+        bRank == 1 ? createI64Const(1) : bDesc.size(rewriter, loc, bRank - 1);
+
+    Value batchCount = createI64Const(1);
+    for (int64_t i : llvm::seq<int64_t>(0, std::max<int64_t>(aRank - 2, 0))) {
+      batchCount = LLVM::MulOp::create(rewriter, loc, batchCount,
+                                       aDesc.size(rewriter, loc, i));
+    }
+
+    Value bBatchStride;
+    if (bRank <= 2) {
+      bBatchStride = createI64Const(0);
+    } else {
+      bool allLeadingStatic = true;
+      int64_t staticLeadingProduct = 1;
+      for (int64_t i : llvm::seq<int64_t>(0, bRank - 2)) {
+        if (bType.isDynamicDim(i)) {
+          allLeadingStatic = false;
+          break;
+        }
+        staticLeadingProduct *= bType.getDimSize(i);
+      }
+      if (allLeadingStatic) {
+        bBatchStride =
+            staticLeadingProduct <= 1
+                ? createI64Const(0)
+                : LLVM::MulOp::create(rewriter, loc, k, n).getResult();
+      } else {
+        Value one = createI64Const(1);
+        Value zero = createI64Const(0);
+        Value leadingProduct = one;
+        for (int64_t i : llvm::seq<int64_t>(0, bRank - 2)) {
+          leadingProduct = LLVM::MulOp::create(rewriter, loc, leadingProduct,
+                                               bDesc.size(rewriter, loc, i));
+        }
+        Value isBroadcast = LLVM::ICmpOp::create(
+            rewriter, loc, LLVM::ICmpPredicate::sle, leadingProduct, one);
+        Value kn = LLVM::MulOp::create(rewriter, loc, k, n);
+        bBatchStride =
+            LLVM::SelectOp::create(rewriter, loc, isBroadcast, zero, kn);
+      }
+    }
+
+    int64_t elementSize = aType.getElementType().getIntOrFloatBitWidth() / 8;
+    using MatMulCall =
+        RuntimeFunc<i32, hostPtr, slotIndex, devicePtr, devicePtr, devicePtr,
+                    i64, i64, i64, i64, i64, i64>;
+    auto matMulFunc = MatMulCall::lookupOrCreateFn(rewriter, loc, module,
+                                                   kWrapHipblasLtMatmul);
+    if (failed(matMulFunc)) {
+      return failure();
+    }
+    if (failed(matMulFunc->call(adaptor.getCtx(), SlotIndex{op.getOperation()},
+                                adaptor.getA(), adaptor.getB(),
+                                adaptor.getInit(), m, n, k, batchCount,
+                                elementSize, bBatchStride))) {
+      return failure();
+    }
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+} // namespace
+
+void mlir::hipsr::populateHipsrMatMulLoweringPatterns(
+    const LLVMTypeConverter &converter, RewritePatternSet &patterns) {
+  patterns.add<MatMulLowering>(converter);
 }

--- a/test/lit/Conversion/hipsr-to-llvm/test_matmul.mlir
+++ b/test/lit/Conversion/hipsr-to-llvm/test_matmul.mlir
@@ -1,0 +1,64 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt %s --convert-to-llvm | FileCheck %s
+
+// CHECK-LABEL: llvm.func @matmul_rank2
+// CHECK-SAME:  (%[[CTX:.*]]: !llvm.ptr,
+// CHECK:       %[[M:.*]] = llvm.extractvalue {{.*}}[3, 0]
+// CHECK-NEXT:  %[[K:.*]] = llvm.extractvalue {{.*}}[3, 1]
+// CHECK-NEXT:  %[[N:.*]] = llvm.extractvalue {{.*}}[3, 1]
+// CHECK-NEXT:  %[[BATCH:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK-NEXT:  %[[B_STRIDE:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-NEXT:  %[[SLOT:.*]] = llvm.mlir.constant(-1 : i32) : i32
+// CHECK-NEXT:  %[[A_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
+// CHECK-NEXT:  %[[B_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
+// CHECK-NEXT:  %[[OUT_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
+// CHECK-NEXT:  %[[ELEM_SIZE:.*]] = llvm.mlir.constant(2 : i64) : i64
+// CHECK-NEXT:  llvm.call @wrap_hipblasLtMatmul(%[[CTX]], %[[SLOT]], %[[A_PTR]], %[[B_PTR]], %[[OUT_PTR]], %[[M]], %[[N]], %[[K]], %[[BATCH]], %[[ELEM_SIZE]], %[[B_STRIDE]]) : (!llvm.ptr, i32, !llvm.ptr<1>, !llvm.ptr<1>, !llvm.ptr<1>, i64, i64, i64, i64, i64, i64) -> i32
+// CHECK-NEXT:  llvm.return
+func.func @matmul_rank2(
+    %ctx: !hipsr.context,
+    %a: memref<128x64xf16, #hipsr.mem<device>>,
+    %b: memref<64x32xf16, #hipsr.mem<device>>,
+    %init: memref<128x32xf16, #hipsr.mem<device>>) {
+  hipsr.matmul(%ctx)
+      ins(%a, %b : memref<128x64xf16, #hipsr.mem<device>>,
+                    memref<64x32xf16, #hipsr.mem<device>>)
+      outs(%init : memref<128x32xf16, #hipsr.mem<device>>)
+  return
+}
+
+// CHECK-LABEL: llvm.func @matmul_dynamic_batch
+// CHECK-SAME:  (%[[DYN_CTX:.*]]: !llvm.ptr,
+// CHECK:       %[[DYN_M:.*]] = llvm.extractvalue {{.*}}[3, 1]
+// CHECK-NEXT:  %[[DYN_K:.*]] = llvm.extractvalue {{.*}}[3, 2]
+// CHECK-NEXT:  %[[DYN_N:.*]] = llvm.extractvalue {{.*}}[3, 2]
+// CHECK-NEXT:  %[[BATCH_INIT:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK-NEXT:  %[[A_BATCH_DIM:.*]] = llvm.extractvalue {{.*}}[3, 0]
+// CHECK-NEXT:  %[[DYN_BATCH:.*]] = llvm.mul %[[BATCH_INIT]], %[[A_BATCH_DIM]] : i64
+// CHECK-NEXT:  %[[ONE:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK-NEXT:  %[[ZERO:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-NEXT:  %[[B_BATCH_DIM:.*]] = llvm.extractvalue {{.*}}[3, 0]
+// CHECK-NEXT:  %[[LEADING_PRODUCT:.*]] = llvm.mul %[[ONE]], %[[B_BATCH_DIM]] : i64
+// CHECK-NEXT:  %[[IS_BROADCAST:.*]] = llvm.icmp "sle" %[[LEADING_PRODUCT]], %[[ONE]] : i64
+// CHECK-NEXT:  %[[KN:.*]] = llvm.mul %[[DYN_K]], %[[DYN_N]] : i64
+// CHECK-NEXT:  %[[DYN_B_STRIDE:.*]] = llvm.select %[[IS_BROADCAST]], %[[ZERO]], %[[KN]] : i1, i64
+// CHECK-NEXT:  %[[DYN_SLOT:.*]] = llvm.mlir.constant(-1 : i32) : i32
+// CHECK-NEXT:  %[[DYN_A_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
+// CHECK-NEXT:  %[[DYN_B_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
+// CHECK-NEXT:  %[[DYN_OUT_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
+// CHECK-NEXT:  %[[DYN_ELEM_SIZE:.*]] = llvm.mlir.constant(2 : i64) : i64
+// CHECK-NEXT:  llvm.call @wrap_hipblasLtMatmul(%[[DYN_CTX]], %[[DYN_SLOT]], %[[DYN_A_PTR]], %[[DYN_B_PTR]], %[[DYN_OUT_PTR]], %[[DYN_M]], %[[DYN_N]], %[[DYN_K]], %[[DYN_BATCH]], %[[DYN_ELEM_SIZE]], %[[DYN_B_STRIDE]]) : (!llvm.ptr, i32, !llvm.ptr<1>, !llvm.ptr<1>, !llvm.ptr<1>, i64, i64, i64, i64, i64, i64) -> i32
+// CHECK-NEXT:  llvm.return
+func.func @matmul_dynamic_batch(
+    %ctx: !hipsr.context,
+    %a: memref<?x128x64xf16, #hipsr.mem<device>>,
+    %b: memref<?x64x32xf16, #hipsr.mem<device>>,
+    %init: memref<?x128x32xf16, #hipsr.mem<device>>) {
+  hipsr.matmul(%ctx)
+      ins(%a, %b : memref<?x128x64xf16, #hipsr.mem<device>>,
+                    memref<?x64x32xf16, #hipsr.mem<device>>)
+      outs(%init : memref<?x128x32xf16, #hipsr.mem<device>>)
+  return
+}


### PR DESCRIPTION
## Summary
- add and register LLVM lowering for `hipsr.matmul`
- derive `M`, `N`, `K`, batch count, element size, and broadcast-aware B batch stride for rank-1, rank-2, and batched operands
- declare the `wrap_hipblasLtMatmul` ABI with the `RuntimeFunc` utility , preserving AS1 for A, B, and output device pointers
- add LIT coverage for static rank-2 and dynamic batched lowering

## Test plan
- [x] Build `hip-mlir-opt`
- [x] Run `MorphizenMLIRLitTests` (360 passed, 3 unsupported)

## AI assistance
Cursor assisted with rebasing the implementation onto current `main`, applying the `RuntimeFunc` refactor, and validating the generated lowering. The resulting code was reviewed, built, and tested with the full MLIR LIT suite.