### PR TITLE
fix(morphizen): guard empty output NodeArg in try_fuse

### DIFF
--- a/morphizen/morphizen-core/src/pass.cpp
+++ b/morphizen/morphizen-core/src/pass.cpp
@@ -49,27 +49,6 @@ static bool node_arg_is_initializer(const Graph &graph,
                      });
 }
 
-// Safety helper for the try_fuse boundary. In large hybrid / quantized models
-// some nodes carry an empty (non-existent) NodeArg in an output slot. Calling
-// node_arg_get_name on such a slot fatal-CHECKs in node_arg.cpp
-// ("node_arg doesn't exist!"). Return the first EXISTING output name instead of
-// unconditionally reading output slot 0. A node reaching fusion must still
-// produce at least one real output, so CHECK (like
-// node_get_first_output_node_arg) if none exists rather than emitting a bogus
-// node name.
-static const std::string &node_first_existing_output_name(const Node &node) {
-  const std::string *name = nullptr;
-  for (const NodeArg *arg : node_get_output_node_args(node)) {
-    if (arg != nullptr && node_arg_exists(*arg)) {
-      name = &node_arg_get_name(*arg);
-      break;
-    }
-  }
-  CHECK(name != nullptr) << "no existing output NodeArg on node: "
-                         << node_as_string(node);
-  return *name;
-}
-
 // return values are Node found by node_arg name and the node_arg names
 // that cannot find the node through node_arg
 // Cannot find the node are three scenarios where the node cannot be found using
@@ -306,9 +285,11 @@ check_loop(const Graph &graph, const std::vector<const Node *> &input_nodes,
         if (hit_output) {
           ret = true;
           auto route = map_route[current_node.ptr()];
-          for (size_t i = 0; i < route.size(); i++) {
-            auto node = route[i];
-            maybe_loop_path.push_back(node_first_existing_output_name(*node));
+          for (auto *node : route) {
+            auto node_ref =
+                morphizen_cxx::NodeConstRef::from_node(graph, *node);
+            maybe_loop_path.push_back(
+                node_get_first_existing_output_name(*node_ref.ptr()));
           }
         }
         return false; // leave callback return value
@@ -622,7 +603,7 @@ IPass_try_fuse(const Graph &graph, const std::string &name,
     meta_def->add_constant_initializers(constant_initializer);
   }
   for (auto node : body_nodes) {
-    meta_def->add_nodes(node_first_existing_output_name(*node));
+    meta_def->add_nodes(node_get_first_existing_output_name(*node));
   }
   meta_def->set_device(device);
   return std::make_pair(

--- a/morphizen/morphizen-core/src/pass.cpp
+++ b/morphizen/morphizen-core/src/pass.cpp
@@ -49,6 +49,27 @@ static bool node_arg_is_initializer(const Graph &graph,
                      });
 }
 
+// Safety helper for the try_fuse boundary. In large hybrid / quantized models
+// some nodes carry an empty (non-existent) NodeArg in an output slot. Calling
+// node_arg_get_name on such a slot fatal-CHECKs in node_arg.cpp
+// ("node_arg doesn't exist!"). Return the first EXISTING output name instead of
+// unconditionally reading output slot 0. A node reaching fusion must still
+// produce at least one real output, so CHECK (like
+// node_get_first_output_node_arg) if none exists rather than emitting a bogus
+// node name.
+static const std::string &node_first_existing_output_name(const Node &node) {
+  const std::string *name = nullptr;
+  for (const NodeArg *arg : node_get_output_node_args(node)) {
+    if (arg != nullptr && node_arg_exists(*arg)) {
+      name = &node_arg_get_name(*arg);
+      break;
+    }
+  }
+  CHECK(name != nullptr) << "no existing output NodeArg on node: "
+                         << node_as_string(node);
+  return *name;
+}
+
 // return values are Node found by node_arg name and the node_arg names
 // that cannot find the node through node_arg
 // Cannot find the node are three scenarios where the node cannot be found using
@@ -135,8 +156,9 @@ calculate_return_values(const Graph &graph, const Node &output_node,
   auto args = node_get_output_node_args(output_node);
   auto graph_outputs = morphizen_cxx::GraphConstRef(graph).outputs();
   for (auto arg : args) {
-    if (arg == nullptr) {
-      // for optional outputs
+    if (arg == nullptr || !node_arg_exists(*arg)) {
+      // for optional outputs (nullptr) or empty optional output slots that
+      // carry a non-null but non-existent NodeArg placeholder.
       continue;
     }
     auto &arg_name = node_arg_get_name(*arg);
@@ -286,10 +308,7 @@ check_loop(const Graph &graph, const std::vector<const Node *> &input_nodes,
           auto route = map_route[current_node.ptr()];
           for (size_t i = 0; i < route.size(); i++) {
             auto node = route[i];
-            auto node_ref =
-                morphizen_cxx::NodeConstRef::from_node(graph, *node);
-            maybe_loop_path.push_back(
-                morphizen::node_arg_get_name(node_ref.first_output_node_arg()));
+            maybe_loop_path.push_back(node_first_existing_output_name(*node));
           }
         }
         return false; // leave callback return value
@@ -548,7 +567,13 @@ IPass_try_fuse(const Graph &graph, const std::string &name,
       body_nodes.push_back(island.ptr());
       // insert island's initalizers input args
       for (auto input : node_inputs_1) {
-        if (input.node == nullptr) {
+        // input.node == nullptr covers both real initializers and empty
+        // optional input slots (e.g. DequantizeLinear's optional zero_point in
+        // INT4-quantized models). The latter carry a non-null but non-existent
+        // NodeArg placeholder, so guard node_arg_get_name with node_arg_exists
+        // to avoid the CHECK failure in node_arg.cpp.
+        if (input.node == nullptr && input.node_arg != nullptr &&
+            node_arg_exists(*input.node_arg)) {
           constant_initializers.insert(node_arg_get_name(*input.node_arg));
         }
       }
@@ -597,7 +622,7 @@ IPass_try_fuse(const Graph &graph, const std::string &name,
     meta_def->add_constant_initializers(constant_initializer);
   }
   for (auto node : body_nodes) {
-    meta_def->add_nodes(node_get_first_output_name(*node));
+    meta_def->add_nodes(node_first_existing_output_name(*node));
   }
   meta_def->set_device(device);
   return std::make_pair(

--- a/morphizen/morphizen-core/src/pass_imp.cpp
+++ b/morphizen/morphizen-core/src/pass_imp.cpp
@@ -411,7 +411,22 @@ MetaDefProto &Pass::fuse(Graph &graph, const std::string &name,
   auto graph_ref = morphizen_cxx::GraphConstRef(graph);
   for (auto n : nodes) {
     auto node_ref = graph_ref.node(n);
-    meta_def->add_nodes(node_get_first_output_name(*node_ref.ptr()));
+    const Node &nd = *node_ref.ptr();
+    // Some nodes carry an empty (non-existent) NodeArg in output slot 0 (e.g.
+    // optional outputs in quantized/hybrid models). Use the first existing
+    // output name instead of unconditionally reading slot 0, which fatal-CHECKs
+    // in node_arg.cpp. A fused node must still produce at least one real
+    // output, so CHECK if none exists.
+    const std::string *picked = nullptr;
+    for (const NodeArg *a : node_get_output_node_args(nd)) {
+      if (a != nullptr && node_arg_exists(*a)) {
+        picked = &node_arg_get_name(*a);
+        break;
+      }
+    }
+    CHECK(picked != nullptr)
+        << "no existing output NodeArg on node: " << node_as_string(nd);
+    meta_def->add_nodes(*picked);
   }
   meta_def->set_device(device);
   morphizen::graph_fuse(graph, name, op_type, nodes, inputs, outputs,

--- a/morphizen/morphizen-core/src/pass_imp.cpp
+++ b/morphizen/morphizen-core/src/pass_imp.cpp
@@ -411,22 +411,7 @@ MetaDefProto &Pass::fuse(Graph &graph, const std::string &name,
   auto graph_ref = morphizen_cxx::GraphConstRef(graph);
   for (auto n : nodes) {
     auto node_ref = graph_ref.node(n);
-    const Node &nd = *node_ref.ptr();
-    // Some nodes carry an empty (non-existent) NodeArg in output slot 0 (e.g.
-    // optional outputs in quantized/hybrid models). Use the first existing
-    // output name instead of unconditionally reading slot 0, which fatal-CHECKs
-    // in node_arg.cpp. A fused node must still produce at least one real
-    // output, so CHECK if none exists.
-    const std::string *picked = nullptr;
-    for (const NodeArg *a : node_get_output_node_args(nd)) {
-      if (a != nullptr && node_arg_exists(*a)) {
-        picked = &node_arg_get_name(*a);
-        break;
-      }
-    }
-    CHECK(picked != nullptr)
-        << "no existing output NodeArg on node: " << node_as_string(nd);
-    meta_def->add_nodes(*picked);
+    meta_def->add_nodes(node_get_first_existing_output_name(*node_ref.ptr()));
   }
   meta_def->set_device(device);
   morphizen::graph_fuse(graph, name, op_type, nodes, inputs, outputs,

--- a/morphizen/morphizen-graph/include/morphizen/node.hpp
+++ b/morphizen/morphizen-graph/include/morphizen/node.hpp
@@ -42,6 +42,10 @@ std::vector<NodeInput> node_get_inputs(const Node &node);
 const NodeArg &node_get_output_node_arg(const Node &node);
 std::vector<const NodeArg *> node_get_output_node_args(const Node &node);
 const std::string &node_get_first_output_name(const Node &node);
+// Like node_get_first_output_name, but skips empty/non-existent output slots
+// (some quantized/hybrid models carry a placeholder NodeArg in an output slot).
+// Returns the first EXISTING output's name; CHECK-fails if the node has none.
+const std::string &node_get_first_existing_output_name(const Node &node);
 
 MORPHIZEN_DLL_SPEC const std::string &node_get_output_name(const Node &node);
 MORPHIZEN_DLL_SPEC bool node_is_op(const Node &node, const std::string &op_type,

--- a/morphizen/morphizen-graph/src/node.cpp
+++ b/morphizen/morphizen-graph/src/node.cpp
@@ -128,6 +128,19 @@ const std::string &node_get_first_output_name(const Node &node) {
   return node_arg_get_name(output);
 }
 
+const std::string &node_get_first_existing_output_name(const Node &node) {
+  const std::string *name = nullptr;
+  for (const NodeArg *arg : node_get_output_node_args(node)) {
+    if (arg != nullptr && node_arg_exists(*arg)) {
+      name = &node_arg_get_name(*arg);
+      break;
+    }
+  }
+  CHECK(name != nullptr) << "no existing output NodeArg on node: "
+                         << node_as_string(node);
+  return *name;
+}
+
 bool node_is_op(const Node &node, const std::string &op_type1,
                 const std::string &domain1) {
   auto domain = MORPHIZEN_ORT_API(node_op_domain)(node);


### PR DESCRIPTION
## Summary
Large hybrid/quantized models (e.g. NemotronH INT4-RTN) contain nodes with empty, non-existent `NodeArg` slots. Two distinct cases show up:

- **Empty first output slot** (the crashing case for NemotronH): a multi-output op whose first output is unused. Concretely, NemotronH's `TopK` consumes only its `Indices` output (output 1); the `Values` output (output 0) is unused, so output slot 0 is an empty `NodeArg`.
- **Empty optional input slot**: `DequantizeLinear`'s optional `zero_point` in INT4-quantized weights.

Reading such a slot via `node_arg_get_name` fatal-CHECKs in `node_arg.cpp` (`node_arg doesn't exist!`), aborting the entire model compilation.

Fix:
- Add `node_get_first_existing_output_name()` as a node utility next to `node_get_first_output_name` (in `node.hpp` / `node.cpp`), and use it at every `try_fuse` boundary that reads a node's output name (`calculate_return_values`, `check_loop`, meta_def node emission, and `Pass::fuse`). It skips empty/non-existent output slots and returns the first existing output name. A fused node must still produce at least one real output, so it `CHECK`s (matching `node_get_first_output_node_arg`) rather than emitting a bogus node name.
- The isolated-node initializer collection additionally guards the empty optional input slot with `node_arg_exists` before reading `zero_point`'s name.

## Test plan
- [x] Incremental build on `fix` branch succeeds; `hipgpu.dll` / `hip-compiler.dll` rebuilt and deployed.
- [x] Llama-3.1-8B (INT4) via OGA `run_oga_dynamic` compiles and runs with no `node_arg doesn't exist` crash (`MorphiZen EP Load ONNX Model Success` + `Compilation successful`).
- [x] Baseline comparison: same Llama run on `main` produces byte-identical output, confirming zero behavioral change for models whose output slots all exist.
- [ ] Nemotron INT4-RTN end-to-end compile (the crashing model) -- long-running (~40min), to confirm the original crash is resolved.

Made with [Cursor](https://cursor.com)
