### PR TITLE
feat(hipsr): add typed placeholder shape dependencies

### DIFF
--- a/include/hip/Conversion/Passes.td
+++ b/include/hip/Conversion/Passes.td
@@ -20,8 +20,9 @@ def ConvertOnnxToHipsrPass : Pass<"convert-onnx-to-hipsr", "mlir::ModuleOp"> {
     style with tensor types. ONNX ops are matched by name via the generic MLIR
     Operation API, so no onnx-mlir headers are required.
 
-    Converted DPS operations form a data graph, while their placeholders form
-    a parallel shape-dependency graph. Block arguments, `arith.constant`, and
+    Converted DPS operations form a data graph. Their tied placeholders form a
+    parallel shape-dependency graph in which downstream placeholders use
+    upstream placeholder results. Block arguments, `arith.constant`, and
     `hipsr.constant` results are graph roots.
 
     Shape regions remain empty for the later population pass.

--- a/include/hip/Conversion/Passes.td
+++ b/include/hip/Conversion/Passes.td
@@ -20,9 +20,11 @@ def ConvertOnnxToHipsrPass : Pass<"convert-onnx-to-hipsr", "mlir::ModuleOp"> {
     style with tensor types. ONNX ops are matched by name via the generic MLIR
     Operation API, so no onnx-mlir headers are required.
 
-    Each shaped op's output-shape computation is emitted by the op's own
-    ShapeRegionInterface::populateShapeRegion(), the single source of truth,
-    so this pass exercises that code path (unlike round-trip tests).
+    Converted DPS operations form a data graph, while their placeholders form
+    a parallel shape-dependency graph. Block arguments, `arith.constant`, and
+    `hipsr.constant` results are graph roots.
+
+    Shape regions remain empty for the later population pass.
   }];
   let dependentDialects = [
     "::mlir::hipsr::HipsrDialect",

--- a/include/hip/Dialect/Hipsr/IR/HipsrAttrs.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrAttrs.td
@@ -26,6 +26,13 @@ def Hipsr_MemorySpaceAttr : AttrDef<Hipsr_Dialect, "MemorySpace"> {
   let assemblyFormat = "`<` $kind `>`";
 }
 
+def Hipsr_PlaceholderTypeAttr : AttrDef<Hipsr_Dialect, "PlaceholderType"> {
+  let mnemonic = "placeholder_type";
+  let summary = "hipsr placeholder shape dependency category";
+  let parameters = (ins EnumParameter<Hipsr_PlaceholderType>:$value);
+  let assemblyFormat = "`<` $value `>`";
+}
+
 // A constant whose bytes live in an external file: absolute path + byte offset
 // + byte size. Read on demand (streaming) via the dialect's file-map cache.
 def Hipsr_FileSourceAttr : AttrDef<Hipsr_Dialect, "FileSource"> {

--- a/include/hip/Dialect/Hipsr/IR/HipsrEnums.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrEnums.td
@@ -24,4 +24,16 @@ def Hipsr_MemorySpaceKind : I32EnumAttr<"MemorySpaceKind",
   let genSpecializedAttr = 0;
 }
 
+def Hipsr_PlaceholderNormal :
+    I32EnumAttrCase<"Normal", 0, "normal">;
+def Hipsr_PlaceholderBarrier :
+    I32EnumAttrCase<"Barrier", 1, "barrier">;
+
+def Hipsr_PlaceholderType : I32EnumAttr<"PlaceholderType",
+    "hipsr placeholder shape dependency category",
+    [Hipsr_PlaceholderNormal, Hipsr_PlaceholderBarrier]> {
+  let cppNamespace = "::mlir::hipsr";
+  let genSpecializedAttr = 0;
+}
+
 #endif // HIPSR_ENUMS

--- a/include/hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.td
@@ -10,13 +10,20 @@
 // Hipsr_PlaceholderOp
 //===----------------------------------------------------------------------===//
 
-def Hipsr_PlaceholderOp : Hipsr_Op<"placeholder"> {
+def Hipsr_PlaceholderOp : Hipsr_Op<
+    "placeholder", [IsolatedFromAbove, SingleBlock]> {
   let summary = "Typed placeholder for hipsr DPS init operands";
   let description = [{
     Provides `outs` init values before a hipsr DPS op computes its output
     shape. Each DPS init must have the same type as the matching op result, so
-    the placeholder uses the op's result types. The shape region still computes
-    the output dimensions.
+    the placeholder uses the op's result types.
+
+    The operands mirror the consuming op's DPS inputs, including
+    `!hipsr.context` as operand 0. `type` marks the placeholder as `normal` or
+    `barrier`.
+
+    The optional `shape_region` defines the placeholder result shapes. It has
+    one block when present and ends with `hipsr.shape_yield`.
 
     One placeholder can have several results for one multi-output DPS op. Each
     result must be used once as a DPS init. All results must go to the same
@@ -36,19 +43,40 @@ def Hipsr_PlaceholderOp : Hipsr_Op<"placeholder"> {
 
     Example:
     ```mlir
-    %inits:2 = hipsr.placeholder : tensor<?x?xf16>, tensor<?xi64>
+    %init = hipsr.placeholder(%ctx, %input
+        : !hipsr.context, tensor<?x?xf16>)
+        {type = #hipsr.placeholder_type<normal>} : tensor<?x?xf16>
     ```
   }];
 
+  let arguments = (ins
+    Hipsr_ContextType:$ctx,
+    Variadic<AnyRankedTensor>:$shape_operands,
+    Hipsr_PlaceholderTypeAttr:$type
+  );
   let results = (outs Variadic<AnyRankedTensor>:$results);
+  let regions = (region MaxSizedRegion<1>:$shape_region);
 
-  let assemblyFormat = "attr-dict `:` type($results)";
+  let assemblyFormat = [{
+    `(` $ctx (`,` $shape_operands^)? `:` type($ctx)
+        (`,` type($shape_operands)^)? `)`
+    attr-dict `:` type($results) (`shape_region` $shape_region^)?
+  }];
 
   let hasVerifier = 1;
 
   let builders = [
-    OpBuilder<(ins "::mlir::TypeRange":$resultTypes), [{
+    OpBuilder<(ins "::mlir::TypeRange":$resultTypes,
+                   "::mlir::Value":$ctx,
+                   "::mlir::ValueRange":$shapeOperands,
+                   "::mlir::hipsr::PlaceholderType":$type), [{
+      $_state.addOperands(ctx);
+      $_state.addOperands(shapeOperands);
+      $_state.addAttribute(
+          "type", ::mlir::hipsr::PlaceholderTypeAttr::get(
+                      $_builder.getContext(), type));
       $_state.addTypes(resultTypes);
+      $_state.addRegion();
     }]>
   ];
 }

--- a/include/hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.td
@@ -18,9 +18,8 @@ def Hipsr_PlaceholderOp : Hipsr_Op<
     shape. Each DPS init must have the same type as the matching op result, so
     the placeholder uses the op's result types.
 
-    `!hipsr.context` is operand 0. The remaining inputs form the shape graph:
-    each is a block argument or a result of another placeholder. `type` marks
-    the placeholder as `normal` or `barrier`.
+    `!hipsr.context` is operand 0. The remaining inputs provide values to the
+    shape graph. `type` marks the placeholder as `normal` or `barrier`.
 
     The optional `shape_region` defines the placeholder result shapes. It has
     one block when present and ends with `hipsr.shape_yield`.

--- a/include/hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.td
@@ -43,8 +43,8 @@ def Hipsr_PlaceholderOp : Hipsr_Op<
 
     Example:
     ```mlir
-    %init = hipsr.placeholder(%ctx, %input
-        : tensor<?x?xf16>)
+    %init = hipsr.placeholder(%ctx)
+        ins(%input : tensor<?x?xf16>)
         {type = #hipsr.placeholder_type<normal>} : tensor<?x?xf16>
     ```
   }];
@@ -58,7 +58,7 @@ def Hipsr_PlaceholderOp : Hipsr_Op<
   let regions = (region MaxSizedRegion<1>:$shape_region);
 
   let assemblyFormat = [{
-    `(` $ctx (`,` $inputs^ `:` type($inputs))? `)`
+    `(` $ctx `)` (`ins` `(` $inputs^ `:` type($inputs) `)`)?
     attr-dict `:` type($results) (`shape_region` $shape_region^)?
   }];
 

--- a/include/hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.td
@@ -24,6 +24,9 @@ def Hipsr_PlaceholderOp : Hipsr_Op<
     `arith.constant`, or `hipsr.constant`. `type` marks the placeholder as
     `normal` or `barrier`.
 
+    The shape graph is independent of DPS data inputs: downstream placeholders
+    use upstream placeholder results rather than DPS data results.
+
     The optional `shape_region` defines the placeholder result shapes. It has
     one block when present and ends with `hipsr.shape_yield`.
 

--- a/include/hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.td
@@ -18,16 +18,16 @@ def Hipsr_PlaceholderOp : Hipsr_Op<
     shape. Each DPS init must have the same type as the matching op result, so
     the placeholder uses the op's result types.
 
-    The operands mirror the consuming op's DPS inputs, including
-    `!hipsr.context` as operand 0. `type` marks the placeholder as `normal` or
-    `barrier`.
+    `!hipsr.context` is operand 0. The remaining inputs form the shape graph:
+    each is a block argument or a result of another placeholder. `type` marks
+    the placeholder as `normal` or `barrier`.
 
     The optional `shape_region` defines the placeholder result shapes. It has
     one block when present and ends with `hipsr.shape_yield`.
 
     One placeholder can have several results for one multi-output DPS op. Each
-    result must be used once as a DPS init. All results must go to the same
-    hipsr op.
+    result initializes exactly one DPS result and may also feed other
+    placeholders. All DPS init uses must go to the same hipsr op.
 
     Each placeholder is tied to one DPS op. It is not `Pure`, so CSE cannot
     merge placeholders used by different ops.
@@ -63,6 +63,12 @@ def Hipsr_PlaceholderOp : Hipsr_Op<
   }];
 
   let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    /// Returns the hipsr DPS operation initialized by this placeholder, or
+    /// null if no such use exists.
+    ::mlir::Operation *getDpsConsumer();
+  }];
 
   let builders = [
     OpBuilder<(ins "::mlir::TypeRange":$resultTypes,

--- a/include/hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.td
@@ -44,22 +44,21 @@ def Hipsr_PlaceholderOp : Hipsr_Op<
     Example:
     ```mlir
     %init = hipsr.placeholder(%ctx, %input
-        : !hipsr.context, tensor<?x?xf16>)
+        : tensor<?x?xf16>)
         {type = #hipsr.placeholder_type<normal>} : tensor<?x?xf16>
     ```
   }];
 
   let arguments = (ins
     Hipsr_ContextType:$ctx,
-    Variadic<AnyRankedTensor>:$shape_operands,
+    Variadic<AnyRankedTensor>:$inputs,
     Hipsr_PlaceholderTypeAttr:$type
   );
   let results = (outs Variadic<AnyRankedTensor>:$results);
   let regions = (region MaxSizedRegion<1>:$shape_region);
 
   let assemblyFormat = [{
-    `(` $ctx (`,` $shape_operands^)? `:` type($ctx)
-        (`,` type($shape_operands)^)? `)`
+    `(` $ctx (`,` $inputs^ `:` type($inputs))? `)`
     attr-dict `:` type($results) (`shape_region` $shape_region^)?
   }];
 
@@ -68,10 +67,10 @@ def Hipsr_PlaceholderOp : Hipsr_Op<
   let builders = [
     OpBuilder<(ins "::mlir::TypeRange":$resultTypes,
                    "::mlir::Value":$ctx,
-                   "::mlir::ValueRange":$shapeOperands,
+                   "::mlir::ValueRange":$inputs,
                    "::mlir::hipsr::PlaceholderType":$type), [{
       $_state.addOperands(ctx);
-      $_state.addOperands(shapeOperands);
+      $_state.addOperands(inputs);
       $_state.addAttribute(
           "type", ::mlir::hipsr::PlaceholderTypeAttr::get(
                       $_builder.getContext(), type));

--- a/include/hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.td
@@ -20,7 +20,9 @@ def Hipsr_PlaceholderOp : Hipsr_Op<
     the placeholder uses the op's result types.
 
     `!hipsr.context` is operand 0. The remaining inputs provide values to the
-    shape graph. `type` marks the placeholder as `normal` or `barrier`.
+    shape graph and must be block arguments or results of `hipsr.placeholder`,
+    `arith.constant`, or `hipsr.constant`. `type` marks the placeholder as
+    `normal` or `barrier`.
 
     The optional `shape_region` defines the placeholder result shapes. It has
     one block when present and ends with `hipsr.shape_yield`.
@@ -65,6 +67,9 @@ def Hipsr_PlaceholderOp : Hipsr_Op<
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
+    /// Returns whether a value may be used as a placeholder shape-graph input.
+    static bool isAllowedShapeGraphInput(::mlir::Value value);
+
     /// Returns the hipsr DPS operation initialized by this placeholder, or
     /// null if no such use exists.
     ::mlir::Operation *getDpsConsumer();

--- a/include/hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.td
@@ -11,7 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 def Hipsr_PlaceholderOp : Hipsr_Op<
-    "placeholder", [IsolatedFromAbove, SingleBlock]> {
+    "placeholder",
+    [IsolatedFromAbove, SingleBlockImplicitTerminator<"ShapeYieldOp">]> {
   let summary = "Typed placeholder for hipsr DPS init operands";
   let description = [{
     Provides `outs` init values before a hipsr DPS op computes its output

--- a/include/hip/Dialect/Hipsr/Transforms/Passes.td
+++ b/include/hip/Dialect/Hipsr/Transforms/Passes.td
@@ -64,34 +64,31 @@ def PartitionPoolDomainsPass
     ```mlir
     func.func @graph(%ctx: !hipsr.context, %input: tensor<?x4xf32>,
         %shape: tensor<2xi64>) -> tensor<?x4xf16> {
-      %cast_init = hipsr.placeholder(
-          %ctx, %input : tensor<?x4xf32>)
+      %cast_init = hipsr.placeholder(%ctx)
+          ins(%input : tensor<?x4xf32>)
           {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
       %cast = hipsr.cast(%ctx) ins(%input : tensor<?x4xf32>)
           outs(%cast_init : tensor<?x4xf16>) : tensor<?x4xf16>
-      %ready_init = hipsr.placeholder(
-          %ctx, %cast : tensor<?x4xf16>)
+      %ready_init = hipsr.placeholder(%ctx)
+          ins(%cast : tensor<?x4xf16>)
           {type = #hipsr.placeholder_type<barrier>} : tensor<?x4xf16>
       %ready = hipsr.example_end_barrier(%ctx)
           ins(%cast : tensor<?x4xf16>)
           outs(%ready_init : tensor<?x4xf16>) : tensor<?x4xf16>
-      %add_init = hipsr.placeholder(
-          %ctx, %ready, %ready
-          : tensor<?x4xf16>, tensor<?x4xf16>)
+      %add_init = hipsr.placeholder(%ctx)
+          ins(%ready, %ready : tensor<?x4xf16>, tensor<?x4xf16>)
           {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
       %sum = hipsr.add(%ctx)
           ins(%ready, %ready : tensor<?x4xf16>, tensor<?x4xf16>)
           outs(%add_init : tensor<?x4xf16>) : tensor<?x4xf16>
-      %expand_init = hipsr.placeholder(
-          %ctx, %sum, %shape
-          : tensor<?x4xf16>, tensor<2xi64>)
+      %expand_init = hipsr.placeholder(%ctx)
+          ins(%sum, %shape : tensor<?x4xf16>, tensor<2xi64>)
           {type = #hipsr.placeholder_type<barrier>} : tensor<?x4xf16>
       %expanded = hipsr.expand(%ctx)
           ins(%sum, %shape : tensor<?x4xf16>, tensor<2xi64>)
           outs(%expand_init : tensor<?x4xf16>) : tensor<?x4xf16>
-      %result_init = hipsr.placeholder(
-          %ctx, %expanded, %expanded
-          : tensor<?x4xf16>, tensor<?x4xf16>)
+      %result_init = hipsr.placeholder(%ctx)
+          ins(%expanded, %expanded : tensor<?x4xf16>, tensor<?x4xf16>)
           {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
       %result = hipsr.add(%ctx)
           ins(%expanded, %expanded : tensor<?x4xf16>, tensor<?x4xf16>)
@@ -108,14 +105,14 @@ def PartitionPoolDomainsPass
           : !hipsr.context, tensor<?x4xf32>) {
       ^bb0(%domain_ctx: !hipsr.context,
            %domain_input: tensor<?x4xf32>):
-        %cast_init = hipsr.placeholder(
-            %domain_ctx, %domain_input : tensor<?x4xf32>)
+        %cast_init = hipsr.placeholder(%domain_ctx)
+            ins(%domain_input : tensor<?x4xf32>)
             {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
         %cast = hipsr.cast(%domain_ctx)
             ins(%domain_input : tensor<?x4xf32>)
             outs(%cast_init : tensor<?x4xf16>) : tensor<?x4xf16>
-        %ready_init = hipsr.placeholder(
-            %domain_ctx, %cast : tensor<?x4xf16>)
+        %ready_init = hipsr.placeholder(%domain_ctx)
+            ins(%cast : tensor<?x4xf16>)
             {type = #hipsr.placeholder_type<barrier>}
             : tensor<?x4xf16>
         %ready = hipsr.example_end_barrier(%domain_ctx)
@@ -127,9 +124,9 @@ def PartitionPoolDomainsPass
           : !hipsr.context, tensor<?x4xf16>) {
       ^bb0(%domain_ctx: !hipsr.context,
            %domain_input: tensor<?x4xf16>):
-        %add_init = hipsr.placeholder(
-            %domain_ctx, %domain_input, %domain_input
-            : tensor<?x4xf16>, tensor<?x4xf16>)
+        %add_init = hipsr.placeholder(%domain_ctx)
+            ins(%domain_input, %domain_input
+                : tensor<?x4xf16>, tensor<?x4xf16>)
             {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
         %sum = hipsr.add(%domain_ctx)
             ins(%domain_input, %domain_input
@@ -142,18 +139,18 @@ def PartitionPoolDomainsPass
       ^bb0(%domain_ctx: !hipsr.context,
            %domain_input: tensor<?x4xf16>,
            %domain_shape: tensor<2xi64>):
-        %expand_init = hipsr.placeholder(
-            %domain_ctx, %domain_input, %domain_shape
-            : tensor<?x4xf16>, tensor<2xi64>)
+        %expand_init = hipsr.placeholder(%domain_ctx)
+            ins(%domain_input, %domain_shape
+                : tensor<?x4xf16>, tensor<2xi64>)
             {type = #hipsr.placeholder_type<barrier>}
             : tensor<?x4xf16>
         %expanded = hipsr.expand(%domain_ctx)
             ins(%domain_input, %domain_shape
                 : tensor<?x4xf16>, tensor<2xi64>)
             outs(%expand_init : tensor<?x4xf16>) : tensor<?x4xf16>
-        %result_init = hipsr.placeholder(
-            %domain_ctx, %expanded, %expanded
-            : tensor<?x4xf16>, tensor<?x4xf16>)
+        %result_init = hipsr.placeholder(%domain_ctx)
+            ins(%expanded, %expanded
+                : tensor<?x4xf16>, tensor<?x4xf16>)
             {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
         %result = hipsr.add(%domain_ctx)
             ins(%expanded, %expanded : tensor<?x4xf16>, tensor<?x4xf16>)

--- a/include/hip/Dialect/Hipsr/Transforms/Passes.td
+++ b/include/hip/Dialect/Hipsr/Transforms/Passes.td
@@ -64,22 +64,35 @@ def PartitionPoolDomainsPass
     ```mlir
     func.func @graph(%ctx: !hipsr.context, %input: tensor<?x4xf32>,
         %shape: tensor<2xi64>) -> tensor<?x4xf16> {
-      %cast_init = hipsr.placeholder : tensor<?x4xf16>
+      %cast_init = hipsr.placeholder(
+          %ctx, %input : !hipsr.context, tensor<?x4xf32>)
+          {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
       %cast = hipsr.cast(%ctx) ins(%input : tensor<?x4xf32>)
           outs(%cast_init : tensor<?x4xf16>) : tensor<?x4xf16>
-      %ready_init = hipsr.placeholder : tensor<?x4xf16>
+      %ready_init = hipsr.placeholder(
+          %ctx, %cast : !hipsr.context, tensor<?x4xf16>)
+          {type = #hipsr.placeholder_type<barrier>} : tensor<?x4xf16>
       %ready = hipsr.example_end_barrier(%ctx)
           ins(%cast : tensor<?x4xf16>)
           outs(%ready_init : tensor<?x4xf16>) : tensor<?x4xf16>
-      %add_init = hipsr.placeholder : tensor<?x4xf16>
+      %add_init = hipsr.placeholder(
+          %ctx, %ready, %ready
+          : !hipsr.context, tensor<?x4xf16>, tensor<?x4xf16>)
+          {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
       %sum = hipsr.add(%ctx)
           ins(%ready, %ready : tensor<?x4xf16>, tensor<?x4xf16>)
           outs(%add_init : tensor<?x4xf16>) : tensor<?x4xf16>
-      %expand_init = hipsr.placeholder : tensor<?x4xf16>
+      %expand_init = hipsr.placeholder(
+          %ctx, %sum, %shape
+          : !hipsr.context, tensor<?x4xf16>, tensor<2xi64>)
+          {type = #hipsr.placeholder_type<barrier>} : tensor<?x4xf16>
       %expanded = hipsr.expand(%ctx)
           ins(%sum, %shape : tensor<?x4xf16>, tensor<2xi64>)
           outs(%expand_init : tensor<?x4xf16>) : tensor<?x4xf16>
-      %result_init = hipsr.placeholder : tensor<?x4xf16>
+      %result_init = hipsr.placeholder(
+          %ctx, %expanded, %expanded
+          : !hipsr.context, tensor<?x4xf16>, tensor<?x4xf16>)
+          {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
       %result = hipsr.add(%ctx)
           ins(%expanded, %expanded : tensor<?x4xf16>, tensor<?x4xf16>)
           outs(%result_init : tensor<?x4xf16>) : tensor<?x4xf16>
@@ -95,11 +108,16 @@ def PartitionPoolDomainsPass
           : !hipsr.context, tensor<?x4xf32>) {
       ^bb0(%domain_ctx: !hipsr.context,
            %domain_input: tensor<?x4xf32>):
-        %cast_init = hipsr.placeholder : tensor<?x4xf16>
+        %cast_init = hipsr.placeholder(
+            %domain_ctx, %domain_input : !hipsr.context, tensor<?x4xf32>)
+            {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
         %cast = hipsr.cast(%domain_ctx)
             ins(%domain_input : tensor<?x4xf32>)
             outs(%cast_init : tensor<?x4xf16>) : tensor<?x4xf16>
-        %ready_init = hipsr.placeholder : tensor<?x4xf16>
+        %ready_init = hipsr.placeholder(
+            %domain_ctx, %cast : !hipsr.context, tensor<?x4xf16>)
+            {type = #hipsr.placeholder_type<barrier>}
+            : tensor<?x4xf16>
         %ready = hipsr.example_end_barrier(%domain_ctx)
             ins(%cast : tensor<?x4xf16>)
             outs(%ready_init : tensor<?x4xf16>) : tensor<?x4xf16>
@@ -109,7 +127,10 @@ def PartitionPoolDomainsPass
           : !hipsr.context, tensor<?x4xf16>) {
       ^bb0(%domain_ctx: !hipsr.context,
            %domain_input: tensor<?x4xf16>):
-        %add_init = hipsr.placeholder : tensor<?x4xf16>
+        %add_init = hipsr.placeholder(
+            %domain_ctx, %domain_input, %domain_input
+            : !hipsr.context, tensor<?x4xf16>, tensor<?x4xf16>)
+            {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
         %sum = hipsr.add(%domain_ctx)
             ins(%domain_input, %domain_input
                 : tensor<?x4xf16>, tensor<?x4xf16>)
@@ -121,12 +142,19 @@ def PartitionPoolDomainsPass
       ^bb0(%domain_ctx: !hipsr.context,
            %domain_input: tensor<?x4xf16>,
            %domain_shape: tensor<2xi64>):
-        %expand_init = hipsr.placeholder : tensor<?x4xf16>
+        %expand_init = hipsr.placeholder(
+            %domain_ctx, %domain_input, %domain_shape
+            : !hipsr.context, tensor<?x4xf16>, tensor<2xi64>)
+            {type = #hipsr.placeholder_type<barrier>}
+            : tensor<?x4xf16>
         %expanded = hipsr.expand(%domain_ctx)
             ins(%domain_input, %domain_shape
                 : tensor<?x4xf16>, tensor<2xi64>)
             outs(%expand_init : tensor<?x4xf16>) : tensor<?x4xf16>
-        %result_init = hipsr.placeholder : tensor<?x4xf16>
+        %result_init = hipsr.placeholder(
+            %domain_ctx, %expanded, %expanded
+            : !hipsr.context, tensor<?x4xf16>, tensor<?x4xf16>)
+            {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
         %result = hipsr.add(%domain_ctx)
             ins(%expanded, %expanded : tensor<?x4xf16>, tensor<?x4xf16>)
             outs(%result_init : tensor<?x4xf16>) : tensor<?x4xf16>

--- a/include/hip/Dialect/Hipsr/Transforms/Passes.td
+++ b/include/hip/Dialect/Hipsr/Transforms/Passes.td
@@ -70,25 +70,25 @@ def PartitionPoolDomainsPass
       %cast = hipsr.cast(%ctx) ins(%input : tensor<?x4xf32>)
           outs(%cast_init : tensor<?x4xf16>) : tensor<?x4xf16>
       %ready_init = hipsr.placeholder(%ctx)
-          ins(%cast : tensor<?x4xf16>)
+          ins(%input : tensor<?x4xf32>)
           {type = #hipsr.placeholder_type<barrier>} : tensor<?x4xf16>
       %ready = hipsr.example_end_barrier(%ctx)
           ins(%cast : tensor<?x4xf16>)
           outs(%ready_init : tensor<?x4xf16>) : tensor<?x4xf16>
       %add_init = hipsr.placeholder(%ctx)
-          ins(%ready, %ready : tensor<?x4xf16>, tensor<?x4xf16>)
+          ins(%input, %input : tensor<?x4xf32>, tensor<?x4xf32>)
           {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
       %sum = hipsr.add(%ctx)
           ins(%ready, %ready : tensor<?x4xf16>, tensor<?x4xf16>)
           outs(%add_init : tensor<?x4xf16>) : tensor<?x4xf16>
       %expand_init = hipsr.placeholder(%ctx)
-          ins(%sum, %shape : tensor<?x4xf16>, tensor<2xi64>)
+          ins(%input, %shape : tensor<?x4xf32>, tensor<2xi64>)
           {type = #hipsr.placeholder_type<barrier>} : tensor<?x4xf16>
       %expanded = hipsr.expand(%ctx)
           ins(%sum, %shape : tensor<?x4xf16>, tensor<2xi64>)
           outs(%expand_init : tensor<?x4xf16>) : tensor<?x4xf16>
       %result_init = hipsr.placeholder(%ctx)
-          ins(%expanded, %expanded : tensor<?x4xf16>, tensor<?x4xf16>)
+          ins(%input, %input : tensor<?x4xf32>, tensor<?x4xf32>)
           {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
       %result = hipsr.add(%ctx)
           ins(%expanded, %expanded : tensor<?x4xf16>, tensor<?x4xf16>)
@@ -112,7 +112,7 @@ def PartitionPoolDomainsPass
             ins(%domain_input : tensor<?x4xf32>)
             outs(%cast_init : tensor<?x4xf16>) : tensor<?x4xf16>
         %ready_init = hipsr.placeholder(%domain_ctx)
-            ins(%cast : tensor<?x4xf16>)
+            ins(%domain_input : tensor<?x4xf32>)
             {type = #hipsr.placeholder_type<barrier>}
             : tensor<?x4xf16>
         %ready = hipsr.example_end_barrier(%domain_ctx)
@@ -120,13 +120,14 @@ def PartitionPoolDomainsPass
             outs(%ready_init : tensor<?x4xf16>) : tensor<?x4xf16>
         hipsr.pool_domain_yield %ready : tensor<?x4xf16>
       } -> tensor<?x4xf16>
-      %1 = hipsr.pool_domain(%ctx, %0
-          : !hipsr.context, tensor<?x4xf16>) {
+      %1 = hipsr.pool_domain(%ctx, %input, %0
+          : !hipsr.context, tensor<?x4xf32>, tensor<?x4xf16>) {
       ^bb0(%domain_ctx: !hipsr.context,
+           %shape_root: tensor<?x4xf32>,
            %domain_input: tensor<?x4xf16>):
         %add_init = hipsr.placeholder(%domain_ctx)
-            ins(%domain_input, %domain_input
-                : tensor<?x4xf16>, tensor<?x4xf16>)
+            ins(%shape_root, %shape_root
+                : tensor<?x4xf32>, tensor<?x4xf32>)
             {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
         %sum = hipsr.add(%domain_ctx)
             ins(%domain_input, %domain_input
@@ -134,14 +135,16 @@ def PartitionPoolDomainsPass
             outs(%add_init : tensor<?x4xf16>) : tensor<?x4xf16>
         hipsr.pool_domain_yield %sum : tensor<?x4xf16>
       } -> tensor<?x4xf16>
-      %2 = hipsr.pool_domain(%ctx, %1, %shape
-          : !hipsr.context, tensor<?x4xf16>, tensor<2xi64>) {
+      %2 = hipsr.pool_domain(%ctx, %input, %1, %shape
+          : !hipsr.context, tensor<?x4xf32>, tensor<?x4xf16>,
+            tensor<2xi64>) {
       ^bb0(%domain_ctx: !hipsr.context,
+           %shape_root: tensor<?x4xf32>,
            %domain_input: tensor<?x4xf16>,
            %domain_shape: tensor<2xi64>):
         %expand_init = hipsr.placeholder(%domain_ctx)
-            ins(%domain_input, %domain_shape
-                : tensor<?x4xf16>, tensor<2xi64>)
+            ins(%shape_root, %domain_shape
+                : tensor<?x4xf32>, tensor<2xi64>)
             {type = #hipsr.placeholder_type<barrier>}
             : tensor<?x4xf16>
         %expanded = hipsr.expand(%domain_ctx)
@@ -149,8 +152,8 @@ def PartitionPoolDomainsPass
                 : tensor<?x4xf16>, tensor<2xi64>)
             outs(%expand_init : tensor<?x4xf16>) : tensor<?x4xf16>
         %result_init = hipsr.placeholder(%domain_ctx)
-            ins(%expanded, %expanded
-                : tensor<?x4xf16>, tensor<?x4xf16>)
+            ins(%shape_root, %shape_root
+                : tensor<?x4xf32>, tensor<?x4xf32>)
             {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
         %result = hipsr.add(%domain_ctx)
             ins(%expanded, %expanded : tensor<?x4xf16>, tensor<?x4xf16>)

--- a/include/hip/Dialect/Hipsr/Transforms/Passes.td
+++ b/include/hip/Dialect/Hipsr/Transforms/Passes.td
@@ -65,33 +65,33 @@ def PartitionPoolDomainsPass
     func.func @graph(%ctx: !hipsr.context, %input: tensor<?x4xf32>,
         %shape: tensor<2xi64>) -> tensor<?x4xf16> {
       %cast_init = hipsr.placeholder(
-          %ctx, %input : !hipsr.context, tensor<?x4xf32>)
+          %ctx, %input : tensor<?x4xf32>)
           {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
       %cast = hipsr.cast(%ctx) ins(%input : tensor<?x4xf32>)
           outs(%cast_init : tensor<?x4xf16>) : tensor<?x4xf16>
       %ready_init = hipsr.placeholder(
-          %ctx, %cast : !hipsr.context, tensor<?x4xf16>)
+          %ctx, %cast : tensor<?x4xf16>)
           {type = #hipsr.placeholder_type<barrier>} : tensor<?x4xf16>
       %ready = hipsr.example_end_barrier(%ctx)
           ins(%cast : tensor<?x4xf16>)
           outs(%ready_init : tensor<?x4xf16>) : tensor<?x4xf16>
       %add_init = hipsr.placeholder(
           %ctx, %ready, %ready
-          : !hipsr.context, tensor<?x4xf16>, tensor<?x4xf16>)
+          : tensor<?x4xf16>, tensor<?x4xf16>)
           {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
       %sum = hipsr.add(%ctx)
           ins(%ready, %ready : tensor<?x4xf16>, tensor<?x4xf16>)
           outs(%add_init : tensor<?x4xf16>) : tensor<?x4xf16>
       %expand_init = hipsr.placeholder(
           %ctx, %sum, %shape
-          : !hipsr.context, tensor<?x4xf16>, tensor<2xi64>)
+          : tensor<?x4xf16>, tensor<2xi64>)
           {type = #hipsr.placeholder_type<barrier>} : tensor<?x4xf16>
       %expanded = hipsr.expand(%ctx)
           ins(%sum, %shape : tensor<?x4xf16>, tensor<2xi64>)
           outs(%expand_init : tensor<?x4xf16>) : tensor<?x4xf16>
       %result_init = hipsr.placeholder(
           %ctx, %expanded, %expanded
-          : !hipsr.context, tensor<?x4xf16>, tensor<?x4xf16>)
+          : tensor<?x4xf16>, tensor<?x4xf16>)
           {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
       %result = hipsr.add(%ctx)
           ins(%expanded, %expanded : tensor<?x4xf16>, tensor<?x4xf16>)
@@ -109,13 +109,13 @@ def PartitionPoolDomainsPass
       ^bb0(%domain_ctx: !hipsr.context,
            %domain_input: tensor<?x4xf32>):
         %cast_init = hipsr.placeholder(
-            %domain_ctx, %domain_input : !hipsr.context, tensor<?x4xf32>)
+            %domain_ctx, %domain_input : tensor<?x4xf32>)
             {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
         %cast = hipsr.cast(%domain_ctx)
             ins(%domain_input : tensor<?x4xf32>)
             outs(%cast_init : tensor<?x4xf16>) : tensor<?x4xf16>
         %ready_init = hipsr.placeholder(
-            %domain_ctx, %cast : !hipsr.context, tensor<?x4xf16>)
+            %domain_ctx, %cast : tensor<?x4xf16>)
             {type = #hipsr.placeholder_type<barrier>}
             : tensor<?x4xf16>
         %ready = hipsr.example_end_barrier(%domain_ctx)
@@ -129,7 +129,7 @@ def PartitionPoolDomainsPass
            %domain_input: tensor<?x4xf16>):
         %add_init = hipsr.placeholder(
             %domain_ctx, %domain_input, %domain_input
-            : !hipsr.context, tensor<?x4xf16>, tensor<?x4xf16>)
+            : tensor<?x4xf16>, tensor<?x4xf16>)
             {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
         %sum = hipsr.add(%domain_ctx)
             ins(%domain_input, %domain_input
@@ -144,7 +144,7 @@ def PartitionPoolDomainsPass
            %domain_shape: tensor<2xi64>):
         %expand_init = hipsr.placeholder(
             %domain_ctx, %domain_input, %domain_shape
-            : !hipsr.context, tensor<?x4xf16>, tensor<2xi64>)
+            : tensor<?x4xf16>, tensor<2xi64>)
             {type = #hipsr.placeholder_type<barrier>}
             : tensor<?x4xf16>
         %expanded = hipsr.expand(%domain_ctx)
@@ -153,7 +153,7 @@ def PartitionPoolDomainsPass
             outs(%expand_init : tensor<?x4xf16>) : tensor<?x4xf16>
         %result_init = hipsr.placeholder(
             %domain_ctx, %expanded, %expanded
-            : !hipsr.context, tensor<?x4xf16>, tensor<?x4xf16>)
+            : tensor<?x4xf16>, tensor<?x4xf16>)
             {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
         %result = hipsr.add(%domain_ctx)
             ins(%expanded, %expanded : tensor<?x4xf16>, tensor<?x4xf16>)

--- a/include/hip/Dialect/Hipsr/Transforms/Passes.td
+++ b/include/hip/Dialect/Hipsr/Transforms/Passes.td
@@ -70,25 +70,25 @@ def PartitionPoolDomainsPass
       %cast = hipsr.cast(%ctx) ins(%input : tensor<?x4xf32>)
           outs(%cast_init : tensor<?x4xf16>) : tensor<?x4xf16>
       %ready_init = hipsr.placeholder(%ctx)
-          ins(%cast_init : tensor<?x4xf16>)
+          ins(%cast : tensor<?x4xf16>)
           {type = #hipsr.placeholder_type<barrier>} : tensor<?x4xf16>
       %ready = hipsr.example_end_barrier(%ctx)
           ins(%cast : tensor<?x4xf16>)
           outs(%ready_init : tensor<?x4xf16>) : tensor<?x4xf16>
       %add_init = hipsr.placeholder(%ctx)
-          ins(%ready_init, %ready_init : tensor<?x4xf16>, tensor<?x4xf16>)
+          ins(%ready, %ready : tensor<?x4xf16>, tensor<?x4xf16>)
           {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
       %sum = hipsr.add(%ctx)
           ins(%ready, %ready : tensor<?x4xf16>, tensor<?x4xf16>)
           outs(%add_init : tensor<?x4xf16>) : tensor<?x4xf16>
       %expand_init = hipsr.placeholder(%ctx)
-          ins(%add_init, %shape : tensor<?x4xf16>, tensor<2xi64>)
+          ins(%sum, %shape : tensor<?x4xf16>, tensor<2xi64>)
           {type = #hipsr.placeholder_type<barrier>} : tensor<?x4xf16>
       %expanded = hipsr.expand(%ctx)
           ins(%sum, %shape : tensor<?x4xf16>, tensor<2xi64>)
           outs(%expand_init : tensor<?x4xf16>) : tensor<?x4xf16>
       %result_init = hipsr.placeholder(%ctx)
-          ins(%expand_init, %expand_init : tensor<?x4xf16>, tensor<?x4xf16>)
+          ins(%expanded, %expanded : tensor<?x4xf16>, tensor<?x4xf16>)
           {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
       %result = hipsr.add(%ctx)
           ins(%expanded, %expanded : tensor<?x4xf16>, tensor<?x4xf16>)
@@ -112,7 +112,7 @@ def PartitionPoolDomainsPass
             ins(%domain_input : tensor<?x4xf32>)
             outs(%cast_init : tensor<?x4xf16>) : tensor<?x4xf16>
         %ready_init = hipsr.placeholder(%domain_ctx)
-            ins(%cast_init : tensor<?x4xf16>)
+            ins(%cast : tensor<?x4xf16>)
             {type = #hipsr.placeholder_type<barrier>}
             : tensor<?x4xf16>
         %ready = hipsr.example_end_barrier(%domain_ctx)
@@ -149,7 +149,7 @@ def PartitionPoolDomainsPass
                 : tensor<?x4xf16>, tensor<2xi64>)
             outs(%expand_init : tensor<?x4xf16>) : tensor<?x4xf16>
         %result_init = hipsr.placeholder(%domain_ctx)
-            ins(%expand_init, %expand_init
+            ins(%expanded, %expanded
                 : tensor<?x4xf16>, tensor<?x4xf16>)
             {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
         %result = hipsr.add(%domain_ctx)

--- a/include/hip/Dialect/Hipsr/Transforms/Passes.td
+++ b/include/hip/Dialect/Hipsr/Transforms/Passes.td
@@ -70,25 +70,25 @@ def PartitionPoolDomainsPass
       %cast = hipsr.cast(%ctx) ins(%input : tensor<?x4xf32>)
           outs(%cast_init : tensor<?x4xf16>) : tensor<?x4xf16>
       %ready_init = hipsr.placeholder(%ctx)
-          ins(%cast : tensor<?x4xf16>)
+          ins(%cast_init : tensor<?x4xf16>)
           {type = #hipsr.placeholder_type<barrier>} : tensor<?x4xf16>
       %ready = hipsr.example_end_barrier(%ctx)
           ins(%cast : tensor<?x4xf16>)
           outs(%ready_init : tensor<?x4xf16>) : tensor<?x4xf16>
       %add_init = hipsr.placeholder(%ctx)
-          ins(%ready, %ready : tensor<?x4xf16>, tensor<?x4xf16>)
+          ins(%ready_init, %ready_init : tensor<?x4xf16>, tensor<?x4xf16>)
           {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
       %sum = hipsr.add(%ctx)
           ins(%ready, %ready : tensor<?x4xf16>, tensor<?x4xf16>)
           outs(%add_init : tensor<?x4xf16>) : tensor<?x4xf16>
       %expand_init = hipsr.placeholder(%ctx)
-          ins(%sum, %shape : tensor<?x4xf16>, tensor<2xi64>)
+          ins(%add_init, %shape : tensor<?x4xf16>, tensor<2xi64>)
           {type = #hipsr.placeholder_type<barrier>} : tensor<?x4xf16>
       %expanded = hipsr.expand(%ctx)
           ins(%sum, %shape : tensor<?x4xf16>, tensor<2xi64>)
           outs(%expand_init : tensor<?x4xf16>) : tensor<?x4xf16>
       %result_init = hipsr.placeholder(%ctx)
-          ins(%expanded, %expanded : tensor<?x4xf16>, tensor<?x4xf16>)
+          ins(%expand_init, %expand_init : tensor<?x4xf16>, tensor<?x4xf16>)
           {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
       %result = hipsr.add(%ctx)
           ins(%expanded, %expanded : tensor<?x4xf16>, tensor<?x4xf16>)
@@ -112,7 +112,7 @@ def PartitionPoolDomainsPass
             ins(%domain_input : tensor<?x4xf32>)
             outs(%cast_init : tensor<?x4xf16>) : tensor<?x4xf16>
         %ready_init = hipsr.placeholder(%domain_ctx)
-            ins(%cast : tensor<?x4xf16>)
+            ins(%cast_init : tensor<?x4xf16>)
             {type = #hipsr.placeholder_type<barrier>}
             : tensor<?x4xf16>
         %ready = hipsr.example_end_barrier(%domain_ctx)
@@ -149,7 +149,7 @@ def PartitionPoolDomainsPass
                 : tensor<?x4xf16>, tensor<2xi64>)
             outs(%expand_init : tensor<?x4xf16>) : tensor<?x4xf16>
         %result_init = hipsr.placeholder(%domain_ctx)
-            ins(%expanded, %expanded
+            ins(%expand_init, %expand_init
                 : tensor<?x4xf16>, tensor<?x4xf16>)
             {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
         %result = hipsr.add(%domain_ctx)

--- a/lib/Conversion/OnnxToHipsr/CastConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/CastConversion.cpp
@@ -42,11 +42,6 @@ struct CastToHipsr : public ::mlir::RewritePattern {
 
     ::mlir::Location loc = op->getLoc();
     ::mlir::Value input = op->getOperand(0);
-    ::mlir::FailureOr<::mlir::Value> placeholderInput =
-        getPlaceholderDependency(input, op, rewriter);
-    if (::mlir::failed(placeholderInput)) {
-      return ::mlir::failure();
-    }
     auto resultType =
         ::mlir::dyn_cast<::mlir::RankedTensorType>(op->getResult(0).getType());
     if (!resultType) {
@@ -56,7 +51,7 @@ struct CastToHipsr : public ::mlir::RewritePattern {
     ::mlir::Value init =
         rewriter
             .create<PlaceholderOp>(loc, ::mlir::TypeRange{resultType}, *ctx,
-                                   ::mlir::ValueRange{*placeholderInput},
+                                   ::mlir::ValueRange{input},
                                    PlaceholderType::Normal)
             .getResult(0);
 

--- a/lib/Conversion/OnnxToHipsr/CastConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/CastConversion.cpp
@@ -49,7 +49,10 @@ struct CastToHipsr : public ::mlir::RewritePattern {
     }
 
     ::mlir::Value init =
-        rewriter.create<PlaceholderOp>(loc, ::mlir::TypeRange{resultType})
+        rewriter
+            .create<PlaceholderOp>(loc, ::mlir::TypeRange{resultType}, *ctx,
+                                   ::mlir::ValueRange{input},
+                                   PlaceholderType::Normal)
             .getResult(0);
 
     auto castOp = rewriter.create<CastOp>(loc, ::mlir::TypeRange{resultType},

--- a/lib/Conversion/OnnxToHipsr/CastConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/CastConversion.cpp
@@ -42,6 +42,11 @@ struct CastToHipsr : public ::mlir::RewritePattern {
 
     ::mlir::Location loc = op->getLoc();
     ::mlir::Value input = op->getOperand(0);
+    ::mlir::FailureOr<::mlir::Value> placeholderInput =
+        getPlaceholderDependency(input, op, rewriter);
+    if (::mlir::failed(placeholderInput)) {
+      return ::mlir::failure();
+    }
     auto resultType =
         ::mlir::dyn_cast<::mlir::RankedTensorType>(op->getResult(0).getType());
     if (!resultType) {
@@ -51,7 +56,7 @@ struct CastToHipsr : public ::mlir::RewritePattern {
     ::mlir::Value init =
         rewriter
             .create<PlaceholderOp>(loc, ::mlir::TypeRange{resultType}, *ctx,
-                                   ::mlir::ValueRange{input},
+                                   ::mlir::ValueRange{*placeholderInput},
                                    PlaceholderType::Normal)
             .getResult(0);
 

--- a/lib/Conversion/OnnxToHipsr/ExpandConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/ExpandConversion.cpp
@@ -31,13 +31,6 @@ struct ExpandToHipsr : public ::mlir::RewritePattern {
 
     ::mlir::Value input = op->getOperand(0);
     ::mlir::Value shape = op->getOperand(1);
-    ::mlir::FailureOr<::mlir::Value> placeholderInput =
-        getPlaceholderDependency(input, op, rewriter);
-    ::mlir::FailureOr<::mlir::Value> placeholderShape =
-        getPlaceholderDependency(shape, op, rewriter);
-    if (::mlir::failed(placeholderInput) || ::mlir::failed(placeholderShape)) {
-      return ::mlir::failure();
-    }
     auto inputType =
         ::mlir::dyn_cast<::mlir::RankedTensorType>(input.getType());
     if (!inputType) {
@@ -79,10 +72,9 @@ struct ExpandToHipsr : public ::mlir::RewritePattern {
 
     ::mlir::Location loc = op->getLoc();
     ::mlir::Value init =
-        PlaceholderOp::create(
-            rewriter, loc, ::mlir::TypeRange{resultType}, *ctx,
-            ::mlir::ValueRange{*placeholderInput, *placeholderShape},
-            PlaceholderType::Barrier)
+        PlaceholderOp::create(rewriter, loc, ::mlir::TypeRange{resultType},
+                              *ctx, ::mlir::ValueRange{input, shape},
+                              PlaceholderType::Barrier)
             .getResult(0);
     auto expandOp =
         ExpandOp::create(rewriter, loc, ::mlir::TypeRange{resultType}, *ctx,

--- a/lib/Conversion/OnnxToHipsr/ExpandConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/ExpandConversion.cpp
@@ -31,6 +31,13 @@ struct ExpandToHipsr : public ::mlir::RewritePattern {
 
     ::mlir::Value input = op->getOperand(0);
     ::mlir::Value shape = op->getOperand(1);
+    ::mlir::FailureOr<::mlir::Value> placeholderInput =
+        getPlaceholderDependency(input, op, rewriter);
+    ::mlir::FailureOr<::mlir::Value> placeholderShape =
+        getPlaceholderDependency(shape, op, rewriter);
+    if (::mlir::failed(placeholderInput) || ::mlir::failed(placeholderShape)) {
+      return ::mlir::failure();
+    }
     auto inputType =
         ::mlir::dyn_cast<::mlir::RankedTensorType>(input.getType());
     if (!inputType) {
@@ -72,9 +79,10 @@ struct ExpandToHipsr : public ::mlir::RewritePattern {
 
     ::mlir::Location loc = op->getLoc();
     ::mlir::Value init =
-        PlaceholderOp::create(rewriter, loc, ::mlir::TypeRange{resultType},
-                              *ctx, ::mlir::ValueRange{input, shape},
-                              PlaceholderType::Barrier)
+        PlaceholderOp::create(
+            rewriter, loc, ::mlir::TypeRange{resultType}, *ctx,
+            ::mlir::ValueRange{*placeholderInput, *placeholderShape},
+            PlaceholderType::Barrier)
             .getResult(0);
     auto expandOp =
         ExpandOp::create(rewriter, loc, ::mlir::TypeRange{resultType}, *ctx,

--- a/lib/Conversion/OnnxToHipsr/ExpandConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/ExpandConversion.cpp
@@ -72,7 +72,9 @@ struct ExpandToHipsr : public ::mlir::RewritePattern {
 
     ::mlir::Location loc = op->getLoc();
     ::mlir::Value init =
-        PlaceholderOp::create(rewriter, loc, ::mlir::TypeRange{resultType})
+        PlaceholderOp::create(rewriter, loc, ::mlir::TypeRange{resultType},
+                              *ctx, ::mlir::ValueRange{input, shape},
+                              PlaceholderType::Barrier)
             .getResult(0);
     auto expandOp =
         ExpandOp::create(rewriter, loc, ::mlir::TypeRange{resultType}, *ctx,

--- a/lib/Conversion/OnnxToHipsr/MatMulConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/MatMulConversion.cpp
@@ -14,18 +14,6 @@ namespace mlir {
 namespace hipsr {
 namespace {
 
-/// onnx.MatMul -> hipsr.matmul. The shape region is left empty here; a later
-/// pass populates every op's shape region uniformly (see populateShapeRegion).
-/// The `!hipsr.context` threaded onto the op comes from function arg 0 (added
-/// in the ONNX phase).
-///
-/// Before:
-///   %0 = "onnx.MatMul"(%A, %B) : (tensor<?x?xf16>, tensor<?x?xf16>)
-///                                 -> tensor<?x?xf16>
-/// After:
-///   %init = hipsr.placeholder : tensor<?x?xf16>
-///   %0 = hipsr.matmul(%ctx) ins(%A, %B : tensor<?x?xf16>, tensor<?x?xf16>)
-///                           outs(%init : tensor<?x?xf16>) : tensor<?x?xf16>
 struct MatMulToHipsr : public ::mlir::RewritePattern {
   MatMulToHipsr(::mlir::MLIRContext *ctx)
       : RewritePattern("onnx.MatMul", /*benefit=*/1, ctx) {}
@@ -54,14 +42,13 @@ struct MatMulToHipsr : public ::mlir::RewritePattern {
       return rewriter.notifyMatchFailure(op, "expected ranked tensor result");
     }
 
-    // A hipsr.placeholder mirroring the result type satisfies the DPS verifier
-    // without computing the output shape here; a later pass fills that in.
-    ::mlir::Value init =
-        rewriter.create<PlaceholderOp>(loc, ::mlir::TypeRange{resultType})
-            .getResult(0);
+    ::mlir::Value init = PlaceholderOp::create(
+                             rewriter, loc, ::mlir::TypeRange{resultType}, *ctx,
+                             ::mlir::ValueRange{a, b}, PlaceholderType::Normal)
+                             .getResult(0);
 
-    auto matmulOp = rewriter.create<MatMulOp>(
-        loc, ::mlir::TypeRange{resultType}, *ctx, a, b, init);
+    auto matmulOp = MatMulOp::create(
+        rewriter, loc, ::mlir::TypeRange{resultType}, *ctx, a, b, init);
 
     rewriter.replaceOp(op, matmulOp.getResult(0));
     return ::mlir::success();

--- a/lib/Conversion/OnnxToHipsr/MatMulConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/MatMulConversion.cpp
@@ -36,6 +36,13 @@ struct MatMulToHipsr : public ::mlir::RewritePattern {
     ::mlir::Location loc = op->getLoc();
     ::mlir::Value a = op->getOperand(0);
     ::mlir::Value b = op->getOperand(1);
+    ::mlir::FailureOr<::mlir::Value> placeholderA =
+        getPlaceholderDependency(a, op, rewriter);
+    ::mlir::FailureOr<::mlir::Value> placeholderB =
+        getPlaceholderDependency(b, op, rewriter);
+    if (::mlir::failed(placeholderA) || ::mlir::failed(placeholderB)) {
+      return ::mlir::failure();
+    }
     auto resultType =
         ::mlir::dyn_cast<::mlir::RankedTensorType>(op->getResult(0).getType());
     if (!resultType) {
@@ -44,7 +51,8 @@ struct MatMulToHipsr : public ::mlir::RewritePattern {
 
     ::mlir::Value init = PlaceholderOp::create(
                              rewriter, loc, ::mlir::TypeRange{resultType}, *ctx,
-                             ::mlir::ValueRange{a, b}, PlaceholderType::Normal)
+                             ::mlir::ValueRange{*placeholderA, *placeholderB},
+                             PlaceholderType::Normal)
                              .getResult(0);
 
     auto matmulOp = MatMulOp::create(

--- a/lib/Conversion/OnnxToHipsr/MatMulConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/MatMulConversion.cpp
@@ -36,13 +36,6 @@ struct MatMulToHipsr : public ::mlir::RewritePattern {
     ::mlir::Location loc = op->getLoc();
     ::mlir::Value a = op->getOperand(0);
     ::mlir::Value b = op->getOperand(1);
-    ::mlir::FailureOr<::mlir::Value> placeholderA =
-        getPlaceholderDependency(a, op, rewriter);
-    ::mlir::FailureOr<::mlir::Value> placeholderB =
-        getPlaceholderDependency(b, op, rewriter);
-    if (::mlir::failed(placeholderA) || ::mlir::failed(placeholderB)) {
-      return ::mlir::failure();
-    }
     auto resultType =
         ::mlir::dyn_cast<::mlir::RankedTensorType>(op->getResult(0).getType());
     if (!resultType) {
@@ -51,8 +44,7 @@ struct MatMulToHipsr : public ::mlir::RewritePattern {
 
     ::mlir::Value init = PlaceholderOp::create(
                              rewriter, loc, ::mlir::TypeRange{resultType}, *ctx,
-                             ::mlir::ValueRange{*placeholderA, *placeholderB},
-                             PlaceholderType::Normal)
+                             ::mlir::ValueRange{a, b}, PlaceholderType::Normal)
                              .getResult(0);
 
     auto matmulOp = MatMulOp::create(

--- a/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
+++ b/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
@@ -6,18 +6,23 @@
 //
 // Converts ONNX dialect IR into hipsr dialect IR (tensor DPS). ONNX ops are
 // matched by name via the generic MLIR Operation API, so no onnx-mlir headers
-// are required. Each pattern emits the hipsr op with its shape region left
-// empty; a later pass fills the region via ShapeRegionInterface.
+// are required. After rewriting, placeholder dependencies are separated from
+// data dependencies. A later pass fills shape regions via ShapeRegionInterface.
 //
 //===----------------------------------------------------------------------===//
 
 #include "hip/Conversion/OnnxToHipsr/OnnxToHipsr.h"
-#include "hip/Dialect/Hipsr/IR/HipsrDialect.h"
+#include "hip/Dialect/Hipsr/IR/HipsrOps.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Shape/IR/Shape.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Interfaces/DestinationStyleOpInterface.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
 
 namespace mlir {
 namespace hipsr {
@@ -26,6 +31,64 @@ namespace hipsr {
 #include "hip/Conversion/Passes.h.inc"
 
 namespace {
+
+// Replace placeholder data dependencies with tied placeholder results.
+static ::mlir::LogicalResult
+finalizePlaceholderDependencies(::mlir::ModuleOp module) {
+  ::llvm::DenseMap<::mlir::Value, ::mlir::Value> placeholderForDataResult;
+  module.walk([&](::mlir::DestinationStyleOpInterface dpsOp) {
+    for (::mlir::OpResult result : dpsOp->getResults()) {
+      ::mlir::OpOperand *initOperand = dpsOp.getTiedOpOperand(result);
+      if (!initOperand) {
+        continue;
+      }
+
+      auto placeholder = initOperand->get().getDefiningOp<PlaceholderOp>();
+      if (!placeholder || placeholder->getDialect() != dpsOp->getDialect()) {
+        continue;
+      }
+      placeholderForDataResult.try_emplace(result, initOperand->get());
+    }
+  });
+
+  ::llvm::SmallVector<std::pair<::mlir::OpOperand *, ::mlir::Value>>
+      replacements;
+  ::mlir::WalkResult walkResult =
+      module.walk([&](PlaceholderOp placeholder) -> ::mlir::WalkResult {
+        ::mlir::MutableOperandRange mutableInputs =
+            placeholder.getInputsMutable();
+        for (auto [inputIndex, input] :
+             ::llvm::enumerate(placeholder.getInputs())) {
+          auto replacement = placeholderForDataResult.find(input);
+          ::mlir::Value resolvedInput =
+              replacement == placeholderForDataResult.end()
+                  ? input
+                  : replacement->second;
+          if (!PlaceholderOp::isAllowedShapeGraphInput(resolvedInput)) {
+            placeholder.emitOpError("input ")
+                << inputIndex
+                << " must be a block argument or a result of "
+                   "hipsr.placeholder, arith.constant, or hipsr.constant; got "
+                   "result of '"
+                << resolvedInput.getDefiningOp()->getName() << "'";
+            return ::mlir::WalkResult::interrupt();
+          }
+          if (resolvedInput != input) {
+            replacements.emplace_back(&mutableInputs[inputIndex],
+                                      resolvedInput);
+          }
+        }
+        return ::mlir::WalkResult::advance();
+      });
+  if (walkResult.wasInterrupted()) {
+    return ::mlir::failure();
+  }
+
+  for (auto [operand, value] : replacements) {
+    operand->set(value);
+  }
+  return ::mlir::success();
+}
 
 struct ConvertOnnxToHipsrPass
     : impl::ConvertOnnxToHipsrPassBase<ConvertOnnxToHipsrPass> {
@@ -43,6 +106,11 @@ struct ConvertOnnxToHipsrPass
     config.setStrictness(::mlir::GreedyRewriteStrictness::ExistingOps);
     if (::mlir::failed(::mlir::applyPatternsGreedily(
             getOperation(), std::move(patterns), config))) {
+      signalPassFailure();
+      return;
+    }
+    // Build the parallel shape graph after all data-graph rewrites finish.
+    if (::mlir::failed(finalizePlaceholderDependencies(getOperation()))) {
       signalPassFailure();
     }
   }

--- a/lib/Conversion/OnnxToHipsr/OnnxToHipsrUtils.h
+++ b/lib/Conversion/OnnxToHipsr/OnnxToHipsrUtils.h
@@ -13,10 +13,11 @@
 #ifndef HIP_CONVERSION_ONNXTOHIPSR_UTILS_H
 #define HIP_CONVERSION_ONNXTOHIPSR_UTILS_H
 
-#include "hip/Dialect/Hipsr/IR/HipsrDialect.h"
+#include "hip/Dialect/Hipsr/IR/HipsrOps.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/Interfaces/DestinationStyleOpInterface.h"
 
 namespace mlir {
 namespace hipsr {
@@ -42,6 +43,36 @@ getHipsrContextArg(::mlir::Operation *op, ::mlir::PatternRewriter &rewriter) {
                                        "first argument is not !hipsr.context");
   }
   return ctx;
+}
+
+/// Maps a data-graph input to the matching shape-graph dependency. Function
+/// inputs are shared roots. A hipsr DPS result maps to its placeholder init.
+inline ::mlir::FailureOr<::mlir::Value>
+getPlaceholderDependency(::mlir::Value input, ::mlir::Operation *op,
+                         ::mlir::PatternRewriter &rewriter) {
+  if (::mlir::isa<::mlir::BlockArgument>(input)) {
+    return input;
+  }
+
+  auto result = ::mlir::dyn_cast<::mlir::OpResult>(input);
+  if (!result) {
+    return rewriter.notifyMatchFailure(op,
+                                       "input has no shape-graph dependency");
+  }
+  auto dpsProducer =
+      ::mlir::dyn_cast<::mlir::DestinationStyleOpInterface>(result.getOwner());
+  if (!dpsProducer || result.getOwner()->getName().getDialectNamespace() !=
+                          HipsrDialect::getDialectNamespace()) {
+    return rewriter.notifyMatchFailure(
+        op, "input is not a function argument or hipsr DPS result");
+  }
+
+  ::mlir::Value init = dpsProducer.getTiedOpOperand(result)->get();
+  if (!init.getDefiningOp<::mlir::hipsr::PlaceholderOp>()) {
+    return rewriter.notifyMatchFailure(
+        op, "hipsr DPS input producer has no placeholder init");
+  }
+  return init;
 }
 
 } // namespace hipsr

--- a/lib/Conversion/OnnxToHipsr/OnnxToHipsrUtils.h
+++ b/lib/Conversion/OnnxToHipsr/OnnxToHipsrUtils.h
@@ -13,11 +13,10 @@
 #ifndef HIP_CONVERSION_ONNXTOHIPSR_UTILS_H
 #define HIP_CONVERSION_ONNXTOHIPSR_UTILS_H
 
-#include "hip/Dialect/Hipsr/IR/HipsrOps.h"
+#include "hip/Dialect/Hipsr/IR/HipsrDialect.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/PatternMatch.h"
-#include "mlir/Interfaces/DestinationStyleOpInterface.h"
 
 namespace mlir {
 namespace hipsr {
@@ -43,36 +42,6 @@ getHipsrContextArg(::mlir::Operation *op, ::mlir::PatternRewriter &rewriter) {
                                        "first argument is not !hipsr.context");
   }
   return ctx;
-}
-
-/// Maps a data-graph input to the matching shape-graph dependency. Function
-/// inputs are shared roots. A hipsr DPS result maps to its placeholder init.
-inline ::mlir::FailureOr<::mlir::Value>
-getPlaceholderDependency(::mlir::Value input, ::mlir::Operation *op,
-                         ::mlir::PatternRewriter &rewriter) {
-  if (::mlir::isa<::mlir::BlockArgument>(input)) {
-    return input;
-  }
-
-  auto result = ::mlir::dyn_cast<::mlir::OpResult>(input);
-  if (!result) {
-    return rewriter.notifyMatchFailure(op,
-                                       "input has no shape-graph dependency");
-  }
-  auto dpsProducer =
-      ::mlir::dyn_cast<::mlir::DestinationStyleOpInterface>(result.getOwner());
-  if (!dpsProducer || result.getOwner()->getName().getDialectNamespace() !=
-                          HipsrDialect::getDialectNamespace()) {
-    return rewriter.notifyMatchFailure(
-        op, "input is not a function argument or hipsr DPS result");
-  }
-
-  ::mlir::Value init = dpsProducer.getTiedOpOperand(result)->get();
-  if (!init.getDefiningOp<::mlir::hipsr::PlaceholderOp>()) {
-    return rewriter.notifyMatchFailure(
-        op, "hipsr DPS input producer has no placeholder init");
-  }
-  return init;
 }
 
 } // namespace hipsr

--- a/lib/Dialect/Hipsr/IR/HipsrPlaceholderOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrPlaceholderOp.cpp
@@ -12,44 +12,77 @@
 using namespace mlir;
 using namespace mlir::hipsr;
 
+Operation *PlaceholderOp::getDpsConsumer() {
+  for (Value result : getResults()) {
+    for (OpOperand &use : result.getUses()) {
+      Operation *owner = use.getOwner();
+      auto dpsOp = dyn_cast<DestinationStyleOpInterface>(owner);
+      if (dpsOp && owner->getDialect() == getOperation()->getDialect() &&
+          dpsOp.isDpsInit(&use)) {
+        return owner;
+      }
+    }
+  }
+  return nullptr;
+}
+
 LogicalResult PlaceholderOp::verify() {
   if (getNumResults() == 0) {
     return emitOpError("must produce at least one tensor DPS init");
   }
 
+  if (!isa<BlockArgument>(getCtx())) {
+    return emitOpError("context must be a block argument");
+  }
+  for (auto [inputIndex, input] : llvm::enumerate(getInputs())) {
+    if (isa<BlockArgument>(input) || input.getDefiningOp<PlaceholderOp>()) {
+      continue;
+    }
+    return emitOpError("input ")
+           << inputIndex
+           << " must be a block argument or result of hipsr.placeholder";
+  }
+
   Operation *consumer = nullptr;
-  for (Value result : getResults()) {
-    if (!result.hasOneUse()) {
-      return emitOpError("requires each result to have exactly one use");
+  for (auto [resultIndex, result] : llvm::enumerate(getResults())) {
+    OpOperand *dpsInitUse = nullptr;
+    for (OpOperand &use : result.getUses()) {
+      Operation *owner = use.getOwner();
+      if (isa<PlaceholderOp>(owner)) {
+        continue;
+      }
+
+      auto dpsOp = dyn_cast<DestinationStyleOpInterface>(owner);
+      if (!dpsOp || owner->getDialect() != getOperation()->getDialect() ||
+          !dpsOp.isDpsInit(&use)) {
+        return emitOpError("requires each result use to be a placeholder input "
+                           "or a DPS init of a hipsr operation");
+      }
+      if (dpsInitUse) {
+        return emitOpError(
+            "requires each result to initialize exactly one hipsr operation");
+      }
+      dpsInitUse = &use;
+    }
+    if (!dpsInitUse) {
+      return emitOpError(
+          "requires each result to initialize exactly one hipsr operation");
     }
 
-    OpOperand &use = *result.getUses().begin();
-    Operation *owner = use.getOwner();
-    auto dpsOp = dyn_cast<DestinationStyleOpInterface>(owner);
-    if (!dpsOp || owner->getDialect() != getOperation()->getDialect() ||
-        !dpsOp.isDpsInit(&use)) {
-      return emitOpError(
-          "requires each result to be used as a DPS init of a hipsr operation");
+    Operation *owner = dpsInitUse->getOwner();
+    auto dpsOp = cast<DestinationStyleOpInterface>(owner);
+    OpResult consumerResult = dpsOp.getTiedOpResult(dpsInitUse);
+    if (result.getType() != consumerResult.getType()) {
+      return emitOpError("result ")
+             << resultIndex << " type " << result.getType()
+             << " must match consumer result type " << consumerResult.getType();
     }
+
     if (consumer && consumer != owner) {
       return emitOpError(
           "requires all results to initialize the same hipsr operation");
     }
     consumer = owner;
-  }
-
-  auto dpsConsumer = cast<DestinationStyleOpInterface>(consumer);
-  SmallVector<Value> consumerInputs = dpsConsumer.getDpsInputs();
-  if (getNumOperands() != consumerInputs.size()) {
-    return emitOpError("operand count must match consumer DPS input count; "
-                       "expected ")
-           << consumerInputs.size() << ", got " << getNumOperands();
-  }
-  for (auto [index, input] : llvm::enumerate(consumerInputs)) {
-    if (getOperand(index) != input) {
-      return emitOpError("operand ")
-             << index << " must match consumer DPS input " << index;
-    }
   }
 
   if (getBodyRegion().empty()) {

--- a/lib/Dialect/Hipsr/IR/HipsrPlaceholderOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrPlaceholderOp.cpp
@@ -5,12 +5,23 @@
 
 #include "hip/Dialect/Hipsr/IR/HipsrOps.h"
 
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Interfaces/DestinationStyleOpInterface.h"
 
 #include "llvm/ADT/STLExtras.h"
 
 using namespace mlir;
 using namespace mlir::hipsr;
+
+bool PlaceholderOp::isAllowedShapeGraphInput(Value value) {
+  if (isa<BlockArgument>(value)) {
+    return true;
+  }
+
+  Operation *definingOp = value.getDefiningOp();
+  return isa_and_nonnull<PlaceholderOp, ConstantOp, arith::ConstantOp>(
+      definingOp);
+}
 
 Operation *PlaceholderOp::getDpsConsumer() {
   for (Value result : getResults()) {
@@ -29,6 +40,16 @@ Operation *PlaceholderOp::getDpsConsumer() {
 LogicalResult PlaceholderOp::verify() {
   if (getNumResults() == 0) {
     return emitOpError("must produce at least one tensor DPS init");
+  }
+
+  for (auto [inputIndex, input] : llvm::enumerate(getInputs())) {
+    if (!isAllowedShapeGraphInput(input)) {
+      return emitOpError("input ")
+             << inputIndex
+             << " must be a block argument or a result of hipsr.placeholder, "
+                "arith.constant, or hipsr.constant; got result of '"
+             << input.getDefiningOp()->getName() << "'";
+    }
   }
 
   Operation *consumer = nullptr;

--- a/lib/Dialect/Hipsr/IR/HipsrPlaceholderOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrPlaceholderOp.cpp
@@ -84,9 +84,5 @@ LogicalResult PlaceholderOp::verify() {
            << getNumOperands() << ", got " << block.getNumArguments();
   }
 
-  if (block.empty() || !isa<ShapeYieldOp>(block.back())) {
-    return emitOpError("shape region must terminate with hipsr.shape_yield");
-  }
-
   return success();
 }

--- a/lib/Dialect/Hipsr/IR/HipsrPlaceholderOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrPlaceholderOp.cpp
@@ -31,18 +31,6 @@ LogicalResult PlaceholderOp::verify() {
     return emitOpError("must produce at least one tensor DPS init");
   }
 
-  if (!isa<BlockArgument>(getCtx())) {
-    return emitOpError("context must be a block argument");
-  }
-  for (auto [inputIndex, input] : llvm::enumerate(getInputs())) {
-    if (isa<BlockArgument>(input) || input.getDefiningOp<PlaceholderOp>()) {
-      continue;
-    }
-    return emitOpError("input ")
-           << inputIndex
-           << " must be a block argument or result of hipsr.placeholder";
-  }
-
   Operation *consumer = nullptr;
   for (auto [resultIndex, result] : llvm::enumerate(getResults())) {
     OpOperand *dpsInitUse = nullptr;

--- a/lib/Dialect/Hipsr/IR/HipsrPlaceholderOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrPlaceholderOp.cpp
@@ -7,6 +7,8 @@
 
 #include "mlir/Interfaces/DestinationStyleOpInterface.h"
 
+#include "llvm/ADT/STLExtras.h"
+
 using namespace mlir;
 using namespace mlir::hipsr;
 
@@ -34,6 +36,35 @@ LogicalResult PlaceholderOp::verify() {
           "requires all results to initialize the same hipsr operation");
     }
     consumer = owner;
+  }
+
+  auto dpsConsumer = cast<DestinationStyleOpInterface>(consumer);
+  SmallVector<Value> consumerInputs = dpsConsumer.getDpsInputs();
+  if (getNumOperands() != consumerInputs.size()) {
+    return emitOpError("operand count must match consumer DPS input count; "
+                       "expected ")
+           << consumerInputs.size() << ", got " << getNumOperands();
+  }
+  for (auto [index, input] : llvm::enumerate(consumerInputs)) {
+    if (getOperand(index) != input) {
+      return emitOpError("operand ")
+             << index << " must match consumer DPS input " << index;
+    }
+  }
+
+  if (getBodyRegion().empty()) {
+    return success();
+  }
+
+  Block &block = *getBody();
+  if (block.getNumArguments() != getNumOperands()) {
+    return emitOpError("shape region block argument count must match operand "
+                       "count; expected ")
+           << getNumOperands() << ", got " << block.getNumArguments();
+  }
+
+  if (block.empty() || !isa<ShapeYieldOp>(block.back())) {
+    return emitOpError("shape region must terminate with hipsr.shape_yield");
   }
 
   return success();

--- a/lib/Dialect/Hipsr/Transforms/PartitionPoolDomains.cpp
+++ b/lib/Dialect/Hipsr/Transforms/PartitionPoolDomains.cpp
@@ -13,7 +13,6 @@
 #include "mlir/Interfaces/DestinationStyleOpInterface.h"
 #include "mlir/Transforms/RegionUtils.h"
 
-#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetVector.h"
@@ -145,6 +144,8 @@ static LogicalResult validatePartitionInput(Block &block) {
 static void computeDomainResults(Domain &domain, Block &parentBlock) {
   llvm::SmallPtrSet<Operation *, 16> domainOperations(domain.operations.begin(),
                                                       domain.operations.end());
+  // Placeholder operands mirror their consumers' inputs. Treat those uses as
+  // internal when the consumer belongs to this domain.
   for (Operation *operation : domain.operations) {
     if (!isHipsrDpsOp(*operation)) {
       continue;
@@ -165,66 +166,6 @@ static void computeDomainResults(Domain &domain, Block &parentBlock) {
       });
       if (escapes) {
         domain.results.push_back(result);
-      }
-    }
-  }
-}
-
-static OpResult getConsumerResult(PlaceholderOp placeholder,
-                                  Value placeholderResult) {
-  Operation *consumer = placeholder.getDpsConsumer();
-  auto dpsConsumer = cast<DestinationStyleOpInterface>(consumer);
-  for (OpOperand &use : placeholderResult.getUses()) {
-    if (use.getOwner() == consumer && dpsConsumer.isDpsInit(&use)) {
-      return dpsConsumer.getTiedOpResult(&use);
-    }
-  }
-  llvm_unreachable("verified placeholder has no DPS init use");
-}
-
-// A placeholder edge that crosses a domain boundary becomes a block argument
-// backed by the matching data result:
-//
-// Before: %prev = hipsr.cast ... outs(%prev_init)
-//         %next_init = hipsr.placeholder ... ins(%prev_init)
-// After:  %prev = hipsr.cast ... outs(%prev_init)
-//         %next_init = hipsr.placeholder ... ins(%prev)
-//
-// makeRegionIsolatedFromAbove then replaces %prev with the destination
-// domain's block argument.
-static void
-redirectCrossDomainShapeDependencies(MutableArrayRef<Domain> domains) {
-  llvm::DenseMap<Operation *, Domain *> operationDomains;
-  for (Domain &domain : domains) {
-    for (Operation *operation : domain.operations) {
-      operationDomains.insert({operation, &domain});
-    }
-  }
-
-  llvm::SmallPtrSet<Operation *, 16> visitedPlaceholders;
-  for (Domain &domain : domains) {
-    for (Operation *operation : domain.operations) {
-      if (!isHipsrDpsOp(*operation)) {
-        continue;
-      }
-      auto dpsOp = cast<DestinationStyleOpInterface>(*operation);
-      for (Value init : dpsOp.getDpsInits()) {
-        auto placeholder = init.getDefiningOp<PlaceholderOp>();
-        if (!placeholder || !visitedPlaceholders.insert(placeholder).second) {
-          continue;
-        }
-
-        for (Value result : placeholder.getResults()) {
-          OpResult consumerResult = getConsumerResult(placeholder, result);
-          for (OpOperand &use : llvm::make_early_inc_range(result.getUses())) {
-            auto dependent = dyn_cast<PlaceholderOp>(use.getOwner());
-            if (!dependent || operationDomains.lookup(
-                                  dependent.getDpsConsumer()) == &domain) {
-              continue;
-            }
-            use.set(consumerResult);
-          }
-        }
       }
     }
   }
@@ -258,7 +199,6 @@ static SmallVector<Domain> partitionIntoDomains(Block &block) {
     }
   }
 
-  redirectCrossDomainShapeDependencies(domains);
   for (Domain &domain : domains) {
     computeDomainResults(domain, block);
   }

--- a/lib/Dialect/Hipsr/Transforms/PartitionPoolDomains.cpp
+++ b/lib/Dialect/Hipsr/Transforms/PartitionPoolDomains.cpp
@@ -13,6 +13,7 @@
 #include "mlir/Interfaces/DestinationStyleOpInterface.h"
 #include "mlir/Transforms/RegionUtils.h"
 
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetVector.h"
@@ -120,8 +121,8 @@ static LogicalResult validatePartitionInput(Block &block) {
     }
 
     if (auto placeholder = dyn_cast<PlaceholderOp>(operation)) {
-      Operation *consumer = *placeholder->getResult(0).getUsers().begin();
-      if (consumer->getBlock() != &block) {
+      Operation *consumer = placeholder.getDpsConsumer();
+      if (!consumer || consumer->getBlock() != &block) {
         placeholder.emitOpError(
             "requires its DPS consumer to be top-level when partitioning pool "
             "domains");
@@ -144,8 +145,6 @@ static LogicalResult validatePartitionInput(Block &block) {
 static void computeDomainResults(Domain &domain, Block &parentBlock) {
   llvm::SmallPtrSet<Operation *, 16> domainOperations(domain.operations.begin(),
                                                       domain.operations.end());
-  // Placeholder operands mirror their consumers' inputs. Treat those uses as
-  // internal when the consumer belongs to this domain.
   for (Operation *operation : domain.operations) {
     if (!isHipsrDpsOp(*operation)) {
       continue;
@@ -166,6 +165,66 @@ static void computeDomainResults(Domain &domain, Block &parentBlock) {
       });
       if (escapes) {
         domain.results.push_back(result);
+      }
+    }
+  }
+}
+
+static OpResult getConsumerResult(PlaceholderOp placeholder,
+                                  Value placeholderResult) {
+  Operation *consumer = placeholder.getDpsConsumer();
+  auto dpsConsumer = cast<DestinationStyleOpInterface>(consumer);
+  for (OpOperand &use : placeholderResult.getUses()) {
+    if (use.getOwner() == consumer && dpsConsumer.isDpsInit(&use)) {
+      return dpsConsumer.getTiedOpResult(&use);
+    }
+  }
+  llvm_unreachable("verified placeholder has no DPS init use");
+}
+
+// A placeholder edge that crosses a domain boundary becomes a block argument
+// backed by the matching data result:
+//
+// Before: %prev = hipsr.cast ... outs(%prev_init)
+//         %next_init = hipsr.placeholder ... ins(%prev_init)
+// After:  %prev = hipsr.cast ... outs(%prev_init)
+//         %next_init = hipsr.placeholder ... ins(%prev)
+//
+// makeRegionIsolatedFromAbove then replaces %prev with the destination
+// domain's block argument.
+static void
+redirectCrossDomainShapeDependencies(MutableArrayRef<Domain> domains) {
+  llvm::DenseMap<Operation *, Domain *> operationDomains;
+  for (Domain &domain : domains) {
+    for (Operation *operation : domain.operations) {
+      operationDomains.insert({operation, &domain});
+    }
+  }
+
+  llvm::SmallPtrSet<Operation *, 16> visitedPlaceholders;
+  for (Domain &domain : domains) {
+    for (Operation *operation : domain.operations) {
+      if (!isHipsrDpsOp(*operation)) {
+        continue;
+      }
+      auto dpsOp = cast<DestinationStyleOpInterface>(*operation);
+      for (Value init : dpsOp.getDpsInits()) {
+        auto placeholder = init.getDefiningOp<PlaceholderOp>();
+        if (!placeholder || !visitedPlaceholders.insert(placeholder).second) {
+          continue;
+        }
+
+        for (Value result : placeholder.getResults()) {
+          OpResult consumerResult = getConsumerResult(placeholder, result);
+          for (OpOperand &use : llvm::make_early_inc_range(result.getUses())) {
+            auto dependent = dyn_cast<PlaceholderOp>(use.getOwner());
+            if (!dependent || operationDomains.lookup(
+                                  dependent.getDpsConsumer()) == &domain) {
+              continue;
+            }
+            use.set(consumerResult);
+          }
+        }
       }
     }
   }
@@ -199,6 +258,7 @@ static SmallVector<Domain> partitionIntoDomains(Block &block) {
     }
   }
 
+  redirectCrossDomainShapeDependencies(domains);
   for (Domain &domain : domains) {
     computeDomainResults(domain, block);
   }

--- a/lib/Dialect/Hipsr/Transforms/PartitionPoolDomains.cpp
+++ b/lib/Dialect/Hipsr/Transforms/PartitionPoolDomains.cpp
@@ -144,8 +144,8 @@ static LogicalResult validatePartitionInput(Block &block) {
 static void computeDomainResults(Domain &domain, Block &parentBlock) {
   llvm::SmallPtrSet<Operation *, 16> domainOperations(domain.operations.begin(),
                                                       domain.operations.end());
-  // Placeholder operands mirror their consumers' inputs. Treat those uses as
-  // internal when the consumer belongs to this domain.
+  // A placeholder belongs to its DPS consumer's domain, so its uses of domain
+  // results remain internal to that domain.
   for (Operation *operation : domain.operations) {
     if (!isHipsrDpsOp(*operation)) {
       continue;

--- a/lib/Dialect/Hipsr/Transforms/PartitionPoolDomains.cpp
+++ b/lib/Dialect/Hipsr/Transforms/PartitionPoolDomains.cpp
@@ -144,6 +144,19 @@ static LogicalResult validatePartitionInput(Block &block) {
 static void computeDomainResults(Domain &domain, Block &parentBlock) {
   llvm::SmallPtrSet<Operation *, 16> domainOperations(domain.operations.begin(),
                                                       domain.operations.end());
+  // Placeholder operands mirror their consumers' inputs. Treat those uses as
+  // internal when the consumer belongs to this domain.
+  for (Operation *operation : domain.operations) {
+    if (!isHipsrDpsOp(*operation)) {
+      continue;
+    }
+    auto dpsOp = cast<DestinationStyleOpInterface>(*operation);
+    for (Value init : dpsOp.getDpsInits()) {
+      if (auto placeholder = init.getDefiningOp<PlaceholderOp>()) {
+        domainOperations.insert(placeholder);
+      }
+    }
+  }
 
   for (Operation *operation : domain.operations) {
     for (Value result : operation->getResults()) {

--- a/lib/Dialect/Hipsr/Transforms/PartitionPoolDomains.cpp
+++ b/lib/Dialect/Hipsr/Transforms/PartitionPoolDomains.cpp
@@ -144,8 +144,7 @@ static LogicalResult validatePartitionInput(Block &block) {
 static void computeDomainResults(Domain &domain, Block &parentBlock) {
   llvm::SmallPtrSet<Operation *, 16> domainOperations(domain.operations.begin(),
                                                       domain.operations.end());
-  // A placeholder belongs to its DPS consumer's domain, so its uses of domain
-  // results remain internal to that domain.
+  // Treat each DPS init placeholder as part of its consumer's domain.
   for (Operation *operation : domain.operations) {
     if (!isHipsrDpsOp(*operation)) {
       continue;

--- a/test/lit/Conversion/onnx-to-hipsr/cast.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/cast.mlir
@@ -8,14 +8,14 @@
 
 // RUN: hip-mlir-opt %s -allow-unregistered-dialect -convert-onnx-to-hipsr | FileCheck %s
 
-// Chained casts produce parallel data and placeholder dependencies. All shape
-// regions remain empty.
+// Each placeholder receives the same input as its cast. All shape regions
+// remain empty.
 // CHECK-LABEL: func.func @cast_chain(
 // CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:    %[[IN:.*]]: tensor<?x8xf32>) -> tensor<?x8xf32> {
 // CHECK-NEXT: %[[FIRST_INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[IN]] : tensor<?x8xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16>
 // CHECK-NEXT: %[[FIRST:.+]] = hipsr.cast(%[[CTX]]) ins(%[[IN]] : tensor<?x8xf32>) outs(%[[FIRST_INIT]] : tensor<?x8xf16>) : tensor<?x8xf16>
-// CHECK-NEXT: %[[SECOND_INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[FIRST_INIT]] : tensor<?x8xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?x8xf32>
+// CHECK-NEXT: %[[SECOND_INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[FIRST]] : tensor<?x8xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?x8xf32>
 // CHECK-NEXT: %[[SECOND:.+]] = hipsr.cast(%[[CTX]]) ins(%[[FIRST]] : tensor<?x8xf16>) outs(%[[SECOND_INIT]] : tensor<?x8xf32>) : tensor<?x8xf32>
 // CHECK-NOT: shape_region
 func.func @cast_chain(

--- a/test/lit/Conversion/onnx-to-hipsr/cast.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/cast.mlir
@@ -12,7 +12,7 @@
 // CHECK-LABEL: func.func @cast(
 // CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:    %[[IN:.*]]: tensor<?x8xf32>) -> tensor<?x8xf16> {
-// CHECK-NEXT: %[[INIT:.+]] = hipsr.placeholder(%[[CTX]], %[[IN]] : tensor<?x8xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16>
+// CHECK-NEXT: %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[IN]] : tensor<?x8xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16>
 // CHECK-NEXT: hipsr.cast(%[[CTX]]) ins(%[[IN]] : tensor<?x8xf32>) outs(%[[INIT]] : tensor<?x8xf16>) : tensor<?x8xf16>
 // CHECK-NOT: shape_region
 func.func @cast(%ctx: !hipsr.context, %input: tensor<?x8xf32>) -> tensor<?x8xf16> {

--- a/test/lit/Conversion/onnx-to-hipsr/cast.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/cast.mlir
@@ -12,7 +12,7 @@
 // CHECK-LABEL: func.func @cast(
 // CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:    %[[IN:.*]]: tensor<?x8xf32>) -> tensor<?x8xf16> {
-// CHECK-NEXT: %[[INIT:.+]] = hipsr.placeholder(%[[CTX]], %[[IN]] : !hipsr.context, tensor<?x8xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16>
+// CHECK-NEXT: %[[INIT:.+]] = hipsr.placeholder(%[[CTX]], %[[IN]] : tensor<?x8xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16>
 // CHECK-NEXT: hipsr.cast(%[[CTX]]) ins(%[[IN]] : tensor<?x8xf32>) outs(%[[INIT]] : tensor<?x8xf16>) : tensor<?x8xf16>
 // CHECK-NOT: shape_region
 func.func @cast(%ctx: !hipsr.context, %input: tensor<?x8xf32>) -> tensor<?x8xf16> {

--- a/test/lit/Conversion/onnx-to-hipsr/cast.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/cast.mlir
@@ -8,14 +8,19 @@
 
 // RUN: hip-mlir-opt %s -allow-unregistered-dialect -convert-onnx-to-hipsr | FileCheck %s
 
-// DPS init is a Normal placeholder. Both placeholder and op regions are empty.
-// CHECK-LABEL: func.func @cast(
+// Chained casts produce parallel data and placeholder dependencies. All shape
+// regions remain empty.
+// CHECK-LABEL: func.func @cast_chain(
 // CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
-// CHECK-SAME:    %[[IN:.*]]: tensor<?x8xf32>) -> tensor<?x8xf16> {
-// CHECK-NEXT: %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[IN]] : tensor<?x8xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16>
-// CHECK-NEXT: hipsr.cast(%[[CTX]]) ins(%[[IN]] : tensor<?x8xf32>) outs(%[[INIT]] : tensor<?x8xf16>) : tensor<?x8xf16>
+// CHECK-SAME:    %[[IN:.*]]: tensor<?x8xf32>) -> tensor<?x8xf32> {
+// CHECK-NEXT: %[[FIRST_INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[IN]] : tensor<?x8xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16>
+// CHECK-NEXT: %[[FIRST:.+]] = hipsr.cast(%[[CTX]]) ins(%[[IN]] : tensor<?x8xf32>) outs(%[[FIRST_INIT]] : tensor<?x8xf16>) : tensor<?x8xf16>
+// CHECK-NEXT: %[[SECOND_INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[FIRST_INIT]] : tensor<?x8xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?x8xf32>
+// CHECK-NEXT: %[[SECOND:.+]] = hipsr.cast(%[[CTX]]) ins(%[[FIRST]] : tensor<?x8xf16>) outs(%[[SECOND_INIT]] : tensor<?x8xf32>) : tensor<?x8xf32>
 // CHECK-NOT: shape_region
-func.func @cast(%ctx: !hipsr.context, %input: tensor<?x8xf32>) -> tensor<?x8xf16> {
+func.func @cast_chain(
+    %ctx: !hipsr.context, %input: tensor<?x8xf32>) -> tensor<?x8xf32> {
   %0 = "onnx.Cast"(%input) : (tensor<?x8xf32>) -> tensor<?x8xf16>
-  return %0 : tensor<?x8xf16>
+  %1 = "onnx.Cast"(%0) : (tensor<?x8xf16>) -> tensor<?x8xf32>
+  return %1 : tensor<?x8xf32>
 }

--- a/test/lit/Conversion/onnx-to-hipsr/cast.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/cast.mlir
@@ -8,12 +8,12 @@
 
 // RUN: hip-mlir-opt %s -allow-unregistered-dialect -convert-onnx-to-hipsr | FileCheck %s
 
-// DPS init is a placeholder, shape region left empty.
+// DPS init is a Normal placeholder. Both placeholder and op regions are empty.
 // CHECK-LABEL: func.func @cast(
 // CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:    %[[IN:.*]]: tensor<?x8xf32>) -> tensor<?x8xf16> {
-// CHECK:     %[[INIT:.+]] = hipsr.placeholder : tensor<?x8xf16>
-// CHECK:     hipsr.cast(%[[CTX]]) ins(%[[IN]] : tensor<?x8xf32>) outs(%[[INIT]] : tensor<?x8xf16>) : tensor<?x8xf16>
+// CHECK-NEXT: %[[INIT:.+]] = hipsr.placeholder(%[[CTX]], %[[IN]] : !hipsr.context, tensor<?x8xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16>
+// CHECK-NEXT: hipsr.cast(%[[CTX]]) ins(%[[IN]] : tensor<?x8xf32>) outs(%[[INIT]] : tensor<?x8xf16>) : tensor<?x8xf16>
 // CHECK-NOT: shape_region
 func.func @cast(%ctx: !hipsr.context, %input: tensor<?x8xf32>) -> tensor<?x8xf16> {
   %0 = "onnx.Cast"(%input) : (tensor<?x8xf32>) -> tensor<?x8xf16>

--- a/test/lit/Conversion/onnx-to-hipsr/cast.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/cast.mlir
@@ -8,14 +8,14 @@
 
 // RUN: hip-mlir-opt %s -allow-unregistered-dialect -convert-onnx-to-hipsr | FileCheck %s
 
-// Each placeholder receives the same input as its cast. All shape regions
-// remain empty.
+// The second placeholder follows the shape graph through the first
+// placeholder, while the second cast follows the data graph.
 // CHECK-LABEL: func.func @cast_chain(
 // CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:    %[[IN:.*]]: tensor<?x8xf32>) -> tensor<?x8xf32> {
 // CHECK-NEXT: %[[FIRST_INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[IN]] : tensor<?x8xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16>
 // CHECK-NEXT: %[[FIRST:.+]] = hipsr.cast(%[[CTX]]) ins(%[[IN]] : tensor<?x8xf32>) outs(%[[FIRST_INIT]] : tensor<?x8xf16>) : tensor<?x8xf16>
-// CHECK-NEXT: %[[SECOND_INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[FIRST]] : tensor<?x8xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?x8xf32>
+// CHECK-NEXT: %[[SECOND_INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[FIRST_INIT]] : tensor<?x8xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?x8xf32>
 // CHECK-NEXT: %[[SECOND:.+]] = hipsr.cast(%[[CTX]]) ins(%[[FIRST]] : tensor<?x8xf16>) outs(%[[SECOND_INIT]] : tensor<?x8xf32>) : tensor<?x8xf32>
 // CHECK-NOT: shape_region
 func.func @cast_chain(

--- a/test/lit/Conversion/onnx-to-hipsr/expand.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/expand.mlir
@@ -10,7 +10,7 @@
 // CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:    %[[INPUT:.*]]: tensor<?x3xf16>,
 // CHECK-SAME:    %[[SHAPE:.*]]: tensor<2xi64>) -> tensor<?x?xf16> {
-// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]], %[[INPUT]], %[[SHAPE]] : !hipsr.context, tensor<?x3xf16>, tensor<2xi64>) {type = #hipsr.placeholder_type<barrier>} : tensor<?x?xf16>
+// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]], %[[INPUT]], %[[SHAPE]] : tensor<?x3xf16>, tensor<2xi64>) {type = #hipsr.placeholder_type<barrier>} : tensor<?x?xf16>
 // CHECK-NEXT:    %[[RESULT:.*]] = hipsr.expand(%[[CTX]]) ins(%[[INPUT]], %[[SHAPE]] : tensor<?x3xf16>, tensor<2xi64>)
 // CHECK-SAME:      outs(%[[INIT]] : tensor<?x?xf16>) : tensor<?x?xf16>
 // CHECK-NOT:     shape_region

--- a/test/lit/Conversion/onnx-to-hipsr/expand.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/expand.mlir
@@ -5,13 +5,12 @@
 // Unsupported forms remain unchanged for another conversion path.
 
 // RUN: hip-mlir-opt %s --split-input-file -allow-unregistered-dialect -convert-onnx-to-hipsr | FileCheck %s
-// RUN: hip-mlir-opt %s --split-input-file -allow-unregistered-dialect -convert-onnx-to-hipsr -canonicalize | FileCheck %s --check-prefix=CANONICALIZE
 
 // CHECK-LABEL: func.func @expand(
 // CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:    %[[INPUT:.*]]: tensor<?x3xf16>,
 // CHECK-SAME:    %[[SHAPE:.*]]: tensor<2xi64>) -> tensor<?x?xf16> {
-// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder : tensor<?x?xf16>
+// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]], %[[INPUT]], %[[SHAPE]] : !hipsr.context, tensor<?x3xf16>, tensor<2xi64>) {type = #hipsr.placeholder_type<barrier>} : tensor<?x?xf16>
 // CHECK-NEXT:    %[[RESULT:.*]] = hipsr.expand(%[[CTX]]) ins(%[[INPUT]], %[[SHAPE]] : tensor<?x3xf16>, tensor<2xi64>)
 // CHECK-SAME:      outs(%[[INIT]] : tensor<?x?xf16>) : tensor<?x?xf16>
 // CHECK-NOT:     shape_region
@@ -21,34 +20,6 @@ func.func @expand(%ctx: !hipsr.context, %input: tensor<?x3xf16>,
   %0 = "onnx.Expand"(%input, %shape)
       : (tensor<?x3xf16>, tensor<2xi64>) -> tensor<?x?xf16>
   return %0 : tensor<?x?xf16>
-}
-
-// -----
-
-// Conversion always preserves the shape operand. Canonicalization folds a
-// ConstantLike shape into shape_attr and removes the now-unused constant.
-// CHECK-LABEL: func.func @expand_constant_shape(
-// CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
-// CHECK-SAME:    %[[INPUT:.*]]: tensor<1x3xf16>) -> tensor<4x3xf16> {
-// CHECK-NEXT:  %[[SHAPE:.*]] = arith.constant dense<[4, 3]> : tensor<2xi64>
-// CHECK-NEXT:  %[[INIT:.*]] = hipsr.placeholder : tensor<4x3xf16>
-// CHECK-NEXT:  %[[RESULT:.*]] = hipsr.expand(%[[CTX]]) ins(%[[INPUT]], %[[SHAPE]] : tensor<1x3xf16>, tensor<2xi64>)
-// CHECK-SAME:    outs(%[[INIT]] : tensor<4x3xf16>) : tensor<4x3xf16>
-// CHECK-NEXT:  return %[[RESULT]] : tensor<4x3xf16>
-// CANONICALIZE-LABEL: func.func @expand_constant_shape(
-// CANONICALIZE-SAME:    %[[CTX:.*]]: !hipsr.context,
-// CANONICALIZE-SAME:    %[[INPUT:.*]]: tensor<1x3xf16>) -> tensor<4x3xf16> {
-// CANONICALIZE-NEXT:  %[[INIT:.*]] = hipsr.placeholder : tensor<4x3xf16>
-// CANONICALIZE-NEXT:  %[[RESULT:.*]] = hipsr.expand(%[[CTX]]) ins(%[[INPUT]] : tensor<1x3xf16>)
-// CANONICALIZE-SAME:    outs(%[[INIT]] : tensor<4x3xf16>) {shape_attr = array<i64: 4, 3>} : tensor<4x3xf16>
-// CANONICALIZE-NEXT:  return %[[RESULT]] : tensor<4x3xf16>
-func.func @expand_constant_shape(%ctx: !hipsr.context,
-                                 %input: tensor<1x3xf16>)
-    -> tensor<4x3xf16> {
-  %shape = arith.constant dense<[4, 3]> : tensor<2xi64>
-  %0 = "onnx.Expand"(%input, %shape)
-      : (tensor<1x3xf16>, tensor<2xi64>) -> tensor<4x3xf16>
-  return %0 : tensor<4x3xf16>
 }
 
 // -----

--- a/test/lit/Conversion/onnx-to-hipsr/expand.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/expand.mlir
@@ -10,7 +10,7 @@
 // CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:    %[[INPUT:.*]]: tensor<?x3xf16>,
 // CHECK-SAME:    %[[SHAPE:.*]]: tensor<2xi64>) -> tensor<?x?xf16> {
-// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]], %[[INPUT]], %[[SHAPE]] : tensor<?x3xf16>, tensor<2xi64>) {type = #hipsr.placeholder_type<barrier>} : tensor<?x?xf16>
+// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]], %[[SHAPE]] : tensor<?x3xf16>, tensor<2xi64>) {type = #hipsr.placeholder_type<barrier>} : tensor<?x?xf16>
 // CHECK-NEXT:    %[[RESULT:.*]] = hipsr.expand(%[[CTX]]) ins(%[[INPUT]], %[[SHAPE]] : tensor<?x3xf16>, tensor<2xi64>)
 // CHECK-SAME:      outs(%[[INIT]] : tensor<?x?xf16>) : tensor<?x?xf16>
 // CHECK-NOT:     shape_region

--- a/test/lit/Conversion/onnx-to-hipsr/matmul.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/matmul.mlir
@@ -14,7 +14,7 @@
 // CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:    %[[A:.*]]: tensor<?x4096xf16>,
 // CHECK-SAME:    %[[B:.*]]: tensor<4096x1024xf16>) -> tensor<?x1024xf16> {
-// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]], %[[A]], %[[B]] : !hipsr.context, tensor<?x4096xf16>, tensor<4096x1024xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?x1024xf16>
+// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]], %[[A]], %[[B]] : tensor<?x4096xf16>, tensor<4096x1024xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?x1024xf16>
 // CHECK-NEXT:    hipsr.matmul(%[[CTX]]) ins(%[[A]], %[[B]] : tensor<?x4096xf16>, tensor<4096x1024xf16>)
 // CHECK-SAME:      outs(%[[INIT]] : tensor<?x1024xf16>) : tensor<?x1024xf16>
 // CHECK-NOT:     shape_region
@@ -32,7 +32,7 @@ func.func @matmul_2d(%ctx: !hipsr.context, %a: tensor<?x4096xf16>,
 // CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:    %[[A:.*]]: tensor<?x4096xf16>,
 // CHECK-SAME:    %[[B:.*]]: tensor<4096xf16>) -> tensor<?xf16> {
-// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]], %[[A]], %[[B]] : !hipsr.context, tensor<?x4096xf16>, tensor<4096xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?xf16>
+// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]], %[[A]], %[[B]] : tensor<?x4096xf16>, tensor<4096xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?xf16>
 // CHECK-NEXT:    hipsr.matmul(%[[CTX]]) ins(%[[A]], %[[B]] : tensor<?x4096xf16>, tensor<4096xf16>)
 // CHECK-SAME:      outs(%[[INIT]] : tensor<?xf16>) : tensor<?xf16>
 // CHECK-NOT:     shape_region

--- a/test/lit/Conversion/onnx-to-hipsr/matmul.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/matmul.mlir
@@ -14,8 +14,8 @@
 // CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:    %[[A:.*]]: tensor<?x4096xf16>,
 // CHECK-SAME:    %[[B:.*]]: tensor<4096x1024xf16>) -> tensor<?x1024xf16> {
-// CHECK:         %[[INIT:.*]] = hipsr.placeholder : tensor<?x1024xf16>
-// CHECK:         hipsr.matmul(%[[CTX]]) ins(%[[A]], %[[B]] : tensor<?x4096xf16>, tensor<4096x1024xf16>)
+// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]], %[[A]], %[[B]] : !hipsr.context, tensor<?x4096xf16>, tensor<4096x1024xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?x1024xf16>
+// CHECK-NEXT:    hipsr.matmul(%[[CTX]]) ins(%[[A]], %[[B]] : tensor<?x4096xf16>, tensor<4096x1024xf16>)
 // CHECK-SAME:      outs(%[[INIT]] : tensor<?x1024xf16>) : tensor<?x1024xf16>
 // CHECK-NOT:     shape_region
 func.func @matmul_2d(%ctx: !hipsr.context, %a: tensor<?x4096xf16>,
@@ -32,8 +32,8 @@ func.func @matmul_2d(%ctx: !hipsr.context, %a: tensor<?x4096xf16>,
 // CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:    %[[A:.*]]: tensor<?x4096xf16>,
 // CHECK-SAME:    %[[B:.*]]: tensor<4096xf16>) -> tensor<?xf16> {
-// CHECK:         %[[INIT:.*]] = hipsr.placeholder : tensor<?xf16>
-// CHECK:         hipsr.matmul(%[[CTX]]) ins(%[[A]], %[[B]] : tensor<?x4096xf16>, tensor<4096xf16>)
+// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]], %[[A]], %[[B]] : !hipsr.context, tensor<?x4096xf16>, tensor<4096xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?xf16>
+// CHECK-NEXT:    hipsr.matmul(%[[CTX]]) ins(%[[A]], %[[B]] : tensor<?x4096xf16>, tensor<4096xf16>)
 // CHECK-SAME:      outs(%[[INIT]] : tensor<?xf16>) : tensor<?xf16>
 // CHECK-NOT:     shape_region
 func.func @matmul_1d_rhs(%ctx: !hipsr.context, %a: tensor<?x4096xf16>,

--- a/test/lit/Conversion/onnx-to-hipsr/matmul.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/matmul.mlir
@@ -14,7 +14,7 @@
 // CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:    %[[A:.*]]: tensor<?x4096xf16>,
 // CHECK-SAME:    %[[B:.*]]: tensor<4096x1024xf16>) -> tensor<?x1024xf16> {
-// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]], %[[A]], %[[B]] : tensor<?x4096xf16>, tensor<4096x1024xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?x1024xf16>
+// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[A]], %[[B]] : tensor<?x4096xf16>, tensor<4096x1024xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?x1024xf16>
 // CHECK-NEXT:    hipsr.matmul(%[[CTX]]) ins(%[[A]], %[[B]] : tensor<?x4096xf16>, tensor<4096x1024xf16>)
 // CHECK-SAME:      outs(%[[INIT]] : tensor<?x1024xf16>) : tensor<?x1024xf16>
 // CHECK-NOT:     shape_region
@@ -32,7 +32,7 @@ func.func @matmul_2d(%ctx: !hipsr.context, %a: tensor<?x4096xf16>,
 // CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:    %[[A:.*]]: tensor<?x4096xf16>,
 // CHECK-SAME:    %[[B:.*]]: tensor<4096xf16>) -> tensor<?xf16> {
-// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]], %[[A]], %[[B]] : tensor<?x4096xf16>, tensor<4096xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?xf16>
+// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[A]], %[[B]] : tensor<?x4096xf16>, tensor<4096xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?xf16>
 // CHECK-NEXT:    hipsr.matmul(%[[CTX]]) ins(%[[A]], %[[B]] : tensor<?x4096xf16>, tensor<4096xf16>)
 // CHECK-SAME:      outs(%[[INIT]] : tensor<?xf16>) : tensor<?xf16>
 // CHECK-NOT:     shape_region

--- a/test/lit/Conversion/onnx-to-hipsr/placeholder-dependencies-invalid.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/placeholder-dependencies-invalid.mlir
@@ -1,0 +1,15 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt %s -allow-unregistered-dialect -convert-onnx-to-hipsr -verify-diagnostics
+
+// Converted placeholders reject dependencies on unsupported ONNX results.
+func.func @unsupported_producer(
+    %ctx: !hipsr.context, %input: tensor<4x8xf32>) -> tensor<4x8xf16> {
+  %unsupported = "onnx.Unsupported"(%input)
+      : (tensor<4x8xf32>) -> tensor<4x8xf32>
+  // expected-error @+1 {{input 0 must be a block argument or a result of hipsr.placeholder, arith.constant, or hipsr.constant; got result of 'onnx.Unsupported'}}
+  %result = "onnx.Cast"(%unsupported)
+      : (tensor<4x8xf32>) -> tensor<4x8xf16>
+  return %result : tensor<4x8xf16>
+}

--- a/test/lit/Dialect/Hipsr/expand.mlir
+++ b/test/lit/Dialect/Hipsr/expand.mlir
@@ -5,13 +5,15 @@
 
 // RUN: hip-mlir-opt --split-input-file --verify-diagnostics %s
 // RUN: hip-mlir-opt --split-input-file --verify-diagnostics -hipsr-populate-shape-region %s | FileCheck %s --check-prefix=POPULATE
+// RUN: hip-mlir-opt --split-input-file --verify-diagnostics -canonicalize %s | FileCheck %s --check-prefix=CANONICALIZE
 
 // Tensor form checks the complete rank-2 ONNX broadcast shape computation.
+// Its constant shape also canonicalizes to shape_attr.
 // POPULATE-LABEL: func.func @expand_tensor(
 // POPULATE-SAME:   %[[CTX:.*]]: !hipsr.context,
 // POPULATE-SAME:   %[[OUTER_INPUT:.*]]: tensor<?x3xf16>,
-// POPULATE-SAME:   %[[OUTER_REQUEST:.*]]: tensor<2xi64>,
 // POPULATE-SAME:   %[[INIT:.*]]: tensor<?x?xf16>) -> tensor<?x?xf16> {
+// POPULATE-NEXT: %[[OUTER_REQUEST:.*]] = arith.constant dense<[4, 3]> : tensor<2xi64>
 // POPULATE-NEXT: %[[RESULT:.*]] = hipsr.expand(%[[CTX]]) ins(%[[OUTER_INPUT]], %[[OUTER_REQUEST]] : tensor<?x3xf16>, tensor<2xi64>)
 // POPULATE-SAME:   outs(%[[INIT]] : tensor<?x?xf16>) : tensor<?x?xf16> shape_region {
 // POPULATE-NEXT: ^bb0(%{{.+}}: !hipsr.context, %[[INPUT:.+]]: tensor<?x3xf16>, %[[REQUEST:.+]]: tensor<2xi64>):
@@ -37,9 +39,16 @@
 // POPULATE-NEXT:   hipsr.shape_yield (%[[DIMS]]#0, %[[DIMS]]#1) : [f16]
 // POPULATE-NEXT: }
 // POPULATE-NEXT: return %[[RESULT]] : tensor<?x?xf16>
+// CANONICALIZE-LABEL: func.func @expand_tensor(
+// CANONICALIZE-SAME:    %[[CTX:.*]]: !hipsr.context,
+// CANONICALIZE-SAME:    %[[INPUT:.*]]: tensor<?x3xf16>,
+// CANONICALIZE-SAME:    %[[INIT:.*]]: tensor<?x?xf16>) -> tensor<?x?xf16> {
+// CANONICALIZE-NEXT:  %[[RESULT:.*]] = hipsr.expand(%[[CTX]]) ins(%[[INPUT]] : tensor<?x3xf16>)
+// CANONICALIZE-SAME:    outs(%[[INIT]] : tensor<?x?xf16>) {shape_attr = array<i64: 4, 3>} : tensor<?x?xf16>
+// CANONICALIZE-NEXT:  return %[[RESULT]] : tensor<?x?xf16>
 func.func @expand_tensor(%ctx: !hipsr.context, %input: tensor<?x3xf16>,
-                         %shape: tensor<2xi64>,
                          %init: tensor<?x?xf16>) -> tensor<?x?xf16> {
+  %shape = arith.constant dense<[4, 3]> : tensor<2xi64>
   %0 = hipsr.expand(%ctx) ins(%input, %shape : tensor<?x3xf16>, tensor<2xi64>)
                    outs(%init : tensor<?x?xf16>) : tensor<?x?xf16>
   return %0 : tensor<?x?xf16>

--- a/test/lit/Dialect/Hipsr/partition-pool-domains-invalid.mlir
+++ b/test/lit/Dialect/Hipsr/partition-pool-domains-invalid.mlir
@@ -59,8 +59,8 @@ func.func @nested_placeholder(%ctx: !hipsr.context,
     -> tensor<4x8xf16> {
   %result = scf.execute_region -> tensor<4x8xf16> {
     // expected-error @+1 {{must be top-level when partitioning pool domains}}
-    %init = hipsr.placeholder(
-        %ctx, %input : tensor<4x8xf32>)
+    %init = hipsr.placeholder(%ctx)
+        ins(%input : tensor<4x8xf32>)
         {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
     %cast = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
         outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
@@ -76,8 +76,8 @@ func.func @nested_placeholder_consumer(%ctx: !hipsr.context,
                                        %input: tensor<4x8xf32>)
     -> tensor<4x8xf16> {
   // expected-error @+1 {{requires its DPS consumer to be top-level when partitioning pool domains}}
-  %init = hipsr.placeholder(
-      %ctx, %input : tensor<4x8xf32>)
+  %init = hipsr.placeholder(%ctx)
+      ins(%input : tensor<4x8xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
   %result = scf.execute_region -> tensor<4x8xf16> {
     %cast = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)

--- a/test/lit/Dialect/Hipsr/partition-pool-domains-invalid.mlir
+++ b/test/lit/Dialect/Hipsr/partition-pool-domains-invalid.mlir
@@ -60,7 +60,7 @@ func.func @nested_placeholder(%ctx: !hipsr.context,
   %result = scf.execute_region -> tensor<4x8xf16> {
     // expected-error @+1 {{must be top-level when partitioning pool domains}}
     %init = hipsr.placeholder(
-        %ctx, %input : !hipsr.context, tensor<4x8xf32>)
+        %ctx, %input : tensor<4x8xf32>)
         {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
     %cast = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
         outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
@@ -77,7 +77,7 @@ func.func @nested_placeholder_consumer(%ctx: !hipsr.context,
     -> tensor<4x8xf16> {
   // expected-error @+1 {{requires its DPS consumer to be top-level when partitioning pool domains}}
   %init = hipsr.placeholder(
-      %ctx, %input : !hipsr.context, tensor<4x8xf32>)
+      %ctx, %input : tensor<4x8xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
   %result = scf.execute_region -> tensor<4x8xf16> {
     %cast = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)

--- a/test/lit/Dialect/Hipsr/partition-pool-domains-invalid.mlir
+++ b/test/lit/Dialect/Hipsr/partition-pool-domains-invalid.mlir
@@ -59,7 +59,9 @@ func.func @nested_placeholder(%ctx: !hipsr.context,
     -> tensor<4x8xf16> {
   %result = scf.execute_region -> tensor<4x8xf16> {
     // expected-error @+1 {{must be top-level when partitioning pool domains}}
-    %init = hipsr.placeholder : tensor<4x8xf16>
+    %init = hipsr.placeholder(
+        %ctx, %input : !hipsr.context, tensor<4x8xf32>)
+        {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
     %cast = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
         outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
     scf.yield %cast : tensor<4x8xf16>
@@ -74,7 +76,9 @@ func.func @nested_placeholder_consumer(%ctx: !hipsr.context,
                                        %input: tensor<4x8xf32>)
     -> tensor<4x8xf16> {
   // expected-error @+1 {{requires its DPS consumer to be top-level when partitioning pool domains}}
-  %init = hipsr.placeholder : tensor<4x8xf16>
+  %init = hipsr.placeholder(
+      %ctx, %input : !hipsr.context, tensor<4x8xf32>)
+      {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
   %result = scf.execute_region -> tensor<4x8xf16> {
     %cast = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
         outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>

--- a/test/lit/Dialect/Hipsr/partition-pool-domains.mlir
+++ b/test/lit/Dialect/Hipsr/partition-pool-domains.mlir
@@ -15,17 +15,17 @@
 // CHECK-SAME: -> tensor<?x4xf16> {
 // CHECK-NEXT: %[[FIRST_DOMAIN:.*]] = hipsr.pool_domain(%[[CTX]], %[[INPUT]] : !hipsr.context, tensor<?x4xf32>) {
 // CHECK-NEXT: ^bb0(%[[FIRST_CTX:.*]]: !hipsr.context, %[[FIRST_INPUT:.*]]: tensor<?x4xf32>):
-// CHECK-NEXT: %[[CAST_INIT:.*]] = hipsr.placeholder(%[[FIRST_CTX]], %[[FIRST_INPUT]] : !hipsr.context, tensor<?x4xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
+// CHECK-NEXT: %[[CAST_INIT:.*]] = hipsr.placeholder(%[[FIRST_CTX]], %[[FIRST_INPUT]] : tensor<?x4xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
 // CHECK-NEXT: %[[CAST:.*]] = hipsr.cast(%[[FIRST_CTX]]) ins(%[[FIRST_INPUT]] : tensor<?x4xf32>) outs(%[[CAST_INIT]] : tensor<?x4xf16>) : tensor<?x4xf16>
-// CHECK-NEXT: %[[SHAPE_ATTR_INIT:.*]] = hipsr.placeholder(%[[FIRST_CTX]], %[[CAST]] : !hipsr.context, tensor<?x4xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
+// CHECK-NEXT: %[[SHAPE_ATTR_INIT:.*]] = hipsr.placeholder(%[[FIRST_CTX]], %[[CAST]] : tensor<?x4xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
 // CHECK-NEXT: %[[SHAPE_ATTR_EXPANDED:.*]] = hipsr.expand(%[[FIRST_CTX]]) ins(%[[CAST]] : tensor<?x4xf16>) outs(%[[SHAPE_ATTR_INIT]] : tensor<?x4xf16>) {shape_attr = array<i64: 1, 4>} : tensor<?x4xf16>
 // CHECK-NEXT: hipsr.pool_domain_yield %[[SHAPE_ATTR_EXPANDED]] : tensor<?x4xf16>
 // CHECK-NEXT: } -> tensor<?x4xf16>
 // CHECK-NEXT: %[[EXPAND_DOMAIN:.*]] = hipsr.pool_domain(%[[CTX]], %[[FIRST_DOMAIN]], %[[SHAPE]] : !hipsr.context, tensor<?x4xf16>, tensor<2xi64>) {
 // CHECK-NEXT: ^bb0(%[[EXPAND_CTX:.*]]: !hipsr.context, %[[EXPAND_INPUT:.*]]: tensor<?x4xf16>, %[[EXPAND_SHAPE:.*]]: tensor<2xi64>):
-// CHECK-NEXT: %[[EXPAND_INIT:.*]] = hipsr.placeholder(%[[EXPAND_CTX]], %[[EXPAND_INPUT]], %[[EXPAND_SHAPE]] : !hipsr.context, tensor<?x4xf16>, tensor<2xi64>) {type = #hipsr.placeholder_type<barrier>} : tensor<?x4xf16>
+// CHECK-NEXT: %[[EXPAND_INIT:.*]] = hipsr.placeholder(%[[EXPAND_CTX]], %[[EXPAND_INPUT]], %[[EXPAND_SHAPE]] : tensor<?x4xf16>, tensor<2xi64>) {type = #hipsr.placeholder_type<barrier>} : tensor<?x4xf16>
 // CHECK-NEXT: %[[EXPANDED:.*]] = hipsr.expand(%[[EXPAND_CTX]]) ins(%[[EXPAND_INPUT]], %[[EXPAND_SHAPE]] : tensor<?x4xf16>, tensor<2xi64>) outs(%[[EXPAND_INIT]] : tensor<?x4xf16>) : tensor<?x4xf16>
-// CHECK-NEXT: %[[ADD_INIT:.*]] = hipsr.placeholder(%[[EXPAND_CTX]], %[[EXPANDED]], %[[EXPANDED]] : !hipsr.context, tensor<?x4xf16>, tensor<?x4xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
+// CHECK-NEXT: %[[ADD_INIT:.*]] = hipsr.placeholder(%[[EXPAND_CTX]], %[[EXPANDED]], %[[EXPANDED]] : tensor<?x4xf16>, tensor<?x4xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
 // CHECK-NEXT: %[[RESULT:.*]] = hipsr.add(%[[EXPAND_CTX]]) ins(%[[EXPANDED]], %[[EXPANDED]] : tensor<?x4xf16>, tensor<?x4xf16>) outs(%[[ADD_INIT]] : tensor<?x4xf16>) : tensor<?x4xf16>
 // CHECK-NEXT: hipsr.pool_domain_yield %[[RESULT]] : tensor<?x4xf16>
 // CHECK-NEXT: } -> tensor<?x4xf16>
@@ -35,12 +35,12 @@ func.func @expand_barrier_modes(
     %ctx: !hipsr.context, %input: tensor<?x4xf32>, %shape: tensor<2xi64>)
     -> tensor<?x4xf16> {
   %cast_init = hipsr.placeholder(
-      %ctx, %input : !hipsr.context, tensor<?x4xf32>)
+      %ctx, %input : tensor<?x4xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
   %cast = hipsr.cast(%ctx) ins(%input : tensor<?x4xf32>)
       outs(%cast_init : tensor<?x4xf16>) : tensor<?x4xf16>
   %shape_attr_init = hipsr.placeholder(
-      %ctx, %cast : !hipsr.context, tensor<?x4xf16>)
+      %ctx, %cast : tensor<?x4xf16>)
       {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
   %shape_attr_expanded = hipsr.expand(%ctx)
       ins(%cast : tensor<?x4xf16>)
@@ -48,14 +48,14 @@ func.func @expand_barrier_modes(
       {shape_attr = array<i64: 1, 4>} : tensor<?x4xf16>
   %runtime_init = hipsr.placeholder(
       %ctx, %shape_attr_expanded, %shape
-      : !hipsr.context, tensor<?x4xf16>, tensor<2xi64>)
+      : tensor<?x4xf16>, tensor<2xi64>)
       {type = #hipsr.placeholder_type<barrier>} : tensor<?x4xf16>
   %runtime_expanded = hipsr.expand(%ctx)
       ins(%shape_attr_expanded, %shape : tensor<?x4xf16>, tensor<2xi64>)
       outs(%runtime_init : tensor<?x4xf16>) : tensor<?x4xf16>
   %add_init = hipsr.placeholder(
       %ctx, %runtime_expanded, %runtime_expanded
-      : !hipsr.context, tensor<?x4xf16>, tensor<?x4xf16>)
+      : tensor<?x4xf16>, tensor<?x4xf16>)
       {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
   %result = hipsr.add(%ctx)
       ins(%runtime_expanded, %runtime_expanded
@@ -77,7 +77,7 @@ func.func @expand_barrier_modes(
 // CHECK-NEXT: %[[SUM:.*]] = arith.addi %[[DCAPTURE]], %[[DCAPTURE]] : i32
 // CHECK-NEXT: scf.yield %[[SUM]] : i32
 // CHECK-NEXT: }
-// CHECK-NEXT: %[[INIT:.*]] = hipsr.placeholder(%[[DCTX]], %[[DINPUT]] : !hipsr.context, tensor<?x8xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16>
+// CHECK-NEXT: %[[INIT:.*]] = hipsr.placeholder(%[[DCTX]], %[[DINPUT]] : tensor<?x8xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16>
 // CHECK-NEXT: %[[CAST:.*]] = hipsr.cast(%[[DCTX]]) ins(%[[DINPUT]] : tensor<?x8xf32>) outs(%[[INIT]] : tensor<?x8xf16>) : tensor<?x8xf16> shape_region {
 // CHECK-NEXT: ^bb0(%[[SHAPE_INPUT:.*]]: tensor<?x8xf32>):
 // CHECK-NEXT: %[[SHAPE:.*]] = shape.shape_of %[[SHAPE_INPUT]] : tensor<?x8xf32> -> tensor<2xindex>
@@ -96,7 +96,7 @@ func.func @nested_shape_region(%ctx: !hipsr.context,
                                %capture: i32)
     -> (tensor<?x8xf16>, i32) {
   %init = hipsr.placeholder(
-      %ctx, %input : !hipsr.context, tensor<?x8xf32>)
+      %ctx, %input : tensor<?x8xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16>
   %region = scf.execute_region -> i32 {
     %sum = arith.addi %capture, %capture : i32

--- a/test/lit/Dialect/Hipsr/partition-pool-domains.mlir
+++ b/test/lit/Dialect/Hipsr/partition-pool-domains.mlir
@@ -8,7 +8,7 @@
 // RUN: hip-mlir-opt --split-input-file -hipsr-partition-pool-domains -cse %s | FileCheck %s
 
 // Expand with a shape attribute stays in its domain. Its placeholder's use of
-// the Cast placeholder remains internal. Runtime Expand starts the next domain.
+// the Cast result remains internal. Runtime Expand starts the next domain.
 // CHECK-LABEL: func.func @expand_barrier_modes(
 // CHECK-SAME: %[[CTX:.*]]: !hipsr.context, %[[INPUT:.*]]: tensor<?x4xf32>,
 // CHECK-SAME: %[[SHAPE:.*]]: tensor<2xi64>)
@@ -17,7 +17,7 @@
 // CHECK-NEXT: ^bb0(%[[FIRST_CTX:.*]]: !hipsr.context, %[[FIRST_INPUT:.*]]: tensor<?x4xf32>):
 // CHECK-NEXT: %[[CAST_INIT:.*]] = hipsr.placeholder(%[[FIRST_CTX]]) ins(%[[FIRST_INPUT]] : tensor<?x4xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
 // CHECK-NEXT: %[[CAST:.*]] = hipsr.cast(%[[FIRST_CTX]]) ins(%[[FIRST_INPUT]] : tensor<?x4xf32>) outs(%[[CAST_INIT]] : tensor<?x4xf16>) : tensor<?x4xf16>
-// CHECK-NEXT: %[[SHAPE_ATTR_INIT:.*]] = hipsr.placeholder(%[[FIRST_CTX]]) ins(%[[CAST_INIT]] : tensor<?x4xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
+// CHECK-NEXT: %[[SHAPE_ATTR_INIT:.*]] = hipsr.placeholder(%[[FIRST_CTX]]) ins(%[[CAST]] : tensor<?x4xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
 // CHECK-NEXT: %[[SHAPE_ATTR_EXPANDED:.*]] = hipsr.expand(%[[FIRST_CTX]]) ins(%[[CAST]] : tensor<?x4xf16>) outs(%[[SHAPE_ATTR_INIT]] : tensor<?x4xf16>) {shape_attr = array<i64: 1, 4>} : tensor<?x4xf16>
 // CHECK-NEXT: hipsr.pool_domain_yield %[[SHAPE_ATTR_EXPANDED]] : tensor<?x4xf16>
 // CHECK-NEXT: } -> tensor<?x4xf16>
@@ -25,7 +25,7 @@
 // CHECK-NEXT: ^bb0(%[[EXPAND_CTX:.*]]: !hipsr.context, %[[EXPAND_INPUT:.*]]: tensor<?x4xf16>, %[[EXPAND_SHAPE:.*]]: tensor<2xi64>):
 // CHECK-NEXT: %[[EXPAND_INIT:.*]] = hipsr.placeholder(%[[EXPAND_CTX]]) ins(%[[EXPAND_INPUT]], %[[EXPAND_SHAPE]] : tensor<?x4xf16>, tensor<2xi64>) {type = #hipsr.placeholder_type<barrier>} : tensor<?x4xf16>
 // CHECK-NEXT: %[[EXPANDED:.*]] = hipsr.expand(%[[EXPAND_CTX]]) ins(%[[EXPAND_INPUT]], %[[EXPAND_SHAPE]] : tensor<?x4xf16>, tensor<2xi64>) outs(%[[EXPAND_INIT]] : tensor<?x4xf16>) : tensor<?x4xf16>
-// CHECK-NEXT: %[[ADD_INIT:.*]] = hipsr.placeholder(%[[EXPAND_CTX]]) ins(%[[EXPAND_INIT]], %[[EXPAND_INIT]] : tensor<?x4xf16>, tensor<?x4xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
+// CHECK-NEXT: %[[ADD_INIT:.*]] = hipsr.placeholder(%[[EXPAND_CTX]]) ins(%[[EXPANDED]], %[[EXPANDED]] : tensor<?x4xf16>, tensor<?x4xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
 // CHECK-NEXT: %[[RESULT:.*]] = hipsr.add(%[[EXPAND_CTX]]) ins(%[[EXPANDED]], %[[EXPANDED]] : tensor<?x4xf16>, tensor<?x4xf16>) outs(%[[ADD_INIT]] : tensor<?x4xf16>) : tensor<?x4xf16>
 // CHECK-NEXT: hipsr.pool_domain_yield %[[RESULT]] : tensor<?x4xf16>
 // CHECK-NEXT: } -> tensor<?x4xf16>
@@ -40,20 +40,20 @@ func.func @expand_barrier_modes(
   %cast = hipsr.cast(%ctx) ins(%input : tensor<?x4xf32>)
       outs(%cast_init : tensor<?x4xf16>) : tensor<?x4xf16>
   %shape_attr_init = hipsr.placeholder(%ctx)
-      ins(%cast_init : tensor<?x4xf16>)
+      ins(%cast : tensor<?x4xf16>)
       {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
   %shape_attr_expanded = hipsr.expand(%ctx)
       ins(%cast : tensor<?x4xf16>)
       outs(%shape_attr_init : tensor<?x4xf16>)
       {shape_attr = array<i64: 1, 4>} : tensor<?x4xf16>
   %runtime_init = hipsr.placeholder(%ctx)
-      ins(%shape_attr_init, %shape : tensor<?x4xf16>, tensor<2xi64>)
+      ins(%shape_attr_expanded, %shape : tensor<?x4xf16>, tensor<2xi64>)
       {type = #hipsr.placeholder_type<barrier>} : tensor<?x4xf16>
   %runtime_expanded = hipsr.expand(%ctx)
       ins(%shape_attr_expanded, %shape : tensor<?x4xf16>, tensor<2xi64>)
       outs(%runtime_init : tensor<?x4xf16>) : tensor<?x4xf16>
   %add_init = hipsr.placeholder(%ctx)
-      ins(%runtime_init, %runtime_init
+      ins(%runtime_expanded, %runtime_expanded
           : tensor<?x4xf16>, tensor<?x4xf16>)
       {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
   %result = hipsr.add(%ctx)

--- a/test/lit/Dialect/Hipsr/partition-pool-domains.mlir
+++ b/test/lit/Dialect/Hipsr/partition-pool-domains.mlir
@@ -1,11 +1,8 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
 
-// CSE before or after partitioning must not merge placeholders used by
-// different ops.
 // Every pool domain receives the function's first hipsr context argument.
-// RUN: hip-mlir-opt --split-input-file -cse -hipsr-partition-pool-domains %s | FileCheck %s
-// RUN: hip-mlir-opt --split-input-file -hipsr-partition-pool-domains -cse %s | FileCheck %s
+// RUN: hip-mlir-opt --split-input-file -hipsr-partition-pool-domains %s | FileCheck %s
 
 // Expand with a shape attribute stays in its domain. Its placeholder's use of
 // the Cast result remains internal. Runtime Expand starts the next domain.

--- a/test/lit/Dialect/Hipsr/partition-pool-domains.mlir
+++ b/test/lit/Dialect/Hipsr/partition-pool-domains.mlir
@@ -7,25 +7,25 @@
 // RUN: hip-mlir-opt --split-input-file -cse -hipsr-partition-pool-domains %s | FileCheck %s
 // RUN: hip-mlir-opt --split-input-file -hipsr-partition-pool-domains -cse %s | FileCheck %s
 
-// Expand with a shape attribute stays in its domain. Runtime Expand starts the
-// next domain.
+// Expand with a shape attribute stays in its domain. Its placeholder's use of
+// the Cast result remains internal. Runtime Expand starts the next domain.
 // CHECK-LABEL: func.func @expand_barrier_modes(
 // CHECK-SAME: %[[CTX:.*]]: !hipsr.context, %[[INPUT:.*]]: tensor<?x4xf32>,
 // CHECK-SAME: %[[SHAPE:.*]]: tensor<2xi64>)
 // CHECK-SAME: -> tensor<?x4xf16> {
 // CHECK-NEXT: %[[FIRST_DOMAIN:.*]] = hipsr.pool_domain(%[[CTX]], %[[INPUT]] : !hipsr.context, tensor<?x4xf32>) {
 // CHECK-NEXT: ^bb0(%[[FIRST_CTX:.*]]: !hipsr.context, %[[FIRST_INPUT:.*]]: tensor<?x4xf32>):
-// CHECK-NEXT: %[[CAST_INIT:.*]] = hipsr.placeholder : tensor<?x4xf16>
+// CHECK-NEXT: %[[CAST_INIT:.*]] = hipsr.placeholder(%[[FIRST_CTX]], %[[FIRST_INPUT]] : !hipsr.context, tensor<?x4xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
 // CHECK-NEXT: %[[CAST:.*]] = hipsr.cast(%[[FIRST_CTX]]) ins(%[[FIRST_INPUT]] : tensor<?x4xf32>) outs(%[[CAST_INIT]] : tensor<?x4xf16>) : tensor<?x4xf16>
-// CHECK-NEXT: %[[SHAPE_ATTR_INIT:.*]] = hipsr.placeholder : tensor<?x4xf16>
+// CHECK-NEXT: %[[SHAPE_ATTR_INIT:.*]] = hipsr.placeholder(%[[FIRST_CTX]], %[[CAST]] : !hipsr.context, tensor<?x4xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
 // CHECK-NEXT: %[[SHAPE_ATTR_EXPANDED:.*]] = hipsr.expand(%[[FIRST_CTX]]) ins(%[[CAST]] : tensor<?x4xf16>) outs(%[[SHAPE_ATTR_INIT]] : tensor<?x4xf16>) {shape_attr = array<i64: 1, 4>} : tensor<?x4xf16>
 // CHECK-NEXT: hipsr.pool_domain_yield %[[SHAPE_ATTR_EXPANDED]] : tensor<?x4xf16>
 // CHECK-NEXT: } -> tensor<?x4xf16>
 // CHECK-NEXT: %[[EXPAND_DOMAIN:.*]] = hipsr.pool_domain(%[[CTX]], %[[FIRST_DOMAIN]], %[[SHAPE]] : !hipsr.context, tensor<?x4xf16>, tensor<2xi64>) {
 // CHECK-NEXT: ^bb0(%[[EXPAND_CTX:.*]]: !hipsr.context, %[[EXPAND_INPUT:.*]]: tensor<?x4xf16>, %[[EXPAND_SHAPE:.*]]: tensor<2xi64>):
-// CHECK-NEXT: %[[EXPAND_INIT:.*]] = hipsr.placeholder : tensor<?x4xf16>
+// CHECK-NEXT: %[[EXPAND_INIT:.*]] = hipsr.placeholder(%[[EXPAND_CTX]], %[[EXPAND_INPUT]], %[[EXPAND_SHAPE]] : !hipsr.context, tensor<?x4xf16>, tensor<2xi64>) {type = #hipsr.placeholder_type<barrier>} : tensor<?x4xf16>
 // CHECK-NEXT: %[[EXPANDED:.*]] = hipsr.expand(%[[EXPAND_CTX]]) ins(%[[EXPAND_INPUT]], %[[EXPAND_SHAPE]] : tensor<?x4xf16>, tensor<2xi64>) outs(%[[EXPAND_INIT]] : tensor<?x4xf16>) : tensor<?x4xf16>
-// CHECK-NEXT: %[[ADD_INIT:.*]] = hipsr.placeholder : tensor<?x4xf16>
+// CHECK-NEXT: %[[ADD_INIT:.*]] = hipsr.placeholder(%[[EXPAND_CTX]], %[[EXPANDED]], %[[EXPANDED]] : !hipsr.context, tensor<?x4xf16>, tensor<?x4xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
 // CHECK-NEXT: %[[RESULT:.*]] = hipsr.add(%[[EXPAND_CTX]]) ins(%[[EXPANDED]], %[[EXPANDED]] : tensor<?x4xf16>, tensor<?x4xf16>) outs(%[[ADD_INIT]] : tensor<?x4xf16>) : tensor<?x4xf16>
 // CHECK-NEXT: hipsr.pool_domain_yield %[[RESULT]] : tensor<?x4xf16>
 // CHECK-NEXT: } -> tensor<?x4xf16>
@@ -34,19 +34,29 @@
 func.func @expand_barrier_modes(
     %ctx: !hipsr.context, %input: tensor<?x4xf32>, %shape: tensor<2xi64>)
     -> tensor<?x4xf16> {
-  %cast_init = hipsr.placeholder : tensor<?x4xf16>
+  %cast_init = hipsr.placeholder(
+      %ctx, %input : !hipsr.context, tensor<?x4xf32>)
+      {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
   %cast = hipsr.cast(%ctx) ins(%input : tensor<?x4xf32>)
       outs(%cast_init : tensor<?x4xf16>) : tensor<?x4xf16>
-  %shape_attr_init = hipsr.placeholder : tensor<?x4xf16>
+  %shape_attr_init = hipsr.placeholder(
+      %ctx, %cast : !hipsr.context, tensor<?x4xf16>)
+      {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
   %shape_attr_expanded = hipsr.expand(%ctx)
       ins(%cast : tensor<?x4xf16>)
       outs(%shape_attr_init : tensor<?x4xf16>)
       {shape_attr = array<i64: 1, 4>} : tensor<?x4xf16>
-  %runtime_init = hipsr.placeholder : tensor<?x4xf16>
+  %runtime_init = hipsr.placeholder(
+      %ctx, %shape_attr_expanded, %shape
+      : !hipsr.context, tensor<?x4xf16>, tensor<2xi64>)
+      {type = #hipsr.placeholder_type<barrier>} : tensor<?x4xf16>
   %runtime_expanded = hipsr.expand(%ctx)
       ins(%shape_attr_expanded, %shape : tensor<?x4xf16>, tensor<2xi64>)
       outs(%runtime_init : tensor<?x4xf16>) : tensor<?x4xf16>
-  %add_init = hipsr.placeholder : tensor<?x4xf16>
+  %add_init = hipsr.placeholder(
+      %ctx, %runtime_expanded, %runtime_expanded
+      : !hipsr.context, tensor<?x4xf16>, tensor<?x4xf16>)
+      {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
   %result = hipsr.add(%ctx)
       ins(%runtime_expanded, %runtime_expanded
           : tensor<?x4xf16>, tensor<?x4xf16>)
@@ -67,7 +77,7 @@ func.func @expand_barrier_modes(
 // CHECK-NEXT: %[[SUM:.*]] = arith.addi %[[DCAPTURE]], %[[DCAPTURE]] : i32
 // CHECK-NEXT: scf.yield %[[SUM]] : i32
 // CHECK-NEXT: }
-// CHECK-NEXT: %[[INIT:.*]] = hipsr.placeholder : tensor<?x8xf16>
+// CHECK-NEXT: %[[INIT:.*]] = hipsr.placeholder(%[[DCTX]], %[[DINPUT]] : !hipsr.context, tensor<?x8xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16>
 // CHECK-NEXT: %[[CAST:.*]] = hipsr.cast(%[[DCTX]]) ins(%[[DINPUT]] : tensor<?x8xf32>) outs(%[[INIT]] : tensor<?x8xf16>) : tensor<?x8xf16> shape_region {
 // CHECK-NEXT: ^bb0(%[[SHAPE_INPUT:.*]]: tensor<?x8xf32>):
 // CHECK-NEXT: %[[SHAPE:.*]] = shape.shape_of %[[SHAPE_INPUT]] : tensor<?x8xf32> -> tensor<2xindex>
@@ -85,7 +95,9 @@ func.func @nested_shape_region(%ctx: !hipsr.context,
                                %input: tensor<?x8xf32>,
                                %capture: i32)
     -> (tensor<?x8xf16>, i32) {
-  %init = hipsr.placeholder : tensor<?x8xf16>
+  %init = hipsr.placeholder(
+      %ctx, %input : !hipsr.context, tensor<?x8xf32>)
+      {type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16>
   %region = scf.execute_region -> i32 {
     %sum = arith.addi %capture, %capture : i32
     scf.yield %sum : i32

--- a/test/lit/Dialect/Hipsr/partition-pool-domains.mlir
+++ b/test/lit/Dialect/Hipsr/partition-pool-domains.mlir
@@ -4,8 +4,8 @@
 // Every pool domain receives the function's first hipsr context argument.
 // RUN: hip-mlir-opt --split-input-file -hipsr-partition-pool-domains %s | FileCheck %s
 
-// Expand with a shape attribute stays in its domain. Its placeholder's use of
-// the Cast result remains internal. Runtime Expand starts the next domain.
+// Expand with a shape attribute stays in its domain. Placeholder dependencies
+// are function roots. Runtime Expand starts the next domain.
 // CHECK-LABEL: func.func @expand_barrier_modes(
 // CHECK-SAME: %[[CTX:.*]]: !hipsr.context, %[[INPUT:.*]]: tensor<?x4xf32>,
 // CHECK-SAME: %[[SHAPE:.*]]: tensor<2xi64>)
@@ -14,15 +14,15 @@
 // CHECK-NEXT: ^bb0(%[[FIRST_CTX:.*]]: !hipsr.context, %[[FIRST_INPUT:.*]]: tensor<?x4xf32>):
 // CHECK-NEXT: %[[CAST_INIT:.*]] = hipsr.placeholder(%[[FIRST_CTX]]) ins(%[[FIRST_INPUT]] : tensor<?x4xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
 // CHECK-NEXT: %[[CAST:.*]] = hipsr.cast(%[[FIRST_CTX]]) ins(%[[FIRST_INPUT]] : tensor<?x4xf32>) outs(%[[CAST_INIT]] : tensor<?x4xf16>) : tensor<?x4xf16>
-// CHECK-NEXT: %[[SHAPE_ATTR_INIT:.*]] = hipsr.placeholder(%[[FIRST_CTX]]) ins(%[[CAST]] : tensor<?x4xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
+// CHECK-NEXT: %[[SHAPE_ATTR_INIT:.*]] = hipsr.placeholder(%[[FIRST_CTX]]) ins(%[[FIRST_INPUT]] : tensor<?x4xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
 // CHECK-NEXT: %[[SHAPE_ATTR_EXPANDED:.*]] = hipsr.expand(%[[FIRST_CTX]]) ins(%[[CAST]] : tensor<?x4xf16>) outs(%[[SHAPE_ATTR_INIT]] : tensor<?x4xf16>) {shape_attr = array<i64: 1, 4>} : tensor<?x4xf16>
 // CHECK-NEXT: hipsr.pool_domain_yield %[[SHAPE_ATTR_EXPANDED]] : tensor<?x4xf16>
 // CHECK-NEXT: } -> tensor<?x4xf16>
-// CHECK-NEXT: %[[EXPAND_DOMAIN:.*]] = hipsr.pool_domain(%[[CTX]], %[[FIRST_DOMAIN]], %[[SHAPE]] : !hipsr.context, tensor<?x4xf16>, tensor<2xi64>) {
-// CHECK-NEXT: ^bb0(%[[EXPAND_CTX:.*]]: !hipsr.context, %[[EXPAND_INPUT:.*]]: tensor<?x4xf16>, %[[EXPAND_SHAPE:.*]]: tensor<2xi64>):
-// CHECK-NEXT: %[[EXPAND_INIT:.*]] = hipsr.placeholder(%[[EXPAND_CTX]]) ins(%[[EXPAND_INPUT]], %[[EXPAND_SHAPE]] : tensor<?x4xf16>, tensor<2xi64>) {type = #hipsr.placeholder_type<barrier>} : tensor<?x4xf16>
+// CHECK-NEXT: %[[EXPAND_DOMAIN:.*]] = hipsr.pool_domain(%[[CTX]], %[[INPUT]], %[[SHAPE]], %[[FIRST_DOMAIN]] : !hipsr.context, tensor<?x4xf32>, tensor<2xi64>, tensor<?x4xf16>) {
+// CHECK-NEXT: ^bb0(%[[EXPAND_CTX:.*]]: !hipsr.context, %[[SHAPE_ROOT:.*]]: tensor<?x4xf32>, %[[EXPAND_SHAPE:.*]]: tensor<2xi64>, %[[EXPAND_INPUT:.*]]: tensor<?x4xf16>):
+// CHECK-NEXT: %[[EXPAND_INIT:.*]] = hipsr.placeholder(%[[EXPAND_CTX]]) ins(%[[SHAPE_ROOT]], %[[EXPAND_SHAPE]] : tensor<?x4xf32>, tensor<2xi64>) {type = #hipsr.placeholder_type<barrier>} : tensor<?x4xf16>
 // CHECK-NEXT: %[[EXPANDED:.*]] = hipsr.expand(%[[EXPAND_CTX]]) ins(%[[EXPAND_INPUT]], %[[EXPAND_SHAPE]] : tensor<?x4xf16>, tensor<2xi64>) outs(%[[EXPAND_INIT]] : tensor<?x4xf16>) : tensor<?x4xf16>
-// CHECK-NEXT: %[[ADD_INIT:.*]] = hipsr.placeholder(%[[EXPAND_CTX]]) ins(%[[EXPANDED]], %[[EXPANDED]] : tensor<?x4xf16>, tensor<?x4xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
+// CHECK-NEXT: %[[ADD_INIT:.*]] = hipsr.placeholder(%[[EXPAND_CTX]]) ins(%[[SHAPE_ROOT]], %[[SHAPE_ROOT]] : tensor<?x4xf32>, tensor<?x4xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
 // CHECK-NEXT: %[[RESULT:.*]] = hipsr.add(%[[EXPAND_CTX]]) ins(%[[EXPANDED]], %[[EXPANDED]] : tensor<?x4xf16>, tensor<?x4xf16>) outs(%[[ADD_INIT]] : tensor<?x4xf16>) : tensor<?x4xf16>
 // CHECK-NEXT: hipsr.pool_domain_yield %[[RESULT]] : tensor<?x4xf16>
 // CHECK-NEXT: } -> tensor<?x4xf16>
@@ -37,21 +37,20 @@ func.func @expand_barrier_modes(
   %cast = hipsr.cast(%ctx) ins(%input : tensor<?x4xf32>)
       outs(%cast_init : tensor<?x4xf16>) : tensor<?x4xf16>
   %shape_attr_init = hipsr.placeholder(%ctx)
-      ins(%cast : tensor<?x4xf16>)
+      ins(%input : tensor<?x4xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
   %shape_attr_expanded = hipsr.expand(%ctx)
       ins(%cast : tensor<?x4xf16>)
       outs(%shape_attr_init : tensor<?x4xf16>)
       {shape_attr = array<i64: 1, 4>} : tensor<?x4xf16>
   %runtime_init = hipsr.placeholder(%ctx)
-      ins(%shape_attr_expanded, %shape : tensor<?x4xf16>, tensor<2xi64>)
+      ins(%input, %shape : tensor<?x4xf32>, tensor<2xi64>)
       {type = #hipsr.placeholder_type<barrier>} : tensor<?x4xf16>
   %runtime_expanded = hipsr.expand(%ctx)
       ins(%shape_attr_expanded, %shape : tensor<?x4xf16>, tensor<2xi64>)
       outs(%runtime_init : tensor<?x4xf16>) : tensor<?x4xf16>
   %add_init = hipsr.placeholder(%ctx)
-      ins(%runtime_expanded, %runtime_expanded
-          : tensor<?x4xf16>, tensor<?x4xf16>)
+      ins(%input, %input : tensor<?x4xf32>, tensor<?x4xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
   %result = hipsr.add(%ctx)
       ins(%runtime_expanded, %runtime_expanded

--- a/test/lit/Dialect/Hipsr/partition-pool-domains.mlir
+++ b/test/lit/Dialect/Hipsr/partition-pool-domains.mlir
@@ -8,7 +8,7 @@
 // RUN: hip-mlir-opt --split-input-file -hipsr-partition-pool-domains -cse %s | FileCheck %s
 
 // Expand with a shape attribute stays in its domain. Its placeholder's use of
-// the Cast result remains internal. Runtime Expand starts the next domain.
+// the Cast placeholder remains internal. Runtime Expand starts the next domain.
 // CHECK-LABEL: func.func @expand_barrier_modes(
 // CHECK-SAME: %[[CTX:.*]]: !hipsr.context, %[[INPUT:.*]]: tensor<?x4xf32>,
 // CHECK-SAME: %[[SHAPE:.*]]: tensor<2xi64>)
@@ -17,7 +17,7 @@
 // CHECK-NEXT: ^bb0(%[[FIRST_CTX:.*]]: !hipsr.context, %[[FIRST_INPUT:.*]]: tensor<?x4xf32>):
 // CHECK-NEXT: %[[CAST_INIT:.*]] = hipsr.placeholder(%[[FIRST_CTX]]) ins(%[[FIRST_INPUT]] : tensor<?x4xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
 // CHECK-NEXT: %[[CAST:.*]] = hipsr.cast(%[[FIRST_CTX]]) ins(%[[FIRST_INPUT]] : tensor<?x4xf32>) outs(%[[CAST_INIT]] : tensor<?x4xf16>) : tensor<?x4xf16>
-// CHECK-NEXT: %[[SHAPE_ATTR_INIT:.*]] = hipsr.placeholder(%[[FIRST_CTX]]) ins(%[[CAST]] : tensor<?x4xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
+// CHECK-NEXT: %[[SHAPE_ATTR_INIT:.*]] = hipsr.placeholder(%[[FIRST_CTX]]) ins(%[[CAST_INIT]] : tensor<?x4xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
 // CHECK-NEXT: %[[SHAPE_ATTR_EXPANDED:.*]] = hipsr.expand(%[[FIRST_CTX]]) ins(%[[CAST]] : tensor<?x4xf16>) outs(%[[SHAPE_ATTR_INIT]] : tensor<?x4xf16>) {shape_attr = array<i64: 1, 4>} : tensor<?x4xf16>
 // CHECK-NEXT: hipsr.pool_domain_yield %[[SHAPE_ATTR_EXPANDED]] : tensor<?x4xf16>
 // CHECK-NEXT: } -> tensor<?x4xf16>
@@ -25,7 +25,7 @@
 // CHECK-NEXT: ^bb0(%[[EXPAND_CTX:.*]]: !hipsr.context, %[[EXPAND_INPUT:.*]]: tensor<?x4xf16>, %[[EXPAND_SHAPE:.*]]: tensor<2xi64>):
 // CHECK-NEXT: %[[EXPAND_INIT:.*]] = hipsr.placeholder(%[[EXPAND_CTX]]) ins(%[[EXPAND_INPUT]], %[[EXPAND_SHAPE]] : tensor<?x4xf16>, tensor<2xi64>) {type = #hipsr.placeholder_type<barrier>} : tensor<?x4xf16>
 // CHECK-NEXT: %[[EXPANDED:.*]] = hipsr.expand(%[[EXPAND_CTX]]) ins(%[[EXPAND_INPUT]], %[[EXPAND_SHAPE]] : tensor<?x4xf16>, tensor<2xi64>) outs(%[[EXPAND_INIT]] : tensor<?x4xf16>) : tensor<?x4xf16>
-// CHECK-NEXT: %[[ADD_INIT:.*]] = hipsr.placeholder(%[[EXPAND_CTX]]) ins(%[[EXPANDED]], %[[EXPANDED]] : tensor<?x4xf16>, tensor<?x4xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
+// CHECK-NEXT: %[[ADD_INIT:.*]] = hipsr.placeholder(%[[EXPAND_CTX]]) ins(%[[EXPAND_INIT]], %[[EXPAND_INIT]] : tensor<?x4xf16>, tensor<?x4xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
 // CHECK-NEXT: %[[RESULT:.*]] = hipsr.add(%[[EXPAND_CTX]]) ins(%[[EXPANDED]], %[[EXPANDED]] : tensor<?x4xf16>, tensor<?x4xf16>) outs(%[[ADD_INIT]] : tensor<?x4xf16>) : tensor<?x4xf16>
 // CHECK-NEXT: hipsr.pool_domain_yield %[[RESULT]] : tensor<?x4xf16>
 // CHECK-NEXT: } -> tensor<?x4xf16>
@@ -40,20 +40,20 @@ func.func @expand_barrier_modes(
   %cast = hipsr.cast(%ctx) ins(%input : tensor<?x4xf32>)
       outs(%cast_init : tensor<?x4xf16>) : tensor<?x4xf16>
   %shape_attr_init = hipsr.placeholder(%ctx)
-      ins(%cast : tensor<?x4xf16>)
+      ins(%cast_init : tensor<?x4xf16>)
       {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
   %shape_attr_expanded = hipsr.expand(%ctx)
       ins(%cast : tensor<?x4xf16>)
       outs(%shape_attr_init : tensor<?x4xf16>)
       {shape_attr = array<i64: 1, 4>} : tensor<?x4xf16>
   %runtime_init = hipsr.placeholder(%ctx)
-      ins(%shape_attr_expanded, %shape : tensor<?x4xf16>, tensor<2xi64>)
+      ins(%shape_attr_init, %shape : tensor<?x4xf16>, tensor<2xi64>)
       {type = #hipsr.placeholder_type<barrier>} : tensor<?x4xf16>
   %runtime_expanded = hipsr.expand(%ctx)
       ins(%shape_attr_expanded, %shape : tensor<?x4xf16>, tensor<2xi64>)
       outs(%runtime_init : tensor<?x4xf16>) : tensor<?x4xf16>
   %add_init = hipsr.placeholder(%ctx)
-      ins(%runtime_expanded, %runtime_expanded
+      ins(%runtime_init, %runtime_init
           : tensor<?x4xf16>, tensor<?x4xf16>)
       {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
   %result = hipsr.add(%ctx)

--- a/test/lit/Dialect/Hipsr/partition-pool-domains.mlir
+++ b/test/lit/Dialect/Hipsr/partition-pool-domains.mlir
@@ -15,17 +15,17 @@
 // CHECK-SAME: -> tensor<?x4xf16> {
 // CHECK-NEXT: %[[FIRST_DOMAIN:.*]] = hipsr.pool_domain(%[[CTX]], %[[INPUT]] : !hipsr.context, tensor<?x4xf32>) {
 // CHECK-NEXT: ^bb0(%[[FIRST_CTX:.*]]: !hipsr.context, %[[FIRST_INPUT:.*]]: tensor<?x4xf32>):
-// CHECK-NEXT: %[[CAST_INIT:.*]] = hipsr.placeholder(%[[FIRST_CTX]], %[[FIRST_INPUT]] : tensor<?x4xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
+// CHECK-NEXT: %[[CAST_INIT:.*]] = hipsr.placeholder(%[[FIRST_CTX]]) ins(%[[FIRST_INPUT]] : tensor<?x4xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
 // CHECK-NEXT: %[[CAST:.*]] = hipsr.cast(%[[FIRST_CTX]]) ins(%[[FIRST_INPUT]] : tensor<?x4xf32>) outs(%[[CAST_INIT]] : tensor<?x4xf16>) : tensor<?x4xf16>
-// CHECK-NEXT: %[[SHAPE_ATTR_INIT:.*]] = hipsr.placeholder(%[[FIRST_CTX]], %[[CAST]] : tensor<?x4xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
+// CHECK-NEXT: %[[SHAPE_ATTR_INIT:.*]] = hipsr.placeholder(%[[FIRST_CTX]]) ins(%[[CAST]] : tensor<?x4xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
 // CHECK-NEXT: %[[SHAPE_ATTR_EXPANDED:.*]] = hipsr.expand(%[[FIRST_CTX]]) ins(%[[CAST]] : tensor<?x4xf16>) outs(%[[SHAPE_ATTR_INIT]] : tensor<?x4xf16>) {shape_attr = array<i64: 1, 4>} : tensor<?x4xf16>
 // CHECK-NEXT: hipsr.pool_domain_yield %[[SHAPE_ATTR_EXPANDED]] : tensor<?x4xf16>
 // CHECK-NEXT: } -> tensor<?x4xf16>
 // CHECK-NEXT: %[[EXPAND_DOMAIN:.*]] = hipsr.pool_domain(%[[CTX]], %[[FIRST_DOMAIN]], %[[SHAPE]] : !hipsr.context, tensor<?x4xf16>, tensor<2xi64>) {
 // CHECK-NEXT: ^bb0(%[[EXPAND_CTX:.*]]: !hipsr.context, %[[EXPAND_INPUT:.*]]: tensor<?x4xf16>, %[[EXPAND_SHAPE:.*]]: tensor<2xi64>):
-// CHECK-NEXT: %[[EXPAND_INIT:.*]] = hipsr.placeholder(%[[EXPAND_CTX]], %[[EXPAND_INPUT]], %[[EXPAND_SHAPE]] : tensor<?x4xf16>, tensor<2xi64>) {type = #hipsr.placeholder_type<barrier>} : tensor<?x4xf16>
+// CHECK-NEXT: %[[EXPAND_INIT:.*]] = hipsr.placeholder(%[[EXPAND_CTX]]) ins(%[[EXPAND_INPUT]], %[[EXPAND_SHAPE]] : tensor<?x4xf16>, tensor<2xi64>) {type = #hipsr.placeholder_type<barrier>} : tensor<?x4xf16>
 // CHECK-NEXT: %[[EXPANDED:.*]] = hipsr.expand(%[[EXPAND_CTX]]) ins(%[[EXPAND_INPUT]], %[[EXPAND_SHAPE]] : tensor<?x4xf16>, tensor<2xi64>) outs(%[[EXPAND_INIT]] : tensor<?x4xf16>) : tensor<?x4xf16>
-// CHECK-NEXT: %[[ADD_INIT:.*]] = hipsr.placeholder(%[[EXPAND_CTX]], %[[EXPANDED]], %[[EXPANDED]] : tensor<?x4xf16>, tensor<?x4xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
+// CHECK-NEXT: %[[ADD_INIT:.*]] = hipsr.placeholder(%[[EXPAND_CTX]]) ins(%[[EXPANDED]], %[[EXPANDED]] : tensor<?x4xf16>, tensor<?x4xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
 // CHECK-NEXT: %[[RESULT:.*]] = hipsr.add(%[[EXPAND_CTX]]) ins(%[[EXPANDED]], %[[EXPANDED]] : tensor<?x4xf16>, tensor<?x4xf16>) outs(%[[ADD_INIT]] : tensor<?x4xf16>) : tensor<?x4xf16>
 // CHECK-NEXT: hipsr.pool_domain_yield %[[RESULT]] : tensor<?x4xf16>
 // CHECK-NEXT: } -> tensor<?x4xf16>
@@ -34,28 +34,27 @@
 func.func @expand_barrier_modes(
     %ctx: !hipsr.context, %input: tensor<?x4xf32>, %shape: tensor<2xi64>)
     -> tensor<?x4xf16> {
-  %cast_init = hipsr.placeholder(
-      %ctx, %input : tensor<?x4xf32>)
+  %cast_init = hipsr.placeholder(%ctx)
+      ins(%input : tensor<?x4xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
   %cast = hipsr.cast(%ctx) ins(%input : tensor<?x4xf32>)
       outs(%cast_init : tensor<?x4xf16>) : tensor<?x4xf16>
-  %shape_attr_init = hipsr.placeholder(
-      %ctx, %cast : tensor<?x4xf16>)
+  %shape_attr_init = hipsr.placeholder(%ctx)
+      ins(%cast : tensor<?x4xf16>)
       {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
   %shape_attr_expanded = hipsr.expand(%ctx)
       ins(%cast : tensor<?x4xf16>)
       outs(%shape_attr_init : tensor<?x4xf16>)
       {shape_attr = array<i64: 1, 4>} : tensor<?x4xf16>
-  %runtime_init = hipsr.placeholder(
-      %ctx, %shape_attr_expanded, %shape
-      : tensor<?x4xf16>, tensor<2xi64>)
+  %runtime_init = hipsr.placeholder(%ctx)
+      ins(%shape_attr_expanded, %shape : tensor<?x4xf16>, tensor<2xi64>)
       {type = #hipsr.placeholder_type<barrier>} : tensor<?x4xf16>
   %runtime_expanded = hipsr.expand(%ctx)
       ins(%shape_attr_expanded, %shape : tensor<?x4xf16>, tensor<2xi64>)
       outs(%runtime_init : tensor<?x4xf16>) : tensor<?x4xf16>
-  %add_init = hipsr.placeholder(
-      %ctx, %runtime_expanded, %runtime_expanded
-      : tensor<?x4xf16>, tensor<?x4xf16>)
+  %add_init = hipsr.placeholder(%ctx)
+      ins(%runtime_expanded, %runtime_expanded
+          : tensor<?x4xf16>, tensor<?x4xf16>)
       {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
   %result = hipsr.add(%ctx)
       ins(%runtime_expanded, %runtime_expanded
@@ -77,7 +76,7 @@ func.func @expand_barrier_modes(
 // CHECK-NEXT: %[[SUM:.*]] = arith.addi %[[DCAPTURE]], %[[DCAPTURE]] : i32
 // CHECK-NEXT: scf.yield %[[SUM]] : i32
 // CHECK-NEXT: }
-// CHECK-NEXT: %[[INIT:.*]] = hipsr.placeholder(%[[DCTX]], %[[DINPUT]] : tensor<?x8xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16>
+// CHECK-NEXT: %[[INIT:.*]] = hipsr.placeholder(%[[DCTX]]) ins(%[[DINPUT]] : tensor<?x8xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16>
 // CHECK-NEXT: %[[CAST:.*]] = hipsr.cast(%[[DCTX]]) ins(%[[DINPUT]] : tensor<?x8xf32>) outs(%[[INIT]] : tensor<?x8xf16>) : tensor<?x8xf16> shape_region {
 // CHECK-NEXT: ^bb0(%[[SHAPE_INPUT:.*]]: tensor<?x8xf32>):
 // CHECK-NEXT: %[[SHAPE:.*]] = shape.shape_of %[[SHAPE_INPUT]] : tensor<?x8xf32> -> tensor<2xindex>
@@ -95,8 +94,8 @@ func.func @nested_shape_region(%ctx: !hipsr.context,
                                %input: tensor<?x8xf32>,
                                %capture: i32)
     -> (tensor<?x8xf16>, i32) {
-  %init = hipsr.placeholder(
-      %ctx, %input : tensor<?x8xf32>)
+  %init = hipsr.placeholder(%ctx)
+      ins(%input : tensor<?x8xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16>
   %region = scf.execute_region -> i32 {
     %sum = arith.addi %capture, %capture : i32

--- a/test/lit/Dialect/Hipsr/partition-pool-domains.mlir
+++ b/test/lit/Dialect/Hipsr/partition-pool-domains.mlir
@@ -4,8 +4,8 @@
 // Every pool domain receives the function's first hipsr context argument.
 // RUN: hip-mlir-opt --split-input-file -hipsr-partition-pool-domains %s | FileCheck %s
 
-// Expand with a shape attribute stays in its domain. Placeholder dependencies
-// are function roots. Runtime Expand starts the next domain.
+// Expand with a shape attribute stays in its domain. This fixture uses function
+// arguments as shape-graph roots. Runtime Expand starts the next domain.
 // CHECK-LABEL: func.func @expand_barrier_modes(
 // CHECK-SAME: %[[CTX:.*]]: !hipsr.context, %[[INPUT:.*]]: tensor<?x4xf32>,
 // CHECK-SAME: %[[SHAPE:.*]]: tensor<2xi64>)

--- a/test/lit/Dialect/Hipsr/placeholder-invalid.mlir
+++ b/test/lit/Dialect/Hipsr/placeholder-invalid.mlir
@@ -43,8 +43,8 @@ func.func @zero_result_placeholder(
 func.func @missing_type(
     %ctx: !hipsr.context, %input: tensor<4x8xf32>) -> tensor<4x8xf16> {
   // expected-error @+1 {{requires attribute 'type'}}
-  %init = hipsr.placeholder(
-      %ctx, %input : tensor<4x8xf32>) : tensor<4x8xf16>
+  %init = hipsr.placeholder(%ctx)
+      ins(%input : tensor<4x8xf32>) : tensor<4x8xf16>
   %result = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
       outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
   return %result : tensor<4x8xf16>
@@ -56,8 +56,8 @@ func.func @missing_type(
 func.func @unused_placeholder(
     %ctx: !hipsr.context, %input: tensor<4x8xf32>) {
   // expected-error @+1 {{requires each result to have exactly one use}}
-  %init = hipsr.placeholder(
-      %ctx, %input : tensor<4x8xf32>)
+  %init = hipsr.placeholder(%ctx)
+      ins(%input : tensor<4x8xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
   return
 }
@@ -68,8 +68,8 @@ func.func @unused_placeholder(
 func.func @non_dps_placeholder_use(
     %ctx: !hipsr.context, %input: tensor<4x8xf32>) -> tensor<?x8xf16> {
   // expected-error @+1 {{requires each result to be used as a DPS init of a hipsr operation}}
-  %init = hipsr.placeholder(
-      %ctx, %input : tensor<4x8xf32>)
+  %init = hipsr.placeholder(%ctx)
+      ins(%input : tensor<4x8xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
   %result = tensor.cast %init : tensor<4x8xf16> to tensor<?x8xf16>
   return %result : tensor<?x8xf16>
@@ -82,8 +82,8 @@ func.func @non_hipsr_dps_use(
     %ctx: !hipsr.context, %input: tensor<4x8xf32>,
     %value: f32) -> tensor<4x8xf32> {
   // expected-error @+1 {{requires each result to be used as a DPS init of a hipsr operation}}
-  %init = hipsr.placeholder(
-      %ctx, %input : tensor<4x8xf32>)
+  %init = hipsr.placeholder(%ctx)
+      ins(%input : tensor<4x8xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf32>
   %result = linalg.fill ins(%value : f32)
       outs(%init : tensor<4x8xf32>) -> tensor<4x8xf32>
@@ -97,8 +97,8 @@ func.func @dps_input_placeholder(
     %ctx: !hipsr.context, %source: tensor<4x8xf32>,
     %init: tensor<4x8xf16>) -> tensor<4x8xf16> {
   // expected-error @+1 {{requires each result to be used as a DPS init of a hipsr operation}}
-  %input = hipsr.placeholder(
-      %ctx, %source : tensor<4x8xf32>)
+  %input = hipsr.placeholder(%ctx)
+      ins(%source : tensor<4x8xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf32>
   %result = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
       outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
@@ -112,8 +112,8 @@ func.func @shared_placeholder(%ctx: !hipsr.context,
                               %input: tensor<4x8xf32>)
     -> (tensor<4x8xf16>, tensor<4x8xf16>) {
   // expected-error @+1 {{requires each result to have exactly one use}}
-  %init = hipsr.placeholder(
-      %ctx, %input : tensor<4x8xf32>)
+  %init = hipsr.placeholder(%ctx)
+      ins(%input : tensor<4x8xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
   %first = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
       outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
@@ -129,8 +129,8 @@ func.func @split_placeholder_consumers(
     %ctx: !hipsr.context, %input: tensor<4x8xf32>)
     -> (tensor<4x8xf16>, tensor<4x8xf16>) {
   // expected-error @+1 {{requires all results to initialize the same hipsr operation}}
-  %inits:2 = hipsr.placeholder(
-      %ctx, %input : tensor<4x8xf32>)
+  %inits:2 = hipsr.placeholder(%ctx)
+      ins(%input : tensor<4x8xf32>)
       {type = #hipsr.placeholder_type<normal>}
       : tensor<4x8xf16>, tensor<4x8xf16>
   %first = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
@@ -188,8 +188,8 @@ func.func @wrong_data_input(
     %ctx: !hipsr.context, %input: tensor<4x8xf32>,
     %other: tensor<4x8xf32>) -> tensor<4x8xf16> {
   // expected-error @+1 {{operand 1 must match consumer DPS input 1}}
-  %init = hipsr.placeholder(
-      %ctx, %other : tensor<4x8xf32>)
+  %init = hipsr.placeholder(%ctx)
+      ins(%other : tensor<4x8xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
   %result = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
       outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
@@ -202,8 +202,8 @@ func.func @wrong_data_input(
 func.func @two_shape_region_blocks(
     %ctx: !hipsr.context, %input: tensor<4x8xf32>) -> tensor<4x8xf16> {
   // expected-error @+1 {{expects region #0 to have 0 or 1 blocks}}
-  %init = hipsr.placeholder(
-      %ctx, %input : tensor<4x8xf32>)
+  %init = hipsr.placeholder(%ctx)
+      ins(%input : tensor<4x8xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
       shape_region {
     hipsr.shape_yield () : [f16]
@@ -221,8 +221,8 @@ func.func @two_shape_region_blocks(
 func.func @shape_region_argument_count(
     %ctx: !hipsr.context, %input: tensor<4x8xf32>) -> tensor<4x8xf16> {
   // expected-error @+1 {{shape region block argument count must match operand count; expected 2, got 1}}
-  %init = hipsr.placeholder(
-      %ctx, %input : tensor<4x8xf32>)
+  %init = hipsr.placeholder(%ctx)
+      ins(%input : tensor<4x8xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
       shape_region {
   ^bb0(%shape_ctx: !hipsr.context):
@@ -239,8 +239,8 @@ func.func @shape_region_argument_count(
 func.func @wrong_shape_region_terminator(
     %ctx: !hipsr.context, %input: tensor<4x8xf32>) -> tensor<4x8xf16> {
   // expected-error @+1 {{shape region must terminate with hipsr.shape_yield}}
-  %init = hipsr.placeholder(
-      %ctx, %input : tensor<4x8xf32>)
+  %init = hipsr.placeholder(%ctx)
+      ins(%input : tensor<4x8xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
       shape_region {
   ^bb0(%shape_ctx: !hipsr.context, %shape_input: tensor<4x8xf32>):

--- a/test/lit/Dialect/Hipsr/placeholder-invalid.mlir
+++ b/test/lit/Dialect/Hipsr/placeholder-invalid.mlir
@@ -184,25 +184,6 @@ func.func @nonleading_context(
 
 // -----
 
-// Placeholder inputs cannot depend directly on data-operation results.
-func.func @operation_result_input(
-    %ctx: !hipsr.context, %input: tensor<4x8xf32>) -> tensor<4x8xf16> {
-  %producer_init = hipsr.placeholder(%ctx)
-      ins(%input : tensor<4x8xf32>)
-      {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf32>
-  %producer = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
-      outs(%producer_init : tensor<4x8xf32>) : tensor<4x8xf32>
-  // expected-error @+1 {{input 0 must be a block argument or result of hipsr.placeholder}}
-  %consumer_init = hipsr.placeholder(%ctx)
-      ins(%producer : tensor<4x8xf32>)
-      {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
-  %result = hipsr.cast(%ctx) ins(%producer : tensor<4x8xf32>)
-      outs(%consumer_init : tensor<4x8xf16>) : tensor<4x8xf16>
-  return %result : tensor<4x8xf16>
-}
-
-// -----
-
 // A placeholder shape region may have at most one block.
 func.func @two_shape_region_blocks(
     %ctx: !hipsr.context, %input: tensor<4x8xf32>) -> tensor<4x8xf16> {

--- a/test/lit/Dialect/Hipsr/placeholder-invalid.mlir
+++ b/test/lit/Dialect/Hipsr/placeholder-invalid.mlir
@@ -15,7 +15,7 @@ func.func @unranked_rejected(
 
 // -----
 
-// Shape operands must be ranked tensors.
+// Inputs must be ranked tensors.
 func.func @unranked_shape_operand_rejected(
     %ctx: !hipsr.context, %input: tensor<*xf32>) {
   // expected-error @+1 {{op operand #1 must be variadic of ranked tensor of any type values}}
@@ -44,7 +44,7 @@ func.func @missing_type(
     %ctx: !hipsr.context, %input: tensor<4x8xf32>) -> tensor<4x8xf16> {
   // expected-error @+1 {{requires attribute 'type'}}
   %init = hipsr.placeholder(
-      %ctx, %input : !hipsr.context, tensor<4x8xf32>) : tensor<4x8xf16>
+      %ctx, %input : tensor<4x8xf32>) : tensor<4x8xf16>
   %result = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
       outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
   return %result : tensor<4x8xf16>
@@ -57,7 +57,7 @@ func.func @unused_placeholder(
     %ctx: !hipsr.context, %input: tensor<4x8xf32>) {
   // expected-error @+1 {{requires each result to have exactly one use}}
   %init = hipsr.placeholder(
-      %ctx, %input : !hipsr.context, tensor<4x8xf32>)
+      %ctx, %input : tensor<4x8xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
   return
 }
@@ -69,7 +69,7 @@ func.func @non_dps_placeholder_use(
     %ctx: !hipsr.context, %input: tensor<4x8xf32>) -> tensor<?x8xf16> {
   // expected-error @+1 {{requires each result to be used as a DPS init of a hipsr operation}}
   %init = hipsr.placeholder(
-      %ctx, %input : !hipsr.context, tensor<4x8xf32>)
+      %ctx, %input : tensor<4x8xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
   %result = tensor.cast %init : tensor<4x8xf16> to tensor<?x8xf16>
   return %result : tensor<?x8xf16>
@@ -83,7 +83,7 @@ func.func @non_hipsr_dps_use(
     %value: f32) -> tensor<4x8xf32> {
   // expected-error @+1 {{requires each result to be used as a DPS init of a hipsr operation}}
   %init = hipsr.placeholder(
-      %ctx, %input : !hipsr.context, tensor<4x8xf32>)
+      %ctx, %input : tensor<4x8xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf32>
   %result = linalg.fill ins(%value : f32)
       outs(%init : tensor<4x8xf32>) -> tensor<4x8xf32>
@@ -98,7 +98,7 @@ func.func @dps_input_placeholder(
     %init: tensor<4x8xf16>) -> tensor<4x8xf16> {
   // expected-error @+1 {{requires each result to be used as a DPS init of a hipsr operation}}
   %input = hipsr.placeholder(
-      %ctx, %source : !hipsr.context, tensor<4x8xf32>)
+      %ctx, %source : tensor<4x8xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf32>
   %result = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
       outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
@@ -113,7 +113,7 @@ func.func @shared_placeholder(%ctx: !hipsr.context,
     -> (tensor<4x8xf16>, tensor<4x8xf16>) {
   // expected-error @+1 {{requires each result to have exactly one use}}
   %init = hipsr.placeholder(
-      %ctx, %input : !hipsr.context, tensor<4x8xf32>)
+      %ctx, %input : tensor<4x8xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
   %first = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
       outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
@@ -130,7 +130,7 @@ func.func @split_placeholder_consumers(
     -> (tensor<4x8xf16>, tensor<4x8xf16>) {
   // expected-error @+1 {{requires all results to initialize the same hipsr operation}}
   %inits:2 = hipsr.placeholder(
-      %ctx, %input : !hipsr.context, tensor<4x8xf32>)
+      %ctx, %input : tensor<4x8xf32>)
       {type = #hipsr.placeholder_type<normal>}
       : tensor<4x8xf16>, tensor<4x8xf16>
   %first = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
@@ -142,7 +142,7 @@ func.func @split_placeholder_consumers(
 
 // -----
 
-// Placeholder operands always start with the HIPSR context.
+// Placeholder inputs always follow the HIPSR context.
 func.func @missing_context(
     %ctx: !hipsr.context, %input: tensor<4x8xf32>) -> tensor<4x8xf16> {
   // expected-error @+1 {{expected 1 or more operands, but found 0}}
@@ -158,10 +158,10 @@ func.func @missing_context(
 // A context after a data operand does not satisfy the context-first contract.
 func.func @nonleading_context(
     %ctx: !hipsr.context, %input: tensor<4x8xf32>) -> tensor<4x8xf16> {
-  // expected-error @+2 {{expected hipsr.context}}
-  %init = hipsr.placeholder(
-      %input, %ctx : tensor<4x8xf32>, !hipsr.context)
-      {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
+  // expected-error @+1 {{operand #0 must be Opaque hipsr execution context}}
+  %init = "hipsr.placeholder"(%input, %ctx) ({})
+      {type = #hipsr.placeholder_type<normal>}
+      : (tensor<4x8xf32>, !hipsr.context) -> tensor<4x8xf16>
   %result = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
       outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
   return %result : tensor<4x8xf16>
@@ -169,11 +169,11 @@ func.func @nonleading_context(
 
 // -----
 
-// Placeholder operands mirror the consumer's complete DPS input list.
+// Placeholder inputs mirror the consumer's data inputs.
 func.func @missing_data_input(
     %ctx: !hipsr.context, %input: tensor<4x8xf32>) -> tensor<4x8xf16> {
   // expected-error @+1 {{operand count must match consumer DPS input count; expected 2, got 1}}
-  %init = hipsr.placeholder(%ctx : !hipsr.context)
+  %init = hipsr.placeholder(%ctx)
       {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
   %result = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
       outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
@@ -182,14 +182,14 @@ func.func @missing_data_input(
 
 // -----
 
-// Matching types are insufficient: each placeholder operand mirrors the same
+// Matching types are insufficient: each placeholder input mirrors the same
 // SSA value used by the consumer.
 func.func @wrong_data_input(
     %ctx: !hipsr.context, %input: tensor<4x8xf32>,
     %other: tensor<4x8xf32>) -> tensor<4x8xf16> {
   // expected-error @+1 {{operand 1 must match consumer DPS input 1}}
   %init = hipsr.placeholder(
-      %ctx, %other : !hipsr.context, tensor<4x8xf32>)
+      %ctx, %other : tensor<4x8xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
   %result = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
       outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
@@ -203,7 +203,7 @@ func.func @two_shape_region_blocks(
     %ctx: !hipsr.context, %input: tensor<4x8xf32>) -> tensor<4x8xf16> {
   // expected-error @+1 {{expects region #0 to have 0 or 1 blocks}}
   %init = hipsr.placeholder(
-      %ctx, %input : !hipsr.context, tensor<4x8xf32>)
+      %ctx, %input : tensor<4x8xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
       shape_region {
     hipsr.shape_yield () : [f16]
@@ -222,7 +222,7 @@ func.func @shape_region_argument_count(
     %ctx: !hipsr.context, %input: tensor<4x8xf32>) -> tensor<4x8xf16> {
   // expected-error @+1 {{shape region block argument count must match operand count; expected 2, got 1}}
   %init = hipsr.placeholder(
-      %ctx, %input : !hipsr.context, tensor<4x8xf32>)
+      %ctx, %input : tensor<4x8xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
       shape_region {
   ^bb0(%shape_ctx: !hipsr.context):
@@ -240,7 +240,7 @@ func.func @wrong_shape_region_terminator(
     %ctx: !hipsr.context, %input: tensor<4x8xf32>) -> tensor<4x8xf16> {
   // expected-error @+1 {{shape region must terminate with hipsr.shape_yield}}
   %init = hipsr.placeholder(
-      %ctx, %input : !hipsr.context, tensor<4x8xf32>)
+      %ctx, %input : tensor<4x8xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
       shape_region {
   ^bb0(%shape_ctx: !hipsr.context, %shape_input: tensor<4x8xf32>):

--- a/test/lit/Dialect/Hipsr/placeholder-invalid.mlir
+++ b/test/lit/Dialect/Hipsr/placeholder-invalid.mlir
@@ -218,22 +218,3 @@ func.func @shape_region_argument_count(
       outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
   return %result : tensor<4x8xf16>
 }
-
-// -----
-
-// Placeholder shape regions terminate with hipsr.shape_yield.
-func.func @wrong_shape_region_terminator(
-    %ctx: !hipsr.context, %input: tensor<4x8xf32>) -> tensor<4x8xf16> {
-  // expected-error @+1 {{shape region must terminate with hipsr.shape_yield}}
-  %init = hipsr.placeholder(%ctx)
-      ins(%input : tensor<4x8xf32>)
-      {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
-      shape_region {
-  ^bb0(%shape_ctx: !hipsr.context, %shape_input: tensor<4x8xf32>):
-    cf.br ^bb0(%shape_ctx, %shape_input
-        : !hipsr.context, tensor<4x8xf32>)
-  }
-  %result = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
-      outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
-  return %result : tensor<4x8xf16>
-}

--- a/test/lit/Dialect/Hipsr/placeholder-invalid.mlir
+++ b/test/lit/Dialect/Hipsr/placeholder-invalid.mlir
@@ -55,7 +55,7 @@ func.func @missing_type(
 // Unused placeholder results are invalid.
 func.func @unused_placeholder(
     %ctx: !hipsr.context, %input: tensor<4x8xf32>) {
-  // expected-error @+1 {{requires each result to have exactly one use}}
+  // expected-error @+1 {{requires each result to initialize exactly one hipsr operation}}
   %init = hipsr.placeholder(%ctx)
       ins(%input : tensor<4x8xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
@@ -64,10 +64,10 @@ func.func @unused_placeholder(
 
 // -----
 
-// Placeholder results must be DPS init values.
+// Uses other than placeholder inputs and HIPSR DPS inits are invalid.
 func.func @non_dps_placeholder_use(
     %ctx: !hipsr.context, %input: tensor<4x8xf32>) -> tensor<?x8xf16> {
-  // expected-error @+1 {{requires each result to be used as a DPS init of a hipsr operation}}
+  // expected-error @+1 {{requires each result use to be a placeholder input or a DPS init of a hipsr operation}}
   %init = hipsr.placeholder(%ctx)
       ins(%input : tensor<4x8xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
@@ -77,11 +77,11 @@ func.func @non_dps_placeholder_use(
 
 // -----
 
-// Placeholder results must be used by hipsr ops.
+// DPS init uses must belong to HIPSR ops.
 func.func @non_hipsr_dps_use(
     %ctx: !hipsr.context, %input: tensor<4x8xf32>,
     %value: f32) -> tensor<4x8xf32> {
-  // expected-error @+1 {{requires each result to be used as a DPS init of a hipsr operation}}
+  // expected-error @+1 {{requires each result use to be a placeholder input or a DPS init of a hipsr operation}}
   %init = hipsr.placeholder(%ctx)
       ins(%input : tensor<4x8xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf32>
@@ -96,7 +96,7 @@ func.func @non_hipsr_dps_use(
 func.func @dps_input_placeholder(
     %ctx: !hipsr.context, %source: tensor<4x8xf32>,
     %init: tensor<4x8xf16>) -> tensor<4x8xf16> {
-  // expected-error @+1 {{requires each result to be used as a DPS init of a hipsr operation}}
+  // expected-error @+1 {{requires each result use to be a placeholder input or a DPS init of a hipsr operation}}
   %input = hipsr.placeholder(%ctx)
       ins(%source : tensor<4x8xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf32>
@@ -111,7 +111,7 @@ func.func @dps_input_placeholder(
 func.func @shared_placeholder(%ctx: !hipsr.context,
                               %input: tensor<4x8xf32>)
     -> (tensor<4x8xf16>, tensor<4x8xf16>) {
-  // expected-error @+1 {{requires each result to have exactly one use}}
+  // expected-error @+1 {{requires each result to initialize exactly one hipsr operation}}
   %init = hipsr.placeholder(%ctx)
       ins(%input : tensor<4x8xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
@@ -138,6 +138,21 @@ func.func @split_placeholder_consumers(
   %second = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
       outs(%inits#1 : tensor<4x8xf16>) : tensor<4x8xf16>
   return %first, %second : tensor<4x8xf16>, tensor<4x8xf16>
+}
+
+// -----
+
+// A placeholder result must match the corresponding consumer result type.
+func.func @result_type_mismatch(
+    %ctx: !hipsr.context, %input: tensor<4x8xf32>) -> tensor<4x8xf32> {
+  // expected-error @+1 {{result 0 type 'tensor<4x8xf16>' must match consumer result type 'tensor<4x8xf32>'}}
+  %init = hipsr.placeholder(%ctx)
+      ins(%input : tensor<4x8xf32>)
+      {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
+  // expected-error @+1 {{expected type of operand #2 ('tensor<4x8xf16>') to match type of corresponding result ('tensor<4x8xf32>')}}
+  %result = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
+      outs(%init : tensor<4x8xf16>) : tensor<4x8xf32>
+  return %result : tensor<4x8xf32>
 }
 
 // -----
@@ -169,30 +184,20 @@ func.func @nonleading_context(
 
 // -----
 
-// Placeholder inputs mirror the consumer's data inputs.
-func.func @missing_data_input(
+// Placeholder inputs cannot depend directly on data-operation results.
+func.func @operation_result_input(
     %ctx: !hipsr.context, %input: tensor<4x8xf32>) -> tensor<4x8xf16> {
-  // expected-error @+1 {{operand count must match consumer DPS input count; expected 2, got 1}}
-  %init = hipsr.placeholder(%ctx)
+  %producer_init = hipsr.placeholder(%ctx)
+      ins(%input : tensor<4x8xf32>)
+      {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf32>
+  %producer = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
+      outs(%producer_init : tensor<4x8xf32>) : tensor<4x8xf32>
+  // expected-error @+1 {{input 0 must be a block argument or result of hipsr.placeholder}}
+  %consumer_init = hipsr.placeholder(%ctx)
+      ins(%producer : tensor<4x8xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
-  %result = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
-      outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
-  return %result : tensor<4x8xf16>
-}
-
-// -----
-
-// Matching types are insufficient: each placeholder input mirrors the same
-// SSA value used by the consumer.
-func.func @wrong_data_input(
-    %ctx: !hipsr.context, %input: tensor<4x8xf32>,
-    %other: tensor<4x8xf32>) -> tensor<4x8xf16> {
-  // expected-error @+1 {{operand 1 must match consumer DPS input 1}}
-  %init = hipsr.placeholder(%ctx)
-      ins(%other : tensor<4x8xf32>)
-      {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
-  %result = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
-      outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
+  %result = hipsr.cast(%ctx) ins(%producer : tensor<4x8xf32>)
+      outs(%consumer_init : tensor<4x8xf16>) : tensor<4x8xf16>
   return %result : tensor<4x8xf16>
 }
 

--- a/test/lit/Dialect/Hipsr/placeholder-invalid.mlir
+++ b/test/lit/Dialect/Hipsr/placeholder-invalid.mlir
@@ -4,36 +4,73 @@
 // RUN: hip-mlir-opt --split-input-file --verify-diagnostics %s
 
 // Results must be ranked tensors.
-func.func @unranked_rejected() {
+func.func @unranked_rejected(
+    %ctx: !hipsr.context, %input: tensor<4x8xf32>) {
   // expected-error @+1 {{op result #0 must be variadic of ranked tensor of any type values}}
-  %0 = "hipsr.placeholder"() : () -> tensor<*xf16>
+  %0 = "hipsr.placeholder"(%ctx, %input) ({})
+      {type = #hipsr.placeholder_type<normal>}
+      : (!hipsr.context, tensor<4x8xf32>) -> tensor<*xf16>
+  return
+}
+
+// -----
+
+// Shape operands must be ranked tensors.
+func.func @unranked_shape_operand_rejected(
+    %ctx: !hipsr.context, %input: tensor<*xf32>) {
+  // expected-error @+1 {{op operand #1 must be variadic of ranked tensor of any type values}}
+  %0 = "hipsr.placeholder"(%ctx, %input) ({})
+      {type = #hipsr.placeholder_type<normal>}
+      : (!hipsr.context, tensor<*xf32>) -> tensor<4x8xf16>
   return
 }
 
 // -----
 
 // Zero-result placeholders are invalid.
-func.func @zero_result_placeholder() {
+func.func @zero_result_placeholder(
+    %ctx: !hipsr.context, %input: tensor<4x8xf32>) {
   // expected-error @+1 {{must produce at least one tensor DPS init}}
-  "hipsr.placeholder"() : () -> ()
+  "hipsr.placeholder"(%ctx, %input) ({})
+      {type = #hipsr.placeholder_type<normal>}
+      : (!hipsr.context, tensor<4x8xf32>) -> ()
   return
 }
 
 // -----
 
+// Placeholder type is required even while its shape region has zero blocks.
+func.func @missing_type(
+    %ctx: !hipsr.context, %input: tensor<4x8xf32>) -> tensor<4x8xf16> {
+  // expected-error @+1 {{requires attribute 'type'}}
+  %init = hipsr.placeholder(
+      %ctx, %input : !hipsr.context, tensor<4x8xf32>) : tensor<4x8xf16>
+  %result = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
+      outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
+  return %result : tensor<4x8xf16>
+}
+
+// -----
+
 // Unused placeholder results are invalid.
-func.func @unused_placeholder() {
+func.func @unused_placeholder(
+    %ctx: !hipsr.context, %input: tensor<4x8xf32>) {
   // expected-error @+1 {{requires each result to have exactly one use}}
-  %init = hipsr.placeholder : tensor<4x8xf16>
+  %init = hipsr.placeholder(
+      %ctx, %input : !hipsr.context, tensor<4x8xf32>)
+      {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
   return
 }
 
 // -----
 
 // Placeholder results must be DPS init values.
-func.func @non_dps_placeholder_use() -> tensor<?x8xf16> {
+func.func @non_dps_placeholder_use(
+    %ctx: !hipsr.context, %input: tensor<4x8xf32>) -> tensor<?x8xf16> {
   // expected-error @+1 {{requires each result to be used as a DPS init of a hipsr operation}}
-  %init = hipsr.placeholder : tensor<4x8xf16>
+  %init = hipsr.placeholder(
+      %ctx, %input : !hipsr.context, tensor<4x8xf32>)
+      {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
   %result = tensor.cast %init : tensor<4x8xf16> to tensor<?x8xf16>
   return %result : tensor<?x8xf16>
 }
@@ -41,9 +78,13 @@ func.func @non_dps_placeholder_use() -> tensor<?x8xf16> {
 // -----
 
 // Placeholder results must be used by hipsr ops.
-func.func @non_hipsr_dps_use(%value: f32) -> tensor<4x8xf32> {
+func.func @non_hipsr_dps_use(
+    %ctx: !hipsr.context, %input: tensor<4x8xf32>,
+    %value: f32) -> tensor<4x8xf32> {
   // expected-error @+1 {{requires each result to be used as a DPS init of a hipsr operation}}
-  %init = hipsr.placeholder : tensor<4x8xf32>
+  %init = hipsr.placeholder(
+      %ctx, %input : !hipsr.context, tensor<4x8xf32>)
+      {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf32>
   %result = linalg.fill ins(%value : f32)
       outs(%init : tensor<4x8xf32>) -> tensor<4x8xf32>
   return %result : tensor<4x8xf32>
@@ -52,10 +93,13 @@ func.func @non_hipsr_dps_use(%value: f32) -> tensor<4x8xf32> {
 // -----
 
 // A placeholder cannot be a DPS input.
-func.func @dps_input_placeholder(%ctx: !hipsr.context) -> tensor<4x8xf16> {
+func.func @dps_input_placeholder(
+    %ctx: !hipsr.context, %source: tensor<4x8xf32>,
+    %init: tensor<4x8xf16>) -> tensor<4x8xf16> {
   // expected-error @+1 {{requires each result to be used as a DPS init of a hipsr operation}}
-  %input = hipsr.placeholder : tensor<4x8xf32>
-  %init = hipsr.placeholder : tensor<4x8xf16>
+  %input = hipsr.placeholder(
+      %ctx, %source : !hipsr.context, tensor<4x8xf32>)
+      {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf32>
   %result = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
       outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
   return %result : tensor<4x8xf16>
@@ -68,7 +112,9 @@ func.func @shared_placeholder(%ctx: !hipsr.context,
                               %input: tensor<4x8xf32>)
     -> (tensor<4x8xf16>, tensor<4x8xf16>) {
   // expected-error @+1 {{requires each result to have exactly one use}}
-  %init = hipsr.placeholder : tensor<4x8xf16>
+  %init = hipsr.placeholder(
+      %ctx, %input : !hipsr.context, tensor<4x8xf32>)
+      {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
   %first = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
       outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
   %second = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
@@ -83,10 +129,125 @@ func.func @split_placeholder_consumers(
     %ctx: !hipsr.context, %input: tensor<4x8xf32>)
     -> (tensor<4x8xf16>, tensor<4x8xf16>) {
   // expected-error @+1 {{requires all results to initialize the same hipsr operation}}
-  %inits:2 = hipsr.placeholder : tensor<4x8xf16>, tensor<4x8xf16>
+  %inits:2 = hipsr.placeholder(
+      %ctx, %input : !hipsr.context, tensor<4x8xf32>)
+      {type = #hipsr.placeholder_type<normal>}
+      : tensor<4x8xf16>, tensor<4x8xf16>
   %first = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
       outs(%inits#0 : tensor<4x8xf16>) : tensor<4x8xf16>
   %second = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
       outs(%inits#1 : tensor<4x8xf16>) : tensor<4x8xf16>
   return %first, %second : tensor<4x8xf16>, tensor<4x8xf16>
+}
+
+// -----
+
+// Placeholder operands always start with the HIPSR context.
+func.func @missing_context(
+    %ctx: !hipsr.context, %input: tensor<4x8xf32>) -> tensor<4x8xf16> {
+  // expected-error @+1 {{expected 1 or more operands, but found 0}}
+  %init = "hipsr.placeholder"() ({})
+      {type = #hipsr.placeholder_type<normal>} : () -> tensor<4x8xf16>
+  %result = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
+      outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
+  return %result : tensor<4x8xf16>
+}
+
+// -----
+
+// A context after a data operand does not satisfy the context-first contract.
+func.func @nonleading_context(
+    %ctx: !hipsr.context, %input: tensor<4x8xf32>) -> tensor<4x8xf16> {
+  // expected-error @+2 {{expected hipsr.context}}
+  %init = hipsr.placeholder(
+      %input, %ctx : tensor<4x8xf32>, !hipsr.context)
+      {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
+  %result = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
+      outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
+  return %result : tensor<4x8xf16>
+}
+
+// -----
+
+// Placeholder operands mirror the consumer's complete DPS input list.
+func.func @missing_data_input(
+    %ctx: !hipsr.context, %input: tensor<4x8xf32>) -> tensor<4x8xf16> {
+  // expected-error @+1 {{operand count must match consumer DPS input count; expected 2, got 1}}
+  %init = hipsr.placeholder(%ctx : !hipsr.context)
+      {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
+  %result = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
+      outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
+  return %result : tensor<4x8xf16>
+}
+
+// -----
+
+// Matching types are insufficient: each placeholder operand mirrors the same
+// SSA value used by the consumer.
+func.func @wrong_data_input(
+    %ctx: !hipsr.context, %input: tensor<4x8xf32>,
+    %other: tensor<4x8xf32>) -> tensor<4x8xf16> {
+  // expected-error @+1 {{operand 1 must match consumer DPS input 1}}
+  %init = hipsr.placeholder(
+      %ctx, %other : !hipsr.context, tensor<4x8xf32>)
+      {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
+  %result = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
+      outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
+  return %result : tensor<4x8xf16>
+}
+
+// -----
+
+// A placeholder shape region may have at most one block.
+func.func @two_shape_region_blocks(
+    %ctx: !hipsr.context, %input: tensor<4x8xf32>) -> tensor<4x8xf16> {
+  // expected-error @+1 {{expects region #0 to have 0 or 1 blocks}}
+  %init = hipsr.placeholder(
+      %ctx, %input : !hipsr.context, tensor<4x8xf32>)
+      {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
+      shape_region {
+    hipsr.shape_yield () : [f16]
+  ^bb1:
+    hipsr.shape_yield () : [f16]
+  }
+  %result = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
+      outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
+  return %result : tensor<4x8xf16>
+}
+
+// -----
+
+// A populated shape region has one block argument per placeholder operand.
+func.func @shape_region_argument_count(
+    %ctx: !hipsr.context, %input: tensor<4x8xf32>) -> tensor<4x8xf16> {
+  // expected-error @+1 {{shape region block argument count must match operand count; expected 2, got 1}}
+  %init = hipsr.placeholder(
+      %ctx, %input : !hipsr.context, tensor<4x8xf32>)
+      {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
+      shape_region {
+  ^bb0(%shape_ctx: !hipsr.context):
+    hipsr.shape_yield () : [f16]
+  }
+  %result = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
+      outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
+  return %result : tensor<4x8xf16>
+}
+
+// -----
+
+// Placeholder shape regions terminate with hipsr.shape_yield.
+func.func @wrong_shape_region_terminator(
+    %ctx: !hipsr.context, %input: tensor<4x8xf32>) -> tensor<4x8xf16> {
+  // expected-error @+1 {{shape region must terminate with hipsr.shape_yield}}
+  %init = hipsr.placeholder(
+      %ctx, %input : !hipsr.context, tensor<4x8xf32>)
+      {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
+      shape_region {
+  ^bb0(%shape_ctx: !hipsr.context, %shape_input: tensor<4x8xf32>):
+    cf.br ^bb0(%shape_ctx, %shape_input
+        : !hipsr.context, tensor<4x8xf32>)
+  }
+  %result = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
+      outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
+  return %result : tensor<4x8xf16>
 }

--- a/test/lit/Dialect/Hipsr/placeholder-invalid.mlir
+++ b/test/lit/Dialect/Hipsr/placeholder-invalid.mlir
@@ -184,6 +184,28 @@ func.func @nonleading_context(
 
 // -----
 
+// Placeholder shape regions cannot capture values from their parent scope.
+func.func @shape_region_capture(
+    %ctx: !hipsr.context, %input: tensor<?x8xf32>) -> tensor<?x8xf16> {
+  // expected-note @+1 {{required by region isolation constraints}}
+  %init = hipsr.placeholder(%ctx)
+      ins(%input : tensor<?x8xf32>)
+      {type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16>
+      shape_region {
+  ^bb0(%shape_ctx: !hipsr.context, %shape_input: tensor<?x8xf32>):
+    %c0 = arith.constant 0 : index
+    // expected-error @+1 {{using value defined outside the region}}
+    %d0 = tensor.dim %input, %c0 : tensor<?x8xf32>
+    %c8 = arith.constant 8 : index
+    hipsr.shape_yield (%d0, %c8) : [f16]
+  }
+  %result = hipsr.cast(%ctx) ins(%input : tensor<?x8xf32>)
+      outs(%init : tensor<?x8xf16>) : tensor<?x8xf16>
+  return %result : tensor<?x8xf16>
+}
+
+// -----
+
 // A placeholder shape region may have at most one block.
 func.func @two_shape_region_blocks(
     %ctx: !hipsr.context, %input: tensor<4x8xf32>) -> tensor<4x8xf16> {
@@ -196,6 +218,23 @@ func.func @two_shape_region_blocks(
   ^bb1:
     hipsr.shape_yield () : [f16]
   }
+  %result = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
+      outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
+  return %result : tensor<4x8xf16>
+}
+
+// -----
+
+// A placeholder shape region must end with hipsr.shape_yield.
+func.func @wrong_shape_region_terminator(
+    %ctx: !hipsr.context, %input: tensor<4x8xf32>) -> tensor<4x8xf16> {
+  // expected-error @+2 {{expects regions to end with 'hipsr.shape_yield'}}
+  // expected-note @+1 {{in custom textual format, the absence of terminator implies 'hipsr.shape_yield'}}
+  %init = "hipsr.placeholder"(%ctx, %input) ({
+  ^bb0(%shape_ctx: !hipsr.context, %shape_input: tensor<4x8xf32>):
+    llvm.unreachable
+  }) {type = #hipsr.placeholder_type<normal>}
+      : (!hipsr.context, tensor<4x8xf32>) -> tensor<4x8xf16>
   %result = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
       outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
   return %result : tensor<4x8xf16>

--- a/test/lit/Dialect/Hipsr/placeholder-invalid.mlir
+++ b/test/lit/Dialect/Hipsr/placeholder-invalid.mlir
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
 
-// RUN: hip-mlir-opt --split-input-file --verify-diagnostics %s
+// RUN: hip-mlir-opt --split-input-file --verify-diagnostics -allow-unregistered-dialect %s
 
 // Results must be ranked tensors.
 func.func @unranked_rejected(
@@ -178,6 +178,41 @@ func.func @nonleading_context(
       {type = #hipsr.placeholder_type<normal>}
       : (tensor<4x8xf32>, !hipsr.context) -> tensor<4x8xf16>
   %result = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
+      outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
+  return %result : tensor<4x8xf16>
+}
+
+// -----
+
+// Shape dependencies use the producer's placeholder, not its data result.
+func.func @data_result_shape_input(
+    %ctx: !hipsr.context, %input: tensor<4x8xf32>) -> tensor<4x8xf32> {
+  %first_init = hipsr.placeholder(%ctx)
+      ins(%input : tensor<4x8xf32>)
+      {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
+  %first = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
+      outs(%first_init : tensor<4x8xf16>) : tensor<4x8xf16>
+  // expected-error @+1 {{input 0 must be a block argument or a result of hipsr.placeholder, arith.constant, or hipsr.constant; got result of 'hipsr.cast'}}
+  %second_init = hipsr.placeholder(%ctx)
+      ins(%first : tensor<4x8xf16>)
+      {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf32>
+  %second = hipsr.cast(%ctx) ins(%first : tensor<4x8xf16>)
+      outs(%second_init : tensor<4x8xf32>) : tensor<4x8xf32>
+  return %second : tensor<4x8xf32>
+}
+
+// -----
+
+// A value from an unconverted operation cannot root the shape graph.
+func.func @unconverted_shape_input(
+    %ctx: !hipsr.context, %input: tensor<4x8xf32>) -> tensor<4x8xf16> {
+  %unconverted = "onnx.Unsupported"(%input)
+      : (tensor<4x8xf32>) -> tensor<4x8xf32>
+  // expected-error @+1 {{input 0 must be a block argument or a result of hipsr.placeholder, arith.constant, or hipsr.constant; got result of 'onnx.Unsupported'}}
+  %init = hipsr.placeholder(%ctx)
+      ins(%unconverted : tensor<4x8xf32>)
+      {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
+  %result = hipsr.cast(%ctx) ins(%unconverted : tensor<4x8xf32>)
       outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
   return %result : tensor<4x8xf16>
 }

--- a/test/lit/Dialect/Hipsr/placeholder.mlir
+++ b/test/lit/Dialect/Hipsr/placeholder.mlir
@@ -12,7 +12,7 @@
 // CHECK-SAME: %[[STATIC_INPUT:.*]]: tensor<4x8xf32>,
 // CHECK-SAME: %[[SCALAR_INPUT:.*]]: tensor<f32>)
 // CHECK-SAME: -> (tensor<?x?xf16>, tensor<4x8xi64>, tensor<f16>) {
-// CHECK-NEXT: %[[DYNAMIC_INIT:.*]] = hipsr.placeholder(%[[CTX]], %[[DYNAMIC_INPUT]] : !hipsr.context, tensor<?x?xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<?x?xf16> shape_region {
+// CHECK-NEXT: %[[DYNAMIC_INIT:.*]] = hipsr.placeholder(%[[CTX]], %[[DYNAMIC_INPUT]] : tensor<?x?xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<?x?xf16> shape_region {
 // CHECK-NEXT: ^bb0(%{{.*}}: !hipsr.context, %[[SHAPE_INPUT:.*]]: tensor<?x?xf32>):
 // CHECK-NEXT: %[[C0:.*]] = arith.constant 0 : index
 // CHECK-NEXT: %[[D0:.*]] = tensor.dim %[[SHAPE_INPUT]], %[[C0]] : tensor<?x?xf32>
@@ -20,9 +20,9 @@
 // CHECK-NEXT: hipsr.shape_yield (%[[D0]], %[[C8]]) : [f16]
 // CHECK-NEXT: }
 // CHECK-NEXT: %[[DYNAMIC_RESULT:.*]] = hipsr.cast(%[[CTX]]) ins(%[[DYNAMIC_INPUT]] : tensor<?x?xf32>) outs(%[[DYNAMIC_INIT]] : tensor<?x?xf16>) : tensor<?x?xf16>
-// CHECK-NEXT: %[[STATIC_INIT:.*]] = hipsr.placeholder(%[[CTX]], %[[STATIC_INPUT]] : !hipsr.context, tensor<4x8xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<4x8xi64>
+// CHECK-NEXT: %[[STATIC_INIT:.*]] = hipsr.placeholder(%[[CTX]], %[[STATIC_INPUT]] : tensor<4x8xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<4x8xi64>
 // CHECK-NEXT: %[[STATIC_RESULT:.*]] = hipsr.cast(%[[CTX]]) ins(%[[STATIC_INPUT]] : tensor<4x8xf32>) outs(%[[STATIC_INIT]] : tensor<4x8xi64>) : tensor<4x8xi64>
-// CHECK-NEXT: %[[SCALAR_INIT:.*]] = hipsr.placeholder(%[[CTX]], %[[SCALAR_INPUT]] : !hipsr.context, tensor<f32>) {type = #hipsr.placeholder_type<normal>} : tensor<f16>
+// CHECK-NEXT: %[[SCALAR_INIT:.*]] = hipsr.placeholder(%[[CTX]], %[[SCALAR_INPUT]] : tensor<f32>) {type = #hipsr.placeholder_type<normal>} : tensor<f16>
 // CHECK-NEXT: %[[SCALAR_RESULT:.*]] = hipsr.cast(%[[CTX]]) ins(%[[SCALAR_INPUT]] : tensor<f32>) outs(%[[SCALAR_INIT]] : tensor<f16>) : tensor<f16>
 // CHECK-NEXT: return %[[DYNAMIC_RESULT]], %[[STATIC_RESULT]], %[[SCALAR_RESULT]] : tensor<?x?xf16>, tensor<4x8xi64>, tensor<f16>
 // CHECK-NEXT: }
@@ -31,7 +31,7 @@ func.func @tensor_forms(
     %static_input: tensor<4x8xf32>, %scalar_input: tensor<f32>)
     -> (tensor<?x?xf16>, tensor<4x8xi64>, tensor<f16>) {
   %dynamic_init = hipsr.placeholder(
-      %ctx, %dynamic_input : !hipsr.context, tensor<?x?xf32>)
+      %ctx, %dynamic_input : tensor<?x?xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<?x?xf16>
       shape_region {
   ^bb0(%shape_ctx: !hipsr.context, %shape_input: tensor<?x?xf32>):
@@ -43,12 +43,12 @@ func.func @tensor_forms(
   %dynamic_result = hipsr.cast(%ctx) ins(%dynamic_input : tensor<?x?xf32>)
       outs(%dynamic_init : tensor<?x?xf16>) : tensor<?x?xf16>
   %static_init = hipsr.placeholder(
-      %ctx, %static_input : !hipsr.context, tensor<4x8xf32>)
+      %ctx, %static_input : tensor<4x8xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<4x8xi64>
   %static_result = hipsr.cast(%ctx) ins(%static_input : tensor<4x8xf32>)
       outs(%static_init : tensor<4x8xi64>) : tensor<4x8xi64>
   %scalar_init = hipsr.placeholder(
-      %ctx, %scalar_input : !hipsr.context, tensor<f32>)
+      %ctx, %scalar_input : tensor<f32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<f16>
   %scalar_result = hipsr.cast(%ctx) ins(%scalar_input : tensor<f32>)
       outs(%scalar_init : tensor<f16>) : tensor<f16>
@@ -62,8 +62,8 @@ func.func @tensor_forms(
 // CSE-LABEL: func.func @cse_keeps_placeholders(
 // CSE-SAME: %[[CTX:.*]]: !hipsr.context, %[[INPUT:.*]]: tensor<4x8xf32>)
 // CSE-SAME: -> (tensor<4x8xf16>, tensor<4x8xf16>) {
-// CSE-NEXT: %[[LHS_INIT:.*]] = hipsr.placeholder(%[[CTX]], %[[INPUT]] : !hipsr.context, tensor<4x8xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
-// CSE-NEXT: %[[RHS_INIT:.*]] = hipsr.placeholder(%[[CTX]], %[[INPUT]] : !hipsr.context, tensor<4x8xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
+// CSE-NEXT: %[[LHS_INIT:.*]] = hipsr.placeholder(%[[CTX]], %[[INPUT]] : tensor<4x8xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
+// CSE-NEXT: %[[RHS_INIT:.*]] = hipsr.placeholder(%[[CTX]], %[[INPUT]] : tensor<4x8xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
 // CSE-NEXT: %[[LHS_RESULT:.*]] = hipsr.cast(%[[CTX]]) ins(%[[INPUT]] : tensor<4x8xf32>) outs(%[[LHS_INIT]] : tensor<4x8xf16>) : tensor<4x8xf16>
 // CSE-NEXT: %[[RHS_RESULT:.*]] = hipsr.cast(%[[CTX]]) ins(%[[INPUT]] : tensor<4x8xf32>) outs(%[[RHS_INIT]] : tensor<4x8xf16>) : tensor<4x8xf16>
 // CSE-NEXT: return %[[LHS_RESULT]], %[[RHS_RESULT]] : tensor<4x8xf16>, tensor<4x8xf16>
@@ -72,10 +72,10 @@ func.func @cse_keeps_placeholders(
     %ctx: !hipsr.context, %input: tensor<4x8xf32>)
     -> (tensor<4x8xf16>, tensor<4x8xf16>) {
   %lhs_init = hipsr.placeholder(
-      %ctx, %input : !hipsr.context, tensor<4x8xf32>)
+      %ctx, %input : tensor<4x8xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
   %rhs_init = hipsr.placeholder(
-      %ctx, %input : !hipsr.context, tensor<4x8xf32>)
+      %ctx, %input : tensor<4x8xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
   %lhs_result = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
       outs(%lhs_init : tensor<4x8xf16>) : tensor<4x8xf16>

--- a/test/lit/Dialect/Hipsr/placeholder.mlir
+++ b/test/lit/Dialect/Hipsr/placeholder.mlir
@@ -5,13 +5,14 @@
 // RUN: hip-mlir-opt --split-input-file -cse %s | FileCheck %s --check-prefix=CSE
 
 // Placeholders preserve dynamic, static, and rank-0 result types. The dynamic
-// case carries one shape-region block; the others have zero blocks.
+// case carries one shape-region block and feeds a second placeholder; the
+// others have zero blocks.
 // CHECK-LABEL: func.func @tensor_forms(
 // CHECK-SAME: %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME: %[[DYNAMIC_INPUT:.*]]: tensor<?x?xf32>,
 // CHECK-SAME: %[[STATIC_INPUT:.*]]: tensor<4x8xf32>,
 // CHECK-SAME: %[[SCALAR_INPUT:.*]]: tensor<f32>)
-// CHECK-SAME: -> (tensor<?x?xf16>, tensor<4x8xi64>, tensor<f16>) {
+// CHECK-SAME: -> (tensor<?x?xf16>, tensor<?x?xf32>, tensor<4x8xi64>, tensor<f16>) {
 // CHECK-NEXT: %[[DYNAMIC_INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[DYNAMIC_INPUT]] : tensor<?x?xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<?x?xf16> shape_region {
 // CHECK-NEXT: ^bb0(%{{.*}}: !hipsr.context, %[[SHAPE_INPUT:.*]]: tensor<?x?xf32>):
 // CHECK-NEXT: %[[C0:.*]] = arith.constant 0 : index
@@ -20,16 +21,18 @@
 // CHECK-NEXT: hipsr.shape_yield (%[[D0]], %[[C8]]) : [f16]
 // CHECK-NEXT: }
 // CHECK-NEXT: %[[DYNAMIC_RESULT:.*]] = hipsr.cast(%[[CTX]]) ins(%[[DYNAMIC_INPUT]] : tensor<?x?xf32>) outs(%[[DYNAMIC_INIT]] : tensor<?x?xf16>) : tensor<?x?xf16>
+// CHECK-NEXT: %[[CHAINED_INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[DYNAMIC_INIT]] : tensor<?x?xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?x?xf32>
+// CHECK-NEXT: %[[CHAINED_RESULT:.*]] = hipsr.cast(%[[CTX]]) ins(%[[DYNAMIC_RESULT]] : tensor<?x?xf16>) outs(%[[CHAINED_INIT]] : tensor<?x?xf32>) : tensor<?x?xf32>
 // CHECK-NEXT: %[[STATIC_INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[STATIC_INPUT]] : tensor<4x8xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<4x8xi64>
 // CHECK-NEXT: %[[STATIC_RESULT:.*]] = hipsr.cast(%[[CTX]]) ins(%[[STATIC_INPUT]] : tensor<4x8xf32>) outs(%[[STATIC_INIT]] : tensor<4x8xi64>) : tensor<4x8xi64>
 // CHECK-NEXT: %[[SCALAR_INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[SCALAR_INPUT]] : tensor<f32>) {type = #hipsr.placeholder_type<normal>} : tensor<f16>
 // CHECK-NEXT: %[[SCALAR_RESULT:.*]] = hipsr.cast(%[[CTX]]) ins(%[[SCALAR_INPUT]] : tensor<f32>) outs(%[[SCALAR_INIT]] : tensor<f16>) : tensor<f16>
-// CHECK-NEXT: return %[[DYNAMIC_RESULT]], %[[STATIC_RESULT]], %[[SCALAR_RESULT]] : tensor<?x?xf16>, tensor<4x8xi64>, tensor<f16>
+// CHECK-NEXT: return %[[DYNAMIC_RESULT]], %[[CHAINED_RESULT]], %[[STATIC_RESULT]], %[[SCALAR_RESULT]] : tensor<?x?xf16>, tensor<?x?xf32>, tensor<4x8xi64>, tensor<f16>
 // CHECK-NEXT: }
 func.func @tensor_forms(
     %ctx: !hipsr.context, %dynamic_input: tensor<?x?xf32>,
     %static_input: tensor<4x8xf32>, %scalar_input: tensor<f32>)
-    -> (tensor<?x?xf16>, tensor<4x8xi64>, tensor<f16>) {
+    -> (tensor<?x?xf16>, tensor<?x?xf32>, tensor<4x8xi64>, tensor<f16>) {
   %dynamic_init = hipsr.placeholder(%ctx)
       ins(%dynamic_input : tensor<?x?xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<?x?xf16>
@@ -42,6 +45,12 @@ func.func @tensor_forms(
   }
   %dynamic_result = hipsr.cast(%ctx) ins(%dynamic_input : tensor<?x?xf32>)
       outs(%dynamic_init : tensor<?x?xf16>) : tensor<?x?xf16>
+  %chained_init = hipsr.placeholder(%ctx)
+      ins(%dynamic_init : tensor<?x?xf16>)
+      {type = #hipsr.placeholder_type<normal>} : tensor<?x?xf32>
+  %chained_result = hipsr.cast(%ctx)
+      ins(%dynamic_result : tensor<?x?xf16>)
+      outs(%chained_init : tensor<?x?xf32>) : tensor<?x?xf32>
   %static_init = hipsr.placeholder(%ctx)
       ins(%static_input : tensor<4x8xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<4x8xi64>
@@ -52,8 +61,8 @@ func.func @tensor_forms(
       {type = #hipsr.placeholder_type<normal>} : tensor<f16>
   %scalar_result = hipsr.cast(%ctx) ins(%scalar_input : tensor<f32>)
       outs(%scalar_init : tensor<f16>) : tensor<f16>
-  return %dynamic_result, %static_result, %scalar_result
-      : tensor<?x?xf16>, tensor<4x8xi64>, tensor<f16>
+  return %dynamic_result, %chained_result, %static_result, %scalar_result
+      : tensor<?x?xf16>, tensor<?x?xf32>, tensor<4x8xi64>, tensor<f16>
 }
 
 // -----

--- a/test/lit/Dialect/Hipsr/placeholder.mlir
+++ b/test/lit/Dialect/Hipsr/placeholder.mlir
@@ -5,8 +5,8 @@
 // RUN: hip-mlir-opt --split-input-file -cse %s | FileCheck %s --check-prefix=CSE
 
 // Placeholders preserve dynamic, static, and rank-0 result types. The dynamic
-// case carries one shape-region block. Its placeholder and data result both
-// feed a second placeholder; the others have zero blocks.
+// case carries one shape-region block and feeds a second placeholder; the
+// others have zero blocks.
 // CHECK-LABEL: func.func @tensor_forms(
 // CHECK-SAME: %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME: %[[DYNAMIC_INPUT:.*]]: tensor<?x?xf32>,
@@ -21,7 +21,7 @@
 // CHECK-NEXT: hipsr.shape_yield (%[[D0]], %[[C8]]) : [f16]
 // CHECK-NEXT: }
 // CHECK-NEXT: %[[DYNAMIC_RESULT:.*]] = hipsr.cast(%[[CTX]]) ins(%[[DYNAMIC_INPUT]] : tensor<?x?xf32>) outs(%[[DYNAMIC_INIT]] : tensor<?x?xf16>) : tensor<?x?xf16>
-// CHECK-NEXT: %[[CHAINED_INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[DYNAMIC_INIT]], %[[DYNAMIC_RESULT]] : tensor<?x?xf16>, tensor<?x?xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?x?xf32>
+// CHECK-NEXT: %[[CHAINED_INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[DYNAMIC_INIT]] : tensor<?x?xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?x?xf32>
 // CHECK-NEXT: %[[CHAINED_RESULT:.*]] = hipsr.cast(%[[CTX]]) ins(%[[DYNAMIC_RESULT]] : tensor<?x?xf16>) outs(%[[CHAINED_INIT]] : tensor<?x?xf32>) : tensor<?x?xf32>
 // CHECK-NEXT: %[[STATIC_INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[STATIC_INPUT]] : tensor<4x8xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<4x8xi64>
 // CHECK-NEXT: %[[STATIC_RESULT:.*]] = hipsr.cast(%[[CTX]]) ins(%[[STATIC_INPUT]] : tensor<4x8xf32>) outs(%[[STATIC_INIT]] : tensor<4x8xi64>) : tensor<4x8xi64>
@@ -46,8 +46,7 @@ func.func @tensor_forms(
   %dynamic_result = hipsr.cast(%ctx) ins(%dynamic_input : tensor<?x?xf32>)
       outs(%dynamic_init : tensor<?x?xf16>) : tensor<?x?xf16>
   %chained_init = hipsr.placeholder(%ctx)
-      ins(%dynamic_init, %dynamic_result
-          : tensor<?x?xf16>, tensor<?x?xf16>)
+      ins(%dynamic_init : tensor<?x?xf16>)
       {type = #hipsr.placeholder_type<normal>} : tensor<?x?xf32>
   %chained_result = hipsr.cast(%ctx)
       ins(%dynamic_result : tensor<?x?xf16>)

--- a/test/lit/Dialect/Hipsr/placeholder.mlir
+++ b/test/lit/Dialect/Hipsr/placeholder.mlir
@@ -5,8 +5,8 @@
 // RUN: hip-mlir-opt --split-input-file -cse %s | FileCheck %s --check-prefix=CSE
 
 // Placeholders preserve dynamic, static, and rank-0 result types. The dynamic
-// case carries one shape-region block and feeds a second placeholder; the
-// others have zero blocks.
+// case carries one shape-region block. Its placeholder and data result both
+// feed a second placeholder; the others have zero blocks.
 // CHECK-LABEL: func.func @tensor_forms(
 // CHECK-SAME: %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME: %[[DYNAMIC_INPUT:.*]]: tensor<?x?xf32>,
@@ -21,7 +21,7 @@
 // CHECK-NEXT: hipsr.shape_yield (%[[D0]], %[[C8]]) : [f16]
 // CHECK-NEXT: }
 // CHECK-NEXT: %[[DYNAMIC_RESULT:.*]] = hipsr.cast(%[[CTX]]) ins(%[[DYNAMIC_INPUT]] : tensor<?x?xf32>) outs(%[[DYNAMIC_INIT]] : tensor<?x?xf16>) : tensor<?x?xf16>
-// CHECK-NEXT: %[[CHAINED_INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[DYNAMIC_INIT]] : tensor<?x?xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?x?xf32>
+// CHECK-NEXT: %[[CHAINED_INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[DYNAMIC_INIT]], %[[DYNAMIC_RESULT]] : tensor<?x?xf16>, tensor<?x?xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?x?xf32>
 // CHECK-NEXT: %[[CHAINED_RESULT:.*]] = hipsr.cast(%[[CTX]]) ins(%[[DYNAMIC_RESULT]] : tensor<?x?xf16>) outs(%[[CHAINED_INIT]] : tensor<?x?xf32>) : tensor<?x?xf32>
 // CHECK-NEXT: %[[STATIC_INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[STATIC_INPUT]] : tensor<4x8xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<4x8xi64>
 // CHECK-NEXT: %[[STATIC_RESULT:.*]] = hipsr.cast(%[[CTX]]) ins(%[[STATIC_INPUT]] : tensor<4x8xf32>) outs(%[[STATIC_INIT]] : tensor<4x8xi64>) : tensor<4x8xi64>
@@ -46,7 +46,8 @@ func.func @tensor_forms(
   %dynamic_result = hipsr.cast(%ctx) ins(%dynamic_input : tensor<?x?xf32>)
       outs(%dynamic_init : tensor<?x?xf16>) : tensor<?x?xf16>
   %chained_init = hipsr.placeholder(%ctx)
-      ins(%dynamic_init : tensor<?x?xf16>)
+      ins(%dynamic_init, %dynamic_result
+          : tensor<?x?xf16>, tensor<?x?xf16>)
       {type = #hipsr.placeholder_type<normal>} : tensor<?x?xf32>
   %chained_result = hipsr.cast(%ctx)
       ins(%dynamic_result : tensor<?x?xf16>)

--- a/test/lit/Dialect/Hipsr/placeholder.mlir
+++ b/test/lit/Dialect/Hipsr/placeholder.mlir
@@ -67,6 +67,30 @@ func.func @tensor_forms(
 
 // -----
 
+// Arith and HIPSR constants are valid shape-graph roots.
+// CHECK-LABEL: func.func @constant_shape_roots(
+// CHECK-SAME: %[[CTX:.*]]: !hipsr.context, %[[INPUT:.*]]: tensor<4x8xf32>) -> tensor<4x8xf16> {
+// CHECK-NEXT: %[[ARITH_SHAPE:.*]] = arith.constant dense<[4, 8]> : tensor<2xi64>
+// CHECK-NEXT: %[[HIPSR_SHAPE:.*]] = hipsr.constant {value = dense<[4, 8]> : tensor<2xi64>} : tensor<2xi64>
+// CHECK-NEXT: %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[ARITH_SHAPE]], %[[HIPSR_SHAPE]] : tensor<2xi64>, tensor<2xi64>) {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
+// CHECK-NEXT: %[[RESULT:.*]] = hipsr.cast(%[[CTX]]) ins(%[[INPUT]] : tensor<4x8xf32>) outs(%[[INIT]] : tensor<4x8xf16>) : tensor<4x8xf16>
+// CHECK-NEXT: return %[[RESULT]] : tensor<4x8xf16>
+// CHECK-NEXT: }
+func.func @constant_shape_roots(
+    %ctx: !hipsr.context, %input: tensor<4x8xf32>) -> tensor<4x8xf16> {
+  %arith_shape = arith.constant dense<[4, 8]> : tensor<2xi64>
+  %hipsr_shape = hipsr.constant
+      {value = dense<[4, 8]> : tensor<2xi64>} : tensor<2xi64>
+  %init = hipsr.placeholder(%ctx)
+      ins(%arith_shape, %hipsr_shape : tensor<2xi64>, tensor<2xi64>)
+      {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
+  %result = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
+      outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
+  return %result : tensor<4x8xf16>
+}
+
+// -----
+
 // CSE must not merge otherwise identical placeholders tied to different ops.
 // CSE-LABEL: func.func @cse_keeps_placeholders(
 // CSE-SAME: %[[CTX:.*]]: !hipsr.context, %[[INPUT:.*]]: tensor<4x8xf32>)

--- a/test/lit/Dialect/Hipsr/placeholder.mlir
+++ b/test/lit/Dialect/Hipsr/placeholder.mlir
@@ -12,7 +12,7 @@
 // CHECK-SAME: %[[STATIC_INPUT:.*]]: tensor<4x8xf32>,
 // CHECK-SAME: %[[SCALAR_INPUT:.*]]: tensor<f32>)
 // CHECK-SAME: -> (tensor<?x?xf16>, tensor<4x8xi64>, tensor<f16>) {
-// CHECK-NEXT: %[[DYNAMIC_INIT:.*]] = hipsr.placeholder(%[[CTX]], %[[DYNAMIC_INPUT]] : tensor<?x?xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<?x?xf16> shape_region {
+// CHECK-NEXT: %[[DYNAMIC_INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[DYNAMIC_INPUT]] : tensor<?x?xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<?x?xf16> shape_region {
 // CHECK-NEXT: ^bb0(%{{.*}}: !hipsr.context, %[[SHAPE_INPUT:.*]]: tensor<?x?xf32>):
 // CHECK-NEXT: %[[C0:.*]] = arith.constant 0 : index
 // CHECK-NEXT: %[[D0:.*]] = tensor.dim %[[SHAPE_INPUT]], %[[C0]] : tensor<?x?xf32>
@@ -20,9 +20,9 @@
 // CHECK-NEXT: hipsr.shape_yield (%[[D0]], %[[C8]]) : [f16]
 // CHECK-NEXT: }
 // CHECK-NEXT: %[[DYNAMIC_RESULT:.*]] = hipsr.cast(%[[CTX]]) ins(%[[DYNAMIC_INPUT]] : tensor<?x?xf32>) outs(%[[DYNAMIC_INIT]] : tensor<?x?xf16>) : tensor<?x?xf16>
-// CHECK-NEXT: %[[STATIC_INIT:.*]] = hipsr.placeholder(%[[CTX]], %[[STATIC_INPUT]] : tensor<4x8xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<4x8xi64>
+// CHECK-NEXT: %[[STATIC_INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[STATIC_INPUT]] : tensor<4x8xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<4x8xi64>
 // CHECK-NEXT: %[[STATIC_RESULT:.*]] = hipsr.cast(%[[CTX]]) ins(%[[STATIC_INPUT]] : tensor<4x8xf32>) outs(%[[STATIC_INIT]] : tensor<4x8xi64>) : tensor<4x8xi64>
-// CHECK-NEXT: %[[SCALAR_INIT:.*]] = hipsr.placeholder(%[[CTX]], %[[SCALAR_INPUT]] : tensor<f32>) {type = #hipsr.placeholder_type<normal>} : tensor<f16>
+// CHECK-NEXT: %[[SCALAR_INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[SCALAR_INPUT]] : tensor<f32>) {type = #hipsr.placeholder_type<normal>} : tensor<f16>
 // CHECK-NEXT: %[[SCALAR_RESULT:.*]] = hipsr.cast(%[[CTX]]) ins(%[[SCALAR_INPUT]] : tensor<f32>) outs(%[[SCALAR_INIT]] : tensor<f16>) : tensor<f16>
 // CHECK-NEXT: return %[[DYNAMIC_RESULT]], %[[STATIC_RESULT]], %[[SCALAR_RESULT]] : tensor<?x?xf16>, tensor<4x8xi64>, tensor<f16>
 // CHECK-NEXT: }
@@ -30,8 +30,8 @@ func.func @tensor_forms(
     %ctx: !hipsr.context, %dynamic_input: tensor<?x?xf32>,
     %static_input: tensor<4x8xf32>, %scalar_input: tensor<f32>)
     -> (tensor<?x?xf16>, tensor<4x8xi64>, tensor<f16>) {
-  %dynamic_init = hipsr.placeholder(
-      %ctx, %dynamic_input : tensor<?x?xf32>)
+  %dynamic_init = hipsr.placeholder(%ctx)
+      ins(%dynamic_input : tensor<?x?xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<?x?xf16>
       shape_region {
   ^bb0(%shape_ctx: !hipsr.context, %shape_input: tensor<?x?xf32>):
@@ -42,13 +42,13 @@ func.func @tensor_forms(
   }
   %dynamic_result = hipsr.cast(%ctx) ins(%dynamic_input : tensor<?x?xf32>)
       outs(%dynamic_init : tensor<?x?xf16>) : tensor<?x?xf16>
-  %static_init = hipsr.placeholder(
-      %ctx, %static_input : tensor<4x8xf32>)
+  %static_init = hipsr.placeholder(%ctx)
+      ins(%static_input : tensor<4x8xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<4x8xi64>
   %static_result = hipsr.cast(%ctx) ins(%static_input : tensor<4x8xf32>)
       outs(%static_init : tensor<4x8xi64>) : tensor<4x8xi64>
-  %scalar_init = hipsr.placeholder(
-      %ctx, %scalar_input : tensor<f32>)
+  %scalar_init = hipsr.placeholder(%ctx)
+      ins(%scalar_input : tensor<f32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<f16>
   %scalar_result = hipsr.cast(%ctx) ins(%scalar_input : tensor<f32>)
       outs(%scalar_init : tensor<f16>) : tensor<f16>
@@ -62,8 +62,8 @@ func.func @tensor_forms(
 // CSE-LABEL: func.func @cse_keeps_placeholders(
 // CSE-SAME: %[[CTX:.*]]: !hipsr.context, %[[INPUT:.*]]: tensor<4x8xf32>)
 // CSE-SAME: -> (tensor<4x8xf16>, tensor<4x8xf16>) {
-// CSE-NEXT: %[[LHS_INIT:.*]] = hipsr.placeholder(%[[CTX]], %[[INPUT]] : tensor<4x8xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
-// CSE-NEXT: %[[RHS_INIT:.*]] = hipsr.placeholder(%[[CTX]], %[[INPUT]] : tensor<4x8xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
+// CSE-NEXT: %[[LHS_INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<4x8xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
+// CSE-NEXT: %[[RHS_INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<4x8xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
 // CSE-NEXT: %[[LHS_RESULT:.*]] = hipsr.cast(%[[CTX]]) ins(%[[INPUT]] : tensor<4x8xf32>) outs(%[[LHS_INIT]] : tensor<4x8xf16>) : tensor<4x8xf16>
 // CSE-NEXT: %[[RHS_RESULT:.*]] = hipsr.cast(%[[CTX]]) ins(%[[INPUT]] : tensor<4x8xf32>) outs(%[[RHS_INIT]] : tensor<4x8xf16>) : tensor<4x8xf16>
 // CSE-NEXT: return %[[LHS_RESULT]], %[[RHS_RESULT]] : tensor<4x8xf16>, tensor<4x8xf16>
@@ -71,11 +71,11 @@ func.func @tensor_forms(
 func.func @cse_keeps_placeholders(
     %ctx: !hipsr.context, %input: tensor<4x8xf32>)
     -> (tensor<4x8xf16>, tensor<4x8xf16>) {
-  %lhs_init = hipsr.placeholder(
-      %ctx, %input : tensor<4x8xf32>)
+  %lhs_init = hipsr.placeholder(%ctx)
+      ins(%input : tensor<4x8xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
-  %rhs_init = hipsr.placeholder(
-      %ctx, %input : tensor<4x8xf32>)
+  %rhs_init = hipsr.placeholder(%ctx)
+      ins(%input : tensor<4x8xf32>)
       {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
   %lhs_result = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
       outs(%lhs_init : tensor<4x8xf16>) : tensor<4x8xf16>

--- a/test/lit/Dialect/Hipsr/placeholder.mlir
+++ b/test/lit/Dialect/Hipsr/placeholder.mlir
@@ -4,18 +4,25 @@
 // RUN: hip-mlir-opt --split-input-file %s | FileCheck %s
 // RUN: hip-mlir-opt --split-input-file -cse %s | FileCheck %s --check-prefix=CSE
 
-// Dynamic, static, and rank-0 results parse and print together.
+// Placeholders preserve dynamic, static, and rank-0 result types. The dynamic
+// case carries one shape-region block; the others have zero blocks.
 // CHECK-LABEL: func.func @tensor_forms(
 // CHECK-SAME: %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME: %[[DYNAMIC_INPUT:.*]]: tensor<?x?xf32>,
 // CHECK-SAME: %[[STATIC_INPUT:.*]]: tensor<4x8xf32>,
 // CHECK-SAME: %[[SCALAR_INPUT:.*]]: tensor<f32>)
 // CHECK-SAME: -> (tensor<?x?xf16>, tensor<4x8xi64>, tensor<f16>) {
-// CHECK-NEXT: %[[DYNAMIC_INIT:.*]] = hipsr.placeholder : tensor<?x?xf16>
+// CHECK-NEXT: %[[DYNAMIC_INIT:.*]] = hipsr.placeholder(%[[CTX]], %[[DYNAMIC_INPUT]] : !hipsr.context, tensor<?x?xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<?x?xf16> shape_region {
+// CHECK-NEXT: ^bb0(%{{.*}}: !hipsr.context, %[[SHAPE_INPUT:.*]]: tensor<?x?xf32>):
+// CHECK-NEXT: %[[C0:.*]] = arith.constant 0 : index
+// CHECK-NEXT: %[[D0:.*]] = tensor.dim %[[SHAPE_INPUT]], %[[C0]] : tensor<?x?xf32>
+// CHECK-NEXT: %[[C8:.*]] = arith.constant 8 : index
+// CHECK-NEXT: hipsr.shape_yield (%[[D0]], %[[C8]]) : [f16]
+// CHECK-NEXT: }
 // CHECK-NEXT: %[[DYNAMIC_RESULT:.*]] = hipsr.cast(%[[CTX]]) ins(%[[DYNAMIC_INPUT]] : tensor<?x?xf32>) outs(%[[DYNAMIC_INIT]] : tensor<?x?xf16>) : tensor<?x?xf16>
-// CHECK-NEXT: %[[STATIC_INIT:.*]] = hipsr.placeholder : tensor<4x8xi64>
+// CHECK-NEXT: %[[STATIC_INIT:.*]] = hipsr.placeholder(%[[CTX]], %[[STATIC_INPUT]] : !hipsr.context, tensor<4x8xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<4x8xi64>
 // CHECK-NEXT: %[[STATIC_RESULT:.*]] = hipsr.cast(%[[CTX]]) ins(%[[STATIC_INPUT]] : tensor<4x8xf32>) outs(%[[STATIC_INIT]] : tensor<4x8xi64>) : tensor<4x8xi64>
-// CHECK-NEXT: %[[SCALAR_INIT:.*]] = hipsr.placeholder : tensor<f16>
+// CHECK-NEXT: %[[SCALAR_INIT:.*]] = hipsr.placeholder(%[[CTX]], %[[SCALAR_INPUT]] : !hipsr.context, tensor<f32>) {type = #hipsr.placeholder_type<normal>} : tensor<f16>
 // CHECK-NEXT: %[[SCALAR_RESULT:.*]] = hipsr.cast(%[[CTX]]) ins(%[[SCALAR_INPUT]] : tensor<f32>) outs(%[[SCALAR_INIT]] : tensor<f16>) : tensor<f16>
 // CHECK-NEXT: return %[[DYNAMIC_RESULT]], %[[STATIC_RESULT]], %[[SCALAR_RESULT]] : tensor<?x?xf16>, tensor<4x8xi64>, tensor<f16>
 // CHECK-NEXT: }
@@ -23,13 +30,26 @@ func.func @tensor_forms(
     %ctx: !hipsr.context, %dynamic_input: tensor<?x?xf32>,
     %static_input: tensor<4x8xf32>, %scalar_input: tensor<f32>)
     -> (tensor<?x?xf16>, tensor<4x8xi64>, tensor<f16>) {
-  %dynamic_init = hipsr.placeholder : tensor<?x?xf16>
+  %dynamic_init = hipsr.placeholder(
+      %ctx, %dynamic_input : !hipsr.context, tensor<?x?xf32>)
+      {type = #hipsr.placeholder_type<normal>} : tensor<?x?xf16>
+      shape_region {
+  ^bb0(%shape_ctx: !hipsr.context, %shape_input: tensor<?x?xf32>):
+    %c0 = arith.constant 0 : index
+    %d0 = tensor.dim %shape_input, %c0 : tensor<?x?xf32>
+    %c8 = arith.constant 8 : index
+    hipsr.shape_yield (%d0, %c8) : [f16]
+  }
   %dynamic_result = hipsr.cast(%ctx) ins(%dynamic_input : tensor<?x?xf32>)
       outs(%dynamic_init : tensor<?x?xf16>) : tensor<?x?xf16>
-  %static_init = hipsr.placeholder : tensor<4x8xi64>
+  %static_init = hipsr.placeholder(
+      %ctx, %static_input : !hipsr.context, tensor<4x8xf32>)
+      {type = #hipsr.placeholder_type<normal>} : tensor<4x8xi64>
   %static_result = hipsr.cast(%ctx) ins(%static_input : tensor<4x8xf32>)
       outs(%static_init : tensor<4x8xi64>) : tensor<4x8xi64>
-  %scalar_init = hipsr.placeholder : tensor<f16>
+  %scalar_init = hipsr.placeholder(
+      %ctx, %scalar_input : !hipsr.context, tensor<f32>)
+      {type = #hipsr.placeholder_type<normal>} : tensor<f16>
   %scalar_result = hipsr.cast(%ctx) ins(%scalar_input : tensor<f32>)
       outs(%scalar_init : tensor<f16>) : tensor<f16>
   return %dynamic_result, %static_result, %scalar_result
@@ -37,25 +57,29 @@ func.func @tensor_forms(
 }
 
 // -----
-// CSE must not merge placeholders used by different DPS ops.
+
+// CSE must not merge otherwise identical placeholders tied to different ops.
 // CSE-LABEL: func.func @cse_keeps_placeholders(
-// CSE-SAME: %[[CTX:.*]]: !hipsr.context, %[[LHS:.*]]: tensor<4x8xf32>,
-// CSE-SAME: %[[RHS:.*]]: tensor<4x8xf32>)
+// CSE-SAME: %[[CTX:.*]]: !hipsr.context, %[[INPUT:.*]]: tensor<4x8xf32>)
 // CSE-SAME: -> (tensor<4x8xf16>, tensor<4x8xf16>) {
-// CSE-NEXT: %[[LHS_INIT:.*]] = hipsr.placeholder : tensor<4x8xf16>
-// CSE-NEXT: %[[RHS_INIT:.*]] = hipsr.placeholder : tensor<4x8xf16>
-// CSE-NEXT: %[[LHS_RESULT:.*]] = hipsr.cast(%[[CTX]]) ins(%[[LHS]] : tensor<4x8xf32>) outs(%[[LHS_INIT]] : tensor<4x8xf16>) : tensor<4x8xf16>
-// CSE-NEXT: %[[RHS_RESULT:.*]] = hipsr.cast(%[[CTX]]) ins(%[[RHS]] : tensor<4x8xf32>) outs(%[[RHS_INIT]] : tensor<4x8xf16>) : tensor<4x8xf16>
+// CSE-NEXT: %[[LHS_INIT:.*]] = hipsr.placeholder(%[[CTX]], %[[INPUT]] : !hipsr.context, tensor<4x8xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
+// CSE-NEXT: %[[RHS_INIT:.*]] = hipsr.placeholder(%[[CTX]], %[[INPUT]] : !hipsr.context, tensor<4x8xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
+// CSE-NEXT: %[[LHS_RESULT:.*]] = hipsr.cast(%[[CTX]]) ins(%[[INPUT]] : tensor<4x8xf32>) outs(%[[LHS_INIT]] : tensor<4x8xf16>) : tensor<4x8xf16>
+// CSE-NEXT: %[[RHS_RESULT:.*]] = hipsr.cast(%[[CTX]]) ins(%[[INPUT]] : tensor<4x8xf32>) outs(%[[RHS_INIT]] : tensor<4x8xf16>) : tensor<4x8xf16>
 // CSE-NEXT: return %[[LHS_RESULT]], %[[RHS_RESULT]] : tensor<4x8xf16>, tensor<4x8xf16>
 // CSE-NEXT: }
 func.func @cse_keeps_placeholders(
-    %ctx: !hipsr.context, %lhs: tensor<4x8xf32>, %rhs: tensor<4x8xf32>)
+    %ctx: !hipsr.context, %input: tensor<4x8xf32>)
     -> (tensor<4x8xf16>, tensor<4x8xf16>) {
-  %lhs_init = hipsr.placeholder : tensor<4x8xf16>
-  %rhs_init = hipsr.placeholder : tensor<4x8xf16>
-  %lhs_result = hipsr.cast(%ctx) ins(%lhs : tensor<4x8xf32>)
+  %lhs_init = hipsr.placeholder(
+      %ctx, %input : !hipsr.context, tensor<4x8xf32>)
+      {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
+  %rhs_init = hipsr.placeholder(
+      %ctx, %input : !hipsr.context, tensor<4x8xf32>)
+      {type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16>
+  %lhs_result = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
       outs(%lhs_init : tensor<4x8xf16>) : tensor<4x8xf16>
-  %rhs_result = hipsr.cast(%ctx) ins(%rhs : tensor<4x8xf32>)
+  %rhs_result = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
       outs(%rhs_init : tensor<4x8xf16>) : tensor<4x8xf16>
   return %lhs_result, %rhs_result : tensor<4x8xf16>, tensor<4x8xf16>
 }


### PR DESCRIPTION
## Summary
- Add typed shape dependencies, `normal`/`barrier` classification, and optional shape regions to `hipsr.placeholder`.
- Finalize a parallel placeholder shape graph after ONNX conversion, independent of rewrite order.
- Enforce placeholder dependency rules and update focused conversion, verifier, and pool-domain tests.

AI assistance: Cursor with GPT-5.6 Sol assisted with implementation and test refinement; the resulting changes were reviewed and validated.