### PR TITLE
perf(gqa): enable the no-expand prefill pipeline by default

### DIFF
--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -693,21 +693,24 @@ static bool gqa_no_expand_enabled() {
   return enabled;
 }
 
-// Env-var gate for enabling the no-expand path on prefill (sq > 1). Default
-// off: today only decode (sq == 1) takes the no-expand fast path, matching the
-// verified pre-step-2 behaviour. Set HIPDNN_EP_GQA_NO_EXPAND_PREFILL=1 to opt
-// prefill into the same group-batched pipeline -- same strides as decode, but
-// with Q/O transpose kernels kept in place because BSHD and BNSD diverge at
-// sq > 1.
+// Env-var gate for enabling the no-expand path on prefill (sq > 1). Now default
+// ON, matching decode: prefill uses the same group-batched pipeline (same
+// strides as decode) with the Q/O transpose kernels kept in place because BSHD
+// and BNSD diverge at sq > 1.
 //
-// Keeping this behind a separate flag lets us A/B just the new prefill
-// behaviour without touching decode. Once verified across model families
-// (Mistral / Llama / GPT-OSS / ...), this can be folded into the main
-// HIPDNN_EP_GQA_NO_EXPAND flag.
+// Verified before flipping the default: the three prefill cases of the numeric
+// suite (test_gqa_prefill_fixed_cache_llama_shape, past_valid 0/64/128) pass
+// against the ORT CPU reference with this path active, and on gpt-oss-20b at
+// seqlen 16384 it drops the two expand_kv dispatches per layer for a 908 ms TTFT
+// win (29,177 -> 28,269 ms).
+//
+// Set HIPDNN_EP_GQA_NO_EXPAND_PREFILL=0 to fall back for A/B testing. The flag
+// stays separate from HIPDNN_EP_GQA_NO_EXPAND so prefill and decode remain
+// independently switchable.
 static bool gqa_no_expand_prefill_enabled() {
   static const bool enabled = [] {
     const char *v = std::getenv("HIPDNN_EP_GQA_NO_EXPAND_PREFILL");
-    return v && std::strcmp(v, "0") != 0;
+    return !v || std::strcmp(v, "0") != 0;
   }();
   return enabled;
 }


### PR DESCRIPTION
## Summary

Makes the no-expand prefill pipeline the default. Prefill now reads K/V straight
out of the BNSD present cache with strided-batched GEMMs, the way decode already
did, instead of materialising `B*H*total_seq*d` fp16 copies through
`expand_kv_k` / `expand_kv_v`. One line of runtime; no kernel changes.

`HIPDNN_EP_GQA_NO_EXPAND_PREFILL=0` still forces the old path for A/B work.

**This is not a TTFT win, and I want that on the record before review.** It
removes two dispatches and the expansion buffer per prefill layer, which is the
reason to take it, but on gpt-oss-20b it does not move time to first token.

## Related issue or design

None. Part of a series on the gpt-oss-20b prefill bottleneck; the companion PR
that does move the needle is the fused-prefill sink change, which is independent
of this one and does not depend on it.

## Why

The expansion is pure overhead in principle: it writes an 8x-replicated copy of
the KV cache just so a dense batched GEMM can consume it. Decode already avoids
it. The path existed behind an env var and was never made default.

The measurement is why this PR is framed as neutral rather than as a win. The
`expand_kv` work does disappear, but the strided layout makes its consumers
slower by almost exactly the amount saved:

| Kernel (attention path, chunk 16, 2-layer capture window) | Before | After | Delta |
|---|---:|---:|---:|
| `expand_kv_kernel` | 3,168 us | 0 us | **-3,168** |
| `causal_mask_kernel_impl` | 4,065 us | 6,426 us | +2,361 |
| score GEMM `Tensile_HSS_Alik_Bljk_MT32x32x64` | 21,682 us | 22,191 us | +508 |
| PV GEMM `Tensile_HHS_Ailk_Bljk_MT64x16x64` | 2,929 us | 3,155 us | +226 |
| **attention path total** | **42,175 us** | **42,142 us** | **-33 (-0.1%)** |

The causal mask regression is a layout artefact, not an inherent cost: the mask
kernel's access pattern is tuned for the expanded layout. A grouped-layout-aware
mask should turn this into a real win. Flagged as a follow-up, not attempted
here, to keep this change to one line.

## Performance

| Metric | Before | After |
|---|---:|---:|
| TTFT, gpt-oss-20b, seqlen 16384 | 32,346 ms | 32,300 ms |
| run-to-run spread (sd, n=3) | 115 ms | 76 ms |
| attention path, RGP chunk 16 | 42,175 us | 42,142 us |

Hardware and method: gfx1151, `model_benchmark -l 16384 --use_random_tokens
-g 1 -r 2 -w 1 -b 1 -ml 0`, `HIPDNN_EP_AUTOTUNE=1`, no `HIPDNN_EP_PERF` or
`HIPDNN_EP_DEBUG`. Three rounds, **interleaved**: prebuilt DLL sets for each arm
are swapped in and alternated so drift hits both arms equally.

Interleaving matters here. Absolute TTFT on this box drifted about 10% over a
long session (the same baseline measured 29,177 ms early and 32,346 ms later), so
a 46 ms effect is only meaningful against an interleaved control. A sequential
before/after comparison of these two builds initially showed a spurious -855 ms;
it did not survive interleaving.

## Test plan

- Numeric suite against the ORT CPU reference
  (`test/numeric/tests/test_gqa.py`, `--backend ort_ep --ep-name AMDGPU`): the
  three `test_gqa_prefill_fixed_cache_llama_shape` cases (past_valid 0/64/128)
  pass with this path active, and the overall pass/fail set is unchanged from
  base.
- RGP dispatch-mode capture at chunk 16 of a 16384-token prefill: both
  `expand_kv` dispatches confirmed gone from the attention path.
- Interleaved TTFT A/B as described above.

Pre-existing, not caused by this change: four
`test_gqa_decode_fixed_cache_llama_shape` cases (1/64/128/200) fail at base and
still fail here, with an identical pass/fail set. This PR touches only the
prefill default and cannot affect decode.

## Notes for reviewers

- No ordering constraint with the sink PR; the two branches are independent and
  neither contains the other's change.
- The honest case for merging is dispatch count and memory footprint. If the
  project would rather not take a neutral change, the alternative is to hold
  this until the layout-aware causal mask exists, at which point it becomes a
  win. I have no objection to that call.
- Substantial AI assistance (Cursor) was used for the investigation, the
  measurement harnesses, and this description. I reviewed the change and the
  evidence, and the numbers above are measurements I ran, not estimates.
