### PR TITLE
perf(qmoe): group prefill expert matmuls

### DIFF
--- a/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
+++ b/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
@@ -2871,6 +2871,86 @@ void MatMulNBitsWMMA_NoZP(
         group_size, num_groups_k, C, ldc, swizzle_n);
 }
 
+template <int BM_T, int BN_T, int WT_M = 2, int WT_N = 2,
+          int WAVES_EU = 8>
+__global__
+__attribute__((amdgpu_flat_work_group_size(
+    GEMM_WG_SZ(BM_T, BN_T, WT_M, WT_N),
+    GEMM_WG_SZ(BM_T, BN_T, WT_M, WT_N))))
+__attribute__((amdgpu_waves_per_eu(WAVES_EU)))
+void MatMulNBitsWMMA_Grouped_NoZP(
+    int N, int K,
+    const _Float16* __restrict__ A,
+    const unsigned char* __restrict__ B_packed,
+    const _Float16* __restrict__ scales,
+    const _Float16* __restrict__ bias,
+    _Float16* __restrict__ C,
+    const int32_t* __restrict__ expert_counts,
+    const int32_t* __restrict__ expert_offsets,
+    int num_experts, int group_size, int num_groups_k, int swizzle_n)
+{
+    const int expert = static_cast<int>(blockIdx.z);
+    if (expert >= num_experts) return;
+
+    const int M = expert_counts[expert];
+    if (M <= 0) return;
+
+    // GemmFp16U4Impl swizzles the logical (by,bx) tile coordinates. Reproduce
+    // that mapping here so rectangular max-M grouped grids can cheaply skip
+    // tiles beyond this expert's actual row count before touching weights.
+    const int n_tiles = static_cast<int>(gridDim.x);
+    const int m_tiles = static_cast<int>(gridDim.y);
+    const int block_id = static_cast<int>(blockIdx.y) * n_tiles +
+                         static_cast<int>(blockIdx.x);
+    const int sw = (n_tiles >= swizzle_n) ? swizzle_n : n_tiles;
+    const int main_cols = (n_tiles / sw) * sw;
+    const int main_blocks = main_cols * m_tiles;
+    int by, bx;
+    if (block_id < main_blocks) {
+        const int super = block_id / (sw * m_tiles);
+        const int rem = block_id % (sw * m_tiles);
+        by = rem / sw;
+        bx = super * sw + rem % sw;
+    } else {
+        const int tail_id = block_id - main_blocks;
+        const int tail_cols = n_tiles - main_cols;
+        by = tail_id / tail_cols;
+        bx = main_cols + tail_id % tail_cols;
+    }
+    if (by * BM_T >= M) return;
+
+    const int64_t row_offset = expert_offsets[expert];
+    const _Float16* A_e = A + row_offset * K;
+    _Float16* C_e = C + row_offset * N;
+    const unsigned char* B_e =
+        B_packed + static_cast<int64_t>(expert) * N * (K >> 1);
+    const _Float16* scales_e =
+        scales + static_cast<int64_t>(expert) * N * num_groups_k;
+    const _Float16* bias_e =
+        bias ? bias + static_cast<int64_t>(expert) * N : nullptr;
+
+    GemmFp16U4Impl<BM_T, BN_T, WT_M, WT_N, false, true>(
+        M, N, K, A_e, K, B_e, scales_e, nullptr, group_size, num_groups_k,
+        C_e, N, swizzle_n);
+
+    if (bias_e) {
+        __syncthreads();
+        for (int idx = threadIdx.x; idx < BM_T * BN_T; idx += blockDim.x) {
+            const int r = idx / BN_T;
+            const int c = idx % BN_T;
+            const int row = by * BM_T + r;
+            const int col = bx * BN_T + c;
+            if (row < M && col < N) {
+                C_e[static_cast<int64_t>(row) * N + col] =
+                    static_cast<_Float16>(
+                        static_cast<float>(
+                            C_e[static_cast<int64_t>(row) * N + col]) +
+                        static_cast<float>(bias_e[col]));
+            }
+        }
+    }
+}
+
 template <int BM_T = 128, int BN_T = 128, int WT_M = 2, int WT_N = 2,
           int WAVES_EU = 8, bool BC = false>
 __global__
@@ -5499,6 +5579,70 @@ extern "C" void hip_matmul_nbits_convert_zp_fp16(
                        static_cast<const unsigned char*>(zp_packed),
                        static_cast<_Float16*>(dst_fp16),
                        N, groups_k, packed_cols);
+}
+
+extern "C" int hip_matmul_nbits_grouped_nozp(
+    void* stream_v,
+    const void* A_v,
+    const void* B_v,
+    const void* scales_v,
+    const void* bias_v,
+    void* C_v,
+    const int32_t* expert_counts,
+    const int32_t* expert_offsets,
+    int64_t num_experts,
+    int64_t max_m,
+    int64_t N,
+    int64_t K,
+    int64_t block_size)
+{
+    if (!stream_v || !A_v || !B_v || !scales_v || !C_v ||
+        !expert_counts || !expert_offsets || num_experts <= 0 || max_m <= 0 ||
+        N <= 0 || K <= 0 || block_size != 32 || (K % 32) != 0) {
+        return hipErrorInvalidValue;
+    }
+
+    hipStream_t stream = static_cast<hipStream_t>(stream_v);
+    const _Float16* A = static_cast<const _Float16*>(A_v);
+    const unsigned char* B = static_cast<const unsigned char*>(B_v);
+    const _Float16* scales = static_cast<const _Float16*>(scales_v);
+    const _Float16* bias = static_cast<const _Float16*>(bias_v);
+    _Float16* C = static_cast<_Float16*>(C_v);
+    const int ngk = static_cast<int>(K / block_size);
+
+    // Qwen3.5 MoE fc1: [M,2048] x [1024,2048]^T.
+    if (N == 1024 && K == 2048) {
+        constexpr int BM = 128, BN = 64, WM = 2, WN = 2;
+        constexpr int THR = GEMM_WG_SZ(BM, BN, WM, WN);
+        dim3 grid(static_cast<unsigned>((N + BN - 1) / BN),
+                  static_cast<unsigned>((max_m + BM - 1) / BM),
+                  static_cast<unsigned>(num_experts));
+        hipLaunchKernelGGL(
+            HIP_KERNEL_NAME(
+                MatMulNBitsWMMA_Grouped_NoZP<BM, BN, WM, WN, 8>),
+            grid, dim3(THR), 0, stream, static_cast<int>(N),
+            static_cast<int>(K), A, B, scales, bias, C, expert_counts,
+            expert_offsets, static_cast<int>(num_experts),
+            static_cast<int>(block_size), ngk, 8);
+    // Qwen3.5 MoE fc2: [M,512] x [2048,512]^T.
+    } else if (N == 2048 && K == 512) {
+        constexpr int BM = 64, BN = 128, WM = 2, WN = 2;
+        constexpr int THR = GEMM_WG_SZ(BM, BN, WM, WN);
+        dim3 grid(static_cast<unsigned>((N + BN - 1) / BN),
+                  static_cast<unsigned>((max_m + BM - 1) / BM),
+                  static_cast<unsigned>(num_experts));
+        hipLaunchKernelGGL(
+            HIP_KERNEL_NAME(
+                MatMulNBitsWMMA_Grouped_NoZP<BM, BN, WM, WN, 8>),
+            grid, dim3(THR), 0, stream, static_cast<int>(N),
+            static_cast<int>(K), A, B, scales, bias, C, expert_counts,
+            expert_offsets, static_cast<int>(num_experts),
+            static_cast<int>(block_size), ngk, 8);
+    } else {
+        return hipErrorInvalidValue;
+    }
+
+    return static_cast<int>(hipGetLastError());
 }
 
 extern "C" int hip_matmul_nbits(

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -1641,6 +1641,30 @@ HIP_KERNEL_API int hip_matmul_nbits(
     const void* pre_unpacked_zp_u8,
     const void* pre_unpacked_zp_fp16);
 
+/* Grouped symmetric-int4 WMMA for MoE prefill.
+ * A/C rows are grouped by expert according to expert_offsets/counts:
+ *   A       [total_pairs, K], C [total_pairs, N]
+ *   B       [num_experts, N, K/2]
+ *   scales  [num_experts, N, K/block_size]
+ * One grid.z slice handles one expert; empty/tail M tiles return early.
+ * Prototype currently supports the two Qwen3.5 MoE projection shapes and
+ * requires zero_points to be absent.
+ */
+HIP_KERNEL_API int hip_matmul_nbits_grouped_nozp(
+    void* stream,
+    const void* A,
+    const void* B,
+    const void* scales,
+    const void* bias,
+    void* C,
+    const int32_t* expert_counts,
+    const int32_t* expert_offsets,
+    int64_t num_experts,
+    int64_t max_m,
+    int64_t N,
+    int64_t K,
+    int64_t block_size);
+
 /* W4A8 integer-dot-product (dp4a) GEMV for a single decode row (M==1).
  * Dynamically quantizes the fp16 activation row to per-group int8 (into
  * caller-owned scratch) and runs a `v_dot4_i32_iu8` (`__builtin_amdgcn_sudot4`)

--- a/lib/Runtime/real/qmoe.cpp
+++ b/lib/Runtime/real/qmoe.cpp
@@ -109,6 +109,12 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
   int64_t blob_size_fc1 = block_size / 2;
   int64_t k_blocks_fc2 = (inter_size + block_size - 1) / block_size;
   int64_t blob_size_fc2 = block_size / 2;
+  const bool grouped_prefill_ok =
+      num_tokens > 1 && elem_size == 2 && expert_weight_bits == 4 &&
+      block_size == 32 && hidden_size == 2048 && inter_size == 512 &&
+      !fc1_zero_points && !fc2_zero_points;
+  const int64_t total_pairs = num_tokens * k;
+  const int64_t work_rows = grouped_prefill_ok ? total_pairs : num_tokens;
 
   // Per-state grow-on-demand scratch in place of 8 hipMalloc/8 hipFree per
   // call. Sub-buffers are 64-byte aligned (matches GPU pool alignment, gives
@@ -117,17 +123,20 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
   auto align_up_64 = [](size_t s) -> size_t { return (s + 63) & ~size_t(63); };
   size_t sz_expert_indices = align_up_64(num_tokens * k * sizeof(int32_t));
   size_t sz_expert_weights = align_up_64(num_tokens * k * elem_size);
-  size_t sz_gather_buf = align_up_64(num_tokens * hidden_size * elem_size);
-  size_t sz_fc1_buf = align_up_64(num_tokens * fusion_inter * elem_size);
+  size_t sz_gather_buf = align_up_64(work_rows * hidden_size * elem_size);
+  size_t sz_fc1_buf = align_up_64(work_rows * fusion_inter * elem_size);
   // Fused decode (num_tokens == 1) reuses act_buf and fc2_buf as the [k,
   // inter] activation slots and [k, hidden] per-expert output slots needed
   // by hip_qmoe_decode_fused (gather/scatter happen inline inside the
   // kernel, indexed by expert_indices). For num_tokens > 1 the multi-pass
   // path uses [num_tokens, ...] sizing. Take the max so the per-state
   // scratch is never under-sized regardless of which path runs.
-  int64_t act_slots = std::max<int64_t>(num_tokens, k);
+  int64_t act_slots = std::max<int64_t>(work_rows, k);
   size_t sz_act_buf = align_up_64(act_slots * inter_size * elem_size);
-  size_t sz_fc2_buf = align_up_64(act_slots * hidden_size * elem_size);
+  // Grouped prefill reuses gather_buf for fc2 output after fc1 has consumed
+  // it. Keep only the decode-sized fc2 slots in that mode.
+  int64_t fc2_slots = grouped_prefill_ok ? k : act_slots;
+  size_t sz_fc2_buf = align_up_64(fc2_slots * hidden_size * elem_size);
   // bucket_tokens outputs (Phase 2): per-expert counts + exclusive prefix sum
   // offsets, plus tokens/weights re-grouped on-device into per-expert
   // contiguous slices. Replaces the old per-expert host h_ids/h_wts_e build +
@@ -288,13 +297,61 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
                              hip_stream));
 
     int64_t active_experts = 0;
+    int64_t max_expert_tokens = 0;
     for (int64_t e = 0; e < num_experts; e++) {
       if (h_counts[e] > 0) {
         active_experts++;
+        max_expert_tokens =
+            std::max<int64_t>(max_expert_tokens, h_counts[e]);
       }
     }
     RUNTIME_DEBUG_LOG("[REAL] wrap_qmoe: %lld/%lld experts active\n",
                       (long long)active_experts, (long long)num_experts);
+
+    // Qwen3.5 symmetric-int4 prefill prototype: gather all routed token pairs
+    // once, then dispatch one grid.z-grouped WMMA for every expert's fc1/fc2.
+    // Intermediate rows stay in expert-sorted order. Scatter remains
+    // per-expert so its non-atomic fp16 read-modify-write is deterministic.
+    if (grouped_prefill_ok && max_expert_tokens > 0) {
+      RUNTIME_DEBUG_LOG(
+          "[REAL] wrap_qmoe: grouped prefill pairs=%lld max_m=%lld "
+          "experts=%lld\n",
+          (long long)total_pairs, (long long)max_expert_tokens,
+          (long long)num_experts);
+
+      HIP_CHECK(hip_qmoe_gather_tokens(
+          stream, input, d_gather_buf, d_sorted_token_ids, hidden_size,
+          total_pairs, elem_size));
+
+      HIP_CHECK(hip_matmul_nbits_grouped_nozp(
+          stream, d_gather_buf, fc1_weights, fc1_scales, fc1_bias, d_fc1_buf,
+          d_expert_counts, d_expert_offsets, num_experts, max_expert_tokens,
+          fusion_inter, hidden_size, block_size));
+
+      HIP_CHECK(hip_qmoe_swiglu(
+          stream, d_fc1_buf, d_act_buf, total_pairs, inter_size,
+          activation_alpha, activation_beta, swiglu_limit, elem_size));
+
+      HIP_CHECK(hip_matmul_nbits_grouped_nozp(
+          stream, d_act_buf, fc2_weights, fc2_scales, fc2_bias, d_gather_buf,
+          d_expert_counts, d_expert_offsets, num_experts, max_expert_tokens,
+          hidden_size, inter_size, block_size));
+
+      for (int64_t e = 0; e < num_experts; e++) {
+        int64_t count = static_cast<int64_t>(h_counts[e]);
+        if (count == 0) continue;
+        int64_t off_e = h_offsets[e];
+        int32_t *d_ids_e = d_sorted_token_ids + off_e;
+        char *d_wts_e = d_sorted_weights + off_e * elem_size;
+        char *d_out_e =
+            static_cast<char *>(d_gather_buf) +
+            off_e * hidden_size * elem_size;
+        HIP_CHECK(hip_qmoe_scatter_add(
+            stream, output, d_out_e, d_ids_e, d_wts_e, hidden_size, count,
+            elem_size));
+      }
+      goto cleanup;
+    }
 
     // Per-session pointer-keyed zero_points unpack cache (qmoe-owned, lives on
     // RuntimeState). Each expert's fc1/fc2 zp is a distinct pointer into the

--- a/lib/Runtime/real/qmoe.cpp
+++ b/lib/Runtime/real/qmoe.cpp
@@ -109,10 +109,10 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
   int64_t blob_size_fc1 = block_size / 2;
   int64_t k_blocks_fc2 = (inter_size + block_size - 1) / block_size;
   int64_t blob_size_fc2 = block_size / 2;
-  const bool grouped_prefill_ok =
-      num_tokens > 1 && elem_size == 2 && expert_weight_bits == 4 &&
-      block_size == 32 && hidden_size == 2048 && inter_size == 512 &&
-      !fc1_zero_points && !fc2_zero_points;
+  const bool grouped_prefill_ok = num_tokens > 1 && elem_size == 2 &&
+                                  expert_weight_bits == 4 && block_size == 32 &&
+                                  hidden_size == 2048 && inter_size == 512 &&
+                                  !fc1_zero_points && !fc2_zero_points;
   const int64_t total_pairs = num_tokens * k;
   const int64_t work_rows = grouped_prefill_ok ? total_pairs : num_tokens;
 
@@ -301,8 +301,7 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
     for (int64_t e = 0; e < num_experts; e++) {
       if (h_counts[e] > 0) {
         active_experts++;
-        max_expert_tokens =
-            std::max<int64_t>(max_expert_tokens, h_counts[e]);
+        max_expert_tokens = std::max<int64_t>(max_expert_tokens, h_counts[e]);
       }
     }
     RUNTIME_DEBUG_LOG("[REAL] wrap_qmoe: %lld/%lld experts active\n",
@@ -319,18 +318,18 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
           (long long)total_pairs, (long long)max_expert_tokens,
           (long long)num_experts);
 
-      HIP_CHECK(hip_qmoe_gather_tokens(
-          stream, input, d_gather_buf, d_sorted_token_ids, hidden_size,
-          total_pairs, elem_size));
+      HIP_CHECK(hip_qmoe_gather_tokens(stream, input, d_gather_buf,
+                                       d_sorted_token_ids, hidden_size,
+                                       total_pairs, elem_size));
 
       HIP_CHECK(hip_matmul_nbits_grouped_nozp(
           stream, d_gather_buf, fc1_weights, fc1_scales, fc1_bias, d_fc1_buf,
           d_expert_counts, d_expert_offsets, num_experts, max_expert_tokens,
           fusion_inter, hidden_size, block_size));
 
-      HIP_CHECK(hip_qmoe_swiglu(
-          stream, d_fc1_buf, d_act_buf, total_pairs, inter_size,
-          activation_alpha, activation_beta, swiglu_limit, elem_size));
+      HIP_CHECK(hip_qmoe_swiglu(stream, d_fc1_buf, d_act_buf, total_pairs,
+                                inter_size, activation_alpha, activation_beta,
+                                swiglu_limit, elem_size));
 
       HIP_CHECK(hip_matmul_nbits_grouped_nozp(
           stream, d_act_buf, fc2_weights, fc2_scales, fc2_bias, d_gather_buf,
@@ -339,16 +338,15 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
 
       for (int64_t e = 0; e < num_experts; e++) {
         int64_t count = static_cast<int64_t>(h_counts[e]);
-        if (count == 0) continue;
+        if (count == 0)
+          continue;
         int64_t off_e = h_offsets[e];
         int32_t *d_ids_e = d_sorted_token_ids + off_e;
         char *d_wts_e = d_sorted_weights + off_e * elem_size;
         char *d_out_e =
-            static_cast<char *>(d_gather_buf) +
-            off_e * hidden_size * elem_size;
-        HIP_CHECK(hip_qmoe_scatter_add(
-            stream, output, d_out_e, d_ids_e, d_wts_e, hidden_size, count,
-            elem_size));
+            static_cast<char *>(d_gather_buf) + off_e * hidden_size * elem_size;
+        HIP_CHECK(hip_qmoe_scatter_add(stream, output, d_out_e, d_ids_e,
+                                       d_wts_e, hidden_size, count, elem_size));
       }
       goto cleanup;
     }


### PR DESCRIPTION
Batch symmetric int4 Qwen3.5 expert projections into grid-z WMMA launches to eliminate per-expert dispatch overhead while preserving deterministic scatter order.

<!--
Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
Licensed under the MIT License.
-->

<!--
Thank you for contributing. Keep the description proportional to the change
and review it for accuracy before requesting review. See CONTRIBUTING.md for
the full workflow and AI-assistance disclosure requirements.
-->

## Summary

<!-- What changed and what user- or developer-visible effect it has. -->

## Related issue or design

<!-- Link the issue/design discussion, use "Fixes #123", or write "None". -->

## Why

<!-- Explain the problem and rationale when the design choice is not obvious. -->

## What

<!-- Optional for small changes. List concrete implementation details. -->

## Test plan

<!-- List commands run and results, or explain why testing was not needed. -->

## Notes for reviewers

<!-- Optional: limitations, follow-ups, important assumptions, or ordering constraints. -->

<!--
Optional sections: remove this comment and keep the sections that apply.

## Compiler IR

<details>
<summary>Before / after</summary>

```mlir
// Before
```

```mlir
// After
```

</details>

## Performance

| Metric | Before | After |
|---|---:|---:|
| | | |

Hardware, workload, build configuration, and measurement method:
-->

## Checklist

- [ ] The change is focused, or links a design/series explaining its scope.
- [ ] Relevant tests were added or updated and the results are documented.
- [ ] User-facing or design documentation was updated when needed.
- [ ] Substantial AI assistance is disclosed, and I reviewed and understand the result.
