### PR TITLE
HIP EP Enablement for MI350

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The provider integrates with ONNX Runtime through the MorphiZen pass framework. 
 |---|---|
 | Build and run on Windows | [Windows quick start](docs/quick_start.md) |
 | Build on Linux, use Docker, or download a prebuilt package | [Linux quick start](docs/quick_start_linux.md) |
+| Run on AMD Instinct MI350X (gfx950, CDNA4) | [MI350X quick start](docs/quick_start_mi350.md) |
 | Understand artifact formats | [LLVM IR vs native artifacts](docs/native-vs-ir-comparison.md) |
 | Extend the pipeline with a plugin | [Plugin authoring guide](docs/plugin_authoring.md) |
 | Contribute to the project | [Contributing guide](CONTRIBUTING.md) |

--- a/docs/quick_start_linux.md
+++ b/docs/quick_start_linux.md
@@ -22,7 +22,9 @@ built from source, so the host needs no system LLVM. The cold from-source LLVM
 build is the long pole (multi-hour); it lands under `<workspace>/build/` and is
 reused across rebuilds.
 
-See [quick_start.md](quick_start.md) for the Windows flow.
+See [quick_start.md](quick_start.md) for the Windows flow. If your target is an
+**AMD Instinct MI350X** (`gfx950`, CDNA4), read this guide first and then
+[quick_start_mi350.md](quick_start_mi350.md), which covers what wave64 changes.
 
 ## Host prerequisites
 

--- a/docs/quick_start_mi350.md
+++ b/docs/quick_start_mi350.md
@@ -1,0 +1,254 @@
+<!--
+Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+Licensed under the MIT License.
+-->
+# Quick Start Guide (AMD Instinct MI350X / gfx950)
+
+This guide covers running hip-ep on **AMD Instinct MI350X** (`gfx950`, CDNA4).
+It is a **delta** on top of [quick_start_linux.md](quick_start_linux.md) — build
+entry paths, `$ROOT` setup, and the shared *Testing & Benchmarking* tooling are
+identical and are not repeated here. Read that guide first; come back here for
+what MI350X does differently.
+
+**Linux only.** MI350X is now only supported on the Linux platform.
+
+
+## Why MI350X needs its own notes
+
+The custom kernels were originally written for RDNA3/RDNA4 (`gfx11xx`/`gfx12xx`),
+which run **wave32** and expose the **WMMA** matrix intrinsics. CDNA4 is a
+different architecture family:
+
+| | RDNA3 / RDNA4 (e.g. gfx1151) | CDNA4 (gfx950 / MI350X) |
+|---|---|---|
+| Wavefront size | 32 | **64** |
+| Matrix intrinsics | WMMA (`__builtin_amdgcn_wmma_*`) | **MFMA** — no WMMA |
+| Mixed-sign dot4 | `__builtin_amdgcn_sudot4` | signed `__builtin_amdgcn_sdot4` only |
+
+The shared kernel sources compile for both families through
+[`lib/Runtime/Kernels/include/hip_arch_compat.h`](../lib/Runtime/Kernels/include/hip_arch_compat.h),
+which supplies a compile-time `HIPDNN_WAVE_SIZE` / `HIPDNN_HAS_WMMA` and a
+portable `hipdnn_sudot4()`. Host-side dispatch decisions are made at **runtime**
+from the device's `warpSize`, not from the architecture string, so the same
+binary behaves correctly on a mixed-GPU host.
+
+## Host prerequisites
+
+Same as the Linux guide, with these differences:
+
+| Tool | Purpose |
+|------|---------|
+| **AMD Instinct MI350X** + `/dev/kfd` + `/dev/dri/renderD*` | HIP runtime (replaces the gfx1151 requirement) |
+| **ROCm with hipBLASLt** | **Hard requirement** on MI350X — see [hipBLASLt is required](#hipblaslt-is-required) |
+| cmake ≥ 3.29, ninja, git, a C++ compiler, python3 | Native build path |
+| Docker 26+ | Docker build path (optional) |
+
+## Build
+
+**You must build from source.** The published `linux-gpu-test-package` is built
+for `gfx1151` only (`HIP_ARCHITECTURES: gfx1151` in
+[`.github/workflows/linux-build.yml`](../.github/workflows/linux-build.yml)), so
+it does not contain the gfx950 kernel library and will not run on MI350X.
+
+`build.py` auto-detects the architecture from
+`/sys/class/kfd/kfd/topology/nodes/*/properties`, where MI350X reports
+`gfx_target_version 90500` → `gfx950`. On an MI350X host no flag is needed:
+
+```bash
+git clone https://github.com/ROCm/hip-ep.git
+cd hip-ep
+python3 build.py                    # auto-detects gfx950
+python3 build.py --hip_arch gfx950  # or state it explicitly
+```
+
+The Docker path detects the arch host-side the same way:
+
+```bash
+./docker/run.sh image        # first time only
+./docker/run.sh build        # auto-detects gfx950
+#   HIP_ARCHITECTURES=gfx950 ./docker/run.sh build   # explicit
+```
+
+There is no gfx950 allow-list anywhere in the tree — the arch string is passed
+through to the HIP compiler, so nothing needs to be registered to add it.
+
+### Artifacts
+
+```
+<workspace>/install/lib/libhipgpu.so                  # the EP
+<workspace>/install/lib/libcustom_kernels_gfx950.so   # gfx950 kernels
+```
+
+`libcustom_kernels_<arch>.so` **must sit next to `libhipgpu.so`**. At session
+init the EP probes `hipGetDeviceProperties(0).gcnArchName`, builds the filename
+from it, and `dlopen`s it from its own directory (the EP is linked with
+`RPATH=$ORIGIN`, so it does not need to be on `LD_LIBRARY_PATH`). A missing or
+wrong-arch kernel library is a **hard failure** at init, not a fallback.
+
+## Runtime setup and benchmarking
+
+Identical to the Linux guide — see
+[Open a container shell and set `$ROOT`](quick_start_linux.md#open-a-container-shell-and-set-root)
+and [Testing & Benchmarking](quick_start_linux.md#testing--benchmarking). Nothing
+in `hip-onnx-runner`, `onnxruntime_perf_test`, or `model_benchmark` is
+MI350X-specific.
+
+A worked end-to-end example, batch 1, INT4 RTN block-32:
+
+```bash
+export THEROCK_DIST=/opt/rocm     # or the auto-downloaded build/hip-ep/_therock
+export LD_LIBRARY_PATH="$ROOT/lib:$THEROCK_DIST/lib:<ort-prefix>/lib"
+
+$ROOT/bin/model_benchmark \
+  -i /path/to/oga-model-dir \
+  -l 2048 -g 128 -r 3 -w 1 -b 1
+```
+
+`THEROCK_DIST` is not optional even when the ROCm libs are already on
+`LD_LIBRARY_PATH`: `hip-compiler` reads it to build the `-L` paths it hands to
+`ld.lld` when linking a per-model native artifact. Without it that link fails
+with `undefined symbol: hipGetDeviceCount`.
+
+`<ort-prefix>` must be the **same ONNX Runtime the EP was compiled against**.
+`cmake/deps.cmake` downloads a specific ORT release into the build tree
+(`build/<repo>/_deps/onnxruntime-src`), and the EP requests that release's API
+version at load time — see [ORT version skew](#ort-version-skew) below.
+
+The EP is selected by the model's `genai_config.json` `provider_options` and
+auto-discovered next to the OGA runtime lib, exactly as on RDNA. (If your OGA
+build needs to be pointed at a specific EP `.so`, that is an onnxruntime-genai
+umbrella-EP override such as `AMDGPU_EP_PATH` — hip-ep itself does not read it.)
+
+## What is not supported on MI350X
+
+Everything below keys off the **runtime wave size** (`warpSize >= 64`), so it
+applies to any CDNA part, not just gfx950.
+
+| Feature | Behaviour on MI350X | Where |
+|---|---|---|
+| **Quantized / INT8 KV cache for GQA** | **Hard error, returns −1.** Use an fp16 KV cache. | `lib/Runtime/real/gqa.cpp` |
+| WMMA fused GQA (`hip_gqa_flash_prefill_v2` / `_decode_v2`) | Silently routed to the decomposed hipBLASLt pipeline | `gqa.cpp` (`fused_supported`) |
+| Legacy `flash_decode` launcher | Silently disabled; `HIPDNN_EP_GQA_FLASH_DECODE=1` has no effect | `gqa.cpp` (`gqa_flash_decode_enabled`) |
+| WMMA MatMulNBits prefill | Replaced by dequant-once + hipBLASLt GEMM for INT4 M≥16 | `matmul_nbits_kernel.hip`, `matmul_nbits.cpp` |
+| WMMA MultiHeadAttention flash prefill | Silently routed to the decomposed path | `multi_head_attention.cpp` |
+
+Only the first is user-visible. If you point an INT8-KV-cache model at MI350X
+you get:
+
+```
+wrap_group_query_attention: quantized KV cache is not supported on wave64
+devices (CDNA, e.g. MI350) -- its kernels are on the WMMA fused path, which is
+RDNA-only. Use an fp16 KV cache.
+```
+
+This fails loudly on purpose rather than misreading quantized bytes as fp16.
+Supporting it on CDNA is follow-up work.
+
+### hipBLASLt is required
+
+On MI350X, hipBLASLt is not an optimization — it is the execution path:
+
+- **GQA** always uses `gqa_forward_hipblaslt()`, because the fused WMMA path is
+  off. A null handle fails the op.
+- **INT4 MatMulNBits prefill** (batch 1, `K % 32 == 0`, M ≥ 16, fp16) dequantizes
+  the weight to fp16 once, caches it per weight pointer, and runs the GEMM
+  through hipBLASLt on the MFMA matrix cores.
+- Session creation calls `hipblasLtCreate()` and fails if it does not succeed.
+
+The first call for each new `(M, N, K)` shape **autotunes** the hipBLASLt
+algorithm by timing the ranked heuristic candidates and caching the winner. This
+is independent of `HIPDNN_EP_AUTOTUNE` (which gates a different code path) and
+has two consequences worth knowing: the first request of a shape is slower, and
+dense-prefill timings vary run to run because a cold autotune under ramping GPU
+clocks can elect a different algorithm.
+
+### Environment variables that behave differently
+
+The GQA env knobs documented for RDNA still parse on MI350X, but several are
+inert because the code path they control is disabled:
+
+| Variable | On MI350X |
+|---|---|
+| `HIPDNN_EP_GQA_FLASH_DECODE` | **Ignored** — flash_decode is off on wave64 regardless |
+| `HIPDNN_GQA_DECODE_WMMA`, `HIPDNN_GQA_DECODE_SCALAR`, `HIPDNN_GQA_DECODE_SPLITS` | **No effect** — they tune the fused decode path, never entered on wave64 |
+| `HIPDNN_EP_GQA_DISABLE_FUSED_DECODE` | Redundant — the decomposed path is already the only one |
+| `HIPDNN_EP_MATMUL_DP4A` | Active; the DP4A GEMV uses the portable `hipdnn_sudot4()` |
+
+## Measured performance
+
+MI350X (gfx950, 8 GPUs present, pinned to device 0), EPYC 9965, ROCm 7.2.0,
+ONNX Runtime 1.25.1. OGA `model_benchmark`, batch 1, generate 128, 1 warmup +
+3 reps, INT4 RTN block-32.
+
+| Model | Prompt | TTFT | Decode | Peak working set |
+|---|---:|---:|---:|---:|
+| phi-4 (14B dense) | 128 | 45.5 ms | 54.0 tok/s | 4.2 GB |
+| phi-4 | 512 | 173.6 ms | 106.5 tok/s | 4.5 GB |
+| phi-4 | 2048 | 550.1 ms | 64.6 tok/s | 6.2 GB |
+| gpt-oss-20b (MoE) | 128 | 683.9 ms | 238.8 tok/s | 4.3 GB |
+| gpt-oss-20b | 512 | 2945.1 ms | 210.5 tok/s | 4.6 GB |
+| gpt-oss-20b | 2048 | 11 153.8 ms | 107.2 tok/s | 6.9 GB |
+
+Two things to read from this. Dense INT4 prefill is healthy (~2.8–3.7k tok/s)
+because it runs the hipBLASLt MFMA path. **MoE prefill is the known weak spot**:
+gpt-oss-20b sits near 180 tok/s regardless of prompt length, because the expert
+FFNs go through the `qmoe` kernel, which was ported for correctness on wave64 but
+still uses the naive, un-tiled prefill route — exactly where MatMulNBits was
+before the dense fast path was added. MoE *decode* is strong.
+
+Dense-prefill TTFT carries roughly ±8 % run-to-run variance from the hipBLASLt
+autotune described above, so treat single samples accordingly and average several
+process invocations for any comparison.
+
+## Troubleshooting
+
+**`LlvmIrJit: Load(.../libcustom_kernels_gfx950.so) ... failed`**
+
+The gfx950 kernel library is missing from the EP's own directory. Confirm it was
+built and co-located:
+
+```bash
+ls -l "$ROOT/lib/libcustom_kernels_"*.so   # expect libcustom_kernels_gfx950.so
+```
+
+If only `libcustom_kernels_gfx1151.so` is present you are running the prebuilt CI
+package, which does not support MI350X — build from source (see [Build](#build)).
+
+**Segfault at session creation, with `The requested API version [N] is not
+available, only API versions [1, M] are supported in this build`**
+
+<a id="ort-version-skew"></a>ONNX Runtime version skew. The EP was compiled
+against the ORT release `cmake/deps.cmake` downloaded into the build tree, but a
+different (older) `libonnxruntime.so` is ahead of it on `LD_LIBRARY_PATH` —
+commonly one belonging to a separately built onnxruntime-genai. The API-version
+line is the only real clue; the process then dies with SIGSEGV.
+
+Point `<ort-prefix>` at the ORT that came with your build tree:
+
+```bash
+ls <workspace>/build/hip-ep/_deps/onnxruntime-src/VERSION_NUMBER
+export LD_LIBRARY_PATH="$ROOT/lib:$THEROCK_DIST/lib:<workspace>/build/hip-ep/_deps/onnxruntime-src/lib"
+```
+
+**`Failed to create hipBLASLt handle`**
+
+hipBLASLt is missing or not on the loader path. It is required on MI350X (see
+[hipBLASLt is required](#hipblaslt-is-required)); make sure the ROCm libs are on
+`LD_LIBRARY_PATH`.
+
+**`quantized KV cache is not supported on wave64 devices`**
+
+Expected — the model uses an INT8 KV cache. Use an fp16-KV-cache build of the
+model.
+
+**Kernels build but produce wrong results after editing a kernel**
+
+Anything reducing across a wavefront must span the whole hardware wave. Use
+`HIPDNN_WAVE_SIZE` (compile-time, inside kernels) and `hipdnn_device_wave_size()`
+(host-side, for launch geometry) rather than a literal 32 or 64 — a block that is
+a partial wave folds inactive lanes into `__shfl_xor` reductions. See
+[`hip_arch_compat.h`](../lib/Runtime/Kernels/include/hip_arch_compat.h).
+
+For everything else, see
+[Troubleshooting in the Linux guide](quick_start_linux.md#troubleshooting) —
+those entries apply unchanged.

--- a/docs/quick_start_mi350.md
+++ b/docs/quick_start_mi350.md
@@ -127,7 +127,7 @@ applies to any CDNA part, not just gfx950.
 | Feature | Behaviour on MI350X | Where |
 |---|---|---|
 | **Quantized / INT8 KV cache for GQA** | **Hard error, returns −1.** Use an fp16 KV cache. | `lib/Runtime/real/gqa.cpp` |
-| WMMA fused GQA (`hip_gqa_flash_prefill_v2` / `_decode_v2`) | Silently routed to the decomposed hipBLASLt pipeline | `gqa.cpp` (`fused_supported`) |
+| WMMA fused GQA (the `hip_gqa_flash_prefill_*` / `_decode_*` kernels, including the attention-sink and sliding-window prefill) | Silently routed to the decomposed hipBLASLt pipeline | `gqa.cpp` (`fused_supported`) |
 | Legacy `flash_decode` launcher | Silently disabled; `HIPDNN_EP_GQA_FLASH_DECODE=1` has no effect | `gqa.cpp` (`gqa_flash_decode_enabled`) |
 | WMMA MatMulNBits prefill | Replaced by dequant-once + hipBLASLt GEMM for INT4 M≥16 | `matmul_nbits_kernel.hip`, `matmul_nbits.cpp` |
 | WMMA MultiHeadAttention flash prefill | Silently routed to the decomposed path | `multi_head_attention.cpp` |
@@ -196,9 +196,17 @@ FFNs go through the `qmoe` kernel, which was ported for correctness on wave64 bu
 still uses the naive, un-tiled prefill route — exactly where MatMulNBits was
 before the dense fast path was added. MoE *decode* is strong.
 
-Dense-prefill TTFT carries roughly ±8 % run-to-run variance from the hipBLASLt
-autotune described above, so treat single samples accordingly and average several
-process invocations for any comparison.
+The TTFT column above is a single sweep, and **dense-prefill TTFT is far noisier
+than that presentation suggests** — the hipBLASLt autotune described above elects
+a different algorithm from run to run. Measured over five separate process
+invocations on one build, phi-4 spans 43.3–55.9 ms at L=128 and 536.7–711.5 ms at
+L=2048, a coefficient of variation near 12 % in both cases.
+
+So do not read a single dense-TTFT sample as a measurement: a 10 % swing between
+two builds is inside the noise. Average several *process* invocations (repeats
+within one process share the elected algorithm and understate the spread) before
+concluding anything about a change. Decode throughput and peak memory are stable
+to ~1 %, so they are the reliable signals for A/B comparisons.
 
 ## Troubleshooting
 

--- a/lib/Runtime/Kernels/hip/gqa_kernel.hip
+++ b/lib/Runtime/Kernels/hip/gqa_kernel.hip
@@ -1096,13 +1096,17 @@ static void launch_softmax_f32_to_out(
     int total_head_queries, int rows, int cols,
     int input_batch_stride, int output_batch_stride,
     const void* head_sink, int num_heads, int use_smooth_softmax) {
-  // Floor of 64 keeps the block a whole multiple of the hardware wave on both
-  // wave32 (RDNA) and wave64 (CDNA/MI350): a 32-thread block would be a partial
-  // wave on wave64 and corrupt the __shfl_xor reduction across inactive lanes.
-  int threads = 64;
+  // The block must be a whole multiple of the hardware wave, else the tail of a
+  // partial wave is inactive and the __shfl_xor reduction folds in its lanes.
+  // The floor is therefore the device wave size: 32 on wave32 (RDNA, unchanged
+  // from the original geometry) and 64 on wave64 (CDNA/MI350). num_waves must
+  // use the same value so the LDS fan-in buffer matches the kernel's
+  // blockDim.x / WAVE_SIZE.
+  const int wave = hipdnn_device_wave_size();
+  int threads = wave;
   while (threads < std::min(rows, 256)) threads *= 2;
   if (threads > 256) threads = 256;
-  int num_waves = threads / WAVE_SIZE;
+  int num_waves = threads / wave;
   softmax_f32_to_out_kernel<TOut><<<total_head_queries, threads,
                                     num_waves * sizeof(float), stream>>>(
       static_cast<const float*>(input_f32), static_cast<TOut*>(output),
@@ -1148,12 +1152,12 @@ extern "C" int hip_gqa_softmax_inplace(
     int batch_stride, const void* head_sink, int num_heads,
     int use_smooth_softmax) {
   hipStream_t stream = static_cast<hipStream_t>(stream_ptr);
-  // Floor of 64: see launch_softmax_f32_to_out -- avoids a partial wave on
-  // wave64 (CDNA/MI350) that would corrupt the __shfl_xor reduction.
-  int threads = 64;
+  // Block floor is the device wave size: see launch_softmax_f32_to_out.
+  const int wave = hipdnn_device_wave_size();
+  int threads = wave;
   while (threads < std::min(rows, 256)) threads *= 2;
   if (threads > 256) threads = 256;
-  int num_waves = threads / WAVE_SIZE;
+  int num_waves = threads / wave;
   (void)hipGetLastError();  // clear stale error for correct attribution
   softmax_inplace_kernel<<<total_head_queries, threads,
                            num_waves * sizeof(float), stream>>>(

--- a/lib/Runtime/Kernels/hip/gqa_kernel.hip
+++ b/lib/Runtime/Kernels/hip/gqa_kernel.hip
@@ -15,10 +15,15 @@
 #include <unordered_map>
 
 #include "hip_custom_kernels.h"
+#include "hip_arch_compat.h"
 #include "debug_log.h"
 
 static constexpr int GQA_THREADS = 256;
-static constexpr int WAVE_SIZE = 32;  // RDNA wave32; not portable to CDNA/wave64
+// Wavefront size: 32 on RDNA (wave32), 64 on CDNA (wave64, e.g. MI350). Keyed
+// off the device-pass arch macros via hip_arch_compat.h so the shuffle-based
+// reductions and per-wave shared-memory fan-in below span the whole hardware
+// wave on both families.
+static constexpr int WAVE_SIZE = HIPDNN_WAVE_SIZE;
 static constexpr float LOG2E = 1.4426950408889634f;
 
 // Element-size dispatch helper for the pure data-movement kernels (transpose,
@@ -617,23 +622,19 @@ __global__ void causal_mask_kernel_impl(
 // Uses shared memory for parallel max-reduction and sum-reduction.
 // -------------------------------------------------------------------------
 
-// Warp-level reduction helpers (RDNA wave32)
+// Warp-level reduction helpers (wave-size portable: 32 on RDNA, 64 on CDNA)
 
 __device__ __forceinline__ float warp_reduce_max(float val) {
-  val = fmaxf(val, __shfl_xor(val, 16));
-  val = fmaxf(val, __shfl_xor(val, 8));
-  val = fmaxf(val, __shfl_xor(val, 4));
-  val = fmaxf(val, __shfl_xor(val, 2));
-  val = fmaxf(val, __shfl_xor(val, 1));
+#pragma unroll
+  for (int offset = WAVE_SIZE >> 1; offset > 0; offset >>= 1)
+    val = fmaxf(val, __shfl_xor(val, offset));
   return val;
 }
 
 __device__ __forceinline__ float warp_reduce_sum(float val) {
-  val += __shfl_xor(val, 16);
-  val += __shfl_xor(val, 8);
-  val += __shfl_xor(val, 4);
-  val += __shfl_xor(val, 2);
-  val += __shfl_xor(val, 1);
+#pragma unroll
+  for (int offset = WAVE_SIZE >> 1; offset > 0; offset >>= 1)
+    val += __shfl_xor(val, offset);
   return val;
 }
 
@@ -1095,7 +1096,10 @@ static void launch_softmax_f32_to_out(
     int total_head_queries, int rows, int cols,
     int input_batch_stride, int output_batch_stride,
     const void* head_sink, int num_heads, int use_smooth_softmax) {
-  int threads = 32;
+  // Floor of 64 keeps the block a whole multiple of the hardware wave on both
+  // wave32 (RDNA) and wave64 (CDNA/MI350): a 32-thread block would be a partial
+  // wave on wave64 and corrupt the __shfl_xor reduction across inactive lanes.
+  int threads = 64;
   while (threads < std::min(rows, 256)) threads *= 2;
   if (threads > 256) threads = 256;
   int num_waves = threads / WAVE_SIZE;
@@ -1144,7 +1148,9 @@ extern "C" int hip_gqa_softmax_inplace(
     int batch_stride, const void* head_sink, int num_heads,
     int use_smooth_softmax) {
   hipStream_t stream = static_cast<hipStream_t>(stream_ptr);
-  int threads = 32;
+  // Floor of 64: see launch_softmax_f32_to_out -- avoids a partial wave on
+  // wave64 (CDNA/MI350) that would corrupt the __shfl_xor reduction.
+  int threads = 64;
   while (threads < std::min(rows, 256)) threads *= 2;
   if (threads > 256) threads = 256;
   int num_waves = threads / WAVE_SIZE;
@@ -1327,7 +1333,13 @@ gqa_flash_decode_kernel(
 
   // LDS tiles for K/V (shared across HPG=4 query heads for dedup). 16B-aligned
   // so the cooperative load can move 8 fp16 per float4 (see staging below).
-  static_assert(EPT % 2 == 0, "EPT must be even for __half2 vectorized loads");
+  // The __half2-vectorized staging below assumes an even EPT. Flash-decode is a
+  // wave32 (RDNA) path only -- it is disabled at dispatch on wave64 (see the
+  // gqa_flash_decode_enabled() gate in gqa.cpp), so this invariant only needs to
+  // hold there. On wave64 (CDNA/MI350) D=64 yields EPT=1; the kernel is then
+  // dead code that must still compile, so exempt the wave64 device pass.
+  static_assert(EPT % 2 == 0 || WAVE_SIZE != 32,
+                "EPT must be even for __half2 vectorized loads (wave32)");
   // HpG==1 (MHA) runs a single wave per block, so the K/V tile in LDS is never
   // reused across waves -- staging is pure overhead (32KB LDS + a __syncthreads
   // every tile). Stream straight from global instead (kStage=false): the LDS
@@ -1454,12 +1466,10 @@ gqa_flash_decode_kernel(
           dot_partial += Q_f[e] * kf.x + Q_f[e + 1] * kf.y;
         }
       }
-      // Warp reduce across 32 lanes -> all lanes hold the full dot.
-      dot_partial += __shfl_xor(dot_partial, 16);
-      dot_partial += __shfl_xor(dot_partial, 8);
-      dot_partial += __shfl_xor(dot_partial, 4);
-      dot_partial += __shfl_xor(dot_partial, 2);
-      dot_partial += __shfl_xor(dot_partial, 1);
+      // Warp reduce across the wave -> all lanes hold the full dot.
+#pragma unroll
+      for (int offset = WAVE_SIZE >> 1; offset > 0; offset >>= 1)
+        dot_partial += __shfl_xor(dot_partial, offset);
 
       const float score = dot_partial * scale_log2e;
       const float m_new = fmaxf(m_acc, score);
@@ -3954,11 +3964,9 @@ legacy_fused_gqa_decode_kernel(
         for (int t_off = 0; t_off < tile_n; ++t_off) {
             float dot = Q_val * __half2float(K_tile[t_off * D + tid]);
 
-            dot += __shfl_xor(dot, 16);
-            dot += __shfl_xor(dot, 8);
-            dot += __shfl_xor(dot, 4);
-            dot += __shfl_xor(dot, 2);
-            dot += __shfl_xor(dot, 1);
+#pragma unroll
+            for (int offset = WAVE_SIZE >> 1; offset > 0; offset >>= 1)
+                dot += __shfl_xor(dot, offset);
 
             if (lane_id == 0)
                 smem[wave_id] = dot;
@@ -4121,11 +4129,9 @@ legacy_gqa_flash_decode_kernel(
         dot_partial += __half2float(Q_reg[e]) *
                        __half2float(K_lds[t * D + lane_id * EPT + e]);
       }
-      dot_partial += __shfl_xor(dot_partial, 16);
-      dot_partial += __shfl_xor(dot_partial, 8);
-      dot_partial += __shfl_xor(dot_partial, 4);
-      dot_partial += __shfl_xor(dot_partial, 2);
-      dot_partial += __shfl_xor(dot_partial, 1);
+#pragma unroll
+      for (int offset = WAVE_SIZE >> 1; offset > 0; offset >>= 1)
+        dot_partial += __shfl_xor(dot_partial, offset);
 
       const float score = dot_partial * scale_log2e;
       const float m_new = fmaxf(m_acc, score);

--- a/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
+++ b/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
@@ -52,6 +52,7 @@
  */
 
 #include "hip_custom_kernels.h"
+#include "hip_arch_compat.h"
 #include "debug_log.h"
 
 #include <hip/hip_runtime.h>
@@ -800,14 +801,19 @@ __global__ void matmul_nbits_gemv_kernel(
     // --- Reduction: warp shuffle then shared memory ---
     // RDNA 3/3.5 (gfx11xx) runs wave32 by default. Compile-time constant
     // for warp_size allows the compiler to dead-strip unused branches.
-    constexpr int WARP_SIZE = 32;
+    // Compile-time wavefront size (32 on RDNA, 64 on CDNA/MI350). For a block
+    // smaller than a hardware wave (e.g. BLOCK_SIZE=32 on wave64) only the first
+    // BLOCK_SIZE lanes are live, so the single-wave shuffle tree below must start
+    // at BLOCK_SIZE/2 -- starting at WARP_SIZE/2 would fold in inactive lanes.
+    constexpr int WARP_SIZE = HIPDNN_WAVE_SIZE;
     const int warp_id   = tid / WARP_SIZE;
     const int lane_id   = tid % WARP_SIZE;
-    constexpr int NUM_WARPS = BLOCK_SIZE / WARP_SIZE;
+    constexpr int NUM_WARPS = (BLOCK_SIZE + WARP_SIZE - 1) / WARP_SIZE;
+    constexpr int RED_W = BLOCK_SIZE < WARP_SIZE ? BLOCK_SIZE : WARP_SIZE;
 
 #pragma unroll
     for (int tn = 0; tn < TILE_N; tn++) {
-        for (int offset = WARP_SIZE >> 1; offset > 0; offset >>= 1)
+        for (int offset = RED_W >> 1; offset > 0; offset >>= 1)
             partial[tn] += __shfl_down(partial[tn], offset);
     }
 
@@ -919,14 +925,18 @@ __global__ void matmul_nbits_quant_act_i8_kernel(
     for (int64_t k = g0 + tid; k < g1; k += BLOCK_SIZE)
         local_max = fmaxf(local_max, fabsf(static_cast<float>(A[k])));
 
-    constexpr int WARP_SIZE = 32;
-    constexpr int NUM_WARPS = BLOCK_SIZE / WARP_SIZE;
-    for (int off = WARP_SIZE >> 1; off > 0; off >>= 1)
+    // Wave-portable (32 on RDNA, 64 on CDNA/MI350). RED_W caps the shuffle to
+    // the active lanes for a sub-wave block, and the per-wave fan-in index uses
+    // tid / WARP_SIZE rather than a hard-coded /32.
+    constexpr int WARP_SIZE = HIPDNN_WAVE_SIZE;
+    constexpr int NUM_WARPS = (BLOCK_SIZE + WARP_SIZE - 1) / WARP_SIZE;
+    constexpr int RED_W = BLOCK_SIZE < WARP_SIZE ? BLOCK_SIZE : WARP_SIZE;
+    for (int off = RED_W >> 1; off > 0; off >>= 1)
         local_max = fmaxf(local_max, __shfl_down(local_max, off));
 
     __shared__ float smax[NUM_WARPS > 0 ? NUM_WARPS : 1];
     if ((tid & (WARP_SIZE - 1)) == 0)
-        smax[tid >> 5] = local_max;
+        smax[tid / WARP_SIZE] = local_max;
     __syncthreads();
     if (tid == 0) {
         float m = 0.0f;
@@ -1017,10 +1027,8 @@ __global__ void matmul_nbits_gemv_dp4a_kernel(
         int a_sum_q = 0;
 #pragma unroll
         for (int j = 0; j < 4; j++) {
-            a_sum_q = __builtin_amdgcn_sudot4(true, a_lo[j], false, 0x01010101,
-                                              a_sum_q, false);
-            a_sum_q = __builtin_amdgcn_sudot4(true, a_hi[j], false, 0x01010101,
-                                              a_sum_q, false);
+            a_sum_q = hipdnn_sudot4(a_lo[j], 0x01010101, a_sum_q);
+            a_sum_q = hipdnn_sudot4(a_hi[j], 0x01010101, a_sum_q);
         }
 
 #pragma unroll
@@ -1032,10 +1040,8 @@ __global__ void matmul_nbits_gemv_dp4a_kernel(
             for (int j = 0; j < 4; j++) {
                 const int lo_w = static_cast<int>(comp[j] & 0x0F0F0F0Fu);
                 const int hi_w = static_cast<int>((comp[j] >> 4) & 0x0F0F0F0Fu);
-                dot = __builtin_amdgcn_sudot4(true, a_lo[j], false, lo_w, dot,
-                                              false);
-                dot = __builtin_amdgcn_sudot4(true, a_hi[j], false, hi_w, dot,
-                                              false);
+                dot = hipdnn_sudot4(a_lo[j], lo_w, dot);
+                dot = hipdnn_sudot4(a_hi[j], hi_w, dot);
             }
             const float sv = static_cast<float>(s_rows[tn][grp]);
             const int   zv = has_zp
@@ -1046,14 +1052,19 @@ __global__ void matmul_nbits_gemv_dp4a_kernel(
     }
 
     // --- Reduction: warp shuffle then shared memory (mirrors int4 path) ---
-    constexpr int WARP_SIZE = 32;
+    // Compile-time wavefront size (32 on RDNA, 64 on CDNA/MI350). For a block
+    // smaller than a hardware wave (e.g. BLOCK_SIZE=32 on wave64) only the first
+    // BLOCK_SIZE lanes are live, so the single-wave shuffle tree below must start
+    // at BLOCK_SIZE/2 -- starting at WARP_SIZE/2 would fold in inactive lanes.
+    constexpr int WARP_SIZE = HIPDNN_WAVE_SIZE;
     const int warp_id   = tid / WARP_SIZE;
     const int lane_id   = tid % WARP_SIZE;
-    constexpr int NUM_WARPS = BLOCK_SIZE / WARP_SIZE;
+    constexpr int NUM_WARPS = (BLOCK_SIZE + WARP_SIZE - 1) / WARP_SIZE;
+    constexpr int RED_W = BLOCK_SIZE < WARP_SIZE ? BLOCK_SIZE : WARP_SIZE;
 
 #pragma unroll
     for (int tn = 0; tn < TILE_N; tn++) {
-        for (int offset = WARP_SIZE >> 1; offset > 0; offset >>= 1)
+        for (int offset = RED_W >> 1; offset > 0; offset >>= 1)
             partial[tn] += __shfl_down(partial[tn], offset);
     }
 
@@ -1859,14 +1870,19 @@ __global__ void matmul_nbits_gemv_kernel_u3(
     }
 
     // --- Reduction: warp shuffle then shared memory (mirrors int4 path) ---
-    constexpr int WARP_SIZE = 32;
+    // Compile-time wavefront size (32 on RDNA, 64 on CDNA/MI350). For a block
+    // smaller than a hardware wave (e.g. BLOCK_SIZE=32 on wave64) only the first
+    // BLOCK_SIZE lanes are live, so the single-wave shuffle tree below must start
+    // at BLOCK_SIZE/2 -- starting at WARP_SIZE/2 would fold in inactive lanes.
+    constexpr int WARP_SIZE = HIPDNN_WAVE_SIZE;
     const int warp_id   = tid / WARP_SIZE;
     const int lane_id   = tid % WARP_SIZE;
-    constexpr int NUM_WARPS = BLOCK_SIZE / WARP_SIZE;
+    constexpr int NUM_WARPS = (BLOCK_SIZE + WARP_SIZE - 1) / WARP_SIZE;
+    constexpr int RED_W = BLOCK_SIZE < WARP_SIZE ? BLOCK_SIZE : WARP_SIZE;
 
 #pragma unroll
     for (int tn = 0; tn < TILE_N; tn++) {
-        for (int offset = WARP_SIZE >> 1; offset > 0; offset >>= 1)
+        for (int offset = RED_W >> 1; offset > 0; offset >>= 1)
             partial[tn] += __shfl_down(partial[tn], offset);
     }
 
@@ -2265,14 +2281,19 @@ __global__ void matmul_nbits_gemv_kernel_u2(
     }
 
     // --- Reduction: warp shuffle then shared memory (mirrors u3 path) ---
-    constexpr int WARP_SIZE = 32;
+    // Compile-time wavefront size (32 on RDNA, 64 on CDNA/MI350). For a block
+    // smaller than a hardware wave (e.g. BLOCK_SIZE=32 on wave64) only the first
+    // BLOCK_SIZE lanes are live, so the single-wave shuffle tree below must start
+    // at BLOCK_SIZE/2 -- starting at WARP_SIZE/2 would fold in inactive lanes.
+    constexpr int WARP_SIZE = HIPDNN_WAVE_SIZE;
     const int warp_id   = tid / WARP_SIZE;
     const int lane_id   = tid % WARP_SIZE;
-    constexpr int NUM_WARPS = BLOCK_SIZE / WARP_SIZE;
+    constexpr int NUM_WARPS = (BLOCK_SIZE + WARP_SIZE - 1) / WARP_SIZE;
+    constexpr int RED_W = BLOCK_SIZE < WARP_SIZE ? BLOCK_SIZE : WARP_SIZE;
 
 #pragma unroll
     for (int tn = 0; tn < TILE_N; tn++) {
-        for (int offset = WARP_SIZE >> 1; offset > 0; offset >>= 1)
+        for (int offset = RED_W >> 1; offset > 0; offset >>= 1)
             partial[tn] += __shfl_down(partial[tn], offset);
     }
 
@@ -5509,6 +5530,30 @@ extern "C" void hip_matmul_nbits_convert_zp_fp16(
                        N, groups_k, packed_cols);
 }
 
+// Full-weight int4 -> fp16 dequantization into a row-major [N, K] buffer, used
+// by the CDNA/wave64 prefill fast path (lib/Runtime/real/matmul_nbits.cpp),
+// which lacks WMMA and instead dequantizes B once (weights are constant) and
+// calls a hipBLASLt fp16 GEMM. scales/zeros are fp16 [N, num_groups_k]; when
+// zeros_fp16 is null the ONNX 4-bit default zero-point (8) is used.
+extern "C" void hip_matmul_nbits_dequant_b_fp16(
+    void* stream, const void* B_packed, const void* scales_fp16,
+    const void* zeros_fp16, void* B_fp16_out, int N, int K, int group_size)
+{
+    int num_groups_k = (K + group_size - 1) / group_size;
+    int threads_along_k = (K + 7) / 8;   // each thread emits 8 contiguous nibbles
+    constexpr int THR = 256;
+    dim3 grid(static_cast<unsigned>((threads_along_k + THR - 1) / THR),
+              static_cast<unsigned>(N));
+    dim3 block(THR);
+    hipLaunchKernelGGL(dequant_u4_to_fp16, grid, block, 0,
+                       static_cast<hipStream_t>(stream),
+                       static_cast<const unsigned char*>(B_packed),
+                       static_cast<const _Float16*>(scales_fp16),
+                       static_cast<const _Float16*>(zeros_fp16),
+                       static_cast<_Float16*>(B_fp16_out),
+                       N, K, group_size, num_groups_k);
+}
+
 extern "C" int hip_matmul_nbits(
     void* stream,
     const void* A,
@@ -5583,7 +5628,8 @@ extern "C" int hip_matmul_nbits(
     const bool wmma_data_format = (batch_count == 1) && (K % 32 == 0);
     const bool use_wmma_i8 =
         wmma_data_format && (M >= kBlockDim) &&
-        (block_size >= 32) && (block_size % 32 == 0);
+        (block_size >= 32) && (block_size % 32 == 0) &&
+        !hipdnn_device_is_wave64();  // WMMA is RDNA-only; wave64 uses GEMV/naive
     const bool use_gemv_i8 = !use_wmma_i8 && (block_size >= kI8GemvMinBs);
 
     if (use_wmma_i8) {
@@ -5709,7 +5755,8 @@ extern "C" int hip_matmul_nbits(
     const bool u2_data_format = (batch_count == 1) && (K % 32 == 0);
     const bool use_wmma_u2 =
         u2_data_format && (M >= kBlockDim) &&
-        (block_size >= 32) && (block_size % 32 == 0);
+        (block_size >= 32) && (block_size % 32 == 0) &&
+        !hipdnn_device_is_wave64();  // WMMA is RDNA-only; wave64 uses GEMV/naive
     const bool is_pow2_bs = (block_size & (block_size - 1)) == 0;
     const bool use_gemv_u2 =
         !use_wmma_u2 && is_pow2_bs && (block_size >= kU2GemvMinBs) &&
@@ -5851,7 +5898,8 @@ extern "C" int hip_matmul_nbits(
     const bool u3_data_format = (batch_count == 1) && (K % 32 == 0);
     const bool use_wmma_u3 =
         u3_data_format && (M >= kBlockDim) &&
-        (block_size >= 32) && (block_size % 32 == 0);
+        (block_size >= 32) && (block_size % 32 == 0) &&
+        !hipdnn_device_is_wave64();  // WMMA is RDNA-only; wave64 uses GEMV/naive
     const bool is_pow2_bs = (block_size & (block_size - 1)) == 0;
     const bool use_gemv_u3 =
         !use_wmma_u3 && is_pow2_bs && (block_size >= kU3GemvMinBs) &&
@@ -5986,7 +6034,12 @@ extern "C" int hip_matmul_nbits(
    * ------------------------------------------------------------------- */
   bool wmma_data_format = (batch_count == 1) && (K % 32 == 0);
 
-  if (wmma_data_format && M >= kBlockDim) {
+  // WMMA is an RDNA3/RDNA4 (wave32) intrinsic. On CDNA (wave64, e.g. MI350)
+  // there is no WMMA, so the prefill fast path is unavailable here; int4 M>=16
+  // is instead served by the dequant-once + hipBLASLt path in
+  // lib/Runtime/real/matmul_nbits.cpp, and any residual case falls through to
+  // the correct GEMV/naive fallback below.
+  if (wmma_data_format && M >= kBlockDim && !hipdnn_device_is_wave64()) {
     CUSTOM_KERNELS_DEBUG_LOG(
         "[custom_kernels] hip_matmul_nbits: WMMA fast path M=%lld N=%lld "
         "K=%lld bs=%lld zp=%s bias=%s\n",

--- a/lib/Runtime/Kernels/hip/qmoe_kernel.hip
+++ b/lib/Runtime/Kernels/hip/qmoe_kernel.hip
@@ -8,6 +8,7 @@
  */
 
 #include "hip_custom_kernels.h"
+#include "hip_arch_compat.h"
 #include "debug_log.h"
 
 #include <hip/hip_runtime.h>
@@ -694,10 +695,18 @@ __global__ void qmoe_decode_fc1_kernel(
   // act_out[slot, sw_base+i] where sw_base = n_base/2. This eliminates the
   // separate qmoe_decode_swiglu_kernel launch (saves 1 launch per layer).
   // Requires TILE_N to be even and n_base to be even (callers ensure both).
-  constexpr int WARP_SIZE = 32;
+  // Wave size is 32 on RDNA and 64 on CDNA/MI350 (HIPDNN_WAVE_SIZE). __shfl_down
+  // defaults to the full hardware-wave width, so warp_id / lane / NUM_WARPS must
+  // all be expressed in terms of the real wave size to keep the shuffle
+  // reduction from crossing wave boundaries.
+  constexpr int WARP_SIZE = HIPDNN_WAVE_SIZE;
   const int warp_id = tid / WARP_SIZE;
   const int lane    = tid % WARP_SIZE;
-  constexpr int NUM_WARPS = BLOCK_SIZE / WARP_SIZE;
+  constexpr int NUM_WARPS = BLOCK_SIZE > WARP_SIZE ? BLOCK_SIZE / WARP_SIZE : 1;
+  // When BLOCK_SIZE < WARP_SIZE (e.g. a 32-thread config on a 64-lane wave) only
+  // the first BLOCK_SIZE lanes are active; cap the reduction span so we never
+  // shuffle in an inactive lane.
+  constexpr int RED_SPAN = BLOCK_SIZE < WARP_SIZE ? BLOCK_SIZE : WARP_SIZE;
   static_assert((TILE_N & 1) == 0, "TILE_N must be even for SwiGLU pairing");
   constexpr int TILE_OUT = TILE_N / 2;
   const int sw_base = n_base / 2;
@@ -705,7 +714,7 @@ __global__ void qmoe_decode_fc1_kernel(
 
   #pragma unroll
   for (int t = 0; t < TILE_N; t++) {
-    for (int off = WARP_SIZE >> 1; off > 0; off >>= 1)
+    for (int off = RED_SPAN >> 1; off > 0; off >>= 1)
       partial[t] += __shfl_down(partial[t], off);
   }
 
@@ -882,14 +891,18 @@ __global__ void qmoe_decode_fc2_kernel(
     }
   }
 
-  constexpr int WARP_SIZE = 32;
+  // See the SwiGLU kernel above: express the warp geometry in terms of the real
+  // hardware wave size (32 on RDNA, 64 on CDNA/MI350) and cap the shuffle span
+  // so a sub-wave block never reduces across inactive lanes.
+  constexpr int WARP_SIZE = HIPDNN_WAVE_SIZE;
   const int warp_id = tid / WARP_SIZE;
   const int lane    = tid % WARP_SIZE;
-  constexpr int NUM_WARPS = BLOCK_SIZE / WARP_SIZE;
+  constexpr int NUM_WARPS = BLOCK_SIZE > WARP_SIZE ? BLOCK_SIZE / WARP_SIZE : 1;
+  constexpr int RED_SPAN = BLOCK_SIZE < WARP_SIZE ? BLOCK_SIZE : WARP_SIZE;
 
   #pragma unroll
   for (int t = 0; t < TILE_N; t++) {
-    for (int off = WARP_SIZE >> 1; off > 0; off >>= 1)
+    for (int off = RED_SPAN >> 1; off > 0; off >>= 1)
       partial[t] += __shfl_down(partial[t], off);
   }
 
@@ -1341,13 +1354,17 @@ __global__ void qmoe_quant_act_i8_kernel(
   for (int k = g0 + tid; k < g1; k += BLOCK_SIZE)
     local_max = fmaxf(local_max, fabsf(static_cast<float>(Arow[k])));
 
-  constexpr int WARP_SIZE = 32;
-  constexpr int NUM_WARPS = BLOCK_SIZE / WARP_SIZE;
-  for (int off = WARP_SIZE >> 1; off > 0; off >>= 1)
+  // Wave-portable (32 on RDNA, 64 on CDNA/MI350). RED_SPAN caps the shuffle to
+  // the active lanes when BLOCK_SIZE is smaller than a hardware wave, and the
+  // per-wave fan-in index uses tid / WARP_SIZE rather than a hard-coded /32.
+  constexpr int WARP_SIZE = HIPDNN_WAVE_SIZE;
+  constexpr int NUM_WARPS = BLOCK_SIZE > WARP_SIZE ? BLOCK_SIZE / WARP_SIZE : 1;
+  constexpr int RED_SPAN = BLOCK_SIZE < WARP_SIZE ? BLOCK_SIZE : WARP_SIZE;
+  for (int off = RED_SPAN >> 1; off > 0; off >>= 1)
     local_max = fmaxf(local_max, __shfl_down(local_max, off));
-  __shared__ float smax[NUM_WARPS > 0 ? NUM_WARPS : 1];
+  __shared__ float smax[NUM_WARPS];
   if ((tid & (WARP_SIZE - 1)) == 0)
-    smax[tid >> 5] = local_max;
+    smax[tid / WARP_SIZE] = local_max;
   __syncthreads();
   if (tid == 0) {
     float m = 0.0f;
@@ -1437,8 +1454,8 @@ __global__ void qmoe_decode_fc1_dp4a_kernel(
     int a_sum_q = 0;
 #pragma unroll
     for (int j = 0; j < 4; j++) {
-      a_sum_q = __builtin_amdgcn_sudot4(true, a_lo[j], false, 0x01010101, a_sum_q, false);
-      a_sum_q = __builtin_amdgcn_sudot4(true, a_hi[j], false, 0x01010101, a_sum_q, false);
+      a_sum_q = hipdnn_sudot4(a_lo[j], 0x01010101, a_sum_q);
+      a_sum_q = hipdnn_sudot4(a_hi[j], 0x01010101, a_sum_q);
     }
 
 #pragma unroll
@@ -1450,8 +1467,8 @@ __global__ void qmoe_decode_fc1_dp4a_kernel(
       for (int j = 0; j < 4; j++) {
         const int lo_w = static_cast<int>(comp[j] & 0x0F0F0F0Fu);
         const int hi_w = static_cast<int>((comp[j] >> 4) & 0x0F0F0F0Fu);
-        dot = __builtin_amdgcn_sudot4(true, a_lo[j], false, lo_w, dot, false);
-        dot = __builtin_amdgcn_sudot4(true, a_hi[j], false, hi_w, dot, false);
+        dot = hipdnn_sudot4(a_lo[j], lo_w, dot);
+        dot = hipdnn_sudot4(a_hi[j], hi_w, dot);
       }
       const float sv = static_cast<float>(S_rows[t][grp]);
       int zv = 8;
@@ -1463,10 +1480,13 @@ __global__ void qmoe_decode_fc1_dp4a_kernel(
     }
   }
 
-  constexpr int WARP_SIZE = 32;
+  // Wave-portable warp geometry (32 on RDNA, 64 on CDNA/MI350); see the fp16
+  // SwiGLU kernel above for the RED_SPAN / NUM_WARPS rationale.
+  constexpr int WARP_SIZE = HIPDNN_WAVE_SIZE;
   const int warp_id = tid / WARP_SIZE;
   const int lane    = tid % WARP_SIZE;
-  constexpr int NUM_WARPS = BLOCK_SIZE / WARP_SIZE;
+  constexpr int NUM_WARPS = BLOCK_SIZE > WARP_SIZE ? BLOCK_SIZE / WARP_SIZE : 1;
+  constexpr int RED_SPAN = BLOCK_SIZE < WARP_SIZE ? BLOCK_SIZE : WARP_SIZE;
   static_assert((TILE_N & 1) == 0, "TILE_N must be even for SwiGLU pairing");
   constexpr int TILE_OUT = TILE_N / 2;
   const int sw_base = n_base / 2;
@@ -1474,7 +1494,7 @@ __global__ void qmoe_decode_fc1_dp4a_kernel(
 
 #pragma unroll
   for (int t = 0; t < TILE_N; t++) {
-    for (int off = WARP_SIZE >> 1; off > 0; off >>= 1)
+    for (int off = RED_SPAN >> 1; off > 0; off >>= 1)
       partial[t] += __shfl_down(partial[t], off);
   }
 
@@ -1600,8 +1620,8 @@ __global__ void qmoe_decode_fc2_dp4a_kernel(
     int a_sum_q = 0;
 #pragma unroll
     for (int j = 0; j < 4; j++) {
-      a_sum_q = __builtin_amdgcn_sudot4(true, a_lo[j], false, 0x01010101, a_sum_q, false);
-      a_sum_q = __builtin_amdgcn_sudot4(true, a_hi[j], false, 0x01010101, a_sum_q, false);
+      a_sum_q = hipdnn_sudot4(a_lo[j], 0x01010101, a_sum_q);
+      a_sum_q = hipdnn_sudot4(a_hi[j], 0x01010101, a_sum_q);
     }
 
 #pragma unroll
@@ -1613,8 +1633,8 @@ __global__ void qmoe_decode_fc2_dp4a_kernel(
       for (int j = 0; j < 4; j++) {
         const int lo_w = static_cast<int>(comp[j] & 0x0F0F0F0Fu);
         const int hi_w = static_cast<int>((comp[j] >> 4) & 0x0F0F0F0Fu);
-        dot = __builtin_amdgcn_sudot4(true, a_lo[j], false, lo_w, dot, false);
-        dot = __builtin_amdgcn_sudot4(true, a_hi[j], false, hi_w, dot, false);
+        dot = hipdnn_sudot4(a_lo[j], lo_w, dot);
+        dot = hipdnn_sudot4(a_hi[j], hi_w, dot);
       }
       const float sv = static_cast<float>(S_rows[t][grp]);
       int zv = 8;
@@ -1626,14 +1646,16 @@ __global__ void qmoe_decode_fc2_dp4a_kernel(
     }
   }
 
-  constexpr int WARP_SIZE = 32;
+  // Wave-portable warp geometry (32 on RDNA, 64 on CDNA/MI350); see above.
+  constexpr int WARP_SIZE = HIPDNN_WAVE_SIZE;
   const int warp_id = tid / WARP_SIZE;
   const int lane    = tid % WARP_SIZE;
-  constexpr int NUM_WARPS = BLOCK_SIZE / WARP_SIZE;
+  constexpr int NUM_WARPS = BLOCK_SIZE > WARP_SIZE ? BLOCK_SIZE / WARP_SIZE : 1;
+  constexpr int RED_SPAN = BLOCK_SIZE < WARP_SIZE ? BLOCK_SIZE : WARP_SIZE;
 
 #pragma unroll
   for (int t = 0; t < TILE_N; t++) {
-    for (int off = WARP_SIZE >> 1; off > 0; off >>= 1)
+    for (int off = RED_SPAN >> 1; off > 0; off >>= 1)
       partial[t] += __shfl_down(partial[t], off);
   }
 

--- a/lib/Runtime/Kernels/include/hip_arch_compat.h
+++ b/lib/Runtime/Kernels/include/hip_arch_compat.h
@@ -73,23 +73,46 @@ __device__ static inline int hipdnn_sudot4(int a, int b, int acc) {
 }
 #endif  /* __HIPCC__ */
 
-/* Host-side runtime probe: does the current device run wave64 (CDNA)?  Used by
- * the host dispatch to avoid launching WMMA kernels on CDNA, where they compile
- * to a trap. Cached after the first query. */
+/* Host-side runtime probe for the wavefront size of the *currently selected*
+ * device. Used by the host dispatch to avoid launching WMMA kernels on CDNA
+ * (where they compile to a trap) and to size blocks as whole waves.
+ *
+ * The result is cached per device ordinal rather than once per process: a host
+ * may drive several GPUs of different families (e.g. a gfx1151 APU alongside a
+ * discrete card), and a single cached answer would then be applied to the wrong
+ * device after hipSetDevice. Query failure yields 32, the RDNA/WMMA-capable
+ * default, so dispatch decisions stay as they were before CDNA support. */
 #ifdef __cplusplus
 #include <hip/hip_runtime.h>
-static inline bool hipdnn_device_is_wave64() {
-  static int cached = -1;
-  if (cached < 0) {
-    int dev = 0;
-    hipGetDevice(&dev);
+static inline int hipdnn_device_wave_size() {
+  constexpr int kMaxCachedDevices = 16;
+  // Zero-initialized (0 == not probed yet), so no thread-safe-statics guard is
+  // emitted; concurrent probes race only to write the same value.
+  static int cached[kMaxCachedDevices] = {};
+
+  auto probe = [](int d) {
     hipDeviceProp_t p;
-    if (hipGetDeviceProperties(&p, dev) == hipSuccess)
-      cached = (p.warpSize >= 64) ? 1 : 0;
-    else
-      cached = 0;  // assume wave32/WMMA-capable on query failure (RDNA default)
+    return (hipGetDeviceProperties(&p, d) == hipSuccess && p.warpSize >= 64)
+               ? 64
+               : 32;
+  };
+
+  int dev = 0;
+  if (hipGetDevice(&dev) != hipSuccess || dev < 0)
+    return 32;
+  if (dev >= kMaxCachedDevices)
+    return probe(dev);
+
+  int w = cached[dev];
+  if (w == 0) {
+    w = probe(dev);
+    cached[dev] = w;
   }
-  return cached == 1;
+  return w;
+}
+
+static inline bool hipdnn_device_is_wave64() {
+  return hipdnn_device_wave_size() >= 64;
 }
 #endif
 

--- a/lib/Runtime/Kernels/include/hip_arch_compat.h
+++ b/lib/Runtime/Kernels/include/hip_arch_compat.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2023 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ *
+ * Wavefront-size / matrix-intrinsic portability shim.
+ *
+ * The custom kernels were originally written for RDNA3/RDNA4 (gfx11xx/gfx12xx),
+ * which run wave32 and expose the WMMA matrix intrinsics
+ * (__builtin_amdgcn_wmma_*). CDNA (gfx9xx, e.g. MI300/MI350) runs wave64 and has
+ * no WMMA -- it uses MFMA instead. This header lets the shared kernel sources
+ * compile for both families:
+ *
+ *   HIPDNN_WAVE_SIZE  compile-time wavefront size in the *device* pass
+ *                     (64 on CDNA/gfx9xx, 32 on RDNA/gfx10xx+). Used to make
+ *                     warp-shuffle reductions span the whole wave correctly.
+ *   HIPDNN_HAS_WMMA   1 only in a device pass for an arch that has the WMMA
+ *                     intrinsics (RDNA3/RDNA4). 0 on CDNA and in the host pass,
+ *                     so WMMA code paths compile away (and are never launched --
+ *                     the host dispatch checks the device warpSize at runtime).
+ *
+ * ROCm 7.x no longer defines __AMDGCN_WAVEFRONT_SIZE[_], so we key off the
+ * clang-provided GPU-family macros (__GFX8__, __GFX9__, __GFX11__, __GFX12__).
+ */
+#ifndef HIP_ARCH_COMPAT_H
+#define HIP_ARCH_COMPAT_H
+
+#if defined(__HIP_DEVICE_COMPILE__)
+#  if defined(__GFX8__) || defined(__GFX9__)
+#    define HIPDNN_WAVE_SIZE 64
+#  else
+#    define HIPDNN_WAVE_SIZE 32
+#  endif
+#else
+/* Host pass: value is unused inside __global__ bodies, but must be a valid
+ * compile-time constant for shared-memory sizing etc. */
+#  define HIPDNN_WAVE_SIZE 32
+#endif
+
+#if defined(__HIP_DEVICE_COMPILE__) && (defined(__GFX11__) || defined(__GFX12__))
+#  define HIPDNN_HAS_WMMA 1
+#else
+#  define HIPDNN_HAS_WMMA 0
+#endif
+
+/* Portable 4x8-bit integer dot-product with i32 accumulate (a signed, b treated
+ * as small non-negative bytes -- e.g. unpacked 4-bit weight nibbles 0..15, or
+ * the 0x01010101 mask used to sum a quantized activation vector).
+ *
+ * RDNA3/RDNA4 (gfx11xx/gfx12xx) expose the mixed-sign v_dot4_i32_iu8 via
+ * __builtin_amdgcn_sudot4 (dot8-insts). CDNA (gfx9xx, e.g. MI300/MI350) has no
+ * dot8-insts but does provide the signed v_dot4_i32_i8
+ * (__builtin_amdgcn_sdot4). Because every `b` operand here is a byte in [0,127],
+ * the signed and unsigned interpretations are numerically identical, so the CDNA
+ * signed intrinsic is a drop-in. The scalar branch keeps the host pass (and any
+ * arch without dot instructions) compilable; it is never used for codegen on the
+ * supported GPUs. Only defined in a HIP translation unit. */
+#if defined(__HIPCC__)
+__device__ static inline int hipdnn_sudot4(int a, int b, int acc) {
+#if defined(__HIP_DEVICE_COMPILE__) && (defined(__GFX11__) || defined(__GFX12__))
+  return __builtin_amdgcn_sudot4(true, a, false, b, acc, false);
+#elif defined(__HIP_DEVICE_COMPILE__) && defined(__GFX9__)
+  return __builtin_amdgcn_sdot4(a, b, acc, false);
+#else
+  int r = acc;
+#pragma unroll
+  for (int i = 0; i < 4; ++i) {
+    const int av = static_cast<int>(static_cast<signed char>((a >> (i * 8)) & 0xFF));
+    const int bv = static_cast<int>(static_cast<unsigned char>((b >> (i * 8)) & 0xFF));
+    r += av * bv;
+  }
+  return r;
+#endif
+}
+#endif  /* __HIPCC__ */
+
+/* Host-side runtime probe: does the current device run wave64 (CDNA)?  Used by
+ * the host dispatch to avoid launching WMMA kernels on CDNA, where they compile
+ * to a trap. Cached after the first query. */
+#ifdef __cplusplus
+#include <hip/hip_runtime.h>
+static inline bool hipdnn_device_is_wave64() {
+  static int cached = -1;
+  if (cached < 0) {
+    int dev = 0;
+    hipGetDevice(&dev);
+    hipDeviceProp_t p;
+    if (hipGetDeviceProperties(&p, dev) == hipSuccess)
+      cached = (p.warpSize >= 64) ? 1 : 0;
+    else
+      cached = 0;  // assume wave32/WMMA-capable on query failure (RDNA default)
+  }
+  return cached == 1;
+}
+#endif
+
+#endif  /* HIP_ARCH_COMPAT_H */

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -1717,6 +1717,15 @@ HIP_KERNEL_API void hip_matmul_nbits_unpack_zp_u8_3bit(
 HIP_KERNEL_API void hip_matmul_nbits_convert_zp_fp16(
     void* stream, const void* zp_packed, void* dst_fp16, int N, int groups_k);
 
+/* Dequantize a full packed int4 weight matrix into row-major fp16 [N, K].
+ * Used by the CDNA/wave64 prefill fast path (no WMMA): dequantize B once
+ * (weights are constant) then run a hipBLASLt fp16 GEMM. scales_fp16 and
+ * zeros_fp16 are fp16 [N, ceil(K/group_size)]; zeros_fp16 may be null (ONNX
+ * 4-bit default zero-point 8). */
+HIP_KERNEL_API void hip_matmul_nbits_dequant_b_fp16(
+    void* stream, const void* B_packed, const void* scales_fp16,
+    const void* zeros_fp16, void* B_fp16_out, int N, int K, int group_size);
+
 /* =========================================================================
  * GatherBlockQuantized (com.microsoft)
  * =========================================================================

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -2092,6 +2092,20 @@ int wrap_group_query_attention(
       head_dim_ok && decode_geometry_ok && attention_bias == nullptr &&
       !hipdnn_device_is_wave64();
 
+  // The quantized-cache kernels live exclusively on the fused path, which is
+  // disabled above on wave64 because it is built on the RDNA-only WMMA
+  // intrinsics. A quantized cache therefore has no implementation at all on
+  // CDNA. Reject it here, naming the architecture: the generic check below
+  // would only report fused_supported=0, pointing a reader at the feature gates
+  // (causal / window / sink / bias) instead of the real reason.
+  if (kv_quantized && hipdnn_device_is_wave64()) {
+    fprintf(stderr,
+            "wrap_group_query_attention: quantized KV cache is not supported on "
+            "wave64 devices (CDNA, e.g. MI350) -- its kernels are on the WMMA "
+            "fused path, which is RDNA-only. Use an fp16 KV cache.\n");
+    return -1;
+  }
+
   // A quantized KV cache is implemented ONLY on the fused path (quant decode +
   // fp16 prefill-over-dequant), for head_dim in {64,128}. The legacy decomposed
   // pipeline reads the cache as fp16 and would misinterpret quantized bytes, so

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -2099,10 +2099,11 @@ int wrap_group_query_attention(
   // would only report fused_supported=0, pointing a reader at the feature gates
   // (causal / window / sink / bias) instead of the real reason.
   if (kv_quantized && hipdnn_device_is_wave64()) {
-    fprintf(stderr,
-            "wrap_group_query_attention: quantized KV cache is not supported on "
-            "wave64 devices (CDNA, e.g. MI350) -- its kernels are on the WMMA "
-            "fused path, which is RDNA-only. Use an fp16 KV cache.\n");
+    fprintf(
+        stderr,
+        "wrap_group_query_attention: quantized KV cache is not supported on "
+        "wave64 devices (CDNA, e.g. MI350) -- its kernels are on the WMMA "
+        "fused path, which is RDNA-only. Use an fp16 KV cache.\n");
     return -1;
   }
 

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -52,6 +52,7 @@
 #include "../runtime_state_internal.h"
 #include "cache_utils.h"
 #include "error_check_macros.h"
+#include "hip_arch_compat.h"
 #include "hip_custom_kernels.h"
 #include "runtime_types.h"
 
@@ -755,11 +756,17 @@ static bool gqa_fused_decode_disabled() {
 // (gqa_flash_decode_min_skv) its 2-kernel overhead may not pay back, so we keep
 // the existing fused_decode for short sequences.
 static bool gqa_flash_decode_enabled() {
-  static const bool enabled = [] {
+  static const bool env_enabled = [] {
     const char *v = std::getenv("HIPDNN_EP_GQA_FLASH_DECODE");
     return !v || std::strcmp(v, "0") != 0;
   }();
-  return enabled;
+  // The legacy flash_decode host launcher sizes the block as HPG * WAVE_SIZE
+  // with WAVE_SIZE fixed to the wave32 host constant, while the device kernel's
+  // __launch_bounds__ and per-lane element mapping (EPT = D / WAVE_SIZE)
+  // resolve to the wave64 device constant on CDNA (MI350). The two disagree on
+  // wave64, so disable flash_decode there and let the dispatch fall back to the
+  // wave-agnostic fused_decode kernel -- correct on both wave sizes.
+  return env_enabled && !hipdnn_device_is_wave64();
 }
 
 // Smart-dispatch threshold for the legacy GQA decode (sq == 1). When total_seq
@@ -2075,9 +2082,15 @@ int wrap_group_query_attention(
   // is unverified here; prefill is what the window costs us on gpt-oss.
   const bool window_ok =
       local_window_size <= 0 || (!is_decode && head_dim == 64);
-  const bool fused_supported = element_size_bytes == 2 && no_causal == 0 &&
-                               window_ok && sink_ok && head_dim_ok &&
-                               decode_geometry_ok && attention_bias == nullptr;
+  // The whole fused path (gqa_forward_fused, including the sink and windowed
+  // prefill kernels above) is built on the RDNA-only WMMA intrinsics, which
+  // trap on CDNA (wave64, e.g. MI350). Route wave64 to the decomposed hipBLASLt
+  // pipeline below (MFMA GEMMs + wave-portable scalar kernels), which is
+  // feature-complete and correct on both wave sizes. RDNA is unaffected.
+  const bool fused_supported =
+      element_size_bytes == 2 && no_causal == 0 && window_ok && sink_ok &&
+      head_dim_ok && decode_geometry_ok && attention_bias == nullptr &&
+      !hipdnn_device_is_wave64();
 
   // A quantized KV cache is implemented ONLY on the fused path (quant decode +
   // fp16 prefill-over-dequant), for head_dim in {64,128}. The legacy decomposed

--- a/lib/Runtime/real/matmul_nbits.cpp
+++ b/lib/Runtime/real/matmul_nbits.cpp
@@ -291,16 +291,18 @@ uint64_t prefill_shape_key(int64_t M, int64_t N, int64_t K) {
 // Y[M,N] (row-major, fp16) = A[M,K] @ Bfp16[N,K]^T + (bias[N]).
 //
 // hipBLASLt is column-major, so we compute D = Y^T = [N,M] col-major:
+// clang-format off
 //   matA = Bfp16 : row-major [N,K] == col-major [K,N] ld=K, TRANSA=OP_T -> [N,K]
 //   matB = A     : row-major [M,K] == col-major [K,M] ld=K, TRANSB=OP_N -> [K,M]
 //   D           : col-major [N,M] ld=N == row-major Y[M,N]
+// clang-format on
 // A per-output-channel bias[N] is the per-row vector of D -> BIAS epilogue.
 int matmul_nbits_prefill_hipblaslt(MatmulNbitsState *mst, RuntimeState *state,
                                    const void *A, const void *Bfp16,
                                    const void *bias, void *Y, int64_t M,
                                    int64_t N, int64_t K) {
-  hipblasLtHandle_t handle = static_cast<hipblasLtHandle_t>(
-      hipdnn_ep_state_get_hipblas_handle(state));
+  hipblasLtHandle_t handle =
+      static_cast<hipblasLtHandle_t>(hipdnn_ep_state_get_hipblas_handle(state));
   hipStream_t stream =
       static_cast<hipStream_t>(hipdnn_ep_state_get_stream(state));
   if (!handle || !stream) {
@@ -473,10 +475,9 @@ int matmul_nbits_prefill_hipblaslt(MatmulNbitsState *mst, RuntimeState *state,
     ws_size = hipdnn_ep_state_get_workspace_size(state);
   }
 
-  HIPBLAS_CHECK(hipblasLtMatmul(handle, desc, &alpha, Bfp16, matA, A, matB,
-                                &beta, Y, matD, Y, matD,
-                                have_algo ? &chosen.algo : nullptr, ws, ws_size,
-                                stream));
+  HIPBLAS_CHECK(hipblasLtMatmul(
+      handle, desc, &alpha, Bfp16, matA, A, matB, &beta, Y, matD, Y, matD,
+      have_algo ? &chosen.algo : nullptr, ws, ws_size, stream));
 
 cleanup:
   if (matA)

--- a/lib/Runtime/real/matmul_nbits.cpp
+++ b/lib/Runtime/real/matmul_nbits.cpp
@@ -8,16 +8,23 @@
 #include "../op_state.h"
 #include "../runtime_state_internal.h"
 #include "error_check_macros.h"
+#include "hip_arch_compat.h"
 #include "hip_custom_kernels.h"
+#include "runtime_types.h"
 #include "zp_unpack_cache.h"
 
 #include <hip/hip_runtime.h>
+#include <hipblaslt/hipblaslt-ext.hpp>
 
+#include <cstdint>
 #include <cstdio>
 #include <mutex>
+#include <unordered_map>
 #include <utility>
+#include <vector>
 
 #define HIP_CHECK(cmd) HIP_CHECK_GOTO(cmd, cleanup)
+#define HIPBLAS_CHECK(cmd) HIPBLAS_CHECK_GOTO(cmd, cleanup)
 
 // ---------------------------------------------------------------------------
 // Asym MatMulNBits zero_points unpack cache (ZpUnpackCache).
@@ -199,6 +206,29 @@ extern "C" void hipdnn_ep_zp_unpack_cache_destroy(void *cache_ptr) {
 // share it.
 struct MatmulNbitsState : OpStateT<MatmulNbitsState> {
   hipdnn_ep_real::ZpUnpackCache zp;
+
+  // CDNA/wave64 prefill fast path: dequantized fp16 weights, keyed by the
+  // packed-B device pointer (stable for the model's lifetime, so each weight
+  // is dequantized at most once and reused across every prefill call).
+  std::mutex b_mu;
+  std::unordered_map<const void *, std::pair<void *, size_t>> b_fp16;
+
+  // Per-shape hipBLASLt algo cache for the prefill GEMM. hipBLASLt's default
+  // internal kernel (algo=nullptr) is pathologically slow for some transposed
+  // small-N shapes, so we enumerate + cache a concrete supported algo per
+  // (M,N,K) -- mirrors the gemm.cpp algo selection.
+  struct PrefillAlgo {
+    hipblasLtMatmulAlgo_t algo;
+    size_t ws;
+    bool has_algo; // false => fall back to default algo (nullptr)
+  };
+  std::mutex algo_mu;
+  std::unordered_map<uint64_t, PrefillAlgo> prefill_algos;
+
+  ~MatmulNbitsState() {
+    for (auto &[k, v] : b_fp16)
+      hipFree(v.first);
+  }
 };
 
 extern "C" int8_t hipdnn_ep_op_state_construct_matmul_nbits(RuntimeState *state,
@@ -206,6 +236,261 @@ extern "C" int8_t hipdnn_ep_op_state_construct_matmul_nbits(RuntimeState *state,
   hipdnn_ep_op_state_set(state, slot, MatmulNbitsState::create().release());
   return 0;
 }
+
+// ---------------------------------------------------------------------------
+// CDNA / wave64 int4 prefill fast path.
+//
+// The GEMM prefill fast path in the kernel library uses WMMA intrinsics, which
+// exist only on RDNA3/RDNA4 (wave32). On CDNA (wave64, e.g. MI350X) M>=16
+// prefill would otherwise fall to the naive O(M*N*K) per-element kernel, which
+// is orders of magnitude too slow. Instead we dequantize the (constant) int4
+// weight to fp16 once, cache it, and run a hipBLASLt fp16 GEMM (MFMA) for every
+// subsequent prefill call.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// Returns the cached row-major fp16 [N,K] dequant of `B`, dequantizing on the
+// first use for this weight pointer. Returns nullptr on hipMalloc failure.
+const void *get_or_dequant_b_fp16(MatmulNbitsState *mst, void *stream,
+                                  const void *B, const void *scales_fp16,
+                                  const void *zeros_fp16, int N, int K,
+                                  int group_size) {
+  const size_t bytes =
+      static_cast<size_t>(N) * static_cast<size_t>(K) * sizeof(__fp16);
+
+  std::lock_guard<std::mutex> lock(mst->b_mu);
+  auto it = mst->b_fp16.find(B);
+  if (it != mst->b_fp16.end() && it->second.second >= bytes)
+    return it->second.first;
+
+  void *dst = nullptr;
+  if (hipMalloc(&dst, bytes) != hipSuccess) {
+    fprintf(stderr, "matmul_nbits: hipMalloc(%zu) for fp16 B cache failed\n",
+            bytes);
+    return nullptr;
+  }
+  hip_matmul_nbits_dequant_b_fp16(stream, B, scales_fp16, zeros_fp16, dst, N, K,
+                                  group_size);
+
+  if (it != mst->b_fp16.end()) {
+    hipFree(it->second.first);
+    it->second = {dst, bytes};
+  } else {
+    mst->b_fp16.emplace(B, std::make_pair(dst, bytes));
+  }
+  return dst;
+}
+
+uint64_t prefill_shape_key(int64_t M, int64_t N, int64_t K) {
+  return ((static_cast<uint64_t>(M) & 0xFFFFF) << 44) |
+         ((static_cast<uint64_t>(N) & 0x3FFFFF) << 22) |
+         (static_cast<uint64_t>(K) & 0x3FFFFF);
+}
+
+// Y[M,N] (row-major, fp16) = A[M,K] @ Bfp16[N,K]^T + (bias[N]).
+//
+// hipBLASLt is column-major, so we compute D = Y^T = [N,M] col-major:
+//   matA = Bfp16 : row-major [N,K] == col-major [K,N] ld=K, TRANSA=OP_T -> [N,K]
+//   matB = A     : row-major [M,K] == col-major [K,M] ld=K, TRANSB=OP_N -> [K,M]
+//   D           : col-major [N,M] ld=N == row-major Y[M,N]
+// A per-output-channel bias[N] is the per-row vector of D -> BIAS epilogue.
+int matmul_nbits_prefill_hipblaslt(MatmulNbitsState *mst, RuntimeState *state,
+                                   const void *A, const void *Bfp16,
+                                   const void *bias, void *Y, int64_t M,
+                                   int64_t N, int64_t K) {
+  hipblasLtHandle_t handle = static_cast<hipblasLtHandle_t>(
+      hipdnn_ep_state_get_hipblas_handle(state));
+  hipStream_t stream =
+      static_cast<hipStream_t>(hipdnn_ep_state_get_stream(state));
+  if (!handle || !stream) {
+    fprintf(stderr, "matmul_nbits prefill: null hipBLASLt handle/stream\n");
+    return -1;
+  }
+
+  // All resources/locals declared up front so the HIPBLAS_CHECK gotos never
+  // jump past an initialization into the shared cleanup label's scope.
+  hipblasLtMatrixLayout_t matA = nullptr, matB = nullptr, matD = nullptr;
+  hipblasLtMatmulDesc_t desc = nullptr;
+  hipblasOperation_t opT = HIPBLAS_OP_T, opN = HIPBLAS_OP_N;
+  hipblasLtEpilogue_t epi = HIPBLASLT_EPILOGUE_BIAS;
+  hipDataType bias_dtype = HIP_R_16F;
+  float alpha = 1.0f, beta = 0.0f;
+  void *ws = nullptr;
+  size_t ws_size = 0;
+  uint64_t key = prefill_shape_key(M, N, K);
+  MatmulNbitsState::PrefillAlgo chosen{};
+  bool have_algo = false;
+  int result = 0;
+
+  HIPBLAS_CHECK(hipblasLtMatrixLayoutCreate(&matA, HIP_R_16F, K, N, K));
+  HIPBLAS_CHECK(hipblasLtMatrixLayoutCreate(&matB, HIP_R_16F, K, M, K));
+  HIPBLAS_CHECK(hipblasLtMatrixLayoutCreate(&matD, HIP_R_16F, N, M, N));
+  HIPBLAS_CHECK(
+      hipblasLtMatmulDescCreate(&desc, HIPBLAS_COMPUTE_32F, HIP_R_32F));
+  HIPBLAS_CHECK(hipblasLtMatmulDescSetAttribute(
+      desc, HIPBLASLT_MATMUL_DESC_TRANSA, &opT, sizeof(opT)));
+  HIPBLAS_CHECK(hipblasLtMatmulDescSetAttribute(
+      desc, HIPBLASLT_MATMUL_DESC_TRANSB, &opN, sizeof(opN)));
+
+  if (bias) {
+    HIPBLAS_CHECK(hipblasLtMatmulDescSetAttribute(
+        desc, HIPBLASLT_MATMUL_DESC_EPILOGUE, &epi, sizeof(epi)));
+    HIPBLAS_CHECK(hipblasLtMatmulDescSetAttribute(
+        desc, HIPBLASLT_MATMUL_DESC_BIAS_POINTER, &bias, sizeof(bias)));
+    HIPBLAS_CHECK(hipblasLtMatmulDescSetAttribute(
+        desc, HIPBLASLT_MATMUL_DESC_BIAS_DATA_TYPE, &bias_dtype,
+        sizeof(bias_dtype)));
+  }
+
+  // Look up (or select + cache) a concrete algo for this shape.
+  {
+    std::lock_guard<std::mutex> lock(mst->algo_mu);
+    auto it = mst->prefill_algos.find(key);
+    if (it != mst->prefill_algos.end()) {
+      chosen = it->second;
+      have_algo = chosen.has_algo;
+    } else {
+      // Cold miss: collect candidates (perf-ranked heuristic first, then the
+      // full enumeration as a fallback) and benchmark them into a scratch
+      // buffer, caching the fastest. hipBLASLt's default internal kernel
+      // (algo=nullptr) is used only if no candidate can be timed -- it is a
+      // good path for large N but pathologically slow for some small-N shapes.
+      constexpr int kMax = 24;
+      std::vector<hipblasLtMatmulHeuristicResult_t> cands;
+      {
+        hipblasLtMatmulPreference_t pref = nullptr;
+        if (hipblasLtMatmulPreferenceCreate(&pref) == HIPBLAS_STATUS_SUCCESS) {
+          uint64_t max_ws = 128ull * 1024 * 1024;
+          hipblasLtMatmulPreferenceSetAttribute(
+              pref, HIPBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES, &max_ws,
+              sizeof(max_ws));
+          hipblasLtMatmulHeuristicResult_t heur[kMax];
+          int returned = 0;
+          hipblasLtMatmulAlgoGetHeuristic(handle, desc, matA, matB, matD, matD,
+                                          pref, kMax, heur, &returned);
+          for (int i = 0; i < returned; ++i)
+            cands.push_back(heur[i]);
+          hipblasLtMatmulPreferenceDestroy(pref);
+        }
+      }
+      if (cands.empty()) {
+        std::vector<hipblasLtMatmulHeuristicResult_t> all;
+        if (hipblaslt_ext::getAllAlgos(
+                handle, hipblaslt_ext::GemmType::HIPBLASLT_GEMM, opT, opN,
+                HIP_R_16F, HIP_R_16F, HIP_R_16F, HIP_R_16F, HIPBLAS_COMPUTE_32F,
+                all) == HIPBLAS_STATUS_SUCCESS) {
+          for (auto &r : all) {
+            if (static_cast<int>(cands.size()) >= kMax)
+              break;
+            size_t need = 0;
+            if (hipblaslt_ext::matmulIsAlgoSupported(
+                    handle, desc, &alpha, matA, matB, &beta, matD, matD, r.algo,
+                    need) == HIPBLAS_STATUS_SUCCESS) {
+              r.workspaceSize = need;
+              cands.push_back(r);
+            }
+          }
+        }
+      }
+
+      // Time every candidate (warmup + 3 iters), plus the default kernel
+      // (algo=nullptr), and keep the fastest.
+      size_t maxws = 0;
+      for (auto &c : cands)
+        if (c.workspaceSize > maxws)
+          maxws = c.workspaceSize;
+      void *bench_ws = nullptr;
+      size_t bench_ws_size = 0;
+      if (maxws > 0 && hipdnn_ep_state_ensure_workspace(state, maxws) == 0) {
+        bench_ws = hipdnn_ep_state_get_workspace(state);
+        bench_ws_size = hipdnn_ep_state_get_workspace_size(state);
+      }
+      void *bench_out = nullptr;
+      size_t bench_bytes =
+          static_cast<size_t>(M) * static_cast<size_t>(N) * sizeof(__fp16);
+      hipEvent_t bs = nullptr, be = nullptr;
+      double best_ms = 1e30;
+      if (bench_bytes > 0 && hipMalloc(&bench_out, bench_bytes) == hipSuccess &&
+          hipEventCreate(&bs) == hipSuccess &&
+          hipEventCreate(&be) == hipSuccess) {
+        // Candidate index -1 == the default internal kernel (algo=nullptr).
+        for (int i = -1; i < static_cast<int>(cands.size()); ++i) {
+          size_t wss = (i < 0) ? 0 : cands[i].workspaceSize;
+          if (wss > bench_ws_size)
+            continue;
+          void *wsp = (wss > 0) ? bench_ws : nullptr;
+          hipblasLtMatmulAlgo_t *ap = (i < 0) ? nullptr : &cands[i].algo;
+          auto run = [&]() {
+            return hipblasLtMatmul(handle, desc, &alpha, Bfp16, matA, A, matB,
+                                   &beta, bench_out, matD, bench_out, matD, ap,
+                                   wsp, wss, stream);
+          };
+          if (run() != HIPBLAS_STATUS_SUCCESS)
+            continue;
+          if (hipEventRecord(bs, stream) != hipSuccess)
+            continue;
+          for (int r = 0; r < 3; ++r)
+            run();
+          if (hipEventRecord(be, stream) != hipSuccess)
+            continue;
+          if (hipEventSynchronize(be) != hipSuccess)
+            continue;
+          float ms = 0.0f;
+          if (hipEventElapsedTime(&ms, bs, be) != hipSuccess)
+            continue;
+          if (ms < best_ms) {
+            best_ms = ms;
+            if (i < 0) {
+              have_algo = false; // default kernel wins
+            } else {
+              chosen.algo = cands[i].algo;
+              chosen.ws = cands[i].workspaceSize;
+              have_algo = true;
+            }
+          }
+        }
+      }
+      if (bs)
+        hipEventDestroy(bs);
+      if (be)
+        hipEventDestroy(be);
+      if (bench_out)
+        hipFree(bench_out);
+
+      chosen.has_algo = have_algo;
+      mst->prefill_algos.emplace(key, chosen);
+    }
+  }
+
+  ws_size = have_algo ? chosen.ws : 0;
+  if (ws_size > 0) {
+    if (hipdnn_ep_state_ensure_workspace(state, ws_size) != 0) {
+      result = -1;
+      goto cleanup;
+    }
+    ws = hipdnn_ep_state_get_workspace(state);
+    ws_size = hipdnn_ep_state_get_workspace_size(state);
+  }
+
+  HIPBLAS_CHECK(hipblasLtMatmul(handle, desc, &alpha, Bfp16, matA, A, matB,
+                                &beta, Y, matD, Y, matD,
+                                have_algo ? &chosen.algo : nullptr, ws, ws_size,
+                                stream));
+
+cleanup:
+  if (matA)
+    hipblasLtMatrixLayoutDestroy(matA);
+  if (matB)
+    hipblasLtMatrixLayoutDestroy(matB);
+  if (matD)
+    hipblasLtMatrixLayoutDestroy(matD);
+  if (desc)
+    hipblasLtMatmulDescDestroy(desc);
+  return result;
+}
+
+} // namespace
 
 int wrap_matmul_nbits(RuntimeState *state, int op_state_slot, const void *A,
                       const void *B, const void *scales,
@@ -335,6 +620,41 @@ int wrap_matmul_nbits(RuntimeState *state, int op_state_slot, const void *A,
             "[REAL] matmul_nbits dp4a rc=%d, falling back to fp GEMV\n", rc);
       }
     }
+  }
+
+  // CDNA/wave64 prefill fast path: dequantize B -> fp16 once and run a
+  // hipBLASLt fp16 GEMM (MFMA). The kernel library's WMMA prefill path is
+  // wave32-only, so on wave64 a large-M GEMM would otherwise hit the naive
+  // fallback. Only int4 fp16 GEMM shapes (batch==1, K%32==0, M>=16) qualify.
+  if (hipdnn_device_is_wave64() && bits == 4 && batch_count == 1 &&
+      (K % 32 == 0) && M >= 16 && elem_size == 2 && block_size > 0) {
+    const void *zeros_fp16 = nullptr;
+    bool zeros_ok = true;
+    if (zero_points) {
+      if (zp_elem_size == 2)
+        zeros_fp16 = zero_points; // already fp16 [N, num_groups_k]
+      else if (pre_zp_fp16)
+        zeros_fp16 = pre_zp_fp16; // asym packed -> converted above
+      else
+        zeros_ok = false; // asym but no fp16 zp available; use slow path
+    }
+
+    if (zeros_ok) {
+      MatmulNbitsState *mst =
+          MatmulNbitsState::get_op_state(state, op_state_slot);
+      if (mst) {
+        const void *b_fp16 = get_or_dequant_b_fp16(
+            mst, stream, B, scales, zeros_fp16, static_cast<int>(N),
+            static_cast<int>(K), static_cast<int>(block_size));
+        if (b_fp16) {
+          result = matmul_nbits_prefill_hipblaslt(mst, state, A, b_fp16, bias,
+                                                  output, M, N, K);
+          goto cleanup;
+        }
+      }
+    }
+    // Any miss (no op-state, alloc failure, unsupported zp) falls through to
+    // the general kernel dispatch below.
   }
 
   HIP_CHECK(hip_matmul_nbits(stream, A, B, scales, zero_points, bias, output, M,

--- a/lib/Runtime/real/multi_head_attention.cpp
+++ b/lib/Runtime/real/multi_head_attention.cpp
@@ -9,6 +9,7 @@
 #include "../op_state.h"
 #include "cache_utils.h"
 #include "error_check_macros.h"
+#include "hip_arch_compat.h"
 #include "hip_custom_kernels.h"
 #include "runtime_types.h"
 
@@ -481,7 +482,12 @@ extern "C" int wrap_multi_head_attention(
   // O stay in their native BSND layout (no Q/O transpose). Always on for
   // eligible shapes; the decomposed path below still handles the ineligible
   // cases (decode Sq==1, causal/unidirectional, head-dim>256).
-  if (Sq > 1 && unidirectional != 1 && (((H + 15) / 16) * 16) <= 256) {
+  //
+  // The kernel is built on the RDNA-only wave32 WMMA intrinsic, which compiles
+  // to __builtin_trap() on CDNA (wave64, e.g. MI350) and aborts the HSA queue
+  // on launch, so wave64 takes the decomposed path instead.
+  if (Sq > 1 && unidirectional != 1 && (((H + 15) / 16) * 16) <= 256 &&
+      !hipdnn_device_is_wave64()) {
     const size_t fa_align = 64;
     auto fa_align_up = [&](size_t v) {
       return (v + fa_align - 1) & ~(fa_align - 1);

--- a/morphizen/3rd-party/onnxruntime-morphizen-headers/morphizen/export.h
+++ b/morphizen/3rd-party/onnxruntime-morphizen-headers/morphizen/export.h
@@ -12,7 +12,12 @@
 #define MORPHIZEN_DLL_SPEC
 #endif
 #else
-#define MORPHIZEN_DLL_SPEC __attribute__((visibility("default")))
+// Empty on non-Windows: protobuf v34's generated *.pb.h emits
+//   class MORPHIZEN_DLL_SPEC [[gnu::warn_unused]] Name
+// and GCC rejects a GNU __attribute__ placed before the C++11 [[...]]
+// attribute (clang tolerates it). Default ELF visibility already exports these
+// symbols, so an empty decoration is correct and portable across GCC and clang.
+#define MORPHIZEN_DLL_SPEC
 #endif
 
 #if defined(_WIN32)

--- a/morphizen/3rd-party/onnxruntime-morphizen-headers/morphizen/export.h
+++ b/morphizen/3rd-party/onnxruntime-morphizen-headers/morphizen/export.h
@@ -12,12 +12,24 @@
 #define MORPHIZEN_DLL_SPEC
 #endif
 #else
-// Empty on non-Windows: protobuf v34's generated *.pb.h emits
-//   class MORPHIZEN_DLL_SPEC [[gnu::warn_unused]] Name
-// and GCC rejects a GNU __attribute__ placed before the C++11 [[...]]
-// attribute (clang tolerates it). Default ELF visibility already exports these
-// symbols, so an empty decoration is correct and portable across GCC and clang.
-#define MORPHIZEN_DLL_SPEC
+#define MORPHIZEN_DLL_SPEC __attribute__((visibility("default")))
+#endif
+
+// Decoration protoc stamps on the generated *.pb.h classes (passed as
+// --cpp_out=dllexport_decl=...). It is deliberately NOT MORPHIZEN_DLL_SPEC:
+// protobuf v34 emits
+//   class MORPHIZEN_PROTO_DLL_SPEC [[gnu::warn_unused]] Name
+// and GCC rejects a GNU __attribute__ placed before a C++11 [[...]] attribute
+// (only clang tolerates it). Generated protobuf symbols do not need the
+// decoration on ELF -- default visibility plus the `*morphizen*` version script
+// already export them -- so it is empty there, while the hand-written API above
+// keeps its explicit visibility attribute. Keep in sync with the
+// MORPHIZEN_PROTO_DLL_SPEC compile definition in morphizen-core/cmake/
+// proto.cmake and morphizen-pattern/CMakeLists.txt.
+#if defined(_WIN32)
+#define MORPHIZEN_PROTO_DLL_SPEC MORPHIZEN_DLL_SPEC
+#else
+#define MORPHIZEN_PROTO_DLL_SPEC
 #endif
 
 #if defined(_WIN32)

--- a/morphizen/morphizen-core/cmake/proto.cmake
+++ b/morphizen/morphizen-core/cmake/proto.cmake
@@ -23,7 +23,7 @@ foreach(PROTO_FILE ${PROTO_FILES})
     COMMAND protobuf::protoc
     ARGS
       --proto_path=${protobuf_SOURCE_DIR}/src
-      --cpp_out=dllexport_decl=MORPHIZEN_DLL_SPEC:${CMAKE_CURRENT_BINARY_DIR}/morphizen
+      --cpp_out=dllexport_decl=MORPHIZEN_PROTO_DLL_SPEC:${CMAKE_CURRENT_BINARY_DIR}/morphizen
       -I ${CMAKE_CURRENT_SOURCE_DIR}/src
       ${CMAKE_CURRENT_SOURCE_DIR}/${PROTO_FILE}
     DEPENDS ${PROTO_FILE})
@@ -32,23 +32,25 @@ foreach(PROTO_FILE ${PROTO_FILES})
 endforeach(PROTO_FILE ${PROTO_FILES})
 
 if(MSVC)
-  set(MORPHIZEN_DLL_SPEC "__declspec(dllexport)")
+  set(MORPHIZEN_PROTO_DLL_SPEC "__declspec(dllexport)")
   set_source_files_properties(
     ${PROTO_SRCS}
-    PROPERTIES COMPILE_DEFINITIONS "MORPHIZEN_DLL_SPEC=${MORPHIZEN_DLL_SPEC}"
+    PROPERTIES COMPILE_DEFINITIONS "MORPHIZEN_PROTO_DLL_SPEC=${MORPHIZEN_PROTO_DLL_SPEC}"
     COMPILE_FLAGS "/w")
 else(MSVC)
-  # Leave the dllexport decoration empty on non-MSVC toolchains. protobuf v34's
-  # generated code emits `class <DLL_SPEC> [[gnu::warn_unused]] Name`; a GNU
-  # __attribute__ placed before the C++11 [[...]] attribute is rejected by GCC
-  # (only accepted by clang). On Linux the default symbol visibility already
-  # exports these proto symbols, so an empty decoration is both correct and
-  # portable across GCC and clang hosts.
+  # Empty decoration for the generated protobuf classes only (the hand-written
+  # API keeps __attribute__((visibility("default"))) via morphizen/export.h).
+  # protobuf v34 emits `class <decl> [[gnu::warn_unused]] Name`, and GCC rejects
+  # a GNU __attribute__ placed before a C++11 [[...]] attribute. Default ELF
+  # visibility plus the `*morphizen*` version script already export these
+  # symbols, so dropping the decoration here costs nothing. Must stay in sync
+  # with MORPHIZEN_PROTO_DLL_SPEC in morphizen/export.h, which supplies the
+  # macro to every other translation unit that includes the generated *.pb.h.
   set_source_files_properties(
     ${PROTO_SRCS}
     PROPERTIES
     COMPILE_DEFINITIONS
-    "MORPHIZEN_DLL_SPEC="
+    "MORPHIZEN_PROTO_DLL_SPEC="
     COMPILE_FLAGS
     "-Wno-unused-variable -Wno-conversion")
 endif(MSVC)

--- a/morphizen/morphizen-core/cmake/proto.cmake
+++ b/morphizen/morphizen-core/cmake/proto.cmake
@@ -38,11 +38,17 @@ if(MSVC)
     PROPERTIES COMPILE_DEFINITIONS "MORPHIZEN_DLL_SPEC=${MORPHIZEN_DLL_SPEC}"
     COMPILE_FLAGS "/w")
 else(MSVC)
+  # Leave the dllexport decoration empty on non-MSVC toolchains. protobuf v34's
+  # generated code emits `class <DLL_SPEC> [[gnu::warn_unused]] Name`; a GNU
+  # __attribute__ placed before the C++11 [[...]] attribute is rejected by GCC
+  # (only accepted by clang). On Linux the default symbol visibility already
+  # exports these proto symbols, so an empty decoration is both correct and
+  # portable across GCC and clang hosts.
   set_source_files_properties(
     ${PROTO_SRCS}
     PROPERTIES
     COMPILE_DEFINITIONS
-    "MORPHIZEN_DLL_SPEC=__attribute__((visibility(\"default\")))"
+    "MORPHIZEN_DLL_SPEC="
     COMPILE_FLAGS
     "-Wno-unused-variable -Wno-conversion")
 endif(MSVC)

--- a/morphizen/morphizen-pattern/CMakeLists.txt
+++ b/morphizen/morphizen-pattern/CMakeLists.txt
@@ -25,7 +25,7 @@ foreach(PROTO_FILE ${PROTO_FILES})
     COMMAND protobuf::protoc
     ARGS
       --proto_path=${protobuf_SOURCE_DIR}/src
-      --cpp_out=dllexport_decl=MORPHIZEN_DLL_SPEC:${CMAKE_CURRENT_BINARY_DIR}/morphizen
+      --cpp_out=dllexport_decl=MORPHIZEN_PROTO_DLL_SPEC:${CMAKE_CURRENT_BINARY_DIR}/morphizen
       -I ${CMAKE_CURRENT_SOURCE_DIR}/proto
       ${CMAKE_CURRENT_SOURCE_DIR}/${PROTO_FILE}
     DEPENDS ${PROTO_FILE})
@@ -34,23 +34,25 @@ foreach(PROTO_FILE ${PROTO_FILES})
 endforeach(PROTO_FILE ${PROTO_FILES})
 
 if(MSVC)
-  set(MORPHIZEN_DLL_SPEC "__declspec(dllexport)")
+  set(MORPHIZEN_PROTO_DLL_SPEC "__declspec(dllexport)")
   set_source_files_properties(
     ${PROTO_SRCS}
-    PROPERTIES COMPILE_DEFINITIONS "MORPHIZEN_DLL_SPEC=${MORPHIZEN_DLL_SPEC}"
+    PROPERTIES COMPILE_DEFINITIONS "MORPHIZEN_PROTO_DLL_SPEC=${MORPHIZEN_PROTO_DLL_SPEC}"
     COMPILE_FLAGS "/w")
 else(MSVC)
-  # Leave the dllexport decoration empty on non-MSVC toolchains. protobuf v34's
-  # generated code emits `class <DLL_SPEC> [[gnu::warn_unused]] Name`; a GNU
-  # __attribute__ placed before the C++11 [[...]] attribute is rejected by GCC
-  # (only accepted by clang). On Linux the default symbol visibility already
-  # exports these proto symbols, so an empty decoration is both correct and
-  # portable across GCC and clang hosts.
+  # Empty decoration for the generated protobuf classes only (the hand-written
+  # API keeps __attribute__((visibility("default"))) via morphizen/export.h).
+  # protobuf v34 emits `class <decl> [[gnu::warn_unused]] Name`, and GCC rejects
+  # a GNU __attribute__ placed before a C++11 [[...]] attribute. Default ELF
+  # visibility plus the `*morphizen*` version script already export these
+  # symbols, so dropping the decoration here costs nothing. Must stay in sync
+  # with MORPHIZEN_PROTO_DLL_SPEC in morphizen/export.h, which supplies the
+  # macro to every other translation unit that includes the generated *.pb.h.
   set_source_files_properties(
     ${PROTO_SRCS}
     PROPERTIES
     COMPILE_DEFINITIONS
-    "MORPHIZEN_DLL_SPEC="
+    "MORPHIZEN_PROTO_DLL_SPEC="
     COMPILE_FLAGS
     "-Wno-unused-variable -Wno-conversion")
 endif(MSVC)

--- a/morphizen/morphizen-pattern/CMakeLists.txt
+++ b/morphizen/morphizen-pattern/CMakeLists.txt
@@ -40,11 +40,17 @@ if(MSVC)
     PROPERTIES COMPILE_DEFINITIONS "MORPHIZEN_DLL_SPEC=${MORPHIZEN_DLL_SPEC}"
     COMPILE_FLAGS "/w")
 else(MSVC)
+  # Leave the dllexport decoration empty on non-MSVC toolchains. protobuf v34's
+  # generated code emits `class <DLL_SPEC> [[gnu::warn_unused]] Name`; a GNU
+  # __attribute__ placed before the C++11 [[...]] attribute is rejected by GCC
+  # (only accepted by clang). On Linux the default symbol visibility already
+  # exports these proto symbols, so an empty decoration is both correct and
+  # portable across GCC and clang hosts.
   set_source_files_properties(
     ${PROTO_SRCS}
     PROPERTIES
     COMPILE_DEFINITIONS
-    "MORPHIZEN_DLL_SPEC=__attribute__((visibility(\"default\")))"
+    "MORPHIZEN_DLL_SPEC="
     COMPILE_FLAGS
     "-Wno-unused-variable -Wno-conversion")
 endif(MSVC)


### PR DESCRIPTION
<!--
Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
Licensed under the MIT License.
-->
## Summary

Enablement of hip-ep on MI350X (gfx950 / CDNA4 / wave64)

- GQA softmax launches now take their block-size floor from the runtime wave size
  instead of a hard-coded 64, which restores the original block geometry on
  wave32.
- The protobuf `dllexport_decl` workaround is narrowed to a new
  `MORPHIZEN_PROTO_DLL_SPEC`, so it no longer strips the visibility attribute
  from morphizen's hand-written public API headers.

## Why

**Softmax block floor.** The wave64 port raised the softmax block-size floor to a
hard-coded 64 for a real reason: a 32-thread block is a partial wave on CDNA, and
the inactive upper lanes get folded into the `__shfl_xor` reduction. But the floor
is unconditional, so it also applies on RDNA, where it forces a second wave for
every row count <= 32 — the common decode shape — with nothing to show for it.
The floor needs to be the *device's* wave size, not the larger of the two.

`num_waves` has to be derived from that same value, because it sizes the dynamic
LDS fan-in buffer and must match what the kernel computes internally
(`blockDim.x / WAVE_SIZE`). Previously it used `HIPDNN_WAVE_SIZE`, which the host
pass hardcodes to 32, so on gfx950 that buffer was over-allocated by 2x.

**Wave-size probe caching.** The probe cached a single answer for the whole
process. A host can drive GPUs from different families at once (e.g. a gfx1151 APU
alongside a discrete card), where that cached answer gets applied to the wrong
device after `hipSetDevice`.

**Export macro over-reach.** protobuf v34 emits
`class <decl> [[gnu::warn_unused]] Name`, and GCC rejects a GNU `__attribute__`
placed before a C++11 `[[...]]` attribute, so the decoration has to be empty on
ELF. The previous fix achieved that by emptying `MORPHIZEN_DLL_SPEC` itself — but
that macro also decorates roughly thirty hand-written public API headers
(`graph.hpp`, `pass.hpp` and friends), not just generated code.

That is harmless today because nothing is built with `-fvisibility=hidden`, which
is exactly what makes it worth fixing now: it is a silent trap. If hidden
visibility ever reaches these targets, the public API stops being exported and the
only symptom is a link failure in a downstream consumer. Splitting the macro keeps
the workaround where it belongs and costs nothing.

## What

- `hip_arch_compat.h`: replace `hipdnn_device_is_wave64()` with
  `hipdnn_device_wave_size()` returning 32 or 64, cached per device ordinal (up to
  16) with an uncached probe beyond that. The cache array is zero-initialized so
  no thread-safe-statics guard is emitted, which matters because this header is
  compiled into bitcode with `-fPIC`. A failed query still yields the wave32
  default. `hipdnn_device_is_wave64()` is kept as a thin wrapper.
- `gqa_kernel.hip`: both softmax launchers (`launch_softmax_f32_to_out`,
  `hip_gqa_softmax_inplace`) seed `threads` and compute `num_waves` from
  `hipdnn_device_wave_size()`.
- `morphizen/export.h`: restore `MORPHIZEN_DLL_SPEC` to
  `__attribute__((visibility("default")))`; add `MORPHIZEN_PROTO_DLL_SPEC`, empty
  on ELF and `__declspec(dllexport)` on Windows.
- `morphizen-core/cmake/proto.cmake`, `morphizen-pattern/CMakeLists.txt`: pass
  `--cpp_out=dllexport_decl=MORPHIZEN_PROTO_DLL_SPEC` and define that macro on the
  generated sources instead. Windows behavior is unchanged.

## Test plan

Built and measured on an 8x MI350X host (gfx950, EPYC 9965, ROCm 7.2.0,
ONNX Runtime 1.25.1):

```bash
python build.py --build_dir /data/mm/onnxbuild/build_hipep \
  --install_dir /data/mm/onnxbuild/install_hipep --hip_arch gfx950 \
  --therock_dist /opt/rocm \
  --cmake_prefix_path /data/mm/onnxbuild/build/_deps/onnxruntime-src \
  --skip_submodule_sync --skip_wheel --skip_tests -j 384
```

Build is clean — no new warnings or errors.

**Artifact-level equivalence (gfx950).** The strongest evidence that this is inert
on CDNA:

| Artifact | Pre-fix vs post-fix |
|---|---|
| `libhipgpu.so` | byte-identical (same SHA-256) |
| `libcustom_kernels_gfx950.so` `.hip_fatbin` | byte-identical — device ISA unchanged |
| `libcustom_kernels_gfx950.so` (whole file) | differs only in host launcher code |

`libhipgpu.so` coming out bit-identical also validates the export split: every
morphizen TU and all six regenerated `.pb.cc` files recompiled against the new
header, and the link output did not change a byte. 2737 `morphizen` symbols remain
in `.dynsym` with `GLOBAL DEFAULT` binding.

**End-to-end sweep.** OGA `model_benchmark`, batch 1, generate 128, 1 warmup +
3 reps, via `run_sweep.sh`. See the Performance table below. Decode is flat within
1% and peak working set is identical everywhere.

**Interleaved A/B.** TTFT scatters in both directions across the sweep, so the
largest apparent gap (phi-4 L=128) was re-measured by swapping only
`libcustom_kernels_gfx950.so` and alternating arms A,B,A,B at 10 reps per launch:
pre averaged 48.5 ms (50.2 / 49.6 / 43.7 / 50.5), post averaged 46.0 ms
(45.0 / 44.4 / 48.5). The post-fix arm is marginally faster, so the sweep figure
was noise.

**Output correctness.** All six runs completed full 128-token generations with
coherent, on-topic text and no NaN/Inf tokens. Stricter text-equality is not
available on this harness: `gpt-oss-20b` has `do_sample: true, top_k: 50`, and even
greedy `phi-4` is not reproducible run-to-run because the wave64 INT4 prefill path
benchmarks hipBLASLt candidates and caches the winner, so a timing-dependent
algorithm choice shifts rounding. Two runs of the *same* pre-fix binary already
diverge. Against that floor the post-fix build reproduces two of three greedy runs
exactly against each baseline — the same rate the two baselines achieve against
each other.

**wave32 side.** Verified by building for gfx1100 and diffing the generated device
ISA against the pre-wave64-port revision (unchanged apart from the content-hash
symbol). Not runtime-tested — see Notes.

## Performance

Baseline is the pre-fix build measured on the same machine on the same day.

| Metric | Model | L | Before | After |
|---|---|---:|---:|---:|
| TTFT | phi-4 | 128 | 45.5 ms | 53.9 ms |
| TTFT | phi-4 | 512 | 173.6 ms | 141.7 ms |
| TTFT | phi-4 | 2048 | 550.1 ms | 622.8 ms |
| TTFT | gpt-oss-20b | 128 | 683.9 ms | 711.2 ms |
| TTFT | gpt-oss-20b | 512 | 2945 ms | 3007 ms |
| TTFT | gpt-oss-20b | 2048 | 11154 ms | 10923 ms |
| Decode | phi-4 | 128 | 54.0 tok/s | 54.1 tok/s |
| Decode | phi-4 | 512 | 106.5 tok/s | 107.9 tok/s |
| Decode | phi-4 | 2048 | 64.6 tok/s | 64.9 tok/s |
| Decode | gpt-oss-20b | 128 | 238.8 tok/s | 238.1 tok/s |
| Decode | gpt-oss-20b | 512 | 210.5 tok/s | 211.7 tok/s |
| Decode | gpt-oss-20b | 2048 | 107.2 tok/s | 110.4 tok/s |

TTFT moves in both directions and is within run-to-run variance: within-run stddev
on phi-4 TTFT is 3–5 ms at L=128 and 42–54 ms at L=2048. The interleaved A/B above
settles the one case that looked like a regression.

Hardware, workload, build configuration, and measurement method: 8x AMD Instinct
MI350X (gfx950, CDNA4, wave64), pinned to device 0, others idle; AMD EPYC
9965 192-core host; ROCm 7.2.0; ONNX Runtime 1.25.1; models phi-4 (14B dense) and
gpt-oss-20b (MoE), both INT4 RTN block-32; OGA `model_benchmark`, batch 1,
generate 128, 1 warmup + 3 measured reps; build command as above.


