### PR TITLE
feat(hipsr): add pool-alloc greedy grouping

### DIFF
--- a/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
+++ b/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
@@ -13,8 +13,10 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Interfaces/DestinationStyleOpInterface.h"
 
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
 
 #include <cstddef>
 #include <optional>
@@ -68,8 +70,57 @@ llvm::DenseMap<Value, Lifetime> computeLiveness(Block &body) {
   return lifetimes;
 }
 
+llvm::SmallVector<llvm::SmallVector<Value>>
+greedyGrouping(Block &body, const llvm::DenseMap<Value, Lifetime> &lifetimes) {
+  llvm::SmallVector<Value> allocs;
+  for (Operation &op : body) {
+    auto allocOp = dyn_cast<memref::AllocOp>(&op);
+    if (!allocOp) {
+      continue;
+    }
+    if (lifetimes.contains(allocOp.getResult())) {
+      allocs.push_back(allocOp.getResult());
+    }
+  }
+  llvm::stable_sort(allocs, [&](Value a, Value b) {
+    return lifetimes.lookup(a).start < lifetimes.lookup(b).start;
+  });
+
+  auto overlaps = [](const Lifetime &a, const Lifetime &b) {
+    return !(a.end < b.start || b.end < a.start);
+  };
+
+  llvm::SmallVector<llvm::SmallVector<Value>> groups;
+  for (Value alloc : allocs) {
+    Lifetime lifetime = lifetimes.lookup(alloc);
+    bool placed = false;
+    for (llvm::SmallVector<Value> &group : groups) {
+      if (llvm::any_of(group, [&](Value member) {
+            return overlaps(lifetimes.lookup(member), lifetime);
+          })) {
+        continue;
+      }
+      group.push_back(alloc);
+      placed = true;
+      break;
+    }
+    if (!placed) {
+      groups.push_back({alloc});
+    }
+  }
+  return groups;
+}
+
 void emitPoolingReport(Block &body,
-                       const llvm::DenseMap<Value, Lifetime> &lifetimes) {
+                       const llvm::DenseMap<Value, Lifetime> &lifetimes,
+                       llvm::ArrayRef<llvm::SmallVector<Value>> groups) {
+  llvm::DenseMap<Value, size_t> groupIndices;
+  for (auto [groupIdx, group] : llvm::enumerate(groups)) {
+    for (Value member : group) {
+      groupIndices[member] = groupIdx;
+    }
+  }
+
   for (Operation &op : body) {
     auto allocOp = dyn_cast<memref::AllocOp>(&op);
     if (!allocOp) {
@@ -80,7 +131,8 @@ void emitPoolingReport(Block &body,
       continue;
     }
     allocOp.emitRemark() << "hipsr-pool-alloc: lifetime [" << it->second.start
-                         << "," << it->second.end << "]";
+                         << "," << it->second.end << "] group "
+                         << groupIndices.lookup(allocOp.getResult());
   }
 }
 
@@ -92,8 +144,10 @@ struct HipsrPoolAllocPass : impl::HipsrPoolAllocPassBase<HipsrPoolAllocPass> {
     getOperation().walk([&](PoolDomainOp domain) {
       Block &body = domain.getBody().front();
       llvm::DenseMap<Value, Lifetime> lifetimes = computeLiveness(body);
+      llvm::SmallVector<llvm::SmallVector<Value>> groups =
+          greedyGrouping(body, lifetimes);
       if (emitPoolReport) {
-        emitPoolingReport(body, lifetimes);
+        emitPoolingReport(body, lifetimes, groups);
       }
     });
   }

--- a/test/lit/Dialect/Hipsr/pool_alloc_report.mlir
+++ b/test/lit/Dialect/Hipsr/pool_alloc_report.mlir
@@ -12,17 +12,17 @@ func.func @interleaved_allocs(%ctx: !hipsr.context,
   hipsr.pool_domain(%ctx, %in
       : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
   ^bb0(%dctx: !hipsr.context, %din: memref<4x1024xf16, #hipsr.mem<device>>):
-    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [1,3]}}
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [1,3] group 0}}
     %a1 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
     hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>,
                                       memref<4x1024xf16, #hipsr.mem<device>>)
                outs(%a1 : memref<4x1024xf16, #hipsr.mem<device>>)
-    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [3,5]}}
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [3,5] group 1}}
     %a2 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
     hipsr.add(%dctx) ins(%a1, %a1 : memref<4x1024xf16, #hipsr.mem<device>>,
                                     memref<4x1024xf16, #hipsr.mem<device>>)
                outs(%a2 : memref<4x1024xf16, #hipsr.mem<device>>)
-    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [5,7]}}
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [5,7] group 0}}
     %a3 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
     hipsr.add(%dctx) ins(%a2, %a2 : memref<4x1024xf16, #hipsr.mem<device>>,
                                     memref<4x1024xf16, #hipsr.mem<device>>)
@@ -49,11 +49,11 @@ func.func @hoisted_allocs(%ctx: !hipsr.context,
   hipsr.pool_domain(%ctx, %in
       : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
   ^bb0(%dctx: !hipsr.context, %din: memref<4x1024xf16, #hipsr.mem<device>>):
-    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [3,4]}}
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [3,4] group 0}}
     %a1 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
-    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [4,5]}}
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [4,5] group 1}}
     %a2 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
-    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [5,6]}}
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [5,6] group 0}}
     %a3 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
     hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>,
                                       memref<4x1024xf16, #hipsr.mem<device>>)
@@ -82,7 +82,7 @@ func.func @nested_region_user(%ctx: !hipsr.context,
   hipsr.pool_domain(%ctx, %in
       : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
   ^bb0(%dctx: !hipsr.context, %din: memref<4x1024xf16, #hipsr.mem<device>>):
-    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [1,2]}}
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [1,2] group 0}}
     %a1 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
     hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>,
                                       memref<4x1024xf16, #hipsr.mem<device>>)
@@ -93,6 +93,69 @@ func.func @nested_region_user(%ctx: !hipsr.context,
                  outs(%din : memref<4x1024xf16, #hipsr.mem<device>>)
       scf.yield
     }
+    hipsr.pool_domain_yield
+  }
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @coalesce_static
+func.func @coalesce_static(%ctx: !hipsr.context,
+                               %in8: memref<8x1024xf16, #hipsr.mem<device>>,
+                               %in4a: memref<4x1024xf16, #hipsr.mem<device>>,
+                               %in2: memref<2x1024xf16, #hipsr.mem<device>>,
+                               %in4b: memref<4x1024xf16, #hipsr.mem<device>>) {
+  hipsr.pool_domain(%ctx, %in8, %in4a, %in2, %in4b :
+      !hipsr.context,
+      memref<8x1024xf16, #hipsr.mem<device>>,
+      memref<4x1024xf16, #hipsr.mem<device>>,
+      memref<2x1024xf16, #hipsr.mem<device>>,
+      memref<4x1024xf16, #hipsr.mem<device>>) {
+  ^bb0(%dctx: !hipsr.context,
+       %d8: memref<8x1024xf16, #hipsr.mem<device>>,
+       %d4a: memref<4x1024xf16, #hipsr.mem<device>>,
+       %d2: memref<2x1024xf16, #hipsr.mem<device>>,
+       %d4b: memref<4x1024xf16, #hipsr.mem<device>>):
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [4,5] group 0}}
+    %a1 = memref.alloc() : memref<8x1024xf16, #hipsr.mem<device>>
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [6,7] group 0}}
+    %a2 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [8,9] group 0}}
+    %a3 = memref.alloc() : memref<2x1024xf16, #hipsr.mem<device>>
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [10,11] group 0}}
+    %a4 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+    hipsr.add(%dctx) ins(%d8, %d8 : memref<8x1024xf16, #hipsr.mem<device>>, memref<8x1024xf16, #hipsr.mem<device>>) outs(%a1 : memref<8x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a1, %a1 : memref<8x1024xf16, #hipsr.mem<device>>, memref<8x1024xf16, #hipsr.mem<device>>) outs(%d8 : memref<8x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%d4a, %d4a : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%a2 : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a2, %a2 : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%d4a : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%d2, %d2 : memref<2x1024xf16, #hipsr.mem<device>>, memref<2x1024xf16, #hipsr.mem<device>>) outs(%a3 : memref<2x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a3, %a3 : memref<2x1024xf16, #hipsr.mem<device>>, memref<2x1024xf16, #hipsr.mem<device>>) outs(%d2 : memref<2x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%d4b, %d4b : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%a4 : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a4, %a4 : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%d4b : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.pool_domain_yield
+  }
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @split_three_groups
+func.func @split_three_groups(%ctx: !hipsr.context, %in: memref<4x1024xf16, #hipsr.mem<device>>) {
+  hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
+  ^bb0(%dctx: !hipsr.context, %din: memref<4x1024xf16, #hipsr.mem<device>>):
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [3,8] group 0}}
+    %a1 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [4,7] group 1}}
+    %a2 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [5,8] group 2}}
+    %a3 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+    hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%a1 : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%a2 : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%a3 : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a1, %a2 : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%din : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a2, %a3 : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%din : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a1, %a3 : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%din : memref<4x1024xf16, #hipsr.mem<device>>)
     hipsr.pool_domain_yield
   }
   return


### PR DESCRIPTION
## Summary

`-hipsr-pool-alloc` now groups each pool domain's allocs by lifetime: an alloc joins the first group whose members are all disjoint from it, otherwise it opens a new one. The pass still rewrites nothing; the `emit-pool-report` remark gained the group each alloc landed in.

## Related issue or design

Upstream [`wcy123/onnx-hipdnn-ep#110`](https://github.com/wcy123/onnx-hipdnn-ep/issues/110) (greedy grouping utility), a step of [`wcy123/onnx-hipdnn-ep#19`](https://github.com/wcy123/onnx-hipdnn-ep/issues/19), which links the HIPSR Pool Allocation Pass design page. Follows [#591](https://github.com/ROCm/hip-ep/pull/591) (`#109`, liveness).

## Why

Group numbering ends up in the report, and `#117` will turn it into pool offsets, so it has to be reproducible. Two things make it so: allocs are collected by walking the block rather than iterating the `Value` -> `Lifetime` map, whose order is pointer-hash dependent; and the sort by lifetime start is stable, because allocs feeding several `outs` of one DPS op share a start and an unstable sort would order them arbitrarily.

Touching endpoints count as overlapping. The op that first writes the later buffer is still reading the earlier one, so `[1,3]` and `[3,5]` cannot share space.

## What

- `greedyGrouping(Block &, const DenseMap<Value, Lifetime> &)` returning groups as vectors of allocs, next to `computeLiveness` in the same anonymous namespace.
- `emitPoolingReport` takes the groups and reports `lifetime [a,b] group N`. Per-domain totals (alloc and group counts, reuse ratio) belong to `#118`.
- `pool_alloc_report.mlir`: existing ranges gained their group, plus the two boundary topologies.

## Test plan

- [x] Full `check-hip-mlir-lit` — 361 passed, 3 unsupported, 0 failed.
- [x] Mutation check: flipping one expected `group N` fails the run, so the new assertions are not vacuous.
- [x] `pre-commit run --all-files` clean.

Grouping is covered by chromatic number of the interval graph: `coalesce_static` (four disjoint allocs of differing sizes, one group), `interleaved_allocs` and `hoisted_allocs` (one alloc over two disjoint ones, two groups), `split_three_groups` (pairwise overlap, three groups).

## Notes for reviewers

- `coalesce_static` and `split_three_groups` are lifted verbatim from the reference implementation in [#572](https://github.com/ROCm/hip-ep/pull/572), minus its `CHECK` lines, which assert the pooled IR that does not exist yet. Keeping the fixtures identical means `#117` adds assertions instead of rewriting tests. They live in `pool_alloc_report.mlir` for now because a remark is the only thing to assert before the rewrite is wired; `#117` moves them to `pool_alloc.mlir`.
- Tests are lit rather than gtest: the inputs are a `Block` and its `Value`s, which gtest would have to build by hand, and the RUN line's `--implicit-check-not=hipsr.get_pool --implicit-check-not=memref.view` doubles as proof the pass is still a no-op. Happy to add a unit test if reviewers prefer one.
- `greedyGrouping` runs unconditionally and its result is only read under `emit-pool-report`, matching how `computeLiveness` landed in `#109`. `#117` consumes it for real.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [x] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.

AI assistance: Cursor implemented `greedyGrouping`, ported the two fixtures, and ran the lit and pre-commit validation above; I reviewed the result and hand-checked every expected lifetime and group against the fixture IR.
