### PR TITLE
ci: trigger builds on slash-named release branches

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -10,7 +10,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
   push:
-    branches: [main]
+    branches: [main, "release/**"]
 
 permissions:
   contents: read
@@ -569,4 +569,4 @@ jobs:
         with:
           name: linux-gpu-test-package
           path: staging/
-          retention-days: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release_')) && 14 || 3 }}
+          retention-days: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && 14 || 3 }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,7 +7,7 @@ name: pre-commit
 on:
   pull_request:
   push:
-    branches: [main, "release_*"]
+    branches: [main, "release/**"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/windows-build-mock.yml
+++ b/.github/workflows/windows-build-mock.yml
@@ -10,7 +10,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
   push:
-    branches: [main, "release_*"]
+    branches: [main, "release/**"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -10,7 +10,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
   push:
-    branches: [main, "release_*"]
+    branches: [main, "release/**"]
 
 permissions:
   contents: read
@@ -626,7 +626,7 @@ jobs:
         with:
           name: gpu-test-package
           path: staging/
-          retention-days: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release_')) && 14 || 3 }}
+          retention-days: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && 14 || 3 }}
 
       # -----------------------------------------------------------------------
       # Python wheel package: the three project wheels + run_onnx.py + OGA
@@ -660,7 +660,7 @@ jobs:
         with:
           name: hip-python-package
           path: wheelpkg/
-          retention-days: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release_')) && 14 || 3 }}
+          retention-days: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && 14 || 3 }}
 
   # ---------------------------------------------------------------------------
   # GPU test job: runs on the self-hosted machine with a real AMD GPU.


### PR DESCRIPTION
## Summary

Release branches must now be named `release/<name>`, but every workflow only matched the old underscore form, so pushing such a branch triggered no builds at all. Switch all branch matching to the slash form and give Linux Build the release trigger it never had.

## Related issue or design

None

## Why

The repository ruleset "Branch Naming Standard" enforces `^(feat|ci|docs|fix|perf|pr|release|test|users)/.*` and cannot be bypassed, so a branch like `release_0_3_0` can no longer be created; the replacement is `release/...`. GitHub Actions branch filters treat `*` as not crossing `/`, so the existing `release_*` pattern never matches `release/...` and no build runs on push. The same mismatch hits `startsWith(github.ref, 'refs/heads/release_')`, which silently downgrades artifact retention from the 14-day release tier to the 3-day PR tier.

The underscore form is replaced rather than kept alongside: the ruleset makes it uncreatable, and the two surviving branches (`release_0_1_0`, `release_0_2_0`) have already shipped, so keeping a second pattern would only leave two competing conventions in the tree.

Linux Build never ran on release branches, which forced release packaging to hunt down the main run sitting at the same commit. It is a single `ubuntu-latest` job with no self-hosted runner, so adding the trigger costs nothing beyond the build itself.

## What

- `windows-build.yml`, `windows-build-mock.yml`, `pre-commit.yml`: push filter `[main, "release_*"]` becomes `[main, "release/**"]`.
- `linux-build.yml`: push filter `[main]` becomes `[main, "release/**"]`, so a release branch produces its own Linux package.
- `retention-days` in the three upload steps (`gpu-test-package`, `hip-python-package`, `linux-gpu-test-package`) now tests `refs/heads/release/`, restoring the 14-day tier.

## Test plan

- [x] `pre-commit run --all-files` passes (`check-yaml` covers the edited workflows)
- [ ] This PR's own `pull_request`-triggered Windows Build, Linux Build, and pre-commit runs are green, confirming the existing trigger paths still work
- [ ] After merge: push a throwaway `release/ci-trigger-smoke` branch, confirm Windows Build and Linux Build queue on it, then cancel the runs and delete the branch

## Notes for reviewers

`release_0_1_0` and `release_0_2_0` stop triggering CI. Their v0.1.0 / v0.2.0 outputs are already stored as non-expiring GitHub Release assets, so nothing becomes unreachable.

Push triggers come from the workflow file on the pushed branch, so this only takes effect for release branches cut after it merges. The existing `release/release_0_3_0` branch is based on an earlier commit and still needs `workflow_dispatch` for its builds.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [x] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.
