### PR TITLE
fix(gbq): key GatherBlockQuantized default zero point off ONNX storage type, not signedness

### DIFF
--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -953,6 +953,13 @@ def Hip_GatherBlockQuantizedOp : Hip_DpsOp<"gather_block_quantized"> {
     HIPDNN_EP_DATATYPE_UINT8 to the runtime instead of the signless-i8 default
     (INT8 / signed int4). Absent for signed INT4 or explicit ui8/i8 storage.
 
+    Optional i64 attribute `quant_storage_bits`: width of one stored ONNX T1
+    element -- 4 for tensor(uint4)/tensor(int4), 8 for tensor(uint8). Selects
+    the default zero point above, and is independent of `bits` since
+    tensor(uint8) legally carries 2- or 4-bit values. convert-onnx-to-hip
+    reads it from the importer's `onnx.element_type` mark on the defining
+    constant, defaulting to `bits` when that mark is absent.
+
     Uses destination-passing style: the `output` buffer is provided as an
     argument. The runtime is responsible for fetching the per-element
     quantized value (handling sub-byte unpacking when `bits == 4`),
@@ -982,8 +989,11 @@ def Hip_GatherBlockQuantizedOp : Hip_DpsOp<"gather_block_quantized"> {
     I64Attr:$block_size,
     I64Attr:$gather_axis,
     I64Attr:$quantize_axis,
-    UnitAttr:$unsigned_quant_storage
+    UnitAttr:$unsigned_quant_storage,
+    OptionalAttr<I64Attr>:$quant_storage_bits
   );
+
+  let hasVerifier = 1;
 
   let assemblyFormat = [{
     `(` $ctx `)` `ins` `(` $data `,` $indices `,` $scales `:`

--- a/lib/Conversion/HipToLLVM/GatherBlockQuantizedLowering.cpp
+++ b/lib/Conversion/HipToLLVM/GatherBlockQuantizedLowering.cpp
@@ -130,6 +130,9 @@ struct GatherBlockQuantizedOpLowering
     Value indicesDtypeVal = createI64Const(indicesDtype);
     Value scalesDtypeVal = createI64Const(scalesDtype);
 
+    Value quantStorageBitsVal =
+        createI64Const(op.getQuantStorageBits().value_or(op.getBits()));
+
     SmallVector<Type, 24> paramTypes = {
         ptrType,                            // state
         ptrType, ptrType, ptrType,          // data, indices, scales
@@ -141,8 +144,9 @@ struct GatherBlockQuantizedOpLowering
         ptrType, i64Type,                   // output_shape, output_rank
         i64Type, i64Type, i64Type, i64Type, // bits, block_size, gather_axis,
                                             // quantize_axis
-        i64Type, i64Type, i64Type           // data_dtype, indices_dtype,
+        i64Type, i64Type, i64Type,          // data_dtype, indices_dtype,
                                             // scales_dtype
+        i64Type                             // quant_storage_bits
     };
 
     FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
@@ -151,11 +155,14 @@ struct GatherBlockQuantizedOpLowering
       return failure();
 
     SmallVector<Value, 24> args = {
-        statePtr,      dataPtr,    indicesPtr, scalesPtr,    zpPtr,
-        outPtr,        dataShape,  dataRank,   indicesShape, indicesRank,
-        scalesShape,   scalesRank, outShape,   outRank,      bits,
-        blockSize,     gatherAxis, quantAxis,  dataDtypeVal, indicesDtypeVal,
-        scalesDtypeVal};
+        statePtr,           dataPtr,         indicesPtr,
+        scalesPtr,          zpPtr,           outPtr,
+        dataShape,          dataRank,        indicesShape,
+        indicesRank,        scalesShape,     scalesRank,
+        outShape,           outRank,         bits,
+        blockSize,          gatherAxis,      quantAxis,
+        dataDtypeVal,       indicesDtypeVal, scalesDtypeVal,
+        quantStorageBitsVal};
 
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
     rewriter.eraseOp(op);

--- a/lib/Conversion/OnnxToHip/GatherBlockQuantizedConversion.cpp
+++ b/lib/Conversion/OnnxToHip/GatherBlockQuantizedConversion.cpp
@@ -44,6 +44,9 @@ inline int normalizeGbqAxis(int64_t axis, int64_t rank) {
   return a;
 }
 
+// `bits == 8` implies unsigned storage because the contrib schema constrains
+// T1 to {tensor(int4), tensor(uint4), tensor(uint8)} -- uint8 is the only
+// legal 8-bit storage type, and tensor(int8) is rejected at model load.
 inline bool resolveUnsignedQuantStorage(int64_t bits, bool hasUnsignedAttr,
                                         Type dataElemType) {
   if (hasUnsignedAttr)
@@ -51,6 +54,39 @@ inline bool resolveUnsignedQuantStorage(int64_t bits, bool hasUnsignedAttr,
   if (bits == 8)
     return true;
   return isUnsignedMlirElementType(dataElemType);
+}
+
+constexpr StringRef kQuantStorageBitsAttr = "quant_storage_bits";
+constexpr StringRef kOnnxElementTypeAttr = "onnx.element_type";
+
+inline std::optional<int64_t> quantStorageBitsFromOnnxType(int64_t onnxType) {
+  switch (onnxType) {
+  case 21: // TensorProto_DataType_UINT4
+  case 22: // TensorProto_DataType_INT4
+    return 4;
+  case 2: // TensorProto_DataType_UINT8
+  case 3: // TensorProto_DataType_INT8
+    return 8;
+  default:
+    return std::nullopt;
+  }
+}
+
+// Falls back to `bits` when the mark is absent (hand-written IR, or a
+// non-constant `data`), reproducing the pre-existing behaviour rather than
+// guessing a storage width.
+inline int64_t resolveQuantStorageBits(Operation *gbq, int64_t bits) {
+  if (auto attr = gbq->getAttrOfType<IntegerAttr>(kQuantStorageBitsAttr))
+    return attr.getInt();
+  if (gbq->getNumOperands() >= 1) {
+    if (Operation *def = gbq->getOperand(0).getDefiningOp()) {
+      if (auto attr = def->getAttrOfType<IntegerAttr>(kOnnxElementTypeAttr)) {
+        if (auto width = quantStorageBitsFromOnnxType(attr.getInt()))
+          return *width;
+      }
+    }
+  }
+  return bits;
 }
 
 inline bool isAlreadyPackedByteTensor(RankedTensorType dataType,
@@ -177,7 +213,7 @@ Operation *recreateExternalConstant(PatternRewriter &rewriter,
   return newConst;
 }
 
-bool annotateGbqSemantics(Operation *gbq, OpBuilder &builder) {
+bool annotateGbqSemantics(Operation *gbq, PatternRewriter &rewriter) {
   if (gbq->getNumOperands() < 3)
     return false;
 
@@ -191,28 +227,46 @@ bool annotateGbqSemantics(Operation *gbq, OpBuilder &builder) {
   if (!dataType || !scalesType)
     return false;
 
-  bool changed = false;
+  // Decide everything up front, then apply as a single rewriter-tracked
+  // mutation. Mutating an op inside a pattern without going through
+  // `modifyOpInPlace` bypasses the driver's listener/worklist bookkeeping.
+  const bool hasUnsignedAttr = gbq->hasAttr("unsigned_quant_storage");
   const bool unsignedStorage = gbq::resolveUnsignedQuantStorage(
-      bits, gbq->hasAttr("unsigned_quant_storage"), dataType.getElementType());
-  if (unsignedStorage) {
-    if (!gbq->hasAttr("unsigned_quant_storage")) {
-      gbq->setAttr("unsigned_quant_storage",
-                   UnitAttr::get(builder.getContext()));
-      changed = true;
-    }
-  } else if (gbq->hasAttr("unsigned_quant_storage")) {
-    gbq->removeAttr("unsigned_quant_storage");
-    changed = true;
-  }
+      bits, hasUnsignedAttr, dataType.getElementType());
+  const bool addUnsigned = unsignedStorage && !hasUnsignedAttr;
+  const bool dropUnsigned = !unsignedStorage && hasUnsignedAttr;
 
+  std::optional<int64_t> inferredAxis;
   if (!gbq->getAttr("quantize_axis")) {
     auto axisOr = gbq::inferQuantizeAxis(dataType, scalesType, blockSize, bits);
-    if (succeeded(axisOr)) {
-      gbq->setAttr("quantize_axis", builder.getI64IntegerAttr(*axisOr));
-      changed = true;
-    }
+    if (succeeded(axisOr))
+      inferredAxis = *axisOr;
   }
-  return changed;
+
+  // Pin the storage width now, while the defining constant still carries the
+  // ONNX element type: legalizeInt4ConstantIfNeeded rewrites the constant
+  // below, after which a 4-bit tensor is shape-indistinguishable from a
+  // uint8 tensor holding packed nibbles.
+  std::optional<int64_t> storageBits;
+  if (!gbq->hasAttr(gbq::kQuantStorageBitsAttr))
+    storageBits = gbq::resolveQuantStorageBits(gbq, bits);
+
+  if (!addUnsigned && !dropUnsigned && !inferredAxis.has_value() &&
+      !storageBits.has_value())
+    return false;
+
+  rewriter.modifyOpInPlace(gbq, [&] {
+    if (addUnsigned)
+      gbq->setAttr("unsigned_quant_storage", rewriter.getUnitAttr());
+    else if (dropUnsigned)
+      gbq->removeAttr("unsigned_quant_storage");
+    if (inferredAxis.has_value())
+      gbq->setAttr("quantize_axis", rewriter.getI64IntegerAttr(*inferredAxis));
+    if (storageBits.has_value())
+      gbq->setAttr(gbq::kQuantStorageBitsAttr,
+                   rewriter.getI64IntegerAttr(*storageBits));
+  });
+  return true;
 }
 
 bool legalizeInt4ConstantIfNeeded(Operation *gbq, PatternRewriter &rewriter) {
@@ -394,6 +448,7 @@ mlir::LogicalResult GatherBlockQuantizedToHip::matchAndRewrite(
 
   bool unsignedQuantStorage = gbq::resolveUnsignedQuantStorage(
       bits, op->hasAttr("unsigned_quant_storage"), dataType.getElementType());
+  const int64_t quantStorageBits = gbq::resolveQuantStorageBits(op, bits);
 
   auto bitsAttr = rewriter.getI64IntegerAttr(bits);
   auto blockSizeAttr = rewriter.getI64IntegerAttr(blockSize);
@@ -436,9 +491,9 @@ mlir::LogicalResult GatherBlockQuantizedToHip::matchAndRewrite(
   auto hipOp = mlir::hip::GatherBlockQuantizedOp::create(
       rewriter, loc, mlir::TypeRange{resultType}, context, data, indices,
       scales, zeroPoints, init, bitsAttr, blockSizeAttr, gatherAxisAttr,
-      quantAxisAttr);
-  if (unsignedQuantStorage)
-    hipOp->setAttr("unsigned_quant_storage", rewriter.getUnitAttr());
+      quantAxisAttr,
+      unsignedQuantStorage ? rewriter.getUnitAttr() : mlir::UnitAttr(),
+      rewriter.getI64IntegerAttr(quantStorageBits));
   rewriter.replaceOp(op, hipOp->getResults());
   return mlir::success();
 }

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -1271,6 +1271,21 @@ void GatherBlockQuantizedOp::getEffects(
   emitDpsMemoryEffects(getDpsInputOperands(), getDpsInitsMutable(), effects);
 }
 
+LogicalResult GatherBlockQuantizedOp::verify() {
+  // T1 is constrained to {uint4, int4, uint8}, so 4 and 8 are the only legal
+  // storage widths. uint8 legally holds 2- or 4-bit values, so the width may
+  // exceed `bits` but never the reverse.
+  if (std::optional<int64_t> storageBits = getQuantStorageBits()) {
+    if (*storageBits != 4 && *storageBits != 8)
+      return emitOpError("quant_storage_bits must be 4 or 8, got ")
+             << *storageBits;
+    if (*storageBits < getBits())
+      return emitOpError("quant_storage_bits (")
+             << *storageBits << ") must be >= bits (" << getBits() << ")";
+  }
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // CausalConvWithStateOp: ins(input, weight, [bias], [past_state])
 //                        outs(output, present_state)

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -1256,9 +1256,10 @@ int wrap_gather_block_quantized(
     int64_t bits,       // 4 or 8
     int64_t block_size, // power of 2, >= 16
     int64_t gather_axis, int64_t quantize_axis,
-    int64_t data_dtype,    // HIPDNN_EP_DATATYPE_* (uint8 packed)
-    int64_t indices_dtype, // INT32 / INT64
-    int64_t scales_dtype); // FLOAT / HALF / BFLOAT16
+    int64_t data_dtype,          // HIPDNN_EP_DATATYPE_* (uint8 packed)
+    int64_t indices_dtype,       // INT32 / INT64
+    int64_t scales_dtype,        // FLOAT / HALF / BFLOAT16
+    int64_t quant_storage_bits); // ONNX T1 width: 4 (uint4/int4) or 8 (uint8)
 
 // QMoE operation wrapper (quantized Mixture-of-Experts)
 // Routes tokens to top-k experts, performs quantized MLP per expert,

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -1378,7 +1378,8 @@ int wrap_gather_block_quantized(
     int64_t indices_rank, const int64_t *scales_shape, int64_t scales_rank,
     const int64_t *output_shape, int64_t output_rank, int64_t bits,
     int64_t block_size, int64_t gather_axis, int64_t quantize_axis,
-    int64_t data_dtype, int64_t indices_dtype, int64_t scales_dtype) {
+    int64_t data_dtype, int64_t indices_dtype, int64_t scales_dtype,
+    int64_t quant_storage_bits) {
   if (!state) {
     fprintf(stderr, "Invalid state in wrap_gather_block_quantized\n");
     return -1;
@@ -1395,12 +1396,13 @@ int wrap_gather_block_quantized(
 
   MOCK_PRINT(
       "[MOCK] wrap_gather_block_quantized(data_rank=%lld, indices_rank=%lld, "
-      "scales_rank=%lld, output_rank=%lld, bits=%lld, block_size=%lld, "
-      "gather_axis=%lld, quantize_axis=%lld, data_dtype=%s(%lld), "
+      "scales_rank=%lld, output_rank=%lld, bits=%lld, storage_bits=%lld, "
+      "block_size=%lld, gather_axis=%lld, quantize_axis=%lld, "
+      "data_dtype=%s(%lld), "
       "indices_dtype=%s(%lld), scales_dtype=%s(%lld), zero_points=%s)\n",
       (long long)data_rank, (long long)indices_rank, (long long)scales_rank,
-      (long long)output_rank, (long long)bits, (long long)block_size,
-      (long long)gather_axis, (long long)quantize_axis,
+      (long long)output_rank, (long long)bits, (long long)quant_storage_bits,
+      (long long)block_size, (long long)gather_axis, (long long)quantize_axis,
       hipdnn_ep_datatype_name(data_dtype), (long long)data_dtype,
       hipdnn_ep_datatype_name(indices_dtype), (long long)indices_dtype,
       hipdnn_ep_datatype_name(scales_dtype), (long long)scales_dtype,

--- a/lib/Runtime/real/gather_block_quantized.cpp
+++ b/lib/Runtime/real/gather_block_quantized.cpp
@@ -62,7 +62,8 @@ extern "C" int wrap_gather_block_quantized(
     int64_t indices_rank, const int64_t *scales_shape, int64_t scales_rank,
     const int64_t *output_shape, int64_t output_rank, int64_t bits,
     int64_t block_size, int64_t gather_axis, int64_t quantize_axis,
-    int64_t data_dtype, int64_t indices_dtype, int64_t scales_dtype) {
+    int64_t data_dtype, int64_t indices_dtype, int64_t scales_dtype,
+    int64_t quant_storage_bits) {
   OP_PROFILE(
       "gather_block_quantized",
       [&] {
@@ -112,25 +113,13 @@ extern "C" int wrap_gather_block_quantized(
     return -1;
   }
 
-  // Default zero point when zero_points is omitted (ONNX spec):
-  // "If zero_points is not provided, the default value is 0 for signed
-  //  types and 2^(bits-1) for unsigned types." That gives the four-way
-  // table:
-  //   bits == 4 + int8  storage (int4)  .. 0
-  //   bits == 4 + uint8 storage (uint4)  .. 8   (= 2^(bits-1))
-  //   bits == 8 + int8  storage (int8)   .. 0
-  //   bits == 8 + uint8 storage (uint8)  .. 128 (= 2^(bits-1))
-  // The previous version hard-coded 0 for bits == 4, which silently
-  // produces values shifted by +(8 * scale) on every uint4-packed weight
-  // (canonical site: Qwen3.5 vision encoder's pos_embed.weight_Q4 — the
-  // model dequantises to roughly +0.65/+0.73 in place of the correct
-  // values, which cluster around 0).
-  int default_zp;
-  if (is_signed_data) {
-    default_zp = 0;
-  } else {
+  // Default zero point when zero_points is omitted. Keyed off the ONNX
+  // storage type T1, not off `bits` and not off signedness -- uint4 defaults
+  // to 0 despite being unsigned. See the T1 dispatch in ORT's
+  // contrib_ops/cpu/quantization/gather_block_quantized.cc.
+  int default_zp = 0;
+  if (quant_storage_bits == 8)
     default_zp = 1 << (static_cast<int>(bits) - 1);
-  }
 
   // Sub-byte storage: when bits == 4 and the data tensor element type is
   // uint8 / int8 (no native int4/uint4 in the EP type system), ONNX stores
@@ -193,14 +182,14 @@ extern "C" int wrap_gather_block_quantized(
 
   RUNTIME_DEBUG_LOG(
       "[REAL] wrap_gather_block_quantized: data_dtype=%s indices_dtype=%s "
-      "scales_dtype=%s bits=%lld block_size=%lld gather_axis=%d "
-      "quantize_axis=%d signed=%d default_zp=%d has_zp=%d "
+      "scales_dtype=%s bits=%lld storage_bits=%lld block_size=%lld "
+      "gather_axis=%d quantize_axis=%d signed=%d default_zp=%d has_zp=%d "
       "data_rank=%lld indices_rank=%lld out_rank=%lld total=%lld\n",
       hipdnn_ep_datatype_name(data_dtype),
       hipdnn_ep_datatype_name(indices_dtype),
       hipdnn_ep_datatype_name(scales_dtype), (long long)bits,
-      (long long)block_size, gather_axis_n, quantize_axis_n,
-      (int)is_signed_data, default_zp, zero_points ? 1 : 0,
+      (long long)quant_storage_bits, (long long)block_size, gather_axis_n,
+      quantize_axis_n, (int)is_signed_data, default_zp, zero_points ? 1 : 0,
       (long long)data_rank, (long long)indices_rank, (long long)output_rank,
       (long long)total);
 

--- a/morphizen/mlir-imp/src/mlir-graph.cpp
+++ b/morphizen/mlir-imp/src/mlir-graph.cpp
@@ -1129,6 +1129,12 @@ void MLIRGraph::add_constant_initialized_tensor(
     state.addAttribute("value", denseAttr);
   }
 
+  // The MLIR element type is lossy for sub-byte storage -- UINT4 and UINT8
+  // both land on ui8 -- so keep the original TensorProto code for consumers
+  // that must tell them apart.
+  state.addAttribute("onnx.element_type",
+                     builder.getI64IntegerAttr(onnxElemType));
+
   mlir::Operation *op = builder.create(state);
   op->setAttr(attr_names::NODE_OUTPUTS,
               builder.getArrayAttr({builder.getStringAttr(name)}));

--- a/test/lit/Conversion/hip-to-llvm/test_gather_block_quantized.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_gather_block_quantized.mlir
@@ -4,7 +4,7 @@
 // RUN: hip-mlir-opt --convert-hip-to-llvm %s | FileCheck %s
 
 // Verify that hip.gather_block_quantized lowers to wrap_gather_block_quantized
-// with the full 21-parameter signature:
+// with the full 22-parameter signature:
 //   state, data, indices, scales, zero_points (nullable), output  (6 ptrs)
 //   data_shape/rank, idx_shape/rank, scl_shape/rank, out_shape/rank
 //                                                              (4 * (ptr, i64))
@@ -87,14 +87,76 @@ module {
          unsigned_quant_storage}
     return
   }
+
+  // ===== Tests 5-7: quant_storage_bits reaches the runtime by value =====
+  // The trailing runtime argument is the ONNX T1 storage width, which is NOT
+  // `bits`: tensor(uint8) legally holds 4-bit values two per byte. The three
+  // cases below are identical apart from that attribute, so checking the
+  // argument list positionally is the only way to catch it being dropped,
+  // reordered, or silently defaulted back to `bits`.
+  //
+  // Shapes deliberately avoid a literal 4 in any dim or rank so the first
+  // `constant(4 : i64)` in each function is unambiguously `bits`.
+
+  // Test 5: uint8 storage, 4-bit values -> storage width 8 while bits is 4.
+
+  func.func @test_gbq_storage_bits_uint8_packed(%ctx: !hip.context,
+                                                 %data: memref<2048x96xui8, 1>,
+                                                 %indices: memref<5xi64, 1>,
+                                                 %scales: memref<2048x12xf16, 1>,
+                                                 %output: memref<5x96xf16, 1>) {
+    hip.gather_block_quantized(%ctx)
+        ins(%data, %indices, %scales :
+            memref<2048x96xui8, 1>, memref<5xi64, 1>, memref<2048x12xf16, 1>)
+        outs(%output : memref<5x96xf16, 1>)
+        {bits = 4 : i64, block_size = 16 : i64,
+         gather_axis = 0 : i64, quantize_axis = 1 : i64,
+         unsigned_quant_storage, quant_storage_bits = 8 : i64}
+    return
+  }
+
+  // Test 6: native uint4 storage -> storage width 4, same bits, same types.
+
+  func.func @test_gbq_storage_bits_uint4(%ctx: !hip.context,
+                                          %data: memref<2048x96xui8, 1>,
+                                          %indices: memref<5xi64, 1>,
+                                          %scales: memref<2048x12xf16, 1>,
+                                          %output: memref<5x96xf16, 1>) {
+    hip.gather_block_quantized(%ctx)
+        ins(%data, %indices, %scales :
+            memref<2048x96xui8, 1>, memref<5xi64, 1>, memref<2048x12xf16, 1>)
+        outs(%output : memref<5x96xf16, 1>)
+        {bits = 4 : i64, block_size = 16 : i64,
+         gather_axis = 0 : i64, quantize_axis = 1 : i64,
+         unsigned_quant_storage, quant_storage_bits = 4 : i64}
+    return
+  }
+
+  // Test 7: attribute absent (hand-written IR, or a non-constant `data`) ->
+  // falls back to `bits` rather than guessing.
+
+  func.func @test_gbq_storage_bits_absent(%ctx: !hip.context,
+                                           %data: memref<2048x96xui8, 1>,
+                                           %indices: memref<5xi64, 1>,
+                                           %scales: memref<2048x12xf16, 1>,
+                                           %output: memref<5x96xf16, 1>) {
+    hip.gather_block_quantized(%ctx)
+        ins(%data, %indices, %scales :
+            memref<2048x96xui8, 1>, memref<5xi64, 1>, memref<2048x12xf16, 1>)
+        outs(%output : memref<5x96xf16, 1>)
+        {bits = 4 : i64, block_size = 16 : i64,
+         gather_axis = 0 : i64, quantize_axis = 1 : i64,
+         unsigned_quant_storage}
+    return
+  }
 }
 
 // CHECK-LABEL: llvm.func @test_gbq_static_with_zp
-// CHECK: llvm.call @wrap_gather_block_quantized({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
+// CHECK: llvm.call @wrap_gather_block_quantized({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
 
 // CHECK-LABEL: llvm.func @test_gbq_static_no_zp
 // CHECK: llvm.mlir.zero
-// CHECK: llvm.call @wrap_gather_block_quantized({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
+// CHECK: llvm.call @wrap_gather_block_quantized({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
 
 // CHECK-LABEL: llvm.func @test_gbq_dynamic_indices
 // indices dim 0 read from descriptor — must be extractvalue, not a constant.
@@ -108,3 +170,43 @@ module {
 // CHECK-DAG: llvm.mlir.constant(7 : i64) : i64
 // CHECK-NOT: llvm.mlir.constant(5 : i64) : i64
 // CHECK: llvm.call @wrap_gather_block_quantized
+
+// The scalar tail is emitted in a fixed order immediately before the call:
+// bits, block_size, gather_axis, quantize_axis, data_dtype, indices_dtype,
+// scales_dtype, quant_storage_bits. Binding each to an SSA name and then
+// requiring that exact sequence as the last eight call operands pins both the
+// value and the position of the storage width.
+
+// CHECK-LABEL: llvm.func @test_gbq_storage_bits_uint8_packed
+// CHECK: %[[BITS:.*]] = llvm.mlir.constant(4 : i64) : i64
+// CHECK: %[[BLK:.*]] = llvm.mlir.constant(16 : i64) : i64
+// CHECK: %[[GA:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK: %[[QA:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK: %[[DDT:.*]] = llvm.mlir.constant(7 : i64) : i64
+// CHECK: %[[IDT:.*]] = llvm.mlir.constant(4 : i64) : i64
+// CHECK: %[[SDT:.*]] = llvm.mlir.constant(1 : i64) : i64
+// storage width 8 even though bits is 4 -- the whole point of the argument.
+// CHECK: %[[QSB:.*]] = llvm.mlir.constant(8 : i64) : i64
+// CHECK: llvm.call @wrap_gather_block_quantized({{.*}}, %[[BITS]], %[[BLK]], %[[GA]], %[[QA]], %[[DDT]], %[[IDT]], %[[SDT]], %[[QSB]])
+
+// CHECK-LABEL: llvm.func @test_gbq_storage_bits_uint4
+// CHECK: %[[BITS:.*]] = llvm.mlir.constant(4 : i64) : i64
+// CHECK: %[[BLK:.*]] = llvm.mlir.constant(16 : i64) : i64
+// CHECK: %[[GA:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK: %[[QA:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK: %[[DDT:.*]] = llvm.mlir.constant(7 : i64) : i64
+// CHECK: %[[IDT:.*]] = llvm.mlir.constant(4 : i64) : i64
+// CHECK: %[[SDT:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK: %[[QSB:.*]] = llvm.mlir.constant(4 : i64) : i64
+// CHECK: llvm.call @wrap_gather_block_quantized({{.*}}, %[[BITS]], %[[BLK]], %[[GA]], %[[QA]], %[[DDT]], %[[IDT]], %[[SDT]], %[[QSB]])
+
+// CHECK-LABEL: llvm.func @test_gbq_storage_bits_absent
+// CHECK: %[[BITS:.*]] = llvm.mlir.constant(4 : i64) : i64
+// CHECK: %[[BLK:.*]] = llvm.mlir.constant(16 : i64) : i64
+// CHECK: %[[GA:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK: %[[QA:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK: %[[DDT:.*]] = llvm.mlir.constant(7 : i64) : i64
+// CHECK: %[[IDT:.*]] = llvm.mlir.constant(4 : i64) : i64
+// CHECK: %[[SDT:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK: %[[QSB:.*]] = llvm.mlir.constant(4 : i64) : i64
+// CHECK: llvm.call @wrap_gather_block_quantized({{.*}}, %[[BITS]], %[[BLK]], %[[GA]], %[[QA]], %[[DDT]], %[[IDT]], %[[SDT]], %[[QSB]])

--- a/test/lit/Conversion/onnx-to-hip/test_gather_block_quantized.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_gather_block_quantized.mlir
@@ -157,4 +157,86 @@ module {
   // CHECK-SAME: quantize_axis = 1
   // CHECK-SAME: unsigned_quant_storage
   // CHECK-NOT: onnx.Custom
+
+  // ===== Tests 6-8: T1 storage width from the importer's element-type mark ==
+  // The importer stamps `onnx.element_type` (the ONNX TensorProto code) on
+  // every constant. These three cases are the reason it has to: they are
+  // pairwise indistinguishable by MLIR type and `bits` alone, yet ONNX gives
+  // them different default zero points (0 for int4/uint4, 2^(bits-1) for
+  // uint8). Only `quant_storage_bits` separates them downstream.
+
+  // Test 6: UINT8 (code 2) carrying two nibbles per byte -> storage width 8.
+
+  func.func @test_gbq_storage_uint8_packed(%indices: tensor<8xi64>) -> tensor<8x96xf16> {
+    %data = "onnx.Constant"() {value = dense<1> : tensor<2048x96xui8>, onnx.element_type = 2 : i64} : () -> tensor<2048x96xui8>
+    %scales = "onnx.Constant"() {value = dense<1.000000e+00> : tensor<2048x12xf16>} : () -> tensor<2048x12xf16>
+    %out = "onnx.Custom"(%data, %indices, %scales) {
+      function_name = "GatherBlockQuantized",
+      domain_name = "com.microsoft",
+      bits = 4 : si64,
+      block_size = 16 : si64,
+      gather_axis = 0 : si64,
+      quantize_axis = 1 : si64,
+      onnx_node_name = "GatherBlockQuantized_5"
+    } : (tensor<2048x96xui8>, tensor<8xi64>, tensor<2048x12xf16>) -> tensor<8x96xf16>
+    return %out : tensor<8x96xf16>
+  }
+
+  // CHECK-LABEL: func.func @test_gbq_storage_uint8_packed
+  // CHECK: hip.gather_block_quantized
+  // CHECK-SAME: bits = 4
+  // CHECK-SAME: quant_storage_bits = 8
+  // CHECK-SAME: unsigned_quant_storage
+  // CHECK-NOT: onnx.Custom
+
+  // Test 7: UINT4 (code 21) -> storage width 4, even though `data` is the same
+  // ui8 byte tensor with the same `bits` as test 6. Getting 8 here is exactly
+  // the bug that biases every uint4 embedding by +(8 * scale).
+
+  func.func @test_gbq_storage_uint4(%indices: tensor<8xi64>) -> tensor<8x96xf16> {
+    %data = "onnx.Constant"() {value = dense<1> : tensor<2048x96xui8>, onnx.element_type = 21 : i64} : () -> tensor<2048x96xui8>
+    %scales = "onnx.Constant"() {value = dense<1.000000e+00> : tensor<2048x12xf16>} : () -> tensor<2048x12xf16>
+    %out = "onnx.Custom"(%data, %indices, %scales) {
+      function_name = "GatherBlockQuantized",
+      domain_name = "com.microsoft",
+      bits = 4 : si64,
+      block_size = 16 : si64,
+      gather_axis = 0 : si64,
+      quantize_axis = 1 : si64,
+      onnx_node_name = "GatherBlockQuantized_6"
+    } : (tensor<2048x96xui8>, tensor<8xi64>, tensor<2048x12xf16>) -> tensor<8x96xf16>
+    return %out : tensor<8x96xf16>
+  }
+
+  // CHECK-LABEL: func.func @test_gbq_storage_uint4
+  // CHECK: hip.gather_block_quantized
+  // CHECK-SAME: bits = 4
+  // CHECK-SAME: quant_storage_bits = 4
+  // CHECK-SAME: unsigned_quant_storage
+  // CHECK-NOT: onnx.Custom
+
+  // Test 8: INT4 (code 22) -> storage width 4 and signed, so no
+  // `unsigned_quant_storage`.
+
+  func.func @test_gbq_storage_int4(%indices: tensor<8xi64>) -> tensor<8x96xf16> {
+    %data = "onnx.Constant"() {value = dense<1> : tensor<2048x96xi8>, onnx.element_type = 22 : i64} : () -> tensor<2048x96xi8>
+    %scales = "onnx.Constant"() {value = dense<1.000000e+00> : tensor<2048x12xf16>} : () -> tensor<2048x12xf16>
+    %out = "onnx.Custom"(%data, %indices, %scales) {
+      function_name = "GatherBlockQuantized",
+      domain_name = "com.microsoft",
+      bits = 4 : si64,
+      block_size = 16 : si64,
+      gather_axis = 0 : si64,
+      quantize_axis = 1 : si64,
+      onnx_node_name = "GatherBlockQuantized_7"
+    } : (tensor<2048x96xi8>, tensor<8xi64>, tensor<2048x12xf16>) -> tensor<8x96xf16>
+    return %out : tensor<8x96xf16>
+  }
+
+  // CHECK-LABEL: func.func @test_gbq_storage_int4
+  // CHECK: hip.gather_block_quantized
+  // CHECK-SAME: bits = 4
+  // CHECK-SAME: quant_storage_bits = 4
+  // CHECK-NOT: unsigned_quant_storage
+  // CHECK-NOT: onnx.Custom
 }

--- a/test/lit/Dialect/hip-gather-block-quantized-verifier.mlir
+++ b/test/lit/Dialect/hip-gather-block-quantized-verifier.mlir
@@ -1,0 +1,102 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --split-input-file --verify-diagnostics %s | FileCheck %s
+
+// `quant_storage_bits` records the width of one stored ONNX T1 element: 4 for
+// tensor(int4)/tensor(uint4), 8 for tensor(uint8). Only those two widths are
+// legal, and the storage element can never be narrower than the quantized
+// value it holds.
+
+// CHECK-LABEL: func.func @gbq_storage_bits_4
+// CHECK:         hip.gather_block_quantized
+func.func @gbq_storage_bits_4(%ctx: !hip.context,
+                              %data: memref<2048x96xui8, 1>,
+                              %indices: memref<8xi64, 1>,
+                              %scales: memref<2048x12xf16, 1>,
+                              %output: memref<8x96xf16, 1>) {
+  hip.gather_block_quantized(%ctx)
+      ins(%data, %indices, %scales :
+          memref<2048x96xui8, 1>, memref<8xi64, 1>, memref<2048x12xf16, 1>)
+      outs(%output : memref<8x96xf16, 1>)
+      {bits = 4 : i64, block_size = 16 : i64,
+       gather_axis = 0 : i64, quantize_axis = 1 : i64,
+       quant_storage_bits = 4 : i64}
+  return
+}
+
+// -----
+
+// uint8 storage holding packed nibbles: storage width 8, quantized width 4.
+// CHECK-LABEL: func.func @gbq_storage_bits_8_with_bits_4
+// CHECK:         hip.gather_block_quantized
+func.func @gbq_storage_bits_8_with_bits_4(%ctx: !hip.context,
+                                          %data: memref<2048x96xui8, 1>,
+                                          %indices: memref<8xi64, 1>,
+                                          %scales: memref<2048x12xf16, 1>,
+                                          %output: memref<8x96xf16, 1>) {
+  hip.gather_block_quantized(%ctx)
+      ins(%data, %indices, %scales :
+          memref<2048x96xui8, 1>, memref<8xi64, 1>, memref<2048x12xf16, 1>)
+      outs(%output : memref<8x96xf16, 1>)
+      {bits = 4 : i64, block_size = 16 : i64,
+       gather_axis = 0 : i64, quantize_axis = 1 : i64,
+       unsigned_quant_storage, quant_storage_bits = 8 : i64}
+  return
+}
+
+// -----
+
+// Omitting the attribute is legal; the lowering falls back to `bits`.
+// CHECK-LABEL: func.func @gbq_storage_bits_absent
+// CHECK:         hip.gather_block_quantized
+func.func @gbq_storage_bits_absent(%ctx: !hip.context,
+                                   %data: memref<2048x96xui8, 1>,
+                                   %indices: memref<8xi64, 1>,
+                                   %scales: memref<2048x12xf16, 1>,
+                                   %output: memref<8x96xf16, 1>) {
+  hip.gather_block_quantized(%ctx)
+      ins(%data, %indices, %scales :
+          memref<2048x96xui8, 1>, memref<8xi64, 1>, memref<2048x12xf16, 1>)
+      outs(%output : memref<8x96xf16, 1>)
+      {bits = 4 : i64, block_size = 16 : i64,
+       gather_axis = 0 : i64, quantize_axis = 1 : i64}
+  return
+}
+
+// -----
+
+func.func @gbq_storage_bits_illegal_width(%ctx: !hip.context,
+                                          %data: memref<2048x96xui8, 1>,
+                                          %indices: memref<8xi64, 1>,
+                                          %scales: memref<2048x12xf16, 1>,
+                                          %output: memref<8x96xf16, 1>) {
+  // expected-error @+1 {{quant_storage_bits must be 4 or 8, got 3}}
+  hip.gather_block_quantized(%ctx)
+      ins(%data, %indices, %scales :
+          memref<2048x96xui8, 1>, memref<8xi64, 1>, memref<2048x12xf16, 1>)
+      outs(%output : memref<8x96xf16, 1>)
+      {bits = 4 : i64, block_size = 16 : i64,
+       gather_axis = 0 : i64, quantize_axis = 1 : i64,
+       quant_storage_bits = 3 : i64}
+  return
+}
+
+// -----
+
+// A 4-bit storage element cannot hold an 8-bit quantized value.
+func.func @gbq_storage_narrower_than_bits(%ctx: !hip.context,
+                                          %data: memref<2048x96xui8, 1>,
+                                          %indices: memref<8xi64, 1>,
+                                          %scales: memref<2048x12xf16, 1>,
+                                          %output: memref<8x96xf16, 1>) {
+  // expected-error @+1 {{quant_storage_bits (4) must be >= bits (8)}}
+  hip.gather_block_quantized(%ctx)
+      ins(%data, %indices, %scales :
+          memref<2048x96xui8, 1>, memref<8xi64, 1>, memref<2048x12xf16, 1>)
+      outs(%output : memref<8x96xf16, 1>)
+      {bits = 8 : i64, block_size = 16 : i64,
+       gather_axis = 0 : i64, quantize_axis = 1 : i64,
+       quant_storage_bits = 4 : i64}
+  return
+}


### PR DESCRIPTION
## Summary

`GatherBlockQuantized`'s default zero point (used when `zero_points` is absent) depends on the ONNX storage type `T1`, which the EP currently cannot observe. `tensor(uint4)` and `tensor(uint8)`-holding-packed-nibbles both arrive at the runtime as `ui8` with `bits=4` and a byte-identical layout, yet the ORT CPU kernel uses **0** for the former and **2^(bits-1)** for the latter:

```cpp
// onnxruntime/contrib_ops/cpu/quantization/gather_block_quantized.cc
if constexpr (std::is_same_v<T1, uint8_t>) {
  ...
  const int32_t default_zero_point = 1 << (static_cast<int>(bits_) - 1);
} else {  // Int4x2 / UInt4x2
  zp_val = zero_points_ptr ? ... : 0;
}
```

Deciding from `is_signed_data`, as `main` does today, therefore biases one of the two by `8 * scale` whichever way the condition is written. In practice `uint4` embedding tables published without `zero_points` come back shifted by `-8 * scale` on every gathered row.

The correct rule is already written down in three places in this repo — `HipOps.td` ("the default is `0` for int4/uint4 and `2^(bits-1)` for uint8", from #368), `hipdnn_ep_runtime.h`, and the ORT schema doc string — but is not what the code implements.

## Approach

Carry the ONNX element type explicitly rather than trying to re-derive it:

1. **Import** (`mlir-graph.cpp`) records `onnx.element_type` on every `onnx.Constant`. This attribute was already listed in the GBQ legalizer's preserve-set but nothing ever set it.
2. **`convert-onnx-to-hip`** pins `quant_storage_bits` from that marker, before `legalizeInt4ConstantIfNeeded` rewrites the constant and erases the shape evidence that would otherwise distinguish the two cases.
3. **`convert-hip-to-llvm`** forwards it to the runtime (22nd parameter).
4. **Runtime** selects `default_zp = (storage_bits == 8) ? 1 << (bits - 1) : 0`.

Signedness no longer participates in the zero-point decision at all. It is still needed for nibble sign extension, which is a separate concern — the previous code used one boolean for both jobs and got the second one wrong.

`quant_storage_bits` is declared in ODS with a verifier rather than attached as a discardable attribute, so producer and consumer share a generated accessor and illegal widths are rejected at verification. It is optional and falls back to `bits`, keeping hand-written IR valid.

Also routes the prepare-pattern attribute edits through `rewriter.modifyOpInPlace` instead of mutating the op behind the driver's back.

## Verification

Built `main` and this branch separately and ran both against the same models with the same ORT CPU reference (`hip-onnx-runner -L`, EP vs `-n` CPU):

| Model | Storage / bits | `zero_points` | `main` L2 | this PR L2 |
|---|---|---|---|---|
| `uint4_nozp` | uint4 / 4 | no | **166.277** | 0 |
| `uint4_nozp_100352x2048` | uint4 / 4, external | no | **940.604** | 0 |
| `int4_nozp` | int4 / 4 | no | 0 | 0 |
| `uint8_nozp` | uint8 / 8 | no | 0 | 0 |
| `u8bits4_nozp` | uint8 / 4 packed | no | 0 | 0 |
| `uint4_zp` | uint4 / 4 | yes | 0 | 0 |
| `uint4_zp_blk16` | uint4 / 4, block 16 | yes | 0 | 0 |
| `int4_zp` | int4 / 4 | yes | 0 | 0 |
| `uint8_zp` | uint8 / 8 | yes | 0 | 0 |
| `uint4_zp_100352x2048` | uint4 / 4, external | yes | 0 | 0 |

The failure signature on `main` is a pure additive shift, not noise or a layout error:

```
ORT CPU (truth) : [0.   0.5  1.   1.5  2.   2.5  3.   3.5]
main            : [-4.  -3.5 -3.  -2.5 -2.  -1.5 -1.  -0.5]
diff            : [-4.  -4.  -4.  -4.  -4.  -4.  -4.  -4.]   == -8 * scale
```

`u8bits4_nozp` is the case that separates the two candidate rules: it is byte-identical to `uint4_nozp` but requires the opposite default. It passes on both builds, confirming the fix keys off storage type and not off `bits`.

361/361 lit tests pass. ORCA-2bit runs end to end; it is unaffected either way because it ships `zero_points`, so the default is never consulted.

## Affected models

Only when all three hold: storage is `tensor(uint4)`, `bits == 4`, and `zero_points` is absent. Anything shipping `zero_points` is unaffected.

## Not addressed here

Deliberately out of scope, flagged for follow-up:

- `bits == 2` is legal for `tensor(uint8)` per the schema, but `convert-onnx-to-hip` still gates on `bits in {4, 8}`, so such models fall back rather than converting.
- `quantize_axis` is still re-derived from shape invariants when the attribute is absent, rather than using the ONNX default of 1.
- `legalizeInt4ConstantIfNeeded` and `recreateExternalConstant` still return `false` / `nullptr` silently instead of emitting diagnostics.
- **The CI L2 suite still contains no GBQ model.** This is the gap that let a wrong default zero point ship. The 10 models above are currently local only; wiring them (or at least `uint4_nozp` and `u8bits4_nozp`) into the gate is the change that prevents a recurrence.

## Test plan

- [ ] CI L2 suite green
- [ ] lit suite green
- [ ] Reviewer sanity-check the storage-width rule against the ORT CPU kernel
- [ ] Decide whether the GBQ models should be added to the CI L2 gate in this PR or a follow-up
