### PR TITLE
fix(tools): align int8-KV merge with hip-ep fp16 GQA and infer genai metadata

### DIFF
--- a/tools/onnx-merged-convert/README.md
+++ b/tools/onnx-merged-convert/README.md
@@ -72,10 +72,12 @@ model-bundle/
 
 | File | Purpose |
 |------|---------|
-| `genai_config.json` | Source for model metadata and search settings. If missing, a default config is generated from the merged graph. |
+| `genai_config.json` | Source for model metadata and search settings. If missing, a default config is generated from the merged graph and bundle metadata (see below). |
 | `adapter.safetensors` | LoRA adapter weights; copied to the output when present. |
 | `tokenizer/` | Not read by the converter; copy manually for inference. |
-| `tokenizer/config.json` or `config.json` | Used to fill in `vocab_size` when the source genai config omits it. |
+| `tokenizer/config.json` or `config.json` | Hugging Face model config; used for `vocab_size`, `context_length`, and decoder architecture fields when the source genai config omits them. |
+| `tokenizer/tokenizer_config.json` or `tokenizer_config.json` | Tokenizer settings; used for pad/EOS token ids when inferring model metadata. |
+| `tokenizer/tokenizer.json` or `tokenizer.json` | Tokenizer vocabulary; used to infer `vocab_size` when not present elsewhere. |
 
 ### What happens if files are missing?
 
@@ -103,7 +105,7 @@ Pipeline **type** is inferred from the decoder prefill graph:
 |------------------|----------|
 | Quantized linear (MatMulNBits) | Standard QDQ removal and merge. |
 | Many Gemm nodes, few MatMulNBits | Treats weights as folded Gemm (pure-Gemm / adapter path); may emit `lora_dequant.json`. |
-| GroupQueryAttention with 8-bit KV cache | Preserves int8 KV path. |
+| GroupQueryAttention with 8-bit KV cache | Preserves int8 KV I/O and GQA quant attrs; rewrites activations to pure fp16 (including RoPE cos/sin at GQA inputs 7–8) for hip-ep. |
 | Many 2-bit MatMulNBits nodes | Low-bit decoder path. |
 
 ## Output files
@@ -120,7 +122,26 @@ The merged `genai_config.json` is adjusted for a single merged graph:
 
 - Decoder inputs use `input_ids` (not precomputed embeddings).
 - Execution provider profile is set to `hip` for AMDGPU stages.
-- `vocab_size` is preserved from the source config or inferred from tokenizer metadata.
+- Missing model and decoder fields are filled in without overwriting values already present in a source config.
+
+### Metadata inference
+
+When no source `genai_config.json` is available, or when specific fields are absent, the converter infers them in this order:
+
+| Field | Primary source | Fallback |
+|-------|----------------|----------|
+| `model.vocab_size` | Source genai config | HF `config.json`, then `tokenizer.json`, then merged graph logits shape |
+| `model.context_length` | Source genai config | HF `max_position_embeddings`, else default (`16384`) |
+| `model.bos_token_id`, `pad_token_id`, `eos_token_id` | Source genai config | HF / tokenizer config files |
+| `decoder.head_size` | HF `head_dim` | First `past_keys_*_0` input shape `[batch, kv_heads, seq, head_dim]` |
+| `decoder.num_attention_heads` | HF `num_attention_heads` | First `GroupQueryAttention` node `num_heads` attribute |
+| `decoder.num_key_value_heads` | HF `num_key_value_heads` | KV input shape or GQA `kv_num_heads` attribute |
+| `decoder.hidden_size` | HF `hidden_size` | `num_attention_heads × head_size` when both are known |
+| `decoder.num_hidden_layers` | Merged graph | Count of `past_keys_*` / `present_keys_*` tensor groups |
+
+HF config paths are checked under `tokenizer/config.json` first, then `config.json` at the bundle root. Tokenizer files follow the same `tokenizer/` subdirectory-first layout.
+
+If inference fails for architecture fields, conservative defaults are used (`head_size=128`, `hidden_size=2048`, `num_attention_heads=24`, `num_key_value_heads=8`). Place an accurate source `genai_config.json` or HF `config.json` in the bundle when automatic detection is insufficient.
 
 ## Code layout
 
@@ -139,8 +160,8 @@ Supporting modules:
 | Module | Role |
 |--------|------|
 | `qdq_ext.py` | Alternate Q/DQ + fp16 path for low-bit models |
-| `int8kv.py` | Decoder conversion with int8 KV cache preserved |
-| `bundle.py` | Input bundle detection and `genai_config.json` generation |
+| `int8kv.py` | Decoder conversion with int8 KV cache preserved; RoPE weights discovered via GQA cos/sin inputs |
+| `bundle.py` | Input bundle detection; merged I/O introspection; `genai_config.json` generation and metadata inference |
 | `pipeline.py` | Wires the steps for each pipeline kind (`quantized_linear`, `int8_kv`, `low_bit`) |
 | `cli.py` | Argument parsing and `main()` |
 
@@ -162,5 +183,7 @@ python -m merged_convert.cli --input-dir ... --output-dir ...
 |---------|----------------|
 | `No decoder pair found` | Missing or misnamed `*_128.onnx` / `*_1.onnx` (or `*_0.onnx` / `*_1.onnx`) pair. |
 | `Missing embedding or lm_head` | Emb or head file missing or name does not match glob patterns. |
-| Runtime error on `vocab_size` | No vocab in source genai config and no `tokenizer/config.json`. Add one or fix paths. |
+| Runtime error on `vocab_size` | No vocab in source genai config and no `tokenizer/config.json` or `tokenizer.json`. Add one or fix paths. |
+| Wrong KV cache / attention layout at runtime | Generated `genai_config.json` has incorrect `head_size`, `num_attention_heads`, or `num_key_value_heads`; supply a source genai config or HF `config.json` with accurate architecture fields. |
 | GenAI rejects `embeddings` input | Re-run with a current script build; merged configs must use `input_ids`. |
+| `Cast->fp32 remain; pure fp16 activations required` | int8-KV decoder still has fp32 activation casts after RoPE/GQA cleanup; inspect remaining `Cast` nodes or upstream export. |

--- a/tools/onnx-merged-convert/merged_convert/bundle.py
+++ b/tools/onnx-merged-convert/merged_convert/bundle.py
@@ -272,14 +272,120 @@ def _collect_eos_token_ids(
     return ids
 
 
+def _bundle_hf_config(input_dir: Path) -> dict[str, Any] | None:
+    return _read_json(input_dir / "tokenizer" / "config.json") or _read_json(
+        input_dir / "config.json"
+    )
+
+
+def _bundle_tokenizer_config(input_dir: Path) -> dict[str, Any] | None:
+    return _read_json(input_dir / "tokenizer" / "tokenizer_config.json") or _read_json(
+        input_dir / "tokenizer_config.json"
+    )
+
+
+def _bundle_tokenizer_json(input_dir: Path) -> dict[str, Any] | None:
+    return _read_json(input_dir / "tokenizer" / "tokenizer.json") or _read_json(
+        input_dir / "tokenizer.json"
+    )
+
+
+_HF_DECODER_FIELD_MAP = (
+    ("hidden_size", "hidden_size"),
+    ("num_attention_heads", "num_attention_heads"),
+    ("num_key_value_heads", "num_key_value_heads"),
+    ("num_hidden_layers", "num_hidden_layers"),
+    ("head_dim", "head_size"),
+)
+
+
+def _infer_decoder_metadata_from_hf(hf_cfg: dict[str, Any] | None) -> dict[str, int]:
+    meta: dict[str, int] = {}
+    if not hf_cfg:
+        return meta
+    for hf_key, dec_key in _HF_DECODER_FIELD_MAP:
+        value = hf_cfg.get(hf_key)
+        if value is not None:
+            meta[dec_key] = int(value)
+    return meta
+
+
+def _infer_decoder_metadata_from_merged(merged_path: Path) -> dict[str, int]:
+    """Infer decoder architecture from merged graph KV I/O and GQA attributes."""
+    model = onnx.load(str(merged_path), load_external_data=False)
+    meta: dict[str, int] = {}
+
+    for vi in model.graph.input:
+        name = vi.name
+        if not name.endswith("_0") or "past_keys_" not in name:
+            continue
+        if name.rsplit("_", 1)[-1] != "0":
+            continue
+        dims = vi.type.tensor_type.shape.dim
+        if len(dims) >= 4:
+            kv_heads = dims[1].dim_value
+            head_size = dims[3].dim_value
+            if kv_heads > 0:
+                meta["num_key_value_heads"] = int(kv_heads)
+            if head_size > 0:
+                meta["head_size"] = int(head_size)
+        break
+
+    for node in model.graph.node:
+        if node.op_type != "GroupQueryAttention":
+            continue
+        attrs = {a.name: a for a in node.attribute}
+        num_heads = attrs.get("num_heads")
+        kv_num_heads = attrs.get("kv_num_heads")
+        if num_heads is not None and num_heads.i > 0:
+            meta["num_attention_heads"] = int(num_heads.i)
+        if kv_num_heads is not None and kv_num_heads.i > 0:
+            meta["num_key_value_heads"] = int(kv_num_heads.i)
+        break
+
+    if "num_attention_heads" in meta and "head_size" in meta:
+        meta.setdefault("hidden_size", meta["num_attention_heads"] * meta["head_size"])
+    return meta
+
+
+def _infer_decoder_metadata(
+    bundle: ModelBundle, merged_path: Path, *, num_layers: int
+) -> dict[str, int]:
+    from_hf = _infer_decoder_metadata_from_hf(_bundle_hf_config(bundle.input_dir))
+    from_onnx = _infer_decoder_metadata_from_merged(merged_path)
+    meta: dict[str, int] = {}
+    for key in (
+        "head_size",
+        "hidden_size",
+        "num_attention_heads",
+        "num_key_value_heads",
+        "num_hidden_layers",
+    ):
+        if key in from_hf:
+            meta[key] = from_hf[key]
+        elif key in from_onnx:
+            meta[key] = from_onnx[key]
+    meta["num_hidden_layers"] = num_layers
+    if "hidden_size" not in meta:
+        if "num_attention_heads" in meta and "head_size" in meta:
+            meta["hidden_size"] = meta["num_attention_heads"] * meta["head_size"]
+    return meta
+
+
+def _fill_missing_decoder_metadata(
+    decoder: dict[str, Any], inferred: dict[str, int]
+) -> None:
+    for key, value in inferred.items():
+        if key not in decoder or decoder[key] in (None, "", 0):
+            decoder[key] = value
+
+
 def _infer_model_metadata(bundle: ModelBundle, merged_path: Path) -> dict[str, Any]:
     """Fill genai model fields when no source genai_config.json is available."""
     input_dir = bundle.input_dir
-    hf_cfg = _read_json(input_dir / "tokenizer" / "config.json") or _read_json(
-        input_dir / "config.json"
-    )
-    tok_cfg = _read_json(input_dir / "tokenizer" / "tokenizer_config.json")
-    tok_json = _read_json(input_dir / "tokenizer" / "tokenizer.json")
+    hf_cfg = _bundle_hf_config(input_dir)
+    tok_cfg = _bundle_tokenizer_config(input_dir)
+    tok_json = _bundle_tokenizer_json(input_dir)
 
     meta: dict[str, Any] = {}
 
@@ -288,7 +394,7 @@ def _infer_model_metadata(bundle: ModelBundle, merged_path: Path) -> dict[str, A
             if key in hf_cfg and hf_cfg[key] is not None:
                 meta[key] = hf_cfg[key]
         if hf_cfg.get("max_position_embeddings") is not None:
-            meta.setdefault("context_length", hf_cfg["max_position_embeddings"])
+            meta["context_length"] = int(hf_cfg["max_position_embeddings"])
 
     if "vocab_size" not in meta and tok_json:
         added = tok_json.get("added_tokens") or []
@@ -336,6 +442,10 @@ def build_genai_config(
     source: Path | None,
 ) -> dict:
     io = introspect_merged_io(merged_path)
+    model_meta = _infer_model_metadata(bundle, merged_path)
+    decoder_meta = _infer_decoder_metadata(
+        bundle, merged_path, num_layers=int(io["num_layers"])
+    )
     prefill = _pipeline_stage(merged_filename, io)
     prefill["run_on_prompt"] = True
     prefill["run_on_token_gen"] = False
@@ -348,7 +458,7 @@ def build_genai_config(
     else:
         cfg = {
             "model": {
-                "context_length": DEFAULT_MAX_SEQ_LEN,
+                "context_length": model_meta.get("context_length", DEFAULT_MAX_SEQ_LEN),
                 "type": "decoder-pipeline",
                 "decoder": {
                     "session_options": {
@@ -356,11 +466,11 @@ def build_genai_config(
                         "session.disable_cpu_ep_fallback": "1",
                         "provider_options": [{"AMDGPU": {"profile": "hip"}}],
                     },
-                    "head_size": 128,
-                    "hidden_size": 2048,
-                    "num_attention_heads": 24,
+                    "head_size": decoder_meta.get("head_size", 128),
+                    "hidden_size": decoder_meta.get("hidden_size", 2048),
+                    "num_attention_heads": decoder_meta.get("num_attention_heads", 24),
                     "num_hidden_layers": int(io["num_layers"]),
-                    "num_key_value_heads": 8,
+                    "num_key_value_heads": decoder_meta.get("num_key_value_heads", 8),
                     "inputs": {
                         "input_ids": "input_ids",
                         "past_sequence_length": "past_seq_len",
@@ -414,6 +524,7 @@ def build_genai_config(
             opt["AMDGPU"]["profile"] = "hip"
 
     _fill_missing_model_metadata(model, bundle, merged_path)
+    _fill_missing_decoder_metadata(decoder, decoder_meta)
 
     search = cfg.setdefault("search", {})
     search["chunk_size"] = bundle.chunk_size

--- a/tools/onnx-merged-convert/merged_convert/int8kv.py
+++ b/tools/onnx-merged-convert/merged_convert/int8kv.py
@@ -7,8 +7,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import numpy as np
 import onnx
-from onnx import TensorProto, helper
+from onnx import TensorProto, helper, numpy_helper
 from onnx.compose import add_prefix, merge_graphs
 
 from .qdq_ext import (
@@ -39,17 +40,7 @@ FP32_q = TensorProto.FLOAT
 INT8 = TensorProto.INT8
 PIPELINE_PREFIXES = ("emb_", "dec_", "head_")
 KV_IO_PARTS = ("past_keys_", "past_values_", "present_keys_", "present_values_")
-
-
-def _count_fp32_casts(model: onnx.ModelProto) -> int:
-    return sum(
-        (
-            1
-            for n in model.graph.node
-            if n.op_type == "Cast"
-            and any((a.name == "to" and a.i == FP32_q for a in n.attribute))
-        )
-    )
+GQA_ROPE_INPUTS = (7, 8)  # cos_cache, sin_cache
 
 
 def assert_int8_kv_io(model: onnx.ModelProto, *, context: str = "") -> None:
@@ -83,60 +74,6 @@ def assert_gqa_int8_quant(model: onnx.ModelProto, *, context: str = "") -> None:
             raise RuntimeError(f"{prefix}expected kv_cache_bit_width=8, got {bw.i}")
 
 
-def wrap_gqa_fp32_query_for_int8_kv(model: onnx.ModelProto) -> int:
-    """ORT CPU GQA with int8 KV requires fp32 Q and matching float aux inputs."""
-    graph = model.graph
-    float_input_indices = (0, 7, 8)
-    new_nodes: list[onnx.NodeProto] = []
-    wrapped = 0
-    for node in graph.node:
-        if node.op_type != "GroupQueryAttention":
-            new_nodes.append(node)
-            continue
-        attrs = {a.name: a for a in node.attribute}
-        bw = attrs.get("kv_cache_bit_width")
-        kq = attrs.get("k_quant_type")
-        if bw is None or bw.i != 8 or kq is None or (kq.s == b"NONE"):
-            new_nodes.append(node)
-            continue
-        cast_nodes: list[onnx.NodeProto] = []
-        for idx in float_input_indices:
-            if idx >= len(node.input):
-                continue
-            src = node.input[idx]
-            if not src:
-                continue
-            fp32_name = f"{node.name}_in{idx}_fp32"
-            cast_nodes.append(
-                helper.make_node(
-                    "Cast",
-                    [src],
-                    [fp32_name],
-                    name=f"{node.name}_in{idx}_cast_fp32",
-                    to=FP32_q,
-                )
-            )
-            node.input[idx] = fp32_name
-        out_fp32 = f"{node.name}_out_fp32"
-        out_orig = node.output[0]
-        node.output[0] = out_fp32
-        new_nodes.extend(cast_nodes)
-        new_nodes.append(node)
-        new_nodes.append(
-            helper.make_node(
-                "Cast",
-                [out_fp32],
-                [out_orig],
-                name=f"{node.name}_out_cast_fp16",
-                to=FP16_q,
-            )
-        )
-        wrapped += 1
-    del graph.node[:]
-    graph.node.extend(new_nodes)
-    return wrapped
-
-
 def _cast_to_q(node: onnx.NodeProto) -> int | None:
     if node.op_type != "Cast":
         return None
@@ -144,6 +81,128 @@ def _cast_to_q(node: onnx.NodeProto) -> int | None:
         if attr.name == "to":
             return int(attr.i)
     return None
+
+
+def _graph_producers(graph: onnx.GraphProto) -> dict[str, onnx.NodeProto]:
+    producer: dict[str, onnx.NodeProto] = {}
+    for node in graph.node:
+        for out in node.output:
+            if out:
+                producer[out] = node
+    return producer
+
+
+def _is_int8_kv_gqa(node: onnx.NodeProto) -> bool:
+    if node.op_type != "GroupQueryAttention":
+        return False
+    attrs = {a.name: a for a in node.attribute}
+    bw = attrs.get("kv_cache_bit_width")
+    kq = attrs.get("k_quant_type")
+    return bw is not None and bw.i == 8 and kq is not None and kq.s != b"NONE"
+
+
+def _trace_to_initializers(
+    tensor: str,
+    producer: dict[str, onnx.NodeProto],
+    init_names: set[str],
+    *,
+    seen: set[str] | None = None,
+) -> set[str]:
+    """Follow RoPE tensor producers back to graph initializers."""
+    if not tensor:
+        return set()
+    if seen is None:
+        seen = set()
+    if tensor in seen:
+        return set()
+    seen.add(tensor)
+    if tensor in init_names:
+        return {tensor}
+    node = producer.get(tensor)
+    if node is None:
+        return set()
+    if node.op_type in {"Cast", "Identity"} and node.input:
+        return _trace_to_initializers(node.input[0], producer, init_names, seen=seen)
+    if node.op_type in {"Gather", "Slice"} and node.input:
+        return _trace_to_initializers(node.input[0], producer, init_names, seen=seen)
+    return set()
+
+
+def _promote_initializer_to_fp16(init: onnx.TensorProto) -> bool:
+    if init.data_type != FP32_q:
+        return False
+    arr = numpy_helper.to_array(init).astype(np.float16)
+    init.CopyFrom(numpy_helper.from_array(arr, name=init.name))
+    return True
+
+
+def _rewire_tensor_consumers(
+    graph: onnx.GraphProto, old_name: str, new_name: str
+) -> int:
+    rewired = 0
+    for consumer in graph.node:
+        for i, inp in enumerate(consumer.input):
+            if inp == old_name:
+                consumer.input[i] = new_name
+                rewired += 1
+    return rewired
+
+
+def ensure_gqa_rope_weights_fp16(model: onnx.ModelProto) -> dict[str, int]:
+    """Promote RoPE cos/sin weights to fp16 for hip-ep fused int8-KV GQA.
+
+    Discovers cos/sin tensors from GroupQueryAttention inputs 7 and 8, traces
+    them back to fp32 initializers, and removes fp16->fp32 Cast wrappers so
+    GQA consumes fp16 RoPE tables directly.
+    """
+    graph = model.graph
+    init_by_name = {i.name: i for i in graph.initializer}
+    init_names = set(init_by_name)
+    producer = _graph_producers(graph)
+
+    stats = {
+        "rope_inits_promoted": 0,
+        "rope_cast_removed": 0,
+        "rope_consumers_rewired": 0,
+    }
+    promote: set[str] = set()
+    remove: set[str] = set()
+
+    for node in graph.node:
+        if not _is_int8_kv_gqa(node):
+            continue
+        for idx in GQA_ROPE_INPUTS:
+            if idx >= len(node.input) or not node.input[idx]:
+                continue
+            rope_tensor = node.input[idx]
+            cast_node = producer.get(rope_tensor)
+            if (
+                cast_node is not None
+                and cast_node.op_type == "Cast"
+                and _cast_to_q(cast_node) == FP32_q
+                and cast_node.input
+            ):
+                fp32_name = cast_node.output[0]
+                fp16_name = cast_node.input[0]
+                node.input[idx] = fp16_name
+                stats["rope_cast_removed"] += 1
+                stats["rope_consumers_rewired"] += _rewire_tensor_consumers(
+                    graph, fp32_name, fp16_name
+                )
+                remove.add(cast_node.name)
+                rope_tensor = fp16_name
+            promote |= _trace_to_initializers(rope_tensor, producer, init_names)
+
+    for name in promote:
+        init = init_by_name.get(name)
+        if init is not None and _promote_initializer_to_fp16(init):
+            stats["rope_inits_promoted"] += 1
+
+    if remove:
+        kept = [n for n in graph.node if n.name not in remove]
+        del graph.node[:]
+        graph.node.extend(kept)
+    return stats
 
 
 def convert_decoder_int8kv(
@@ -169,7 +228,7 @@ def convert_decoder_int8kv(
         graph, inits, new_inits, remove_inits
     )
     stats["weight_dq_fold"] = fold_weight_dq_q(
-        graph, inits, new_inits, remove_inits, weight_dtype=__import__("numpy").float16
+        graph, inits, new_inits, remove_inits, weight_dtype=np.float16
     )
     if new_inits or remove_inits:
         apply_new_initializers_q(graph, new_inits)
@@ -181,12 +240,15 @@ def convert_decoder_int8kv(
     fp16_stats = optimize_fp16_activations(model)
     stats["gqa_getitem_fp32_removed"] = fp16_stats["gqa_getitem_fp32_removed"]
     stats["mnbits_fp16_casts_folded"] = fp16_stats["mnbits_fp16_casts_folded"]
-    stats["gqa_fp32_query_wrap"] = wrap_gqa_fp32_query_for_int8_kv(model)
-    stats["fp32_casts_remaining"] = _count_fp32_casts(model)
-    allowed_fp32_casts = 3 * stats["gqa_fp32_query_wrap"]
-    if stats["fp32_casts_remaining"] > allowed_fp32_casts:
+    rope_stats = ensure_gqa_rope_weights_fp16(model)
+    for key, value in rope_stats.items():
+        stats[f"rope_{key}"] = value
+    # Re-count fp32 casts after RoPE rewiring.
+    fp16_stats = optimize_fp16_activations(model)
+    stats["fp32_casts_remaining"] = fp16_stats["fp32_casts_remaining"]
+    if stats["fp32_casts_remaining"]:
         raise RuntimeError(
-            f"{dst.name}: {stats['fp32_casts_remaining']} Cast->fp32 remain (allowed {allowed_fp32_casts} at GQA boundaries)"
+            f"{dst.name}: {stats['fp32_casts_remaining']} Cast->fp32 remain; pure fp16 activations required"
         )
     stats["gqa_seqlens_rewrite"] = (
         rewrite_gqa_past_seq_len_to_seqlens_k_q(model) if gqa_seqlens_rewrite else 0


### PR DESCRIPTION
Replace ORT-CPU fp32 GQA boundary casts with graph-traced RoPE fp16 promotion for int8-KV decoders, requiring pure fp16 activations for hip-ep. Infer decoder architecture fields in genai_config.json from HF config or merged ONNX when the source config omits them.