### PR TITLE
Skill to profile HIP, DML, CPU EPs

### DIFF
--- a/.cursor/skills/ort-ep-profiling/SKILL.md
+++ b/.cursor/skills/ort-ep-profiling/SKILL.md
@@ -1,0 +1,181 @@
+<!--
+Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+Licensed under the MIT License.
+-->
+---
+name: ort-ep-profiling
+description: Profile ONNX models with onnxruntime_perf_test across HIP (hipgpu), DML, and CPU execution providers. Converts ORT profile JSON to op/shape tables and captures HIPDNN_EP_PERF breakdowns. Use when comparing EP performance, running ort profiling, onnxruntime_perf_test -p profile, or generating hipdnn_ep_perf tables. Run one EP at a time; never parallelize profiling runs.
+---
+
+# ORT Execution Provider Profiling
+
+Compare per-op performance across **HIP** (hipgpu plugin EP), **DML**, and **CPU** using `onnxruntime_perf_test`. Execute commands yourself; do not only print instructions.
+
+## Serial execution (all EPs)
+
+**Never run profiling for more than one EP at a time** — not in parallel shell commands, not as concurrent background jobs, not via parallel tool calls. This applies to **HIP, DML, and CPU**.
+
+When comparing multiple EPs:
+1. Run **one EP at a time**, wait for it to finish completely.
+2. Then run the next.
+
+Parallel runs skew timings (GPU contention for HIP/DML; CPU/memory bandwidth contention for CPU) and can cause driver or EP conflicts.
+
+## Required inputs
+
+Ask the user for anything missing before running:
+
+1. **onnxruntime_perf_test path** — full path to `onnxruntime_perf_test.exe` (Windows) or `onnxruntime_perf_test` (Linux).
+2. **ONNX model path**
+3. **Execution provider** — one of: `HIP`, `DML`, `CPU`
+4. **hipgpu.dll path** (HIP only) — if not beside `onnxruntime_perf_test.exe`
+
+Optional: working directory for profile output (default: directory containing the perf_test binary).
+
+## Clean stale profile files (CPU/DML)
+
+`-p profile` writes `profile_<timestamp>.json` into the **current working directory**. Old files make it easy to analyze the wrong run. **Always delete existing `profile_*.json` in `<CWD>` immediately before starting perf_test** (CPU and DML paths).
+
+```powershell
+python .cursor/skills/ort-ep-profiling/scripts/clean_profile_files.py "<CWD>"
+```
+
+`<CWD>` is usually the directory containing `onnxruntime_perf_test` (where you `Set-Location` before running). Use `--dry-run` to list matches without deleting.
+
+After a successful run, the new trace is the `profile_*.json` file(s) created in that directory — with pre-run cleanup there should be exactly one.
+
+## Base command flags
+
+All runs use:
+
+```text
+-I -m times -r 2 -p profile <model>
+```
+
+- `-I` — sequential inputs
+- `-m times` — measure by iteration count
+- `-r 2` — two repetitions (warmup + profiled run)
+- `-p profile` — emit Chrome-tracing JSON (`profile_<timestamp>.json`)
+
+## Execution provider commands
+
+### CPU
+
+No `-e` or `--plugin_ep*` flags. Clean profile files first (see above).
+
+```powershell
+python .cursor/skills/ort-ep-profiling/scripts/clean_profile_files.py "<CWD>"
+& "<PERF_TEST>" -I -m times -r 2 -p profile "<MODEL>"
+```
+
+### DML
+
+Add `-e dml` and disable graph fusion for per-op visibility. Clean profile files first (see above).
+
+```powershell
+python .cursor/skills/ort-ep-profiling/scripts/clean_profile_files.py "<CWD>"
+& "<PERF_TEST>" -I -m times -r 2 -p profile "<MODEL>" `
+  -e dml `
+  -C "ep.dml.disable_graph_fusion|1"
+```
+
+### HIP (hipgpu plugin EP)
+
+Do **not** pass `-e`. Load the hipgpu plugin and enable EP perf printing:
+
+```powershell
+$env:HIPDNN_EP_PERF = "1"
+& "<PERF_TEST>" -I -m times -r 2 -p profile "<MODEL>" `
+  --plugin_ep_libs "hipgpu|<HIPGPU_DLL>" `
+  --plugin_eps "hipgpu"
+```
+
+- Default `<HIPGPU_DLL>`: `hipgpu.dll` in the same directory as `onnxruntime_perf_test.exe`.
+- If missing, ask the user for the full path.
+- Ensure ROCm/TheRock runtime DLLs are on `PATH` when running HIP (see repo `docs/quick_start.md`).
+
+## Post-run outputs
+
+### HIP — extract the **last** `[PERF]` table from perf_test output (not profile JSON)
+
+The hipgpu plugin EP does **not** produce useful per-op metrics in the ORT `profile_*.json` trace. With `$env:HIPDNN_EP_PERF=1`, hip-ep prints a full op/shape table **once per inference**. Because `-r 2` (plus compile/warmup runs) repeats inference, the log contains **multiple** tables — always report **only the last one** (final timed repetition, after warmup/compile).
+
+Capture stdout+stderr (PowerShell `Tee-Object` writes UTF-16; the extractor handles that):
+
+```powershell
+& "<PERF_TEST>" ... 2>&1 | Tee-Object -FilePath "<LOG.txt>"
+```
+
+Extract the last table with the helper script (do not hand-pick blocks from earlier repetitions):
+
+```powershell
+python .cursor/skills/ort-ep-profiling/scripts/extract_hip_perf_table.py "<LOG.txt>"
+python .cursor/skills/ort-ep-profiling/scripts/extract_hip_perf_table.py "<LOG.txt>" -o "<TABLE.txt>"
+```
+
+The script finds separator-delimited blocks that contain the `calls  gpu (ms)  cpu (ms)  gpu %` header and returns the final block only.
+
+Report that block to the user. Ignore `profile_*.json` for HIP.
+
+### CPU and DML — convert ORT profile JSON
+
+After pre-run cleanup and a successful perf_test, locate the new trace in `<CWD>`:
+
+```powershell
+Get-ChildItem -Path "<CWD>" -Filter "profile_*.json"
+```
+
+There should be one file. If multiple exist (unexpected), take the newest by `LastWriteTime` and note the ambiguity in the report.
+
+Convert to a summarized op/shape table in the same grouping as the hip-ep `[PERF]` table (op type → shape detail):
+
+```powershell
+python .cursor/skills/ort-ep-profiling/scripts/ort_profile_table.py "<PROFILE_JSON>" -o "<OUTPUT.tsv>"
+```
+
+Table columns: `Op`, `Detail`, `Calls`, `Time (ms)`.
+
+The script also prints an **op-type summary** (`Op`, `Calls`, `Time (ms)`) sorted by total time descending — include this when reporting CPU/DML results.
+
+To print to stdout, omit `-o`.
+
+## Workflow checklist
+
+```
+Task Progress:
+- [ ] Collect perf_test path, model path, EP choice
+- [ ] If profiling multiple EPs: schedule runs sequentially (never parallel)
+- [ ] Resolve hipgpu.dll (HIP only)
+- [ ] CPU/DML: clean profile_*.json in CWD before running
+- [ ] Set HIPDNN_EP_PERF=1 (HIP only)
+- [ ] Run onnxruntime_perf_test with EP-specific flags
+- [ ] HIP: capture perf_test output and extract last [PERF] table (ignore profile JSON)
+- [ ] CPU/DML: locate new profile_*.json and run ort_profile_table.py
+- [ ] Report both summary table and total inference time if available
+```
+
+## Report back
+
+Summarize for the user:
+
+1. EP profiled and command used
+2. Profile artifact path (`profile_*.json` or perf log)
+3. Per-op table — `[PERF]` block (HIP) or TSV from `ort_profile_table.py` (CPU/DML), including the op-type summary with **calls** and total time per op
+4. Any errors (missing DLL, EP registration failure, model load failure)
+
+## Notes
+
+- **Never run more than one EP profiling session concurrently** (HIP, DML, or CPU); run sequentially and wait for each to exit.
+- HIP profile JSON from `-p profile` is not useful for hip-ep op breakdown; always use the `[PERF]` stderr table.
+- `-r 2` prints multiple `[PERF]` tables; use `extract_hip_perf_table.py` and never report an earlier repetition.
+- Do not use `HIPDNN_EP_PERF=1` when measuring raw throughput; it adds profiling overhead. This skill intentionally enables it for HIP op breakdowns.
+- For DML, graph fusion is disabled so fused ops appear as individual nodes in the trace (closer to HIP/CPU granularity).
+- Always run `clean_profile_files.py` before CPU/DML perf_test; never convert a pre-existing `profile_*.json` without confirming it came from the current run.
+- Quote paths that contain spaces.
+
+## Scripts
+
+- [scripts/ort_profile_shapes.py](scripts/ort_profile_shapes.py) — ONNX op → shape detail formatters (aligned with `lib/Runtime/real/` OP_PROFILE).
+- [scripts/clean_profile_files.py](scripts/clean_profile_files.py) — delete stale `profile_*.json` before a CPU/DML run.
+- [scripts/ort_profile_table.py](scripts/ort_profile_table.py) — converts ORT profile JSON to op/shape TSV (CPU/DML).
+- [scripts/extract_hip_perf_table.py](scripts/extract_hip_perf_table.py) — extracts the **last** `[PERF]` table from a HIP perf_test log.

--- a/.cursor/skills/ort-ep-profiling/scripts/clean_profile_files.py
+++ b/.cursor/skills/ort-ep-profiling/scripts/clean_profile_files.py
@@ -1,0 +1,60 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+
+"""Remove stale onnxruntime_perf_test profile_*.json files from a directory."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def clean_profile_files(directory: Path, dry_run: bool = False) -> list[Path]:
+    matches = sorted(directory.glob("profile_*.json"))
+    if not dry_run:
+        for path in matches:
+            path.unlink()
+    return matches
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Delete profile_*.json files before a fresh perf_test -p profile run."
+    )
+    parser.add_argument(
+        "directory",
+        type=Path,
+        nargs="?",
+        default=Path("."),
+        help="Directory to clean (default: current working directory)",
+    )
+    parser.add_argument(
+        "-n",
+        "--dry-run",
+        action="store_true",
+        help="List matching files without deleting them",
+    )
+    args = parser.parse_args()
+
+    directory = args.directory.resolve()
+    if not directory.is_dir():
+        print(f"error: not a directory: {directory}", file=sys.stderr)
+        return 1
+
+    removed = clean_profile_files(directory, dry_run=args.dry_run)
+    if not removed:
+        print(f"no profile_*.json files in {directory}", file=sys.stderr)
+        return 0
+
+    verb = "would remove" if args.dry_run else "removed"
+    for path in removed:
+        print(f"{verb}: {path}", file=sys.stderr)
+    print(f"{verb} {len(removed)} file(s) from {directory}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.cursor/skills/ort-ep-profiling/scripts/extract_hip_perf_table.py
+++ b/.cursor/skills/ort-ep-profiling/scripts/extract_hip_perf_table.py
@@ -1,0 +1,251 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+
+"""Extract the last HIPDNN_EP_PERF op table from onnxruntime_perf_test output."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+SEP = re.compile(r"^\[PERF\] ={10,}$")
+HEADER = re.compile(r"calls\s+gpu \(ms\)\s+cpu \(ms\)\s+gpu %")
+DATA_ROW = re.compile(
+    r"^\[PERF\](?P<prefix>    |  )"
+    r"(?P<name>.+?)"
+    r"\s+(?P<calls>\d+)"
+    r"\s+(?P<gpu>[\d.]+|n/a)"
+    r"\s+(?P<cpu>[\d.]+)"
+    r"(?:\s+(?P<pct>[\d.]+%|n/a))?"
+    r"\s*$"
+)
+TOTAL_ROW = re.compile(r"^\[PERF\]\s+TOTAL\s+(?P<gpu>[\d.]+)\s+(?P<cpu>[\d.]+)\s*$")
+
+
+@dataclass
+class ShapeRow:
+    shape: str
+    calls: int
+    gpu_ms: float | None
+    cpu_ms: float
+    gpu_pct: float | None
+
+
+@dataclass
+class OpRow:
+    name: str
+    calls: int
+    gpu_ms: float | None
+    cpu_ms: float
+    gpu_pct: float | None
+    is_outer: bool = False
+    shapes: list[ShapeRow] = field(default_factory=list)
+
+    @property
+    def has_gpu(self) -> bool:
+        return self.gpu_ms is not None
+
+
+def read_log_text(path: Path) -> str:
+    raw = path.read_bytes()
+    if raw.startswith(b"\xff\xfe") or raw.startswith(b"\xfe\xff"):
+        return raw.decode("utf-16")
+    if raw.startswith(b"\xef\xbb\xbf"):
+        return raw.decode("utf-8-sig")
+    return raw.decode("utf-8", errors="replace")
+
+
+def _parse_float(value: str) -> float | None:
+    if value == "n/a":
+        return None
+    return float(value)
+
+
+def _parse_pct(value: str | None) -> float | None:
+    if value is None or value == "n/a":
+        return None
+    return float(value.rstrip("%"))
+
+
+def parse_perf_table(block: str) -> tuple[list[OpRow], float, float]:
+    ops: list[OpRow] = []
+    current: OpRow | None = None
+    total_gpu = 0.0
+    total_cpu = 0.0
+
+    for line in block.splitlines():
+        if SEP.match(line) or HEADER.search(line):
+            continue
+
+        total_match = TOTAL_ROW.match(line)
+        if total_match:
+            total_gpu = float(total_match.group("gpu"))
+            total_cpu = float(total_match.group("cpu"))
+            continue
+
+        row_match = DATA_ROW.match(line)
+        if not row_match:
+            continue
+
+        indent = row_match.group("prefix")
+        name = row_match.group("name").strip()
+        calls = int(row_match.group("calls"))
+        gpu_ms = _parse_float(row_match.group("gpu"))
+        cpu_ms = float(row_match.group("cpu"))
+        gpu_pct = _parse_pct(row_match.group("pct"))
+
+        if indent == "    ":
+            if current is None:
+                continue
+            current.shapes.append(
+                ShapeRow(
+                    shape=name,
+                    calls=calls,
+                    gpu_ms=gpu_ms,
+                    cpu_ms=cpu_ms,
+                    gpu_pct=gpu_pct,
+                )
+            )
+            continue
+
+        current = OpRow(
+            name=name, calls=calls, gpu_ms=gpu_ms, cpu_ms=cpu_ms, gpu_pct=gpu_pct
+        )
+        current.is_outer = name.startswith("[outer]")
+        ops.append(current)
+
+    if not ops:
+        raise ValueError("No [PERF] op rows found in extracted table block")
+
+    return ops, total_gpu, total_cpu
+
+
+def sort_perf_rows(ops: list[OpRow]) -> None:
+    for op in ops:
+        op.shapes.sort(key=lambda shape: -(shape.gpu_ms or 0.0))
+
+    ops.sort(
+        key=lambda op: (
+            -int(op.has_gpu),
+            -(op.gpu_ms or 0.0) if op.has_gpu else 0.0,
+            -op.cpu_ms if not op.has_gpu else 0.0,
+        )
+    )
+
+
+def format_perf_table(ops: list[OpRow], total_gpu: float, total_cpu: float) -> str:
+    max_name_len = 22
+    for op in ops:
+        max_name_len = max(max_name_len, len(op.name))
+        for shape in op.shapes:
+            if shape.shape:
+                max_name_len = max(max_name_len, len(shape.shape) + 2)
+
+    line_width = max_name_len + 2 + 5 + 1 + 9 + 1 + 9 + 1 + 6
+    lines = [
+        "[PERF] " + "=" * line_width,
+        f"[PERF]  {'':<{max_name_len}} {'calls':>5} {'gpu (ms)':>9} {'cpu (ms)':>9} {'gpu %':>6}",
+    ]
+
+    grand_total_gpu = sum(op.gpu_ms or 0.0 for op in ops if op.has_gpu)
+    if total_gpu <= 0:
+        total_gpu = grand_total_gpu
+
+    for op in ops:
+        if op.has_gpu:
+            pct = op.gpu_ms / total_gpu * 100 if total_gpu > 0 else 0.0
+            lines.append(
+                f"[PERF]  {op.name:<{max_name_len}} {op.calls:5d} {op.gpu_ms:9.1f} {op.cpu_ms:9.1f} {pct:5.1f}%"
+            )
+        else:
+            lines.append(
+                f"[PERF]  {op.name:<{max_name_len}} {op.calls:5d} {'n/a':>9} {op.cpu_ms:9.1f} {'n/a':>6}"
+            )
+
+        has_shapes = len(op.shapes) > 1 or (len(op.shapes) == 1 and op.shapes[0].shape)
+        if has_shapes:
+            for shape in op.shapes:
+                if not shape.shape:
+                    continue
+                pct = (
+                    shape.gpu_ms / total_gpu * 100
+                    if total_gpu > 0 and shape.gpu_ms is not None
+                    else 0.0
+                )
+                gpu_text = (
+                    f"{shape.gpu_ms:9.1f}"
+                    if shape.gpu_ms is not None
+                    else f"{'n/a':>9}"
+                )
+                pct_text = f"{pct:5.1f}%" if shape.gpu_ms is not None else f"{'n/a':>6}"
+                lines.append(
+                    f"[PERF]    {shape.shape:<{max_name_len - 2}} {shape.calls:5d} {gpu_text} {shape.cpu_ms:9.1f} {pct_text}"
+                )
+
+    lines.append(
+        f"[PERF]  {'TOTAL':<{max_name_len}} {'':>5} {total_gpu:9.1f} {total_cpu:9.1f}"
+    )
+    lines.append("[PERF] " + "=" * line_width)
+    return "\n".join(lines)
+
+
+def extract_last_perf_table(text: str) -> str:
+    lines = text.splitlines()
+    sep_indices = [i for i, line in enumerate(lines) if SEP.match(line)]
+
+    tables: list[str] = []
+    for idx, start in enumerate(sep_indices):
+        if idx + 1 >= len(sep_indices):
+            break
+        end = sep_indices[idx + 1]
+        block = lines[start : end + 1]
+        if any(HEADER.search(line) for line in block):
+            tables.append("\n".join(block))
+
+    if not tables:
+        raise ValueError(
+            "No [PERF] op table found (expected separator + calls/gpu/cpu header block)"
+        )
+
+    ops, total_gpu, total_cpu = parse_perf_table(tables[-1])
+    sort_perf_rows(ops)
+    return format_perf_table(ops, total_gpu, total_cpu)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Extract the last HIPDNN_EP_PERF per-op table from a perf_test log."
+    )
+    parser.add_argument(
+        "log_path", type=Path, help="Captured stdout+stderr from perf_test"
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        help="Write extracted table here (default: stdout)",
+    )
+    args = parser.parse_args()
+
+    if not args.log_path.is_file():
+        print(f"error: log file not found: {args.log_path}", file=sys.stderr)
+        return 1
+
+    table = extract_last_perf_table(read_log_text(args.log_path))
+
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(table + "\n", encoding="utf-8")
+        print(f"wrote {args.output}", file=sys.stderr)
+    else:
+        print(table)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.cursor/skills/ort-ep-profiling/scripts/ort_profile_shapes.py
+++ b/.cursor/skills/ort-ep-profiling/scripts/ort_profile_shapes.py
@@ -1,0 +1,586 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+
+"""Shape detail formatters aligned with hip-ep OP_PROFILE strings in lib/Runtime/real/."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+
+def _tensor(inp: list[dict], idx: int = 0) -> tuple[str, list[int]]:
+    spec = inp[idx]
+    dtype = next(iter(spec))
+    return dtype, list(spec[dtype])
+
+
+def _short_dtype(dtype: str) -> str:
+    return {
+        "float16": "f16",
+        "half": "f16",
+        "bfloat16": "bf16",
+        "float": "f32",
+        "double": "f64",
+        "int64": "i64",
+        "int32": "i32",
+        "int8": "i8",
+        "uint8": "u8",
+        "bool": "bool",
+    }.get(dtype, dtype)
+
+
+def _numel(shape: list[int]) -> int:
+    n = 1
+    for dim in shape:
+        n *= dim
+    return n
+
+
+def _pad4(shape: list[int]) -> list[int]:
+    dims = list(shape)
+    while len(dims) < 4:
+        dims.insert(0, 1)
+    return dims[-4:]
+
+
+def _output_tensor(node_args: dict, idx: int = 0) -> tuple[str, list[int]] | None:
+    outputs = node_args.get("output_type_shape")
+    if not outputs or idx >= len(outputs):
+        return None
+    return _tensor(outputs, idx)
+
+
+def default_shape(node_args: dict) -> str:
+    dtype, shape = _tensor(node_args["input_type_shape"], 0)
+    return f"{'x'.join(map(str, shape))},{_short_dtype(dtype)}"
+
+
+def conv_shape(node_args: dict) -> str:
+    """Conv: NxCxHxW,k=KxKhxKw,dt (matches wrap_miopenConvolutionForward)."""
+    dtype, x = _tensor(node_args["input_type_shape"], 0)
+    _, w = _tensor(node_args["input_type_shape"], 1)
+    dt = _short_dtype(dtype)
+    if len(w) == 4:
+        out_c, kh, kw = w[0], w[2], w[3]
+    elif len(w) == 3:
+        out_c, kh, kw = w[0], w[1], w[2]
+    else:
+        return default_shape(node_args)
+    if len(x) == 4:
+        n, c, h, wi = x
+    elif len(x) == 3:
+        n, c, h, wi = 1, x[0], x[1], x[2]
+    else:
+        return default_shape(node_args)
+    return f"{n}x{c}x{h}x{wi},k={out_c}x{kh}x{kw},{dt}"
+
+
+def conv_transpose_shape(node_args: dict) -> str:
+    dtype, x = _tensor(node_args["input_type_shape"], 0)
+    _, w = _tensor(node_args["input_type_shape"], 1)
+    dt = _short_dtype(dtype)
+    if len(x) != 4 or len(w) < 3:
+        return default_shape(node_args)
+    n, c, h, wi = x
+    kh, kw = (w[2], w[3]) if len(w) == 4 else (w[1], w[2])
+    out_c = w[0]
+    stride = 1
+    attrs = node_args.get("attributes") or {}
+    if "strides" in attrs:
+        strides = attrs["strides"]
+        stride = strides[0] if isinstance(strides, list) and strides else strides
+    return f"{n}x{c}x{h}x{wi},m={out_c},k={kh}x{kw},s={stride},{dt}"
+
+
+def gemm_shape(node_args: dict) -> str:
+    _, a = _tensor(node_args["input_type_shape"], 0)
+    _, b = _tensor(node_args["input_type_shape"], 1)
+
+    def mat_dims(shape: list[int]) -> tuple[int, int]:
+        if len(shape) == 1:
+            return 1, shape[0]
+        return shape[-2], shape[-1]
+
+    m, k = mat_dims(a)
+    k_b, n = mat_dims(b)
+    if k_b not in (k, 0):
+        k = k_b
+    return f"m={m},n={n},k={k}"
+
+
+def elementwise_shape(node_args: dict) -> str:
+    outputs = _output_tensor(node_args, 0)
+    if outputs:
+        _, shape = outputs
+    else:
+        _, shape = _tensor(node_args["input_type_shape"], 0)
+    n, c, h, w = _pad4(shape)
+    return f"{n}x{c}x{h}x{w}"
+
+
+def comparison_shape(node_args: dict) -> str:
+    outputs = _output_tensor(node_args, 0)
+    if outputs:
+        dtype, shape = outputs
+    else:
+        dtype, shape = _tensor(node_args["input_type_shape"], 0)
+    n, c, h, w = _pad4(shape)
+    return f"{n}x{c}x{h}x{w}:{_short_dtype(dtype)}"
+
+
+def unary_numel_shape(node_args: dict) -> str:
+    dtype, shape = _tensor(node_args["input_type_shape"], 0)
+    return f"{_numel(shape)}:{_short_dtype(dtype)}"
+
+
+def activation_n_shape(node_args: dict) -> str:
+    _, shape = _tensor(node_args["input_type_shape"], 0)
+    return f"n={_numel(shape)}"
+
+
+def gelu_shape(node_args: dict) -> str:
+    _, shape = _tensor(node_args["input_type_shape"], 0)
+    return f"n={_numel(shape)}"
+
+
+def bias_gelu_shape(node_args: dict) -> str:
+    _, x = _tensor(node_args["input_type_shape"], 0)
+    n = _numel(x)
+    if len(node_args["input_type_shape"]) > 1:
+        _, bias = _tensor(node_args["input_type_shape"], 1)
+        return f"n={n},bias={_numel(bias)}"
+    return f"n={n},bias=0"
+
+
+def softmax_shape(node_args: dict) -> str:
+    _, shape = _tensor(node_args["input_type_shape"], 0)
+    if len(shape) >= 2:
+        rows, cols = shape[-2], shape[-1]
+        return f"{rows}x{cols}"
+    return f"1x{_numel(shape)}"
+
+
+def layernorm_shape(node_args: dict) -> str:
+    inp = node_args["input_type_shape"]
+    dtype, x = _tensor(inp, 0)
+    scale = _tensor(inp, 1)[1] if len(inp) > 1 else []
+    hidden = scale[-1] if scale else (x[-1] if x else 0)
+    outer = _numel(x) // hidden if hidden else 0
+    dt = "f16" if "16" in dtype else "f32"
+    suffix = ":b" if len(inp) > 2 else ""
+    return f"{outer}x{hidden}:{dt}{suffix}"
+
+
+def skip_layernorm_shape(node_args: dict) -> str:
+    return layernorm_shape(node_args)
+
+
+def reduce_shape(node_args: dict) -> str:
+    _, x = _tensor(node_args["input_type_shape"], 0)
+    in_n = _numel(x)
+    out = _output_tensor(node_args, 0)
+    out_n = _numel(out[1]) if out else 0
+    return f"{in_n}->{out_n}"
+
+
+def reduce_labeled_shape(label: str) -> Callable[[dict], str]:
+    def fmt(node_args: dict) -> str:
+        detail = reduce_shape(node_args)
+        attrs = node_args.get("attributes") or {}
+        keep = attrs.get("keepdims")
+        suffix = ":keep" if keep in (1, True) else ""
+        return f"{detail}{suffix}"
+
+    _ = label
+    return fmt
+
+
+def cast_shape(node_args: dict) -> str:
+    _, shape = _tensor(node_args["input_type_shape"], 0)
+    return f"n={_numel(shape)}"
+
+
+def pool_shape(node_args: dict) -> str:
+    _, x = _tensor(node_args["input_type_shape"], 0)
+    n, c, in0, in1 = _pad4(x)
+    out = _output_tensor(node_args, 0)
+    if out:
+        _, y = out
+        _, _, out0, out1 = _pad4(y)
+    else:
+        out0, out1 = in0, in1
+    spatial_rank = max(len(x) - 2, 1)
+    return f"rank={spatial_rank},N={n},C={c},in=[{in0},{in1},1],out=[{out0},{out1},1]"
+
+
+def global_pool_shape(node_args: dict) -> str:
+    _, x = _tensor(node_args["input_type_shape"], 0)
+    if len(x) <= 1:
+        return default_shape(node_args)
+    outer = x[0]
+    reduce_size = _numel(x[1:])
+    p = (node_args.get("attributes") or {}).get("p", 2)
+    return f"outer={outer},reduce={reduce_size},p={p}"
+
+
+def gqa_shape(node_args: dict) -> str:
+    inp = node_args["input_type_shape"]
+    _, q = _tensor(inp, 0)
+    if len(q) == 3:
+        b, sq, hidden = q
+        h = (node_args.get("attributes") or {}).get("num_heads", 0)
+        d = hidden // h if h else 0
+        skv = (
+            _tensor(inp, 1)[1][-2]
+            if len(inp) > 1 and len(_tensor(inp, 1)[1]) >= 2
+            else sq
+        )
+        return f"b={b},sq={sq},skv={skv},h={h},d={d}"
+    return default_shape(node_args)
+
+
+def multi_head_attention_shape(node_args: dict) -> str:
+    inp = node_args["input_type_shape"]
+    _, q = _tensor(inp, 0)
+    attrs = node_args.get("attributes") or {}
+    unidirectional = attrs.get("unidirectional", 0)
+    causal = ",causal" if unidirectional in (1, True) else ""
+    if len(q) == 3:
+        b, sq, hidden = q
+        n = attrs.get("num_heads", 0)
+        h = hidden // n if n else 0
+        skv = sq
+        if len(inp) > 3:
+            _, k = _tensor(inp, 3)
+            if len(k) >= 2:
+                skv = k[-2]
+        return f"b={b},sq={sq},skv={skv},n={n},h={h}{causal}"
+    return default_shape(node_args)
+
+
+def rotary_emb_shape(node_args: dict) -> str:
+    attrs = node_args.get("attributes") or {}
+    inp = node_args["input_type_shape"]
+    _, x = _tensor(inp, 0)
+    num_heads = attrs.get("num_heads", 0)
+    head_dim = attrs.get("head_size", x[-1] if x else 0)
+    rotary_dim = attrs.get("rotary_embedding_dim", head_dim)
+    is_bnsh = 1 if len(x) == 4 else 0
+    return f"h={num_heads},hd={head_dim},rd={rotary_dim},bnsh={is_bnsh}"
+
+
+def gather_shape(node_args: dict) -> str:
+    _, x = _tensor(node_args["input_type_shape"], 0)
+    return f"n={_numel(x)}"
+
+
+def gather_elements_shape(node_args: dict) -> str:
+    _, x = _tensor(node_args["input_type_shape"], 0)
+    return f"r{len(x)}:n={_numel(x)}"
+
+
+def gather_nd_shape(node_args: dict) -> str:
+    inp = node_args["input_type_shape"]
+    _, data = _tensor(inp, 0)
+    idx_rank = len(_tensor(inp, 1)[1]) if len(inp) > 1 else 0
+    batch = len(data) if data else 0
+    dtype = _short_dtype(_tensor(inp, 0)[0])
+    return f"dr{len(data)}:ir{idx_rank}:bd={batch}:{dtype}"
+
+
+def slice_shape(node_args: dict) -> str:
+    inp = node_args["input_type_shape"]
+    _, x = _tensor(inp, 0)
+    starts_rank = len(_tensor(inp, 1)[1]) if len(inp) > 1 else 0
+    dtype = _short_dtype(_tensor(inp, 0)[0])
+    return f"r{len(x)}:K{starts_rank}:{dtype}"
+
+
+def transpose_shape(node_args: dict) -> str:
+    _, x = _tensor(node_args["input_type_shape"], 0)
+    return f"n={_numel(x)} rank={len(x)}"
+
+
+def pad_shape(node_args: dict) -> str:
+    _, x = _tensor(node_args["input_type_shape"], 0)
+    pads = node_args["input_type_shape"]
+    pad_count = len(pads[1]) if len(pads) > 1 else 0
+    dtype = _short_dtype(_tensor(node_args["input_type_shape"], 0)[0])
+    return f"r{len(x)}:{dtype}:pads={pad_count}"
+
+
+def resize_shape(node_args: dict) -> str:
+    _, x = _tensor(node_args["input_type_shape"], 0)
+    out = _output_tensor(node_args, 0)
+    if len(x) == 4:
+        _, _, in0, in1 = x
+        spatial_rank = 2
+        in2 = 1
+    else:
+        spatial_rank = max(len(x), 1)
+        in0, in1, in2 = (x + [1, 1, 1])[:3]
+    if out:
+        _, y = out
+        if len(y) == 4:
+            _, _, out0, out1 = y
+            out2 = 1
+        else:
+            out0, out1, out2 = (y + [1, 1, 1])[:3]
+    else:
+        out0, out1, out2 = in0, in1, in2
+    mode = (node_args.get("attributes") or {}).get("mode", 0)
+    return f"rank={spatial_rank},in=[{in0},{in1},{in2}],out=[{out0},{out1},{out2}],mode={mode}"
+
+
+def tile_shape(node_args: dict) -> str:
+    _, x = _tensor(node_args["input_type_shape"], 0)
+    reps = (
+        _tensor(node_args["input_type_shape"], 1)[1]
+        if len(node_args["input_type_shape"]) > 1
+        else []
+    )
+    return f"r{len(x)}:{'x'.join(map(str, reps)) if reps else '1'}"
+
+
+def expand_shape(node_args: dict) -> str:
+    _, x = _tensor(node_args["input_type_shape"], 0)
+    out = _output_tensor(node_args, 0)
+    in_n = _numel(x)
+    out_n = _numel(out[1]) if out else in_n
+    dtype = _short_dtype(_tensor(node_args["input_type_shape"], 0)[0])
+    return f"{in_n}->{out_n}:{dtype}"
+
+
+def cumsum_shape(node_args: dict) -> str:
+    _, x = _tensor(node_args["input_type_shape"], 0)
+    axis = (node_args.get("attributes") or {}).get("axis", 0)
+    exclusive = (node_args.get("attributes") or {}).get("exclusive", 0)
+    reverse = (node_args.get("attributes") or {}).get("reverse", 0)
+    return f"r{len(x)}:{axis}:{'ex' if exclusive else ''}{'rev' if reverse else ''}"
+
+
+def top_k_shape(node_args: dict) -> str:
+    _, x = _tensor(node_args["input_type_shape"], 0)
+    axis = (node_args.get("attributes") or {}).get("axis", -1)
+    return f"r{len(x)}:axis={axis}"
+
+
+def one_hot_shape(node_args: dict) -> str:
+    inp = node_args["input_type_shape"]
+    _, indices = _tensor(inp, 0)
+    axis = (node_args.get("attributes") or {}).get("axis", -1)
+    return f"axis={axis}:n={_numel(indices)}"
+
+
+def scatter_elements_shape(node_args: dict) -> str:
+    _, data = _tensor(node_args["input_type_shape"], 0)
+    axis = (node_args.get("attributes") or {}).get("axis", 0)
+    dtype = _short_dtype(_tensor(node_args["input_type_shape"], 0)[0])
+    return f"axis={axis}:{dtype}:n={_numel(data)}"
+
+
+def scatter_nd_shape(node_args: dict) -> str:
+    inp = node_args["input_type_shape"]
+    _, data = _tensor(inp, 0)
+    idx_rank = len(_tensor(inp, 1)[1]) if len(inp) > 1 else 0
+    dtype = _short_dtype(_tensor(inp, 0)[0])
+    updates = _short_dtype(_tensor(inp, 2)[0]) if len(inp) > 2 else dtype
+    return f"dr{len(data)}:ir{idx_rank}:{dtype}:{updates}"
+
+
+def compress_shape(node_args: dict) -> str:
+    inp = node_args["input_type_shape"]
+    _, data = _tensor(inp, 0)
+    axis = (node_args.get("attributes") or {}).get("axis", 0)
+    return f"flat={_numel(data)}:axis={axis}:n={len(data)}"
+
+
+def nonzero_shape(node_args: dict) -> str:
+    _, x = _tensor(node_args["input_type_shape"], 0)
+    dtype = _short_dtype(_tensor(node_args["input_type_shape"], 0)[0])
+    return f"numel={_numel(x)}:rank={len(x)}:{dtype}"
+
+
+def power_shape(node_args: dict) -> str:
+    _, x = _tensor(node_args["input_type_shape"], 0)
+    return f"n={_numel(x)}"
+
+
+def mod_shape(node_args: dict) -> str:
+    dtype, shape = _tensor(node_args["input_type_shape"], 0)
+    fmod = (node_args.get("attributes") or {}).get("fmod", 0)
+    return f"{_numel(shape)}:{_short_dtype(dtype)}{':fmod' if fmod else ''}"
+
+
+def qmoe_shape(node_args: dict) -> str:
+    inp = node_args["input_type_shape"]
+    _, x = _tensor(inp, 0)
+    experts = _tensor(inp, 1)[1][0] if len(inp) > 1 and _tensor(inp, 1)[1] else 0
+    if len(x) == 3:
+        return f"{x[0]}x{x[1]}x{x[2]},e={experts}"
+    return default_shape(node_args)
+
+
+def linear_attention_shape(node_args: dict) -> str:
+    inp = node_args["input_type_shape"]
+    _, q = _tensor(inp, 0)
+    attrs = node_args.get("attributes") or {}
+    if len(q) == 4:
+        b, sq, hq, dk = q[0], q[1], q[2], q[3]
+        hkv = attrs.get("kv_num_heads", hq)
+        dv = attrs.get("v_head_size", dk)
+        return f"b={b},sq={sq},hq={hq},hkv={hkv},dk={dk},dv={dv}"
+    return default_shape(node_args)
+
+
+def causal_conv_shape(node_args: dict) -> str:
+    dtype, x = _tensor(node_args["input_type_shape"], 0)
+    _, w = _tensor(node_args["input_type_shape"], 1)
+    dt = _short_dtype(dtype)
+    if len(x) >= 2 and len(w) >= 1:
+        return f"{x[0]}x{x[1]}x{len(x) if len(x) > 2 else 1},k={w[-1]},{dt}"
+    return default_shape(node_args)
+
+
+def memcpy_2d_shape(node_args: dict) -> str:
+    _, x = _tensor(node_args["input_type_shape"], 0)
+    if len(x) >= 2:
+        return f"w={x[-1]} h={x[-2]}"
+    return default_shape(node_args)
+
+
+def concat_shape(node_args: dict) -> str:
+    inp = node_args["input_type_shape"]
+    if not inp:
+        return ""
+    _, first = _tensor(inp, 0)
+    axis = (node_args.get("attributes") or {}).get("axis", 0)
+    return f"r{len(first)}:axis={axis}:inputs={len(inp)}"
+
+
+# ONNX / ORT op_name -> formatter (mirrors lib/Runtime/real/ OP_PROFILE labels)
+SHAPE_FNS: dict[str, Callable[[dict], str]] = {
+    # conv
+    "Conv": conv_shape,
+    "DmlFusedConv": conv_shape,
+    "ConvTranspose": conv_transpose_shape,
+    # gemm / matmul
+    "Gemm": gemm_shape,
+    "MatMul": gemm_shape,
+    "MatMulNBits": gemm_shape,
+    "FusedMatMul": gemm_shape,
+    "DmlFusedGemm": gemm_shape,
+    "QLinearMatMul": gemm_shape,
+    # pool
+    "MaxPool": pool_shape,
+    "AveragePool": pool_shape,
+    "LpPool": pool_shape,
+    "GlobalMaxPool": global_pool_shape,
+    "GlobalAveragePool": global_pool_shape,
+    "GlobalLpPool": global_pool_shape,
+    # elementwise binary
+    "Add": elementwise_shape,
+    "Sub": elementwise_shape,
+    "Mul": elementwise_shape,
+    "Div": elementwise_shape,
+    "And": elementwise_shape,
+    "Or": elementwise_shape,
+    "Xor": elementwise_shape,
+    "Min": elementwise_shape,
+    "Max": elementwise_shape,
+    "BitwiseAnd": elementwise_shape,
+    "BitwiseOr": elementwise_shape,
+    "BitwiseXor": elementwise_shape,
+    "DmlFusedAdd": elementwise_shape,
+    "DmlFusedMul": elementwise_shape,
+    "Prelu": elementwise_shape,
+    # comparisons
+    "Equal": comparison_shape,
+    "Less": comparison_shape,
+    "Greater": comparison_shape,
+    "LessOrEqual": comparison_shape,
+    "GreaterOrEqual": comparison_shape,
+    # unary
+    "Abs": unary_numel_shape,
+    "Neg": unary_numel_shape,
+    "Sign": unary_numel_shape,
+    "Sin": unary_numel_shape,
+    "Cos": unary_numel_shape,
+    "Exp": unary_numel_shape,
+    "Log": unary_numel_shape,
+    "Ceil": unary_numel_shape,
+    "Floor": unary_numel_shape,
+    "Not": unary_numel_shape,
+    "IsNaN": unary_numel_shape,
+    "Reciprocal": unary_numel_shape,
+    "Sqrt": unary_numel_shape,
+    "Erf": unary_numel_shape,
+    # activations
+    "Relu": activation_n_shape,
+    "Sigmoid": activation_n_shape,
+    "Tanh": activation_n_shape,
+    "Softplus": activation_n_shape,
+    "Softsign": activation_n_shape,
+    "HardSigmoid": activation_n_shape,
+    "LeakyRelu": activation_n_shape,
+    "Elu": activation_n_shape,
+    "Selu": activation_n_shape,
+    "ThresholdedRelu": activation_n_shape,
+    "Gelu": gelu_shape,
+    "FastGelu": bias_gelu_shape,
+    "BiasGelu": bias_gelu_shape,
+    "QuickGelu": gelu_shape,
+    # softmax
+    "Softmax": softmax_shape,
+    "LogSoftmax": softmax_shape,
+    # norm
+    "LayerNormalization": layernorm_shape,
+    "SimplifiedLayerNormalization": skip_layernorm_shape,
+    "SkipLayerNormalization": skip_layernorm_shape,
+    "SkipSimplifiedLayerNormalization": skip_layernorm_shape,
+    # reduce
+    "ReduceSum": reduce_shape,
+    "ReduceMean": reduce_shape,
+    "ReduceMax": reduce_labeled_shape("reduce_max"),
+    "ReduceMin": reduce_labeled_shape("reduce_min"),
+    "ReduceProd": reduce_labeled_shape("reduce_prod"),
+    "ReduceL2": reduce_shape,
+    "ArgMax": reduce_shape,
+    "ArgMin": reduce_shape,
+    # attention
+    "GroupQueryAttention": gqa_shape,
+    "MultiHeadAttention": multi_head_attention_shape,
+    "RotaryEmbedding": rotary_emb_shape,
+    "LinearAttention": linear_attention_shape,
+    # data movement / layout
+    "Cast": cast_shape,
+    "Gather": gather_shape,
+    "GatherElements": gather_elements_shape,
+    "GatherND": gather_nd_shape,
+    "Slice": slice_shape,
+    "Transpose": transpose_shape,
+    "Pad": pad_shape,
+    "Resize": resize_shape,
+    "Tile": tile_shape,
+    "Expand": expand_shape,
+    "CumSum": cumsum_shape,
+    "TopK": top_k_shape,
+    "OneHot": one_hot_shape,
+    "ScatterElements": scatter_elements_shape,
+    "ScatterND": scatter_nd_shape,
+    "Compress": compress_shape,
+    "NonZero": nonzero_shape,
+    "Pow": power_shape,
+    "Mod": mod_shape,
+    "Concat": concat_shape,
+    "Qmoe": qmoe_shape,
+    "CausalConv": causal_conv_shape,
+}
+
+
+def shape_detail(node_args: dict) -> str:
+    op_type = node_args["op_name"]
+    shape_fn = SHAPE_FNS.get(op_type, default_shape)
+    return shape_fn(node_args)

--- a/.cursor/skills/ort-ep-profiling/scripts/ort_profile_table.py
+++ b/.cursor/skills/ort-ep-profiling/scripts/ort_profile_table.py
@@ -1,0 +1,139 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+
+"""Summarize onnxruntime_perf_test -p profile JSON into an op/shape table."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
+
+from ort_profile_shapes import shape_detail  # noqa: E402
+
+
+def last_session_nodes(trace_path: Path) -> list[dict]:
+    import json
+
+    with trace_path.open(encoding="utf-8") as fp:
+        trace = json.load(fp)
+
+    sessions = [x for x in trace if x["cat"] == "Session" and x["name"] == "model_run"]
+    if not sessions:
+        raise ValueError(f"No Session/model_run events found in {trace_path}")
+
+    last_session = max(sessions, key=lambda x: x["ts"])
+    start = last_session["ts"]
+    end = last_session["ts"] + last_session["dur"]
+
+    return [
+        x
+        for x in trace
+        if x["cat"] == "Node" and x["ts"] > start and (x["ts"] + x["dur"]) < end
+    ]
+
+
+def summarize_trace(trace_path: Path) -> list[tuple[str, str, int, float]]:
+    stats: dict[str, dict[str, dict[str, float | int]]] = {}
+
+    for node in last_session_nodes(trace_path):
+        node_args = node["args"]
+        op_type = node_args["op_name"]
+        op_stats = stats.setdefault(op_type, {})
+
+        shape = shape_detail(node_args)
+        op_shape_stats = op_stats.setdefault(shape, {})
+
+        op_shape_stats["num_calls"] = int(op_shape_stats.get("num_calls", 0)) + 1
+        op_shape_stats["latency"] = float(op_shape_stats.get("latency", 0.0)) + (
+            node["dur"] / 1000
+        )
+
+    rows: list[tuple[str, str, int, float]] = []
+    for op_type, op_stats in stats.items():
+        for shape, op_shape_stats in op_stats.items():
+            rows.append(
+                (
+                    op_type,
+                    shape,
+                    int(op_shape_stats["num_calls"]),
+                    float(op_shape_stats["latency"]),
+                )
+            )
+    return rows
+
+
+def summarize_by_op(
+    rows: list[tuple[str, str, int, float]],
+) -> list[tuple[str, int, float]]:
+    totals: dict[str, dict[str, float | int]] = {}
+    for op_type, _, num_calls, latency_ms in rows:
+        op_total = totals.setdefault(op_type, {"calls": 0, "time_ms": 0.0})
+        op_total["calls"] = int(op_total["calls"]) + num_calls
+        op_total["time_ms"] = float(op_total["time_ms"]) + latency_ms
+
+    return sorted(
+        (
+            (op_type, int(stats["calls"]), float(stats["time_ms"]))
+            for op_type, stats in totals.items()
+        ),
+        key=lambda item: -item[2],
+    )
+
+
+def print_op_summary(rows: list[tuple[str, str, int, float]], out_fp) -> None:
+    print("Op summary (sorted by total time):", file=out_fp)
+    print("Op", "Calls", "Time (ms)", sep="\t", file=out_fp)
+    for op_type, num_calls, latency_ms in summarize_by_op(rows):
+        print(op_type, num_calls, f"{latency_ms:.3f}", sep="\t", file=out_fp)
+
+
+def print_table(rows: list[tuple[str, str, int, float]], out_fp) -> None:
+    print("Op", "Detail", "Calls", "Time (ms)", sep="\t", file=out_fp)
+    for op_type, shape, num_calls, latency_ms in rows:
+        print(op_type, shape, num_calls, f"{latency_ms:.3f}", sep="\t", file=out_fp)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Convert onnxruntime_perf_test profile JSON to an op/shape table."
+    )
+    parser.add_argument(
+        "trace_path", type=Path, help="profile_<timestamp>.json from -p profile"
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        help="Write TSV here (default: stdout)",
+    )
+    args = parser.parse_args()
+
+    if not args.trace_path.is_file():
+        print(f"error: trace file not found: {args.trace_path}", file=sys.stderr)
+        return 1
+
+    rows = summarize_trace(args.trace_path)
+    print_op_summary(rows, sys.stderr)
+    print(file=sys.stderr)
+
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        with args.output.open("w", encoding="utf-8", newline="\n") as fp:
+            print_table(rows, fp)
+        print(f"wrote {args.output}", file=sys.stderr)
+    else:
+        print_op_summary(rows, sys.stdout)
+        print(file=sys.stdout)
+        print_table(rows, sys.stdout)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
<!--
Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
Licensed under the MIT License.
-->

## Summary

Add a Cursor agent skill and helper scripts for comparing per-op ONNX Runtime performance across **HIP** (hipgpu plugin EP), **DML**, and **CPU** using `onnxruntime_perf_test`. The skill documents EP-specific run commands, enforces serial profiling (no concurrent EP runs), and post-processes results into comparable op/shape tables: HIP uses the last `HIPDNN_EP_PERF` table from perf_test stdout; CPU/DML use ORT `profile_*.json` converted via shared shape formatters aligned with hip-ep's `OP_PROFILE` labels.

## Related issue or design

None

## Why

Comparing HIP, DML, and CPU performance today requires different artifacts and manual parsing: hip-ep's useful breakdown comes from `HIPDNN_EP_PERF` stderr output (not ORT profile JSON), while CPU/DML rely on `-p profile` traces that need aggregation and shape labeling. Stale `profile_*.json` files and multiple `[PERF]` tables from `-r 2` warmup runs are easy to misread. This skill codifies the correct workflow so agents and developers produce consistent, apples-to-apples op/shape reports without re-deriving the steps each time.

## What

- **`.cursor/skills/ort-ep-profiling/SKILL.md`** — agent workflow: required inputs, EP-specific `onnxruntime_perf_test` flags, serial-run rules, and reporting checklist.
- **`scripts/clean_profile_files.py`** — delete stale `profile_*.json` before CPU/DML runs.
- **`scripts/extract_hip_perf_table.py`** — parse perf_test log (UTF-8/UTF-16), extract the **last** `[PERF]` table, sort and reformat.
- **`scripts/ort_profile_shapes.py`** — ONNX op → shape detail strings mirroring `lib/Runtime/real/` `OP_PROFILE` formatters (Conv, Gemm, GQA, LayerNorm, etc.).
- **`scripts/ort_profile_table.py`** — summarize the last `model_run` session from ORT profile JSON into op/shape TSV plus op-type summary.

## Test plan

- No repo unit tests added — scripts are standalone profiling helpers under `.cursor/skills/`; no compiler/runtime behavior changed.

## Notes for reviewers

- This is agent/tooling only; no changes to compiler, runtime, or CI.
- `HIPDNN_EP_PERF=1` adds profiling overhead — intentional for op breakdown, not for raw throughput benchmarks (called out in the skill).
- DML graph fusion is disabled in the documented command so fused ops stay visible at per-op granularity.
- Untracked local profiling artifacts in the workspace (`ort_profile_*.tsv`, `sample_*.json`, etc.) are **not** part of this branch.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [ ] Relevant tests were added or updated and the results are documented.
- [x] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.
