### PR TITLE
chore: add amd-bqiao to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,45 +17,45 @@
 # compiler tree here because it shares the same owners today; split into
 # its own runtime entry if a runtime-only owner joins.
 # ---------------------------------------------------------------------------
-/lib/Compiler/                  @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd
-/lib/Conversion/                @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd
-/lib/Dialect/                   @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd
-/lib/Target/                    @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd
-/lib/CInterface/                @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd
-/include/hip/Compiler/          @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd
-/include/hip/Conversion/        @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd
-/include/hip/Dialect/           @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd
-/include/hip/Target/            @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd
-/include/hip/Support/           @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd
-/include/hip/InitAllPasses.h    @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd
-/include/hip/compiler_api.h     @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd
-/include/hip/compiler_types.h   @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd
-/backend-mlir-compiler/         @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd
-/morphizen_mlir_init/           @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd
-/schemas/                       @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd
-/test/lit/                      @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd
-/tools/hip-compiler/            @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd
-/tools/hip-mlir-opt/            @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd
-/tools/hip-inspect/             @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd
+/lib/Compiler/                  @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
+/lib/Conversion/                @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
+/lib/Dialect/                   @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
+/lib/Target/                    @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
+/lib/CInterface/                @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
+/include/hip/Compiler/          @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
+/include/hip/Conversion/        @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
+/include/hip/Dialect/           @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
+/include/hip/Target/            @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
+/include/hip/Support/           @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
+/include/hip/InitAllPasses.h    @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
+/include/hip/compiler_api.h     @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
+/include/hip/compiler_types.h   @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
+/backend-mlir-compiler/         @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
+/morphizen_mlir_init/           @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
+/schemas/                       @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
+/test/lit/                      @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
+/tools/hip-compiler/            @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
+/tools/hip-mlir-opt/            @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
+/tools/hip-inspect/             @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
 
 # ---------------------------------------------------------------------------
 # Runtime: EP runtime state, real/mock GPU backends, graph runtime, runtime
 # test tools that exercise the EP ABI.
 # ---------------------------------------------------------------------------
-/lib/Runtime/                   @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd
-/lib/HipDNNGraphRuntime/        @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd
-/tools/hip-onnx-runner/         @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd
-/tools/hip-test/                @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd
+/lib/Runtime/                   @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
+/lib/HipDNNGraphRuntime/        @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
+/tools/hip-onnx-runner/         @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
+/tools/hip-test/                @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
 
 # ---------------------------------------------------------------------------
 # Shared: utilities and graph machinery used by both compiler and runtime.
 # ---------------------------------------------------------------------------
-/lib/Support/                   @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd
-/lib/HipDNNGraph/               @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd
+/lib/Support/                   @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
+/lib/HipDNNGraph/               @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
 
 # ---------------------------------------------------------------------------
 # Tests + design docs: integration / accuracy / TPS coverage and
 # architecture decisions.
 # ---------------------------------------------------------------------------
-/test/python/                   @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd
-/docs/design/                   @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd
+/test/python/                   @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
+/docs/design/                   @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao


### PR DESCRIPTION
Adding `amd-bqiao` as one of the codeowners as per the discussion.