### PR TITLE
perf(gqa): support sliding windows in the fused flash prefill kernel (-65.7% TTFT cumulative)

### DIFF
--- a/lib/Runtime/Kernels/hip/gqa_kernel.hip
+++ b/lib/Runtime/Kernels/hip/gqa_kernel.hip
@@ -3664,11 +3664,14 @@ static int prefillV5Run(
     _Float16* O_ptr       = static_cast<_Float16*>(O);
     const _Float16* sink_ptr = static_cast<const _Float16*>(head_sink);
 
-    // The sink is absent from the key on purpose: it does not change the tuned
-    // tile shape (see tunePrefillV5Cfg).
+    // Neither skv nor the sink belongs in the key. skv only scales the KV loop
+    // length, uniformly across candidates, so it cannot reorder them: measured
+    // on gpt-oss-20b, M_TILES=2/BKV=32 wins at all 32 chunk skv values from 512
+    // to 16384 with an identical candidate ranking. Keying on skv re-tuned once
+    // per chunk of a chunked prefill instead of once per process. The sink is
+    // one FMA per row in the epilogue (see tunePrefillV5Cfg).
     std::string key = std::to_string(d) + "_" + std::to_string(sq) + "_" +
-                      std::to_string(skv) + "_" + std::to_string(Hq) + "_" +
-                      std::to_string(G);
+                      std::to_string(Hq) + "_" + std::to_string(G);
     int cfg;
     {
         std::lock_guard<std::mutex> lk(g_v5_cfg_mutex);

--- a/lib/Runtime/Kernels/hip/gqa_kernel.hip
+++ b/lib/Runtime/Kernels/hip/gqa_kernel.hip
@@ -2500,7 +2500,9 @@ gqa_flash_prefill_v5_kernel(
     const _Float16* __restrict__ Vcache,  // [B, G, max_seq, D]
     _Float16* __restrict__ O,             // [B, sq, Hq, D]
     int B_count, int Hq, int G, int sq, int skv, int max_seq, int past_len,
-    float scale, int ablate)
+    float scale, int ablate,
+    const _Float16* __restrict__ head_sink,  // [num_heads] or null
+    int num_heads, int smooth_softmax)
 {
     // ablation bitmask (perf diagnostics only; wrong numerics):
     //   bit0 skip softmax, bit1 skip valueGEMM, bit2 skip scoreGEMM,
@@ -2697,6 +2699,36 @@ gqa_flash_prefill_v5_kernel(
         __syncthreads();   // WAR: P_lds reused by next tile's softmax
     }
 
+    // ---- Attention sink: one extra term in the softmax denominator ----
+    // m_reg / l_reg are in log2 space (scores were premultiplied by
+    // scale * kLog2e above and exp2f is used for both), so m_reg == m_nat *
+    // kLog2e and the natural-units sink term exp(s - m_nat) becomes
+    // exp2(s * kLog2e - m_reg) -- the same identity the decode reduce kernel
+    // documents. Row-invariant in the D dimension, so it is folded into l once
+    // here rather than inside the D_TILES loop below.
+    //
+    // smooth_softmax with a null sink means s = 0, matching
+    // softmax_f32_to_out_kernel. A row where every key was masked keeps
+    // m_reg == -INFINITY; it must be skipped, because the exponent would
+    // otherwise be +inf and the whole row would come out zero instead of
+    // sink-only.
+    float l_final[M_TILES][8];
+    const bool apply_sink = (head_sink != nullptr) || (smooth_softmax != 0);
+    float sink_logit = 0.0f;
+    if (head_sink != nullptr)
+        sink_logit = static_cast<float>(
+            head_sink[num_heads > 0 ? (head_q % num_heads) : head_q]);
+    #pragma unroll
+    for (int mi = 0; mi < M_TILES; ++mi) {
+        #pragma unroll
+        for (int e = 0; e < 8; ++e) {
+            float l = l_reg[mi][e];
+            if (apply_sink && m_reg[mi][e] > -INFINITY)
+                l += exp2f(sink_logit * kLog2e - m_reg[mi][e]);
+            l_final[mi][e] = fmaxf(l, 1e-6f);
+        }
+    }
+
     // ---- Epilogue: O / l ----
     #pragma unroll
     for (int mi = 0; mi < M_TILES; ++mi) {
@@ -2708,8 +2740,7 @@ gqa_flash_prefill_v5_kernel(
                 const int c     = tj * 16 + wmma_lane;
                 const int q_pos = q_start + row;
                 if (q_pos < sq && c < D) {
-                    const float l_val   = fmaxf(l_reg[mi][e], 1e-6f);
-                    const float out_val = O_frag[mi][tj][e] / l_val;
+                    const float out_val = O_frag[mi][tj][e] / l_final[mi][e];
                     O[(static_cast<size_t>(batch * sq + q_pos) * Hq + head_q) * D + c] =
                         static_cast<_Float16>(out_val);
                 }
@@ -2734,7 +2765,8 @@ static inline void dispatchPrefillV5(
     int m_tiles, int bkv, int d, hipStream_t stream,
     const _Float16* Q, const _Float16* Kcache, const _Float16* Vcache,
     _Float16* O, int B, int Hq, int G, int sq, int skv, int max_seq,
-    int past_len, float scale)
+    int past_len, float scale,
+    const _Float16* head_sink, int num_heads, int smooth_softmax)
 {
     const int rows = m_tiles * 16;
     const int num_q_tiles = (sq + rows - 1) / rows;
@@ -2746,7 +2778,7 @@ static inline void dispatchPrefillV5(
         gqa_flash_prefill_v5_kernel<MT_, BKV_, D_>                              \
             <<<grid, 32, smem, stream>>>(                                       \
                 Q, Kcache, Vcache, O, B, Hq, G, sq, skv, max_seq, past_len,     \
-                scale, ablate)
+                scale, ablate, head_sink, num_heads, smooth_softmax)
 
     if (d == 64) {
         if (m_tiles == 2 && bkv == 64)      LAUNCH_V5(2, 64, 64);
@@ -2786,9 +2818,13 @@ static int tunePrefillV5Cfg(
     const int nc = prefillV5Candidates(d, cands);
     constexpr int kWarmup = 30, kRounds = 4, kIters = 30;
 
+    // Tuning launches carry no sink: it is a single fused-multiply-add per row in
+    // the epilogue, so it cannot shift which (M_TILES, BKV) wins, and leaving it
+    // out keeps tuned configs comparable with the non-sink case.
     auto launch_cfg = [&](const PrefillV5Cfg& c) {
         dispatchPrefillV5(c.m_tiles, c.bkv, d, stream, Q, Kcache, Vcache, O,
-                          B, Hq, G, sq, skv, max_seq, past_len, scale);
+                          B, Hq, G, sq, skv, max_seq, past_len, scale,
+                          nullptr, Hq, 0);
     };
 
     for (int w = 0; w < kWarmup; ++w) launch_cfg(cands[w % nc]);
@@ -3613,11 +3649,11 @@ extern "C" void hip_gqa_flash_prefill_v5_set_ablate(int mask) {
     g_v5_ablate = mask;
 }
 
-extern "C" int hip_gqa_flash_prefill_v5_v2(
+static int prefillV5Run(
     void* stream_ptr,
     const void* Q, const void* Kcache, const void* Vcache, void* O,
     int B, int Hq, int G, int sq, int skv, int d, int max_seq, int past_len,
-    float scale)
+    float scale, const void* head_sink, int num_heads, int smooth_softmax)
 {
     if (d != 64 && d != 128) return -1;
 
@@ -3626,7 +3662,10 @@ extern "C" int hip_gqa_flash_prefill_v5_v2(
     const _Float16* K_ptr = static_cast<const _Float16*>(Kcache);
     const _Float16* V_ptr = static_cast<const _Float16*>(Vcache);
     _Float16* O_ptr       = static_cast<_Float16*>(O);
+    const _Float16* sink_ptr = static_cast<const _Float16*>(head_sink);
 
+    // The sink is absent from the key on purpose: it does not change the tuned
+    // tile shape (see tunePrefillV5Cfg).
     std::string key = std::to_string(d) + "_" + std::to_string(sq) + "_" +
                       std::to_string(skv) + "_" + std::to_string(Hq) + "_" +
                       std::to_string(G);
@@ -3646,8 +3685,19 @@ extern "C" int hip_gqa_flash_prefill_v5_v2(
     }
     int m_tiles = cfg / 1000, bkv = cfg % 1000;
     dispatchPrefillV5(m_tiles, bkv, d, stream, Q_ptr, K_ptr, V_ptr, O_ptr,
-                      B, Hq, G, sq, skv, max_seq, past_len, scale);
+                      B, Hq, G, sq, skv, max_seq, past_len, scale,
+                      sink_ptr, num_heads, smooth_softmax);
     return 0;
+}
+
+extern "C" int hip_gqa_flash_prefill_v5_v2(
+    void* stream_ptr,
+    const void* Q, const void* Kcache, const void* Vcache, void* O,
+    int B, int Hq, int G, int sq, int skv, int d, int max_seq, int past_len,
+    float scale)
+{
+    return prefillV5Run(stream_ptr, Q, Kcache, Vcache, O, B, Hq, G, sq, skv, d,
+                        max_seq, past_len, scale, nullptr, Hq, 0);
 }
 
 
@@ -3714,6 +3764,33 @@ extern "C" void hip_gqa_flash_prefill_v8_set_ablate(int mask) {
 // to lift occupancy). The runtime only has to call this one symbol for any
 // eligible (fp16, causal, GQA) prefill and gets the right kernel automatically.
 // Returns -1 for unsupported head dims so the caller can fall back.
+// Wide entry: adds attention sinks (and reserves sliding-window) on top of v2.
+// v2 stays the narrow ABI so the standalone harnesses and shim headers that
+// redeclare it keep linking unchanged.
+//
+// Sinks are implemented for d == 64 (the v5 kernel) only. For any other d we
+// return -1 rather than silently ignoring the sink, so the runtime keeps routing
+// those shapes to the decomposed path, which does implement it.
+extern "C" int hip_gqa_flash_prefill_v3(
+    void* stream_ptr,
+    const void* Q, const void* Kcache, const void* Vcache, void* O,
+    int B, int Hq, int G, int sq, int skv, int d, int max_seq, int past_len,
+    float scale, int local_window_size, const void* head_sink,
+    int num_heads, int smooth_softmax)
+{
+    const bool wants_sink = (head_sink != nullptr) || (smooth_softmax != 0);
+    // Sliding window is not implemented in the flash prefill kernels yet.
+    if (local_window_size > 0) return -1;
+    if (wants_sink && d != 64) return -1;
+    if (!wants_sink) {
+        return hip_gqa_flash_prefill_v2(stream_ptr, Q, Kcache, Vcache, O, B, Hq,
+                                        G, sq, skv, d, max_seq, past_len, scale);
+    }
+    return prefillV5Run(stream_ptr, Q, Kcache, Vcache, O, B, Hq, G, sq, skv, d,
+                        max_seq, past_len, scale, head_sink, num_heads,
+                        smooth_softmax);
+}
+
 extern "C" int hip_gqa_flash_prefill_v2(
     void* stream_ptr,
     const void* Q, const void* Kcache, const void* Vcache, void* O,

--- a/lib/Runtime/Kernels/hip/gqa_kernel.hip
+++ b/lib/Runtime/Kernels/hip/gqa_kernel.hip
@@ -2502,7 +2502,8 @@ gqa_flash_prefill_v5_kernel(
     int B_count, int Hq, int G, int sq, int skv, int max_seq, int past_len,
     float scale, int ablate,
     const _Float16* __restrict__ head_sink,  // [num_heads] or null
-    int num_heads, int smooth_softmax)
+    int num_heads, int smooth_softmax,
+    int local_window_size)                   // <= 0 for full attention
 {
     // ablation bitmask (perf diagnostics only; wrong numerics):
     //   bit0 skip softmax, bit1 skip valueGEMM, bit2 skip scoreGEMM,
@@ -2594,11 +2595,22 @@ gqa_flash_prefill_v5_kernel(
                     S_reg[mi][sj][e] *= scale * kLog2e;
     };
 
+    const bool has_window = local_window_size > 0;
     const int kv_max    = (skv - 1 < past_len + q_start + ROWS - 1)
                               ? (skv - 1) : (past_len + q_start + ROWS - 1);
     const int num_tiles = kv_max / BKV + 1;
 
-    for (int t = 0; t < num_tiles; ++t) {
+    // With a window, every row in this Q tile has a lower bound at least as high
+    // as the first row's, so starting from the first row's bound covers the whole
+    // tile and the per-row mask trims the rest. This is what makes the window
+    // cheaper rather than merely masked: the number of tiles walked stops growing
+    // with skv once the window is filled.
+    const int kv_lo_tile = has_window
+                               ? (past_len + q_start - local_window_size + 1)
+                               : 0;
+    const int t_start = (kv_lo_tile > 0) ? (kv_lo_tile / BKV) : 0;
+
+    for (int t = t_start; t < num_tiles; ++t) {
         const int kv0 = t * BKV;
 
         // Stage V tile into LDS with coalesced HALF16 loads along D.
@@ -2631,12 +2643,15 @@ gqa_flash_prefill_v5_kernel(
             for (int e = 0; e < 8; ++e) {
                 const int row    = mi * 16 + e * 2 + pair;        // local q row
                 const int q_pos  = q_start + row;
-                // causal mask + per-row partial max over this lane's columns
+                // causal mask, sliding-window lower bound, and per-row partial
+                // max over this lane's columns
+                const int abs_q = past_len + q_pos;
+                const int kv_lo = has_window ? (abs_q - local_window_size + 1) : 0;
                 float rmax = -INFINITY;
                 #pragma unroll
                 for (int sj = 0; sj < S_TILES_J; ++sj) {
                     const int kv_pos = kv0 + sj * 16 + wmma_lane;
-                    if (kv_pos >= skv || kv_pos > past_len + q_pos)
+                    if (kv_pos >= skv || kv_pos > abs_q || kv_pos < kv_lo)
                         S_reg[mi][sj][e] = -INFINITY;
                     rmax = fmaxf(rmax, S_reg[mi][sj][e]);
                 }
@@ -2647,13 +2662,20 @@ gqa_flash_prefill_v5_kernel(
 
                 const float m_old = m_reg[mi][e];
                 const float m_new = fmaxf(m_old, rmax);
-                const float corr  = exp2f(m_old - m_new);
+                // A window can mask a whole tile for a row while that row has
+                // still seen nothing, leaving m_old and m_new both at -inf.
+                // exp2f(-inf - -inf) is NaN, so short-circuit: contribute
+                // nothing and leave the running state untouched. Causal-only
+                // never reaches this, since tile 0 always holds key 0.
+                const bool empty = (m_new == -INFINITY);
+                const float corr  = empty ? 1.0f : exp2f(m_old - m_new);
                 corr_reg[mi][e]   = corr;
 
                 float rsum = 0.0f;
                 #pragma unroll
                 for (int sj = 0; sj < S_TILES_J; ++sj) {
-                    const float p = exp2f(S_reg[mi][sj][e] - m_new);
+                    const float p =
+                        empty ? 0.0f : exp2f(S_reg[mi][sj][e] - m_new);
                     rsum += p;
                     P_lds[row * P_STR + sj * 16 + wmma_lane] = static_cast<_Float16>(p);
                 }
@@ -2766,7 +2788,8 @@ static inline void dispatchPrefillV5(
     const _Float16* Q, const _Float16* Kcache, const _Float16* Vcache,
     _Float16* O, int B, int Hq, int G, int sq, int skv, int max_seq,
     int past_len, float scale,
-    const _Float16* head_sink, int num_heads, int smooth_softmax)
+    const _Float16* head_sink, int num_heads, int smooth_softmax,
+    int local_window_size)
 {
     const int rows = m_tiles * 16;
     const int num_q_tiles = (sq + rows - 1) / rows;
@@ -2778,7 +2801,8 @@ static inline void dispatchPrefillV5(
         gqa_flash_prefill_v5_kernel<MT_, BKV_, D_>                              \
             <<<grid, 32, smem, stream>>>(                                       \
                 Q, Kcache, Vcache, O, B, Hq, G, sq, skv, max_seq, past_len,     \
-                scale, ablate, head_sink, num_heads, smooth_softmax)
+                scale, ablate, head_sink, num_heads, smooth_softmax,            \
+                local_window_size)
 
     if (d == 64) {
         if (m_tiles == 2 && bkv == 64)      LAUNCH_V5(2, 64, 64);
@@ -2812,7 +2836,7 @@ static int tunePrefillV5Cfg(
     int d, hipStream_t stream,
     const _Float16* Q, const _Float16* Kcache, const _Float16* Vcache,
     _Float16* O, int B, int Hq, int G, int sq, int skv, int max_seq,
-    int past_len, float scale)
+    int past_len, float scale, int local_window_size)
 {
     PrefillV5Cfg cands[8];
     const int nc = prefillV5Candidates(d, cands);
@@ -2820,11 +2844,13 @@ static int tunePrefillV5Cfg(
 
     // Tuning launches carry no sink: it is a single fused-multiply-add per row in
     // the epilogue, so it cannot shift which (M_TILES, BKV) wins, and leaving it
-    // out keeps tuned configs comparable with the non-sink case.
+    // out keeps tuned configs comparable with the non-sink case. The window is
+    // passed through, because it changes how many KV tiles each block walks and
+    // therefore genuinely can change the winner.
     auto launch_cfg = [&](const PrefillV5Cfg& c) {
         dispatchPrefillV5(c.m_tiles, c.bkv, d, stream, Q, Kcache, Vcache, O,
                           B, Hq, G, sq, skv, max_seq, past_len, scale,
-                          nullptr, Hq, 0);
+                          nullptr, Hq, 0, local_window_size);
     };
 
     for (int w = 0; w < kWarmup; ++w) launch_cfg(cands[w % nc]);
@@ -3653,7 +3679,8 @@ static int prefillV5Run(
     void* stream_ptr,
     const void* Q, const void* Kcache, const void* Vcache, void* O,
     int B, int Hq, int G, int sq, int skv, int d, int max_seq, int past_len,
-    float scale, const void* head_sink, int num_heads, int smooth_softmax)
+    float scale, const void* head_sink, int num_heads, int smooth_softmax,
+    int local_window_size)
 {
     if (d != 64 && d != 128) return -1;
 
@@ -3670,8 +3697,12 @@ static int prefillV5Run(
     // to 16384 with an identical candidate ranking. Keying on skv re-tuned once
     // per chunk of a chunked prefill instead of once per process. The sink is
     // one FMA per row in the epilogue (see tunePrefillV5Cfg).
+    //
+    // The window does belong in the key: it caps how many KV tiles a block walks,
+    // which is a different work profile, not a scaled one.
     std::string key = std::to_string(d) + "_" + std::to_string(sq) + "_" +
-                      std::to_string(Hq) + "_" + std::to_string(G);
+                      std::to_string(Hq) + "_" + std::to_string(G) + "_w" +
+                      std::to_string(local_window_size > 0 ? local_window_size : 0);
     int cfg;
     {
         std::lock_guard<std::mutex> lk(g_v5_cfg_mutex);
@@ -3680,7 +3711,8 @@ static int prefillV5Run(
             cfg = it->second;
         } else {
             cfg = tunePrefillV5Cfg(d, stream, Q_ptr, K_ptr, V_ptr, O_ptr,
-                                   B, Hq, G, sq, skv, max_seq, past_len, scale);
+                                   B, Hq, G, sq, skv, max_seq, past_len, scale,
+                                   local_window_size);
             g_v5_cfg_cache[key] = cfg;
             snprintf(g_v5_tune_info, sizeof(g_v5_tune_info),
                      "gqa_flash_prefill_v5 cfg=M%d_BKV%d", cfg / 1000, cfg % 1000);
@@ -3689,7 +3721,7 @@ static int prefillV5Run(
     int m_tiles = cfg / 1000, bkv = cfg % 1000;
     dispatchPrefillV5(m_tiles, bkv, d, stream, Q_ptr, K_ptr, V_ptr, O_ptr,
                       B, Hq, G, sq, skv, max_seq, past_len, scale,
-                      sink_ptr, num_heads, smooth_softmax);
+                      sink_ptr, num_heads, smooth_softmax, local_window_size);
     return 0;
 }
 
@@ -3700,7 +3732,7 @@ extern "C" int hip_gqa_flash_prefill_v5_v2(
     float scale)
 {
     return prefillV5Run(stream_ptr, Q, Kcache, Vcache, O, B, Hq, G, sq, skv, d,
-                        max_seq, past_len, scale, nullptr, Hq, 0);
+                        max_seq, past_len, scale, nullptr, Hq, 0, 0);
 }
 
 
@@ -3771,9 +3803,10 @@ extern "C" void hip_gqa_flash_prefill_v8_set_ablate(int mask) {
 // v2 stays the narrow ABI so the standalone harnesses and shim headers that
 // redeclare it keep linking unchanged.
 //
-// Sinks are implemented for d == 64 (the v5 kernel) only. For any other d we
-// return -1 rather than silently ignoring the sink, so the runtime keeps routing
-// those shapes to the decomposed path, which does implement it.
+// Sinks and sliding windows are implemented for d == 64 (the v5 kernel) only.
+// For any other d we return -1 rather than silently ignoring them, so the
+// runtime keeps routing those shapes to the decomposed path, which does
+// implement both.
 extern "C" int hip_gqa_flash_prefill_v3(
     void* stream_ptr,
     const void* Q, const void* Kcache, const void* Vcache, void* O,
@@ -3781,17 +3814,16 @@ extern "C" int hip_gqa_flash_prefill_v3(
     float scale, int local_window_size, const void* head_sink,
     int num_heads, int smooth_softmax)
 {
-    const bool wants_sink = (head_sink != nullptr) || (smooth_softmax != 0);
-    // Sliding window is not implemented in the flash prefill kernels yet.
-    if (local_window_size > 0) return -1;
-    if (wants_sink && d != 64) return -1;
-    if (!wants_sink) {
+    const bool wants_sink   = (head_sink != nullptr) || (smooth_softmax != 0);
+    const bool wants_window = local_window_size > 0;
+    if ((wants_sink || wants_window) && d != 64) return -1;
+    if (!wants_sink && !wants_window) {
         return hip_gqa_flash_prefill_v2(stream_ptr, Q, Kcache, Vcache, O, B, Hq,
                                         G, sq, skv, d, max_seq, past_len, scale);
     }
     return prefillV5Run(stream_ptr, Q, Kcache, Vcache, O, B, Hq, G, sq, skv, d,
                         max_seq, past_len, scale, head_sink, num_heads,
-                        smooth_softmax);
+                        smooth_softmax, local_window_size);
 }
 
 extern "C" int hip_gqa_flash_prefill_v2(

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -751,6 +751,26 @@ HIP_KERNEL_API int hip_gqa_flash_prefill_v2(
     void* O, int B, int Hq, int G, int sq, int skv, int d, int max_seq,
     int past_len, float scale);
 
+/* Same as hip_gqa_flash_prefill_v2, plus attention sinks / smooth softmax.
+ * Kept as a separate symbol rather than widening v2, because v2 is redeclared
+ * locally by the standalone GQA harnesses and the dispatch_bench shim header;
+ * widening it in place would break those and risk a silent host/kernel ABI skew.
+ *
+ *   local_window_size : <= 0 for full attention. > 0 returns -1 for now
+ *                       (sliding window is not implemented in flash prefill).
+ *   head_sink         : [num_heads] __half of per-head sink logits, or null.
+ *   smooth_softmax    : non-zero adds a sink logit of 0, matching the
+ *                       decomposed path when head_sink is null.
+ *
+ * Returns 0 on success and -1 when the request cannot be served exactly (any
+ * window > 0, or a sink with d != 64), so the caller falls back to the
+ * decomposed path instead of silently dropping the sink. */
+HIP_KERNEL_API int hip_gqa_flash_prefill_v3(
+    void* stream, const void* Q, const void* Kcache, const void* Vcache,
+    void* O, int B, int Hq, int G, int sq, int skv, int d, int max_seq,
+    int past_len, float scale, int local_window_size, const void* head_sink,
+    int num_heads, int smooth_softmax);
+
 /* NB: prefill is compute-bound, so there is deliberately NO separate int8
  * prefill kernel. The runtime (real/gqa.cpp) dequantizes the int8 KV cache to an
  * fp16 scratch ONCE (hip_gqa_dequant_kv_i8_to_fp16) and reuses the tuned fp16

--- a/lib/Runtime/Kernels/test/example/gqa/prefill/test_gqa_prefill.cpp
+++ b/lib/Runtime/Kernels/test/example/gqa/prefill/test_gqa_prefill.cpp
@@ -35,6 +35,13 @@ extern "C" int hip_gqa_flash_prefill_v2(
     void* O, int B, int Hq, int G, int sq, int skv, int d, int max_seq,
     int past_len, float scale);
 
+// Wide entry: same as v2 plus attention sinks / smooth softmax.
+extern "C" int hip_gqa_flash_prefill_v3(
+    void* stream, const void* Q, const void* Kcache, const void* Vcache,
+    void* O, int B, int Hq, int G, int sq, int skv, int d, int max_seq,
+    int past_len, float scale, int local_window_size, const void* head_sink,
+    int num_heads, int smooth_softmax);
+
 extern "C" int hip_gqa_flash_prefill_v7(
     void* stream, const void* Q, const void* Kcache, const void* Vcache,
     void* O, int B, int Hq, int G, int sq, int skv, int d, int max_seq,
@@ -50,9 +57,21 @@ extern "C" int hip_gqa_flash_prefill_v7(
     }                                                                          \
   } while (0)
 
+// Sink handling, matching softmax_f32_to_out_kernel exactly: the row max is
+// taken over the scores only (the sink does NOT participate), and the sink
+// contributes a single exp(s - max) term to the denominator. kSinkSmooth is the
+// smooth_softmax case, i.e. a sink logit of 0 with no sink tensor.
+enum SinkMode { kSinkNone = 0, kSinkPerHead = 1, kSinkSmooth = 2 };
+
 struct Case {
   const char* name;
-  int B, H, G, D, sq;  // pure prefill: skv = sq, past_len = 0
+  int B, H, G, D, sq;
+  int past;       // past_len; total_seq = past + sq. 0 = pure prefill.
+  int sink_mode;  // SinkMode
+  // Expect the kernel to decline (rc != 0) instead of computing. Used for the
+  // shapes v3 must refuse so the runtime falls back to the decomposed path
+  // rather than dropping the sink.
+  bool expect_reject;
 };
 
 // CPU fp32 reference: causal GQA attention. Q/O BSHD, K/V cache BNSD.
@@ -60,7 +79,8 @@ static void cpu_reference(const std::vector<float>& Q,
                           const std::vector<float>& K,
                           const std::vector<float>& V, std::vector<float>& O,
                           int B, int H, int G, int D, int sq, int max_seq,
-                          int past_len, float scale) {
+                          int past_len, float scale, int sink_mode,
+                          const std::vector<float>& sink) {
   const int HPG = H / G;
   const int total = past_len + sq;
   std::vector<float> scores(total);
@@ -83,6 +103,10 @@ static void cpu_reference(const std::vector<float>& Q,
           scores[k] = std::exp(scores[k] - m);
           l += scores[k];
         }
+        if (sink_mode == kSinkPerHead)
+          l += std::exp(sink[hq] - m);
+        else if (sink_mode == kSinkSmooth)
+          l += std::exp(0.0f - m);
         const float inv = (l > 0.0f) ? 1.0f / l : 0.0f;
         float* o = &O[((size_t)(b * sq + s) * H + hq) * D];
         for (int e = 0; e < D; ++e) o[e] = 0.0f;
@@ -108,13 +132,14 @@ static double rel_l2(const std::vector<float>& a, const std::vector<float>& b) {
 
 static bool run_case(const Case& c, int iters) {
   const int B = c.B, H = c.H, G = c.G, D = c.D, sq = c.sq;
-  const int max_seq = sq;       // pure-prefill cache buffer
-  const int past_len = 0, skv = sq;
+  const int past_len = c.past;
+  const int skv = past_len + sq;   // total_seq
+  const int max_seq = skv;         // cache buffer holds exactly total_seq
   const float scale = 1.0f / std::sqrt((float)D);
 
   const size_t qn = (size_t)B * sq * H * D;
   const size_t kn = (size_t)B * G * max_seq * D;
-  std::mt19937 rng(1234 + sq + D);
+  std::mt19937 rng(1234 + sq + D + past_len + c.sink_mode);
   std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
 
   std::vector<float> Qf(qn), Kf(kn), Vf(kn), Oref(qn);
@@ -122,31 +147,57 @@ static bool run_case(const Case& c, int iters) {
   for (auto& x : Kf) x = dist(rng);
   for (auto& x : Vf) x = dist(rng);
 
-  cpu_reference(Qf, Kf, Vf, Oref, B, H, G, D, sq, max_seq, past_len, scale);
+  // gpt-oss ships sink logits around O(1); span a wider range so a sign or
+  // scaling error in the log2-space conversion cannot hide. Round-trip through
+  // fp16 first, because that is what the kernel reads -- otherwise the
+  // comparison would charge the kernel for the host's rounding.
+  std::vector<__half> sinkh(H);
+  std::vector<float> sinkf(H);
+  for (int h = 0; h < H; ++h) {
+    sinkh[h] = __float2half(-2.0f + 4.0f * (float)h / (float)H);
+    sinkf[h] = __half2float(sinkh[h]);
+  }
+
+  cpu_reference(Qf, Kf, Vf, Oref, B, H, G, D, sq, max_seq, past_len, scale,
+                c.sink_mode, sinkf);
 
   std::vector<__half> Qh(qn), Kh(kn), Vh(kn);
   for (size_t i = 0; i < qn; ++i) Qh[i] = __float2half(Qf[i]);
   for (size_t i = 0; i < kn; ++i) { Kh[i] = __float2half(Kf[i]); Vh[i] = __float2half(Vf[i]); }
 
-  __half *dQ, *dK, *dV, *dO;
+  __half *dQ, *dK, *dV, *dO, *dSink;
   HIP_CHECK(hipMalloc(&dQ, qn * sizeof(__half)));
   HIP_CHECK(hipMalloc(&dK, kn * sizeof(__half)));
   HIP_CHECK(hipMalloc(&dV, kn * sizeof(__half)));
   HIP_CHECK(hipMalloc(&dO, qn * sizeof(__half)));
+  HIP_CHECK(hipMalloc(&dSink, (size_t)H * sizeof(__half)));
   HIP_CHECK(hipMemcpy(dQ, Qh.data(), qn * sizeof(__half), hipMemcpyHostToDevice));
   HIP_CHECK(hipMemcpy(dK, Kh.data(), kn * sizeof(__half), hipMemcpyHostToDevice));
   HIP_CHECK(hipMemcpy(dV, Vh.data(), kn * sizeof(__half), hipMemcpyHostToDevice));
+  HIP_CHECK(hipMemcpy(dSink, sinkh.data(), (size_t)H * sizeof(__half), hipMemcpyHostToDevice));
 
   // Route through the unified entry (same path the runtime takes); it dispatches
   // v5 (D==64) / v7 (D==128) internally.
+  const void* sink_arg = (c.sink_mode == kSinkPerHead) ? (const void*)dSink : nullptr;
+  const int smooth_arg = (c.sink_mode == kSinkSmooth) ? 1 : 0;
   auto launch = [&]() {
-    return hip_gqa_flash_prefill_v2(nullptr, dQ, dK, dV, dO, B, H, G, sq, skv, D,
-                                 max_seq, past_len, scale);
+    return hip_gqa_flash_prefill_v3(nullptr, dQ, dK, dV, dO, B, H, G, sq, skv, D,
+                                    max_seq, past_len, scale,
+                                    /*local_window_size=*/-1, sink_arg, H,
+                                    smooth_arg);
   };
 
   int rc = launch();  // first call self-tunes
   HIP_CHECK(hipDeviceSynchronize());
-  if (rc != 0) { fprintf(stderr, "kernel returned %d\n", rc); return false; }
+  if (c.expect_reject) {
+    const bool ok = (rc != 0);
+    printf("%-16s B%d H%d G%d(hpg%d) D%-3d sq=%-5d past=%-5d %-6s | rc=%d (expected decline)  %s\n",
+           c.name, B, H, G, H / G, D, sq, past_len,
+           c.sink_mode == kSinkPerHead ? "sink" : "-", rc, ok ? "PASS" : "FAIL");
+    hipFree(dQ); hipFree(dK); hipFree(dV); hipFree(dO); hipFree(dSink);
+    return ok;
+  }
+  if (rc != 0) { fprintf(stderr, "%s: kernel returned %d\n", c.name, rc); return false; }
 
   std::vector<__half> Oh(qn);
   HIP_CHECK(hipMemcpy(Oh.data(), dO, qn * sizeof(__half), hipMemcpyDeviceToHost));
@@ -167,13 +218,16 @@ static bool run_case(const Case& c, int iters) {
   HIP_CHECK(hipEventElapsedTime(&ms, e0, e1));
   ms /= iters;
 
+  const char* sink_tag = (c.sink_mode == kSinkPerHead) ? "sink"
+                       : (c.sink_mode == kSinkSmooth)  ? "smooth"
+                                                       : "-";
   const bool pass = err < 2e-3;
-  printf("%-16s B%d H%d G%d(hpg%d) D%-3d sq=%-5d | relL2=%.2e  latency=%.4f ms  %s (v%d)\n",
-         c.name, B, H, G, H / G, D, sq, err, ms, pass ? "PASS" : "FAIL",
-         D == 64 ? 5 : 7);
+  printf("%-16s B%d H%d G%d(hpg%d) D%-3d sq=%-5d past=%-5d %-6s | relL2=%.2e  latency=%.4f ms  %s (v%d)\n",
+         c.name, B, H, G, H / G, D, sq, past_len, sink_tag, err, ms,
+         pass ? "PASS" : "FAIL", D == 64 ? 5 : 7);
 
   hipEventDestroy(e0); hipEventDestroy(e1);
-  hipFree(dQ); hipFree(dK); hipFree(dV); hipFree(dO);
+  hipFree(dQ); hipFree(dK); hipFree(dV); hipFree(dO); hipFree(dSink);
   return pass;
 }
 
@@ -183,12 +237,24 @@ int main(int argc, char** argv) {
     if (!std::strcmp(argv[i], "--iters") && i + 1 < argc) iters = std::atoi(argv[++i]);
 
   const Case cases[] = {
-      {"gpt_oss-20b",  1, 64, 8,  64, 512},
-      {"gpt_oss-20b",  1, 64, 8,  64, 2048},
-      {"llama-3.2-1b", 1, 32, 8,  64, 512},
-      {"llama-3.2-1b", 1, 32, 8,  64, 2048},
-      {"llama-3.1-8b", 1, 32, 8, 128, 512},
-      {"llama-3.1-8b", 1, 32, 8, 128, 2048},
+      // No-sink regression set (must stay as accurate as before).
+      {"gpt_oss-20b",  1, 64, 8,  64, 512,  0,    kSinkNone,    false},
+      {"gpt_oss-20b",  1, 64, 8,  64, 2048, 0,    kSinkNone,    false},
+      {"llama-3.2-1b", 1, 32, 8,  64, 512,  0,    kSinkNone,    false},
+      {"llama-3.2-1b", 1, 32, 8,  64, 2048, 0,    kSinkNone,    false},
+      {"llama-3.1-8b", 1, 32, 8, 128, 512,  0,    kSinkNone,    false},
+      {"llama-3.1-8b", 1, 32, 8, 128, 2048, 0,    kSinkNone,    false},
+      // Sink set at the real gpt-oss geometry (H=64, G=8, d=64), including
+      // chunked prefill (past > 0), which is what a 16k prompt actually runs.
+      {"gpt_oss-sink",  1, 64, 8,  64, 512,  0,    kSinkPerHead, false},
+      {"gpt_oss-sink",  1, 64, 8,  64, 2048, 0,    kSinkPerHead, false},
+      {"gpt_oss-sink",  1, 64, 8,  64, 512,  512,  kSinkPerHead, false},
+      {"gpt_oss-sink",  1, 64, 8,  64, 512,  8192, kSinkPerHead, false},
+      {"gpt_oss-smooth",1, 64, 8,  64, 512,  0,    kSinkSmooth,  false},
+      {"gpt_oss-smooth",1, 64, 8,  64, 512,  512,  kSinkSmooth,  false},
+      // A sink must not silently apply at d == 128: v3 declines so the runtime
+      // falls back to the decomposed path, which does implement it.
+      {"llama-sink-d128",1, 32, 8, 128, 512, 0,    kSinkPerHead, true},
   };
   int fails = 0;
   for (const auto& c : cases) if (!run_case(c, iters)) ++fails;

--- a/lib/Runtime/Kernels/test/example/gqa/prefill/test_gqa_prefill.cpp
+++ b/lib/Runtime/Kernels/test/example/gqa/prefill/test_gqa_prefill.cpp
@@ -70,8 +70,11 @@ struct Case {
   int sink_mode;  // SinkMode
   // Expect the kernel to decline (rc != 0) instead of computing. Used for the
   // shapes v3 must refuse so the runtime falls back to the decomposed path
-  // rather than dropping the sink.
+  // rather than dropping the sink or the window.
   bool expect_reject;
+  // Sliding window; <= 0 is full attention. Convention matches
+  // causal_mask_kernel_impl: key k is masked when k < past_len + q - window + 1.
+  int window;
 };
 
 // CPU fp32 reference: causal GQA attention. Q/O BSHD, K/V cache BNSD.
@@ -80,7 +83,7 @@ static void cpu_reference(const std::vector<float>& Q,
                           const std::vector<float>& V, std::vector<float>& O,
                           int B, int H, int G, int D, int sq, int max_seq,
                           int past_len, float scale, int sink_mode,
-                          const std::vector<float>& sink) {
+                          const std::vector<float>& sink, int window) {
   const int HPG = H / G;
   const int total = past_len + sq;
   std::vector<float> scores(total);
@@ -90,8 +93,11 @@ static void cpu_reference(const std::vector<float>& Q,
       for (int s = 0; s < sq; ++s) {
         const float* q = &Q[((size_t)(b * sq + s) * H + hq) * D];
         const int kmax = past_len + s;  // causal: attend to keys 0..kmax
+        const int kmin = (window > 0 && kmax - window + 1 > 0)
+                             ? (kmax - window + 1)
+                             : 0;
         float m = -1e30f;
-        for (int k = 0; k <= kmax; ++k) {
+        for (int k = kmin; k <= kmax; ++k) {
           const float* kp = &K[((size_t)(b * G + hkv) * max_seq + k) * D];
           float dot = 0.0f;
           for (int e = 0; e < D; ++e) dot += q[e] * kp[e];
@@ -99,7 +105,7 @@ static void cpu_reference(const std::vector<float>& Q,
           if (scores[k] > m) m = scores[k];
         }
         float l = 0.0f;
-        for (int k = 0; k <= kmax; ++k) {
+        for (int k = kmin; k <= kmax; ++k) {
           scores[k] = std::exp(scores[k] - m);
           l += scores[k];
         }
@@ -110,7 +116,7 @@ static void cpu_reference(const std::vector<float>& Q,
         const float inv = (l > 0.0f) ? 1.0f / l : 0.0f;
         float* o = &O[((size_t)(b * sq + s) * H + hq) * D];
         for (int e = 0; e < D; ++e) o[e] = 0.0f;
-        for (int k = 0; k <= kmax; ++k) {
+        for (int k = kmin; k <= kmax; ++k) {
           const float* vp = &V[((size_t)(b * G + hkv) * max_seq + k) * D];
           const float w = scores[k] * inv;
           for (int e = 0; e < D; ++e) o[e] += w * vp[e];
@@ -159,7 +165,7 @@ static bool run_case(const Case& c, int iters) {
   }
 
   cpu_reference(Qf, Kf, Vf, Oref, B, H, G, D, sq, max_seq, past_len, scale,
-                c.sink_mode, sinkf);
+                c.sink_mode, sinkf, c.window);
 
   std::vector<__half> Qh(qn), Kh(kn), Vh(kn);
   for (size_t i = 0; i < qn; ++i) Qh[i] = __float2half(Qf[i]);
@@ -180,20 +186,21 @@ static bool run_case(const Case& c, int iters) {
   // v5 (D==64) / v7 (D==128) internally.
   const void* sink_arg = (c.sink_mode == kSinkPerHead) ? (const void*)dSink : nullptr;
   const int smooth_arg = (c.sink_mode == kSinkSmooth) ? 1 : 0;
+  const int window_arg = (c.window > 0) ? c.window : -1;
   auto launch = [&]() {
     return hip_gqa_flash_prefill_v3(nullptr, dQ, dK, dV, dO, B, H, G, sq, skv, D,
-                                    max_seq, past_len, scale,
-                                    /*local_window_size=*/-1, sink_arg, H,
-                                    smooth_arg);
+                                    max_seq, past_len, scale, window_arg,
+                                    sink_arg, H, smooth_arg);
   };
 
   int rc = launch();  // first call self-tunes
   HIP_CHECK(hipDeviceSynchronize());
   if (c.expect_reject) {
     const bool ok = (rc != 0);
-    printf("%-16s B%d H%d G%d(hpg%d) D%-3d sq=%-5d past=%-5d %-6s | rc=%d (expected decline)  %s\n",
+    printf("%-16s B%d H%d G%d(hpg%d) D%-3d sq=%-5d past=%-5d %-6s w=%-5d | rc=%d (expected decline)  %s\n",
            c.name, B, H, G, H / G, D, sq, past_len,
-           c.sink_mode == kSinkPerHead ? "sink" : "-", rc, ok ? "PASS" : "FAIL");
+           c.sink_mode == kSinkPerHead ? "sink" : "-", c.window, rc,
+           ok ? "PASS" : "FAIL");
     hipFree(dQ); hipFree(dK); hipFree(dV); hipFree(dO); hipFree(dSink);
     return ok;
   }
@@ -222,8 +229,8 @@ static bool run_case(const Case& c, int iters) {
                        : (c.sink_mode == kSinkSmooth)  ? "smooth"
                                                        : "-";
   const bool pass = err < 2e-3;
-  printf("%-16s B%d H%d G%d(hpg%d) D%-3d sq=%-5d past=%-5d %-6s | relL2=%.2e  latency=%.4f ms  %s (v%d)\n",
-         c.name, B, H, G, H / G, D, sq, past_len, sink_tag, err, ms,
+  printf("%-16s B%d H%d G%d(hpg%d) D%-3d sq=%-5d past=%-5d %-6s w=%-5d | relL2=%.2e  latency=%.4f ms  %s (v%d)\n",
+         c.name, B, H, G, H / G, D, sq, past_len, sink_tag, c.window, err, ms,
          pass ? "PASS" : "FAIL", D == 64 ? 5 : 7);
 
   hipEventDestroy(e0); hipEventDestroy(e1);
@@ -238,23 +245,45 @@ int main(int argc, char** argv) {
 
   const Case cases[] = {
       // No-sink regression set (must stay as accurate as before).
-      {"gpt_oss-20b",  1, 64, 8,  64, 512,  0,    kSinkNone,    false},
-      {"gpt_oss-20b",  1, 64, 8,  64, 2048, 0,    kSinkNone,    false},
-      {"llama-3.2-1b", 1, 32, 8,  64, 512,  0,    kSinkNone,    false},
-      {"llama-3.2-1b", 1, 32, 8,  64, 2048, 0,    kSinkNone,    false},
-      {"llama-3.1-8b", 1, 32, 8, 128, 512,  0,    kSinkNone,    false},
-      {"llama-3.1-8b", 1, 32, 8, 128, 2048, 0,    kSinkNone,    false},
+      {"gpt_oss-20b",  1, 64, 8,  64, 512,  0,    kSinkNone,    false, 0},
+      {"gpt_oss-20b",  1, 64, 8,  64, 2048, 0,    kSinkNone,    false, 0},
+      {"llama-3.2-1b", 1, 32, 8,  64, 512,  0,    kSinkNone,    false, 0},
+      {"llama-3.2-1b", 1, 32, 8,  64, 2048, 0,    kSinkNone,    false, 0},
+      {"llama-3.1-8b", 1, 32, 8, 128, 512,  0,    kSinkNone,    false, 0},
+      {"llama-3.1-8b", 1, 32, 8, 128, 2048, 0,    kSinkNone,    false, 0},
       // Sink set at the real gpt-oss geometry (H=64, G=8, d=64), including
       // chunked prefill (past > 0), which is what a 16k prompt actually runs.
-      {"gpt_oss-sink",  1, 64, 8,  64, 512,  0,    kSinkPerHead, false},
-      {"gpt_oss-sink",  1, 64, 8,  64, 2048, 0,    kSinkPerHead, false},
-      {"gpt_oss-sink",  1, 64, 8,  64, 512,  512,  kSinkPerHead, false},
-      {"gpt_oss-sink",  1, 64, 8,  64, 512,  8192, kSinkPerHead, false},
-      {"gpt_oss-smooth",1, 64, 8,  64, 512,  0,    kSinkSmooth,  false},
-      {"gpt_oss-smooth",1, 64, 8,  64, 512,  512,  kSinkSmooth,  false},
+      {"gpt_oss-sink",  1, 64, 8,  64, 512,  0,    kSinkPerHead, false, 0},
+      {"gpt_oss-sink",  1, 64, 8,  64, 2048, 0,    kSinkPerHead, false, 0},
+      {"gpt_oss-sink",  1, 64, 8,  64, 512,  512,  kSinkPerHead, false, 0},
+      {"gpt_oss-sink",  1, 64, 8,  64, 512,  8192, kSinkPerHead, false, 0},
+      {"gpt_oss-smooth",1, 64, 8,  64, 512,  0,    kSinkSmooth,  false, 0},
+      {"gpt_oss-smooth",1, 64, 8,  64, 512,  512,  kSinkSmooth,  false, 0},
       // A sink must not silently apply at d == 128: v3 declines so the runtime
       // falls back to the decomposed path, which does implement it.
-      {"llama-sink-d128",1, 32, 8, 128, 512, 0,    kSinkPerHead, true},
+      {"llama-sink-d128",1, 32, 8, 128, 512, 0,    kSinkPerHead, true,  0},
+
+      // Sliding window, gpt-oss geometry, window=128 as the model ships.
+      // Window alone first, so a window bug cannot hide behind the sink.
+      {"gpt_oss-win",   1, 64, 8,  64, 512,  0,    kSinkNone,    false, 128},
+      {"gpt_oss-win",   1, 64, 8,  64, 2048, 0,    kSinkNone,    false, 128},
+      // Chunked: past deeper than the window is the case where whole KV tiles
+      // must be skipped rather than merely masked.
+      {"gpt_oss-win",   1, 64, 8,  64, 512,  512,  kSinkNone,    false, 128},
+      {"gpt_oss-win",   1, 64, 8,  64, 512,  8192, kSinkNone,    false, 128},
+      // Window not aligned to any BKV (32/64), to catch an off-by-one in the
+      // start-tile clamp.
+      {"gpt_oss-win",   1, 64, 8,  64, 512,  1000, kSinkNone,    false, 100},
+      // Window wider than the whole sequence must equal full attention.
+      {"gpt_oss-win-big",1, 64, 8, 64, 512,  0,    kSinkNone,    false, 4096},
+      // Window == 1 is the degenerate case: each query sees only itself.
+      {"gpt_oss-win1",  1, 64, 8,  64, 512,  512,  kSinkNone,    false, 1},
+      // Window together with the sink, which is what gpt-oss actually runs on
+      // its 12 sliding layers.
+      {"gpt_oss-win+sk",1, 64, 8,  64, 512,  0,    kSinkPerHead, false, 128},
+      {"gpt_oss-win+sk",1, 64, 8,  64, 512,  8192, kSinkPerHead, false, 128},
+      // A window must not silently apply at d == 128 either.
+      {"llama-win-d128",1, 32, 8, 128, 512,  0,    kSinkNone,    true,  128},
   };
   int fails = 0;
   for (const auto& c : cases) if (!run_case(c, iters)) ++fails;

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -11,14 +11,18 @@
 // the HipToLLVM lowering keeps resolving). Path selection:
 //
 //   * Common fp16 causal GQA (head_dim in {64,128}, templated decode geometry,
-//     no sliding window / sink / smooth) -> optimized fused custom kernels:
+//     no sliding window) -> optimized fused custom kernels:
 //       prefill (sq > 1): [split] -> [rope] -> kv-cache update ->
-//                         hip_gqa_flash_prefill_v2
+//                         hip_gqa_flash_prefill_v3
 //       decode  (sq == 1): [split] -> [rope] -> kv-cache update ->
 //                         hip_gqa_flash_decode_v2
+//     Attention sinks / smooth softmax are applied here too: by flash decode
+//     for any supported geometry, and by flash prefill at head_dim == 64 (the
+//     v5 kernel). Prefill at head_dim 128/256 with a sink still goes
+//     decomposed.
 //
 //   * Everything else the fused kernels do not implement (fp32, no_causal /
-//     bidirectional, sliding window, head sink / smooth softmax, additive
+//     bidirectional, sliding window, a sink on 128/256-wide prefill, additive
 //     attention bias, other head_dim, untemplated decode geometry) -> the
 //     feature-complete legacy decomposed hipBLASLt pipeline
 //     gqa_forward_hipblaslt below. This is a verbatim port of the proven
@@ -313,7 +317,8 @@ static int gqa_forward_fused(
     int64_t B, int64_t sq, int64_t skv, int64_t past_buf_seq, int64_t H,
     int64_t G, int64_t d, float scale, int64_t do_rotary,
     const void *k_scale = nullptr, const void *v_scale = nullptr,
-    KvCacheFormat kv_format = KvCacheFormat::Fp16) {
+    KvCacheFormat kv_format = KvCacheFormat::Fp16,
+    const void *head_sink = nullptr, bool use_smooth_softmax = false) {
 
   // Any non-fp16 cache reads/writes quantized bytes on the concat/append/decode
   // path; the specific scheme is carried by kv_format (extensible to INT4/FP8).
@@ -467,8 +472,8 @@ static int gqa_forward_fused(
           static_cast<int>(B), static_cast<int>(H), static_cast<int>(G),
           static_cast<int>(d), static_cast<int>(skv),
           static_cast<int>(present_seq), kFlashDecodeMaxSplits, scale,
-          seqlens_k_ptr, /*local_window_size=*/0, /*head_sink=*/nullptr,
-          /*smooth_softmax=*/0, kv_dtype_abi(kv_format),
+          seqlens_k_ptr, /*local_window_size=*/0, head_sink,
+          use_smooth_softmax ? 1 : 0, kv_dtype_abi(kv_format),
           kv_quantized ? k_scale : nullptr, kv_quantized ? v_scale : nullptr);
       if (drc != 0)
         return -1;
@@ -643,18 +648,22 @@ static int gqa_forward_fused(
   }
 
   // Single unified entry; v5 (d==64) / v7 (d==128) selection lives in the
-  // kernel TU (gqa_kernel.hip).
-  int fp_rc = hip_gqa_flash_prefill_v2(
+  // kernel TU (gqa_kernel.hip). v3 carries the sink; it returns -1 rather than
+  // dropping it when the kernel for this d cannot apply it, and the caller then
+  // falls back to the decomposed path.
+  int fp_rc = hip_gqa_flash_prefill_v3(
       stream, qSrc, kAttn, vAttn, output, static_cast<int>(B),
       static_cast<int>(H), static_cast<int>(G), static_cast<int>(sq),
       static_cast<int>(total_seq), static_cast<int>(d), attn_max_seq,
-      static_cast<int>(past_len), scale);
+      static_cast<int>(past_len), scale, /*local_window_size=*/-1, head_sink,
+      static_cast<int>(H), use_smooth_softmax ? 1 : 0);
   RUNTIME_DEBUG_LOG(
       "[REAL] GQA fused prefill (%s d=%lld -> v%d): B=%lld sq=%lld "
-      "total_seq=%lld H=%lld G=%lld past_len=%lld rc=%d\n",
+      "total_seq=%lld H=%lld G=%lld past_len=%lld sink=%d smooth=%d rc=%d\n",
       kv_quantized ? "quant" : "fp16", (long long)d, (d == 64 ? 5 : 7),
       (long long)B, (long long)sq, (long long)total_seq, (long long)H,
-      (long long)G, (long long)past_len, fp_rc);
+      (long long)G, (long long)past_len, static_cast<int>(head_sink != nullptr),
+      static_cast<int>(use_smooth_softmax), fp_rc);
   return fp_rc != 0 ? -1 : 0;
 }
 
@@ -2012,14 +2021,14 @@ int wrap_group_query_attention(
   //===------------------------------------------------------------------===//
   // Path selection. The optimized fused/flash kernels are fp16 causal GQA
   // with head_dim in {64,128} and a templated decode geometry (HpG in
-  // {1,2,3,4,8,16}). Anything they do not implement -- fp32, no_causal /
-  // bidirectional, sliding window, head sink / smooth softmax, other
-  // head_dim, or an untemplated decode geometry -- is handled by the legacy
-  // decomposed hipBLASLt pipeline (gqa_forward_hipblaslt above), which is the
-  // verbatim-ported gqa_back.cpp strategy: feature-complete, and keeps the
-  // legacy fast decode kernel for the sliding-window / sink decode case so
-  // that path is not slower than the original. The common fp16 causal case
-  // still takes the fast fused path here.
+  // {1,2,3,4,8,16}), and now also cover attention sinks (decode always,
+  // prefill at head_dim == 64). Anything they do not implement -- fp32,
+  // no_causal / bidirectional, sliding window, a sink on 128/256-wide prefill,
+  // other head_dim, or an untemplated decode geometry -- is handled by the
+  // legacy decomposed hipBLASLt pipeline (gqa_forward_hipblaslt above), which
+  // is the verbatim-ported gqa_back.cpp strategy: feature-complete, and keeps
+  // the legacy fast decode kernel for the sliding-window case so that path is
+  // not slower than the original.
   //===------------------------------------------------------------------===//
   const bool is_decode = (seq_len_q == 1);
   const bool decode_geometry_ok =
@@ -2034,10 +2043,21 @@ int wrap_group_query_attention(
   // decomposed pipeline (Step 8b); the lean fused path would silently drop it,
   // so exclude it here to route masked attention to gqa_forward_hipblaslt
   // below.
-  const bool fused_supported = element_size_bytes == 2 && no_causal == 0 &&
-                               local_window_size <= 0 && head_sink == nullptr &&
-                               smooth_softmax != 1 && head_dim_ok &&
-                               decode_geometry_ok && attention_bias == nullptr;
+  //
+  // Smooth softmax is active when a sink is supplied OR the attribute is
+  // explicitly 1, matching ORT (gqa_attention_base.h:
+  // use_smooth_softmax_ || head_sink != nullptr).
+  const bool has_smooth_softmax = (head_sink != nullptr || smooth_softmax == 1);
+  // Sinks on the fused path: the flash decode kernel applies them for any
+  // supported geometry, and flash prefill applies them at head_dim == 64 (the
+  // v5 kernel). Prefill at head_dim 128/256 has no sink support yet, so those
+  // shapes must keep routing to the decomposed pipeline -- admitting them here
+  // would make hip_gqa_flash_prefill_v3 return -1 and fail the op outright
+  // instead of falling back.
+  const bool sink_ok = !has_smooth_softmax || is_decode || head_dim == 64;
+  const bool fused_supported =
+      element_size_bytes == 2 && no_causal == 0 && local_window_size <= 0 &&
+      sink_ok && head_dim_ok && decode_geometry_ok && attention_bias == nullptr;
 
   // A quantized KV cache is implemented ONLY on the fused path (quant decode +
   // fp16 prefill-over-dequant), for head_dim in {64,128}. The legacy decomposed
@@ -2047,8 +2067,8 @@ int wrap_group_query_attention(
       (!fused_supported || (head_dim != 64 && head_dim != 128))) {
     fprintf(stderr,
             "wrap_group_query_attention: quantized KV cache requires the fused "
-            "path (fp16, causal, no window/sink/smooth/bias, head_dim 64 or "
-            "128); got fused_supported=%d head_dim=%lld\n",
+            "path (fp16, causal, no window/bias, head_dim 64 or 128); got "
+            "fused_supported=%d head_dim=%lld\n",
             static_cast<int>(fused_supported), (long long)head_dim);
     return -1;
   }
@@ -2060,11 +2080,6 @@ int wrap_group_query_attention(
       fprintf(stderr, "wrap_group_query_attention: null hipblas handle\n");
       return -1;
     }
-    // Smooth softmax: activated when head_sink is provided OR the
-    // smooth_softmax attribute is explicitly 1, matching ORT behaviour
-    // (gqa_attention_base.h: use_smooth_softmax_ || head_sink != nullptr).
-    const bool has_smooth_softmax =
-        (head_sink != nullptr || smooth_softmax == 1);
     RUNTIME_DEBUG_LOG(
         "[REAL] wrap_group_query_attention: routing to legacy decomposed "
         "pipeline "
@@ -2097,11 +2112,12 @@ int wrap_group_query_attention(
       (long long)do_rotary,
       static_cast<int>(key == nullptr && value == nullptr));
 
-  int rc = gqa_forward_fused(
-      state, stream, query, key, value, past_key, past_value, seqlens_k,
-      cos_cache, sin_cache, output, present_key, present_value, batch_size,
-      seq_len_q, seq_len_kv, past_buf_seq, num_heads, kv_num_heads, head_dim,
-      scale, do_rotary, k_scale, v_scale, kv_format);
+  int rc = gqa_forward_fused(state, stream, query, key, value, past_key,
+                             past_value, seqlens_k, cos_cache, sin_cache,
+                             output, present_key, present_value, batch_size,
+                             seq_len_q, seq_len_kv, past_buf_seq, num_heads,
+                             kv_num_heads, head_dim, scale, do_rotary, k_scale,
+                             v_scale, kv_format, head_sink, has_smooth_softmax);
   if (rc != 0)
     fprintf(stderr,
             "wrap_group_query_attention: gqa_forward_fused failed "

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -10,8 +10,8 @@
 // The generated IR calls `wrap_group_query_attention` (39-arg ABI, unchanged so
 // the HipToLLVM lowering keeps resolving). Path selection:
 //
-//   * Common fp16 causal GQA (head_dim in {64,128}, templated decode geometry,
-//     no sliding window) -> optimized fused custom kernels:
+//   * Common fp16 causal GQA (head_dim in {64,128}, templated decode geometry)
+//     -> optimized fused custom kernels:
 //       prefill (sq > 1): [split] -> [rope] -> kv-cache update ->
 //                         hip_gqa_flash_prefill_v3
 //       decode  (sq == 1): [split] -> [rope] -> kv-cache update ->
@@ -19,10 +19,12 @@
 //     Attention sinks / smooth softmax are applied here too: by flash decode
 //     for any supported geometry, and by flash prefill at head_dim == 64 (the
 //     v5 kernel). Prefill at head_dim 128/256 with a sink still goes
-//     decomposed.
+//     decomposed. Sliding windows are applied by flash prefill at
+//     head_dim == 64; windowed decode still goes decomposed.
 //
 //   * Everything else the fused kernels do not implement (fp32, no_causal /
-//     bidirectional, sliding window, a sink on 128/256-wide prefill, additive
+//     bidirectional, a window on decode or on 128/256-wide prefill, a sink on
+//     128/256-wide prefill, additive
 //     attention bias, other head_dim, untemplated decode geometry) -> the
 //     feature-complete legacy decomposed hipBLASLt pipeline
 //     gqa_forward_hipblaslt below. This is a verbatim port of the proven
@@ -318,7 +320,8 @@ static int gqa_forward_fused(
     int64_t G, int64_t d, float scale, int64_t do_rotary,
     const void *k_scale = nullptr, const void *v_scale = nullptr,
     KvCacheFormat kv_format = KvCacheFormat::Fp16,
-    const void *head_sink = nullptr, bool use_smooth_softmax = false) {
+    const void *head_sink = nullptr, bool use_smooth_softmax = false,
+    int local_window_size = -1) {
 
   // Any non-fp16 cache reads/writes quantized bytes on the concat/append/decode
   // path; the specific scheme is carried by kv_format (extensible to INT4/FP8).
@@ -648,14 +651,14 @@ static int gqa_forward_fused(
   }
 
   // Single unified entry; v5 (d==64) / v7 (d==128) selection lives in the
-  // kernel TU (gqa_kernel.hip). v3 carries the sink; it returns -1 rather than
-  // dropping it when the kernel for this d cannot apply it, and the caller then
-  // falls back to the decomposed path.
+  // kernel TU (gqa_kernel.hip). v3 carries the sink and the window; it returns
+  // -1 rather than dropping either when the kernel for this d cannot apply it,
+  // and the caller then falls back to the decomposed path.
   int fp_rc = hip_gqa_flash_prefill_v3(
       stream, qSrc, kAttn, vAttn, output, static_cast<int>(B),
       static_cast<int>(H), static_cast<int>(G), static_cast<int>(sq),
       static_cast<int>(total_seq), static_cast<int>(d), attn_max_seq,
-      static_cast<int>(past_len), scale, /*local_window_size=*/-1, head_sink,
+      static_cast<int>(past_len), scale, local_window_size, head_sink,
       static_cast<int>(H), use_smooth_softmax ? 1 : 0);
   RUNTIME_DEBUG_LOG(
       "[REAL] GQA fused prefill (%s d=%lld -> v%d): B=%lld sq=%lld "
@@ -2055,9 +2058,15 @@ int wrap_group_query_attention(
   // would make hip_gqa_flash_prefill_v3 return -1 and fail the op outright
   // instead of falling back.
   const bool sink_ok = !has_smooth_softmax || is_decode || head_dim == 64;
-  const bool fused_supported =
-      element_size_bytes == 2 && no_causal == 0 && local_window_size <= 0 &&
-      sink_ok && head_dim_ok && decode_geometry_ok && attention_bias == nullptr;
+  // Sliding window on the fused path: implemented by flash prefill at
+  // head_dim == 64 (the v5 kernel). Decode is deliberately left on the
+  // decomposed pipeline even though its kernel clamps kv_lo, because that path
+  // is unverified here; prefill is what the window costs us on gpt-oss.
+  const bool window_ok =
+      local_window_size <= 0 || (!is_decode && head_dim == 64);
+  const bool fused_supported = element_size_bytes == 2 && no_causal == 0 &&
+                               window_ok && sink_ok && head_dim_ok &&
+                               decode_geometry_ok && attention_bias == nullptr;
 
   // A quantized KV cache is implemented ONLY on the fused path (quant decode +
   // fp16 prefill-over-dequant), for head_dim in {64,128}. The legacy decomposed
@@ -2112,12 +2121,12 @@ int wrap_group_query_attention(
       (long long)do_rotary,
       static_cast<int>(key == nullptr && value == nullptr));
 
-  int rc = gqa_forward_fused(state, stream, query, key, value, past_key,
-                             past_value, seqlens_k, cos_cache, sin_cache,
-                             output, present_key, present_value, batch_size,
-                             seq_len_q, seq_len_kv, past_buf_seq, num_heads,
-                             kv_num_heads, head_dim, scale, do_rotary, k_scale,
-                             v_scale, kv_format, head_sink, has_smooth_softmax);
+  int rc = gqa_forward_fused(
+      state, stream, query, key, value, past_key, past_value, seqlens_k,
+      cos_cache, sin_cache, output, present_key, present_value, batch_size,
+      seq_len_q, seq_len_kv, past_buf_seq, num_heads, kv_num_heads, head_dim,
+      scale, do_rotary, k_scale, v_scale, kv_format, head_sink,
+      has_smooth_softmax, static_cast<int>(local_window_size));
   if (rc != 0)
     fprintf(stderr,
             "wrap_group_query_attention: gqa_forward_fused failed "


### PR DESCRIPTION
## Summary

Teaches the fused flash prefill kernel about sliding windows, which puts the
last of gpt-oss-20b's attention layers on the fused path.

**Includes [#598](https://github.com/ROCm/hip-ep/pull/598)** (attention sinks).
This PR targets `main`, so the diff is #598's four commits plus three window
commits on top; the window commits are the last three and are self-contained.
The window is not observable end-to-end without #598, because the sink gate
otherwise rejects all 24 gpt-oss layers. Merging #598 first will shrink this
diff to the window commits alone.

TTFT at seqlen 16384, interleaved: **29,483 ms base -> 10,113 ms, -65.7%**.
#598 gets the first 8,434 ms; this PR adds the other 10,936 ms.

After this, a 2048-token prefill logs **96 of 96** GQA calls (4 chunks x 24
layers) as fused prefill and none as decomposed.

## Related issue or design

None. Third in a series on the gpt-oss-20b prefill bottleneck, after the
no-expand default ([#597](https://github.com/ROCm/hip-ep/pull/597), independent
and performance-neutral) and sinks ([#598](https://github.com/ROCm/hip-ep/pull/598),
which this one requires).

## Why

gpt-oss alternates full-attention and sliding-window layers, 12 of each. The
window was only ever applied as extra masking on the decomposed path, so a
windowed layer cost the same as a full one ΓÇö in fact marginally more, because
the mask kernel writes more `-inf`. A window is an opportunity to do less work,
and none of it was being taken.

The saving is not in the mask, it is in the loop bound. Applying the window
in v5 has two parts:

- The per-row mask gains the lower bound `causal_mask_kernel_impl` already
  defines, `k < past_len + q - window + 1`.
- The KV loop starts at the first tile any row of the Q tile can reach instead
  of at tile 0. Every row in a Q tile has a lower bound at least as high as the
  first row's, so that start covers the tile and the per-row mask trims the
  remainder.

The second part is what makes a window cheaper rather than merely masked: the
number of tiles a block walks stops growing with `skv` once the window is
filled. In the standalone harness at gpt-oss geometry, `window=128` costs
0.157 ms at `past_len` 512 and 0.134 ms at `past_len` 8192 ΓÇö flat in KV depth ΓÇö
against 6.27 ms for the same shape unwindowed.

### A NaN the window introduces

Skipping tiles creates a case causal-only attention never produces: a row can
have every key in a tile masked while it has still seen nothing, leaving both
`m_old` and `m_new` at `-inf`, and `exp2f(-inf - -inf)` is NaN, which then
propagates through the correction factor into the accumulator.

This was not hypothetical ΓÇö it reproduced immediately as NaN output on the
`window=128` cases. It is worth noting that it does **not** reproduce at
`window=1` or at a window wider than the sequence, both of which passed while
the bug was live. Those two cases alone would have signed off a broken kernel,
which is why the harness covers the mid-range and chunked cases too.

The guard contributes nothing for such a row and leaves its running state
untouched.

## What

- `gqa_kernel.hip`: window lower bound in the per-row mask; KV loop start-tile
  clamp; the all-masked-tile guard above; `local_window_size` threaded through
  `dispatchPrefillV5`, the tuner and `prefillV5Run`; `v3` now accepts a window
  at `d == 64` and still declines elsewhere.
- The window is added to the autotune key. Unlike `skv` (removed from the key in
  #598 because it only scales the KV loop uniformly), the window caps how many
  tiles a block walks, which is a different work profile and can genuinely
  change which candidate wins.
- `gqa.cpp`: the prefill call site was passing a hardcoded `-1`; it now passes
  the real window, and the blanket `local_window_size <= 0` rejection becomes a
  `window_ok` term admitting `d == 64` prefill.

## Performance

| Metric | base | +sinks (#598) | +windows (this PR) |
|---|---:|---:|---:|
| TTFT, gpt-oss-20b, seqlen 16384 | 29,483 ms | 21,049 ms | **10,113 ms** |
| run-to-run spread (sd, n=3) | 32 ms | 100 ms | 105 ms |
| vs base | ΓÇö | -28.6% | **-65.7%** |
| v5 kernel, window=128, past_len 512 | ΓÇö | ΓÇö | 0.157 ms |
| v5 kernel, window=128, past_len 8192 | ΓÇö | ΓÇö | 0.134 ms |

Hardware and method: gfx1151, `model_benchmark -l 16384 --use_random_tokens
-g 1 -r 2 -w 1 -b 1 -ml 0`, `HIPDNN_EP_AUTOTUNE=1`, no `HIPDNN_EP_PERF` or
`HIPDNN_EP_DEBUG`. Three rounds, **interleaved**: prebuilt DLL sets per arm are
swapped in and alternated so machine drift hits every arm equally. All three
arms were rebuilt from the same `main` (`f5ac3547`).

Interleaving is not optional on this box: absolute TTFT drifts about 10% over a
session. The sink arm measured -28.6% both in this session (21,049 against
29,483) and in an earlier one (23,108 against 32,346), i.e. the ratio reproduces
even though the absolutes moved by 3 s.

## Test plan

- Standalone prefill harness against a CPU fp32 reference, **23 cases, all
  pass**. Ten are new window cases, chosen so a window bug cannot hide:
  - window alone before window plus sink, so the two features fail separately;
  - `past_len` 8192 with `window` 128, where whole KV tiles must be skipped
    rather than merely masked;
  - `window=100` against BKV of 32 and 64, to catch an off-by-one in the
    start-tile clamp;
  - a window wider than the sequence, which must reproduce full attention, and
    `window=1`, which must reduce to each query seeing only itself;
  - a `d=128` case asserting `v3` declines the window rather than ignoring it.
  - Windowed cases land at relL2 3.3e-04 to 3.5e-04, in line with the no-window
    cases.
- Numeric suite against the ORT CPU reference: pass/fail set **identical** to
  the sink branch (22 tests compared one by one).
- Path check with `HIPDNN_EP_DEBUG=1`: 96 of 96 prefill GQA calls fused.

Pre-existing, not caused by this change: the same four
`test_gqa_decode_fixed_cache_llama_shape` failures present at base.

## Notes for reviewers

- Please look hardest at the start-tile clamp and the all-masked-tile guard.
  The clamp is only correct because rows within a Q tile have monotonically
  non-decreasing lower bounds; if that ever stopped holding, the kernel would
  silently drop keys.
- Windowed **decode** is deliberately untouched. Its kernel already clamps
  `kv_lo`, so enabling it is nearly a one-word change, but nothing here verifies
  it and prefill is where the window was costing us.
- This makes the planned fp32 -> fp16 score-matrix optimisation moot for
  gpt-oss: there is no longer a score matrix in its prefill. That work would now
  only help models still on the decomposed path.
- Substantial AI assistance (Cursor) was used for the kernel change, the test
  cases, the measurement harnesses and this description. I reviewed the change
  and the evidence, and every number above is a measurement I ran.

