### PR TITLE
perf(gqa): fused flash prefill for attention sinks and sliding windows (-65.7% TTFT)

### DIFF
--- a/lib/Runtime/Kernels/hip/gqa_kernel.hip
+++ b/lib/Runtime/Kernels/hip/gqa_kernel.hip
@@ -2492,7 +2492,11 @@ typedef float float8_t __attribute__((ext_vector_type(8)));
 // Each wave owns M_TILES 16-row q-subtiles x all BKV columns. Only LDS is
 // P_lds (C->A transpose); only sync is single-wave around it.
 // ---------------------------------------------------------------------
-template <int M_TILES, int BKV, int D>
+// HAS_WINDOW is a template parameter rather than a runtime test because this
+// kernel runs at the VGPR ceiling: carrying the window's per-row state live in
+// the full-attention instantiation pushed M_TILES=2 from 120 to 180 bytes/lane
+// of scratch (38 -> 68 spills) and cost that path 21% at deep KV.
+template <int M_TILES, int BKV, int D, bool HAS_WINDOW>
 __global__ void __launch_bounds__(32)
 gqa_flash_prefill_v5_kernel(
     const _Float16* __restrict__ Q,       // [B, sq, Hq, D]
@@ -2500,7 +2504,10 @@ gqa_flash_prefill_v5_kernel(
     const _Float16* __restrict__ Vcache,  // [B, G, max_seq, D]
     _Float16* __restrict__ O,             // [B, sq, Hq, D]
     int B_count, int Hq, int G, int sq, int skv, int max_seq, int past_len,
-    float scale, int ablate)
+    float scale, int ablate,
+    const _Float16* __restrict__ head_sink,  // [num_heads] or null
+    int num_heads, int smooth_softmax,
+    int local_window_size)                   // <= 0 for full attention
 {
     // ablation bitmask (perf diagnostics only; wrong numerics):
     //   bit0 skip softmax, bit1 skip valueGEMM, bit2 skip scoreGEMM,
@@ -2596,7 +2603,18 @@ gqa_flash_prefill_v5_kernel(
                               ? (skv - 1) : (past_len + q_start + ROWS - 1);
     const int num_tiles = kv_max / BKV + 1;
 
-    for (int t = 0; t < num_tiles; ++t) {
+    // With a window, every row in this Q tile has a lower bound at least as high
+    // as the first row's, so starting from the first row's bound covers the whole
+    // tile and the per-row mask trims the rest. This is what makes the window
+    // cheaper rather than merely masked: the number of tiles walked stops growing
+    // with skv once the window is filled.
+    int t_start = 0;
+    if constexpr (HAS_WINDOW) {
+        const int kv_lo_tile = past_len + q_start - local_window_size + 1;
+        t_start = (kv_lo_tile > 0) ? (kv_lo_tile / BKV) : 0;
+    }
+
+    for (int t = t_start; t < num_tiles; ++t) {
         const int kv0 = t * BKV;
 
         // Stage V tile into LDS with coalesced HALF16 loads along D.
@@ -2629,13 +2647,18 @@ gqa_flash_prefill_v5_kernel(
             for (int e = 0; e < 8; ++e) {
                 const int row    = mi * 16 + e * 2 + pair;        // local q row
                 const int q_pos  = q_start + row;
-                // causal mask + per-row partial max over this lane's columns
+                // causal mask, sliding-window lower bound, and per-row partial
+                // max over this lane's columns
+                const int abs_q = past_len + q_pos;
+                int kv_lo = 0;
+                if constexpr (HAS_WINDOW) kv_lo = abs_q - local_window_size + 1;
                 float rmax = -INFINITY;
                 #pragma unroll
                 for (int sj = 0; sj < S_TILES_J; ++sj) {
                     const int kv_pos = kv0 + sj * 16 + wmma_lane;
-                    if (kv_pos >= skv || kv_pos > past_len + q_pos)
-                        S_reg[mi][sj][e] = -INFINITY;
+                    bool masked = (kv_pos >= skv || kv_pos > abs_q);
+                    if constexpr (HAS_WINDOW) masked = masked || (kv_pos < kv_lo);
+                    if (masked) S_reg[mi][sj][e] = -INFINITY;
                     rmax = fmaxf(rmax, S_reg[mi][sj][e]);
                 }
                 rmax = fmaxf(rmax, __shfl_xor(rmax, 1));
@@ -2645,13 +2668,22 @@ gqa_flash_prefill_v5_kernel(
 
                 const float m_old = m_reg[mi][e];
                 const float m_new = fmaxf(m_old, rmax);
-                const float corr  = exp2f(m_old - m_new);
+                // A window can mask a whole tile for a row while that row has
+                // still seen nothing, leaving m_old and m_new both at -inf.
+                // exp2f(-inf - -inf) is NaN, so short-circuit: contribute
+                // nothing and leave the running state untouched. Causal-only
+                // never reaches this, since tile 0 always holds key 0, so the
+                // guard folds away in the full-attention instantiation.
+                bool empty = false;
+                if constexpr (HAS_WINDOW) empty = (m_new == -INFINITY);
+                const float corr  = empty ? 1.0f : exp2f(m_old - m_new);
                 corr_reg[mi][e]   = corr;
 
                 float rsum = 0.0f;
                 #pragma unroll
                 for (int sj = 0; sj < S_TILES_J; ++sj) {
-                    const float p = exp2f(S_reg[mi][sj][e] - m_new);
+                    const float p =
+                        empty ? 0.0f : exp2f(S_reg[mi][sj][e] - m_new);
                     rsum += p;
                     P_lds[row * P_STR + sj * 16 + wmma_lane] = static_cast<_Float16>(p);
                 }
@@ -2697,6 +2729,36 @@ gqa_flash_prefill_v5_kernel(
         __syncthreads();   // WAR: P_lds reused by next tile's softmax
     }
 
+    // ---- Attention sink: one extra term in the softmax denominator ----
+    // m_reg / l_reg are in log2 space (scores were premultiplied by
+    // scale * kLog2e above and exp2f is used for both), so m_reg == m_nat *
+    // kLog2e and the natural-units sink term exp(s - m_nat) becomes
+    // exp2(s * kLog2e - m_reg) -- the same identity the decode reduce kernel
+    // documents. Row-invariant in the D dimension, so it is folded into l once
+    // here rather than inside the D_TILES loop below.
+    //
+    // smooth_softmax with a null sink means s = 0, matching
+    // softmax_f32_to_out_kernel. A row where every key was masked keeps
+    // m_reg == -INFINITY; it must be skipped, because the exponent would
+    // otherwise be +inf and the whole row would come out zero instead of
+    // sink-only.
+    float l_final[M_TILES][8];
+    const bool apply_sink = (head_sink != nullptr) || (smooth_softmax != 0);
+    float sink_logit = 0.0f;
+    if (head_sink != nullptr)
+        sink_logit = static_cast<float>(
+            head_sink[num_heads > 0 ? (head_q % num_heads) : head_q]);
+    #pragma unroll
+    for (int mi = 0; mi < M_TILES; ++mi) {
+        #pragma unroll
+        for (int e = 0; e < 8; ++e) {
+            float l = l_reg[mi][e];
+            if (apply_sink && m_reg[mi][e] > -INFINITY)
+                l += exp2f(sink_logit * kLog2e - m_reg[mi][e]);
+            l_final[mi][e] = fmaxf(l, 1e-6f);
+        }
+    }
+
     // ---- Epilogue: O / l ----
     #pragma unroll
     for (int mi = 0; mi < M_TILES; ++mi) {
@@ -2708,8 +2770,7 @@ gqa_flash_prefill_v5_kernel(
                 const int c     = tj * 16 + wmma_lane;
                 const int q_pos = q_start + row;
                 if (q_pos < sq && c < D) {
-                    const float l_val   = fmaxf(l_reg[mi][e], 1e-6f);
-                    const float out_val = O_frag[mi][tj][e] / l_val;
+                    const float out_val = O_frag[mi][tj][e] / l_final[mi][e];
                     O[(static_cast<size_t>(batch * sq + q_pos) * Hq + head_q) * D + c] =
                         static_cast<_Float16>(out_val);
                 }
@@ -2734,7 +2795,9 @@ static inline void dispatchPrefillV5(
     int m_tiles, int bkv, int d, hipStream_t stream,
     const _Float16* Q, const _Float16* Kcache, const _Float16* Vcache,
     _Float16* O, int B, int Hq, int G, int sq, int skv, int max_seq,
-    int past_len, float scale)
+    int past_len, float scale,
+    const _Float16* head_sink, int num_heads, int smooth_softmax,
+    int local_window_size)
 {
     const int rows = m_tiles * 16;
     const int num_q_tiles = (sq + rows - 1) / rows;
@@ -2742,22 +2805,33 @@ static inline void dispatchPrefillV5(
     const size_t smem = prefillV5SmemBytes(m_tiles, bkv, d);
     const int ablate = g_v5_ablate;
 
-    #define LAUNCH_V5(MT_, BKV_, D_)                                            \
-        gqa_flash_prefill_v5_kernel<MT_, BKV_, D_>                              \
+    #define LAUNCH_V5(MT_, BKV_, D_, HW_)                                       \
+        gqa_flash_prefill_v5_kernel<MT_, BKV_, D_, HW_>                         \
             <<<grid, 32, smem, stream>>>(                                       \
                 Q, Kcache, Vcache, O, B, Hq, G, sq, skv, max_seq, past_len,     \
-                scale, ablate)
+                scale, ablate, head_sink, num_heads, smooth_softmax,            \
+                local_window_size)
 
+    // Only d == 64 gets windowed instantiations: hip_gqa_flash_prefill_v3
+    // rejects a window at any other head dim, so d == 128 with a window would
+    // be dead code.
     if (d == 64) {
-        if (m_tiles == 2 && bkv == 64)      LAUNCH_V5(2, 64, 64);
-        else if (m_tiles == 2)              LAUNCH_V5(2, 32, 64);
-        else if (bkv == 64)                 LAUNCH_V5(1, 64, 64);
-        else                                LAUNCH_V5(1, 32, 64);
+        if (local_window_size > 0) {
+            if (m_tiles == 2 && bkv == 64)  LAUNCH_V5(2, 64, 64, true);
+            else if (m_tiles == 2)          LAUNCH_V5(2, 32, 64, true);
+            else if (bkv == 64)             LAUNCH_V5(1, 64, 64, true);
+            else                            LAUNCH_V5(1, 32, 64, true);
+        } else {
+            if (m_tiles == 2 && bkv == 64)  LAUNCH_V5(2, 64, 64, false);
+            else if (m_tiles == 2)          LAUNCH_V5(2, 32, 64, false);
+            else if (bkv == 64)             LAUNCH_V5(1, 64, 64, false);
+            else                            LAUNCH_V5(1, 32, 64, false);
+        }
     } else {
-        if (m_tiles == 2 && bkv == 64)      LAUNCH_V5(2, 64, 128);
-        else if (m_tiles == 2)              LAUNCH_V5(2, 32, 128);
-        else if (bkv == 64)                 LAUNCH_V5(1, 64, 128);
-        else                                LAUNCH_V5(1, 32, 128);
+        if (m_tiles == 2 && bkv == 64)      LAUNCH_V5(2, 64, 128, false);
+        else if (m_tiles == 2)              LAUNCH_V5(2, 32, 128, false);
+        else if (bkv == 64)                 LAUNCH_V5(1, 64, 128, false);
+        else                                LAUNCH_V5(1, 32, 128, false);
     }
     #undef LAUNCH_V5
 }
@@ -2780,15 +2854,21 @@ static int tunePrefillV5Cfg(
     int d, hipStream_t stream,
     const _Float16* Q, const _Float16* Kcache, const _Float16* Vcache,
     _Float16* O, int B, int Hq, int G, int sq, int skv, int max_seq,
-    int past_len, float scale)
+    int past_len, float scale, int local_window_size)
 {
     PrefillV5Cfg cands[8];
     const int nc = prefillV5Candidates(d, cands);
     constexpr int kWarmup = 30, kRounds = 4, kIters = 30;
 
+    // Tuning launches carry no sink: it is a single fused-multiply-add per row in
+    // the epilogue, so it cannot shift which (M_TILES, BKV) wins, and leaving it
+    // out keeps tuned configs comparable with the non-sink case. The window is
+    // passed through, because it changes how many KV tiles each block walks and
+    // therefore genuinely can change the winner.
     auto launch_cfg = [&](const PrefillV5Cfg& c) {
         dispatchPrefillV5(c.m_tiles, c.bkv, d, stream, Q, Kcache, Vcache, O,
-                          B, Hq, G, sq, skv, max_seq, past_len, scale);
+                          B, Hq, G, sq, skv, max_seq, past_len, scale,
+                          nullptr, Hq, 0, local_window_size);
     };
 
     for (int w = 0; w < kWarmup; ++w) launch_cfg(cands[w % nc]);
@@ -3613,11 +3693,12 @@ extern "C" void hip_gqa_flash_prefill_v5_set_ablate(int mask) {
     g_v5_ablate = mask;
 }
 
-extern "C" int hip_gqa_flash_prefill_v5_v2(
+static int prefillV5Run(
     void* stream_ptr,
     const void* Q, const void* Kcache, const void* Vcache, void* O,
     int B, int Hq, int G, int sq, int skv, int d, int max_seq, int past_len,
-    float scale)
+    float scale, const void* head_sink, int num_heads, int smooth_softmax,
+    int local_window_size)
 {
     if (d != 64 && d != 128) return -1;
 
@@ -3626,10 +3707,20 @@ extern "C" int hip_gqa_flash_prefill_v5_v2(
     const _Float16* K_ptr = static_cast<const _Float16*>(Kcache);
     const _Float16* V_ptr = static_cast<const _Float16*>(Vcache);
     _Float16* O_ptr       = static_cast<_Float16*>(O);
+    const _Float16* sink_ptr = static_cast<const _Float16*>(head_sink);
 
+    // Neither skv nor the sink belongs in the key. skv only scales the KV loop
+    // length, uniformly across candidates, so it cannot reorder them: measured
+    // on gpt-oss-20b, M_TILES=2/BKV=32 wins at all 32 chunk skv values from 512
+    // to 16384 with an identical candidate ranking. Keying on skv re-tuned once
+    // per chunk of a chunked prefill instead of once per process. The sink is
+    // one FMA per row in the epilogue (see tunePrefillV5Cfg).
+    //
+    // The window does belong in the key: it caps how many KV tiles a block walks,
+    // which is a different work profile, not a scaled one.
     std::string key = std::to_string(d) + "_" + std::to_string(sq) + "_" +
-                      std::to_string(skv) + "_" + std::to_string(Hq) + "_" +
-                      std::to_string(G);
+                      std::to_string(Hq) + "_" + std::to_string(G) + "_w" +
+                      std::to_string(local_window_size > 0 ? local_window_size : 0);
     int cfg;
     {
         std::lock_guard<std::mutex> lk(g_v5_cfg_mutex);
@@ -3638,7 +3729,8 @@ extern "C" int hip_gqa_flash_prefill_v5_v2(
             cfg = it->second;
         } else {
             cfg = tunePrefillV5Cfg(d, stream, Q_ptr, K_ptr, V_ptr, O_ptr,
-                                   B, Hq, G, sq, skv, max_seq, past_len, scale);
+                                   B, Hq, G, sq, skv, max_seq, past_len, scale,
+                                   local_window_size);
             g_v5_cfg_cache[key] = cfg;
             snprintf(g_v5_tune_info, sizeof(g_v5_tune_info),
                      "gqa_flash_prefill_v5 cfg=M%d_BKV%d", cfg / 1000, cfg % 1000);
@@ -3646,8 +3738,19 @@ extern "C" int hip_gqa_flash_prefill_v5_v2(
     }
     int m_tiles = cfg / 1000, bkv = cfg % 1000;
     dispatchPrefillV5(m_tiles, bkv, d, stream, Q_ptr, K_ptr, V_ptr, O_ptr,
-                      B, Hq, G, sq, skv, max_seq, past_len, scale);
+                      B, Hq, G, sq, skv, max_seq, past_len, scale,
+                      sink_ptr, num_heads, smooth_softmax, local_window_size);
     return 0;
+}
+
+extern "C" int hip_gqa_flash_prefill_v5_v2(
+    void* stream_ptr,
+    const void* Q, const void* Kcache, const void* Vcache, void* O,
+    int B, int Hq, int G, int sq, int skv, int d, int max_seq, int past_len,
+    float scale)
+{
+    return prefillV5Run(stream_ptr, Q, Kcache, Vcache, O, B, Hq, G, sq, skv, d,
+                        max_seq, past_len, scale, nullptr, Hq, 0, 0);
 }
 
 
@@ -3706,6 +3809,35 @@ extern "C" void hip_gqa_flash_prefill_v8_set_ablate(int mask) {
     g_v8_ablate = mask;
 }
 
+
+// Wide fused flash-prefill entry: adds attention sinks and the sliding window
+// on top of v2. v2 stays the narrow ABI so the standalone harnesses and shim
+// headers that redeclare it keep linking unchanged.
+//
+// Both features are implemented for d == 64 (the v5 kernel) only. For any other
+// d we return -1 rather than silently ignoring them, so the runtime keeps
+// routing those shapes to the decomposed path, which does implement both. A
+// request carrying neither is forwarded to v2 and keeps v2's head-dim coverage
+// and its v5/v7/v8 selection; d == 64 lands on v5 either way, so a sink or a
+// window never changes which kernel runs.
+extern "C" int hip_gqa_flash_prefill_v3(
+    void* stream_ptr,
+    const void* Q, const void* Kcache, const void* Vcache, void* O,
+    int B, int Hq, int G, int sq, int skv, int d, int max_seq, int past_len,
+    float scale, int local_window_size, const void* head_sink,
+    int num_heads, int smooth_softmax)
+{
+    const bool wants_sink   = (head_sink != nullptr) || (smooth_softmax != 0);
+    const bool wants_window = local_window_size > 0;
+    if ((wants_sink || wants_window) && d != 64) return -1;
+    if (!wants_sink && !wants_window) {
+        return hip_gqa_flash_prefill_v2(stream_ptr, Q, Kcache, Vcache, O, B, Hq,
+                                        G, sq, skv, d, max_seq, past_len, scale);
+    }
+    return prefillV5Run(stream_ptr, Q, Kcache, Vcache, O, B, Hq, G, sq, skv, d,
+                        max_seq, past_len, scale, head_sink, num_heads,
+                        smooth_softmax, local_window_size);
+}
 
 // Unified fused flash-prefill entry. The kernel-selection strategy lives here
 // (in the kernel TU) instead of in the runtime dispatcher: v5 wins at d==64

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -751,6 +751,31 @@ HIP_KERNEL_API int hip_gqa_flash_prefill_v2(
     void* O, int B, int Hq, int G, int sq, int skv, int d, int max_seq,
     int past_len, float scale);
 
+/* Same as hip_gqa_flash_prefill_v2, plus attention sinks / smooth softmax and
+ * a sliding window.
+ * Kept as a separate symbol rather than widening v2, because v2 is redeclared
+ * locally by the standalone GQA harnesses and the dispatch_bench shim header;
+ * widening it in place would break those and risk a silent host/kernel ABI skew.
+ *
+ *   local_window_size : <= 0 for full attention. > 0 masks key k for query q
+ *                       when k < past_len + q - local_window_size + 1, the same
+ *                       convention causal_mask_kernel_impl uses.
+ *   head_sink         : [num_heads] __half of per-head sink logits, or null.
+ *   smooth_softmax    : non-zero adds a sink logit of 0, matching the
+ *                       decomposed path when head_sink is null. head_sink takes
+ *                       precedence when both are supplied.
+ *
+ * Sinks and windows are implemented by the v5 kernel, i.e. at d == 64 only.
+ * Returns 0 on success and -1 when the request cannot be served exactly (a sink
+ * or a window with d != 64), so the caller falls back to the decomposed path
+ * instead of silently dropping either. A request with neither is forwarded to
+ * v2 and keeps v2's head-dim coverage. */
+HIP_KERNEL_API int hip_gqa_flash_prefill_v3(
+    void* stream, const void* Q, const void* Kcache, const void* Vcache,
+    void* O, int B, int Hq, int G, int sq, int skv, int d, int max_seq,
+    int past_len, float scale, int local_window_size, const void* head_sink,
+    int num_heads, int smooth_softmax);
+
 /* NB: prefill is compute-bound, so there is deliberately NO separate int8
  * prefill kernel. The runtime (real/gqa.cpp) dequantizes the int8 KV cache to an
  * fp16 scratch ONCE (hip_gqa_dequant_kv_i8_to_fp16) and reuses the tuned fp16

--- a/lib/Runtime/Kernels/test/example/gqa/prefill/test_gqa_prefill.cpp
+++ b/lib/Runtime/Kernels/test/example/gqa/prefill/test_gqa_prefill.cpp
@@ -35,6 +35,14 @@ extern "C" int hip_gqa_flash_prefill_v2(
     void* O, int B, int Hq, int G, int sq, int skv, int d, int max_seq,
     int past_len, float scale);
 
+// Wide entry: same as v2 plus attention sinks / smooth softmax and a sliding
+// window.
+extern "C" int hip_gqa_flash_prefill_v3(
+    void* stream, const void* Q, const void* Kcache, const void* Vcache,
+    void* O, int B, int Hq, int G, int sq, int skv, int d, int max_seq,
+    int past_len, float scale, int local_window_size, const void* head_sink,
+    int num_heads, int smooth_softmax);
+
 extern "C" int hip_gqa_flash_prefill_v7(
     void* stream, const void* Q, const void* Kcache, const void* Vcache,
     void* O, int B, int Hq, int G, int sq, int skv, int d, int max_seq,
@@ -50,9 +58,35 @@ extern "C" int hip_gqa_flash_prefill_v7(
     }                                                                          \
   } while (0)
 
+// Sink handling, matching softmax_f32_to_out_kernel exactly: the row max is
+// taken over the scores only (the sink does NOT participate), and the sink
+// contributes a single exp(s - max) term to the denominator. kSinkSmooth is the
+// smooth_softmax case, i.e. a sink logit of 0 with no sink tensor.
+//
+// kSinkBoth sends a sink tensor AND smooth_softmax=1, which is the only
+// combination the runtime ever produces: gqa.cpp derives smooth from
+// (head_sink != nullptr || smooth_softmax == 1) and then passes both. head_sink
+// takes precedence, so the reference folds in the per-head logit alone; a kernel
+// that also added the smooth term would double-count the denominator and fail.
+enum SinkMode {
+  kSinkNone = 0,
+  kSinkPerHead = 1,
+  kSinkSmooth = 2,
+  kSinkBoth = 3
+};
+
 struct Case {
   const char* name;
-  int B, H, G, D, sq;  // pure prefill: skv = sq, past_len = 0
+  int B, H, G, D, sq;
+  int past;       // past_len; total_seq = past + sq. 0 = pure prefill.
+  int sink_mode;  // SinkMode
+  // Expect the kernel to decline (rc != 0) instead of computing. Used for the
+  // shapes v3 must refuse so the runtime falls back to the decomposed path
+  // rather than dropping the sink or the window.
+  bool expect_reject;
+  // Sliding window; <= 0 is full attention. Convention matches
+  // causal_mask_kernel_impl: key k is masked when k < past_len + q - window + 1.
+  int window;
 };
 
 // CPU fp32 reference: causal GQA attention. Q/O BSHD, K/V cache BNSD.
@@ -60,7 +94,8 @@ static void cpu_reference(const std::vector<float>& Q,
                           const std::vector<float>& K,
                           const std::vector<float>& V, std::vector<float>& O,
                           int B, int H, int G, int D, int sq, int max_seq,
-                          int past_len, float scale) {
+                          int past_len, float scale, int sink_mode,
+                          const std::vector<float>& sink, int window) {
   const int HPG = H / G;
   const int total = past_len + sq;
   std::vector<float> scores(total);
@@ -70,8 +105,11 @@ static void cpu_reference(const std::vector<float>& Q,
       for (int s = 0; s < sq; ++s) {
         const float* q = &Q[((size_t)(b * sq + s) * H + hq) * D];
         const int kmax = past_len + s;  // causal: attend to keys 0..kmax
+        const int kmin = (window > 0 && kmax - window + 1 > 0)
+                             ? (kmax - window + 1)
+                             : 0;
         float m = -1e30f;
-        for (int k = 0; k <= kmax; ++k) {
+        for (int k = kmin; k <= kmax; ++k) {
           const float* kp = &K[((size_t)(b * G + hkv) * max_seq + k) * D];
           float dot = 0.0f;
           for (int e = 0; e < D; ++e) dot += q[e] * kp[e];
@@ -79,14 +117,18 @@ static void cpu_reference(const std::vector<float>& Q,
           if (scores[k] > m) m = scores[k];
         }
         float l = 0.0f;
-        for (int k = 0; k <= kmax; ++k) {
+        for (int k = kmin; k <= kmax; ++k) {
           scores[k] = std::exp(scores[k] - m);
           l += scores[k];
         }
+        if (sink_mode == kSinkPerHead || sink_mode == kSinkBoth)
+          l += std::exp(sink[hq] - m);
+        else if (sink_mode == kSinkSmooth)
+          l += std::exp(0.0f - m);
         const float inv = (l > 0.0f) ? 1.0f / l : 0.0f;
         float* o = &O[((size_t)(b * sq + s) * H + hq) * D];
         for (int e = 0; e < D; ++e) o[e] = 0.0f;
-        for (int k = 0; k <= kmax; ++k) {
+        for (int k = kmin; k <= kmax; ++k) {
           const float* vp = &V[((size_t)(b * G + hkv) * max_seq + k) * D];
           const float w = scores[k] * inv;
           for (int e = 0; e < D; ++e) o[e] += w * vp[e];
@@ -108,13 +150,14 @@ static double rel_l2(const std::vector<float>& a, const std::vector<float>& b) {
 
 static bool run_case(const Case& c, int iters) {
   const int B = c.B, H = c.H, G = c.G, D = c.D, sq = c.sq;
-  const int max_seq = sq;       // pure-prefill cache buffer
-  const int past_len = 0, skv = sq;
+  const int past_len = c.past;
+  const int skv = past_len + sq;   // total_seq
+  const int max_seq = skv;         // cache buffer holds exactly total_seq
   const float scale = 1.0f / std::sqrt((float)D);
 
   const size_t qn = (size_t)B * sq * H * D;
   const size_t kn = (size_t)B * G * max_seq * D;
-  std::mt19937 rng(1234 + sq + D);
+  std::mt19937 rng(1234 + sq + D + past_len + c.sink_mode);
   std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
 
   std::vector<float> Qf(qn), Kf(kn), Vf(kn), Oref(qn);
@@ -122,31 +165,65 @@ static bool run_case(const Case& c, int iters) {
   for (auto& x : Kf) x = dist(rng);
   for (auto& x : Vf) x = dist(rng);
 
-  cpu_reference(Qf, Kf, Vf, Oref, B, H, G, D, sq, max_seq, past_len, scale);
+  // gpt-oss ships sink logits around O(1); span a wider range so a sign or
+  // scaling error in the log2-space conversion cannot hide. Round-trip through
+  // fp16 first, because that is what the kernel reads -- otherwise the
+  // comparison would charge the kernel for the host's rounding.
+  std::vector<__half> sinkh(H);
+  std::vector<float> sinkf(H);
+  for (int h = 0; h < H; ++h) {
+    sinkh[h] = __float2half(-2.0f + 4.0f * (float)h / (float)H);
+    sinkf[h] = __half2float(sinkh[h]);
+  }
+
+  cpu_reference(Qf, Kf, Vf, Oref, B, H, G, D, sq, max_seq, past_len, scale,
+                c.sink_mode, sinkf, c.window);
 
   std::vector<__half> Qh(qn), Kh(kn), Vh(kn);
   for (size_t i = 0; i < qn; ++i) Qh[i] = __float2half(Qf[i]);
   for (size_t i = 0; i < kn; ++i) { Kh[i] = __float2half(Kf[i]); Vh[i] = __float2half(Vf[i]); }
 
-  __half *dQ, *dK, *dV, *dO;
+  __half *dQ, *dK, *dV, *dO, *dSink;
   HIP_CHECK(hipMalloc(&dQ, qn * sizeof(__half)));
   HIP_CHECK(hipMalloc(&dK, kn * sizeof(__half)));
   HIP_CHECK(hipMalloc(&dV, kn * sizeof(__half)));
   HIP_CHECK(hipMalloc(&dO, qn * sizeof(__half)));
+  HIP_CHECK(hipMalloc(&dSink, (size_t)H * sizeof(__half)));
   HIP_CHECK(hipMemcpy(dQ, Qh.data(), qn * sizeof(__half), hipMemcpyHostToDevice));
   HIP_CHECK(hipMemcpy(dK, Kh.data(), kn * sizeof(__half), hipMemcpyHostToDevice));
   HIP_CHECK(hipMemcpy(dV, Vh.data(), kn * sizeof(__half), hipMemcpyHostToDevice));
+  HIP_CHECK(hipMemcpy(dSink, sinkh.data(), (size_t)H * sizeof(__half), hipMemcpyHostToDevice));
 
   // Route through the unified entry (same path the runtime takes); it dispatches
   // v5 (D==64) / v7 (D==128) internally.
+  const void* sink_arg =
+      (c.sink_mode == kSinkPerHead || c.sink_mode == kSinkBoth)
+          ? (const void*)dSink
+          : nullptr;
+  const int smooth_arg =
+      (c.sink_mode == kSinkSmooth || c.sink_mode == kSinkBoth) ? 1 : 0;
+  const int window_arg = (c.window > 0) ? c.window : -1;
+  const char* sink_tag = (c.sink_mode == kSinkPerHead) ? "sink"
+                       : (c.sink_mode == kSinkSmooth)  ? "smooth"
+                       : (c.sink_mode == kSinkBoth)    ? "both"
+                                                       : "-";
   auto launch = [&]() {
-    return hip_gqa_flash_prefill_v2(nullptr, dQ, dK, dV, dO, B, H, G, sq, skv, D,
-                                 max_seq, past_len, scale);
+    return hip_gqa_flash_prefill_v3(nullptr, dQ, dK, dV, dO, B, H, G, sq, skv, D,
+                                    max_seq, past_len, scale, window_arg,
+                                    sink_arg, H, smooth_arg);
   };
 
   int rc = launch();  // first call self-tunes
   HIP_CHECK(hipDeviceSynchronize());
-  if (rc != 0) { fprintf(stderr, "kernel returned %d\n", rc); return false; }
+  if (c.expect_reject) {
+    const bool ok = (rc != 0);
+    printf("%-16s B%d H%d G%d(hpg%d) D%-3d sq=%-5d past=%-5d %-6s w=%-5d | rc=%d (expected decline)  %s\n",
+           c.name, B, H, G, H / G, D, sq, past_len, sink_tag, c.window, rc,
+           ok ? "PASS" : "FAIL");
+    hipFree(dQ); hipFree(dK); hipFree(dV); hipFree(dO); hipFree(dSink);
+    return ok;
+  }
+  if (rc != 0) { fprintf(stderr, "%s: kernel returned %d\n", c.name, rc); return false; }
 
   std::vector<__half> Oh(qn);
   HIP_CHECK(hipMemcpy(Oh.data(), dO, qn * sizeof(__half), hipMemcpyDeviceToHost));
@@ -168,12 +245,12 @@ static bool run_case(const Case& c, int iters) {
   ms /= iters;
 
   const bool pass = err < 2e-3;
-  printf("%-16s B%d H%d G%d(hpg%d) D%-3d sq=%-5d | relL2=%.2e  latency=%.4f ms  %s (v%d)\n",
-         c.name, B, H, G, H / G, D, sq, err, ms, pass ? "PASS" : "FAIL",
-         D == 64 ? 5 : 7);
+  printf("%-16s B%d H%d G%d(hpg%d) D%-3d sq=%-5d past=%-5d %-6s w=%-5d | relL2=%.2e  latency=%.4f ms  %s (v%d)\n",
+         c.name, B, H, G, H / G, D, sq, past_len, sink_tag, c.window, err, ms,
+         pass ? "PASS" : "FAIL", D == 64 ? 5 : 7);
 
   hipEventDestroy(e0); hipEventDestroy(e1);
-  hipFree(dQ); hipFree(dK); hipFree(dV); hipFree(dO);
+  hipFree(dQ); hipFree(dK); hipFree(dV); hipFree(dO); hipFree(dSink);
   return pass;
 }
 
@@ -183,12 +260,54 @@ int main(int argc, char** argv) {
     if (!std::strcmp(argv[i], "--iters") && i + 1 < argc) iters = std::atoi(argv[++i]);
 
   const Case cases[] = {
-      {"gpt_oss-20b",  1, 64, 8,  64, 512},
-      {"gpt_oss-20b",  1, 64, 8,  64, 2048},
-      {"llama-3.2-1b", 1, 32, 8,  64, 512},
-      {"llama-3.2-1b", 1, 32, 8,  64, 2048},
-      {"llama-3.1-8b", 1, 32, 8, 128, 512},
-      {"llama-3.1-8b", 1, 32, 8, 128, 2048},
+      // No-sink regression set (must stay as accurate as before).
+      {"gpt_oss-20b",  1, 64, 8,  64, 512,  0,    kSinkNone,    false, 0},
+      {"gpt_oss-20b",  1, 64, 8,  64, 2048, 0,    kSinkNone,    false, 0},
+      {"llama-3.2-1b", 1, 32, 8,  64, 512,  0,    kSinkNone,    false, 0},
+      {"llama-3.2-1b", 1, 32, 8,  64, 2048, 0,    kSinkNone,    false, 0},
+      {"llama-3.1-8b", 1, 32, 8, 128, 512,  0,    kSinkNone,    false, 0},
+      {"llama-3.1-8b", 1, 32, 8, 128, 2048, 0,    kSinkNone,    false, 0},
+      // Sink set at the real gpt-oss geometry (H=64, G=8, d=64), including
+      // chunked prefill (past > 0), which is what a 16k prompt actually runs.
+      {"gpt_oss-sink",  1, 64, 8,  64, 512,  0,    kSinkPerHead, false, 0},
+      {"gpt_oss-sink",  1, 64, 8,  64, 2048, 0,    kSinkPerHead, false, 0},
+      {"gpt_oss-sink",  1, 64, 8,  64, 512,  512,  kSinkPerHead, false, 0},
+      {"gpt_oss-sink",  1, 64, 8,  64, 512,  8192, kSinkPerHead, false, 0},
+      {"gpt_oss-smooth",1, 64, 8,  64, 512,  0,    kSinkSmooth,  false, 0},
+      {"gpt_oss-smooth",1, 64, 8,  64, 512,  512,  kSinkSmooth,  false, 0},
+      // Sink tensor AND smooth_softmax=1 together. The cases above each set one
+      // argument, but gqa.cpp only ever sets both at once, so without this the
+      // exact combination the runtime sends is untested.
+      {"gpt_oss-both",  1, 64, 8,  64, 512,  0,    kSinkBoth,    false, 0},
+      {"gpt_oss-both",  1, 64, 8,  64, 512,  512,  kSinkBoth,    false, 0},
+      // A sink must not silently apply at d == 128: v3 declines so the runtime
+      // falls back to the decomposed path, which does implement it.
+      {"llama-sink-d128",1, 32, 8, 128, 512, 0,    kSinkPerHead, true,  0},
+
+      // Sliding window, gpt-oss geometry, window=128 as the model ships.
+      // Window alone first, so a window bug cannot hide behind the sink.
+      {"gpt_oss-win",   1, 64, 8,  64, 512,  0,    kSinkNone,    false, 128},
+      {"gpt_oss-win",   1, 64, 8,  64, 2048, 0,    kSinkNone,    false, 128},
+      // Chunked: past deeper than the window is the case where whole KV tiles
+      // must be skipped rather than merely masked.
+      {"gpt_oss-win",   1, 64, 8,  64, 512,  512,  kSinkNone,    false, 128},
+      {"gpt_oss-win",   1, 64, 8,  64, 512,  8192, kSinkNone,    false, 128},
+      // Window not aligned to any BKV (32/64), to catch an off-by-one in the
+      // start-tile clamp.
+      {"gpt_oss-win",   1, 64, 8,  64, 512,  1000, kSinkNone,    false, 100},
+      // Window wider than the whole sequence must equal full attention.
+      {"gpt_oss-win-big",1, 64, 8, 64, 512,  0,    kSinkNone,    false, 4096},
+      // Window == 1 is the degenerate case: each query sees only itself.
+      {"gpt_oss-win1",  1, 64, 8,  64, 512,  512,  kSinkNone,    false, 1},
+      // Window together with the sink, which is what gpt-oss actually runs on
+      // its 12 sliding layers.
+      {"gpt_oss-win+sk",1, 64, 8,  64, 512,  0,    kSinkPerHead, false, 128},
+      {"gpt_oss-win+sk",1, 64, 8,  64, 512,  8192, kSinkPerHead, false, 128},
+      // The full production configuration of a gpt-oss sliding layer: window,
+      // sink tensor and smooth together, deep enough to skip whole KV tiles.
+      {"gpt_oss-win+bo",1, 64, 8,  64, 512,  8192, kSinkBoth,    false, 128},
+      // A window must not silently apply at d == 128 either.
+      {"llama-win-d128",1, 32, 8, 128, 512,  0,    kSinkNone,    true,  128},
   };
   int fails = 0;
   for (const auto& c : cases) if (!run_case(c, iters)) ++fails;

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -10,22 +10,27 @@
 // The generated IR calls `wrap_group_query_attention` (39-arg ABI, unchanged so
 // the HipToLLVM lowering keeps resolving). Path selection:
 //
-//   * Common fp16 causal GQA (head_dim in {64,128}, templated decode geometry,
-//     no sliding window / sink / smooth) -> optimized fused custom kernels:
+//   * Common fp16 causal GQA (head_dim in {64,128}, templated decode geometry)
+//     -> optimized fused custom kernels:
 //       prefill (sq > 1): [split] -> [rope] -> kv-cache update ->
-//                         hip_gqa_flash_prefill_v2
+//                         hip_gqa_flash_prefill_v3
 //       decode  (sq == 1): [split] -> [rope] -> kv-cache update ->
 //                         hip_gqa_flash_decode_v2
+//     Attention sinks / smooth softmax are applied here too: by flash decode
+//     for any supported geometry, and by flash prefill at head_dim == 64 (the
+//     v5 kernel). Prefill at head_dim 128/256 with a sink still goes
+//     decomposed. Sliding windows are applied by flash prefill at
+//     head_dim == 64; windowed decode still goes decomposed.
 //
 //   * Everything else the fused kernels do not implement (fp32, no_causal /
-//     bidirectional, sliding window, head sink / smooth softmax, additive
-//     attention bias, other head_dim, untemplated decode geometry) -> the
-//     feature-complete legacy decomposed hipBLASLt pipeline
-//     gqa_forward_hipblaslt below. This is a verbatim port of the proven
-//     gqa_back.cpp strategy (the read-only backup stays out of the build); its
-//     fast decode kernels (hip_gqa_fused_decode / hip_gqa_flash_decode) are
-//     folded into gqa_kernel.hip so the sliding-window / sink decode case keeps
-//     the legacy kernel's performance.
+//     bidirectional, a window on decode or on 128/256-wide prefill, a sink on
+//     128/256-wide prefill, additive attention bias, other head_dim,
+//     untemplated decode geometry) -> the feature-complete legacy decomposed
+//     hipBLASLt pipeline gqa_forward_hipblaslt below. This is a verbatim port
+//     of the proven gqa_back.cpp strategy (the read-only backup stays out of
+//     the build); its fast decode kernels (hip_gqa_fused_decode /
+//     hip_gqa_flash_decode) are folded into gqa_kernel.hip so the windowed
+//     decode case keeps the legacy kernel's performance.
 //
 //   * The additive attention bias (onnx.Attention attn_mask) IS supported, but
 //     only by the decomposed path (Step 8b adds it; a causal op then masks the
@@ -313,7 +318,9 @@ static int gqa_forward_fused(
     int64_t B, int64_t sq, int64_t skv, int64_t past_buf_seq, int64_t H,
     int64_t G, int64_t d, float scale, int64_t do_rotary,
     const void *k_scale = nullptr, const void *v_scale = nullptr,
-    KvCacheFormat kv_format = KvCacheFormat::Fp16) {
+    KvCacheFormat kv_format = KvCacheFormat::Fp16,
+    const void *head_sink = nullptr, bool use_smooth_softmax = false,
+    int local_window_size = -1) {
 
   // Any non-fp16 cache reads/writes quantized bytes on the concat/append/decode
   // path; the specific scheme is carried by kv_format (extensible to INT4/FP8).
@@ -462,13 +469,21 @@ static int gqa_forward_fused(
       // Decode is bandwidth-bound: a quantized cache is read directly (e.g.
       // int8 halves the DRAM traffic). One entry serves every format --
       // kv_dtype selects the code path inside the kernel; scales feed dequant.
+      //
+      // local_window_size is pinned to 0 rather than forwarded from the
+      // parameter: window_ok in wrap_group_query_attention sends every windowed
+      // decode to the decomposed pipeline, so the parameter is always <= 0 here
+      // and forwarding it would only look like the windowed decode path is
+      // supported. This kernel does clamp kv_lo, so enabling it is roughly this
+      // one argument -- but nothing in the harness verifies it yet, so it stays
+      // an explicit 0 until something does.
       int drc = hip_gqa_flash_decode_v2(
           stream, qSrc, present_key, present_value, output, partials,
           static_cast<int>(B), static_cast<int>(H), static_cast<int>(G),
           static_cast<int>(d), static_cast<int>(skv),
           static_cast<int>(present_seq), kFlashDecodeMaxSplits, scale,
-          seqlens_k_ptr, /*local_window_size=*/0, /*head_sink=*/nullptr,
-          /*smooth_softmax=*/0, kv_dtype_abi(kv_format),
+          seqlens_k_ptr, /*local_window_size=*/0, head_sink,
+          use_smooth_softmax ? 1 : 0, kv_dtype_abi(kv_format),
           kv_quantized ? k_scale : nullptr, kv_quantized ? v_scale : nullptr);
       if (drc != 0)
         return -1;
@@ -643,18 +658,25 @@ static int gqa_forward_fused(
   }
 
   // Single unified entry; v5 (d==64) / v7 (d==128) selection lives in the
-  // kernel TU (gqa_kernel.hip).
-  int fp_rc = hip_gqa_flash_prefill_v2(
+  // kernel TU (gqa_kernel.hip). v3 carries the sink and the window; it returns
+  // -1 rather than dropping either when the kernel for this d cannot apply it,
+  // and the caller then falls back to the decomposed path.
+  int fp_rc = hip_gqa_flash_prefill_v3(
       stream, qSrc, kAttn, vAttn, output, static_cast<int>(B),
       static_cast<int>(H), static_cast<int>(G), static_cast<int>(sq),
       static_cast<int>(total_seq), static_cast<int>(d), attn_max_seq,
-      static_cast<int>(past_len), scale);
+      static_cast<int>(past_len), scale, local_window_size, head_sink,
+      static_cast<int>(H), use_smooth_softmax ? 1 : 0);
+  // window is logged because it selects the HAS_WINDOW instantiation, so a
+  // dispatch that looks identical here can be two different kernels.
   RUNTIME_DEBUG_LOG(
       "[REAL] GQA fused prefill (%s d=%lld -> v%d): B=%lld sq=%lld "
-      "total_seq=%lld H=%lld G=%lld past_len=%lld rc=%d\n",
+      "total_seq=%lld H=%lld G=%lld past_len=%lld sink=%d smooth=%d window=%d "
+      "rc=%d\n",
       kv_quantized ? "quant" : "fp16", (long long)d, (d == 64 ? 5 : 7),
       (long long)B, (long long)sq, (long long)total_seq, (long long)H,
-      (long long)G, (long long)past_len, fp_rc);
+      (long long)G, (long long)past_len, static_cast<int>(head_sink != nullptr),
+      static_cast<int>(use_smooth_softmax), local_window_size, fp_rc);
   return fp_rc != 0 ? -1 : 0;
 }
 
@@ -2012,14 +2034,15 @@ int wrap_group_query_attention(
   //===------------------------------------------------------------------===//
   // Path selection. The optimized fused/flash kernels are fp16 causal GQA
   // with head_dim in {64,128} and a templated decode geometry (HpG in
-  // {1,2,3,4,8,16}). Anything they do not implement -- fp32, no_causal /
-  // bidirectional, sliding window, head sink / smooth softmax, other
+  // {1,2,3,4,8,16}), and now also cover attention sinks (decode always,
+  // prefill at head_dim == 64) and sliding windows (prefill at head_dim == 64).
+  // Anything they do not implement -- fp32, no_causal / bidirectional, a window
+  // on decode or on 128/256-wide prefill, a sink on 128/256-wide prefill, other
   // head_dim, or an untemplated decode geometry -- is handled by the legacy
   // decomposed hipBLASLt pipeline (gqa_forward_hipblaslt above), which is the
   // verbatim-ported gqa_back.cpp strategy: feature-complete, and keeps the
-  // legacy fast decode kernel for the sliding-window / sink decode case so
-  // that path is not slower than the original. The common fp16 causal case
-  // still takes the fast fused path here.
+  // legacy fast decode kernel for the windowed decode case so that path is not
+  // slower than the original.
   //===------------------------------------------------------------------===//
   const bool is_decode = (seq_len_q == 1);
   const bool decode_geometry_ok =
@@ -2034,9 +2057,26 @@ int wrap_group_query_attention(
   // decomposed pipeline (Step 8b); the lean fused path would silently drop it,
   // so exclude it here to route masked attention to gqa_forward_hipblaslt
   // below.
+  //
+  // Smooth softmax is active when a sink is supplied OR the attribute is
+  // explicitly 1, matching ORT (gqa_attention_base.h:
+  // use_smooth_softmax_ || head_sink != nullptr).
+  const bool has_smooth_softmax = (head_sink != nullptr || smooth_softmax == 1);
+  // Sinks on the fused path: the flash decode kernel applies them for any
+  // supported geometry, and flash prefill applies them at head_dim == 64 (the
+  // v5 kernel). Prefill at head_dim 128/256 has no sink support yet, so those
+  // shapes must keep routing to the decomposed pipeline -- admitting them here
+  // would make hip_gqa_flash_prefill_v3 return -1 and fail the op outright
+  // instead of falling back.
+  const bool sink_ok = !has_smooth_softmax || is_decode || head_dim == 64;
+  // Sliding window on the fused path: implemented by flash prefill at
+  // head_dim == 64 (the v5 kernel). Decode is deliberately left on the
+  // decomposed pipeline even though its kernel clamps kv_lo, because that path
+  // is unverified here; prefill is what the window costs us on gpt-oss.
+  const bool window_ok =
+      local_window_size <= 0 || (!is_decode && head_dim == 64);
   const bool fused_supported = element_size_bytes == 2 && no_causal == 0 &&
-                               local_window_size <= 0 && head_sink == nullptr &&
-                               smooth_softmax != 1 && head_dim_ok &&
+                               window_ok && sink_ok && head_dim_ok &&
                                decode_geometry_ok && attention_bias == nullptr;
 
   // A quantized KV cache is implemented ONLY on the fused path (quant decode +
@@ -2047,8 +2087,9 @@ int wrap_group_query_attention(
       (!fused_supported || (head_dim != 64 && head_dim != 128))) {
     fprintf(stderr,
             "wrap_group_query_attention: quantized KV cache requires the fused "
-            "path (fp16, causal, no window/sink/smooth/bias, head_dim 64 or "
-            "128); got fused_supported=%d head_dim=%lld\n",
+            "path (fp16, causal, no attention bias, any window/sink only where "
+            "the fused kernels implement it, head_dim 64 or 128); got "
+            "fused_supported=%d head_dim=%lld\n",
             static_cast<int>(fused_supported), (long long)head_dim);
     return -1;
   }
@@ -2060,11 +2101,6 @@ int wrap_group_query_attention(
       fprintf(stderr, "wrap_group_query_attention: null hipblas handle\n");
       return -1;
     }
-    // Smooth softmax: activated when head_sink is provided OR the
-    // smooth_softmax attribute is explicitly 1, matching ORT behaviour
-    // (gqa_attention_base.h: use_smooth_softmax_ || head_sink != nullptr).
-    const bool has_smooth_softmax =
-        (head_sink != nullptr || smooth_softmax == 1);
     RUNTIME_DEBUG_LOG(
         "[REAL] wrap_group_query_attention: routing to legacy decomposed "
         "pipeline "
@@ -2101,7 +2137,8 @@ int wrap_group_query_attention(
       state, stream, query, key, value, past_key, past_value, seqlens_k,
       cos_cache, sin_cache, output, present_key, present_value, batch_size,
       seq_len_q, seq_len_kv, past_buf_seq, num_heads, kv_num_heads, head_dim,
-      scale, do_rotary, k_scale, v_scale, kv_format);
+      scale, do_rotary, k_scale, v_scale, kv_format, head_sink,
+      has_smooth_softmax, static_cast<int>(local_window_size));
   if (rc != 0)
     fprintf(stderr,
             "wrap_group_query_attention: gqa_forward_fused failed "


### PR DESCRIPTION
## Summary

Puts every gpt-oss-20b attention layer on the fused flash prefill path, and then
pays back the register cost that doing so imposed on the full-attention path.

This PR targets `main` and supersedes #598 (attention sinks) and #622 (sliding
windows), both closed in favour of it. Nothing here is stacked and the diff is
complete against `main`. It was developed as eight commits and has been squashed
into one, since the three parts below only make sense together: the sinks alone
still left half the gpt-oss layers on the decomposed path, and the windows alone
regressed full attention until templated.

Three parts:

1. **Sinks.** gpt-oss carries a learned per-head sink logit on every layer, and
   the fused gate rejected any sink, so all 24 layers fell back to materialising
   an fp32 score matrix.
2. **Windows.** gpt-oss alternates full-attention and sliding-window layers, 12
   of each. The window was only ever applied as extra masking on the decomposed
   path, so a windowed layer cost the same as a full one.
3. **Templating.** Making the window a runtime argument in step 2 spilled
   registers in a kernel already at the VGPR ceiling, and the cost landed on the
   full-attention path, which gained nothing from the window.

After this, a 2048-token prefill logs **96 of 96** GQA calls (4 chunks x 24
layers) as fused prefill and none as decomposed.

## Related issue or design

None. Follows the no-expand prefill default (#597), which is independent and
performance-neutral.

## Why

### Sinks

The fused-path gate required `head_sink == nullptr`. The sink folds into the v5
softmax denominator in the epilogue at a cost of one `exp2f` and one add per
row: `m_reg` already holds the row max scaled by `log2(e)`, so the natural-space
term `exp(sink - m)` becomes `exp2f(sink * kLog2e - m_reg)`.

Supporting sinks exposed a second problem. The v5 config cache was keyed on
`skv`, which advances by one chunk on every call of a chunked prefill, so a 16k
prefill ran 32 tuning sweeps of 526 launches each. That was invisible while
nothing on the gpt-oss path reached v5. `skv` only scales the length of the KV
loop, uniformly across candidates, so it cannot change which candidate wins --
confirmed rather than assumed, with `HIPDNN_PREFILL_TUNE_DEBUG=1` the ranking of
all four candidates is identical at all 32 `skv` values from 512 to 16384.
Keying on `(d, sq, Hq, G)` cut cold TTFT at 16k from 139,582 ms to 21,905 ms.

### Windows

The saving is not in the mask, it is in the loop bound:

- The per-row mask gains the lower bound `causal_mask_kernel_impl` already
  defines, `k < past_len + q - window + 1`.
- The KV loop starts at the first tile any row of the Q tile can reach instead
  of at tile 0. Every row in a Q tile has a lower bound at least as high as the
  first row's, so that start covers the tile and the per-row mask trims the
  remainder.

The second part is what makes a window cheaper rather than merely masked: the
number of tiles a block walks stops growing with `skv` once the window is
filled. In the standalone harness at gpt-oss geometry, `window=128` costs
0.157 ms at `past_len` 512 and 0.134 ms at `past_len` 8192 -- flat in KV depth --
against 6.27 ms for the same shape unwindowed.

**A NaN the window introduces.** Skipping tiles creates a case causal-only
attention never produces: a row can have every key in a tile masked while it has
still seen nothing, leaving both `m_old` and `m_new` at `-inf`, and
`exp2f(-inf - -inf)` is NaN, which propagates through the correction factor into
the accumulator. This was not hypothetical -- it reproduced immediately as NaN
output on the `window=128` cases. It does **not** reproduce at `window=1` or at
a window wider than the sequence, both of which passed while the bug was live,
which is why the harness covers the mid-range and chunked cases too.

### Templating

Because the window arrived as a runtime argument, its per-row state -- the
`kv_lo` lower bound, the all-masked-row `empty` guard and the selects they drive
-- stayed live in every instantiation, whether or not a window was configured.
In the instantiation the autotuner picks for gpt-oss, that state spills:

| `M_TILES=2 BKV=32 D=64` | before windows | with runtime window |
|---|---:|---:|
| scratch (bytes/lane) | 120 | **180** |
| VGPR spills | 38 | **68** |

`-Rpass-analysis=kernel-resource-usage`, gfx1151.

## What

- `gqa_kernel.hip`: sink folded into the v5 softmax denominator; window lower
  bound in the per-row mask; KV loop start-tile clamp; the all-masked-tile
  guard; `local_window_size` threaded through `dispatchPrefillV5`, the tuner and
  `prefillV5Run`; a new `hip_gqa_flash_prefill_v3` entry point with `v2` kept as
  a thin wrapper so existing callers and test harnesses keep their signature.
- `bool HAS_WINDOW` becomes a fourth template parameter and the three window
  sites go under `if constexpr`: the start-tile clamp, the per-row `kv_lo` mask
  in the innermost loop, and the all-masked-row short-circuit.
  `local_window_size` stays a runtime argument, since the windowed instantiation
  still needs its value; only the branches become compile-time.
  `dispatchPrefillV5` selects on `local_window_size > 0`. Only `D == 64` gets a
  windowed instantiation, because `hip_gqa_flash_prefill_v3` declines a window
  at any other head dim, so a `D=128` windowed variant would be dead code. That
  puts the instantiation count at 12 rather than 16.
- The autotune key drops `skv` and gains the window. Unlike `skv`, the window
  caps how many tiles a block walks, which is a genuinely different work profile
  and can change which candidate wins. No further autotuner change is needed for
  the templating: the cache key already carries `_w<window>`, so each
  instantiation tunes itself.
- `gqa.cpp`: `head_sink` and `smooth_softmax` threaded through
  `gqa_forward_fused` to both decode and prefill; the `head_sink == nullptr`
  term becomes a `sink_ok` gate admitting sinks on decode and on `d == 64`
  prefill; the prefill call site was passing a hardcoded `-1` for the window and
  now passes the real one; the blanket `local_window_size <= 0` rejection
  becomes a `window_ok` term admitting `d == 64` prefill.

## Performance

All measurements on gfx1151 (Radeon 8060S / Strix Halo), ROCm 7.1. Interleaving
is not optional on this box: absolute TTFT drifts about 10% over a session, so
prebuilt DLL sets per arm are swapped in and alternated. **Numbers below come
from two separate sessions and should not be subtracted across the divide**;
each session's arms were interleaved against each other.

Session A -- TTFT, gpt-oss-20b, seqlen 16384, three interleaved rounds, all arms
rebuilt from the same `main` (`f5ac3547`):

| Metric | base | +sinks | +windows |
|---|---:|---:|---:|
| TTFT | 29,483 ms | 21,049 ms | **10,113 ms** |
| run-to-run spread (sd, n=3) | 32 ms | 100 ms | 105 ms |
| vs base | -- | -28.6% | **-65.7%** |

Session B -- the templating change against the runtime-window arm, three
interleaved rounds. Every round of this PR is below every round of the runtime
window, against a ~52 ms spread:

| arm | mean TTFT | min | max | sd |
|---|---:|---:|---:|---:|
| runtime window | 9,956 ms | 9,917 | 10,016 | 53 |
| this PR (templated) | **9,462 ms** | 9,405 | 9,504 | 51 |

Every `HAS_WINDOW=false` instantiation is byte-identical in resource usage to
the pre-window kernel -- the goal of the templating was parity, not improvement:

| | pre-window | runtime window | this PR |
|---|---:|---:|---:|
| `M2 B32 D64` scratch B/lane | 120 | 180 | **120** |
| `M2 B32 D64` VGPR spills | 38 | 68 | **38** |
| `M1 B32 D64` VGPRs / occupancy | 188 / 8 | 196 / 7 | **188 / 8** |

Standalone prefill harness, interleaved arms, 4 rounds, only
`custom_kernels_gfx1151.dll` differing (ms):

| case | pre-window | runtime window | this PR |
|---|---:|---:|---:|
| `gpt_oss-sink sq512 past8192` (full attention, deep KV) | 5.16 | 6.29 | **5.16** |
| `gpt_oss-sink sq512 past512` | 0.57 | 0.60 | 0.56 |
| `llama-3.2-1b sq2048` | 1.45 | 1.57 | 1.42 |
| `llama-3.1-8b sq2048` (D=128, control) | 2.75 | 2.72 | 2.72 |
| `gpt_oss-win sq512 past8192 w128` (windowed) | n/a | 0.13 | 0.15 |

RGP capture, chunk 16, layer 1. The two layer types now dispatch different
instantiations, so they separate by name rather than by duration:

| dispatch | runtime window | this PR |
|---|---:|---:|
| full attention | 8,313 us (n=13, 8,033-8,613) | **5,970 us** (n=7, 5,865-6,105) |
| windowed | 229 us (n=13) | 233 us (n=6) |

## Known trade-off

One shape moves the other way under templating. On `gpt_oss-20b sq2048 past0` at
`M_TILES=2 BKV=32`, the spilled codegen of the runtime window is *faster* --
3.29 ms against 3.74 pre-window and 3.77 here (medians of 5 interleaved
autotuner sweeps). It reproduces, and it does not appear in the other three
no-window shapes, where the runtime window is 20-30% slower at that config.
Restoring the pre-window codegen restores its weakness on that shape along with
its strengths. Net TTFT still improves by 494 ms, but the ~13% there is
unexplained and worth a look on its own.

Related: the regression was partly masked by the autotuner. With the runtime
window the degraded `M_TILES=2 BKV=32` loses to `M_TILES=1 BKV=32` on three of
four no-window shapes, so end-to-end timings understated the per-config damage.

## Test plan

- [x] Standalone prefill harness against a CPU fp32 reference, **26 cases, all
  pass**. Ten are window cases, chosen so a window bug cannot hide:
  - window alone before window plus sink, so the two features fail separately;
  - `past_len` 8192 with `window` 128, where whole KV tiles must be skipped
    rather than merely masked;
  - `window=100` against BKV of 32 and 64, to catch an off-by-one in the
    start-tile clamp;
  - a window wider than the sequence, which must reproduce full attention, and
    `window=1`, which must reduce to each query seeing only itself;
  - a `d=128` case asserting `v3` declines the window rather than ignoring it.
  - Windowed cases land at relL2 3.3e-04 to 3.5e-04, in line with the no-window
    cases.
- [x] Three cases send a sink tensor **and** `smooth_softmax=1` together. That is
  the only combination the runtime actually produces -- `gqa.cpp` derives smooth
  from `(head_sink != nullptr || smooth_softmax == 1)` and then passes both --
  but every earlier case set exactly one of the two, so the real configuration
  was untested. `head_sink` takes precedence in both kernel and reference; a
  kernel that also added the smooth term would double-count the denominator and
  fail these.
- [x] Every `relL2` bit-identical before and after the templating change.
  Removing the `empty` guard from the no-window path is a behavioural change on
  paper, so the cases that caught the original NaN were checked specifically:
  `window=1`, `window > sequence`, and `past_len 8192`.
- [x] Numeric suite against the ORT CPU reference: pass/fail set **identical**
  to the sink branch (22 tests compared one by one).
- [x] Path check with `HIPDNN_EP_DEBUG=1`: 96 of 96 prefill GQA calls fused.
- [x] Resource usage compared instantiation by instantiation against the
  pre-window kernel (table above).
- [x] Interleaved harness A/B, interleaved TTFT, and RGP dispatch-level capture
  (tables above).
- [x] Rebased onto `main` at `fcfdf0cf` and rebuilt; harness re-run, 26/26 pass.
- [ ] CI.

Pre-existing, not caused by this change: the same four
`test_gqa_decode_fixed_cache_llama_shape` failures present at base.

## Notes for reviewers

- Please look hardest at the start-tile clamp and the all-masked-tile guard.
  The clamp is only correct because rows within a Q tile have monotonically
  non-decreasing lower bounds; if that ever stopped holding, the kernel would
  silently drop keys.
- Tuning launches deliberately omit the sink: one FMA per row cannot reorder the
  `(M_TILES, BKV)` candidates, and leaving it out keeps tuned configs comparable
  with the non-sink case.
- Windowed **decode** is deliberately untouched. Its kernel already clamps
  `kv_lo`, so enabling it is nearly a one-word change, but nothing here verifies
  it and prefill is where the window was costing us. The fused decode call site
  passes an explicit `0` rather than forwarding the parameter, because
  `window_ok` routes every windowed decode to the decomposed path and
  forwarding it would only look like the path were supported.
- This makes the planned fp32 -> fp16 score-matrix optimisation moot for
  gpt-oss: there is no longer a score matrix in its prefill. That work would now
  only help models still on the decomposed path.
- Substantial AI assistance (Cursor) was used for the kernel change, the test
  cases, the measurement harnesses and this description. I reviewed the change
  and the evidence, and every number above is a measurement I ran.
