### PR TITLE
fix(promote-strided): include hip.npi_* ops in strided-input promotion

### DIFF
--- a/lib/Dialect/Transforms/PromoteStridedHipOperands.cpp
+++ b/lib/Dialect/Transforms/PromoteStridedHipOperands.cpp
@@ -147,8 +147,17 @@ void PromoteStridedHipOperandsPass::runOnOperation() {
   // ops) does not invalidate the walk.
   SmallVector<DestinationStyleOpInterface> consumers;
   funcOp.walk([&](DestinationStyleOpInterface dpsOp) {
+    // Include all HIP-namespace DPS ops: the upstream HipDialect ops AND any
+    // NPI plugin ops (hip.npi_quantize, hip.npi_dequantize, etc.) that live in
+    // NpiDialect but use the hip.* namespace and the same contiguous-pointer ABI.
+    // Excluding NPI ops causes strided subview inputs (e.g. the K/V slices from
+    // onnx.Split → memref.subview) to be passed directly to hip.npi_quantize,
+    // whose kernel reads them as flat arrays, silently producing wrong values.
+    // Accept HipDialect ops AND NPI plugin ops (dialect namespace "npi" but
+    // op name "hip.npi_*"). Both use the hip.* namespace and the same ABI.
     Operation *op = dpsOp.getOperation();
-    if (op->getDialect() != op->getContext()->getLoadedDialect<HipDialect>())
+    llvm::StringRef fullOpName = op->getName().getStringRef();
+    if (!fullOpName.starts_with("hip."))
       return;
     consumers.push_back(dpsOp);
   });
@@ -162,7 +171,6 @@ void PromoteStridedHipOperandsPass::runOnOperation() {
         continue;
       tmps.push_back(materializeContiguousCopy(*input, consumer));
     }
-
     // Emit deallocs in the same order as the allocations (TA, TB, ...).
     // Without anchoring, repeated `setInsertionPointAfter(consumer)` would
     // push each new dealloc directly after the consumer, reversing the

--- a/lib/Dialect/Transforms/PromoteStridedHipOperands.cpp
+++ b/lib/Dialect/Transforms/PromoteStridedHipOperands.cpp
@@ -147,14 +147,12 @@ void PromoteStridedHipOperandsPass::runOnOperation() {
   // ops) does not invalidate the walk.
   SmallVector<DestinationStyleOpInterface> consumers;
   funcOp.walk([&](DestinationStyleOpInterface dpsOp) {
-    // Include all HIP-namespace DPS ops: the upstream HipDialect ops AND any
-    // NPI plugin ops (hip.npi_quantize, hip.npi_dequantize, etc.) that live in
-    // NpiDialect but use the hip.* namespace and the same contiguous-pointer ABI.
-    // Excluding NPI ops causes strided subview inputs (e.g. the K/V slices from
-    // onnx.Split → memref.subview) to be passed directly to hip.npi_quantize,
-    // whose kernel reads them as flat arrays, silently producing wrong values.
-    // Accept HipDialect ops AND NPI plugin ops (dialect namespace "npi" but
-    // op name "hip.npi_*"). Both use the hip.* namespace and the same ABI.
+    // Match on op-name prefix rather than dialect object: NPI plugin ops
+    // (hip.npi_quantize, hip.npi_dequantize, etc.) live in NpiDialect but
+    // carry "hip.*" names and the same contiguous-pointer ABI. The old
+    // dialect-object check excluded them, causing strided subview inputs
+    // (e.g. Q/K/V slices from onnx.Split) to be passed uncopied to NPI
+    // kernels that read them as flat arrays, producing wrong values.
     Operation *op = dpsOp.getOperation();
     llvm::StringRef fullOpName = op->getName().getStringRef();
     if (!fullOpName.starts_with("hip."))
@@ -171,6 +169,7 @@ void PromoteStridedHipOperandsPass::runOnOperation() {
         continue;
       tmps.push_back(materializeContiguousCopy(*input, consumer));
     }
+
     // Emit deallocs in the same order as the allocations (TA, TB, ...).
     // Without anchoring, repeated `setInsertionPointAfter(consumer)` would
     // push each new dealloc directly after the consumer, reversing the


### PR DESCRIPTION
## Problem
`PromoteStridedHipOperands` filtered ops using `op->getDialect() == HipDialect`.
NPI plugin ops (`hip.npi_quantize`, `hip.npi_dequantize`, etc.) are registered
in `NpiDialect` — a separate dialect object — even though their op names start
with `hip.` and they use the same contiguous-pointer kernel ABI. The dialect
check therefore excluded them, so strided `memref.subview` inputs (e.g. Q/K/V
slices produced by `onnx.Split`) were passed directly to NPI kernels that read
them as flat contiguous arrays, producing silently wrong values. On Qwen 7B VLM
(gfx1151) this caused cosine similarity to drop from ~1.0 to ~0.36.

## Fix
Replace the dialect-object check with an op-name prefix check
(`fullOpName.starts_with("hip.")`), which covers both `HipDialect` ops and
`hip.npi_*` ops regardless of which dialect object owns them.

## Testing
Verified on gfx1151 (Strix Halo, Windows D3D12 HMM): cosine similarity for
Qwen 7B VLM restored to ~1.0 after this fix.