### PR TITLE
fix(matmul-lowering): use extractMemRefDataPtr for offset-correct pointers

### DIFF
--- a/lib/Conversion/HipToLLVM/MatmulLowering.cpp
+++ b/lib/Conversion/HipToLLVM/MatmulLowering.cpp
@@ -32,16 +32,23 @@ struct MatmulOpLowering : public ConvertOpToLLVMPattern<MatmulOp> {
                                       rewriter.getI64IntegerAttr(value));
     };
 
-    // Extract pointers
+    // Extract pointers — use extractMemRefDataPtr (alignedPtr + offset) so that
+    // subview operands (e.g. Q/V slices from onnx.Split → memref.subview) are
+    // correctly offset-adjusted. extractContiguousMemRefPtr ignores the descriptor
+    // offset and silently reads the parent buffer's base, which gives the wrong
+    // slice when offset != 0 (Bug 4 in gnpu-onnx-flow).
     Value statePtr = adaptor.getCtx();
-    Value APtr = extractContiguousMemRefPtr(adaptor.getA(), rewriter, loc);
-    Value BPtr = extractContiguousMemRefPtr(adaptor.getB(), rewriter, loc);
-    Value outputPtr =
-        extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
-
-    // Get memref types and shapes
     auto AType = cast<MemRefType>(op.getA().getType());
     auto BType = cast<MemRefType>(op.getB().getType());
+    auto OutType = cast<MemRefType>(op.getOutput().getType());
+    Value APtr = extractMemRefDataPtr(adaptor.getA(), AType,
+                                      getTypeConverter(), rewriter, loc);
+    Value BPtr = extractMemRefDataPtr(adaptor.getB(), BType,
+                                      getTypeConverter(), rewriter, loc);
+    Value outputPtr = extractMemRefDataPtr(adaptor.getOutput(), OutType,
+                                           getTypeConverter(), rewriter, loc);
+
+    // Get memref types and shapes (AType/BType/OutType declared above)
     int64_t ARank = AType.getRank();
     int64_t BRank = BType.getRank();
 

--- a/lib/Conversion/HipToLLVM/MatmulLowering.cpp
+++ b/lib/Conversion/HipToLLVM/MatmulLowering.cpp
@@ -40,10 +40,10 @@ struct MatmulOpLowering : public ConvertOpToLLVMPattern<MatmulOp> {
     auto AType = cast<MemRefType>(op.getA().getType());
     auto BType = cast<MemRefType>(op.getB().getType());
     auto OutType = cast<MemRefType>(op.getOutput().getType());
-    Value APtr = extractMemRefDataPtr(adaptor.getA(), AType,
-                                      getTypeConverter(), rewriter, loc);
-    Value BPtr = extractMemRefDataPtr(adaptor.getB(), BType,
-                                      getTypeConverter(), rewriter, loc);
+    Value APtr = extractMemRefDataPtr(adaptor.getA(), AType, getTypeConverter(),
+                                      rewriter, loc);
+    Value BPtr = extractMemRefDataPtr(adaptor.getB(), BType, getTypeConverter(),
+                                      rewriter, loc);
     Value outputPtr = extractMemRefDataPtr(adaptor.getOutput(), OutType,
                                            getTypeConverter(), rewriter, loc);
 

--- a/lib/Conversion/HipToLLVM/MatmulLowering.cpp
+++ b/lib/Conversion/HipToLLVM/MatmulLowering.cpp
@@ -32,11 +32,10 @@ struct MatmulOpLowering : public ConvertOpToLLVMPattern<MatmulOp> {
                                       rewriter.getI64IntegerAttr(value));
     };
 
-    // Extract pointers — use extractMemRefDataPtr (alignedPtr + offset) so that
-    // subview operands (e.g. Q/V slices from onnx.Split → memref.subview) are
-    // correctly offset-adjusted. extractContiguousMemRefPtr ignores the descriptor
-    // offset and silently reads the parent buffer's base, which gives the wrong
-    // slice when offset != 0 (Bug 4 in gnpu-onnx-flow).
+    // Use extractMemRefDataPtr (alignedPtr + GEP(offset)) so that subview
+    // operands with non-zero descriptor offsets are correctly adjusted.
+    // extractContiguousMemRefPtr returns alignedPtr only and silently reads
+    // the parent buffer base when offset != 0.
     Value statePtr = adaptor.getCtx();
     auto AType = cast<MemRefType>(op.getA().getType());
     auto BType = cast<MemRefType>(op.getB().getType());
@@ -48,7 +47,7 @@ struct MatmulOpLowering : public ConvertOpToLLVMPattern<MatmulOp> {
     Value outputPtr = extractMemRefDataPtr(adaptor.getOutput(), OutType,
                                            getTypeConverter(), rewriter, loc);
 
-    // Get memref types and shapes (AType/BType/OutType declared above)
+    // Get memref types and shapes
     int64_t ARank = AType.getRank();
     int64_t BRank = BType.getRank();
 


### PR DESCRIPTION
## Problem
`MatmulOpLowering` used `extractContiguousMemRefPtr` which returns only
`alignedPtr` from the memref descriptor, ignoring the `offset` field.

When `onnx.Split` produces Q/K/V slices via `memref.subview`, each slice
carries a non-zero offset into the parent buffer. `extractContiguousMemRefPtr`
returned the parent buffer's base address for all three, so Q and V MatMuls
silently read K's data instead of their own — reducing end-to-end model
accuracy to ~0.36 cosine on Qwen 7B VLM (gfx1151).

## Fix
Switch A, B, and output to `extractMemRefDataPtr`, which computes
`alignedPtr + GEP(offset)` — the GEP advances by `offset` elements,
correctly accounting for element size:

    // Before:
    Value APtr = extractContiguousMemRefPtr(adaptor.getA(), rewriter, loc);
    // After:
    auto AType = cast<MemRefType>(op.getA().getType());
    Value APtr = extractMemRefDataPtr(adaptor.getA(), AType,
                                      getTypeConverter(), rewriter, loc);

## Testing
Verified on gfx1151 (Strix Halo, Windows D3D12 HMM): cosine similarity
for Qwen 7B VLM restored to ~1.0 after this fix.
