### PR TITLE
refactor(hipsr): enforce strict ONNX conversion legality

### DIFF
--- a/include/hip/Conversion/Passes.td
+++ b/include/hip/Conversion/Passes.td
@@ -21,9 +21,10 @@ def ConvertOnnxToHipsrPass : Pass<"convert-onnx-to-hipsr", "mlir::ModuleOp"> {
     Operation API, so no onnx-mlir headers are required.
 
     Every ONNX operation must be converted. Outside `hipsr.compute`, only
-    module and function structure and hipsr operations are legal. Helper
-    operations from other dialects are legal at any depth inside
-    `hipsr.compute`, but nested ONNX operations must still be converted.
+    module and function structure, hipsr operations, and scalar
+    `arith.constant` operations are legal. Other helper operations are legal at
+    any depth inside `hipsr.compute`, but nested ONNX operations must still be
+    converted.
 
     Each operation pattern creates its data operation and tied placeholder.
     After conversion, downstream placeholder inputs are rewired from data

--- a/include/hip/Conversion/Passes.td
+++ b/include/hip/Conversion/Passes.td
@@ -20,12 +20,16 @@ def ConvertOnnxToHipsrPass : Pass<"convert-onnx-to-hipsr", "mlir::ModuleOp"> {
     style with tensor types. ONNX ops are matched by name via the generic MLIR
     Operation API, so no onnx-mlir headers are required.
 
-    Converted DPS operations form a data graph. Their tied placeholders form a
-    parallel shape-dependency graph in which downstream placeholders use
-    upstream placeholder results. Block arguments, `arith.constant`, and
-    `hipsr.constant` results are graph roots.
+    Every ONNX operation must be converted. Outside `hipsr.compute`, only
+    module and function structure and hipsr operations are legal. Helper
+    operations from other dialects are legal at any depth inside
+    `hipsr.compute`, but nested ONNX operations must still be converted.
 
-    Shape regions remain empty for the later population pass.
+    Each operation pattern creates its data operation and tied placeholder.
+    After conversion, downstream placeholder inputs are rewired from data
+    results to the corresponding upstream placeholder results, forming a
+    parallel shape-dependency graph. Placeholder shape regions remain empty for
+    the later population pass.
   }];
   let dependentDialects = [
     "::mlir::hipsr::HipsrDialect",

--- a/lib/Conversion/OnnxToHipsr/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHipsr/CMakeLists.txt
@@ -20,6 +20,7 @@ target_link_libraries(OnnxToHipsr PUBLIC
   HipsrDialectIR
   MLIRPass
   MLIRTransforms
+  MLIRFuncDialect
   MLIRTensorDialect
   MLIRShapeDialect
   MLIRArithDialect

--- a/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
+++ b/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
@@ -5,9 +5,9 @@
 //===- OnnxToHipsr.cpp - Convert ONNX dialect to the hipsr dialect --------===//
 //
 // Converts ONNX dialect IR into hipsr dialect IR (tensor DPS). The conversion
-// target keeps helper operations inside hipsr.compute, so the enclosing graph
-// contains only hipsr computation operations. After conversion, placeholder
-// dependencies are rewired into a parallel shape graph.
+// target keeps helper computations inside hipsr.compute while allowing scalar
+// constants as graph roots. After conversion, placeholder dependencies are
+// rewired into a parallel shape graph.
 //
 //===----------------------------------------------------------------------===//
 
@@ -96,6 +96,7 @@ struct ConvertOnnxToHipsrPass
     target.addIllegalDialect("onnx");
     target.addLegalDialect<HipsrDialect>();
     target.addLegalOp<ModuleOp, func::FuncOp, func::ReturnOp>();
+    target.addLegalOp<arith::ConstantOp>();
     target.markUnknownOpDynamicallyLegal([](Operation *op) {
       return op->getParentOfType<ComputeOp>() != nullptr;
     });

--- a/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
+++ b/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
@@ -91,6 +91,7 @@ static LogicalResult finalizePlaceholderDependencies(ModuleOp module) {
 struct ConvertOnnxToHipsrPass
     : impl::ConvertOnnxToHipsrPassBase<ConvertOnnxToHipsrPass> {
   void runOnOperation() override {
+    ModuleOp module = getOperation();
     ConversionTarget target(getContext());
     target.addIllegalDialect("onnx");
     target.addLegalDialect<HipsrDialect>();
@@ -100,13 +101,12 @@ struct ConvertOnnxToHipsrPass
     });
 
     RewritePatternSet patterns(&getContext());
-    if (failed(
-            applyFullConversion(getOperation(), target, std::move(patterns)))) {
+    if (failed(applyFullConversion(module, target, std::move(patterns)))) {
       signalPassFailure();
       return;
     }
     // Build the parallel shape graph after all data-graph rewrites finish.
-    if (failed(finalizePlaceholderDependencies(getOperation()))) {
+    if (failed(finalizePlaceholderDependencies(module))) {
       signalPassFailure();
     }
   }

--- a/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
+++ b/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
@@ -4,10 +4,10 @@
  */
 //===- OnnxToHipsr.cpp - Convert ONNX dialect to the hipsr dialect --------===//
 //
-// Converts ONNX dialect IR into hipsr dialect IR (tensor DPS). ONNX ops are
-// matched by name via the generic MLIR Operation API, so no onnx-mlir headers
-// are required. After rewriting, placeholder dependencies are separated from
-// data dependencies. A later pass fills shape regions via ShapeRegionInterface.
+// Converts ONNX dialect IR into hipsr dialect IR (tensor DPS). The conversion
+// target keeps helper operations inside hipsr.compute, so the enclosing graph
+// contains only hipsr computation operations. After conversion, placeholder
+// dependencies are rewired into a parallel shape graph.
 //
 //===----------------------------------------------------------------------===//
 
@@ -15,10 +15,12 @@
 #include "hip/Dialect/Hipsr/IR/HipsrOps.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Shape/IR/Shape.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/Interfaces/DestinationStyleOpInterface.h"
-#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/DialectConversion.h"
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
@@ -32,13 +34,12 @@ namespace hipsr {
 
 namespace {
 
-// Replace placeholder data dependencies with tied placeholder results.
-static ::mlir::LogicalResult
-finalizePlaceholderDependencies(::mlir::ModuleOp module) {
-  ::llvm::DenseMap<::mlir::Value, ::mlir::Value> placeholderForDataResult;
-  module.walk([&](::mlir::DestinationStyleOpInterface dpsOp) {
-    for (::mlir::OpResult result : dpsOp->getResults()) {
-      ::mlir::OpOperand *initOperand = dpsOp.getTiedOpOperand(result);
+// Shape dependencies flow through placeholders instead of computed data.
+static LogicalResult finalizePlaceholderDependencies(ModuleOp module) {
+  llvm::DenseMap<Value, Value> placeholderForDataResult;
+  module.walk([&](DestinationStyleOpInterface dpsOp) {
+    for (OpResult result : dpsOp->getResults()) {
+      OpOperand *initOperand = dpsOp.getTiedOpOperand(result);
       if (!initOperand) {
         continue;
       }
@@ -51,19 +52,16 @@ finalizePlaceholderDependencies(::mlir::ModuleOp module) {
     }
   });
 
-  ::llvm::SmallVector<std::pair<::mlir::OpOperand *, ::mlir::Value>>
-      replacements;
-  ::mlir::WalkResult walkResult =
-      module.walk([&](PlaceholderOp placeholder) -> ::mlir::WalkResult {
-        ::mlir::MutableOperandRange mutableInputs =
-            placeholder.getInputsMutable();
+  llvm::SmallVector<std::pair<OpOperand *, Value>> replacements;
+  WalkResult walkResult =
+      module.walk([&](PlaceholderOp placeholder) -> WalkResult {
+        MutableOperandRange mutableInputs = placeholder.getInputsMutable();
         for (auto [inputIndex, input] :
-             ::llvm::enumerate(placeholder.getInputs())) {
+             llvm::enumerate(placeholder.getInputs())) {
           auto replacement = placeholderForDataResult.find(input);
-          ::mlir::Value resolvedInput =
-              replacement == placeholderForDataResult.end()
-                  ? input
-                  : replacement->second;
+          Value resolvedInput = replacement == placeholderForDataResult.end()
+                                    ? input
+                                    : replacement->second;
           if (!PlaceholderOp::isAllowedShapeGraphInput(resolvedInput)) {
             placeholder.emitOpError("input ")
                 << inputIndex
@@ -71,46 +69,44 @@ finalizePlaceholderDependencies(::mlir::ModuleOp module) {
                    "hipsr.placeholder, arith.constant, or hipsr.constant; got "
                    "result of '"
                 << resolvedInput.getDefiningOp()->getName() << "'";
-            return ::mlir::WalkResult::interrupt();
+            return WalkResult::interrupt();
           }
           if (resolvedInput != input) {
             replacements.emplace_back(&mutableInputs[inputIndex],
                                       resolvedInput);
           }
         }
-        return ::mlir::WalkResult::advance();
+        return WalkResult::advance();
       });
   if (walkResult.wasInterrupted()) {
-    return ::mlir::failure();
+    return failure();
   }
 
   for (auto [operand, value] : replacements) {
     operand->set(value);
   }
-  return ::mlir::success();
+  return success();
 }
 
 struct ConvertOnnxToHipsrPass
     : impl::ConvertOnnxToHipsrPassBase<ConvertOnnxToHipsrPass> {
   void runOnOperation() override {
-    ::mlir::RewritePatternSet patterns(&getContext());
-    populateOnnxToHipsrConstantPatterns(patterns);
-    populateCastConversionPatterns(patterns, &getContext());
-    populateMatMulConversionPatterns(patterns, &getContext());
-    populateExpandConversionPatterns(patterns, &getContext());
+    ConversionTarget target(getContext());
+    target.addIllegalDialect("onnx");
+    target.addLegalDialect<HipsrDialect>();
+    target.addLegalOp<ModuleOp, func::FuncOp, func::ReturnOp>();
+    target.markUnknownOpDynamicallyLegal([](Operation *op) {
+      return op->getParentOfType<ComputeOp>() != nullptr;
+    });
 
-    // Same driver/config as convert-onnx-to-hip (greedy, ExistingOps): ONNX ops
-    // are matched by name and only the ops present on entry are rewritten, so
-    // generated hipsr / shape-region IR is left untouched.
-    ::mlir::GreedyRewriteConfig config;
-    config.setStrictness(::mlir::GreedyRewriteStrictness::ExistingOps);
-    if (::mlir::failed(::mlir::applyPatternsGreedily(
-            getOperation(), std::move(patterns), config))) {
+    RewritePatternSet patterns(&getContext());
+    if (failed(
+            applyFullConversion(getOperation(), target, std::move(patterns)))) {
       signalPassFailure();
       return;
     }
     // Build the parallel shape graph after all data-graph rewrites finish.
-    if (::mlir::failed(finalizePlaceholderDependencies(getOperation()))) {
+    if (failed(finalizePlaceholderDependencies(getOperation()))) {
       signalPassFailure();
     }
   }

--- a/test/lit/Conversion/onnx-to-hipsr/conversion-target-invalid.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/conversion-target-invalid.mlir
@@ -23,6 +23,15 @@ func.func @foreign_top_level() -> tensor<2xf32> {
 
 // -----
 
+// Only arith.constant is legal from the arith dialect at top level.
+func.func @foreign_arith_top_level(%lhs: f32, %rhs: f32) -> f32 {
+  // expected-error @+1 {{failed to legalize operation 'arith.addf'}}
+  %result = arith.addf %lhs, %rhs : f32
+  return %result : f32
+}
+
+// -----
+
 // ONNX operations remain illegal at any nesting depth inside hipsr.compute.
 func.func @nested_onnx(
     %ctx: !hipsr.context, %input: tensor<2x3xf16>,

--- a/test/lit/Conversion/onnx-to-hipsr/conversion-target-invalid.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/conversion-target-invalid.mlir
@@ -1,0 +1,43 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --convert-onnx-to-hipsr --split-input-file --verify-diagnostics %s
+
+// Every top-level ONNX operation requires a conversion pattern.
+func.func @unconverted_onnx(
+    %input: tensor<2x3xf16>) -> tensor<2x3xf16> {
+  // expected-error @+1 {{failed to legalize operation 'onnx.Unsupported'}}
+  %result = "onnx.Unsupported"(%input)
+      : (tensor<2x3xf16>) -> tensor<2x3xf16>
+  return %result : tensor<2x3xf16>
+}
+
+// -----
+
+// Helper operations from other dialects must be nested in hipsr.compute.
+func.func @foreign_top_level() -> tensor<2xf32> {
+  // expected-error @+1 {{failed to legalize operation 'tensor.empty'}}
+  %result = tensor.empty() : tensor<2xf32>
+  return %result : tensor<2xf32>
+}
+
+// -----
+
+// ONNX operations remain illegal at any nesting depth inside hipsr.compute.
+func.func @nested_onnx(
+    %ctx: !hipsr.context, %input: tensor<2x3xf16>,
+    %init: tensor<6xf16>) -> tensor<6xf16> {
+  %result = hipsr.compute(%ctx) ins(%input : tensor<2x3xf16>)
+                                  outs(%init : tensor<6xf16>) {
+  ^bb0(%body_ctx: !hipsr.context, %body_input: tensor<2x3xf16>,
+       %body_init: tensor<6xf16>):
+    %nested = scf.execute_region -> tensor<6xf16> {
+      // expected-error @+1 {{failed to legalize operation 'onnx.Unsupported'}}
+      %onnx = "onnx.Unsupported"(%body_input)
+          : (tensor<2x3xf16>) -> tensor<6xf16>
+      scf.yield %onnx : tensor<6xf16>
+    }
+    hipsr.compute_yield %nested : tensor<6xf16>
+  } : tensor<6xf16>
+  return %result : tensor<6xf16>
+}

--- a/test/lit/Conversion/onnx-to-hipsr/conversion-target.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/conversion-target.mlir
@@ -3,10 +3,12 @@
 
 // RUN: hip-mlir-opt --convert-onnx-to-hipsr %s | FileCheck %s
 
-// Helper operations remain legal at any nesting depth inside hipsr.compute.
+// Scalar constants are legal at top level, and other helper operations remain
+// legal at any nesting depth inside hipsr.compute.
 // CHECK-LABEL: func.func @recursive_legality(
 // CHECK-SAME: %[[CTX:.+]]: !hipsr.context, %[[INPUT:.+]]: tensor<2x3xf16>,
 // CHECK-SAME: %[[INIT:.+]]: tensor<6xf16>) -> tensor<6xf16> {
+// CHECK-NEXT: arith.constant 1.000000e+00 : f32
 // CHECK-NEXT: %[[RESULT:.+]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<2x3xf16>) outs(%[[INIT]] : tensor<6xf16>) {
 // CHECK-NEXT: ^bb0(%{{.+}}: !hipsr.context, %[[BODY_INPUT:.+]]: tensor<2x3xf16>, %{{.+}}: tensor<6xf16>):
 // CHECK-NEXT: %[[NESTED:.+]] = scf.execute_region -> tensor<6xf16> {
@@ -20,6 +22,7 @@
 func.func @recursive_legality(
     %ctx: !hipsr.context, %input: tensor<2x3xf16>,
     %init: tensor<6xf16>) -> tensor<6xf16> {
+  %scalar = arith.constant 1.0 : f32
   %result = hipsr.compute(%ctx) ins(%input : tensor<2x3xf16>)
                                   outs(%init : tensor<6xf16>) {
   ^bb0(%body_ctx: !hipsr.context, %body_input: tensor<2x3xf16>,

--- a/test/lit/Conversion/onnx-to-hipsr/conversion-target.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/conversion-target.mlir
@@ -1,0 +1,35 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --convert-onnx-to-hipsr %s | FileCheck %s
+
+// Helper operations remain legal at any nesting depth inside hipsr.compute.
+// CHECK-LABEL: func.func @recursive_legality(
+// CHECK-SAME: %[[CTX:.+]]: !hipsr.context, %[[INPUT:.+]]: tensor<2x3xf16>,
+// CHECK-SAME: %[[INIT:.+]]: tensor<6xf16>) -> tensor<6xf16> {
+// CHECK-NEXT: %[[RESULT:.+]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<2x3xf16>) outs(%[[INIT]] : tensor<6xf16>) {
+// CHECK-NEXT: ^bb0(%{{.+}}: !hipsr.context, %[[BODY_INPUT:.+]]: tensor<2x3xf16>, %{{.+}}: tensor<6xf16>):
+// CHECK-NEXT: %[[NESTED:.+]] = scf.execute_region -> tensor<6xf16> {
+// CHECK-NEXT: %[[FLAT:.+]] = tensor.collapse_shape %[[BODY_INPUT]] {{\[\[}}0, 1]] : tensor<2x3xf16> into tensor<6xf16>
+// CHECK-NEXT: scf.yield %[[FLAT]] : tensor<6xf16>
+// CHECK-NEXT: }
+// CHECK-NEXT: hipsr.compute_yield %[[NESTED]] : tensor<6xf16>
+// CHECK-NEXT: } : tensor<6xf16>
+// CHECK-NEXT: return %[[RESULT]] : tensor<6xf16>
+// CHECK-NEXT: }
+func.func @recursive_legality(
+    %ctx: !hipsr.context, %input: tensor<2x3xf16>,
+    %init: tensor<6xf16>) -> tensor<6xf16> {
+  %result = hipsr.compute(%ctx) ins(%input : tensor<2x3xf16>)
+                                  outs(%init : tensor<6xf16>) {
+  ^bb0(%body_ctx: !hipsr.context, %body_input: tensor<2x3xf16>,
+       %body_init: tensor<6xf16>):
+    %nested = scf.execute_region -> tensor<6xf16> {
+      %flat = tensor.collapse_shape %body_input [[0, 1]]
+          : tensor<2x3xf16> into tensor<6xf16>
+      scf.yield %flat : tensor<6xf16>
+    }
+    hipsr.compute_yield %nested : tensor<6xf16>
+  } : tensor<6xf16>
+  return %result : tensor<6xf16>
+}


### PR DESCRIPTION
## Summary
- Replace greedy rewriting with a strict MLIR conversion target for ONNX-to-HipSR.
- Require all ONNX operations to convert, allow scalar `arith.constant` operations at top level, and allow other helper operations inside `hipsr.compute`.
- Preserve placeholder shape-graph finalization and add focused legality tests.

## AI assistance
Cursor assisted with implementation and validation.
