### PR TITLE
feat(hipsr): add parallel placeholder shape yield

### DIFF
--- a/include/hip/Dialect/Hipsr/IR/HipsrOps.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrOps.h
@@ -10,6 +10,7 @@
 #include "hip/Dialect/Hipsr/IR/HipsrShapeRegionInterface.h"
 
 #include "mlir/Bytecode/BytecodeOpInterface.h"
+#include "mlir/Dialect/Shape/IR/Shape.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"

--- a/include/hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.td
@@ -12,7 +12,7 @@
 
 def Hipsr_PlaceholderOp : Hipsr_Op<
     "placeholder",
-    [IsolatedFromAbove, SingleBlockImplicitTerminator<"ShapeYieldOp">]> {
+    [IsolatedFromAbove, SingleBlockImplicitTerminator<"ShapeYield2Op">]> {
   let summary = "Typed placeholder for hipsr DPS init operands";
   let description = [{
     Provides `outs` init values before a hipsr DPS op computes its output
@@ -28,7 +28,7 @@ def Hipsr_PlaceholderOp : Hipsr_Op<
     use upstream placeholder results rather than DPS data results.
 
     The optional `shape_region` defines the placeholder result shapes. It has
-    one block when present and ends with `hipsr.shape_yield`.
+    one block when present and ends with `hipsr.shape_yield2`.
 
     One placeholder can have several results for one multi-output DPS op. Each
     result initializes exactly one DPS result and may also feed other

--- a/include/hip/Dialect/Hipsr/IR/HipsrShapeYieldOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrShapeYieldOp.td
@@ -6,6 +6,8 @@
 // ops and the shared Hipsr_Op base class live in HipsrOps.td.
 //
 
+include "mlir/Dialect/Shape/IR/ShapeBase.td"
+
 //===----------------------------------------------------------------------===//
 // Hipsr_ShapeYieldOp
 //===----------------------------------------------------------------------===//
@@ -57,6 +59,38 @@ def Hipsr_ShapeYieldOp : Hipsr_Op<"shape_yield", [Pure, Terminator]> {
                    CArg<"::mlir::TypeRange", "{}">:$elementTypes), [{
       build($_builder, $_state, shapes,
             $_builder.getTypeArrayAttr(elementTypes));
+    }]>
+  ];
+}
+
+//===----------------------------------------------------------------------===//
+// Hipsr_ShapeYield2Op
+//===----------------------------------------------------------------------===//
+
+def Hipsr_ShapeYield2Op : Hipsr_Op<
+    "shape_yield2", [Pure, Terminator, HasParent<"PlaceholderOp">]> {
+  let summary = "Yield result shapes from a placeholder shape region";
+  let description = [{
+    Ends a `hipsr.placeholder` shape region and yields one `!shape.shape`
+    value for each placeholder result. Element types and ranked tensor types
+    remain on the placeholder results.
+
+    A scalar result still has one shape operand whose extent list is empty.
+    For example:
+    ```mlir
+    hipsr.shape_yield2 %shape : !shape.shape
+    hipsr.shape_yield2 %values_shape, %indices_shape
+        : !shape.shape, !shape.shape
+    ```
+  }];
+
+  let arguments = (ins Variadic<Shape_ShapeType>:$shapes);
+  let assemblyFormat = "$shapes attr-dict `:` type($shapes)";
+  let hasVerifier = 1;
+
+  let builders = [
+    OpBuilder<(ins), [{
+      $_state.addOperands(::mlir::ValueRange{});
     }]>
   ];
 }

--- a/lib/Dialect/Hipsr/IR/HipsrShapeYieldOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrShapeYieldOp.cpp
@@ -16,8 +16,20 @@ LogicalResult ShapeYieldOp::verify() {
   // here: there must be one element type per result.
   size_t numResults = getRanks().size();
   size_t numTypes = getElementTypes().size();
-  if (numTypes != numResults)
+  if (numTypes != numResults) {
     return emitOpError() << "has " << numResults << " result(s) but "
                          << numTypes << " element type(s)";
+  }
+  return success();
+}
+
+LogicalResult ShapeYield2Op::verify() {
+  auto placeholder = cast<PlaceholderOp>(getOperation()->getParentOp());
+  if (getShapes().size() != placeholder.getNumResults()) {
+    return emitOpError(
+               "must yield one !shape.shape per enclosing placeholder result; "
+               "expected ")
+           << placeholder.getNumResults() << ", got " << getShapes().size();
+  }
   return success();
 }

--- a/test/lit/Dialect/Hipsr/shape_yield2.mlir
+++ b/test/lit/Dialect/Hipsr/shape_yield2.mlir
@@ -1,0 +1,86 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --split-input-file --verify-diagnostics %s | FileCheck %s
+
+// Multi-result placeholders yield one shape per result. A scalar still has one
+// shape value, produced from an empty extent list.
+// CHECK-LABEL: func.func @multiple_results_and_scalar(
+// CHECK: %[[INITS:.+]]:2 = hipsr.placeholder
+// CHECK-SAME: shape_region {
+// CHECK-NEXT: ^bb0(%{{.+}}: !hipsr.context):
+// CHECK-NEXT: %[[C2:.+]] = arith.constant 2 : index
+// CHECK-NEXT: %[[C3:.+]] = arith.constant 3 : index
+// CHECK-NEXT: %[[VALUES_SHAPE:.+]] = shape.from_extents %[[C2]], %[[C3]]
+// CHECK-NEXT: %[[SCALAR_SHAPE:.+]] = shape.from_extents
+// CHECK-NEXT: hipsr.shape_yield2 %[[VALUES_SHAPE]], %[[SCALAR_SHAPE]]
+// CHECK-SAME: : !shape.shape, !shape.shape
+// CHECK-NEXT: }
+func.func @multiple_results_and_scalar(%ctx: !hipsr.context)
+    -> (tensor<2x3xf16>, tensor<f16>) {
+  %inits:2 = hipsr.placeholder(%ctx)
+      {type = #hipsr.placeholder_type<barrier>}
+      : tensor<2x3xf16>, tensor<f16> shape_region {
+  ^bb0(%shape_ctx: !hipsr.context):
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %values_shape = "shape.from_extents"(%c2, %c3)
+        : (index, index) -> !shape.shape
+    %scalar_shape = "shape.from_extents"() : () -> !shape.shape
+    hipsr.shape_yield2 %values_shape, %scalar_shape
+        : !shape.shape, !shape.shape
+  }
+  %results:2 = hipsr.compute(%ctx) ins()
+      outs(%inits#0, %inits#1 : tensor<2x3xf16>, tensor<f16>) {
+  ^bb0(%body_ctx: !hipsr.context, %values_dest: tensor<2x3xf16>,
+       %scalar_dest: tensor<f16>):
+    hipsr.compute_yield %values_dest, %scalar_dest
+        : tensor<2x3xf16>, tensor<f16>
+  } : tensor<2x3xf16>, tensor<f16>
+  return %results#0, %results#1 : tensor<2x3xf16>, tensor<f16>
+}
+
+// -----
+
+// Shape-yield operands must use the Shape dialect's value shape type.
+func.func @non_shape_operand(%ctx: !hipsr.context) -> tensor<f16> {
+  %init = hipsr.placeholder(%ctx)
+      {type = #hipsr.placeholder_type<barrier>} : tensor<f16>
+      shape_region {
+  ^bb0(%shape_ctx: !hipsr.context):
+    %extent = arith.constant 1 : index
+    // expected-error @+1 {{operand #0 must be variadic of , but got 'index'}}
+    hipsr.shape_yield2 %extent : index
+  }
+  %result = hipsr.compute(%ctx) ins() outs(%init : tensor<f16>) {
+  ^bb0(%body_ctx: !hipsr.context, %dest: tensor<f16>):
+    hipsr.compute_yield %dest : tensor<f16>
+  } : tensor<f16>
+  return %result : tensor<f16>
+}
+
+// -----
+
+// An empty block gets an implicit zero-operand yield, which cannot describe
+// the placeholder's result.
+func.func @implicit_empty_yield(%ctx: !hipsr.context) -> tensor<f16> {
+  // expected-error @+1 {{must yield one !shape.shape per enclosing placeholder result; expected 1, got 0}}
+  %init = hipsr.placeholder(%ctx)
+      {type = #hipsr.placeholder_type<barrier>} : tensor<f16> shape_region {
+  ^bb0(%shape_ctx: !hipsr.context):
+  }
+  %result = hipsr.compute(%ctx) ins() outs(%init : tensor<f16>) {
+  ^bb0(%body_ctx: !hipsr.context, %dest: tensor<f16>):
+    hipsr.compute_yield %dest : tensor<f16>
+  } : tensor<f16>
+  return %result : tensor<f16>
+}
+
+// -----
+
+// ShapeYield2 terminates placeholder shape regions only.
+func.func @wrong_parent() {
+  %shape = "shape.from_extents"() : () -> !shape.shape
+  // expected-error @+1 {{expects parent op 'hipsr.placeholder'}}
+  hipsr.shape_yield2 %shape : !shape.shape
+}


### PR DESCRIPTION
## Summary
- Add temporary `hipsr.shape_yield2`, yielding one `!shape.shape` per placeholder result.
- Use it for placeholder shape regions while keeping `hipsr.shape_yield` unchanged for DPS shape regions.
- Add focused LIT coverage for the new op.