### PR TITLE
feat(onnx-to-hip): stamp Slice params before constant externalization

### DIFF
--- a/lib/Conversion/OnnxToHip/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHip/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library(OnnxToHip STATIC
   GatherShapeFold.cpp
   ReshapeShapeFold.cpp
   PadShapeFold.cpp
+  SliceShapeFold.cpp
   ShapeConversion.cpp
   ReshapeConversion.cpp
   CausalConvWithStateConversion.cpp

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -813,6 +813,7 @@ void ConvertOnnxToHipPass::runOnOperation() {
         populateGatherBlockQuantizedPreparePatterns(preLoweringPatterns, ctx);
         populateReshapeShapeFoldPatterns(preLoweringPatterns, ctx);
         populatePadShapeFoldPatterns(preLoweringPatterns, ctx);
+        populateSliceShapeFoldPatterns(preLoweringPatterns, ctx);
         populateFastGeluFusionPatterns(preLoweringPatterns, ctx);
         populateErfGeluFusionPatterns(preLoweringPatterns, ctx);
         populateProjectorOpsRewritePatterns(preLoweringPatterns, ctx);

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
@@ -494,6 +494,14 @@ void populateReshapeShapeFoldPatterns(RewritePatternSet &patterns,
 void populatePadShapeFoldPatterns(RewritePatternSet &patterns,
                                   MLIRContext *ctx);
 
+/// Pre-lowering pattern set: stamp compile-time `onnx.Slice` starts/ends/axes/
+/// steps onto the op as `hipdnn.slice_*` attributes so SliceDecompose can
+/// rewrite to `tensor.extract_slice` after `lowerOnnxConstants` externalizes
+/// the operand constants. Sibling of PadShapeFold; must run BEFORE
+/// lowerOnnxConstants. See SliceShapeFold.cpp.
+void populateSliceShapeFoldPatterns(RewritePatternSet &patterns,
+                                    MLIRContext *ctx);
+
 /// Pre-lowering pattern set: collapse ORT's inlined `FastGelu` primitive
 /// chain (Pow / Mul / Sum / Tanh) back into a single
 /// `onnx.Gelu(approximate="tanh")`. ORT inlines the Gelu function body

--- a/lib/Conversion/OnnxToHip/SliceConversion.cpp
+++ b/lib/Conversion/OnnxToHip/SliceConversion.cpp
@@ -155,8 +155,8 @@ struct SliceDecompose : public mlir::RewritePattern {
                                                  axesVec)))
           return rewriter.notifyMatchFailure(
               op, "axes is not a compile-time constant");
-      } else if (auto attr =
-                     op->getAttrOfType<mlir::DenseI64ArrayAttr>("hipdnn.slice_axes")) {
+      } else if (auto attr = op->getAttrOfType<mlir::DenseI64ArrayAttr>(
+                     "hipdnn.slice_axes")) {
         axesVec.assign(attr.asArrayRef().begin(), attr.asArrayRef().end());
       }
     }
@@ -168,12 +168,12 @@ struct SliceDecompose : public mlir::RewritePattern {
     if (op->getNumOperands() == 5) {
       mlir::Value steps = normaliseOptional(op->getOperand(4));
       if (steps) {
-        if (mlir::failed(extractSliceParamVector(op, "hipdnn.slice_steps", steps,
-                                                 stepsVec)))
+        if (mlir::failed(extractSliceParamVector(op, "hipdnn.slice_steps",
+                                                 steps, stepsVec)))
           return rewriter.notifyMatchFailure(
               op, "steps is not a compile-time constant");
-      } else if (auto attr =
-                     op->getAttrOfType<mlir::DenseI64ArrayAttr>("hipdnn.slice_steps")) {
+      } else if (auto attr = op->getAttrOfType<mlir::DenseI64ArrayAttr>(
+                     "hipdnn.slice_steps")) {
         stepsVec.assign(attr.asArrayRef().begin(), attr.asArrayRef().end());
       }
     }

--- a/lib/Conversion/OnnxToHip/SliceConversion.cpp
+++ b/lib/Conversion/OnnxToHip/SliceConversion.cpp
@@ -68,13 +68,10 @@ static mlir::DenseElementsAttr getCompileTimeConstantTensor(mlir::Value value) {
   return nullptr;
 }
 
-/// Extract a 1-D integer tensor constant into a SmallVector<int64_t>.
-/// Returns failure if the tensor is missing, not 1-D, or not int32/int64.
+/// Populate \p out from a dense 1-D integer tensor attribute.
 static mlir::LogicalResult
-extractIntVector(mlir::Value v, llvm::SmallVectorImpl<int64_t> &out) {
-  if (!v)
-    return mlir::failure();
-  auto dense = getCompileTimeConstantTensor(v);
+denseIntVectorToSmallVector(mlir::DenseElementsAttr dense,
+                            llvm::SmallVectorImpl<int64_t> &out) {
   if (!dense)
     return mlir::failure();
   auto tensorType = mlir::dyn_cast<mlir::RankedTensorType>(dense.getType());
@@ -83,9 +80,32 @@ extractIntVector(mlir::Value v, llvm::SmallVectorImpl<int64_t> &out) {
   auto elemTy = tensorType.getElementType();
   if (!elemTy.isInteger(64) && !elemTy.isInteger(32))
     return mlir::failure();
+  out.clear();
   for (mlir::APInt entry : dense.getValues<mlir::APInt>())
     out.push_back(entry.getSExtValue());
   return mlir::success();
+}
+
+/// Extract a 1-D integer tensor constant into a SmallVector<int64_t>.
+/// Returns failure if the tensor is missing, not 1-D, or not int32/int64.
+static mlir::LogicalResult
+extractIntVector(mlir::Value v, llvm::SmallVectorImpl<int64_t> &out) {
+  if (!v)
+    return mlir::failure();
+  return denseIntVectorToSmallVector(getCompileTimeConstantTensor(v), out);
+}
+
+/// Prefer compile-time slice params stamped by SliceShapeFold (captured
+/// before constant externalization); fall back to reading inline operands.
+static mlir::LogicalResult
+extractSliceParamVector(mlir::Operation *op, llvm::StringRef attrName,
+                        mlir::Value operand,
+                        llvm::SmallVectorImpl<int64_t> &out) {
+  if (auto attr = op->getAttrOfType<mlir::DenseI64ArrayAttr>(attrName)) {
+    out.assign(attr.asArrayRef().begin(), attr.asArrayRef().end());
+    return mlir::success();
+  }
+  return extractIntVector(operand, out);
 }
 
 /// Normalise an ONNX Slice operand reference (`v`): if it is an `onnx.NoValue`
@@ -120,8 +140,10 @@ struct SliceDecompose : public mlir::RewritePattern {
     int64_t rank = dataType.getRank();
 
     llvm::SmallVector<int64_t> startsVec, endsVec;
-    if (mlir::failed(extractIntVector(op->getOperand(1), startsVec)) ||
-        mlir::failed(extractIntVector(op->getOperand(2), endsVec)))
+    if (mlir::failed(extractSliceParamVector(op, "hipdnn.slice_starts",
+                                             op->getOperand(1), startsVec)) ||
+        mlir::failed(extractSliceParamVector(op, "hipdnn.slice_ends",
+                                             op->getOperand(2), endsVec)))
       return rewriter.notifyMatchFailure(
           op, "starts/ends are not compile-time constants");
 
@@ -129,9 +151,13 @@ struct SliceDecompose : public mlir::RewritePattern {
     if (op->getNumOperands() >= 4) {
       mlir::Value axes = normaliseOptional(op->getOperand(3));
       if (axes) {
-        if (mlir::failed(extractIntVector(axes, axesVec)))
+        if (mlir::failed(extractSliceParamVector(op, "hipdnn.slice_axes", axes,
+                                                 axesVec)))
           return rewriter.notifyMatchFailure(
               op, "axes is not a compile-time constant");
+      } else if (auto attr =
+                     op->getAttrOfType<mlir::DenseI64ArrayAttr>("hipdnn.slice_axes")) {
+        axesVec.assign(attr.asArrayRef().begin(), attr.asArrayRef().end());
       }
     }
     if (axesVec.empty())
@@ -142,9 +168,13 @@ struct SliceDecompose : public mlir::RewritePattern {
     if (op->getNumOperands() == 5) {
       mlir::Value steps = normaliseOptional(op->getOperand(4));
       if (steps) {
-        if (mlir::failed(extractIntVector(steps, stepsVec)))
+        if (mlir::failed(extractSliceParamVector(op, "hipdnn.slice_steps", steps,
+                                                 stepsVec)))
           return rewriter.notifyMatchFailure(
               op, "steps is not a compile-time constant");
+      } else if (auto attr =
+                     op->getAttrOfType<mlir::DenseI64ArrayAttr>("hipdnn.slice_steps")) {
+        stepsVec.assign(attr.asArrayRef().begin(), attr.asArrayRef().end());
       }
     }
     if (stepsVec.empty())

--- a/lib/Conversion/OnnxToHip/SliceShapeFold.cpp
+++ b/lib/Conversion/OnnxToHip/SliceShapeFold.cpp
@@ -128,15 +128,15 @@ struct SliceStampConstParams : public mlir::RewritePattern {
       if (steps) {
         stepsVec = getInlineIntVector(steps);
         if (!stepsVec)
-          return rewriter.notifyMatchFailure(op, "slice.steps_not_inline_const");
+          return rewriter.notifyMatchFailure(op,
+                                             "slice.steps_not_inline_const");
       }
     }
 
     rewriter.modifyOpInPlace(op, [&] {
       op->setAttr("hipdnn.slice_starts",
                   rewriter.getDenseI64ArrayAttr(*startsVec));
-      op->setAttr("hipdnn.slice_ends",
-                  rewriter.getDenseI64ArrayAttr(*endsVec));
+      op->setAttr("hipdnn.slice_ends", rewriter.getDenseI64ArrayAttr(*endsVec));
       if (axesVec)
         op->setAttr("hipdnn.slice_axes",
                     rewriter.getDenseI64ArrayAttr(*axesVec));

--- a/lib/Conversion/OnnxToHip/SliceShapeFold.cpp
+++ b/lib/Conversion/OnnxToHip/SliceShapeFold.cpp
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- SliceShapeFold.cpp - Pre-lowering Slice param stamping ------------===//
+//
+// Sibling pre-lowering fold to PadShapeFold. Captures the compile-time value
+// of `onnx.Slice`'s starts/ends/axes/steps operands onto the op as attributes
+// BEFORE `lowerOnnxConstants` externalizes the constants -- so SliceDecompose
+// (which runs in `convertComputeOps`, after externalization) can rewrite to
+// `tensor.extract_slice` without reading the operand.
+//
+// SwinV2 window/partition slices use small 1-element i64 constants for every
+// param; production builds externalize even those into `memref.global` entries
+// with null `initial_value` (bytes live in constants.bin / ORT mem). Without
+// this stamp SliceDecompose fails `extractIntVector` and every slice falls
+// through to the stub `hip.slice` runtime op.
+//
+//   Before:
+//     %s = onnx.Constant {value = dense<0> : tensor<1xi64>}
+//     %e = onnx.Constant {value = dense<8> : tensor<1xi64>}
+//     %a = onnx.Constant {value = dense<1> : tensor<1xi64>}
+//     %out = onnx.Slice(%data, %s, %e, %a)
+//
+//   After:
+//     %out = onnx.Slice(%data, %s, %e, %a)
+//              {hipdnn.slice_starts = array<i64: 0>,
+//               hipdnn.slice_ends   = array<i64: 8>,
+//               hipdnn.slice_axes   = array<i64: 1>}
+//
+//===----------------------------------------------------------------------===//
+
+#include "OnnxToHipUtils.h"
+
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/Statistic.h"
+#include "llvm/Support/Debug.h"
+
+#include <optional>
+
+#define DEBUG_TYPE "slice-shape-fold"
+
+STATISTIC(NumSliceConstStamps,
+          "Number of onnx.Slice ops whose constant params were stamped as "
+          "attributes before externalization");
+
+namespace mlir {
+namespace hip {
+
+namespace {
+
+static mlir::Value normaliseOptional(mlir::Value v) {
+  if (!v)
+    return v;
+  auto defOp = v.getDefiningOp();
+  if (defOp && defOp->getName().getStringRef() == "onnx.NoValue")
+    return mlir::Value();
+  return v;
+}
+
+/// Inline 1-D integer constant (`arith.constant` or `onnx.Constant`), or
+/// std::nullopt. Runs before externalization so `bufferization.to_tensor` is
+/// intentionally not handled here.
+static std::optional<llvm::SmallVector<int64_t>>
+getInlineIntVector(mlir::Value v) {
+  if (!v)
+    return std::nullopt;
+  mlir::Operation *defOp = v.getDefiningOp();
+  if (!defOp)
+    return std::nullopt;
+
+  mlir::DenseElementsAttr dense;
+  if (auto cst = mlir::dyn_cast<mlir::arith::ConstantOp>(defOp))
+    dense = mlir::dyn_cast<mlir::DenseElementsAttr>(cst.getValue());
+  else if (defOp->getName().getStringRef() == "onnx.Constant")
+    dense = defOp->getAttrOfType<mlir::DenseElementsAttr>("value");
+
+  if (!dense)
+    return std::nullopt;
+  auto tensorType = mlir::dyn_cast<mlir::RankedTensorType>(dense.getType());
+  if (!tensorType || tensorType.getRank() != 1)
+    return std::nullopt;
+  auto elemTy = tensorType.getElementType();
+  if (!elemTy.isInteger(64) && !elemTy.isInteger(32))
+    return std::nullopt;
+
+  llvm::SmallVector<int64_t> out;
+  for (mlir::APInt entry : dense.getValues<mlir::APInt>())
+    out.push_back(entry.getSExtValue());
+  return out;
+}
+
+struct SliceStampConstParams : public mlir::RewritePattern {
+  SliceStampConstParams(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.Slice", /*benefit=*/1, ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override {
+    if (op->hasAttr("hipdnn.slice_starts"))
+      return rewriter.notifyMatchFailure(op, "slice.already_stamped");
+
+    if (op->getNumOperands() < 3 || op->getNumOperands() > 5)
+      return rewriter.notifyMatchFailure(op, "slice.arity");
+
+    auto startsVec = getInlineIntVector(op->getOperand(1));
+    if (!startsVec)
+      return rewriter.notifyMatchFailure(op, "slice.starts_not_inline_const");
+    auto endsVec = getInlineIntVector(op->getOperand(2));
+    if (!endsVec)
+      return rewriter.notifyMatchFailure(op, "slice.ends_not_inline_const");
+
+    std::optional<llvm::SmallVector<int64_t>> axesVec;
+    if (op->getNumOperands() >= 4) {
+      mlir::Value axes = normaliseOptional(op->getOperand(3));
+      if (axes) {
+        axesVec = getInlineIntVector(axes);
+        if (!axesVec)
+          return rewriter.notifyMatchFailure(op, "slice.axes_not_inline_const");
+      }
+    }
+
+    std::optional<llvm::SmallVector<int64_t>> stepsVec;
+    if (op->getNumOperands() == 5) {
+      mlir::Value steps = normaliseOptional(op->getOperand(4));
+      if (steps) {
+        stepsVec = getInlineIntVector(steps);
+        if (!stepsVec)
+          return rewriter.notifyMatchFailure(op, "slice.steps_not_inline_const");
+      }
+    }
+
+    rewriter.modifyOpInPlace(op, [&] {
+      op->setAttr("hipdnn.slice_starts",
+                  rewriter.getDenseI64ArrayAttr(*startsVec));
+      op->setAttr("hipdnn.slice_ends",
+                  rewriter.getDenseI64ArrayAttr(*endsVec));
+      if (axesVec)
+        op->setAttr("hipdnn.slice_axes",
+                    rewriter.getDenseI64ArrayAttr(*axesVec));
+      if (stepsVec)
+        op->setAttr("hipdnn.slice_steps",
+                    rewriter.getDenseI64ArrayAttr(*stepsVec));
+    });
+
+    LLVM_DEBUG(llvm::dbgs() << "[" DEBUG_TYPE << "] stamped slice params ("
+                            << startsVec->size() << " entries)\n");
+    ++NumSliceConstStamps;
+    return mlir::success();
+  }
+};
+
+} // namespace
+
+void populateSliceShapeFoldPatterns(mlir::RewritePatternSet &patterns,
+                                    MLIRContext *ctx) {
+  patterns.add<SliceStampConstParams>(ctx);
+}
+
+} // namespace hip
+} // namespace mlir

--- a/test/lit/Conversion/onnx-to-hip/test_slice_swinv2_window.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_slice_swinv2_window.mlir
@@ -1,0 +1,60 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// SwinV2 shifted-window slice from /layers.0/blocks.1/Slice_1:
+//   input  1x128x256x96
+//   axis=1, start=0, end=8  ->  1x8x256x96
+//
+// Uses onnx.Constant operands (externalized by convert-onnx-to-hip) so the
+// SliceShapeFold -> SliceDecompose path is exercised end-to-end.
+
+// RUN: mkdir -p %t && hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip='externalize-min-num-elements=1 externalize-output-dir=%t' %s | FileCheck %s
+
+module {
+  func.func @main_graph(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+    return %arg0 : tensor<4xf32>
+  }
+
+  func.func @test_swinv2_window_slice(%input: tensor<1x128x256x96xf16>)
+      -> tensor<1x8x256x96xf16> {
+    // CHECK-LABEL: func.func @test_swinv2_window_slice
+    %starts = "onnx.Constant"() {value = dense<0> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %ends = "onnx.Constant"() {value = dense<8> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %axes = "onnx.Constant"() {value = dense<1> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %r = "onnx.Slice"(%input, %starts, %ends, %axes)
+        : (tensor<1x128x256x96xf16>, tensor<1xi64>, tensor<1xi64>,
+           tensor<1xi64>) -> tensor<1x8x256x96xf16>
+
+    // CHECK-NOT: onnx.Slice
+    // CHECK-NOT: hip.slice
+    // CHECK: tensor.extract_slice {{.*}}[0, 0, 0, 0] [1, 8, 256, 96] [1, 1, 1, 1]
+
+    return %r : tensor<1x8x256x96xf16>
+  }
+
+  // SwinV2 downsample strided slice from /layers.0/downsample/Slice_2:
+  //   axis=1, start=1, end=INT64_MAX, step=2  on  1x128x256x96  ->  1x64x256x96
+  func.func @test_swinv2_downsample_stride_slice(%input: tensor<1x128x256x96xf16>)
+      -> tensor<1x64x256x96xf16> {
+    // CHECK-LABEL: func.func @test_swinv2_downsample_stride_slice
+    %starts = "onnx.Constant"() {value = dense<1> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %ends = "onnx.Constant"() {value = dense<9223372036854775807> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %axes = "onnx.Constant"() {value = dense<1> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %steps = "onnx.Constant"() {value = dense<2> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %r = "onnx.Slice"(%input, %starts, %ends, %axes, %steps)
+        : (tensor<1x128x256x96xf16>, tensor<1xi64>, tensor<1xi64>,
+           tensor<1xi64>, tensor<1xi64>) -> tensor<1x64x256x96xf16>
+
+    // CHECK-NOT: hip.slice
+    // CHECK: tensor.extract_slice {{.*}}[0, 1, 0, 0] [1, 64, 256, 96] [1, 2, 1, 1]
+
+    return %r : tensor<1x64x256x96xf16>
+  }
+}


### PR DESCRIPTION
## Summary

- Add `SliceShapeFold` pre-lowering pass to stamp compile-time `onnx.Slice` starts/ends/axes/steps onto the op as `hipdnn.slice_*` attributes before `lowerOnnxConstants` externalizes operand constants.
- Update `SliceDecompose` to prefer stamped attributes so slices rewrite to `tensor.extract_slice` instead of falling through to the `hip.slice` runtime stub.
- Add LIT coverage for SwinV2 window and downsample stride slice patterns.

## Motivation

Production builds externalize even small 1-element i64 Slice param constants into `memref.global` entries. Without stamping params before externalization, `SliceDecompose` cannot read compile-time values and every slice falls through to the stub runtime op. This blocks models like SwinV2 that rely on window/partition slices.

## Test plan

- [x] `pre-commit run --all-files`
- [ ] `ctest --test-dir ../build/hip-ep_20260724 -C Release -R MorphizenMLIRLitTests --verbose`
- [ ] Verify SwinV2 slice paths compile to `tensor.extract_slice` (no `hip.slice` stub)
