### PR TITLE
fix(runtime): harden MatMul and Gemm contracts

### DIFF
--- a/build.py
+++ b/build.py
@@ -326,8 +326,8 @@ def build_targets(args, build_dir):
 def run_tests(args, build_dir):
     """Run the GPU-free test suites (no device needed, so they run on the build
     machine in every CI job): the MLIR LIT pass-verification suite plus the
-    compiler-plugin registrar, output-allocator, custom-op status, and
-    symbolic-metadata ctest unit tests."""
+    compiler-plugin registrar, output-allocator, custom-op status,
+    symbolic-metadata, and MatMul/Gemm ctest unit tests."""
     step("Test (check-hip-mlir-lit)")
     run_subprocess(
         [
@@ -353,7 +353,8 @@ def run_tests(args, build_dir):
             args.config,
             "-R",
             "StaticPlugins|OutputAllocator|CustomOpComputeStatus|"
-            "ArtifactAbi|TensorBufferLifecycle|SymbolicDims|CacheIdentity",
+            "ArtifactAbi|TensorBufferLifecycle|SymbolicDims|CacheIdentity|"
+            "MatmulGemmContractUnitTest",
             "--output-on-failure",
         ]
     )

--- a/docs/design/compiler-runtime-contract.md
+++ b/docs/design/compiler-runtime-contract.md
@@ -249,6 +249,17 @@ dynamic descriptor equality before copying or dispatching f16, bf16, or f32
 storage through the typed custom kernel. This contract supersedes the former
 element-byte-width argument and therefore requires artifact invalidation.
 
+HIP MatMul and Gemm carry two contraction extents in generated calls. MatMul
+calls `wrap_hipblasLtMatmul` with `A[-1]`, `B[-2]`, and one i1 proving
+all right-aligned runtime batch axes and output extents agree with ONNX
+broadcast. Gemm passes the transpose-aware K extent from each operand. The real
+and mock wrappers validate these contracts before descriptor/cache creation or
+dispatch, then use the equal K value in cache keys. Runtime-invalid dimensions
+and checked output-size overflow set the shared error flag and skip BLAS work;
+a known, valid nonempty output allocation is zero-filled on failure.
+
+Artifacts built against the former 11-argument MatMul signature or the old
+one-K Gemm signature must be recompiled.
 ---
 
 ## Consumers

--- a/docs/design/per-op-profiling.md
+++ b/docs/design/per-op-profiling.md
@@ -15,10 +15,14 @@ Per-operator GPU profiling measures GPU and CPU time for each runtime wrapper fu
 Each operator wrapper contains one macro call:
 
 ```cpp
-int wrap_hipblasLtMatmul(RuntimeState *state, ..., int64_t M, int64_t N, int64_t K, ...) {
+int wrap_hipblasLtMatmul(RuntimeState *state, ..., int64_t M, int64_t N,
+                         int64_t K_a, int64_t K_b, ...) {
+  // The wrapper has already established K_a == K_b.
+  int64_t K_equal = K_a;
   OP_PROFILE("matmul", [&] {
     char b[64];
-    snprintf(b, sizeof(b), "%lldx%lldx%lld", (long long)M, (long long)N, (long long)K);
+    snprintf(b, sizeof(b), "%lldx%lldx%lld", (long long)M, (long long)N,
+             (long long)K_equal);
     return std::string(b);
   }, state);
   // ... operator implementation ...

--- a/docs/hip_dialect_intro.md
+++ b/docs/hip_dialect_intro.md
@@ -44,11 +44,12 @@ Matrix multiplication backed by the hipBLASLt library (`hipblasLtMatmul`).
 
 | Op | DPS Syntax | Runtime | Status |
 |---|---|---|---|
-| `hip.hipblaslt.matmul` | `(%ctx) ins(%A, %B : ...) outs(%C : ...)` | `hip_hipblaslt_matmul(handle, A, B, C, rankA, rankB, batch, M, K, N)` | Full impl |
+| `hip.matmul` | `(%ctx) ins(%A, %B : ...) outs(%C : ...)` | `wrap_hipblasLtMatmul(state, slot, A, B, C, batch_axes_valid, M, N, K_a, K_b, batch, elem, a_batches, b_batches, a_stride, b_stride)` | Full impl |
 
-Rank-generic: batch is determined from A's rank (3D -> batched, 2D -> single).
-If B has fewer dims than A (e.g. `X[B,S,D] @ W[D,D]`), B is broadcast across
-batches (`stride_B = 0`). Supports strided batched GEMM via hipBLASLt.
+The generated-code ABI carries both contraction extents and validates their
+equality plus every right-aligned batch axis before dispatch. Either operand may
+be a single matrix broadcast across all output batches or provide one matrix
+per output batch.
 
 ---
 

--- a/include/hip/Conversion/HipsrToLLVM/HipsrToLLVM.h
+++ b/include/hip/Conversion/HipsrToLLVM/HipsrToLLVM.h
@@ -31,6 +31,7 @@ namespace hipsr {
 
 namespace detail {
 
+struct I1Tag {};
 struct I32Tag {};
 struct I64Tag {};
 struct HostPtrTag {};
@@ -38,6 +39,12 @@ struct DevicePtrTag {};
 struct SlotIndexTag {};
 
 template <typename Tag> struct TypeMaterializer;
+
+template <> struct TypeMaterializer<I1Tag> {
+  static Type get(MLIRContext *, OpBuilder &builder) {
+    return builder.getI1Type();
+  }
+};
 
 template <> struct TypeMaterializer<I32Tag> {
   static Type get(MLIRContext *, OpBuilder &builder) {
@@ -76,6 +83,7 @@ Type materializeType(MLIRContext *ctx, OpBuilder &builder) {
 
 } // namespace detail
 
+using i1 = detail::I1Tag;
 using i32 = detail::I32Tag;
 using i64 = detail::I64Tag;
 using hostPtr = detail::HostPtrTag;
@@ -89,6 +97,12 @@ struct SlotIndex {
 namespace detail {
 
 template <typename Tag, typename ArgType> struct ArgConverter;
+
+template <> struct ArgConverter<I1Tag, Value> {
+  static Value convert(ConversionPatternRewriter &, Location, Value value) {
+    return value;
+  }
+};
 
 template <> struct ArgConverter<DevicePtrTag, Value> {
   static Value convert(ConversionPatternRewriter &rewriter, Location loc,

--- a/lib/Conversion/HipToLLVM/GemmLowering.cpp
+++ b/lib/Conversion/HipToLLVM/GemmLowering.cpp
@@ -30,6 +30,8 @@ struct GemmOpLowering : public ConvertOpToLLVMPattern<GemmOp> {
     };
 
     auto AType = cast<MemRefType>(op.getInputA().getType());
+    auto BType = cast<MemRefType>(op.getInputB().getType());
+
     Type elemType = AType.getElementType();
     int64_t typeCode;
     if (elemType.isF16())
@@ -69,18 +71,19 @@ struct GemmOpLowering : public ConvertOpToLLVMPattern<GemmOp> {
 
     // A.shape = transA ? [K, M] : [M, K]
     // B.shape = transB ? [N, K] : [K, N]
-    Value M, K, N;
+    Value M, Ka, Kb, N;
     if (adaptor.getTransA()) {
-      K = getMemRefDimSize(AType, 0, adaptor.getInputA(), rewriter, loc);
+      Ka = getMemRefDimSize(AType, 0, adaptor.getInputA(), rewriter, loc);
       M = getMemRefDimSize(AType, 1, adaptor.getInputA(), rewriter, loc);
     } else {
       M = getMemRefDimSize(AType, 0, adaptor.getInputA(), rewriter, loc);
-      K = getMemRefDimSize(AType, 1, adaptor.getInputA(), rewriter, loc);
+      Ka = getMemRefDimSize(AType, 1, adaptor.getInputA(), rewriter, loc);
     }
-    auto BType = cast<MemRefType>(op.getInputB().getType());
     if (adaptor.getTransB()) {
       N = getMemRefDimSize(BType, 0, adaptor.getInputB(), rewriter, loc);
+      Kb = getMemRefDimSize(BType, 1, adaptor.getInputB(), rewriter, loc);
     } else {
+      Kb = getMemRefDimSize(BType, 0, adaptor.getInputB(), rewriter, loc);
       N = getMemRefDimSize(BType, 1, adaptor.getInputB(), rewriter, loc);
     }
 
@@ -105,7 +108,7 @@ struct GemmOpLowering : public ConvertOpToLLVMPattern<GemmOp> {
       cDim1 = createI64Const(0);
     }
 
-    SmallVector<Type, 16> paramTypes = {
+    SmallVector<Type, 17> paramTypes = {
         ptrType, // state
         i32Type, // op_state_slot
         ptrType, // A
@@ -114,7 +117,8 @@ struct GemmOpLowering : public ConvertOpToLLVMPattern<GemmOp> {
         ptrType, // output
         i64Type, // M
         i64Type, // N
-        i64Type, // K
+        i64Type, // K_a
+        i64Type, // K_b
         f32Type, // alpha
         f32Type, // beta
         i64Type, // transA
@@ -129,15 +133,16 @@ struct GemmOpLowering : public ConvertOpToLLVMPattern<GemmOp> {
       return failure();
     }
 
-    SmallVector<Value, 16> args = {
+    SmallVector<Value, 17> args = {
         statePtr,    getOpStateSlotValue(op, rewriter, loc),
         input_A_ptr, input_B_ptr,
         input_C_ptr, output_ptr,
         M,           N,
-        K,           alpha,
-        beta,        transA,
-        transB,      typeCodeVal,
-        cDim0,       cDim1};
+        Ka,          Kb,
+        alpha,       beta,
+        transA,      transB,
+        typeCodeVal, cDim0,
+        cDim1};
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
     rewriter.eraseOp(op);
     return success();

--- a/lib/Conversion/HipToLLVM/MatmulLowering.cpp
+++ b/lib/Conversion/HipToLLVM/MatmulLowering.cpp
@@ -5,15 +5,23 @@
 
 #include "HipToLLVMUtils.h"
 
+#include "llvm/ADT/STLExtras.h"
+
 namespace mlir {
 namespace hip {
 namespace {
 
-// ===== hipBLASLt ops =========================================================
-
-// hip.hipblaslt.matmul(handle) ins(A, B) outs(C)
-//   -> hip_hipblaslt_matmul(handle, A, B, C, rankA, rankB, batch, M, K, N)
-// Rank-generic: batch from A if 3D, B broadcast if rankB < rankA.
+// Lower `hip.matmul` to the hipBLASLt runtime ABI. Each operand gets an
+// independent batch stride so either whole matrix may be broadcast.
+//
+// Before:
+//   hip.matmul ins(%a, %b : memref<128x4096xf16>,
+//                           memref<2x4096x1024xf16>) outs(%out : ...)
+// After:
+//   %a_stride = llvm.mlir.constant(0 : i64) : i64
+//   %b_stride = llvm.mul %k_b, %n : i64
+//   llvm.call @wrap_hipblasLtMatmul(
+//       ..., %k_a, %k_b, ..., %a_stride, %b_stride)
 struct MatmulOpLowering : public ConvertOpToLLVMPattern<MatmulOp> {
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
@@ -23,134 +31,156 @@ struct MatmulOpLowering : public ConvertOpToLLVMPattern<MatmulOp> {
     Location loc = op.getLoc();
     ModuleOp module = op->getParentOfType<ModuleOp>();
     Type ptrType = getPtrType();
+    Type i1Type = rewriter.getI1Type();
     Type i32Type = rewriter.getI32Type();
     Type i64Type = rewriter.getI64Type();
 
-    // Helper: create i64 constant
     auto createI64Const = [&](int64_t value) -> Value {
       return LLVM::ConstantOp::create(rewriter, loc, i64Type,
                                       rewriter.getI64IntegerAttr(value));
     };
 
-    // Extract pointers
+    auto AType = cast<MemRefType>(op.getA().getType());
+    auto BType = cast<MemRefType>(op.getB().getType());
+    auto outputType = cast<MemRefType>(op.getOutput().getType());
+    int64_t ARank = AType.getRank();
+    int64_t BRank = BType.getRank();
+    int64_t outputRank = outputType.getRank();
+
     Value statePtr = adaptor.getCtx();
     Value APtr = extractContiguousMemRefPtr(adaptor.getA(), rewriter, loc);
     Value BPtr = extractContiguousMemRefPtr(adaptor.getB(), rewriter, loc);
     Value outputPtr =
         extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
 
-    // Get memref types and shapes
-    auto AType = cast<MemRefType>(op.getA().getType());
-    auto BType = cast<MemRefType>(op.getB().getType());
-    int64_t ARank = AType.getRank();
-    int64_t BRank = BType.getRank();
-
-    // === DYNAMIC SHAPE SUPPORT ===
-    // For dynamic shapes, we compute dimensions at runtime
     MemRefDescriptor ADesc(adaptor.getA());
     MemRefDescriptor BDesc(adaptor.getB());
+    MemRefDescriptor outputDesc(adaptor.getOutput());
 
-    // Compute M, K, N from runtime dimensions
-    // A: [..., M, K], B: [..., K, N] or B: [K, N]
-    Value M =
-        (ARank >= 2) ? ADesc.size(rewriter, loc, ARank - 2) : createI64Const(1);
-    Value K = ADesc.size(rewriter, loc, ARank - 1);
-    Value N = BDesc.size(rewriter, loc, BRank - 1);
+    // Validate every right-aligned batch axis before flattening. The exact
+    // broadcast choice matches reification:
+    //   select(A == 1, B, A)
+    // after requiring A == B || A == 1 || B == 1. Missing leading operand
+    // axes are implicit ones. The output descriptor is checked independently
+    // so a malformed caller cannot hide an incompatible broadcast behind an
+    // equal flattened matrix count (for example [2,3] vs [3,2]).
+    int64_t outputBatchRank = outputRank - 2;
+    int64_t aBatchRank = ARank - 2;
+    int64_t bBatchRank = BRank - 2;
+    Value one = createI64Const(1);
+    Value batchAxesValid = LLVM::ConstantOp::create(rewriter, loc, i1Type,
+                                                    rewriter.getBoolAttr(true));
+    for (int64_t outAxis : llvm::seq<int64_t>(0, outputBatchRank)) {
+      int64_t aAxis = outAxis - (outputBatchRank - aBatchRank);
+      int64_t bAxis = outAxis - (outputBatchRank - bBatchRank);
+      Value aDim = aAxis < 0 ? one : ADesc.size(rewriter, loc, aAxis);
+      Value bDim = bAxis < 0 ? one : BDesc.size(rewriter, loc, bAxis);
+      Value outDim = outputDesc.size(rewriter, loc, outAxis);
 
-    // Compute batch count from leading dimensions of A
-    Value batchCount;
-    if (ARank == 2) {
-      batchCount = createI64Const(1);
-    } else {
-      batchCount = ADesc.size(rewriter, loc, 0);
-      for (int64_t i = 1; i < ARank - 2; ++i) {
-        Value dim = ADesc.size(rewriter, loc, i);
-        batchCount = LLVM::MulOp::create(rewriter, loc, batchCount, dim);
-      }
+      Value aEqualsB = LLVM::ICmpOp::create(
+          rewriter, loc, LLVM::ICmpPredicate::eq, aDim, bDim);
+      Value aIsOne = LLVM::ICmpOp::create(rewriter, loc,
+                                          LLVM::ICmpPredicate::eq, aDim, one);
+      Value bIsOne = LLVM::ICmpOp::create(rewriter, loc,
+                                          LLVM::ICmpPredicate::eq, bDim, one);
+      Value eitherIsOne = LLVM::OrOp::create(rewriter, loc, aIsOne, bIsOne);
+      Value compatible =
+          LLVM::OrOp::create(rewriter, loc, aEqualsB, eitherIsOne);
+      Value expectedOutput =
+          LLVM::SelectOp::create(rewriter, loc, aIsOne, bDim, aDim);
+      Value outputMatches = LLVM::ICmpOp::create(
+          rewriter, loc, LLVM::ICmpPredicate::eq, outDim, expectedOutput);
+      Value axisValid =
+          LLVM::AndOp::create(rewriter, loc, compatible, outputMatches);
+      batchAxesValid =
+          LLVM::AndOp::create(rewriter, loc, batchAxesValid, axisValid);
     }
 
-    // Compute element size in bytes
+    Value M = ADesc.size(rewriter, loc, ARank - 2);
+    Value Ka = ADesc.size(rewriter, loc, ARank - 1);
+    Value Kb = BDesc.size(rewriter, loc, BRank - 2);
+    Value N = BDesc.size(rewriter, loc, BRank - 1);
+
+    // The output shape already contains the broadcasted leading dimensions.
+    Value batchCount = createI64Const(1);
+    for (int64_t i : llvm::seq<int64_t>(0, outputRank - 2)) {
+      Value dim = outputDesc.size(rewriter, loc, i);
+      batchCount = LLVM::MulOp::create(rewriter, loc, batchCount, dim);
+    }
+
     unsigned elemBits = AType.getElementType().getIntOrFloatBitWidth();
     Value elemSize = createI64Const(elemBits / 8);
 
-    // b_batch_stride: the per-batch stride (in elements) for hipBLASLt's
-    // STRIDED_BATCH_OFFSET on layA when batch_count > 1. Two distinct B
-    // memref shapes both reach this site with batch_count > 1 and need
-    // DIFFERENT strides:
-    //   * Rank-2 broadcast weight `[K, N]` → one matrix shared across all
-    //     batches → stride = 0.
-    //   * Rank-N per-batch weight `[d_0, ..., d_{N-3}, K, N]` whose leading
-    //     dims hold more than one matrix → stride = K * N.
-    //   * Rank-N weight whose leading dims multiply to 1 (e.g. `[1, K, N]`,
-    //     `[1, 1, K, N]`) → still ONE matrix; stride = 0.
-    // Previously encoded as a `b_batched` bool keyed on `BRank > 2`. That
-    // misclassified the `[1, K, N]` leading-one case as per-batch, causing
-    // OOB reads of `K*N` elements past the end of the weight on every batch
-    // beyond the first.
-    //
-    // Leading-dim product is computed at compile time when all leading dims
-    // are static (the common case for shipping models). When any leading dim
-    // is dynamic we emit a runtime `select` over the leading-product so the
-    // descriptor cache picks the right pre-built layout per call.
-    //
-    // Before:
-    //   hip.matmul ins(%A, %B : memref<2x128x4096xf16>,
-    //   memref<1x4096x1024xf16>)
-    // After:
-    //   %stride = llvm.mlir.constant(0 : i64) : i64   // leading product is 1
-    //   llvm.call @wrap_hipblasLtMatmul(..., %stride) : (...) -> i32
-    Value bBatchStride;
-    if (BRank == 2) {
-      bBatchStride = createI64Const(0);
-    } else {
-      bool allLeadingStatic = true;
-      int64_t staticLeadingProduct = 1;
-      for (int64_t i : llvm::seq<int64_t>(0, BRank - 2)) {
-        if (BType.isDynamicDim(i)) {
-          allLeadingStatic = false;
-          break;
-        }
-        staticLeadingProduct *= BType.getDimSize(i);
+    auto operandBatchCount = [&](MemRefType type,
+                                 MemRefDescriptor desc) -> Value {
+      ArrayRef<int64_t> batch = type.getShape().drop_back(2);
+      if (!ShapedType::isDynamicShape(batch))
+        return createI64Const(llvm::product_of(batch));
+
+      Value count = createI64Const(1);
+      for (unsigned i : llvm::seq<unsigned>(0, batch.size()))
+        count = LLVM::MulOp::create(rewriter, loc, count,
+                                    desc.size(rewriter, loc, i));
+      return count;
+    };
+    Value aBatchCount = operandBatchCount(AType, ADesc);
+    Value bBatchCount = operandBatchCount(BType, BDesc);
+
+    // A stride can represent exactly one matrix (stride 0) or one matrix per
+    // output batch (matrix-size stride). Static validation rejects visible
+    // partial broadcasts. Dynamic layouts select stride from the runtime count;
+    // the runtime rejects any count other than 1 or `batchCount`.
+    // `rows` x `cols` is the operand's matrix size in elements, materialized
+    // only on the paths that need it.
+    auto batchStride = [&](MemRefType type, Value count, Value rows,
+                           Value cols) -> Value {
+      ArrayRef<int64_t> batch = type.getShape().drop_back(2);
+      if (!ShapedType::isDynamicShape(batch)) {
+        if (llvm::product_of(batch) == 1)
+          return createI64Const(0);
+        return LLVM::MulOp::create(rewriter, loc, rows, cols).getRes();
       }
-      if (allLeadingStatic) {
-        bBatchStride = (staticLeadingProduct <= 1)
-                           ? createI64Const(0)
-                           : LLVM::MulOp::create(rewriter, loc, K, N).getRes();
-      } else {
-        Value one = createI64Const(1);
-        Value zero = createI64Const(0);
-        Value leadingProduct = one;
-        for (int64_t i : llvm::seq<int64_t>(0, BRank - 2)) {
-          Value dim = BDesc.size(rewriter, loc, i);
-          leadingProduct =
-              LLVM::MulOp::create(rewriter, loc, leadingProduct, dim).getRes();
-        }
-        Value isBroadcast = LLVM::ICmpOp::create(
-            rewriter, loc, LLVM::ICmpPredicate::sle, leadingProduct, one);
-        Value kn = LLVM::MulOp::create(rewriter, loc, K, N).getRes();
-        bBatchStride =
-            LLVM::SelectOp::create(rewriter, loc, isBroadcast, zero, kn)
-                .getRes();
-      }
-    }
+
+      Value perBatch = LLVM::ICmpOp::create(
+          rewriter, loc, LLVM::ICmpPredicate::eq, count, batchCount);
+      // Both arms in locals, so the emission order does not depend on the
+      // unspecified evaluation order of call arguments.
+      Value matrixElements = LLVM::MulOp::create(rewriter, loc, rows, cols);
+      Value zero = createI64Const(0);
+      return LLVM::SelectOp::create(rewriter, loc, perBatch, matrixElements,
+                                    zero)
+          .getRes();
+    };
+    Value aBatchStride = batchStride(AType, aBatchCount, M, Ka);
+    Value bBatchStride = batchStride(BType, bBatchCount, Kb, N);
 
     // Runtime signature:
     // int wrap_hipblasLtMatmul(RuntimeState* state,
     //                          const void* A, const void* B, void* output,
-    //                          int64_t M, int64_t N, int64_t K,
+    //                          bool batch_axes_valid,
+    //                          int64_t M, int64_t N,
+    //                          int64_t K_a, int64_t K_b,
     //                          int64_t batch_count, int64_t elem_size,
-    //                          int64_t b_batch_stride, int op_state_slot)
-    SmallVector<Type, 11> paramTypes = {
+    //                          int64_t a_batch_count,
+    //                          int64_t b_batch_count,
+    //                          int64_t a_batch_stride,
+    //                          int64_t b_batch_stride)
+    SmallVector<Type, 16> paramTypes = {
         ptrType, // state
         i32Type, // op_state_slot
         ptrType, // A
         ptrType, // B
         ptrType, // output
+        i1Type,  // batch_axes_valid
         i64Type, // M
         i64Type, // N
-        i64Type, // K
+        i64Type, // K_a
+        i64Type, // K_b
         i64Type, // batch_count
         i64Type, // elem_size
+        i64Type, // a_batch_count
+        i64Type, // b_batch_count
+        i64Type, // a_batch_stride
         i64Type  // b_batch_stride
     };
 
@@ -159,13 +189,22 @@ struct MatmulOpLowering : public ConvertOpToLLVMPattern<MatmulOp> {
     if (failed(funcOp))
       return failure();
 
-    SmallVector<Value, 11> args = {
-        statePtr,    getOpStateSlotValue(op, rewriter, loc),
-        APtr,        BPtr,
-        outputPtr,   M,
-        N,           K,
-        batchCount,  elemSize,
-        bBatchStride};
+    SmallVector<Value, 16> args = {statePtr,
+                                   getOpStateSlotValue(op, rewriter, loc),
+                                   APtr,
+                                   BPtr,
+                                   outputPtr,
+                                   batchAxesValid,
+                                   M,
+                                   N,
+                                   Ka,
+                                   Kb,
+                                   batchCount,
+                                   elemSize,
+                                   aBatchCount,
+                                   bBatchCount,
+                                   aBatchStride,
+                                   bBatchStride};
 
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
     rewriter.eraseOp(op);

--- a/lib/Dialect/Hipsr/IR/HipsrMatMulOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrMatMulOp.cpp
@@ -155,6 +155,7 @@ struct MatMulLowering : ConvertOpToLLVMPattern<MatMulOp> {
     Value m =
         aRank == 1 ? createI64Const(1) : aDesc.size(rewriter, loc, aRank - 2);
     Value k = aDesc.size(rewriter, loc, aRank - 1);
+    Value bK = bDesc.size(rewriter, loc, bRank == 1 ? 0 : bRank - 2);
     Value n =
         bRank == 1 ? createI64Const(1) : bDesc.size(rewriter, loc, bRank - 1);
 
@@ -164,8 +165,10 @@ struct MatMulLowering : ConvertOpToLLVMPattern<MatMulOp> {
                                        aDesc.size(rewriter, loc, i));
     }
 
+    Value bBatchCount;
     Value bBatchStride;
     if (bRank <= 2) {
+      bBatchCount = createI64Const(1);
       bBatchStride = createI64Const(0);
     } else {
       bool allLeadingStatic = true;
@@ -178,30 +181,34 @@ struct MatMulLowering : ConvertOpToLLVMPattern<MatMulOp> {
         staticLeadingProduct *= bType.getDimSize(i);
       }
       if (allLeadingStatic) {
+        bBatchCount = createI64Const(staticLeadingProduct);
         bBatchStride =
             staticLeadingProduct <= 1
                 ? createI64Const(0)
-                : LLVM::MulOp::create(rewriter, loc, k, n).getResult();
+                : LLVM::MulOp::create(rewriter, loc, bK, n).getResult();
       } else {
         Value one = createI64Const(1);
         Value zero = createI64Const(0);
-        Value leadingProduct = one;
+        bBatchCount = one;
         for (int64_t i : llvm::seq<int64_t>(0, bRank - 2)) {
-          leadingProduct = LLVM::MulOp::create(rewriter, loc, leadingProduct,
-                                               bDesc.size(rewriter, loc, i));
+          bBatchCount = LLVM::MulOp::create(rewriter, loc, bBatchCount,
+                                            bDesc.size(rewriter, loc, i));
         }
         Value isBroadcast = LLVM::ICmpOp::create(
-            rewriter, loc, LLVM::ICmpPredicate::sle, leadingProduct, one);
-        Value kn = LLVM::MulOp::create(rewriter, loc, k, n);
+            rewriter, loc, LLVM::ICmpPredicate::sle, bBatchCount, one);
+        Value kn = LLVM::MulOp::create(rewriter, loc, bK, n);
         bBatchStride =
             LLVM::SelectOp::create(rewriter, loc, isBroadcast, zero, kn);
       }
     }
 
+    Value batchAxesValid = LLVM::ConstantOp::create(
+        rewriter, loc, rewriter.getI1Type(), rewriter.getBoolAttr(true));
+    Value aBatchStride = LLVM::MulOp::create(rewriter, loc, m, k);
     int64_t elementSize = aType.getElementType().getIntOrFloatBitWidth() / 8;
     using MatMulCall =
         RuntimeFunc<i32, hostPtr, slotIndex, devicePtr, devicePtr, devicePtr,
-                    i64, i64, i64, i64, i64, i64>;
+                    i1, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64>;
     auto matMulFunc = MatMulCall::lookupOrCreateFn(rewriter, loc, module,
                                                    kWrapHipblasLtMatmul);
     if (failed(matMulFunc)) {
@@ -209,8 +216,9 @@ struct MatMulLowering : ConvertOpToLLVMPattern<MatMulOp> {
     }
     if (failed(matMulFunc->call(adaptor.getCtx(), SlotIndex{op.getOperation()},
                                 adaptor.getA(), adaptor.getB(),
-                                adaptor.getInit(), m, n, k, batchCount,
-                                elementSize, bBatchStride))) {
+                                adaptor.getInit(), batchAxesValid, m, n, k, bK,
+                                batchCount, elementSize, batchCount,
+                                bBatchCount, aBatchStride, bBatchStride))) {
       return failure();
     }
     rewriter.eraseOp(op);

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -261,6 +261,7 @@ macro(compile_to_bitcode SOURCE_FILE OUTPUT_BC)
                 ${CMAKE_CURRENT_SOURCE_DIR}/hipdnn_ep_runtime.h
                 ${CMAKE_CURRENT_SOURCE_DIR}/runtime_state_internal.h
                 ${CMAKE_CURRENT_SOURCE_DIR}/tensor_buffer_internal.h
+                ${CMAKE_CURRENT_SOURCE_DIR}/matmul_gemm_contract.h
                 ${CMAKE_CURRENT_SOURCE_DIR}/op_state.h
                 ${CMAKE_CURRENT_SOURCE_DIR}/op_profile.h
                 ${CMAKE_CURRENT_SOURCE_DIR}/chrome_trace.h

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -427,7 +427,8 @@ int hipdnn_ep_state_ensure_la_scratch(RuntimeState *state, size_t needed_size);
 bool hipdnn_ep_op_states_alloc(RuntimeState *state, int64_t n);
 
 // Shared runtime error flag. Generated code records every nonzero operation
-// status here; kernels may also write the device pointer directly.
+// status here; kernels may write the device pointer directly, and wrappers can
+// queue a generic host-detected failure on the inference stream.
 void *hipdnn_ep_state_get_error_flag_device_ptr(RuntimeState *state);
 int hipdnn_ep_state_reset_error_flag(RuntimeState *state);
 int hipdnn_ep_state_set_error_flag(RuntimeState *state);
@@ -814,37 +815,28 @@ int wrap_hipblasLtGemm(void *handle, // hipBLASLt handle
                        const void *beta,  // Scalar beta
                        void *C);          // Matrix C GPU pointer (in/out)
 
-// MatMul operation wrapper (batched matrix multiplication)
-// Called by generated IR for onnx.MatMul lowering
-// Computes output = A @ B for each batch
-// A: [batch_count x M x K], B: [K x N] (broadcast) or [batch_count x K x N]
-// output: [batch_count x M x N]
+// HIP MatMul ABI. Either operand may contain one matrix broadcast across all
+// output batches or one matrix per output batch.
 //
-// `b_batch_stride` is hipBLASLt's STRIDED_BATCH_OFFSET on layA when
-// `batch_count > 1`: the per-batch advance in elements through B. It MUST be:
-//   * 0   when B is a broadcast weight — one matrix reused across all
-//         batches. Includes both rank-2 `[K, N]` and rank-N
-//         `[1, ..., 1, K, N]` (any leading-dim product == 1).
-//   * K*N when B is per-batch — leading-dim product > 1, so the buffer
-//         actually holds multiple `[K, N]` matrices laid out contiguously.
-// Mis-setting this to K*N for a broadcast B causes hipBLASLt to step K*N
-// elements past the end of the weight buffer on every batch beyond the
-// first, reading uninitialised memory into the GEMM and producing wrong
-// (often NaN) outputs for batch > 0. For batch_count == 1 the value is
-// ignored. Always pass an exact stride; the compiler computes 0 vs K*N
-// at compile time when B's leading dims are static, else at runtime.
-int wrap_hipblasLtMatmul(
-    RuntimeState *state,
-    int op_state_slot,       // per-instance op-state slot (shared algo table)
-    const void *A,           // Matrix A GPU pointer
-    const void *B,           // Matrix B GPU pointer
-    void *output,            // Output GPU pointer
-    int64_t M,               // Rows of A (per batch)
-    int64_t N,               // Columns of B
-    int64_t K,               // Columns of A / Rows of B
-    int64_t batch_count,     // Number of batches
-    int64_t elem_size,       // Element size in bytes (2=f16, 4=f32)
-    int64_t b_batch_stride); // 0 = broadcast (any rank); K*N = per-batch
+// `batch_axes_valid` is the lowering's per-axis right-aligned broadcast and
+// output-shape check. False records a recoverable error before cache/BLAS work.
+//
+// `a_batch_stride` / `b_batch_stride` are hipBLASLt's per-batch advances in
+// elements. A stride is 0 when one matrix is broadcast across all batches;
+// otherwise it is M*K_a for A or K_b*N for B.
+//
+// `a_batch_count` / `b_batch_count` are validated at runtime because dynamic
+// batch extents can conceal a partial per-axis broadcast from the static
+// verifier. Each count must be either 1 or `batch_count`; otherwise the wrapper
+// records a recoverable runtime error and does not dispatch hipBLASLt.
+// `K_a` and `K_b` are compared before cache lookup or descriptor creation.
+// Artifacts compiled against the earlier 11-argument ABI must be rebuilt.
+int wrap_hipblasLtMatmul(RuntimeState *state, int op_state_slot, const void *A,
+                         const void *B, void *output, bool batch_axes_valid,
+                         int64_t M, int64_t N, int64_t K_a, int64_t K_b,
+                         int64_t batch_count, int64_t elem_size,
+                         int64_t a_batch_count, int64_t b_batch_count,
+                         int64_t a_batch_stride, int64_t b_batch_stride);
 
 // GroupQueryAttention operation wrapper (Full MS spec)
 // Called by generated IR for onnx.Custom(GroupQueryAttention) lowering
@@ -1383,10 +1375,13 @@ int wrap_linear_attention(
 // ONNX Gemm via hipBLASLt
 //==============================================================================
 // Y = alpha * op(A) * op(B) + beta * C
-// op(A) shape: [M, K], op(B) shape: [K, N], C optional broadcastable to [M, N]
+// op(A) shape: [M, K_a], op(B) shape: [K_b, N].
+// K_a and K_b are checked before descriptors, cache lookup, or dispatch.
+// C is optional and broadcastable to [M, N]. This ABI is incompatible with
+// artifacts that passed one compiler-proven K.
 int wrap_gemm(RuntimeState *state, int op_state_slot, const void *A,
               const void *B, const void *C, void *output, int64_t M, int64_t N,
-              int64_t K, float alpha, float beta, int64_t transA,
+              int64_t K_a, int64_t K_b, float alpha, float beta, int64_t transA,
               int64_t transB, int64_t typeCode, int64_t cDim0, int64_t cDim1);
 
 // Element-wise Equal. Operand shapes are passed as 4D (N, C, H, W), left-

--- a/lib/Runtime/matmul_gemm_contract.h
+++ b/lib/Runtime/matmul_gemm_contract.h
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#ifndef HIPDNN_EP_MATMUL_GEMM_CONTRACT_H
+#define HIPDNN_EP_MATMUL_GEMM_CONTRACT_H
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+
+namespace hipdnn_ep {
+namespace blas_contract {
+
+struct OutputSize {
+  size_t elements = 0;
+  size_t bytes = 0;
+};
+
+inline bool checkedMul(size_t lhs, size_t rhs, size_t &result) {
+  if (rhs != 0 && lhs > std::numeric_limits<size_t>::max() / rhs)
+    return false;
+  result = lhs * rhs;
+  return true;
+}
+
+inline bool checkedI64Mul(int64_t lhs, int64_t rhs, int64_t &result) {
+  if (lhs < 0 || rhs < 0)
+    return false;
+  if (rhs != 0 && lhs > std::numeric_limits<int64_t>::max() / rhs)
+    return false;
+  result = lhs * rhs;
+  return true;
+}
+
+inline bool computeOutputSize(int64_t batch, int64_t m, int64_t n,
+                              int64_t elementBytes, OutputSize &result) {
+  if (batch < 0 || m < 0 || n < 0 || elementBytes <= 0)
+    return false;
+
+  int64_t elementsI64 = 0;
+  if (!checkedI64Mul(batch, m, elementsI64) ||
+      !checkedI64Mul(elementsI64, n, elementsI64))
+    return false;
+  size_t elements = static_cast<size_t>(elementsI64);
+
+  size_t bytes = 0;
+  if (!checkedMul(elements, static_cast<size_t>(elementBytes), bytes))
+    return false;
+  result = {elements, bytes};
+  return true;
+}
+
+inline bool validateMatrixProducts(int64_t m, int64_t n, int64_t kA,
+                                   int64_t kB) {
+  int64_t ignored = 0;
+  return kA >= 0 && kB >= 0 && checkedI64Mul(m, n, ignored) &&
+         checkedI64Mul(m, kA, ignored) && checkedI64Mul(kB, n, ignored);
+}
+
+inline int64_t gemmElementBytes(int64_t typeCode) {
+  switch (typeCode) {
+  case 0: // f16
+  case 3: // bf16
+    return 2;
+  case 1: // f32
+    return 4;
+  case 2: // f64
+    return 8;
+  default:
+    return -1;
+  }
+}
+
+enum class ValidationStatus {
+  Success,
+  EmptyOutput,
+  Failure,
+};
+
+struct ValidationResult {
+  ValidationStatus status = ValidationStatus::Success;
+  OutputSize outputSize;
+  bool outputSizeKnown = false;
+  const char *errorMessage = nullptr;
+};
+
+inline ValidationResult
+validateMatmul(bool batchAxesValid, int64_t m, int64_t n, int64_t kA,
+               int64_t kB, int64_t batchCount, int64_t elementBytes,
+               int64_t aBatchCount, int64_t bBatchCount, int64_t aBatchStride,
+               int64_t bBatchStride, bool hasA, bool hasB, bool hasOutput) {
+  ValidationResult result;
+  bool elementSizeSupported = elementBytes == 2 || elementBytes == 4;
+  result.outputSizeKnown =
+      elementSizeSupported &&
+      computeOutputSize(batchCount, m, n, elementBytes, result.outputSize);
+  auto fail = [&](const char *message) {
+    result.status = ValidationStatus::Failure;
+    result.errorMessage = message;
+    return result;
+  };
+
+  if (!batchAxesValid)
+    return fail("wrap_hipblasLtMatmul: invalid runtime batch axes");
+  if (!elementSizeSupported)
+    return fail("wrap_hipblasLtMatmul: unsupported element size");
+  if (!result.outputSizeKnown || !validateMatrixProducts(m, n, kA, kB) ||
+      aBatchCount < 0 || bBatchCount < 0 || aBatchStride < 0 ||
+      bBatchStride < 0)
+    return fail("wrap_hipblasLtMatmul: invalid or overflowing dimensions");
+  if (kA != kB)
+    return fail("wrap_hipblasLtMatmul: contraction dimensions do not match");
+  if ((aBatchCount != 1 && aBatchCount != batchCount) ||
+      (bBatchCount != 1 && bBatchCount != batchCount))
+    return fail("wrap_hipblasLtMatmul: runtime batch layout is not "
+                "representable by one stride per operand");
+  if (result.outputSize.elements == 0) {
+    result.status = ValidationStatus::EmptyOutput;
+    return result;
+  }
+  if (!hasA || !hasB || !hasOutput)
+    return fail("Invalid tensor pointer in wrap_hipblasLtMatmul");
+  return result;
+}
+
+inline ValidationResult validateGemm(int64_t m, int64_t n, int64_t kA,
+                                     int64_t kB, int64_t transA, int64_t transB,
+                                     int64_t typeCode, bool hasC, int64_t cDim0,
+                                     int64_t cDim1, bool hasA, bool hasB,
+                                     bool hasOutput) {
+  ValidationResult result;
+  result.outputSizeKnown = computeOutputSize(
+      /*batch=*/1, m, n, gemmElementBytes(typeCode), result.outputSize);
+  bool cShapeValid = !hasC ? cDim0 == 0 && cDim1 == 0
+                           : cDim0 >= 0 && cDim1 >= 0 &&
+                                 (cDim0 == 1 || cDim0 == m) &&
+                                 (cDim1 == 1 || cDim1 == n);
+  auto fail = [&](const char *message) {
+    result.status = ValidationStatus::Failure;
+    result.errorMessage = message;
+    return result;
+  };
+
+  if (!result.outputSizeKnown || !validateMatrixProducts(m, n, kA, kB) ||
+      (transA != 0 && transA != 1) || (transB != 0 && transB != 1) ||
+      !cShapeValid)
+    return fail("wrap_gemm: invalid or overflowing dimensions");
+  if (kA != kB)
+    return fail("wrap_gemm: contraction dimensions do not match");
+  if (result.outputSize.elements == 0) {
+    result.status = ValidationStatus::EmptyOutput;
+    return result;
+  }
+  if (!hasA || !hasB || !hasOutput)
+    return fail("wrap_gemm: invalid tensor pointer");
+  return result;
+}
+
+} // namespace blas_contract
+} // namespace hipdnn_ep
+
+#endif // HIPDNN_EP_MATMUL_GEMM_CONTRACT_H

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 #include "hipdnn_ep_runtime.h"
+#include "matmul_gemm_contract.h"
 #include "runtime_types.h"
 
 #include <cstdio>
@@ -35,6 +36,24 @@
 
 // Comprehensive mock implementations for all GPU functions
 // Prints all operations for debugging and verification
+
+#ifdef HIPDNN_EP_RUNTIME_TESTING
+static int mockMatmulDispatchCount = 0;
+static int mockGemmDispatchCount = 0;
+
+extern "C" void hipdnn_ep_mock_reset_blas_dispatch_counts() {
+  mockMatmulDispatchCount = 0;
+  mockGemmDispatchCount = 0;
+}
+
+extern "C" int hipdnn_ep_mock_matmul_dispatch_count() {
+  return mockMatmulDispatchCount;
+}
+
+extern "C" int hipdnn_ep_mock_gemm_dispatch_count() {
+  return mockGemmDispatchCount;
+}
+#endif
 
 // Mock HIP device functions
 extern "C" hipError_t hipGetDeviceCount(int *count) {
@@ -595,20 +614,88 @@ int wrap_hipblasLtGemm(void *handle, void *stream, int64_t m, int64_t n,
 }
 
 int wrap_hipblasLtMatmul(RuntimeState *state, int op_state_slot, const void *A,
-                         const void *B, void *output, int64_t M, int64_t N,
-                         int64_t K, int64_t batch_count, int64_t elem_size,
-                         int64_t b_batch_stride) {
-  (void)b_batch_stride;
+                         const void *B, void *output, bool batch_axes_valid,
+                         int64_t M, int64_t N, int64_t K_a, int64_t K_b,
+                         int64_t batch_count, int64_t elem_size,
+                         int64_t a_batch_count, int64_t b_batch_count,
+                         int64_t a_batch_stride, int64_t b_batch_stride) {
+  using namespace hipdnn_ep::blas_contract;
   (void)op_state_slot;
   if (!state) {
     fprintf(stderr, "Invalid state in wrap_hipblasLtMatmul\n");
     return -1;
   }
 
-  MOCK_PRINT("[MOCK] wrap_hipblasLtMatmul(M=%lld, N=%lld, K=%lld, "
-             "batch=%lld, elem_size=%lld)\n",
-             (long long)M, (long long)N, (long long)K, (long long)batch_count,
-             (long long)elem_size);
+  ValidationResult validation = validateMatmul(
+      batch_axes_valid, M, N, K_a, K_b, batch_count, elem_size, a_batch_count,
+      b_batch_count, a_batch_stride, b_batch_stride, A != nullptr, B != nullptr,
+      output != nullptr);
+  auto fail = [&]() {
+    (void)hipdnn_ep_state_set_error_flag(state);
+    if (validation.outputSizeKnown && validation.outputSize.bytes != 0 &&
+        output)
+      memset(output, 0, validation.outputSize.bytes);
+    return -1;
+  };
+
+  if (validation.status == ValidationStatus::EmptyOutput)
+    return 0;
+  if (validation.status != ValidationStatus::Success)
+    return fail();
+
+#ifdef HIPDNN_EP_RUNTIME_TESTING
+  ++mockMatmulDispatchCount;
+#endif
+
+  MOCK_PRINT("[MOCK] wrap_hipblasLtMatmul(M=%lld, N=%lld, K_a=%lld, "
+             "K_b=%lld, batch=%lld, elem_size=%lld, a_batches=%lld, "
+             "b_batches=%lld, a_batch_stride=%lld, b_batch_stride=%lld)\n",
+             (long long)M, (long long)N, (long long)K_a, (long long)K_b,
+             (long long)batch_count, (long long)elem_size,
+             (long long)a_batch_count, (long long)b_batch_count,
+             (long long)a_batch_stride, (long long)b_batch_stride);
+
+  return 0;
+}
+
+int wrap_gemm(RuntimeState *state, int op_state_slot, const void *A,
+              const void *B, const void *C, void *output, int64_t M, int64_t N,
+              int64_t K_a, int64_t K_b, float alpha, float beta, int64_t transA,
+              int64_t transB, int64_t typeCode, int64_t cDim0, int64_t cDim1) {
+  using namespace hipdnn_ep::blas_contract;
+  (void)op_state_slot;
+  (void)alpha;
+  (void)beta;
+  if (!state) {
+    fprintf(stderr, "Invalid state in wrap_gemm\n");
+    return -1;
+  }
+
+  ValidationResult validation =
+      validateGemm(M, N, K_a, K_b, transA, transB, typeCode, C != nullptr,
+                   cDim0, cDim1, A != nullptr, B != nullptr, output != nullptr);
+  auto fail = [&]() {
+    (void)hipdnn_ep_state_set_error_flag(state);
+    if (validation.outputSizeKnown && validation.outputSize.bytes != 0 &&
+        output)
+      memset(output, 0, validation.outputSize.bytes);
+    return -1;
+  };
+
+  if (validation.status == ValidationStatus::EmptyOutput)
+    return 0;
+  if (validation.status != ValidationStatus::Success)
+    return fail();
+
+#ifdef HIPDNN_EP_RUNTIME_TESTING
+  ++mockGemmDispatchCount;
+#endif
+
+  MOCK_PRINT("[MOCK] wrap_gemm(M=%lld, N=%lld, K_a=%lld, K_b=%lld, "
+             "transA=%lld, transB=%lld, typeCode=%lld, C=%s)\n",
+             (long long)M, (long long)N, (long long)K_a, (long long)K_b,
+             (long long)transA, (long long)transB, (long long)typeCode,
+             C ? "yes" : "null");
 
   return 0;
 }

--- a/lib/Runtime/real/gemm.cpp
+++ b/lib/Runtime/real/gemm.cpp
@@ -4,6 +4,7 @@
  */
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../matmul_gemm_contract.h"
 #include "../op_profile.h"
 #include "../op_state.h"
 #include "error_check_macros.h"
@@ -485,8 +486,43 @@ static GemmCacheEntry selectGemmAlgo(
 
 int wrap_gemm(RuntimeState *state, int op_state_slot, const void *A,
               const void *B, const void *C, void *output, int64_t M, int64_t N,
-              int64_t K, float alpha, float beta, int64_t transA,
+              int64_t K_a, int64_t K_b, float alpha, float beta, int64_t transA,
               int64_t transB, int64_t typeCode, int64_t cDim0, int64_t cDim1) {
+  using namespace hipdnn_ep::blas_contract;
+
+  ValidationResult validation =
+      validateGemm(M, N, K_a, K_b, transA, transB, typeCode, C != nullptr,
+                   cDim0, cDim1, A != nullptr, B != nullptr, output != nullptr);
+  const OutputSize &outputSize = validation.outputSize;
+  if (!state) {
+    fprintf(stderr, "wrap_gemm: invalid state\n");
+    return -1;
+  }
+
+  auto fail = [&](const char *message) {
+    if (message)
+      fprintf(stderr, "%s\n", message);
+    (void)hipdnn_ep_state_set_error_flag(state);
+    if (validation.outputSizeKnown && outputSize.bytes != 0 && output) {
+      hipStream_t failureStream =
+          static_cast<hipStream_t>(hipdnn_ep_state_get_stream(state));
+      if (failureStream) {
+        hipError_t zeroStatus =
+            hipMemsetAsync(output, 0, outputSize.bytes, failureStream);
+        if (zeroStatus != hipSuccess)
+          fprintf(stderr, "wrap_gemm: failed to zero invalid output (%d): %s\n",
+                  (int)zeroStatus, hipGetErrorString(zeroStatus));
+      }
+    }
+    return -1;
+  };
+
+  if (validation.status == ValidationStatus::EmptyOutput)
+    return 0;
+  if (validation.status == ValidationStatus::Failure)
+    return fail(validation.errorMessage);
+
+  int64_t K = K_a; // Cache and descriptors consume K only after equality.
   OP_PROFILE(
       "gemm",
       [&] {
@@ -496,10 +532,6 @@ int wrap_gemm(RuntimeState *state, int op_state_slot, const void *A,
         return std::string(b);
       },
       state);
-  if (!state || !A || !B || !output) {
-    fprintf(stderr, "wrap_gemm: invalid arguments\n");
-    return -1;
-  }
 
   hipblasLtHandle_t handle =
       static_cast<hipblasLtHandle_t>(hipdnn_ep_state_get_hipblas_handle(state));
@@ -507,14 +539,12 @@ int wrap_gemm(RuntimeState *state, int op_state_slot, const void *A,
       static_cast<hipStream_t>(hipdnn_ep_state_get_stream(state));
 
   if (!handle || !stream) {
-    fprintf(stderr, "wrap_gemm: null handle or stream\n");
-    return -1;
+    return fail("wrap_gemm: null handle or stream");
   }
 
   GemmState *gs = GemmState::get_op_state(state, op_state_slot);
   if (!gs || !gs->table) {
-    fprintf(stderr, "wrap_gemm: missing op-state for slot %d\n", op_state_slot);
-    return -1;
+    return fail("wrap_gemm: missing op-state");
   }
   GemmAlgoTable &table = *gs->table;
 
@@ -522,9 +552,7 @@ int wrap_gemm(RuntimeState *state, int op_state_slot, const void *A,
   hipblasComputeType_t computeType;
   hipDataType scaleType;
   if (!resolveGemmTypes(typeCode, dataType, computeType, scaleType)) {
-    fprintf(stderr, "wrap_gemm: unsupported typeCode %lld\n",
-            (long long)typeCode);
-    return -1;
+    return fail("wrap_gemm: unsupported typeCode");
   }
 
   // Fused-bias epilogue eligibility: a per-output-feature [N] / [1,N] bias
@@ -560,7 +588,7 @@ int wrap_gemm(RuntimeState *state, int op_state_slot, const void *A,
     int bc_result = broadcastBiasToOutput(state, C, output, M, N, cDim0, cDim1,
                                           beta, typeCode);
     if (bc_result != 0)
-      return bc_result;
+      return fail("wrap_gemm: bias broadcast failed");
   }
 
   // Select effective beta and C pointer for hipblasLtMatmul.
@@ -737,5 +765,7 @@ cleanup:
   if (matmul_desc)
     hipblasLtMatmulDescDestroy(matmul_desc);
 
+  if (result != 0)
+    return fail(nullptr);
   return result;
 }

--- a/lib/Runtime/real/matmul.cpp
+++ b/lib/Runtime/real/matmul.cpp
@@ -4,6 +4,7 @@
  */
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../matmul_gemm_contract.h"
 #include "../op_profile.h"
 #include "../op_state.h"
 #include "cache_utils.h"
@@ -45,22 +46,13 @@ static bool autotune_enabled() {
 
 struct MatmulCacheKey {
   int64_t M, N, K, batch_count, elem_size;
-  // hipBLASLt's STRIDED_BATCH_OFFSET on layA, in elements. Two distinct
-  // values reach this site at the same (M,N,K,batch,elem_size):
-  //   * 0   — B is a broadcast weight (rank-2 [K,N], or rank-N
-  //           [1,...,1,K,N] whose leading-dim product is 1).
-  //   * K*N — B is per-batch (leading-dim product > 1; the buffer holds
-  //           multiple [K,N] matrices laid out contiguously).
-  // Part of the cache key because the layout descriptor is parameterised
-  // by the stride: mixing the two would silently route one path through
-  // the other's stride and read past the end of a broadcast weight buffer.
-  // Keyed on the actual int stride (not a 0/1 bool) so any future site
-  // that legitimately uses a stride other than {0, K*N} also gets its
-  // own cache entry rather than aliasing one of these two.
-  int64_t b_batch_stride;
+  // hipBLASLt STRIDED_BATCH_OFFSET values for the user's A and B buffers.
+  // They are part of the key because both matrix layouts depend on them.
+  int64_t a_batch_stride, b_batch_stride;
   bool operator==(const MatmulCacheKey &o) const {
     return M == o.M && N == o.N && K == o.K && batch_count == o.batch_count &&
-           elem_size == o.elem_size && b_batch_stride == o.b_batch_stride;
+           elem_size == o.elem_size && a_batch_stride == o.a_batch_stride &&
+           b_batch_stride == o.b_batch_stride;
   }
 };
 
@@ -72,15 +64,17 @@ struct MatmulCacheKeyHash {
     hash_combine_val(h, k.K);
     hash_combine_val(h, k.batch_count);
     hash_combine_val(h, k.elem_size);
+    hash_combine_val(h, k.a_batch_stride);
     hash_combine_val(h, k.b_batch_stride);
     return h;
   }
 };
 
 /// Cached hipBLASLt descriptors + multi-algorithm auto-tune state for a
-/// single (M, N, K, batch, elem_size) shape. Descriptors are created in
-/// queryOrCreateMatmul() and owned by the MatmulAlgoTable, which frees them
-/// when the last session sharing it is destroyed.
+/// single (M, N, K, batch, elem_size, A stride, B stride) configuration.
+/// Descriptors are created in queryOrCreateMatmul() and owned by the
+/// MatmulAlgoTable, which frees them when the last session sharing it is
+/// destroyed.
 struct MatmulCacheEntry {
   hipblasLtMatmulDesc_t desc;
   hipblasLtMatrixLayout_t layA, layB, layC;
@@ -198,19 +192,10 @@ static MatmulCacheEntry *queryOrCreateMatmul(MatmulAlgoTable &table,
 
   if (key.batch_count > 1) {
     int64_t bc = key.batch_count;
-    // layA → user's B. The stride is whatever the compiler computed —
-    // 0 for broadcast B (rank-2 [K,N] or rank-N [1,...,1,K,N]), K*N for
-    // per-batch B (rank-N with leading-dim product > 1). Setting sA = K*N
-    // for a broadcast weight reads K*N elements PAST the end of the
-    // buffer on batch 1+ and feeds garbage into the GEMM — typical symptom
-    // on vision models is image-0 correct, image-1+ NaN (the OOB read
-    // often lands in a fp16-NaN pattern from adjacent pool slots /
-    // constants). Mis-setting sA = 0 for a per-batch B does the opposite:
-    // every batch reads matrix 0 instead of its own.
-    // layB → user's A and layC → output are always per-batch (the BATCH
-    // partition comes from A's leading dim by construction).
+    // Row-major -> column-major swaps operands: layA describes user's B and
+    // layB describes user's A.
     int64_t sA = key.b_batch_stride;
-    int64_t sB = M * K, sC = M * N;
+    int64_t sB = key.a_batch_stride, sC = M * N;
     MATMUL_CACHE_CHECK(hipblasLtMatrixLayoutSetAttribute(
         entry.layA, HIPBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &bc, sizeof(bc)));
     MATMUL_CACHE_CHECK(hipblasLtMatrixLayoutSetAttribute(
@@ -433,9 +418,49 @@ static void autotuneMatmul(hipblasLtHandle_t handle, hipStream_t stream,
 //===----------------------------------------------------------------------===//
 
 int wrap_hipblasLtMatmul(RuntimeState *state, int op_state_slot, const void *A,
-                         const void *B, void *output, int64_t M, int64_t N,
-                         int64_t K, int64_t batch_count, int64_t elem_size,
-                         int64_t b_batch_stride) {
+                         const void *B, void *output, bool batch_axes_valid,
+                         int64_t M, int64_t N, int64_t K_a, int64_t K_b,
+                         int64_t batch_count, int64_t elem_size,
+                         int64_t a_batch_count, int64_t b_batch_count,
+                         int64_t a_batch_stride, int64_t b_batch_stride) {
+  using namespace hipdnn_ep::blas_contract;
+
+  ValidationResult validation = validateMatmul(
+      batch_axes_valid, M, N, K_a, K_b, batch_count, elem_size, a_batch_count,
+      b_batch_count, a_batch_stride, b_batch_stride, A != nullptr, B != nullptr,
+      output != nullptr);
+  const OutputSize &outputSize = validation.outputSize;
+  if (!state) {
+    fprintf(stderr, "Invalid state in wrap_hipblasLtMatmul\n");
+    return -1;
+  }
+
+  auto fail = [&](const char *message) {
+    if (message)
+      fprintf(stderr, "%s\n", message);
+    (void)hipdnn_ep_state_set_error_flag(state);
+    if (validation.outputSizeKnown && outputSize.bytes != 0 && output) {
+      hipStream_t failureStream =
+          static_cast<hipStream_t>(hipdnn_ep_state_get_stream(state));
+      if (failureStream) {
+        hipError_t zeroStatus =
+            hipMemsetAsync(output, 0, outputSize.bytes, failureStream);
+        if (zeroStatus != hipSuccess)
+          fprintf(stderr,
+                  "wrap_hipblasLtMatmul: failed to zero invalid output "
+                  "(%d): %s\n",
+                  (int)zeroStatus, hipGetErrorString(zeroStatus));
+      }
+    }
+    return -1;
+  };
+
+  if (validation.status == ValidationStatus::EmptyOutput)
+    return 0;
+  if (validation.status == ValidationStatus::Failure)
+    return fail(validation.errorMessage);
+
+  int64_t K = K_a; // Cache and descriptors consume K only after equality.
   OP_PROFILE(
       "matmul",
       [&] {
@@ -445,10 +470,6 @@ int wrap_hipblasLtMatmul(RuntimeState *state, int op_state_slot, const void *A,
         return std::string(b);
       },
       state);
-  if (!state || !A || !B || !output) {
-    fprintf(stderr, "Invalid arguments to wrap_hipblasLtMatmul\n");
-    return -1;
-  }
 
   hipblasLtHandle_t handle =
       static_cast<hipblasLtHandle_t>(hipdnn_ep_state_get_hipblas_handle(state));
@@ -456,40 +477,34 @@ int wrap_hipblasLtMatmul(RuntimeState *state, int op_state_slot, const void *A,
       static_cast<hipStream_t>(hipdnn_ep_state_get_stream(state));
 
   if (!handle || !stream) {
-    fprintf(stderr, "wrap_hipblasLtMatmul: null handle or stream\n");
-    return -1;
-  }
-
-  if (elem_size != 2 && elem_size != 4) {
-    fprintf(stderr, "wrap_hipblasLtMatmul: unsupported elem_size %lld\n",
-            (long long)elem_size);
-    return -1;
+    return fail("wrap_hipblasLtMatmul: null handle or stream");
   }
 
   const char *type_name = (elem_size == 2) ? "f16" : "f32";
   RUNTIME_DEBUG_LOG("[REAL] wrap_hipblasLtMatmul: M=%lld, N=%lld, K=%lld, "
-                    "batch=%lld, b_batch_stride=%lld, elem_size=%lld (%s), "
-                    "total_bytes=%lld\n",
+                    "batch=%lld, a_batches=%lld, b_batches=%lld, "
+                    "a_batch_stride=%lld, b_batch_stride=%lld, "
+                    "elem_size=%lld (%s), total_bytes=%lld\n",
                     (long long)M, (long long)N, (long long)K,
-                    (long long)batch_count, (long long)b_batch_stride,
-                    (long long)elem_size, type_name,
+                    (long long)batch_count, (long long)a_batch_count,
+                    (long long)b_batch_count, (long long)a_batch_stride,
+                    (long long)b_batch_stride, (long long)elem_size, type_name,
                     (long long)(batch_count * M * N * elem_size));
 
   MatmulState *ms = MatmulState::get_op_state(state, op_state_slot);
   if (!ms || !ms->table) {
-    fprintf(stderr, "wrap_hipblasLtMatmul: missing op-state for slot %d\n",
-            op_state_slot);
-    return -1;
+    return fail("wrap_hipblasLtMatmul: missing op-state");
   }
 
-  MatmulCacheKey key{M, N, K, batch_count, elem_size, b_batch_stride};
+  MatmulCacheKey key{
+      M, N, K, batch_count, elem_size, a_batch_stride, b_batch_stride};
   MatmulCacheEntry *cached = queryOrCreateMatmul(*ms->table, handle, key);
   if (!cached) {
     fprintf(stderr,
             "wrap_hipblasLtMatmul: failed to create/find cached "
             "descriptors for M=%lld N=%lld K=%lld batch=%lld\n",
             (long long)M, (long long)N, (long long)K, (long long)batch_count);
-    return -1;
+    return fail(nullptr);
   }
 
   // Ensure workspace is large enough for auto-tune candidates (if pending)
@@ -498,7 +513,7 @@ int wrap_hipblasLtMatmul(RuntimeState *state, int op_state_slot, const void *A,
       cached->tuned ? cached->workspace_size : cached->max_candidate_workspace;
   if (needed_ws > 0) {
     if (hipdnn_ep_state_ensure_workspace(state, needed_ws) != 0)
-      return -1;
+      return fail("wrap_hipblasLtMatmul: workspace allocation failed");
   }
 
   void *ws_ptr = hipdnn_ep_state_get_workspace(state);
@@ -540,7 +555,7 @@ int wrap_hipblasLtMatmul(RuntimeState *state, int op_state_slot, const void *A,
 
   if (st != HIPBLAS_STATUS_SUCCESS) {
     fprintf(stderr, "wrap_hipblasLtMatmul: hipblasLtMatmul failed (%d)\n", st);
-    return -1;
+    return fail(nullptr);
   }
 
   RUNTIME_DEBUG_LOG("[REAL] wrap_hipblasLtMatmul: completed successfully\n");

--- a/test/lit/Conversion/hip-to-llvm/test_gemm.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_gemm.mlir
@@ -13,12 +13,12 @@
 // - Attributes: alpha, beta, transA, transB passed as constants
 // - M/N/K dimensions extracted correctly (respecting transA/transB)
 // - C shape (cDim0, cDim1) extracted and passed for broadcast support
-// - 16-param signature: state, A, B, C, output, M, N, K,
+// - 17-param signature: state, A, B, C, output, M, N, K_a, K_b,
 //                        alpha, beta, transA, transB, typeCode, cDim0, cDim1,
 //                        op_state_slot
 //
 // Expected: wrap_gemm(state, A_ptr, B_ptr, C_ptr, output_ptr,
-//             M, N, K, alpha, beta, transA, transB, typeCode, cDim0, cDim1,
+//             M, N, K_a, K_b, alpha, beta, transA, transB, typeCode, cDim0, cDim1,
 //             op_state_slot)
 // ============================================================================
 
@@ -39,7 +39,7 @@ module {
     hip.gemm(%ctx) ins(%a, %b, %c : memref<1x5120xf16, 1>, memref<5120x5120xf16, 1>, memref<5120xf16, 1>)
                    outs(%y : memref<1x5120xf16, 1>)
 
-    // CHECK: llvm.call @wrap_gemm({{.*}}) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, f32, f32, i64, i64, i64, i64, i64) -> i32
+    // CHECK: llvm.call @wrap_gemm({{.*}}) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, f32, f32, i64, i64, i64, i64, i64) -> i32
 
     return
   }
@@ -59,7 +59,7 @@ module {
 
     // null pointer for absent C
     // CHECK: llvm.mlir.zero
-    // CHECK: llvm.call @wrap_gemm({{.*}}) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, f32, f32, i64, i64, i64, i64, i64) -> i32
+    // CHECK: llvm.call @wrap_gemm({{.*}}) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, f32, f32, i64, i64, i64, i64, i64) -> i32
 
     return
   }
@@ -79,7 +79,7 @@ module {
                    outs(%y : memref<1x512xf16, 1>)
                    {transB = 1 : i64}
 
-    // CHECK: llvm.call @wrap_gemm({{.*}}) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, f32, f32, i64, i64, i64, i64, i64) -> i32
+    // CHECK: llvm.call @wrap_gemm({{.*}}) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, f32, f32, i64, i64, i64, i64, i64) -> i32
 
     return
   }
@@ -99,7 +99,7 @@ module {
                    outs(%y : memref<128x512xf32, 1>)
                    {alpha = 2.000000e+00 : f32, beta = 5.000000e-01 : f32, transA = 1 : i64}
 
-    // CHECK: llvm.call @wrap_gemm({{.*}}) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, f32, f32, i64, i64, i64, i64, i64) -> i32
+    // CHECK: llvm.call @wrap_gemm({{.*}}) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, f32, f32, i64, i64, i64, i64, i64) -> i32
 
     return
   }
@@ -118,8 +118,28 @@ module {
     hip.gemm(%ctx) ins(%a, %b, %c : memref<128x256xf32, 1>, memref<256x512xf32, 1>, memref<128x512xf32, 1>)
                    outs(%y : memref<128x512xf32, 1>)
 
-    // CHECK: llvm.call @wrap_gemm({{.*}}) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, f32, f32, i64, i64, i64, i64, i64) -> i32
+    // CHECK: llvm.call @wrap_gemm({{.*}}) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, f32, f32, i64, i64, i64, i64, i64) -> i32
 
+    return
+  }
+
+  // Test 6: transpose-aware dynamic contraction extraction.
+  // transA=1 takes K_a from A.dim0; transB=1 takes K_b from B.dim1.
+  func.func @gemm_dynamic_k_transposed(
+      %ctx: !hip.context,
+      %a: memref<?x2xf16, 1>,
+      %b: memref<3x?xf16, 1>,
+      %y: memref<2x3xf16, 1>) {
+    // CHECK-LABEL: llvm.func @gemm_dynamic_k_transposed
+    // CHECK: %[[KA:.*]] = llvm.extractvalue {{.*}}[3, 0]
+    // CHECK: %[[KB:.*]] = llvm.extractvalue {{.*}}[3, 1]
+
+    hip.gemm(%ctx)
+      ins(%a, %b : memref<?x2xf16, 1>, memref<3x?xf16, 1>)
+      outs(%y : memref<2x3xf16, 1>)
+      {transA = 1 : i64, transB = 1 : i64}
+
+    // CHECK: llvm.call @wrap_gemm({{.*}}, %[[KA]], %[[KB]], {{.*}}) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, f32, f32, i64, i64, i64, i64, i64) -> i32
     return
   }
 }

--- a/test/lit/Conversion/hip-to-llvm/test_matmul.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_matmul.mlir
@@ -3,11 +3,21 @@
 
 // RUN: hip-mlir-opt --convert-hip-to-llvm %s | FileCheck %s
 
-// ----- Rank-2 broadcast B [K, N] ---------------------------------------------
-// b_batch_stride MUST be a constant 0 (no leading dims to multiply).
-// `CHECK-NOT` between the label and the call asserts the compile-time
-// constant path was taken (no runtime `llvm.icmp` / `llvm.select` over a
-// leading-dim product).
+// `wrap_hipblasLtMatmul` takes 16 arguments:
+//   - 4 pointers: state, A, B, output
+//   - 1 i1: right-aligned per-axis batch/output validity
+//   - 10 i64: M, N, K_a, K_b, output batch count, element size,
+//            A/B operand batch counts, A/B strides
+//   - 1 i32: op_state_slot (-1 here; --assign-op-state-slots is not in this RUN)
+//
+// Each operand's stride is 0 when it holds a single matrix broadcast across the
+// output batches, and the matrix size when it holds one matrix per output batch.
+// The two strides are the last arguments, so each case anchors on the
+// `elem_size` constant (2 for f16) that immediately precedes them.
+
+// ----- Both operands hold a single matrix ------------------------------------
+// A's leading dim is statically 1 and B is rank 2, so both strides fold to a
+// compile-time 0. Per-axis runtime validation is still emitted independently.
 
 module {
   func.func @test_matmul_rank2_b(%ctx: !hip.context,
@@ -22,22 +32,19 @@ module {
 }
 
 // CHECK-LABEL: llvm.func @test_matmul_rank2_b
-// CHECK-NOT: llvm.icmp
-// CHECK-NOT: llvm.select
-// CHECK: llvm.call @wrap_hipblasLtMatmul({{.*}}) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64) -> i32
-// Verify 11 parameters:
-// - 4 pointers: state, A, B, output
-// - 6 i64: M=128, N=1024, K=4096, batch_count=1, elem_size=2, b_batch_stride=0
-//   (B is rank-2 [K, N] = broadcast weight → stride = 0, compile-time const)
-// - 1 i32: op_state_slot (-1 here — --assign-op-state-slots not run in this RUN)
+// CHECK-NOT: @wrap_hipblasLtMatmul(
+// CHECK: %[[ELEM0:.*]] = llvm.mlir.constant(2 : i64) : i64
+// CHECK: %[[A0_COUNT:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK: %[[B0_COUNT:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK: %[[A0_STRIDE:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK: %[[B0_STRIDE:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK: llvm.call @wrap_hipblasLtMatmul({{.*}}, %[[ELEM0]], %[[A0_COUNT]], %[[B0_COUNT]], %[[A0_STRIDE]], %[[B0_STRIDE]]) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, i1, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
 
 // ----- Rank-3 leading-one B [1, K, N] ----------------------------------------
-// Leading dim is statically 1: still ONE [K, N] matrix in the buffer, so
-// b_batch_stride must be 0 (NOT K*N). The compiler folds this at compile
-// time when all leading dims are static — verified via CHECK-NOT for icmp /
-// select. Encoding this case as "rank > 2 ⇒ per-batch" (the prior `b_batched`
-// bool rule) caused hipBLASLt to step K*N elements past the end of the
-// weight buffer on batch > 0 and feed garbage into the GEMM.
+// B's leading dim is statically 1, so the buffer still holds ONE [K, N] matrix
+// and its stride must be 0, not K*N. Treating "rank > 2" as per-batch made
+// hipBLASLt step K*N elements past the end of the weight on batch > 0 and feed
+// garbage into the GEMM. A carries two batches and gets stride M*K.
 
 module {
   func.func @test_matmul_rank3_leading_one_b(%ctx: !hip.context,
@@ -52,6 +59,139 @@ module {
 }
 
 // CHECK-LABEL: llvm.func @test_matmul_rank3_leading_one_b
-// CHECK-NOT: llvm.icmp
-// CHECK-NOT: llvm.select
-// CHECK: llvm.call @wrap_hipblasLtMatmul({{.*}}) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64) -> i32
+// CHECK-NOT: @wrap_hipblasLtMatmul(
+// CHECK: %[[ELEM1:.*]] = llvm.mlir.constant(2 : i64) : i64
+// CHECK: %[[A1_COUNT:.*]] = llvm.mlir.constant(2 : i64) : i64
+// CHECK: %[[B1_COUNT:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK: %[[A1_STRIDE:.*]] = llvm.mul %{{.*}}, %{{.*}} : i64
+// CHECK: %[[B1_STRIDE:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK: llvm.call @wrap_hipblasLtMatmul({{.*}}, %[[ELEM1]], %[[A1_COUNT]], %[[B1_COUNT]], %[[A1_STRIDE]], %[[B1_STRIDE]]) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, i1, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
+
+// ----- Rank-2 broadcast A against rank-3 B -----------------------------------
+// The mirror image of the case above: A holds one matrix (stride 0) while B and
+// the output carry two batches (stride K*N). Independent per-operand strides are
+// what let either whole matrix broadcast across the other's batches.
+
+module {
+  func.func @test_matmul_rank2_a(%ctx: !hip.context,
+                                 %A: memref<128x4096xf16, 1>,
+                                 %B: memref<2x4096x1024xf16, 1>,
+                                 %output: memref<2x128x1024xf16, 1>) {
+    hip.matmul(%ctx)
+        ins(%A, %B : memref<128x4096xf16, 1>, memref<2x4096x1024xf16, 1>)
+        outs(%output : memref<2x128x1024xf16, 1>)
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @test_matmul_rank2_a
+// CHECK-NOT: @wrap_hipblasLtMatmul(
+// CHECK: %[[ELEM2:.*]] = llvm.mlir.constant(2 : i64) : i64
+// CHECK: %[[A2_COUNT:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK: %[[B2_COUNT:.*]] = llvm.mlir.constant(2 : i64) : i64
+// CHECK: %[[A2_STRIDE:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK: %[[B2_STRIDE:.*]] = llvm.mul %{{.*}}, %{{.*}} : i64
+// CHECK: llvm.call @wrap_hipblasLtMatmul({{.*}}, %[[ELEM2]], %[[A2_COUNT]], %[[B2_COUNT]], %[[A2_STRIDE]], %[[B2_STRIDE]]) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, i1, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
+
+// ----- Single-axis dynamic batch on both operands ----------------------------
+// With one batch axis, each operand necessarily contains either one matrix or
+// one matrix per output batch for every valid broadcast. Runtime stride
+// selection can therefore represent both operands without extra metadata.
+
+module {
+  func.func @test_matmul_dynamic_batch(%ctx: !hip.context,
+                                       %A: memref<?x4x16xf16, 1>,
+                                       %B: memref<?x16x32xf16, 1>,
+                                       %output: memref<?x4x32xf16, 1>) {
+    hip.matmul(%ctx)
+        ins(%A, %B : memref<?x4x16xf16, 1>, memref<?x16x32xf16, 1>)
+        outs(%output : memref<?x4x32xf16, 1>)
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @test_matmul_dynamic_batch
+// CHECK: %[[ELEM3:.*]] = llvm.mlir.constant(2 : i64) : i64
+// CHECK: %[[A3_COUNT:.*]] = llvm.mul
+// CHECK: %[[B3_COUNT:.*]] = llvm.mul
+// CHECK: %[[A3_CMP:.*]] = llvm.icmp "eq" %[[A3_COUNT]],
+// CHECK: %[[A3_STRIDE:.*]] = llvm.select %[[A3_CMP]]
+// CHECK: %[[B3_CMP:.*]] = llvm.icmp "eq" %[[B3_COUNT]],
+// CHECK: %[[B3_STRIDE:.*]] = llvm.select %[[B3_CMP]]
+// CHECK: llvm.call @wrap_hipblasLtMatmul({{.*}}, %[[ELEM3]], %[[A3_COUNT]], %[[B3_COUNT]], %[[A3_STRIDE]], %[[B3_STRIDE]]) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, i1, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
+
+// ----- Dynamic K from both operands ------------------------------------------
+// The ABI receives A[-1] and B[-2] independently. B's matrix stride must use
+// B's K, not A's K, so a runtime mismatch cannot make the lowering address B
+// with an unrelated extent before the wrapper rejects it.
+
+module {
+  func.func @test_matmul_dynamic_k(%ctx: !hip.context,
+                                    %A: memref<2x?x?xf16, 1>,
+                                    %B: memref<2x?x?xf16, 1>,
+                                    %output: memref<2x?x?xf16, 1>) {
+    hip.matmul(%ctx)
+        ins(%A, %B : memref<2x?x?xf16, 1>, memref<2x?x?xf16, 1>)
+        outs(%output : memref<2x?x?xf16, 1>)
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @test_matmul_dynamic_k
+// CHECK: %[[M:.*]] = llvm.extractvalue {{.*}}[3, 1]
+// CHECK: %[[KA:.*]] = llvm.extractvalue {{.*}}[3, 2]
+// CHECK: %[[KB:.*]] = llvm.extractvalue {{.*}}[3, 1]
+// CHECK: %[[N:.*]] = llvm.extractvalue {{.*}}[3, 2]
+// CHECK: %[[B_STRIDE:.*]] = llvm.mul %[[KB]], %[[N]] : i64
+// CHECK: llvm.call @wrap_hipblasLtMatmul({{.*}}, %[[M]], %[[N]], %[[KA]], %[[KB]], {{.*}}, %[[B_STRIDE]]) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, i1, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
+
+// ----- Gemma-shaped multi-axis dynamic batches ------------------------------
+// Both operand counts multiply both dynamic batch extents. Each stride selects
+// matrix-size only when that count equals the output count; a partial runtime
+// broadcast therefore reaches the runtime wrapper with an intermediate count
+// and is rejected before BLAS.
+
+module {
+  func.func @test_matmul_gemma_dynamic_batches(
+      %ctx: !hip.context,
+      %A: memref<?x?x4x16xf16, 1>,
+      %B: memref<?x?x16x32xf16, 1>,
+      %output: memref<?x?x4x32xf16, 1>) {
+    hip.matmul(%ctx)
+        ins(%A, %B : memref<?x?x4x16xf16, 1>,
+             memref<?x?x16x32xf16, 1>)
+        outs(%output : memref<?x?x4x32xf16, 1>)
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @test_matmul_gemma_dynamic_batches
+// CHECK: %[[A0_EQ_B0:.*]] = llvm.icmp "eq"
+// CHECK: %[[A0_ONE:.*]] = llvm.icmp "eq"
+// CHECK: %[[B0_ONE:.*]] = llvm.icmp "eq"
+// CHECK: %[[EITHER0:.*]] = llvm.or %[[A0_ONE]], %[[B0_ONE]]
+// CHECK: %[[COMPAT0:.*]] = llvm.or %[[A0_EQ_B0]], %[[EITHER0]]
+// CHECK: %[[EXPECTED0:.*]] = llvm.select %[[A0_ONE]]
+// CHECK: %[[OUT_MATCH0:.*]] = llvm.icmp "eq" {{.*}}, %[[EXPECTED0]]
+// CHECK: %[[AXIS0:.*]] = llvm.and %[[COMPAT0]], %[[OUT_MATCH0]]
+// CHECK: %[[VALID0:.*]] = llvm.and {{.*}}, %[[AXIS0]]
+// CHECK: %[[A1_EQ_B1:.*]] = llvm.icmp "eq"
+// CHECK: %[[A1_ONE:.*]] = llvm.icmp "eq"
+// CHECK: %[[B1_ONE:.*]] = llvm.icmp "eq"
+// CHECK: %[[EITHER1:.*]] = llvm.or %[[A1_ONE]], %[[B1_ONE]]
+// CHECK: %[[COMPAT1:.*]] = llvm.or %[[A1_EQ_B1]], %[[EITHER1]]
+// CHECK: %[[EXPECTED1:.*]] = llvm.select %[[A1_ONE]]
+// CHECK: %[[OUT_MATCH1:.*]] = llvm.icmp "eq" {{.*}}, %[[EXPECTED1]]
+// CHECK: %[[AXIS1:.*]] = llvm.and %[[COMPAT1]], %[[OUT_MATCH1]]
+// CHECK: %[[BATCH_VALID:.*]] = llvm.and %[[VALID0]], %[[AXIS1]]
+// CHECK: %[[OUT_BATCH0:.*]] = llvm.mul
+// CHECK: %[[OUT_BATCH:.*]] = llvm.mul %[[OUT_BATCH0]],
+// CHECK: %[[A_COUNT0:.*]] = llvm.mul
+// CHECK: %[[A_COUNT:.*]] = llvm.mul %[[A_COUNT0]],
+// CHECK: %[[B_COUNT0:.*]] = llvm.mul
+// CHECK: %[[B_COUNT:.*]] = llvm.mul %[[B_COUNT0]],
+// CHECK: %[[A_MATCH:.*]] = llvm.icmp "eq" %[[A_COUNT]], %[[OUT_BATCH]]
+// CHECK: %[[A_STRIDE:.*]] = llvm.select %[[A_MATCH]]
+// CHECK: %[[B_MATCH:.*]] = llvm.icmp "eq" %[[B_COUNT]], %[[OUT_BATCH]]
+// CHECK: %[[B_STRIDE2:.*]] = llvm.select %[[B_MATCH]]
+// CHECK: llvm.call @wrap_hipblasLtMatmul({{.*}}, %[[BATCH_VALID]], {{.*}}, %[[OUT_BATCH]], {{.*}}, %[[A_COUNT]], %[[B_COUNT]], %[[A_STRIDE]], %[[B_STRIDE2]])

--- a/test/lit/Conversion/hipsr-to-llvm/matmul.mlir
+++ b/test/lit/Conversion/hipsr-to-llvm/matmul.mlir
@@ -7,15 +7,19 @@
 // CHECK-SAME:  (%[[CTX:.*]]: !llvm.ptr,
 // CHECK:       %[[M:.*]] = llvm.extractvalue {{.*}}[3, 0]
 // CHECK-NEXT:  %[[K:.*]] = llvm.extractvalue {{.*}}[3, 1]
+// CHECK-NEXT:  %[[B_K:.*]] = llvm.extractvalue {{.*}}[3, 0]
 // CHECK-NEXT:  %[[N:.*]] = llvm.extractvalue {{.*}}[3, 1]
 // CHECK-NEXT:  %[[BATCH:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK-NEXT:  %[[B_COUNT:.*]] = llvm.mlir.constant(1 : i64) : i64
 // CHECK-NEXT:  %[[B_STRIDE:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-NEXT:  %[[VALID:.*]] = llvm.mlir.constant({{.*}}) : i1
+// CHECK-NEXT:  %[[A_STRIDE:.*]] = llvm.mul %[[M]], %[[K]] : i64
 // CHECK-NEXT:  %[[SLOT:.*]] = llvm.mlir.constant(-1 : i32) : i32
 // CHECK-NEXT:  %[[A_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
 // CHECK-NEXT:  %[[B_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
 // CHECK-NEXT:  %[[OUT_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
 // CHECK-NEXT:  %[[ELEM_SIZE:.*]] = llvm.mlir.constant(2 : i64) : i64
-// CHECK-NEXT:  llvm.call @wrap_hipblasLtMatmul(%[[CTX]], %[[SLOT]], %[[A_PTR]], %[[B_PTR]], %[[OUT_PTR]], %[[M]], %[[N]], %[[K]], %[[BATCH]], %[[ELEM_SIZE]], %[[B_STRIDE]]) : (!llvm.ptr, i32, !llvm.ptr<1>, !llvm.ptr<1>, !llvm.ptr<1>, i64, i64, i64, i64, i64, i64) -> i32
+// CHECK-NEXT:  llvm.call @wrap_hipblasLtMatmul(%[[CTX]], %[[SLOT]], %[[A_PTR]], %[[B_PTR]], %[[OUT_PTR]], %[[VALID]], %[[M]], %[[N]], %[[K]], %[[B_K]], %[[BATCH]], %[[ELEM_SIZE]], %[[BATCH]], %[[B_COUNT]], %[[A_STRIDE]], %[[B_STRIDE]]) : (!llvm.ptr, i32, !llvm.ptr<1>, !llvm.ptr<1>, !llvm.ptr<1>, i1, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
 // CHECK-NEXT:  llvm.return
 func.func @matmul_rank2(
     %ctx: !hipsr.context,
@@ -33,6 +37,7 @@ func.func @matmul_rank2(
 // CHECK-SAME:  (%[[DYN_CTX:.*]]: !llvm.ptr,
 // CHECK:       %[[DYN_M:.*]] = llvm.extractvalue {{.*}}[3, 1]
 // CHECK-NEXT:  %[[DYN_K:.*]] = llvm.extractvalue {{.*}}[3, 2]
+// CHECK-NEXT:  %[[DYN_B_K:.*]] = llvm.extractvalue {{.*}}[3, 1]
 // CHECK-NEXT:  %[[DYN_N:.*]] = llvm.extractvalue {{.*}}[3, 2]
 // CHECK-NEXT:  %[[BATCH_INIT:.*]] = llvm.mlir.constant(1 : i64) : i64
 // CHECK-NEXT:  %[[A_BATCH_DIM:.*]] = llvm.extractvalue {{.*}}[3, 0]
@@ -40,16 +45,18 @@ func.func @matmul_rank2(
 // CHECK-NEXT:  %[[ONE:.*]] = llvm.mlir.constant(1 : i64) : i64
 // CHECK-NEXT:  %[[ZERO:.*]] = llvm.mlir.constant(0 : i64) : i64
 // CHECK-NEXT:  %[[B_BATCH_DIM:.*]] = llvm.extractvalue {{.*}}[3, 0]
-// CHECK-NEXT:  %[[LEADING_PRODUCT:.*]] = llvm.mul %[[ONE]], %[[B_BATCH_DIM]] : i64
-// CHECK-NEXT:  %[[IS_BROADCAST:.*]] = llvm.icmp "sle" %[[LEADING_PRODUCT]], %[[ONE]] : i64
-// CHECK-NEXT:  %[[KN:.*]] = llvm.mul %[[DYN_K]], %[[DYN_N]] : i64
+// CHECK-NEXT:  %[[B_COUNT:.*]] = llvm.mul %[[ONE]], %[[B_BATCH_DIM]] : i64
+// CHECK-NEXT:  %[[IS_BROADCAST:.*]] = llvm.icmp "sle" %[[B_COUNT]], %[[ONE]] : i64
+// CHECK-NEXT:  %[[KN:.*]] = llvm.mul %[[DYN_B_K]], %[[DYN_N]] : i64
 // CHECK-NEXT:  %[[DYN_B_STRIDE:.*]] = llvm.select %[[IS_BROADCAST]], %[[ZERO]], %[[KN]] : i1, i64
+// CHECK-NEXT:  %[[DYN_VALID:.*]] = llvm.mlir.constant({{.*}}) : i1
+// CHECK-NEXT:  %[[DYN_A_STRIDE:.*]] = llvm.mul %[[DYN_M]], %[[DYN_K]] : i64
 // CHECK-NEXT:  %[[DYN_SLOT:.*]] = llvm.mlir.constant(-1 : i32) : i32
 // CHECK-NEXT:  %[[DYN_A_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
 // CHECK-NEXT:  %[[DYN_B_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
 // CHECK-NEXT:  %[[DYN_OUT_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
 // CHECK-NEXT:  %[[DYN_ELEM_SIZE:.*]] = llvm.mlir.constant(2 : i64) : i64
-// CHECK-NEXT:  llvm.call @wrap_hipblasLtMatmul(%[[DYN_CTX]], %[[DYN_SLOT]], %[[DYN_A_PTR]], %[[DYN_B_PTR]], %[[DYN_OUT_PTR]], %[[DYN_M]], %[[DYN_N]], %[[DYN_K]], %[[DYN_BATCH]], %[[DYN_ELEM_SIZE]], %[[DYN_B_STRIDE]]) : (!llvm.ptr, i32, !llvm.ptr<1>, !llvm.ptr<1>, !llvm.ptr<1>, i64, i64, i64, i64, i64, i64) -> i32
+// CHECK-NEXT:  llvm.call @wrap_hipblasLtMatmul(%[[DYN_CTX]], %[[DYN_SLOT]], %[[DYN_A_PTR]], %[[DYN_B_PTR]], %[[DYN_OUT_PTR]], %[[DYN_VALID]], %[[DYN_M]], %[[DYN_N]], %[[DYN_K]], %[[DYN_B_K]], %[[DYN_BATCH]], %[[DYN_ELEM_SIZE]], %[[DYN_BATCH]], %[[B_COUNT]], %[[DYN_A_STRIDE]], %[[DYN_B_STRIDE]]) : (!llvm.ptr, i32, !llvm.ptr<1>, !llvm.ptr<1>, !llvm.ptr<1>, i1, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
 // CHECK-NEXT:  llvm.return
 func.func @matmul_dynamic_batch(
     %ctx: !hipsr.context,

--- a/test/lit/e2e/test_matmul_model.mlir
+++ b/test/lit/e2e/test_matmul_model.mlir
@@ -13,7 +13,7 @@
 // CHECK: module attributes {
 // CHECK-SAME: hipdnn.input_count = 1
 // CHECK-SAME: hipdnn.output_count = 1
-// CHECK: llvm.func @wrap_hipblasLtMatmul
+// CHECK: llvm.func @wrap_hipblasLtMatmul(
 // CHECK: llvm.func @inference_init
 // CHECK: llvm.func @inference_compute
 // CHECK: llvm.func @inference_cleanup

--- a/test/lit/e2e/test_mlp_model.mlir
+++ b/test/lit/e2e/test_mlp_model.mlir
@@ -15,7 +15,7 @@
 // CHECK: module attributes {
 // CHECK-SAME: hipdnn.input_count = 1
 // CHECK-SAME: hipdnn.output_count = 1
-// CHECK: llvm.func @wrap_hipblasLtMatmul
+// CHECK: llvm.func @wrap_hipblasLtMatmul(
 // CHECK: llvm.func @inference_init
 // CHECK: llvm.func @inference_compute
 // CHECK: llvm.func @inference_cleanup

--- a/test/runtime/CMakeLists.txt
+++ b/test/runtime/CMakeLists.txt
@@ -147,3 +147,22 @@ target_link_libraries(test-cache-identity PRIVATE
 )
 add_test(NAME CacheIdentityUnitTest COMMAND test-cache-identity)
 set_target_properties(test-cache-identity PROPERTIES FOLDER "runtime-tests")
+
+# Shared MatMul/Gemm runtime preflight and mock ABI behavior. Dispatch counters
+# prove invalid contractions return before the simulated BLAS boundary.
+add_executable(test-matmul-gemm-contract
+    test_matmul_gemm_contract.cpp
+    ${CMAKE_SOURCE_DIR}/lib/Runtime/mock/mock_gpu.cpp
+)
+target_compile_features(test-matmul-gemm-contract PRIVATE cxx_std_17)
+target_include_directories(test-matmul-gemm-contract PRIVATE
+    ${CMAKE_SOURCE_DIR}/lib/Runtime
+    ${CMAKE_SOURCE_DIR}/lib/Runtime/mock
+    ${CMAKE_SOURCE_DIR}/include
+)
+target_compile_definitions(test-matmul-gemm-contract PRIVATE
+    HIPDNN_EP_RT_NO_EXPORT
+    HIPDNN_EP_RUNTIME_TESTING
+)
+add_test(NAME MatmulGemmContractUnitTest COMMAND test-matmul-gemm-contract)
+set_target_properties(test-matmul-gemm-contract PROPERTIES FOLDER "runtime-tests")

--- a/test/runtime/test_matmul_gemm_contract.cpp
+++ b/test/runtime/test_matmul_gemm_contract.cpp
@@ -1,0 +1,224 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "hipdnn_ep_runtime.h"
+#include "matmul_gemm_contract.h"
+#include "runtime_state_internal.h"
+
+#include <array>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <limits>
+
+extern "C" void hipdnn_ep_mock_reset_blas_dispatch_counts();
+extern "C" int hipdnn_ep_mock_matmul_dispatch_count();
+extern "C" int hipdnn_ep_mock_gemm_dispatch_count();
+
+namespace {
+
+int failures = 0;
+int errorFlagCalls = 0;
+
+#define CHECK(condition)                                                       \
+  do {                                                                         \
+    if (!(condition)) {                                                        \
+      std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__,             \
+                   #condition);                                                \
+      ++failures;                                                              \
+    }                                                                          \
+  } while (false)
+
+template <size_t N> bool allZero(const std::array<unsigned char, N> &buffer) {
+  for (unsigned char byte : buffer)
+    if (byte != 0)
+      return false;
+  return true;
+}
+
+void testSharedSizing() {
+  using namespace hipdnn_ep::blas_contract;
+  OutputSize size;
+  CHECK(computeOutputSize(2, 3, 4, 2, size));
+  CHECK(size.elements == 24);
+  CHECK(size.bytes == 48);
+  CHECK(!computeOutputSize(1, -1, 4, 2, size));
+  CHECK(!computeOutputSize(1, std::numeric_limits<int64_t>::max(), 2, 8, size));
+  CHECK(validateMatrixProducts(2, 3, 4, 4));
+  CHECK(!validateMatrixProducts(std::numeric_limits<int64_t>::max(), 3, 4, 4));
+  CHECK(validateMatmul(true, 2, 3, 4, 5, 1, 2, 1, 1, 0, 0, true, true, true)
+            .status == ValidationStatus::Failure);
+  CHECK(
+      validateGemm(2, 3, 4, 4, 0, 0, 1, false, 0, 0, true, true, true).status ==
+      ValidationStatus::Success);
+}
+
+void testMatmulWrapper() {
+  RuntimeState state{};
+  std::array<unsigned char, 48> a{};
+  std::array<unsigned char, 64> b{};
+  std::array<unsigned char, 24> output{};
+
+  hipdnn_ep_mock_reset_blas_dispatch_counts();
+  errorFlagCalls = 0;
+  output.fill(0x5a);
+  CHECK(wrap_hipblasLtMatmul(&state, 0, a.data(), b.data(), output.data(),
+                             /*batch_axes_valid=*/true,
+                             /*M=*/2, /*N=*/3, /*K_a=*/4, /*K_b=*/4,
+                             /*batch=*/2, /*elem=*/2, /*a_batches=*/2,
+                             /*b_batches=*/1, /*a_stride=*/8,
+                             /*b_stride=*/0) == 0);
+  CHECK(hipdnn_ep_mock_matmul_dispatch_count() == 1);
+  CHECK(errorFlagCalls == 0);
+
+  output.fill(0x5a);
+  CHECK(wrap_hipblasLtMatmul(&state, 0, a.data(), b.data(), output.data(), true,
+                             2, 3, 4, 5, 2, 2, 2, 1, 8, 0) != 0);
+  CHECK(hipdnn_ep_mock_matmul_dispatch_count() == 1);
+  CHECK(errorFlagCalls == 1);
+  CHECK(allZero(output));
+
+  CHECK(wrap_hipblasLtMatmul(&state, 0, nullptr, nullptr, nullptr,
+                             /*batch_axes_valid=*/true,
+                             /*M=*/0, /*N=*/3, /*K_a=*/4, /*K_b=*/4,
+                             /*batch=*/2, /*elem=*/2, /*a_batches=*/2,
+                             /*b_batches=*/1, /*a_stride=*/0,
+                             /*b_stride=*/0) == 0);
+  CHECK(hipdnn_ep_mock_matmul_dispatch_count() == 1);
+  CHECK(errorFlagCalls == 1);
+
+  CHECK(wrap_hipblasLtMatmul(&state, 0, a.data(), b.data(), output.data(),
+                             /*batch_axes_valid=*/true,
+                             std::numeric_limits<int64_t>::max(), 3, 4, 4, 2, 2,
+                             2, 2, 8, 12) != 0);
+  CHECK(hipdnn_ep_mock_matmul_dispatch_count() == 1);
+  CHECK(errorFlagCalls == 2);
+}
+
+void testDynamicPartialBatchRejected() {
+  RuntimeState state{};
+  std::array<unsigned char, 32> a{};
+  std::array<unsigned char, 144> b{};
+  std::array<unsigned char, 72> output{};
+
+  hipdnn_ep_mock_reset_blas_dispatch_counts();
+  errorFlagCalls = 0;
+  output.fill(0x5a);
+  CHECK(wrap_hipblasLtMatmul(&state, 0, a.data(), b.data(), output.data(),
+                             /*batch_axes_valid=*/true,
+                             /*M=*/2, /*N=*/3, /*K_a=*/4, /*K_b=*/4,
+                             /*output batches=*/6, /*elem=*/2,
+                             /*partial A batches=*/2, /*full B batches=*/6,
+                             /*lowering-selected A stride=*/0,
+                             /*B stride=*/12) != 0);
+  CHECK(hipdnn_ep_mock_matmul_dispatch_count() == 0);
+  CHECK(errorFlagCalls == 1);
+  CHECK(allZero(output));
+}
+
+void testPerAxisBatchValidation() {
+  RuntimeState state{};
+  std::array<unsigned char, 96> a{};
+  std::array<unsigned char, 144> b{};
+  std::array<unsigned char, 72> output{};
+
+  hipdnn_ep_mock_reset_blas_dispatch_counts();
+  errorFlagCalls = 0;
+
+  // Equal dynamic axes: [2,3] with [2,3].
+  CHECK(wrap_hipblasLtMatmul(&state, 0, a.data(), b.data(), output.data(),
+                             /*batch_axes_valid=*/true, /*M=*/2, /*N=*/3,
+                             /*K_a=*/4, /*K_b=*/4, /*output batches=*/6,
+                             /*elem=*/2,
+                             /*A batches=*/6, /*B batches=*/6, /*A stride=*/8,
+                             /*B stride=*/12) == 0);
+
+  // Valid unit broadcast: [1,1] with [2,3].
+  CHECK(wrap_hipblasLtMatmul(&state, 0, a.data(), b.data(), output.data(),
+                             /*batch_axes_valid=*/true, /*M=*/2, /*N=*/3,
+                             /*K_a=*/4, /*K_b=*/4, /*output batches=*/6,
+                             /*elem=*/2,
+                             /*A batches=*/1, /*B batches=*/6, /*A stride=*/0,
+                             /*B stride=*/12) == 0);
+  CHECK(hipdnn_ep_mock_matmul_dispatch_count() == 2);
+  CHECK(errorFlagCalls == 0);
+
+  // Equal flattened products cannot hide incompatible axes: [2,3] vs [3,2].
+  output.fill(0x5a);
+  CHECK(wrap_hipblasLtMatmul(&state, 0, a.data(), b.data(), output.data(),
+                             /*batch_axes_valid=*/false, /*M=*/2, /*N=*/3,
+                             /*K_a=*/4, /*K_b=*/4, /*output batches=*/6,
+                             /*elem=*/2,
+                             /*A batches=*/6, /*B batches=*/6, /*A stride=*/8,
+                             /*B stride=*/12) != 0);
+  CHECK(hipdnn_ep_mock_matmul_dispatch_count() == 2);
+  CHECK(errorFlagCalls == 1);
+  CHECK(allZero(output));
+
+  // A caller-provided output extent that disagrees with the exact broadcast
+  // choice is rejected through the same lowering validity bit.
+  output.fill(0x5a);
+  CHECK(wrap_hipblasLtMatmul(&state, 0, a.data(), b.data(), output.data(),
+                             /*batch_axes_valid=*/false, /*M=*/2, /*N=*/3,
+                             /*K_a=*/4, /*K_b=*/4, /*output batches=*/6,
+                             /*elem=*/2,
+                             /*A batches=*/6, /*B batches=*/6, /*A stride=*/8,
+                             /*B stride=*/12) != 0);
+  CHECK(hipdnn_ep_mock_matmul_dispatch_count() == 2);
+  CHECK(errorFlagCalls == 2);
+  CHECK(allZero(output));
+}
+
+void testGemmWrapper() {
+  RuntimeState state{};
+  std::array<unsigned char, 32> a{};
+  std::array<unsigned char, 32> b{};
+  std::array<unsigned char, 24> output{};
+
+  hipdnn_ep_mock_reset_blas_dispatch_counts();
+  errorFlagCalls = 0;
+  output.fill(0x5a);
+  CHECK(wrap_gemm(&state, 0, a.data(), b.data(), nullptr, output.data(),
+                  /*M=*/2, /*N=*/3, /*K_a=*/4, /*K_b=*/4, 1.0f, 0.0f,
+                  /*transA=*/1, /*transB=*/1, /*f32=*/1,
+                  /*cDim0=*/0, /*cDim1=*/0) == 0);
+  CHECK(hipdnn_ep_mock_gemm_dispatch_count() == 1);
+  CHECK(errorFlagCalls == 0);
+
+  output.fill(0x5a);
+  CHECK(wrap_gemm(&state, 0, a.data(), b.data(), nullptr, output.data(), 2, 3,
+                  4, 5, 1.0f, 0.0f, 0, 0, 1, 0, 0) != 0);
+  CHECK(hipdnn_ep_mock_gemm_dispatch_count() == 1);
+  CHECK(errorFlagCalls == 1);
+  CHECK(allZero(output));
+
+  CHECK(wrap_gemm(&state, 0, nullptr, nullptr, nullptr, nullptr,
+                  /*M=*/2, /*N=*/0, /*K_a=*/4, /*K_b=*/4, 1.0f, 0.0f, 0, 0, 1,
+                  0, 0) == 0);
+  CHECK(hipdnn_ep_mock_gemm_dispatch_count() == 1);
+  CHECK(errorFlagCalls == 1);
+}
+
+} // namespace
+
+extern "C" int hipdnn_ep_state_set_error_flag(RuntimeState *) {
+  ++errorFlagCalls;
+  return 0;
+}
+
+int main() {
+  testSharedSizing();
+  testMatmulWrapper();
+  testDynamicPartialBatchRejected();
+  testPerAxisBatchValidation();
+  testGemmWrapper();
+  if (failures == 0) {
+    std::printf("MatMul/Gemm contract unit test: ALL PASS\n");
+    return 0;
+  }
+  std::fprintf(stderr, "MatMul/Gemm contract unit test: %d FAILURE(S)\n",
+               failures);
+  return 1;
+}


### PR DESCRIPTION
## Why

MatMul and Gemm previously worked out their result shapes separately in ONNX conversion, HIP shape reification, and verification. Those paths could disagree about broadcasting, transpose-aware dimensions, or dynamic shapes.

The runtime also received only one contraction size (`K`). When both operands had dynamic dimensions, it could not verify that `A` and `B` agreed before dispatching to hipBLASLt.

Batched MatMul had a similar limitation: one operand could broadcast across every batch, but the runtime contract did not describe both operands independently. Partial per-axis broadcasting could therefore reach a runtime that only supports one fixed stride per operand.

This PR gives conversion, verification, lowering, and runtime one shared contract. Dynamic dimensions remain supported, while invalid runtime shapes fail safely before BLAS dispatch.

## IR example

The changed MatMul lowering test includes the mirror broadcast case where A is one rank-2 matrix and B carries two batches:

```mlir
module {
  func.func @test_matmul_rank2_a(%ctx: !hip.context,
                                 %A: memref<128x4096xf16, 1>,
                                 %B: memref<2x4096x1024xf16, 1>,
                                 %output: memref<2x128x1024xf16, 1>) {
    hip.matmul(%ctx)
        ins(%A, %B : memref<128x4096xf16, 1>, memref<2x4096x1024xf16, 1>)
        outs(%output : memref<2x128x1024xf16, 1>)
    return
  }
}
```

Lowering records one A matrix with stride zero and two B matrices with a nonzero matrix stride. The expanded runtime call receives independent A and B contraction sizes, matrix counts, and strides, plus the per-axis batch-validity bit. The wrapper checks those values before descriptor creation, cache lookup, or dispatch.

## What changes

- Add shared shape rules for MatMul, Gemm, and MatMulNBits.
- Make conversion, verification, and shape reification use those rules.
- Support dynamic contraction dimensions by passing A and B's `K` values independently.
- Reject static contraction mismatches during compilation.
- Check dynamic contraction mismatches before runtime dispatch.
- Support whole-matrix batch broadcasting for either MatMul operand.
- Derive independent matrix counts and batch strides for A and B.
- Reject partial per-axis batch layouts that one fixed stride cannot represent.
- Validate dynamically concealed batch incompatibilities at runtime.
- Validate Gemm transpose-aware dimensions and optional C broadcasting.
- Share runtime validation between the real and mock backends.
- Record recoverable runtime errors and zero known nonempty outputs on failure.
- Expand the existing MatMul runtime symbol instead of adding a second ABI name.
- Minimally adapt Hipsr lowering to supply the expanded arguments.
- Add compiler, lowering, mock-runtime, and numeric coverage for the contracts.

HIP model artifacts compiled against the previous MatMul or one-K Gemm runtime ABI must be rebuilt.

## Stack

1. [#688 — Constant carrier and externalization](https://github.com/ROCm/hip-ep/pull/688)
2. [#754 — Physical-byte i1 pool sizing](https://github.com/ROCm/hip-ep/pull/754)
3. [#756 — Generated failure propagation](https://github.com/ROCm/hip-ep/pull/756)
4. [#758 — Exact supported output views](https://github.com/ROCm/hip-ep/pull/758)
5. [#755 — Function-site pool namespaces](https://github.com/ROCm/hip-ep/pull/755)
6. [#757 — Function-site host scratch](https://github.com/ROCm/hip-ep/pull/757)
7. [#724 — Symbolic metadata transport](https://github.com/ROCm/hip-ep/pull/724)
8. [#759 — Artifact ABI validation](https://github.com/ROCm/hip-ep/pull/759)
9. [#639 — Shape-rule foundation](https://github.com/ROCm/hip-ep/pull/639)
10. [#681 — Reshape provenance](https://github.com/ROCm/hip-ep/pull/681)
11. [#725 — Exact broadcast activation](https://github.com/ROCm/hip-ep/pull/725)
12. [#763 — Softmax transient reuse](https://github.com/ROCm/hip-ep/pull/763)
13. [#640 — MatMul/Gemm runtime contracts](https://github.com/ROCm/hip-ep/pull/640) ← this PR
14. [#734 — MatMul/Gemm shape contracts](https://github.com/ROCm/hip-ep/pull/734)
15. [#641 — Broadcast contracts](https://github.com/ROCm/hip-ep/pull/641)
16. [#735 — Shared reduction conversion](https://github.com/ROCm/hip-ep/pull/735)
17. [#736 — Reduction contracts](https://github.com/ROCm/hip-ep/pull/736)
18. [#689 — Loop frame ABI](https://github.com/ROCm/hip-ep/pull/689)
19. [#737 — Shape-changing loop carriers](https://github.com/ROCm/hip-ep/pull/737)
20. [#762 — Loop carrier bank recycling](https://github.com/ROCm/hip-ep/pull/762)
21. [#642 — Grouped payload readback](https://github.com/ROCm/hip-ep/pull/642)
22. [#727 — Constant payload shapes](https://github.com/ROCm/hip-ep/pull/727)
23. [#728 — Tile and Range](https://github.com/ROCm/hip-ep/pull/728)
24. [#729 — Slice normalization](https://github.com/ROCm/hip-ep/pull/729)
25. [#731 — Exact Slice ABI](https://github.com/ROCm/hip-ep/pull/731)
26. [#733 — Loop payload integration](https://github.com/ROCm/hip-ep/pull/733)
27. [#643 — Conv/ConvTranspose](https://github.com/ROCm/hip-ep/pull/643)
28. [#738 — Pool/GlobalPool](https://github.com/ROCm/hip-ep/pull/738)
29. [#742 — CausalConv](https://github.com/ROCm/hip-ep/pull/742)
30. [#644 — Gather/tensor](https://github.com/ROCm/hip-ep/pull/644)
31. [#739 — Block-quantized Gather](https://github.com/ROCm/hip-ep/pull/739)
32. [#645 — Normalization](https://github.com/ROCm/hip-ep/pull/645)
33. [#740 — Attention/Rotary](https://github.com/ROCm/hip-ep/pull/740)
34. [#741 — GQA capacity](https://github.com/ROCm/hip-ep/pull/741)
35. [#743 — GQA feature rejection](https://github.com/ROCm/hip-ep/pull/743)
36. [#646 — Explicit DPS contracts](https://github.com/ROCm/hip-ep/pull/646)
37. [#730 — Contract inventory audit](https://github.com/ROCm/hip-ep/pull/730)
38. [#732 — Converter dedup audit](https://github.com/ROCm/hip-ep/pull/732)
39. [#647 — Refinement hardening](https://github.com/ROCm/hip-ep/pull/647)
40. [#761 — Shape utility headers](https://github.com/ROCm/hip-ep/pull/761)
41. [#764 — Shape destination authority](https://github.com/ROCm/hip-ep/pull/764)

## AI assistance

AI tools assisted with the refactoring and stack reconstruction. The contributor reviewed and validated the resulting code.

Made-with: Cursor
