### PR TITLE
feat(hip): add grouped shape readback

### DIFF
--- a/build.py
+++ b/build.py
@@ -354,7 +354,7 @@ def run_tests(args, build_dir):
             "StaticPlugins|OutputAllocator|CustomOpComputeStatus|"
             "ArtifactAbi|TensorBufferLifecycle|SymbolicDims|CacheIdentity|"
             "MatmulGemmContractUnitTest|ReductionStatusUnitTest|"
-            "LoopFrameUnitTest",
+            "LoopFrameUnitTest|ReadbackControlUnitTest",
             "--output-on-failure",
         ]
     )

--- a/include/hip/Dialect/IR/HipBufferize.h
+++ b/include/hip/Dialect/IR/HipBufferize.h
@@ -8,6 +8,7 @@
 #include "hip/Dialect/IR/HipDialect.h"
 #include "mlir/Dialect/Bufferization/IR/BufferizableOpInterface.h"
 #include "mlir/Dialect/Bufferization/IR/DstBufferizableOpInterfaceImpl.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/DialectRegistry.h"
 #include "mlir/IR/OperationSupport.h"
 
@@ -134,6 +135,7 @@ struct HipLoopBufferizableModel
   LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
                           const bufferization::BufferizationOptions &options,
                           bufferization::BufferizationState &state) const {
+    auto loop = cast<LoopOp>(op);
     SmallVector<Value> newOperands;
     newOperands.reserve(op->getNumOperands());
     for (OpOperand &operand : op->getOpOperands()) {
@@ -145,6 +147,41 @@ struct HipLoopBufferizableModel
           getBuffer(rewriter, operand.get(), options, state);
       if (failed(buffer))
         return failure();
+
+      // A tensor.extract_slice seed bufferizes to a strided view, while the
+      // descriptor-return loop contract and outlined body use identity-layout
+      // carrier descriptors. Materialize only loop-carried seeds into that
+      // joined descriptor type. The allocation intentionally has no local
+      // dealloc: zero-trip/failure may return this borrowed seed, and the loop
+      // may-alias relation keeps it live through all carrier-result users.
+      for (auto [index, init] : llvm::enumerate(loop.getVInitMutable())) {
+        if (&init != &operand)
+          continue;
+        auto tensorType =
+            dyn_cast<RankedTensorType>(loop.getResult(index).getType());
+        if (!tensorType)
+          return loop.emitOpError(
+              "loop bufferization requires ranked tensor results");
+        auto desiredType =
+            MemRefType::get(tensorType.getShape(), tensorType.getElementType());
+        if ((*buffer).getType() == desiredType)
+          break;
+        auto sourceType = dyn_cast<MemRefType>((*buffer).getType());
+        if (!sourceType || sourceType.getRank() != desiredType.getRank())
+          return loop.emitOpError(
+              "loop seed buffer rank must match joined carrier rank");
+        SmallVector<Value> dynamicSizes;
+        for (int64_t dim : llvm::seq<int64_t>(desiredType.getRank()))
+          if (desiredType.isDynamicDim(dim))
+            dynamicSizes.push_back(
+                memref::DimOp::create(rewriter, op->getLoc(), *buffer, dim));
+        auto copy = memref::AllocOp::create(rewriter, op->getLoc(), desiredType,
+                                            dynamicSizes);
+        memref::CopyOp::create(rewriter, op->getLoc(), *buffer,
+                               copy.getResult());
+        *buffer = copy.getResult();
+        break;
+      }
       newOperands.push_back(*buffer);
     }
 
@@ -173,6 +210,85 @@ struct HipLoopBufferizableModel
   }
 };
 
+struct HipReadbackShapeBufferizableModel
+    : public bufferization::BufferizableOpInterface::ExternalModel<
+          HipReadbackShapeBufferizableModel, ReadbackShapeOp> {
+  bool bufferizesToMemoryRead(Operation *, OpOperand &,
+                              const bufferization::AnalysisState &) const {
+    return true;
+  }
+  bool bufferizesToMemoryWrite(Operation *, OpOperand &,
+                               const bufferization::AnalysisState &) const {
+    return false;
+  }
+  bufferization::AliasingValueList
+  getAliasingValues(Operation *, OpOperand &,
+                    const bufferization::AnalysisState &) const {
+    return {};
+  }
+  LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
+                          const bufferization::BufferizationOptions &options,
+                          bufferization::BufferizationState &state) const {
+    auto readback = cast<ReadbackShapeOp>(op);
+    FailureOr<Value> vectorBuf =
+        getBuffer(rewriter, readback.getVector(), options, state);
+    if (failed(vectorBuf))
+      return failure();
+    auto newOp = ReadbackShapeOp::create(
+        rewriter, op->getLoc(), readback.getResultTypes(), readback.getCtx(),
+        *vectorBuf, readback.getCountAttr());
+    bufferization::replaceOpWithBufferizedValues(rewriter, op,
+                                                 newOp.getResults());
+    return success();
+  }
+};
+
+struct HipReadbackControlBufferizableModel
+    : public bufferization::BufferizableOpInterface::ExternalModel<
+          HipReadbackControlBufferizableModel, ReadbackControlOp> {
+  bool bufferizesToMemoryRead(Operation *, OpOperand &operand,
+                              const bufferization::AnalysisState &) const {
+    return isa<TensorType>(operand.get().getType()) ||
+           isa<MemRefType>(operand.get().getType());
+  }
+  bool bufferizesToMemoryWrite(Operation *, OpOperand &,
+                               const bufferization::AnalysisState &) const {
+    return false;
+  }
+  bufferization::AliasingValueList
+  getAliasingValues(Operation *, OpOperand &,
+                    const bufferization::AnalysisState &) const {
+    return {};
+  }
+  LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
+                          const bufferization::BufferizationOptions &options,
+                          bufferization::BufferizationState &state) const {
+    auto readback = cast<ReadbackControlOp>(op);
+    SmallVector<Value> operands = {readback.getCtx()};
+    operands.reserve(1 + readback.getSources().size());
+    for (Value source : readback.getSources()) {
+      if (isa<TensorType>(source.getType())) {
+        FailureOr<Value> buffer = getBuffer(rewriter, source, options, state);
+        if (failed(buffer))
+          return failure();
+        operands.push_back(*buffer);
+      } else {
+        operands.push_back(source);
+      }
+    }
+
+    OperationState newState(op->getLoc(), op->getName().getStringRef());
+    newState.addOperands(operands);
+    newState.addTypes(op->getResultTypes());
+    newState.addAttributes(op->getAttrs());
+    newState.propertiesAttr = op->getPropertiesAsAttribute();
+    Operation *newOp = rewriter.create(newState);
+    bufferization::replaceOpWithBufferizedValues(rewriter, op,
+                                                 newOp->getResults());
+    return success();
+  }
+};
+
 inline void
 registerHipBufferizableOpInterfaceModels(DialectRegistry &registry) {
   registry.addExtension(+[](MLIRContext *ctx, HipDialect *) {
@@ -180,6 +296,9 @@ registerHipBufferizableOpInterfaceModels(DialectRegistry &registry) {
         *ctx);
     ReadbackScalarOp::attachInterface<
         HipReadbackBufferizableModel<ReadbackScalarOp>>(*ctx);
+    ReadbackShapeOp::attachInterface<HipReadbackShapeBufferizableModel>(*ctx);
+    ReadbackControlOp::attachInterface<HipReadbackControlBufferizableModel>(
+        *ctx);
     ConvOp::attachInterface<HipDstBufferizableModel<ConvOp>>(*ctx);
     ConvTransposeOp::attachInterface<HipDstBufferizableModel<ConvTransposeOp>>(
         *ctx);

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -4315,4 +4315,70 @@ def Hip_ReadbackScalarOp : Hip_Op<"readback_scalar",
     `(` $ctx `,` $scalar `:` type($scalar) `)` attr-dict `->` type($value)
   }];
 }
+
+// hip.readback_shape : synchronize once and read a statically-sized rank-1
+// i64 shape vector into one host index SSA value per element. Used when a
+// payload tensor (e.g. Tile repeats) determines allocation extents.
+def Hip_ReadbackShapeOp : Hip_Op<"readback_shape",
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+  let summary = "Synchronize and read a device i64 shape vector";
+  let description = [{
+    Copies the statically-sized rank-1 i64 `vector` from device to host with
+    one stream synchronization and returns each entry as an `index`.
+
+    Negative entries are runtime-invalid shape extents. The runtime clamps
+    them to zero and records the shared recoverable error flag so generated
+    inference returns a non-zero status instead of allocating with a negative
+    extent or aborting the host.
+
+    This op has device-to-host copy and synchronization side effects and is not
+    speculatable.
+  }];
+
+  let arguments = (ins
+    Hip_ContextType:$ctx,
+    Hip_TensorOrMemRef:$vector,
+    I64Attr:$count
+  );
+  let results = (outs Variadic<Index>:$dims);
+
+  let assemblyFormat = [{
+    `(` $ctx `,` $vector `:` type($vector) `)` attr-dict
+    `->` `(` type($dims) `)`
+  }];
+
+  let hasVerifier = 1;
+}
+
+// hip.readback_control : one synchronized host boundary for a group of small
+// integer control tensors. Unlike readback_shape, signed values are preserved.
+def Hip_ReadbackControlOp : Hip_Op<"readback_control",
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
+  let summary = "Read statically-sized integer control tensors with one sync";
+  let description = [{
+    Copies one or more statically-sized rank-0/rank-1 i32/i64 sources from
+    device-visible memory to the host. Results are flattened in operand-major
+    order and converted to signed i64 (i32 values are sign-extended). `valid`
+    is false if argument validation, any copy enqueue, or the single stream
+    synchronization fails. Values are initialized to zero before the runtime
+    call and are never clamped.
+
+    This op has device-to-host copy and synchronization side effects and is not
+    speculatable.
+  }];
+
+  let arguments = (ins
+    Hip_ContextType:$ctx,
+    Variadic<Hip_TensorOrMemRef>:$sources
+  );
+  let results = (outs I1:$valid, Variadic<I64>:$values);
+
+  let assemblyFormat = [{
+    `(` $ctx `,` $sources `:` type($sources) `)` attr-dict
+    `->` `(` type($valid) (`,` type($values)^)? `)`
+  }];
+
+  let hasVerifier = 1;
+}
 #endif // HIP_OPS

--- a/include/hip/Dialect/IR/HipShapeUtils.h
+++ b/include/hip/Dialect/IR/HipShapeUtils.h
@@ -20,6 +20,21 @@
 namespace mlir {
 namespace hip {
 
+/// Static grouping information for `hip.readback_control`. Sources are
+/// flattened in operand-major order; `resultOffsets[i]` is the first i64 result
+/// produced for source `i`, and the final entry equals `totalCount`.
+struct ReadbackControlLayout {
+  SmallVector<int64_t> sourceLengths;
+  SmallVector<int64_t> resultOffsets;
+  int64_t totalCount = 0;
+};
+
+/// Validate rank-0/rank-1 statically-sized i32/i64 source types and compute the
+/// operand-major result grouping used by conversion, verification, and
+/// lowering. At least one source is required.
+FailureOr<ReadbackControlLayout>
+getReadbackControlLayout(TypeRange sourceTypes);
+
 /// Parse the payload of a rank-0 or rank-1 dense integer tensor into signed
 /// i64 values. `expectedRank` may restrict callers to scalar or vector form.
 bool parseDenseIntElements(DenseElementsAttr dense,

--- a/lib/Conversion/HipToLLVM/CMakeLists.txt
+++ b/lib/Conversion/HipToLLVM/CMakeLists.txt
@@ -54,6 +54,8 @@ add_library(HipToLLVM STATIC
   NonZeroLowering.cpp
   ReadbackDimLowering.cpp
   ReadbackScalarLowering.cpp
+  ReadbackShapeLowering.cpp
+  ReadbackControlLowering.cpp
   SizeLowering.cpp
   LoopLowering.cpp
   IfLowering.cpp

--- a/lib/Conversion/HipToLLVM/HipToLLVM.cpp
+++ b/lib/Conversion/HipToLLVM/HipToLLVM.cpp
@@ -292,6 +292,8 @@ void ConvertHipToLLVMPass::runOnOperation() {
   populateNonZeroLoweringPatterns(typeConverter, patterns);
   populateReadbackDimLoweringPatterns(typeConverter, patterns);
   populateReadbackScalarLoweringPatterns(typeConverter, patterns);
+  populateReadbackShapeLoweringPatterns(typeConverter, patterns);
+  populateReadbackControlLoweringPatterns(typeConverter, patterns);
   populateSizeLoweringPatterns(typeConverter, patterns);
   populatePoolLoweringPatterns(typeConverter, patterns);
   populateResizeLoweringPatterns(typeConverter, patterns);

--- a/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
+++ b/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
@@ -148,6 +148,9 @@ inline constexpr const char *kHipReadbackI32 = "hipdnn_ep_readback_i32";
 // width into a host buffer (used by hip.readback_scalar for non-i32 scalars
 // such as the i64/f32/f16 operands of a data-dependent onnx.Range).
 inline constexpr const char *kHipReadbackScalar = "hipdnn_ep_readback_scalar";
+inline constexpr const char *kHipReadbackShapeI64 =
+    "hipdnn_ep_readback_shape_i64";
+inline constexpr const char *kHipReadbackControl = "hipdnn_ep_readback_control";
 
 // LLVM memref descriptor struct field indices.
 // Layout: { allocatedPtr, alignedPtr, offset, sizes[rank], strides[rank] }
@@ -498,6 +501,10 @@ void populateReadbackDimLoweringPatterns(const LLVMTypeConverter &converter,
 // scalar of arbitrary element type (the i64/f32/f16 sibling of readback_dim).
 void populateReadbackScalarLoweringPatterns(const LLVMTypeConverter &converter,
                                             RewritePatternSet &patterns);
+void populateReadbackShapeLoweringPatterns(const LLVMTypeConverter &converter,
+                                           RewritePatternSet &patterns);
+void populateReadbackControlLoweringPatterns(const LLVMTypeConverter &converter,
+                                             RewritePatternSet &patterns);
 void populateSizeLoweringPatterns(const LLVMTypeConverter &converter,
                                   RewritePatternSet &patterns);
 void populateLoopLoweringPatterns(const LLVMTypeConverter &converter,

--- a/lib/Conversion/HipToLLVM/ReadbackControlLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ReadbackControlLowering.cpp
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "HipToLLVMUtils.h"
+#include "hip/Dialect/IR/HipShapeUtils.h"
+
+namespace mlir {
+namespace hip {
+namespace {
+
+// hip.readback_control(%ctx, %sources...) -> (i1, i64...)
+//
+// The generated stack arrays describe all source groups to one runtime call.
+// The runtime initializes and fills the host result array, queues every D2H
+// copy, and performs exactly one stream synchronization.
+struct ReadbackControlOpLowering
+    : public ConvertOpToLLVMPattern<ReadbackControlOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(ReadbackControlOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    ModuleOp module = op->getParentOfType<ModuleOp>();
+    Type ptrType = getPtrType();
+    Type i32Type = rewriter.getI32Type();
+    Type i64Type = rewriter.getI64Type();
+
+    SmallVector<Type> sourceTypes(op.getSources().getTypes());
+    FailureOr<ReadbackControlLayout> layout =
+        getReadbackControlLayout(sourceTypes);
+    if (failed(layout))
+      return rewriter.notifyMatchFailure(op, "invalid source grouping");
+
+    auto i64Constant = [&](int64_t value) {
+      return LLVM::ConstantOp::create(rewriter, loc, i64Type,
+                                      rewriter.getI64IntegerAttr(value));
+    };
+    auto i32Constant = [&](int32_t value) {
+      return LLVM::ConstantOp::create(rewriter, loc, i32Type,
+                                      rewriter.getI32IntegerAttr(value));
+    };
+
+    Value one = i64Constant(1);
+    Value sourceCount = i64Constant(op.getSources().size());
+    Value totalCount = i64Constant(layout->totalCount);
+    Value hostCount = i64Constant(std::max<int64_t>(layout->totalCount, 1));
+    Value hostValues =
+        LLVM::AllocaOp::create(rewriter, loc, ptrType, i64Type, hostCount,
+                               /*alignment=*/8);
+    Value sourcePointers =
+        LLVM::AllocaOp::create(rewriter, loc, ptrType, ptrType, sourceCount,
+                               /*alignment=*/8);
+    Value sourceLengths =
+        LLVM::AllocaOp::create(rewriter, loc, ptrType, i64Type, sourceCount,
+                               /*alignment=*/8);
+    Value elementBytes =
+        LLVM::AllocaOp::create(rewriter, loc, ptrType, i64Type, sourceCount,
+                               /*alignment=*/8);
+
+    Value zeroI64 = i64Constant(0);
+    for (int64_t i : llvm::seq<int64_t>(layout->totalCount)) {
+      Value index = i64Constant(i);
+      Value slot = LLVM::GEPOp::create(rewriter, loc, ptrType, i64Type,
+                                       hostValues, index);
+      LLVM::StoreOp::create(rewriter, loc, zeroI64, slot);
+    }
+
+    for (auto [i, source] : llvm::enumerate(op.getSources())) {
+      auto memrefType = dyn_cast<MemRefType>(source.getType());
+      if (!memrefType)
+        return rewriter.notifyMatchFailure(op,
+                                           "source operand must be a memref");
+      Value sourcePtr = extractMemRefDataPtr(
+          adaptor.getSources()[i], memrefType, typeConverter, rewriter, loc);
+      if (!sourcePtr)
+        return rewriter.notifyMatchFailure(op,
+                                           "failed to compute source pointer");
+
+      Value index = i64Constant(i);
+      Value pointerSlot = LLVM::GEPOp::create(rewriter, loc, ptrType, ptrType,
+                                              sourcePointers, index);
+      LLVM::StoreOp::create(rewriter, loc, sourcePtr, pointerSlot);
+
+      Value lengthSlot = LLVM::GEPOp::create(rewriter, loc, ptrType, i64Type,
+                                             sourceLengths, index);
+      LLVM::StoreOp::create(rewriter, loc,
+                            i64Constant(layout->sourceLengths[i]), lengthSlot);
+
+      Value widthSlot = LLVM::GEPOp::create(rewriter, loc, ptrType, i64Type,
+                                            elementBytes, index);
+      int64_t bytes =
+          cast<IntegerType>(memrefType.getElementType()).getWidth() / 8;
+      LLVM::StoreOp::create(rewriter, loc, i64Constant(bytes), widthSlot);
+    }
+
+    SmallVector<Type> parameterTypes = {ptrType, ptrType, ptrType, ptrType,
+                                        ptrType, i64Type, i64Type};
+    FailureOr<LLVM::LLVMFuncOp> function = LLVM::lookupOrCreateFn(
+        rewriter, module, kHipReadbackControl, parameterTypes, i32Type);
+    if (failed(function))
+      return failure();
+    LLVM::CallOp call = LLVM::CallOp::create(
+        rewriter, loc, *function,
+        ValueRange{adaptor.getCtx(), hostValues, sourcePointers, sourceLengths,
+                   elementBytes, sourceCount, totalCount});
+
+    Value status = call.getResult();
+    Value valid = LLVM::ICmpOp::create(rewriter, loc, LLVM::ICmpPredicate::eq,
+                                       status, i32Constant(0));
+
+    SmallVector<Value> results;
+    results.reserve(1 + layout->totalCount);
+    results.push_back(valid);
+    for (int64_t i : llvm::seq<int64_t>(layout->totalCount)) {
+      Value index = i64Constant(i);
+      Value slot = LLVM::GEPOp::create(rewriter, loc, ptrType, i64Type,
+                                       hostValues, index);
+      results.push_back(LLVM::LoadOp::create(rewriter, loc, i64Type, slot));
+    }
+    rewriter.replaceOp(op, results);
+    return success();
+  }
+};
+
+} // namespace
+
+void populateReadbackControlLoweringPatterns(const LLVMTypeConverter &converter,
+                                             RewritePatternSet &patterns) {
+  patterns.add<ReadbackControlOpLowering>(converter);
+}
+
+} // namespace hip
+} // namespace mlir

--- a/lib/Conversion/HipToLLVM/ReadbackShapeLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ReadbackShapeLowering.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "HipToLLVMUtils.h"
+
+namespace mlir {
+namespace hip {
+namespace {
+
+// hip.readback_shape(%ctx, %vector {count = N}) -> N x index
+//   -> %host = llvm.alloca N x i64
+//      llvm.call @hipdnn_ep_readback_shape_i64(..., %host, %vector, N)
+//      N x llvm.load %host[i]
+//
+// The runtime performs one D2H copy and one stream synchronization for the
+// entire vector, then clamps negative entries and records the recoverable error
+// flag. Index lowers to i64 in the generated ABI.
+struct ReadbackShapeOpLowering
+    : public ConvertOpToLLVMPattern<ReadbackShapeOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(ReadbackShapeOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    int64_t count = op.getCount();
+    if (count == 0) {
+      rewriter.eraseOp(op);
+      return success();
+    }
+
+    auto vectorType = dyn_cast<MemRefType>(op.getVector().getType());
+    if (!vectorType)
+      return rewriter.notifyMatchFailure(op, "vector operand must be a memref");
+
+    ModuleOp module = op->getParentOfType<ModuleOp>();
+    Type ptrType = getPtrType();
+    Type i32Type = rewriter.getI32Type();
+    Type i64Type = rewriter.getI64Type();
+    Type voidType = LLVM::LLVMVoidType::get(rewriter.getContext());
+
+    Value vectorPtr = extractMemRefDataPtr(adaptor.getVector(), vectorType,
+                                           typeConverter, rewriter, loc);
+    if (!vectorPtr)
+      return rewriter.notifyMatchFailure(op, "failed to compute vector ptr");
+
+    Value countValue = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(count));
+    Value hostArray =
+        LLVM::AllocaOp::create(rewriter, loc, ptrType, i64Type, countValue,
+                               /*alignment=*/8);
+
+    SmallVector<Type, 4> parameterTypes = {ptrType, ptrType, ptrType, i64Type};
+    FailureOr<LLVM::LLVMFuncOp> function = LLVM::lookupOrCreateFn(
+        rewriter, module, kHipReadbackShapeI64, parameterTypes, voidType);
+    if (failed(function))
+      return failure();
+    LLVM::CallOp::create(
+        rewriter, loc, *function,
+        ValueRange{adaptor.getCtx(), hostArray, vectorPtr, countValue});
+
+    SmallVector<Value> results;
+    results.reserve(count);
+    for (int64_t i : llvm::seq<int64_t>(0, count)) {
+      Value index = LLVM::ConstantOp::create(rewriter, loc, i32Type,
+                                             rewriter.getI32IntegerAttr(i));
+      Value slot = LLVM::GEPOp::create(rewriter, loc, ptrType, i64Type,
+                                       hostArray, index);
+      results.push_back(LLVM::LoadOp::create(rewriter, loc, i64Type, slot));
+    }
+    rewriter.replaceOp(op, results);
+    return success();
+  }
+};
+
+} // namespace
+
+void populateReadbackShapeLoweringPatterns(const LLVMTypeConverter &converter,
+                                           RewritePatternSet &patterns) {
+  patterns.add<ReadbackShapeOpLowering>(converter);
+}
+
+} // namespace hip
+} // namespace mlir

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -2179,6 +2179,95 @@ void ReadbackScalarOp::getEffects(
                          SideEffects::DefaultResource::get());
 }
 
+void ReadbackShapeOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  // Operand order is (ctx, vector); attach the Read to the vector operand.
+  if (isa<MemRefType>(getVector().getType()))
+    effects.emplace_back(MemoryEffects::Read::get(),
+                         &getOperation()->getOpOperand(1),
+                         SideEffects::DefaultResource::get());
+}
+
+LogicalResult ReadbackShapeOp::verify() {
+  auto vectorType = dyn_cast<ShapedType>(getVector().getType());
+  if (!vectorType || !vectorType.hasRank() || vectorType.getRank() != 1)
+    return emitOpError("vector must be rank 1");
+  if (!vectorType.getElementType().isInteger(64))
+    return emitOpError("vector element type must be i64");
+  int64_t count = getCount();
+  if (count < 0)
+    return emitOpError("count must be non-negative");
+  if (vectorType.isDynamicDim(0) || vectorType.getDimSize(0) != count)
+    return emitOpError("vector length must be static and equal count");
+  if (static_cast<int64_t>(getNumResults()) != count)
+    return emitOpError("result count must equal count");
+  if (llvm::any_of(getResultTypes(),
+                   [](Type type) { return !isa<IndexType>(type); }))
+    return emitOpError("all results must be index type");
+  return success();
+}
+
+void ReadbackControlOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  for (OpOperand &source : getSourcesMutable()) {
+    if (isa<MemRefType>(source.get().getType()))
+      effects.emplace_back(MemoryEffects::Read::get(), &source,
+                           SideEffects::DefaultResource::get());
+  }
+}
+
+LogicalResult ReadbackControlOp::inferReturnTypes(
+    MLIRContext *context, std::optional<Location> location, ValueRange operands,
+    DictionaryAttr attributes, OpaqueProperties properties, RegionRange regions,
+    SmallVectorImpl<Type> &inferredReturnTypes) {
+  ReadbackControlOpAdaptor adaptor(operands, attributes, properties, regions);
+  SmallVector<Type> sourceTypes;
+  llvm::transform(adaptor.getSources(), std::back_inserter(sourceTypes),
+                  [](Value value) { return value.getType(); });
+  FailureOr<ReadbackControlLayout> layout =
+      getReadbackControlLayout(sourceTypes);
+  if (failed(layout))
+    return failure();
+
+  inferredReturnTypes.push_back(IntegerType::get(context, 1));
+  inferredReturnTypes.append(layout->totalCount, IntegerType::get(context, 64));
+  return success();
+}
+
+LogicalResult ReadbackControlOp::verify() {
+  SmallVector<Type> sourceTypes(getSources().getTypes());
+  FailureOr<ReadbackControlLayout> layout =
+      getReadbackControlLayout(sourceTypes);
+  if (failed(layout))
+    return emitOpError(
+        "requires one or more statically-sized rank-0/rank-1 i32/i64 sources");
+
+  for (auto [index, source] : llvm::enumerate(getSources())) {
+    auto memref = dyn_cast<MemRefType>(source.getType());
+    if (!memref || memref.getRank() == 0)
+      continue;
+    SmallVector<int64_t> strides;
+    int64_t offset = 0;
+    if (failed(memref.getStridesAndOffset(strides, offset)) ||
+        strides.size() != 1 || strides.front() != 1)
+      return emitOpError("memref source #")
+             << index << " must be contiguous (unit rank-1 stride)";
+  }
+
+  if (!getValid().getType().isInteger(1))
+    return emitOpError("valid result must be i1");
+  if (static_cast<int64_t>(getValues().size()) != layout->totalCount)
+    return emitOpError("expected ")
+           << layout->totalCount << " i64 value results, got "
+           << getValues().size();
+  if (llvm::any_of(getValues().getTypes(),
+                   [](Type type) { return !type.isInteger(64); }))
+    return emitOpError("all flattened value results must be i64");
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // SizeOp: ins(x), outs(y)
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/IR/HipShapeUtils.cpp
+++ b/lib/Dialect/IR/HipShapeUtils.cpp
@@ -62,6 +62,41 @@ std::string formatShape(ArrayRef<int64_t> shape) {
 
 } // namespace mlir::hip::detail
 
+FailureOr<ReadbackControlLayout>
+mlir::hip::getReadbackControlLayout(TypeRange sourceTypes) {
+  if (sourceTypes.empty())
+    return failure();
+
+  ReadbackControlLayout layout;
+  layout.sourceLengths.reserve(sourceTypes.size());
+  layout.resultOffsets.reserve(sourceTypes.size() + 1);
+  layout.resultOffsets.push_back(0);
+
+  for (Type type : sourceTypes) {
+    auto shaped = dyn_cast<ShapedType>(type);
+    if (!shaped || !shaped.hasRank() ||
+        (shaped.getRank() != 0 && shaped.getRank() != 1))
+      return failure();
+    Type elementType = shaped.getElementType();
+    if (!elementType.isInteger(32) && !elementType.isInteger(64))
+      return failure();
+
+    int64_t length = 1;
+    if (shaped.getRank() == 1) {
+      if (shaped.isDynamicDim(0))
+        return failure();
+      length = shaped.getDimSize(0);
+    }
+    if (length < 0 ||
+        layout.totalCount > std::numeric_limits<int64_t>::max() - length)
+      return failure();
+    layout.sourceLengths.push_back(length);
+    layout.totalCount += length;
+    layout.resultOffsets.push_back(layout.totalCount);
+  }
+  return layout;
+}
+
 namespace {
 
 FailureOr<OpFoldResult>

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -450,6 +450,7 @@ if(NOT BUILD_MOCK_RUNTIME)
 else()
     # Mock runtime for testing without GPU
     compile_to_bitcode(mock/mock_gpu.cpp runtime_mock.bc)
+    compile_to_bitcode(mock/readback_control.cpp runtime_readback_control.bc)
     compile_to_bitcode(mock/memory.cpp runtime_memory.bc)
     compile_to_bitcode(mock/test_hip_from_dll.cpp test_hip_from_dll.bc)
     # Mock per-op state constructors (real ones live in each op's real/ TU).
@@ -468,6 +469,7 @@ else()
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_op_state.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_op_state_stubs.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_memory.bc
+        ${CMAKE_CURRENT_BINARY_DIR}/runtime_readback_control.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_mock.bc
         ${CMAKE_CURRENT_BINARY_DIR}/test_hip_from_dll.bc
     )

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -1466,6 +1466,23 @@ int32_t hipdnn_ep_readback_i32(RuntimeState *state, const void *device_scalar);
 void hipdnn_ep_readback_scalar(RuntimeState *state, void *host_dst,
                                const void *device_scalar, int64_t num_bytes);
 
+// Synchronize once and copy a rank-1 i64 shape vector to `host_out`, which must
+// contain `count` slots. Negative entries are clamped to zero and record the
+// recoverable runtime error flag.
+void hipdnn_ep_readback_shape_i64(RuntimeState *state, int64_t *host_out,
+                                  const void *device_vector, int64_t count);
+
+// Read a group of statically-sized i32/i64 control buffers with one stream
+// synchronization. Sources are flattened in operand-major order. `host_out`
+// is zero-initialized before any HIP call; i32 values are sign-extended and i64
+// values are preserved without clamping. Returns zero only when all copies and
+// the synchronization succeed, otherwise records the shared error flag.
+int hipdnn_ep_readback_control(RuntimeState *state, int64_t *host_out,
+                               const void *const *device_sources,
+                               const int64_t *element_counts,
+                               const int64_t *element_bytes,
+                               int64_t source_count, int64_t total_count);
+
 // ONNX Size wrapper (dynamic-shape path only).
 //
 // Static-shape Size ops are folded into arith.constant at OnnxToHip time

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -1853,6 +1853,23 @@ void hipdnn_ep_readback_scalar(RuntimeState *state, void *host_dst,
   memcpy(host_dst, device_scalar, static_cast<size_t>(num_bytes));
 }
 
+void hipdnn_ep_readback_shape_i64(RuntimeState *state, int64_t *host_out,
+                                  const void *device_vector, int64_t count) {
+  if (!state || !host_out || count < 0 || (count > 0 && !device_vector)) {
+    if (state)
+      (void)hipdnn_ep_state_set_error_flag(state);
+    return;
+  }
+  const int64_t *input = static_cast<const int64_t *>(device_vector);
+  bool invalid = false;
+  for (int64_t i = 0; i < count; ++i) {
+    invalid |= input[i] < 0;
+    host_out[i] = input[i] < 0 ? 0 : input[i];
+  }
+  if (invalid)
+    (void)hipdnn_ep_state_set_error_flag(state);
+}
+
 int wrap_cos(RuntimeState *state, void *input, void *output,
              int64_t num_elements, int64_t data_type) {
   if (!state) {

--- a/lib/Runtime/mock/readback_control.cpp
+++ b/lib/Runtime/mock/readback_control.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "../hipdnn_ep_runtime.h"
+
+#include <cstring>
+#include <limits>
+
+int hipdnn_ep_readback_control(RuntimeState *state, int64_t *host_out,
+                               const void *const *device_sources,
+                               const int64_t *element_counts,
+                               const int64_t *element_bytes,
+                               int64_t source_count, int64_t total_count) {
+  auto setError = [&]() {
+    if (state)
+      (void)hipdnn_ep_state_set_error_flag(state);
+    return -1;
+  };
+  bool outputRangeValid =
+      host_out && total_count >= 0 &&
+      static_cast<uint64_t>(total_count) <=
+          std::numeric_limits<size_t>::max() / sizeof(int64_t);
+  auto zeroOutput = [&]() {
+    if (!outputRangeValid)
+      return;
+    for (int64_t i = 0; i < total_count; ++i)
+      host_out[i] = 0;
+  };
+
+  if (!state || !outputRangeValid || !device_sources || !element_counts ||
+      !element_bytes || source_count <= 0 ||
+      static_cast<uint64_t>(source_count) >
+          std::numeric_limits<size_t>::max() / sizeof(void *)) {
+    zeroOutput();
+    return setError();
+  }
+
+  // Validate the complete descriptor table before copying source 0. A malformed
+  // late source must not leave an earlier source visible in host_out.
+  int64_t checkedTotal = 0;
+  bool descriptorsValid = true;
+  for (int64_t i = 0; i < source_count; ++i) {
+    int64_t count = element_counts[i];
+    int64_t width = element_bytes[i];
+    if (count < 0 || (width != 4 && width != 8) ||
+        (count > 0 && !device_sources[i]) ||
+        count > std::numeric_limits<int64_t>::max() - checkedTotal ||
+        static_cast<uint64_t>(count) >
+            std::numeric_limits<size_t>::max() / static_cast<size_t>(width)) {
+      descriptorsValid = false;
+      break;
+    }
+    checkedTotal += count;
+  }
+  if (!descriptorsValid || checkedTotal != total_count) {
+    zeroOutput();
+    return setError();
+  }
+
+  zeroOutput();
+  int64_t outputIndex = 0;
+  for (int64_t i = 0; i < source_count; ++i) {
+    const unsigned char *source =
+        static_cast<const unsigned char *>(device_sources[i]);
+    for (int64_t j = 0; j < element_counts[i]; ++j) {
+      if (element_bytes[i] == 4) {
+        int32_t value = 0;
+        std::memcpy(&value, source + static_cast<size_t>(j) * sizeof(value),
+                    sizeof(value));
+        host_out[outputIndex++] = static_cast<int64_t>(value);
+      } else {
+        int64_t value = 0;
+        std::memcpy(&value, source + static_cast<size_t>(j) * sizeof(value),
+                    sizeof(value));
+        host_out[outputIndex++] = value;
+      }
+    }
+  }
+  return 0;
+}

--- a/lib/Runtime/real/memory.cpp
+++ b/lib/Runtime/real/memory.cpp
@@ -9,6 +9,9 @@
 #include "runtime_types.h"
 
 #include <cstdio>
+#include <cstring>
+#include <limits>
+#include <vector>
 
 // GPU D2D memcpy via hipMemcpyAsync.
 // Follows opaque RuntimeState pattern - extracts stream internally
@@ -247,4 +250,163 @@ void hipdnn_ep_readback_scalar(RuntimeState *state, void *host_dst,
     fprintf(stderr, "hipdnn_ep_readback_scalar: stream sync failed: %s\n",
             hipGetErrorString(err));
   }
+}
+
+void hipdnn_ep_readback_shape_i64(RuntimeState *state, int64_t *host_out,
+                                  const void *device_vector, int64_t count) {
+  OP_PROFILE_CPU("readback_shape", state);
+  if (!state || !host_out || count < 0 || (count > 0 && !device_vector)) {
+    fprintf(stderr, "hipdnn_ep_readback_shape_i64: invalid argument\n");
+    if (state)
+      (void)hipdnn_ep_state_set_error_flag(state);
+    return;
+  }
+  if (count == 0)
+    return;
+
+  auto fail = [&]() {
+    for (int64_t i = 0; i < count; ++i)
+      host_out[i] = 0;
+    (void)hipdnn_ep_state_set_error_flag(state);
+  };
+
+  hipStream_t stream =
+      static_cast<hipStream_t>(hipdnn_ep_state_get_stream(state));
+  hipError_t err = hipMemcpyAsync(host_out, device_vector,
+                                  static_cast<size_t>(count) * sizeof(int64_t),
+                                  hipMemcpyDefault, stream);
+  if (err != hipSuccess) {
+    fprintf(stderr, "hipdnn_ep_readback_shape_i64: D2H copy failed: %s\n",
+            hipGetErrorString(err));
+    fail();
+    return;
+  }
+  err = hipStreamSynchronize(stream);
+  if (err != hipSuccess) {
+    fprintf(stderr, "hipdnn_ep_readback_shape_i64: stream sync failed: %s\n",
+            hipGetErrorString(err));
+    fail();
+    return;
+  }
+
+  bool invalid = false;
+  for (int64_t i = 0; i < count; ++i) {
+    invalid |= host_out[i] < 0;
+    if (host_out[i] < 0)
+      host_out[i] = 0;
+  }
+  if (invalid)
+    (void)hipdnn_ep_state_set_error_flag(state);
+}
+
+int hipdnn_ep_readback_control(RuntimeState *state, int64_t *host_out,
+                               const void *const *device_sources,
+                               const int64_t *element_counts,
+                               const int64_t *element_bytes,
+                               int64_t source_count, int64_t total_count) {
+  OP_PROFILE_CPU("readback_control", state);
+
+  auto fail = [&]() {
+    if (state)
+      (void)hipdnn_ep_state_set_error_flag(state);
+    return -1;
+  };
+  if (!state || !host_out || !device_sources || !element_counts ||
+      !element_bytes || source_count <= 0 || total_count < 0 ||
+      static_cast<uint64_t>(source_count) >
+          std::numeric_limits<size_t>::max() / sizeof(size_t) ||
+      static_cast<uint64_t>(total_count) >
+          std::numeric_limits<size_t>::max() / sizeof(int64_t)) {
+    fprintf(stderr, "hipdnn_ep_readback_control: invalid argument\n");
+    return fail();
+  }
+
+  for (int64_t i = 0; i < total_count; ++i)
+    host_out[i] = 0;
+
+  size_t totalBytes = 0;
+  int64_t checkedTotal = 0;
+  std::vector<size_t> byteOffsets(static_cast<size_t>(source_count));
+  for (int64_t i = 0; i < source_count; ++i) {
+    int64_t count = element_counts[i];
+    int64_t width = element_bytes[i];
+    if (count < 0 || (width != 4 && width != 8) ||
+        (count > 0 && !device_sources[i]) ||
+        count > std::numeric_limits<int64_t>::max() - checkedTotal ||
+        static_cast<uint64_t>(count) >
+            std::numeric_limits<size_t>::max() / static_cast<size_t>(width)) {
+      fprintf(stderr,
+              "hipdnn_ep_readback_control: invalid source descriptor %lld\n",
+              (long long)i);
+      return fail();
+    }
+    size_t bytes = static_cast<size_t>(count) * static_cast<size_t>(width);
+    if (bytes > std::numeric_limits<size_t>::max() - totalBytes) {
+      fprintf(stderr, "hipdnn_ep_readback_control: byte count overflow\n");
+      return fail();
+    }
+    byteOffsets[static_cast<size_t>(i)] = totalBytes;
+    totalBytes += bytes;
+    checkedTotal += count;
+  }
+  if (checkedTotal != total_count) {
+    fprintf(stderr,
+            "hipdnn_ep_readback_control: flattened count mismatch "
+            "(descriptors=%lld, output=%lld)\n",
+            (long long)checkedTotal, (long long)total_count);
+    return fail();
+  }
+
+  std::vector<unsigned char> staging(totalBytes);
+  hipStream_t stream =
+      static_cast<hipStream_t>(hipdnn_ep_state_get_stream(state));
+  bool enqueueFailed = false;
+  for (int64_t i = 0; i < source_count; ++i) {
+    int64_t count = element_counts[i];
+    if (count == 0)
+      continue;
+    size_t bytes =
+        static_cast<size_t>(count) * static_cast<size_t>(element_bytes[i]);
+    hipError_t err =
+        hipMemcpyAsync(staging.data() + byteOffsets[static_cast<size_t>(i)],
+                       device_sources[i], bytes, hipMemcpyDefault, stream);
+    if (err != hipSuccess) {
+      fprintf(stderr,
+              "hipdnn_ep_readback_control: source %lld D2H enqueue failed: "
+              "%s\n",
+              (long long)i, hipGetErrorString(err));
+      enqueueFailed = true;
+    }
+  }
+
+  // Exactly one synchronization covers every successfully enqueued source.
+  // It is intentionally unconditional after enqueue attempts so a partial
+  // enqueue failure cannot leave an earlier copy using `staging` after return.
+  hipError_t syncError = hipStreamSynchronize(stream);
+  if (syncError != hipSuccess) {
+    fprintf(stderr, "hipdnn_ep_readback_control: stream sync failed: %s\n",
+            hipGetErrorString(syncError));
+  }
+  if (enqueueFailed || syncError != hipSuccess)
+    return fail();
+
+  int64_t outputIndex = 0;
+  for (int64_t i = 0; i < source_count; ++i) {
+    if (element_counts[i] == 0)
+      continue;
+    const unsigned char *source =
+        staging.data() + byteOffsets[static_cast<size_t>(i)];
+    for (int64_t j = 0; j < element_counts[i]; ++j) {
+      if (element_bytes[i] == 4) {
+        int32_t value = 0;
+        std::memcpy(&value, source + static_cast<size_t>(j) * 4, sizeof(value));
+        host_out[outputIndex++] = static_cast<int64_t>(value);
+      } else {
+        int64_t value = 0;
+        std::memcpy(&value, source + static_cast<size_t>(j) * 8, sizeof(value));
+        host_out[outputIndex++] = value;
+      }
+    }
+  }
+  return 0;
 }

--- a/test/lit/Conversion/hip-to-llvm/test_readback_control.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_readback_control.mlir
@@ -1,0 +1,22 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --convert-hip-to-llvm %s | FileCheck %s
+
+// CHECK-LABEL: llvm.func @readback_control
+// CHECK: %[[HOST:.*]] = llvm.alloca
+// CHECK: llvm.getelementptr
+// CHECK-COUNT-1: llvm.call @hipdnn_ep_readback_control
+// CHECK-SAME: (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64) -> i32
+// CHECK: llvm.icmp "eq"
+// CHECK-COUNT-3: llvm.load
+func.func @readback_control(
+    %ctx: !hip.context,
+    %i32s: memref<2xi32, strided<[1], offset: ?>>,
+    %i64scalar: memref<i64>) -> (i1, i64, i64, i64) {
+  %r:4 = hip.readback_control(
+      %ctx, %i32s, %i64scalar :
+      memref<2xi32, strided<[1], offset: ?>>, memref<i64>)
+      -> (i1, i64, i64, i64)
+  return %r#0, %r#1, %r#2, %r#3 : i1, i64, i64, i64
+}

--- a/test/lit/Conversion/hip-to-llvm/test_readback_shape.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_readback_shape.mlir
@@ -1,0 +1,21 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --convert-hip-to-llvm %s | FileCheck %s
+
+// CHECK-LABEL: llvm.func @readback_shape
+// CHECK: %[[HOST:.*]] = llvm.alloca
+// CHECK-COUNT-1: llvm.call @hipdnn_ep_readback_shape_i64
+// CHECK: llvm.getelementptr %[[HOST]]
+// CHECK: llvm.load
+// CHECK: llvm.getelementptr %[[HOST]]
+// CHECK: llvm.load
+// CHECK: llvm.getelementptr %[[HOST]]
+// CHECK: llvm.load
+func.func @readback_shape(%ctx: !hip.context,
+                          %shape: memref<3xi64, 1>)
+    -> (index, index, index) {
+  %d:3 = hip.readback_shape(%ctx, %shape : memref<3xi64, 1>)
+      {count = 3 : i64} -> (index, index, index)
+  return %d#0, %d#1, %d#2 : index, index, index
+}

--- a/test/lit/Dialect/hip-readback-control-bufferize.mlir
+++ b/test/lit/Dialect/hip-readback-control-bufferize.mlir
@@ -1,0 +1,18 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --one-shot-bufferize="bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" %s | FileCheck %s
+
+// CHECK-LABEL: func.func @bufferize
+// CHECK-SAME: %[[I32:[^,]+]]: memref<2xi32>
+// CHECK-SAME: %[[I64:[^)]+]]: memref<i64>
+// CHECK: %[[VALID:.*]], %[[VALUES:.*]]:3 = hip.readback_control
+// CHECK-SAME: %[[I32]], %[[I64]] : memref<2xi32>, memref<i64>
+// CHECK-SAME: -> (i1, i64, i64, i64)
+func.func @bufferize(%ctx: !hip.context, %i32s: tensor<2xi32>,
+                     %i64scalar: tensor<i64>) -> i1 {
+  %r:4 = hip.readback_control(
+      %ctx, %i32s, %i64scalar : tensor<2xi32>, tensor<i64>)
+      -> (i1, i64, i64, i64)
+  return %r#0 : i1
+}

--- a/test/lit/Dialect/hip-readback-control-verifier.mlir
+++ b/test/lit/Dialect/hip-readback-control-verifier.mlir
@@ -1,0 +1,44 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --split-input-file --verify-diagnostics %s
+
+func.func @dynamic_length(%ctx: !hip.context, %source: tensor<?xi32>) {
+  // expected-error @+1 {{requires one or more statically-sized rank-0/rank-1 i32/i64 sources}}
+  %r:2 = hip.readback_control(%ctx, %source : tensor<?xi32>) -> (i1, i64)
+  return
+}
+
+// -----
+
+func.func @rank_two(%ctx: !hip.context, %source: tensor<1x1xi64>) {
+  // expected-error @+1 {{requires one or more statically-sized rank-0/rank-1 i32/i64 sources}}
+  %r:2 = hip.readback_control(%ctx, %source : tensor<1x1xi64>) -> (i1, i64)
+  return
+}
+
+// -----
+
+func.func @wrong_element_type(%ctx: !hip.context, %source: tensor<1xf32>) {
+  // expected-error @+1 {{requires one or more statically-sized rank-0/rank-1 i32/i64 sources}}
+  %r:2 = hip.readback_control(%ctx, %source : tensor<1xf32>) -> (i1, i64)
+  return
+}
+
+// -----
+
+func.func @wrong_result_count(%ctx: !hip.context, %source: tensor<2xi64>) {
+  // expected-error @+1 {{expected 2 i64 value results, got 1}}
+  %r:2 = hip.readback_control(%ctx, %source : tensor<2xi64>) -> (i1, i64)
+  return
+}
+
+// -----
+
+func.func @noncontiguous(%ctx: !hip.context,
+                         %source: memref<2xi64, strided<[2]>>) {
+  // expected-error @+1 {{memref source #0 must be contiguous}}
+  %r:3 = hip.readback_control(
+      %ctx, %source : memref<2xi64, strided<[2]>>) -> (i1, i64, i64)
+  return
+}

--- a/test/runtime/CMakeLists.txt
+++ b/test/runtime/CMakeLists.txt
@@ -205,3 +205,16 @@ target_compile_definitions(test-loop-frame PRIVATE
 target_link_libraries(test-loop-frame PRIVATE Threads::Threads)
 add_test(NAME LoopFrameUnitTest COMMAND test-loop-frame)
 set_target_properties(test-loop-frame PROPERTIES FOLDER "runtime-tests")
+
+# Mock grouped-control readback semantics, including failure atomicity when a
+# later source descriptor is malformed.
+add_executable(test-readback-control
+    test_readback_control.cpp
+    ${CMAKE_SOURCE_DIR}/lib/Runtime/mock/readback_control.cpp
+)
+target_compile_features(test-readback-control PRIVATE cxx_std_17)
+target_include_directories(test-readback-control PRIVATE
+    ${CMAKE_SOURCE_DIR}/lib/Runtime
+)
+add_test(NAME ReadbackControlUnitTest COMMAND test-readback-control)
+set_target_properties(test-readback-control PROPERTIES FOLDER "runtime-tests")

--- a/test/runtime/test_readback_control.cpp
+++ b/test/runtime/test_readback_control.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "hipdnn_ep_runtime.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <limits>
+
+struct RuntimeState {
+  bool error = false;
+};
+
+extern "C" int hipdnn_ep_state_set_error_flag(RuntimeState *state) {
+  if (state)
+    state->error = true;
+  return 0;
+}
+
+namespace {
+
+int failures = 0;
+
+void expect(bool condition, const char *message) {
+  if (condition)
+    return;
+  std::fprintf(stderr, "FAIL: %s\n", message);
+  ++failures;
+}
+
+} // namespace
+
+int main() {
+  RuntimeState state;
+  int32_t i32Values[] = {-7, 19};
+  int64_t i64Value = std::numeric_limits<int64_t>::min();
+  const void *sources[] = {i32Values, &i64Value};
+  int64_t counts[] = {2, 1};
+  int64_t widths[] = {4, 8};
+  int64_t output[] = {91, 92, 93};
+
+  int status =
+      hipdnn_ep_readback_control(&state, output, sources, counts, widths, 2, 3);
+  expect(status == 0 && !state.error, "valid descriptors must succeed");
+  expect(output[0] == -7 && output[1] == 19 &&
+             output[2] == std::numeric_limits<int64_t>::min(),
+         "i32 sign extension and signed i64 preservation");
+
+  // Source 0 is valid and would be copied first by the old implementation.
+  // Source 1 is deliberately malformed late in the table. No partial values
+  // may survive: failure leaves every declared output slot safely zero.
+  state.error = false;
+  output[0] = 81;
+  output[1] = 82;
+  output[2] = 83;
+  int64_t malformedWidths[] = {4, 2};
+  status = hipdnn_ep_readback_control(&state, output, sources, counts,
+                                      malformedWidths, 2, 3);
+  expect(status != 0 && state.error,
+         "late malformed source must set the shared error flag");
+  expect(output[0] == 0 && output[1] == 0 && output[2] == 0,
+         "late malformed source must not expose a partial copy");
+
+  if (failures != 0)
+    return 1;
+  std::puts("Readback control tests passed");
+  return 0;
+}


### PR DESCRIPTION
## Why

Some operations derive output dimensions from runtime tensor values rather than from input tensor shapes alone. They need a payload-driven shape path that can read a small vector of values from the GPU once, then use those values to construct the correct destination shape.

Reading each scalar separately would add synchronization and duplicate dtype handling. Payload consumers also need one contract for visible constants, stamped values, and runtime values so converter construction and shape reification cannot drift.

This PR adds grouped control readback for Tile and shares constant or stamped payload rules across Pad, Slice, Expand, Range, and Tile. It keeps Slice's physical destination capacity distinct from its runtime logical extent and retains DPS-init fallback when payload values are not statically available.

## IR example

The changed bufferization test reads a two-element i32 tensor and an i64 scalar in one operation:

```mlir
func.func @bufferize(%ctx: !hip.context, %i32s: tensor<2xi32>,
                     %i64scalar: tensor<i64>) -> i1 {
  %r:4 = hip.readback_control(
      %ctx, %i32s, %i64scalar : tensor<2xi32>, tensor<i64>)
      -> (i1, i64, i64, i64)
  return %r#0 : i1
}
```

One-Shot Bufferize converts the tensor operands to memrefs while preserving one validity result and three widened i64 values. The real runtime performs one synchronized grouped readback; the mock runtime follows the same contract.

## What changes

- Introduce grouped `hip.readback_control` with bufferization, LLVM lowering, and real and mock runtime support.
- Use one synchronized readback to size Tile outputs from runtime repeats, including partially static results.
- Share constant and stamped Pad, Slice, Expand, Range, and Tile shape rules between converter construction and reification.
- Preserve Slice's distinction between physical destination capacity and runtime logical extent.
- Use DPS-init shape fallback when payload values cannot be resolved statically.
- Consolidate constant extraction used by payload converters and pre-lowering folds.
- Carry integer element types through grouped readback and widen supported values to i64.
- Keep strided loop captures safe before runtime calls that consume contiguous pointers.
- Add dialect, conversion, lowering, pipeline, runtime, numeric, and end-to-end coverage.

## Stack

1. [#688 — constant externalization](https://github.com/ROCm/hip-ep/pull/688)
2. [#754 — i1 pool sizing](https://github.com/ROCm/hip-ep/pull/754)
3. [#756 — ORT error propagation](https://github.com/ROCm/hip-ep/pull/756)
4. [#758 — exact output views](https://github.com/ROCm/hip-ep/pull/758)
5. [#755 — pool namespaces](https://github.com/ROCm/hip-ep/pull/755)
6. [#757 — host-scratch namespaces](https://github.com/ROCm/hip-ep/pull/757)
7. [#724 — symbolic transport](https://github.com/ROCm/hip-ep/pull/724)
8. [#759 — artifact ABI guard](https://github.com/ROCm/hip-ep/pull/759)
9. [#639 — shape-rule foundation](https://github.com/ROCm/hip-ep/pull/639)
10. [#681 — reshape provenance](https://github.com/ROCm/hip-ep/pull/681)
11. [#725 — broadcast activation](https://github.com/ROCm/hip-ep/pull/725)
12. [#763 — Softmax buffer reuse](https://github.com/ROCm/hip-ep/pull/763)
13. [#640 — MatMul/Gemm runtime](https://github.com/ROCm/hip-ep/pull/640)
14. [#734 — MatMul/Gemm shapes](https://github.com/ROCm/hip-ep/pull/734)
15. [#641 — broadcast contracts](https://github.com/ROCm/hip-ep/pull/641)
16. [#735 — reduction conversion](https://github.com/ROCm/hip-ep/pull/735)
17. [#736 — reduction contracts](https://github.com/ROCm/hip-ep/pull/736)
18. [#689 — loop frame ABI](https://github.com/ROCm/hip-ep/pull/689)
19. [#737 — shape-changing loops](https://github.com/ROCm/hip-ep/pull/737)
20. [#762 — loop bank recycling](https://github.com/ROCm/hip-ep/pull/762)
21. [#642 — grouped readback](https://github.com/ROCm/hip-ep/pull/642) ← this PR
22. [#727 — payload shapes](https://github.com/ROCm/hip-ep/pull/727)
23. [#728 — Tile/Range destinations](https://github.com/ROCm/hip-ep/pull/728)
24. [#729 — Slice normalization](https://github.com/ROCm/hip-ep/pull/729)
25. [#731 — exact Slice ABI](https://github.com/ROCm/hip-ep/pull/731)
26. [#733 — loop payload integration](https://github.com/ROCm/hip-ep/pull/733)
27. [#643 — convolution contracts](https://github.com/ROCm/hip-ep/pull/643)
28. [#738 — pooling contracts](https://github.com/ROCm/hip-ep/pull/738)
29. [#742 — causal convolution contracts](https://github.com/ROCm/hip-ep/pull/742)
30. [#644 — gather/tensor contracts](https://github.com/ROCm/hip-ep/pull/644)
31. [#739 — block-quantized Gather](https://github.com/ROCm/hip-ep/pull/739)
32. [#645 — normalization contracts](https://github.com/ROCm/hip-ep/pull/645)
33. [#740 — attention contracts](https://github.com/ROCm/hip-ep/pull/740)
34. [#741 — GQA capacity](https://github.com/ROCm/hip-ep/pull/741)
35. [#743 — GQA feature rejection](https://github.com/ROCm/hip-ep/pull/743)
36. [#646 — explicit DPS contracts](https://github.com/ROCm/hip-ep/pull/646)
37. [#730 — contract inventory audit](https://github.com/ROCm/hip-ep/pull/730)
38. [#732 — converter dedup audit](https://github.com/ROCm/hip-ep/pull/732)
39. [#647 — refinement hardening](https://github.com/ROCm/hip-ep/pull/647)
40. [#761 — split shape utilities](https://github.com/ROCm/hip-ep/pull/761)
41. [#764 — destination authority](https://github.com/ROCm/hip-ep/pull/764)

## AI assistance

AI tools assisted with the payload-shape refactoring and stack reconstruction. The contributor reviewed and validated the resulting code.

Made-with: Cursor