### PR TITLE
fix(shape): share normalization contracts

### DIFF
--- a/docs/design/hip-shape-inference.md
+++ b/docs/design/hip-shape-inference.md
@@ -123,7 +123,7 @@ This gives two related but distinct jobs:
 | `InferTypeOpInterface` | Builds result types from DPS init operand types |
 | `ReifyRankedShapedTypeOpInterface` | Materializes static dimensions as attributes and dynamic dimensions as SSA values |
 | `InferShapedTypeOpInterface` | Not used as the primary HIP DPS contract |
-| `HipDpsOpInterface` | Dialect marker interface extending `DestinationStyleOpInterface`; owns the shared default reification body |
+| `HipDpsOpInterface` | Dialect marker extending `DestinationStyleOpInterface`; owns shared whole-shape and direct-dimension reification |
 
 `HipDpsOpInterface` is a generated MLIR `OpInterface`, but it is not a replacement for the standard InferType/Reify contracts. It marks HIP DPS compute operations and provides their shared default reification behavior. In tensor mode it walks `DestinationStyleOpInterface::getDpsInits()` and returns each destination's mixed sizes through `tensor::getMixedSizes`, exactly one vector per SSA result. In memref mode there are no SSA results, so it succeeds with an empty list.
 
@@ -270,6 +270,10 @@ Reification returns one `OpFoldResult` for each result dimension:
 Reification is allowed to create IR at the caller's insertion point. Helpers therefore reuse operand dimensions where possible, fold constant operands and attributes, and avoid pretending that a runtime-computed extent is static. For operations whose runtime extent cannot be represented before execution, the honest result remains dynamic.
 
 Reification is per result: `reifyResultShapes` returns one shape vector for every tensor result. The number and rank of those vectors must match the operation's tensor results even when the implementation derives them from DPS init operands.
+
+Dimension-only consumers use the standard `ReifyRankedShapedTypeOpInterface::reifyDimOfResult` hook. HIP DPS operations implement it directly from `DestinationStyleOpInterface::getTiedOpOperand`, whose contract gives every tensor result one destination with the same type and runtime extents. This direct path validates the result/init cardinality, exact types, and dimension index before emitting IR, then materializes only the requested destination extent.
+
+Whole-shape semantic reification remains the authority for inference and refinement. The direct hook is its bounded, destination-based equivalent for a valid DPS operation.
 
 ### Shared converter/reification shape helpers
 

--- a/docs/design/hip-shape-inference.md
+++ b/docs/design/hip-shape-inference.md
@@ -174,7 +174,8 @@ Choose the smallest mechanism that matches the operation's semantics:
 | OneHot, Compress, TopK | Dedicated reification thunks |
 | Pad, Tile, Expand, Slice, Range | Fold-or-bail helpers with fallback to DPS-init shape |
 | MatMul/Gemm/MatMulNBits | Dedicated shape logic based on operand dimensions and attributes |
-| Attention or normalization with multiple destinations | One shape vector per DPS init unless an op supplies a dedicated thunk |
+| LayerNormalization | Y equals input; Mean/InvStdDev use keepdims reduction shape over `[axis, rank)` |
+| SkipSimplifiedLayerNormalization | Output and optional residual sum equal input; training stats rejected |
 | Forward Conv (rank-3 converter/rank-4 HIP op) | Shared signed-floor spatial-window formula used by converter, reification, and verifier |
 | Rank-4 NCHW ConvTranspose | Shared ONNX formula used by converter, reification, and verifier |
 | CausalConvWithState | Runtime-supported 1D output/state formulas from input and depthwise kernel |
@@ -337,6 +338,16 @@ more dynamic than the weight, the state length still comes from `weight.K-1`.
 The mixed helper emits subtraction only after its pure helper has validated
 rank, depthwise layout, channel agreement, optional bias/state, and the current
 runtime restriction `ndim=1`.
+
+SkipSimplifiedLayerNormalization's implemented outputs are the normalized
+output and optional `input_skip_bias_sum`; both have the input shape. The
+runtime flattens every non-final input axis into `num_rows`, requires skip to
+match input, and takes `hidden_dim` from rank-1 gamma (and optional bias).
+The ONNX schema's optional mean and inverse-standard-deviation outputs are
+training outputs and are not implemented by `hip.skip_rms_norm`. Conversion
+accepts every inference output arity (one to four schema slots with omitted
+stats) but rejects a real stats tensor rather than treating the last present
+tensor as the residual output.
 
 Reductions resolve to one internal out-to-in dimension map, consumed by both
 `inferReductionShape` (static extents) and `reifyReductionResultShape` (mixed

--- a/include/hip/Conversion/HipConversionUtils.h
+++ b/include/hip/Conversion/HipConversionUtils.h
@@ -32,6 +32,12 @@ DenseElementsAttr matchHipCompileTimeConstantTensor(Value value);
 bool isResultTypeCompatibleWithInferredShape(
     RankedTensorType resultType, llvm::ArrayRef<int64_t> inferredShape);
 
+/// Derive a ranked tensor type from a reified shape. Constant dimensions become
+/// static and every SSA dimension remains dynamic.
+RankedTensorType
+getTensorTypeFromReifiedShape(llvm::ArrayRef<OpFoldResult> reifiedShape,
+                              Type elementType, Attribute encoding = {});
+
 /// Build a tensor.empty with \p resultType and the dynamic sizes described by
 /// \p reifiedShape. Validation completes before index or destination IR emits.
 FailureOr<Value>

--- a/include/hip/Dialect/IR/HipDpsOpInterface.td
+++ b/include/hip/Dialect/IR/HipDpsOpInterface.td
@@ -12,7 +12,8 @@ include "mlir/Interfaces/DestinationStyleOpInterface.td"
 def HipDpsOpInterface : OpInterface<"HipDpsOp", [DestinationStyleOpInterface]> {
   let description = [{
     Marker interface for HIP destination-passing-style compute ops. Carries
-    a single shared default `reifyResultShapes` body. In tensor mode it walks
+    shared `reifyResultShapes` and `reifyDimOfResult` bodies. In tensor mode
+    whole-shape reification walks
     `DestinationStyleOpInterface::getDpsInits()` and lifts each init operand's
     runtime shape via `tensor::getMixedSizes`, producing exactly one vector per
     SSA result. In memref mode the operation has no SSA results, so reification
@@ -21,9 +22,11 @@ def HipDpsOpInterface : OpInterface<"HipDpsOp", [DestinationStyleOpInterface]> {
     `B.shape[-1]` rather than from the outs operand -- select a manual-reify
     family and provide a per-op override.
 
-    The interface owns the default body in a sibling `.cpp` file, and
-    the per-op `ReifyRankedShapedTypeOpInterface::reifyResultShapes` is
-    a three-line dispatcher emitted by the operation's behavior family.
+    Single-dimension reification follows the exact tied DPS destination through
+    `DestinationStyleOpInterface::getTiedOpOperand`. This avoids rebuilding
+    every result dimension when an upstream dim-resolution pattern requests
+    only one. The interface owns both default bodies in a sibling `.cpp` file;
+    operation behavior families emit the standard-interface dispatchers.
   }];
 
   let cppNamespace = "::mlir::hip";
@@ -43,6 +46,11 @@ def HipDpsOpInterface : OpInterface<"HipDpsOp", [DestinationStyleOpInterface]> {
     ::mlir::LogicalResult reifyResultShapes(
         ::mlir::OpBuilder &b,
         ::mlir::ReifiedRankedShapedTypeDims &reifiedReturnShapes);
+
+    /// Return one result dimension from its tied DPS destination. All result,
+    /// destination, and dimension checks complete before this method emits IR.
+    ::llvm::FailureOr<::mlir::OpFoldResult> reifyDimOfResult(
+        ::mlir::OpBuilder &b, int resultIndex, int dim);
   }];
 }
 

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -1109,7 +1109,9 @@ def Hip_RmsNormOp : Hip_DpsOp_WithInfer<"rms_norm", "Output"> {
   let hasVerifier = 1;
 }
 
-def Hip_LayerNormOp : Hip_DpsOp_AutoReify<"layer_norm", [AttrSizedOperandSegments]> {
+def Hip_LayerNormOp :
+    Hip_DpsOp_SemanticNoInfer<"layer_norm",
+                              /*traits=*/[AttrSizedOperandSegments]> {
   let summary = "Standard layer normalization (ONNX LayerNormalization opset 17)";
   let description = [{
     Full ONNX LayerNormalization (opset 17+) with mean subtraction and an
@@ -1243,7 +1245,7 @@ def Hip_InstanceNormOp : Hip_DpsOp_AutoReifyInfer<"instance_norm"> {
 }
 
 def Hip_SkipRmsNormOp :
-    Hip_DpsOp_AutoReify<"skip_rms_norm", [AttrSizedOperandSegments]> {
+    Hip_DpsOp_SemanticNoInfer<"skip_rms_norm", [AttrSizedOperandSegments]> {
   let summary = "Fused skip + RMS normalization (com.microsoft.SkipSimplifiedLayerNormalization)";
   let description = [{
     Full alignment with Microsoft ONNX Runtime SkipSimplifiedLayerNormalization

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -39,9 +39,17 @@ class Hip_DpsOp<string mnemonic, list<Trait> traits = []> :
                                   ["getDpsInitsMutable"]>,
         HipDpsOpInterface,
         DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface,
-                                  ["reifyResultShapes"]>
+                                  ["reifyResultShapes", "reifyDimOfResult"]>
       ],
       traits)> {
+  code reifyDimClassDefinition = [{
+    ::llvm::FailureOr<::mlir::OpFoldResult> $cppClass::reifyDimOfResult(
+        ::mlir::OpBuilder &b, int resultIndex, int dim) {
+      return ::llvm::cast<::mlir::hip::HipDpsOp>(getOperation())
+          .reifyDimOfResult(b, resultIndex, dim);
+    }
+  }];
+  let extraClassDefinition = reifyDimClassDefinition;
   let results = (outs Variadic<AnyRankedTensor>:$result_tensors);
 }
 
@@ -71,7 +79,7 @@ class Hip_DpsOp_WithInfer<string mnemonic,
         return ::mlir::success();
       }
     }]);
-  let extraClassDefinition = inferClassDefinition;
+  let extraClassDefinition = reifyDimClassDefinition # inferClassDefinition;
 }
 
 // Uses the shared HipDpsOpInterface implementation to lift the runtime shape
@@ -86,7 +94,7 @@ class Hip_DpsOp_AutoReify<string mnemonic, list<Trait> traits = []> :
           .reifyResultShapes(b, reified);
     }
   }];
-  let extraClassDefinition = reifyClassDefinition;
+  let extraClassDefinition = reifyDimClassDefinition # reifyClassDefinition;
 }
 
 // Combines the two common generated methods without exposing independent
@@ -103,7 +111,8 @@ class Hip_DpsOp_AutoReifyInfer<string mnemonic,
           .reifyResultShapes(b, reified);
     }
   }];
-  let extraClassDefinition = reifyClassDefinition # inferClassDefinition;
+  let extraClassDefinition =
+      reifyDimClassDefinition # reifyClassDefinition # inferClassDefinition;
 }
 
 /// Shape behavior supplied by a dedicated semantic implementation.
@@ -147,7 +156,8 @@ class Hip_DpsOp_Reduction<string mnemonic, list<Trait> traits = []> :
     }
   }];
   let extraClassDefinition =
-      reifyClassDefinition # inferClassDefinition # verifyClassDefinition;
+      reifyDimClassDefinition # reifyClassDefinition # inferClassDefinition #
+      verifyClassDefinition;
   let hasVerifier = 1;
 }
 
@@ -192,7 +202,8 @@ class Hip_DpsOp_Broadcast<string mnemonic, list<string> operandGetters,
     }
   }]);
   let extraClassDefinition =
-      reifyClassDefinition # inferClassDefinition # verifyClassDefinition;
+      reifyDimClassDefinition # reifyClassDefinition # inferClassDefinition #
+      verifyClassDefinition;
   let hasVerifier = 1;
 }
 

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -1121,8 +1121,7 @@ def Hip_RmsNormOp : Hip_DpsOp_WithInfer<"rms_norm", "Output"> {
 }
 
 def Hip_LayerNormOp :
-    Hip_DpsOp_SemanticNoInfer<"layer_norm",
-                              /*traits=*/[AttrSizedOperandSegments]> {
+    Hip_DpsOp<"layer_norm", /*traits=*/[AttrSizedOperandSegments]> {
   let summary = "Standard layer normalization (ONNX LayerNormalization opset 17)";
   let description = [{
     Full ONNX LayerNormalization (opset 17+) with mean subtraction and an
@@ -1256,7 +1255,7 @@ def Hip_InstanceNormOp : Hip_DpsOp_AutoReifyInfer<"instance_norm"> {
 }
 
 def Hip_SkipRmsNormOp :
-    Hip_DpsOp_SemanticNoInfer<"skip_rms_norm", [AttrSizedOperandSegments]> {
+    Hip_DpsOp<"skip_rms_norm", [AttrSizedOperandSegments]> {
   let summary = "Fused skip + RMS normalization (com.microsoft.SkipSimplifiedLayerNormalization)";
   let description = [{
     Full alignment with Microsoft ONNX Runtime SkipSimplifiedLayerNormalization

--- a/include/hip/Dialect/IR/HipShapeUtils.h
+++ b/include/hip/Dialect/IR/HipShapeUtils.h
@@ -300,6 +300,22 @@ FailureOr<SmallVector<OpFoldResult>>
 reifyReductionResultShape(OpBuilder &b, Location loc, Value data,
                           ArrayRef<int64_t> axes, int64_t keepdims);
 
+/// ONNX LayerNormalization output shapes. Output 0 (Y) equals the input;
+/// optional Mean and InvStdDev outputs use the keepdims reduction shape over
+/// `[axis, rank)`.
+FailureOr<SmallVector<SmallVector<int64_t>>>
+inferLayerNormOutputShapes(ArrayRef<int64_t> inputShape, int64_t axis,
+                           unsigned numOutputs);
+
+/// Mixed-shape form of `inferLayerNormOutputShapes`.
+FailureOr<ReifiedRankedShapedTypeDims>
+reifyLayerNormOutputShapes(OpBuilder &b, Location loc, Value input,
+                           int64_t axis, unsigned numOutputs);
+
+/// Runtime-supported LayerNormalization stats element type for ONNX
+/// `stash_type` (TensorProto enum): 0/1 -> f32, 10 -> f16.
+FailureOr<Type> inferLayerNormStatsType(MLIRContext *ctx, int64_t stashType);
+
 /// CausalConvWithState output shapes for the runtime-supported 1D layout:
 ///   output        = input = [B, C, L] or [B, L, C] when channels-last
 ///   present_state = [B, C, weight[2] - 1]
@@ -319,6 +335,23 @@ FailureOr<ReifiedRankedShapedTypeDims> reifyCausalConvWithStateOutputShapes(
     OpBuilder &b, Location loc, Value input, Value weight, Value bias,
     Value pastState, int64_t ndim, bool channelsLast,
     function_ref<InFlightDiagnostic()> emitError);
+
+/// SkipSimplifiedLayerNormalization output shapes. The normalized output and
+/// optional `input_skip_bias_sum` both equal the input shape. The runtime
+/// flattens every non-final input axis into rows, requires skip with the same
+/// shape, and rank-1 gamma/optional bias whose length equals the input's final
+/// extent.
+FailureOr<SmallVector<SmallVector<int64_t>>> inferSkipRmsNormOutputShapes(
+    ArrayRef<int64_t> inputShape, ArrayRef<int64_t> skipShape,
+    ArrayRef<int64_t> gammaShape, std::optional<ArrayRef<int64_t>> biasShape,
+    unsigned numOutputs, function_ref<InFlightDiagnostic()> emitError);
+
+/// Mixed-shape form of `inferSkipRmsNormOutputShapes`.
+FailureOr<ReifiedRankedShapedTypeDims>
+reifySkipRmsNormOutputShapes(OpBuilder &b, Location loc, Value input,
+                             Value skip, Value gamma, Value bias,
+                             unsigned numOutputs,
+                             function_ref<InFlightDiagnostic()> emitError);
 
 /// One-shot reify body for ONNX-style reduction ops. Structurally-proven
 /// constant `axes` use the shared semantic dimension map. Runtime,

--- a/lib/Conversion/HipConversionUtils.cpp
+++ b/lib/Conversion/HipConversionUtils.cpp
@@ -68,6 +68,16 @@ bool isResultTypeCompatibleWithInferredShape(
   return true;
 }
 
+RankedTensorType
+getTensorTypeFromReifiedShape(llvm::ArrayRef<OpFoldResult> reifiedShape,
+                              Type elementType, Attribute encoding) {
+  llvm::SmallVector<int64_t> shape;
+  shape.reserve(reifiedShape.size());
+  for (OpFoldResult dim : reifiedShape)
+    shape.push_back(getConstantIntValue(dim).value_or(ShapedType::kDynamic));
+  return RankedTensorType::get(shape, elementType, encoding);
+}
+
 FailureOr<Value>
 createEmptyTensorFromReifiedShape(OpBuilder &builder, Location loc,
                                   RankedTensorType resultType,

--- a/lib/Conversion/OnnxToHip/NormConversion.cpp
+++ b/lib/Conversion/OnnxToHip/NormConversion.cpp
@@ -228,39 +228,93 @@ mlir::LogicalResult SkipSimplifiedLayerNormToHip::matchAndRewrite(
   if (!epsilonAttr)
     return rewriter.notifyMatchFailure(op, "missing epsilon attribute");
 
-  // MS spec outputs (1-4): output, [mean], [inv_std_var], [input_skip_bias_sum]
-  // mean and inv_std_var are training-only; not modeled in HIP op.
+  // MS outputs are positional: output, mean, inv_std_var,
+  // input_skip_bias_sum. The HIP runtime is inference-only, so real training
+  // stats are unsupported and must not be mistaken for the residual output.
   unsigned numResults = op->getNumResults();
+  if (numResults < 1 || numResults > 4)
+    return rewriter.notifyMatchFailure(
+        op, "SkipSimplifiedLayerNormalization expects 1-4 results");
+  for (unsigned index : {1u, 2u})
+    if (index < numResults &&
+        !mlir::isa<mlir::NoneType>(op->getResult(index).getType()))
+      return rewriter.notifyMatchFailure(
+          op, "training mean/inv_std_var outputs are not supported");
 
   auto outputType =
-      mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
-  mlir::Value outputInit = createEmptyTensor(rewriter, loc, outputType, input);
+      mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
+  auto inputType = mlir::dyn_cast<mlir::RankedTensorType>(input.getType());
+  auto skipType = mlir::dyn_cast<mlir::RankedTensorType>(skip.getType());
+  auto gammaType = mlir::dyn_cast<mlir::RankedTensorType>(gamma.getType());
+  auto biasType = bias ? mlir::dyn_cast<mlir::RankedTensorType>(bias.getType())
+                       : mlir::RankedTensorType{};
+  if (!outputType || !inputType || !skipType || !gammaType ||
+      (bias && !biasType))
+    return rewriter.notifyMatchFailure(
+        op, "SkipSimplifiedLayerNormalization requires ranked tensors");
 
-  // Find input_skip_bias_sum: it's the last non-None result (index 1 or 3)
-  bool hasSkipOutput = numResults >= 2;
-  unsigned skipOutIdx = hasSkipOutput ? numResults - 1 : 0;
-
-  // Check if the last result is actually a real tensor (not None)
-  bool skipOutputIsReal = false;
+  bool skipOutputIsReal =
+      numResults == 4 && !mlir::isa<mlir::NoneType>(op->getResult(3).getType());
   mlir::RankedTensorType skipOutputType;
-  if (hasSkipOutput) {
-    mlir::Type lastType = op->getResult(skipOutIdx).getType();
-    if (!mlir::isa<mlir::NoneType>(lastType)) {
-      skipOutputIsReal = true;
-      skipOutputType = mlir::cast<mlir::RankedTensorType>(lastType);
-    }
+  if (skipOutputIsReal) {
+    skipOutputType =
+        mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(3).getType());
+    if (!skipOutputType)
+      return rewriter.notifyMatchFailure(
+          op, "input_skip_bias_sum must be a ranked tensor");
   }
+  unsigned hipOutputCount = skipOutputIsReal ? 2 : 1;
 
-  mlir::Value skipOutputInit = nullptr;
-  if (skipOutputIsReal)
-    skipOutputInit = createEmptyTensor(rewriter, loc, skipOutputType, input);
+  std::optional<llvm::ArrayRef<int64_t>> biasShape;
+  if (biasType)
+    biasShape = biasType.getShape();
+  auto staticShapes = mlir::hip::inferSkipRmsNormOutputShapes(
+      inputType.getShape(), skipType.getShape(), gammaType.getShape(),
+      biasShape, hipOutputCount, [&]() { return op->emitError(); });
+  if (mlir::failed(staticShapes))
+    return mlir::failure();
+  auto importedTypeAgrees = [](mlir::RankedTensorType imported,
+                               llvm::ArrayRef<int64_t> expected) {
+    if (imported.getRank() != static_cast<int64_t>(expected.size()))
+      return false;
+    for (int64_t dim : llvm::seq<int64_t>(0, imported.getRank()))
+      if (!imported.isDynamicDim(dim) &&
+          !mlir::ShapedType::isDynamic(expected[dim]) &&
+          imported.getDimSize(dim) != expected[dim])
+        return false;
+    return true;
+  };
+  if (!importedTypeAgrees(outputType, (*staticShapes)[0]) ||
+      (skipOutputIsReal &&
+       !importedTypeAgrees(skipOutputType, (*staticShapes)[1])))
+    return rewriter.notifyMatchFailure(
+        op, "SkipSimplifiedLayerNormalization outputs must match input shape");
+
+  auto resultShapes = mlir::hip::reifySkipRmsNormOutputShapes(
+      rewriter, loc, input, skip, gamma, bias, hipOutputCount,
+      [&]() { return op->emitError(); });
+  if (mlir::failed(resultShapes))
+    return mlir::failure();
+  auto outputInit = createEmptyTensorFromReifiedShape(rewriter, loc, outputType,
+                                                      (*resultShapes)[0]);
+  if (mlir::failed(outputInit))
+    return rewriter.notifyMatchFailure(op, "output shape is not reifiable");
+  mlir::Value skipOutputInit;
+  if (skipOutputIsReal) {
+    auto init = createEmptyTensorFromReifiedShape(rewriter, loc, skipOutputType,
+                                                  (*resultShapes)[1]);
+    if (mlir::failed(init))
+      return rewriter.notifyMatchFailure(
+          op, "input_skip_bias_sum shape is not reifiable");
+    skipOutputInit = *init;
+  }
   constexpr int64_t kCtxSize = 1;
   constexpr int64_t kInputSize = 1;
   constexpr int64_t kSkipSize = 1;
   constexpr int64_t kGammaSize = 1;
   int64_t kBiasSize = bias ? 1 : 0;
   // Variadic outputs: always output (1) + optional skip_output (0|1)
-  int64_t kOutputsSize = 1 + (skipOutputIsReal ? 1 : 0);
+  int64_t kOutputsSize = hipOutputCount;
   // Build operands list for hip.skip_rms_norm
   mlir::SmallVector<mlir::Value> operands;
   operands.push_back(context);
@@ -270,7 +324,7 @@ mlir::LogicalResult SkipSimplifiedLayerNormToHip::matchAndRewrite(
   if (bias)
     operands.push_back(bias);
   // DPS outs (Variadic): [output] or [output, input_skip_bias_sum]
-  operands.push_back(outputInit);
+  operands.push_back(*outputInit);
   if (skipOutputInit)
     operands.push_back(skipOutputInit);
 
@@ -307,26 +361,9 @@ mlir::LogicalResult SkipSimplifiedLayerNormToHip::matchAndRewrite(
   llvm::SmallVector<mlir::Value> replacements;
   replacements.push_back(hipOp->getResult(0)); // output
 
-  if (hasSkipOutput) {
-    // Fill intermediate None results (mean, inv_std_var) with empty tensors
-    for (unsigned i = 1; i < skipOutIdx; ++i) {
-      mlir::Type origType = op->getResult(i).getType();
-      if (mlir::isa<mlir::NoneType>(origType)) {
-        replacements.push_back(mlir::Value{});
-        continue;
-      }
-      auto dummyType = mlir::cast<mlir::RankedTensorType>(origType);
-      replacements.push_back(mlir::tensor::EmptyOp::create(
-          rewriter, loc, dummyType.getShape(), dummyType.getElementType()));
-    }
-    if (skipOutputIsReal)
-      replacements.push_back(hipOp->getResult(1)); // input_skip_bias_sum
-    else {
-      auto dummyType = mlir::RankedTensorType::get({}, rewriter.getF32Type());
-      replacements.push_back(mlir::tensor::EmptyOp::create(
-          rewriter, loc, dummyType.getShape(), dummyType.getElementType()));
-    }
-  }
+  for (unsigned index = 1; index < numResults; ++index)
+    replacements.push_back(index == 3 && skipOutputIsReal ? hipOp->getResult(1)
+                                                          : mlir::Value{});
 
   rewriter.replaceOp(op, replacements);
   return mlir::success();
@@ -538,25 +575,66 @@ LayerNormToHip::matchAndRewrite(mlir::Operation *op,
   if (auto a = op->getAttrOfType<mlir::IntegerAttr>("stash_type"))
     stashType = a.getSInt();
 
-  // First output (Y) is required and dictates the result shape.
+  auto inputType = mlir::dyn_cast<mlir::RankedTensorType>(input.getType());
+  if (!inputType)
+    return rewriter.notifyMatchFailure(op, "input must be a ranked tensor");
+
+  // First output (Y) is required. Optional InvStdDev requires a real mean
+  // scratch output because the HIP/runtime ABI uses contiguous [Y, Mean,
+  // InvStdDev] slots even when ONNX leaves Mean as None.
   auto outputType =
       mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
-  mlir::Value outputInit = createEmptyTensor(rewriter, loc, outputType, input);
-
-  // Optional Mean (output 1) and InvStdDev (output 2). Each is real iff the
-  // corresponding ONNX result is a non-None ranked tensor.
   mlir::Value meanResult = getOptionalResult(op, 1);
   mlir::Value invStdResult = getOptionalResult(op, 2);
+  bool needsMean = meanResult || invStdResult;
+  unsigned numHipOutputs = 1 + static_cast<unsigned>(needsMean) +
+                           static_cast<unsigned>(bool(invStdResult));
+  mlir::FailureOr<mlir::ReifiedRankedShapedTypeDims> outputShapes =
+      mlir::hip::reifyLayerNormOutputShapes(rewriter, loc, input, axis,
+                                            numHipOutputs);
+  if (mlir::failed(outputShapes))
+    return rewriter.notifyMatchFailure(
+        op, "LayerNormalization axis/output shape is invalid");
+  mlir::FailureOr<mlir::Type> statsElementType =
+      mlir::hip::inferLayerNormStatsType(rewriter.getContext(), stashType);
+  if (mlir::failed(statsElementType))
+    return rewriter.notifyMatchFailure(
+        op, "LayerNormalization runtime supports stash_type 0/1 or 10");
+
+  mlir::FailureOr<mlir::Value> outputInit = createEmptyTensorFromReifiedShape(
+      rewriter, loc, outputType, (*outputShapes)[0]);
+  if (mlir::failed(outputInit))
+    return rewriter.notifyMatchFailure(
+        op, "LayerNormalization Y type contradicts input shape");
 
   mlir::Value meanInit, invStdInit;
   mlir::RankedTensorType meanType, invStdType;
-  if (meanResult) {
-    meanType = mlir::cast<mlir::RankedTensorType>(meanResult.getType());
-    meanInit = createEmptyTensor(rewriter, loc, meanType, input);
+  if (needsMean) {
+    meanType = meanResult
+                   ? mlir::cast<mlir::RankedTensorType>(meanResult.getType())
+                   : getTensorTypeFromReifiedShape((*outputShapes)[1],
+                                                   *statsElementType);
+    if (meanType.getElementType() != *statsElementType)
+      return rewriter.notifyMatchFailure(
+          op, "LayerNormalization Mean dtype contradicts stash_type");
+    mlir::FailureOr<mlir::Value> init = createEmptyTensorFromReifiedShape(
+        rewriter, loc, meanType, (*outputShapes)[1]);
+    if (mlir::failed(init))
+      return rewriter.notifyMatchFailure(
+          op, "LayerNormalization Mean shape contradicts axis");
+    meanInit = *init;
   }
   if (invStdResult) {
     invStdType = mlir::cast<mlir::RankedTensorType>(invStdResult.getType());
-    invStdInit = createEmptyTensor(rewriter, loc, invStdType, input);
+    if (invStdType.getElementType() != *statsElementType)
+      return rewriter.notifyMatchFailure(
+          op, "LayerNormalization InvStdDev dtype contradicts stash_type");
+    mlir::FailureOr<mlir::Value> init = createEmptyTensorFromReifiedShape(
+        rewriter, loc, invStdType, (*outputShapes)[2]);
+    if (mlir::failed(init))
+      return rewriter.notifyMatchFailure(
+          op, "LayerNormalization InvStdDev shape contradicts axis");
+    invStdInit = *init;
   }
 
   // hip.layer_norm uses AttrSizedOperandSegments for [ctx, input, scale,
@@ -564,7 +642,7 @@ LayerNormToHip::matchAndRewrite(mlir::Operation *op,
   // collapse [output, mean?, inv_std?] into a single trailing run.
   llvm::SmallVector<mlir::Value> hipOutputs;
   llvm::SmallVector<mlir::Type> hipResultTypes;
-  hipOutputs.push_back(outputInit);
+  hipOutputs.push_back(*outputInit);
   hipResultTypes.push_back(outputType);
   if (meanInit) {
     hipOutputs.push_back(meanInit);
@@ -614,17 +692,16 @@ LayerNormToHip::matchAndRewrite(mlir::Operation *op,
   // Map HIP results back to the ONNX result list, preserving Mean / InvStdDev
   // None slots when they were not requested.
   llvm::SmallVector<mlir::Value> replacements;
-  unsigned hipResultIdx = 0;
-  replacements.push_back(hipOp->getResult(hipResultIdx++)); // Y
+  replacements.push_back(hipOp->getResult(/*Y=*/0));
   if (op->getNumResults() >= 2) {
     if (meanResult)
-      replacements.push_back(hipOp->getResult(hipResultIdx++));
+      replacements.push_back(hipOp->getResult(/*mean=*/1));
     else
       replacements.push_back(mlir::Value{}); // None -> drop
   }
   if (op->getNumResults() >= 3) {
     if (invStdResult)
-      replacements.push_back(hipOp->getResult(hipResultIdx++));
+      replacements.push_back(hipOp->getResult(/*inv_std=*/2));
     else
       replacements.push_back(mlir::Value{}); // None -> drop
   }

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -757,7 +757,63 @@ void SkipRmsNormOp::getEffects(
   emitDpsMemoryEffects(getDpsInputOperands(), getDpsInitsMutable(), effects);
 }
 
-LogicalResult SkipRmsNormOp::verify() { return success(); }
+LogicalResult SkipRmsNormOp::verify() {
+  unsigned numOutputs = getOutputs().size();
+  if (numOutputs < 1 || numOutputs > 2)
+    return emitOpError("expected 1 or 2 output buffers, got ") << numOutputs;
+
+  SmallVector<Value> operands = {getInput(), getSkip(), getGamma()};
+  if (Value bias = getBias())
+    operands.push_back(bias);
+  llvm::append_range(operands, getOutputs());
+  if (failed(verifyDpsComputeOp(*this, operands, numOutputs)))
+    return failure();
+
+  auto inputType = dyn_cast<ShapedType>(getInput().getType());
+  auto skipType = dyn_cast<ShapedType>(getSkip().getType());
+  auto gammaType = dyn_cast<ShapedType>(getGamma().getType());
+  if (!inputType || !inputType.hasRank() || !skipType || !skipType.hasRank() ||
+      !gammaType || !gammaType.hasRank())
+    return emitOpError("input, skip, and gamma must be ranked");
+  std::optional<ArrayRef<int64_t>> biasShape;
+  if (Value bias = getBias()) {
+    auto biasType = dyn_cast<ShapedType>(bias.getType());
+    if (!biasType || !biasType.hasRank())
+      return emitOpError("bias must be ranked");
+    biasShape = biasType.getShape();
+  }
+
+  FailureOr<SmallVector<SmallVector<int64_t>>> expected =
+      inferSkipRmsNormOutputShapes(inputType.getShape(), skipType.getShape(),
+                                   gammaType.getShape(), biasShape, numOutputs,
+                                   [&]() { return this->emitOpError(); });
+  if (failed(expected))
+    return failure();
+
+  Type elementType = inputType.getElementType();
+  if (!elementType.isF16() && !elementType.isF32())
+    return emitOpError("runtime supports only f16/f32 input");
+  for (Value value : operands)
+    if (cast<ShapedType>(value.getType()).getElementType() != elementType)
+      return emitOpError("all input and output element types must match");
+  if (getEpsilon().convertToDouble() < 0.0)
+    return emitOpError("epsilon must be non-negative");
+
+  for (unsigned index = 0; index < numOutputs; ++index) {
+    if (failed(verifyHipOpShape(
+            *this,
+            [&]() -> FailureOr<SmallVector<int64_t>> {
+              return (*expected)[index];
+            },
+            index)))
+      return failure();
+    if (getNumResults() &&
+        getResult(index).getType() != getOutputs()[index].getType())
+      return emitOpError("tensor result #")
+             << index << " type must match its output buffer type";
+  }
+  return success();
+}
 
 //===----------------------------------------------------------------------===//
 // LayerNormOp: ins(input, scale, [bias]) outs(output, [mean, [inv_std]])
@@ -790,7 +846,76 @@ LogicalResult LayerNormOp::verify() {
     dataOperands.push_back(b);
   for (Value out : getOutputs())
     dataOperands.push_back(out);
-  return verifyDpsComputeOp(*this, dataOperands, /*numInits=*/numOutputs);
+  if (failed(verifyDpsComputeOp(*this, dataOperands, /*numInits=*/numOutputs)))
+    return failure();
+
+  auto inputType = dyn_cast<ShapedType>(getInput().getType());
+  auto scaleType = dyn_cast<ShapedType>(getScale().getType());
+  if (!inputType || !inputType.hasRank() || inputType.getRank() < 1 ||
+      !scaleType || !scaleType.hasRank())
+    return emitOpError("input and scale must be ranked");
+  int64_t rank = inputType.getRank();
+  int64_t rawAxis = static_cast<int64_t>(getAxis());
+  int64_t axis = rawAxis < 0 ? rawAxis + rank : rawAxis;
+  if (axis < 0 || axis >= rank)
+    return emitOpError("axis must be in [-rank, rank)");
+
+  int64_t normalizedRank = rank - axis;
+  if (scaleType.getRank() != normalizedRank)
+    return emitOpError(
+        "runtime requires scale rank to equal the normalized suffix rank");
+  for (int64_t i : llvm::seq<int64_t>(0, normalizedRank)) {
+    int64_t inputDim = inputType.getDimSize(axis + i);
+    int64_t scaleDim = scaleType.getDimSize(i);
+    if (!ShapedType::isDynamic(inputDim) && !ShapedType::isDynamic(scaleDim) &&
+        inputDim != scaleDim)
+      return emitOpError("scale shape must equal input.shape[axis:]");
+  }
+  if (Value bias = getBias()) {
+    auto biasType = dyn_cast<ShapedType>(bias.getType());
+    if (!biasType || !biasType.hasRank() ||
+        biasType.getShape() != scaleType.getShape())
+      return emitOpError("bias shape must equal scale shape");
+  }
+
+  Type inputElementType = inputType.getElementType();
+  if (!inputElementType.isF16() && !inputElementType.isF32())
+    return emitOpError("runtime supports only f16/f32 input");
+  if (scaleType.getElementType() != inputElementType)
+    return emitOpError("scale element type must match input");
+  if (Value bias = getBias())
+    if (cast<ShapedType>(bias.getType()).getElementType() != inputElementType)
+      return emitOpError("bias element type must match input");
+  if (cast<ShapedType>(getOutputs().front().getType()).getElementType() !=
+      inputElementType)
+    return emitOpError("output element type must match input");
+  FailureOr<Type> statsElementType =
+      mlir::hip::inferLayerNormStatsType(getContext(), getStashType());
+  if (failed(statsElementType))
+    return emitOpError("runtime supports stash_type 0/1 (f32) or 10 (f16)");
+
+  FailureOr<SmallVector<SmallVector<int64_t>>> expected =
+      mlir::hip::inferLayerNormOutputShapes(inputType.getShape(), getAxis(),
+                                            numOutputs);
+  if (failed(expected))
+    return emitOpError("could not infer output shapes");
+  for (auto [index, output] : llvm::enumerate(getOutputs())) {
+    auto outputType = dyn_cast<ShapedType>(output.getType());
+    if (!outputType || !outputType.hasRank() ||
+        outputType.getRank() != static_cast<int64_t>((*expected)[index].size()))
+      return emitOpError("output #") << index << " has the wrong rank";
+    for (int64_t dim : llvm::seq<int64_t>(0, outputType.getRank())) {
+      int64_t actual = outputType.getDimSize(dim);
+      int64_t wanted = (*expected)[index][dim];
+      if (!ShapedType::isDynamic(actual) && !ShapedType::isDynamic(wanted) &&
+          actual != wanted)
+        return emitOpError("output #")
+               << index << " dimension " << dim << " must be " << wanted;
+    }
+    if (index > 0 && outputType.getElementType() != *statsElementType)
+      return emitOpError("stats output element type must match stash_type");
+  }
+  return success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/IR/HipDpsOpInterface.cpp
+++ b/lib/Dialect/IR/HipDpsOpInterface.cpp
@@ -4,10 +4,11 @@
  */
 //===- HipDpsOpInterface.cpp - HipDpsOp default reify body ----------------===//
 //
-// Single shared default `reifyResultShapes` body for HIP DPS ops. In tensor
-// mode, walks `DestinationStyleOpInterface::getDpsInits()` and lifts each
-// init's runtime shape via `tensor::getMixedSizes`. In memref mode there are
-// no SSA results, so it returns an empty reified-result list.
+// Shared reification bodies for HIP DPS ops. Whole-shape reification walks
+// `DestinationStyleOpInterface::getDpsInits()` and lifts each init's runtime
+// shape. Direct dimension reification follows one result's tied destination
+// and materializes only the requested extent. In memref mode there are no SSA
+// results, so whole-shape reification returns an empty list.
 // Ops that need a tighter contract select a manual-reify family and provide a
 // per-op override in `HipReifyResultShapesImpl.cpp`.
 //
@@ -80,4 +81,32 @@ HipDpsOp::reifyResultShapes(OpBuilder &b,
     reified.emplace_back(std::move(dims));
   }
   return success();
+}
+
+FailureOr<OpFoldResult> HipDpsOp::reifyDimOfResult(OpBuilder &b,
+                                                   int resultIndex, int dim) {
+  Operation *op = getOperation();
+  auto dpsOp = cast<DestinationStyleOpInterface>(op);
+  Operation::operand_range inits = dpsOp.getDpsInits();
+
+  // getTiedOpOperand asserts that the result and init indices are valid. Check
+  // the complete DPS relationship before asking for the tie or emitting a
+  // tensor.dim operation.
+  if (resultIndex < 0 || resultIndex >= static_cast<int>(op->getNumResults()) ||
+      inits.size() != op->getNumResults())
+    return failure();
+
+  OpResult result = op->getResult(resultIndex);
+  auto resultType = dyn_cast<RankedTensorType>(result.getType());
+  if (!resultType || dim < 0 || dim >= resultType.getRank())
+    return failure();
+
+  OpOperand *tiedOperand = dpsOp.getTiedOpOperand(result);
+  if (!tiedOperand)
+    return failure();
+  auto initType = dyn_cast<RankedTensorType>(tiedOperand->get().getType());
+  if (!initType || initType != resultType)
+    return failure();
+
+  return tensor::getMixedSize(b, op->getLoc(), tiedOperand->get(), dim);
 }

--- a/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
+++ b/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
@@ -119,6 +119,41 @@ MatmulOp::reifyResultShapes(OpBuilder &b,
 }
 
 //===----------------------------------------------------------------------===//
+// SkipRmsNormOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult SkipRmsNormOp::reifyResultShapes(
+    OpBuilder &b, ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
+  if (getNumResults() < 1 || getNumResults() > 2)
+    return failure();
+  FailureOr<ReifiedRankedShapedTypeDims> shapes =
+      mlir::hip::reifySkipRmsNormOutputShapes(
+          b, getLoc(), getInput(), getSkip(), getGamma(), getBias(),
+          getNumResults(), [&]() { return this->emitOpError(); });
+  if (failed(shapes))
+    return failure();
+  reifiedReturnShapes = std::move(*shapes);
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// LayerNormOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult LayerNormOp::reifyResultShapes(
+    OpBuilder &b, ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
+  if (getNumResults() == 0)
+    return failure();
+  FailureOr<ReifiedRankedShapedTypeDims> shapes =
+      mlir::hip::reifyLayerNormOutputShapes(b, getLoc(), getInput(), getAxis(),
+                                            getNumResults());
+  if (failed(shapes))
+    return failure();
+  reifiedReturnShapes = std::move(*shapes);
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // RopeOp
 //
 // Result shape == input data tensor's shape (rotary embedding rotates

--- a/lib/Dialect/IR/HipShapeUtilsAttention.cpp
+++ b/lib/Dialect/IR/HipShapeUtilsAttention.cpp
@@ -2,13 +2,19 @@
  * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Licensed under the MIT License.
  */
-//===- HipShapeUtilsAttention.cpp - Attention shape helpers --------------===//
+//===- HipShapeUtilsAttention.cpp - Attention and normalization shapes ---===//
+//
+// Category implementation for the public shape helpers declared in
+// `hip/Dialect/IR/HipShapeUtils.h`.
+//
+//===----------------------------------------------------------------------===//
 
 #include "HipShapeUtilsInternal.h"
 #include "hip/Dialect/IR/HipShapeUtils.h"
 
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/Sequence.h"
 
 #include <optional>
@@ -23,6 +29,67 @@ bool areCompatibleStaticExtents(int64_t lhs, int64_t rhs) {
 }
 
 } // namespace
+
+FailureOr<SmallVector<SmallVector<int64_t>>>
+mlir::hip::inferLayerNormOutputShapes(ArrayRef<int64_t> inputShape,
+                                      int64_t axis, unsigned numOutputs) {
+  if (numOutputs < 1 || numOutputs > 3 || inputShape.empty())
+    return failure();
+  int64_t rank = inputShape.size();
+  int64_t normalizedAxis = axis < 0 ? axis + rank : axis;
+  if (normalizedAxis < 0 || normalizedAxis >= rank)
+    return failure();
+  SmallVector<int64_t> reductionAxes =
+      llvm::to_vector(llvm::seq<int64_t>(normalizedAxis, rank));
+  FailureOr<SmallVector<int64_t>> statsShape =
+      inferReductionShape(inputShape, reductionAxes, /*keepdims=*/1);
+  if (failed(statsShape))
+    return failure();
+
+  SmallVector<SmallVector<int64_t>> results;
+  results.push_back(SmallVector<int64_t>(inputShape));
+  if (numOutputs >= 2)
+    results.push_back(*statsShape);
+  if (numOutputs >= 3)
+    results.push_back(*statsShape);
+  return results;
+}
+
+FailureOr<ReifiedRankedShapedTypeDims>
+mlir::hip::reifyLayerNormOutputShapes(OpBuilder &b, Location loc, Value input,
+                                      int64_t axis, unsigned numOutputs) {
+  auto inputType = dyn_cast<RankedTensorType>(input.getType());
+  if (!inputType || failed(inferLayerNormOutputShapes(inputType.getShape(),
+                                                      axis, numOutputs)))
+    return failure();
+  int64_t rank = inputType.getRank();
+  int64_t normalizedAxis = axis < 0 ? axis + rank : axis;
+  SmallVector<int64_t> reductionAxes =
+      llvm::to_vector(llvm::seq<int64_t>(normalizedAxis, rank));
+
+  FailureOr<SmallVector<OpFoldResult>> outputShape =
+      reifyElementwiseSameShape(b, loc, input);
+  FailureOr<SmallVector<OpFoldResult>> statsShape =
+      reifyReductionResultShape(b, loc, input, reductionAxes, /*keepdims=*/1);
+  if (failed(outputShape) || failed(statsShape))
+    return failure();
+  ReifiedRankedShapedTypeDims results;
+  results.push_back(std::move(*outputShape));
+  if (numOutputs >= 2)
+    results.push_back(*statsShape);
+  if (numOutputs >= 3)
+    results.push_back(std::move(*statsShape));
+  return results;
+}
+
+FailureOr<Type> mlir::hip::inferLayerNormStatsType(MLIRContext *ctx,
+                                                   int64_t stashType) {
+  if (stashType == 0 || stashType == 1)
+    return Float32Type::get(ctx);
+  if (stashType == 10)
+    return Float16Type::get(ctx);
+  return failure();
+}
 
 FailureOr<SmallVector<SmallVector<int64_t>>>
 mlir::hip::inferCausalConvWithStateOutputShapes(
@@ -133,4 +200,84 @@ mlir::hip::reifyCausalConvWithStateOutputShapes(
       tensor::getMixedSize(b, loc, input, channelDim), *stateLength};
   return ReifiedRankedShapedTypeDims{std::move(outputShape),
                                      std::move(presentStateShape)};
+}
+
+FailureOr<SmallVector<SmallVector<int64_t>>>
+mlir::hip::inferSkipRmsNormOutputShapes(
+    ArrayRef<int64_t> inputShape, ArrayRef<int64_t> skipShape,
+    ArrayRef<int64_t> gammaShape, std::optional<ArrayRef<int64_t>> biasShape,
+    unsigned numOutputs, function_ref<InFlightDiagnostic()> emitError) {
+  if (numOutputs < 1 || numOutputs > 2) {
+    emitError() << "skip_rms_norm expects 1 or 2 output buffers";
+    return failure();
+  }
+  if (inputShape.empty()) {
+    emitError() << "skip_rms_norm input must have rank at least 1";
+    return failure();
+  }
+  if (skipShape.size() != inputShape.size()) {
+    emitError() << "skip_rms_norm skip rank must match input rank";
+    return failure();
+  }
+
+  for (size_t dim : llvm::seq<size_t>(0, inputShape.size())) {
+    if (!areCompatibleStaticExtents(skipShape[dim], inputShape[dim])) {
+      emitError() << "skip_rms_norm skip dimension " << dim
+                  << " must match input";
+      return failure();
+    }
+  }
+  if (gammaShape.size() != 1) {
+    emitError() << "skip_rms_norm gamma must have rank 1";
+    return failure();
+  }
+  if (!areCompatibleStaticExtents(gammaShape[0], inputShape.back())) {
+    emitError() << "skip_rms_norm gamma length must match the input's final "
+                   "dimension";
+    return failure();
+  }
+  if (biasShape) {
+    if (biasShape->size() != 1) {
+      emitError() << "skip_rms_norm bias must have rank 1";
+      return failure();
+    }
+    if (!areCompatibleStaticExtents((*biasShape)[0], inputShape.back())) {
+      emitError() << "skip_rms_norm bias length must match the input's final "
+                     "dimension";
+      return failure();
+    }
+  }
+
+  SmallVector<SmallVector<int64_t>> results;
+  results.assign(numOutputs, SmallVector<int64_t>(inputShape));
+  return results;
+}
+
+FailureOr<ReifiedRankedShapedTypeDims> mlir::hip::reifySkipRmsNormOutputShapes(
+    OpBuilder &b, Location loc, Value input, Value skip, Value gamma,
+    Value bias, unsigned numOutputs,
+    function_ref<InFlightDiagnostic()> emitError) {
+  auto inputType = dyn_cast<RankedTensorType>(input.getType());
+  auto skipType = dyn_cast<RankedTensorType>(skip.getType());
+  auto gammaType = dyn_cast<RankedTensorType>(gamma.getType());
+  auto biasType =
+      bias ? dyn_cast<RankedTensorType>(bias.getType()) : RankedTensorType{};
+  if (!inputType || !skipType || !gammaType || (bias && !biasType)) {
+    emitError() << "skip_rms_norm operands must be ranked tensors";
+    return failure();
+  }
+
+  std::optional<ArrayRef<int64_t>> biasShape;
+  if (biasType)
+    biasShape = biasType.getShape();
+  if (failed(inferSkipRmsNormOutputShapes(
+          inputType.getShape(), skipType.getShape(), gammaType.getShape(),
+          biasShape, numOutputs, emitError)))
+    return failure();
+
+  // Reify once and reuse the same extent SSA for the optional residual output.
+  SmallVector<OpFoldResult> shape = tensor::getMixedSizes(b, loc, input);
+  ReifiedRankedShapedTypeDims results;
+  results.assign(numOutputs, shape);
+  return results;
 }

--- a/lib/Dialect/Transforms/ResolveTensorDims.cpp
+++ b/lib/Dialect/Transforms/ResolveTensorDims.cpp
@@ -88,10 +88,10 @@ void ResolveTensorDimsPass::runOnOperation() {
   // Upstream reify-driven dim folds.  `populateResolveRankedShapedType...`
   // contributes
   // `DimOfReifyRankedShapedTypeOpInterface<{memref,tensor}::DimOp>`, which
-  // dispatches through the op's `reifyResultShapes`
-  // (`ReifyRankedShapedTypeOpInterface`).  The companion populator covers ops
-  // on `InferShapedTypeOpInterface` (`tensor.dim` of HIP DPS results, via
-  // `reifyReturnTypeShapes`).
+  // dispatches through `ReifyRankedShapedTypeOpInterface::reifyDimOfResult`.
+  // HIP DPS ops implement that direct hook from the tied destination, so one
+  // query does not materialize every dimension of every result. The companion
+  // populator covers ops on `InferShapedTypeOpInterface`.
   memref::populateResolveRankedShapedTypeResultDimsPatterns(patterns);
   memref::populateResolveShapedTypeResultDimsPatterns(patterns);
 

--- a/test/lib/Dialect/Hip/TestHipPasses.cpp
+++ b/test/lib/Dialect/Hip/TestHipPasses.cpp
@@ -7,12 +7,16 @@
 
 #include "hip/Dialect/IR/HipDialect.h"
 
+#include "mlir/Dialect/Arith/Utils/Utils.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/DialectRegistry.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #include <iterator>
+#include <optional>
 
 namespace {
 
@@ -58,6 +62,64 @@ public:
   }
 };
 
+/// Resolve tensor.dim through the whole-shape interface implementation. This
+/// test-only path keeps semantic reifier tests independent from the production
+/// direct-dimension override.
+struct ResolveDimFromWholeShapeReify final
+    : public mlir::OpRewritePattern<mlir::tensor::DimOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  void initialize() { setHasBoundedRewriteRecursion(); }
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::tensor::DimOp dimOp,
+                  mlir::PatternRewriter &rewriter) const final {
+    auto result = mlir::dyn_cast<mlir::OpResult>(dimOp.getSource());
+    if (!result || !mlir::isa<mlir::hip::HipDpsOp>(result.getOwner()))
+      return mlir::failure();
+    std::optional<int64_t> dim = dimOp.getConstantIndex();
+    if (!dim)
+      return mlir::failure();
+
+    auto reify =
+        mlir::cast<mlir::ReifyRankedShapedTypeOpInterface>(result.getOwner());
+    mlir::ReifiedRankedShapedTypeDims shapes;
+    if (mlir::failed(reify.reifyResultShapes(rewriter, shapes)) ||
+        result.getResultNumber() >= shapes.size() || *dim < 0 ||
+        *dim >= static_cast<int64_t>(shapes[result.getResultNumber()].size()))
+      return mlir::failure();
+
+    mlir::OpFoldResult extent = shapes[result.getResultNumber()][*dim];
+    if (!extent)
+      return mlir::failure();
+    mlir::Value value =
+        mlir::getValueOrCreateConstantIndexOp(rewriter, dimOp.getLoc(), extent);
+    rewriter.replaceOp(dimOp, value);
+    return mlir::success();
+  }
+};
+
+struct TestHipWholeShapeDimReifyPass final
+    : public mlir::PassWrapper<TestHipWholeShapeDimReifyPass,
+                               mlir::OperationPass<mlir::ModuleOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TestHipWholeShapeDimReifyPass)
+
+  llvm::StringRef getArgument() const final {
+    return "test-hip-whole-shape-dim-reify";
+  }
+  llvm::StringRef getDescription() const final {
+    return "Resolve HIP result dims through whole-shape semantic reification";
+  }
+
+  void runOnOperation() final {
+    mlir::RewritePatternSet patterns(&getContext());
+    patterns.add<ResolveDimFromWholeShapeReify>(&getContext());
+    if (mlir::failed(
+            mlir::applyPatternsGreedily(getOperation(), std::move(patterns))))
+      signalPassFailure();
+  }
+};
+
 /// Probe the HipDpsOp shared default on a zero-result memref-mode operation.
 struct TestHipDpsDefaultReifyPass final
     : public mlir::PassWrapper<TestHipDpsDefaultReifyPass,
@@ -76,6 +138,56 @@ struct TestHipDpsDefaultReifyPass final
     mlir::WalkResult walkResult =
         getOperation().walk([&](mlir::hip::HipDpsOp op) -> mlir::WalkResult {
           mlir::Operation *operation = op.getOperation();
+          if (operation->hasAttr("test.default_reify_dim_failure_atomic")) {
+            if (operation->getNumResults() == 0) {
+              operation->emitOpError(
+                  "direct-dim atomicity fixture requires a tensor result");
+              return mlir::WalkResult::interrupt();
+            }
+
+            auto dps = mlir::cast<mlir::DestinationStyleOpInterface>(operation);
+            mlir::OpResult result = operation->getResult(0);
+            mlir::OpOperand *tiedOperand = dps.getTiedOpOperand(result);
+            auto initType = mlir::cast<mlir::RankedTensorType>(
+                tiedOperand->get().getType());
+            if (initType.getRank() == 0) {
+              operation->emitOpError(
+                  "direct-dim atomicity fixture requires positive rank");
+              return mlir::WalkResult::interrupt();
+            }
+
+            llvm::SmallVector<int64_t> invalidShape(initType.getShape());
+            invalidShape[0] =
+                initType.isDynamicDim(0) ? 7 : initType.getDimSize(0) + 1;
+            mlir::Type invalidType = mlir::RankedTensorType::get(
+                invalidShape, initType.getElementType(),
+                initType.getEncoding());
+            tiedOperand->get().setType(invalidType);
+
+            mlir::Block *block = operation->getBlock();
+            size_t before = std::distance(block->begin(), block->end());
+            rewriter.setInsertionPoint(operation);
+            auto reify =
+                mlir::cast<mlir::ReifyRankedShapedTypeOpInterface>(operation);
+            bool rejected =
+                mlir::failed(reify.reifyDimOfResult(rewriter, -1, 0)) &&
+                mlir::failed(reify.reifyDimOfResult(rewriter, 0, -1)) &&
+                mlir::failed(
+                    reify.reifyDimOfResult(rewriter, 0, initType.getRank())) &&
+                mlir::failed(reify.reifyDimOfResult(rewriter, 0, 0));
+            size_t after = std::distance(block->begin(), block->end());
+            tiedOperand->get().setType(initType);
+
+            if (!rejected || after != before) {
+              operation->emitOpError(
+                  "invalid direct-dim reification mutated IR or succeeded");
+              return mlir::WalkResult::interrupt();
+            }
+            operation->setAttr("test.default_reify_dim_failure_atomic_passed",
+                               rewriter.getUnitAttr());
+            return mlir::WalkResult::advance();
+          }
+
           if (operation->hasAttr("test.reify_rank_zero")) {
             auto reify =
                 mlir::cast<mlir::ReifyRankedShapedTypeOpInterface>(operation);
@@ -162,5 +274,6 @@ void mlir::hip::test::registerHipTestPasses(DialectRegistry &registry) {
   registry.addExtension(+[](MLIRContext *, HipDialect *dialect) {
     RegisteredOperationName::insert<TestMalformedReifyOp>(*dialect);
   });
+  PassRegistration<TestHipWholeShapeDimReifyPass>();
   PassRegistration<TestHipDpsDefaultReifyPass>();
 }

--- a/test/lit/Conversion/hip-to-llvm/test_layer_normalization.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_layer_normalization.mlir
@@ -8,6 +8,7 @@
 // Test cases:
 // 1. Static shape: 1x128x4096 f16, with bias, output only
 // 2. Dynamic shape: ?x?x512 f16, with bias, output only
+// 3. Axis=1 with Mean/InvStdDev output buffers
 // ============================================================================
 
 // RUN: hip-mlir-opt %s --convert-hip-to-llvm | FileCheck %s
@@ -48,6 +49,26 @@ module {
     // CHECK: llvm.mul
     // CHECK: llvm.extractvalue {{.*}}[3, 1]
     // CHECK: llvm.mul
+    // CHECK: llvm.call @wrap_layer_normalization
+    return
+  }
+
+  // --- Case 3: optional stats outputs and non-default axis ---
+  func.func @layer_norm_stats(
+      %ctx: !hip.context,
+      %input: memref<2x3x4xf16, 1>,
+      %scale: memref<3x4xf16, 1>,
+      %output: memref<2x3x4xf16, 1>,
+      %mean: memref<2x1x1xf32, 1>,
+      %inv_std: memref<2x1x1xf32, 1>) {
+    // CHECK-LABEL: llvm.func @layer_norm_stats
+    hip.layer_norm(%ctx)
+        ins(%input, %scale : memref<2x3x4xf16, 1>, memref<3x4xf16, 1>)
+        outs(%output, %mean, %inv_std :
+             memref<2x3x4xf16, 1>, memref<2x1x1xf32, 1>,
+             memref<2x1x1xf32, 1>)
+        {axis = 1 : i64, epsilon = 9.99999974E-6 : f32,
+         stash_type = 1 : i64}
     // CHECK: llvm.call @wrap_layer_normalization
     return
   }

--- a/test/lit/Conversion/onnx-to-hip/test_layer_normalization.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_layer_normalization.mlir
@@ -61,4 +61,66 @@ module {
   // CHECK: %[[INIT:.*]] = tensor.empty(%[[DIM0]], %[[DIM1]]) : tensor<?x?x512xf16>
   // CHECK: hip.layer_norm(%[[CTX]])
   // CHECK-SAME: outs(%[[INIT]] :
+
+  // --- Case 4: all optional outputs, axis=-1 ---
+  func.func @layer_norm_stats(
+      %X: tensor<2x3x4xf16>, %Scale: tensor<4xf16>)
+      -> (tensor<2x3x4xf16>, tensor<2x3x1xf32>, tensor<2x3x1xf32>) {
+    %Y:3 = "onnx.LayerNormalization"(%X, %Scale)
+      {axis = -1 : si64, epsilon = 9.99999974E-6 : f32,
+       stash_type = 1 : si64}
+      : (tensor<2x3x4xf16>, tensor<4xf16>)
+        -> (tensor<2x3x4xf16>, tensor<2x3x1xf32>, tensor<2x3x1xf32>)
+    return %Y#0, %Y#1, %Y#2
+      : tensor<2x3x4xf16>, tensor<2x3x1xf32>, tensor<2x3x1xf32>
+  }
+
+  // CHECK-LABEL: func.func @layer_norm_stats
+  // CHECK-DAG: %[[YINIT:.*]] = tensor.empty() : tensor<2x3x4xf16>
+  // CHECK-DAG: %[[MINIT:.*]] = tensor.empty() : tensor<2x3x1xf32>
+  // CHECK-DAG: %[[IINIT:.*]] = tensor.empty() : tensor<2x3x1xf32>
+  // CHECK: %[[LN:.*]]:3 = hip.layer_norm
+  // CHECK-SAME: outs(%[[YINIT]], %[[MINIT]], %[[IINIT]]
+
+  // --- Case 5: dynamic prefix, positive axis ---
+  func.func @layer_norm_dynamic_stats(
+      %X: tensor<?x3x4xf16>, %Scale: tensor<3x4xf16>)
+      -> (tensor<?x3x4xf16>, tensor<?x1x1xf32>, tensor<?x1x1xf32>) {
+    %Y:3 = "onnx.LayerNormalization"(%X, %Scale)
+      {axis = 1 : si64, epsilon = 9.99999974E-6 : f32,
+       stash_type = 1 : si64}
+      : (tensor<?x3x4xf16>, tensor<3x4xf16>)
+        -> (tensor<?x3x4xf16>, tensor<?x1x1xf32>, tensor<?x1x1xf32>)
+    return %Y#0, %Y#1, %Y#2
+      : tensor<?x3x4xf16>, tensor<?x1x1xf32>, tensor<?x1x1xf32>
+  }
+
+  // CHECK-LABEL: func.func @layer_norm_dynamic_stats
+  // CHECK-SAME: %[[DX:[^,]+]]: tensor<?x3x4xf16>
+  // CHECK: %[[DN:.*]] = tensor.dim %[[DX]], %{{.*}}
+  // CHECK: %[[SDN:.*]] = tensor.dim %[[DX]], %{{.*}}
+  // CHECK-DAG: %[[DY:.*]] = tensor.empty(%[[DN]]) : tensor<?x3x4xf16>
+  // CHECK-DAG: %[[DM:.*]] = tensor.empty(%[[SDN]]) : tensor<?x1x1xf32>
+  // CHECK-DAG: %[[DI:.*]] = tensor.empty(%[[SDN]]) : tensor<?x1x1xf32>
+  // CHECK: hip.layer_norm
+  // CHECK-SAME: outs(%[[DY]], %[[DM]], %[[DI]]
+
+  // --- Case 6: InvStdDev requested without Mean. HIP gets a mean scratch. ---
+  func.func @layer_norm_inv_without_mean(
+      %X: tensor<2x4xf16>, %Scale: tensor<4xf16>)
+      -> (tensor<2x4xf16>, tensor<2x1xf32>) {
+    %Y:3 = "onnx.LayerNormalization"(%X, %Scale)
+      {axis = -1 : si64, epsilon = 9.99999974E-6 : f32,
+       stash_type = 1 : si64}
+      : (tensor<2x4xf16>, tensor<4xf16>)
+        -> (tensor<2x4xf16>, none, tensor<2x1xf32>)
+    return %Y#0, %Y#2 : tensor<2x4xf16>, tensor<2x1xf32>
+  }
+
+  // CHECK-LABEL: func.func @layer_norm_inv_without_mean
+  // CHECK-DAG: %[[SY:.*]] = tensor.empty() : tensor<2x4xf16>
+  // CHECK-DAG: %[[SM:.*]] = tensor.empty() : tensor<2x1xf32>
+  // CHECK-DAG: %[[SI:.*]] = tensor.empty() : tensor<2x1xf32>
+  // CHECK: %[[SLN:.*]]:3 = hip.layer_norm
+  // CHECK-SAME: outs(%[[SY]], %[[SM]], %[[SI]]
 }

--- a/test/lit/Conversion/onnx-to-hip/test_skip_rms_norm.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_skip_rms_norm.mlir
@@ -27,19 +27,19 @@
 // RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
 
 module {
-  // ===== Test 1: Basic 3-input, 2-output =====
+  // ===== Test 1: Basic 3-input with residual output in schema slot 3 =====
 
   func.func @main_graph(%input: tensor<1x128x4096xf16>,
                          %skip: tensor<1x128x4096xf16>,
                          %gamma: tensor<4096xf16>)
       -> (tensor<1x128x4096xf16>, tensor<1x128x4096xf16>) {
-    %output, %skip_output = "onnx.Custom"(%input, %skip, %gamma) {
+    %0:4 = "onnx.Custom"(%input, %skip, %gamma) {
       function_name = "SkipSimplifiedLayerNormalization",
       domain_name = "com.microsoft",
       epsilon = 9.99999974E-6 : f32
     } : (tensor<1x128x4096xf16>, tensor<1x128x4096xf16>, tensor<4096xf16>)
-        -> (tensor<1x128x4096xf16>, tensor<1x128x4096xf16>)
-    return %output, %skip_output : tensor<1x128x4096xf16>, tensor<1x128x4096xf16>
+        -> (tensor<1x128x4096xf16>, none, none, tensor<1x128x4096xf16>)
+    return %0#0, %0#3 : tensor<1x128x4096xf16>, tensor<1x128x4096xf16>
   }
 
   // ===== Test 2: Dynamic shape =====
@@ -48,30 +48,30 @@ module {
                                     %skip: tensor<?x?xf16>,
                                     %gamma: tensor<?xf16>)
       -> (tensor<?x?xf16>, tensor<?x?xf16>) {
-    %output, %skip_output = "onnx.Custom"(%input, %skip, %gamma) {
+    %0:4 = "onnx.Custom"(%input, %skip, %gamma) {
       function_name = "SkipSimplifiedLayerNormalization",
       domain_name = "com.microsoft",
       epsilon = 1.0e-05 : f32
     } : (tensor<?x?xf16>, tensor<?x?xf16>, tensor<?xf16>)
-        -> (tensor<?x?xf16>, tensor<?x?xf16>)
-    return %output, %skip_output : tensor<?x?xf16>, tensor<?x?xf16>
+        -> (tensor<?x?xf16>, none, none, tensor<?x?xf16>)
+    return %0#0, %0#3 : tensor<?x?xf16>, tensor<?x?xf16>
   }
 
   // ===== Test 3: With optional bias (4 inputs) =====
 
-  func.func @with_bias(%input: tensor<1x128x4096xf16>,
+  func.func @with_bias_output_only(%input: tensor<1x128x4096xf16>,
                         %skip: tensor<1x128x4096xf16>,
                         %gamma: tensor<4096xf16>,
                         %bias: tensor<4096xf16>)
-      -> (tensor<1x128x4096xf16>, tensor<1x128x4096xf16>) {
-    %output, %skip_output = "onnx.Custom"(%input, %skip, %gamma, %bias) {
+      -> tensor<1x128x4096xf16> {
+    %output = "onnx.Custom"(%input, %skip, %gamma, %bias) {
       function_name = "SkipSimplifiedLayerNormalization",
       domain_name = "com.microsoft",
       epsilon = 9.99999974E-6 : f32
     } : (tensor<1x128x4096xf16>, tensor<1x128x4096xf16>,
          tensor<4096xf16>, tensor<4096xf16>)
-        -> (tensor<1x128x4096xf16>, tensor<1x128x4096xf16>)
-    return %output, %skip_output : tensor<1x128x4096xf16>, tensor<1x128x4096xf16>
+        -> tensor<1x128x4096xf16>
+    return %output : tensor<1x128x4096xf16>
   }
 
   // ===== Test 4: 4-output ONNX pattern (output, none, none, input_skip_bias_sum) =====
@@ -87,6 +87,60 @@ module {
     } : (tensor<1x128x4096xf16>, tensor<1x128x4096xf16>, tensor<4096xf16>)
         -> (tensor<1x128x4096xf16>, none, none, tensor<1x128x4096xf16>)
     return %0#0, %0#3 : tensor<1x128x4096xf16>, tensor<1x128x4096xf16>
+  }
+
+  // ===== Tests 5-6: omitted trailing optional outputs =====
+
+  func.func @two_output_slots(%input: tensor<2x16xf32>,
+                              %skip: tensor<2x16xf32>,
+                              %gamma: tensor<16xf32>) -> tensor<2x16xf32> {
+    %0:2 = "onnx.Custom"(%input, %skip, %gamma) {
+      function_name = "SkipSimplifiedLayerNormalization",
+      domain_name = "com.microsoft",
+      epsilon = 1.0e-05 : f32
+    } : (tensor<2x16xf32>, tensor<2x16xf32>, tensor<16xf32>)
+        -> (tensor<2x16xf32>, none)
+    return %0#0 : tensor<2x16xf32>
+  }
+
+  func.func @three_output_slots(%input: tensor<2x16xf32>,
+                                %skip: tensor<2x16xf32>,
+                                %gamma: tensor<16xf32>) -> tensor<2x16xf32> {
+    %0:3 = "onnx.Custom"(%input, %skip, %gamma) {
+      function_name = "SkipSimplifiedLayerNormalization",
+      domain_name = "com.microsoft",
+      epsilon = 1.0e-05 : f32
+    } : (tensor<2x16xf32>, tensor<2x16xf32>, tensor<16xf32>)
+        -> (tensor<2x16xf32>, none, none)
+    return %0#0 : tensor<2x16xf32>
+  }
+
+  func.func @four_slots_no_residual(%input: tensor<2x16xf32>,
+                                    %skip: tensor<2x16xf32>,
+                                    %gamma: tensor<16xf32>)
+      -> tensor<2x16xf32> {
+    %0:4 = "onnx.Custom"(%input, %skip, %gamma) {
+      function_name = "SkipSimplifiedLayerNormalization",
+      domain_name = "com.microsoft",
+      epsilon = 1.0e-05 : f32
+    } : (tensor<2x16xf32>, tensor<2x16xf32>, tensor<16xf32>)
+        -> (tensor<2x16xf32>, none, none, none)
+    return %0#0 : tensor<2x16xf32>
+  }
+
+  // A real training-stat tensor is intentionally unsupported. It remains
+  // onnx.Custom rather than being misidentified as input_skip_bias_sum.
+  func.func @training_mean_not_lowered(%input: tensor<2x16xf32>,
+                                       %skip: tensor<2x16xf32>,
+                                       %gamma: tensor<16xf32>)
+      -> (tensor<2x16xf32>, tensor<2x1xf32>) {
+    %0:2 = "onnx.Custom"(%input, %skip, %gamma) {
+      function_name = "SkipSimplifiedLayerNormalization",
+      domain_name = "com.microsoft",
+      epsilon = 1.0e-05 : f32
+    } : (tensor<2x16xf32>, tensor<2x16xf32>, tensor<16xf32>)
+        -> (tensor<2x16xf32>, tensor<2x1xf32>)
+    return %0#0, %0#1 : tensor<2x16xf32>, tensor<2x1xf32>
   }
 }
 
@@ -108,14 +162,30 @@ module {
 // CHECK: hip.skip_rms_norm(%[[CTX]]) ins(%[[INPUT]], %[[SKIP]], %[[GAMMA]] : tensor<?x?xf16>, tensor<?x?xf16>, tensor<?xf16>) outs({{.*}}, {{.*}} : tensor<?x?xf16>, tensor<?x?xf16>) {epsilon = 9.99999974E-6 : f32}
 // CHECK-NOT: onnx.Custom
 
-// CHECK-LABEL: func.func @with_bias
+// CHECK-LABEL: func.func @with_bias_output_only
 // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[INPUT:.*]]: tensor<1x128x4096xf16>, %[[SKIP:.*]]: tensor<1x128x4096xf16>, %[[GAMMA:.*]]: tensor<4096xf16>, %[[BIAS:.*]]: tensor<4096xf16>)
 // CHECK: hip.skip_rms_norm(%[[CTX]]) ins(%[[INPUT]], %[[SKIP]], %[[GAMMA]], %[[BIAS]] :
 // CHECK-SAME: tensor<1x128x4096xf16>, tensor<1x128x4096xf16>, tensor<4096xf16>, tensor<4096xf16>)
-// CHECK-SAME: outs({{.*}}, {{.*}} : tensor<1x128x4096xf16>, tensor<1x128x4096xf16>)
+// CHECK-SAME: outs({{.*}} : tensor<1x128x4096xf16>)
 // CHECK-SAME: {epsilon = 9.99999974E-6 : f32}
 // CHECK-NOT: onnx.Custom
 
 // CHECK-LABEL: func.func @four_output
 // CHECK: hip.skip_rms_norm(%{{.*}}) ins({{.*}}) outs({{.*}})
 // CHECK-NOT: onnx.Custom
+
+// CHECK-LABEL: func.func @two_output_slots
+// CHECK: hip.skip_rms_norm(%{{.*}}) ins({{.*}}) outs({{.*}} : tensor<2x16xf32>)
+// CHECK-NOT: onnx.Custom
+
+// CHECK-LABEL: func.func @three_output_slots
+// CHECK: hip.skip_rms_norm(%{{.*}}) ins({{.*}}) outs({{.*}} : tensor<2x16xf32>)
+// CHECK-NOT: onnx.Custom
+
+// CHECK-LABEL: func.func @four_slots_no_residual
+// CHECK: hip.skip_rms_norm(%{{.*}}) ins({{.*}}) outs({{.*}} : tensor<2x16xf32>)
+// CHECK-NOT: onnx.Custom
+
+// CHECK-LABEL: func.func @training_mean_not_lowered
+// CHECK: "onnx.Custom"
+// CHECK-NOT: hip.skip_rms_norm

--- a/test/lit/Dialect/hip-broadcast-reify-shapes.mlir
+++ b/test/lit/Dialect/hip-broadcast-reify-shapes.mlir
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
 
-// RUN: hip-mlir-opt --resolve-shaped-type-result-dims %s | FileCheck %s --check-prefix=REIFY
+// RUN: hip-mlir-opt --test-hip-whole-shape-dim-reify %s | FileCheck %s --check-prefix=REIFY
 // RUN: hip-mlir-opt --hip-infer-shapes %s | FileCheck %s --check-prefix=INFER
 
 // Dynamic/dynamic broadcast must select the non-unit runtime extent.

--- a/test/lit/Dialect/hip-causal-conv-reify-shapes.mlir
+++ b/test/lit/Dialect/hip-causal-conv-reify-shapes.mlir
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
 
-// RUN: hip-mlir-opt --resolve-shaped-type-result-dims %s | FileCheck %s
+// RUN: hip-mlir-opt --test-hip-whole-shape-dim-reify %s | FileCheck %s
 
 // CHECK-LABEL: func.func @dynamic_kernel
 // CHECK-SAME: %[[INPUT:[^,]+]]: tensor<?x32x?xf16>

--- a/test/lit/Dialect/hip-conv-reify-shapes.mlir
+++ b/test/lit/Dialect/hip-conv-reify-shapes.mlir
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
 
-// RUN: hip-mlir-opt --resolve-shaped-type-result-dims %s | FileCheck %s
+// RUN: hip-mlir-opt --test-hip-whole-shape-dim-reify %s | FileCheck %s
 
 // CHECK-LABEL: func.func @reify_dynamic_spatial
 // CHECK: %[[N:.*]] = tensor.dim %{{.*}}, %{{.*}} : tensor<?x4x?x?xf32>

--- a/test/lit/Dialect/hip-convtranspose-reify-shapes.mlir
+++ b/test/lit/Dialect/hip-convtranspose-reify-shapes.mlir
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
 
-// RUN: hip-mlir-opt --resolve-shaped-type-result-dims %s | FileCheck %s
+// RUN: hip-mlir-opt --test-hip-whole-shape-dim-reify %s | FileCheck %s
 
 // Proves that ConvTranspose reification derives dynamic result dimensions from
 // the operands and attributes rather than echoing the DPS init.

--- a/test/lit/Dialect/hip-dps-op-interface.mlir
+++ b/test/lit/Dialect/hip-dps-op-interface.mlir
@@ -6,8 +6,10 @@
 
 // What this file tests
 // --------------------
-// `HipDpsOp::reifyResultShapes` -- the SHARED default body carried by the
-// in-dialect `HipDpsOpInterface`. `Hip_DpsOp_AutoReify` emits a per-op
+// `HipDpsOp::reifyResultShapes` and `reifyDimOfResult` -- the shared
+// whole-result and direct-dimension bodies carried by the in-dialect
+// `HipDpsOpInterface`. Every HIP DPS family emits a direct-dimension
+// dispatcher; `Hip_DpsOp_AutoReify` additionally emits a per-op
 // `ReifyRankedShapedTypeOpInterface::reifyResultShapes` dispatcher that
 // forwards to that default. The default walks
 // `getDpsInits()` in tensor mode and lifts each init operand's runtime shape
@@ -194,4 +196,20 @@ func.func @default_reify_second_result_failure(
       : tensor<?x?xf16>, tensor<?x?xf32>, tensor<?x?xf32>
   return %result#0, %result#1, %result#2 :
       tensor<?x?xf16>, tensor<?x?xf32>, tensor<?x?xf32>
+}
+
+// -----
+
+// Invalid result/dimension indices and an exact-type mismatch must all fail
+// before the shared direct-dimension path emits tensor.dim.
+// MEMREF: hip.silu
+// MEMREF-SAME: test.default_reify_dim_failure_atomic_passed
+func.func @default_reify_dim_failure_atomic(
+    %ctx: !hip.context, %input: tensor<?x8xf16>,
+    %output: tensor<?x8xf16>) -> tensor<?x8xf16> {
+  %result = hip.silu(%ctx)
+      ins(%input : tensor<?x8xf16>)
+      outs(%output : tensor<?x8xf16>)
+      {test.default_reify_dim_failure_atomic} -> tensor<?x8xf16>
+  return %result : tensor<?x8xf16>
 }

--- a/test/lit/Dialect/hip-gemm-reify-shapes.mlir
+++ b/test/lit/Dialect/hip-gemm-reify-shapes.mlir
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
 
-// RUN: hip-mlir-opt --resolve-shaped-type-result-dims %s | FileCheck %s
+// RUN: hip-mlir-opt --test-hip-whole-shape-dim-reify %s | FileCheck %s
 
 // CHECK-LABEL: func.func @gemm_dynamic_default
 // CHECK-SAME: (%{{.*}}: !hip.context, %[[A:[A-Za-z0-9_]+]]: tensor<?x4xf16>, %[[B:[A-Za-z0-9_]+]]: tensor<4x?xf16>

--- a/test/lit/Dialect/hip-infer-shapes.mlir
+++ b/test/lit/Dialect/hip-infer-shapes.mlir
@@ -839,40 +839,33 @@ func.func @refine_gqa_multi_result_dps_out_fallback(
 
 // -----
 
-// `hip.layer_norm` is variadic-multi-result: 1, 2, or 3 outs (output
-// required; mean and inv_std optional, training-only). The default
-// `Hip_DpsOp::reifyResultShapes` body walks `getDpsInits()` regardless
-// of arity; this case exercises the full 3-out form so the variadic
-// iteration is covered (1-out covered implicitly by every Tier-2
-// fallback test).
-//
-// Same matching-dynamic-outs pattern as the gqa case above: pass walks
-// all 3 results, reify lifts dynamic outs, no narrowing happens, op
-// stays intact -- guards "Variadic outputs interpreted correctly".
+// `hip.layer_norm` is variadic-multi-result: Y has the input shape; Mean and
+// InvStdDev keep reduced axes as 1. For axis=-1 over rank 3, stats are
+// `[d0, d1, 1]`. This guards semantic multi-result reification.
 // CHECK-LABEL: func.func @refine_layer_norm_variadic_three_outs
 // CHECK:         %[[E0:.*]] = tensor.empty(%{{.*}}, %{{.*}}, %{{.*}}) : tensor<?x?x?xf16>
-// CHECK:         %[[E1:.*]] = tensor.empty(%{{.*}}, %{{.*}}, %{{.*}}) : tensor<?x?x?xf32>
-// CHECK:         %[[E2:.*]] = tensor.empty(%{{.*}}, %{{.*}}, %{{.*}}) : tensor<?x?x?xf32>
+// CHECK:         %[[E1:.*]] = tensor.empty(%{{.*}}, %{{.*}}) : tensor<?x?x1xf32>
+// CHECK:         %[[E2:.*]] = tensor.empty(%{{.*}}, %{{.*}}) : tensor<?x?x1xf32>
 // CHECK:         %[[R:.*]]:3 = hip.layer_norm
 // CHECK-SAME:      outs(%[[E0]], %[[E1]], %[[E2]] :
-// CHECK-SAME:           tensor<?x?x?xf16>, tensor<?x?x?xf32>, tensor<?x?x?xf32>)
+// CHECK-SAME:           tensor<?x?x?xf16>, tensor<?x?x1xf32>, tensor<?x?x1xf32>)
 // CHECK:         return %[[R]]#0, %[[R]]#1, %[[R]]#2
 func.func @refine_layer_norm_variadic_three_outs(
     %ctx: !hip.context,
     %input: tensor<?x?x?xf16>,
     %scale: tensor<?xf16>,
     %d0: index, %d1: index, %d2: index)
-    -> (tensor<?x?x?xf16>, tensor<?x?x?xf32>, tensor<?x?x?xf32>) {
+    -> (tensor<?x?x?xf16>, tensor<?x?x1xf32>, tensor<?x?x1xf32>) {
   %e0 = tensor.empty(%d0, %d1, %d2) : tensor<?x?x?xf16>
-  %e1 = tensor.empty(%d0, %d1, %d2) : tensor<?x?x?xf32>
-  %e2 = tensor.empty(%d0, %d1, %d2) : tensor<?x?x?xf32>
+  %e1 = tensor.empty(%d0, %d1) : tensor<?x?x1xf32>
+  %e2 = tensor.empty(%d0, %d1) : tensor<?x?x1xf32>
   %r:3 = hip.layer_norm(%ctx)
     ins(%input, %scale : tensor<?x?x?xf16>, tensor<?xf16>)
     outs(%e0, %e1, %e2 :
-         tensor<?x?x?xf16>, tensor<?x?x?xf32>, tensor<?x?x?xf32>)
+         tensor<?x?x?xf16>, tensor<?x?x1xf32>, tensor<?x?x1xf32>)
     {axis = -1 : i64, epsilon = 9.99999974e-06 : f32, stash_type = 1 : i64}
-    : tensor<?x?x?xf16>, tensor<?x?x?xf32>, tensor<?x?x?xf32>
-  return %r#0, %r#1, %r#2 : tensor<?x?x?xf16>, tensor<?x?x?xf32>, tensor<?x?x?xf32>
+    : tensor<?x?x?xf16>, tensor<?x?x1xf32>, tensor<?x?x1xf32>
+  return %r#0, %r#1, %r#2 : tensor<?x?x?xf16>, tensor<?x?x1xf32>, tensor<?x?x1xf32>
 }
 
 // -----

--- a/test/lit/Dialect/hip-layernorm-reify-shapes.mlir
+++ b/test/lit/Dialect/hip-layernorm-reify-shapes.mlir
@@ -1,0 +1,31 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --resolve-shaped-type-result-dims %s | FileCheck %s
+
+// CHECK-LABEL: func.func @dynamic_stats
+// CHECK-SAME: %[[INPUT:[^,]+]]: tensor<?x3x4xf16>
+// CHECK-DAG: %[[YD:.*]] = tensor.dim %[[INPUT]], %{{.*}}
+// CHECK-DAG: %[[MD:.*]] = tensor.dim %[[INPUT]], %{{.*}}
+// CHECK-DAG: %[[ONE:.*]] = arith.constant 1 : index
+// CHECK: return %[[YD]], %[[MD]], %[[ONE]] : index, index, index
+func.func @dynamic_stats(
+    %ctx: !hip.context,
+    %input: tensor<?x3x4xf16>,
+    %scale: tensor<3x4xf16>,
+    %y_init: tensor<?x3x4xf16>,
+    %mean_init: tensor<?x1x1xf32>,
+    %inv_init: tensor<?x1x1xf32>) -> (index, index, index) {
+  %result:3 = hip.layer_norm(%ctx)
+    ins(%input, %scale : tensor<?x3x4xf16>, tensor<3x4xf16>)
+    outs(%y_init, %mean_init, %inv_init :
+         tensor<?x3x4xf16>, tensor<?x1x1xf32>, tensor<?x1x1xf32>)
+    {axis = 1 : i64, stash_type = 1 : i64}
+    : tensor<?x3x4xf16>, tensor<?x1x1xf32>, tensor<?x1x1xf32>
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %yd = tensor.dim %result#0, %c0 : tensor<?x3x4xf16>
+  %md = tensor.dim %result#1, %c0 : tensor<?x1x1xf32>
+  %one = tensor.dim %result#2, %c1 : tensor<?x1x1xf32>
+  return %yd, %md, %one : index, index, index
+}

--- a/test/lit/Dialect/hip-layernorm-reify-shapes.mlir
+++ b/test/lit/Dialect/hip-layernorm-reify-shapes.mlir
@@ -4,9 +4,13 @@
 // RUN: hip-mlir-opt --resolve-shaped-type-result-dims %s | FileCheck %s
 
 // CHECK-LABEL: func.func @dynamic_stats
-// CHECK-SAME: %[[INPUT:[^,]+]]: tensor<?x3x4xf16>
-// CHECK-DAG: %[[YD:.*]] = tensor.dim %[[INPUT]], %{{.*}}
-// CHECK-DAG: %[[MD:.*]] = tensor.dim %[[INPUT]], %{{.*}}
+// CHECK-SAME: %[[INPUT:[^,]+]]: tensor<?x3x4xf16>,
+// CHECK-SAME: %[[SCALE:[^,]+]]: tensor<3x4xf16>,
+// CHECK-SAME: %[[Y_INIT:[^,]+]]: tensor<?x3x4xf16>,
+// CHECK-SAME: %[[MEAN_INIT:[^,]+]]: tensor<?x1x1xf32>,
+// CHECK-SAME: %[[INV_INIT:[^)]+]]: tensor<?x1x1xf32>)
+// CHECK-DAG: %[[YD:.*]] = tensor.dim %[[Y_INIT]], %{{.*}}
+// CHECK-DAG: %[[MD:.*]] = tensor.dim %[[MEAN_INIT]], %{{.*}}
 // CHECK-DAG: %[[ONE:.*]] = arith.constant 1 : index
 // CHECK: return %[[YD]], %[[MD]], %[[ONE]] : index, index, index
 func.func @dynamic_stats(

--- a/test/lit/Dialect/hip-layernorm-shape-verifier.mlir
+++ b/test/lit/Dialect/hip-layernorm-shape-verifier.mlir
@@ -1,0 +1,80 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --split-input-file --verify-diagnostics %s
+
+func.func @valid(%ctx: !hip.context,
+                 %input: memref<2x3x4xf16, 1>,
+                 %scale: memref<3x4xf16, 1>,
+                 %output: memref<2x3x4xf16, 1>,
+                 %mean: memref<2x1x1xf32, 1>,
+                 %inv: memref<2x1x1xf32, 1>) {
+  hip.layer_norm(%ctx)
+    ins(%input, %scale : memref<2x3x4xf16, 1>, memref<3x4xf16, 1>)
+    outs(%output, %mean, %inv : memref<2x3x4xf16, 1>,
+                                      memref<2x1x1xf32, 1>,
+                                      memref<2x1x1xf32, 1>)
+    {axis = 1 : i64, stash_type = 1 : i64}
+  return
+}
+
+// -----
+
+func.func @wrong_stats_shape(
+    %ctx: !hip.context,
+    %input: memref<2x3x4xf16, 1>,
+    %scale: memref<4xf16, 1>,
+    %output: memref<2x3x4xf16, 1>,
+    %mean: memref<2x3x4xf32, 1>) {
+  // expected-error @+1 {{output #1 dimension 2 must be 1}}
+  hip.layer_norm(%ctx)
+    ins(%input, %scale : memref<2x3x4xf16, 1>, memref<4xf16, 1>)
+    outs(%output, %mean : memref<2x3x4xf16, 1>, memref<2x3x4xf32, 1>)
+    {axis = -1 : i64, stash_type = 1 : i64}
+  return
+}
+
+// -----
+
+func.func @wrong_scale_shape(
+    %ctx: !hip.context,
+    %input: memref<2x3x4xf16, 1>,
+    %scale: memref<4xf16, 1>,
+    %output: memref<2x3x4xf16, 1>) {
+  // expected-error @+1 {{runtime requires scale rank to equal the normalized suffix rank}}
+  hip.layer_norm(%ctx)
+    ins(%input, %scale : memref<2x3x4xf16, 1>, memref<4xf16, 1>)
+    outs(%output : memref<2x3x4xf16, 1>)
+    {axis = 1 : i64, stash_type = 1 : i64}
+  return
+}
+
+// -----
+
+func.func @wrong_stats_type(
+    %ctx: !hip.context,
+    %input: memref<2x4xf16, 1>,
+    %scale: memref<4xf16, 1>,
+    %output: memref<2x4xf16, 1>,
+    %mean: memref<2x1xf16, 1>) {
+  // expected-error @+1 {{stats output element type must match stash_type}}
+  hip.layer_norm(%ctx)
+    ins(%input, %scale : memref<2x4xf16, 1>, memref<4xf16, 1>)
+    outs(%output, %mean : memref<2x4xf16, 1>, memref<2x1xf16, 1>)
+    {axis = -1 : i64, stash_type = 1 : i64}
+  return
+}
+
+// -----
+
+func.func @invalid_axis(%ctx: !hip.context,
+                        %input: memref<2x4xf16, 1>,
+                        %scale: memref<4xf16, 1>,
+                        %output: memref<2x4xf16, 1>) {
+  // expected-error @+1 {{axis must be in [-rank, rank)}}
+  hip.layer_norm(%ctx)
+    ins(%input, %scale : memref<2x4xf16, 1>, memref<4xf16, 1>)
+    outs(%output : memref<2x4xf16, 1>)
+    {axis = 2 : i64, stash_type = 1 : i64}
+  return
+}

--- a/test/lit/Dialect/hip-matmul-reify-shapes.mlir
+++ b/test/lit/Dialect/hip-matmul-reify-shapes.mlir
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
 
-// RUN: hip-mlir-opt --resolve-shaped-type-result-dims %s | FileCheck %s
+// RUN: hip-mlir-opt --test-hip-whole-shape-dim-reify %s | FileCheck %s
 
 // What this file tests
 // --------------------
@@ -26,7 +26,7 @@
 // dynamic ones. A bug in reify's dynamic-dim source-picking (wrong
 // operand chosen, wrong local dim index, or a malformed `tensor.dim`
 // emitted) is therefore invisible to the pass test. Upstream's
-// `--resolve-shaped-type-result-dims` materializes every `OpFoldResult`
+// `--test-hip-whole-shape-dim-reify` materializes every `OpFoldResult`
 // — static and dynamic — into IR that FileCheck can inspect, exposing
 // those bugs. The upstream pass is used here purely as a generic
 // producer-contract validator; it is not part of the production

--- a/test/lit/Dialect/hip-skip-rms-norm-dim-resolution.mlir
+++ b/test/lit/Dialect/hip-skip-rms-norm-dim-resolution.mlir
@@ -1,0 +1,276 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt %s --hip-infer-shapes | FileCheck %s --check-prefix=INFER
+// RUN: hip-mlir-opt %s --hip-resolve-tensor-dims | FileCheck %s --check-prefix=DIM
+
+// Whole-shape reification remains semantic: the static leading input extent
+// refines both SkipRMSNorm results and their DPS destinations.
+// INFER-LABEL: func.func @semantic_whole_shape
+// INFER: %[[OUT:.*]] = tensor.empty(%{{.*}}) : tensor<2x?x64xf16>
+// INFER: %[[RES:.*]] = tensor.empty(%{{.*}}) : tensor<2x?x64xf16>
+// INFER: %[[RESULT:.*]]:2 = hip.skip_rms_norm
+// INFER-SAME: outs(%[[OUT]], %[[RES]] : tensor<2x?x64xf16>, tensor<2x?x64xf16>)
+// INFER-SAME: : tensor<2x?x64xf16>, tensor<2x?x64xf16>
+func.func @semantic_whole_shape(
+    %ctx: !hip.context,
+    %input: tensor<2x?x64xf16>,
+    %skip: tensor<2x?x64xf16>,
+    %gamma: tensor<64xf16>,
+    %d0: index, %d1: index)
+    -> (tensor<?x?x64xf16>, tensor<?x?x64xf16>) {
+  %out = tensor.empty(%d0, %d1) : tensor<?x?x64xf16>
+  %residual = tensor.empty(%d0, %d1) : tensor<?x?x64xf16>
+  %result:2 = hip.skip_rms_norm(%ctx)
+      ins(%input, %skip, %gamma :
+          tensor<2x?x64xf16>, tensor<2x?x64xf16>, tensor<64xf16>)
+      outs(%out, %residual : tensor<?x?x64xf16>, tensor<?x?x64xf16>)
+      {epsilon = 1.0e-05 : f32}
+      : tensor<?x?x64xf16>, tensor<?x?x64xf16>
+  return %result#0, %result#1 : tensor<?x?x64xf16>, tensor<?x?x64xf16>
+}
+
+// Direct per-dimension reification follows the exact result/init ties.
+// DIM-LABEL: func.func @direct_two_output_dims
+// DIM-SAME: %[[INPUT:[^,]+]]: tensor<?x?x64xf16>,
+// DIM-SAME: %[[SKIP:[^,]+]]: tensor<?x?x64xf16>,
+// DIM-SAME: %[[GAMMA:[^,]+]]: tensor<64xf16>,
+// DIM-SAME: %[[OUTPUT:[^,]+]]: tensor<?x?x64xf16>,
+// DIM-SAME: %[[RESIDUAL:[^)]+]]: tensor<?x?x64xf16>)
+// DIM: %[[OUT_DIM:.*]] = tensor.dim %[[OUTPUT]], %{{.*}}
+// DIM: %[[RES_DIM:.*]] = tensor.dim %[[RESIDUAL]], %{{.*}}
+// DIM: return %[[OUT_DIM]], %[[RES_DIM]]
+func.func @direct_two_output_dims(
+    %ctx: !hip.context,
+    %input: tensor<?x?x64xf16>,
+    %skip: tensor<?x?x64xf16>,
+    %gamma: tensor<64xf16>,
+    %output: tensor<?x?x64xf16>,
+    %residual: tensor<?x?x64xf16>) -> (index, index) {
+  %result:2 = hip.skip_rms_norm(%ctx)
+      ins(%input, %skip, %gamma :
+          tensor<?x?x64xf16>, tensor<?x?x64xf16>, tensor<64xf16>)
+      outs(%output, %residual : tensor<?x?x64xf16>, tensor<?x?x64xf16>)
+      {epsilon = 1.0e-05 : f32}
+      : tensor<?x?x64xf16>, tensor<?x?x64xf16>
+  %c0 = arith.constant 0 : index
+  %out_dim = tensor.dim %result#0, %c0 : tensor<?x?x64xf16>
+  %res_dim = tensor.dim %result#1, %c0 : tensor<?x?x64xf16>
+  return %out_dim, %res_dim : index, index
+}
+
+// A long residual chain used to expand one tail query through every dimension
+// of both results at every preceding layer. The direct hook terminates at the
+// tied residual destination instead.
+// DIM-LABEL: func.func @deep_residual_chain
+// DIM-SAME: %[[INPUT:[^,]+]]: tensor<?x?x64xf16>,
+// DIM-SAME: %[[SKIP:[^,]+]]: tensor<?x?x64xf16>,
+// DIM-SAME: %[[GAMMA:[^,]+]]: tensor<64xf16>,
+// DIM-SAME: %[[OUTPUT:[^,]+]]: tensor<?x?x64xf16>,
+// DIM-SAME: %[[RESIDUAL:[^)]+]]: tensor<?x?x64xf16>)
+// DIM-NOT: tensor.dim %{{.*}}#
+// DIM: %[[TAIL_DIM:.*]] = tensor.dim %[[RESIDUAL]], %{{.*}}
+// DIM: return %[[TAIL_DIM]]
+func.func @deep_residual_chain(
+    %ctx: !hip.context,
+    %input: tensor<?x?x64xf16>,
+    %skip: tensor<?x?x64xf16>,
+    %gamma: tensor<64xf16>,
+    %output: tensor<?x?x64xf16>,
+    %residual: tensor<?x?x64xf16>) -> index {
+  %r0:2 = hip.skip_rms_norm(%ctx)
+      ins(%input, %skip, %gamma :
+          tensor<?x?x64xf16>, tensor<?x?x64xf16>, tensor<64xf16>)
+      outs(%output, %residual : tensor<?x?x64xf16>, tensor<?x?x64xf16>)
+      {epsilon = 1.0e-05 : f32}
+      : tensor<?x?x64xf16>, tensor<?x?x64xf16>
+  %r1:2 = hip.skip_rms_norm(%ctx)
+      ins(%r0#0, %r0#1, %gamma :
+          tensor<?x?x64xf16>, tensor<?x?x64xf16>, tensor<64xf16>)
+      outs(%output, %residual : tensor<?x?x64xf16>, tensor<?x?x64xf16>)
+      {epsilon = 1.0e-05 : f32}
+      : tensor<?x?x64xf16>, tensor<?x?x64xf16>
+  %r2:2 = hip.skip_rms_norm(%ctx)
+      ins(%r1#0, %r1#1, %gamma :
+          tensor<?x?x64xf16>, tensor<?x?x64xf16>, tensor<64xf16>)
+      outs(%output, %residual : tensor<?x?x64xf16>, tensor<?x?x64xf16>)
+      {epsilon = 1.0e-05 : f32}
+      : tensor<?x?x64xf16>, tensor<?x?x64xf16>
+  %r3:2 = hip.skip_rms_norm(%ctx)
+      ins(%r2#0, %r2#1, %gamma :
+          tensor<?x?x64xf16>, tensor<?x?x64xf16>, tensor<64xf16>)
+      outs(%output, %residual : tensor<?x?x64xf16>, tensor<?x?x64xf16>)
+      {epsilon = 1.0e-05 : f32}
+      : tensor<?x?x64xf16>, tensor<?x?x64xf16>
+  %r4:2 = hip.skip_rms_norm(%ctx)
+      ins(%r3#0, %r3#1, %gamma :
+          tensor<?x?x64xf16>, tensor<?x?x64xf16>, tensor<64xf16>)
+      outs(%output, %residual : tensor<?x?x64xf16>, tensor<?x?x64xf16>)
+      {epsilon = 1.0e-05 : f32}
+      : tensor<?x?x64xf16>, tensor<?x?x64xf16>
+  %r5:2 = hip.skip_rms_norm(%ctx)
+      ins(%r4#0, %r4#1, %gamma :
+          tensor<?x?x64xf16>, tensor<?x?x64xf16>, tensor<64xf16>)
+      outs(%output, %residual : tensor<?x?x64xf16>, tensor<?x?x64xf16>)
+      {epsilon = 1.0e-05 : f32}
+      : tensor<?x?x64xf16>, tensor<?x?x64xf16>
+  %r6:2 = hip.skip_rms_norm(%ctx)
+      ins(%r5#0, %r5#1, %gamma :
+          tensor<?x?x64xf16>, tensor<?x?x64xf16>, tensor<64xf16>)
+      outs(%output, %residual : tensor<?x?x64xf16>, tensor<?x?x64xf16>)
+      {epsilon = 1.0e-05 : f32}
+      : tensor<?x?x64xf16>, tensor<?x?x64xf16>
+  %r7:2 = hip.skip_rms_norm(%ctx)
+      ins(%r6#0, %r6#1, %gamma :
+          tensor<?x?x64xf16>, tensor<?x?x64xf16>, tensor<64xf16>)
+      outs(%output, %residual : tensor<?x?x64xf16>, tensor<?x?x64xf16>)
+      {epsilon = 1.0e-05 : f32}
+      : tensor<?x?x64xf16>, tensor<?x?x64xf16>
+  %r8:2 = hip.skip_rms_norm(%ctx)
+      ins(%r7#0, %r7#1, %gamma :
+          tensor<?x?x64xf16>, tensor<?x?x64xf16>, tensor<64xf16>)
+      outs(%output, %residual : tensor<?x?x64xf16>, tensor<?x?x64xf16>)
+      {epsilon = 1.0e-05 : f32}
+      : tensor<?x?x64xf16>, tensor<?x?x64xf16>
+  %r9:2 = hip.skip_rms_norm(%ctx)
+      ins(%r8#0, %r8#1, %gamma :
+          tensor<?x?x64xf16>, tensor<?x?x64xf16>, tensor<64xf16>)
+      outs(%output, %residual : tensor<?x?x64xf16>, tensor<?x?x64xf16>)
+      {epsilon = 1.0e-05 : f32}
+      : tensor<?x?x64xf16>, tensor<?x?x64xf16>
+  %r10:2 = hip.skip_rms_norm(%ctx)
+      ins(%r9#0, %r9#1, %gamma :
+          tensor<?x?x64xf16>, tensor<?x?x64xf16>, tensor<64xf16>)
+      outs(%output, %residual : tensor<?x?x64xf16>, tensor<?x?x64xf16>)
+      {epsilon = 1.0e-05 : f32}
+      : tensor<?x?x64xf16>, tensor<?x?x64xf16>
+  %r11:2 = hip.skip_rms_norm(%ctx)
+      ins(%r10#0, %r10#1, %gamma :
+          tensor<?x?x64xf16>, tensor<?x?x64xf16>, tensor<64xf16>)
+      outs(%output, %residual : tensor<?x?x64xf16>, tensor<?x?x64xf16>)
+      {epsilon = 1.0e-05 : f32}
+      : tensor<?x?x64xf16>, tensor<?x?x64xf16>
+  %r12:2 = hip.skip_rms_norm(%ctx)
+      ins(%r11#0, %r11#1, %gamma :
+          tensor<?x?x64xf16>, tensor<?x?x64xf16>, tensor<64xf16>)
+      outs(%output, %residual : tensor<?x?x64xf16>, tensor<?x?x64xf16>)
+      {epsilon = 1.0e-05 : f32}
+      : tensor<?x?x64xf16>, tensor<?x?x64xf16>
+  %r13:2 = hip.skip_rms_norm(%ctx)
+      ins(%r12#0, %r12#1, %gamma :
+          tensor<?x?x64xf16>, tensor<?x?x64xf16>, tensor<64xf16>)
+      outs(%output, %residual : tensor<?x?x64xf16>, tensor<?x?x64xf16>)
+      {epsilon = 1.0e-05 : f32}
+      : tensor<?x?x64xf16>, tensor<?x?x64xf16>
+  %r14:2 = hip.skip_rms_norm(%ctx)
+      ins(%r13#0, %r13#1, %gamma :
+          tensor<?x?x64xf16>, tensor<?x?x64xf16>, tensor<64xf16>)
+      outs(%output, %residual : tensor<?x?x64xf16>, tensor<?x?x64xf16>)
+      {epsilon = 1.0e-05 : f32}
+      : tensor<?x?x64xf16>, tensor<?x?x64xf16>
+  %r15:2 = hip.skip_rms_norm(%ctx)
+      ins(%r14#0, %r14#1, %gamma :
+          tensor<?x?x64xf16>, tensor<?x?x64xf16>, tensor<64xf16>)
+      outs(%output, %residual : tensor<?x?x64xf16>, tensor<?x?x64xf16>)
+      {epsilon = 1.0e-05 : f32}
+      : tensor<?x?x64xf16>, tensor<?x?x64xf16>
+  %r16:2 = hip.skip_rms_norm(%ctx)
+      ins(%r15#0, %r15#1, %gamma :
+          tensor<?x?x64xf16>, tensor<?x?x64xf16>, tensor<64xf16>)
+      outs(%output, %residual : tensor<?x?x64xf16>, tensor<?x?x64xf16>)
+      {epsilon = 1.0e-05 : f32}
+      : tensor<?x?x64xf16>, tensor<?x?x64xf16>
+  %r17:2 = hip.skip_rms_norm(%ctx)
+      ins(%r16#0, %r16#1, %gamma :
+          tensor<?x?x64xf16>, tensor<?x?x64xf16>, tensor<64xf16>)
+      outs(%output, %residual : tensor<?x?x64xf16>, tensor<?x?x64xf16>)
+      {epsilon = 1.0e-05 : f32}
+      : tensor<?x?x64xf16>, tensor<?x?x64xf16>
+  %r18:2 = hip.skip_rms_norm(%ctx)
+      ins(%r17#0, %r17#1, %gamma :
+          tensor<?x?x64xf16>, tensor<?x?x64xf16>, tensor<64xf16>)
+      outs(%output, %residual : tensor<?x?x64xf16>, tensor<?x?x64xf16>)
+      {epsilon = 1.0e-05 : f32}
+      : tensor<?x?x64xf16>, tensor<?x?x64xf16>
+  %r19:2 = hip.skip_rms_norm(%ctx)
+      ins(%r18#0, %r18#1, %gamma :
+          tensor<?x?x64xf16>, tensor<?x?x64xf16>, tensor<64xf16>)
+      outs(%output, %residual : tensor<?x?x64xf16>, tensor<?x?x64xf16>)
+      {epsilon = 1.0e-05 : f32}
+      : tensor<?x?x64xf16>, tensor<?x?x64xf16>
+  %r20:2 = hip.skip_rms_norm(%ctx)
+      ins(%r19#0, %r19#1, %gamma :
+          tensor<?x?x64xf16>, tensor<?x?x64xf16>, tensor<64xf16>)
+      outs(%output, %residual : tensor<?x?x64xf16>, tensor<?x?x64xf16>)
+      {epsilon = 1.0e-05 : f32}
+      : tensor<?x?x64xf16>, tensor<?x?x64xf16>
+  %r21:2 = hip.skip_rms_norm(%ctx)
+      ins(%r20#0, %r20#1, %gamma :
+          tensor<?x?x64xf16>, tensor<?x?x64xf16>, tensor<64xf16>)
+      outs(%output, %residual : tensor<?x?x64xf16>, tensor<?x?x64xf16>)
+      {epsilon = 1.0e-05 : f32}
+      : tensor<?x?x64xf16>, tensor<?x?x64xf16>
+  %r22:2 = hip.skip_rms_norm(%ctx)
+      ins(%r21#0, %r21#1, %gamma :
+          tensor<?x?x64xf16>, tensor<?x?x64xf16>, tensor<64xf16>)
+      outs(%output, %residual : tensor<?x?x64xf16>, tensor<?x?x64xf16>)
+      {epsilon = 1.0e-05 : f32}
+      : tensor<?x?x64xf16>, tensor<?x?x64xf16>
+  %r23:2 = hip.skip_rms_norm(%ctx)
+      ins(%r22#0, %r22#1, %gamma :
+          tensor<?x?x64xf16>, tensor<?x?x64xf16>, tensor<64xf16>)
+      outs(%output, %residual : tensor<?x?x64xf16>, tensor<?x?x64xf16>)
+      {epsilon = 1.0e-05 : f32}
+      : tensor<?x?x64xf16>, tensor<?x?x64xf16>
+  %r24:2 = hip.skip_rms_norm(%ctx)
+      ins(%r23#0, %r23#1, %gamma :
+          tensor<?x?x64xf16>, tensor<?x?x64xf16>, tensor<64xf16>)
+      outs(%output, %residual : tensor<?x?x64xf16>, tensor<?x?x64xf16>)
+      {epsilon = 1.0e-05 : f32}
+      : tensor<?x?x64xf16>, tensor<?x?x64xf16>
+  %r25:2 = hip.skip_rms_norm(%ctx)
+      ins(%r24#0, %r24#1, %gamma :
+          tensor<?x?x64xf16>, tensor<?x?x64xf16>, tensor<64xf16>)
+      outs(%output, %residual : tensor<?x?x64xf16>, tensor<?x?x64xf16>)
+      {epsilon = 1.0e-05 : f32}
+      : tensor<?x?x64xf16>, tensor<?x?x64xf16>
+  %r26:2 = hip.skip_rms_norm(%ctx)
+      ins(%r25#0, %r25#1, %gamma :
+          tensor<?x?x64xf16>, tensor<?x?x64xf16>, tensor<64xf16>)
+      outs(%output, %residual : tensor<?x?x64xf16>, tensor<?x?x64xf16>)
+      {epsilon = 1.0e-05 : f32}
+      : tensor<?x?x64xf16>, tensor<?x?x64xf16>
+  %r27:2 = hip.skip_rms_norm(%ctx)
+      ins(%r26#0, %r26#1, %gamma :
+          tensor<?x?x64xf16>, tensor<?x?x64xf16>, tensor<64xf16>)
+      outs(%output, %residual : tensor<?x?x64xf16>, tensor<?x?x64xf16>)
+      {epsilon = 1.0e-05 : f32}
+      : tensor<?x?x64xf16>, tensor<?x?x64xf16>
+  %r28:2 = hip.skip_rms_norm(%ctx)
+      ins(%r27#0, %r27#1, %gamma :
+          tensor<?x?x64xf16>, tensor<?x?x64xf16>, tensor<64xf16>)
+      outs(%output, %residual : tensor<?x?x64xf16>, tensor<?x?x64xf16>)
+      {epsilon = 1.0e-05 : f32}
+      : tensor<?x?x64xf16>, tensor<?x?x64xf16>
+  %r29:2 = hip.skip_rms_norm(%ctx)
+      ins(%r28#0, %r28#1, %gamma :
+          tensor<?x?x64xf16>, tensor<?x?x64xf16>, tensor<64xf16>)
+      outs(%output, %residual : tensor<?x?x64xf16>, tensor<?x?x64xf16>)
+      {epsilon = 1.0e-05 : f32}
+      : tensor<?x?x64xf16>, tensor<?x?x64xf16>
+  %r30:2 = hip.skip_rms_norm(%ctx)
+      ins(%r29#0, %r29#1, %gamma :
+          tensor<?x?x64xf16>, tensor<?x?x64xf16>, tensor<64xf16>)
+      outs(%output, %residual : tensor<?x?x64xf16>, tensor<?x?x64xf16>)
+      {epsilon = 1.0e-05 : f32}
+      : tensor<?x?x64xf16>, tensor<?x?x64xf16>
+  %r31:2 = hip.skip_rms_norm(%ctx)
+      ins(%r30#0, %r30#1, %gamma :
+          tensor<?x?x64xf16>, tensor<?x?x64xf16>, tensor<64xf16>)
+      outs(%output, %residual : tensor<?x?x64xf16>, tensor<?x?x64xf16>)
+      {epsilon = 1.0e-05 : f32}
+      : tensor<?x?x64xf16>, tensor<?x?x64xf16>
+  %c0 = arith.constant 0 : index
+  %tail_dim = tensor.dim %r31#1, %c0 : tensor<?x?x64xf16>
+  return %tail_dim : index
+}

--- a/test/lit/Dialect/hip-skip-rms-norm-reify-shapes.mlir
+++ b/test/lit/Dialect/hip-skip-rms-norm-reify-shapes.mlir
@@ -4,11 +4,15 @@
 // RUN: hip-mlir-opt --resolve-shaped-type-result-dims %s | FileCheck %s
 
 // CHECK-LABEL: func.func @two_outputs
-// CHECK-SAME: %[[INPUT:[^,]+]]: tensor<?x?x64xf16>
-// CHECK: %[[O0:.*]] = tensor.dim %[[INPUT]], %{{.*}}
-// CHECK: %[[O1:.*]] = tensor.dim %[[INPUT]], %{{.*}}
-// CHECK: %[[R0:.*]] = tensor.dim %[[INPUT]], %{{.*}}
-// CHECK: %[[R1:.*]] = tensor.dim %[[INPUT]], %{{.*}}
+// CHECK-SAME: %[[INPUT:[^,]+]]: tensor<?x?x64xf16>,
+// CHECK-SAME: %[[SKIP:[^,]+]]: tensor<?x?x64xf16>,
+// CHECK-SAME: %[[GAMMA:[^,]+]]: tensor<64xf16>,
+// CHECK-SAME: %[[OUTPUT:[^,]+]]: tensor<?x?x64xf16>,
+// CHECK-SAME: %[[RESIDUAL:[^)]+]]: tensor<?x?x64xf16>)
+// CHECK: %[[O0:.*]] = tensor.dim %[[OUTPUT]], %{{.*}}
+// CHECK: %[[O1:.*]] = tensor.dim %[[OUTPUT]], %{{.*}}
+// CHECK: %[[R0:.*]] = tensor.dim %[[RESIDUAL]], %{{.*}}
+// CHECK: %[[R1:.*]] = tensor.dim %[[RESIDUAL]], %{{.*}}
 // CHECK: return %[[O0]], %[[O1]], %[[R0]], %[[R1]]
 func.func @two_outputs(
     %ctx: !hip.context,
@@ -34,8 +38,11 @@ func.func @two_outputs(
 }
 
 // CHECK-LABEL: func.func @one_output
-// CHECK-SAME: %[[INPUT:[^,]+]]: tensor<?x32xf32>
-// CHECK: %[[D0:.*]] = tensor.dim %[[INPUT]], %{{.*}}
+// CHECK-SAME: %[[INPUT:[^,]+]]: tensor<?x32xf32>,
+// CHECK-SAME: %[[SKIP:[^,]+]]: tensor<?x32xf32>,
+// CHECK-SAME: %[[GAMMA:[^,]+]]: tensor<32xf32>,
+// CHECK-SAME: %[[OUTPUT:[^)]+]]: tensor<?x32xf32>)
+// CHECK: %[[D0:.*]] = tensor.dim %[[OUTPUT]], %{{.*}}
 // CHECK: return %[[D0]]
 func.func @one_output(
     %ctx: !hip.context,

--- a/test/lit/Dialect/hip-skip-rms-norm-reify-shapes.mlir
+++ b/test/lit/Dialect/hip-skip-rms-norm-reify-shapes.mlir
@@ -1,0 +1,55 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --resolve-shaped-type-result-dims %s | FileCheck %s
+
+// CHECK-LABEL: func.func @two_outputs
+// CHECK-SAME: %[[INPUT:[^,]+]]: tensor<?x?x64xf16>
+// CHECK: %[[O0:.*]] = tensor.dim %[[INPUT]], %{{.*}}
+// CHECK: %[[O1:.*]] = tensor.dim %[[INPUT]], %{{.*}}
+// CHECK: %[[R0:.*]] = tensor.dim %[[INPUT]], %{{.*}}
+// CHECK: %[[R1:.*]] = tensor.dim %[[INPUT]], %{{.*}}
+// CHECK: return %[[O0]], %[[O1]], %[[R0]], %[[R1]]
+func.func @two_outputs(
+    %ctx: !hip.context,
+    %input: tensor<?x?x64xf16>,
+    %skip: tensor<?x?x64xf16>,
+    %gamma: tensor<64xf16>,
+    %output: tensor<?x?x64xf16>,
+    %residual: tensor<?x?x64xf16>) -> (index, index, index, index) {
+  %result:2 = hip.skip_rms_norm(%ctx)
+      ins(%input, %skip, %gamma :
+          tensor<?x?x64xf16>, tensor<?x?x64xf16>, tensor<64xf16>)
+      outs(%output, %residual :
+           tensor<?x?x64xf16>, tensor<?x?x64xf16>)
+      {epsilon = 1.0e-05 : f32}
+      : tensor<?x?x64xf16>, tensor<?x?x64xf16>
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %out0 = tensor.dim %result#0, %c0 : tensor<?x?x64xf16>
+  %out1 = tensor.dim %result#0, %c1 : tensor<?x?x64xf16>
+  %res0 = tensor.dim %result#1, %c0 : tensor<?x?x64xf16>
+  %res1 = tensor.dim %result#1, %c1 : tensor<?x?x64xf16>
+  return %out0, %out1, %res0, %res1 : index, index, index, index
+}
+
+// CHECK-LABEL: func.func @one_output
+// CHECK-SAME: %[[INPUT:[^,]+]]: tensor<?x32xf32>
+// CHECK: %[[D0:.*]] = tensor.dim %[[INPUT]], %{{.*}}
+// CHECK: return %[[D0]]
+func.func @one_output(
+    %ctx: !hip.context,
+    %input: tensor<?x32xf32>,
+    %skip: tensor<?x32xf32>,
+    %gamma: tensor<32xf32>,
+    %output: tensor<?x32xf32>) -> index {
+  %result = hip.skip_rms_norm(%ctx)
+      ins(%input, %skip, %gamma :
+          tensor<?x32xf32>, tensor<?x32xf32>, tensor<32xf32>)
+      outs(%output : tensor<?x32xf32>)
+      {epsilon = 1.0e-05 : f32}
+      : tensor<?x32xf32>
+  %c0 = arith.constant 0 : index
+  %d0 = tensor.dim %result, %c0 : tensor<?x32xf32>
+  return %d0 : index
+}

--- a/test/lit/Dialect/hip-skip-rms-norm-shape-verifier.mlir
+++ b/test/lit/Dialect/hip-skip-rms-norm-shape-verifier.mlir
@@ -1,0 +1,93 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --verify-diagnostics %s
+
+func.func @wrong_skip_shape(
+    %ctx: !hip.context, %input: memref<2x4x16xf16>,
+    %skip: memref<2x5x16xf16>, %gamma: memref<16xf16>,
+    %output: memref<2x4x16xf16>) {
+  // expected-error @+1 {{'hip.skip_rms_norm' op skip_rms_norm skip dimension 1 must match input}}
+  hip.skip_rms_norm(%ctx)
+      ins(%input, %skip, %gamma :
+          memref<2x4x16xf16>, memref<2x5x16xf16>, memref<16xf16>)
+      outs(%output : memref<2x4x16xf16>) {epsilon = 1.0e-05 : f32}
+  return
+}
+
+func.func @wrong_gamma(
+    %ctx: !hip.context, %input: memref<8x16xf16>,
+    %skip: memref<8x16xf16>, %gamma: memref<15xf16>,
+    %output: memref<8x16xf16>) {
+  // expected-error @+1 {{'hip.skip_rms_norm' op skip_rms_norm gamma length must match the input's final dimension}}
+  hip.skip_rms_norm(%ctx)
+      ins(%input, %skip, %gamma :
+          memref<8x16xf16>, memref<8x16xf16>, memref<15xf16>)
+      outs(%output : memref<8x16xf16>) {epsilon = 1.0e-05 : f32}
+  return
+}
+
+func.func @wrong_bias(
+    %ctx: !hip.context, %input: memref<8x16xf16>,
+    %skip: memref<8x16xf16>, %gamma: memref<16xf16>,
+    %bias: memref<8x16xf16>, %output: memref<8x16xf16>) {
+  // expected-error @+1 {{'hip.skip_rms_norm' op skip_rms_norm bias must have rank 1}}
+  hip.skip_rms_norm(%ctx)
+      ins(%input, %skip, %gamma, %bias :
+          memref<8x16xf16>, memref<8x16xf16>, memref<16xf16>,
+          memref<8x16xf16>)
+      outs(%output : memref<8x16xf16>) {epsilon = 1.0e-05 : f32}
+  return
+}
+
+func.func @wrong_residual_shape(
+    %ctx: !hip.context, %input: memref<8x16xf16>,
+    %skip: memref<8x16xf16>, %gamma: memref<16xf16>,
+    %output: memref<8x16xf16>, %residual: memref<7x16xf16>) {
+  // expected-error @+1 {{'hip.skip_rms_norm' op dim 0 of result mismatch: expected 8}}
+  hip.skip_rms_norm(%ctx)
+      ins(%input, %skip, %gamma :
+          memref<8x16xf16>, memref<8x16xf16>, memref<16xf16>)
+      outs(%output, %residual : memref<8x16xf16>, memref<7x16xf16>)
+      {epsilon = 1.0e-05 : f32}
+  return
+}
+
+func.func @too_many_outputs(
+    %ctx: !hip.context, %input: memref<8x16xf16>,
+    %skip: memref<8x16xf16>, %gamma: memref<16xf16>,
+    %out0: memref<8x16xf16>, %out1: memref<8x16xf16>,
+    %out2: memref<8x16xf16>) {
+  // expected-error @+1 {{'hip.skip_rms_norm' op expected 1 or 2 output buffers, got 3}}
+  hip.skip_rms_norm(%ctx)
+      ins(%input, %skip, %gamma :
+          memref<8x16xf16>, memref<8x16xf16>, memref<16xf16>)
+      outs(%out0, %out1, %out2 :
+           memref<8x16xf16>, memref<8x16xf16>, memref<8x16xf16>)
+      {epsilon = 1.0e-05 : f32}
+  return
+}
+
+func.func @mismatched_dtype(
+    %ctx: !hip.context, %input: memref<8x16xf16>,
+    %skip: memref<8x16xf32>, %gamma: memref<16xf16>,
+    %output: memref<8x16xf16>) {
+  // expected-error @+1 {{'hip.skip_rms_norm' op all input and output element types must match}}
+  hip.skip_rms_norm(%ctx)
+      ins(%input, %skip, %gamma :
+          memref<8x16xf16>, memref<8x16xf32>, memref<16xf16>)
+      outs(%output : memref<8x16xf16>) {epsilon = 1.0e-05 : f32}
+  return
+}
+
+func.func @negative_epsilon(
+    %ctx: !hip.context, %input: memref<8x16xf16>,
+    %skip: memref<8x16xf16>, %gamma: memref<16xf16>,
+    %output: memref<8x16xf16>) {
+  // expected-error @+1 {{'hip.skip_rms_norm' op epsilon must be non-negative}}
+  hip.skip_rms_norm(%ctx)
+      ins(%input, %skip, %gamma :
+          memref<8x16xf16>, memref<8x16xf16>, memref<16xf16>)
+      outs(%output : memref<8x16xf16>) {epsilon = -1.0 : f32}
+  return
+}

--- a/test/lit/e2e/test_layer_norm_stats_model.mlir
+++ b/test/lit/e2e/test_layer_norm_stats_model.mlir
@@ -1,0 +1,24 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt %s --hipdnn-pipeline | FileCheck %s
+
+// CHECK: llvm.func @wrap_layer_normalization
+// CHECK: llvm.func @inference_compute
+// CHECK-NOT: onnx.LayerNormalization
+module {
+  func.func @main_graph(
+      %input: tensor<2x4xf16> {onnx.name = "input"},
+      %scale: tensor<4xf16> {onnx.name = "scale"})
+      -> (tensor<2x4xf16> {onnx.name = "output"},
+          tensor<2x1xf32> {onnx.name = "inv_std"}) {
+    %result:3 = "onnx.LayerNormalization"(%input, %scale)
+      {axis = -1 : si64, epsilon = 9.99999974E-6 : f32,
+       stash_type = 1 : si64}
+      : (tensor<2x4xf16>, tensor<4xf16>)
+        -> (tensor<2x4xf16>, none, tensor<2x1xf32>)
+    "onnx.Return"(%result#0, %result#2)
+      : (tensor<2x4xf16>, tensor<2x1xf32>) -> ()
+  }
+  "onnx.EntryPoint"() {func = @main_graph} : () -> ()
+}

--- a/test/numeric/tests/test_layer_norm.py
+++ b/test/numeric/tests/test_layer_norm.py
@@ -342,6 +342,50 @@ def _make_layer_norm_model(
     return make_model_from_nodes([node], [X], [Y], initializers=initializers)
 
 
+def _make_layer_norm_stats_model(
+    input_shape: list[int],
+    axis: int,
+    *,
+    include_mean: bool,
+    include_inv_std: bool,
+):
+    normalized_axis = axis if axis >= 0 else axis + len(input_shape)
+    scale_shape = input_shape[normalized_axis:]
+    stats_shape = input_shape[:normalized_axis] + [1] * (
+        len(input_shape) - normalized_axis
+    )
+    X = helper.make_tensor_value_info("X", TensorProto.FLOAT16, input_shape)
+    Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT16, input_shape)
+    output_names = ["Y"]
+    outputs = [Y]
+    if include_mean:
+        output_names.append("Mean")
+        outputs.append(
+            helper.make_tensor_value_info("Mean", TensorProto.FLOAT, stats_shape)
+        )
+    else:
+        output_names.append("")
+    if include_inv_std:
+        output_names.append("InvStdDev")
+        outputs.append(
+            helper.make_tensor_value_info("InvStdDev", TensorProto.FLOAT, stats_shape)
+        )
+
+    rng = np.random.default_rng(117)
+    scale_init = numpy_helper.from_array(
+        rng.uniform(0.5, 1.5, scale_shape).astype(np.float16), name="scale"
+    )
+    node = helper.make_node(
+        "LayerNormalization",
+        ["X", "scale"],
+        output_names,
+        axis=axis,
+        epsilon=1e-5,
+        stash_type=1,
+    )
+    return make_model_from_nodes([node], [X], outputs, initializers=[scale_init])
+
+
 class TestLayerNormalization:
     """Full LN: (x - mean) * rsqrt(var + eps) * scale [+ bias]."""
 
@@ -393,6 +437,28 @@ class TestLayerNormalization:
         x = rng.uniform(-2, 2, input_shape).astype(np.float32)
         actual, expected = model_runner.run_sample(model, [x])
         compare_outputs(actual, expected, atol=1e-5, rtol=1e-5)
+
+    @pytest.mark.parametrize(
+        "input_shape,axis,include_mean,include_inv_std",
+        [
+            ([2, 3, 4], -1, True, True),
+            ([2, 3, 4], 1, True, True),
+            ([2, 4], -1, False, True),
+        ],
+    )
+    def test_layer_norm_stats_outputs(
+        self, model_runner, input_shape, axis, include_mean, include_inv_std
+    ):
+        model = _make_layer_norm_stats_model(
+            input_shape,
+            axis,
+            include_mean=include_mean,
+            include_inv_std=include_inv_std,
+        )
+        rng = np.random.default_rng(118)
+        x = rng.uniform(-2, 2, input_shape).astype(np.float16)
+        actual, expected = model_runner.run_sample(model, [x])
+        compare_outputs(actual, expected, atol=2e-3, rtol=1e-3)
 
     @pytest.mark.parametrize("num_patches", [256, 1024])
     def test_layer_norm_qwen35b_vision_shape(self, model_runner, num_patches):


### PR DESCRIPTION
## Why

Attention and normalization operations previously derived related result and state shapes through separate converter, reifier, and verifier paths. That duplication was especially risky for optional outputs, cache capacity, logical sequence length, and synchronized GPU readback.

This PR gives those operations shared semantic contracts so output allocation and shape verification use the same formulas.

## IR example

The added GQA verifier test uses separate current and past key/value inputs and makes the three-result state contract explicit:

```mlir
%result:3 = hip.gqa(%ctx)
  ins(%query, %key, %value, %past_key, %past_value, %seqlens, %total :
      tensor<1x2x32xf16>, tensor<1x3x16xf16>, tensor<1x3x16xf16>,
      tensor<1x2x4x8xf16>, tensor<1x2x4x8xf16>, tensor<1xi32>,
      tensor<i32>)
  outs(%out, %present_key, %present_value :
      tensor<1x2x32xf16>, tensor<1x2x5x8xf16>, tensor<1x2x5x8xf16>)
  {num_heads = 4 : i64, kv_num_heads = 2 : i64,
   qk_output = 0 : i64, softcap = 0.000000e+00 : f32}
  : tensor<1x2x32xf16>, tensor<1x2x5x8xf16>,
    tensor<1x2x5x8xf16>
```

The output keeps the query batch/sequence/hidden shape, while both present caches use the shared batch, KV-head, sequence-capacity, and head-size contract.

## What changes

- Share MultiHeadAttention and LinearAttention output/state formulas across converters, reifiers, and verifiers.
- Define LayerNormalization output, Mean, and InvStdDev shapes through the same input/reduction rules.
- Define SkipRmsNorm output and optional residual shapes from the input contract while rejecting unsupported training statistics.
- Consolidate RotaryEmbedding configuration inference across ONNX and Microsoft-domain converters.
- Size dynamic GQA present caches as `max(past capacity, total_seq_len)` while using logical sequence length for optional QK output.
- Reuse one synchronized logical-length readback across GQA present-key, present-value, and QK destination construction.
- Keep GQA capacity selection, output allocator behavior, converter wiring, and focused tests in the same layer.

Review note: the canonical no-share-cache model set is not installed on the current validation host. This PR should remain draft until that test is run.

## Stack

Merged prerequisite plus the 22 active shape PRs:

1. [#688 — refactor(hip): externalize constants after ONNX conversion](https://github.com/ROCm/hip-ep/pull/688)
2. [#724 — feat(shape): preserve symbolic compiler inputs](https://github.com/ROCm/hip-ep/pull/724)
3. [#639 — refactor(hip): establish shared shape-rule foundation](https://github.com/ROCm/hip-ep/pull/639)
4. [#681 — fix(shape): canonicalize host reshape provenance](https://github.com/ROCm/hip-ep/pull/681)
5. [#725 — fix(shape): activate exact broadcasts with symbolic proofs](https://github.com/ROCm/hip-ep/pull/725)
6. [#734 — fix(shape): share MatMul and Gemm contracts](https://github.com/ROCm/hip-ep/pull/734)
7. [#641 — fix(shape): enforce shared broadcast contracts](https://github.com/ROCm/hip-ep/pull/641)
8. [#735 — refactor(conversion): share ONNX reduction conversion](https://github.com/ROCm/hip-ep/pull/735)
9. [#736 — fix(shape): normalize reduction contracts](https://github.com/ROCm/hip-ep/pull/736)
10. [#643 — fix(shape): share convolution contracts](https://github.com/ROCm/hip-ep/pull/643)
11. [#742 — fix(shape): share causal convolution contracts](https://github.com/ROCm/hip-ep/pull/742)
12. [#645 — fix(shape): share normalization contracts](https://github.com/ROCm/hip-ep/pull/645) ← this PR
13. [#740 — fix(shape): share attention contracts](https://github.com/ROCm/hip-ep/pull/740)
14. [#741 — fix(shape): share GQA capacity contracts](https://github.com/ROCm/hip-ep/pull/741)
15. [#644 — fix(shape): share gather and tensor contracts](https://github.com/ROCm/hip-ep/pull/644)
16. [#727 — feat(shape): consume constant payload shapes directly](https://github.com/ROCm/hip-ep/pull/727)
17. [#728 — feat(shape): add exact Tile and Range destinations](https://github.com/ROCm/hip-ep/pull/728)
18. [#646 — refactor(hip): declare explicit DPS shape contracts](https://github.com/ROCm/hip-ep/pull/646)
19. [#730 — test(hip): audit explicit DPS contract inventory](https://github.com/ROCm/hip-ep/pull/730)
20. [#732 — test(hip): audit ONNX converter deduplication](https://github.com/ROCm/hip-ep/pull/732)
21. [#647 — fix(hip): harden shape refinement failure handling](https://github.com/ROCm/hip-ep/pull/647)
22. [#761 — refactor(hip): split shape utility headers by family](https://github.com/ROCm/hip-ep/pull/761)
23. [#764 — refactor(hip): clarify shape destination authority](https://github.com/ROCm/hip-ep/pull/764)

## AI assistance

AI tools assisted with the shape-contract refactoring and stack reconstruction. The contributor reviewed and validated the resulting code.

Made-with: Cursor

