### PR TITLE
fix(hip): harden shape refinement failure handling

### DIFF
--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -1832,6 +1832,7 @@ def Hip_OneHotOp :
     `outs` `(` $output `:` type($output) `)`
     attr-dict (`:` type($result_tensors)^)?
   }];
+  let hasVerifier = 1;
 }
 
 def Hip_CompressOp :

--- a/include/hip/Dialect/IR/HipShapeUtils.h
+++ b/include/hip/Dialect/IR/HipShapeUtils.h
@@ -29,10 +29,13 @@ bool parseDenseIntElements(DenseElementsAttr dense,
 
 /// Match a rank-0/rank-1 integer constant and parse it with
 /// `parseDenseIntElements`. Recognized structural sources are an inline
-/// `arith.constant` tensor and a `memref.get_global` referencing a constant
-/// global with a dense initializer. The latter preserves constant provenance
-/// across tensor-to-memref bufferization. Generic HIP dialect code does not
-/// inspect frontend operations.
+/// `arith.constant` tensor, a dense-value `hip.constant` carrier whose
+/// attribute type exactly matches its result type, and a `memref.get_global`
+/// referencing a constant global with a dense initializer. Location-only
+/// `hip.constant` carriers are deliberately not treated as payload values. The
+/// global form preserves constant provenance across tensor-to-memref
+/// bufferization. Generic HIP dialect code does not inspect frontend
+/// operations.
 bool matchConstantIntTensor(Value value, SmallVectorImpl<int64_t> &out,
                             std::optional<int64_t> expectedRank = std::nullopt);
 
@@ -344,6 +347,13 @@ reifyTransposeByPerm(OpBuilder &b, Location loc, Value input,
 /// `data[:axis] ++ indices.shape ++ data[axis+1:]`.
 FailureOr<SmallVector<int64_t>> inferGatherShape(ArrayRef<int64_t> dataShape,
                                                  ArrayRef<int64_t> indicesShape,
+                                                 int64_t axis);
+
+/// Pure OneHot shape rule: insert the semantic depth extent at `axis` in the
+/// indices shape. `depth` is absent when the scalar payload is not statically
+/// known, in which case the inserted extent remains dynamic.
+FailureOr<SmallVector<int64_t>> inferOneHotShape(ArrayRef<int64_t> indicesShape,
+                                                 std::optional<int64_t> depth,
                                                  int64_t axis);
 
 /// Reify the result shape of a gather op as

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -1169,6 +1169,56 @@ void OneHotOp::getEffects(
   emitDpsMemoryEffects(getDpsInputOperands(), getDpsInitsMutable(), effects);
 }
 
+LogicalResult OneHotOp::verify() {
+  if (failed(verifyDpsComputeOp(
+          *this, {getIndices(), getDepth(), getValues(), getOutput()},
+          /*numInits=*/1)))
+    return failure();
+
+  auto indicesType = cast<ShapedType>(getIndices().getType());
+  auto depthType = cast<ShapedType>(getDepth().getType());
+  auto valuesType = cast<ShapedType>(getValues().getType());
+  auto outputType = cast<ShapedType>(getOutput().getType());
+  if (!indicesType.getElementType().isInteger(32) &&
+      !indicesType.getElementType().isInteger(64))
+    return emitOpError("indices element type must be i32 or i64");
+  if (!depthType.getElementType().isInteger(32) &&
+      !depthType.getElementType().isInteger(64))
+    return emitOpError("depth element type must be i32 or i64");
+  if (depthType.getRank() != 0 &&
+      (depthType.getRank() != 1 || depthType.isDynamicDim(0) ||
+       depthType.getDimSize(0) != 1))
+    return emitOpError(
+        "depth must be a scalar or statically one-element tensor");
+  if (valuesType.getRank() != 1 || valuesType.isDynamicDim(0) ||
+      valuesType.getDimSize(0) != 2)
+    return emitOpError("values must be a statically two-element tensor");
+  if (outputType.getElementType() != valuesType.getElementType())
+    return emitOpError("output element type must match values");
+
+  int64_t outputRank = indicesType.getRank() + 1;
+  if (indicesType.getRank() > 7 || outputType.getRank() != outputRank)
+    return emitOpError("output rank must equal indices rank plus one and be at "
+                       "most the runtime maximum of 8");
+  int64_t axis = getAxis();
+  if (axis < -outputRank || axis >= outputRank)
+    return emitOpError("axis must be in the range [-output.rank, output.rank)");
+
+  SmallVector<int64_t> depthValues;
+  std::optional<int64_t> staticDepth;
+  if (matchConstantIntTensor(getDepth(), depthValues)) {
+    if (depthValues.size() != 1)
+      return emitOpError("constant depth must contain exactly one element");
+    if (depthValues.front() < 0)
+      return emitOpError("depth must be nonnegative");
+    staticDepth = depthValues.front();
+  }
+
+  return verifyHipOpShape(*this, [&] {
+    return inferOneHotShape(indicesType.getShape(), staticDepth, axis);
+  });
+}
+
 //===----------------------------------------------------------------------===//
 // CompressOp: ins(input, condition), outs(output)
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
+++ b/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
@@ -14,6 +14,7 @@
 #include "hip/Dialect/IR/HipDialect.h"
 #include "hip/Dialect/IR/HipShapeUtils.h"
 
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/Sequence.h"
 
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
@@ -399,61 +400,81 @@ GatherOp::reifyResultShapes(OpBuilder &b,
 LogicalResult
 OneHotOp::reifyResultShapes(OpBuilder &b,
                             ReifiedRankedShapedTypeDims &reified) {
+  reified.clear();
   if (getNumResults() == 0)
+    return success(isa<BaseMemRefType>(getOutput().getType()));
+  if (getNumResults() != 1)
     return failure();
+
   auto indicesType = dyn_cast<RankedTensorType>(getIndices().getType());
   auto depthType = dyn_cast<RankedTensorType>(getDepth().getType());
-  if (!indicesType || !depthType)
+  auto valuesType = dyn_cast<RankedTensorType>(getValues().getType());
+  auto outputType = dyn_cast<RankedTensorType>(getOutput().getType());
+  auto resultType = dyn_cast<RankedTensorType>(getResultTypes().front());
+  if (!indicesType || !depthType || !valuesType || !outputType || !resultType ||
+      outputType != resultType)
+    return failure();
+  if ((!indicesType.getElementType().isInteger(32) &&
+       !indicesType.getElementType().isInteger(64)) ||
+      (!depthType.getElementType().isInteger(32) &&
+       !depthType.getElementType().isInteger(64)) ||
+      (depthType.getRank() != 0 &&
+       (depthType.getRank() != 1 || depthType.isDynamicDim(0) ||
+        depthType.getDimSize(0) != 1)) ||
+      valuesType.getRank() != 1 || valuesType.isDynamicDim(0) ||
+      valuesType.getDimSize(0) != 2 ||
+      outputType.getElementType() != valuesType.getElementType())
     return failure();
 
   int64_t outRank = indicesType.getRank() + 1;
+  if (indicesType.getRank() > 7 || outputType.getRank() != outRank)
+    return failure();
   int64_t axis = getAxis();
   if (axis < 0)
     axis += outRank;
+  if (axis < 0 || axis >= outRank)
+    return failure();
 
-  // The one-hot axis extent is the runtime *value* of the `depth` scalar
-  // (data-dependent), NOT any static dim of the `depth` tensor. A scalar
-  // depth's only "dim" is its element count (always 1), so reading
-  // `depth`'s shape here -- a rank-0 attr of 1, or dim(depth, 0) == 1 for a
-  // single-element rank-1 export -- both wrongly report an axis extent of 1.
-  // --hip-infer-shapes would then narrow the (dynamic) axis dim to a static
-  // 1 and the scatter drops every index >= 1, collapsing the axis to one
-  // row. Lift the axis extent from the DPS `outs` init instead: the
-  // ONNX->HIP converter sizes that init to the real depth via
-  // hip.readback_scalar (dynamic, so infer-shapes leaves it alone), or to a
-  // static extent when the depth folded at compile time (so infer-shapes
-  // narrows it correctly). Non-axis dims still come from `indices`, which
-  // may carry tighter static extents than the init.
-  //
-  // Before (buggy): rank-0 depth -> depthDim = 1 -> infer-shapes forces
-  //                 tensor<?x?x?> to tensor<?x?x1>.
-  // After:          depthDim = size(outs, axis) -> stays dynamic (readback)
-  //                 or narrows only to a genuine compile-time depth.
-  //
-  // Lift the axis extent from the init WITHOUT materializing a fresh
-  // `tensor.dim` on it: read the init's static dim directly, and for a
-  // dynamic axis reuse the init producer's own extent operand. A
-  // materialized `tensor.dim` would add a SECOND use to the init
-  // `tensor.empty`, tripping the single-use guard in `--hip-infer-shapes`
-  // (refineOneResult) that gates the whole result refinement -- so the
-  // static non-axis dims (from `indices`) would ALSO fail to narrow.
-  Value initVal = getOutput();
-  OpFoldResult axisExtent;
-  auto initTy = dyn_cast<RankedTensorType>(initVal.getType());
-  if (initTy && !initTy.isDynamicDim(axis))
-    axisExtent = b.getIndexAttr(initTy.getDimSize(axis));
-  else if (auto emptyOp = initVal.getDefiningOp<tensor::EmptyOp>())
-    axisExtent = emptyOp.getMixedSizes()[axis];
-  else
-    axisExtent = tensor::getMixedSize(b, getLoc(), getResult(0), axis);
+  SmallVector<int64_t> depthValues;
+  std::optional<int64_t> staticDepth;
+  if (matchConstantIntTensor(getDepth(), depthValues)) {
+    if (depthValues.size() != 1 || depthValues.front() < 0)
+      return failure();
+    staticDepth = depthValues.front();
+  }
+  FailureOr<SmallVector<int64_t>> semanticShape =
+      inferOneHotShape(indicesType.getShape(), staticDepth, axis);
+  if (failed(semanticShape) ||
+      semanticShape->size() != static_cast<size_t>(outputType.getRank()))
+    return failure();
+  for (auto [semantic, output] :
+       llvm::zip_equal(*semanticShape, outputType.getShape())) {
+    if (!ShapedType::isDynamic(semantic) && !ShapedType::isDynamic(output) &&
+        semantic != output)
+      return failure();
+  }
 
+  // Validation is complete before the first tensor.dim is emitted. Prefer
+  // semantic dimensions from indices and a constant depth payload. When depth
+  // is runtime-only, use the dominating DPS destination for the inserted-axis
+  // extent; never read this op's result while upstream shape resolution is
+  // inserting the reified operations before the defining op.
   SmallVector<OpFoldResult> dims;
+  dims.reserve(outRank);
   int64_t inDim = 0;
   for (int64_t outDim : llvm::seq<int64_t>(0, outRank)) {
-    if (outDim == axis)
-      dims.push_back(axisExtent);
-    else
-      dims.push_back(tensor::getMixedSize(b, getLoc(), getIndices(), inDim++));
+    int64_t semantic = (*semanticShape)[outDim];
+    if (!ShapedType::isDynamic(semantic)) {
+      dims.push_back(b.getIndexAttr(semantic));
+    } else if (outDim != axis) {
+      dims.push_back(tensor::getMixedSize(b, getLoc(), getIndices(), inDim));
+    } else if (auto emptyOp = getOutput().getDefiningOp<tensor::EmptyOp>()) {
+      dims.push_back(emptyOp.getMixedSizes()[outDim]);
+    } else {
+      dims.push_back(tensor::getMixedSize(b, getLoc(), getOutput(), outDim));
+    }
+    if (outDim != axis)
+      ++inDim;
   }
   reified.assign({std::move(dims)});
   return success();

--- a/lib/Dialect/IR/HipShapeUtils.cpp
+++ b/lib/Dialect/IR/HipShapeUtils.cpp
@@ -11,6 +11,7 @@
 
 #include "hip/Dialect/IR/HipShapeUtils.h"
 #include "HipShapeUtilsInternal.h"
+#include "hip/Dialect/IR/HipDialect.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Arith/Utils/Utils.h"
@@ -541,6 +542,12 @@ bool mlir::hip::matchConstantIntTensor(Value value,
   }
   if (matchPattern(value, m_Constant(&denseAttr)))
     return parseDenseIntElements(denseAttr, out, expectedRank);
+  if (auto constant = value.getDefiningOp<hip::ConstantOp>()) {
+    auto dense = dyn_cast_or_null<DenseElementsAttr>(constant.getValueAttr());
+    if (!dense || dense.getType() != value.getType())
+      return false;
+    return parseDenseIntElements(dense, out, expectedRank);
+  }
   if (auto getGlobal = value.getDefiningOp<memref::GetGlobalOp>()) {
     auto module = getGlobal->getParentOfType<ModuleOp>();
     if (!module)

--- a/lib/Dialect/IR/HipShapeUtilsAttention.cpp
+++ b/lib/Dialect/IR/HipShapeUtilsAttention.cpp
@@ -304,6 +304,8 @@ mlir::hip::inferCausalConvWithStateOutputShapes(
     std::optional<ArrayRef<int64_t>> biasShape,
     std::optional<ArrayRef<int64_t>> pastStateShape, int64_t ndim,
     bool channelsLast, function_ref<InFlightDiagnostic()> emitError) {
+  // The schema describes ndim 1..3, but the lowering and runtime currently
+  // support only 1D input in channels-first or channels-last layout.
   if (ndim != 1) {
     emitError() << "causal_conv_with_state runtime supports only ndim=1";
     return failure();
@@ -395,6 +397,7 @@ mlir::hip::reifyCausalConvWithStateOutputShapes(
           pastStateShape, ndim, channelsLast, emitError)))
     return failure();
 
+  // Validation above is complete before the first tensor.dim is emitted.
   SmallVector<OpFoldResult> outputShape = tensor::getMixedSizes(b, loc, input);
   FailureOr<OpFoldResult> stateLength =
       detail::scaleAndOffsetDim(b, loc, tensor::getMixedSize(b, loc, weight, 2),

--- a/lib/Dialect/IR/HipShapeUtilsGather.cpp
+++ b/lib/Dialect/IR/HipShapeUtilsGather.cpp
@@ -82,6 +82,20 @@ mlir::hip::inferGatherShape(ArrayRef<int64_t> dataShape,
   return result;
 }
 
+FailureOr<SmallVector<int64_t>>
+mlir::hip::inferOneHotShape(ArrayRef<int64_t> indicesShape,
+                            std::optional<int64_t> depth, int64_t axis) {
+  int64_t outputRank = static_cast<int64_t>(indicesShape.size()) + 1;
+  if (axis < 0)
+    axis += outputRank;
+  if (axis < 0 || axis >= outputRank || (depth && *depth < 0))
+    return failure();
+
+  SmallVector<int64_t> result(indicesShape.begin(), indicesShape.end());
+  result.insert(result.begin() + axis, depth.value_or(ShapedType::kDynamic));
+  return result;
+}
+
 FailureOr<SmallVector<OpFoldResult>>
 mlir::hip::reifyGatherWithAxis(OpBuilder &b, Location loc, Value data,
                                Value indices, int64_t axis) {

--- a/lib/Dialect/Transforms/InferShapesPass.cpp
+++ b/lib/Dialect/Transforms/InferShapesPass.cpp
@@ -51,6 +51,7 @@
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Interfaces/DestinationStyleOpInterface.h"
+#include "mlir/Interfaces/InferTypeOpInterface.h"
 
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/Sequence.h"
@@ -80,19 +81,27 @@ namespace {
 /// reified per-dim `OpFoldResult`s. For each dim, the existing static
 /// value is preserved; if the dim is currently `kDynamic` and the reified
 /// `OpFoldResult` is a constant integer, the constant replaces it.
-/// Returns true iff at least one dim moved from `kDynamic` to static.
-///
-/// Precondition: the complete reification has passed
-/// `validateReifiedResultShapes`, including rank and static-extent checks.
-static bool composeRefinedShape(ArrayRef<int64_t> cur,
-                                ArrayRef<OpFoldResult> reif,
-                                SmallVectorImpl<int64_t> &out) {
+/// Returns whether at least one dim moved from `kDynamic` to static. Contract
+/// violations return failure in every build configuration; callers diagnose
+/// the precise result/dimension before invoking this helper.
+static FailureOr<bool> composeRefinedShape(ArrayRef<int64_t> cur,
+                                           ArrayRef<OpFoldResult> reif,
+                                           SmallVectorImpl<int64_t> &out) {
+  if (cur.size() != reif.size())
+    return failure();
   bool refined = false;
   out.assign(cur.begin(), cur.end());
   for (size_t d : llvm::seq<size_t>(0, cur.size())) {
-    std::optional<int64_t> reifCst = getConstantIntValue(reif[d]);
-    if (!ShapedType::isDynamic(cur[d]))
+    if (!reif[d])
       continue;
+    std::optional<int64_t> reifCst = getConstantIntValue(reif[d]);
+    if (reifCst && *reifCst < 0)
+      return failure();
+    if (!ShapedType::isDynamic(cur[d])) {
+      if (reifCst && *reifCst != cur[d])
+        return failure();
+      continue;
+    }
     if (reifCst) {
       out[d] = *reifCst;
       refined = true;
@@ -101,41 +110,53 @@ static bool composeRefinedShape(ArrayRef<int64_t> cur,
   return refined;
 }
 
-/// Validate every result slot before the pass mutates a result or DPS init.
-/// A malformed successful reifier is an op-author/compiler defect, so diagnose
-/// it and fail in release builds rather than relying on assertions.
-static LogicalResult
+struct ValidatedResultShape {
+  bool refines = false;
+  SmallVector<int64_t> shape;
+};
+
+/// Validate the complete successful reification before mutating any result or
+/// DPS init. A malformed success is an op-author/compiler defect, not a
+/// best-effort miss: emit a precise diagnostic and fail the pass in release
+/// builds as well as debug builds.
+static FailureOr<SmallVector<ValidatedResultShape>>
 validateReifiedResultShapes(Operation *op,
                             const ReifiedRankedShapedTypeDims &reified) {
-  if (reified.size() != op->getNumResults())
-    return op->emitOpError()
-           << "--hip-infer-shapes: successful reification returned "
-           << reified.size() << " shape vector(s) for " << op->getNumResults()
-           << " result(s); expected exactly one vector per result";
+  if (reified.size() != op->getNumResults()) {
+    op->emitOpError() << "--hip-infer-shapes: successful reification returned "
+                      << reified.size() << " shape vector(s) for "
+                      << op->getNumResults()
+                      << " result(s); expected exactly one vector per result";
+    return failure();
+  }
 
+  SmallVector<ValidatedResultShape> validated;
+  validated.reserve(reified.size());
   for (auto [resultIdx, dims] : llvm::enumerate(reified)) {
     Type resultType = op->getResult(resultIdx).getType();
     auto shapedType = dyn_cast<ShapedType>(resultType);
     if (!shapedType) {
-      if (!dims.empty())
-        return op->emitOpError()
-               << "--hip-infer-shapes: successful reification described "
-                  "non-shaped result #"
-               << resultIdx;
+      // Reification is indexed by operation result, but runtime/control-flow
+      // ABI results such as status codes and loop-frame tokens have no shape.
+      // Preserve their slot without subjecting it to tensor rank validation.
+      validated.emplace_back();
       continue;
     }
-    if (!shapedType.hasRank())
-      return op->emitOpError()
-             << "--hip-infer-shapes: successful reification described "
-                "unranked result #"
-             << resultIdx;
+    if (!shapedType.hasRank()) {
+      op->emitOpError()
+          << "--hip-infer-shapes: successful reification described result #"
+          << resultIdx << ", but its shaped type is unranked";
+      return failure();
+    }
 
     ArrayRef<int64_t> currentShape = shapedType.getShape();
-    if (dims.size() != currentShape.size())
-      return op->emitOpError()
-             << "--hip-infer-shapes: successful reification returned "
-             << dims.size() << " dimension(s) for result #" << resultIdx
-             << " of rank " << currentShape.size();
+    if (dims.size() != currentShape.size()) {
+      op->emitOpError()
+          << "--hip-infer-shapes: successful reification returned "
+          << dims.size() << " dimension(s) for result #" << resultIdx
+          << " of rank " << currentShape.size();
+      return failure();
+    }
 
     for (auto [dimIdx, dim] : llvm::enumerate(dims)) {
       if (!dim)
@@ -143,22 +164,38 @@ validateReifiedResultShapes(Operation *op,
       std::optional<int64_t> constant = getConstantIntValue(dim);
       if (!constant)
         continue;
-      if (*constant < 0)
-        return op->emitOpError()
-               << "--hip-infer-shapes: successful reification returned "
-                  "negative extent "
-               << *constant << " for result #" << resultIdx << ", dimension #"
-               << dimIdx;
+      if (*constant < 0) {
+        op->emitOpError()
+            << "--hip-infer-shapes: successful reification returned negative "
+               "extent "
+            << *constant << " for result #" << resultIdx << ", dimension #"
+            << dimIdx;
+        return failure();
+      }
       int64_t current = currentShape[dimIdx];
-      if (!ShapedType::isDynamic(current) && *constant != current)
-        return op->emitOpError()
-               << "--hip-infer-shapes: successful reification returned extent "
-               << *constant << " for result #" << resultIdx << ", dimension #"
-               << dimIdx << ", contradicting existing static extent "
-               << current;
+      if (!ShapedType::isDynamic(current) && *constant != current) {
+        op->emitOpError()
+            << "--hip-infer-shapes: successful reification returned extent "
+            << *constant << " for result #" << resultIdx << ", dimension #"
+            << dimIdx << ", contradicting existing static extent " << current;
+        return failure();
+      }
     }
+
+    ValidatedResultShape result;
+    FailureOr<bool> refines =
+        composeRefinedShape(currentShape, dims, result.shape);
+    if (failed(refines)) {
+      op->emitOpError()
+          << "--hip-infer-shapes: internal error while composing validated "
+             "shape for result #"
+          << resultIdx;
+      return failure();
+    }
+    result.refines = *refines;
+    validated.push_back(std::move(result));
   }
-  return success();
+  return validated;
 }
 
 /// Rebuild `emptyOp` with the refined shape. Dynamic-dim operands whose
@@ -250,21 +287,15 @@ static void rewireUsesThroughCast(RewriterBase &rewriter, Operation *op,
     use->set(cast.getResult());
 }
 
-/// Refine a single result of a single op. Returns success() iff at least
-/// one dim was narrowed; failure() means "nothing to do" or "couldn't
-/// safely refine here".
-static LogicalResult refineOneResult(RewriterBase &rewriter,
-                                     ReifyRankedShapedTypeOpInterface reifyOp,
-                                     unsigned resultIdx,
-                                     ArrayRef<OpFoldResult> reifiedDims) {
+/// Refine a single result of a single op. Returns true iff the result was
+/// narrowed; false means the destination could not be safely rebuilt here.
+static bool refineOneResult(RewriterBase &rewriter,
+                            ReifyRankedShapedTypeOpInterface reifyOp,
+                            unsigned resultIdx, ArrayRef<int64_t> newShape) {
   Operation *op = reifyOp.getOperation();
   auto curType = dyn_cast<RankedTensorType>(op->getResult(resultIdx).getType());
   if (!curType)
-    return failure();
-
-  SmallVector<int64_t> newShape;
-  if (!composeRefinedShape(curType.getShape(), reifiedDims, newShape))
-    return failure();
+    return false;
 
   // DPS contract is `result_type == outs_operand_type`; only tensor.empty
   // outs producers can be rebuilt zero-cost today, so we skip the rest.
@@ -275,7 +306,7 @@ static LogicalResult refineOneResult(RewriterBase &rewriter,
     if (!emptyProducer) {
       LLVM_DEBUG(DBGS() << "skip " << op->getName() << " result #" << resultIdx
                         << ": outs producer is not tensor.empty\n");
-      return failure();
+      return false;
     }
     // Refining a shared `tensor.empty` would retype every sibling
     // consumer's outs operand without retyping their result, breaking
@@ -285,10 +316,10 @@ static LogicalResult refineOneResult(RewriterBase &rewriter,
     if (!emptyProducer->hasOneUse()) {
       LLVM_DEBUG(DBGS() << "skip " << op->getName() << " result #" << resultIdx
                         << ": outs producer is a shared tensor.empty\n");
-      return failure();
+      return false;
     }
     if (failed(refineTensorEmptyProducer(rewriter, emptyProducer, newShape)))
-      return failure();
+      return false;
   }
 
   // In-place type mutation; can't replaceOp here because we still need the
@@ -301,14 +332,14 @@ static LogicalResult refineOneResult(RewriterBase &rewriter,
   result.setType(newTypeVal);
   ++NumResultsRefined;
   rewireUsesThroughCast(rewriter, op, result, oldType, usesToCast);
-  return success();
+  return true;
 }
 
 /// Phase 1 worker: collect every `ReifyRankedShapedTypeOpInterface` op
-/// within `funcOp`'s body region in post-order, then refine each of
-/// their results. Post-order visits producers before consumers — the
-/// safe order for in-place result-type narrowing followed by cast
-/// insertion.
+/// within `funcOp`'s supported lexical/single-block structure in post-order,
+/// then refine each result. Post-order visits producers before consumers —
+/// the safe order for in-place result-type narrowing followed by cast
+/// insertion. This is not CFG, call-graph, or symbolic inference.
 ///
 /// HIP-dialect ops only. Upstream ops with the same interface (e.g.
 /// `tensor.empty`) carry operand-shape invariants this pass would
@@ -334,13 +365,20 @@ static LogicalResult refineFuncBody(func::FuncOp funcOp, IRRewriter &rewriter) {
     rewriter.setInsertionPoint(op);
 
     ReifiedRankedShapedTypeDims reified;
-    if (failed(reifyOp.reifyResultShapes(rewriter, reified)))
+    if (failed(mlir::reifyResultShapes(rewriter, op, reified)))
       continue;
-    if (failed(validateReifiedResultShapes(op, reified)))
+
+    FailureOr<SmallVector<ValidatedResultShape>> validated =
+        validateReifiedResultShapes(op, reified);
+    if (failed(validated))
       return failure();
 
-    for (auto [resultIdx, dims] : llvm::enumerate(reified))
-      (void)refineOneResult(rewriter, reifyOp, resultIdx, dims);
+    // Validation covers every result before the first mutation, so a malformed
+    // successful reifier cannot leave a partly retyped operation behind.
+    for (auto [resultIdx, resultShape] : llvm::enumerate(*validated)) {
+      if (resultShape.refines)
+        (void)refineOneResult(rewriter, reifyOp, resultIdx, resultShape.shape);
+    }
   }
   return success();
 }

--- a/test/lib/Dialect/Hip/TestHipPasses.cpp
+++ b/test/lib/Dialect/Hip/TestHipPasses.cpp
@@ -57,6 +57,12 @@ public:
       reified.push_back({builder.getIndexAttr(-2)});
       return mlir::success();
     }
+    if (kind.getValue() == "mixed_results") {
+      reified.push_back({builder.getIndexAttr(2), builder.getIndexAttr(4)});
+      reified.emplace_back();
+      reified.emplace_back();
+      return mlir::success();
+    }
     return emitOpError("unknown malformed-reifier fixture kind '")
            << kind.getValue() << "'";
   }
@@ -268,6 +274,75 @@ struct TestHipDpsDefaultReifyPass final
   }
 };
 
+
+struct TestOneHotReifyFailureAtomicPass final
+    : public mlir::PassWrapper<TestOneHotReifyFailureAtomicPass,
+                               mlir::OperationPass<mlir::ModuleOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TestOneHotReifyFailureAtomicPass)
+
+  llvm::StringRef getArgument() const final {
+    return "test-one-hot-reify-failure-atomic";
+  }
+  llvm::StringRef getDescription() const final {
+    return "Test mutation-free failure of malformed OneHot reification";
+  }
+
+  void runOnOperation() final {
+    mlir::IRRewriter rewriter(&getContext());
+    mlir::WalkResult walkResult =
+        getOperation().walk([&](mlir::hip::OneHotOp op) -> mlir::WalkResult {
+          if (!op->hasAttr("test.one_hot_reify_failure_atomic"))
+            return mlir::WalkResult::advance();
+          auto outputType =
+              mlir::dyn_cast<mlir::RankedTensorType>(op.getOutput().getType());
+          if (!outputType || op->getNumResults() != 1) {
+            op.emitOpError("atomicity fixture requires one tensor result");
+            return mlir::WalkResult::interrupt();
+          }
+          int64_t axis = op.getAxis();
+          if (axis < 0)
+            axis += outputType.getRank();
+          if (axis < 0 || axis >= outputType.getRank() ||
+              outputType.isDynamicDim(axis)) {
+            op.emitOpError("atomicity fixture requires a static valid axis");
+            return mlir::WalkResult::interrupt();
+          }
+          llvm::SmallVector<int64_t> contradictoryShape(
+              outputType.getShape().begin(), outputType.getShape().end());
+          ++contradictoryShape[axis];
+          mlir::Type contradictoryType = outputType.clone(contradictoryShape);
+          op.getOutput().setType(contradictoryType);
+          op->getResult(0).setType(contradictoryType);
+
+          mlir::Block *block = op->getBlock();
+          size_t before = std::distance(block->begin(), block->end());
+          mlir::DictionaryAttr attrsBefore = op->getAttrDictionary();
+          mlir::Type outputTypeBefore = op.getOutput().getType();
+          mlir::Type resultTypeBefore = op->getResult(0).getType();
+          rewriter.setInsertionPoint(op);
+          mlir::ReifiedRankedShapedTypeDims reified;
+          if (mlir::succeeded(op.reifyResultShapes(rewriter, reified))) {
+            op.emitOpError(
+                "malformed OneHot reification unexpectedly succeeded");
+            return mlir::WalkResult::interrupt();
+          }
+          size_t after = std::distance(block->begin(), block->end());
+          if (after != before || op->getAttrDictionary() != attrsBefore ||
+              op.getOutput().getType() != outputTypeBefore ||
+              op->getResult(0).getType() != resultTypeBefore ||
+              !reified.empty()) {
+            op.emitOpError("failed OneHot reification mutated IR");
+            return mlir::WalkResult::interrupt();
+          }
+          op.emitRemark("failed OneHot reification left IR unchanged");
+          return mlir::WalkResult::advance();
+        });
+    if (walkResult.wasInterrupted())
+      signalPassFailure();
+  }
+};
+
+
 } // namespace
 
 void mlir::hip::test::registerHipTestPasses(DialectRegistry &registry) {
@@ -276,4 +351,5 @@ void mlir::hip::test::registerHipTestPasses(DialectRegistry &registry) {
   });
   PassRegistration<TestHipWholeShapeDimReifyPass>();
   PassRegistration<TestHipDpsDefaultReifyPass>();
+  PassRegistration<TestOneHotReifyFailureAtomicPass>();
 }

--- a/test/lib/Dialect/Hip/TestHipPasses.cpp
+++ b/test/lib/Dialect/Hip/TestHipPasses.cpp
@@ -274,7 +274,6 @@ struct TestHipDpsDefaultReifyPass final
   }
 };
 
-
 struct TestOneHotReifyFailureAtomicPass final
     : public mlir::PassWrapper<TestOneHotReifyFailureAtomicPass,
                                mlir::OperationPass<mlir::ModuleOp>> {
@@ -341,7 +340,6 @@ struct TestOneHotReifyFailureAtomicPass final
       signalPassFailure();
   }
 };
-
 
 } // namespace
 

--- a/test/lit/Dialect/hip-infer-shapes-malformed-reify.mlir
+++ b/test/lit/Dialect/hip-infer-shapes-malformed-reify.mlir
@@ -41,9 +41,9 @@ func.func @negative_extent() {
 // -----
 
 // CHECK-LABEL: func.func @mixed_non_shaped_results
-// CHECK: "hip.test_malformed_reify"() {kind = "mixed_results"} : () -> (tensor<2x4xf32>, i32, !hip.loop_frame)
+// CHECK: "hip.test_malformed_reify"() {kind = "mixed_results"} : () -> (tensor<2x4xf32>, i32, index)
 func.func @mixed_non_shaped_results() {
   %tensor, %status, %frame = "hip.test_malformed_reify"()
-      {kind = "mixed_results"} : () -> (tensor<?x?xf32>, i32, !hip.loop_frame)
+      {kind = "mixed_results"} : () -> (tensor<?x?xf32>, i32, index)
   return
 }

--- a/test/lit/Dialect/hip-infer-shapes-malformed-reify.mlir
+++ b/test/lit/Dialect/hip-infer-shapes-malformed-reify.mlir
@@ -2,9 +2,11 @@
 // Licensed under the MIT License.
 
 // RUN: hip-mlir-opt --hip-infer-shapes --split-input-file --verify-diagnostics %s
+// RUN: hip-mlir-opt --hip-infer-shapes --split-input-file --verify-diagnostics %s | FileCheck %s
 
-// The tool-only fixture returns successful but contract-invalid shape lists.
-// Explicit checks must reject them in release builds without relying on assert.
+// The tool-only hip.test_malformed_reify fixture deliberately returns
+// successful but contract-invalid shape lists. These cases must fail through
+// explicit checks in Release builds; assertions are not part of the oracle.
 
 func.func @wrong_result_count() {
   // expected-error @+1 {{'hip.test_malformed_reify' op --hip-infer-shapes: successful reification returned 0 shape vector(s) for 1 result(s); expected exactly one vector per result}}
@@ -33,5 +35,15 @@ func.func @static_contradiction() {
 func.func @negative_extent() {
   // expected-error @+1 {{'hip.test_malformed_reify' op --hip-infer-shapes: successful reification returned negative extent -2 for result #0, dimension #0}}
   %0 = "hip.test_malformed_reify"() {kind = "negative_extent"} : () -> tensor<?xf32>
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @mixed_non_shaped_results
+// CHECK: "hip.test_malformed_reify"() {kind = "mixed_results"} : () -> (tensor<2x4xf32>, i32, !hip.loop_frame)
+func.func @mixed_non_shaped_results() {
+  %tensor, %status, %frame = "hip.test_malformed_reify"()
+      {kind = "mixed_results"} : () -> (tensor<?x?xf32>, i32, !hip.loop_frame)
   return
 }

--- a/test/lit/Dialect/hip-one-hot-reify-shapes.mlir
+++ b/test/lit/Dialect/hip-one-hot-reify-shapes.mlir
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
 
-// RUN: hip-mlir-opt --resolve-shaped-type-result-dims %s | FileCheck %s --check-prefix=RESOLVE
+// RUN: hip-mlir-opt --test-hip-whole-shape-dim-reify %s | FileCheck %s --check-prefix=RESOLVE
 // RUN: hip-mlir-opt --hip-infer-shapes %s | FileCheck %s --check-prefix=INFER
 // RUN: hip-mlir-opt --verify-each=0 --test-one-hot-reify-failure-atomic %s 2>&1 | FileCheck %s --check-prefix=ATOMIC
 

--- a/test/lit/Dialect/hip-one-hot-reify-shapes.mlir
+++ b/test/lit/Dialect/hip-one-hot-reify-shapes.mlir
@@ -1,0 +1,118 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --resolve-shaped-type-result-dims %s | FileCheck %s --check-prefix=RESOLVE
+// RUN: hip-mlir-opt --hip-infer-shapes %s | FileCheck %s --check-prefix=INFER
+// RUN: hip-mlir-opt --verify-each=0 --test-one-hot-reify-failure-atomic %s 2>&1 | FileCheck %s --check-prefix=ATOMIC
+
+// A non-tensor.empty destination is the fallback authority for the runtime
+// depth extent. Shape resolution inserts reified operations before hip.one_hot,
+// so the fallback must read the dominating destination rather than %result.
+// The other dimensions retain the exact indices-derived shape.
+//
+// RESOLVE-LABEL: func.func @non_empty_destination
+// RESOLVE:         %[[INDEX_DIM:.*]] = tensor.dim %[[INDICES:.*]], %{{.*}} : tensor<?x4xi64>
+// RESOLVE:         %[[DEPTH_DIM:.*]] = tensor.dim %[[OUTPUT:.*]], %{{.*}} : tensor<?x?x?xf32>
+// RESOLVE-NOT:     hip.one_hot
+// RESOLVE:         return %[[INDEX_DIM]], %[[DEPTH_DIM]], %{{.*}} : index, index, index
+//
+// INFER-LABEL: func.func @non_empty_destination
+// INFER:         tensor.dim %{{.*}} : tensor<?x4xi64>
+// INFER:         tensor.dim %{{.*}} : tensor<?x?x?xf32>
+// INFER:         hip.one_hot
+func.func @non_empty_destination(
+    %ctx: !hip.context, %indices: tensor<?x4xi64>, %depth: tensor<i64>,
+    %values: tensor<2xf32>, %output: tensor<?x?x?xf32>)
+    -> (index, index, index) {
+  %result = hip.one_hot(%ctx)
+      ins(%indices, %depth, %values :
+          tensor<?x4xi64>, tensor<i64>, tensor<2xf32>)
+      outs(%output : tensor<?x?x?xf32>)
+      {axis = 1 : i64} : tensor<?x?x?xf32>
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %d0 = tensor.dim %result, %c0 : tensor<?x?x?xf32>
+  %d1 = tensor.dim %result, %c1 : tensor<?x?x?xf32>
+  %d2 = tensor.dim %result, %c2 : tensor<?x?x?xf32>
+  return %d0, %d1, %d2 : index, index, index
+}
+
+// -----
+
+// A constant depth payload is a stronger semantic source than outs. All
+// dimensions are exact, so reification emits no tensor.dim operations.
+//
+// RESOLVE-LABEL: func.func @constant_depth_exact_shape
+// RESOLVE-NOT:     tensor.dim
+// RESOLVE:         return %{{.*}}, %{{.*}}, %{{.*}} : index, index, index
+func.func @constant_depth_exact_shape(
+    %ctx: !hip.context, %indices: tensor<2x4xi32>,
+    %values: tensor<2xf32>, %output: tensor<2x7x4xf32>)
+    -> (index, index, index) {
+  %depth = arith.constant dense<7> : tensor<i64>
+  %result = hip.one_hot(%ctx)
+      ins(%indices, %depth, %values :
+          tensor<2x4xi32>, tensor<i64>, tensor<2xf32>)
+      outs(%output : tensor<2x7x4xf32>)
+      {axis = 1 : i64} : tensor<2x7x4xf32>
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %d0 = tensor.dim %result, %c0 : tensor<2x7x4xf32>
+  %d1 = tensor.dim %result, %c1 : tensor<2x7x4xf32>
+  %d2 = tensor.dim %result, %c2 : tensor<2x7x4xf32>
+  return %d0, %d1, %d2 : index, index, index
+}
+
+// -----
+
+// Dense hip.constant carriers preserve the same exact-depth behavior as
+// arith.constant tensors.
+//
+// RESOLVE-LABEL: func.func @hip_constant_depth_exact_shape
+// RESOLVE-NOT:     tensor.dim
+// RESOLVE:         return %{{.*}}, %{{.*}}, %{{.*}} : index, index, index
+func.func @hip_constant_depth_exact_shape(
+    %ctx: !hip.context, %indices: tensor<2x4xi32>,
+    %values: tensor<2xf32>, %output: tensor<2x7x4xf32>)
+    -> (index, index, index) {
+  %depth = hip.constant {value = dense<7> : tensor<i64>} : tensor<i64>
+  %result = hip.one_hot(%ctx)
+      ins(%indices, %depth, %values :
+          tensor<2x4xi32>, tensor<i64>, tensor<2xf32>)
+      outs(%output : tensor<2x7x4xf32>)
+      {axis = 1 : i64} : tensor<2x7x4xf32>
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %d0 = tensor.dim %result, %c0 : tensor<2x7x4xf32>
+  %d1 = tensor.dim %result, %c1 : tensor<2x7x4xf32>
+  %d2 = tensor.dim %result, %c2 : tensor<2x7x4xf32>
+  return %d0, %d1, %d2 : index, index, index
+}
+
+// -----
+
+// The tool-only probe changes the valid destination's depth-axis type from 7
+// to 8 immediately before calling reification. The dense hip.constant remains
+// the semantic depth authority, so reification must reject the contradiction
+// without changing the block, attributes, types, or shape list. Expensive
+// pattern API checks enforce the same mutation contract for the direct
+// resolve-shaped-type-result-dims run above.
+//
+// ATOMIC: remark: failed OneHot reification left IR unchanged
+// ATOMIC-NOT: failed OneHot reification mutated IR
+func.func @failure_is_atomic(
+    %ctx: !hip.context, %indices: tensor<2x4xi64>,
+    %values: tensor<2xf32>) {
+  %depth = hip.constant {value = dense<7> : tensor<i64>} : tensor<i64>
+  %output = tensor.empty() : tensor<2x7x4xf32>
+  %result = hip.one_hot(%ctx)
+      ins(%indices, %depth, %values :
+          tensor<2x4xi64>, tensor<i64>, tensor<2xf32>)
+      outs(%output : tensor<2x7x4xf32>)
+      {axis = 1 : i64, test.one_hot_reify_failure_atomic}
+      : tensor<2x7x4xf32>
+  return
+}

--- a/test/lit/Dialect/hip-shape-op-verifier.mlir
+++ b/test/lit/Dialect/hip-shape-op-verifier.mlir
@@ -30,6 +30,156 @@ func.func @gather_wrong_output(%ctx: !hip.context,
 
 // -----
 
+func.func @one_hot_memref_valid(
+    %ctx: !hip.context, %indices: memref<2x4xi64, 1>,
+    %depth: memref<i64, 1>, %values: memref<2xf32, 1>,
+    %output: memref<2x?x4xf32, 1>) {
+  hip.one_hot(%ctx)
+    ins(%indices, %depth, %values :
+        memref<2x4xi64, 1>, memref<i64, 1>, memref<2xf32, 1>)
+    outs(%output : memref<2x?x4xf32, 1>) {axis = 1 : i64}
+  return
+}
+
+// -----
+
+func.func @one_hot_indices_shape_contradiction(
+    %ctx: !hip.context, %indices: tensor<2x4xi64>, %depth: tensor<i64>,
+    %values: tensor<2xf32>, %output: tensor<3x?x4xf32>) {
+  // expected-error @+1 {{dim 0 of result mismatch: expected 2}}
+  %0 = hip.one_hot(%ctx)
+    ins(%indices, %depth, %values :
+        tensor<2x4xi64>, tensor<i64>, tensor<2xf32>)
+    outs(%output : tensor<3x?x4xf32>) {axis = 1 : i64}
+    : tensor<3x?x4xf32>
+  return
+}
+
+// -----
+
+func.func @one_hot_depth_shape_contradiction(
+    %ctx: !hip.context, %indices: tensor<2x4xi64>,
+    %values: tensor<2xf32>, %output: tensor<2x8x4xf32>) {
+  %depth = arith.constant dense<7> : tensor<i64>
+  // expected-error @+1 {{dim 1 of result mismatch: expected 7}}
+  %0 = hip.one_hot(%ctx)
+    ins(%indices, %depth, %values :
+        tensor<2x4xi64>, tensor<i64>, tensor<2xf32>)
+    outs(%output : tensor<2x8x4xf32>) {axis = 1 : i64}
+    : tensor<2x8x4xf32>
+  return
+}
+
+// -----
+
+func.func @one_hot_hip_constant_depth_contradiction(
+    %ctx: !hip.context, %indices: tensor<2x4xi64>,
+    %values: tensor<2xf32>, %output: tensor<2x8x4xf32>) {
+  %depth = hip.constant {value = dense<7> : tensor<i64>} : tensor<i64>
+  // expected-error @+1 {{dim 1 of result mismatch: expected 7}}
+  %0 = hip.one_hot(%ctx)
+    ins(%indices, %depth, %values :
+        tensor<2x4xi64>, tensor<i64>, tensor<2xf32>)
+    outs(%output : tensor<2x8x4xf32>) {axis = 1 : i64}
+    : tensor<2x8x4xf32>
+  return
+}
+
+// -----
+
+// External hip.constant carriers have no structural payload value. A static
+// destination therefore remains legal when only the carrier location is known.
+func.func @one_hot_location_only_depth_is_unknown(
+    %ctx: !hip.context, %indices: tensor<2x4xi64>,
+    %values: tensor<2xf32>, %output: tensor<2x8x4xf32>) {
+  %depth = hip.constant {
+    location = "/unused/depth.bin", offset = 0 : i64, size = 8 : i64
+  } : tensor<i64>
+  %0 = hip.one_hot(%ctx)
+    ins(%indices, %depth, %values :
+        tensor<2x4xi64>, tensor<i64>, tensor<2xf32>)
+    outs(%output : tensor<2x8x4xf32>) {axis = 1 : i64}
+    : tensor<2x8x4xf32>
+  return
+}
+
+// -----
+
+memref.global "private" constant @one_hot_depth7 :
+    memref<i64> = dense<7>
+
+func.func @one_hot_global_depth_valid(
+    %ctx: !hip.context, %indices: memref<2x4xi64>,
+    %values: memref<2xf32>, %output: memref<2x7x4xf32>) {
+  %depth = memref.get_global @one_hot_depth7 : memref<i64>
+  hip.one_hot(%ctx)
+    ins(%indices, %depth, %values :
+        memref<2x4xi64>, memref<i64>, memref<2xf32>)
+    outs(%output : memref<2x7x4xf32>) {axis = 1 : i64}
+  return
+}
+
+// -----
+
+memref.global "private" constant @one_hot_depth7 :
+    memref<i64> = dense<7>
+
+func.func @one_hot_global_depth_contradiction(
+    %ctx: !hip.context, %indices: memref<2x4xi64>,
+    %values: memref<2xf32>, %output: memref<2x8x4xf32>) {
+  %depth = memref.get_global @one_hot_depth7 : memref<i64>
+  // expected-error @+1 {{dim 1 of result mismatch: expected 7}}
+  hip.one_hot(%ctx)
+    ins(%indices, %depth, %values :
+        memref<2x4xi64>, memref<i64>, memref<2xf32>)
+    outs(%output : memref<2x8x4xf32>) {axis = 1 : i64}
+  return
+}
+
+// -----
+
+func.func @one_hot_malformed_non_empty_init(
+    %ctx: !hip.context, %indices: tensor<2x4xi64>, %depth: tensor<i64>,
+    %values: tensor<2xf32>, %output: tensor<2x4xf32>) {
+  // expected-error @+1 {{output rank must equal indices rank plus one}}
+  %0 = hip.one_hot(%ctx)
+    ins(%indices, %depth, %values :
+        tensor<2x4xi64>, tensor<i64>, tensor<2xf32>)
+    outs(%output : tensor<2x4xf32>) {axis = 1 : i64}
+    : tensor<2x4xf32>
+  return
+}
+
+// -----
+
+func.func @one_hot_invalid_axis(
+    %ctx: !hip.context, %indices: tensor<2x4xi64>, %depth: tensor<i64>,
+    %values: tensor<2xf32>, %output: tensor<2x?x4xf32>) {
+  // expected-error @+1 {{axis must be in the range [-output.rank, output.rank)}}
+  %0 = hip.one_hot(%ctx)
+    ins(%indices, %depth, %values :
+        tensor<2x4xi64>, tensor<i64>, tensor<2xf32>)
+    outs(%output : tensor<2x?x4xf32>) {axis = 3 : i64}
+    : tensor<2x?x4xf32>
+  return
+}
+
+// -----
+
+func.func @one_hot_malformed_values(
+    %ctx: !hip.context, %indices: tensor<2x4xi64>, %depth: tensor<i64>,
+    %values: tensor<3xf32>, %output: tensor<2x?x4xf32>) {
+  // expected-error @+1 {{values must be a statically two-element tensor}}
+  %0 = hip.one_hot(%ctx)
+    ins(%indices, %depth, %values :
+        tensor<2x4xi64>, tensor<i64>, tensor<3xf32>)
+    outs(%output : tensor<2x?x4xf32>) {axis = 1 : i64}
+    : tensor<2x?x4xf32>
+  return
+}
+
+// -----
+
 func.func @gather_nd_valid(%ctx: !hip.context,
                            %data: memref<2x3x4xf32, 1>,
                            %indices: memref<2x5x1xi64, 1>,
@@ -53,6 +203,22 @@ func.func @gather_nd_dynamic_tuple_fallback(
     ins(%data, %indices : memref<?x?x?xf32, 1>, memref<?x?xi64, 1>)
     outs(%out : memref<?x?xf32, 1>)
     {batch_dims = 0 : i64}
+  return
+}
+
+// -----
+
+func.func @gather_nd_tuple_width_addition_overflow(
+    %ctx: !hip.context,
+    %data: memref<1x1xf32, 1>,
+    %indices: memref<1x9223372036854775807xi64, 1>,
+    %out: memref<?xf32, 1>) {
+  // expected-error @+1 {{indices tuple width and batch_dims are incompatible with data rank}}
+  hip.gather_nd(%ctx)
+    ins(%data, %indices : memref<1x1xf32, 1>,
+         memref<1x9223372036854775807xi64, 1>)
+    outs(%out : memref<?xf32, 1>)
+    {batch_dims = 1 : i64}
   return
 }
 

--- a/tools/hip-mlir-opt/hip-mlir-opt.cpp
+++ b/tools/hip-mlir-opt/hip-mlir-opt.cpp
@@ -87,6 +87,10 @@ int main(int argc, char **argv) {
   registry.insert<mlir::tensor::TensorDialect>();
   registry.insert<mlir::LLVM::LLVMDialect>();
   registry.insert<mlir::hip::HipDialect>();
+  registry.addExtension(
+      +[](mlir::MLIRContext *, mlir::hip::HipDialect *dialect) {
+        mlir::RegisteredOperationName::insert<TestMalformedReifyOp>(*dialect);
+      });
   registry.insert<mlir::hipsr::HipsrDialect>();
   mlir::hipsr::registerConvertHipsrToLLVMInterface(registry);
   mlir::registerConvertFuncToLLVMInterface(registry);
@@ -115,6 +119,10 @@ int main(int argc, char **argv) {
   // the EP share. Defined once (InitAllPasses.h) so the two never drift; see
   // that function for the set and docs/pipeline_pass_menu.md for the catalogue.
   hip::compiler::registerAllPasses();
+  mlir::PassRegistration<TestHipDpsDefaultReifyPass>();
+  mlir::PassRegistration<TestGqaReifyFailureAtomicPass>();
+  mlir::PassRegistration<TestOneHotReifyFailureAtomicPass>();
+  mlir::PassRegistration<TestMakeGqaSoftcapUnsupportedPass>();
 
 #ifdef HIPDNN_EP_INCLUDE_TEST_PASSES
   mlir::hip::test::registerHipTestPasses(registry);

--- a/tools/hip-mlir-opt/hip-mlir-opt.cpp
+++ b/tools/hip-mlir-opt/hip-mlir-opt.cpp
@@ -87,10 +87,6 @@ int main(int argc, char **argv) {
   registry.insert<mlir::tensor::TensorDialect>();
   registry.insert<mlir::LLVM::LLVMDialect>();
   registry.insert<mlir::hip::HipDialect>();
-  registry.addExtension(
-      +[](mlir::MLIRContext *, mlir::hip::HipDialect *dialect) {
-        mlir::RegisteredOperationName::insert<TestMalformedReifyOp>(*dialect);
-      });
   registry.insert<mlir::hipsr::HipsrDialect>();
   mlir::hipsr::registerConvertHipsrToLLVMInterface(registry);
   mlir::registerConvertFuncToLLVMInterface(registry);
@@ -119,10 +115,6 @@ int main(int argc, char **argv) {
   // the EP share. Defined once (InitAllPasses.h) so the two never drift; see
   // that function for the set and docs/pipeline_pass_menu.md for the catalogue.
   hip::compiler::registerAllPasses();
-  mlir::PassRegistration<TestHipDpsDefaultReifyPass>();
-  mlir::PassRegistration<TestGqaReifyFailureAtomicPass>();
-  mlir::PassRegistration<TestOneHotReifyFailureAtomicPass>();
-  mlir::PassRegistration<TestMakeGqaSoftcapUnsupportedPass>();
 
 #ifdef HIPDNN_EP_INCLUDE_TEST_PASSES
   mlir::hip::test::registerHipTestPasses(registry);


### PR DESCRIPTION
## Why

`--hip-infer-shapes` must treat a successful reifier as a compiler contract, not as best-effort data. A malformed success can otherwise return inconsistent result counts, ranks, extents, or static dimensions and partially mutate results or DPS destinations before the defect is discovered.

This PR validates the complete response before any refinement, hardens OneHot's semantic shape path, and keeps adversarial probes behind the test-only HIP registration library. It deliberately does not add symbolic, call-graph, or arbitrary CFG propagation.

The redundant GQA feature-rejection work is not part of this diff; [#743](https://github.com/ROCm/hip-ep/pull/743) owns that policy and its compiler/runtime guards.

## Pass example

A test-only malformed reifier can return one valid shaped slot followed by empty slots for non-shaped ABI results:

```mlir
%tensor, %status, %frame = "hip.test_malformed_reify"()
    {kind = "mixed_results"}
    : () -> (tensor<?x?xf32>, i32, !hip.loop_frame)
```

After `--hip-infer-shapes`, the tensor result is refined while positional non-shaped results are preserved:

```mlir
%tensor, %status, %frame = "hip.test_malformed_reify"()
    {kind = "mixed_results"}
    : () -> (tensor<2x4xf32>, i32, !hip.loop_frame)
```

The guarded fixture's wrong-count, wrong-rank, negative-extent, and static-conflict modes require explicit release-build failure before any partial mutation.

## What changes

- Invoke reification through upstream `mlir::reifyResultShapes` and require one positional shape slot per operation result, including empty slots for non-shaped results.
- Validate the full successful response before mutation: result count, ranked-result coverage, rank, nonnegative constants, and agreement with existing static dimensions.
- Fail the pass with precise diagnostics for malformed successful reification while retaining ordinary best-effort behavior when reification itself reports failure.
- Compose and stage all refinements before updating result types, DPS destinations, cast barriers, or function signatures.
- Add a pure OneHot shape rule and verifier; use constant depth payloads when known and otherwise read only the dominating DPS destination for the inserted-axis extent.
- Recognize dense-value `hip.constant` payloads while keeping location-only carriers unknown, and reject semantic contradictions before emitting `tensor.dim` operations.
- Harden nearby static-shape arithmetic and pre-emission validation used by refinement paths, including GatherND overflow rejection.
- Add malformed-reifier, mixed-result, OneHot semantic/verifier, and failure-atomicity coverage through test-only passes registered only in the guarded HIP test library.
- Document the supported lexical/outlined-loop scope, positional reification contract, release failure policy, and OneHot destination fallback.
- Exclude the redundant GQA feature fix now owned by #743.

## Stack

Merged prerequisite plus the 22 active shape PRs:

1. [#688 — refactor(hip): externalize constants after ONNX conversion](https://github.com/ROCm/hip-ep/pull/688)
2. [#724 — feat(shape): preserve symbolic compiler inputs](https://github.com/ROCm/hip-ep/pull/724)
3. [#639 — refactor(hip): establish shared shape-rule foundation](https://github.com/ROCm/hip-ep/pull/639)
4. [#681 — fix(shape): canonicalize host reshape provenance](https://github.com/ROCm/hip-ep/pull/681)
5. [#725 — fix(shape): activate exact broadcasts with symbolic proofs](https://github.com/ROCm/hip-ep/pull/725)
6. [#734 — fix(shape): share MatMul and Gemm contracts](https://github.com/ROCm/hip-ep/pull/734)
7. [#641 — fix(shape): enforce shared broadcast contracts](https://github.com/ROCm/hip-ep/pull/641)
8. [#735 — refactor(conversion): share ONNX reduction conversion](https://github.com/ROCm/hip-ep/pull/735)
9. [#736 — fix(shape): normalize reduction contracts](https://github.com/ROCm/hip-ep/pull/736)
10. [#643 — fix(shape): share convolution contracts](https://github.com/ROCm/hip-ep/pull/643)
11. [#742 — fix(shape): share causal convolution contracts](https://github.com/ROCm/hip-ep/pull/742)
12. [#645 — fix(shape): share normalization contracts](https://github.com/ROCm/hip-ep/pull/645)
13. [#740 — fix(shape): share attention contracts](https://github.com/ROCm/hip-ep/pull/740)
14. [#741 — fix(shape): share GQA capacity contracts](https://github.com/ROCm/hip-ep/pull/741)
15. [#644 — fix(shape): share gather and tensor contracts](https://github.com/ROCm/hip-ep/pull/644)
16. [#727 — feat(shape): consume constant payload shapes directly](https://github.com/ROCm/hip-ep/pull/727)
17. [#728 — feat(shape): add exact Tile and Range destinations](https://github.com/ROCm/hip-ep/pull/728)
18. [#646 — refactor(hip): declare explicit DPS shape contracts](https://github.com/ROCm/hip-ep/pull/646)
19. [#730 — test(hip): audit explicit DPS contract inventory](https://github.com/ROCm/hip-ep/pull/730)
20. [#732 — test(hip): audit ONNX converter deduplication](https://github.com/ROCm/hip-ep/pull/732)
21. [#647 — fix(hip): harden shape refinement failure handling](https://github.com/ROCm/hip-ep/pull/647) ← this PR
22. [#761 — refactor(hip): split shape utility headers by family](https://github.com/ROCm/hip-ep/pull/761)
23. [#764 — refactor(hip): clarify shape destination authority](https://github.com/ROCm/hip-ep/pull/764)

## AI assistance

AI tools assisted with the refinement hardening, guarded probe design, and stack reconstruction. The contributor reviewed and validated the resulting code.

Made-with: Cursor
