### PR TITLE
fix(promote-strided): select consumers by DPS interface

### DIFF
--- a/docs/design/pool-allocs-memory-planning.md
+++ b/docs/design/pool-allocs-memory-planning.md
@@ -60,7 +60,7 @@ The default domain ID is zero and is omitted from textual IR. Additional domains
 
 ### Correctness and ABI preparation
 
-`hip-promote-strided-operands` materializes contiguous temporaries for HIP runtime calls whose ABI carries a bare pointer but no offset/stride metadata. It must run before pooling so those temporaries become pool views.
+`hip-promote-strided-operands` materializes identity-layout temporaries for non-identity-layout DPS-input memrefs. Selecting by interface covers HIP and plugin runtime consumers without coupling the pass to a dialect or operation-name prefix. The pass must run before pooling so its temporaries become pool views.
 
 `hip-use-output-allocator` must run before pooling so returned buffers are rewritten to runtime-owned `hip.alloc_output` operations rather than absorbed into the transient pool. The production pipeline intentionally omits ownership-based buffer deallocation because every transient is pooled and outputs are runtime-owned. See [output-allocator-design.md](output-allocator-design.md).
 

--- a/docs/pipeline_pass_menu.md
+++ b/docs/pipeline_pass_menu.md
@@ -123,7 +123,7 @@ Options use MLIR's pipeline-option syntax:
 | `hip-use-output-allocator` | func.func | Rewrite returned `memref.alloc` → `hip.alloc_output` (graph outputs become EP/runtime-owned, not pooled or deallocated). |
 | `hip-fix-loop-accumulator-offset` | func.func | Rewrite frozen Concat-accumulator offsets in loop bodies to iter-driven offsets. |
 | `hip-optimize-memrefs` | func.func | HIP-specific buffer reuse / subview folding. |
-| `hip-promote-strided-operands` | func.func | Materialize contiguous temporaries for strided memref operands of `hip.*` ops. |
+| `hip-promote-strided-operands` | func.func | Materialize identity-layout temporaries for non-identity-layout DPS-input memrefs. |
 | `hip-materialize-host-scalars` | func.func | Redirect tiny host-fed scalar allocs to runtime-owned host-mapped scratch (away from the GPU pool). |
 | `hip-resolve-memref-dims` | func.func | Fold post-bufferization `memref.dim` through view/reshape chains before pool planning. |
 | `hip-hoist-alloc-size-arith` | func.func | Hoist speculatable size arithmetic above the earliest dynamic alloc (PoolAllocs precondition). |

--- a/include/hip/Dialect/Transforms/Passes.td
+++ b/include/hip/Dialect/Transforms/Passes.td
@@ -193,12 +193,11 @@ def OptimizeMemRefsPass : Pass<"hip-optimize-memrefs", "mlir::func::FuncOp"> {
 
 def PromoteStridedHipOperandsPass
     : Pass<"hip-promote-strided-operands", "mlir::func::FuncOp"> {
-  let summary = "Materialize contiguous temporaries for non-canonical memref "
-                "operands of hip.* ops";
+  let summary = "Materialize identity-layout temporaries for DPS-input memrefs "
+                "with non-identity layouts";
   let description = [{
-    Walks every DestinationStyleOpInterface op in the `hip` dialect.  For
-    each input (DPS-input) operand whose memref type has a non-identity
-    layout (non-zero offset or non-contiguous strides), inserts:
+    Walks every DestinationStyleOpInterface op. For each DPS-input memref with
+    a non-identity layout (a non-zero offset or non-contiguous strides), inserts:
 
     ```mlir
     %tmp = memref.alloc() : memref<...identity-layout...>
@@ -207,15 +206,18 @@ def PromoteStridedHipOperandsPass
     memref.dealloc %tmp : memref<...identity-layout...>
     ```
 
-    DPS-init (output) operands are left untouched: in this pipeline they are
-    always either fresh `memref.alloc` results or function arguments under
-    `IdentityLayoutMap`, so they are guaranteed contiguous by construction.
+    DPS-init operands are intentionally left untouched because promoting a
+    write target requires copy-back and must preserve read-before-write
+    semantics. The production pipeline normally supplies identity-layout inits
+    through fresh allocations, `hip.alloc_output`, or `IdentityLayoutMap` at
+    function boundaries.
 
     The pass exists to bridge the contract gap between the IR (which can
-    represent strided memrefs faithfully via memref.subview) and the HIP
-    runtime call ABI (which receives a single bare pointer with no offset /
-    strides channel).  Without this promotion, hip.* runtime calls silently
-    read the base of the parent buffer instead of the intended slice.
+    represent non-identity layouts faithfully) and runtime ABIs that receive a
+    bare pointer with no offset or strides. Matching the DPS interface rather
+    than a dialect or operation name covers plugin ops without dialect
+    coupling. In the ONNX-to-HIP pipeline, this pass runs after linalg cleanup;
+    the remaining DPS operations are HIP or plugin operations.
 
     Recommended pipeline position:
       hip-optimize-memrefs -> hip-promote-strided-operands -> hip-pool-allocs
@@ -544,7 +546,7 @@ def ResolveMemRefDimsPass
     function argument).
 
     The strided views that pin these queries are created during bufferization
-    and by `--hip-promote-strided-hip-operands`, i.e. after resolve-tensor-dims
+    and by `--hip-promote-strided-operands`, i.e. after resolve-tensor-dims
     ran, so the patterns had nothing to fold then. Re-rooting the size to a
     block-top arg dim lets `--hip-hoist-alloc-size-arith` lift it, so
     `--hip-pool-allocs` shares one pool across many allocs instead of splitting

--- a/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
+++ b/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
@@ -209,11 +209,11 @@ enum class TensorOp : int64_t {
 // (e.g., the result of memref.subview) silently produces a pointer to the
 // base of the parent buffer, not the slice.
 //
-// The --hip-promote-strided-operands pass enforces this precondition for
-// hip.* DPS-input operands by materializing contiguous temporaries upstream.
-// Direct callers (outside the standard hip.* lowering path) must guarantee
-// it themselves; if you need the descriptor's offset / strides, use
-// extractMemRefDescriptor below.
+// The --hip-promote-strided-operands pass establishes this precondition for
+// DPS-input memrefs. It does not rewrite DPS inits, whose layouts must satisfy
+// the precondition independently. Other callers must also establish the
+// precondition; use extractMemRefDescriptor below when the ABI carries offset
+// or stride metadata.
 //
 // Uses alignedPtr (not allocatedPtr) so that memref.view offsets into a memory
 // pool are respected -- each view has the same allocatedPtr but a distinct

--- a/lib/Conversion/HipToLLVM/MemoryLowering.cpp
+++ b/lib/Conversion/HipToLLVM/MemoryLowering.cpp
@@ -192,7 +192,7 @@ struct GetPoolOpLowering : public ConvertOpToLLVMPattern<GetPoolOp> {
 // The runtime returns hipHostMalloc(hipHostMallocMapped) memory, which is
 // accessible from both host and device. The result memref uses the default
 // address space (AS 0) — so host stores from materialized scalars work, and
-// downstream GPU ops that consume it via hip-promote-strided-hip-operands /
+// downstream GPU ops that consume it via hip-promote-strided-operands /
 // memref.view see the same pointer.
 struct GetHostScratchOpLowering
     : public ConvertOpToLLVMPattern<GetHostScratchOp> {

--- a/lib/Dialect/Transforms/Pipelines.cpp
+++ b/lib/Dialect/Transforms/Pipelines.cpp
@@ -245,14 +245,12 @@ static void buildOnnxToHipPipelineTail(OpPassManager &pm) {
   //     before pooling (6a and 6b).
   //   - Shape preconditions used only to improve pool quality (grouped in 6c).
 
-  // 6a. Correctness/ABI: promote strided memref operands of hip.* ops to
-  //     contiguous temporaries. The HIP runtime ABI (--convert-hip-to-llvm)
-  //     forwards only a bare aligned pointer per memref, with no offset or
-  //     stride metadata; otherwise, a hip.* op fed a `memref.subview` would
-  //     read the parent buffer's base instead of the slice. Runs after
-  //     OptimizeMemRefs to avoid competing subview rewrites and before pooling
-  //     so the new temporaries become pool views rather than per-inference
-  //     allocations.
+  // 6a. Correctness/ABI: materialize identity-layout temporaries for
+  //     non-identity-layout DPS-input memrefs. The interface-based selection
+  //     covers plugin ops whose bare-pointer runtime ABI carries no descriptor
+  //     offset or strides. Runs after linalg cleanup and OptimizeMemRefs, and
+  //     before pooling so the temporaries become pool views rather than
+  //     per-inference allocations.
   pm.addNestedPass<func::FuncOp>(
       mlir::hip::createPromoteStridedHipOperandsPass());
 

--- a/lib/Dialect/Transforms/PromoteStridedHipOperands.cpp
+++ b/lib/Dialect/Transforms/PromoteStridedHipOperands.cpp
@@ -2,36 +2,32 @@
  * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Licensed under the MIT License.
  */
-//===- PromoteStridedHipOperands.cpp - Strided -> contiguous copy ---------===//
+//===- PromoteStridedHipOperands.cpp - Normalize DPS input layouts --------===//
 //
-// Materializes a contiguous temporary buffer for any DPS-input memref operand
-// of a hip.* op that has a non-identity layout (non-zero offset or
-// non-contiguous strides).
+// Materializes an identity-layout temporary for each DPS-input memref operand
+// with a non-identity layout (a non-zero offset or non-contiguous strides).
 //
 // Why this pass exists
 // --------------------
-// The HIP runtime call ABI used by --convert-hip-to-llvm receives a single
-// bare pointer per memref operand (see extractContiguousMemRefPtr in
-// HipToLLVMUtils.h).  There is no parameter on the wrapper signatures for
-// per-dimension strides or for a base offset.  When a hip op consumes a
-// strided memref (e.g., the result of memref.subview from onnx.Split), the
-// wrapper would otherwise read the parent buffer from its base, ignoring the
-// slice — silently producing wrong results.
+// HIP and plugin runtime wrappers commonly receive one bare pointer per memref
+// operand (see extractContiguousMemRefPtr in HipToLLVMUtils.h), with no channel
+// for the descriptor offset or strides. Passing a non-identity-layout memref
+// directly to such a wrapper would address the parent buffer rather than the
+// intended logical view.
 //
 // Rather than grow every wrapper signature and every backing library call
 // site to accept (offset, strides[]), we promote upstream: insert a fresh
-// contiguous alloc, copy the strided source into it, and rewrite the
-// consumer's operand.  This mirrors upstream linalg::promoteSubViews and
-// preserves a clean "hip.* ops always see contiguous memrefs" invariant.
+// identity-layout allocation, copy the source into it, and rewrite the
+// consumer's operand. This mirrors upstream linalg::promoteSubViews and
+// establishes that DPS-input memrefs have identity layout after this pass.
 //
 // DPS-init (output) operands
 // --------------------------
-// Outs are left untouched.  In this pipeline they always come from either:
-//   (a) memref.alloc() introduced by --one-shot-bufferize (identity layout),
-//       or
-//   (b) function arguments forced to identity layout by IdentityLayoutMap at
-//       function boundaries.
-// Either way they are guaranteed contiguous by construction.
+// Inits are intentionally left untouched: promoting a write target requires
+// copy-back and must preserve any read-before-write semantics. The production
+// pipeline normally supplies identity-layout inits through fresh allocations,
+// hip.alloc_output, or IdentityLayoutMap at function boundaries. Lowerings
+// that extract a bare pointer rely on that independent output-side invariant.
 //
 // Pipeline placement
 // ------------------
@@ -42,7 +38,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "hip/Dialect/IR/HipDialect.h"
 #include "hip/Dialect/Transforms/Passes.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -56,7 +51,7 @@
 #define DEBUG_TYPE "hip-promote-strided-operands"
 
 STATISTIC(NumOperandsPromoted,
-          "Number of strided hip.* DPS-input operands promoted to contiguous");
+          "Number of non-identity-layout DPS inputs promoted");
 
 namespace mlir {
 namespace hip {
@@ -67,61 +62,61 @@ namespace hip {
 namespace {
 
 /// Returns true iff \p type's layout is non-identity, i.e., the memref has
-/// either a non-zero offset or non-contiguous strides.  Identity-layout
+/// either a non-zero offset or non-contiguous strides. Identity-layout
 /// memrefs (no layout attribute, or a strided<> attribute that happens to be
-/// canonical) are reported as contiguous.
+/// canonical) are reported as false.
 static bool isNonIdentityMemRef(MemRefType type) {
   return !type.getLayout().isIdentity();
 }
 
 /// Builds a memref type with the same shape, element type, and memory space
-/// as \p src but with identity layout.
-static MemRefType makeContiguousType(MemRefType src) {
-  return MemRefType::get(src.getShape(), src.getElementType(),
+/// as \p sourceType but with identity layout.
+static MemRefType makeIdentityLayoutType(MemRefType sourceType) {
+  return MemRefType::get(sourceType.getShape(), sourceType.getElementType(),
                          /*layout=*/MemRefLayoutAttrInterface{},
-                         src.getMemorySpace());
+                         sourceType.getMemorySpace());
 }
 
-/// Collects SSA values for each dynamic dimension of \p src (in dim order).
+/// Collects SSA values for each dynamic dimension of \p source (in dim order).
 /// Emits memref.dim ops at the current insertion point of \p builder.
 static SmallVector<Value> collectDynamicSizes(OpBuilder &builder, Location loc,
-                                              Value src, MemRefType type) {
+                                              Value source, MemRefType type) {
   SmallVector<Value> sizes;
   for (int64_t i : llvm::seq<int64_t>(type.getRank())) {
     if (type.isDynamicDim(i))
-      sizes.push_back(memref::DimOp::create(builder, loc, src, i));
+      sizes.push_back(memref::DimOp::create(builder, loc, source, i));
   }
   return sizes;
 }
 
-/// Materializes a contiguous temporary for \p strided just before \p consumer
-/// and rewrites \p use to point at it.  Returns the new contiguous buffer so
-/// the caller can place a paired dealloc.
+/// Materializes an identity-layout copy of \p input immediately before
+/// \p consumer and rewrites the operand to use it. Returns the temporary so the
+/// caller can place a paired deallocation.
 ///
 /// Resulting IR (alloc + copy only):
 ///   %tmp = memref.alloc(%dyn0, %dyn1, ...) : memref<...identity...>
-///   memref.copy %strided, %tmp
+///   memref.copy %source, %tmp
 ///   <consumer rewritten to read %tmp>
-static Value materializeContiguousCopy(OpOperand &use, Operation *consumer) {
-  Value strided = use.get();
-  auto stridedType = cast<MemRefType>(strided.getType());
-  MemRefType contiguousType = makeContiguousType(stridedType);
+static Value materializeIdentityLayoutCopy(OpOperand &input,
+                                           Operation *consumer) {
+  Value source = input.get();
+  auto sourceType = cast<MemRefType>(source.getType());
+  MemRefType identityType = makeIdentityLayoutType(sourceType);
 
   OpBuilder builder(consumer);
   Location loc = consumer->getLoc();
 
   SmallVector<Value> dynSizes =
-      collectDynamicSizes(builder, loc, strided, stridedType);
+      collectDynamicSizes(builder, loc, source, sourceType);
 
-  auto allocOp =
-      memref::AllocOp::create(builder, loc, contiguousType, dynSizes);
-  memref::CopyOp::create(builder, loc, strided, allocOp.getResult());
+  auto allocOp = memref::AllocOp::create(builder, loc, identityType, dynSizes);
+  memref::CopyOp::create(builder, loc, source, allocOp.getResult());
 
-  use.set(allocOp.getResult());
+  input.set(allocOp.getResult());
 
   ++NumOperandsPromoted;
-  LLVM_DEBUG(llvm::dbgs() << "  promoted " << stridedType << " -> "
-                          << contiguousType << " before " << consumer->getName()
+  LLVM_DEBUG(llvm::dbgs() << "  promoted " << sourceType << " -> "
+                          << identityType << " before " << consumer->getName()
                           << "\n");
 
   return allocOp.getResult();
@@ -146,21 +141,17 @@ void PromoteStridedHipOperandsPass::runOnOperation() {
   // Collect candidate consumers first so that rewriting (which inserts new
   // ops) does not invalidate the walk.
   SmallVector<DestinationStyleOpInterface> consumers;
-  funcOp.walk([&](DestinationStyleOpInterface dpsOp) {
-    Operation *op = dpsOp.getOperation();
-    if (op->getDialect() != op->getContext()->getLoadedDialect<HipDialect>())
-      return;
-    consumers.push_back(dpsOp);
-  });
+  funcOp.walk(
+      [&](DestinationStyleOpInterface dpsOp) { consumers.push_back(dpsOp); });
 
   for (DestinationStyleOpInterface dpsOp : consumers) {
     Operation *consumer = dpsOp.getOperation();
-    SmallVector<Value> tmps;
+    SmallVector<Value> temporaries;
     for (OpOperand *input : dpsOp.getDpsInputOperands()) {
       auto type = dyn_cast<MemRefType>(input->get().getType());
       if (!type || !isNonIdentityMemRef(type))
         continue;
-      tmps.push_back(materializeContiguousCopy(*input, consumer));
+      temporaries.push_back(materializeIdentityLayoutCopy(*input, consumer));
     }
 
     // Emit deallocs in the same order as the allocations (TA, TB, ...).
@@ -170,9 +161,10 @@ void PromoteStridedHipOperandsPass::runOnOperation() {
     // IR easier to read in tests / dumps.
     Operation *anchor = consumer;
     OpBuilder builder(consumer);
-    for (Value tmp : tmps) {
+    for (Value temporary : temporaries) {
       builder.setInsertionPointAfter(anchor);
-      anchor = memref::DeallocOp::create(builder, consumer->getLoc(), tmp);
+      anchor =
+          memref::DeallocOp::create(builder, consumer->getLoc(), temporary);
     }
   }
 }

--- a/lib/Dialect/Transforms/ResolveMemRefDims.cpp
+++ b/lib/Dialect/Transforms/ResolveMemRefDims.cpp
@@ -9,7 +9,7 @@
 // ultimately `memref.dim` of a function argument.  Post-bufferize twin of
 // `--hip-resolve-tensor-dims`: it re-applies the reify-based `memref` dim folds
 // once the memref views exist (they are created during bufferization and by
-// `--hip-promote-strided-hip-operands`, i.e. after resolve-tensor-dims ran).
+// `--hip-promote-strided-operands`, i.e. after resolve-tensor-dims ran).
 //
 // Why: `--hip-pool-allocs` opens a new pool "domain" for every alloc whose
 // size SSA is defined below the earliest pooled alloc.  `memref.dim` of a
@@ -26,7 +26,7 @@
 //   %d = memref.dim %arg, %c0        // size at block top, hoistable
 //   %a = memref.alloc(%d)            // --hip-pool-allocs merges the domain
 //
-// Placement: after --hip-promote-strided-hip-operands /
+// Placement: after --hip-promote-strided-operands /
 // --hip-materialize-host-scalars, before --hip-hoist-alloc-size-arith /
 // --hip-pool-allocs.  Idempotent.
 //

--- a/test/lit/Dialect/hip-promote-strided-operands.mlir
+++ b/test/lit/Dialect/hip-promote-strided-operands.mlir
@@ -4,17 +4,16 @@
 //===----------------------------------------------------------------------===//
 // FileCheck tests for --hip-promote-strided-operands.
 //
-// The pass inserts memref.alloc + memref.copy + memref.dealloc for any
-// DPS-input memref operand of a hip.* op whose layout is non-identity
-// (non-zero offset or non-contiguous strides).  DPS-init (output) operands
-// and already-contiguous inputs are left untouched.
+// The pass inserts memref.alloc + memref.copy + memref.dealloc for each
+// non-identity-layout DPS-input memref, regardless of the operation's dialect.
+// DPS-init operands and identity-layout inputs are left untouched.
 //===----------------------------------------------------------------------===//
 
 // RUN: hip-mlir-opt --hip-promote-strided-operands %s | FileCheck %s
 
 // ----------------------------------------------------------------------------
-// Positive: strided subview feeding hip.sigmoid is promoted to a contiguous
-// alloc, copied in, consumed, then deallocated after the consumer.
+// Positive: a non-identity-layout subview feeding hip.sigmoid is copied into
+// an identity-layout allocation, consumed, then deallocated.
 //
 // Models the bug pattern from onnx.Split -> onnx.Sigmoid: bufferization
 // produces memref.subview with offset/stride layout, which would otherwise
@@ -44,8 +43,7 @@ func.func @sigmoid_promotes_strided_input(
 }
 
 // ----------------------------------------------------------------------------
-// Negative: a hip.sigmoid with an already-contiguous (identity-layout) input
-// is not rewritten.
+// Negative: a hip.sigmoid with an identity-layout input is not rewritten.
 // ----------------------------------------------------------------------------
 // CHECK-LABEL: func.func @sigmoid_contiguous_input_untouched
 // CHECK-SAME:    (%[[CTX:.*]]: !hip.context,
@@ -66,8 +64,8 @@ func.func @sigmoid_contiguous_input_untouched(
 }
 
 // ----------------------------------------------------------------------------
-// Multiple strided inputs: a hip.add with two subview operands gets two
-// independent promotions (separate allocs, copies, and deallocs).
+// Multiple non-identity-layout inputs: a hip.add with two subview operands gets
+// two independent promotions (separate allocs, copies, and deallocs).
 // ----------------------------------------------------------------------------
 // CHECK-LABEL: func.func @add_promotes_both_inputs
 // CHECK:         %[[SVA:.*]] = memref.subview
@@ -98,11 +96,9 @@ func.func @add_promotes_both_inputs(
 }
 
 // ----------------------------------------------------------------------------
-// DPS-init (output) operand is left untouched even when its type carries an
-// explicit strided layout.  Outs are guaranteed contiguous by construction in
-// this pipeline; promoting them would also change observable behavior because
-// the consumer writes through the operand (the strided slice is the intended
-// destination, not a temporary to copy back).
+// DPS-init operands are outside this pass's scope. Even when presented with a
+// non-identity layout, the init is not rewritten: safe output promotion would
+// require copy-back and preservation of any read-before-write semantics.
 // ----------------------------------------------------------------------------
 // CHECK-LABEL: func.func @strided_output_left_alone
 // CHECK:         %[[SV:.*]] = memref.subview
@@ -155,8 +151,9 @@ func.func @func_arg_strided_promoted(
 //
 // Models the pattern from hip-optimize-memrefs buffer-reuse: a single backing
 // allocation can be re-bound at multiple offsets for non-overlapping live
-// ranges.  When the resulting reinterpret_cast carries a non-zero offset, our
-// pass must materialize a contiguous temporary just like the subview case.
+// ranges. When the resulting reinterpret_cast carries a non-zero offset, the
+// pass must materialize an identity-layout temporary just like the subview
+// case.
 // ----------------------------------------------------------------------------
 // CHECK-LABEL: func.func @reinterpret_cast_with_offset_promoted
 // CHECK:         %[[RC:.*]] = memref.reinterpret_cast
@@ -209,11 +206,11 @@ func.func @dynamic_shape_promoted(
 }
 
 // ----------------------------------------------------------------------------
-// Memory-space preservation: the promoted alloc must inherit the memory
-// space of the strided source, not silently fall back to the default space.
+// Memory-space preservation: the promoted allocation must inherit the source
+// memory space rather than silently falling back to the default.
 //
-// makeContiguousType(src) preserves src.getMemorySpace() — this test pins the
-// behavior so a future refactor of that helper can't drop memory spaces.
+// makeIdentityLayoutType preserves sourceType.getMemorySpace(); this test pins
+// that behavior across future refactors.
 // ----------------------------------------------------------------------------
 // CHECK-LABEL: func.func @memory_space_preserved
 // CHECK:         memref.alloc() : memref<1x128x1024xf16, 1>
@@ -260,5 +257,84 @@ func.func @mixed_strided_and_contiguous_inputs(
     ins(%sv, %b : memref<1x128x1024xf16, strided<[262144, 2048, 1], offset: 1024>>,
                   memref<1x128x1024xf16>)
     outs(%out : memref<1x128x1024xf16>)
+  return
+}
+
+// ----------------------------------------------------------------------------
+// MatMul lowering extracts bare pointers, so both DPS-input matrices must have
+// identity layout. This case exercises non-contiguous strides for A and
+// canonical strides with a non-zero offset for B. The identity-layout DPS init
+// remains unchanged.
+// ----------------------------------------------------------------------------
+// CHECK-LABEL: func.func @matmul_promotes_strided_inputs
+// CHECK-SAME:    (%[[CTX:.*]]: !hip.context,
+// CHECK-SAME:     %[[A_PARENT:.*]]: memref<2x8xf16>,
+// CHECK-SAME:     %[[B_PARENT:.*]]: memref<8x3xf16>,
+// CHECK-SAME:     %[[OUT:.*]]: memref<2x3xf16>)
+// CHECK:         %[[A_SV:.*]] = memref.subview %[[A_PARENT]]
+// CHECK:         %[[B_SV:.*]] = memref.subview %[[B_PARENT]]
+// CHECK:         %[[A_TMP:.*]] = memref.alloc() : memref<2x4xf16>
+// CHECK:         memref.copy %[[A_SV]], %[[A_TMP]]
+// CHECK:         %[[B_TMP:.*]] = memref.alloc() : memref<4x3xf16>
+// CHECK:         memref.copy %[[B_SV]], %[[B_TMP]]
+// CHECK:         hip.matmul(%[[CTX]])
+// CHECK-SAME:      ins(%[[A_TMP]], %[[B_TMP]] : memref<2x4xf16>, memref<4x3xf16>)
+// CHECK-SAME:      outs(%[[OUT]] : memref<2x3xf16>)
+// CHECK:         memref.dealloc %[[A_TMP]]
+// CHECK:         memref.dealloc %[[B_TMP]]
+// CHECK:         return
+func.func @matmul_promotes_strided_inputs(
+    %ctx: !hip.context,
+    %a_parent: memref<2x8xf16>,
+    %b_parent: memref<8x3xf16>,
+    %out: memref<2x3xf16>) {
+  %a = memref.subview %a_parent[0, 4][2, 4][1, 1]
+      : memref<2x8xf16>
+        to memref<2x4xf16, strided<[8, 1], offset: 4>>
+  %b = memref.subview %b_parent[4, 0][4, 3][1, 1]
+      : memref<8x3xf16>
+        to memref<4x3xf16, strided<[3, 1], offset: 12>>
+  hip.matmul(%ctx)
+    ins(%a, %b : memref<2x4xf16, strided<[8, 1], offset: 4>>,
+                 memref<4x3xf16, strided<[3, 1], offset: 12>>)
+    outs(%out : memref<2x3xf16>)
+  return
+}
+
+// ----------------------------------------------------------------------------
+// Interface selection: linalg.generic is the lightest non-HIP DPS operation
+// available in this test. The production pipeline lowers linalg before this
+// pass, but the isolated pass deliberately selects by
+// DestinationStyleOpInterface rather than by dialect or operation name.
+// ----------------------------------------------------------------------------
+// CHECK-LABEL: func.func @non_hip_dps_input_promoted
+// CHECK-SAME:    (%[[SRC:.*]]: memref<2x4xf32>,
+// CHECK-SAME:     %[[OUT:.*]]: memref<2x2xf32>)
+// CHECK:         %[[SV:.*]] = memref.subview %[[SRC]]
+// CHECK:         %[[TMP:.*]] = memref.alloc() : memref<2x2xf32>
+// CHECK:         memref.copy %[[SV]], %[[TMP]]
+// CHECK:         linalg.generic
+// CHECK-SAME:      ins(%[[TMP]] : memref<2x2xf32>)
+// CHECK-SAME:      outs(%[[OUT]] : memref<2x2xf32>)
+// CHECK:         memref.dealloc %[[TMP]]
+// CHECK:         return
+func.func @non_hip_dps_input_promoted(
+    %src: memref<2x4xf32>,
+    %out: memref<2x2xf32>) {
+  %sv = memref.subview %src[0, 2][2, 2][1, 1]
+      : memref<2x4xf32>
+        to memref<2x2xf32, strided<[4, 1], offset: 2>>
+  linalg.generic {
+      indexing_maps = [
+        affine_map<(d0, d1) -> (d0, d1)>,
+        affine_map<(d0, d1) -> (d0, d1)>
+      ],
+      iterator_types = ["parallel", "parallel"]
+    }
+    ins(%sv : memref<2x2xf32, strided<[4, 1], offset: 2>>)
+    outs(%out : memref<2x2xf32>) {
+  ^bb0(%in: f32, %unused: f32):
+    linalg.yield %in : f32
+  }
   return
 }


### PR DESCRIPTION
## Issue

`hip-promote-strided-operands` only handled operations owned by `HipDialect`. Plugin operations can also use destination-passing style and the same bare-pointer runtime ABI, but the pass skipped them. A plugin operation receiving a subview could therefore read the parent buffer instead of the intended slice because the ABI does not carry the memref offset or strides.

## Fix

Select consumers through `DestinationStyleOpInterface` instead of their dialect. For every non-identity-layout DPS input, the pass creates an identity-layout temporary, copies the logical view into it, and passes that temporary to the consumer. DPS init operands remain unchanged.

```mlir
// Before
%view = memref.subview %source[...] [...] [...]
  : memref<...> to memref<..., strided<...>>
plugin.compute ins(%view : memref<..., strided<...>>)

// After
%tmp = memref.alloc() : memref<...>
memref.copy %view, %tmp
plugin.compute ins(%tmp : memref<...>)
memref.dealloc %tmp
```

Made with [Cursor](https://cursor.com)