### PR TITLE
fix(gqa): size present KV init to past + current seq length

### DIFF
--- a/lib/Conversion/OnnxToHip/GqaConversion.cpp
+++ b/lib/Conversion/OnnxToHip/GqaConversion.cpp
@@ -184,11 +184,58 @@ mlir::LogicalResult GroupQueryAttentionToHip::matchAndRewrite(
   // === Create DPS init tensors ===
 
   mlir::Value outputInit = createEmptyTensor(rewriter, loc, outputType, query);
-  mlir::Value presentKeyInit = createEmptyTensor(
-      rewriter, loc, presentKeyType, pastKey ? pastKey : (key ? key : query));
-  mlir::Value presentValueInit =
-      createEmptyTensor(rewriter, loc, presentValueType,
-                        pastValue ? pastValue : (value ? value : query));
+
+  // present KV is concat(past, current) along the seq axis, so its seq extent
+  // is past_seq + current_seq. Taking it from the past operand alone collapses
+  // present to zero length on a fresh prefill (past_seq == 0); the output
+  // allocator then hands the runtime a null present_key/present_value and
+  // wrap_group_query_attention rejects the call, leaving attention zero-filled.
+  // Same reasoning as OnnxAttentionConversion.cpp.
+  // Only rank-3 BSH query (seq at dim 1) and rank-4 BNSH present (seq at dim 2)
+  // are modelled here; for any other layout keep the positional behaviour
+  // rather than guessing which axis carries the sequence.
+  const bool canSizeFromTotal = queryType.getRank() == 3;
+
+  mlir::Value totalKvIdx;
+  auto getTotalKvIdx = [&]() -> mlir::Value {
+    if (totalKvIdx)
+      return totalKvIdx;
+    totalKvIdx = mlir::tensor::DimOp::create(rewriter, loc, query, 1);
+    if (pastKey) {
+      mlir::Value pastIdx =
+          mlir::tensor::DimOp::create(rewriter, loc, pastKey, 2);
+      totalKvIdx =
+          mlir::arith::AddIOp::create(rewriter, loc, pastIdx, totalKvIdx);
+    }
+    return totalKvIdx;
+  };
+
+  auto buildPresentInit = [&](mlir::RankedTensorType t,
+                              mlir::Value fallback) -> mlir::Value {
+    if (!canSizeFromTotal || t.getRank() != 4)
+      return createEmptyTensor(rewriter, loc, t, fallback);
+    llvm::SmallVector<mlir::Value> dynSizes;
+    for (int64_t dimIdx : llvm::seq<int64_t>(t.getRank())) {
+      if (!t.isDynamicDim(dimIdx))
+        continue;
+      if (dimIdx == 2)
+        dynSizes.push_back(getTotalKvIdx());
+      else if (dimIdx == 0)
+        dynSizes.push_back(
+            mlir::tensor::DimOp::create(rewriter, loc, query, 0).getResult());
+      else
+        dynSizes.push_back(
+            mlir::tensor::DimOp::create(rewriter, loc, fallback, dimIdx)
+                .getResult());
+    }
+    return mlir::tensor::EmptyOp::create(rewriter, loc, t.getShape(),
+                                         t.getElementType(), dynSizes);
+  };
+
+  mlir::Value presentKeyInit =
+      buildPresentInit(presentKeyType, pastKey ? pastKey : (key ? key : query));
+  mlir::Value presentValueInit = buildPresentInit(
+      presentValueType, pastValue ? pastValue : (value ? value : query));
 
   mlir::Value outputQkInit = nullptr;
   if (outputQkType)

--- a/test/lit/Conversion/onnx-to-hip/test_gqa_dynamic_present.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_gqa_dynamic_present.mlir
@@ -1,0 +1,86 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Lock in the present_key/present_value DPS init sizing when the present seq
+// dim is DYNAMIC.
+//
+// present KV is concat(past, current) along the seq axis, so the present seq
+// extent is past_seq + current_seq. Sizing it from the past operand alone
+// collapses present to a zero-length buffer on a fresh prefill (past_seq == 0);
+// the output allocator then hands the runtime a null present_key/present_value
+// and wrap_group_query_attention rejects the call, leaving attention output
+// zero-filled (observed as gibberish text on gpt-oss-20b).
+//
+// The other GQA lit tests all use fully static present shapes, where the init
+// is a plain tensor.empty() with no dynamic operands and the sizing source is
+// therefore unobservable. This test uses dynamic batch/seq so the computed
+// extents appear in the IR.
+//
+// Companion: OnnxAttentionConversion.cpp applies the same %tot = %past + %cur
+// rule for onnx.Attention.
+// ============================================================================
+
+// RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
+
+module {
+  // ===========================================================================
+  // Dynamic batch + dynamic seq, separate K/V, dynamic past KV.
+  // Function must be named @main_graph for --hip-add-context-arg to fire.
+  // ===========================================================================
+  func.func @main_graph(
+      %query: tensor<?x?x4096xf16>,
+      %key: tensor<?x?x1024xf16>,
+      %value: tensor<?x?x1024xf16>,
+      %past_key: tensor<?x8x?x128xf16>,
+      %past_value: tensor<?x8x?x128xf16>,
+      %seqlens_k: tensor<?x1xi32>,
+      %total_seq_len: tensor<i32>)
+      -> (tensor<?x?x4096xf16>, tensor<?x8x?x128xf16>, tensor<?x8x?x128xf16>) {
+
+    // CHECK-LABEL: func.func @main_graph
+    // CHECK-SAME: %[[CTX:[a-zA-Z0-9_]+]]: !hip.context,
+    // CHECK-SAME: %[[Q:[a-zA-Z0-9_]+]]: tensor<?x?x4096xf16>,
+    // CHECK-SAME: %[[PK:[a-zA-Z0-9_]+]]: tensor<?x8x?x128xf16>,
+
+    %none1 = "onnx.NoValue"() {value} : () -> none
+    %none2 = "onnx.NoValue"() {value} : () -> none
+
+    %out:3 = "onnx.Custom"(%query, %key, %value, %past_key, %past_value,
+                            %seqlens_k, %total_seq_len, %none1, %none2)
+        <{function_name = "GroupQueryAttention"}>
+        {domain_name = "com.microsoft",
+         num_heads = 32 : si64,
+         kv_num_heads = 8 : si64,
+         scale = 0.0883883461 : f32,
+         softcap = 0.000000e+00 : f32,
+         do_rotary = 0 : si64,
+         rotary_interleaved = 0 : si64}
+        : (tensor<?x?x4096xf16>, tensor<?x?x1024xf16>, tensor<?x?x1024xf16>,
+           tensor<?x8x?x128xf16>, tensor<?x8x?x128xf16>,
+           tensor<?x1xi32>, tensor<i32>, none, none)
+        -> (tensor<?x?x4096xf16>, tensor<?x8x?x128xf16>, tensor<?x8x?x128xf16>)
+
+    // The output init comes first; anchor on it so the dims below are the
+    // present-init ones.
+    // CHECK: tensor.empty(%{{.*}}, %{{.*}}) : tensor<?x?x4096xf16>
+
+    // present seq extent must be past + current, NOT past alone.
+    // current KV tokens == query seq length (rank-3 BSH, dim 1);
+    // valid past length == dim(past_key, 2) (rank-4 BNSH).
+    // CHECK: %[[B:.*]] = tensor.dim %[[Q]], %{{.*}} : tensor<?x?x4096xf16>
+    // CHECK: %[[CUR:.*]] = tensor.dim %[[Q]], %{{.*}} : tensor<?x?x4096xf16>
+    // CHECK: %[[PAST:.*]] = tensor.dim %[[PK]], %{{.*}} : tensor<?x8x?x128xf16>
+    // CHECK: %[[TOT:.*]] = arith.addi %[[PAST]], %[[CUR]] : index
+    // CHECK: tensor.empty(%[[B]], %[[TOT]]) : tensor<?x8x?x128xf16>
+    // CHECK: %[[B2:.*]] = tensor.dim %[[Q]], %{{.*}} : tensor<?x?x4096xf16>
+    // CHECK: tensor.empty(%[[B2]], %[[TOT]]) : tensor<?x8x?x128xf16>
+    // CHECK: hip.gqa(%[[CTX]])
+    // CHECK-SAME: kv_num_heads = 8
+    // CHECK-SAME: num_heads = 32
+    // CHECK-NOT: onnx.Custom
+
+    return %out#0, %out#1, %out#2 : tensor<?x?x4096xf16>, tensor<?x8x?x128xf16>, tensor<?x8x?x128xf16>
+  }
+}


### PR DESCRIPTION
## Summary

`GroupQueryAttentionToHip` sized the `present_key` / `present_value` DPS init tensors from the **past** operand alone. Present KV is `concat(past, current)` along the seq axis, so its seq extent is `past_seq + current_seq`. On a fresh prefill `past_seq == 0`, so the init collapsed to a **zero-length buffer**; the output allocator then hands the runtime a null `present_key`/`present_value`, `wrap_group_query_attention` rejects the call, and the attention output is left zero-filled.

On gpt-oss-20b this skips *every* GQA call in the graph (24 layers), and the model emits gibberish.

This ports the `%tot = %past + %cur` rule that `OnnxAttentionConversion.cpp` already applies to `onnx.Attention`.

## Root cause / when it was introduced

- Introduced in db7c51fc, "Port LLaMA operations from PR-17: rope, matmul, gqa, gather" (#34, 2026-03-15) — the very first GQA conversion, as `createEmptyTensor(rewriter, loc, presentKeyType, pastKey)`.
- #62 ("GQA: Complete MS Specification Alignment") later changed it to `pastKey ? pastKey : (key ? key : query)`, which only added a null fallback and kept the wrong dimension source.
- #98 moved the code into `GqaConversion.cpp` during the monolith split.

So this is a day-one bug in the GQA path, not a recent regression.

## Why lit never caught it

Every existing GQA lit test (`test_gqa.mlir`, `test_gqa_prefill_sentinel.mlir`) uses **fully static** present shapes. With a static result type the init is a plain `tensor.empty()` with no dynamic operands, so the sizing source is unobservable and the buggy and correct code emit identical IR. The bug only shows up when the present seq dim is dynamic, which is what the real gpt-oss export produces.

This PR adds `test_gqa_dynamic_present.mlir` with dynamic batch/seq. Verified it **fails** against a pre-fix `hip-mlir-opt` and **passes** after the fix.

Pre-fix IR (present sized from `%arg4` = `past_key` only, no `addi`):

```mlir
%dim_1 = tensor.dim %arg4, %c0 : tensor<?x8x?x128xf16>
%dim_2 = tensor.dim %arg4, %c2 : tensor<?x8x?x128xf16>
%1 = tensor.empty(%dim_1, %dim_2) : tensor<?x8x?x128xf16>   // past_seq == 0 -> empty
```

Post-fix IR:

```mlir
%dim_2 = tensor.dim %arg1, %c1 : tensor<?x?x4096xf16>       // current
%dim_3 = tensor.dim %arg4, %c2 : tensor<?x8x?x128xf16>      // past
%1 = arith.addi %dim_3, %dim_2 : index                      // total
%2 = tensor.empty(%dim_1, %1) : tensor<?x8x?x128xf16>
```

## Scope guard

Only rank-3 BSH query (seq at dim 1) with rank-4 BNSH present (seq at dim 2) is re-sized. Any other layout falls back to the previous positional behaviour rather than guessing which axis carries the sequence.

## Validation

Local gpt-oss-20b greedy decode, 125-token prompt, 128 new tokens, HipEP on gfx1151:

| | before | after |
|---|---|---|
| `GQA requires present_key/present_value` errors | 3072 (24 layers x 128 steps) | 0 |
| first token | `11` (`,`) | `20837` (`' AI'`) — matches CPU EP exactly |
| output | `, and la) (H] (H] (H] (H]...` | ` AI, fully or partially or fully?\n\nAMD has fully embraced generative AI...` |
| prefill logits cosine vs CPU EP | — | 0.99998 |

Lit: all `onnx-to-hip` conversion tests pass (107 pass; 4 negative tests need `not`, 2 need `%t`, both limitations of my ad-hoc local runner, not the tests).

## Test plan

- [ ] CI lit: `test/lit/Conversion/onnx-to-hip/test_gqa_dynamic_present.mlir`
- [ ] CI accuracy/E2E on gpt-oss-20b (this is the run to watch — please confirm the CI gibberish clears)
- [ ] Existing GQA/Attention conversion tests still green
