### PR TITLE
perf(gqa): fused v5 prefill for sinks and sliding windows, at 44% fewer instructions per KV tile

### DIFF
--- a/lib/Runtime/Kernels/hip/gqa_kernel.hip
+++ b/lib/Runtime/Kernels/hip/gqa_kernel.hip
@@ -2492,7 +2492,11 @@ typedef float float8_t __attribute__((ext_vector_type(8)));
 // Each wave owns M_TILES 16-row q-subtiles x all BKV columns. Only LDS is
 // P_lds (C->A transpose); only sync is single-wave around it.
 // ---------------------------------------------------------------------
-template <int M_TILES, int BKV, int D>
+// HAS_WINDOW is a template parameter rather than a runtime test because this
+// kernel runs at the VGPR ceiling: carrying the window's per-row state live in
+// the full-attention instantiation pushed M_TILES=2 from 120 to 180 bytes/lane
+// of scratch (38 -> 68 spills) and cost that path 21% at deep KV.
+template <int M_TILES, int BKV, int D, bool HAS_WINDOW>
 __global__ void __launch_bounds__(32)
 gqa_flash_prefill_v5_kernel(
     const _Float16* __restrict__ Q,       // [B, sq, Hq, D]
@@ -2500,7 +2504,10 @@ gqa_flash_prefill_v5_kernel(
     const _Float16* __restrict__ Vcache,  // [B, G, max_seq, D]
     _Float16* __restrict__ O,             // [B, sq, Hq, D]
     int B_count, int Hq, int G, int sq, int skv, int max_seq, int past_len,
-    float scale, int ablate)
+    float scale, int ablate,
+    const _Float16* __restrict__ head_sink,  // [num_heads] or null
+    int num_heads, int smooth_softmax,
+    int local_window_size)                   // <= 0 for full attention
 {
     // ablation bitmask (perf diagnostics only; wrong numerics):
     //   bit0 skip softmax, bit1 skip valueGEMM, bit2 skip scoreGEMM,
@@ -2596,7 +2603,18 @@ gqa_flash_prefill_v5_kernel(
                               ? (skv - 1) : (past_len + q_start + ROWS - 1);
     const int num_tiles = kv_max / BKV + 1;
 
-    for (int t = 0; t < num_tiles; ++t) {
+    // With a window, every row in this Q tile has a lower bound at least as high
+    // as the first row's, so starting from the first row's bound covers the whole
+    // tile and the per-row mask trims the rest. This is what makes the window
+    // cheaper rather than merely masked: the number of tiles walked stops growing
+    // with skv once the window is filled.
+    int t_start = 0;
+    if constexpr (HAS_WINDOW) {
+        const int kv_lo_tile = past_len + q_start - local_window_size + 1;
+        t_start = (kv_lo_tile > 0) ? (kv_lo_tile / BKV) : 0;
+    }
+
+    for (int t = t_start; t < num_tiles; ++t) {
         const int kv0 = t * BKV;
 
         // Stage V tile into LDS with coalesced HALF16 loads along D.
@@ -2629,13 +2647,18 @@ gqa_flash_prefill_v5_kernel(
             for (int e = 0; e < 8; ++e) {
                 const int row    = mi * 16 + e * 2 + pair;        // local q row
                 const int q_pos  = q_start + row;
-                // causal mask + per-row partial max over this lane's columns
+                // causal mask, sliding-window lower bound, and per-row partial
+                // max over this lane's columns
+                const int abs_q = past_len + q_pos;
+                int kv_lo = 0;
+                if constexpr (HAS_WINDOW) kv_lo = abs_q - local_window_size + 1;
                 float rmax = -INFINITY;
                 #pragma unroll
                 for (int sj = 0; sj < S_TILES_J; ++sj) {
                     const int kv_pos = kv0 + sj * 16 + wmma_lane;
-                    if (kv_pos >= skv || kv_pos > past_len + q_pos)
-                        S_reg[mi][sj][e] = -INFINITY;
+                    bool masked = (kv_pos >= skv || kv_pos > abs_q);
+                    if constexpr (HAS_WINDOW) masked = masked || (kv_pos < kv_lo);
+                    if (masked) S_reg[mi][sj][e] = -INFINITY;
                     rmax = fmaxf(rmax, S_reg[mi][sj][e]);
                 }
                 rmax = fmaxf(rmax, __shfl_xor(rmax, 1));
@@ -2645,13 +2668,22 @@ gqa_flash_prefill_v5_kernel(
 
                 const float m_old = m_reg[mi][e];
                 const float m_new = fmaxf(m_old, rmax);
-                const float corr  = exp2f(m_old - m_new);
+                // A window can mask a whole tile for a row while that row has
+                // still seen nothing, leaving m_old and m_new both at -inf.
+                // exp2f(-inf - -inf) is NaN, so short-circuit: contribute
+                // nothing and leave the running state untouched. Causal-only
+                // never reaches this, since tile 0 always holds key 0, so the
+                // guard folds away in the full-attention instantiation.
+                bool empty = false;
+                if constexpr (HAS_WINDOW) empty = (m_new == -INFINITY);
+                const float corr  = empty ? 1.0f : exp2f(m_old - m_new);
                 corr_reg[mi][e]   = corr;
 
                 float rsum = 0.0f;
                 #pragma unroll
                 for (int sj = 0; sj < S_TILES_J; ++sj) {
-                    const float p = exp2f(S_reg[mi][sj][e] - m_new);
+                    const float p =
+                        empty ? 0.0f : exp2f(S_reg[mi][sj][e] - m_new);
                     rsum += p;
                     P_lds[row * P_STR + sj * 16 + wmma_lane] = static_cast<_Float16>(p);
                 }
@@ -2697,6 +2729,36 @@ gqa_flash_prefill_v5_kernel(
         __syncthreads();   // WAR: P_lds reused by next tile's softmax
     }
 
+    // ---- Attention sink: one extra term in the softmax denominator ----
+    // m_reg / l_reg are in log2 space (scores were premultiplied by
+    // scale * kLog2e above and exp2f is used for both), so m_reg == m_nat *
+    // kLog2e and the natural-units sink term exp(s - m_nat) becomes
+    // exp2(s * kLog2e - m_reg) -- the same identity the decode reduce kernel
+    // documents. Row-invariant in the D dimension, so it is folded into l once
+    // here rather than inside the D_TILES loop below.
+    //
+    // smooth_softmax with a null sink means s = 0, matching
+    // softmax_f32_to_out_kernel. A row where every key was masked keeps
+    // m_reg == -INFINITY; it must be skipped, because the exponent would
+    // otherwise be +inf and the whole row would come out zero instead of
+    // sink-only.
+    float l_final[M_TILES][8];
+    const bool apply_sink = (head_sink != nullptr) || (smooth_softmax != 0);
+    float sink_logit = 0.0f;
+    if (head_sink != nullptr)
+        sink_logit = static_cast<float>(
+            head_sink[num_heads > 0 ? (head_q % num_heads) : head_q]);
+    #pragma unroll
+    for (int mi = 0; mi < M_TILES; ++mi) {
+        #pragma unroll
+        for (int e = 0; e < 8; ++e) {
+            float l = l_reg[mi][e];
+            if (apply_sink && m_reg[mi][e] > -INFINITY)
+                l += exp2f(sink_logit * kLog2e - m_reg[mi][e]);
+            l_final[mi][e] = fmaxf(l, 1e-6f);
+        }
+    }
+
     // ---- Epilogue: O / l ----
     #pragma unroll
     for (int mi = 0; mi < M_TILES; ++mi) {
@@ -2708,8 +2770,7 @@ gqa_flash_prefill_v5_kernel(
                 const int c     = tj * 16 + wmma_lane;
                 const int q_pos = q_start + row;
                 if (q_pos < sq && c < D) {
-                    const float l_val   = fmaxf(l_reg[mi][e], 1e-6f);
-                    const float out_val = O_frag[mi][tj][e] / l_val;
+                    const float out_val = O_frag[mi][tj][e] / l_final[mi][e];
                     O[(static_cast<size_t>(batch * sq + q_pos) * Hq + head_q) * D + c] =
                         static_cast<_Float16>(out_val);
                 }
@@ -2734,7 +2795,9 @@ static inline void dispatchPrefillV5(
     int m_tiles, int bkv, int d, hipStream_t stream,
     const _Float16* Q, const _Float16* Kcache, const _Float16* Vcache,
     _Float16* O, int B, int Hq, int G, int sq, int skv, int max_seq,
-    int past_len, float scale)
+    int past_len, float scale,
+    const _Float16* head_sink, int num_heads, int smooth_softmax,
+    int local_window_size)
 {
     const int rows = m_tiles * 16;
     const int num_q_tiles = (sq + rows - 1) / rows;
@@ -2742,22 +2805,33 @@ static inline void dispatchPrefillV5(
     const size_t smem = prefillV5SmemBytes(m_tiles, bkv, d);
     const int ablate = g_v5_ablate;
 
-    #define LAUNCH_V5(MT_, BKV_, D_)                                            \
-        gqa_flash_prefill_v5_kernel<MT_, BKV_, D_>                              \
+    #define LAUNCH_V5(MT_, BKV_, D_, HW_)                                       \
+        gqa_flash_prefill_v5_kernel<MT_, BKV_, D_, HW_>                         \
             <<<grid, 32, smem, stream>>>(                                       \
                 Q, Kcache, Vcache, O, B, Hq, G, sq, skv, max_seq, past_len,     \
-                scale, ablate)
+                scale, ablate, head_sink, num_heads, smooth_softmax,            \
+                local_window_size)
 
+    // Only d == 64 gets windowed instantiations: hip_gqa_flash_prefill_v3
+    // rejects a window at any other head dim, so d == 128 with a window would
+    // be dead code.
     if (d == 64) {
-        if (m_tiles == 2 && bkv == 64)      LAUNCH_V5(2, 64, 64);
-        else if (m_tiles == 2)              LAUNCH_V5(2, 32, 64);
-        else if (bkv == 64)                 LAUNCH_V5(1, 64, 64);
-        else                                LAUNCH_V5(1, 32, 64);
+        if (local_window_size > 0) {
+            if (m_tiles == 2 && bkv == 64)  LAUNCH_V5(2, 64, 64, true);
+            else if (m_tiles == 2)          LAUNCH_V5(2, 32, 64, true);
+            else if (bkv == 64)             LAUNCH_V5(1, 64, 64, true);
+            else                            LAUNCH_V5(1, 32, 64, true);
+        } else {
+            if (m_tiles == 2 && bkv == 64)  LAUNCH_V5(2, 64, 64, false);
+            else if (m_tiles == 2)          LAUNCH_V5(2, 32, 64, false);
+            else if (bkv == 64)             LAUNCH_V5(1, 64, 64, false);
+            else                            LAUNCH_V5(1, 32, 64, false);
+        }
     } else {
-        if (m_tiles == 2 && bkv == 64)      LAUNCH_V5(2, 64, 128);
-        else if (m_tiles == 2)              LAUNCH_V5(2, 32, 128);
-        else if (bkv == 64)                 LAUNCH_V5(1, 64, 128);
-        else                                LAUNCH_V5(1, 32, 128);
+        if (m_tiles == 2 && bkv == 64)      LAUNCH_V5(2, 64, 128, false);
+        else if (m_tiles == 2)              LAUNCH_V5(2, 32, 128, false);
+        else if (bkv == 64)                 LAUNCH_V5(1, 64, 128, false);
+        else                                LAUNCH_V5(1, 32, 128, false);
     }
     #undef LAUNCH_V5
 }
@@ -2780,15 +2854,21 @@ static int tunePrefillV5Cfg(
     int d, hipStream_t stream,
     const _Float16* Q, const _Float16* Kcache, const _Float16* Vcache,
     _Float16* O, int B, int Hq, int G, int sq, int skv, int max_seq,
-    int past_len, float scale)
+    int past_len, float scale, int local_window_size)
 {
     PrefillV5Cfg cands[8];
     const int nc = prefillV5Candidates(d, cands);
     constexpr int kWarmup = 30, kRounds = 4, kIters = 30;
 
+    // Tuning launches carry no sink: it is a single fused-multiply-add per row in
+    // the epilogue, so it cannot shift which (M_TILES, BKV) wins, and leaving it
+    // out keeps tuned configs comparable with the non-sink case. The window is
+    // passed through, because it changes how many KV tiles each block walks and
+    // therefore genuinely can change the winner.
     auto launch_cfg = [&](const PrefillV5Cfg& c) {
         dispatchPrefillV5(c.m_tiles, c.bkv, d, stream, Q, Kcache, Vcache, O,
-                          B, Hq, G, sq, skv, max_seq, past_len, scale);
+                          B, Hq, G, sq, skv, max_seq, past_len, scale,
+                          nullptr, Hq, 0, local_window_size);
     };
 
     for (int w = 0; w < kWarmup; ++w) launch_cfg(cands[w % nc]);
@@ -3613,11 +3693,12 @@ extern "C" void hip_gqa_flash_prefill_v5_set_ablate(int mask) {
     g_v5_ablate = mask;
 }
 
-extern "C" int hip_gqa_flash_prefill_v5_v2(
+static int prefillV5Run(
     void* stream_ptr,
     const void* Q, const void* Kcache, const void* Vcache, void* O,
     int B, int Hq, int G, int sq, int skv, int d, int max_seq, int past_len,
-    float scale)
+    float scale, const void* head_sink, int num_heads, int smooth_softmax,
+    int local_window_size)
 {
     if (d != 64 && d != 128) return -1;
 
@@ -3626,10 +3707,20 @@ extern "C" int hip_gqa_flash_prefill_v5_v2(
     const _Float16* K_ptr = static_cast<const _Float16*>(Kcache);
     const _Float16* V_ptr = static_cast<const _Float16*>(Vcache);
     _Float16* O_ptr       = static_cast<_Float16*>(O);
+    const _Float16* sink_ptr = static_cast<const _Float16*>(head_sink);
 
+    // Neither skv nor the sink belongs in the key. skv only scales the KV loop
+    // length, uniformly across candidates, so it cannot reorder them: measured
+    // on gpt-oss-20b, M_TILES=2/BKV=32 wins at all 32 chunk skv values from 512
+    // to 16384 with an identical candidate ranking. Keying on skv re-tuned once
+    // per chunk of a chunked prefill instead of once per process. The sink is
+    // one FMA per row in the epilogue (see tunePrefillV5Cfg).
+    //
+    // The window does belong in the key: it caps how many KV tiles a block walks,
+    // which is a different work profile, not a scaled one.
     std::string key = std::to_string(d) + "_" + std::to_string(sq) + "_" +
-                      std::to_string(skv) + "_" + std::to_string(Hq) + "_" +
-                      std::to_string(G);
+                      std::to_string(Hq) + "_" + std::to_string(G) + "_w" +
+                      std::to_string(local_window_size > 0 ? local_window_size : 0);
     int cfg;
     {
         std::lock_guard<std::mutex> lk(g_v5_cfg_mutex);
@@ -3638,7 +3729,8 @@ extern "C" int hip_gqa_flash_prefill_v5_v2(
             cfg = it->second;
         } else {
             cfg = tunePrefillV5Cfg(d, stream, Q_ptr, K_ptr, V_ptr, O_ptr,
-                                   B, Hq, G, sq, skv, max_seq, past_len, scale);
+                                   B, Hq, G, sq, skv, max_seq, past_len, scale,
+                                   local_window_size);
             g_v5_cfg_cache[key] = cfg;
             snprintf(g_v5_tune_info, sizeof(g_v5_tune_info),
                      "gqa_flash_prefill_v5 cfg=M%d_BKV%d", cfg / 1000, cfg % 1000);
@@ -3646,8 +3738,19 @@ extern "C" int hip_gqa_flash_prefill_v5_v2(
     }
     int m_tiles = cfg / 1000, bkv = cfg % 1000;
     dispatchPrefillV5(m_tiles, bkv, d, stream, Q_ptr, K_ptr, V_ptr, O_ptr,
-                      B, Hq, G, sq, skv, max_seq, past_len, scale);
+                      B, Hq, G, sq, skv, max_seq, past_len, scale,
+                      sink_ptr, num_heads, smooth_softmax, local_window_size);
     return 0;
+}
+
+extern "C" int hip_gqa_flash_prefill_v5_v2(
+    void* stream_ptr,
+    const void* Q, const void* Kcache, const void* Vcache, void* O,
+    int B, int Hq, int G, int sq, int skv, int d, int max_seq, int past_len,
+    float scale)
+{
+    return prefillV5Run(stream_ptr, Q, Kcache, Vcache, O, B, Hq, G, sq, skv, d,
+                        max_seq, past_len, scale, nullptr, Hq, 0, 0);
 }
 
 
@@ -3706,6 +3809,35 @@ extern "C" void hip_gqa_flash_prefill_v8_set_ablate(int mask) {
     g_v8_ablate = mask;
 }
 
+
+// Wide fused flash-prefill entry: adds attention sinks and the sliding window
+// on top of v2. v2 stays the narrow ABI so the standalone harnesses and shim
+// headers that redeclare it keep linking unchanged.
+//
+// Both features are implemented for d == 64 (the v5 kernel) only. For any other
+// d we return -1 rather than silently ignoring them, so the runtime keeps
+// routing those shapes to the decomposed path, which does implement both. A
+// request carrying neither is forwarded to v2 and keeps v2's head-dim coverage
+// and its v5/v7/v8 selection; d == 64 lands on v5 either way, so a sink or a
+// window never changes which kernel runs.
+extern "C" int hip_gqa_flash_prefill_v3(
+    void* stream_ptr,
+    const void* Q, const void* Kcache, const void* Vcache, void* O,
+    int B, int Hq, int G, int sq, int skv, int d, int max_seq, int past_len,
+    float scale, int local_window_size, const void* head_sink,
+    int num_heads, int smooth_softmax)
+{
+    const bool wants_sink   = (head_sink != nullptr) || (smooth_softmax != 0);
+    const bool wants_window = local_window_size > 0;
+    if ((wants_sink || wants_window) && d != 64) return -1;
+    if (!wants_sink && !wants_window) {
+        return hip_gqa_flash_prefill_v2(stream_ptr, Q, Kcache, Vcache, O, B, Hq,
+                                        G, sq, skv, d, max_seq, past_len, scale);
+    }
+    return prefillV5Run(stream_ptr, Q, Kcache, Vcache, O, B, Hq, G, sq, skv, d,
+                        max_seq, past_len, scale, head_sink, num_heads,
+                        smooth_softmax, local_window_size);
+}
 
 // Unified fused flash-prefill entry. The kernel-selection strategy lives here
 // (in the kernel TU) instead of in the runtime dispatcher: v5 wins at d==64

--- a/lib/Runtime/Kernels/hip/gqa_kernel.hip
+++ b/lib/Runtime/Kernels/hip/gqa_kernel.hip
@@ -2488,6 +2488,44 @@ typedef float float8_t __attribute__((ext_vector_type(8)));
 
 
 // ---------------------------------------------------------------------
+// The v5 KV loop is bound by instruction issue, not by occupancy, bandwidth or
+// the matrix units: it issued 1734 instructions per tile to retire 32 WMMA.
+// Three changes below cut that to 967 on the 99.6% of tiles that need no
+// causal mask, and they are the reason this kernel is 21.4% faster than the
+// shape of it that shipped first. They are described where they appear:
+//
+//   - native exp2 in the softmax, at V5_EXP2 just below
+//   - the l reduction deferred out of the loop, at the epilogue that consumes
+//     l_reg unreduced
+//   - the mask-free / masked tile split, at tileBody
+//
+// Measured on gpt_oss-sink sq=512 past=8192, interleaved: exp2 alone -0.5%,
+// the deferred reduction alone -8.9%, both -12.4%, all three -21.4%, and 16k
+// in-model TTFT 9,653 -> 9,172 ms. Native exp2 pays nothing on its own because
+// the reduction chain it sits behind is what the loop waits on.
+//
+// The split is not separable from the restructure it needs: the same lambda
+// without the split costs 32% on every D=64 full-attention case, because the
+// split is what lets the compiler keep a tile's live values in registers
+// instead of scratch (in-loop scratch traffic 52 ops -> 6).
+// ---------------------------------------------------------------------
+
+// Tag for the mask-free / masked dispatch below. A local type rather than
+// std::integral_constant so this TU keeps its current include set.
+template <bool B> struct v5_masked_tag { static constexpr bool value = B; };
+
+// exp2f routes to __builtin_exp2f, whose OCML lowering wraps each v_exp_f32 in
+// a denormal-safe compare/select/bias/ldexp sequence: six instructions where
+// one would do, 48 of each per tile. Both KV-loop call sites take arguments
+// that are always <= 0 (S_reg <= m_new and m_old <= m_new by construction), so
+// results land in (0, 1] and the only value the denormal path protects is one
+// below 2^-126 -- a key scoring 126 log2-units under its row max, contributing
+// ~1e-38 to a sum containing 1.0. Flushing that to zero is the correct answer,
+// not an approximation of it. This is HIP's own idiom: __expf and __exp10f are
+// defined the same way.
+#define V5_EXP2(x) __builtin_amdgcn_exp2f(x)
+
+// ---------------------------------------------------------------------
 // Warp-private prefill kernel (v5). Grid: (num_q_tiles*B, Hq). Block: 32.
 // Each wave owns M_TILES 16-row q-subtiles x all BKV columns. Only LDS is
 // P_lds (C->A transpose); only sync is single-wave around it.
@@ -2614,7 +2652,11 @@ gqa_flash_prefill_v5_kernel(
         t_start = (kv_lo_tile > 0) ? (kv_lo_tile / BKV) : 0;
     }
 
-    for (int t = t_start; t < num_tiles; ++t) {
+    // Tag-dispatched so the mask-free tile shape gets its own instantiation
+    // without a second copy of the source. MASKED is a compile-time constant in
+    // each, so the per-element mask below is gone from the mask-free one.
+    auto tileBody = [&](int t, auto masked_tag) {
+        constexpr bool MASKED = decltype(masked_tag)::value;
         const int kv0 = t * BKV;
 
         // Stage V tile into LDS with coalesced HALF16 loads along D.
@@ -2655,10 +2697,12 @@ gqa_flash_prefill_v5_kernel(
                 float rmax = -INFINITY;
                 #pragma unroll
                 for (int sj = 0; sj < S_TILES_J; ++sj) {
-                    const int kv_pos = kv0 + sj * 16 + wmma_lane;
-                    bool masked = (kv_pos >= skv || kv_pos > abs_q);
-                    if constexpr (HAS_WINDOW) masked = masked || (kv_pos < kv_lo);
-                    if (masked) S_reg[mi][sj][e] = -INFINITY;
+                    if constexpr (MASKED) {
+                        const int kv_pos = kv0 + sj * 16 + wmma_lane;
+                        bool masked = (kv_pos >= skv || kv_pos > abs_q);
+                        if constexpr (HAS_WINDOW) masked = masked || (kv_pos < kv_lo);
+                        if (masked) S_reg[mi][sj][e] = -INFINITY;
+                    }
                     rmax = fmaxf(rmax, S_reg[mi][sj][e]);
                 }
                 rmax = fmaxf(rmax, __shfl_xor(rmax, 1));
@@ -2676,22 +2720,24 @@ gqa_flash_prefill_v5_kernel(
                 // guard folds away in the full-attention instantiation.
                 bool empty = false;
                 if constexpr (HAS_WINDOW) empty = (m_new == -INFINITY);
-                const float corr  = empty ? 1.0f : exp2f(m_old - m_new);
+                const float corr  = empty ? 1.0f : V5_EXP2(m_old - m_new);
                 corr_reg[mi][e]   = corr;
 
                 float rsum = 0.0f;
                 #pragma unroll
                 for (int sj = 0; sj < S_TILES_J; ++sj) {
                     const float p =
-                        empty ? 0.0f : exp2f(S_reg[mi][sj][e] - m_new);
+                        empty ? 0.0f : V5_EXP2(S_reg[mi][sj][e] - m_new);
                     rsum += p;
                     P_lds[row * P_STR + sj * 16 + wmma_lane] = static_cast<_Float16>(p);
                 }
-                rsum += __shfl_xor(rsum, 1);
-                rsum += __shfl_xor(rsum, 2);
-                rsum += __shfl_xor(rsum, 4);
-                rsum += __shfl_xor(rsum, 8);
-
+                // rsum is deliberately left unreduced across the 16 lanes: that
+                // reduction is deferred to the epilogue, which costs 64 fewer
+                // ds_bpermute per tile. Valid because corr is lane-uniform (it
+                // is a function of m_new, already reduced over these same 16
+                // lanes), so sum_lanes(corr*l + rsum) is corr*sum_lanes(l) +
+                // sum_lanes(rsum) and the recursion survives the deferral.
+                // Nothing between here and the epilogue reads l_reg.
                 m_reg[mi][e] = m_new;
                 l_reg[mi][e] = corr * l_reg[mi][e] + rsum;
             }
@@ -2727,6 +2773,21 @@ gqa_flash_prefill_v5_kernel(
             }
         }
         __syncthreads();   // WAR: P_lds reused by next tile's softmax
+    };
+
+    // The tile split is full attention only. With a window the band spans about
+    // five tiles at ROWS=32, so nearly every tile touches a boundary and a
+    // mask-free copy would buy nothing while still costing register pressure.
+    if constexpr (!HAS_WINDOW) {
+        // A tile is mask-free when its highest key is within skv and within the
+        // causal bound of the tile's *first* row; later rows only admit more.
+        const int mask_free_hi = (skv - 1 < past_len + q_start) ? (skv - 1)
+                                                                : (past_len + q_start);
+        const int t_split = (mask_free_hi + 1) / BKV;   // leading mask-free tiles
+        for (int t = t_start; t < t_split;   ++t) tileBody(t, v5_masked_tag<false>{});
+        for (int t = t_split; t < num_tiles; ++t) tileBody(t, v5_masked_tag<true>{});
+    } else {
+        for (int t = t_start; t < num_tiles; ++t) tileBody(t, v5_masked_tag<true>{});
     }
 
     // ---- Attention sink: one extra term in the softmax denominator ----
@@ -2753,6 +2814,13 @@ gqa_flash_prefill_v5_kernel(
         #pragma unroll
         for (int e = 0; e < 8; ++e) {
             float l = l_reg[mi][e];
+            // The reduction the KV loop skipped, paid once per row instead of
+            // once per tile. It must precede the sink, or the sink is counted
+            // 16 times.
+            l += __shfl_xor(l, 1);
+            l += __shfl_xor(l, 2);
+            l += __shfl_xor(l, 4);
+            l += __shfl_xor(l, 8);
             if (apply_sink && m_reg[mi][e] > -INFINITY)
                 l += exp2f(sink_logit * kLog2e - m_reg[mi][e]);
             l_final[mi][e] = fmaxf(l, 1e-6f);
@@ -2791,6 +2859,37 @@ static constexpr size_t kPrefillV5MaxSmem = 65536;
 
 static int g_v5_ablate = 0;  // perf-diagnostics ablation bitmask (default off)
 
+// Measurement-only knobs, read once and off unless the env var is set, so a
+// normal run pays a single cached check and nothing else. They exist because the
+// two questions this kernel raises are otherwise unmeasurable from outside:
+//   HIPDNN_PREFILL_V5_ABLATE=<mask>  drives the same bitmask as the exported
+//     hip_gqa_flash_prefill_v5_set_ablate(), which has no caller reachable from
+//     an in-model run. Bits: 1 softmax, 2 valueGEMM, 4 scoreGEMM, 8 global
+//     loads. Numerics are wrong under any of them -- timing only.
+//   HIPDNN_PREFILL_V5_CFG=M,BKV      pins the config so one candidate can be
+//     timed on its own. Without it every measurement is of whatever the
+//     four-candidate sweep picked, which is the thing under test.
+static int prefillV5AblateEnv() {
+    static const int v = [] {
+        const char* e = getenv("HIPDNN_PREFILL_V5_ABLATE");
+        return e ? atoi(e) : 0;
+    }();
+    return v;
+}
+
+// Returns m_tiles*1000 + bkv, or 0 when unset.
+static int prefillV5CfgOverride() {
+    static const int v = [] {
+        const char* e = getenv("HIPDNN_PREFILL_V5_CFG");
+        if (!e) return 0;
+        int mt = 0, bkv = 0;
+        if (sscanf(e, "%d,%d", &mt, &bkv) != 2) return 0;
+        if ((mt != 1 && mt != 2) || (bkv != 32 && bkv != 64)) return 0;
+        return mt * 1000 + bkv;
+    }();
+    return v;
+}
+
 static inline void dispatchPrefillV5(
     int m_tiles, int bkv, int d, hipStream_t stream,
     const _Float16* Q, const _Float16* Kcache, const _Float16* Vcache,
@@ -2803,7 +2902,7 @@ static inline void dispatchPrefillV5(
     const int num_q_tiles = (sq + rows - 1) / rows;
     dim3 grid(num_q_tiles * B, Hq);
     const size_t smem = prefillV5SmemBytes(m_tiles, bkv, d);
-    const int ablate = g_v5_ablate;
+    const int ablate = g_v5_ablate | prefillV5AblateEnv();
 
     #define LAUNCH_V5(MT_, BKV_, D_, HW_)                                       \
         gqa_flash_prefill_v5_kernel<MT_, BKV_, D_, HW_>                         \
@@ -3722,6 +3821,11 @@ static int prefillV5Run(
                       std::to_string(Hq) + "_" + std::to_string(G) + "_w" +
                       std::to_string(local_window_size > 0 ? local_window_size : 0);
     int cfg;
+    // An override also skips tuning, so a pinned run costs no sweep and the
+    // dispatch under test is the only one in the trace.
+    if (const int forced = prefillV5CfgOverride()) {
+        cfg = forced;
+    } else
     {
         std::lock_guard<std::mutex> lk(g_v5_cfg_mutex);
         auto it = g_v5_cfg_cache.find(key);

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -751,6 +751,31 @@ HIP_KERNEL_API int hip_gqa_flash_prefill_v2(
     void* O, int B, int Hq, int G, int sq, int skv, int d, int max_seq,
     int past_len, float scale);
 
+/* Same as hip_gqa_flash_prefill_v2, plus attention sinks / smooth softmax and
+ * a sliding window.
+ * Kept as a separate symbol rather than widening v2, because v2 is redeclared
+ * locally by the standalone GQA harnesses and the dispatch_bench shim header;
+ * widening it in place would break those and risk a silent host/kernel ABI skew.
+ *
+ *   local_window_size : <= 0 for full attention. > 0 masks key k for query q
+ *                       when k < past_len + q - local_window_size + 1, the same
+ *                       convention causal_mask_kernel_impl uses.
+ *   head_sink         : [num_heads] __half of per-head sink logits, or null.
+ *   smooth_softmax    : non-zero adds a sink logit of 0, matching the
+ *                       decomposed path when head_sink is null. head_sink takes
+ *                       precedence when both are supplied.
+ *
+ * Sinks and windows are implemented by the v5 kernel, i.e. at d == 64 only.
+ * Returns 0 on success and -1 when the request cannot be served exactly (a sink
+ * or a window with d != 64), so the caller falls back to the decomposed path
+ * instead of silently dropping either. A request with neither is forwarded to
+ * v2 and keeps v2's head-dim coverage. */
+HIP_KERNEL_API int hip_gqa_flash_prefill_v3(
+    void* stream, const void* Q, const void* Kcache, const void* Vcache,
+    void* O, int B, int Hq, int G, int sq, int skv, int d, int max_seq,
+    int past_len, float scale, int local_window_size, const void* head_sink,
+    int num_heads, int smooth_softmax);
+
 /* NB: prefill is compute-bound, so there is deliberately NO separate int8
  * prefill kernel. The runtime (real/gqa.cpp) dequantizes the int8 KV cache to an
  * fp16 scratch ONCE (hip_gqa_dequant_kv_i8_to_fp16) and reuses the tuned fp16

--- a/lib/Runtime/Kernels/test/example/gqa/prefill/test_gqa_prefill.cpp
+++ b/lib/Runtime/Kernels/test/example/gqa/prefill/test_gqa_prefill.cpp
@@ -35,6 +35,14 @@ extern "C" int hip_gqa_flash_prefill_v2(
     void* O, int B, int Hq, int G, int sq, int skv, int d, int max_seq,
     int past_len, float scale);
 
+// Wide entry: same as v2 plus attention sinks / smooth softmax and a sliding
+// window.
+extern "C" int hip_gqa_flash_prefill_v3(
+    void* stream, const void* Q, const void* Kcache, const void* Vcache,
+    void* O, int B, int Hq, int G, int sq, int skv, int d, int max_seq,
+    int past_len, float scale, int local_window_size, const void* head_sink,
+    int num_heads, int smooth_softmax);
+
 extern "C" int hip_gqa_flash_prefill_v7(
     void* stream, const void* Q, const void* Kcache, const void* Vcache,
     void* O, int B, int Hq, int G, int sq, int skv, int d, int max_seq,
@@ -50,9 +58,35 @@ extern "C" int hip_gqa_flash_prefill_v7(
     }                                                                          \
   } while (0)
 
+// Sink handling, matching softmax_f32_to_out_kernel exactly: the row max is
+// taken over the scores only (the sink does NOT participate), and the sink
+// contributes a single exp(s - max) term to the denominator. kSinkSmooth is the
+// smooth_softmax case, i.e. a sink logit of 0 with no sink tensor.
+//
+// kSinkBoth sends a sink tensor AND smooth_softmax=1, which is the only
+// combination the runtime ever produces: gqa.cpp derives smooth from
+// (head_sink != nullptr || smooth_softmax == 1) and then passes both. head_sink
+// takes precedence, so the reference folds in the per-head logit alone; a kernel
+// that also added the smooth term would double-count the denominator and fail.
+enum SinkMode {
+  kSinkNone = 0,
+  kSinkPerHead = 1,
+  kSinkSmooth = 2,
+  kSinkBoth = 3
+};
+
 struct Case {
   const char* name;
-  int B, H, G, D, sq;  // pure prefill: skv = sq, past_len = 0
+  int B, H, G, D, sq;
+  int past;       // past_len; total_seq = past + sq. 0 = pure prefill.
+  int sink_mode;  // SinkMode
+  // Expect the kernel to decline (rc != 0) instead of computing. Used for the
+  // shapes v3 must refuse so the runtime falls back to the decomposed path
+  // rather than dropping the sink or the window.
+  bool expect_reject;
+  // Sliding window; <= 0 is full attention. Convention matches
+  // causal_mask_kernel_impl: key k is masked when k < past_len + q - window + 1.
+  int window;
 };
 
 // CPU fp32 reference: causal GQA attention. Q/O BSHD, K/V cache BNSD.
@@ -60,7 +94,8 @@ static void cpu_reference(const std::vector<float>& Q,
                           const std::vector<float>& K,
                           const std::vector<float>& V, std::vector<float>& O,
                           int B, int H, int G, int D, int sq, int max_seq,
-                          int past_len, float scale) {
+                          int past_len, float scale, int sink_mode,
+                          const std::vector<float>& sink, int window) {
   const int HPG = H / G;
   const int total = past_len + sq;
   std::vector<float> scores(total);
@@ -70,8 +105,11 @@ static void cpu_reference(const std::vector<float>& Q,
       for (int s = 0; s < sq; ++s) {
         const float* q = &Q[((size_t)(b * sq + s) * H + hq) * D];
         const int kmax = past_len + s;  // causal: attend to keys 0..kmax
+        const int kmin = (window > 0 && kmax - window + 1 > 0)
+                             ? (kmax - window + 1)
+                             : 0;
         float m = -1e30f;
-        for (int k = 0; k <= kmax; ++k) {
+        for (int k = kmin; k <= kmax; ++k) {
           const float* kp = &K[((size_t)(b * G + hkv) * max_seq + k) * D];
           float dot = 0.0f;
           for (int e = 0; e < D; ++e) dot += q[e] * kp[e];
@@ -79,14 +117,18 @@ static void cpu_reference(const std::vector<float>& Q,
           if (scores[k] > m) m = scores[k];
         }
         float l = 0.0f;
-        for (int k = 0; k <= kmax; ++k) {
+        for (int k = kmin; k <= kmax; ++k) {
           scores[k] = std::exp(scores[k] - m);
           l += scores[k];
         }
+        if (sink_mode == kSinkPerHead || sink_mode == kSinkBoth)
+          l += std::exp(sink[hq] - m);
+        else if (sink_mode == kSinkSmooth)
+          l += std::exp(0.0f - m);
         const float inv = (l > 0.0f) ? 1.0f / l : 0.0f;
         float* o = &O[((size_t)(b * sq + s) * H + hq) * D];
         for (int e = 0; e < D; ++e) o[e] = 0.0f;
-        for (int k = 0; k <= kmax; ++k) {
+        for (int k = kmin; k <= kmax; ++k) {
           const float* vp = &V[((size_t)(b * G + hkv) * max_seq + k) * D];
           const float w = scores[k] * inv;
           for (int e = 0; e < D; ++e) o[e] += w * vp[e];
@@ -108,13 +150,14 @@ static double rel_l2(const std::vector<float>& a, const std::vector<float>& b) {
 
 static bool run_case(const Case& c, int iters) {
   const int B = c.B, H = c.H, G = c.G, D = c.D, sq = c.sq;
-  const int max_seq = sq;       // pure-prefill cache buffer
-  const int past_len = 0, skv = sq;
+  const int past_len = c.past;
+  const int skv = past_len + sq;   // total_seq
+  const int max_seq = skv;         // cache buffer holds exactly total_seq
   const float scale = 1.0f / std::sqrt((float)D);
 
   const size_t qn = (size_t)B * sq * H * D;
   const size_t kn = (size_t)B * G * max_seq * D;
-  std::mt19937 rng(1234 + sq + D);
+  std::mt19937 rng(1234 + sq + D + past_len + c.sink_mode);
   std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
 
   std::vector<float> Qf(qn), Kf(kn), Vf(kn), Oref(qn);
@@ -122,31 +165,65 @@ static bool run_case(const Case& c, int iters) {
   for (auto& x : Kf) x = dist(rng);
   for (auto& x : Vf) x = dist(rng);
 
-  cpu_reference(Qf, Kf, Vf, Oref, B, H, G, D, sq, max_seq, past_len, scale);
+  // gpt-oss ships sink logits around O(1); span a wider range so a sign or
+  // scaling error in the log2-space conversion cannot hide. Round-trip through
+  // fp16 first, because that is what the kernel reads -- otherwise the
+  // comparison would charge the kernel for the host's rounding.
+  std::vector<__half> sinkh(H);
+  std::vector<float> sinkf(H);
+  for (int h = 0; h < H; ++h) {
+    sinkh[h] = __float2half(-2.0f + 4.0f * (float)h / (float)H);
+    sinkf[h] = __half2float(sinkh[h]);
+  }
+
+  cpu_reference(Qf, Kf, Vf, Oref, B, H, G, D, sq, max_seq, past_len, scale,
+                c.sink_mode, sinkf, c.window);
 
   std::vector<__half> Qh(qn), Kh(kn), Vh(kn);
   for (size_t i = 0; i < qn; ++i) Qh[i] = __float2half(Qf[i]);
   for (size_t i = 0; i < kn; ++i) { Kh[i] = __float2half(Kf[i]); Vh[i] = __float2half(Vf[i]); }
 
-  __half *dQ, *dK, *dV, *dO;
+  __half *dQ, *dK, *dV, *dO, *dSink;
   HIP_CHECK(hipMalloc(&dQ, qn * sizeof(__half)));
   HIP_CHECK(hipMalloc(&dK, kn * sizeof(__half)));
   HIP_CHECK(hipMalloc(&dV, kn * sizeof(__half)));
   HIP_CHECK(hipMalloc(&dO, qn * sizeof(__half)));
+  HIP_CHECK(hipMalloc(&dSink, (size_t)H * sizeof(__half)));
   HIP_CHECK(hipMemcpy(dQ, Qh.data(), qn * sizeof(__half), hipMemcpyHostToDevice));
   HIP_CHECK(hipMemcpy(dK, Kh.data(), kn * sizeof(__half), hipMemcpyHostToDevice));
   HIP_CHECK(hipMemcpy(dV, Vh.data(), kn * sizeof(__half), hipMemcpyHostToDevice));
+  HIP_CHECK(hipMemcpy(dSink, sinkh.data(), (size_t)H * sizeof(__half), hipMemcpyHostToDevice));
 
   // Route through the unified entry (same path the runtime takes); it dispatches
   // v5 (D==64) / v7 (D==128) internally.
+  const void* sink_arg =
+      (c.sink_mode == kSinkPerHead || c.sink_mode == kSinkBoth)
+          ? (const void*)dSink
+          : nullptr;
+  const int smooth_arg =
+      (c.sink_mode == kSinkSmooth || c.sink_mode == kSinkBoth) ? 1 : 0;
+  const int window_arg = (c.window > 0) ? c.window : -1;
+  const char* sink_tag = (c.sink_mode == kSinkPerHead) ? "sink"
+                       : (c.sink_mode == kSinkSmooth)  ? "smooth"
+                       : (c.sink_mode == kSinkBoth)    ? "both"
+                                                       : "-";
   auto launch = [&]() {
-    return hip_gqa_flash_prefill_v2(nullptr, dQ, dK, dV, dO, B, H, G, sq, skv, D,
-                                 max_seq, past_len, scale);
+    return hip_gqa_flash_prefill_v3(nullptr, dQ, dK, dV, dO, B, H, G, sq, skv, D,
+                                    max_seq, past_len, scale, window_arg,
+                                    sink_arg, H, smooth_arg);
   };
 
   int rc = launch();  // first call self-tunes
   HIP_CHECK(hipDeviceSynchronize());
-  if (rc != 0) { fprintf(stderr, "kernel returned %d\n", rc); return false; }
+  if (c.expect_reject) {
+    const bool ok = (rc != 0);
+    printf("%-16s B%d H%d G%d(hpg%d) D%-3d sq=%-5d past=%-5d %-6s w=%-5d | rc=%d (expected decline)  %s\n",
+           c.name, B, H, G, H / G, D, sq, past_len, sink_tag, c.window, rc,
+           ok ? "PASS" : "FAIL");
+    hipFree(dQ); hipFree(dK); hipFree(dV); hipFree(dO); hipFree(dSink);
+    return ok;
+  }
+  if (rc != 0) { fprintf(stderr, "%s: kernel returned %d\n", c.name, rc); return false; }
 
   std::vector<__half> Oh(qn);
   HIP_CHECK(hipMemcpy(Oh.data(), dO, qn * sizeof(__half), hipMemcpyDeviceToHost));
@@ -168,12 +245,12 @@ static bool run_case(const Case& c, int iters) {
   ms /= iters;
 
   const bool pass = err < 2e-3;
-  printf("%-16s B%d H%d G%d(hpg%d) D%-3d sq=%-5d | relL2=%.2e  latency=%.4f ms  %s (v%d)\n",
-         c.name, B, H, G, H / G, D, sq, err, ms, pass ? "PASS" : "FAIL",
-         D == 64 ? 5 : 7);
+  printf("%-16s B%d H%d G%d(hpg%d) D%-3d sq=%-5d past=%-5d %-6s w=%-5d | relL2=%.2e  latency=%.4f ms  %s (v%d)\n",
+         c.name, B, H, G, H / G, D, sq, past_len, sink_tag, c.window, err, ms,
+         pass ? "PASS" : "FAIL", D == 64 ? 5 : 7);
 
   hipEventDestroy(e0); hipEventDestroy(e1);
-  hipFree(dQ); hipFree(dK); hipFree(dV); hipFree(dO);
+  hipFree(dQ); hipFree(dK); hipFree(dV); hipFree(dO); hipFree(dSink);
   return pass;
 }
 
@@ -183,12 +260,54 @@ int main(int argc, char** argv) {
     if (!std::strcmp(argv[i], "--iters") && i + 1 < argc) iters = std::atoi(argv[++i]);
 
   const Case cases[] = {
-      {"gpt_oss-20b",  1, 64, 8,  64, 512},
-      {"gpt_oss-20b",  1, 64, 8,  64, 2048},
-      {"llama-3.2-1b", 1, 32, 8,  64, 512},
-      {"llama-3.2-1b", 1, 32, 8,  64, 2048},
-      {"llama-3.1-8b", 1, 32, 8, 128, 512},
-      {"llama-3.1-8b", 1, 32, 8, 128, 2048},
+      // No-sink regression set (must stay as accurate as before).
+      {"gpt_oss-20b",  1, 64, 8,  64, 512,  0,    kSinkNone,    false, 0},
+      {"gpt_oss-20b",  1, 64, 8,  64, 2048, 0,    kSinkNone,    false, 0},
+      {"llama-3.2-1b", 1, 32, 8,  64, 512,  0,    kSinkNone,    false, 0},
+      {"llama-3.2-1b", 1, 32, 8,  64, 2048, 0,    kSinkNone,    false, 0},
+      {"llama-3.1-8b", 1, 32, 8, 128, 512,  0,    kSinkNone,    false, 0},
+      {"llama-3.1-8b", 1, 32, 8, 128, 2048, 0,    kSinkNone,    false, 0},
+      // Sink set at the real gpt-oss geometry (H=64, G=8, d=64), including
+      // chunked prefill (past > 0), which is what a 16k prompt actually runs.
+      {"gpt_oss-sink",  1, 64, 8,  64, 512,  0,    kSinkPerHead, false, 0},
+      {"gpt_oss-sink",  1, 64, 8,  64, 2048, 0,    kSinkPerHead, false, 0},
+      {"gpt_oss-sink",  1, 64, 8,  64, 512,  512,  kSinkPerHead, false, 0},
+      {"gpt_oss-sink",  1, 64, 8,  64, 512,  8192, kSinkPerHead, false, 0},
+      {"gpt_oss-smooth",1, 64, 8,  64, 512,  0,    kSinkSmooth,  false, 0},
+      {"gpt_oss-smooth",1, 64, 8,  64, 512,  512,  kSinkSmooth,  false, 0},
+      // Sink tensor AND smooth_softmax=1 together. The cases above each set one
+      // argument, but gqa.cpp only ever sets both at once, so without this the
+      // exact combination the runtime sends is untested.
+      {"gpt_oss-both",  1, 64, 8,  64, 512,  0,    kSinkBoth,    false, 0},
+      {"gpt_oss-both",  1, 64, 8,  64, 512,  512,  kSinkBoth,    false, 0},
+      // A sink must not silently apply at d == 128: v3 declines so the runtime
+      // falls back to the decomposed path, which does implement it.
+      {"llama-sink-d128",1, 32, 8, 128, 512, 0,    kSinkPerHead, true,  0},
+
+      // Sliding window, gpt-oss geometry, window=128 as the model ships.
+      // Window alone first, so a window bug cannot hide behind the sink.
+      {"gpt_oss-win",   1, 64, 8,  64, 512,  0,    kSinkNone,    false, 128},
+      {"gpt_oss-win",   1, 64, 8,  64, 2048, 0,    kSinkNone,    false, 128},
+      // Chunked: past deeper than the window is the case where whole KV tiles
+      // must be skipped rather than merely masked.
+      {"gpt_oss-win",   1, 64, 8,  64, 512,  512,  kSinkNone,    false, 128},
+      {"gpt_oss-win",   1, 64, 8,  64, 512,  8192, kSinkNone,    false, 128},
+      // Window not aligned to any BKV (32/64), to catch an off-by-one in the
+      // start-tile clamp.
+      {"gpt_oss-win",   1, 64, 8,  64, 512,  1000, kSinkNone,    false, 100},
+      // Window wider than the whole sequence must equal full attention.
+      {"gpt_oss-win-big",1, 64, 8, 64, 512,  0,    kSinkNone,    false, 4096},
+      // Window == 1 is the degenerate case: each query sees only itself.
+      {"gpt_oss-win1",  1, 64, 8,  64, 512,  512,  kSinkNone,    false, 1},
+      // Window together with the sink, which is what gpt-oss actually runs on
+      // its 12 sliding layers.
+      {"gpt_oss-win+sk",1, 64, 8,  64, 512,  0,    kSinkPerHead, false, 128},
+      {"gpt_oss-win+sk",1, 64, 8,  64, 512,  8192, kSinkPerHead, false, 128},
+      // The full production configuration of a gpt-oss sliding layer: window,
+      // sink tensor and smooth together, deep enough to skip whole KV tiles.
+      {"gpt_oss-win+bo",1, 64, 8,  64, 512,  8192, kSinkBoth,    false, 128},
+      // A window must not silently apply at d == 128 either.
+      {"llama-win-d128",1, 32, 8, 128, 512,  0,    kSinkNone,    true,  128},
   };
   int fails = 0;
   for (const auto& c : cases) if (!run_case(c, iters)) ++fails;

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -10,22 +10,27 @@
 // The generated IR calls `wrap_group_query_attention` (39-arg ABI, unchanged so
 // the HipToLLVM lowering keeps resolving). Path selection:
 //
-//   * Common fp16 causal GQA (head_dim in {64,128}, templated decode geometry,
-//     no sliding window / sink / smooth) -> optimized fused custom kernels:
+//   * Common fp16 causal GQA (head_dim in {64,128}, templated decode geometry)
+//     -> optimized fused custom kernels:
 //       prefill (sq > 1): [split] -> [rope] -> kv-cache update ->
-//                         hip_gqa_flash_prefill_v2
+//                         hip_gqa_flash_prefill_v3
 //       decode  (sq == 1): [split] -> [rope] -> kv-cache update ->
 //                         hip_gqa_flash_decode_v2
+//     Attention sinks / smooth softmax are applied here too: by flash decode
+//     for any supported geometry, and by flash prefill at head_dim == 64 (the
+//     v5 kernel). Prefill at head_dim 128/256 with a sink still goes
+//     decomposed. Sliding windows are applied by flash prefill at
+//     head_dim == 64; windowed decode still goes decomposed.
 //
 //   * Everything else the fused kernels do not implement (fp32, no_causal /
-//     bidirectional, sliding window, head sink / smooth softmax, additive
-//     attention bias, other head_dim, untemplated decode geometry) -> the
-//     feature-complete legacy decomposed hipBLASLt pipeline
-//     gqa_forward_hipblaslt below. This is a verbatim port of the proven
-//     gqa_back.cpp strategy (the read-only backup stays out of the build); its
-//     fast decode kernels (hip_gqa_fused_decode / hip_gqa_flash_decode) are
-//     folded into gqa_kernel.hip so the sliding-window / sink decode case keeps
-//     the legacy kernel's performance.
+//     bidirectional, a window on decode or on 128/256-wide prefill, a sink on
+//     128/256-wide prefill, additive attention bias, other head_dim,
+//     untemplated decode geometry) -> the feature-complete legacy decomposed
+//     hipBLASLt pipeline gqa_forward_hipblaslt below. This is a verbatim port
+//     of the proven gqa_back.cpp strategy (the read-only backup stays out of
+//     the build); its fast decode kernels (hip_gqa_fused_decode /
+//     hip_gqa_flash_decode) are folded into gqa_kernel.hip so the windowed
+//     decode case keeps the legacy kernel's performance.
 //
 //   * The additive attention bias (onnx.Attention attn_mask) IS supported, but
 //     only by the decomposed path (Step 8b adds it; a causal op then masks the
@@ -313,7 +318,9 @@ static int gqa_forward_fused(
     int64_t B, int64_t sq, int64_t skv, int64_t past_buf_seq, int64_t H,
     int64_t G, int64_t d, float scale, int64_t do_rotary,
     const void *k_scale = nullptr, const void *v_scale = nullptr,
-    KvCacheFormat kv_format = KvCacheFormat::Fp16) {
+    KvCacheFormat kv_format = KvCacheFormat::Fp16,
+    const void *head_sink = nullptr, bool use_smooth_softmax = false,
+    int local_window_size = -1) {
 
   // Any non-fp16 cache reads/writes quantized bytes on the concat/append/decode
   // path; the specific scheme is carried by kv_format (extensible to INT4/FP8).
@@ -462,13 +469,21 @@ static int gqa_forward_fused(
       // Decode is bandwidth-bound: a quantized cache is read directly (e.g.
       // int8 halves the DRAM traffic). One entry serves every format --
       // kv_dtype selects the code path inside the kernel; scales feed dequant.
+      //
+      // local_window_size is pinned to 0 rather than forwarded from the
+      // parameter: window_ok in wrap_group_query_attention sends every windowed
+      // decode to the decomposed pipeline, so the parameter is always <= 0 here
+      // and forwarding it would only look like the windowed decode path is
+      // supported. This kernel does clamp kv_lo, so enabling it is roughly this
+      // one argument -- but nothing in the harness verifies it yet, so it stays
+      // an explicit 0 until something does.
       int drc = hip_gqa_flash_decode_v2(
           stream, qSrc, present_key, present_value, output, partials,
           static_cast<int>(B), static_cast<int>(H), static_cast<int>(G),
           static_cast<int>(d), static_cast<int>(skv),
           static_cast<int>(present_seq), kFlashDecodeMaxSplits, scale,
-          seqlens_k_ptr, /*local_window_size=*/0, /*head_sink=*/nullptr,
-          /*smooth_softmax=*/0, kv_dtype_abi(kv_format),
+          seqlens_k_ptr, /*local_window_size=*/0, head_sink,
+          use_smooth_softmax ? 1 : 0, kv_dtype_abi(kv_format),
           kv_quantized ? k_scale : nullptr, kv_quantized ? v_scale : nullptr);
       if (drc != 0)
         return -1;
@@ -643,18 +658,25 @@ static int gqa_forward_fused(
   }
 
   // Single unified entry; v5 (d==64) / v7 (d==128) selection lives in the
-  // kernel TU (gqa_kernel.hip).
-  int fp_rc = hip_gqa_flash_prefill_v2(
+  // kernel TU (gqa_kernel.hip). v3 carries the sink and the window; it returns
+  // -1 rather than dropping either when the kernel for this d cannot apply it,
+  // and the caller then falls back to the decomposed path.
+  int fp_rc = hip_gqa_flash_prefill_v3(
       stream, qSrc, kAttn, vAttn, output, static_cast<int>(B),
       static_cast<int>(H), static_cast<int>(G), static_cast<int>(sq),
       static_cast<int>(total_seq), static_cast<int>(d), attn_max_seq,
-      static_cast<int>(past_len), scale);
+      static_cast<int>(past_len), scale, local_window_size, head_sink,
+      static_cast<int>(H), use_smooth_softmax ? 1 : 0);
+  // window is logged because it selects the HAS_WINDOW instantiation, so a
+  // dispatch that looks identical here can be two different kernels.
   RUNTIME_DEBUG_LOG(
       "[REAL] GQA fused prefill (%s d=%lld -> v%d): B=%lld sq=%lld "
-      "total_seq=%lld H=%lld G=%lld past_len=%lld rc=%d\n",
+      "total_seq=%lld H=%lld G=%lld past_len=%lld sink=%d smooth=%d window=%d "
+      "rc=%d\n",
       kv_quantized ? "quant" : "fp16", (long long)d, (d == 64 ? 5 : 7),
       (long long)B, (long long)sq, (long long)total_seq, (long long)H,
-      (long long)G, (long long)past_len, fp_rc);
+      (long long)G, (long long)past_len, static_cast<int>(head_sink != nullptr),
+      static_cast<int>(use_smooth_softmax), local_window_size, fp_rc);
   return fp_rc != 0 ? -1 : 0;
 }
 
@@ -2012,14 +2034,15 @@ int wrap_group_query_attention(
   //===------------------------------------------------------------------===//
   // Path selection. The optimized fused/flash kernels are fp16 causal GQA
   // with head_dim in {64,128} and a templated decode geometry (HpG in
-  // {1,2,3,4,8,16}). Anything they do not implement -- fp32, no_causal /
-  // bidirectional, sliding window, head sink / smooth softmax, other
+  // {1,2,3,4,8,16}), and now also cover attention sinks (decode always,
+  // prefill at head_dim == 64) and sliding windows (prefill at head_dim == 64).
+  // Anything they do not implement -- fp32, no_causal / bidirectional, a window
+  // on decode or on 128/256-wide prefill, a sink on 128/256-wide prefill, other
   // head_dim, or an untemplated decode geometry -- is handled by the legacy
   // decomposed hipBLASLt pipeline (gqa_forward_hipblaslt above), which is the
   // verbatim-ported gqa_back.cpp strategy: feature-complete, and keeps the
-  // legacy fast decode kernel for the sliding-window / sink decode case so
-  // that path is not slower than the original. The common fp16 causal case
-  // still takes the fast fused path here.
+  // legacy fast decode kernel for the windowed decode case so that path is not
+  // slower than the original.
   //===------------------------------------------------------------------===//
   const bool is_decode = (seq_len_q == 1);
   const bool decode_geometry_ok =
@@ -2034,9 +2057,26 @@ int wrap_group_query_attention(
   // decomposed pipeline (Step 8b); the lean fused path would silently drop it,
   // so exclude it here to route masked attention to gqa_forward_hipblaslt
   // below.
+  //
+  // Smooth softmax is active when a sink is supplied OR the attribute is
+  // explicitly 1, matching ORT (gqa_attention_base.h:
+  // use_smooth_softmax_ || head_sink != nullptr).
+  const bool has_smooth_softmax = (head_sink != nullptr || smooth_softmax == 1);
+  // Sinks on the fused path: the flash decode kernel applies them for any
+  // supported geometry, and flash prefill applies them at head_dim == 64 (the
+  // v5 kernel). Prefill at head_dim 128/256 has no sink support yet, so those
+  // shapes must keep routing to the decomposed pipeline -- admitting them here
+  // would make hip_gqa_flash_prefill_v3 return -1 and fail the op outright
+  // instead of falling back.
+  const bool sink_ok = !has_smooth_softmax || is_decode || head_dim == 64;
+  // Sliding window on the fused path: implemented by flash prefill at
+  // head_dim == 64 (the v5 kernel). Decode is deliberately left on the
+  // decomposed pipeline even though its kernel clamps kv_lo, because that path
+  // is unverified here; prefill is what the window costs us on gpt-oss.
+  const bool window_ok =
+      local_window_size <= 0 || (!is_decode && head_dim == 64);
   const bool fused_supported = element_size_bytes == 2 && no_causal == 0 &&
-                               local_window_size <= 0 && head_sink == nullptr &&
-                               smooth_softmax != 1 && head_dim_ok &&
+                               window_ok && sink_ok && head_dim_ok &&
                                decode_geometry_ok && attention_bias == nullptr;
 
   // A quantized KV cache is implemented ONLY on the fused path (quant decode +
@@ -2047,8 +2087,9 @@ int wrap_group_query_attention(
       (!fused_supported || (head_dim != 64 && head_dim != 128))) {
     fprintf(stderr,
             "wrap_group_query_attention: quantized KV cache requires the fused "
-            "path (fp16, causal, no window/sink/smooth/bias, head_dim 64 or "
-            "128); got fused_supported=%d head_dim=%lld\n",
+            "path (fp16, causal, no attention bias, any window/sink only where "
+            "the fused kernels implement it, head_dim 64 or 128); got "
+            "fused_supported=%d head_dim=%lld\n",
             static_cast<int>(fused_supported), (long long)head_dim);
     return -1;
   }
@@ -2060,11 +2101,6 @@ int wrap_group_query_attention(
       fprintf(stderr, "wrap_group_query_attention: null hipblas handle\n");
       return -1;
     }
-    // Smooth softmax: activated when head_sink is provided OR the
-    // smooth_softmax attribute is explicitly 1, matching ORT behaviour
-    // (gqa_attention_base.h: use_smooth_softmax_ || head_sink != nullptr).
-    const bool has_smooth_softmax =
-        (head_sink != nullptr || smooth_softmax == 1);
     RUNTIME_DEBUG_LOG(
         "[REAL] wrap_group_query_attention: routing to legacy decomposed "
         "pipeline "
@@ -2101,7 +2137,8 @@ int wrap_group_query_attention(
       state, stream, query, key, value, past_key, past_value, seqlens_k,
       cos_cache, sin_cache, output, present_key, present_value, batch_size,
       seq_len_q, seq_len_kv, past_buf_seq, num_heads, kv_num_heads, head_dim,
-      scale, do_rotary, k_scale, v_scale, kv_format);
+      scale, do_rotary, k_scale, v_scale, kv_format, head_sink,
+      has_smooth_softmax, static_cast<int>(local_window_size));
   if (rc != 0)
     fprintf(stderr,
             "wrap_group_query_attention: gqa_forward_fused failed "


### PR DESCRIPTION
## Summary

Two commits against the GQA prefill path, both on `gqa_flash_prefill_v5` (the `d==64` warp-private kernel):

1. **`perf(gqa): fused flash prefill for attention sinks and sliding windows`** — teaches v5 attention sinks, smooth softmax and sliding windows so gpt-oss no longer falls back to the decomposed path for its 12 sliding layers and 24 sink layers. `HAS_WINDOW` is a template parameter rather than a runtime test because the kernel runs at the VGPR ceiling: carrying the window's per-row state live in the full-attention instantiation pushed `M_TILES=2` from 120 to 180 bytes/lane of scratch and cost that path 21% at deep KV.

2. **`perf(gqa): cut v5 prefill KV-loop instruction count 44%`** — the loop was bound by instruction *issue*, not occupancy, bandwidth or the matrix units: 1,734 instructions per KV tile to retire 32 WMMA, so the matrix units saw 2% of the stream. Three changes take that to **967 on the 99.6% of tiles that need no causal mask**: native `exp2` in the softmax, the softmax denominator's cross-lane reduction deferred out of the loop into the epilogue, and a mask-free/masked tile split via a tag-dispatched tile body.

## Measured

Interleaved A/B on `gpt_oss-sink sq=512 past=8192`, each arm a separate build, 3 rounds:

| arm | vs parent |
|---|---|
| native exp2 alone | -0.5% |
| deferred reduction alone | -8.9% |
| both | -12.4% |
| **all three** | **-21.4%** |

`exp2` pays nothing on its own because the reduction chain it sits behind is what the loop waits on; it only becomes visible once that chain is gone. The tile split is likewise not separable from the restructure it needs — the same lambda without the split costs 32% on every `d=64` full-attention case, because the split is what lets the compiler keep a tile's live values in registers (in-loop scratch traffic 52 ops → 6).

In-model, 16k-token gpt-oss-20b prefill, RGP capture:

| | before | after |
|---|---|---|
| v5 full-attention dispatch mean | 5,989.7 us | **5,207.7 us** |
| share of capture window | 25.3% | **23.0%** |
| TTFT | 9,653 ms | **9,172 ms (-5.0%)** |

## Correctness

`test_gqa_prefill` covers 26 cases against an fp32 CPU reference: all four sink/smooth/both/none modes, windows at 1/100/128/4096, `past` at 0/512/1000/8192, `d` at 64 and 128, and the two `d=128` cases that assert v5 *declines* so the runtime falls back rather than silently ignoring a sink or a window. **All 26 pass**, worst `relL2` 5.74e-4, unchanged by commit 2 — the reordered summation in the deferred reduction is not observable at this tolerance.

Across the 24 cases the suite also times: 21 faster, 1 tie, no regressions. `d=128` routes to v7 and is unaffected (1.00x, 1.01x).

The new mask-free instantiation is exercised by every full-attention case with `past > 0`, and by the interior q-tiles of the `past = 0` cases.

## Notes for review

- The three A/B switches used to select these changes are **not** in the diff; they were collapsed to their enabled path before this PR. The collapse is provably free: the device image is byte-identical to the switched build across all 443,062 lines of gfx1151 ISA, differing only in the `__hip_cuid` symbol, which is a hash of the translation unit and moves when a comment does.
- Commit 2 adds two measurement-only env knobs, read once and inert unless set: `HIPDNN_PREFILL_V5_ABLATE` (per-phase timing bitmask; numerics are deliberately wrong under it, timing only) and `HIPDNN_PREFILL_V5_CFG` (pins `M_TILES,BKV` so one autotune candidate can be timed alone). Both exist because the questions this kernel raises are otherwise unmeasurable from outside the process. Happy to drop them if that is not wanted here.
- The RGP one-shot capture fence used to take the in-model numbers is deliberately **not** in this PR; it is unrelated profiling infrastructure and belongs in its own.

## What is deliberately left on the table

Re-profiling after the fact says the phase order inverted: the value GEMM is now the largest phase at 36.5% (was 19.8%) and softmax has fallen to 24.2% (was 39.1%). The loop is now only 28-41% issue-bound, so instruction count has largely stopped being the lever. Two candidates remain, both aimed at the LDS pipe and both sized from the ISA but **not built**: storing V transposed in LDS to turn 128 `ds_load_u16` into 16 `ds_load_b128` (worth -5.4% by instruction count, 3.6-7.1% by an LDS-pipe model, against an unquantified bank-conflict risk), and DPP `row_xmask` for the remaining 64 `ds_bpermute` (verified available on gfx1151, but it does not fold into the consuming `v_max`, so it is instruction-neutral and worth 0% or 4.6-9.1% depending on which LDS throughput assumption holds). Together roughly 2% of prefill at the optimistic end.

## Test plan

- [x] `test_gqa_prefill` — 26/26 pass, fp32 reference, worst `relL2` 5.74e-4
- [x] `test_gqa_prefill` timing sweep, 24 cases, 20 and 40 iters, no regressions
- [x] Byte-level ISA equivalence of the shipped source against the measured build
- [x] In-model 16k gpt-oss-20b prefill, RGP capture, TTFT -5.0%
- [ ] CI on this branch
- [ ] A reviewer's opinion on whether the two env knobs stay
